### PR TITLE
Add expansion support to HHashTable to optimize HashAgg

### DIFF
--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -5008,6 +5008,7 @@ add_agg_cost(PlannerInfo *root, Plan *plan,
 	Path		agg_path;		/* dummy for result of cost_agg */
 	QualCost	qual_cost;
 	HashAggTableSizes hash_info;
+	double entrywidth;
 
 	UnusedArg(grpColIdx);
 	UnusedArg(num_nullcols);
@@ -5027,12 +5028,13 @@ add_agg_cost(PlannerInfo *root, Plan *plan,
 
 	if (aggstrategy == AGG_HASHED)
 	{
+		/* The following estimate is very rough but good enough for planning. */
+		entrywidth = agg_hash_entrywidth(numAggs,
+								   sizeof(HeapTupleData) + sizeof(HeapTupleHeaderData) + plan->plan_width,
+								   transSpace);
 		if (!calcHashAggTableSizes(global_work_mem(root),
 								   numGroups,
-								   numAggs,
-								   /* The following estimate is very rough but good enough for planning. */
-								   sizeof(HeapTupleData) + sizeof(HeapTupleHeaderData) + plan->plan_width,
-								   transSpace,
+								   entrywidth,
 								   true,
 								   &hash_info))
 		{

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -937,7 +937,7 @@ typedef struct Agg
 	 */
 	bool        lastAgg;
 
-	/* Should we stream this agg */
+	/* Stream entries when out of memory instead of spilling to disk */
 	bool 		streaming;
 } Agg;
 

--- a/src/test/regress/expected/workfile/hashagg_spill.out
+++ b/src/test/regress/expected/workfile/hashagg_spill.out
@@ -62,6 +62,73 @@ select * from hashagg_spill.is_workfile_created('explain analyze select max(i1) 
                    1
 (1 row)
 
+-- Test HashAgg with increasing amount of overflows
+reset all;
+-- Returns the number of overflows from EXPLAIN ANALYZE output
+create or replace function hashagg_spill.num_hashagg_overflows(explain_query text)
+returns setof int as
+$$
+import re
+query = "select count(*) as nsegments from gp_segment_configuration where role='p' and content >= 0;"
+rv = plpy.execute(query)
+rv = plpy.execute(explain_query)
+result = []
+for i in range(len(rv)):
+    cur_line = rv[i]['QUERY PLAN']
+    p = re.compile('.+\((seg[\d]+).+ ([\d+]) overflows;')
+    m = p.match(cur_line)
+    if m:
+      overflows = int(m.group(2))
+      result.append(overflows)
+return result
+$$
+language plpythonu;
+-- Test agg spilling scenarios
+drop table if exists aggspill;
+create table aggspill (i int, j int, t text) distributed by (i);
+insert into aggspill select i, i*2, i::text from generate_series(1, 10000) i;
+insert into aggspill select i, i*2, i::text from generate_series(1, 100000) i;
+insert into aggspill select i, i*2, i::text from generate_series(1, 1000000) i;
+-- No spill with large statement memory 
+set statement_mem = '125MB';
+select count(*) from (select i, count(*) from aggspill group by i,j having count(*) = 1) g;
+ count  
+--------
+ 900000
+(1 row)
+
+-- Reduce the statement memory to induce spilling
+set statement_mem = '10MB';
+select overflows >= 1 from hashagg_spill.num_hashagg_overflows('explain analyze
+select count(*) from (select i, count(*) from aggspill group by i,j having count(*) = 2) g') overflows;
+ ?column? 
+----------
+ t
+(1 row)
+
+select count(*) from (select i, count(*) from aggspill group by i,j having count(*) = 2) g;
+ count 
+-------
+ 90000
+(1 row)
+
+-- Reduce the statement memory, nbatches and entrysize even further to cause multiple overflows
+set gp_hashagg_default_nbatches = 4;
+set statement_mem = '5MB';
+select overflows > 1 from hashagg_spill.num_hashagg_overflows('explain analyze
+select count(*) from (select i, count(*) from aggspill group by i,j,t having count(*) = 3) g') overflows;
+ ?column? 
+----------
+ t
+(1 row)
+
+select count(*) from (select i, count(*) from aggspill group by i,j,t having count(*) = 3) g;
+ count 
+-------
+ 10000
+(1 row)
+
 drop schema hashagg_spill cascade;
-NOTICE:  drop cascades to table testhagg
-NOTICE:  drop cascades to function is_workfile_created(text)
+NOTICE:  drop cascades to function hashagg_spill.num_hashagg_overflows(text)
+NOTICE:  drop cascades to table hashagg_spill.testhagg
+NOTICE:  drop cascades to function hashagg_spill.is_workfile_created(text)


### PR DESCRIPTION
With reference to https://github.com/greenplum-db/gpdb/pull/2155, this PR adds support for an expandable hash table for HashAgg. 

* When creating the hash table, instead of determining the number of buckets (nbuckets) only by the available memory, it now computes the nbuckets as a function of estimated number of entries by the planner/optimizer. So in the extreme case of the example below it reduces the iteration time from 419.731 ms to 31 ms, which is a 10X improvement:
```
template1=# explain analyze select i, sum(j) from foo group by i;explain analyze select i, sum(j) from foo
 group by i;
                                     QUERY PLAN
-------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=992.79..606.58 rows=1000 width=12)
   Rows out:  0 rows at destination with 31 ms to end, start offset by 0.355 ms.
   ->  HashAggregate  (cost=992.79..606.58 rows=334 width=12)
         Group By: i
         Rows out:  0 rows (seg0) with 0.210 ms to end, start offset by 21 ms.
         Executor memory:  16K bytes avg, 16K bytes max (seg0).
         ->  Seq Scan on foo  (cost=0.00..961.00 rows=28700 width=8)
               Rows out:  0 rows (seg0) with 0.131 ms to end, start offset by 21 ms.
 Slice statistics:
   (slice0)    Executor memory: 322K bytes.
   (slice1)    Executor memory: 102K bytes avg x 3 workers, 102K bytes max (seg0).
 Statement statistics:
   Memory used: 8388608K bytes
 Optimizer status: legacy query optimizer
 Total runtime: 31.828 ms
(15 rows)
```
* When reloading spilled groups a spill file, we can re-compute the number of buckets based on the number of entries that were written to the file. This means in the reloading case, in most cases we will not need to expand the hash table - and in the best case reduce the allocation and zero-ing costs.
* This PR also includes some refactoring code that fixes the memory computations. This should mean we stay within memory bounds more often, although many corner cases still remain. See the FIXME comment in `spill_hash_table()`. I have a created a separate story in the QX backlog to tackle that.
* I also fixed the EXPLAIN ANALYZE metrics in the context of an expanding hashtable (total_buckets & chainlength).
* The hash table can spill in multiple "layers" i.e spill again when it is processing an already spilled file. There were no tests in ICG testing the correctness for level > 1, so I added some tests for that. Any other recommendation for testing the expansion is welcome - although I suspect a component will tested in multiple places.