### PR TITLE
{third_party_tar} Remove apr, zlib and sigar from third party tar

### DIFF
--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -69,10 +69,6 @@ function make_sync_tools() {
     # Requires these variables in the env:
     # IVYREPO_HOST IVYREPO_REALM IVYREPO_USER IVYREPO_PASSWD
     make sync_tools
-    # We have compiled LLVM with native zlib on CentOS6 and not from
-    # the zlib downloaded from artifacts.  Therefore, remove the zlib
-    # downloaded from artifacts in order to use the native zlib.
-    find ext -name 'libz.*' -exec rm -f {} \;
   popd
 }
 

--- a/gpAux/releng/make/dependencies/ivy.xml
+++ b/gpAux/releng/make/dependencies/ivy.xml
@@ -11,12 +11,15 @@
     </configurations>
 
     <dependencies>
+      <dependency org="Hyperic"         name="sigar"           rev="1.6.3"          conf="rhel7_x86_64->rhel5_x86_64;suse11_x86_64->suse10_x86_64" />
+      <dependency org="apache"          name="apr"             rev="1.5.2"          conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64;suse11_x86_64->sles11_x86_64" />
+      <dependency org="apache"          name="apr-util"        rev="1.2.12"         conf="rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64;suse11_x86_64->suse10_x86_64" />
       <dependency org="xerces"          name="xerces-c"        rev="3.1.1-p1"       conf="rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64;suse11_x86_64->suse10_x86_64" />
       <dependency org="OpenSSL"         name="openssl"         rev="0.9.8zg"        conf="rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64;suse11_x86_64->suse10_x86_64" />
       <dependency org="emc"             name="DDBoostSDK"      rev="3.3.0.4-550644" conf="rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64" />
       <dependency org="gnu"             name="libstdc"         rev="6.0.22"         conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64;suse11_x86_64->suse11_x86_64" />
       <dependency org="third-party"     name="ext"             rev="1.1"            conf="win32->win32" />
-      <dependency org="third-party"     name="ext"             rev="2.5"            conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64;suse11_x86_64->sles11_x86_64" />
+      <dependency org="third-party"     name="ext"             rev="3.0"            conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64;suse11_x86_64->sles11_x86_64" />
       <dependency org="NetBackup"       name="SDK-7.1"         rev="7.1"            conf="rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64" />
       <dependency org="NetBackup"       name="SDK-7.5"         rev="7.5"            conf="rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64" />
       <dependency org="NetBackup"       name="SDK-7.6"         rev="7.6"            conf="rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64" />


### PR DESCRIPTION
- Use independent ext and sigar from artifactory
- zlib was not used anymore
[#143414851]
[#143441561]

Signed-off-by: Tom Meyer <tmeyer@pivotal.io>