### PR TITLE
Put a bandaid around xpath tests

### DIFF
--- a/src/test/regress/expected/xpath.out
+++ b/src/test/regress/expected/xpath.out
@@ -1,7 +1,7 @@
 set xmloption='document';
 set optimizer_disable_missing_stats_collection = on;
 --start_ignore
-drop table table if exists readxml;
+drop table if exists readxml;
 NOTICE:  table "readxml" does not exist, skipping
 --end_ignore
 create table readxml (text xml);
@@ -12,11 +12,11 @@ select xml_in('<a></a>');
  <a></a>
 (1 row)
 
+\set verbosity terse
 select xml_in('<a></>');
 ERROR:  invalid XML document
 DETAIL:  Entity: line 1: parser error : Opening and ending tag mismatch: a line 1 and unparseable
-<a></>
-      ^
+\set verbosity default
 select xml_out((select xml_in('<a></a>')));
  xml_out 
 ---------
@@ -272,14 +272,12 @@ select xml_out((select * from readxml));
 (1 row)
 
 --negative test
+\set verbosity terse
 select xml_out((select xml_in('<a>hello<a>')));
 ERROR:  invalid XML document
 DETAIL:  Entity: line 1: parser error : Premature end of data in tag a line 1
-<a>hello<a>
-           ^
 Entity: line 1: parser error : Premature end of data in tag a line 1
-<a>hello<a>
-           ^
+\set verbosity default
 select xmlcomment(E'<a>hello<\a>');
      xmlcomment     
 --------------------

--- a/src/test/regress/sql/xpath.sql
+++ b/src/test/regress/sql/xpath.sql
@@ -10,14 +10,18 @@ create table readxml (text xml);
 \copy readxml from 'data/CD.xml' with escape 'off' newline as 'CRLF';
 
 select xml_in('<a></a>');
+\set verbosity terse
 select xml_in('<a></>');
+\set verbosity default
 select xml_out((select xml_in('<a></a>')));
 select xml_out((select xml_in('<a>hello</a>')));
 select xml_out((select * from readxml));
 
 --negative test
 
+\set verbosity terse
 select xml_out((select xml_in('<a>hello<a>')));
+\set verbosity default
 
 select xmlcomment(E'<a>hello<\a>');
 select xmlcomment('adsfasdfasdfsadf');


### PR DESCRIPTION
On a vanilla CentOS, the xpath test would always fail due to some
patches Red Hat applies to libxml2.
The xpath test in general is fairly questionable: it largely overlaps in
coverage with the xml test from upstream, and the two offending tests
were only failing because of an error message that doesn't even come
from our (Postgres) code: it's an implementation detail of libxml2.
I am not fully comfortable ripping xpath out yet, but this patch should
make sure it passes on CentOS without vendoring a special version of
libxml2.