### PR TITLE
Modifying runaway tinc udf to trigger runaway detection only on one segment

### DIFF
--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/sql/hit_vlim_crit_section.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/sql/hit_vlim_crit_section.sql
@@ -4,4 +4,4 @@
 -- @slimMB 0
 
 -- content/segment = 0; size = 901MB; sleep = 0 sec; crit_section = true
-select gp_allocate_palloc_test_all_segs(0, 901 * 1024 * 1024, 0, true);
+select gp_allocate_palloc_test_one_seg(0, 901 * 1024 * 1024, 0, true);

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/udfs/runaway_test.sql.in
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/udfs/runaway_test.sql.in
@@ -54,6 +54,30 @@ LANGUAGE SQL;
 
 --------------------------------------------------------------------------------
 -- @function: 
+--        gp_allocate_palloc_test_one_seg
+-- @in:
+--		content - segment on which to allocate; master is not supported.
+--		size - amount of memory to allocate (in bytes)
+--		sleep - sleep for a number of seconds after allocation. 0 is disable
+--		crit_section - allocate in critical section if true
+-- @out:
+-- 		int - amount allocated
+--
+-- @doc:
+--		Allocates a specified amount of memory using a single palloc call on
+--		the specified segment.
+--        
+--------------------------------------------------------------------------------
+CREATE FUNCTION gp_allocate_palloc_test_one_seg(content int, size int, sleep int, crit_section bool)
+RETURNS SETOF int
+AS
+$$
+ SELECT gp_allocate_palloc_test_f($1, $2, $3, $4) from gp_dist_random('gp_id');
+$$
+LANGUAGE SQL;
+
+--------------------------------------------------------------------------------
+-- @function: 
 --        gp_allocate_top_memory_ctxt_test_f
 -- @in:
 --		content - segment on which to allocate. -1 is master. -2 is all.


### PR DESCRIPTION
We add one more udf that only allocates on one specific segment and modify the hit_vlim_crit_section test to use the new udf. The original generic UDF uses an union all which creates one extra slice on segment 0. This allowed existence of two QE processes on segment 0. 

The test checks if we successfully ignore runaway termination as long as we are in critical section. The critical section is a per-process state and therefore a second runaway detector on the same segment can still mark the session as runaway. This causes the session to eventually trigger a runaway cleanup after it comes out of critical section. We still don't PANIC as runaway termination successfully ignores. But, the runaway detection couldn't ignore the critical section because of per-process critical section state and this eventually produces a diff in concourse occasionally. 

An alternative to introducing a new UDF is to modify the test to trigger it on a different segment other than segment 0, where the extra QE process currently gets created. I am waiting someone from QO to explain why we need an extra slice on segment 0. Until then I would rather not patch the test to trigger it on a different segment without having a guarantee that in the future planner will not generate the extra slice on another segment.