### PR TITLE
Fix issues reported by Coverity in xlog.c

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -11696,13 +11696,11 @@ int XLogFillZero(
 	}
 
 exit:
-	if (fd > 0) {
-		if (close(fd)) {
-			ereport(WARNING,
-					(errcode_for_file_access(),
-					 errmsg("could not close file \"%s\": %m", path)));
-			status = STATUS_ERROR;
-		}
+	if (close(fd)) {
+		ereport(WARNING,
+				(errcode_for_file_access(),
+				 errmsg("could not close file \"%s\": %m", path)));
+		status = STATUS_ERROR;
 	}
 
 	return status;
@@ -12028,9 +12026,11 @@ int XLogAddRecordsToChangeTracking(
 	 */
 	if (lastChangeTrackingEndLoc == NULL)
 	{
-		/* read xlog till the end to get last lsn on disk (EndRecPtr) */
-		while(record != NULL)
-			record = XLogReadRecord(NULL, false, LOG);
+		/*
+		 * Xlog must have been read till the end to get last lsn on
+		 * disk (EndRecPtr).
+		 */
+		Assert (record == NULL);
 
 		if (! (lastChangeTrackingLogEndLoc.xlogid == 0 && lastChangeTrackingLogEndLoc.xrecoff == 0) &&
 			XLByteLT(EndRecPtr, lastChangeTrackingLogEndLoc))


### PR DESCRIPTION
## CID 130007 Resource leak (file descriptor) in XlogFillZero()

Coverity thinks that a file descriptor with value 0 may be leaked (no
matching close() for an open()).  But open() will never return a file
descriptor 0 in this case.  Change the code still to make Coverity happy.

## CID 129351 Dead code in XLogAddRecordsToChangeTracking()

This is a legitimate case.  The `while (1)` loop already scans xlog
until the end, so that (record == NULL) is true.  There is no point in
trying to traverse till the end of xlog yet another time aftre
breaking out of the `while (1)`.  So replace the code and add assert
instead.