### PR TITLE
Remove `optimizer_explain_show_status` [#143820417]

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -668,20 +668,17 @@ ExplainOnePlan(PlannedStmt *plannedstmt, ParamListInfo params,
         appendStringInfoChar(&buf, '\n');
     }
 
-#ifdef USE_ORCA
     /* Display optimizer status: either 'legacy query optimizer' or Orca version number */
-    if (optimizer_explain_show_status)
-    {
-		appendStringInfo(&buf, "Optimizer status: ");
-    	if (queryDesc->plannedstmt->planGen == PLANGEN_PLANNER)
-    	{
-			appendStringInfo(&buf, "legacy query optimizer\n");
-    	}
-    	else /* PLANGEN_OPTIMIZER */
-    	{
-			appendStringInfo(&buf, "PQO version %s\n", OptVersion());
-    	}
-    }
+	appendStringInfo(&buf, "Optimizer status: ");
+	if (queryDesc->plannedstmt->planGen == PLANGEN_PLANNER)
+	{
+		appendStringInfo(&buf, "legacy query optimizer\n");
+	}
+#ifdef USE_ORCA
+	else /* PLANGEN_OPTIMIZER */
+	{
+		appendStringInfo(&buf, "PQO version %s\n", OptVersion());
+	}
 #endif
 
     /*

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -553,7 +553,6 @@ bool		optimizer_dml_constraints;
 bool		optimizer_enable_master_only_queries;
 bool		optimizer_multilevel_partitioning;
 bool		optimizer_enable_derive_stats_all_groups;
-bool		optimizer_explain_show_status;
 bool		optimizer_prefer_scalar_dqa_multistage_agg;
 bool 		optimizer_parallel_union;
 bool		optimizer_array_constraints;
@@ -2798,16 +2797,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 		},
 		&optimizer_enable_derive_stats_all_groups,
 		false, NULL, NULL
-	},
-
-	{
-		{"optimizer_explain_show_status", PGC_USERSET, DEVELOPER_OPTIONS,
-			gettext_noop("Display optimizer version information in explain messages."),
-			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&optimizer_explain_show_status,
-		true, NULL, NULL
 	},
 
 	{

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -468,7 +468,6 @@ extern bool optimizer_control;	/* controls whether the user can change the setti
 extern bool optimizer_enable_master_only_queries;
 extern bool optimizer_multilevel_partitioning;
 extern bool optimizer_enable_derive_stats_all_groups;
-extern bool optimizer_explain_show_status;
 extern bool optimizer_prefer_scalar_dqa_multistage_agg;
 extern bool optimizer_parallel_union;
 extern bool optimizer_array_constraints;


### PR DESCRIPTION
`optimizer_explain_show_status` GUC is guarding the optimizer
status string in the explain output. There is no added value
for guarding the optimizer status output with a GUC. Therefore,
we are removing it.