### PR TITLE
PR Pipeline: test gpperfmon on all pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,16 @@ your system.
 ./configure --with-perl --with-python --with-libxml ---enable-mapreduce --enable-codegen --prefix=/usr/local/gpdb --with-codegen-prefix="/path/to/llvm;/path/to/clang"
 ```
 
+### Build GPDB with gpperfmon enabled
+
+gpperfmon tracks a variety of queries, statistics, system properties, and metrics.
+To build with it enabled, change your `configure` to have an additional option
+`--enable-gpperfmon`
+
+See [more information about gpperfmon here](gpAux/gpperfmon/README.md)
+
+gpperfmon is dependent on several libraries like apr, apu, and libsigar
+
 ## Regression tests
 
 * The default regression tests

--- a/concourse/pipelines/pr_pipeline.yml
+++ b/concourse/pipelines/pr_pipeline.yml
@@ -114,6 +114,18 @@ jobs:
         timeout: 10m
         on_failure: *pr_failure
 
+      - task: gpperfmon
+        file: gpdb_pr/concourse/tasks/behave_gpdb.yml
+        image: centos-gpdb-dev-6
+        input_mapping:
+          gpdb_src: gpdb_pr
+          bin_gpdb: gpdb_artifacts
+        params:
+          BEHAVE_TAGS: gpperfmon
+          BLDWRAP_POSTGRES_CONF_ADDONS: ""
+        timeout: 20m
+        on_failure: *pr_failure
+
     - task: separate_qautils_files_for_rc
       file: gpdb_pr/concourse/tasks/separate_qautils_files_for_rc.yml
       image: centos-gpdb-dev-6


### PR DESCRIPTION
- gpperfmon tracks a variety of queries and statistics and system
  properties and metrics in a dedicated database
- Until recently, it hadn't been tested or built very reliably here. It
  is now part of the gpdb_master pipeline.
- We are doing a lot of work to revitalize and provide tests for this
  feature; we plan to make many upcoming pull requests for this
  feature in different ways
- We will look into testing this with installcheck, but for now, it is
  tested with Behave
- Building it as part of PRs will help us get faster feedback
- This should add negligible time to compilation: the tests themselves
  run in less than 5 minutes typically, and will be running in parallel
  with ICW