### PR TITLE
Correct LOG ERRORS document

### DIFF
--- a/doc/src/sgml/ref/create_external_table.sgml
+++ b/doc/src/sgml/ref/create_external_table.sgml
@@ -46,7 +46,7 @@ CREATE [READABLE] EXTERNAL TABLE table_name
                [FILL MISSING FIELDS] )]
            | 'CUSTOM' (Formatter=<formatter specifications>)
      [ ENCODING 'encoding' ]
-     [ [LOG ERRORS INTO error_table] SEGMENT REJECT LIMIT count 
+     [ [LOG ERRORS] SEGMENT REJECT LIMIT count
        [ROWS | PERCENT] ]
 CREATE [READABLE] EXTERNAL WEB TABLE table_name 
      ( column_name data_type [, ...] | LIKE other_table )
@@ -74,7 +74,7 @@ CREATE [READABLE] EXTERNAL WEB TABLE table_name
                [FILL MISSING FIELDS] )]
            | 'CUSTOM' (Formatter=<formatter specifications>)
      [ ENCODING 'encoding' ]
-     [ [LOG ERRORS INTO error_table] SEGMENT REJECT LIMIT count 
+     [ [LOG ERRORS] SEGMENT REJECT LIMIT count
        [ROWS | PERCENT] ]
 CREATE WRITABLE EXTERNAL TABLE table_name
     ( column_name data_type [, ...] | LIKE other_table )


### PR DESCRIPTION
Error table feature was removed, but `\h CREATE EXTERNAL TABLE` still
has the description. This commit corrects it.