### PR TITLE
Don't ignore "application_name" in the startup packet in GPDB.

### DIFF
--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -2793,8 +2793,6 @@ retry1:
 				port->user_name = pstrdup(valptr);
 			else if (strcmp(nameptr, "options") == 0)
 				port->cmdline_options = pstrdup(valptr);
-			else if (strcmp(nameptr, "application_name") == 0)
-				/* ignore for compatibility with libpq >= 8.5 */ ;
 			else if (strcmp(nameptr, "gpqeid") == 0)
 				gpqeid = valptr;
 			else if (strcmp(nameptr, "replication") == 0)


### PR DESCRIPTION
This reverts upstream commit 3c77fbd285 that we got as part of the 8.3
merge. We have back-ported the full application_name feature from
PostgreSQL 9.0 earlier already, so we don't need the hack to ignore
application_name.