### PR TITLE
Restore changes to report the partial indexes to ORCA [#120303669]

### DIFF
--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -440,9 +440,12 @@ CConfigParamMapping::PbsPack
 		 pbs->FExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfMaxOneRow2Assert));
 	}
 
-	CBitSet *pbsHeterogeneousIndex = CXform::PbsHeterogeneousIndexXforms(pmp);
-	pbs->Union(pbsHeterogeneousIndex);
-	pbsHeterogeneousIndex->Release();
+	if (!optimizer_enable_partial_index)
+	{
+		CBitSet *pbsHeterogeneousIndex = CXform::PbsHeterogeneousIndexXforms(pmp);
+		pbs->Union(pbsHeterogeneousIndex);
+		pbsHeterogeneousIndex->Release();
+	}
 
 	return pbs;
 }

--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -3042,17 +3042,4 @@ gpdb::FMDCacheNeedsReset
 	return true;
 }
 
-bool
-gpdb::FPartialLogicalIndex
-		(
-			const LogicalIndexInfo *logicalIndexInfo
-		)
-{
-	// A logical index is complete when it's on all leaf partitions
-	// A partial logical index will have part constraints or default levels
-	// set
-	// c.f. BuildLogicalIndexInfo in cdbpartindex.c
-	return logicalIndexInfo->partCons || logicalIndexInfo->defaultLevels;
-}
-
 // EOF

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -343,10 +343,7 @@ CTranslatorRelcacheToDXL::PlIndexOidsPartTable
 	for (ULONG ul = 0; ul < ulIndexes; ul++)
 	{
 		LogicalIndexInfo *pidxinfo = (plgidx->logicalIndexInfo)[ul];
-		if (!gpdb::FPartialLogicalIndex(pidxinfo))
-		{
-			plOids = gpdb::PlAppendOid(plOids, pidxinfo->logicalIndexOid);
-		}
+		plOids = gpdb::PlAppendOid(plOids, pidxinfo->logicalIndexOid);
 	}
 	
 	gpdb::GPDBFree(plgidx);
@@ -1227,7 +1224,7 @@ CTranslatorRelcacheToDXL::PmdindexPartTable
 		}
 	}
 
-	BOOL fPartial = gpdb::FPartialLogicalIndex(pidxinfo);
+	BOOL fPartial = (NULL != pnodePartCnstr || NIL != plDefaultLevels);
 
 	if (NULL == pnodePartCnstr)
 	{

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -548,6 +548,7 @@ bool		optimizer_apply_left_outer_to_union_all_disregarding_stats;
 bool		optimizer_enable_ctas;
 bool		optimizer_remove_order_below_dml;
 bool		optimizer_static_partition_selection;
+bool		optimizer_enable_partial_index;
 bool		optimizer_dml_triggers;
 bool		optimizer_dml_constraints;
 bool		optimizer_enable_master_only_queries;
@@ -3011,6 +3012,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_static_partition_selection,
+		true, NULL, NULL
+	},
+
+	{
+		{"optimizer_enable_partial_index", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Enable heterogeneous index plans."),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_enable_partial_index,
 		true, NULL, NULL
 	},
 

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -516,10 +516,6 @@ namespace gpdb {
 	// close the given relation
 	void CloseRelation(Relation rel);
 
-	// A logical index is partial if it's not present on all leaf partitions
-	// c.f. BuildLogicalIndexInfo in cdbpartindex.c
-	bool FPartialLogicalIndex(const LogicalIndexInfo* logicalIndexInfo);
-
 	// return the logical indexes for a partitioned table
 	LogicalIndexes *Plgidx(Oid oid);
 	

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -461,6 +461,7 @@ extern bool optimizer_apply_left_outer_to_union_all_disregarding_stats;
 extern bool optimizer_enable_ctas;
 extern bool optimizer_remove_order_below_dml;
 extern bool optimizer_static_partition_selection;
+extern bool optimizer_enable_partial_index;
 extern bool optimizer_dml_triggers;
 extern bool	optimizer_dml_constraints;
 extern bool optimizer_direct_dispatch;

--- a/src/test/regress/expected/bfv_partition_optimizer.out
+++ b/src/test/regress/expected/bfv_partition_optimizer.out
@@ -1579,7 +1579,7 @@ select * from pp where b=2 and c=2;
 select count_operator('select * from pp where b=2 and c=2;','Partition Selector');
  count_operator 
 ----------------
-              0
+              1
 (1 row)
 
 -- CLEANUP

--- a/src/test/regress/expected/gp_optimizer.out
+++ b/src/test/regress/expected/gp_optimizer.out
@@ -8228,21 +8228,27 @@ insert into orca.t_date values('01-03-2012'::date,6,'tag1','tag2');
 insert into orca.t_date values('01-03-2012'::date,7,'tag1','tag2');
 insert into orca.t_date values('01-03-2012'::date,8,'tag1','tag2');
 insert into orca.t_date values('01-03-2012'::date,9,'tag1','tag2');
+set optimizer_enable_partial_index=on;
 set optimizer_enable_space_pruning=off;
 set optimizer_enable_constant_expression_evaluation=on;
 set optimizer_enumerate_plans=on;
+set optimizer_plan_id = 2;
 explain select * from orca.t_date where user_id=9;
-                                              QUERY PLAN                                              
-------------------------------------------------------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.00 rows=1 width=28)
-   ->  Sequence  (cost=0.00..431.00 rows=1 width=28)
-         ->  Partition Selector for t_date (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
-               Partitions selected: 6 (out of 6)
-         ->  Dynamic Table Scan on t_date (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=28)
-               Filter: user_id = 9::numeric
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..437.00 rows=1 width=28)
+   ->  Sequence  (cost=0.00..437.00 rows=1 width=28)
+         ->  Partition Selector for t_date (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
+               Partitions selected:  6 (out of 6)
+         ->  Result  (cost=0.00..437.00 rows=1 width=28)
+               ->  Append  (cost=0.00..437.00 rows=1 width=28)
+                     ->  Dynamic Index Scan on t_date (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=58)
+                           Index Cond: user_id = 9::numeric
+                     ->  Dynamic Table Scan on t_date (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=58)
+                           Filter: user_id = 9::numeric
  Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 2.22.0
-(8 rows)
+ Optimizer status: PQO version 1.602
+(12 rows)
 
 select * from orca.t_date where user_id=9;
    timest   | user_id | tag1  | tag2  
@@ -8281,18 +8287,23 @@ insert into orca.t_text values('01-03-2012'::date,9,'ugly','tag2');
 set optimizer_enable_space_pruning=off;
 set optimizer_enable_constant_expression_evaluation=on;
 set optimizer_enumerate_plans=on;
+set optimizer_plan_id = 2;
 explain select * from orca.t_text where user_id=9;
-                                              QUERY PLAN                                              
-------------------------------------------------------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.00 rows=1 width=28)
-   ->  Sequence  (cost=0.00..431.00 rows=1 width=28)
-         ->  Partition Selector for t_text (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
-               Partitions selected: 3 (out of 3)
-         ->  Dynamic Table Scan on t_text (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=28)
-               Filter: user_id = 9::numeric
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..437.00 rows=1 width=28)
+   ->  Sequence  (cost=0.00..437.00 rows=1 width=28)
+         ->  Partition Selector for t_text (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
+               Partitions selected:  3 (out of 3)
+         ->  Result  (cost=0.00..437.00 rows=1 width=28)
+               ->  Append  (cost=0.00..437.00 rows=1 width=28)
+                     ->  Dynamic Index Scan on t_text (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=58)
+                           Index Cond: user_id = 9::numeric
+                     ->  Dynamic Table Scan on t_text (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=58)
+                           Filter: user_id = 9::numeric
  Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 2.22.0
-(8 rows)
+ Optimizer status: PQO version 1.602
+(12 rows)
 
 select * from orca.t_text where user_id=9;
    timest   | user_id | tag1  | tag2  
@@ -8374,6 +8385,7 @@ select enable_xform('CXformDynamicGet2DynamicTableScan');
 (1 row)
 
 reset optimizer_enable_constant_expression_evaluation;
+reset optimizer_enable_partial_index;
 -- test that constant expression evaluation works with integers
 drop table if exists orca.t_ceeval_ints;
 NOTICE:  table "t_ceeval_ints" does not exist, skipping
@@ -8390,22 +8402,28 @@ insert into orca.t_ceeval_ints values(2, 100, 'tag1', 'tag2');
 insert into orca.t_ceeval_ints values(3, 100, 'tag1', 'tag2');
 insert into orca.t_ceeval_ints values(4, 101, 'tag1', 'tag2');
 insert into orca.t_ceeval_ints values(5, 102, 'tag1', 'tag2');
+set optimizer_enable_partial_index=on;
 set optimizer_enable_space_pruning=off;
 set optimizer_enable_constant_expression_evaluation=on;
 set optimizer_use_external_constant_expression_evaluation_for_ints = on;
 set optimizer_enumerate_plans=on;
+set optimizer_plan_id = 2;
 explain select * from orca.t_ceeval_ints where user_id=4;
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.00 rows=1 width=28)
-   ->  Sequence  (cost=0.00..431.00 rows=1 width=28)
-         ->  Partition Selector for t_ceeval_ints (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
-               Partitions selected: 3 (out of 3)
-         ->  Dynamic Table Scan on t_ceeval_ints (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=28)
-               Filter: user_id = 4::numeric
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..437.00 rows=1 width=28)
+   ->  Sequence  (cost=0.00..437.00 rows=1 width=28)
+         ->  Partition Selector for t_ceeval_ints (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
+               Partitions selected:  3 (out of 3)
+         ->  Result  (cost=0.00..437.00 rows=1 width=28)
+               ->  Append  (cost=0.00..437.00 rows=1 width=28)
+                     ->  Dynamic Index Scan on t_ceeval_ints (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=58)
+                           Index Cond: user_id = 4::numeric
+                     ->  Dynamic Table Scan on t_ceeval_ints (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=58)
+                           Filter: user_id = 4::numeric
  Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 2.22.0
-(8 rows)
+ Optimizer status: PQO version 1.602
+(12 rows)
 
 select * from orca.t_ceeval_ints where user_id=4;
  user_id | category_id | tag1  | tag2  
@@ -8417,6 +8435,7 @@ reset optimizer_enable_space_pruning;
 reset optimizer_enumerate_plans;
 reset optimizer_use_external_constant_expression_evaluation_for_ints;
 reset optimizer_enable_constant_expression_evaluation;
+reset optimizer_enable_partial_index;
 -- test project elements in TVF
 CREATE FUNCTION orca.csq_f(a int) RETURNS int AS $$ select $1 $$ LANGUAGE SQL;
 CREATE TABLE orca.csq_r(a int);
@@ -9721,6 +9740,7 @@ select disable_xform('CXformInnerJoin2NLJoin');
  CXformInnerJoin2NLJoin is disabled
 (1 row)
 
+set optimizer_enable_partial_index=on;
 set optimizer_enable_indexjoin=on;
 -- force_explain
 set optimizer_segments = 3;
@@ -9733,36 +9753,49 @@ WHERE tq.sym = tt.symbol AND
       tt.event_ts <  tq.end_ts
 GROUP BY 1
 ORDER BY 1 asc ;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-                                                                QUERY PLAN                                                                 
--------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=240615.63..240618.13 rows=1000 width=16)
-   Merge Key: (tt.event_ts / 100000 / 5 * 5)
-   ->  Sort  (cost=240615.63..240618.13 rows=334 width=16)
-         Sort Key: (tt.event_ts / 100000 / 5 * 5)
-         ->  HashAggregate  (cost=240553.30..240565.80 rows=334 width=16)
-               Group By: (tt.event_ts / 100000 / 5 * 5)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=240510.80..240538.30 rows=334 width=16)
-                     Hash Key: (tt.event_ts / 100000 / 5 * 5)
-                     ->  HashAggregate  (cost=240510.80..240518.30 rows=334 width=16)
-                           Group By: tt.event_ts / 100000 / 5 * 5
-                           ->  Hash Join  (cost=604.00..240341.56 rows=11283 width=8)
-                                 Hash Cond: tq.sym::bpchar = tt.symbol
-                                 Join Filter: tt.event_ts >= tq.ets AND tt.event_ts < tq.end_ts AND plusone(tq.bid_price) < tt.trade_price
-                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1424.00 rows=13600 width=98)
-                                       Hash Key: tq.sym
-                                       ->  Append  (cost=0.00..608.00 rows=13600 width=98)
-                                             ->  Seq Scan on my_tq_agg_opt_part_1_prt_p1 tq  (cost=0.00..304.00 rows=6800 width=98)
-                                             ->  Seq Scan on my_tq_agg_opt_part_1_prt_p2 tq  (cost=0.00..304.00 rows=6800 width=98)
-                                 ->  Hash  (cost=324.00..324.00 rows=7467 width=108)
-                                       ->  Seq Scan on my_tt_agg_opt tt  (cost=0.00..324.00 rows=7467 width=108)
+                                                                                                                            QUERY PLAN                                                                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate  (cost=0.00..1305.01 rows=1 width=16)
+   Group By: fivemin
+   ->  Gather Motion 2:1  (slice3; segments: 2)  (cost=0.00..1305.01 rows=1 width=16)
+         Merge Key: fivemin
+         ->  Result  (cost=0.00..1305.01 rows=1 width=16)
+               ->  GroupAggregate  (cost=0.00..1305.01 rows=1 width=16)
+                     Group By: fivemin
+                     ->  Sort  (cost=0.00..1305.01 rows=1 width=8)
+                           Sort Key: fivemin
+                           ->  Result  (cost=0.00..1305.01 rows=1 width=8)
+                                 ->  Sequence  (cost=0.00..1305.01 rows=1 width=8)
+                                       ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=1 width=1)
+                                             ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+                                                   ->  Table Scan on my_tt_agg_opt  (cost=0.00..431.00 rows=1 width=62)
+                                       ->  Sequence  (cost=0.00..874.01 rows=1 width=8)
+                                             ->  Partition Selector for my_tq_agg_opt_part (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
+                                                   Partitions selected:  2 (out of 2)
+                                             ->  Result  (cost=0.00..874.01 rows=1 width=8)
+                                                   ->  Append  (cost=0.00..874.01 rows=1 width=8)
+                                                         ->  Nested Loop  (cost=0.00..437.00 rows=1 width=132)
+                                                               Join Filter: true
+                                                               ->  Broadcast Motion 2:2  (slice1; segments: 2)  (cost=0.00..431.00 rows=2 width=62)
+                                                                     ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=1 width=62)
+                                                               ->  Dynamic Index Scan on my_tq_agg_opt_part (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=70)
+                                                                     Index Cond: public.my_tq_agg_opt_part.ets <= "outer".event_ts AND public.my_tq_agg_opt_part.end_ts > "outer".event_ts
+                                                                     Filter: public.my_tq_agg_opt_part.sym::bpchar = "outer".symbol AND plusone(public.my_tq_agg_opt_part.bid_price) < "outer".trade_price
+                                                         ->  Nested Loop  (cost=0.00..437.00 rows=1 width=132)
+                                                               Join Filter: true
+                                                               ->  Broadcast Motion 2:2  (slice2; segments: 2)  (cost=0.00..431.00 rows=2 width=62)
+                                                                     ->  Shared Scan (share slice:id 2:0)  (cost=0.00..431.00 rows=1 width=62)
+                                                               ->  Dynamic Index Scan on my_tq_agg_opt_part (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=70)
+                                                                     Index Cond: public.my_tq_agg_opt_part.ets <= "outer".event_ts
+                                                                     Filter: public.my_tq_agg_opt_part.sym::bpchar = "outer".symbol AND plusone(public.my_tq_agg_opt_part.bid_price) < "outer".trade_price AND "outer".event_ts < public.my_tq_agg_opt_part.end_ts
  Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: legacy query optimizer
-(22 rows)
+ Optimizer status: PQO version 1.602
+(35 rows)
 
 reset optimizer_segments;
 reset optimizer_enable_constant_expression_evaluation;
 reset optimizer_enable_indexjoin;
+reset optimizer_enable_partial_index;
 select enable_xform('CXformInnerJoin2DynamicIndexGetApply');
                   enable_xform                   
 -------------------------------------------------

--- a/src/test/regress/expected/gp_optimizer.out
+++ b/src/test/regress/expected/gp_optimizer.out
@@ -8228,7 +8228,9 @@ insert into orca.t_date values('01-03-2012'::date,6,'tag1','tag2');
 insert into orca.t_date values('01-03-2012'::date,7,'tag1','tag2');
 insert into orca.t_date values('01-03-2012'::date,8,'tag1','tag2');
 insert into orca.t_date values('01-03-2012'::date,9,'tag1','tag2');
+set optimizer_enable_space_pruning=off;
 set optimizer_enable_constant_expression_evaluation=on;
+set optimizer_enumerate_plans=on;
 explain select * from orca.t_date where user_id=9;
                                               QUERY PLAN                                              
 ------------------------------------------------------------------------------------------------------
@@ -8248,6 +8250,8 @@ select * from orca.t_date where user_id=9;
  01-03-2012 |       9 | tag1  | tag2 
 (1 row)
 
+reset optimizer_enable_space_pruning;
+set optimizer_enumerate_plans=off;
 set optimizer_enable_constant_expression_evaluation=off;
 drop table if exists orca.t_text;
 NOTICE:  table "t_text" does not exist, skipping
@@ -8274,7 +8278,9 @@ insert into orca.t_text values('01-03-2012'::date,6,'ugly','tag2');
 insert into orca.t_text values('01-03-2012'::date,7,'good','tag2');
 insert into orca.t_text values('01-03-2012'::date,8,'bad','tag2');
 insert into orca.t_text values('01-03-2012'::date,9,'ugly','tag2');
+set optimizer_enable_space_pruning=off;
 set optimizer_enable_constant_expression_evaluation=on;
+set optimizer_enumerate_plans=on;
 explain select * from orca.t_text where user_id=9;
                                               QUERY PLAN                                              
 ------------------------------------------------------------------------------------------------------
@@ -8294,6 +8300,8 @@ select * from orca.t_text where user_id=9;
  01-03-2012 |       9 | ugly  | tag2 
 (1 row)
 
+reset optimizer_enable_space_pruning;
+set optimizer_enumerate_plans=off;
 set optimizer_enable_constant_expression_evaluation=off;
 -- create a user defined type and only define equality on it
 -- the type can be used in the partitioning list, but Orca is not able to pick a heterogenous index
@@ -8382,8 +8390,10 @@ insert into orca.t_ceeval_ints values(2, 100, 'tag1', 'tag2');
 insert into orca.t_ceeval_ints values(3, 100, 'tag1', 'tag2');
 insert into orca.t_ceeval_ints values(4, 101, 'tag1', 'tag2');
 insert into orca.t_ceeval_ints values(5, 102, 'tag1', 'tag2');
+set optimizer_enable_space_pruning=off;
 set optimizer_enable_constant_expression_evaluation=on;
 set optimizer_use_external_constant_expression_evaluation_for_ints = on;
+set optimizer_enumerate_plans=on;
 explain select * from orca.t_ceeval_ints where user_id=4;
                                                  QUERY PLAN                                                  
 -------------------------------------------------------------------------------------------------------------
@@ -8403,6 +8413,8 @@ select * from orca.t_ceeval_ints where user_id=4;
        4 |         101 | tag1  | tag2 
 (1 row)
 
+reset optimizer_enable_space_pruning;
+reset optimizer_enumerate_plans;
 reset optimizer_use_external_constant_expression_evaluation_for_ints;
 reset optimizer_enable_constant_expression_evaluation;
 -- test project elements in TVF

--- a/src/test/regress/sql/gp_optimizer.sql
+++ b/src/test/regress/sql/gp_optimizer.sql
@@ -522,9 +522,11 @@ insert into orca.t_date values('01-03-2012'::date,7,'tag1','tag2');
 insert into orca.t_date values('01-03-2012'::date,8,'tag1','tag2');
 insert into orca.t_date values('01-03-2012'::date,9,'tag1','tag2');
 
+set optimizer_enable_partial_index=on;
 set optimizer_enable_space_pruning=off;
 set optimizer_enable_constant_expression_evaluation=on;
 set optimizer_enumerate_plans=on;
+set optimizer_plan_id = 2;
 explain select * from orca.t_date where user_id=9;
 select * from orca.t_date where user_id=9;
 
@@ -560,6 +562,7 @@ insert into orca.t_text values('01-03-2012'::date,9,'ugly','tag2');
 set optimizer_enable_space_pruning=off;
 set optimizer_enable_constant_expression_evaluation=on;
 set optimizer_enumerate_plans=on;
+set optimizer_plan_id = 2;
 
 explain select * from orca.t_text where user_id=9;
 select * from orca.t_text where user_id=9;
@@ -612,6 +615,7 @@ select * from orca.t_employee where user_id = 2;
 select enable_xform('CXformDynamicGet2DynamicTableScan');
 
 reset optimizer_enable_constant_expression_evaluation;
+reset optimizer_enable_partial_index;
 
 -- test that constant expression evaluation works with integers
 drop table if exists orca.t_ceeval_ints;
@@ -628,10 +632,12 @@ insert into orca.t_ceeval_ints values(3, 100, 'tag1', 'tag2');
 insert into orca.t_ceeval_ints values(4, 101, 'tag1', 'tag2');
 insert into orca.t_ceeval_ints values(5, 102, 'tag1', 'tag2');
 
+set optimizer_enable_partial_index=on;
 set optimizer_enable_space_pruning=off;
 set optimizer_enable_constant_expression_evaluation=on;
 set optimizer_use_external_constant_expression_evaluation_for_ints = on;
 set optimizer_enumerate_plans=on;
+set optimizer_plan_id = 2;
 
 explain select * from orca.t_ceeval_ints where user_id=4;
 select * from orca.t_ceeval_ints where user_id=4;
@@ -640,6 +646,7 @@ reset optimizer_enable_space_pruning;
 reset optimizer_enumerate_plans;
 reset optimizer_use_external_constant_expression_evaluation_for_ints;
 reset optimizer_enable_constant_expression_evaluation;
+reset optimizer_enable_partial_index;
 
 -- test project elements in TVF
 
@@ -1178,6 +1185,7 @@ select disable_xform('CXformInnerJoin2HashJoin');
 select disable_xform('CXformInnerJoin2IndexGetApply');
 select disable_xform('CXformInnerJoin2NLJoin');
 
+set optimizer_enable_partial_index=on;
 set optimizer_enable_indexjoin=on;
 
 -- force_explain
@@ -1194,6 +1202,7 @@ ORDER BY 1 asc ;
 reset optimizer_segments;
 reset optimizer_enable_constant_expression_evaluation;
 reset optimizer_enable_indexjoin;
+reset optimizer_enable_partial_index;
 
 select enable_xform('CXformInnerJoin2DynamicIndexGetApply');
 select enable_xform('CXformInnerJoin2HashJoin');

--- a/src/test/regress/sql/gp_optimizer.sql
+++ b/src/test/regress/sql/gp_optimizer.sql
@@ -522,10 +522,14 @@ insert into orca.t_date values('01-03-2012'::date,7,'tag1','tag2');
 insert into orca.t_date values('01-03-2012'::date,8,'tag1','tag2');
 insert into orca.t_date values('01-03-2012'::date,9,'tag1','tag2');
 
+set optimizer_enable_space_pruning=off;
 set optimizer_enable_constant_expression_evaluation=on;
+set optimizer_enumerate_plans=on;
 explain select * from orca.t_date where user_id=9;
 select * from orca.t_date where user_id=9;
 
+reset optimizer_enable_space_pruning;
+set optimizer_enumerate_plans=off;
 set optimizer_enable_constant_expression_evaluation=off;
 
 drop table if exists orca.t_text;
@@ -553,11 +557,15 @@ insert into orca.t_text values('01-03-2012'::date,7,'good','tag2');
 insert into orca.t_text values('01-03-2012'::date,8,'bad','tag2');
 insert into orca.t_text values('01-03-2012'::date,9,'ugly','tag2');
 
+set optimizer_enable_space_pruning=off;
 set optimizer_enable_constant_expression_evaluation=on;
+set optimizer_enumerate_plans=on;
 
 explain select * from orca.t_text where user_id=9;
 select * from orca.t_text where user_id=9;
 
+reset optimizer_enable_space_pruning;
+set optimizer_enumerate_plans=off;
 set optimizer_enable_constant_expression_evaluation=off;
 
 -- create a user defined type and only define equality on it
@@ -620,12 +628,16 @@ insert into orca.t_ceeval_ints values(3, 100, 'tag1', 'tag2');
 insert into orca.t_ceeval_ints values(4, 101, 'tag1', 'tag2');
 insert into orca.t_ceeval_ints values(5, 102, 'tag1', 'tag2');
 
+set optimizer_enable_space_pruning=off;
 set optimizer_enable_constant_expression_evaluation=on;
 set optimizer_use_external_constant_expression_evaluation_for_ints = on;
+set optimizer_enumerate_plans=on;
 
 explain select * from orca.t_ceeval_ints where user_id=4;
 select * from orca.t_ceeval_ints where user_id=4;
 
+reset optimizer_enable_space_pruning;
+reset optimizer_enumerate_plans;
 reset optimizer_use_external_constant_expression_evaluation_for_ints;
 reset optimizer_enable_constant_expression_evaluation;
 


### PR DESCRIPTION
These commits disabled heterogenous index scans in ORCA. This was done as a part of implementing a feature for ORCA wherein we enable index scans while querying leaf partitions directly.
 
We are rethinking this approach. Hence reverting it to original behavior.