### PR TITLE
Fix infinite execution of partition selector

### DIFF
--- a/src/backend/executor/nodePartitionSelector.c
+++ b/src/backend/executor/nodePartitionSelector.c
@@ -146,8 +146,8 @@ ExecPartitionSelector(PartitionSelectorState *node)
 	PartitionSelector *ps = (PartitionSelector *) node->ps.plan;
 	EState	   *estate = node->ps.state;
 	ExprContext *econtext = node->ps.ps_ExprContext;
-	TupleTableSlot *inputSlot;
-	TupleTableSlot *candidateOutputSlot;
+	TupleTableSlot *inputSlot = NULL;
+	TupleTableSlot *candidateOutputSlot = NULL;
 
 	if (ps->staticSelection)
 	{
@@ -195,7 +195,10 @@ ExecPartitionSelector(PartitionSelectorState *node)
 	econtext->ecxt_outertuple = inputSlot;
 	econtext->ecxt_scantuple = inputSlot;
 
-	candidateOutputSlot = ExecProject(node->ps.ps_ProjInfo, NULL);
+	if (NULL != inputSlot)
+	{
+		candidateOutputSlot = ExecProject(node->ps.ps_ProjInfo, NULL);
+	}
 
 	/*
 	 * If we have a partitioning projection, project the input tuple

--- a/src/backend/executor/nodePartitionSelector.c
+++ b/src/backend/executor/nodePartitionSelector.c
@@ -146,7 +146,7 @@ ExecPartitionSelector(PartitionSelectorState *node)
 	PartitionSelector *ps = (PartitionSelector *) node->ps.plan;
 	EState	   *estate = node->ps.state;
 	ExprContext *econtext = node->ps.ps_ExprContext;
-	TupleTableSlot *inputSlot = NULL;
+	TupleTableSlot *inputSlot;
 	TupleTableSlot *candidateOutputSlot;
 
 	if (ps->staticSelection)
@@ -181,12 +181,12 @@ ExecPartitionSelector(PartitionSelectorState *node)
 		PlanState *outerPlan = outerPlanState(node);
 		Assert(outerPlan);
 		inputSlot = ExecProcNode(outerPlan);
-	}
 
-	if (TupIsNull(inputSlot))
-	{
-		/* no more tuples from outerPlan */
-		return NULL;
+		if (TupIsNull(inputSlot))
+		{
+			/* no more tuples from outerPlan */
+			return NULL;
+		}
 	}
 
 	/* partition elimination with the given input tuple */

--- a/src/test/regress/expected/bfv_partition.out
+++ b/src/test/regress/expected/bfv_partition.out
@@ -1938,6 +1938,31 @@ explain analyze select a.* from mpp8031 a, mpp8031 b where a.oid = b.oid;
 (34 rows)
 
 drop table mpp8031;
+-- Test Query on Partition table when optimizer_static_partition_selection is OFF.
+-- start_ignore
+DROP TABLE IF EXISTS partitioned_table;
+NOTICE:  table "partitioned_table" does not exist, skipping
+-- end_ignore
+CREATE TABLE partitioned_table (a int)
+PARTITION BY RANGE(a)
+(
+   END(10),
+   END(20),
+   END(30)
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "partitioned_table_1_prt_1" for table "partitioned_table"
+NOTICE:  CREATE TABLE will create partition "partitioned_table_1_prt_2" for table "partitioned_table"
+NOTICE:  CREATE TABLE will create partition "partitioned_table_1_prt_3" for table "partitioned_table"
+INSERT INTO partitioned_table VALUES(11);
+SET optimizer_static_partition_selection = off;
+SELECT * FROM partitioned_table;
+ a
+----
+ 11
+(1 row)
+
 -- CLEANUP
 -- start_ignore
 drop schema if exists bfv_partition;

--- a/src/test/regress/expected/bfv_partition_optimizer.out
+++ b/src/test/regress/expected/bfv_partition_optimizer.out
@@ -1938,6 +1938,31 @@ explain analyze select a.* from mpp8031 a, mpp8031 b where a.oid = b.oid;
 (31 rows)
 
 drop table mpp8031;
+-- Test Query on Partition table when optimizer_static_partition_selection is OFF.
+-- start_ignore
+DROP TABLE IF EXISTS partitioned_table;
+NOTICE:  table "partitioned_table" does not exist, skipping
+-- end_ignore
+CREATE TABLE partitioned_table (a int)
+PARTITION BY RANGE(a)
+(
+   END(10),
+   END(20),
+   END(30)
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "partitioned_table_1_prt_1" for table "partitioned_table"
+NOTICE:  CREATE TABLE will create partition "partitioned_table_1_prt_2" for table "partitioned_table"
+NOTICE:  CREATE TABLE will create partition "partitioned_table_1_prt_3" for table "partitioned_table"
+INSERT INTO partitioned_table VALUES(11);
+SET optimizer_static_partition_selection = off;
+SELECT * FROM partitioned_table;
+ a
+----
+ 11
+(1 row)
+
 -- CLEANUP
 -- start_ignore
 drop schema if exists bfv_partition;

--- a/src/test/regress/sql/bfv_partition.sql
+++ b/src/test/regress/sql/bfv_partition.sql
@@ -794,6 +794,25 @@ EVERY ('2 mons'::interval)
 explain analyze select a.* from mpp8031 a, mpp8031 b where a.oid = b.oid;
 drop table mpp8031;
 
+-- Test Query on Partition table when optimizer_static_partition_selection is OFF.
+-- start_ignore
+DROP TABLE IF EXISTS partitioned_table;
+-- end_ignore
+
+CREATE TABLE partitioned_table (a int)
+PARTITION BY RANGE(a)
+(
+   END(10),
+   END(20),
+   END(30)
+);
+
+INSERT INTO partitioned_table VALUES(11);
+
+SET optimizer_static_partition_selection = off;
+
+SELECT * FROM partitioned_table;
+
 -- CLEANUP
 -- start_ignore
 drop schema if exists bfv_partition;


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/greenplum-db/gpdb/commit/e378d84bf32922b324a8ce6e8a66be358a0b805f where the partition selector may go in an infinite loop because it never got a chance to actually _select_ the partitions.

This fixes https://github.com/greenplum-db/gpdb/issues/2249