### PR TITLE
Fix partition_locking test that fails intermittently

### DIFF
--- a/src/test/regress/expected/partition_locking.out
+++ b/src/test/regress/expected/partition_locking.out
@@ -58,248 +58,185 @@ SELECT coalesce(
 -- Partitioned table with toast table
 begin;
 -- creation
-create table g (i int, t text) partition by range(i)
+create table partlockt (i int, t text) partition by range(i)
 (start(1) end(10) every(1));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-NOTICE:  CREATE TABLE will create partition "g_1_prt_1" for table "g"
-NOTICE:  CREATE TABLE will create partition "g_1_prt_2" for table "g"
-NOTICE:  CREATE TABLE will create partition "g_1_prt_3" for table "g"
-NOTICE:  CREATE TABLE will create partition "g_1_prt_4" for table "g"
-NOTICE:  CREATE TABLE will create partition "g_1_prt_5" for table "g"
-NOTICE:  CREATE TABLE will create partition "g_1_prt_6" for table "g"
-NOTICE:  CREATE TABLE will create partition "g_1_prt_7" for table "g"
-NOTICE:  CREATE TABLE will create partition "g_1_prt_8" for table "g"
-NOTICE:  CREATE TABLE will create partition "g_1_prt_9" for table "g"
-select * from locktest_master;
-          coalesce          |        mode         | locktype |  node  
-----------------------------+---------------------+----------+--------
- g                          | AccessExclusiveLock | relation | master
- gp_distribution_policy     | RowExclusiveLock    | relation | master
- pg_class                   | AccessShareLock     | relation | master
- pg_class                   | RowExclusiveLock    | relation | master
- pg_class_oid_index         | AccessShareLock     | relation | master
- pg_class_relname_nsp_index | AccessShareLock     | relation | master
- pg_depend                  | RowExclusiveLock    | relation | master
- pg_locks                   | AccessShareLock     | relation | master
- pg_partition               | AccessShareLock     | relation | master
- pg_partition               | RowExclusiveLock    | relation | master
- pg_partition_rule          | RowExclusiveLock    | relation | master
- pg_type                    | RowExclusiveLock    | relation | master
- toast index                | AccessExclusiveLock | relation | master
- toast table                | ShareLock           | relation | master
-(14 rows)
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_1" for table "partlockt"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_2" for table "partlockt"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_3" for table "partlockt"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_4" for table "partlockt"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_5" for table "partlockt"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_6" for table "partlockt"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_7" for table "partlockt"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_8" for table "partlockt"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_9" for table "partlockt"
+select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+  coalesce   |        mode         | locktype |  node  
+-------------+---------------------+----------+--------
+ partlockt   | AccessExclusiveLock | relation | master
+ toast index | AccessExclusiveLock | relation | master
+ toast table | ShareLock           | relation | master
+(3 rows)
 
-select * from locktest_segments;
+select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
   coalesce   |        mode         | locktype |    node    
 -------------+---------------------+----------+------------
- toast table | ShareLock           | relation | n segments
- pg_class    | AccessShareLock     | relation | n segments
- g           | AccessExclusiveLock | relation | n segments
+ partlockt   | AccessExclusiveLock | relation | n segments
  toast index | AccessExclusiveLock | relation | n segments
-(4 rows)
+ toast table | ShareLock           | relation | n segments
+(3 rows)
 
 commit;
 -- drop
 begin;
-drop table g;
-select * from locktest_master;
-          coalesce          |        mode         | locktype |  node  
-----------------------------+---------------------+----------+--------
- dropped table              | AccessExclusiveLock | relation | master
- dropped table              | AccessExclusiveLock | relation | master
- dropped table              | AccessExclusiveLock | relation | master
- gp_distribution_policy     | RowExclusiveLock    | relation | master
- pg_class                   | AccessShareLock     | relation | master
- pg_class                   | RowExclusiveLock    | relation | master
- pg_class_oid_index         | AccessShareLock     | relation | master
- pg_class_relname_nsp_index | AccessShareLock     | relation | master
- pg_depend                  | RowExclusiveLock    | relation | master
- pg_locks                   | AccessShareLock     | relation | master
- pg_partition               | RowExclusiveLock    | relation | master
- pg_partition_rule          | RowExclusiveLock    | relation | master
- pg_type                    | RowExclusiveLock    | relation | master
-(13 rows)
+drop table partlockt;
+select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+   coalesce    |        mode         | locktype |  node  
+---------------+---------------------+----------+--------
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+(3 rows)
 
-select * from locktest_segments;
-        coalesce        |         mode        | locktype |    node    
-------------------------+---------------------+----------+------------
- dropped table          | AccessExclusiveLock | relation | n segments
- dropped table          | AccessExclusiveLock | relation | n segments
- dropped table          | AccessExclusiveLock | relation | n segments
- gp_distribution_policy | RowExclusiveLock    | relation | n segments
- pg_class               | AccessShareLock     | relation | n segments
-(5 rows)
+select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+   coalesce    |        mode         | locktype |    node    
+---------------+---------------------+----------+------------
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+(3 rows)
 
 commit;
 -- AO table (ao segments, block directory won't exist after create)
 begin;
 -- creation
-create table g (i int, t text, n numeric)
+create table partlockt (i int, t text, n numeric)
 with (appendonly = true)
 partition by list(i)
 (values(1), values(2), values(3));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-NOTICE:  CREATE TABLE will create partition "g_1_prt_1" for table "g"
-NOTICE:  CREATE TABLE will create partition "g_1_prt_2" for table "g"
-NOTICE:  CREATE TABLE will create partition "g_1_prt_3" for table "g"
-select * from locktest_master;
-          coalesce          |        mode         | locktype |  node  
-----------------------------+---------------------+----------+--------
- g                          | AccessExclusiveLock | relation | master
- gp_distribution_policy     | RowExclusiveLock    | relation | master
- pg_appendonly              | RowExclusiveLock    | relation | master
- pg_class                   | AccessShareLock     | relation | master
- pg_class                   | RowExclusiveLock    | relation | master
- pg_class_oid_index         | AccessShareLock     | relation | master
- pg_class_relname_nsp_index | AccessShareLock     | relation | master
- pg_depend                  | RowExclusiveLock    | relation | master
- pg_locks                   | AccessShareLock     | relation | master
- pg_partition               | AccessShareLock     | relation | master
- pg_partition               | RowExclusiveLock    | relation | master
- pg_partition_rule          | RowExclusiveLock    | relation | master
- pg_type                    | RowExclusiveLock    | relation | master
- toast index                | AccessExclusiveLock | relation | master
- toast table                | ShareLock           | relation | master
-(15 rows)
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_1" for table "partlockt"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_2" for table "partlockt"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_3" for table "partlockt"
+select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+  coalesce   |        mode         | locktype |  node  
+-------------+---------------------+----------+--------
+ partlockt   | AccessExclusiveLock | relation | master
+ toast index | AccessExclusiveLock | relation | master
+ toast table | ShareLock           | relation | master
+(3 rows)
 
-select * from locktest_segments;
-   coalesce    |        mode         | locktype |    node    
----------------+---------------------+----------+------------
- toast table   | ShareLock           | relation | n segments
- pg_class      | AccessShareLock     | relation | n segments
- g             | AccessExclusiveLock | relation | n segments
- toast index   | AccessExclusiveLock | relation | n segments
- pg_appendonly | RowExclusiveLock    | relation | n segments
-(5 rows)
+select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+  coalesce   |        mode         | locktype |    node    
+-------------+---------------------+----------+------------
+ toast index | AccessExclusiveLock | relation | n segments
+ partlockt   | AccessExclusiveLock | relation | n segments
+ toast table | ShareLock           | relation | n segments
+(3 rows)
 
 commit;
 begin;
 -- add a little data
-insert into g values(1), (2), (3);
-insert into g values(1), (2), (3);
-insert into g values(1), (2), (3);
-insert into g values(1), (2), (3);
-insert into g values(1), (2), (3);
-select * from locktest_master;
-          coalesce          |        mode         |         locktype         |  node  
-----------------------------+---------------------+--------------------------+--------
- g                          | RowExclusiveLock    | relation                 | master
- g_1_prt_1                  | AccessExclusiveLock | append-only segment file | master
- g_1_prt_1                  | AccessShareLock     | relation                 | master
- g_1_prt_2                  | AccessExclusiveLock | append-only segment file | master
- g_1_prt_2                  | AccessShareLock     | relation                 | master
- g_1_prt_3                  | AccessExclusiveLock | append-only segment file | master
- g_1_prt_3                  | AccessShareLock     | relation                 | master
- pg_class                   | AccessShareLock     | relation                 | master
- pg_class_oid_index         | AccessShareLock     | relation                 | master
- pg_class_relname_nsp_index | AccessShareLock     | relation                 | master
- pg_locks                   | AccessShareLock     | relation                 | master
-(11 rows)
+insert into partlockt values(1), (2), (3);
+insert into partlockt values(1), (2), (3);
+insert into partlockt values(1), (2), (3);
+insert into partlockt values(1), (2), (3);
+insert into partlockt values(1), (2), (3);
+select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+     coalesce      |        mode         |         locktype         |  node  
+-------------------+---------------------+--------------------------+--------
+ partlockt         | RowExclusiveLock    | relation                 | master
+ partlockt_1_prt_1 | AccessExclusiveLock | append-only segment file | master
+ partlockt_1_prt_1 | AccessShareLock     | relation                 | master
+ partlockt_1_prt_2 | AccessExclusiveLock | append-only segment file | master
+ partlockt_1_prt_2 | AccessShareLock     | relation                 | master
+ partlockt_1_prt_3 | AccessExclusiveLock | append-only segment file | master
+ partlockt_1_prt_3 | AccessShareLock     | relation                 | master
+(7 rows)
 
-select * from locktest_segments;
-  coalesce   |        mode         |         locktype         |    node    
--------------+---------------------+--------------------------+------------
- g_1_prt_3   | RowExclusiveLock    | relation                 | 1 segment
- pg_class    | AccessShareLock     | relation                 | n segments
- g_1_prt_3   | AccessExclusiveLock | append-only segment file | 1 segment
- g_1_prt_2   | RowExclusiveLock    | relation                 | 1 segment
- aoseg table | AccessShareLock     | relation                 | n segments
- aoseg table | AccessShareLock     | relation                 | n segments
- aoseg table | AccessShareLock     | relation                 | n segments
- aoseg table | AccessShareLock     | relation                 | n segments
- g_1_prt_2   | AccessExclusiveLock | append-only segment file | 1 segment
- g_1_prt_1   | AccessExclusiveLock | append-only segment file | 1 segment
- g_1_prt_1   | RowExclusiveLock    | relation                 | 1 segment
- g           | RowExclusiveLock    | relation                 | n segments
-(12 rows)
+select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+     coalesce      |        mode         |         locktype         |    node    
+-------------------+---------------------+--------------------------+------------
+ partlockt         | RowExclusiveLock    | relation                 | n segments
+ aoseg table       | AccessShareLock     | relation                 | n segments
+ aoseg table       | AccessShareLock     | relation                 | n segments
+ partlockt_1_prt_1 | AccessExclusiveLock | append-only segment file | 1 segment
+ partlockt_1_prt_3 | AccessExclusiveLock | append-only segment file | 1 segment
+ partlockt_1_prt_3 | RowExclusiveLock    | relation                 | 1 segment
+ partlockt_1_prt_2 | RowExclusiveLock    | relation                 | 1 segment
+ partlockt_1_prt_2 | AccessExclusiveLock | append-only segment file | 1 segment
+ aoseg table       | AccessShareLock     | relation                 | n segments
+ aoseg table       | AccessShareLock     | relation                 | n segments
+ partlockt_1_prt_1 | RowExclusiveLock    | relation                 | 1 segment
+(11 rows)
 
 commit;
 -- drop
 begin;
-drop table g;
-select * from locktest_master;
-          coalesce          |        mode         | locktype |  node  
-----------------------------+---------------------+----------+--------
- dropped table              | AccessExclusiveLock | relation | master
- dropped table              | AccessExclusiveLock | relation | master
- dropped table              | AccessExclusiveLock | relation | master
- dropped table              | AccessExclusiveLock | relation | master
- dropped table              | AccessExclusiveLock | relation | master
- dropped table              | AccessExclusiveLock | relation | master
- gp_distribution_policy     | RowExclusiveLock    | relation | master
- pg_appendonly              | RowExclusiveLock    | relation | master
- pg_class                   | AccessShareLock     | relation | master
- pg_class                   | RowExclusiveLock    | relation | master
- pg_class_oid_index         | AccessShareLock     | relation | master
- pg_class_relname_nsp_index | AccessShareLock     | relation | master
- pg_depend                  | RowExclusiveLock    | relation | master
- pg_locks                   | AccessShareLock     | relation | master
- pg_partition               | RowExclusiveLock    | relation | master
- pg_partition_rule          | RowExclusiveLock    | relation | master
- pg_type                    | RowExclusiveLock    | relation | master
-(17 rows)
+drop table partlockt;
+select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+   coalesce    |        mode         | locktype |  node  
+---------------+---------------------+----------+--------
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+(6 rows)
 
-select * from locktest_segments;
-        coalesce        |        mode         | locktype |    node    
-------------------------+---------------------+----------+------------
- pg_class               | AccessShareLock     | relation | n segments
- dropped table          | AccessExclusiveLock | relation | n segments
- dropped table          | AccessExclusiveLock | relation | n segments
- dropped table          | AccessExclusiveLock | relation | n segments
- dropped table          | AccessExclusiveLock | relation | n segments
- dropped table          | AccessExclusiveLock | relation | n segments
- dropped table          | AccessExclusiveLock | relation | n segments
- gp_distribution_policy | RowExclusiveLock    | relation | n segments
- pg_appendonly          | RowExclusiveLock    | relation | n segments
-(9 rows)
+select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+   coalesce    |        mode         | locktype |    node    
+---------------+---------------------+----------+------------
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+(6 rows)
 
 commit;
 -- Indexing
-create table g (i int, t text) partition by range(i)
+create table partlockt (i int, t text) partition by range(i)
 (start(1) end(10) every(1));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-NOTICE:  CREATE TABLE will create partition "g_1_prt_1" for table "g"
-NOTICE:  CREATE TABLE will create partition "g_1_prt_2" for table "g"
-NOTICE:  CREATE TABLE will create partition "g_1_prt_3" for table "g"
-NOTICE:  CREATE TABLE will create partition "g_1_prt_4" for table "g"
-NOTICE:  CREATE TABLE will create partition "g_1_prt_5" for table "g"
-NOTICE:  CREATE TABLE will create partition "g_1_prt_6" for table "g"
-NOTICE:  CREATE TABLE will create partition "g_1_prt_7" for table "g"
-NOTICE:  CREATE TABLE will create partition "g_1_prt_8" for table "g"
-NOTICE:  CREATE TABLE will create partition "g_1_prt_9" for table "g"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_1" for table "partlockt"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_2" for table "partlockt"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_3" for table "partlockt"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_4" for table "partlockt"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_5" for table "partlockt"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_6" for table "partlockt"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_7" for table "partlockt"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_8" for table "partlockt"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_9" for table "partlockt"
 begin;
-create index g_idx on g(i);
-NOTICE:  building index for child partition "g_1_prt_1"
-NOTICE:  building index for child partition "g_1_prt_2"
-NOTICE:  building index for child partition "g_1_prt_3"
-NOTICE:  building index for child partition "g_1_prt_4"
-NOTICE:  building index for child partition "g_1_prt_5"
-NOTICE:  building index for child partition "g_1_prt_6"
-NOTICE:  building index for child partition "g_1_prt_7"
-NOTICE:  building index for child partition "g_1_prt_8"
-NOTICE:  building index for child partition "g_1_prt_9"
-select * from locktest_master;
-          coalesce          |        mode         | locktype |  node  
-----------------------------+---------------------+----------+--------
- g                          | ShareLock           | relation | master
- g_idx                      | AccessExclusiveLock | relation | master
- pg_class                   | AccessShareLock     | relation | master
- pg_class_oid_index         | AccessShareLock     | relation | master
- pg_class_relname_nsp_index | AccessShareLock     | relation | master
- pg_locks                   | AccessShareLock     | relation | master
- pg_partition_rule          | AccessShareLock     | relation | master
-(7 rows)
+create index partlockt_idx on partlockt(i);
+NOTICE:  building index for child partition "partlockt_1_prt_1"
+NOTICE:  building index for child partition "partlockt_1_prt_2"
+NOTICE:  building index for child partition "partlockt_1_prt_3"
+NOTICE:  building index for child partition "partlockt_1_prt_4"
+NOTICE:  building index for child partition "partlockt_1_prt_5"
+NOTICE:  building index for child partition "partlockt_1_prt_6"
+NOTICE:  building index for child partition "partlockt_1_prt_7"
+NOTICE:  building index for child partition "partlockt_1_prt_8"
+NOTICE:  building index for child partition "partlockt_1_prt_9"
+select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+   coalesce    |        mode         | locktype |  node  
+---------------+---------------------+----------+--------
+ partlockt     | ShareLock           | relation | master
+ partlockt_idx | AccessExclusiveLock | relation | master
+(2 rows)
 
-select * from locktest_segments;
- coalesce |        mode         | locktype |    node    
-----------+---------------------+----------+------------
- g        | ShareLock           | relation | n segments
- pg_class | AccessShareLock     | relation | n segments
- g_idx    | AccessExclusiveLock | relation | n segments
-(3 rows)
+select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+   coalesce    |        mode         | locktype |    node    
+---------------+---------------------+----------+------------
+ partlockt     | ShareLock           | relation | n segments
+ partlockt_idx | AccessExclusiveLock | relation | n segments
+(2 rows)
 
 commit;
 -- Force use of the index in the select and delete below. We're not interested
@@ -309,109 +246,82 @@ commit;
 set enable_seqscan=off;
 -- test select locking
 begin;
-select * from g where i = 1;
+select * from partlockt where i = 1;
  i | t 
 ---+---
 (0 rows)
 
 -- Known_opt_diff: MPP-20936
-select * from locktest_master;
-          coalesce          |      mode       | locktype |  node  
-----------------------------+-----------------+----------+--------
- g                          | AccessShareLock | relation | master
- g_1_prt_1                  | AccessShareLock | relation | master
- g_idx_1_prt_1              | AccessShareLock | relation | master
- pg_class                   | AccessShareLock | relation | master
- pg_class_oid_index         | AccessShareLock | relation | master
- pg_class_relname_nsp_index | AccessShareLock | relation | master
- pg_locks                   | AccessShareLock | relation | master
-(7 rows)
-
-select * from locktest_segments;
-   coalesce    |      mode       | locktype |    node    
----------------+-----------------+----------+------------
- g_idx_1_prt_1 | AccessShareLock | relation | 1 segment
- pg_class      | AccessShareLock | relation | n segments
- g_1_prt_1     | AccessShareLock | relation | 1 segment
+select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+       coalesce        |      mode       | locktype |  node  
+-----------------------+-----------------+----------+--------
+ partlockt             | AccessShareLock | relation | master
+ partlockt_1_prt_1     | AccessShareLock | relation | master
+ partlockt_idx_1_prt_1 | AccessShareLock | relation | master
 (3 rows)
+
+select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+       coalesce        |      mode       | locktype |   node    
+-----------------------+-----------------+----------+-----------
+ partlockt_idx_1_prt_1 | AccessShareLock | relation | 1 segment
+ partlockt_1_prt_1     | AccessShareLock | relation | 1 segment
+(2 rows)
 
 commit;
 begin;
 -- insert locking
-insert into g values(3, 'f');
-select * from locktest_master;
-          coalesce          |       mode       | locktype |  node  
-----------------------------+------------------+----------+--------
- g                          | RowExclusiveLock | relation | master
- pg_class                   | AccessShareLock  | relation | master
- pg_class_oid_index         | AccessShareLock  | relation | master
- pg_class_relname_nsp_index | AccessShareLock  | relation | master
- pg_locks                   | AccessShareLock  | relation | master
-(5 rows)
+insert into partlockt values(3, 'f');
+select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+ coalesce  |       mode       | locktype |  node  
+-----------+------------------+----------+--------
+ partlockt | RowExclusiveLock | relation | master
+(1 row)
 
-select * from locktest_segments;
- coalesce  |       mode       | locktype |    node    
------------+------------------+----------+------------
- g         | RowExclusiveLock | relation | 1 segment
- g_1_prt_3 | RowExclusiveLock | relation | 1 segment
- pg_class  | AccessShareLock  | relation | n segments
-(3 rows)
+select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+     coalesce      |       mode       | locktype |   node    
+-------------------+------------------+----------+-----------
+ partlockt         | RowExclusiveLock | relation | 1 segment
+ partlockt_1_prt_3 | RowExclusiveLock | relation | 1 segment
+(2 rows)
 
 commit;
 -- delete locking
 begin;
-delete from g where i = 4;
+delete from partlockt where i = 4;
 -- Known_opt_diff: MPP-20936
-select * from locktest_master;
-          coalesce          |       mode      | locktype |  node  
-----------------------------+-----------------+----------+--------
- g                          | ExclusiveLock   | relation | master
- g_1_prt_4                  | ExclusiveLock   | relation | master
- pg_class                   | AccessShareLock | relation | master
- pg_class_oid_index         | AccessShareLock | relation | master
- pg_class_relname_nsp_index | AccessShareLock | relation | master
- pg_locks                   | AccessShareLock | relation | master
-(6 rows)
-
-select * from locktest_segments;
- coalesce  |       mode       | locktype |    node    
------------+------------------+----------+------------
- pg_class  | AccessShareLock  | relation | n segments
- g_1_prt_4 | RowExclusiveLock | relation | 1 segment
+select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+     coalesce      |     mode      | locktype |  node  
+-------------------+---------------+----------+--------
+ partlockt         | ExclusiveLock | relation | master
+ partlockt_1_prt_4 | ExclusiveLock | relation | master
 (2 rows)
+
+select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+     coalesce      |       mode       | locktype |   node    
+-------------------+------------------+----------+-----------
+ partlockt_1_prt_4 | RowExclusiveLock | relation | 1 segment
+(1 row)
 
 commit;
 -- drop index
 begin;
-drop table g;
-select * from locktest_master;
-          coalesce          |        mode         | locktype |  node  
-----------------------------+---------------------+----------+--------
- dropped table              | AccessExclusiveLock | relation | master
- dropped table              | AccessExclusiveLock | relation | master
- dropped table              | AccessExclusiveLock | relation | master
- dropped table              | AccessExclusiveLock | relation | master
- gp_distribution_policy     | RowExclusiveLock    | relation | master
- pg_class                   | AccessShareLock     | relation | master
- pg_class                   | RowExclusiveLock    | relation | master
- pg_class_oid_index         | AccessShareLock     | relation | master
- pg_class_relname_nsp_index | AccessShareLock     | relation | master
- pg_depend                  | RowExclusiveLock    | relation | master
- pg_locks                   | AccessShareLock     | relation | master
- pg_partition               | RowExclusiveLock    | relation | master
- pg_partition_rule          | RowExclusiveLock    | relation | master
- pg_type                    | RowExclusiveLock    | relation | master
-(14 rows)
+drop table partlockt;
+select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+   coalesce    |        mode         | locktype |  node  
+---------------+---------------------+----------+--------
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+(4 rows)
 
-select * from locktest_segments;
-        coalesce        |        mode         | locktype |    node    
-------------------------+---------------------+----------+------------
- pg_class               | AccessShareLock     | relation | n segments
- dropped table          | AccessExclusiveLock | relation | n segments
- dropped table          | AccessExclusiveLock | relation | n segments
- dropped table          | AccessExclusiveLock | relation | n segments
- dropped table          | AccessExclusiveLock | relation | n segments
- gp_distribution_policy | RowExclusiveLock    | relation | n segments
-(6 rows)
+select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+   coalesce    |        mode         | locktype |    node    
+---------------+---------------------+----------+------------
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+(4 rows)
 
 commit;

--- a/src/test/regress/expected/partition_locking_optimizer.out
+++ b/src/test/regress/expected/partition_locking_optimizer.out
@@ -58,248 +58,185 @@ SELECT coalesce(
 -- Partitioned table with toast table
 begin;
 -- creation
-create table g (i int, t text) partition by range(i)
+create table partlockt (i int, t text) partition by range(i)
 (start(1) end(10) every(1));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-NOTICE:  CREATE TABLE will create partition "g_1_prt_1" for table "g"
-NOTICE:  CREATE TABLE will create partition "g_1_prt_2" for table "g"
-NOTICE:  CREATE TABLE will create partition "g_1_prt_3" for table "g"
-NOTICE:  CREATE TABLE will create partition "g_1_prt_4" for table "g"
-NOTICE:  CREATE TABLE will create partition "g_1_prt_5" for table "g"
-NOTICE:  CREATE TABLE will create partition "g_1_prt_6" for table "g"
-NOTICE:  CREATE TABLE will create partition "g_1_prt_7" for table "g"
-NOTICE:  CREATE TABLE will create partition "g_1_prt_8" for table "g"
-NOTICE:  CREATE TABLE will create partition "g_1_prt_9" for table "g"
-select * from locktest_master;
-          coalesce          |        mode         | locktype |  node  
-----------------------------+---------------------+----------+--------
- g                          | AccessExclusiveLock | relation | master
- gp_distribution_policy     | RowExclusiveLock    | relation | master
- pg_class                   | AccessShareLock     | relation | master
- pg_class                   | RowExclusiveLock    | relation | master
- pg_class_oid_index         | AccessShareLock     | relation | master
- pg_class_relname_nsp_index | AccessShareLock     | relation | master
- pg_depend                  | RowExclusiveLock    | relation | master
- pg_locks                   | AccessShareLock     | relation | master
- pg_partition               | AccessShareLock     | relation | master
- pg_partition               | RowExclusiveLock    | relation | master
- pg_partition_rule          | RowExclusiveLock    | relation | master
- pg_type                    | RowExclusiveLock    | relation | master
- toast index                | AccessExclusiveLock | relation | master
- toast table                | ShareLock           | relation | master
-(14 rows)
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_1" for table "partlockt"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_2" for table "partlockt"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_3" for table "partlockt"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_4" for table "partlockt"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_5" for table "partlockt"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_6" for table "partlockt"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_7" for table "partlockt"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_8" for table "partlockt"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_9" for table "partlockt"
+select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+  coalesce   |        mode         | locktype |  node  
+-------------+---------------------+----------+--------
+ partlockt   | AccessExclusiveLock | relation | master
+ toast index | AccessExclusiveLock | relation | master
+ toast table | ShareLock           | relation | master
+(3 rows)
 
-select * from locktest_segments;
+select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
   coalesce   |        mode         | locktype |    node    
 -------------+---------------------+----------+------------
  toast index | AccessExclusiveLock | relation | n segments
  toast table | ShareLock           | relation | n segments
- g           | AccessExclusiveLock | relation | n segments
- pg_class    | AccessShareLock     | relation | n segments
-(4 rows)
+ partlockt   | AccessExclusiveLock | relation | n segments
+(3 rows)
 
 commit;
 -- drop
 begin;
-drop table g;
-select * from locktest_master;
-          coalesce          |        mode         | locktype |  node  
-----------------------------+---------------------+----------+--------
- dropped table              | AccessExclusiveLock | relation | master
- dropped table              | AccessExclusiveLock | relation | master
- dropped table              | AccessExclusiveLock | relation | master
- gp_distribution_policy     | RowExclusiveLock    | relation | master
- pg_class                   | AccessShareLock     | relation | master
- pg_class                   | RowExclusiveLock    | relation | master
- pg_class_oid_index         | AccessShareLock     | relation | master
- pg_class_relname_nsp_index | AccessShareLock     | relation | master
- pg_depend                  | RowExclusiveLock    | relation | master
- pg_locks                   | AccessShareLock     | relation | master
- pg_partition               | RowExclusiveLock    | relation | master
- pg_partition_rule          | RowExclusiveLock    | relation | master
- pg_type                    | RowExclusiveLock    | relation | master
-(13 rows)
+drop table partlockt;
+select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+   coalesce    |        mode         | locktype |  node  
+---------------+---------------------+----------+--------
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+(3 rows)
 
-select * from locktest_segments;
-        coalesce        |        mode         | locktype |    node    
-------------------------+---------------------+----------+------------
- dropped table          | AccessExclusiveLock | relation | n segments
- gp_distribution_policy | RowExclusiveLock    | relation | n segments
- dropped table          | AccessExclusiveLock | relation | n segments
- pg_class               | AccessShareLock     | relation | n segments
- dropped table          | AccessExclusiveLock | relation | n segments
-(5 rows)
+select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+   coalesce    |        mode         | locktype |    node    
+---------------+---------------------+----------+------------
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+(3 rows)
 
 commit;
 -- AO table (ao segments, block directory won't exist after create)
 begin;
 -- creation
-create table g (i int, t text, n numeric)
+create table partlockt (i int, t text, n numeric)
 with (appendonly = true)
 partition by list(i)
 (values(1), values(2), values(3));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-NOTICE:  CREATE TABLE will create partition "g_1_prt_1" for table "g"
-NOTICE:  CREATE TABLE will create partition "g_1_prt_2" for table "g"
-NOTICE:  CREATE TABLE will create partition "g_1_prt_3" for table "g"
-select * from locktest_master;
-          coalesce          |        mode         | locktype |  node  
-----------------------------+---------------------+----------+--------
- g                          | AccessExclusiveLock | relation | master
- gp_distribution_policy     | RowExclusiveLock    | relation | master
- pg_appendonly              | RowExclusiveLock    | relation | master
- pg_class                   | AccessShareLock     | relation | master
- pg_class                   | RowExclusiveLock    | relation | master
- pg_class_oid_index         | AccessShareLock     | relation | master
- pg_class_relname_nsp_index | AccessShareLock     | relation | master
- pg_depend                  | RowExclusiveLock    | relation | master
- pg_locks                   | AccessShareLock     | relation | master
- pg_partition               | AccessShareLock     | relation | master
- pg_partition               | RowExclusiveLock    | relation | master
- pg_partition_rule          | RowExclusiveLock    | relation | master
- pg_type                    | RowExclusiveLock    | relation | master
- toast index                | AccessExclusiveLock | relation | master
- toast table                | ShareLock           | relation | master
-(15 rows)
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_1" for table "partlockt"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_2" for table "partlockt"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_3" for table "partlockt"
+select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+  coalesce   |        mode         | locktype |  node  
+-------------+---------------------+----------+--------
+ partlockt   | AccessExclusiveLock | relation | master
+ toast index | AccessExclusiveLock | relation | master
+ toast table | ShareLock           | relation | master
+(3 rows)
 
-select * from locktest_segments;
-   coalesce    |        mode         | locktype |    node    
----------------+---------------------+----------+------------
- pg_class      | AccessShareLock     | relation | n segments
- pg_appendonly | RowExclusiveLock    | relation | n segments
- g             | AccessExclusiveLock | relation | n segments
- toast table   | ShareLock           | relation | n segments
- toast index   | AccessExclusiveLock | relation | n segments
-(5 rows)
+select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+  coalesce   |        mode         | locktype |    node    
+-------------+---------------------+----------+------------
+ toast index | AccessExclusiveLock | relation | n segments
+ toast table | ShareLock           | relation | n segments
+ partlockt   | AccessExclusiveLock | relation | n segments
+(3 rows)
 
 commit;
 begin;
 -- add a little data
-insert into g values(1), (2), (3);
-insert into g values(1), (2), (3);
-insert into g values(1), (2), (3);
-insert into g values(1), (2), (3);
-insert into g values(1), (2), (3);
-select * from locktest_master;
-          coalesce          |        mode         |         locktype         |  node  
-----------------------------+---------------------+--------------------------+--------
- g                          | RowExclusiveLock    | relation                 | master
- g_1_prt_1                  | AccessExclusiveLock | append-only segment file | master
- g_1_prt_1                  | AccessShareLock     | relation                 | master
- g_1_prt_2                  | AccessExclusiveLock | append-only segment file | master
- g_1_prt_2                  | AccessShareLock     | relation                 | master
- g_1_prt_3                  | AccessExclusiveLock | append-only segment file | master
- g_1_prt_3                  | AccessShareLock     | relation                 | master
- pg_class                   | AccessShareLock     | relation                 | master
- pg_class_oid_index         | AccessShareLock     | relation                 | master
- pg_class_relname_nsp_index | AccessShareLock     | relation                 | master
- pg_locks                   | AccessShareLock     | relation                 | master
-(11 rows)
+insert into partlockt values(1), (2), (3);
+insert into partlockt values(1), (2), (3);
+insert into partlockt values(1), (2), (3);
+insert into partlockt values(1), (2), (3);
+insert into partlockt values(1), (2), (3);
+select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+     coalesce      |        mode         |         locktype         |  node  
+-------------------+---------------------+--------------------------+--------
+ partlockt         | RowExclusiveLock    | relation                 | master
+ partlockt_1_prt_1 | AccessExclusiveLock | append-only segment file | master
+ partlockt_1_prt_1 | AccessShareLock     | relation                 | master
+ partlockt_1_prt_2 | AccessExclusiveLock | append-only segment file | master
+ partlockt_1_prt_2 | AccessShareLock     | relation                 | master
+ partlockt_1_prt_3 | AccessExclusiveLock | append-only segment file | master
+ partlockt_1_prt_3 | AccessShareLock     | relation                 | master
+(7 rows)
 
-select * from locktest_segments;
-  coalesce   |        mode         |         locktype         |    node    
--------------+---------------------+--------------------------+------------
- g_1_prt_3   | AccessExclusiveLock | append-only segment file | 1 segment
- g_1_prt_2   | RowExclusiveLock    | relation                 | 1 segment
- aoseg table | AccessShareLock     | relation                 | n segments
- g           | RowExclusiveLock    | relation                 | n segments
- g_1_prt_1   | AccessExclusiveLock | append-only segment file | 1 segment
- g_1_prt_1   | RowExclusiveLock    | relation                 | 1 segment
- pg_class    | AccessShareLock     | relation                 | n segments
- g_1_prt_3   | RowExclusiveLock    | relation                 | 1 segment
- aoseg table | AccessShareLock     | relation                 | n segments
- aoseg table | AccessShareLock     | relation                 | n segments
- aoseg table | AccessShareLock     | relation                 | n segments
- g_1_prt_2   | AccessExclusiveLock | append-only segment file | 1 segment
-(12 rows)
+select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+     coalesce      |        mode         |         locktype         |    node    
+-------------------+---------------------+--------------------------+------------
+ aoseg table       | AccessShareLock     | relation                 | n segments
+ aoseg table       | AccessShareLock     | relation                 | n segments
+ aoseg table       | AccessShareLock     | relation                 | n segments
+ partlockt_1_prt_1 | RowExclusiveLock    | relation                 | 1 segment
+ partlockt_1_prt_2 | AccessExclusiveLock | append-only segment file | 1 segment
+ aoseg table       | AccessShareLock     | relation                 | n segments
+ partlockt         | RowExclusiveLock    | relation                 | n segments
+ partlockt_1_prt_2 | RowExclusiveLock    | relation                 | 1 segment
+ partlockt_1_prt_1 | AccessExclusiveLock | append-only segment file | 1 segment
+ partlockt_1_prt_3 | RowExclusiveLock    | relation                 | 1 segment
+ partlockt_1_prt_3 | AccessExclusiveLock | append-only segment file | 1 segment
+(11 rows)
 
 commit;
 -- drop
 begin;
-drop table g;
-select * from locktest_master;
-          coalesce          |        mode         | locktype |  node  
-----------------------------+---------------------+----------+--------
- dropped table              | AccessExclusiveLock | relation | master
- dropped table              | AccessExclusiveLock | relation | master
- dropped table              | AccessExclusiveLock | relation | master
- dropped table              | AccessExclusiveLock | relation | master
- dropped table              | AccessExclusiveLock | relation | master
- dropped table              | AccessExclusiveLock | relation | master
- gp_distribution_policy     | RowExclusiveLock    | relation | master
- pg_appendonly              | RowExclusiveLock    | relation | master
- pg_class                   | AccessShareLock     | relation | master
- pg_class                   | RowExclusiveLock    | relation | master
- pg_class_oid_index         | AccessShareLock     | relation | master
- pg_class_relname_nsp_index | AccessShareLock     | relation | master
- pg_depend                  | RowExclusiveLock    | relation | master
- pg_locks                   | AccessShareLock     | relation | master
- pg_partition               | RowExclusiveLock    | relation | master
- pg_partition_rule          | RowExclusiveLock    | relation | master
- pg_type                    | RowExclusiveLock    | relation | master
-(17 rows)
+drop table partlockt;
+select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+   coalesce    |        mode         | locktype |  node  
+---------------+---------------------+----------+--------
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+(6 rows)
 
-select * from locktest_segments;
-        coalesce        |        mode         | locktype |    node    
-------------------------+---------------------+----------+------------
- dropped table          | AccessExclusiveLock | relation | n segments
- dropped table          | AccessExclusiveLock | relation | n segments
- gp_distribution_policy | RowExclusiveLock    | relation | n segments
- dropped table          | AccessExclusiveLock | relation | n segments
- dropped table          | AccessExclusiveLock | relation | n segments
- dropped table          | AccessExclusiveLock | relation | n segments
- pg_class               | AccessShareLock     | relation | n segments
- pg_appendonly          | RowExclusiveLock    | relation | n segments
- dropped table          | AccessExclusiveLock | relation | n segments
-(9 rows)
+select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+   coalesce    |        mode         | locktype |    node    
+---------------+---------------------+----------+------------
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+(6 rows)
 
 commit;
 -- Indexing
-create table g (i int, t text) partition by range(i)
+create table partlockt (i int, t text) partition by range(i)
 (start(1) end(10) every(1));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-NOTICE:  CREATE TABLE will create partition "g_1_prt_1" for table "g"
-NOTICE:  CREATE TABLE will create partition "g_1_prt_2" for table "g"
-NOTICE:  CREATE TABLE will create partition "g_1_prt_3" for table "g"
-NOTICE:  CREATE TABLE will create partition "g_1_prt_4" for table "g"
-NOTICE:  CREATE TABLE will create partition "g_1_prt_5" for table "g"
-NOTICE:  CREATE TABLE will create partition "g_1_prt_6" for table "g"
-NOTICE:  CREATE TABLE will create partition "g_1_prt_7" for table "g"
-NOTICE:  CREATE TABLE will create partition "g_1_prt_8" for table "g"
-NOTICE:  CREATE TABLE will create partition "g_1_prt_9" for table "g"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_1" for table "partlockt"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_2" for table "partlockt"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_3" for table "partlockt"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_4" for table "partlockt"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_5" for table "partlockt"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_6" for table "partlockt"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_7" for table "partlockt"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_8" for table "partlockt"
+NOTICE:  CREATE TABLE will create partition "partlockt_1_prt_9" for table "partlockt"
 begin;
-create index g_idx on g(i);
-NOTICE:  building index for child partition "g_1_prt_1"
-NOTICE:  building index for child partition "g_1_prt_2"
-NOTICE:  building index for child partition "g_1_prt_3"
-NOTICE:  building index for child partition "g_1_prt_4"
-NOTICE:  building index for child partition "g_1_prt_5"
-NOTICE:  building index for child partition "g_1_prt_6"
-NOTICE:  building index for child partition "g_1_prt_7"
-NOTICE:  building index for child partition "g_1_prt_8"
-NOTICE:  building index for child partition "g_1_prt_9"
-select * from locktest_master;
-          coalesce          |        mode         | locktype |  node  
-----------------------------+---------------------+----------+--------
- g                          | ShareLock           | relation | master
- g_idx                      | AccessExclusiveLock | relation | master
- pg_class                   | AccessShareLock     | relation | master
- pg_class_oid_index         | AccessShareLock     | relation | master
- pg_class_relname_nsp_index | AccessShareLock     | relation | master
- pg_locks                   | AccessShareLock     | relation | master
- pg_partition_rule          | AccessShareLock     | relation | master
-(7 rows)
+create index partlockt_idx on partlockt(i);
+NOTICE:  building index for child partition "partlockt_1_prt_1"
+NOTICE:  building index for child partition "partlockt_1_prt_2"
+NOTICE:  building index for child partition "partlockt_1_prt_3"
+NOTICE:  building index for child partition "partlockt_1_prt_4"
+NOTICE:  building index for child partition "partlockt_1_prt_5"
+NOTICE:  building index for child partition "partlockt_1_prt_6"
+NOTICE:  building index for child partition "partlockt_1_prt_7"
+NOTICE:  building index for child partition "partlockt_1_prt_8"
+NOTICE:  building index for child partition "partlockt_1_prt_9"
+select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+   coalesce    |        mode         | locktype |  node  
+---------------+---------------------+----------+--------
+ partlockt     | ShareLock           | relation | master
+ partlockt_idx | AccessExclusiveLock | relation | master
+(2 rows)
 
-select * from locktest_segments;
- coalesce |        mode         | locktype |    node    
-----------+---------------------+----------+------------
- g        | ShareLock           | relation | n segments
- pg_class | AccessShareLock     | relation | n segments
- g_idx    | AccessExclusiveLock | relation | n segments
-(3 rows)
+select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+   coalesce    |        mode         | locktype |    node    
+---------------+---------------------+----------+------------
+ partlockt_idx | AccessExclusiveLock | relation | n segments
+ partlockt     | ShareLock           | relation | n segments
+(2 rows)
 
 commit;
 -- Force use of the index in the select and delete below. We're not interested
@@ -309,108 +246,81 @@ commit;
 set enable_seqscan=off;
 -- test select locking
 begin;
-select * from g where i = 1;
+select * from partlockt where i = 1;
  i | t 
 ---+---
 (0 rows)
 
 -- Known_opt_diff: MPP-20936
-select * from locktest_master;
-          coalesce          |      mode       | locktype |  node  
-----------------------------+-----------------+----------+--------
- g                          | AccessShareLock | relation | master
- pg_class                   | AccessShareLock | relation | master
- pg_class_oid_index         | AccessShareLock | relation | master
- pg_class_relname_nsp_index | AccessShareLock | relation | master
- pg_locks                   | AccessShareLock | relation | master
-(5 rows)
+select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+ coalesce  |      mode       | locktype |  node  
+-----------+-----------------+----------+--------
+ partlockt | AccessShareLock | relation | master
+(1 row)
 
-select * from locktest_segments;
-   coalesce    |      mode       | locktype |    node    
----------------+-----------------+----------+------------
- g_idx_1_prt_1 | AccessShareLock | relation | 1 segment
- pg_class      | AccessShareLock | relation | n segments
- g_1_prt_1     | AccessShareLock | relation | 1 segment
-(3 rows)
+select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+       coalesce        |      mode       | locktype |   node    
+-----------------------+-----------------+----------+-----------
+ partlockt_idx_1_prt_1 | AccessShareLock | relation | 1 segment
+ partlockt_1_prt_1     | AccessShareLock | relation | 1 segment
+(2 rows)
 
 commit;
 begin;
 -- insert locking
-insert into g values(3, 'f');
-select * from locktest_master;
-          coalesce          |       mode       | locktype |  node  
-----------------------------+------------------+----------+--------
- g                          | RowExclusiveLock | relation | master
- pg_class                   | AccessShareLock  | relation | master
- pg_class_oid_index         | AccessShareLock  | relation | master
- pg_class_relname_nsp_index | AccessShareLock  | relation | master
- pg_locks                   | AccessShareLock  | relation | master
-(5 rows)
+insert into partlockt values(3, 'f');
+select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+ coalesce  |       mode       | locktype |  node  
+-----------+------------------+----------+--------
+ partlockt | RowExclusiveLock | relation | master
+(1 row)
 
-select * from locktest_segments;
- coalesce  |       mode       | locktype |    node    
------------+------------------+----------+------------
- pg_class  | AccessShareLock  | relation | n segments
- g_1_prt_3 | RowExclusiveLock | relation | 1 segment
- g         | RowExclusiveLock | relation | 1 segment
-(3 rows)
+select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+     coalesce      |       mode       | locktype |   node    
+-------------------+------------------+----------+-----------
+ partlockt         | RowExclusiveLock | relation | 1 segment
+ partlockt_1_prt_3 | RowExclusiveLock | relation | 1 segment
+(2 rows)
 
 commit;
 -- delete locking
 begin;
-delete from g where i = 4;
+delete from partlockt where i = 4;
 -- Known_opt_diff: MPP-20936
-select * from locktest_master;
-          coalesce          |       mode      | locktype |  node  
-----------------------------+-----------------+----------+--------
- g                          | ExclusiveLock   | relation | master
- pg_class                   | AccessShareLock | relation | master
- pg_class_oid_index         | AccessShareLock | relation | master
- pg_class_relname_nsp_index | AccessShareLock | relation | master
- pg_locks                   | AccessShareLock | relation | master
-(5 rows)
+select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+ coalesce  |     mode      | locktype |  node  
+-----------+---------------+----------+--------
+ partlockt | ExclusiveLock | relation | master
+(1 row)
 
-select * from locktest_segments;
-   coalesce    |       mode       | locktype |    node    
----------------+------------------+----------+------------
- g             | RowExclusiveLock | relation | n segments
- g_1_prt_4     | AccessShareLock  | relation | n segments
- pg_class      | AccessShareLock  | relation | n segments
- g_idx_1_prt_4 | AccessShareLock  | relation | n segments
-(4 rows)
+select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+       coalesce        |       mode       | locktype |    node    
+-----------------------+------------------+----------+------------
+ partlockt             | RowExclusiveLock | relation | n segments
+ partlockt_1_prt_4     | AccessShareLock  | relation | n segments
+ partlockt_idx_1_prt_4 | AccessShareLock  | relation | n segments
+(3 rows)
 
 commit;
 -- drop index
 begin;
-drop table g;
-select * from locktest_master;
-          coalesce          |        mode         | locktype |  node  
-----------------------------+---------------------+----------+--------
- dropped table              | AccessExclusiveLock | relation | master
- dropped table              | AccessExclusiveLock | relation | master
- dropped table              | AccessExclusiveLock | relation | master
- dropped table              | AccessExclusiveLock | relation | master
- gp_distribution_policy     | RowExclusiveLock    | relation | master
- pg_class                   | AccessShareLock     | relation | master
- pg_class                   | RowExclusiveLock    | relation | master
- pg_class_oid_index         | AccessShareLock     | relation | master
- pg_class_relname_nsp_index | AccessShareLock     | relation | master
- pg_depend                  | RowExclusiveLock    | relation | master
- pg_locks                   | AccessShareLock     | relation | master
- pg_partition               | RowExclusiveLock    | relation | master
- pg_partition_rule          | RowExclusiveLock    | relation | master
- pg_type                    | RowExclusiveLock    | relation | master
-(14 rows)
+drop table partlockt;
+select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+   coalesce    |        mode         | locktype |  node  
+---------------+---------------------+----------+--------
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+(4 rows)
 
-select * from locktest_segments;
-        coalesce        |        mode         | locktype |    node    
-------------------------+---------------------+----------+------------
- dropped table          | AccessExclusiveLock | relation | n segments
- gp_distribution_policy | RowExclusiveLock    | relation | n segments
- dropped table          | AccessExclusiveLock | relation | n segments
- dropped table          | AccessExclusiveLock | relation | n segments
- pg_class               | AccessShareLock     | relation | n segments
- dropped table          | AccessExclusiveLock | relation | n segments
-(6 rows)
+select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+   coalesce    |        mode         | locktype |    node    
+---------------+---------------------+----------+------------
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+(4 rows)
 
 commit;

--- a/src/test/regress/sql/partition_locking.sql
+++ b/src/test/regress/sql/partition_locking.sql
@@ -63,57 +63,57 @@ SELECT coalesce(
 begin;
 
 -- creation
-create table g (i int, t text) partition by range(i)
+create table partlockt (i int, t text) partition by range(i)
 (start(1) end(10) every(1));
 
-select * from locktest_master;
-select * from locktest_segments;
+select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
 commit;
 
 -- drop
 begin;
-drop table g;
-select * from locktest_master;
-select * from locktest_segments;
+drop table partlockt;
+select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
 commit;
 
 -- AO table (ao segments, block directory won't exist after create)
 begin;
 -- creation
-create table g (i int, t text, n numeric)
+create table partlockt (i int, t text, n numeric)
 with (appendonly = true)
 partition by list(i)
 (values(1), values(2), values(3));
-select * from locktest_master;
-select * from locktest_segments;
+select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
 commit;
 begin;
 
 -- add a little data
-insert into g values(1), (2), (3);
-insert into g values(1), (2), (3);
-insert into g values(1), (2), (3);
-insert into g values(1), (2), (3);
-insert into g values(1), (2), (3);
-select * from locktest_master;
-select * from locktest_segments;
+insert into partlockt values(1), (2), (3);
+insert into partlockt values(1), (2), (3);
+insert into partlockt values(1), (2), (3);
+insert into partlockt values(1), (2), (3);
+insert into partlockt values(1), (2), (3);
+select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
 commit;
 
 -- drop
 begin;
-drop table g;
-select * from locktest_master;
-select * from locktest_segments;
+drop table partlockt;
+select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
 commit;
 
 -- Indexing
-create table g (i int, t text) partition by range(i)
+create table partlockt (i int, t text) partition by range(i)
 (start(1) end(10) every(1));
 
 begin;
-create index g_idx on g(i);
-select * from locktest_master;
-select * from locktest_segments;
+create index partlockt_idx on partlockt(i);
+select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
 commit;
 
 -- Force use of the index in the select and delete below. We're not interested
@@ -124,30 +124,30 @@ set enable_seqscan=off;
 
 -- test select locking
 begin;
-select * from g where i = 1;
+select * from partlockt where i = 1;
 -- Known_opt_diff: MPP-20936
-select * from locktest_master;
-select * from locktest_segments;
+select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
 commit;
 
 begin;
 -- insert locking
-insert into g values(3, 'f');
-select * from locktest_master;
-select * from locktest_segments;
+insert into partlockt values(3, 'f');
+select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
 commit;
 
 -- delete locking
 begin;
-delete from g where i = 4;
+delete from partlockt where i = 4;
 -- Known_opt_diff: MPP-20936
-select * from locktest_master;
-select * from locktest_segments;
+select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
 commit;
 
 -- drop index
 begin;
-drop table g;
-select * from locktest_master;
-select * from locktest_segments;
+drop table partlockt;
+select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
 commit;


### PR DESCRIPTION
Objective of the test is only to check if DDL/DML on partition tables lock only
the root table on QD.  Child partitions are locked on QE as needed.  The
intermittent failures are due to more locks acquired than expected.  In all
such cases, the additional locks were AccessShare locks on some catalog table.
This commit filters out locks on catalog tables from expected output.

The intermittent failures merit investigation but that can happen regardless of
this test fix.