### PR TITLE
gpperfmon and coverity: resolve issues with `make distclean`

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -104,6 +104,9 @@ clean:
 	$(MAKE) -C contrib/pg_upgrade_support $@
 	$(MAKE) -C contrib/pg_upgrade $@
 	$(MAKE) -C contrib/pgcrypto $@
+# leap over gpAux/Makefile into subdirectories to avoid circular dependency.
+# gpAux/Makefile is the entry point for the enterprise build, which ends up
+# calling top-level configure and this Makefile
 	$(MAKE) -C gpAux/extensions $@
 	$(MAKE) -C gpAux/gpperfmon $@
 	$(MAKE) -C gpMgmt $@
@@ -115,6 +118,7 @@ clean:
 distclean maintainer-clean:
 #	-$(MAKE) -C doc $@
 	-$(MAKE) -C gpAux/extensions $@
+	-$(MAKE) -C gpAux/gpperfmon $@
 	-$(MAKE) -C contrib $@
 	-$(MAKE) -C config $@
 	-$(MAKE) -C src $@

--- a/concourse/scripts/scan_with_coverity.bash
+++ b/concourse/scripts/scan_with_coverity.bash
@@ -45,7 +45,6 @@ function build_gpdb_and_scan_with_coverity() {
   local cov_int_dir="$1"
 
   pushd gpdb_src/gpAux
-    make distclean
     cov-build --dir "$cov_int_dir" make BLD_TARGETS="gpdb" GPROOT=/usr/local
   popd
 }

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -1035,7 +1035,6 @@ clean :
 	@if [ -d Release -a -f Release/GNUmakefile ]; then cd Release; $(MAKE) clean; fi
 	@if [ -d $(GPPGDIR) -a -f $(GPPGDIR)/GNUmakefile ]; then cd $(GPPGDIR); $(MAKE) clean; fi
 	@if [ -d $(GPMGMT)/bin ]; then cd $(GPMGMT)/bin; $(MAKE) clean; fi
-	@if [ -d $(GPPERFMON) ]; then cd $(GPPERFMON); $(MAKE) clean; fi
 
 distclean :
 #	@if [ ! -f $(ISCONFIG) ]; then echo "GPDB root not configured, no need to clean it"; fi
@@ -1043,7 +1042,6 @@ distclean :
 	@if [ -d Release -a -f Release/GNUmakefile ]; then cd Release; $(MAKE) distclean; fi
 	@if [ -d $(GPPGDIR) -a -f $(GPPGDIR)/GNUmakefile ]; then cd $(GPPGDIR); $(MAKE) distclean; fi
 	@if [ -d $(GPMGMT)/bin ]; then cd $(GPMGMT)/bin; $(MAKE) distclean; fi
-	@if [ -d $(GPPERFMON) ]; then cd $(GPPERFMON); $(MAKE) clean; fi
 	@rm -f VERSION
 	@rm -f env.sh
 

--- a/gpAux/gpperfmon/Makefile
+++ b/gpAux/gpperfmon/Makefile
@@ -17,7 +17,7 @@ gpsmon:
 gpmmon:
 	$(MAKE) -C src/gpmon gpmmon BUILDDIR=$(BUILDDIR)
 
-clean:
+clean distclean:
 	$(MAKE) -C src/gpmon clean
 
 install:


### PR DESCRIPTION
The coverity build was failing on the gpperfmon `make distclean` step

Fixed on both sides:
- Don't call `make distclean` in the coverity build script -- not
  necessary
- Don't clean gpperfmon from `gpAux/Makefile`: this Makefile's clean
  targets are for enterprise-build related artifacts. General developers
  should be running `make clean distclean` from the top level directory of
  this repository.

Additional fix -- doesn't address the coverity red but a similar
cleanup:
- Add cleanup of gpperfmon to the top level makefile's `distclean`
  target. Not sure why it wasn't there; probably just an accidental
  omission.
- Add note explaining why the top level makefile has to circumvent
  `gpAux/Makefile`

Pipeline to verify that this works: http://gpdb.ci.pivotalci.info/teams/gpdb/pipelines/gpperfmon-broke-coverity-fix (note: we've disabled it from pushing to Coverity)