### PR TITLE
Return early from distributed snapshot check if local xid is not normal.

### DIFF
--- a/contrib/xlogdump/xlogdump_rmgr.c
+++ b/contrib/xlogdump/xlogdump_rmgr.c
@@ -612,11 +612,10 @@ print_rmgr_standby(XLogRecPtr cur, XLogRecord *record, uint8 info)
 void
 print_rmgr_heap2(XLogRecPtr cur, XLogRecord *record, uint8 info)
 {
-#if PG_VERSION_NUM >= 90000
 	char spaceName[NAMEDATALEN];
 	char dbName[NAMEDATALEN];
 	char relName[NAMEDATALEN];
-#endif
+
 	char buf[1024];
 
 	switch (info)
@@ -650,6 +649,10 @@ print_rmgr_heap2(XLogRecPtr cur, XLogRecord *record, uint8 info)
 			getSpaceName(xlrec.node.spcNode, spaceName, sizeof(spaceName));
 			getDbName(xlrec.node.dbNode, dbName, sizeof(dbName));
 			getRelName(xlrec.node.relNode, relName, sizeof(relName));
+#else
+			getSpaceName(xlrec.heapnode.node.spcNode, spaceName, sizeof(spaceName));
+			getDbName(xlrec.heapnode.node.dbNode, dbName, sizeof(dbName));
+			getRelName(xlrec.heapnode.node.relNode, relName, sizeof(relName));
 #endif
 
 			total_off = (record->xl_len - SizeOfHeapClean) / sizeof(OffsetNumber);
@@ -662,8 +665,9 @@ print_rmgr_heap2(XLogRecPtr cur, XLogRecord *record, uint8 info)
 			       "",
 			       spaceName, dbName, relName,
 #else
-			snprintf(buf, sizeof(buf), "clean%s: block:%u redirected/dead/unused:%d/%d/%d",
+			snprintf(buf, sizeof(buf), "clean%s: s/d/r:%s/%s/%s block:%u redirected/dead/unused:%d/%d/%d",
 			       info == XLOG_HEAP2_CLEAN_MOVE ? "_move" : "",
+					 spaceName, dbName, relName,
 #endif
 			       xlrec.block,
 			       xlrec.nredirected, xlrec.ndead, nunused

--- a/src/backend/cdb/cdbdistributedsnapshot.c
+++ b/src/backend/cdb/cdbdistributedsnapshot.c
@@ -27,8 +27,7 @@
 DistributedSnapshotCommitted 
 DistributedSnapshotWithLocalMapping_CommittedTest(
 	DistributedSnapshotWithLocalMapping		*dslm,
-	TransactionId 							localXid,
-	bool									isXmax)
+	TransactionId 							localXid)
 {
 	DistributedSnapshotHeader *header = &dslm->header;
 	DistributedSnapshotMapEntry *inProgressEntryArray = dslm->inProgressEntryArray;

--- a/src/backend/cdb/cdbdistributedsnapshot.c
+++ b/src/backend/cdb/cdbdistributedsnapshot.c
@@ -37,6 +37,13 @@ DistributedSnapshotWithLocalMapping_CommittedTest(
 	bool							found;
 	DistributedTransactionId		distribXid = InvalidDistributedTransactionId;
 
+	/*
+	 * Return early if local xid is not normal as it cannot have distributed
+	 * xid associated with it.
+	 */
+	if (!TransactionIdIsNormal(localXid))
+		return DISTRIBUTEDSNAPSHOT_COMMITTED_IGNORE;
+
 	count = header->count;
 
 	/*

--- a/src/include/cdb/cdbdistributedsnapshot.h
+++ b/src/include/cdb/cdbdistributedsnapshot.h
@@ -115,8 +115,7 @@ typedef enum
 
 extern DistributedSnapshotCommitted DistributedSnapshotWithLocalMapping_CommittedTest(
 	DistributedSnapshotWithLocalMapping		*dslm,
-	TransactionId 							localXid,
-	bool									isXmax);
+	TransactionId 							localXid);
 
 extern void DistributedSnapshot_Reset(
 	DistributedSnapshot *distributedSnapshot);


### PR DESCRIPTION
PR has three commits:

1] Only normal xids can have distributed xids, so no point trying to check
distributed log and lookout for its corresponding distributed xid. Not sure how
much performance this impacts but its more important to not go chasing down
non-existent file, corresponding to frozen xids. Though currently for distributed
log it treats that as local transaction but just lot of extra work to get that
answer.

2] Print relation info in xlogdump for xl_heap_clean record type. (just minor fix not related)
3] Remove dead isXmax argument to Snapshot functions. (just minor cleanup not related)