### PR TITLE
Fix coverity issues in pg_basebackup.c

### DIFF
--- a/contrib/pg_standby/pg_standby.c
+++ b/contrib/pg_standby/pg_standby.c
@@ -308,7 +308,7 @@ SetWALFileNameForCleanup(void)
 		if (strcmp(restartWALFileName, nextWALFileName) > 0)
 			return false;
 
-		strcpy(exclusiveCleanupFileName, restartWALFileName);
+		strlcpy(exclusiveCleanupFileName, restartWALFileName, sizeof(exclusiveCleanupFileName));
 		return true;
 	}
 

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -6048,7 +6048,6 @@ recoveryStopsHere(XLogRecord *record, bool *includeThis)
 								recoveryStopXid,
 								timestamptz_to_str(recoveryStopTime))));
 		}
-
 		if (recoveryStopAfter)
 			recoveryLastXTime = recordXtime;
 	}
@@ -6580,7 +6579,6 @@ StartupXLOG(void)
 				(errmsg("requested timeline %u is not a child of database system timeline %u",
 						recoveryTargetTLI,
 						ControlFile->checkPointCopy.ThisTimeLineID)));
-
 	/*
 	 * Save the selected recovery target timeline ID in shared memory so that
 	 * other processes can see them

--- a/src/backend/tsearch/spell.c
+++ b/src/backend/tsearch/spell.c
@@ -181,7 +181,7 @@ NIAddSpell(IspellDict *Conf, const char *word, const char *flag)
 	}
 	Conf->Spell[Conf->nspell] = (SPELL *) tmpalloc(SPELLHDRSZ + strlen(word) + 1);
 	strcpy(Conf->Spell[Conf->nspell]->word, word);
-	strncpy(Conf->Spell[Conf->nspell]->p.flag, flag, MAXFLAGLEN);
+	strlcpy(Conf->Spell[Conf->nspell]->p.flag, flag, MAXFLAGLEN);
 	Conf->nspell++;
 }
 

--- a/src/bin/pg_basebackup/pg_basebackup.c
+++ b/src/bin/pg_basebackup/pg_basebackup.c
@@ -1409,7 +1409,7 @@ BaseBackup(void)
 				progname);
 		disconnect_and_exit(1);
 	}
-	strcpy(xlogstart, PQgetvalue(res, 0, 0));
+	strlcpy(xlogstart, PQgetvalue(res, 0, 0), sizeof(xlogstart));
 	if (verbose && includewal)
 		fprintf(stderr, "transaction log start point: %s\n", xlogstart);
 	PQclear(res);
@@ -1509,7 +1509,7 @@ BaseBackup(void)
 				progname);
 		disconnect_and_exit(1);
 	}
-	strcpy(xlogend, PQgetvalue(res, 0, 0));
+	strlcpy(xlogend, PQgetvalue(res, 0, 0), sizeof(xlogend));
 	if (verbose && includewal)
 		fprintf(stderr, "transaction log end point: %s\n", xlogend);
 	PQclear(res);

--- a/src/interfaces/ecpg/preproc/pgc.l
+++ b/src/interfaces/ecpg/preproc/pgc.l
@@ -1269,7 +1269,7 @@ parse_include(void)
 	{
 		yytext[i] = '\0';
 		memmove(yytext, yytext+1, strlen(yytext));
-	
+
 		strlcpy(inc_file, yytext, sizeof(inc_file));
 		yyin = fopen(inc_file, "r");
 		if (!yyin)


### PR DESCRIPTION
CID 130131: Copy into fixed size buffer (STRING_OVERFLOW)
Coverity reported that we might overrun the buffer `current_path` while trying
to copy the return value of `PQgetvalue()` since we don't check its length.
Fix this by using `strlcpy()` in order avoid buffer overruns. This is also how
it has been fixed upstream.

CID 157318: Resource leak (RESOURCE_LEAK)
`build_exclude_list()` returns a string which has been allocated memory using
malloc and since we never store the return value, the allocated memory can
never be freed.  Fix this by storing the results of the function in a separate
variable and then freeing it once it has been used.