### PR TITLE
Minor fix on resource group statistic information

### DIFF
--- a/src/backend/postmaster/pgstat.c
+++ b/src/backend/postmaster/pgstat.c
@@ -2420,7 +2420,7 @@ pgstat_report_xact_timestamp(TimestampTz tstamp)
  * Report the timestamp of transaction start queueing on the resource group.
  */
 void
-pgstat_report_resgroup_wait(TimestampTz tstamp, Oid groupid)
+pgstat_report_resgroup(TimestampTz queueStart, Oid groupid)
 {
 	volatile PgBackendStatus *beentry = MyBEEntry;
 
@@ -2433,9 +2433,13 @@ pgstat_report_resgroup_wait(TimestampTz tstamp, Oid groupid)
 	 * ensure the compiler doesn't try to get cute.
 	 */
 	beentry->st_changecount++;
-	beentry->st_resgroup_queue_start_timestamp = tstamp;
+	if (queueStart != 0)
+	{
+		beentry->st_resgroup_queue_start_timestamp = queueStart;
+		beentry->st_waiting = PGBE_WAITING_RESGROUP;
+	}
+
 	beentry->st_rsgid = groupid;
-	beentry->st_waiting = PGBE_WAITING_RESGROUP;
 	beentry->st_changecount++;
 	Assert((beentry->st_changecount & 1) == 0);
 }

--- a/src/backend/utils/adt/pgstatfuncs.c
+++ b/src/backend/utils/adt/pgstatfuncs.c
@@ -632,25 +632,21 @@ pg_stat_get_activity(PG_FUNCTION_ARGS)
 
 			if (funcctx->tuple_desc->natts > 13)
 			{
-				if (beentry->st_waiting == PGBE_WAITING_RESGROUP)
-				{
-					Datum now = TimestampTzGetDatum(GetCurrentTimestamp());
-					char *groupName = GetResGroupNameForId(beentry->st_rsgid, AccessShareLock);
+				Datum now = TimestampTzGetDatum(GetCurrentTimestamp());
+				char *groupName = GetResGroupNameForId(beentry->st_rsgid, AccessShareLock);
 
-					values[13] = ObjectIdGetDatum(beentry->st_rsgid);
-					if (groupName != NULL)
-						values[14] = CStringGetTextDatum(groupName);
-					else
-						nulls[14] = true;
+				values[13] = ObjectIdGetDatum(beentry->st_rsgid);
+
+				if (groupName != NULL)
+					values[14] = CStringGetTextDatum(groupName);
+				else
+					nulls[14] = true;
+
+				if (beentry->st_waiting == PGBE_WAITING_RESGROUP)
 					values[15] = DirectFunctionCall2(timestamptz_age, now,
 													 TimestampTzGetDatum(beentry->st_resgroup_queue_start_timestamp));
-				}
 				else
-				{
-					nulls[13] = true;
-					nulls[14] = true;
 					nulls[15] = true;
-				}
 			}
 		}
 		else

--- a/src/include/pgstat.h
+++ b/src/include/pgstat.h
@@ -728,7 +728,7 @@ extern void pgstat_report_appname(const char *appname);
 extern void pgstat_report_xact_timestamp(TimestampTz tstamp);
 extern const char *pgstat_get_backend_current_activity(int pid, bool checkUser);
 
-extern void pgstat_report_resgroup_wait(TimestampTz tstamp, Oid groupid);
+extern void pgstat_report_resgroup(TimestampTz queueStart, Oid groupid);
 extern TimestampTz pgstat_fetch_resgroup_queue_timestamp(void);
 
 extern void pgstat_initstats(Relation rel);

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -29,7 +29,7 @@ typedef struct ResGroupData
 	PROC_QUEUE	waitProcs;
 	int			totalExecuted;	/* total number of executed trans */
 	int			totalQueued;	/* total number of queued trans	*/
-	int			totalQueuedTime;/* total queue time */
+	Interval	totalQueuedTime;/* total queue time */
 } ResGroupData;
 typedef ResGroupData *ResGroup;
 
@@ -71,7 +71,7 @@ extern void ResGroupSlotAcquire(void);
 extern void ResGroupSlotRelease(void);
 
 /* Retrieve statistic information of type from resource group */
-extern int ResGroupGetStat(Oid groupId, ResGroupStatType type);
+extern void ResGroupGetStat(Oid groupId, ResGroupStatType type, char *retStr, int retStrLen);
 
 #define LOG_RESGROUP_DEBUG(...) \
 	do {if (Debug_resource_group) elog(__VA_ARGS__); } while(false);

--- a/src/test/isolation2/expected/resource_group.out
+++ b/src/test/isolation2/expected/resource_group.out
@@ -4,7 +4,7 @@ CREATE
 0:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
 rsgname            |num_running|num_queueing|num_queued|num_executed
 -------------------+-----------+------------+----------+------------
-rg_concurrency_test|0          |0           |0         |0           
+rg_concurrency_test|           |            |          |            
 (1 row)
 
 -- enable resource group and restart cluster.


### PR DESCRIPTION
1.Change the format of 'total_queue_duration' in 'gp_toolkit.gp_resgroup_status' to keep
it consistent with 'rsgqueueduration' in 'pg_stat_activity'.
2.Show resource group information for running queries in 'pg_stat_activity'.

Signed-off-by: Richard Guo<riguo@pivotal.io>