### PR TITLE
GPDB DOCS - update external table column information for 5.0.0

### DIFF
--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_exttable.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_exttable.xml
@@ -1,13 +1,109 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
-<topic id="topic1" xml:lang="en"><title id="gn143896">pg_exttable</title><body><p>The <codeph>pg_exttable</codeph> system catalog table is used to track
-external tables and web tables created by the <codeph>CREATE EXTERNAL
-TABLE</codeph> command.</p><table id="gn143898"><title>pg_catalog.pg_exttable</title><tgroup cols="4"><colspec colnum="1" colname="col1" colwidth="131pt"/><colspec colnum="2" colname="col2" colwidth="86pt"/><colspec colnum="3" colname="col3" colwidth="85pt"/><colspec colnum="4" colname="col4" colwidth="147pt"/><thead><row><entry colname="col1">column</entry><entry colname="col2">type</entry><entry colname="col3">references</entry><entry colname="col4">description</entry></row></thead><tbody><row><entry colname="col1"><codeph>reloid</codeph></entry><entry colname="col2">oid</entry><entry colname="col3">pg_class.oid</entry><entry colname="col4">The OID of this external table.</entry></row><row><entry colname="col1"><codeph>location</codeph></entry><entry colname="col2">text[]</entry><entry colname="col3"/><entry colname="col4">The URI location(s) of the external table files.</entry></row><row><entry colname="col1"><codeph>fmttype</codeph></entry><entry colname="col2">char</entry><entry colname="col3"/><entry colname="col4">Format of the external table files: <codeph>t</codeph>
-for text, or <codeph>c</codeph> for csv.</entry></row><row><entry colname="col1"><codeph>fmtopts</codeph></entry><entry colname="col2">text</entry><entry colname="col3"/><entry colname="col4">Formatting options of the external table files,
-such as the field delimiter, null string, escape character, etc.</entry></row><row><entry colname="col1"><codeph>command</codeph></entry><entry colname="col2">text</entry><entry colname="col3"/><entry colname="col4">The OS command to execute when the external
-table is accessed.</entry></row><row><entry colname="col1"><codeph>rejectlimit</codeph></entry><entry colname="col2">integer</entry><entry colname="col3"/><entry colname="col4">The per segment reject limit for rows with errors,
-after which the load will fail.</entry></row><row><entry colname="col1"><codeph>rejectlimittype</codeph></entry><entry colname="col2">char</entry><entry colname="col3"/><entry colname="col4">Type of reject limit threshold: <codeph>r</codeph>
-for number of rows.</entry></row><row><entry colname="col1"><codeph>fmterrtbl</codeph></entry><entry colname="col2">oid</entry><entry colname="col3">pg_class.oid</entry><entry colname="col4">The object id of the error table where format
-errors will be logged.</entry></row><row><entry colname="col1"><codeph>encoding</codeph></entry><entry colname="col2">text</entry><entry colname="col3"/><entry colname="col4">The client encoding.</entry></row><row><entry colname="col1"><codeph>writable</codeph></entry><entry colname="col2">boolean</entry><entry colname="col3"/><entry colname="col4"><codeph>0</codeph> for readable external tables,
-<codeph>1</codeph> for writable external tables.</entry></row></tbody></tgroup></table></body></topic>
+<topic id="topic1" xml:lang="en">
+  <title id="gn143896">pg_exttable</title>
+  <body>
+    <p>The <codeph>pg_exttable</codeph> system catalog table is used to track external tables and
+      web tables created by the <codeph>CREATE EXTERNAL TABLE</codeph> command.</p>
+    <table id="gn143898">
+      <title>pg_catalog.pg_exttable</title>
+      <tgroup cols="4">
+        <colspec colnum="1" colname="col1" colwidth="131pt"/>
+        <colspec colnum="2" colname="col2" colwidth="86pt"/>
+        <colspec colnum="3" colname="col3" colwidth="85pt"/>
+        <colspec colnum="4" colname="col4" colwidth="147pt"/>
+        <thead>
+          <row>
+            <entry colname="col1">column</entry>
+            <entry colname="col2">type</entry>
+            <entry colname="col3">references</entry>
+            <entry colname="col4">description</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry colname="col1"><codeph>reloid</codeph></entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3">pg_class.oid</entry>
+            <entry colname="col4">The OID of this external table.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>urilocation</codeph></entry>
+            <entry colname="col2">text[]</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">The URI location(s) of the external table files.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>execlocation</codeph></entry>
+            <entry colname="col2">text[]</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">The ON segment locations defined for the external table.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>fmttype</codeph></entry>
+            <entry colname="col2">char</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Format of the external table files: <codeph>t</codeph> for text,
+              or <codeph>c</codeph> for csv.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>fmtopts</codeph></entry>
+            <entry colname="col2">text</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Formatting options of the external table files, such as the field
+              delimiter, null string, escape character, etc.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>options</codeph></entry>
+            <entry colname="col2">text[]</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">The options defined for the external table.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>command</codeph></entry>
+            <entry colname="col2">text</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">The OS command to execute when the external table is
+              accessed.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>rejectlimit</codeph></entry>
+            <entry colname="col2">integer</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">The per segment reject limit for rows with errors, after which the
+              load will fail.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>rejectlimittype</codeph></entry>
+            <entry colname="col2">char</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Type of reject limit threshold: <codeph>r</codeph> for number of
+              rows.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>fmterrtbl</codeph></entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3">pg_class.oid</entry>
+            <entry colname="col4">The object id of the error table where format errors will be
+                  logged.<p><b>NOTE:</b> This column is no longer used and will be removed in a
+                future release.</p></entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>encoding</codeph></entry>
+            <entry colname="col2">text</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">The client encoding.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>writable</codeph></entry>
+            <entry colname="col2">boolean</entry>
+            <entry colname="col3"/>
+            <entry colname="col4"><codeph>0</codeph> for readable external tables,
+                <codeph>1</codeph> for writable external tables.</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>


### PR DESCRIPTION
Changed name location -> urilocation 

Added 2 columns
 - execlocation
 - options

deprecated
- fmterrtbl (no longer used, error table has been removed in 5.0)

[ci skip]
