### PR TITLE
Vacuum and freezing consider distributed visibility, also enable page pruning for all tables

### DIFF
--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -4330,9 +4330,22 @@ heap_inplace_update(Relation relation, HeapTuple tuple)
  * exclusive lock ensures no other backend is in process of checking the
  * tuple status.  Also, getting exclusive lock makes it safe to adjust the
  * infomask bits.
+ *
+ * In GPDB, cutoff_xid is passed as pointer, as this function may change its
+ * value. cutoff_xid passed in is just based on local visibility and hence may
+ * not be met always. Function checks localxid from distributed aspect and may
+ * not be able to freeze (remove) all xids lower than cutoff_xid if still
+ * needed from distributed visibility perspective. So, for such cases the
+ * cutoff_xid (freeze limit) is lowered and updated new lower value reflected
+ * back to caller. Using the same caller can then correctly set *relfrozenxid*
+ * of the relation. If this is not done, relation may have xids lower than
+ * relfrozenxid which is wrong. As based on relfrozenxid, datfrozenxid gets
+ * set, which finally controls cut-off point for clog or distributed commit
+ * log. Not correctly reflecting relfrozenxid may end-up trying to read
+ * non-existent clog files.
  */
 bool
-heap_freeze_tuple(HeapTupleHeader tuple, TransactionId cutoff_xid,
+heap_freeze_tuple(HeapTupleHeader tuple, TransactionId *cutoff_xid,
 				  Buffer buf, bool xlog_replay)
 {
 	bool		changed = false;
@@ -4343,7 +4356,7 @@ heap_freeze_tuple(HeapTupleHeader tuple, TransactionId cutoff_xid,
 
 	xid = HeapTupleHeaderGetXmin(tuple);
 	if (TransactionIdIsNormal(xid) &&
-		TransactionIdPrecedes(xid, cutoff_xid))
+		TransactionIdPrecedes(xid, *cutoff_xid))
 	{
 		/*
 		 * Will consult distributed snapshot and freeze xmin only if globally
@@ -4375,6 +4388,10 @@ heap_freeze_tuple(HeapTupleHeader tuple, TransactionId cutoff_xid,
 			tuple->t_infomask |= HEAP_XMIN_COMMITTED;
 			changed = true;
 		}
+		else
+		{
+			*cutoff_xid = xid;
+		}
 	}
 
 	/*
@@ -4389,7 +4406,7 @@ recheck_xmax:
 	{
 		xid = HeapTupleHeaderGetXmax(tuple);
 		if (TransactionIdIsNormal(xid) &&
-			TransactionIdPrecedes(xid, cutoff_xid))
+			TransactionIdPrecedes(xid, *cutoff_xid))
 		{
 			/*
 			 * Need to prevent case where due to distributed visibility the
@@ -4433,6 +4450,10 @@ recheck_xmax:
 				HeapTupleHeaderClearHotUpdated(tuple);
 				changed = true;
 			}
+			else
+			{
+				*cutoff_xid = xid;
+			}
 		}
 	}
 	else
@@ -4465,7 +4486,7 @@ recheck_xvac:
 	{
 		xid = HeapTupleHeaderGetXvac(tuple);
 		if (TransactionIdIsNormal(xid) &&
-			TransactionIdPrecedes(xid, cutoff_xid))
+			TransactionIdPrecedes(xid, *cutoff_xid))
 		{
 			if (buf != InvalidBuffer)
 			{
@@ -5102,7 +5123,7 @@ heap_xlog_freeze(XLogRecPtr lsn, XLogRecord *record)
 			ItemId		lp = PageGetItemId(page, *offsets);
 			HeapTupleHeader tuple = (HeapTupleHeader) PageGetItem(page, lp);
 
-			(void) heap_freeze_tuple(tuple, cutoff_xid, InvalidBuffer, true);
+			(void) heap_freeze_tuple(tuple, &cutoff_xid, InvalidBuffer, true);
 			offsets++;
 		}
 	}

--- a/src/backend/access/heap/pruneheap.c
+++ b/src/backend/access/heap/pruneheap.c
@@ -105,11 +105,11 @@ heap_page_prune_opt(Relation relation, Buffer buffer, TransactionId OldestXmin)
 	if (PageIsFull(dp) || PageGetHeapFreeSpace((Page) dp) < minfree)
 	{
 		/*
-		 * If we don't have gp_persistent_relation_node information, to be added
-		 * to the XLOG record, give up. It's too late to fetch it here, we might
-		 * already be holding locks that would be needed to fetch the information.
+		 * Check if we have gp_persistent_relation_node information, to be
+		 * added to the XLOG record. As in some cases it maybe too late to
+		 * fetch the same and hence for such cases just give-up.
 		 */
-		if (RelationNeedToFetchGpRelationNodeForXLog(relation))
+		if (!RelationAllowedToGenerateXLogRecord(relation))
 			return;
 
 		/* OK, try to get exclusive buffer lock */

--- a/src/backend/access/heap/rewriteheap.c
+++ b/src/backend/access/heap/rewriteheap.c
@@ -339,7 +339,7 @@ rewrite_heap_tuple(RewriteState state,
 	 * we can get the right things to happen by passing InvalidBuffer for the
 	 * buffer.
 	 */
-	heap_freeze_tuple(new_tuple->t_data, state->rs_freeze_xid, InvalidBuffer, false);
+	heap_freeze_tuple(new_tuple->t_data, &state->rs_freeze_xid, InvalidBuffer, false);
 
 	/*
 	 * Invalid ctid means that ctid should point to the tuple itself. We'll
@@ -654,4 +654,11 @@ raw_heap_insert(RewriteState state, HeapTuple tup)
 	/* If heaptup is a private copy, release it. */
 	if (heaptup != tup)
 		heap_freetuple(heaptup);
+}
+
+TransactionId
+get_rewrite_freeze_xid(RewriteState state)
+{
+	Assert(state != NULL);
+	return state->rs_freeze_xid;
 }

--- a/src/backend/access/heap/rewriteheap.c
+++ b/src/backend/access/heap/rewriteheap.c
@@ -339,7 +339,7 @@ rewrite_heap_tuple(RewriteState state,
 	 * we can get the right things to happen by passing InvalidBuffer for the
 	 * buffer.
 	 */
-	heap_freeze_tuple(new_tuple->t_data, state->rs_freeze_xid, InvalidBuffer);
+	heap_freeze_tuple(new_tuple->t_data, state->rs_freeze_xid, InvalidBuffer, false);
 
 	/*
 	 * Invalid ctid means that ctid should point to the tuple itself. We'll

--- a/src/backend/cdb/test/Makefile
+++ b/src/backend/cdb/test/Makefile
@@ -2,12 +2,14 @@ subdir=src/backend/cdb
 top_builddir=../../../..
 include $(top_builddir)/src/Makefile.global
 
-TARGETS=cdbbufferedread \
+TARGETS=cdbtm \
+	cdbbufferedread \
 	cdbbackup \
 	cdbfilerep \
 	cdbsrlz
 
 include $(top_builddir)/src/backend/mock.mk
+cdbtm.t: $(MOCK_DIR)/backend/storage/lmgr/lwlock_mock.o
 
 cdbfilerep.t: \
 	$(MOCK_DIR)/backend/postmaster/fork_process_mock.o \

--- a/src/backend/cdb/test/cdbtm_test.c
+++ b/src/backend/cdb/test/cdbtm_test.c
@@ -1,0 +1,142 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include "cmockery.h"
+#include "postgres.h"
+
+#include "../cdbtm.c"
+
+#define SIZE_OF_IN_PROGRESS_ARRAY (10 * sizeof(DistributedSnapshotMapEntry))
+
+void setup(TmControlBlock *controlBlock, TMGXACT *gxact_array)
+{
+	shmNumGxacts = &controlBlock->num_active_xacts;
+	shmGxactArray = gxact_array;
+	shmGIDSeq = &controlBlock->seqno;
+	shmNextSnapshotId = &controlBlock->NextSnapshotId;
+	shmDistribTimeStamp = &controlBlock->distribTimeStamp;
+
+	/* Some imaginary LWLockId number */
+	controlBlock->ControlLock = 1000;
+	shmControlLock = controlBlock->ControlLock;
+	*shmDistribTimeStamp = time(NULL);
+	*shmGIDSeq = 25;
+	*shmNumGxacts = 0;
+
+	TMGXACT *tmp_gxact = (TMGXACT*)malloc(5 * sizeof(TMGXACT));
+	shmGxactArray[0] = tmp_gxact++;
+	shmGxactArray[1] = tmp_gxact++;
+	shmGxactArray[2] = tmp_gxact++;
+	shmGxactArray[3] = tmp_gxact++;
+	shmGxactArray[4] = tmp_gxact++;
+}
+
+void
+test__createDtxSnapshot(void **state)
+{
+	TMGXACT gxact_array[5];
+	TmControlBlock controlBlock;
+	DistributedSnapshotWithLocalMapping distribSnapshotWithLocalMapping;
+	distribSnapshotWithLocalMapping.inProgressEntryArray = (DistributedSnapshotMapEntry *)malloc(SIZE_OF_IN_PROGRESS_ARRAY);
+	distribSnapshotWithLocalMapping.header.maxCount = 10;
+
+	setup(&controlBlock, &gxact_array);
+
+	expect_value_count(LWLockAcquire, lockid, shmControlLock, -1);
+	expect_value_count(LWLockAcquire, mode, LW_EXCLUSIVE, -1);
+	will_be_called_count(LWLockAcquire, -1);
+	expect_value_count(LWLockRelease, lockid, shmControlLock, -1);
+	will_be_called_count(LWLockRelease, -1);
+
+	/* This is going to act as our gxact */
+	shmGxactArray[0]->gxid = 20;
+	shmGxactArray[0]->state = DTX_STATE_ACTIVE_DISTRIBUTED;
+	shmGxactArray[0]->xminDistributedSnapshot = 20;
+	(*shmNumGxacts)++;
+	currentGxact = shmGxactArray[0];
+
+	/********************************************************
+	 * Basic case, no other in progress transaction in system
+	 */
+	memset(distribSnapshotWithLocalMapping.inProgressEntryArray, 0, SIZE_OF_IN_PROGRESS_ARRAY);
+	createDtxSnapshot(&distribSnapshotWithLocalMapping);
+
+	/* perform all the validations */
+	assert_true(distribSnapshotWithLocalMapping.header.xminAllDistributedSnapshots == 20);
+	assert_true(distribSnapshotWithLocalMapping.header.xmin == 20);
+	assert_true(distribSnapshotWithLocalMapping.header.xmax == 25);
+	assert_true(distribSnapshotWithLocalMapping.header.count == 0);
+	assert_true(currentGxact->xminDistributedSnapshot == 20);
+
+	/*************************************************************************
+	 * Case where there exist in-progress having taken snpashot with lower
+	 * gxid than ours. This case demonstrates when xmin of snapshot will
+	 * differ from xminAllDistributedSnapshots. Also, validates xmin and xmax
+	 * get adjusted correctly based on in-progress.
+	 */
+	shmGxactArray[1]->gxid = 10;
+	shmGxactArray[1]->state = DTX_STATE_ACTIVE_DISTRIBUTED;
+	shmGxactArray[1]->xminDistributedSnapshot = 5;
+	(*shmNumGxacts)++;
+
+	shmGxactArray[2]->gxid = 30;
+	shmGxactArray[2]->state = DTX_STATE_ACTIVE_DISTRIBUTED;
+	shmGxactArray[2]->xminDistributedSnapshot = 20;
+	(*shmNumGxacts)++;
+
+	memset(distribSnapshotWithLocalMapping.inProgressEntryArray, 0, SIZE_OF_IN_PROGRESS_ARRAY);
+	createDtxSnapshot(&distribSnapshotWithLocalMapping);
+
+	/* perform all the validations */
+	assert_true(distribSnapshotWithLocalMapping.header.xminAllDistributedSnapshots == 5);
+	assert_true(distribSnapshotWithLocalMapping.header.xmin == 10);
+	assert_true(distribSnapshotWithLocalMapping.header.xmax == 30);
+	assert_true(distribSnapshotWithLocalMapping.header.count == 2);
+	assert_true(currentGxact->xminDistributedSnapshot == 10);
+
+	/*************************************************************************
+	 * Add more elemnets, just to have validation that in-progress array is in
+	 * ascending sorted order with distributed transactions.
+	 */
+	shmGxactArray[3]->gxid = 15;
+	shmGxactArray[3]->state = DTX_STATE_ACTIVE_DISTRIBUTED;
+	shmGxactArray[3]->xminDistributedSnapshot = 12;
+	(*shmNumGxacts)++;
+
+	shmGxactArray[4]->gxid = 7;
+	shmGxactArray[4]->state = DTX_STATE_ACTIVE_DISTRIBUTED;
+	shmGxactArray[4]->xminDistributedSnapshot = 7;
+	(*shmNumGxacts)++;
+
+	memset(distribSnapshotWithLocalMapping.inProgressEntryArray, 0, SIZE_OF_IN_PROGRESS_ARRAY);
+	createDtxSnapshot(&distribSnapshotWithLocalMapping);
+
+	/* perform all the validations */
+	assert_true(distribSnapshotWithLocalMapping.header.xminAllDistributedSnapshots == 5);
+	assert_true(distribSnapshotWithLocalMapping.header.xmin == 7);
+	assert_true(distribSnapshotWithLocalMapping.header.xmax == 30);
+	assert_true(distribSnapshotWithLocalMapping.header.count == 4);
+	assert_true(currentGxact->xminDistributedSnapshot == 7);
+	assert_true(distribSnapshotWithLocalMapping.inProgressEntryArray[0].distribXid == 7);
+	assert_true(distribSnapshotWithLocalMapping.inProgressEntryArray[1].distribXid == 10);
+	assert_true(distribSnapshotWithLocalMapping.inProgressEntryArray[2].distribXid == 15);
+	assert_true(distribSnapshotWithLocalMapping.inProgressEntryArray[3].distribXid == 30);
+
+	free(distribSnapshotWithLocalMapping.inProgressEntryArray);
+	free(shmGxactArray[0]);
+}
+
+int
+main(int argc, char* argv[])
+{
+	cmockery_parse_arguments(argc, argv);
+
+	const UnitTest tests[] =
+	{
+		unit_test(test__createDtxSnapshot)
+	};
+
+	MemoryContextInit();
+
+	return run_tests(tests);
+}

--- a/src/backend/commands/cluster.c
+++ b/src/backend/commands/cluster.c
@@ -987,6 +987,9 @@ copy_heap_data(Oid OIDNewHeap, Oid OIDOldHeap, Oid OIDOldIndex)
 
 	index_endscan(scan);
 
+	/* Update FreezeXid based on adjustments made by heap_freeze_tuple() */
+	FreezeXid = get_rewrite_freeze_xid(rwstate);
+
 	/* Write out any remaining tuples, and fsync if needed */
 	end_heap_rewrite(rwstate);
 

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -3215,7 +3215,7 @@ scan_heap(VRelStats *vacrelstats, Relation onerel,
 				 * freezing.
 				 */
 				if (heap_freeze_tuple(tuple.t_data, FreezeLimit,
-									  InvalidBuffer))
+									  InvalidBuffer, false))
 					frozen[nfrozen++] = offnum;
 			}
 		}						/* scan along page */

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -3214,7 +3214,7 @@ scan_heap(VRelStats *vacrelstats, Relation onerel,
 				 * Each non-removable tuple must be checked to see if it needs
 				 * freezing.
 				 */
-				if (heap_freeze_tuple(tuple.t_data, FreezeLimit,
+				if (heap_freeze_tuple(tuple.t_data, &FreezeLimit,
 									  InvalidBuffer, false))
 					frozen[nfrozen++] = offnum;
 			}

--- a/src/backend/commands/vacuumlazy.c
+++ b/src/backend/commands/vacuumlazy.c
@@ -730,7 +730,7 @@ lazy_scan_heap(Relation onerel, LVRelStats *vacrelstats,
 				 * freezing.  Note we already have exclusive buffer lock.
 				 */
 				if (heap_freeze_tuple(tuple.t_data, FreezeLimit,
-									  InvalidBuffer))
+									  InvalidBuffer, false))
 					frozen[nfrozen++] = offnum;
 			}
 		}						/* scan along page */

--- a/src/backend/commands/vacuumlazy.c
+++ b/src/backend/commands/vacuumlazy.c
@@ -729,7 +729,7 @@ lazy_scan_heap(Relation onerel, LVRelStats *vacrelstats,
 				 * Each non-removable tuple must be checked to see if it needs
 				 * freezing.  Note we already have exclusive buffer lock.
 				 */
-				if (heap_freeze_tuple(tuple.t_data, FreezeLimit,
+				if (heap_freeze_tuple(tuple.t_data, &FreezeLimit,
 									  InvalidBuffer, false))
 					frozen[nfrozen++] = offnum;
 			}

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -980,7 +980,10 @@ FillInDistributedSnapshot(Snapshot snapshot)
 
 				dslm->header.distribTransactionTimeStamp = ds->header.distribTransactionTimeStamp;
 				dslm->header.distribSnapshotId = ds->header.distribSnapshotId;
-				
+				Assert(ds->header.xminAllDistributedSnapshots);
+				Assert(ds->header.xminAllDistributedSnapshots <= ds->header.xmin);
+				dslm->header.xminAllDistributedSnapshots = ds->header.xminAllDistributedSnapshots;
+
 				dslm->header.xmin = ds->header.xmin;
 				dslm->header.xmax = ds->header.xmax;
 				dslm->header.count = ds->header.count;

--- a/src/include/access/heapam.h
+++ b/src/include/access/heapam.h
@@ -270,7 +270,7 @@ extern HTSU_Result heap_lock_tuple(Relation relation, HeapTuple tuple,
 extern void heap_inplace_update(Relation relation, HeapTuple tuple);
 extern void frozen_heap_inplace_update(Relation relation, HeapTuple tuple);
 extern bool heap_freeze_tuple(HeapTupleHeader tuple, TransactionId cutoff_xid,
-				  Buffer buf);
+							  Buffer buf, bool xlog_replay);
 
 extern Oid	simple_heap_insert(Relation relation, HeapTuple tup);
 extern Oid frozen_heap_insert(Relation relation, HeapTuple tup);

--- a/src/include/access/heapam.h
+++ b/src/include/access/heapam.h
@@ -269,7 +269,7 @@ extern HTSU_Result heap_lock_tuple(Relation relation, HeapTuple tuple,
 				LockTupleMode mode, LockTupleWaitType waittype);
 extern void heap_inplace_update(Relation relation, HeapTuple tuple);
 extern void frozen_heap_inplace_update(Relation relation, HeapTuple tuple);
-extern bool heap_freeze_tuple(HeapTupleHeader tuple, TransactionId cutoff_xid,
+extern bool heap_freeze_tuple(HeapTupleHeader tuple, TransactionId *cutoff_xid,
 							  Buffer buf, bool xlog_replay);
 
 extern Oid	simple_heap_insert(Relation relation, HeapTuple tup);

--- a/src/include/access/heapam.h
+++ b/src/include/access/heapam.h
@@ -156,6 +156,8 @@ RelationFetchGpRelationNodeForXLog(Relation relation)
 	}
 }
 
+extern bool
+RelationAllowedToGenerateXLogRecord(Relation relation);
 
 typedef enum
 {

--- a/src/include/access/rewriteheap.h
+++ b/src/include/access/rewriteheap.h
@@ -26,5 +26,6 @@ extern void end_heap_rewrite(RewriteState state);
 extern void rewrite_heap_tuple(RewriteState state, HeapTuple oldTuple,
 				   HeapTuple newTuple);
 extern void rewrite_heap_dead_tuple(RewriteState state, HeapTuple oldTuple);
+extern TransactionId get_rewrite_freeze_xid(RewriteState state);
 
 #endif   /* REWRITE_HEAP_H */

--- a/src/include/cdb/cdbdistributedsnapshot.h
+++ b/src/include/cdb/cdbdistributedsnapshot.h
@@ -113,9 +113,13 @@ typedef enum
 	
 } DistributedSnapshotCommitted;
 
+extern bool
+localXidSatisfiesAnyDistributedSnapshot(TransactionId localXid);
+
 extern DistributedSnapshotCommitted DistributedSnapshotWithLocalMapping_CommittedTest(
 	DistributedSnapshotWithLocalMapping		*dslm,
-	TransactionId 							localXid);
+	TransactionId 							localXid,
+	bool isVacuumCheck);
 
 extern void DistributedSnapshot_Reset(
 	DistributedSnapshot *distributedSnapshot);

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -216,6 +216,10 @@ typedef struct TMGXACT
 	
 	bool						explicitBeginRemembered;
 
+	/*
+	 * This is similar to xmin of PROC, stores lowest dxid on first snapshot
+	 * by process with this as currentGXact.
+	 */
 	DistributedTransactionId	xminDistributedSnapshot;
 
 	bool						bumpedPhase1Count;
@@ -259,7 +263,6 @@ typedef struct TmControlBlock
 	int							SegmentCount;
 	int							SegmentsStatesByteLen;
 	uint32						NextSnapshotId;
-	DistributedTransactionId	xminAllDistributedSnapshots;
 	int							num_active_xacts;
 	int							currentPhase1Count;
 									/* Current count of how many DTX 

--- a/src/test/isolation/expected/heap-serializable-vacuum-freeze.out
+++ b/src/test/isolation/expected/heap-serializable-vacuum-freeze.out
@@ -1,0 +1,293 @@
+Parsed test spec with 4 sessions
+
+starting permutation: s2begin s1delete s1setfreezeminage s1vacuumfreeze s2select s1select s2abort s3selectinvisible s3checkrelfrozenxidwithxmax s1vacuumfreeze s3selectinvisible s3checkrelfrozenxidwithxmax
+step s2begin: BEGIN ISOLATION LEVEL SERIALIZABLE;
+		 SELECT 123 AS "establish snapshot";
+establish snapshot
+
+123            
+step s1delete: DELETE FROM heaptest;
+step s1setfreezeminage: SET vacuum_freeze_min_age = 0;
+step s1vacuumfreeze: VACUUM heaptest;
+step s2select: 
+    SELECT CASE 
+         WHEN xmin = 2 THEN 'FrozenXid' 
+         ELSE 'NormalXid' 
+       END AS xmin, 
+       CASE 
+         WHEN xmax = 0 THEN 'InvalidXid' 
+         ELSE 'NormalXid' 
+       END AS xmax, 
+       * 
+    FROM heaptest 
+    ORDER BY i;
+
+xmin           xmax           i              j              
+
+FrozenXid      NormalXid      0              0              
+FrozenXid      NormalXid      1              1              
+FrozenXid      NormalXid      2              2              
+FrozenXid      NormalXid      3              3              
+FrozenXid      NormalXid      4              4              
+FrozenXid      NormalXid      5              5              
+FrozenXid      NormalXid      6              6              
+FrozenXid      NormalXid      7              7              
+FrozenXid      NormalXid      8              8              
+FrozenXid      NormalXid      9              9              
+step s1select: SELECT COUNT(*) FROM heaptest;
+count          
+
+0              
+step s2abort: ABORT;
+step s3selectinvisible: 
+    SET gp_select_invisible=TRUE;
+
+    SELECT CASE 
+         WHEN xmin = 2 THEN 'FrozenXid' 
+         ELSE 'NormalXid' 
+       END AS xmin, 
+       CASE 
+         WHEN xmax = 0 THEN 'InvalidXid' 
+         ELSE 'NormalXid' 
+       END AS xmax, 
+       * 
+    FROM heaptest 
+    ORDER BY i;
+
+xmin           xmax           i              j              
+
+FrozenXid      NormalXid      0              0              
+FrozenXid      NormalXid      1              1              
+FrozenXid      NormalXid      2              2              
+FrozenXid      NormalXid      3              3              
+FrozenXid      NormalXid      4              4              
+FrozenXid      NormalXid      5              5              
+FrozenXid      NormalXid      6              6              
+FrozenXid      NormalXid      7              7              
+FrozenXid      NormalXid      8              8              
+FrozenXid      NormalXid      9              9              
+step s3checkrelfrozenxidwithxmax: 
+    SELECT *
+    FROM   (SELECT gp_segment_id,
+	    Min(Int4in(Xidout(xmax))) AS xmax
+	    FROM   heaptest
+	    WHERE  Int4in(Xidout(xmax)) != 0
+	    GROUP  BY gp_segment_id) tb
+    JOIN (SELECT gp_segment_id,
+	  Int4in(Xidout(relfrozenxid)) AS relfrozenxid
+	  FROM   Gp_dist_random('pg_class')
+	  WHERE  relname = 'heaptest') pg
+    ON ( tb.gp_segment_id = pg.gp_segment_id )
+    WHERE  ( xmax < relfrozenxid )
+
+gp_segment_id  xmax           gp_segment_id  relfrozenxid   
+
+step s1vacuumfreeze: VACUUM heaptest;
+step s3selectinvisible: 
+    SET gp_select_invisible=TRUE;
+
+    SELECT CASE 
+         WHEN xmin = 2 THEN 'FrozenXid' 
+         ELSE 'NormalXid' 
+       END AS xmin, 
+       CASE 
+         WHEN xmax = 0 THEN 'InvalidXid' 
+         ELSE 'NormalXid' 
+       END AS xmax, 
+       * 
+    FROM heaptest 
+    ORDER BY i;
+
+xmin           xmax           i              j              
+
+step s3checkrelfrozenxidwithxmax: 
+    SELECT *
+    FROM   (SELECT gp_segment_id,
+	    Min(Int4in(Xidout(xmax))) AS xmax
+	    FROM   heaptest
+	    WHERE  Int4in(Xidout(xmax)) != 0
+	    GROUP  BY gp_segment_id) tb
+    JOIN (SELECT gp_segment_id,
+	  Int4in(Xidout(relfrozenxid)) AS relfrozenxid
+	  FROM   Gp_dist_random('pg_class')
+	  WHERE  relname = 'heaptest') pg
+    ON ( tb.gp_segment_id = pg.gp_segment_id )
+    WHERE  ( xmax < relfrozenxid )
+
+gp_segment_id  xmax           gp_segment_id  relfrozenxid   
+
+
+starting permutation: s4begin s4delete s4abort s1setfreezeminage s1vacuumfreeze s2select
+step s4begin: BEGIN;
+step s4delete: DELETE FROM heaptest;
+step s4abort: ABORT;
+step s1setfreezeminage: SET vacuum_freeze_min_age = 0;
+step s1vacuumfreeze: VACUUM heaptest;
+step s2select: 
+    SELECT CASE 
+         WHEN xmin = 2 THEN 'FrozenXid' 
+         ELSE 'NormalXid' 
+       END AS xmin, 
+       CASE 
+         WHEN xmax = 0 THEN 'InvalidXid' 
+         ELSE 'NormalXid' 
+       END AS xmax, 
+       * 
+    FROM heaptest 
+    ORDER BY i;
+
+xmin           xmax           i              j              
+
+FrozenXid      InvalidXid     0              0              
+FrozenXid      InvalidXid     1              1              
+FrozenXid      InvalidXid     2              2              
+FrozenXid      InvalidXid     3              3              
+FrozenXid      InvalidXid     4              4              
+FrozenXid      InvalidXid     5              5              
+FrozenXid      InvalidXid     6              6              
+FrozenXid      InvalidXid     7              7              
+FrozenXid      InvalidXid     8              8              
+FrozenXid      InvalidXid     9              9              
+
+starting permutation: s2begin s1insert s1setfreezeminage s1vacuumfreeze s2select s1select s2abort s2select s3checkrelfrozenxidwithxmin s1vacuumfreeze s2select s3checkrelfrozenxidwithxmin
+step s2begin: BEGIN ISOLATION LEVEL SERIALIZABLE;
+		 SELECT 123 AS "establish snapshot";
+establish snapshot
+
+123            
+step s1insert: INSERT INTO heaptest SELECT i, i FROM generate_series(10, 19) i;
+step s1setfreezeminage: SET vacuum_freeze_min_age = 0;
+step s1vacuumfreeze: VACUUM heaptest;
+step s2select: 
+    SELECT CASE 
+         WHEN xmin = 2 THEN 'FrozenXid' 
+         ELSE 'NormalXid' 
+       END AS xmin, 
+       CASE 
+         WHEN xmax = 0 THEN 'InvalidXid' 
+         ELSE 'NormalXid' 
+       END AS xmax, 
+       * 
+    FROM heaptest 
+    ORDER BY i;
+
+xmin           xmax           i              j              
+
+FrozenXid      InvalidXid     0              0              
+FrozenXid      InvalidXid     1              1              
+FrozenXid      InvalidXid     2              2              
+FrozenXid      InvalidXid     3              3              
+FrozenXid      InvalidXid     4              4              
+FrozenXid      InvalidXid     5              5              
+FrozenXid      InvalidXid     6              6              
+FrozenXid      InvalidXid     7              7              
+FrozenXid      InvalidXid     8              8              
+FrozenXid      InvalidXid     9              9              
+step s1select: SELECT COUNT(*) FROM heaptest;
+count          
+
+20             
+step s2abort: ABORT;
+step s2select: 
+    SELECT CASE 
+         WHEN xmin = 2 THEN 'FrozenXid' 
+         ELSE 'NormalXid' 
+       END AS xmin, 
+       CASE 
+         WHEN xmax = 0 THEN 'InvalidXid' 
+         ELSE 'NormalXid' 
+       END AS xmax, 
+       * 
+    FROM heaptest 
+    ORDER BY i;
+
+xmin           xmax           i              j              
+
+FrozenXid      InvalidXid     0              0              
+FrozenXid      InvalidXid     1              1              
+FrozenXid      InvalidXid     2              2              
+FrozenXid      InvalidXid     3              3              
+FrozenXid      InvalidXid     4              4              
+FrozenXid      InvalidXid     5              5              
+FrozenXid      InvalidXid     6              6              
+FrozenXid      InvalidXid     7              7              
+FrozenXid      InvalidXid     8              8              
+FrozenXid      InvalidXid     9              9              
+NormalXid      InvalidXid     10             10             
+NormalXid      InvalidXid     11             11             
+NormalXid      InvalidXid     12             12             
+NormalXid      InvalidXid     13             13             
+NormalXid      InvalidXid     14             14             
+NormalXid      InvalidXid     15             15             
+NormalXid      InvalidXid     16             16             
+NormalXid      InvalidXid     17             17             
+NormalXid      InvalidXid     18             18             
+NormalXid      InvalidXid     19             19             
+step s3checkrelfrozenxidwithxmin: 
+    SELECT *
+    FROM   (SELECT gp_segment_id,
+	    Min(Int4in(Xidout(xmin))) AS xmin
+	    FROM   heaptest
+	    WHERE  Int4in(Xidout(xmin)) > 2
+	    GROUP  BY gp_segment_id) tb
+    JOIN (SELECT gp_segment_id,
+	  Int4in(Xidout(relfrozenxid)) AS relfrozenxid
+	  FROM   Gp_dist_random('pg_class')
+	  WHERE  relname = 'heaptest') pg
+    ON ( tb.gp_segment_id = pg.gp_segment_id )
+    WHERE  ( xmin < relfrozenxid )
+
+gp_segment_id  xmin           gp_segment_id  relfrozenxid   
+
+step s1vacuumfreeze: VACUUM heaptest;
+step s2select: 
+    SELECT CASE 
+         WHEN xmin = 2 THEN 'FrozenXid' 
+         ELSE 'NormalXid' 
+       END AS xmin, 
+       CASE 
+         WHEN xmax = 0 THEN 'InvalidXid' 
+         ELSE 'NormalXid' 
+       END AS xmax, 
+       * 
+    FROM heaptest 
+    ORDER BY i;
+
+xmin           xmax           i              j              
+
+FrozenXid      InvalidXid     0              0              
+FrozenXid      InvalidXid     1              1              
+FrozenXid      InvalidXid     2              2              
+FrozenXid      InvalidXid     3              3              
+FrozenXid      InvalidXid     4              4              
+FrozenXid      InvalidXid     5              5              
+FrozenXid      InvalidXid     6              6              
+FrozenXid      InvalidXid     7              7              
+FrozenXid      InvalidXid     8              8              
+FrozenXid      InvalidXid     9              9              
+FrozenXid      InvalidXid     10             10             
+FrozenXid      InvalidXid     11             11             
+FrozenXid      InvalidXid     12             12             
+FrozenXid      InvalidXid     13             13             
+FrozenXid      InvalidXid     14             14             
+FrozenXid      InvalidXid     15             15             
+FrozenXid      InvalidXid     16             16             
+FrozenXid      InvalidXid     17             17             
+FrozenXid      InvalidXid     18             18             
+FrozenXid      InvalidXid     19             19             
+step s3checkrelfrozenxidwithxmin: 
+    SELECT *
+    FROM   (SELECT gp_segment_id,
+	    Min(Int4in(Xidout(xmin))) AS xmin
+	    FROM   heaptest
+	    WHERE  Int4in(Xidout(xmin)) > 2
+	    GROUP  BY gp_segment_id) tb
+    JOIN (SELECT gp_segment_id,
+	  Int4in(Xidout(relfrozenxid)) AS relfrozenxid
+	  FROM   Gp_dist_random('pg_class')
+	  WHERE  relname = 'heaptest') pg
+    ON ( tb.gp_segment_id = pg.gp_segment_id )
+    WHERE  ( xmin < relfrozenxid )
+
+gp_segment_id  xmin           gp_segment_id  relfrozenxid   
+

--- a/src/test/isolation/expected/heap-serializable-vacuum.out
+++ b/src/test/isolation/expected/heap-serializable-vacuum.out
@@ -1,0 +1,16 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1begin s1delete s2begin s1commit s1vacuum s2select
+step s1begin: begin;
+step s1delete: delete from heaptest;
+step s2begin: BEGIN ISOLATION LEVEL SERIALIZABLE;
+		  select 123 as "establish snapshot";
+establish snapshot
+
+123            
+step s1commit: commit;
+step s1vacuum: vacuum heaptest;
+step s2select: select count(*) from heaptest;
+count          
+
+100            

--- a/src/test/isolation/isolation_schedule
+++ b/src/test/isolation/isolation_schedule
@@ -1,5 +1,6 @@
 
 # GPDB-specific tests
+test: heap-serializable-vacuum-freeze
 test: heap-serializable-vacuum
 test: ao-serializable-read
 test: ao-serializable-vacuum

--- a/src/test/isolation/isolation_schedule
+++ b/src/test/isolation/isolation_schedule
@@ -1,6 +1,6 @@
 
 # GPDB-specific tests
-
+test: heap-serializable-vacuum
 test: ao-serializable-read
 test: ao-serializable-vacuum
 test: ao-insert-eof

--- a/src/test/isolation/specs/heap-serializable-vacuum-freeze.spec
+++ b/src/test/isolation/specs/heap-serializable-vacuum-freeze.spec
@@ -1,0 +1,131 @@
+# Test behaviour with distributed (serializable) snapshots and vacuum freeze.
+#
+# At highlevel main intent of tests is to validate xmax and xmin correctly gets
+# freezed on vacuum freeze. Also, relfrozenxid for pg_class correctly reflects
+# lowest XID in the table, all this considering distributed aspect. Individual
+# test details are mentioned below.
+
+setup
+{
+    CREATE TABLE heaptest (i INT, j INT);
+    INSERT INTO heaptest SELECT i, i FROM generate_series(0, 9) i;
+}
+
+teardown
+{
+    DROP TABLE IF EXISTS heaptest;
+}
+
+session "s1"
+step "s1insert" { INSERT INTO heaptest SELECT i, i FROM generate_series(10, 19) i; }
+step "s1delete"	{ DELETE FROM heaptest; }
+step "s1setfreezeminage" { SET vacuum_freeze_min_age = 0; }
+step "s1vacuumfreeze" { VACUUM heaptest; }
+step "s1select" { SELECT COUNT(*) FROM heaptest; }
+
+session "s2"
+step "s2begin" { BEGIN ISOLATION LEVEL SERIALIZABLE;
+		 SELECT 123 AS "establish snapshot"; }
+step "s2select" {
+    SELECT CASE 
+         WHEN xmin = 2 THEN 'FrozenXid' 
+         ELSE 'NormalXid' 
+       END AS xmin, 
+       CASE 
+         WHEN xmax = 0 THEN 'InvalidXid' 
+         ELSE 'NormalXid' 
+       END AS xmax, 
+       * 
+    FROM heaptest 
+    ORDER BY i;
+}
+step "s2abort" { ABORT; }
+
+session "s3"
+step "s3selectinvisible" { 
+    SET gp_select_invisible=TRUE;
+
+    SELECT CASE 
+         WHEN xmin = 2 THEN 'FrozenXid' 
+         ELSE 'NormalXid' 
+       END AS xmin, 
+       CASE 
+         WHEN xmax = 0 THEN 'InvalidXid' 
+         ELSE 'NormalXid' 
+       END AS xmax, 
+       * 
+    FROM heaptest 
+    ORDER BY i;
+}
+step "s3checkrelfrozenxidwithxmin" {
+    SELECT *
+    FROM   (SELECT gp_segment_id,
+	    Min(Int4in(Xidout(xmin))) AS xmin
+	    FROM   heaptest
+	    WHERE  Int4in(Xidout(xmin)) > 2
+	    GROUP  BY gp_segment_id) tb
+    JOIN (SELECT gp_segment_id,
+	  Int4in(Xidout(relfrozenxid)) AS relfrozenxid
+	  FROM   Gp_dist_random('pg_class')
+	  WHERE  relname = 'heaptest') pg
+    ON ( tb.gp_segment_id = pg.gp_segment_id )
+    WHERE  ( xmin < relfrozenxid )
+}
+step "s3checkrelfrozenxidwithxmax" {
+    SELECT *
+    FROM   (SELECT gp_segment_id,
+	    Min(Int4in(Xidout(xmax))) AS xmax
+	    FROM   heaptest
+	    WHERE  Int4in(Xidout(xmax)) != 0
+	    GROUP  BY gp_segment_id) tb
+    JOIN (SELECT gp_segment_id,
+	  Int4in(Xidout(relfrozenxid)) AS relfrozenxid
+	  FROM   Gp_dist_random('pg_class')
+	  WHERE  relname = 'heaptest') pg
+    ON ( tb.gp_segment_id = pg.gp_segment_id )
+    WHERE  ( xmax < relfrozenxid )
+}
+
+session "s4"
+step "s4begin"  { BEGIN; }
+step "s4delete" { DELETE FROM heaptest; }
+step "s4abort"  { ABORT; }
+
+# Intent of this permutation is to validate xmax of deleted tuple is not freezed
+# (marked invalid) after HeapTupleSatisfiesVacuum() returns tuple cannot be
+# deleted based on global transaction state.
+#
+# Session 2 begins a serializable transaction, but it doesn't immediately do any
+# command in that transaction that would acquire snapshot on QEs. Hence,
+# GetSnapshotData() isn't called in the QEs for session 2 the "s2select"
+# stage. Meanwhile, session 1 deletes rows from the table that due to session
+# 2's existence will not be deleted by vacuum. But if there is no mechanism to
+# validate the global transaction state while freezing, it will merrily mark
+# xmax as invalid and make the deleted tuple visible to everyone. Also, make
+# sure relfrozenxid in pg_class after vacuum freeze is not set to freezelimit
+# locally but actually reflects the lowest xmax it was able to freeze till.
+permutation "s2begin" "s1delete" "s1setfreezeminage" "s1vacuumfreeze" "s2select" "s1select" "s2abort" "s3selectinvisible" "s3checkrelfrozenxidwithxmax" "s1vacuumfreeze" "s3selectinvisible" "s3checkrelfrozenxidwithxmax"
+
+# Intent of this permutation is to validate xmax freezing is correctly
+# continuing to work, when deleting transaction is aborted.
+#
+# So, its pretty simple sequence, start transaction, delete and abort. Then
+# vacuum freeze and check if xmax was freezed means set to invalidXid.
+permutation "s4begin" "s4delete" "s4abort" "s1setfreezeminage" "s1vacuumfreeze" "s2select"
+
+# Intent of this permutation is to validate xmin of tuple is not freezed
+# incorrectly just because its lower than local lowest xmin for that segment but
+# takes into account distributed nature and avoids marking it as frozen and
+# making it visible to all the distributed transactions, if some distributed
+# transaction still can't see it.
+#
+# Session 2 begins a serializable transaction, but it doesn't immediately do any
+# command in that transaction that would acquire snapshot on the QEs. Hence,
+# GetSnapshotData() isn't called in the QEs for session 2 the "s2select"
+# stage. Meanwhile, session 1 inserts more rows to the table and then performs
+# vacuum freeze. These additional rows, due to session 2's existence will not be
+# freezed. Session 2 as started earlier than session1 shouldn't see these
+# additional tuples after vacuum freeze. Also, make sure relfrozenxid in
+# pg_class after vacuum freeze is not set to freezelimit locally but actually
+# reflects the lowest xmin it was able to freeze till.
+permutation "s2begin" "s1insert" "s1setfreezeminage" "s1vacuumfreeze" "s2select" "s1select" "s2abort" "s2select" "s3checkrelfrozenxidwithxmin" "s1vacuumfreeze" "s2select" "s3checkrelfrozenxidwithxmin"

--- a/src/test/isolation/specs/heap-serializable-vacuum.spec
+++ b/src/test/isolation/specs/heap-serializable-vacuum.spec
@@ -1,0 +1,40 @@
+# Test behaviour with distributed (serializable) snapshots and vacuum.
+#
+# The crux of this test is that session 2 begins a serializable
+# transaction, but it doesn't immediately do any actions in that transaction
+# that would open the connections to the QEs. Hence, GetSnapshotData() isn't
+# called in the QEs for session 2 the "s2select" stage. Meanwhile, session 1
+# deletes rows from the table that session 2 later needs to see, and runs
+# vacuum. If there is no mechanism to prevent the global "oldest xmin" from
+# advancing, it will merrily vacuum away tuples that session 2 needs to see
+# later.
+#
+# In a single-node system, the dummy "establish snapshot" query will set
+# MyProc->xmin and prevent the tuples it needs to see later from being
+# vacuumed away. In MPP, the dummy query establishes a distributed snapshot,
+# but that doesn't immediately set the xmin values in QEs.
+setup
+{
+    create table heaptest (i int, j int);
+    insert into heaptest select i, i from generate_series(0, 99) i;
+}
+
+teardown
+{
+    drop table if exists heaptest;
+}
+
+session "s1"
+step "s1begin"  { begin; }
+step "s1delete"	{ delete from heaptest; }
+step "s1commit"  { commit; }
+
+step "s1vacuum"	{ vacuum heaptest; }
+
+session "s2"
+step "s2begin"	{ BEGIN ISOLATION LEVEL SERIALIZABLE;
+		  select 123 as "establish snapshot"; }
+step "s2select"	{ select count(*) from heaptest; }
+teardown	{ abort; }
+
+permutation "s1begin" "s1delete" "s2begin" "s1commit" "s1vacuum" "s2select"


### PR DESCRIPTION
I gave my full justification to think through and cover all spots (my examining all usage of OldestXmin and RecentXmin) and playing around. **Looking for extensive feedback on the PR, with as many eyes as possible and from as many perspectives as possible (like making it as much less painful and error-prone for future merges, or missed this case or we can make it better by....)**

So, this PR fixes #801, which essentially means

- HeapTupleSatisfiesVacuum consider also distributedXmin.
Vacuum now uses distributed lowest dxid to decide oldest transaction *globally*
running in cluster to make sure tuple is DEAD globally before removing the
same. HeapTupleSatisfiesVacuum() consults distributed snapshot by reverse
mapping localXid to distributed xid to check xminAllDistributedSnapshots and
verifies its not needed anymore globally. Note the check is conservative from
perpective if cannot check against distributed snapshot (like utility mode
vacuum) will try to keep the tuple than prematurely getting rid of it and
suffering the same problem.
This fixes the problem of not removing the tuple still needed. Earlier it
performed the check just based on local information (oldestXmin) on a segment,
and hence may cleanup a tuple visible to a distributed query yet to reach the
segment, which breaks snapshot isolation.

- Correct calculation of xminAllDistributedSnapshots and set it on QE's.

- Skip invalidating xmax for tuple, live due to distributed snapshot.

- Freeze xmin only if can be seen by *all* distributed transactions.

- Correctly reflect FreezeLimit and avoid incorrect clog truncation.

- Enable heap page prunning for all tables.

Each commit message has more border description of the change, plus tests associated. So, reviewing commit-by-commit in the order they appear may help. Code change in terms of number of lines is small just critical.