### PR TITLE
set cdb_strict of Material Node to be true when its outernode is a Pa…

### DIFF
--- a/src/backend/executor/nodePartitionSelector.c
+++ b/src/backend/executor/nodePartitionSelector.c
@@ -343,5 +343,26 @@ partition_propagation(EState *estate, List *partOids, List *scanIds, int32 selec
 	}
 }
 
+static bool
+partition_selector_walker(Node *node, void *context)
+{
+	Node *outerNode = NULL;
+
+	Assert(IsA(node, Material));
+
+	outerNode = (Node *)((Plan *)node)->lefttree;
+	if (outerNode == NULL)
+	{
+		return false;
+	}
+	return IsA(outerNode, PartitionSelector);
+}
+
+bool
+contain_partition_selector(Node *node)
+{
+	return partition_selector_walker(node, NULL);
+}
+
 /* EOF */
 

--- a/src/include/executor/nodePartitionSelector.h
+++ b/src/include/executor/nodePartitionSelector.h
@@ -20,5 +20,13 @@ extern void ExecReScanPartitionSelector(PartitionSelectorState *node, ExprContex
 extern int ExecCountSlotsPartitionSelector(PartitionSelector *node);
 extern void initGpmonPktForPartitionSelector(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
 
+/*
+ * partition_selector_walker - check whether the child nodes contain partition selector
+ *
+ * @node				the root node
+ * @return			True if contain partition selector; otherwise false
+ */
+extern bool contain_partition_selector(Node *node);
+
 #endif   /* NODEPARTITIONSELECTOR_H */
 


### PR DESCRIPTION
Set cdb_strict of Material Node to be true when its outernode is a Partition Selector Node.

I will explain this issue a little as follows.

First of all, this PR is like #2168 , more like a bug report than a bug fix. And there must be some better solution.

Following are the reproduce steps for this issue.

Actually, this issue was found when I ran the install check good case: dpe. To simplify the reproduce steps, I just extracted the sql commands with interest as follows.

Environment: Two segments without mirror, optimizer is set off (meaning we use the legacy planner).

SQLs:

    create table pt(dist int, pt1 text, pt2 text, pt3 text, ptid int)
    DISTRIBUTED BY (dist)
    PARTITION BY RANGE(ptid)
              (
              START (0) END (5) EVERY (1),
              DEFAULT PARTITION junk_data
              )
    ;

    create table t(dist int, tid int, t1 text, t2 text);

    create index pt1_idx on pt using btree (pt1);

    create index ptid_idx on pt using btree (ptid);

    insert into pt select i, 'hello' || i, 'world', 'drop this', i % 6 from generate_series(0,53) i;

    insert into t select i, i % 6, 'hello' || i, 'bar' from generate_series(0,1) i;

    analyze pt;
    analyze t;

    --
    -- NL Index Scan
    --

    set enable_nestloop=on;
    set enable_indexscan=on;
    set enable_seqscan=off;
    set enable_hashjoin=off;

    explain select * from t, pt where tid = ptid;

    select * from t, pt where tid = ptid;

Here is the expected result (18 rows):
    
    postgres=# select * from t, pt where tid = ptid;
    dist | tid |   t1   | t2  | dist |   pt1   |  pt2  |    pt3    | ptid 
    ------+-----+--------+-----+------+---------+-------+-----------+------
    1 |   1 | hello1 | bar |   49 | hello49 | world | drop this |    1
    1 |   1 | hello1 | bar |   43 | hello43 | world | drop this |    1
    1 |   1 | hello1 | bar |   37 | hello37 | world | drop this |    1
    1 |   1 | hello1 | bar |   31 | hello31 | world | drop this |    1
    1 |   1 | hello1 | bar |   25 | hello25 | world | drop this |    1
    1 |   1 | hello1 | bar |   19 | hello19 | world | drop this |    1
    1 |   1 | hello1 | bar |   13 | hello13 | world | drop this |    1
    1 |   1 | hello1 | bar |    7 | hello7  | world | drop this |    1
    1 |   1 | hello1 | bar |    1 | hello1  | world | drop this |    1
    0 |   0 | hello0 | bar |   48 | hello48 | world | drop this |    0
    0 |   0 | hello0 | bar |   42 | hello42 | world | drop this |    0
    0 |   0 | hello0 | bar |   36 | hello36 | world | drop this |    0
    0 |   0 | hello0 | bar |   30 | hello30 | world | drop this |    0
    0 |   0 | hello0 | bar |   24 | hello24 | world | drop this |    0
    0 |   0 | hello0 | bar |   18 | hello18 | world | drop this |    0
    0 |   0 | hello0 | bar |   12 | hello12 | world | drop this |    0
    0 |   0 | hello0 | bar |    6 | hello6  | world | drop this |    0
    0 |   0 | hello0 | bar |    0 | hello0  | world | drop this |    0
    (18 rows)

The run time output is unstable:

    postgres=# select * from t, pt where tid = ptid;
    dist | tid |   t1   | t2  | dist |   pt1   |  pt2  |    pt3    | ptid 
    ------+-----+--------+-----+------+---------+-------+-----------+------
    1 |   1 | hello1 | bar |   49 | hello49 | world | drop this |    1
    1 |   1 | hello1 | bar |   43 | hello43 | world | drop this |    1
    1 |   1 | hello1 | bar |   37 | hello37 | world | drop this |    1
    1 |   1 | hello1 | bar |   31 | hello31 | world | drop this |    1
    1 |   1 | hello1 | bar |   25 | hello25 | world | drop this |    1
    1 |   1 | hello1 | bar |   19 | hello19 | world | drop this |    1
    1 |   1 | hello1 | bar |   13 | hello13 | world | drop this |    1
    1 |   1 | hello1 | bar |    7 | hello7  | world | drop this |    1
    1 |   1 | hello1 | bar |    1 | hello1  | world | drop this |    1
    (9 rows)

    postgres=# select * from t, pt where tid = ptid;
    dist | tid |   t1   | t2  | dist |   pt1   |  pt2  |    pt3    | ptid 
    ------+-----+--------+-----+------+---------+-------+-----------+------
    0 |   0 | hello0 | bar |   48 | hello48 | world | drop this |    0
    0 |   0 | hello0 | bar |   42 | hello42 | world | drop this |    0
    0 |   0 | hello0 | bar |   36 | hello36 | world | drop this |    0
    0 |   0 | hello0 | bar |   30 | hello30 | world | drop this |    0
    0 |   0 | hello0 | bar |   24 | hello24 | world | drop this |    0
    0 |   0 | hello0 | bar |   18 | hello18 | world | drop this |    0
    0 |   0 | hello0 | bar |   12 | hello12 | world | drop this |    0
    0 |   0 | hello0 | bar |    6 | hello6  | world | drop this |    0
    0 |   0 | hello0 | bar |    0 | hello0  | world | drop this |    0
    (9 rows)

    postgres=# select * from t, pt where tid = ptid;
    dist | tid |   t1   | t2  | dist |   pt1   |  pt2  |    pt3    | ptid 
    ------+-----+--------+-----+------+---------+-------+-----------+------
    (0 rows)

    postgres=# select * from t, pt where tid = ptid;
    dist | tid |   t1   | t2  | dist |   pt1   |  pt2  |    pt3    | ptid 
    ------+-----+--------+-----+------+---------+-------+-----------+------
    1 |   1 | hello1 | bar |   49 | hello49 | world | drop this |    1
    1 |   1 | hello1 | bar |   43 | hello43 | world | drop this |    1
    1 |   1 | hello1 | bar |   37 | hello37 | world | drop this |    1
    1 |   1 | hello1 | bar |   31 | hello31 | world | drop this |    1
    1 |   1 | hello1 | bar |   25 | hello25 | world | drop this |    1
    1 |   1 | hello1 | bar |   19 | hello19 | world | drop this |    1
    1 |   1 | hello1 | bar |   13 | hello13 | world | drop this |    1
    1 |   1 | hello1 | bar |    7 | hello7  | world | drop this |    1
    1 |   1 | hello1 | bar |    1 | hello1  | world | drop this |    1
    0 |   0 | hello0 | bar |   48 | hello48 | world | drop this |    0
    0 |   0 | hello0 | bar |   42 | hello42 | world | drop this |    0
    0 |   0 | hello0 | bar |   36 | hello36 | world | drop this |    0
    0 |   0 | hello0 | bar |   30 | hello30 | world | drop this |    0
    0 |   0 | hello0 | bar |   24 | hello24 | world | drop this |    0
    0 |   0 | hello0 | bar |   18 | hello18 | world | drop this |    0
    0 |   0 | hello0 | bar |   12 | hello12 | world | drop this |    0
    0 |   0 | hello0 | bar |    6 | hello6  | world | drop this |    0
    0 |   0 | hello0 | bar |    0 | hello0  | world | drop this |    0
    (18 rows)

The above four outputs are all possible.

Here is the EXPLAIN result:

    postgres=# explain select * from t, pt where tid = ptid;
                                                               QUERY PLAN                                                   
    ----------------------------------------------------------------------------------------------
    -----------------------------------
     Gather Motion 2:1  (slice2; segments: 2)  (cost=2.08..2409.27 rows=54 width=50)
       ->  Nested Loop  (cost=2.08..2409.27 rows=27 width=50)
             Join Filter: t.tid = public.pt.ptid
             ->  Append  (cost=0.00..2402.33 rows=27 width=31)
                   ->  Result  (cost=0.00..400.39 rows=5 width=31)
                         One-Time Filter: PartSelected
                         ->  Index Scan using ptid_idx_1_prt_junk_data on pt_1_prt_junk_data pt  (cost=0.00..400.39 rows=5 width=31)
                   ->  Result  (cost=0.00..400.39 rows=5 width=31)
                         One-Time Filter: PartSelected
                         ->  Index Scan using ptid_idx_1_prt_2 on pt_1_prt_2 pt  (cost=0.00..400.39 rows=5 width=31)
                   ->  Result  (cost=0.00..400.39 rows=5 width=31)
                         One-Time Filter: PartSelected
                         ->  Index Scan using ptid_idx_1_prt_3 on pt_1_prt_3 pt  (cost=0.00..400.39 rows=5 width=31)
                   ->  Result  (cost=0.00..400.39 rows=5 width=31)
                         One-Time Filter: PartSelected
                         ->  Index Scan using ptid_idx_1_prt_4 on pt_1_prt_4 pt  (cost=0.00..400.39 rows=5 width=31)
                   ->  Result  (cost=0.00..400.39 rows=5 width=31)
                         One-Time Filter: PartSelected
                         ->  Index Scan using ptid_idx_1_prt_5 on pt_1_prt_5 pt  (cost=0.00..400.39 rows=5 width=31)
                   ->  Result  (cost=0.00..400.39 rows=5 width=31)
                         One-Time Filter: PartSelected
                         ->  Index Scan using ptid_idx_1_prt_6 on pt_1_prt_6 pt  (cost=0.00..400.39 rows=5 width=31)
             ->  Materialize  (cost=2.08..2.12 rows=2 width=19)
                   ->  Partition Selector for pt (dynamic scan id: 1)  (cost=0.00..2.08 rows=2 with=19)
                         Filter: t.tid
                         ->  Broadcast Motion 2:2  (slice1; segments: 2)  (cost=0.00..2.08 rows=2 width=19)
                               ->  Seq Scan on t  (cost=0.00..2.02 rows=1 width=19)
     Settings:  enable_hashjoin=off; enable_indexscan=on; enable_nestloop=on; enable_seqscan=off
     Optimizer status: legacy query optimizer
    (29 rows)

Root cause analyze:

From the execution plan, this is a nestloop join: the inner node is a Material node, while the outer node is Append node. And the outer node of the Material node is a Partition Selector Node.

Code snippet of the Material Node (ExecuteMaterial function):

    	while (((Material *) node->ss.ps.plan)->cdb_strict
				|| ma->share_type != SHARE_NOTSHARED)
		{
			TupleTableSlot *outerslot = ExecProcNode(outerPlanState(node));

			if (TupIsNull(outerslot))
			{
				node->eof_underlying = true;
				ntuplestore_acc_seek_bof(tsa);

				break;
			}
			Gpmon_M_Incr(GpmonPktFromMaterialState(node), GPMON_QEXEC_M_ROWSIN);

			ntuplestore_acc_put_tupleslot(tsa, outerslot);
		}

In this case,

    ((Material *) node->ss.ps.plan)->cdb_strict == false;
    ma->share_type == SHARE_NOTSHARED;

So, it doesn't enter into this while loop, which performs the prefetch action. And then, it enters the following code snippet:

    if (eof_tuplestore && !node->eof_underlying)
	{
		PlanState  *outerNode;
		TupleTableSlot *outerslot;

		/*
		 * We can only get here with forward==true, so no need to worry about
		 * which direction the subplan will go.
		 */
		outerNode = outerPlanState(node);
		outerslot = ExecProcNode(outerNode);
		if (TupIsNull(outerslot))
		{
			node->eof_underlying = true;
			if (!node->ss.ps.delayEagerFree)
			{
				ExecEagerFreeMaterial(node);
			}

			return NULL;
		}

		Gpmon_M_Incr(GpmonPktFromMaterialState(node), GPMON_QEXEC_M_ROWSIN);

		if (tsa)
			ntuplestore_acc_put_tupleslot(tsa, outerslot);

		/*
		 * And return a copy of the tuple.	(XXX couldn't we just return the
		 * outerslot?)
		 */
		Gpmon_M_Incr_Rows_Out(GpmonPktFromMaterialState(node));
		CheckSendPlanStateGpmonPkt(&node->ss.ps);
		return ExecCopySlot(slot, outerslot);
	}

Before returning one slot (also the first slot), ExecProcNode(outerNode) is called once. As aforementioned, the outerNode is a Partition Selector, following the code snippet with interest (ExecPartitionSelector function):

    if (ps->partTabTargetlist)
	{
		TupleTableSlot *slot;
		List	   *oids;
		ListCell   *lc;

		slot = ExecProject(node->partTabProj, NULL);
		slot_getallattrs(slot);

		oids = selectPartitionMulti(node->rootPartitionNode,
									slot_get_values(slot),
									slot_get_isnull(slot),
									slot->tts_tupleDescriptor,
									node->accessMethods);
		if (oids != NIL)
		{
			foreach (lc, oids)
			{
				InsertPidIntoDynamicTableScanInfo(estate, ps->scanId, lfirst_oid(lc), ps->selectorId);
			}
		}
		else
		{
			/* no partitions matched. */
			InsertPidIntoDynamicTableScanInfo(estate, ps->scanId, InvalidOid, ps->selectorId);
		}
	}

Based on the value of input slot, this code figured out the matched partition tables, and then inserted those table oids into the dynamic table scan info. Note that, before the function ExecMaterial returning its first output, the function ExecPartitionSelector was called JUST once, which means the oids of the dynamic table scan info were not complete (partial).

After the ExecMaterial running its first output, let's lookup the code snippet of ExecNestLoop:

    	if (node->nl_NeedNewOuter)
		{
			ENL1_printf("getting new outer tuple");
			outerTupleSlot = ExecProcNode(outerPlan);
			Gpmon_M_Incr(GpmonPktFromNLJState(node), GPMON_NLJ_OUTERTUPLE);
			Gpmon_M_Incr(GpmonPktFromNLJState(node), GPMON_QEXEC_M_ROWSIN);

			/*
			 * if there are no more outer tuples, then the join is complete..
			 */
			if (TupIsNull(outerTupleSlot))
			{
				ENL1_printf("no outer tuple, ending join");

				/*
				 * CDB: If outer tuple stream was empty, notify inner
				 * subplan that we won't fetch its results, so QEs in
				 * lower gangs won't keep trying to send to us.  Else
				 * we have reached inner end-of-data at least once and
				 * squelch is not needed.
				 */
				if (node->nl_innerSquelchNeeded)
				{
					ExecSquelchNode(innerPlan);
				}

				/*
				 * The memory used by child nodes might not be freed because
				 * they are not eager free safe. However, when the nestloop is done,
				 * we can free the memory used by the child nodes.
				 */
				if (!node->js.ps.delayEagerFree)
				{
					ExecEagerFreeChildNodes((PlanState *)node, false);
				}

				return NULL;
			}

			ENL1_printf("saving new outer tuple information");
			node->js.ps.ps_OuterTupleSlot = outerTupleSlot;
			econtext->ecxt_outertuple = outerTupleSlot;
			node->nl_NeedNewOuter = false;
			node->nl_MatchedOuter = false;

			/*
			 * now rescan the inner plan
			 */
			ENL1_printf("rescanning inner plan");

			/*
			 * The scan key of the inner plan might depend on the current
			 * outer tuple (e.g. in index scans), that's why we pass our expr
			 * context.
			 */
			if ( node->require_inner_reset || node->reset_inner )
			{
				ExecReScan(innerPlan, econtext);
				node->reset_inner = false;
			}
		}

After getting the first tuple from its inner node (the Material node), the nest loop node tried to fetch a tuple from its outer node. As aforementioned, this is a partition table scan node. Based on the dynamic table scan info (calculated by the Partition Selector under the Material node), the partition tables are selected and the scan operation was performed. 

Unfortunately, based on the value of the input slot when calling ExecPartitionSelector the first time (the tuple order of the broadcast motion node is not unstable), the dynamic table scan info may be different each time, and was not complete. In some case, this would cause that the first output tuple of the outer node of the nest loop node was null, which then would cause the nest loop end by returning null tuple.

In summary, my solution is that, if there is a partition selector as the child node of a material node, then the cdb_strict field of the material node should be true, forcing prefetch, making the partition selector node build a complete dynamic table scan info before any partition table scan is performed.

Of cause, there must be some better solution (in other places) to set the cdb_strict field of a material node to be true. My solution is just a simple and conservative one.

Apparently, this issue is related to QP. So, @karthijrk and @foyzur or other QP guys, please have a check. Thanks.