### PR TITLE
Resolve pgcrypto coverity warnings

### DIFF
--- a/contrib/pgcrypto/pgp-decrypt.c
+++ b/contrib/pgcrypto/pgp-decrypt.c
@@ -340,37 +340,33 @@ mdc_free(void *priv)
 }
 
 static int
-mdc_finish(PGP_Context *ctx, PullFilter *src,
-		   int len, uint8 **data_p)
+mdc_finish(PGP_Context *ctx, PullFilter *src, int len)
 {
 	int			res;
 	uint8		hash[20];
-	uint8		tmpbuf[22];
+	uint8		tmpbuf[20];
+	uint8	   *data;
 
-	if (len + 1 > sizeof(tmpbuf))
+	/* should not happen */
+	if (ctx->use_mdcbuf_filter)
 		return PXE_BUG;
 
+	/* It's SHA1 */
+	if (len != 20)
+		return PXE_PGP_CORRUPT_DATA;
+
+	/* mdc_read should not call md_update */
+	ctx->in_mdc_pkt = 1;
+
 	/* read data */
-	res = pullf_read_max(src, len + 1, data_p, tmpbuf);
+	res = pullf_read_max(src, len, &data, tmpbuf);
 	if (res < 0)
 		return res;
 	if (res == 0)
 	{
-		if (ctx->mdc_checked == 0)
-		{
-			px_debug("no mdc");
-			return PXE_PGP_CORRUPT_DATA;
-		}
-		return 0;
-	}
-
-	/* safety check */
-	if (ctx->in_mdc_pkt > 1)
-	{
-		px_debug("mdc_finish: several times here?");
+		px_debug("no mdc");
 		return PXE_PGP_CORRUPT_DATA;
 	}
-	ctx->in_mdc_pkt++;
 
 	/* is the packet sane? */
 	if (res != 20)
@@ -383,7 +379,7 @@ mdc_finish(PGP_Context *ctx, PullFilter *src,
 	 * ok, we got the hash, now check
 	 */
 	px_md_finish(ctx->mdc_ctx, hash);
-	res = memcmp(hash, *data_p, 20);
+	res = memcmp(hash, data, 20);
 	px_memset(hash, 0, 20);
 	px_memset(tmpbuf, 0, sizeof(tmpbuf));
 	if (res != 0)
@@ -392,7 +388,7 @@ mdc_finish(PGP_Context *ctx, PullFilter *src,
 		return PXE_PGP_CORRUPT_DATA;
 	}
 	ctx->mdc_checked = 1;
-	return len;
+	return 0;
 }
 
 static int
@@ -403,11 +399,8 @@ mdc_read(void *priv, PullFilter *src, int len,
 	PGP_Context *ctx = priv;
 
 	/* skip this filter? */
-	if (ctx->use_mdcbuf_filter)
+	if (ctx->use_mdcbuf_filter || ctx->in_mdc_pkt)
 		return pullf_read(src, len, data_p);
-
-	if (ctx->in_mdc_pkt)
-		return mdc_finish(ctx, src, len, data_p);
 
 	res = pullf_read(src, len, data_p);
 	if (res < 0)
@@ -884,7 +877,6 @@ process_data_packets(PGP_Context *ctx, MBuf *dst, PullFilter *src,
 	int			got_data = 0;
 	int			got_mdc = 0;
 	PullFilter *pkt = NULL;
-	uint8	   *tmp;
 
 	while (1)
 	{
@@ -943,11 +935,8 @@ process_data_packets(PGP_Context *ctx, MBuf *dst, PullFilter *src,
 					break;
 				}
 
-				/* notify mdc_filter */
-				ctx->in_mdc_pkt = 1;
-
-				res = pullf_read(pkt, 8192, &tmp);
-				if (res > 0)
+				res = mdc_finish(ctx, pkt, len);
+				if (res >= 0)
 					got_mdc = 1;
 				break;
 			default:

--- a/contrib/pgcrypto/pgp-pgsql.c
+++ b/contrib/pgcrypto/pgp-pgsql.c
@@ -573,35 +573,25 @@ decrypt_internal(int is_pubenc, int need_text, text *data,
 		err = pgp_set_symkey(ctx, (uint8 *) VARDATA(key),
 							 VARSIZE(key) - VARHDRSZ);
 
-	/*
-	 * decrypt
-	 */
+	/* decrypt */
 	if (err >= 0)
+	{
 		err = pgp_decrypt(ctx, src, dst);
 
-	/*
-	 * failed?
-	 */
-	if (err < 0)
-		goto out;
+		if (ex.expect)
+			check_expect(ctx, &ex);
 
-	if (ex.expect)
-		check_expect(ctx, &ex);
+		/* remember the setting */
+		got_unicode = pgp_get_unicode_mode(ctx);
+	}
 
-	/* remember the setting */
-	got_unicode = pgp_get_unicode_mode(ctx);
-
-out:
-	if (src)
-		mbuf_free(src);
-	if (ctx)
-		pgp_free(ctx);
+	mbuf_free(src);
+	pgp_free(ctx);
 
 	if (err)
 	{
 		px_set_debug_handler(NULL);
-		if (dst)
-			mbuf_free(dst);
+		mbuf_free(dst);
 		ereport(ERROR,
 				(errcode(ERRCODE_EXTERNAL_ROUTINE_INVOCATION_EXCEPTION),
 				 errmsg("%s", px_strerror(err))));


### PR DESCRIPTION
This cherry-picks two commits from upstream which addresses Coverity warnings in the pgcrypto code.  While we would get these eventually anyway, having a clean(er) Coverity report is a good thing, especially in crypto code. Since this code moves very infrequently, pull these in ahead of time to avoid having to ignore actual issues.