### PR TITLE
Use CHashSet for print missing stats for Orca

### DIFF
--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -120,7 +120,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" resolve);
 	@echo "Resolve finished";
 
-	LD_LIBRARY_PATH='' wget -O - https://github.com/greenplum-db/gporca/releases/download/v2.26.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget -O - https://github.com/greenplum-db/gporca/releases/download/v2.28.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 
 clean_tools: opt_write_test
 	@cd releng/make/dependencies; \

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -1016,7 +1016,7 @@ COptTasks::PvOptimizeTask
 	CDXLNode *pdxlnPlan = NULL;
 
 	DrgPmdid *pdrgmdidCol = NULL;
-	HMMDIdMDId *phmmdidRel = NULL;
+	HSMDId *phsmdidRel = NULL;
 
 	GPOS_TRY
 	{
@@ -1107,10 +1107,10 @@ COptTasks::PvOptimizeTask
 			pdrgmdidCol = GPOS_NEW(pmp) DrgPmdid(pmp);
 			pstatsconf->CollectMissingStatsColumns(pdrgmdidCol);
 
-			phmmdidRel = GPOS_NEW(pmp) HMMDIdMDId(pmp);
-			PrintMissingStatsWarning(pmp, &mda, pdrgmdidCol, phmmdidRel);
+			phsmdidRel = GPOS_NEW(pmp) HSMDId(pmp);
+			PrintMissingStatsWarning(pmp, &mda, pdrgmdidCol, phsmdidRel);
 
-			phmmdidRel->Release();
+			phsmdidRel->Release();
 			pdrgmdidCol->Release();
 
 			pceeval->Release();
@@ -1122,7 +1122,7 @@ COptTasks::PvOptimizeTask
 	GPOS_CATCH_EX(ex)
 	{
 		ResetTraceflags(pbsEnabled, pbsDisabled);
-		CRefCount::SafeRelease(phmmdidRel);
+		CRefCount::SafeRelease(phsmdidRel);
 		CRefCount::SafeRelease(pdrgmdidCol);
 		CRefCount::SafeRelease(pbsEnabled);
 		CRefCount::SafeRelease(pbsDisabled);
@@ -1175,12 +1175,12 @@ COptTasks::PrintMissingStatsWarning
 	IMemoryPool *pmp,
 	CMDAccessor *pmda,
 	DrgPmdid *pdrgmdidCol,
-	HMMDIdMDId *phmmdidRel
+	HSMDId *phsmdidRel
 	)
 {
 	GPOS_ASSERT(NULL != pmda);
 	GPOS_ASSERT(NULL != pdrgmdidCol);
-	GPOS_ASSERT(NULL != phmmdidRel);
+	GPOS_ASSERT(NULL != phsmdidRel);
 
 	CWStringDynamic str(pmp);
 	COstreamString oss(&str);
@@ -1197,7 +1197,7 @@ COptTasks::PrintMissingStatsWarning
 
 		if (IMDRelation::ErelstorageExternal != pmdrel->Erelstorage())
 		{
-			if (NULL == phmmdidRel->PtLookup(pmdidRel))
+			if (!phsmdidRel->FExists(pmdidRel))
 			{
 				if (0 != ul)
 				{
@@ -1206,7 +1206,7 @@ COptTasks::PrintMissingStatsWarning
 
 				pmdidRel->AddRef();
 				pmdidRel->AddRef();
-				phmmdidRel->FInsert(pmdidRel, pmdidRel);
+				phsmdidRel->FInsert(pmdidRel);
 				oss << pmdrel->Mdname().Pstr()->Wsz();
 			}
 
@@ -1215,7 +1215,7 @@ COptTasks::PrintMissingStatsWarning
 		}
 	}
 
-	if (0 < phmmdidRel->UlEntries())
+	if (0 < phsmdidRel->UlEntries())
 	{
 		ereport(NOTICE,
 				(errcode(ERRCODE_SUCCESSFUL_COMPLETION),

--- a/src/include/gpopt/utils/COptTasks.h
+++ b/src/include/gpopt/utils/COptTasks.h
@@ -251,7 +251,7 @@ class COptTasks
 
 		// print warning messages for columns with missing statistics
 		static
-		void PrintMissingStatsWarning(IMemoryPool *pmp, CMDAccessor *pmda, DrgPmdid *pdrgmdidCol, HMMDIdMDId *phmmdidRel);
+		void PrintMissingStatsWarning(IMemoryPool *pmp, CMDAccessor *pmda, DrgPmdid *pdrgmdidCol, HSMDId *phsmdidRel);
 
 	public:
 


### PR DESCRIPTION
This PR provides compliance for GPDB with the recent changes in Orca for transforming CHashMap to CHashSet. Specifically this PR provides updates necessary for column statistics configuration.

Signed-off-by: Jemish Patel <jpatel@pivotal.io>