### PR TITLE
Always annotate outer/inner edges in the plan

### DIFF
--- a/src/test/regress/explain.pm
+++ b/src/test/regress/explain.pm
@@ -25,10 +25,10 @@ use warnings;
 # than changing the parser to handle both cases.
 #
 # Parse_node:
-#   InitPlan entries in greenplum are in separate slices, so explain.pl
-#   prefixes them with an arrow (and adds a fake cost) to make them
-#   look like a top-level execution node.  Again, this technique was
-#   easier than modifying the parser to special case InitPlan.
+#   InitPlan entries in greenplum are in separate slices sometimes, so
+#   explain.pl prefixes them with an arrow (and adds a fake cost) to make them
+#   look like a top-level execution node.  Again, this technique was easier
+#   than modifying the parser to special case InitPlan.
 #
 #  Plan parsing in general:
 #  The original code only dealt with the TPCH formatted output:
@@ -702,7 +702,7 @@ sub parse_node
         # XXX XXX XXX XXX XXX XXX XXX XXX XXX XXX XXX XXX XXX XXX XXX
         # make initplan into a fake node so the graphs look nicer (eg
         # tpch query 15).  Prefix it with an arrow and add a fake cost.
-        if ($row =~ m/\|(\s)*InitPlan(.*)slice/)
+        if ($row =~ m/\|(\s)*InitPlan/)
         {
             $row =~ s/InitPlan/\-\>  InitPlan/;
             if ($row !~ m/\(cost=/)
@@ -1577,14 +1577,13 @@ sub human_num
     return $esti;
 }
 
-# label left and right for nest loops
-sub nestedloop_fixup
+# label left and right children
+sub label_fixup
 {
     my ($node, $ctx) = @_;
 
     return
-        unless (exists($node->{short}) &&
-                ($node->{short} =~ m/Nested Loop/));
+        unless (exists($node->{short}));
 
     my @kidlist;
 
@@ -1592,24 +1591,35 @@ sub nestedloop_fixup
     {
         for my $kid (@{$node->{child}})
         {
-            push @kidlist, $kid;
+            # Ignore InitPlans when deciding inner/outer child
+            if ($kid->{txt} !~ /InitPlan/)
+            {
+                push @kidlist, $kid;
+            }
         }
     }
 
-    return
-        unless (2 == scalar(@kidlist));
+    my $nkids;
+    $nkids = scalar(@kidlist);
 
-    if ($kidlist[0]->{id} < $kidlist[1]->{id})
+    return
+        unless ($nkids >= 2);
+
+    # sort kidlist by id for labeling
+    my @sortedkidlist = sort { $a->{id} <=> $b->{id} } @kidlist;
+
+    if ($nkids == 2 && $node->{txt} !~ /Append/)
     {
-        $kidlist[0]->{nested_loop_position} = "left";
-        $kidlist[1]->{nested_loop_position} = "right";
+        $sortedkidlist[0]->{label} = "outer";
+        $sortedkidlist[1]->{label} = "inner";
     }
     else
     {
-        $kidlist[1]->{nested_loop_position} = "left";
-        $kidlist[0]->{nested_loop_position} = "right";
+        for my $i (0 .. $nkids)
+        {
+            $sortedkidlist[$i]->{label} = "child$i"
+        }
     }
-
 }
 
 # find rows out information
@@ -1837,9 +1847,9 @@ sub dodotfile
             undef,
             $ctx);
 
-    # always label the left/right sides of nested loop
+    # always label the left/right sides
     treeMap($plantree,
-            'nestedloop_fixup($node, $ctx); ',
+            'label_fixup($node, $ctx); ',
             undef,
             $ctx);
 
@@ -1907,9 +1917,9 @@ sub dotkid
 
             print $outfh '"' . $kid->{id} . '" -> "' . $node->{id} . '"';
 
-            if (exists($kid->{nested_loop_position}))
+            if (exists($kid->{label}))
             {
-                $edge_label .= $kid->{nested_loop_position};
+                $edge_label .= $kid->{label};
             }
 
             if (exists($kid->{rows_out}))


### PR DESCRIPTION
This way, in the case that graphviz decides to swap the left/right children - at least it's clearly visible instead of a human having to check through big plans.

Also for future reference, the way to generate these images is:
```
cd src/test/regress
cat plan.txt | ./explain.pl -option dot | dot -Tsvg -o /tmp/plan.svg
```
And open the SVG file in a browser.

@d @karthijrk @hsyuan

For example, for the plan : 
```
$ cat plan.txt
                                                        QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=0.00..431.00 rows=1 width=8)
   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
               ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
                     Group By: i, j, t
                     ->  Sort  (cost=0.00..431.00 rows=1 width=16)
                           Sort Key: i, j, t
                           ->  Sequence  (cost=0.00..431.00 rows=1 width=16)
                                 ->  Partition Selector for foo (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
                                       Partitions selected: 2 (out of 2)
                                 ->  Dynamic Table Scan on foo (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=16)
 Settings:  optimizer=on
 Optimizer status: PQO version 2.27.0
(13 rows)

```

It'll now add the outer/inner labels to the edges : 
```
digraph plan1 {
rankdir=BT;
"2" -> "1";
"3" -> "2";
"4" -> "3";
"5" -> "4";
"6" -> "5";
"7" -> "6" [label="outer" ] ;
"8" -> "6" [label="inner" ] ;
"1" [shape=record, label="Aggregate", style=filled, color="#66c2a5", fillcolor="#66c2a5"];
"2" [shape=record, label="Gather Motion 3:1  (slice1; segments: 3)", style=filled, color="#fc8d62", fillcolor="#fc8d62"];
"3" [shape=record, label="Aggregate", style=filled, color="#fc8d62", fillcolor="#fc8d62"];
"4" [shape=record, label="GroupAggregate", style=filled, color="#fc8d62", fillcolor="#fc8d62"];
"5" [shape=record, label="Sort", style=filled, color="#fc8d62", fillcolor="#fc8d62"];
"6" [shape=record, label="Sequence", style=filled, color="#fc8d62", fillcolor="#fc8d62"];
"7" [shape=record, label="Partition Selector for foo (dynamic scan id: 1)", style=filled, color="#fc8d62", fillcolor="#fc8d62"];
"8" [shape=record, label="Dynamic Table Scan on foo (dynamic scan id: 1)", style=filled, color="#fc8d62", fillcolor="#fc8d62"];

}
```

This results to this SVG:

<img width="782" alt="screen shot 2017-04-26 at 11 36 06 am" src="https://cloud.githubusercontent.com/assets/2496677/25450704/99463464-2a74-11e7-8019-9cd77c666a56.png">
