### PR TITLE
Update ivy to use libsigar 1.6.5 from artifactory

### DIFF
--- a/gpAux/releng/make/dependencies/ivy.xml
+++ b/gpAux/releng/make/dependencies/ivy.xml
@@ -11,7 +11,6 @@
     </configurations>
 
     <dependencies>
-      <dependency org="Hyperic"         name="sigar"           rev="1.6.3"          conf="rhel7_x86_64->rhel5_x86_64;suse11_x86_64->suse10_x86_64" />
       <dependency org="apache"          name="apr"             rev="1.5.2"          conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64;suse11_x86_64->sles11_x86_64" />
       <dependency org="apache"          name="apr-util"        rev="1.2.12"         conf="rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64;suse11_x86_64->suse10_x86_64" />
       <dependency org="xerces"          name="xerces-c"        rev="3.1.1-p1"       conf="rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64;suse11_x86_64->suse10_x86_64" />
@@ -20,6 +19,7 @@
       <dependency org="gnu"             name="libstdc"         rev="6.0.22"         conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64;suse11_x86_64->suse11_x86_64" />
       <dependency org="third-party"     name="ext"             rev="1.1"            conf="win32->win32" />
       <dependency org="third-party"     name="ext"             rev="3.0"            conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64;suse11_x86_64->sles11_x86_64" />
+      <dependency org="Hyperic"         name="sigar"           rev="1.6.5"          conf="rhel6_x86_64->rhel6_x86_64;rhel7_x86_64->rhel7_x86_64;suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64"/>
       <dependency org="NetBackup"       name="SDK-7.1"         rev="7.1"            conf="rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64" />
       <dependency org="NetBackup"       name="SDK-7.5"         rev="7.5"            conf="rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64" />
       <dependency org="NetBackup"       name="SDK-7.6"         rev="7.6"            conf="rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64" />


### PR DESCRIPTION
We built libsigar 1.6.5 from the most recent commit, and uploaded it to artifactory. We changed the dependencies ivy file to use the new one.