### PR TITLE
Support COPY ON SEGMENT command

### DIFF
--- a/doc/src/sgml/ref/copy.sgml
+++ b/doc/src/sgml/ref/copy.sgml
@@ -38,6 +38,7 @@ COPY table [(column [, ...])] FROM {'file' | STDIN}
 
 COPY {table [(column [, ...])] | (query)} TO {'file' | STDOUT}
       [ [WITH] 
+        [ON SEGMENT]
         [BINARY]
         [OIDS]
         [HEADER]

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -465,6 +465,16 @@ CopySendEndOfRow(CopyState cstate)
 				ereport(ERROR,
 						(errcode_for_file_access(),
 						 errmsg("could not write to COPY file: %m")));
+
+			/* Send "\n" to QD for "processed" line number counting */
+			if (cstate->on_segment && Gp_role == GP_ROLE_EXECUTE)
+			{
+				if (!cstate->not_count_line) /* not the csv header */
+					(void) pq_putmessage('d', "\n", 1);
+				else /* ignore the csv header, set the flag */
+					cstate->not_count_line = false;
+			}
+
 			break;
 		case COPY_OLD_FE:
 			/* The FE/BE protocol uses \n as newline for all platforms */
@@ -1134,6 +1144,14 @@ DoCopyInternal(const CopyStmt *stmt, const char *queryString, CopyState cstate)
 						 errmsg("conflicting or redundant options")));
 			cstate->eol_str = strVal(defel->arg);
 		}
+		else if (strcmp(defel->defname, "on_segment") == 0)
+		{
+			if (cstate->on_segment)
+				ereport(ERROR,
+						(errcode(ERRCODE_SYNTAX_ERROR),
+						 errmsg("conflicting or redundant options")));
+			cstate->on_segment = TRUE;
+		}
 		else
 			elog(ERROR, "option \"%s\" not recognized",
 				 defel->defname);
@@ -1267,7 +1285,37 @@ DoCopyInternal(const CopyStmt *stmt, const char *queryString, CopyState cstate)
 						 "psql's \\copy command also works for anyone.")));
 
 	cstate->copy_dest = COPY_FILE;		/* default */
-	cstate->filename = (Gp_role == GP_ROLE_EXECUTE ? NULL : stmt->filename); /* QE COPY always uses STDIN */
+    if (Gp_role == GP_ROLE_EXECUTE)
+	{
+		if (cstate->on_segment) /* Save data to a local file */
+		{
+			StringInfoData filepath;
+			initStringInfo(&filepath);
+			appendStringInfoString(&filepath, stmt->filename);
+
+			replaceStringInfoString(&filepath, "<SEG_DATA_DIR>", strrchr(DataDir, '/') + 1);
+
+			if (strstr(stmt->filename, "<SEGID>") == NULL)
+				ereport(ERROR,
+					(0, errmsg("<SEGID> is required for file name")));
+
+			char segid_buf[8];
+			snprintf(segid_buf, 8, "%d", GpIdentity.segindex);
+			replaceStringInfoString(&filepath, "<SEGID>", segid_buf);
+
+			cstate->filename = filepath.data;
+
+			pipe = false;
+		}
+		else
+		{
+			cstate->filename = NULL; /* QE COPY always uses STDIN */
+		}
+	}
+	else
+	{
+		cstate->filename = stmt->filename; /* Not on_segment, QD saves file to local */
+	}
 	cstate->copy_file = NULL;
 	cstate->fe_msgbuf = NULL;
 	cstate->fe_eof = false;
@@ -1286,25 +1334,32 @@ DoCopyInternal(const CopyStmt *stmt, const char *queryString, CopyState cstate)
 		{
 			mode_t		oumask; /* Pre-existing umask value */
 			struct stat st;
+			char* filename = cstate->filename;
+
+			/*
+			 * If on_segment, QD receives "\n" for "processed" line number counting, saves
+			 * them to /dev/null to avoid nonsense file
+			 */
+			if (cstate->on_segment && Gp_role == GP_ROLE_DISPATCH)
+				filename = "/dev/null";
 
 			/*
 			 * Prevent write to relative path ... too easy to shoot oneself in the
 			 * foot by overwriting a database file ...
 			 */
-			if (!is_absolute_path(cstate->filename))
+			if (!is_absolute_path(filename))
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_NAME),
 						 errmsg("relative path not allowed for COPY to file")));
 
 			oumask = umask((mode_t) 022);
-			cstate->copy_file = AllocateFile(cstate->filename, PG_BINARY_W);
+			cstate->copy_file = AllocateFile(filename, PG_BINARY_W);
 			umask(oumask);
 
 			if (cstate->copy_file == NULL)
 				ereport(ERROR,
 						(errcode_for_file_access(),
-						 errmsg("could not open file \"%s\" for writing: %m",
-								cstate->filename)));
+						 errmsg("could not open file \"%s\" for writing: %m", filename)));
 
 			// Increase buffer size to improve performance  (cmcdevitt)
 			setvbuf(cstate->copy_file, NULL, _IOFBF, 393216); // 384 Kbytes
@@ -1313,7 +1368,7 @@ DoCopyInternal(const CopyStmt *stmt, const char *queryString, CopyState cstate)
 			if (S_ISDIR(st.st_mode))
 				ereport(ERROR,
 						(errcode(ERRCODE_WRONG_OBJECT_TYPE),
-						 errmsg("\"%s\" is a directory", cstate->filename)));
+						 errmsg("\"%s\" is a directory", filename)));
 		}
 
 	}
@@ -1813,6 +1868,15 @@ DoCopyTo(CopyState cstate)
 	{
 		if (cstate->fe_copy)
 			SendCopyBegin(cstate);
+		else if	(Gp_role == GP_ROLE_EXECUTE && cstate->on_segment)
+		{
+			SendCopyBegin(cstate);
+			/*
+			 * For COPY ON SEGMENT command, segment writes to file
+			 * instead of front end. Switch to COPY_FILE
+			 */
+			cstate->copy_dest = COPY_FILE;
+		}
 
 		/*
 		 * We want to dispatch COPY TO commands only in the case that
@@ -1829,6 +1893,15 @@ DoCopyTo(CopyState cstate)
 
 		if (cstate->fe_copy)
 			SendCopyEnd(cstate);
+		else if (Gp_role == GP_ROLE_EXECUTE && cstate->on_segment)
+		{
+			/*
+			 * For COPY ON SEGMENT command, switch back to front end
+			 * before sending copy end which is "\."
+			 */
+			cstate->copy_dest = COPY_NEW_FE;
+			SendCopyEnd(cstate);
+		}
 	}
 	PG_CATCH();
 	{
@@ -1897,7 +1970,14 @@ static void CopyToCreateDispatchCommand(CopyState cstate,
 			appendStringInfo(cdbcopy_cmd, ")");
 	}
 
-	appendStringInfo(cdbcopy_cmd, " TO STDOUT WITH");
+	if (cstate->on_segment)
+	{
+		appendStringInfo(cdbcopy_cmd, " TO '%s' WITH ON SEGMENT", cstate->filename);
+	}
+	else
+	{
+		appendStringInfo(cdbcopy_cmd, " TO STDOUT WITH");
+	}
 
 	if (cstate->oids)
 		appendStringInfo(cdbcopy_cmd, " OIDS");
@@ -1916,6 +1996,14 @@ static void CopyToCreateDispatchCommand(CopyState cstate,
 		if (cstate->csv_mode)
 		{
 			appendStringInfo(cdbcopy_cmd, " CSV");
+
+			/*
+			 * If on_segment, QE needs to write their own CSV header. If not,
+			 * only QD needs to, QE doesn't send CSV header to QD
+			 */
+			if (cstate->on_segment && cstate->header_line)
+				appendStringInfo(cdbcopy_cmd, " HEADER");
+
 			appendStringInfo(cdbcopy_cmd, " QUOTE AS E'%s'", escape_quotes(cstate->quote));
 			appendStringInfo(cdbcopy_cmd, " ESCAPE AS E'%s'", escape_quotes(cstate->escape));
 
@@ -2073,6 +2161,7 @@ CopyToDispatch(CopyState cstate)
 		}
 
 		/* add a newline and flush the data */
+		cstate->not_count_line = true; /* CSV header line doesn't count in "processed" line numbers */
 		CopySendEndOfRow(cstate);
 	}
 
@@ -2228,7 +2317,7 @@ CopyTo(CopyState cstate)
 	if (cstate->binary)
 	{
 		/* binary header should not be sent in execute mode. */
-		if (Gp_role != GP_ROLE_EXECUTE)
+		if (Gp_role != GP_ROLE_EXECUTE || (Gp_role == GP_ROLE_EXECUTE && cstate->on_segment ))
 		{
 			/* Generate header for a binary copy */
 			int32		tmp;
@@ -2251,7 +2340,7 @@ CopyTo(CopyState cstate)
 		if (cstate->header_line)
 		{
 			/* header should not be printed in execute mode. */
-			if (Gp_role != GP_ROLE_EXECUTE)
+			if (Gp_role != GP_ROLE_EXECUTE || (Gp_role == GP_ROLE_EXECUTE && cstate->on_segment ))
 			{
 				bool		hdr_delim = false;
 
@@ -2269,7 +2358,7 @@ CopyTo(CopyState cstate)
 					CopyAttributeOutCSV(cstate, colname, false,
 										list_length(cstate->attnumlist) == 1);
 				}
-
+				cstate->not_count_line = true; /* CSV header line doesn't count in "processed" line numbers */
 				CopySendEndOfRow(cstate);
 			}
 		}
@@ -2432,12 +2521,20 @@ CopyTo(CopyState cstate)
 	}
 
 	/* binary trailer should not be sent in execute mode. */
-	if (cstate->binary && Gp_role != GP_ROLE_EXECUTE)
+	if (cstate->binary)
 	{
-		/* Generate trailer for a binary copy */
-		CopySendInt16(cstate, -1);
-		/* Need to flush out the trailer */
-		CopySendEndOfRow(cstate);
+		if (Gp_role != GP_ROLE_EXECUTE || (Gp_role == GP_ROLE_EXECUTE && cstate->on_segment))
+		{
+			/* Generate trailer for a binary copy */
+			CopySendInt16(cstate, -1);
+
+			/* Trailer doesn't count in "processed" line numbers */
+			if (Gp_role == GP_ROLE_EXECUTE && cstate->on_segment)
+				cstate->not_count_line = true;
+
+			/* Need to flush out the trailer */
+			CopySendEndOfRow(cstate);
+		}
 	}
 
 	MemoryContextDelete(cstate->rowcontext);

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -3373,6 +3373,10 @@ copy_opt_item:
 				{
 					$$ = makeDefElem("newline", (Node *)makeString($3));
 				}	
+			| ON SEGMENT
+				{
+					$$ = makeDefElem("on_segment", (Node *)makeInteger(TRUE));
+				}
 		;
 
 /* The following exist for backward compatibility */

--- a/src/include/commands/copy.h
+++ b/src/include/commands/copy.h
@@ -244,8 +244,8 @@ typedef struct CopyStateData
 	bool          skip_ext_partition;  /* skip external partition */
 
 	bool		on_segment; /* QE save data files locally */
-	bool		not_count_line; /* Doesn't count CSV header or binary trailer in
-								   "processed" line number for on_segment mode*/
+	bool		ignore_extra_line; /* Don't count CSV header or binary trailer in
+									  "processed" line number for on_segment mode*/
 	/* end Greenplum Database specific variables */
 } CopyStateData;
 

--- a/src/include/commands/copy.h
+++ b/src/include/commands/copy.h
@@ -242,8 +242,11 @@ typedef struct CopyStateData
 	PartitionNode *partitions; /* partitioning meta data from dispatcher */
 	List		  *ao_segnos;  /* AO table meta data from dispatcher */
 	bool          skip_ext_partition;  /* skip external partition */
-	/* end Greenplum Database specific variables */
 
+	bool		on_segment; /* QE save data files locally */
+	bool		not_count_line; /* Doesn't count CSV header or binary trailer in
+								   "processed" line number for on_segment mode*/
+	/* end Greenplum Database specific variables */
 } CopyStateData;
 
 typedef CopyStateData *CopyState;

--- a/src/test/regress/expected/gpcopy.out
+++ b/src/test/regress/expected/gpcopy.out
@@ -698,29 +698,14 @@ INSERT INTO test_copy_on_segment VALUES (4, 'i', 'l');
 INSERT INTO test_copy_on_segment VALUES (5, 'q', 'w');
 COPY test_copy_on_segment TO '/tmp/invalid_filename.txt' ON SEGMENT;
 ERROR:  <SEGID> is required for file name
-COPY test_copy_on_segment TO '/tmp/<SEG_DATA_DIR>valid_filename<SEGID>.txt' ON SEGMENT;
 COPY test_copy_on_segment TO '/tmp/valid_filename<SEGID>.txt' ON SEGMENT;
 COPY test_copy_on_segment TO '/tmp/valid_filename<SEGID>.bin' ON SEGMENT BINARY;
 COPY test_copy_on_segment TO '/tmp/valid_filename<SEGID>.csv' ON SEGMENT CSV HEADER;
 CREATE EXTERNAL WEB TABLE check_copy_onsegment_txt1 (a int, b text, c text)
-EXECUTE E'(cat /tmp/?*valid_filename*.txt)'
-ON SEGMENT 0
-FORMAT 'text';
-SELECT * FROM check_copy_onsegment_txt1 ORDER BY a;
- a | b | c 
----+---+---
- 1 | s | d
- 2 | f | g
- 3 | h | j
- 4 | i | l
- 5 | q | w
-(5 rows)
-
-CREATE EXTERNAL WEB TABLE check_copy_onsegment_txt2 (a int, b text, c text)
 EXECUTE E'(cat /tmp/valid_filename*.txt)'
 ON SEGMENT 0
 FORMAT 'text';
-SELECT * FROM check_copy_onsegment_txt2 ORDER BY a;
+SELECT * FROM check_copy_onsegment_txt1 ORDER BY a;
  a | b | c 
 ---+---+---
  1 | s | d
@@ -791,7 +776,6 @@ SELECT * FROM rm_copy_onsegment_files;
 
 DROP TABLE IF EXISTS test_copy_on_segment;
 DROP EXTERNAL TABLE IF EXISTS check_copy_onsegment_txt1;
-DROP EXTERNAL TABLE IF EXISTS check_copy_onsegment_txt2;
 DROP EXTERNAL TABLE IF EXISTS check_copy_onsegment_csv1;
 DROP EXTERNAL TABLE IF EXISTS check_onek_copy_onsegment;
 DROP EXTERNAL TABLE IF EXISTS rm_copy_onsegment_files;

--- a/src/test/regress/expected/gpcopy.out
+++ b/src/test/regress/expected/gpcopy.out
@@ -688,3 +688,110 @@ SELECT COUNT(*) FROM test_first_segment_reject_limit;
      8
 (1 row)
 
+-- start_ignore
+-- end_ignore
+CREATE TABLE test_copy_on_segment (a int, b text, c text);
+INSERT INTO test_copy_on_segment VALUES (1, 's', 'd');
+INSERT INTO test_copy_on_segment VALUES (2, 'f', 'g');
+INSERT INTO test_copy_on_segment VALUES (3, 'h', 'j');
+INSERT INTO test_copy_on_segment VALUES (4, 'i', 'l');
+INSERT INTO test_copy_on_segment VALUES (5, 'q', 'w');
+COPY test_copy_on_segment TO '/tmp/invalid_filename.txt' ON SEGMENT;
+ERROR:  <SEGID> is required for file name
+COPY test_copy_on_segment TO '/tmp/<SEG_DATA_DIR>valid_filename<SEGID>.txt' ON SEGMENT;
+COPY test_copy_on_segment TO '/tmp/valid_filename<SEGID>.txt' ON SEGMENT;
+COPY test_copy_on_segment TO '/tmp/valid_filename<SEGID>.bin' ON SEGMENT BINARY;
+COPY test_copy_on_segment TO '/tmp/valid_filename<SEGID>.csv' ON SEGMENT CSV HEADER;
+CREATE EXTERNAL WEB TABLE check_copy_onsegment_txt1 (a int, b text, c text)
+EXECUTE E'(cat /tmp/?*valid_filename*.txt)'
+ON SEGMENT 0
+FORMAT 'text';
+SELECT * FROM check_copy_onsegment_txt1 ORDER BY a;
+ a | b | c 
+---+---+---
+ 1 | s | d
+ 2 | f | g
+ 3 | h | j
+ 4 | i | l
+ 5 | q | w
+(5 rows)
+
+CREATE EXTERNAL WEB TABLE check_copy_onsegment_txt2 (a int, b text, c text)
+EXECUTE E'(cat /tmp/valid_filename*.txt)'
+ON SEGMENT 0
+FORMAT 'text';
+SELECT * FROM check_copy_onsegment_txt2 ORDER BY a;
+ a | b | c 
+---+---+---
+ 1 | s | d
+ 2 | f | g
+ 3 | h | j
+ 4 | i | l
+ 5 | q | w
+(5 rows)
+
+CREATE EXTERNAL WEB TABLE check_copy_onsegment_csv1 (a int, b text, c text)
+EXECUTE E'(tail -q -n +2 /tmp/valid_filename*.csv)'
+ON SEGMENT 0
+FORMAT 'csv';
+SELECT * FROM check_copy_onsegment_csv1 ORDER BY a;
+ a | b | c 
+---+---+---
+ 1 | s | d
+ 2 | f | g
+ 3 | h | j
+ 4 | i | l
+ 5 | q | w
+(5 rows)
+
+CREATE TABLE onek_copy_onsegment (
+    unique1     int4,
+    unique2     int4,
+    two         int4,
+    four        int4,
+    ten         int4,
+    twenty      int4,
+    hundred     int4,
+    thousand    int4,
+    twothousand int4,
+    fivethous   int4,
+    tenthous    int4,
+    odd         int4,
+    even        int4,
+    stringu1    name,
+    stringu2    name,
+    string4     name
+);
+\COPY onek_copy_onsegment FROM 'data/onek.data';
+SELECT count(*) FROM onek_copy_onsegment;
+ count 
+-------
+  1000
+(1 row)
+
+COPY onek_copy_onsegment TO '/tmp/valid_filename_onek_copy_onsegment<SEGID>.txt' ON SEGMENT;
+CREATE EXTERNAL WEB TABLE check_onek_copy_onsegment (a int)
+EXECUTE E'(cat /tmp/valid_filename_onek_copy_onsegment*.txt |wc -l)'
+ON SEGMENT 0
+FORMAT 'text';
+SELECT * FROM check_onek_copy_onsegment;
+  a   
+------
+ 1000
+(1 row)
+
+CREATE EXTERNAL WEB TABLE rm_copy_onsegment_files (a int)
+EXECUTE E'(rm -rf /tmp/*valid_filename*.*)'
+ON SEGMENT 0
+FORMAT 'text';
+SELECT * FROM rm_copy_onsegment_files;
+ a 
+---
+(0 rows)
+
+DROP TABLE IF EXISTS test_copy_on_segment;
+DROP EXTERNAL TABLE IF EXISTS check_copy_onsegment_txt1;
+DROP EXTERNAL TABLE IF EXISTS check_copy_onsegment_txt2;
+DROP EXTERNAL TABLE IF EXISTS check_copy_onsegment_csv1;
+DROP EXTERNAL TABLE IF EXISTS check_onek_copy_onsegment;
+DROP EXTERNAL TABLE IF EXISTS rm_copy_onsegment_files;

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -70,7 +70,7 @@ m/^WARNING:  could not close temporary file .*: No such file or directory/
 -- end_matchignore
 
 -- start_matchsubs
-#entry db matches
+# entry db matches
 m/\s+\(entry db(.*)+\spid=\d+\)/
 s/\s+\(entry db(.*)+\spid=\d+\)//
 
@@ -85,4 +85,8 @@ s/Table "pg_temp_\d+.temp/Table "pg_temp_#####/
 # Mask out timestamp and whoami message for gpfaultinjector
 m/^\d+.*gpfaultinjector.*-\[INFO\]:-/
 s/^\d+.*gpfaultinjector.*-\[INFO\]:-//
+
+# Mask out line numbers
+m/ERROR:  <SEGID> is required for file name.*/
+s/ERROR:  <SEGID> is required for file name.*/ERROR:  <SEGID> is required for file name/
 -- end_matchsubs

--- a/src/test/regress/sql/gpcopy.sql
+++ b/src/test/regress/sql/gpcopy.sql
@@ -697,7 +697,6 @@ SELECT COUNT(*) FROM test_first_segment_reject_limit;
 -- start_ignore
 DROP TABLE IF EXISTS test_copy_on_segment;
 DROP EXTERNAL TABLE IF EXISTS check_copy_onsegment_txt1;
-DROP EXTERNAL TABLE IF EXISTS check_copy_onsegment_txt2;
 DROP EXTERNAL TABLE IF EXISTS check_copy_onsegment_csv1;
 DROP EXTERNAL TABLE IF EXISTS rm_copy_onsegment_files;
 -- end_ignore
@@ -710,22 +709,15 @@ INSERT INTO test_copy_on_segment VALUES (4, 'i', 'l');
 INSERT INTO test_copy_on_segment VALUES (5, 'q', 'w');
 
 COPY test_copy_on_segment TO '/tmp/invalid_filename.txt' ON SEGMENT;
-COPY test_copy_on_segment TO '/tmp/<SEG_DATA_DIR>valid_filename<SEGID>.txt' ON SEGMENT;
 COPY test_copy_on_segment TO '/tmp/valid_filename<SEGID>.txt' ON SEGMENT;
 COPY test_copy_on_segment TO '/tmp/valid_filename<SEGID>.bin' ON SEGMENT BINARY;
 COPY test_copy_on_segment TO '/tmp/valid_filename<SEGID>.csv' ON SEGMENT CSV HEADER;
 
 CREATE EXTERNAL WEB TABLE check_copy_onsegment_txt1 (a int, b text, c text)
-EXECUTE E'(cat /tmp/?*valid_filename*.txt)'
-ON SEGMENT 0
-FORMAT 'text';
-SELECT * FROM check_copy_onsegment_txt1 ORDER BY a;
-
-CREATE EXTERNAL WEB TABLE check_copy_onsegment_txt2 (a int, b text, c text)
 EXECUTE E'(cat /tmp/valid_filename*.txt)'
 ON SEGMENT 0
 FORMAT 'text';
-SELECT * FROM check_copy_onsegment_txt2 ORDER BY a;
+SELECT * FROM check_copy_onsegment_txt1 ORDER BY a;
 
 CREATE EXTERNAL WEB TABLE check_copy_onsegment_csv1 (a int, b text, c text)
 EXECUTE E'(tail -q -n +2 /tmp/valid_filename*.csv)'
@@ -769,7 +761,6 @@ SELECT * FROM rm_copy_onsegment_files;
 
 DROP TABLE IF EXISTS test_copy_on_segment;
 DROP EXTERNAL TABLE IF EXISTS check_copy_onsegment_txt1;
-DROP EXTERNAL TABLE IF EXISTS check_copy_onsegment_txt2;
 DROP EXTERNAL TABLE IF EXISTS check_copy_onsegment_csv1;
 DROP EXTERNAL TABLE IF EXISTS check_onek_copy_onsegment;
 DROP EXTERNAL TABLE IF EXISTS rm_copy_onsegment_files;

--- a/src/test/regress/sql/gpcopy.sql
+++ b/src/test/regress/sql/gpcopy.sql
@@ -693,3 +693,83 @@ error3
 7|7_number
 \.
 SELECT COUNT(*) FROM test_first_segment_reject_limit;
+
+-- start_ignore
+DROP TABLE IF EXISTS test_copy_on_segment;
+DROP EXTERNAL TABLE IF EXISTS check_copy_onsegment_txt1;
+DROP EXTERNAL TABLE IF EXISTS check_copy_onsegment_txt2;
+DROP EXTERNAL TABLE IF EXISTS check_copy_onsegment_csv1;
+DROP EXTERNAL TABLE IF EXISTS rm_copy_onsegment_files;
+-- end_ignore
+
+CREATE TABLE test_copy_on_segment (a int, b text, c text);
+INSERT INTO test_copy_on_segment VALUES (1, 's', 'd');
+INSERT INTO test_copy_on_segment VALUES (2, 'f', 'g');
+INSERT INTO test_copy_on_segment VALUES (3, 'h', 'j');
+INSERT INTO test_copy_on_segment VALUES (4, 'i', 'l');
+INSERT INTO test_copy_on_segment VALUES (5, 'q', 'w');
+
+COPY test_copy_on_segment TO '/tmp/invalid_filename.txt' ON SEGMENT;
+COPY test_copy_on_segment TO '/tmp/<SEG_DATA_DIR>valid_filename<SEGID>.txt' ON SEGMENT;
+COPY test_copy_on_segment TO '/tmp/valid_filename<SEGID>.txt' ON SEGMENT;
+COPY test_copy_on_segment TO '/tmp/valid_filename<SEGID>.bin' ON SEGMENT BINARY;
+COPY test_copy_on_segment TO '/tmp/valid_filename<SEGID>.csv' ON SEGMENT CSV HEADER;
+
+CREATE EXTERNAL WEB TABLE check_copy_onsegment_txt1 (a int, b text, c text)
+EXECUTE E'(cat /tmp/?*valid_filename*.txt)'
+ON SEGMENT 0
+FORMAT 'text';
+SELECT * FROM check_copy_onsegment_txt1 ORDER BY a;
+
+CREATE EXTERNAL WEB TABLE check_copy_onsegment_txt2 (a int, b text, c text)
+EXECUTE E'(cat /tmp/valid_filename*.txt)'
+ON SEGMENT 0
+FORMAT 'text';
+SELECT * FROM check_copy_onsegment_txt2 ORDER BY a;
+
+CREATE EXTERNAL WEB TABLE check_copy_onsegment_csv1 (a int, b text, c text)
+EXECUTE E'(tail -q -n +2 /tmp/valid_filename*.csv)'
+ON SEGMENT 0
+FORMAT 'csv';
+SELECT * FROM check_copy_onsegment_csv1 ORDER BY a;
+
+CREATE TABLE onek_copy_onsegment (
+    unique1     int4,
+    unique2     int4,
+    two         int4,
+    four        int4,
+    ten         int4,
+    twenty      int4,
+    hundred     int4,
+    thousand    int4,
+    twothousand int4,
+    fivethous   int4,
+    tenthous    int4,
+    odd         int4,
+    even        int4,
+    stringu1    name,
+    stringu2    name,
+    string4     name
+);
+\COPY onek_copy_onsegment FROM 'data/onek.data';
+SELECT count(*) FROM onek_copy_onsegment;
+COPY onek_copy_onsegment TO '/tmp/valid_filename_onek_copy_onsegment<SEGID>.txt' ON SEGMENT;
+
+CREATE EXTERNAL WEB TABLE check_onek_copy_onsegment (a int)
+EXECUTE E'(cat /tmp/valid_filename_onek_copy_onsegment*.txt |wc -l)'
+ON SEGMENT 0
+FORMAT 'text';
+SELECT * FROM check_onek_copy_onsegment;
+
+CREATE EXTERNAL WEB TABLE rm_copy_onsegment_files (a int)
+EXECUTE E'(rm -rf /tmp/*valid_filename*.*)'
+ON SEGMENT 0
+FORMAT 'text';
+SELECT * FROM rm_copy_onsegment_files;
+
+DROP TABLE IF EXISTS test_copy_on_segment;
+DROP EXTERNAL TABLE IF EXISTS check_copy_onsegment_txt1;
+DROP EXTERNAL TABLE IF EXISTS check_copy_onsegment_txt2;
+DROP EXTERNAL TABLE IF EXISTS check_copy_onsegment_csv1;
+DROP EXTERNAL TABLE IF EXISTS check_onek_copy_onsegment;
+DROP EXTERNAL TABLE IF EXISTS rm_copy_onsegment_files;


### PR DESCRIPTION
Support COPY statement that exports the table directly from segment
to local file parallelly.

This commit adds a keyword "on segment" to save the copied file on
"segment" instead of on "master".

Two place holders are used, which are "<SEG_DATA_DIR>" and "<SEGID>"
and will be replced to segment datadir and segment id.

E.g.

```
COPY tbl TO '/tmp/<SEG_DATA_DIR>filename<SEGID>.txt' ON SEGMENT;
```

Signed-off-by: Yuan Zhao <yuzhao@pivotal.io>
Signed-off-by: Haozhou Wang <hawang@pivotal.io>
Signed-off-by: Adam Lee <ali@pivotal.io>