### PR TITLE
Fix memory leak when using plan cache

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -231,20 +231,11 @@ CdbDispatchPlan(struct QueryDesc *queryDesc,
 		MemoryContext oldContext;
 		List *cursors;
 
-		oldContext = CurrentMemoryContext;
-		if (stmt->qdContext)
-		{
-			oldContext = MemoryContextSwitchTo(stmt->qdContext);
-		}
-		else
 		/*
 		 * memory context of plan tree should not change
 		 */
-		{
-			MemoryContext mc = GetMemoryChunkContext(stmt->planTree);
-
-			oldContext = MemoryContextSwitchTo(mc);
-		}
+		MemoryContext mc = GetMemoryChunkContext(stmt->planTree);
+		oldContext = MemoryContextSwitchTo(mc);
 
 		stmt->planTree = (Plan *) exec_make_plan_constant(stmt, is_SRI, &cursors);
 

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -71,16 +71,6 @@ typedef struct PlannedStmt
 
 	bool		transientPlan;	/* redo plan when TransactionXmin changes? */
 
-	/* Field qdContext communicates memory context on the QD  from portal to
-	 * dispatch.
-	 *
-	 * TODO Remove the field once evaluation of stable (and sequence) functions
-	 *      moves out of dispatch and into the executor.
-	 *
-	 * Do not copy or serialize.
-	 */
-	MemoryContext qdContext;
-
 	struct Plan *planTree;		/* tree of Plan nodes */
 
 	List	   *rtable;			/* list of RangeTblEntry nodes */


### PR DESCRIPTION
When a cached plan is used, this plan resides in a memory context called
CachedPlan. GPDB would make a copy of the plan before dispatching, to evaluate
the STABLE/IMMUTABLE functions, and this copy is allocated in the same memory
context with the cached plan, hence in CachedPlan context. This memory context
would not be freed across queries, so OOM would be hit if plan cache is heavily
used.

Fix is to copy the cached plan into portal's memory context, so the copy
mentioned above would be in portal's memory context as well, and would be freed
when the portal is dropped.

This solves the issue reported in https://github.com/greenplum-db/gpdb/issues/1995