### PR TITLE
Remove unsupported versions of Netbackup.

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -876,7 +876,7 @@ jobs:
 
 # Stage 3: Trigger jobs that rely on packaging
 
-- name: MU_netbackup76
+- name: MU_netbackup77
   plan:
   - get: nightly-trigger
     trigger: true
@@ -907,7 +907,7 @@ jobs:
       gpdb_src_behave_tarball: gpdb_src_behave_tarball
     params: &pulse_properties
       PULSE_URL: {{pulse_url}}
-      PULSE_PROJECT_NAME: "GPDB-BehaveNetBackup76"
+      PULSE_PROJECT_NAME: "GPDB-BehaveNetBackup77"
       PULSE_USERNAME: {{pulse_username}}
       PULSE_PASSWORD: {{pulse_password}}
   - task: monitor_pulse
@@ -915,26 +915,6 @@ jobs:
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/monitor_pulse.yml
     params: *pulse_properties
-
-- name: MU_netbackup77
-  plan:
-  - get: nightly-trigger
-    trigger: true
-  - aggregate: *post_packaging_gets_trigger_false
-  - task: trigger_pulse
-    tags: ["gpdb5-pulse-worker"]
-    file: gpdb_src/ci/pulse/api/trigger_pulse.yml
-    input_mapping: *input_mappings
-    params:
-      <<: *pulse_properties
-      PULSE_PROJECT_NAME: "GPDB-BehaveNetBackup77"
-  - task: monitor_pulse
-    attempts: 2
-    tags: ["gpdb5-pulse-worker"]
-    file: gpdb_src/ci/pulse/api/monitor_pulse.yml
-    params:
-      <<: *pulse_properties
-      PULSE_PROJECT_NAME: "GPDB-BehaveNetBackup77"
 
 - name: MU_backup-restore
   plan:

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -942,8 +942,6 @@ ifeq ($(BLD_ARCH),$(filter $(BLD_ARCH),rhel7_x86_64 rhel6_x86_64 rhel5_x86_64))
 	rm -f $(INSTLOC)/lib/libnbclientcST.so;
 	rm -f $(INSTLOC)/lib/libnbbasecST.so;
 	rm -f $(INSTLOC)/lib/libvxcPBXST.so;
-	cp -fpr $(BLD_THIRDPARTY_LIB_DIR)/../Netbackup/nbu71 $(INSTLOC)/lib/;
-	cp -fpr $(BLD_THIRDPARTY_LIB_DIR)/../Netbackup/nbu75 $(INSTLOC)/lib/;
 endif
 
 copylibs : thirdparty-dist copy-nbu-libs

--- a/gpAux/releng/make/dependencies/ivy.xml
+++ b/gpAux/releng/make/dependencies/ivy.xml
@@ -20,9 +20,6 @@
       <dependency org="third-party"     name="ext"             rev="1.1"            conf="win32->win32" />
       <dependency org="third-party"     name="ext"             rev="3.0"            conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64;suse11_x86_64->sles11_x86_64" />
       <dependency org="Hyperic"         name="sigar"           rev="1.6.5"          conf="rhel6_x86_64->rhel6_x86_64;rhel7_x86_64->rhel7_x86_64;suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64"/>
-      <dependency org="NetBackup"       name="SDK-7.1"         rev="7.1"            conf="rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64" />
-      <dependency org="NetBackup"       name="SDK-7.5"         rev="7.5"            conf="rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64" />
-      <dependency org="NetBackup"       name="SDK-7.6"         rev="7.6"            conf="rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64" />
       <dependency org="NetBackup"       name="SDK-7.7"         rev="7.7"            conf="rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64" />
       <dependency org="R-Project"       name="R"               rev="3.1.0"          conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64;suse11_x86_64->suse10_x86_64" />
       <dependency org="Python"          name="python"          rev="2.7.12"         conf="rhel6_x86_64->rhel6_x86_64;rhel7_x86_64->rhel6_x86_64;suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64" />

--- a/gpMgmt/test/behave/mgmt_utils/netbackup.feature
+++ b/gpMgmt/test/behave/mgmt_utils/netbackup.feature
@@ -5,18 +5,6 @@ Feature: NetBackup Integration with GPDB
     Scenario: Setup to load NBU libraries
         Given the NetBackup "7.7" libraries are loaded
 
-    @nbusetup76
-    Scenario: Setup to load NBU libraries
-        Given the NetBackup "7.6" libraries are loaded
-
-    @nbusetup75
-    Scenario: Setup to load NBU libraries
-        Given the NetBackup "7.5" libraries are loaded
-
-    @nbusetup71
-    Scenario: Setup to load NBU libraries
-        Given the NetBackup "7.1" libraries are loaded
-
     @nbupartI
     Scenario: Valgrind test of gp_dump with netbackup
         Given the backup test is initialized with no backup files

--- a/src/bin/pg_dump/cdb/Makefile
+++ b/src/bin/pg_dump/cdb/Makefile
@@ -28,9 +28,6 @@ endif
 
 ifeq ($(enable_netbackup), yes)
 NETBACKUPLIB77 += -L$(top_srcdir)/gpAux/ext/$(BLD_ARCH)/Netbackup/nbu77/lib -lxbsa64
-NETBACKUPLIB76 += -L$(top_srcdir)/gpAux/ext/$(BLD_ARCH)/Netbackup/nbu76/lib -lxbsa64
-NETBACKUPLIB75 += -L$(top_srcdir)/gpAux/ext/$(BLD_ARCH)/Netbackup/nbu75/lib -lxbsa64 -lnbclientcST -lnbbasecST -lvxcPBXST
-NETBACKUPLIB71 += -L$(top_srcdir)/gpAux/ext/$(BLD_ARCH)/Netbackup/nbu71/lib -lxbsa64 -lnbclientcST -lnbbasecST -lvxcPBXST
 GPBSALIB += -L$(top_builddir)/src/bin/pg_dump/cdb -lgpbsa -Wl,-rpath-link,'$(top_builddir)/gpAux/ext/$(BLD_ARCH)/Netbackup/nbu77/lib'
 override CFLAGS += -I$(top_builddir)/gpAux/ext/$(BLD_ARCH)/Netbackup/nbu77/include
 override CPPFLAGS += -I$(top_builddir)/gpAux/ext/$(BLD_ARCH)/Netbackup/nbu77/include
@@ -60,7 +57,7 @@ $(PGDUMP_SRC): % : $(PGDUMP_DIR)/%
 all: submake-libpq submake-libpgport cdb_dump cdb_dump_agent cdb_restore \
 	cdb_restore_agent gpddboost cdb_bsa_dump_agent cdb_bsa_restore_agent \
 	cdb_bsa_query_agent cdb_bsa_delete_agent \
-	libgpbsa.so libgpbsa77.so libgpbsa76.so libgpbsa75.so libgpbsa71.so
+	libgpbsa.so libgpbsa77.so
 
 ifeq ($(enable_netbackup), yes)
 cdb_bsa_dump_agent cdb_bsa_restore_agent cdb_bsa_query_agent cdb_bsa_delete_agent: libgpbsa.so
@@ -84,15 +81,6 @@ gpddboost: cdb_ddboost_util.o cdb_backup_status.o cdb_seginst.o cdb_backup_state
 libgpbsa77.so: cdb_bsa_util.c $(libpq_builddir)/libpq.a
 	$(CC) $(CFLAGS_SL) $(CPPFLAGS) cdb_bsa_util.c $(libpq) $(LDFLAGS) -shared $(DDBOOSTLIB) $(NETBACKUPLIB77) $(LIBS) -o $@
 
-libgpbsa76.so: cdb_bsa_util.c $(libpq_builddir)/libpq.a
-	$(CC) $(CFLAGS_SL) $(CPPFLAGS) cdb_bsa_util.c $(libpq) $(LDFLAGS) -shared $(DDBOOSTLIB) $(NETBACKUPLIB76) $(LIBS) -o $@
-
-libgpbsa75.so: cdb_bsa_util.c $(libpq_builddir)/libpq.a
-	$(CC) $(CFLAGS_SL) $(CPPFLAGS) cdb_bsa_util.c $(libpq) $(LDFLAGS) -shared $(DDBOOSTLIB) $(NETBACKUPLIB75) $(LIBS) -o $@
-
-libgpbsa71.so: cdb_bsa_util.o $(libpq_builddir)/libpq.a
-	$(CC) $(CFLAGS_SL) $(CPPFLAGS) cdb_bsa_util.c $(libpq) $(LDFLAGS) -shared $(DDBOOSTLIB) $(NETBACKUPLIB71) $(LIBS) -o $@
-
 libgpbsa.so: libgpbsa77.so
 	cp libgpbsa77.so libgpbsa.so
 
@@ -115,9 +103,6 @@ install: all installdirs
 	$(INSTALL_PROGRAM) cdb_restore_agent$(X) $(DESTDIR)$(bindir)/gp_restore_agent$(X)
 	$(INSTALL_PROGRAM) gpddboost$(X) $(DESTDIR)$(bindir)/gpddboost$(X)
 	$(INSTALL_PROGRAM) libgpbsa77.so $(DESTDIR)$(libdir)/nbu77/lib/libgpbsa.so
-	$(INSTALL_PROGRAM) libgpbsa76.so $(DESTDIR)$(libdir)/nbu76/lib/libgpbsa.so
-	$(INSTALL_PROGRAM) libgpbsa75.so $(DESTDIR)$(libdir)/nbu75/lib/libgpbsa.so
-	$(INSTALL_PROGRAM) libgpbsa71.so $(DESTDIR)$(libdir)/nbu71/lib/libgpbsa.so
 	$(INSTALL_PROGRAM) cdb_bsa_dump_agent$(X) $(DESTDIR)$(bindir)/gp_bsa_dump_agent$(X)
 	$(INSTALL_PROGRAM) cdb_bsa_restore_agent$(X) $(DESTDIR)$(bindir)/gp_bsa_restore_agent$(X)
 	$(INSTALL_PROGRAM) cdb_bsa_query_agent$(X) $(DESTDIR)$(bindir)/gp_bsa_query_agent$(X)

--- a/src/bin/pg_dump/cdb/test/Makefile
+++ b/src/bin/pg_dump/cdb/test/Makefile
@@ -18,12 +18,9 @@ DDBOOSTLIB += -lDDBoost
 endif
 
 ifeq ($(enable_netbackup), yes)
-NETBACKUPLIB75 += -L$(top_srcdir)/gpAux/ext/$(BLD_ARCH)/Netbackup/nbu75/lib -lxbsa64 -lnbclientcST -lnbbasecST -lvxcPBXST
-NETBACKUPLIB71 += -L$(top_srcdir)/gpAux/ext/$(BLD_ARCH)/Netbackup/nbu71/lib -lxbsa64 -lnbclientcST -lnbbasecST -lvxcPBXST
-GPBSALIB += -L$(top_builddir)/src/bin/pg_dump/cdb -lgpbsa -Wl,-rpath-link,'$(top_srcdir)/gpAux/ext/$(BLD_ARCH)/Netbackup/nbu75/lib'
-override CFLAGS += -I$(top_srcdir)/gpAux/ext/$(BLD_ARCH)/Netbackup/nbu75/include
+GPBSALIB += -L$(top_builddir)/src/bin/pg_dump/cdb -lgpbsa -Wl,-rpath-link,'$(top_srcdir)/gpAux/ext/$(BLD_ARCH)/Netbackup/nbu77/lib'
+override CFLAGS += -I$(top_srcdir)/gpAux/ext/$(BLD_ARCH)/Netbackup/nbu77/include
 endif
-
 
 # The command line here should resemble the one used to build cdb_dump_agent
 cdb_dump_util.t: cdb_dump_util_test.o ../dumputils.o ../cdb_lockbox.o ../keywords.o ../kwlookup.o $(CMOCKERY_OBJS)
@@ -31,8 +28,8 @@ cdb_dump_util.t: cdb_dump_util_test.o ../dumputils.o ../cdb_lockbox.o ../keyword
 
 # The command line here should resemble the one used to build libgpbsa
 cdb_bsa_util.t: cdb_bsa_util_test.o ../cdb_dump_util.o ../cdb_lockbox.o ../dumputils.o ../keywords.o ../kwlookup.o $(CMOCKERY_OBJS)
-	$(CC) $^ $(libpq) $(LDFLAGS) $(LIBS) $(DDBOOSTLIB) $(NETBACKUPLIB75) -o $@
+	$(CC) $^ $(libpq) $(LDFLAGS) $(LIBS) $(DDBOOSTLIB) -o $@
 
 # The command line here should resemble the one used to build libgpbsa
 cdb_lockbox.t: cdb_lockbox_test.o ../cdb_dump_util.o ../dumputils.o ../keywords.o ../kwlookup.o $(CMOCKERY_OBJS)
-	$(CC) $^ $(libpq) $(LDFLAGS) $(LIBS) $(DDBOOSTLIB) $(NETBACKUPLIB75) -o $@
+	$(CC) $^ $(libpq) $(LDFLAGS) $(LIBS) $(DDBOOSTLIB) -o $@


### PR DESCRIPTION
Netbackup 7.1, 7.5, and 7.6 are end of life and will not be supported in
gpdb5.

Signed-off-by: Karen Huddleston <khuddleston@pivotal.io>