### PR TITLE
fix unstable cases when using ORCA optimizer

### DIFF
--- a/src/test/regress/expected/alter_table_aocs.out
+++ b/src/test/regress/expected/alter_table_aocs.out
@@ -405,8 +405,8 @@ insert into addcol7 values
    ('201203', 202, 5, 'p2', null, null),
    ('201203', 203, 6, 'p2', null, null),
    ('201204', 301, 7, 'p3', 22/7::float, 'newcol2'),
-   ('201204', 301, 8, 'p3', null, null),
-   ('201204', 301, 9, 'p3', null, null);
+   ('201204', 302, 8, 'p3', null, null),
+   ('201204', 303, 9, 'p3', null, null);
 select * from addcol7 where tag2 like 'p%' order by user_id;
  timest | user_id | tag1 | tag2 |       new1        |  new2   
 --------+---------+------+------+-------------------+---------
@@ -416,9 +416,9 @@ select * from addcol7 where tag2 like 'p%' order by user_id;
  201203 |     201 |    4 | p2   | 0.333333333333333 | newcol2
  201203 |     202 |    5 | p2   |                   | 
  201203 |     203 |    6 | p2   |                   | 
- 201204 |     301 |    8 | p3   |                   | 
  201204 |     301 |    7 | p3   |  3.14285714285714 | newcol2
- 201204 |     301 |    9 | p3   |                   | 
+ 201204 |     302 |    8 | p3   |                   | 
+ 201204 |     303 |    9 | p3   |                   | 
 (9 rows)
 
 update addcol7 set new1 = 0, tag1 = -1 where tag2 like 'p%';

--- a/src/test/regress/expected/polymorphism.out
+++ b/src/test/regress/expected/polymorphism.out
@@ -613,7 +613,7 @@ create aggregate build_group(anyelement, integer) (
   SFUNC = add_group,
   STYPE = anyarray
 );
-select build_group(q1,3) from (select q1 from int8_tbl order by q1 limit 3) as t;
+select build_group(q1,3) from (select q1 from int8_tbl order by q1 limit 5) as t;
         build_group         
 ----------------------------
  {123,123,4567890123456789}

--- a/src/test/regress/expected/polymorphism.out
+++ b/src/test/regress/expected/polymorphism.out
@@ -613,7 +613,7 @@ create aggregate build_group(anyelement, integer) (
   SFUNC = add_group,
   STYPE = anyarray
 );
-select build_group(q1,3) from (select q1 from int8_tbl order by q1) as t;
+select build_group(q1,3) from (select q1 from int8_tbl order by q1 limit 3) as t;
         build_group         
 ----------------------------
  {123,123,4567890123456789}

--- a/src/test/regress/sql/alter_table_aocs.sql
+++ b/src/test/regress/sql/alter_table_aocs.sql
@@ -256,8 +256,8 @@ insert into addcol7 values
    ('201203', 202, 5, 'p2', null, null),
    ('201203', 203, 6, 'p2', null, null),
    ('201204', 301, 7, 'p3', 22/7::float, 'newcol2'),
-   ('201204', 301, 8, 'p3', null, null),
-   ('201204', 301, 9, 'p3', null, null);
+   ('201204', 302, 8, 'p3', null, null),
+   ('201204', 303, 9, 'p3', null, null);
 select * from addcol7 where tag2 like 'p%' order by user_id;
 update addcol7 set new1 = 0, tag1 = -1 where tag2 like 'p%';
 delete from addcol7 where new2 is null;

--- a/src/test/regress/sql/polymorphism.sql
+++ b/src/test/regress/sql/polymorphism.sql
@@ -433,7 +433,7 @@ create aggregate build_group(anyelement, integer) (
   STYPE = anyarray
 );
 
-select build_group(q1,3) from (select q1 from int8_tbl order by q1) as t;
+select build_group(q1,3) from (select q1 from int8_tbl order by q1 limit 3) as t;
 
 -- this should fail because stype isn't compatible with arg
 create aggregate build_group(int8, integer) (

--- a/src/test/regress/sql/polymorphism.sql
+++ b/src/test/regress/sql/polymorphism.sql
@@ -433,7 +433,7 @@ create aggregate build_group(anyelement, integer) (
   STYPE = anyarray
 );
 
-select build_group(q1,3) from (select q1 from int8_tbl order by q1 limit 3) as t;
+select build_group(q1,3) from (select q1 from int8_tbl order by q1 limit 5) as t;
 
 -- this should fail because stype isn't compatible with arg
 create aggregate build_group(int8, integer) (


### PR DESCRIPTION
**polymorphism** 
As discussed in issue #2318, ORCA will not add order by clause in derived table, thus we add 'limit 3' to force it add SORT node to make sure test result is consistent. 

**alter_table_aocs**
fix the input data to make order by select gets stable result. 

@vraghavan78 @hsyuan Would you please help take a look? Thanks so much!