### PR TITLE
Fix resource leaks in gp_dump by freeing out of scope variables

### DIFF
--- a/src/backend/cdb/cdbbackup.c
+++ b/src/backend/cdb/cdbbackup.c
@@ -831,9 +831,13 @@ gp_backup_launch__(PG_FUNCTION_ARGS)
 				pszDDBoostDirName,
 				pszDDBoostFileName,
 				dd_boost_buffer_size);
+			free(pszDDBoostDirName);
 
 			if (pszDDBoostStorageUnitName)
+			{
 				sprintf(gpDDBoostCmdLine + strlen(gpDDBoostCmdLine), "--ddboost-storage-unit=%s", pszDDBoostStorageUnitName);
+				free(pszDDBoostStorageUnitName);
+			}
 
 			/* if user selected a compression program */
 			if (pszCompressionProgram[0] != '\0')
@@ -2425,7 +2429,7 @@ static char *formDDBoostFileName(char *pszBackupKey, bool isPostData, bool isCom
 	segid = GpIdentity.dbid;
 
 	if (is_old_format)
-	   instid = (instid == -1) ? 1 : 0;   /* dispatch node */	 
+	   instid = (instid == -1) ? 1 : 0;   /* dispatch node */
 
 	memset(szFileNamePrefix, 0, sizeof(szFileNamePrefix));
 	   snprintf(szFileNamePrefix, 1 + MAX_PATH_NAME, "%sgp_dump_%d_%d_", DUMP_PREFIX, instid, segid);

--- a/src/bin/pg_dump/cdb/cdb_dump.c
+++ b/src/bin/pg_dump/cdb/cdb_dump.c
@@ -1205,6 +1205,8 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
 			ddboost_directory = pg_strdup("db_dumps/");
 
 		pInputOpts->pszPassThroughParms = addPassThroughLongParm("dd_boost_dir", ddboost_directory, pInputOpts->pszPassThroughParms);
+		if (ddboost_directory)
+			free(ddboost_directory);
 	}
 #endif
 
@@ -1586,6 +1588,7 @@ reportBackupResults(InputOptions inputopts, ThreadParmArray *pParmAr)
 	{
 		exit_nicely();
 	}
+
 	fRptFile = fopen(pszReportPathName, "w");
 	if (fRptFile == NULL)
 		mpp_err_msg(logWarn, progname, "Cannot open report file %s for writing.  Will use stdout instead.\n",

--- a/src/bin/pg_dump/cdb/cdb_dump_agent.c
+++ b/src/bin/pg_dump/cdb/cdb_dump_agent.c
@@ -4430,11 +4430,17 @@ dumpOpr(Archive *fout, OprInfo *oprinfo)
 
 	name = convertRegProcReference(oprrest);
 	if (name)
+	{
 		appendPQExpBuffer(details, ",\n    RESTRICT = %s", name);
+		free(name);
+	}
 
 	name = convertRegProcReference(oprjoin);
 	if (name)
+	{
 		appendPQExpBuffer(details, ",\n    JOIN = %s", name);
+		free(name);
+	}
 
 	/*
 	 * DROP must be fully qualified in case same name appears in pg_catalog
@@ -5346,7 +5352,7 @@ dumpAgg(Archive *fout, AggInfo *agginfo)
 	{
 		mpp_err_msg(logWarn, progname, "WARNING: aggregate function %s could not be dumped correctly for this database version; ignored\n",
 					aggsig);
-		return;
+		goto cleanup;
 	}
 
 	/* If using 7.3's regproc or regtype, data is already quoted */
@@ -5423,8 +5429,11 @@ dumpAgg(Archive *fout, AggInfo *agginfo)
 			agginfo->aggfn.dobj.namespace->dobj.name,
 			agginfo->aggfn.rolname, agginfo->aggfn.proacl);
 
-	free(aggsig);
-	free(aggsig_tag);
+cleanup:
+	if (aggsig)
+		free(aggsig);
+	if (aggsig_tag)
+		free(aggsig_tag);
 
 	PQclear(res);
 
@@ -6309,7 +6318,7 @@ dumpExternal(TableInfo *tbinfo, PQExpBuffer query, PQExpBuffer q, PQExpBuffer de
 			case 'p':
 				tabfmt = "parquet";
 				customfmt = custom_fmtopts_string(tmpstring);
-				break;	
+				break;
 			default:
 				tabfmt = "csv";
 		}
@@ -6759,6 +6768,10 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 				appendPQExpBuffer(q, "DROP TABLE %s; ", fmtId(tmpExtTable));
 
 				appendPQExpBuffer(q, "\n");
+				if (relname)
+					free(relname);
+				if (parname)
+					free(parname);
 			}
 
 			PQclear(res);

--- a/src/bin/pg_dump/cdb/cdb_dump_include.c
+++ b/src/bin/pg_dump/cdb/cdb_dump_include.c
@@ -947,7 +947,7 @@ expand_schema_name_patterns(SimpleStringList *patterns, SimpleOidList *oids)
 	destroyPQExpBuffer(query);
 }
 
-/* 
+/*
  * Loop the table input list in batches
  * convert the table names to oids.
  *
@@ -961,7 +961,7 @@ expand_table_name_patterns_long(SimpleStringList *patterns, SimpleOidList *oids,
 	SimpleStringList partial_list = {0};
 
 	int i = 0;
-    
+
 	if (!patterns)
 		return; /* nothing to do */
 
@@ -1455,6 +1455,7 @@ getTypeStorageOptions(int *numTypes)
 	{
 		numTypes = 0;
 		tstorageoptions = (TypeStorageOptions *) malloc(0);
+		destroyPQExpBuffer(query);
 		return tstorageoptions;
 	}
 
@@ -3119,7 +3120,7 @@ getTableAttrs(TableInfo *tblinfo, int numTables)
 		oid = atoi(PQgetvalue(res, i, 0));
 		typstorage = *(PQgetvalue(res, i, 1));
 		if (insertIntoHashTable(oid, typstorage) < 0)
-		{		
+		{
 			mpp_err_msg(logError, progname, "Unable to insert the following values into hash table Oid: %u, typstorage: %c"
 																									, oid, typstorage);
 			exit_nicely();
@@ -3388,8 +3389,8 @@ getTableAttrs(TableInfo *tblinfo, int numTables)
 				 * split out from the table definition.
 				 */
 			}
-			
-			
+
+
 			PQclear(res);
 		}
 
@@ -3403,7 +3404,7 @@ getTableAttrs(TableInfo *tblinfo, int numTables)
 	}
 
 		mpp_err_msg(logInfo, progname, "last batch of sql commands finished executing\n");
-	
+
 	cleanUpTable();
 
 	destroyPQExpBuffer(q);
@@ -3456,6 +3457,7 @@ getTSParsers(int *numTSParsers)
 	if (!g_gp_supportsFullText)
 	{
 		*numTSParsers = 0;
+		destroyPQExpBuffer(query);
 		return NULL;
 	}
 
@@ -3543,6 +3545,7 @@ getTSDictionaries(int *numTSDicts)
 	if (!g_gp_supportsFullText)
 	{
 		*numTSDicts = 0;
+		destroyPQExpBuffer(query);
 		return NULL;
 	}
 
@@ -3624,6 +3627,7 @@ getTSTemplates(int *numTSTemplates)
 	if (!g_gp_supportsFullText)
 	{
 		*numTSTemplates = 0;
+		destroyPQExpBuffer(query);
 		return NULL;
 	}
 
@@ -3698,6 +3702,7 @@ getTSConfigurations(int *numTSConfigs)
 	if (!g_gp_supportsFullText)
 	{
 		*numTSConfigs = 0;
+		destroyPQExpBuffer(query);
 		return NULL;
 	}
 

--- a/src/bin/pg_dump/dumputils.c
+++ b/src/bin/pg_dump/dumputils.c
@@ -565,7 +565,11 @@ buildACLCommands(const char *name, const char *type,
 	{
 		if (!parseAclItem(aclitems[i], type, name, remoteVersion,
 						  grantee, grantor, privs, privswgo))
+		{
+			if (aclitems)
+				free(aclitems);
 			return false;
+		}
 
 		if (grantor->len == 0 && owner)
 			printfPQExpBuffer(grantor, "%s", owner);
@@ -709,7 +713,11 @@ parseAclItem(const char *item, const char *type, const char *name,
 		*slpos++ = '\0';
 		slpos = copyAclUserName(grantor, slpos);
 		if (*slpos != '\0')
+		{
+			if (buf)
+				free(buf);
 			return false;
+		}
 	}
 	else
 		resetPQExpBuffer(grantor);
@@ -1158,7 +1166,15 @@ custom_fmtopts_string(const char *src)
 		int        last = 0;
 
 		if(!src || !srcdup || !result)
+		{
+			if (result)
+				free(result);
+			if (srcdup)
+				free(srcdup);
+			if (srcdup_start)
+				free(srcdup_start);
 			return NULL;
+		}
 
 		while (srcdup)
 		{

--- a/src/bin/pg_dump/pg_backup_tar.c
+++ b/src/bin/pg_dump/pg_backup_tar.c
@@ -511,6 +511,8 @@ newTempFile(void)
 			}
 
 			/* Error is considered fatal. */
+			if (tempFileName)
+				free(tempFileName);
 			return NULL;
 		}
 

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -10043,6 +10043,8 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 				appendPQExpBuffer(q, "DROP TABLE %s; ", fmtId(tmpExtTable));
 
 				appendPQExpBuffer(q, "\n");
+				free(relname);
+				free(parname);
 			}
 
 			PQclear(res);

--- a/src/bin/pg_dump/pg_dumpall.c
+++ b/src/bin/pg_dump/pg_dumpall.c
@@ -794,6 +794,8 @@ dumpResQueues(PGconn *conn)
 
 	PQclear(res);
 
+	destroyPQExpBuffer(buf);
+
 	fprintf(OPF, "\n\n");
 }
 


### PR DESCRIPTION
This commit fixes all of the minor resource leaks found by Coverity that are not already addressed in upstream Postgres.

Authors: Karen Huddleston, Jamie McAtamney