### PR TITLE
gpperfmon: retain line breaks in query logging

### DIFF
--- a/gpAux/gpperfmon/src/gpmon/gpmon_agg.c
+++ b/gpAux/gpperfmon/src/gpmon/gpmon_agg.c
@@ -1761,10 +1761,7 @@ static int get_and_print_next_query_file_kvp(FILE* outfd, FILE* queryfd, char* q
                 (*bytes_written)++;
             }
 
-            if ((*p == '\n') || (*p == '\r'))
-                fputc(' ', outfd);
-            else
-                fputc(*p, outfd);
+            fputc(*p, outfd);
 
             (*bytes_written)++;
 
@@ -1779,7 +1776,7 @@ static int get_and_print_next_query_file_kvp(FILE* outfd, FILE* queryfd, char* q
     int n = fread(line, 1, 1, queryfd);
     if (n != 1)
     {
-	    gpmon_warning(FLINE, "missing expeceted newline in file: %s", qfname);
+	    gpmon_warning(FLINE, "missing expected newline in file: %s", qfname);
         return APR_NOTFOUND;
     }
 

--- a/gpMgmt/test/behave/mgmt_utils/gpperfmon.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpperfmon.feature
@@ -40,6 +40,23 @@ Feature: gpperfmon
         Then psql should return a return code of 0
         Then wait until the results from boolean sql "SELECT count(*) > 0 FROM queries_history" is "true"
 
+    @gpperfmon_query_history
+    Scenario: gpperfmon adds to query_history table with carriage returns
+        Given gpperfmon is configured and running in qamode
+        When the user truncates "queries_history" tables in "gpperfmon"
+        And execute following sql in db "gpperfmon" and store result in the context
+            """
+            --some comment
+            SELECT 1
+            ;
+            """
+        Then wait until the results from boolean sql "SELECT count(*) > 0 FROM queries_history where query_text like '--some%'" is "true"
+        When execute following sql in db "gpperfmon" and store result in the context
+            """
+            SELECT query_text FROM queries_history where query_text like '--some%'
+            """
+        Then validate that first column of first stored row has "3" lines of raw output
+
     @gpperfmon_system_history
     Scenario: gpperfmon adds to system_history table
         Given gpperfmon is configured and running in qamode

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -2549,6 +2549,14 @@ def impl(context, numlines):
         raise Exception("Found %d of stored query result but expected %d records" % (num_found, numlines))
 
 
+@then('validate that first column of first stored row has "{numlines}" lines of raw output')
+def impl(context, numlines):
+    raw_lines_count = len(context.stored_rows[0][0].splitlines())
+    numlines = int(numlines)
+    if raw_lines_count != numlines:
+        raise Exception("Found %d of stored query result but expected %d records" % (raw_lines_count, numlines))
+
+
 def get_standby_host():
     gparray = GpArray.initFromCatalog(dbconn.DbURL())
     segments = gparray.getDbList()


### PR DESCRIPTION
- We think that external tables previously broke with newlines. This is
  no longer the case, so removing space replacement logic.

Pipeline to demonstrate: http://gpdb.ci.pivotalci.info/teams/gpdb/pipelines/dev:MU_gpperfmon_linebreaks

Signed-off-by: C.J. Jameson <cjameson@pivotal.io>