### PR TITLE
Track the number of HashAgg expansions.

### DIFF
--- a/src/backend/executor/execHHashagg.c
+++ b/src/backend/executor/execHHashagg.c
@@ -1451,7 +1451,7 @@ expand_hash_table(AggState *aggstate)
 #endif
 		}
 	}
-
+	hashtable->num_expansions++;
 	Assert(hashtable->mem_for_metadata > 0);
 	Assert(nentries == hashtable->num_entries);
 }
@@ -2119,11 +2119,13 @@ agg_hash_explain(AggState *aggstate)
 	{
 		appendStringInfo(hbuf,
 				"Hash chain length %.1f avg, %.0f max,"
-				" using %d of " INT64_FORMAT " buckets.\n",
+				" using %d of " INT64_FORMAT " buckets"
+				"; total %d expansions.\n",
 				cdbexplain_agg_avg(&hashtable->chainlength),
 				hashtable->chainlength.vmax,
 				hashtable->chainlength.vcnt,
-				hashtable->total_buckets);
+				hashtable->total_buckets,
+				hashtable->num_expansions);
 	}
 }
 

--- a/src/include/executor/execHHashagg.h
+++ b/src/include/executor/execHHashagg.h
@@ -203,6 +203,7 @@ typedef struct HashAggTable
 	uint64 num_entries; /* number of currently in-memory groups/entries */
 	uint64 num_spill_groups; /* number of spilled groups */
 	uint32 num_overflows; /* number of times hash table overflows */
+	uint32 num_expansions; /* number of times hash table is expanded */
 
 	bool is_spilling; /* indicate that spilling happened for this batch. */
 	bool expandable;  /* hash table buckets still have space to grow */


### PR DESCRIPTION
```
shardikar=# explain analyze select count(*) from (select i, count(*) from foo group by i, j) g;
                                                                            QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=4393.70..4393.71 rows=1 width=8)
   Rows out:  1 rows with 1584 ms to end, start offset by 136 ms.
   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=4393.63..4393.68 rows=1 width=8)
         Rows out:  3 rows at destination with 1430 ms to first row, 1584 ms to end, start offset by 136 ms.
         ->  Aggregate  (cost=4393.63..4393.64 rows=1 width=8)
               Rows out:  Avg 1.0 rows x 3 workers.  Max 1 rows (seg0) with 1381 ms to end, start offset by 185 ms.
               ->  Subquery Scan g  (cost=1888.55..4143.12 rows=33401 width=0)
                     Rows out:  Avg 333333.3 rows x 3 workers.  Max 333385 rows (seg2) with 1241 ms to first row, 1454 ms to end, start offset by 210 ms.
                     ->  HashAggregate  (cost=1888.55..3141.09 rows=33401 width=16)
                           Group By: foo.i, foo.j
                           Rows out:  Avg 333333.3 rows x 3 workers.  Max 333385 rows (seg2) with 1241 ms to first row, 1381 ms to end, start offset by 210 ms.
                           Executor memory:  20335K bytes avg, 20335K bytes max (seg0).
                           (seg2)   Hash chain length 2.8 avg, 12 max, using 120836 of 131072 buckets; total 2 expansions.
                           ->  Seq Scan on foo  (cost=0.00..1137.03 rows=33401 width=8)
                                 Rows out:  Avg 833333.3 rows x 3 workers.  Max 833452 rows (seg0) with 13 ms to first row, 433 ms to end, start offset by 185 ms.
 Slice statistics:
   (slice0)    Executor memory: 386K bytes.
   (slice1)    Executor memory: 20484K bytes avg x 3 workers, 20484K bytes max (seg0).
 Statement statistics:
   Memory used: 128000K bytes
 Optimizer status: legacy query optimizer
 Total runtime: 1720.032 ms
(22 rows)
```

@foyzur @vraghavan78 @karthijrk @hsyuan Please take a look.