### PR TITLE
Cleanups for UnpackCheckPointRecord() and couple of others

### DIFF
--- a/src/backend/access/common/heaptuple.c
+++ b/src/backend/access/common/heaptuple.c
@@ -1192,18 +1192,6 @@ heap_deform_tuple(HeapTuple tuple, TupleDesc tupleDesc,
 
 		values[attnum] = fetchatt(thisatt, tp + off);
 
-#ifdef USE_ASSERT_CHECKING
-		/* Ignore attributes with dropped types */
-		if (thisatt->attlen == -1 && !thisatt->attisdropped)
-		{
-			Assert(VARATT_IS_SHORT(DatumGetPointer(values[attnum])) ||
-				   !VARATT_CAN_MAKE_SHORT(DatumGetPointer(values[attnum])) ||
-				   thisatt->atttypid == OIDVECTOROID ||
-				   thisatt->atttypid == INT2VECTOROID ||
-				   thisatt->atttypid >= FirstNormalObjectId);	
-		}
-#endif
-
 		off = att_addlength_pointer(off, thisatt->attlen, tp + off);
 	}
 

--- a/src/backend/cdb/cdbfilerepprimary.c
+++ b/src/backend/cdb/cdbfilerepprimary.c
@@ -635,6 +635,9 @@ FileRepPrimary_MirrorFlush(FileRepIdentifier_u		fileRepIdentifier,
 											   ""); // tableName
 			}
 #endif
+			/* Just to make compiler happy */
+			descr.defaultDesc.placeholder = false;
+
 			status = FileRepPrimary_ConstructAndInsertMessage(
 															  fileRepIdentifier,
 															  fileRepRelationType,
@@ -664,7 +667,10 @@ FileRepPrimary_MirrorClose(FileRepIdentifier_u		fileRepIdentifier,
 		if (! (dataState == DataStateInResync &&
 			   fileRepRelationType == FileRepRelationTypeFlatFile &&
 			   segmentState != SegmentStateInSyncTransition))
-		{
+		{				
+			/* Just to make compiler happy */
+			descr.defaultDesc.placeholder = false;
+
 			status = FileRepPrimary_ConstructAndInsertMessage(
 															  fileRepIdentifier,
 															  fileRepRelationType,
@@ -694,7 +700,10 @@ FileRepPrimary_MirrorFlushAndClose(FileRepIdentifier_u		fileRepIdentifier,
 		if (! (dataState == DataStateInResync &&
 			   fileRepRelationType == FileRepRelationTypeFlatFile &&
 			   segmentState != SegmentStateInSyncTransition))
-		{
+		{			
+			/* Just to make compiler happy */
+			descr.defaultDesc.placeholder = false;
+
 			status = FileRepPrimary_ConstructAndInsertMessage(
 															  fileRepIdentifier,
 															  fileRepRelationType,
@@ -1037,7 +1046,10 @@ FileRepPrimary_MirrorDrop(FileRepIdentifier_u	fileRepIdentifier,
 		if (! (dataState == DataStateInResync &&
 			   fileRepRelationType == FileRepRelationTypeFlatFile &&
 			   segmentState != SegmentStateInSyncTransition))
-		{
+		{			
+			/* Just to make compiler happy */
+			descr.defaultDesc.placeholder = false;
+
 			status = FileRepPrimary_ConstructAndInsertMessage(
 															  fileRepIdentifier,
 															  fileRepRelationType,
@@ -1064,6 +1076,9 @@ FileRepPrimary_MirrorDropFilesFromDir(FileRepIdentifier_u	fileRepIdentifier,
 
 	if (FileRepPrimary_IsMirroringRequired(fileRepRelationType, FileRepOperationDropFilesFromDir))
 	{
+		/* Just to make compiler happy */
+		descr.defaultDesc.placeholder = false;
+
 		status = FileRepPrimary_ConstructAndInsertMessage(
 														  fileRepIdentifier,
 														  fileRepRelationType,
@@ -1090,6 +1105,9 @@ FileRepPrimary_MirrorDropTemporaryFiles(
 
 	if (FileRepPrimary_IsMirroringRequired(fileRepRelationType, FileRepOperationDropTemporaryFiles))
 	{
+		/* Just to make compiler happy */
+		descr.defaultDesc.placeholder = false;
+
 		status = FileRepPrimary_ConstructAndInsertMessage(
 														  fileRepIdentifier,
 														  fileRepRelationType,
@@ -1197,6 +1215,9 @@ FileRepPrimary_MirrorShutdown(void)
     /* send graceful shutdown if required */
 	if ( shouldSendShutdownToMirror )
 	{
+		/* Just to make compiler happy */
+		descr.defaultDesc.placeholder = false;
+
         status = FileRepPrimary_ConstructAndInsertMessage(
 														  fileRepIdentifier,
 														  FileRepRelationTypeUnknown,
@@ -1251,6 +1272,9 @@ FileRepPrimary_MirrorInSyncTransition(void)
 
 	if (FileRepPrimary_IsMirroringRequired(FileRepRelationTypeUnknown, FileRepOperationInSyncTransition))
 	{
+		/* Just to make compiler happy */
+		descr.defaultDesc.placeholder = false;
+
 		status = FileRepPrimary_ConstructAndInsertMessage(
 														  fileRepIdentifier,
 														  FileRepRelationTypeUnknown,
@@ -1766,6 +1790,7 @@ FileRepPrimary_MirrorStartChecksum(FileRepIdentifier_u fileRepIdentifier)
 	if (FileRepPrimary_IsMirroringRequired(FileRepRelationTypeFlatFile,
 										   FileRepOperationStartSlruChecksum))
 	{
+		descr.startChecksum.mirrorStatus = FileRepStatusSuccess;
 
 		status = FileRepPrimary_ConstructAndInsertMessage(fileRepIdentifier,
 														  FileRepRelationTypeFlatFile,

--- a/src/include/access/twophase.h
+++ b/src/include/access/twophase.h
@@ -20,7 +20,6 @@
 #include "storage/proc.h"
 #include "utils/timestamp.h"
 
-
 /*
  * Directory where two phase commit files reside within PGDATA
  */
@@ -33,7 +32,7 @@
 typedef struct prpt_map
 {
   TransactionId xid;
-  XLogRecPtr    xlogrecptr;;
+  XLogRecPtr    xlogrecptr;
 } prpt_map;
 
 typedef struct prepared_transaction_agg_state
@@ -48,7 +47,6 @@ typedef struct prepared_transaction_agg_state
 
 #define PREPARED_TRANSACTION_CHECKPOINT_BYTES(count) \
 	(offsetof(prepared_transaction_agg_state, maps) + sizeof(prpt_map) * (count))
-
 
 /*
  * GlobalTransactionData is defined in twophase.c; other places have no
@@ -109,7 +107,7 @@ extern void TwoPhaseAddPreparedTransaction(
 
 extern void getTwoPhasePreparedTransactionData(prepared_transaction_agg_state **ptas, char *caller);
 
-extern void SetupCheckpointPreparedTransactionList(XLogRecord *record);
+extern void SetupCheckpointPreparedTransactionList(prepared_transaction_agg_state *ptas);
 
 extern bool TwoPhaseFindRecoverPostCheckpointPreparedTransactionsMapEntry(TransactionId xid, XLogRecPtr *m, char *caller);
 

--- a/src/include/access/xlogmm.h
+++ b/src/include/access/xlogmm.h
@@ -122,6 +122,15 @@ typedef struct dbdir_agg_state
 #define DBDIR_CHECKPOINT_BYTES(count) \
 	(offsetof(dbdir_agg_state, maps) + sizeof(dbdir_map) * (count))
 
+typedef struct MasterMirrorCheckpointInfo
+{
+	fspc_agg_state  *fspc;
+	uint32          fspcMapLen;
+	tspc_agg_state  *tspc;
+	uint32          tspcMapLen;
+	dbdir_agg_state *dbdir;
+	uint32          dbdirMapLen;
+} MasterMirrorCheckpointInfo;
 
 extern void mmxlog_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record);
 extern void mmxlog_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record);
@@ -146,7 +155,8 @@ extern void mmxlog_log_create_database(Oid tablespace, Oid database);
 extern void mmxlog_log_create_relfilenode(Oid tablespace, Oid database,
 										  Oid relfilenode, uint32 segnum);
 extern void mmxlog_append_checkpoint_data(XLogRecData rdata[5]);
-extern void mmxlog_read_checkpoint_data(char *cpdata, int masterMirroringLen, int checkpointLen, XLogRecPtr *beginLoc);
+extern void mmxlog_read_checkpoint_data(MasterMirrorCheckpointInfo mmckptInfo,
+										XLogRecPtr *beginLoc);
 extern bool mmxlog_filespace_get_path(
 	Oid fspcoid,
 
@@ -177,7 +187,8 @@ extern void mmxlog_add_database(
 		dbdir_agg_state **das, int *maxCount,
 		Oid database, Oid tablespace, char *caller);
 
-extern char *mmxlog_get_checkpoint_record_suffix(XLogRecord *checkpointRecord);
+extern uint32 mmxlog_get_checkpoint_record_fields(char *recordStart,
+	MasterMirrorCheckpointInfo *mmckpt);
 
 extern bool mmxlog_get_checkpoint_info(char *cpdata, int masterMirroringLen, int checkpointLen, XLogRecPtr *beginLoc, int errlevel,
 		fspc_agg_state **f,

--- a/src/include/cdb/cdbfilerep.h
+++ b/src/include/cdb/cdbfilerep.h
@@ -952,18 +952,9 @@ typedef struct FileRepOperationDescriptionVerify_u
 
 } FileRepOperationDescriptionVerify_u;
 
-
-typedef struct FileRepVerifyLoggingOptions_s
-{
-	char token[FILEREP_VERIFY_MAX_REQUEST_TOKEN_LEN+1];
-	int  level;
-	char logPath[MAXPGPATH+1];
-	char fixPath[MAXPGPATH+1];
-	char chkpntPath[MAXPGPATH+1];
-
-	char externalTablePath[MAXPGPATH+1];
-	char resultsPath[MAXPGPATH+1];
-} FileRepVerifyLoggingOptions_s;
+typedef struct FileRepOperationDescriptionDefault_s {
+	bool placeholder;
+} FileRepOperationDescriptionDefault_s;
 
 /*
  *
@@ -994,6 +985,7 @@ typedef union FileRepOperationDescription_u
 
 	FileRepOperationDescriptionVerifyDirectoryChecksum_s verifyDirectoryChecksum;
 
+	FileRepOperationDescriptionDefault_s defaultDesc;
 } FileRepOperationDescription_u;
 
 /*


### PR DESCRIPTION
PR contains some cleanups

1. UnpackCheckPointRecord() as pointed out by @hlinnaka. The function contained code to deal with old checkpoint records, from upgrades between versions 4.0-4.3. That's no longer relevant with GPDB 5, so the function has been cleaned up significantly.

1. Remove incorrect assertion from heap_deform_tuple, as reported in #2115.

1. Fixing some compiler warning for uninitialized desc reported in filerep code.
