### PR TITLE
Fix flakiness for FTS test primary_sync_mirror_cannot_keepup_failover.

### DIFF
--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/fts/fts_transitions/__init__.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/fts/fts_transitions/__init__.py
@@ -130,9 +130,6 @@ class FtsTransitions(MPPTestCase):
     def run_fts_test_ddl_dml_ct(self):
         PSQL.run_sql_file(local_path('fts_test_ddl_dml_ct.sql'))
 
-    def run_sql_in_background(self):
-        PSQL.run_sql_command('drop table if exists bar; create table bar(i int);', background=True)
-
     def restart_db(self):
         self.gpstop.run_gpstop_cmd(immediate = True)
         self.gpstart.run_gpstart_cmd()

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/fts/fts_transitions/fts_transitions.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/fts/fts_transitions/fts_transitions.py
@@ -121,15 +121,17 @@ class FTSTestCase(ScenarioTestCase, MPPTestCase):
         self.check_system()
 
         test_case_list0 = []
-        test_case_list0.append(('mpp.gpdb.tests.storage.fts.fts_transitions.FtsTransitions.set_faults', ['filerep_receiver', 'sleep', 'primary'], {'sleeptime':150}))
+        test_case_list0.append(('mpp.gpdb.tests.storage.fts.fts_transitions.FtsTransitions.set_faults', ['filerep_receiver', 'sleep', 'primary'], {'occurence':0, 'sleeptime':150}))
         self.test_case_scenario.append(test_case_list0)
 
-        test_case_list1 = []
-        test_case_list1.append('mpp.gpdb.tests.storage.fts.fts_transitions.FtsTransitions.run_sql_in_background')
-        self.test_case_scenario.append(test_case_list1, serial=True)
+        # *heartbeat* between primary and mirror triggers every minute. It will
+        # get blocked due to above fault. As the time it blocks exceeds
+        # gp_segment_connect_timeout, mirror should get makred as down and
+        # primary transition to CT.
 
         test_case_list3 = []
         test_case_list3.append('mpp.gpdb.tests.storage.fts.fts_transitions.FtsTransitions.wait_till_change_tracking')
+        test_case_list3.append(('mpp.gpdb.tests.storage.fts.fts_transitions.FtsTransitions.set_faults', ['filerep_receiver', 'reset', 'primary'], {'occurence':0, 'sleeptime':150}))
         test_case_list3.append('mpp.gpdb.tests.storage.fts.fts_transitions.FtsTransitions.run_fts_test_ddl_dml')
         self.test_case_scenario.append(test_case_list3, serial=True)
 

--- a/src/test/tinc/tincrepo/mpp/lib/filerep_util.py
+++ b/src/test/tinc/tincrepo/mpp/lib/filerep_util.py
@@ -77,7 +77,7 @@ class Filerepe2e_Util():
             fault_cmd = fault_cmd + " -s %s" % seg_id
         if sleeptime :
             fault_cmd = fault_cmd + " -z %s" % sleeptime
-        if o:
+        if o != None:
             fault_cmd = fault_cmd + " -o %s" % o
         if p :
             fault_cmd = fault_cmd + " -p %s" % p


### PR DESCRIPTION
Setting the fault to always hit using `-o 0` instead of only once. Also, loose
out running SQL command. Instead make it clear `hearbeat` operation between
primary and mirror (triggering every minute) is what test relies on to validate,
if mirror is not responding back in `gp_segment_connect_timeout` should mark it
down and transition primary to change tracking.