### PR TITLE
Remove unused argument mt_bind in functions of memtup.h and callers

### DIFF
--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -1064,7 +1064,7 @@ upgrade_tuple(AppendOnlyExecutorReadBlock *executorReadBlock,
 		/*
 		 * make a modifiable copy
 		 */
-		newtuple = memtuple_copy_to(mtup, pbind, NULL, NULL);
+		newtuple = memtuple_copy_to(mtup, NULL, NULL);
 	}
 
 	/*
@@ -1150,7 +1150,7 @@ AppendOnlyExecutorReadBlock_ProcessTuple(
 		     AppendOnlyStorageRead_RelationName(executorReadBlock->storageRead),
 		     AOTupleIdToString(aoTupleId),
 		     tupleLen,
-		     memtuple_get_size(tuple, slot->tts_mt_bind),
+		     memtuple_get_size(tuple),
 		     executorReadBlock->headerOffsetInFile);
 
 	return valid;
@@ -2972,8 +2972,7 @@ appendonly_insert_init(Relation rel, int segno, bool update_mode)
 		need_toast = false;
 	else
 		need_toast = (MemTupleHasExternal(instup, aoInsertDesc->mt_bind) ||
-					  memtuple_get_size(instup, aoInsertDesc->mt_bind) >
-					  aoInsertDesc->toast_tuple_threshold);
+					  memtuple_get_size(instup) > aoInsertDesc->toast_tuple_threshold);
 
 	/*
 	 * If the new tuple is too big for storage or contains already toasted
@@ -2994,7 +2993,7 @@ appendonly_insert_init(Relation rel, int segno, bool update_mode)
 	/*
 	 * get space to insert our next item (tuple)
 	 */
-	itemLen = memtuple_get_size(tup, aoInsertDesc->mt_bind);
+	itemLen = memtuple_get_size(tup);
 	isLargeContent = false;
 
 	/*

--- a/src/backend/cdb/motion/tupser.c
+++ b/src/backend/cdb/motion/tupser.c
@@ -527,8 +527,8 @@ SerializeTupleIntoChunks(HeapTuple tuple, SerTupInfo * pSerInfo, TupleChunkList 
 
 	if (is_heaptuple_memtuple(tuple))
 	{
-		addByteStringToChunkList(tcList, (char *)tuple, memtuple_get_size((MemTuple)tuple, NULL), &pSerInfo->chunkCache);
-		addPadding(tcList, &pSerInfo->chunkCache, memtuple_get_size((MemTuple)tuple, NULL));
+		addByteStringToChunkList(tcList, (char *)tuple, memtuple_get_size((MemTuple)tuple), &pSerInfo->chunkCache);
+		addPadding(tcList, &pSerInfo->chunkCache, memtuple_get_size((MemTuple)tuple));
 	}
 	else
 	{
@@ -819,7 +819,7 @@ SerializeTupleDirect(HeapTuple tuple, SerTupInfo * pSerInfo, struct directTransp
 			int tupleSize;
 			int paddedSize;
 
-			tupleSize = memtuple_get_size((MemTuple)tuple, NULL);
+			tupleSize = memtuple_get_size((MemTuple)tuple);
 			paddedSize = TYPEALIGN(TUPLE_CHUNK_ALIGN, tupleSize);
 
 			if (paddedSize + TUPLE_CHUNK_HEADER_SIZE > b->prilen)

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -646,7 +646,7 @@ MemTuple ExecCopySlotMemTuple(TupleTableSlot *slot)
 	 * tts_mintuple since that's a tad cheaper.
 	 */
 	if (slot->PRIVATE_tts_memtuple)
-		return memtuple_copy_to(slot->PRIVATE_tts_memtuple, slot->tts_mt_bind, NULL, NULL);
+		return memtuple_copy_to(slot->PRIVATE_tts_memtuple, NULL, NULL);
 	
 	slot_getallattrs(slot);
 
@@ -669,12 +669,12 @@ MemTuple ExecCopySlotMemTupleTo(TupleTableSlot *slot, MemoryContext pctxt, char 
 	
 	if (TupHasMemTuple(slot))
 	{
-		mtup = memtuple_copy_to(slot->PRIVATE_tts_memtuple, slot->tts_mt_bind, (MemTuple) dest, len);
+		mtup = memtuple_copy_to(slot->PRIVATE_tts_memtuple, (MemTuple) dest, len);
 		if(mtup || !pctxt)
 			return mtup;
 
 		mtup = (MemTuple) ctxt_alloc(pctxt, *len);
-		mtup = memtuple_copy_to(slot->PRIVATE_tts_memtuple, slot->tts_mt_bind, mtup, len);
+		mtup = memtuple_copy_to(slot->PRIVATE_tts_memtuple, mtup, len);
 		Assert(mtup);
 
 		return mtup;
@@ -774,7 +774,7 @@ MemTuple ExecFetchSlotMemTuple(TupleTableSlot *slot, bool inline_toast)
 
 	if(slot->PRIVATE_tts_memtuple)
 	{
-		if(!inline_toast || !memtuple_get_hasext(slot->PRIVATE_tts_memtuple, slot->tts_mt_bind))
+		if(!inline_toast || !memtuple_get_hasext(slot->PRIVATE_tts_memtuple))
 			return slot->PRIVATE_tts_memtuple;
 
 		oldTuple = slot->PRIVATE_tts_mtup_buf;

--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -1612,8 +1612,7 @@ agg_retrieve_hash_table(AggState *aggstate)
 		 */
 		ExecStoreMinimalTuple((MemTuple)entry->tuple_and_aggs, firstSlot, false);
 		pergroup = (AggStatePerGroup)((char *)entry->tuple_and_aggs + 
-					      MAXALIGN(memtuple_get_size((MemTuple)entry->tuple_and_aggs,
-									 aggstate->hashslot->tts_mt_bind)));
+					      MAXALIGN(memtuple_get_size((MemTuple)entry->tuple_and_aggs)));
 
 		/*
 		 * Finalize each aggregate calculation, and stash results in the

--- a/src/backend/executor/nodeHash.c
+++ b/src/backend/executor/nodeHash.c
@@ -812,7 +812,7 @@ ExecHashIncreaseNumBatches(HashJoinTable hashtable)
 
 				hashtable->totalTuples--;
 
-				spaceTuple = HJTUPLE_OVERHEAD + memtuple_get_size(HJTUPLE_MINTUPLE(tuple), NULL); 
+				spaceTuple = HJTUPLE_OVERHEAD + memtuple_get_size(HJTUPLE_MINTUPLE(tuple));
 				spaceFreed += spaceTuple;
 				if (stats)
 					stats->batchstats[batchno].spillspace_in += spaceTuple;
@@ -944,7 +944,7 @@ ExecHashTableInsert(HashState *hashState, HashJoinTable hashtable,
 							  &bucketno, &batchno);
 
 	batch = hashtable->batches[batchno];
-	hashTupleSize = HJTUPLE_OVERHEAD + memtuple_get_size(tuple, NULL); 
+	hashTupleSize = HJTUPLE_OVERHEAD + memtuple_get_size(tuple);
 
 	/* Update batch size. */
 	batch->innertuples++;
@@ -963,7 +963,7 @@ ExecHashTableInsert(HashState *hashState, HashJoinTable hashtable,
 		hashTuple = (HashJoinTuple) MemoryContextAlloc(hashtable->batchCxt,
 													   hashTupleSize);
 		hashTuple->hashvalue = hashvalue;
-		memcpy(HJTUPLE_MINTUPLE(hashTuple), tuple, memtuple_get_size(tuple, NULL)); 
+		memcpy(HJTUPLE_MINTUPLE(hashTuple), tuple, memtuple_get_size(tuple));
 		hashTuple->next = hashtable->buckets[bucketno];
 		hashtable->buckets[bucketno] = hashTuple;
 		hashtable->totalTuples += 1;

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -1045,7 +1045,7 @@ ExecHashJoinSaveTuple(PlanState *ps, MemTuple tuple, uint32 hashvalue,
 		workfile_mgr_report_error();
 	}
 
-	if (!ExecWorkFile_Write(batchside->workfile, (void *) tuple, memtuple_get_size(tuple, NULL)))
+	if (!ExecWorkFile_Write(batchside->workfile, (void *) tuple, memtuple_get_size(tuple)))
 	{
 		workfile_mgr_report_error();
 	}
@@ -1055,7 +1055,7 @@ ExecHashJoinSaveTuple(PlanState *ps, MemTuple tuple, uint32 hashvalue,
 	if (ps)
 	{
 		Gpmon_M_Incr(&ps->gpmon_pkt, GPMON_HASHJOIN_SPILLTUPLE);
-		Gpmon_M_Add(&ps->gpmon_pkt, GPMON_HASHJOIN_SPILLBYTE, memtuple_get_size(tuple, NULL));
+		Gpmon_M_Add(&ps->gpmon_pkt, GPMON_HASHJOIN_SPILLBYTE, memtuple_get_size(tuple));
 		CheckSendPlanStateGpmonPkt(ps);
 	}
 }
@@ -1091,7 +1091,7 @@ ExecHashJoinGetSavedTuple(HashJoinState *hjstate,
 
 	*hashvalue = header[0];
 	tuple = (MemTuple) palloc(memtuple_size_from_uint32(header[1]));
-	memtuple_set_mtlen(tuple, NULL, header[1]);
+	memtuple_set_mtlen(tuple, header[1]);
 
 	nread = ExecWorkFile_Read(batchside->workfile,
 							  (void *) ((char *) tuple + sizeof(uint32)),

--- a/src/backend/utils/sort/tuplesort.c
+++ b/src/backend/utils/sort/tuplesort.c
@@ -2854,7 +2854,7 @@ copytup_heap(Tuplesortstate *state, SortTuple *stup, void *tup)
 static void
 writetup_heap(Tuplesortstate *state, LogicalTape *lt, SortTuple *stup)
 {
-	uint32 tuplen = memtuple_get_size(stup->tuple, NULL); 
+	uint32 tuplen = memtuple_get_size(stup->tuple);
 
 	LogicalTapeWrite(state->tapeset, lt, (void *) stup->tuple, tuplen);
 
@@ -2882,7 +2882,7 @@ readtup_heap(Tuplesortstate *state, TuplesortPos *pos, SortTuple *stup,
 
 	stup->tuple = (MemTuple) palloc(memtuple_size_from_uint32(len));
 	USEMEM(state, GetMemoryChunkSpace(stup->tuple));
-	memtuple_set_mtlen(stup->tuple, NULL, len);
+	memtuple_set_mtlen(stup->tuple, len);
 
 	Assert(lt);
 	readSize = LogicalTapeRead(state->tapeset, lt,

--- a/src/backend/utils/sort/tuplesort_mk.c
+++ b/src/backend/utils/sort/tuplesort_mk.c
@@ -2769,7 +2769,7 @@ copytup_heap(Tuplesortstate_mk *state, MKEntry *e, void *tup)
 									   NULL, NULL, false
 		);
 
-	state->totalTupleBytes += memtuple_get_size((MemTuple) e->ptr, NULL);
+	state->totalTupleBytes += memtuple_get_size((MemTuple) e->ptr);
 
 	Assert(state->mt_bind);
 }
@@ -2781,7 +2781,7 @@ copytup_heap(Tuplesortstate_mk *state, MKEntry *e, void *tup)
 static long
 writetup_heap(Tuplesortstate_mk *state, LogicalTape *lt, MKEntry *e)
 {
-	uint32		tuplen = memtuple_get_size(e->ptr, NULL);
+	uint32		tuplen = memtuple_get_size(e->ptr);
 	long		ret = tuplen;
 
 	LogicalTapeWrite(state->tapeset, lt, e->ptr, tuplen);
@@ -2824,7 +2824,7 @@ readtup_heap(Tuplesortstate_mk *state, TuplesortPos_mk *pos, MKEntry *e, Logical
 	MemSet(e, 0, sizeof(MKEntry));
 	e->ptr = palloc(memtuple_size_from_uint32(len));
 
-	memtuple_set_mtlen((MemTuple) e->ptr, NULL, len);
+	memtuple_set_mtlen((MemTuple) e->ptr, len);
 
 	Assert(lt);
 	readSize = LogicalTapeRead(state->tapeset, lt,

--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -1069,7 +1069,7 @@ copytup_heap(Tuplestorestate *state, TuplestorePos *pos, void *tup)
 	if(!is_heaptuple_memtuple((HeapTuple) tup))
 		return heaptuple_copy_to((HeapTuple) tup, NULL, NULL);
 
-	return memtuple_copy_to((MemTuple) tup, NULL, NULL, NULL);
+	return memtuple_copy_to((MemTuple) tup, NULL, NULL);
 }
 
 static void
@@ -1079,7 +1079,7 @@ writetup_heap(Tuplestorestate *state, TuplestorePos *pos, void *tup)
 	Size         memsize = 0;
 
 	if(is_heaptuple_memtuple((HeapTuple) tup))
-		tuplen = memtuple_get_size((MemTuple) tup, NULL);
+		tuplen = memtuple_get_size((MemTuple) tup);
 	else
 	{
 		Assert(!is_heaptuple_splitter((HeapTuple) tup));
@@ -1123,7 +1123,7 @@ readtup_heap(Tuplestorestate *state, TuplestorePos *pos, uint32 len)
 	if(is_len_memtuplen(len))
 	{
 		/* read in the tuple proper */
-		memtuple_set_mtlen((MemTuple) tup, NULL, len);
+		memtuple_set_mtlen((MemTuple) tup, len);
 
 		if (BufFileRead(state->myfile, (void *) ((char *) tup + sizeof(uint32)), 
 					tuplen - sizeof(uint32)) 

--- a/src/include/access/memtup.h
+++ b/src/include/access/memtup.h
@@ -81,78 +81,45 @@ static inline uint32 memtuple_size_from_uint32(uint32 len)
 	Assert ((len & MEMTUP_LEAD_BIT) != 0);
 	return len & MEMTUP_LEN_MASK;
 }
-static inline uint32 memtuple_get_size(MemTuple mtup, MemTupleBinding *pbind)
+static inline uint32 memtuple_get_size(MemTuple mtup)
 {
-	UnusedArg(pbind);
 	Assert(memtuple_lead_bit_set(mtup));
 	return (mtup->PRIVATE_mt_len & MEMTUP_LEN_MASK);
 }
-static inline void memtuple_set_size(MemTuple mtup, MemTupleBinding *pbind, uint32 len)
+static inline void memtuple_set_mtlen(MemTuple mtup, uint32 mtlen)
 {
-	UnusedArg(pbind);
-	Assert((len & (~MEMTUP_LEN_MASK)) == 0); 
-	mtup->PRIVATE_mt_len |= MEMTUP_LEAD_BIT;
-	mtup->PRIVATE_mt_len = (mtup->PRIVATE_mt_len & (~MEMTUP_LEN_MASK)) | len;
-}
-static inline void memtuple_set_mtlen(MemTuple mtup, MemTupleBinding *pbind, uint32 mtlen)
-{
-	UnusedArg(pbind);
 	Assert((mtlen & MEMTUP_LEAD_BIT) != 0);
 	mtup->PRIVATE_mt_len = mtlen;
 }
-static inline bool memtuple_get_hasnull(MemTuple mtup, MemTupleBinding *pbind)
+static inline bool memtuple_get_hasnull(MemTuple mtup)
 {
-	UnusedArg(pbind);
 	Assert(memtuple_lead_bit_set(mtup));
 	return (mtup->PRIVATE_mt_len & MEMTUP_HASNULL) != 0;
 }
-static inline void memtuple_set_hasnull(MemTuple mtup, MemTupleBinding *pbind)
+static inline void memtuple_set_hasnull(MemTuple mtup)
 {
-	UnusedArg(pbind);
 	Assert(memtuple_lead_bit_set(mtup));
 	mtup->PRIVATE_mt_len |= MEMTUP_HASNULL;
 }
-static inline void memtuple_clear_hasnull(MemTuple mtup, MemTupleBinding *pbind)
+static inline bool memtuple_get_islarge(MemTuple mtup)
 {
-	UnusedArg(pbind);
-	Assert(memtuple_lead_bit_set(mtup));
-	mtup->PRIVATE_mt_len &= (~MEMTUP_HASNULL);
-}
-static inline bool memtuple_get_islarge(MemTuple mtup, MemTupleBinding *pbind)
-{
-	UnusedArg(pbind);
 	Assert(memtuple_lead_bit_set(mtup));
 	return (mtup->PRIVATE_mt_len & MEMTUP_LARGETUP) != 0;
 }
-static inline void memtuple_set_islarge(MemTuple mtup, MemTupleBinding *pbind)
+static inline void memtuple_set_islarge(MemTuple mtup)
 {
-	UnusedArg(pbind);
 	Assert(memtuple_lead_bit_set(mtup));
 	mtup->PRIVATE_mt_len |= MEMTUP_LARGETUP; 
 }
-static inline void memtuple_clear_islarge(MemTuple mtup, MemTupleBinding *pbind)
+static inline bool memtuple_get_hasext(MemTuple mtup)
 {
-	UnusedArg(pbind);
-	Assert(memtuple_lead_bit_set(mtup));
-	mtup->PRIVATE_mt_len &= (~MEMTUP_LARGETUP); 
-}
-static inline bool memtuple_get_hasext(MemTuple mtup, MemTupleBinding *pbind)
-{
-	UnusedArg(pbind);
 	Assert(memtuple_lead_bit_set(mtup));
 	return (mtup->PRIVATE_mt_len & MEMTUP_HASEXTERNAL) != 0;
 }
-static inline void memtuple_set_hasext(MemTuple mtup, MemTupleBinding *pbind)
+static inline void memtuple_set_hasext(MemTuple mtup)
 {
-	UnusedArg(pbind);
 	Assert(memtuple_lead_bit_set(mtup));
 	mtup->PRIVATE_mt_len |= MEMTUP_HASEXTERNAL;
-}
-static inline void memtuple_clear_hasext(MemTuple mtup, MemTupleBinding *pbind)
-{
-	UnusedArg(pbind);
-	Assert(memtuple_lead_bit_set(mtup));
-	mtup->PRIVATE_mt_len &= (~MEMTUP_HASEXTERNAL);
 }
 
 
@@ -164,7 +131,7 @@ extern bool memtuple_attisnull(MemTuple mtup, MemTupleBinding *pbind, int attnum
 
 extern uint32 compute_memtuple_size(MemTupleBinding *pbind, Datum *values, bool *isnull, bool hasnull, uint32 *nullsaves);
 
-extern MemTuple memtuple_copy_to(MemTuple mtup, MemTupleBinding *pbind, MemTuple dest, uint32 *destlen);
+extern MemTuple memtuple_copy_to(MemTuple mtup, MemTuple dest, uint32 *destlen);
 extern MemTuple memtuple_form_to(MemTupleBinding *pbind, Datum *values, bool *isnull, MemTuple dest, uint32 *destlen, bool inline_toast);
 extern void memtuple_deform(MemTuple mtup, MemTupleBinding *pbind, Datum *datum, bool *isnull);
 extern void memtuple_deform_misaligned(MemTuple mtup, MemTupleBinding *pbind, Datum *datum, bool *isnull);
@@ -175,6 +142,5 @@ extern void MemTupleSetOid(MemTuple mtup, MemTupleBinding *pbind, Oid oid);
 extern bool MemTupleHasExternal(MemTuple mtup, MemTupleBinding *pbind);
 
 extern bool memtuple_has_misaligned_attribute(MemTuple mtup, MemTupleBinding *pbind);
-extern MemTuple memtuple_aligned_clone(MemTuple mtup, MemTupleBinding *pbind, bool use_null_saves_aligned);
 
 #endif /* MEMTUP_H */


### PR DESCRIPTION
Many functions has unused argument `MemTupleBinding`. So just clean it up to help our future work on adjusting `tuplestore.c` to use `MemTuple`.

Also remove some unused functions in `memtup.h`:
`memtuple_set_size`
`memtuple_clear_hasnull`
`memtuple_clear_islarge`
`memtuple_clear_hasext`
`memtuple_aligned_clone`