### PR TITLE
Removing dead code in gpMgmt bash libraries

### DIFF
--- a/configure
+++ b/configure
@@ -5489,6 +5489,12 @@ if grep '\$\$' $GP_VERSION_IN > /dev/null 2>&1 ; then
     sed "s,\\$.*\\$\\$,$GP_VERSION," $GP_VERSION_IN > $GP_VERSION_HEADER
 fi
 
+GP_BASH_VERSION_IN="gpMgmt/bin/lib/gp_bash_version.sh.in"
+GP_BASH_VERSION_SH="gpMgmt/bin/lib/gp_bash_version.sh"
+if grep '##' $GP_BASH_VERSION_IN > /dev/null 2>&1 ; then
+    sed "s,##.*##,$GP_VERSION," $GP_BASH_VERSION_IN > $GP_BASH_VERSION_SH
+fi
+
 # Create compiler version string
 if test x"$GCC" = x"yes" ; then
   cc_string="GCC `${CC} --version | sed q`"

--- a/configure.in
+++ b/configure.in
@@ -580,6 +580,12 @@ if grep '\$\$' $GP_VERSION_IN > /dev/null 2>&1 ; then
     sed "s,\\$.*\\$\\$,$GP_VERSION," $GP_VERSION_IN > $GP_VERSION_HEADER
 fi
 
+GP_BASH_VERSION_IN="gpMgmt/bin/lib/gp_bash_version.sh.in"
+GP_BASH_VERSION_SH="gpMgmt/bin/lib/gp_bash_version.sh"
+if grep '##' $GP_BASH_VERSION_IN > /dev/null 2>&1 ; then
+    sed "s,##.*##,$GP_VERSION," $GP_BASH_VERSION_IN > $GP_BASH_VERSION_SH
+fi
+
 # Create compiler version string
 if test x"$GCC" = x"yes" ; then
   cc_string="GCC `${CC} --version | sed q`"

--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -30,7 +30,7 @@ if [ -f $FUNCTIONS ]; then
     . $FUNCTIONS
     . $WORKDIR/lib/gp_bash_version.sh
 else
-    echo "[FATAL]:-Cannot source $FUNCTIONS file Script Exits!"
+    echo "[FATAL]:-Cannot source $FUNCTIONS file, script Exits!"
     exit 2
 fi
 

--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -150,7 +150,7 @@ USAGE () {
 		$ECHO "      0 - No problems encountered with requested operation"
 		$ECHO "      1 - Warning generated, but instance operational"
 		$ECHO "      2 - Fatal error, instance not created/started, or in an inconsistent state,"
-	    	$ECHO "            see log file for failure reason."
+		$ECHO "          see log file for failure reason."
 		$ECHO
 		exit $EXIT_STATUS
 	fi
@@ -347,15 +347,15 @@ CHK_PARAMS () {
 			ERROR_EXIT "[FATAL]:-MASTER_DIRECTORY variable not set" 2
 		fi
 		# Check that we have write access to the proposed master data directory
-                W_DIR=$MASTER_DIRECTORY
-                LOG_MSG "[INFO]:-Checking write access to $W_DIR on master host"
-                $TOUCH ${W_DIR}/tmp_file_test
-                RETVAL=$?
-                if [ $RETVAL -ne 0 ];then
-                        ERROR_EXIT "[FATAL]:-Cannot write to $W_DIR on master host " 2
-                else
-                        $RM -f ${W_DIR}/tmp_file_test
-                        LOG_MSG "[INFO]:-Write test passed $W_DIR directory on master host"
+		W_DIR=$MASTER_DIRECTORY
+		LOG_MSG "[INFO]:-Checking write access to $W_DIR on master host"
+		$TOUCH ${W_DIR}/tmp_file_test
+		RETVAL=$?
+		if [ $RETVAL -ne 0 ];then
+			ERROR_EXIT "[FATAL]:-Cannot write to $W_DIR on master host " 2
+		else
+			$RM -f ${W_DIR}/tmp_file_test
+			LOG_MSG "[INFO]:-Write test passed $W_DIR directory on master host"
 		fi	
 		# Check that the master segment directory does not exist
 		if [ -d ${MASTER_DIRECTORY}/${SEG_PREFIX}-1 ];then
@@ -600,9 +600,9 @@ END_PYTHON_CODE
                 ((REMAINDER=$NUM_DATADIR % $NUM_MHOST_NODE))                
                 ((MULTIPLE=$NUM_DATADIR / $NUM_MHOST_NODE))
                 if [ $REMAINDER -ne 0 ] || [ $MULTIPLE -eq 0 ] ;then                        
-		    LOG_MSG "[FATAL]:-Inconsistency between number of multi-home hostnames and number of segments per host" 1
-		    LOG_MSG "[INFO]:-Have $NUM_DATADIR data directories and $NUM_MHOST_NODE multi-home hostnames for each host" 1
-		    LOG_MSG "[INFO]:-For multi-home configuration, number of segment instance data directories per host must be multiple of" 1
+                    LOG_MSG "[FATAL]:-Inconsistency between number of multi-home hostnames and number of segments per host" 1
+                    LOG_MSG "[INFO]:-Have $NUM_DATADIR data directories and $NUM_MHOST_NODE multi-home hostnames for each host" 1
+                    LOG_MSG "[INFO]:-For multi-home configuration, number of segment instance data directories per host must be multiple of" 1
                     LOG_MSG "[INFO]:-the number of multi-home hostnames within the GPDB array" 1
                     ERROR_EXIT "[FATAL]:-Unable to continue" 2
                 fi
@@ -799,8 +799,8 @@ CHK_QES () {
             if [ $EXISTS -eq 0 ]; then
                 ERROR_EXIT "[FATAL]:-Instance directory $GP_DIR exists on segment instance $GP_HOSTADDRESS" 2
             fi
-                            # Check that we can write to the QE directory
-                        W_DIR=`$DIRNAME $GP_DIR`
+            # Check that we can write to the QE directory
+            W_DIR=`$DIRNAME $GP_DIR`
             LOG_MSG "[INFO]:-Checking write access to $W_DIR on $GP_HOSTADDRESS"
             $TRUSTED_SHELL $GP_HOSTADDRESS "$TOUCH ${W_DIR}/tmp_file_test"
             RETVAL=$?
@@ -854,11 +854,10 @@ CHK_SEG () {
     if [ $RETVAL -ne 0 ];then
          ERROR_EXIT "[FATAL]:-Cannot write to $W_DIR on $GP_HOSTADDRESS " 2
     else
-             $TRUSTED_SHELL $GP_HOSTADDRESS "$RM -f ${W_DIR}/tmp_file_test"
-             LOG_MSG "[INFO]:-Write test passed on $GP_HOSTADDRESS $W_DIR directory"
+         $TRUSTED_SHELL $GP_HOSTADDRESS "$RM -f ${W_DIR}/tmp_file_test"
+         LOG_MSG "[INFO]:-Write test passed on $GP_HOSTADDRESS $W_DIR directory"
     fi
     
-	
 	# Check that we have a GP_LIBRARY_PATH directory on the QE
 	CHK_DIR $GP_LIBRARY_PATH $GP_HOSTADDRESS
 	if [ $EXISTS -ne 0 ]; then
@@ -871,43 +870,43 @@ CHK_SEG () {
 }
 
 CHK_QES_FROM_INPUTFILE () {
-		LOG_MSG "[INFO]:-Start Function $FUNCNAME"
-		LOG_MSG "[INFO]:-Checking Master host" 1
-		SET_VAR $QD_PRIMARY_ARRAY
-                CHK_DIR $GP_DIR
-                if [ $EXISTS -eq 0 ]; then
-                                ERROR_EXIT "[FATAL]:-Master directory $GP_DIR already exists" 2
-                fi
-		GET_PG_PID_ACTIVE $GP_PORT
-		if [ $PID -ne 0 ];then
-			ERROR_EXIT "[FATAL]:-Found indication of postmaster process on port $GP_PORT on Master host" 2
+	LOG_MSG "[INFO]:-Start Function $FUNCNAME"
+	LOG_MSG "[INFO]:-Checking Master host" 1
+	SET_VAR $QD_PRIMARY_ARRAY
+	CHK_DIR $GP_DIR
+	if [ $EXISTS -eq 0 ]; then
+		ERROR_EXIT "[FATAL]:-Master directory $GP_DIR already exists" 2
+	fi
+	GET_PG_PID_ACTIVE $GP_PORT
+	if [ $PID -ne 0 ];then
+		ERROR_EXIT "[FATAL]:-Found indication of postmaster process on port $GP_PORT on Master host" 2
+	fi
+	LOG_MSG "[INFO]:-Checking new segment hosts, please wait..." 1
+	
+	for QE in ${QE_PRIMARY_ARRAY[@]}
+	do
+		CHK_SEG $QE            
+	done
+	
+	for QE in ${QE_MIRROR_ARRAY[@]}
+	do
+		CHK_SEG $QE            
+	done
+	        
+	if [ x"" != x"$STANDBY_HOSTNAME" ];then
+		PING_HOST $STANDBY_HOSTNAME 
+		CHK_LOCALE_KNOWN $STANDBY_HOSTNAME
+		CHK_OPEN_FILES $GP_HOSTADDRESS
+		#Check standby host directory
+		CHK_DIR $MASTER_DIRECTORY $STANDBY_HOSTNAME
+		if [ $EXISTS -ne 0 ];then
+			ERROR_EXIT "[FATAL]:-Standby host directory $MASTER_DIRECTORY, does not exist" 2
 		fi
-		LOG_MSG "[INFO]:-Checking new segment hosts, please wait..." 1
-
-        for QE in ${QE_PRIMARY_ARRAY[@]}
-        do
-            CHK_SEG $QE            
-        done
-        
-        for QE in ${QE_MIRROR_ARRAY[@]}
-        do
-            CHK_SEG $QE            
-        done
-                
-        if [ x"" != x"$STANDBY_HOSTNAME" ];then
-            PING_HOST $STANDBY_HOSTNAME 
-            CHK_LOCALE_KNOWN $STANDBY_HOSTNAME
-            CHK_OPEN_FILES $GP_HOSTADDRESS
-            #Check standby host directory
-            CHK_DIR $MASTER_DIRECTORY $STANDBY_HOSTNAME
-            if [ $EXISTS -ne 0 ];then
-                ERROR_EXIT "[FATAL]:-Standby host directory $MASTER_DIRECTORY, does not exist" 2
-            fi
-        fi
-
-		if [ $DEBUG_LEVEL -eq 0 ] && [ x"" != x"$VERBOSE" ];then $ECHO;fi
-		LOG_MSG "[INFO]:-Checking new segment hosts, Completed" 1
-		LOG_MSG "[INFO]:-End Function $FUNCNAME"
+	fi
+	
+	if [ $DEBUG_LEVEL -eq 0 ] && [ x"" != x"$VERBOSE" ];then $ECHO;fi
+	LOG_MSG "[INFO]:-Checking new segment hosts, Completed" 1
+	LOG_MSG "[INFO]:-End Function $FUNCNAME"
 }
 
 POSTGRES_PORT_CHK () {

--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -28,6 +28,7 @@ WORKDIR=`dirname $0`
 FUNCTIONS=$WORKDIR/lib/gp_bash_functions.sh
 if [ -f $FUNCTIONS ]; then
     . $FUNCTIONS
+    . $WORKDIR/lib/gp_bash_version.sh
 else
     echo "[FATAL]:-Cannot source $FUNCTIONS file Script Exits!"
     exit 2
@@ -99,7 +100,7 @@ DCA_SEGMENT_RESQUEUE_PRIORITY_SWEEPER_INTERVAL_VAL=1000
 # Functions
 #******************************************************************************
 USAGE () {
-	if [ -f ${GPDOCDIR}/$HELP_DOC_NAME ] && [ x"" == x"$SCRIPT_USAGE" ];then
+	if [ "$1" == "print_doc" ] && [ -f ${GPDOCDIR}/$HELP_DOC_NAME ]; then
 		$LESSCMD ${GPDOCDIR}/$HELP_DOC_NAME
 		exit 0
 	else
@@ -110,7 +111,6 @@ USAGE () {
 		$ECHO "      segment instance hosts."
 		$ECHO
 		$ECHO "      General options:"
-		$ECHO "      -?, display this help message & exit"
 		$ECHO "      -v, display version information & exit"
 		$ECHO
 		$ECHO "      Logging options:"
@@ -136,7 +136,6 @@ USAGE () {
 		$ECHO "      -s, standby_hostname [optional]"
 		$ECHO "      -P, standby_port [optional]"
 		$ECHO "      -F, standby_filespaces [optiona]"
-		$ECHO "      -i, do not initialize standby sync process [default:- start process]"
 		$ECHO "      -m, maximum number of connections for master instance [default ${DEFAULT_QD_MAX_CONNECT}]"
 		$ECHO "      -b, shared_buffers per instance [default $DEFAULT_BUFFERS]"
 		$ECHO "          Specify either the number of database I/O buffers (without suffix) or the"
@@ -845,14 +844,6 @@ CHK_SEG () {
 	if [ $VERSION_MATCH -ne 1 ] ; then
 	   ERROR_EXIT "Postgres version does not match" 2
 	fi
-	
-	# since this is from the input config file we only check our one datadir
-	#CHK_DIR $GP_DIR $QE_ID
-	#if [ $EXISTS -ne 0 ]; then
-	#	ERROR_EXIT "[FATAL]:-No $GP_DIR on segment instance $QE_ID" 2
-	#else
-	#	LOG_MSG "[INFO]:-$QE_ID $GP_DIR checked"
-	#fi
 	
 	#make sure we can write to it.
 	# Check that we can write to the QE directory
@@ -1915,13 +1906,10 @@ SET_DCA_CONFIG_SETTINGS () {
 # Main Section
 #******************************************************************************
 trap 'ERROR_EXIT "[FATAL]:-Received INT or TERM signal" 2' INT TERM
-while getopts ":v'?'aiqe:c:l:-:p:m:h:on:s:P:F:b:!DB:SI:O:" opt
+while getopts ":vaqe:c:l:-:p:m:h:n:s:P:F:b:DB:SI:O:" opt
 		do
 		case $opt in
-				v ) VERSION_INFO ;;
-				'?' ) USAGE ;;
-				! ) SCRIPT_USAGE=1
-				    USAGE ;;
+				v ) print_version ;;
 				a ) unset INTERACTIVE ;;
 				q ) unset VERBOSE ;;
 				c ) CLUSTER_CONFIG=$OPTARG ;;
@@ -1954,13 +1942,15 @@ while getopts ":v'?'aiqe:c:l:-:p:m:h:on:s:P:F:b:!DB:SI:O:" opt
 						"lc-monetary"     ) LCMONETARY=$VAL ;;
 						"lc-numeric"      ) LCNUMERIC=$VAL ;;
 						"lc-time"         ) LCTIME=$VAL ;;
-						* ) LOG_MSG "[ERROR]:-Unknown option $NAME" 1; USAGE ;;
+						"help"            ) USAGE "print_doc" ;;
+						"version"         ) print_version ;;
+						* ) LOG_MSG "[ERROR]:-Unknown option --$NAME" 1; USAGE ;;
 					esac
 
 					# Check if we are missing the long option value.  Currently all
 					# long options require a value so we can just do the check once.
 					if [ x"$NAME" == x"$VAL" ]; then
-						LOG_MSG "[FATAL]:-Missing value for option $NAME" 1;
+						LOG_MSG "[FATAL]:-Missing value for option --$NAME" 1;
 						USAGE;
 					fi
 					;;

--- a/gpMgmt/bin/lib/.gitignore
+++ b/gpMgmt/bin/lib/.gitignore
@@ -3,7 +3,4 @@ netserver
 stream
 Crypto
 paramiko
-stream
-Crypto
-paramiko
 gp_bash_version.sh

--- a/gpMgmt/bin/lib/.gitignore
+++ b/gpMgmt/bin/lib/.gitignore
@@ -6,3 +6,4 @@ paramiko
 stream
 Crypto
 paramiko
+gp_bash_version.sh

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -41,7 +41,7 @@ GP_UNIQUE_COMMAND=gpstart
 
 findCmdInPath() {
 		cmdtofind=$1
-		
+
 		if [ $cmdtofind = 'awk' ] && [ `uname` = SunOS ]; then
 			if [ -f "/usr/xpg4/bin/awk" ]; then
 				CMD=/usr/xpg4/bin/awk
@@ -172,7 +172,7 @@ FROM pg_catalog.pg_database d
   JOIN pg_catalog.pg_authid r ON d.datdba = r.oid
 ORDER BY 1;"
 #******************************************************************************
-# Greenplum OS Settings 
+# Greenplum OS Settings
 #******************************************************************************
 OS_OPENFILES=65535
 #******************************************************************************
@@ -253,12 +253,12 @@ LOG_MSG () {
 		if [ x"" == x"$DEBUG_LEVEL" ];then
 			DEBUG_LEVEL=1
 		fi
-		if [ $# -eq 2 ];then 
+		if [ $# -eq 2 ];then
 			DISPLAY_TXT=1
 		fi
 		if [ $VERBOSE ]; then
 				if [ $DEBUG_LEVEL -eq 1 ] || [ $DISPLAY_TXT -eq 1 ];then
-			        $ECHO "${CUR_DATE}:${TIME}:${PROG_PIDNAME}:${CALL_HOST}:${USER_NAME}-$1" | $TEE -a $LOG_FILE	
+			        $ECHO "${CUR_DATE}:${TIME}:${PROG_PIDNAME}:${CALL_HOST}:${USER_NAME}-$1" | $TEE -a $LOG_FILE
 				else
 				$ECHO "${CUR_DATE}:${TIME}:${PROG_PIDNAME}:${CALL_HOST}:${USER_NAME}-$1" >> $LOG_FILE
 				fi
@@ -290,7 +290,7 @@ POSTGRES_VERSION_CHK() {
     else
 	VERSION_MATCH=1
     fi
-    
+
 
     LOG_MSG "[INFO]:-End Function $FUNCNAME"
 
@@ -339,8 +339,8 @@ ERROR_CHK () {
 			LOG_MSG "[INFO]:-End Function $FUNCNAME"
 			ERROR_EXIT "[FATAL]:-Failed to complete $MSG_TXT " 2
 		fi
-	fi	
-	LOG_MSG "[INFO]:-End Function $FUNCNAME"	
+	fi
+	LOG_MSG "[INFO]:-End Function $FUNCNAME"
 }
 
 SED_PG_CONF () {
@@ -363,7 +363,7 @@ SED_PG_CONF () {
 				if [ $RETVAL -ne 0 ]; then
 					LOG_MSG "[WARN]:-Failed to append line $SUB_TXT to $FILENAME" 1
 				else
-					LOG_MSG "[INFO]:-Appended line $SUB_TXT to $FILENAME" 
+					LOG_MSG "[INFO]:-Appended line $SUB_TXT to $FILENAME"
 				fi
 			else
 				if [ $KEEP_PREV -eq 0 ];then
@@ -460,29 +460,29 @@ CREATE_SPREAD_MIRROR_ARRAY () {
 	# Current host and subnet we are working on
 	CURRENT_HOST=0
 	CURRENT_SUBNET=0
-	
+
 	# Destination host and subnet
 	DEST_HOST=0
 	DEST_SUBNET=0
-	
+
 	if [ x"$NUM_MHOST_NODE" != x"" ] && [ $NUM_MHOST_NODE -gt 0 ] ; then
 		((DIRS_PER_SUBNET=$NUM_DATADIR/$NUM_MHOST_NODE))
 	else
 		DIRS_PER_SUBNET=$NUM_DATADIR
 	fi
-	
+
 	((MAX_SUBNET=$NUM_DATADIR/$DIRS_PER_SUBNET))
 	((MAX_HOST=${#QE_PRIMARY_ARRAY[@]}/$NUM_DATADIR))
-	
+
 	SEGS_PROCESSED=0
 	SEGS_PROCESSED_HOST=0
 
 
 	# The following is heavily dependent on sort order of primary array.  This sort
-	# order will be affected by hostnames so something non-standard will cause 
-	# strange behaviour.  This isn't new (just recording this fact for future generations) 
+	# order will be affected by hostnames so something non-standard will cause
+	# strange behaviour.  This isn't new (just recording this fact for future generations)
 	# and can be worked around with a mapping file to gpinitsystem (-I option).
-	# The right way to do this would require us to connect to remote hosts, determine 
+	# The right way to do this would require us to connect to remote hosts, determine
 	# what subnet we are on for that hostname and then build the array that way.  We *will*
 	# do this once this is in python (or anything other than BASH)
 	LOG_MSG "[INFO]:-Building spread mirror array type $MULTI_TXT, please wait..." 1
@@ -514,12 +514,12 @@ CREATE_SPREAD_MIRROR_ARRAY () {
 			if [ $DEST_SUBNET -ge $MAX_SUBNET ] ; then DEST_SUBNET=0; fi
 			# Increment the number of segments we've processed for this host
 			((SEGS_PROCESSED_HOST=$SEGS_PROCESSED_HOST+1))
-		fi			
-        
+		fi
+
         # Handle the case where it's a single hostname (thus a single subnet)
 		# This case will mainly be for QA testing
 		if [ $NUM_DATADIR -eq $DIRS_PER_SUBNET ] ; then DEST_SUBNET=0; fi
-		
+
 		# Handle possible loop
 		if [ $DEST_SUBNET -ge $MAX_SUBNET ] ; then DEST_SUBNET=0; fi
 
@@ -561,7 +561,7 @@ CREATE_GROUP_MIRROR_ARRAY () {
 
 	# Current host we are working on
 	CURRENT_HOST=0
-	
+
 	# Destination host and subnet
 	DEST_HOST=0
 	DEST_SUBNET=0
@@ -579,11 +579,11 @@ CREATE_GROUP_MIRROR_ARRAY () {
 		else
 			if [ $(($PRIMARY_INDEX%$DIRS_PER_SUBNET)) -eq 0 ] ; then
 				((DEST_SUBNET=$DEST_SUBNET+1))
-			fi	
+			fi
 		fi
 
 		# Handle possible loop
-		if [ $DEST_SUBNET -ge $MAX_SUBNET ] ; then DEST_SUBNET=0; fi		
+		if [ $DEST_SUBNET -ge $MAX_SUBNET ] ; then DEST_SUBNET=0; fi
 
 		((MIRROR_INDEX=($DEST_HOST*$NUM_DATADIR)+($DEST_SUBNET*$DIRS_PER_SUBNET)))
 
@@ -597,7 +597,7 @@ CREATE_GROUP_MIRROR_ARRAY () {
 		P_REPL_PORT=`$ECHO $QE_LINE|$AWK -F"~" '{print $6}'`
 		GP_M_PORT=$(($P_PORT+$MIRROR_OFFSET))
 		M_REPL_PORT=$(($P_REPL_PORT+$MIRROR_REPLICATION_PORT_OFFSET))
-		
+
 		QE_MIRROR_ARRAY=(${QE_MIRROR_ARRAY[@]} ${QE_M_NAME}~${GP_M_PORT}~${GP_M_DIR}~${DBID_COUNT}~${M_CONTENT}~${M_REPL_PORT})
 		POSTGRES_PORT_CHK $GP_M_PORT $QE_M_NAME
 
@@ -620,8 +620,8 @@ GET_REPLY () {
 		LOG_MSG "[WARN]:-User abort requested, Script Exits!" 1
 		exit 1
 	fi
-} 
-	
+}
+
 CHK_MULTI_HOME () {
 	LOG_MSG "[INFO]:-Start Function $FUNCNAME"
 	GET_QE_DETAILS
@@ -839,56 +839,56 @@ BUILD_PERFMON() {
 	$MKDIR -p $GP_DIR/gpperfmon/conf $GP_DIR/gpperfmon/logs $GP_DIR/gpperfmon/data
 	$CAT <<_EOF_ >> $GP_DIR/gpperfmon/conf/gpperfmon.conf
 [GPMMON]
-# quantum specifies the time in seconds between updates from 
-# performance monitor agents on all segments. Valid values 
+# quantum specifies the time in seconds between updates from
+# performance monitor agents on all segments. Valid values
 # are 10, 15, 20, 30, or 60
 quantum = 15
 
-# min_query_time specifies the minimum query run time 
-# in seconds for statistics collection. The monitor logs all 
-# queries that run longer than this value in the queries_history 
-# table. For queries with shorter run times, no historical 
+# min_query_time specifies the minimum query run time
+# in seconds for statistics collection. The monitor logs all
+# queries that run longer than this value in the queries_history
+# table. For queries with shorter run times, no historical
 # data is collected.
 min_query_time = 20
 
-# Specifies the minimum iterator run time in seconds for 
-# statistics collection. The monitor logs all iterators that 
-# run longer than this value in the iterators_history table. 
-# For iterators with shorter run times, no data is collected. 
+# Specifies the minimum iterator run time in seconds for
+# statistics collection. The monitor logs all iterators that
+# run longer than this value in the iterators_history table.
+# For iterators with shorter run times, no data is collected.
 # Minimum value is 10 seconds.
 min_detailed_query_time = 60
 
 # This should be a percentage between 0 and 100 and should be
-# less than the error_disk_space_percentage.  If a filesystem’s 
-# disk space used percentage equals or exceeds this value a 
-# warning will be logged and a warning email/snmp trap may be 
-# sent.  If this configuration is set to 0 or not specified, no 
+# less than the error_disk_space_percentage.  If a filesystem’s
+# disk space used percentage equals or exceeds this value a
+# warning will be logged and a warning email/snmp trap may be
+# sent.  If this configuration is set to 0 or not specified, no
 # warnings are sent.
 #warning_disk_space_percentage = 80
 
-# This should be a percentage between 0 and 100 and should be 
-# greater than the warning_disk_space_percentage. If a 
-# filesystem’s disk space used percentage equals or exceeds 
-# this value an error will be logged and a error email/snmp 
-# trap may be sent.  If this configuration is set to 0 or not 
+# This should be a percentage between 0 and 100 and should be
+# greater than the warning_disk_space_percentage. If a
+# filesystem’s disk space used percentage equals or exceeds
+# this value an error will be logged and a error email/snmp
+# trap may be sent.  If this configuration is set to 0 or not
 # specified, no errors are sent.
 #error_disk_space_percentage = 90
 
-#This is the interval in minutes that limits the number of 
-#error/warning messages that are sent. The minimum value for 
-#this configuration is 1.  Setting this to 0 or not specifying 
-#this configuration results in it getting set to the minimum.  
+#This is the interval in minutes that limits the number of
+#error/warning messages that are sent. The minimum value for
+#this configuration is 1.  Setting this to 0 or not specifying
+#this configuration results in it getting set to the minimum.
 disk_space_interval = 60
 
-#This is the maximum number of error/warning messages that 
+#This is the maximum number of error/warning messages that
 #will be sent in the disk_space_interval.  The maximum value
-#for this configuration is 50.  The minimum value for this 
-#configuration is 1.  Setting this configuration to greater 
-#than 50 or not specifying this configuration results in it 
+#for this configuration is 50.  The minimum value for this
+#configuration is 1.  Setting this configuration to greater
+#than 50 or not specifying this configuration results in it
 #getting set to the maximum.
 max_disk_space_messages_per_interval = 10
 
-# The number of partitions for statistics data in month 
+# The number of partitions for statistics data in month
 # will be retained. Older partitions will be dropped.
 #partition_age = 6
 
@@ -910,7 +910,7 @@ CHK_DB_RUNNING () {
 		if [ ! -f $MASTER_DATA_DIRECTORY/$PG_PID ]; then
 			LOG_MSG "[FATAL]:-No $MASTER_DATA_DIRECTORY/$PG_PID file" 1
 			ERROR_EXIT "[FATAL]:-Run gpstart to start the Greenplum database." 2
-		fi		
+		fi
 		GET_MASTER_PORT $MASTER_DATA_DIRECTORY
 		export $EXPORT_LIB_PATH;env PGOPTIONS="-c gp_session_role=utility" $PSQL -p $MASTER_PORT -d "$DEFAULTDB" -A -t -c"SELECT d.datname as \"Name\",
        r.rolname as \"Owner\",
@@ -944,7 +944,7 @@ ORDER BY 1;" >> $LOG_FILE 2>&1
 GET_QD_DB_NAME () {
 		LOG_MSG "[INFO]:-Start Function $FUNCNAME"
 		GET_MASTER_PORT $MASTER_DATA_DIRECTORY
-		CHK_DB_RUNNING	
+		CHK_DB_RUNNING
 		#Check if we have PGDATABASE environment variable set, if so see if that database exists
 		if [ x"" != x"$PGDATABASE" ];then
 			LOG_MSG "[INFO]:-PGDATABASE set, checking for this database"
@@ -979,7 +979,7 @@ GET_QE_DETAILS () {
 		else
 		    DBUSER=$PGUSER
 		fi
-		
+
 		if [ $# -eq 0 ];then
 			QE_ARRAY=(`${EXPORT_LIB_PATH};env PGOPTIONS="-c gp_session_role=utility" $PSQL -q -p $MASTER_PORT -U $DBUSER -d "$QD_DBNAME" -A -t -c"select a.hostname, a.datadir, a.port, b.valid, b.definedprimary from $CONFIG_TABLE a, $GP_PG_VIEW b where a.dbid=b.dbid and a.content<>-1 order by b.dbid;"`) > /dev/null 2>&1
 		else
@@ -1062,7 +1062,7 @@ GET_PG_PID_ACTIVE () {
 			if [ $RETVAL -ne 0 ];then
 				PID=0
 				EXIT_STATUS=1
-			else	
+			else
 				PORT_ARRAY=(`$TRUSTED_SHELL $HOST "$NETSTAT -an 2>/dev/null |$GREP ".s.PGSQL.${PORT}" 2>/dev/null"|$AWK '{print $NF}'|$AWK -F"." '{print $NF}'|$SORT -u`)
 				for P_CHK in ${PORT_ARRAY[@]}
 				do
@@ -1230,7 +1230,7 @@ PARALLEL_WAIT () {
 }
 
 PARALLEL_SUMMARY_STATUS_REPORT () {
-	LOG_MSG "[INFO]:-Start Function $FUNCNAME"	
+	LOG_MSG "[INFO]:-Start Function $FUNCNAME"
 	REPORT_FAIL=0
 	if [ -f $1 ];then
 	        KILLED_COUNT=`$GREP -c "KILLED:" $PARALLEL_STATUS_FILE`
@@ -1262,7 +1262,7 @@ PARALLEL_SUMMARY_STATUS_REPORT () {
 }
 
 CHK_GPDB_ID () {
-	LOG_MSG "[INFO]:-Start Function $FUNCNAME"	
+	LOG_MSG "[INFO]:-Start Function $FUNCNAME"
 	if [ -f ${INITDB} ];then
 	        PERMISSION=`ls -al ${INITDB}|$AWK '{print $1}'`
 		MASTER_INITDB_ID=`ls -al ${INITDB}|$AWK '{print $3}'`
@@ -1285,9 +1285,9 @@ CHK_GPDB_ID () {
 			GPDB_GROUPID_CHK=`$ECHO $GPDB_GROUPID|$CUT -c1-$GROUP_INIT_CHAR`
 		else
 			GPDB_GROUPID_CHK=$GPDB_GROUPID
-		fi		
+		fi
 
-		if [ x$GPDB_ID_CHK == x$MASTER_INITDB_ID ] && [ x"x" == x"$USER_EXECUTE" ];then		
+		if [ x$GPDB_ID_CHK == x$MASTER_INITDB_ID ] && [ x"x" == x"$USER_EXECUTE" ];then
 		    LOG_MSG "[INFO]:-Current user id of $GPDB_ID, matches initdb id of $MASTER_INITDB_ID"
 		elif [ x$GPDB_GROUPID_CHK == x$MASTER_INITDB_GROUPID ] && [ x"x" == x"$GROUP_EXECUTE" ] ; then
 		    LOG_MSG "[INFO]:-Current group id of $GPDB_GROUPID, matches initdb group id of $MASTER_INITDB_GROUPID"
@@ -1431,7 +1431,7 @@ case $OS_TYPE in
         	PING6=`findCmdInPath ping6`
 		PING_TIME="-c 1"
 		DF="`findCmdInPath df` -P"
-		DU_TXT="-c" ;;	
+		DU_TXT="-c" ;;
 	freebsd ) IPV4_ADDR_LIST_CMD="$IFCONFIG -a inet"
 		IPV6_ADDR_LIST_CMD="$IFCONFIG -a inet6"
 		LIB_TYPE="LD_LIBRARY_PATH"
@@ -1441,10 +1441,9 @@ case $OS_TYPE in
 		DEFAULT_LOCALE_SETTING=en_US.utf8
 		PING_TIME="-c 1"
 		DF="`findCmdInPath df` -P"
-		DU_TXT="-c" ;;	
+		DU_TXT="-c" ;;
 	* ) echo unknown ;;
 esac
-
 
 GP_LIBRARY_PATH=`$DIRNAME \`$DIRNAME $INITDB\``/lib
 

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 #	Filename:-		gp_bash_functions.sh
-#	Version:-		$Revision$
-#	Updated:-		$Date$
-#	Status:-		Released	
+#	Status:-		Released
 #	Author:-		G L Coombe (Greenplum)
 #	Contact:-		gcoombe@greenplum.com
 #	Release date:-		March 2006
@@ -10,17 +8,6 @@
 #                               Copyright (c) Metapa 2005. All Rights Reserved.
 #                               Copyright (c) Greenplum 2005. All Rights Reserved
 #	Brief descn:-		Common functions used by various scripts
-#******************************************************************************
-# Update History
-#******************************************************************************
-# Ver	Date		Who		Update
-#******************************************************************************
-# Detailed Description
-#******************************************************************************
-#
-#******************************************************************************
-# Prep Code
-#
 #***************************************************************
 # Location Functions
 #******************************************************************************
@@ -96,7 +83,6 @@ findMppPath() {
 AWK=`findCmdInPath awk`
 BASENAME=`findCmdInPath basename`
 CAT=`findCmdInPath cat`
-CLEAR=`findCmdInPath clear`
 CKSUM=`findCmdInPath cksum`
 CUT=`findCmdInPath cut`
 DATE=`findCmdInPath date`
@@ -105,28 +91,16 @@ DIRNAME=`findCmdInPath dirname`
 DF=`findCmdInPath df`
 DU=`findCmdInPath du`
 ECHO=`findCmdInPath echo`
-#ETHTOOL=`findCmdInPath ethtool`
-EXPR=`findCmdInPath expr`
 FIND=`findCmdInPath find`
-TABECHO=$ECHO
-PROMPT="$ECHO"
-#TABECHO="$ECHO -e \t"
-#PROMPT="$ECHO -n -e \t"
 GREP=`findCmdInPath grep`
-GZIPCMD=`findCmdInPath gzip`
 EGREP=`findCmdInPath egrep`
 HEAD=`findCmdInPath head`
 HOSTNAME=`findCmdInPath hostname`
-IPCS=`findCmdInPath ipcs`
 IFCONFIG=`findCmdInPath ifconfig`
-KILL=`findCmdInPath kill`
 LESSCMD=`findCmdInPath less`
-LS=`findCmdInPath ls`
 LOCALE=`findCmdInPath locale`
 MV=`findCmdInPath mv`
-MORECMD=`findCmdInPath more`
 MKDIR=`findCmdInPath mkdir`
-MKFIFO=`findCmdInPath mkfifo`
 NETSTAT=`findCmdInPath netstat`
 PING=`findCmdInPath ping`
 PS=`findCmdInPath ps`
@@ -136,17 +110,13 @@ SCP=`findCmdInPath scp`
 SED=`findCmdInPath sed`
 SLEEP=`findCmdInPath sleep`
 SORT=`findCmdInPath sort`
-SPLIT=`findCmdInPath split`
 SSH=`findCmdInPath ssh`
 TAIL=`findCmdInPath tail`
-TAR=`findCmdInPath tar`
 TEE=`findCmdInPath tee`
 TOUCH=`findCmdInPath touch`
-#PTIME=`findCmdInPath ptime`
 TR=`findCmdInPath tr`
 WC=`findCmdInPath wc`
 WHICH=`findCmdInPath which`
-WHOAMI=`findCmdInPath whoami`
 ZCAT=`findCmdInPath zcat`
 #***************#******************************************************************************
 # Script Specific Variables
@@ -175,36 +145,24 @@ SCRIPTDIR="`$DIRNAME $PSQLBIN`/bin"
 #******************************************************************************
 # Greenplum Scripts
 #******************************************************************************
-GPACTIVATEMASTER=$SCRIPTDIR/gpactivatemaster
-GPACTIVATESTANDBY=$SCRIPTDIR/gpactivatestandby
-GPADDMIRRORS=$SCRIPTDIR/gpaddmirrors
 GPINITSYSTEM=$SCRIPTDIR/gpinitsystem
 GPCONFIG=$SCRIPTDIR/gpconfig
 GPCRONDUMP=$SCRIPTDIR/gpcrondump
-GPDELETESYSTEM=$SCRIPTDIR/gpdeletesystem
 GPINITSTANDBY=$SCRIPTDIR/gpinitstandby
-GPREBUILDCLUSTER=$SCRIPTDIR/gprebuildcluster
 GPRECOVERSEG=$SCRIPTDIR/gprecoverseg
 GPSTART=$SCRIPTDIR/gpstart
 GPSTATE=$SCRIPTDIR/gpstate
 GPSTOP=$SCRIPTDIR/gpstop
-MAILFILE=$SCRIPTDIR/mail_contacts
-HMAILFILE=$HOME/mail_contacts
 GPDOCDIR=${GPHOME}/docs/cli_help/
-GPSUBSCRIPTDIR=${SCRIPTDIR}/lib
 #******************************************************************************
 # Greenplum Command Variables
 #******************************************************************************
 INITDB=$PSQLBIN/initdb
-MPPLOADER=$CMDBIN/loader.sh
 PG_CTL=$PSQLBIN/pg_ctl
 PG_DUMP=$PSQLBIN/pg_dump
 PG_DUMPALL=$PSQLBIN/pg_dumpall
 PG_RESTORE=$PSQLBIN/pg_restore
 PSQL=$PSQLBIN/psql
-GP_DUMP=$PSQLBIN/gp_dump
-GP_RESTORE=$PSQLBIN/gp_restore
-GPSYNCMASTER=$PSQLBIN/gpsyncmaster
 
 
 GPLISTDATABASEQTY="SELECT d.datname as \"Name\",
@@ -228,7 +186,6 @@ PG_HBA=pg_hba.conf
 if [ x"$TRUSTED_SHELL" = x"" ]; then TRUSTED_SHELL="$SSH"; fi
 if [ x"$TRUSTED_COPY" = x"" ]; then TRUSTED_COPY="$SCP"; fi
 PG_CONF_ADD_FILE=$WORKDIR/postgresql_conf_gp_additions
-RECOVER_FLAG=/tmp/active_recovery_in_progress
 SCHEMA_FILE=cdb_schema.sql
 DEFAULTDB=template1
 
@@ -243,22 +200,7 @@ CONFIG_TABLE="(SELECT dbid, content, role, preferred_role, mode, status,
 GP_PG_VIEW="(SELECT dbid, role = 'p' as isprimary, content, status = 'u' as valid,
 		preferred_role = 'p' as definedprimary FROM gp_segment_configuration)"
 
-ACTIVITY_TABLE=pg_stat_activity
-GP_INITDB_VER_TABLE=gp_version_at_initdb
-CLASS_TABLE=pg_class
-EXTERNAL_TABLE=pg_exttable
-SCHEMA_TABLE=pg_namespace
-ATTRIBUTE_TABLE=pg_attribute
-INHERIT_TABLE=pg_inherits
-INDEX_TABLE=pg_indexes
-TYPE_TABLE=pg_type
-CONSTRAINT_TABLE=pg_constraint
-RULES_TABLE=pg_rules
-PG_SIZE_FUNC=pg_relation_size
-DISTRIB_TABLE=gp_distribution_policy
-CHILD_TABLE_ID="_c_d_"
 DEFAULT_CHK_PT_SEG=8
-#DEFAULT_IP_ALLOW="0.0.0.0/0"
 DEFAULT_QD_MAX_CONNECT=250
 QE_CONNECT_FACTOR=3
 # DEFAULT_BUFFERS sets the default shared_buffers unless overridden by '-b'.
@@ -270,7 +212,6 @@ DEBUG_LEVEL=0
 BATCH_DEFAULT=60
 WAIT_LIMIT=1800
 WARN_MARK="<<<<<"
-IDX_TYPE_ARRAY=(btree bitmap hash)
 #******************************************************************************
 # Functions
 #******************************************************************************
@@ -282,24 +223,6 @@ IN_ARRAY () {
         fi
     done
     return 0
-}
-
-CHK_DB_QD_SET () {
-		if [ ! $MASTER_DATA_DIRECTORY ]; then
-				ERROR_EXIT "[FATAL]:-MASTER_DATA_DIRECTORY parameter not set, update user start-up file [i.e. .bashrc]." 2
-		fi
-}
-
-VERSION_INFO () {
-		VERSION=`$HEAD -10 $0|$GREP -i Version: | $CUT -d# -f2|$CUT -d- -f2|$TR -d '\t'`
-		STATUS=`$HEAD -10 $0|$GREP -i Status: | $CUT -d# -f2|$CUT -d- -f2|$TR -d '\t'`
-		UPDATE=`$HEAD -10 $0|$GREP -i Updated:| $CUT -d# -f2|$CUT -d- -f2|$TR -d '\t'`
-		CHK_SUM=`$CKSUM $0|$AWK '{print $1" "$2}'`
-		$ECHO "`basename $0` Version   = $VERSION"
-		$ECHO "`basename $0` Status    = $STATUS"
-		$ECHO "`basename $0` Update    = $UPDATE"
-		$ECHO "`basename $0` Check sum = $CHK_SUM"
-		exit 0
 }
 
 LOG_MSG () {
@@ -389,26 +312,6 @@ ERROR_EXIT () {
 				fi
 		fi
 		exit $2
-	LOG_MSG "[INFO]:-End Function $FUNCNAME"
-}
-
-READ_CHK () {
-	LOG_MSG "[INFO]:-Start Function $FUNCNAME"
-	NROWS=`env PGOPTIONS="-c gp_session_role=utility" $PSQL -A -t -p $MASTER_PORT -d "$DEFAULTDB" -c" select * from $CONFIG_TABLE a where port<0;"`
-	RETVAL=$?
-	if [ $RETVAL -ne 0 ];then
-		READ_COUNT=0
-		#Could not connect to database so set read count to zero
-		LOG_MSG "[WARN]:-Could not obtain read count from database"
-		EXIT_STATUS=1
-	else
-		if [ x"" == x"$NROWS" ];then
-			READ_COUNT=0
-		else
-			READ_COUNT=`$ECHO $NROWS|$WC -l`
-		fi
-		LOG_MSG "[INFO]:-Obtained -ve port read count $READ_COUNT"
-	fi
 	LOG_MSG "[INFO]:-End Function $FUNCNAME"
 }
 
@@ -537,206 +440,7 @@ SED_PG_CONF () {
 
 CHK_EXTERNAL () {
 	LOG_MSG "[INFO]:-Start Function $FUNCNAME"
-	EXTERNAL=`$EXPORT_LIB_PATH;$PSQL -A -t -q -p  $MASTER_PORT -d "$QD_DBNAME" -c"select 1 from $EXTERNAL_TABLE where reloid in (select oid from $CLASS_TABLE where relname='$TABLENAME' and relnamespace in (select oid from $SCHEMA_TABLE where nspname='$SCHEMA_NAME'));"|$WC -l`
-	LOG_MSG "[INFO]:-End Function $FUNCNAME"
-}
-
-
-# Specifies the regular expressions used to parse a qualified table name.
-declare -r TABLE_IDENTIFIER_PATTERN='((")((([^"]{1,})|""){1,})")|([^".]{1,})'
-declare -r QUALIFIED_TABLE_IDENTIFIER_PATTERN="^((${TABLE_IDENTIFIER_PATTERN})\\.){0,1}(${TABLE_IDENTIFIER_PATTERN})$"
-
-GET_TABLE_IDENTIFIER () {
-    # -----------------------------------------------------------------
-    # Parses a properly quoted, fully-qualified SQL table name into
-    # the schema and table name parts.  If a part is quoted, the quotes
-    # are removed; if a part is not quoted, the part is lower-cased.
-    #
-    # The schema name, if any, is returned in ${SQL_NAME[0]}, the
-    # "quoted" version in ${SQL_NAME[2]}; the table name is returned 
-    # in ${SQL_NAME[1]}, the "quoted" version in ${SQL_NAME[3]}.
-    # 
-    # Quoted identifiers can contain any character, except the 
-    # character with code zero. (To include a double quote, write two 
-    # double quotes.)
-    # -----------------------------------------------------------------
-    if PARSE_TABLE_IDENTIFIER "${1}" ; then
-        # Get schema name; may be omitted
-        if [ "${BASH_REMATCH[2]}" ] ; then
-            if [ "${BASH_REMATCH[4]}" ] ; then
-                # Quoted name; undouble quotes but otherwise take literally
-                SQL_NAME[0]="${BASH_REMATCH[5]//\"\"/\"}"
-                SQL_NAME[2]="\"${BASH_REMATCH[5]}\""
-            else
-                # Unquoted name; make lower-case
-                if [ "$OS_TYPE" == "sunos" ] ; then
-                	SQL_NAME[0]=$($ECHO "${BASH_REMATCH[2]}" | $MBTR '[:upper:]' '[:lower:]')
-                else
-                	SQL_NAME[0]=$($ECHO "${BASH_REMATCH[2]}" | $TR '[:upper:]' '[:lower:]')
-                fi
-                SQL_NAME[2]="${SQL_NAME[0]}"
-            fi
-        else
-            SQL_NAME[0]=
-        fi
-        # Get table name
-        if [ "${BASH_REMATCH[11]}" ] ; then
-            # Quoted name; undouble quotes but otherwise take literally
-            SQL_NAME[1]="${BASH_REMATCH[12]//\"\"/\"}"
-            SQL_NAME[3]="\"${BASH_REMATCH[12]}\""
-        else
-            # Unquoted name; make lower-case
-            if [ "$OS_TYPE" == "sunos" ] ; then
-                SQL_NAME[1]=$($ECHO "${BASH_REMATCH[9]}" | $MBTR '[:upper:]' '[:lower:]')
-            else
-                SQL_NAME[1]=$($ECHO "${BASH_REMATCH[9]}" | $TR '[:upper:]' '[:lower:]')
-            fi            
-            SQL_NAME[3]="${SQL_NAME[1]}"
-        fi
-    else
-        SQL_NAME=('' '' '' '')
-    fi
-}
-
-# Determine if the bash regular expression operator '=~' is supported.
-# If so, define the version of PARSE_TABLE_IDENTIFER using the operator;
-# otherwise, use the sed-based version.
-if $BASH -c '[[ "string" =~ string ]]' 2>/dev/null ; then
-    eval 'PARSE_TABLE_IDENTIFIER () {
-        [[ "${1}" =~ ${QUALIFIED_TABLE_IDENTIFIER_PATTERN} ]]
-    }'
-else
-    # Determine the option, if any, for sed to enable support of the regular
-    # expression used to parse the qualified table identifier.
-    for reOption in "-r" "-E" ""; do
-        reTest=$($ECHO "\"Mixed Case\".\"TableName\"" | $SED ${reOption} -e "s/${QUALIFIED_TABLE_IDENTIFIER_PATTERN}/\\9/" 2>/dev/null)
-        if [ $? -eq 0 ] && [ "${reTest}" == "\"TableName\"" ] ; then
-            break
-        fi
-        reOption=
-    done
-    unset reTest
-    if [ ! "${reOption}" ] ; then
-        ERROR_EXIT "[FATAL]:-$SED lacks support for the regular expression used to parse qualified table identifiers" 2
-    fi
-
-    # The PARSE_TABLE_IDENTIFIER function provides a functional replacement for a 
-    # [[ "${1}" =~ ${QUALIFIED_TABLE_IDENTIFIER} ]] statement that could be used
-    # in the GET_TABLE_IDENTIFIER function in newer versions of BASH.  Once support
-    # for "old" BASH is dropped, the call to this function should be replaced with
-    # the BASH regular expression pattern matching expression above.  (Attempts to
-    # conditionally use the =~ operator fail BASH syntax checking.)
-    PARSE_TABLE_IDENTIFIER () {
-        local nl=$'\\\n'
-        local nullTag=$'~\t~'
-        names="$($ECHO "${1}" | $SED ${reOption} -n -e "
-            p
-            h
-            # Process the schema portion of the name
-            s/${QUALIFIED_TABLE_IDENTIFIER_PATTERN}/${nl}\\1${nl}\\2${nl}\\3${nl}\\4${nl}\\5${nl}\\6${nl}\\7${nl}\\8/
-            x
-            # Reduce to table portion of the name (must have)
-            s/${QUALIFIED_TABLE_IDENTIFIER_PATTERN}/\\9/
-            t haveTable
-            q
-            :haveTable
-            s/(${TABLE_IDENTIFIER_PATTERN})$/\\1${nl}\\2${nl}\\3${nl}\\4${nl}\\5${nl}\\6${nl}\\7${nl}/
-            H
-            g
-            # Word splitting eliminates adjacent separators; provide a "null" value
-            :setNulls
-            s/\\n\\n/${nl}${nullTag}${nl}/g
-            t setNulls
-            p
-            ")"
-        local oldIFS="${IFS}"
-        IFS=$'\n'
-        BASH_REMATCH=(${names})
-        IFS="${oldIFS}"
-        if [ "${#BASH_REMATCH[@]}" -eq 1 ]
-        then
-            # No table name appeared (only original string is in ${names}
-            BASH_REMATCH=()
-            return 1
-        else
-            # Reduce the "null" value to an actual empty string
-            local i
-            for (( i=0; i <"${#BASH_REMATCH[@]}"; i++ )); do
-                [ "${BASH_REMATCH[$i]}" == "${nullTag}" ] && BASH_REMATCH[$i]=""
-            done
-        fi
-        return 0
-    }
-
-fi
-
-CHK_EXISTS_TABLE () {
-	LOG_MSG "[INFO]:-Start Function $FUNCNAME"
-	TABLENAME="$1"
-	MASTER_PORT=$2
-	QD_DBNAME=$3
-	if [ $# -ne 3 ];then
-		ERROR_EXIT "[FATAL]:-Incorrect number of parameters passed expected 3 got $#" 2;fi
-	DB_THERE=`$EXPORT_LIB_PATH;$PSQL -A -t -q -p  $MASTER_PORT -d "$DEFAULTDB" -c"select 1 from pg_database where datname='$QD_DBNAME';" |$WC -l`
-	if [ $DB_THERE -eq 0 ];then
-		ERROR_EXIT "[FATAL]:-Database $QD_DBNAME does not exist" 2
-	fi
-	LOG_MSG "[INFO]:-Checking for table $TABLENAME in database $QD_DBNAME"
-	GET_TABLE_IDENTIFIER "$TABLENAME"
-	SCHEMA_NAME="${SQL_NAME[0]}"
-	QUOTED_SCHEMA_NAME="${SQL_NAME[2]}"
-	TABLENAME="${SQL_NAME[1]}"
-	QUOTED_TABLENAME="${SQL_NAME[3]}"
-	if [ "${SCHEMA_NAME}" ];then
-		TMP_OUT=`$EXPORT_LIB_PATH;$PSQL -A -t -q -p  $MASTER_PORT -d "$QD_DBNAME" -c"select 1 from pg_class where relname='$TABLENAME' and relnamespace in (select oid from pg_namespace where nspname='$SCHEMA_NAME');"`
-		TAB_COUNT=`$EXPORT_LIB_PATH;$PSQL -A -t -q -p  $MASTER_PORT -d "$QD_DBNAME" -c"select 1 from pg_class where relname='$TABLENAME' and relnamespace in (select oid from pg_namespace where nspname='$SCHEMA_NAME');" |$WC -l`
-		if [ $TAB_COUNT -eq 1 ];then
-			LOG_MSG "[INFO]:-Found table ${QUOTED_SCHEMA_NAME}.${QUOTED_TABLENAME} in database $QD_DBNAME"
-			CHK_EXTERNAL
-			PARTITIONED=`$EXPORT_LIB_PATH;$PSQL -A -t -q -p  $MASTER_PORT -d "$QD_DBNAME" -c"select relhassubclass from pg_class where relname='$TABLENAME' and relnamespace in (select oid from pg_namespace where nspname='$SCHEMA_NAME');"`
-		fi
-	else
-	    TMP_OUT=`$EXPORT_LIB_PATH;$PSQL -A -t -q -p  $MASTER_PORT -d "$QD_DBNAME" -c"select 1 from pg_class where relname='$TABLENAME';"`
-		TAB_COUNT=`$EXPORT_LIB_PATH;$PSQL -A -t -q -p  $MASTER_PORT -d "$QD_DBNAME" -c"select 1 from pg_class where relname='$TABLENAME';" |$WC -l`
-		if [ $TAB_COUNT -eq 1 ];then
-			PARTITIONED=`$EXPORT_LIB_PATH;$PSQL -A -t -q -p  $MASTER_PORT -d "$QD_DBNAME" -c"select relhassubclass from pg_class where relname='$TABLENAME';"`
-			SCHEMA_NAME=`$EXPORT_LIB_PATH;$PSQL -A -t -q -p  $MASTER_PORT -d "$QD_DBNAME" -c"select nspname from pg_namespace where oid in(select relnamespace from pg_class where relname='$TABLENAME');"`
-			CHK_EXTERNAL
-		fi
-	fi
-#		$EXPORT_LIB_PATH;$PSQL -q -p  $MASTER_PORT -d "$QD_DBNAME" -c"\d $TABLENAME;" -o /dev/null
-	if [ $TAB_COUNT -eq 0 ] || [ $TAB_COUNT -gt 1 ];then
-		EXISTS=1
-	else
-		EXISTS=0
-	fi
-	LOG_MSG "[INFO]:-End Function $FUNCNAME"
-}
-
-EVENT_MAIL () {
-	LOG_MSG "[INFO]:-Start Function $FUNCNAME"
-	case $OS_TYPE in
-		sunos ) MAIL=/bin/mailx ;;
-		*) MAIL=`findCmdInPath mail` ;;
-	esac
-	MAIL_SUBJECT=$1;shift
-	MAIL_MESSAGE=$1
-	if [ ! -f $MAILFILE ] && [ ! -f $HMAILFILE ] ;then
-		LOG_MSG "[WARN]:-No $MAILFILE" 1
-		LOG_MSG "[WARN]:-or $HMAILFILE" 1
-		LOG_MSG "[WARN]:-Unable to send email notification" 1
-		LOG_MSG "[INFO]:-To enable email notification, create $MAILFILE" 1
-		LOG_MSG "[INFO]:-or $HMAILFILE containing required email addresses" 1
-		EXIT_STATUS=1
-	else
-		if [ -f $HMAILFILE ];then MAILFILE=$HMAILFILE;fi
-		for MAIL_ADDRESS in `$CAT $MAILFILE | $GREP -v "^#"`
-		do
-			LOG_MSG "[INFO]:-Sending mail to $MAIL_ADDRESS using file $MAILFILE" 1
-			$ECHO "$MAIL_MESSAGE"|$MAIL -s "$MAIL_SUBJECT" $MAIL_ADDRESS
-			ERROR_CHK $? "send email to $MAIL_ADDRESS" 1
-		done
-	fi
+	EXTERNAL=`$EXPORT_LIB_PATH;$PSQL -A -t -q -p  $MASTER_PORT -d "$QD_DBNAME" -c"select 1 from pg_exttable where reloid in (select oid from pg_class where relname='$TABLENAME' and relnamespace in (select oid from pg_namespace where nspname='$SCHEMA_NAME'));"|$WC -l`
 	LOG_MSG "[INFO]:-End Function $FUNCNAME"
 }
 
@@ -836,14 +540,6 @@ CREATE_SPREAD_MIRROR_ARRAY () {
 		((SEGS_PROCESSED=$SEGS_PROCESSED+1))
 	done
 	if [ $DEBUG_LEVEL -eq 0 ] && [ x"" != x"$VERBOSE" ];then $ECHO;fi
-	LOG_MSG "[INFO]:-End Function $FUNCNAME"
-}
-
-GET_MAX_LEN () {
-	LOG_MSG "[INFO]:-Start Function $FUNCNAME"
-	LOG_MSG "[INFO]:-Formatting output, please wait..." 1
-	GET_MASTER_PORT $MASTER_DATA_DIRECTORY
-	LEN_ARRAY=(`$EXPORT_LIB_PATH;env PGOPTIONS="-c gp_session_role=utility" $PSQL -F" " -A -t -q -p  $MASTER_PORT -d "$DEFAULTDB" -c"select max(length(hostname))+1, max(length(port))+1, max(length(datadir))+1, max(length(content))+1, max(length(dbid)) from $CONFIG_TABLE a where content<>-1;"`)
 	LOG_MSG "[INFO]:-End Function $FUNCNAME"
 }
 
@@ -964,46 +660,6 @@ CHK_MULTI_HOME () {
 	LOG_MSG "[INFO]:-End Function $FUNCNAME"
 }
 
-GET_DISTRIB_COLS () {
-	LOG_MSG "[INFO]:-Start Function $FUNCNAME"
-	if [ $# -ne 3 ];then
-		ERROR_EXIT "[FATAL]:-Incorrect # parameters supplied, got $# expected 3" 2;fi
-	T_NAME=$1
-	if [ `$ECHO $1|$GREP -c "\."` -eq 1 ];then
-		T_NAME=`$ECHO $1|$CUT -d"." -f2`
-		S_NAME=`$ECHO $1|$CUT -d"." -f1`
-		DISTRIB_COLS=`${EXPORT_LIB_PATH};$PSQL -p $2 -d "$3" -A -t -c"select attrnums from  $DISTRIB_TABLE  where localoid in (select oid from pg_class where relname='${T_NAME}' and relnamespace in (select oid from pg_namespace where nspname='${S_NAME}'));"`
-		if [ x"" == x"$DISTRIB_COLS" ];then
-			DISTRIB_COLS='';fi
-	else
-		LOG_MSG "[WARN]:-Incorrect table name sent to function, should be schema.tablename" 1
-		ERROR_EXIT "[FATAL]:-Error in $FUNCNAME parameters" 2
-	fi
-	LOG_MSG "[INFO]:-End Function $FUNCNAME"
-}
-
-GET_TABLE_TYPE () {
-	LOG_MSG "[INFO]:-Start Function $FUNCNAME"
-	if [ $# -ne 3 ];then
-		ERROR_EXIT "[FATAL]:-Incorrect # parameters supplied, got $# expected 3" 2;fi
-	T_NAME=$1
-	if [ `$ECHO $1|$GREP -c "\."` -eq 1 ];then
-		T_NAME=`$ECHO $1|$CUT -d"." -f2`
-		S_NAME=`$ECHO $1|$CUT -d"." -f1`
-		TAB_TYPE=`${EXPORT_LIB_PATH};$PSQL -p $2 -d "$3" -A -t -c"select 1 from pg_depend where objid in (select oid from pg_class where relname='${T_NAME}' and relnamespace in (select oid from pg_namespace where nspname='${S_NAME}')) and refobjid not in (select relnamespace from pg_class where relname='${T_NAME}' and relnamespace in (select oid from pg_namespace where nspname='${S_NAME}'));"|$WC -l`
-		if [ $TAB_TYPE -eq 1 ];then
-			TAB_TYPE_TXT="Child table"
-			TAB_PARENT_NAME=(`${EXPORT_LIB_PATH};$PSQL -p $2 -d "$3" -R" " -A -t -c"select relname from pg_class where oid in (select refobjid from pg_depend  where objid in (select oid from pg_class where relname='${T_NAME}' and relnamespace in (select oid from pg_namespace where nspname='${S_NAME}')) and refobjid not in (select relnamespace from pg_class where relname='${T_NAME}' and relnamespace in (select oid from pg_namespace where nspname='${S_NAME}')));"`)
-		else
-			TAB_TYPE_TXT="Not child table"
-		fi
-	else
-		LOG_MSG "[WARN]:-Incorrect table name sent to function, should be schema.tablename" 1
-		ERROR_EXIT "[FATAL]:-Error in $FUNCNAME parameters" 2
-	fi
-	LOG_MSG "[INFO]:-End Function $FUNCNAME"
-}
-	
 CHK_FILE () {
 		LOG_MSG "[INFO]:-Start Function $FUNCNAME"
 		FILENAME=$1
@@ -1050,26 +706,6 @@ CHK_DIR () {
 		fi
 }
 
-CHK_WRITE_DIR () {
-	LOG_MSG "[INFO]:-Start Function $FUNCNAME"
-	DIR_NAME=$1;shift
-	DIR_HOST=$1;shift
-	NOEXIT=$1
-	LOG_MSG "[INFO]:-Checking write access to $DIR_NAME on $DIR_HOST"
-	$TRUSTED_SHELL $DIR_HOST "$TOUCH ${DIR_NAME}/tmp_file_test"
-	RETVAL=$?
-	if [ $RETVAL -ne 0 ];then
-		if [ x"" == x"$NOEXIT" ];then
-			ERROR_EXIT "[FATAL]:-Cannot write to $DIR_NAME on $DIR_HOST" 2
-		else
-			LOG_MSG "[FATAL]:-Cannot write to $DIR_NAME on $DIR_HOST" 1
-		fi
-	else
-		$TRUSTED_SHELL $DIR_HOST "$RM -f ${DIR_NAME}/tmp_file_test"
-	LOG_MSG "[INFO]:-Write test passed on $DIR_HOST $DIR_NAME directory"
-	fi
-	LOG_MSG "[INFO]:-End Function $FUNCNAME"
-}
 GET_MASTER_PORT () {
 		LOG_MSG "[INFO]:-Start Function $FUNCNAME"
 		MASTER_DATA_DIRECTORY=$1
@@ -1121,30 +757,6 @@ GET_MASTER_PORT_RECUR () {
     else
         ERROR_EXIT "[FATAL]:-Could not open configuration file \"$INCLUDED_FILE\": maximum nesting depth exceeded"
     fi
-}
-
-CHK_ON_PASSIVE_STANDBY () {
-	LOG_MSG "[INFO]:-Start Function $FUNCNAME"
-	GPSYNC_COUNT=0
-	CHK_DB_QD_SET
-	GET_MASTER_PORT $MASTER_DATA_DIRECTORY
-	GET_PG_PID_ACTIVE $MASTER_PORT
-	if [ -f $MASTER_DATA_DIRECTORY/postmaster.opts ];then
-		GPSYNC_COUNT=`$GREP -c gpsync $MASTER_DATA_DIRECTORY/postmaster.opts`
-	fi
-	if [ $PID -ne 0 ] && [ $GPSYNC_COUNT -ne 0 ];then
-		LOG_MSG "[FATAL]:-Cannot run this script on a passive standby instance" 1
-		LOG_MSG "[FATAL]:-where there is a conflict with the current value of" 1
-		LOG_MSG "[FATAL]:-the MASTER_DATA_DIRECTORY environment variable setting." 1
-		ERROR_EXIT "[FATAL]:-Unable to process requested command" 2
-	fi
-	if [ $GPSYNC_COUNT -ne 0 ];then
-		LOG_MSG "[FATAL]:-Cannot run this script on the standby instance" 1
-		LOG_MSG "[FATAL]:-Status indicates that standby instance processs not running" 1
-		LOG_MSG "[FATAL]:-Check standby process status via gpstate -f on Master instance" 1
-		ERROR_EXIT "[FATAL]:-Unable to process requested command" 2
-	fi
-	LOG_MSG "[INFO]:-End Function $FUNCNAME"
 }
 
 GET_CIDRADDR () {
@@ -1359,33 +971,6 @@ GET_QD_DB_NAME () {
 		LOG_MSG "[INFO]:-End Function $FUNCNAME"
 }
 
-GET_STANDBY_COUNT () {
-	LOG_MSG "[INFO]:-Start Function $FUNCNAME"
-	GET_QD_DB_NAME
-	STANDBY_COUNT=`${EXPORT_LIB_PATH};env PGOPTIONS="-c gp_session_role=utility" $PSQL -q -p $MASTER_PORT -d "$QD_DBNAME" -A -t -c"select 1 from $CONFIG_TABLE a where content=-1 and dbid<>1 ;"|$WC -l`
-	ERROR_CHK $? "obtain standby master host count" 1
-	LOG_MSG "[INFO]:-End Function $FUNCNAME"
-}
-
-GET_STANDBY_DETAILS () {
-	LOG_MSG "[INFO]:-Start Function $FUNCNAME"
-	GET_QD_DB_NAME
-	STANDBY_ARRAY=(`${EXPORT_LIB_PATH};env PGOPTIONS="-c gp_session_role=utility" $PSQL -q -p $MASTER_PORT -d "$QD_DBNAME" -A -t -c"select hostname, datadir, port, mode, status, preferred_role, role from $CONFIG_TABLE a where content=-1 and dbid<>1"`) > /dev/null 2>&1
-	RETVAL=$?
-	if [ $RETVAL -ne 0 ]; then
-		LOG_MSG "[INFO]:-Unable to obtain standby master details, error code $RETVAL returned" 1
-		EXIT_STATUS=1
-	fi
-	LOG_MSG "[INFO]:-End Function $FUNCNAME"
-}
-
-GET_TRANS_READ () {
-	LOG_MSG "[INFO]:-Start Function $FUNCNAME"
-	TRANS_STATE=`${EXPORT_LIB_PATH};$PSQL -q -p $MASTER_PORT -d "$QD_DBNAME" -A -t -c"show transaction_read_only;"|$AWK '{print $NF}'`
-	ERROR_CHK $? "obtain transaction state" 1
-	LOG_MSG "[INFO]:-End Function $FUNCNAME"
-}
-
 GET_QE_DETAILS () {
 		LOG_MSG "[INFO]:-Start Function $FUNCNAME"
 		GET_QD_DB_NAME
@@ -1409,95 +994,12 @@ GET_QE_DETAILS () {
 		LOG_MSG "[INFO]:-End Function $FUNCNAME"
 }
 
-GET_DB_LIST () {
-	LOG_MSG "[INFO]:-Start Function $FUNCNAME"
-	GET_MASTER_PORT $MASTER_DATA_DIRECTORY
-	DB_ARRAY=(`env PGOPTIONS="-c gp_session_role=utility" $PSQL -q -p $MASTER_PORT -d "$DEFAULTDB" -A -t -c"select datname from pg_database where datname not in ('template1', 'template0', 'postgres');"`)
-	LOG_MSG "[INFO]:-End Function $FUNCNAME"
-}
-
 CHK_MIRRORS_CONFIGURED () {
 	LOG_MSG "[INFO]:-Start Function $FUNCNAME"
 	MIRROR_COUNT=`${EXPORT_LIB_PATH};env PGOPTIONS="-c gp_session_role=utility" $PSQL -p $MASTER_PORT -d "$DEFAULTDB" -A -t -c"select count(dbid)/count(distinct(content)) from $CONFIG_TABLE a where content<>-1;"`
 	ERROR_CHK $? "obtain mirror count from master instance" 2
 	LOG_MSG "[INFO]:-Obtained $MIRROR_COUNT as check value"
 	LOG_MSG "[INFO]:-End Function $FUNCNAME"
-}
-
-GET_MIRROR_TYPE () {
-	LOG_MSG "[INFO]:-Start Function $FUNCNAME"
-	CHK_MIRRORS_CONFIGURED
-	if [ $MIRROR_COUNT -eq 1 ];then
-		MIR_TYPE="No Mirror";MIR_TYPE_NUM=0
-	else
-		SEP_COUNT=`${EXPORT_LIB_PATH};$PSQL -p $MASTER_PORT -d "$DEFAULTDB" -A -t -c"select count(distinct hostname)/(select count(distinct hostname) from $CONFIG_TABLE a where preferred_role = 'p' and content<>-1) from $CONFIG_TABLE a where content<>-1;"`
-		if [ $SEP_COUNT -eq 2 ];then
-			SEP_TEXT="[Separate array]"
-		else
-			SEP_TEXT="[Shared array]"
-		fi
-		#Get number of primary hosts
-		NUM_SEG_HOSTS=`${EXPORT_LIB_PATH};$PSQL -p $MASTER_PORT -d "$DEFAULTDB" -A -t -c"select count(distinct(hostname)) from $CONFIG_TABLE a where content<>-1;"`
-		#Get the primary and mirror hostnames for the first segment instance host
-		FIRST_PRI_MIR_ARRAY=(`${EXPORT_LIB_PATH};$PSQL -p $MASTER_PORT -d "$DEFAULTDB" -A -t -c"select hostname, content from $CONFIG_TABLE a where content>-1 and content<(select max(port)-min(port)+1 from $CONFIG_TABLE a where content<>-1 and preferred_role='p') order by content,dbid;"|$TR '\n' ' '`)
-		((SEG_PER_HOST=${#FIRST_PRI_MIR_ARRAY[@]}/2))
-		CHK_MULTI_HOME
-		if [ $MULTI_HOME -eq 0 ];then
-			if [ `$ECHO ${FIRST_PRI_MIR_ARRAY[@]}|$TR ' ' '\n'|$AWK -F"|" '{print $1}'|$SORT -u|$WC -l` -eq 2 ] || [ $NUM_SEG_HOSTS -eq 1 ];then
-				MIR_TYPE="Group [Single-home] $SEP_TEXT";MIR_TYPE_NUM=1
-			else
-				MIR_TYPE="Spread [Single-home] $SEP_TEXT";MIR_TYPE_NUM=2
-			fi
-		else
-			J=0
-			MIR_H_NAME_ARRAY=()
-			while [ $J -lt $SEG_PER_HOST ]
-			do
-				MIR_HOST=`$ECHO ${FIRST_PRI_MIR_ARRAY[@]}|$TR ' ' '\n'|$GREP "|${J}$"|$AWK -F"|" '{print $1}'|$TAIL -1`
-				PRI_HOST=`$ECHO ${FIRST_PRI_MIR_ARRAY[@]}|$TR ' ' '\n'|$GREP "|${J}$"|$AWK -F"|" '{print $1}'|$HEAD -1`
-				#MIR_H_HOST=`$ECHO ${MULTI_ARRAY[@]}|$TR ' ' '\n'|$GREP "${MIR_HOST}~"|$SORT -u|$AWK -F"~" '{print $2}'`
-				MIR_H_CONFIG_HOST=`${EXPORT_LIB_PATH};$PSQL -p $MASTER_PORT -d "$DEFAULTDB" -A -t -c"select hostname from $CONFIG_TABLE a where hostname<>'${PRI_HOST}' and content=${J};"`
-				MIR_H_HOST=`$TRUSTED_SHELL $MIR_H_CONFIG_HOST "$HOSTNAME"|$AWK '{print $1}'`
-				#MIR_HOST_VAL=`$TRUSTED_SHELL $MIR_HOST "$HOSTNAME"`
-				MIR_H_NAME_ARRAY=(${MIR_H_NAME_ARRAY[@]} $MIR_H_HOST)
-				#MIR_H_NAME_ARRAY=(${MIR_H_NAME_ARRAY[@]} $MIR_HOST_VAL)
-				((J=$J+1))
-			done
-			UNIQ_COUNT=`$ECHO ${MIR_H_NAME_ARRAY[@]}|$TR ' ' '\n'|$SORT -u|$WC -l`
-			if [ $UNIQ_COUNT -eq 1 ];then
-				MIR_TYPE="Group [Multi-home] $SEP_TEXT";MIR_TYPE_NUM=3
-			else
-				MIR_TYPE="Spread [Multi-home] $SEP_TEXT";MIR_TYPE_NUM=4;fi
-		
-		fi	
-	fi
-	LOG_MSG "[INFO]:-End Function $FUNCNAME"
-}
-
-GET_QE_PRIMARY_DETAILS () {
-		LOG_MSG "[INFO]:-Start Function $FUNCNAME"
-		GET_QD_DB_NAME
-		QE_PRIMARY_ARRAY=(`${EXPORT_LIB_PATH};env PGOPTIONS="-c gp_session_role=utility" $PSQL -q -p $MASTER_PORT -d "$QD_DBNAME" -A -t -c"select a.hostname, a.datadir, a.port, b.valid, b.isprimary from $CONFIG_TABLE a, $GP_PG_VIEW b where a.dbid=b.dbid and a.content<>-1 and  a.preferred_role = 'p' order by a.content;" 2>/dev/null`) > /dev/null 2>&1
-
-		RETVAL=$?
-		if [ $RETVAL -ne 0 ]; then
-				LOG_MSG "[WARN]:-Unable to obtain segment instance primary host details from Master db, error code $RETVAL returned" 1
-				EXIT_STATUS=1
-		fi
-		LOG_MSG "[INFO]:-End Function $FUNCNAME"
-}
-
-GET_QE_MIRROR_DETAILS () {
-		LOG_MSG "[INFO]:-Start Function $FUNCNAME"
-		GET_QD_DB_NAME
-		QE_MIRROR_ARRAY=(`${EXPORT_LIB_PATH};env PGOPTIONS="-c gp_session_role=utility" $PSQL -q -p $MASTER_PORT -d "$QD_DBNAME" -A -t -c"select a.hostname, a.datadir, a.port, b.valid, b.isprimary from $CONFIG_TABLE a, $GP_PG_VIEW b where a.dbid=b.dbid and a.content<>-1 and a.preferred_role='m' order by a.content;" 2>/dev/null`) > /dev/null 2>&1
-
-		RETVAL=$?
-		if [ $RETVAL -ne 0 ]; then
-				LOG_MSG "[WARN]:-Unable to obtain segment instance mirror host details from Master db, error code $RETVAL returned" 1
-				EXIT_STATUS=1
-		fi
-		LOG_MSG "[INFO]:-End Function $FUNCNAME"
 }
 
 GET_PG_PID_ACTIVE () {
@@ -1567,7 +1069,7 @@ GET_PG_PID_ACTIVE () {
 					if [ $P_CHK -eq $PORT ];then  PG_LOCK_NETSTAT=$PORT;fi
 				done
 				#PG_LOCK_NETSTAT=`$TRUSTED_SHELL $HOST "$NETSTAT -an 2>/dev/null |$GREP ".s.PGSQL.${PORT}" 2>/dev/null"|$AWK '{print $NF}'|$HEAD -1`
-				PG_LOCK_TMP=`$TRUSTED_SHELL $HOST "$LS ${PG_LOCK_FILE} 2>/dev/null"|$WC -l`
+				PG_LOCK_TMP=`$TRUSTED_SHELL $HOST "ls ${PG_LOCK_FILE} 2>/dev/null"|$WC -l`
 				if [ x"" == x"$PG_LOCK_NETSTAT" ] && [ $PG_LOCK_TMP -eq 0 ];then
 					PID=0
 					LOG_MSG "[INFO]:-No socket connection or lock file $PG_LOCK_FILE found for port=${PORT}"
@@ -1597,25 +1099,13 @@ GET_PG_PID_ACTIVE () {
 						if [ $CAN_READ -eq 1 ];then
 							PID=`$TRUSTED_SHELL $HOST "$CAT ${PG_LOCK_FILE}|$HEAD -1 2>/dev/null"|$AWK '{print $1}'`
 						else
-							LOG_MSG "[WARN]:-Unable to access ${PG_LOCK_FILE} on $HOST" 1	
+							LOG_MSG "[WARN]:-Unable to access ${PG_LOCK_FILE} on $HOST" 1
 							EXIT_STATUS=1
 						fi
 						LOG_MSG "[INFO]:-Have lock file $PG_LOCK_FILE and a process running on port $PORT on $HOST"
-					fi				
+					fi
 				fi
 			fi
-		fi
-		LOG_MSG "[INFO]:-End Function $FUNCNAME"
-}
-
-RUN_COMMAND () {
-		LOG_MSG "[INFO]:-Start Function $FUNCNAME"
-		COMMAND="$1"
-		LOG_MSG "[INFO]:-Commencing local $COMMAND"
-		$COMMAND >> $LOG_FILE 2>&1
-		RETVAL=$?
-		if [ $RETVAL -ne 0 ]; then
-				ERROR_EXIT "[FATAL]:- Command $COMMAND failed with error status $RETVAL, see log file $LOG_FILE for more detail" 2
 		fi
 		LOG_MSG "[INFO]:-End Function $FUNCNAME"
 }
@@ -1657,49 +1147,33 @@ PING_HOST () {
 	if [ x"" == x"$PING_EXIT" ];then PING_EXIT=0;fi
 	case $OS_TYPE in
 		darwin )
-			$PING $PING_TIME $TARGET_HOST > /dev/null 2>&1 || $PING6 $PING_TIME $TARGET_HOST > /dev/null 2>&1 
+			$PING $PING_TIME $TARGET_HOST > /dev/null 2>&1 || $PING6 $PING_TIME $TARGET_HOST > /dev/null 2>&1
                         ;;
 		linux )
-			$PING $TARGET_HOST $PING_TIME > /dev/null 2>&1 || $PING6 $TARGET_HOST $PING_TIME > /dev/null 2>&1 
+			$PING $TARGET_HOST $PING_TIME > /dev/null 2>&1 || $PING6 $TARGET_HOST $PING_TIME > /dev/null 2>&1
                         ;;
 		* )
 			$PING $TARGET_HOST $PING_TIME > /dev/null 2>&1
 	esac
 	RETVAL=$?
 	case $RETVAL in
-		0) LOG_MSG "[INFO]:-$TARGET_HOST contact established" 
+		0) LOG_MSG "[INFO]:-$TARGET_HOST contact established"
                    ;;
 		1) if [ $PING_EXIT -eq 0 ];then
 			ERROR_EXIT "[FATAL]:-Unable to contact $TARGET_HOST" 2
 		   else
 		        LOG_MSG "[WARN]:-Unable to contact $TARGET_HOST" 1
-		   fi 
+		   fi
                    ;;
 		2) if [ $PING_EXIT -eq 0 ];then
 		 	ERROR_EXIT "[FATAL]:-Unknown host $TARGET_HOST" 2
 		   else
 			LOG_MSG "[WARN]:-Unknown host $TARGET_HOST" 1
-		   fi 
+		   fi
                    ;;
 	esac
 	LOG_MSG "[INFO]:-End Function $FUNCNAME"
 	return $RETVAL
-}
-
-STANDBY_CATALOG_UPDATE () {
-	LOG_MSG "[INFO]:-Start Function $FUNCNAME"
-	MASTER_STANDBY_HOSTNAME=$1;shift
-	MASTER_STANDBY_DATA_DIRECTORY=$1;shift
-	MASTER_STANDBY_PORT=$1
-	STANDBY_HOST_COUNT=`${EXPORT_LIB_PATH};env PGOPTIONS="-c gp_session_role=utility" $PSQL -p $MASTER_PORT -A -t -d "$QD_DBNAME" -c"select distinct hostname from $CONFIG_TABLE a where hostname='${MASTER_STANDBY_HOSTNAME}';"|$WC -l`
-	ERROR_CHK $? "obtain standby host count" 2
-    LOG_MSG "[INFO]:-Creating new gp_segment_configuration record for ${MASTER_STANDBY_HOSTNAME}"
-    MAX_DB_ID=`${EXPORT_LIB_PATH};env PGOPTIONS="-c gp_session_role=utility" $PSQL -p $MASTER_PORT -A -t -d "$QD_DBNAME" -c"select max(dbid)+1 from $CONFIG_TABLE a;"`
-	ERROR_CHK $? "obtain max dbid from gp_configuration" 2
-    $EXPORT_LIB_PATH;env PGOPTIONS="-c gp_session_role=utility" $PSQL -p $MASTER_PORT -A -t -d "$QD_DBNAME" -c"insert into gp_segment_configuration (dbid, content, role, preferred_role, mode, status, hostname, address, port) values (${MAX_DB_ID},-1,'m', 'm', 'u', 's', '${MASTER_STANDBY_HOSTNAME}','${MASTER_STANDBY_HOSTNAME}',${MASTER_STANDBY_PORT});"
-    $EXPORT_LIB_PATH;env PGOPTIONS="-c gp_session_role=utility" $PSQL -p $MASTER_PORT -A -t -d "$QD_DBNAME" -c"insert into pg_filespace_entry (fsefsoid, fsedbid, fselocation) values (3052, ${MAX_DB_ID},'${MASTER_STANDBY_DATA_DIRECTORY}');"
-    ERROR_CHK $? "add standby host gp_configuration record" 2
-	LOG_MSG "[INFO]:-End Function $FUNCNAME"
 }
 
 PARALLEL_SETUP () {
@@ -1787,23 +1261,6 @@ PARALLEL_SUMMARY_STATUS_REPORT () {
 	LOG_MSG "[INFO]:-End Function $FUNCNAME"
 }
 
-RESET_BATCH_VALUE () {
-	LOG_MSG "[INFO]:-Start Function $FUNCNAME"
-	LOG_MSG "[INFO]:-Batch value being re-configured from $BATCH_DEFAULT to $BATCH_LIMIT" 1
-	SAVE_BATCH=$BATCH_DEFAULT
-	BATCH_DEFAULT=$BATCH_LIMIT
-	LOG_MSG "[INFO]:-End Function $FUNCNAME"
-}
-
-RESTORE_BATCH_VALUE () {
-	LOG_MSG "[INFO]:-Start Function $FUNCNAME"
-	if [ x"" != x"$SAVE_BATCH" ];then
-		BATCH_DEFAULT=$SAVE_BATCH
-		SAVE_BATCH=""
-	fi
-	LOG_MSG "[INFO]:-End Function $FUNCNAME"
-}
-
 CHK_GPDB_ID () {
 	LOG_MSG "[INFO]:-Start Function $FUNCNAME"	
 	if [ -f ${INITDB} ];then
@@ -1876,62 +1333,6 @@ CHK_GPDB_ID () {
 	LOG_MSG "[INFO]:-End Function $FUNCNAME"
 }
 
-PARSE_PERMISSIONS () {
-	LOG_MSG "[INFO]:-Start Function $FUNCNAME"
-	#Expect 3 parameters schema.tablename port database
-	if [ $# -ne 3 ];then
-		ERROR_EXIT "[FATAL]:-Got $# parameters, expected 3" 2
-	fi
-	T_NAME=$1;shift
-	PORT=$1;shift
-	DB=$1
-	#Check to ensure that we have schema_name.tablename
-	if [ `$ECHO $T_NAME|grep -c "."` -ne 1 ];then
-		ERROR_EXIT "[FATAL]:-Schema name not supplied" 2
-	else
-		SCHEMA_NAME=`$ECHO $T_NAME|$AWK -F"." '{print $1}'`
-		TABLENAME=`$ECHO $T_NAME|$AWK -F"." '{print $2}'`
-	fi
-	#Get relacl information
-	PERM_COUNT=0
-	for PERM_LINE in `$PSQL -p $PORT -d "$DB" -A -t -c "select relacl from pg_class where relname='${TABLENAME}' and relnamespace in (select oid from pg_namespace where nspname='$SCHEMA_NAME');"|$TR -d '{'|$TR -d '}'|$TR ',' '\n'|$GREP -v "${USER}="|$TR '/' '\n'|$GREP -v "${USER}" `
-	do
-		DB_ACCOUNTNAME=`$ECHO $PERM_LINE|$AWK -F"=" '{print $1}'`
-		if [ x"" != x"$DB_ACCOUNTNAME" ];then
-		    PERM_ALLOW=`$ECHO $PERM_LINE|$AWK -F"=" '{print $2}'`
-		    if [ `$ECHO $PERM_ALLOW|$GREP -c "r"` -eq 1 ];then PERM_TEXT="$PERM_TEXT select";fi
-		    if [ `$ECHO $PERM_ALLOW|$GREP -c "w"` -eq 1 ];then PERM_TEXT="$PERM_TEXT update";fi
-		    if [ `$ECHO $PERM_ALLOW|$GREP -c "d"` -eq 1 ];then PERM_TEXT="$PERM_TEXT delete";fi
-		    if [ `$ECHO $PERM_ALLOW|$GREP -c "a"` -eq 1 ];then PERM_TEXT="$PERM_TEXT insert";fi
-		    if [ `$ECHO $PERM_ALLOW|$GREP -c "R"` -eq 1 ];then PERM_TEXT="$PERM_TEXT rule";fi
-		    if [ `$ECHO $PERM_ALLOW|$GREP -c "x"` -eq 1 ];then PERM_TEXT="$PERM_TEXT references";fi
-		    if [ `$ECHO $PERM_ALLOW|$GREP -c "t"` -eq 1 ];then PERM_TEXT="$PERM_TEXT trigger";fi
-		    PERM_TEXT=`$ECHO $PERM_TEXT|$TR ' ' ','`
-		    PERM_ARRAY[$PERM_COUNT]="grant $PERM_TEXT on ~ to $DB_ACCOUNTNAME;"
-		    PERM_TEXT=''
-		    ((PERM_COUNT=$PERM_COUNT+1))
-		fi
-	done
-	LOG_MSG "[INFO]:-End Function $FUNCNAME"
-}
-
-
-CHK_START_ERROR_TXT () {
-	LOG_MSG "[INFO]:-Start Function $FUNCNAME"
-	if [ $DISPLAY_ERROR -eq 1 ];then
-		LOG_MSG "[INFO]:-*********************************************************************************" 1
-		LOG_MSG "[WARN]:-There are $INVALID_COUNT segment(s) marked as invalid" 1
-		LOG_MSG "[INFO]:-The GPDB gp_fault_action parameter is set to continue in the event of failure" 1
-		LOG_MSG "[INFO]:-To recover from this current invalid state, review usage of gprecoverseg" 1
-		LOG_MSG "[INFO]:-management utility, which will recover failed segment instance databases" 1
-		LOG_MSG "[WARN]:-As gp_fault_action is set to continue, recovery will need to shutdown the" 1
-		LOG_MSG "[WARN]:-GPDB database to ensure a consistent recovery can be completed" 1	
-		LOG_MSG "[INFO]:-*********************************************************************************" 1
-		EXIT_STATUS=1 
-	fi
-	LOG_MSG "[INFO]:-End Function $FUNCNAME"
-}
-
 # Make a dbid file at a particular host. The dbid file is used by gpstart
 # to tell the process in question which segment/master it is.
 # Arguments:
@@ -1985,11 +1386,6 @@ if [ ! -d $DEFLOGDIR ]; then
 fi
 LOG_FILE=$DEFLOGDIR/${PROG_NAME}_${CUR_DATE}.log
 
-if [ $# -ne 0 ]; then
-		if [ "$1" == "-v" ]; then
-				VERSION_INFO
-		fi
-fi
 #Set up OS type for scripts to change command lines
 OS_TYPE=`uname -s|tr '[A-Z]' '[a-z]'`
 case $OS_TYPE in
@@ -2051,9 +1447,6 @@ esac
 
 
 GP_LIBRARY_PATH=`$DIRNAME \`$DIRNAME $INITDB\``/lib
-SHARE_PATH=`$DIRNAME \`$DIRNAME $INITDB\``/share
-SCRIPTS_DIR=`$DIRNAME \` $DIRNAME $INITDB\``/bin
-
 
 ##
 # we setup some EXPORT foo='blah' commands for when we dispatch to segments and standby master

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -1305,7 +1305,7 @@ CHK_GPDB_ID () {
 			fi
 			if [ x$GPDB_ID_CHK != x$USER_CHK ];then
 				LOG_MSG "[WARN]:-\$USER mismatch, id returns $GPDB_ID, \$USER returns $USER" 1
-				LOG_MSG "[WARN]:-The GPDB super user account that owns the initdb binary should run these utilities" 1
+				LOG_MSG "[WARN]:-The GPDB superuser account that owns the initdb binary should run these utilities" 1
 				LOG_MSG "[WARN]:-This may cause problems when these utilities are run as $USER" 1
 			fi
 		else
@@ -1320,7 +1320,7 @@ CHK_GPDB_ID () {
 			fi
 			if [ x$GPDB_ID_CHK != x$LOGNAME_CHK ];then
 				LOG_MSG "[WARN]:-\$LOGNAME mismatch, id returns $GPDB_ID_CHK, \$LOGNAME returns $LOGNAME_CHK" 1
-				LOG_MSG "[WARN]:-The GPDB super user account that owns the initdb binary should run these utilities" 1
+				LOG_MSG "[WARN]:-The GPDB superuser account that owns the initdb binary should run these utilities" 1
 				LOG_MSG "[WARN]:-This may cause problems when these utilities are run as $LOGNAME" 1
 			fi
 		else

--- a/gpMgmt/bin/lib/gp_bash_version.sh.in
+++ b/gpMgmt/bin/lib/gp_bash_version.sh.in
@@ -1,0 +1,8 @@
+gp_version="##version##"
+
+print_version ()
+{
+	progname="$(basename $0)"
+	echo "${progname} ${gp_version}"
+	exit 0
+}

--- a/gpMgmt/bin/lib/gpcreateseg.sh
+++ b/gpMgmt/bin/lib/gpcreateseg.sh
@@ -58,14 +58,6 @@ TMP_PG_HBA=/tmp/pg_hba_conf_master.$$
 #******************************************************************************
 # Functions
 #******************************************************************************
-USAGE () {
-    $ECHO
-    $ECHO "      `basename $0`"
-    $ECHO
-    $ECHO "      Script called by gpinitsystem, this should not"
-    $ECHO "      be run directly"
-    exit $EXIT_STATUS
-}
 
 CHK_CALL () {
 	FILE_PREFIX=`$ECHO $PARALLEL_STATUS_FILE|$CUT -d"." -f1`
@@ -253,16 +245,15 @@ START_QE() {
 # Main Section
 #******************************************************************************
 trap '$ECHO "KILLED:$SEGMENT_LINE" >> $PARALLEL_STATUS_FILE;ERROR_EXIT "[FATAL]:-[$INST_COUNT]-Recieved INT or TERM signal" 2' INT TERM
-while getopts ":v'?'aiqe:c:l:p:m:h:on:s:" opt
+while getopts ":qp:" opt
 do
 	case $opt in
-		v ) VERSION_INFO ;;
-		'?' ) USAGE ;;
 		q ) unset VERBOSE ;;
-	        p ) PG_CONF_ADD_FILE=$OPTARG
+		p ) PG_CONF_ADD_FILE=$OPTARG
 		    shift
 		    shift ;;
-		* ) USAGE 
+		\? ) echo "Invalid option: -$OPTARG"
+			 exit 1 ;;
 	esac
 done
 

--- a/gpMgmt/bin/lib/gpsegdelete.sh
+++ b/gpMgmt/bin/lib/gpsegdelete.sh
@@ -45,14 +45,6 @@ EXIT_STATUS=0
 #******************************************************************************
 # Functions
 #******************************************************************************
-USAGE () {
-		$ECHO
-		$ECHO "      `basename $0`"
-		$ECHO
-		$ECHO "      Script called by gpdeletesystem, this should not be run directly"
-		exit $EXIT_STATUS
-}
-
 CHK_CALL () {
 	FILE_PREFIX=`$ECHO $PARALLEL_STATUS_FILE|$CUT -d"." -f1`
 	if [ ! -f ${FILE_PREFIX}.$PARENT_PID ];then
@@ -109,14 +101,6 @@ DEL_SEGMENT () {
 # Main Section
 #******************************************************************************
 trap '$ECHO "KILLED|${QE_LINE}" >> $PARALLEL_STATUS_FILE;ERROR_EXIT "[FATAL]:-[$INST_COUNT]-Recieved INT or TERM signal" 2' INT TERM
-while getopts ":v'?'" opt
-	do
-	case $opt in
-		v ) VERSION_INFO ;;
-		'?' ) USAGE ;;
-		* ) USAGE 
-	esac
-done
 #Now process supplied call parameters
 PARENT_PID=$1;shift		#PID of gpstate process calling this script
 CHK_CALL

--- a/gpMgmt/bin/lib/gpseginitsb.sh
+++ b/gpMgmt/bin/lib/gpseginitsb.sh
@@ -45,14 +45,6 @@ EXIT_STATUS=0
 #******************************************************************************
 # Functions
 #******************************************************************************
-USAGE () {
-		$ECHO
-		$ECHO "      `basename $0`"
-		$ECHO
-		$ECHO "      Script called by gpinitstandby, this should not be run directly"
-		exit $EXIT_STATUS
-}
-
 CHK_CALL () {
 	FILE_PREFIX=`$ECHO $PARALLEL_STATUS_FILE|$CUT -d"." -f1`
 	if [ ! -f ${FILE_PREFIX}.$PARENT_PID ];then
@@ -88,14 +80,6 @@ UPDATE_PGHBA () {
 # Main Section
 #******************************************************************************
 trap '$ECHO "KILLED:${QE_NAME}:${QE_BASE_DIR}" >> $PARALLEL_STATUS_FILE;ERROR_EXIT "[FATAL]:-[$INST_COUNT]-Recieved INT or TERM signal" 2' INT TERM
-while getopts ":v'?'" opt
-	do
-	case $opt in
-		v ) VERSION_INFO ;;
-		'?' ) USAGE ;;
-		* ) USAGE 
-	esac
-done
 #Now process supplied call parameters
 PARENT_PID=$1;shift		#PID of gpstate process calling this script
 CHK_CALL

--- a/gpMgmt/bin/lib/gpsegstate.sh
+++ b/gpMgmt/bin/lib/gpsegstate.sh
@@ -45,14 +45,6 @@ EXIT_STATUS=0
 #******************************************************************************
 # Functions
 #******************************************************************************
-USAGE () {
-		$ECHO
-		$ECHO "      `basename $0`"
-		$ECHO
-		$ECHO "      Script called by gpstate, this should not be run directly"
-		exit $EXIT_STATUS
-}
-
 CHK_CALL () {
 	FILE_PREFIX=`$ECHO $PARALLEL_STATUS_FILE|$CUT -d"." -f1`
 	if [ ! -f ${FILE_PREFIX}.$PARENT_PID ];then
@@ -151,14 +143,6 @@ GET_SEGMENT_STATUS () {
 # Main Section
 #******************************************************************************
 trap '$ECHO "KILLED:${QE_LINE}" >> $PARALLEL_STATUS_FILE;ERROR_EXIT "[FATAL]:-[$INST_COUNT]-Recieved INT or TERM signal" 2' INT TERM
-while getopts ":v'?'" opt
-	do
-	case $opt in
-		v ) VERSION_INFO ;;
-		'?' ) USAGE ;;
-		* ) USAGE 
-	esac
-done
 #Now process supplied call parameters
 PARENT_PID=$1;shift		#PID of gpstate process calling this script
 CHK_CALL

--- a/gpMgmt/doc/gpinitsystem_help
+++ b/gpMgmt/doc/gpinitsystem_help
@@ -21,8 +21,6 @@ gpinitsystem -c <gpinitsystem_config>
             [--lc-time=<locale>] [--su_password=<password>] 
             [-S] [-a] [-q] [-l <logfile_directory>] [-D]
 
-gpinitsystem -? 
-
 gpinitsystem -v
 
 
@@ -234,12 +232,12 @@ OPTIONS
  than the number of segment instances).
 
 
--v (show utility version)
+-v | --version
 
  Displays the version of this utility.
 
 
--? (help)
+--help
 
  Displays the online help.
 

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpinitsystem.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpinitsystem.xml
@@ -21,8 +21,6 @@
             [<b>--lc-time</b>=<varname>locale</varname>] [<b>--su_password</b>=<varname>password</varname>] 
             [<b>-S</b>] [<b>-a</b>] [<b>-q</b>] [<b>-l</b> <varname>logfile_directory</varname>] [<b>-D</b>]
 
-<b>gpinitsystem</b> <b>-?</b>
-
 <b>gpinitsystem</b> <b>-v</b></codeblock>
         </section>
         <section id="section3">
@@ -209,11 +207,11 @@
                         than the number of segment instances.</pd>
                 </plentry>
                 <plentry>
-                    <pt>-v (show utility version)</pt>
+                    <pt>-v | --version</pt>
                     <pd>Displays the version of this utility.</pd>
                 </plentry>
                 <plentry>
-                    <pt>-? (help)</pt>
+                    <pt>--help</pt>
                     <pd>Displays the online help.</pd>
                 </plentry>
             </parml>


### PR DESCRIPTION
While in there looking at other things, realized that there was quite a lot of dead/unused code in the gpMgmt bin/lib bash files. This mostly removes dead code, but also a bit of unused functionality like printing the version (which incidentally doesn't work at all).

A bit of whitespace cleanup was done to stay sane, but there is lots of space/tab mixups left in there.