### PR TITLE
Fix flakiness for FTS test primary_sync_mirror_cannot_keepup_failover.

### DIFF
--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/fts/fts_transitions/__init__.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/fts/fts_transitions/__init__.py
@@ -130,9 +130,6 @@ class FtsTransitions(MPPTestCase):
     def run_fts_test_ddl_dml_ct(self):
         PSQL.run_sql_file(local_path('fts_test_ddl_dml_ct.sql'))
 
-    def run_sql_in_background(self):
-        PSQL.run_sql_command('drop table if exists bar; create table bar(i int);', background=True)
-
     def restart_db(self):
         self.gpstop.run_gpstop_cmd(immediate = True)
         self.gpstart.run_gpstart_cmd()

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/lib/base.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/lib/base.py
@@ -63,20 +63,27 @@ class BaseClass(MPPTestCase):
     def wait_till_insync(self):
         self.gprecover.wait_till_insync_transition()
 
-    def set_gpconfig(self, param, value):
+    def set_gpconfig(self, param, value, restart_for_config=True):
         ''' Set the configuration parameter using gpconfig '''
         command = "gpconfig -c %s -v \"\'%s\'\" --skipvalidation" % (param, value)
         rc = run_shell_command(command)
         if not rc:
             raise Exception('Unable to set the configuration parameter %s ' % param)
-        gpstop = GpStop()
-        gpstop.run_gpstop_cmd(restart=True)
 
-    def reset_gpconfig(self,param):
+        gpstop = GpStop()
+        if restart_for_config:
+            gpstop.run_gpstop_cmd(restart=True)
+        else:
+            gpstop.run_gpstop_cmd(reload=True)
+
+    def reset_gpconfig(self,param, restart_for_config=True):
         ''' Reset the configuration parameter '''
         command = "gpconfig -r %s " % (param)
         rc = run_shell_command(command)
         if not rc:
             raise Exception('Unable to reset the configuration parameter %s ' % param)
         gpstop = GpStop()
-        gpstop.run_gpstop_cmd(restart=True)
+        if restart_for_config:
+            gpstop.run_gpstop_cmd(restart=True)
+        else:
+            gpstop.run_gpstop_cmd(reload=True)

--- a/src/test/tinc/tincrepo/mpp/lib/filerep_util.py
+++ b/src/test/tinc/tincrepo/mpp/lib/filerep_util.py
@@ -77,7 +77,7 @@ class Filerepe2e_Util():
             fault_cmd = fault_cmd + " -s %s" % seg_id
         if sleeptime :
             fault_cmd = fault_cmd + " -z %s" % sleeptime
-        if o:
+        if o != None:
             fault_cmd = fault_cmd + " -o %s" % o
         if p :
             fault_cmd = fault_cmd + " -p %s" % p


### PR DESCRIPTION
Setting the fault to always hit using `-o 0` instead of only once. Also, loose
out running SQL command. Instead make it clear `hearbeat` operation between
primary and mirror (triggering every minute) is what test relies on to validate,
if mirror is not responding back in `gp_segment_connect_timeout` should mark it
down and transition primary to change tracking.