### PR TITLE
Port tuplestore from Postgres 9.0

### DIFF
--- a/src/backend/executor/execAmi.c
+++ b/src/backend/executor/execAmi.c
@@ -6,7 +6,7 @@
  * Portions Copyright (c) 1996-2008, PostgreSQL Global Development Group
  * Portions Copyright (c) 1994, Regents of the University of California
  *
- *	$PostgreSQL: pgsql/src/backend/executor/execAmi.c,v 1.94.2.2 2008/08/05 21:28:36 tgl Exp $
+ *	$PostgreSQL: pgsql/src/backend/executor/execAmi.c,v 1.98 2008/10/01 19:51:49  tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -312,10 +312,6 @@ ExecMarkPos(PlanState *node)
 			ExecTidMarkPos((TidScanState *) node);
 			break;
 
-		case T_FunctionScanState:
-			ExecFunctionMarkPos((FunctionScanState *) node);
-			break;
-
 		case T_ValuesScanState:
 			ExecValuesMarkPos((ValuesScanState *) node);
 			break;
@@ -390,10 +386,6 @@ ExecRestrPos(PlanState *node)
 			ExecTidRestrPos((TidScanState *) node);
 			break;
 
-		case T_FunctionScanState:
-			ExecFunctionRestrPos((FunctionScanState *) node);
-			break;
-
 		case T_ValuesScanState:
 			ExecValuesRestrPos((ValuesScanState *) node);
 			break;
@@ -433,7 +425,7 @@ ExecRestrPos(PlanState *node)
  * (However, since the only present use of mark/restore is in mergejoin,
  * there is no need to support mark/restore in any plan type that is not
  * capable of generating ordered output.  So the seqscan, tidscan,
- * functionscan, and valuesscan support is actually useless code at present.)
+ * and valuesscan support is actually useless code at present.)
  */
 bool
 ExecSupportsMarkRestore(NodeTag plantype)
@@ -443,7 +435,6 @@ ExecSupportsMarkRestore(NodeTag plantype)
 		case T_SeqScan:
 		case T_IndexScan:
 		case T_TidScan:
-		case T_FunctionScan:
 		case T_ValuesScan:
 		case T_Material:
 		case T_Sort:

--- a/src/backend/executor/execQual.c
+++ b/src/backend/executor/execQual.c
@@ -1696,7 +1696,7 @@ restart:
 	{
 		Assert(isDone);				/* it was provided before ... */
 		if (tuplestore_gettupleslot(fcache->funcResultStore, true,
-									fcache->funcResultSlot))
+									false, fcache->funcResultSlot))
 		{
 			*isDone = ExprMultipleResult;
 			if (fcache->funcReturnsTuple)

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -692,7 +692,6 @@ MemTuple ExecCopySlotMemTupleTo(TupleTableSlot *slot, MemoryContext pctxt, char 
 	return mtup;
 }
 		
-	
 /* --------------------------------
  *		ExecFetchSlotTuple
  *			Fetch the slot's regular physical tuple.

--- a/src/backend/executor/execWorkfile.c
+++ b/src/backend/executor/execWorkfile.c
@@ -361,7 +361,7 @@ ExecWorkFile_Rewind(ExecWorkFile *workfile)
 	switch(workfile->fileType)
 	{
 		case BUFFILE:
-			ret = BufFileSeek((BufFile *)workfile->file, 0L  /* offset */, SEEK_SET);
+			ret = BufFileSeek((BufFile *)workfile->file, 0 /* fileno */, 0L  /* offset */, SEEK_SET);
 			/* BufFileSeek returns 0 if everything went OK */
 			return (0 == ret);
 		case BFZ:
@@ -389,7 +389,7 @@ ExecWorkFile_Tell64(ExecWorkFile *workfile)
 	switch(workfile->fileType)
 	{
 		case BUFFILE:
-			BufFileTell((BufFile *)workfile->file, (int64 *) &bytes);
+			BufFileTell((BufFile *)workfile->file, NULL, (int64 *) &bytes);
 			break;
 			
 		case BFZ:
@@ -522,7 +522,7 @@ ExecWorkFile_Seek(ExecWorkFile *workfile, uint64 offset, int whence)
 	switch(workfile->fileType)
 	{
 	case BUFFILE:
-		result = BufFileSeek((BufFile *)workfile->file, offset, whence);
+		result = BufFileSeek((BufFile *)workfile->file, 0 /* fileno */, offset, whence);
 		if (additional_size > 0)
 		{
 			workfile->size = BufFileGetSize((BufFile *)workfile->file);

--- a/src/backend/storage/file/buffile.c
+++ b/src/backend/storage/file/buffile.c
@@ -506,9 +506,12 @@ BufFileFlush(BufFile *file)
  * impossible seek is attempted.
  */
 int
-BufFileSeek(BufFile *file, int64 offset, int whence)
+BufFileSeek(BufFile *file, int fileno, off_t offset, int whence)
 {
 	int64 newOffset;
+
+	/* GPDB doesn't support multiple files */
+	Assert(fileno == 0);
 
 	switch (whence)
 	{
@@ -557,8 +560,12 @@ BufFileSeek(BufFile *file, int64 offset, int whence)
 }
 
 void
-BufFileTell(BufFile *file, int64 *offset)
+BufFileTell(BufFile *file, int *fileno, off_t *offset)
 {
+	if (fileno != NULL)
+	{
+		*fileno = 0;
+	}
 	*offset = file->offset + file->pos;
 }
 
@@ -576,7 +583,7 @@ BufFileTell(BufFile *file, int64 *offset)
 int
 BufFileSeekBlock(BufFile *file, int64 blknum)
 {
-	return BufFileSeek(file, blknum * BLCKSZ, SEEK_SET);
+	return BufFileSeek(file, 0 /* fileno */, blknum * BLCKSZ, SEEK_SET);
 }
 
 /*

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -1319,7 +1319,7 @@ RunFromStore(Portal portal, ScanDirection direction, int64 count,
 
 			oldcontext = MemoryContextSwitchTo(portal->holdContext);
 
-			ok = tuplestore_gettupleslot(portal->holdStore, forward, slot);
+			ok = tuplestore_gettupleslot(portal->holdStore, forward, false, slot);
 
 			MemoryContextSwitchTo(oldcontext);
 

--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -8,89 +8,65 @@
  * a dumbed-down version of tuplesort.c; it does no sorting of tuples
  * but can only store and regurgitate a sequence of tuples.  However,
  * because no sort is required, it is allowed to start reading the sequence
- * before it has all been written.	This is particularly useful for cursors,
+ * before it has all been written.  This is particularly useful for cursors,
  * because it allows random access within the already-scanned portion of
  * a query without having to process the underlying scan to completion.
+ * Also, it is possible to support multiple independent read pointers.
+ *
  * A temporary file is used to handle the data if it exceeds the
  * space limit specified by the caller.
  *
  * The (approximate) amount of memory allowed to the tuplestore is specified
- * in kilobytes by the caller.	We absorb tuples and simply store them in an
+ * in kilobytes by the caller.  We absorb tuples and simply store them in an
  * in-memory array as long as we haven't exceeded maxKBytes.  If we do exceed
  * maxKBytes, we dump all the tuples into a temp file and then read from that
  * when needed.
  *
+ * Upon creation, a tuplestore supports a single read pointer, numbered 0.
+ * Additional read pointers can be created using tuplestore_alloc_read_pointer.
+ * Mark/restore behavior is supported by copying read pointers.
+ *
  * When the caller requests backward-scan capability, we write the temp file
  * in a format that allows either forward or backward scan.  Otherwise, only
- * forward scan is allowed.  Rewind and markpos/restorepos are normally allowed
- * but can be turned off via tuplestore_set_eflags; turning off both backward
- * scan and rewind enables truncation of the tuplestore at the mark point
- * (if any) for minimal memory usage.
+ * forward scan is allowed.  A request for backward scan must be made before
+ * putting any tuples into the tuplestore.  Rewind is normally allowed but
+ * can be turned off via tuplestore_set_eflags; turning off rewind for all
+ * read pointers enables truncation of the tuplestore at the oldest read point
+ * for minimal memory usage.  (The caller must explicitly call tuplestore_trim
+ * at appropriate times for truncation to actually happen.)
  *
- * Because we allow reading before writing is complete, there are two
- * interesting positions in the temp file: the current read position and
- * the current write position.	At any given instant, the temp file's seek
- * position corresponds to one of these, and the other one is remembered in
- * the Tuplestore's state.
+ * Note: in TSS_WRITEFILE state, the temp file's seek position is the
+ * current write position, and the write-position variables in the tuplestore
+ * aren't kept up to date.  Similarly, in TSS_READFILE state the temp file's
+ * seek position is the active read pointer's position, and that read pointer
+ * isn't kept up to date.  We update the appropriate variables using ftell()
+ * before switching to the other state or activating a different read pointer.
  *
  *
- * Portions Copyright (c) 2007-2009, Greenplum inc
+ * Portions Copyright (c) 2007-2017, Pivotal Software Inc.
  * Portions Copyright (c) 1996-2009, PostgreSQL Global Development Group
  * Portions Copyright (c) 1994, Regents of the University of California
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/utils/sort/tuplestore.c,v 1.36.2.1 2009/12/29 17:41:18 heikki Exp $
+ *	  $PostgreSQL: pgsql/src/backend/utils/sort/tuplestore.c,v 1.48.2.1 2009/12/29 17:41:09 heikki Exp $
  *
  *-------------------------------------------------------------------------
  */
 
 #include "postgres.h"
 
-#include "access/heapam.h"
 #include "commands/tablespace.h"
-#include "executor/instrument.h"        /* struct Instrumentation */
 #include "executor/executor.h"
 #include "storage/buffile.h"
 #include "utils/memutils.h"
 #include "utils/resowner.h"
 #include "utils/tuplestore.h"
-
-#include "utils/debugbreak.h"
-
-#include "cdb/cdbvars.h"                /* currentSliceId */
-
+#include "cdb/cdbvars.h"
+#include "access/memtup.h"
+#include "executor/instrument.h"        /* struct Instrumentation */
 
 /*
- * Data structure describes the current postion of tuple store 
- */
-struct TuplestorePos
-{
-	/*
-	 * In state WRITEFILE, the current file seek position is the write point,
-	 * and the read position is remembered in readpos_xxx; in state READFILE,
-	 * the current file seek position is the read point, and the write
-	 * position is remembered in writepos_xxx.	(The write position is the
-	 * same as EOF, but since BufFileSeek doesn't currently implement
-	 * SEEK_END, we have to remember it explicitly.)
-	 *
-	 * Special case: if we are in WRITEFILE state and eof_reached is true,
-	 * then the read position is implicitly equal to the write position (and
-	 * hence to the file seek position); this way we need not update the
-	 * readpos_xxx variables on each write.
-	 */
-	bool		eof_reached;	/* read reached EOF (always valid) */
-	int			current;		/* next array index (valid if INMEM) */
-	int64		readpos_offset; /* offset (valid if WRITEFILE and not eof) */
-	int64		writepos_offset;	/* offset (valid if READFILE) */
-
-	/* markpos_xxx holds marked position for mark and restore */
-	int64			markpos_current;	/* saved "current" */
-	int64			markpos_file;	/* saved "readpos_file" */
-	int64		markpos_offset; /* saved "readpos_offset" */
-};
-
-/*
- * Possible states of a Tuplestore object.	These denote the states that
+ * Possible states of a Tuplestore object.  These denote the states that
  * persist between calls of Tuplestore routines.
  */
 typedef enum
@@ -101,13 +77,36 @@ typedef enum
 } TupStoreStatus;
 
 /*
+ * State for a single read pointer.  If we are in state INMEM then all the
+ * read pointers' "current" fields denote the read positions.  In state
+ * WRITEFILE, the file/offset fields denote the read positions.  In state
+ * READFILE, inactive read pointers have valid file/offset, but the active
+ * read pointer implicitly has position equal to the temp file's seek position.
+ *
+ * Special case: if eof_reached is true, then the pointer's read position is
+ * implicitly equal to the write position, and current/file/offset aren't
+ * maintained.  This way we need not update all the read pointers each time
+ * we write.
+ */
+typedef struct
+{
+	int			eflags;			/* capability flags */
+	bool		eof_reached;	/* read has reached EOF */
+	int			current;		/* next array index to read */
+	int			file;			/* temp file# */
+	off_t		offset;			/* byte offset in file */
+} TSReadPointer;
+
+/*
  * Private state of a Tuplestore operation.
  */
 struct Tuplestorestate
 {
 	TupStoreStatus status;		/* enumerated value as shown above */
-	int			eflags;			/* capability flags */
+	int			eflags;			/* capability flags (OR of pointers' flags) */
+	bool		backward;		/* store extra length words in file? */
 	bool		interXact;		/* keep open through transactions? */
+	bool		truncated;		/* tuplestore_trim has removed tuples? */
 	long		availMem;		/* remaining memory available, in bytes */
 	BufFile    *myfile;			/* underlying file, or NULL if none */
 	MemoryContext context;		/* memory context for holding tuples */
@@ -127,16 +126,16 @@ struct Tuplestorestate
 	 * the representation must be "flat" in one palloc chunk.) state->availMem
 	 * must be decreased by the amount of space used.
 	 */
-	void	   *(*copytup) (Tuplestorestate *state, TuplestorePos *pos, void *tup);
+	void	   *(*copytup) (Tuplestorestate *state, void *tup);
 
 	/*
-	 * Function to write a stored tuple onto tape.	The representation of the
+	 * Function to write a stored tuple onto tape.  The representation of the
 	 * tuple on tape need not be the same as it is in memory; requirements on
 	 * the tape representation are given below.  After writing the tuple,
 	 * pfree() it, and increase state->availMem by the amount of memory space
 	 * thereby released.
 	 */
-	void		(*writetup) (Tuplestorestate *state, TuplestorePos *pos, void *tup);
+	void		(*writetup) (Tuplestorestate *state, void *tup);
 
 	/*
 	 * Function to read a stored tuple from tape back into memory. 'len' is
@@ -144,65 +143,59 @@ struct Tuplestorestate
 	 * palloc'd copy, and decrease state->availMem by the amount of memory
 	 * space consumed.
 	 */
-	void	   *(*readtup) (Tuplestorestate *state, TuplestorePos *pos, uint32 len);
+	void	   *(*readtup) (Tuplestorestate *state, unsigned int len);
 
 	/*
 	 * This array holds pointers to tuples in memory if we are in state INMEM.
 	 * In states WRITEFILE and READFILE it's not used.
+	 *
+	 * When memtupdeleted > 0, the first memtupdeleted pointers are already
+	 * released due to a tuplestore_trim() operation, but we haven't expended
+	 * the effort to slide the remaining pointers down.  These unused pointers
+	 * are set to NULL to catch any invalid accesses.  Note that memtupcount
+	 * includes the deleted pointers.
 	 */
 	void	  **memtuples;		/* array of pointers to palloc'd tuples */
+	int			memtupdeleted;	/* the first N slots are currently unused */
 	int			memtupcount;	/* number of tuples currently present */
 	int			memtupsize;		/* allocated length of memtuples array */
 
-	TuplestorePos pos;
-
 	/*
-	 * These variables are used to keep track of the current position.
+	 * These variables are used to keep track of the current positions.
 	 *
-	 * In state WRITEFILE, the current file seek position is the write point,
-	 * and the read position is remembered in readpos_xxx; in state READFILE,
-	 * the current file seek position is the read point, and the write
-	 * position is remembered in writepos_xxx.	(The write position is the
-	 * same as EOF, but since BufFileSeek doesn't currently implement
-	 * SEEK_END, we have to remember it explicitly.)
-	 *
-	 * Special case: if we are in WRITEFILE state and eof_reached is true,
-	 * then the read position is implicitly equal to the write position (and
-	 * hence to the file seek position); this way we need not update the
-	 * readpos_xxx variables on each write.
+	 * In state WRITEFILE, the current file seek position is the write point;
+	 * in state READFILE, the write position is remembered in writepos_xxx.
+	 * (The write position is the same as EOF, but since BufFileSeek doesn't
+	 * currently implement SEEK_END, we have to remember it explicitly.)
 	 */
-	bool		eof_reached;	/* read reached EOF (always valid) */
-	int			current;		/* next array index (valid if INMEM) */
-	int64		readpos_offset; /* offset (valid if WRITEFILE and not eof) */
-	int64		writepos_offset;	/* offset (valid if READFILE) */
+	TSReadPointer *readptrs;	/* array of read pointers */
+	int			activeptr;		/* index of the active read pointer */
+	int			readptrcount;	/* number of pointers currently valid */
+	int			readptrsize;	/* allocated length of readptrs array */
 
-	/* markpos_xxx holds marked position for mark and restore */
-	int64			markpos_current;	/* saved "current" */
-	int64			markpos_file;	/* saved "readpos_file" */
-	int64		markpos_offset; /* saved "readpos_offset" */
+	int			writepos_file;	/* file# (valid if READFILE state) */
+	off_t		writepos_offset;	/* offset (valid if READFILE state) */
 
     /*
      * CDB: EXPLAIN ANALYZE reporting interface and statistics.
      */
-    struct Instrumentation *instrument;
+	struct Instrumentation *instrument;
 	long		allowedMem;		/* total memory allowed, in bytes */
-    long        availMemMin;    /* availMem low water mark (bytes) */
-    int64       spilledBytes;   /* memory used for spilled tuples */
+	long        availMemMin;    /* availMem low water mark (bytes) */
+	int64       spilledBytes;   /* memory used for spilled tuples */
 };
-#define COPYTUP(state,pos, tup)	((*(state)->copytup) (state, pos, tup))
-#define WRITETUP(state,pos, tup) ((*(state)->writetup) (state, pos, tup))
-#define READTUP(state,pos,len)	((*(state)->readtup) (state, pos, len))
+
+#define COPYTUP(state,tup)	((*(state)->copytup) (state, tup))
+#define WRITETUP(state,tup) ((*(state)->writetup) (state, tup))
+#define READTUP(state,len)	((*(state)->readtup) (state, len))
 #define LACKMEM(state)		((state)->availMem < 0)
 #define USEMEM(state,amt)	((state)->availMem -= (amt))
-
-static inline void
-FREEMEM(Tuplestorestate *state, int amt)
-{
-    if (state->availMemMin > state->availMem)
-        state->availMemMin = state->availMem;
-    state->availMem += amt;
-}
-
+#define FREEMEM(state,amt)	\
+	do { \
+		if ((state)->availMemMin > (state)->availMem) \
+			(state)->availMemMin = (state)->availMem; \
+		(state)->availMem += (amt); \
+	} while(0)
 
 /*--------------------
  *
@@ -253,14 +246,13 @@ FREEMEM(Tuplestorestate *state, int amt)
 static Tuplestorestate *tuplestore_begin_common(int eflags,
 						bool interXact,
 						int maxKBytes);
+static void tuplestore_puttuple_common(Tuplestorestate *state, void *tuple);
+static void dumptuples(Tuplestorestate *state);
+static unsigned int getlen(Tuplestorestate *state, bool eofOK);
+static void *copytup_heap(Tuplestorestate *state, void *tup);
+static void writetup_heap(Tuplestorestate *state, void *tup);
+static void *readtup_heap(Tuplestorestate *state, unsigned int len);
 
-static void tuplestore_puttuple_common(Tuplestorestate *state, TuplestorePos *pos, void *tuple);
-static void dumptuples(Tuplestorestate *state, TuplestorePos *pos);
-static void tuplestore_trim(Tuplestorestate *state, int ntuples);
-static uint32 getlen(Tuplestorestate *state, TuplestorePos *pos, bool eofOK);
-static void *copytup_heap(Tuplestorestate *state, TuplestorePos *pos, void *tup);
-static void writetup_heap(Tuplestorestate *state, TuplestorePos *pos, void *tup);
-static void *readtup_heap(Tuplestorestate *state, TuplestorePos *pos, uint32 len);
 
 /*
  *		tuplestore_begin_xxx
@@ -277,24 +269,37 @@ tuplestore_begin_common(int eflags, bool interXact, int maxKBytes)
 	state->status = TSS_INMEM;
 	state->eflags = eflags;
 	state->interXact = interXact;
+	state->truncated = false;
 	state->availMem = maxKBytes * 1024L;
-    state->availMemMin = state->availMem;
-    state->allowedMem = state->availMem;
+	state->availMemMin = state->availMem;
+	state->allowedMem = state->availMem;
 	state->myfile = NULL;
 	state->context = CurrentMemoryContext;
 	state->resowner = CurrentResourceOwner;
 
+	state->memtupdeleted = 0;
 	state->memtupcount = 0;
-	state->memtupsize = 1024;	/* initial guess */
-	state->memtuples = (void **) palloc(state->memtupsize * sizeof(void *));
+	/*
+	 * Initial size of array must be more than ALLOCSET_SEPARATE_THRESHOLD;
+	 * see comments in grow_memtuples().
+	 */
+	state->memtupsize = Max(16384 / sizeof(void *),
+							ALLOCSET_SEPARATE_THRESHOLD / sizeof(void *) + 1);
 
-	state->pos.eof_reached = false;
-	state->pos.current = 0;
+	state->memtuples = (void **) palloc(state->memtupsize * sizeof(void *));
 
 	USEMEM(state, GetMemoryChunkSpace(state->memtuples));
 
-	state->eof_reached = false;
-	state->current = 0;
+	state->activeptr = 0;
+	state->readptrcount = 1;
+	state->readptrsize = 8;		/* arbitrary */
+	state->readptrs = (TSReadPointer *)
+		palloc(state->readptrsize * sizeof(TSReadPointer));
+
+	state->readptrs[0].eflags = eflags;
+	state->readptrs[0].eof_reached = false;
+	state->readptrs[0].current = 0;
+
 	return state;
 }
 
@@ -309,7 +314,7 @@ tuplestore_begin_common(int eflags, bool interXact, int maxKBytes)
  * tuple store are allowed.
  *
  * interXact: if true, the files used for on-disk storage persist beyond the
- * end of the current transaction.	NOTE: It's the caller's responsibility to
+ * end of the current transaction.  NOTE: It's the caller's responsibility to
  * create such a tuplestore in a memory context and resource owner that will
  * also survive transaction boundaries, and to ensure the tuplestore is closed
  * when it's no longer wanted.
@@ -328,8 +333,8 @@ tuplestore_begin_heap(bool randomAccess, bool interXact, int maxKBytes)
 	 * the pre-8.3 behavior of tuplestores.
 	 */
 	eflags = randomAccess ?
-		(EXEC_FLAG_BACKWARD | EXEC_FLAG_REWIND | EXEC_FLAG_MARK) :
-		(EXEC_FLAG_REWIND | EXEC_FLAG_MARK);
+		(EXEC_FLAG_BACKWARD | EXEC_FLAG_REWIND) :
+		(EXEC_FLAG_REWIND);
 
 	state = tuplestore_begin_common(eflags, interXact, maxKBytes);
 
@@ -341,43 +346,109 @@ tuplestore_begin_heap(bool randomAccess, bool interXact, int maxKBytes)
 }
 
 /*
- * tuplestore_set_instrument
- *
- * May be called after tuplestore_begin_xxx() to enable reporting of
- * statistics and events for EXPLAIN ANALYZE.
- *
- * The 'instr' ptr is retained in the 'state' object.  The caller must 
- * ensure that it remains valid for the life of the Tuplestorestate object.
- */
-void 
-tuplestore_set_instrument(Tuplestorestate          *state,
-                          struct Instrumentation   *instrument)
-{
-    state->instrument = instrument;
-}                               /* tuplestore_set_instrument */
-
-/*
  * tuplestore_set_eflags
  *
- * Set capability flags at a finer grain than is allowed by
- * tuplestore_begin_xxx.  This must be called before inserting any data
- * into the tuplestore.
+ * Set the capability flags for read pointer 0 at a finer grain than is
+ * allowed by tuplestore_begin_xxx.  This must be called before inserting
+ * any data into the tuplestore.
  *
  * eflags is a bitmask following the meanings used for executor node
- * startup flags (see executor.h).	tuplestore pays attention to these bits:
+ * startup flags (see executor.h).  tuplestore pays attention to these bits:
  *		EXEC_FLAG_REWIND		need rewind to start
  *		EXEC_FLAG_BACKWARD		need backward fetch
- *		EXEC_FLAG_MARK			need mark/restore
- * If tuplestore_set_eflags is not called, REWIND and MARK are allowed,
- * and BACKWARD is set per "randomAccess" in the tuplestore_begin_xxx call.
+ * If tuplestore_set_eflags is not called, REWIND is allowed, and BACKWARD
+ * is set per "randomAccess" in the tuplestore_begin_xxx call.
+ *
+ * NOTE: setting BACKWARD without REWIND means the pointer can read backwards,
+ * but not further than the truncation point (the furthest-back read pointer
+ * position at the time of the last tuplestore_trim call).
  */
 void
 tuplestore_set_eflags(Tuplestorestate *state, int eflags)
 {
-	Assert(state->status == TSS_INMEM);
-	Assert(state->memtupcount == 0);
+	int			i;
 
+	if (state->status != TSS_INMEM || state->memtupcount != 0)
+		elog(ERROR, "too late to call tuplestore_set_eflags");
+
+	state->readptrs[0].eflags = eflags;
+	for (i = 1; i < state->readptrcount; i++)
+		eflags |= state->readptrs[i].eflags;
 	state->eflags = eflags;
+}
+
+/*
+ * tuplestore_alloc_read_pointer - allocate another read pointer.
+ *
+ * Returns the pointer's index.
+ *
+ * The new pointer initially copies the position of read pointer 0.
+ * It can have its own eflags, but if any data has been inserted into
+ * the tuplestore, these eflags must not represent an increase in
+ * requirements.
+ */
+int
+tuplestore_alloc_read_pointer(Tuplestorestate *state, int eflags)
+{
+	/* Check for possible increase of requirements */
+	if (state->status != TSS_INMEM || state->memtupcount != 0)
+	{
+		if ((state->eflags | eflags) != state->eflags)
+			elog(ERROR, "too late to require new tuplestore eflags");
+	}
+
+	/* Make room for another read pointer if needed */
+	if (state->readptrcount >= state->readptrsize)
+	{
+		int			newcnt = state->readptrsize * 2;
+
+		state->readptrs = (TSReadPointer *)
+			repalloc(state->readptrs, newcnt * sizeof(TSReadPointer));
+		state->readptrsize = newcnt;
+	}
+
+	/* And set it up */
+	state->readptrs[state->readptrcount] = state->readptrs[0];
+	state->readptrs[state->readptrcount].eflags = eflags;
+
+	state->eflags |= eflags;
+
+	return state->readptrcount++;
+}
+
+/*
+ * tuplestore_clear
+ *
+ *	Delete all the contents of a tuplestore, and reset its read pointers
+ *	to the start.
+ */
+void
+tuplestore_clear(Tuplestorestate *state)
+{
+	int			i;
+	TSReadPointer *readptr;
+
+	if (state->myfile)
+		BufFileClose(state->myfile);
+	state->myfile = NULL;
+	if (state->memtuples)
+	{
+		for (i = state->memtupdeleted; i < state->memtupcount; i++)
+		{
+			FREEMEM(state, GetMemoryChunkSpace(state->memtuples[i]));
+			pfree(state->memtuples[i]);
+		}
+	}
+	state->status = TSS_INMEM;
+	state->truncated = false;
+	state->memtupdeleted = 0;
+	state->memtupcount = 0;
+	readptr = state->readptrs;
+	for (i = 0; i < state->readptrcount; readptr++, i++)
+	{
+		readptr->eof_reached = false;
+		readptr->current = 0;
+	}
 }
 
 /*
@@ -390,111 +461,168 @@ tuplestore_end(Tuplestorestate *state)
 {
 	int			i;
 
-    /* 
-     * CDB: Report statistics to EXPLAIN ANALYZE.
-     */ 
-    if (state->instrument)
-    {
-        double  nbytes;
+	/*
+	 * CDB: Report statistics to EXPLAIN ANALYZE.
+	 */
+	if (state->instrument)
+	{
+		double  nbytes;
 
-        /* How close did we come to the work_mem limit? */
-        FREEMEM(state, 0);              /* update low-water mark */
-        nbytes = state->allowedMem - state->availMemMin;
-        state->instrument->workmemused = Max(state->instrument->workmemused, nbytes);
+		/* How close did we come to the work_mem limit? */
+		FREEMEM(state, 0);              /* update low-water mark */
+		nbytes = state->allowedMem - state->availMemMin;
+		state->instrument->workmemused = Max(state->instrument->workmemused, nbytes);
 
-        /* How much work_mem would be enough to hold all tuples in memory? */
-        if (state->spilledBytes > 0)
-        {
-            nbytes = state->allowedMem - state->availMem + state->spilledBytes;
-            state->instrument->workmemwanted =
-                Max(state->instrument->workmemwanted, nbytes);
-        }
-    }
+		/* How much work_mem would be enough to hold all tuples in memory? */
+		if (state->spilledBytes > 0)
+		{
+			nbytes = state->allowedMem - state->availMem + state->spilledBytes;
+			state->instrument->workmemwanted =
+				Max(state->instrument->workmemwanted, nbytes);
+		}
+	}
 
 	if (state->myfile)
 		BufFileClose(state->myfile);
 	if (state->memtuples)
 	{
-		for (i = 0; i < state->memtupcount; i++)
-		{
-			if(state->memtuples[i])
-				pfree(state->memtuples[i]);
-		}
+		for (i = state->memtupdeleted; i < state->memtupcount; i++)
+			pfree(state->memtuples[i]);
 		pfree(state->memtuples);
 	}
+	pfree(state->readptrs);
 	pfree(state);
+}
+
+/*
+ * tuplestore_select_read_pointer - make the specified read pointer active
+ */
+void
+tuplestore_select_read_pointer(Tuplestorestate *state, int ptr)
+{
+	TSReadPointer *readptr;
+	TSReadPointer *oldptr;
+
+	Assert(ptr >= 0 && ptr < state->readptrcount);
+
+	/* No work if already active */
+	if (ptr == state->activeptr)
+		return;
+
+	readptr = &state->readptrs[ptr];
+	oldptr = &state->readptrs[state->activeptr];
+
+	switch (state->status)
+	{
+		case TSS_INMEM:
+		case TSS_WRITEFILE:
+			/* no work */
+			break;
+		case TSS_READFILE:
+
+			/*
+			 * First, save the current read position in the pointer about to
+			 * become inactive.
+			 */
+			if (!oldptr->eof_reached)
+				BufFileTell(state->myfile,
+							&oldptr->file,
+							&oldptr->offset);
+
+			/*
+			 * We have to make the temp file's seek position equal to the
+			 * logical position of the new read pointer.  In eof_reached
+			 * state, that's the EOF, which we have available from the saved
+			 * write position.
+			 */
+			if (readptr->eof_reached)
+			{
+				if (BufFileSeek(state->myfile,
+								state->writepos_file,
+								state->writepos_offset,
+								SEEK_SET) != 0)
+					elog(ERROR, "tuplestore seek failed");
+			}
+			else
+			{
+				if (BufFileSeek(state->myfile,
+								readptr->file,
+								readptr->offset,
+								SEEK_SET) != 0)
+					elog(ERROR, "tuplestore seek failed");
+			}
+			break;
+		default:
+			elog(ERROR, "invalid tuplestore state");
+			break;
+	}
+
+	state->activeptr = ptr;
 }
 
 /*
  * tuplestore_ateof
  *
- * Returns the current eof_reached state.
+ * Returns the active read pointer's eof_reached state.
  */
 bool
 tuplestore_ateof(Tuplestorestate *state)
 {
-	return state->pos.eof_reached;
+	return state->readptrs[state->activeptr].eof_reached;
 }
-
 
 /*
  * Accept one tuple and append it to the tuplestore.
  *
  * Note that the input tuple is always copied; the caller need not save it.
  *
- * If the read status is currently "AT EOF" then it remains so (the read
- * pointer advances along with the write pointer); otherwise the read
- * pointer is unchanged.  This is for the convenience of nodeMaterial.c.
+ * If the active read pointer is currently "at EOF", it remains so (the read
+ * pointer implicitly advances along with the write pointer); otherwise the
+ * read pointer is unchanged.  Non-active read pointers do not move, which
+ * means they are certain to not be "at EOF" immediately after puttuple.
+ * This curious-seeming behavior is for the convenience of nodeMaterial.c and
+ * nodeCtescan.c, which would otherwise need to do extra pointer repositioning
+ * steps.
  *
  * tuplestore_puttupleslot() is a convenience routine to collect data from
  * a TupleTableSlot without an extra copy operation.
  */
 void
-tuplestore_puttupleslot_pos(Tuplestorestate *state, TuplestorePos *pos,
+tuplestore_puttupleslot(Tuplestorestate *state,
 						TupleTableSlot *slot)
 {
 	MemTuple tuple;
 	MemoryContext oldcxt = MemoryContextSwitchTo(state->context);
 
 	/*
-	 * Form a MinimalTuple in working memory
+	 * Form a MemTuple in working memory
 	 */
 	tuple = ExecCopySlotMemTuple(slot);
 	USEMEM(state, GetMemoryChunkSpace(tuple));
 
-	tuplestore_puttuple_common(state, pos, (void *) tuple);
+	tuplestore_puttuple_common(state, (void *) tuple);
 
 	MemoryContextSwitchTo(oldcxt);
-}
-void
-tuplestore_puttupleslot(Tuplestorestate *state, TupleTableSlot *slot)
-{
-	tuplestore_puttupleslot_pos(state, &state->pos, slot);
 }
 
 /*
  * "Standard" case to copy from a HeapTuple.  This is actually now somewhat
  * deprecated, but not worth getting rid of in view of the number of callers.
- * (Consider adding something that takes a tupdesc+values/nulls arrays so
- * that we can use heap_form_minimal_tuple() and avoid a copy step.)
  */
 void
-tuplestore_puttuple_pos(Tuplestorestate *state, TuplestorePos *pos, HeapTuple tuple)
+tuplestore_puttuple(Tuplestorestate *state, HeapTuple tuple)
 {
 	MemoryContext oldcxt = MemoryContextSwitchTo(state->context);
 
 	/*
-	 * Copy the tuple.	(Must do this even in WRITEFILE case.)
+	 * Copy the tuple.  (Must do this even in WRITEFILE case.  Note that
+	 * COPYTUP includes USEMEM, so we needn't do that here.)
 	 */
-	tuple = COPYTUP(state, pos, tuple);
+	tuple = COPYTUP(state, tuple);
 
-	tuplestore_puttuple_common(state, pos, (void *) tuple);
+	tuplestore_puttuple_common(state, (void *) tuple);
 
 	MemoryContextSwitchTo(oldcxt);
-}
-void tuplestore_puttuple(Tuplestorestate *state, HeapTuple tuple)
-{
-	tuplestore_puttuple_pos(state, &state->pos, tuple);
 }
 
 /*
@@ -503,7 +631,7 @@ void tuplestore_puttuple(Tuplestorestate *state, HeapTuple tuple)
  */
 void
 tuplestore_putvalues(Tuplestorestate *state, TupleDesc tdesc,
-                     Datum *values, bool *isnull)
+					 Datum *values, bool *isnull)
 {
 	MemoryContext oldcxt = MemoryContextSwitchTo(state->context);
 
@@ -512,19 +640,34 @@ tuplestore_putvalues(Tuplestorestate *state, TupleDesc tdesc,
 
 	USEMEM(state, GetMemoryChunkSpace(tuple));
 
-	tuplestore_puttuple_common(state, &state->pos, (void *) tuple);
+	tuplestore_puttuple_common(state, (void *) tuple);
 
 	MemoryContextSwitchTo(oldcxt);
 }
 
 static void
-tuplestore_puttuple_common(Tuplestorestate *state, TuplestorePos *pos, void *tuple)
+tuplestore_puttuple_common(Tuplestorestate *state, void *tuple)
 {
+	TSReadPointer *readptr;
+	int			i;
 	ResourceOwner oldowner;
 
 	switch (state->status)
 	{
 		case TSS_INMEM:
+
+			/*
+			 * Update read pointers as needed; see API spec above.
+			 */
+			readptr = state->readptrs;
+			for (i = 0; i < state->readptrcount; readptr++, i++)
+			{
+				if (readptr->eof_reached && i != state->activeptr)
+				{
+					readptr->eof_reached = false;
+					readptr->current = state->memtupcount;
+				}
+			}
 
 			/*
 			 * Grow the array as needed.  Note that we try to grow the array
@@ -547,15 +690,13 @@ tuplestore_puttuple_common(Tuplestorestate *state, TuplestorePos *pos, void *tup
 						repalloc(state->memtuples,
 								 state->memtupsize * sizeof(void *));
 					USEMEM(state, GetMemoryChunkSpace(state->memtuples));
+					if (LACKMEM(state))
+						elog(ERROR, "unexpected out-of-memory situation in tuplestore");
 				}
 			}
 
 			/* Stash the tuple in the in-memory array */
 			state->memtuples[state->memtupcount++] = tuple;
-
-			/* If eof_reached, keep read position in sync */
-			if (pos->eof_reached)
-				pos->current = state->memtupcount;
 
 			/*
 			 * Done if we still fit in available memory and have array slots.
@@ -573,34 +714,72 @@ tuplestore_puttuple_common(Tuplestorestate *state, TuplestorePos *pos, void *tup
 			oldowner = CurrentResourceOwner;
 			CurrentResourceOwner = state->resowner;
 
-			{
-				char tmpprefix[50];
-				snprintf(tmpprefix, 50, "slice%d_tuplestore", currentSliceId);
-				state->myfile = BufFileCreateTemp(tmpprefix, state->interXact);
-			}
+			char tmpprefix[50];
+			snprintf(tmpprefix, 50, "slice%d_tuplestore", currentSliceId);
+			state->myfile = BufFileCreateTemp(tmpprefix, state->interXact);
 
 			CurrentResourceOwner = oldowner;
 
+			/*
+			 * Freeze the decision about whether trailing length words will be
+			 * used.  We can't change this choice once data is on tape, even
+			 * though callers might drop the requirement.
+			 */
+			state->backward = (state->eflags & EXEC_FLAG_BACKWARD) != 0;
 			state->status = TSS_WRITEFILE;
-			dumptuples(state, pos);
+			dumptuples(state);
 			break;
 		case TSS_WRITEFILE:
-			WRITETUP(state, pos, tuple);
+
+			/*
+			 * Update read pointers as needed; see API spec above. Note:
+			 * BufFileTell is quite cheap, so not worth trying to avoid
+			 * multiple calls.
+			 */
+			readptr = state->readptrs;
+			for (i = 0; i < state->readptrcount; readptr++, i++)
+			{
+				if (readptr->eof_reached && i != state->activeptr)
+				{
+					readptr->eof_reached = false;
+					BufFileTell(state->myfile,
+								&readptr->file,
+								&readptr->offset);
+				}
+			}
+
+			WRITETUP(state, tuple);
 			break;
 		case TSS_READFILE:
 
 			/*
 			 * Switch from reading to writing.
 			 */
-			if (!pos->eof_reached)
+			if (!state->readptrs[state->activeptr].eof_reached)
 				BufFileTell(state->myfile,
-							&pos->readpos_offset);
+							&state->readptrs[state->activeptr].file,
+							&state->readptrs[state->activeptr].offset);
 			if (BufFileSeek(state->myfile,
-							pos->writepos_offset,
+							state->writepos_file, state->writepos_offset,
 							SEEK_SET) != 0)
-				elog(ERROR, "seek to EOF failed");
+				elog(ERROR, "tuplestore seek to EOF failed");
 			state->status = TSS_WRITEFILE;
-			WRITETUP(state, pos, tuple);
+
+			/*
+			 * Update read pointers as needed; see API spec above.
+			 */
+			readptr = state->readptrs;
+			for (i = 0; i < state->readptrcount; readptr++, i++)
+			{
+				if (readptr->eof_reached && i != state->activeptr)
+				{
+					readptr->eof_reached = false;
+					readptr->file = state->writepos_file;
+					readptr->offset = state->writepos_offset;
+				}
+			}
+
+			WRITETUP(state, tuple);
 			break;
 		default:
 			elog(ERROR, "invalid tuplestore state");
@@ -610,20 +789,21 @@ tuplestore_puttuple_common(Tuplestorestate *state, TuplestorePos *pos, void *tup
 
 /*
  * Fetch the next tuple in either forward or back direction.
- * Returns NULL if no more tuples.	If should_free is set, the
+ * Returns NULL if no more tuples.  If should_free is set, the
  * caller must pfree the returned tuple when done with it.
  *
  * Backward scan is only allowed if randomAccess was set true or
  * EXEC_FLAG_BACKWARD was specified to tuplestore_set_eflags().
  */
 static void *
-tuplestore_gettuple(Tuplestorestate *state, TuplestorePos *pos, bool forward,
+tuplestore_gettuple(Tuplestorestate *state, bool forward,
 					bool *should_free)
 {
-	uint32 tuplen;
+	TSReadPointer *readptr = &state->readptrs[state->activeptr];
+	unsigned int tuplen;
 	void	   *tup;
 
-	Assert(forward || (state->eflags & EXEC_FLAG_BACKWARD));
+	Assert(forward || (readptr->eflags & EXEC_FLAG_BACKWARD));
 
 	switch (state->status)
 	{
@@ -631,47 +811,60 @@ tuplestore_gettuple(Tuplestorestate *state, TuplestorePos *pos, bool forward,
 			*should_free = false;
 			if (forward)
 			{
-				if (pos->current < state->memtupcount)
-					return state->memtuples[pos->current++];
-				pos->eof_reached = true;
+				if (readptr->eof_reached)
+					return NULL;
+				if (readptr->current < state->memtupcount)
+				{
+					/* We have another tuple, so return it */
+					return state->memtuples[readptr->current++];
+				}
+				readptr->eof_reached = true;
 				return NULL;
 			}
 			else
 			{
-				if (pos->current <= 0)
-					return NULL;
-
 				/*
 				 * if all tuples are fetched already then we return last
-				 * tuple, else - tuple before last returned.
+				 * tuple, else tuple before last returned.
 				 */
-				if (pos->eof_reached)
-					pos->eof_reached = false;
+				if (readptr->eof_reached)
+				{
+					readptr->current = state->memtupcount;
+					readptr->eof_reached = false;
+				}
 				else
 				{
-					pos->current--;	/* last returned tuple */
-					if (pos->current <= 0)
+					if (readptr->current <= state->memtupdeleted)
+					{
+						Assert(!state->truncated);
 						return NULL;
+					}
+					readptr->current--; /* last returned tuple */
 				}
-				return state->memtuples[pos->current - 1];
+				if (readptr->current <= state->memtupdeleted)
+				{
+					Assert(!state->truncated);
+					return NULL;
+				}
+				return state->memtuples[readptr->current - 1];
 			}
 			break;
 
 		case TSS_WRITEFILE:
 			/* Skip state change if we'll just return NULL */
-			if (pos->eof_reached && forward)
+			if (readptr->eof_reached && forward)
 				return NULL;
 
 			/*
 			 * Switch from writing to reading.
 			 */
 			BufFileTell(state->myfile,
-						&pos->writepos_offset);
-			if (!pos->eof_reached)
+						&state->writepos_file, &state->writepos_offset);
+			if (!readptr->eof_reached)
 				if (BufFileSeek(state->myfile,
-								pos->readpos_offset,
+								readptr->file, readptr->offset,
 								SEEK_SET) != 0)
-					elog(ERROR, "seek failed");
+					elog(ERROR, "tuplestore seek failed");
 			state->status = TSS_READFILE;
 			/* FALL THRU into READFILE case */
 
@@ -679,9 +872,9 @@ tuplestore_gettuple(Tuplestorestate *state, TuplestorePos *pos, bool forward,
 			*should_free = true;
 			if (forward)
 			{
-				if ((tuplen = getlen(state, pos, true)) != 0)
+				if ((tuplen = getlen(state, true)) != 0)
 				{
-					tup = READTUP(state, pos, tuplen);
+					tup = READTUP(state, tuplen);
 
 					/* CDB XXX XXX XXX XXX */
 					/* MPP-1347: EXPLAIN ANALYZE shows runaway memory usage.
@@ -692,13 +885,13 @@ tuplestore_gettuple(Tuplestorestate *state, TuplestorePos *pos, bool forward,
 					 * heap for actual memory usage than use this
 					 * homemade accounting.
 					 */
-					FREEMEM(state, GetMemoryChunkSpace(tup)); 
+					FREEMEM(state, GetMemoryChunkSpace(tup));
 					/* CDB XXX XXX XXX XXX */
 					return tup;
 				}
 				else
 				{
-					pos->eof_reached = true;
+					readptr->eof_reached = true;
 					return NULL;
 				}
 			}
@@ -707,7 +900,7 @@ tuplestore_gettuple(Tuplestorestate *state, TuplestorePos *pos, bool forward,
 			 * Backward.
 			 *
 			 * if all tuples are fetched already then we return last tuple,
-			 * else - tuple before last returned.
+			 * else tuple before last returned.
 			 *
 			 * Back up to fetch previously-returned tuple's ending length
 			 * word. If seek fails, assume we are at start of file.
@@ -715,14 +908,19 @@ tuplestore_gettuple(Tuplestorestate *state, TuplestorePos *pos, bool forward,
 
 			insist_log(false, "Backward scanning of tuplestores are not supported at this time");
 
-			if (BufFileSeek(state->myfile, -(long) sizeof(uint32) /* offset */,
+			if (BufFileSeek(state->myfile, readptr->file, -(long) sizeof(unsigned int),
 							SEEK_CUR) != 0)
-				return NULL;
-			tuplen = getlen(state, pos, false);
-
-			if (pos->eof_reached)
 			{
-				pos->eof_reached = false;
+				/* even a failed backwards fetch gets you out of eof state */
+				readptr->eof_reached = false;
+				Assert(!state->truncated);
+				return NULL;
+			}
+			tuplen = getlen(state, false);
+
+			if (readptr->eof_reached)
+			{
+				readptr->eof_reached = false;
 				/* We will return the tuple returned before returning NULL */
 			}
 			else
@@ -730,8 +928,8 @@ tuplestore_gettuple(Tuplestorestate *state, TuplestorePos *pos, bool forward,
 				/*
 				 * Back up to get ending length word of tuple before it.
 				 */
-				if (BufFileSeek(state->myfile,
-								-(long) (tuplen + 2 * sizeof(uint32)) /* offset */,
+				if (BufFileSeek(state->myfile, readptr->file,
+								-(long) (tuplen + 2 * sizeof(unsigned int)),
 								SEEK_CUR) != 0)
 				{
 					/*
@@ -740,13 +938,14 @@ tuplestore_gettuple(Tuplestorestate *state, TuplestorePos *pos, bool forward,
 					 * in forward direction (not obviously right, but that is
 					 * what in-memory case does).
 					 */
-					if (BufFileSeek(state->myfile,
-									-(long) (tuplen + sizeof(uint32)) /* offset */,
+					if (BufFileSeek(state->myfile, readptr->file,
+									-(long) (tuplen + sizeof(unsigned int)),
 									SEEK_CUR) != 0)
 						elog(ERROR, "bogus tuple length in backward scan");
+					Assert(!state->truncated);
 					return NULL;
 				}
-				tuplen = getlen(state, pos, false);
+				tuplen = getlen(state, false);
 			}
 
 			/*
@@ -754,11 +953,11 @@ tuplestore_gettuple(Tuplestorestate *state, TuplestorePos *pos, bool forward,
 			 * Note: READTUP expects we are positioned after the initial
 			 * length word of the tuple, so back up to that point.
 			 */
-			if (BufFileSeek(state->myfile,
-							-(long) tuplen /* offset */,
+			if (BufFileSeek(state->myfile, readptr->file,
+							-(long) tuplen,
 							SEEK_CUR) != 0)
 				elog(ERROR, "bogus tuple length in backward scan");
-			tup = READTUP(state, pos, tuplen);
+			tup = READTUP(state, tuplen);
 			return tup;
 
 		default:
@@ -768,22 +967,34 @@ tuplestore_gettuple(Tuplestorestate *state, TuplestorePos *pos, bool forward,
 }
 
 /*
- * tuplestore_gettupleslot - exported function to fetch a MinimalTuple
+ * tuplestore_gettupleslot - exported function to fetch a MemTuple
  *
  * If successful, put tuple in slot and return TRUE; else, clear the slot
  * and return FALSE.
+ *
+ * If copy is TRUE, the slot receives a copied tuple (allocated in current
+ * memory context) that will stay valid regardless of future manipulations of
+ * the tuplestore's state.  If copy is FALSE, the slot may just receive a
+ * pointer to a tuple held within the tuplestore.  The latter is more
+ * efficient but the slot contents may be corrupted if additional writes to
+ * the tuplestore occur.  (If using tuplestore_trim, see comments therein.)
  */
 bool
-tuplestore_gettupleslot_pos(Tuplestorestate *state, TuplestorePos *pos, bool forward,
-						TupleTableSlot *slot)
+tuplestore_gettupleslot(Tuplestorestate *state, bool forward,
+						bool copy, TupleTableSlot *slot)
 {
 	MemTuple tuple;
-	bool		should_free = false;
+	bool		should_free;
 
-	tuple = (MemTuple) tuplestore_gettuple(state, pos, forward, &should_free);
+	tuple = (MemTuple) tuplestore_gettuple(state, forward, &should_free);
 
 	if (tuple)
 	{
+		if (copy && !should_free)
+		{
+			tuple = memtuple_copy_to(tuple, NULL, NULL);
+			should_free = true;
+		}
 		ExecStoreMinimalTuple(tuple, slot, should_free);
 		return true;
 	}
@@ -793,25 +1004,21 @@ tuplestore_gettupleslot_pos(Tuplestorestate *state, TuplestorePos *pos, bool for
 		return false;
 	}
 }
-bool
-tuplestore_gettupleslot(Tuplestorestate *state, bool forward, TupleTableSlot *slot)
-{
-	return tuplestore_gettupleslot_pos(state, &state->pos, forward, slot);
-}
 
 /*
  * tuplestore_advance - exported function to adjust position without fetching
  *
  * We could optimize this case to avoid palloc/pfree overhead, but for the
- * moment it doesn't seem worthwhile.
+ * moment it doesn't seem worthwhile.  (XXX this probably needs to be
+ * reconsidered given the needs of window functions.)
  */
 bool
-tuplestore_advance_pos(Tuplestorestate *state, TuplestorePos *pos, bool forward)
+tuplestore_advance(Tuplestorestate *state, bool forward)
 {
 	void	   *tuple;
-	bool		should_free = false;
+	bool		should_free;
 
-	tuple = tuplestore_gettuple(state, pos, forward, &should_free);
+	tuple = tuplestore_gettuple(state, forward, &should_free);
 
 	if (tuple)
 	{
@@ -824,153 +1031,143 @@ tuplestore_advance_pos(Tuplestorestate *state, TuplestorePos *pos, bool forward)
 		return false;
 	}
 }
-bool
-tuplestore_advance(Tuplestorestate *state, bool forward)
-{
-	return tuplestore_advance_pos(state, &state->pos, forward);
-}
 
 /*
  * dumptuples - remove tuples from memory and write to tape
  *
- * As a side effect, we must set readpos and markpos to the value
- * corresponding to "current"; otherwise, a dump would lose the current read
- * position.
+ * As a side effect, we must convert each read pointer's position from
+ * "current" to file/offset format.  But eof_reached pointers don't
+ * need to change state.
  */
 static void
-dumptuples(Tuplestorestate *state, TuplestorePos *pos)
+dumptuples(Tuplestorestate *state)
 {
 	int			i;
 
-	for (i = 0;; i++)
+	for (i = state->memtupdeleted;; i++)
 	{
-		if (i == pos->current)
-			BufFileTell(state->myfile,
-						&pos->readpos_offset);
-		if (i == pos->markpos_current)
-			BufFileTell(state->myfile,
-						&pos->markpos_offset);
+		TSReadPointer *readptr = state->readptrs;
+		int			j;
+
+		for (j = 0; j < state->readptrcount; readptr++, j++)
+		{
+			if (i == readptr->current && !readptr->eof_reached)
+				BufFileTell(state->myfile,
+							&readptr->file, &readptr->offset);
+		}
 		if (i >= state->memtupcount)
 			break;
-		WRITETUP(state, pos, state->memtuples[i]);
+		WRITETUP(state, state->memtuples[i]);
 	}
+	state->memtupdeleted = 0;
 	state->memtupcount = 0;
 }
 
 /*
- * tuplestore_rescan		- rewind and replay the scan
+ * tuplestore_rescan		- rewind the active read pointer to start
  */
 void
-tuplestore_rescan_pos(Tuplestorestate *state, TuplestorePos *pos)
+tuplestore_rescan(Tuplestorestate *state)
 {
-	Assert(state->eflags & EXEC_FLAG_REWIND);
+	TSReadPointer *readptr = &state->readptrs[state->activeptr];
+
+	Assert(readptr->eflags & EXEC_FLAG_REWIND);
+	Assert(!state->truncated);
 
 	switch (state->status)
 	{
 		case TSS_INMEM:
-			pos->eof_reached = false;
-			pos->current = 0;
+			readptr->eof_reached = false;
+			readptr->current = 0;
 			break;
 		case TSS_WRITEFILE:
-			pos->eof_reached = false;
-			pos->readpos_offset = 0L;
+			readptr->eof_reached = false;
+			readptr->file = 0;
+			readptr->offset = 0L;
 			break;
 		case TSS_READFILE:
-			pos->eof_reached = false;
-			if (BufFileSeek(state->myfile, 0L /* offset */, SEEK_SET) != 0)
-				elog(ERROR, "seek to start failed");
+			readptr->eof_reached = false;
+			if (BufFileSeek(state->myfile, 0, 0L, SEEK_SET) != 0)
+				elog(ERROR, "tuplestore seek to start failed");
 			break;
 		default:
 			elog(ERROR, "invalid tuplestore state");
 			break;
 	}
 }
-void
-tuplestore_rescan(Tuplestorestate *state) 
-{
-	tuplestore_rescan_pos(state, &state->pos);
-}
 
 /*
- * tuplestore_markpos	- saves current position in the tuple sequence
+ * tuplestore_copy_read_pointer - copy a read pointer's state to another
  */
 void
-tuplestore_markpos_pos(Tuplestorestate *state, TuplestorePos *pos)
+tuplestore_copy_read_pointer(Tuplestorestate *state,
+							 int srcptr, int destptr)
 {
-	Assert(state->eflags & EXEC_FLAG_MARK);
+	TSReadPointer *sptr = &state->readptrs[srcptr];
+	TSReadPointer *dptr = &state->readptrs[destptr];
+
+	Assert(srcptr >= 0 && srcptr < state->readptrcount);
+	Assert(destptr >= 0 && destptr < state->readptrcount);
+
+	/* Assigning to self is a no-op */
+	if (srcptr == destptr)
+		return;
+
+	if (dptr->eflags != sptr->eflags)
+	{
+		/* Possible change of overall eflags, so copy and then recompute */
+		int			eflags;
+		int			i;
+
+		*dptr = *sptr;
+		eflags = state->readptrs[0].eflags;
+		for (i = 1; i < state->readptrcount; i++)
+			eflags |= state->readptrs[i].eflags;
+		state->eflags = eflags;
+	}
+	else
+		*dptr = *sptr;
 
 	switch (state->status)
 	{
 		case TSS_INMEM:
-			pos->markpos_current = pos->current;
+		case TSS_WRITEFILE:
+			/* no work */
+			break;
+		case TSS_READFILE:
 
 			/*
-			 * We can truncate the tuplestore if neither backward scan nor
-			 * rewind capability are required by the caller.  There will never
-			 * be a need to back up past the mark point.
-			 *
-			 * Note: you might think we could remove all the tuples before
-			 * "current", since that one is the next to be returned.  However,
-			 * since tuplestore_gettuple returns a direct pointer to our
-			 * internal copy of the tuple, it's likely that the caller has
-			 * still got the tuple just before "current" referenced in a slot.
-			 * Don't free it yet.
+			 * This case is a bit tricky since the active read pointer's
+			 * position corresponds to the seek point, not what is in its
+			 * variables.  Assigning to the active requires a seek, and
+			 * assigning from the active requires a tell, except when
+			 * eof_reached.
 			 */
-			if (!(state->eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_REWIND)))
-				tuplestore_trim(state, 1);
-			break;
-		case TSS_WRITEFILE:
-			if (pos->eof_reached)
+			if (destptr == state->activeptr)
 			{
-				/* Need to record the implicit read position */
-				BufFileTell(state->myfile,
-							&pos->markpos_offset);
+				if (dptr->eof_reached)
+				{
+					if (BufFileSeek(state->myfile,
+									state->writepos_file,
+									state->writepos_offset,
+									SEEK_SET) != 0)
+						elog(ERROR, "tuplestore seek failed");
+				}
+				else
+				{
+					if (BufFileSeek(state->myfile,
+									dptr->file, dptr->offset,
+									SEEK_SET) != 0)
+						elog(ERROR, "tuplestore seek failed");
+				}
 			}
-			else
+			else if (srcptr == state->activeptr)
 			{
-				pos->markpos_offset = pos->readpos_offset;
+				if (!dptr->eof_reached)
+					BufFileTell(state->myfile,
+								&dptr->file,
+								&dptr->offset);
 			}
-			break;
-		case TSS_READFILE:
-			BufFileTell(state->myfile,
-						&pos->markpos_offset);
-			break;
-		default:
-			elog(ERROR, "invalid tuplestore state");
-			break;
-	}
-}
-void
-tuplestore_markpos(Tuplestorestate *state)
-{
-	tuplestore_markpos_pos(state, &state->pos);
-}
-
-/*
- * tuplestore_restorepos - restores current position in tuple sequence to
- *						  last saved position
- */
-void
-tuplestore_restorepos_pos(Tuplestorestate *state, TuplestorePos *pos)
-{
-	Assert(state->eflags & EXEC_FLAG_MARK);
-
-	switch (state->status)
-	{
-		case TSS_INMEM:
-			pos->eof_reached = false;
-			pos->current = pos->markpos_current;
-			break;
-		case TSS_WRITEFILE:
-			pos->eof_reached = false;
-			pos->readpos_offset = pos->markpos_offset;
-			break;
-		case TSS_READFILE:
-			pos->eof_reached = false;
-			if (BufFileSeek(state->myfile,
-							pos->markpos_offset,
-							SEEK_SET) != 0)
-				elog(ERROR, "tuplestore_restorepos failed");
 			break;
 		default:
 			elog(ERROR, "invalid tuplestore state");
@@ -978,20 +1175,31 @@ tuplestore_restorepos_pos(Tuplestorestate *state, TuplestorePos *pos)
 	}
 }
 
-void
-tuplestore_restorepos(Tuplestorestate *state)
-{
-	tuplestore_restorepos_pos(state, &state->pos);
-}
-
 /*
- * tuplestore_trim	- remove all but ntuples tuples before current
+ * tuplestore_trim	- remove all no-longer-needed tuples
+ *
+ * Calling this function authorizes the tuplestore to delete all tuples
+ * before the oldest read pointer, if no read pointer is marked as requiring
+ * REWIND capability.
+ *
+ * Note: this is obviously safe if no pointer has BACKWARD capability either.
+ * If a pointer is marked as BACKWARD but not REWIND capable, it means that
+ * the pointer can be moved backward but not before the oldest other read
+ * pointer.
  */
-static void
-tuplestore_trim(Tuplestorestate *state, int ntuples)
+void
+tuplestore_trim(Tuplestorestate *state)
 {
+	int			oldest;
 	int			nremove;
 	int			i;
+
+	/*
+	 * Truncation is disallowed if any read pointer requires rewind
+	 * capability.
+	 */
+	if (state->eflags & EXEC_FLAG_REWIND)
+		return;
 
 	/*
 	 * We don't bother trimming temp files since it usually would mean more
@@ -1000,27 +1208,57 @@ tuplestore_trim(Tuplestorestate *state, int ntuples)
 	if (state->status != TSS_INMEM)
 		return;
 
-	nremove = state->current - ntuples;
-	if (nremove <= 0)
-		return;					/* nothing to do */
-	Assert(nremove <= state->memtupcount);
-
-	/* Release no-longer-needed tuples */
-	for (i = 0; i < nremove; i++)
+	/* Find the oldest read pointer */
+	oldest = state->memtupcount;
+	for (i = 0; i < state->readptrcount; i++)
 	{
-		FREEMEM(state, GetMemoryChunkSpace(state->memtuples[i]));
-		pfree(state->memtuples[i]);
+		if (!state->readptrs[i].eof_reached)
+			oldest = Min(oldest, state->readptrs[i].current);
 	}
 
 	/*
-	 * Slide the array down and readjust pointers.	This may look pretty
-	 * stupid, but we expect that there will usually not be very many
-	 * tuple-pointers to move, so this isn't that expensive; and it keeps a
-	 * lot of other logic simple.
+	 * Note: you might think we could remove all the tuples before the oldest
+	 * "current", since that one is the next to be returned.  However, since
+	 * tuplestore_gettuple returns a direct pointer to our internal copy of
+	 * the tuple, it's likely that the caller has still got the tuple just
+	 * before "current" referenced in a slot. So we keep one extra tuple
+	 * before the oldest "current".  (Strictly speaking, we could require such
+	 * callers to use the "copy" flag to tuplestore_gettupleslot, but for
+	 * efficiency we allow this one case to not use "copy".)
+	 */
+	nremove = oldest - 1;
+	if (nremove <= 0)
+		return;					/* nothing to do */
+
+	Assert(nremove >= state->memtupdeleted);
+	Assert(nremove <= state->memtupcount);
+
+	/* Release no-longer-needed tuples */
+	for (i = state->memtupdeleted; i < nremove; i++)
+	{
+		FREEMEM(state, GetMemoryChunkSpace(state->memtuples[i]));
+		pfree(state->memtuples[i]);
+		state->memtuples[i] = NULL;
+	}
+	state->memtupdeleted = nremove;
+
+	/* mark tuplestore as truncated (used for Assert crosschecks only) */
+	state->truncated = true;
+
+	/*
+	 * If nremove is less than 1/8th memtupcount, just stop here, leaving the
+	 * "deleted" slots as NULL.  This prevents us from expending O(N^2) time
+	 * repeatedly memmove-ing a large pointer array.  The worst case space
+	 * wastage is pretty small, since it's just pointers and not whole tuples.
+	 */
+	if (nremove < state->memtupcount / 8)
+		return;
+
+	/*
+	 * Slide the array down and readjust pointers.
 	 *
-	 * In fact, in the current usage for merge joins, it's demonstrable that
-	 * there will always be exactly one non-removed tuple; so optimize that
-	 * case.
+	 * In mergejoin's current usage, it's demonstrable that there will always
+	 * be exactly one non-removed tuple; so optimize that case.
 	 */
 	if (nremove + 1 == state->memtupcount)
 		state->memtuples[0] = state->memtuples[nremove];
@@ -1028,9 +1266,26 @@ tuplestore_trim(Tuplestorestate *state, int ntuples)
 		memmove(state->memtuples, state->memtuples + nremove,
 				(state->memtupcount - nremove) * sizeof(void *));
 
+	state->memtupdeleted = 0;
 	state->memtupcount -= nremove;
-	state->current -= nremove;
-	state->markpos_current -= nremove;
+	for (i = 0; i < state->readptrcount; i++)
+	{
+		if (!state->readptrs[i].eof_reached)
+			state->readptrs[i].current -= nremove;
+	}
+}
+
+/*
+ * tuplestore_in_memory
+ *
+ * Returns true if the tuplestore has not spilled to disk.
+ *
+ * XXX exposing this is a violation of modularity ... should get rid of it.
+ */
+bool
+tuplestore_in_memory(Tuplestorestate *state)
+{
+	return (state->status == TSS_INMEM);
 }
 
 
@@ -1038,17 +1293,19 @@ tuplestore_trim(Tuplestorestate *state, int ntuples)
  * Tape interface routines
  */
 
-static uint32
-getlen(Tuplestorestate *state, TuplestorePos *pos, bool eofOK)
+static unsigned int
+getlen(Tuplestorestate *state, bool eofOK)
 {
-	uint32 len;
+	unsigned int len;
 	size_t		nbytes;
 
 	nbytes = BufFileRead(state->myfile, (void *) &len, sizeof(len));
 	if (nbytes == sizeof(len))
 		return len;
-	insist_log(nbytes == 0, "unexpected end of tape");
-	insist_log(eofOK, "unexpected end of data");
+	if (nbytes != 0)
+		elog(ERROR, "unexpected end of tape");
+	if (!eofOK)
+		elog(ERROR, "unexpected end of data");
 	return 0;
 }
 
@@ -1064,7 +1321,7 @@ getlen(Tuplestorestate *state, TuplestorePos *pos, bool eofOK)
  */
 
 static void *
-copytup_heap(Tuplestorestate *state, TuplestorePos *pos, void *tup)
+copytup_heap(Tuplestorestate *state, void *tup)
 {
 	if(!is_heaptuple_memtuple((HeapTuple) tup))
 		return heaptuple_copy_to((HeapTuple) tup, NULL, NULL);
@@ -1073,9 +1330,9 @@ copytup_heap(Tuplestorestate *state, TuplestorePos *pos, void *tup)
 }
 
 static void
-writetup_heap(Tuplestorestate *state, TuplestorePos *pos, void *tup)
+writetup_heap(Tuplestorestate *state, void *tup)
 {
-	uint32 tuplen = 0; 
+	uint32 tuplen = 0;
 	Size         memsize = 0;
 
 	if(is_heaptuple_memtuple((HeapTuple) tup))
@@ -1088,7 +1345,7 @@ writetup_heap(Tuplestorestate *state, TuplestorePos *pos, void *tup)
 
 	if (BufFileWrite(state->myfile, (void *) tup, tuplen) != (size_t) tuplen)
 		elog(ERROR, "write failed");
-	if (state->eflags & EXEC_FLAG_BACKWARD)		/* need trailing length word? */
+	if (state->backward)		/* need trailing length word? */
 		if (BufFileWrite(state->myfile, (void *) &tuplen,
 						 sizeof(tuplen)) != sizeof(tuplen))
 			elog(ERROR, "write failed");
@@ -1102,11 +1359,11 @@ writetup_heap(Tuplestorestate *state, TuplestorePos *pos, void *tup)
 }
 
 static void *
-readtup_heap(Tuplestorestate *state, TuplestorePos *pos, uint32 len)
+readtup_heap(Tuplestorestate *state, unsigned int len)
 {
 	void *tup = NULL;
-	uint32 tuplen = 0;  
-	
+	uint32 tuplen = 0;
+
 	if(is_len_memtuplen(len))
 	{
 		tuplen = memtuple_size_from_uint32(len);
@@ -1125,8 +1382,8 @@ readtup_heap(Tuplestorestate *state, TuplestorePos *pos, uint32 len)
 		/* read in the tuple proper */
 		memtuple_set_mtlen((MemTuple) tup, len);
 
-		if (BufFileRead(state->myfile, (void *) ((char *) tup + sizeof(uint32)), 
-					tuplen - sizeof(uint32)) 
+		if (BufFileRead(state->myfile, (void *) ((char *) tup + sizeof(uint32)),
+					tuplen - sizeof(uint32))
 				!= (size_t) (tuplen - sizeof(uint32)))
 		{
 			insist_log(false, "unexpected end of data");
@@ -1146,13 +1403,28 @@ readtup_heap(Tuplestorestate *state, TuplestorePos *pos, uint32 len)
 		htup->t_data = (HeapTupleHeader ) ((char *) tup + HEAPTUPLESIZE);
 	}
 
-	if (state->eflags & EXEC_FLAG_BACKWARD)		/* need trailing length word? */
-	{
+	if (state->backward)	/* need trailing length word? */
 		if (BufFileRead(state->myfile, (void *) &tuplen,
 						sizeof(tuplen)) != sizeof(tuplen))
 		{
 			insist_log(false, "unexpected end of data");
 		}
-	}
 	return (void *) tup;
 }
+
+/*
+ * tuplestore_set_instrument
+ *
+ * May be called after tuplestore_begin_xxx() to enable reporting of
+ * statistics and events for EXPLAIN ANALYZE.
+ *
+ * The 'instr' ptr is retained in the 'state' object.  The caller must
+ * ensure that it remains valid for the life of the Tuplestorestate object.
+ */
+void
+tuplestore_set_instrument(Tuplestorestate          *state,
+                          struct Instrumentation   *instrument)
+{
+    state->instrument = instrument;
+}                               /* tuplestore_set_instrument */
+

--- a/src/backend/utils/time/combocid.c
+++ b/src/backend/utils/time/combocid.c
@@ -528,7 +528,7 @@ loadSharedComboCommandId(TransactionId xmin, CommandId combocid, CommandId *cmin
 	Assert(combocid_map != NULL);
 
 	/* Seek to the beginning to start our search ? */
-	if (BufFileSeek(combocid_map, 0 /* offset */, SEEK_SET) != 0)
+	if (BufFileSeek(combocid_map, 0 /* fileno */, 0 /* offset */, SEEK_SET) != 0)
 	{
 		elog(ERROR, "loadSharedComboCommandId: seek to beginning failed.");
 	}

--- a/src/backend/utils/time/sharedsnapshot.c
+++ b/src/backend/utils/time/sharedsnapshot.c
@@ -781,7 +781,7 @@ dumpSharedLocalSnapshot_forCursor(void)
 		 * our original zero-length. count does not include
 		 * subtransaction ids.
 		 */
-		if (BufFileSeek(f, 0 /* offset */, SEEK_SET) != 0)
+		if (BufFileSeek(f, 0 /* fileno */, 0 /* offset */, SEEK_SET) != 0)
 			break;
 
 		if (!FileWriteOK(f, &count, sizeof(count)))
@@ -857,7 +857,7 @@ readSharedLocalSnapshot_forCursor(Snapshot snapshot)
 	 * We're going to read this all in one go, the size
 	 * of this buffer should be more than a few hundred bytes.
 	 */
-	if (BufFileSeek(f, 0 /* offset */, SEEK_SET) != 0)
+	if (BufFileSeek(f, 0 /* fileno */, 0 /* offset */, SEEK_SET) != 0)
 		elog(ERROR, "Cursor snapshot: failed to seek.");
 
 	if (!FileReadOK(f, buffer, count))

--- a/src/include/access/htup.h
+++ b/src/include/access/htup.h
@@ -429,11 +429,17 @@ do { \
  *
  * Note that t_hoff is computed the same as in a full tuple, hence it includes
  * the MINIMAL_TUPLE_OFFSET distance.  t_len does not include that, however.
+ *
+ * MINIMAL_TUPLE_DATA_OFFSET is the offset to the first useful (non-pad) data
+ * other than the length word.  tuplesort.c and tuplestore.c use this to avoid
+ * writing the padding to disk.
  */
 #define MINIMAL_TUPLE_OFFSET \
 	((offsetof(HeapTupleHeaderData, t_infomask2) - sizeof(uint32)) / MAXIMUM_ALIGNOF * MAXIMUM_ALIGNOF)
 #define MINIMAL_TUPLE_PADDING \
 	((offsetof(HeapTupleHeaderData, t_infomask2) - sizeof(uint32)) % MAXIMUM_ALIGNOF)
+#define MINIMAL_TUPLE_DATA_OFFSET \
+	offsetof(MinimalTupleData, t_infomask2)
 
 typedef struct MinimalTupleData
 {

--- a/src/include/executor/nodeFunctionscan.h
+++ b/src/include/executor/nodeFunctionscan.h
@@ -7,7 +7,7 @@
  * Portions Copyright (c) 1996-2008, PostgreSQL Global Development Group
  * Portions Copyright (c) 1994, Regents of the University of California
  *
- * $PostgreSQL: pgsql/src/include/executor/nodeFunctionscan.h,v 1.11 2008/01/01 19:45:57 momjian Exp $
+ * $PostgreSQL: pgsql/src/include/executor/nodeFunctionscan.h,v 1.12 2008/10/01 19:51:49 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -20,8 +20,6 @@ extern int	ExecCountSlotsFunctionScan(FunctionScan *node);
 extern FunctionScanState *ExecInitFunctionScan(FunctionScan *node, EState *estate, int eflags);
 extern TupleTableSlot *ExecFunctionScan(FunctionScanState *node);
 extern void ExecEndFunctionScan(FunctionScanState *node);
-extern void ExecFunctionMarkPos(FunctionScanState *node);
-extern void ExecFunctionRestrPos(FunctionScanState *node);
 extern void ExecFunctionReScan(FunctionScanState *node, ExprContext *exprCtxt);
 extern void ExecEagerFreeFunctionScan(FunctionScanState *node);
 

--- a/src/include/storage/buffile.h
+++ b/src/include/storage/buffile.h
@@ -45,8 +45,8 @@ extern void BufFileClose(BufFile *file);
 extern Size BufFileRead(BufFile *file, void *ptr, Size size);
 extern Size BufFileWrite(BufFile *file, const void *ptr, Size size);
 
-extern int BufFileSeek(BufFile *file, int64 offset, int whence);
-extern void BufFileTell(BufFile *file, int64 *offset);
+extern int BufFileSeek(BufFile *file, int fileno, off_t offset, int whence);
+extern void BufFileTell(BufFile *file, int *fileno, off_t *offset);
 extern int	BufFileSeekBlock(BufFile *file, int64 blknum);
 extern void BufFileFlush(BufFile *file);
 extern int64 BufFileGetSize(BufFile *buffile);

--- a/src/include/utils/memutils.h
+++ b/src/include/utils/memutils.h
@@ -278,6 +278,14 @@ extern uint64 mpool_bytes_used(MPool *mpool);
 #define ALLOCSET_SMALL_INITSIZE  (1 * 1024)
 #define ALLOCSET_SMALL_MAXSIZE	 (8 * 1024)
 
+/*
+ * Threshold above which a request in an AllocSet context is certain to be
+ * allocated separately (and thereby have constant allocation overhead).
+ * Few callers should be interested in this, but tuplesort/tuplestore need
+ * to know it.
+ */
+#define ALLOCSET_SEPARATE_THRESHOLD  8192
+
 typedef struct SwitchedMemoryContext
 {
 	MemoryContext oldContext;

--- a/src/test/regress/workfile_mgr_test.c
+++ b/src/test/regress/workfile_mgr_test.c
@@ -1390,7 +1390,7 @@ buffile_size_test(void)
 	unit_test_result(test_size == expected_size);
 
 	elog(LOG, "Running sub-test: seeking back and writing then testing size");
-	BufFileSeek(testBf, expected_size/2, SEEK_SET);
+	BufFileSeek(testBf, 0 /* fileno */, expected_size/2, SEEK_SET);
 	/* This write should not add to the size */
 	BufFileWrite(testBf, text->data, expected_size / 10);
 	test_size = BufFileGetSize(testBf);
@@ -1414,7 +1414,7 @@ buffile_size_test(void)
 	elog(LOG, "Running sub-test: Seek past end, appending and testing size");
 	int past_end_offset = 100;
 	int past_end_write = 200;
-	BufFileSeek(testBf, expected_size + past_end_offset, SEEK_SET);
+	BufFileSeek(testBf, 0 /* fileno */, expected_size + past_end_offset, SEEK_SET);
 	BufFileWrite(testBf, text->data, past_end_write);
 	expected_size += past_end_offset + past_end_write;
 	test_size = BufFileGetSize(testBf);
@@ -1553,7 +1553,7 @@ buffile_large_file_test(void)
 
 	char *buffer = palloc(nchars * sizeof(char));
 
-	BufFileSeek(bfile,  (int64) ((int64)test_entry * (int64) nchars), SEEK_SET);
+	BufFileSeek(bfile, 0 /* fileno */, (int64) ((int64)test_entry * (int64) nchars), SEEK_SET);
 
 	int nread = BufFileRead(bfile, buffer, nchars*sizeof(char));
 


### PR DESCRIPTION
We are porting Postgres 9.0's tuplestore to facilitate CTE 9.0 merge.

