### PR TITLE
Remove extra blank line of gpstart

### DIFF
--- a/gpMgmt/bin/gpstart
+++ b/gpMgmt/bin/gpstart
@@ -652,7 +652,6 @@ class GpStart:
         tableLog.outputTable()
 
         attentionFlag = "<<<<<<<<" if started != totalTriedToStart else ""
-        logger.info("")
         if len(invalidSegments) > 0 :
             skippedMsg = ", skipped %s other segments" % len(invalidSegments)
         else:


### PR DESCRIPTION
When I use gpstart, there is an extra blank line.

[gp@node ~]$ gpstart -a
20170502:20:30:02:004948 gpstart:node:gp-[INFO]:-Starting gpstart with args: -a
20170502:20:30:02:004948 gpstart:node:gp-[INFO]:-Gathering information and validating the environment...
20170502:20:30:02:004948 gpstart:node:gp-[INFO]:-Greenplum Binary Version: 'postgres (Greenplum Database) 5.0.0-alpha.2+dev.12.gf2513c1 build dev'
20170502:20:30:02:004948 gpstart:node:gp-[INFO]:-Greenplum Catalog Version: '301703191'
20170502:20:30:02:004948 gpstart:node:gp-[INFO]:-Starting Master instance in admin mode
20170502:20:30:03:004948 gpstart:node:gp-[INFO]:-Obtaining Greenplum Master catalog information
20170502:20:30:03:004948 gpstart:node:gp-[INFO]:-Obtaining Segment details from master...
20170502:20:30:04:004948 gpstart:node:gp-[INFO]:-Setting new master era
20170502:20:30:04:004948 gpstart:node:gp-[INFO]:-Master Started...
20170502:20:30:04:004948 gpstart:node:gp-[INFO]:-Shutting down master
20170502:20:30:05:004948 gpstart:node:gp-[INFO]:-Commencing parallel segment instance startup, please wait...
... 
20170502:20:30:08:004948 gpstart:node:gp-[INFO]:-Process results...
20170502:20:30:08:004948 gpstart:node:gp-[INFO]:-----------------------------------------------------
20170502:20:30:08:004948 gpstart:node:gp-[INFO]:-   Successful segment starts                                            = 2
20170502:20:30:08:004948 gpstart:node:gp-[INFO]:-   Failed segment starts                                                = 0
20170502:20:30:08:004948 gpstart:node:gp-[INFO]:-   Skipped segment starts (segments are marked down in configuration)   = 0
20170502:20:30:08:004948 gpstart:node:gp-[INFO]:-----------------------------------------------------
**20170502:20:30:08:004948 gpstart:node:gp-[INFO]:-**
20170502:20:30:08:004948 gpstart:node:gp-[INFO]:-Successfully started 2 of 2 segment instances 
20170502:20:30:08:004948 gpstart:node:gp-[INFO]:-----------------------------------------------------
20170502:20:30:08:004948 gpstart:node:gp-[INFO]:-Starting Master instance node directory /data/gp/master/gpseg-1 
20170502:20:30:09:004948 gpstart:node:gp-[INFO]:-Command pg_ctl reports Master node instance active
20170502:20:30:10:004948 gpstart:node:gp-[INFO]:-No standby master configured.  skipping...
20170502:20:30:10:004948 gpstart:node:gp-[INFO]:-Database successfully started