### PR TITLE
GPDB DOCS - Add ALTER/CREATE/DROP EXTENSION cmds and catalog updates.

### DIFF
--- a/gpdb-doc/dita/client_tool_guides/common/client_sql_ref.xml
+++ b/gpdb-doc/dita/client_tool_guides/common/client_sql_ref.xml
@@ -28,6 +28,11 @@
         </section>
         <p conref="../../ref_guide/sql_commands/ALTER_DOMAIN.xml#topic1/sql_command_desc"/>
         <codeblock conref="../../ref_guide/sql_commands/ALTER_DOMAIN.xml#topic1/sql_command_synopsis"/>
+        <section>
+            <title>ALTER EXTENSION</title>
+        </section>
+        <p conref="../../ref_guide/sql_commands/ALTER_EXTENSION.xml#topic1/sql_command_desc"/>
+        <codeblock conref="../../ref_guide/sql_commands/ALTER_EXTENSION.xml#topic1/sql_command_synopsis"/>
         <section id="ae1903351">
             <title>ALTER EXTERNAL TABLE</title>
         </section>
@@ -178,11 +183,15 @@
         </section>
         <p conref="../../ref_guide/sql_commands/CREATE_DOMAIN.xml#topic1/sql_command_desc"/>
         <codeblock conref="../../ref_guide/sql_commands/CREATE_DOMAIN.xml#topic1/sql_command_synopsis"/>
+        <section>
+            <title>CREATE EXTENSION</title>
+        </section>
+        <p conref="../../ref_guide/sql_commands/CREATE_EXTENSION.xml#topic1/sql_command_desc"/>
+        <codeblock conref="../../ref_guide/sql_commands/CREATE_EXTENSION.xml#topic1/sql_command_synopsis"/>
         <section id="ae1904025">
             <title>CREATE EXTERNAL TABLE</title>
         </section>
-        <p
-            conref="../../ref_guide/sql_commands/CREATE_EXTERNAL_TABLE.xml#topic1/sql_command_desc"/>
+        <p conref="../../ref_guide/sql_commands/CREATE_EXTERNAL_TABLE.xml#topic1/sql_command_desc"/>
         <codeblock conref="../../ref_guide/sql_commands/CREATE_EXTERNAL_TABLE.xml#topic1/sql_command_synopsis"/>
         <section id="ae1904203">
             <title>CREATE FUNCTION</title>
@@ -212,8 +221,7 @@
         <section id="ae1904315">
             <title>CREATE OPERATOR CLASS</title>
         </section>
-        <p
-            conref="../../ref_guide/sql_commands/CREATE_OPERATOR_CLASS.xml#topic1/sql_command_desc"/>
+        <p conref="../../ref_guide/sql_commands/CREATE_OPERATOR_CLASS.xml#topic1/sql_command_desc"/>
         <codeblock conref="../../ref_guide/sql_commands/CREATE_OPERATOR_CLASS.xml#topic1/sql_command_synopsis"/>
         <section>
             <title>CREATE PROTOCOL</title>
@@ -223,8 +231,7 @@
         <section id="ae1904333">
             <title>CREATE RESOURCE QUEUE</title>
         </section>
-        <p
-            conref="../../ref_guide/sql_commands/CREATE_RESOURCE_QUEUE.xml#topic1/sql_command_desc"/>
+        <p conref="../../ref_guide/sql_commands/CREATE_RESOURCE_QUEUE.xml#topic1/sql_command_desc"/>
         <codeblock conref="../../ref_guide/sql_commands/CREATE_RESOURCE_QUEUE.xml#topic1/sql_command_synopsis"/>
         <section id="ae1904361">
             <title>CREATE ROLE</title>
@@ -316,6 +323,11 @@
         </section>
         <p conref="../../ref_guide/sql_commands/DROP_DOMAIN.xml#topic1/sql_command_desc"/>
         <codeblock conref="../../ref_guide/sql_commands/DROP_DOMAIN.xml#topic1/sql_command_synopsis"/>
+        <section>
+            <title>DROP EXTENSION</title>
+        </section>
+        <p conref="../../ref_guide/sql_commands/DROP_EXTENSION.xml#topic1/sql_command_desc"/>
+        <codeblock conref="../../ref_guide/sql_commands/DROP_EXTENSION.xml#topic1/sql_command_synopsis"/>
         <section id="ae1904845">
             <title>DROP EXTERNAL TABLE</title>
         </section>
@@ -499,8 +511,7 @@
         <section id="ae1905235">
             <title>ROLLBACK TO SAVEPOINT</title>
         </section>
-        <p
-            conref="../../ref_guide/sql_commands/ROLLBACK_TO_SAVEPOINT.xml#topic1/sql_command_desc"/>
+        <p conref="../../ref_guide/sql_commands/ROLLBACK_TO_SAVEPOINT.xml#topic1/sql_command_desc"/>
         <codeblock conref="../../ref_guide/sql_commands/ROLLBACK_TO_SAVEPOINT.xml#topic1/sql_command_synopsis"/>
         <section id="ae1905241">
             <title>SAVEPOINT</title>

--- a/gpdb-doc/dita/ref_guide/GPReferenceSQLSummaryLOP.xml
+++ b/gpdb-doc/dita/ref_guide/GPReferenceSQLSummaryLOP.xml
@@ -37,13 +37,20 @@
 		<codeblock conref="sql_commands/ALTER_DOMAIN.xml#topic1/sql_command_synopsis"/>
 		<p otherprops="op-html">See <xref href="sql_commands/ALTER_DOMAIN.xml"/> for more
 			information.</p>
+		<section>
+			<title>ALTER EXTENSION</title>
+		</section>
+		<p conref="sql_commands/ALTER_EXTENSION.xml#topic1/sql_command_desc"/>
+		<codeblock conref="sql_commands/ALTER_EXTENSION.xml#topic1/sql_command_synopsis"/>
+		<p otherprops="op-html">See <xref href="sql_commands/ALTER_EXTENSION.xml"/> for more
+			information.</p>
 		<section id="ae1903351">
 			<title>ALTER EXTERNAL TABLE</title>
 		</section>
 		<p conref="sql_commands/ALTER_EXTERNAL_TABLE.xml#topic1/sql_command_desc"/>
 		<codeblock conref="sql_commands/ALTER_EXTERNAL_TABLE.xml#topic1/sql_command_synopsis"/>
-		<p otherprops="op-html">See <xref href="sql_commands/ALTER_EXTERNAL_TABLE.xml"/> for more
-			information.</p>
+		<p otherprops="op-html">See <xref href="sql_commands/ALTER_EXTERNAL_TABLE.xml"/> for
+			more information.</p>
 		<section id="ae1903373">
 			<title>ALTER FILESPACE</title>
 		</section>
@@ -257,6 +264,13 @@
 		<codeblock conref="sql_commands/CREATE_DOMAIN.xml#topic1/sql_command_synopsis"/>
 		<p otherprops="op-html">See <xref href="sql_commands/CREATE_DOMAIN.xml"/> for more
 			information.</p>
+		<section>
+			<title>CREATE EXTENSION</title>
+		</section>
+		<p conref="sql_commands/CREATE_EXTENSION.xml#topic1/sql_command_desc"/>
+		<codeblock conref="sql_commands/CREATE_EXTENSION.xml#topic1/sql_command_synopsis"/>
+		<p otherprops="op-html">See <xref href="sql_commands/CREATE_EXTENSION.xml"/> for more
+			information.</p>
 		<section id="ae1904025">
 			<title>CREATE EXTERNAL TABLE</title>
 		</section>
@@ -463,6 +477,13 @@
 		<p conref="sql_commands/DROP_DOMAIN.xml#topic1/sql_command_desc"/>
 		<codeblock conref="sql_commands/DROP_DOMAIN.xml#topic1/sql_command_synopsis"/>
 		<p otherprops="op-html">See <xref href="sql_commands/DROP_DOMAIN.xml"/> for more
+			information.</p>
+		<section>
+			<title>DROP EXTENSION</title>
+		</section>
+		<p conref="sql_commands/DROP_EXTENSION.xml#topic1/sql_command_desc"/>
+		<codeblock conref="sql_commands/DROP_EXTENSION.xml#topic1/sql_command_synopsis"/>
+		<p otherprops="op-html">See <xref href="sql_commands/DROP_EXTENSION.xml"/> for more
 			information.</p>
 		<section id="ae1904845">
 			<title>DROP EXTERNAL TABLE</title>

--- a/gpdb-doc/dita/ref_guide/ref_guide.ditamap
+++ b/gpdb-doc/dita/ref_guide/ref_guide.ditamap
@@ -9,6 +9,7 @@
 			<topicref href="sql_commands/ALTER_CONVERSION.xml"/>
 			<topicref href="sql_commands/ALTER_DATABASE.xml"/>
 			<topicref href="sql_commands/ALTER_DOMAIN.xml"/>
+			<topicref href="sql_commands/ALTER_EXTENSION.xml"/>
 			<topicref href="sql_commands/ALTER_EXTERNAL_TABLE.xml"/>
 			<topicref href="sql_commands/ALTER_FILESPACE.xml"/>
 			<topicref href="sql_commands/ALTER_FUNCTION.xml"/>
@@ -42,6 +43,7 @@
 			<topicref href="sql_commands/CREATE_CONVERSION.xml"/>
 			<topicref href="sql_commands/CREATE_DATABASE.xml"/>
 			<topicref href="sql_commands/CREATE_DOMAIN.xml"/>
+			<topicref href="sql_commands/CREATE_EXTENSION.xml"/>
 			<topicref href="sql_commands/CREATE_EXTERNAL_TABLE.xml"/>
 			<topicref href="sql_commands/CREATE_FUNCTION.xml"/>
 			<topicref href="sql_commands/CREATE_GROUP.xml"/>
@@ -73,6 +75,7 @@
 			<topicref href="sql_commands/DROP_CONVERSION.xml"/>
 			<topicref href="sql_commands/DROP_DATABASE.xml"/>
 			<topicref href="sql_commands/DROP_DOMAIN.xml"/>
+			<topicref href="sql_commands/DROP_EXTENSION.xml"/>
 			<topicref href="sql_commands/DROP_EXTERNAL_TABLE.xml"/>
 			<topicref href="sql_commands/DROP_FILESPACE.xml"/>
 			<topicref href="sql_commands/DROP_FUNCTION.xml"/>
@@ -166,6 +169,8 @@
 				<topicref href="system_catalogs/pg_attribute_encoding.xml"/>
 				<topicref href="system_catalogs/pg_auth_members.xml"/>
 				<topicref href="system_catalogs/pg_authid.xml"/>
+				<topicref href="system_catalogs/pg_available_extension_versions.xml"/>
+				<topicref href="system_catalogs/pg_available_extensions.xml"/>
 				<topicref href="system_catalogs/pg_cast.xml"/>
 				<topicref href="system_catalogs/pg_class.xml"/>
 				<topicref href="system_catalogs/pg_compression.xml"/>
@@ -175,6 +180,7 @@
 				<topicref href="system_catalogs/pg_depend.xml"/>
 				<topicref href="system_catalogs/pg_description.xml"/>
 				<topicref href="system_catalogs/pg_enum.xml"/>
+				<topicref href="system_catalogs/pg_extension.xml"/>
 				<topicref href="system_catalogs/pg_exttable.xml"/>
 				<topicref href="system_catalogs/pg_filespace.xml"/>
 				<topicref href="system_catalogs/pg_filespace_entry.xml"/>
@@ -184,6 +190,7 @@
 				<topicref href="system_catalogs/pg_largeobject.xml"/>
 				<topicref href="system_catalogs/pg_listener.xml"/>
 				<topicref href="system_catalogs/pg_locks.xml"/>
+				<topicref href="system_catalogs/pg_max_external_files.xml"/>
 				<topicref href="system_catalogs/pg_namespace.xml"/>
 				<topicref href="system_catalogs/pg_opclass.xml"/>
 				<topicref href="system_catalogs/pg_operator.xml"/>
@@ -240,4 +247,6 @@
 		<topicref href="feature_summary.xml" navtitle="Summary of Greenplum Features"
 			id="feature_summary"/>
 	</topicref>
-	<topicref href="../../homenav.html" scope="external" navtitle="Greenplum Database Docs Home" format="html" otherprops="pivotal"/></map>
+	<topicref href="../../homenav.html" scope="external" navtitle="Greenplum Database Docs Home"
+		format="html" otherprops="pivotal"/>
+</map>

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_EXTENSION.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_EXTENSION.xml
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic id="topic1">
+  <title id="cw20941">ALTER EXTENSION</title>
+  <body>
+    <p id="sql_command_desc">Change the definition of an extension that is registered in a Greenplum
+      database.</p>
+    <section id="section2">
+      <title>Synopsis</title>
+      <codeblock id="sql_command_synopsis">ALTER EXTENSION <varname>name</varname> UPDATE [ TO <varname>new_version</varname> ]
+ALTER EXTENSION <varname>name</varname> SET SCHEMA <varname>new_schema</varname>
+ALTER EXTENSION <varname>name</varname> ADD <varname>member_object</varname>
+ALTER EXTENSION <varname>name</varname> DROP <varname>member_object</varname>
+
+where <varname>member_object</varname> is:
+
+  ACCESS METHOD <varname>object_name</varname> |
+  AGGREGATE <varname>aggregate_name</varname> ( <varname>aggregate_signature</varname> ) |
+  CAST (<varname>source_type</varname> AS <varname>target_type</varname>) |
+  COLLATION <varname>object_name</varname> |
+  CONVERSION <varname>object_name</varname> |
+  DOMAIN <varname>object_name</varname> |
+  EVENT TRIGGER <varname>object_name</varname> |
+  FOREIGN DATA WRAPPER <varname>object_name</varname> |
+  FOREIGN TABLE <varname>object_name</varname> |
+  FUNCTION <varname>function_name</varname> ( [ [ <varname>argmode</varname> ] [ <varname>argname</varname> ] <varname>argtype</varname> [, ...] ] ) |
+  MATERIALIZED VIEW <varname>object_name</varname> |
+  OPERATOR <varname>operator_name</varname> (<varname>left_type</varname>, <varname>right_type</varname>) |
+  OPERATOR CLASS <varname>object_name</varname> USING <varname>index_method</varname> |
+  OPERATOR FAMILY <varname>object_name</varname> USING <varname>index_method</varname> |
+  [ PROCEDURAL ] LANGUAGE <varname>object_name</varname> |
+  SCHEMA <varname>object_name</varname> |
+  SEQUENCE <varname>object_name</varname> |
+  SERVER <varname>object_name</varname> |
+  TABLE <varname>object_name</varname> |
+  TEXT SEARCH CONFIGURATION <varname>object_name</varname> |
+  TEXT SEARCH DICTIONARY <varname>object_name</varname> |
+  TEXT SEARCH PARSER <varname>object_name</varname> |
+  TEXT SEARCH TEMPLATE <varname>object_name</varname> |
+  TRANSFORM FOR <varname>type_name</varname> LANGUAGE <varname>lang_name</varname> |
+  TYPE <varname>object_name</varname> |
+  VIEW <varname>object_name</varname>
+
+and <varname>aggregate_signature</varname> is:
+
+* | [ <varname>argmode</varname> ] [ <varname>argname</varname> ] <varname>argtype</varname> [ , ... ] |
+  [ [ <varname>argmode</varname> ] [ <varname>argname</varname> ] <varname>argtype</varname> [ , ... ] ] 
+    ORDER BY [ <varname>argmode</varname> ] [ <varname>argname</varname> ] <varname>argtype</varname> [ , ... ]</codeblock>
+    </section>
+    <section id="section3">
+      <title>Description</title>
+      <p><codeph>ALTER EXTENSION</codeph> changes the definition of an installed extension. These
+        are the subforms:</p>
+      <parml>
+        <plentry>
+          <pt>UPDATE</pt>
+          <pd>
+            <p>This form updates the extension to a newer version. The extension must supply a
+              suitable update script (or series of scripts) that can modify the currently-installed
+              version into the requested version.</p>
+          </pd>
+        </plentry>
+        <plentry>
+          <pt>SET SCHEMA</pt>
+          <pd>
+            <p>This form moves the extension member objects into another schema. The extension must
+              be <i>relocatable</i>.</p>
+          </pd>
+        </plentry>
+        <plentry>
+          <pt>ADD <varname>member_object</varname></pt>
+          <pd>
+            <p>This form adds an existing object to the extension. This is useful in extension
+              update scripts. The added object is treated as a member of the extension. The object
+              can only be dropped by dropping the extension.</p>
+          </pd>
+        </plentry>
+        <plentry>
+          <pt>DROP <varname>member_object</varname></pt>
+          <pd>
+            <p>This form removes a member object from the extension. This is mainly useful in
+              extension update scripts. The object is not dropped, only disassociated from the
+              extension.</p>
+          </pd>
+        </plentry>
+      </parml>
+      <p>See <xref href="https://www.postgresql.org/docs/9.6/static/extend-extensions.html"
+          format="html" scope="external">Packaging Related Objects into an Extension</xref> for more
+        information about these operations. </p>
+      <p>You must own the extension to use <codeph>ALTER EXTENSION</codeph>. The
+          <codeph>ADD</codeph> and <codeph>DROP</codeph> forms also require ownership of the object
+        that is being added or dropped.</p>
+    </section>
+    <section id="section4">
+      <title>Parameters</title>
+      <parml>
+        <plentry>
+          <pt><varname>name</varname></pt>
+          <pd>
+            <p>The name of an installed extension.</p>
+          </pd>
+        </plentry>
+        <plentry>
+          <pt><varname>new_version</varname></pt>
+          <pd>
+            <p>The new version of the extension. The <varname>new_version</varname> can be either an
+              identifier or a string literal. If not specified, the command attempts to update to
+              the default version in the extension control file.</p>
+          </pd>
+        </plentry>
+        <plentry>
+          <pt><varname>new_schema</varname></pt>
+          <pd>
+            <p>The new schema for the extension.</p>
+          </pd>
+        </plentry>
+        <plentry>
+          <pt><varname>object_name</varname></pt>
+          <pt><varname>aggregate_name</varname></pt>
+          <pt><varname>function_name</varname></pt>
+          <pt><varname>operator_name</varname></pt>
+          <pd>
+            <p>The name of an object to be added to or removed from the extension. Names of tables,
+              aggregates, domains, foreign tables, functions, operators, operator classes, operator
+              families, sequences, text search objects, types, and views can be
+              schema-qualified.</p>
+          </pd>
+        </plentry>
+        <plentry>
+          <pt><varname>source_type</varname></pt>
+          <pd>
+            <p>The name of the source data type of the cast.</p>
+          </pd>
+        </plentry>
+        <plentry>
+          <pt><varname>target_type</varname></pt>
+          <pd>
+            <p>The name of the target data type of the cast.</p>
+          </pd>
+        </plentry>
+        <plentry>
+          <pt><varname>argmode</varname></pt>
+          <pd>
+            <p>The mode of a function or aggregate argument: <codeph>IN</codeph>,
+                <codeph>OUT</codeph>, <codeph>INOUT</codeph>, or <codeph>VARIADIC</codeph>. The
+              default is <codeph>IN</codeph>. </p>
+            <p>The command ignores the <codeph>OUT</codeph> arguments. Only the input arguments are
+              required to determine the function identity. It is sufficient to list the
+                <codeph>IN</codeph>, <codeph>INOUT</codeph>, and <codeph>VARIADIC</codeph>
+              arguments.</p>
+          </pd>
+        </plentry>
+        <plentry>
+          <pt><varname>argname</varname></pt>
+          <pd>
+            <p>The name of a function or aggregate argument. </p>
+            <p>The command ignores argument names, since only the argument data types are required
+              to determine the function identity.</p>
+          </pd>
+        </plentry>
+        <plentry>
+          <pt><varname>argtype</varname></pt>
+          <pd>
+            <p>The data type of a function or aggregate argument.</p>
+          </pd>
+        </plentry>
+        <plentry>
+          <pt><varname>left_type</varname></pt>
+          <pt><varname>right_type</varname></pt>
+          <pd>
+            <p>The data types (optionally schema-qualified) of the operator arguments. Specify
+                <codeph>NONE</codeph> for the missing argument of a prefix or postfix operator.</p>
+          </pd>
+        </plentry>
+        <plentry>
+          <pt>PROCEDURAL</pt>
+          <pd>
+            <p>This is a noise word.</p>
+          </pd>
+        </plentry>
+        <plentry>
+          <pt><varname>type_name</varname></pt>
+          <pd>
+            <p>The name of the data type of the transform.</p>
+          </pd>
+        </plentry>
+        <plentry>
+          <pt><varname>lang_name</varname></pt>
+          <pd>
+            <p>The name of the language of the transform.</p>
+          </pd>
+        </plentry>
+      </parml>
+    </section>
+    <section id="section5">
+      <title>Examples</title>
+      <p>To update the hstore extension to version 2.0:</p>
+      <codeblock>ALTER EXTENSION hstore UPDATE TO '2.0';</codeblock>
+      <p>To change the schema of the <codeph>hstore</codeph> extension to
+        <codeph>utils</codeph>:</p>
+      <codeblock>ALTER EXTENSION hstore SET SCHEMA utils;</codeblock>
+      <p>To add an existing function to the <codeph>hstore</codeph> extension:</p>
+      <codeblock>ALTER EXTENSION hstore ADD FUNCTION populate_record(anyelement, hstore);</codeblock>
+    </section>
+    <section id="section6">
+      <title>Compatibility</title>
+      <p><codeph>ALTER EXTENSION</codeph> is a Greenplum Database extension. </p>
+    </section>
+    <section id="section7">
+      <title>See Also</title>
+      <p><codeph><xref href="CREATE_EXTENSION.xml#topic1">CREATE EXTENSION</xref></codeph>,
+            <codeph><xref href="DROP_EXTENSION.xml#topic1">DROP EXTENSION</xref></codeph></p>
+    </section>
+  </body>
+</topic>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_EXTENSION.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_EXTENSION.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic id="topic1">
+    <title id="bv20941">CREATE EXTENSION</title>
+    <body>
+        <p id="sql_command_desc">Registers an extension in a Greenplum database.</p>
+        <section id="section2">
+            <title>Synopsis</title>
+            <codeblock id="sql_command_synopsis">CREATE EXTENSION [ IF NOT EXISTS ] <varname>extension_name</varname>
+  [ WITH ] [ SCHEMA <varname>schema_name</varname> ]
+           [ VERSION <varname>version</varname> ]
+           [ FROM <varname>old_version</varname> ]
+           [ CASCADE ]</codeblock>
+        </section>
+        <section id="section3">
+            <title>Description</title>
+            <p><codeph>CREATE EXTENSION</codeph> loads a new extension into the current database.
+                There must not be an extension of the same name already loaded.</p>
+            <p>Loading an extension essentially amounts to running the extension script file. The
+                script typically creates new SQL objects such as functions, data types, operators
+                and index support methods. The <codeph>CREATE EXTENSION</codeph> command also
+                records the identities of all the created objects, so that they can be dropped again
+                if <codeph>DROP EXTENSION</codeph> is issued.</p>
+            <p>Loading an extension requires the same privileges that would be required to create
+                the component extension objects. For most extensions this means superuser or
+                database owner privileges are required. The user who runs <codeph>CREATE
+                    EXTENSION</codeph> becomes the owner of the extension for purposes of later
+                privilege checks, as well as the owner of any objects created by the extension
+                script.</p>
+        </section>
+        <section id="section4">
+            <title>Parameters</title>
+            <parml>
+                <plentry>
+                    <pt>IF NOT EXISTS</pt>
+                    <pd>
+                        <p>Do not throw an error if an extension with the same name already exists.
+                            A notice is issued in this case. There is no guarantee that the existing
+                            extension is similar to the extension that would have been installed.
+                        </p>
+                    </pd>
+                </plentry>
+                <plentry>
+                    <pt><varname>extension_name</varname></pt>
+                    <pd>
+                        <p>The name of the extension to be installed. The name must be unique within
+                            the database. An extension is created from the details in the extension
+                            control file
+                                    <codeph><varname>SHAREDIR</varname>/extension/<varname>extension_name</varname>.control</codeph>. </p>
+                        <p><varname>SHAREDIR</varname> is the installation shared-data directory,
+                            for example <codeph>/usr/local/greenplum-db/share/postgresql</codeph>.
+                            The command <codeph>pg_config --sharedir</codeph> displays the
+                            directory.</p>
+                    </pd>
+                </plentry>
+                <plentry>
+                    <pt>SCHEMA <varname>schema_name</varname></pt>
+                    <pd>
+                        <p>The name of the schema in which to install the extension objects. This
+                            assumes that the extension allows its contents to be relocated. The
+                            named schema must already exist. If not specified, and the extension
+                            control file does not specify a schema, the current default object
+                            creation schema is used.</p>
+                        <p>If the extension specifies a schema parameter in its control file, then
+                            that schema cannot be overridden with a <codeph>SCHEMA</codeph> clause.
+                            Normally, an error is raised if a <codeph>SCHEMA</codeph> clause is
+                            given and it conflicts with the extension schema parameter. However, if
+                            the <codeph>CASCADE</codeph> clause is also given, then
+                                <varname>schema_name</varname> is ignored when it conflicts. The
+                            given <varname>schema_name</varname> is used for the installation of any
+                            needed extensions that do not a specify schema in their control
+                            files.</p>
+                        <p>The extension itself is not within any schema: extensions have
+                            unqualified names that must be unique within the database. But objects
+                            belonging to the extension can be within a schema.</p>
+                    </pd>
+                </plentry>
+                <plentry>
+                    <pt>VERSION <varname>version</varname></pt>
+                    <pd>
+                        <p>The version of the extension to install. This can be written as either an
+                            identifier or a string literal. The default version is value that is
+                            specified in the extension control file.</p>
+                    </pd>
+                </plentry>
+                <plentry>
+                    <pt>FROM <varname>old_version</varname></pt>
+                    <pd>
+                        <p>Specify <codeph>FROM <varname>old_version</varname></codeph> only if you
+                            are attempting to install an extension that replaces an <i>old-style</i>
+                            module that is a collection of objects that is not packaged into an
+                            extension. If specified, <codeph>CREATE EXTENSION</codeph> runs an
+                            alternative installation script that absorbs the existing objects into
+                            the extension, instead of creating new objects. Ensure that
+                                <codeph>SCHEMA</codeph> clause specifies the schema containing these
+                            pre-existing objects.</p>
+                        <p>The value to use for <varname>old_version</varname> is determined by the
+                            extension author, and might vary if there is more than one version of
+                            the old-style module that can be upgraded into an extension. For the
+                            standard additional modules supplied with pre-9.1 PostgreSQL, specify
+                                <codeph>unpackaged</codeph> for the <varname>old_version</varname>
+                            when updating a module to extension style.</p>
+                    </pd>
+                </plentry>
+                <plentry>
+                    <pt>CASCADE</pt>
+                    <pd>
+                        <p>Automatically install dependant extensions are not already installed.
+                            Dependant extensions are checked recursively and those dependencies are
+                            also installed automatically. If the <varname>SCHEMA</varname> clause is
+                            specified, the schema applies to the extension and all dependant
+                            extensions that are installed. Other options that are specified are not
+                            applied to the automatically-installed dependant extensions. In
+                            particular, default versions are always selected when installing
+                            dependant extensions.</p>
+                    </pd>
+                </plentry>
+            </parml>
+        </section>
+        <section id="section5">
+            <title>Notes</title>
+            <p>The extensions currently available for loading can be identified from the <i><xref
+                        href="../system_catalogs/pg_available_extensions.xml#topic1"
+                        >pg_available_extensions</xref></i> or <i><xref
+                        href="../system_catalogs/pg_available_extension_versions.xml#topic_sln_wfx_tz"
+                        >pg_available_extension_versions</xref></i> system views.</p>
+            <p>Before you use <codeph>CREATE EXTENSION</codeph> to load an extension into a
+                database, the supporting extension files must be installed including an extension
+                control file and at least one least one SQL script file. The support files must be
+                installed in the same location on all Greenplum Database hosts. For information
+                about creating new extensions, see PostgreSQL information about <xref
+                    href="https://www.postgresql.org/docs/9.6/static/extend-extensions.html"
+                    format="html" scope="external">Packaging Related Objects into an
+                    Extension</xref>.</p>
+        </section>
+        <section id="section7">
+            <title>Compatibility</title>
+            <p><codeph>CREATE EXTENSION</codeph> is a Greenplum Database extension. </p>
+        </section>
+        <section id="section8">
+            <title>See Also</title>
+            <p><codeph><xref href="ALTER_EXTENSION.xml#topic1">ALTER EXTENSION</xref></codeph>,
+                        <codeph><xref href="DROP_EXTENSION.xml#topic1">DROP
+                    EXTENSION</xref></codeph></p>
+        </section>
+    </body>
+</topic>

--- a/gpdb-doc/dita/ref_guide/sql_commands/DROP_EXTENSION.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/DROP_EXTENSION.xml
@@ -12,8 +12,9 @@
     <section id="section3">
       <title>Description</title>
       <p><codeph>DROP EXTENSION</codeph> removes extensions from the database. Dropping an extension
-        causes its component objects to be dropped as well. The required supporting extension files
-        what were installed to create the extension are not deleted.</p>
+        causes its component objects to be dropped as well. </p>
+      <note>The required supporting extension files what were installed to create the extension are
+        not deleted. The files must be manually removed from the Greenplum Database hosts.</note>
       <p>You must own the extension to use <codeph>DROP EXTENSION</codeph>.</p>
       <p>This command fails if any of the extension objects are in use in the database. For example,
         if a table is defined with columns of the extension type. Add the <codeph>CASCADE</codeph>

--- a/gpdb-doc/dita/ref_guide/sql_commands/DROP_EXTENSION.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/DROP_EXTENSION.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic id="topic1">
+  <title id="cw20941">DROP EXTENSION</title>
+  <body>
+    <p id="sql_command_desc">Removes an extension from a Greenplum database.</p>
+    <section id="section2">
+      <title>Synopsis</title>
+      <codeblock id="sql_command_synopsis">DROP EXTENSION [ IF EXISTS ] <varname>name</varname> [, ...] [ CASCADE | RESTRICT ]</codeblock>
+    </section>
+    <section id="section3">
+      <title>Description</title>
+      <p><codeph>DROP EXTENSION</codeph> removes extensions from the database. Dropping an extension
+        causes its component objects to be dropped as well. The required supporting extension files
+        what were installed to create the extension are not deleted.</p>
+      <p>You must own the extension to use <codeph>DROP EXTENSION</codeph>.</p>
+      <p>This command fails if any of the extension objects are in use in the database. For example,
+        if a table is defined with columns of the extension type. Add the <codeph>CASCADE</codeph>
+        option to forcibly remove those dependent objects.</p>
+      <note type="important">Before issuing a <codeph>DROP EXTENSION</codeph> with the
+          <codeph>CASCADE</codeph> keyword, you should be aware of all object that depend on the
+        extension to avoid unintended consequences.</note>
+    </section>
+    <section id="section4">
+      <title>Parameters</title>
+      <parml>
+        <plentry>
+          <pt>IF EXISTS</pt>
+          <pd>
+            <p>Do not throw an error if the extension does not exist. A notice is issued.</p>
+          </pd>
+        </plentry>
+        <plentry>
+          <pt><varname>name</varname></pt>
+          <pd>
+            <p>The name of an installed extension.</p>
+          </pd>
+        </plentry>
+        <plentry>
+          <pt>CASCADE</pt>
+          <pd>
+            <p>Automatically drop objects that depend on the extension, and in turn all objects that
+              depend on those objects. See the PostgreSQL information about <xref
+                href="https://www.postgresql.org/docs/9.6/static/ddl-depend.html" format="html"
+                scope="external">Dependency Tracking</xref>.</p>
+          </pd>
+        </plentry>
+        <plentry>
+          <pt>RESTRICT</pt>
+          <pd>
+            <p>Refuse to drop an extension if any objects depend on it, other than the extension
+              member objects. This is the default.</p>
+          </pd>
+        </plentry>
+      </parml>
+    </section>
+    <section id="section6">
+      <title>Compatibility</title>
+      <p><codeph>DROP EXTENSION</codeph> is a Greenplum Database extension. </p>
+    </section>
+    <section id="section7">
+      <title>See Also</title>
+      <p><codeph><xref href="CREATE_EXTENSION.xml#topic1">CREATE EXTENSION</xref></codeph>,
+            <codeph><xref href="ALTER_EXTENSION.xml#topic1">ALTER EXTENSION</xref></codeph></p>
+    </section>
+  </body>
+</topic>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/catalog_ref-views.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/catalog_ref-views.xml
@@ -25,8 +25,8 @@
       <li>
         <xref href="./gpexpand_expansion_progress.xml#topic1" type="topic" format="dita"/>
       </li>
-      <li>pg_max_external_files (shows number of external table files allowed per segment host when
-        using the file protocol)</li>
+      <li>
+        <xref href="./pg_max_external_files.xml#topic1" type="topic" format="dita"/></li>
       <li>
         <xref href="./pg_partition_columns.xml#topic1" type="topic" format="dita"/>
       </li>
@@ -37,23 +37,24 @@
         <xref href="./pg_partitions.xml#topic1" type="topic" format="dita"/>
       </li>
       <li>
+        <xref href="./pg_resqueue_attributes.xml#topic1" type="topic" format="dita"/>
+      </li>
+      <li>pg_resqueue_status (Deprecated. Use <xref href="../gp_toolkit.xml#topic31"
+          >gp_toolkit.gp_resqueue_status</xref>.)</li>
+      <li>
         <xref href="./pg_stat_activity.xml#topic1" type="topic" format="dita"/>
       </li>
       <li>
         <xref href="./pg_stat_replication.xml#topic1" type="topic" format="dita"/>
       </li>
       <li>
-        <xref href="./pg_resqueue_attributes.xml#topic1" type="topic" format="dita"/>
-      </li>
-      <li>pg_resqueue_status (Deprecated. Use gp_toolkit.gp_resqueue_status.)</li>
-      <li>
         <xref href="./pg_stats_resqueue.xml#topic1" type="topic" format="dita"/>
       </li>
-      <li>pg_user_mappings (not supported)</li>
       <li>session_level_memory_consumption (See "Viewing Session Memory Usage Information" in the
-            <cite>Greenplum Database Administrator Guide</cite>.)</li>
+          <cite>Greenplum Database Administrator Guide</cite>.)</li>
     </ul>
-    <p>For more information about the standard system views supported in PostgreSQL and Greenplum Database, see the following sections of the PostgreSQL documentation:</p>
+    <p>For more information about the standard system views supported in PostgreSQL and Greenplum
+      Database, see the following sections of the PostgreSQL documentation:</p>
     <ul id="ul_c5v_3bd_xp">
       <li>
         <xref href="https://www.postgresql.org/docs/8.3/static/views-overview.html" scope="external"

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_available_extension_versions.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_available_extension_versions.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic xml:lang="en" id="topic_sln_wfx_tz">
+  <title>pg_available_extension_versions</title>
+  <body>
+    <p>The <codeph>pg_available_extension_versions</codeph> view lists the specific extension
+      versions that are available for installation. The <xref
+        href="pg_extension.xml#topic_ygy_xfx_tz"><i>pg_extension</i></xref> system catalog table
+      shows the extensions currently installed.</p>
+    <p>The view is read only.</p>
+    <table id="table_tln_wfx_tz">
+      <title>pg_catalog.pg_available_extension_versions</title>
+      <tgroup cols="3">
+        <colspec colnum="1" colname="col1" colwidth="131pt"/>
+        <colspec colnum="2" colname="col2" colwidth="86pt"/>
+        <colspec colnum="3" colname="col4" colwidth="147pt"/>
+        <thead>
+          <row>
+            <entry colname="col1">column</entry>
+            <entry colname="col2">type</entry>
+            <entry colname="col4">description</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry colname="col1"><codeph>name</codeph></entry>
+            <entry colname="col2">name</entry>
+            <entry colname="col4">Extension name.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>version</codeph></entry>
+            <entry colname="col2">text</entry>
+            <entry colname="col4">Version name.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>installed</codeph></entry>
+            <entry colname="col2">boolean</entry>
+            <entry colname="col4"><codeph>True</codeph> if this version of this extension is
+              currently installed, <codeph>False</codeph> otherwise.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>superuser</codeph></entry>
+            <entry colname="col2">boolean</entry>
+            <entry colname="col4"><codeph>True</codeph> if only superusers are allowed to install
+              the extension, <codeph>False</codeph> otherwise.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>relocatable</codeph></entry>
+            <entry colname="col2">boolean</entry>
+            <entry colname="col4"><codeph>True</codeph> if extension can be relocated to another
+              schema, <codeph>False</codeph> otherwise.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>schema</codeph></entry>
+            <entry colname="col2">name</entry>
+            <entry colname="col4">Name of the schema that the extension must be installed into, or
+                <codeph>NULL</codeph> if partially or fully relocatable.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>requires</codeph></entry>
+            <entry colname="col2">name[]</entry>
+            <entry colname="col4">Names of prerequisite extensions, or <codeph>NULL</codeph> if
+              none</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>comment</codeph></entry>
+            <entry colname="col2">text</entry>
+            <entry colname="col4">Comment string from the extension control file.</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_available_extensions.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_available_extensions.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic id="topic1" xml:lang="en">
+  <title id="gn143896">pg_available_extensions</title>
+  <body>
+    <p>The <codeph>pg_available_extensions</codeph> view lists the extensions that are available for
+      installation. The <xref href="pg_extension.xml#topic_ygy_xfx_tz"><i>pg_extension</i></xref>
+      system catalog table shows the extensions currently installed.</p>
+    <p>The view is read only.</p>
+    <table id="gn143898">
+      <title>pg_catalog.pg_available_extensions</title>
+      <tgroup cols="3">
+        <colspec colnum="1" colname="col1" colwidth="131pt"/>
+        <colspec colnum="2" colname="col2" colwidth="86pt"/>
+        <colspec colnum="3" colname="col4" colwidth="147pt"/>
+        <thead>
+          <row>
+            <entry colname="col1">column</entry>
+            <entry colname="col2">type</entry>
+            <entry colname="col4">description</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry colname="col1"><codeph>name</codeph></entry>
+            <entry colname="col2">name</entry>
+            <entry colname="col4">Extension name.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>default_version</codeph></entry>
+            <entry colname="col2">text</entry>
+            <entry colname="col4">Name of default version, or <codeph>NULL</codeph> if none is
+              specified.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>installed_version</codeph></entry>
+            <entry colname="col2">text</entry>
+            <entry colname="col4">Currently installed version of the extension, or
+                <codeph>NULL</codeph> if not installed.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>comment</codeph></entry>
+            <entry colname="col2">text</entry>
+            <entry colname="col4">Comment string from the extension control file.</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_extension.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_extension.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic xml:lang="en" id="topic1">
+  <title>pg_extension</title>
+  <body>
+    <p>The system catalog table <codeph>pg_extension</codeph> stores information about installed
+      extensions.</p>
+    <table id="table_zgy_xfx_tz">
+      <title>pg_catalog.pg_extension</title>
+      <tgroup cols="4">
+        <colspec colnum="1" colname="col1" colwidth="131pt"/>
+        <colspec colnum="2" colname="col2" colwidth="86pt"/>
+        <colspec colnum="3" colname="col3" colwidth="85pt"/>
+        <colspec colnum="4" colname="col4" colwidth="147pt"/>
+        <thead>
+          <row>
+            <entry colname="col1">column</entry>
+            <entry colname="col2">type</entry>
+            <entry colname="col3">references</entry>
+            <entry colname="col4">description</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry colname="col1"><codeph>extname</codeph></entry>
+            <entry colname="col2">name</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Name of the extension.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>extowner</codeph></entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3">pg_authid.oid</entry>
+            <entry colname="col4">Owner of the extension</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>extnamespace</codeph></entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3">pg_namespace.oid</entry>
+            <entry colname="col4">Schema containing the extension exported objects.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>extrelocatable</codeph></entry>
+            <entry colname="col2">boolean</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">True if the extension can be relocated to another schema.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>extversion</codeph></entry>
+            <entry colname="col2">text</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Version name for the extension.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>extconfig</codeph></entry>
+            <entry colname="col2">oid[]</entry>
+            <entry colname="col3">pg_class.oid</entry>
+            <entry colname="col4">Array of <codeph>regclass</codeph> OIDs for the extension
+              configuration tables, or <codeph>NULL</codeph> if none.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>extcondition</codeph></entry>
+            <entry colname="col2">text[]</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Array of <codeph>WHERE</codeph>-clause filter conditions for the
+              extension configuration tables, or <codeph>NULL</codeph> if none.</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+    <p>Unlike most catalogs with a namespace column, <codeph>extnamespace</codeph> does not imply
+      that the extension belongs to that schema. Extension names are never schema-qualified. The
+        <codeph>extnamespace</codeph> schema indicates the schema that contains most or all of the
+      extension objects. If <codeph>extrelocatable</codeph> is <codeph>true</codeph>, then this
+      schema must contain all schema-qualifiable objects that belong to the extension.</p>
+  </body>
+</topic>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_max_external_files.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_max_external_files.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic id="topic1" xml:lang="en">
+  <title id="go138336">pg_max_external_files</title>
+  <body>
+    <p>The <codeph>pg_max_external_files</codeph> view shows the maximum number of external table
+      files allowed per segment host when using the external table <codeph>file</codeph>
+      protocol.</p>
+    <table id="go138428">
+      <title>pg_catalog.pg_max_external_files</title>
+      <tgroup cols="4">
+        <colspec colnum="1" colname="col1" colwidth="131pt"/>
+        <colspec colnum="2" colname="col2" colwidth="97pt"/>
+        <colspec colnum="3" colname="col3" colwidth="82pt"/>
+        <colspec colnum="4" colname="col4" colwidth="138pt"/>
+        <thead>
+          <row>
+            <entry colname="col1">column</entry>
+            <entry colname="col2">type</entry>
+            <entry colname="col3">references</entry>
+            <entry colname="col4">description</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry colname="col1"><codeph>hostname</codeph></entry>
+            <entry colname="col2">name</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">The host name used to access a particular segment instance on a
+              segment host. </entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>maxfiles</codeph></entry>
+            <entry colname="col2">bigint</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Number of primary segment instances on the host.</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>


### PR DESCRIPTION
Add ALTER/CREATE/DROP EXTENSION cmds
Add related tables/views 
-pg_available_extensions
-pg_extension
-pg_available_extension_versions

NOTE: cmds and table and views based on PostgresSQL 9.6 documentation. 

Clean up system catalog topics.
-Removed deprecated catalog tables/views
-Add catalog table pg_max_external_files

[ci skip]