### PR TITLE
Documentation fixups

### DIFF
--- a/gpMgmt/doc/gp_dump_help
+++ b/gpMgmt/doc/gp_dump_help
@@ -222,7 +222,7 @@ port number provided at compile time is used.
 -U <username>
 --username=<user>
 
-The database super user account name, for example bgadmin. 
+The database superuser account name, for example bgadmin.
 If not provided, the value of $PGUSER or the current OS 
 user name is used.
 

--- a/gpMgmt/doc/gpactivatestandby_help
+++ b/gpMgmt/doc/gpactivatestandby_help
@@ -83,7 +83,7 @@ gpinitstandby utility.
 OPTIONS
 *****************************************************
 
--a (do not prompt) 
+-a
 
  Do not prompt the user for confirmation. 
 
@@ -100,7 +100,7 @@ OPTIONS
  If a directory cannot be determined, the utility returns an error. 
 
 
--f (force activation) 
+-f
 
  Use this option to force activation of the backup master host. Use this 
  option only if you are sure that the standby and primary master hosts 
@@ -112,13 +112,13 @@ OPTIONS
  The directory to write the log file. Defaults to ~/gpAdminLogs. 
 
 
--q (no screen output) 
+-q
 
  Run in quiet mode. Command output is not displayed on the screen, but is 
  still written to the log file. 
 
 
--v (show utility version) 
+-v
 
  Displays the version, status, last updated date, and check sum of this 
  utility. 

--- a/gpMgmt/doc/gpaddmirrors_help
+++ b/gpMgmt/doc/gpaddmirrors_help
@@ -103,7 +103,7 @@ before running gpaddmirrors.
 OPTIONS
 *****************************************************
 
--a (do not prompt)
+-a
 
  Run in quiet mode - do not prompt for information. Must supply 
  a configuration file with either -m or -i if this option is used.
@@ -191,7 +191,7 @@ OPTIONS
  52001, and a primary replication port of 53001 by default.
 
 
--s (spread mirrors)
+-s
 
  Spreads the mirror segments across the available hosts. The 
  default is to group a set of mirror segments together on an 
@@ -202,17 +202,17 @@ OPTIONS
  or equal to the number of segment instances per host).
 
 
--v (verbose)
+-v
 
  Sets logging output to verbose.
 
 
---version (show utility version)
+--version
 
  Displays the version of this utility.
 
 
--? (help)
+-?
 
  Displays the online help.
 

--- a/gpMgmt/doc/gpcrondump_help
+++ b/gpMgmt/doc/gpcrondump_help
@@ -143,12 +143,12 @@ Limitations
 OPTIONS
 *****************************************************
 
--a (do not prompt) 
+-a
 
  Do not prompt the user for confirmation. 
 
 
--b (bypass disk space check) 
+-b
 
  Bypass disk space check. The default is to check for available disk 
  space, unless --ddboost is specified. When using Data Domain Boost, this 
@@ -166,7 +166,7 @@ OPTIONS
  processes depending on how many segment instances it needs to dump. 
 
 
--c (clear old dump files first)
+-c
 
  Specify this option to delete old backups before performing a back up. 
  In the db_dumps directory, the directory where the name is the oldest 
@@ -188,7 +188,7 @@ OPTIONS
  This option is not supported with the -u option.
 
  
--C (clean catalog before restore) 
+-C
 
  Clean out the catalog schema prior to restoring database objects. 
  gpcrondump adds the DROP command to the SQL script files when creating 
@@ -423,7 +423,7 @@ OPTIONS
  specified. 
 
 
--g (copy config files) 
+-g
 
  Secure a copy of the master and segment configuration files 
  postgresql.conf, pg_ident.conf, and pg_hba.conf. These configuration 
@@ -435,7 +435,7 @@ OPTIONS
  from cluster's config file, under the default directory configured by
  --ddboost-backupdir when the Data Domain Boost credentials were set.
 
--G (dump global objects) 
+-G
 
  Use pg_dumpall to dump global objects such as roles and tablespaces. 
  Global objects are dumped in the master data directory to 
@@ -446,14 +446,14 @@ OPTIONS
  from cluster's config file, under the default directory configured by
  --ddboost-backupdir when the Data Domain Boost credentials were set.
 
--h (record dump details) 
+-h
 
  Record details of database dump in database table 
  public.gpcrondump_history in database supplied via -x option. Utility 
  will create table if it does not currently exist. 
  This option will be deprecated in a future release.
 
--H (disable recording dump details)
+-H
 
  Disable recording details of database dump in database table
  public.gpcrondump_history in database supplied via -x option.
@@ -461,7 +461,7 @@ OPTIONS
  public.gpcrondump_history table.
  -H option cannot be selected with -h option.
 
---incremental (backup changes to append-optimized tables)
+--incremental
 
  Adds an incremental backup to a backup set. When performing an 
  incremental backup, the complete backup set created prior to the 
@@ -521,7 +521,7 @@ OPTIONS
  If --incremental is specified, this option is not supported. 
 
 
--j (vacuum before dump) 
+-j
 
  Run VACUUM before the dump starts. 
 
@@ -567,7 +567,7 @@ OPTIONS
  supported. 
 
 
--k (vacuum after dump) 
+-k
 
  Run VACUUM after the dump has completed successfully. 
 
@@ -629,7 +629,7 @@ OPTIONS
  Do not output commands to set object privileges (GRANT/REVOKE commands). 
 
 
--o (clear old dump files only)
+-o
 
  Clear out old dump files only, but do not run a dump. This will remove 
  the oldest dump directory except the current date's dump directory. 
@@ -671,13 +671,13 @@ OPTIONS
  is not supported.
 
 
--q (no screen output) 
+-q
 
  Run in quiet mode. Command output is not displayed on the screen, but is 
  still written to the log file. 
 
 
--r (rollback on failure) 
+-r
 
  Rollback the dump files (delete a partial dump) if a failure is 
  detected. The default is to not rollback. 
@@ -822,7 +822,7 @@ OPTIONS
  Specifies verbose mode. 
 
 
---version (show utility version) 
+--version
 
  Displays the version of this utility. 
 
@@ -833,7 +833,7 @@ OPTIONS
  multiple databases. 
 
 
--z (no compression) 
+-z
 
  Do not use compression. Default is to compress the dump files using 
  gzip. 
@@ -842,7 +842,7 @@ OPTIONS
  backups. 
 
 
--? (help) 
+-?
 
  Displays the online help. 
 

--- a/gpMgmt/doc/gpdbrestore_help
+++ b/gpMgmt/doc/gpdbrestore_help
@@ -122,7 +122,7 @@ directory by default.
 *****************************************************
 OPTIONS
 *****************************************************
--a (do not prompt) 
+-a
 
  Do not prompt the user for confirmation. 
 
@@ -185,7 +185,7 @@ OPTIONS
  This option is not supported if --netbackup-service-host is specified. 
 
 
--e (drop target database before restore) 
+-e
 
  Drops the target database before doing the restore and then recreates 
  it. 
@@ -217,13 +217,13 @@ OPTIONS
  backup.
 
 
--L (list tablenames in backup set) 
+-L
 
  When used with the -t option, lists the table names that exist in the 
  named backup set and exits. Does not perform a restore. 
 
 
--m (restore metadata only)
+-m
 
  Performs a restore of database metadata (schema and table definitions, SET
  statements, and so forth) without restoring data.  If the --restore-stats or
@@ -286,7 +286,7 @@ OPTIONS
  that were included or excluded for the backup. 
 
 
--q (no screen output) 
+-q
 
  Run in quiet mode. Command output is not displayed on the screen, but is 
  still written to the log file. 
@@ -407,12 +407,12 @@ OPTIONS
  Specifies verbose mode. 
 
 
---version (show utility version) 
+--version
 
  Displays the version of this utility. 
 
 
--? (help) 
+-?
 
  Displays the online help. 
 

--- a/gpMgmt/doc/gpinitstandby_help
+++ b/gpMgmt/doc/gpinitstandby_help
@@ -70,12 +70,12 @@ management.
 OPTIONS
 *****************************************************
 
--a (do not prompt) 
+-a
 
  Do not prompt the user for confirmation. 
 
 
--D (debug) 
+-D
 
  Sets logging level to debug. 
 
@@ -102,7 +102,7 @@ OPTIONS
  The directory to write the log file. Defaults to ~/gpAdminLogs. 
 
 
--n (restart standby master) 
+-n
 
  Specify this option to start a Greenplum Database standby master that 
  has been configured but has stopped for some reason. 
@@ -120,13 +120,13 @@ OPTIONS
  returns an error. 
 
 
--q (no screen output) 
+-q
 
  Run in quiet mode. Command output is not displayed on the screen, but is 
  still written to the log file. 
 
 
--r (remove standby master) 
+-r
 
  Removes the currently configured standby master host from your Greenplum 
  Database system. 
@@ -137,13 +137,13 @@ OPTIONS
  The host name of the standby master host. 
 
 
--v (show utility version) 
+-v
 
  Displays the version, status, last updated date, and check sum of this 
  utility. 
 
 
--? (help) 
+-?
 
  Displays the online help. 
 

--- a/gpMgmt/doc/gpinitsystem_help
+++ b/gpMgmt/doc/gpinitsystem_help
@@ -70,7 +70,7 @@ This utility performs the following tasks:
 OPTIONS
 *****************************************************
 
--a (do not prompt)
+-a
 
  Do not prompt the user for confirmation.
 
@@ -87,7 +87,7 @@ OPTIONS
  contains all of the defined parameters to configure and initialize a 
  new Greenplum system. See INITIALIZATION CONFIGURATION FILE FORMAT below.
 
--D (debug)
+-D
 
  Sets log output level to debug.
 
@@ -178,7 +178,7 @@ OPTIONS
  the gpconfig utility.
 
 
--q (no screen output)
+-q
 
  Run in quiet mode. Command output is not displayed on the screen, 
  but is still written to the log file.
@@ -223,7 +223,7 @@ OPTIONS
  change default passwords immediately after installation.
 
 
--S (spread mirror configuration)
+-S
 
  If mirroring parameters are specified, spreads the mirror segments 
  across the available hosts. The default is to group the set of mirror 
@@ -234,12 +234,12 @@ OPTIONS
  than the number of segment instances).
 
 
--v (show utility version)
+-v
 
  Displays the version of this utility.
 
 
--? (help)
+-?
 
  Displays the online help.
 

--- a/gpMgmt/doc/gpmfr_help
+++ b/gpMgmt/doc/gpmfr_help
@@ -80,7 +80,7 @@ Domain system.
 OPTIONS
 *****************************************************
 
--a (do not prompt) 
+-a
 
  Do not prompt the user for confirmation. Progress information is 
  displayed on the output. Specify the option -q or --quiet to write 
@@ -147,7 +147,7 @@ OPTIONS
  systems.
 
 
--q | --quiet (no screen output) 
+-q | --quiet
 
  Runs in quiet mode. File transfer progress information is not displayed 
  on the output, it is written to the log file. If this option is not 

--- a/gpMgmt/doc/gppkg_help
+++ b/gpMgmt/doc/gppkg_help
@@ -59,7 +59,7 @@ OPTIONS
 *****************************************************
 
 Options
--a (do not prompt)
+-a
 
  Do not prompt the user for confirmation.
 

--- a/gpMgmt/doc/gprecoverseg_help
+++ b/gpMgmt/doc/gprecoverseg_help
@@ -114,7 +114,7 @@ gpstop -r
 OPTIONS
 ******************************************************
 
--a (do not prompt)
+-a
 
 Do not prompt the user for confirmation.
 
@@ -132,7 +132,7 @@ Optional. The master host data directory. If not specified,
 the value set for $MASTER_DATA_DIRECTORY will be used.
 
 
--F (full recovery)
+-F
 
 Optional. Perform a full copy of the active segment instance 
 in order to recover the failed segment. The default is to 
@@ -241,13 +241,13 @@ exchanged, number of network interfaces, network interface naming
 convention, and so on.).
 
 
--q (no screen output)
+-q
 
 Run in quiet mode. Command output is not displayed on 
 the screen, but is still written to the log file.
 
 
--r (rebalance segments)
+-r
 
 After a segment recovery, segment instances may not be returned to the 
 preferred role that they were given at system initialization time. This 
@@ -288,15 +288,15 @@ filespace configuration file in the format that is
 required by the -s option. This file should be edited 
 to supply the correct alternate filespace locations.
 
--v (verbose)
+-v
 
 Sets logging output to verbose.
 
---version (version)
+--version
 
 Displays the version of this utility.
 
--? (help)
+-?
 Displays the online help.
 
 

--- a/gpMgmt/doc/gpreload_help
+++ b/gpMgmt/doc/gpreload_help
@@ -55,7 +55,7 @@ data.
 OPTIONS
 *****************************************************
 
--a (do not prompt)
+-a
 
  Optional. If specified, the gpreload utility does not prompt the user
  for confirmation. 
@@ -111,12 +111,12 @@ OPTIONS
  ascending order. 
 
 
---version (show utility version)
+--version
 
  Displays the version of this utility.
 
 
--? (help)
+-?
 
  Displays the online help.
 

--- a/gpMgmt/doc/gpstart_help
+++ b/gpMgmt/doc/gpstart_help
@@ -42,7 +42,7 @@ the system using gpinitsystem first.
 OPTIONS
 *****************************************************
 
--a (do not prompt)
+-a
 
   Do not prompt the user for confirmation.
 
@@ -65,7 +65,7 @@ OPTIONS
   The directory to write the log file. Defaults to ~/gpAdminLogs.
 
 
--m (master only)
+-m
 
   Optional. Starts the master instance only, which may be necessary 
   for maintenance tasks. This mode only allows connections to the master 
@@ -78,13 +78,13 @@ OPTIONS
   may lead to a split-brain condition and possible data loss.
 
 
--q (no screen output)
+-q
 
   Run in quiet mode. Command output is not displayed on the screen, 
   but is still written to the log file.
 
 
--R (restricted mode)
+-R
 
   Starts Greenplum Database in restricted mode (only database superusers 
   are allowed to connect).
@@ -100,23 +100,23 @@ OPTIONS
   is 60 seconds.
 
 
--v (verbose output)
+-v
 
   Displays detailed status, progress and error messages output by the utility.
 
 
--y (do not start standby master)
+-y
 
   Optional. Do not start the standby master host. The default is to start 
   the standby master host and synchronization process.
 
 
--? | -h | --help (help)
+-? | -h | --help
 
   Displays the online help.
 
 
---version (show utility version)
+--version
 
   Displays the version of this utility.
 

--- a/gpMgmt/doc/gpstop_help
+++ b/gpMgmt/doc/gpstop_help
@@ -51,7 +51,7 @@ changes until they reconnect to the database.
 OPTIONS
 *****************************************************
 
--a (do not prompt)
+-a
 
  Do not prompt the user for confirmation.
 
@@ -74,19 +74,19 @@ OPTIONS
  The directory to write the log file. Defaults to ~/gpAdminLogs.
 
 
--m (master only)
+-m
 
  Optional. Shuts down a Greenplum master instance that was 
  started in maintenance mode.
 
 
--M fast (fast shutdown - rollback)
+-M fast
 
  Fast shut down. Any transactions in progress are interrupted 
  and rolled back. 
 
 
--M immediate (immediate shutdown - abort)
+-M immediate
 
  Immediate shut down. Any transactions in progress are aborted. This 
  shutdown mode is not recommended, and in some circumstances can cause 
@@ -97,19 +97,19 @@ OPTIONS
  in-process work files. 
 
 
--M smart (smart shutdown - warn)
+-M smart
  
  Smart shut down. If there are active connections, this command 
  fails with a warning. This is the default shutdown mode.
 
 
--q (no screen output)
+-q
 
  Run in quiet mode. Command output is not displayed on the 
  screen, but is still written to the log file.
 
 
--r (restart)
+-r
 
  Restart after shutdown is complete.
 
@@ -127,7 +127,7 @@ OPTIONS
  and surpass the default timeout period of 600 seconds.
 
 
--u (reload pg_hba.conf and postgresql.conf files only)
+-u
 
  This option reloads the pg_hba.conf files of the master and 
  segments and the runtime parameters of the postgresql.conf files 
@@ -137,24 +137,24 @@ OPTIONS
  configuration parameters that are designated as runtime parameters.
 
 
--v (verbose output)
+-v
 
  Displays detailed status, progress and error messages output 
  by the utility.
 
 
---version (show utility version)
+--version
 
  Displays the version of this utility.
 
 
--y (do not stop standby master)
+-y
 
  Do not stop the standby master process. The default is to stop 
  the standby master.
 
 
--? | -h | --help (help)
+-? | -h | --help
 
  Displays the online help.
 

--- a/gpdb-doc/dita/best_practices/data_loading.xml
+++ b/gpdb-doc/dita/best_practices/data_loading.xml
@@ -52,7 +52,7 @@
         which has a <codeph>LOCATION</codeph> clause to define the location of the data and a
           <codeph>FORMAT</codeph> clause to define the formatting of the source data so that the
         system can parse the input data. Files use the <codeph>file://</codeph> protocol, and must
-        reside on a segment host in a location accessible by the Greenplum super user. The data can
+        reside on a segment host in a location accessible by the Greenplum superuser. The data can
         be spread out among the segment hosts with no more than one file per primary segment on each
         host. The number of files listed in the <codeph>LOCATION</codeph> clause is the number of
         segments that will read the external table in parallel. </p>

--- a/gpdb-doc/dita/client_tool_guides/client/windows/win_client_run.xml
+++ b/gpdb-doc/dita/client_tool_guides/client/windows/win_client_run.xml
@@ -85,7 +85,7 @@ $ psql.exe</codeblock>
             <p>After connecting to a database, <codeph>psql</codeph> provides a prompt with the name
                 of the database to which <codeph>psql</codeph> is currently connected, followed by
                 the string <codeph>=&gt;</codeph> (or <codeph>=#</codeph> if you are the database
-                super user). For example:</p>
+                superuser). For example:</p>
             <codeblock>gpdatabase=&gt;</codeblock>
             <p>At the prompt, you may type in SQL commands. A SQL command must end with a
                     <codeph>;</codeph> (semicolon) in order to be sent to the server and executed.

--- a/gpdb-doc/dita/ref_guide/extensions/pl_java.xml
+++ b/gpdb-doc/dita/ref_guide/extensions/pl_java.xml
@@ -859,7 +859,7 @@ Date(System.currentTimeMillis()));</codeblock>
     <topic id="topic29" xml:lang="en">
       <title id="pv157625">Installation</title>
       <body>
-        <p>Only a database super user can install PL/Java. The PL/Java utility functions are
+        <p>Only a database superuser can install PL/Java. The PL/Java utility functions are
           installed using SECURITY DEFINER so that they execute with the access permissions that
           where granted to the creator of the functions.</p>
       </body>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpinitsystem.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpinitsystem.xml
@@ -64,7 +64,7 @@
             <title>Options</title>
             <parml>
                 <plentry>
-                    <pt>-a (do not prompt)</pt>
+                    <pt>-a</pt>
                     <pd>Do not prompt the user for confirmation.</pd>
                 </plentry>
                 <plentry>
@@ -80,7 +80,7 @@
                             format="dita"/> for a description of this file.</pd>
                 </plentry>
                 <plentry>
-                    <pt>-D (debug)</pt>
+                    <pt>-D</pt>
                     <pd>Sets log output level to debug.</pd>
                 </plentry>
                 <plentry>
@@ -168,7 +168,7 @@
                             <codeph>gpconfig</codeph> utility.</pd>
                 </plentry>
                 <plentry>
-                    <pt>-q (no screen output)</pt>
+                    <pt>-q</pt>
                     <pd>Run in quiet mode. Command output is not displayed on the screen, but is
                         still written to the log file.</pd>
                 </plentry>
@@ -200,7 +200,7 @@
                         </ul></pd>
                 </plentry>
                 <plentry>
-                    <pt>-S (spread mirror configuration)</pt>
+                    <pt>-S</pt>
                     <pd>If mirroring parameters are specified, spreads the mirror segments across
                         the available hosts. The default is to group the set of mirror segments
                         together on an alternate host from their primary segment set. Mirror

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpinitsystem.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpinitsystem.xml
@@ -14,7 +14,7 @@
             [<b>-B</b> <varname>parallel_processes</varname>] 
             [<b>-p</b> <varname>postgresql_conf_param_file</varname>]
             [<b>-s</b> <varname>standby_master_host</varname>]
-            [<b>--max_connections</b>=<varname>number</varname>] [<b>--shared_buffers</b> <varname>=size</varname>]
+            [<b>--max_connections</b>=<varname>number</varname>] [<b>--shared_buffers</b>=<varname>size</varname>]
             [<b>--locale</b>=<varname>locale</varname>] [<b>--lc-collate</b>=<varname>locale</varname>] 
             [<b>--lc-ctype</b>=<varname>locale</varname>] [<b>--lc-messages</b>=<varname>locale</varname>] 
             [<b>--lc-monetary</b>=<varname>locale</varname>] [<b>--lc-numeric</b>=<varname>locale</varname>] 

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpmfr.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpmfr.xml
@@ -76,7 +76,7 @@
          <title>Options</title>
          <parml>
             <plentry>
-               <pt>-a (do not prompt)</pt>
+               <pt>-a</pt>
                <pd>Do not prompt the user for confirmation. Progress information is displayed on the
                   output. Specify the option <codeph>-q</codeph> or <codeph>--quiet</codeph> to
                   write progress information to the log file.</pd>
@@ -138,7 +138,7 @@
                   copying the backup set between the local and remote Data Domain systems.</pd>
             </plentry>
             <plentry>
-               <pt>-q | --quiet (no screen output)</pt>
+               <pt>-q | --quiet</pt>
                <pd>Runs in quiet mode. File transfer progress information is not displayed on the
                   output, it is written to the log file. If this option is not specified, progress
                   information is only displayed on screen, it is not written to the log file.</pd>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpmfr.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpmfr.xml
@@ -11,23 +11,23 @@
       <section id="section2">
          <title>Synopsis</title>
          <codeblock><b>gpmfr</b> <b>--delete</b> {<b>LATEST</b> | <b>OLDEST</b> | <varname>timestamp</varname>}[<b>--remote</b>]
-   [<b>--master-port=</b> <varname>master_port</varname>] [<b>--skip-ping</b>] 
-   [<b>--ddboost-storage-unit</b> =<varname>unit-ID</varname>]
+   [<b>--master-port=</b><varname>master_port</varname>] [<b>--skip-ping</b>]
+   [<b>--ddboost-storage-unit</b>=<varname>unit-ID</varname>]
    [<b>-a</b>] [<b>-v</b> | <b>--verbose</b>]
 
 <b>gpmfr</b> {<b>--replicate | --recover</b>} {<b>LATEST</b> | <b>OLDEST | </b> <varname>timestamp</varname>}
-   <b>--max-streams </b> <varname>max_IO_streams</varname> [<b>--master-port=</b> <varname>master_port</varname>] <b>[--skip-ping]</b>
-   [<b>--ddboost-storage-unit</b> =<varname>unit-ID</varname>]
+   <b>--max-streams</b> <varname>max_IO_streams</varname> [<b>--master-port=</b> <varname>master_port</varname>] <b>[--skip-ping]</b>
+   [<b>--ddboost-storage-unit</b>=<varname>unit-ID</varname>]
    [<b>-a</b>] [<b>-q</b> | <b>--quiet</b>] [<b>-v</b> | <b>--verbose</b>]
 
 <b>gpmfr</b> {<b>--list</b> {<b>LATEST</b> | <b>OLDEST</b> | <varname>timestamp</varname>} }
-   [<b>--ddboost-storage-unit</b> =<varname>unit-ID</varname>]
-   [<b>--master-port=</b> <varname>master_port</varname>] [<b>--remote</b>] [<b>--skip-ping</b>]
+   [<b>--ddboost-storage-unit</b>=<varname>unit-ID</varname>]
+   [<b>--master-port=</b><varname>master_port</varname>] [<b>--remote</b>] [<b>--skip-ping</b>]
    [<b>-v</b> | <b>--verbose</b>]
 
 <b>gpmfr</b> <b>--list-files</b> {<b>LATEST</b> | <b>OLDEST</b> | <varname>timestamp</varname>}
-   [<b>--ddboost-storage-unit</b> =<varname>unit-ID</varname>]
-   [<b>--master-port=</b> <varname>master_port</varname>] [<b>--remote</b>] [<b>--skip-ping</b>]
+   [<b>--ddboost-storage-unit</b>=<varname>unit-ID</varname>]
+   [<b>--master-port=</b><varname>master_port</varname>] [<b>--remote</b>] [<b>--skip-ping</b>]
    [-v | <b>--verbose</b>]
 
 <b>gpmfr</b> <b>--show-streams</b> [<b>--skip-ping</b>] [<b>-v</b> | <b>--verbose</b>]
@@ -105,7 +105,7 @@
                   identified by the <codeph>timestamp</codeph>.</pd>
             </plentry>
             <plentry>
-               <pt>--list </pt>
+               <pt>--list</pt>
                <pd>Lists the Greenplum Database backup sets that are on the local Data Domain
                   system. The backup sets are identified by timestamps
                      (<codeph>yyyymmddhhmmss</codeph>). </pd>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpstart.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpstart.xml
@@ -37,7 +37,7 @@
             <title>Options</title>
             <parml>
                 <plentry>
-                    <pt>-a (do not prompt)</pt>
+                    <pt>-a</pt>
                     <pd>Do not prompt the user for confirmation.</pd>
                 </plentry>
                 <plentry>
@@ -57,7 +57,7 @@
                             <codeph>~/gpAdminLogs</codeph>.</pd>
                 </plentry>
                 <plentry>
-                    <pt>-m (master only)</pt>
+                    <pt>-m</pt>
                     <pd>Optional. Starts the master instance only, which may be useful for
                         maintenance tasks. This mode only allows connections to the master in
                         utility mode. For example:</pd>
@@ -66,12 +66,12 @@
                     </pd>
                 </plentry>
                 <plentry>
-                    <pt>-q (no screen output)</pt>
+                    <pt>-q</pt>
                     <pd>Run in quiet mode. Command output is not displayed on the screen, but is
                         still written to the log file.</pd>
                 </plentry>
                 <plentry>
-                    <pt>-R (restricted mode)</pt>
+                    <pt>-R</pt>
                     <pd>Starts Greenplum Database in restricted mode (only database superusers are
                         allowed to connect).</pd>
                 </plentry>
@@ -85,21 +85,21 @@
                         seconds.</pd>
                 </plentry>
                 <plentry>
-                    <pt>-v (verbose output)</pt>
+                    <pt>-v</pt>
                     <pd>Displays detailed status, progress and error messages output by the
                         utility.</pd>
                 </plentry>
                 <plentry>
-                    <pt>-y (do not start standby master)</pt>
+                    <pt>-y</pt>
                     <pd>Optional. Do not start the standby master host. The default is to start the
                         standby master host and synchronization process.</pd>
                 </plentry>
                 <plentry>
-                    <pt>-? | -h | --help (help)</pt>
+                    <pt>-? | -h | --help</pt>
                     <pd>Displays the online help.</pd>
                 </plentry>
                 <plentry>
-                    <pt>--version (show utility version)</pt>
+                    <pt>--version</pt>
                     <pd>Displays the version of this utility.</pd>
                 </plentry>
             </parml>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpstop.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpstop.xml
@@ -43,7 +43,7 @@
             <title>Options</title>
             <parml>
                 <plentry>
-                    <pt>-a (do not prompt)</pt>
+                    <pt>-a</pt>
                     <pd>Do not prompt the user for confirmation.</pd>
                 </plentry>
                 <plentry>
@@ -63,34 +63,34 @@
                             <codeph>~/gpAdminLogs</codeph>.</pd>
                 </plentry>
                 <plentry>
-                    <pt>-m (master only)</pt>
+                    <pt>-m</pt>
                     <pd>Optional. Shuts down a Greenplum master instance that was started in
                         maintenance mode.</pd>
                 </plentry>
                 <plentry>
-                    <pt>-M fast (fast shutdown - rollback)</pt>
+                    <pt>-M fast</pt>
                     <pd>Fast shut down. Any transactions in progress are interrupted and rolled
                         back.</pd>
                 </plentry>
                 <plentry>
-                    <pt>-M immediate (immediate shutdown - abort)</pt>
+                    <pt>-M immediate</pt>
                     <pd>Immediate shut down. Any transactions in progress are aborted. </pd>
                     <pd>This mode kills all <codeph>postgres</codeph> processes without allowing the
                         database server to complete transaction processing or clean up any temporary
                         or in-process work files.</pd>
                 </plentry>
                 <plentry>
-                    <pt>-M smart (smart shutdown - warn)</pt>
+                    <pt>-M smart</pt>
                     <pd>Smart shut down. If there are active connections, this command fails with a
                         warning. This is the default shutdown mode.</pd>
                 </plentry>
                 <plentry>
-                    <pt>-q (no screen output)</pt>
+                    <pt>-q</pt>
                     <pd>Run in quiet mode. Command output is not displayed on the screen, but is
                         still written to the log file.</pd>
                 </plentry>
                 <plentry>
-                    <pt>-r (restart)</pt>
+                    <pt>-r</pt>
                     <pd>Restart after shutdown is complete.</pd>
                 </plentry>
                 <plentry>
@@ -106,8 +106,7 @@
                         timeout period of 600 seconds.</pd>
                 </plentry>
                 <plentry>
-                    <pt>-u (reload <codeph>pg_hba.conf</codeph> and <codeph>postgresql.conf</codeph>
-                        files only)</pt>
+                    <pt>-u</pt>
                     <pd>This option reloads the <codeph>pg_hba.conf</codeph> files of the master and
                         segments and the runtime parameters of the <codeph>postgresql.conf</codeph>
                         files but does not shutdown the Greenplum Database array. Use this option to
@@ -117,21 +116,21 @@
                             <i>runtime</i> parameters.</pd>
                 </plentry>
                 <plentry>
-                    <pt>-v (verbose output)</pt>
+                    <pt>-v</pt>
                     <pd>Displays detailed status, progress and error messages output by the
                         utility.</pd>
                 </plentry>
                 <plentry>
-                    <pt>-y (do not stop standby master)</pt>
+                    <pt>-y</pt>
                     <pd>Do not stop the standby master process. The default is to stop the standby
                         master.</pd>
                 </plentry>
                 <plentry>
-                    <pt>-? | -h | --help (help)</pt>
+                    <pt>-? | -h | --help</pt>
                     <pd>Displays the online help.</pd>
                 </plentry>
                 <plentry>
-                    <pt>--version (show utility version)</pt>
+                    <pt>--version</pt>
                     <pd>Displays the version of this utility.</pd>
                 </plentry>
             </parml>


### PR DESCRIPTION
A small collection of things that caught my eye when reading documentation. It might just be me who dislike the short descriptions we have on some options, but I find them superfluous at best (cofusing at worst). The full description is plenty to describe the option.

Ping @dyozie @mkiyama 