### PR TITLE
Fix broken string in database version reporting

### DIFF
--- a/configure
+++ b/configure
@@ -5497,7 +5497,7 @@ else
 fi
 
 cat >>confdefs.h <<_ACEOF
-#define PG_VERSION_STR "PostgreSQL $PG_VERSION (Greenplum Database $GP_VERSION) on $host, compiled by $cc_string"
+#define PG_VERSION_STR "PostgreSQL $PG_PACKAGE_VERSION (Greenplum Database $GP_VERSION) on $host, compiled by $cc_string"
 _ACEOF
 
 

--- a/configure.in
+++ b/configure.in
@@ -587,7 +587,7 @@ else
   cc_string=$CC
 fi
 AC_DEFINE_UNQUOTED(PG_VERSION_STR,
-                   ["PostgreSQL $PG_VERSION (Greenplum Database $GP_VERSION) on $host, compiled by $cc_string"],
+                   ["PostgreSQL $PG_PACKAGE_VERSION (Greenplum Database $GP_VERSION) on $host, compiled by $cc_string"],
                    [A string containing the version number, platform, and C compiler])
 
 AC_DEFINE_UNQUOTED(GP_VERSION,

--- a/src/test/regress/expected/gp_metadata.out
+++ b/src/test/regress/expected/gp_metadata.out
@@ -1,0 +1,12 @@
+select version() ~ '^PostgreSQL ([0-9]+\.){2}([0-9]+)? \(Greenplum Database ([0-9]+\.){2}[0-9]+.+' as version;
+ version
+---------
+ t
+(1 row)
+
+select gp_opt_version() ~ '^GPOPT version: ([0-9]+\.){2}[0-9]+, Xerces version: ([0-9]+\.){2}[0-9]+$' as version;
+ version
+---------
+ t
+(1 row)
+

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -15,7 +15,7 @@
 #   hitting max_connections limit on segments.
 #
 
-test: variadic_parameters default_parameters function_extensions spi
+test: gp_metadata variadic_parameters default_parameters function_extensions spi
 
 test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp gpcopy gp_create_table
 test: filter gpctas gpdist matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var gp_explain

--- a/src/test/regress/sql/gp_metadata.sql
+++ b/src/test/regress/sql/gp_metadata.sql
@@ -1,0 +1,2 @@
+select version() ~ '^PostgreSQL ([0-9]+\.){2}([0-9]+)? \(Greenplum Database ([0-9]+\.){2}[0-9]+.+' as version;
+select gp_opt_version() ~ '^GPOPT version: ([0-9]+\.){2}[0-9]+, Xerces version: ([0-9]+\.){2}[0-9]+$' as version;


### PR DESCRIPTION
When splitting the Greenplum and PostgreSQL versioning in autoconf, the wrong variable was used when building the version string. This fixes issue #2375