### PR TITLE
Reduce backup/restore test flakiness

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -657,7 +657,7 @@ def impl(context, dbname, tablename):
 @when('the segments are synchronized')
 @then('the segments are synchronized')
 def impl(context):
-    times = 30
+    times = 60
     sleeptime = 10
 
     for i in range(times):

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/utilities/backup_restore/full/__init__.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/utilities/backup_restore/full/__init__.py
@@ -105,7 +105,7 @@ class BackupTestCase(TINCTestCase):
 
         #If a DDBOOST Directory wasn't specify create one
         if 'DDBOOST_DIR' not in BackupTestCase.TSTINFO:
-            dir = os.getenv('PULSE_PROJECT') + '_DIR'
+            dir = os.getenv('PULSE_PROJECT', default='GPDB') + os.getenv('PULSE_BUILD_VERSION', default='') + '_DIR'
         BackupTestCase.TSTINFO['DDBOOST_DIR'] = dir
 
         tinctest.logger.info("Using %s as the DDBoost directory to store backups" % BackupTestCase.TSTINFO['DDBOOST_DIR'])

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/utilities/backup_restore/full/test_mfr.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/utilities/backup_restore/full/test_mfr.py
@@ -423,8 +423,12 @@ class test_mfr(BackupTestCase):
                                   secondary_dumped_files, ALTERNATIVE_STORAGE_UNIT, 'remote')
 
     def test_23_remove_backup_dir(self):
+        cmd_check_dir = "gpddboost --listDirectory --dir=%s" % BackupTestCase.TSTINFO['DDBOOST_DIR']
+        (err, out) = self.run_command(cmd_check_dir)
+        if err:
+            return
         cmd_del_dir = "gpddboost --del-dir=%s" % BackupTestCase.TSTINFO['DDBOOST_DIR']
         (err, out) = self.run_command(cmd_del_dir)
         if err:
-            msg = "Failed to delete backup directory\n" % BackupTestCase.TSTINFO['DDBOOST_DIR']
+            msg = "Failed to delete backup directory %s\n" % BackupTestCase.TSTINFO['DDBOOST_DIR']
             raise Exception('Error: %s\n%s'% (msg,out))

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/utilities/backup_restore/incremental/__init__.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/utilities/backup_restore/incremental/__init__.py
@@ -77,7 +77,7 @@ class BackupTestCase(TINCTestCase):
 
             #If a DDBOOST Directory wasn't specify create one
             if 'DDBOOST_DIR' not in BackupTestCase.TSTINFO:
-                dir = os.getenv('PULSE_PROJECT') + '_DIR'
+                dir = os.getenv('PULSE_PROJECT', default='GPDB') + os.getenv('PULSE_BUILD_VERSION', default='') + '_DIR'
             BackupTestCase.TSTINFO['DDBOOST_DIR'] = dir
 
             tinctest.logger.info("Using %s as the DDBoost directory to store backups" % BackupTestCase.TSTINFO['DDBOOST_DIR'])


### PR DESCRIPTION
This reduces some of the flakiness in the backup/restore test suites.

* Increases time for segments to become synchronized after gprecoverseg.
* Allows parallel runs of DDBoost tests by making the directory based on the build number
* Checks that directory exists on Data Domain server before attempting to clean up directory