### PR TITLE
Skip squelchNodeWalker when there is a SharedInputScan shared in the same slice

### DIFF
--- a/src/test/regress/expected/qp_with_clause.out
+++ b/src/test/regress/expected/qp_with_clause.out
@@ -10144,14 +10144,35 @@ ORDER BY 1, 2, 3, 4 DESC LIMIT 25;
  1025NAME      |            625 | 5NAME        |              1
 (25 rows)
 
+-- Test that SharedInputScan within the same slice is always executed 
+set gp_cte_sharing=on;
+-- start_ignore
+CREATE TABLE car (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE zoo (c int, d int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into car select i, (i+1) from generate_series(1,10) i;
+insert into zoo values (4,4);
+-- end_ignore
+WITH c as (SELECT sum(a) as a_sum, b FROM car GROUP BY b)
+SELECT * FROM c as c1, zoo WHERE zoo.c != 4 AND c1.b = zoo.c
+UNION ALL
+SELECT * FROM c as c1, zoo WHERE zoo.c = c1.b;
+ a_sum | b | c | d 
+-------+---+---+---
+     3 | 4 | 4 | 4
+(1 row)
+
 -- start_ignore
 drop schema qp_with_clause cascade;
+NOTICE:  drop cascades to table zoo
+NOTICE:  drop cascades to table car
 NOTICE:  drop cascades to table manager
 NOTICE:  drop cascades to table emp
 NOTICE:  drop cascades to table bar
 NOTICE:  drop cascades to table foo
-NOTICE:  drop cascades to table y
-NOTICE:  drop cascades to table x
 NOTICE:  drop cascades to table tbl87
 NOTICE:  drop cascades to append only columnar table countrylanguage_co
 NOTICE:  drop cascades to append only columnar table country_co

--- a/src/test/regress/sql/qp_with_clause.sql
+++ b/src/test/regress/sql/qp_with_clause.sql
@@ -10239,6 +10239,21 @@ WHERE  e.deptno = dc1.deptno AND
        m.deptno = dmc1.dept_mgr_no
 ORDER BY 1, 2, 3, 4 DESC LIMIT 25;
 
+-- Test that SharedInputScan within the same slice is always executed 
+set gp_cte_sharing=on;
+
+-- start_ignore
+CREATE TABLE car (a int, b int);
+CREATE TABLE zoo (c int, d int);
+insert into car select i, (i+1) from generate_series(1,10) i;
+insert into zoo values (4,4);
+-- end_ignore
+
+WITH c as (SELECT sum(a) as a_sum, b FROM car GROUP BY b)
+SELECT * FROM c as c1, zoo WHERE zoo.c != 4 AND c1.b = zoo.c
+UNION ALL
+SELECT * FROM c as c1, zoo WHERE zoo.c = c1.b;
+
 -- start_ignore
 drop schema qp_with_clause cascade;
 -- end_ignore


### PR DESCRIPTION
When a query plan produced by planner has a SharedInputScan that is shared with the same slice and a Redistribute Motion beneath the `SharedInputScan` then there are some cases where the resulting relation will be empty. For example in the following query plan:

![plan_tree](https://cloud.githubusercontent.com/assets/449917/25765213/acb224da-31a0-11e7-9b6c-08897f806488.gif)

The left subtree of the `Append` operation has its `HashJoin` operation short-circuited because the inner Hash Operator returns 0 rows. This results in `squelchNodeWalker` to be called. This will cause the Redistribute Motion to be stopped and the second `SharedInputScan` (slice:6 id:1) will see 0 rows because the tuples were never received. 

The fix implemented in this patch is to check if a same slice `SharedInputScan` exists in a subtree when executing `squelchNodeWalker` and to return immediately. This ensures that the next consumer of the SharedInputScan can actually execute the subtree and receive the rows from the `MotionNode`.