### PR TITLE
Add a new utility pgnormalizer

### DIFF
--- a/gpMgmt/bin/gppylib/test/unit/test_unit_pgnormalizer.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_pgnormalizer.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+import sys
+import StringIO
+import mock
+
+import pgnormalizer
+
+__copyright__ = "Copyright (c) 2017-Present Pivotal Software, Inc"
+
+
+class PGNOptionTest(unittest.TestCase):
+    def test_option_empty(self):
+        argv = [""]
+        self.assertRaises(pgnormalizer.PGNError, pgnormalizer.PGNOption, argv)
+
+    def test_option_with_both_r_and_e(self):
+        argv = ["", "-r", "-e"]
+        self.assertRaises(pgnormalizer.PGNError, pgnormalizer.PGNOption, argv)
+
+    def test_option_empty_without_r_or_e(self):
+        argv = ["", "-c", "abc"]
+        self.assertRaises(pgnormalizer.PGNError, pgnormalizer.PGNOption, argv)
+
+    def test_option_column_delimiter_too_long(self):
+        argv = ["", "-r", "-c", "123456789"]
+        self.assertRaises(pgnormalizer.PGNError, pgnormalizer.PGNOption, argv)
+
+    def test_option_line_delimiter_too_long(self):
+        argv = ["", "-r", "-l", "123456789"]
+        self.assertRaises(pgnormalizer.PGNError, pgnormalizer.PGNOption, argv)
+
+    def test_option_column_delimiter_contains_tab(self):
+        argv = ["", "-r", "-c", "123\t"]
+        self.assertRaises(pgnormalizer.PGNError, pgnormalizer.PGNOption, argv)
+
+    def test_option_column_delimiter_contains_lf(self):
+        argv = ["", "-r", "-c", "123\n"]
+        self.assertRaises(pgnormalizer.PGNError, pgnormalizer.PGNOption, argv)
+
+    def test_option_line_delimiter_contains_tab(self):
+        argv = ["", "-r", "-l", "123\t"]
+        self.assertRaises(pgnormalizer.PGNError, pgnormalizer.PGNOption, argv)
+
+    def test_option_line_delimiter_contains_lf(self):
+        argv = ["", "-r", "-l", "123\n"]
+        self.assertRaises(pgnormalizer.PGNError, pgnormalizer.PGNOption, argv)
+
+    def test_option_with_r_and_c(self):
+        argv = ["", "-r", "-c", "abc"]
+        pgn = pgnormalizer.PGNOption(argv)
+        self.assertEqual(pgn.column_delimiter, "abc")
+        self.assertTrue(pgn.raw_mode)
+        self.assertFalse(pgn.escape_mode)
+
+    def test_option_with_r_and_l(self):
+        argv = ["", "-r", "-l", "abc"]
+        pgn = pgnormalizer.PGNOption(argv)
+        self.assertEqual(pgn.line_delimiter, "abc")
+        self.assertTrue(pgn.raw_mode)
+        self.assertFalse(pgn.escape_mode)
+
+    def test_option_with_r_and_lc(self):
+        argv = ["", "-e", "-c", "abc", "-l", "def"]
+        pgn = pgnormalizer.PGNOption(argv)
+        self.assertEqual(pgn.column_delimiter, "abc")
+        self.assertEqual(pgn.line_delimiter, "def")
+        self.assertTrue(pgn.escape_mode)
+        self.assertFalse(pgn.raw_mode)
+
+    def test_option_unprintable_chars(self):
+        argv = ["", "-r", "-c", "\\x080d", "-l", "\\x0a"]
+        pgn = pgnormalizer.PGNOption(argv)
+        self.assertEqual(pgn.column_delimiter, "\b\r")
+        self.assertEqual(pgn.line_delimiter, "\n")
+        self.assertTrue(pgn.raw_mode)
+        self.assertFalse(pgn.escape_mode)
+
+    def test_option_escape_chars(self):
+        argv = ["", "-r", "-c", "\\b\\r", "-l", "\\b\\b"]
+        pgn = pgnormalizer.PGNOption(argv)
+        self.assertEqual(pgn.column_delimiter, "\b\r")
+        self.assertEqual(pgn.line_delimiter, "\b\b")
+        self.assertTrue(pgn.raw_mode)
+        self.assertFalse(pgn.escape_mode)
+
+
+class PGNReaderTest(unittest.TestCase):
+    def test_write_reading_from_line(self):
+        lines = "1abc11abc111\n2abc22abc222\n3abc33abc333"
+        argv = ["", "-r", "-c", "abc"]
+
+        in_source = StringIO.StringIO(lines)
+        options = pgnormalizer.PGNOption(argv)
+        with mock.patch('sys.stdout') as fake_stdout:
+            pgn = pgnormalizer.PGNormalizer(1024, in_source, sys.stdout)
+            pgn.write_out(options)
+
+        fake_stdout.assert_has_calls([
+            mock.call.write("1\t11\t111\n2\t22\t222\n3"),
+            mock.call.write('\t33\t333'),
+            mock.call.flush()
+        ])
+
+    def test_write_reading_from_chuck(self):
+        lines = "1abc11abc111def2abc22abc222def3abc33abc333"
+        argv = ["", "-r", "-c", "abc", "-l", "def"]
+
+        in_source = StringIO.StringIO(lines)
+        options = pgnormalizer.PGNOption(argv)
+        with mock.patch('sys.stdout') as fake_stdout:
+            pgn = pgnormalizer.PGNormalizer(1024, in_source, sys.stdout)
+            pgn.write_out(options)
+
+        fake_stdout.assert_has_calls([
+            mock.call.write("1\t11\t111\n2\t22\t222\n3"),
+            mock.call.write('\t33\t333'),
+            mock.call.flush()
+        ])
+
+    def test_write_reading_from_chuck_raw(self):
+        lines = "1abc1\n1abc11\t1def2abc2\\t2abc222def3\\nabc33abc333"
+        argv = ["", "-r", "-c", "abc", "-l", "def"]
+
+        in_source = StringIO.StringIO(lines)
+        options = pgnormalizer.PGNOption(argv)
+        with mock.patch('sys.stdout') as fake_stdout:
+            pgn = pgnormalizer.PGNormalizer(1024, in_source, sys.stdout)
+            pgn.write_out(options)
+
+        fake_stdout.assert_has_calls([
+            mock.call.write("1\t1\\n1\t11\\t1\n2\t2\\\\t2\t222\n3\\\\n"),
+            mock.call.write('\t33\t333'),
+            mock.call.flush()
+        ])
+
+    def test_write_reading_from_chuck_escape(self):
+        lines = "1abc1\n1abc11\t1def2abc2\\t2abc222def3\\nabc33abc333"
+        argv = ["", "-e", "-c", "abc", "-l", "def"]
+
+        in_source = StringIO.StringIO(lines)
+        options = pgnormalizer.PGNOption(argv)
+        with mock.patch('sys.stdout') as fake_stdout:
+            pgn = pgnormalizer.PGNormalizer(1024, in_source, sys.stdout)
+            pgn.write_out(options)
+
+        fake_stdout.assert_has_calls([
+            mock.call.write("1\t1\\n1\t11\\t1\n2\t2\\t2\t222\n3\\n"),
+            mock.call.write('\t33\t333'),
+            mock.call.flush()
+        ])
+
+    def test_write_reading_from_small_chuck(self):
+        lines = "1abc11abc111def2abc22abc222def3abc33abc333"
+        argv = ["", "-r", "-c", "abc", "-l", "def"]
+
+        in_source = StringIO.StringIO(lines)
+        out_source = StringIO.StringIO()
+        options = pgnormalizer.PGNOption(argv)
+        pgn = pgnormalizer.PGNormalizer(8, in_source, out_source)
+        pgn.write_out(options)
+        self.assertEqual("1\t11\t111\n2\t22\t222\n3\t33\t333", out_source.getvalue())
+
+    def test_write_with_single_unprintable_char(self):
+        lines = "1\b11\b111\v2\b22\b222\v3\b33\b333"
+        argv = ["", "-r", "-c", "\\x08", "-l", "\\x0b"]
+
+        in_source = StringIO.StringIO(lines)
+        options = pgnormalizer.PGNOption(argv)
+        with mock.patch('sys.stdout') as fake_stdout:
+            pgn = pgnormalizer.PGNormalizer(1024, in_source, sys.stdout)
+            pgn.write_out(options)
+
+        fake_stdout.assert_has_calls([
+            mock.call.write("1\t11\t111\n2\t22\t222\n3"),
+            mock.call.write('\t33\t333'),
+            mock.call.flush()
+        ])
+
+    def test_write_with_multiple_unprintable_chars(self):
+        lines = "1\b\f11\b\f111\v2\b\f22\b\f222\v3\b\f33\b\f333"
+        argv = ["", "-r", "-c", "\\x080c", "-l", "\\x0b"]
+
+        in_source = StringIO.StringIO(lines)
+        options = pgnormalizer.PGNOption(argv)
+        with mock.patch('sys.stdout') as fake_stdout:
+            pgn = pgnormalizer.PGNormalizer(1024, in_source, sys.stdout)
+            pgn.write_out(options)
+
+        fake_stdout.assert_has_calls([
+            mock.call.write("1\t11\t111\n2\t22\t222\n3"),
+            mock.call.write('\t33\t333'),
+            mock.call.flush()
+        ])
+
+    def test_write_with_multiple_unprintable_chars_lc(self):
+        lines = "1\b\f11\b\f111\b\v2\b\f22\b\f222\b\v3\b\f33\b\f333"
+        argv = ["", "-r", "-c", "\\x080c", "-l", "\\x080b"]
+
+        in_source = StringIO.StringIO(lines)
+        options = pgnormalizer.PGNOption(argv)
+        with mock.patch('sys.stdout') as fake_stdout:
+            pgn = pgnormalizer.PGNormalizer(1024, in_source, sys.stdout)
+            pgn.write_out(options)
+
+        fake_stdout.assert_has_calls([
+            mock.call.write("1\t11\t111\n2\t22\t222\n3"),
+            mock.call.write('\t33\t333'),
+            mock.call.flush()
+        ])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/gpMgmt/bin/pgnormalizer.py
+++ b/gpMgmt/bin/pgnormalizer.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import sys
+import getopt
+
+__copyright__ = "Copyright (c) 2017-Present Pivotal Software, Inc"
+
+
+class PGNormalizer:
+    def __init__(self, buffer_size, in_source, out_source):
+        self.buffer_size = buffer_size
+        self.in_source = in_source
+        self.out_source = out_source
+
+    def chunk_reader(self):
+        while True:
+            buf = self.in_source.read(self.buffer_size)
+
+            if buf:
+                yield buf
+            else:
+                return
+
+    def write_out(self, options):
+        last7 = ""
+
+        try:
+            while True:
+                lines = next(self.chunk_reader())
+
+                if options.raw_mode:
+                    lines = lines.replace("\\", "\\\\")
+
+                if options.column_delimiter and options.column_delimiter is not "\t":
+                    lines = lines.replace("\t", "\\t")
+
+                if options.line_delimiter and options.line_delimiter is not "\n":
+                    lines = lines.replace("\n", "\\n")
+
+                lines = last7 + lines
+
+                if options.column_delimiter and options.column_delimiter is not "\t":
+                    lines = lines.replace(options.column_delimiter, "\t")
+
+                if options.line_delimiter and options.line_delimiter is not "\n":
+                    lines = lines.replace(options.line_delimiter, "\n")
+                else:
+                    lines = lines.replace("\r\n", "\n")
+
+                self.out_source.write(lines[:-7])
+                last7 = lines[-7:]
+        except StopIteration:
+            self.out_source.write(last7)
+            self.out_source.flush()
+            return
+
+
+class PGNOption:
+    def __init__(self, sys_argv, options="ec:hl:r"):
+        self.escape_mode = False
+        self.raw_mode = False
+        self.line_delimiter = ""
+        self.column_delimiter = ""
+        self.sys_argv = sys_argv
+        self.options = options
+
+        try:
+            opts, args = getopt.getopt(self.sys_argv[1:], self.options)
+        except getopt.GetoptError as err:
+            raise PGNError(str(err))
+
+        for o, a in opts:
+            if o == "-h":
+                print usage()
+                raise PGNExit()
+            elif o == "-e":
+                self.escape_mode = True
+            elif o == "-r":
+                self.raw_mode = True
+            elif o == "-l":
+                if a.startswith("\\x"):
+                    self.line_delimiter = a[2:].decode("hex")
+                else:
+                    self.line_delimiter = a.decode("unicode-escape")
+            elif o == "-c":
+                if a.startswith("\\x"):
+                    self.column_delimiter = a[2:].decode("hex")
+                else:
+                    self.column_delimiter = a.decode("unicode-escape")
+            else:
+                assert False, "unhandled option"
+
+        if len(self.column_delimiter) > 8 or len(self.line_delimiter) > 8:
+            raise PGNError("The length of delimiter must be smaller than 8.")
+
+        if not self.escape_mode and not self.raw_mode:
+            raise PGNError("You must specify the mode, raw or escape.")
+
+        if self.escape_mode and self.raw_mode:
+            raise PGNError("You can only specify one mode.")
+
+        if len(self.column_delimiter) > 1 and ("\t" in self.column_delimiter or "\n" in self.column_delimiter):
+            raise PGNError("Column delimiters could not contain any TAB or NEWLINE character.")
+
+        if len(self.line_delimiter) > 1 and ("\t" in self.line_delimiter or "\n" in self.line_delimiter):
+            raise PGNError("Line delimiters could not contain any TAB or NEWLINE character.")
+
+
+def usage():
+    return "Usage: " + sys.argv[0] + " -e/r [-c column_delimiter] [-l column_delimiter]"
+
+
+class PGNError(Exception):
+    def __init__(self, msg):
+        self.message = msg
+
+    def __str__(self):
+        return repr(self.message)
+
+
+class PGNExit(Exception):
+    pass
+
+
+def main():
+    try:
+        options = PGNOption(sys.argv)
+    except PGNError as err:
+        sys.stderr.write(err.message + "\n\n" + usage())
+        sys.exit(1)
+    except PGNExit:
+        sys.exit(0)
+
+    pgn = PGNormalizer(64 * 1024 * 1024, sys.stdin, sys.stdout)
+
+    pgn.write_out(options)
+
+    return
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
pgnormalizer will do the on-the-fly transcoding of input data and feed
to gpfdist through pipe, to support multiple characters delimiters while
loading.

Signed-off-by: Haozhou Wang <hawang@pivotal.io>