### PR TITLE
pg_upgrade support for 5.0->5.0 and ICW integration

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -152,6 +152,7 @@ installcheck-world:
 	$(MAKE) -C src/test/kerberos installcheck
 	$(MAKE) -C gpMgmt/bin installcheck
 	gpcheckcat -A
+	$(MAKE) -C contrib/pg_upgrade check
 
 installcheck-resgroup:
 	$(MAKE) -C src/test/isolation2 $@

--- a/contrib/pg_upgrade/.gitignore
+++ b/contrib/pg_upgrade/.gitignore
@@ -1,1 +1,2 @@
 /pg_upgrade
+lalshell

--- a/contrib/pg_upgrade/Makefile
+++ b/contrib/pg_upgrade/Makefile
@@ -3,6 +3,8 @@
 #
 # $PostgreSQL: pgsql/contrib/pg_upgrade/Makefile,v 1.4 2010/07/03 14:23:13 momjian Exp $
 
+top_builddir = ../..
+
 PGFILEDESC = "pg_upgrade - an in-place binary upgrade utility"
 PGAPPICON = win32
 
@@ -22,7 +24,9 @@ PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 else
 subdir = contrib/pg_upgrade
-top_builddir = ../..
 include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk
 endif
+
+check: test_gpdb.sh all
+	$(SHELL) $< -o $(top_builddir)/gpAux/gpdemo/datadirs/ -b $(DESTDIR)$(bindir)

--- a/contrib/pg_upgrade/function.c
+++ b/contrib/pg_upgrade/function.c
@@ -189,6 +189,12 @@ install_system_functions_internal(migratorContext *ctx, char *dbname)
 							  "RETURNS VOID "
 							  "AS '$libdir/pg_upgrade_support' "
 							  "LANGUAGE C STRICT;"));
+	PQclear(executeQueryOrDie(ctx, conn,
+							  "CREATE OR REPLACE FUNCTION "
+							  "binary_upgrade.preassign_amop_oid(OID, OID) "
+							  "RETURNS VOID "
+							  "AS '$libdir/pg_upgrade_support' "
+							  "LANGUAGE C STRICT;"));
 	PQfinish(conn);
 }
 

--- a/contrib/pg_upgrade/function.c
+++ b/contrib/pg_upgrade/function.c
@@ -179,7 +179,7 @@ install_system_functions_internal(migratorContext *ctx, char *dbname)
 							  "LANGUAGE C STRICT;"));
 	PQclear(executeQueryOrDie(ctx, conn,
 							  "CREATE OR REPLACE FUNCTION "
-							  "binary_upgrade.preassign_extension_oid(OID, OID, TEXT) "
+							  "binary_upgrade.preassign_extension_oid(OID, TEXT) "
 							  "RETURNS VOID "
 							  "AS '$libdir/pg_upgrade_support' "
 							  "LANGUAGE C STRICT;"));

--- a/contrib/pg_upgrade/function.c
+++ b/contrib/pg_upgrade/function.c
@@ -153,6 +153,42 @@ install_system_functions_internal(migratorContext *ctx, char *dbname)
 							  "RETURNS VOID "
 							  "AS '$libdir/pg_upgrade_support' "
 							  "LANGUAGE C STRICT;"));
+	PQclear(executeQueryOrDie(ctx, conn,
+							  "CREATE OR REPLACE FUNCTION "
+							  "binary_upgrade.preassign_tsparser_oid(OID, OID, TEXT) "
+							  "RETURNS VOID "
+							  "AS '$libdir/pg_upgrade_support' "
+							  "LANGUAGE C STRICT;"));
+	PQclear(executeQueryOrDie(ctx, conn,
+							  "CREATE OR REPLACE FUNCTION "
+							  "binary_upgrade.preassign_tsdict_oid(OID, OID, TEXT) "
+							  "RETURNS VOID "
+							  "AS '$libdir/pg_upgrade_support' "
+							  "LANGUAGE C STRICT;"));
+	PQclear(executeQueryOrDie(ctx, conn,
+							  "CREATE OR REPLACE FUNCTION "
+							  "binary_upgrade.preassign_tstemplate_oid(OID, OID, TEXT) "
+							  "RETURNS VOID "
+							  "AS '$libdir/pg_upgrade_support' "
+							  "LANGUAGE C STRICT;"));
+	PQclear(executeQueryOrDie(ctx, conn,
+							  "CREATE OR REPLACE FUNCTION "
+							  "binary_upgrade.preassign_tsconfig_oid(OID, OID, TEXT) "
+							  "RETURNS VOID "
+							  "AS '$libdir/pg_upgrade_support' "
+							  "LANGUAGE C STRICT;"));
+	PQclear(executeQueryOrDie(ctx, conn,
+							  "CREATE OR REPLACE FUNCTION "
+							  "binary_upgrade.preassign_extension_oid(OID, OID, TEXT) "
+							  "RETURNS VOID "
+							  "AS '$libdir/pg_upgrade_support' "
+							  "LANGUAGE C STRICT;"));
+	PQclear(executeQueryOrDie(ctx, conn,
+							  "CREATE OR REPLACE FUNCTION "
+							  "binary_upgrade.preassign_enum_oid(OID, OID, TEXT) "
+							  "RETURNS VOID "
+							  "AS '$libdir/pg_upgrade_support' "
+							  "LANGUAGE C STRICT;"));
 	PQfinish(conn);
 }
 

--- a/contrib/pg_upgrade/info.c
+++ b/contrib/pg_upgrade/info.c
@@ -479,6 +479,7 @@ get_rel_infos(migratorContext *ctx, const DbInfo *dbinfo,
 		RelInfo    *curr = &relinfos[num_rels++];
 		const char *tblspace;
 
+		curr->gpdb4_heap_conversion_needed = false;
 		curr->reloid = atooid(PQgetvalue(res, relnum, i_oid));
 
 		nspname = PQgetvalue(res, relnum, i_nspname);
@@ -788,9 +789,12 @@ get_rel_infos(migratorContext *ctx, const DbInfo *dbinfo,
 
 			/*
 			 * Regardless of if there is a NUMERIC attribute there is a
-			 * conversion needed to fix the headers of heap pages.
+			 * conversion needed to fix the headers of heap pages if the
+			 * old cluster is based on PostgreSQL 8.2 or older (Greenplum
+			 * 4.3 or older).
 			 */
-			curr->gpdb4_heap_conversion_needed = true;
+			if (GET_MAJOR_VERSION(ctx->old.major_version) <= 802)
+				curr->gpdb4_heap_conversion_needed = true;
 		}
 		else
 			curr->gpdb4_heap_conversion_needed = false;

--- a/contrib/pg_upgrade/info.c
+++ b/contrib/pg_upgrade/info.c
@@ -581,9 +581,40 @@ get_rel_infos(migratorContext *ctx, const DbInfo *dbinfo,
 		if (relstorage == 'a' || relstorage == 'c')
 		{
 			char		aoquery[QUERY_ALLOC];
+			char	   *segrel;
+			char	   *visimaprel;
+			char	   *blkdirrel = NULL;
 			PGresult   *aores;
 			int			j;
-			Oid			blkdirrelid;
+
+			/*
+			 * First query the catalog for the auxiliary heap relations which
+			 * describe AO{CS} relations. The segrel and visimap must exist
+			 * but the blkdirrel is created when required so it might be exist
+			 */
+			snprintf(aoquery, sizeof(aoquery),
+					 "SELECT cs.relname AS segrel, "
+					 "       cv.relname AS visimaprel, "
+					 "       cb.relname AS blkdirrel "
+					 "FROM   pg_appendonly a "
+					 "       JOIN pg_class cs on (cs.oid = a.segrelid) "
+					 "       JOIN pg_class cv on (cv.oid = a.visimaprelid) "
+					 "       LEFT JOIN pg_class cb on (cb.oid = a.blkdirrelid "
+					 "                                 AND a.blkdirrelid <> 0) "
+					 "WHERE  a.relid = %u::pg_catalog.oid",
+					 curr->reloid);
+
+			aores = executeQueryOrDie(ctx, conn, aoquery);
+			if (PQntuples(aores) == 0)
+				pg_log(ctx, PG_FATAL, "Unable to find auxiliary AO relations for %u (%s)\n",
+					   curr->reloid, curr->relname);
+
+			segrel = pg_strdup(ctx, PQgetvalue(aores, 0, PQfnumber(aores, "segrel")));
+			visimaprel = pg_strdup(ctx, PQgetvalue(aores, 0, PQfnumber(aores, "visimaprel")));
+			if (!PQgetisnull(aores, 0, PQfnumber(aores, "blkdirrel")))
+				blkdirrel = pg_strdup(ctx, PQgetvalue(aores, 0, PQfnumber(aores, "blkdirrel")));
+
+			PQclear(aores);
 
 			if (relstorage == 'a')
 			{
@@ -598,17 +629,22 @@ get_rel_infos(migratorContext *ctx, const DbInfo *dbinfo,
 				if (GET_MAJOR_VERSION(ctx->old.major_version) <= 802 && whichCluster == CLUSTER_OLD)
 				{
 					snprintf(aoquery, sizeof(aoquery),
-							 "SELECT segno, eof, tupcount, varblockcount, eofuncompressed, modcount, state, ao.version as formatversion "
-							 "FROM pg_aoseg.pg_aoseg_%u, pg_catalog.pg_appendonly ao "
-							 "WHERE ao.relid = %u /* %s */",
-							 curr->reloid, curr->reloid, relname);
+							 "SELECT segno, eof, tupcount, varblockcount, "
+							 "       eofuncompressed, modcount, state, "
+							 "       ao.version as formatversion "
+							 "FROM   pg_aoseg.%s, "
+							 "       pg_catalog.pg_appendonly ao "
+							 "WHERE  ao.relid = %u",
+							 segrel, curr->reloid);
 				}
 				else
 				{
 					snprintf(aoquery, sizeof(aoquery),
-							 "SELECT segno, eof, tupcount, varblockcount, eofuncompressed, modcount, state, formatversion "
-							 "FROM pg_aoseg.pg_aoseg_%u",
-							 curr->reloid);
+							 "SELECT segno, eof, tupcount, varblockcount, "
+							 "       eofuncompressed, modcount, state, "
+							 "       formatversion "
+							 "FROM   pg_aoseg.%s",
+							 segrel);
 				}
 				aores = executeQueryOrDie(ctx, conn, aoquery);
 
@@ -639,18 +675,18 @@ get_rel_infos(migratorContext *ctx, const DbInfo *dbinfo,
 					snprintf(aoquery, sizeof(aoquery),
 							 "SELECT segno, tupcount, varblockcount, vpinfo, "
 							 "       modcount, state, ao.version as formatversion "
-							 "FROM   pg_aoseg.pg_aocsseg_%u, "
+							 "FROM   pg_aoseg.%s, "
 							 "       pg_catalog.pg_appendonly ao "
 							 "WHERE  ao.relid = %u",
-							 curr->reloid, curr->reloid);
+							 segrel, curr->reloid);
 				}
 				else
 				{
 					snprintf(aoquery, sizeof(aoquery),
 							 "SELECT segno, tupcount, varblockcount, vpinfo, "
 							 "       modcount, formatversion, state "
-							 "FROM   pg_aoseg.pg_aocsseg_%u",
-							 curr->reloid);
+							 "FROM   pg_aoseg.%s",
+							 segrel);
 				}
 
 				aores = executeQueryOrDie(ctx, conn, aoquery);
@@ -697,15 +733,15 @@ get_rel_infos(migratorContext *ctx, const DbInfo *dbinfo,
 				}
 				snprintf(aoquery, sizeof(aoquery),
 						 "SELECT segno, first_row_no, pg_temp.bitmaphack(visimap) as visimap "
-						 "FROM pg_aoseg.pg_aovisimap_%u",
-						 curr->reloid);
+						 "FROM pg_aoseg.%s",
+						 visimaprel);
 			}
 			else
 			{
 				snprintf(aoquery, sizeof(aoquery),
 						 "SELECT segno, first_row_no, visimap "
-						 "FROM pg_aoseg.pg_aovisimap_%u",
-						 curr->reloid);
+						 "FROM pg_aoseg.%s",
+						 visimaprel);
 			}
 			aores = executeQueryOrDie(ctx, conn, aoquery);
 
@@ -727,20 +763,12 @@ get_rel_infos(migratorContext *ctx, const DbInfo *dbinfo,
 			 * Get contents of pg_aoblkdir_<oid>. If pg_appendonly.blkdirrelid
 			 * is InvalidOid then there is no blkdir table.
 			 */
-			snprintf(aoquery, sizeof(aoquery),
-					 "SELECT blkdirrelid FROM pg_appendonly WHERE relid = '%u'::pg_catalog.oid",
-					 curr->reloid);
-			aores = executeQueryOrDie(ctx, conn, aoquery);
-
-			blkdirrelid = atooid(PQgetvalue(aores, 0, PQfnumber(aores, "blkdirrelid")));
-			PQclear(aores);
-			
-			if (blkdirrelid != InvalidOid)
+			if (blkdirrel)
 			{
 				snprintf(aoquery, sizeof(aoquery),
 						 "SELECT segno, columngroup_no, first_row_no, minipage::bit(36)::bigint "
-						 "FROM   pg_aoseg.pg_aoblkdir_%u",
-						 curr->reloid);
+						 "FROM   pg_aoseg.%s",
+						 blkdirrel);
 				aores = executeQueryOrDie(ctx, conn, aoquery);
 
 				curr->naoblkdirs = PQntuples(aores);
@@ -763,6 +791,12 @@ get_rel_infos(migratorContext *ctx, const DbInfo *dbinfo,
 				curr->aoblkdirs = NULL;
 				curr->naoblkdirs = 0;
 			}
+
+
+			pg_free(segrel);
+			pg_free(visimaprel);
+			pg_free(blkdirrel);
+
 		}
 		else
 		{

--- a/contrib/pg_upgrade/pg_upgrade.c
+++ b/contrib/pg_upgrade/pg_upgrade.c
@@ -101,7 +101,7 @@ main(int argc, char **argv)
 	 * because there is no need to have the schema load use new oids.
 	 */
 	prep_status(&ctx, "Setting next oid for new cluster");
-	exec_prog(&ctx, true, SYSTEMQUOTE "\"%s/pg_resetxlog\" -o %u \"%s\" > "
+	exec_prog(&ctx, true, SYSTEMQUOTE "\"%s/pg_resetxlog\" -y -o %u \"%s\" > "
 			  DEVNULL SYSTEMQUOTE,
 		  ctx.new.bindir, ctx.old.controldata.chkpnt_nxtoid, ctx.new.pgdata);
 	check_ok(&ctx);
@@ -538,13 +538,13 @@ copy_clog_xlog_xid(migratorContext *ctx)
 
 	/* set the next transaction id of the new cluster */
 	prep_status(ctx, "Setting next transaction id for new cluster");
-	exec_prog(ctx, true, SYSTEMQUOTE "\"%s/pg_resetxlog\" -f -x %u \"%s\" > " DEVNULL SYSTEMQUOTE,
+	exec_prog(ctx, true, SYSTEMQUOTE "\"%s/pg_resetxlog\" -y -f -x %u \"%s\" > " DEVNULL SYSTEMQUOTE,
 	   ctx->new.bindir, ctx->old.controldata.chkpnt_nxtxid, ctx->new.pgdata);
 	check_ok(ctx);
 
 	/* now reset the wal archives in the new cluster */
 	prep_status(ctx, "Resetting WAL archives");
-	exec_prog(ctx, true, SYSTEMQUOTE "\"%s/pg_resetxlog\" -l 1,%u,%u \"%s\" >> \"%s\" 2>&1" SYSTEMQUOTE,
+	exec_prog(ctx, true, SYSTEMQUOTE "\"%s/pg_resetxlog\" -y -l 1,%u,%u \"%s\" >> \"%s\" 2>&1" SYSTEMQUOTE,
 			  ctx->new.bindir,
 			  ctx->old.controldata.logid, ctx->old.controldata.nxtlogseg,
 			  ctx->new.pgdata,

--- a/contrib/pg_upgrade/test_gpdb.sh
+++ b/contrib/pg_upgrade/test_gpdb.sh
@@ -2,7 +2,7 @@
 
 # contrib/pg_upgrade/test_gpdb.sh
 #
-# Test driver for upgrading a Greenplum cluster with pg_upgrade. For testdata,
+# Test driver for upgrading a Greenplum cluster with pg_upgrade. For test data,
 # this script assumes the gpdemo cluster in gpAux/gpdemo/datadirs contains the
 # end-state of an ICW test run. Performs a pg_dumpall, initializes a parallel
 # gpdemo cluster and upgrades it against the ICW cluster and then performs
@@ -36,15 +36,15 @@ realpath()
 
 restore_cluster()
 {
-	# Reset the pg_control files from the old cluster which were renamed .old
-	# by pg_upgrade to avoid booting up an upgraded cluster.
+	# Reset the pg_control files from the old cluster which were renamed
+	# .old by pg_upgrade to avoid booting up an upgraded cluster.
 	find ${OLD_DATADIR} -type f -name 'pg_control.old' |
 	while read control_file; do
 		mv "${control_file}" "${control_file%.old}"
 	done
 
-	# Remove the copied lalshell unless we're running in the gpdemo directory
-	# where it's version controlled
+	# Remove the copied lalshell unless we're running in the gpdemo
+	# directory where it's version controlled
 	if ! git ls-files lalshell --error-unmatch >/dev/null 2>&1; then
 		rm -f lalshell
 	fi
@@ -53,9 +53,9 @@ restore_cluster()
 upgrade_node()
 {
 	mkdir -p $1
-	# If we are passed a filename as the fourth parameter, copy the file into
-	# our working directory for the upgrade. This is useful for the Oid file
-	# from the QD to the segments
+	# If we are passed a filename as the fourth parameter, copy the file
+	# into our working directory for the upgrade. This is useful for the
+	# Oid file from the QD to the segments
 	if [ $# == 4 ] && [ -f $4 ]; then
 		cp $4 $1
 	fi
@@ -120,9 +120,9 @@ fi
 
 trap restore_cluster EXIT
 
-# The cluster should be running by now, but in case it isn't issue a restart.
-# Worst case we powercycle once for no reason but better than failing due to
-# not having a cluster to work with.
+# The cluster should be running by now, but in case it isn't, issue a restart.
+# Worst case we powercycle once for no reason, but it's better than failing
+# due to not having a cluster to work with.
 gpstart -a
 
 # Run any pre-upgrade tasks to prep the cluster
@@ -130,8 +130,8 @@ if [ -f "test_gpdb_pre.sql" ]; then
 	psql -f test_gpdb_pre.sql regression
 fi
 
-# Ensure that the catalog is sane before attempting an upgrade, while there is
-# (limited) catalog checking inside pg_upgrade it won't catch all issues and
+# Ensure that the catalog is sane before attempting an upgrade. While there is
+# (limited) catalog checking inside pg_upgrade, it won't catch all issues, and
 # upgrading a faulty catalog won't work.
 gpcheckcat
 if (( $? )) ; then

--- a/contrib/pg_upgrade/test_gpdb.sh
+++ b/contrib/pg_upgrade/test_gpdb.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+
+# contrib/pg_upgrade/test_gpdb.sh
+#
+# Test driver for upgrading a Greenplum cluster with pg_upgrade. For testdata,
+# this script assumes the gpdemo cluster in gpAux/gpdemo/datadirs contains the
+# end-state of an ICW test run. Performs a pg_dumpall, initializes a parallel
+# gpdemo cluster and upgrades it against the ICW cluster and then performs
+# another pg_dumpall. If the two dumps match then the upgrade created a new
+# identical copy of the cluster.
+
+OLD_BINDIR=
+OLD_DATADIR=
+NEW_BINDIR=
+NEW_DATADIR=
+
+qddir=
+
+# Not all platforms have a realpath binary in PATH, most notably macOS doesn't,
+# so provide an alternative implementation. Returns an absolute path in the
+# variable reference passed as the first parameter.  Code inspired by:
+# http://stackoverflow.com/questions/3572030/bash-script-absolute-path-with-osx
+realpath()
+{
+	local __ret=$1
+	local path
+
+	if [[ $2 = /* ]]; then
+		path="$2"
+	else
+		path="$PWD/${2#./}"
+	fi
+
+	eval $__ret="'$path'"
+}
+
+restore_cluster()
+{
+	# Reset the pg_control files from the old cluster which were renamed .old
+	# by pg_upgrade to avoid booting up an upgraded cluster.
+	find ${OLD_DATADIR} -type f -name 'pg_control.old' |
+	while read control_file; do
+		mv "${control_file}" "${control_file%.old}"
+	done
+
+	# Remove the copied lalshell unless we're running in the gpdemo directory
+	# where it's version controlled
+	if ! git ls-files lalshell --error-unmatch >/dev/null 2>&1; then
+		rm -f lalshell
+	fi
+}
+
+upgrade_node()
+{
+	mkdir -p $1
+	# If we are passed a filename as the fourth parameter, copy the file into
+	# our working directory for the upgrade. This is useful for the Oid file
+	# from the QD to the segments
+	if [ $# == 4 ] && [ -f $4 ]; then
+		cp $4 $1
+	fi
+	pushd $1
+	time ${NEW_BINDIR}/pg_upgrade --old-bindir=${OLD_BINDIR} --old-datadir=$2 --new-bindir=${NEW_BINDIR} --new-datadir=$3
+	if (( $? )) ; then
+		echo "ERROR: Failure encountered in upgrading node"
+		exit 1
+	fi
+	popd
+}
+
+upgrade_qd()
+{
+	upgrade_qddir=$1
+	qddir=$2
+	upgrade_node $1 $2 $3
+}
+
+upgrade_segment()
+{
+	upgrade_node $1 $2 $3 "$qddir/pg_upgrade_dump_arraytypes.sql"
+}
+
+usage()
+{
+	appname=`basename $0`
+	echo "$appname usage:"
+	echo " -o <dir>     Directory containing old datadir"
+	echo " -b <dir>     Directory containing binaries"
+	exit 0
+}
+
+# Main
+temp_root=`pwd`/tmp_check
+
+while getopts ":o:b:" opt; do
+	case ${opt} in
+		o )
+			realpath OLD_DATADIR "${OPTARG}"
+			;;
+		b )
+			realpath NEW_BINDIR "${OPTARG}"
+			realpath OLD_BINDIR "${OPTARG}"
+			;;
+		* )
+			usage
+			;;
+	esac
+done
+
+if [ -z "${OLD_DATADIR}" ] || [ -z "${NEW_BINDIR}" ]; then
+	usage
+fi
+
+rm -rf "$temp_root"
+mkdir -p "$temp_root"
+if [ ! -d "$temp_root" ]; then
+	echo "ERROR: unable to create workdir: $temp_root"
+	exit 1
+fi
+
+trap restore_cluster EXIT
+
+# The cluster should be running by now, but in case it isn't issue a restart.
+# Worst case we powercycle once for no reason but better than failing due to
+# not having a cluster to work with.
+gpstart -a
+
+# Run any pre-upgrade tasks to prep the cluster
+if [ -f "test_gpdb_pre.sql" ]; then
+	psql -f test_gpdb_pre.sql regression
+fi
+
+# Ensure that the catalog is sane before attempting an upgrade, while there is
+# (limited) catalog checking inside pg_upgrade it won't catch all issues and
+# upgrading a faulty catalog won't work.
+gpcheckcat
+if (( $? )) ; then
+	echo "ERROR: gpcheckcat reported catalog issues, fix before upgrading"
+	exit 1
+fi
+
+${NEW_BINDIR}/pg_dumpall --schema-only -f "$temp_root/dump1.sql"
+
+gpstop -a
+
+# Create a new gpdemo cluster in the temproot. Using the old datadir for the
+# path to demo_cluster.sh is a bit of a hack, but since this test relies on
+# gpdemo having been used for ICW it will do for now.
+export MASTER_DEMO_PORT=17432
+export DEMO_PORT_BASE=27432
+export NUM_PRIMARY_MIRROR_PAIRS=3
+export MASTER_DATADIR=${temp_root}
+cp ${OLD_DATADIR}/../lalshell .
+${OLD_DATADIR}/../demo_cluster.sh
+
+NEW_DATADIR="${temp_root}/datadirs"
+
+export MASTER_DATA_DIRECTORY="${NEW_DATADIR}/qddir/demoDataDir-1"
+export PGPORT=17432
+gpstop -a
+MASTER_DATA_DIRECTORY=""; unset MASTER_DATA_DIRECTORY
+PGPORT=""; unset PGPORT
+PGOPTIONS=""; unset PGOPTIONS
+
+# Start by upgrading the master
+upgrade_qd "${temp_root}/upgrade/qd" "${OLD_DATADIR}/qddir/demoDataDir-1/" "${NEW_DATADIR}/qddir/demoDataDir-1/"
+
+# Upgrade all the segments and mirrors. In a production setup the segments
+# would be upgraded first and then the mirrors once the segments are verified.
+# In this scenario we can cut corners since we don't have any important data
+# in the test cluster and we only consern ourselves with 100% success rate.
+for i in 1 2 3
+do
+	j=$(($i-1))
+	upgrade_segment "${temp_root}/upgrade/dbfast$i" "${OLD_DATADIR}/dbfast$i/demoDataDir$j/" "${NEW_DATADIR}/dbfast$i/demoDataDir$j/"
+	upgrade_segment "${temp_root}/upgrade/dbfast_mirror$i" "${OLD_DATADIR}/dbfast_mirror$i/demoDataDir$j/" "${NEW_DATADIR}/dbfast_mirror$i/demoDataDir$j/"
+done
+
+. ${NEW_BINDIR}/../greenplum_path.sh
+
+# Start the new cluster, dump it and stop it again when done. We need to bump
+# the exports to the new cluster for starting it but reset back to the old
+# when done. Set the same variables as gpdemo-env.sh exports. Since creation
+# of that file can collide between the gpdemo clusters, perform it manually
+export PGPORT=17432
+export MASTER_DATA_DIRECTORY="${NEW_DATADIR}/qddir/demoDataDir-1"
+gpstart -a
+
+# Run any post-upgrade tasks to prep the cluster for diffing
+if [ -f "test_gpdb_post.sql" ]; then
+	psql -f test_gpdb_post.sql regression
+fi
+
+pg_dumpall --schema-only -f "$temp_root/dump2.sql"
+gpstop -a
+export PGPORT=15432
+export MASTER_DATA_DIRECTORY="${OLD_DATADIR}/qddir/demoDataDir-1"
+
+if diff "$temp_root/dump1.sql" "$temp_root/dump2.sql" >/dev/null; then
+	echo "Passed"
+	exit 0
+else
+	# To aid debugging in pipelines, print the diff to stdout
+	diff "$temp_root/dump1.sql" "$temp_root/dump2.sql"
+	echo "Error: before and after dumps differ"
+	exit 1
+fi

--- a/contrib/pg_upgrade/test_gpdb_pre.sql
+++ b/contrib/pg_upgrade/test_gpdb_pre.sql
@@ -1,0 +1,12 @@
+DROP TABLE IF EXISTS alter_ao_part_tables_column.sto_altap3 CASCADE;
+DROP TABLE IF EXISTS alter_ao_part_tables_row.sto_altap3 CASCADE;
+DROP TABLE IF EXISTS co_cr_sub_partzlib8192_1_2 CASCADE;
+DROP TABLE IF EXISTS co_cr_sub_partzlib8192_1 CASCADE;
+DROP TABLE IF EXISTS co_wt_sub_partrle_type8192_1_2 CASCADE;
+DROP TABLE IF EXISTS co_wt_sub_partrle_type8192_1 CASCADE;
+DROP TABLE IF EXISTS ao_wt_sub_partzlib8192_5 CASCADE;
+DROP TABLE IF EXISTS ao_wt_sub_partzlib8192_5_2 CASCADE;
+DROP TABLE IF EXISTS constraint_pt1 CASCADE;
+DROP TABLE IF EXISTS constraint_pt2 CASCADE;
+DROP TABLE IF EXISTS constraint_pt3 CASCADE;
+DROP TABLE IF EXISTS contest_inherit CASCADE;

--- a/contrib/pg_upgrade_support/pg_upgrade_support.c
+++ b/contrib/pg_upgrade_support/pg_upgrade_support.c
@@ -13,6 +13,7 @@
 #include "fmgr.h"
 #include "catalog/dependency.h"
 #include "catalog/oid_dispatch.h"
+#include "catalog/pg_amop.h"
 #include "catalog/pg_attrdef.h"
 #include "catalog/pg_authid.h"
 #include "catalog/pg_cast.h"
@@ -86,6 +87,7 @@ Datum		preassign_tstemplate_oid(PG_FUNCTION_ARGS);
 Datum		preassign_tsconfig_oid(PG_FUNCTION_ARGS);
 Datum		preassign_extension_oid(PG_FUNCTION_ARGS);
 Datum		preassign_enum_oid(PG_FUNCTION_ARGS);
+Datum		preassign_amop_oid(PG_FUNCTION_ARGS);
 
 PG_FUNCTION_INFO_V1(preassign_type_oid);
 PG_FUNCTION_INFO_V1(preassign_arraytype_oid);
@@ -114,6 +116,7 @@ PG_FUNCTION_INFO_V1(preassign_tstemplate_oid);
 PG_FUNCTION_INFO_V1(preassign_tsconfig_oid);
 PG_FUNCTION_INFO_V1(preassign_extension_oid);
 PG_FUNCTION_INFO_V1(preassign_enum_oid);
+PG_FUNCTION_INFO_V1(preassign_amop_oid);
 
 Datum
 preassign_type_oid(PG_FUNCTION_ARGS)
@@ -544,6 +547,25 @@ preassign_enum_oid(PG_FUNCTION_ARGS)
 	{
 		AddPreassignedOidFromBinaryUpgrade(enumoid, EnumRelationId, enumlabel,
 										   InvalidOid, typeoid, InvalidOid);
+	}
+
+	PG_RETURN_VOID();
+}
+
+Datum
+preassign_amop_oid(PG_FUNCTION_ARGS)
+{
+	Oid			amopoid = PG_GETARG_OID(0);
+	Oid			amopmethod = PG_GETARG_OID(1);
+
+	if (Gp_role == GP_ROLE_UTILITY)
+	{
+		AddPreassignedOidFromBinaryUpgrade(amopoid,
+										   AccessMethodOperatorRelationId,
+										   NULL,
+										   InvalidOid,
+										   amopmethod,
+										   InvalidOid);
 	}
 
 	PG_RETURN_VOID();

--- a/contrib/pg_upgrade_support/pg_upgrade_support.c
+++ b/contrib/pg_upgrade_support/pg_upgrade_support.c
@@ -138,7 +138,7 @@ preassign_arraytype_oid(PG_FUNCTION_ARGS)
 	char	   *objname = GET_STR(PG_GETARG_TEXT_P(1));
 	Oid			typnamespace = PG_GETARG_OID(2);
 
-	if (Gp_role == GP_ROLE_UTILITY)
+	if (Gp_role != GP_ROLE_UTILITY)
 		PG_RETURN_VOID();
 
 	if (typoid == InvalidOid && GpIdentity.dbid != MASTER_DBID)

--- a/contrib/pg_upgrade_support/pg_upgrade_support.c
+++ b/contrib/pg_upgrade_support/pg_upgrade_support.c
@@ -523,13 +523,12 @@ Datum
 preassign_extension_oid(PG_FUNCTION_ARGS)
 {
 	Oid			extensionoid = PG_GETARG_OID(0);
-	Oid			nsoid = PG_GETARG_OID(1);
-	char	   *extensionname = GET_STR(PG_GETARG_TEXT_P(2));
+	char	   *extensionname = GET_STR(PG_GETARG_TEXT_P(1));
 
 	if (Gp_role == GP_ROLE_UTILITY)
 	{
 		AddPreassignedOidFromBinaryUpgrade(extensionoid, ExtensionRelationId,
-										   extensionname, nsoid, InvalidOid,
+										   extensionname, InvalidOid, InvalidOid,
 										   InvalidOid);
 	}
 

--- a/contrib/pg_upgrade_support/pg_upgrade_support.c
+++ b/contrib/pg_upgrade_support/pg_upgrade_support.c
@@ -200,7 +200,7 @@ preassign_opclass_oid(PG_FUNCTION_ARGS)
 {
 	Oid			opcoid = PG_GETARG_OID(0);
 	char	   *objname = GET_STR(PG_GETARG_TEXT_P(1));
-	Oid			opcnamespace = PG_GETARG_OID(1);
+	Oid			opcnamespace = PG_GETARG_OID(2);
 
 	if (Gp_role == GP_ROLE_UTILITY)
 	{

--- a/gpAux/gpdemo/demo_cluster.sh
+++ b/gpAux/gpdemo/demo_cluster.sh
@@ -4,7 +4,12 @@
 # Data Directories
 # ======================================================================
 
-DATADIRS=${DATADIRS:-`pwd`/datadirs}
+if [ -z "${MASTER_DATADIR}" ]; then
+  DATADIRS=${DATADIRS:-`pwd`/datadirs}
+else
+  DATADIRS="${MASTER_DATADIR}/datadirs"
+fi
+
 QDDIR=$DATADIRS/qddir
 SEG_PREFIX=demoDataDir
 

--- a/src/backend/catalog/oid_dispatch.c
+++ b/src/backend/catalog/oid_dispatch.c
@@ -554,8 +554,9 @@ GetPreassignedOidForTuple(Relation catalogrel, HeapTuple tuple)
 			 RelationGetRelationName(catalogrel));
 
 	if ((oid = GetPreassignedOid(&searchkey)) == InvalidOid)
-		elog(ERROR, "no pre-assigned OID for %s tuple \"%s\"",
-			 RelationGetRelationName(catalogrel), searchkey.objname ? searchkey.objname : "");
+		elog(ERROR, "no pre-assigned OID for %s tuple \"%s\" (namespace:%u keyOid1:%u keyOid2:%u)",
+			 RelationGetRelationName(catalogrel), searchkey.objname ? searchkey.objname : "",
+			 searchkey.namespaceOid, searchkey.keyOid1, searchkey.keyOid2);
 	return oid;
 }
 

--- a/src/backend/catalog/oid_dispatch.c
+++ b/src/backend/catalog/oid_dispatch.c
@@ -221,7 +221,11 @@ CreateKeyFromCatalogTuple(Relation catalogrel, HeapTuple tuple,
 			{
 				Form_pg_extension extForm = (Form_pg_extension) GETSTRUCT(tuple);
 
-				key.namespaceOid = extForm->extnamespace;
+				/*
+				 * Note that unlike most catalogs with a "namespace" column,
+				 * extnamespace is not meant to imply that the extension
+				 * belongs to that schema.
+				 */
 				key.objname = NameStr(extForm->extname);
 				break;
 			}

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -6299,6 +6299,13 @@ ATPrepColumnDefault(Relation rel, bool recurse, AlterTableCmd *cmd)
 	 */
 	if (!recurse && find_inheritance_children(RelationGetRelid(rel)) != NIL)
 	{
+		/*
+		 * In binary upgrade we are handling the children manually when dumping
+		 * the schema so not recursing is allowed
+		 */
+		if (IsBinaryUpgrade)
+			return;
+
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
 				 errmsg("Column default of relation \"%s\" must be added to its child relation(s)",

--- a/src/bin/pg_dump/binary_upgrade.c
+++ b/src/bin/pg_dump/binary_upgrade.c
@@ -462,8 +462,8 @@ dumpOpClassOid(PGconn *conn, Archive *AH, OpclassInfo *info)
 	opcnamespace = atooid(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "opcnamespace")));
 
 	snprintf(query_buffer, sizeof(query_buffer),
-			 "SELECT binary_upgrade.preassign_opclass_oid('%u'::pg_opclass.oid, "
-			 "'%s'::text, '%u'::pg_opclass.opcnamespace);",
+			 "SELECT binary_upgrade.preassign_opclass_oid('%u'::pg_catalog.oid, "
+			 "'%s'::text, '%u'::pg_catalog.oid);",
 			 info->dobj.catId.oid, info->dobj.name, opcnamespace);
 
 	PQclear(upgrade_res);

--- a/src/bin/pg_dump/binary_upgrade.c
+++ b/src/bin/pg_dump/binary_upgrade.c
@@ -1128,7 +1128,7 @@ dumpTableOid(PGconn *conn, Archive *fout, Archive *AH, TableInfo *info)
 	int		j;
 
 	/* Skip if not to be dumped */
-	if (!info->dobj.dump)
+	if (!info->dobj.dump && info->parrelid == 0)
 		return;
 
 	preassign_pg_class_oids(conn, fout, AH, info->dobj.catId.oid);
@@ -1540,94 +1540,6 @@ preassign_type_oids_by_rel_oid(PGconn *conn, Archive *fout, Archive *AH, Oid pg_
 																	   "'pg_toast_%u'::text, "
 																	   "'%u'::pg_catalog.oid);\n",
 						  pg_type_toast_oid, pg_rel_oid, pg_type_toast_namespace_oid);
-	}
-
-	/*
-	 * If the table is partitioned and is the parent, we need to dump the Oids
-	 * of the child tables as well
-	 */
-	if (!PQgetisnull(upgrade_res, 0, PQfnumber(upgrade_res, "par_parent")))
-	{
-		PQExpBuffer parquery = createPQExpBuffer();
-		PGresult   *par_res;
-		int			i;
-		char		name[NAMEDATALEN];
-		Oid			part_oid;
-		Oid			conns_oid;
-		Oid			contyp_oid;
-		Oid			con_oid;
-		Oid			prev_oid = InvalidOid;
-		Oid			attrdef_oid;
-		int			adnum;
-		int			partups;
-
-		appendPQExpBuffer(parquery,
-						  "SELECT cc.oid, "
-						  "       p.partitiontablename AS name, "
-						  "       co.oid AS conoid, "
-						  "       co.conname, "
-						  "       co.connamespace, "
-						  "       co.contypid, "
-						  "       d.oid AS attrdefoid, "
-						  "       d.adnum "
-						  "FROM pg_partitions p "
-						  "JOIN pg_catalog.pg_class c ON "
-						  "  (p.tablename = c.relname AND c.oid = '%u'::pg_catalog.oid) "
-						  "JOIN pg_catalog.pg_class cc ON "
-						  "  (p.partitiontablename = cc.relname) "
-						  "LEFT JOIN pg_catalog.pg_constraint co ON "
-						  "  (cc.oid = co.conrelid) "
-						  "LEFT JOIN pg_catalog.pg_attrdef d ON "
-						  "  (cc.oid = d.adrelid) "
-						  "ORDER BY 1;",
-						  pg_rel_oid);
-
-		par_res = PQexec(conn, parquery->data);
-		check_sql_result(par_res, conn, parquery->data, PGRES_TUPLES_OK);
-
-		partups = PQntuples(par_res);
-
-		if (partups > 0)
-		{
-			for (i = 0; i < partups; i++)
-			{
-				part_oid = atooid(PQgetvalue(par_res, i, PQfnumber(par_res, "oid")));
-
-				/*
-				 * Partitions with multiple constraint will be on multiple
-				 * rows, so ensure to save the non-constrant related Oids only
-				 * once (relation, type and attrdef).
-				 */
-				if (part_oid != prev_oid)
-				{
-					strlcpy(name, PQgetvalue(par_res, i, PQfnumber(par_res, "name")), sizeof(name));
-					preassign_type_oids_by_rel_oid(conn, fout, AH, part_oid, name);
-					preassign_pg_class_oids(conn, fout, AH, part_oid);
-
-					attrdef_oid = atooid(PQgetvalue(par_res, i, PQfnumber(par_res, "attrdefoid")));
-					if (OidIsValid(attrdef_oid))
-					{
-						adnum = atoi(PQgetvalue(par_res, i, PQfnumber(par_res, "adnum")));
-						preassign_attrdefs_oid(AH, attrdef_oid, part_oid, adnum);
-					}
-				}
-
-				if (!PQgetisnull(par_res, i, PQfnumber(par_res, "conname")))
-				{
-					strlcpy(name, PQgetvalue(par_res, i, PQfnumber(par_res, "conname")), sizeof(name));
-					con_oid = atooid(PQgetvalue(par_res, i, PQfnumber(par_res, "conoid")));
-					conns_oid = atooid(PQgetvalue(par_res, i, PQfnumber(par_res, "connamespace")));
-					contyp_oid = atooid(PQgetvalue(par_res, i, PQfnumber(par_res, "contypid")));
-
-					preassign_constraint_oid(AH, con_oid, conns_oid, name, part_oid, contyp_oid);
-				}
-
-				prev_oid = part_oid;
-			}
-		}
-
-		PQclear(par_res);
-		destroyPQExpBuffer(parquery);
 	}
 
 	if (!PQgetisnull(upgrade_res, 0, PQfnumber(upgrade_res, "aosegrel")))

--- a/src/bin/pg_dump/binary_upgrade.c
+++ b/src/bin/pg_dump/binary_upgrade.c
@@ -609,9 +609,8 @@ dumpExtensionOid(Archive *AH, ExtensionInfo *info)
 
 	snprintf(query_buffer, sizeof(query_buffer),
 			 "SELECT binary_upgrade.preassign_extension_oid('%u'::pg_catalog.oid, "
-			 "'%u'::pg_catalog.oid, $$%s$$::text);\n",
-			 info->dobj.catId.oid, info->dobj.namespace->dobj.catId.oid,
-			 info->dobj.name);
+			 "$$%s$$::text);\n",
+			 info->dobj.catId.oid, info->dobj.name);
 
 	ArchiveEntry(AH, nilCatalogId, createDumpId(),
 				 "preassign_extension",

--- a/src/bin/pg_dump/binary_upgrade.c
+++ b/src/bin/pg_dump/binary_upgrade.c
@@ -67,7 +67,7 @@ dumpNamespaceOid(Archive *AH, NamespaceInfo *info)
 
 	snprintf(query_buffer, sizeof(query_buffer),
 			 "SELECT binary_upgrade.preassign_namespace_oid("
-			 "'%u'::pg_catalog.oid, '%s'::text);\n",
+			 "'%u'::pg_catalog.oid, $$%s$$::text);\n",
 			 info->dobj.catId.oid, info->dobj.name);
 
 	ArchiveEntry(AH, nilCatalogId, createDumpId(),
@@ -120,7 +120,7 @@ dumpAggProcedureOid(PGconn *conn, Archive *fout, Archive *AH, AggInfo *info)
 
 		appendPQExpBuffer(upgrade_buffer,
 						  "SELECT binary_upgrade.preassign_procedure_oid("
-						  "'%u'::pg_catalog.oid, '%s'::text, '%u'::pg_catalog.oid);\n",
+						  "'%u'::pg_catalog.oid, $$%s$$::text, '%u'::pg_catalog.oid);\n",
 						  procoid, proname, nsoid);
 
 		PQclear(upgrade_res);
@@ -172,7 +172,7 @@ dumpProcedureOid(PGconn *conn, Archive *fout, Archive *AH, FuncInfo *info)
 
 	snprintf(query_buffer, sizeof(query_buffer),
 			 "SELECT binary_upgrade.preassign_procedure_oid("
-			 "'%u'::pg_catalog.oid, '%s'::text, '%u'::pg_catalog.oid);\n",
+			 "'%u'::pg_catalog.oid, $$%s$$::text, '%u'::pg_catalog.oid);\n",
 			 info->dobj.catId.oid, info->dobj.name, info->dobj.namespace->dobj.catId.oid);
 
 	ArchiveEntry(AH, nilCatalogId, createDumpId(),
@@ -224,7 +224,7 @@ dumpProcLangOid(PGconn *conn, Archive *fout, Archive *AH, ProcLangInfo *info)
 					  "       LEFT OUTER JOIN pg_catalog.pg_proc v "
 					  "            ON (v.proname = tmplvalidator) "
 					  "       %s "
-					  "WHERE  tmplname = '%s'::text;",
+					  "WHERE  tmplname = $$%s$$::text;",
 					  (fout->remoteVersion >= 80300)
 					  ? ",i.oid AS inlineoid, i.pronamespace AS inlinens, i.proname AS inline"
 					  : "",
@@ -249,7 +249,7 @@ dumpProcLangOid(PGconn *conn, Archive *fout, Archive *AH, ProcLangInfo *info)
 	proname = PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "handler"));
 	appendPQExpBuffer(upgrade_buffer,
 					  "SELECT binary_upgrade.preassign_procedure_oid("
-					  "'%u'::pg_catalog.oid, '%s'::text, '%u'::pg_catalog.oid);\n",
+					  "'%u'::pg_catalog.oid, $$%s$$::text, '%u'::pg_catalog.oid);\n",
 					  procoid, proname, nsoid);
 
 	/* Validator function */
@@ -260,7 +260,7 @@ dumpProcLangOid(PGconn *conn, Archive *fout, Archive *AH, ProcLangInfo *info)
 		proname = PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "validator"));
 		appendPQExpBuffer(upgrade_buffer,
 						  "SELECT binary_upgrade.preassign_procedure_oid("
-						  "'%u'::pg_catalog.oid, '%s'::text, '%u'::pg_catalog.oid);\n",
+						  "'%u'::pg_catalog.oid, $$%s$$::text, '%u'::pg_catalog.oid);\n",
 						  procoid, proname, nsoid);
 	}
 
@@ -274,14 +274,14 @@ dumpProcLangOid(PGconn *conn, Archive *fout, Archive *AH, ProcLangInfo *info)
 			proname = PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "inline"));
 			appendPQExpBuffer(upgrade_buffer,
 							  "SELECT binary_upgrade.preassign_procedure_oid("
-							  "'%u'::pg_catalog.oid, '%s'::text, '%u'::pg_catalog.oid);\n",
+							  "'%u'::pg_catalog.oid, $$%s$$::text, '%u'::pg_catalog.oid);\n",
 							  procoid, proname, nsoid);
 		}
 	}
 
 	appendPQExpBuffer(upgrade_buffer,
 					  "SELECT binary_upgrade.preassign_language_oid("
-					  "'%u'::pg_catalog.oid, '%s'::text);\n",
+					  "'%u'::pg_catalog.oid, $$%s$$::text);\n",
 					  info->dobj.catId.oid, info->dobj.name);
 
 	ArchiveEntry(AH, nilCatalogId, createDumpId(),
@@ -357,7 +357,7 @@ dumpConversionOid(PGconn *conn, Archive *AH, ConvInfo *info)
 
 	snprintf(query_buffer, sizeof(query_buffer),
 			 "SELECT binary_upgrade.preassign_conversion_oid('%u'::pg_catalog.oid, "
-			 "'%s'::text, '%u'::pg_catalog.oid);\n",
+			 "$$%s$$::text, '%u'::pg_catalog.oid);\n",
 			 info->dobj.catId.oid, info->dobj.name, connamespace);
 
 	PQclear(upgrade_res);
@@ -386,7 +386,7 @@ dumpRuleOid(Archive *AH, RuleInfo *info)
 
 	snprintf(query_buffer, sizeof(query_buffer),
 			 "SELECT binary_upgrade.preassign_rule_oid("
-			 "'%u'::pg_catalog.oid, '%u'::pg_catalog.oid, '%s'::text);\n",
+			 "'%u'::pg_catalog.oid, '%u'::pg_catalog.oid, $$%s$$::text);\n",
 			 info->dobj.catId.oid, tbinfo->dobj.catId.oid, info->dobj.name);
 
 	ArchiveEntry(AH, nilCatalogId, createDumpId(),
@@ -436,7 +436,7 @@ dumpOpFamilyOid(PGconn *conn, Archive *AH, OpfamilyInfo *info)
 
 	snprintf(query_buffer, sizeof(query_buffer),
 			 "SELECT binary_upgrade.preassign_opfam_oid('%u'::pg_catalog.oid, "
-			 "'%s'::text, '%u'::pg_catalog.oid);",
+			 "$$%s$$::text, '%u'::pg_catalog.oid);",
 			 info->dobj.catId.oid, info->dobj.name, opfnamespace);
 
 	PQclear(upgrade_res);
@@ -473,7 +473,7 @@ dumpOpClassOid(PGconn *conn, Archive *AH, OpclassInfo *info)
 	appendPQExpBuffer(upgrade_query,
 					  "SELECT oid, opcnamespace "
 					  "FROM pg_catalog.pg_opclass "
-					  "WHERE opcname = '%s'::text",
+					  "WHERE opcname = $$%s$$::text",
 					  info->dobj.name);
 
 	upgrade_res = PQexec(conn, upgrade_query->data);
@@ -490,7 +490,7 @@ dumpOpClassOid(PGconn *conn, Archive *AH, OpclassInfo *info)
 
 	snprintf(query_buffer, sizeof(query_buffer),
 			 "SELECT binary_upgrade.preassign_opclass_oid('%u'::pg_catalog.oid, "
-			 "'%s'::text, '%u'::pg_catalog.oid);",
+			 "$$%s$$::text, '%u'::pg_catalog.oid);",
 			 info->dobj.catId.oid, info->dobj.name, opcnamespace);
 
 	PQclear(upgrade_res);
@@ -540,7 +540,7 @@ dumpTSObjectOid(Archive *AH, DumpableObject *info)
 
 	snprintf(query_buffer, sizeof(query_buffer),
 			 "SELECT binary_upgrade.%s('%u'::pg_catalog.oid, "
-			 "'%u'::pg_catalog.oid, '%s'::text);\n",
+			 "'%u'::pg_catalog.oid, $$%s$$::text);\n",
 			 funcname, d->catId.oid, d->namespace->dobj.catId.oid, d->name);
 
 	ArchiveEntry(AH, nilCatalogId, createDumpId(),
@@ -560,7 +560,7 @@ dumpExtensionOid(Archive *AH, ExtensionInfo *info)
 
 	snprintf(query_buffer, sizeof(query_buffer),
 			 "SELECT binary_upgrade.preassign_extension_oid('%u'::pg_catalog.oid, "
-			 "'%u'::pg_catalog.oid, '%s'::text);\n",
+			 "'%u'::pg_catalog.oid, $$%s$$::text);\n",
 			 info->dobj.catId.oid, info->dobj.namespace->dobj.catId.oid,
 			 info->dobj.name);
 
@@ -589,7 +589,7 @@ dumpShellTypeOid(PGconn *conn, Archive *fout, Archive *AH, ShellTypeInfo *info)
 	appendPQExpBuffer(upgrade_query,
 					  "SELECT oid "
 					  "FROM   pg_catalog.pg_type "
-					  "WHERE  typname = '%s'::text;",
+					  "WHERE  typname = $$%s$$::text;",
 					  info->dobj.name);
 
 	upgrade_res = PQexec(conn, upgrade_query->data);
@@ -686,7 +686,7 @@ preassign_enum_oid(PGconn *conn, Archive *AH, Oid enum_oid, char *objname)
 						  "SELECT binary_upgrade.preassign_enum_oid("
 								"'%u'::pg_catalog.oid, "
 								"'%u'::pg_catalog.oid, "
-								"'%s'::text);\n",
+								"$$%s$$::text);\n",
 						  oid, enum_oid, label);
 	}
 
@@ -829,7 +829,7 @@ preassign_type_oid(PGconn *conn, Archive *fout, Archive *AH, Oid pg_type_oid, ch
 
 	appendPQExpBuffer(upgrade_buffer,
 			 		  "SELECT binary_upgrade.preassign_type_oid("
-					  "'%u'::pg_catalog.oid, '%s'::text, '%u'::pg_catalog.oid);\n",
+					  "'%u'::pg_catalog.oid, $$%s$$::text, '%u'::pg_catalog.oid);\n",
 					  pg_type_oid, type->dobj.name, type->typnsp);
 
 	/*
@@ -840,7 +840,7 @@ preassign_type_oid(PGconn *conn, Archive *fout, Archive *AH, Oid pg_type_oid, ch
 	{
 		appendPQExpBuffer(upgrade_buffer,
 						  "SELECT binary_upgrade.preassign_arraytype_oid("
-						  "'%u'::pg_catalog.oid, '%s'::text, '%u'::pg_catalog.oid);\n",
+						  "'%u'::pg_catalog.oid, $$%s$$::text, '%u'::pg_catalog.oid);\n",
 						  type->arraytypoid, type->arraytypname, type->arraytypnsp);
 	}
 
@@ -924,7 +924,7 @@ preassign_constraint_oid(Archive *AH, Oid constroid, Oid nsoid, char *objname, O
 {
 	snprintf(query_buffer, sizeof(query_buffer),
 			 "SELECT binary_upgrade.preassign_constraint_oid('%u'::pg_catalog.oid, "
-			 "'%u'::pg_catalog.oid, '%s'::text, '%u'::pg_catalog.oid, '%u'::pg_catalog.oid);\n",
+			 "'%u'::pg_catalog.oid, $$%s$$::text, '%u'::pg_catalog.oid, '%u'::pg_catalog.oid);\n",
 			 constroid, nsoid, objname, contable, condomain);
 
 	ArchiveEntry(AH, nilCatalogId, createDumpId(),
@@ -949,7 +949,7 @@ dumpExternalProtocolOid(Archive *AH, ExtProtInfo *info)
 
 	snprintf(query_buffer, sizeof(query_buffer),
 			 "SELECT binary_upgrade.preassign_extprotocol_oid("
-			 "'%u'::pg_catalog.oid, '%s'::text);\n",
+			 "'%u'::pg_catalog.oid, $$%s$$::text);\n",
 			 info->dobj.catId.oid, info->dobj.name);
 
 	ArchiveEntry(AH, nilCatalogId, createDumpId(),
@@ -1077,7 +1077,7 @@ preassign_view_rule_oids(PGconn *conn, Archive *AH, Oid view_oid)
 
 		appendPQExpBuffer(upgrade_buffer,
 			 "SELECT binary_upgrade.preassign_rule_oid("
-			 "'%u'::pg_catalog.oid, '%u'::pg_catalog.oid, '%s'::text);\n",
+			 "'%u'::pg_catalog.oid, '%u'::pg_catalog.oid, $$%s$$::text);\n",
 			 rule_oid, view_oid, rule_name);
 	}
 
@@ -1165,7 +1165,7 @@ preassign_pg_class_oids(PGconn *conn, Archive *fout, Archive *AH, Oid pg_class_o
 
 	appendPQExpBuffer(upgrade_buffer,
 					  "SELECT binary_upgrade.preassign_relation_oid('%u'::pg_catalog.oid, "
-																   "'%s'::text, "
+																   "$$%s$$::text, "
 																   "'%u'::pg_catalog.oid);\n",
 					  pg_class_oid, pg_class_relname, pg_class_relnamespace);
 
@@ -1276,7 +1276,7 @@ preassign_pg_class_oids(PGconn *conn, Archive *fout, Archive *AH, Oid pg_class_o
 		bm_name = PQgetvalue(bm_res, 0, PQfnumber(bm_res, "bm_name"));
 		appendPQExpBuffer(upgrade_buffer,
 						  "SELECT binary_upgrade.preassign_relation_oid('%u'::pg_catalog.oid, "
-																	   "'%s'::text, "
+																	   "$$%s$$::text, "
 																	   "'%u'::pg_catalog.oid);\n",
 						  bm_oid, bm_name, bm_ns);
 
@@ -1288,7 +1288,7 @@ preassign_pg_class_oids(PGconn *conn, Archive *fout, Archive *AH, Oid pg_class_o
 		bm_name = PQgetvalue(bm_res, 0, PQfnumber(bm_res, "bmi_name"));
 		appendPQExpBuffer(upgrade_buffer,
 						  "SELECT binary_upgrade.preassign_relation_oid('%u'::pg_catalog.oid, "
-																	   "'%s'::text, "
+																	   "$$%s$$::text, "
 																	   "'%u'::pg_catalog.oid);\n",
 						  bm_oid, bm_name, bm_ns);
 

--- a/src/bin/pg_dump/binary_upgrade.c
+++ b/src/bin/pg_dump/binary_upgrade.c
@@ -498,13 +498,14 @@ dumpShellTypeOid(PGconn *conn, Archive *fout, Archive *AH, ShellTypeInfo *info)
 	/* Skip if not to be dumped */
 	if (!info->dobj.dump)
 		return;
-	
+
 	upgrade_query = createPQExpBuffer();
 
 	appendPQExpBuffer(upgrade_query,
-					  "SELECT oid FROM pg_catalog.pg_type "
-					  "WHERE typname = '%s'::text;",
-					 info->dobj.name);
+					  "SELECT oid "
+					  "FROM   pg_catalog.pg_type "
+					  "WHERE  typname = '%s'::text;",
+					  info->dobj.name);
 
 	upgrade_res = PQexec(conn, upgrade_query->data);
 	check_sql_result(upgrade_res, conn, upgrade_query->data, PGRES_TUPLES_OK);
@@ -597,9 +598,10 @@ preassign_enum_oid(PGconn *conn, Archive *AH, Oid enum_oid, char *objname)
 		label = PQgetvalue(upgrade_res, i, PQfnumber(upgrade_res, "enumlabel"));
 
 		appendPQExpBuffer(upgrade_buffer,
-						  "SELECT binary_upgrade.preassign_enum_oid('%u'::pg_catalog.oid, "
-																   "'%u'::pg_catalog.oid, "
-																   "'%s'::text);\n",
+						  "SELECT binary_upgrade.preassign_enum_oid("
+								"'%u'::pg_catalog.oid, "
+								"'%u'::pg_catalog.oid, "
+								"'%s'::text);\n",
 						  oid, enum_oid, label);
 	}
 
@@ -730,7 +732,7 @@ preassign_type_oid(PGconn *conn, Archive *fout, Archive *AH, Oid pg_type_oid, ch
 	/* This shouldn't happen.. */
 	if (!type)
 	{
-		write_msg(NULL, "ERROR: didn't find type information in cache\n");
+		write_msg(NULL, "ERROR: didn't find type information in cache for %u (%s)\n", pg_type_oid, objname);
 		exit_nicely();
 	}
 

--- a/src/bin/pg_dump/binary_upgrade.c
+++ b/src/bin/pg_dump/binary_upgrade.c
@@ -1162,26 +1162,53 @@ preassign_pg_class_oids(PGconn *conn, Archive *fout, Archive *AH, Oid pg_class_o
 	PQExpBuffer aoseg_query;
 	PGresult   *aoseg_res;
 	Oid			aoseg_namespace;
-	bool		columnstore;
 	bool		bitmapindex;
 	PQExpBuffer bm_query;
 	PGresult   *bm_res;
 	Oid			bm_oid;
 	Oid			bm_ns;
 	char	   *bm_name;
+	char	   *segrelname;
+	char	   *blkdirrelname;
+	char	   *blkdiridxname;
+	char	   *visimaprelname;
+	char	   *visimapidxname;
 
 	appendPQExpBuffer(upgrade_query,
-					  "SELECT c.reltoastrelid, t.reltoastidxid, "
-					  "       t.relnamespace as toastnamespace, "
-					  "       ao.segrelid, c.relnamespace, "
-					  "       ao.blkdirrelid, ao.blkdiridxid, "
-					  "       ao.visimaprelid, ao.visimapidxid, "
-					  "       c.relname, ao.columnstore, "
+					  "SELECT c.relname, c.relnamespace, "
+					  "       c.reltoastrelid, t.reltoastidxid, t.relnamespace AS toastnamespace, "
+					  /* AO segments aux relation */
+					  "       ao.segrelid, "
+					  "       aoseg.relname AS segrelname, "
+					  /* AO blkdir aux relations */
+					  "       ao.blkdirrelid, "
+					  "       aoblk.relname AS blkdirrelname, "
+					  "       ao.blkdiridxid, "
+					  "       aoblkidx.relname AS blkdiridxname, "
+					  /* AO Visimap aux relations */
+					  "       ao.visimaprelid, "
+					  "       aovis.relname AS visimaprelname, "
+					  "       ao.visimapidxid, "
+					  "       aovisidx.relname AS visimapidxname, "
+					  /* Index access method name */
 					  "       a.amname "
 					  "FROM   pg_catalog.pg_class c "
-					  "       LEFT JOIN pg_catalog.pg_class t ON (c.reltoastrelid = t.oid) "
-					  "       LEFT JOIN pg_catalog.pg_appendonly ao ON (ao.relid = c.oid) "
-					  "       LEFT JOIN pg_catalog.pg_am a ON (a.oid = c.relam AND c.relam <> 0) "
+					  "       LEFT JOIN pg_catalog.pg_class t "
+					  "           ON (c.reltoastrelid = t.oid) "
+					  "       LEFT JOIN pg_catalog.pg_appendonly ao "
+					  "           ON (ao.relid = c.oid) "
+					  "       LEFT JOIN pg_catalog.pg_class aoseg "
+					  "           ON (ao.segrelid = aoseg.oid) "
+					  "       LEFT JOIN pg_catalog.pg_class aovis "
+					  "           ON (ao.visimaprelid = aovis.oid) "
+					  "       LEFT JOIN pg_catalog.pg_class aovisidx "
+					  "           ON (ao.visimapidxid = aovisidx.oid) "
+					  "       LEFT JOIN pg_catalog.pg_class aoblk "
+					  "           ON (ao.blkdirrelid = aoblk.oid) "
+					  "       LEFT JOIN pg_catalog.pg_class aoblkidx "
+					  "           ON (ao.blkdiridxid = aoblkidx.oid) "
+					  "       LEFT JOIN pg_catalog.pg_am a "
+					  "           ON (a.oid = c.relam AND c.relam <> 0) "
 					  "WHERE  c.oid = '%u'::pg_catalog.oid;",
 					  pg_class_oid);
 
@@ -1209,7 +1236,6 @@ preassign_pg_class_oids(PGconn *conn, Archive *fout, Archive *AH, Oid pg_class_o
 	pg_appendonly_blkdiridxid = atooid(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "blkdiridxid")));
 	pg_appendonly_visimaprelid = atooid(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "visimaprelid")));
 	pg_appendonly_visimapidxid = atooid(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "visimapidxid")));
-	columnstore = (strcmp(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "columnstore")), "t") == 0) ? true : false;
 	bitmapindex = (strcmp(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "amname")), "bitmap") == 0) ? true : false;
 
 	appendPQExpBuffer(upgrade_buffer,
@@ -1261,41 +1287,46 @@ preassign_pg_class_oids(PGconn *conn, Archive *fout, Archive *AH, Oid pg_class_o
 	}
 	if (OidIsValid(pg_appendonly_segrelid))
 	{
+		segrelname = PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "segrelname"));
 		appendPQExpBuffer(upgrade_buffer,
 						  "SELECT binary_upgrade.preassign_relation_oid('%u'::pg_catalog.oid, "
-																	   "'pg_ao%sseg_%u'::text, "
+																	   "$$%s$$::text, "
 																	   "'%u'::pg_catalog.oid);\n",
-						  pg_appendonly_segrelid, (columnstore ? "cs" : ""), pg_class_oid, aoseg_namespace);
+						  pg_appendonly_segrelid, segrelname, aoseg_namespace);
 	}
 	if (OidIsValid(pg_appendonly_blkdirrelid))
 	{
+		blkdirrelname = PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "blkdirrelname"));
 		appendPQExpBuffer(upgrade_buffer,
 						  "SELECT binary_upgrade.preassign_relation_oid('%u'::pg_catalog.oid, "
-																	   "'pg_aoblkdir_%u'::text, "
+																	   "$$%s$$::text, "
 																	   "'%u'::pg_catalog.oid);\n",
-						  pg_appendonly_blkdirrelid, pg_class_oid, aoseg_namespace);
+						  pg_appendonly_blkdirrelid, blkdirrelname, aoseg_namespace);
 
 		/* every aoblkdir table has an index */
+		blkdiridxname = PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "blkdiridxname"));
 		appendPQExpBuffer(upgrade_buffer,
 						  "SELECT binary_upgrade.preassign_relation_oid('%u'::pg_catalog.oid, "
-																	   "'pg_aoblkdir_%u_index'::text, "
+																	   "$$%s$$::text, "
 																	   "'%u'::pg_catalog.oid);\n",
-						  pg_appendonly_blkdiridxid, pg_class_oid, aoseg_namespace);
+						  pg_appendonly_blkdiridxid, blkdiridxname, aoseg_namespace);
 	}
 	if (OidIsValid(pg_appendonly_visimaprelid))
 	{
+		visimaprelname = PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "visimaprelname"));
 		appendPQExpBuffer(upgrade_buffer,
 						  "SELECT binary_upgrade.preassign_relation_oid('%u'::pg_catalog.oid, "
-																	   "'pg_aovisimap_%u'::text, "
+																	   "$$%s$$::text, "
 																	   "'%u'::pg_catalog.oid);\n",
-						  pg_appendonly_visimaprelid, pg_class_oid, aoseg_namespace);
+						  pg_appendonly_visimaprelid, visimaprelname, aoseg_namespace);
 
 		/* every aovisimap table has an index */
+		visimapidxname = PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "visimapidxname"));
 		appendPQExpBuffer(upgrade_buffer,
 						  "SELECT binary_upgrade.preassign_relation_oid('%u'::pg_catalog.oid, "
-																	   "'pg_aovisimap_%u_index'::text, "
+																	   "$$%s$$::text, "
 																	   "'%u'::pg_catalog.oid);\n",
-						  pg_appendonly_visimapidxid, pg_class_oid, aoseg_namespace);
+						  pg_appendonly_visimapidxid, visimapidxname, aoseg_namespace);
 	}
 
 	/*
@@ -1368,7 +1399,6 @@ preassign_type_oids_by_rel_oid(PGconn *conn, Archive *fout, Archive *AH, Oid pg_
 	int			ntups;
 	PGresult   *upgrade_res;
 	Oid			pg_type_oid;
-	bool		columnstore;
 
 	upgrade_query = createPQExpBuffer();
 	upgrade_buffer = createPQExpBuffer();
@@ -1376,27 +1406,36 @@ preassign_type_oids_by_rel_oid(PGconn *conn, Archive *fout, Archive *AH, Oid pg_
 	appendPQExpBuffer(upgrade_query,
 					  "SELECT c.reltype AS crel, t.reltype AS trel, "
 					  "       t.relnamespace AS trelnamespace, "
+
+					  /* AO segments aux relation */
 					  "       aoseg.reltype AS aosegrel, "
 					  "       aoseg.relnamespace AS aonamespace, "
+					  "       aoseg.relname AS aosegrelname, "
+
+					  /* AO blkdir aux relations */
 					  "       aoblkdir.reltype AS aoblkdirrel, "
 					  "       aoblkdir.relnamespace AS aoblkdirnamespace, "
+					  "       aoblkdir.relname AS aoblkdirrelname, "
+
+					  /* AO visimap aux relations */
 					  "       aovisimap.reltype AS aovisimaprel, "
 					  "       aovisimap.relnamespace AS aovisimapnamespace, "
-					  "       ao.columnstore, "
+					  "       aovisimap.relname AS aovisimaprelname, "
+
 					  "       CASE WHEN c.relhassubclass THEN True "
 					  "       ELSE NULL END AS par_parent "
-					  "FROM pg_catalog.pg_class c "
-					  "LEFT JOIN pg_catalog.pg_class t ON "
-					  "  (c.reltoastrelid = t.oid) "
-					  "LEFT JOIN pg_catalog.pg_appendonly ao ON "
-					  "  (c.oid = ao.relid) "
-					  "LEFT JOIN pg_catalog.pg_class aoseg ON "
-					  "  (ao.segrelid = aoseg.oid) "
-					  "LEFT JOIN pg_catalog.pg_class aoblkdir ON "
-					  "  (ao.blkdirrelid = aoblkdir.oid) "
-					  "LEFT JOIN pg_catalog.pg_class aovisimap ON "
-					  "  (ao.visimaprelid = aovisimap.oid) "
-					  "WHERE c.oid = '%u'::pg_catalog.oid;",
+					  "FROM   pg_catalog.pg_class c "
+					  "       LEFT JOIN pg_catalog.pg_class t "
+					  "           ON (c.reltoastrelid = t.oid) "
+					  "       LEFT JOIN pg_catalog.pg_appendonly ao "
+					  "           ON (c.oid = ao.relid) "
+					  "       LEFT JOIN pg_catalog.pg_class aoseg "
+					  "           ON (ao.segrelid = aoseg.oid) "
+					  "       LEFT JOIN pg_catalog.pg_class aoblkdir "
+					  "           ON (ao.blkdirrelid = aoblkdir.oid) "
+					  "       LEFT JOIN pg_catalog.pg_class aovisimap "
+					  "           ON (ao.visimaprelid = aovisimap.oid) "
+					  "WHERE  c.oid = '%u'::pg_catalog.oid;",
 					  pg_rel_oid);
 
 	upgrade_res = PQexec(conn, upgrade_query->data);
@@ -1414,7 +1453,6 @@ preassign_type_oids_by_rel_oid(PGconn *conn, Archive *fout, Archive *AH, Oid pg_
 	}
 
 	pg_type_oid = atooid(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "crel")));
-	columnstore = (strcmp(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "columnstore")), "t") == 0) ? true : false;
 
 	preassign_type_oid(conn, fout, AH, pg_type_oid, objname);
 
@@ -1528,12 +1566,13 @@ preassign_type_oids_by_rel_oid(PGconn *conn, Archive *fout, Archive *AH, Oid pg_
 											PQfnumber(upgrade_res, "aosegrel")));
 		Oid			pg_type_aonamespace_oid = atooid(PQgetvalue(upgrade_res, 0,
 											PQfnumber(upgrade_res, "aonamespace")));
+		char 	   *aosegrelname = PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "aosegrelname"));
 
 		appendPQExpBuffer(upgrade_buffer,
 						  "SELECT binary_upgrade.preassign_type_oid('%u'::pg_catalog.oid, "
-																   "'pg_ao%sseg_%u'::text, "
+																   "$$%s$$::text, "
 																   "'%u'::pg_catalog.oid);\n",
-						  pg_type_aosegments_oid, (columnstore ? "cs" : ""), pg_rel_oid, pg_type_aonamespace_oid);
+						  pg_type_aosegments_oid, aosegrelname, pg_type_aonamespace_oid);
 	}
 
 	if (!PQgetisnull(upgrade_res, 0, PQfnumber(upgrade_res, "aoblkdirrel")))
@@ -1543,12 +1582,13 @@ preassign_type_oids_by_rel_oid(PGconn *conn, Archive *fout, Archive *AH, Oid pg_
 											PQfnumber(upgrade_res, "aoblkdirrel")));
 		Oid			pg_type_aoblockdir_namespace = atooid(PQgetvalue(upgrade_res, 0,
 											PQfnumber(upgrade_res, "aoblkdirnamespace")));
+		char	   *aoblkdirrelname = PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "aoblkdirrelname"));
 
 		appendPQExpBuffer(upgrade_buffer,
 						  "SELECT binary_upgrade.preassign_type_oid('%u'::pg_catalog.oid, "
-																   "'pg_aoblkdir_%u'::text, "
+																   "$$%s$$::text, "
 																   "'%u'::pg_catalog.oid);\n",
-						  pg_type_aoblockdir_oid, pg_rel_oid, pg_type_aoblockdir_namespace);
+						  pg_type_aoblockdir_oid, aoblkdirrelname, pg_type_aoblockdir_namespace);
 	}
 
 	if (!PQgetisnull(upgrade_res, 0, PQfnumber(upgrade_res, "aovisimaprel")))
@@ -1558,12 +1598,13 @@ preassign_type_oids_by_rel_oid(PGconn *conn, Archive *fout, Archive *AH, Oid pg_
 											PQfnumber(upgrade_res, "aovisimaprel")));
 		Oid			pg_type_aovisimap_namespace = atooid(PQgetvalue(upgrade_res, 0,
 											PQfnumber(upgrade_res, "aovisimapnamespace")));
+		char	   *aovisimaprelname = PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "aovisimaprelname"));
 
 		appendPQExpBuffer(upgrade_buffer,
 						  "SELECT binary_upgrade.preassign_type_oid('%u'::pg_catalog.oid, "
-																   "'pg_aovisimap_%u'::text, "
+																   "$$%s$$::text, "
 																   "'%u'::pg_catalog.oid);\n",
-						  pg_type_aovisimap_oid, pg_rel_oid, pg_type_aovisimap_namespace);
+						  pg_type_aovisimap_oid, aovisimaprelname, pg_type_aovisimap_namespace);
 	}
 
 	PQclear(upgrade_res);

--- a/src/bin/pg_dump/binary_upgrade.h
+++ b/src/bin/pg_dump/binary_upgrade.h
@@ -16,11 +16,30 @@
 #ifndef BINARY_UPGRADE_H
 #define BINARY_UPGRADE_H
 
-#define QUERY_ALLOC 8192
-
 #include "postgres_fe.h"
 #include "pg_backup_archiver.h"
 #include "libpq/libpq-fs.h"
+
+#define QUERY_ALLOC 8192
+
+#define AGG_FUNCS	6
+
+typedef struct AggregateFunction
+{
+	char	name[NAMEDATALEN];
+	int		version;
+} AggregateFunction;
+
+static AggregateFunction agg_fns[AGG_FUNCS] =
+{
+	{"aggfnoid",		80300},
+	{"aggtransfn",		80300},
+	{"agginvtransfn",	80300},
+	{"aggfinalfn",		80300},
+	{"aggprelimfn",		80300},
+	{"agginvprelimfn",	80300}
+};
+
 
 extern void dumpTableOid(PGconn *conn, Archive *fout, Archive *AH, TableInfo *info);
 extern void dumpIndexOid(PGconn *conn, Archive *AH, IndxInfo *info);
@@ -40,5 +59,6 @@ extern void dumpProcLangOid(PGconn *conn, Archive *fout, Archive *AH, ProcLangIn
 extern void dumpCastOid(Archive *AH, CastInfo *info);
 extern void dumpTSObjectOid(Archive *AH, DumpableObject *info);
 extern void dumpExtensionOid(Archive *AH, ExtensionInfo *info);
+extern void dumpAggProcedureOid(PGconn *conn, Archive *fout, Archive *AH, AggInfo *info);
 
 #endif /* BINARY_UPGRADE_H */

--- a/src/bin/pg_dump/binary_upgrade.h
+++ b/src/bin/pg_dump/binary_upgrade.h
@@ -42,7 +42,7 @@ static AggregateFunction agg_fns[AGG_FUNCS] =
 
 
 extern void dumpTableOid(PGconn *conn, Archive *fout, Archive *AH, TableInfo *info);
-extern void dumpIndexOid(PGconn *conn, Archive *AH, IndxInfo *info);
+extern void dumpIndexOid(PGconn *conn, Archive *fout, Archive *AH, IndxInfo *info);
 extern void dumpAttrDefsOid(Archive *AH, AttrDefInfo *info);
 extern void dumpConversionOid(PGconn *conn, Archive *AH, ConvInfo *info);
 extern void dumpOperatorOid(Archive *AH, OprInfo *info);
@@ -54,7 +54,7 @@ extern void dumpShellTypeOid(PGconn *conn, Archive *fout, Archive *AH, ShellType
 extern void dumpTypeOid(PGconn *conn, Archive *fout, Archive *AH, TypeInfo *info);
 extern void dumpNamespaceOid(Archive *AH, NamespaceInfo *info);
 extern void dumpRuleOid(Archive *AH, RuleInfo *info);
-extern void dumpConstraintOid(PGconn *conn, Archive *AH, ConstraintInfo *info);
+extern void dumpConstraintOid(PGconn *conn, Archive *fout, Archive *AH, ConstraintInfo *info);
 extern void dumpProcLangOid(PGconn *conn, Archive *fout, Archive *AH, ProcLangInfo *info);
 extern void dumpCastOid(Archive *AH, CastInfo *info);
 extern void dumpTSObjectOid(Archive *AH, DumpableObject *info);

--- a/src/bin/pg_dump/binary_upgrade.h
+++ b/src/bin/pg_dump/binary_upgrade.h
@@ -49,7 +49,7 @@ extern void dumpOperatorOid(Archive *AH, OprInfo *info);
 extern void dumpOpFamilyOid(PGconn *conn, Archive *AH, OpfamilyInfo *info);
 extern void dumpOpClassOid(PGconn *conn, Archive *AH, OpclassInfo *info);
 extern void dumpExternalProtocolOid(Archive *AH, ExtProtInfo *info);
-extern void dumpProcedureOid(Archive *AH, FuncInfo *info);
+extern void dumpProcedureOid(PGconn *conn, Archive *fout, Archive *AH, FuncInfo *info);
 extern void dumpShellTypeOid(PGconn *conn, Archive *fout, Archive *AH, ShellTypeInfo *info);
 extern void dumpTypeOid(PGconn *conn, Archive *fout, Archive *AH, TypeInfo *info);
 extern void dumpNamespaceOid(Archive *AH, NamespaceInfo *info);

--- a/src/bin/pg_dump/binary_upgrade.h
+++ b/src/bin/pg_dump/binary_upgrade.h
@@ -47,7 +47,7 @@ extern void dumpAttrDefsOid(Archive *AH, AttrDefInfo *info);
 extern void dumpConversionOid(PGconn *conn, Archive *AH, ConvInfo *info);
 extern void dumpOperatorOid(Archive *AH, OprInfo *info);
 extern void dumpOpFamilyOid(PGconn *conn, Archive *AH, OpfamilyInfo *info);
-extern void dumpOpClassOid(PGconn *conn, Archive *AH, OpclassInfo *info);
+extern void dumpOpClassOid(PGconn *conn, Archive *fout, Archive *AH, OpclassInfo *info);
 extern void dumpExternalProtocolOid(Archive *AH, ExtProtInfo *info);
 extern void dumpProcedureOid(PGconn *conn, Archive *fout, Archive *AH, FuncInfo *info);
 extern void dumpShellTypeOid(PGconn *conn, Archive *fout, Archive *AH, ShellTypeInfo *info);

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -5448,14 +5448,14 @@ dumpBinaryUpgrade(Archive *fout, DumpableObject **dobjs, int numObjs)
 				dumpAttrDefsOid(fout, (AttrDefInfo *) dobj);
 				break;
 			case DO_INDEX:
-				dumpIndexOid(g_conn, fout, (IndxInfo *) dobj);
+				dumpIndexOid(g_conn, g_fout, fout, (IndxInfo *) dobj);
 				break;
 			case DO_RULE:
 				dumpRuleOid(fout, (RuleInfo *) dobj);
 				break;
 			case DO_FK_CONSTRAINT:
 			case DO_CONSTRAINT:
-				dumpConstraintOid(g_conn, fout, (ConstraintInfo *) dobj);
+				dumpConstraintOid(g_conn, g_fout, fout, (ConstraintInfo *) dobj);
 				break;
 			case DO_AGG:
 				dumpAggProcedureOid(g_conn, g_fout, fout, (AggInfo *) dobj);

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -7955,7 +7955,8 @@ dumpOpclass(Archive *fout, OpclassInfo *opcinfo)
 	i_opcfamilynsp = PQfnumber(res, "opcfamilynsp");
 	i_amname = PQfnumber(res, "amname");
 
-	opcintype = PQgetvalue(res, 0, i_opcintype);
+	/* opcintype may still be needed after we PQclear res */
+	opcintype = pg_strdup(PQgetvalue(res, 0, i_opcintype));
 	opckeytype = PQgetvalue(res, 0, i_opckeytype);
 	opcdefault = PQgetvalue(res, 0, i_opcdefault);
 	opcfamily = PQgetvalue(res, 0, i_opcfamily);
@@ -8117,6 +8118,15 @@ dumpOpclass(Archive *fout, OpclassInfo *opcinfo)
 
 	PQclear(res);
 
+	/*
+	 * If needComma is still false it means we haven't added anything after
+	 * the AS keyword.  To avoid printing broken SQL, append a dummy STORAGE
+	 * clause with the same datatype.  This isn't sanctioned by the
+	 * documentation, but actually DefineOpClass will treat it as a no-op.
+	 */
+	if (!needComma)
+		appendPQExpBuffer(q, "STORAGE %s", opcintype);
+
 	appendPQExpBuffer(q, ";\n");
 
 	ArchiveEntry(fout, opcinfo->dobj.catId, opcinfo->dobj.dumpId,
@@ -8138,6 +8148,7 @@ dumpOpclass(Archive *fout, OpclassInfo *opcinfo)
 				NULL, opcinfo->rolname,
 				opcinfo->dobj.catId, 0, opcinfo->dobj.dumpId);
 
+	free(opcintype);
 	free(amname);
 	destroyPQExpBuffer(query);
 	destroyPQExpBuffer(q);

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -5433,7 +5433,7 @@ dumpBinaryUpgrade(Archive *fout, DumpableObject **dobjs, int numObjs)
 				dumpOperatorOid(fout, (OprInfo *) dobj);
 				break;
 			case DO_OPCLASS:
-				dumpOpClassOid(g_conn, fout, (OpclassInfo *) dobj);
+				dumpOpClassOid(g_conn, g_fout, fout, (OpclassInfo *) dobj);
 				break;
 			case DO_OPFAMILY:
 				dumpOpFamilyOid(g_conn, fout, (OpfamilyInfo *) dobj);

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -5457,6 +5457,9 @@ dumpBinaryUpgrade(Archive *fout, DumpableObject **dobjs, int numObjs)
 			case DO_CONSTRAINT:
 				dumpConstraintOid(g_conn, fout, (ConstraintInfo *) dobj);
 				break;
+			case DO_AGG:
+				dumpAggProcedureOid(g_conn, g_fout, fout, (AggInfo *) dobj);
+				break;
 			case DO_PROCLANG:
 				dumpProcLangOid(g_conn, g_fout, fout, (ProcLangInfo *) dobj);
 				break;
@@ -5483,7 +5486,6 @@ dumpBinaryUpgrade(Archive *fout, DumpableObject **dobjs, int numObjs)
 			 * only or are exempt from Oid pre-assignment due to handling Oid
 			 * synchronization in another way.
 			 */
-			case DO_AGG:
 			case DO_BLOBS:
 			case DO_BLOB_COMMENTS:
 			case DO_TRIGGER:

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -5424,7 +5424,7 @@ dumpBinaryUpgrade(Archive *fout, DumpableObject **dobjs, int numObjs)
 				dumpShellTypeOid(g_conn, g_fout, fout, (ShellTypeInfo *) dobj);
 				break;
 			case DO_FUNC:
-				dumpProcedureOid(fout, (FuncInfo *) dobj);
+				dumpProcedureOid(g_conn, g_fout, fout, (FuncInfo *) dobj);
 				break;
 			case DO_EXTPROTOCOL:
 				dumpExternalProtocolOid(fout, (ExtProtInfo *) dobj);

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -4762,8 +4762,8 @@ getTableAttrs(TableInfo *tblinfo, int numTables)
 bool
 shouldPrintColumn(TableInfo *tbinfo, int colno)
 {
-	return ((tbinfo->attislocal[colno] || tbinfo->relstorage == RELSTORAGE_EXTERNAL) &&
-			(!tbinfo->attisdropped[colno] || binary_upgrade));
+	return (((tbinfo->attislocal[colno] || tbinfo->relstorage == RELSTORAGE_EXTERNAL) &&
+			!tbinfo->attisdropped[colno]) || binary_upgrade);
 }
 
 
@@ -9822,6 +9822,7 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 				if (actual_atts > 0)
 					appendPQExpBuffer(q, ",");
 				appendPQExpBuffer(q, "\n    ");
+				actual_atts++;
 
 				/* Attribute name */
 				appendPQExpBuffer(q, "%s ",
@@ -9852,17 +9853,17 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 									  tbinfo->attrdefs[j]->adef_expr);
 
 				/*
-				 * Not Null constraint --- suppress if inherited
+				 * Not Null constraint --- suppress if inherited, except in
+				 * binary-upgrade mode where taht won't work.
 				 */
-				if (tbinfo->notnull[j] && !tbinfo->inhNotNull[j])
+				if (tbinfo->notnull[j] &&
+					(!tbinfo->inhNotNull[j] || binary_upgrade))
 					appendPQExpBuffer(q, " NOT NULL");
 
 				/* Column Storage attributes */
 				if (tbinfo->attencoding[j] != NULL)
 					appendPQExpBuffer(q, " ENCODING (%s)",
 										tbinfo->attencoding[j]);
-
-				actual_atts++;
 			}
 		}
 
@@ -9891,7 +9892,7 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 		/*
 		 * Emit the INHERITS clause if this table has parents.
 		 */
-		if (numParents > 0)
+		if (numParents > 0 && !binary_upgrade)
 		{
 			appendPQExpBuffer(q, "\nINHERITS (");
 			for (k = 0; k < numParents; k++)
@@ -10116,6 +10117,11 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 				}
 			}
 
+/*
+ * GPDB_84_MERGE_FIXME - When we in 8.4 get conislocal, reactivate this code
+ * for handling constraints. Left if 0'd out to minimize merge conflicts.
+ */
+#if 0
 			for (k = 0; k < tbinfo->ncheck; k++)
 			{
 				ConstraintInfo *constr = &(tbinfo->checkexprs[k]);
@@ -10143,6 +10149,7 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 				appendStringLiteralAH(q, fmtId(tbinfo->dobj.name), fout);
 				appendPQExpBuffer(q, "::pg_catalog.regclass;\n");
 			}
+#endif
 
 			if (numParents > 0)
 			{

--- a/src/bin/pg_resetxlog/pg_resetxlog.c
+++ b/src/bin/pg_resetxlog/pg_resetxlog.c
@@ -89,6 +89,7 @@ main(int argc, char *argv[])
 {
 	int			c;
 	bool		force = false;
+	bool		binary_upgrade = false;
 	bool		noupdate = false;
 	uint32		set_xid_epoch = (uint32) -1;
 	TransactionId set_xid = 0;
@@ -129,10 +130,14 @@ main(int argc, char *argv[])
 	}
 
 
-	while ((c = getopt(argc, argv, "fl:m:no:r:O:x:e:")) != -1)
+	while ((c = getopt(argc, argv, "yfl:m:no:r:O:x:e:")) != -1)
 	{
 		switch (c)
 		{
+			case 'y':
+				binary_upgrade = true;
+				break;
+
 			case 'f':
 				force = true;
 				break;
@@ -389,7 +394,7 @@ main(int argc, char *argv[])
 	/*
 	 * Warn user of using pg_resetxlog with GPDB
 	 */
-	if(!AcceptWarning())
+	if(!binary_upgrade && !AcceptWarning())
 	{
 		printf(_("Abort %s!\n"), progname);
 		exit(1);


### PR DESCRIPTION
This PR completes `pg_upgrade` by adding support for same-version upgrades on 5.0 and hooks `pg_upgrade` into ICW such that it's tested on each PR/changeset. Same-version-upgrades (ie 5.0->5.0) are important to support in order to be able to easily test `pg_upgrade`, and keeping a same-version upgrade in the pipeline ensures that new object types cannot be added without proper handling in `pg_upgrade` is added as well.