### PR TITLE
Fortify SED_PG_CONF() shell function, as called by gpinitsystem

### DIFF
--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -347,6 +347,7 @@ TRY_AND_RETRY () {
 	eval "$1"
 	RETVAL=$?
 	if [ $RETVAL -ne 0 ]; then
+		$SLEEP 10 # Arbitrary wait time. There is a very slim chance of an ssh failure.
 		LOG_MSG "[WARN]:-Retrying command -- $1"
 		eval "$1"
 		RETVAL=$?

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -343,19 +343,7 @@ ERROR_CHK () {
 	LOG_MSG "[INFO]:-End Function $FUNCNAME"
 }
 
-TRY_AND_RETRY () {
-	eval "$1"
-	RETVAL=$?
-	if [ $RETVAL -ne 0 ]; then
-		$SLEEP 10 # Arbitrary wait time. There is a very slim chance of an ssh failure.
-		LOG_MSG "[WARN]:-Retrying command -- $1"
-		eval "$1"
-		RETVAL=$?
-	fi
-	return $RETVAL
-}
-RETRY()
-{
+RETRY () {
 	RETVAL=$?
 	if [[ "$CURRENT" =~ "ssh" ]]; then
 		for i in 2 4 8; do

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -405,8 +405,11 @@ SED_PG_CONF () {
 				fi
 			fi
 	else
-		# Call out retry for commands that fail
+		# trap DEBUG will always be called first, when other traps are triggered.
+		# We need to make sure that we save the current running command, so
+		# that the RETRY function re-runs the command
 		trap 'CURRENT=$BASH_COMMAND' DEBUG
+		# Call out retry for commands that fail
 		trap RETRY ERR
 		RETVAL=0 # RETVAL gets modified in RETRY function whenever the trap is called
 

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -417,7 +417,7 @@ SED_PG_CONF () {
 		if [ `$TRUSTED_SHELL $SED_HOST "$GREP -c \"${SEARCH_TXT}\" $FILENAME"` -eq 0 ] || [ $APPEND -eq 1 ]; then
 			$TRUSTED_SHELL $SED_HOST "$ECHO \"$SUB_TXT\" >> $FILENAME"
 			if [ $RETVAL -ne 0 ]; then
-				ERROR_EXIT "[WARN]:-Failed to append line $SUB_TXT to $FILENAME on $SED_HOST, retrying" 1
+				ERROR_EXIT "[FATAL]:-Failed to append line $SUB_TXT to $FILENAME on $SED_HOST" 2
 			else
 				LOG_MSG "[INFO]:-Appended line $SUB_TXT to $FILENAME on $SED_HOST" 1
 			fi
@@ -430,7 +430,7 @@ SED_PG_CONF () {
 			$CAT $SED_TMP_FILE | $TRUSTED_SHELL ${SED_HOST} $DD of=$SED_TMP_FILE > /dev/null 2>&1
 			$TRUSTED_SHELL $SED_HOST "sed -i'.bak1' -f $SED_TMP_FILE $FILENAME" > /dev/null 2>&1
 			if [ $RETVAL -ne 0 ]; then
-				ERROR_EXIT "[WARN]:-Failed to insert $SUB_TXT in $FILENAME on $SED_HOST, retrying" 1
+				ERROR_EXIT "[FATAL]:-Failed to insert $SUB_TXT in $FILENAME on $SED_HOST" 2
 			else
 				LOG_MSG "[INFO]:-Replaced line in $FILENAME on $SED_HOST"
 				$TRUSTED_SHELL $SED_HOST "$RM -f ${FILENAME}.bak1" > /dev/null 2>&1
@@ -439,7 +439,7 @@ SED_PG_CONF () {
 			$CAT $SED_TMP_FILE | $TRUSTED_SHELL ${SED_HOST} $DD of=$SED_TMP_FILE > /dev/null 2>&1
 			$TRUSTED_SHELL $SED_HOST "sed -i'.bak2' -f $SED_TMP_FILE $FILENAME" > /dev/null 2>&1
 			if [ $RETVAL -ne 0 ]; then
-				ERROR_EXIT "[WARN]:-Failed to substitute #${SEARCH_TXT} in $FILENAME on $SED_HOST, retrying" 1
+				ERROR_EXIT "[FATAL]:-Failed to substitute #${SEARCH_TXT} in $FILENAME on $SED_HOST" 2
 			else
 				LOG_MSG "[INFO]:-Replaced line in $FILENAME on $SED_HOST"
 				$TRUSTED_SHELL $SED_HOST "$RM -f ${FILENAME}.bak2" > /dev/null 2>&1


### PR DESCRIPTION
It's also called via gpcreateseg.sh

There is a chance where gpinitsystem may miss a GUC change in one of the
segments and left undetected. This would cause failures down the line.

More robust in three ways:
- Retry ssh calls in case they fail
- Actually error exit if it does fail, for quicker diagnosis if the
  value in postgres.conf did not get updated
- When keeping a version of the key-value pair in a comment, only
  archive the first-matched key-value (otherwise you get comments on
  your comments)

Signed-off-by: Marbin Tan <mtan@pivotal.io>