### PR TITLE
Limit the optimizer mdcache default size to 16MB.

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4516,7 +4516,7 @@ struct config_int ConfigureNamesInt_gp[] =
 			GUC_UNIT_KB | GUC_GPDB_ADDOPT
 		},
 		&optimizer_mdcache_size,
-		0, 0, INT_MAX, NULL, NULL
+		16384, 0, INT_MAX, NULL, NULL
 	},
 
 	{


### PR DESCRIPTION
Based on the experiments with tpch and tpcds, we found that 16MB would
be the optimal size of mdcache.
[#96490982].

The changes in the guc `optimizer_mdcache_vsize` is automatically reflected when we executed the orca.

```
In function COptTasks::PvOptimizeTask

// initialize metadata cache, or purge if needed, or change size if requested
	if (!CMDCache::FInitialized())
	{
		CMDCache::Init();
		CMDCache::SetCacheQuota(optimizer_mdcache_size * 1024L);
	}
	else if (reset_mdcache)
	{
		CMDCache::Reset();
		CMDCache::SetCacheQuota(optimizer_mdcache_size * 1024L);
	}
	else if (CMDCache::ULLGetCacheQuota() != (ULLONG) optimizer_mdcache_size * 1024L)
	{
		CMDCache::SetCacheQuota(optimizer_mdcache_size * 1024L);
	}
```

@vraghavan78 @hardikar @foyzur @hsyuan @kavinderd Please take a look.