### PR TITLE
Fix planner bug that initplan may be removed mistakenly

### DIFF
--- a/src/test/regress/expected/subselect_gp2.out
+++ b/src/test/regress/expected/subselect_gp2.out
@@ -30,3 +30,22 @@ where (select count(*) from echotable as i where i.c2 = o.c2) >= 2;
   2 |  2
 (2 rows)
 
+-- Planner test to make sure the initplan is not removed for function scan
+explain select sess_id from pg_stat_activity where current_query = (select current_query());
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Hash Join  (cost=2.10..17.18 rows=4 width=4)
+   Hash Cond: s.usesysid = u.oid
+   InitPlan
+     ->  Result  (cost=0.00..0.01 rows=1 width=0)
+   ->  Hash Join  (cost=1.07..16.11 rows=4 width=8)
+         Hash Cond: s.datid = d.oid
+         ->  Function Scan on pg_stat_get_activity s  (cost=0.00..15.00 rows=1 width=12)
+               Filter: current_query = $0
+         ->  Hash  (cost=1.03..1.03 rows=1 width=4)
+               ->  Seq Scan on pg_database d  (cost=0.00..1.03 rows=3 width=4)
+   ->  Hash  (cost=1.01..1.01 rows=1 width=4)
+         ->  Seq Scan on pg_authid u  (cost=0.00..1.01 rows=1 width=4)
+ Optimizer status: legacy query optimizer
+(13 rows)
+

--- a/src/test/regress/sql/subselect_gp2.sql
+++ b/src/test/regress/sql/subselect_gp2.sql
@@ -20,3 +20,6 @@ select c2 from echotable group by c2 having count(*) >= 2;
 
 select * from test_ext_foo as o
 where (select count(*) from echotable as i where i.c2 = o.c2) >= 2;
+
+-- Planner test to make sure the initplan is not removed for function scan
+explain select sess_id from pg_stat_activity where current_query = (select current_query());


### PR DESCRIPTION
The old implementation of function `remove_unused_initplans` is buggy, we can
come up with multiple ways to break it, because it doesn't utilize postgres
plan/expression tree walker correctly. Rewrite the whole function to resolve
found and potential bugs.