### PR TITLE
Make a copy of Gp_interconnect_queue_depth for each interconnect …

### DIFF
--- a/src/include/cdb/cdbinterconnect.h
+++ b/src/include/cdb/cdbinterconnect.h
@@ -251,7 +251,8 @@ struct MotionConn
 	socklen_t peer_len;					/* And remember the actual length */
 
 	/* a queue of maximum length Gp_interconnect_queue_depth */
-	int			pkt_q_size;
+	int			pkt_q_capacity;			/*max capacity of the queue*/
+	int			pkt_q_size;				/*number of packets in the queue*/
 	int			pkt_q_head;
 	int			pkt_q_tail;
 	uint8		**pkt_q;

--- a/src/test/regress/expected/cursor.out
+++ b/src/test/regress/expected/cursor.out
@@ -610,6 +610,18 @@ FETCH ABSOLUTE 3 IN CUR;
 
 CLOSE CUR;
 COMMIT;
+--
+-- Change of Gp_interconnect_queue_depth after a Cursor will success
+BEGIN;
+DECLARE CUR SCROLL CURSOR FOR SELECT * FROM ctest WHERE id >= 990::bigint order by 1;
+SET gp_interconnect_queue_depth to 20;
+FETCH ABSOLUTE 1 IN CUR;
+ id  |  name   
+-----+---------
+ 990 | Test990
+(1 row)
+
+COMMIT;
 --start_ignore
 DROP INDEX if exists ctest_id_idx;
 NOTICE:  index "ctest_id_idx" does not exist, skipping

--- a/src/test/regress/sql/cursor.sql
+++ b/src/test/regress/sql/cursor.sql
@@ -375,6 +375,15 @@ FETCH ABSOLUTE 3 IN CUR;
 CLOSE CUR;
 
 COMMIT;
+--
+-- Change of Gp_interconnect_queue_depth after a Cursor will success
+BEGIN;
+
+DECLARE CUR SCROLL CURSOR FOR SELECT * FROM ctest WHERE id >= 990::bigint order by 1;
+SET gp_interconnect_queue_depth to 20;
+FETCH ABSOLUTE 1 IN CUR;
+
+COMMIT;
 --start_ignore
 DROP INDEX if exists ctest_id_idx;
 DROP TABLE if exists ctest;


### PR DESCRIPTION
…setup

Formally, GPDB assumed Gp_interconnect_queue_depth was constant during the interconnect life-time which was incorrect for Cursors, if Gp_interconnect_queue_depth was changed after a Cursor was declared, a panic occurred. To avoid this, we make a copy of Gp_interconnect_queue_depth when interconnect is set up. Gp_interconnect_snd_queue_depth has no such problem because it is only used by senders and senders of Cursor will never receive the GUC change command.