### PR TITLE
concourse: ignore docs changes from pipeline runs

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -9,6 +9,9 @@ resources:
     branch: {{gpdb-git-branch}}
     private_key: {{gpdb-git-key}}
     uri: {{gpdb-git-remote}}
+    ignore_paths:
+    - gpdb-doc/*
+    - README*
 
 - name: gpaddon_src
   type: git


### PR DESCRIPTION
Until now, people working on documentation would indicate that their
commits did not need to be run through automated testing by using the
`[ci skip]` annotation on their commit messages. This automates the same.