### PR TITLE
Fix partition_pruning test for sles11

### DIFF
--- a/src/test/regress/expected/partition_pruning.out
+++ b/src/test/regress/expected/partition_pruning.out
@@ -12,6 +12,7 @@
 set enable_seqscan=off;
 set enable_bitmapscan=on;
 set enable_indexscan=on;
+set max_stack_depth to '500kB';
 create schema partition_pruning;
 set search_path to partition_pruning, public;
 -- Set up common test tables.

--- a/src/test/regress/expected/partition_pruning_optimizer.out
+++ b/src/test/regress/expected/partition_pruning_optimizer.out
@@ -12,6 +12,7 @@
 set enable_seqscan=off;
 set enable_bitmapscan=on;
 set enable_indexscan=on;
+set max_stack_depth to '500kB';
 create schema partition_pruning;
 set search_path to partition_pruning, public;
 -- Set up common test tables.

--- a/src/test/regress/sql/partition_pruning.sql
+++ b/src/test/regress/sql/partition_pruning.sql
@@ -13,6 +13,7 @@
 set enable_seqscan=off;
 set enable_bitmapscan=on;
 set enable_indexscan=on;
+set max_stack_depth to '500kB';
 
 create schema partition_pruning;
 set search_path to partition_pruning, public;


### PR DESCRIPTION
Partition pruning test in ICW is failing because of `max_stack_depth` is
too small for sles11 environment. This PR increases the limit from
`100kB` to `500kB`.