### PR TITLE
Use params to plan certain PL/pgSQL statements efficiently

### DIFF
--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -1788,7 +1788,7 @@ _SPI_execute_plan(_SPI_plan * plan, ParamListInfo paramLI,
 			if (plan->saved)
 			{
 				/* Replan if needed, and increment plan refcount locally */
-				cplan = RevalidateCachedPlan(plansource, true);
+				cplan = RevalidateCachedPlanWithParams(plansource, true, paramLI, NULL);
 				stmt_list = cplan->stmt_list;
 			}
 			else


### PR DESCRIPTION
Executing PL/pgSQL statements (such as SELECT INTO and PERFORM) undergo
planning twice, once during _SPI_prepare_plan and then right before
executing via RevalidateCachedPlan. Function params are unavailable
during the first planning stage, but with this commit, the second
planning stage can use them to generate better plans by substituting
parameters with constants, applying static partition elimination etc.

This problem does not occur when running a EXPLAIN or EXPLAIN ANALYZE
query and capturing the output using FOR. This is because EXPLAIN-type
queries go through a different code path via ProcessUtility() that has
the params available. This results in an awkward scenario where the
query plan extracted by running FOR ... EXPLAIN Q is different from
running the query Q directly because of constant parameter substitution
in the former case.

This kind of parameter substitution is not implemented in upstream
postgres till 9.2; and it was done for SELECT INTO by re-implmenting
that logic as a utility statement. The changes seem messy to port right
now. This is a simple fix instead.


Repro : 
```
DROP TABLE IF EXISTS test;
CREATE TABLE test (i int, j int, t text);

create or replace function test_with_explain_fn()
returns void as
$body$
declare
  rec record;
  a integer;
begin
  a := 5;
  for rec in
    explain
      select i, sum(i)
        from test
       where j = a
       group by i
  loop
    raise NOTICE ' - %', rec;
  end loop;

  drop table if exists tmp_output;
end;
$body$
language plpgsql volatile;

create or replace function test_no_explain_fn()
returns void as
$body$
declare
  a integer;
begin
  a := 5;
  PERFORM i, sum(i)
      from test
     where j = a
     group by i;
end;
$body$
language plpgsql volatile;
```

Then executing `SELECT test_with_explain_fn();` will show a plan with the parameter `a` substituted with `5` in the SeqScan qual.. But running `SELECT test_no_explain_fn();` on master and then using a debugger to look at the plan right before execution, you can see '$3' or such parameter. Placing breakpoints in `planner()`, it is clear that one case it is called with `boundParams=NULL` and the other with right `boundParams`.