### PR TITLE
Enhancing clean up routine for workfile_set.

### DIFF
--- a/src/include/utils/workfile_mgr.h
+++ b/src/include/utils/workfile_mgr.h
@@ -94,6 +94,14 @@ typedef struct workfile_set
 	/* Operator-specific metadata */
 	workfile_set_op_metadata metadata;
 
+  /*
+   * To make sure we don't leak workfile_set handles on abort, we keep them in
+   * a linked list. We use the ResourceOwner mechanism to free them on abort.
+   */
+  ResourceOwner owner;
+  struct workfile_set *next;
+  struct workfile_set *prev;
+
 } workfile_set;
 
 /* The key for an entry stored in the Queryspace Hashtable */

--- a/src/test/regress/expected/segspace.out
+++ b/src/test/regress/expected/segspace.out
@@ -394,3 +394,34 @@ select max(bytes) as max, min(bytes) as min from gp_toolkit.gp_workfile_mgr_used
    0 |   0
 (1 row)
 
+-- Check if we delete workfile_set at each subtransaction.
+-- This test doesn't depend on the guc `gp_workfile_limit_per_segment` like rest
+-- start_ignore
+drop external table if exists exttest;
+NOTICE:  table "exttest" does not exist, skipping
+create external web table exttest (x int)
+execute E'echo 1; echo 2; echo 3; echo bogus; echo 5'
+on master
+format 'text';
+-- end_ignore
+create or replace function workset_cleanup_test()
+returns integer as
+$func$
+begin
+   for i in 1..2 loop
+     begin
+       select * from exttest a, exttest b;
+     exception when others then
+       raise notice 'caught exception: %', sqlerrm;
+     end;
+   end loop;
+  return (select count(*) from gp_toolkit.gp_workfile_entries);
+end;
+$func$ language plpgsql;
+select workset_cleanup_test();
+NOTICE:  caught exception: invalid input syntax for integer: "bogus"
+NOTICE:  caught exception: invalid input syntax for integer: "bogus"
+ workset_cleanup_test 
+----------------------
+                    3
+(1 row)


### PR DESCRIPTION
Earlier `workfile_set` gets cleaned up only at the top transaction level.  If we
have a lot of sub-transaction, we found that we couldn't create more
`workfile_set` in shared memory. So we used resource owner to clean up
the `workfile_set` at the respective transaction level itself.

Thanks to Robert Mu <dbx_c@hotmail.com> for coming up with the initial
fix through the PR #2325.

This would resolve #1767

Signed-off-by: Karthikeyan Jambu Rajaraman <karthi.jrk@gmail.com>