### PR TITLE
Removes unittest2 from shipped gpdb

### DIFF
--- a/gpMgmt/Makefile
+++ b/gpMgmt/Makefile
@@ -75,7 +75,13 @@ install: generate_greenplum_path_file
 
 	# Setup /lib/python contents
 	cp -rp bin/gppylib $(DESTDIR)$(prefix)/lib/python
-	cp -rp bin/ext/* $(DESTDIR)$(prefix)/lib/python
+	cp -rp bin/ext/Crypto $(DESTDIR)$(prefix)/lib/python
+	cp -rp bin/ext/__init__.py $(DESTDIR)$(prefix)/lib/python
+	cp -rp bin/ext/lockfile $(DESTDIR)$(prefix)/lib/python
+	cp -rp bin/ext/paramiko $(DESTDIR)$(prefix)/lib/python
+	cp -rp bin/ext/psutil $(DESTDIR)$(prefix)/lib/python
+	cp -rp bin/ext/pygresql $(DESTDIR)$(prefix)/lib/python
+	cp -rp bin/ext/yaml $(DESTDIR)$(prefix)/lib/python
 
 	# Setup /bin contents
 	cp -rp bin $(DESTDIR)$(prefix)


### PR DESCRIPTION
This is an updated version of https://github.com/greenplum-db/gpdb/pull/2234 that actually removes unittest2 from the shipped binary.

Signed-off-by: Chris Hajas <chajas@pivotal.io>