### PR TITLE
Sync JSON functions with PostgreSQL 9.3.17.

### DIFF
--- a/src/backend/utils/adt/jsonfuncs.c
+++ b/src/backend/utils/adt/jsonfuncs.c
@@ -19,7 +19,6 @@
 #include "fmgr.h"
 #include "funcapi.h"
 #include "miscadmin.h"
-#include "access/htup.h"
 #include "catalog/pg_type.h"
 #include "lib/stringinfo.h"
 #include "mb/pg_wchar.h"
@@ -96,20 +95,20 @@ typedef enum
 	JSON_SEARCH_OBJECT = 1,
 	JSON_SEARCH_ARRAY,
 	JSON_SEARCH_PATH
-}	JsonSearch;
+} JsonSearch;
 
 /* state for json_object_keys */
-typedef struct okeysState
+typedef struct OkeysState
 {
 	JsonLexContext *lex;
 	char	  **result;
 	int			result_size;
 	int			result_count;
 	int			sent_count;
-}	okeysState, *OkeysState;
+}	OkeysState;
 
 /* state for json_get* functions */
-typedef struct getState
+typedef struct GetState
 {
 	JsonLexContext *lex;
 	JsonSearch	search_type;
@@ -127,17 +126,17 @@ typedef struct getState
 	bool	   *pathok;
 	int		   *array_level_index;
 	int		   *path_level_index;
-}	getState, *GetState;
+}	GetState;
 
 /* state for json_array_length */
-typedef struct alenState
+typedef struct AlenState
 {
 	JsonLexContext *lex;
 	int			count;
-}	alenState, *AlenState;
+}	AlenState;
 
 /* state for json_each */
-typedef struct eachState
+typedef struct EachState
 {
 	JsonLexContext *lex;
 	Tuplestorestate *tuple_store;
@@ -147,20 +146,20 @@ typedef struct eachState
 	bool		normalize_results;
 	bool		next_scalar;
 	char	   *normalized_scalar;
-}	eachState, *EachState;
+}	EachState;
 
 /* state for json_array_elements */
-typedef struct elementsState
+typedef struct ElementsState
 {
 	JsonLexContext *lex;
 	Tuplestorestate *tuple_store;
 	TupleDesc	ret_tdesc;
 	MemoryContext tmp_cxt;
 	char	   *result_start;
-}	elementsState, *ElementsState;
+}	ElementsState;
 
 /* state for get_json_object_as_hash */
-typedef struct jhashState
+typedef struct JhashState
 {
 	JsonLexContext *lex;
 	HTAB	   *hash;
@@ -168,16 +167,16 @@ typedef struct jhashState
 	char	   *save_json_start;
 	bool		use_json_as_text;
 	char	   *function_name;
-}	jhashState, *JHashState;
+}	JHashState;
 
 /* used to build the hashtable */
-typedef struct jsonHashEntry
+typedef struct JsonHashEntry
 {
 	char		fname[NAMEDATALEN];
 	char	   *val;
 	char	   *json;
 	bool		isnull;
-}	jsonHashEntry, *JsonHashEntry;
+}	JsonHashEntry;
 
 /* these two are stolen from hstore / record_out, used in populate_record* */
 typedef struct ColumnIOData
@@ -197,7 +196,7 @@ typedef struct RecordIOData
 } RecordIOData;
 
 /* state for populate_recordset */
-typedef struct populateRecordsetState
+typedef struct PopulateRecordsetState
 {
 	JsonLexContext *lex;
 	HTAB	   *json_hash;
@@ -209,7 +208,7 @@ typedef struct populateRecordsetState
 	HeapTupleHeader rec;
 	RecordIOData *my_extra;
 	MemoryContext fn_mcxt;		/* used to stash IO funcs */
-}	populateRecordsetState, *PopulateRecordsetState;
+}	PopulateRecordsetState;
 
 /*
  * SQL function json_object-keys
@@ -229,22 +228,22 @@ Datum
 json_object_keys(PG_FUNCTION_ARGS)
 {
 	FuncCallContext *funcctx;
-	OkeysState	state;
+	OkeysState *state;
 	int			i;
 
 	if (SRF_IS_FIRSTCALL())
 	{
 		text	   *json = PG_GETARG_TEXT_P(0);
 		JsonLexContext *lex = makeJsonLexContext(json, true);
-		JsonSemAction sem;
+		JsonSemAction *sem;
 
 		MemoryContext oldcontext;
 
 		funcctx = SRF_FIRSTCALL_INIT();
 		oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
 
-		state = palloc(sizeof(okeysState));
-		sem = palloc0(sizeof(jsonSemAction));
+		state = palloc(sizeof(OkeysState));
+		sem = palloc0(sizeof(JsonSemAction));
 
 		state->lex = lex;
 		state->result_size = 256;
@@ -272,7 +271,7 @@ json_object_keys(PG_FUNCTION_ARGS)
 	}
 
 	funcctx = SRF_PERCALL_SETUP();
-	state = (OkeysState) funcctx->user_fctx;
+	state = (OkeysState *) funcctx->user_fctx;
 
 	if (state->sent_count < state->result_count)
 	{
@@ -293,7 +292,7 @@ json_object_keys(PG_FUNCTION_ARGS)
 static void
 okeys_object_field_start(void *state, char *fname, bool isnull)
 {
-	OkeysState	_state = (OkeysState) state;
+	OkeysState *_state = (OkeysState *) state;
 
 	/* only collecting keys for the top level object */
 	if (_state->lex->lex_level != 1)
@@ -314,7 +313,7 @@ okeys_object_field_start(void *state, char *fname, bool isnull)
 static void
 okeys_array_start(void *state)
 {
-	OkeysState	_state = (OkeysState) state;
+	OkeysState *_state = (OkeysState *) state;
 
 	/* top level must be a json object */
 	if (_state->lex->lex_level == 0)
@@ -326,7 +325,7 @@ okeys_array_start(void *state)
 static void
 okeys_scalar(void *state, char *token, JsonTokenType tokentype)
 {
-	OkeysState	_state = (OkeysState) state;
+	OkeysState *_state = (OkeysState *) state;
 
 	/* top level must be a json object */
 	if (_state->lex->lex_level == 0)
@@ -491,16 +490,16 @@ get_worker(text *json,
 		   int npath,
 		   bool normalize_results)
 {
-	GetState	state;
+	GetState   *state;
 	JsonLexContext *lex = makeJsonLexContext(json, true);
-	JsonSemAction sem;
+	JsonSemAction *sem;
 
 	/* only allowed to use one of these */
 	Assert(elem_index < 0 || (tpath == NULL && ipath == NULL && field == NULL));
 	Assert(tpath == NULL || field == NULL);
 
-	state = palloc0(sizeof(getState));
-	sem = palloc0(sizeof(jsonSemAction));
+	state = palloc0(sizeof(GetState));
+	sem = palloc0(sizeof(JsonSemAction));
 
 	state->lex = lex;
 	/* is it "_as_text" variant? */
@@ -560,7 +559,7 @@ get_worker(text *json,
 static void
 get_object_start(void *state)
 {
-	GetState	_state = (GetState) state;
+	GetState   *_state = (GetState *) state;
 
 	/* json structure check */
 	if (_state->lex->lex_level == 0 && _state->search_type == JSON_SEARCH_ARRAY)
@@ -572,7 +571,7 @@ get_object_start(void *state)
 static void
 get_object_field_start(void *state, char *fname, bool isnull)
 {
-	GetState	_state = (GetState) state;
+	GetState   *_state = (GetState *) state;
 	bool		get_next = false;
 	int			lex_level = _state->lex->lex_level;
 
@@ -624,7 +623,7 @@ get_object_field_start(void *state, char *fname, bool isnull)
 static void
 get_object_field_end(void *state, char *fname, bool isnull)
 {
-	GetState	_state = (GetState) state;
+	GetState   *_state = (GetState *) state;
 	bool		get_last = false;
 	int			lex_level = _state->lex->lex_level;
 
@@ -674,7 +673,7 @@ get_object_field_end(void *state, char *fname, bool isnull)
 static void
 get_array_start(void *state)
 {
-	GetState	_state = (GetState) state;
+	GetState   *_state = (GetState *) state;
 	int			lex_level = _state->lex->lex_level;
 
 	/* json structure check */
@@ -682,16 +681,20 @@ get_array_start(void *state)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("cannot extract field from a non-object")));
-	/* initialize array count for this nesting level */
+
+	/*
+	 * initialize array count for this nesting level Note: the lex_level seen
+	 * by array_start is one less than that seen by the elements of the array.
+	 */
 	if (_state->search_type == JSON_SEARCH_PATH &&
-		lex_level <= _state->npath)
+		lex_level < _state->npath)
 		_state->array_level_index[lex_level] = -1;
 }
 
 static void
 get_array_element_start(void *state, bool isnull)
 {
-	GetState	_state = (GetState) state;
+	GetState   *_state = (GetState *) state;
 	bool		get_next = false;
 	int			lex_level = _state->lex->lex_level;
 
@@ -750,7 +753,7 @@ get_array_element_start(void *state, bool isnull)
 static void
 get_array_element_end(void *state, bool isnull)
 {
-	GetState	_state = (GetState) state;
+	GetState   *_state = (GetState *) state;
 	bool		get_last = false;
 	int			lex_level = _state->lex->lex_level;
 
@@ -788,7 +791,7 @@ get_array_element_end(void *state, bool isnull)
 static void
 get_scalar(void *state, char *token, JsonTokenType tokentype)
 {
-	GetState	_state = (GetState) state;
+	GetState   *_state = (GetState *) state;
 
 	if (_state->lex->lex_level == 0 && _state->search_type != JSON_SEARCH_PATH)
 		ereport(ERROR,
@@ -812,12 +815,12 @@ json_array_length(PG_FUNCTION_ARGS)
 {
 	text	   *json = PG_GETARG_TEXT_P(0);
 
-	AlenState	state;
+	AlenState  *state;
 	JsonLexContext *lex = makeJsonLexContext(json, false);
-	JsonSemAction sem;
+	JsonSemAction *sem;
 
-	state = palloc0(sizeof(alenState));
-	sem = palloc0(sizeof(jsonSemAction));
+	state = palloc0(sizeof(AlenState));
+	sem = palloc0(sizeof(JsonSemAction));
 
 	/* palloc0 does this for us */
 #if 0
@@ -843,7 +846,7 @@ json_array_length(PG_FUNCTION_ARGS)
 static void
 alen_object_start(void *state)
 {
-	AlenState	_state = (AlenState) state;
+	AlenState  *_state = (AlenState *) state;
 
 	/* json structure check */
 	if (_state->lex->lex_level == 0)
@@ -855,7 +858,7 @@ alen_object_start(void *state)
 static void
 alen_scalar(void *state, char *token, JsonTokenType tokentype)
 {
-	AlenState	_state = (AlenState) state;
+	AlenState  *_state = (AlenState *) state;
 
 	/* json structure check */
 	if (_state->lex->lex_level == 0)
@@ -867,7 +870,7 @@ alen_scalar(void *state, char *token, JsonTokenType tokentype)
 static void
 alen_array_element_start(void *state, bool isnull)
 {
-	AlenState	_state = (AlenState) state;
+	AlenState  *_state = (AlenState *) state;
 
 	/* just count up all the level 1 elements */
 	if (_state->lex->lex_level == 1)
@@ -901,14 +904,14 @@ each_worker(PG_FUNCTION_ARGS, bool as_text)
 {
 	text	   *json = PG_GETARG_TEXT_P(0);
 	JsonLexContext *lex = makeJsonLexContext(json, true);
-	JsonSemAction sem;
+	JsonSemAction *sem;
 	ReturnSetInfo *rsi;
 	MemoryContext old_cxt;
 	TupleDesc	tupdesc;
-	EachState	state;
+	EachState  *state;
 
-	state = palloc0(sizeof(eachState));
-	sem = palloc0(sizeof(jsonSemAction));
+	state = palloc0(sizeof(EachState));
+	sem = palloc0(sizeof(JsonSemAction));
 
 	rsi = (ReturnSetInfo *) fcinfo->resultinfo;
 
@@ -930,6 +933,7 @@ each_worker(PG_FUNCTION_ARGS, bool as_text)
 
 	state->ret_tdesc = CreateTupleDescCopy(tupdesc);
 	BlessTupleDesc(state->ret_tdesc);
+	/* GPDB_84_MERGE_FIXME: Use SFRM_Materialize_Random here */
 	state->tuple_store =
 		tuplestore_begin_heap(rsi->allowedModes & SFRM_Materialize,
 							  false, work_mem);
@@ -954,6 +958,8 @@ each_worker(PG_FUNCTION_ARGS, bool as_text)
 
 	pg_parse_json(lex, sem);
 
+	MemoryContextDelete(state->tmp_cxt); 
+
 	rsi->setResult = state->tuple_store;
 	rsi->setDesc = state->ret_tdesc;
 
@@ -964,7 +970,7 @@ each_worker(PG_FUNCTION_ARGS, bool as_text)
 static void
 each_object_field_start(void *state, char *fname, bool isnull)
 {
-	EachState	_state = (EachState) state;
+	EachState  *_state = (EachState *) state;
 
 	/* save a pointer to where the value starts */
 	if (_state->lex->lex_level == 1)
@@ -984,7 +990,7 @@ each_object_field_start(void *state, char *fname, bool isnull)
 static void
 each_object_field_end(void *state, char *fname, bool isnull)
 {
-	EachState	_state = (EachState) state;
+	EachState  *_state = (EachState *) state;
 	MemoryContext old_cxt;
 	int			len;
 	text	   *val;
@@ -1031,7 +1037,7 @@ each_object_field_end(void *state, char *fname, bool isnull)
 static void
 each_array_start(void *state)
 {
-	EachState	_state = (EachState) state;
+	EachState  *_state = (EachState *) state;
 
 	/* json structure check */
 	if (_state->lex->lex_level == 0)
@@ -1043,7 +1049,7 @@ each_array_start(void *state)
 static void
 each_scalar(void *state, char *token, JsonTokenType tokentype)
 {
-	EachState	_state = (EachState) state;
+	EachState  *_state = (EachState *) state;
 
 	/* json structure check */
 	if (_state->lex->lex_level == 0)
@@ -1070,14 +1076,14 @@ json_array_elements(PG_FUNCTION_ARGS)
 
 	/* elements doesn't need any escaped strings, so use false here */
 	JsonLexContext *lex = makeJsonLexContext(json, false);
-	JsonSemAction sem;
+	JsonSemAction *sem;
 	ReturnSetInfo *rsi;
 	MemoryContext old_cxt;
 	TupleDesc	tupdesc;
-	ElementsState state;
+	ElementsState *state;
 
-	state = palloc0(sizeof(elementsState));
-	sem = palloc0(sizeof(jsonSemAction));
+	state = palloc0(sizeof(ElementsState));
+	sem = palloc0(sizeof(JsonSemAction));
 
 	rsi = (ReturnSetInfo *) fcinfo->resultinfo;
 
@@ -1100,6 +1106,7 @@ json_array_elements(PG_FUNCTION_ARGS)
 
 	state->ret_tdesc = CreateTupleDescCopy(tupdesc);
 	BlessTupleDesc(state->ret_tdesc);
+	/* GPDB_84_MERGE_FIXME: Use SFRM_Materialize_Random here */
 	state->tuple_store =
 		tuplestore_begin_heap(rsi->allowedModes & SFRM_Materialize,
 							  false, work_mem);
@@ -1121,6 +1128,8 @@ json_array_elements(PG_FUNCTION_ARGS)
 
 	pg_parse_json(lex, sem);
 
+	MemoryContextDelete(state->tmp_cxt); 
+
 	rsi->setResult = state->tuple_store;
 	rsi->setDesc = state->ret_tdesc;
 
@@ -1130,7 +1139,7 @@ json_array_elements(PG_FUNCTION_ARGS)
 static void
 elements_array_element_start(void *state, bool isnull)
 {
-	ElementsState _state = (ElementsState) state;
+	ElementsState *_state = (ElementsState *) state;
 
 	/* save a pointer to where the value starts */
 	if (_state->lex->lex_level == 1)
@@ -1140,7 +1149,7 @@ elements_array_element_start(void *state, bool isnull)
 static void
 elements_array_element_end(void *state, bool isnull)
 {
-	ElementsState _state = (ElementsState) state;
+	ElementsState *_state = (ElementsState *) state;
 	MemoryContext old_cxt;
 	int			len;
 	text	   *val;
@@ -1172,7 +1181,7 @@ elements_array_element_end(void *state, bool isnull)
 static void
 elements_object_start(void *state)
 {
-	ElementsState _state = (ElementsState) state;
+	ElementsState *_state = (ElementsState *) state;
 
 	/* json structure check */
 	if (_state->lex->lex_level == 0)
@@ -1184,7 +1193,7 @@ elements_object_start(void *state)
 static void
 elements_scalar(void *state, char *token, JsonTokenType tokentype)
 {
-	ElementsState _state = (ElementsState) state;
+	ElementsState *_state = (ElementsState *) state;
 
 	/* json structure check */
 	if (_state->lex->lex_level == 0)
@@ -1213,8 +1222,8 @@ Datum
 json_populate_record(PG_FUNCTION_ARGS)
 {
 	Oid			argtype = get_fn_expr_argtype(fcinfo->flinfo, 0);
-	text	   *json = PG_GETARG_TEXT_P(1);
-	bool		use_json_as_text = PG_GETARG_BOOL(2);
+	text	   *json;
+	bool		use_json_as_text;
 	HTAB	   *json_hash;
 	HeapTupleHeader rec;
 	Oid			tupType;
@@ -1228,13 +1237,14 @@ json_populate_record(PG_FUNCTION_ARGS)
 	Datum	   *values;
 	bool	   *nulls;
 	char		fname[NAMEDATALEN];
-	JsonHashEntry hashentry;
+	JsonHashEntry *hashentry;
 
+	use_json_as_text = PG_ARGISNULL(2) ? false : PG_GETARG_BOOL(2);
 
 	if (!type_is_rowtype(argtype))
 		ereport(ERROR,
 				(errcode(ERRCODE_DATATYPE_MISMATCH),
-				 errmsg("first argument must be a rowtype")));
+				 errmsg("first argument of json_populate_record must be a row type")));
 
 	if (PG_ARGISNULL(0))
 	{
@@ -1263,6 +1273,8 @@ json_populate_record(PG_FUNCTION_ARGS)
 		tupTypmod = HeapTupleHeaderGetTypMod(rec);
 	}
 
+	json = PG_GETARG_TEXT_P(1);
+
 	json_hash = get_json_object_as_hash(json, "json_populate_record", use_json_as_text);
 
 	/*
@@ -1271,8 +1283,10 @@ json_populate_record(PG_FUNCTION_ARGS)
 	 * nulls.
 	 */
 	if (hash_get_num_entries(json_hash) == 0 && rec)
+	{
+		hash_destroy(json_hash);
 		PG_RETURN_POINTER(rec);
-
+	}
 
 	tupdesc = lookup_rowtype_tupdesc(tupType, tupTypmod);
 	ncolumns = tupdesc->natts;
@@ -1396,6 +1410,8 @@ json_populate_record(PG_FUNCTION_ARGS)
 
 	ReleaseTupleDesc(tupdesc);
 
+	hash_destroy(json_hash);
+
 	PG_RETURN_DATUM(HeapTupleGetDatum(rettuple));
 }
 
@@ -1415,21 +1431,21 @@ get_json_object_as_hash(text *json, char *funcname, bool use_json_as_text)
 {
 	HASHCTL		ctl;
 	HTAB	   *tab;
-	JHashState	state;
+	JHashState *state;
 	JsonLexContext *lex = makeJsonLexContext(json, true);
-	JsonSemAction sem;
+	JsonSemAction *sem;
 
 	memset(&ctl, 0, sizeof(ctl));
 	ctl.keysize = NAMEDATALEN;
-	ctl.entrysize = sizeof(jsonHashEntry);
+	ctl.entrysize = sizeof(JsonHashEntry);
 	ctl.hcxt = CurrentMemoryContext;
 	tab = hash_create("json object hashtable",
 					  100,
 					  &ctl,
 					  HASH_ELEM | HASH_CONTEXT);
 
-	state = palloc0(sizeof(jhashState));
-	sem = palloc0(sizeof(jsonSemAction));
+	state = palloc0(sizeof(JHashState));
+	sem = palloc0(sizeof(JsonSemAction));
 
 	state->function_name = funcname;
 	state->hash = tab;
@@ -1450,7 +1466,7 @@ get_json_object_as_hash(text *json, char *funcname, bool use_json_as_text)
 static void
 hash_object_field_start(void *state, char *fname, bool isnull)
 {
-	JHashState	_state = (JHashState) state;
+	JHashState *_state = (JHashState *) state;
 
 	if (_state->lex->lex_level > 1)
 		return;
@@ -1475,8 +1491,8 @@ hash_object_field_start(void *state, char *fname, bool isnull)
 static void
 hash_object_field_end(void *state, char *fname, bool isnull)
 {
-	JHashState	_state = (JHashState) state;
-	JsonHashEntry hashentry;
+	JHashState *_state = (JHashState *) state;
+	JsonHashEntry *hashentry;
 	bool		found;
 	char		name[NAMEDATALEN];
 
@@ -1517,7 +1533,7 @@ hash_object_field_end(void *state, char *fname, bool isnull)
 static void
 hash_array_start(void *state)
 {
-	JHashState	_state = (JHashState) state;
+	JHashState *_state = (JHashState *) state;
 
 	if (_state->lex->lex_level == 0)
 		ereport(ERROR,
@@ -1528,7 +1544,7 @@ hash_array_start(void *state)
 static void
 hash_scalar(void *state, char *token, JsonTokenType tokentype)
 {
-	JHashState	_state = (JHashState) state;
+	JHashState *_state = (JHashState *) state;
 
 	if (_state->lex->lex_level == 0)
 		ereport(ERROR,
@@ -1554,8 +1570,8 @@ Datum
 json_populate_recordset(PG_FUNCTION_ARGS)
 {
 	Oid			argtype = get_fn_expr_argtype(fcinfo->flinfo, 0);
-	text	   *json = PG_GETARG_TEXT_P(1);
-	bool		use_json_as_text = PG_GETARG_BOOL(2);
+	text	   *json;
+	bool		use_json_as_text;
 	ReturnSetInfo *rsi;
 	MemoryContext old_cxt;
 	Oid			tupType;
@@ -1565,13 +1581,15 @@ json_populate_recordset(PG_FUNCTION_ARGS)
 	RecordIOData *my_extra;
 	int			ncolumns;
 	JsonLexContext *lex;
-	JsonSemAction sem;
-	PopulateRecordsetState state;
+	JsonSemAction *sem;
+	PopulateRecordsetState *state;
+
+	use_json_as_text = PG_ARGISNULL(2) ? false : PG_GETARG_BOOL(2);
 
 	if (!type_is_rowtype(argtype))
 		ereport(ERROR,
 				(errcode(ERRCODE_DATATYPE_MISMATCH),
-				 errmsg("first argument must be a rowtype")));
+				 errmsg("first argument of json_populate_recordset must be a row type")));
 
 	rsi = (ReturnSetInfo *) fcinfo->resultinfo;
 
@@ -1592,8 +1610,8 @@ json_populate_recordset(PG_FUNCTION_ARGS)
 	 */
 	(void) get_call_result_type(fcinfo, NULL, &tupdesc);
 
-	state = palloc0(sizeof(populateRecordsetState));
-	sem = palloc0(sizeof(jsonSemAction));
+	state = palloc0(sizeof(PopulateRecordsetState));
+	sem = palloc0(sizeof(JsonSemAction));
 
 
 	/* make these in a sufficiently long-lived memory context */
@@ -1601,6 +1619,7 @@ json_populate_recordset(PG_FUNCTION_ARGS)
 
 	state->ret_tdesc = CreateTupleDescCopy(tupdesc);
 	BlessTupleDesc(state->ret_tdesc);
+	/* GPDB_84_MERGE_FIXME: Use SFRM_Materialize_Random here */
 	state->tuple_store =
 		tuplestore_begin_heap(rsi->allowedModes & SFRM_Materialize,
 							  false, work_mem);
@@ -1610,6 +1629,8 @@ json_populate_recordset(PG_FUNCTION_ARGS)
 	/* if the json is null send back an empty set */
 	if (PG_ARGISNULL(1))
 		PG_RETURN_NULL();
+
+	json = PG_GETARG_TEXT_P(1);
 
 	if (PG_ARGISNULL(0))
 		rec = NULL;
@@ -1678,23 +1699,30 @@ json_populate_recordset(PG_FUNCTION_ARGS)
 static void
 populate_recordset_object_start(void *state)
 {
-	PopulateRecordsetState _state = (PopulateRecordsetState) state;
+	PopulateRecordsetState *_state = (PopulateRecordsetState *) state;
 	int			lex_level = _state->lex->lex_level;
 	HASHCTL		ctl;
 
+	/* Reject object at top level: we must have an array at level 0 */
 	if (lex_level == 0)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("cannot call json_populate_recordset on an object")));
-	else if (lex_level > 1 && !_state->use_json_as_text)
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-		 errmsg("cannot call json_populate_recordset with nested objects")));
 
-	/* set up a new hash for this entry */
+	/* Nested objects, if allowed, require no special processing */
+	if (lex_level > 1)
+	{
+		if (!_state->use_json_as_text)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("cannot call json_populate_recordset with nested objects")));
+		return;
+	}
+
+	/* Object at level 1: set up a new hash table for this object */
 	memset(&ctl, 0, sizeof(ctl));
 	ctl.keysize = NAMEDATALEN;
-	ctl.entrysize = sizeof(jsonHashEntry);
+	ctl.entrysize = sizeof(JsonHashEntry);
 	ctl.hcxt = CurrentMemoryContext;
 	_state->json_hash = hash_create("json object hashtable",
 									100,
@@ -1705,7 +1733,7 @@ populate_recordset_object_start(void *state)
 static void
 populate_recordset_object_end(void *state)
 {
-	PopulateRecordsetState _state = (PopulateRecordsetState) state;
+	PopulateRecordsetState *_state = (PopulateRecordsetState *) state;
 	HTAB	   *json_hash = _state->json_hash;
 	Datum	   *values;
 	bool	   *nulls;
@@ -1714,13 +1742,15 @@ populate_recordset_object_end(void *state)
 	RecordIOData *my_extra = _state->my_extra;
 	int			ncolumns = my_extra->ncolumns;
 	TupleDesc	tupdesc = _state->ret_tdesc;
-	JsonHashEntry hashentry;
+	JsonHashEntry *hashentry;
 	HeapTupleHeader rec = _state->rec;
 	HeapTuple	rettuple;
 
+	/* Nested objects require no special processing */
 	if (_state->lex->lex_level > 1)
 		return;
 
+	/* Otherwise, construct and return a tuple based on this level-1 object */
 	values = (Datum *) palloc(ncolumns * sizeof(Datum));
 	nulls = (bool *) palloc(ncolumns * sizeof(bool));
 
@@ -1811,25 +1841,27 @@ populate_recordset_object_end(void *state)
 
 	tuplestore_puttuple(_state->tuple_store, rettuple);
 
+	/* Done with hash for this object */
 	hash_destroy(json_hash);
+	_state->json_hash = NULL;
 }
 
 static void
 populate_recordset_array_element_start(void *state, bool isnull)
 {
-	PopulateRecordsetState _state = (PopulateRecordsetState) state;
+	PopulateRecordsetState *_state = (PopulateRecordsetState *) state;
 
 	if (_state->lex->lex_level == 1 &&
 		_state->lex->token_type != JSON_TOKEN_OBJECT_START)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-			 errmsg("must call populate_recordset on an array of objects")));
+			 errmsg("must call json_populate_recordset on an array of objects")));
 }
 
 static void
 populate_recordset_array_start(void *state)
 {
-	PopulateRecordsetState _state = (PopulateRecordsetState) state;
+	PopulateRecordsetState *_state = (PopulateRecordsetState *) state;
 
 	if (_state->lex->lex_level != 0 && !_state->use_json_as_text)
 		ereport(ERROR,
@@ -1840,7 +1872,7 @@ populate_recordset_array_start(void *state)
 static void
 populate_recordset_scalar(void *state, char *token, JsonTokenType tokentype)
 {
-	PopulateRecordsetState _state = (PopulateRecordsetState) state;
+	PopulateRecordsetState *_state = (PopulateRecordsetState *) state;
 
 	if (_state->lex->lex_level == 0)
 		ereport(ERROR,
@@ -1854,7 +1886,7 @@ populate_recordset_scalar(void *state, char *token, JsonTokenType tokentype)
 static void
 populate_recordset_object_field_start(void *state, char *fname, bool isnull)
 {
-	PopulateRecordsetState _state = (PopulateRecordsetState) state;
+	PopulateRecordsetState *_state = (PopulateRecordsetState *) state;
 
 	if (_state->lex->lex_level > 2)
 		return;
@@ -1877,8 +1909,8 @@ populate_recordset_object_field_start(void *state, char *fname, bool isnull)
 static void
 populate_recordset_object_field_end(void *state, char *fname, bool isnull)
 {
-	PopulateRecordsetState _state = (PopulateRecordsetState) state;
-	JsonHashEntry hashentry;
+	PopulateRecordsetState *_state = (PopulateRecordsetState *) state;
+	JsonHashEntry *hashentry;
 	bool		found;
 	char		name[NAMEDATALEN];
 

--- a/src/include/utils/json.h
+++ b/src/include/utils/json.h
@@ -3,7 +3,7 @@
  * json.h
  *	  Declarations for JSON data type support.
  *
- * Portions Copyright (c) 1996-2012, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1996-2013, PostgreSQL Global Development Group
  * Portions Copyright (c) 1994, Regents of the University of California
  *
  * src/include/utils/json.h
@@ -26,7 +26,12 @@ extern Datum array_to_json(PG_FUNCTION_ARGS);
 extern Datum array_to_json_pretty(PG_FUNCTION_ARGS);
 extern Datum row_to_json(PG_FUNCTION_ARGS);
 extern Datum row_to_json_pretty(PG_FUNCTION_ARGS);
-extern void  escape_json(StringInfo buf, const char *str);
+extern Datum to_json(PG_FUNCTION_ARGS);
+
+extern Datum json_agg_transfn(PG_FUNCTION_ARGS);
+extern Datum json_agg_finalfn(PG_FUNCTION_ARGS);
+
+extern void escape_json(StringInfo buf, const char *str);
 
 /* functions in jsonfuncs.c */
 extern Datum json_object_field(PG_FUNCTION_ARGS);

--- a/src/include/utils/jsonapi.h
+++ b/src/include/utils/jsonapi.h
@@ -30,8 +30,8 @@ typedef enum
 	JSON_TOKEN_TRUE,
 	JSON_TOKEN_FALSE,
 	JSON_TOKEN_NULL,
-	JSON_TOKEN_END,
-}	JsonTokenType;
+	JSON_TOKEN_END
+} JsonTokenType;
 
 
 /*
@@ -74,7 +74,7 @@ typedef void (*json_scalar_action) (void *state, char *token, JsonTokenType toke
  * to doing a pure parse with no side-effects, and is therefore exactly
  * what the json input routines do.
  */
-typedef struct jsonSemAction
+typedef struct JsonSemAction
 {
 	void	   *semstate;
 	json_struct_action object_start;
@@ -86,7 +86,7 @@ typedef struct jsonSemAction
 	json_aelem_action array_element_start;
 	json_aelem_action array_element_end;
 	json_scalar_action scalar;
-}	jsonSemAction, *JsonSemAction;
+} JsonSemAction;
 
 /*
  * parse_json will parse the string in the lex calling the
@@ -97,7 +97,7 @@ typedef struct jsonSemAction
  * points to. If the action pointers are NULL the parser
  * does nothing and just continues.
  */
-extern void pg_parse_json(JsonLexContext *lex, JsonSemAction sem);
+extern void pg_parse_json(JsonLexContext *lex, JsonSemAction *sem);
 
 /*
  * constructor for JsonLexContext, with or without strval element.
@@ -106,5 +106,12 @@ extern void pg_parse_json(JsonLexContext *lex, JsonSemAction sem);
  * it should be avoided if the de-escaped lexeme is not required.
  */
 extern JsonLexContext *makeJsonLexContext(text *json, bool need_escapes);
+
+/*
+ * Utility function to check if a string is a valid JSON number.
+ *
+ * str agrument does not need to be nul-terminated.
+ */
+extern bool IsValidJsonNumber(const char * str, int len);
 
 #endif   /* JSONAPI_H */


### PR DESCRIPTION
We had cherry-picked some of the PostgreSQL 9.3 functions, but not all the
subsequent fixes to them. I believe we need at least upstream commit
66008564f8 to fix github issue #2430, and surely the other bug fixes are
needed too.

Rather than cherry-pick individual commits, this replaces the JSON related
source files with the upstream files in toto. This will make diffing and
maintenance of these backported JSON function easier in the future.