### PR TITLE
CTE parser update

### DIFF
--- a/src/backend/parser/Makefile
+++ b/src/backend/parser/Makefile
@@ -2,7 +2,7 @@
 #
 # Makefile for parser
 #
-# $PostgreSQL: pgsql/src/backend/parser/Makefile,v 1.45 2007/06/23 22:12:51 tgl Exp $
+# $PostgreSQL: pgsql/src/backend/parser/Makefile,v 1.48 2008/10/04 21:56:54 tgl Exp $
 #
 #-------------------------------------------------------------------------
 
@@ -12,7 +12,7 @@ include $(top_builddir)/src/Makefile.global
 
 override CPPFLAGS := -I$(srcdir) $(CPPFLAGS)
 
-OBJS= analyze.o gram.o keywords.o parser.o parse_agg.o parse_clause.o parse_cte.o \
+OBJS= analyze.o gram.o keywords.o parser.o parse_agg.o parse_cte.o parse_clause.o \
       parse_expr.o parse_func.o parse_node.o parse_oper.o parse_relation.o \
       parse_type.o parse_coerce.o parse_target.o scansup.o parse_utilcmd.o kwlookup.o \
       parse_partition.o

--- a/src/backend/parser/keywords.c
+++ b/src/backend/parser/keywords.c
@@ -8,7 +8,7 @@
  *
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/parser/keywords.c,v 1.194 2008/01/01 19:45:50 momjian Exp $
+ *	  $PostgreSQL: pgsql/src/backend/parser/keywords.c,v 1.202 2008/10/04 21:56:54 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/parser/parse_agg.c
+++ b/src/backend/parser/parse_agg.c
@@ -8,7 +8,7 @@
  *
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/parser/parse_agg.c,v 1.79 2008/01/01 19:45:50 momjian Exp $
+ *	  $PostgreSQL: pgsql/src/backend/parser/parse_agg.c,v 1.84 2008/10/04 21:56:54 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -208,12 +208,28 @@ parseCheckAggregates(ParseState *pstate, Query *qry)
 	bool		have_non_var_grouping;
 	ListCell   *l;
 	bool		hasJoinRTEs;
+	bool		hasSelfRefRTEs;
 	PlannerInfo *root;
 	Node	   *clause;
 
 	/* This should only be called if we found aggregates or grouping */
 	Assert(pstate->p_hasAggs || qry->groupClause || qry->havingQual);
 
+	/*
+	 * Scan the range table to see if there are JOIN or self-reference CTE
+	 * entries.  We'll need this info below.
+	 */
+	hasJoinRTEs = hasSelfRefRTEs = false;
+	foreach(l, pstate->p_rtable)
+	{
+		RangeTblEntry *rte = (RangeTblEntry *) lfirst(l);
+
+		if (rte->rtekind == RTE_JOIN)
+			hasJoinRTEs = true;
+		else if (rte->rtekind == RTE_CTE && rte->self_reference)
+			hasSelfRefRTEs = true;
+	}	
+	
 	/*
 	 * Aggregates and window functions must never appear in WHERE or 
 	 * JOIN/ON clauses.  Window function must never appear in HAVING
@@ -266,20 +282,6 @@ parseCheckAggregates(ParseState *pstate, Query *qry)
 	 * underlying vars, so that aliased and unaliased vars will be correctly
 	 * taken as equal.	We can skip the expense of doing this if no rangetable
 	 * entries are RTE_JOIN kind.
-	 */
-	hasJoinRTEs = false;
-	foreach(l, pstate->p_rtable)
-	{
-		RangeTblEntry *rte = (RangeTblEntry *) lfirst(l);
-
-		if (rte->rtekind == RTE_JOIN)
-		{
-			hasJoinRTEs = true;
-			break;
-		}
-	}
-
-	/*
 	 * We use the planner's flatten_join_alias_vars routine to do the
 	 * flattening; it wants a PlannerInfo root node, which fortunately can be
 	 * mostly dummy.
@@ -342,6 +344,16 @@ parseCheckAggregates(ParseState *pstate, Query *qry)
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("correlated subquery cannot contain percentile functions")));
 	}
+
+	/*
+	 * Per spec, aggregates can't appear in a recursive term.
+	 */
+	if (pstate->p_hasAggs && hasSelfRefRTEs)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_RECURSION),
+				 errmsg("aggregates not allowed in a recursive query's recursive term"),
+				 parser_errposition(pstate,
+									locate_agg_of_level((Node *) qry, 0))));
 }
 
 

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -9,7 +9,7 @@
  *
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/parser/parse_clause.c,v 1.168 2008/01/01 19:45:50 momjian Exp $
+ *	  $PostgreSQL: pgsql/src/backend/parser/parse_clause.c,v 1.180 2008/10/04 21:56:54 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -66,6 +66,8 @@ static Node *transformJoinOnClause(ParseState *pstate, JoinExpr *j,
 					  List *relnamespace,
 					  Relids containedRels);
 static RangeTblEntry *transformTableEntry(ParseState *pstate, RangeVar *r);
+static RangeTblEntry *transformCTEReference(ParseState *pstate, RangeVar *r,
+					  CommonTableExpr *cte, Index levelsup);
 static RangeTblEntry *transformRangeSubselect(ParseState *pstate,
 						RangeSubselect *r);
 static RangeTblEntry *transformRangeFunction(ParseState *pstate,
@@ -1124,6 +1126,20 @@ transformTableEntry(ParseState *pstate, RangeVar *r)
 	return rte;
 }
 
+/*
+ * transformCTEReference --- transform a RangeVar that references a common
+ * table expression (ie, a sub-SELECT defined in a WITH clause)
+ */
+static RangeTblEntry *
+transformCTEReference(ParseState *pstate, RangeVar *r,
+					  CommonTableExpr *cte, Index levelsup)
+{
+	RangeTblEntry *rte;
+
+	rte = addRangeTableEntryForCTE(pstate, cte, levelsup, r->alias, true);
+
+	return rte;
+}
 
 /*
  * transformRangeSubselect --- transform a sub-SELECT appearing in FROM
@@ -1371,32 +1387,46 @@ transformFromClauseItem(ParseState *pstate, Node *n,
 
 	if (IsA(n, RangeVar))
 	{
-		/* Plain relation reference */
+		/* Plain relation reference, or perhaps a CTE reference */
+		RangeVar *rv = (RangeVar *) n;
 		RangeTblRef *rtr;
 		RangeTblEntry *rte = NULL;
 		int			rtindex;
 		RangeVar *rangeVar = (RangeVar *)n;
 
 		/*
-		 * If it is an unqualified name, it might be a CTE reference.
+		 * If it is an unqualified name, it might be a reference to some
+		 * CTE visible in this or a parent query.
 		 */
-		if (rangeVar->schemaname == NULL)
+		if (!rv->schemaname)
 		{
-			CommonTableExpr *cte;
-			Index levelsup;
+			ParseState *ps;
+			Index	levelsup;
 
-			cte = scanNameSpaceForCTE(pstate, rangeVar->relname, &levelsup);
-			if (cte)
+			for (ps = pstate, levelsup = 0;
+				 ps != NULL;
+				 ps = ps->parentParseState, levelsup++)
 			{
-				rte = addRangeTableEntryForCTE(pstate, cte, levelsup, rangeVar, true);
+				ListCell *lc;
+
+				foreach(lc, ps->p_ctenamespace)
+				{
+					CommonTableExpr *cte = (CommonTableExpr *) lfirst(lc);
+
+					if (strcmp(rv->relname, cte->ctename) == 0)
+					{
+						rte = transformCTEReference(pstate, rv, cte, levelsup);
+						break;
+					}
+				}
+				if (rte)
+					break;
 			}
 		}
 
-		/* If it is not a CTE reference, it must be a simple relation reference. */
-		if (rte == NULL)
-		{
-			rte = transformTableEntry(pstate, rangeVar);
-		}
+		/* if not found as a CTE, must be a table reference */
+		if (!rte)
+			rte = transformTableEntry(pstate, rv);
 
 		/* assume new rte is at end */
 		rtindex = list_length(pstate->p_rtable);

--- a/src/backend/parser/parse_cte.c
+++ b/src/backend/parser/parse_cte.c
@@ -1,26 +1,100 @@
-/*
- * parse_cte.c
- *    Handle WITH clause in parser.
+/*-------------------------------------------------------------------------
  *
- * Copyright (c) 2011 - present, EMC Greenplum.
+ * parse_cte.c
+ *	  handle CTEs (common table expressions) in parser
+ *
+ * Portions Copyright (c) 1996-2008, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ *
+ * IDENTIFICATION
+ *	  $PostgreSQL: pgsql/src/backend/parser/parse_cte.c,v 2.1 2008/10/04 21:56:54 tgl Exp $
+ *
+ *-------------------------------------------------------------------------
  */
 #include "postgres.h"
 
-#include "parser/analyze.h"
-#include "parser/parse_node.h"
-#include "parser/parse_cte.h"
-#include "parser/parse_expr.h"
-#include "parser/parse_relation.h"
-#include "nodes/parsenodes.h"
 #include "nodes/nodeFuncs.h"
+#include "parser/analyze.h"
+#include "parser/parse_cte.h"
+#include "utils/builtins.h"
+
+
+/* Enumeration of contexts in which a self-reference is disallowed */
+typedef enum
+{
+	RECURSION_OK,
+	RECURSION_NONRECURSIVETERM,	/* inside the left-hand term */
+	RECURSION_SUBLINK,			/* inside a sublink */
+	RECURSION_OUTERJOIN,		/* inside nullable side of an outer join */
+	RECURSION_INTERSECT,		/* underneath INTERSECT (ALL) */
+	RECURSION_EXCEPT			/* underneath EXCEPT (ALL) */
+} RecursionContext;
+
+/* Associated error messages --- each must have one %s for CTE name */
+static const char * const recursion_errormsgs[] = {
+	/* RECURSION_OK */
+	NULL,
+	/* RECURSION_NONRECURSIVETERM */
+	gettext_noop("recursive reference to query \"%s\" must not appear within its non-recursive term"),
+	/* RECURSION_SUBLINK */
+	gettext_noop("recursive reference to query \"%s\" must not appear within a subquery"),
+	/* RECURSION_OUTERJOIN */
+	gettext_noop("recursive reference to query \"%s\" must not appear within an outer join"),
+	/* RECURSION_INTERSECT */
+	gettext_noop("recursive reference to query \"%s\" must not appear within INTERSECT"),
+	/* RECURSION_EXCEPT */
+	gettext_noop("recursive reference to query \"%s\" must not appear within EXCEPT")
+};
+
+/*
+ * For WITH RECURSIVE, we have to find an ordering of the clause members
+ * with no forward references, and determine which members are recursive
+ * (i.e., self-referential).  It is convenient to do this with an array
+ * of CteItems instead of a list of CommonTableExprs.
+ */
+typedef struct CteItem
+{
+	CommonTableExpr *cte;			/* One CTE to examine */
+	int			id;					/* Its ID number for dependencies */
+	Node	   *non_recursive_term;	/* Its nonrecursive part, if identified */
+	Bitmapset  *depends_on;			/* CTEs depended on (not including self) */
+} CteItem;
+
+/* CteState is what we need to pass around in the tree walkers */
+typedef struct CteState
+{
+	/* global state: */
+	ParseState *pstate;			/* global parse state */
+	CteItem	   *items;			/* array of CTEs and extra data */
+	int			numitems;		/* number of CTEs */
+	/* working state during a tree walk: */
+	int			curitem;		/* index of item currently being examined */
+	List	   *innerwiths;		/* list of lists of CommonTableExpr */
+	/* working state for checkWellFormedRecursion walk only: */
+	int			selfrefcount;	/* number of self-references detected */
+	RecursionContext context;	/* context to allow or disallow self-ref */
+} CteState;
+
 
 static void analyzeCTE(ParseState *pstate, CommonTableExpr *cte);
 static void analyzeCTETargetList(ParseState *pstate, CommonTableExpr *cte, List *tlist);
 
+/* Dependency processing functions */
+static void makeDependencyGraph(CteState *cstate);
+static bool makeDependencyGraphWalker(Node *node, CteState *cstate);
+static void TopologicalSort(ParseState *pstate, CteItem *items, int numitems);
+
+/* Recursion validity checker functions */
+static void checkWellFormedRecursion(CteState *cstate);
+static bool checkWellFormedRecursionWalker(Node *node, CteState *cstate);
+static void checkWellFormedSelectStmt(SelectStmt *stmt, CteState *cstate);
+
+
 /*
  * transformWithClause -
- *	  Transform the list of WITH clause "common table expressions" into
- *	  Query nodes.
+ *    Transform the list of WITH clause "common table expressions" into
+ *    Query nodes.
  *
  * The result is the list of transformed CTEs to be put into the output
  * Query.  (This is in fact the same as the ending value of p_ctenamespace,
@@ -31,9 +105,7 @@ transformWithClause(ParseState *pstate, WithClause *withClause)
 {
 	ListCell   *lc;
 
-	if (withClause == NULL)
-		return NULL;
-	
+	/* FIXME: Remove this when we support recursive CTE*/
 	if (withClause->recursive)
 	{
 		ereport(ERROR, 
@@ -46,10 +118,11 @@ transformWithClause(ParseState *pstate, WithClause *withClause)
 	Assert(pstate->p_future_ctes == NIL);
 
 	/*
-	 * For either type of WITH, there must not be duplicate CTE names in the
-	 * list.  Check this right away so we needn't worry later.
+	 * For either type of WITH, there must not be duplicate CTE names in
+	 * the list.  Check this right away so we needn't worry later.
 	 *
-	 * Also, initialize other variables in CommonTableExpr.
+	 * Also, tentatively mark each CTE as non-recursive, and initialize
+	 * its reference count to zero.
 	 */
 	foreach(lc, withClause->ctes)
 	{
@@ -63,8 +136,8 @@ transformWithClause(ParseState *pstate, WithClause *withClause)
 			if (strcmp(cte->ctename, cte2->ctename) == 0)
 				ereport(ERROR,
 						(errcode(ERRCODE_DUPLICATE_ALIAS),
-					errmsg("WITH query name \"%s\" specified more than once",
-						   cte2->ctename),
+						 errmsg("WITH query name \"%s\" specified more than once",
+								cte2->ctename),
 						 parser_errposition(pstate, cte2->location)));
 		}
 
@@ -72,114 +145,192 @@ transformWithClause(ParseState *pstate, WithClause *withClause)
 		cte->cterefcount = 0;
 	}
 
-	/*
-	 * For non-recursive WITH, just analyze each CTE in sequence and then
-	 * add it to the ctenamespace.	This corresponds to the spec's
-	 * definition of the scope of each WITH name.  However, to allow error
-	 * reports to be aware of the possibility of an erroneous reference,
-	 * we maintain a list in p_future_ctes of the not-yet-visible CTEs.
-	 */
-	pstate->p_future_ctes = list_copy(withClause->ctes);
-
-	foreach (lc, withClause->ctes)
+	if (withClause->recursive)
 	{
-		CommonTableExpr *cte = (CommonTableExpr *)lfirst(lc);
-		analyzeCTE(pstate, cte);
-		pstate->p_ctenamespace = lappend(pstate->p_ctenamespace, cte);
-		pstate->p_future_ctes = list_delete_first(pstate->p_future_ctes);
+		/*
+		 * For WITH RECURSIVE, we rearrange the list elements if needed
+		 * to eliminate forward references.  First, build a work array
+		 * and set up the data structure needed by the tree walkers.
+		 */
+		CteState cstate;
+		int		i;
+
+		cstate.pstate = pstate;
+		cstate.numitems = list_length(withClause->ctes);
+		cstate.items = (CteItem *) palloc0(cstate.numitems * sizeof(CteItem));
+		i = 0;
+		foreach(lc, withClause->ctes)
+		{
+			cstate.items[i].cte = (CommonTableExpr *) lfirst(lc);
+			cstate.items[i].id = i;
+			i++;
+		}
+
+		/*
+		 * Find all the dependencies and sort the CteItems into a safe
+		 * processing order.  Also, mark CTEs that contain self-references.
+		 */
+		makeDependencyGraph(&cstate);
+
+		/*
+		 * Check that recursive queries are well-formed.
+		 */
+		checkWellFormedRecursion(&cstate);
+
+		/*
+		 * Set up the ctenamespace for parse analysis.  Per spec, all
+		 * the WITH items are visible to all others, so stuff them all in
+		 * before parse analysis.  We build the list in safe processing
+		 * order so that the planner can process the queries in sequence.
+		 */
+		for (i = 0; i < cstate.numitems; i++)
+		{
+			CommonTableExpr *cte = cstate.items[i].cte;
+
+			pstate->p_ctenamespace = lappend(pstate->p_ctenamespace, cte);
+		}
+
+		/*
+		 * Do parse analysis in the order determined by the topological sort.
+		 */
+		for (i = 0; i < cstate.numitems; i++)
+		{
+			CommonTableExpr *cte = cstate.items[i].cte;
+
+			/*
+			 * If it's recursive, we have to do a throwaway parse analysis
+			 * of the non-recursive term in order to determine the set of
+			 * output columns for the recursive CTE.
+			 */
+			if (cte->cterecursive)
+			{
+				Node   *nrt;
+				Query  *nrq;
+
+				if (!cstate.items[i].non_recursive_term)
+					elog(ERROR, "could not find non-recursive term for %s",
+						 cte->ctename);
+				/* copy the term to be sure we don't modify original query */
+				nrt = copyObject(cstate.items[i].non_recursive_term);
+				nrq = parse_sub_analyze(nrt, pstate);
+				analyzeCTETargetList(pstate, cte, nrq->targetList);
+			}
+
+			analyzeCTE(pstate, cte);
+		}
+	}
+	else
+	{
+		/*
+		 * For non-recursive WITH, just analyze each CTE in sequence and then
+		 * add it to the ctenamespace.	This corresponds to the spec's
+		 * definition of the scope of each WITH name.  However, to allow error
+		 * reports to be aware of the possibility of an erroneous reference,
+		 * we maintain a list in p_future_ctes of the not-yet-visible CTEs.
+		 */
+		pstate->p_future_ctes = list_copy(withClause->ctes);
+
+		foreach (lc, withClause->ctes)
+		{
+			CommonTableExpr *cte = (CommonTableExpr *)lfirst(lc);
+			analyzeCTE(pstate, cte);
+			pstate->p_ctenamespace = lappend(pstate->p_ctenamespace, cte);
+			pstate->p_future_ctes = list_delete_first(pstate->p_future_ctes);
+		}
 	}
 
 	return pstate->p_ctenamespace;
 }
 
-/*
- * GetCTEForRTE
- *    Find CommonTableExpr stored in pstate that is referenced by rte.
- *
- * rtelevelsup is the number of query levels above the given pstate that the
- * RTE came from.  Callers that don't have this information readily available
- * may pass -1 instead.
- *
- * Report error if not such CTE found.
- */
-CommonTableExpr *
-GetCTEForRTE(ParseState *pstate, RangeTblEntry *rte, int rtelevelsup)
-{
-	Assert(pstate != NULL && rte != NULL);
-	Assert(rte->rtekind == RTE_CTE);
-
-	/* Determine RTE's levelsup if caller didn't know it */
-	if (rtelevelsup < 0)
-		(void) RTERangeTablePosn(pstate, rte, &rtelevelsup);
-
-	Index levelsup = rte->ctelevelsup + rtelevelsup;
-	while (levelsup > 0)
-	{
-		pstate = pstate->parentParseState;
-		Assert(pstate != NULL);
-		levelsup--;
-	}
-
-	if (pstate->p_ctenamespace == NULL)
-		return NULL;
-	
-	ListCell *lc;
-	foreach (lc, pstate->p_ctenamespace)
-	{
-		CommonTableExpr *cte = (CommonTableExpr *)lfirst(lc);
-		if (strcmp(cte->ctename, rte->ctename) == 0)
-		{
-			return cte;
-		}
-	}
-	
-	/* shouldn't happen */
-	elog(ERROR, "unexpected error while parsing WITH query \"%s\"", rte->ctename);
-	return NULL;
-}
-
 
 /*
- * analyzeCTE
- *    Analyze the given CommonTableExpr.
- *
- * Report errors if the given CTE has one of the following:
- *   (1) not a Query statement.
- *   (2) containing INTO clause.
+ * Perform the actual parse analysis transformation of one CTE.  All
+ * CTEs it depends on have already been loaded into pstate->p_ctenamespace,
+ * and have been marked with the correct output column names/types.
  */
 static void
 analyzeCTE(ParseState *pstate, CommonTableExpr *cte)
 {
-	Query	   *query;
+	Query  *query;
 
-	Assert(cte != NULL);
-	Assert(cte->ctequery != NULL);
-	Assert(!IsA(cte->ctequery, Query));
+	/* Analysis not done already */
+	Assert(IsA(cte->ctequery, SelectStmt));
 
 	query = parse_sub_analyze(cte->ctequery, pstate);
 	cte->ctequery = (Node *) query;
 
-	Assert(IsA(query, Query));
-
-	/* Check if the query is what we expected. */
-	if (!IsA(query, Query))
-		elog(ERROR, "unexpected non-Query statement in WITH clause");
-	if (query->utilityStmt != NULL)
-		elog(ERROR, "unexpected utility statement in WITH clause");
-
+	/*
+	 * Check that we got something reasonable.	Many of these conditions are
+	 * impossible given restrictions of the grammar, but check 'em anyway.
+	 * (These are the same checks as in transformRangeSubselect.)
+	 */
+	if (!IsA(query, Query) ||
+		query->commandType != CMD_SELECT ||
+		query->utilityStmt != NULL)
+		elog(ERROR, "unexpected non-SELECT command in subquery in WITH");
 	if (query->intoClause)
 		ereport(ERROR,
 				(errcode(ERRCODE_SYNTAX_ERROR),
-				 errmsg("query defined in WITH clause cannot have SELECT INTO"),
+				 errmsg("subquery in WITH cannot have SELECT INTO"),
 				 parser_errposition(pstate,
 									exprLocation((Node *) query->intoClause))));
 
 	/* CTE queries are always marked as not canSetTag */
 	query->canSetTag = false;
 
-	/* Compute the column types, typmods. */
-	analyzeCTETargetList(pstate, cte, GetCTETargetList(cte));
+	if (!cte->cterecursive)
+	{
+		/* Compute the output column names/types if not done yet */
+		analyzeCTETargetList(pstate, cte, query->targetList);
+	}
+	else
+	{
+		/*
+		 * Verify that the previously determined output column types match
+		 * what the query really produced.  We have to check this because
+		 * the recursive term could have overridden the non-recursive term,
+		 * and we don't have any easy way to fix that.
+		 */
+		ListCell   *lctlist,
+				   *lctyp,
+				   *lctypmod;
+		int			varattno;
+
+		lctyp = list_head(cte->ctecoltypes);
+		lctypmod = list_head(cte->ctecoltypmods);
+		varattno = 0;
+		foreach(lctlist, query->targetList)
+		{
+			TargetEntry *te = (TargetEntry *) lfirst(lctlist);
+			Node   *texpr;
+
+			if (te->resjunk)
+				continue;
+			varattno++;
+			Assert(varattno == te->resno);
+			if (lctyp == NULL || lctypmod == NULL)		/* shouldn't happen */
+				elog(ERROR, "wrong number of output columns in WITH");
+			texpr = (Node *) te->expr;
+			if (exprType(texpr) != lfirst_oid(lctyp) ||
+				exprTypmod(texpr) != lfirst_int(lctypmod))
+				ereport(ERROR,
+						(errcode(ERRCODE_DATATYPE_MISMATCH),
+						 errmsg("recursive query \"%s\" column %d has type %s in non-recursive term but type %s overall",
+								cte->ctename, varattno,
+								format_type_with_typemod(lfirst_oid(lctyp),
+														 lfirst_int(lctypmod)),
+								format_type_with_typemod(exprType(texpr),
+														 exprTypmod(texpr))),
+						 errhint("Cast the output of the non-recursive term to the correct type."),
+						 parser_errposition(pstate, exprLocation(texpr))));
+			lctyp = lnext(lctyp);
+			lctypmod = lnext(lctypmod);
+		}
+		if (lctyp != NULL || lctypmod != NULL)		/* shouldn't happen */
+			elog(ERROR, "wrong number of output columns in WITH");
+	}
 }
+
 
 /*
  * reportDuplicateNames
@@ -217,9 +368,7 @@ reportDuplicateNames(const char *queryName, List *names)
 }
 
 /*
- * analayzeCTETargetList
- *    Compute colnames, coltypes, and coltypmods from the targetlist generated
- * after analyze.
+ * Compute derived fields of a CTE, given the transformed output targetlist
  */
 static void
 analyzeCTETargetList(ParseState *pstate, CommonTableExpr *cte, List *tlist)
@@ -228,15 +377,12 @@ analyzeCTETargetList(ParseState *pstate, CommonTableExpr *cte, List *tlist)
 	int			varattno;
 	ListCell   *tlistitem;
 
-	/* Not done already ... */
-	Assert(cte->ctecolnames == NIL);
-
 	/*
 	 * We need to determine column names and types.  The alias column names
 	 * override anything coming from the query itself.  (Note: the SQL spec
-	 * says that the alias list must be empty or exactly as long as the output
-	 * column set. Also, the alias can not have the same name. We report
-	 * errors if this is not the case.)
+	 * says that the alias list must be empty or exactly as long as the
+	 * output column set; but we allow it to be shorter for consistency
+	 * with Alias handling.)
 	 */
 	cte->ctecolnames = copyObject(cte->aliascolnames);
 	cte->ctecoltypes = cte->ctecoltypmods = NIL;
@@ -245,8 +391,6 @@ analyzeCTETargetList(ParseState *pstate, CommonTableExpr *cte, List *tlist)
 	foreach(tlistitem, tlist)
 	{
 		TargetEntry *te = (TargetEntry *) lfirst(tlistitem);
-		Oid			coltype;
-		int32		coltypmod;
 
 		if (te->resjunk)
 			continue;
@@ -256,31 +400,554 @@ analyzeCTETargetList(ParseState *pstate, CommonTableExpr *cte, List *tlist)
 		{
 			char	   *attrname;
 
-			if (numaliases > 0)
-			{
-				ereport(ERROR,
-						(errcode(ERRCODE_SYNTAX_ERROR),
-						 errmsg(ERRMSG_GP_WITH_COLUMNS_MISMATCH, cte->ctename),
-						 parser_errposition(pstate, cte->location)));
-			}
-
 			attrname = pstrdup(te->resname);
 			cte->ctecolnames = lappend(cte->ctecolnames, makeString(attrname));
 		}
-		coltype = exprType((Node *) te->expr);
-		coltypmod = exprTypmod((Node *) te->expr);
-
-		cte->ctecoltypes = lappend_oid(cte->ctecoltypes, coltype);
-		cte->ctecoltypmods = lappend_int(cte->ctecoltypmods, coltypmod);
+		cte->ctecoltypes = lappend_oid(cte->ctecoltypes,
+									   exprType((Node *) te->expr));
+		cte->ctecoltypmods = lappend_int(cte->ctecoltypmods,
+										 exprTypmod((Node *) te->expr));
 	}
-
 	if (varattno < numaliases)
-	{
 		ereport(ERROR,
-				(errcode(ERRCODE_SYNTAX_ERROR),
-				 errmsg(ERRMSG_GP_WITH_COLUMNS_MISMATCH, cte->ctename),
+				(errcode(ERRCODE_INVALID_COLUMN_REFERENCE),
+				 errmsg("WITH query \"%s\" has %d columns available but %d columns specified",
+						cte->ctename, varattno, numaliases),
 				 parser_errposition(pstate, cte->location)));
-	}
 
 	reportDuplicateNames(cte->ctename, cte->ctecolnames);
+}
+
+
+/*
+ * Identify the cross-references of a list of WITH RECURSIVE items,
+ * and sort into an order that has no forward references.
+ */
+static void
+makeDependencyGraph(CteState *cstate)
+{
+	int			i;
+
+	for (i = 0; i < cstate->numitems; i++)
+	{
+		CommonTableExpr *cte = cstate->items[i].cte;
+
+		cstate->curitem = i;
+		cstate->innerwiths = NIL;
+		makeDependencyGraphWalker((Node *) cte->ctequery, cstate);
+		Assert(cstate->innerwiths == NIL);
+	}
+
+	TopologicalSort(cstate->pstate, cstate->items, cstate->numitems);
+}
+
+/*
+ * Tree walker function to detect cross-references and self-references of the
+ * CTEs in a WITH RECURSIVE list.
+ */
+static bool
+makeDependencyGraphWalker(Node *node, CteState *cstate)
+{
+	if (node == NULL)
+		return false;
+	if (IsA(node, RangeVar))
+	{
+		RangeVar   *rv = (RangeVar *) node;
+
+		/* If unqualified name, might be a CTE reference */
+		if (!rv->schemaname)
+		{
+			ListCell *lc;
+			int		i;
+
+			/* ... but first see if it's captured by an inner WITH */
+			foreach(lc, cstate->innerwiths)
+			{
+				List   *withlist = (List *) lfirst(lc);
+				ListCell *lc2;
+
+				foreach(lc2, withlist)
+				{
+					CommonTableExpr *cte = (CommonTableExpr *) lfirst(lc2);
+
+					if (strcmp(rv->relname, cte->ctename) == 0)
+						return false;				/* yes, so bail out */
+				}
+			}
+
+			/* No, could be a reference to the query level we are working on */
+			for (i = 0; i < cstate->numitems; i++)
+			{
+				CommonTableExpr *cte = cstate->items[i].cte;
+
+				if (strcmp(rv->relname, cte->ctename) == 0)
+				{
+					int		myindex = cstate->curitem;
+
+					if (i != myindex)
+					{
+						/* Add cross-item dependency */
+						cstate->items[myindex].depends_on =
+							bms_add_member(cstate->items[myindex].depends_on,
+										   cstate->items[i].id);
+					}
+					else
+					{
+						/* Found out this one is self-referential */
+						cte->cterecursive = true;
+					}
+					break;
+				}
+			}
+		}
+		return false;
+	}
+	if (IsA(node, SelectStmt))
+	{
+		SelectStmt *stmt = (SelectStmt *) node;
+		ListCell *lc;
+
+		if (stmt->withClause)
+		{
+			if (stmt->withClause->recursive)
+			{
+				/*
+				 * In the RECURSIVE case, all query names of the WITH are
+				 * visible to all WITH items as well as the main query.
+				 * So push them all on, process, pop them all off.
+				 */
+				cstate->innerwiths = lcons(stmt->withClause->ctes,
+										   cstate->innerwiths);
+				foreach(lc, stmt->withClause->ctes)
+				{
+					CommonTableExpr *cte = (CommonTableExpr *) lfirst(lc);
+
+					(void) makeDependencyGraphWalker(cte->ctequery, cstate);
+				}
+				(void) raw_expression_tree_walker(node,
+												  makeDependencyGraphWalker,
+												  (void *) cstate);
+				cstate->innerwiths = list_delete_first(cstate->innerwiths);
+			}
+			else
+			{
+				/*
+				 * In the non-RECURSIVE case, query names are visible to
+				 * the WITH items after them and to the main query.
+				 */
+				ListCell   *cell1;
+
+				cstate->innerwiths = lcons(NIL, cstate->innerwiths);
+				cell1 = list_head(cstate->innerwiths);
+				foreach(lc, stmt->withClause->ctes)
+				{
+					CommonTableExpr *cte = (CommonTableExpr *) lfirst(lc);
+
+					(void) makeDependencyGraphWalker(cte->ctequery, cstate);
+					lfirst(cell1) = lappend((List *) lfirst(cell1), cte);
+				}
+				(void) raw_expression_tree_walker(node,
+												  makeDependencyGraphWalker,
+												  (void *) cstate);
+				cstate->innerwiths = list_delete_first(cstate->innerwiths);
+			}
+			/* We're done examining the SelectStmt */
+			return false;
+		}
+		/* if no WITH clause, just fall through for normal processing */
+	}
+	if (IsA(node, WithClause))
+	{
+		/*
+		 * Prevent raw_expression_tree_walker from recursing directly into
+		 * a WITH clause.  We need that to happen only under the control
+		 * of the code above.
+		 */
+		return false;
+	}
+	return raw_expression_tree_walker(node,
+									  makeDependencyGraphWalker,
+									  (void *) cstate);
+}
+
+/*
+ * Sort by dependencies, using a standard topological sort operation
+ */
+static void
+TopologicalSort(ParseState *pstate, CteItem *items, int numitems)
+{
+	int i, j;
+
+	/* for each position in sequence ... */
+	for (i = 0; i < numitems; i++)
+	{
+		/* ... scan the remaining items to find one that has no dependencies */
+		for (j = i; j < numitems; j++)
+		{
+			if (bms_is_empty(items[j].depends_on))
+				break;
+		}
+
+		/* if we didn't find one, the dependency graph has a cycle */
+		if (j >= numitems)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("mutual recursion between WITH items is not implemented"),
+					 parser_errposition(pstate, items[i].cte->location)));
+
+		/*
+		 * Found one.  Move it to front and remove it from every other
+		 * item's dependencies.
+		 */
+		if (i != j)
+		{
+			CteItem tmp;
+				
+			tmp = items[i];
+			items[i] = items[j];
+			items[j] = tmp;
+		}
+		/*
+		 * Items up through i are known to have no dependencies left,
+		 * so we can skip them in this loop.
+		 */
+		for (j = i + 1; j < numitems; j++)
+		{
+			items[j].depends_on = bms_del_member(items[j].depends_on,
+												 items[i].id);
+		}
+	}
+}
+
+
+/*
+ * Check that recursive queries are well-formed.
+ */
+static void
+checkWellFormedRecursion(CteState *cstate)
+{
+	int			i;
+
+	for (i = 0; i < cstate->numitems; i++)
+	{
+		CommonTableExpr *cte = cstate->items[i].cte;
+		SelectStmt		*stmt = (SelectStmt *) cte->ctequery;
+
+		Assert(IsA(stmt, SelectStmt));				/* not analyzed yet */
+
+		/* Ignore items that weren't found to be recursive */
+		if (!cte->cterecursive)
+			continue;
+
+		/* Must have top-level UNION ALL */
+		if (stmt->op != SETOP_UNION || !stmt->all)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_RECURSION),
+					 errmsg("recursive query \"%s\" does not have the form non-recursive-term UNION ALL recursive-term",
+							cte->ctename),
+					 parser_errposition(cstate->pstate, cte->location)));
+
+		/* The left-hand operand mustn't contain self-reference at all */
+		cstate->curitem = i;
+		cstate->innerwiths = NIL;
+		cstate->selfrefcount = 0;
+		cstate->context = RECURSION_NONRECURSIVETERM;
+		checkWellFormedRecursionWalker((Node *) stmt->larg, cstate);
+		Assert(cstate->innerwiths == NIL);
+
+		/* Right-hand operand should contain one reference in a valid place */
+		cstate->curitem = i;
+		cstate->innerwiths = NIL;
+		cstate->selfrefcount = 0;
+		cstate->context = RECURSION_OK;
+		checkWellFormedRecursionWalker((Node *) stmt->rarg, cstate);
+		Assert(cstate->innerwiths == NIL);
+		if (cstate->selfrefcount != 1)			/* shouldn't happen */
+			elog(ERROR, "missing recursive reference");
+
+		/*
+		 * Disallow ORDER BY and similar decoration atop the UNION ALL.
+		 * These don't make sense because it's impossible to figure out what
+		 * they mean when we have only part of the recursive query's results.
+		 * (If we did allow them, we'd have to check for recursive references
+		 * inside these subtrees.)
+		 */
+		if (stmt->sortClause)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("ORDER BY in a recursive query is not implemented"),
+					 parser_errposition(cstate->pstate,
+										exprLocation((Node *) stmt->sortClause))));
+		if (stmt->limitOffset)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("OFFSET in a recursive query is not implemented"),
+					 parser_errposition(cstate->pstate,
+										exprLocation(stmt->limitOffset))));
+		if (stmt->limitCount)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("LIMIT in a recursive query is not implemented"),
+					 parser_errposition(cstate->pstate,
+										exprLocation(stmt->limitCount))));
+		if (stmt->lockingClause)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("FOR UPDATE/SHARE in a recursive query is not implemented"),
+					 parser_errposition(cstate->pstate,
+										exprLocation((Node *) stmt->lockingClause))));
+
+		/*
+		 * Save non_recursive_term.
+		 */
+		cstate->items[i].non_recursive_term = (Node *) stmt->larg;
+	}
+}
+
+/*
+ * Tree walker function to detect invalid self-references in a recursive query.
+ */
+static bool
+checkWellFormedRecursionWalker(Node *node, CteState *cstate)
+{
+	RecursionContext save_context = cstate->context;
+
+	if (node == NULL)
+		return false;
+	if (IsA(node, RangeVar))
+	{
+		RangeVar   *rv = (RangeVar *) node;
+
+		/* If unqualified name, might be a CTE reference */
+		if (!rv->schemaname)
+		{
+			ListCell *lc;
+			CommonTableExpr *mycte;
+
+			/* ... but first see if it's captured by an inner WITH */
+			foreach(lc, cstate->innerwiths)
+			{
+				List   *withlist = (List *) lfirst(lc);
+				ListCell *lc2;
+
+				foreach(lc2, withlist)
+				{
+					CommonTableExpr *cte = (CommonTableExpr *) lfirst(lc2);
+
+					if (strcmp(rv->relname, cte->ctename) == 0)
+						return false;				/* yes, so bail out */
+				}
+			}
+
+			/* No, could be a reference to the query level we are working on */
+			mycte = cstate->items[cstate->curitem].cte;
+			if (strcmp(rv->relname, mycte->ctename) == 0)
+			{
+				/* Found a recursive reference to the active query */
+				if (cstate->context != RECURSION_OK)
+					ereport(ERROR,
+							(errcode(ERRCODE_INVALID_RECURSION),
+							 errmsg(recursion_errormsgs[cstate->context],
+									mycte->ctename),
+							 parser_errposition(cstate->pstate,
+												rv->location)));
+				/* Count references */
+				if (++(cstate->selfrefcount) > 1)
+					ereport(ERROR,
+							(errcode(ERRCODE_INVALID_RECURSION),
+							 errmsg("recursive reference to query \"%s\" must not appear more than once",
+									mycte->ctename),
+							 parser_errposition(cstate->pstate,
+												rv->location)));
+			}
+		}
+		return false;
+	}
+	if (IsA(node, SelectStmt))
+	{
+		SelectStmt *stmt = (SelectStmt *) node;
+		ListCell *lc;
+
+		if (stmt->withClause)
+		{
+			if (stmt->withClause->recursive)
+			{
+				/*
+				 * In the RECURSIVE case, all query names of the WITH are
+				 * visible to all WITH items as well as the main query.
+				 * So push them all on, process, pop them all off.
+				 */
+				cstate->innerwiths = lcons(stmt->withClause->ctes,
+										   cstate->innerwiths);
+				foreach(lc, stmt->withClause->ctes)
+				{
+					CommonTableExpr *cte = (CommonTableExpr *) lfirst(lc);
+
+					(void) checkWellFormedRecursionWalker(cte->ctequery, cstate);
+				}
+				checkWellFormedSelectStmt(stmt, cstate);
+				cstate->innerwiths = list_delete_first(cstate->innerwiths);
+			}
+			else
+			{
+				/*
+				 * In the non-RECURSIVE case, query names are visible to
+				 * the WITH items after them and to the main query.
+				 */
+				ListCell   *cell1;
+
+				cstate->innerwiths = lcons(NIL, cstate->innerwiths);
+				cell1 = list_head(cstate->innerwiths);
+				foreach(lc, stmt->withClause->ctes)
+				{
+					CommonTableExpr *cte = (CommonTableExpr *) lfirst(lc);
+
+					(void) checkWellFormedRecursionWalker(cte->ctequery, cstate);
+					lfirst(cell1) = lappend((List *) lfirst(cell1), cte);
+				}
+				checkWellFormedSelectStmt(stmt, cstate);
+				cstate->innerwiths = list_delete_first(cstate->innerwiths);
+			}
+		}
+		else
+				checkWellFormedSelectStmt(stmt, cstate);
+		/* We're done examining the SelectStmt */
+		return false;
+	}
+	if (IsA(node, WithClause))
+	{
+		/*
+		 * Prevent raw_expression_tree_walker from recursing directly into
+		 * a WITH clause.  We need that to happen only under the control
+		 * of the code above.
+		 */
+		return false;
+	}
+	if (IsA(node, JoinExpr))
+	{
+		JoinExpr *j = (JoinExpr *) node;
+
+		switch (j->jointype)
+		{
+			case JOIN_INNER:
+				checkWellFormedRecursionWalker(j->larg, cstate);
+				checkWellFormedRecursionWalker(j->rarg, cstate);
+				checkWellFormedRecursionWalker(j->quals, cstate);
+				break;
+			case JOIN_LEFT:
+				checkWellFormedRecursionWalker(j->larg, cstate);
+				if (save_context == RECURSION_OK)
+					cstate->context = RECURSION_OUTERJOIN;
+				checkWellFormedRecursionWalker(j->rarg, cstate);
+				cstate->context = save_context;
+				checkWellFormedRecursionWalker(j->quals, cstate);
+				break;
+			case JOIN_FULL:
+				if (save_context == RECURSION_OK)
+					cstate->context = RECURSION_OUTERJOIN;
+				checkWellFormedRecursionWalker(j->larg, cstate);
+				checkWellFormedRecursionWalker(j->rarg, cstate);
+				cstate->context = save_context;
+				checkWellFormedRecursionWalker(j->quals, cstate);
+				break;
+			case JOIN_RIGHT:
+				if (save_context == RECURSION_OK)
+					cstate->context = RECURSION_OUTERJOIN;
+				checkWellFormedRecursionWalker(j->larg, cstate);
+				cstate->context = save_context;
+				checkWellFormedRecursionWalker(j->rarg, cstate);
+				checkWellFormedRecursionWalker(j->quals, cstate);
+				break;
+			default:
+				elog(ERROR, "unrecognized join type: %d",
+					 (int) j->jointype);
+		}
+		return false;
+	}
+	if (IsA(node, SubLink))
+	{
+		SubLink *sl = (SubLink *) node;
+
+		/*
+		 * we intentionally override outer context, since subquery is
+		 * independent
+		 */
+		cstate->context = RECURSION_SUBLINK;
+		checkWellFormedRecursionWalker(sl->subselect, cstate);
+		cstate->context = save_context;
+		checkWellFormedRecursionWalker(sl->testexpr, cstate);
+		return false;
+	}
+	return raw_expression_tree_walker(node,
+									  checkWellFormedRecursionWalker,
+									  (void *) cstate);
+}
+
+/*
+ * subroutine for checkWellFormedRecursionWalker: process a SelectStmt
+ * without worrying about its WITH clause
+ */
+static void
+checkWellFormedSelectStmt(SelectStmt *stmt, CteState *cstate)
+{
+	RecursionContext save_context = cstate->context;
+
+	if (save_context != RECURSION_OK)
+	{
+		/* just recurse without changing state */
+		raw_expression_tree_walker((Node *) stmt,
+								   checkWellFormedRecursionWalker,
+								   (void *) cstate);
+	}
+	else
+	{
+		switch (stmt->op)
+		{
+			case SETOP_NONE:
+			case SETOP_UNION:
+				raw_expression_tree_walker((Node *) stmt,
+										   checkWellFormedRecursionWalker,
+										   (void *) cstate);
+				break;
+			case SETOP_INTERSECT:
+				if (stmt->all)
+					cstate->context = RECURSION_INTERSECT;
+				checkWellFormedRecursionWalker((Node *) stmt->larg,
+											   cstate);
+				checkWellFormedRecursionWalker((Node *) stmt->rarg,
+											   cstate);
+				cstate->context = save_context;
+				checkWellFormedRecursionWalker((Node *) stmt->sortClause,
+											   cstate);
+				checkWellFormedRecursionWalker((Node *) stmt->limitOffset,
+											   cstate);
+				checkWellFormedRecursionWalker((Node *) stmt->limitCount,
+											   cstate);
+				checkWellFormedRecursionWalker((Node *) stmt->lockingClause,
+											   cstate);
+				break;
+				break;
+			case SETOP_EXCEPT:
+				if (stmt->all)
+					cstate->context = RECURSION_EXCEPT;
+				checkWellFormedRecursionWalker((Node *) stmt->larg,
+											   cstate);
+				cstate->context = RECURSION_EXCEPT;
+				checkWellFormedRecursionWalker((Node *) stmt->rarg,
+											   cstate);
+				cstate->context = save_context;
+				checkWellFormedRecursionWalker((Node *) stmt->sortClause,
+											   cstate);
+				checkWellFormedRecursionWalker((Node *) stmt->limitOffset,
+											   cstate);
+				checkWellFormedRecursionWalker((Node *) stmt->limitCount,
+											   cstate);
+				checkWellFormedRecursionWalker((Node *) stmt->lockingClause,
+											   cstate);
+				break;
+			default:
+				elog(ERROR, "unrecognized set op: %d",
+					 (int) stmt->op);
+		}
+	}
 }

--- a/src/backend/parser/parse_target.c
+++ b/src/backend/parser/parse_target.c
@@ -338,7 +338,7 @@ markTargetListOrigin(ParseState *pstate, TargetEntry *tle,
  * colname		target column name (ie, name of attribute to be assigned to)
  * attrno		target attribute number
  * indirection	subscripts/field names for target column, if any
- * location		error cursor position, or -1
+ * location		error cursor position for the target column, or -1
  *
  * Returns the modified expression.
  */
@@ -423,7 +423,8 @@ transformAssignedExpr(ParseState *pstate,
 			 */
 			colVar = (Node *) make_var(pstate,
 									   pstate->p_target_rangetblentry,
-									   attrno, location);
+									   attrno,
+									   location);
 		}
 
 		expr = (Expr *)
@@ -828,7 +829,7 @@ checkInsertTargets(ParseState *pstate, List *cols, List **attrnos)
  * ExpandColumnRefStar()
  *		Transforms foo.* into a list of expressions or targetlist entries.
  *
- * This handles the case where '*' appears as the last or only name in a
+ * This handles the case where '*' appears as the last or only item in a
  * ColumnRef.  The code is shared between the case of foo.* at the top level
  * in a SELECT target list (where we want TargetEntry nodes in the result)
  * and foo.* in a ROW() or VALUES() construct (where we want just bare

--- a/src/backend/parser/parse_target.c
+++ b/src/backend/parser/parse_target.c
@@ -8,7 +8,7 @@
  *
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/parser/parse_target.c,v 1.158 2008/01/01 19:45:51 momjian Exp $
+ *	  $PostgreSQL: pgsql/src/backend/parser/parse_target.c,v 1.165 2008/10/04 21:56:54 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -284,25 +284,6 @@ markTargetListOrigin(ParseState *pstate, TargetEntry *tle,
 				tle->resorigcol = ste->resorigcol;
 			}
 			break;
-		case RTE_CTE:
-			/* Similar to RTE_SUBQUERY */
-			if (attnum != InvalidAttrNumber)
-			{
-				/* Find the CommonTableExpr based on the query name */
-				CommonTableExpr *cte = GetCTEForRTE(pstate, rte, netlevelsup);
-				Assert(cte != NULL);
-				
-				TargetEntry *ste = get_tle_by_resno(GetCTETargetList(cte), attnum);
-				if (ste == NULL || ste->resjunk)
-				{
-					elog(ERROR, "WITH query %s does not have attribute %d",
-						 rte->ctename, attnum);
-				}
-				
-				tle->resorigtbl = ste->resorigtbl;
-				tle->resorigcol = ste->resorigcol;
-			}
-			break;
 		case RTE_JOIN:
 			/* Join RTE --- recursively inspect the alias variable */
 			if (attnum != InvalidAttrNumber)
@@ -318,8 +299,26 @@ markTargetListOrigin(ParseState *pstate, TargetEntry *tle,
 		case RTE_TABLEFUNCTION:
 		case RTE_FUNCTION:
 		case RTE_VALUES:
-        case RTE_VOID:
+		case RTE_VOID:
 			/* not a simple relation, leave it unmarked */
+			break;
+		case RTE_CTE:
+			/* CTE reference: copy up from the subquery */
+			if (attnum != InvalidAttrNumber)
+			{
+				CommonTableExpr *cte = GetCTEForRTE(pstate, rte, netlevelsup);
+				TargetEntry *ste;
+
+				/* should be analyzed by now */
+				Assert(IsA(cte->ctequery, Query));
+				ste = get_tle_by_resno(((Query *) cte->ctequery)->targetList,
+									   attnum);
+				if (ste == NULL || ste->resjunk)
+					elog(ERROR, "subquery %s does not have attribute %d",
+						 rte->eref->aliasname, attnum);
+				tle->resorigtbl = ste->resorigtbl;
+				tle->resorigcol = ste->resorigcol;
+			}
 			break;
 	}
 }
@@ -1182,6 +1181,22 @@ expandRecordVariable(ParseState *pstate, Var *var, int levelsup)
 				/* else fall through to inspect the expression */
 			}
 			break;
+		case RTE_JOIN:
+			/* Join RTE --- recursively inspect the alias variable */
+			Assert(attnum > 0 && attnum <= list_length(rte->joinaliasvars));
+			expr = (Node *) list_nth(rte->joinaliasvars, attnum - 1);
+			if (IsA(expr, Var))
+				return expandRecordVariable(pstate, (Var *) expr, netlevelsup);
+			/* else fall through to inspect the expression */
+			break;
+		case RTE_TABLEFUNCTION:
+		case RTE_FUNCTION:
+
+			/*
+			 * We couldn't get here unless a function is declared with one of
+			 * its result columns as RECORD, which is not allowed.
+			 */
+			break;
 		case RTE_CTE:
 			if (!rte->self_reference)
 			{
@@ -1220,25 +1235,9 @@ expandRecordVariable(ParseState *pstate, Var *var, int levelsup)
 				/* else fall through to inspect the expression */
 			}
 			break;
-		case RTE_JOIN:
-			/* Join RTE --- recursively inspect the alias variable */
-			Assert(attnum > 0 && attnum <= list_length(rte->joinaliasvars));
-			expr = (Node *) list_nth(rte->joinaliasvars, attnum - 1);
-			if (IsA(expr, Var))
-				return expandRecordVariable(pstate, (Var *) expr, netlevelsup);
-			/* else fall through to inspect the expression */
-			break;
-		case RTE_TABLEFUNCTION:
-		case RTE_FUNCTION:
-
-			/*
-			 * We couldn't get here unless a function is declared with one of
-			 * its result columns as RECORD, which is not allowed.
-			 */
-			break;
-        case RTE_VOID:
-            Insist(0);
-            break;
+		case RTE_VOID:
+	            Insist(0);
+        	    break;
 	}
 
 	/*

--- a/src/backend/parser/parse_type.c
+++ b/src/backend/parser/parse_type.c
@@ -9,7 +9,7 @@
  *
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/parser/parse_type.c,v 1.94 2008/01/01 19:45:51 momjian Exp $
+ *	  $PostgreSQL: pgsql/src/backend/parser/parse_type.c,v 1.100 2008/10/04 21:56:54 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -4,7 +4,7 @@
  * Portions Copyright (c) 2005-2010, Greenplum inc
  * Copyright (c) 2000-2010, PostgreSQL Global Development Group
  *
- * src/bin/psql/tab-complete.c
+ * $PostgreSQL: pgsql/src/bin/psql/tab-complete.c,v 1.173 2008/10/04 21:56:54 tgl Exp $
  */
 
 /*----------------------------------------------------------------------

--- a/src/include/parser/parse_node.h
+++ b/src/include/parser/parse_node.h
@@ -120,7 +120,7 @@ extern void setup_parser_errposition_callback(ParseCallbackState *pcbstate,
 extern void cancel_parser_errposition_callback(ParseCallbackState *pcbstate);
 
 extern Var *make_var(ParseState *pstate, RangeTblEntry *rte, int attrno,
-		 int location);
+					 int location);
 extern Oid	transformArrayType(Oid arrayType);
 extern ArrayRef *transformArraySubscripts(ParseState *pstate,
 						 Node *arrayBase,

--- a/src/include/parser/parse_node.h
+++ b/src/include/parser/parse_node.h
@@ -7,7 +7,7 @@
  * Portions Copyright (c) 1996-2009, PostgreSQL Global Development Group
  * Portions Copyright (c) 1994, Regents of the University of California
  *
- * $PostgreSQL: pgsql/src/include/parser/parse_node.h,v 1.53 2008/01/01 19:45:58 momjian Exp $
+ * $PostgreSQL: pgsql/src/include/parser/parse_node.h,v 1.57 2008/10/04 21:56:55 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -52,6 +52,10 @@ struct HTAB;  /* utils/hsearch.h */
  * refer to the JOIN, not the member tables).  Also, we put POSTQUEL-style
  * implicit RTEs into p_relnamespace but not p_varnamespace, so that they
  * do not affect the set of columns available for unqualified references.
+ *
+ * p_ctenamespace: list of CommonTableExprs (WITH items) that are visible
+ * at the moment.  This is different from p_relnamespace because you have
+ * to make an RTE before you can access a CTE.
  *
  * p_paramtypes: an array of p_numparams type OIDs for $n parameter symbols
  * (zeroth entry in array corresponds to $1).  If p_variableparams is true, the

--- a/src/include/parser/parse_relation.h
+++ b/src/include/parser/parse_relation.h
@@ -7,7 +7,7 @@
  * Portions Copyright (c) 1996-2009, PostgreSQL Global Development Group
  * Portions Copyright (c) 1994, Regents of the University of California
  *
- * $PostgreSQL: pgsql/src/include/parser/parse_relation.h,v 1.57 2008/01/01 19:45:58 momjian Exp $
+ * $PostgreSQL: pgsql/src/include/parser/parse_relation.h,v 1.59 2008/10/04 21:56:55 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -38,6 +38,7 @@ extern int RTERangeTablePosn(ParseState *pstate,
 extern RangeTblEntry *GetRTEByRangeTablePosn(ParseState *pstate,
 					   int varno,
 					   int sublevels_up);
+extern CommonTableExpr *GetCTEForRTE(ParseState *pstate, RangeTblEntry *rte, int rtelevelsup);
 extern Node *scanRTEForColumn(ParseState *pstate, RangeTblEntry *rte,
 				 char *colname, int location);
 extern Node *colNameToVar(ParseState *pstate, char *colname, bool localonly,
@@ -78,10 +79,10 @@ extern RangeTblEntry *addRangeTableEntryForJoin(ParseState *pstate,
 						  Alias *alias,
 						  bool inFromCl);
 extern RangeTblEntry *addRangeTableEntryForCTE(ParseState *pstate,
-											   CommonTableExpr *cte,
-											   Index levelsup,
-											   RangeVar *rangeVar,
-											   bool inFromCl);
+						 CommonTableExpr *cte,
+						 Index levelsup,
+						 Alias *alias,
+						 bool inFromCl);
 extern bool isSimplyUpdatableRelation(Oid relid, bool noerror);
 extern Index extractSimplyUpdatableRTEIndex(List *rtable);
 extern void addRTEtoQuery(ParseState *pstate, RangeTblEntry *rte,

--- a/src/include/utils/errcodes.h
+++ b/src/include/utils/errcodes.h
@@ -12,7 +12,7 @@
  * Portions Copyright (c) 2005-2008, Greenplum inc.
  * Copyright (c) 2003-2010, PostgreSQL Global Development Group
  *
- * $PostgreSQL: pgsql/src/include/utils/errcodes.h,v 1.32 2010/03/13 14:55:57 momjian Exp $
+ * $PostgreSQL: pgsql/src/include/utils/errcodes.h,v 1.26 2008/10/04 21:56:55 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */

--- a/src/pl/plpgsql/src/plerrcodes.h
+++ b/src/pl/plpgsql/src/plerrcodes.h
@@ -9,7 +9,7 @@
  *
  * Copyright (c) 2003-2008, PostgreSQL Global Development Group
  *
- * $PostgreSQL: pgsql/src/pl/plpgsql/src/plerrcodes.h,v 1.13 2008/01/15 01:36:53 tgl Exp $
+ * $PostgreSQL: pgsql/src/pl/plpgsql/src/plerrcodes.h,v 1.15 2008/10/04 21:56:55 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -477,6 +477,10 @@
 
 {
 	"grouping_error", ERRCODE_GROUPING_ERROR
+},
+
+{
+	"invalid_recursion", ERRCODE_INVALID_RECURSION
 },
 
 {

--- a/src/test/regress/expected/qp_with_clause.out
+++ b/src/test/regress/expected/qp_with_clause.out
@@ -881,16 +881,249 @@ with capitals(code,id) as
 (select country.code,id,city.name from city,country 
  where city.countrycode = country.code AND city.id = country.capital)
 select * from capitals;
-ERROR:  specified number of columns in WITH query "capitals" must not exceed the number of available columns
-LINE 1: with capitals(code,id) as 
-             ^
+ code |  id  |               name                
+------+------+-----------------------------------
+ AIA  |   62 | The Valley
+ ARE  |   65 | Abu Dhabi
+ AUS  |  135 | Canberra
+ BHS  |  148 | Nassau
+ BHR  |  149 | al-Manama
+ BGD  |  150 | Dhaka
+ BLZ  |  185 | Belmopan
+ BWA  |  204 | Gaborone
+ CYM  |  553 | George Town
+ CHL  |  554 | Santiago de Chile
+ COK  |  583 | Avarua
+ CRI  |  584 | San Jose
+ DJI  |  585 | Djibouti
+ DMA  |  586 | Roseau
+ ERI  |  652 | Asmara
+ ETH  |  756 | Addis Abeba
+ GAB  |  902 | Libreville
+ GEO  |  905 | Tbilisi
+ GIB  |  915 | Gibraltar
+ GLP  |  919 | Basse-Terre
+ GUM  |  921 | Agaaa
+ HTI  |  929 | Port-au-Prince
+ SJM  |  938 | Longyearbyen
+ IDN  |  939 | Jakarta
+ IND  | 1109 | New Delhi
+ IRN  | 1380 | Teheran
+ JAM  | 1530 | Kingston
+ JPN  | 1532 | Tokyo
+ CAF  | 1889 | Bangui
+ COM  | 2295 | Moroni
+ COD  | 2298 | Kinshasa
+ CYP  | 2430 | Nicosia
+ LVA  | 2434 | Riga
+ LBN  | 2438 | Beirut
+ LIE  | 2446 | Vaduz
+ MAC  | 2454 | Macao
+ MWI  | 2462 | Lilongwe
+ MLI  | 2482 | Bamako
+ MLT  | 2484 | Valletta
+ MAR  | 2486 | Rabat
+ MTQ  | 2508 | Fort-de-France
+ MRT  | 2509 | Nouakchott
+ MCO  | 2695 | Monaco-Ville
+ MOZ  | 2698 | Maputo
+ NPL  | 2729 | Kathmandu
+ NIU  | 2805 | Alofi
+ NFK  | 2806 | Kingston
+ CIV  | 2814 | Yamoussoukro
+ PAK  | 2831 | Islamabad
+ PLW  | 2881 | Koror
+ PER  | 2890 | Lima
+ GNQ  | 2972 | Malabo
+ QAT  | 2973 | Doha
+ GUF  | 3014 | Cayenne
+ SHN  | 3063 | Jamestown
+ LCA  | 3065 | Castries
+ VCT  | 3066 | Kingstown
+ STP  | 3172 | Sao Tome
+ SAU  | 3173 | Riyadh
+ SEN  | 3198 | Dakar
+ SVN  | 3212 | Ljubljana
+ SUR  | 3243 | Paramaribo
+ SWZ  | 3244 | Mbabane
+ SYR  | 3250 | Damascus
+ THA  | 3320 | Bangkok
+ TKL  | 3333 | Fakaofo
+ TON  | 3334 | Nukualofa
+ TTO  | 3336 | Port-of-Spain
+ TUN  | 3349 | Tunis
+ TUR  | 3358 | Ankara
+ TKM  | 3419 | Ashgabat
+ UKR  | 3426 | Kyiv
+ NCL  | 3493 | Noumea
+ WLF  | 3536 | Mata-Utu
+ EST  | 3791 | Tallinn
+ AFG  |    1 | Kabul
+ ANT  |   33 | Willemstad
+ ALB  |   34 | Tirana
+ DZA  |   35 | Alger
+ ATG  |   63 | Saint Johns
+ ARG  |   69 | Buenos Aires
+ BRB  |  174 | Bridgetown
+ BEN  |  187 | Porto-Novo
+ BTN  |  192 | Thimphu
+ BOL  |  194 | La Paz
+ GBR  |  456 | London
+ VGB  |  537 | Road Town
+ BRN  |  538 | Bandar Seri Begawan
+ BDI  |  552 | Bujumbura
+ DOM  |  587 | Santo Domingo de Guzman
+ ECU  |  594 | Quito
+ EGY  |  608 | Cairo
+ SLV  |  645 | San Salvador
+ PHL  |  766 | Manila
+ GMB  |  904 | Banjul
+ GRD  |  916 | Saint Georges
+ GTM  |  922 | Ciudad de Guatemala
+ HND  |  933 | Tegucigalpa
+ IRQ  | 1365 | Baghdad
+ ISR  | 1450 | Jerusalem
+ ITA  | 1464 | Roma
+ AUT  | 1523 | Wien
+ YEM  | 1780 | Sanaa
+ CXR  | 1791 | Flying Fish Cove
+ YUG  | 1792 | Beograd
+ KAZ  | 1864 | Astana
+ COG  | 2296 | Brazzaville
+ CCK  | 2317 | West Island
+ GRC  | 2401 | Athenai
+ HRV  | 2409 | Zagreb
+ LBR  | 2440 | Monrovia
+ LBY  | 2441 | Tripoli
+ LUX  | 2452 | Luxembourg [Luxemburg/Letzebuerg]
+ MKD  | 2460 | Skopje
+ MYS  | 2464 | Kuala Lumpur
+ MUS  | 2511 | Port-Louis
+ FSM  | 2689 | Palikir
+ MSR  | 2697 | Plymouth
+ NAM  | 2726 | Windhoek
+ NRU  | 2728 | Yaren
+ NIC  | 2734 | Managua
+ NGA  | 2754 | Abuja
+ PNG  | 2884 | Port Moresby
+ PRY  | 2885 | Asuncion
+ PCN  | 2912 | Adamstown
+ POL  | 2928 | Warszawa
+ FRA  | 2974 | Paris
+ REU  | 3017 | Saint-Denis
+ ROM  | 3018 | Bucuresti
+ SPM  | 3067 | Saint-Pierre
+ WSM  | 3169 | Apia
+ SMR  | 3171 | San Marino
+ SGP  | 3208 | Singapore
+ SVK  | 3209 | Bratislava
+ LKA  | 3217 | Colombo
+ SDN  | 3225 | Khartum
+ CHE  | 3248 | Bern
+ TGO  | 3332 | Lome
+ TCD  | 3337 | NDjamena
+ CZE  | 3339 | Praha
+ TCA  | 3423 | Cockburn Town
+ TUV  | 3424 | Funafuti
+ URY  | 3492 | Montevideo
+ NZL  | 3499 | Wellington
+ VUT  | 3537 | Port-Vila
+ VAT  | 3538 | Citta del Vaticano
+ VEN  | 3539 | Caracas
+ RUS  | 3580 | Moscow
+ VNM  | 3770 | Hanoi
+ NLD  |    5 | Amsterdam
+ ASM  |   54 | Fagatogo
+ AND  |   55 | Andorra la Vella
+ AGO  |   56 | Luanda
+ ARM  |  126 | Yerevan
+ ABW  |  129 | Oranjestad
+ AZE  |  144 | Baku
+ BEL  |  179 | Bruxelles [Brussel]
+ BMU  |  191 | Hamilton
+ BIH  |  201 | Sarajevo
+ BRA  |  211 | Brasilia
+ BGR  |  539 | Sofija
+ BFA  |  549 | Ouagadougou
+ ESP  |  653 | Madrid
+ ZAF  |  716 | Pretoria
+ FLK  |  763 | Stanley
+ FJI  |  764 | Suva
+ FRO  |  901 | Torshavn
+ GHA  |  910 | Accra
+ GRL  |  917 | Nuuk
+ GIN  |  926 | Conakry
+ GNB  |  927 | Bissau
+ GUY  |  928 | Georgetown
+ HKG  |  937 | Victoria
+ IRL  | 1447 | Dublin
+ ISL  | 1449 | Reykjavik
+ TMP  | 1522 | Dili
+ JOR  | 1786 | Amman
+ KHM  | 1800 | Phnom Penh
+ CMR  | 1804 | Yaounde
+ CAN  | 1822 | Ottawa
+ CPV  | 1859 | Praia
+ KEN  | 1881 | Nairobi
+ CHN  | 1891 | Peking
+ KGZ  | 2253 | Bishkek
+ KIR  | 2256 | Bairiki
+ COL  | 2257 | Santafe de Bogota
+ PRK  | 2318 | Pyongyang
+ KOR  | 2331 | Seoul
+ CUB  | 2413 | La Habana
+ KWT  | 2429 | Kuwait
+ LAO  | 2432 | Vientiane
+ LSO  | 2437 | Maseru
+ LTU  | 2447 | Vilnius
+ ESH  | 2453 | El-Aaiun
+ MDG  | 2455 | Antananarivo
+ MDV  | 2463 | Male
+ MHL  | 2507 | Dalap-Uliga-Darrit
+ MYT  | 2514 | Mamoutzou
+ MEX  | 2515 | Ciudad de Mexico
+ MDA  | 2690 | Chisinau
+ MNG  | 2696 | Ulan Bator
+ MMR  | 2710 | Rangoon (Yangon)
+ NER  | 2738 | Niamey
+ NOR  | 2807 | Oslo
+ OMN  | 2821 | Masqat
+ PAN  | 2882 | Ciudad de Panama
+ MNP  | 2913 | Garapan
+ PRT  | 2914 | Lisboa
+ PRI  | 2919 | San Juan
+ PYF  | 3016 | Papeete
+ RWA  | 3047 | Kigali
+ SWE  | 3048 | Stockholm
+ KNA  | 3064 | Basseterre
+ DEU  | 3068 | Berlin
+ SLB  | 3161 | Honiara
+ ZMB  | 3162 | Lusaka
+ SYC  | 3206 | Victoria
+ SLE  | 3207 | Freetown
+ SOM  | 3214 | Mogadishu
+ FIN  | 3236 | Helsinki [Helsingfors]
+ TJK  | 3261 | Dushanbe
+ TWN  | 3263 | Taipei
+ TZA  | 3306 | Dodoma
+ DNK  | 3315 | Kobenhavn
+ UGA  | 3425 | Kampala
+ HUN  | 3483 | Budapest
+ UZB  | 3503 | Toskent
+ BLR  | 3520 | Minsk
+ USA  | 3813 | Washington
+ VIR  | 4067 | Charlotte Amalie
+ ZWE  | 4068 | Harare
+ PSE  | 4074 | Gaza
+(232 rows)
+
 --query 2
 with lang_total(lang_count,code,countrycode,name) as
 ( select count(*) as lang_count,country.code,countrylanguage.countrycode
   from country join countrylanguage on (country.code=countrylanguage.countrycode and governmentform='Federal Republic')
   group by country.code,countrylanguage.countrycode order by country.code)
 select * from lang_total;
-ERROR:  specified number of columns in WITH query "lang_total" must not exceed the number of available columns
+ERROR:  WITH query "lang_total" has 3 columns available but 4 columns specified
 LINE 1: with lang_total(lang_count,code,countrycode,name) as
              ^
 -- queries with CTEs using hash joins

--- a/src/test/regress/expected/with_clause.out
+++ b/src/test/regress/expected/with_clause.out
@@ -1143,9 +1143,20 @@ LINE 1: ..._sum(total) as (select sum(value) from with_test1 into total...
 with my_sum(group_total) as (select i, sum(value) from with_test1 group by i)
 select *
 from my_sum;
-ERROR:  specified number of columns in WITH query "my_sum" must not exceed the number of available columns
-LINE 1: with my_sum(group_total) as (select i, sum(value) from with_...
-             ^
+ group_total | sum 
+-------------+-----
+           9 | 180
+           8 | 170
+           7 | 160
+           6 | 150
+           4 | 130
+           3 | 120
+           5 | 140
+           1 | 100
+           2 | 110
+           0 |  90
+(10 rows)
+
 with my_sum as (select i, sum(value) as i from with_test1 group by i)
 select *
 from my_sum;


### PR DESCRIPTION
This commit just ports the parser changes from the initial CTE commits in
Postgres (44d5be0e5308e951c0c5dc522b4bcacf2bcbc476).

This partial commit is based on the following commit by @hsyuan https://github.com/hsyuan/postgres/commit/12dc46df5e6b3477140caa392012812ae0265e91

NOTE: This PR is not intended to be merged into master but will first be merged into a separate [cte_merge](https://github.com/greenplum-db/gpdb/tree/cte_merge) branch

Signed-off-by: Karthikeyan Jambu Rajaraman