### PR TITLE
Fixup subplans

### DIFF
--- a/src/backend/optimizer/plan/planpartition.c
+++ b/src/backend/optimizer/plan/planpartition.c
@@ -305,7 +305,18 @@ FindEqKey(PlannerInfo *root, Bitmapset *inner_relids,
 
 					if (!bms_is_subset(inner_em->em_relids, inner_relids))
 						continue; /* not computable on the inner side */
-
+					/*
+					 * The condition will be duplicated as the partition
+					 * selection key in the PartitionSelector node. It is
+					 * not OK to duplicate the expression, if it contains
+					 * SubPlans, because the code that adds motion nodes to a
+					 * subplan gets confused if there are multiple SubPlans
+					 * referring the same subplan ID. It would probably
+					 * perform badly too, since subplans are typically quite
+					 * expensive.
+					 */
+					if (contain_subplans((Node *) inner_em->em_expr))
+						continue;
 					/*
 					 * This can be computed from the inner side.
 					 *

--- a/src/include/cdb/cdbmutate.h
+++ b/src/include/cdb/cdbmutate.h
@@ -13,6 +13,7 @@
 #include "nodes/plannodes.h"
 #include "nodes/params.h"
 #include "nodes/relation.h"
+#include "optimizer/walkers.h"
 
 extern Plan *apply_motion(struct PlannerInfo *root, Plan *plan, Query *query);
 
@@ -47,7 +48,7 @@ extern void assign_plannode_id(PlannedStmt *stmt);
 extern List *getExprListFromTargetList(List *tlist, int numCols, AttrNumber *colIdx,
 									   bool useExecutorVarFormat);
 extern void remove_unused_initplans(Plan *plan, PlannerInfo *root);
-extern void remove_unused_subplans(Plan *plan, PlannerInfo *root);
+extern void remove_unused_subplans(PlannerInfo *root, SubPlanWalkerContext *context);
 
 extern int32 cdbhash_const(Const *pconst, int iSegments);
 extern int32 cdbhash_const_list(List *plConsts, int iSegments);
@@ -55,4 +56,5 @@ extern int32 cdbhash_const_list(List *plConsts, int iSegments);
 extern Node *exec_make_plan_constant(struct PlannedStmt *stmt, bool is_SRI, List **cursorPositions);
 extern Node *planner_make_plan_constant(struct PlannerInfo *root, Node *n, bool is_SRI);
 extern void remove_subquery_in_RTEs(Node *node);
+extern void fixup_subplans(Plan *plan, PlannerInfo *root, SubPlanWalkerContext *context);
 #endif   /* CDBMUTATE_H */

--- a/src/include/optimizer/walkers.h
+++ b/src/include/optimizer/walkers.h
@@ -46,6 +46,15 @@ typedef struct plan_tree_base_prefix
 	Node *node; /* PlannerInfo* or PlannedStmt* */
 } plan_tree_base_prefix;
 
+/*
+ * Structure to hold the SUBPLAN plan_id used in the plan
+ */
+typedef struct SubPlanWalkerContext
+{
+	plan_tree_base_prefix base; /* Required prefix for plan_tree_walker/mutator */
+	Bitmapset	   *bms_subplans; /* Bitmapset for used subplans */
+} SubPlanWalkerContext;
+
 extern void planner_init_plan_tree_base(plan_tree_base_prefix *base, PlannerInfo *root);
 extern void exec_init_plan_tree_base(plan_tree_base_prefix *base, PlannedStmt *stmt);
 extern Plan *plan_tree_base_subplan_get_plan(plan_tree_base_prefix *base, SubPlan *subplan);

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -1330,3 +1330,17 @@ where exists (select 1 from CT where CT.a = foo.a);
 ---+---
 (0 rows)
 
+--
+-- Multiple SUBPLAN nodes must not refer to same plan_id
+--
+CREATE TABLE bar_s (c integer, d character varying(10));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO bar_s VALUES (9,9);
+SELECT * FROM bar_s T1 WHERE c = (SELECT max(c) FROM bar_s T2 WHERE T2.d = T1.d GROUP BY c) AND c < 10;
+ c | d
+---+---
+ 9 | 9
+(1 row)
+
+DROP TABLE bar_s;

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -1343,4 +1343,20 @@ SELECT * FROM bar_s T1 WHERE c = (SELECT max(c) FROM bar_s T2 WHERE T2.d = T1.d 
  9 | 9
 (1 row)
 
+CREATE TABLE foo_s (a integer, b integer)  PARTITION BY RANGE(b)
+    (PARTITION sub_one START (1) END (10),
+     PARTITION sub_two START (11) END (22));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "foo_s_1_prt_sub_one" for table "foo_s"
+NOTICE:  CREATE TABLE will create partition "foo_s_1_prt_sub_two" for table "foo_s"
+INSERT INTO foo_s VALUES (9,9);
+INSERT INTO foo_s VALUES (2,9);
+SELECT bar_s.c from bar_s, foo_s WHERE foo_s.a=2 AND foo_s.b = (SELECT max(b) FROM foo_s WHERE bar_s.c = 9);
+ c 
+---
+ 9
+(1 row)
+
 DROP TABLE bar_s;
+DROP TABLE foo_s;

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -1358,5 +1358,17 @@ SELECT bar_s.c from bar_s, foo_s WHERE foo_s.a=2 AND foo_s.b = (SELECT max(b) FR
  9
 (1 row)
 
+CREATE TABLE baz_s (i int4);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO baz_s VALUES (9);
+SELECT bar_s.c FROM bar_s, foo_s WHERE foo_s.b = (SELECT max(i) FROM baz_s WHERE bar_s.c = 9) AND foo_s.b = bar_s.d::int4;
+ c 
+---
+ 9
+ 9
+(2 rows)
+
 DROP TABLE bar_s;
 DROP TABLE foo_s;
+DROP TABLE baz_s;

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -1314,3 +1314,17 @@ where exists (select 1 from CT where CT.a = foo.a);
 ---+---
 (0 rows)
 
+--
+-- Multiple SUBPLAN nodes must not refer to same plan_id
+--
+CREATE TABLE bar_s (c integer, d character varying(10));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO bar_s VALUES (9,9);
+SELECT * FROM bar_s T1 WHERE c = (SELECT max(c) FROM bar_s T2 WHERE T2.d = T1.d GROUP BY c) AND c < 10;
+ c | d
+---+---
+ 9 | 9
+(1 row)
+
+DROP TABLE bar_s;

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -1322,9 +1322,25 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO bar_s VALUES (9,9);
 SELECT * FROM bar_s T1 WHERE c = (SELECT max(c) FROM bar_s T2 WHERE T2.d = T1.d GROUP BY c) AND c < 10;
- c | d
+ c | d 
 ---+---
  9 | 9
 (1 row)
 
+CREATE TABLE foo_s (a integer, b integer)  PARTITION BY RANGE(b)
+    (PARTITION sub_one START (1) END (10),
+     PARTITION sub_two START (11) END (22));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "foo_s_1_prt_sub_one" for table "foo_s"
+NOTICE:  CREATE TABLE will create partition "foo_s_1_prt_sub_two" for table "foo_s"
+INSERT INTO foo_s VALUES (9,9);
+INSERT INTO foo_s VALUES (2,9);
+SELECT bar_s.c from bar_s, foo_s WHERE foo_s.a=2 AND foo_s.b = (SELECT max(b) FROM foo_s WHERE bar_s.c = 9);
+ c 
+---
+ 9
+(1 row)
+
 DROP TABLE bar_s;
+DROP TABLE foo_s;

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -1342,5 +1342,17 @@ SELECT bar_s.c from bar_s, foo_s WHERE foo_s.a=2 AND foo_s.b = (SELECT max(b) FR
  9
 (1 row)
 
+CREATE TABLE baz_s (i int4);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO baz_s VALUES (9);
+SELECT bar_s.c FROM bar_s, foo_s WHERE foo_s.b = (SELECT max(i) FROM baz_s WHERE bar_s.c = 9) AND foo_s.b = bar_s.d::int4;
+ c 
+---
+ 9
+ 9
+(2 rows)
+
 DROP TABLE bar_s;
 DROP TABLE foo_s;
+DROP TABLE baz_s;

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -619,5 +619,9 @@ CREATE TABLE foo_s (a integer, b integer)  PARTITION BY RANGE(b)
 INSERT INTO foo_s VALUES (9,9);
 INSERT INTO foo_s VALUES (2,9);
 SELECT bar_s.c from bar_s, foo_s WHERE foo_s.a=2 AND foo_s.b = (SELECT max(b) FROM foo_s WHERE bar_s.c = 9);
+CREATE TABLE baz_s (i int4);
+INSERT INTO baz_s VALUES (9);
+SELECT bar_s.c FROM bar_s, foo_s WHERE foo_s.b = (SELECT max(i) FROM baz_s WHERE bar_s.c = 9) AND foo_s.b = bar_s.d::int4;
 DROP TABLE bar_s;
 DROP TABLE foo_s;
+DROP TABLE baz_s;

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -607,3 +607,10 @@ create table bar(a int, b int) distributed by (a);
 with CT as (select a from foo except select a from bar)
 select * from foo
 where exists (select 1 from CT where CT.a = foo.a);
+--
+-- Multiple SUBPLAN nodes must not refer to same plan_id
+--
+CREATE TABLE bar_s (c integer, d character varying(10));
+INSERT INTO bar_s VALUES (9,9);
+SELECT * FROM bar_s T1 WHERE c = (SELECT max(c) FROM bar_s T2 WHERE T2.d = T1.d GROUP BY c) AND c < 10;
+DROP TABLE bar_s;

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -613,4 +613,11 @@ where exists (select 1 from CT where CT.a = foo.a);
 CREATE TABLE bar_s (c integer, d character varying(10));
 INSERT INTO bar_s VALUES (9,9);
 SELECT * FROM bar_s T1 WHERE c = (SELECT max(c) FROM bar_s T2 WHERE T2.d = T1.d GROUP BY c) AND c < 10;
+CREATE TABLE foo_s (a integer, b integer)  PARTITION BY RANGE(b)
+    (PARTITION sub_one START (1) END (10),
+     PARTITION sub_two START (11) END (22));
+INSERT INTO foo_s VALUES (9,9);
+INSERT INTO foo_s VALUES (2,9);
+SELECT bar_s.c from bar_s, foo_s WHERE foo_s.a=2 AND foo_s.b = (SELECT max(b) FROM foo_s WHERE bar_s.c = 9);
 DROP TABLE bar_s;
+DROP TABLE foo_s;


### PR DESCRIPTION
Fixup subplans referring to same plan_id: Before parallelization on nodes in cdbparallelize if there are any subplan nodes in the plan which refer to the same plan_id, parallelization step breaks as a node must be processed only once by it.
This patch fixes the issue by generating a new subplan node in glob subplans, and updating the plan_id of the subplan to refer to the newly created node.

Skip subplan nodes in equivalence lists: Skip duplicating subplans clauses as multiple subplan node referring to same plan_id of subplans breaks cdbparallize. cdbparallize expects to apply motion only to a node once, so if two subplan nodes refers to the same plan_id the assertion breaks.