### PR TITLE
Don't inject partition selector if the join condition contains subplan on inner side

### DIFF
--- a/src/test/regress/expected/subselect_gp2.out
+++ b/src/test/regress/expected/subselect_gp2.out
@@ -49,3 +49,21 @@ explain select sess_id from pg_stat_activity where current_query = (select curre
  Optimizer status: legacy query optimizer
 (13 rows)
 
+CREATE TABLE foo (a integer, b integer)  PARTITION BY RANGE(b)
+    (PARTITION sub_one START (1) END (10),
+     PARTITION sub_two START (11) END (22));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_sub_one" for table "foo"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_sub_two" for table "foo"
+CREATE TABLE bar (c integer, d character varying(10));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into foo values (9,9);
+insert into bar values (9,9);
+select bar.c from bar, foo where foo.b = (select max(b) from foo where bar.c = 9);
+ c 
+---
+ 9
+(1 row)
+

--- a/src/test/regress/sql/subselect_gp2.sql
+++ b/src/test/regress/sql/subselect_gp2.sql
@@ -1,3 +1,7 @@
+-- start_ignore
+create schema subselect_gp2;
+set search_path to subselect_gp2;
+-- end_ignore
 -- Test using an external table in a subquery.
 --
 -- We used to have a bug where the scan on the external table was not
@@ -23,3 +27,11 @@ where (select count(*) from echotable as i where i.c2 = o.c2) >= 2;
 
 -- Planner test to make sure the initplan is not removed for function scan
 explain select sess_id from pg_stat_activity where current_query = (select current_query());
+
+CREATE TABLE foo (a integer, b integer)  PARTITION BY RANGE(b)
+    (PARTITION sub_one START (1) END (10),
+     PARTITION sub_two START (11) END (22));
+CREATE TABLE bar (c integer, d character varying(10));
+insert into foo values (9,9);
+insert into bar values (9,9);
+select bar.c from bar, foo where foo.b = (select max(b) from foo where bar.c = 9);


### PR DESCRIPTION
Previously, if the join condition on the inner side is a subplan, we inject
partition selector with that subplan as filter, but we never deep copy subplan
tree, causing wrong slice table and wrong result. However, I think we should
stop injecting partition selector in this case.

Fixes issue #2440.
I don't know whether or not this is the correct direction to resolve the issue,
just open PR to get more advice.