### PR TITLE
Fix support for dumping ProcLangs with anonymous block support

### DIFF
--- a/src/bin/pg_dump/cdb/cdb_dump_include.c
+++ b/src/bin/pg_dump/cdb/cdb_dump_include.c
@@ -2883,13 +2883,18 @@ getProcLangs(int *numProcLangs)
 	/* Make sure we are in proper schema */
 	selectSourceSchema("pg_catalog");
 
+	/*
+	 * The laninline column was added in upstream 90000 but was backported to
+	 * Greenplum 5, so the check needs to go further back than 90000.
+	 */
 	if (g_gp_supportsLanOwner)
 	{
+		/* pg_language has a laninline column */
 		/* pg_language has a lanowner column */
 		appendPQExpBuffer(query, "SELECT tableoid, oid, "
 						  "lanname, lanpltrusted, lanplcallfoid, "
-						  "lanvalidator,  lanacl, "
-						  "(%s lanowner) as lanowner "
+						  "laninline, lanvalidator, lanacl, "
+						  "(%s lanowner) AS lanowner "
 						  "FROM pg_language "
 						  "WHERE lanispl "
 						  "ORDER BY oid",

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -4215,13 +4215,18 @@ getProcLangs(int *numProcLangs)
 	/* Make sure we are in proper schema */
 	selectSourceSchema("pg_catalog");
 
+	/*
+	 * The laninline column was added in upstream 90000 but was backported to
+	 * Greenplum 5, so the check needs to go further back than 90000.
+	 */
 	if (g_fout->remoteVersion >= 80300)
 	{
+		/* pg_language has a laninline column */
 		/* pg_language has a lanowner column */
 		appendPQExpBuffer(query, "SELECT tableoid, oid, "
 						  "lanname, lanpltrusted, lanplcallfoid, "
-						  "lanvalidator,  lanacl, "
-						  "(%s lanowner) as lanowner "
+						  "laninline, lanvalidator, lanacl, "
+						  "(%s lanowner) AS lanowner "
 						  "FROM pg_language "
 						  "WHERE lanispl "
 						  "ORDER BY oid",


### PR DESCRIPTION
The support for anonymous blocks which was backported in commit cacb2839ac869b3f0ab9e9fc4b152f7d83e71 missed updating the query in `getProcLangs()` to correctly extract the laninline function. Fix by updating the query to what it looks like in upstream 9.0 where anonymous blocks first appeared.

Added a small comment to explain why for when this conflicts in a merge. There shouldn't be a conflict until we merge 9.0 since getProcLangs() was quite stable during 8.4, but one never know.

Includes a fix for cdb_dump as well, although with #2410 I'm not sure how much more work should go in there.