### PR TITLE
Porting rewriter changes from Postgres.

### DIFF
--- a/src/backend/rewrite/rewriteDefine.c
+++ b/src/backend/rewrite/rewriteDefine.c
@@ -9,7 +9,7 @@
  *
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/rewrite/rewriteDefine.c,v 1.124 2008/01/01 19:45:51 momjian Exp $
+ *	  $PostgreSQL: pgsql/src/backend/rewrite/rewriteDefine.c,v 1.130 2008/10/04 21:56:54 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -717,16 +717,14 @@ setRuleCheckAsUser_Query(Query *qry, Oid userid)
 	}
 
 	/* If there are sublinks, search for them and process their RTEs */
-	/* ignore subqueries in rtable because we already processed them */
 	if (qry->hasSubLinks)
 		query_tree_walker(qry, setRuleCheckAsUser_walker, (void *) &userid,
-						  QTW_IGNORE_RT_SUBQUERIES);
+						  QTW_IGNORE_RC_SUBQUERIES);
 }
 
 
 /*
  * Change the firing semantics of an existing rule.
- *
  */
 void
 EnableDisableRule(Relation rel, const char *rulename,


### PR DESCRIPTION
This commit just ports the rewriter changes from the initial CTE commits in Postgres (44d5be0).

This partial commit is based on the following commit by @hsyuan https://github.com/hsyuan/postgres/commit/16ed71df8911fc52d0a1e1eaf844e626aedef8ab

NOTE: This PR is not intended to be merged into master but will first be merged into a separate cte_merge branch