### PR TITLE
gpperfmon: Add Ipv6 to gpperfmon install

### DIFF
--- a/gpAux/gpperfmon/src/gpmon/gpperfmon_install
+++ b/gpAux/gpperfmon/src/gpmon/gpperfmon_install
@@ -166,6 +166,9 @@ if __name__ == '__main__':
         cmd = Command("""echo "host     all         gpmon         127.0.0.1/28    md5" >> %s""" % pg_hba, showOutput=True)
         commands.append(cmd)
 
+        cmd = Command("""echo "host     all         gpmon         ::1/128    md5" >> %s""" % pg_hba, showOutput=True)
+        commands.append(cmd)
+
         ################################################
         # these commands add a new line to the top of .pgpass and save a copy of old .pgpass
         cmd = Command("""touch %s""" % (pg_pass))

--- a/gpAux/gpperfmon/src/gpmon/gpperfmon_install
+++ b/gpAux/gpperfmon/src/gpmon/gpperfmon_install
@@ -24,12 +24,12 @@ import os, sys, time, re
 from subprocess import Popen
 
 try:
-    from optparse import Option, OptionParser 
+    from optparse import Option, OptionParser
     from gppylib.gpparseopts import OptParser, OptChecker
     from gppylib.userinput import ask_input
     from gppylib.gplog import get_default_logger, setup_tool_logging
     from gppylib.commands.unix import getLocalHostname, getUserName
-except ImportError, e:    
+except ImportError, e:
     sys.exit('Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
 
 EXECNAME = os.path.split(__file__)[-1]
@@ -74,7 +74,7 @@ def cli_help():
 
 def usage():
     print cli_help() or __doc__
-    
+
 
 ###### main()
 if __name__ == '__main__':
@@ -106,7 +106,7 @@ if __name__ == '__main__':
         usage()
         sys.exit(1)
 
-    if not options.port: 
+    if not options.port:
         logger.error("--port must be specified")
         sys.exit(1)
 
@@ -149,7 +149,7 @@ if __name__ == '__main__':
         if not os.path.isfile( pg_hba ):
             logger.error("can not find pg_hba.conf at %s" % pg_hba)
             sys.exit(1)
-        
+
         if not os.path.isdir(home_dir):
             logger.error("can not find $HOME")
             sys.exit(1)

--- a/gpMgmt/test/behave/mgmt_utils/gpperfmon.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpperfmon.feature
@@ -17,7 +17,8 @@ Feature: gpperfmon
         Given the database "gpperfmon" does not exist
         When the user runs "gpperfmon_install --port 15432 --enable --password foo"
         Then gpperfmon_install should return a return code of 0
-        Then verify that the last line of the master postgres configuration file contains the string "gpperfmon_log_alert_level=warning"
+        Then verify that the last line of the file "postgresql.conf" in the master data directory contains the string "gpperfmon_log_alert_level=warning"
+        Then verify that the last line of the file "pg_hba.conf" in the master data directory contains the string "host     all         gpmon         ::1/128    md5"
         And verify that there is a "heap" table "database_history" in "gpperfmon"
 
     @gpperfmon_run

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -4213,11 +4213,11 @@ def impl(context, filename, output):
     check_stdout_msg(context, output)
 
 
-@then('verify that the last line of the master postgres configuration file contains the string "{output}"')
-def impl(context, output):
+@then('verify that the last line of the file "{filename}" in the master data directory contains the string "{output}"')
+def impl(context, filename, output):
     contents = ''
-    filename = master_data_dir + "/postgresql.conf"
-    with open(filename) as fr:
+    file_path = os.path.join(master_data_dir, filename)
+    with open(file_path) as fr:
         for line in fr:
             contents = line.strip()
     pat = re.compile(output)
@@ -4883,7 +4883,7 @@ def impl(context):
             When the user runs "gpstart -a"
             Then gpstart should return a return code of 0
             And verify that a role "gpmon" exists in database "gpperfmon"
-            And verify that the last line of the master postgres configuration file contains the string "gpperfmon_log_alert_level=warning"
+            And verify that the last line of the file "postgresql.conf" in the master data directory contains the string "gpperfmon_log_alert_level=warning"
             And verify that there is a "heap" table "database_history" in "gpperfmon"
             Then wait until the process "gpmmon" is up
             And wait until the process "gpsmon" is up


### PR DESCRIPTION
If IPv6 is enabled, gpperfmon will complain that it can't connect to
the database, because gpmon does not have permission to access through ::1

```
 klamath in ~/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1/gpperfmon/logs
$tail gpdb-alert-2017-05-09_162531.csv
2017-05-09 16:25:31.546909 PDT,"gpmon","gpperfmon",p19084,th-1167621184,"::1","58749",2017-05-09 16:25:31 PDT,0,con5,,seg-1,,,,sx1,"FATAL","28000","no pg_hba.conf entry for host ""::1"", user ""gpmon"", database ""gpperfmon""",,,,,,,0,,"auth.c",608,
2017-05-09 16:26:31.762381 PDT,"gpmon","gpperfmon",p19556,th-1167621184,"::1","58794",2017-05-09 16:26:31 PDT,0,con13,,seg-1,,,,sx1,"FATAL","28000","no pg_hba.conf entry for host ""::1"", user ""gpmon"", database ""gpperfmon""",,,,,,,0,,"auth.c",608,
```

This commit addresses this issue.