### PR TITLE
pg_upgrade catchup with 5.0

### DIFF
--- a/contrib/pg_upgrade/check.c
+++ b/contrib/pg_upgrade/check.c
@@ -708,7 +708,7 @@ check_for_reg_data_type_usage(migratorContext *ctx, Cluster whichCluster)
 			pg83_atts_str = "0";
 		else
 			pg83_atts_str =		"'pg_catalog.regconfig'::pg_catalog.regtype, "
-								"			'pg_catalog.regdictionary'::pg_catalog.regtype) AND ";
+								"			'pg_catalog.regdictionary'::pg_catalog.regtype ";
 
 		snprintf(query, sizeof(query),
 								"SELECT n.nspname, c.relname, a.attname "

--- a/src/bin/pg_dump/binary_upgrade.c
+++ b/src/bin/pg_dump/binary_upgrade.c
@@ -241,7 +241,7 @@ dumpCastOid(Archive *AH, CastInfo *info)
 void
 dumpConversionOid(PGconn *conn, Archive *AH, ConvInfo *info)
 {
-	PQExpBuffer	upgrade_query = createPQExpBuffer();
+	PQExpBuffer	upgrade_query;
 	int			ntups;
 	PGresult   *upgrade_res;
 	Oid			connamespace;
@@ -249,6 +249,8 @@ dumpConversionOid(PGconn *conn, Archive *AH, ConvInfo *info)
 	/* Skip if not to be dumped */
 	if (!info->dobj.dump)
 		return;
+
+	upgrade_query = createPQExpBuffer();
 
 	appendPQExpBuffer(upgrade_query,
 					  "SELECT connamespace "
@@ -318,7 +320,7 @@ dumpRuleOid(Archive *AH, RuleInfo *info)
 void
 dumpOpFamilyOid(PGconn *conn, Archive *AH, OpfamilyInfo *info)
 {
-	PQExpBuffer	upgrade_query = createPQExpBuffer();
+	PQExpBuffer	upgrade_query;
 	int			ntups;
 	PGresult   *upgrade_res;
 	Oid			opfnamespace;
@@ -326,6 +328,8 @@ dumpOpFamilyOid(PGconn *conn, Archive *AH, OpfamilyInfo *info)
 	/* Skip if not to be dumped */
 	if (!info->dobj.dump)
 		return;
+
+	upgrade_query = createPQExpBuffer();
 
 	appendPQExpBuffer(upgrade_query,
 					  "SELECT opfnamespace "
@@ -369,7 +373,7 @@ dumpOpFamilyOid(PGconn *conn, Archive *AH, OpfamilyInfo *info)
 void
 dumpOpClassOid(PGconn *conn, Archive *AH, OpclassInfo *info)
 {
-	PQExpBuffer	upgrade_query = createPQExpBuffer();
+	PQExpBuffer	upgrade_query;
 	int			ntups;
 	PGresult   *upgrade_res;
 	Oid			pg_opclass_oid;
@@ -378,6 +382,8 @@ dumpOpClassOid(PGconn *conn, Archive *AH, OpclassInfo *info)
 	/* Skip if not to be dumped */
 	if (!info->dobj.dump)
 		return;
+
+	upgrade_query = createPQExpBuffer();
 
 	appendPQExpBuffer(upgrade_query,
 					  "SELECT oid, opcnamespace "

--- a/src/bin/pg_dump/binary_upgrade.h
+++ b/src/bin/pg_dump/binary_upgrade.h
@@ -36,7 +36,9 @@ extern void dumpTypeOid(PGconn *conn, Archive *fout, Archive *AH, TypeInfo *info
 extern void dumpNamespaceOid(Archive *AH, NamespaceInfo *info);
 extern void dumpRuleOid(Archive *AH, RuleInfo *info);
 extern void dumpConstraintOid(PGconn *conn, Archive *AH, ConstraintInfo *info);
-extern void dumpProcLangOid(Archive *AH, ProcLangInfo *info);
+extern void dumpProcLangOid(PGconn *conn, Archive *fout, Archive *AH, ProcLangInfo *info);
 extern void dumpCastOid(Archive *AH, CastInfo *info);
+extern void dumpTSObjectOid(Archive *AH, DumpableObject *info);
+extern void dumpExtensionOid(Archive *AH, ExtensionInfo *info);
 
 #endif /* BINARY_UPGRADE_H */

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -8279,7 +8279,7 @@ dumpOpfamily(Archive *fout, OpfamilyInfo *opfinfo)
 	resetPQExpBuffer(query);
 
 	appendPQExpBuffer(query, "SELECT "
-	 "(SELECT amname FROM pg_catalog.pg_am WHERE oid = opfmethod) AS amname, "
+	 "(SELECT amname FROM pg_catalog.pg_am WHERE oid = opfmethod) AS amname "
 					  "FROM pg_catalog.pg_opfamily "
 					  "WHERE oid = '%u'::pg_catalog.oid",
 					  opfinfo->dobj.catId.oid);


### PR DESCRIPTION
`pg_upgrade` support for all object types in 5.0 was left out of the initial PR due to optimizing for getting 4.3 upgrades tested. This revisits and adds support for the remaining objects as well as fixes many issues with the objects that had broken support.

Added support:
* ENUM types
* extensions
* Text Search objects (parsers, configurations etc)

Fixed support:
* VIEWs
* Procedural languages
* Tables without any toastable attributes but with dropped columns

The individual commit messages carry further information.