### PR TITLE
Use unittest module instead of unittest2 module for python unit tests.

### DIFF
--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -31,7 +31,7 @@ PYLIB_DIR=$(SRC)/ext
 core: pygresql subprocess32
 
 ifneq "$(wildcard $(CURDIR)/pythonSrc/ext/*.tar.gz)" ""
-all: core lockfile paramiko pycrypto stream psutil unittest2
+all: core lockfile paramiko pycrypto stream psutil
 else
 all: core stream
 endif
@@ -199,15 +199,6 @@ $(BEHAVE_BIN):
 	@cd $(PYLIB_SRC_EXT)/$(BEHAVE_DIR)/ && PYTHONPATH=$(PYTHONSRC_INSTALL_PYTHON_PATH) python setup.py install --prefix $(PYTHONSRC_INSTALL)
 	@echo "--- behave done"
 
-UNITTEST2_VERSION=0.5.1
-UNITTEST2_DIR=unittest2-${UNITTEST2_VERSION}
-unittest2:
-	@echo "--- unittest2"
-	cd $(PYLIB_SRC_EXT)/ && $(TAR) xzf $(UNITTEST2_DIR).tar.gz
-	cd $(PYLIB_SRC_EXT)/$(UNITTEST2_DIR)/ && python setup.py build
-	cp -r $(PYLIB_SRC_EXT)/$(UNITTEST2_DIR)/build/lib/unittest2  $(PYLIB_DIR)/
-
-
 PYTHON_FILES=`grep -l --exclude=Makefile --exclude=gplogfilter "/bin/env python" *`\
 			 `grep -l "/bin/env python" $(SRC)/../sbin/*`\
 			 `find ./gppylib -name "*.py"`\
@@ -224,7 +215,7 @@ check-regress:
 	@PYTHONPATH=$(SRC):$(SRC)/ext:$(PYTHONPATH) \
 	gppylib/gpunit discover --verbose -s gppylib -p "test_regress*.py" 2> $(SRC)/../gpMgmt_testregress_results.log 1> $(SRC)/../gpMgmt_testregress_output.log
 
-check: $(MOCK_BIN) unittest2
+check: $(MOCK_BIN)
 	@echo "Running pure unit and also "unit" tests that require cluster to be up..."
 	@TMPDIR=/tmp PYTHONPATH=$(SERVER_SRC):$(SERVER_SBIN):$(PYTHONPATH):$(PYTHONSRC_INSTALL_PYTHON_PATH):$(SRC)/ext:$(SBIN_DIR):$(LIB_DIR):$(PYLIB_DIR)/mock-1.0.1 \
 	gppylib/gpunit discover --verbose -s $(SRC)/gppylib -p "test_unit*.py" 2> $(SRC)/../gpMgmt_testunit_results.log 1> $(SRC)/../gpMgmt_testunit_output.log
@@ -233,7 +224,7 @@ check: $(MOCK_BIN) unittest2
 
 unitdevel:
 	@echo "Running pure unit tests..."
-	python -m unittest2 discover --verbose -s $(SRC)/gppylib -p "test_unit*.py"
+	python -m unittest discover --verbose -s $(SRC)/gppylib -p "test_unit*.py"
 
 solarisTest:
 	@if [ `uname -s` = 'SunOS' ]; then \

--- a/gpMgmt/bin/README
+++ b/gpMgmt/bin/README
@@ -176,8 +176,8 @@ Testing Management Scripts
 --------------------------
 
 This directory contains the unit tests for the management scripts. These tests
-require the following Python modules to be installed: mock, pygresql, and
-unittest2.  These modules can be installed by running "git submodule update --init --recursive"
+require the following Python modules to be installed: mock and pygresql.
+These modules can be installed by running "git submodule update --init --recursive"
 if they are not already installed on your machine.
 
 If you installed the dependencies using the above git command, you can run the tests with
@@ -192,9 +192,9 @@ be installed and currently running.
 If you did not install the dependencies using the git submodule, use the following commands in
 place of the above make commands, still in the current directory:
 
-"python -m unittest2 discover --verbose -s gppylib -p 'test_unit*.py' -p 'test_cluster*.py'" will
+"python -m unittest discover --verbose -s gppylib -p 'test_unit*.py' -p 'test_cluster*.py'" will
 run all of the unit tests.
 
-"python -m unittest2 discover --verbose -s gppylib -p 'test_unit*.py'" will run only the unit
+"python -m unittest discover --verbose -s gppylib -p 'test_unit*.py'" will run only the unit
 tests that do not require a running cluster.
 

--- a/gpMgmt/bin/gppylib/commands/test/unit/test_unit_base.py
+++ b/gpMgmt/bin/gppylib/commands/test/unit/test_unit_base.py
@@ -3,7 +3,7 @@
 # Copyright (c) Greenplum Inc 2012. All Rights Reserved. 
 #
 
-import unittest2 as unittest
+import unittest
 from gppylib.commands.base import Command, WorkerPool
 from mock import patch
 

--- a/gpMgmt/bin/gppylib/commands/test/unit/test_unit_gp.py
+++ b/gpMgmt/bin/gppylib/commands/test/unit/test_unit_gp.py
@@ -5,7 +5,7 @@
 
 import os
 import shutil
-import unittest2 as unittest
+import unittest
 from gppylib.commands.base import CommandResult
 from mock import patch, MagicMock, Mock
 import gppylib.commands.gp as gp

--- a/gpMgmt/bin/gppylib/db/test/__init__.py
+++ b/gpMgmt/bin/gppylib/db/test/__init__.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest
 from gppylib.db.dbconn import connect, DbURL
 
 def skipIfDatabaseDown():

--- a/gpMgmt/bin/gppylib/db/test/regress/test_regress_catalog.py
+++ b/gpMgmt/bin/gppylib/db/test/regress/test_regress_catalog.py
@@ -5,7 +5,7 @@
 # Unit Testing of catalog module.
 #
 
-import unittest2 as unittest
+import unittest
 
 
 

--- a/gpMgmt/bin/gppylib/db/test/test_catalog.py
+++ b/gpMgmt/bin/gppylib/db/test/test_catalog.py
@@ -5,7 +5,7 @@
 # Unit Testing of catalog module.
 #
 
-import unittest2 as unittest
+import unittest
 
 
 

--- a/gpMgmt/bin/gppylib/gpMgmttest/__init__.py
+++ b/gpMgmt/bin/gppylib/gpMgmttest/__init__.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest
 import time
 
 class GpMgmtTestRunner(unittest.TextTestRunner):

--- a/gpMgmt/bin/gppylib/gp_dbid.py
+++ b/gpMgmt/bin/gppylib/gp_dbid.py
@@ -139,7 +139,7 @@ def writeGpDbidFile(directory, dbid, logger=None):
 #
 if __name__ == '__main__':
     import copy, shutil
-    import unittest2 as unittest
+    import unittest
 
     TESTDIR = 'test_gp_dbid1'
 

--- a/gpMgmt/bin/gppylib/gp_era.py
+++ b/gpMgmt/bin/gppylib/gp_era.py
@@ -154,7 +154,7 @@ def read_era(datadir, logger):
 #
 if __name__ == '__main__':
     import copy, shutil
-    import unittest2 as unittest
+    import unittest
 
     TESTDIR = 'test_gp_era1'
 

--- a/gpMgmt/bin/gppylib/gpunit
+++ b/gpMgmt/bin/gppylib/gpunit
@@ -13,8 +13,8 @@ so that it can be integrated with Pulse.
 
 __unittest = True
 
-import unittest2 as unittest
-from unittest2.main import USAGE_AS_MAIN
+import unittest
+from unittest.main import USAGE_AS_MAIN
 from gppylib import gpMgmttest
 
 unittest.TestProgram.USAGE = USAGE_AS_MAIN

--- a/gpMgmt/bin/gppylib/operations/test/regress/test_package/__init__.py
+++ b/gpMgmt/bin/gppylib/operations/test/regress/test_package/__init__.py
@@ -1,6 +1,6 @@
 import os
 import shutil
-import unittest2 as unittest
+import unittest
 import tempfile
 import platform
 import getpass

--- a/gpMgmt/bin/gppylib/operations/test/regress/test_package/test_regress_simple_gppkg.py
+++ b/gpMgmt/bin/gppylib/operations/test/regress/test_package/test_regress_simple_gppkg.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import unittest2 as unittest
+import unittest
 
 from gppylib.operations.test.regress.test_package import GppkgTestCase, GppkgSpec, BuildGppkg, RPMSpec, BuildRPM, run_command, run_remote_command
 

--- a/gpMgmt/bin/gppylib/operations/test/regress/test_regress_filespace.py
+++ b/gpMgmt/bin/gppylib/operations/test/regress/test_regress_filespace.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import unittest2 as unittest
+import unittest
 
 from gppylib.operations.filespace import FileType 
 from gppylib.commands.base import Command, WorkerPool

--- a/gpMgmt/bin/gppylib/operations/test/test_package.py
+++ b/gpMgmt/bin/gppylib/operations/test/test_package.py
@@ -2,7 +2,7 @@
 
 import os
 import shutil
-import unittest2 as unittest
+import unittest
 import tempfile
 import platform
 import getpass

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_backup_utils.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_backup_utils.py
@@ -5,7 +5,7 @@
 
 import os
 import shutil
-import unittest2 as unittest
+import unittest
 from gppylib.commands.base import CommandResult
 from gppylib.gparray import GpArray, GpDB
 from gppylib.operations.backup_utils import *

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_buildMirrorSegments.py
@@ -3,7 +3,7 @@
 # Copyright (c) Greenplum Inc 2008. All Rights Reserved. 
 #
 
-import unittest2 as unittest
+import unittest
 import tempfile, os, shutil
 from gppylib.commands.base import CommandResult
 from gppylib.operations.buildMirrorSegments import GpMirrorListToBuild

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_deletesystem.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_deletesystem.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import unittest2 as unittest
+import unittest
 from gppylib.operations.deletesystem import validate_pgport
 from mock import patch, MagicMock, Mock
 

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_dump.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_dump.py
@@ -2,7 +2,7 @@
 # Copyright (c) Greenplum Inc 2012. All Rights Reserved.
 #
 
-import unittest2 as unittest
+import unittest
 from datetime import datetime
 from gppylib.commands.base import Command, CommandResult
 from gppylib.gparray import GpArray, GpDB

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_filespace.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_filespace.py
@@ -3,7 +3,7 @@
 # Copyright (c) Greenplum Inc 2012. All Rights Reserved. 
 #
 
-import unittest2 as unittest
+import unittest
 from mock import patch
 from gppylib.operations.filespace import is_filespace_configured
 import os

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_initstandby.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_initstandby.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import os
-import unittest2 as unittest
+import unittest
 
 from gppylib.mainUtils import ExceptionNoStackTraceNeeded
 from gppylib.operations.initstandby import get_standby_pg_hba_info, update_pg_hba, update_pg_hba_conf_on_segments

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_persistent_rebuild.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_persistent_rebuild.py
@@ -6,7 +6,7 @@
 import os
 import re
 import shutil
-import unittest2 as unittest
+import unittest
 from collections import defaultdict
 from gppylib.gpversion import GpVersion
 from gppylib.commands.base import Command, CommandResult, ExecutionError

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_reload.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_reload.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import os
-import unittest2 as unittest
+import unittest
 
 from gppylib.mainUtils import ExceptionNoStackTraceNeeded
 from gppylib.operations.reload import GpReload

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_restore.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_restore.py
@@ -5,7 +5,7 @@
 #
 
 import sys
-import unittest2 as unittest
+import unittest
 import tempfile, os, shutil
 from gppylib.commands.base import CommandResult, Command, ExecutionError
 from gppylib.operations.backup_utils import *

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_unix.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_unix.py
@@ -3,7 +3,7 @@
 # Copyright (c) Greenplum Inc 2014. All Rights Reserved. 
 #
 
-import unittest2 as unittest
+import unittest
 from gppylib.commands.base import CommandResult
 from gppylib.operations.unix import RemoteOperation, CleanSharedMem
 from mock import Mock, MagicMock, patch

--- a/gpMgmt/bin/gppylib/test/regress/test_regress_gpexpand.py
+++ b/gpMgmt/bin/gppylib/test/regress/test_regress_gpexpand.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import unittest2 as unittest
+import unittest
 import os, socket
 
 from gppylib.commands.base import Command, ExecutionError

--- a/gpMgmt/bin/gppylib/test/regress/test_regress_gpssh.py
+++ b/gpMgmt/bin/gppylib/test/regress/test_regress_gpssh.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import os, signal, time, re
-import unittest2 as unittest
+import unittest
 import psutil
 from subprocess import PIPE
 

--- a/gpMgmt/bin/gppylib/test/regress/test_regress_pygresql.py
+++ b/gpMgmt/bin/gppylib/test/regress/test_regress_pygresql.py
@@ -6,7 +6,7 @@
 """ Unittesting for pygres module
 """
 import logging
-import unittest2 as unittest
+import unittest
 
 
 from pygresql import pg

--- a/gpMgmt/bin/gppylib/test/unit/gp_unittest.py
+++ b/gpMgmt/bin/gppylib/test/unit/gp_unittest.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest
 
 
 class GpTestCase(unittest.TestCase):

--- a/gpMgmt/bin/gppylib/test/unit/test_cluster_gpcrondump.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_cluster_gpcrondump.py
@@ -5,7 +5,7 @@ import sys
 import imp
 gpcrondump_path = os.path.abspath('gpcrondump')
 gpcrondump = imp.load_source('gpcrondump', gpcrondump_path)
-import unittest2 as unittest
+import unittest
 from datetime import datetime
 from gppylib import gplog
 from gpcrondump import GpCronDump

--- a/gpMgmt/bin/gppylib/test/unit/test_cluster_gpsegstart.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_cluster_gpsegstart.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import os, sys
-import unittest2 as unittest
+import unittest
 from gppylib import gplog
 from gpsegstart import GpSegStart
 from mock import patch

--- a/gpMgmt/bin/gppylib/test/unit/test_cluster_gpsegstop.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_cluster_gpsegstop.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import os, sys
-import unittest2 as unittest
+import unittest
 from gppylib import gplog
 from gppylib.commands.base import CommandResult
 from gpsegstop import SegStop, SegStopStatus

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpdbrestore.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpdbrestore.py
@@ -14,7 +14,7 @@ from gppylib.operations.backup_utils import write_lines_to_file
 from gppylib.operations.dump import MailDumpEvent
 from gppylib.operations.utils import DEFAULT_NUM_WORKERS
 from mock import patch, Mock, MagicMock, mock_open
-import unittest2 as unittest
+import unittest
 from . import setup_fake_gparray
 
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gphostcachelookup.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gphostcachelookup.py
@@ -6,7 +6,7 @@
 """ Unittesting for gphostcachelookup module
 """
 import os, sys
-import unittest2 as unittest
+import unittest
 from gppylib import gplog
 from gppylib.commands.base import Command, ExecutionError
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gprestore_filter.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gprestore_filter.py
@@ -2,7 +2,7 @@
 # coding: utf-8
 
 import os, sys
-import unittest2 as unittest
+import unittest
 from gppylib import gplog
 from mock import patch
 from gppylib.mainUtils import ExceptionNoStackTraceNeeded

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gprestore_post_data_filter.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gprestore_post_data_filter.py
@@ -2,7 +2,7 @@
 # coding: utf-8 
 
 import os, sys
-import unittest2 as unittest
+import unittest
 from gppylib import gplog
 from mock import patch
 from gppylib.mainUtils import ExceptionNoStackTraceNeeded

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpversion.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpversion.py
@@ -5,7 +5,7 @@
 """ 
 Unit testing for gpversion module
 """
-import unittest2 as unittest
+import unittest
 
 from gpversion import *
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_userinput.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_userinput.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import sys, os, getpass
-import unittest2 as unittest
+import unittest
 from gppylib.userinput import ask_create_password
 
 

--- a/gpMgmt/bin/gppylib/unit2
+++ b/gpMgmt/bin/gppylib/unit2
@@ -2,6 +2,6 @@
 
 __unittest = True
 
-from unittest2.main import main_
+from unittest.main import main_
 
 main_()

--- a/gpMgmt/bin/gppylib/util/test/unit/test_cluster_ssh_utils.py
+++ b/gpMgmt/bin/gppylib/util/test/unit/test_cluster_ssh_utils.py
@@ -2,7 +2,7 @@
 
 import mock
 import sys, os, pwd
-import unittest2 as unittest
+import unittest
 from StringIO import StringIO
 from mock import patch
 


### PR DESCRIPTION
Since python 2.7 has the features of the unittest2 module included, we do not need to use
unittest2 anymore. This removes this dependency requirement. We
previously used the unittest2 module as it included features that were
not present in python 2.6. There are still unittest2 dependencies in the
TINC tests, but that may be a more intensive effort.