### PR TITLE
Merging executor CTE changes from upstream

### DIFF
--- a/doc/src/sgml/ref/select.sgml
+++ b/doc/src/sgml/ref/select.sgml
@@ -20,7 +20,7 @@ PostgreSQL documentation
 
  <refsynopsisdiv>
 <synopsis>
-[ WITH <replaceable class="parameter">with_query</replaceable> [, ...] ]
+[ WITH [ RECURSIVE ] <replaceable class="parameter">with_query</replaceable> [, ...] ]
 SELECT [ ALL | DISTINCT [ ON ( <replaceable class="parameter">expression</replaceable> [, ...] ) ] ]
     * | <replaceable class="parameter">expression</replaceable> [ [AS] <replaceable class="parameter">output_name</replaceable> ] [, ...]
     [ FROM <replaceable class="parameter">from_item</replaceable> [, ...] ]
@@ -62,6 +62,7 @@ where <replaceable class="parameter">from_item</replaceable> can be one of:
 
     [ ONLY ] <replaceable class="parameter">table_name</replaceable> [ * ] [ [ AS ] <replaceable class="parameter">alias</replaceable> [ ( <replaceable class="parameter">column_alias</replaceable> [, ...] ) ] ]
     ( <replaceable class="parameter">select</replaceable> ) [ AS ] <replaceable class="parameter">alias</replaceable> [ ( <replaceable class="parameter">column_alias</replaceable> [, ...] ) ]
+    <replaceable class="parameter">with_query_name</replaceable> [ [ AS ] <replaceable class="parameter">alias</replaceable> [ ( <replaceable class="parameter">column_alias</replaceable> [, ...] ) ] ]
     <replaceable class="parameter">function_name</replaceable> ( [ <replaceable class="parameter">argument</replaceable> [, ...] ] ) [ AS ] <replaceable class="parameter">alias</replaceable> [ ( <replaceable class="parameter">column_alias</replaceable> [, ...] | <replaceable class="parameter">column_definition</replaceable> [, ...] ) ]
     <replaceable class="parameter">function_name</replaceable> ( [ <replaceable class="parameter">argument</replaceable> [, ...] ] ) AS ( <replaceable class="parameter">column_definition</replaceable> [, ...] )
     <replaceable class="parameter">from_item</replaceable> [ NATURAL ] <replaceable class="parameter">join_type</replaceable> <replaceable class="parameter">from_item</replaceable> [ ON <replaceable class="parameter">join_condition</replaceable> | USING ( <replaceable class="parameter">join_column</replaceable> [, ...] ) ]
@@ -73,10 +74,9 @@ where <replaceable class="parameter">group_elem</replaceable> can be one of:
     GROUPING SETS ( <replaceable class="parameter">group_elem</replaceable> [, ...] ] )
     ( )
 
-and <replaceable class="parameter">with_query</replaceable> can be:
-    <replaceable class="parameter">query_name</replaceable> [ ( <replaceable class="parameter">column</replaceable> [, ...] ) ]
-    AS ( { VALUES ( <replaceable class="PARAMETER">expression</replaceable> [, ...] ) | <replaceable class="parameter">query</replaceable> } )
+and <replaceable class="parameter">with_query</replaceable> is:
 
+    <replaceable class="parameter">with_query_name</replaceable> [ ( <replaceable class="parameter">column_name</replaceable> [, ...] ) ] AS ( <replaceable class="parameter">select</replaceable> )
 </synopsis>
 
  </refsynopsisdiv>
@@ -89,6 +89,17 @@ and <replaceable class="parameter">with_query</replaceable> can be:
    The general processing of <command>SELECT</command> is as follows:
 
    <orderedlist>
+    <listitem>
+     <para>
+      All queries in the <literal>WITH</literal> list are computed.
+      These effectively serve as temporary tables that can be referenced
+      in the <literal>FROM</literal> list.  A <literal>WITH</literal> query
+      that is referenced more than once in <literal>FROM</literal> is
+      computed only once.
+      (See <xref linkend="sql-with" endterm="sql-with-title"> below.)
+     </para>
+    </listitem>
+
     <listitem>
      <para>
       All elements in the <literal>FROM</literal> list are computed.
@@ -201,6 +212,56 @@ and <replaceable class="parameter">with_query</replaceable> can be:
  <refsect1>
   <title>Parameters</title>
 
+  <refsect2 id="SQL-WITH">
+   <title id="sql-with-title"><literal>WITH</literal> Clause</title>
+
+   <para>
+    The <literal>WITH</literal> clause allows you to specify one or more
+    subqueries that can be referenced by name in the primary query.
+    The subqueries effectively act as temporary tables or views
+    for the duration of the primary query.
+   </para>
+
+   <para>
+    A name (without schema qualification) must be specified for each
+    <literal>WITH</literal> query.  Optionally, a list of column names
+    can be specified; if this is omitted,
+    the column names are inferred from the subquery.
+   </para>
+
+   <para>
+    If <literal>RECURSIVE</literal> is specified, it allows a
+    subquery to reference itself by name.  Such a subquery must have
+    the form
+<synopsis>
+<replaceable class="parameter">non_recursive_term</replaceable> UNION ALL <replaceable class="parameter">recursive_term</replaceable>
+</synopsis>
+    where the recursive self-reference must appear on the right-hand
+    side of <literal>UNION ALL</>.  Only one recursive self-reference
+    is permitted per query.
+   </para>
+
+   <para>
+    Another effect of <literal>RECURSIVE</literal> is that
+    <literal>WITH</literal> queries need not be ordered: a query
+    can reference another one that is later in the list.  (However,
+    circular references, or mutual recursion, are not implemented.)
+    Without <literal>RECURSIVE</literal>, <literal>WITH</literal> queries
+    can only reference sibling <literal>WITH</literal> queries
+    that are earlier in the <literal>WITH</literal> list.
+   </para>
+
+   <para>
+    A useful property of <literal>WITH</literal> queries is that they
+    are evaluated only once per execution of the primary query,
+    even if the primary query refers to them more than once.
+   </para>
+
+   <para>
+    See <xref linkend="queries-with"> for additional information.
+   </para>
+  </refsect2>
+
   <refsect2 id="SQL-FROM">
    <title id="sql-from-title"><literal>FROM</literal> Clause</title>
 
@@ -263,6 +324,21 @@ and <replaceable class="parameter">with_query</replaceable> can be:
         provided for it.  A
         <xref linkend="sql-values" endterm="sql-values-title"> command
         can also be used here.
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry>
+      <term><replaceable class="parameter">with_query_name</replaceable></term>
+      <listitem>
+       <para>
+        A <literal>WITH</> query is referenced by writing its name,
+        just as though the query's name were a table name.  (In fact,
+        the <literal>WITH</> query hides any real table of the same name
+        for the purposes of the primary query.  If necessary, you can
+        refer to a real table of the same name by schema-qualifying
+        the table's name.)
+        An alias can be provided in the same way as for a table.
        </para>
       </listitem>
      </varlistentry>
@@ -1135,6 +1211,58 @@ SELECT * FROM distributors_2(111) AS (f1 int, f2 text);
  111 | Walt Disney
 </programlisting>
   </para>
+
+  <para>
+   This example shows how to use a simple <literal>WITH</> clause:
+
+<programlisting>
+WITH t AS (
+    SELECT random() as x FROM generate_series(1, 3)
+  )
+SELECT * FROM t
+UNION ALL
+SELECT * FROM t
+
+         x          
+--------------------
+  0.534150459803641
+  0.520092216785997
+ 0.0735620250925422
+  0.534150459803641
+  0.520092216785997
+ 0.0735620250925422
+</programlisting>
+
+   Notice that the <literal>WITH</> query was evaluated only once,
+   so that we got two sets of the same three random values.
+  </para>
+
+  <para>
+   This example uses <literal>WITH RECURSIVE</literal> to find all
+   subordinates (direct or indirect) of the employee Mary, and their
+   level of indirectness, from a table that shows only direct
+   subordinates:
+
+<programlisting>
+WITH RECURSIVE employee_recursive(distance, employee_name, manager_name) AS (
+    SELECT 1, employee_name, manager_name
+    FROM employee
+    WHERE manager_name = 'Mary'
+  UNION ALL
+    SELECT er.distance + 1, e.employee_name, e.manager_name
+    FROM employee_recursive er, employee e
+    WHERE er.employee_name = e.manager_name
+  )
+SELECT distance, employee_name FROM employee_recursive;
+</programlisting>
+
+   Notice the typical form of recursive queries:
+   an initial condition, followed by <literal>UNION ALL</literal>,
+   followed by the recursive part of the query. Be sure that the
+   recursive part of the query will eventually return no tuples, or
+   else the query will loop indefinitely.  (See <xref linkend="queries-with">
+   for more examples.)
+  </para>
  </refsect1>
  
  <refsect1>
@@ -1216,7 +1344,7 @@ SELECT distributors.* WHERE distributors.name = 'Westward';
 
    <para>
     SQL:1999 and later use a slightly different definition which is not
-    entirely upward compatible with SQL-92.  
+    entirely upward compatible with SQL-92.
     In most cases, however, <productname>PostgreSQL</productname>
     will interpret an <literal>ORDER BY</literal> or <literal>GROUP
     BY</literal> expression the same way SQL:1999 does.

--- a/doc/src/sgml/ref/select_into.sgml
+++ b/doc/src/sgml/ref/select_into.sgml
@@ -20,17 +20,18 @@ PostgreSQL documentation
 
  <refsynopsisdiv>
 <synopsis>
-SELECT [ ALL | DISTINCT [ ON ( <replaceable class="PARAMETER">expression</replaceable> [, ...] ) ] ]
-    * | <replaceable class="PARAMETER">expression</replaceable> [ AS <replaceable class="PARAMETER">output_name</replaceable> ] [, ...]
-    INTO [ TEMPORARY | TEMP ] [ TABLE ] <replaceable class="PARAMETER">new_table</replaceable>
-    [ FROM <replaceable class="PARAMETER">from_item</replaceable> [, ...] ]
-    [ WHERE <replaceable class="PARAMETER">condition</replaceable> ]
-    [ GROUP BY <replaceable class="parameter">group_elem</replaceable> [, ...] ]
-    [ HAVING <replaceable class="PARAMETER">condition</replaceable> [, ...] ]
-    [ { UNION | INTERSECT | EXCEPT } [ ALL ] <replaceable class="PARAMETER">select</replaceable> ]
+[ WITH [ RECURSIVE ] <replaceable class="parameter">with_query</replaceable> [, ...] ]
+SELECT [ ALL | DISTINCT [ ON ( <replaceable class="parameter">expression</replaceable> [, ...] ) ] ]
+    * | <replaceable class="parameter">expression</replaceable> [ [ AS ] <replaceable class="parameter">output_name</replaceable> ] [, ...]
+    INTO [ TEMPORARY | TEMP ] [ TABLE ] <replaceable class="parameter">new_table</replaceable>
+    [ FROM <replaceable class="parameter">from_item</replaceable> [, ...] ]
+    [ WHERE <replaceable class="parameter">condition</replaceable> ]
+    [ GROUP BY <replaceable class="parameter">expression</replaceable> [, ...] ]
+    [ HAVING <replaceable class="parameter">condition</replaceable> [, ...] ]
+    [ { UNION | INTERSECT | EXCEPT } [ ALL ] <replaceable class="parameter">select</replaceable> ]
     [ ORDER BY <replaceable class="parameter">expression</replaceable> [ ASC | DESC | USING <replaceable class="parameter">operator</replaceable> ] [ NULLS { FIRST | LAST } ] [, ...] ]
-    [ LIMIT { <replaceable class="PARAMETER">count</replaceable> | ALL } ]
-    [ OFFSET <replaceable class="PARAMETER">start</replaceable> ]
+    [ LIMIT { <replaceable class="parameter">count</replaceable> | ALL } ]
+    [ OFFSET <replaceable class="parameter">start</replaceable> ]
     [ FOR { UPDATE | SHARE } [ OF <replaceable class="parameter">table_name</replaceable> [, ...] ] [ NOWAIT ] [...] ]
 </synopsis>
  </refsynopsisdiv>
@@ -46,7 +47,7 @@ SELECT [ ALL | DISTINCT [ ON ( <replaceable class="PARAMETER">expression</replac
    output columns of the <command>SELECT</command>.
   </para>
  </refsect1>
-  
+
  <refsect1>
   <title>Parameters</title>
 

--- a/src/backend/executor/Makefile
+++ b/src/backend/executor/Makefile
@@ -20,10 +20,11 @@ OBJS = execAmi.o execCurrent.o execGrouping.o execJunk.o execMain.o \
        nodeBitmapAnd.o nodeBitmapOr.o \
        nodeBitmapHeapscan.o nodeBitmapIndexscan.o nodeHash.o \
        nodeHashjoin.o nodeIndexscan.o nodeMaterial.o nodeMergejoin.o \
-       nodeNestloop.o nodeFunctionscan.o nodeResult.o \
+       nodeNestloop.o nodeFunctionscan.o nodeRecursiveunion.o nodeResult.o \
        nodeSetOp.o nodeSort.o nodeUnique.o \
-       nodeValuesscan.o nodeLimit.o \
-       nodeSubplan.o nodeSubqueryscan.o nodeTidscan.o tstoreReceiver.o spi.o \
+       nodeValuesscan.o nodeCtescan.o nodeWorktablescan.o \
+       nodeLimit.o nodeSubplan.o nodeSubqueryscan.o nodeTidscan.o \
+       tstoreReceiver.o spi.o \
        nodeBitmapTableScan.o \
        nodeExternalscan.o \
        nodeDynamicIndexscan.o \
@@ -45,4 +46,5 @@ OBJS = execAmi.o execCurrent.o execGrouping.o execJunk.o execMain.o \
        execIndexscan.o \
        execHHashagg.o execGpmon.o execWorkfile.o execHeapScan.o execAOScan.o \
        execAOCSScan.o nodeBitmapAppendOnlyscan.o
+
 include $(top_srcdir)/src/backend/common.mk

--- a/src/backend/executor/execProcnode.c
+++ b/src/backend/executor/execProcnode.c
@@ -13,7 +13,7 @@
  *
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/executor/execProcnode.c,v 1.62 2008/01/01 19:45:49 momjian Exp $
+ *	  $PostgreSQL: pgsql/src/backend/executor/execProcnode.c,v 1.63 2008/10/04 21:56:53 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -55,7 +55,7 @@
  *	  * ExecInitNode() notices that it is looking at a nest loop and
  *		as the code below demonstrates, it calls ExecInitNestLoop().
  *		Eventually this calls ExecInitNode() on the right and left subplans
- *		and so forth until the entire plan is initialized.  The result
+ *		and so forth until the entire plan is initialized.	The result
  *		of ExecInitNode() is a plan state tree built with the same structure
  *		as the underlying plan tree.
  *
@@ -84,19 +84,10 @@
 #include "executor/instrument.h"
 #include "executor/nodeAgg.h"
 #include "executor/nodeAppend.h"
-#include "executor/nodeAssertOp.h"
-#include "executor/nodeSequence.h"
 #include "executor/nodeBitmapAnd.h"
 #include "executor/nodeBitmapHeapscan.h"
 #include "executor/nodeBitmapIndexscan.h"
-#include "executor/nodeBitmapTableScan.h"
 #include "executor/nodeBitmapOr.h"
-#include "executor/nodeBitmapAppendOnlyscan.h"
-#include "executor/nodeExternalscan.h"
-#include "executor/nodeTableScan.h"
-#include "executor/nodeDML.h"
-#include "executor/nodeDynamicIndexscan.h"
-#include "executor/nodeDynamicTableScan.h"
 #include "executor/nodeFunctionscan.h"
 #include "executor/nodeHash.h"
 #include "executor/nodeHashjoin.h"
@@ -104,23 +95,35 @@
 #include "executor/nodeLimit.h"
 #include "executor/nodeMaterial.h"
 #include "executor/nodeMergejoin.h"
-#include "executor/nodeMotion.h"
 #include "executor/nodeNestloop.h"
-#include "executor/nodeRepeat.h"
+#include "executor/nodeRecursiveunion.h"
 #include "executor/nodeResult.h"
-#include "executor/nodeRowTrigger.h"
 #include "executor/nodeSetOp.h"
-#include "executor/nodeShareInputScan.h"
 #include "executor/nodeSort.h"
-#include "executor/nodeSplitUpdate.h"
 #include "executor/nodeSubplan.h"
 #include "executor/nodeSubqueryscan.h"
-#include "executor/nodeTableFunction.h"
 #include "executor/nodeTidscan.h"
 #include "executor/nodeUnique.h"
 #include "executor/nodeValuesscan.h"
+#include "executor/nodeCtescan.h"
+#include "executor/nodeWorktablescan.h"
+#include "executor/nodeAssertOp.h"
+#include "executor/nodeSequence.h"
+#include "executor/nodeBitmapTableScan.h"
+#include "executor/nodeBitmapAppendOnlyscan.h"
+#include "executor/nodeExternalscan.h"
+#include "executor/nodeTableScan.h"
+#include "executor/nodeDML.h"
+#include "executor/nodeDynamicIndexscan.h"
+#include "executor/nodeDynamicTableScan.h"
+#include "executor/nodeMotion.h"
+#include "executor/nodeRowTrigger.h"
+#include "executor/nodeShareInputScan.h"
+#include "executor/nodeTableFunction.h"
+#include "executor/nodeSplitUpdate.h"
 #include "executor/nodeWindow.h"
 #include "executor/nodePartitionSelector.h"
+#include "executor/nodeRepeat.h"
 #include "miscadmin.h"
 #include "tcop/tcopprot.h"
 #include "cdb/cdbvars.h"
@@ -191,6 +194,7 @@ setSubplanSliceId(SubPlan *subplan, EState *estate)
 		estate->currentExecutingSliceId = estate->rootSliceId;
 	}
 }
+
 
 
 /* ------------------------------------------------------------------------
@@ -304,6 +308,11 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			END_MEMORY_ACCOUNT();
 			break;
 
+		case T_RecursiveUnion:
+			result = (PlanState *) ExecInitRecursiveUnion((RecursiveUnion *) node,
+														  estate, eflags);
+			break;
+
 		case T_BitmapAnd:
 			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, BitmapAnd);
 
@@ -379,7 +388,7 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitDynamicTableScan((DynamicTableScan *) node,
-													 estate, eflags);
+												   estate, eflags);
 			}
 			END_MEMORY_ACCOUNT();
 			break;
@@ -516,6 +525,16 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			END_MEMORY_ACCOUNT();
 			break;
 
+		case T_CteScan:
+			result = (PlanState *) ExecInitCteScan((CteScan *) node,
+												   estate, eflags);
+			break;
+
+		case T_WorkTableScan:
+			result = (PlanState *) ExecInitWorkTableScan((WorkTableScan *) node,
+														 estate, eflags);
+			break;
+
 			/*
 			 * join nodes
 			 */
@@ -596,7 +615,7 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitAgg((Agg *) node,
-											   estate, eflags);
+												 estate, eflags);
 			/*
 			 * Enroll targetlist & quals' expression evaluation functions
 			 * in codegen_manager
@@ -722,7 +741,7 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
  												  estate, eflags);
 			}
 			END_MEMORY_ACCOUNT();
- 			break;
+			break;
 		case T_RowTrigger:
 			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, RowTrigger);
 
@@ -770,7 +789,7 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 		subps = lappend(subps, sstate);
 	}
 	if (result != NULL)
-		result->initPlan = subps;
+	result->initPlan = subps;
 
 	estate->currentSliceIdInPlan = origSliceIdInPlan;
 	estate->currentExecutingSliceId = origExecutingSliceId;
@@ -996,6 +1015,10 @@ ExecProcNode(PlanState *node)
 			result = ExecAppend((AppendState *) node);
 			break;
 
+		case T_RecursiveUnionState:
+			result = ExecRecursiveUnion((RecursiveUnionState *) node);
+			break;
+
 		case T_SequenceState:
 			result = ExecSequence((SequenceState *) node);
 			break;
@@ -1059,6 +1082,14 @@ ExecProcNode(PlanState *node)
 
 		case T_ValuesScanState:
 			result = ExecValuesScan((ValuesScanState *) node);
+			break;
+
+		case T_CteScanState:
+			result = ExecCteScan((CteScanState *) node);
+			break;
+
+		case T_WorkTableScanState:
+			result = ExecWorkTableScan((WorkTableScanState *) node);
 			break;
 
 			/*
@@ -1217,37 +1248,37 @@ MultiExecProcNode(PlanState *node)
 	{
 		PG_TRACE5(execprocnode__enter, Gp_segment, currentSliceId, nodeTag(node), node->plan->plan_node_id, node->plan->plan_parent_node_id);
 
-		if (node->chgParam != NULL)		/* something changed */
-			ExecReScan(node, NULL);		/* let ReScan handle this */
+	if (node->chgParam != NULL) /* something changed */
+		ExecReScan(node, NULL); /* let ReScan handle this */
 
-		switch (nodeTag(node))
-		{
-				/*
+	switch (nodeTag(node))
+	{
+			/*
 				 * Only node types that actually support multiexec will be
 				 * listed
-				 */
+			 */
 
-			case T_HashState:
-				result = MultiExecHash((HashState *) node);
-				break;
+		case T_HashState:
+			result = MultiExecHash((HashState *) node);
+			break;
 
-			case T_BitmapIndexScanState:
-				result = MultiExecBitmapIndexScan((BitmapIndexScanState *) node);
-				break;
+		case T_BitmapIndexScanState:
+			result = MultiExecBitmapIndexScan((BitmapIndexScanState *) node);
+			break;
 
-			case T_BitmapAndState:
-				result = MultiExecBitmapAnd((BitmapAndState *) node);
-				break;
+		case T_BitmapAndState:
+			result = MultiExecBitmapAnd((BitmapAndState *) node);
+			break;
 
-			case T_BitmapOrState:
-				result = MultiExecBitmapOr((BitmapOrState *) node);
-				break;
+		case T_BitmapOrState:
+			result = MultiExecBitmapOr((BitmapOrState *) node);
+			break;
 
-			default:
-				elog(ERROR, "unrecognized node type: %d", (int) nodeTag(node));
-				result = NULL;
-				break;
-		}
+		default:
+			elog(ERROR, "unrecognized node type: %d", (int) nodeTag(node));
+			result = NULL;
+			break;
+	}
 
 		PG_TRACE5(execprocnode__exit, Gp_segment, currentSliceId, nodeTag(node), node->plan->plan_node_id, node->plan->plan_parent_node_id);
 	}
@@ -1278,6 +1309,9 @@ ExecCountSlotsNode(Plan *node)
 
 		case T_Append:
 			return ExecCountSlotsAppend((Append *) node);
+
+		case T_RecursiveUnion:
+			return ExecCountSlotsRecursiveUnion((RecursiveUnion *) node);
 
 		case T_Sequence:
 			return ExecCountSlotsSequence((Sequence *) node);
@@ -1335,6 +1369,12 @@ ExecCountSlotsNode(Plan *node)
 
 		case T_ValuesScan:
 			return ExecCountSlotsValuesScan((ValuesScan *) node);
+
+		case T_CteScan:
+			return ExecCountSlotsCteScan((CteScan *) node);
+
+		case T_WorkTableScan:
+			return ExecCountSlotsWorkTableScan((WorkTableScan *) node);
 
 			/*
 			 * join nodes
@@ -1500,7 +1540,7 @@ ExecUpdateTransportState(PlanState *node, ChunkTransportState * state)
  *		at 'node'.
  *
  *		After this operation, the query plan will not be able to
- *		processed any further.  This should be called only after
+ *		processed any further.	This should be called only after
  *		the query plan has been fully executed.
  * ----------------------------------------------------------------
  */
@@ -1548,6 +1588,10 @@ ExecEndNode(PlanState *node)
 
 		case T_AppendState:
 			ExecEndAppend((AppendState *) node);
+			break;
+
+		case T_RecursiveUnionState:
+			ExecEndRecursiveUnion((RecursiveUnionState *) node);
 			break;
 
 		case T_SequenceState:
@@ -1625,6 +1669,14 @@ ExecEndNode(PlanState *node)
 
 		case T_ValuesScanState:
 			ExecEndValuesScan((ValuesScanState *) node);
+			break;
+
+		case T_CteScanState:
+			ExecEndCteScan((CteScanState *) node);
+			break;
+
+		case T_WorkTableScanState:
+			ExecEndWorkTableScan((WorkTableScanState *) node);
 			break;
 
 			/*
@@ -2170,7 +2222,7 @@ planstate_walk_kids(PlanState *planstate,
 				v1 = planstate_walk_node_extended(ips, walker, context, flags);
 			}
 		}
-	}
+}
 
 	/* Sub plan subtree */
 	if (v == CdbVisit_Walk)

--- a/src/backend/executor/execProcnode.c
+++ b/src/backend/executor/execProcnode.c
@@ -309,8 +309,14 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			break;
 
 		case T_RecursiveUnion:
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, Sequence);
+
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
+			{
 			result = (PlanState *) ExecInitRecursiveUnion((RecursiveUnion *) node,
 														  estate, eflags);
+			}
+			END_MEMORY_ACCOUNT();
 			break;
 
 		case T_BitmapAnd:
@@ -526,13 +532,25 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			break;
 
 		case T_CteScan:
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, CteScan);
+
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
+			{
 			result = (PlanState *) ExecInitCteScan((CteScan *) node,
 												   estate, eflags);
+			}
+			END_MEMORY_ACCOUNT();
 			break;
 
 		case T_WorkTableScan:
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, WorkTableScan);
+
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
+			{
 			result = (PlanState *) ExecInitWorkTableScan((WorkTableScan *) node,
 														 estate, eflags);
+			}
+			END_MEMORY_ACCOUNT();
 			break;
 
 			/*

--- a/src/backend/executor/nodeCtescan.c
+++ b/src/backend/executor/nodeCtescan.c
@@ -1,0 +1,337 @@
+/*-------------------------------------------------------------------------
+ *
+ * nodeCtescan.c
+ *	  routines to handle CteScan nodes.
+ *
+ * Portions Copyright (c) 1996-2008, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ *
+ * IDENTIFICATION
+ *	  $PostgreSQL: pgsql/src/backend/executor/nodeCtescan.c,v 1.1 2008/10/04 21:56:53 tgl Exp $
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "executor/execdebug.h"
+#include "executor/nodeCtescan.h"
+#include "miscadmin.h"
+
+static TupleTableSlot *CteScanNext(CteScanState *node);
+
+/* ----------------------------------------------------------------
+ *		CteScanNext
+ *
+ *		This is a workhorse for ExecCteScan
+ * ----------------------------------------------------------------
+ */
+static TupleTableSlot *
+CteScanNext(CteScanState *node)
+{
+	EState	   *estate;
+	ScanDirection dir;
+	bool		forward;
+	Tuplestorestate *tuplestorestate;
+	bool		eof_tuplestore;
+	TupleTableSlot *slot;
+
+	/*
+	 * get state info from node
+	 */
+	estate = node->ss.ps.state;
+	dir = estate->es_direction;
+	forward = ScanDirectionIsForward(dir);
+	tuplestorestate = node->leader->cte_table;
+	tuplestore_select_read_pointer(tuplestorestate, node->readptr);
+	slot = node->ss.ss_ScanTupleSlot;
+
+	/*
+	 * If we are not at the end of the tuplestore, or are going backwards, try
+	 * to fetch a tuple from tuplestore.
+	 */
+	eof_tuplestore = tuplestore_ateof(tuplestorestate);
+
+	if (!forward && eof_tuplestore)
+	{
+		if (!node->leader->eof_cte)
+		{
+			/*
+			 * When reversing direction at tuplestore EOF, the first
+			 * gettupleslot call will fetch the last-added tuple; but we want
+			 * to return the one before that, if possible. So do an extra
+			 * fetch.
+			 */
+			if (!tuplestore_advance(tuplestorestate, forward))
+				return NULL;	/* the tuplestore must be empty */
+		}
+		eof_tuplestore = false;
+	}
+
+	/*
+	 * If we can fetch another tuple from the tuplestore, return it.
+	 *
+	 * Note: we have to use copy=true in the tuplestore_gettupleslot call,
+	 * because we are sharing the tuplestore with other nodes that might write
+	 * into the tuplestore before we get called again.
+	 */
+	if (!eof_tuplestore)
+	{
+		if (tuplestore_gettupleslot(tuplestorestate, forward, true, slot))
+			return slot;
+		if (forward)
+			eof_tuplestore = true;
+	}
+
+	/*
+	 * If necessary, try to fetch another row from the CTE query.
+	 *
+	 * Note: the eof_cte state variable exists to short-circuit further calls
+	 * of the CTE plan.  It's not optional, unfortunately, because some plan
+	 * node types are not robust about being called again when they've already
+	 * returned NULL.
+	 */
+	if (eof_tuplestore && !node->leader->eof_cte)
+	{
+		TupleTableSlot *cteslot;
+
+		/*
+		 * We can only get here with forward==true, so no need to worry about
+		 * which direction the subplan will go.
+		 */
+		cteslot = ExecProcNode(node->cteplanstate);
+		if (TupIsNull(cteslot))
+		{
+			node->leader->eof_cte = true;
+			return NULL;
+		}
+
+		/*
+		 * Append a copy of the returned tuple to tuplestore.  NOTE: because
+		 * our read pointer is certainly in EOF state, its read position will
+		 * move forward over the added tuple.  This is what we want.  Also,
+		 * any other readers will *not* move past the new tuple, which is
+		 * what they want.
+		 */
+		tuplestore_puttupleslot(tuplestorestate, cteslot);
+
+		/*
+		 * We MUST copy the CTE query's output tuple into our own slot.
+		 * This is because other CteScan nodes might advance the CTE query
+		 * before we are called again, and our output tuple must stay
+		 * stable over that.
+		 */
+		return ExecCopySlot(slot, cteslot);
+	}
+
+	/*
+	 * Nothing left ...
+	 */
+	return ExecClearTuple(slot);
+}
+
+/* ----------------------------------------------------------------
+ *		ExecCteScan(node)
+ *
+ *		Scans the CTE sequentially and returns the next qualifying tuple.
+ *		It calls the ExecScan() routine and passes it the access method
+ *		which retrieves tuples sequentially.
+ * ----------------------------------------------------------------
+ */
+TupleTableSlot *
+ExecCteScan(CteScanState *node)
+{
+	/*
+	 * use CteScanNext as access method
+	 */
+	return ExecScan(&node->ss, (ExecScanAccessMtd) CteScanNext);
+}
+
+
+/* ----------------------------------------------------------------
+ *		ExecInitCteScan
+ * ----------------------------------------------------------------
+ */
+CteScanState *
+ExecInitCteScan(CteScan *node, EState *estate, int eflags)
+{
+	CteScanState *scanstate;
+	ParamExecData *prmdata;
+
+	/* check for unsupported flags */
+	Assert(!(eflags & EXEC_FLAG_MARK));
+
+	/*
+	 * For the moment we have to force the tuplestore to allow REWIND, because
+	 * we might be asked to rescan the CTE even though upper levels didn't
+	 * tell us to be prepared to do it efficiently.  Annoying, since this
+	 * prevents truncation of the tuplestore.  XXX FIXME
+	 */
+	eflags |= EXEC_FLAG_REWIND;
+
+	/*
+	 * CteScan should not have any children.
+	 */
+	Assert(outerPlan(node) == NULL);
+	Assert(innerPlan(node) == NULL);
+
+	/*
+	 * create new CteScanState for node
+	 */
+	scanstate = makeNode(CteScanState);
+	scanstate->ss.ps.plan = (Plan *) node;
+	scanstate->ss.ps.state = estate;
+	scanstate->eflags = eflags;
+	scanstate->cte_table = NULL;
+	scanstate->eof_cte = false;
+
+	/*
+	 * Find the already-initialized plan for the CTE query.
+	 */
+	scanstate->cteplanstate = (PlanState *) list_nth(estate->es_subplanstates,
+													 node->ctePlanId - 1);
+
+	/*
+	 * The Param slot associated with the CTE query is used to hold a
+	 * pointer to the CteState of the first CteScan node that initializes
+	 * for this CTE.  This node will be the one that holds the shared
+	 * state for all the CTEs.
+	 */
+	prmdata = &(estate->es_param_exec_vals[node->cteParam]);
+	Assert(prmdata->execPlan == NULL);
+	Assert(!prmdata->isnull);
+	scanstate->leader = (CteScanState *) DatumGetPointer(prmdata->value);
+	if (scanstate->leader == NULL)
+	{
+		/* I am the leader */
+		prmdata->value = PointerGetDatum(scanstate);
+		scanstate->leader = scanstate;
+		scanstate->cte_table = tuplestore_begin_heap(true, false, work_mem);
+		tuplestore_set_eflags(scanstate->cte_table, scanstate->eflags);
+		scanstate->readptr = 0;
+	}
+	else
+	{
+		/* Not the leader */
+		Assert(IsA(scanstate->leader, CteScanState));
+		scanstate->readptr =
+			tuplestore_alloc_read_pointer(scanstate->leader->cte_table,
+										  scanstate->eflags);
+	}
+
+	/*
+	 * Miscellaneous initialization
+	 *
+	 * create expression context for node
+	 */
+	ExecAssignExprContext(estate, &scanstate->ss.ps);
+
+	/*
+	 * initialize child expressions
+	 */
+	scanstate->ss.ps.targetlist = (List *)
+		ExecInitExpr((Expr *) node->scan.plan.targetlist,
+					 (PlanState *) scanstate);
+	scanstate->ss.ps.qual = (List *)
+		ExecInitExpr((Expr *) node->scan.plan.qual,
+					 (PlanState *) scanstate);
+
+#define CTESCAN_NSLOTS 2
+
+	/*
+	 * tuple table initialization
+	 */
+	ExecInitResultTupleSlot(estate, &scanstate->ss.ps);
+	ExecInitScanTupleSlot(estate, &scanstate->ss);
+
+	/*
+	 * The scan tuple type (ie, the rowtype we expect to find in the work
+	 * table) is the same as the result rowtype of the CTE query.
+	 */
+	ExecAssignScanType(&scanstate->ss,
+					   ExecGetResultType(scanstate->cteplanstate));
+
+	/*
+	 * Initialize result tuple type and projection info.
+	 */
+	ExecAssignResultTypeFromTL(&scanstate->ss.ps);
+	ExecAssignScanProjectionInfo(&scanstate->ss);
+
+	return scanstate;
+}
+
+int
+ExecCountSlotsCteScan(CteScan *node)
+{
+	return ExecCountSlotsNode(outerPlan(node)) +
+		ExecCountSlotsNode(innerPlan(node)) +
+		CTESCAN_NSLOTS;
+}
+
+/* ----------------------------------------------------------------
+ *		ExecEndCteScan
+ *
+ *		frees any storage allocated through C routines.
+ * ----------------------------------------------------------------
+ */
+void
+ExecEndCteScan(CteScanState *node)
+{
+	/*
+	 * Free exprcontext
+	 */
+	ExecFreeExprContext(&node->ss.ps);
+
+	/*
+	 * clean out the tuple table
+	 */
+	ExecClearTuple(node->ss.ps.ps_ResultTupleSlot);
+	ExecClearTuple(node->ss.ss_ScanTupleSlot);
+
+	/*
+	 * If I am the leader, free the tuplestore.
+	 */
+	if (node->leader == node)
+		tuplestore_end(node->cte_table);
+}
+
+/* ----------------------------------------------------------------
+ *		ExecCteScanReScan
+ *
+ *		Rescans the relation.
+ * ----------------------------------------------------------------
+ */
+void
+ExecCteScanReScan(CteScanState *node, ExprContext *exprCtxt)
+{
+	Tuplestorestate *tuplestorestate;
+
+	tuplestorestate = node->leader->cte_table;
+
+	ExecClearTuple(node->ss.ps.ps_ResultTupleSlot);
+
+	if (node->leader == node)
+	{
+		/*
+		 * The leader is responsible for clearing the tuplestore if a new
+		 * scan of the underlying CTE is required.
+		 */
+		if (node->cteplanstate->chgParam != NULL)
+		{
+			tuplestore_clear(tuplestorestate);
+			node->eof_cte = false;
+		}
+		else
+		{
+			tuplestore_select_read_pointer(tuplestorestate, node->readptr);
+			tuplestore_rescan(tuplestorestate);
+		}
+	}
+	else
+	{
+		/* Not leader, so just rewind my own pointer */
+		tuplestore_select_read_pointer(tuplestorestate, node->readptr);
+		tuplestore_rescan(tuplestorestate);
+	}
+}

--- a/src/backend/executor/nodeRecursiveunion.c
+++ b/src/backend/executor/nodeRecursiveunion.c
@@ -1,0 +1,225 @@
+/*-------------------------------------------------------------------------
+ *
+ * nodeRecursiveunion.c
+ *	  routines to handle RecursiveUnion nodes.
+ *
+ * Portions Copyright (c) 1996-2008, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ *
+ * IDENTIFICATION
+ *	  $PostgreSQL: pgsql/src/backend/executor/nodeRecursiveunion.c,v 1.1 2008/10/04 21:56:53 tgl Exp $
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include "executor/execdebug.h"
+#include "executor/nodeRecursiveunion.h"
+#include "miscadmin.h"
+
+
+/* ----------------------------------------------------------------
+ *		ExecRecursiveUnion(node)
+ *
+ *		Scans the recursive query sequentially and returns the next
+ *      qualifying tuple.
+ *
+ * 1. evaluate non recursive term and assign the result to RT
+ *
+ * 2. execute recursive terms
+ *
+ * 2.1 WT := RT
+ * 2.2 while WT is not empty repeat 2.3 to 2.6. if WT is empty returns RT
+ * 2.3 replace the name of recursive term with WT
+ * 2.4 evaluate the recursive term and store into WT
+ * 2.5 append WT to RT
+ * 2.6 go back to 2.2
+ * ----------------------------------------------------------------
+ */
+TupleTableSlot *
+ExecRecursiveUnion(RecursiveUnionState *node)
+{
+	PlanState  *outerPlan = outerPlanState(node);
+	PlanState  *innerPlan = innerPlanState(node);
+	RecursiveUnion *plan = (RecursiveUnion *) node->ps.plan;
+	TupleTableSlot *slot;
+
+	/* 1. Evaluate non-recursive term */
+	if (!node->recursing)
+	{
+		slot = ExecProcNode(outerPlan);
+		if (!TupIsNull(slot))
+		{
+			tuplestore_puttupleslot(node->working_table, slot);
+			return slot;
+		}
+		node->recursing = true;
+	}
+
+retry:
+	/* 2. Execute recursive term */
+	slot = ExecProcNode(innerPlan);
+	if (TupIsNull(slot))
+	{
+		if (node->intermediate_empty)
+			return NULL;
+
+		/* done with old working table ... */
+		tuplestore_end(node->working_table);
+
+		/* intermediate table becomes working table */
+		node->working_table = node->intermediate_table;
+
+		/* create new empty intermediate table */
+		node->intermediate_table = tuplestore_begin_heap(false, false, work_mem);
+		node->intermediate_empty = true;
+
+		/* and reset the inner plan */
+		innerPlan->chgParam = bms_add_member(innerPlan->chgParam,
+											 plan->wtParam);
+		goto retry;
+	}
+ 	else
+ 	{
+ 		node->intermediate_empty = false;
+ 		tuplestore_puttupleslot(node->intermediate_table, slot);
+ 	}
+
+	return slot;
+}
+
+/* ----------------------------------------------------------------
+ *		ExecInitRecursiveUnionScan
+ * ----------------------------------------------------------------
+ */
+RecursiveUnionState *
+ExecInitRecursiveUnion(RecursiveUnion *node, EState *estate, int eflags)
+{
+	RecursiveUnionState *rustate;
+	ParamExecData *prmdata;
+
+	/* check for unsupported flags */
+	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));
+
+	/*
+	 * create state structure
+	 */
+	rustate = makeNode(RecursiveUnionState);
+	rustate->ps.plan = (Plan *) node;
+	rustate->ps.state = estate;
+
+	/* initialize processing state */
+	rustate->recursing = false;
+	rustate->intermediate_empty = true;
+	rustate->working_table = tuplestore_begin_heap(false, false, work_mem);
+	rustate->intermediate_table = tuplestore_begin_heap(false, false, work_mem);
+
+	/*
+	 * Make the state structure available to descendant WorkTableScan nodes
+	 * via the Param slot reserved for it.
+	 */
+	prmdata = &(estate->es_param_exec_vals[node->wtParam]);
+	Assert(prmdata->execPlan == NULL);
+	prmdata->value = PointerGetDatum(rustate);
+	prmdata->isnull = false;
+
+	/*
+	 * Miscellaneous initialization
+	 *
+	 * RecursiveUnion plans don't have expression contexts because they never
+	 * call ExecQual or ExecProject.
+	 */
+	Assert(node->plan.qual == NIL);
+
+#define RECURSIVEUNION_NSLOTS 1
+
+	/*
+	 * RecursiveUnion nodes still have Result slots, which hold pointers to
+	 * tuples, so we have to initialize them.
+	 */
+	ExecInitResultTupleSlot(estate, &rustate->ps);
+
+	/*
+	 * Initialize result tuple type and projection info.  (Note: we have
+	 * to set up the result type before initializing child nodes, because
+	 * nodeWorktablescan.c expects it to be valid.)
+	 */
+	ExecAssignResultTypeFromTL(&rustate->ps);
+	rustate->ps.ps_ProjInfo = NULL;
+
+	/*
+	 * initialize child nodes
+	 */
+	outerPlanState(rustate) = ExecInitNode(outerPlan(node), estate, eflags);
+	innerPlanState(rustate) = ExecInitNode(innerPlan(node), estate, eflags);
+
+	return rustate;
+}
+
+int
+ExecCountSlotsRecursiveUnion(RecursiveUnion *node)
+{
+	return ExecCountSlotsNode(outerPlan(node)) +
+		ExecCountSlotsNode(innerPlan(node)) +
+		RECURSIVEUNION_NSLOTS;
+}
+
+/* ----------------------------------------------------------------
+ *		ExecEndRecursiveUnionScan
+ *
+ *		frees any storage allocated through C routines.
+ * ----------------------------------------------------------------
+ */
+void
+ExecEndRecursiveUnion(RecursiveUnionState *node)
+{
+	/* Release tuplestores */
+	tuplestore_end(node->working_table);
+	tuplestore_end(node->intermediate_table);
+
+	/*
+	 * clean out the upper tuple table
+	 */
+	ExecClearTuple(node->ps.ps_ResultTupleSlot);
+
+	/*
+	 * close down subplans
+	 */
+	ExecEndNode(outerPlanState(node));
+	ExecEndNode(innerPlanState(node));
+}
+
+/* ----------------------------------------------------------------
+ *		ExecRecursiveUnionReScan
+ *
+ *		Rescans the relation.
+ * ----------------------------------------------------------------
+ */
+void
+ExecRecursiveUnionReScan(RecursiveUnionState *node, ExprContext *exprCtxt)
+{
+	PlanState  *outerPlan = outerPlanState(node);
+	PlanState  *innerPlan = innerPlanState(node);
+	RecursiveUnion *plan = (RecursiveUnion *) node->ps.plan;
+
+	/*
+	 * Set recursive term's chgParam to tell it that we'll modify the
+	 * working table and therefore it has to rescan.
+	 */
+	innerPlan->chgParam = bms_add_member(innerPlan->chgParam, plan->wtParam);
+
+	/*
+	 * if chgParam of subnode is not null then plan will be re-scanned by
+	 * first ExecProcNode.  Because of above, we only have to do this to
+	 * the non-recursive term.
+	 */
+	if (outerPlan->chgParam == NULL)
+		ExecReScan(outerPlan, exprCtxt);
+
+	/* reset processing state */
+	node->recursing = false;
+	node->intermediate_empty = true;
+	tuplestore_clear(node->working_table);
+	tuplestore_clear(node->intermediate_table);
+}

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -4,11 +4,11 @@
  *	  routines to support subselects
  *
  * Portions Copyright (c) 2005-2010, Greenplum inc
- * Portions Copyright (c) 1996-2009, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1996-2008, PostgreSQL Global Development Group
  * Portions Copyright (c) 1994, Regents of the University of California
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/executor/nodeSubplan.c,v 1.92.2.1 2010/07/28 04:51:14 tgl Exp $
+ *	  $PostgreSQL: pgsql/src/backend/executor/nodeSubplan.c,v 1.95 2008/10/04 21:56:53 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -21,21 +21,19 @@
 
 #include <math.h>
 
-#include "access/heapam.h"
 #include "executor/executor.h"
 #include "executor/nodeSubplan.h"
-#include "cdb/cdbexplain.h"             /* cdbexplain_recvExecStats */
-#include "cdb/cdbvars.h"
-#include "cdb/cdbdisp.h"
-#include "cdb/cdbdisp_query.h"
-#include "cdb/ml_ipc.h"
 #include "nodes/makefuncs.h"
 #include "optimizer/clauses.h"
 #include "utils/array.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
-
-#include <math.h>                       /* ceil() */
+#include "access/heapam.h"
+#include "cdb/cdbexplain.h"             /* cdbexplain_recvExecStats */
+#include "cdb/cdbvars.h"
+#include "cdb/cdbdisp.h"
+#include "cdb/cdbdisp_query.h"
+#include "cdb/ml_ipc.h"
 
 
 static Datum ExecHashSubPlan(SubPlanState *node,
@@ -69,12 +67,16 @@ ExecSubPlan(SubPlanState *node,
 	if (isDone)
 		*isDone = ExprSingleResult;
 
+	/* Sanity checks */
+	if (subplan->subLinkType == CTE_SUBLINK)
+		elog(ERROR, "CTE subplans should not be executed via ExecSubPlan");
 	if (subplan->setParam != NIL)
 		elog(ERROR, "cannot set parent params from subquery");
 
 	/* Remember that we're recursing into a sub-plan */
 	node->planstate->state->currentSubplanLevel++;
 
+	/* Select appropriate evaluation strategy */
 	if (subplan->useHashTable)
 		result = ExecHashSubPlan(node, econtext, isNull);
 	else
@@ -704,11 +706,14 @@ ExecInitSubPlan(SubPlan *subplan, PlanState *parent)
 	 * If this plan is un-correlated or undirect correlated one and want to
 	 * set params for parent plan then mark parameters as needing evaluation.
 	 *
+	 * A CTE subplan's output parameter is never to be evaluated in the normal
+	 * way, so skip this in that case.
+	 *
 	 * Note that in the case of un-correlated subqueries we don't care about
 	 * setting parent->chgParam here: indices take care about it, for others -
 	 * it doesn't matter...
 	 */
-	if (subplan->setParam != NIL)
+	if (subplan->setParam != NIL && subplan->subLinkType != CTE_SUBLINK)
 	{
 		ListCell   *lst;
 
@@ -1037,22 +1042,21 @@ PG_TRY();
 		}
 	}
 
+	if (subLinkType == ANY_SUBLINK ||
+		subLinkType == ALL_SUBLINK)
+		elog(ERROR, "ANY/ALL subselect unsupported as initplan");
+	if (subLinkType == CTE_SUBLINK)
+		elog(ERROR, "CTE subplans should not be executed via ExecSetParamPlan");
+
 	/*
 	 * Must switch to per-query memory context.
 	 */
 	oldcontext = MemoryContextSwitchTo(econtext->ecxt_per_query_memory);
 
-	if (subLinkType == ANY_SUBLINK ||
-		subLinkType == ALL_SUBLINK)
-		elog(ERROR, "ANY/ALL subselect unsupported as initplan");
-
 	/*
-	 * By definition, an initplan has no parameters from our query level, but
-	 * it could have some from an outer level.	Rescan it if needed.
+	 * Run the plan.  (If it needs to be rescanned, the first ExecProcNode
+	 * call will take care of that.)
 	 */
-	if (planstate->chgParam != NULL)
-		ExecReScan(planstate, NULL);
-
 	for (slot = ExecProcNode(planstate);
 		 !TupIsNull(slot);
 		 slot = ExecProcNode(planstate))
@@ -1061,7 +1065,7 @@ PG_TRY();
 
 		if (subLinkType == EXISTS_SUBLINK || subLinkType == NOT_EXISTS_SUBLINK)
 		{
-			/* There can be only one param... */
+			/* There can be only one setParam... */
 			int			paramid = linitial_int(subplan->setParam);
 			ParamExecData *prm = &(econtext->ecxt_param_exec_vals[paramid]);
 
@@ -1069,7 +1073,7 @@ PG_TRY();
 			if (subLinkType == NOT_EXISTS_SUBLINK)
 				prm->value = BoolGetDatum(false);
 			else
-				prm->value = BoolGetDatum(true);
+			prm->value = BoolGetDatum(true);
 			prm->isnull = false;
 			found = true;
 
@@ -1133,12 +1137,12 @@ PG_TRY();
 	if (!found)
 	{
 		if (subLinkType == EXISTS_SUBLINK || subLinkType == NOT_EXISTS_SUBLINK)
-		{
-			/* There can be only one param... */
-			int			paramid = linitial_int(subplan->setParam);
-			ParamExecData *prm = &(econtext->ecxt_param_exec_vals[paramid]);
+	{
+		/* There can be only one setParam... */
+		int			paramid = linitial_int(subplan->setParam);
+		ParamExecData *prm = &(econtext->ecxt_param_exec_vals[paramid]);
 
-			prm->execPlan = NULL;
+		prm->execPlan = NULL;
 			if (subLinkType == NOT_EXISTS_SUBLINK)
 				prm->value = BoolGetDatum(true);
 			else
@@ -1159,17 +1163,17 @@ PG_TRY();
 		}
 	}
 	else if (subLinkType == ARRAY_SUBLINK)
-	{
-		/* There can be only one param... */
-		int			paramid = linitial_int(subplan->setParam);
-		ParamExecData *prm = &(econtext->ecxt_param_exec_vals[paramid]);
+		{
+			/* There can be only one setParam... */
+			int			paramid = linitial_int(subplan->setParam);
+			ParamExecData *prm = &(econtext->ecxt_param_exec_vals[paramid]);
 
 		Assert(astate != NULL);
-		prm->execPlan = NULL;
+			prm->execPlan = NULL;
 		/* We build the result in query context so it won't disappear */
 		prm->value = makeArrayResult(astate, econtext->ecxt_per_query_memory);
-		prm->isnull = false;
-	}
+			prm->isnull = false;
+		}
 
 	/*
 	 * If we dispatched to QEs, wait for completion and check for errors.
@@ -1207,7 +1211,7 @@ PG_TRY();
 		
 	/* Clean up the interconnect. */
 	if (shouldTeardownInterconnect)
-	{
+			{
 		shouldTeardownInterconnect = false;
 
 		TeardownInterconnect(queryDesc->estate->interconnect_context, 
@@ -1215,7 +1219,7 @@ PG_TRY();
 							 false); /* following success on QD */
 		queryDesc->estate->interconnect_context = NULL;
 	}
-}
+			}
 PG_CATCH();
 {
 	/* If EXPLAIN ANALYZE, collect local and distributed execution stats. */
@@ -1299,18 +1303,25 @@ ExecReScanSetParamPlan(SubPlanState *node, PlanState *parent)
 		elog(ERROR, "extParam set of initplan is empty");
 
 	/*
-	 * Don't actually re-scan: ExecSetParamPlan does it if needed.
+	 * Don't actually re-scan: it'll happen inside ExecSetParamPlan if needed.
 	 */
 
 	/*
-	 * Mark this subplan's output parameters as needing recalculation
+	 * Mark this subplan's output parameters as needing recalculation.
+	 *
+	 * CTE subplans are never executed via parameter recalculation; instead
+	 * they get run when called by nodeCtescan.c.  So don't mark the output
+	 * parameter of a CTE subplan as dirty, but do set the chgParam bit
+	 * for it so that dependent plan nodes will get told to rescan.
 	 */
 	foreach(l, subplan->setParam)
 	{
 		int			paramid = lfirst_int(l);
 		ParamExecData *prm = &(estate->es_param_exec_vals[paramid]);
 
-		prm->execPlan = node;
+		if (subplan->subLinkType != CTE_SUBLINK)
+			prm->execPlan = node;
+
 		parent->chgParam = bms_add_member(parent->chgParam, paramid);
 	}
 }

--- a/src/backend/executor/nodeWorktablescan.c
+++ b/src/backend/executor/nodeWorktablescan.c
@@ -1,0 +1,190 @@
+/*-------------------------------------------------------------------------
+ *
+ * nodeWorktablescan.c
+ *	  routines to handle WorkTableScan nodes.
+ *
+ * Portions Copyright (c) 1996-2008, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ *
+ * IDENTIFICATION
+ *	  $PostgreSQL: pgsql/src/backend/executor/nodeWorktablescan.c,v 1.1 2008/10/04 21:56:53 tgl Exp $
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "executor/execdebug.h"
+#include "executor/nodeWorktablescan.h"
+
+static TupleTableSlot *WorkTableScanNext(WorkTableScanState *node);
+
+/* ----------------------------------------------------------------
+ *		WorkTableScanNext
+ *
+ *		This is a workhorse for ExecWorkTableScan
+ * ----------------------------------------------------------------
+ */
+static TupleTableSlot *
+WorkTableScanNext(WorkTableScanState *node)
+{
+	TupleTableSlot *slot;
+	EState	   *estate;
+	ScanDirection direction;
+	Tuplestorestate *tuplestorestate;
+
+	/*
+	 * get information from the estate and scan state
+	 */
+	estate = node->ss.ps.state;
+	direction = estate->es_direction;
+
+	tuplestorestate = node->rustate->working_table;
+
+	/*
+	 * Get the next tuple from tuplestore. Return NULL if no more tuples.
+	 */
+	slot = node->ss.ss_ScanTupleSlot;
+	(void) tuplestore_gettupleslot(tuplestorestate, true, false, slot);
+	return slot;
+}
+
+/* ----------------------------------------------------------------
+ *		ExecWorkTableScan(node)
+ *
+ *		Scans the worktable sequentially and returns the next qualifying tuple.
+ *		It calls the ExecScan() routine and passes it the access method
+ *		which retrieves tuples sequentially.
+ * ----------------------------------------------------------------
+ */
+TupleTableSlot *
+ExecWorkTableScan(WorkTableScanState *node)
+{
+	/*
+	 * use WorkTableScanNext as access method
+	 */
+	return ExecScan(&node->ss, (ExecScanAccessMtd) WorkTableScanNext);
+}
+
+
+/* ----------------------------------------------------------------
+ *		ExecInitWorkTableScan
+ * ----------------------------------------------------------------
+ */
+WorkTableScanState *
+ExecInitWorkTableScan(WorkTableScan *node, EState *estate, int eflags)
+{
+	WorkTableScanState *scanstate;
+	ParamExecData *prmdata;
+
+	/* check for unsupported flags */
+	Assert(!(eflags & EXEC_FLAG_MARK));
+
+	/*
+	 * WorkTableScan should not have any children.
+	 */
+	Assert(outerPlan(node) == NULL);
+	Assert(innerPlan(node) == NULL);
+
+	/*
+	 * create new WorkTableScanState for node
+	 */
+	scanstate = makeNode(WorkTableScanState);
+	scanstate->ss.ps.plan = (Plan *) node;
+	scanstate->ss.ps.state = estate;
+
+	/*
+	 * Find the ancestor RecursiveUnion's state
+	 * via the Param slot reserved for it.
+	 */
+	prmdata = &(estate->es_param_exec_vals[node->wtParam]);
+	Assert(prmdata->execPlan == NULL);
+	Assert(!prmdata->isnull);
+	scanstate->rustate = (RecursiveUnionState *) DatumGetPointer(prmdata->value);
+	Assert(scanstate->rustate && IsA(scanstate->rustate, RecursiveUnionState));
+
+	/*
+	 * Miscellaneous initialization
+	 *
+	 * create expression context for node
+	 */
+	ExecAssignExprContext(estate, &scanstate->ss.ps);
+
+	/*
+	 * initialize child expressions
+	 */
+	scanstate->ss.ps.targetlist = (List *)
+		ExecInitExpr((Expr *) node->scan.plan.targetlist,
+					 (PlanState *) scanstate);
+	scanstate->ss.ps.qual = (List *)
+		ExecInitExpr((Expr *) node->scan.plan.qual,
+					 (PlanState *) scanstate);
+
+#define WORKTABLESCAN_NSLOTS 2
+
+	/*
+	 * tuple table initialization
+	 */
+	ExecInitResultTupleSlot(estate, &scanstate->ss.ps);
+	ExecInitScanTupleSlot(estate, &scanstate->ss);
+
+	/*
+	 * The scan tuple type (ie, the rowtype we expect to find in the work
+	 * table) is the same as the result rowtype of the ancestor RecursiveUnion
+	 * node.  Note this depends on the assumption that RecursiveUnion doesn't
+	 * allow projection.
+	 */
+	ExecAssignScanType(&scanstate->ss,
+					   ExecGetResultType(&scanstate->rustate->ps));
+
+	/*
+	 * Initialize result tuple type and projection info.
+	 */
+	ExecAssignResultTypeFromTL(&scanstate->ss.ps);
+	ExecAssignScanProjectionInfo(&scanstate->ss);
+
+	return scanstate;
+}
+
+int
+ExecCountSlotsWorkTableScan(WorkTableScan *node)
+{
+	return ExecCountSlotsNode(outerPlan(node)) +
+		ExecCountSlotsNode(innerPlan(node)) +
+		WORKTABLESCAN_NSLOTS;
+}
+
+/* ----------------------------------------------------------------
+ *		ExecEndWorkTableScan
+ *
+ *		frees any storage allocated through C routines.
+ * ----------------------------------------------------------------
+ */
+void
+ExecEndWorkTableScan(WorkTableScanState *node)
+{
+	/*
+	 * Free exprcontext
+	 */
+	ExecFreeExprContext(&node->ss.ps);
+
+	/*
+	 * clean out the tuple table
+	 */
+	ExecClearTuple(node->ss.ps.ps_ResultTupleSlot);
+	ExecClearTuple(node->ss.ss_ScanTupleSlot);
+}
+
+/* ----------------------------------------------------------------
+ *		ExecWorkTableScanReScan
+ *
+ *		Rescans the relation.
+ * ----------------------------------------------------------------
+ */
+void
+ExecWorkTableScanReScan(WorkTableScanState *node, ExprContext *exprCtxt)
+{
+	ExecClearTuple(node->ss.ps.ps_ResultTupleSlot);
+	tuplestore_rescan(node->rustate->working_table);
+}

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -23,7 +23,7 @@
  * Portions Copyright (c) 1994, Regents of the University of California
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/nodes/equalfuncs.c,v 1.318.2.1 2009/04/16 20:42:27 tgl Exp $
+ *	  $PostgreSQL: pgsql/src/backend/nodes/equalfuncs.c,v 1.332 2008/10/04 21:56:53 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -2226,24 +2226,24 @@ _equalRangeTblEntry(RangeTblEntry *a, RangeTblEntry *b)
 	COMPARE_SCALAR_FIELD(rtekind);
 	COMPARE_SCALAR_FIELD(relid);
 	COMPARE_NODE_FIELD(subquery);
+	COMPARE_SCALAR_FIELD(jointype);
+	COMPARE_NODE_FIELD(joinaliasvars);
 	COMPARE_NODE_FIELD(funcexpr);
 	COMPARE_NODE_FIELD(funccoltypes);
 	COMPARE_NODE_FIELD(funccoltypmods);
 	COMPARE_VARLENA_FIELD(funcuserdata, -1);
 	COMPARE_NODE_FIELD(values_lists);
-	COMPARE_SCALAR_FIELD(jointype);
-	COMPARE_NODE_FIELD(joinaliasvars);
+	COMPARE_STRING_FIELD(ctename);
+	COMPARE_SCALAR_FIELD(ctelevelsup);
+	COMPARE_SCALAR_FIELD(self_reference);
+	COMPARE_NODE_FIELD(ctecoltypes);
+	COMPARE_NODE_FIELD(ctecoltypmods);
 	COMPARE_NODE_FIELD(alias);
 	COMPARE_NODE_FIELD(eref);
 	COMPARE_SCALAR_FIELD(inh);
 	COMPARE_SCALAR_FIELD(inFromCl);
 	COMPARE_SCALAR_FIELD(requiredPerms);
 	COMPARE_SCALAR_FIELD(checkAsUser);
-	COMPARE_STRING_FIELD(ctename);
-	COMPARE_SCALAR_FIELD(ctelevelsup);
-	COMPARE_SCALAR_FIELD(self_reference);
-	COMPARE_NODE_FIELD(ctecoltypes);
-	COMPARE_NODE_FIELD(ctecoltypmods);
 
 	return true;
 }
@@ -3122,10 +3122,10 @@ equal(void *a, void *b)
 			retval = _equalRowMarkClause(a, b);
 			break;
 		case T_WithClause:
-			retval = _equalWithClause(a,b);
+			retval = _equalWithClause(a, b);
 			break;
 		case T_CommonTableExpr:
-			retval = _equalCommonTableExpr(a,b);
+			retval = _equalCommonTableExpr(a, b);
 			break;
 		case T_FkConstraint:
 			retval = _equalFkConstraint(a, b);

--- a/src/backend/nodes/nodeFuncs.c
+++ b/src/backend/nodes/nodeFuncs.c
@@ -8,7 +8,7 @@
  *
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/nodes/nodeFuncs.c,v 1.29 2008/01/01 19:45:50 momjian Exp $
+ *	  $PostgreSQL: pgsql/src/backend/nodes/nodeFuncs.c,v 1.33 2008/10/04 21:56:53 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/nodes/print.c
+++ b/src/backend/nodes/print.c
@@ -8,7 +8,7 @@
  *
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/nodes/print.c,v 1.87 2008/01/01 19:45:50 momjian Exp $
+ *	  $PostgreSQL: pgsql/src/backend/nodes/print.c,v 1.90 2008/10/04 21:56:53 tgl Exp $
  *
  * HISTORY
  *	  AUTHOR			DATE			MAJOR EVENT

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -9,7 +9,7 @@
  *
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/nodes/readfuncs.c,v 1.210 2008/01/01 19:45:50 momjian Exp $
+ *	  $PostgreSQL: pgsql/src/backend/nodes/readfuncs.c,v 1.215 2008/10/04 21:56:53 tgl Exp $
  *
  * NOTES
  *	  Path and Plan nodes do not need to have any readfuncs support, because we
@@ -2042,12 +2042,9 @@ _readRangeTblEntry(void)
 		case RTE_SUBQUERY:
 			READ_NODE_FIELD(subquery);
 			break;
-		case RTE_CTE:
-			READ_STRING_FIELD(ctename);
-			READ_INT_FIELD(ctelevelsup);
-			READ_BOOL_FIELD(self_reference);
-			READ_NODE_FIELD(ctecoltypes);
-			READ_NODE_FIELD(ctecoltypmods);
+		case RTE_JOIN:
+			READ_ENUM_FIELD(jointype, JoinType);
+			READ_NODE_FIELD(joinaliasvars);
 			break;
 		case RTE_FUNCTION:
 			READ_NODE_FIELD(funcexpr);
@@ -2067,9 +2064,12 @@ _readRangeTblEntry(void)
 		case RTE_VALUES:
 			READ_NODE_FIELD(values_lists);
 			break;
-		case RTE_JOIN:
-			READ_ENUM_FIELD(jointype, JoinType);
-			READ_NODE_FIELD(joinaliasvars);
+		case RTE_CTE:
+			READ_STRING_FIELD(ctename);
+			READ_UINT_FIELD(ctelevelsup);
+			READ_BOOL_FIELD(self_reference);
+			READ_NODE_FIELD(ctecoltypes);
+			READ_NODE_FIELD(ctecoltypmods);
 			break;
         case RTE_VOID:                                                  /*CDB*/
             break;

--- a/src/backend/optimizer/util/walkers.c
+++ b/src/backend/optimizer/util/walkers.c
@@ -1447,3 +1447,304 @@ find_nodes_walker(Node *node, find_nodes_context *context)
 
 	return expression_tree_walker(node, find_nodes_walker, (void *) context);
 }
+
+/*
+ * raw_expression_tree_walker --- walk raw parse trees
+ *
+ * This has exactly the same API as expression_tree_walker, but instead of
+ * walking post-analysis parse trees, it knows how to walk the node types
+ * found in raw grammar output.  (There is not currently any need for a
+ * combined walker, so we keep them separate in the name of efficiency.)
+ * Unlike expression_tree_walker, there is no special rule about query
+ * boundaries: we descend to everything that's possibly interesting.
+ *
+ * Currently, the node type coverage extends to SelectStmt and everything
+ * that could appear under it, but not other statement types.
+ */
+bool
+raw_expression_tree_walker(Node *node, bool (*walker) (), void *context)
+{
+	ListCell   *temp;
+
+	/*
+	 * The walker has already visited the current node, and so we need only
+	 * recurse into any sub-nodes it has.
+	 */
+	if (node == NULL)
+		return false;
+
+	/* Guard against stack overflow due to overly complex expressions */
+	check_stack_depth();
+
+	switch (nodeTag(node))
+	{
+		case T_SetToDefault:
+		case T_CurrentOfExpr:
+		case T_Integer:
+		case T_Float:
+		case T_String:
+		case T_BitString:
+		case T_Null:
+		case T_ParamRef:
+		case T_A_Const:
+		case T_A_Star:
+			/* primitive node types with no subnodes */
+			break;
+		case T_Alias:
+			/* we assume the colnames list isn't interesting */
+			break;
+		case T_RangeVar:
+			return walker(((RangeVar *) node)->alias, context);
+		case T_SubLink:
+			{
+				SubLink    *sublink = (SubLink *) node;
+
+				if (walker(sublink->testexpr, context))
+					return true;
+				/* we assume the operName is not interesting */
+				if (walker(sublink->subselect, context))
+					return true;
+			}
+			break;
+		case T_CaseExpr:
+			{
+				CaseExpr   *caseexpr = (CaseExpr *) node;
+
+				if (walker(caseexpr->arg, context))
+					return true;
+				/* we assume walker doesn't care about CaseWhens, either */
+				foreach(temp, caseexpr->args)
+				{
+					CaseWhen   *when = (CaseWhen *) lfirst(temp);
+
+					Assert(IsA(when, CaseWhen));
+					if (walker(when->expr, context))
+						return true;
+					if (walker(when->result, context))
+						return true;
+				}
+				if (walker(caseexpr->defresult, context))
+					return true;
+			}
+			break;
+		case T_RowExpr:
+			return walker(((RowExpr *) node)->args, context);
+		case T_CoalesceExpr:
+			return walker(((CoalesceExpr *) node)->args, context);
+		case T_MinMaxExpr:
+			return walker(((MinMaxExpr *) node)->args, context);
+		case T_XmlExpr:
+			{
+				XmlExpr    *xexpr = (XmlExpr *) node;
+
+				if (walker(xexpr->named_args, context))
+					return true;
+				/* we assume walker doesn't care about arg_names */
+				if (walker(xexpr->args, context))
+					return true;
+			}
+			break;
+		case T_NullTest:
+			return walker(((NullTest *) node)->arg, context);
+		case T_BooleanTest:
+			return walker(((BooleanTest *) node)->arg, context);
+		case T_JoinExpr:
+			{
+				JoinExpr   *join = (JoinExpr *) node;
+
+				if (walker(join->larg, context))
+					return true;
+				if (walker(join->rarg, context))
+					return true;
+				if (walker(join->quals, context))
+					return true;
+				if (walker(join->alias, context))
+					return true;
+				/* using list is deemed uninteresting */
+			}
+			break;
+		case T_IntoClause:
+			{
+				IntoClause *into = (IntoClause *) node;
+
+				if (walker(into->rel, context))
+					return true;
+				/* colNames, options are deemed uninteresting */
+			}
+			break;
+		case T_List:
+			foreach(temp, (List *) node)
+			{
+				if (walker((Node *) lfirst(temp), context))
+					return true;
+			}
+			break;
+		case T_SelectStmt:
+			{
+				SelectStmt *stmt = (SelectStmt *) node;
+
+				if (walker(stmt->distinctClause, context))
+					return true;
+				if (walker(stmt->intoClause, context))
+					return true;
+				if (walker(stmt->targetList, context))
+					return true;
+				if (walker(stmt->fromClause, context))
+					return true;
+				if (walker(stmt->whereClause, context))
+					return true;
+				if (walker(stmt->groupClause, context))
+					return true;
+				if (walker(stmt->havingClause, context))
+					return true;
+				if (walker(stmt->withClause, context))
+					return true;
+				if (walker(stmt->valuesLists, context))
+					return true;
+				if (walker(stmt->sortClause, context))
+					return true;
+				if (walker(stmt->limitOffset, context))
+					return true;
+				if (walker(stmt->limitCount, context))
+					return true;
+				if (walker(stmt->lockingClause, context))
+					return true;
+				if (walker(stmt->larg, context))
+					return true;
+				if (walker(stmt->rarg, context))
+					return true;
+			}
+			break;
+		case T_A_Expr:
+			{
+				A_Expr *expr = (A_Expr *) node;
+
+				if (walker(expr->lexpr, context))
+					return true;
+				if (walker(expr->rexpr, context))
+					return true;
+				/* operator name is deemed uninteresting */
+			}
+			break;
+		case T_ColumnRef:
+			/* we assume the fields contain nothing interesting */
+			break;
+		case T_FuncCall:
+			{
+				FuncCall *fcall = (FuncCall *) node;
+
+				if (walker(fcall->args, context))
+					return true;
+				/* function name is deemed uninteresting */
+			}
+			break;
+		case T_A_Indices:
+			{
+				A_Indices *indices = (A_Indices *) node;
+
+				if (walker(indices->lidx, context))
+					return true;
+				if (walker(indices->uidx, context))
+					return true;
+			}
+			break;
+		case T_A_Indirection:
+			{
+				A_Indirection *indir = (A_Indirection *) node;
+
+				if (walker(indir->arg, context))
+					return true;
+				if (walker(indir->indirection, context))
+					return true;
+			}
+			break;
+		case T_A_ArrayExpr:
+			return walker(((A_ArrayExpr *) node)->elements, context);
+		case T_ResTarget:
+			{
+				ResTarget *rt = (ResTarget *) node;
+
+				if (walker(rt->indirection, context))
+					return true;
+				if (walker(rt->val, context))
+					return true;
+			}
+			break;
+		case T_TypeCast:
+			{
+				TypeCast *tc = (TypeCast *) node;
+
+				if (walker(tc->arg, context))
+					return true;
+				if (walker(tc->typname, context))
+					return true;
+			}
+			break;
+		case T_SortBy:
+			return walker(((SortBy *) node)->node, context);
+		case T_RangeSubselect:
+			{
+				RangeSubselect *rs = (RangeSubselect *) node;
+
+				if (walker(rs->subquery, context))
+					return true;
+				if (walker(rs->alias, context))
+					return true;
+			}
+			break;
+		case T_RangeFunction:
+			{
+				RangeFunction *rf = (RangeFunction *) node;
+
+				if (walker(rf->funccallnode, context))
+					return true;
+				if (walker(rf->alias, context))
+					return true;
+			}
+			break;
+		case T_TypeName:
+			{
+				TypeName *tn = (TypeName *) node;
+
+				if (walker(tn->typmods, context))
+					return true;
+				if (walker(tn->arrayBounds, context))
+					return true;
+				/* type name itself is deemed uninteresting */
+			}
+			break;
+		case T_ColumnDef:
+			{
+				ColumnDef *coldef = (ColumnDef *) node;
+
+				if (walker(coldef->typname, context))
+					return true;
+				if (walker(coldef->raw_default, context))
+					return true;
+				/* for now, constraints are ignored */
+			}
+			break;
+		case T_LockingClause:
+			return walker(((LockingClause *) node)->lockedRels, context);
+		case T_XmlSerialize:
+			{
+				XmlSerialize *xs = (XmlSerialize *) node;
+
+				if (walker(xs->expr, context))
+					return true;
+				if (walker(xs->typeName, context))
+					return true;
+			}
+			break;
+		case T_WithClause:
+			return walker(((WithClause *) node)->ctes, context);
+		case T_CommonTableExpr:
+			return walker(((CommonTableExpr *) node)->ctequery, context);
+		default:
+			elog(ERROR, "unrecognized node type: %d",
+				 (int) nodeTag(node));
+			break;
+	}
+	return false;
+}
+

--- a/src/backend/parser/Makefile
+++ b/src/backend/parser/Makefile
@@ -2,7 +2,7 @@
 #
 # Makefile for parser
 #
-# $PostgreSQL: pgsql/src/backend/parser/Makefile,v 1.45 2007/06/23 22:12:51 tgl Exp $
+# $PostgreSQL: pgsql/src/backend/parser/Makefile,v 1.48 2008/10/04 21:56:54 tgl Exp $
 #
 #-------------------------------------------------------------------------
 
@@ -12,7 +12,7 @@ include $(top_builddir)/src/Makefile.global
 
 override CPPFLAGS := -I$(srcdir) $(CPPFLAGS)
 
-OBJS= analyze.o gram.o keywords.o parser.o parse_agg.o parse_clause.o parse_cte.o \
+OBJS= analyze.o gram.o keywords.o parser.o parse_agg.o parse_cte.o parse_clause.o \
       parse_expr.o parse_func.o parse_node.o parse_oper.o parse_relation.o \
       parse_type.o parse_coerce.o parse_target.o scansup.o parse_utilcmd.o kwlookup.o \
       parse_partition.o

--- a/src/backend/parser/keywords.c
+++ b/src/backend/parser/keywords.c
@@ -8,7 +8,7 @@
  *
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/parser/keywords.c,v 1.194 2008/01/01 19:45:50 momjian Exp $
+ *	  $PostgreSQL: pgsql/src/backend/parser/keywords.c,v 1.202 2008/10/04 21:56:54 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/parser/parse_agg.c
+++ b/src/backend/parser/parse_agg.c
@@ -8,7 +8,7 @@
  *
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/parser/parse_agg.c,v 1.79 2008/01/01 19:45:50 momjian Exp $
+ *	  $PostgreSQL: pgsql/src/backend/parser/parse_agg.c,v 1.84 2008/10/04 21:56:54 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -208,12 +208,28 @@ parseCheckAggregates(ParseState *pstate, Query *qry)
 	bool		have_non_var_grouping;
 	ListCell   *l;
 	bool		hasJoinRTEs;
+	bool		hasSelfRefRTEs;
 	PlannerInfo *root;
 	Node	   *clause;
 
 	/* This should only be called if we found aggregates or grouping */
 	Assert(pstate->p_hasAggs || qry->groupClause || qry->havingQual);
 
+	/*
+	 * Scan the range table to see if there are JOIN or self-reference CTE
+	 * entries.  We'll need this info below.
+	 */
+	hasJoinRTEs = hasSelfRefRTEs = false;
+	foreach(l, pstate->p_rtable)
+	{
+		RangeTblEntry *rte = (RangeTblEntry *) lfirst(l);
+
+		if (rte->rtekind == RTE_JOIN)
+			hasJoinRTEs = true;
+		else if (rte->rtekind == RTE_CTE && rte->self_reference)
+			hasSelfRefRTEs = true;
+	}	
+	
 	/*
 	 * Aggregates and window functions must never appear in WHERE or 
 	 * JOIN/ON clauses.  Window function must never appear in HAVING
@@ -266,20 +282,6 @@ parseCheckAggregates(ParseState *pstate, Query *qry)
 	 * underlying vars, so that aliased and unaliased vars will be correctly
 	 * taken as equal.	We can skip the expense of doing this if no rangetable
 	 * entries are RTE_JOIN kind.
-	 */
-	hasJoinRTEs = false;
-	foreach(l, pstate->p_rtable)
-	{
-		RangeTblEntry *rte = (RangeTblEntry *) lfirst(l);
-
-		if (rte->rtekind == RTE_JOIN)
-		{
-			hasJoinRTEs = true;
-			break;
-		}
-	}
-
-	/*
 	 * We use the planner's flatten_join_alias_vars routine to do the
 	 * flattening; it wants a PlannerInfo root node, which fortunately can be
 	 * mostly dummy.
@@ -342,6 +344,16 @@ parseCheckAggregates(ParseState *pstate, Query *qry)
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("correlated subquery cannot contain percentile functions")));
 	}
+
+	/*
+	 * Per spec, aggregates can't appear in a recursive term.
+	 */
+	if (pstate->p_hasAggs && hasSelfRefRTEs)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_RECURSION),
+				 errmsg("aggregates not allowed in a recursive query's recursive term"),
+				 parser_errposition(pstate,
+									locate_agg_of_level((Node *) qry, 0))));
 }
 
 

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -9,7 +9,7 @@
  *
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/parser/parse_clause.c,v 1.168 2008/01/01 19:45:50 momjian Exp $
+ *	  $PostgreSQL: pgsql/src/backend/parser/parse_clause.c,v 1.180 2008/10/04 21:56:54 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -66,6 +66,8 @@ static Node *transformJoinOnClause(ParseState *pstate, JoinExpr *j,
 					  List *relnamespace,
 					  Relids containedRels);
 static RangeTblEntry *transformTableEntry(ParseState *pstate, RangeVar *r);
+static RangeTblEntry *transformCTEReference(ParseState *pstate, RangeVar *r,
+					  CommonTableExpr *cte, Index levelsup);
 static RangeTblEntry *transformRangeSubselect(ParseState *pstate,
 						RangeSubselect *r);
 static RangeTblEntry *transformRangeFunction(ParseState *pstate,
@@ -1124,6 +1126,20 @@ transformTableEntry(ParseState *pstate, RangeVar *r)
 	return rte;
 }
 
+/*
+ * transformCTEReference --- transform a RangeVar that references a common
+ * table expression (ie, a sub-SELECT defined in a WITH clause)
+ */
+static RangeTblEntry *
+transformCTEReference(ParseState *pstate, RangeVar *r,
+					  CommonTableExpr *cte, Index levelsup)
+{
+	RangeTblEntry *rte;
+
+	rte = addRangeTableEntryForCTE(pstate, cte, levelsup, r->alias, true);
+
+	return rte;
+}
 
 /*
  * transformRangeSubselect --- transform a sub-SELECT appearing in FROM
@@ -1371,32 +1387,46 @@ transformFromClauseItem(ParseState *pstate, Node *n,
 
 	if (IsA(n, RangeVar))
 	{
-		/* Plain relation reference */
+		/* Plain relation reference, or perhaps a CTE reference */
+		RangeVar *rv = (RangeVar *) n;
 		RangeTblRef *rtr;
 		RangeTblEntry *rte = NULL;
 		int			rtindex;
 		RangeVar *rangeVar = (RangeVar *)n;
 
 		/*
-		 * If it is an unqualified name, it might be a CTE reference.
+		 * If it is an unqualified name, it might be a reference to some
+		 * CTE visible in this or a parent query.
 		 */
-		if (rangeVar->schemaname == NULL)
+		if (!rv->schemaname)
 		{
-			CommonTableExpr *cte;
-			Index levelsup;
+			ParseState *ps;
+			Index	levelsup;
 
-			cte = scanNameSpaceForCTE(pstate, rangeVar->relname, &levelsup);
-			if (cte)
+			for (ps = pstate, levelsup = 0;
+				 ps != NULL;
+				 ps = ps->parentParseState, levelsup++)
 			{
-				rte = addRangeTableEntryForCTE(pstate, cte, levelsup, rangeVar, true);
+				ListCell *lc;
+
+				foreach(lc, ps->p_ctenamespace)
+				{
+					CommonTableExpr *cte = (CommonTableExpr *) lfirst(lc);
+
+					if (strcmp(rv->relname, cte->ctename) == 0)
+					{
+						rte = transformCTEReference(pstate, rv, cte, levelsup);
+						break;
+					}
+				}
+				if (rte)
+					break;
 			}
 		}
 
-		/* If it is not a CTE reference, it must be a simple relation reference. */
-		if (rte == NULL)
-		{
-			rte = transformTableEntry(pstate, rangeVar);
-		}
+		/* if not found as a CTE, must be a table reference */
+		if (!rte)
+			rte = transformTableEntry(pstate, rv);
 
 		/* assume new rte is at end */
 		rtindex = list_length(pstate->p_rtable);

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -1392,7 +1392,6 @@ transformFromClauseItem(ParseState *pstate, Node *n,
 		RangeTblRef *rtr;
 		RangeTblEntry *rte = NULL;
 		int			rtindex;
-		RangeVar *rangeVar = (RangeVar *)n;
 
 		/*
 		 * If it is an unqualified name, it might be a reference to some

--- a/src/backend/parser/parse_cte.c
+++ b/src/backend/parser/parse_cte.c
@@ -1,26 +1,100 @@
-/*
- * parse_cte.c
- *    Handle WITH clause in parser.
+/*-------------------------------------------------------------------------
  *
- * Copyright (c) 2011 - present, EMC Greenplum.
+ * parse_cte.c
+ *	  handle CTEs (common table expressions) in parser
+ *
+ * Portions Copyright (c) 1996-2008, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ *
+ * IDENTIFICATION
+ *	  $PostgreSQL: pgsql/src/backend/parser/parse_cte.c,v 2.1 2008/10/04 21:56:54 tgl Exp $
+ *
+ *-------------------------------------------------------------------------
  */
 #include "postgres.h"
 
-#include "parser/analyze.h"
-#include "parser/parse_node.h"
-#include "parser/parse_cte.h"
-#include "parser/parse_expr.h"
-#include "parser/parse_relation.h"
-#include "nodes/parsenodes.h"
 #include "nodes/nodeFuncs.h"
+#include "parser/analyze.h"
+#include "parser/parse_cte.h"
+#include "utils/builtins.h"
+
+
+/* Enumeration of contexts in which a self-reference is disallowed */
+typedef enum
+{
+	RECURSION_OK,
+	RECURSION_NONRECURSIVETERM,	/* inside the left-hand term */
+	RECURSION_SUBLINK,			/* inside a sublink */
+	RECURSION_OUTERJOIN,		/* inside nullable side of an outer join */
+	RECURSION_INTERSECT,		/* underneath INTERSECT (ALL) */
+	RECURSION_EXCEPT			/* underneath EXCEPT (ALL) */
+} RecursionContext;
+
+/* Associated error messages --- each must have one %s for CTE name */
+static const char * const recursion_errormsgs[] = {
+	/* RECURSION_OK */
+	NULL,
+	/* RECURSION_NONRECURSIVETERM */
+	gettext_noop("recursive reference to query \"%s\" must not appear within its non-recursive term"),
+	/* RECURSION_SUBLINK */
+	gettext_noop("recursive reference to query \"%s\" must not appear within a subquery"),
+	/* RECURSION_OUTERJOIN */
+	gettext_noop("recursive reference to query \"%s\" must not appear within an outer join"),
+	/* RECURSION_INTERSECT */
+	gettext_noop("recursive reference to query \"%s\" must not appear within INTERSECT"),
+	/* RECURSION_EXCEPT */
+	gettext_noop("recursive reference to query \"%s\" must not appear within EXCEPT")
+};
+
+/*
+ * For WITH RECURSIVE, we have to find an ordering of the clause members
+ * with no forward references, and determine which members are recursive
+ * (i.e., self-referential).  It is convenient to do this with an array
+ * of CteItems instead of a list of CommonTableExprs.
+ */
+typedef struct CteItem
+{
+	CommonTableExpr *cte;			/* One CTE to examine */
+	int			id;					/* Its ID number for dependencies */
+	Node	   *non_recursive_term;	/* Its nonrecursive part, if identified */
+	Bitmapset  *depends_on;			/* CTEs depended on (not including self) */
+} CteItem;
+
+/* CteState is what we need to pass around in the tree walkers */
+typedef struct CteState
+{
+	/* global state: */
+	ParseState *pstate;			/* global parse state */
+	CteItem	   *items;			/* array of CTEs and extra data */
+	int			numitems;		/* number of CTEs */
+	/* working state during a tree walk: */
+	int			curitem;		/* index of item currently being examined */
+	List	   *innerwiths;		/* list of lists of CommonTableExpr */
+	/* working state for checkWellFormedRecursion walk only: */
+	int			selfrefcount;	/* number of self-references detected */
+	RecursionContext context;	/* context to allow or disallow self-ref */
+} CteState;
+
 
 static void analyzeCTE(ParseState *pstate, CommonTableExpr *cte);
 static void analyzeCTETargetList(ParseState *pstate, CommonTableExpr *cte, List *tlist);
 
+/* Dependency processing functions */
+static void makeDependencyGraph(CteState *cstate);
+static bool makeDependencyGraphWalker(Node *node, CteState *cstate);
+static void TopologicalSort(ParseState *pstate, CteItem *items, int numitems);
+
+/* Recursion validity checker functions */
+static void checkWellFormedRecursion(CteState *cstate);
+static bool checkWellFormedRecursionWalker(Node *node, CteState *cstate);
+static void checkWellFormedSelectStmt(SelectStmt *stmt, CteState *cstate);
+
+
 /*
  * transformWithClause -
- *	  Transform the list of WITH clause "common table expressions" into
- *	  Query nodes.
+ *    Transform the list of WITH clause "common table expressions" into
+ *    Query nodes.
  *
  * The result is the list of transformed CTEs to be put into the output
  * Query.  (This is in fact the same as the ending value of p_ctenamespace,
@@ -31,9 +105,7 @@ transformWithClause(ParseState *pstate, WithClause *withClause)
 {
 	ListCell   *lc;
 
-	if (withClause == NULL)
-		return NULL;
-	
+	/* FIXME: Remove this when we support recursive CTE*/
 	if (withClause->recursive)
 	{
 		ereport(ERROR, 
@@ -46,10 +118,11 @@ transformWithClause(ParseState *pstate, WithClause *withClause)
 	Assert(pstate->p_future_ctes == NIL);
 
 	/*
-	 * For either type of WITH, there must not be duplicate CTE names in the
-	 * list.  Check this right away so we needn't worry later.
+	 * For either type of WITH, there must not be duplicate CTE names in
+	 * the list.  Check this right away so we needn't worry later.
 	 *
-	 * Also, initialize other variables in CommonTableExpr.
+	 * Also, tentatively mark each CTE as non-recursive, and initialize
+	 * its reference count to zero.
 	 */
 	foreach(lc, withClause->ctes)
 	{
@@ -63,8 +136,8 @@ transformWithClause(ParseState *pstate, WithClause *withClause)
 			if (strcmp(cte->ctename, cte2->ctename) == 0)
 				ereport(ERROR,
 						(errcode(ERRCODE_DUPLICATE_ALIAS),
-					errmsg("WITH query name \"%s\" specified more than once",
-						   cte2->ctename),
+						 errmsg("WITH query name \"%s\" specified more than once",
+								cte2->ctename),
 						 parser_errposition(pstate, cte2->location)));
 		}
 
@@ -72,114 +145,192 @@ transformWithClause(ParseState *pstate, WithClause *withClause)
 		cte->cterefcount = 0;
 	}
 
-	/*
-	 * For non-recursive WITH, just analyze each CTE in sequence and then
-	 * add it to the ctenamespace.	This corresponds to the spec's
-	 * definition of the scope of each WITH name.  However, to allow error
-	 * reports to be aware of the possibility of an erroneous reference,
-	 * we maintain a list in p_future_ctes of the not-yet-visible CTEs.
-	 */
-	pstate->p_future_ctes = list_copy(withClause->ctes);
-
-	foreach (lc, withClause->ctes)
+	if (withClause->recursive)
 	{
-		CommonTableExpr *cte = (CommonTableExpr *)lfirst(lc);
-		analyzeCTE(pstate, cte);
-		pstate->p_ctenamespace = lappend(pstate->p_ctenamespace, cte);
-		pstate->p_future_ctes = list_delete_first(pstate->p_future_ctes);
+		/*
+		 * For WITH RECURSIVE, we rearrange the list elements if needed
+		 * to eliminate forward references.  First, build a work array
+		 * and set up the data structure needed by the tree walkers.
+		 */
+		CteState cstate;
+		int		i;
+
+		cstate.pstate = pstate;
+		cstate.numitems = list_length(withClause->ctes);
+		cstate.items = (CteItem *) palloc0(cstate.numitems * sizeof(CteItem));
+		i = 0;
+		foreach(lc, withClause->ctes)
+		{
+			cstate.items[i].cte = (CommonTableExpr *) lfirst(lc);
+			cstate.items[i].id = i;
+			i++;
+		}
+
+		/*
+		 * Find all the dependencies and sort the CteItems into a safe
+		 * processing order.  Also, mark CTEs that contain self-references.
+		 */
+		makeDependencyGraph(&cstate);
+
+		/*
+		 * Check that recursive queries are well-formed.
+		 */
+		checkWellFormedRecursion(&cstate);
+
+		/*
+		 * Set up the ctenamespace for parse analysis.  Per spec, all
+		 * the WITH items are visible to all others, so stuff them all in
+		 * before parse analysis.  We build the list in safe processing
+		 * order so that the planner can process the queries in sequence.
+		 */
+		for (i = 0; i < cstate.numitems; i++)
+		{
+			CommonTableExpr *cte = cstate.items[i].cte;
+
+			pstate->p_ctenamespace = lappend(pstate->p_ctenamespace, cte);
+		}
+
+		/*
+		 * Do parse analysis in the order determined by the topological sort.
+		 */
+		for (i = 0; i < cstate.numitems; i++)
+		{
+			CommonTableExpr *cte = cstate.items[i].cte;
+
+			/*
+			 * If it's recursive, we have to do a throwaway parse analysis
+			 * of the non-recursive term in order to determine the set of
+			 * output columns for the recursive CTE.
+			 */
+			if (cte->cterecursive)
+			{
+				Node   *nrt;
+				Query  *nrq;
+
+				if (!cstate.items[i].non_recursive_term)
+					elog(ERROR, "could not find non-recursive term for %s",
+						 cte->ctename);
+				/* copy the term to be sure we don't modify original query */
+				nrt = copyObject(cstate.items[i].non_recursive_term);
+				nrq = parse_sub_analyze(nrt, pstate);
+				analyzeCTETargetList(pstate, cte, nrq->targetList);
+			}
+
+			analyzeCTE(pstate, cte);
+		}
+	}
+	else
+	{
+		/*
+		 * For non-recursive WITH, just analyze each CTE in sequence and then
+		 * add it to the ctenamespace.	This corresponds to the spec's
+		 * definition of the scope of each WITH name.  However, to allow error
+		 * reports to be aware of the possibility of an erroneous reference,
+		 * we maintain a list in p_future_ctes of the not-yet-visible CTEs.
+		 */
+		pstate->p_future_ctes = list_copy(withClause->ctes);
+
+		foreach (lc, withClause->ctes)
+		{
+			CommonTableExpr *cte = (CommonTableExpr *)lfirst(lc);
+			analyzeCTE(pstate, cte);
+			pstate->p_ctenamespace = lappend(pstate->p_ctenamespace, cte);
+			pstate->p_future_ctes = list_delete_first(pstate->p_future_ctes);
+		}
 	}
 
 	return pstate->p_ctenamespace;
 }
 
-/*
- * GetCTEForRTE
- *    Find CommonTableExpr stored in pstate that is referenced by rte.
- *
- * rtelevelsup is the number of query levels above the given pstate that the
- * RTE came from.  Callers that don't have this information readily available
- * may pass -1 instead.
- *
- * Report error if not such CTE found.
- */
-CommonTableExpr *
-GetCTEForRTE(ParseState *pstate, RangeTblEntry *rte, int rtelevelsup)
-{
-	Assert(pstate != NULL && rte != NULL);
-	Assert(rte->rtekind == RTE_CTE);
-
-	/* Determine RTE's levelsup if caller didn't know it */
-	if (rtelevelsup < 0)
-		(void) RTERangeTablePosn(pstate, rte, &rtelevelsup);
-
-	Index levelsup = rte->ctelevelsup + rtelevelsup;
-	while (levelsup > 0)
-	{
-		pstate = pstate->parentParseState;
-		Assert(pstate != NULL);
-		levelsup--;
-	}
-
-	if (pstate->p_ctenamespace == NULL)
-		return NULL;
-	
-	ListCell *lc;
-	foreach (lc, pstate->p_ctenamespace)
-	{
-		CommonTableExpr *cte = (CommonTableExpr *)lfirst(lc);
-		if (strcmp(cte->ctename, rte->ctename) == 0)
-		{
-			return cte;
-		}
-	}
-	
-	/* shouldn't happen */
-	elog(ERROR, "unexpected error while parsing WITH query \"%s\"", rte->ctename);
-	return NULL;
-}
-
 
 /*
- * analyzeCTE
- *    Analyze the given CommonTableExpr.
- *
- * Report errors if the given CTE has one of the following:
- *   (1) not a Query statement.
- *   (2) containing INTO clause.
+ * Perform the actual parse analysis transformation of one CTE.  All
+ * CTEs it depends on have already been loaded into pstate->p_ctenamespace,
+ * and have been marked with the correct output column names/types.
  */
 static void
 analyzeCTE(ParseState *pstate, CommonTableExpr *cte)
 {
-	Query	   *query;
+	Query  *query;
 
-	Assert(cte != NULL);
-	Assert(cte->ctequery != NULL);
-	Assert(!IsA(cte->ctequery, Query));
+	/* Analysis not done already */
+	Assert(IsA(cte->ctequery, SelectStmt));
 
 	query = parse_sub_analyze(cte->ctequery, pstate);
 	cte->ctequery = (Node *) query;
 
-	Assert(IsA(query, Query));
-
-	/* Check if the query is what we expected. */
-	if (!IsA(query, Query))
-		elog(ERROR, "unexpected non-Query statement in WITH clause");
-	if (query->utilityStmt != NULL)
-		elog(ERROR, "unexpected utility statement in WITH clause");
-
+	/*
+	 * Check that we got something reasonable.	Many of these conditions are
+	 * impossible given restrictions of the grammar, but check 'em anyway.
+	 * (These are the same checks as in transformRangeSubselect.)
+	 */
+	if (!IsA(query, Query) ||
+		query->commandType != CMD_SELECT ||
+		query->utilityStmt != NULL)
+		elog(ERROR, "unexpected non-SELECT command in subquery in WITH");
 	if (query->intoClause)
 		ereport(ERROR,
 				(errcode(ERRCODE_SYNTAX_ERROR),
-				 errmsg("query defined in WITH clause cannot have SELECT INTO"),
+				 errmsg("subquery in WITH cannot have SELECT INTO"),
 				 parser_errposition(pstate,
 									exprLocation((Node *) query->intoClause))));
 
 	/* CTE queries are always marked as not canSetTag */
 	query->canSetTag = false;
 
-	/* Compute the column types, typmods. */
-	analyzeCTETargetList(pstate, cte, GetCTETargetList(cte));
+	if (!cte->cterecursive)
+	{
+		/* Compute the output column names/types if not done yet */
+		analyzeCTETargetList(pstate, cte, query->targetList);
+	}
+	else
+	{
+		/*
+		 * Verify that the previously determined output column types match
+		 * what the query really produced.  We have to check this because
+		 * the recursive term could have overridden the non-recursive term,
+		 * and we don't have any easy way to fix that.
+		 */
+		ListCell   *lctlist,
+				   *lctyp,
+				   *lctypmod;
+		int			varattno;
+
+		lctyp = list_head(cte->ctecoltypes);
+		lctypmod = list_head(cte->ctecoltypmods);
+		varattno = 0;
+		foreach(lctlist, query->targetList)
+		{
+			TargetEntry *te = (TargetEntry *) lfirst(lctlist);
+			Node   *texpr;
+
+			if (te->resjunk)
+				continue;
+			varattno++;
+			Assert(varattno == te->resno);
+			if (lctyp == NULL || lctypmod == NULL)		/* shouldn't happen */
+				elog(ERROR, "wrong number of output columns in WITH");
+			texpr = (Node *) te->expr;
+			if (exprType(texpr) != lfirst_oid(lctyp) ||
+				exprTypmod(texpr) != lfirst_int(lctypmod))
+				ereport(ERROR,
+						(errcode(ERRCODE_DATATYPE_MISMATCH),
+						 errmsg("recursive query \"%s\" column %d has type %s in non-recursive term but type %s overall",
+								cte->ctename, varattno,
+								format_type_with_typemod(lfirst_oid(lctyp),
+														 lfirst_int(lctypmod)),
+								format_type_with_typemod(exprType(texpr),
+														 exprTypmod(texpr))),
+						 errhint("Cast the output of the non-recursive term to the correct type."),
+						 parser_errposition(pstate, exprLocation(texpr))));
+			lctyp = lnext(lctyp);
+			lctypmod = lnext(lctypmod);
+		}
+		if (lctyp != NULL || lctypmod != NULL)		/* shouldn't happen */
+			elog(ERROR, "wrong number of output columns in WITH");
+	}
 }
+
 
 /*
  * reportDuplicateNames
@@ -217,9 +368,7 @@ reportDuplicateNames(const char *queryName, List *names)
 }
 
 /*
- * analayzeCTETargetList
- *    Compute colnames, coltypes, and coltypmods from the targetlist generated
- * after analyze.
+ * Compute derived fields of a CTE, given the transformed output targetlist
  */
 static void
 analyzeCTETargetList(ParseState *pstate, CommonTableExpr *cte, List *tlist)
@@ -228,15 +377,12 @@ analyzeCTETargetList(ParseState *pstate, CommonTableExpr *cte, List *tlist)
 	int			varattno;
 	ListCell   *tlistitem;
 
-	/* Not done already ... */
-	Assert(cte->ctecolnames == NIL);
-
 	/*
 	 * We need to determine column names and types.  The alias column names
 	 * override anything coming from the query itself.  (Note: the SQL spec
-	 * says that the alias list must be empty or exactly as long as the output
-	 * column set. Also, the alias can not have the same name. We report
-	 * errors if this is not the case.)
+	 * says that the alias list must be empty or exactly as long as the
+	 * output column set; but we allow it to be shorter for consistency
+	 * with Alias handling.)
 	 */
 	cte->ctecolnames = copyObject(cte->aliascolnames);
 	cte->ctecoltypes = cte->ctecoltypmods = NIL;
@@ -245,8 +391,6 @@ analyzeCTETargetList(ParseState *pstate, CommonTableExpr *cte, List *tlist)
 	foreach(tlistitem, tlist)
 	{
 		TargetEntry *te = (TargetEntry *) lfirst(tlistitem);
-		Oid			coltype;
-		int32		coltypmod;
 
 		if (te->resjunk)
 			continue;
@@ -256,31 +400,554 @@ analyzeCTETargetList(ParseState *pstate, CommonTableExpr *cte, List *tlist)
 		{
 			char	   *attrname;
 
-			if (numaliases > 0)
-			{
-				ereport(ERROR,
-						(errcode(ERRCODE_SYNTAX_ERROR),
-						 errmsg(ERRMSG_GP_WITH_COLUMNS_MISMATCH, cte->ctename),
-						 parser_errposition(pstate, cte->location)));
-			}
-
 			attrname = pstrdup(te->resname);
 			cte->ctecolnames = lappend(cte->ctecolnames, makeString(attrname));
 		}
-		coltype = exprType((Node *) te->expr);
-		coltypmod = exprTypmod((Node *) te->expr);
-
-		cte->ctecoltypes = lappend_oid(cte->ctecoltypes, coltype);
-		cte->ctecoltypmods = lappend_int(cte->ctecoltypmods, coltypmod);
+		cte->ctecoltypes = lappend_oid(cte->ctecoltypes,
+									   exprType((Node *) te->expr));
+		cte->ctecoltypmods = lappend_int(cte->ctecoltypmods,
+										 exprTypmod((Node *) te->expr));
 	}
-
 	if (varattno < numaliases)
-	{
 		ereport(ERROR,
-				(errcode(ERRCODE_SYNTAX_ERROR),
-				 errmsg(ERRMSG_GP_WITH_COLUMNS_MISMATCH, cte->ctename),
+				(errcode(ERRCODE_INVALID_COLUMN_REFERENCE),
+				 errmsg("WITH query \"%s\" has %d columns available but %d columns specified",
+						cte->ctename, varattno, numaliases),
 				 parser_errposition(pstate, cte->location)));
-	}
 
 	reportDuplicateNames(cte->ctename, cte->ctecolnames);
+}
+
+
+/*
+ * Identify the cross-references of a list of WITH RECURSIVE items,
+ * and sort into an order that has no forward references.
+ */
+static void
+makeDependencyGraph(CteState *cstate)
+{
+	int			i;
+
+	for (i = 0; i < cstate->numitems; i++)
+	{
+		CommonTableExpr *cte = cstate->items[i].cte;
+
+		cstate->curitem = i;
+		cstate->innerwiths = NIL;
+		makeDependencyGraphWalker((Node *) cte->ctequery, cstate);
+		Assert(cstate->innerwiths == NIL);
+	}
+
+	TopologicalSort(cstate->pstate, cstate->items, cstate->numitems);
+}
+
+/*
+ * Tree walker function to detect cross-references and self-references of the
+ * CTEs in a WITH RECURSIVE list.
+ */
+static bool
+makeDependencyGraphWalker(Node *node, CteState *cstate)
+{
+	if (node == NULL)
+		return false;
+	if (IsA(node, RangeVar))
+	{
+		RangeVar   *rv = (RangeVar *) node;
+
+		/* If unqualified name, might be a CTE reference */
+		if (!rv->schemaname)
+		{
+			ListCell *lc;
+			int		i;
+
+			/* ... but first see if it's captured by an inner WITH */
+			foreach(lc, cstate->innerwiths)
+			{
+				List   *withlist = (List *) lfirst(lc);
+				ListCell *lc2;
+
+				foreach(lc2, withlist)
+				{
+					CommonTableExpr *cte = (CommonTableExpr *) lfirst(lc2);
+
+					if (strcmp(rv->relname, cte->ctename) == 0)
+						return false;				/* yes, so bail out */
+				}
+			}
+
+			/* No, could be a reference to the query level we are working on */
+			for (i = 0; i < cstate->numitems; i++)
+			{
+				CommonTableExpr *cte = cstate->items[i].cte;
+
+				if (strcmp(rv->relname, cte->ctename) == 0)
+				{
+					int		myindex = cstate->curitem;
+
+					if (i != myindex)
+					{
+						/* Add cross-item dependency */
+						cstate->items[myindex].depends_on =
+							bms_add_member(cstate->items[myindex].depends_on,
+										   cstate->items[i].id);
+					}
+					else
+					{
+						/* Found out this one is self-referential */
+						cte->cterecursive = true;
+					}
+					break;
+				}
+			}
+		}
+		return false;
+	}
+	if (IsA(node, SelectStmt))
+	{
+		SelectStmt *stmt = (SelectStmt *) node;
+		ListCell *lc;
+
+		if (stmt->withClause)
+		{
+			if (stmt->withClause->recursive)
+			{
+				/*
+				 * In the RECURSIVE case, all query names of the WITH are
+				 * visible to all WITH items as well as the main query.
+				 * So push them all on, process, pop them all off.
+				 */
+				cstate->innerwiths = lcons(stmt->withClause->ctes,
+										   cstate->innerwiths);
+				foreach(lc, stmt->withClause->ctes)
+				{
+					CommonTableExpr *cte = (CommonTableExpr *) lfirst(lc);
+
+					(void) makeDependencyGraphWalker(cte->ctequery, cstate);
+				}
+				(void) raw_expression_tree_walker(node,
+												  makeDependencyGraphWalker,
+												  (void *) cstate);
+				cstate->innerwiths = list_delete_first(cstate->innerwiths);
+			}
+			else
+			{
+				/*
+				 * In the non-RECURSIVE case, query names are visible to
+				 * the WITH items after them and to the main query.
+				 */
+				ListCell   *cell1;
+
+				cstate->innerwiths = lcons(NIL, cstate->innerwiths);
+				cell1 = list_head(cstate->innerwiths);
+				foreach(lc, stmt->withClause->ctes)
+				{
+					CommonTableExpr *cte = (CommonTableExpr *) lfirst(lc);
+
+					(void) makeDependencyGraphWalker(cte->ctequery, cstate);
+					lfirst(cell1) = lappend((List *) lfirst(cell1), cte);
+				}
+				(void) raw_expression_tree_walker(node,
+												  makeDependencyGraphWalker,
+												  (void *) cstate);
+				cstate->innerwiths = list_delete_first(cstate->innerwiths);
+			}
+			/* We're done examining the SelectStmt */
+			return false;
+		}
+		/* if no WITH clause, just fall through for normal processing */
+	}
+	if (IsA(node, WithClause))
+	{
+		/*
+		 * Prevent raw_expression_tree_walker from recursing directly into
+		 * a WITH clause.  We need that to happen only under the control
+		 * of the code above.
+		 */
+		return false;
+	}
+	return raw_expression_tree_walker(node,
+									  makeDependencyGraphWalker,
+									  (void *) cstate);
+}
+
+/*
+ * Sort by dependencies, using a standard topological sort operation
+ */
+static void
+TopologicalSort(ParseState *pstate, CteItem *items, int numitems)
+{
+	int i, j;
+
+	/* for each position in sequence ... */
+	for (i = 0; i < numitems; i++)
+	{
+		/* ... scan the remaining items to find one that has no dependencies */
+		for (j = i; j < numitems; j++)
+		{
+			if (bms_is_empty(items[j].depends_on))
+				break;
+		}
+
+		/* if we didn't find one, the dependency graph has a cycle */
+		if (j >= numitems)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("mutual recursion between WITH items is not implemented"),
+					 parser_errposition(pstate, items[i].cte->location)));
+
+		/*
+		 * Found one.  Move it to front and remove it from every other
+		 * item's dependencies.
+		 */
+		if (i != j)
+		{
+			CteItem tmp;
+				
+			tmp = items[i];
+			items[i] = items[j];
+			items[j] = tmp;
+		}
+		/*
+		 * Items up through i are known to have no dependencies left,
+		 * so we can skip them in this loop.
+		 */
+		for (j = i + 1; j < numitems; j++)
+		{
+			items[j].depends_on = bms_del_member(items[j].depends_on,
+												 items[i].id);
+		}
+	}
+}
+
+
+/*
+ * Check that recursive queries are well-formed.
+ */
+static void
+checkWellFormedRecursion(CteState *cstate)
+{
+	int			i;
+
+	for (i = 0; i < cstate->numitems; i++)
+	{
+		CommonTableExpr *cte = cstate->items[i].cte;
+		SelectStmt		*stmt = (SelectStmt *) cte->ctequery;
+
+		Assert(IsA(stmt, SelectStmt));				/* not analyzed yet */
+
+		/* Ignore items that weren't found to be recursive */
+		if (!cte->cterecursive)
+			continue;
+
+		/* Must have top-level UNION ALL */
+		if (stmt->op != SETOP_UNION || !stmt->all)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_RECURSION),
+					 errmsg("recursive query \"%s\" does not have the form non-recursive-term UNION ALL recursive-term",
+							cte->ctename),
+					 parser_errposition(cstate->pstate, cte->location)));
+
+		/* The left-hand operand mustn't contain self-reference at all */
+		cstate->curitem = i;
+		cstate->innerwiths = NIL;
+		cstate->selfrefcount = 0;
+		cstate->context = RECURSION_NONRECURSIVETERM;
+		checkWellFormedRecursionWalker((Node *) stmt->larg, cstate);
+		Assert(cstate->innerwiths == NIL);
+
+		/* Right-hand operand should contain one reference in a valid place */
+		cstate->curitem = i;
+		cstate->innerwiths = NIL;
+		cstate->selfrefcount = 0;
+		cstate->context = RECURSION_OK;
+		checkWellFormedRecursionWalker((Node *) stmt->rarg, cstate);
+		Assert(cstate->innerwiths == NIL);
+		if (cstate->selfrefcount != 1)			/* shouldn't happen */
+			elog(ERROR, "missing recursive reference");
+
+		/*
+		 * Disallow ORDER BY and similar decoration atop the UNION ALL.
+		 * These don't make sense because it's impossible to figure out what
+		 * they mean when we have only part of the recursive query's results.
+		 * (If we did allow them, we'd have to check for recursive references
+		 * inside these subtrees.)
+		 */
+		if (stmt->sortClause)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("ORDER BY in a recursive query is not implemented"),
+					 parser_errposition(cstate->pstate,
+										exprLocation((Node *) stmt->sortClause))));
+		if (stmt->limitOffset)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("OFFSET in a recursive query is not implemented"),
+					 parser_errposition(cstate->pstate,
+										exprLocation(stmt->limitOffset))));
+		if (stmt->limitCount)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("LIMIT in a recursive query is not implemented"),
+					 parser_errposition(cstate->pstate,
+										exprLocation(stmt->limitCount))));
+		if (stmt->lockingClause)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("FOR UPDATE/SHARE in a recursive query is not implemented"),
+					 parser_errposition(cstate->pstate,
+										exprLocation((Node *) stmt->lockingClause))));
+
+		/*
+		 * Save non_recursive_term.
+		 */
+		cstate->items[i].non_recursive_term = (Node *) stmt->larg;
+	}
+}
+
+/*
+ * Tree walker function to detect invalid self-references in a recursive query.
+ */
+static bool
+checkWellFormedRecursionWalker(Node *node, CteState *cstate)
+{
+	RecursionContext save_context = cstate->context;
+
+	if (node == NULL)
+		return false;
+	if (IsA(node, RangeVar))
+	{
+		RangeVar   *rv = (RangeVar *) node;
+
+		/* If unqualified name, might be a CTE reference */
+		if (!rv->schemaname)
+		{
+			ListCell *lc;
+			CommonTableExpr *mycte;
+
+			/* ... but first see if it's captured by an inner WITH */
+			foreach(lc, cstate->innerwiths)
+			{
+				List   *withlist = (List *) lfirst(lc);
+				ListCell *lc2;
+
+				foreach(lc2, withlist)
+				{
+					CommonTableExpr *cte = (CommonTableExpr *) lfirst(lc2);
+
+					if (strcmp(rv->relname, cte->ctename) == 0)
+						return false;				/* yes, so bail out */
+				}
+			}
+
+			/* No, could be a reference to the query level we are working on */
+			mycte = cstate->items[cstate->curitem].cte;
+			if (strcmp(rv->relname, mycte->ctename) == 0)
+			{
+				/* Found a recursive reference to the active query */
+				if (cstate->context != RECURSION_OK)
+					ereport(ERROR,
+							(errcode(ERRCODE_INVALID_RECURSION),
+							 errmsg(recursion_errormsgs[cstate->context],
+									mycte->ctename),
+							 parser_errposition(cstate->pstate,
+												rv->location)));
+				/* Count references */
+				if (++(cstate->selfrefcount) > 1)
+					ereport(ERROR,
+							(errcode(ERRCODE_INVALID_RECURSION),
+							 errmsg("recursive reference to query \"%s\" must not appear more than once",
+									mycte->ctename),
+							 parser_errposition(cstate->pstate,
+												rv->location)));
+			}
+		}
+		return false;
+	}
+	if (IsA(node, SelectStmt))
+	{
+		SelectStmt *stmt = (SelectStmt *) node;
+		ListCell *lc;
+
+		if (stmt->withClause)
+		{
+			if (stmt->withClause->recursive)
+			{
+				/*
+				 * In the RECURSIVE case, all query names of the WITH are
+				 * visible to all WITH items as well as the main query.
+				 * So push them all on, process, pop them all off.
+				 */
+				cstate->innerwiths = lcons(stmt->withClause->ctes,
+										   cstate->innerwiths);
+				foreach(lc, stmt->withClause->ctes)
+				{
+					CommonTableExpr *cte = (CommonTableExpr *) lfirst(lc);
+
+					(void) checkWellFormedRecursionWalker(cte->ctequery, cstate);
+				}
+				checkWellFormedSelectStmt(stmt, cstate);
+				cstate->innerwiths = list_delete_first(cstate->innerwiths);
+			}
+			else
+			{
+				/*
+				 * In the non-RECURSIVE case, query names are visible to
+				 * the WITH items after them and to the main query.
+				 */
+				ListCell   *cell1;
+
+				cstate->innerwiths = lcons(NIL, cstate->innerwiths);
+				cell1 = list_head(cstate->innerwiths);
+				foreach(lc, stmt->withClause->ctes)
+				{
+					CommonTableExpr *cte = (CommonTableExpr *) lfirst(lc);
+
+					(void) checkWellFormedRecursionWalker(cte->ctequery, cstate);
+					lfirst(cell1) = lappend((List *) lfirst(cell1), cte);
+				}
+				checkWellFormedSelectStmt(stmt, cstate);
+				cstate->innerwiths = list_delete_first(cstate->innerwiths);
+			}
+		}
+		else
+				checkWellFormedSelectStmt(stmt, cstate);
+		/* We're done examining the SelectStmt */
+		return false;
+	}
+	if (IsA(node, WithClause))
+	{
+		/*
+		 * Prevent raw_expression_tree_walker from recursing directly into
+		 * a WITH clause.  We need that to happen only under the control
+		 * of the code above.
+		 */
+		return false;
+	}
+	if (IsA(node, JoinExpr))
+	{
+		JoinExpr *j = (JoinExpr *) node;
+
+		switch (j->jointype)
+		{
+			case JOIN_INNER:
+				checkWellFormedRecursionWalker(j->larg, cstate);
+				checkWellFormedRecursionWalker(j->rarg, cstate);
+				checkWellFormedRecursionWalker(j->quals, cstate);
+				break;
+			case JOIN_LEFT:
+				checkWellFormedRecursionWalker(j->larg, cstate);
+				if (save_context == RECURSION_OK)
+					cstate->context = RECURSION_OUTERJOIN;
+				checkWellFormedRecursionWalker(j->rarg, cstate);
+				cstate->context = save_context;
+				checkWellFormedRecursionWalker(j->quals, cstate);
+				break;
+			case JOIN_FULL:
+				if (save_context == RECURSION_OK)
+					cstate->context = RECURSION_OUTERJOIN;
+				checkWellFormedRecursionWalker(j->larg, cstate);
+				checkWellFormedRecursionWalker(j->rarg, cstate);
+				cstate->context = save_context;
+				checkWellFormedRecursionWalker(j->quals, cstate);
+				break;
+			case JOIN_RIGHT:
+				if (save_context == RECURSION_OK)
+					cstate->context = RECURSION_OUTERJOIN;
+				checkWellFormedRecursionWalker(j->larg, cstate);
+				cstate->context = save_context;
+				checkWellFormedRecursionWalker(j->rarg, cstate);
+				checkWellFormedRecursionWalker(j->quals, cstate);
+				break;
+			default:
+				elog(ERROR, "unrecognized join type: %d",
+					 (int) j->jointype);
+		}
+		return false;
+	}
+	if (IsA(node, SubLink))
+	{
+		SubLink *sl = (SubLink *) node;
+
+		/*
+		 * we intentionally override outer context, since subquery is
+		 * independent
+		 */
+		cstate->context = RECURSION_SUBLINK;
+		checkWellFormedRecursionWalker(sl->subselect, cstate);
+		cstate->context = save_context;
+		checkWellFormedRecursionWalker(sl->testexpr, cstate);
+		return false;
+	}
+	return raw_expression_tree_walker(node,
+									  checkWellFormedRecursionWalker,
+									  (void *) cstate);
+}
+
+/*
+ * subroutine for checkWellFormedRecursionWalker: process a SelectStmt
+ * without worrying about its WITH clause
+ */
+static void
+checkWellFormedSelectStmt(SelectStmt *stmt, CteState *cstate)
+{
+	RecursionContext save_context = cstate->context;
+
+	if (save_context != RECURSION_OK)
+	{
+		/* just recurse without changing state */
+		raw_expression_tree_walker((Node *) stmt,
+								   checkWellFormedRecursionWalker,
+								   (void *) cstate);
+	}
+	else
+	{
+		switch (stmt->op)
+		{
+			case SETOP_NONE:
+			case SETOP_UNION:
+				raw_expression_tree_walker((Node *) stmt,
+										   checkWellFormedRecursionWalker,
+										   (void *) cstate);
+				break;
+			case SETOP_INTERSECT:
+				if (stmt->all)
+					cstate->context = RECURSION_INTERSECT;
+				checkWellFormedRecursionWalker((Node *) stmt->larg,
+											   cstate);
+				checkWellFormedRecursionWalker((Node *) stmt->rarg,
+											   cstate);
+				cstate->context = save_context;
+				checkWellFormedRecursionWalker((Node *) stmt->sortClause,
+											   cstate);
+				checkWellFormedRecursionWalker((Node *) stmt->limitOffset,
+											   cstate);
+				checkWellFormedRecursionWalker((Node *) stmt->limitCount,
+											   cstate);
+				checkWellFormedRecursionWalker((Node *) stmt->lockingClause,
+											   cstate);
+				break;
+				break;
+			case SETOP_EXCEPT:
+				if (stmt->all)
+					cstate->context = RECURSION_EXCEPT;
+				checkWellFormedRecursionWalker((Node *) stmt->larg,
+											   cstate);
+				cstate->context = RECURSION_EXCEPT;
+				checkWellFormedRecursionWalker((Node *) stmt->rarg,
+											   cstate);
+				cstate->context = save_context;
+				checkWellFormedRecursionWalker((Node *) stmt->sortClause,
+											   cstate);
+				checkWellFormedRecursionWalker((Node *) stmt->limitOffset,
+											   cstate);
+				checkWellFormedRecursionWalker((Node *) stmt->limitCount,
+											   cstate);
+				checkWellFormedRecursionWalker((Node *) stmt->lockingClause,
+											   cstate);
+				break;
+			default:
+				elog(ERROR, "unrecognized set op: %d",
+					 (int) stmt->op);
+		}
+	}
 }

--- a/src/backend/parser/parse_target.c
+++ b/src/backend/parser/parse_target.c
@@ -338,7 +338,7 @@ markTargetListOrigin(ParseState *pstate, TargetEntry *tle,
  * colname		target column name (ie, name of attribute to be assigned to)
  * attrno		target attribute number
  * indirection	subscripts/field names for target column, if any
- * location		error cursor position, or -1
+ * location		error cursor position for the target column, or -1
  *
  * Returns the modified expression.
  */
@@ -423,7 +423,8 @@ transformAssignedExpr(ParseState *pstate,
 			 */
 			colVar = (Node *) make_var(pstate,
 									   pstate->p_target_rangetblentry,
-									   attrno, location);
+									   attrno,
+									   location);
 		}
 
 		expr = (Expr *)
@@ -828,7 +829,7 @@ checkInsertTargets(ParseState *pstate, List *cols, List **attrnos)
  * ExpandColumnRefStar()
  *		Transforms foo.* into a list of expressions or targetlist entries.
  *
- * This handles the case where '*' appears as the last or only name in a
+ * This handles the case where '*' appears as the last or only item in a
  * ColumnRef.  The code is shared between the case of foo.* at the top level
  * in a SELECT target list (where we want TargetEntry nodes in the result)
  * and foo.* in a ROW() or VALUES() construct (where we want just bare

--- a/src/backend/parser/parse_target.c
+++ b/src/backend/parser/parse_target.c
@@ -8,7 +8,7 @@
  *
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/parser/parse_target.c,v 1.158 2008/01/01 19:45:51 momjian Exp $
+ *	  $PostgreSQL: pgsql/src/backend/parser/parse_target.c,v 1.165 2008/10/04 21:56:54 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -284,25 +284,6 @@ markTargetListOrigin(ParseState *pstate, TargetEntry *tle,
 				tle->resorigcol = ste->resorigcol;
 			}
 			break;
-		case RTE_CTE:
-			/* Similar to RTE_SUBQUERY */
-			if (attnum != InvalidAttrNumber)
-			{
-				/* Find the CommonTableExpr based on the query name */
-				CommonTableExpr *cte = GetCTEForRTE(pstate, rte, netlevelsup);
-				Assert(cte != NULL);
-				
-				TargetEntry *ste = get_tle_by_resno(GetCTETargetList(cte), attnum);
-				if (ste == NULL || ste->resjunk)
-				{
-					elog(ERROR, "WITH query %s does not have attribute %d",
-						 rte->ctename, attnum);
-				}
-				
-				tle->resorigtbl = ste->resorigtbl;
-				tle->resorigcol = ste->resorigcol;
-			}
-			break;
 		case RTE_JOIN:
 			/* Join RTE --- recursively inspect the alias variable */
 			if (attnum != InvalidAttrNumber)
@@ -318,8 +299,26 @@ markTargetListOrigin(ParseState *pstate, TargetEntry *tle,
 		case RTE_TABLEFUNCTION:
 		case RTE_FUNCTION:
 		case RTE_VALUES:
-        case RTE_VOID:
+		case RTE_VOID:
 			/* not a simple relation, leave it unmarked */
+			break;
+		case RTE_CTE:
+			/* CTE reference: copy up from the subquery */
+			if (attnum != InvalidAttrNumber)
+			{
+				CommonTableExpr *cte = GetCTEForRTE(pstate, rte, netlevelsup);
+				TargetEntry *ste;
+
+				/* should be analyzed by now */
+				Assert(IsA(cte->ctequery, Query));
+				ste = get_tle_by_resno(((Query *) cte->ctequery)->targetList,
+									   attnum);
+				if (ste == NULL || ste->resjunk)
+					elog(ERROR, "subquery %s does not have attribute %d",
+						 rte->eref->aliasname, attnum);
+				tle->resorigtbl = ste->resorigtbl;
+				tle->resorigcol = ste->resorigcol;
+			}
 			break;
 	}
 }
@@ -1182,6 +1181,22 @@ expandRecordVariable(ParseState *pstate, Var *var, int levelsup)
 				/* else fall through to inspect the expression */
 			}
 			break;
+		case RTE_JOIN:
+			/* Join RTE --- recursively inspect the alias variable */
+			Assert(attnum > 0 && attnum <= list_length(rte->joinaliasvars));
+			expr = (Node *) list_nth(rte->joinaliasvars, attnum - 1);
+			if (IsA(expr, Var))
+				return expandRecordVariable(pstate, (Var *) expr, netlevelsup);
+			/* else fall through to inspect the expression */
+			break;
+		case RTE_TABLEFUNCTION:
+		case RTE_FUNCTION:
+
+			/*
+			 * We couldn't get here unless a function is declared with one of
+			 * its result columns as RECORD, which is not allowed.
+			 */
+			break;
 		case RTE_CTE:
 			if (!rte->self_reference)
 			{
@@ -1220,25 +1235,9 @@ expandRecordVariable(ParseState *pstate, Var *var, int levelsup)
 				/* else fall through to inspect the expression */
 			}
 			break;
-		case RTE_JOIN:
-			/* Join RTE --- recursively inspect the alias variable */
-			Assert(attnum > 0 && attnum <= list_length(rte->joinaliasvars));
-			expr = (Node *) list_nth(rte->joinaliasvars, attnum - 1);
-			if (IsA(expr, Var))
-				return expandRecordVariable(pstate, (Var *) expr, netlevelsup);
-			/* else fall through to inspect the expression */
-			break;
-		case RTE_TABLEFUNCTION:
-		case RTE_FUNCTION:
-
-			/*
-			 * We couldn't get here unless a function is declared with one of
-			 * its result columns as RECORD, which is not allowed.
-			 */
-			break;
-        case RTE_VOID:
-            Insist(0);
-            break;
+		case RTE_VOID:
+	            Insist(0);
+        	    break;
 	}
 
 	/*

--- a/src/backend/parser/parse_type.c
+++ b/src/backend/parser/parse_type.c
@@ -9,7 +9,7 @@
  *
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/parser/parse_type.c,v 1.94 2008/01/01 19:45:51 momjian Exp $
+ *	  $PostgreSQL: pgsql/src/backend/parser/parse_type.c,v 1.100 2008/10/04 21:56:54 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/rewrite/rewriteDefine.c
+++ b/src/backend/rewrite/rewriteDefine.c
@@ -9,7 +9,7 @@
  *
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/rewrite/rewriteDefine.c,v 1.124 2008/01/01 19:45:51 momjian Exp $
+ *	  $PostgreSQL: pgsql/src/backend/rewrite/rewriteDefine.c,v 1.130 2008/10/04 21:56:54 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -717,16 +717,14 @@ setRuleCheckAsUser_Query(Query *qry, Oid userid)
 	}
 
 	/* If there are sublinks, search for them and process their RTEs */
-	/* ignore subqueries in rtable because we already processed them */
 	if (qry->hasSubLinks)
 		query_tree_walker(qry, setRuleCheckAsUser_walker, (void *) &userid,
-						  QTW_IGNORE_RT_SUBQUERIES);
+						  QTW_IGNORE_RC_SUBQUERIES);
 }
 
 
 /*
  * Change the firing semantics of an existing rule.
- *
  */
 void
 EnableDisableRule(Relation rel, const char *rulename,

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -4,7 +4,7 @@
  * Portions Copyright (c) 2005-2010, Greenplum inc
  * Copyright (c) 2000-2010, PostgreSQL Global Development Group
  *
- * src/bin/psql/tab-complete.c
+ * $PostgreSQL: pgsql/src/bin/psql/tab-complete.c,v 1.173 2008/10/04 21:56:54 tgl Exp $
  */
 
 /*----------------------------------------------------------------------

--- a/src/include/executor/nodeCtescan.h
+++ b/src/include/executor/nodeCtescan.h
@@ -1,0 +1,25 @@
+/*-------------------------------------------------------------------------
+ *
+ * nodeCtescan.h
+ *
+ *
+ *
+ * Portions Copyright (c) 1996-2008, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * $PostgreSQL: pgsql/src/include/executor/nodeCtescan.h,v 1.1 2008/10/04 21:56:55 tgl Exp $
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef NODECTESCAN_H
+#define NODECTESCAN_H
+
+#include "nodes/execnodes.h"
+
+extern int	ExecCountSlotsCteScan(CteScan *node);
+extern CteScanState *ExecInitCteScan(CteScan *node, EState *estate, int eflags);
+extern TupleTableSlot *ExecCteScan(CteScanState *node);
+extern void ExecEndCteScan(CteScanState *node);
+extern void ExecCteScanReScan(CteScanState *node, ExprContext *exprCtxt);
+
+#endif   /* NODECTESCAN_H */

--- a/src/include/executor/nodeRecursiveunion.h
+++ b/src/include/executor/nodeRecursiveunion.h
@@ -1,0 +1,25 @@
+/*-------------------------------------------------------------------------
+ *
+ * nodeRecursiveunion.h
+ *
+ *
+ *
+ * Portions Copyright (c) 1996-2008, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * $PostgreSQL: pgsql/src/include/executor/nodeRecursiveunion.h,v 1.1 2008/10/04 21:56:55 tgl Exp $
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef NODERECURSIVEUNION_H
+#define NODERECURSIVEUNION_H
+
+#include "nodes/execnodes.h"
+
+extern int	ExecCountSlotsRecursiveUnion(RecursiveUnion *node);
+extern RecursiveUnionState *ExecInitRecursiveUnion(RecursiveUnion *node, EState *estate, int eflags);
+extern TupleTableSlot *ExecRecursiveUnion(RecursiveUnionState *node);
+extern void ExecEndRecursiveUnion(RecursiveUnionState *node);
+extern void ExecRecursiveUnionReScan(RecursiveUnionState *node, ExprContext *exprCtxt);
+
+#endif   /* NODERECURSIVEUNION_H */

--- a/src/include/executor/nodeWorktablescan.h
+++ b/src/include/executor/nodeWorktablescan.h
@@ -1,0 +1,25 @@
+/*-------------------------------------------------------------------------
+ *
+ * nodeWorktablescan.h
+ *
+ *
+ *
+ * Portions Copyright (c) 1996-2008, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * $PostgreSQL: pgsql/src/include/executor/nodeWorktablescan.h,v 1.1 2008/10/04 21:56:55 tgl Exp $
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef NODEWORKTABLESCAN_H
+#define NODEWORKTABLESCAN_H
+
+#include "nodes/execnodes.h"
+
+extern int	ExecCountSlotsWorkTableScan(WorkTableScan *node);
+extern WorkTableScanState *ExecInitWorkTableScan(WorkTableScan *node, EState *estate, int eflags);
+extern TupleTableSlot *ExecWorkTableScan(WorkTableScanState *node);
+extern void ExecEndWorkTableScan(WorkTableScanState *node);
+extern void ExecWorkTableScanReScan(WorkTableScanState *node, ExprContext *exprCtxt);
+
+#endif   /* NODEWORKTABLESCAN_H */

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -8,7 +8,7 @@
  * Portions Copyright (c) 1996-2009, PostgreSQL Global Development Group
  * Portions Copyright (c) 1994, Regents of the University of California
  *
- * $PostgreSQL: pgsql/src/include/nodes/execnodes.h,v 1.183.2.1 2010/07/28 04:51:14 tgl Exp $
+ * $PostgreSQL: pgsql/src/include/nodes/execnodes.h,v 1.189 2008/10/04 21:56:55 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -1552,6 +1552,26 @@ typedef struct SequenceState
 } SequenceState;
 
 /* ----------------
+ *	 RecursiveUnionState information
+ *
+ *		RecursiveUnionState is used for performing a recursive union.
+ *
+ *		recursing			T when we're done scanning the non-recursive term
+ *		intermediate_empty	T if intermediate_table is currently empty
+ *		working_table		working table (to be scanned by recursive term)
+ *		intermediate_table	current recursive output (next generation of WT)
+ * ----------------
+ */
+typedef struct RecursiveUnionState
+{
+	PlanState	ps;				/* its first field is NodeTag */
+	bool		recursing;
+	bool		intermediate_empty;
+	Tuplestorestate *working_table;
+	Tuplestorestate *intermediate_table;
+} RecursiveUnionState;
+
+/* ----------------
  *	 BitmapAndState information
  * ----------------
  */
@@ -1962,6 +1982,44 @@ typedef struct ValuesScanState
 	int			marked_idx;
 	bool		cdb_want_ctid;	/* true => ctid is referenced in targetlist */
 } ValuesScanState;
+
+/* ----------------
+ *	 CteScanState information
+ *
+ *		CteScan nodes are used to scan a CommonTableExpr query.
+ *
+ * Multiple CteScan nodes can read out from the same CTE query.  We use
+ * a tuplestore to hold rows that have been read from the CTE query but
+ * not yet consumed by all readers.
+ * ----------------
+ */
+typedef struct CteScanState
+{
+	ScanState	ss;				/* its first field is NodeTag */
+	int			eflags;			/* capability flags to pass to tuplestore */
+	int			readptr;		/* index of my tuplestore read pointer */
+	PlanState  *cteplanstate;	/* PlanState for the CTE query itself */
+	/* Link to the "leader" CteScanState (possibly this same node) */
+	struct CteScanState *leader;
+	/* The remaining fields are only valid in the "leader" CteScanState */
+	Tuplestorestate *cte_table;	/* rows already read from the CTE query */
+	bool		eof_cte;		/* reached end of CTE query? */
+} CteScanState;
+
+/* ----------------
+ *	 WorkTableScanState information
+ *
+ *		WorkTableScan nodes are used to scan the work table created by
+ *		a RecursiveUnion node.  We locate the RecursiveUnion node
+ *		during executor startup.
+ * ----------------
+ */
+typedef struct WorkTableScanState
+{
+	ScanState	ss;				/* its first field is NodeTag */
+	RecursiveUnionState *rustate;
+} WorkTableScanState;
+
 
 /* ----------------
  *         ExternalScanState information

--- a/src/include/nodes/nodes.h
+++ b/src/include/nodes/nodes.h
@@ -8,7 +8,7 @@
  * Portions Copyright (c) 1996-2009, PostgreSQL Global Development Group
  * Portions Copyright (c) 1994, Regents of the University of California
  *
- * $PostgreSQL: pgsql/src/include/nodes/nodes.h,v 1.205 2008/01/01 19:45:58 momjian Exp $
+ * $PostgreSQL: pgsql/src/include/nodes/nodes.h,v 1.213 2008/10/04 21:56:55 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -53,7 +53,6 @@ typedef enum NodeTag
 	T_Plan = 100,
 	T_Scan,
 	T_Join,
-	T_CteScan,
 
 	/* Real plan node starts below.  Scan and Join are "Virtal nodes",
 	 * It will take the form of IndexScan, SeqScan, etc. 
@@ -62,6 +61,7 @@ typedef enum NodeTag
 	T_Result,
 	T_Plan_Start = T_Result,
 	T_Append,
+	T_RecursiveUnion,
 	T_Sequence,
 	T_BitmapAnd,
 	T_BitmapOr,
@@ -82,6 +82,8 @@ typedef enum NodeTag
 	T_FunctionScan,
 	T_TableFunctionScan,
 	T_ValuesScan,
+	T_CteScan,
+	T_WorkTableScan,
 	T_NestLoop,
 	T_MergeJoin,
 	T_HashJoin,
@@ -119,6 +121,7 @@ typedef enum NodeTag
 	 */
 	T_ResultState,
 	T_AppendState,
+	T_RecursiveUnionState,
 	T_SequenceState,
 	T_BitmapAndState,
 	T_BitmapOrState,
@@ -139,6 +142,8 @@ typedef enum NodeTag
 	T_FunctionScanState,
 	T_TableFunctionState,
 	T_ValuesScanState,
+	T_CteScanState,
+	T_WorkTableScanState,
 	T_NestLoopState,
 	T_MergeJoinState,
 	T_HashJoinState,
@@ -461,6 +466,7 @@ typedef enum NodeTag
 	T_ParamRef,
 	T_A_Const,
 	T_FuncCall,
+	T_A_Star,
 	T_A_Indices,
 	T_A_Indirection,
 	T_A_ArrayExpr,

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -9,7 +9,7 @@
  * Portions Copyright (c) 1996-2008, PostgreSQL Global Development Group
  * Portions Copyright (c) 1994, Regents of the University of California
  *
- * $PostgreSQL: pgsql/src/include/nodes/plannodes.h,v 1.99 2008/01/01 19:45:58 momjian Exp $
+ * $PostgreSQL: pgsql/src/include/nodes/plannodes.h,v 1.104 2008/10/04 21:56:55 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -369,6 +369,20 @@ typedef struct Sequence
 } Sequence;
 
 /* ----------------
+ *	RecursiveUnion node -
+ *		Generate a recursive union of two subplans.
+ *
+ * The "outer" subplan is always the non-recursive term, and the "inner"
+ * subplan is the recursive term.
+ * ----------------
+ */
+typedef struct RecursiveUnion
+{
+	Plan		plan;
+	int			wtParam;		/* ID of Param representing work table */
+} RecursiveUnion;
+
+/* ----------------
  *	 BitmapAnd node -
  *		Generate the intersection of the results of sub-plans.
  *
@@ -634,6 +648,27 @@ typedef struct ValuesScan
 	Scan		scan;
 	List	   *values_lists;	/* list of expression lists */
 } ValuesScan;
+
+/* ----------------
+ *		CteScan node
+ * ----------------
+ */
+typedef struct CteScan
+{
+	Scan		scan;
+	int			ctePlanId;		/* ID of init SubPlan for CTE */
+	int			cteParam;		/* ID of Param representing CTE output */
+} CteScan;
+
+/* ----------------
+ *		WorkTableScan node
+ * ----------------
+ */
+typedef struct WorkTableScan
+{
+	Scan		scan;
+	int			wtParam;		/* ID of Param representing work table */
+} WorkTableScan;
 
 /* ----------------
 * External Scan node

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -11,7 +11,7 @@
  * Portions Copyright (c) 1996-2009, PostgreSQL Global Development Group
  * Portions Copyright (c) 1994, Regents of the University of California
  *
- * $PostgreSQL: pgsql/src/include/nodes/primnodes.h,v 1.137 2008/01/01 19:45:58 momjian Exp $
+ * $PostgreSQL: pgsql/src/include/nodes/primnodes.h,v 1.142 2008/10/04 21:56:55 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -556,6 +556,9 @@ typedef struct TableValueExpr
  *
  * In EXISTS, EXPR, and ARRAY SubLinks, testexpr and operName are unused and
  * are always null.
+ *
+ * The CTE_SUBLINK case never occurs in actual SubLink nodes, but it is used
+ * in SubPlans generated for WITH subqueries.
  */
 typedef enum SubLinkType
 {
@@ -565,6 +568,7 @@ typedef enum SubLinkType
 	ROWCOMPARE_SUBLINK,
 	EXPR_SUBLINK,
 	ARRAY_SUBLINK,
+	CTE_SUBLINK,
 	NOT_EXISTS_SUBLINK
 } SubLinkType;
 

--- a/src/include/optimizer/walkers.h
+++ b/src/include/optimizer/walkers.h
@@ -32,6 +32,8 @@ extern bool range_table_walker(List *rtable, bool (*walker) (),
 extern bool query_or_expression_tree_walker(Node *node, bool (*walker) (),
 												   void *context, int flags);
 
+extern bool raw_expression_tree_walker(Node *node, bool (*walker) (),
+									   void *context);
 
 /* The plan associated with a SubPlan is found in a list.  During planning this is in
  * the global structure found through the root PlannerInfo.  After planning this is in

--- a/src/include/parser/parse_node.h
+++ b/src/include/parser/parse_node.h
@@ -120,7 +120,7 @@ extern void setup_parser_errposition_callback(ParseCallbackState *pcbstate,
 extern void cancel_parser_errposition_callback(ParseCallbackState *pcbstate);
 
 extern Var *make_var(ParseState *pstate, RangeTblEntry *rte, int attrno,
-		 int location);
+					 int location);
 extern Oid	transformArrayType(Oid arrayType);
 extern ArrayRef *transformArraySubscripts(ParseState *pstate,
 						 Node *arrayBase,

--- a/src/include/parser/parse_node.h
+++ b/src/include/parser/parse_node.h
@@ -7,7 +7,7 @@
  * Portions Copyright (c) 1996-2009, PostgreSQL Global Development Group
  * Portions Copyright (c) 1994, Regents of the University of California
  *
- * $PostgreSQL: pgsql/src/include/parser/parse_node.h,v 1.53 2008/01/01 19:45:58 momjian Exp $
+ * $PostgreSQL: pgsql/src/include/parser/parse_node.h,v 1.57 2008/10/04 21:56:55 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -52,6 +52,10 @@ struct HTAB;  /* utils/hsearch.h */
  * refer to the JOIN, not the member tables).  Also, we put POSTQUEL-style
  * implicit RTEs into p_relnamespace but not p_varnamespace, so that they
  * do not affect the set of columns available for unqualified references.
+ *
+ * p_ctenamespace: list of CommonTableExprs (WITH items) that are visible
+ * at the moment.  This is different from p_relnamespace because you have
+ * to make an RTE before you can access a CTE.
  *
  * p_paramtypes: an array of p_numparams type OIDs for $n parameter symbols
  * (zeroth entry in array corresponds to $1).  If p_variableparams is true, the

--- a/src/include/parser/parse_relation.h
+++ b/src/include/parser/parse_relation.h
@@ -7,7 +7,7 @@
  * Portions Copyright (c) 1996-2009, PostgreSQL Global Development Group
  * Portions Copyright (c) 1994, Regents of the University of California
  *
- * $PostgreSQL: pgsql/src/include/parser/parse_relation.h,v 1.57 2008/01/01 19:45:58 momjian Exp $
+ * $PostgreSQL: pgsql/src/include/parser/parse_relation.h,v 1.59 2008/10/04 21:56:55 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -38,6 +38,7 @@ extern int RTERangeTablePosn(ParseState *pstate,
 extern RangeTblEntry *GetRTEByRangeTablePosn(ParseState *pstate,
 					   int varno,
 					   int sublevels_up);
+extern CommonTableExpr *GetCTEForRTE(ParseState *pstate, RangeTblEntry *rte, int rtelevelsup);
 extern Node *scanRTEForColumn(ParseState *pstate, RangeTblEntry *rte,
 				 char *colname, int location);
 extern Node *colNameToVar(ParseState *pstate, char *colname, bool localonly,
@@ -78,10 +79,10 @@ extern RangeTblEntry *addRangeTableEntryForJoin(ParseState *pstate,
 						  Alias *alias,
 						  bool inFromCl);
 extern RangeTblEntry *addRangeTableEntryForCTE(ParseState *pstate,
-											   CommonTableExpr *cte,
-											   Index levelsup,
-											   RangeVar *rangeVar,
-											   bool inFromCl);
+						 CommonTableExpr *cte,
+						 Index levelsup,
+						 Alias *alias,
+						 bool inFromCl);
 extern bool isSimplyUpdatableRelation(Oid relid, bool noerror);
 extern Index extractSimplyUpdatableRTEIndex(List *rtable);
 extern void addRTEtoQuery(ParseState *pstate, RangeTblEntry *rte,

--- a/src/include/utils/errcodes.h
+++ b/src/include/utils/errcodes.h
@@ -12,7 +12,7 @@
  * Portions Copyright (c) 2005-2008, Greenplum inc.
  * Copyright (c) 2003-2010, PostgreSQL Global Development Group
  *
- * $PostgreSQL: pgsql/src/include/utils/errcodes.h,v 1.32 2010/03/13 14:55:57 momjian Exp $
+ * $PostgreSQL: pgsql/src/include/utils/errcodes.h,v 1.26 2008/10/04 21:56:55 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */

--- a/src/include/utils/memaccounting.h
+++ b/src/include/utils/memaccounting.h
@@ -132,6 +132,9 @@ typedef enum MemoryOwnerType
 	MEMORY_OWNER_TYPE_Exec_AssertOp,
 	MEMORY_OWNER_TYPE_Exec_BitmapTableScan,
 	MEMORY_OWNER_TYPE_Exec_PartitionSelector,
+	MEMORY_OWNER_TYPE_Exec_RecursiveUnion,
+	MEMORY_OWNER_TYPE_Exec_CteScan,
+	MEMORY_OWNER_TYPE_Exec_WorkTableScan,
 	MEMORY_OWNER_TYPE_EXECUTOR_END = MEMORY_OWNER_TYPE_Exec_PartitionSelector,
 	MEMORY_OWNER_TYPE_END_SHORT_LIVING = MEMORY_OWNER_TYPE_EXECUTOR_END
 } MemoryOwnerType;

--- a/src/pl/plpgsql/src/plerrcodes.h
+++ b/src/pl/plpgsql/src/plerrcodes.h
@@ -9,7 +9,7 @@
  *
  * Copyright (c) 2003-2008, PostgreSQL Global Development Group
  *
- * $PostgreSQL: pgsql/src/pl/plpgsql/src/plerrcodes.h,v 1.13 2008/01/15 01:36:53 tgl Exp $
+ * $PostgreSQL: pgsql/src/pl/plpgsql/src/plerrcodes.h,v 1.15 2008/10/04 21:56:55 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -477,6 +477,10 @@
 
 {
 	"grouping_error", ERRCODE_GROUPING_ERROR
+},
+
+{
+	"invalid_recursion", ERRCODE_INVALID_RECURSION
 },
 
 {

--- a/src/test/regress/expected/qp_with_clause.out
+++ b/src/test/regress/expected/qp_with_clause.out
@@ -881,16 +881,249 @@ with capitals(code,id) as
 (select country.code,id,city.name from city,country 
  where city.countrycode = country.code AND city.id = country.capital)
 select * from capitals;
-ERROR:  specified number of columns in WITH query "capitals" must not exceed the number of available columns
-LINE 1: with capitals(code,id) as 
-             ^
+ code |  id  |               name                
+------+------+-----------------------------------
+ AIA  |   62 | The Valley
+ ARE  |   65 | Abu Dhabi
+ AUS  |  135 | Canberra
+ BHS  |  148 | Nassau
+ BHR  |  149 | al-Manama
+ BGD  |  150 | Dhaka
+ BLZ  |  185 | Belmopan
+ BWA  |  204 | Gaborone
+ CYM  |  553 | George Town
+ CHL  |  554 | Santiago de Chile
+ COK  |  583 | Avarua
+ CRI  |  584 | San Jose
+ DJI  |  585 | Djibouti
+ DMA  |  586 | Roseau
+ ERI  |  652 | Asmara
+ ETH  |  756 | Addis Abeba
+ GAB  |  902 | Libreville
+ GEO  |  905 | Tbilisi
+ GIB  |  915 | Gibraltar
+ GLP  |  919 | Basse-Terre
+ GUM  |  921 | Agaaa
+ HTI  |  929 | Port-au-Prince
+ SJM  |  938 | Longyearbyen
+ IDN  |  939 | Jakarta
+ IND  | 1109 | New Delhi
+ IRN  | 1380 | Teheran
+ JAM  | 1530 | Kingston
+ JPN  | 1532 | Tokyo
+ CAF  | 1889 | Bangui
+ COM  | 2295 | Moroni
+ COD  | 2298 | Kinshasa
+ CYP  | 2430 | Nicosia
+ LVA  | 2434 | Riga
+ LBN  | 2438 | Beirut
+ LIE  | 2446 | Vaduz
+ MAC  | 2454 | Macao
+ MWI  | 2462 | Lilongwe
+ MLI  | 2482 | Bamako
+ MLT  | 2484 | Valletta
+ MAR  | 2486 | Rabat
+ MTQ  | 2508 | Fort-de-France
+ MRT  | 2509 | Nouakchott
+ MCO  | 2695 | Monaco-Ville
+ MOZ  | 2698 | Maputo
+ NPL  | 2729 | Kathmandu
+ NIU  | 2805 | Alofi
+ NFK  | 2806 | Kingston
+ CIV  | 2814 | Yamoussoukro
+ PAK  | 2831 | Islamabad
+ PLW  | 2881 | Koror
+ PER  | 2890 | Lima
+ GNQ  | 2972 | Malabo
+ QAT  | 2973 | Doha
+ GUF  | 3014 | Cayenne
+ SHN  | 3063 | Jamestown
+ LCA  | 3065 | Castries
+ VCT  | 3066 | Kingstown
+ STP  | 3172 | Sao Tome
+ SAU  | 3173 | Riyadh
+ SEN  | 3198 | Dakar
+ SVN  | 3212 | Ljubljana
+ SUR  | 3243 | Paramaribo
+ SWZ  | 3244 | Mbabane
+ SYR  | 3250 | Damascus
+ THA  | 3320 | Bangkok
+ TKL  | 3333 | Fakaofo
+ TON  | 3334 | Nukualofa
+ TTO  | 3336 | Port-of-Spain
+ TUN  | 3349 | Tunis
+ TUR  | 3358 | Ankara
+ TKM  | 3419 | Ashgabat
+ UKR  | 3426 | Kyiv
+ NCL  | 3493 | Noumea
+ WLF  | 3536 | Mata-Utu
+ EST  | 3791 | Tallinn
+ AFG  |    1 | Kabul
+ ANT  |   33 | Willemstad
+ ALB  |   34 | Tirana
+ DZA  |   35 | Alger
+ ATG  |   63 | Saint Johns
+ ARG  |   69 | Buenos Aires
+ BRB  |  174 | Bridgetown
+ BEN  |  187 | Porto-Novo
+ BTN  |  192 | Thimphu
+ BOL  |  194 | La Paz
+ GBR  |  456 | London
+ VGB  |  537 | Road Town
+ BRN  |  538 | Bandar Seri Begawan
+ BDI  |  552 | Bujumbura
+ DOM  |  587 | Santo Domingo de Guzman
+ ECU  |  594 | Quito
+ EGY  |  608 | Cairo
+ SLV  |  645 | San Salvador
+ PHL  |  766 | Manila
+ GMB  |  904 | Banjul
+ GRD  |  916 | Saint Georges
+ GTM  |  922 | Ciudad de Guatemala
+ HND  |  933 | Tegucigalpa
+ IRQ  | 1365 | Baghdad
+ ISR  | 1450 | Jerusalem
+ ITA  | 1464 | Roma
+ AUT  | 1523 | Wien
+ YEM  | 1780 | Sanaa
+ CXR  | 1791 | Flying Fish Cove
+ YUG  | 1792 | Beograd
+ KAZ  | 1864 | Astana
+ COG  | 2296 | Brazzaville
+ CCK  | 2317 | West Island
+ GRC  | 2401 | Athenai
+ HRV  | 2409 | Zagreb
+ LBR  | 2440 | Monrovia
+ LBY  | 2441 | Tripoli
+ LUX  | 2452 | Luxembourg [Luxemburg/Letzebuerg]
+ MKD  | 2460 | Skopje
+ MYS  | 2464 | Kuala Lumpur
+ MUS  | 2511 | Port-Louis
+ FSM  | 2689 | Palikir
+ MSR  | 2697 | Plymouth
+ NAM  | 2726 | Windhoek
+ NRU  | 2728 | Yaren
+ NIC  | 2734 | Managua
+ NGA  | 2754 | Abuja
+ PNG  | 2884 | Port Moresby
+ PRY  | 2885 | Asuncion
+ PCN  | 2912 | Adamstown
+ POL  | 2928 | Warszawa
+ FRA  | 2974 | Paris
+ REU  | 3017 | Saint-Denis
+ ROM  | 3018 | Bucuresti
+ SPM  | 3067 | Saint-Pierre
+ WSM  | 3169 | Apia
+ SMR  | 3171 | San Marino
+ SGP  | 3208 | Singapore
+ SVK  | 3209 | Bratislava
+ LKA  | 3217 | Colombo
+ SDN  | 3225 | Khartum
+ CHE  | 3248 | Bern
+ TGO  | 3332 | Lome
+ TCD  | 3337 | NDjamena
+ CZE  | 3339 | Praha
+ TCA  | 3423 | Cockburn Town
+ TUV  | 3424 | Funafuti
+ URY  | 3492 | Montevideo
+ NZL  | 3499 | Wellington
+ VUT  | 3537 | Port-Vila
+ VAT  | 3538 | Citta del Vaticano
+ VEN  | 3539 | Caracas
+ RUS  | 3580 | Moscow
+ VNM  | 3770 | Hanoi
+ NLD  |    5 | Amsterdam
+ ASM  |   54 | Fagatogo
+ AND  |   55 | Andorra la Vella
+ AGO  |   56 | Luanda
+ ARM  |  126 | Yerevan
+ ABW  |  129 | Oranjestad
+ AZE  |  144 | Baku
+ BEL  |  179 | Bruxelles [Brussel]
+ BMU  |  191 | Hamilton
+ BIH  |  201 | Sarajevo
+ BRA  |  211 | Brasilia
+ BGR  |  539 | Sofija
+ BFA  |  549 | Ouagadougou
+ ESP  |  653 | Madrid
+ ZAF  |  716 | Pretoria
+ FLK  |  763 | Stanley
+ FJI  |  764 | Suva
+ FRO  |  901 | Torshavn
+ GHA  |  910 | Accra
+ GRL  |  917 | Nuuk
+ GIN  |  926 | Conakry
+ GNB  |  927 | Bissau
+ GUY  |  928 | Georgetown
+ HKG  |  937 | Victoria
+ IRL  | 1447 | Dublin
+ ISL  | 1449 | Reykjavik
+ TMP  | 1522 | Dili
+ JOR  | 1786 | Amman
+ KHM  | 1800 | Phnom Penh
+ CMR  | 1804 | Yaounde
+ CAN  | 1822 | Ottawa
+ CPV  | 1859 | Praia
+ KEN  | 1881 | Nairobi
+ CHN  | 1891 | Peking
+ KGZ  | 2253 | Bishkek
+ KIR  | 2256 | Bairiki
+ COL  | 2257 | Santafe de Bogota
+ PRK  | 2318 | Pyongyang
+ KOR  | 2331 | Seoul
+ CUB  | 2413 | La Habana
+ KWT  | 2429 | Kuwait
+ LAO  | 2432 | Vientiane
+ LSO  | 2437 | Maseru
+ LTU  | 2447 | Vilnius
+ ESH  | 2453 | El-Aaiun
+ MDG  | 2455 | Antananarivo
+ MDV  | 2463 | Male
+ MHL  | 2507 | Dalap-Uliga-Darrit
+ MYT  | 2514 | Mamoutzou
+ MEX  | 2515 | Ciudad de Mexico
+ MDA  | 2690 | Chisinau
+ MNG  | 2696 | Ulan Bator
+ MMR  | 2710 | Rangoon (Yangon)
+ NER  | 2738 | Niamey
+ NOR  | 2807 | Oslo
+ OMN  | 2821 | Masqat
+ PAN  | 2882 | Ciudad de Panama
+ MNP  | 2913 | Garapan
+ PRT  | 2914 | Lisboa
+ PRI  | 2919 | San Juan
+ PYF  | 3016 | Papeete
+ RWA  | 3047 | Kigali
+ SWE  | 3048 | Stockholm
+ KNA  | 3064 | Basseterre
+ DEU  | 3068 | Berlin
+ SLB  | 3161 | Honiara
+ ZMB  | 3162 | Lusaka
+ SYC  | 3206 | Victoria
+ SLE  | 3207 | Freetown
+ SOM  | 3214 | Mogadishu
+ FIN  | 3236 | Helsinki [Helsingfors]
+ TJK  | 3261 | Dushanbe
+ TWN  | 3263 | Taipei
+ TZA  | 3306 | Dodoma
+ DNK  | 3315 | Kobenhavn
+ UGA  | 3425 | Kampala
+ HUN  | 3483 | Budapest
+ UZB  | 3503 | Toskent
+ BLR  | 3520 | Minsk
+ USA  | 3813 | Washington
+ VIR  | 4067 | Charlotte Amalie
+ ZWE  | 4068 | Harare
+ PSE  | 4074 | Gaza
+(232 rows)
+
 --query 2
 with lang_total(lang_count,code,countrycode,name) as
 ( select count(*) as lang_count,country.code,countrylanguage.countrycode
   from country join countrylanguage on (country.code=countrylanguage.countrycode and governmentform='Federal Republic')
   group by country.code,countrylanguage.countrycode order by country.code)
 select * from lang_total;
-ERROR:  specified number of columns in WITH query "lang_total" must not exceed the number of available columns
+ERROR:  WITH query "lang_total" has 3 columns available but 4 columns specified
 LINE 1: with lang_total(lang_count,code,countrycode,name) as
              ^
 -- queries with CTEs using hash joins

--- a/src/test/regress/expected/with_clause.out
+++ b/src/test/regress/expected/with_clause.out
@@ -1143,9 +1143,20 @@ LINE 1: ..._sum(total) as (select sum(value) from with_test1 into total...
 with my_sum(group_total) as (select i, sum(value) from with_test1 group by i)
 select *
 from my_sum;
-ERROR:  specified number of columns in WITH query "my_sum" must not exceed the number of available columns
-LINE 1: with my_sum(group_total) as (select i, sum(value) from with_...
-             ^
+ group_total | sum 
+-------------+-----
+           9 | 180
+           8 | 170
+           7 | 160
+           6 | 150
+           4 | 130
+           3 | 120
+           5 | 140
+           1 | 100
+           2 | 110
+           0 |  90
+(10 rows)
+
 with my_sum as (select i, sum(value) as i from with_test1 group by i)
 select *
 from my_sum;


### PR DESCRIPTION
This is the seventh installment (others might be pending) to bring in CTEScan from Postgres. This PR only touches executor changes for non-recursive CTEs.

This cherry-pick mostly brings in changes from 1098844e4b9bbf5582562e01aba5fbde45f8150e in git@github.com:hsyuan/postgres.git

We also modify few places to minimize diffs with upstream by reorganizing few lines. Moreover, we added memory accounts to support the new operators.