### PR TITLE
Enable kerberos build and test on suse

### DIFF
--- a/concourse/scripts/ic_gpdb.bash
+++ b/concourse/scripts/ic_gpdb.bash
@@ -62,8 +62,9 @@ function _main() {
     # This ugly block exists since sles11 installs kerberos at a different path that is a test-only dependency
     if [ "$TEST_OS" == "sles" ]; then
       zypper addrepo --no-gpgcheck http://download.opensuse.org/distribution/11.4/repo/oss/ ossrepo
-      zypper -n install krb5-server
+      zypper -n install krb5 krb5-client krb5-server
       cp /usr/lib/mit/sbin/krb5kdc /usr/sbin/
+      export PATH=/usr/lib/mit/sbin/:$PATH
       # Kerberos upgrades perl, so we have to re-do the symlink. Ideally, we
       # wouldn't have a symlink at all, but this step is necessary as long as
       # we build against a different version of perl, and explicitly link to

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -167,9 +167,9 @@ rhel5_x86_32_CONFIGFLAGS=--host=i686-pc-linux-gnu --enable-snmp --enable-ddboost
 rhel5_x86_64_CONFIGFLAGS=--enable-snmp --enable-gpperfmon --enable-ddboost --with-gssapi --enable-netbackup ${ORCA_CONFIG} ${CODEGEN_CONFIG} --with-libxml $(APR_CONFIG) $(APU_CONFIG)
 rhel6_x86_64_CONFIGFLAGS=--enable-snmp --enable-gpperfmon --enable-ddboost --with-gssapi --enable-netbackup ${ORCA_CONFIG} ${CODEGEN_CONFIG} --with-libxml $(APR_CONFIG) $(APU_CONFIG)
 rhel7_x86_64_CONFIGFLAGS=--enable-snmp --enable-gpperfmon --enable-ddboost --with-gssapi --enable-netbackup ${ORCA_CONFIG} ${CODEGEN_CONFIG} --with-libxml $(APR_CONFIG) $(APU_CONFIG)
-suse10_x86_64_CONFIGFLAGS=--enable-snmp --enable-ddboost --enable-gpperfmon ${ORCA_CONFIG} ${CODEGEN_CONFIG} --with-libxml $(APR_CONFIG) $(APU_CONFIG)
-suse11_x86_64_CONFIGFLAGS=--enable-snmp --enable-ddboost --enable-gpperfmon ${ORCA_CONFIG} ${CODEGEN_CONFIG} --with-libxml $(APR_CONFIG) $(APU_CONFIG)
-sles11_x86_64_CONFIGFLAGS=--enable-snmp --enable-ddboost --enable-gpperfmon ${ORCA_CONFIG} ${CODEGEN_CONFIG} --with-libxml $(APR_CONFIG) $(APU_CONFIG)
+suse10_x86_64_CONFIGFLAGS=--enable-snmp --enable-ddboost --enable-gpperfmon --with-gssapi ${ORCA_CONFIG} ${CODEGEN_CONFIG} --with-libxml $(APR_CONFIG) $(APU_CONFIG)
+suse11_x86_64_CONFIGFLAGS=--enable-snmp --enable-ddboost --enable-gpperfmon --with-gssapi ${ORCA_CONFIG} ${CODEGEN_CONFIG} --with-libxml $(APR_CONFIG) $(APU_CONFIG)
+sles11_x86_64_CONFIGFLAGS=--enable-snmp --enable-ddboost --enable-gpperfmon --with-gssapi ${ORCA_CONFIG} ${CODEGEN_CONFIG} --with-libxml $(APR_CONFIG) $(APU_CONFIG)
 linux_x86_64_CONFIGFLAGS=--enable-snmp ${ORCA_CONFIG} ${CODEGEN_CONFIG} --with-libxml $(APR_CONFIG)
 osx106_x86_CONFIGFLAGS=--enable-snmp ${ORCA_CONFIG} ${CODEGEN_CONFIG} --with-libxml $(APR_CONFIG)
 

--- a/src/test/kerberos/test-gpdb-auth-with-kdc.sh
+++ b/src/test/kerberos/test-gpdb-auth-with-kdc.sh
@@ -60,20 +60,20 @@ LD_LIBRARY_PATH= kinit -k -t ./client.keytab krbtestuser@GPDB.EXAMPLE
 # Test that we can connect, now that we have run kinit.
 #
 echo "Testing connection, should succeed and print version"
-psql "dbname=postgres hostaddr=127.0.0.1 krbsrvname=postgres  host=localhost user=krbtestuser" -c "SELECT version()" | tee
+psql -P pager=off "dbname=postgres hostaddr=127.0.0.1 krbsrvname=postgres  host=localhost user=krbtestuser" -c "SELECT version()"
 
 ###
 # Also test expiration
-psql "dbname=template1" -c "ALTER USER krbtestuser valid until '2014-04-10 11:46:00-07'" | tee
+psql -P pager=off "dbname=template1" -c "ALTER USER krbtestuser valid until '2014-04-10 11:46:00-07'"
 
 # should not be able to connect anymore
 echo "Testing connection, with expired user account. Should not succeed"
 ! psql "dbname=postgres hostaddr=127.0.0.1 krbsrvname=postgres  host=localhost user=krbtestuser" -c "SELECT version()"
 
-psql "dbname=template1" -c "ALTER USER krbtestuser valid until '2054-04-10 11:46:00-07'" | tee
+psql -P pager=off "dbname=template1" -c "ALTER USER krbtestuser valid until '2054-04-10 11:46:00-07'"
 # now it should succeed again.
 echo "Testing connection, with user account with expiration in future. Should succeed"
-psql "dbname=postgres hostaddr=127.0.0.1 krbsrvname=postgres  host=localhost user=krbtestuser" -c "SELECT version()" | tee
+psql -P pager=off "dbname=postgres hostaddr=127.0.0.1 krbsrvname=postgres  host=localhost user=krbtestuser" -c "SELECT version()" 
 
 ###
 # All done! Restore previous pg_hba.conf and postgresql.conf

--- a/src/test/kerberos/test-gpdb-auth-with-kdc.sh
+++ b/src/test/kerberos/test-gpdb-auth-with-kdc.sh
@@ -60,20 +60,20 @@ LD_LIBRARY_PATH= kinit -k -t ./client.keytab krbtestuser@GPDB.EXAMPLE
 # Test that we can connect, now that we have run kinit.
 #
 echo "Testing connection, should succeed and print version"
-psql "dbname=postgres hostaddr=127.0.0.1 krbsrvname=postgres  host=localhost user=krbtestuser" -c "SELECT version()"
+psql "dbname=postgres hostaddr=127.0.0.1 krbsrvname=postgres  host=localhost user=krbtestuser" -c "SELECT version()" | tee
 
 ###
 # Also test expiration
-psql "dbname=template1" -c "ALTER USER krbtestuser valid until '2014-04-10 11:46:00-07'"
+psql "dbname=template1" -c "ALTER USER krbtestuser valid until '2014-04-10 11:46:00-07'" | tee
 
 # should not be able to connect anymore
 echo "Testing connection, with expired user account. Should not succeed"
 ! psql "dbname=postgres hostaddr=127.0.0.1 krbsrvname=postgres  host=localhost user=krbtestuser" -c "SELECT version()"
 
-psql "dbname=template1" -c "ALTER USER krbtestuser valid until '2054-04-10 11:46:00-07'"
+psql "dbname=template1" -c "ALTER USER krbtestuser valid until '2054-04-10 11:46:00-07'" | tee
 # now it should succeed again.
 echo "Testing connection, with user account with expiration in future. Should succeed"
-psql "dbname=postgres hostaddr=127.0.0.1 krbsrvname=postgres  host=localhost user=krbtestuser" -c "SELECT version()"
+psql "dbname=postgres hostaddr=127.0.0.1 krbsrvname=postgres  host=localhost user=krbtestuser" -c "SELECT version()" | tee
 
 ###
 # All done! Restore previous pg_hba.conf and postgresql.conf


### PR DESCRIPTION
1. Add --with-gssapi to suse configurations in gpAux/Makefile to enable kerberos build
2. Add kerberos sbin path to PATH for sles.
3. Use tee to avoid pager and prevent test from hanging forever on concourse.

     Signed-off-by: Yuan Zhao <yuzhao@pivotal.io>