### PR TITLE
Fix Default partition level for indexes

### DIFF
--- a/src/test/regress/expected/bfv_partition.out
+++ b/src/test/regress/expected/bfv_partition.out
@@ -1882,6 +1882,58 @@ explain analyze select a.* from mpp8031 a, mpp8031 b where a.oid = b.oid;
 (34 rows)
 
 drop table mpp8031;
+-- Partitioned tables with default partitions and indexes on all parts,
+-- queries on them with a predicate on index column must not consider the scan
+-- as partial and should not fallback.
+CREATE TABLE part_tbl
+(
+	time_client_key numeric(16,0) NOT NULL,
+	ngin_service_key numeric NOT NULL,
+	profile_key numeric NOT NULL
+)
+DISTRIBUTED BY (time_client_key)
+PARTITION BY RANGE(time_client_key)
+SUBPARTITION BY LIST (ngin_service_key)
+SUBPARTITION TEMPLATE
+(
+	SUBPARTITION Package5 VALUES (479534741),
+	DEFAULT SUBPARTITION other_services
+)
+(
+	PARTITION p20151110 START (2015111000::numeric) 
+END (2015111100::numeric) WITH (appendonly=false)
+);
+NOTICE:  CREATE TABLE will create partition "part_tbl_1_prt_p20151110" for table "part_tbl"
+NOTICE:  CREATE TABLE will create partition "part_tbl_1_prt_p20151110_2_prt_package5" for table "part_tbl_1_prt_p20151110"
+NOTICE:  CREATE TABLE will create partition "part_tbl_1_prt_p20151110_2_prt_other_services" for table "part_tbl_1_prt_p20151110"
+INSERT INTO part_tbl VALUES (2015111000, 479534741, 99999999);
+INSERT INTO part_tbl VALUES (2015111000, 479534742, 99999999);
+CREATE INDEX part_tbl_idx 
+ON part_tbl(profile_key);
+NOTICE:  building index for child partition "part_tbl_1_prt_p20151110"
+NOTICE:  building index for child partition "part_tbl_1_prt_p20151110_2_prt_package5"
+NOTICE:  building index for child partition "part_tbl_1_prt_p20151110_2_prt_other_services"
+EXPLAIN SELECT * FROM part_tbl WHERE profile_key = 99999999;
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..942.50 rows=60 width=80)
+   ->  Append  (cost=0.00..942.50 rows=20 width=80)
+         ->  Seq Scan on part_tbl_1_prt_p20151110_2_prt_package5 part_tbl  (cost=0.00..471.25 rows=10 width=80)
+               Filter: profile_key = 99999999::numeric
+         ->  Seq Scan on part_tbl_1_prt_p20151110_2_prt_other_services part_tbl  (cost=0.00..471.25 rows=10 width=80)
+               Filter: profile_key = 99999999::numeric
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(8 rows)
+
+SELECT * FROM part_tbl WHERE profile_key = 99999999;
+ time_client_key | ngin_service_key | profile_key 
+-----------------+------------------+-------------
+      2015111000 |        479534741 |    99999999
+      2015111000 |        479534742 |    99999999
+(2 rows)
+
+DROP TABLE part_tbl;
 -- CLEANUP
 -- start_ignore
 drop schema if exists bfv_partition;

--- a/src/test/regress/expected/bfv_partition_optimizer.out
+++ b/src/test/regress/expected/bfv_partition_optimizer.out
@@ -1884,6 +1884,57 @@ explain analyze select a.* from mpp8031 a, mpp8031 b where a.oid = b.oid;
 (31 rows)
 
 drop table mpp8031;
+-- Partitioned tables with default partitions and indexes on all parts,
+-- queries on them with a predicate on index column must not consider the scan
+-- as partial and should not fallback.
+CREATE TABLE part_tbl
+(
+	time_client_key numeric(16,0) NOT NULL,
+	ngin_service_key numeric NOT NULL,
+	profile_key numeric NOT NULL
+)
+DISTRIBUTED BY (time_client_key)
+PARTITION BY RANGE(time_client_key)
+SUBPARTITION BY LIST (ngin_service_key)
+SUBPARTITION TEMPLATE
+(
+	SUBPARTITION Package5 VALUES (479534741),
+	DEFAULT SUBPARTITION other_services
+)
+(
+	PARTITION p20151110 START (2015111000::numeric) 
+END (2015111100::numeric) WITH (appendonly=false)
+);
+NOTICE:  CREATE TABLE will create partition "part_tbl_1_prt_p20151110" for table "part_tbl"
+NOTICE:  CREATE TABLE will create partition "part_tbl_1_prt_p20151110_2_prt_package5" for table "part_tbl_1_prt_p20151110"
+NOTICE:  CREATE TABLE will create partition "part_tbl_1_prt_p20151110_2_prt_other_services" for table "part_tbl_1_prt_p20151110"
+INSERT INTO part_tbl VALUES (2015111000, 479534741, 99999999);
+INSERT INTO part_tbl VALUES (2015111000, 479534742, 99999999);
+CREATE INDEX part_tbl_idx 
+ON part_tbl(profile_key);
+NOTICE:  building index for child partition "part_tbl_1_prt_p20151110"
+NOTICE:  building index for child partition "part_tbl_1_prt_p20151110_2_prt_package5"
+NOTICE:  building index for child partition "part_tbl_1_prt_p20151110_2_prt_other_services"
+EXPLAIN SELECT * FROM part_tbl WHERE profile_key = 99999999;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.00 rows=1 width=24)
+   ->  Sequence  (cost=0.00..2.00 rows=1 width=24)
+         ->  Partition Selector for part_tbl (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+               Partitions selected: 2 (out of 2)
+         ->  Dynamic Index Scan on part_tbl (dynamic scan id: 1)  (cost=0.00..2.00 rows=1 width=24)
+               Index Cond: profile_key = 99999999::numeric
+ Optimizer status: PQO version 2.31.0
+(7 rows)
+
+SELECT * FROM part_tbl WHERE profile_key = 99999999;
+ time_client_key | ngin_service_key | profile_key 
+-----------------+------------------+-------------
+      2015111000 |        479534742 |    99999999
+      2015111000 |        479534741 |    99999999
+(2 rows)
+
+DROP TABLE part_tbl;
 -- CLEANUP
 -- start_ignore
 drop schema if exists bfv_partition;

--- a/src/test/regress/sql/bfv_partition.sql
+++ b/src/test/regress/sql/bfv_partition.sql
@@ -784,6 +784,35 @@ EVERY ('2 mons'::interval)
 explain analyze select a.* from mpp8031 a, mpp8031 b where a.oid = b.oid;
 drop table mpp8031;
 
+-- Partitioned tables with default partitions and indexes on all parts,
+-- queries on them with a predicate on index column must not consider the scan
+-- as partial and should not fallback.
+CREATE TABLE part_tbl
+(
+	time_client_key numeric(16,0) NOT NULL,
+	ngin_service_key numeric NOT NULL,
+	profile_key numeric NOT NULL
+)
+DISTRIBUTED BY (time_client_key)
+PARTITION BY RANGE(time_client_key)
+SUBPARTITION BY LIST (ngin_service_key)
+SUBPARTITION TEMPLATE
+(
+	SUBPARTITION Package5 VALUES (479534741),
+	DEFAULT SUBPARTITION other_services
+)
+(
+	PARTITION p20151110 START (2015111000::numeric) 
+END (2015111100::numeric) WITH (appendonly=false)
+);
+INSERT INTO part_tbl VALUES (2015111000, 479534741, 99999999);
+INSERT INTO part_tbl VALUES (2015111000, 479534742, 99999999);
+CREATE INDEX part_tbl_idx 
+ON part_tbl(profile_key);
+EXPLAIN SELECT * FROM part_tbl WHERE profile_key = 99999999;
+SELECT * FROM part_tbl WHERE profile_key = 99999999;
+DROP TABLE part_tbl;
+
 -- CLEANUP
 -- start_ignore
 drop schema if exists bfv_partition;


### PR DESCRIPTION
- Before building Index object (IMDIndex), we build LogicalIndexes
  via calling `gpdb::Plgidx(oidRel)` in which a partition tables is
  traversed and index  information (such as logicalIndexOid,
  nColumns, indexKeys, indPred, indExprs, indIsUnique, partCons,
  defaultLevels) is captured.
- For Indexes which are available on all the partitions partCons
  and defaultLevels are NULL/empty.
- Later in `CTranslatorRelcacheToDXL::PmdindexPartTable` to build
  Index object, we use the derived LogicalIndexes information and
  populates the array  holding the levels on which default
  partitions exists. But since defaultLevels is NIL in this case,
  pdrgpulDefaultLevels is set to empty i,e `default partitions on levels: {}`, 
 however that is not true.
- This causes an issue while trying to build the propagation expression,
  as because of wrong number of default partitions on level we mark the
  scan as partial and tries to construct a test propagation expression
  instead of a const propagation expression in `CTranslatorExprToDXLUtils::PdxlnPropExprPartitionSelector`
- This patch fixes the issue by marking the default partitions on
  levels for index equal to the default partitions on levels for the
  part relation if the index exists on all the parts.

Signed-off-by: Jemish Patel <jpatel@pivotal.io>