### PR TITLE
doc updates for variadic function arguments and type modifier functions

### DIFF
--- a/gpdb-doc/dita/ref_guide/data_types.xml
+++ b/gpdb-doc/dita/ref_guide/data_types.xml
@@ -372,6 +372,10 @@
         example, declaring a function as <codeph>myfunc(<i>anyelement</i>, <i>anyenum</i>)</codeph>
         is equivalent to declaring it as <codeph>myfunc(<i>anyenum</i>, <i>anyenum</i>)</codeph>:
         both actual arguments must be the same <codeph>enum</codeph> type.</p>
+      <p>A variadic function (one taking a variable number of arguments) is polymorphic when its 
+        last parameter is declared as <codeph>VARIADIC <i>anyarray</i></codeph>. For purposes of
+        argument matching and determining the actual result type, such a function behaves the 
+        same as if you had declared the appropriate number of <i>anynonarray</i> parameters.</p>
       <p>For more information about polymorphic types, see the Postgres documentation about <xref
           href="https://www.postgresql.org/docs/8.3/static/xfunc-c.html#AEN41553" format="html"
           scope="external">Polymorphic Arguments and Return Types</xref>.</p>

--- a/gpdb-doc/dita/ref_guide/extensions/pl_sql.xml
+++ b/gpdb-doc/dita/ref_guide/extensions/pl_sql.xml
@@ -253,6 +253,45 @@ $$ LANGUAGE plpgsql VOLATILE;</codeblock>
       </body>
     </topic>
 
+    <topic xml:lang="en" id="topic_lsh_5n5_2z1717">
+      <title>Example: Using a Variable Number of Arguments</title>
+      <body>
+        <p>You can declare a PL/pgSQL function to accept variable numbers of arguments, as long as
+          all of the optional arguments are of the same data type. You must mark the last argument
+          of the function as <codeph>VARIADIC</codeph> and declare the argument using an array type.
+          You can refer to a function that includes <codeph>VARIADIC</codeph> arguments as a
+          variadic function.
+          </p>
+        <p>For example, this variadic function returns the minimum value of a variable array
+          of numerics:</p>
+        <p>
+          <codeblock>CREATE FUNCTION mleast (VARIADIC numeric[]) 
+    RETURNS numeric AS $$
+  DECLARE minval numeric;
+  BEGIN
+    SELECT min($1[i]) FROM generate_subscripts( $1, 1) g(i) INTO minval;
+    RETURN minval;
+END;
+$$ LANGUAGE plpgsql;
+CREATE FUNCTION
+
+SELECT mleast(10, -1, 5, 4.4);
+ mleast
+--------
+     -1
+(1 row)
+</codeblock>
+        </p>
+        <p>Effectively, all of the actual arguments at or beyond the <codeph>VARIADIC</codeph> 
+          position are gathered up into a one-dimensional array.</p>
+        <p>You can pass an already-constructed array into a variadic function. This is particularly
+          useful when you want to pass arrays between variadic functions. Specify
+          <codeph>VARIADIC</codeph> in the function call as follows:</p>
+          <codeblock>SELECT mleast(VARIADIC ARRAY[10, -1, 5, 4.4]);</codeblock>
+        <p>This prevents PL/pgSQL from expanding the function's variadic parameter into its element type.</p>
+    </body>
+  </topic>
+
     <topic xml:lang="en" id="topic_lsh_5n5_2z1313">
       <title>Example: Using Default Argument Values</title>
       <body>
@@ -339,6 +378,7 @@ $$ LANGUAGE plpgsql;</codeblock>
             3.3
 (1 row)</codeblock>
         <p>The return type of <codeph>add_two_values()</codeph> in this case is float.</p>
+        <p>You can also specify <codeph>VARIADIC</codeph> arguments in polymorphic functions.</p>
     </body>
   </topic>
   <topic id="topic_isw_3sx_cz">

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_FUNCTION.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_FUNCTION.xml
@@ -26,12 +26,12 @@ or indirect member of the new owning role, and that role must have <codeph>CREAT
 privilege on the function's schema. (These restrictions enforce that
 altering the owner does not do anything you could not do by dropping
 and recreating the function. However, a superuser can alter ownership
-of any function anyway.) </p></section><section id="section4"><title>Parameters</title><parml><plentry><pt><varname>name</varname></pt><pd>The name (optionally schema-qualified) of an existing function. </pd></plentry><plentry><pt><varname>argmode</varname></pt><pd>The mode of an argument: either <codeph>IN</codeph>, <codeph>OUT</codeph>,
-or <codeph>INOUT</codeph>. If omitted, the default is <codeph>IN</codeph>.
+of any function anyway.) </p></section><section id="section4"><title>Parameters</title><parml><plentry><pt><varname>name</varname></pt><pd>The name (optionally schema-qualified) of an existing function. </pd></plentry><plentry><pt><varname>argmode</varname></pt><pd>The mode of an argument: either <codeph>IN</codeph>, <codeph>OUT</codeph>, <codeph>INOUT</codeph>, 
+or <codeph>VARIADIC</codeph>. If omitted, the default is <codeph>IN</codeph>.
 Note that <codeph>ALTER FUNCTION</codeph> does not actually pay any attention
 to <codeph>OUT</codeph> arguments, since only the input arguments are
 needed to determine the function's identity. So it is sufficient to
-list the <codeph>IN</codeph> and <codeph>INOUT</codeph> arguments.</pd></plentry><plentry><pt><varname>argname</varname></pt><pd>The name of an argument. Note that <codeph>ALTER FUNCTION</codeph>
+list the <codeph>IN</codeph>, <codeph>INOUT</codeph>, and <codeph>VARIADIC</codeph> arguments.</pd></plentry><plentry><pt><varname>argname</varname></pt><pd>The name of an argument. Note that <codeph>ALTER FUNCTION</codeph>
 does not actually pay any attention to argument names, since only the
 argument data types are needed to determine the function's identity.
 </pd></plentry><plentry><pt><varname>argtype</varname></pt><pd>The data type(s) of the function's arguments (optionally schema-qualified),

--- a/gpdb-doc/dita/ref_guide/sql_commands/COMMENT.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/COMMENT.xml
@@ -39,11 +39,11 @@ domains, functions, indexes, operators, operator classes, sequences,
 types, and views may be schema-qualified. <note>Greenplum Database does not support triggers.</note></pd></plentry><plentry><pt><varname>agg_type</varname></pt><pd>An input data type on which the aggregate function operates. To reference
 a zero-argument aggregate function, write <codeph>*</codeph> in place
 of the list of input data types. </pd></plentry><plentry><pt><varname>sourcetype</varname></pt><pd>The name of the source data type of the cast. </pd></plentry><plentry><pt><varname>targettype</varname></pt><pd>The name of the target data type of the cast. </pd></plentry><plentry><pt><varname>argmode</varname></pt><pd>The mode of a function argument: either <codeph>IN</codeph>, <codeph>OUT</codeph>,
-or <codeph>INOUT</codeph>. If omitted, the default is <codeph>IN</codeph>.
+<codeph>INOUT</codeph> or <codeph>VARIADIC</codeph>. If omitted, the default is <codeph>IN</codeph>.
 Note that <codeph>COMMENT ON FUNCTION</codeph> does not actually pay
 any attention to <codeph>OUT</codeph> arguments, since only the input
 arguments are needed to determine the function's identity. So it is
-sufficient to list the <codeph>IN</codeph> and <codeph>INOUT</codeph>
+sufficient to list the <codeph>IN</codeph>, <codeph>INOUT</codeph>, and <codeph>VARIADIC</codeph> 
 arguments. </pd></plentry><plentry><pt><varname>argname</varname></pt><pd>The name of a function argument. Note that <codeph>COMMENT ON FUNCTION</codeph>
 does not actually pay any attention to argument names, since only the
 argument data types are needed to determine the function's identity.

--- a/gpdb-doc/dita/ref_guide/sql_commands/COMMENT.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/COMMENT.xml
@@ -39,7 +39,7 @@ domains, functions, indexes, operators, operator classes, sequences,
 types, and views may be schema-qualified. <note>Greenplum Database does not support triggers.</note></pd></plentry><plentry><pt><varname>agg_type</varname></pt><pd>An input data type on which the aggregate function operates. To reference
 a zero-argument aggregate function, write <codeph>*</codeph> in place
 of the list of input data types. </pd></plentry><plentry><pt><varname>sourcetype</varname></pt><pd>The name of the source data type of the cast. </pd></plentry><plentry><pt><varname>targettype</varname></pt><pd>The name of the target data type of the cast. </pd></plentry><plentry><pt><varname>argmode</varname></pt><pd>The mode of a function argument: either <codeph>IN</codeph>, <codeph>OUT</codeph>,
-<codeph>INOUT</codeph> or <codeph>VARIADIC</codeph>. If omitted, the default is <codeph>IN</codeph>.
+<codeph>INOUT</codeph>, or <codeph>VARIADIC</codeph>. If omitted, the default is <codeph>IN</codeph>.
 Note that <codeph>COMMENT ON FUNCTION</codeph> does not actually pay
 any attention to <codeph>OUT</codeph> arguments, since only the input
 arguments are needed to determine the function's identity. So it is

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_FUNCTION.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_FUNCTION.xml
@@ -46,8 +46,8 @@ in the <codeph>FROM</codeph> clause simply returns a set of
 rows, execution may be allowed on the segments:</p><codeblock>SELECT * FROM foo();</codeblock><p>One exception to this rule are functions that return a table reference
 (<codeph>rangeFuncs</codeph>) or functions that use the <codeph>refCursor</codeph>
 data type. Note that you cannot return a <codeph>refcursor</codeph> from
-any kind of function in Greenplum Database.</p></sectiondiv></section><section id="section5"><title>Parameters</title><parml><plentry><pt><varname>name</varname></pt><pd>The name (optionally schema-qualified) of the function to create.</pd></plentry><plentry><pt><varname>argmode</varname></pt><pd>The mode of an argument: either <codeph>IN</codeph>, <codeph>OUT</codeph>,
-or <codeph>INOUT</codeph>. If omitted, the default is <codeph>IN</codeph>.
+any kind of function in Greenplum Database.</p></sectiondiv></section><section id="section5"><title>Parameters</title><parml><plentry><pt><varname>name</varname></pt><pd>The name (optionally schema-qualified) of the function to create.</pd></plentry><plentry><pt><varname>argmode</varname></pt><pd>The mode of an argument: either <codeph>IN</codeph>, <codeph>OUT</codeph>, <codeph>INOUT</codeph>, 
+or <codeph>VARIADIC</codeph>. Only <codeph>OUT</codeph> arguments can follow an argument declared as <codeph>VARIADIC</codeph>. If omitted, the default is <codeph>IN</codeph>.
 </pd></plentry><plentry><pt><varname>argname</varname></pt><pd>The name of an argument. Some languages (currently only PL/pgSQL)
 let you use the name in the function body. For other languages the name
 of an input argument is just extra documentation. But the name of an
@@ -179,8 +179,8 @@ CREATE FUNCTION foo(int, int default 42) ...</codeblock>
 be called.</p>
 <p>When repeated <codeph>CREATE FUNCTION</codeph> calls refer to the same
 object file, the file is only loaded once. To unload and reload the file,
-use the <codeph>LOAD</codeph> command. </p><p>To be able to define a function, the user must have the <codeph>USAGE</codeph>
-privilege on the language.</p><p>It is often helpful to use dollar quoting to write the function definition
+use the <codeph>LOAD</codeph> command. </p><p>You must have the <codeph>USAGE</codeph> privilege on a language to be able to define a function using that language.</p>
+<p>It is often helpful to use dollar quoting to write the function definition
 string, rather than the normal single quote syntax. Without dollar quoting,
 any single quotes or backslashes in the function definition must be escaped
 by doubling them. A dollar-quoted string constant consists of a dollar
@@ -200,7 +200,12 @@ $SomeTag$Dianne's horse$SomeTag$</codeblock>
                     FUNCTION</codeph>
                 <codeph>SET</codeph> clause, much as it would for a previous <codeph>SET
                     LOCAL</codeph> command. The effects of such a command will persist after the
-                function exits, unless the current transaction is rolled back.</p><sectiondiv id="section7"><b>Using Functions With Queries on Distributed Data</b><p>In some cases, Greenplum Database does not support using functions in
+                function exits, unless the current transaction is rolled back.</p>
+            <p>If a function with a <codeph>VARIADIC</codeph> argument is declared as
+              <codeph>STRICT</codeph>, the strictness check tests that the variadic array as a
+               whole is non-null. PL/pgSQL will still call the function if the array has null
+               elements.</p>
+<sectiondiv id="section7"><b>Using Functions With Queries on Distributed Data</b><p>In some cases, Greenplum Database does not support using functions in
 a query where the data in a table specified in the <codeph>FROM</codeph>
 clause is distributed over Greenplum Database segments. As an example,
 this SQL query contains the function <codeph>func()</codeph>:</p><codeblock>SELECT func(a) FROM table1;</codeblock><p>The function is not supported for use in the query if all of the following

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TYPE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TYPE.xml
@@ -10,6 +10,8 @@ CREATE TYPE <varname>name</varname> (
     OUTPUT = <varname>output_function</varname>
     [, RECEIVE = <varname>receive_function</varname>]
     [, SEND = <varname>send_function</varname>]
+    [, TYPMOD_IN = <varname>type_modifier_input_function</varname> ]
+    [, TYPMOD_OUT = <varname>type_modifier_output_function</varname> ]
     [, INTERNALLENGTH = {<varname>internallength</varname> | VARIABLE}]
     [, PASSEDBYVALUE]
     [, ALIGNMENT = <varname>alignment</varname>]
@@ -40,7 +42,7 @@ PostgreSQL documentation. Enum types take a list of one or more quoted labels, e
                     not only that shown in the syntax, and most are optional. You must register two
                     or more functions (using <codeph>CREATE FUNCTION</codeph>) before defining the
                     type. The support functions <varname>input_function</varname> and <varname>output_function</varname> are
-                    required, while the functions <varname>receive_function</varname>, <varname>send_function</varname> and
+                    required, while the functions <varname>receive_function</varname>, <varname>send_function</varname>, <varname>type_modifier_input_function</varname>, <varname>type_modifier_output_function</varname>, and
                         <varname>analyze_function</varname> are optional. Generally these functions have to be
                     coded in C or another low-level language. In Greenplum Database, any function
                     used to implement a data type must be defined as
@@ -86,7 +88,32 @@ PostgreSQL documentation. Enum types take a list of one or more quoted labels, e
                     If this function is not supplied, the type cannot participate in binary output.
                     The send function must be declared as taking one argument of the new data type.
                     The send function must return type <codeph>bytea</codeph>. Send functions are
-                    not invoked for <codeph>NULL</codeph> values. </p><p>You should at this point be
+                    not invoked for <codeph>NULL</codeph> values. </p>
+                    <p>The optional <varname>type_modifier_input_function</varname> and
+                      <varname>type_modifier_output_function</varname> are required if the type
+                      supports modifiers. Modifiers are optional constraints attached to a type
+                      declaration, such as <codeph>char(5)</codeph> or 
+                      <codeph>numeric(30,2)</codeph>. While Greenplum Database
+                      allows user-defined types to take one or more simple constants or identifiers
+                      as modifiers, this information must fit into a single
+                      non-negative integer value for storage in the system catalogs. Greenplum
+                      Database passes the declared modifier(s) to the
+                      <varname>type_modifier_input_function</varname> in the form of a
+                      <codeph>cstring</codeph> array. The modifier input function must check the
+                      values for validity, throwing an error if they are incorrect. If the values
+                      are correct, the modifier input function returns a single non-negative integer
+                      value that Greenplum Database stores as the column "typmod". Type modifiers
+                      are rejected if the type
+                      was not defined with a <varname>type_modifier_input_function</varname>.
+                      The <varname>type_modifier_output_function</varname> converts the internal
+                      integer typmod value back to the correct form for user display. The 
+                      modifier output function must return a <codeph>cstring</codeph> value that
+                      is the exact string to append to the type name. For example,
+                      <codeph>numeric</codeph>'s function might return <codeph>(30,2)</codeph>.
+                      The <varname>type_modifier_output_function</varname> is optional. When not
+                      specified, the default display format is the stored typmod integer value
+                      enclosed in parentheses.</p>
+                    <p>You should at this point be
                     wondering how the input and output functions can be declared to have results or
                     arguments of the new type, when they have to be created before the new type can
                     be created. The answer is that the type should first be defined as a shell type,
@@ -168,7 +195,10 @@ type. </pd></plentry>
 textual form to its internal form. </pd></plentry><plentry><pt><varname>output_function</varname></pt><pd>The name of a function that converts data from the type's internal
 form to its external textual form. </pd></plentry><plentry><pt><varname>receive_function</varname></pt><pd>The name of a function that converts data from the type's external
 binary form to its internal form. </pd></plentry><plentry><pt><varname>send_function</varname></pt><pd>The name of a function that converts data from the type's internal
-form to its external binary form. </pd></plentry><plentry><pt><varname>internallength</varname></pt><pd>A numeric constant that specifies the length in bytes of the new
+form to its external binary form. </pd></plentry>
+<plentry><pt><varname>type_modifier_input_function</varname></pt><pd>The name of a function that converts an array of modifier(s) for the type to internal form.</pd></plentry> 
+<plentry><pt><varname>type_modifier_output_function</varname></pt><pd>The name of a function that converts the internal form of the type's modifier(s) to external textual form.</pd></plentry> 
+<plentry><pt><varname>internallength</varname></pt><pd>A numeric constant that specifies the length in bytes of the new
 type's internal representation. The default assumption is that it is
 variable-length. </pd></plentry><plentry><pt><varname>alignment</varname></pt><pd>The storage alignment requirement of the data type. Must be one of
 <codeph>char</codeph>, <codeph>int2</codeph>, <codeph>int4</codeph>,

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TYPE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TYPE.xml
@@ -102,16 +102,16 @@ PostgreSQL documentation. Enum types take a list of one or more quoted labels, e
                       <codeph>cstring</codeph> array. The modifier input function must check the
                       values for validity, throwing an error if they are incorrect. If the values
                       are correct, the modifier input function returns a single non-negative integer
-                      value that Greenplum Database stores as the column "typmod". Type modifiers
+                      value that Greenplum Database stores as the column <codeph>typmod</codeph>. Type modifiers
                       are rejected if the type
                       was not defined with a <varname>type_modifier_input_function</varname>.
                       The <varname>type_modifier_output_function</varname> converts the internal
-                      integer typmod value back to the correct form for user display. The 
+                      integer <codeph>typmod</codeph> value back to the correct form for user display. The 
                       modifier output function must return a <codeph>cstring</codeph> value that
                       is the exact string to append to the type name. For example,
                       <codeph>numeric</codeph>'s function might return <codeph>(30,2)</codeph>.
                       The <varname>type_modifier_output_function</varname> is optional. When not
-                      specified, the default display format is the stored typmod integer value
+                      specified, the default display format is the stored <codeph>typmod</codeph> integer value
                       enclosed in parentheses.</p>
                     <p>You should at this point be
                     wondering how the input and output functions can be declared to have results or

--- a/gpdb-doc/dita/ref_guide/sql_commands/DROP_FUNCTION.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/DROP_FUNCTION.xml
@@ -7,11 +7,11 @@ function. To execute this command the user must be the owner of the function.
 The argument types to the function must be specified, since several different
 functions may exist with the same name and different argument lists.</p></section><section id="section4"><title>Parameters</title><parml><plentry><pt>IF EXISTS</pt><pd>Do not throw an error if the function does not exist. A notice is
 issued in this case. </pd></plentry><plentry><pt><varname>name</varname></pt><pd>The name (optionally schema-qualified) of an existing function.</pd></plentry><plentry><pt><varname>argmode</varname></pt><pd>The mode of an argument: either <codeph>IN</codeph>, <codeph>OUT</codeph>,
-or <codeph>INOUT</codeph>. If omitted, the default is IN. Note that <codeph>DROP
+<codeph>INOUT</codeph>, or <codeph>VARIADIC</codeph>. If omitted, the default is IN. Note that <codeph>DROP
 FUNCTION</codeph> does not actually pay any attention to <codeph>OUT</codeph>
 arguments, since only the input arguments are needed to determine the
-function's identity. So it is sufficient to list the <codeph>IN</codeph>
-and <codeph>INOUT</codeph> arguments. </pd></plentry><plentry><pt><varname>argname</varname></pt><pd>The name of an argument. Note that <codeph>DROP FUNCTION</codeph>
+function's identity. So it is sufficient to list the <codeph>IN</codeph>,
+ <codeph>INOUT</codeph>, and <codeph>VARIADIC</codeph> arguments. </pd></plentry><plentry><pt><varname>argname</varname></pt><pd>The name of an argument. Note that <codeph>DROP FUNCTION</codeph>
 does not actually pay any attention to argument names, since only the
 argument data types are needed to determine the function's identity.
 </pd></plentry><plentry><pt><varname>argtype</varname></pt><pd>The data type(s) of the function's arguments (optionally schema-qualified),

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_proc.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_proc.xml
@@ -66,6 +66,24 @@
           </row>
           <row>
             <entry colname="col1">
+              <codeph>procost</codeph>
+            </entry>
+            <entry colname="col2">float4</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Estimated execution cost (in cpu_operator_cost units); if 
+              proretset is <codeph>true</codeph>, identifies the cost per row returned.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>provariadic</codeph>
+            </entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3">pg_type.oid</entry>
+            <entry colname="col4">Data type of the variadic array parameter's elements, or zero
+              if the function does not have a variadic parameter.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
               <codeph>proisagg</codeph>
             </entry>
             <entry colname="col2">boolean</entry>
@@ -123,6 +141,14 @@
           </row>
           <row>
             <entry colname="col1">
+              <codeph>pronargdefaults</codeph>
+            </entry>
+            <entry colname="col2">int2</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Number of arguments that have default values.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
               <codeph>prorettype</codeph>
             </entry>
             <entry colname="col2">oid</entry>
@@ -145,7 +171,8 @@
             <entry colname="col2">oidvector</entry>
             <entry colname="col3">pg_type.oid</entry>
             <entry colname="col4">An array with the data types of the function arguments. This
-              includes only input arguments (including <codeph>INOUT</codeph> arguments), and thus
+              includes only input arguments (including <codeph>INOUT</codeph> and 
+              <codeph>VARIADIC</codeph> arguments), and thus
               represents the call signature of the function.</entry>
           </row>
           <row>
@@ -168,7 +195,8 @@
             <entry colname="col3"/>
             <entry colname="col4">An array with the modes of the function arguments:
                 <codeph>i</codeph> = <codeph>IN</codeph>, <codeph>o</codeph> = <codeph>OUT</codeph>
-              , <codeph>b</codeph> = <codeph>INOUT</codeph>. If all the arguments are IN arguments,
+              , <codeph>b</codeph> = <codeph>INOUT</codeph>, <codeph>v</codeph> = 
+              <codeph>VARIADIC</codeph>. If all the arguments are IN arguments,
               this field will be null. Note that subscripts correspond to positions of
               proallargtypes not proargtypes.</entry>
           </row>
@@ -182,6 +210,18 @@
               without a name are set to empty strings in the array. If none of the arguments have a
               name, this field will be null. Note that subscripts correspond to positions of
               proallargtypes not proargtypes.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>proargdefaults</codeph>
+            </entry>
+            <entry colname="col2"> text </entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Expression trees for default argument values. This is a list with 
+              pronargdefaults elements, corresponding to the last
+              <varname>N</varname> input arguments (i.e., the last <varname>N</varname>
+              proargtypes positions). If none of the arguments have defaults,
+              this field is empty.</entry>
           </row>
           <row>
             <entry colname="col1">

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_type.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_type.xml
@@ -168,6 +168,24 @@
           </row>
           <row>
             <entry colname="col1">
+              <codeph>typmodin</codeph>
+            </entry>
+            <entry colname="col2">regproc</entry>
+            <entry colname="col3">pg_proc.oid</entry>
+            <entry colname="col4">Type modifier input function, or 0 if the type does not support
+              modifiers.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>typmodout</codeph>
+            </entry>
+            <entry colname="col2">regproc</entry>
+            <entry colname="col3">pg_proc.oid</entry>
+            <entry colname="col4">Type modifier output function, or 0 to use the standard 
+              format.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
               <codeph>typanalyze</codeph>
             </entry>
             <entry colname="col2">regproc</entry>


### PR DESCRIPTION
added info about variadic function arguments and type modifiers to the docs.  changes to various SQL command pages, catalog table refs, plpgsql, 

also added pg_proc columns procost, pronargdefaults, proargdefaults in this PR, i missed them when i updated the docs for create function COST and DEFAULT clauses.

question @hlinnaka  - there wasn't much info about the type modifier functions in the postgres docs aside from the CREATE TYPE page.  the text that this page referred multiple times to a "typmod" column.  is this the same as the pg_attribute atttypmod column?  if not, to what is it referring?  i am curious, and also wasn't sure how to format the text.  thanks.