### PR TITLE
Remove duplicate unit test in pipeline compile script

### DIFF
--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -181,7 +181,6 @@ function _main() {
       # require `./configure --with-zlib`.
       unittest_check_gpdb
   fi
-  unittest_check_gpdb
   export_gpdb
   export_gpdb_extensions
   export_gpdb_win32_ccl


### PR DESCRIPTION
Remove duplicate unittest_check_gpdb in compile_gpdb.bash, it's already run by the above "if" block when needed.