### PR TITLE
Makefile.behave change: remove option --no-color

### DIFF
--- a/gpMgmt/Makefile.behave
+++ b/gpMgmt/Makefile.behave
@@ -13,9 +13,9 @@ $(BEHAVE_BIN):
 behave: $(BEHAVE_BIN)
 	@echo "Running behave on management scripts..."
 	if [ -n ""$(tags)"" ] && [ -n ""$(skip_tags)"" ]; then \
-	        PYTHONPATH=$(PYTHONSRC_INSTALL_PYTHON_PATH):$(GPMGMT_SRC) python $(BEHAVE_BIN) $(GPMGMT_SRC)/test/behave/* --no-color -s -k --tags=$(tags) --tags=$(skip_tags) 2>&1 ; \
+	        PYTHONPATH=$(PYTHONSRC_INSTALL_PYTHON_PATH):$(GPMGMT_SRC) python $(BEHAVE_BIN) $(GPMGMT_SRC)/test/behave/* -s -k --tags=$(tags) --tags=$(skip_tags) 2>&1 ; \
 	elif [ -n ""$(tags)"" ]; then \
-	        PYTHONPATH=$(PYTHONSRC_INSTALL_PYTHON_PATH):$(GPMGMT_SRC) python $(BEHAVE_BIN) $(GPMGMT_SRC)/test/behave/* --no-color -s -k --tags=$(tags) 2>&1 ; \
+	        PYTHONPATH=$(PYTHONSRC_INSTALL_PYTHON_PATH):$(GPMGMT_SRC) python $(BEHAVE_BIN) $(GPMGMT_SRC)/test/behave/* -s -k --tags=$(tags) 2>&1 ; \
 	else \
-	        PYTHONPATH=$(PYTHONSRC_INSTALL_PYTHON_PATH):$(GPMGMT_SRC) python $(BEHAVE_BIN) $(GPMGMT_SRC)/test/behave/* --no-color -s 2>&1; \
+	        PYTHONPATH=$(PYTHONSRC_INSTALL_PYTHON_PATH):$(GPMGMT_SRC) python $(BEHAVE_BIN) $(GPMGMT_SRC)/test/behave/* -s 2>&1; \
 	fi


### PR DESCRIPTION
There was no colorization for Behave output on Concourse. This change fixes that, removing an option called "--no-color" when running Behave.

On pulse, this seemed to make no change
On concourse, this added color

Signed-off-by: Nadeem Ghani <nghani@pivotal.io>