### PR TITLE
pg_regress: converted files should be placed in `outputdir`

### DIFF
--- a/src/test/regress/pg_regress.c
+++ b/src/test/regress/pg_regress.c
@@ -776,10 +776,9 @@ convert_sourcefiles_in(char *source, char * dest_dir, char *dest, char *suffix)
 static void
 convert_sourcefiles(void)
 {
-	convert_sourcefiles_in("input", inputdir, "sql", "sql");
+	convert_sourcefiles_in("input", outputdir, "sql", "sql");
 	convert_sourcefiles_in("output", outputdir, "expected", "out");
-
-	convert_sourcefiles_in("mapred", inputdir, "yml", "yml");
+	convert_sourcefiles_in("mapred", outputdir, "yml", "yml");
 }
 
 /*


### PR DESCRIPTION
`outputdir` here is where to place the converted files, not the
directory named `output`. PostgreSQL places them into `outputdir`
rightly.

    commit 64cdbbc48cade73d7b0831444a62e19fd4a342f8
    Author: Peter Eisentraut <peter_e@gmx.net>
    Date:   Sat Feb 14 21:33:41 2015 -0500

        pg_regress: Write processed input/*.source into output dir

        Before, it was writing the processed files into the input directory,
        which is incorrect in a vpath build.