### PR TITLE
Renamed `typname` or other variant to `typeName`.

### DIFF
--- a/src/backend/access/common/tupdesc.c
+++ b/src/backend/access/common/tupdesc.c
@@ -549,10 +549,10 @@ BuildDescForRelation(List *schema)
 		attnum++;
 
 		attname = entry->colname;
-		atttypid = typenameTypeId(NULL, entry->typname, &atttypmod);
-		attdim = list_length(entry->typname->arrayBounds);
+		atttypid = typenameTypeId(NULL, entry->typeName, &atttypmod);
+		attdim = list_length(entry->typeName->arrayBounds);
 
-		if (entry->typname->setof)
+		if (entry->typeName->setof)
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
 					 errmsg("column \"%s\" cannot be declared SETOF",

--- a/src/backend/commands/sequence.c
+++ b/src/backend/commands/sequence.c
@@ -411,48 +411,48 @@ DefineSequence(CreateSeqStmt *seq)
 		switch (i)
 		{
 			case SEQ_COL_NAME:
-				coldef->typname = makeTypeNameFromOid(NAMEOID, -1);
+				coldef->typeName = makeTypeNameFromOid(NAMEOID, -1);
 				coldef->colname = "sequence_name";
 				namestrcpy(&name, seq->sequence->relname);
 				value[i - 1] = NameGetDatum(&name);
 				break;
 			case SEQ_COL_LASTVAL:
-				coldef->typname = makeTypeNameFromOid(INT8OID, -1);
+				coldef->typeName = makeTypeNameFromOid(INT8OID, -1);
 				coldef->colname = "last_value";
 				value[i - 1] = Int64GetDatumFast(new.last_value);
 				break;
 			case SEQ_COL_INCBY:
-				coldef->typname = makeTypeNameFromOid(INT8OID, -1);
+				coldef->typeName = makeTypeNameFromOid(INT8OID, -1);
 				coldef->colname = "increment_by";
 				value[i - 1] = Int64GetDatumFast(new.increment_by);
 				break;
 			case SEQ_COL_MAXVALUE:
-				coldef->typname = makeTypeNameFromOid(INT8OID, -1);
+				coldef->typeName = makeTypeNameFromOid(INT8OID, -1);
 				coldef->colname = "max_value";
 				value[i - 1] = Int64GetDatumFast(new.max_value);
 				break;
 			case SEQ_COL_MINVALUE:
-				coldef->typname = makeTypeNameFromOid(INT8OID, -1);
+				coldef->typeName = makeTypeNameFromOid(INT8OID, -1);
 				coldef->colname = "min_value";
 				value[i - 1] = Int64GetDatumFast(new.min_value);
 				break;
 			case SEQ_COL_CACHE:
-				coldef->typname = makeTypeNameFromOid(INT8OID, -1);
+				coldef->typeName = makeTypeNameFromOid(INT8OID, -1);
 				coldef->colname = "cache_value";
 				value[i - 1] = Int64GetDatumFast(new.cache_value);
 				break;
 			case SEQ_COL_LOG:
-				coldef->typname = makeTypeNameFromOid(INT8OID, -1);
+				coldef->typeName = makeTypeNameFromOid(INT8OID, -1);
 				coldef->colname = "log_cnt";
 				value[i - 1] = Int64GetDatum((int64) 0);
 				break;
 			case SEQ_COL_CYCLE:
-				coldef->typname = makeTypeNameFromOid(BOOLOID, -1);
+				coldef->typeName = makeTypeNameFromOid(BOOLOID, -1);
 				coldef->colname = "is_cycled";
 				value[i - 1] = BoolGetDatum(new.is_cycled);
 				break;
 			case SEQ_COL_CALLED:
-				coldef->typname = makeTypeNameFromOid(BOOLOID, -1);
+				coldef->typeName = makeTypeNameFromOid(BOOLOID, -1);
 				coldef->colname = "is_called";
 				value[i - 1] = BoolGetDatum(false);
 				break;

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -1549,7 +1549,7 @@ MergeAttributes(List *schema, List *supers, bool istemp, bool isPartitioned,
 						(errmsg("merging multiple inherited definitions of column \"%s\"",
 								attributeName)));
 				def = (ColumnDef *) list_nth(inhSchema, exist_attno - 1);
-				defTypeId = typenameTypeId(NULL, def->typname, &deftypmod);
+				defTypeId = typenameTypeId(NULL, def->typeName, &deftypmod);
 				if (defTypeId != attribute->atttypid ||
 					deftypmod != attribute->atttypmod)
 					ereport(ERROR,
@@ -1557,7 +1557,7 @@ MergeAttributes(List *schema, List *supers, bool istemp, bool isPartitioned,
 						errmsg("inherited column \"%s\" has a type conflict",
 							   attributeName),
 							 errdetail("%s versus %s",
-									   TypeNameToString(def->typname),
+									   TypeNameToString(def->typeName),
 									   format_type_be(attribute->atttypid))));
 				def->inhcount++;
 				/* Merge of NOT NULL constraints = OR 'em together */
@@ -1594,7 +1594,7 @@ MergeAttributes(List *schema, List *supers, bool istemp, bool isPartitioned,
 				 */
 				def = makeNode(ColumnDef);
 				def->colname = pstrdup(attributeName);
-				def->typname = makeTypeNameFromOid(attribute->atttypid,
+				def->typeName = makeTypeNameFromOid(attribute->atttypid,
 													attribute->atttypmod);
 				def->inhcount = 1;
 				def->is_local = false;
@@ -1735,16 +1735,16 @@ MergeAttributes(List *schema, List *supers, bool istemp, bool isPartitioned,
 				   (errmsg("merging column \"%s\" with inherited definition",
 						   attributeName)));
 				def = (ColumnDef *) list_nth(inhSchema, exist_attno - 1);
-				defTypeId = typenameTypeId(NULL, def->typname, &deftypmod);
-				newTypeId = typenameTypeId(NULL, newdef->typname, &newtypmod);
+				defTypeId = typenameTypeId(NULL, def->typeName, &deftypmod);
+				newTypeId = typenameTypeId(NULL, newdef->typeName, &newtypmod);
 				if (defTypeId != newTypeId || deftypmod != newtypmod)
 					ereport(ERROR,
 							(errcode(ERRCODE_DATATYPE_MISMATCH),
 							 errmsg("column \"%s\" has a type conflict",
 									attributeName),
 							 errdetail("%s versus %s",
-									   TypeNameToString(def->typname),
-									   TypeNameToString(newdef->typname))));
+									   TypeNameToString(def->typeName),
+									   TypeNameToString(newdef->typeName))));
 				/* Mark the column as locally defined */
 				def->is_local = true;
 				/* Merge of NOT NULL constraints = OR 'em together */
@@ -5838,7 +5838,7 @@ ATExecAddColumn(AlteredTableInfo *tab, Relation rel,
 			int32		ctypmod;
 
 			/* Okay if child matches by type */
-			ctypeId = typenameTypeId(NULL, colDef->typname, &ctypmod);
+			ctypeId = typenameTypeId(NULL, colDef->typeName, &ctypmod);
 
 			if (ctypeId != childatt->atttypid ||
 				ctypmod != childatt->atttypmod)
@@ -5896,7 +5896,7 @@ ATExecAddColumn(AlteredTableInfo *tab, Relation rel,
 						MaxHeapAttributeNumber)));
 	i = minattnum + 1;
 
-	typeTuple = typenameType(NULL, colDef->typname, &typmod);
+	typeTuple = typenameType(NULL, colDef->typeName, &typmod);
 	tform = (Form_pg_type) GETSTRUCT(typeTuple);
 	typeOid = HeapTupleGetOid(typeTuple);
 
@@ -5920,7 +5920,7 @@ ATExecAddColumn(AlteredTableInfo *tab, Relation rel,
 	attribute->atttypmod = typmod;
 	attribute->attnum = i;
 	attribute->attbyval = tform->typbyval;
-	attribute->attndims = list_length(colDef->typname->arrayBounds);
+	attribute->attndims = list_length(colDef->typeName->arrayBounds);
 	attribute->attstorage = tform->typstorage;
 	attribute->attalign = tform->typalign;
 	attribute->attnotnull = colDef->is_not_null;
@@ -6078,7 +6078,7 @@ ATExecAddColumn(AlteredTableInfo *tab, Relation rel,
 		else
 		{
 			/* Use the type specific storage directive, if one exists */
-			c->encoding = TypeNameGetStorageDirective(colDef->typname);
+			c->encoding = TypeNameGetStorageDirective(colDef->typeName);
 			
 			if (!c->encoding)
 				c->encoding = default_column_encoding_clause();
@@ -11475,7 +11475,7 @@ prebuild_temp_table(Relation rel, RangeVar *tmpname, List *distro, List *opts,
 			}
 
 			tname->location = -1;
-			cd->typname = tname;
+			cd->typeName = tname;
 			cs->tableElts = lappend(cs->tableElts, cd);
 		}
 		q = parse_analyze((Node *)cs, NULL, NULL, 0);

--- a/src/backend/commands/typecmds.c
+++ b/src/backend/commands/typecmds.c
@@ -689,7 +689,7 @@ DefineDomain(CreateDomainStmt *stmt)
 	bool		saw_default = false;
 	bool		typNotNull = false;
 	bool		nullDefined = false;
-	int32		typNDims = list_length(stmt->typname->arrayBounds);
+	int32		typNDims = list_length(stmt->typeName->arrayBounds);
 	HeapTuple	typeTup;
 	List	   *schema = stmt->constraints;
 	ListCell   *listptr;
@@ -729,7 +729,7 @@ DefineDomain(CreateDomainStmt *stmt)
 	/*
 	 * Look up the base type.
 	 */
-	typeTup = typenameType(NULL, stmt->typname, &basetypeMod);
+	typeTup = typenameType(NULL, stmt->typeName, &basetypeMod);
 	baseType = (Form_pg_type) GETSTRUCT(typeTup);
 	basetypeoid = HeapTupleGetOid(typeTup);
 
@@ -745,7 +745,7 @@ DefineDomain(CreateDomainStmt *stmt)
 		ereport(ERROR,
 				(errcode(ERRCODE_DATATYPE_MISMATCH),
 				 errmsg("\"%s\" is not a valid base type for a domain",
-						TypeNameToString(stmt->typname))));
+						TypeNameToString(stmt->typeName))));
 
 	/* passed by value */
 	byValue = baseType->typbyval;
@@ -2835,7 +2835,7 @@ AlterTypeNamespaceInternal(Oid typeOid, Oid nspOid,
 void
 AlterType(AlterTypeStmt *stmt)
 {
-	TypeName	   *typname = stmt->typname;
+	TypeName	   *typname = stmt->typeName;
 	Oid				typid;
 	int32			typmod;
 	HeapTuple		tup;

--- a/src/backend/commands/view.c
+++ b/src/backend/commands/view.c
@@ -128,7 +128,7 @@ DefineVirtualRelation(const RangeVar *relation, List *tlist, bool replace)
 			ColumnDef  *def = makeNode(ColumnDef);
 
 			def->colname = pstrdup(tle->resname);
-			def->typname = makeTypeNameFromOid(exprType((Node *) tle->expr),
+			def->typeName = makeTypeNameFromOid(exprType((Node *) tle->expr),
 											 exprTypmod((Node *) tle->expr));
 			def->inhcount = 0;
 			def->is_local = true;

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -2451,7 +2451,7 @@ _copyAConst(A_Const *from)
 			break;
 	}
 
-	COPY_NODE_FIELD(typname);
+	COPY_NODE_FIELD(typeName);
 	COPY_SCALAR_FIELD(location);    /*CDB*/
 
 	return newnode;
@@ -2581,7 +2581,7 @@ _copyTypeCast(TypeCast *from)
 	TypeCast   *newnode = makeNode(TypeCast);
 
 	COPY_NODE_FIELD(arg);
-	COPY_NODE_FIELD(typname);
+	COPY_NODE_FIELD(typeName);
 
 	return newnode;
 }
@@ -2606,7 +2606,7 @@ _copyColumnDef(ColumnDef *from)
 	ColumnDef  *newnode = makeNode(ColumnDef);
 
 	COPY_STRING_FIELD(colname);
-	COPY_NODE_FIELD(typname);
+	COPY_NODE_FIELD(typeName);
 	COPY_SCALAR_FIELD(inhcount);
 	COPY_SCALAR_FIELD(is_local);
 	COPY_SCALAR_FIELD(is_not_null);
@@ -2981,7 +2981,7 @@ _copyAlterDomainStmt(AlterDomainStmt *from)
 	AlterDomainStmt *newnode = makeNode(AlterDomainStmt);
 
 	COPY_SCALAR_FIELD(subtype);
-	COPY_NODE_FIELD(typname);
+	COPY_NODE_FIELD(typeName);
 	COPY_STRING_FIELD(name);
 	COPY_NODE_FIELD(def);
 	COPY_SCALAR_FIELD(behavior);
@@ -3682,7 +3682,7 @@ _copyCreateDomainStmt(CreateDomainStmt *from)
 	CreateDomainStmt *newnode = makeNode(CreateDomainStmt);
 
 	COPY_NODE_FIELD(domainname);
-	COPY_NODE_FIELD(typname);
+	COPY_NODE_FIELD(typeName);
 	COPY_NODE_FIELD(constraints);
 
 	return newnode;
@@ -4389,7 +4389,7 @@ _copyAlterTypeStmt(AlterTypeStmt *from)
 {
 	AlterTypeStmt *newnode = makeNode(AlterTypeStmt);
 
-	COPY_NODE_FIELD(typname);
+	COPY_NODE_FIELD(typeName);
 	COPY_NODE_FIELD(encoding);
 
 	return newnode;

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -1046,7 +1046,7 @@ static bool
 _equalAlterDomainStmt(AlterDomainStmt *a, AlterDomainStmt *b)
 {
 	COMPARE_SCALAR_FIELD(subtype);
-	COMPARE_NODE_FIELD(typname);
+	COMPARE_NODE_FIELD(typeName);
 	COMPARE_STRING_FIELD(name);
 	COMPARE_NODE_FIELD(def);
 	COMPARE_SCALAR_FIELD(behavior);
@@ -1520,7 +1520,7 @@ static bool
 _equalCreateDomainStmt(CreateDomainStmt *a, CreateDomainStmt *b)
 {
 	COMPARE_NODE_FIELD(domainname);
-	COMPARE_NODE_FIELD(typname);
+	COMPARE_NODE_FIELD(typeName);
 	COMPARE_NODE_FIELD(constraints);
 
 	return true;
@@ -2043,7 +2043,7 @@ _equalAConst(A_Const *a, A_Const *b)
 {
 	if (!equal(&a->val, &b->val))		/* hack for in-line Value field */
 		return false;
-	COMPARE_NODE_FIELD(typname);
+	COMPARE_NODE_FIELD(typeName);
 	/* do not compare 'location' field */;
 
 	return true;
@@ -2123,7 +2123,7 @@ static bool
 _equalTypeCast(TypeCast *a, TypeCast *b)
 {
 	COMPARE_NODE_FIELD(arg);
-	COMPARE_NODE_FIELD(typname);
+	COMPARE_NODE_FIELD(typeName);
 
 	return true;
 }
@@ -2175,7 +2175,7 @@ static bool
 _equalColumnDef(ColumnDef *a, ColumnDef *b)
 {
 	COMPARE_STRING_FIELD(colname);
-	COMPARE_NODE_FIELD(typname);
+	COMPARE_NODE_FIELD(typeName);
 	COMPARE_SCALAR_FIELD(inhcount);
 	COMPARE_SCALAR_FIELD(is_local);
 	COMPARE_SCALAR_FIELD(is_not_null);
@@ -2415,7 +2415,7 @@ _equalTableValueExpr(TableValueExpr *a, TableValueExpr *b)
 static bool
 _equalAlterTypeStmt(AlterTypeStmt *a, AlterTypeStmt *b)
 {
-	COMPARE_NODE_FIELD(typname);
+	COMPARE_NODE_FIELD(typeName);
 	COMPARE_NODE_FIELD(encoding);
 
 	return true;

--- a/src/backend/nodes/nodeFuncs.c
+++ b/src/backend/nodes/nodeFuncs.c
@@ -309,7 +309,7 @@ exprLocation(Node *expr)
 				 * so any of the components might be leftmost.
 				 */
 				loc = exprLocation(tc->arg);
-				loc = leftmostLoc(loc, tc->typname->location);
+				loc = leftmostLoc(loc, tc->typeName->location);
 				loc = leftmostLoc(loc, tc->location);
 			}
 			break;

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -806,7 +806,7 @@ _outCreateDomainStmt(StringInfo str, CreateDomainStmt *node)
 {
 	WRITE_NODE_TYPE("CREATEDOMAINSTMT");
 	WRITE_NODE_FIELD(domainname);
-	WRITE_NODE_FIELD(typname);
+	WRITE_NODE_FIELD(typeName);
 	WRITE_NODE_FIELD(constraints);
 }
 
@@ -815,7 +815,7 @@ _outAlterDomainStmt(StringInfo str, AlterDomainStmt *node)
 {
 	WRITE_NODE_TYPE("ALTERDOMAINSTMT");
 	WRITE_CHAR_FIELD(subtype);
-	WRITE_NODE_FIELD(typname);
+	WRITE_NODE_FIELD(typeName);
 	WRITE_STRING_FIELD(name);
 	WRITE_NODE_FIELD(def);
 	WRITE_ENUM_FIELD(behavior, DropBehavior);
@@ -827,7 +827,7 @@ _outColumnDef(StringInfo str, ColumnDef *node)
 	WRITE_NODE_TYPE("COLUMNDEF");
 
 	WRITE_STRING_FIELD(colname);
-	WRITE_NODE_FIELD(typname);
+	WRITE_NODE_FIELD(typeName);
 	WRITE_INT_FIELD(inhcount);
 	WRITE_BOOL_FIELD(is_local);
 	WRITE_BOOL_FIELD(is_not_null);
@@ -860,7 +860,7 @@ _outTypeCast(StringInfo str, TypeCast *node)
 	WRITE_NODE_TYPE("TYPECAST");
 
 	WRITE_NODE_FIELD(arg);
-	WRITE_NODE_FIELD(typname);
+	WRITE_NODE_FIELD(typeName);
 }
 
 static void
@@ -1056,7 +1056,7 @@ _outAConst(StringInfo str, A_Const *node)
 	WRITE_NODE_TYPE("A_CONST");
 
 	_outValue(str, &(node->val));
-	WRITE_NODE_FIELD(typname);
+	WRITE_NODE_FIELD(typeName);
 	WRITE_INT_FIELD(location);  /*CDB*/
 
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -2646,7 +2646,7 @@ _outCreateDomainStmt(StringInfo str, CreateDomainStmt *node)
 {
 	WRITE_NODE_TYPE("CREATEDOMAINSTMT");
 	WRITE_NODE_FIELD(domainname);
-	WRITE_NODE_FIELD_AS(typname, typename);
+	WRITE_NODE_FIELD_AS(typeName, typename);
 	WRITE_NODE_FIELD(constraints);
 }
 #endif /* COMPILING_BINARY_FUNCS */
@@ -2657,7 +2657,7 @@ _outAlterDomainStmt(StringInfo str, AlterDomainStmt *node)
 {
 	WRITE_NODE_TYPE("ALTERDOMAINSTMT");
 	WRITE_CHAR_FIELD(subtype);
-	WRITE_NODE_FIELD_AS(typname, typename);
+	WRITE_NODE_FIELD_AS(typeName, typename);
 	WRITE_STRING_FIELD(name);
 	WRITE_NODE_FIELD(def);
 	WRITE_ENUM_FIELD(behavior, DropBehavior);
@@ -3303,7 +3303,7 @@ _outColumnDef(StringInfo str, ColumnDef *node)
 	WRITE_NODE_TYPE("COLUMNDEF");
 
 	WRITE_STRING_FIELD(colname);
-	WRITE_NODE_FIELD_AS(typname, typename);
+	WRITE_NODE_FIELD_AS(typeName, typename);
 	WRITE_INT_FIELD(inhcount);
 	WRITE_BOOL_FIELD(is_local);
 	WRITE_BOOL_FIELD(is_not_null);
@@ -3340,7 +3340,7 @@ _outTypeCast(StringInfo str, TypeCast *node)
 	WRITE_NODE_TYPE("TYPECAST");
 
 	WRITE_NODE_FIELD(arg);
-	WRITE_NODE_FIELD_AS(typname, typename);
+	WRITE_NODE_FIELD_AS(typeName, typename);
 }
 #endif /* COMPILING_BINARY_FUNCS */
 
@@ -3844,7 +3844,7 @@ _outAConst(StringInfo str, A_Const *node)
 	appendStringInfoChar(str, ' ');
 
 	_outValue(str, &(node->val));
-	WRITE_NODE_FIELD_AS(typname, typename);
+	WRITE_NODE_FIELD_AS(typeName, typename);
     /*
      * CDB: For now we don't serialize the 'location' field, for compatibility
      * so stored constants can be read by pre-3.2 releases.  Anyway it's only
@@ -4225,7 +4225,7 @@ _outAlterTypeStmt(StringInfo str, AlterTypeStmt *node)
 {
 	WRITE_NODE_TYPE("ALTERTYPESTMT");
 
-	WRITE_NODE_FIELD(typname);
+	WRITE_NODE_FIELD(typeName);
 	WRITE_NODE_FIELD(encoding);
 }
 

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -744,8 +744,8 @@ _readAConst(void)
 	 		break;
 	}
 
-	local_node->typname = NULL;
-	READ_NODE_FIELD(typname);
+	local_node->typeName = NULL;
+	READ_NODE_FIELD(typeName);
     READ_INT_FIELD(location);   /*CDB*/
 	READ_DONE();
 }
@@ -1364,7 +1364,7 @@ _readAlterDomainStmt(void)
 	READ_LOCALS(AlterDomainStmt);
 
 	READ_CHAR_FIELD(subtype);
-	READ_NODE_FIELD(typname);
+	READ_NODE_FIELD(typeName);
 	READ_STRING_FIELD(name);
 	READ_NODE_FIELD(def);
 	READ_ENUM_FIELD(behavior, DropBehavior); Assert(local_node->behavior <= DROP_CASCADE);

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -1219,8 +1219,8 @@ _readAConst(void)
 		}
 	}
 
-	local_node->typname = NULL;
-	READ_NODE_FIELD(typname);
+	local_node->typeName = NULL;
+	READ_NODE_FIELD(typeName);
 
     /* CDB: 'location' field is not serialized */
     local_node->location = -1;
@@ -1951,7 +1951,7 @@ _readColumnDef(void)
 	READ_LOCALS(ColumnDef);
 
 	READ_STRING_FIELD(colname);
-	READ_NODE_FIELD(typname);
+	READ_NODE_FIELD(typeName);
 	READ_INT_FIELD(inhcount);
 	READ_BOOL_FIELD(is_local);
 	READ_BOOL_FIELD(is_not_null);
@@ -2013,7 +2013,7 @@ _readTypeCast(void)
 	READ_LOCALS(TypeCast);
 
 	READ_NODE_FIELD(arg);
-	READ_NODE_FIELD(typname);
+	READ_NODE_FIELD(typeName);
 
 	READ_DONE();
 }
@@ -2378,7 +2378,7 @@ _readCreateDomainStmt(void)
 	READ_LOCALS(CreateDomainStmt);
 
 	READ_NODE_FIELD(domainname);
-	READ_NODE_FIELD(typname);
+	READ_NODE_FIELD(typeName);
 	READ_NODE_FIELD(constraints);
 
 	READ_DONE();
@@ -2391,7 +2391,7 @@ _readAlterDomainStmt(void)
 	READ_LOCALS(AlterDomainStmt);
 
 	READ_CHAR_FIELD(subtype);
-	READ_NODE_FIELD(typname);
+	READ_NODE_FIELD(typeName);
 	READ_STRING_FIELD(name);
 	READ_NODE_FIELD(def);
 	READ_ENUM_FIELD(behavior, DropBehavior);
@@ -2854,7 +2854,7 @@ _readAlterTypeStmt(void)
 {
 	READ_LOCALS(AlterTypeStmt);
 
-	READ_NODE_FIELD(typname);
+	READ_NODE_FIELD(typeName);
 	READ_NODE_FIELD(encoding);
 
 	READ_DONE();

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -1975,7 +1975,7 @@ zone_value:
 									(errcode(ERRCODE_SYNTAX_ERROR),
 									 errmsg("time zone interval must be HOUR or HOUR TO MINUTE"),
 									 scanner_errposition(@3)));
-						n->typname->typmods = list_make1(makeIntConst($3, @3));
+						n->typeName->typmods = list_make1(makeIntConst($3, @3));
 					}
 					$$ = (Node *)n;
 				}
@@ -1988,7 +1988,7 @@ zone_value:
 								(errcode(ERRCODE_SYNTAX_ERROR),
 								 errmsg("time zone interval must be HOUR or HOUR TO MINUTE"),
 									 scanner_errposition(@6)));
-					n->typname->typmods = list_make2(makeIntConst($6, @6),
+					n->typeName->typmods = list_make2(makeIntConst($6, @6),
 													 makeIntConst($3, @3));
 					$$ = (Node *)n;
 				}
@@ -3547,7 +3547,7 @@ columnDef:	ColId Typename ColQualList opt_storage_encoding
 				{
 					ColumnDef *n = makeNode(ColumnDef);
 					n->colname = $1;
-					n->typname = $2;
+					n->typeName = $2;
 					n->constraints = $3;
 					n->is_local = true;
 					n->encoding = $4;
@@ -4637,7 +4637,7 @@ CreateAsElement:
 				{
 					ColumnDef *n = makeNode(ColumnDef);
 					n->colname = $1;
-					n->typname = NULL;
+					n->typeName = NULL;
 					n->inhcount = 0;
 					n->is_local = true;
 					n->is_not_null = false;
@@ -4913,7 +4913,7 @@ ExtcolumnDef:	ColId Typename
 		{
 			ColumnDef *n = makeNode(ColumnDef);
 			n->colname = $1;
-			n->typname = $2;
+			n->typeName = $2;
 			n->is_local = true;
 			n->is_not_null = false;
 			n->constraints = NIL;
@@ -7581,7 +7581,7 @@ AlterTypeStmt: ALTER TYPE_P SimpleTypename SET DEFAULT ENCODING definition
 				{
 					AlterTypeStmt *n = makeNode(AlterTypeStmt);
 
-					n->typname = $3;
+					n->typeName = $3;
 					n->encoding = $7;
 					$$ = (Node *)n;
 				}
@@ -8533,7 +8533,7 @@ CreateDomainStmt:
 				{
 					CreateDomainStmt *n = makeNode(CreateDomainStmt);
 					n->domainname = $3;
-					n->typname = $5;
+					n->typeName = $5;
 					n->constraints = $6;
 					$$ = (Node *)n;
 				}
@@ -8545,7 +8545,7 @@ AlterDomainStmt:
 				{
 					AlterDomainStmt *n = makeNode(AlterDomainStmt);
 					n->subtype = 'T';
-					n->typname = $3;
+					n->typeName = $3;
 					n->def = $4;
 					$$ = (Node *)n;
 				}
@@ -8554,7 +8554,7 @@ AlterDomainStmt:
 				{
 					AlterDomainStmt *n = makeNode(AlterDomainStmt);
 					n->subtype = 'N';
-					n->typname = $3;
+					n->typeName = $3;
 					$$ = (Node *)n;
 				}
 			/* ALTER DOMAIN <domain> SET NOT NULL */
@@ -8562,7 +8562,7 @@ AlterDomainStmt:
 				{
 					AlterDomainStmt *n = makeNode(AlterDomainStmt);
 					n->subtype = 'O';
-					n->typname = $3;
+					n->typeName = $3;
 					$$ = (Node *)n;
 				}
 			/* ALTER DOMAIN <domain> ADD CONSTRAINT ... */
@@ -8570,7 +8570,7 @@ AlterDomainStmt:
 				{
 					AlterDomainStmt *n = makeNode(AlterDomainStmt);
 					n->subtype = 'C';
-					n->typname = $3;
+					n->typeName = $3;
 					n->def = $5;
 					$$ = (Node *)n;
 				}
@@ -8579,7 +8579,7 @@ AlterDomainStmt:
 				{
 					AlterDomainStmt *n = makeNode(AlterDomainStmt);
 					n->subtype = 'X';
-					n->typname = $3;
+					n->typeName = $3;
 					n->name = $6;
 					n->behavior = $7;
 					$$ = (Node *)n;
@@ -10298,7 +10298,7 @@ TableFuncElement:	ColId Typename
 				{
 					ColumnDef *n = makeNode(ColumnDef);
 					n->colname = $1;
-					n->typname = $2;
+					n->typeName = $2;
 					n->constraints = NIL;
 					n->is_local = true;
 					$$ = (Node *)n;
@@ -11574,7 +11574,7 @@ func_expr:	simple_func FILTER '(' WHERE a_expr ')'
 
 					s->val.type = T_String;
 					s->val.val.str = "now";
-					s->typname = SystemTypeName("text");
+					s->typeName = SystemTypeName("text");
 
 					d = SystemTypeName("date");
 
@@ -11591,7 +11591,7 @@ func_expr:	simple_func FILTER '(' WHERE a_expr ')'
 
 					s->val.type = T_String;
 					s->val.val.str = "now";
-					s->typname = SystemTypeName("text");
+					s->typeName = SystemTypeName("text");
 
 					d = SystemTypeName("timetz");
 
@@ -11608,7 +11608,7 @@ func_expr:	simple_func FILTER '(' WHERE a_expr ')'
 
 					s->val.type = T_String;
 					s->val.val.str = "now";
-					s->typname = SystemTypeName("text");
+					s->typeName = SystemTypeName("text");
 					d = SystemTypeName("timetz");
 					d->typmods = list_make1(makeIntConst($3, @3));
 
@@ -11642,7 +11642,7 @@ func_expr:	simple_func FILTER '(' WHERE a_expr ')'
 
 					s->val.type = T_String;
 					s->val.val.str = "now";
-					s->typname = SystemTypeName("text");
+					s->typeName = SystemTypeName("text");
 
 					d = SystemTypeName("timestamptz");
 					d->typmods = list_make1(makeIntConst($3, @3));
@@ -11660,7 +11660,7 @@ func_expr:	simple_func FILTER '(' WHERE a_expr ')'
 
 					s->val.type = T_String;
 					s->val.val.str = "now";
-					s->typname = SystemTypeName("text");
+					s->typeName = SystemTypeName("text");
 
 					d = SystemTypeName("time");
 
@@ -11677,7 +11677,7 @@ func_expr:	simple_func FILTER '(' WHERE a_expr ')'
 
 					s->val.type = T_String;
 					s->val.val.str = "now";
-					s->typname = SystemTypeName("text");
+					s->typeName = SystemTypeName("text");
 					d = SystemTypeName("time");
 					d->typmods = list_make1(makeIntConst($3, @3));
 
@@ -11694,7 +11694,7 @@ func_expr:	simple_func FILTER '(' WHERE a_expr ')'
 
 					s->val.type = T_String;
 					s->val.val.str = "now";
-					s->typname = SystemTypeName("text");
+					s->typeName = SystemTypeName("text");
 
 					d = SystemTypeName("timestamp");
 
@@ -11711,7 +11711,7 @@ func_expr:	simple_func FILTER '(' WHERE a_expr ')'
 
 					s->val.type = T_String;
 					s->val.val.str = "now";
-					s->typname = SystemTypeName("text");
+					s->typeName = SystemTypeName("text");
 
 					d = SystemTypeName("timestamp");
 					d->typmods = list_make1(makeIntConst($3, @3));
@@ -12827,8 +12827,8 @@ AexprConst: Iconst
 				{
 					/* generic type 'literal' syntax */
 					A_Const *n = makeNode(A_Const);
-					n->typname = makeTypeNameFromNameList($1);
-					n->typname->location = @1;
+					n->typeName = makeTypeNameFromNameList($1);
+					n->typeName->location = @1;
 					n->val.type = T_String;
 					n->val.val.str = $2;
 					n->location = @1;                   /*CDB*/
@@ -12838,9 +12838,9 @@ AexprConst: Iconst
 				{
 					/* generic syntax with a type modifier */
 					A_Const *n = makeNode(A_Const);
-					n->typname = makeTypeNameFromNameList($1);
-					n->typname->typmods = $3;
-					n->typname->location = @1;
+					n->typeName = makeTypeNameFromNameList($1);
+					n->typeName->typmods = $3;
+					n->typeName->location = @1;
 					n->val.type = T_String;
 					n->val.val.str = $5;
 					n->location = @1;                   /*CDB*/
@@ -12849,7 +12849,7 @@ AexprConst: Iconst
 			| ConstTypename Sconst
 				{
 					A_Const *n = makeNode(A_Const);
-					n->typname = $1;
+					n->typeName = $1;
 					n->val.type = T_String;
 					n->val.val.str = $2;
 					n->location = @2;                   /*CDB*/
@@ -12858,23 +12858,23 @@ AexprConst: Iconst
 			| ConstInterval Sconst opt_interval
 				{
 					A_Const *n = makeNode(A_Const);
-					n->typname = $1;
+					n->typeName = $1;
 					n->val.type = T_String;
 					n->val.val.str = $2;
 					n->location = @2;                   /*CDB*/
 					/* precision is not specified, but fields may be... */
 					if ($3 != INTERVAL_FULL_RANGE)
-						n->typname->typmods = list_make1(makeIntConst($3, @3));
+						n->typeName->typmods = list_make1(makeIntConst($3, @3));
 					$$ = (Node *)n;
 				}
 			| ConstInterval '(' Iconst ')' Sconst opt_interval
 				{
 					A_Const *n = makeNode(A_Const);
-					n->typname = $1;
+					n->typeName = $1;
 					n->val.type = T_String;
 					n->val.val.str = $5;
 					n->location = @1;                   /*CDB*/
-					n->typname->typmods = list_make2(makeIntConst($6, @6),
+					n->typeName->typmods = list_make2(makeIntConst($6, @6),
 													 makeIntConst($3, @3));
 					$$ = (Node *)n;
 				}
@@ -13832,7 +13832,7 @@ makeTypeCast(Node *arg, TypeName *typename, int location)
 {
 	TypeCast *n = makeNode(TypeCast);
 	n->arg = arg;
-	n->typname = typename;
+	n->typeName = typename;
 	n->location = location;
 	return (Node *) n;
 }
@@ -13844,7 +13844,7 @@ makeStringConst(char *str, TypeName *typname, int location)
 
 	n->val.type = T_String;
 	n->val.val.str = str;
-	n->typname = typname;
+	n->typeName = typname;
 	n->location = location;
 
 	return (Node *)n;
@@ -13857,7 +13857,7 @@ makeIntConst(int val, int location)
 	n->val.type = T_Integer;
 	n->val.val.ival = val;
 	n->location = location;
-	n->typname = SystemTypeName("int4");
+	n->typeName = SystemTypeName("int4");
 
 	return (Node *)n;
 }
@@ -13870,7 +13870,7 @@ makeFloatConst(char *str, int location)
 	n->val.type = T_Float;
 	n->val.val.str = str;
 	n->location = location;
-	n->typname = SystemTypeName("float8");
+	n->typeName = SystemTypeName("float8");
 
 	return (Node *)n;
 }
@@ -13919,7 +13919,7 @@ makeBoolAConst(bool state, int location)
 	A_Const *n = makeNode(A_Const);
 	n->val.type = T_String;
 	n->val.val.str = (state ? "t" : "f");
-	n->typname = SystemTypeName("bool");
+	n->typeName = SystemTypeName("bool");
 	n->location = location;
 	return n;
 }

--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -141,10 +141,10 @@ transformExpr(ParseState *pstate, Node *expr)
 				Value	   *val = &con->val;
 
 				result = (Node *) make_const(pstate, val, con->location);
-				if (con->typname != NULL) {
-					con->typname->location = con->location;
+				if (con->typeName != NULL) {
+					con->typeName->location = con->location;
 					result = typecast_expression(pstate, result,
-												 con->typname);
+												 con->typeName);
 				}
 				break;
 			}
@@ -182,7 +182,7 @@ transformExpr(ParseState *pstate, Node *expr)
 					Oid			elementType;
 					int32		targetTypmod;
 
-					targetType = typenameTypeId(pstate, tc->typname,
+					targetType = typenameTypeId(pstate, tc->typeName,
 												&targetTypmod);
 
 					elementType = get_element_type(targetType);
@@ -207,7 +207,7 @@ transformExpr(ParseState *pstate, Node *expr)
 				}
 
 				arg = transformExpr(pstate, tc->arg);
-				result = typecast_expression(pstate, arg, tc->typname);
+				result = typecast_expression(pstate, arg, tc->typeName);
 				break;
 			}
 
@@ -476,7 +476,7 @@ parse_expr_location(Expr *expr)
 
             loc = parse_expr_location((Expr *)typecast->arg);
             if (loc < 0)
-                loc = parse_expr_location((Expr *)typecast->typname);
+                loc = parse_expr_location((Expr *)typecast->typeName);
             break;
         }
 
@@ -931,7 +931,7 @@ exprIsNullConstant(Node *arg)
 		A_Const    *con = (A_Const *) arg;
 
 		if (con->val.type == T_Null &&
-			con->typname == NULL)
+			con->typeName == NULL)
 			return true;
 	}
 	return false;

--- a/src/backend/parser/parse_partition.c
+++ b/src/backend/parser/parse_partition.c
@@ -326,16 +326,16 @@ transformPartitionBy(ParseState *pstate, CreateStmtContext *cxt,
 
 				if (lookup_opclass)
 				{
-					typeid = column->typname->typid;
+					typeid = column->typeName->typid;
 
 					if (!OidIsValid(typeid))
 					{
 						int32		typmod;
 
-						typeid = typenameTypeId(pstate, column->typname, &typmod);
+						typeid = typenameTypeId(pstate, column->typeName, &typmod);
 
-						column->typname->typid = typeid;
-						column->typname->typemod = typmod;
+						column->typeName->typid = typeid;
+						column->typeName->typemod = typmod;
 					}
 				}
 				break;
@@ -1977,7 +1977,7 @@ deparse_partition_rule(Node *pNode, char *outbuf, size_t outsize)
 
 				if (acs->val.type == T_String)
 				{
-					if (acs->typname)	/* deal with explicit types */
+					if (acs->typeName)	/* deal with explicit types */
 					{
 						/*
 						 * XXX XXX: simple types only -- need to handle
@@ -1986,7 +1986,7 @@ deparse_partition_rule(Node *pNode, char *outbuf, size_t outsize)
 
 						snprintf(outbuf, outsize, "\'%s\'::%s",
 								 acs->val.val.str,
-								 TypeNameToString(acs->typname));
+								 TypeNameToString(acs->typeName));
 					}
 					else
 					{
@@ -2136,7 +2136,7 @@ make_prule_catalog(ParseState *pstate,
 
 		acs->val.type = T_String;
 		acs->val.val.str = pstrdup(parent_tab_name->relname);
-		acs->typname = SystemTypeName("text");
+		acs->typeName = SystemTypeName("text");
 		acs->location = -1;
 
 		vl1 = list_make1(acs);
@@ -2144,7 +2144,7 @@ make_prule_catalog(ParseState *pstate,
 		acs = makeNode(A_Const);
 		acs->val.type = T_String;
 		acs->val.val.str = pstrdup(child_name_str);
-		acs->typname = SystemTypeName("text");
+		acs->typeName = SystemTypeName("text");
 		acs->location = -1;
 
 		vl1 = lappend(vl1, acs);
@@ -2152,7 +2152,7 @@ make_prule_catalog(ParseState *pstate,
 		acs = makeNode(A_Const);
 		acs->val.type = T_String;
 		acs->val.val.str = pstrdup(exprBuf);
-		acs->typname = SystemTypeName("text");
+		acs->typeName = SystemTypeName("text");
 		acs->location = -1;
 
 		vl1 = lappend(vl1, acs);
@@ -2160,7 +2160,7 @@ make_prule_catalog(ParseState *pstate,
 		acs = makeNode(A_Const);
 		acs->val.type = T_String;
 		acs->val.val.str = pstrdup(ruleBuf);
-		acs->typname = SystemTypeName("text");
+		acs->typeName = SystemTypeName("text");
 		acs->location = -1;
 
 		vl1 = lappend(vl1, acs);
@@ -2952,13 +2952,13 @@ preprocess_range_spec(partValidationState *vstate)
 			if (strcmp(column->colname, colname) == 0)
 			{
 				found = true;
-				if (!OidIsValid(column->typname->typid))
+				if (!OidIsValid(column->typeName->typid))
 				{
-					column->typname->typid =
-						typenameTypeId(vstate->pstate, column->typname,
-									   &column->typname->typemod);
+					column->typeName->typid =
+						typenameTypeId(vstate->pstate, column->typeName,
+									   &column->typeName->typemod);
 				}
-				typname = column->typname;
+				typname = column->typeName;
 				break;
 			}
 		}
@@ -4619,13 +4619,13 @@ validate_list_partition(partValidationState *vstate)
 			if (strcmp(column->colname, colname) == 0)
 			{
 				found = true;
-				if (!OidIsValid(column->typname->typid))
+				if (!OidIsValid(column->typeName->typid))
 				{
-					column->typname->typid
-						= typenameTypeId(vstate->pstate, column->typname,
-										 &column->typname->typemod);
+					column->typeName->typid
+						= typenameTypeId(vstate->pstate, column->typeName,
+										 &column->typeName->typemod);
 				}
-				typname = column->typname;
+				typname = column->typeName;
 				break;
 			}
 		}

--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -1163,13 +1163,13 @@ addRangeTableEntryForFunction(ParseState *pstate,
 			int32		attrtypmod;
 
 			attrname = pstrdup(n->colname);
-			if (n->typname->setof)
+			if (n->typeName->setof)
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
 						 errmsg("column \"%s\" cannot be declared SETOF",
 								attrname),
-						 parser_errposition(pstate, n->typname->location)));
-			attrtype = typenameTypeId(pstate, n->typname, &attrtypmod);
+						 parser_errposition(pstate, n->typeName->location)));
+			attrtype = typenameTypeId(pstate, n->typeName, &attrtypmod);
 			eref->colnames = lappend(eref->colnames, makeString(attrname));
 			rte->funccoltypes = lappend_oid(rte->funccoltypes, attrtype);
 			rte->funccoltypmods = lappend_int(rte->funccoltypmods, attrtypmod);

--- a/src/backend/parser/parse_target.c
+++ b/src/backend/parser/parse_target.c
@@ -1341,9 +1341,9 @@ FigureColnameInternal(Node *node, char **name)
 			}
 			break;
 		case T_A_Const:
-			if (((A_Const *) node)->typname != NULL)
+			if (((A_Const *) node)->typeName != NULL)
 			{
-				*name = strVal(llast(((A_Const *) node)->typname->names));
+				*name = strVal(llast(((A_Const *) node)->typeName->names));
 				return 1;
 			}
 			break;
@@ -1352,9 +1352,9 @@ FigureColnameInternal(Node *node, char **name)
 											 name);
 			if (strength <= 1)
 			{
-				if (((TypeCast *) node)->typname != NULL)
+				if (((TypeCast *) node)->typeName != NULL)
 				{
-					*name = strVal(llast(((TypeCast *) node)->typname->names));
+					*name = strVal(llast(((TypeCast *) node)->typeName->names));
 					return 1;
 				}
 			}

--- a/src/backend/parser/parse_type.c
+++ b/src/backend/parser/parse_type.c
@@ -300,7 +300,7 @@ typenameTypeMod(ParseState *pstate, const TypeName *typename, Type typ)
 				cstr = (char *) palloc(32);
 				snprintf(cstr, 32, "%ld", (long) ac->val.val.ival);
 			}
-			else if (ac->typname == NULL)		/* no casts allowed */
+			else if (ac->typeName == NULL)		/* no casts allowed */
 			{
 				/* otherwise we can just use the str field directly. */
 				cstr = ac->val.val.str;
@@ -611,7 +611,7 @@ parseTypeString(const char *str, Oid *type_id, int32 *typmod_p)
 		typecast->arg == NULL ||
 		!IsA(typecast->arg, A_Const))
 		goto fail;
-	typename = typecast->typname;
+	typename = typecast->typeName;
 	if (typename == NULL ||
 		!IsA(typename, TypeName))
 		goto fail;

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -394,23 +394,23 @@ transformColumnDefinition(ParseState *pstate, CreateStmtContext *cxt,
 
 	/* Check for SERIAL pseudo-types */
 	is_serial = false;
-	if (list_length(column->typname->names) == 1)
+	if (list_length(column->typeName->names) == 1)
 	{
-		char	   *typname = strVal(linitial(column->typname->names));
+		char	   *typname = strVal(linitial(column->typeName->names));
 
 		if (strcmp(typname, "serial") == 0 ||
 			strcmp(typname, "serial4") == 0)
 		{
 			is_serial = true;
-			column->typname->names = NIL;
-			column->typname->typid = INT4OID;
+			column->typeName->names = NIL;
+			column->typeName->typid = INT4OID;
 		}
 		else if (strcmp(typname, "bigserial") == 0 ||
 				 strcmp(typname, "serial8") == 0)
 		{
 			is_serial = true;
-			column->typname->names = NIL;
-			column->typname->typid = INT8OID;
+			column->typeName->names = NIL;
+			column->typeName->typid = INT8OID;
 		}
 	}
 
@@ -497,7 +497,7 @@ transformColumnDefinition(ParseState *pstate, CreateStmtContext *cxt,
 		snamenode = makeNode(A_Const);
 		snamenode->val.type = T_String;
 		snamenode->val.val.str = qstring;
-		snamenode->typname = SystemTypeName("regclass");
+		snamenode->typeName = SystemTypeName("regclass");
 		snamenode->location = -1;					/* CDB */
 		funccallnode = makeNode(FuncCall);
 		funccallnode->funcname = SystemFuncName("nextval");
@@ -751,7 +751,7 @@ transformInhRelation(ParseState *pstate, CreateStmtContext *cxt,
 		 */
 		def = makeNode(ColumnDef);
 		def->colname = pstrdup(attributeName);
-		def->typname = makeTypeNameFromOid(attribute->atttypid,
+		def->typeName = makeTypeNameFromOid(attribute->atttypid,
 											attribute->atttypmod);
 		def->inhcount = 0;
 		def->is_local = true;
@@ -1618,7 +1618,7 @@ transformDistributedBy(ParseState *pstate, CreateStmtContext *cxt,
 				column = (ColumnDef *) lfirst(columns);
 				colindex++;
 
-				typeOid = typenameTypeId(NULL, column->typname, &typmod);
+				typeOid = typenameTypeId(NULL, column->typeName, &typmod);
 
 				/*
 				 * if we can hash on this type, or if it's an array type (which
@@ -1728,7 +1728,7 @@ transformDistributedBy(ParseState *pstate, CreateStmtContext *cxt,
 							Oid			typeOid;
 							int32		typmod;
 
-							typeOid = typenameTypeId(NULL, column->typname, &typmod);
+							typeOid = typenameTypeId(NULL, column->typeName, &typmod);
 							
 							/*
 							 * To be a part of a distribution key, this type must
@@ -3383,7 +3383,7 @@ transformColumnType(ParseState *pstate, ColumnDef *column)
 	/*
 	 * All we really need to do here is verify that the type is valid.
 	 */
-	Type		ctype = typenameType(pstate, column->typname, NULL);
+	Type		ctype = typenameType(pstate, column->typeName, NULL);
 
 	ReleaseSysCache(ctype);
 }
@@ -3944,7 +3944,7 @@ transformAttributeEncoding(List *stenc, CreateStmt *stmt, CreateStmtContext *cxt
 					c->encoding = copyObject(deflt->encoding);
 				else
 				{
-					List *te = TypeNameGetStorageDirective(d->typname);
+					List *te = TypeNameGetStorageDirective(d->typeName);
 
 					if (te)
 						c->encoding = copyObject(te);

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -1226,23 +1226,23 @@ ProcessUtility(Node *parsetree,
 						 * Recursively alter column default for table and, if
 						 * requested, for descendants
 						 */
-						AlterDomainDefault(stmt->typname,
+						AlterDomainDefault(stmt->typeName,
 										   stmt->def);
 						break;
 					case 'N':	/* ALTER DOMAIN DROP NOT NULL */
-						AlterDomainNotNull(stmt->typname,
+						AlterDomainNotNull(stmt->typeName,
 										   false);
 						break;
 					case 'O':	/* ALTER DOMAIN SET NOT NULL */
-						AlterDomainNotNull(stmt->typname,
+						AlterDomainNotNull(stmt->typeName,
 										   true);
 						break;
 					case 'C':	/* ADD CONSTRAINT */
-						AlterDomainAddConstraint(stmt->typname,
+						AlterDomainAddConstraint(stmt->typeName,
 												 stmt->def);
 						break;
 					case 'X':	/* DROP CONSTRAINT */
-						AlterDomainDropConstraint(stmt->typname,
+						AlterDomainDropConstraint(stmt->typeName,
 												  stmt->name,
 												  stmt->behavior);
 						break;

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -5337,7 +5337,7 @@ flatten_set_variable_args(const char *name, List *args)
 				break;
 			case T_String:
 				val = strVal(&arg->val);
-				if (arg->typname != NULL)
+				if (arg->typeName != NULL)
 				{
 					/*
 					 * Must be a ConstInterval argument for TIME ZONE. Coerce
@@ -5349,7 +5349,7 @@ flatten_set_variable_args(const char *name, List *args)
 					Datum		interval;
 					char	   *intervalout;
 
-					typoid = typenameTypeId(NULL, arg->typname, &typmod);
+					typoid = typenameTypeId(NULL, arg->typeName, &typmod);
 					Assert(typoid == INTERVALOID);
 
 					interval =

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -280,7 +280,7 @@ typedef struct A_Const
 {
 	NodeTag		type;
 	Value		val;			/* value (includes type info, see value.h) */
-	TypeName   *typname;		/* typecast, or NULL if none */
+	TypeName   *typeName;		/* typecast, or NULL if none */
 	int			location;		/* token location, or -1 if unknown */
 } A_Const;
 
@@ -297,7 +297,7 @@ typedef struct TypeCast
 {
 	NodeTag		type;
 	Node	   *arg;			/* the expression being casted */
-	TypeName   *typname;		/* the target type */
+	TypeName   *typeName;		/* the target type */
 	int			location;		/* token location, or -1 if unknown */
 } TypeCast;
 
@@ -447,7 +447,7 @@ typedef struct ColumnDef
 {
 	NodeTag		type;
 	char	   *colname;		/* name of column */
-	TypeName   *typname;		/* type of column */
+	TypeName   *typeName;		/* type of column */
 	int			inhcount;		/* number of times column is inherited */
 	bool		is_local;		/* column has local (non-inherited) def'n */
 	bool		is_not_null;	/* NOT NULL constraint specified? */
@@ -1314,7 +1314,7 @@ typedef struct AlterDomainStmt
 								 *	X = drop constraint
 								 *------------
 								 */
-	List	   *typname;		/* domain to work on */
+	List	   *typeName;		/* domain to work on */
 	char	   *name;			/* column or constraint name to act on */
 	Node	   *def;			/* definition of default or constraint */
 	DropBehavior behavior;		/* RESTRICT or CASCADE for DROP cases */
@@ -2001,7 +2001,7 @@ typedef struct CreateDomainStmt
 {
 	NodeTag		type;
 	List	   *domainname;		/* qualified name (list of Value strings) */
-	TypeName   *typname;		/* the base type */
+	TypeName   *typeName;		/* the base type */
 	List	   *constraints;	/* constraints (list of Constraint nodes) */
 } CreateDomainStmt;
 
@@ -2361,7 +2361,7 @@ typedef struct AlterOwnerStmt
 typedef struct AlterTypeStmt
 {
 	NodeTag		type;
-	TypeName   *typname;
+	TypeName   *typeName;
 	List	   *encoding;
 } AlterTypeStmt;
 


### PR DESCRIPTION
This way we are consistent now with the upstream Postgres.