### PR TITLE
Fix MU_check concourse task to print failing unit test on error.

### DIFF
--- a/concourse/scripts/gpMgmt_check_gpdb.bash
+++ b/concourse/scripts/gpMgmt_check_gpdb.bash
@@ -7,27 +7,20 @@ source "${CWDIR}/common.bash"
 
 function gen_env(){
   cat > /opt/run_test.sh <<-EOF
+
+		RESULT_FILE="\${1}/gpdb_src/gpMgmt/gpMgmt_testunit_results.log"
 		trap look4results ERR
 
 		function look4results() {
 
-		    results_files="../gpMgmt/gpMgmt_testunit_results.log"
+		echo "======================================================================"
+		echo "RESULT FILE: \${RESULT_FILE}"
+		echo "======================================================================"
 
-		    for results_file in \${results_files}; do
-			if [ -f "\${results_file}" ]; then
-			    cat <<-FEOF
-
-						======================================================================
-						RESULTS FILE: \${results_file}
-						----------------------------------------------------------------------
-
-						\$(cat "\${results_file}")
-
-					FEOF
-			fi
-		    done
-		    exit 1
+		cat "\${RESULT_FILE}"
+		exit 1
 		}
+
 		base_path=\${1}
 		source /usr/local/greenplum-db-devel/greenplum_path.sh
 		source /opt/gcc_env.sh

--- a/concourse/scripts/gpMgmt_check_gpdb.bash
+++ b/concourse/scripts/gpMgmt_check_gpdb.bash
@@ -8,27 +8,23 @@ source "${CWDIR}/common.bash"
 function gen_env(){
   cat > /opt/run_test.sh <<-EOF
 
-		RESULT_FILE="\${1}/gpdb_src/gpMgmt/gpMgmt_testunit_results.log"
+		base_path=\${1}
+		RESULT_FILE="\${base_path}/gpdb_src/gpMgmt/gpMgmt_testunit_results.log"
 		trap look4results ERR
 
 		function look4results() {
-
-		echo "======================================================================"
-		echo "RESULT FILE: \${RESULT_FILE}"
-		echo "======================================================================"
 
 		cat "\${RESULT_FILE}"
 		exit 1
 		}
 
-		base_path=\${1}
 		source /usr/local/greenplum-db-devel/greenplum_path.sh
 		source /opt/gcc_env.sh
 		source \${base_path}/gpdb_src/gpAux/gpdemo/gpdemo-env.sh
 		cd \${base_path}/gpdb_src/gpMgmt/bin
 		make check
 		# show results into concourse
-		cat \${base_path}/gpdb_src/gpMgmt/gpMgmt_testunit_results.log
+		cat \${RESULT_FILE}
 	EOF
 
 	chmod a+x /opt/run_test.sh


### PR DESCRIPTION
The concourse task was printing the results on success, but not when the unit test failed.