### PR TITLE
Fix defects in cgroup ops.

### DIFF
--- a/src/backend/utils/resgroup/resgroup-ops-cgroup.c
+++ b/src/backend/utils/resgroup/resgroup-ops-cgroup.c
@@ -266,12 +266,8 @@ createDir(Oid group, const char *comp)
 
 	buildPath(group, comp, "", path, pathsize);
 
-	if (access(path, F_OK))
-	{
-		/* the dir is not created yet, create it */
-		if (mkdir(path, 0755) && errno != EEXIST)
-			return false;
-	}
+	if (mkdir(path, 0755) && errno != EEXIST)
+		return false;
 
 	return true;
 }
@@ -376,7 +372,7 @@ readData(Oid group, const char *comp, const char *prop, char *data, size_t datas
 	if (fd < 0)
 		CGROUP_ERROR("can't open file '%s': %s", path, strerror(errno));
 
-	size_t ret = read(fd, data, datasize);
+	ssize_t ret = read(fd, data, datasize);
 
 	/* save errno before close() */
 	int err = errno;
@@ -403,7 +399,7 @@ writeData(Oid group, const char *comp, const char *prop, char *data, size_t data
 	if (fd < 0)
 		CGROUP_ERROR("can't open file '%s': %s", path, strerror(errno));
 
-	size_t ret = write(fd, data, datasize);
+	ssize_t ret = write(fd, data, datasize);
 
 	/* save errno before close */
 	int err = errno;


### PR DESCRIPTION
This patch is to fix below defects reported by Coverity Scan.

```
New defect(s) Reported-by: Coverity Scan
Showing 3 of 3 defect(s)

** CID 169611:  Security best practices violations  (TOCTOU)
/tmp/build/0e1b53a0/gpdb_src/src/backend/utils/resgroup/resgroup-ops-cgroup.c:
272 in createDir()

________________________________________________________________________________________________________
*** CID 169611:  Security best practices violations  (TOCTOU)
/tmp/build/0e1b53a0/gpdb_src/src/backend/utils/resgroup/resgroup-ops-cgroup.c:
272 in createDir()
266
267             buildPath(group, comp, "", path, pathsize);
268
269             if (access(path, F_OK))
270             {
271                     /* the dir is not created yet, create it */
>>>     CID 169611:  Security best practices violations  (TOCTOU)
>>>     Calling function "mkdir" that uses "path" after a check
>>>     function. This can cause a time-of-check, time-of-use race
>>>     condition.
272                     if (mkdir(path, 0755) && errno != EEXIST)
273                             return false;
274             }
275
276             return true;
277     }

** CID 169610:  Control flow issues  (NO_EFFECT)
/tmp/build/0e1b53a0/gpdb_src/src/backend/utils/resgroup/resgroup-ops-cgroup.c:
412 in writeData()

________________________________________________________________________________________________________
*** CID 169610:  Control flow issues  (NO_EFFECT)
/tmp/build/0e1b53a0/gpdb_src/src/backend/utils/resgroup/resgroup-ops-cgroup.c:
412 in writeData()
406             size_t ret = write(fd, data, datasize);
407
408             /* save errno before close */
409             int err = errno;
410             close(fd);
411
>>>     CID 169610:  Control flow issues  (NO_EFFECT)
>>>     This less-than-zero comparison of an unsigned value is never
>>>     true. "ret < 0UL".
412             if (ret < 0)
413                     CGROUP_ERROR("can't write data to file '%s':
%s", path, strerror(err));
414             if (ret != datasize)
415                     CGROUP_ERROR("can't write all data to file
'%s'", path);
416     }
417

** CID 169609:  Control flow issues  (NO_EFFECT)
/tmp/build/0e1b53a0/gpdb_src/src/backend/utils/resgroup/resgroup-ops-cgroup.c:
385 in readData()

________________________________________________________________________________________________________
*** CID 169609:  Control flow issues  (NO_EFFECT)
/tmp/build/0e1b53a0/gpdb_src/src/backend/utils/resgroup/resgroup-ops-cgroup.c:
385 in readData()
379             size_t ret = read(fd, data, datasize);
380
381             /* save errno before close() */
382             int err = errno;
383             close(fd);
384
>>>     CID 169609:  Control flow issues  (NO_EFFECT)
>>>     This less-than-zero comparison of an unsigned value is never
>>>     true. "ret < 0UL".
385             if (ret < 0)
386                     CGROUP_ERROR("can't read data from file '%s':
%s", path, strerror(err));
387
388             return ret;
389     }
390
```