### PR TITLE
Reduce dependency on pl/perl in ICW

### DIFF
--- a/src/pl/plperl/expected/plperl_gp.out
+++ b/src/pl/plperl/expected/plperl_gp.out
@@ -45,3 +45,5 @@ CONTEXT:  PL/Perl function "plperlerrorhandling1_0"
  124
 (1 row)
 
+CREATE FUNCTION tf_perl(anytable) returns int AS $$ return 1 $$ language plperl NO SQL;
+ERROR:  PL/Perl functions cannot accept type anytable

--- a/src/pl/plperl/sql/plperl_gp.sql
+++ b/src/pl/plperl/sql/plperl_gp.sql
@@ -32,3 +32,5 @@ $$ language PLPERL;
 
 select PLPERLerrorhandling1_0();
 select * from PLPERLerrorhandling1_0();
+
+CREATE FUNCTION tf_perl(anytable) returns int AS $$ return 1 $$ language plperl NO SQL;

--- a/src/test/regress/expected/metadata_track.out
+++ b/src/test/regress/expected/metadata_track.out
@@ -1084,18 +1084,10 @@ drop group mdt_group1;
 --
 create user mdt_user1 with superuser;
 create group mdt_group1 with superuser;
--- start_ignore
-drop language if exists plperl cascade;
-NOTICE:  language "plperl" does not exist, skipping
--- end_ignore
-create language plperl;
-grant usage on language plperl to mdt_user1 with grant option;
-revoke grant option for usage on language plperl from mdt_user1;
 grant usage on language plpgsql to group mdt_group1 with grant option;
 REVOKE  usage on language plpgsql from group mdt_group1 cascade;
 grant all privileges on language sql to public;
 revoke all privileges on language sql from public restrict; 
-drop language plperl;
 drop user mdt_user1;
 drop group mdt_group1;
 --

--- a/src/test/regress/input/table_functions.source
+++ b/src/test/regress/input/table_functions.source
@@ -578,7 +578,6 @@ SELECT * FROM multiset_5( TABLE( SELECT 1::integer, 'hello'::text) ) as tf;
 -- ============================================
 -- start_ignore
 -- These may have been created by previous test
-create language plperl;
 create language plpythonu;
 -- end_ignore
 
@@ -589,8 +588,6 @@ BEGIN
   RETURN 1;
 END; 
 $$ language plpgsql NO SQL;
-
-CREATE FUNCTION tf_perl(anytable) returns int AS $$ return 1 $$ language plperl NO SQL;
 
 -- python functions have no validator, error at call time.
 CREATE FUNCTION tf_python(anytable) returns int AS $$ return 1 $$ language plpythonu NO SQL;

--- a/src/test/regress/output/table_functions.source
+++ b/src/test/regress/output/table_functions.source
@@ -2302,7 +2302,6 @@ SELECT * FROM multiset_5( TABLE( SELECT 1::integer, 'hello'::text) ) as tf;
 -- ============================================
 -- start_ignore
 -- These may have been created by previous test
-create language plperl;
 create language plpythonu;
 -- end_ignore
 CREATE FUNCTION tf_sql(anytable) returns int AS $$ SELECT 1 $$ language sql CONTAINS SQL;
@@ -2313,8 +2312,6 @@ BEGIN
 END; 
 $$ language plpgsql NO SQL;
 ERROR:  PL/pgSQL functions cannot accept type anytable
-CREATE FUNCTION tf_perl(anytable) returns int AS $$ return 1 $$ language plperl NO SQL;
-ERROR:  PL/Perl functions cannot accept type anytable
 -- python functions have no validator, error at call time.
 CREATE FUNCTION tf_python(anytable) returns int AS $$ return 1 $$ language plpythonu NO SQL;
 SELECT * FROM tf_python( TABLE(SELECT 1) );

--- a/src/test/regress/output/table_functions_optimizer.source
+++ b/src/test/regress/output/table_functions_optimizer.source
@@ -2303,7 +2303,6 @@ SELECT * FROM multiset_5( TABLE( SELECT 1::integer, 'hello'::text) ) as tf;
 -- ============================================
 -- start_ignore
 -- These may have been created by previous test
-create language plperl;
 create language plpythonu;
 -- end_ignore
 CREATE FUNCTION tf_sql(anytable) returns int AS $$ SELECT 1 $$ language sql CONTAINS SQL;
@@ -2314,8 +2313,6 @@ BEGIN
 END; 
 $$ language plpgsql NO SQL;
 ERROR:  PL/pgSQL functions cannot accept type anytable
-CREATE FUNCTION tf_perl(anytable) returns int AS $$ return 1 $$ language plperl NO SQL;
-ERROR:  PL/Perl functions cannot accept type anytable
 -- python functions have no validator, error at call time.
 CREATE FUNCTION tf_python(anytable) returns int AS $$ return 1 $$ language plpythonu NO SQL;
 SELECT * FROM tf_python( TABLE(SELECT 1) );

--- a/src/test/regress/sql/metadata_track.sql
+++ b/src/test/regress/sql/metadata_track.sql
@@ -1220,12 +1220,6 @@ drop group mdt_group1;
 --
 create user mdt_user1 with superuser;
 create group mdt_group1 with superuser;
--- start_ignore
-drop language if exists plperl cascade;
--- end_ignore
-create language plperl;
-grant usage on language plperl to mdt_user1 with grant option;
-revoke grant option for usage on language plperl from mdt_user1;
 
 grant usage on language plpgsql to group mdt_group1 with grant option;
 REVOKE  usage on language plpgsql from group mdt_group1 cascade;
@@ -1233,7 +1227,6 @@ REVOKE  usage on language plpgsql from group mdt_group1 cascade;
 grant all privileges on language sql to public;
 revoke all privileges on language sql from public restrict; 
 
-drop language plperl;
 drop user mdt_user1;
 drop group mdt_group1;
 


### PR DESCRIPTION
PL/Perl is an optional component, and the main ICW should not use it as it may not be present. Move the tests that seem useful to the plperl test suite instead and remove the ones which we have ample coverage for elsewhere.