### PR TITLE
Generate Xlog for AO/CO operations.

### DIFF
--- a/configure
+++ b/configure
@@ -732,6 +732,7 @@ enable_thread_safety
 INCLUDES
 HAVE_CXX11
 enable_gpcloud
+enable_segwalrep
 enable_mapreduce
 enable_netbackup
 enable_ddboost
@@ -856,6 +857,7 @@ enable_ddboost
 enable_netbackup
 enable_mapreduce
 enable_gpcloud
+enable_segwalrep
 enable_thread_safety
 enable_thread_safety_force
 with_tcl
@@ -1536,6 +1538,7 @@ Optional Features:
   --enable-netbackup      enable NetBackup support
   --enable-mapreduce      enable Greenplum Mapreduce support
   --disable-gpcloud       disable gpcloud support
+  --enable-segwalrep      enable segment WAL replication
   --disable-thread-safety  Do not make client libraries thread-safe
   --enable-thread-safety-force  force thread-safety despite thread test failure
   --disable-largefile     omit support for large files
@@ -6927,6 +6930,40 @@ $as_echo "#define HAVE_CXX11 1" >>confdefs.h
 
 
 fi # fi
+
+
+#
+# Enable segment WAL replication
+#
+
+pgac_args="$pgac_args enable_segwalrep"
+
+# Check whether --enable-segwalrep was given.
+if test "${enable_segwalrep+set}" = set; then :
+  enableval=$enable_segwalrep;
+  case $enableval in
+    yes)
+
+$as_echo "#define USE_SEGWALREP 1" >>confdefs.h
+
+      ;;
+    no)
+      :
+      ;;
+    *)
+      as_fn_error $? "no argument expected for --enable-segwalrep option" "$LINENO" 5
+      ;;
+  esac
+
+else
+  enable_segwalrep=no
+
+fi
+
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: checking whether to build with segment WAL replication... $enable_segwalrep" >&5
+$as_echo "checking whether to build with segment WAL replication... $enable_segwalrep" >&6; }
+
 
 #
 # Include directories

--- a/configure.in
+++ b/configure.in
@@ -745,6 +745,15 @@ AS_IF([test "$enable_gpcloud" = yes],
 ]) # fi
 
 #
+# Enable segment WAL replication
+#
+PGAC_ARG_BOOL(enable, segwalrep, no, [  --enable-segwalrep      enable segment WAL replication ],
+              [AC_DEFINE([USE_SEGWALREP], 1,
+                         [Define to 1 to enable segment WAL replication. (--enable-segwalrep)])])
+AC_MSG_RESULT([checking whether to build with segment WAL replication... $enable_segwalrep])
+AC_SUBST(enable_segwalrep)
+
+#
 # Include directories
 #
 ac_save_IFS=$IFS

--- a/contrib/xlogdump/xlogdump.c
+++ b/contrib/xlogdump/xlogdump.c
@@ -542,6 +542,13 @@ dumpXLogRecord(XLogRecord *record, bool header_only)
 		case RM_SEQ_ID:
 			print_rmgr_seq(curRecPtr, record, info);
 			break;
+
+#ifdef USE_SEGWALREP
+		case RM_APPEND_ONLY_ID:
+			print_rmgr_ao(curRecPtr, record, info);
+			break;
+#endif		/* USE_SEGWALREP */
+
 		default:
 			fprintf(stderr, "Unknown RMID %d.\n", record->xl_rmid);
 			break;

--- a/contrib/xlogdump/xlogdump_rmgr.h
+++ b/contrib/xlogdump/xlogdump_rmgr.h
@@ -77,4 +77,8 @@ void print_rmgr_gin(XLogRecPtr, XLogRecord *, uint8);
 void print_rmgr_gist(XLogRecPtr, XLogRecord *, uint8);
 void print_rmgr_seq(XLogRecPtr, XLogRecord *, uint8);
 
+#ifdef USE_SEGWALREP
+void print_rmgr_ao(XLogRecPtr, XLogRecord *, uint8);
+#endif      /* USE_SEGWALREP */
+
 #endif /* __XLOGDUMP_RMGR_H__ */

--- a/src/Makefile.global.in
+++ b/src/Makefile.global.in
@@ -196,6 +196,8 @@ enable_mapreduce    = @enable_mapreduce@
 enable_gpcloud 	    = @enable_gpcloud@
 enable_gpperfmon    = @enable_gpperfmon@
 
+enable_segwalrep    = @enable_segwalrep@
+
 python_includespec	= @python_includespec@
 python_libdir		= @python_libdir@
 python_libspec		= @python_libspec@

--- a/src/backend/access/transam/rmgr.c
+++ b/src/backend/access/transam/rmgr.c
@@ -23,7 +23,7 @@
 #include "commands/sequence.h"
 #include "commands/tablespace.h"
 #include "storage/smgr.h"
-
+#include "cdb/cdbappendonlyam.h"
 
 const RmgrData RmgrTable[RM_MAX_ID + 1] = {
 	{"XLOG", xlog_redo, xlog_desc, NULL, NULL, NULL},
@@ -44,5 +44,10 @@ const RmgrData RmgrTable[RM_MAX_ID + 1] = {
 	{"Sequence", seq_redo, seq_desc, NULL, NULL, NULL},
 	{"Bitmap", bitmap_redo, bitmap_desc, bitmap_xlog_startup, bitmap_xlog_cleanup, bitmap_safe_restartpoint},
 	{"DistributedLog", DistributedLog_redo, DistributedLog_desc, NULL, NULL, NULL},
-	{"Master Mirror Log Records", mmxlog_redo, mmxlog_desc, NULL, NULL, NULL}
+	{"Master Mirror Log Records", mmxlog_redo, mmxlog_desc, NULL, NULL, NULL},
+
+#ifdef USE_SEGWALREP
+	{"Appendonly Table Log Records", appendonly_redo, appendonly_desc, NULL, NULL, NULL}
+#endif		/* USE_SEGWALREP */
+
 };

--- a/src/backend/cdb/cdbappendonlystorage.c
+++ b/src/backend/cdb/cdbappendonlystorage.c
@@ -12,6 +12,11 @@
 #include "cdb/cdbappendonlystorage.h"
 #include "utils/guc.h"
 
+#ifdef USE_SEGWALREP
+#include "cdb/cdbappendonlyam.h"
+#endif		/* USE_SEGWALREP */
+
+
 int32 AppendOnlyStorage_GetUsableBlockSize(int32 configBlockSize)
 {
 	int32 result;
@@ -28,3 +33,29 @@ int32 AppendOnlyStorage_GetUsableBlockSize(int32 configBlockSize)
 	
 	return result;
 }
+
+#ifdef USE_SEGWALREP
+void
+appendonly_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record)
+{
+	/* TODO add logic here to replay AO xlog records */
+}
+
+void
+appendonly_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record)
+{
+	xl_ao_insert *xlrec = (xl_ao_insert *)XLogRecGetData(record);
+	uint8		  xl_info = record->xl_info;
+	uint8		  info = xl_info & ~XLR_INFO_MASK;
+
+	if (info == XLOG_APPENDONLY_INSERT)
+	{
+		appendStringInfo(buf, "insert: rel %u/%u/%u seg/offset:%u/%lu len:%lu",
+						 xlrec->node.spcNode, xlrec->node.dbNode,
+						 xlrec->node.relNode, xlrec->segment_filenum,
+						 xlrec->offset, record->xl_len - SizeOfAOInsert);
+	}
+	else
+		appendStringInfo(buf, "UNKNOWN");
+}
+#endif		/* USE_SEGWALREP */

--- a/src/backend/cdb/cdbresynchronizechangetracking.c
+++ b/src/backend/cdb/cdbresynchronizechangetracking.c
@@ -584,8 +584,13 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 		case RM_DBASE_ID:
 		case RM_TBLSPC_ID:
 		case RM_MMXLOG_ID:
+
+#ifdef USE_SEGWALREP
+		case RM_APPEND_ONLY_ID:
+#endif		/* USE_SEGWALREP */
+
 			break;
-			
+
 		/* 
 		 * These aren't supported in GPDB
 		 */

--- a/src/include/access/rmgr.h
+++ b/src/include/access/rmgr.h
@@ -33,6 +33,12 @@ typedef uint8 RmgrId;
 #define RM_BITMAP_ID			16
 #define RM_DISTRIBUTEDLOG_ID	17
 #define RM_MMXLOG_ID			18
-#define RM_MAX_ID				RM_MMXLOG_ID
+
+#ifdef USE_SEGWALREP
+#define RM_APPEND_ONLY_ID		19
+#define RM_MAX_ID				RM_APPEND_ONLY_ID
+#else
+#define RM_MAX_ID               RM_MMXLOG_ID
+#endif      /* USE_SEGWALREP */
 
 #endif   /* RMGR_H */

--- a/src/include/cdb/cdbappendonlyam.h
+++ b/src/include/cdb/cdbappendonlyam.h
@@ -367,5 +367,25 @@ extern HTSU_Result appendonly_update(
 		MemTuple memTuple,
 		AOTupleId* aoTupleId,
 		AOTupleId* newAoTupleId);
+
+#ifdef USE_SEGWALREP
+#define XLOG_APPENDONLY_INSERT    0x00
+
+typedef struct xl_ao_insert
+{
+	/* meta data about the inserted block of AO data*/
+	RelFileNode node;
+	uint		segment_filenum;
+	uint64		offset;
+		/* BLOCK DATA FOLLOWS AT END OF STRUCT */
+} xl_ao_insert;
+
+#define SizeOfAOInsert (offsetof(xl_ao_insert, offset) + sizeof(uint64))
+
+extern void appendonly_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record);
+extern void appendonly_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record);
+#endif  /* USE_SEGWALREP */
+
 extern void appendonly_update_finish(AppendOnlyUpdateDesc aoUpdateDesc);
+
 #endif   /* CDBAPPENDONLYAM_H */

--- a/src/include/pg_config.h.in
+++ b/src/include/pg_config.h.in
@@ -884,6 +884,9 @@
 /* Define to select Win32-style shared memory. */
 #undef USE_WIN32_SHARED_MEMORY
 
+/* Define to build Segment WAL replication*/
+#undef USE_SEGWALREP
+
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */
 #if defined AC_APPLE_UNIVERSAL_BUILD

--- a/src/test/walrep/Makefile
+++ b/src/test/walrep/Makefile
@@ -1,13 +1,16 @@
 MODULES=gplibpq
 PG_CONFIG=pg_config
 
-REGRESS = setup walreceiver
-REGRESS_OPTS = --dbname="walrep_regression"
-
 subdir = src/test/walrep/
 top_builddir = ../../..
 
 include $(top_builddir)/src/Makefile.global
+
+REGRESS = setup walreceiver
+ifeq ($(enable_segwalrep), yes)
+REGRESS += generate_ao_xlog generate_aoco_xlog
+endif
+REGRESS_OPTS = --dbname="walrep_regression"
 
 NO_PGXS = 1
 include $(top_srcdir)/src/makefiles/pgxs.mk

--- a/src/test/walrep/expected/generate_ao_xlog.out
+++ b/src/test/walrep/expected/generate_ao_xlog.out
@@ -1,0 +1,44 @@
+-- Test AO XLogging
+CREATE OR REPLACE FUNCTION get_ao_eof(tablename TEXT) RETURNS BIGINT[] AS
+$$
+DECLARE
+eofval BIGINT[];
+eof_scalar BIGINT;
+BEGIN
+   SELECT eof INTO eof_scalar FROM gp_toolkit.__gp_aoseg_name(tablename);
+   eofval[0] := eof_scalar;
+   RETURN eofval;
+END;
+$$ LANGUAGE plpgsql;
+CREATE TABLE generate_ao_xlog_table(a INT, b INT) WITH (APPENDONLY=TRUE);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Store the location of xlog in a temporary table so that we can
+-- use it to request walsender to start streaming from this point
+CREATE TEMP TABLE tmp(startpoint TEXT);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'startpoint' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO tmp SELECT pg_current_xlog_location() FROM
+gp_dist_random('gp_id') WHERE gp_segment_id = 0;
+-- Generate some xlog records for AO
+INSERT INTO generate_ao_xlog_table VALUES(1, 10);
+-- Verify that AO xlog record was received
+SELECT test_xlog_ao((SELECT 'port=' || port FROM gp_segment_configuration
+       		     WHERE dbid=2),
+		    (SELECT startpoint FROM tmp),
+                    (SELECT oid FROM pg_tablespace WHERE spcname = 'pg_default'),
+                    (SELECT oid FROM pg_database
+		     WHERE datname = current_database()),
+                    (SELECT relfilenode FROM gp_dist_random('pg_class')
+		     WHERE relname = 'generate_ao_xlog_table'
+		     AND gp_segment_id = 0),
+		    (SELECT get_ao_eof('generate_ao_xlog_table')
+		     FROM gp_dist_random('gp_id')
+		     WHERE gp_segment_id = 0),
+		    false) FROM
+gp_dist_random('gp_id') WHERE gp_segment_id = 0;
+ test_xlog_ao 
+--------------
+            1
+(1 row)
+

--- a/src/test/walrep/expected/generate_aoco_xlog.out
+++ b/src/test/walrep/expected/generate_aoco_xlog.out
@@ -1,0 +1,49 @@
+-- Test AOCO XLogging
+CREATE OR REPLACE FUNCTION get_aoco_eofs(tablename TEXT) RETURNS BIGINT[] AS
+$$
+DECLARE
+eofvals BIGINT[];
+i      INT;
+result    RECORD;
+BEGIN
+   i := 0;
+   FOR result IN SELECT * FROM gp_toolkit.__gp_aocsseg_name(tablename)
+   LOOP
+	eofvals[i] := result.eof;
+	i := i + 1;
+   END LOOP;
+   RETURN eofvals;
+END;
+$$ LANGUAGE plpgsql;
+CREATE TABLE generate_aoco_xlog_table(a INT, b INT) WITH (APPENDONLY=TRUE, ORIENTATION=COLUMN);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Store the location of xlog in a temporary table so that we can
+-- use it to request walsender to start streaming from this point
+CREATE TEMP TABLE tmp(startpoint TEXT);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'startpoint' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO tmp SELECT pg_current_xlog_location() FROM
+gp_dist_random('gp_id') WHERE gp_segment_id = 0;
+-- Generate some xlog records for AOCO
+INSERT INTO generate_aoco_xlog_table VALUES(1, 10);
+-- Verify that AOCO xlog record was received
+SELECT test_xlog_ao((SELECT 'port=' || port FROM gp_segment_configuration
+                     WHERE dbid=2),
+		    (SELECT startpoint FROM tmp),
+                    (SELECT oid FROM pg_tablespace WHERE spcname = 'pg_default'),
+                    (SELECT oid FROM pg_database
+		     WHERE datname = current_database()),
+                    (SELECT relfilenode FROM gp_dist_random('pg_class')
+		     WHERE relname = 'generate_aoco_xlog_table'
+		     AND gp_segment_id = 0),
+		    (SELECT get_aoco_eofs('generate_aoco_xlog_table')
+		     FROM gp_dist_random('gp_id')
+		     WHERE gp_segment_id = 0),
+		    true) FROM
+gp_dist_random('gp_id') WHERE gp_segment_id = 0;
+ test_xlog_ao 
+--------------
+            2
+(1 row)
+

--- a/src/test/walrep/input/setup.source
+++ b/src/test/walrep/input/setup.source
@@ -12,3 +12,7 @@ create or replace function test_send() RETURNS bool AS
 
 create or replace function test_receive_and_verify(text, text) RETURNS bool AS
  '@abs_builddir@/gplibpq@DLSUFFIX@' LANGUAGE C VOLATILE STRICT NO SQL;
+
+create or replace function test_xlog_ao(text, text, oid, oid, oid, bigint[], bool)
+ RETURNS int AS
+ '@abs_builddir@/gplibpq@DLSUFFIX@' LANGUAGE C VOLATILE STRICT NO SQL;

--- a/src/test/walrep/output/setup.source
+++ b/src/test/walrep/output/setup.source
@@ -8,3 +8,6 @@ create or replace function test_send() RETURNS bool AS
  '@abs_builddir@/gplibpq@DLSUFFIX@' LANGUAGE C VOLATILE STRICT NO SQL;
 create or replace function test_receive_and_verify(text, text) RETURNS bool AS
  '@abs_builddir@/gplibpq@DLSUFFIX@' LANGUAGE C VOLATILE STRICT NO SQL;
+create or replace function test_xlog_ao(text, text, oid, oid, oid, bigint[], bool)
+ RETURNS int AS
+ '@abs_builddir@/gplibpq@DLSUFFIX@' LANGUAGE C VOLATILE STRICT NO SQL;

--- a/src/test/walrep/sql/generate_ao_xlog.sql
+++ b/src/test/walrep/sql/generate_ao_xlog.sql
@@ -1,0 +1,41 @@
+-- Test AO XLogging
+
+CREATE OR REPLACE FUNCTION get_ao_eof(tablename TEXT) RETURNS BIGINT[] AS
+$$
+DECLARE
+eofval BIGINT[];
+eof_scalar BIGINT;
+BEGIN
+   SELECT eof INTO eof_scalar FROM gp_toolkit.__gp_aoseg_name(tablename);
+   eofval[0] := eof_scalar;
+   RETURN eofval;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TABLE generate_ao_xlog_table(a INT, b INT) WITH (APPENDONLY=TRUE);
+
+-- Store the location of xlog in a temporary table so that we can
+-- use it to request walsender to start streaming from this point
+CREATE TEMP TABLE tmp(startpoint TEXT);
+INSERT INTO tmp SELECT pg_current_xlog_location() FROM
+gp_dist_random('gp_id') WHERE gp_segment_id = 0;
+
+-- Generate some xlog records for AO
+INSERT INTO generate_ao_xlog_table VALUES(1, 10);
+
+-- Verify that AO xlog record was received
+SELECT test_xlog_ao((SELECT 'port=' || port FROM gp_segment_configuration
+       		     WHERE dbid=2),
+		    (SELECT startpoint FROM tmp),
+                    (SELECT oid FROM pg_tablespace WHERE spcname = 'pg_default'),
+                    (SELECT oid FROM pg_database
+		     WHERE datname = current_database()),
+                    (SELECT relfilenode FROM gp_dist_random('pg_class')
+		     WHERE relname = 'generate_ao_xlog_table'
+		     AND gp_segment_id = 0),
+		    (SELECT get_ao_eof('generate_ao_xlog_table')
+		     FROM gp_dist_random('gp_id')
+		     WHERE gp_segment_id = 0),
+		    false) FROM
+gp_dist_random('gp_id') WHERE gp_segment_id = 0;
+

--- a/src/test/walrep/sql/generate_aoco_xlog.sql
+++ b/src/test/walrep/sql/generate_aoco_xlog.sql
@@ -1,0 +1,46 @@
+-- Test AOCO XLogging
+
+CREATE OR REPLACE FUNCTION get_aoco_eofs(tablename TEXT) RETURNS BIGINT[] AS
+$$
+DECLARE
+eofvals BIGINT[];
+i      INT;
+result    RECORD;
+BEGIN
+   i := 0;
+   FOR result IN SELECT * FROM gp_toolkit.__gp_aocsseg_name(tablename)
+   LOOP
+	eofvals[i] := result.eof;
+	i := i + 1;
+   END LOOP;
+   RETURN eofvals;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TABLE generate_aoco_xlog_table(a INT, b INT) WITH (APPENDONLY=TRUE, ORIENTATION=COLUMN);
+
+-- Store the location of xlog in a temporary table so that we can
+-- use it to request walsender to start streaming from this point
+CREATE TEMP TABLE tmp(startpoint TEXT);
+INSERT INTO tmp SELECT pg_current_xlog_location() FROM
+gp_dist_random('gp_id') WHERE gp_segment_id = 0;
+
+-- Generate some xlog records for AOCO
+INSERT INTO generate_aoco_xlog_table VALUES(1, 10);
+
+-- Verify that AOCO xlog record was received
+SELECT test_xlog_ao((SELECT 'port=' || port FROM gp_segment_configuration
+                     WHERE dbid=2),
+		    (SELECT startpoint FROM tmp),
+                    (SELECT oid FROM pg_tablespace WHERE spcname = 'pg_default'),
+                    (SELECT oid FROM pg_database
+		     WHERE datname = current_database()),
+	            (SELECT relfilenode FROM gp_dist_random('pg_class')
+		     WHERE relname = 'generate_aoco_xlog_table'
+		     AND gp_segment_id = 0),
+		    (SELECT get_aoco_eofs('generate_aoco_xlog_table')
+		     FROM gp_dist_random('gp_id')
+		     WHERE gp_segment_id = 0),
+		    true) FROM
+gp_dist_random('gp_id') WHERE gp_segment_id = 0;
+


### PR DESCRIPTION
Define a xlog format for AO operations. The xlog is generated when an AO block
is written.

A test is added to receive the AO log from the WAL Sender process after an
INSERT operation and verify that the the received xlog has the AO xlog record in
it.

Signed-off-by: Abhijit Subramanya <asubramanya@pivotal.io>