### PR TITLE
Add gp_always_schema_qualify GUC

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -590,6 +590,11 @@ char	   *gp_default_storage_options = NULL;
 
 int			writable_external_table_bufsize = 64;
 
+/*
+ * GUC for formatting relation names during backup
+ */
+bool		gp_always_schema_qualify;
+
 IndexCheckType gp_indexcheck_insert = INDEX_CHECK_NONE;
 IndexCheckType gp_indexcheck_vacuum = INDEX_CHECK_NONE;
 
@@ -3258,6 +3263,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 		},
 		&pljava_classpath_insecure,
 		false, assign_pljava_classpath_insecure, NULL
+	},
+
+	{
+		{"gp_always_schema_qualify", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Functions for formatting database object definitions will always schema qualify table names"),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&gp_always_schema_qualify,
+		false, NULL, NULL
 	},
 	/* End-of-list marker */
 	{

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -546,6 +546,11 @@ extern int log_count_recovered_files_batch;
 
 extern int writable_external_table_bufsize;
 
+/*
+ * GUC for formatting relation names during backup
+ */
+extern bool gp_always_schema_qualify;
+
 typedef enum
 {
 	INDEX_CHECK_NONE,

--- a/src/test/regress/expected/guc.out
+++ b/src/test/regress/expected/guc.out
@@ -605,6 +605,35 @@ SELECT current_user = 'temp_reset_user';
 
 DROP ROLE temp_reset_user;
 --
+-- Tests for gp_always_schema_qualify GUC
+--
+BEGIN;
+CREATE TABLE test_schema_qualify(i int);
+CREATE INDEX qualify_index ON test_schema_qualify USING btree (i);
+-- GUC not set
+SET gp_always_schema_qualify=false;
+SELECT pg_get_indexdef(i.indexrelid)
+FROM pg_index i
+JOIN pg_class t ON (t.oid = i.indexrelid)
+WHERE i.indrelid = 'test_schema_qualify' :: regclass :: oid;
+                             pg_get_indexdef
+-------------------------------------------------------------------
+ CREATE INDEX qualify_index ON test_schema_qualify USING btree (i)
+(1 row)
+
+-- GUC set
+SET gp_always_schema_qualify=true;
+SELECT pg_get_indexdef(i.indexrelid)
+FROM pg_index i
+JOIN pg_class t ON (t.oid = i.indexrelid)
+WHERE i.indrelid = 'test_schema_qualify' :: regclass :: oid;
+                             pg_get_indexdef
+--------------------------------------------------------------------------
+ CREATE INDEX qualify_index ON public.test_schema_qualify USING btree (i)
+(1 row)
+
+ROLLBACK;
+--
 -- Tests for function-local GUC settings
 --
 set regex_flavor = advanced;

--- a/src/test/regress/sql/guc.sql
+++ b/src/test/regress/sql/guc.sql
@@ -183,6 +183,28 @@ SELECT current_user = 'temp_reset_user';
 DROP ROLE temp_reset_user;
 
 --
+-- Tests for gp_always_schema_qualify GUC
+--
+BEGIN;
+CREATE TABLE test_schema_qualify(i int);
+CREATE INDEX qualify_index ON test_schema_qualify USING btree (i);
+
+-- GUC not set
+SET gp_always_schema_qualify=false;
+SELECT pg_get_indexdef(i.indexrelid)
+FROM pg_index i
+JOIN pg_class t ON (t.oid = i.indexrelid)
+WHERE i.indrelid = 'test_schema_qualify' :: regclass :: oid;
+
+-- GUC set
+SET gp_always_schema_qualify=true;
+SELECT pg_get_indexdef(i.indexrelid)
+FROM pg_index i
+JOIN pg_class t ON (t.oid = i.indexrelid)
+WHERE i.indrelid = 'test_schema_qualify' :: regclass :: oid;
+ROLLBACK;
+
+--
 -- Tests for function-local GUC settings
 --
 


### PR DESCRIPTION
- Generate_relation_name uses this GUC to determine whether it should
  always schema qualify relation names.
- Includes ICW test

Signed-off-by: Karen Huddleston <khuddleston@pivotal.io>