### PR TITLE
Add gpcheckperf to open source build

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -30,6 +30,7 @@ all:
 	$(MAKE) -C contrib/pgcrypto all
 	$(MAKE) -C gpAux/extensions mapreduce
 	$(MAKE) -C gpAux/gpperfmon all
+	$(MAKE) -C gpAux/platform all
 	@echo "All of Greenplum Database successfully made. Ready to install."
 
 install:
@@ -54,6 +55,7 @@ install:
 	$(MAKE) -C gpMgmt $@
 	$(MAKE) -C gpAux/extensions $@
 	$(MAKE) -C gpAux/gpperfmon $@
+	$(MAKE) -C gpAux/platform $@
 	@echo "Greenplum Database installation complete."
 
 installdirs uninstall:
@@ -109,6 +111,7 @@ clean:
 # calling top-level configure and this Makefile
 	$(MAKE) -C gpAux/extensions $@
 	$(MAKE) -C gpAux/gpperfmon $@
+	$(MAKE) -C gpAux/platform $@
 	$(MAKE) -C gpMgmt $@
 # Garbage from autoconf:
 	@rm -rf autom4te.cache/
@@ -119,6 +122,7 @@ distclean maintainer-clean:
 #	-$(MAKE) -C doc $@
 	-$(MAKE) -C gpAux/extensions $@
 	-$(MAKE) -C gpAux/gpperfmon $@
+	-$(MAKE) -C gpAux/platform $@
 	-$(MAKE) -C contrib $@
 	-$(MAKE) -C config $@
 	-$(MAKE) -C src $@

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -326,7 +326,6 @@ define BUILD_STEPS
 	#@$(MAKE) mgmtcopy INSTLOC=$(INSTLOC)
 	@$(MAKE) mkpgbouncer INSTLOC=$(INSTLOC) BUILDDIR=$(BUILDDIR)
 	@$(MAKE) mkpgbench INSTLOC=$(INSTLOC) BUILDDIR=$(BUILDDIR)
-	@$(MAKE) mkplatform INSTLOC=$(INSTLOC)
 	if [ "$(findstring $(BLD_ARCH),$(SERVER_PLATFORMS))" != "" ]; then \
 	  $(MAKE) mkgpcloud INSTLOC=$(INSTLOC) && \
 	  $(MAKE) mkgphdfs INSTLOC=$(INSTLOC) && \
@@ -869,11 +868,6 @@ else
 	@cd extensions/pgbouncer/source && ./configure --with-libevent=$(BLD_TOP)/ext/$(BLD_ARCH) --prefix=$(INSTLOC) --enable-evdns
 	$(MAKE) -C extensions/pgbouncer/source install
 endif
-
-mkplatform:
-	@cd $(PLATFORM) && $(MAKE)
-	cp -p platform/gpnetbench/gpnetbenchServer $(INSTLOC)/bin/lib
-	cp -p platform/gpnetbench/gpnetbenchClient $(INSTLOC)/bin/lib
 
 copydocs :
 	@if [ ! -d $($INSTLOC)/docs ] ; then mkdir -p $(INSTLOC)/docs; fi

--- a/gpAux/platform/Makefile
+++ b/gpAux/platform/Makefile
@@ -1,10 +1,11 @@
-all: gpnetbenchClient gpnetbenchServer
+.PHONY: gpnetbench
+all: gpnetbench
 
-gpnetbenchServer:
-	$(MAKE) -C gpnetbench gpnetbenchServer
-
-gpnetbenchClient:
-	$(MAKE) -C gpnetbench gpnetbenchClient
+gpnetbench:
+	$(MAKE) -C gpnetbench all
 
 clean:
 	$(MAKE) -C gpnetbench clean
+
+install: all
+	$(MAKE) -C gpnetbench install

--- a/gpAux/platform/gpnetbench/Makefile
+++ b/gpAux/platform/gpnetbench/Makefile
@@ -2,33 +2,29 @@ SHELL=/bin/bash
 
 default: all
 
-BLD_TOP=$(shell echo `pwd`/../../)
-include $(BLD_TOP)/Makefile.global
-include $(BLD_TOP)/Makefile.thirdparty
-
-EXT_DIR=$(BLD_TOP)/ext/$(BLD_ARCH)/
-
-CC=$(strip $(BLD_CC))
+top_builddir = ../../..
+include $(top_builddir)/src/Makefile.global
 
 SERVER_OBJS=gpnetbenchServer.o
 CLIENT_OBJS=gpnetbenchClient.o
 
 CFLAGS=-Werror -Wall -g -O2
 
-ifeq (sol,$(findstring sol,$(BLD_ARCH)))
-	GPNETBENCH_LIBS+=-lsocket -lnsl
-endif
-
 all: gpnetbenchServer gpnetbenchClient
 
 gpnetbenchServer: $(SERVER_OBJS)
-	$(CC) -o gpnetbenchServer $(SERVER_OBJS) $(GPNETBENCH_LIBS)
+	$(CC) -o gpnetbenchServer $(SERVER_OBJS)
 
 gpnetbenchClient: $(CLIENT_OBJS)
-	$(CC) -o gpnetbenchClient $(CLIENT_OBJS) $(GPNETBENCH_LIBS)
+	$(CC) -o gpnetbenchClient $(CLIENT_OBJS)
 
 %.o: %.c
 	$(CC) $(CFLAGS) -o $@ -c $<
 
 clean:
 	rm -rf *.o gpnetbenchServer gpnetbenchClient
+
+install: all
+	mkdir -p $(prefix)/bin/lib
+	cp -p gpnetbenchServer $(prefix)/bin/lib
+	cp -p gpnetbenchClient $(prefix)/bin/lib

--- a/gpMgmt/bin/gpcheckperf
+++ b/gpMgmt/bin/gpcheckperf
@@ -373,6 +373,7 @@ def runSetup():
         cmd = 'rm -rf %s ; mkdir -p %s' % (dirs, dirs)
         (ok, out) = gpssh(cmd)
         if not ok:
+            print 'failed gpssh: %s' % out
             sys.exit("[Error] unable to make gpcheckperf directory. \n"
                      + "        command failed: " + cmd)
 


### PR DESCRIPTION
Add targets for gpnetbenchClient and gpnetbenchServer to top-level
Makefile so that gpcheckperf runs with the open source build

Signed-off-by: Melanie Plageman <mplageman@pivotal.io>