### PR TITLE
Fix behavior when gpexpand runs longer than duration

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -2240,10 +2240,10 @@ UPDATE gp_distribution_policy
         while not self.queue.isDone():
             logger.debug(
                 "woke up.  queue: %d finished %d  " % (self.queue.num_assigned, self.queue.completed_queue.qsize()))
-            time.sleep(5)
             if stopTime and datetime.datetime.now() >= stopTime:
                 stoppedEarly = True
                 break
+            time.sleep(5)
 
         expansionStopped = datetime.datetime.now()
 
@@ -2552,6 +2552,11 @@ class ExpandTable():
                 dbconn.execSQL(table_conn, sql)
                 table_conn.commit()
 
+            return True
+
+        # I can only get here if the cancel flag is True
+        return False
+
     def mark_finished(self, status_conn, start_time, finish_time):
         sql = """UPDATE %s.%s
                   SET status = '%s', expansion_started='%s', expansion_finished='%s'
@@ -2725,8 +2730,8 @@ class ExpandCommand(SQLCommand):
                 if not options.simple_progress:
                     self.table.mark_started(status_conn, table_conn, start_time, self.cancel_flag)
 
-                self.table.expand(table_conn, self.cancel_flag)
-                table_exp_success = True
+                table_exp_success = self.table.expand(table_conn, self.cancel_flag)
+
         except Exception, ex:
             if ex.__str__().find('canceling statement due to user request') == -1 and not self.cancel_flag:
                 table_expand_error = True


### PR DESCRIPTION
This should fix the situation where gpexpand completes, but takes longer than the user-specified duration, and so marks the expansion as failed. 