### PR TITLE
Fix deadlock on master with ENTRY_DB_SINGLETON

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsInjectFault.py
+++ b/gpMgmt/bin/gppylib/programs/clsInjectFault.py
@@ -348,6 +348,7 @@ class GpInjectFaultProgram:
 			      "checkpoint (inject fault before checkpoint is taken), " \
 			      "change_tracking_compacting_report (report if compacting is in progress), " \
 			      "change_tracking_disable (inject fault before fsync to Change Tracking log files), " \
+			      "transaction_start_under_entry_db_singleton (inject fault during transaction start with DistributedTransactionContext in ENTRY_DB_SINGLETON mode), " \
 			      "transaction_abort_after_distributed_prepared (abort prepared transaction), " \
 			      "transaction_commit_pass1_from_create_pending_to_created, " \
 			      "transaction_commit_pass1_from_drop_in_memory_to_drop_pending, " \

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -2896,6 +2896,11 @@ StartTransaction(void)
 	TransactionState s;
 	VirtualTransactionId vxid;
 
+	if (DistributedTransactionContext == DTX_CONTEXT_QE_ENTRY_DB_SINGLETON)
+	{
+		SIMPLE_FAULT_INJECTOR(TransactionStartUnderEntryDbSingleton);
+	}
+
 	/*
 	 * Let's just make sure the state stack is empty
 	 */

--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -604,11 +604,11 @@ LockAcquire(const LOCKTAG *locktag,
 					lockHolderProcPtr = proc;
 				}
 				else
-					elog(DEBUG1,"Could not find writer proc entry!");
+					elog(ERROR,"could not find writer proc entry!");
 		
-					elog(DEBUG1,"Reader gang member trying to acquire a lock [%u,%u] %s %d",
-						 locktag->locktag_field1, locktag->locktag_field2,
-						 lock_mode_names[lockmode], (int)locktag->locktag_type);
+				elog(DEBUG1,"Reader gang member trying to acquire a lock [%u,%u] %s %d",
+					 locktag->locktag_field1, locktag->locktag_field2,
+					 lock_mode_names[lockmode], (int)locktag->locktag_type);
 			}
 				
 		}
@@ -831,34 +831,44 @@ LockAcquire(const LOCKTAG *locktag,
 		Insist(false);
 	}
 
-	/*
-	 * If WRITER (MyProc == lockHolderProcPtr), check if lock requested
-	 * conflicts with locks requested by waiters, must join wait queue.
-	 *
-	 * If READER (MyProc != lockHolderProcPtr), check if requested a same
-	 * lock already held by its writer, just granted (STATUS_OK), otherwise
-	 * wait in the queue if conflicting with waitMask.
-	 *
-	 * Otherwise, check for conflict with already-held locks. (That's
-	 * last because most complex check.)
-	 */
-	status = STATUS_ERROR; /*init to an invalid value.*/
 	if (MyProc == lockHolderProcPtr)
 	{
+		/*
+		 * We are a writer or utility mode connection.  The following logic is
+		 * identical to upstream PostgreSQL.
+		 */
+
+		/*
+		 * If lock requested conflicts with locks requested by waiters, must join
+		 * wait queue.	Otherwise, check for conflict with already-held locks.
+		 * (That's last because most complex check.)
+		 */
 		if (lockMethodTable->conflictTab[lockmode] & lock->waitMask)
 			status = STATUS_FOUND;
+		else
+			status = LockCheckConflicts(lockMethodTable, lockmode,
+										lock, proclock, MyProc);
 	}
-	else if (MyProc != lockHolderProcPtr)
+	else
 	{
-		PROCLOCKTAG writerProcLockTag;
+		/*
+		 * We are a reader.  Check if the writer holds the lock already.  If
+		 * no, waitMask must be checked to avoid starvation of backends already
+		 * waiting on the same lock.
+		 */
+		Assert(!Gp_is_writer);
 
+		PROCLOCKTAG writerProcLockTag;
 		uint32 writerProcLockHashCode;
 
 		writerProcLockTag.myLock = lock;
 		writerProcLockTag.myProc = lockHolderProcPtr;
-
 		writerProcLockHashCode = ProcLockHashCode(&writerProcLockTag, hashcode);
-
+		/*
+		 * It is safe to access LockMethodProcLock hash table because
+		 * partitionLock is already held at this point.
+		 */
+		Assert(LWLockHeldByMe(partitionLock));
 		hash_search_with_hash_value(LockMethodProcLockHash,
 									(void *) &writerProcLockTag,
 									writerProcLockHashCode,
@@ -866,18 +876,24 @@ LockAcquire(const LOCKTAG *locktag,
 									&found);
 		if (found)
 		{
+			/*
+			 * Writer already holds this lock, grant it to reader
+			 * unconditionally.
+			 */
 			status = STATUS_OK;
 		}
 		else if (lockMethodTable->conflictTab[lockmode] & lock->waitMask)
 		{
+			/*
+			 * Writer does not hold this lock and the lockmode conflicts with
+			 * another process waiting on the same lock.  Reader must wait so
+			 * as not to starve existing waiters.
+			 */
 			status = STATUS_FOUND;
 		}
-	}
-
-	if (status == STATUS_ERROR)
-	{
-		status = LockCheckConflicts(lockMethodTable, lockmode,
-									lock, proclock, MyProc);
+		else
+			status = LockCheckConflicts(lockMethodTable, lockmode,
+										lock, proclock, MyProc);
 	}
 
 	if (status == STATUS_OK)

--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -835,7 +835,7 @@ LockAcquire(const LOCKTAG *locktag,
 	 * wait queue.	Otherwise, check for conflict with already-held locks.
 	 * (That's last because most complex check.)
 	 */
-	if (lockMethodTable->conflictTab[lockmode] & lock->waitMask)
+	if (MyProc == lockHolderProcPtr && (lockMethodTable->conflictTab[lockmode] & lock->waitMask))
 		status = STATUS_FOUND;
 	else
 		status = LockCheckConflicts(lockMethodTable, lockmode,

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -175,6 +175,8 @@ FaultInjectorIdentifierEnumToString[] = {
 		/* report if compacting is in progress */
 	_("change_tracking_disable"),
 		/* inject fault during fsync to Change Tracking log */
+	_("transaction_start_under_entry_db_singleton"),
+		/* inject fault during transaction start with DistributedTransactionContext in ENTRY_DB_SINGLETON mode */
 	_("transaction_abort_after_distributed_prepared"),
 		/* inject fault after transaction is prepared */
 	_("transaction_commit_pass1_from_create_pending_to_created"),

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -85,6 +85,8 @@ typedef enum FaultInjectorIdentifier_e {
 	
 	ChangeTrackingDisable,
 	
+	TransactionStartUnderEntryDbSingleton,
+
 	TransactionAbortAfterDistributedPrepared,
 	
 	TransactionCommitPass1FromCreatePendingToCreated,

--- a/src/test/isolation2/expected/deadlock_under_entry_db_singleton.out
+++ b/src/test/isolation2/expected/deadlock_under_entry_db_singleton.out
@@ -1,48 +1,81 @@
+-- Test to validate that ENTRY_DB_SINGLETON reader does not cause a
+-- deadlock.
+--
+-- The deadlock used to happen when ENTRY_DB_SINGLETON enters
+-- LockAcquire with its writer already holding the lock.  And the
+-- requested lockmode conflicts with another session's requested
+-- lockmode who is waiting on the same lock.  The waitMask check in
+-- LockAcquire would put the ENTRY_DB_SINGLETON into wait queue.  If
+-- the ENTRY_DB_SINGLETON is supposed to produce some tuples that need
+-- to be consumed by other nodes in the plan, either QEs or the writer
+-- QD may wait for ENTRY_DB_SINGLETON and we will have a wait cycle,
+-- causing deadlock.
+--
+-- This test creates one such scenario using a volatile funciton.  It
+-- is critical that the function be volatile, otherwise,
+-- ENTRY_DB_SIGNLETON reader is not spawned to execute the query.
+--
+-- This thread on gpdb-dev has more details:
+-- https://groups.google.com/a/greenplum.org/d/msg/gpdb-dev/OS1-ODIK0P4/ZIzayBbMBwAJ
+
 CREATE TABLE deadlock_entry_db_singleton_table (c int, d int);
 CREATE
 INSERT INTO deadlock_entry_db_singleton_table select i, i+1 from generate_series(1,10) i;
 INSERT 10
 
+-- Function that needs ExclusiceLock on a table.  Declare this
+-- function volatile so that ENTRY_DB_SINGLETON process executes the
+-- function and the lock is requested during execution of the fuction.
+-- Without volatile, the lock is requested during plan generation of
+-- the calling SQL statement and we don't get ENTRY_DB_SINGLETON
+-- process.
 CREATE FUNCTION function_volatile(x int) RETURNS int AS $$ /*in func*/ BEGIN /*in func*/ UPDATE deadlock_entry_db_singleton_table SET d = d + 1  WHERE c = $1; /*in func*/ RETURN $1 + 1; /*in func*/ END $$ /*in func*/ LANGUAGE plpgsql VOLATILE MODIFIES SQL DATA;
 CREATE
 
 -- inject fault on QD
 ! gpfaultinjector -f transaction_start_under_entry_db_singleton -m async -y reset -o 0 -s 1;
-20170522:18:08:22:036621 gpfaultinjector:xzhangmac:xzhang-[INFO]:-Starting gpfaultinjector with args: -f transaction_start_under_entry_db_singleton -m async -y reset -o 0 -s 1
-20170522:18:08:22:036621 gpfaultinjector:xzhangmac:xzhang-[INFO]:-Injecting fault on content=-1:dbid=1:mode=s:status=u
-20170522:18:08:22:036621 gpfaultinjector:xzhangmac:xzhang-[INFO]:-DONE
+20170605:16:59:30:008493 gpfaultinjector:asimmac:apraveen-[INFO]:-Starting gpfaultinjector with args: -f transaction_start_under_entry_db_singleton -m async -y reset -o 0 -s 1
+20170605:16:59:30:008493 gpfaultinjector:asimmac:apraveen-[INFO]:-Injecting fault on content=-1:dbid=1:mode=s:status=u
+20170605:16:59:30:008493 gpfaultinjector:asimmac:apraveen-[INFO]:-DONE
 
 ! gpfaultinjector -f transaction_start_under_entry_db_singleton -m async -y suspend -o 0 -s 1;
-20170522:18:08:23:036633 gpfaultinjector:xzhangmac:xzhang-[INFO]:-Starting gpfaultinjector with args: -f transaction_start_under_entry_db_singleton -m async -y suspend -o 0 -s 1
-20170522:18:08:23:036633 gpfaultinjector:xzhangmac:xzhang-[INFO]:-Injecting fault on content=-1:dbid=1:mode=s:status=u
-20170522:18:08:23:036633 gpfaultinjector:xzhangmac:xzhang-[INFO]:-DONE
+20170605:16:59:30:008505 gpfaultinjector:asimmac:apraveen-[INFO]:-Starting gpfaultinjector with args: -f transaction_start_under_entry_db_singleton -m async -y suspend -o 0 -s 1
+20170605:16:59:30:008505 gpfaultinjector:asimmac:apraveen-[INFO]:-Injecting fault on content=-1:dbid=1:mode=s:status=u
+20170605:16:59:30:008505 gpfaultinjector:asimmac:apraveen-[INFO]:-DONE
 
 
--- now, the QD should already hold RowExclusiveLock and ExclusiveLock on `deadlock_entry_db_singleton_table`
--- the QE ENTRY_DB_SINGLETON will stop at the StartTransaction.
+-- The QD should already hold RowExclusiveLock and ExclusiveLock on
+-- deadlock_entry_db_singleton_table and the QE ENTRY_DB_SINGLETON
+-- will stop at in StartTransaction due to suspend fault.
 1&:UPDATE deadlock_entry_db_singleton_table set d = d + 1 FROM (select 1 from deadlock_entry_db_singleton_table, function_volatile(5)) t;  <waiting ...>
 
 -- verify the fault hit
 ! gpfaultinjector -f transaction_start_under_entry_db_singleton -m async -y status -o 0 -s 1;
-20170522:18:08:23:036655 gpfaultinjector:xzhangmac:xzhang-[INFO]:-Starting gpfaultinjector with args: -f transaction_start_under_entry_db_singleton -m async -y status -o 0 -s 1
-20170522:18:08:23:036655 gpfaultinjector:xzhangmac:xzhang-[INFO]:-Injecting fault on content=-1:dbid=1:mode=s:status=u
-20170522:18:08:23:036655 gpfaultinjector:xzhangmac:xzhang-[INFO]:-fault name:'transaction_start_under_entry_db_singleton' fault type:'suspend' ddl statement:'' database name:'' table name:'' occurrence:'-1' sleep time:'10' fault injection state:'triggered'  num times hit:'1' 
-20170522:18:08:23:036655 gpfaultinjector:xzhangmac:xzhang-[INFO]:-DONE
+20170605:16:59:31:008529 gpfaultinjector:asimmac:apraveen-[INFO]:-Starting gpfaultinjector with args: -f transaction_start_under_entry_db_singleton -m async -y status -o 0 -s 1
+20170605:16:59:31:008529 gpfaultinjector:asimmac:apraveen-[INFO]:-Injecting fault on content=-1:dbid=1:mode=s:status=u
+20170605:16:59:31:008529 gpfaultinjector:asimmac:apraveen-[INFO]:-fault name:'transaction_start_under_entry_db_singleton' fault type:'suspend' ddl statement:'' database name:'' table name:'' occurrence:'-1' sleep time:'10' fault injection state:'triggered'  num times hit:'1' 
+20170605:16:59:31:008529 gpfaultinjector:asimmac:apraveen-[INFO]:-DONE
 
 
--- in separate session, try to update the `deadlock_entry_db_singleton_table` table, and it will wait for ExclusiveLock on `deadlock_entry_db_singleton_table`
+-- This session will wait for ExclusiveLock on
+-- deadlock_entry_db_singleton_table.
 2&: update deadlock_entry_db_singleton_table set d = d + 1;  <waiting ...>
 
--- we expect to hit deadlock
+-- The ENTRY_DB_SINGLETON will acquire exclusive lock on
+-- deadlock_entry_db_singleton_table.  The lockmode conflicts with the
+-- lock's waitMask due to session2 already waiting for the same lock.
+-- In spite of the waitMask conflict the lock should be granted to
+-- ENTRY_DB_SINGLETON reader because its writer already holds the
+-- lock.  Otherwise, we may have a deadlock.
 ! gpfaultinjector -f transaction_start_under_entry_db_singleton -m async -y resume  -o 0 -s 1;
-20170522:18:08:24:036672 gpfaultinjector:xzhangmac:xzhang-[INFO]:-Starting gpfaultinjector with args: -f transaction_start_under_entry_db_singleton -m async -y resume -o 0 -s 1
-20170522:18:08:24:036672 gpfaultinjector:xzhangmac:xzhang-[INFO]:-Injecting fault on content=-1:dbid=1:mode=s:status=u
-20170522:18:08:24:036672 gpfaultinjector:xzhangmac:xzhang-[INFO]:-DONE
+20170605:16:59:32:008543 gpfaultinjector:asimmac:apraveen-[INFO]:-Starting gpfaultinjector with args: -f transaction_start_under_entry_db_singleton -m async -y resume -o 0 -s 1
+20170605:16:59:32:008543 gpfaultinjector:asimmac:apraveen-[INFO]:-Injecting fault on content=-1:dbid=1:mode=s:status=u
+20170605:16:59:32:008543 gpfaultinjector:asimmac:apraveen-[INFO]:-DONE
 
 ! gpfaultinjector -f transaction_start_under_entry_db_singleton -m async -y reset -o 0 -s 1;
-20170522:18:08:24:036685 gpfaultinjector:xzhangmac:xzhang-[INFO]:-Starting gpfaultinjector with args: -f transaction_start_under_entry_db_singleton -m async -y reset -o 0 -s 1
-20170522:18:08:24:036685 gpfaultinjector:xzhangmac:xzhang-[INFO]:-Injecting fault on content=-1:dbid=1:mode=s:status=u
-20170522:18:08:24:036685 gpfaultinjector:xzhangmac:xzhang-[INFO]:-DONE
+20170605:16:59:32:008555 gpfaultinjector:asimmac:apraveen-[INFO]:-Starting gpfaultinjector with args: -f transaction_start_under_entry_db_singleton -m async -y reset -o 0 -s 1
+20170605:16:59:32:008555 gpfaultinjector:asimmac:apraveen-[INFO]:-Injecting fault on content=-1:dbid=1:mode=s:status=u
+20170605:16:59:32:008555 gpfaultinjector:asimmac:apraveen-[INFO]:-DONE
 
 
 -- verify the deadlock across multiple pids with same mpp session id
@@ -52,11 +85,11 @@ founddeadlockprocess
 0                   
 (1 row)
 
--- join the session 1 and session 2
+-- join the session1 and session2
 -- we expect to see an ERROR message here due to function_volatile function
--- tried to update table from ENTRY_DB_SINGLETON (which is read-only) in session 1
+-- tried to update table from ENTRY_DB_SINGLETON (which is read-only) in session1
 1<:  <... completed>
-ERROR:  function cannot execute on segment because it issues a non-SELECT statement  (entry db 127.0.0.1:15432 pid=36654)
+ERROR:  function cannot execute on segment because it issues a non-SELECT statement  (entry db 127.0.0.1:15432 pid=8528)
 DETAIL:  
 SQL statement "UPDATE deadlock_entry_db_singleton_table SET d = d + 1 WHERE c =  $1 "
 PL/pgSQL function "function_volatile" line 3 at SQL statement

--- a/src/test/isolation2/expected/deadlock_under_entry_db_singleton.out
+++ b/src/test/isolation2/expected/deadlock_under_entry_db_singleton.out
@@ -1,0 +1,64 @@
+CREATE TABLE deadlock_entry_db_singleton_table (c int, d int);
+CREATE
+INSERT INTO deadlock_entry_db_singleton_table select i, i+1 from generate_series(1,10) i;
+INSERT 10
+
+CREATE FUNCTION function_volatile(x int) RETURNS int AS $$ /*in func*/ BEGIN /*in func*/ UPDATE deadlock_entry_db_singleton_table SET d = d + 1  WHERE c = $1; /*in func*/ RETURN $1 + 1; /*in func*/ END $$ /*in func*/ LANGUAGE plpgsql VOLATILE MODIFIES SQL DATA;
+CREATE
+
+-- inject fault on QD
+! gpfaultinjector -f transaction_start_under_entry_db_singleton -m async -y reset -o 0 -s 1;
+20170522:18:08:22:036621 gpfaultinjector:xzhangmac:xzhang-[INFO]:-Starting gpfaultinjector with args: -f transaction_start_under_entry_db_singleton -m async -y reset -o 0 -s 1
+20170522:18:08:22:036621 gpfaultinjector:xzhangmac:xzhang-[INFO]:-Injecting fault on content=-1:dbid=1:mode=s:status=u
+20170522:18:08:22:036621 gpfaultinjector:xzhangmac:xzhang-[INFO]:-DONE
+
+! gpfaultinjector -f transaction_start_under_entry_db_singleton -m async -y suspend -o 0 -s 1;
+20170522:18:08:23:036633 gpfaultinjector:xzhangmac:xzhang-[INFO]:-Starting gpfaultinjector with args: -f transaction_start_under_entry_db_singleton -m async -y suspend -o 0 -s 1
+20170522:18:08:23:036633 gpfaultinjector:xzhangmac:xzhang-[INFO]:-Injecting fault on content=-1:dbid=1:mode=s:status=u
+20170522:18:08:23:036633 gpfaultinjector:xzhangmac:xzhang-[INFO]:-DONE
+
+
+-- now, the QD should already hold RowExclusiveLock and ExclusiveLock on `deadlock_entry_db_singleton_table`
+-- the QE ENTRY_DB_SINGLETON will stop at the StartTransaction.
+1&:UPDATE deadlock_entry_db_singleton_table set d = d + 1 FROM (select 1 from deadlock_entry_db_singleton_table, function_volatile(5)) t;  <waiting ...>
+
+-- verify the fault hit
+! gpfaultinjector -f transaction_start_under_entry_db_singleton -m async -y status -o 0 -s 1;
+20170522:18:08:23:036655 gpfaultinjector:xzhangmac:xzhang-[INFO]:-Starting gpfaultinjector with args: -f transaction_start_under_entry_db_singleton -m async -y status -o 0 -s 1
+20170522:18:08:23:036655 gpfaultinjector:xzhangmac:xzhang-[INFO]:-Injecting fault on content=-1:dbid=1:mode=s:status=u
+20170522:18:08:23:036655 gpfaultinjector:xzhangmac:xzhang-[INFO]:-fault name:'transaction_start_under_entry_db_singleton' fault type:'suspend' ddl statement:'' database name:'' table name:'' occurrence:'-1' sleep time:'10' fault injection state:'triggered'  num times hit:'1' 
+20170522:18:08:23:036655 gpfaultinjector:xzhangmac:xzhang-[INFO]:-DONE
+
+
+-- in separate session, try to update the `deadlock_entry_db_singleton_table` table, and it will wait for ExclusiveLock on `deadlock_entry_db_singleton_table`
+2&: update deadlock_entry_db_singleton_table set d = d + 1;  <waiting ...>
+
+-- we expect to hit deadlock
+! gpfaultinjector -f transaction_start_under_entry_db_singleton -m async -y resume  -o 0 -s 1;
+20170522:18:08:24:036672 gpfaultinjector:xzhangmac:xzhang-[INFO]:-Starting gpfaultinjector with args: -f transaction_start_under_entry_db_singleton -m async -y resume -o 0 -s 1
+20170522:18:08:24:036672 gpfaultinjector:xzhangmac:xzhang-[INFO]:-Injecting fault on content=-1:dbid=1:mode=s:status=u
+20170522:18:08:24:036672 gpfaultinjector:xzhangmac:xzhang-[INFO]:-DONE
+
+! gpfaultinjector -f transaction_start_under_entry_db_singleton -m async -y reset -o 0 -s 1;
+20170522:18:08:24:036685 gpfaultinjector:xzhangmac:xzhang-[INFO]:-Starting gpfaultinjector with args: -f transaction_start_under_entry_db_singleton -m async -y reset -o 0 -s 1
+20170522:18:08:24:036685 gpfaultinjector:xzhangmac:xzhang-[INFO]:-Injecting fault on content=-1:dbid=1:mode=s:status=u
+20170522:18:08:24:036685 gpfaultinjector:xzhangmac:xzhang-[INFO]:-DONE
+
+
+-- verify the deadlock across multiple pids with same mpp session id
+with lock_on_deadlock_entry_db_singleton_table as (select * from pg_locks where relation = 'deadlock_entry_db_singleton_table'::regclass and gp_segment_id = -1) select count(*) as FoundDeadlockProcess from lock_on_deadlock_entry_db_singleton_table where granted = false and mppsessionid in ( select mppsessionid from lock_on_deadlock_entry_db_singleton_table where granted = true );
+founddeadlockprocess
+--------------------
+0                   
+(1 row)
+
+-- join the session 1 and session 2
+-- we expect to see an ERROR message here due to function_volatile function
+-- tried to update table from ENTRY_DB_SINGLETON (which is read-only) in session 1
+1<:  <... completed>
+ERROR:  function cannot execute on segment because it issues a non-SELECT statement  (entry db 127.0.0.1:15432 pid=36654)
+DETAIL:  
+SQL statement "UPDATE deadlock_entry_db_singleton_table SET d = d + 1 WHERE c =  $1 "
+PL/pgSQL function "function_volatile" line 3 at SQL statement
+2<:  <... completed>
+UPDATE 10

--- a/src/test/isolation2/expected/deadlock_under_entry_db_singleton.out
+++ b/src/test/isolation2/expected/deadlock_under_entry_db_singleton.out
@@ -23,25 +23,24 @@ CREATE
 INSERT INTO deadlock_entry_db_singleton_table select i, i+1 from generate_series(1,10) i;
 INSERT 10
 
--- Function that needs ExclusiceLock on a table.  Declare this
--- function volatile so that ENTRY_DB_SINGLETON process executes the
--- function and the lock is requested during execution of the fuction.
--- Without volatile, the lock is requested during plan generation of
--- the calling SQL statement and we don't get ENTRY_DB_SINGLETON
--- process.
+-- Function that needs ExclusiveLock on a table.  Use a non-SQL
+-- language for this function so that parser cannot understand its
+-- definition.  That way, ExclusiveLock is requested during during
+-- execution of the fuction.  If the lock is acquired during plan
+-- generation of the calling SQL statement, we don't get the deadlock.
 CREATE FUNCTION function_volatile(x int) RETURNS int AS $$ /*in func*/ BEGIN /*in func*/ UPDATE deadlock_entry_db_singleton_table SET d = d + 1  WHERE c = $1; /*in func*/ RETURN $1 + 1; /*in func*/ END $$ /*in func*/ LANGUAGE plpgsql VOLATILE MODIFIES SQL DATA;
 CREATE
 
 -- inject fault on QD
 ! gpfaultinjector -f transaction_start_under_entry_db_singleton -m async -y reset -o 0 -s 1;
-20170605:16:59:30:008493 gpfaultinjector:asimmac:apraveen-[INFO]:-Starting gpfaultinjector with args: -f transaction_start_under_entry_db_singleton -m async -y reset -o 0 -s 1
-20170605:16:59:30:008493 gpfaultinjector:asimmac:apraveen-[INFO]:-Injecting fault on content=-1:dbid=1:mode=s:status=u
-20170605:16:59:30:008493 gpfaultinjector:asimmac:apraveen-[INFO]:-DONE
+20170615:16:48:25:020364 gpfaultinjector::-[INFO]:-Starting gpfaultinjector with args: -f transaction_start_under_entry_db_singleton -m async -y reset -o 0 -s 1
+20170615:16:48:25:020364 gpfaultinjector::-[INFO]:-Injecting fault on content=-1:dbid=1:mode=s:status=u
+20170615:16:48:25:020364 gpfaultinjector::-[INFO]:-DONE
 
 ! gpfaultinjector -f transaction_start_under_entry_db_singleton -m async -y suspend -o 0 -s 1;
-20170605:16:59:30:008505 gpfaultinjector:asimmac:apraveen-[INFO]:-Starting gpfaultinjector with args: -f transaction_start_under_entry_db_singleton -m async -y suspend -o 0 -s 1
-20170605:16:59:30:008505 gpfaultinjector:asimmac:apraveen-[INFO]:-Injecting fault on content=-1:dbid=1:mode=s:status=u
-20170605:16:59:30:008505 gpfaultinjector:asimmac:apraveen-[INFO]:-DONE
+20170615:16:48:25:020376 gpfaultinjector::-[INFO]:-Starting gpfaultinjector with args: -f transaction_start_under_entry_db_singleton -m async -y suspend -o 0 -s 1
+20170615:16:48:25:020376 gpfaultinjector::-[INFO]:-Injecting fault on content=-1:dbid=1:mode=s:status=u
+20170615:16:48:25:020376 gpfaultinjector::-[INFO]:-DONE
 
 
 -- The QD should already hold RowExclusiveLock and ExclusiveLock on
@@ -51,10 +50,10 @@ CREATE
 
 -- verify the fault hit
 ! gpfaultinjector -f transaction_start_under_entry_db_singleton -m async -y status -o 0 -s 1;
-20170605:16:59:31:008529 gpfaultinjector:asimmac:apraveen-[INFO]:-Starting gpfaultinjector with args: -f transaction_start_under_entry_db_singleton -m async -y status -o 0 -s 1
-20170605:16:59:31:008529 gpfaultinjector:asimmac:apraveen-[INFO]:-Injecting fault on content=-1:dbid=1:mode=s:status=u
-20170605:16:59:31:008529 gpfaultinjector:asimmac:apraveen-[INFO]:-fault name:'transaction_start_under_entry_db_singleton' fault type:'suspend' ddl statement:'' database name:'' table name:'' occurrence:'-1' sleep time:'10' fault injection state:'triggered'  num times hit:'1' 
-20170605:16:59:31:008529 gpfaultinjector:asimmac:apraveen-[INFO]:-DONE
+20170615:16:48:26:020397 gpfaultinjector::-[INFO]:-Starting gpfaultinjector with args: -f transaction_start_under_entry_db_singleton -m async -y status -o 0 -s 1
+20170615:16:48:26:020397 gpfaultinjector::-[INFO]:-Injecting fault on content=-1:dbid=1:mode=s:status=u
+20170615:16:48:26:020397 gpfaultinjector::-[INFO]:-fault name:'transaction_start_under_entry_db_singleton' fault type:'suspend' ddl statement:'' database name:'' table name:'' occurrence:'-1' sleep time:'10' fault injection state:'triggered'  num times hit:'1' 
+20170615:16:48:26:020397 gpfaultinjector::-[INFO]:-DONE
 
 
 -- This session will wait for ExclusiveLock on
@@ -68,14 +67,14 @@ CREATE
 -- ENTRY_DB_SINGLETON reader because its writer already holds the
 -- lock.  Otherwise, we may have a deadlock.
 ! gpfaultinjector -f transaction_start_under_entry_db_singleton -m async -y resume  -o 0 -s 1;
-20170605:16:59:32:008543 gpfaultinjector:asimmac:apraveen-[INFO]:-Starting gpfaultinjector with args: -f transaction_start_under_entry_db_singleton -m async -y resume -o 0 -s 1
-20170605:16:59:32:008543 gpfaultinjector:asimmac:apraveen-[INFO]:-Injecting fault on content=-1:dbid=1:mode=s:status=u
-20170605:16:59:32:008543 gpfaultinjector:asimmac:apraveen-[INFO]:-DONE
+20170615:16:48:27:020411 gpfaultinjector::-[INFO]:-Starting gpfaultinjector with args: -f transaction_start_under_entry_db_singleton -m async -y resume -o 0 -s 1
+20170615:16:48:27:020411 gpfaultinjector::-[INFO]:-Injecting fault on content=-1:dbid=1:mode=s:status=u
+20170615:16:48:27:020411 gpfaultinjector::-[INFO]:-DONE
 
 ! gpfaultinjector -f transaction_start_under_entry_db_singleton -m async -y reset -o 0 -s 1;
-20170605:16:59:32:008555 gpfaultinjector:asimmac:apraveen-[INFO]:-Starting gpfaultinjector with args: -f transaction_start_under_entry_db_singleton -m async -y reset -o 0 -s 1
-20170605:16:59:32:008555 gpfaultinjector:asimmac:apraveen-[INFO]:-Injecting fault on content=-1:dbid=1:mode=s:status=u
-20170605:16:59:32:008555 gpfaultinjector:asimmac:apraveen-[INFO]:-DONE
+20170615:16:48:27:020423 gpfaultinjector::-[INFO]:-Starting gpfaultinjector with args: -f transaction_start_under_entry_db_singleton -m async -y reset -o 0 -s 1
+20170615:16:48:27:020423 gpfaultinjector::-[INFO]:-Injecting fault on content=-1:dbid=1:mode=s:status=u
+20170615:16:48:27:020423 gpfaultinjector::-[INFO]:-DONE
 
 
 -- verify the deadlock across multiple pids with same mpp session id
@@ -89,7 +88,7 @@ founddeadlockprocess
 -- we expect to see an ERROR message here due to function_volatile function
 -- tried to update table from ENTRY_DB_SINGLETON (which is read-only) in session1
 1<:  <... completed>
-ERROR:  function cannot execute on segment because it issues a non-SELECT statement  (entry db 127.0.0.1:15432 pid=8528)
+ERROR:  function cannot execute on segment because it issues a non-SELECT statement  (entry db 127.0.0.1:15432 pid=20396)
 DETAIL:  
 SQL statement "UPDATE deadlock_entry_db_singleton_table SET d = d + 1 WHERE c =  $1 "
 PL/pgSQL function "function_volatile" line 3 at SQL statement

--- a/src/test/isolation2/expected/starve_case.out
+++ b/src/test/isolation2/expected/starve_case.out
@@ -1,0 +1,74 @@
+-- This test validate NO starvation of waiting sessions
+-- due to READER ignore waitMask
+
+create table starve (c int);
+CREATE
+create table starve_helper (c int);
+CREATE
+
+CREATE OR REPLACE FUNCTION function_starve_volatile(x int) RETURNS int AS $$ /*in func*/ declare /*in func*/ v int; /*in func*/ BEGIN /*in func*/ SELECT count(c) into v FROM starve; /*in func*/ RETURN $1 + 1; /*in func*/ END $$ /*in func*/ LANGUAGE plpgsql VOLATILE MODIFIES SQL DATA;
+CREATE
+
+-- hold access shared lock
+1: begin;
+BEGIN
+1: select * from starve; 
+-- waiting on access exclusive lock
+2: begin;
+c
+-
+(0 rows)
+2>: alter table starve rename column c to d;  <waiting ...>
+
+select pg_sleep(1);
+pg_sleep
+--------
+        
+(1 row)
+
+-- check the locks, expect session 2 wait
+-- expect: 1 row with AccessExclusiveLock
+select mode from pg_locks where granted=false and locktype = 'relation' and gp_segment_id = -1;
+mode               
+-------------------
+AccessExclusiveLock
+(1 row)
+
+-- ENTRY_DB_SINGLETON reader request access share lock
+3: begin;
+BEGIN
+3>: select * from starve_helper, function_starve_volatile(5);  <waiting ...>
+
+select pg_sleep(1);
+pg_sleep
+--------
+        
+(1 row)
+
+-- check the locks again, expect both session 2 and session 3 wait
+-- expect: 2 rows with AccessExclusiveLock and AccessSharedLock
+select mode from pg_locks where granted=false and locktype = 'relation' and gp_segment_id = -1;
+mode               
+-------------------
+AccessExclusiveLock
+AccessShareLock    
+(2 rows)
+
+-- session 1 release lock
+1: commit;
+COMMIT
+
+-- session 2 join
+2<:  <... completed>
+ALTER
+2: commit;
+COMMIT
+
+-- session 3 join
+-- CORRECT BEHAVIOR: session 3 should wait for session 2 because of waitMask
+-- conflict, then we should see error column 'c' doesn't exist
+3<:  <... completed>
+ERROR:  column "c" does not exist  (entry db 127.0.0.1:15432 pid=14591)
+DETAIL:  PL/pgSQL function "function_starve_volatile" line 5 at SQL statement
+3: commit;
+COMMIT

--- a/src/test/isolation2/expected/starve_case.out
+++ b/src/test/isolation2/expected/starve_case.out
@@ -1,74 +1,159 @@
--- This test validate NO starvation of waiting sessions
--- due to READER ignore waitMask
+--
+-- Test to ensure that reader processes do not cause starvation of
+-- processes already waiting on a lock.  Readers must wait on a lock
+-- if their writer does not already hold the lock and the requested
+-- lockmode conflicts with existing waiter's lockmode (waitMask
+-- conflict).
+--
 
 create table starve (c int);
 CREATE
-create table starve_helper (c int);
+create table starve_helper (name varchar, sessionid int);
 CREATE
 
-CREATE OR REPLACE FUNCTION function_starve_volatile(x int) RETURNS int AS $$ /*in func*/ declare /*in func*/ v int; /*in func*/ BEGIN /*in func*/ SELECT count(c) into v FROM starve; /*in func*/ RETURN $1 + 1; /*in func*/ END $$ /*in func*/ LANGUAGE plpgsql VOLATILE MODIFIES SQL DATA;
+-- Function to access a table so that AccessShare lock is requested on
+-- the table.  Declare this function volatile so that
+-- ENTRY_DB_SINGLETON process executes the function and the lock is
+-- requested during execution of the fuction.  Without volatile, the
+-- lock is requested during plan generation of the calling SQL
+-- statement and we don't get ENTRY_DB_SINGLETON process.
+CREATE OR REPLACE FUNCTION function_starve_volatile(x int) /*in func*/ RETURNS int AS $$ /*in func*/ declare /*in func*/ v int; /*in func*/ BEGIN /*in func*/ SELECT count(c) into v FROM starve; /*in func*/ RETURN $1 + 1; /*in func*/ END $$ /*in func*/ LANGUAGE plpgsql VOLATILE MODIFIES SQL DATA;
 CREATE
 
--- hold access shared lock
+-- Function to wait until a specific session is reported as waiting on
+-- a lock.  The session's mppsessionid is obtained from starve_helper
+-- table.  Timeout if no locks are awaited within 2 seconds.
+CREATE OR REPLACE FUNCTION wait_until_locks_awaited(sess_name varchar) /*in func*/ RETURNS bool AS $$ /*in func*/ declare /*in func*/ num_awaited int := 0; /*in func*/ iterations int := 0; /*in func*/ begin /*in func*/ while num_awaited = 0 and iterations < 20 loop /*in func*/ with locks_awaited as /*in func*/ (select * from pg_locks where granted = false and gp_segment_id = -1) /*in func*/ select count(*) into num_awaited from starve_helper s where /*in func*/ s.name = sess_name and s.sessionid in /*in func*/ (select mppsessionid from locks_awaited); /*in func*/ perform pg_sleep(.1); /*in func*/ iterations := iterations + 1; /*in func*/ end loop; /*in func*/ return num_awaited > 0; /*in func*/ end $$ /*in func*/ LANGUAGE plpgsql STABLE;
+CREATE
+
+-- Hold access shared lock, so that session2 must wait.
 1: begin;
 BEGIN
-1: select * from starve; 
--- waiting on access exclusive lock
-2: begin;
+1: select * from starve;
 c
 -
 (0 rows)
+
+2: insert into starve_helper select 'session2', setting::int from pg_settings where name = 'gp_session_id';
+INSERT 1
+-- Wait on access exclusive lock.
+2: begin;
+BEGIN
 2>: alter table starve rename column c to d;  <waiting ...>
 
-select pg_sleep(1);
-pg_sleep
---------
-        
+select wait_until_locks_awaited('session2');
+wait_until_locks_awaited
+------------------------
+t                       
 (1 row)
 
--- check the locks, expect session 2 wait
--- expect: 1 row with AccessExclusiveLock
-select mode from pg_locks where granted=false and locktype = 'relation' and gp_segment_id = -1;
-mode               
--------------------
-AccessExclusiveLock
-(1 row)
-
--- ENTRY_DB_SINGLETON reader request access share lock
+3: insert into starve_helper select 'session3', setting::int from pg_settings where name = 'gp_session_id';
+INSERT 1
+-- ENTRY_DB_SINGLETON reader requests access share lock on table
+-- starve.  The lockmode conflicts with already existing waiter's
+-- lockmode (access exclusive).  And the writer is not holding any
+-- lock on starve table.  So the reader must wait.
 3: begin;
 BEGIN
 3>: select * from starve_helper, function_starve_volatile(5);  <waiting ...>
 
-select pg_sleep(1);
-pg_sleep
---------
-        
+select wait_until_locks_awaited('session3');
+wait_until_locks_awaited
+------------------------
+t                       
 (1 row)
 
--- check the locks again, expect both session 2 and session 3 wait
+-- Check the lock table, expect both session2 and session3 to wait.
 -- expect: 2 rows with AccessExclusiveLock and AccessSharedLock
-select mode from pg_locks where granted=false and locktype = 'relation' and gp_segment_id = -1;
+select mode from pg_locks where granted=false and relation='starve'::regclass and gp_segment_id=-1;
 mode               
 -------------------
-AccessExclusiveLock
 AccessShareLock    
+AccessExclusiveLock
 (2 rows)
 
--- session 1 release lock
+-- Let everyone move forward.
 1: commit;
 COMMIT
 
--- session 2 join
+-- session2 is granted the lock on starve table first.
 2<:  <... completed>
 ALTER
+2: select mode from pg_locks where granted=false and relation='starve'::regclass and gp_segment_id=-1;
+mode           
+---------------
+AccessShareLock
+(1 row)
 2: commit;
 COMMIT
 
--- session 3 join
--- CORRECT BEHAVIOR: session 3 should wait for session 2 because of waitMask
--- conflict, then we should see error column 'c' doesn't exist
+-- session3 is granted the lock after session2 commits.  We should
+-- see error column 'c' doesn't exist because session2 renamed it.
 3<:  <... completed>
-ERROR:  column "c" does not exist  (entry db 127.0.0.1:15432 pid=14591)
+ERROR:  column "c" does not exist  (entry db 127.0.0.1:15432 pid=16367)
 DETAIL:  PL/pgSQL function "function_starve_volatile" line 5 at SQL statement
+3: commit;
+COMMIT
+
+
+--
+-- Test to ensure that writers do not starve processes already waiting
+-- on a lock in case of waitMask conflict.
+--
+truncate table starve_helper;
+TRUNCATE
+
+-- Hold access shared lock, so that session2 must wait.
+1: begin;
+BEGIN
+1: select * from starve;
+d
+-
+(0 rows)
+
+2: insert into starve_helper select 'session2', setting::int from pg_settings where name = 'gp_session_id';
+INSERT 1
+-- Wait on access exclusive lock.
+2: begin;
+BEGIN
+2>: alter table starve add column e int default 0;  <waiting ...>
+
+select wait_until_locks_awaited('session2');
+wait_until_locks_awaited
+------------------------
+t                       
+(1 row)
+
+3: insert into starve_helper select 'session3', setting::int from pg_settings where name = 'gp_session_id';
+INSERT 1
+3: begin;
+BEGIN
+-- Wait on RowExclusiveLock on table starve because session2 is
+-- waiting on the same lock with a conflicting lockmode.
+3>: insert into starve values (1), (2);  <waiting ...>
+
+select wait_until_locks_awaited('session3');
+wait_until_locks_awaited
+------------------------
+t                       
+(1 row)
+
+1: commit;
+COMMIT
+-- Session2 must go first.
+2<:  <... completed>
+ALTER
+-- Ensure that session3 is still waiting.
+2: select mode from pg_locks where granted=false and relation='starve'::regclass and gp_segment_id=-1;
+mode            
+----------------
+RowExclusiveLock
+(1 row)
+2: commit;
+COMMIT
+
+-- Session3 gets the lock only after session2 commits.
+3<:  <... completed>
+INSERT 2
 3: commit;
 COMMIT

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -1,4 +1,5 @@
 test: deadlock_under_entry_db_singleton
+test: starve_case
 test: commit_transaction_block_checkpoint
 test: pg_views_concurrent_drop
 test: resource_queue

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -1,3 +1,4 @@
+test: deadlock_under_entry_db_singleton
 test: commit_transaction_block_checkpoint
 test: pg_views_concurrent_drop
 test: resource_queue

--- a/src/test/isolation2/sql/deadlock_under_entry_db_singleton.sql
+++ b/src/test/isolation2/sql/deadlock_under_entry_db_singleton.sql
@@ -1,6 +1,32 @@
+-- Test to validate that ENTRY_DB_SINGLETON reader does not cause a
+-- deadlock.
+--
+-- The deadlock used to happen when ENTRY_DB_SINGLETON enters
+-- LockAcquire with its writer already holding the lock.  And the
+-- requested lockmode conflicts with another session's requested
+-- lockmode who is waiting on the same lock.  The waitMask check in
+-- LockAcquire would put the ENTRY_DB_SINGLETON into wait queue.  If
+-- the ENTRY_DB_SINGLETON is supposed to produce some tuples that need
+-- to be consumed by other nodes in the plan, either QEs or the writer
+-- QD may wait for ENTRY_DB_SINGLETON and we will have a wait cycle,
+-- causing deadlock.
+--
+-- This test creates one such scenario using a volatile funciton.  It
+-- is critical that the function be volatile, otherwise,
+-- ENTRY_DB_SIGNLETON reader is not spawned to execute the query.
+--
+-- This thread on gpdb-dev has more details:
+-- https://groups.google.com/a/greenplum.org/d/msg/gpdb-dev/OS1-ODIK0P4/ZIzayBbMBwAJ
+
 CREATE TABLE deadlock_entry_db_singleton_table (c int, d int);
 INSERT INTO deadlock_entry_db_singleton_table select i, i+1 from generate_series(1,10) i;
 
+-- Function that needs ExclusiceLock on a table.  Declare this
+-- function volatile so that ENTRY_DB_SINGLETON process executes the
+-- function and the lock is requested during execution of the fuction.
+-- Without volatile, the lock is requested during plan generation of
+-- the calling SQL statement and we don't get ENTRY_DB_SINGLETON
+-- process.
 CREATE FUNCTION function_volatile(x int) RETURNS int AS $$ /*in func*/
 BEGIN /*in func*/
 	UPDATE deadlock_entry_db_singleton_table SET d = d + 1  WHERE c = $1; /*in func*/
@@ -12,29 +38,37 @@ LANGUAGE plpgsql VOLATILE MODIFIES SQL DATA;
 ! gpfaultinjector -f transaction_start_under_entry_db_singleton -m async -y reset -o 0 -s 1;
 ! gpfaultinjector -f transaction_start_under_entry_db_singleton -m async -y suspend -o 0 -s 1;
 
--- now, the QD should already hold RowExclusiveLock and ExclusiveLock on `deadlock_entry_db_singleton_table`
--- the QE ENTRY_DB_SINGLETON will stop at the StartTransaction.
+-- The QD should already hold RowExclusiveLock and ExclusiveLock on
+-- deadlock_entry_db_singleton_table and the QE ENTRY_DB_SINGLETON
+-- will stop at in StartTransaction due to suspend fault.
 1&:UPDATE deadlock_entry_db_singleton_table set d = d + 1 FROM (select 1 from deadlock_entry_db_singleton_table, function_volatile(5)) t;
 
 -- verify the fault hit
 ! gpfaultinjector -f transaction_start_under_entry_db_singleton -m async -y status -o 0 -s 1;
 
--- in separate session, try to update the `deadlock_entry_db_singleton_table` table, and it will wait for ExclusiveLock on `deadlock_entry_db_singleton_table`
+-- This session will wait for ExclusiveLock on
+-- deadlock_entry_db_singleton_table.
 2&: update deadlock_entry_db_singleton_table set d = d + 1;
 
--- we expect to hit deadlock
+-- The ENTRY_DB_SINGLETON will acquire exclusive lock on
+-- deadlock_entry_db_singleton_table.  The lockmode conflicts with the
+-- lock's waitMask due to session2 already waiting for the same lock.
+-- In spite of the waitMask conflict the lock should be granted to
+-- ENTRY_DB_SINGLETON reader because its writer already holds the
+-- lock.  Otherwise, we may have a deadlock.
 ! gpfaultinjector -f transaction_start_under_entry_db_singleton -m async -y resume  -o 0 -s 1;
 ! gpfaultinjector -f transaction_start_under_entry_db_singleton -m async -y reset -o 0 -s 1;
 
 -- verify the deadlock across multiple pids with same mpp session id
-with lock_on_deadlock_entry_db_singleton_table as (select * from pg_locks where relation = 'deadlock_entry_db_singleton_table'::regclass and gp_segment_id = -1) 
-select count(*) as FoundDeadlockProcess from lock_on_deadlock_entry_db_singleton_table 
+with lock_on_deadlock_entry_db_singleton_table as (select * from pg_locks
+where relation = 'deadlock_entry_db_singleton_table'::regclass and gp_segment_id = -1)
+select count(*) as FoundDeadlockProcess from lock_on_deadlock_entry_db_singleton_table
 where granted = false and mppsessionid in (
 	select mppsessionid from lock_on_deadlock_entry_db_singleton_table where granted = true
 );
 
--- join the session 1 and session 2
+-- join the session1 and session2
 -- we expect to see an ERROR message here due to function_volatile function
--- tried to update table from ENTRY_DB_SINGLETON (which is read-only) in session 1
+-- tried to update table from ENTRY_DB_SINGLETON (which is read-only) in session1
 1<:
 2<:

--- a/src/test/isolation2/sql/deadlock_under_entry_db_singleton.sql
+++ b/src/test/isolation2/sql/deadlock_under_entry_db_singleton.sql
@@ -1,0 +1,40 @@
+CREATE TABLE deadlock_entry_db_singleton_table (c int, d int);
+INSERT INTO deadlock_entry_db_singleton_table select i, i+1 from generate_series(1,10) i;
+
+CREATE FUNCTION function_volatile(x int) RETURNS int AS $$ /*in func*/
+BEGIN /*in func*/
+	UPDATE deadlock_entry_db_singleton_table SET d = d + 1  WHERE c = $1; /*in func*/
+	RETURN $1 + 1; /*in func*/
+END $$ /*in func*/
+LANGUAGE plpgsql VOLATILE MODIFIES SQL DATA;
+
+-- inject fault on QD
+! gpfaultinjector -f transaction_start_under_entry_db_singleton -m async -y reset -o 0 -s 1;
+! gpfaultinjector -f transaction_start_under_entry_db_singleton -m async -y suspend -o 0 -s 1;
+
+-- now, the QD should already hold RowExclusiveLock and ExclusiveLock on `deadlock_entry_db_singleton_table`
+-- the QE ENTRY_DB_SINGLETON will stop at the StartTransaction.
+1&:UPDATE deadlock_entry_db_singleton_table set d = d + 1 FROM (select 1 from deadlock_entry_db_singleton_table, function_volatile(5)) t;
+
+-- verify the fault hit
+! gpfaultinjector -f transaction_start_under_entry_db_singleton -m async -y status -o 0 -s 1;
+
+-- in separate session, try to update the `deadlock_entry_db_singleton_table` table, and it will wait for ExclusiveLock on `deadlock_entry_db_singleton_table`
+2&: update deadlock_entry_db_singleton_table set d = d + 1;
+
+-- we expect to hit deadlock
+! gpfaultinjector -f transaction_start_under_entry_db_singleton -m async -y resume  -o 0 -s 1;
+! gpfaultinjector -f transaction_start_under_entry_db_singleton -m async -y reset -o 0 -s 1;
+
+-- verify the deadlock across multiple pids with same mpp session id
+with lock_on_deadlock_entry_db_singleton_table as (select * from pg_locks where relation = 'deadlock_entry_db_singleton_table'::regclass and gp_segment_id = -1) 
+select count(*) as FoundDeadlockProcess from lock_on_deadlock_entry_db_singleton_table 
+where granted = false and mppsessionid in (
+	select mppsessionid from lock_on_deadlock_entry_db_singleton_table where granted = true
+);
+
+-- join the session 1 and session 2
+-- we expect to see an ERROR message here due to function_volatile function
+-- tried to update table from ENTRY_DB_SINGLETON (which is read-only) in session 1
+1<:
+2<:

--- a/src/test/isolation2/sql/deadlock_under_entry_db_singleton.sql
+++ b/src/test/isolation2/sql/deadlock_under_entry_db_singleton.sql
@@ -21,12 +21,11 @@
 CREATE TABLE deadlock_entry_db_singleton_table (c int, d int);
 INSERT INTO deadlock_entry_db_singleton_table select i, i+1 from generate_series(1,10) i;
 
--- Function that needs ExclusiceLock on a table.  Declare this
--- function volatile so that ENTRY_DB_SINGLETON process executes the
--- function and the lock is requested during execution of the fuction.
--- Without volatile, the lock is requested during plan generation of
--- the calling SQL statement and we don't get ENTRY_DB_SINGLETON
--- process.
+-- Function that needs ExclusiveLock on a table.  Use a non-SQL
+-- language for this function so that parser cannot understand its
+-- definition.  That way, ExclusiveLock is requested during during
+-- execution of the fuction.  If the lock is acquired during plan
+-- generation of the calling SQL statement, we don't get the deadlock.
 CREATE FUNCTION function_volatile(x int) RETURNS int AS $$ /*in func*/
 BEGIN /*in func*/
 	UPDATE deadlock_entry_db_singleton_table SET d = d + 1  WHERE c = $1; /*in func*/

--- a/src/test/isolation2/sql/starve_case.sql
+++ b/src/test/isolation2/sql/starve_case.sql
@@ -1,0 +1,51 @@
+-- This test validate NO starvation of waiting sessions
+-- due to READER ignore waitMask
+
+create table starve (c int);
+create table starve_helper (c int);
+
+CREATE OR REPLACE FUNCTION function_starve_volatile(x int) RETURNS int AS $$ /*in func*/
+declare /*in func*/
+  v int; /*in func*/
+BEGIN /*in func*/
+	SELECT count(c) into v FROM starve; /*in func*/
+  RETURN $1 + 1; /*in func*/
+END $$ /*in func*/
+LANGUAGE plpgsql VOLATILE MODIFIES SQL DATA;
+
+-- hold access shared lock
+1: begin;
+1: select * from starve; 
+
+-- waiting on access exclusive lock
+2: begin;
+2>: alter table starve rename column c to d;
+
+select pg_sleep(1);
+
+-- check the locks, expect session 2 wait
+-- expect: 1 row with AccessExclusiveLock
+select mode from pg_locks where granted=false and locktype = 'relation' and gp_segment_id = -1;
+
+-- ENTRY_DB_SINGLETON reader request access share lock
+3: begin;
+3>: select * from starve_helper, function_starve_volatile(5);
+
+select pg_sleep(1);
+
+-- check the locks again, expect both session 2 and session 3 wait
+-- expect: 2 rows with AccessExclusiveLock and AccessSharedLock
+select mode from pg_locks where granted=false and locktype = 'relation' and gp_segment_id = -1;
+
+-- session 1 release lock
+1: commit;
+
+-- session 2 join
+2<:
+2: commit;
+
+-- session 3 join
+-- CORRECT BEHAVIOR: session 3 should wait for session 2 because of waitMask
+-- conflict, then we should see error column 'c' doesn't exist
+3<:
+3: commit;

--- a/src/test/isolation2/sql/starve_case.sql
+++ b/src/test/isolation2/sql/starve_case.sql
@@ -1,51 +1,123 @@
--- This test validate NO starvation of waiting sessions
--- due to READER ignore waitMask
+--
+-- Test to ensure that reader processes do not cause starvation of
+-- processes already waiting on a lock.  Readers must wait on a lock
+-- if their writer does not already hold the lock and the requested
+-- lockmode conflicts with existing waiter's lockmode (waitMask
+-- conflict).
+--
 
 create table starve (c int);
-create table starve_helper (c int);
+create table starve_helper (name varchar, sessionid int);
 
-CREATE OR REPLACE FUNCTION function_starve_volatile(x int) RETURNS int AS $$ /*in func*/
+-- Function to access a table so that AccessShare lock is requested on
+-- the table.  Declare this function volatile so that
+-- ENTRY_DB_SINGLETON process executes the function and the lock is
+-- requested during execution of the fuction.  Without volatile, the
+-- lock is requested during plan generation of the calling SQL
+-- statement and we don't get ENTRY_DB_SINGLETON process.
+CREATE OR REPLACE FUNCTION function_starve_volatile(x int) /*in func*/
+RETURNS int AS $$ /*in func*/
 declare /*in func*/
   v int; /*in func*/
 BEGIN /*in func*/
 	SELECT count(c) into v FROM starve; /*in func*/
-  RETURN $1 + 1; /*in func*/
+	RETURN $1 + 1; /*in func*/
 END $$ /*in func*/
 LANGUAGE plpgsql VOLATILE MODIFIES SQL DATA;
 
--- hold access shared lock
-1: begin;
-1: select * from starve; 
+-- Function to wait until a specific session is reported as waiting on
+-- a lock.  The session's mppsessionid is obtained from starve_helper
+-- table.  Timeout if no locks are awaited within 2 seconds.
+CREATE OR REPLACE FUNCTION wait_until_locks_awaited(sess_name varchar) /*in func*/
+RETURNS bool AS $$ /*in func*/
+declare /*in func*/
+	num_awaited int := 0; /*in func*/
+	iterations int := 0; /*in func*/
+begin /*in func*/
+	while num_awaited = 0 and iterations < 20 loop /*in func*/
+		with locks_awaited as /*in func*/
+		(select * from pg_locks where granted = false and gp_segment_id = -1) /*in func*/
+		select count(*) into num_awaited from starve_helper s where /*in func*/
+		s.name = sess_name and s.sessionid in /*in func*/
+		(select mppsessionid from locks_awaited); /*in func*/
+		perform pg_sleep(.1); /*in func*/
+		iterations := iterations + 1; /*in func*/
+	end loop; /*in func*/
+	return num_awaited > 0; /*in func*/
+end $$ /*in func*/
+LANGUAGE plpgsql STABLE;
 
--- waiting on access exclusive lock
+-- Hold access shared lock, so that session2 must wait.
+1: begin;
+1: select * from starve;
+
+2: insert into starve_helper select 'session2', setting::int from pg_settings where name = 'gp_session_id';
+-- Wait on access exclusive lock.
 2: begin;
 2>: alter table starve rename column c to d;
 
-select pg_sleep(1);
+select wait_until_locks_awaited('session2');
 
--- check the locks, expect session 2 wait
--- expect: 1 row with AccessExclusiveLock
-select mode from pg_locks where granted=false and locktype = 'relation' and gp_segment_id = -1;
-
--- ENTRY_DB_SINGLETON reader request access share lock
+3: insert into starve_helper select 'session3', setting::int from pg_settings where name = 'gp_session_id';
+-- ENTRY_DB_SINGLETON reader requests access share lock on table
+-- starve.  The lockmode conflicts with already existing waiter's
+-- lockmode (access exclusive).  And the writer is not holding any
+-- lock on starve table.  So the reader must wait.
 3: begin;
 3>: select * from starve_helper, function_starve_volatile(5);
 
-select pg_sleep(1);
+select wait_until_locks_awaited('session3');
 
--- check the locks again, expect both session 2 and session 3 wait
+-- Check the lock table, expect both session2 and session3 to wait.
 -- expect: 2 rows with AccessExclusiveLock and AccessSharedLock
-select mode from pg_locks where granted=false and locktype = 'relation' and gp_segment_id = -1;
+select mode from pg_locks where granted=false and relation='starve'::regclass and gp_segment_id=-1;
 
--- session 1 release lock
+-- Let everyone move forward.
 1: commit;
 
--- session 2 join
+-- session2 is granted the lock on starve table first.
 2<:
+2: select mode from pg_locks where granted=false and relation='starve'::regclass and gp_segment_id=-1;
 2: commit;
 
--- session 3 join
--- CORRECT BEHAVIOR: session 3 should wait for session 2 because of waitMask
--- conflict, then we should see error column 'c' doesn't exist
+-- session3 is granted the lock after session2 commits.  We should
+-- see error column 'c' doesn't exist because session2 renamed it.
+3<:
+3: commit;
+
+
+--
+-- Test to ensure that writers do not starve processes already waiting
+-- on a lock in case of waitMask conflict.
+--
+truncate table starve_helper;
+
+-- Hold access shared lock, so that session2 must wait.
+1: begin;
+1: select * from starve;
+
+2: insert into starve_helper select 'session2', setting::int from pg_settings where name = 'gp_session_id';
+-- Wait on access exclusive lock.
+2: begin;
+2>: alter table starve add column e int default 0;
+
+select wait_until_locks_awaited('session2');
+
+3: insert into starve_helper select 'session3', setting::int from pg_settings where name = 'gp_session_id';
+3: begin;
+-- Wait on RowExclusiveLock on table starve because session2 is
+-- waiting on the same lock with a conflicting lockmode.
+3>: insert into starve values (1), (2);
+
+select wait_until_locks_awaited('session3');
+
+1: commit;
+-- Session2 must go first.
+2<:
+-- Ensure that session3 is still waiting.
+2: select mode from pg_locks where granted=false and relation='starve'::regclass and gp_segment_id=-1;
+2: commit;
+
+-- Session3 gets the lock only after session2 commits.
 3<:
 3: commit;


### PR DESCRIPTION
Original deadlock is caused by a reader requesting a lock which is already held
by the writer of the same MPP session, and another session is waiting for a
conflicting mode on the same lock.

The fix is to avoid checking waitMask conflicts for reader (i.e. MyProc is
different from lockHolderProcPtr).

Detailed discussion of the deadlock issue is at:
https://groups.google.com/a/greenplum.org/d/msg/gpdb-dev/OS1-ODIK0P4/ZIzayBbMBwAJ

Signed-off-by: Xin Zhang <xzhang@pivotal.io>