### PR TITLE
GPDB DOCS - new GUCs from 4.3.x and mdcache

### DIFF
--- a/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-notes.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-notes.xml
@@ -3,8 +3,7 @@
 <topic id="topic1">
   <title>Considerations when Using GPORCA</title>
   <abstract>
-    <shortdesc> To execute queries optimally with GPORCA, query criteria to
-      consider. </shortdesc>
+    <shortdesc> To execute queries optimally with GPORCA, query criteria to consider. </shortdesc>
   </abstract>
   <body>
     <p>Ensure the following criteria are met:<ul id="ul_bpd_4rb_kr">
@@ -23,36 +22,51 @@
       table schema. </p>
     <p>These server configuration parameters affect GPORCA query processing.</p>
     <ul id="ul_jt3_nnq_1y">
-      <li>The parameter <codeph>optimizer_join_order_threshold</codeph> specifies the maximum number
-        of join children for which GPORCA uses the dynamic programming-based
-        join ordering algorithm.</li>
-      <li>The parameter <codeph>optimizer_parallel_union</codeph> controls the amount of
-        parallelization that occurs for queries that contain a <codeph>UNION</codeph> or
-          <codeph>UNION ALL</codeph> clause. When the value is <codeph>on</codeph>, Pivotal Query
-        Optimizer can generate a query plan the child operations of a <codeph>UNION</codeph> or
-          <codeph>UNION ALL</codeph> operation execute in parallel on segment instances. </li>
-      <li>The parameter <codeph>optimizer_sort_factor</codeph> controls the cost factor that Pivotal
-        Query Optimizer applies to sorting operations during query optimization. The cost factor can
-        be adjusted for queries when data skew is present. </li>
+      <li><codeph>optimizer_cte_inlining_bound</codeph> controls the amount of inlining performed
+        for common table expression (CTE) queries (queries that contain a <codeph>WHERE</codeph>
+        clause).</li>
+      <li><codeph>optimizer_force_multistage_agg</codeph> forces GPORCA to chooses 3 stage aggregate
+        plan for a scalar distinct qualified aggregate. </li>
+      <li><codeph>optimizer_force_three_stage_scalar_dqa</codeph> forces GPORCA to chooses a plan
+        with multistage aggregates when such a plan alternative is generated. </li>
+      <li><codeph>optimizer_join_order_threshold</codeph> specifies the maximum number of join
+        children for which GPORCA uses the dynamic programming-based join ordering algorithm.</li>
+      <li><codeph>optimizer_nestloop_factor</codeph> controls nested loop join cost factor to apply
+        to during query optimization.</li>
+      <li><codeph>optimizer_parallel_union</codeph> controls the amount of parallelization that
+        occurs for queries that contain a <codeph>UNION</codeph> or <codeph>UNION ALL</codeph>
+        clause. When the value is <codeph>on</codeph>, GPORCA can generate a query plan the child
+        operations of a <codeph>UNION</codeph> or <codeph>UNION ALL</codeph> operation execute in
+        parallel on segment instances. </li>
+      <li><codeph>optimizer_sort_factor</codeph> controls the cost factor that GPORCA applies to
+        sorting operations during query optimization. The cost factor can be adjusted for queries
+        when data skew is present. </li>
     </ul>
-    <p> For information about the parameter, see the <cite>Greenplum Database Reference
-      Guide</cite>.</p>
-    <p>GPORCA generates minidumps to describe the optimization context for a
-      given query. The minidump files are used by Pivotal support to analyze Greenplum Database
-      issues. The information in the file is not in a format that can be easily used by customers
-      for debugging or troubleshooting. The minidump file is located under the master data directory
-      and uses the following naming format:</p>
+    <p>These server configuration parameters control the display and logging of information.</p>
+    <ul id="ul_t3j_fhw_xz">
+      <li><codeph>optimizer_print_missing_stats</codeph> controls the display of column information
+        about columns with missing statistics for a query (default is <codeph>true</codeph>)</li>
+      <li><codeph>optimizer_print_optimization_stats</codeph> controls the logging of GPORCA query
+        optimization metrics for a query (default is <codeph>off</codeph>)</li>
+    </ul>
+    <p> For information about the parameters, see the <cite>Greenplum Database Reference
+        Guide</cite>.</p>
+    <p>GPORCA generates minidumps to describe the optimization context for a given query. The
+      minidump files are used by Pivotal support to analyze Greenplum Database issues. The
+      information in the file is not in a format that can be easily used by customers for debugging
+      or troubleshooting. The minidump file is located under the master data directory and uses the
+      following naming format:</p>
     <p>
       <codeph>Minidump_<varname>date</varname>_<varname>time</varname>.mdp</codeph>
     </p>
     <p>For information about the minidump file, see the server configuration parameter
         <codeph>optimizer_minidump</codeph> in the <cite>Greenplum Database Reference
       Guide</cite>.</p>
-    <p>When the <codeph>EXPLAIN ANALYZE</codeph> command uses GPORCA, the
-        <codeph>EXPLAIN</codeph> plan shows only the number of partitions that are being eliminated.
-      The scanned partitions are not shown. To show name of the scanned partitions in the segment
-      logs set the server configuration parameter <codeph>gp_log_dynamic_partition_pruning</codeph>
-      to <codeph>on</codeph>. This example <codeph>SET</codeph> command enables the parameter.</p>
+    <p>When the <codeph>EXPLAIN ANALYZE</codeph> command uses GPORCA, the <codeph>EXPLAIN</codeph>
+      plan shows only the number of partitions that are being eliminated. The scanned partitions are
+      not shown. To show name of the scanned partitions in the segment logs set the server
+      configuration parameter <codeph>gp_log_dynamic_partition_pruning</codeph> to
+        <codeph>on</codeph>. This example <codeph>SET</codeph> command enables the parameter.</p>
     <p>
       <codeblock>SET gp_log_dynamic_partition_pruning = on;</codeblock>
     </p>

--- a/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-notes.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-notes.xml
@@ -25,9 +25,9 @@
       <li><codeph>optimizer_cte_inlining_bound</codeph> controls the amount of inlining performed
         for common table expression (CTE) queries (queries that contain a <codeph>WHERE</codeph>
         clause).</li>
-      <li><codeph>optimizer_force_multistage_agg</codeph> forces GPORCA to chooses 3 stage aggregate
+      <li><codeph>optimizer_force_multistage_agg</codeph> forces GPORCA to choose 3 stage aggregate
         plan for a scalar distinct qualified aggregate. </li>
-      <li><codeph>optimizer_force_three_stage_scalar_dqa</codeph> forces GPORCA to chooses a plan
+      <li><codeph>optimizer_force_three_stage_scalar_dqa</codeph> forces GPORCA to choose a plan
         with multistage aggregates when such a plan alternative is generated. </li>
       <li><codeph>optimizer_join_order_threshold</codeph> specifies the maximum number of join
         children for which GPORCA uses the dynamic programming-based join ordering algorithm.</li>

--- a/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-notes.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-notes.xml
@@ -25,7 +25,7 @@
       <li><codeph>optimizer_cte_inlining_bound</codeph> controls the amount of inlining performed
         for common table expression (CTE) queries (queries that contain a <codeph>WHERE</codeph>
         clause).</li>
-      <li><codeph>optimizer_force_multistage_agg</codeph> forces GPORCA to choose 3 stage aggregate
+      <li><codeph>optimizer_force_multistage_agg</codeph> forces GPORCA to choose a 3 stage aggregate
         plan for a scalar distinct qualified aggregate. </li>
       <li><codeph>optimizer_force_three_stage_scalar_dqa</codeph> forces GPORCA to choose a plan
         with multistage aggregates when such a plan alternative is generated. </li>

--- a/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-notes.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-notes.xml
@@ -25,8 +25,8 @@
       <li><codeph>optimizer_cte_inlining_bound</codeph> controls the amount of inlining performed
         for common table expression (CTE) queries (queries that contain a <codeph>WHERE</codeph>
         clause).</li>
-      <li><codeph>optimizer_force_multistage_agg</codeph> forces GPORCA to choose a 3 stage aggregate
-        plan for a scalar distinct qualified aggregate. </li>
+      <li><codeph>optimizer_force_multistage_agg</codeph> forces GPORCA to choose a 3 stage
+        aggregate plan for a scalar distinct qualified aggregate. </li>
       <li><codeph>optimizer_force_three_stage_scalar_dqa</codeph> forces GPORCA to choose a plan
         with multistage aggregates when such a plan alternative is generated. </li>
       <li><codeph>optimizer_join_order_threshold</codeph> specifies the maximum number of join
@@ -51,11 +51,11 @@
     </ul>
     <p> For information about the parameters, see the <cite>Greenplum Database Reference
         Guide</cite>.</p>
-    <p>GPORCA generates minidumps to describe the optimization context for a given query. The
-      minidump files are used by Pivotal support to analyze Greenplum Database issues. The
-      information in the file is not in a format that can be easily used by customers for debugging
-      or troubleshooting. The minidump file is located under the master data directory and uses the
-      following naming format:</p>
+    <p>GPORCA generates minidumps to describe the optimization context for a given query. <ph
+        otherprops="pivotal">The minidump files are used by Pivotal support to analyze Greenplum
+        Database issues. </ph>The information in the file is not in a format that can be easily used
+      by customers for debugging or troubleshooting. The minidump file is located under the master
+      data directory and uses the following naming format:</p>
     <p>
       <codeph>Minidump_<varname>date</varname>_<varname>time</varname>.mdp</codeph>
     </p>
@@ -64,7 +64,7 @@
       Guide</cite>.</p>
     <p>When the <codeph>EXPLAIN ANALYZE</codeph> command uses GPORCA, the <codeph>EXPLAIN</codeph>
       plan shows only the number of partitions that are being eliminated. The scanned partitions are
-      not shown. To show name of the scanned partitions in the segment logs set the server
+      not shown. To show the name of the scanned partitions in the segment logs set the server
       configuration parameter <codeph>gp_log_dynamic_partition_pruning</codeph> to
         <codeph>on</codeph>. This example <codeph>SET</codeph> command enables the parameter.</p>
     <p>

--- a/gpdb-doc/dita/admin_guide/topics/g-pivotal-query-optimizer-parameters.xml
+++ b/gpdb-doc/dita/admin_guide/topics/g-pivotal-query-optimizer-parameters.xml
@@ -4,24 +4,34 @@
 <topic id="topic28">
    <title>GPORCA Configuration Parameters</title>
    <body>
-      <ul>
-         <li>
-            <codeph>optimizer</codeph>
-         </li>
-         <li>
-            <codeph>optimizer_array_expansion_threshold</codeph>
-         </li>
-         <li>
-            <codeph>optimizer_analyze_root_partition</codeph>
-         </li>
-         <li>
-            <codeph>optimizer_control</codeph>
-         </li>
-         <li>
-            <codeph>optimizer_enable_master_only_queries</codeph>
-         </li>
-         <li><codeph>optimizer_parallel_union</codeph></li>
-         <li><codeph>optimizer_sort_factor</codeph></li>
-      </ul>
+      <simpletable id="kh171216">
+         <strow>
+            <stentry>
+               <p>
+                  <codeph>optimizer</codeph></p>
+               <p><codeph>optimizer_analyze_root_partition</codeph>
+               </p>
+               <p><codeph>optimizer_array_expansion_threshold</codeph>
+               </p>
+               <p>
+                  <codeph>optimizer_control</codeph>
+               </p>
+               <p><codeph>optimizer_cte_inlining_bound</codeph></p>
+               <p><codeph>optimizer_enable_master_only_queries</codeph>
+               </p>
+               <p><codeph>optimizer_force_multistage_agg</codeph></p>
+               <p><codeph>optimizer_force_three_stage_scalar_dqa</codeph></p>
+            </stentry>
+            <stentry>
+               <p><codeph>optimizer_mdcache_size</codeph></p>
+               <p><codeph>optimizer_metadata_caching</codeph></p>
+               <p><codeph>optimizer_nestloop_factor</codeph></p>
+               <p><codeph>optimizer_parallel_union</codeph></p>
+               <p><codeph>optimizer_print_missing_stats</codeph></p>
+               <p><codeph>optimizer_print_optimization_stats</codeph></p>
+               <p><codeph>optimizer_sort_factor</codeph></p>
+            </stentry>
+         </strow>
+      </simpletable>
    </body>
 </topic>

--- a/gpdb-doc/dita/admin_guide/topics/g-what-to-log.xml
+++ b/gpdb-doc/dita/admin_guide/topics/g-what-to-log.xml
@@ -41,41 +41,30 @@
                   <codeph>log_duration</codeph>
                </p>
             </stentry>
-            <stentry>
-               <p>
+            <stentry><p>
                   <codeph>log_executor_stats</codeph>
-               </p>
-               <p>
+               </p><p>
                   <codeph>log_hostname</codeph>
-               </p>
-               <p>
+               </p><p>
                   <codeph>log_parser_stats</codeph>
-               </p>
-               <p>
+               </p><p>
                   <codeph>log_planner_stats</codeph>
-               </p>
-               <p>
+               </p><p>
                   <codeph>log_statement</codeph>
-               </p>
-               <p>
+               </p><p>
                   <codeph>log_statement_stats</codeph>
-               </p>
-               <p>
+               </p><p>
                   <codeph>log_timezone</codeph>
-               </p>
-               <p>
+               </p><p>
                   <codeph>gp_debug_linger</codeph>
-               </p>
-               <p>
+               </p><p>
                   <codeph>gp_log_format</codeph>
-               </p>
+               </p><codeph>gp_log_gang</codeph>
                <p>
                   <codeph>gp_max_csv_line_length</codeph>
-               </p>
-               <p>
+               </p><p>
                   <codeph>gp_reraise_signal</codeph>
-               </p>
-            </stentry>
+               </p></stentry>
          </strow>
       </simpletable>
    </body>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -351,6 +351,9 @@
               <xref href="#gp_log_fts"/>
             </li>
             <li>
+              <xref href="#gp_log_gang"/>
+            </li>
+            <li>
               <xref href="#gp_max_csv_line_length"/>
             </li>
             <li>
@@ -625,19 +628,49 @@
               <xref href="#optimizer_control" type="section">optimizer_control</xref>
             </li>
             <li>
+              <xref href="#optimizer_cte_inlining_bound" type="section"
+                >optimizer_cte_inlining_bound</xref>
+            </li>
+            <li>
               <xref href="#optimizer_enable_master_only_queries" type="section"
                 >optimizer_enable_master_only_queries</xref>
+            </li>
+            <li>
+              <xref href="#optimizer_force_multistage_agg" type="section"
+                >optimizer_force_multistage_agg</xref>
+            </li>
+            <li>
+              <xref href="#optimizer_force_three_stage_scalar_dqa" type="section"
+                >optimizer_force_three_stage_scalar_dqa</xref>
             </li>
             <li>
               <xref href="#optimizer_join_order_threshold" type="section"
                 >optimizer_join_order_threshold</xref>
             </li>
             <li>
+              <xref href="#optimizer_mdcache_size" type="section"/>
+            </li>
+            <li>
+              <xref href="#optimizer_metadata_caching" type="section"/>
+            </li>
+            <li>
               <xref href="#optimizer_minidump" type="section">optimizer_minidump</xref>
+            </li>
+            <li>
+              <xref href="#optimizer_nestloop_factor" type="section"
+                >optimizer_nestloop_factor</xref>
             </li>
             <li>
               <xref href="#optimizer_parallel_union" type="section"
               >optimizer_parallel_union</xref></li>
+            <li>
+              <xref href="#optimizer_print_missing_stats" type="section"
+                >optimizer_print_missing_stats</xref>
+            </li>
+            <li>
+              <xref href="#optimizer_print_optimization_stats" type="section"
+                >optimizer_print_optimization_stats</xref>
+            </li>
             <li>
               <xref href="#optimizer_sort_factor" format="dita">optimizer_sort_factor</xref></li>
             <li>
@@ -3837,6 +3870,35 @@
       </table>
     </body>
   </topic>
+  <topic id="gp_log_gang">
+    <title>gp_log_gang</title>
+    <body>
+      <p>Controls the amount of information that is written to the log file about query worker
+        process creation and query management. The default value is <codeph>OFF</codeph>, do not log
+        information.</p>
+      <table id="gp_log_fts_table">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">OFF<p>TERSE</p><p>VERBOSE</p><p>DEBUG</p></entry>
+              <entry colname="col2">OFF</entry>
+              <entry colname="col3">master<p>session</p><p>restart</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
   <topic id="gp_gpperfmon_send_interval">
     <title>gp_gpperfmon_send_interval</title>
     <body>
@@ -4148,8 +4210,8 @@
   <topic id="gp_interconnect_setup_timeout">
     <title>gp_interconnect_setup_timeout</title>
     <body>
-      <note>This parameter is deprecated, as it applies only to an interconnect type that is no
-        longer supported (<codeph>UDP</codeph>).</note>
+      <p>Specifies the amount of time to wait for the Greenplum Database interconnect to complete
+        setup before it times out.</p>
       <table id="gp_interconnect_setup_timeout_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>
@@ -4388,7 +4450,7 @@
   <topic id="gp_max_packet_size">
     <title>gp_max_packet_size</title>
     <body>
-      <p>Sets the tuple-serialization chunk size for the interconnect.</p>
+      <p>Sets the tuple-serialization chunk size for the Greenplum Database interconnect.</p>
       <table id="gp_max_packet_size_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>
@@ -6469,7 +6531,7 @@
         well. For more information about limiting concurrent connections, see "Configuring Client
         Authentication" in the <i>Greenplum Database Administrator Guide</i>.</p>
       <p>Increasing this parameter may cause Greenplum Database to request more shared
-        memory. Increasing this parameter might cause Greenplum Database to request more shared
+        memory.Increasing this parameter might cause Greenplum Database to request more shared
         memory. See <xref href="#shared_buffers" format="dita"/> for information about Greenplum
         server instance shared memory buffers.</p>
       <table id="max_connections_table">
@@ -6997,6 +7059,37 @@
       </table>
     </body>
   </topic>
+  <topic id="optimizer_cte_inlining_bound">
+    <title>optimizer_cte_inlining_bound</title>
+    <body>
+      <p>When GPORCA is enabled (the default), this parameter controls the amount of inlining
+        performed for common table expression (CTE) queries (queries that contain a
+          <codeph>WHERE</codeph> clause). The default value, 0, disables inlining.</p>
+      <p>The parameter can be set for a database system, an individual database, or a session or
+        query.</p>
+      <table id="table_dq1_xlj_tz">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">Decimal >= 0</entry>
+              <entry colname="col2">0</entry>
+              <entry colname="col3">master<p>session</p><p>reload</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
   <topic id="optimizer_enable_master_only_queries">
     <title>optimizer_enable_master_only_queries</title>
     <body>
@@ -7033,12 +7126,76 @@
       </table>
     </body>
   </topic>
+  <topic id="optimizer_force_multistage_agg">
+    <title>optimizer_force_multistage_agg</title>
+    <body>
+      <p>For the default settings, GPORCA is enabled and this parameter is <codeph>true</codeph>,
+        GPORCA chooses a 3 stage aggregate plan for scalar distinct qualified aggregate when such a
+        plan alternative is generated. When the value is <codeph>false</codeph>, GPORCA makes a cost
+        based choice rather than a heuristic choice.</p>
+      <p>The parameter can be set for a database system, an individual database, or a session or
+        query. </p>
+      <table id="table_kmz_vnr_tz">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">Boolean</entry>
+              <entry colname="col2">true</entry>
+              <entry colname="col3">master<p>session</p><p>reload</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
+  <topic id="optimizer_force_three_stage_scalar_dqa">
+    <title>optimizer_force_three_stage_scalar_dqa</title>
+    <body>
+      <p>For the default settings, GPORCA is enabled and this parameter is <codeph>true</codeph>,
+        GPORCA chooses a plan with multistage aggregates when such a plan alternative is generated.
+        When the value is <codeph>false</codeph>, GPORCA makes a cost based choice rather than a
+        heuristic choice.</p>
+      <p>The parameter can be set for a database system, an individual database, or a session, or
+        query.</p>
+      <table id="table_dqy_vnr_tz">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">Boolean</entry>
+              <entry colname="col2">true</entry>
+              <entry colname="col3">master<p>session</p><p>reload</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
   <topic id="optimizer_join_order_threshold">
     <title>optimizer_join_order_threshold</title>
     <body>
-      <p>Sets the maximum number of join children for which GPORCA will use the dynamic
-        programming-based join ordering algorithm. You can set this value for a single query or for
-        an entire session.</p>
+      <p>When GPORCA is enabled (the default), this parameter sets the maximum number of join
+        children for which GPORCA will use the dynamic programming-based join ordering algorithm.
+        You can set this value for a single query or for an entire session.</p>
       <table id="table_z1c_bqp_jx">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>
@@ -7055,6 +7212,82 @@
             <row>
               <entry colname="col1">0 - INT_MAX</entry>
               <entry colname="col2">10</entry>
+              <entry colname="col3">master<p>session</p><p>reload</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
+  <topic id="optimizer_mdcache_size">
+    <title>optimizer_mdcache_size</title>
+    <body>
+      <p dir="ltr">Sets the maximum amount of memory on the Greenplum Database master that GPORCA
+        uses to cache query metadata (optimization data) during query optimization. The memory limit
+        session based. GPORCA caches query metadata during query optimization with the default
+        settings: GPORCA is enabled and <codeph><xref href="#optimizer_metadata_caching"
+            format="dita">optimizer_metadata_caching</xref></codeph> is <codeph>on</codeph>. </p>
+      <p dir="ltr">The default value is 16384 (16MB). This is an optimal value that has been
+        determined through performance analysis.</p>
+      <p dir="ltr">You can specify a value in KB, MB, or GB. The default unit is KB. For example, a
+        value of 16384 is 16384KB. A value of 1GB is the same as 1024MB or 1048576KB. If the value
+        is 0, the size of the cache is not limited. </p>
+      <p>This parameter can be set for a database system, an individual database, or a session or
+        query.</p>
+      <table id="optimizer_mdcache_size_table">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">Integer >= 0</entry>
+              <entry colname="col2">16384</entry>
+              <entry colname="col3">master<p>session</p><p>reload</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
+  <topic id="optimizer_metadata_caching">
+    <title>optimizer_metadata_caching</title>
+    <body>
+      <p dir="ltr" id="docs-internal-guid-698e4ca6-574c-b75b-5cbe-8c7bfd011557">When GPORCA is
+        enabled (the default), this parameter specifies whether GPORCA caches query metadata
+        (optimization data) in memory on the Greenplum Database master during query optimization.
+        The default for this parameter is <codeph>on</codeph>, enable caching. The cache is session
+        based. When a session ends, the cache is released. If the amount of query metadata exceeds
+        the cache size, then old, unused metadata is evicted from the cache. </p>
+      <p dir="ltr">If the value is <codeph>off</codeph>, GPORCA does not cache metadata during query
+        optimization.</p>
+      <p>This parameter can be set for a database system, an individual database, or a session or
+        query.</p>
+      <p>The server configuration parameter <codeph><xref href="#optimizer_mdcache_size"
+            format="dita"/></codeph> controls the size of the query metadata cache.</p>
+      <table id="optimizer_metadata_caching_table">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">Boolean</entry>
+              <entry colname="col2">on</entry>
               <entry colname="col3">master<p>session</p><p>reload</p></entry>
             </row>
           </tbody>
@@ -7110,6 +7343,39 @@
       </table>
     </body>
   </topic>
+  <topic id="optimizer_nestloop_factor">
+    <title>optimizer_nestloop_factor</title>
+    <body>
+      <p>When GPORCA is enabled (the default), this parameter controls nested loop join cost factor
+        to apply to during query optimization. The default value, <codeph>1</codeph>, specifies the
+        default sort cost factor. The value is a ratio of increase or decrease from the default
+        factor. For example, a value of <codeph>2.0</codeph> sets the cost factor at twice the
+        default, and a value of <codeph>0.5</codeph> sets the factor at half the default.</p>
+      <p>The parameter can be set for a database system, an individual database, or a session or
+        query.</p>
+      <table id="table_zy2_xlj_tz">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">Decimal > 0</entry>
+              <entry colname="col2">1</entry>
+              <entry colname="col3">master<p>session</p><p>reload</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
   <topic id="optimizer_parallel_union">
     <title>optimizer_parallel_union</title>
     <body>
@@ -7140,6 +7406,78 @@
           <tbody>
             <row>
               <entry colname="col1">boolean</entry>
+              <entry colname="col2">off</entry>
+              <entry colname="col3">master<p>session</p><p>reload</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
+  <topic id="optimizer_print_missing_stats">
+    <title>optimizer_print_missing_stats</title>
+    <body>
+      <p>When GPORCA is enabled (the default), this parameter controls the display of table column
+        information about columns with missing statistics for a query. The default value is
+          <codeph>true</codeph>, display the column information to the client. When the value is
+          <codeph>false</codeph>, the information is not sent to the client.</p>
+      <p>The information is displayed during query execution, or with the <codeph>EXPLAIN</codeph>
+        or <codeph>EXPLAIN ANALYZE</codeph> commands.</p>
+      <p>The parameter can be set for a database system, an individual database, or a session. </p>
+      <table id="table_z35_fsj_tz">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">Boolean</entry>
+              <entry colname="col2">true</entry>
+              <entry colname="col3">master<p>session</p><p>reload</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
+  <topic id="optimizer_print_optimization_stats">
+    <title>optimizer_print_optimization_stats</title>
+    <body>
+      <p>When GPORCA is enabled (the default), this parameter enables logging of GPORCA query
+        optimization statistics for various optimization stages for a query. The default value is
+          <systemoutput>off</systemoutput>, do not log optimization statistics. To log the
+        optimization statistics, this parameter must be set to <systemoutput>on</systemoutput> and
+        the parameter <systemoutput>client_min_messages</systemoutput> must be set to
+          <systemoutput>log</systemoutput>.<ul id="ul_ysz_tx2_5z">
+          <li><codeph>set optimizer_print_optimization_stats = on;</codeph></li>
+          <li><codeph>set client_min_messages = 'log';</codeph></li>
+        </ul></p>
+      <p>The information is logged during query execution, or with the <codeph>EXPLAIN</codeph> or
+          <codeph>EXPLAIN ANALYZE</codeph> commands.</p>
+      <p>This parameter can be set for a database system, an individual database,or a session or
+        query.</p>
+      <table id="table_pdm_kx2_5z">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">Boolean</entry>
               <entry colname="col2">off</entry>
               <entry colname="col3">master<p>session</p><p>reload</p></entry>
             </row>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -7346,11 +7346,12 @@
   <topic id="optimizer_nestloop_factor">
     <title>optimizer_nestloop_factor</title>
     <body>
-      <p>When GPORCA is enabled (the default), this parameter controls nested loop join cost factor
-        to apply to during query optimization. The default value, <codeph>1</codeph>, specifies the
-        default sort cost factor. The value is a ratio of increase or decrease from the default
-        factor. For example, a value of <codeph>2.0</codeph> sets the cost factor at twice the
-        default, and a value of <codeph>0.5</codeph> sets the factor at half the default.</p>
+      <p>When GPORCA is enabled (the default), this parameter controls the nested loop join cost
+        factor to apply to during query optimization. The default value, <codeph>1</codeph>,
+        specifies the default sort cost factor. The value is a ratio of increase or decrease from
+        the default factor. For example, a value of <codeph>2.0</codeph> sets the cost factor at
+        twice the default, and a value of <codeph>0.5</codeph> sets the factor at half the
+        default.</p>
       <p>The parameter can be set for a database system, an individual database, or a session or
         query.</p>
       <table id="table_zy2_xlj_tz">

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -333,23 +333,42 @@
               <xref href="guc-list.xml#optimizer" type="section">optimizer</xref>
             </p>
             <p>
-              <xref href="guc-list.xml#optimizer_array_expansion_threshold" type="section"
-                >optimizer_array_expansion_threshold</xref></p>
-            <p>
               <xref href="guc-list.xml#optimizer_analyze_root_partition" type="section"
                 >optimizer_analyze_root_partition</xref>
             </p>
-          </stentry>
-          <stentry>
+            <p>
+              <xref href="guc-list.xml#optimizer_array_expansion_threshold" type="section"
+                >optimizer_array_expansion_threshold</xref></p>
+            <p><xref href="guc-list.xml#optimizer_cte_inlining_bound" type="section"
+                >optimizer_cte_inlining_bound</xref>
+            </p>
             <p><xref href="guc-list.xml#optimizer_control" type="section">optimizer_control</xref>
             </p>
             <p><xref href="guc-list.xml#optimizer_enable_master_only_queries" type="section"
-                >optimizer_enable_master_only_queries</xref>
+                >optimizer_enable_master_only_queries</xref></p>
+            <p><xref href="guc-list.xml#optimizer_force_multistage_agg" type="section"
+                >optimizer_force_multistage_agg</xref>
             </p>
+            <p><xref href="guc-list.xml#optimizer_force_three_stage_scalar_dqa" type="section"
+                >optimizer_force_three_stage_scalar_dqa</xref></p>
+          </stentry>
+          <stentry>
             <p><xref href="guc-list.xml#optimizer_join_order_threshold" format="dita"
                 >optimizer_join_order_threshold</xref></p>
+            <p><xref href="guc-list.xml#optimizer_mdcache_size" type="section"
+                >optimizer_mdcache_size</xref>
+            </p>
+            <p><xref href="guc-list.xml#optimizer_metadata_caching" type="section"
+                >optimizer_metadata_caching</xref>
+            </p>
             <p><xref href="guc-list.xml#optimizer_parallel_union" type="section"
                 >optimizer_parallel_union</xref></p>
+            <p><xref href="guc-list.xml#optimizer_print_missing_stats" type="section"
+                >optimizer_print_missing_stats</xref>
+            </p>
+            <p><xref href="guc-list.xml#optimizer_print_optimization_stats" type="section"
+                >optimizer_print_optimization_stats</xref>
+            </p>
             <p><xref href="guc-list.xml#optimizer_sort_factor" format="dita"
                 >optimizer_sort_factor</xref></p>
           </stentry>
@@ -874,8 +893,9 @@
     <topic id="topic36" xml:lang="en">
       <title>Greenplum Command Center Agent</title>
       <body>
-        <p>The following parameters configure the data collection agents that populate the <codeph>gpperfmon</codeph> database for Greenplum Command Center.</p>
-         <simpletable id="kh171891" frame="none">
+        <p>The following parameters configure the data collection agents that populate the
+            <codeph>gpperfmon</codeph> database for Greenplum Command Center.</p>
+        <simpletable id="kh171891" frame="none">
           <strow>
             <stentry>
               <p>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -118,6 +118,7 @@
             <topicref href="guc-list.xml#gp_interconnect_type"/>
             <topicref href="guc-list.xml#gp_log_format"/>
             <topicref href="guc-list.xml#gp_log_fts"/>
+            <topicref href="guc-list.xml#gp_log_gang"/>
             <topicref href="guc-list.xml#gp_max_csv_line_length"/>
             <topicref href="guc-list.xml#gp_max_databases"/>
             <topicref href="guc-list.xml#gp_max_filespaces"/>
@@ -208,10 +209,18 @@
             <topicref href="guc-list.xml#optimizer_array_expansion_threshold"/>
             <topicref href="guc-list.xml#optimizer_analyze_root_partition"/>
             <topicref href="guc-list.xml#optimizer_control"/>
+            <topicref href="guc-list.xml#optimizer_cte_inlining_bound"/>
             <topicref href="guc-list.xml#optimizer_enable_master_only_queries"/>
+            <topicref href="guc-list.xml#optimizer_force_multistage_agg"/>
+            <topicref href="guc-list.xml#optimizer_force_three_stage_scalar_dqa"/>
             <topicref href="guc-list.xml#optimizer_join_order_threshold"/>
+            <topicref href="guc-list.xml#optimizer_mdcache_size"/>
+            <topicref href="guc-list.xml#optimizer_metadata_caching"/>
             <topicref href="guc-list.xml#optimizer_minidump"/>
+            <topicref href="guc-list.xml#optimizer_nestloop_factor"/>
             <topicref href="guc-list.xml#optimizer_parallel_union"/>
+            <topicref href="guc-list.xml#optimizer_print_missing_stats"/>
+            <topicref href="guc-list.xml#optimizer_print_optimization_stats"/>
             <topicref href="guc-list.xml#optimizer_sort_factor"/>
             <topicref href="guc-list.xml#password_encryption"/>
             <topicref href="guc-list.xml#password_hash_algorithm"/>


### PR DESCRIPTION
Add documentation for these GUCs

gp_log_gang
optimizer_cte_inlining_bound
optimizer_force_multistage_agg
optimizer_force_three_stage_scalar_dqa
optimizer_nestloop_factor
optimizer_print_missing_stats
optimizer_print_optimization_stats

These GUCs are for MDcache are GPDB 5.0 specific.
optimizer_metadata_caching
optimizer_mdcache_size

All the GUC definitions have been reviewed at some level by dev.

The main documentation (GUC definition) is in the file 
gpdb-doc/dita/ref_guide/config_params/guc-list.xml

[ci skip]