### PR TITLE
Add dummy.source to input/output directories to skip --ao-dir parameter

### DIFF
--- a/src/test/isolation2/input/dummy.source
+++ b/src/test/isolation2/input/dummy.source
@@ -1,0 +1,2 @@
+-- This dummy.source file to is support running pg_regress without --ao-dir parameter
+-- otherwise, people will get error message like: `no *.source files found`

--- a/src/test/isolation2/output/dummy.source
+++ b/src/test/isolation2/output/dummy.source
@@ -1,0 +1,2 @@
+-- This dummy.source file to is support running pg_regress without --ao-dir parameter
+-- otherwise, people will get error message like: `no *.source files found`


### PR DESCRIPTION
This will speed-up the isolation2 sql tests without waiting for uao generation.
This is useful for iterating a test that does not involve uao templates.

Signed-off-by: Xin Zhang <xzhang@pivotal.io>