### PR TITLE
Make some const array variables static in gpopt translator

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -116,7 +116,7 @@ CTranslatorDXLToPlStmt::InitTranslators()
 	}
 
 	// array mapping operator type to translator function
-	STranslatorMapping rgTranslators[] =
+	static const STranslatorMapping rgTranslators[] =
 	{
 			{EdxlopPhysicalTableScan,				&gpopt::CTranslatorDXLToPlStmt::PtsFromDXLTblScan},
 			{EdxlopPhysicalExternalScan,			&gpopt::CTranslatorDXLToPlStmt::PtsFromDXLTblScan},

--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -84,7 +84,7 @@ CTranslatorDXLToScalar::PexprFromDXLNodeScalar
 	CMappingColIdVar *pmapcidvar
 	)
 {
-	STranslatorElem rgTranslators[] =
+	static const STranslatorElem rgTranslators[] =
 	{
 		{EdxlopScalarIdent, &CTranslatorDXLToScalar::PexprFromDXLNodeScId},
 		{EdxlopScalarCmp, &CTranslatorDXLToScalar::PopexprFromDXLNodeScCmp},
@@ -1358,7 +1358,7 @@ CTranslatorDXLToScalar::PconstFromDXLDatum
 {
 	GPOS_ASSERT(NULL != pdxldatum);
 	
-	SDatumTranslatorElem rgTranslators[] =
+	static const SDatumTranslatorElem rgTranslators[] =
 		{
 			{CDXLDatum::EdxldatumInt2 , &CTranslatorDXLToScalar::PconstInt2},
 			{CDXLDatum::EdxldatumInt4 , &CTranslatorDXLToScalar::PconstInt4},

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -64,7 +64,7 @@ extern bool optimizer_enable_dml_constraints;
 extern bool optimizer_enable_multiple_distinct_aggs;
 
 // OIDs of variants of LEAD window function
-const OID rgOIDLead[] =
+static const OID rgOIDLead[] =
 	{
 	7011, 7074, 7075, 7310, 7312,
 	7314, 7316, 7318,
@@ -91,7 +91,7 @@ const OID rgOIDLead[] =
 	};
 
 // OIDs of variants of LAG window function
-const OID rgOIDLag[] =
+static const OID rgOIDLag[] =
 	{
 	7675, 7491, 7493, 7495, 7497, 7499,
 	7501, 7503, 7505, 7507, 7509,
@@ -294,7 +294,7 @@ CTranslatorQueryToDXL::CheckUnsupportedNodeTypes
 	Query *pquery
 	)
 {
-	SUnsupportedFeature rgUnsupported[] =
+	static const SUnsupportedFeature rgUnsupported[] =
 	{
 		{T_RowExpr, GPOS_WSZ_LIT("ROW EXPRESSION")},
 		{T_RowCompareExpr, GPOS_WSZ_LIT("ROW COMPARE")},
@@ -415,7 +415,7 @@ CTranslatorQueryToDXL::CheckSupportedCmdType
 		return;
 	}
 
-	SCmdNameElem rgStrMap[] =
+	static const SCmdNameElem rgStrMap[] =
 		{
 		{CMD_UTILITY, GPOS_WSZ_LIT("UTILITY command")}
 		};
@@ -2870,7 +2870,7 @@ CTranslatorQueryToDXL::PdxlnFromGPDBFromClauseEntry
 			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("gp_dist_random"));
 		}
 
-		SRTETranslator rgTranslators[] =
+		static const SRTETranslator rgTranslators[] =
 		{
 			{RTE_RELATION, &CTranslatorQueryToDXL::PdxlnFromRelation},
 			{RTE_VALUES, &CTranslatorQueryToDXL::PdxlnFromValues},
@@ -2934,7 +2934,7 @@ CTranslatorQueryToDXL::UnsupportedRTEKind
 				|| RTE_FUNCTION == rtekind || RTE_SUBQUERY == rtekind
 				|| RTE_VALUES == rtekind));
 
-	SRTENameElem rgStrMap[] =
+	static const SRTENameElem rgStrMap[] =
 		{
 		{RTE_JOIN, GPOS_WSZ_LIT("RangeTableEntry of type Join")},
 		{RTE_SPECIAL, GPOS_WSZ_LIT("RangeTableEntry of type Special")},

--- a/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
@@ -99,7 +99,7 @@ CTranslatorScalarToDXL::EdxlbooltypeFromGPDBBoolType
 	)
 	const
 {
-	ULONG rgrgulMapping[][2] =
+	static ULONG rgrgulMapping[][2] =
 		{
 		{NOT_EXPR, Edxlnot},
 		{AND_EXPR, Edxland},
@@ -202,7 +202,7 @@ CTranslatorScalarToDXL::PdxlnScOpFromExpr
 	BOOL *pfHasDistributedTables // output
 	)
 {
-	STranslatorElem rgTranslators[] =
+	static const STranslatorElem rgTranslators[] =
 	{
 		{T_Var, &CTranslatorScalarToDXL::PdxlnScIdFromVar},
 		{T_OpExpr, &CTranslatorScalarToDXL::PdxlnScOpExprFromExpr},
@@ -690,7 +690,7 @@ CTranslatorScalarToDXL::PdxlnScBooleanTestFromExpr
 
 	GPOS_ASSERT(NULL != pbooleantest->arg);
 
-	ULONG rgrgulMapping[][2] =
+	static ULONG rgrgulMapping[][2] =
 		{
 		{IS_TRUE, EdxlbooleantestIsTrue},
 		{IS_NOT_TRUE, EdxlbooleantestIsNotTrue},
@@ -1299,7 +1299,7 @@ CTranslatorScalarToDXL::PdxlnScAggrefFromAggref
 	GPOS_ASSERT(IsA(pexpr, Aggref));
 	const Aggref *paggref = (Aggref *) pexpr;
 
-	ULONG rgrgulMapping[][2] =
+	static ULONG rgrgulMapping[][2] =
 		{
 		{AGGSTAGE_NORMAL, EdxlaggstageNormal},
 		{AGGSTAGE_PARTIAL, EdxlaggstagePartial},
@@ -1373,7 +1373,7 @@ CTranslatorScalarToDXL::Edxlfb
 	)
 	const
 {
-	ULONG rgrgulMapping[][2] =
+	static ULONG rgrgulMapping[][2] =
 			{
 			{WINDOW_UNBOUND_PRECEDING, EdxlfbUnboundedPreceding},
 			{WINDOW_BOUND_PRECEDING, EdxlfbBoundedPreceding},
@@ -1439,7 +1439,7 @@ CTranslatorScalarToDXL::Pdxlwf
 	EdxlFrameBoundary edxlfbLead = Edxlfb(pwindowframe->lead->kind, pwindowframe->lead->val);
 	EdxlFrameBoundary edxlfbTrail = Edxlfb(pwindowframe->trail->kind, pwindowframe->trail->val);
 
-	ULONG rgrgulExclusionMapping[][2] =
+	static ULONG rgrgulExclusionMapping[][2] =
 			{
 			{WINDOW_EXCLUSION_NULL, EdxlfesNulls},
 			{WINDOW_EXCLUSION_CUR_ROW, EdxlfesCurrentRow},
@@ -1551,7 +1551,7 @@ CTranslatorScalarToDXL::PdxlnScWindowref
 
 	const WindowRef *pwindowref = (WindowRef *) pexpr;
 
-	ULONG rgrgulMapping[][2] =
+	static ULONG rgrgulMapping[][2] =
 		{
 		{WINSTAGE_IMMEDIATE, EdxlwinstageImmediate},
 		{WINSTAGE_PRELIMINARY, EdxlwinstagePreliminary},
@@ -2088,7 +2088,7 @@ CTranslatorScalarToDXL::Pdxldatum
 	Datum datum
 	)
 {
-	SDXLDatumTranslatorElem rgTranslators[] =
+	static const SDXLDatumTranslatorElem rgTranslators[] =
 		{
 			{IMDType::EtiInt2  , &CTranslatorScalarToDXL::PdxldatumInt2},
 			{IMDType::EtiInt4  , &CTranslatorScalarToDXL::PdxldatumInt4},


### PR DESCRIPTION
Static variables when used inside function are initialized only once and stored
on static storage area. The original code without static initializes these
variables every time the function is called and these variables are stored in
stack. Since we don't change the array value, they can be static const.