### PR TITLE
Check ORCA version in configure [#146310957]

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -43,3 +43,21 @@ AC_CHECK_LIB(gpopt, gpopt_init, [], [AC_MSG_ERROR([library 'gpopt' is required f
 AC_LANG_POP([C++])
 ]
 )
+
+AC_DEFUN([PGAC_CHECK_ORCA_VERSION],
+[
+AC_MSG_CHECKING([[Checking ORCA version]])
+AC_LANG_PUSH([C++])
+AC_RUN_IFELSE([AC_LANG_PROGRAM([[
+#include "gpopt/version.h"
+#include <string.h>
+]],
+[
+return strncmp("2.32.", GPORCA_VERSION_STRING, 5);
+])],
+[AC_MSG_RESULT([[ok]])],
+[AC_MSG_ERROR([Your ORCA version is expected to be 2.32.XXX])]
+)
+AC_LANG_POP([C++])
+])# PGAC_CHECK_ORCA_VERSION
+

--- a/configure
+++ b/configure
@@ -11687,6 +11687,55 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking Checking ORCA version" >&5
+$as_echo_n "checking Checking ORCA version... " >&6; }
+ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+if test "$cross_compiling" = yes; then :
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "cannot run test program while cross compiling
+See \`config.log' for more details" "$LINENO" 5; }
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#include "gpopt/version.h"
+#include <string.h>
+
+int
+main ()
+{
+
+return strncmp("2.32.", GPORCA_VERSION_STRING, 5);
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_run "$LINENO"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
+$as_echo "ok" >&6; }
+else
+  as_fn_error $? "Your ORCA version is expected to be 2.32.XXX" "$LINENO" 5
+
+fi
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+  conftest.$ac_objext conftest.beam conftest.$ac_ext
+fi
+
+ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+
 fi # fi
 
 for ac_header in atomic.h crypt.h dld.h endian.h fp_class.h getopt.h ieeefp.h ifaddrs.h langinfo.h mbarrier.h poll.h pwd.h sys/ioctl.h sys/ipc.h sys/poll.h sys/pstat.h sys/resource.h sys/select.h sys/sem.h sys/shm.h sys/socket.h sys/sockio.h sys/tas.h sys/time.h sys/un.h termios.h ucred.h utime.h wchar.h wctype.h kernel/OS.h kernel/image.h SupportDefs.h

--- a/configure.in
+++ b/configure.in
@@ -1302,6 +1302,7 @@ AS_IF([test "$enable_orca" = yes],
   PGAC_CHECK_ORCA_HEADERS
   PGAC_CHECK_ORCA_XERCES
   PGAC_CHECK_ORCA_LIBS
+  PGAC_CHECK_ORCA_VERSION
 ]) # fi
 
 dnl sys/socket.h is required by AC_FUNC_ACCEPT_ARGTYPES


### PR DESCRIPTION
As proposed by @hsyuan, we are going to explicitly check ORCA major and minor version when ORCA has an API change. This is the first attempt to have ORCA version check in configure.  