### PR TITLE
Skip testing uninstalled components (Perl) on SLES

### DIFF
--- a/concourse/scripts/common.bash
+++ b/concourse/scripts/common.bash
@@ -23,8 +23,13 @@ function configure() {
   pushd gpdb_src
       # The full set of configure options which were used for building the
       # tree must be used here as well since the toplevel Makefile depends
-      # on these options for deciding what to test
-      ./configure --prefix=/usr/local/greenplum-db-devel --with-perl --with-python --with-libxml --enable-mapreduce --disable-orca
+      # on these options for deciding what to test. Since we don't ship
+      # Perl on SLES we must also skip GPMapreduce as it uses pl/perl.
+      if [ "$TEST_OS" == "sles" ]; then
+        ./configure --prefix=/usr/local/greenplum-db-devel --with-python --with-libxml --disable-orca
+	  else
+        ./configure --prefix=/usr/local/greenplum-db-devel --with-perl --with-python --with-libxml --enable-mapreduce --disable-orca
+      fi
   popd
 }
 


### PR DESCRIPTION
PL/Perl support is not shipped on SLES so skip including Perl, and components which depend on Perl, in the test set. This addresses the remaining issue in ICW on SLES in the pipeline:
```
../../../src/test/regress/pg_regress --init-file=init_file --dbname=pl_regression --load-language=plperl --load-language=plperlu plperl plperl_lc plperl_trigger plperl_shared plperl_elog plperl_util plperl_init plperlu plperl_array plperl_plperlu plperl_gp
(using postmaster on Unix socket, port 15432)
============== dropping database "pl_regression"      ==============
NOTICE:  database "pl_regression" does not exist, skipping
DROP DATABASE
============== creating database "pl_regression"      ==============
CREATE DATABASE
ALTER DATABASE
============== installing plperl                      ==============
ERROR:  could not access file "$libdir/plperl": No such file or directory
command failed: "/usr/local/greenplum-db-devel/bin/psql" -X -c "CREATE LANGUAGE \"plperl\"" "pl_regression"
make[2]: *** [installcheck] Error 2```