### PR TITLE
Update AO README with correct aoseg table naming

### DIFF
--- a/src/backend/access/appendonly/README
+++ b/src/backend/access/appendonly/README
@@ -50,11 +50,14 @@ Aosegments table
 In addition to the segment files that store the user data, there are
 three auxiliary heap tables for each AO table, which store metadata.
 The aosegments table is always named as "pg_aoseg.pg_aoseg_<oid>",
-where <oid> is the current oid value of the AO table's pg_class row.
-The mapping between AO tables and their respective aosegments tables
-is recorded in "pg_catalog.pg_appendonly". These are similar to the
-TOAST tables, for heaps. An append-only table can also have a TOAST
-table, too, in addition to the AO-specific auxiliary tables.
+where <oid> is the initial Oid with which the table was created. This
+is not guaranteed to match the current Oid of the aosegments table,
+as some ALTER TABLE operations will rewrite the table causing the
+Oid to change. In order to find the aosegments table of an AO table,
+the "pg_catalog.pg_appendonly" catalog relation must be queried.
+Aosegment tables are similar to the TOAST tables, for heaps. An
+append-only table can have a TOAST table, too, in addition to the
+AO-specific auxiliary tables.
 
 The segment table lists all the segment files that exist. For each
 segfile, it stores the current length of the table. This is used to

--- a/src/backend/access/appendonly/README
+++ b/src/backend/access/appendonly/README
@@ -48,11 +48,12 @@ Aosegments table
 ----------------
 
 In addition to the segment files that store the user data, there are
-three auxiliary heap tables for each AO table, which store
-metadata. The aosegments table is always named as
-"pg_aoseg.pg_aoseg_<relfilenode>", where <relfilenode> is the current
-relfilenode value of the AO table's pg_class row. These are similar to
-the TOAST tables, for heaps. An append-only table can also have a TOAST
+three auxiliary heap tables for each AO table, which store metadata.
+The aosegments table is always named as "pg_aoseg.pg_aoseg_<oid>",
+where <oid> is the current oid value of the AO table's pg_class row.
+The mapping between AO tables and their respective aosegments tables
+is recorded in "pg_catalog.pg_appendonly". These are similar to the
+TOAST tables, for heaps. An append-only table can also have a TOAST
 table, too, in addition to the AO-specific auxiliary tables.
 
 The segment table lists all the segment files that exist. For each
@@ -75,7 +76,7 @@ Visibility map table
 --------------------
 
 The visibility map for each AO table is stored in a heap table named
-"pg_aoseg.pg_aovisimap_<relfilenode>".  It is not to be confused with
+"pg_aoseg.pg_aovisimap_<oid>".  It is not to be confused with
 the visibility map used for heaps in PostgreSQL 8.4 and above!
 
 The AO visibility map is used to implement DELETEs and UPDATEs. An


### PR DESCRIPTION
The aosegments table is in fact using the oid of the relation and
not the relfilenode. Also add a short note about the mapping in
pg_appendonly and reflow the section with the new content.