### PR TITLE
Fix dump of functions in pg_dump to not add extra semicolon

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -7307,8 +7307,6 @@ dumpFunc(Archive *fout, FuncInfo *finfo)
 	else if (prodataaccess[0] == PRODATAACCESS_MODIFIES)
 		appendPQExpBuffer(q, " MODIFIES SQL DATA");
 
-	appendPQExpBuffer(q, ";\n");
-
 	for (i = 0; i < nconfigitems; i++)
 	{
 		/* we feel free to scribble on configitems[] here */


### PR DESCRIPTION
pg_dump will append an extra semicolon to function definitions prior to
printing SET statements for function GUCs. This results in the SET statements
actually being printed outside the CREATE FUNCTION statement, so the GUCs are
set on a session level rather than being set for the scope of the function.