### PR TITLE
gpperfmon: Remove config parameter min_detailed_query_time

### DIFF
--- a/gpAux/gpperfmon/src/gpmon/gpmmon.c
+++ b/gpAux/gpperfmon/src/gpmon/gpmmon.c
@@ -90,7 +90,6 @@ int verbose = 0; /* == opt.v */
 int very_verbose = 0; /* == opt.V */
 int quantum = 15; /* == opt.q */
 int min_query_time = 60; /* == opt.m */
-int min_detailed_query_time = 60; /* == opt.d */
 
 /* thread handles */
 static apr_thread_t* conm_th = NULL;
@@ -1140,7 +1139,6 @@ static int read_conf_file(char *conffile)
 
 	opt.q = quantum;
 	opt.m = min_query_time;
-	opt.d = min_detailed_query_time;
 	opt.harvest_interval = 120;
 	opt.max_log_size = 0;
 	opt.log_dir = strdup(DEFAULT_GPMMON_LOGDIR);
@@ -1201,10 +1199,6 @@ static int read_conf_file(char *conffile)
 			else if (apr_strnatcasecmp(pName, "min_query_time") == 0)
 			{
 				opt.m = atoi(pVal);
-			}
-			else if (apr_strnatcasecmp(pName, "min_detailed_query_time") == 0)
-			{
-				opt.d = atoi(pVal);
 			}
 			else if (apr_strnatcasecmp(pName, "verbose") == 0)
 			{
@@ -1311,20 +1305,6 @@ static int read_conf_file(char *conffile)
 	if (opt.m < 0)
 		opt.m = 0;
 
-	if (opt.d < opt.m)
-	{
-		opt.d = opt.m;
-		fprintf(stderr, "Performance Monitor - min_detail_query_time cannot be less than min_query_time.  "
-				"Setting min_detail_query_time equal to min_query_time\n");
-	}
-
-	if (opt.d < 10 && !opt.qamode)
-	{
-		fprintf(stderr, "Performance Monitor - invalid value for min_detailed_query_time.  "
-				"Using default value 60\n");
-		opt.d = 60;
-	}
-
 	if (opt.log_dir == NULL)
 	{
 		char log_dir[MAXPATHLEN + 1] = { 0 };
@@ -1383,7 +1363,6 @@ static int read_conf_file(char *conffile)
 
 	verbose = opt.v;
 	min_query_time = opt.m;
-	min_detailed_query_time = opt.d;
 	quantum = opt.q;
 
 	fclose(fp);

--- a/gpAux/gpperfmon/src/gpmon/gpmmon.c
+++ b/gpAux/gpperfmon/src/gpmon/gpmmon.c
@@ -1138,7 +1138,7 @@ static int read_conf_file(char *conffile)
 	int section = 0, section_found = 0;
 
 	opt.q = quantum;
-	opt.m = min_query_time;
+	opt.min_query_time = min_query_time;
 	opt.harvest_interval = 120;
 	opt.max_log_size = 0;
 	opt.log_dir = strdup(DEFAULT_GPMMON_LOGDIR);
@@ -1198,7 +1198,7 @@ static int read_conf_file(char *conffile)
 			}
 			else if (apr_strnatcasecmp(pName, "min_query_time") == 0)
 			{
-				opt.m = atoi(pVal);
+				opt.min_query_time = atoi(pVal);
 			}
 			else if (apr_strnatcasecmp(pName, "verbose") == 0)
 			{
@@ -1302,8 +1302,8 @@ static int read_conf_file(char *conffile)
 		opt.q = 15;
 	}
 
-	if (opt.m < 0)
-		opt.m = 0;
+	if (opt.min_query_time < 0)
+		opt.min_query_time = 0;
 
 	if (opt.log_dir == NULL)
 	{
@@ -1362,7 +1362,7 @@ static int read_conf_file(char *conffile)
 	}
 
 	verbose = opt.v;
-	min_query_time = opt.m;
+	min_query_time = opt.min_query_time;
 	quantum = opt.q;
 
 	fclose(fp);

--- a/gpAux/gpperfmon/src/gpmon/gpmon_agg.c
+++ b/gpAux/gpperfmon/src/gpmon/gpmon_agg.c
@@ -77,7 +77,6 @@ typedef struct dbmetrics_t {
 } dbmetrics_t;
 
 extern int min_query_time;
-extern int min_detailed_query_time;
 extern mmon_options_t opt;
 extern apr_queue_t* message_queue;
 

--- a/gpAux/gpperfmon/src/gpmon/gpmon_agg.c
+++ b/gpAux/gpperfmon/src/gpmon/gpmon_agg.c
@@ -999,14 +999,14 @@ static apr_uint32_t write_dbmetrics(dbmetrics_t* dbmetrics, char* nowstr)
              dbmetrics->queries_running,
              dbmetrics->queries_queued);
 
-	bytes_written = strlen(line) + 1;
-	if (bytes_written == line_size){
-		gpmon_warning(FLINE, "dbmetrics line too long ... ignored:: %s", line);
-		return 0;
+	if (strlen(line) + 1 == line_size){
+		gpmon_warning(FLINE, "dbmetrics line too long ... ignored: %s", line);
+		bytes_written = 0;
+	} else {
+		fprintf(fp, "%s\n", line);
+		fprintf(fp2, "%s\n", line);
+		bytes_written = strlen(line) + 1;
 	}
-
-	fprintf(fp, "%s\n", line);
-    fprintf(fp2, "%s\n", line);
 
     fclose(fp);
     fclose(fp2);

--- a/gpAux/gpperfmon/src/gpmon/gpmonlib.h
+++ b/gpAux/gpperfmon/src/gpmon/gpmonlib.h
@@ -128,7 +128,6 @@ typedef struct mmon_options_t
 	int v;
 	int q;
 	int m;
-	int d;
 	int qamode;
 	int harvest_interval;
 	apr_uint64_t tail_buffer_max;

--- a/gpAux/gpperfmon/src/gpmon/gpmonlib.h
+++ b/gpAux/gpperfmon/src/gpmon/gpmonlib.h
@@ -127,7 +127,7 @@ typedef struct mmon_options_t
 	int max_fd; /* this is the max fd value we ever seen */
 	int v;
 	int q;
-	int m;
+	int min_query_time;
 	int qamode;
 	int harvest_interval;
 	apr_uint64_t tail_buffer_max;

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -870,13 +870,6 @@ quantum = 15
 # data is collected.
 min_query_time = 20
 
-# Specifies the minimum iterator run time in seconds for
-# statistics collection. The monitor logs all iterators that
-# run longer than this value in the iterators_history table.
-# For iterators with shorter run times, no data is collected.
-# Minimum value is 10 seconds.
-min_detailed_query_time = 60
-
 # This should be a percentage between 0 and 100 and should be
 # less than the error_disk_space_percentage.  If a filesystem’s
 # disk space used percentage equals or exceeds this value a

--- a/gpdb-doc/dita/ref_guide/gpperfmon/db-queries.xml
+++ b/gpdb-doc/dita/ref_guide/gpperfmon/db-queries.xml
@@ -139,9 +139,8 @@
                         primary segments in the database system.</p>
                      <p>Note that the value is logged as 0 if the query runtime
                         is shorter than the value for the quantum. This occurs even if the query
-                        runtime is greater than the values for <codeph>min_query_time</codeph> and
-                           <codeph>min_detailed_query</codeph>, and these values are lower than the
-                        value for the quantum.</p>
+                        runtime is greater than the value for <codeph>min_query_time</codeph>,
+                        and this value is lower than the value for the quantum.</p>
                   </entry>
                </row>
                <row>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpperfmon_install.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpperfmon_install.xml
@@ -166,24 +166,6 @@ host       all           gpmon  ::1/128        <b>password</b></codeblock></p>
           </stentry>
         </strow>
         <strow>
-          <stentry>min_detailed_query_time</stentry>
-          <stentry>
-            <p>Specifies the minimum iterator run time in seconds for statistics collection.
-              Iterators that run longer than this value are logged in the
-                <codeph>iterators_history</codeph> table. For iterators with shorter run times, no
-              data is collected. Minimum value is 10 seconds.</p>
-            <p>This parameter’s value must always be equal to, or greater than, the value of
-                <codeph>min_query_time</codeph>. Setting <codeph>min_detailed_query_time</codeph>
-              higher than <codeph>min_query_time</codeph> allows you to log detailed query plan
-              iterator data only for especially complex, long-running queries, while still logging
-              basic query data for shorter queries.</p>
-            <p>Given the complexity and size of iterator data, you may want to adjust this parameter
-              according to the size of data collected. If the <codeph>iterators_*</codeph> tables
-              are growing to excessive size without providing useful information, you can raise the
-              value of this parameter to log iterator detail for fewer queries.</p>
-          </stentry>
-        </strow>
-        <strow>
           <stentry>max_log_size</stentry>
           <stentry>
             <p>This parameter is not included in <codeph>gpperfmon.conf</codeph>, but it may be


### PR DESCRIPTION
Remove usage of configuration parameter min_detailed_query_time, and its documentation. 

- Also fix Coverity issues.

NOTE: this branch is based on the gpperfmon_cut_iterators branch.  The first four commits are for that branch, and will be removed from this PR when that PR is merged.  This PR must follow PR https://github.com/greenplum-db/gpdb/pull/2558

