### PR TITLE
Reorganize gpfdist and gpcloud makefile targets

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -28,8 +28,7 @@ all:
 	$(MAKE) -C contrib/pg_upgrade_support all
 	$(MAKE) -C contrib/pg_upgrade all
 	$(MAKE) -C contrib/pgcrypto all
-	$(MAKE) -C gpAux/extensions mapreduce
-	$(MAKE) -C gpAux/extensions mkgpcloud
+	$(MAKE) -C gpAux/extensions all
 	$(MAKE) -C gpAux/gpperfmon all
 	$(MAKE) -C gpAux/platform all
 	@echo "All of Greenplum Database successfully made. Ready to install."

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -28,7 +28,7 @@ all : devel
 .PHONY : autoconf
 
 # Internal functions which are invoked by other rules within this makefile
-.PHONY : mkgpfdist copydocs mgmtcopy copylibs
+.PHONY : copydocs mgmtcopy copylibs
 .PHONY : greenplum_path RECONFIG HOMEDEP GPROOTDEP GPROOTDEP GPROOTFAIL
 .PHONY : gccVersionCheck clients loaders gppkg
 
@@ -331,7 +331,6 @@ define BUILD_STEPS
 	@$(MAKE) mkpgbouncer INSTLOC=$(INSTLOC) BUILDDIR=$(BUILDDIR)
 	@$(MAKE) mkpgbench INSTLOC=$(INSTLOC) BUILDDIR=$(BUILDDIR)
 	if [ "$(findstring $(BLD_ARCH),$(SERVER_PLATFORMS))" != "" ]; then \
-	  $(MAKE) mkgpcloud INSTLOC=$(INSTLOC) && \
 	  $(MAKE) mkgphdfs INSTLOC=$(INSTLOC) && \
 	  $(MAKE) mkorafce INSTLOC=$(INSTLOC);  \
 	fi
@@ -352,7 +351,6 @@ ifeq "$(BLD_GPDB_BUILDSET)" "aix_subset"
 define BUILD_STEPS
 	rm -rf $(INSTLOC)
 	cd $(BUILDDIR)/src/include/ && $(MAKE) install
-	@$(MAKE) mkgpfdist INSTLOC=$(INSTLOC)
 	@$(MAKE) mgmtcopy INSTLOC=$(INSTLOC)
 	@$(MAKE) copylibs INSTLOC=$(INSTLOC)
 	@$(MAKE) loaders INSTLOC=$(INSTLOC) LOADERSINSTLOC=$(LOADERSINSTLOC)
@@ -855,15 +853,8 @@ set_scripts_version :
 # Internal functions
 #---------------------------------------------------------------------
 
-mkgpfdist:
-	@cd extensions && $(MAKE) mkgpfdist OPT="$(INSTCFLAGS)" INSTLOC=$(INSTLOC)
-	cp -p extensions/gpfdist/gpfdist$(EXE_EXT) $(INSTLOC)/bin/
-
 mkgphdfs:
 	@cd extensions && $(MAKE) mkgphdfs OPT="$(INSTCFLAGS)" INSTLOC=$(INSTLOC)
-
-mkgpcloud:
-	@cd extensions && $(MAKE) mkgpcloud OPT="$(INSTCFLAGS)" INSTLOC=$(INSTLOC) install
 
 mkorafce:
 	@cd extensions && $(MAKE) mkorafce OPT="$(INSTCFLAGS)" INSTLOC=$(INSTLOC)

--- a/gpAux/extensions/Makefile
+++ b/gpAux/extensions/Makefile
@@ -15,16 +15,28 @@ ifneq (${ENV_JAVA_HOME},)
 	JAVA_HOME=${ENV_JAVA_HOME}
 endif
 
-all: mkgphdfs
+.PHONY: all install clean distclean installcheck mapreduce gpcloud mkgphdfs mkorafce
 
-.PHONY:
+#
+# targets built via top_builddir/GNUmakefile
+#
+
+all: mapreduce gpcloud
+
 mapreduce:
 	@if [ "$(enable_mapreduce)" = "yes" ]; then \
 		echo "gpmapreduce enabled"; \
 		$(MAKE) -C gpmapreduce; \
 	fi
 
-install: mapreduce mkgpcloud
+gpcloud:
+	@if [ "$(enable_gpcloud)" = "yes" ]; then \
+		echo "gpcloud enabled"; \
+		$(MAKE) -C gpcloud; \
+		$(MAKE) -C gpcloud/bin/gpcheckcloud; \
+	fi
+
+install:
 	@if [ "$(enable_mapreduce)" = "yes" ]; then \
 		$(MAKE) -C gpmapreduce install; \
 	fi
@@ -35,26 +47,31 @@ install: mapreduce mkgpcloud
 
 clean:
 	if [ "$(enable_mapreduce)" = "yes" ]; then $(MAKE) -C gpmapreduce clean; fi
-
+	if [ "$(enable_gpcloud)" = "yes" ]; then $(MAKE) -C gpcloud clean; fi
 
 distclean:
 	if [ "$(enable_mapreduce)" = "yes" ]; then $(MAKE) -C gpmapreduce distclean; fi
+	if [ "$(enable_gpcloud)" = "yes" ]; then $(MAKE) -C gpcloud distclean; fi
 
-.PHONY:
+installcheck:
+	if [ -d "$(ext_dir)" ]; then \
+		PATH=$(INSTLOC)/bin:$(PATH) $(MAKE) -C orafce installcheck USE_PGXS=1 && \
+		PATH=$(INSTLOC)/bin:$(PATH) $(MAKE) -C gphdfs installcheck USE_PGXS=1 ; \
+	fi; \
+	if [ "$(enable_mapreduce)" = "yes" ]; then \
+		$(MAKE) -C gpmapreduce installcheck; \
+	fi
+
+#
+# below targets will be built via top_builddir/gpAux/Makefile
+#
+
 mkgphdfs:
 	PATH=$(INSTLOC)/bin:$(PATH) $(MAKE) -C gphdfs USE_PGXS=1 docdir=$(INSTLOC)/docs install \
 		ANT=/opt/releng/apache-ant/bin/ant \
 		JAVA_HOME=${JAVA_HOME}
 
-.PHONY:
-mkgpcloud:
-	@if [ "$(enable_gpcloud)" = "yes" ]; then \
-		echo "gpcloud enabled"; \
-		$(MAKE) -C gpcloud; \
-		$(MAKE) -C gpcloud/bin/gpcheckcloud; \
-	fi
-
-# Only include include these files when running enterprise build
+# Only include these files when running enterprise build
 ENTERPRISE_TARGETS="mkgphdfs mkorafce"
 ifneq ($(findstring $(MAKECMDGOALS), $(ENTERPRISE_TARGETS)),)
 include $(BLD_TOP)/Makefile.global
@@ -84,17 +101,5 @@ JAVAH=${JAVA_HOME}/bin/javah
 JAR=${JAVA_HOME}/bin/jar
 JAVADOC=${JAVA_HOME}/bin/javadoc
 
-
-.PHONY:
 mkorafce:
 	PATH=$(INSTLOC)/bin:$(PATH) $(MAKE) -C orafce install USE_PGXS=1
-
-installcheck:
-	if [ -d "$(ext_dir)" ]; then \
-		PATH=$(INSTLOC)/bin:$(PATH) $(MAKE) -C orafce installcheck USE_PGXS=1 && \
-		PATH=$(INSTLOC)/bin:$(PATH) $(MAKE) -C gphdfs installcheck USE_PGXS=1 ; \
-	fi; \
-	if [ "$(enable_mapreduce)" = "yes" ]; then \
-		$(MAKE) -C gpmapreduce installcheck; \
-	fi
-


### PR DESCRIPTION
gpfdist and gpcloud were shifted to top level by below commits, should
be moved out of gpAux/Makefile.

    commit 6125ac85cae720f484d0d45042131f4b859779d2
    Author: Marbin Tan <mtan@pivotal.io>
    Date:   Fri Feb 5 11:23:06 2016 -0800

        Move gpfdist to gpdb core.

    commit 4e34d8bb332c33992527c45662bf5348f76581e6
    Author: Adam Lee <ali@pivotal.io>
    Date:   Wed May 24 16:53:15 2017 +0800

        Add a build flag for gpcloud