### PR TITLE
concourse: ignore docs changes on PR Pipeline

### DIFF
--- a/concourse/pipelines/pr_pipeline.yml
+++ b/concourse/pipelines/pr_pipeline.yml
@@ -3,17 +3,20 @@
 ## ======================================================================
 
 resource_types:
-  - name: pull_request_with_submodule
+  - name: pull_request
     type: docker-image
     source:
       repository: jtarchie/pr
 
 resources:
   - name: gpdb_pr
-    type: pull_request_with_submodule
+    type: pull_request
     source:
       repo: greenplum-db/gpdb
       access_token: {{gpdb-git-access-token}}
+      ignore_paths:
+      - gpdb-doc/*
+      - README*
 
   - name: centos-gpdb-dev-6
     type: docker-image


### PR DESCRIPTION
Various people working on documentation, either user-facing or READMEs,
have concourse unnecessarily run against their PRs. With this change,
there will be less load on the PR pipeline and PRs with only docs
changes won't get a green or red mark from concourse.

This extends a configuration from the master pipeline now to the PR
pipeline, since it's now supported for the PR resource.