### PR TITLE
Move client build to top level makefile

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -8,7 +8,6 @@ subdir =
 top_builddir = .
 include $(top_builddir)/src/Makefile.global
 
-
 all:
 #	$(MAKE) -C doc all
 	$(MAKE) -C src all
@@ -57,6 +56,7 @@ install:
 	$(MAKE) -C gpAux/extensions $@
 	$(MAKE) -C gpAux/gpperfmon $@
 	$(MAKE) -C gpAux/platform $@
+	$(MAKE) -C gpAux/client $@ 
 	@echo "Greenplum Database installation complete."
 
 installdirs uninstall:

--- a/configure
+++ b/configure
@@ -729,10 +729,11 @@ with_python
 with_perl
 with_tcl
 enable_thread_safety
+enable_clients
 INCLUDES
+enable_segwalrep
 HAVE_CXX11
 enable_gpcloud
-enable_segwalrep
 enable_mapreduce
 enable_netbackup
 enable_ddboost
@@ -858,6 +859,7 @@ enable_netbackup
 enable_mapreduce
 enable_gpcloud
 enable_segwalrep
+enable_clients
 enable_thread_safety
 enable_thread_safety_force
 with_tcl
@@ -1539,6 +1541,7 @@ Optional Features:
   --enable-mapreduce      enable Greenplum Mapreduce support
   --disable-gpcloud       disable gpcloud support
   --enable-segwalrep      enable segment WAL replication
+  --disable-clients       disable clients support
   --disable-thread-safety  Do not make client libraries thread-safe
   --enable-thread-safety-force  force thread-safety despite thread test failure
   --disable-largefile     omit support for large files
@@ -6931,7 +6934,6 @@ $as_echo "#define HAVE_CXX11 1" >>confdefs.h
 
 fi # fi
 
-
 #
 # Enable segment WAL replication
 #
@@ -6981,6 +6983,39 @@ $as_echo "$as_me: WARNING: *** Include directory $dir does not exist." >&2;}
 done
 IFS=$ac_save_IFS
 
+
+# clients, enabled by default
+#
+
+pgac_args="$pgac_args enable_clients"
+
+# Check whether --enable-clients was given.
+if test "${enable_clients+set}" = set; then :
+  enableval=$enable_clients;
+  case $enableval in
+    yes)
+
+$as_echo "#define USE_CLIENTS 1" >>confdefs.h
+
+      ;;
+    no)
+      :
+      ;;
+    *)
+      as_fn_error $? "no argument expected for --enable-clients option" "$LINENO" 5
+      ;;
+  esac
+
+else
+  enable_clients=yes
+
+$as_echo "#define USE_CLIENTS 1" >>confdefs.h
+
+fi
+
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: checking whether to build with clients... $enable_clients" >&5
+$as_echo "checking whether to build with clients... $enable_clients" >&6; }
 
 
 #

--- a/configure.in
+++ b/configure.in
@@ -769,6 +769,13 @@ done
 IFS=$ac_save_IFS
 AC_SUBST(INCLUDES)
 
+# clients, enabled by default
+#
+PGAC_ARG_BOOL(enable, clients, yes, [  --disable-clients       disable clients support],
+              [AC_DEFINE([USE_CLIENTS], 1,
+                                    [Define to 1 to build with clients (--enable-clients)])])
+AC_MSG_RESULT([checking whether to build with clients... $enable_clients])
+AC_SUBST(enable_clients)
 
 #
 # Library directories

--- a/gpAux/client/Makefile
+++ b/gpAux/client/Makefile
@@ -1,0 +1,49 @@
+all: clients
+top_builddir:=../..
+include $(top_builddir)/src/Makefile.global
+
+INSTLOC:=${prefix}
+
+CLIENT_HOME_DIR:=${prefix}
+LOADERS_HOME_DIR:=${prefix}
+
+CLIENTINSTLOC=$(CLIENT_HOME_DIR)/greenplum-clients
+CLIENTINSTLOC_BIN=$(CLIENTINSTLOC)/bin
+CLIENTINSTLOC_LIB=$(CLIENTINSTLOC)/lib
+CLIENTINSTLOC_INCLUDE=$(CLIENTINSTLOC)/include
+CLIENTINSTLOC_DOCS=$(CLIENTINSTLOC)/docs
+CLIENTINSTLOC_OPENSOURCE=$(CLIENTINSTLOC)/thirdparty
+
+LOADERSINSTLOC=$(LOADERS_HOME_DIR)/greenplum-loaders
+LOADERSINSTLOC_BIN=$(LOADERSINSTLOC)/bin
+LOADERSINSTLOC_BINEXT=$(LOADERSINSTLOC)/bin/ext/
+LOADERSINSTLOC_EXT=$(LOADERSINSTLOC)/ext
+LOADERSINSTLOC_LIB=$(LOADERSINSTLOC)/lib
+LOADERSINSTLOC_LIB_PWARE=$(LOADERSINSTLOC)/lib/pware
+LOADERSINSTLOC_DOCS=$(LOADERSINSTLOC)/docs
+LOADERSINSTLOC_OPENSOURCE=$(LOADERSINSTLOC)/thirdparty
+
+define tmpCLIENT_FILESET
+	pg_dump
+	pg_dumpall
+	psql
+endef
+CLIENT_FILESET = $(strip $(tmpCLIENT_FILESET))
+install: clients
+	echo "installing clients"
+
+clients:
+	if [ "$(enable_clients)" = "yes" ]; then $(MAKE) clients_internal; fi
+clients_internal:
+	mkdir -p $(CLIENTINSTLOC_BIN)
+	(cd $(INSTLOC)/bin && $(TAR) cf - $(CLIENT_FILESET)) | (cd $(CLIENTINSTLOC_BIN)/ && $(TAR) xpf -)$(check_pipe_for_errors)
+	mkdir -p $(CLIENTINSTLOC_INCLUDE)
+	(cd $(INSTLOC)/include && $(TAR) cf - *) | (cd $(CLIENTINSTLOC_INCLUDE)/ && $(TAR) xpf -)$(check_pipe_for_errors)
+	mkdir -p $(CLIENTINSTLOC_LIB)
+	(cd $(INSTLOC)/lib && $(TAR) cf - *) | (cd $(CLIENTINSTLOC_LIB)/ && $(TAR) xpf -)$(check_pipe_for_errors)
+ifneq "$(FILESET_LIB_GCC)" ""
+	(cd $(CLIENTINSTLOC_LIB)/ && $(TAR) cf - -C $(FILESET_LIB_GCC_LOC) $(FILESET_LIB_GCC) | $(TAR) xpf -)$(check_pipe_for_errors)
+endif
+	# ---- copy license files ----
+	cp $(top_builddir)/LICENSE $(CLIENTINSTLOC)
+	cp $(top_builddir)/NOTICE $(CLIENTINSTLOC)

--- a/src/Makefile.global.in
+++ b/src/Makefile.global.in
@@ -182,6 +182,7 @@ enable_rpath	= @enable_rpath@
 # this in configure.in
 # enable_nls	= @enable_nls@
 enable_debug	= @enable_debug@
+enable_clients     = @enable_clients@
 enable_dtrace	= @enable_dtrace@
 enable_coverage	= @enable_coverage@
 enable_thread_safety	= @enable_thread_safety@


### PR DESCRIPTION
Add a flag to control client configuration (--enable-client).
Add top level target to build client only.
Move client target out of gpAux/Makfile, create one in gpAux/client/Makefile.

Signed-off-by: Yuan Zhao <yuzhao@pivotal.io>