### PR TITLE
Remove intermittent external protocol test

### DIFF
--- a/contrib/extprotocol/expected/exttableext.out
+++ b/contrib/extprotocol/expected/exttableext.out
@@ -711,9 +711,8 @@ NOTICE:  table "exttabtest_r_invalid" does not exist, skipping
     -- Add a column (value3) to RET
     ALTER EXTERNAL TABLE exttabtest_r_invalid ADD COLUMN value3 int;
     -- Access RET again with changed structure, the data file format is invalid now
-    SELECT count(*) from exttabtest_r_invalid;
-ERROR:  missing data for column "value3"  (seg0 slice1 rh55-qavm55:7532 pid=14575)
-DETAIL:  External table exttabtest_r_invalid, line 1 of demoprot://exttabtest.txt: "1	name1	2	3"
+    -- Comment this out since output file is undeterministic
+    -- SELECT count(*) from exttabtest_r_invalid;
     -- Drop a column (id) from RET
     ALTER EXTERNAL TABLE exttabtest_r_invalid DROP COLUMN id;
     -- Access RET again with changed structure, the data file format is also invalid

--- a/contrib/extprotocol/sql/exttableext.sql
+++ b/contrib/extprotocol/sql/exttableext.sql
@@ -568,7 +568,8 @@ select max(cnt) - min(cnt)  > 20 from t;
     ALTER EXTERNAL TABLE exttabtest_r_invalid ADD COLUMN value3 int;
 
     -- Access RET again with changed structure, the data file format is invalid now
-    SELECT count(*) from exttabtest_r_invalid;
+    -- Comment this out since output file is undeterministic
+    -- SELECT count(*) from exttabtest_r_invalid;
 
     -- Drop a column (id) from RET
     ALTER EXTERNAL TABLE exttabtest_r_invalid DROP COLUMN id;


### PR DESCRIPTION
A test output in extprotocol is undeterministic in which case all
segments will report an error, you can not tell which segment will
report it firstly. Normally it's segment 0 first report that, but we
can not count on this.


This is a fix for https://gpdb.ci.pivotalci.info/teams/gpdb/pipelines/gpdb_master/jobs/icw_planner_ictcp_centos6/builds/15