### PR TITLE
gpperfmon fix coverity issues and compiler warning

### DIFF
--- a/gpAux/gpperfmon/src/gpmon/gpmon_agg.c
+++ b/gpAux/gpperfmon/src/gpmon/gpmon_agg.c
@@ -641,7 +641,6 @@ apr_status_t agg_dump(agg_t* agg)
 	apr_hash_index_t *hi;
 	bloom_t bloom;
 	char nowstr[GPMON_DATE_BUF_SIZE];
-	int e = 0;
 	FILE* fp_queries_now = 0;
 	FILE* fp_queries_tail = 0;
 
@@ -690,10 +689,7 @@ apr_status_t agg_dump(agg_t* agg)
 	incremement_tail_bytes(temp_bytes_written);
 
 	if (! (fp_queries_tail = fopen(GPMON_DIR "queries_tail.dat", "a")))
-	{
-		e = APR_FROM_OS_ERROR(errno);
-		goto bail;
-	}
+		return APR_FROM_OS_ERROR(errno);
 
 	/* loop through queries */
 	for (hi = apr_hash_first(0, agg->qtab); hi; hi = apr_hash_next(hi))
@@ -743,10 +739,7 @@ apr_status_t agg_dump(agg_t* agg)
 	incremement_tail_bytes(temp_bytes_written);
 
 	if (! (fp_queries_now = fopen(GPMON_DIR "_queries_now.dat", "w")))
-	{
-		e = APR_FROM_OS_ERROR(errno);
-		goto bail;
-	}
+		return APR_FROM_OS_ERROR(errno);
 
 	for (hi = apr_hash_first(0, agg->qtab); hi; hi = apr_hash_next(hi))
 	{
@@ -791,11 +784,6 @@ apr_status_t agg_dump(agg_t* agg)
 	delete_old_files(&bloom);
 
 	return 0;
-
-	bail:
-	if (fp_queries_now) fclose(fp_queries_now);
-	if (fp_queries_tail) fclose(fp_queries_tail);
-	return e;
 }
 
 extern int gpmmon_quantum(void);

--- a/gpAux/gpperfmon/src/gpmon/gpmon_agg.c
+++ b/gpAux/gpperfmon/src/gpmon/gpmon_agg.c
@@ -411,6 +411,9 @@ static apr_status_t agg_put_qexec(agg_t* agg, const qexec_packet_t* qexec_packet
 	}
 	else {
 		/* not found, make new hash entry */
+		if (! (mmon_qexec_existing = apr_palloc(agg->pool, sizeof(mmon_qexec_t))))
+			return APR_ENOMEM;		
+
 		memcpy(&mmon_qexec_existing->key, &qexec_packet->data.key, sizeof(gpmon_qexeckey_t));
 		mmon_qexec_existing->_cpu_elapsed = qexec_packet->data._cpu_elapsed;
 		mmon_qexec_existing->measures_rows_in = qexec_packet->data.measures_rows_in;

--- a/gpAux/gpperfmon/src/gpmon/gpsmon.c
+++ b/gpAux/gpperfmon/src/gpmon/gpsmon.c
@@ -845,24 +845,6 @@ static void send_machine_metrics(SOCKET sock)
 	pswap = swap, pcpu = cpu;
 }
 
-
-/*
-* This helper function sums the upper and lower portions of the new 64 bit value
-* The upper_sum is the value being used to calculate the upper portion (56 bits worth) of the sum
-* The lower_sum is the value being used to calculate the lower portion (8 bits worth) of the sum
-* The upper_sum can handle the maximum value up to 4096 max values before it overflows ((2^56)-1) X 4096 = (2^64)-1)
-* The lower_sum can handle the maximum value up to 16843009 max values before it overflows ((2^8)-1) X 16843009 = (2^32)-1)
-*/
-static inline void qexec_average_sum_calc_64_unsigned(apr_uint64_t* upper_sum, apr_uint32_t* lower_sum, apr_uint64_t new_value)
-{
-	if (new_value == 0){
-		return;
-	}
-	*upper_sum+= (new_value >> 8);
-	*lower_sum+= (new_value & 0xFF);
-	return;
-}
-
 static void gx_gettcpcmd(SOCKET sock, short event, void* arg)
 {
 	char dump;


### PR DESCRIPTION
   -  Removing unused function that got left over from code cleanup.

    - CID 170478:  Control flow issues  (DEADCODE)
    the "goto" function was dead code. We are closing the currently opened
    file right before we open up a new file already, so the FILE pointer was
    always NULL when "goto bail" occurred.

    - CID 170479: (Null pointer dereferences)
    We were trying to access access a pointer that may potentially be NULL
    as the key value pair might not exist in the the apr_hash.
    Ensure that we allocate memory before doing a memcpy.