### PR TITLE
Assign Rollover as parent account if the parent account is obsolete

### DIFF
--- a/src/backend/utils/mmgr/memaccounting.c
+++ b/src/backend/utils/mmgr/memaccounting.c
@@ -811,9 +811,13 @@ ConvertMemoryAccountArrayToTree(MemoryAccount** longLiving, MemoryAccount** shor
 			{
 				parentAccount = longLiving[shortLivingAccount->parentId];
 			}
-			else
+			else if (shortLivingAccount->parentId >= liveStartId)
 			{
 				parentAccount = shortLiving[shortLivingAccount->parentId - liveStartId];
+			}
+			else /* Dead parent account. Use Rollover as parent */
+			{
+				parentAccount = longLiving[MEMORY_OWNER_TYPE_Rollover];
 			}
 
 			Assert(NULL != parentAccount);


### PR DESCRIPTION
The generational memory accounting (originally implemented in https://github.com/greenplum-db/gpdb/pull/1175) automatically frees all the short living accounts at the end of each statement. All the code is guarded already to detect accounts that are "dead" or obsolete (from previous statements). Such account ownership is transparently transferred to Rollover account. 

A plan node that outlives a SQL statement may save memory account id that can be used to switch to a dead account. This is innocuous as successive allocations transparently goes under Rollover. 

Additionally, dead account can also become parent of a newly created account. In such cases, during serialization of an account tree (e.g., if we need to write to CSV during a OOM logging), the serializer tries to access the parent account by translating soft pointer (array index) to an actual pointer. As the parent account is obsolete, we won't be able to translate to a valid pointer. 

To prevent this, this PR looks at the parent account id and translates any outdated account id to rollover. Unit test is added to verify such parent changes.