### PR TITLE
Remove unreachable and unused code

### DIFF
--- a/gpAux/gpperfmon/src/gpmon/gpmmon.c
+++ b/gpAux/gpperfmon/src/gpmon/gpmmon.c
@@ -1628,9 +1628,6 @@ char* get_ip_for_host(char* host, bool* returnParamIsIpv6)
 		return NULL;
 	}
 
-	if (addrs == NULL)
-		return NULL;
-
 	ipstr = malloc(128);
 	/* just grab the first address... it should be fine */
 	if (addrs->ai_family == AF_INET)

--- a/gpAux/gpperfmon/src/gpmon/gpmondb.c
+++ b/gpAux/gpperfmon/src/gpmon/gpmondb.c
@@ -392,12 +392,6 @@ void process_line_in_hadoop_cluster_info(apr_pool_t* tmp_pool, apr_hash_t* htab,
 		*location = 0; // remove comments from the line
 	}
 
-	if (!line)
-	{
-		gpmon_warningx(FLINE, 0, "Line in devices file is null after removing comments, skipping");
-		return;
-	}
-
 	// we do these in reverse order so inserting null chars does not prevent finding other tokens
 	if (find_token_in_config_string(line, &category, "Categories"))
 	{

--- a/src/backend/utils/mmgr/memprot.c
+++ b/src/backend/utils/mmgr/memprot.c
@@ -377,7 +377,7 @@ static void *gp_malloc_internal(int64 requested_size)
 	Assert(requested_size > 0);
 	size_t size_with_overhead = UserPtrSize_GetVmemPtrSize(requested_size);
 
-	Assert(size_with_overhead >= 0 && size_with_overhead <= MAX_REQUESTABLE_SIZE);
+	Assert(size_with_overhead <= MAX_REQUESTABLE_SIZE);
 
 	MemoryAllocationStatus stat = VmemTracker_ReserveVmem(size_with_overhead);
 	if (MemoryAllocation_Success == stat)

--- a/src/backend/utils/sort/tuplesort_mk.c
+++ b/src/backend/utils/sort/tuplesort_mk.c
@@ -1223,8 +1223,6 @@ grow_unsorted_array(Tuplesortstate_mk *state)
 
 	uint64		availMem = state->memAllowed - MemoryContextGetCurrentSpace(state->sortcontext);
 	uint64		avgTupSize = (uint64) (((double) state->totalTupleBytes) / ((double) state->totalNumTuples));
-
-	Assert(avgTupSize >= 0);
 	uint64		avgExtraForPrep = (uint64) (((double) state->mkctxt.estimatedExtraForPrep) / ((double) state->totalNumTuples));
 
 	if ((availMem / (sizeof(MKEntry) + avgTupSize + avgExtraForPrep)) == 0)

--- a/src/bin/pg_dump/cdb/cdb_ddboost_util.c
+++ b/src/bin/pg_dump/cdb/cdb_ddboost_util.c
@@ -2496,8 +2496,6 @@ cleanup:
 		free(full_path);
 	if (dest_path)
 		free(dest_path);
-	if (fp)
-		fclose(fp);
 	if (dird != DDP_INVALID_DESCRIPTOR)
 	{
 		ddp_close_dir(dird);

--- a/src/include/utils/memaccounting_private.h
+++ b/src/include/utils/memaccounting_private.h
@@ -172,8 +172,6 @@ MemoryAccounting_Free(MemoryAccountIdType memoryAccountId, Size allocatedSize)
 
 	MemoryAccountingOutstandingBalance -= allocatedSize;
 
-	Assert(MemoryAccountingOutstandingBalance >= 0);
-
 	return true;
 }
 


### PR DESCRIPTION
This removes code which is either unreachable due to prior identical
tests which break the codepath, or which is dead due to always being
true. Asserting that an unsigned integer is >= 0 will always be true,
so it's pointless.

Per "logically dead code" gripes by Coverity