### PR TITLE
Set a flag when window's child is exhausted.

### DIFF
--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2503,6 +2503,9 @@ typedef struct WindowState
 
 	/* Indicate if any function need a peer count. */
 	bool		need_peercount;
+
+	/* Indicate if child is done returning tuples */
+	bool	    is_input_done;
 } WindowState;
 
 /* ----------------

--- a/src/test/regress/expected/olap_window_seq.out
+++ b/src/test/regress/expected/olap_window_seq.out
@@ -8297,3 +8297,28 @@ explain select foo.a, sum(b) over (partition by bar.a order by bar.b) from foo, 
 (14 rows)
 
 drop table foo, bar;
+-- Test to verify fix for https://github.com/greenplum-db/gpdb/issues/2571
+drop table if exists foo;
+drop table if exists bar;
+create table foo (a int, b int) distributed by (a);
+create table bar (c int, d int) distributed by (c);
+insert into foo select i,i from generate_series(1,10) i;
+insert into bar select i,i from generate_series(1,10) i;
+set optimizer_segments to 1; 
+SELECT bar.*, count(*) OVER() AS e FROM foo, bar where foo.b = bar.d;
+ c  | d  | e  
+----+----+----
+  1 |  1 | 10
+  2 |  2 | 10
+  3 |  3 | 10
+  4 |  4 | 10
+  5 |  5 | 10
+  6 |  6 | 10
+  7 |  7 | 10
+  8 |  8 | 10
+  9 |  9 | 10
+ 10 | 10 | 10
+(10 rows)
+
+reset optimizer_segments;
+drop table foo, bar;

--- a/src/test/regress/expected/olap_window_seq_optimizer.out
+++ b/src/test/regress/expected/olap_window_seq_optimizer.out
@@ -8311,3 +8311,28 @@ explain select foo.a, sum(b) over (partition by bar.a order by bar.b) from foo, 
 (16 rows)
 
 drop table foo, bar;
+-- Test to verify fix for https://github.com/greenplum-db/gpdb/issues/2571
+drop table if exists foo;
+drop table if exists bar;
+create table foo (a int, b int) distributed by (a);
+create table bar (c int, d int) distributed by (c);
+insert into foo select i,i from generate_series(1,10) i;
+insert into bar select i,i from generate_series(1,10) i;
+set optimizer_segments to 1;
+SELECT bar.*, count(*) OVER() AS e FROM foo, bar where foo.b = bar.d;
+ c  | d  | e 
+----+----+----
+  1 |  1 | 10
+  2 |  2 | 10
+  3 |  3 | 10
+  4 |  4 | 10
+  5 |  5 | 10
+  6 |  6 | 10
+  7 |  7 | 10
+  8 |  8 | 10
+  9 |  9 | 10
+ 10 | 10 | 10
+(10 rows)
+
+reset optimizer_segments;
+drop table foo, bar;

--- a/src/test/regress/sql/olap_window_seq.sql
+++ b/src/test/regress/sql/olap_window_seq.sql
@@ -1652,3 +1652,16 @@ select foo.a, sum(b) over (partition by bar.a order by bar.b) from foo, bar wher
 explain select foo.a, sum(b) over (partition by bar.a order by bar.b) from foo, bar where foo.a = bar.a;
 
 drop table foo, bar;
+
+-- Test to verify fix for https://github.com/greenplum-db/gpdb/issues/2571
+drop table if exists foo;
+drop table if exists bar;
+create table foo (a int, b int) distributed by (a);
+create table bar (c int, d int) distributed by (c);
+insert into foo select i,i from generate_series(1,10) i;
+insert into bar select i,i from generate_series(1,10) i;
+set optimizer_segments to 1; 
+SELECT bar.*, count(*) OVER() AS e FROM foo, bar where foo.b = bar.d;
+
+reset optimizer_segments;
+drop table foo, bar;


### PR DESCRIPTION
There is an assert failure when Window's child is a HashJoin operator
and while filling its buffer Window receives a NULL tuple. In this case
HashJoin will call ExecEagerFreeHashJoin() since it is done returning
any tuples. However, Window once it has returned all the tuples in its
input buffer will call ExecProcNode() on HashJoin. This casues an assert
failure in HashJoin that states that ExecHashJoin() should not be called
if HashJoin's hashtable has already been released.

This commit fixes the above issue by setting a flag in WindowState when
Window encounters a null tuple while filling its buffer. This flag then
guards any subsequent call to ExecProcNode() from fetchCurrentRow()

This fixes #2571 