### PR TITLE
Fix WIN32 Compilation Issue in encnames.c

### DIFF
--- a/src/include/mb/pg_wchar.h
+++ b/src/include/mb/pg_wchar.h
@@ -254,6 +254,9 @@ typedef struct pg_encname
 {
 	char	   *name;
 	pg_enc		encoding;
+#ifdef WIN32
+	unsigned	codepage;
+#endif
 } pg_encname;
 
 extern pg_encname pg_encname_tbl[];


### PR DESCRIPTION
The original cherry-pick didn't get all the changes under WIN32.
The pg_enc2name struct is inconsistent between src/include/mb/pg_wchar.h
and encnames.c under WIN32, the "codepage" field is missing.
We re-port the change. We have tested under WIN32 and built successfully.

    Author: Magnus Hagander <magnus@hagander.net>
    Date:   Sat Oct 17 00:24:51 2009 +0000

        Write to the Windows eventlog in UTF16, converting the message encoding
        as necessary.

        Itagaki Takahiro with some changes from me
        (cherry picked from commit 748771379b9463ee7454630b3cb3f3087b3157cb)