### PR TITLE
Remap varattnos of qual and indexqualorig for DynamicIndexScan.

### DIFF
--- a/src/backend/executor/execDynamicIndexScan.c
+++ b/src/backend/executor/execDynamicIndexScan.c
@@ -85,6 +85,7 @@ IndexScan_RemapIndexScanVars(IndexScanState *indexScanState, bool initQual, bool
 		IndexScan_RemapLogicalIndexInfo(indexScanState, attMap);
 
 		DynamicScan_RemapExpression((ScanState *)indexScanState, attMap, (Node*)indexScan->indexqual);
+		DynamicScan_RemapExpression((ScanState *)indexScanState, attMap, (Node*)indexScan->indexqualorig);
 
 		if (initQual)
 		{

--- a/src/backend/executor/execDynamicIndexScan.c
+++ b/src/backend/executor/execDynamicIndexScan.c
@@ -85,7 +85,6 @@ IndexScan_RemapIndexScanVars(IndexScanState *indexScanState, bool initQual, bool
 		IndexScan_RemapLogicalIndexInfo(indexScanState, attMap);
 
 		DynamicScan_RemapExpression((ScanState *)indexScanState, attMap, (Node*)indexScan->indexqual);
-		DynamicScan_RemapExpression((ScanState *)indexScanState, attMap, (Node*)indexScan->indexqualorig);
 
 		if (initQual)
 		{

--- a/src/backend/executor/nodeDynamicIndexscan.c
+++ b/src/backend/executor/nodeDynamicIndexscan.c
@@ -122,7 +122,9 @@ DynamicIndexScan_ReMapColumns(DynamicIndexScanState *scanState, Oid newOid)
 	{
 		IndexScan_MapLogicalIndexInfo(indexScan->logicalIndexInfo, attMap, indexScan->scan.scanrelid);
 		change_varattnos_of_a_varno((Node*)indexScan->scan.plan.targetlist, attMap, indexScan->scan.scanrelid);
+		change_varattnos_of_a_varno((Node*)indexScan->scan.plan.qual, attMap, indexScan->scan.scanrelid);
 		change_varattnos_of_a_varno((Node*)indexScan->indexqual, attMap, indexScan->scan.scanrelid);
+		change_varattnos_of_a_varno((Node*)indexScan->indexqualorig, attMap, indexScan->scan.scanrelid);
 
 		pfree(attMap);
 

--- a/src/backend/executor/nodeDynamicIndexscan.c
+++ b/src/backend/executor/nodeDynamicIndexscan.c
@@ -124,7 +124,6 @@ DynamicIndexScan_ReMapColumns(DynamicIndexScanState *scanState, Oid newOid)
 		change_varattnos_of_a_varno((Node*)indexScan->scan.plan.targetlist, attMap, indexScan->scan.scanrelid);
 		change_varattnos_of_a_varno((Node*)indexScan->scan.plan.qual, attMap, indexScan->scan.scanrelid);
 		change_varattnos_of_a_varno((Node*)indexScan->indexqual, attMap, indexScan->scan.scanrelid);
-		change_varattnos_of_a_varno((Node*)indexScan->indexqualorig, attMap, indexScan->scan.scanrelid);
 
 		pfree(attMap);
 

--- a/src/test/regress/expected/partition_pruning.out
+++ b/src/test/regress/expected/partition_pruning.out
@@ -2889,7 +2889,7 @@ select * from sales where region = 'usa' or region = 'asia';
         1 | 01-01-2011 |  10.10 | usa
 (1 row)
 
--- Test DynamicIndexScan with dropped column
+-- Test DynamicIndexScan with extra filter
 create index idx_sales_date on sales(date);
 NOTICE:  building index for child partition "sales_1_prt_outlying_dates"
 NOTICE:  building index for child partition "sales_1_prt_outlying_dates_2_prt_usa"

--- a/src/test/regress/expected/partition_pruning.out
+++ b/src/test/regress/expected/partition_pruning.out
@@ -2889,6 +2889,66 @@ select * from sales where region = 'usa' or region = 'asia';
         1 | 01-01-2011 |  10.10 | usa
 (1 row)
 
+-- Test DynamicIndexScan with dropped column
+create index idx_sales_date on sales(date);
+NOTICE:  building index for child partition "sales_1_prt_outlying_dates"
+NOTICE:  building index for child partition "sales_1_prt_outlying_dates_2_prt_usa"
+NOTICE:  building index for child partition "sales_1_prt_outlying_dates_2_prt_asia"
+NOTICE:  building index for child partition "sales_1_prt_outlying_dates_2_prt_europe"
+NOTICE:  building index for child partition "sales_1_prt_outlying_dates_2_prt_other_regions"
+NOTICE:  building index for child partition "sales_1_prt_2"
+NOTICE:  building index for child partition "sales_1_prt_2_2_prt_asia"
+NOTICE:  building index for child partition "sales_1_prt_2_2_prt_europe"
+NOTICE:  building index for child partition "sales_1_prt_2_2_prt_other_regions"
+NOTICE:  building index for child partition "sales_1_prt_2_2_prt_usa"
+NOTICE:  building index for child partition "sales_1_prt_3"
+NOTICE:  building index for child partition "sales_1_prt_3_2_prt_usa"
+NOTICE:  building index for child partition "sales_1_prt_3_2_prt_asia"
+NOTICE:  building index for child partition "sales_1_prt_3_2_prt_europe"
+NOTICE:  building index for child partition "sales_1_prt_3_2_prt_other_regions"
+NOTICE:  building index for child partition "sales_1_prt_4"
+NOTICE:  building index for child partition "sales_1_prt_4_2_prt_usa"
+NOTICE:  building index for child partition "sales_1_prt_4_2_prt_asia"
+NOTICE:  building index for child partition "sales_1_prt_4_2_prt_europe"
+NOTICE:  building index for child partition "sales_1_prt_4_2_prt_other_regions"
+NOTICE:  building index for child partition "sales_1_prt_5"
+NOTICE:  building index for child partition "sales_1_prt_5_2_prt_usa"
+NOTICE:  building index for child partition "sales_1_prt_5_2_prt_asia"
+NOTICE:  building index for child partition "sales_1_prt_5_2_prt_europe"
+NOTICE:  building index for child partition "sales_1_prt_5_2_prt_other_regions"
+explain select * from sales where date = '2011-01-01' and region = 'usa';
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=100.64..4773.83 rows=5 width=47)
+   ->  Append  (cost=100.64..4773.83 rows=3 width=47)
+         ->  Bitmap Heap Scan on sales_1_prt_outlying_dates_2_prt_usa sales  (cost=100.64..1524.49 rows=1 width=53)
+               Recheck Cond: date = '01-01-2011'::date
+               Filter: region = 'usa'::text
+               ->  Bitmap Index Scan on idx_sales_date_1_prt_outlying_dates_2_prt_usa  (cost=0.00..100.64 rows=20 width=0)
+                     Index Cond: date = '01-01-2011'::date
+         ->  Bitmap Heap Scan on sales_1_prt_outlying_dates_2_prt_other_regions sales  (cost=100.64..1524.49 rows=1 width=53)
+               Recheck Cond: date = '01-01-2011'::date
+               Filter: region = 'usa'::text
+               ->  Bitmap Index Scan on idx_sales_date_1_prt_outlying_dates_2_prt_other_regions  (cost=0.00..100.64 rows=20 width=0)
+                     Index Cond: date = '01-01-2011'::date
+         ->  Bitmap Heap Scan on sales_1_prt_2_2_prt_other_regions sales  (cost=100.64..1524.49 rows=1 width=53)
+               Recheck Cond: date = '01-01-2011'::date
+               Filter: region = 'usa'::text
+               ->  Bitmap Index Scan on idx_sales_date_1_prt_2_2_prt_other_regions  (cost=0.00..100.64 rows=20 width=0)
+                     Index Cond: date = '01-01-2011'::date
+         ->  Index Scan using idx_sales_date_1_prt_2_2_prt_usa on sales_1_prt_2_2_prt_usa sales  (cost=0.00..200.37 rows=1 width=21)
+               Index Cond: date = '01-01-2011'::date
+               Filter: region = 'usa'::text
+ Settings:  enable_bitmapscan=on; enable_indexscan=on; enable_seqscan=off; optimizer=off
+ Optimizer status: legacy query optimizer
+(22 rows)
+
+select * from sales where date = '2011-01-01' and region = 'usa';
+ trans_id |    date    | amount | region 
+----------+------------+--------+--------
+        1 | 01-01-2011 |  10.10 | usa
+(1 row)
+
 -- Updating partition key
 select * from sales_1_prt_2_2_prt_usa;
  trans_id |    date    | amount | region 

--- a/src/test/regress/expected/partition_pruning_optimizer.out
+++ b/src/test/regress/expected/partition_pruning_optimizer.out
@@ -2500,7 +2500,7 @@ select * from sales where region = 'usa' or region = 'asia';
         1 | 01-01-2011 |  10.10 | usa
 (1 row)
 
--- Test DynamicIndexScan with dropped column
+-- Test DynamicIndexScan with extra filter
 create index idx_sales_date on sales(date);
 NOTICE:  building index for child partition "sales_1_prt_outlying_dates"
 NOTICE:  building index for child partition "sales_1_prt_outlying_dates_2_prt_usa"

--- a/src/test/regress/expected/partition_pruning_optimizer.out
+++ b/src/test/regress/expected/partition_pruning_optimizer.out
@@ -2500,6 +2500,54 @@ select * from sales where region = 'usa' or region = 'asia';
         1 | 01-01-2011 |  10.10 | usa
 (1 row)
 
+-- Test DynamicIndexScan with dropped column
+create index idx_sales_date on sales(date);
+NOTICE:  building index for child partition "sales_1_prt_outlying_dates"
+NOTICE:  building index for child partition "sales_1_prt_outlying_dates_2_prt_usa"
+NOTICE:  building index for child partition "sales_1_prt_outlying_dates_2_prt_asia"
+NOTICE:  building index for child partition "sales_1_prt_outlying_dates_2_prt_europe"
+NOTICE:  building index for child partition "sales_1_prt_outlying_dates_2_prt_other_regions"
+NOTICE:  building index for child partition "sales_1_prt_2"
+NOTICE:  building index for child partition "sales_1_prt_2_2_prt_asia"
+NOTICE:  building index for child partition "sales_1_prt_2_2_prt_europe"
+NOTICE:  building index for child partition "sales_1_prt_2_2_prt_other_regions"
+NOTICE:  building index for child partition "sales_1_prt_2_2_prt_usa"
+NOTICE:  building index for child partition "sales_1_prt_3"
+NOTICE:  building index for child partition "sales_1_prt_3_2_prt_usa"
+NOTICE:  building index for child partition "sales_1_prt_3_2_prt_asia"
+NOTICE:  building index for child partition "sales_1_prt_3_2_prt_europe"
+NOTICE:  building index for child partition "sales_1_prt_3_2_prt_other_regions"
+NOTICE:  building index for child partition "sales_1_prt_4"
+NOTICE:  building index for child partition "sales_1_prt_4_2_prt_usa"
+NOTICE:  building index for child partition "sales_1_prt_4_2_prt_asia"
+NOTICE:  building index for child partition "sales_1_prt_4_2_prt_europe"
+NOTICE:  building index for child partition "sales_1_prt_4_2_prt_other_regions"
+NOTICE:  building index for child partition "sales_1_prt_5"
+NOTICE:  building index for child partition "sales_1_prt_5_2_prt_usa"
+NOTICE:  building index for child partition "sales_1_prt_5_2_prt_asia"
+NOTICE:  building index for child partition "sales_1_prt_5_2_prt_europe"
+NOTICE:  building index for child partition "sales_1_prt_5_2_prt_other_regions"
+explain select * from sales where date = '2011-01-01' and region = 'usa';
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..3.00 rows=1 width=24)
+   ->  Sequence  (cost=0.00..3.00 rows=1 width=24)
+         ->  Partition Selector for sales (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
+               Filter: date = '01-01-2011'::date AND region = 'usa'::text
+               Partitions selected: 1 (out of 20)
+         ->  Dynamic Index Scan on sales (dynamic scan id: 1)  (cost=0.00..3.00 rows=1 width=24)
+               Index Cond: date = '01-01-2011'::date
+               Filter: date = '01-01-2011'::date AND region = 'usa'::text
+ Settings:  enable_bitmapscan=on; enable_indexscan=on; enable_seqscan=off
+ Optimizer status: PQO version 2.32.0
+(10 rows)
+
+select * from sales where date = '2011-01-01' and region = 'usa';
+ trans_id |    date    | amount | region 
+----------+------------+--------+--------
+        1 | 01-01-2011 |  10.10 | usa
+(1 row)
+
 -- Updating partition key
 select * from sales_1_prt_2_2_prt_usa;
  trans_id |    date    | amount | region 

--- a/src/test/regress/sql/partition_pruning.sql
+++ b/src/test/regress/sql/partition_pruning.sql
@@ -792,6 +792,11 @@ EXCHANGE PARTITION FOR ('usa') WITH TABLE sales_exchange_part ;
 select get_selected_parts('explain analyze select * from sales where region = ''usa'' or region = ''asia'';');
 select * from sales where region = 'usa' or region = 'asia';
 
+-- Test DynamicIndexScan with dropped column
+create index idx_sales_date on sales(date);
+explain select * from sales where date = '2011-01-01' and region = 'usa';
+select * from sales where date = '2011-01-01' and region = 'usa';
+
 -- Updating partition key
 
 select * from sales_1_prt_2_2_prt_usa;

--- a/src/test/regress/sql/partition_pruning.sql
+++ b/src/test/regress/sql/partition_pruning.sql
@@ -792,7 +792,7 @@ EXCHANGE PARTITION FOR ('usa') WITH TABLE sales_exchange_part ;
 select get_selected_parts('explain analyze select * from sales where region = ''usa'' or region = ''asia'';');
 select * from sales where region = 'usa' or region = 'asia';
 
--- Test DynamicIndexScan with dropped column
+-- Test DynamicIndexScan with extra filter
 create index idx_sales_date on sales(date);
 explain select * from sales where date = '2011-01-01' and region = 'usa';
 select * from sales where date = '2011-01-01' and region = 'usa';


### PR DESCRIPTION
Following example failed because we forgot to remap varattnos of plan.qual for DynamicIndexScan.

1. prepare
```
CREATE TABLE sales (trans_id int, to_be_dropped1 int, date date, amount 
decimal(9,2), to_be_dropped2 int, region text) 
DISTRIBUTED BY (trans_id)
PARTITION BY RANGE (date)
SUBPARTITION BY LIST (region)
SUBPARTITION TEMPLATE
( SUBPARTITION usa VALUES ('usa'), 
  SUBPARTITION asia VALUES ('asia'), 
  SUBPARTITION europe VALUES ('europe'), 
  DEFAULT SUBPARTITION other_regions)
  (START (date '2011-01-01') INCLUSIVE
   END (date '2012-01-01') EXCLUSIVE
   EVERY (INTERVAL '3 month'), 
   DEFAULT PARTITION outlying_dates );
   
alter table sales drop column to_be_dropped1;
alter table sales drop column to_be_dropped2;

create table sales_exchange_part (trans_id int, date date, amount 
decimal(9,2), region text);
-- Insert some data
insert into sales_exchange_part values(1, '2011-01-01', 10.1, 'usa');
-- Exchange
ALTER TABLE sales 
ALTER PARTITION FOR (RANK(1))
EXCHANGE PARTITION FOR ('usa') WITH TABLE sales_exchange_part ;

create index txxx on sales(date);
```

2. test
```
TEST=# select * from sales where date = '2011-01-01' and region = 'usa';
ERROR:  attribute 3 has wrong type (execQual.c:770)  (seg0 slice1 127.0.0.1:40000 pid=6769)
DETAIL:  Table has type numeric, but query expects date.
```

This pull request fix this problem, and also remap varattnos of indexqualorig which
may use later.

P.S.: 
For now, ORCA don't support index with express or constraints, so it's OK
to remap logical index info with scan's relid by calling IndexScan_MapLogicalIndexInfo().
Maybe later when we should consider remap them with hard-coded 1
as in gp_get_physical_index_relid().