### PR TITLE
Fix delete old partitions behavior and add tests

### DIFF
--- a/gpAux/gpperfmon/src/gpmon/gpmmon.c
+++ b/gpAux/gpperfmon/src/gpmon/gpmmon.c
@@ -1530,6 +1530,7 @@ int main(int argc, const char* const argv[])
 			interuptable_sleep(30); // sleep to prevent loop of forking process and failing
 			gpmon_fatal(FLINE, "\nfailed (1) to open perfmon log file %s\n", mmon_log_filename);
 		}
+		TR0(("starting mmon logging\n"));
 	}
 
 	/* check port */

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -4878,6 +4878,25 @@ def impl(context):
             And wait until the process "gpsmon" is up
         ''')
 
+@given('the setting "{variable_name}" is NOT set in the configuration file "{path_to_file}"')
+@when('the setting "{variable_name}" is NOT set in the configuration file "{path_to_file}"')
+def impl(context, variable_name, path_to_file):
+    path = os.path.join(os.getenv("MASTER_DATA_DIRECTORY"), path_to_file)
+    match_start_of_line = '^' + variable_name + '.*'
+    pattern = re.compile(match_start_of_line)
+    with open(path, 'r') as f:
+        for line in f.read().split('\n'):
+            if pattern.match(line):
+                raise Exception('found in file %s the setting: %s' % (line, variable_name))
+
+
+@given('the setting "{setting_string}" is placed in the configuration file "{path_to_file}"')
+@when('the setting "{setting_string}" is placed in the configuration file "{path_to_file}"')
+def impl(context, setting_string, path_to_file):
+    path = os.path.join(os.getenv("MASTER_DATA_DIRECTORY"), path_to_file)
+    with open(path, 'a') as f:
+        f.write(setting_string)
+        f.write("\n")
 
 @given('the latest gpperfmon gpdb-alert log is copied to a file with a fake (earlier) timestamp')
 @when('the latest gpperfmon gpdb-alert log is copied to a file with a fake (earlier) timestamp')


### PR DESCRIPTION
The gpperfmon feature for managing the size of its internal database (the `partition_age` feature, managing the database 'gpperfmon') was using an sql statement to drop partitions that was syntactically incorrect, so `partition_age` gpperfmon feature was not working.

The problem is that the old code was using the rows in partitionrangestart column from
pg_partition to generate sql to drop specific partitions. The row value from
partitionrangestart was reported as
```
 '2017-02-01 00:00:00'::timestamp(0) without time zone.
``` 
and the ALTER DROP execution was reporting an error "Not a constant expression".

To fix this, we use only the first part of partitionrangestart (just the timestamp) to make our ALTER DROP query work.

- Added behave test to confirm that it is now working


Signed-off-by: Larry Hamel <lhamel@pivotal.io>