### PR TITLE
Manipulate callback functions for resource group related operations.

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -33,6 +33,7 @@
 #include "catalog/namespace.h"
 #include "catalog/oid_dispatch.h"
 #include "commands/async.h"
+#include "commands/resgroupcmds.h"
 #include "commands/tablecmds.h"
 #include "commands/trigger.h"
 #include "executor/spi.h"
@@ -2735,6 +2736,9 @@ CommitTransaction(void)
 	/* All relations that are in the vacuum process are being commited now. */
 	ResetVacuumRels();
 
+	/* Process resource group related callbacks */
+	AtEOXact_ResGroup(true);
+
 	/* Check we've released all buffer pins */
 	AtEOXact_Buffers(true);
 
@@ -3039,6 +3043,9 @@ PrepareTransaction(void)
 						 RESOURCE_RELEASE_BEFORE_LOCKS,
 						 true, true);
 
+	/* Process resource group related callbacks */
+	AtEOXact_ResGroup(true);
+
 	/* Check we've released all buffer pins */
 	AtEOXact_Buffers(true);
 
@@ -3262,6 +3269,7 @@ AbortTransaction(void)
 		ResourceOwnerRelease(TopTransactionResourceOwner,
 							 RESOURCE_RELEASE_BEFORE_LOCKS,
 							 false, true);
+		AtEOXact_ResGroup(false);
 		AtEOXact_Buffers(false);
 		AtEOXact_RelationCache(false);
 		AtEOXact_Inval(false);

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -548,6 +548,10 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 			callbackCtx->value.i = newConcurrency;
 			callbackCtx->proposed.i = concurrency;
 			break;
+		default:
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("unsupported resource group limit type '%s'", defel->defname)));
 	}
 
 

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -1306,7 +1306,8 @@ AlterResourceGroupStmt:
 				 {
 					AlterResourceGroupStmt *n = makeNode(AlterResourceGroupStmt);
 					n->name = $4;
-					n->concurrency = $7;
+					n->prop = $6;
+					n->value.i = $7;
 					$$ = (Node *)n;
 				 }
 		;

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -248,6 +248,9 @@ static Node *makeIsNotDistinctFromNode(Node *expr, int position);
 %type <list>	OptQueueList
 %type <defelt>	OptQueueElem
 
+%type <list>	OptResourceGroupList
+%type <defelt>	OptResourceGroupElem
+
 %type <str>		OptSchemaName
 %type <list>	OptSchemaEltList
 
@@ -1302,14 +1305,27 @@ DropResourceGroupStmt:
  *
  *****************************************************************************/
 AlterResourceGroupStmt:
-			ALTER RESOURCE GROUP_P name SET CONCURRENCY SignedIconst
+			ALTER RESOURCE GROUP_P name SET OptResourceGroupList
 				 {
 					AlterResourceGroupStmt *n = makeNode(AlterResourceGroupStmt);
 					n->name = $4;
-					n->prop = $6;
-					n->value.i = $7;
+					n->options = $6;
 					$$ = (Node *)n;
 				 }
+		;
+
+/*
+ * Option for ALTER RESOURCE GROUP
+ */
+OptResourceGroupList: OptResourceGroupElem			{ $$ = list_make1($1); }
+		;
+
+OptResourceGroupElem:
+			CONCURRENCY IntegerOnly
+				{
+					/* was "concurrency" */
+					$$ = makeDefElem("concurrency", (Node *)$2);
+				}
 		;
 
 /*****************************************************************************

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -344,14 +344,11 @@ void ResGroupDropCheckForWakeup(Oid groupId, bool isCommit)
  * Wake up the backends in the wait queue when 'concurrency' is increased.
  * This function is called in the callback function of ALTER RESOURCE GROUP.
  */
-void ResGroupAlterCheckForWakeup(Oid groupId)
+void ResGroupAlterCheckForWakeup(Oid groupId, int value, int proposed)
 {
-	int	proposed;
 	int wakeNum;
 	PROC_QUEUE	*waitQueue;
 	ResGroup	group;
-
-	GetConcurrencyForResGroup(groupId, NULL, &proposed);
 
 	LWLockAcquire(ResGroupLock, LW_EXCLUSIVE);
 

--- a/src/include/commands/resgroupcmds.h
+++ b/src/include/commands/resgroupcmds.h
@@ -25,5 +25,6 @@ extern char *GetResGroupNameForId(Oid oid, LOCKMODE lockmode);
 extern void GetConcurrencyForResGroup(int groupId, int *value, int *proposed);
 extern float GetCpuRateLimitForResGroup(int groupId);
 extern Oid GetResGroupIdForRole(Oid roleid);
+extern void AtEOXact_ResGroup(bool isCommit);
 
 #endif   /* RESGROUPCMDS_H */

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1894,7 +1894,11 @@ typedef struct AlterResourceGroupStmt
 {
 	NodeTag		type;
 	char	   *name;			/* resource group to alter */
-	int			concurrency;
+	const char *prop;			/* property name */
+	union {
+		int		i;
+		float	f;
+	}			value;			/* property value */
 } AlterResourceGroupStmt;
 
 /* ----------------------

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1894,11 +1894,7 @@ typedef struct AlterResourceGroupStmt
 {
 	NodeTag		type;
 	char	   *name;			/* resource group to alter */
-	const char *prop;			/* property name */
-	union {
-		int		i;
-		float	f;
-	}			value;			/* property value */
+	List	   *options;		/* List of DefElem nodes */
 } AlterResourceGroupStmt;
 
 /* ----------------------

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -92,7 +92,7 @@ extern void ResGroupGetStat(Oid groupId, ResGroupStatType type, char *retStr, in
 /* Update the memory usage of resource group */
 extern void ResGroupUpdateMemoryUsage(int32 memoryChunks);
 
-extern void ResGroupAlterCheckForWakeup(Oid groupId);
+extern void ResGroupAlterCheckForWakeup(Oid groupId, int value, int proposed);
 extern void ResGroupDropCheckForWakeup(Oid groupId, bool isCommit);
 extern void ResGroupCheckForDrop(Oid groupId, char *name);
 extern int CalcConcurrencyValue(int groupId, int val, int proposed, int newProposed);

--- a/src/test/isolation2/expected/resgroup/resgroup_callback.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_callback.out
@@ -1,0 +1,73 @@
+-- start_ignore
+DROP RESOURCE GROUP rg_callback_test;
+ERROR:  resource group "rg_callback_test" does not exist
+-- end_ignore
+
+-- process callbacks on ABORT
+BEGIN;
+BEGIN
+CREATE RESOURCE GROUP rg_callback_test WITH (concurrency=10, cpu_rate_limit=0.1, memory_limit=0.1);
+CREATE
+ALTER RESOURCE GROUP rg_callback_test SET concurrency 20;
+ALTER
+DROP RESOURCE GROUP rg_callback_test;
+DROP
+ABORT;
+ABORT
+
+-- process callbacks on COMMIT
+BEGIN;
+BEGIN
+CREATE RESOURCE GROUP rg_callback_test WITH (concurrency=10, cpu_rate_limit=0.1, memory_limit=0.1);
+CREATE
+ALTER RESOURCE GROUP rg_callback_test SET concurrency 20;
+ALTER
+DROP RESOURCE GROUP rg_callback_test;
+DROP
+COMMIT;
+COMMIT
+
+-- process callbacks on ABORT after CREATE
+CREATE RESOURCE GROUP rg_callback_test WITH (concurrency=10, cpu_rate_limit=0.1, memory_limit=0.1);
+CREATE
+BEGIN;
+BEGIN
+ALTER RESOURCE GROUP rg_callback_test SET concurrency 20;
+ALTER
+DROP RESOURCE GROUP rg_callback_test;
+DROP
+ABORT;
+ABORT
+
+-- process callbacks on COMMIT after CREATE
+BEGIN;
+BEGIN
+ALTER RESOURCE GROUP rg_callback_test SET concurrency 20;
+ALTER
+DROP RESOURCE GROUP rg_callback_test;
+DROP
+COMMIT;
+COMMIT
+
+-- process callbacks on ABORT without DROP
+BEGIN;
+BEGIN
+CREATE RESOURCE GROUP rg_callback_test WITH (concurrency=10, cpu_rate_limit=0.1, memory_limit=0.1);
+CREATE
+ALTER RESOURCE GROUP rg_callback_test SET concurrency 20;
+ALTER
+ABORT;
+ABORT
+
+-- process callbacks on COMMIT without DROP
+BEGIN;
+BEGIN
+CREATE RESOURCE GROUP rg_callback_test WITH (concurrency=10, cpu_rate_limit=0.1, memory_limit=0.1);
+CREATE
+ALTER RESOURCE GROUP rg_callback_test SET concurrency 20;
+ALTER
+COMMIT;
+COMMIT
+
+DROP RESOURCE GROUP rg_callback_test;
+DROP

--- a/src/test/isolation2/expected/resgroup/resgroup_syntax.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_syntax.out
@@ -4,7 +4,7 @@
 
 --start_ignore
 DROP ROLE IF EXISTS rg_test_role;
-NOTICE:  role "rg_test_role" does not exist, skipping
+DROP
 --end_ignore
 CREATE ROLE rg_test_role;
 CREATE
@@ -185,3 +185,47 @@ ALTER
 
 DROP RESOURCE GROUP rg_test_group;
 DROP
+
+-- ----------------------------------------------------------------------
+-- Test: create/alter/drop a resource group in subtransaction
+-- ----------------------------------------------------------------------
+
+-- CREATE RESOURCE GROUP cannot run inside a subtransaction
+BEGIN;
+BEGIN
+SAVEPOINT rg_savepoint;
+SAVEPOINT
+CREATE RESOURCE GROUP rg_test_group WITH (concurrency=1, cpu_rate_limit=.05, memory_limit=.05, memory_redzone_limit=.7);
+ERROR:  CREATE RESOURCE GROUP cannot run inside a subtransaction
+ROLLBACK TO SAVEPOINT rg_savepoint;
+ROLLBACK
+ABORT;
+ABORT
+
+-- ALTER RESOURCE GROUP cannot run inside a subtransaction
+BEGIN;
+BEGIN
+CREATE RESOURCE GROUP rg_test_group WITH (concurrency=1, cpu_rate_limit=.05, memory_limit=.05, memory_redzone_limit=.7);
+CREATE
+SAVEPOINT rg_savepoint;
+SAVEPOINT
+ALTER RESOURCE GROUP rg_test_group SET CONCURRENCY 10;
+ERROR:  ALTER RESOURCE GROUP cannot run inside a subtransaction
+ROLLBACK TO SAVEPOINT rg_savepoint;
+ROLLBACK
+ABORT;
+ABORT
+
+-- DROP RESOURCE GROUP cannot run inside a subtransaction
+BEGIN;
+BEGIN
+CREATE RESOURCE GROUP rg_test_group WITH (concurrency=1, cpu_rate_limit=.05, memory_limit=.05, memory_redzone_limit=.7);
+CREATE
+SAVEPOINT rg_savepoint;
+SAVEPOINT
+DROP RESOURCE GROUP rg_test_group;
+ERROR:  DROP RESOURCE GROUP cannot run inside a subtransaction
+ROLLBACK TO SAVEPOINT rg_savepoint;
+ROLLBACK
+ABORT;
+ABORT

--- a/src/test/isolation2/isolation2_resgroup_schedule
+++ b/src/test/isolation2/isolation2_resgroup_schedule
@@ -6,5 +6,6 @@ test: resgroup/resgroup_cpu_rate_limit
 test: resgroup/resgroup_concurrency
 test: resgroup/drop_resgroup
 test: resgroup/resgroup_memory
+test: resgroup/resgroup_callback
 
 test: resgroup/disable_resgroup

--- a/src/test/isolation2/sql/resgroup/resgroup_callback.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_callback.sql
@@ -1,0 +1,44 @@
+-- start_ignore
+DROP RESOURCE GROUP rg_callback_test;
+-- end_ignore
+
+-- process callbacks on ABORT
+BEGIN;
+CREATE RESOURCE GROUP rg_callback_test WITH (concurrency=10, cpu_rate_limit=0.1, memory_limit=0.1);
+ALTER RESOURCE GROUP rg_callback_test SET concurrency 20;
+DROP RESOURCE GROUP rg_callback_test;
+ABORT;
+
+-- process callbacks on COMMIT
+BEGIN;
+CREATE RESOURCE GROUP rg_callback_test WITH (concurrency=10, cpu_rate_limit=0.1, memory_limit=0.1);
+ALTER RESOURCE GROUP rg_callback_test SET concurrency 20;
+DROP RESOURCE GROUP rg_callback_test;
+COMMIT;
+
+-- process callbacks on ABORT after CREATE
+CREATE RESOURCE GROUP rg_callback_test WITH (concurrency=10, cpu_rate_limit=0.1, memory_limit=0.1);
+BEGIN;
+ALTER RESOURCE GROUP rg_callback_test SET concurrency 20;
+DROP RESOURCE GROUP rg_callback_test;
+ABORT;
+
+-- process callbacks on COMMIT after CREATE
+BEGIN;
+ALTER RESOURCE GROUP rg_callback_test SET concurrency 20;
+DROP RESOURCE GROUP rg_callback_test;
+COMMIT;
+
+-- process callbacks on ABORT without DROP
+BEGIN;
+CREATE RESOURCE GROUP rg_callback_test WITH (concurrency=10, cpu_rate_limit=0.1, memory_limit=0.1);
+ALTER RESOURCE GROUP rg_callback_test SET concurrency 20;
+ABORT;
+
+-- process callbacks on COMMIT without DROP
+BEGIN;
+CREATE RESOURCE GROUP rg_callback_test WITH (concurrency=10, cpu_rate_limit=0.1, memory_limit=0.1);
+ALTER RESOURCE GROUP rg_callback_test SET concurrency 20;
+COMMIT;
+
+DROP RESOURCE GROUP rg_callback_test;

--- a/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
@@ -97,3 +97,30 @@ ALTER RESOURCE GROUP rg_test_group SET CONCURRENCY 2;
 ALTER RESOURCE GROUP rg_test_group SET CONCURRENCY 1000;
 
 DROP RESOURCE GROUP rg_test_group;
+
+-- ----------------------------------------------------------------------
+-- Test: create/alter/drop a resource group in subtransaction
+-- ----------------------------------------------------------------------
+
+-- CREATE RESOURCE GROUP cannot run inside a subtransaction
+BEGIN;
+SAVEPOINT rg_savepoint;
+CREATE RESOURCE GROUP rg_test_group WITH (concurrency=1, cpu_rate_limit=.05, memory_limit=.05, memory_redzone_limit=.7);
+ROLLBACK TO SAVEPOINT rg_savepoint;
+ABORT;
+
+-- ALTER RESOURCE GROUP cannot run inside a subtransaction
+BEGIN;
+CREATE RESOURCE GROUP rg_test_group WITH (concurrency=1, cpu_rate_limit=.05, memory_limit=.05, memory_redzone_limit=.7);
+SAVEPOINT rg_savepoint;
+ALTER RESOURCE GROUP rg_test_group SET CONCURRENCY 10;
+ROLLBACK TO SAVEPOINT rg_savepoint;
+ABORT;
+
+-- DROP RESOURCE GROUP cannot run inside a subtransaction
+BEGIN;
+CREATE RESOURCE GROUP rg_test_group WITH (concurrency=1, cpu_rate_limit=.05, memory_limit=.05, memory_redzone_limit=.7);
+SAVEPOINT rg_savepoint;
+DROP RESOURCE GROUP rg_test_group;
+ROLLBACK TO SAVEPOINT rg_savepoint;
+ABORT;


### PR DESCRIPTION
Maintain a dedicated list for resource group related callbacks.

At transaction end, the callback functions are processed in the order
of FIFO on COMMIT, and in the order of LIFO on ABORT.

Signed-off-by: Pengzhou Tang <ptang@pivotal.io>