### PR TITLE
gpperfmon: Remove solaris specific code

### DIFF
--- a/gpAux/gpperfmon/src/gpmon/gpmmon.c
+++ b/gpAux/gpperfmon/src/gpmon/gpmmon.c
@@ -842,7 +842,6 @@ static void* message_main(apr_thread_t* thread_, void* arg_)
 {
 	apr_queue_t *queue = arg_;
 	void *query = NULL;
-	char *query_str = NULL;
 	apr_status_t status;
 
 	TR2(("In message_main: error_disk_space_percentage = %d, warning_disk_space_percentage = %d, disk_space_interval = %d, max_disk_space_messages_per_interval = %d\n",
@@ -868,10 +867,9 @@ static void* message_main(apr_thread_t* thread_, void* arg_)
 		}
 		else
 		{ // send the message
-			query_str = query; // have to do this because we still build on SUN!!!
-			if (!gpdb_exec_search_for_at_least_one_row((const char *)query_str, NULL))
+			if (!gpdb_exec_search_for_at_least_one_row((const char *)query, NULL))
 			{
-				TR0(("message_main ERROR: query %s failed. Cannot send message\n", query_str));
+				TR0(("message_main ERROR: query %s failed. Cannot send message\n", query));
 			}
 			free(query);
 		}

--- a/gpAux/gpperfmon/src/gpmon/gpmon_agg.c
+++ b/gpAux/gpperfmon/src/gpmon/gpmon_agg.c
@@ -825,7 +825,7 @@ static void delete_old_files(bloom_t* bloom)
 
 			if (0 == stat(p, &stbuf))
 			{
-#if defined(sun) || defined(linux)
+#if defined(linux)
 				int expired = stbuf.st_mtime < cutoff;
 #else
 				int expired = stbuf.st_mtimespec.tv_sec < cutoff;

--- a/gpAux/gpperfmon/src/gpmon/gpmonlib.h
+++ b/gpAux/gpperfmon/src/gpmon/gpmonlib.h
@@ -35,9 +35,9 @@ extern int verbose;
 #define TR1_FILE(x) if (verbose == 1) gpmon_print_file x
 
 /* Architecture specific limits for metrics */
-#if defined(osx104_x86) || defined(osx105_x86) || defined(rhel4_x86_32) || defined(rhel5_x86_32)
+#if defined(osx104_x86) || defined(osx105_x86) || defined(rhel5_x86_32)
 	#define GPSMON_METRIC_MAX 0xffffffffUL
-#elif defined(rhel4_x86_64) || defined(rhel5_x86_64) || defined(rhel7_x86_64) || defined(rhel6_x86_64) || defined(sol10_x86_64) || defined(suse10_x86_64)
+#elif defined(rhel5_x86_64) || defined(rhel7_x86_64) || defined(rhel6_x86_64) || defined(suse10_x86_64)
 	#define GPSMON_METRIC_MAX 0xffffffffffffffffULL
 #else
 	#define GPSMON_METRIC_MAX 0xffffffffUL

--- a/gpAux/gpperfmon/src/gpmon/gpsmon.c
+++ b/gpAux/gpperfmon/src/gpmon/gpsmon.c
@@ -21,11 +21,6 @@
 
 #define FMT64 APR_INT64_T_FMT
 
-/* Macros for min because solaris doesn't have it. */
-#ifndef MIN
-#define	MIN(a,b) (((a)<(b))?(a):(b))
-#endif /* MIN */
-
 void update_log_filename(void);
 void gx_main(int, apr_int64_t);
 
@@ -368,7 +363,7 @@ static apr_uint64_t metric_diff_calc( sigar_uint64_t newval, apr_uint64_t oldval
 	{
 		diff = newval - oldval;
 	}
-#if defined(rhel4_x86_64) || defined(rhel5_x86_64) || defined(rhel7_x86_64) || defined(rhel6_x86_64) || defined(sol10_x86_64) || defined(suse10_x86_64)
+#if defined(rhel5_x86_64) || defined(rhel7_x86_64) || defined(rhel6_x86_64) || defined(suse10_x86_64)
 	// Add this debug on 64 bit machines to try and debug strange values we are seeing
 	if(diff > 1000000000000000000  ) {
 		TR0(("Crazy high value for diff! new value=%" APR_UINT64_T_FMT ", old value=%" APR_UINT64_T_FMT ", diff=%" APR_UINT64_T_FMT "  for %s metric %s; assume the value was reset and set diff to new value.\n",


### PR DESCRIPTION
Solaris is no longer supported as a GPDB server, so all of the solaris
code is dead code.
Removed the #if define(sun) blocks and other solaris mentions.