### PR TITLE
Set pipelines using github deploy keys

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -7,7 +7,6 @@ resources:
   type: git
   source:
     branch: {{gpdb-git-branch}}
-    private_key: {{gpdb-git-key}}
     uri: {{gpdb-git-remote}}
     ignore_paths:
     - gpdb-doc/*
@@ -17,7 +16,6 @@ resources:
   type: git
   source:
     branch: {{gpdb-binary-swap-git-tag}}
-    private_key: {{gpdb-git-key}}
     uri: {{gpdb-binary-swap-git-remote}}
     ignore_paths:
     - gpdb-doc/*

--- a/concourse/pipelines/pr_pipeline.yml
+++ b/concourse/pipelines/pr_pipeline.yml
@@ -14,7 +14,6 @@ resources:
     source:
       repo: greenplum-db/gpdb
       access_token: {{gpdb-git-access-token}}
-      private_key: {{gpdb-git-key}}
 
   - name: centos-gpdb-dev-6
     type: docker-image
@@ -28,7 +27,7 @@ resources:
     type: git
     source:
       branch: {{gpaddon-git-branch}}
-      private_key: {{gpdb-git-key}}
+      private_key: {{gpaddon-git-key}}
       uri: {{gpaddon-git-remote}}
 
 jobs:


### PR DESCRIPTION
In an effort to make each secret have less access we are moving to use
git deploy keys to pull changes from github.

Signed-off-by: Divya Bhargov <dbhargov@pivotal.io>
Signed-off-by: Jim Doty <jdoty@pivotal.io>