### PR TITLE
Add PID suffix to the output filenames of concurrent tests.

### DIFF
--- a/src/test/tinc/tincrepo/mpp/models/sql_concurrency_tc.py
+++ b/src/test/tinc/tincrepo/mpp/models/sql_concurrency_tc.py
@@ -93,8 +93,8 @@ class SQLConcurrencyTestCase(SQLTestCase, ConcurrencyTestCase):
         thread_list = []
         for sql_file in sql_file_list:
             now = datetime.datetime.now()
-            timestamp = '%s%s%s%s%s%s%s'%(now.year,now.month,now.day,now.hour,now.minute,now.second,now.microsecond)
-            out_file = sql_file.replace('.sql', '_' + timestamp + '.out')
+            timestamp_pid = '%s%s%s%s%s%s%s_%s'%(now.year,now.month,now.day,now.hour,now.minute,now.second,now.microsecond,os.getpid())
+            out_file = sql_file.replace('.sql', '_' + timestamp_pid + '.out')
             out_file = os.path.join(self.get_out_dir(), os.path.basename(out_file))
             subst_ans_file = out_file.replace('.out', '.ans')
             ans_file = sql_file.replace('.sql', '.ans')


### PR DESCRIPTION
The storage/access_methods/appendonly_eof/test_ao_eof.py test achieves its
concurrency by inheriting from the SQLConcurrencyTestCase class defined in
/tincrepo/mpp/models/sql_concurrency_tc.py.  The run_test() method of this class
is called concurrently from multiple processes. To have a unique filename for
the output of each concurrent invocation, the test uses a timestamp suffix to
the output file. Even though the microsecond part of the timestamp is used, it
is possible that two concurrent runs of the test would get the same microsecond
part for the `datetime.datetime.now()`.  Hence, it is possible that two tests
would have the same timestamp resulting in identical output file names.

The proposed fix is to add the pid also to the timestamp.  That should make it
completely unique.