### PR TITLE
Coverity pipeline no longer needs git private key

### DIFF
--- a/concourse/pipelines/pipeline_coverity.yml
+++ b/concourse/pipelines/pipeline_coverity.yml
@@ -3,7 +3,6 @@ resources:
   type: git
   source:
     branch: {{gpdb-git-branch}}
-    private_key: {{gpdb-git-key}}
     uri: {{gpdb-git-remote}}
 
 - name: centos-coverity


### PR DESCRIPTION
[#147251383](https://www.pivotaltracker.com/story/show/147251383)

Signed-off-by: Divya Bhargov <dbhargov@pivotal.io>