### PR TITLE
Remove docker credentials from pr_pipeline

### DIFF
--- a/concourse/pipelines/pr_pipeline.yml
+++ b/concourse/pipelines/pr_pipeline.yml
@@ -20,8 +20,6 @@ resources:
     source:
       repository: pivotaldata/centos-gpdb-dev
       tag: '6-gcc6.2-llvm3.7'
-      username: {{docker_username}}
-      password: {{docker_password}}
 
   - name: gpaddon_src
     type: git


### PR DESCRIPTION
Docker dependancies for this pipeline are now public, thus no authorized access is needed.