### PR TITLE
Add --gpfdist-verbose and --gpfdist-very-verbose options to gptransfer

### DIFF
--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gptransfer.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gptransfer.py
@@ -96,6 +96,7 @@ class GpTransfer(GpTestCase):
             gpfdist_port='foo',
             gpfdist_last_port='foo',
             gpfdist_instance_count='foo',
+            gpfdist_verbosity='foo',
             max_line_length='foo',
             timeout='foo',
             wait_time='foo',
@@ -147,6 +148,8 @@ class GpTransfer(GpTestCase):
             truncate=False,
             validator=None,
             verbose=None,
+            gpfdist_verbose=False,
+            gpfdist_very_verbose=False,
             wait_time=3,
             work_base_dir='/home/gpadmin/',
         )
@@ -155,6 +158,62 @@ class GpTransfer(GpTestCase):
         shutil.rmtree(self.TEMP_DIR)
         super(GpTransfer, self).tearDown()
 
+    def test__GpCreateGpfdist(self):
+        cmd = self.subject.GpCreateGpfdist(
+            'gpfdist for table %s on %s' % ("some table",
+                                            "some segment"),
+            "some dirname",
+            "some datafile",
+            0,
+            1,
+            2,
+            3,
+            "pid_file",
+            "log_file",
+            ctxt=self.subject.REMOTE,
+            remoteHost="address")
+        self.assertEqual('nohup gpfdist -d some dirname -p 0 -P 1 -m 2 -t 3 > log_file 2>&1 < /dev/null & echo \\$! ' \
+                         '> pid_file && bash -c "(sleep 1 && kill -0 \\`cat pid_file 2> /dev/null\\` && cat log_file) ' \
+                         '|| (cat log_file >&2 && exit 1)"', cmd.cmdStr)
+
+
+    def test__GpCreateGpfdist_with_verbosity(self):
+        cmd = self.subject.GpCreateGpfdist(
+            'gpfdist for table %s on %s' % ("some table",
+                                            "some segment"),
+            "some dirname",
+            "some datafile",
+            0,
+            1,
+            2,
+            3,
+            "pid_file",
+            "log_file",
+            ctxt = self.subject.REMOTE,
+            remoteHost = "address",
+            verbosity = "-v ")
+        self.assertEqual('nohup gpfdist -d some dirname -p 0 -P 1 -m 2 -t 3 -v > log_file 2>&1 < /dev/null & echo \\$! ' \
+                         '> pid_file && bash -c "(sleep 1 && kill -0 \\`cat pid_file 2> /dev/null\\` && cat log_file) ' \
+                         '|| (cat log_file >&2 && exit 1)"', cmd.cmdStr)
+
+    def test__GpCreateGpfdist_with_very_verbosity(self):
+        cmd = self.subject.GpCreateGpfdist(
+            'gpfdist for table %s on %s' % ("some table",
+                                            "some segment"),
+            "some dirname",
+            "some datafile",
+            0,
+            1,
+            2,
+            3,
+            "pid_file",
+            "log_file",
+            ctxt = self.subject.REMOTE,
+            remoteHost = "address",
+            verbosity = "-V ")
+        self.assertEqual('nohup gpfdist -d some dirname -p 0 -P 1 -m 2 -t 3 -V > log_file 2>&1 < /dev/null & echo \\$! ' \
+                         '> pid_file && bash -c "(sleep 1 && kill -0 \\`cat pid_file 2> /dev/null\\` && cat log_file) ' \
+                         '|| (cat log_file >&2 && exit 1)"', cmd.cmdStr)
 
     @patch('gptransfer.TableValidatorFactory', return_value=Mock())
     def test__get_distributed_by_quotes_column_name(self, mock1):

--- a/gpMgmt/bin/gptransfer
+++ b/gpMgmt/bin/gptransfer
@@ -4260,10 +4260,6 @@ class GpTransfer(object):
 # Main
 # --------------------------------------------------------------------------
 if __name__ == '__main__':
-    if curr_platform != LINUX:
-        logger.error("gptransfer is only available on Linux.")
-        sys.exit(1)
-
     # Preemptively check for command -h | --help.
     # This will automacially exit gptransfer and print the help text if -h | --help is found
     exit_on_help = create_parser()

--- a/gpMgmt/bin/gptransfer
+++ b/gpMgmt/bin/gptransfer
@@ -592,6 +592,27 @@ def create_parser():
 
     parser.add_option_group(validation_option_group)
 
+    # Gpfdist Options ####
+    gpfdist_option_group = OptionGroup(parser, 'Gpfdist Options')
+
+    gpfdist_option_group.add_option(
+        '--gpfdist-verbose',
+        dest='gpfdist_verbose',
+        action='store_true',
+        default=False,
+        help='Run gpfdist with -v'
+    )
+
+    gpfdist_option_group.add_option(
+        '--gpfdist-very-verbose',
+        dest='gpfdist_very_verbose',
+        action='store_true',
+        default=False,
+        help='Run gpfdist with -V'
+    )
+
+    parser.add_option_group(gpfdist_option_group)
+
     parser.setHelp(__help__)
 
     return parser
@@ -1288,7 +1309,7 @@ class GpCreateGpfdist(Command):
     """
 
     def __init__(self, name, directory, data_file, port, last_port, max_line_length, timeout,
-                 pid_file, log_file, ctxt=LOCAL, remoteHost=None):
+                 pid_file, log_file, ctxt=LOCAL, remoteHost=None, verbosity=""):
         """
         name: name of the command
         dir: directory for gpfdist to use as its root directory
@@ -1301,9 +1322,9 @@ class GpCreateGpfdist(Command):
         self._data_file = data_file
 
         cmdStr = \
-            'nohup gpfdist -d %s -p %d -P %d -m %d -t %d > %s 2>&1 < /dev/null & echo \\$! > ' \
+            'nohup gpfdist -d %s -p %d -P %d -m %d -t %d %s> %s 2>&1 < /dev/null & echo \\$! > ' \
             '%s && bash -c "(sleep 1 && kill -0 \`cat %s 2> /dev/null\` && cat %s) || (cat %s >&2 && exit 1)"' % \
-            (directory, port, last_port, max_line_length, timeout, log_file, pid_file, pid_file, log_file, log_file)
+            (directory, port, last_port, max_line_length, timeout, verbosity, log_file, pid_file, pid_file, log_file, log_file)
 
         Command.__init__(self, name, cmdStr, ctxt, remoteHost)
 
@@ -1474,7 +1495,7 @@ class GpTransferCommand(Command):
             dest_user, table_pair, dest_exists, truncate, analyze, drop,
             fast_mode, exclusive_lock, schema_only, work_dir,
             host_map, source_config, batch_size, gpfdist_port, gpfdist_last_port,
-            gpfdist_instance_count, max_line_length, timeout, wait_time,
+            gpfdist_instance_count, gpfdist_verbosity, max_line_length, timeout, wait_time,
             delimiter, validator, format, quote, table_transfer_set_total):
         """
         name: name of the command
@@ -1530,6 +1551,7 @@ class GpTransferCommand(Command):
         self._gpfdist_port = gpfdist_port
         self._gpfdist_last_port = gpfdist_last_port
         self._gpfdist_instance_count = gpfdist_instance_count
+        self._gpfdist_verbosity = gpfdist_verbosity
         self._max_line_length = max_line_length
         self._timeout = timeout
         self._wait_time = wait_time
@@ -1927,8 +1949,9 @@ FROM (
                                      % (str(self._table_pair.source), i)),
                         os.path.join(self._work_dir, 'gpfdist_write_%s_%d.log'
                                      % (str(self._table_pair.source), i)),
-                        REMOTE,
-                        address
+                        ctxt = REMOTE,
+                        remoteHost = address,
+                        verbosity =  self._gpfdist_verbosity
                     )
                     self._pool.addCommand(cmd)
 
@@ -1969,8 +1992,10 @@ FROM (
                                  % (str(self._table_pair.source), seg.getSegmentContentId())),
                     os.path.join(self._work_dir, 'gpfdist_read_%s_%d.log'
                                  % (str(self._table_pair.source), seg.getSegmentContentId())),
-                    REMOTE,
-                    address)
+                    ctxt = REMOTE,
+                    remoteHost = address,
+                    verbosity =  self._gpfdist_verbosity
+                )
                 self._pool.addCommand(cmd)
         else:
             for host in self._host_map.keys():
@@ -1990,8 +2015,9 @@ FROM (
                                      % (str(self._table_pair.source), i)),
                         os.path.join(self._work_dir, 'gpfdist_read_%s_%d.log'
                                      % (str(self._table_pair.source), i)),
-                        REMOTE,
-                        address,
+                        ctxt = REMOTE,
+                        remoteHost = address,
+                        verbosity =  self._gpfdist_verbosity
                     )
                     self._pool.addCommand(cmd)
         self._pool.join()
@@ -2526,6 +2552,12 @@ class GpTransfer(object):
             if self._options.partition_transfer_non_pt_target:
                 self.before_dest_tables_dict = self.get_dest_row_count_before_transfer()
 
+            gpfdist_verbosity = ""
+            if self._options.gpfdist_verbose:
+                gpfdist_verbosity = "-v "
+            elif self._options.gpfdist_very_verbose:
+                gpfdist_verbosity = "-V "
+
             for table_pair in self._table_transfer_set:
                 truncate = (True if self._options.truncate and table_pair.dest in self._dest_tables else False)
                 drop = (True if self._options.drop and table_pair.dest in self._dest_tables else False)
@@ -2554,6 +2586,7 @@ class GpTransfer(object):
                     self._options.base_port,
                     self._options.last_port,
                     self._gpfdist_instance_count,
+                    gpfdist_verbosity,
                     self._options.max_line_length,
                     self._options.timeout,
                     self._options.wait_time,
@@ -2971,7 +3004,7 @@ class GpTransfer(object):
                                                      'used with --validate option')
 
         if self._options.truncate and self._options.partition_transfer_non_pt_target:
-            raise Exception('--truncate is not allowed with option --partition-transfer-non-partition-target')
+            raise ProgramArgumentValidationException('--truncate is not allowed with option --partition-transfer-non-partition-target')
 
         if self._options.full and (self._options.truncate or self._options.drop or
                                        self._options.skip_existing):
@@ -3084,6 +3117,9 @@ class GpTransfer(object):
         if self._options.delimiter == ',' and self._options.format.lower() == 'text':
             raise ProgramArgumentValidationException(
                 'Invalid --delimiter. Default delimiter "," is not allowed in TEXT format. Specify --delimiter option for TEXT')
+
+        if self._options.gpfdist_verbose and self._options.gpfdist_very_verbose:
+            raise ProgramArgumentValidationException('--gpfdist-verbose option cannot be used with the --gpfdist-very-verbose option')
 
     def _post_validate_options(self):
         """

--- a/gpMgmt/doc/gptransfer_help
+++ b/gpMgmt/doc/gptransfer_help
@@ -36,7 +36,9 @@ gptransfer
    [--quote=<character> ]
 
    [-v | --verbose] 
-   [-q | --quiet] 
+   [-q | --quiet]
+   [--gpfdist-verbose]
+   [--gpfdist-very-verbose]
    [-a] 
 
 gptransfer --version 
@@ -526,13 +528,27 @@ OPTIONS
  number of tables with large amounts of data. Because of the overhead 
  required to set up parallel transfers, the utility is not recommended 
  when the databases contain tables with small amounts of data. For more 
- information, see Notes. 
+ information, see Notes.
 
+--gpfdist-verbose
+
+ Set the logging level for gpfdist processes to verbose (-v). Cannot be 
+ specified with --gpfdist-very-verbose. The output is recorded in gpfdist 
+ log files in the ~/gptransfer_process_id directory on segment hosts in 
+ the source Greenplum Database cluster.
+
+--gpfdist-very-verbose
+
+ Set the logging level for gpfdist processes to very verbose (-V). Cannot 
+ be specified with --gpfdist-verbose. The output is recorded in gpfdist 
+ log files in the ~/gptransfer_process_id directory on segment hosts in 
+ the source Greenplum Database cluster.
 
 -l <log_dir> 
 
  Specify the gptransfer log file directory. If not specified, the default 
- is ~/gpAdminLogs. 
+ is ~/gpAdminLogs. This directory is created on the master host in the 
+ source Greenplum cluster.
 
 
 --max-line-length=<length> 

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gptransfer.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gptransfer.xml
@@ -36,6 +36,8 @@
 
    [<b>-v</b> | <b>--verbose</b>]
    [<b>-q</b> | <b>--quiet</b>]
+   [<b>--gpfdist-verbose</b>]
+   [<b>--gpfdist-very-verbose</b>]
    [<b>-a</b>]
 
 <b>gptransfer --version</b>
@@ -124,6 +126,19 @@
             <p>Source and destination systems must be able to access the <codeph>gptransfer</codeph>
                 work directory. The default directory is the user's home directory. You can specify
                 a different directory with the <codeph>--work-base-dir</codeph> option. </p>
+            <p>The <codeph>gptransfer</codeph> utility logs messages in the
+                    <codeph>~/gpAdminLogs</codeph> directory on the master host.
+                    <codeph>gptransfer</codeph> creates a log file with the name
+                        <codeph>gptransfer_<varname>date</varname>.log</codeph> and appends messages
+                to it each time it runs on that day. You can specify a different directory for the
+                log file using the <codeph>-l <varname>log_directory</varname></codeph> option. </p>
+            <p>Work directories named <codeph>~/gptransfer_<varname>process_id</varname></codeph>
+                are created on segment hosts in the source cluster. Log files for the
+                    <codeph>gpfdist</codeph> instances that <codeph>gptransfer</codeph> creates are
+                in these directories. Adding the <codeph>--gpfdist-verbose</codeph> or
+                    <codeph>--gpfdist-very-verbose</codeph> options to the
+                    <codeph>gptransfer</codeph> command line increases the <codeph>gpfdist</codeph>
+                logging level.</p>
             <p>The <codeph>gptransfer</codeph> utility does not move configuration files such as
                     <codeph>postgres.conf</codeph> and <codeph>pg_hba.conf</codeph>. You must set up
                 the destination system configuration separately. </p>
@@ -169,11 +184,11 @@
             <sectiondiv id="section5">
                 <b>Limitation for the Source and Destination Systems</b>
                 <p>If you are copying data from a system with a larger number of segments to a
-                    system with a fewer number of segment hosts, then the total number of primary segments on
-                    the destination system must be greater than or equal to the total number of
-                    segment hosts on the source system. </p>
-                <p>For example, assume a destination system has a total of 24 primary
-                    segments. This means that the source system cannot have more than 24 segment hosts.</p>
+                    system with a fewer number of segment hosts, then the total number of primary
+                    segments on the destination system must be greater than or equal to the total
+                    number of segment hosts on the source system. </p>
+                <p>For example, assume a destination system has a total of 24 primary segments. This
+                    means that the source system cannot have more than 24 segment hosts.</p>
                 <p>When you copy data from a source Greenplum Database system with a larger number
                     of primary segment instances than on the destination system, the data transfer
                     might be slower when compared to a transfer where the source system has fewer
@@ -503,9 +518,28 @@
                         >Notes</xref>.</note></pd>
                 </plentry>
                 <plentry>
+                    <pt>--gpfdist-verbose</pt>
+                    <pd>Set the logging level for <codeph>gpfdist</codeph> processes to verbose
+                            (<codeph>-v</codeph>). Cannot be specified with
+                            <codeph>--gpfdist-very-verbose</codeph>.</pd>
+                    <pd>The output is recorded in <codeph>gpfdist</codeph> log files in the
+                                <codeph>~/gptransfer_<varname>process_id</varname></codeph>
+                        directory on segment hosts in the source Greenplum Database cluster.</pd>
+                </plentry>
+                <plentry>
+                    <pt>--gpfdist-very-verbose</pt>
+                    <pd>Set the logging level for <codeph>gpfdist</codeph> processes to very verbose
+                            (<codeph>-V</codeph>). Cannot be specified with
+                            <codeph>--gpfdist-verbose</codeph>.</pd>
+                    <pd>The output is recorded in <codeph>gpfdist</codeph> log files in the
+                                <codeph>~/gptransfer_<varname>process_id</varname></codeph>
+                        directory on segment hosts in the source Greenplum Database cluster.</pd>
+                </plentry>
+                <plentry>
                     <pt>-l <varname>log_dir</varname></pt>
                     <pd>Specify the <codeph>gptransfer</codeph> log file directory. If not
-                        specified, the default is <codeph>~/gpAdminLogs</codeph>.</pd>
+                        specified, the default is <codeph>~/gpAdminLogs</codeph>. This directory is
+                        created on the master host in the source Greenplum cluster.</pd>
                 </plentry>
                 <plentry>
                     <pt>--max-line-length=<varname>length</varname></pt>


### PR DESCRIPTION
Display gpfdist verbose (-v) and very verbose (-V) logs in gptransfer output for debugging.

Additionally, remove Linux-only restriction on gptransfer so it can be run on non-Linux development machines.