### PR TITLE
Fix gptransfer distribution key quoting in fast mode

### DIFF
--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gptransfer.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gptransfer.py
@@ -167,7 +167,7 @@ class GpTransfer(GpTestCase):
         dest_table = gptransfer.GpTransferTable(*dest_args)
         cmd_args['table_pair'] = gptransfer.GpTransferTablePair(source_table, dest_table)
         side_effect = CursorSideEffect()
-        side_effect.append_regexp_key(cursor_keys['attname'], ['foo'])
+        side_effect.append_regexp_key(cursor_keys['attname'], [['foo']])
         self.cursor.side_effect = side_effect.cursor_side_effect
         self.subject.escapeDoubleQuoteInSQLString.return_value='"escaped_string"'
         table_validator = gptransfer.GpTransferCommand(**cmd_args)
@@ -186,7 +186,7 @@ class GpTransfer(GpTestCase):
         dest_table = gptransfer.GpTransferTable(*dest_args)
         cmd_args['table_pair'] = gptransfer.GpTransferTablePair(source_table, dest_table)
         side_effect = CursorSideEffect()
-        side_effect.append_regexp_key(cursor_keys['attname'], ['foo', 'bar'])
+        side_effect.append_regexp_key(cursor_keys['attname'], [['foo'], ['bar']])
         self.cursor.side_effect = side_effect.cursor_side_effect
         self.subject.escapeDoubleQuoteInSQLString.side_effect = ['"first_escaped_value"', '"second_escaped_value"']
         table_validator = gptransfer.GpTransferCommand(**cmd_args)

--- a/gpMgmt/bin/gptransfer
+++ b/gpMgmt/bin/gptransfer
@@ -1699,7 +1699,7 @@ FROM (
 
             # NOTE: ideally, we can use pg.escape_identifier for this part, but
             # that is introduced in pygresql 4.1 and we are in 4.0
-            escaped_attnames = [escapeDoubleQuoteInSQLString(attname) for attname in attnames]
+            escaped_attnames = [escapeDoubleQuoteInSQLString(attname[0]) for attname in attnames]
             distributed_by = ", ".join(escaped_attnames)
             return '''DISTRIBUTED BY (%s)''' % distributed_by
         except Exception as e:


### PR DESCRIPTION
Previously, gptransfer was creating intermediate external tables with DISTRIBUTED RANDOMLY regardless of the actual distribution key, because the column name quoting logic expected a list of strings but was getting a list of lists of strings.  The table was being created correctly in the destination database, but was showing some warnings to the user.

Now, the external tables are being created with the correct distribution keys and no warnings are generated.