### PR TITLE
AcquireExecutorLocks() should keep parity with CdbTryOpenRelation()

### DIFF
--- a/src/backend/utils/cache/plancache.c
+++ b/src/backend/utils/cache/plancache.c
@@ -757,7 +757,15 @@ AcquireExecutorLocks(List *stmt_list, bool acquire)
 			 * acquire a non-conflicting lock.
 			 */
 			if (list_member_int(plannedstmt->resultRelations, rt_index))
-				lockmode = RowExclusiveLock;
+			{
+				/*
+				 * RowExclusiveLock is acquired in PostgreSQL here.  Greenplum
+				 * acquires ExclusiveLock to avoid distributed deadlock due to
+				 * concurrent UPDATE/DELETE on the same table.  This is in
+				 * parity with CdbTryOpenRelation().
+				 */
+				lockmode = ExclusiveLock;
+			}
 			else if (rowmark_member(plannedstmt->rowMarks, rt_index))
 				lockmode = RowShareLock;
 			else

--- a/src/backend/utils/cache/plancache.c
+++ b/src/backend/utils/cache/plancache.c
@@ -825,7 +825,15 @@ ScanQueryForLocks(Query *parsetree, bool acquire)
 			case RTE_RELATION:
 				/* Acquire or release the appropriate type of lock */
 				if (rt_index == parsetree->resultRelation)
-					lockmode = RowExclusiveLock;
+				{
+					/*
+					 * RowExclusiveLock is acquired in PostgreSQL here.
+					 * Greenplum acquires ExclusiveLock to avoid distributed
+					 * deadlock due to concurrent UPDATE/DELETE on the same
+					 * table.  This is in parity with CdbTryOpenRelation().
+					 */
+					lockmode = ExclusiveLock;
+				}
 				else if (rowmark_member(parsetree->rowMarks, rt_index))
 					lockmode = RowShareLock;
 				else


### PR DESCRIPTION
by acquiring ExclusiveLock in place of RowExclusiveLock for DML.  If it
acquires RowExclusiveLock, we may have a local deadlock on QD if concurrent
UPDATE statements are executed from within UDFs.

The problem is described in more detail here:
https://groups.google.com/a/greenplum.org/d/msg/gpdb-dev/PC0Z_zw-YaY/tsCmPdADBQAJ

I'm not familiar with plan/plancache area.  Definitely need experts to take a look here.  ICW seems sufficient to test this change, so no new tests are added.  