### PR TITLE
Reinstate RTEKind enum entries to the original order before 41c3b6

### DIFF
--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -632,9 +632,9 @@ typedef enum RTEKind
 	RTE_SPECIAL,				/* special rule relation (NEW or OLD) */
 	RTE_FUNCTION,				/* function in FROM */
 	RTE_VALUES,					/* VALUES (<exprlist>), (<exprlist>), ... */
+	RTE_VOID,                   /* CDB: deleted RTE */
 	RTE_CTE,					/* common table expr (WITH list element) */
 	RTE_TABLEFUNCTION,          /* CDB: Functions over multiset input */
-	RTE_VOID,                   /* CDB: deleted RTE */
 } RTEKind;
 
 typedef struct RangeTblEntry


### PR DESCRIPTION
Commit 41c3b698616bd984b64629c5bae9c0549f07b8ff changed the numbering of RTEKind (with the intent to
converge with upstream ordering). RTEKind is included in the
RangeTblEntry struct, which in turn is included in a parse tree. Parse
trees are serialized (via `nodeToString`) in the catalog when we store
view definitions. That means re-ordering an ostensibly internal enum
will break catalog compatibility. Reverting the re-ordering of
`RTEKind`.