### PR TITLE
Do not generate StatsBuckets for Text/Varchar/Char/Bpchar columns in DXL

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -2806,4 +2806,18 @@ CTranslatorUtils::UlNonSystemColumns
 	return ulNonSystemCols;
 }
 
+// Function to check if we should create stats bucket in DXL
+// Returns true if column datatype is not text/char/varchar/bpchar
+BOOL
+CTranslatorUtils::FCreateStatsBucket
+	(
+	OID oidAttType
+	)
+{
+	if (oidAttType != TEXTOID && oidAttType != CHAROID && oidAttType != VARCHAROID && oidAttType != BPCHAROID)
+		return true;
+
+	return false;
+}
+
 // EOF

--- a/src/include/gpopt/translate/CTranslatorUtils.h
+++ b/src/include/gpopt/translate/CTranslatorUtils.h
@@ -410,6 +410,10 @@ namespace gpdxl
 			// return the count of non-system columns in the relation
 			static
 			ULONG UlNonSystemColumns(const IMDRelation *pmdrel);
+
+			// check if we need to create stats buckets in DXL for the column attribute
+			static
+			BOOL FCreateStatsBucket(OID oidAttType);
 	};
 }
 


### PR DESCRIPTION
For Text/Varchar/Char/Bpchar columns, we should ignore generating buckets.

Instead we should maintain NDVRemain and NullFreq to do Cardinality
Estimation.

Jemish & Ekta