### PR TITLE
Coverity fix for bitmapxlog.c

### DIFF
--- a/src/backend/access/bitmap/bitmapxlog.c
+++ b/src/backend/access/bitmap/bitmapxlog.c
@@ -914,6 +914,7 @@ bitmap_xlog_cleanup(void)
 
 		lovBuffer = XLogReadBuffer(reln, action->bm_lov_blkno, false);
 
+		newWords.curword = action->bm_num_cwords;
 		newWords.num_cwords = action->bm_num_cwords;
 		newWords.start_wordno = action->bm_start_wordno;
 


### PR DESCRIPTION
CID 130205: Uninitialized scalar variable (UNINIT)
uninit_use_in_call: Using uninitialized value newWords.curword when calling
_bitmap_write_new_bitmapwords