### PR TITLE
baby step towards segment wal replication

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -721,20 +721,21 @@ static bool CheckForStandbyTrigger(void);
  */
 bool XLog_CanBypassWal(void)
 {
-	if (Debug_bulk_load_bypass_wal)
-	{
-		/*
-		 * We need the XLOG to be transmitted to the standby master since
-		 * it is not using FileRep technology yet.  Master also could skip
-		 * some of the WAL operations for optimization when standby is not
-		 * configured, but for now we lean towards safety.
-		 */
-		return GpIdentity.segindex != MASTER_CONTENT_ID;
-	}
-	else
-	{
-		return false;
-	}
+#ifdef USE_SEGWALREP
+	/*
+	 * Wal replication enabled for segments, shouldn't skip anything from
+	 * wal.
+	 */
+	return false;
+#else
+	/*
+	 * We need the XLOG to be transmitted to the standby master since it is
+	 * not using FileRep technology yet. Master also could skip some of the
+	 * WAL operations for optimization when standby is not configured, but for
+	 * now we lean towards safety.
+	 */
+	return GpIdentity.segindex != MASTER_CONTENT_ID;
+#endif
 }
 
 /*

--- a/src/backend/access/transam/xlog_mm.c
+++ b/src/backend/access/transam/xlog_mm.c
@@ -526,107 +526,107 @@ emit_mmxlog_fs_record(mm_fs_obj_type type, Oid filespace,
 					  Oid tablespace, Oid database, Oid relfilenode,
 					  uint32 segnum, uint8 flags, XLogRecPtr *beginLoc)
 {
+	XLogRecData rdata;
+	xl_mm_fs_obj xlrec;
+	char *master_path = NULL;
+	char *mirror_path = NULL;
+	int16 master_dbid;
+	int16 mirror_dbid;
+
 	MemSet(beginLoc, 0, sizeof(XLogRecPtr));
 
 	if (InRecovery)
 		/* no business here */
 		return false;
 
-	/* only interesting on the master */
-	if (GpIdentity.segindex == MASTER_CONTENT_ID)
+#ifndef USE_SEGWALREP
+	/*
+	 * Only interesting on the master, if wal replication not enabled for
+	 * segments.
+	 */
+	if (GpIdentity.segindex != MASTER_CONTENT_ID)
+		return false;
+#endif
+
+	master_dbid = GpIdentity.dbid;
+	mirror_dbid = GetStandbyDbid();
+
+	if (type == MM_OBJ_FILESPACE)
 	{
-		XLogRecData rdata;
-		xl_mm_fs_obj xlrec;
-		char *master_path;
-		char *mirror_path;
-		int16 master_dbid = GpIdentity.dbid;
-		int16 mirror_dbid = GetStandbyDbid();
-
-		Insist(Gp_role == GP_ROLE_DISPATCH ||
-			   Gp_role == GP_ROLE_UTILITY);
-
-		master_path = NULL;
-		mirror_path = NULL;
-
-		if (type == MM_OBJ_FILESPACE)
-		{
-			Insist(OidIsValid(filespace));
-			get_filespace_paths(filespace, &master_path, &mirror_path);
-		}
-		else
-		{
-			Insist(OidIsValid(tablespace));
-
-			tblspc_get_filespace_paths(tablespace, master_dbid, mirror_dbid,
-									   &master_path, &mirror_path);
-
-			filespace = PersistentTablespace_GetFileSpaceOid(tablespace);
-		}
-
-		/*
-		 * Make an XLOG entry showing the file creation.  If we abort, the file
-		 * will be dropped at abort time.
-		 */
-		xlrec.objtype = type;
-		xlrec.filespace = filespace;
-		xlrec.tablespace = tablespace;
-		xlrec.database = database;
-		xlrec.relfilenode = relfilenode;
-		xlrec.segnum = segnum;
-
-		xlrec.u.dbid.master = master_dbid;
-		xlrec.u.dbid.mirror = mirror_dbid;
-
-		Insist(!master_path ||
-			   strlen(master_path) <= MAXPGPATH);
-
-		xlrec.master_path[0] = '\0';
-		if (master_path)
-			strncpy(xlrec.master_path, master_path,
-					sizeof(xlrec.master_path));
-		else
-		{
-			/*
-			 * Allow relative paths if we didn't get anything when we looked up
-			 * the filespace. We must allow this for the default filespace.
-			 */
-			xlrec.master_path[0] = '.';
-			xlrec.master_path[1] = '\0';
-		}
-
-		append_file_parts(type, xlrec.master_path, tablespace, database,
-						  relfilenode, segnum);
-
-		xlrec.mirror_path[0] = '\0';
-		if (mirror_path)
-			strncpy(xlrec.mirror_path, mirror_path,
-					sizeof(xlrec.mirror_path));
-		else
-		{
-			xlrec.mirror_path[0] = '.';
-			xlrec.mirror_path[1] = '\0';
-		}
-
-		append_file_parts(type, xlrec.mirror_path, tablespace, database,
-						  relfilenode, segnum);
-
-		if (Debug_print_qd_mirroring)
-			elog(DEBUG1, "XLOG: type = %i, flags = %i, dbid = (%u, %u), path = (%s, %s)",
-				 type, flags, xlrec.u.dbid.master, xlrec.u.dbid.mirror,
-				 xlrec.master_path, xlrec.mirror_path);
-
-		rdata.data = (char *) &xlrec;
-		rdata.len = sizeof(xlrec);
-		rdata.buffer = InvalidBuffer;
-		rdata.next = NULL;
-
-		XLogInsert(RM_MMXLOG_ID, flags, &rdata);
-		*beginLoc = XLogLastInsertBeginLoc();
-
-		return true;
+		Insist(OidIsValid(filespace));
+		get_filespace_paths(filespace, &master_path, &mirror_path);
 	}
 	else
-		return false;
+	{
+		Insist(OidIsValid(tablespace));
+
+		tblspc_get_filespace_paths(tablespace, master_dbid, mirror_dbid,
+								   &master_path, &mirror_path);
+
+		filespace = PersistentTablespace_GetFileSpaceOid(tablespace);
+	}
+
+	/*
+	 * Make an XLOG entry showing the file creation.  If we abort, the file
+	 * will be dropped at abort time.
+	 */
+	xlrec.objtype = type;
+	xlrec.filespace = filespace;
+	xlrec.tablespace = tablespace;
+	xlrec.database = database;
+	xlrec.relfilenode = relfilenode;
+	xlrec.segnum = segnum;
+
+	xlrec.u.dbid.master = master_dbid;
+	xlrec.u.dbid.mirror = mirror_dbid;
+
+	Insist(!master_path ||
+		   strlen(master_path) <= MAXPGPATH);
+
+	xlrec.master_path[0] = '\0';
+	if (master_path)
+		strncpy(xlrec.master_path, master_path,
+				sizeof(xlrec.master_path));
+	else
+	{
+		/*
+		 * Allow relative paths if we didn't get anything when we looked up
+		 * the filespace. We must allow this for the default filespace.
+		 */
+		xlrec.master_path[0] = '.';
+		xlrec.master_path[1] = '\0';
+	}
+
+	append_file_parts(type, xlrec.master_path, tablespace, database,
+					  relfilenode, segnum);
+
+	xlrec.mirror_path[0] = '\0';
+	if (mirror_path)
+		strncpy(xlrec.mirror_path, mirror_path,
+				sizeof(xlrec.mirror_path));
+	else
+	{
+		xlrec.mirror_path[0] = '.';
+		xlrec.mirror_path[1] = '\0';
+	}
+
+	append_file_parts(type, xlrec.mirror_path, tablespace, database,
+					  relfilenode, segnum);
+
+	if (Debug_print_qd_mirroring)
+		elog(DEBUG1, "XLOG: type = %i, flags = %i, dbid = (%u, %u), path = (%s, %s)",
+			 type, flags, xlrec.u.dbid.master, xlrec.u.dbid.mirror,
+			 xlrec.master_path, xlrec.mirror_path);
+
+	rdata.data = (char *) &xlrec;
+	rdata.len = sizeof(xlrec);
+	rdata.buffer = InvalidBuffer;
+	rdata.next = NULL;
+
+	XLogInsert(RM_MMXLOG_ID, flags, &rdata);
+	*beginLoc = XLogLastInsertBeginLoc();
+
+	return true;
 }
 
 /* External interface to filespace removal logging */

--- a/src/backend/storage/smgr/md.c
+++ b/src/backend/storage/smgr/md.c
@@ -2221,7 +2221,7 @@ register_dirty_segment(SMgrRelation reln, MdMirVec *seg)
  * As with register_dirty_segment, this could involve either a local or
  * a remote pending-ops table.
  */
-static void
+static void pg_attribute_unused()
 register_unlink(RelFileNode rnode)
 {
 	if (pendingOpsTable)

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -198,7 +198,6 @@ bool		Debug_persistent_bootstrap_print = false;
 bool		persistent_integrity_checks = true;
 bool		debug_persistent_ptcat_verification = false;
 bool		debug_print_persistent_checks = false;
-bool		Debug_bulk_load_bypass_wal = true;
 bool		Debug_persistent_appendonly_commit_count_print = false;
 bool		Debug_cancel_print = false;
 bool		Debug_datumstream_write_print_small_varlena_info = false;
@@ -1672,16 +1671,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 		},
 		&debug_print_persistent_checks,
 		false, NULL, NULL
-	},
-
-	{
-		{"Debug_bulk_load_bypass_wal", PGC_SUSET, DEVELOPER_OPTIONS,
-			gettext_noop("Use new bulk load bypass WAL logic."),
-			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&Debug_bulk_load_bypass_wal,
-		true, NULL, NULL
 	},
 
 	{

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -210,7 +210,6 @@ extern bool Debug_persistent_bootstrap_print;
 extern bool persistent_integrity_checks;
 extern bool debug_persistent_ptcat_verification;
 extern bool debug_print_persistent_checks;
-extern bool Debug_bulk_load_bypass_wal;
 extern bool Debug_persistent_appendonly_commit_count_print;
 extern bool Debug_cancel_print;
 extern bool Debug_datumstream_write_print_small_varlena_info;


### PR DESCRIPTION
This PR removes basic hurdle to setup wal replication for segments like `pg_basebackup` and helps validate basic streaming for heap tables and object creation for segments. Since it already works for master, nothing too major/magical required to make it work for segments. It's iterative step to move us forward, closer to next iteration step.

After this patch can now manually setup mirrors (yes, yes wal rep ones) for segments creating cluster initially with no mirrors. Run full ICW (except filespace test) against it. WAL generated gets streamed across and replayed, without any issues/crashes by mirrors. Validated for selective heap tables the data correctly gets reflected on mirror.

## Steps to setup walrep manually
1. Update the pg_hba.conf file to add replication for primary else will get error
    - `pg_basebackup: could not connect to server: FATAL:  no pg_hba.conf entry for replication connection from host "::1", user "username"`
    - Need to add entry like this to pg_hba.conf
`host	replication		username	samenet	trust`
1. Take online backup
`pg_basebackup -x -R -c fast -E ./pg_log -E ./db_dumps -E ./gpperfmon/data -E ./gpperfmon/logs -D <mirror_dir> -h <primary_hostname> -p <primary_port>`
1. mkdir <mirror_dir>/pg_log and <mirror_dir>/pg_xlog/archive_status
1. Start Standby server. WAL Recv will start automatically unless something breaks 
`pg_ctl -D <mirror_dir> -o '-p <mirror_port> --gp_dbid=6 --silent-mode=true -i -M mirrorless --gp_num_contents_in_cluster=3 --gp_contentid=0' start`
(currently these options are identical to the primary options except the port # and dbid)

To stop standby
`pg_ctl -D <mirror_dir> stop`

*Note: This is just the start. Lots, lots,..... of work ahead, mainly enhancing*
- to work with non-default file spaces (currently only works for default filespace)
- handling of whole object lifecycle (creation / drops of filesystem objects)
- overall native implementation of filepsace / tablespace itself
- replay of AO and CO wal
- automation of above mentioned steps
- ...........
- ....