### PR TITLE
Add library cleaning to gppc

### DIFF
--- a/src/interfaces/gppc/Makefile
+++ b/src/interfaces/gppc/Makefile
@@ -37,9 +37,7 @@ installcheck: install
 
 uninstall: uninstall-lib
 
-clean:
+clean distclean: clean-lib
 	rm -f $(OBJS)
  
-distclean: clean clean-lib
- 
-maintainer-clean: distclean
+maintainer-clean: distclean maintainer-clean-lib


### PR DESCRIPTION
Just removing the .o file on clean leaves .a and the shlib files
around which can cause problems when building. Add the clean-lib
targets from Makefile.shlib.