### PR TITLE
Remove IncrIndexProcessed

### DIFF
--- a/src/backend/access/gist/gistget.c
+++ b/src/backend/access/gist/gistget.c
@@ -425,8 +425,6 @@ gistindex_keytest(IndexTuple tuple,
 	giststate = so->giststate;
 	p = BufferGetPage(so->curbuf);
 
-	IncrIndexProcessed();
-
 	/*
 	 * Tuple doesn't restore after crash recovery because of incomplete insert
 	 */

--- a/src/backend/access/hash/hashutil.c
+++ b/src/backend/access/hash/hashutil.c
@@ -31,8 +31,6 @@ _hash_checkqual(IndexScanDesc scan, IndexTuple itup)
 	ScanKey		key = scan->keyData;
 	int			scanKeySize = scan->numberOfKeys;
 
-	IncrIndexProcessed();
-
 	while (scanKeySize > 0)
 	{
 		Datum		datum;

--- a/src/backend/access/nbtree/nbtutils.c
+++ b/src/backend/access/nbtree/nbtutils.c
@@ -818,8 +818,6 @@ _bt_checkkeys(IndexScanDesc scan,
 
 	tuple = (IndexTuple) PageGetItem(page, iid);
 
-	IncrIndexProcessed();
-
 	tupdesc = RelationGetDescr(scan->indexRelation);
 	so = (BTScanOpaque) scan->opaque;
 	keysz = so->numberOfKeys;

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -2995,7 +2995,6 @@ ExecSelect(TupleTableSlot *slot,
 		   EState *estate)
 {
 	(*dest->receiveSlot) (slot, dest);
-	IncrRetrieved();
 	(estate->es_processed)++;
 }
 
@@ -3225,7 +3224,6 @@ ExecInsert(TupleTableSlot *slot,
 							true, true, GetCurrentTransactionId());
 	}
 
-	IncrAppended();
 	(estate->es_processed)++;
 	(resultRelInfo->ri_aoprocessed)++;
 	estate->es_lastoid = newId;
@@ -3476,7 +3474,6 @@ ldelete:;
 
 	if (!isUpdate)
 	{
-		IncrDeleted();
 		(estate->es_processed)++;
 		/*
 		 * To notify master if tuples deleted or not, to update mod_count.
@@ -3918,7 +3915,6 @@ lreplace:;
 		heap_freetuple(persistentTuple);
 	}
 
-	IncrReplaced();
 	(estate->es_processed)++;
 	(resultRelInfo->ri_aoprocessed)++;
 
@@ -5058,8 +5054,6 @@ intorel_receive(TupleTableSlot *slot, DestReceiver *self)
 	}
 
 	/* We know this is a newly created relation, so there are no indexes */
-
-	IncrAppended();
 }
 
 /*

--- a/src/backend/executor/execQual.c
+++ b/src/backend/executor/execQual.c
@@ -6131,8 +6131,6 @@ ExecQual(List *qual, ExprContext *econtext, bool resultForNull)
 	EV_nodeDisplay(qual);
 	EV_printf("\n");
 
-	IncrProcessed();
-
 	/*
 	 * Run in short-lived per-tuple context while computing expressions.
 	 */

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -72,81 +72,7 @@
 #include "nodes/makefuncs.h"
 #include "storage/ipc.h"
 
-/* ----------------------------------------------------------------
- *		global counters for number of tuples processed, retrieved,
- *		appended, replaced, deleted.
- * ----------------------------------------------------------------
- */
-int			NTupleProcessed;
-int			NTupleRetrieved;
-int			NTupleReplaced;
-int			NTupleAppended;
-int			NTupleDeleted;
-int			NIndexTupleInserted;
-int			NIndexTupleProcessed;
-
 static void ShutdownExprContext(ExprContext *econtext);
-
-
-/* ----------------------------------------------------------------
- *						statistic functions
- * ----------------------------------------------------------------
- */
-
-/* ----------------------------------------------------------------
- *		ResetTupleCount
- * ----------------------------------------------------------------
- */
-#ifdef NOT_USED
-void
-ResetTupleCount(void)
-{
-	NTupleProcessed = 0;
-	NTupleRetrieved = 0;
-	NTupleAppended = 0;
-	NTupleDeleted = 0;
-	NTupleReplaced = 0;
-	NIndexTupleProcessed = 0;
-}
-#endif
-
-/* ----------------------------------------------------------------
- *		PrintTupleCount
- * ----------------------------------------------------------------
- */
-#ifdef NOT_USED
-void
-DisplayTupleCount(FILE *statfp)
-{
-	if (NTupleProcessed > 0)
-		fprintf(statfp, "!\t%d tuple%s processed, ", NTupleProcessed,
-				(NTupleProcessed == 1) ? "" : "s");
-	else
-	{
-		fprintf(statfp, "!\tno tuples processed.\n");
-		return;
-	}
-	if (NIndexTupleProcessed > 0)
-		fprintf(statfp, "%d indextuple%s processed, ", NIndexTupleProcessed,
-				(NIndexTupleProcessed == 1) ? "" : "s");
-	if (NIndexTupleInserted > 0)
-		fprintf(statfp, "%d indextuple%s inserted, ", NIndexTupleInserted,
-				(NIndexTupleInserted == 1) ? "" : "s");
-	if (NTupleRetrieved > 0)
-		fprintf(statfp, "%d tuple%s retrieved. ", NTupleRetrieved,
-				(NTupleRetrieved == 1) ? "" : "s");
-	if (NTupleAppended > 0)
-		fprintf(statfp, "%d tuple%s appended. ", NTupleAppended,
-				(NTupleAppended == 1) ? "" : "s");
-	if (NTupleDeleted > 0)
-		fprintf(statfp, "%d tuple%s deleted. ", NTupleDeleted,
-				(NTupleDeleted == 1) ? "" : "s");
-	if (NTupleReplaced > 0)
-		fprintf(statfp, "%d tuple%s replaced. ", NTupleReplaced,
-				(NTupleReplaced == 1) ? "" : "s");
-	fprintf(statfp, "\n");
-}
-#endif
 
 
 /* ----------------------------------------------------------------
@@ -1225,10 +1151,6 @@ ExecInsertIndexTuples(TupleTableSlot *slot,
 					 heapRelation,
 					 relationDescs[i]->rd_index->indisunique && !is_vacuum);
 
-		/*
-		 * keep track of index inserts for debugging
-		 */
-		IncrIndexInserted();
 	}
 }
 

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -5585,7 +5585,6 @@ ResetUsage(void)
 	getrusage(RUSAGE_SELF, &Save_r);
 	gettimeofday(&Save_t, NULL);
 	ResetBufferUsage();
-	/* ResetTupleCount(); */
 }
 
 void

--- a/src/include/executor/execdebug.h
+++ b/src/include/executor/execdebug.h
@@ -31,16 +31,6 @@
  */
 
 /* ----------------
- *		EXEC_TUPLECOUNT is a #define which causes the
- *		executor to keep track of tuple counts.  This might be
- *		causing some problems with the decstation stuff so
- *		you might want to undefine this if you are doing work
- *		on the decs  - cim 10/20/89
- * ----------------
-#undef EXEC_TUPLECOUNT
- */
-
-/* ----------------
  *		EXEC_NESTLOOPDEBUG is a flag which turns on debugging of the
  *		nest loop node by NL_printf() and ENL_printf() in nodeNestloop.c
  * ----------------
@@ -79,39 +69,6 @@
 #define T_OR_F(b)				((b) ? "true" : "false")
 #define NULL_OR_TUPLE(slot)		(TupIsNull(slot) ? "null" : "a tuple")
 
-
-/* ----------------
- *		tuple count debugging defines
- * ----------------
- */
-#ifdef EXEC_TUPLECOUNT
-extern int	NTupleProcessed;
-extern int	NTupleRetrieved;
-extern int	NTupleReplaced;
-extern int	NTupleAppended;
-extern int	NTupleDeleted;
-extern int	NIndexTupleProcessed;
-extern int	NIndexTupleInserted;
-
-#define IncrRetrieved()			NTupleRetrieved++
-#define IncrAppended()			NTupleAppended++
-#define IncrDeleted()			NTupleDeleted++
-#define IncrReplaced()			NTupleReplaced++
-#define IncrInserted()			NTupleInserted++
-#define IncrProcessed()			NTupleProcessed++
-#define IncrIndexProcessed()	NIndexTupleProcessed++
-#define IncrIndexInserted()		NIndexTupleInserted++
-#else
-/* stop compiler warnings */
-#define IncrRetrieved()			(void)(0)
-#define IncrAppended()			(void)(0)
-#define IncrDeleted()			(void)(0)
-#define IncrReplaced()			(void)(0)
-#define IncrInserted()			(void)(0)
-#define IncrProcessed()			(void)(0)
-#define IncrIndexProcessed()	(void)(0)
-#define IncrIndexInserted()		(void)(0)
-#endif   /* EXEC_TUPLECOUNT */
 
 /* ----------------
  *		nest loop debugging defines


### PR DESCRIPTION
This was removed in upstream in c970292a94e0fff468d500db430d751b6221a0b4,
and is one step forward to make a number of counters 64 bit safe.