### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/backend/parser/parse_cte.c
+++ b/src/backend/parser/parse_cte.c
@@ -15,6 +15,7 @@
 #include "postgres.h"
 
 #include "nodes/nodeFuncs.h"
+#include "optimizer/walkers.h"
 #include "parser/analyze.h"
 #include "parser/parse_cte.h"
 #include "parser/parse_expr.h"

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -2250,7 +2250,6 @@ get_select_query_def(Query *query, deparse_context *context,
 {
 	StringInfo	buf = context->buf;
 	bool		force_colno;
-	const char *sep;
 	ListCell   *l;
 
 	/* Insert the WITH clause if given */
@@ -2646,7 +2645,7 @@ get_rule_grouplist(List *grplist, List *tlist,
 				   bool in_grpsets, deparse_context *context)
 {
 	StringInfo buf = context->buf;
-	char *sep;
+	const char *sep;
 	ListCell *lc;
 
 	sep = "";
@@ -5237,7 +5236,7 @@ get_sortlist_expr(List *l, List *targetList, bool force_colno,
                   deparse_context *context, char *keyword_clause)
 {
 	ListCell *cell;
-	char *sep;
+	const char *sep;
 	StringInfo buf = context->buf;
 
 	appendContextKeyword(context, keyword_clause,

--- a/src/include/nodes/nodeFuncs.h
+++ b/src/include/nodes/nodeFuncs.h
@@ -22,7 +22,4 @@ extern bool single_node(Node *node);
 extern bool var_is_outer(Var *var);
 extern bool var_is_rel(Var *var);
 
-extern bool raw_expression_tree_walker(Node *node, bool (*walker) (),
-									   void *context);
-
 #endif   /* NODEFUNCS_H */

--- a/src/include/optimizer/walkers.h
+++ b/src/include/optimizer/walkers.h
@@ -32,6 +32,9 @@ extern bool range_table_walker(List *rtable, bool (*walker) (),
 extern bool query_or_expression_tree_walker(Node *node, bool (*walker) (),
 												   void *context, int flags);
 
+extern bool raw_expression_tree_walker(Node *node, bool (*walker) (),
+									   void *context);
+
 /* The plan associated with a SubPlan is found in a list.  During planning this is in
  * the global structure found through the root PlannerInfo.  After planning this is in
  * the PlannedStmt.


### PR DESCRIPTION
1. unused variable `const char *seq` in ruleutils.c
2. walkers.c:1466:1: warning: no previous prototype for function
'raw_expression_tree_walker' [-Wmissing-prototypes]