### PR TITLE
Adding SQL tests to check successful elimination of alien nodes.

### DIFF
--- a/src/test/regress/expected/memconsumption.out
+++ b/src/test/regress/expected/memconsumption.out
@@ -1,0 +1,46 @@
+-- Memory consumption of operators 
+-- start_ignore
+create schema memconsumption;
+set search_path to memconsumption;
+-- end_ignore
+create table test (i int, j int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+set explain_memory_verbosity=detail;
+set execute_pruned_plan=on;
+insert into test select i, i % 100 from generate_series(1,1000) as i;
+-- start_ignore
+create language plpythonu;
+-- end_ignore
+create or replace function sum_alien_consumption(query text) returns int as
+$$
+import re
+rv = plpy.execute('EXPLAIN ANALYZE '+ query)
+search_text = 'X_Alien'
+total_consumption = 0
+count = 0
+comp_regex = re.compile("[^0-9]+(\d+)\/(\d+).+")
+for i in range(len(rv)):
+    cur_line = rv[i]['QUERY PLAN']
+    if search_text.lower() in cur_line.lower():
+        print search_text
+        m = comp_regex.match(cur_line)
+        if m is not None:
+            count = count + 1
+            total_consumption = total_consumption + int(m.group(2))
+return total_consumption
+$$
+language plpythonu;
+select sum_alien_consumption('SELECT t1.i, t2.j FROM test as t1 join test as t2 on t1.i = t2.j') = 0;
+ ?column? 
+----------
+ t
+(1 row)
+
+set execute_pruned_plan=off;
+select sum_alien_consumption('SELECT t1.i, t2.j FROM test as t1 join test as t2 on t1.i = t2.j') > 0;
+ ?column? 
+----------
+ t
+(1 row)
+

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -103,7 +103,7 @@ test: bfv_catalog bfv_index bfv_olap bfv_aggregate bfv_partition DML_over_joins 
 test: aggregate_with_groupingsets 
 
 test: nested_case_null sort bb_mpph
-test: bb_memory_quota
+test: bb_memory_quota memconsumption
 
 # NOTE: The bfv_temp test assumes that there are no temporary tables in
 # other sessions. Therefore the other tests in this group mustn't create

--- a/src/test/regress/sql/memconsumption.sql
+++ b/src/test/regress/sql/memconsumption.sql
@@ -1,0 +1,42 @@
+-- Memory consumption of operators 
+
+-- start_ignore
+create schema memconsumption;
+set search_path to memconsumption;
+-- end_ignore
+
+create table test (i int, j int);
+
+set explain_memory_verbosity=detail;
+set execute_pruned_plan=on;
+
+insert into test select i, i % 100 from generate_series(1,1000) as i;
+
+-- start_ignore
+create language plpythonu;
+-- end_ignore
+
+create or replace function sum_alien_consumption(query text) returns int as
+$$
+import re
+rv = plpy.execute('EXPLAIN ANALYZE '+ query)
+search_text = 'X_Alien'
+total_consumption = 0
+count = 0
+comp_regex = re.compile("[^0-9]+(\d+)\/(\d+).+")
+for i in range(len(rv)):
+    cur_line = rv[i]['QUERY PLAN']
+    if search_text.lower() in cur_line.lower():
+        print search_text
+        m = comp_regex.match(cur_line)
+        if m is not None:
+            count = count + 1
+            total_consumption = total_consumption + int(m.group(2))
+return total_consumption
+$$
+language plpythonu;
+
+select sum_alien_consumption('SELECT t1.i, t2.j FROM test as t1 join test as t2 on t1.i = t2.j') = 0;
+
+set execute_pruned_plan=off;
+select sum_alien_consumption('SELECT t1.i, t2.j FROM test as t1 join test as t2 on t1.i = t2.j') > 0;


### PR DESCRIPTION
This PR adds SQL test to verify that memory consumption of alien nodes drops to zero after we set the guc execute_pruned_plan=on.

Signed-off-by: Foyzur Rahman <foyzur@gmail.com>