### PR TITLE
gpfdist should reject http request without proper header fields "X-GP…

### DIFF
--- a/src/bin/gpfdist/regress/input/exttab1.source
+++ b/src/bin/gpfdist/regress/input/exttab1.source
@@ -77,6 +77,10 @@ SELECT count(*) FROM EXT_NATION_MATCH;
 SELECT * FROM EXT_REGION;
 SELECT * FROM EXT_REGION as r, EXT_NATION as n WHERE n.N_REGIONKEY = r.R_REGIONKEY;
 
+-- test: http request header needed for gpfdist
+\! wget http://@hostname@:7070/exttab1/missing_fields1.data >/dev/null 2>&1 || echo "Execute error";
+\! wget --header='X-GP-PROTO:0' http://@hostname@:7070/exttab1/missing_fields1.data >/dev/null 2>&1 && echo "Execute successully";
+
 -- start_ignore
 select * from exttab1_gpfdist_stop;
 -- end_ignore

--- a/src/bin/gpfdist/regress/output/exttab1.source
+++ b/src/bin/gpfdist/regress/output/exttab1.source
@@ -146,6 +146,11 @@ SELECT * FROM EXT_REGION as r, EXT_NATION as n WHERE n.N_REGIONKEY = r.R_REGIONK
            4 | MIDDLE EAST               | uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl        |           4 | EGYPT                     |           4 | y above the carefully unusual theodolites. final dugouts are quickly across the furiously regular d
 (25 rows)
 
+-- test: http request header needed for gpfdist
+\! wget http://@hostname@:7070/exttab1/missing_fields1.data >/dev/null 2>&1 || echo "Execute error";
+Execute error
+\! wget --header='X-GP-PROTO:0' http://@hostname@:7070/exttab1/missing_fields1.data >/dev/null 2>&1 && echo "Execute successully";
+Execute successully
 -- start_ignore
 -- end_ignore
 -- drop tables


### PR DESCRIPTION
…-PROTO"

Any http request to gpfdist with pipe will lead original pipe reader process hung.
In order to avoid the situation that random http request to the working gpfdist instance,
gpfdist will check request header.

Any manual request should run as:
wget --header='X-GP-PROTO:0' http://host:port/file