### PR TITLE
Ensure that stable functions in a prepared statement are re-evaluated.

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -101,6 +101,7 @@ _copyPlannedStmt(PlannedStmt *from)
 	COPY_SCALAR_FIELD(planGen);
 	COPY_SCALAR_FIELD(canSetTag);
 	COPY_SCALAR_FIELD(transientPlan);
+	COPY_SCALAR_FIELD(oneoffPlan);
 	COPY_NODE_FIELD(planTree);
 	COPY_NODE_FIELD(rtable);
 	COPY_NODE_FIELD(resultRelations);

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -314,6 +314,7 @@ _outPlannedStmt(StringInfo str, PlannedStmt *node)
 	WRITE_ENUM_FIELD(planGen, PlanGenerator);
 	WRITE_BOOL_FIELD(canSetTag);
 	WRITE_BOOL_FIELD(transientPlan);
+	WRITE_BOOL_FIELD(oneoffPlan);
 
 	WRITE_NODE_FIELD(planTree);
 

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -293,6 +293,7 @@ _outPlannedStmt(StringInfo str, PlannedStmt *node)
 	WRITE_ENUM_FIELD(planGen, PlanGenerator);
 	WRITE_BOOL_FIELD(canSetTag);
 	WRITE_BOOL_FIELD(transientPlan);
+	WRITE_BOOL_FIELD(oneoffPlan);
 	WRITE_NODE_FIELD(planTree);
 	WRITE_NODE_FIELD(rtable);
 	WRITE_NODE_FIELD(resultRelations);
@@ -1979,6 +1980,7 @@ _outPlannerGlobal(StringInfo str, PlannerGlobal *node)
 	WRITE_NODE_FIELD(relationOids);
 	WRITE_NODE_FIELD(invalItems);
 	WRITE_BOOL_FIELD(transientPlan);
+	WRITE_BOOL_FIELD(oneoffPlan);
 	WRITE_NODE_FIELD(share.motStack);
 	WRITE_NODE_FIELD(share.qdShares);
 	WRITE_NODE_FIELD(share.qdSlices);

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -1427,6 +1427,7 @@ _readPlannedStmt(void)
 	READ_ENUM_FIELD(planGen, PlanGenerator);
 	READ_BOOL_FIELD(canSetTag);
 	READ_BOOL_FIELD(transientPlan);
+	READ_BOOL_FIELD(oneoffPlan);
 	READ_NODE_FIELD(planTree);
 	READ_NODE_FIELD(rtable);
 	READ_NODE_FIELD(resultRelations);

--- a/src/backend/optimizer/plan/orca.c
+++ b/src/backend/optimizer/plan/orca.c
@@ -104,6 +104,7 @@ optimize_query(Query *parse, ParamListInfo boundParams)
 	glob->subrtables = NIL;
 	glob->rewindPlanIDs = NULL;
 	glob->transientPlan = false;
+	glob->oneoffPlan = false;
 	glob->share.producers = NULL;
 	glob->share.producer_count = 0;
 	glob->share.sliceMarks = NULL;
@@ -233,6 +234,8 @@ optimize_query(Query *parse, ParamListInfo boundParams)
 	result->subplans = glob->subplans;
 	result->relationOids = glob->relationOids;
 	result->invalItems = glob->invalItems;
+	result->oneoffPlan = glob->oneoffPlan;
+	result->transientPlan = glob->transientPlan;
 
 	return result;
 }

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -242,6 +242,7 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	glob->relationOids = NIL;
 	glob->invalItems = NIL;
 	glob->transientPlan = false;
+	glob->oneoffPlan = false;
 	/* ApplyShareInputContext initialization. */
 	glob->share.producers = NULL;
 	glob->share.producer_count = 0;
@@ -392,6 +393,7 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	result->commandType = parse->commandType;
 	result->canSetTag = parse->canSetTag;
 	result->transientPlan = glob->transientPlan;
+	result->oneoffPlan = glob->oneoffPlan;
 	result->planTree = top_plan;
 	result->rtable = glob->finalrtable;
 	result->resultRelations = root->resultRelations;

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -2520,19 +2520,7 @@ exec_bind_message(StringInfo input_message)
 		 * destruction.
 		 */
 		cplan = RevalidateCachedPlan(psrc, false);
-
-		/*
-		 * Make a copy of the plan in portal's memory context, because GPDB
-		 * would modify the plan tree later in exec_make_plan_constant before
-		 * dispatching, and the modification would make another copy of the plan
-		 * from the same memory context of the plan tree, so if we use the
-		 * cached plan directly here, the copy in exec_make_plan_constant would
-		 * be allocated in CachedPlan context, which lives for the whole life
-		 * span of the process and can cause memory leak.
-		 */
-		oldContext = MemoryContextSwitchTo(PortalGetHeapMemory(portal));
-		plan_list = copyObject(cplan->stmt_list);
-		MemoryContextSwitchTo(oldContext);
+		plan_list = cplan->stmt_list;
 	}
 	else
 	{

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -71,6 +71,7 @@ typedef struct PlannedStmt
 	bool		canSetTag;		/* do I set the command result tag? */
 
 	bool		transientPlan;	/* redo plan when TransactionXmin changes? */
+	bool		oneoffPlan;		/* redo plan on every execution? */
 
 	struct Plan *planTree;		/* tree of Plan nodes */
 

--- a/src/include/nodes/relation.h
+++ b/src/include/nodes/relation.h
@@ -109,6 +109,7 @@ typedef struct PlannerGlobal
 	List	   *invalItems;		/* other dependencies, as PlanInvalItems */
 
 	bool		transientPlan;	/* redo plan when TransactionXmin changes? */
+	bool		oneoffPlan;		/* redo plan on every execution? */
 
 	ApplyShareInputContext share;	/* workspace for GPDB plan sharing */
 

--- a/src/test/regress/expected/bfv_planner.out
+++ b/src/test/regress/expected/bfv_planner.out
@@ -255,6 +255,50 @@ select * from tstest where t @@ 'bar' for share of tstest;
  'bar'
 (1 row)
 
+-- Stable (and volatile) functions need to be re-evaluated on every
+-- execution of a prepared statement. There used to be a bug, where
+-- they were evaluated once at planning time or at first execution,
+-- and the same value was incorrectly reused on subsequent executions.
+create function stabletestfunc() returns integer as $$
+begin
+  raise notice 'stabletestfunc executed';
+  return 123;
+end;
+$$ language plpgsql stable;
+create table stabletesttab (id integer);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into stabletesttab values (1);
+insert into stabletesttab values (1000);
+-- This might evaluate the function, for cost estimate purposes. That's
+-- not of importance for this test.
+prepare myprep as select * from stabletesttab where id < stabletestfunc();
+NOTICE:  stabletestfunc executed
+-- Check that the stable function should be re-executed on every execution of the prepared statetement.
+execute myprep;
+NOTICE:  stabletestfunc executed
+NOTICE:  stabletestfunc executed
+ id 
+----
+  1
+(1 row)
+
+execute myprep;
+NOTICE:  stabletestfunc executed
+NOTICE:  stabletestfunc executed
+ id 
+----
+  1
+(1 row)
+
+execute myprep;
+NOTICE:  stabletestfunc executed
+NOTICE:  stabletestfunc executed
+ id 
+----
+  1
+(1 row)
+
 -- start_ignore
 drop table if exists bfv_planner_x;
 drop table if exists testbadsql;

--- a/src/test/regress/expected/partition_pruning.out
+++ b/src/test/regress/expected/partition_pruning.out
@@ -99,6 +99,31 @@ INSERT INTO pt_lt_tab_df VALUES(NULL,NULL,NULL,NULL);
 INSERT INTO pt_lt_tab_df VALUES(NULL,NULL,NULL,NULL);
 INSERT INTO pt_lt_tab_df VALUES(NULL,NULL,NULL,NULL);
 ANALYZE pt_lt_tab_df;
+--
+-- Test that stable functions are evaluated when constructing the plan. This
+-- differs from PostgreSQL. In PostgreSQL, PREPARE/EXECUTE creates a reusable
+-- plan, while in GPDB, we re-plan the query on every execution, so that the
+-- stable function is executed during planning, and we can therefore do
+-- partition pruning based on its result.
+--
+create or replace function stabletestfunc() returns integer as $$
+begin
+  return 10;
+end;
+$$ language plpgsql stable;
+PREPARE prep_prune AS select * from pt_lt_tab WHERE col2 = stabletestfunc();
+-- The plan should only scan one partition, where col2 = 10.
+EXPLAIN EXECUTE prep_prune;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.12 rows=1 width=14)
+   ->  Append  (cost=0.00..3.12 rows=1 width=14)
+         ->  Seq Scan on pt_lt_tab_1_prt_part1 pt_lt_tab  (cost=0.00..3.12 rows=1 width=14)
+               Filter: col2 = 10::numeric
+ Settings:  enable_bitmapscan=on; enable_indexscan=on; enable_seqscan=off; optimizer=off
+ Optimizer status: legacy query optimizer
+(6 rows)
+
 -- @description B-tree single index key = non-partitioning key
 CREATE INDEX idx1 on pt_lt_tab(col1);
 NOTICE:  building index for child partition "pt_lt_tab_1_prt_part1"

--- a/src/test/regress/expected/partition_pruning_optimizer.out
+++ b/src/test/regress/expected/partition_pruning_optimizer.out
@@ -99,6 +99,33 @@ INSERT INTO pt_lt_tab_df VALUES(NULL,NULL,NULL,NULL);
 INSERT INTO pt_lt_tab_df VALUES(NULL,NULL,NULL,NULL);
 INSERT INTO pt_lt_tab_df VALUES(NULL,NULL,NULL,NULL);
 ANALYZE pt_lt_tab_df;
+--
+-- Test that stable functions are evaluated when constructing the plan. This
+-- differs from PostgreSQL. In PostgreSQL, PREPARE/EXECUTE creates a reusable
+-- plan, while in GPDB, we re-plan the query on every execution, so that the
+-- stable function is executed during planning, and we can therefore do
+-- partition pruning based on its result.
+--
+create or replace function stabletestfunc() returns integer as $$
+begin
+  return 10;
+end;
+$$ language plpgsql stable;
+PREPARE prep_prune AS select * from pt_lt_tab WHERE col2 = stabletestfunc();
+-- The plan should only scan one partition, where col2 = 10.
+EXPLAIN EXECUTE prep_prune;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=14)
+   ->  Sequence  (cost=0.00..431.00 rows=1 width=14)
+         ->  Partition Selector for pt_lt_tab (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+               Filter: col2 = 10::numeric
+               Partitions selected: 1 (out of 5)
+         ->  Dynamic Table Scan on pt_lt_tab (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=14)
+               Filter: col2 = 10::numeric
+ Settings:  enable_bitmapscan=on; enable_indexscan=on; enable_seqscan=off; optimizer=on
+(9 rows)
+
 -- @description B-tree single index key = non-partitioning key
 CREATE INDEX idx1 on pt_lt_tab(col1);
 NOTICE:  building index for child partition "pt_lt_tab_1_prt_part1"


### PR DESCRIPTION
If a prepared statement, or a cached plan for an SPI query e.g. from a
PL/pgSQL function, contains stable functions, the stable functions were
incorrectly evaluated only once at plan time, instead of on every
execution of the plan. This happened to not be a problem in queries
that contain any parameters, because in GPDB, they are re-planned on
every invocation anyway, but non-parameter queries were broken.

There were two bugs here that both needed to be fixed, to get the test
case working correctly:

1. In the planner, when simplifying expressions, we set the
transform_stable_funcs flag to true for every query, and evaluated
all stable functions at planning time. Change it to false, and also
rename it back to 'estimate', as it's called in the upstream. That flag
was changed back in 2010, in order to allow partition pruning to work
with qual containing stable functions, like TO_DATE. I think back then,
we always re-planned every query, so that was OK, but we do cache plans
now.

To avoid regressing to worse plans, change eval_const_expressions()
so that it still does evaluate stable functions, even when the
'estimate' flag is off. But when it does so, mark the plan as
"one-off", meaning that it must be re-planned on every execution.
That gives the old, intended, behavior, that such plans are indeed
re-planned, but it still allows plans that don't use stable functions
to be cached.

2. When dispatching a plan, we created a modified copy of the plan with
the calls to stable functions replaced with the results of evaluating
them. However, we scribbled on the PlannedStmt directly, so if it was
part of a cached plan, we modified the cached plan, and it would be
executed with the same values on subsequent executions. To fix, make
a copy.

This seems to fix github issue #2661. Looking at the direct dispatch
code in apply_motion(), I suspect there are more issues like this lurking
there. There's a call to planner_make_plan_constant(), modifying the
target list in place, and that happens during planning. But this at least
fixes the non-direct dispatch cases, and is a necessary step for fixing
any remaining issues.

For some reason, the query now gets planned *twice* for every invocation.
That's not ideal, but it was an existing issue for prepared statements
with parameters, already. So let's deal with that separately.