### PR TITLE
Fix dumping of "COUNT(*) FILTER (...)" expressions.

### DIFF
--- a/src/backend/parser/parse_func.c
+++ b/src/backend/parser/parse_func.c
@@ -597,7 +597,16 @@ ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
 		aggref->aggfnoid    = funcid;
 		aggref->aggtype     = rettype;
 		aggref->args        = fargs;
-		aggref->aggstar     = agg_star;
+
+		/*
+		 * If we had a FILTER clause with a star, we replaced the star with
+		 * a CASE WHEN expression above. Set 'aggstar' accordingly.
+		 */
+		if (agg_filter && agg_star)
+			aggref->aggstar = false;
+		else
+			aggref->aggstar = agg_star;
+
 		aggref->aggdistinct = agg_distinct;
 		aggref->location = location;
 

--- a/src/test/regress/expected/filter.out
+++ b/src/test/regress/expected/filter.out
@@ -643,6 +643,13 @@ ERROR:  function maxodd(integer) is not defined as STRICT
 LINE 1: SELECT j, maxodd(i) FILTER (WHERE TRUE) from filter_test gro...
                   ^
 HINT:  The filter clause is only supported over functions defined as STRICT.
+-- TEST view deparsing of FILTER expressions.
+CREATE VIEW filter_view AS SELECT count(*) FILTER (WHERE TRUE) FROM filter_test;
+SELECT definition from pg_views WHERE viewname='filter_view';
+                                      definition                                       
+---------------------------------------------------------------------------------------
+ SELECT count(CASE WHEN true THEN 1 ELSE NULL::integer END) AS count FROM filter_test;
+(1 row)
+
 drop aggregate maxodd(int);
 drop function _maxodd(int,int);
-drop table filter_test;

--- a/src/test/regress/sql/filter.sql
+++ b/src/test/regress/sql/filter.sql
@@ -173,6 +173,9 @@ SELECT maxodd(i) FILTER (WHERE TRUE) from filter_test;
 SELECT j, maxodd(i) FROM filter_test group by j order by j;
 SELECT j, maxodd(i) FILTER (WHERE TRUE) from filter_test group by j order by j;
 
+-- TEST view deparsing of FILTER expressions.
+CREATE VIEW filter_view AS SELECT count(*) FILTER (WHERE TRUE) FROM filter_test;
+SELECT definition from pg_views WHERE viewname='filter_view';
+
 drop aggregate maxodd(int);
 drop function _maxodd(int,int);
-drop table filter_test;


### PR DESCRIPTION
Without this fix, the FILTER expression would be left out of the deparsed
DDL of a view. Now it gets dumped as the CASE - WHEN expression that we
tranform the FILTER to at parse analysis. Ideally, we would dump it using
the original FILTER syntax, but that would be a much bigger patch. We'll
get that when we merge the upstream FILTER implementation, in PostgreSQL
9.4.

Fixes github issue #1854.