### PR TITLE
Disallow rescanning motion regardless of param change

### DIFF
--- a/src/backend/executor/nodeMotion.c
+++ b/src/backend/executor/nodeMotion.c
@@ -1548,10 +1548,8 @@ doSendTuple(Motion * motion, MotionState * node, TupleTableSlot *outerTupleSlot)
 void
 ExecReScanMotion(MotionState *node, ExprContext *exprCtxt)
 {
-	if (node->ps.chgParam != NULL
-			&& (node->mstype != MOTIONSTATE_RECV ||
+	if (node->mstype != MOTIONSTATE_RECV ||
 					node->numTuplesToParent != 0)
-		)
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_INTERNAL_ERROR),


### PR DESCRIPTION
Context: unlike upstream Postgres, not every operator in Greenplum is
rescannable, noticeably motions. Semantically, a motion is not
rescannable except for one very limited cases:

1. When the motion has been initialized, but it has never streamed out
any tuples yet. Rescanning is permitted here, because it is as good as
not rescanning.

Historically, we've been checking for exactly this condition, until in
4.2 we added a check to allow rescanning when parameters changed.
Corellated subquery was cited as the intent of the commit (private), but
come to think of it, motions are not rescannable regardless of parameter
change. In fact, if execution reaches this point, the optimizer must
have generated a wrong plan.

This commit reinstates the original stricter check.