### PR TITLE
Restore statistics file in gpdbrestore --restore-stats with ddboost

### DIFF
--- a/src/bin/pg_dump/cdb/cdb_ddboost_util.c
+++ b/src/bin/pg_dump/cdb/cdb_ddboost_util.c
@@ -2544,6 +2544,9 @@ isFileToBeCopied(const char *filename)
 	if (strstr(filename, ".tar"))
 		return 1;
 
+	if (strstr(filename, "gp_statistics_"))
+		return 1;
+
 	return 0;
 }
 


### PR DESCRIPTION
The gp_statsistics prefix was not included in the list of files to
restore from ddboost, causing restore to fail when gpdbrestore
--restore-stats was used.