### PR TITLE
Fixes to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ building, see the README at the following repositories:
     ```
     git clone https://github.com/greenplum-db/gp-xerces
     mkdir gp-xerces/build
-    cd gp-xerces/build
+    pushd gp-xerces/build
     ../configure
     make install
+    popd
     ```
 
 1. ORCA requires [CMake](https://cmake.org) and
@@ -62,9 +63,10 @@ building, see the README at the following repositories:
     ```
     git clone https://github.com/greenplum-db/gporca
     mkdir gporca/build
-    cd gporca/build
+    pushd gporca/build
     cmake -GNinja ..
     ninja install
+    popd
     ```
     **Note**: Get the latest ORCA `git pull --ff-only` if you see an error message like below:
     ```

--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ building, see the README at the following repositories:
     ```
     git clone https://github.com/greenplum-db/gp-xerces
     mkdir gp-xerces/build
-    pushd gp-xerces/build
+    cd gp-xerces/build
     ../configure
     make install
-    popd
+    cd ../..
     ```
 
 1. ORCA requires [CMake](https://cmake.org) and
@@ -63,10 +63,10 @@ building, see the README at the following repositories:
     ```
     git clone https://github.com/greenplum-db/gporca
     mkdir gporca/build
-    pushd gporca/build
+    cd gporca/build
     cmake -GNinja ..
     ninja install
-    popd
+    cd ../..
     ```
     **Note**: Get the latest ORCA `git pull --ff-only` if you see an error message like below:
     ```
@@ -87,9 +87,6 @@ building, see the README at the following repositories:
     
 ### Build the database
 ```
-# Clean environment
-make distclean
-
 # Configure build environment to install at /usr/local/gpdb
 ./configure --with-perl --with-python --with-libxml --prefix=/usr/local/gpdb
 
@@ -135,6 +132,11 @@ select gp_opt_version();
 To turn ORCA off and use legacy planner for query optimization:
 ```
 set optimizer=off;
+```
+
+If you want to clean all generated files
+```
+make distclean
 ```
 
 ## Running tests


### PR DESCRIPTION
On a brand new machine, the user can not run `make distclean` prior to configure.

What exactly should a developer use `make distclean` ?  Let me know how I should update this comment.