### PR TITLE
Pull in the foundation for heap checksum feature - pg_control change

### DIFF
--- a/concourse/tasks/ic_gpdb_binary_swap.yml
+++ b/concourse/tasks/ic_gpdb_binary_swap.yml
@@ -10,7 +10,7 @@ params:
   MAKE_TEST_COMMAND: ""
   BLDWRAP_POSTGRES_CONF_ADDONS: ""
   TEST_OS: ""
-  TEST_BINARY_SWAP: true
+  TEST_BINARY_SWAP: false
   CONFIGURE_FLAGS: ""
 run:
   path: gpdb_src/concourse/scripts/ic_gpdb.bash

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -89,7 +89,7 @@
 #include "cdb/cdbpersistentfilesysobj.h"
 #include "cdb/cdbpersistentcheck.h"
 
-
+extern uint32 bootstrap_data_checksum_version;
 
 /* File path names (all relative to $PGDATA) */
 #define RECOVERY_COMMAND_FILE	"recovery.conf"
@@ -5273,6 +5273,10 @@ ReadControlFile(void)
 	SetConfigOption("lc_ctype", ControlFile->lc_ctype,
 					PGC_INTERNAL, PGC_S_OVERRIDE);
 
+	/* Make the initdb settings visible as GUC variables, too */
+	SetConfigOption("data_checksums", DataChecksumsEnabled() ? "yes" : "no",
+					PGC_INTERNAL, PGC_S_OVERRIDE);
+
 	if (!ControlFileWatcher->watcherInitialized)
 	{
 		ControlFileWatcherSaveInitial();
@@ -5421,6 +5425,16 @@ GetSystemIdentifier(void)
 {
 	Assert(ControlFile != NULL);
 	return ControlFile->system_identifier;
+}
+
+/*
+ * Are checksums enabled for data pages?
+ */
+bool
+DataChecksumsEnabled(void)
+{
+	Assert(ControlFile != NULL);
+	return (ControlFile->data_checksum_version > 0);
 }
 
 /*
@@ -5675,6 +5689,8 @@ BootStrapXLOG(void)
 	ControlFile->time = checkPoint.time;
 	ControlFile->checkPoint = checkPoint.redo;
 	ControlFile->checkPointCopy = checkPoint;
+	ControlFile->data_checksum_version = bootstrap_data_checksum_version;
+
 	/* some additional ControlFile fields are set in WriteControlFile() */
 
 	WriteControlFile();

--- a/src/backend/bootstrap/bootstrap.c
+++ b/src/backend/bootstrap/bootstrap.c
@@ -34,6 +34,7 @@
 #include "postmaster/bgwriter.h"
 #include "postmaster/walwriter.h"
 #include "replication/walreceiver.h"
+#include "storage/bufpage.h"
 #include "storage/freespace.h"
 #include "storage/ipc.h"
 #include "storage/proc.h"
@@ -46,6 +47,8 @@
 
 extern int	optind;
 extern char *optarg;
+
+uint32 bootstrap_data_checksum_version = 0;  /* No checksum */
 
 extern void FileRepResetPeer_Main(void);
 
@@ -255,7 +258,7 @@ AuxiliaryProcessMain(int argc, char *argv[])
 
 	MyAuxProcType = CheckerProcess;
 
-	while ((flag = getopt(argc, argv, "B:c:d:D:Fr:x:y:-:")) != -1)
+	while ((flag = getopt(argc, argv, "B:c:d:D:Fkr:x:y:-:")) != -1)
 	{
 		switch (flag)
 		{
@@ -281,6 +284,9 @@ AuxiliaryProcessMain(int argc, char *argv[])
 			case 'F':
 				SetConfigOption("fsync", "false", PGC_POSTMASTER, PGC_S_ARGV);
 				break;
+ 			case 'k':
+				bootstrap_data_checksum_version = PG_DATA_CHECKSUM_VERSION;
+ 				break;
 			case 'r':
 				strlcpy(OutputFileName, optarg, MAXPGPATH);
 				break;

--- a/src/backend/storage/page/README
+++ b/src/backend/storage/page/README
@@ -1,0 +1,8 @@
+src/backend/storage/page/README
+
+Checksums
+---------
+
+Checksums will soon be supported for heap tables in Greenplum by
+pulling in commits from upstream PostgreSQL 9.3.  Append-optimized
+tables are already protected with checksums.

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -287,6 +287,7 @@ static int	max_function_args;
 static int	max_index_keys;
 static int	max_identifier_length;
 static int	block_size;
+static bool	data_checksums;
 static bool integer_datetimes;
 //static bool standard_conforming_strings;
 static char *allow_system_table_mods_str;
@@ -1167,6 +1168,18 @@ static struct config_bool ConfigureNamesBool[] =
 		&IgnoreSystemIndexes,
 		false, NULL, NULL
 	},
+
+	{
+		{"data_checksums", PGC_INTERNAL, PRESET_OPTIONS,
+			gettext_noop("Shows whether data checksums are turned on for this cluster"),
+			NULL,
+			GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE
+		},
+		&data_checksums,
+		false,
+		NULL, NULL, NULL
+	},
+
 	/* End-of-list marker */
 	{
 		{NULL, 0, 0, NULL, NULL}, NULL, false, NULL, NULL

--- a/src/bin/pg_controldata/pg_controldata.c
+++ b/src/bin/pg_controldata/pg_controldata.c
@@ -230,6 +230,8 @@ main(int argc, char *argv[])
 		   ControlFile.lc_collate);
 	printf(_("LC_CTYPE:                             %s\n"),
 		   ControlFile.lc_ctype);
+	printf(_("Data page checksum version:           %u\n"),
+		   ControlFile.data_checksum_version);
 
 	return 0;
 }

--- a/src/bin/pg_resetxlog/pg_resetxlog.c
+++ b/src/bin/pg_resetxlog/pg_resetxlog.c
@@ -671,6 +671,8 @@ PrintControlValues(bool guessed)
 		   ControlFile.lc_collate);
 	printf(_("LC_CTYPE:                             %s\n"),
 		   ControlFile.lc_ctype);
+	printf(_("Data page checksum version:           %u\n"),
+		   ControlFile.data_checksum_version);
 }
 
 

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -263,6 +263,7 @@ extern XLogRecPtr GetFlushRecPtr(void);
 
 extern void UpdateControlFile(void);
 extern uint64 GetSystemIdentifier(void);
+extern bool DataChecksumsEnabled(void);
 extern Size XLOGShmemSize(void);
 extern void XLOGShmemInit(void);
 extern void XLogStartupInit(void);

--- a/src/include/catalog/pg_control.h
+++ b/src/include/catalog/pg_control.h
@@ -185,6 +185,9 @@ typedef struct ControlFileData
 	char		lc_collate[LOCALE_NAME_BUFLEN];
 	char		lc_ctype[LOCALE_NAME_BUFLEN];
 
+	/* Are data pages protected by checksums? Zero if no checksum version */
+	uint32		data_checksum_version;
+
 	/* CRC of all above ... MUST BE LAST! */
 	pg_crc32c	crc;
 } ControlFileData;

--- a/src/include/storage/bufpage.h
+++ b/src/include/storage/bufpage.h
@@ -165,13 +165,16 @@ typedef PageHeaderData *PageHeader;
  *		added the pd_flags field (by stealing some bits from pd_tli),
  *		as well as adding the pd_prune_xid field (which enlarges the header).
  *
+ * As of Release 9.3, the checksum version must also be considered when
+ * handling pages.
+ *
  * GPDB 4 uses 4. However, it didn't have the pd_prune_xid field
  * GPDB 5.0 uses 14. The layout is the same as PostgreSQL 8.3's, but
  *		we couldn't use the same version number, because we had already
  *		used 4 for the previous format.
  */
 #define PG_PAGE_LAYOUT_VERSION		14
-
+#define PG_DATA_CHECKSUM_VERSION	1
 
 /* ----------------------------------------------------------------
  *						page support macros


### PR DESCRIPTION
This patch pulls in the addition of checksum version information to pg_control
and a GUC to report the checksum version.  Heap data checksum feature will be
pulled in its entirety as subsequent patches.

Upstream commit that this patch pulls from:

commit 96ef3b8ff1cf1950e897fd2f766d4bd9ef0d5d56
Author: Simon Riggs <simon@2ndQuadrant.com>
Date:   Fri Mar 22 13:54:07 2013 +0000

    Allow I/O reliability checks using 16-bit checksums

commit 443951748ce4c94b001877c7cf88b0ee969c79e7
Author: Simon Riggs <simon@2ndQuadrant.com>
Date:   Tue Apr 30 12:27:12 2013 +0100

    Record data_checksum_version in control file.
commit 5a7e75849cb595943fc605c4532716e9dd69f8a0
Author: Heikki Linnakangas <heikki.linnakangas@iki.fi>
Date:   Mon Sep 16 14:36:01 2013 +0300

    Add a GUC to report whether data page checksums are enabled.