### PR TITLE
Destory dangling Gang if interrupted during creation.

### DIFF
--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -53,7 +53,7 @@
  */
 int qe_gang_id = 0;
 MemoryContext GangContext = NULL;
-Gang *gangInCreating = NULL;
+Gang *CurrentGangCreating = NULL;
 
 CreateGangFunc pCreateGangFunc = NULL;
 
@@ -1421,11 +1421,11 @@ void freeGangsForPortal(char *portal_name)
 	if (Gp_role != GP_ROLE_DISPATCH)
 		return;
 
-	if (gangInCreating != NULL)
+	if (CurrentGangCreating != NULL)
 	{
-		GangType type = gangInCreating->type;
-		DisconnectAndDestroyGang(gangInCreating);
-		gangInCreating = NULL;
+		GangType type = CurrentGangCreating->type;
+		DisconnectAndDestroyGang(CurrentGangCreating);
+		CurrentGangCreating = NULL;
 
 		if (type == GANGTYPE_PRIMARY_WRITER)
 		{

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -52,8 +52,8 @@
  * the slice this QE should execute
  */
 int qe_gang_id = 0;
-
 MemoryContext GangContext = NULL;
+Gang *gangInCreating = NULL;
 
 CreateGangFunc pCreateGangFunc = NULL;
 
@@ -1420,6 +1420,19 @@ void freeGangsForPortal(char *portal_name)
 
 	if (Gp_role != GP_ROLE_DISPATCH)
 		return;
+
+	if (gangInCreating != NULL)
+	{
+		GangType type = gangInCreating->type;
+		DisconnectAndDestroyGang(gangInCreating);
+		gangInCreating = NULL;
+
+		if (type == GANGTYPE_PRIMARY_WRITER)
+		{
+			DisconnectAndDestroyAllGangs(true);
+			CheckForResetSession();
+		}
+	}
 
 	/*
 	 * the primary writer gangs "belong" to the unnamed portal --

--- a/src/backend/cdb/dispatcher/cdbgang_async.c
+++ b/src/backend/cdb/dispatcher/cdbgang_async.c
@@ -64,7 +64,7 @@ createGang_async(GangType type, int gang_id, int size, int content)
 	if (type == GANGTYPE_PRIMARY_WRITER)
 		Insist(!GangsExist());
 
-	Assert(gangInCreating == NULL);
+	Assert(CurrentGangCreating == NULL);
 
 create_gang_retry:
 	/* If we're in a retry, we may need to reset our initial state, a bit */
@@ -75,7 +75,7 @@ create_gang_retry:
 
 	/* allocate and initialize a gang structure */
 	newGangDefinition = buildGangDefinition(type, gang_id, size, content);
-	gangInCreating = newGangDefinition;
+	CurrentGangCreating = newGangDefinition;
 
 	Assert(newGangDefinition != NULL);
 	Assert(newGangDefinition->size == size);
@@ -266,7 +266,7 @@ create_gang_retry:
 
 			DisconnectAndDestroyGang(newGangDefinition);
 			newGangDefinition = NULL;
-			gangInCreating = NULL;
+			CurrentGangCreating = NULL;
 			retry = true;
 		}
 	}
@@ -281,7 +281,7 @@ create_gang_retry:
 
 			DisconnectAndDestroyGang(newGangDefinition);
 			newGangDefinition = NULL;
-			gangInCreating = NULL;
+			CurrentGangCreating = NULL;
 			DisconnectAndDestroyAllGangs(true);
 			CheckForResetSession();
 			ereport(ERROR, (errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
@@ -292,7 +292,7 @@ create_gang_retry:
 
 		DisconnectAndDestroyGang(newGangDefinition);
 		newGangDefinition = NULL;
-		gangInCreating = NULL;
+		CurrentGangCreating = NULL;
 
 		if (type == GANGTYPE_PRIMARY_WRITER)
 		{
@@ -317,7 +317,7 @@ create_gang_retry:
 
 	setLargestGangsize(size);
 
-	gangInCreating = NULL;
+	CurrentGangCreating = NULL;
 
 	return newGangDefinition;
 }

--- a/src/backend/cdb/dispatcher/cdbgang_async.c
+++ b/src/backend/cdb/dispatcher/cdbgang_async.c
@@ -64,6 +64,8 @@ createGang_async(GangType type, int gang_id, int size, int content)
 	if (type == GANGTYPE_PRIMARY_WRITER)
 		Insist(!GangsExist());
 
+	Assert(gangInCreating == NULL);
+
 create_gang_retry:
 	/* If we're in a retry, we may need to reset our initial state, a bit */
 	newGangDefinition = NULL;
@@ -73,6 +75,7 @@ create_gang_retry:
 
 	/* allocate and initialize a gang structure */
 	newGangDefinition = buildGangDefinition(type, gang_id, size, content);
+	gangInCreating = newGangDefinition;
 
 	Assert(newGangDefinition != NULL);
 	Assert(newGangDefinition->size == size);
@@ -263,6 +266,7 @@ create_gang_retry:
 
 			DisconnectAndDestroyGang(newGangDefinition);
 			newGangDefinition = NULL;
+			gangInCreating = NULL;
 			retry = true;
 		}
 	}
@@ -277,6 +281,7 @@ create_gang_retry:
 
 			DisconnectAndDestroyGang(newGangDefinition);
 			newGangDefinition = NULL;
+			gangInCreating = NULL;
 			DisconnectAndDestroyAllGangs(true);
 			CheckForResetSession();
 			ereport(ERROR, (errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
@@ -287,6 +292,7 @@ create_gang_retry:
 
 		DisconnectAndDestroyGang(newGangDefinition);
 		newGangDefinition = NULL;
+		gangInCreating = NULL;
 
 		if (type == GANGTYPE_PRIMARY_WRITER)
 		{
@@ -298,6 +304,8 @@ create_gang_retry:
 	}
 	PG_END_TRY();
 
+	SIMPLE_FAULT_INJECTOR(GangCreated);
+
 	if (retry)
 	{
 		CHECK_FOR_INTERRUPTS();
@@ -308,6 +316,9 @@ create_gang_retry:
 	}
 
 	setLargestGangsize(size);
+
+	gangInCreating = NULL;
+
 	return newGangDefinition;
 }
 

--- a/src/backend/cdb/dispatcher/cdbgang_thread.c
+++ b/src/backend/cdb/dispatcher/cdbgang_thread.c
@@ -93,7 +93,7 @@ createGang_thread(GangType type, int gang_id, int size, int content)
 
 	initPQExpBuffer(&create_gang_error);
 
-	Assert(gangInCreating == NULL);
+	Assert(CurrentGangCreating == NULL);
 
 create_gang_retry:
 	/*
@@ -108,7 +108,7 @@ create_gang_retry:
 
 	/* allocate and initialize a gang structure */
 	newGangDefinition = buildGangDefinition(type, gang_id, size, content);
-	gangInCreating = newGangDefinition;
+	CurrentGangCreating = newGangDefinition;
 
 	Assert(newGangDefinition != NULL);
 	Assert(newGangDefinition->size == size);
@@ -201,7 +201,7 @@ create_gang_retry:
 	{
 		setLargestGangsize(size);
 		termPQExpBuffer(&create_gang_error);
-		gangInCreating = NULL;
+		CurrentGangCreating = NULL;
 
 		return newGangDefinition;
 	}
@@ -229,7 +229,7 @@ create_gang_retry:
 			 */
 			DisconnectAndDestroyGang(newGangDefinition);
 			newGangDefinition = NULL;
-			gangInCreating = NULL;
+			CurrentGangCreating = NULL;
 	
 			ELOG_DISPATCHER_DEBUG("createGang: gang creation failed, but retryable.");
 	
@@ -253,7 +253,7 @@ exit:
 		CheckForResetSession();
 	}
 
-	gangInCreating = NULL;
+	CurrentGangCreating = NULL;
 
 	ereport(ERROR,
 			(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),

--- a/src/backend/cdb/dispatcher/cdbgang_thread.c
+++ b/src/backend/cdb/dispatcher/cdbgang_thread.c
@@ -93,6 +93,8 @@ createGang_thread(GangType type, int gang_id, int size, int content)
 
 	initPQExpBuffer(&create_gang_error);
 
+	Assert(gangInCreating == NULL);
+
 create_gang_retry:
 	/*
 	 * If we're in a retry, we may need to reset our initial state a bit. We
@@ -106,6 +108,8 @@ create_gang_retry:
 
 	/* allocate and initialize a gang structure */
 	newGangDefinition = buildGangDefinition(type, gang_id, size, content);
+	gangInCreating = newGangDefinition;
+
 	Assert(newGangDefinition != NULL);
 	Assert(newGangDefinition->size == size);
 	Assert(newGangDefinition->perGangContext != NULL);
@@ -182,6 +186,8 @@ create_gang_retry:
 	destroyConnectParms(doConnectParmsAr, threadCount);
 	doConnectParmsAr = NULL;
 
+	SIMPLE_FAULT_INJECTOR(GangCreated);
+
 	/* find out the successful connections and the failed ones */
 	checkConnectionStatus(newGangDefinition, &in_recovery_mode_count,
 			&successful_connections, &create_gang_error);
@@ -195,6 +201,8 @@ create_gang_retry:
 	{
 		setLargestGangsize(size);
 		termPQExpBuffer(&create_gang_error);
+		gangInCreating = NULL;
+
 		return newGangDefinition;
 	}
 
@@ -221,6 +229,7 @@ create_gang_retry:
 			 */
 			DisconnectAndDestroyGang(newGangDefinition);
 			newGangDefinition = NULL;
+			gangInCreating = NULL;
 	
 			ELOG_DISPATCHER_DEBUG("createGang: gang creation failed, but retryable.");
 	
@@ -243,6 +252,8 @@ exit:
 		DisconnectAndDestroyAllGangs(true);
 		CheckForResetSession();
 	}
+
+	gangInCreating = NULL;
 
 	ereport(ERROR,
 			(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),

--- a/src/backend/cdb/dispatcher/test/Makefile
+++ b/src/backend/cdb/dispatcher/test/Makefile
@@ -20,6 +20,7 @@ cdbgang.t: \
 	$(MOCK_DIR)/backend/cdb/cdbfts_mock.o \
 	$(MOCK_DIR)/backend/utils/misc/superuser_mock.o \
 	$(MOCK_DIR)/backend/gp_libpq_fe/fe-connect_mock.o \
-	$(MOCK_DIR)/backend/utils/mmgr/redzone_handler_mock.o
+	$(MOCK_DIR)/backend/utils/mmgr/redzone_handler_mock.o \
+	$(MOCK_DIR)/backend/utils/misc/faultinjector_mock.o
 
 include $(top_builddir)/src/backend/mock.mk

--- a/src/backend/cdb/dispatcher/test/cdbgang_test.c
+++ b/src/backend/cdb/dispatcher/test/cdbgang_test.c
@@ -138,6 +138,12 @@ static void test__createWriterGang(void **state)
 	will_return_count(getgpsegmentCount, segmentCount, -1);
 	will_return_count(getFtsVersion, ftsVersion, 1);
 
+	expect_any(FaultInjector_InjectFaultIfSet, identifier);
+	expect_any(FaultInjector_InjectFaultIfSet, ddlStatement);
+	expect_any(FaultInjector_InjectFaultIfSet, databaseName);
+	expect_any(FaultInjector_InjectFaultIfSet, tableName);
+	will_return(FaultInjector_InjectFaultIfSet, false);
+
 	mockLibpq(conn, motionListener, qePid);
 
 	cdbgang_setAsync(false);
@@ -184,6 +190,11 @@ static void test__createReaderGang(void **state)
 	will_return_count(getgpsegmentCount, segmentCount, -1);
 	will_return_count(getFtsVersion, ftsVersion, 1);
 
+	expect_any(FaultInjector_InjectFaultIfSet, identifier);
+	expect_any(FaultInjector_InjectFaultIfSet, ddlStatement);
+	expect_any(FaultInjector_InjectFaultIfSet, databaseName);
+	expect_any(FaultInjector_InjectFaultIfSet, tableName);
+	will_return(FaultInjector_InjectFaultIfSet, false);
 	mockLibpq(conn, motionListener, qePid);
 
 	cdbgang_setAsync(false);

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -327,6 +327,8 @@ FaultInjectorIdentifierEnumToString[] = {
 		/* inject fault to count buffers fsync'ed by checkpoint process */
 	_("finish_prepared_after_record_commit_prepared"),
 		/* inject fault in FinishPreparedTransaction() after recording the commit prepared record */
+	_("gang_created"),
+		/* inject fault to report ERROR just after creating Gang */
 	_("not recognized"),
 };
 

--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -12,6 +12,7 @@
 #include "cdb/cdbutil.h"
 #include "executor/execdesc.h"
 #include <pthread.h>
+#include "utils/faultinjector.h"
 
 struct Port;
 struct QueryDesc;
@@ -53,8 +54,8 @@ typedef struct Gang
 } Gang;
 
 extern int qe_gang_id;
-
 extern MemoryContext GangContext;
+extern Gang *gangInCreating;
 
 extern Gang *AllocateReaderGang(GangType type, char *portal_name);
 

--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -55,7 +55,7 @@ typedef struct Gang
 
 extern int qe_gang_id;
 extern MemoryContext GangContext;
-extern Gang *gangInCreating;
+extern Gang *CurrentGangCreating;
 
 extern Gang *AllocateReaderGang(GangType type, char *portal_name);
 

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -220,6 +220,9 @@ typedef enum FaultInjectorIdentifier_e {
 	BgBufferSyncDefaultLogic,
 
 	FinishPreparedAfterRecordCommitPrepared,
+
+	GangCreated,
+
 	/* INSERT has to be done before that line */
 	FaultInjectorIdMax,
 	

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -299,3 +299,14 @@ SELECT numActiveMotionConns();
 
 DROP FUNCTION numActiveMotionConns();
 DROP TABLE foo_test;
+
+--
+-- Test dangling Gang would be destroyed if interrupted during the creation
+--
+\c
+\! gpfaultinjector -q -f gang_created -y reset -s 1
+\! gpfaultinjector -q -f gang_created -y error -s 1
+select 1 from gp_dist_random('gp_id') limit 1;
+-- if previous gang is not destroyed, snapshot collision would happen
+select 1 from gp_dist_random('gp_id') limit 1;
+\! gpfaultinjector -q -f gang_created -y reset -s 1

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -397,3 +397,19 @@ SELECT numActiveMotionConns();
 
 DROP FUNCTION numActiveMotionConns();
 DROP TABLE foo_test;
+--
+-- Test dangling Gang would be destroyed if interrupted during the creation
+--
+\c
+\! gpfaultinjector -q -f gang_created -y reset -s 1
+\! gpfaultinjector -q -f gang_created -y error -s 1
+select 1 from gp_dist_random('gp_id') limit 1;
+ERROR:  fault triggered, fault name:'gang_created' fault type:'error'
+-- if previous gang is not destroyed, snapshot collision would happen
+select 1 from gp_dist_random('gp_id') limit 1;
+ ?column?
+----------
+        1
+(1 row)
+
+\! gpfaultinjector -q -f gang_created -y reset -s 1


### PR DESCRIPTION
If QD receives a `SIGINT` and calls `CHECK_FOR_INTERRUPTS` after finishing Gang creation, but before recording this Gang in global variables like `primaryWriterGang`, this Gang would not be destroyed, hence next time QD wants to create a new writer Gang, it would find existing writer Gang on segments, and report snapshot collision error.