### PR TITLE
DOCS: Adding security guide source

### DIFF
--- a/gpdb-doc/dita/security-guide/security-guide.ditamap
+++ b/gpdb-doc/dita/security-guide/security-guide.ditamap
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map>
+ <title>Security Configuration Guide</title>
+ <topicref href="topics/preface.xml" id="preface"/>
+ <topicref href="topics/SecuringGPDB.xml"/>
+ <topicref href="topics/ports_and_protocols.xml"/>
+ <topicref href="topics/Authenticate.xml"/>
+ <topicref href="topics/Authorization.xml"/>
+ <topicref href="topics/gpcc.xml" otherprops="pivotal"/>
+ <topicref href="topics/Auditing.xml"/>
+ <topicref href="topics/Encryption.xml"/>
+ <topicref href="topics/kerberos-hdfs.xml"/>
+ <topicref href="topics/BestPractices.xml"/>
+</map>

--- a/gpdb-doc/dita/security-guide/security-guide.ditaval
+++ b/gpdb-doc/dita/security-guide/security-guide.ditaval
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<val>
+	<prop att="otherprops" val="op-draft" action="exclude"/>
+	<prop att="otherprops" val="op-help" action="exclude"/>
+	<prop att="otherprops" val="op-hidden" action="exclude"/>
+	<prop att="otherprops" val="op-print" action="include"/>
+</val>

--- a/gpdb-doc/dita/security-guide/setup-pki.html.md.erb
+++ b/gpdb-doc/dita/security-guide/setup-pki.html.md.erb
@@ -1,0 +1,386 @@
+---
+title: Setting Up Secure Two-Way Authentication for Greenplum Command Center
+---
+
+<html class="list-style-none"></html>
+
+This topic helps you to set up Greenplum Command Center to authenticate users with digital certificates and to encrypt connections between users' web browsers and the Command Center web server.
+
+Greenplum Command Center is a browser-based application that, by default, uses basic authentication to allow connections. When the user browses to the Greenplum Command Center web server, the server prompts for a user name and password. The user enters their Greenplum Database role name and password and the server uses it to log in to the *gpperfmon* database. The password is md5-encoded, but the data transferred over the network is otherwise unencrypted.
+
+To encrypt data over the connection requires a secure, two-way authenticated connection between the user's browser and the Greenplum Command Center web server. The Command Center web server and users' browsers are configured with X.509 certificates. The client uses the server's certificate to verify they have connected to the correct server and the server uses the client's certificate to verify the user's identity and to look up the user's Greenplum Database role name. Once the certificates are installed in the server and users' browsers, connections are established automatically when users browse to the Command Center URL.
+
+Certificate-based authentication requires that both the server and client certificates are digitally signed by a trusted Certificate Authority (CA). Any web server accessible on the Internet should have a certificate signed by a well-known commercial CA, such as Symantec, to prevent man-in-the-middle attacks and other malicious attacks.
+
+If your users and servers are confined to an intranet, you can set up a public key infrastructure (PKI) that allows you to act as the CA for your organization, or even for just the Greenplum Command Center. You create a public/private key pair for your CA, use it to generate a certificate signing request (CSR), and then sign it with your own certificate, resulting in a *self-signed certificate*. This certificate can then be used to sign CSRs for the Command Center web server and for GPCC users. The CA public key must be installed into users' web browsers, along with their own signed user certificates.
+
+A user's certificate contains an attribute, Common Name (CN), which Command Center uses to look up the user's Greenplum Database role. The CN attribute is mapped to the database role in the *user\_cert\_mapping* table in the *gpperfmon* database. When the user connects to the Command Center web server, the Command Center web application logs in to the *gpperfmon* database with the `gpmon` role and looks up the CN in the *user\_cert\_mapping* table to find the user's Greenplum Database role.
+
+**Note:**  
+When SSL is enabled for a Greenplum Command Center installation, all web browsers connecting to Greenplum Command Center must be configured with a client SSL certificate. In a multi-cluster configuration, all hosts must have the same SSL configuration. SSL must be enabled or disabled for all hosts. For information about multi-cluster configuration, see [Enabling Multi-Cluster Support](setup-multi-cluster.html#topic_c1z_kbv_yp).
+
+These tasks enable certificate-based authentication and encryption of Command Center sessions:
+
+-   [Setting Up an OpenSSL PKI](#topic_fwy_k1n_jq)
+-   [Configuring the Command Center Web Server](#topic_blr_4zm_jq)
+-   [Creating a Client SSL Certificate](#topic_lhr_11n_jq)
+-   [Configuring the GPCC Database (gpperfmon)](#topic_yyd_fps_jq)
+-   [Configuring a Web Browser](#topic_bv3_lzm_jq)
+
+This process sets up a simple PKI using OpenSSL. The OpenSSL `openssl` command-line utility is included with GPCC and is added to your path when you source the `gpcc_path.env` file. See the OpenSSL documentation for information about OpenSSL and the commands that are used.
+
+## <a id="topic_fwy_k1n_jq"></a>Setting Up an OpenSSL PKI
+
+The instructions in this section set up an OpenSSL public key infrastructure (PKI) that enables you to generate and sign Greenplum Command Center user certificates.
+
+1.  Log in to the server where you installed Greenplum Command Center and source the Greenplum environment files.
+
+    ``` pre
+    $ source /usr/local/greenplum-db/greenplum_path.sh
+    $ source /usr/local/greenplum-cc-web/gpcc_path.sh
+    ```
+
+2.  Change to the `$GPPERFMONHOME/etc` directory, where the `openssl.cnf` is located.
+
+    ``` pre
+    $ cd $GPPERFMONHOME/etc
+    ```
+
+3.  *(Optional)* The `openssl.cnf` file contains default settings for a Certificate Authority named `demoCA`. You can edit the file, or a copy of the file, and change the settings to suit your own organization. Refer to the [OpenSSL documentation](https://www.openssl.org/docs/apps/config.html) for help. Note that the `[Default_CA]` section defines directory and file names that are used in the following steps. If you change them, be sure to use the new values in the following commands.
+4.  Create a directory named `demoCA` at the location where the `openssl.cnf` file is located.
+
+    ``` pre
+    $ mkdir demoCA
+    ```
+
+5.  Create the PKI directory structure in the `demoCA` directory.
+
+    ``` pre
+    $ mkdir demoCA/certs
+    $ mkdir demoCA/newcerts
+    $ mkdir demoCA/private
+    ```
+
+6.  Create `serial`, `crlnumber` and `index.txt` files in the `demoCA` directory.
+
+    ``` pre
+    $ echo "00" >> demoCA/serial
+    $ echo "00" >> demoCA/crlnumber
+    $ touch demoCA/index.txt
+    ```
+
+7.  Generate a private RSA key for the CA. This command generates an RSA 2048 bit private key for the CA:
+
+    ``` pre
+    $ openssl genrsa -out demoCA/cakey.key 2048
+    ```
+
+8. Use the generated private key to sign itself. You are prompted to enter the information about the CA you are establishing:  
+   - **Country Name:**The two-letter code for the country, with no punctuation.
+   - **State or Province:** Spell out the state name completely.
+   - **Locality or City:** The city or town name.
+   - **Company:** The name of the company. If the company or department has an &, @, or any other symbol using the shift key in its name, spell out the symbol or omit it.
+   - **Organizational Unit:** *(Optional)* Can be used to help identify certificates registered to an organization.
+   - **Common Name:** The name of this CA.
+   - **Email Address:** *(Optional)* The email address of the owner of this certificate.
+
+    The following example creates a new self-signed X.509 certificate that is valid for ten years for the keypair in the `certAut.key` file. This key will be used to sign certificates generated for the web server and client Command Center users.
+
+    ``` pre
+    $ openssl req -new -x509 -days 3650 -key demoCA/cakey.key -out demoCA/cacert.crt -config openssl.cnf
+    You are about to be asked to enter information that will be incorporated
+    into your certificate request.
+    What you are about to enter is what is called a Distinguished Name or a DN.
+    There are quite a few fields but you can leave some blank
+    For some fields there will be a default value,
+    If you enter '.', the field will be left blank.
+    -----
+    Country Name (2 letter code) [AU]:US
+    State or Province Name (full name) [Some-State]:California
+    Locality Name (eg, city) []:Palo Alto
+    Organization Name (eg, company) [Internet Widgits Pty Ltd]:Pivotal Software, Inc.
+    Organizational Unit Name (eg, section) []:
+    Common Name (e.g. server FQDN or YOUR name) []:GPCC CA
+    Email Address []:
+    ```
+
+9.  Move the CA key and certificate files into place in the `demoCA` directory. The names and locations of the files are specified in the `openssl.cnf` file.
+
+    ``` pre
+    $ mv demoCA/cakey.key demoCA/private/cakey.pem
+    $ mv demoCA/cacert.crt demoCA/cacert.pem
+    ```
+
+## <a id="topic_blr_4zm_jq"></a>Configuring the Command Center Web Server
+
+1. Generate a private key for the Command Center web server.
+
+   ``` pre
+   $ openssl genrsa -out demoCA/private/wskey.key 2048
+   ```
+
+2. Create a CSR for the web server's private key. You are prompted to enter information about the server where the certificate will be installed. Set the Common Name to the name of the host were the Command Center web server is running.
+   - **Country Name:**The two-letter code for the country, with no punctuation.
+   - **State or Province:** Spell out the state name completely.
+   - **Locality or City:** The city or town name.
+   - **Company:** The name of the company. If the company or department has an &, @, or any other symbol using the shift key in its name, spell out the symbol or omit it.
+   - **Organizational Unit:** *(Optional)* Can be used to help identify certificates registered to an organization.
+   - **Common Name:** The exact name of the web server.
+   - **Email Address:** *(Optional)* The email address of the owner of this certificate.
+
+    ``` pre
+    openssl req -new -key demoCA/private/wskey.key -out wskey.csr -config openssl.cnf
+    Enter pass phrase for demoCA/private/wskey.key:
+    You are about to be asked to enter information that will be incorporated
+    into your certificate request.
+    What you are about to enter is what is called a Distinguished Name or a DN.
+    There are quite a few fields but you can leave some blank
+    For some fields there will be a default value,
+    If you enter '.', the field will be left blank.
+    -----
+    Country Name (2 letter code) [AU]:US
+    State or Province Name (full name) [Some-State]:California
+    Locality Name (eg, city) []:Palo Alto
+    Organization Name (eg, company) [Internet Widgits Pty Ltd]:Pivotal Software, Inc.
+    Organizational Unit Name (eg, section) []:
+    Common Name (e.g. server FQDN or YOUR name) []:mdw.pivotal.lan
+    Email Address []:
+
+    Please enter the following 'extra' attributes
+    to be sent with your certificate request
+    A challenge password []:many_secret
+    An optional company name []:
+    ```
+
+3.  Sign the web server's private key using your CA certificate:
+
+    ``` pre
+    $ openssl ca -in wskey.csr -out demoCA/certs/wscert.crt -config openssl.cnf
+    Using configuration from openssl.cnf
+    Check that the request matches the signature
+    Signature ok
+    Certificate Details:
+            Serial Number: 0 (0x0)
+            Validity
+                Not Before: Jun  5 23:16:30 2015 GMT
+                Not After : Jun  4 23:16:30 2016 GMT
+            Subject:
+                countryName               = US
+                stateOrProvinceName       = California
+                organizationName          = Pivotal Software, Inc.
+                commonName                = mdw.pivotal.lan
+            X509v3 extensions:
+                X509v3 Basic Constraints: 
+                    CA:FALSE
+                Netscape Comment: 
+                    OpenSSL Generated Certificate
+                X509v3 Subject Key Identifier: 
+                    09:20:A4:74:43:12:72:24:C3:F3:14:34:7E:A8:3A:BD:42:CA:3B:0E
+                X509v3 Authority Key Identifier: 
+                    keyid:4D:4A:F1:FA:50:B8:EA:19:D4:1F:6F:18:34:E6:B8:CD:26:61:71:96
+
+    Certificate is to be certified until Jun  4 23:16:30 2016 GMT (365 days)
+    Sign the certificate? [y/n]:y
+
+
+    1 out of 1 certificate requests certified, commit? [y/n]y
+    Write out database with 1 new entries
+    Data Base Updated
+    ```
+
+4.  Create a PEM file containing the web server's private key and certificate. The web server requires this file.
+
+    ``` pre
+    $ cat demoCA/private/wskey.key demoCA/certs/wscert.crt > wscert.pem
+    ```
+
+5.  Edit the configuration file `app.conf` for the instance configured for Greenplum Command Center. The configuration file is located in `$GPPERFMONHOME/instances/instance/conf`, where *instance* is the value you specified when you created the instance.
+
+    Add the following parameters to enable SSL-based client authentication:
+
+    ``` pre
+    ssl.engine = "enable"
+    ssl.ca-file = "/usr/local/greenplum-cc-web/etc/demoCA/cacert.pem"
+    ssl.pemfile = "/usr/local/greenplum-cc-web/etc/wscert.pem"
+    ssl.verifyclient.activate = "enable"
+    ssl.verifyclient.enforce = "enable"
+    ssl.verifyclient.username = "SSL_CLIENT_S_DN_CN"
+    ```
+
+**Note:**  
+ For the `ssl.ca-file` and `ssl.pemfile` parameters, you must specify the fully qualified paths to the `cacert.pem` and `wscert.pem` files, respectively.
+
+Enter `gpcmdr --restart instance_name` to restart the web server after updating the configuration file.
+
+## <a id="topic_lhr_11n_jq"></a>Creating a Client SSL Certificate
+
+Follow these steps for each GPCC user to create a signed certificate to install in the user's web browsers.
+
+1.  Open a command line terminal and source the Greenplum environment files.
+
+    ``` pre
+    $ source /usr/local/greenplum-db/greenplum_path.sh 
+    $ source /usr/local/greenplum-cc-web/gpcc_path.sh
+    ```
+
+2.  Change to the `$GPPERFMONHOME/etc` directory. -pp
+
+    ``` pre
+    $ cd $GPPERFMONHOME/etc
+    ```
+
+3.  Generate a client private key by executing the following command. Replace *client* in this and following commands with a string such as the user's login name or database role name.
+
+    ``` pre
+    $ openssl genrsa -out demoCA/private/client.key 2048
+    ```
+
+4.  Generate a certificate signing request for the user's private key. The value you enter for the Common Name field must be unique for each user; it is used to map the user to their Greenplum Database role.
+
+    ``` pre
+    $ openssl req -new -key demoCA/private/client.key -out client.csr -config openssl.cnf
+    You are about to be asked to enter information that will be incorporated
+    into your certificate request.
+    What you are about to enter is what is called a Distinguished Name or a DN.
+    There are quite a few fields but you can leave some blank
+    For some fields there will be a default value,
+    If you enter '.', the field will be left blank.
+    -----
+    Country Name (2 letter code) [AU]:US
+    State or Province Name (full name) [Some-State]:California
+    Locality Name (eg, city) []:Palo Alto
+    Organization Name (eg, company) [Internet Widgits Pty Ltd]:Pivotal Software, Inc.
+    Organizational Unit Name (eg, section) []:
+    Common Name (e.g. server FQDN or YOUR name) []:gpcc_user_1
+    Email Address []:
+
+    Please enter the following 'extra' attributes
+    to be sent with your certificate request
+    A challenge password []:many_secret
+    An optional company name []:
+    ```
+
+5.  Sign the client certificate with the CA certificate:
+
+    ``` pre
+    $ openssl ca -in client.csr -out demoCA/certs/client.crt -config openssl.cnf -policy policy_anything
+    Using configuration from openssl.cnf
+    Check that the request matches the signature
+    Signature ok
+    Certificate Details:
+            Serial Number: 1 (0x1)
+            Validity
+                Not Before: Jun  5 23:46:39 2015 GMT
+                Not After : Jun  4 23:46:39 2016 GMT
+            Subject:
+                countryName               = US
+                stateOrProvinceName       = California
+                localityName              = Palo Alto
+                organizationName          = Pivotal Software, Inc.
+                commonName                = gpcc_user_1
+            X509v3 extensions:
+                X509v3 Basic Constraints: 
+                    CA:FALSE
+                Netscape Comment: 
+                    OpenSSL Generated Certificate
+                X509v3 Subject Key Identifier: 
+                    C9:1D:18:66:FB:0F:7E:FA:40:FB:EA:DF:94:B5:FD:3E:FC:FC:46:41
+                X509v3 Authority Key Identifier: 
+                    keyid:4D:4A:F1:FA:50:B8:EA:19:D4:1F:6F:18:34:E6:B8:CD:26:61:71:96
+
+    Certificate is to be certified until Jun  4 23:46:39 2016 GMT (365 days)
+    Sign the certificate? [y/n]:y
+
+
+    1 out of 1 certificate requests certified, commit? [y/n]y
+    Write out database with 1 new entries
+    Data Base Updated
+    ```
+
+    **Note:** The value for the `-days` option must be less than or equal to the value specified for the CA certificate.
+
+6.  Create a `.pem` file containing the client's private key and certificate.
+
+    ``` pre
+    $ cat demoCA/private/client.key demoCA/certs/client.crt > client.pem
+    ```
+
+7.  Convert the signed client certificate to PKCS\#12 format. The PKCS \#12 format is an archive file format for storing many cryptographic objects as a single file. It is commonly used to bundle a private key with its X.509 certificate.
+
+    ``` pre
+    $ openssl pkcs12 -export -in demoCA/certs/client.crt -inkey demoCA/private/client.key -certfile demoCA/cacert.pem -out client.p12 
+    Enter Export Password:
+    Verifying - Enter Export Password:
+    ```
+
+    **Important:** The export password is required when the client certificate is imported into a client web browser. See [Configuring a Web Browser](#topic_bv3_lzm_jq).
+
+8.  Send the `client.pem` file and the `client.p12` file to the GPCC user. Securely communicate the export password for the `.p12` file to the user.
+
+## <a id="topic_yyd_fps_jq"></a>Configuring the GPCC Database (gpperfmon)
+
+When the GPCC web server is configured to use SSL based client authentication, the GPCC web server queries the *user\_cert\_mapping* table in the *gpperfmon* database as part of the authentication process. The *user\_cert\_mapping* table maps the client certificate user ID (the common name in the client certificate) with the *gpperfmon* user role.
+
+You must create the *user\_cert\_mapping* table and populate it with the proper user information.
+
+1.  Create the *user\_cert\_mapping* table in the *gpperfmon* database.
+
+    ``` sql
+    =# psql gpperfmon
+    =# CREATE TABLE public.user_cert_mapping(mapping text primary key, username text);
+    ```
+
+2.  For each Greenplum Command Center user who accesses the *gpperfmon* database, a row must exist in the *user\_cert\_mapping* table. The *mapping* column contains the common name that you specified when creating the client certificate. The corresponding *username* column contains the *gpperfmon* user role.
+
+    The format of the common name in the *mapping* column is `'common_name, common_name'`. The common name listed twice, separated by a comma and space. For this example, the common name is `gpcc_user1`, and the *gpperfmon* user role is `perfmon_user1`:
+
+    ``` sql
+    =# INSERT INTO public.user_cert_mapping VALUES ('gpcc_user1, gpcc_user1', 'perfmon_user1');
+    ```
+
+## <a id="topic_bv3_lzm_jq"></a>Configuring a Web Browser
+
+When Greenplum Command Center is configured to use SSL, web browsers connecting to Greenplum Command Center must have a client certificate and CA certificate. You import the created client certificate and CA certificate to your browser so that it can forward the certificates to Greenplum Command Center when connecting to a Greenplum database from Greenplum Command Center.
+
+Follow these steps to import the certificates into Firefox and Chrome browsers, or into the Mac OS X Keychain Access utility.
+
+### Mozilla Firefox
+
+1.  From the menu, select **Preferences**.
+2.  Click **Advanced** and then click the **Certificates** tab.
+3.  Click **View Certificates**.
+4.  In the **Certificate Manager** dialog, open the **Authorities** tab, and click **Import**. Select your CA certificate (for example, `cacrt.crt`).
+    -   In the **Downloading Certificate** dialog, check **Trust this CA to identify websites.**
+
+5.  In the **Your Certificates** tab, click **Import** and select your client certificate (for example `client.p12`).
+
+    The import process prompts for a password for the client certificate. Enter the export password that you entered when you converted the client certificate to PKCS\#12. See [Creating a Client SSL Certificate](#topic_lhr_11n_jq).
+
+6.  Click **OK** to apply the configuration changes.
+
+### Google Chrome
+
+1.  From the customization menu, select **Settings** and then select **Show Advanced Settings**.
+2.  In the section **HTTPS/SSL**, click **Manage certificates...**.
+3.  In the **Manage Certificates** dialog, open the **Trusted Root Certification Authorities** tab . Click **Import** and select your CA certificate (for example, `certAut.crt`).
+4.  Open the **Personal** tab. Click **Import** and select the client certificate (for example, `client.p12`).
+
+    The import process prompts for a password the client certificate. Enter the export password that you entered when you converted the client certificate to PKCS\#12. See [Creating a Client SSL Certificate](#topic_lhr_11n_jq).
+
+5.  Click **Ok** to apply configuration changes.
+6.  Browse to the Greenplum Command Center URL, for example `https://mdw:28080`. A **User Identification Request** window will appear. Choose the client certificate you imported and click **OK**.
+
+### Mac OS X
+
+Mac OS X has a built-in certificate manager, Keychain Access. Google Chrome, Safari, and Mozilla Firefox use Keychain Access for certificate management. You will be asked to authenticate as an admin user on your Mac several times while following these steps.
+
+To begin, the user needs the `cacert.pem` CA certificate and the `.pem` file containing the user's private key and certificate.
+
+1.  Open **Keychain Access** (**Applications &gt; Utilities &gt; Keychain Access**.
+2.  Choose **File &gt;** **Import** , select the CA `.pem` file for the CA you setup (`cacert.pem`), and click **Open**.
+3.  On the dialog window that displays, click **Always Trust**.
+4.  Choose **File &gt; Import**, select the `.pem` file for the GPCC user you setup (`client.pem`), and click **Open**.
+5.  In a web browser, browse to the GPCC Command Center (`https://gpcc_host:28080`).
+6.  Choose the GPCC client certificate in the **Select a certificate** dialog and click **OK**.
+
+

--- a/gpdb-doc/dita/security-guide/topics/Auditing.xml
+++ b/gpdb-doc/dita/security-guide/topics/Auditing.xml
@@ -27,7 +27,7 @@
         Schema</i> appendix in the <i>Greenplum Database Reference Guide</i>.</p>
     <section>
       <title>Viewing the Database Server Log Files</title>
-      <p> Every database instance in Greenplum Database (master and segments) is a running a
+      <p> Every database instance in Greenplum Database (master and segments) is a running
         PostgreSQL database server with its own server log file. Daily log files are created in the
           <codeph>pg_log</codeph> directory of the master and each segment data directory. </p>
       <p> The server log files are written in comma-separated values (CSV) format. Not all log
@@ -59,7 +59,6 @@
             </row>
           </thead>
           <tbody>
-
             <row>
               <entry>
                 <p> 1 </p>
@@ -497,7 +496,7 @@
         last three lines of each segment log
         file:<codeblock>$ gpssh -f seg_host_file
   => source /usr/local/greenplum-db/greenplum_path.sh
-  => gplogfilter -n 3 /gpdata/gp*/pg_log/gpdb*.log</codeblock></p>
+  => gplogfilter -n 3 /gpdata/gp*/pg_log/gpdb*.csv</codeblock></p>
       <p> The following are the Greenplum security-related audit (or logging) server configuration
         parameters that are set in the postgresql.conf configuration file:</p>
       <table>
@@ -523,10 +522,9 @@
             </row>
           </thead>
           <tbody>
-
             <row>
               <entry>
-                <p> Log_connections </p>
+                <p> log_connections </p>
               </entry>
               <entry>
                 <p> Boolean </p>
@@ -543,7 +541,7 @@
             </row>
             <row>
               <entry>
-                <p> Log_disconnections </p>
+                <p> log_disconnections </p>
               </entry>
               <entry>
                 <p> Boolean </p>
@@ -558,7 +556,7 @@
             </row>
             <row>
               <entry>
-                <p> Log_statement </p>
+                <p> log_statement </p>
               </entry>
               <entry>
                 <p> NONE </p>
@@ -578,7 +576,7 @@
             </row>
             <row>
               <entry>
-                <p> Log_hostname </p>
+                <p> log_hostname </p>
               </entry>
               <entry>
                 <p> Boolean </p>
@@ -595,7 +593,7 @@
             </row>
             <row>
               <entry>
-                <p> Log_duration </p>
+                <p> log_duration </p>
               </entry>
               <entry>
                 <p> Boolean </p>
@@ -610,7 +608,7 @@
             </row>
             <row>
               <entry>
-                <p> Log_error_verbosity </p>
+                <p> log_error_verbosity </p>
               </entry>
               <entry>
                 <p> TERSE </p>
@@ -724,7 +722,6 @@
           </tbody>
         </tgroup>
       </table>
-
     </section>
   </body>
 </topic>

--- a/gpdb-doc/dita/security-guide/topics/Auditing.xml
+++ b/gpdb-doc/dita/security-guide/topics/Auditing.xml
@@ -1,0 +1,730 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="topic_ufw_zn2_jr">
+  <title>Auditing</title>
+  <body>
+    <p>Greenplum Database is capable of auditing a variety of events, including startup and shutdown
+      of the system, segment database failures, SQL statements that result in an error, and all
+      connection attempts and disconnections. Greenplum Database also logs SQL statements and
+      information regarding SQL statements, and can be configured in a variety of ways to record
+      audit information with more or less detail. The <codeph>log_error_verbosity</codeph>
+      configuration parameter controls the amount of detail written in the server log for each
+      message that is logged.  Similarly, the <codeph>log_min_error_statement</codeph> parameter
+      allows administrators to configure the level of detail recorded specifically for SQL
+      statements, and the <codeph>log_statement</codeph> parameter determines the kind of SQL
+      statements that are audited. Greenplum Database records the username for all auditable events,
+      when the event is initiated by a subject outside the Greenplum Database.</p>
+    <p>Greenplum Database prevents unauthorized modification and deletion of audit records by only
+      allowing administrators with an appropriate role to perform any operations on log files.  Logs
+      are stored in a proprietary format using comma-separated values (CSV).  Each segment and the
+      master stores its own log files, although these can be accessed remotely by an administrator. 
+      Greenplum Database also authorizes overwriting of old log files via the
+        <codeph>log_truncate_on_rotation</codeph> parameter.  This is a local parameter and must be
+      set on each segment and master configuration file.</p>
+    <p>Greenplum provides an administrative schema called <codeph>gp_toolkit</codeph> that you can
+      use to query log files, as well as system catalogs and operating enviroment for system status
+      information. For more information, including usage, refer to <i>The gp_tookit Administrative
+        Schema</i> appendix in the <i>Greenplum Database Reference Guide</i>.</p>
+    <section>
+      <title>Viewing the Database Server Log Files</title>
+      <p> Every database instance in Greenplum Database (master and segments) is a running a
+        PostgreSQL database server with its own server log file. Daily log files are created in the
+          <codeph>pg_log</codeph> directory of the master and each segment data directory. </p>
+      <p> The server log files are written in comma-separated values (CSV) format. Not all log
+        entries will have values for all of the log fields. For example, only log entries associated
+        with a query worker process will have the <codeph>slice_id</codeph> populated. Related log
+        entries of a particular query can be identified by its session identifier
+          (<codeph>gp_session_id</codeph>) and command identifier
+        (<codeph>gp_command_count</codeph>).</p>
+      <table>
+        <tgroup cols="0">
+          <colspec colwidth="10*" align="left"/>
+          <colspec colwidth="20*" align="left"/>
+          <colspec colwidth="20*" align="left"/>
+          <colspec colwidth="35*" align="left"/>
+          <thead>
+            <row>
+              <entry>
+                <p> # </p>
+              </entry>
+              <entry>
+                <p> Field Name </p>
+              </entry>
+              <entry>
+                <p> Data Type </p>
+              </entry>
+              <entry>
+                <p> Description </p>
+              </entry>
+            </row>
+          </thead>
+          <tbody>
+
+            <row>
+              <entry>
+                <p> 1 </p>
+              </entry>
+              <entry>
+                <p> event_time </p>
+              </entry>
+              <entry>
+                <p> timestamp with time zone </p>
+              </entry>
+              <entry>
+                <p> Time that the log entry was written to the log </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> 2 </p>
+              </entry>
+              <entry>
+                <p> user_name </p>
+              </entry>
+              <entry>
+                <p> varchar(100) </p>
+              </entry>
+              <entry>
+                <p> The database user name </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> 3 </p>
+              </entry>
+              <entry>
+                <p> database_name </p>
+              </entry>
+              <entry>
+                <p> varchar(100) </p>
+              </entry>
+              <entry>
+                <p> The database name </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> 4 </p>
+              </entry>
+              <entry>
+                <p> process_id </p>
+              </entry>
+              <entry>
+                <p> varchar(10) </p>
+              </entry>
+              <entry>
+                <p> The system process id (prefixed with &quot;p&quot;) </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> 5 </p>
+              </entry>
+              <entry>
+                <p> thread_id </p>
+              </entry>
+              <entry>
+                <p> varchar(50) </p>
+              </entry>
+              <entry>
+                <p> The thread count (prefixed with &quot;th&quot;) </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> 6 </p>
+              </entry>
+              <entry>
+                <p> remote_host </p>
+              </entry>
+              <entry>
+                <p> varchar(100) </p>
+              </entry>
+              <entry>
+                <p> On the master, the hostname/address of the client machine. On the segment, the
+                  hostname/address of the master. </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> 7 </p>
+              </entry>
+              <entry>
+                <p> remote_port </p>
+              </entry>
+              <entry>
+                <p> varchar(10) </p>
+              </entry>
+              <entry>
+                <p> The segment or master port number </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> 8 </p>
+              </entry>
+              <entry>
+                <p> session_start_time </p>
+              </entry>
+              <entry>
+                <p> timestamp with time zone </p>
+              </entry>
+              <entry>
+                <p> Time session connection was opened </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> 9 </p>
+              </entry>
+              <entry>
+                <p> transaction_id </p>
+              </entry>
+              <entry>
+                <p> int </p>
+              </entry>
+              <entry>
+                <p> Top-level transaction ID on the master. This ID is the parent of any
+                  subtransactions. </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> 10 </p>
+              </entry>
+              <entry>
+                <p> gp_session_id </p>
+              </entry>
+              <entry>
+                <p> text </p>
+              </entry>
+              <entry>
+                <p> Session identifier number (prefixed with &quot;con&quot;) </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> 11 </p>
+              </entry>
+              <entry>
+                <p> gp_command_count </p>
+              </entry>
+              <entry>
+                <p> text </p>
+              </entry>
+              <entry>
+                <p> The command number within a session (prefixed with &quot;cmd&quot;) </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> 12 </p>
+              </entry>
+              <entry>
+                <p> gp_segment </p>
+              </entry>
+              <entry>
+                <p> text </p>
+              </entry>
+              <entry>
+                <p> The segment content identifier (prefixed with &quot;seg&quot; for primaries or
+                  &quot;mir&quot; for mirrors). The master always has a content id of -1. </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> 13 </p>
+              </entry>
+              <entry>
+                <p> slice_id </p>
+              </entry>
+              <entry>
+                <p> text </p>
+              </entry>
+              <entry>
+                <p> The slice id (portion of the query plan being executed) </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> 14 </p>
+              </entry>
+              <entry>
+                <p> distr_tranx_id </p>
+              </entry>
+              <entry>
+                <p> text </p>
+              </entry>
+              <entry>
+                <p> Distributed transaction ID </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> 15 </p>
+              </entry>
+              <entry>
+                <p> local_tranx_id </p>
+              </entry>
+              <entry>
+                <p> text </p>
+              </entry>
+              <entry>
+                <p> Local transaction ID </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> 16 </p>
+              </entry>
+              <entry>
+                <p> sub_tranx_id </p>
+              </entry>
+              <entry>
+                <p> text </p>
+              </entry>
+              <entry>
+                <p> Subtransaction ID </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> 17 </p>
+              </entry>
+              <entry>
+                <p> event_severity </p>
+              </entry>
+              <entry>
+                <p> varchar(10) </p>
+              </entry>
+              <entry>
+                <p> Values include: LOG, ERROR, FATAL, PANIC, DEBUG1, DEBUG2 </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> 18 </p>
+              </entry>
+              <entry>
+                <p> sql_state_code </p>
+              </entry>
+              <entry>
+                <p> varchar(10) </p>
+              </entry>
+              <entry>
+                <p> SQL state code associated with the log message </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> 19 </p>
+              </entry>
+              <entry>
+                <p> event_message </p>
+              </entry>
+              <entry>
+                <p> text </p>
+              </entry>
+              <entry>
+                <p> Log or error message text </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> 20 </p>
+              </entry>
+              <entry>
+                <p> event_detail </p>
+              </entry>
+              <entry>
+                <p> text </p>
+              </entry>
+              <entry>
+                <p> Detail message text associated with an error or warning message </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> 21 </p>
+              </entry>
+              <entry>
+                <p> event_hint </p>
+              </entry>
+              <entry>
+                <p> text </p>
+              </entry>
+              <entry>
+                <p> Hint message text associated with an error or warning message </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> 22 </p>
+              </entry>
+              <entry>
+                <p> internal_query </p>
+              </entry>
+              <entry>
+                <p> text </p>
+              </entry>
+              <entry>
+                <p> The internally-generated query text </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> 23 </p>
+              </entry>
+              <entry>
+                <p> internal_query_pos </p>
+              </entry>
+              <entry>
+                <p> int </p>
+              </entry>
+              <entry>
+                <p> The cursor index into the internally-generated query text </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> 24 </p>
+              </entry>
+              <entry>
+                <p> event_context </p>
+              </entry>
+              <entry>
+                <p> text </p>
+              </entry>
+              <entry>
+                <p> The context in which this message gets generated </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> 25 </p>
+              </entry>
+              <entry>
+                <p> debug_query_string </p>
+              </entry>
+              <entry>
+                <p> text </p>
+              </entry>
+              <entry>
+                <p> User-supplied query string with full detail for debugging. This string can be
+                  modified for internal use. </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> 26 </p>
+              </entry>
+              <entry>
+                <p> error_cursor_pos </p>
+              </entry>
+              <entry>
+                <p> int </p>
+              </entry>
+              <entry>
+                <p> The cursor index into the query string </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> 27 </p>
+              </entry>
+              <entry>
+                <p> func_name </p>
+              </entry>
+              <entry>
+                <p> text </p>
+              </entry>
+              <entry>
+                <p> The function in which this message is generated </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> 28 </p>
+              </entry>
+              <entry>
+                <p> file_name </p>
+              </entry>
+              <entry>
+                <p> text </p>
+              </entry>
+              <entry>
+                <p> The internal code file where the message originated </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> 29 </p>
+              </entry>
+              <entry>
+                <p> file_line </p>
+              </entry>
+              <entry>
+                <p> int </p>
+              </entry>
+              <entry>
+                <p> The line of the code file where the message originated </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> 30 </p>
+              </entry>
+              <entry>
+                <p> stack_trace </p>
+              </entry>
+              <entry>
+                <p> text </p>
+              </entry>
+              <entry>
+                <p> Stack trace text associated with this message </p>
+              </entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+      <p>Greenplum provides a utility called <codeph>gplogfilter</codeph> that can be used to search
+        through a Greenplum Database log file for entries matching the specified criteria. By
+        default, this utility searches through the Greenplum master log file in the default logging
+        location. For example, to display the last three lines of the master log file:
+        <codeblock>$ gplogfilter -n 3</codeblock></p>
+      <p> You can also use <codeph>gplogfilter</codeph> to search through all segment log files at
+        once by running it through the <codeph>gpssh</codeph> utility. For example, to display the
+        last three lines of each segment log
+        file:<codeblock>$ gpssh -f seg_host_file
+  => source /usr/local/greenplum-db/greenplum_path.sh
+  => gplogfilter -n 3 /gpdata/gp*/pg_log/gpdb*.log</codeblock></p>
+      <p> The following are the Greenplum security-related audit (or logging) server configuration
+        parameters that are set in the postgresql.conf configuration file:</p>
+      <table>
+        <tgroup cols="0">
+          <colspec colwidth="15*" align="left"/>
+          <colspec colwidth="15*" align="left"/>
+          <colspec colwidth="10*" align="left"/>
+          <colspec colwidth="25*" align="left"/>
+          <thead>
+            <row>
+              <entry>
+                <p> Field Name </p>
+              </entry>
+              <entry>
+                <p> Value Range </p>
+              </entry>
+              <entry>
+                <p> Default </p>
+              </entry>
+              <entry>
+                <p> Description </p>
+              </entry>
+            </row>
+          </thead>
+          <tbody>
+
+            <row>
+              <entry>
+                <p> Log_connections </p>
+              </entry>
+              <entry>
+                <p> Boolean </p>
+              </entry>
+              <entry>
+                <p> off </p>
+              </entry>
+              <entry>
+                <p> This outputs a line to the server log detailing each successful connection. Some
+                  client programs, like psql, attempt to connect twice while determining if a
+                  password is required, so duplicate “connection received” messages do not always
+                  indicate a problem. </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> Log_disconnections </p>
+              </entry>
+              <entry>
+                <p> Boolean </p>
+              </entry>
+              <entry>
+                <p> off </p>
+              </entry>
+              <entry>
+                <p> This outputs a line in the server log at termination of a client session, and
+                  includes the duration of the session. </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> Log_statement </p>
+              </entry>
+              <entry>
+                <p> NONE </p>
+                <p> DDL </p>
+                <p> MOD </p>
+                <p> ALL </p>
+              </entry>
+              <entry>
+                <p> ALL </p>
+              </entry>
+              <entry>
+                <p> Controls which SQL statements are logged. DDL logs all data definition commands
+                  like CREATE, ALTER, and DROP commands. MOD logs all DDL statements, plus INSERT,
+                  UPDATE, DELETE, TRUNCATE, and COPY FROM. PREPARE and EXPLAIN ANALYZE statements
+                  are also logged if their contained command is of an appropriate type. </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> Log_hostname </p>
+              </entry>
+              <entry>
+                <p> Boolean </p>
+              </entry>
+              <entry>
+                <p> off </p>
+              </entry>
+              <entry>
+                <p> By default, connection log messages only show the IP address of the connecting
+                  host. Turning on this option causes logging of the host name as well. Note that
+                  depending on your host name resolution setup this might impose a non-negligible
+                  performance penalty. </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> Log_duration </p>
+              </entry>
+              <entry>
+                <p> Boolean </p>
+              </entry>
+              <entry>
+                <p> off </p>
+              </entry>
+              <entry>
+                <p> Causes the duration of every completed statement which satisfies log_statement
+                  to be logged. </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> Log_error_verbosity </p>
+              </entry>
+              <entry>
+                <p> TERSE </p>
+                <p> DEFAULT </p>
+                <p> VERBOSE </p>
+              </entry>
+              <entry>
+                <p> DEFAULT </p>
+              </entry>
+              <entry>
+                <p> Controls the amount of detail written in the server log for each message that is
+                  logged. </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> log_min_duration_statement </p>
+              </entry>
+              <entry>
+                <p> number of milliseconds, 0, -1 </p>
+              </entry>
+              <entry>
+                <p> -1 </p>
+              </entry>
+              <entry>
+                <p> Logs the statement and its duration on a single log line if its duration is
+                  greater than or equal to the specified number of milliseconds. Setting this to 0
+                  will print all statements and their durations. -1 disables the feature. For
+                  example, if you set it to 250 then all SQL statements that run 250ms or longer
+                  will be logged. Enabling this option can be useful in tracking down unoptimized
+                  queries in your applications. </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> log_min_messages </p>
+              </entry>
+              <entry>
+                <p> DEBUG5 </p>
+                <p> DEBUG4 </p>
+                <p> DEBUG3 </p>
+                <p> DEBUG2 </p>
+                <p> DEBUG1 </p>
+                <p> INFO </p>
+                <p> NOTICE </p>
+                <p> WARNING </p>
+                <p> ERROR </p>
+                <p> LOG </p>
+                <p> FATAL </p>
+                <p> PANIC </p>
+              </entry>
+              <entry>
+                <p> NOTICE </p>
+              </entry>
+              <entry>
+                <p> Controls which message levels are written to the server log. Each level includes
+                  all the levels that follow it. The later the level, the fewer messages are sent to
+                  the log. </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> log_rotation_age </p>
+              </entry>
+              <entry>
+                <p> Any valid time expression (number and unit) </p>
+              </entry>
+              <entry>
+                <p> 1d </p>
+              </entry>
+              <entry>
+                <p> Determines the maximum lifetime of an individual log file. After this time has
+                  elapsed, a new log file will be created. Set to zero to disable time-based
+                  creation of new log files. </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> log_statement_stats </p>
+              </entry>
+              <entry>
+                <p> Boolean </p>
+              </entry>
+              <entry>
+                <p> off </p>
+              </entry>
+              <entry>
+                <p> For each query, write total performance statistics of the query parser, planner,
+                  and executor to the server log. This is a crude profiling instrument. </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <p> log_truncate_on_rotation </p>
+              </entry>
+              <entry>
+                <p> Boolean </p>
+              </entry>
+              <entry>
+                <p> off </p>
+              </entry>
+              <entry>
+                <p> Truncates (overwrites), rather than appends to, any existing log file of the
+                  same name. Truncation will occur only when a new file is being opened due to
+                  time-based rotation. For example, using this setting in combination with a
+                  log_filename such as gpseg#-%H.log would result in generating twenty-four hourly
+                  log files and then cyclically overwriting them. When off, pre-existing files will
+                  be appended to in all cases. </p>
+              </entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+
+    </section>
+  </body>
+</topic>

--- a/gpdb-doc/dita/security-guide/topics/Authenticate.xml
+++ b/gpdb-doc/dita/security-guide/topics/Authenticate.xml
@@ -193,16 +193,16 @@ host    all   dba   192.168.0.0/32  md5
             </plentry>
           </parml></p>
         <p>Following are some sample <codeph>pg_hba.conf</codeph> basic authentication
-          entries:<codeblock>Hostnossl    all   all        0.0.0.0   reject
+          entries:<codeblock>hostnossl    all   all        0.0.0.0   reject
 hostssl      all   testuser   0.0.0.0/0 md5
-Local        all   gpuser               ident
+local        all   gpuser               ident
 </codeblock></p>
       </section>
       <section id="kerberos_auth">
         <title>Kerberos Authentication</title>
         <p>You can authenticate against a Kerberos server (RFC 2743, 1964).</p>
         <p>The format for Kerberos authentication in the <codeph>pg_hba.conf</codeph> file
-          is:<codeblock>Servicename/hostname@realm</codeblock></p>
+          is:<codeblock>servicename/hostname@realm</codeblock></p>
         <p>The following options may be added to the entry:<parml>
             <plentry>
               <pt>Map</pt>
@@ -224,7 +224,7 @@ Local        all   gpuser               ident
           </parml></p>
         <p>Following is an example <codeph>pg_hba.conf</codeph> entry for
           Kerberos:<codeblock>host    all all 0.0.0.0/0   krb5
-Hostssl all all 0.0.0.0/0   krb5 map=krbmap
+hostssl all all 0.0.0.0/0   krb5 map=krbmap
 </codeblock></p>
         <p>The following Kerberos server settings are specified in <codeph>postgresql.conf</codeph>: <parml>
             <plentry>
@@ -280,27 +280,27 @@ Hostssl all all 0.0.0.0/0   krb5 map=krbmap
           </ol></p>
         <p>Specify the following parameter <codeph>auth-options</codeph>. <parml>
             <plentry>
-              <pt>Ldapserver</pt>
+              <pt>ldapserver</pt>
               <pd>Names or IP addresses of LDAP servers to connect to. Multiple servers may be
                 specified, separated by spaces.</pd>
             </plentry>
             <plentry>
-              <pt>Ldapprefix</pt>
+              <pt>ldapprefix</pt>
               <pd>String to prepend to the user name when forming the DN to bind as, when doing
                 simple bind authentication.</pd>
             </plentry>
             <plentry>
-              <pt>Ldapsuffix</pt>
+              <pt>ldapsuffix</pt>
               <pd>String to append to the user name when forming the DN to bind as, when doing
                 simple bind authentication.</pd>
             </plentry>
             <plentry>
-              <pt>Ldapport</pt>
+              <pt>ldapport</pt>
               <pd>Port number on LDAP server to connect to. If no port is specified, the LDAP
                 library's default port setting will be used.</pd>
             </plentry>
             <plentry>
-              <pt>Ldaptls</pt>
+              <pt>ldaptls</pt>
               <pd>Set to 1 to make the connection between PostgreSQL and the LDAP server use TLS
                 encryption. Note that this only encrypts the traffic to the LDAP server — the
                 connection to the client will still be unencrypted unless SSL is used.</pd>
@@ -423,7 +423,7 @@ Hostssl testdb all 192.168.0.0/16 cert map=gpuser
       <p>SSL options:<parml>
           <plentry>
             <pt>
-              <codeph>Require</codeph>
+              <codeph>require</codeph>
             </pt>
             <pd>Only use SSL connection. If a root CA file is present, verify the certificate in the
               same way as if <codeph>verify-ca</codeph> was specified.</pd>
@@ -443,33 +443,33 @@ Hostssl testdb all 192.168.0.0/16 cert map=gpuser
               trusted CA and that the server host name matches that in the certificate.</pd>
           </plentry>
           <plentry>
-            <pt>Sslcert</pt>
+            <pt>sslcert</pt>
             <pd>The file name of the client SSL certificate. The default is
                 <codeph>~/.postgresql/postgresql.crt</codeph>. </pd>
           </plentry>
           <plentry>
-            <pt>Sslkey</pt>
+            <pt>sslkey</pt>
             <pd>The secret key used for the client certificate. The default is
                 <codeph>~/.postgresql/postgresql.key</codeph>.</pd>
           </plentry>
           <plentry>
-            <pt>Sslrootcert</pt>
+            <pt>sslrootcert</pt>
             <pd>The name of a file containing SSL Certificate Authority certificate(s). The default
               is <codeph>~/.postgresql/root.crt</codeph>.</pd>
           </plentry>
           <plentry>
-            <pt>Sslcrl</pt>
+            <pt>sslcrl</pt>
             <pd>The name of the SSL certificate revocation list. The default is
                 <codeph>~/.postgresql/root.crl</codeph>.</pd>
           </plentry>
         </parml></p>
       <p>The client connection parameters can be set using the following environment variables:<ul
           id="ul_yph_5g2_jr">
-          <li><codeph>Sslmode</codeph> – <codeph>PGSSLMODE</codeph></li>
-          <li><codeph>Sslkey</codeph> – <codeph>PGSSLKEY</codeph></li>
-          <li><codeph>Sslrootcert</codeph> – <codeph>PGSSLROOTCERT</codeph></li>
-          <li><codeph>Sslcert</codeph> – <codeph>PGSSLCERT</codeph></li>
-          <li><codeph>Sslcrl</codeph> – <codeph>PGSSLCRL</codeph> </li>
+          <li><codeph>sslmode</codeph> – <codeph>PGSSLMODE</codeph></li>
+          <li><codeph>sslkey</codeph> – <codeph>PGSSLKEY</codeph></li>
+          <li><codeph>sslrootcert</codeph> – <codeph>PGSSLROOTCERT</codeph></li>
+          <li><codeph>sslcert</codeph> – <codeph>PGSSLCERT</codeph></li>
+          <li><codeph>sslcrl</codeph> – <codeph>PGSSLCRL</codeph> </li>
         </ul></p>
     </body>
   </topic>
@@ -515,25 +515,25 @@ Hostssl testdb all 192.168.0.0/16 cert map=gpuser
         <title>RADIUS Authentication Options</title>
         <parml>
           <plentry>
-            <pt>Radiusserver</pt>
-            <pd>The ame of the RADIUS server.</pd>
+            <pt>radiusserver</pt>
+            <pd>The name of the RADIUS server.</pd>
           </plentry>
           <plentry>
-            <pt>Radiussecret</pt>
+            <pt>radiussecret</pt>
             <pd>The RADIUS shared secret.</pd>
           </plentry>
           <plentry>
-            <pt>Radiusport</pt>
+            <pt>radiusport</pt>
             <pd>The port to connect to on the RADIUS server.</pd>
           </plentry>
           <plentry>
-            <pt>Radiusidentifier</pt>
+            <pt>radiusidentifier</pt>
             <pd>NAS identifier in RADIUS requests.</pd>
           </plentry>
         </parml>
       </section>
       <p>Following are sample <codeph>pg_hba.conf</codeph> entries for RADIUS client
-        authentication:<codeblock>ostssl  all all 0.0.0.0/0 radius radiusserver=servername radiussecret=<varname>sharedsecret</varname></codeblock></p>
+        authentication:<codeblock>hostssl  all all 0.0.0.0/0 radius radiusserver=servername radiussecret=<varname>sharedsecret</varname></codeblock></p>
     </body>
   </topic>
   <topic id="topic_hwn_bk2_jr">

--- a/gpdb-doc/dita/security-guide/topics/Authenticate.xml
+++ b/gpdb-doc/dita/security-guide/topics/Authenticate.xml
@@ -1,0 +1,607 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="topic_n5w_gtd_jr">
+  <title>Configuring Client Authentication</title>
+  <body>
+    <p>When a Greenplum Database system is first initialized, the system contains one predefined
+      superuser role. This role will have the same name as the operating system user who initialized
+      the Greenplum Database system. This role is referred to as gpadmin. By default, the system is
+      configured to only allow local connections to the database from the gpadmin role. If you want
+      to allow any other roles to connect, or if you want to allow connections from remote hosts,
+      you have to configure Greenplum Database to allow such connections. This section explains how
+      to configure client connections and authentication to Greenplum Database.<ul
+        id="ul_kpg_sgq_kr">
+        <li><xref href="#topic_ln1_ptd_jr" format="dita"/></li>
+        <li><xref href="#topic_xwr_rvd_jr" format="dita"/></li>
+        <li><xref href="#topic_nyh_gwd_jr" format="dita"/></li>
+        <li><xref href="#topic_hwn_bk2_jr" format="dita"/></li>
+        <li><xref href="#topic_ibc_nl2_jr" format="dita"/></li>
+      </ul></p>
+  </body>
+  <topic id="topic_ln1_ptd_jr">
+    <title>Allowing Connections to Greenplum Database</title>
+    <body>
+      <p>Client access and authentication is controlled by a configuration file named
+          <codeph>pg_hba.conf</codeph> (the standard PostgreSQL host-based authentication file). For
+        detailed information about this file, see <xref
+          href="http://www.postgresql.org/docs/9.0/interactive/auth-pg-hba-conf.html" format="html"
+          scope="external">The pg_hba.conf File</xref> in the PostgreSQL documentation. </p>
+      <p>In Greenplum Database, the <codeph>pg_hba.conf</codeph> file of the master instance
+        controls client access and authentication to your Greenplum system. The segments also have
+          <codeph>pg_hba.conf</codeph> files, but these are already correctly configured to only
+        allow client connections from the master host. The segments never accept outside client
+        connections, so there is no need to alter the <codeph>pg_hba.conf</codeph> file on segments. </p>
+      <p>The general format of the <codeph>pg_hba.conf</codeph> file is a set of records, one per
+        line. Blank lines are ignored, as is any text after a # comment character. A record is made
+        up of a number of fields which are separated by spaces and/or tabs. Fields can contain white
+        space if the field value is quoted. Records cannot be continued across lines. Each remote
+        client access record is in this format:
+        <codeblock>host   database   role   CIDR-address   authentication-method
+</codeblock></p>
+      <p>Each UNIX-domain socket access record is in this format:
+        <codeblock>local   database   role   authentication-method
+</codeblock></p>
+      <p>The meaning of the <codeph>pg_hba_conf</codeph> fields is as follows: <parml>
+          <plentry>
+            <pt>local</pt>
+            <pd> Matches connection attempts using UNIX-domain sockets. Without a record of this
+              type, UNIX-domain socket connections are disallowed. </pd>
+          </plentry>
+          <plentry>
+            <pt>host</pt>
+            <pd> Matches connection attempts made using TCP/IP. Remote TCP/IP connections will not
+              be possible unless the server is started with an appropriate value for the
+              listen_addresses server configuration parameter. </pd>
+          </plentry>
+          <plentry>
+            <pt>hostssl</pt>
+            <pd> Matches connection attempts made using TCP/IP, but only when the connection is made
+              with SSL encryption. SSL must be enabled at server start time by setting the
+                <codeph>ssl</codeph> configuration parameter. Requires SSL authentication be
+              configured in <codeph>postgresql.conf</codeph>. See <xref
+                href="#topic_fzv_wb2_jr/ssl_postgresql" format="dita"/>. </pd>
+          </plentry>
+          <plentry>
+            <pt>hostnossl</pt>
+            <pd> Matches connection attempts made over TCP/IP that do not use SSL. Requires SSL
+              authentication be configured in <codeph>postgresql.conf</codeph>. See <xref
+                href="#topic_fzv_wb2_jr/ssl_postgresql" format="dita"/>.</pd>
+          </plentry>
+          <plentry>
+            <pt>database</pt>
+            <pd>Specifies which database names this record matches. The value <codeph>all</codeph>
+              specifies that it matches all databases. Multiple database names can be supplied by
+              separating them with commas. A separate file containing database names can be
+              specified by preceding the file name with <codeph>@</codeph>. </pd>
+          </plentry>
+          <plentry>
+            <pt> role </pt>
+            <pd>Specifies which database role names this record matches. The value all specifies
+              that it matches all roles. If the specified role is a group and you want all members
+              of that group to be included, precede the role name with a +. Multiple role names can
+              be supplied by separating them with commas. A separate file containing role names can
+              be specified by preceding the file name with @. </pd>
+          </plentry>
+          <plentry>
+            <pt> CIDR-address </pt>
+            <pd> Specifies the client machine IP address range that this record matches. It contains
+              an IP address in standard dotted decimal notation and a CIDR mask length. IP addresses
+              can only be specified numerically, not as domain or host names. The mask length
+              indicates the number of high-order bits of the client IP address that must match. Bits
+              to the right of this must be zero in the given IP address. There must not be any white
+              space between the IP address, the /, and the CIDR mask length. <p>Typical examples of
+                a CIDR-address are 172.20.143.89/32 for a single host, or 172.20.143.0/24 for a
+                small network, or 10.6.0.0/16 for a larger one. To specify a single host, use a CIDR
+                mask of 32 for IPv4 or 128 for IPv6. In a network address, do not omit trailing
+                zeroes.</p>
+            </pd>
+          </plentry>
+          <plentry>
+            <pt>IP-address</pt>
+            <pt>IP-mask </pt>
+            <pd> These fields can be used as an alternative to the CIDR-address notation. Instead of
+              specifying the mask length, the actual mask is specified in a separate column. For
+              example, 255.0.0.0 represents an IPv4 CIDR mask length of 8, and 255.255.255.255
+              represents a CIDR mask length of 32. These fields only apply to host, hostssl, and
+              hostnossl records. </pd>
+          </plentry>
+          <plentry>
+            <pt> authentication-method </pt>
+            <pd> Specifies the authentication method to use when connecting. See <xref
+                href="#topic_nyh_gwd_jr" format="dita"/> for more details. </pd>
+          </plentry>
+        </parml></p>
+    </body>
+  </topic>
+  <topic id="topic_xwr_rvd_jr">
+    <title>Editing the pg_hba.conf File</title>
+    <body>
+      <p>This example shows how to edit the <codeph>pg_hba.conf</codeph> file of the master to allow
+        remote client access to all databases from all roles using encrypted password
+        authentication. </p>
+      <note>For a more secure system, consider removing all connections that use trust
+        authentication from your master <codeph>pg_hba.conf</codeph>. Trust authentication means the
+        role is granted access without any authentication, therefore bypassing all security. Replace
+        trust entries with ident authentication if your system has an ident service available. </note>
+      <p>To edit <codeph>pg_hba.conf</codeph>:<ol id="ol_krz_zvd_jr">
+          <li>Open the file <codeph>$MASTER_DATA_DIRECTORY/pg_hba.conf</codeph> in a text
+            editor.</li>
+          <li>Add a line to the file for each type of connection you want to allow. Records are read
+            sequentially, so the order of the records is significant. Typically, earlier records
+            will have tight connection match parameters and weaker authentication methods, while
+            later records will have looser match parameters and stronger authentication methods. For
+            example:<codeblock># allow the gpadmin user local access to all databases
+# using ident authentication
+local   all   gpadmin   ident         sameuser
+host    all   gpadmin   127.0.0.1/32  ident
+host    all   gpadmin   ::1/128       ident
+# allow the 'dba' role access to any database from any
+# host with IP address 192.168.x.x and use md5 encrypted
+# passwords to authenticate the user
+# Note that to use SHA-256 encryption, replace md5 with
+# password in the line below
+host    all   dba   192.168.0.0/32  md5
+</codeblock></li>
+        </ol></p>
+    </body>
+  </topic>
+  <topic id="topic_nyh_gwd_jr">
+    <title>Authentication Methods</title>
+    <body>
+      <ul id="ul_qgp_1jq_kr">
+        <li>
+          <xref href="#topic_nyh_gwd_jr/basic_auth" format="dita"/>
+        </li>
+        <li>
+          <xref href="#topic_nyh_gwd_jr/kerberos_auth" format="dita"/>
+        </li>
+        <li>
+          <xref href="#topic_nyh_gwd_jr/ldap_auth" format="dita"/>
+        </li>
+        <li>
+          <xref href="#topic_fzv_wb2_jr" format="dita"/>
+        </li>
+        <li>
+          <xref href="#topic_yxp_5h2_jr" format="dita"/>
+        </li>
+        <li>
+          <xref href="#topic_ed4_d32_jr" format="dita"/>
+        </li>
+      </ul>
+      <section id="basic_auth">
+        <title>Basic Authentication</title>
+        <p>The following basic authentication methods are supported: <parml id="ul_zsk_kwd_jr">
+            <plentry>
+              <pt>Password or MD5</pt>
+              <pd>Requires clients to provide a password, one of either: <ul id="ul_m21_nwd_jr">
+                  <li>Md5 &#8211; password transmitted as an MD5 hash.</li>
+                  <li>Password &#8211; A password transmitted in clear text. Always use SSL
+                    connections to prevent password sniffing during transit. This is configurable,
+                    see "Encrypting Passwords" in the <i>Greenplum Database Administrator Guide</i>
+                    for more information.</li>
+                </ul></pd>
+            </plentry>
+            <plentry>
+              <pt>Reject</pt>
+              <pd>Reject the connections with the matching parameters. You should typically use this
+                to restrict access from specific hosts or insecure connections.</pd>
+            </plentry>
+            <plentry>
+              <pt>Ident</pt>
+              <pd>Authenticates based on the client's operating system user name. You should only
+                use this for local connections.</pd>
+            </plentry>
+          </parml></p>
+        <p>Following are some sample <codeph>pg_hba.conf</codeph> basic authentication
+          entries:<codeblock>Hostnossl    all   all        0.0.0.0   reject
+hostssl      all   testuser   0.0.0.0/0 md5
+Local        all   gpuser               ident
+</codeblock></p>
+      </section>
+      <section id="kerberos_auth">
+        <title>Kerberos Authentication</title>
+        <p>You can authenticate against a Kerberos server (RFC 2743, 1964).</p>
+        <p>The format for Kerberos authentication in the <codeph>pg_hba.conf</codeph> file
+          is:<codeblock>Servicename/hostname@realm</codeblock></p>
+        <p>The following options may be added to the entry:<parml>
+            <plentry>
+              <pt>Map</pt>
+              <pd>Map system and database users.</pd>
+            </plentry>
+            <plentry>
+              <pt>Include_realm</pt>
+              <pd>Option to specify realm name included in the system-user name in the ident map
+                file.</pd>
+            </plentry>
+            <plentry>
+              <pt>Krb_realm</pt>
+              <pd>Specify the realm name for matching the principals.</pd>
+            </plentry>
+            <plentry>
+              <pt>Krb_server_hostname</pt>
+              <pd>The hostname of the service principal.</pd>
+            </plentry>
+          </parml></p>
+        <p>Following is an example <codeph>pg_hba.conf</codeph> entry for
+          Kerberos:<codeblock>host    all all 0.0.0.0/0   krb5
+Hostssl all all 0.0.0.0/0   krb5 map=krbmap
+</codeblock></p>
+        <p>The following Kerberos server settings are specified in <codeph>postgresql.conf</codeph>: <parml>
+            <plentry>
+              <pt><codeph>krb_server_key <i>file</i></codeph></pt>
+              <pd>Sets the location of the Kerberos server key file.</pd>
+            </plentry>
+            <plentry>
+              <pt>
+                <codeph>krb_srvname <i>string</i></codeph></pt>
+              <pd>Kerberos service name.</pd>
+            </plentry>
+            <plentry>
+              <pt><codeph>krb_caseins_users <i>boolean</i></codeph></pt>
+              <pd>Case-sensitivity. The default is off. </pd>
+            </plentry>
+          </parml></p>
+        <p>The following client setting is specified as a connection parameter: <parml>
+            <plentry>
+              <pt>
+                <codeph>Krbsrvname</codeph></pt>
+              <pd>The Kerberos service name to use for authentication.</pd>
+            </plentry>
+          </parml>
+        </p>
+      </section>
+      <section id="ldap_auth">
+        <title>LDAP Authentication</title>
+        <p>You can authenticate against an LDAP directory.</p>
+        <ul>
+          <li>LDAPS and LDAP over TLS options encrypt the connection to the LDAP server.</li>
+          <li>The connection from the client to the server is not encrypted unless SSL is enabled.
+            Configure client connections to use SSL to encrypt connections from the client.</li>
+          <li>To configure or customize LDAP settings, set the <codeph>LDAPCONF</codeph> environment
+            variable with the path to the <codeph>ldap.conf</codeph> file and add this to the
+              <codeph>greenplum_path.sh</codeph> script.</li>
+        </ul>
+        <p>Following are the recommended steps for configuring your system for LDAP authentication: <ol>
+            <li> Set up the LDAP server with the database users/roles to be authenticated via
+              LDAP.</li>
+            <li>On the database:<ol>
+                <li>Verify that the database users to be authenticated via LDAP exist on the
+                  database. LDAP is only used for verifying username/password pairs, so the roles
+                  should exist in the database.</li>
+                <li>Update the <codeph>pg_hba.conf</codeph> file in the
+                    <codeph>$MASTER_DATA_DIRECTORY</codeph> to use LDAP as the authentication method
+                  for the respective users. Note that the first entry to match the user/role in the
+                    <codeph>pg_hba.conf</codeph> file will be used as the authentication mechanism,
+                  so the position of the entry in the file is important.</li>
+                <li>Reload the server for the <codeph>pg_hba.conf</codeph> configuration settings to
+                  take effect (<codeph>gpstop -u</codeph>).</li>
+              </ol>
+            </li>
+          </ol></p>
+        <p>Specify the following parameter <codeph>auth-options</codeph>. <parml>
+            <plentry>
+              <pt>Ldapserver</pt>
+              <pd>Names or IP addresses of LDAP servers to connect to. Multiple servers may be
+                specified, separated by spaces.</pd>
+            </plentry>
+            <plentry>
+              <pt>Ldapprefix</pt>
+              <pd>String to prepend to the user name when forming the DN to bind as, when doing
+                simple bind authentication.</pd>
+            </plentry>
+            <plentry>
+              <pt>Ldapsuffix</pt>
+              <pd>String to append to the user name when forming the DN to bind as, when doing
+                simple bind authentication.</pd>
+            </plentry>
+            <plentry>
+              <pt>Ldapport</pt>
+              <pd>Port number on LDAP server to connect to. If no port is specified, the LDAP
+                library's default port setting will be used.</pd>
+            </plentry>
+            <plentry>
+              <pt>Ldaptls</pt>
+              <pd>Set to 1 to make the connection between PostgreSQL and the LDAP server use TLS
+                encryption. Note that this only encrypts the traffic to the LDAP server — the
+                connection to the client will still be unencrypted unless SSL is used.</pd>
+            </plentry>
+            <plentry>
+              <pt>ldapbasedn</pt>
+              <pd>Root DN to begin the search for the user in, when doing search+bind
+                authentication.</pd>
+            </plentry>
+            <plentry>
+              <pt>ldapbinddn</pt>
+              <pd>DN of user to bind to the directory with to perform the search when doing
+                search+bind authentication.</pd>
+            </plentry>
+            <plentry>
+              <pt>ldapbindpasswd</pt>
+              <pd>Password for user to bind to the directory with to perform the search when doing
+                search+bind authentication.</pd>
+            </plentry>
+            <plentry>
+              <pt>ldapsearchattribute</pt>
+              <pd>Attribute to match against the user name in the search when doing search+bind
+                authentication.</pd>
+            </plentry>
+          </parml>
+        </p>
+        <p>Example:
+          <codeblock>ldapserver=ldap.greenplum.com prefix="cn=" suffix=", dc=greenplum, dc=com"</codeblock></p>
+        <p>Following are sample <codeph>pg_hba.conf</codeph> file entries for LDAP authentication:
+          <codeblock>host all testuser 0.0.0.0/0 ldap ldap
+ldapserver=ldapserver.greenplum.com ldapport=389 ldapprefix="cn=" ldapsuffix=",ou=people,dc=greenplum,dc=com"
+hostssl   all   ldaprole   0.0.0.0/0   ldap
+ldapserver=ldapserver.greenplum.com ldaptls=1 ldapprefix="cn=" ldapsuffix=",ou=people,dc=greenplum,dc=com"          
+        </codeblock></p>
+      </section>
+    </body>
+  </topic>
+  <topic id="topic_fzv_wb2_jr">
+    <title>SSL Client Authentication</title>
+    <body>
+      <p>SSL authentication compares the Common Name (cn) attribute of an SSL certificate provided
+        by the connecting client during the SSL handshake to the requested database user name. The
+        database user should exist in the database. A map file can be used for mapping between
+        system and database user names. </p>
+      <section>
+        <title>SSL Authentication Parameters</title>
+        <p>Authentication method:<ul id="ul_fr4_fc2_jr">
+            <li>Cert<p>Authentication options:<parml>
+                  <plentry>
+                    <pt>Hostssl</pt>
+                    <pd>Connection type must be hostssl.</pd>
+                  </plentry>
+                  <plentry>
+                    <pt>map=<varname>mapping</varname></pt>
+                    <pd>mapping. </pd>
+                    <pd>This is specified in the <codeph>pg_ident.conf</codeph>, or in the file
+                      specified in the <codeph>ident_file</codeph> server setting.</pd>
+                  </plentry>
+                </parml></p><p>Following are sample <codeph>pg_hba.conf</codeph> entries for SSL
+                client
+                authentication:<codeblock>Hostssl testdb certuser 192.168.0.0/16 cert
+Hostssl testdb all 192.168.0.0/16 cert map=gpuser
+</codeblock></p></li>
+          </ul></p>
+      </section>
+      <section id="openssl_config">
+        <title>OpenSSL Configuration</title>
+        <p>Greenplum Database reads the OpenSSL configuration file specified in
+            <codeph>$GP_HOME/etc/openssl.cnf</codeph> by default. You can make changes to the
+          default configuration for OpenSSL by modifying or updating this file and restarting the
+          server.</p>
+      </section>
+      <section id="create_a_cert">
+        <title>Creating a Self-Signed Certificate</title>
+        <p>A self-signed certificate can be used for testing, but a certificate signed by a
+          certificate authority (CA) (either one of the global CAs or a local one) should be used in
+          production so that clients can verify the server's identity. If all the clients are local
+          to the organization, using a local CA is recommended. </p>
+        <p>To create a self-signed certificate for the server:<ol id="ol_qpr_p4x_kr">
+            <li>Enter the following <codeph>openssl</codeph>
+              command:<codeblock>openssl req -new -text -out server.req</codeblock></li>
+            <li>Enter the requested information at the prompts. <p>Make sure you enter the local
+                host name for the Common Name. The challenge password can be left blank. </p></li>
+            <li>The program generates a key that is passphrase-protected; it does not accept a
+              passphrase that is less than four characters long. To remove the passphrase (and you
+              must if you want automatic start-up of the server), run the following
+              command:<codeblock>openssl rsa -in privkey.pem -out server.key rm privkey.pem</codeblock></li>
+            <li>Enter the old passphrase to unlock the existing key. Then run the following
+                command:<codeblock>openssl req -x509 -in server.req -text -key server.key -out server.crt</codeblock><p>This
+                turns the certificate into a self-signed certificate and copies the key and
+                certificate to where the server will look for them. </p></li>
+            <li>Finally, run the following
+              command:<codeblock>chmod og-rwx server.key</codeblock></li>
+          </ol></p>
+        <p>For more details on how to create your server private key and certificate, refer to the
+          OpenSSL documentation. </p>
+      </section>
+      <section id="ssl_postgresql">
+        <title>Configuring postgresql.conf for SSL Authentication</title>
+        <p>The following Server settings need to be specified in the
+            <codeph>postgresql.conf</codeph> configuration file: <ul id="ul_bzs_b22_jr">
+            <li><codeph>ssl</codeph>
+              <i>boolean</i>. Enables SSL connections.</li>
+            <li><codeph>ssl_renegotiation_limit</codeph>
+              <i>integer</i>. Specifies the data limit before key renegotiation.</li>
+            <li><codeph>ssl_ciphers</codeph>
+              <i>string</i>. Lists SSL ciphers that are allowed.</li>
+          </ul></p>
+        <p>The following SSL server files can be found in the Master Data Directory: <ul
+            id="ul_gzs_b22_jr">
+            <li><codeph>server.crt</codeph>. Server certificate.</li>
+            <li><codeph>server.key</codeph>. Server private key.</li>
+            <li><codeph>root.crt</codeph>. Trusted certificate authorities.</li>
+            <li><codeph>root.crl</codeph>. Certificates revoked by certificate authorities.</li>
+          </ul></p>
+      </section>
+      <section id="config_ssl_client_conn">
+        <title>Configuring the SSL Client Connection</title>
+      </section>
+      <p>SSL options:<parml>
+          <plentry>
+            <pt>
+              <codeph>Require</codeph>
+            </pt>
+            <pd>Only use SSL connection. If a root CA file is present, verify the certificate in the
+              same way as if <codeph>verify-ca</codeph> was specified.</pd>
+          </plentry>
+          <plentry>
+            <pt>
+              <codeph>verify-ca</codeph>
+            </pt>
+            <pd>Only use an SSL connection. Verify that the server certificate is issued by a
+              trusted CA.</pd>
+          </plentry>
+          <plentry>
+            <pt>
+              <codeph>verify-full</codeph>
+            </pt>
+            <pd>Only use an SSL connection. Verify that the server certificate is issued by a
+              trusted CA and that the server host name matches that in the certificate.</pd>
+          </plentry>
+          <plentry>
+            <pt>Sslcert</pt>
+            <pd>The file name of the client SSL certificate. The default is
+                <codeph>~/.postgresql/postgresql.crt</codeph>. </pd>
+          </plentry>
+          <plentry>
+            <pt>Sslkey</pt>
+            <pd>The secret key used for the client certificate. The default is
+                <codeph>~/.postgresql/postgresql.key</codeph>.</pd>
+          </plentry>
+          <plentry>
+            <pt>Sslrootcert</pt>
+            <pd>The name of a file containing SSL Certificate Authority certificate(s). The default
+              is <codeph>~/.postgresql/root.crt</codeph>.</pd>
+          </plentry>
+          <plentry>
+            <pt>Sslcrl</pt>
+            <pd>The name of the SSL certificate revocation list. The default is
+                <codeph>~/.postgresql/root.crl</codeph>.</pd>
+          </plentry>
+        </parml></p>
+      <p>The client connection parameters can be set using the following environment variables:<ul
+          id="ul_yph_5g2_jr">
+          <li><codeph>Sslmode</codeph> – <codeph>PGSSLMODE</codeph></li>
+          <li><codeph>Sslkey</codeph> – <codeph>PGSSLKEY</codeph></li>
+          <li><codeph>Sslrootcert</codeph> – <codeph>PGSSLROOTCERT</codeph></li>
+          <li><codeph>Sslcert</codeph> – <codeph>PGSSLCERT</codeph></li>
+          <li><codeph>Sslcrl</codeph> – <codeph>PGSSLCRL</codeph> </li>
+        </ul></p>
+    </body>
+  </topic>
+  <topic id="topic_yxp_5h2_jr">
+    <title>PAM Based Authentication</title>
+    <body>
+      <p>"PAM" (Pluggable Authentication Modules) is used to validate username/password pairs,
+        similar to basic authentication. PAM authentication only works if the users already exist in
+        the database. </p>
+      <section>
+        <title>Parameters</title>
+        <p>
+          <parml>
+            <plentry>
+              <pt>
+                <codeph>pamservice</codeph>
+              </pt>
+              <pd>The default PAM service is <codeph>postgresql</codeph>. Note that if PAM is set up
+                to read <codeph>/etc/shadow</codeph>, authentication will fail because the
+                PostgreSQL server is started by a non-root user.</pd>
+            </plentry>
+          </parml>
+        </p>
+        <p>Following are sample <codeph>pg_hba.conf</codeph> entries for PAM client
+          authentication:<codeblock>local    all gpuser am pamservice=postgresql</codeblock></p>
+      </section>
+    </body>
+  </topic>
+  <topic id="topic_ed4_d32_jr">
+    <title>Radius Authentication</title>
+    <body>
+      <p>RADIUS (Remote Authentication Dial In User Service) authentication works by sending an
+        Access Request message of type 'Authenticate Only' to a configured RADIUS server. It
+        includes parameters for user name, password (encrypted), and the Network Access Server (NAS)
+        Identifier. The request is encrypted using the shared secret specified in the
+          <codeph>radiussecret</codeph> option. The RADIUS server responds with either
+          <codeph>Access Accept</codeph> or <codeph>Access Reject</codeph>. </p>
+      <note>RADIUS accounting is not supported.</note>
+      <p> RADIUS authentication only works if the users already exist in the database.</p>
+      <p>The RADIUS encryption vector requires SSL to be enabled in order to be cryptographically
+        strong.</p>
+      <section>
+        <title>RADIUS Authentication Options</title>
+        <parml>
+          <plentry>
+            <pt>Radiusserver</pt>
+            <pd>The ame of the RADIUS server.</pd>
+          </plentry>
+          <plentry>
+            <pt>Radiussecret</pt>
+            <pd>The RADIUS shared secret.</pd>
+          </plentry>
+          <plentry>
+            <pt>Radiusport</pt>
+            <pd>The port to connect to on the RADIUS server.</pd>
+          </plentry>
+          <plentry>
+            <pt>Radiusidentifier</pt>
+            <pd>NAS identifier in RADIUS requests.</pd>
+          </plentry>
+        </parml>
+      </section>
+      <p>Following are sample <codeph>pg_hba.conf</codeph> entries for RADIUS client
+        authentication:<codeblock>ostssl  all all 0.0.0.0/0 radius radiusserver=servername radiussecret=<varname>sharedsecret</varname></codeblock></p>
+    </body>
+  </topic>
+  <topic id="topic_hwn_bk2_jr">
+    <title>Limiting Concurrent Connections</title>
+    <body>
+      <p>To limit the number of active concurrent sessions to your Greenplum Database system, you
+        can configure the <codeph>max_connections</codeph> server configuration parameter. This is a
+        local parameter, meaning that you must set it in the <codeph>postgresql.conf</codeph> file
+        of the master, the standby master, and each segment instance (primary and mirror). The value
+        of <codeph>max_connections</codeph> on segments must be 5-10 times the value on the master. </p>
+      <p>When you set <codeph>max_connections</codeph>, you must also set the dependent parameter
+          <codeph>max_prepared_transactions</codeph>. This value must be at least as large as the
+        value of <codeph>max_connections</codeph> on the master, and segment instances should be set
+        to the same value as the master. </p>
+      <p>In <codeph>$MASTER_DATA_DIRECTORY/postgresql.conf</codeph> (including standby
+        master):<codeblock>max_connections=100
+max_prepared_transactions=100</codeblock></p>
+      <p>In <codeph>SEGMENT_DATA_DIRECTORY/postgresql.conf</codeph> for all segment
+        instances:<codeblock>max_connections=500
+max_prepared_transactions=100</codeblock></p>
+      <note>Note: Raising the values of these parameters may cause Greenplum Database to request
+        more shared memory. To mitigate this effect, consider decreasing other memory-related
+        parameters such as <codeph>gp_cached_segworkers_threshold</codeph>.</note>
+      <p>To change the number of allowed connections:<ol id="ol_etb_rk2_jr">
+          <li>Stop your Greenplum Database system:<codeblock>$ gpstop</codeblock></li>
+          <li>On the master host, edit <codeph>$MASTER_DATA_DIRECTORY/postgresql.conf</codeph> and
+            change the following two parameters:<ul id="ul_e5k_vk2_jr">
+              <li><codeph>max_connections</codeph> – the number of active user sessions you want to
+                allow plus the number of <codeph>superuser_reserved_connections</codeph>.</li>
+              <li><codeph>max_prepared_transactions</codeph> – must be greater than or equal to
+                  <codeph>max_connections</codeph>.</li>
+            </ul></li>
+          <li>On each segment instance, edit <codeph>SEGMENT_DATA_DIRECTORY/postgresql.conf</codeph>
+            and change the following two parameters:<ul id="ul_iwf_1l2_jr">
+              <li><codeph>max_connections</codeph> – must be 5-10 times the value on the
+                master.</li>
+              <li><codeph>max_prepared_transactions</codeph> – must be equal to the value on the
+                master.</li>
+            </ul></li>
+          <li>Restart your Greenplum Database system:<codeblock>$ gpstart</codeblock></li>
+        </ol></p>
+    </body>
+  </topic>
+  <topic id="topic_ibc_nl2_jr">
+    <title>Encrypting Client/Server Connections</title>
+    <body>
+      <p>Greenplum Database has native support for SSL connections between the client and the master
+        server. SSL connections prevent third parties from snooping on the packets, and also prevent
+        man-in-the-middle attacks. SSL should be used whenever the client connection goes through an
+        insecure link, and must be used whenever client certificate authentication is used. </p>
+      <note>For information about encrypting data between the <codeph>gpfdist</codeph> server and
+        Greenplum Database segment hosts, see <xref href="Encryption.xml#gpfdist_connections"/>. </note>
+      <p>To enable SSL requires that OpenSSL be installed on both the client and the master server
+        systems. Greenplum can be started with SSL enabled by setting the server configuration
+        parameter <codeph>ssl=on</codeph> in the master <codeph>postgresql.conf</codeph>. When
+        starting in SSL mode, the server will look for the files <codeph>server.key</codeph> (server
+        private key) and <codeph>server.crt</codeph> (server certificate) in the master data
+        directory. These files must be set up correctly before an SSL-enabled Greenplum system can
+        start.</p>
+      <note type="important">Do not protect the private key with a passphrase. The server does not
+        prompt for a passphrase for the private key, and the database startup fails with an error if
+        one is required.</note>
+      <p>A self-signed certificate can be used for testing, but a certificate signed by a
+        certificate authority (CA) should be used in production, so the client can verify the
+        identity of the server. Either a global or local CA can be used. If all the clients are
+        local to the organization, a local CA is recommended. See <xref
+          href="#topic_fzv_wb2_jr/create_a_cert" format="dita"/> for steps to create a self-signed
+        certificate.</p>
+    </body>
+  </topic>
+</topic>

--- a/gpdb-doc/dita/security-guide/topics/Authorization.xml
+++ b/gpdb-doc/dita/security-guide/topics/Authorization.xml
@@ -1,0 +1,401 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="topic_ivr_cs2_jr">
+  <title>Configuring Database Authorization</title>
+  <body>
+    <p>Authorization governs access to Greenplum Database database objects. </p>
+  </body>
+  <topic id="topic_k35_qtx_kr">
+    <title>Access Permissions and Roles</title>
+    <body>
+      <p>Greenplum Database manages database access permissions using <i>roles</i>. The concept of
+        roles subsumes the concepts of users and groups. A role can be a database user, a group, or
+        both. Roles can own database objects (for example, tables) and can assign privileges on
+        those objects to other roles to control access to the objects. Roles can be members of other
+        roles, thus a member role can inherit the object privileges of its parent role. </p>
+      <p>Every Greenplum Database system contains a set of database roles (users and groups). Those
+        roles are separate from the users and groups managed by the operating system on which the
+        server runs. However, for convenience you may want to maintain a relationship between
+        operating system user names and Greenplum Database role names, since many of the client
+        applications use the current operating system user name as the default. </p>
+      <p> In Greenplum Database, users log in and connect through the master instance, which
+        verifies their role and access privileges. The master then issues out commands to the
+        segment instances behind the scenes using the currently logged in role. </p>
+      <p> Roles are defined at the system level, so they are valid for all databases in the system. </p>
+      <p> To bootstrap the Greenplum Database system, a freshly initialized system always contains
+        one predefined superuser role (also referred to as the system user). This role will have the
+        same name as the operating system user that initialized the Greenplum Database system.
+        Customarily, this role is named <codeph>gpadmin</codeph>. To create more roles you first
+        must connect as this initial role. </p>
+    </body>
+  </topic>
+  <topic id="managing_obj_priv">
+    <title>Managing Object Privileges</title>
+    <body>
+      <p> When an object (table, view, sequence, database, function, language, schema, or
+        tablespace) is created, it is assigned an owner. The owner is normally the role that
+        executed the creation statement. For most kinds of objects, the initial state is that only
+        the owner (or a superuser) can do anything with the object. To allow other roles to use it,
+        privileges must be granted. Greenplum Database supports the following privileges for each
+        object type: </p>
+      <table>
+        <tgroup cols="0">
+          <colspec colwidth="50*" align="left"/>
+          <colspec colwidth="50*" align="left"/>
+          <thead>
+            <row>
+              <entry> Object Type </entry>
+              <entry> Privileges </entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry> Tables, Views, Sequences </entry>
+              <entry>
+                <sl>
+                  <sli>
+                    <codeph>SELECT</codeph>
+                  </sli>
+                  <sli>
+                    <codeph>INSERT</codeph>
+                  </sli>
+                  <sli>
+                    <codeph>UPDATE</codeph>
+                  </sli>
+                  <sli>
+                    <codeph>DELETE</codeph>
+                  </sli>
+                  <sli>
+                    <codeph>RULE</codeph>
+                  </sli>
+                  <sli>
+                    <codeph>ALL</codeph>
+                  </sli>
+                </sl>
+              </entry>
+            </row>
+            <row>
+              <entry> External Tables </entry>
+              <entry>
+                <sl>
+                  <sli>
+                    <codeph>SELECT</codeph>
+                  </sli>
+                  <sli>
+                    <codeph>RULE</codeph>
+                  </sli>
+                  <sli>
+                    <codeph>ALL</codeph>
+                  </sli>
+                </sl>
+              </entry>
+            </row>
+            <row>
+              <entry> Databases </entry>
+              <entry>
+                <sl>
+                  <sli>
+                    <codeph>CONNECT</codeph>
+                  </sli>
+                  <sli>
+                    <codeph>CREATE</codeph>
+                  </sli>
+                  <sli>
+                    <codeph>TEMPORARY | TEMP</codeph>
+                  </sli>
+                  <sli>
+                    <codeph>ALL</codeph>
+                  </sli>
+                </sl>
+              </entry>
+            </row>
+            <row>
+              <entry> Functions </entry>
+              <entry>
+                <codeph>EXECUTE</codeph>
+              </entry>
+            </row>
+            <row>
+              <entry> Procedural Languages </entry>
+              <entry>
+                <codeph>USAGE</codeph>
+              </entry>
+            </row>
+            <row>
+              <entry> Schemas </entry>
+              <entry>
+                <sl>
+                  <sli>
+                    <codeph>CREATE</codeph>
+                  </sli>
+                  <sli>
+                    <codeph>USAGE</codeph>
+                  </sli>
+                  <sli>
+                    <codeph>ALL</codeph>
+                  </sli>
+                </sl>
+              </entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+      <p> Privileges must be granted for each object individually. For example, granting
+          <codeph>ALL</codeph> on a database does not grant full access to the objects within that
+        database. It only grants all of the database-level privileges (<codeph>CONNECT</codeph>,
+          <codeph>CREATE</codeph>, <codeph>TEMPORARY</codeph>) to the database itself. </p>
+      <p> Use the <codeph>GRANT</codeph> SQL command to give a specified role privileges on an
+        object. For example: <codeblock>=# GRANT INSERT ON mytable TO jsmith; </codeblock></p>
+      <p> To revoke privileges, use the <codeph>REVOKE</codeph> command. For example:
+        <codeblock>=# REVOKE ALL PRIVILEGES ON mytable FROM jsmith; </codeblock></p>
+      <p> You can also use the <codeph>DROP OWNED</codeph> and <codeph>REASSIGN OWNED</codeph>
+        commands for managing objects owned by deprecated roles. (Note: only an object's owner or a
+        superuser can drop an object or reassign ownership.) For example:
+        <codeblock> =# REASSIGN OWNED BY sally TO bob;
+ =# DROP OWNED BY visitor; </codeblock></p>
+    </body>
+  </topic>
+  <topic id="using-ssh-256">
+    <title>Using SSH-256 Encryption</title>
+    <body>
+      <p>Greenplum Database access control corresponds roughly to the Orange Book 'C2' level of
+        security, not the 'B1' level. Greenplum Database currently supports access privileges at the
+        object level. Row-level or column-level access is not supported, nor is labeled security. </p>
+      <p>Row-level and column-level access can be simulated using views to restrict the columns
+        and/or rows that are selected. Row-level labels can be simulated by adding an extra column
+        to the table to store sensitivity information, and then using views to control row-level
+        access based on this column. Roles can then be granted access to the views rather than the
+        base table. While these workarounds do not provide the same as "B1" level security, they may
+        still be a viable alternative for many organizations. </p>
+      <p> To use SHA-256 encryption, you must set a parameter either at the system or the session
+        level. This section outlines how to use a server parameter to implement SHA-256 encrypted
+        password storage. Note that in order to use SHA-256 encryption for storage, the client
+        authentication method must be set to password rather than the default, MD5. (See <xref
+          href="Authenticate.xml#topic_fzv_wb2_jr/config_ssl_client_conn"/> for more details.) This
+        means that the password is transmitted in clear text over the network, so we highly
+        recommend that you set up SSL to encrypt the client server communication channel. </p>
+      <p> You can set your chosen encryption method system-wide or on a per-session basis. The
+        available encryption methods are SHA-256  and MD5 (for backward compatibility). </p>
+    </body>
+    <topic id="system-wide">
+      <title>Setting Encryption Method System-wide</title>
+      <body>
+        <p>To set the <codeph>password_hash_algorithm</codeph> server parameter on a complete
+          Greenplum system (master and its segments): <ol id="ol_hcg_hw2_jr">
+            <li> Log in to your Greenplum Database instance as a superuser. </li>
+            <li> Execute <codeph>gpconfig</codeph> with the <codeph>password_hash_algorithm</codeph>
+              set to
+              SHA-256:<codeblock>$ gpconfig -c password_hash_algorithm -v 'SHA-256' </codeblock></li>
+            <li> Verify the setting: <codeblock>$ gpconfig -s</codeblock><p> You will see:
+                <codeblock>Master value: SHA-256
+Segment value: SHA-256 </codeblock></p></li>
+          </ol></p>
+      </body>
+    </topic>
+    <topic id="individual_session">
+      <title>Setting Encryption Method for an Individual Session</title>
+      <body>
+        <p> To set the <codeph>password_hash_algorithm</codeph> server parameter for an individual
+          session: </p>
+        <ol id="ol_iv1_cvx_kr">
+          <li> Log in to your Greenplum Database instance as a superuser. </li>
+          <li> Set the <codeph>password_hash_algorithm</codeph> to
+            SHA-256:<codeblock># set password_hash_algorithm = 'SHA-256'
+  </codeblock></li>
+          <li> Verify the setting: <codeblock># show password_hash_algorithm;</codeblock><p> You
+              will see: </p><codeblock>SHA-256 </codeblock></li>
+        </ol>
+        <p> Following is an example of how the new setting works: </p>
+        <ol id="ol_ex1_cvx_kr">
+          <li> Log in as a super user and verify the password hash algorithm
+            setting:<codeblock># show password_hash_algorithm 
+ password_hash_algorithm 
+ ------------------------------- 
+ SHA-256</codeblock></li>
+          <li> Create a new role with password that has login privileges.
+            <codeblock>create role testdb with password 'testdb12345#' LOGIN; </codeblock></li>
+          <li> Change the client authentication method to allow for storage of SHA-256 encrypted
+              passwords:<p> Open the <codeph>pg_hba.conf</codeph> file on the master and add the
+              following line: </p><codeblock>host all testdb 0.0.0.0/0 password
+  </codeblock></li>
+          <li> Restart the cluster. </li>
+          <li> Log in to the database as the user just created, <codeph>testdb</codeph>.
+            <codeblock>psql -U testdb</codeblock></li>
+          <li> Enter the correct password at the prompt. </li>
+          <li> Verify that the password is stored as a SHA-256 hash. <p> Password hashes are stored
+              in <codeph>pg_authid.rolpasswod</codeph>. </p></li>
+          <li> Log in as the super user. </li>
+          <li> Execute the following query:
+            <codeblock>
+    # SELECT rolpassword FROM pg_authid WHERE rolname = 'testdb';
+    Rolpassword
+    -----------
+    sha256&lt;64 hexidecimal characters&gt;
+  </codeblock></li>
+
+        </ol>
+      </body>
+    </topic>
+  </topic>
+  <topic id="time-based-restriction">
+    <title>Restricting Access by Time</title>
+    <body>
+      <p> Greenplum Database enables the administrator to restrict access to certain times by role.
+        Use the <codeph>CREATE ROLE</codeph> or <codeph>ALTER ROLE</codeph> commands to specify
+        time-based constraints. </p>
+      <p> Access can be restricted by day or by day and time. The constraints are removable without
+        deleting and recreating the role. </p>
+      <p> Time-based constraints only apply to the role to which they are assigned. If a role is a
+        member of another role that contains a time constraint, the time constraint is not
+        inherited. </p>
+      <p> Time-based constraints are enforced only during login. The <codeph>SET ROLE</codeph> and
+          <codeph>SET SESSION AUTHORIZATION</codeph> commands are not affected by any time-based
+        constraints. </p>
+      <p> Superuser or <codeph>CREATEROLE</codeph> privileges are required to set time-based
+        constraints for a role. No one can add time-based constraints to a superuser. </p>
+      <p> There are two ways to add time-based constraints. Use the keyword <codeph>DENY</codeph> in
+        the <codeph>CREATE ROLE</codeph> or <codeph>ALTER ROLE</codeph> command followed by one of
+        the following. <ul id="ul_bjq_jz2_jr">
+          <li> A day, and optionally a time, when access is restricted. For example, no access on
+            Wednesdays. </li>
+          <li> An interval—that is, a beginning and ending day and optional time—when access is
+            restricted. For example, no access from Wednesday 10 p.m. through Thursday at 8 a.m.
+          </li>
+        </ul></p>
+      <p> You can specify more than one restriction; for example, no access Wednesdays at any time
+        and no access on Fridays between 3:00 p.m. and 5:00 p.m.  </p>
+      <p> There are two ways to specify a day. Use the word <codeph>DAY</codeph> followed by either
+        the English term for the weekday, in single quotation marks, or a number between 0 and 6, as
+        shown in the table below. </p>
+      <table id="table_az1_cvx_kr">
+        <tgroup cols="0">
+          <colspec colwidth="50*" align="left"/>
+          <colspec colwidth="50*" align="left"/>
+          <thead>
+            <row>
+              <entry> English Term </entry>
+              <entry> Number </entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry> DAY 'Sunday' </entry>
+              <entry> DAY 0 </entry>
+            </row>
+            <row>
+              <entry> DAY 'Monday' </entry>
+              <entry> DAY 1 </entry>
+            </row>
+            <row>
+              <entry> DAY 'Tuesday' </entry>
+              <entry> DAY 2 </entry>
+            </row>
+            <row>
+              <entry> DAY 'Wednesday' </entry>
+              <entry> DAY 3 </entry>
+            </row>
+            <row>
+              <entry> DAY 'Thursday' </entry>
+              <entry> DAY 4 </entry>
+            </row>
+            <row>
+              <entry> DAY 'Friday' </entry>
+              <entry> DAY 5 </entry>
+            </row>
+            <row>
+              <entry> DAY 'Saturday' </entry>
+              <entry> DAY 6 </entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+      <p> A time of day is specified in either 12- or 24-hour format. The word <codeph>TIME</codeph>
+        is followed by the specification in single quotation marks. Only hours and minutes are
+        specified and are separated by a colon ( : ). If using a 12-hour format, add
+          <codeph>AM</codeph> or <codeph>PM</codeph> at the end. The following examples show various
+        time specifications. </p>
+      <codeblock>TIME '14:00'     # 24-hour time implied
+TIME '02:00 PM'  # 12-hour time specified by PM 
+TIME '02:00'     # 24-hour time implied. This is equivalent to TIME '02:00 AM'. </codeblock>
+      <note type="important">Time-based authentication is enforced with the server time. Timezones
+        are disregarded. </note>
+      <p> To specify an interval of time during which access is denied, use two day/time
+        specifications with the words <codeph>BETWEEN</codeph> and <codeph>AND</codeph>, as shown.
+          <codeph>DAY</codeph> is always required. </p>
+      <codeblock>BETWEEN DAY 'Monday' AND DAY 'Tuesday' 
+
+BETWEEN DAY 'Monday' TIME '00:00' AND
+        DAY 'Monday' TIME '01:00'
+
+BETWEEN DAY 'Monday' TIME '12:00 AM' AND
+        DAY 'Tuesday' TIME '02:00 AM'
+
+BETWEEN DAY 'Monday' TIME '00:00' AND
+        DAY 'Tuesday' TIME '02:00'
+        DAY 2 TIME '02:00'</codeblock>
+      <p>The last three statements are equivalent. </p>
+      <note>Intervals of days cannot wrap past Saturday.</note>
+      <p>The following syntax is not correct:
+        <codeblock>DENY BETWEEN DAY 'Saturday' AND DAY 'Sunday'</codeblock>
+      </p>
+      <p> The correct specification uses two DENY clauses, as follows: </p>
+      <codeblock>DENY DAY 'Saturday'
+DENY DAY 'Sunday'</codeblock>
+      <p> The following examples demonstrate creating a role with time-based constraints and
+        modifying a role to add time-based constraints. Only the statements needed for time-based
+        constraints are shown. For more details on creating and altering roles see the descriptions
+        of <codeph>CREATE ROLE</codeph> and <codeph>ALTER ROLE</codeph> in in the <i>Greenplum
+          Database Reference Guide</i>. </p>
+      <section>
+        <title> Example 1 – Create a New Role with Time-based Constraints </title>
+        <p> No access is allowed on weekends. </p>
+        <codeblock> CREATE ROLE generaluser
+ DENY DAY 'Saturday'
+ DENY DAY 'Sunday'
+ ... </codeblock>
+      </section>
+      <section>
+        <title>Example 2 – Alter a Role to Add Time-based Constraints </title>
+        <p> No access is allowed every night between 2:00 a.m. and 4:00 a.m. </p>
+        <codeblock>ALTER ROLE generaluser
+ DENY BETWEEN DAY 'Monday' TIME '02:00' AND DAY 'Monday' TIME '04:00'
+ DENY BETWEEN DAY 'Tuesday' TIME '02:00' AND DAY 'Tuesday' TIME '04:00'
+ DENY BETWEEN DAY 'Wednesday' TIME '02:00' AND DAY 'Wednesday' TIME '04:00'
+ DENY BETWEEN DAY 'Thursday' TIME '02:00' AND DAY 'Thursday' TIME '04:00'
+ DENY BETWEEN DAY 'Friday' TIME '02:00' AND DAY 'Friday' TIME '04:00'
+ DENY BETWEEN DAY 'Saturday' TIME '02:00' AND DAY 'Saturday' TIME '04:00'
+ DENY BETWEEN DAY 'Sunday' TIME '02:00' AND DAY 'Sunday' TIME '04:00'
+  ... </codeblock>
+      </section>
+      <section>
+        <title>Excample 3 – Alter a Role to Add Time-based Constraints </title>
+        <p> No access is allowed Wednesdays or Fridays between 3:00 p.m. and 5:00 p.m. </p>
+        <codeblock>ALTER ROLE generaluser
+ DENY DAY 'Wednesday'
+ DENY BETWEEN DAY 'Friday' TIME '15:00' AND DAY 'Friday' TIME '17:00'
+ </codeblock>
+      </section>
+    </body>
+  </topic>
+  <topic id="drop_timebased_restriction">
+    <title> Dropping a Time-based Restriction </title>
+    <body>
+      <p> To remove a time-based restriction, use the ALTER ROLE command. Enter the keywords DROP
+        DENY FOR followed by a day/time specification to drop. </p>
+      <codeblock>DROP DENY FOR DAY 'Sunday' </codeblock>
+      <p> Any constraint containing all or part of the conditions in a DROP clause is removed. For
+        example, if an existing constraint denies access on Mondays and Tuesdays, and the DROP
+        clause removes constraints for Mondays, the existing constraint is completely dropped. The
+        DROP clause completely removes all constraints that overlap with the contraint in the drop
+        clause. The overlapping constraints are completely removed even if they contain more
+        restrictions that the restrictions mentioned in the DROP clause. </p>
+      <p> Example 1 - Remove a Time-based Restriction from a Role </p>
+      <codeblock> ALTER ROLE generaluser
+ DROP DENY FOR DAY 'Monday'
+    ... </codeblock>
+      <p> This statement would remove all constraints that overlap with a Monday constraint for the
+        role <codeph>generaluser</codeph> in Example 2, even if there are additional
+        constraints.</p>
+    </body>
+  </topic>
+</topic>

--- a/gpdb-doc/dita/security-guide/topics/BestPractices.xml
+++ b/gpdb-doc/dita/security-guide/topics/BestPractices.xml
@@ -3,8 +3,8 @@
 <topic id="topic_nyc_mdf_jr">
   <title>Security Best Practices</title>
   <body>
-    <p> This chapter describes basic security best practices that you should follow to
-      ensure the highest level of system security.  </p>
+    <p> This chapter describes basic security best practices that you should follow to ensure the
+      highest level of system security.  </p>
     <p>Greenplum Database default security configuration:<ul id="ul_mhk_rrg_4r">
         <li>Only local connections are allowed. </li>
         <li>Basic authentication is configured for the superuser (<codeph>gpadmin</codeph>).</li>
@@ -92,13 +92,13 @@
       <ul id="ul_gd3_fxg_4r">
         <li> John The Ripper. A fast and flexible password cracking program. It allows the use of
           multiple word lists and is capable of brute-force password cracking. It is available
-          online at <xref href="http://www.commoncriteriaportal.org/products/?expand#ALL"
-            format="html" scope="external">http://www.openwall.com/john/</xref>. </li>
+          online at <xref href="http://www.openwall.com/john/" format="html" scope="external"
+            >http://www.openwall.com/john/</xref>. </li>
         <li>Crack. Perhaps the most well-known password cracking software, Crack is also very fast,
           though not as easy to use as John The Ripper. It can be found online at <xref
-            href="http://www.commoncriteriaportal.org/products/?expand#ALL" format="html"
-            scope="external">http://www.crypticide.com/alecm/security/crack/c50-faq.html</xref>. 
-        </li>
+            href="https://dropsafe.crypticide.com/alecm/software/crack/c50-faq.html" format="html"
+            scope="external"
+            >https://dropsafe.crypticide.com/alecm/software/crack/c50-faq.html</xref>.  </li>
       </ul>
       <p>The security of the entire system depends on the strength of the root password. This
         password should be at least 12 characters long and include a mix of capitalized letters,
@@ -217,6 +217,5 @@ chmod 644 passwd group
 chmod 400 shadow gshadow
 </codeblock>
     </section>
-
   </body>
 </topic>

--- a/gpdb-doc/dita/security-guide/topics/BestPractices.xml
+++ b/gpdb-doc/dita/security-guide/topics/BestPractices.xml
@@ -1,0 +1,222 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="topic_nyc_mdf_jr">
+  <title>Security Best Practices</title>
+  <body>
+    <p> This chapter describes basic security best practices that you should follow to
+      ensure the highest level of system security.  </p>
+    <p>Greenplum Database default security configuration:<ul id="ul_mhk_rrg_4r">
+        <li>Only local connections are allowed. </li>
+        <li>Basic authentication is configured for the superuser (<codeph>gpadmin</codeph>).</li>
+        <li>The superuser is authorized to do anything.</li>
+        <li>Only database role passwords are encrypted.</li>
+      </ul></p>
+    <section>
+      <title>System User (gpadmin)</title>
+      <p>Secure and limit access to the <codeph>gpadmin</codeph> system user. </p>
+      <p>Greenplum requires a UNIX user id to install and initialize the Greenplum Database system.
+        This system user is referred to as <codeph>gpadmin</codeph> in the Greenplum documentation.
+        The <codeph>gpadmin</codeph> user is the default database superuser in Greenplum Database,
+        as well as the file system owner of the Greenplum installation and its underlying data
+        files. The default administrator account is fundamental to the design of Greenplum Database.
+        The system cannot run without it, and there is no way to limit the access of the
+          <codeph>gpadmin</codeph> user id. </p>
+      <p>The <codeph>gpadmin</codeph> user can bypass all security features of Greenplum Database.
+        Anyone who logs on to a Greenplum host with this user id can read, alter, or delete any
+        data, including system catalog data and database access rights. Therefore, it is very
+        important to secure the <codeph>gpadmin</codeph> user id and only allow essential system
+        administrators access to it. </p>
+      <p>Administrators should only log in to Greenplum as <codeph>gpadmin</codeph> when performing
+        certain system maintenance tasks (such as upgrade or expansion). </p>
+      <p>Database users should never log on as <codeph>gpadmin</codeph>, and ETL or production
+        workloads should never run as <codeph>gpadmin</codeph>. </p>
+    </section>
+    <section>
+      <title>Superusers</title>
+      <p>Roles granted the <codeph>SUPERUSER</codeph> attribute are superusers. Superusers bypass
+        all access privilege checks and resource queues. Only system administrators should be given
+        superuser rights. </p>
+      <p> See "Altering Role Attributes" in the <i>Greenplum Database Administrator Guide</i>. </p>
+    </section>
+    <section>
+      <title>Login Users</title>
+      <p>Assign a distinct role to each user who logs in and set the <codeph>LOGIN</codeph>
+        attribute. </p>
+      <p>For logging and auditing purposes, each user who is allowed to log in to Greenplum Database
+        should be given their own database role. For applications or web services, consider creating
+        a distinct role for each application or service. See "Creating New Roles (Users)" in the
+          <i>Greenplum Database Administrator Guide</i>. </p>
+      <p>Each login role should be assigned to a single, non-default resource queue.</p>
+    </section>
+    <section>
+      <title>Groups</title>
+      <p>Use groups to manage access privileges.</p>
+      <p>Create a group for each logical grouping of object/access permissions. </p>
+      <p>Every login user should belong to one or more roles. Use the <codeph>GRANT</codeph>
+        statement to add group access to a role. Use the <codeph>REVOKE</codeph> statement to remove
+        group access from a role. </p>
+      <p>The <codeph>LOGIN</codeph> attribute should not be set for group roles. </p>
+      <p>See "Creating Groups (Role Membership)" in the <i>Greenplum Database Administrator
+          Guide</i>. </p>
+    </section>
+    <section>
+      <title>Object Privileges</title>
+      <p>Only the owner and superusers have full permissions to new objects. Permission must be
+        granted to allow other rules (users or groups) to access objects. Each type of database
+        object has different privileges that may be granted. Use the <codeph>GRANT</codeph>
+        statement to add a permission to a role and the <codeph>REVOKE</codeph> statement to remove
+        the permission.</p>
+      <p>You can change the owner of an object using the <codeph>REASIGN OWNED BY</codeph>
+        statement. For example, to prepare to drop a role, change the owner of the objects that
+        belong to the role. Use the <codeph>DROP OWNED BY</codeph> to drop objects, including
+        dependent objects, that are owned by a role.</p>
+      <p>Schemas can be used to enforce an additional layer of object permissions checking, but
+        schema permissions do not override object privileges set on objects contained within the
+        schema.</p>
+    </section>
+    <section id="password-strength-recommendations">
+      <title>Operating System Users and File System</title>
+      <p> To protect the network from intrusion, system administrators should verify the passwords
+        used within an organization are sufficently strong. The following recommendations can
+        strengthen a password: </p>
+      <ul>
+        <li> Minimum password length recommendation: At least 9 characters. MD5 passwords should be
+          15 characters or longer. </li>
+        <li> Mix upper and lower case letters. </li>
+        <li> Mix letters and numbers. </li>
+        <li> Include non-alphanumeric characters. </li>
+        <li> Pick a password you can remember. </li>
+      </ul>
+      <p> The following are recommendations for password cracker software that you can use to
+        determine the strength of a password. </p>
+      <ul id="ul_gd3_fxg_4r">
+        <li> John The Ripper. A fast and flexible password cracking program. It allows the use of
+          multiple word lists and is capable of brute-force password cracking. It is available
+          online at <xref href="http://www.commoncriteriaportal.org/products/?expand#ALL"
+            format="html" scope="external">http://www.openwall.com/john/</xref>. </li>
+        <li>Crack. Perhaps the most well-known password cracking software, Crack is also very fast,
+          though not as easy to use as John The Ripper. It can be found online at <xref
+            href="http://www.commoncriteriaportal.org/products/?expand#ALL" format="html"
+            scope="external">http://www.crypticide.com/alecm/security/crack/c50-faq.html</xref>. 
+        </li>
+      </ul>
+      <p>The security of the entire system depends on the strength of the root password. This
+        password should be at least 12 characters long and include a mix of capitalized letters,
+        lowercase letters, special characters, and numbers. It should not be based on any dictionary
+        word. </p>
+      <p> Password expiration parameters should be configured. </p>
+      <p> Ensure the following line exists within the file <codeph>/etc/libuser.conf</codeph> under
+        the <codeph>[import]</codeph> section. </p>
+      <codeblock>login_defs = /etc/login.defs
+</codeblock>
+      <p> Ensure no lines in the <codeph>[userdefaults]</codeph> section begin with the following
+        text, as these words override settings from <codeph>/etc/login.defs</codeph>: </p>
+      <ul id="ul_ef3_fxg_4r">
+        <li>
+          <codeph>LU_SHADOWMAX</codeph>
+        </li>
+        <li>
+          <codeph>LU_SHADOWMIN</codeph>
+        </li>
+        <li>
+          <codeph>LU_SHADOWWARNING</codeph>
+        </li>
+      </ul>
+      <p> Ensure the following command produces no output. Any accounts listed by running this
+        command should be locked. </p>
+      <codeblock>
+grep &quot;^+:&quot; /etc/passwd /etc/shadow /etc/group
+</codeblock>
+      <p> Note: We strongly recommend that customers change their passwords after initial setup. </p>
+      <codeblock>
+cd /etc
+chown root:root passwd shadow group gshadow
+chmod 644 passwd group
+chmod 400 shadow gshadow
+</codeblock>
+      <p> Find all the files that are world-writable and that do not have their sticky bits set. </p>
+      <codeblock>
+find / -xdev -type d \( -perm -0002 -a ! -perm -1000 \) -print
+</codeblock>
+      <p> Set the sticky bit (<codeph># chmod +t {dir}</codeph>) for all the directories that result
+        from running the previous command. </p>
+      <p> Find all the files that are world-writable and fix each file listed. </p>
+      <codeblock>
+find / -xdev -type f -perm -0002 -print
+</codeblock>
+      <p> Set the right permissions (<codeph># chmod o-w {file}</codeph>) for all the files
+        generated by running the aforementioned command. </p>
+      <p> Find all the files that do not belong to a valid user or group and either assign an owner
+        or remove the file, as appropriate. </p>
+      <codeblock>
+find / -xdev \( -nouser -o -nogroup \) -print
+</codeblock>
+      <p> Find all the directories that are world-writable and ensure they are owned by either root
+        or a system account (assuming only system accounts have a User ID lower than 500). If the
+        command generates any output, verify the assignment is correct or reassign it to root. </p>
+      <codeblock>
+find / -xdev -type d -perm -0002 -uid +500 -print
+</codeblock>
+      <p> Authentication settings such as password quality, password expiration policy, password
+        reuse, password retry attempts, and more can be configured using the Pluggable
+        Authentication Modules (PAM) framework. PAM looks in the directory
+          <codeph>/etc/pam.d</codeph> for application-specific configuration information. Running
+          <codeph>authconfig</codeph> or <codeph>system-config-authentication</codeph> will re-write
+        the PAM configuration files, destroying any manually made changes and replacing them with
+        system defaults. </p>
+      <p> The default <codeph>pam_cracklib</codeph> PAM module provides strength checking for
+        passwords. To configure <codeph>pam_cracklib</codeph> to require at least one uppercase
+        character, lowercase character, digit, and special character, as recommended by the U.S.
+        Department of Defense guidelines, edit the file <codeph>/etc/pam.d/system-auth</codeph> to
+        include the following parameters in the line corresponding to password requisite
+          <codeph>pam_cracklib.so try_first_pass</codeph>. </p>
+      <codeblock>retry=3:
+dcredit=-1. Require at least one digit
+ucredit=-1. Require at least one upper case character
+ocredit=-1. Require at least one special character
+lcredit=-1. Require at least one lower case character
+minlen-14. Require a minimum password length of 14.</codeblock>
+      <p> For example: </p>
+      <codeblock>
+password required pam_cracklib.so try_first_pass retry=3\minlen=14 dcredit=-1 ucredit=-1 ocredit=-1 lcredit=-1
+</codeblock>
+      <p> These parameters can be set to reflect your security policy requirements. Note that the
+        password restrictions are not applicable to the root password. </p>
+      <p> The <codeph>pam_tally2</codeph> PAM module provides the capability to lock out user
+        accounts after a specified number of failed login attempts. To enforce password lockout,
+        edit the file <codeph>/etc/pam.d/system-auth</codeph> to include the following lines:<ul
+          id="ul_ehw_ls2_lr">
+          <li>The first of the auth lines should
+            include:<codeblock>auth required pam_tally2.so deny=5 onerr=fail unlock_time=900</codeblock></li>
+          <li>The first of the account lines should
+            include:<codeblock>account required pam_tally2.so</codeblock></li>
+        </ul></p>
+      <p>Here, the deny parameter is set to limit the number of retries to 5 and the
+          <codeph>unlock_time</codeph> has been set to 900 seconds to keep the account locked for
+        900 seconds before it is unlocked. These parameters may be configured appropriately to
+        reflect your security policy requirements. A locked account can be manually unlocked using
+        the <codeph>pam_tally2</codeph>
+        utility:<codeblock>
+/sbin/pam_tally2 --user {username} -reset
+</codeblock></p>
+      <p> You can use PAM to limit the reuse of recent passwords. The remember option for the
+          <codeph>pam_ unix</codeph> module can be set to remember the recent passwords and prevent
+        their reuse. To accomplish this, edit the appropriate line in
+          <codeph>/etc/pam.d/system-auth</codeph> to include the remember option. </p>
+      <p> For example: </p>
+      <codeblock>
+password sufficient pam_unix.so [ … existing_options …] 
+remember=5
+</codeblock>
+      <p> You can set the number of previous passwords to remember to appropriately reflect your
+        security policy requirements. </p>
+      <codeblock>
+cd /etc
+chown root:root passwd shadow group gshadow
+chmod 644 passwd group
+chmod 400 shadow gshadow
+</codeblock>
+    </section>
+
+  </body>
+</topic>

--- a/gpdb-doc/dita/security-guide/topics/Encryption.xml
+++ b/gpdb-doc/dita/security-guide/topics/Encryption.xml
@@ -134,7 +134,6 @@ FORMAT 'TEXT' ( DELIMITER '|' NULL ' ') ;
         compress data before encrypting. </p>
       <p>Pgcrypto has various levels of encryption ranging from basic to advanced built-in
         functions. The following table shows the supported encryption algorithms.</p>
-
       <table id="table_wzb_4fd_lr">
         <title>Pgcrypto Supported Encryption Functions</title>
         <tgroup cols="4">
@@ -146,7 +145,6 @@ FORMAT 'TEXT' ( DELIMITER '|' NULL ' ') ;
               <entry> Value Functionality </entry>
               <entry> Built-in </entry>
               <entry> With OpenSSL </entry>
-              
             </row>
           </thead>
           <tbody>
@@ -154,64 +152,54 @@ FORMAT 'TEXT' ( DELIMITER '|' NULL ' ') ;
               <entry> MD5 </entry>
               <entry> yes </entry>
               <entry> yes </entry>
-              
             </row>
             <row>
               <entry> SHA1 </entry>
               <entry> yes </entry>
               <entry> yes </entry>
-              
             </row>
             <row>
               <entry> SHA224/256/384/512 </entry>
               <entry> yes </entry>
               <entry> yes <fn>SHA2 algorithms were added to OpenSSL in version 0.9.8. For older
                   versions, pgcrypto will use built-in code.</fn></entry>
-              
             </row>
             <row>
               <entry> Other digest algorithms </entry>
               <entry> no </entry>
               <entry> yes <fn>Any digest algorithm OpenSSL supports is automatically picked up. This
                   is not possible with ciphers, which need to be supported explicitly.</fn></entry>
-              
             </row>
             <row>
               <entry> Blowfish </entry>
               <entry> yes </entry>
               <entry> yes </entry>
-              
             </row>
             <row>
               <entry> AES </entry>
               <entry> yes </entry>
               <entry> yes<fn>AES is included in OpenSSL since version 0.9.7. For older versions,
                   pgcrypto will use built-in code.</fn></entry>
-              
             </row>
             <row>
               <entry> DES/3DES/CAST5 </entry>
               <entry> no </entry>
               <entry> yes </entry>
-              
             </row>
             <row>
               <entry> Raw Encryption </entry>
               <entry> yes </entry>
               <entry> yes </entry>
-              
             </row>
             <row>
               <entry> PGP Symmetric-Key </entry>
               <entry> yes </entry>
               <entry> yes </entry>
-              
             </row>
             <row>
               <entry> PGP Public Key </entry>
               <entry> yes </entry>
               <entry> yes </entry>
-              
             </row>
           </tbody>
         </tgroup>
@@ -221,11 +209,11 @@ FORMAT 'TEXT' ( DELIMITER '|' NULL ' ') ;
         <p>To use PGP asymmetric encryption in Greenplum Database, you must first create public and
           private keys and install them. </p>
         <p>This section assumes you are installing Greenplum Database on a Linux machine with the
-          Gnu Privacy Guard (<codeph>gpg</codeph>) command line tool. Use the
-          latest version of GPG to create keys. Download and install Gnu Privacy Guard (GPG) for
-          your operating system from <xref href="https://www.gnupg.org/download/" format="html"
-            scope="external"/>. On the GnuPG website you will find installers for popular Linux
-          distributions and links for Windows and Mac OS X installers. </p>
+          Gnu Privacy Guard (<codeph>gpg</codeph>) command line tool. Use the latest version of GPG
+          to create keys. Download and install Gnu Privacy Guard (GPG) for your operating system
+          from <xref href="https://www.gnupg.org/download/" format="html" scope="external"/>. On the
+          GnuPG website you will find installers for popular Linux distributions and links for
+          Windows and Mac OS X installers. </p>
         <ol id="ol_vnm_h54_kr">
           <li>As root, execute the following command and choose option 1 from the
             menu:<codeblock># gpg --gen-key 
@@ -233,11 +221,11 @@ gpg (GnuPG) 2.0.14; Copyright (C) 2009 Free Software Foundation, Inc.
 This is free software: you are free to change and redistribute it.
 There is NO WARRANTY, to the extent permitted by law.
  
-gpg: directory `/root/.gnupg' created
-gpg: new configuration file `/root/.gnupg/gpg.conf' created
-gpg: WARNING: options in `/root/.gnupg/gpg.conf' are not yet active during this run
-gpg: keyring `/root/.gnupg/secring.gpg' created
-gpg: keyring `/root/.gnupg/pubring.gpg' created
+gpg: directory '/root/.gnupg' created
+gpg: new configuration file '/root/.gnupg/gpg.conf' created
+gpg: WARNING: options in '/root/.gnupg/gpg.conf' are not yet active during this run
+gpg: keyring '/root/.gnupg/secring.gpg' created
+gpg: keyring '/root/.gnupg/pubring.gpg' created
 Please select what kind of key you want:
  (1) RSA and RSA (default)
  (2) DSA and Elgamal
@@ -269,7 +257,7 @@ You selected this USER-ID:
 Change (N)ame, (C)omment, (E)mail or (O)kay/(Q)uit? <b>O</b>
 You need a Passphrase to protect your secret key.
 <i>(For this demo the passphrase is blank.)</i>
-can't connect to `/root/.gnupg/S.gpg-agent': No such file or directory
+can't connect to '/root/.gnupg/S.gpg-agent': No such file or directory
 You don't want a passphrase - this is probably a *bad* idea!
 I will do it anyway.  You can change your passphrase at any time,
 using this program with the option "--edit-key".
@@ -301,9 +289,7 @@ sub   2048R/4FD2EFBB 2015-01-13 [expires: 2016-01-13]
 ------------------------
 sec   2048R/2027CC30 2015-01-13 [expires: 2016-01-13]
 uid                  John Doe &lt;jdoe@email.com&gt;
-ssb   2048R/4FD2EFBB 2015-01-13
-
-</codeblock><p>2027CC30
+ssb   2048R/4FD2EFBB 2015-01-13</codeblock><p>2027CC30
               is the public key and will be used to <i>encrypt</i> data in the database. 4FD2EFBB is
               the private (secret) key and will be used to <i>decrypt</i> data.</p></li>
           <li>Export the keys using the following
@@ -311,8 +297,8 @@ ssb   2048R/4FD2EFBB 2015-01-13
 # gpg -a --export-secret-keys 2027CC30 &gt; secret.key</codeblock></li>
         </ol>
         <p>See the <xref href="http://www.postgresql.org/docs/8.3/static/pgcrypto.html"
-            format="html" scope="external">pgcrypto</xref> documentation for for more information
-          about PGP encryption functions. </p>
+            format="html" scope="external">pgcrypto</xref> documentation for more information about
+          PGP encryption functions. </p>
       </section>
       <section>
         <title>Encrypting Data in Tables using PGP</title>
@@ -407,7 +393,7 @@ f \015\004\242\231\263\225%\032\271a\001\035\277\021\375X\232\304\305/\340\334\0
 315G^\027:K_9\254\362\354\215&lt;\001\304\357\331\355\323,\302\213Fe\265\315\232\367\254\245%(\\\373
 4\254\230\331\356\006B\257\333\326H\022\013\353\216F?\023\220\370\035vH5/\227\344b\322\227\026\362=\
 42\033\322&lt;\001}\243\224;)\030zqX\214\340\221\035\275U\345\327\214\032\351\223c\2442\345\304K\016\
-011\214\307\227\237\270\026`R\205\205a~1\263\236[\037C\260\031\205\374\245\317\033k|\366\253\037
+011\214\307\227\237\270\026'R\205\205a~1\263\236[\037C\260\031\205\374\245\317\033k|\366\253\037
 ---------+--------------------------------------------------------------------------------------------
 ------------------------------------------------------------------------------------------------------
 ------------------------------------------------------------------------------------------------------
@@ -422,11 +408,11 @@ ssn_id   | 2
 username | Bob
 ssn      | \301\300L\003\235M%_O\322\357\273\001\007\377t>\345\343,\200\256\272\300\012\033M4\265\032L
 L[v\262k\244\2435\264\232B\357\370d9\375\011\002\327\235&lt;\246\210b\030\012\337@\226Z\361\246\032\00
-7`\012c\353]\355d7\360T\335\314\367\370;X\371\350*\231\212\260B\010#RQ0\223\253c7\0132b\355\242\233\34
+7'\012c\353]\355d7\360T\335\314\367\370;X\371\350*\231\212\260B\010#RQ0\223\253c7\0132b\355\242\233\34
 1\000\370\370\366\013\022\357\005i\202~\005\\z\301o\012\230Z\014\362\244\324&amp;\243g\351\362\325\375
 \213\032\226$\2751\256XR\346k\266\030\234\267\201vUh\004\250\337A\231\223u\247\366/i\022\275\276\350\2
 20\316\306|\203+\010\261;\232\254tp\255\243\261\373Rq;\316w\357\006\207\374U\333\365\365\245hg\031\005
-\322\347ea\220\015l\212g\337\264\336b\263\004\311\210.4\340G+\221\274D\035\375\2216\241`\346a0\273wE\2
+\322\347ea\220\015l\212g\337\264\336b\263\004\311\210.4\340G+\221\274D\035\375\2216\241'\346a0\273wE\2
 12\342y^\202\262|A7\202t\240\333p\345G\373\253\243oCO\011\360\247\211\014\024{\272\271\322&lt;\001\267
 \347\240\005\213\0078\036\210\307$\317\322\311\222\035\354\006&lt;\266\264\004\376\251q\256\220(+\030\
 3270\013c\327\272\212%\363\033\252\322\337\354\276\225\232\201\212^\304\210\2269@\3230\370{
@@ -554,8 +540,6 @@ username | decrypted_ssn
               you created a key with passphrase, you may have to enter it here. However for the
               purpose of this example, the passphrase is blank. </p></li>
         </ol>
-
-
       </section>
       <section>
         <title>Key Management</title>
@@ -577,5 +561,4 @@ username | decrypted_ssn
       </section>
     </body>
   </topic>
-
 </topic>

--- a/gpdb-doc/dita/security-guide/topics/Encryption.xml
+++ b/gpdb-doc/dita/security-guide/topics/Encryption.xml
@@ -1,0 +1,581 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="topic_th5_5bf_jr">
+  <title>Encrypting Data and Database Connections</title>
+  <body>
+    <p>Encryption can be used to protect data in transit over the network between the database and
+      clients, and data at rest in the database. </p>
+    <ul id="ul_wxd_dxc_lr">
+      <li>Connections between clients and the master database can be encrypted with SSL. This is
+        enabled with the <codeph>ssl</codeph> server configuration parameter, which is
+          <codeph>off</codeph> by default. Setting the <codeph>ssl</codeph> parameter to
+          <codeph>on</codeph> allows client communications with the master to be encrypted. The
+        master database must be set up for SSL. See <xref
+          href="Authenticate.xml#topic_fzv_wb2_jr/openssl_config"/> for more about encrypting client
+        connections with SSL.</li>
+      <li>Greenplum Database allows SSL encryption of data in transit between the Greenplum parallel
+        file distribution server, <codeph>gpfdist</codeph>, and segment hosts. See <xref
+          href="#gpfdist_connections" format="dita"/> for more information. </li>
+      <li>The <codeph>pgcrypto</codeph> package of encryption/decryptions functions protect data at
+        rest in the database. Encryption at the column level protects sensitive information, such as
+        social security numbers or credit card numbers. See <xref href="#pgcrypto" format="dita"/>
+        for more information. </li>
+    </ul>
+  </body>
+  <topic id="gpfdist_connections">
+    <title>Encrypting gpfdist Connections</title>
+    <body>
+      <p>The <codeph>gpfdists</codeph> protocol is a secure version of the <codeph>gpfdist</codeph>
+        protocol that securely identifies the file server and the Greenplum Database and encrypts
+        the communications between them. Using <codeph>gpfdists</codeph> protects against
+        eavesdropping and man-in-the-middle attacks.</p>
+      <p> The <codeph>gpfdists</codeph> protocol implements client/server SSL security with the
+        following notable features: </p>
+      <ul id="ul_yyk_vq4_kr">
+        <li>Client certificates are required. </li>
+        <li>Multilingual certificates are not supported. </li>
+        <li>A Certificate Revocation List (CRL) is not supported. </li>
+        <li>The TLSv1 protocol is used with the <codeph>TLS_RSA_WITH_AES_128_CBC_SHA</codeph>
+          encryption algorithm. These SSL parameters cannot be changed. </li>
+        <li>SSL renegotiation is supported. </li>
+        <li>The SSL ignore host mismatch parameter is set to false. </li>
+        <li>Private keys containing a passphrase are not supported for the <codeph>gpfdist</codeph>
+          file server (server.key) or for the Greenplum Database (client.key). </li>
+        <li>It is the user's responsibility to issue certificates that are appropriate for the
+          operating system in use. Generally, converting certificates to the required format is
+          supported, for example using the SSL Converter at <xref
+            href="http://www.commoncriteriaportal.org/products/?expand#ALL" format="html"
+            scope="external">https://www.sslshopper.com/ssl-converter.html</xref>. </li>
+      </ul>
+      <p>A <codeph>gpfdist</codeph> server started with the <codeph>--ssl</codeph> option can only
+        communicate with the <codeph>gpfdists</codeph> protocol. A <codeph>gpfdist</codeph> server
+        started without the <codeph>--ssl</codeph> option can only communicate with the
+          <codeph>gpfdist</codeph> protocol. For more detail about <codeph>gpfdist</codeph> refer to
+        the <i>Greenplum Database Administrator Guide</i>.</p>
+      <p>There are two ways to enable the <codeph>gpfdists</codeph> protocol: <ul id="ul_xdc_ycd_lr">
+          <li>Run <codeph>gpfdist</codeph> with the <codeph>--ssl</codeph> option and then use the
+              <codeph>gpfdists</codeph> protocol in the <codeph>LOCATION</codeph> clause of a
+              <codeph>CREATE EXTERNAL TABLE</codeph> statement. </li>
+          <li> Use a YAML control file with the SSL option set to true and run
+              <codeph>gpload</codeph>. Running <codeph>gpload</codeph> starts the
+              <codeph>gpfdist</codeph> server with the <codeph>--ssl</codeph> option and then uses
+            the <codeph>gpfdists</codeph> protocol. </li>
+        </ul></p>
+      <p> When using gpfdists, the following client certificates must be located in the
+          <codeph>$PGDATA/gpfdists</codeph> directory on each segment:</p>
+      <ul id="ul_afc_bdd_lr">
+        <li>The client certificate file, <codeph>client.crt</codeph>
+        </li>
+        <li>The client private key file, <codeph>client.key</codeph>
+        </li>
+        <li>The trusted certificate authorities, <codeph>root.crt</codeph>
+        </li>
+      </ul>
+      <note type="important"> Do not protect the private key with a passphrase. The server does not
+        prompt for a passphrase for the private key, and loading data fails with an error if one is
+        required. </note>
+      <p>When using <codeph>gpload</codeph> with SSL you specify the location of the server
+        certificates in the YAML control file. When using <codeph>gpfdist</codeph> with SSL, you
+        specify the location of the server certificates with the --ssl option. </p>
+      <p>The following example shows how to securely load data into an external table. The example
+        creates a readable external table named <codeph>ext_expenses</codeph> from all files with
+        the <codeph>txt</codeph> extension, using the <codeph>gpfdists</codeph> protocol. The files
+        are formatted with a pipe (<codeph>|</codeph>) as the column delimiter and an empty space as
+        null. <ol id="ol_wwy_j2d_lr">
+          <li>Run <codeph>gpfdist</codeph> with the <codeph>--ssl</codeph> option on the segment
+            hosts. </li>
+          <li>Log into the database and execute the following
+            command:<codeblock>
+=# CREATE EXTERNAL TABLE ext_expenses 
+   ( name text, date date, amount float4, category text, desc1 text )
+LOCATION ('gpfdists://etlhost-1:8081/*.txt', 'gpfdists://etlhost-2:8082/*.txt')
+FORMAT 'TEXT' ( DELIMITER '|' NULL ' ') ;
+</codeblock></li>
+        </ol></p>
+    </body>
+  </topic>
+  <topic id="pgcrypto">
+    <title>Encrypting Data at Rest with pgcrypto</title>
+    <body>
+      <p>The pgcrypto package for Greenplum Database provides functions for encrypting data at rest
+        in the database. Administrators can encrypt columns with sensitive information, such as
+        social security numbers or credit card numbers, to provide an extra layer of protection.
+        Database data stored in encrypted form cannot be read by users who do not have the
+        encryption key, and the data cannot be read directly from disk. </p>
+      <p>pgcrypto allows PGP encryption using symmetric and asymmetric encryption. Symmetric
+        encryption encrypts and decrypts data using the same key and is faster than asymmetric
+        encryption. It is the preferred method in an environment where exchanging secret keys is not
+        an issue. With asymmetric encryption, a public key is used to encrypt data and a private key
+        is used to decrypt data. This is slower then symmetric encryption and it requires a stronger
+        key. </p>
+      <p>Using pgcrypto always comes at the cost of performance and maintainability. It is important
+        to use encryption only with the data that requires it. Also, keep in mind that you cannot
+        search encrypted data by indexing the data. </p>
+      <p>Before you implement in-database encryption, consider the following PGP limitations.<ul
+          id="ul_ihq_xt4_kr">
+          <li> No support for signing. That also means that it is not checked whether the encryption
+            sub-key belongs to the master key.</li>
+          <li> No support for encryption key as master key. This practice is generally discouraged,
+            so this limitation should not be a problem.</li>
+          <li> No support for several subkeys. This may seem like a problem, as this is common
+            practice. On the other hand, you should not use your regular GPG/PGP keys with pgcrypto,
+            but create new ones, as the usage scenario is rather different.</li>
+        </ul></p>
+      <p>Greenplum Database is compiled with zlib by default; this allows PGP encryption functions
+        to compress data before encrypting. When compiled with OpenSSL, more algorithms will be
+        available. </p>
+      <p>Because pgcrypto functions run inside the database server, the data and passwords move
+        between pgcrypto and the client application in clear-text. For optimal security, you should
+        connect locally or use SSL connections and you should trust both the system and database
+        administrators. </p>
+      <p>pgcrypto configures itself according to the findings of the main PostgreSQL configure
+        script.</p>
+      <p>When compiled with <codeph>zlib</codeph>, pgcrypto encryption functions are able to
+        compress data before encrypting. </p>
+      <p>Pgcrypto has various levels of encryption ranging from basic to advanced built-in
+        functions. The following table shows the supported encryption algorithms.</p>
+
+      <table id="table_wzb_4fd_lr">
+        <title>Pgcrypto Supported Encryption Functions</title>
+        <tgroup cols="4">
+          <colspec colwidth="33*" align="left"/>
+          <colspec colwidth="33*" align="left"/>
+          <colspec colwidth="33*" align="left"/>
+          <thead>
+            <row>
+              <entry> Value Functionality </entry>
+              <entry> Built-in </entry>
+              <entry> With OpenSSL </entry>
+              
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry> MD5 </entry>
+              <entry> yes </entry>
+              <entry> yes </entry>
+              
+            </row>
+            <row>
+              <entry> SHA1 </entry>
+              <entry> yes </entry>
+              <entry> yes </entry>
+              
+            </row>
+            <row>
+              <entry> SHA224/256/384/512 </entry>
+              <entry> yes </entry>
+              <entry> yes <fn>SHA2 algorithms were added to OpenSSL in version 0.9.8. For older
+                  versions, pgcrypto will use built-in code.</fn></entry>
+              
+            </row>
+            <row>
+              <entry> Other digest algorithms </entry>
+              <entry> no </entry>
+              <entry> yes <fn>Any digest algorithm OpenSSL supports is automatically picked up. This
+                  is not possible with ciphers, which need to be supported explicitly.</fn></entry>
+              
+            </row>
+            <row>
+              <entry> Blowfish </entry>
+              <entry> yes </entry>
+              <entry> yes </entry>
+              
+            </row>
+            <row>
+              <entry> AES </entry>
+              <entry> yes </entry>
+              <entry> yes<fn>AES is included in OpenSSL since version 0.9.7. For older versions,
+                  pgcrypto will use built-in code.</fn></entry>
+              
+            </row>
+            <row>
+              <entry> DES/3DES/CAST5 </entry>
+              <entry> no </entry>
+              <entry> yes </entry>
+              
+            </row>
+            <row>
+              <entry> Raw Encryption </entry>
+              <entry> yes </entry>
+              <entry> yes </entry>
+              
+            </row>
+            <row>
+              <entry> PGP Symmetric-Key </entry>
+              <entry> yes </entry>
+              <entry> yes </entry>
+              
+            </row>
+            <row>
+              <entry> PGP Public Key </entry>
+              <entry> yes </entry>
+              <entry> yes </entry>
+              
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+      <section id="creating_pgp_keys">
+        <title>Creating PGP Keys</title>
+        <p>To use PGP asymmetric encryption in Greenplum Database, you must first create public and
+          private keys and install them. </p>
+        <p>This section assumes you are installing Greenplum Database on a Linux machine with the
+          Gnu Privacy Guard (<codeph>gpg</codeph>) command line tool. Use the
+          latest version of GPG to create keys. Download and install Gnu Privacy Guard (GPG) for
+          your operating system from <xref href="https://www.gnupg.org/download/" format="html"
+            scope="external"/>. On the GnuPG website you will find installers for popular Linux
+          distributions and links for Windows and Mac OS X installers. </p>
+        <ol id="ol_vnm_h54_kr">
+          <li>As root, execute the following command and choose option 1 from the
+            menu:<codeblock># gpg --gen-key 
+gpg (GnuPG) 2.0.14; Copyright (C) 2009 Free Software Foundation, Inc.
+This is free software: you are free to change and redistribute it.
+There is NO WARRANTY, to the extent permitted by law.
+ 
+gpg: directory `/root/.gnupg' created
+gpg: new configuration file `/root/.gnupg/gpg.conf' created
+gpg: WARNING: options in `/root/.gnupg/gpg.conf' are not yet active during this run
+gpg: keyring `/root/.gnupg/secring.gpg' created
+gpg: keyring `/root/.gnupg/pubring.gpg' created
+Please select what kind of key you want:
+ (1) RSA and RSA (default)
+ (2) DSA and Elgamal
+ (3) DSA (sign only)
+ (4) RSA (sign only)
+Your selection? <b>1</b></codeblock></li>
+          <li>Respond to the prompts and follow the instructions, as shown in this
+            example:<codeblock>RSA keys may be between 1024 and 4096 bits long.
+What keysize do you want? (2048) Press enter to accept default key size
+Requested keysize is 2048 bits
+Please specify how long the key should be valid.
+ 0 = key does not expire
+ &lt;n&gt; = key expires in n days
+ &lt;n&gt;w = key expires in n weeks
+ &lt;n&gt;m = key expires in n months
+ &lt;n&gt;y = key expires in n years
+ Key is valid for? (0) <b>365</b>
+Key expires at Wed 13 Jan 2016 10:35:39 AM PST
+Is this correct? (y/N) <b>y</b>
+
+GnuPG needs to construct a user ID to identify your key.
+
+Real name: <b>John Doe</b>
+Email address: <b>jdoe@email.com</b>
+Comment: 
+You selected this USER-ID:
+ "John Doe &lt;jdoe@email.com&gt;"
+
+Change (N)ame, (C)omment, (E)mail or (O)kay/(Q)uit? <b>O</b>
+You need a Passphrase to protect your secret key.
+<i>(For this demo the passphrase is blank.)</i>
+can't connect to `/root/.gnupg/S.gpg-agent': No such file or directory
+You don't want a passphrase - this is probably a *bad* idea!
+I will do it anyway.  You can change your passphrase at any time,
+using this program with the option "--edit-key".
+
+We need to generate a lot of random bytes. It is a good idea to perform
+some other action (type on the keyboard, move the mouse, utilize the
+disks) during the prime generation; this gives the random number
+generator a better chance to gain enough entropy.
+We need to generate a lot of random bytes. It is a good idea to perform
+some other action (type on the keyboard, move the mouse, utilize the
+disks) during the prime generation; this gives the random number
+generator a better chance to gain enough entropy.
+gpg: /root/.gnupg/trustdb.gpg: trustdb created
+gpg: key 2027CC30 marked as ultimately trusted
+public and secret key created and signed.
+
+gpg:  checking the trustdbgpg: 
+      3 marginal(s) needed, 1 complete(s) needed, PGP trust model
+gpg:  depth: 0  valid:   1  signed:   0  trust: 0-, 0q, 0n, 0m, 0f, 1u
+gpg:  next trustdb check due at 2016-01-13
+pub   2048R/2027CC30 2015-01-13 [expires: 2016-01-13]
+      Key fingerprint = 7EDA 6AD0 F5E0 400F 4D45   3259 077D 725E 2027 CC30
+uid                  John Doe &lt;jdoe@email.com>
+sub   2048R/4FD2EFBB 2015-01-13 [expires: 2016-01-13]
+</codeblock></li>
+          <li>List the PGP keys by entering the following
+              command:<codeblock>gpg --list-secret-keys 
+/root/.gnupg/secring.gpg
+------------------------
+sec   2048R/2027CC30 2015-01-13 [expires: 2016-01-13]
+uid                  John Doe &lt;jdoe@email.com&gt;
+ssb   2048R/4FD2EFBB 2015-01-13
+
+</codeblock><p>2027CC30
+              is the public key and will be used to <i>encrypt</i> data in the database. 4FD2EFBB is
+              the private (secret) key and will be used to <i>decrypt</i> data.</p></li>
+          <li>Export the keys using the following
+            commands:<codeblock># gpg -a --export 4FD2EFBB &gt; public.key
+# gpg -a --export-secret-keys 2027CC30 &gt; secret.key</codeblock></li>
+        </ol>
+        <p>See the <xref href="http://www.postgresql.org/docs/8.3/static/pgcrypto.html"
+            format="html" scope="external">pgcrypto</xref> documentation for for more information
+          about PGP encryption functions. </p>
+      </section>
+      <section>
+        <title>Encrypting Data in Tables using PGP</title>
+        <p>This section shows how to encrypt data inserted into a column using the PGP keys you
+          generated. </p>
+        <ol id="ol_nty_qzd_lr">
+          <li>Dump the contents of the <codeph>public.key</codeph> file and then copy it to the
+            clipboard:<codeblock># cat public.key
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+Version: GnuPG v2.0.14 (GNU/Linux)
+            
+mQENBFS1Zf0BCADNw8Qvk1V1C36Kfcwd3Kpm/dijPfRyyEwB6PqKyA05jtWiXZTh
+2His1ojSP6LI0cSkIqMU9LAlncecZhRIhBhuVgKlGSgd9texg2nnSL9Admqik/yX
+R5syVKG+qcdWuvyZg9oOOmeyjhc3n+kkbRTEMuM3flbMs8shOwzMvstCUVmuHU/V
+vG5rJAe8PuYDSJCJ74I6w7SOH3RiRIc7IfL6xYddV42l3ctd44bl8/i71hq2UyN2
+/Hbsjii2ymg7ttw3jsWAx2gP9nssDgoy8QDy/o9nNqC8EGlig96ZFnFnE6Pwbhn+
+ic8MD0lK5/GAlR6Hc0ZIHf8KEcavruQlikjnABEBAAG0HHRlc3Qga2V5IDx0ZXN0
+a2V5QGVtYWlsLmNvbT6JAT4EEwECACgFAlS1Zf0CGwMFCQHhM4AGCwkIBwMCBhUI
+AgkKCwQWAgMBAh4BAheAAAoJEAd9cl4gJ8wwbfwH/3VyVsPkQl1owRJNxvXGt1bY
+7BfrvU52yk+PPZYoes9UpdL3CMRk8gAM9bx5Sk08q2UXSZLC6fFOpEW4uWgmGYf8
+JRoC3ooezTkmCBW8I1bU0qGetzVxopdXLuPGCE7hVWQe9HcSntiTLxGov1mJAwO7
+TAoccXLbyuZh9Rf5vLoQdKzcCyOHh5IqXaQOT100TeFeEpb9TIiwcntg3WCSU5P0
+DGoUAOanjDZ3KE8Qp7V74fhG1EZVzHb8FajR62CXSHFKqpBgiNxnTOk45NbXADn4
+eTUXPSnwPi46qoAp9UQogsfGyB1XDOTB2UOqhutAMECaM7VtpePv79i0Z/NfnBe5
+AQ0EVLVl/QEIANabFdQ+8QMCADOipM1bF/JrQt3zUoc4BTqICaxdyzAfz0tUSf/7
+Zro2us99GlARqLWd8EqJcl/xmfcJiZyUam6ZAzzFXCgnH5Y1sdtMTJZdLp5WeOjw
+gCWG/ZLu4wzxOFFzDkiPv9RDw6e5MNLtJrSp4hS5o2apKdbO4Ex83O4mJYnav/rE
+iDDCWU4T0lhv3hSKCpke6LcwsX+7liozp+aNmP0Ypwfi4hR3UUMP70+V1beFqW2J
+bVLz3lLLouHRgpCzla+PzzbEKs16jq77vG9kqZTCIzXoWaLljuitRlfJkO3vQ9hO
+v/8yAnkcAmowZrIBlyFg2KBzhunYmN2YvkUAEQEAAYkBJQQYAQIADwUCVLVl/QIb
+DAUJAeEzgAAKCRAHfXJeICfMMOHYCACFhInZA9uAM3TC44l+MrgMUJ3rW9izrO48
+WrdTsxR8WkSNbIxJoWnYxYuLyPb/shc9k65huw2SSDkj//0fRrI61FPHQNPSvz62
+WH+N2lasoUaoJjb2kQGhLOnFbJuevkyBylRz+hI/+8rJKcZOjQkmmK8Hkk8qb5x/
+HMUc55H0g2qQAY0BpnJHgOOQ45Q6pk3G2/7Dbek5WJ6K1wUrFy51sNlGWE8pvgEx
+/UUZB+dYqCwtvX0nnBu1KNCmk2AkEcFK3YoliCxomdOxhFOv9AKjjojDyC65KJci
+Pv2MikPS2fKOAg1R3LpMa8zDEtl4w3vckPQNrQNnYuUtfj6ZoCxv
+=XZ8J
+-----END PGP PUBLIC KEY BLOCK-----
+</codeblock></li>
+          <li>Create a table called <codeph>userssn</codeph> and insert some sensitive data, social
+            security numbers for Bob and Alice, in this example. Paste the public.key contents after
+            "dearmor(".
+            <codeblock>CREATE TABLE userssn( ssn_id SERIAL PRIMARY KEY, 
+    username varchar(100), ssn bytea); 
+
+INSERT INTO userssn(username, ssn)
+SELECT robotccs.username, pgp_pub_encrypt(robotccs.ssn, keys.pubkey) AS ssn
+FROM ( 
+        VALUES ('Alice', '123-45-6788'), ('Bob', '123-45-6799')) 
+            AS robotccs(username, ssn)
+CROSS JOIN  (SELECT  dearmor('-----BEGIN PGP PUBLIC KEY BLOCK-----
+Version: GnuPG v2.0.14 (GNU/Linux)
+            
+mQENBFS1Zf0BCADNw8Qvk1V1C36Kfcwd3Kpm/dijPfRyyEwB6PqKyA05jtWiXZTh
+2His1ojSP6LI0cSkIqMU9LAlncecZhRIhBhuVgKlGSgd9texg2nnSL9Admqik/yX
+R5syVKG+qcdWuvyZg9oOOmeyjhc3n+kkbRTEMuM3flbMs8shOwzMvstCUVmuHU/V
+vG5rJAe8PuYDSJCJ74I6w7SOH3RiRIc7IfL6xYddV42l3ctd44bl8/i71hq2UyN2
+/Hbsjii2ymg7ttw3jsWAx2gP9nssDgoy8QDy/o9nNqC8EGlig96ZFnFnE6Pwbhn+
+ic8MD0lK5/GAlR6Hc0ZIHf8KEcavruQlikjnABEBAAG0HHRlc3Qga2V5IDx0ZXN0
+a2V5QGVtYWlsLmNvbT6JAT4EEwECACgFAlS1Zf0CGwMFCQHhM4AGCwkIBwMCBhUI
+AgkKCwQWAgMBAh4BAheAAAoJEAd9cl4gJ8wwbfwH/3VyVsPkQl1owRJNxvXGt1bY
+7BfrvU52yk+PPZYoes9UpdL3CMRk8gAM9bx5Sk08q2UXSZLC6fFOpEW4uWgmGYf8
+JRoC3ooezTkmCBW8I1bU0qGetzVxopdXLuPGCE7hVWQe9HcSntiTLxGov1mJAwO7
+TAoccXLbyuZh9Rf5vLoQdKzcCyOHh5IqXaQOT100TeFeEpb9TIiwcntg3WCSU5P0
+DGoUAOanjDZ3KE8Qp7V74fhG1EZVzHb8FajR62CXSHFKqpBgiNxnTOk45NbXADn4
+eTUXPSnwPi46qoAp9UQogsfGyB1XDOTB2UOqhutAMECaM7VtpePv79i0Z/NfnBe5
+AQ0EVLVl/QEIANabFdQ+8QMCADOipM1bF/JrQt3zUoc4BTqICaxdyzAfz0tUSf/7
+Zro2us99GlARqLWd8EqJcl/xmfcJiZyUam6ZAzzFXCgnH5Y1sdtMTJZdLp5WeOjw
+gCWG/ZLu4wzxOFFzDkiPv9RDw6e5MNLtJrSp4hS5o2apKdbO4Ex83O4mJYnav/rE
+iDDCWU4T0lhv3hSKCpke6LcwsX+7liozp+aNmP0Ypwfi4hR3UUMP70+V1beFqW2J
+bVLz3lLLouHRgpCzla+PzzbEKs16jq77vG9kqZTCIzXoWaLljuitRlfJkO3vQ9hO
+v/8yAnkcAmowZrIBlyFg2KBzhunYmN2YvkUAEQEAAYkBJQQYAQIADwUCVLVl/QIb
+DAUJAeEzgAAKCRAHfXJeICfMMOHYCACFhInZA9uAM3TC44l+MrgMUJ3rW9izrO48
+WrdTsxR8WkSNbIxJoWnYxYuLyPb/shc9k65huw2SSDkj//0fRrI61FPHQNPSvz62
+WH+N2lasoUaoJjb2kQGhLOnFbJuevkyBylRz+hI/+8rJKcZOjQkmmK8Hkk8qb5x/
+HMUc55H0g2qQAY0BpnJHgOOQ45Q6pk3G2/7Dbek5WJ6K1wUrFy51sNlGWE8pvgEx
+/UUZB+dYqCwtvX0nnBu1KNCmk2AkEcFK3YoliCxomdOxhFOv9AKjjojDyC65KJci
+Pv2MikPS2fKOAg1R3LpMa8zDEtl4w3vckPQNrQNnYuUtfj6ZoCxv
+=XZ8J
+-----END PGP PUBLIC KEY BLOCK-----' AS pubkey) AS keys;
+</codeblock></li>
+          <li>Verify that the <codeph>ssn</codeph> column is
+            encrypted.<codeblock>test_db=# select * from userssn;
+ssn_id   | 1
+username | Alice
+ssn      | \301\300L\003\235M%_O\322\357\273\001\010\000\272\227\010\341\216\360\217C\020\261)_\367
+[\227\034\313:C\354d&lt;\337\006Q\351('\2330\031lX\263Qf\341\262\200\3015\235\036AK\242fL+\315g\322
+7u\270*\304\361\355\220\021\330"\200%\264\274}R\213\377\363\235\366\030\023)\364!\331\303\237t\277=
+f \015\004\242\231\263\225%\032\271a\001\035\277\021\375X\232\304\305/\340\334\0131\325\344[~\362\0
+37-\251\336\303\340\377_\011\275\301/MY\334\343\245\244\372y\257S\374\230\346\277\373W\346\230\276\
+017fi\226Q\307\012\326\3646\000\326\005:E\364W\252=zz\010(:\343Y\237\257iqU\0326\350=v0\362\327\350\
+315G^\027:K_9\254\362\354\215&lt;\001\304\357\331\355\323,\302\213Fe\265\315\232\367\254\245%(\\\373
+4\254\230\331\356\006B\257\333\326H\022\013\353\216F?\023\220\370\035vH5/\227\344b\322\227\026\362=\
+42\033\322&lt;\001}\243\224;)\030zqX\214\340\221\035\275U\345\327\214\032\351\223c\2442\345\304K\016\
+011\214\307\227\237\270\026`R\205\205a~1\263\236[\037C\260\031\205\374\245\317\033k|\366\253\037
+---------+--------------------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------
+------------------------------------------------------------------------------
+ssn_id   | 2
+username | Bob
+ssn      | \301\300L\003\235M%_O\322\357\273\001\007\377t>\345\343,\200\256\272\300\012\033M4\265\032L
+L[v\262k\244\2435\264\232B\357\370d9\375\011\002\327\235&lt;\246\210b\030\012\337@\226Z\361\246\032\00
+7`\012c\353]\355d7\360T\335\314\367\370;X\371\350*\231\212\260B\010#RQ0\223\253c7\0132b\355\242\233\34
+1\000\370\370\366\013\022\357\005i\202~\005\\z\301o\012\230Z\014\362\244\324&amp;\243g\351\362\325\375
+\213\032\226$\2751\256XR\346k\266\030\234\267\201vUh\004\250\337A\231\223u\247\366/i\022\275\276\350\2
+20\316\306|\203+\010\261;\232\254tp\255\243\261\373Rq;\316w\357\006\207\374U\333\365\365\245hg\031\005
+\322\347ea\220\015l\212g\337\264\336b\263\004\311\210.4\340G+\221\274D\035\375\2216\241`\346a0\273wE\2
+12\342y^\202\262|A7\202t\240\333p\345G\373\253\243oCO\011\360\247\211\014\024{\272\271\322&lt;\001\267
+\347\240\005\213\0078\036\210\307$\317\322\311\222\035\354\006&lt;\266\264\004\376\251q\256\220(+\030\
+3270\013c\327\272\212%\363\033\252\322\337\354\276\225\232\201\212^\304\210\2269@\3230\370{
+</codeblock></li>
+          <li>Extract the public.key ID from the database: <codeblock>SELECT pgp_key_id(dearmor('-----BEGIN PGP PUBLIC KEY BLOCK-----
+Version: GnuPG v2.0.14 (GNU/Linux)
+
+mQENBFS1Zf0BCADNw8Qvk1V1C36Kfcwd3Kpm/dijPfRyyEwB6PqKyA05jtWiXZTh
+2His1ojSP6LI0cSkIqMU9LAlncecZhRIhBhuVgKlGSgd9texg2nnSL9Admqik/yX
+R5syVKG+qcdWuvyZg9oOOmeyjhc3n+kkbRTEMuM3flbMs8shOwzMvstCUVmuHU/V
+vG5rJAe8PuYDSJCJ74I6w7SOH3RiRIc7IfL6xYddV42l3ctd44bl8/i71hq2UyN2
+/Hbsjii2ymg7ttw3jsWAx2gP9nssDgoy8QDy/o9nNqC8EGlig96ZFnFnE6Pwbhn+
+ic8MD0lK5/GAlR6Hc0ZIHf8KEcavruQlikjnABEBAAG0HHRlc3Qga2V5IDx0ZXN0
+a2V5QGVtYWlsLmNvbT6JAT4EEwECACgFAlS1Zf0CGwMFCQHhM4AGCwkIBwMCBhUI
+AgkKCwQWAgMBAh4BAheAAAoJEAd9cl4gJ8wwbfwH/3VyVsPkQl1owRJNxvXGt1bY
+7BfrvU52yk+PPZYoes9UpdL3CMRk8gAM9bx5Sk08q2UXSZLC6fFOpEW4uWgmGYf8
+JRoC3ooezTkmCBW8I1bU0qGetzVxopdXLuPGCE7hVWQe9HcSntiTLxGov1mJAwO7
+TAoccXLbyuZh9Rf5vLoQdKzcCyOHh5IqXaQOT100TeFeEpb9TIiwcntg3WCSU5P0
+DGoUAOanjDZ3KE8Qp7V74fhG1EZVzHb8FajR62CXSHFKqpBgiNxnTOk45NbXADn4
+eTUXPSnwPi46qoAp9UQogsfGyB1XDOTB2UOqhutAMECaM7VtpePv79i0Z/NfnBe5
+AQ0EVLVl/QEIANabFdQ+8QMCADOipM1bF/JrQt3zUoc4BTqICaxdyzAfz0tUSf/7
+Zro2us99GlARqLWd8EqJcl/xmfcJiZyUam6ZAzzFXCgnH5Y1sdtMTJZdLp5WeOjw
+gCWG/ZLu4wzxOFFzDkiPv9RDw6e5MNLtJrSp4hS5o2apKdbO4Ex83O4mJYnav/rE
+iDDCWU4T0lhv3hSKCpke6LcwsX+7liozp+aNmP0Ypwfi4hR3UUMP70+V1beFqW2J
+bVLz3lLLouHRgpCzla+PzzbEKs16jq77vG9kqZTCIzXoWaLljuitRlfJkO3vQ9hO
+v/8yAnkcAmowZrIBlyFg2KBzhunYmN2YvkUAEQEAAYkBJQQYAQIADwUCVLVl/QIb
+DAUJAeEzgAAKCRAHfXJeICfMMOHYCACFhInZA9uAM3TC44l+MrgMUJ3rW9izrO48
+WrdTsxR8WkSNbIxJoWnYxYuLyPb/shc9k65huw2SSDkj//0fRrI61FPHQNPSvz62
+WH+N2lasoUaoJjb2kQGhLOnFbJuevkyBylRz+hI/+8rJKcZOjQkmmK8Hkk8qb5x/
+HMUc55H0g2qQAY0BpnJHgOOQ45Q6pk3G2/7Dbek5WJ6K1wUrFy51sNlGWE8pvgEx
+/UUZB+dYqCwtvX0nnBu1KNCmk2AkEcFK3YoliCxomdOxhFOv9AKjjojDyC65KJci
+Pv2MikPS2fKOAg1R3LpMa8zDEtl4w3vckPQNrQNnYuUtfj6ZoCxv
+=XZ8J
+-----END PGP PUBLIC KEY BLOCK-----'));
+
+pgp_key_id | 9D4D255F4FD2EFBB
+</codeblock>
+            <p>This shows that the PGP key ID used to encrypt the <codeph>ssn</codeph> column is
+              9D4D255F4FD2EFBB. It is recommended to perform this step whenever a new key is created
+              and then store the ID for tracking. </p><p>You can use this key to see which key pair
+              was used to encrypt the data:</p>
+            <codeblock>SELECT username, pgp_key_id(ssn) As key_used
+FROM userssn;
+username | Bob
+key_used | 9D4D255F4FD2EFBB
+---------+-----------------
+username | Alice
+key_used | 9D4D255F4FD2EFBB
+</codeblock>
+            <note>Different keys may have the same ID. This is rare, but is a normal event. The
+              client application should try to decrypt with each one to see which fits — like
+              handling <codeph>ANYKEY</codeph>. See <xref
+                href="http://www.postgresql.org/docs/8.3/static/pgcrypto.html" format="html"
+                scope="external">pgp_key_id()</xref> in the pgcrypto documentation. </note>
+          </li>
+          <li>Decrypt the data using the private key.
+              <codeblock>SELECT username, pgp_pub_decrypt(ssn, keys.privkey) 
+                 AS decrypted_ssn FROM userssn
+                 CROSS JOIN
+                 (SELECT dearmor('-----BEGIN PGP PRIVATE KEY BLOCK-----
+Version: GnuPG v2.0.14 (GNU/Linux)
+
+lQOYBFS1Zf0BCADNw8Qvk1V1C36Kfcwd3Kpm/dijPfRyyEwB6PqKyA05jtWiXZTh
+2His1ojSP6LI0cSkIqMU9LAlncecZhRIhBhuVgKlGSgd9texg2nnSL9Admqik/yX
+R5syVKG+qcdWuvyZg9oOOmeyjhc3n+kkbRTEMuM3flbMs8shOwzMvstCUVmuHU/V
+vG5rJAe8PuYDSJCJ74I6w7SOH3RiRIc7IfL6xYddV42l3ctd44bl8/i71hq2UyN2
+/Hbsjii2ymg7ttw3jsWAx2gP9nssDgoy8QDy/o9nNqC8EGlig96ZFnFnE6Pwbhn+
+ic8MD0lK5/GAlR6Hc0ZIHf8KEcavruQlikjnABEBAAEAB/wNfjjvP1brRfjjIm/j
+XwUNm+sI4v2Ur7qZC94VTukPGf67lvqcYZJuqXxvZrZ8bl6mvl65xEUiZYy7BNA8
+fe0PaM4Wy+Xr94Cz2bPbWgawnRNN3GAQy4rlBTrvqQWy+kmpbd87iTjwZidZNNmx
+02iSzraq41Rt0Zx21Jh4rkpF67ftmzOH0vlrS0bWOvHUeMY7tCwmdPe9HbQeDlPr
+n9CllUqBn4/acTtCClWAjREZn0zXAsNixtTIPC1V+9nO9YmecMkVwNfIPkIhymAM
+OPFnuZ/Dz1rCRHjNHb5j6ZyUM5zDqUVnnezktxqrOENSxm0gfMGcpxHQogUMzb7c
+6UyBBADSCXHPfo/VPVtMm5p1yGrNOR2jR2rUj9+poZzD2gjkt5G/xIKRlkB4uoQl
+emu27wr9dVEX7ms0nvDq58iutbQ4d0JIDlcHMeSRQZluErblB75Vj3HtImblPjpn
+4Jx6SWRXPUJPGXGI87u0UoBH0Lwij7M2PW7l1ao+MLEA9jAjQwQA+sr9BKPL4Ya2
+r5nE72gsbCCLowkC0rdldf1RGtobwYDMpmYZhOaRKjkOTMG6rCXJxrf6LqiN8w/L
+/gNziTmch35MCq/MZzA/bN4VMPyeIlwzxVZkJLsQ7yyqX/A7ac7B7DH0KfXciEXW
+MSOAJhMmklW1Q1RRNw3cnYi8w3q7X40EAL/w54FVvvPqp3+sCd86SAAapM4UO2R3
+tIsuNVemMWdgNXwvK8AJsz7VreVU5yZ4B8hvCuQj1C7geaN/LXhiT8foRsJC5o71
+Bf+iHC/VNEv4k4uDb4lOgnHJYYyifB1wC+nn/EnXCZYQINMia1a4M6Vqc/RIfTH4
+nwkZt/89LsAiR/20HHRlc3Qga2V5IDx0ZXN0a2V5QGVtYWlsLmNvbT6JAT4EEwEC
+ACgFAlS1Zf0CGwMFCQHhM4AGCwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEAd9
+cl4gJ8wwbfwH/3VyVsPkQl1owRJNxvXGt1bY7BfrvU52yk+PPZYoes9UpdL3CMRk
+8gAM9bx5Sk08q2UXSZLC6fFOpEW4uWgmGYf8JRoC3ooezTkmCBW8I1bU0qGetzVx
+opdXLuPGCE7hVWQe9HcSntiTLxGov1mJAwO7TAoccXLbyuZh9Rf5vLoQdKzcCyOH
+h5IqXaQOT100TeFeEpb9TIiwcntg3WCSU5P0DGoUAOanjDZ3KE8Qp7V74fhG1EZV
+zHb8FajR62CXSHFKqpBgiNxnTOk45NbXADn4eTUXPSnwPi46qoAp9UQogsfGyB1X
+DOTB2UOqhutAMECaM7VtpePv79i0Z/NfnBedA5gEVLVl/QEIANabFdQ+8QMCADOi
+pM1bF/JrQt3zUoc4BTqICaxdyzAfz0tUSf/7Zro2us99GlARqLWd8EqJcl/xmfcJ
+iZyUam6ZAzzFXCgnH5Y1sdtMTJZdLp5WeOjwgCWG/ZLu4wzxOFFzDkiPv9RDw6e5
+MNLtJrSp4hS5o2apKdbO4Ex83O4mJYnav/rEiDDCWU4T0lhv3hSKCpke6LcwsX+7
+liozp+aNmP0Ypwfi4hR3UUMP70+V1beFqW2JbVLz3lLLouHRgpCzla+PzzbEKs16
+jq77vG9kqZTCIzXoWaLljuitRlfJkO3vQ9hOv/8yAnkcAmowZrIBlyFg2KBzhunY
+mN2YvkUAEQEAAQAH/A7r4hDrnmzX3QU6FAzePlRB7niJtE2IEN8AufF05Q2PzKU/
+c1S72WjtqMAIAgYasDkOhfhcxanTneGuFVYggKT3eSDm1RFKpRjX22m0zKdwy67B
+Mu95V2Oklul6OCm8dO6+2fmkGxGqc4ZsKy+jQxtxK3HG9YxMC0dvA2v2C5N4TWi3
+Utc7zh//k6IbmaLd7F1d7DXt7Hn2Qsmo8I1rtgPE8grDToomTnRUodToyejEqKyI
+ORwsp8n8g2CSFaXSrEyU6HbFYXSxZealhQJGYLFOZdR0MzVtZQCn/7n+IHjupndC
+Nd2a8DVx3yQS3dAmvLzhFacZdjXi31wvj0moFOkEAOCz1E63SKNNksniQ11lRMJp
+gaov6Ux/zGLMstwTzNouI+Kr8/db0GlSAy1Z3UoAB4tFQXEApoX9A4AJ2KqQjqOX
+cZVULenfDZaxrbb9Lid7ZnTDXKVyGTWDF7ZHavHJ4981mCW17lU11zHBB9xMlx6p
+dhFvb0gdy0jSLaFMFr/JBAD0fz3RrhP7e6Xll2zdBqGthjC5S/IoKwwBgw6ri2yx
+LoxqBr2pl9PotJJ/JUMPhD/LxuTcOZtYjy8PKgm5jhnBDq3Ss0kNKAY1f5EkZG9a
+6I4iAX/NekqSyF+OgBfC9aCgS5RG8hYoOCbp8na5R3bgiuS8IzmVmm5OhZ4MDEwg
+nQP7BzmR0p5BahpZ8r3Ada7FcK+0ZLLRdLmOYF/yUrZ53SoYCZRzU/GmtQ7LkXBh
+Gjqied9Bs1MHdNUolq7GaexcjZmOWHEf6w9+9M4+vxtQq1nkIWqtaphewEmd5/nf
+EP3sIY0EAE3mmiLmHLqBju+UJKMNwFNeyMTqgcg50ISH8J9FRIkBJQQYAQIADwUC
+VLVl/QIbDAUJAeEzgAAKCRAHfXJeICfMMOHYCACFhInZA9uAM3TC44l+MrgMUJ3r
+W9izrO48WrdTsxR8WkSNbIxJoWnYxYuLyPb/shc9k65huw2SSDkj//0fRrI61FPH
+QNPSvz62WH+N2lasoUaoJjb2kQGhLOnFbJuevkyBylRz+hI/+8rJKcZOjQkmmK8H
+kk8qb5x/HMUc55H0g2qQAY0BpnJHgOOQ45Q6pk3G2/7Dbek5WJ6K1wUrFy51sNlG
+WE8pvgEx/UUZB+dYqCwtvX0nnBu1KNCmk2AkEcFK3YoliCxomdOxhFOv9AKjjojD
+yC65KJciPv2MikPS2fKOAg1R3LpMa8zDEtl4w3vckPQNrQNnYuUtfj6ZoCxv
+=fa+6
+-----END PGP PRIVATE KEY BLOCK-----') AS privkey) AS keys;
+
+username | decrypted_ssn 
+----------+---------------
+ Alice    | 123-45-6788
+ Bob      | 123-45-6799
+(2 rows)
+
+</codeblock><p>If
+              you created a key with passphrase, you may have to enter it here. However for the
+              purpose of this example, the passphrase is blank. </p></li>
+        </ol>
+
+
+      </section>
+      <section>
+        <title>Key Management</title>
+        <p>Whether you are using symmetric (single private key) or asymmetric (public and private
+          key) cryptography, it is important to store the master or private key securely. There are
+          many options for storing encryption keys, for example, on a file system, key vault,
+          encrypted USB, trusted platform module (TPM), or hardware security module (HSM). </p>
+        <p>Consider the following questions when planning for key management:</p>
+        <ul id="ul_vqd_sl2_lr">
+          <li> Where will the keys be stored?</li>
+          <li> When should keys expire?</li>
+          <li> How are keys protected?</li>
+          <li> How are keys accessed?</li>
+          <li> How can keys be recovered and revoked?</li>
+        </ul>
+        <p>The Open Web Application Security Project (OWASP) provides a very comprehensive <xref
+            href="https://www.owasp.org/index.php/Cryptographic_Storage_Cheat_Sheet" format="html"
+            scope="external">guide to securing encryption keys</xref>.</p>
+      </section>
+    </body>
+  </topic>
+
+</topic>

--- a/gpdb-doc/dita/security-guide/topics/SecuringGPDB.xml
+++ b/gpdb-doc/dita/security-guide/topics/SecuringGPDB.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="topic_iqr_ym2_jr">
+  <title>Securing the Database</title>
+  <body>
+    <p>The intent of security configuration is to configure the Greenplum Database server to
+      eliminate as many security vulnerabilities as possible. This guide provides a baseline for
+      minimum security requirements, and is supplemented by additional security documentation. </p>
+    <p>The essential security requirements fall into the following categories: <ul
+        id="ul_fwy_bn2_jr">
+        <li><xref href="Authenticate.xml#topic_n5w_gtd_jr">Authentication</xref> covers the
+          mechanisms that are supported and that can be used by the Greenplum database server to
+          establish the identity of a client application.</li>
+        <li><xref href="Authorization.xml#topic_ivr_cs2_jr">Authorization</xref> pertains to the
+          privilege and permission models used by the database to authorize client access. </li>
+        <li><xref href="Auditing.xml#topic_ufw_zn2_jr">Auditing</xref>, or log settings, covers the
+          logging options available in Greenplum Database to track successful or failed user
+          actions.</li>
+        <li><xref href="Encryption.xml#topic_th5_5bf_jr">Data Encryption</xref> addresses the
+          encryption capabilities that are available for protecting data at rest and data in
+          transit. This includes the security certifications that are relevant to the Greenplum
+          Database. </li>
+      </ul></p>
+    <section>
+      <title>Accessing a Kerberized Hadoop Cluster</title>
+      <p>Greenplum Database can read or write external tables in a Hadoop file system. If the Hadoop
+        cluster is secured with Kerberos ("Kerberized"), Greenplum Database must be configured to
+        allow external table owners to authenticate with Kerberos. See <xref
+          href="kerberos-hdfs.xml#topic_lhr_yrf_qr"/> for the steps to perform this setup. </p>
+    </section>
+    <section>
+      <title>Platform Hardening</title>
+      <p>Platform hardening involves assessing and minimizing system vulnerability by following best
+        practices and enforcing federal security standards. Hardening the product is based on the US
+        Department of Defense (DoD) guidelines Security Template Implementation Guides (STIG).
+        Hardening removes unnecessary packages, disables services that are not required, sets up
+        restrictive file and directory permissions, removes unowned files and directories, performs
+        authentication for single-user mode, and provides options for end users to configure the
+        package to be compliant to the latest STIGs.  </p>
+    </section>
+  </body>
+</topic>

--- a/gpdb-doc/dita/security-guide/topics/gpcc.xml
+++ b/gpdb-doc/dita/security-guide/topics/gpcc.xml
@@ -4,81 +4,122 @@
   <title>Greenplum Command Center Security</title>
   <body>
     <p>Greenplum Command Center (GPCC) is a web-based application for monitoring and managing
-      Greenplum clusters. GPCC works with data collected by agents running on the segment hosts
-      and saved to the gpperfmon database. The gpperfmon database is created by running the
-      <codeph>gpperfmon_install</codeph> utility, which also creates the <codeph>gpmon</codeph>
+      Greenplum clusters. GPCC works with data collected by agents running on the segment hosts and
+      saved to the gpperfmon database. The gpperfmon database is created by running the
+        <codeph>gpperfmon_install</codeph> utility, which also creates the <codeph>gpmon</codeph>
       database role that GPCC uses to access the gpperfmon database. </p>
     <section>
       <title>The gpmon User</title>
-      <p>The <codeph>gpperfmon_install</codeph> utility creates the <codeph>gpmon</codeph>
-        database role and adds the role to the <codeph>pg_hba.conf</codeph> file with the
-        following
-        entries:<codeblock>local    gpperfmon   gpmon                         md5
-host     all         gpmon         127.0.0.1/28    md5</codeblock>These
-        entries allow <codeph>gpmon</codeph> to establish a local socket connection to the
-        gpperfmon database and a TCP/IP connection to any database. </p>
+      <p>The <codeph>gpperfmon_install</codeph> utility creates the <codeph>gpmon</codeph> database
+        role and adds the role to the <codeph>pg_hba.conf</codeph> file with the following
+        entries:<codeblock>local    gpperfmon   gpmon         md5
+host     all         gpmon         127.0.0.1/28    md5
+host     all         gpmon         ::1/128         md5</codeblock>These
+        entries allow <codeph>gpmon</codeph> to establish a local socket connection to the gpperfmon
+        database and a TCP/IP connection to any database. </p>
       <p>The <codeph>gpmon</codeph> database role is a superuser. In a secure or production
         environment, it may be desirable to restrict the <codeph>gpmon</codeph> user to just the
         gpperfmon database. Do this by editing the <codeph>gpmon</codeph> host entry in the
-        <codeph>pg_hba.conf</codeph> file and changing <codeph>all</codeph> in the database
-        field to
+          <codeph>pg_hba.conf</codeph> file and changing <codeph>all</codeph> in the database field
+        to
         <codeph>gpperfmon</codeph>:<codeblock>local   gpperfmon   gpmon                        md5
-host    gpperfmon   gpmon    127.0.0.1/28        md5</codeblock></p>
+host    gpperfmon   gpmon    127.0.0.1/28        md5
+host    gpperfmon   gpmon    ::1/128             md5</codeblock></p>
       <p>The password used to authenticate the <codeph>gpmon</codeph> user is set by the
-        <codeph>gpperfmon_install</codeph> utility and is stored in the <codeph>gpadmin</codeph>
+          <codeph>gpperfmon_install</codeph> utility and is stored in the <codeph>gpadmin</codeph>
         home directory in the <codeph>~/.pgpass</codeph> file. The <codeph>~/.pgpass</codeph> file
-        must be owned by the <codeph>gpadmin</codeph> user and RW-accessible only by the
-        <codeph>gpadmin</codeph> user. To change the <codeph>gpmon</codeph> password, use the
-        <codeph>ALTER ROLE</codeph> command to change the password in the database, change the
+        must be owned by the <codeph>gpadmin</codeph> user and be RW-accessible only by the
+          <codeph>gpadmin</codeph> user. To change the <codeph>gpmon</codeph> password, use the
+          <codeph>ALTER ROLE</codeph> command to change the password in the database, change the
         password in the <codeph>~/.pgpass</codeph> file, and then restart GPCC with the
-        <codeph>gpcmdr --restart <varname>instance_name</varname></codeph> command. </p>
+          <codeph>gpcmdr --restart <varname>instance_name</varname></codeph> command. </p>
       <note>The GPCC web server can be configured to encrypt connections with SSL. Two-way
         authentication with public keys can also be enabled for GPCC users. However, the
-        <codeph>gpmon</codeph> user always uses md5 authentication with the password saved in
-        the <codeph>~/.pgpass</codeph> file. </note>
+          <codeph>gpmon</codeph> user always uses md5 authentication with the password saved in the
+          <codeph>~/.pgpass</codeph> file.</note>
       <p>GPCC does not allow logins from any role configured with trust authentication, including
         the <codeph>gpadmin</codeph> user. </p>
-      <p>The <codeph>gpmon</codeph> user can log in to the Command Center Console and has access
-        to all of the application's features. You can allow other database roles access to GPCC so
-        that you can secure the <codeph>gpmon</codeph> user and restrict other users' access to
-        GPCC features. Setting up other GPCC users is described in the next section. </p>
+      <p>The <codeph>gpmon</codeph> user can log in to the Command Center Console and has access to
+        all of the application's features. You can allow other database roles access to GPCC so that
+        you can secure the <codeph>gpmon</codeph> user and restrict other users' access to GPCC
+        features. Setting up other GPCC users is described in the next section. </p>
     </section>
     <section>
       <title>Greenplum Command Center Users</title>
-      <p>GPCC has three types of users:<ul id="ul_tdv_qnt_g5">
-        <li><i>Regular</i> users can view their own queries in GPCC, but do not have access to
-          administrative tasks in GPCC. </li>
-        <li><i>Operators</i> have access to more functionality in the Command Center Console
-          than regular users. They can view and cancel all queries and they have limited access
-          to administrative tasks. </li>
-        <li><i>Superusers</i> are Greenplum Database superusers. They can use all GPCC features,
-          including viewing information for all database queries, system metrics, and performing
-          potentially disruptive administrative tasks, such as stopping or restarting the
-          database system.</li>
-      </ul></p>
+      <p>GPCC has the following types of users:<ul id="ul_tdv_qnt_g5">
+          <li><i>Self Only</i> users can view metrics and view and cancel their own queries. Any
+            Greenplum Database user successfully authenticated through the Greenplum Database
+            authentication system can access Greenplum Command Center with Self Only permission.
+            Higher permission levels are required to view and cancel other’s queries and to access
+            the System and Admin Control Center features.</li>
+          <li><i>Basic</i> users can view metrics, view all queries, and cancel their own queries.
+            Users with Basic permission are members of the Greenplum Database
+              <codeph>gpcc_basic</codeph> group. </li>
+          <li><i>Operator Basic</i> users can view metrics, view their own and others’ queries,
+            cancel their own queries, and view the System and Admin screens. Users with Operator
+            Basic permission are members of the Greenplum Database
+              <codeph>gpcc_operator_basic</codeph> group.</li>
+          <li><i>Operator</i> users can view their own and others’ queries, cancel their own and
+            other’s queries, and view the System and Admin screens. Users with Operator permission
+            are members of the Greenplum Database <codeph>gpcc_operator</codeph> group.</li>
+          <li><i>Admin</i> users can access all views and capabilities in the Command Center.
+            Greenplum Database users with the <codeph>SUPERUSER</codeph> privilege have Admin
+            permissions in Command Center.</li>
+        </ul></p>
       <p>To log in to the GPCC web application, a user must be allowed access to the gpperfmon
         database in <codeph>pg_hba.conf</codeph>. For example, to make <codeph>user1</codeph> a
-        regular GPCC user, edit the <codeph>pg_hba.conf</codeph> file and either add or edit a
-        line for the user so that the gpperfmon database is included in the database field. For
+        regular GPCC user, edit the <codeph>pg_hba.conf</codeph> file and either add or edit a line
+        for the user so that the gpperfmon database is included in the database field. For
         example:</p>
       <codeblock>host     gpperfmon,accounts   user1     127.0.0.1/28    md5</codeblock>
-      <p>To designate a user as an operator, create the <codeph>gpcc_operator</codeph> role, if it
-        does not already exist:<codeblock>=# CREATE ROLE gpcc_operator;</codeblock></p>
-      <p>Then grant the <codeph>gpcc_operator</codeph> role to the
+      <p>To designate a user as an operator, grant the <codeph>gpcc_operator</codeph> role to the
         user:<codeblock>=# GRANT gpcc_operator TO <varname>user</varname>;</codeblock></p>
       <p>You can also grant <codeph>gpcc_operator</codeph> to a group role to make all members of
         the group GPCC operators.</p>
       <p>See the <codeph>gpperfmon_install</codeph> reference in <cite>Greenplum Database Utility
-        Guide</cite> and the <cite>Greenplum Command Center Administrator Guide</cite> for more
-        information about managing the <codeph>gpperfmon</codeph> database and GPCC security.</p>
+          Guide</cite> for more information about managing the <codeph>gpperfmon</codeph>
+        database.</p>
     </section>
     <section>
       <title>Enabling SSL for Greenplum Command Center</title>
       <p>The GPCC web server can be configured to support SSL so that client connections are
-        encrypted. A server certificate can be generated when the Command Center instance is
-        created or you can supply an existing certificate. </p>
+        encrypted. A server certificate can be generated when the Command Center instance is created
+        or you can supply an existing certificate. </p>
       <p>Two-way authentication with public key encryption can also be enabled for GPCC. See the
-        <cite>Greenplum Command Center Administration Guide</cite> for instructions. </p>
+          <cite>Greenplum Command Center Administration Guide</cite> for instructions. </p>
     </section>
+    <section>
+      <title>Enabling Kerberos Authentication for Greenplum Command Center Users</title>
+      <p>If Kerberos authentication is enabled for Greenplum Database, Command Center users can also
+        authenticate with Kerberos. Command Center supports three Kerberos authentication modes:
+          <i>strict</i>, <i>normal</i>, and <i>gpmon-only</i>. </p>
+      <parml>
+        <plentry>
+          <pt>Strict</pt>
+          <pd>Command Center has a Kerberos keytab file containing the Command Center service
+            principal and a principal for every Command Center user. If the principal in the
+            client’s connection request is in the keytab file, the web server grants the client
+            access and the web server connects to Greenplum Database using the client’s principal
+            name. If the principal is not in the keytab file, the connection request fails.</pd>
+        </plentry>
+        <plentry>
+          <pt>Normal</pt>
+          <pd>The Command Center Kerberos keytab file contains the Command Center principal and may
+            contain principals for Command Center users. If the principal in the client’s connection
+            request is in Command Center’s keytab file, it uses the client’s principal for database
+            connections. Otherwise, Command Center uses the <codeph>gpmon</codeph> user for database
+            connections.</pd>
+        </plentry>
+        <plentry>
+          <pt>gpmon-only</pt>
+          <pd>The Command Center uses the <codeph>gpmon</codeph> database role for all Greenplum
+            Database connections. No client principals are needed in the Command Center’s keytab
+            file.</pd>
+        </plentry>
+      </parml>
+    </section>
+    <p>See the <xref href="http://gptext.docs.pivotal.io" format="html" scope="external">Greenplum
+        Command Center documentation</xref> for instructions to enable Kerberos authentication with
+      Greenplum Command Center</p>
   </body>
 </topic>

--- a/gpdb-doc/dita/security-guide/topics/gpcc.xml
+++ b/gpdb-doc/dita/security-guide/topics/gpcc.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="topic_zyt_rxp_f5">
+  <title>Greenplum Command Center Security</title>
+  <body>
+    <p>Greenplum Command Center (GPCC) is a web-based application for monitoring and managing
+      Greenplum clusters. GPCC works with data collected by agents running on the segment hosts
+      and saved to the gpperfmon database. The gpperfmon database is created by running the
+      <codeph>gpperfmon_install</codeph> utility, which also creates the <codeph>gpmon</codeph>
+      database role that GPCC uses to access the gpperfmon database. </p>
+    <section>
+      <title>The gpmon User</title>
+      <p>The <codeph>gpperfmon_install</codeph> utility creates the <codeph>gpmon</codeph>
+        database role and adds the role to the <codeph>pg_hba.conf</codeph> file with the
+        following
+        entries:<codeblock>local    gpperfmon   gpmon                         md5
+host     all         gpmon         127.0.0.1/28    md5</codeblock>These
+        entries allow <codeph>gpmon</codeph> to establish a local socket connection to the
+        gpperfmon database and a TCP/IP connection to any database. </p>
+      <p>The <codeph>gpmon</codeph> database role is a superuser. In a secure or production
+        environment, it may be desirable to restrict the <codeph>gpmon</codeph> user to just the
+        gpperfmon database. Do this by editing the <codeph>gpmon</codeph> host entry in the
+        <codeph>pg_hba.conf</codeph> file and changing <codeph>all</codeph> in the database
+        field to
+        <codeph>gpperfmon</codeph>:<codeblock>local   gpperfmon   gpmon                        md5
+host    gpperfmon   gpmon    127.0.0.1/28        md5</codeblock></p>
+      <p>The password used to authenticate the <codeph>gpmon</codeph> user is set by the
+        <codeph>gpperfmon_install</codeph> utility and is stored in the <codeph>gpadmin</codeph>
+        home directory in the <codeph>~/.pgpass</codeph> file. The <codeph>~/.pgpass</codeph> file
+        must be owned by the <codeph>gpadmin</codeph> user and RW-accessible only by the
+        <codeph>gpadmin</codeph> user. To change the <codeph>gpmon</codeph> password, use the
+        <codeph>ALTER ROLE</codeph> command to change the password in the database, change the
+        password in the <codeph>~/.pgpass</codeph> file, and then restart GPCC with the
+        <codeph>gpcmdr --restart <varname>instance_name</varname></codeph> command. </p>
+      <note>The GPCC web server can be configured to encrypt connections with SSL. Two-way
+        authentication with public keys can also be enabled for GPCC users. However, the
+        <codeph>gpmon</codeph> user always uses md5 authentication with the password saved in
+        the <codeph>~/.pgpass</codeph> file. </note>
+      <p>GPCC does not allow logins from any role configured with trust authentication, including
+        the <codeph>gpadmin</codeph> user. </p>
+      <p>The <codeph>gpmon</codeph> user can log in to the Command Center Console and has access
+        to all of the application's features. You can allow other database roles access to GPCC so
+        that you can secure the <codeph>gpmon</codeph> user and restrict other users' access to
+        GPCC features. Setting up other GPCC users is described in the next section. </p>
+    </section>
+    <section>
+      <title>Greenplum Command Center Users</title>
+      <p>GPCC has three types of users:<ul id="ul_tdv_qnt_g5">
+        <li><i>Regular</i> users can view their own queries in GPCC, but do not have access to
+          administrative tasks in GPCC. </li>
+        <li><i>Operators</i> have access to more functionality in the Command Center Console
+          than regular users. They can view and cancel all queries and they have limited access
+          to administrative tasks. </li>
+        <li><i>Superusers</i> are Greenplum Database superusers. They can use all GPCC features,
+          including viewing information for all database queries, system metrics, and performing
+          potentially disruptive administrative tasks, such as stopping or restarting the
+          database system.</li>
+      </ul></p>
+      <p>To log in to the GPCC web application, a user must be allowed access to the gpperfmon
+        database in <codeph>pg_hba.conf</codeph>. For example, to make <codeph>user1</codeph> a
+        regular GPCC user, edit the <codeph>pg_hba.conf</codeph> file and either add or edit a
+        line for the user so that the gpperfmon database is included in the database field. For
+        example:</p>
+      <codeblock>host     gpperfmon,accounts   user1     127.0.0.1/28    md5</codeblock>
+      <p>To designate a user as an operator, create the <codeph>gpcc_operator</codeph> role, if it
+        does not already exist:<codeblock>=# CREATE ROLE gpcc_operator;</codeblock></p>
+      <p>Then grant the <codeph>gpcc_operator</codeph> role to the
+        user:<codeblock>=# GRANT gpcc_operator TO <varname>user</varname>;</codeblock></p>
+      <p>You can also grant <codeph>gpcc_operator</codeph> to a group role to make all members of
+        the group GPCC operators.</p>
+      <p>See the <codeph>gpperfmon_install</codeph> reference in <cite>Greenplum Database Utility
+        Guide</cite> and the <cite>Greenplum Command Center Administrator Guide</cite> for more
+        information about managing the <codeph>gpperfmon</codeph> database and GPCC security.</p>
+    </section>
+    <section>
+      <title>Enabling SSL for Greenplum Command Center</title>
+      <p>The GPCC web server can be configured to support SSL so that client connections are
+        encrypted. A server certificate can be generated when the Command Center instance is
+        created or you can supply an existing certificate. </p>
+      <p>Two-way authentication with public key encryption can also be enabled for GPCC. See the
+        <cite>Greenplum Command Center Administration Guide</cite> for instructions. </p>
+    </section>
+  </body>
+</topic>

--- a/gpdb-doc/dita/security-guide/topics/install.xml
+++ b/gpdb-doc/dita/security-guide/topics/install.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="topic_ewg_q3c_pr">
+  <title>Installing Greenplum Workload Manager</title>
+  <body>
+    <section>Prerequisites</section>
+    <ul id="ul_il5_53c_pr">
+      <li>Red Hat Enterprise Linux (RHEL) 5 or 6</li>
+      <li>Greenplum Database version 4.3.<i>x</i></li>
+    </ul>
+    <section>
+      <title>Running the Greenplum Workload Manager Installer</title>
+      <p>The Greenplum Workload Manager installer binary is installed on the Greenplum Database
+        master node. It will then automatically distribute to all segment servers in the database
+        cluster.</p>
+      <p>
+        <ol id="ol_sg3_bjc_pr">
+          <li>Run the Greenplum Workload Manager installer. You must specify the absolute path to an
+            installation directory where you have write permission. For example:
+            <codeblock>$ /bin/bash gp­wlm.bin ­­install=/usr/local/</codeblock> This command
+            installs Greenplum Workload Manager in the gp­wlmsubdirectory of the specified directory
+            on all of the segments, creating directories as needed. For example, the above command
+            installs Workload Manager in the <codeph>/usr/local/gp­wlmdirectory</codeph>.</li>
+          <li>For convenience you may source
+              <codeph><i>INSTALL­DIR</i>/gp­wlm/gp­wlm_path.sh</codeph> to add the Workload Manager
+            executables to your path.</li>
+        </ol>
+      </p>
+      <p>To uninstall Greenplum Workload Manager, run the following command:
+        <codeblock>$ <i>INSTALLDIR</i>/gp­wlm/bin/uninstall.sh ­­symlink <i>INSTALLDIR</i>/gp­wlm</codeblock></p>
+    </section>
+  </body>
+</topic>

--- a/gpdb-doc/dita/security-guide/topics/kerberos-hdfs.xml
+++ b/gpdb-doc/dita/security-guide/topics/kerberos-hdfs.xml
@@ -1,0 +1,329 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="topic_lhr_yrf_qr">
+  <title>Enabling gphdfs Authentication with a Kerberos-secured Hadoop Cluster</title>
+  <shortdesc>Using external tables and the <codeph>gphdfs</codeph> protocol, Greenplum Database can
+    read files from and write files to a Hadoop File System (HDFS). Greenplum segments read and
+    write files in parallel from HDFS for fast performance. </shortdesc>
+  <body>
+    <p>When a Hadoop cluster is secured with Kerberos ("Kerberized"), Greenplum Database must be
+      configured to allow the Greenplum Database gpadmin role, which owns external tables in HDFS,
+      to authenticate through Kerberos. This topic provides the steps for configuring Greenplum
+      Database to work with a Kerberized HDFS, including verifying and troubleshooting the
+      configuration.</p>
+    <ul id="ul_i3b_xvm_qr">
+      <li>
+        <xref href="#topic_gbw_rjl_qr" format="dita"/>
+      </li>
+      <li>
+        <xref href="#topic_t11_tjl_qr" format="dita"/>
+      </li>
+      <li>
+        <xref href="#topic_wtt_y1r_zr" format="dita"/>
+      </li>
+      <li>
+        <xref href="#topic_jsb_cll_qr" format="dita"/>
+      </li>
+      <li>
+        <xref href="#topic_dlj_yjv_yr" format="dita"/>
+      </li>
+      <li>
+        <xref href="#topic_mwd_rlm_qr" format="dita"/>
+      </li>
+    </ul>
+  </body>
+  <topic id="topic_gbw_rjl_qr">
+    <title>Prerequisites</title>
+    <body>
+      <p>Make sure the following components are functioning and accessible on the network:</p>
+      <ul id="ul_krv_t5f_qr">
+        <li>Greenplum Database cluster</li>
+        <li>Kerberos-secured Hadoop cluster. See the <i>Greenplum Database Release Notes</i> for
+          supported Hadoop versions.</li>
+        <li>Kerberos Key Distribution Center (KDC) server.</li>
+      </ul>
+    </body>
+  </topic>
+  <topic id="topic_t11_tjl_qr">
+    <title>Configuring the Greenplum Cluster</title>
+    <body>
+      <p>The hosts in the Greenplum Cluster must have a Java JRE, Hadoop client files, and Kerberos
+        clients installed. </p>
+      <p>Follow these steps to prepare the Greenplum Cluster. </p>
+      <ol id="ol_ykk_rwf_qr">
+        <li>Install a Java 1.6 or later JRE on all Greenplum cluster hosts. <p>Match the JRE version
+            the Hadoop cluster is running. You can find the JRE version by running <codeph>java
+              --version</codeph> on a Hadoop node.</p></li>
+        <li><i>(Optional) </i>Confirm that Java Cryptography Extension (JCE) is present.<p>The
+            default location of the JCE libraries is
+              <filepath><varname>JAVA_HOME</varname>/lib/security</filepath>. If a JDK is installed,
+            the directory is <filepath><varname>JAVA_HOME</varname>/jre/lib/security</filepath>. The
+            files <filepath>local_policy.jar</filepath> and
+              <filepath>US_export_policy.jar</filepath> should be present in the JCE
+            directory.</p><p>The Greenplum cluster and the Kerberos server should, preferably, use
+            the same version of the JCE libraries. You can copy the JCE files from the Kerberos
+            server to the Greenplum cluster, if needed.</p></li>
+        <li>Set the <codeph>JAVA_HOME</codeph> environment variable to the location of the JRE in
+          the <filepath>.bashrc</filepath> or <filepath>.bash_profile</filepath> file for the
+            <codeph>gpadmin</codeph> account. For
+          example:<codeblock>export JAVA_HOME=/usr/java/default</codeblock></li>
+        <li>Source the <filepath>.bashrc</filepath> or <filepath>.bash_profile</filepath> file to
+          apply the change to your environment. For
+          example:<codeblock>$ source ~/.bashrc</codeblock></li>
+        <li>Install the Kerberos client utilities on all cluster hosts. Ensure the libraries match
+          the version on the KDC server before you install them. <p>For example, the following
+            command installs the Kerberos client files on Red Hat or CentOS
+            Linux:<codeblock>$ sudo yum install krb5-libs krb5-workstation</codeblock></p><p>Use the
+              <codeph>kinit</codeph> command to confirm the Kerberos client is installed and
+            correctly configured.</p></li>
+        <li>Install Hadoop client files on all hosts in the Greenplum Cluster. Refer to the
+          documentation for your Hadoop distribution for instructions.</li>
+        <li>Set the Greenplum Database server configuration parameters for Hadoop. The
+            <codeph>gp_hadoop_target_version</codeph> parameter specifies the version of the Hadoop
+          cluster. See the <i>Greenplum Database Release Notes</i> for the target version value that
+          corresponds to your Hadoop distribution. The <codeph>gp_hadoop_home</codeph> parameter
+          specifies the Hadoop installation
+            directory.<codeblock>$ gpconfig -c gp_hadoop_target_version -v "hdp2"
+$ gpconfig -c gp_hadoop_home -v "/usr/lib/hadoop"</codeblock><p>See
+            the <i>Greenplum Database Reference Guide</i> for more information.</p></li>
+        <li>Reload the updated <filepath>postgresql.conf</filepath> files for master and
+            segments:<codeblock>gpstop -u</codeblock><p>You can confirm the changes with the
+            following
+            commands:<codeblock>$ gpconfig -s gp_hadoop_target_version
+$ gpconfig -s gp_hadoop_home</codeblock></p></li>
+        <li>Grant Greenplum Database gphdfs protocol privileges to roles that own external tables in
+          HDFS, including <codeph>gpadmin</codeph> and other superuser roles. Grant
+            <codeph>SELECT</codeph> privileges to enable creating readable external tables in HDFS.
+          Grant <codeph>INSERT</codeph> privileges to enable creating writable exeternal tables on
+          HDFS.
+          <codeblock>#= GRANT SELECT ON PROTOCOL gphdfs TO gpadmin;
+#= GRANT INSERT ON PROTOCOL gphdfs TO gpadmin;</codeblock></li>
+        <li>Grant Greenplum Database external table privileges to external table owner
+            roles:<codeblock>ALTER ROLE <varname>HDFS_USER</varname> CREATEEXTTABLE (type='readable');
+ALTER ROLE <varname>HDFS_USER</varname> CREATEEXTTABLE (type='writable');</codeblock><note>It
+            is best practice to review database privileges, including gphdfs external table
+            privileges, at least annually. </note></li>
+      </ol>
+    </body>
+  </topic>
+  <topic id="topic_wtt_y1r_zr">
+    <title>Creating and Installing Keytab Files</title>
+    <body>
+      <ol id="ol_tch_2br_zr">
+        <li>Log in to the KDC server as root.</li>
+        <li>Use the <codeph>kadmin.local</codeph> command to create a new principal for the
+            <codeph>gpadmin</codeph>
+          user:<codeblock># kadmin.local -q "addprinc -randkey gpadmin@<i>LOCAL.DOMAIN</i>"</codeblock></li>
+        <li>Use <codeph>kadmin.local</codeph> to generate a Kerberos service principal for each host
+          in the Greenplum Database cluster. The service principal should be of the form
+            <varname>name</varname>/<varname>role</varname>@<varname>REALM</varname>, where:<ul
+            id="ul_cbd_dcr_zr">
+            <li><i>name</i> is the gphdfs service user name. This example uses
+                <codeph>gphdfs</codeph>.</li>
+            <li><i>role</i> is the DNS-resolvable host name of a Greenplum cluster host (the output
+              of the <codeph>hostname -f</codeph> command).</li>
+            <li><i>REALM</i> is the Kerberos realm, for example <codeph>LOCAL.DOMAIN</codeph>. </li>
+          </ul><p>For example, the following commands add service principals for four Greenplum
+            Database hosts, mdw.example.com, smdw.example.com, sdw1.example.com, and
+            sdw2.example.com:<codeblock># kadmin.local -q "addprinc -randkey gphdfs/mdw.example.com@LOCAL.DOMAIN"
+# kadmin.local -q "addprinc -randkey gphdfs/smdw.example.com@LOCAL.DOMAIN"
+# kadmin.local -q "addprinc -randkey gphdfs/sdw1.example.com@LOCAL.DOMAIN"
+# kadmin.local -q "addprinc -randkey gphdfs/sdw2.example.com@LOCAL.DOMAIN"</codeblock></p><p>Create
+            a principal for each Greenplum cluster host. Use the same principal name and realm,
+            substituting the fully-qualified domain name for each host. </p></li>
+        <li>Generate a keytab file for each principal that you created (<codeph>gpadmin</codeph> and
+          each <codeph>gphdfs</codeph> service principal). You can store the keytab files in any
+          convenient location (this example uses the directory
+            <filepath>/etc/security/keytabs</filepath>). You will deploy the service principal
+          keytab files to their respective Greenplum host machines in a later
+          step:<codeblock># kadmin.local -q “xst -k /etc/security/keytabs/gphdfs.service.keytab gpadmin@LOCAL.DOMAIN”
+# kadmin.local -q “xst -k /etc/security/keytabs/mdw.service.keytab gpadmin/mdw gphdfs/mdw.example.com@LOCAL.DOMAIN”
+# kadmin.local -q “xst -k /etc/security/keytabs/smdw.service.keytab gpadmin/smdw gphdfs/smdw.example.com@LOCAL.DOMAIN”
+# kadmin.local -q “xst -k /etc/security/keytabs/sdw1.service.keytab gpadmin/sdw1 gphdfs/sdw1.example.com@LOCAL.DOMAIN”
+# kadmin.local -q “xst -k /etc/security/keytabs/sdw2.service.keytab gpadmin/sdw2 gphdfs/sdw2.example.com@LOCAL.DOMAIN”
+# kadmin.local -q “listprincs”</codeblock></li>
+        <li>Change the ownership and permissions on <codeph>gphdfs.service.keytab</codeph> as
+          follows:<codeblock># chown gpadmin:gpadmin /etc/security/keytabs/gphdfs.service.keytab
+# chmod 440 /etc/security/keytabs/gphdfs.service.keytab</codeblock></li>
+        <li>Copy the keytab file for <codeph>gpadmin@LOCAL.DOMAIN</codeph> to the Greenplum master
+          host:<codeblock># scp /etc/security/keytabs/gphdfs.service.keytab mdw_fqdn:/home/gpadmin/gphdfs.service.keytab</codeblock></li>
+        <li>Copy the keytab file for each service principal to its respective Greenplum
+          host:<codeblock># scp /etc/security/keytabs/mdw.service.keytab mdw_fqdn:/home/gpadmin/mdw.service.keytab
+# scp /etc/security/keytabs/smdw.service.keytab smdw_fqdn:/home/gpadmin/smdw.service.keytab
+# scp /etc/security/keytabs/sdw1.service.keytab sdw1_fqdn:/home/gpadmin/sdw1.service.keytab
+# scp /etc/security/keytabs/sdw2.service.keytab sdw2_fqdn:/home/gpadmin/sdw2.service.keytab</codeblock></li>
+      </ol>
+    </body>
+  </topic>
+  <topic id="topic_jsb_cll_qr">
+    <title>Configuring gphdfs for Kerberos</title>
+    <body>
+      <ol id="ol_lnj_f4l_qr">
+        <li>Edit the Hadoop <filepath>core-site.xml</filepath> client configuration file on all
+          Greenplum cluster hosts. Enable service-level authorization for Hadoop by setting the
+            <codeph>hadoop.security.authorization</codeph> property to <codeph>true</codeph>. For
+          example:<codeblock>&lt;property>
+    &lt;name>hadoop.security.authorization&lt;/name>
+    &lt;value>true&lt;/value>
+&lt;/property></codeblock></li>
+        <li>Edit the <filepath>yarn-site.xml</filepath> client configuration file on all cluster
+          hosts. Set the resource manager address and yarn Kerberos service principle. For
+          example:<codeblock>&lt;property>
+    &lt;name>yarn.resourcemanager.address&lt;/name>
+    &lt;value><varname>hostname</varname>:<varname>8032</varname>&lt;/value>
+&lt;/property>
+&lt;property>
+    &lt;name>yarn.resourcemanager.principal&lt;/name>
+    &lt;value>yarn/<varname>hostname</varname>@<varname>DOMAIN</varname>&lt;/value>
+&lt;/property></codeblock></li>
+        <li>Edit the <filepath>hdfs-site.xml</filepath> client configuration file on all cluster
+          hosts. Set properties to identify the NameNode Kerberos principals, the location of the
+          Kerberos keytab file, and the principal it is for:<ul id="ul_t3s_w4l_qr">
+            <li><codeph>dfs.namenode.kerberos.principal</codeph> - the Kerberos principal name the
+              gphdfs protocol will use for the NameNode, for example
+                <codeph>gpadmin@LOCAL.DOMAIN</codeph>.</li>
+            <li><codeph>dfs.namenode.https.principal</codeph> - the Kerberos principal name the
+              gphdfs protocol will use for the NameNode's secure HTTP server, for example
+                <codeph>gpadmin@LOCAL.DOMAIN</codeph>.</li>
+            <li><codeph>com.emc.greenplum.gpdb.hdfsconnector.security.user.keytab.file</codeph> -
+              the path to the keytab file for the Kerberos HDFS service, for example
+                <codeph>/home/gpadmin/mdw.service.keytab</codeph>. . </li>
+            <li><codeph>com.emc.greenplum.gpdb.hdfsconnector.security.user.name</codeph> - the
+              gphdfs service principal for the host, for example
+                <codeph>gphdfs/mdw.example.com@LOCAL.DOMAIN</codeph>.</li>
+          </ul><p>For
+          example:</p><codeblock>&lt;property>
+    &lt;name>dfs.namenode.kerberos.principal&lt;/name>
+    &lt;value>gphdfs/gpadmin@LOCAL.DOMAIN&lt;/value>
+&lt;/property>
+&lt;property>
+    &lt;name>dfs.namenode.https.principal&lt;/name>
+    &lt;value>gphdfs/gpadmin@LOCAL.DOMAIN&lt;/value>
+&lt;/property>
+&lt;property>
+    &lt;name>com.emc.greenplum.gpdb.hdfsconnector.security.user.keytab.file&lt;/name>
+    &lt;value>/home/gpadmin/gpadmin.hdfs.keytab&lt;/value>
+&lt;/property>
+&lt;property>
+    &lt;name>com.emc.greenplum.gpdb.hdfsconnector.security.user.name&lt;/name>
+    &lt;value>gpadmin/@LOCAL.DOMAIN&lt;/value>
+&lt;/property></codeblock></li>
+      </ol>
+    </body>
+  </topic>
+  <topic id="topic_dlj_yjv_yr">
+    <title>Testing Greenplum Database Access to HDFS</title>
+    <body>
+      <p>Confirm that HDFS is accessible via Kerberos authentication on all hosts in the Greenplum
+        cluster. For example, enter the following command to list an HDFS
+        directory:<codeblock>hdfs dfs -ls hdfs://<varname>namenode</varname>:8020</codeblock></p>
+      <section>
+        <title>Create a Readable External Table in HDFS</title>
+        <p>Follow these steps to verify that you can create a readable external table in a
+          Kerberized Hadoop cluser. </p>
+        <ol id="ol_elf_2ql_qr">
+          <li>Create a comma-delimited text file, <codeph>test1.txt</codeph>, with contents such as
+            the following:<codeblock>25, Bill
+19, Anne
+32, Greg
+27, Gloria</codeblock></li>
+          <li>Persist the sample text file in
+            HDFS:<codeblock>hdfs dfs -put <varname>test1.txt</varname> hdfs://<varname>namenode</varname>:8020/tmp</codeblock></li>
+          <li>Log in to Greenplum Database and create a readable external table that points to the
+              <codeph>test1.txt</codeph> file in
+            Hadoop:<codeblock>CREATE EXTERNAL TABLE test_hdfs (age int, name text) 
+LOCATION('gphdfs://<varname>namenode</varname>:<varname>8020</varname>/tmp/test1.txt') 
+FORMAT 'text' (delimiter ',');</codeblock></li>
+          <li>Read data from the external table:<codeblock>SELECT * FROM test_hdfs;</codeblock></li>
+        </ol>
+      </section>
+      <section>
+        <title>Create a Writable External Table in HDFS</title>
+        <p>Follow these steps to verify that you can create a writable external table in a
+          Kerberized Hadoop cluster. The steps use the <codeph>test_hdfs</codeph> readable external
+          table created previously. </p>
+        <ol id="ol_ht3_kfm_qr">
+          <li>Log in to Greenplum Database and create a writable external table pointing to a text
+            file in
+            HDFS:<codeblock>CREATE WRITABLE EXTERNAL TABLE test_hdfs2 (LIKE test_hdfs) 
+LOCATION ('gphdfs://<varname>namenode</varname>:8020/tmp/test2.txt'
+FORMAT 'text' (DELIMITER ',');</codeblock></li>
+          <li>Load data into the writable external
+            table:<codeblock>INSERT INTO test_hdfs2 
+SELECT * FROM test_hdfs;</codeblock></li>
+          <li>Check that the file exists in
+            HDFS:<codeblock>hdfs dfs -ls hdfs://<varname>namenode</varname>:8020/tmp/test2.txt</codeblock></li>
+          <li>Verify the contents of the external
+            file:<codeblock>hdfs dfs -cat hdfs://<varname>namenode</varname>:8020/tmp/test2.txt</codeblock></li>
+        </ol>
+      </section>
+    </body>
+  </topic>
+  <topic id="topic_mwd_rlm_qr">
+    <title>Troubleshooting HDFS with Kerberos</title>
+    <body>
+      <section>
+        <title>Forcing Classpaths</title>
+        <p>If you encounter "class not found" errors when executing <codeph>SELECT</codeph>
+          statements from <codeph>gphdfs</codeph> external tables, edit the
+            <filepath>$GPHOME/lib/hadoop-env.sh</filepath> file and add the following lines towards
+          the end of the file, before the <codeph>JAVA_LIBRARY_PATH</codeph> is set. Update the
+          script on all of the cluster
+          hosts.<codeblock>if [ -d "/usr/hdp/current" ]; then
+for f in /usr/hdp/current/**/*.jar; do
+    CLASSPATH=${CLASSPATH}:$f;
+done
+fi</codeblock></p>
+      </section>
+      <section>
+        <title>Enabling Kerberos Client Debug Messages</title>
+        <p>To see debug messages from the Kerberos client, edit the
+            <filepath>$GPHOME/lib/hadoop-env.sh</filepath> client shell script on all cluster hosts
+          and set the <codeph>HADOOP_OPTS</codeph> variable as
+          follows:<codeblock>export HADOOP_OPTS="-Djava.net.prefIPv4Stack=true -Dsun.security.krb5.debug=true ${HADOOP_OPTS}"</codeblock></p>
+      </section>
+      <section>
+        <title>Adjusting JVM Process Memory on Segment Hosts</title>
+        <p>Each segment launches a JVM process when reading or writing an external table in HDFS. To
+          change the amount of memory allocated to each JVM process, configure the
+            <codeph>GP_JAVA_OPT</codeph> environment variable. </p>
+        <p>Edit the <filepath>$GPHOME/lib/hadoop-env.sh</filepath> client shell script on all
+          cluster hosts. </p>
+        <p>For example:<codeblock>export GP_JAVA_OPT=-Xmx1000m</codeblock></p>
+      </section>
+      <section>
+        <title>Verify Kerberos Security Settings</title>
+        <p>Review the <filepath>/etc/krb5.conf</filepath> file:</p>
+        <ul id="ul_os5_f4m_qr">
+          <li>If AES256 encryption is not disabled, ensure that all cluster hosts have the JCE
+            Unlimited Strength Jurisdiction Policy Files installed.</li>
+          <li>Ensure all encryption types in the Kerberos keytab file match definitions in the
+              <filepath>krb5.conf</filepath> file.
+            <codeblock>cat /etc/krb5.conf | egrep supported_enctypes</codeblock></li>
+        </ul>
+      </section>
+      <section>
+        <title>Test Connectivity on an Individual Segment Host</title>
+        <p>Follow these steps to test that a single Greenplum Database host can read HDFS data. This
+          test method executes the Greenplum <codeph>HDFSReader</codeph> Java class at the
+          command-line, and can help to troubleshoot connectivity problems outside of the database. </p>
+        <ol id="ol_vm1_m4m_qr">
+          <li>Save a sample data file in HDFS.
+            <codeblock>hdfs dfs -put test1.txt hdfs://<varname>namenode</varname>:8020/tmp</codeblock></li>
+          <li>On the segment host to be tested, create an environment script,
+              <codeph>env.sh</codeph>, like the
+            following:<codeblock>export JAVA_HOME=/usr/java/default
+export HADOOP_HOME=/usr/lib/hadoop
+export GP_HADOOP_CON_VERSION=hdp2
+export GP_HADOOP_CON_JARDIR=/usr/lib/hadoop</codeblock></li>
+          <li>Source all environment
+            scripts:<codeblock>source /usr/local/greenplum-db/greenplum_path.sh
+source env.sh
+source $GPHOME/lib/hadoop-env.sh</codeblock></li>
+          <li>Test the Greenplum Database HDFS
+            reader:<codeblock>java com.emc.greenplum.gpdb.hdfsconnector.HDFSReader 0 32 TEXT hdp2 gphdfs://<varname>namenode</varname>:8020/tmp/test1.txt</codeblock></li>
+        </ol>
+      </section>
+    </body>
+  </topic>
+</topic>

--- a/gpdb-doc/dita/security-guide/topics/ports_and_protocols.xml
+++ b/gpdb-doc/dita/security-guide/topics/ports_and_protocols.xml
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="greenplum_database_ports_and_protocols">
+  <title>Greenplum Database Ports and Protocols</title>
+  <body>
+    <p>Greenplum Database clients connect with TCP to the Greenplum master instance at the client
+      connection port, 5432 by default. The listen port can be reconfigured in the
+        <filepath>postgresql.conf</filepath> configuration file. Client connections use the
+      PostgreSQL libpq API. The <codeph>psql</codeph> command-line interface, several Greenplum
+      utilities, and language-specific programming APIs all either use the libpq library directly or
+      implement the libpq protocol internally. </p>
+    <p>Each segment instance also has a client connection port, used solely by the master instance
+      to coordinate database operations with the segments. The <codeph>gpstate -p</codeph> command,
+      executed on the Greenplum master, lists the port assignments for the Greenplum master and the
+      primary segments and mirrors. For example:
+      <codeblock>[gpadmin@mdw ~]$ gpstate -p
+20160126:15:40:22:028389 gpstate:mdw:gpadmin-[INFO]:-Starting gpstate with args: -p
+20160126:15:40:22:028389 gpstate:mdw:gpadmin-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 4.3.6.0 build 62994'
+20160126:15:40:22:028389 gpstate:mdw:gpadmin-[INFO]:-master Greenplum Version: 'PostgreSQL 8.2.15 (Greenplum Database 4.3.6.0 build 62994) on x86_64-unknown-linux-gnu, compiled by GCC gcc (GCC) 4.4.2 compiled on Jul 24 2015 11:35:08'
+20160126:15:40:22:028389 gpstate:mdw:gpadmin-[INFO]:-Obtaining Segment details from master...
+20160126:15:40:22:028389 gpstate:mdw:gpadmin-[INFO]:--Master segment instance  /data/master/gpseg-1  port = 5432
+20160126:15:40:22:028389 gpstate:mdw:gpadmin-[INFO]:--Segment instance port assignments
+20160126:15:40:22:028389 gpstate:mdw:gpadmin-[INFO]:-----------------------------------
+20160126:15:40:22:028389 gpstate:mdw:gpadmin-[INFO]:-   Host   Datadir                Port
+20160126:15:40:22:028389 gpstate:mdw:gpadmin-[INFO]:-   sdw1   /data/primary/gpseg0   40000
+20160126:15:40:22:028389 gpstate:mdw:gpadmin-[INFO]:-   sdw2   /data/mirror/gpseg0    50000
+20160126:15:40:22:028389 gpstate:mdw:gpadmin-[INFO]:-   sdw2   /data/primary/gpseg1   40000
+20160126:15:40:22:028389 gpstate:mdw:gpadmin-[INFO]:-   sdw1   /data/mirror/gpseg1    50001
+20160126:15:40:22:028389 gpstate:mdw:gpadmin-[INFO]:-   sdw3   /data/primary/gpseg2   40000
+20160126:15:40:22:028389 gpstate:mdw:gpadmin-[INFO]:-   sdw4   /data/mirror/gpseg2    50000
+20160126:15:40:22:028389 gpstate:mdw:gpadmin-[INFO]:-   sdw4   /data/primary/gpseg3   40000
+20160126:15:40:22:028389 gpstate:mdw:gpadmin-[INFO]:-   sdw3   /data/mirror/gpseg3    50001
+</codeblock></p>
+    <p>Additional Greenplum Database network connections are created for features such as standby
+      replication, segment mirroring, statistics collection, and data exchange between segments.
+      Some persistent connections are established when the database starts up and other transient
+      connections are created during operations such as query execution. Transient connections for
+      query execution processes, data movement, and statistics collection use available ports in the
+      range 1025 to 65535 with both TCP and UDP protocols. </p>
+    <p>Some add-on products and services that work with Greenplum Database have additional
+      networking requirements. The following table lists ports and protocols used within the
+      Greenplum cluster, and includes services and applications that integrate with Greenplum
+      Database.</p>
+    <table frame="all" rowsep="1" colsep="1" id="table_zf3_lzz_s5">
+      <title>Greenplum Database Ports and Protocols</title>
+      <tgroup cols="3">
+        <colspec colname="newCol1" colnum="1" colwidth="1*"/>
+        <colspec colname="c1" colnum="2" colwidth="1.0*"/>
+        <colspec colname="c3" colnum="3" colwidth="2.0*"/>
+        <thead>
+          <row>
+            <entry>Service</entry>
+            <entry>Protocol/Port</entry>
+            <entry>Description</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry>Master SQL client connection</entry>
+            <entry>TCP 5432, libpq</entry>
+            <entry>SQL client connection port on the Greenplum master host. Supports clients using
+              the PostgreSQL libpq API. Configurable.</entry>
+          </row>
+          <row>
+            <entry>Segment SQL client connection</entry>
+            <entry>varies, libpq</entry>
+            <entry>The SQL client connection port for a segment instance. Each primary and mirror
+              segment on a host must have a unique port. Ports are assigned when the Greenplum
+              system is initialized or expanded. The <codeph>gp_segment_configuration</codeph>
+              system catalog records port numbers for each segment in the <codeph>port</codeph>
+              column. Run <codeph>gpstate -p</codeph> to view the ports in use.</entry>
+          </row>
+          <row>
+            <entry>Segment mirroring port</entry>
+            <entry>varies, libpq</entry>
+            <entry>The port where a segment receives mirrored blocks from its primary. The port is
+              assigned when the mirror is set up. The port number is stored in the
+                <codeph>gp_segment_configuration</codeph> system catalog in the
+                <codeph>mirror_port</codeph> column.</entry>
+          </row>
+          <row>
+            <entry>Greenplum Database Interconnect</entry>
+            <entry>UDP 1025-65535, dynamically allocated</entry>
+            <entry>The Interconnect transports database tuples between Greenplum segments during
+              query execution. </entry>
+          </row>
+          <row>
+            <entry>Standby master client listener</entry>
+            <entry>TCP 5432, libpq</entry>
+            <entry>SQL client connection port on the standby master host. Usually the same as the
+              master client connection port. Configure with the <codeph>gpinitstandby</codeph>
+              utility <codeph>-P</codeph> option.</entry>
+          </row>
+          <row>
+            <entry>Standby master replicator</entry>
+            <entry>TCP 1025-65535, gpsyncmaster</entry>
+            <entry>The <codeph>gpsyncmaster</codeph> process on the master host establishes a
+              connection to the secondary master host to replicate the master's log to the standby
+              master. </entry>
+          </row>
+          <row otherprops="pivotal">
+            <entry>Greenplum Control Center (GPCC)</entry>
+            <entry>TCP 28080, HTTP/HTTPS</entry>
+            <entry>Default listen port for the GPCC console web server, which is usually installed
+              on the master host. Configured in the <filepath>lighttpd.conf</filepath> file in the
+              GPCC instance.</entry>
+          </row>
+          <row>
+            <entry>Greenplum database file load and transfer utilities: gpfdist, gpload,
+              gptransfer</entry>
+            <entry>TCP 8080, HTTP<p>TCP 9000, HTTPS</p></entry>
+            <entry>The gpfdist file serving utility can run on Greenplum hosts or external hosts.
+              Specify the connection port with the <codeph>-p</codeph> option when starting the
+              server. <p>The gpload and gptransfer utilities run one or more instances of gpfdist
+                with ports or port ranges specified in a configuration file.</p></entry>
+          </row>
+          <row>
+            <entry>GPCC agents</entry>
+            <entry>TCP 8888</entry>
+            <entry>Connection port for GPCC agents executing on each Greenplum host. Configure by
+              setting the <codeph>gpperfmon_port</codeph> configuration variable in
+                <filepath>postgresql.conf</filepath> on master and segment hosts.</entry>
+          </row>
+          <row>
+            <entry>Backup completion notification</entry>
+            <entry>TCP 25, TCP 587, SMTP</entry>
+            <entry>The gpcrondump backup utility can optionally send email to a list of email
+              addresses at completion of a backup. The SMTP service must be enabled on the Greenplum
+              master host. </entry>
+          </row>
+          <row>
+            <entry>Greenplum Database secure shell (SSH): gpssh, gpscp, gpssh-exkeys, gppkg,
+              gpseginstall</entry>
+            <entry>TCP 22, SSH</entry>
+            <entry>Many Greenplum utilities use scp and ssh to transfer files between hosts and
+              manage the Greenplum system within the cluster. </entry>
+          </row>
+          <row>
+            <entry>gphdfs</entry>
+            <entry>TCP 8020</entry>
+            <entry>The gphdfs protocol allows access to data in a Hadoop file system via Greenplum
+              external tables. The URL in the <codeph>LOCATION</codeph> clause of the <codeph>CREATE
+                EXTERNAL TABLE</codeph> command specifies the host address and port number for the
+              Hadoop namenode service. </entry>
+          </row>
+          <row otherprops="pivotal">
+            <entry morerows="2">Greenplum Workload Manager (GP-WLM)</entry>
+            <entry>TCP 4369, epmd</entry>
+            <entry>Erlang port mapper (epmd) allows nodes in the cluster to resolve node names.
+            </entry>
+          </row>
+          <row otherprops="pivotal">
+            <entry>TCP 25672</entry>
+            <entry>rabbitmq clustering</entry>
+          </row>
+          <row otherprops="pivotal">
+            <entry>TCP 7777</entry>
+            <entry>rabbitmq main port</entry>
+          </row>
+          <row otherprops="pivotal">
+            <entry morerows="3">EMC Data Domain and DD Boost</entry>
+            <entry>TCP/UDP 111, NFS portmapper </entry>
+            <entry>Used to assign a random port for the mountd service used by NFS and DD Boost. The
+              mountd service port can be statically assigned on the Data Domain server.</entry>
+          </row>
+          <row otherprops="pivotal">
+            <entry>TCP 2052</entry>
+            <entry>Main port used by NFS mountd. This port can be set on the Data Domain system
+              using the <codeph>nfs set mountd-port</codeph> command .</entry>
+          </row>
+          <row otherprops="pivotal">
+            <entry>TCP 2049, NFS</entry>
+            <entry>Main port used by NFS. This port can be configured using the <codeph>nfs set
+                server-port</codeph> command on the Data Domain server. </entry>
+          </row>
+          <row otherprops="pivotal">
+            <entry>TCP 2051, replication</entry>
+            <entry>Used when replication is configured on the Data Domain system. This port can be
+              configured using the <codeph>replication modify</codeph> command on the Data Domain
+              server.</entry>
+          </row>
+          <row>
+            <entry morerows="1">Symantec NetBackup</entry>
+            <entry>TCP/UDB 1556, veritas-pbx</entry>
+            <entry>The Symantec NetBackup client network port. </entry>
+          </row>
+          <row>
+            <entry>TCP 13724, vnetd</entry>
+            <entry>Symantec NetBackup vnetd communication port.</entry>
+          </row>
+          <row>
+            <entry>Pgbouncer connection pooler</entry>
+            <entry>TCP, libpq</entry>
+            <entry>The pgbouncer connection pooler runs between libpq clients and Greenplum (or
+              PostgreSQL) databases. It can be run on the Greenplum master host, but running it on a
+              host outside of the Greenplum cluster is recommended. When it runs on a separate host,
+              pgbouncer can act as a warm standby mechanism for the Greenplum master host, switching
+              to the Greenplum standby host without requiring clients to reconfigure. Set the client
+              connection port and the Greenplum master host address and port in the
+                <filepath>pgbouncer.ini</filepath> configuration file. </entry>
+          </row>
+          <row>
+            <entry>stunnel SSL proxy</entry>
+            <entry>TCP, ssh, libpq</entry>
+            <entry>A stunnel SSL proxy can be used to add SSL support for database clients accessing
+              the database through a pgbouncer connection pool. A secure tunnel can be set up by
+              setting up stunnel on the client and the pgbouncer host. Newer versions of stunnel
+              that support encrypted libpq connections only require stunnel on the pgbouncer host.
+              The stunnel proxy's connection ports and the pgbouncer host and port are specified in
+              the <filepath>stunnel.conf</filepath> configuration file.</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>

--- a/gpdb-doc/dita/security-guide/topics/preface.xml
+++ b/gpdb-doc/dita/security-guide/topics/preface.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic id="topic1" xml:lang="en">
+  <title id="nk110126">About This Guide</title>
+  <body>
+    <p>This guide describes how to secure a Greenplum Database system. The guide consists of the
+      following sections:</p>
+    <ul id="ul_tnm_vl3_34">
+      <li id="nk169273"><xref href="SecuringGPDB.xml#topic_iqr_ym2_jr"/> introduces Greenplum
+        Database security topics. </li>
+      <li><xref href="ports_and_protocols.xml#greenplum_database_ports_and_protocols"/> lists
+        network ports and protocols used within the Greenplum cluster. </li>
+      <li id="nk169420"><xref href="Authenticate.xml#topic_n5w_gtd_jr"/> describes the available
+        methods for authenticating Greenplum Database clients. </li>
+      <li id="nk169450"><xref href="Authorization.xml#topic_ivr_cs2_jr"/> describes how to restrict
+        access to database data at the user level by using roles and permissions.</li>
+      <li id="nk169480"><xref href="Auditing.xml#topic_ufw_zn2_jr"/> describes Greenplum Database
+        events that are logged and should be monitored to detect security threats. </li>
+      <li id="nk169507"><xref href="Encryption.xml#topic_th5_5bf_jr"/> describes how to encrypt data
+        in the database or in transit over the network, to protect from evesdroppers or
+        man-in-the-middle attacks. </li>
+      <li><xref href="kerberos-hdfs.xml#topic_lhr_yrf_qr"/> provides steps for configuring Greenplum
+        Database to access external tables in a Hadoop cluster secured with Kerberos.</li>
+      <li><xref href="BestPractices.xml#topic_nyc_mdf_jr"/> provides steps for securing Greenplum
+        Database hosts and the cluster. </li>
+    </ul>
+    <p>This guide assumes knowledge of Linux/UNIX system administration and database management
+      systems. Familiarity with structured query language (SQL) is helpful.</p>
+    <p>Because Greenplum Database is based on PostgreSQL8.3.23, this guide assumes some familiarity
+      with PostgreSQL. References to <xref
+        href="http://www.postgresql.org/docs/8.3/static/index.html" scope="external" format="html"
+          ><ph>PostgreSQL documentation</ph></xref> are provided throughout this guide for features
+      that are similar to those in Greenplum Database.</p>
+    <p>This guide provides information for system administrators responsible for administering a
+      Greenplum Database system.</p>
+  </body>
+</topic>


### PR DESCRIPTION
Updated security guide source added:
- Removed FIPS references
- Removed/updated references to older 4.x version
- Updated postgres base version to 8.3
- Removed ipsec info
- Removed DCA references
- Conditionalized GPCC/WLM info for pivotal-specific builds