### PR TITLE
Add "interesting" explain tests for subselect merge

### DIFF
--- a/src/test/regress/expected/DML_over_joins.out
+++ b/src/test/regress/expected/DML_over_joins.out
@@ -62,7 +62,47 @@ delete from r;
 delete from s;
 insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
 insert into s select generate_series(1, 100), generate_series(1, 100) * 4;
+explain update s set b = b + 1 where exists (select 1 from r where s.a = r.b);
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Update (slice0; segments: 3)  (rows=34 width=28)
+   ->  Explicit Redistribute Motion 3:3  (slice3; segments: 3)  (cost=153.00..154.25 rows=34 width=28)
+         ->  HashAggregate  (cost=153.00..154.25 rows=34 width=28)
+               Group By: s.ctid::bigint, s.gp_segment_id
+               ->  Result  (cost=11.75..152.50 rows=34 width=28)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=11.75..152.50 rows=34 width=28)
+                           Hash Key: s.ctid
+                           ->  Hash Join  (cost=11.75..150.50 rows=34 width=28)
+                                 Hash Cond: r.b = s.a
+                                 ->  Seq Scan on r  (cost=0.00..112.00 rows=3334 width=4)
+                                 ->  Hash  (cost=8.00..8.00 rows=100 width=18)
+                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..8.00 rows=100 width=18)
+                                             ->  Seq Scan on s  (cost=0.00..4.00 rows=34 width=18)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(15 rows)
+
 update s set b = b + 1 where exists (select 1 from r where s.a = r.b);
+explain delete from s where exists (select 1 from r where s.a = r.b);
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Delete (slice0; segments: 3)  (rows=34 width=20)
+   ->  Explicit Redistribute Motion 3:3  (slice3; segments: 3)  (cost=153.00..154.00 rows=34 width=20)
+         ->  HashAggregate  (cost=153.00..154.00 rows=34 width=20)
+               Group By: s.ctid::bigint, s.gp_segment_id
+               ->  Result  (cost=11.75..152.50 rows=34 width=20)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=11.75..152.50 rows=34 width=20)
+                           Hash Key: s.ctid
+                           ->  Hash Join  (cost=11.75..150.50 rows=34 width=20)
+                                 Hash Cond: r.b = s.a
+                                 ->  Seq Scan on r  (cost=0.00..112.00 rows=3334 width=4)
+                                 ->  Hash  (cost=8.00..8.00 rows=100 width=14)
+                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..8.00 rows=100 width=14)
+                                             ->  Seq Scan on s  (cost=0.00..4.00 rows=34 width=14)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(15 rows)
+
 delete from s where exists (select 1 from r where s.a = r.b);
 -- ----------------------------------------------------------------------
 -- Test: heap_motion1.sql

--- a/src/test/regress/expected/DML_over_joins_optimizer.out
+++ b/src/test/regress/expected/DML_over_joins_optimizer.out
@@ -63,7 +63,43 @@ delete from r;
 delete from s;
 insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
 insert into s select generate_series(1, 100), generate_series(1, 100) * 4;
+explain update s set b = b + 1 where exists (select 1 from r where s.a = r.b);
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Update  (cost=0.00..869.57 rows=34 width=1)
+   ->  Result  (cost=0.00..862.80 rows=67 width=26)
+         ->  Split  (cost=0.00..862.80 rows=67 width=22)
+               ->  Result  (cost=0.00..862.80 rows=34 width=22)
+                     ->  Hash EXISTS Join  (cost=0.00..862.80 rows=34 width=18)
+                           Hash Cond: dml_over_joins.s.a = r.b
+                           ->  Table Scan on s  (cost=0.00..431.00 rows=34 width=18)
+                           ->  Hash  (cost=431.15..431.15 rows=3334 width=4)
+                                 ->  Result  (cost=0.00..431.15 rows=3334 width=4)
+                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.14 rows=3334 width=4)
+                                             Hash Key: r.b
+                                             ->  Table Scan on r  (cost=0.00..431.07 rows=3334 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(14 rows)
+
 update s set b = b + 1 where exists (select 1 from r where s.a = r.b);
+explain delete from s where exists (select 1 from r where s.a = r.b);
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Delete  (cost=0.00..866.18 rows=34 width=1)
+   ->  Result  (cost=0.00..862.80 rows=34 width=26)
+         ->  Hash EXISTS Join  (cost=0.00..862.80 rows=34 width=18)
+               Hash Cond: dml_over_joins.s.a = r.b
+               ->  Table Scan on s  (cost=0.00..431.00 rows=34 width=18)
+               ->  Hash  (cost=431.15..431.15 rows=3334 width=4)
+                     ->  Result  (cost=0.00..431.15 rows=3334 width=4)
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.14 rows=3334 width=4)
+                                 Hash Key: r.b
+                                 ->  Table Scan on r  (cost=0.00..431.07 rows=3334 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(12 rows)
+
 delete from s where exists (select 1 from r where s.a = r.b);
 -- ----------------------------------------------------------------------
 -- Test: heap_motion1.sql

--- a/src/test/regress/expected/notin.out
+++ b/src/test/regress/expected/notin.out
@@ -74,6 +74,22 @@ insert into l1 values (generate_series (1,10), generate_series (1,10), generate_
 --
 --q1
 --
+explain select c1 from t1 where c1 not in 
+	(select c2 from t2);
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=2.49..5.68 rows=4 width=4)
+   ->  Hash Left Anti Semi Join (Not-In)  (cost=2.49..5.68 rows=2 width=4)
+         Hash Cond: t1.c1 = "NotIn_SUBQUERY".c2
+         ->  Seq Scan on t1  (cost=0.00..3.10 rows=4 width=4)
+         ->  Hash  (cost=2.30..2.30 rows=5 width=4)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.30 rows=5 width=4)
+                     ->  Subquery Scan "NotIn_SUBQUERY"  (cost=0.00..2.10 rows=2 width=4)
+                           ->  Seq Scan on t2  (cost=0.00..2.05 rows=2 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(10 rows)
+
 select c1 from t1 where c1 not in 
 	(select c2 from t2);
  c1 
@@ -88,6 +104,29 @@ select c1 from t1 where c1 not in
 --
 --q2
 --
+explain select c1 from t1 where c1 not in 
+	(select c2 from t2 where c2 > 2 and c2 not in 
+		(select c3 from t3));
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=4.49..7.66 rows=4 width=4)
+   ->  Hash Left Anti Semi Join (Not-In)  (cost=4.49..7.66 rows=2 width=4)
+         Hash Cond: t1.c1 = "NotIn_SUBQUERY".c2
+         ->  Seq Scan on t1  (cost=0.00..3.10 rows=4 width=4)
+         ->  Hash  (cost=4.45..4.45 rows=2 width=4)
+               ->  Subquery Scan "NotIn_SUBQUERY"  (cost=2.29..4.45 rows=2 width=4)
+                     ->  Hash Left Anti Semi Join (Not-In)  (cost=2.29..4.41 rows=2 width=4)
+                           Hash Cond: t2.c2 = "NotIn_SUBQUERY".c3
+                           ->  Seq Scan on t2  (cost=0.00..2.06 rows=2 width=4)
+                                 Filter: c2 > 2
+                           ->  Hash  (cost=2.18..2.18 rows=3 width=4)
+                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.18 rows=3 width=4)
+                                       ->  Subquery Scan "NotIn_SUBQUERY"  (cost=0.00..2.06 rows=1 width=4)
+                                             ->  Seq Scan on t3  (cost=0.00..2.03 rows=1 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(16 rows)
+
 select c1 from t1 where c1 not in 
 	(select c2 from t2 where c2 > 2 and c2 not in 
 		(select c3 from t3));
@@ -107,6 +146,36 @@ select c1 from t1 where c1 not in
 --
 --q3
 --
+explain select c1 from t1 where c1 not in 
+	(select c2 from t2 where c2 not in 
+		(select c3 from t3 where c3 not in 
+			(select c4 from t4)));
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)  (cost=5.98..9.17 rows=4 width=4)
+   ->  Hash Left Anti Semi Join (Not-In)  (cost=5.98..9.17 rows=2 width=4)
+         Hash Cond: t1.c1 = "NotIn_SUBQUERY".c2
+         ->  Seq Scan on t1  (cost=0.00..3.10 rows=4 width=4)
+         ->  Hash  (cost=5.86..5.86 rows=4 width=4)
+               ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=3.57..5.86 rows=4 width=4)
+                     ->  Subquery Scan "NotIn_SUBQUERY"  (cost=3.57..5.73 rows=2 width=4)
+                           ->  Hash Left Anti Semi Join (Not-In)  (cost=3.57..5.69 rows=2 width=4)
+                                 Hash Cond: t2.c2 = "NotIn_SUBQUERY".c3
+                                 ->  Seq Scan on t2  (cost=0.00..2.05 rows=2 width=4)
+                                 ->  Hash  (cost=3.45..3.45 rows=4 width=4)
+                                       ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=1.20..3.45 rows=4 width=4)
+                                             ->  Subquery Scan "NotIn_SUBQUERY"  (cost=1.20..3.31 rows=2 width=4)
+                                                   ->  Hash Left Anti Semi Join (Not-In)  (cost=1.20..3.28 rows=2 width=4)
+                                                         Hash Cond: t3.c3 = "NotIn_SUBQUERY".c4
+                                                         ->  Seq Scan on t3  (cost=0.00..2.03 rows=1 width=4)
+                                                         ->  Hash  (cost=1.12..1.12 rows=2 width=4)
+                                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.12 rows=2 width=4)
+                                                                     ->  Subquery Scan "NotIn_SUBQUERY"  (cost=0.00..1.04 rows=1 width=4)
+                                                                           ->  Seq Scan on t4  (cost=0.00..1.02 rows=1 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(22 rows)
+
 select c1 from t1 where c1 not in 
 	(select c2 from t2 where c2 not in 
 		(select c3 from t3 where c3 not in 
@@ -124,6 +193,28 @@ select c1 from t1 where c1 not in
 --
 --q4
 --
+explain select c1 from t1, 
+(select c2 from t2 where c2 not in 
+	(select c3 from t3)) foo 
+	where c1 = foo.c2;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=4.45..7.62 rows=4 width=4)
+   ->  Hash Join  (cost=4.45..7.62 rows=2 width=4)
+         Hash Cond: t1.c1 = t2.c2
+         ->  Seq Scan on t1  (cost=0.00..3.10 rows=4 width=4)
+         ->  Hash  (cost=4.41..4.41 rows=2 width=4)
+               ->  Hash Left Anti Semi Join (Not-In)  (cost=2.29..4.41 rows=2 width=4)
+                     Hash Cond: t2.c2 = "NotIn_SUBQUERY".c3
+                     ->  Seq Scan on t2  (cost=0.00..2.05 rows=2 width=4)
+                     ->  Hash  (cost=2.18..2.18 rows=3 width=4)
+                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.18 rows=3 width=4)
+                                 ->  Subquery Scan "NotIn_SUBQUERY"  (cost=0.00..2.06 rows=1 width=4)
+                                       ->  Seq Scan on t3  (cost=0.00..2.03 rows=1 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(14 rows)
+
 select c1 from t1, 
 (select c2 from t2 where c2 not in 
 	(select c3 from t3)) foo 
@@ -137,6 +228,30 @@ select c1 from t1,
 --
 --q5
 --
+explain select c1 from t1, 
+(select c2 from t2 where c2 not in 
+	(select c3 from t3) and c2 > 4) foo 
+	where c1 = foo.c2;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=4.44..7.62 rows=4 width=4)
+   ->  Hash Join  (cost=4.44..7.62 rows=2 width=4)
+         Hash Cond: t1.c1 = t2.c2
+         ->  Seq Scan on t1  (cost=0.00..3.12 rows=3 width=4)
+               Filter: c1 > 4
+         ->  Hash  (cost=4.40..4.40 rows=2 width=4)
+               ->  Hash Left Anti Semi Join (Not-In)  (cost=2.29..4.40 rows=2 width=4)
+                     Hash Cond: t2.c2 = "NotIn_SUBQUERY".c3
+                     ->  Seq Scan on t2  (cost=0.00..2.06 rows=1 width=4)
+                           Filter: c2 > 4
+                     ->  Hash  (cost=2.18..2.18 rows=3 width=4)
+                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.18 rows=3 width=4)
+                                 ->  Subquery Scan "NotIn_SUBQUERY"  (cost=0.00..2.06 rows=1 width=4)
+                                       ->  Seq Scan on t3  (cost=0.00..2.03 rows=1 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(16 rows)
+
 select c1 from t1, 
 (select c2 from t2 where c2 not in 
 	(select c3 from t3) and c2 > 4) foo 
@@ -149,6 +264,23 @@ select c1 from t1,
 --
 --q6
 --
+explain select c1 from t1 where c1 not in 
+	(select c2 from t2) and c1 > 1;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=2.49..5.71 rows=4 width=4)
+   ->  Hash Left Anti Semi Join (Not-In)  (cost=2.49..5.71 rows=2 width=4)
+         Hash Cond: t1.c1 = "NotIn_SUBQUERY".c2
+         ->  Seq Scan on t1  (cost=0.00..3.12 rows=4 width=4)
+               Filter: c1 > 1
+         ->  Hash  (cost=2.30..2.30 rows=5 width=4)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.30 rows=5 width=4)
+                     ->  Subquery Scan "NotIn_SUBQUERY"  (cost=0.00..2.10 rows=2 width=4)
+                           ->  Seq Scan on t2  (cost=0.00..2.05 rows=2 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(11 rows)
+
 select c1 from t1 where c1 not in 
 	(select c2 from t2) and c1 > 1;
  c1 
@@ -163,6 +295,23 @@ select c1 from t1 where c1 not in
 --
 --q7
 --
+explain select c1 from t1 where c1 > 6 and c1 not in 
+	(select c2 from t2) and c1 < 10;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=2.49..5.70 rows=4 width=4)
+   ->  Hash Left Anti Semi Join (Not-In)  (cost=2.49..5.70 rows=2 width=4)
+         Hash Cond: t1.c1 = "NotIn_SUBQUERY".c2
+         ->  Seq Scan on t1  (cost=0.00..3.15 rows=2 width=4)
+               Filter: c1 > 6 AND c1 < 10
+         ->  Hash  (cost=2.30..2.30 rows=5 width=4)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.30 rows=5 width=4)
+                     ->  Subquery Scan "NotIn_SUBQUERY"  (cost=0.00..2.10 rows=2 width=4)
+                           ->  Seq Scan on t2  (cost=0.00..2.05 rows=2 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(11 rows)
+
 select c1 from t1 where c1 > 6 and c1 not in 
 	(select c2 from t2) and c1 < 10;
  c1 
@@ -175,6 +324,26 @@ select c1 from t1 where c1 > 6 and c1 not in
 --
 --q8 introduce join
 --
+explain select c1 from t1,t2 where c1 not in 
+	(select c3 from t3) and c1 = c2;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=4.40..7.65 rows=4 width=4)
+   ->  Hash Left Anti Semi Join (Not-In)  (cost=4.40..7.65 rows=2 width=4)
+         Hash Cond: t1.c1 = "NotIn_SUBQUERY".c3
+         ->  Hash Join  (cost=2.11..5.30 rows=2 width=4)
+               Hash Cond: t1.c1 = t2.c2
+               ->  Seq Scan on t1  (cost=0.00..3.10 rows=4 width=4)
+               ->  Hash  (cost=2.05..2.05 rows=2 width=4)
+                     ->  Seq Scan on t2  (cost=0.00..2.05 rows=2 width=4)
+         ->  Hash  (cost=2.18..2.18 rows=3 width=4)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.18 rows=3 width=4)
+                     ->  Subquery Scan "NotIn_SUBQUERY"  (cost=0.00..2.06 rows=1 width=4)
+                           ->  Seq Scan on t3  (cost=0.00..2.03 rows=1 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(14 rows)
+
 select c1 from t1,t2 where c1 not in 
 	(select c3 from t3) and c1 = c2;
  c1 
@@ -240,6 +409,42 @@ select a,b from g1 where (a,b) not in
 --
 --q13
 --
+explain select x,y from l1 where (x,y) not in
+	(select distinct y, sum(x) from l1 group by y having y < 4 order by y) order by 1,2;
+                                                                        QUERY PLAN                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)  (cost=7.44..7.46 rows=10 width=8)
+   Merge Key: notin.l1.x, notin.l1.y
+   ->  Sort  (cost=7.44..7.46 rows=4 width=8)
+         Sort Key: notin.l1.x, notin.l1.y
+         ->  Nested Loop Left Anti Semi Join (Not-In)  (cost=3.42..7.27 rows=4 width=8)
+               Join Filter: notin.l1.x = "NotIn_SUBQUERY".y AND notin.l1.y = "NotIn_SUBQUERY".sum
+               ->  Seq Scan on l1  (cost=0.00..3.10 rows=4 width=8)
+               ->  Materialize  (cost=3.42..3.45 rows=1 width=12)
+                     ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=3.36..3.42 rows=1 width=12)
+                           ->  Subquery Scan "NotIn_SUBQUERY"  (cost=3.36..3.38 rows=1 width=12)
+                                 ->  Unique  (cost=3.36..3.37 rows=1 width=16)
+                                       Group By: notin.l1.y, (pg_catalog.sum((sum(notin.l1.x))))
+                                       ->  Sort  (cost=3.36..3.37 rows=1 width=16)
+                                             Sort Key (Distinct): notin.l1.y, (pg_catalog.sum((sum(notin.l1.x))))
+                                             ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=3.31..3.35 rows=1 width=16)
+                                                   Hash Key: notin.l1.y, (pg_catalog.sum((sum(notin.l1.x))))
+                                                   ->  Unique  (cost=3.31..3.33 rows=1 width=16)
+                                                         Group By: notin.l1.y, (pg_catalog.sum((sum(notin.l1.x))))
+                                                         ->  Sort  (cost=3.31..3.32 rows=1 width=16)
+                                                               Sort Key (Distinct): notin.l1.y, (pg_catalog.sum((sum(notin.l1.x))))
+                                                               ->  HashAggregate  (cost=3.25..3.28 rows=1 width=16)
+                                                                     Group By: notin.l1.y
+                                                                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=3.14..3.20 rows=1 width=12)
+                                                                           Hash Key: notin.l1.y
+                                                                           ->  HashAggregate  (cost=3.14..3.14 rows=1 width=12)
+                                                                                 Group By: notin.l1.y
+                                                                                 ->  Seq Scan on l1  (cost=0.00..3.12 rows=2 width=8)
+                                                                                       Filter: y < 4
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(30 rows)
+
 select x,y from l1 where (x,y) not in
 	(select distinct y, sum(x) from l1 group by y having y < 4 order by y) order by 1,2;
  x  | y  
@@ -256,6 +461,22 @@ select x,y from l1 where (x,y) not in
 --
 --q14
 --
+explain select * from g1 where (a,b,c) not in 
+	(select x,y,z from l1);
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=3.63..14.81 rows=11 width=12)
+   ->  Nested Loop Left Anti Semi Join (Not-In)  (cost=3.63..14.81 rows=4 width=12)
+         Join Filter: g1.a = "NotIn_SUBQUERY".x AND g1.b = "NotIn_SUBQUERY".y AND g1.c = "NotIn_SUBQUERY".z
+         ->  Seq Scan on g1  (cost=0.00..2.11 rows=4 width=12)
+         ->  Materialize  (cost=3.63..3.93 rows=10 width=12)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.60 rows=10 width=12)
+                     ->  Subquery Scan "NotIn_SUBQUERY"  (cost=0.00..3.20 rows=4 width=12)
+                           ->  Seq Scan on l1  (cost=0.00..3.10 rows=4 width=12)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(10 rows)
+
 select * from g1 where (a,b,c) not in 
 	(select x,y,z from l1);
  a | b | c 
@@ -271,6 +492,27 @@ select * from g1 where (a,b,c) not in
 --
 --q15
 --
+explain select c1 from t1, t2 where c1 not in 
+	(select c3 from t3 where c3 = c1) and c1 = c2;
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=2.11..15.49 rows=4 width=4)
+   ->  Hash Join  (cost=2.11..15.49 rows=2 width=4)
+         Hash Cond: t1.c1 = t2.c2
+         ->  Seq Scan on t1  (cost=0.00..13.32 rows=2 width=4)
+               Filter: (subplan)
+               SubPlan 1
+                 ->  Result  (cost=2.04..2.05 rows=1 width=4)
+                       Filter: t3.c3 = $0
+                       ->  Materialize  (cost=2.04..2.05 rows=1 width=4)
+                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.04 rows=1 width=4)
+                                   ->  Seq Scan on t3  (cost=0.00..2.04 rows=1 width=4)
+         ->  Hash  (cost=2.05..2.05 rows=2 width=4)
+               ->  Seq Scan on t2  (cost=0.00..2.05 rows=2 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(15 rows)
+
 select c1 from t1, t2 where c1 not in 
 	(select c3 from t3 where c3 = c1) and c1 = c2;
  c1 
@@ -320,6 +562,25 @@ select c1 from t1 join t2 on c1 = c2 where c1 not in
 --
 --q20
 --
+explain select c1 from t1 where c1 not in 
+	(select sum(c2) as s from t2 where c2 > 2 group by c2 having c2 > 3);
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=2.29..5.46 rows=4 width=4)
+   ->  Hash Left Anti Semi Join (Not-In)  (cost=2.29..5.46 rows=2 width=4)
+         Hash Cond: t1.c1 = "NotIn_SUBQUERY".s
+         ->  Seq Scan on t1  (cost=0.00..3.10 rows=4 width=4)
+         ->  Hash  (cost=2.21..2.21 rows=2 width=8)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=2.09..2.21 rows=2 width=8)
+                     ->  Subquery Scan "NotIn_SUBQUERY"  (cost=2.09..2.13 rows=1 width=8)
+                           ->  HashAggregate  (cost=2.09..2.11 rows=1 width=16)
+                                 Group By: t2.c2
+                                 ->  Seq Scan on t2  (cost=0.00..2.08 rows=1 width=4)
+                                       Filter: c2 > 2 AND c2 > 3
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(13 rows)
+
 select c1 from t1 where c1 not in 
 	(select sum(c2) as s from t2 where c2 > 2 group by c2 having c2 > 3);
  c1 
@@ -406,6 +667,39 @@ select c1 from t1 where c1 not in
 --
 --q26
 --
+explain select (case when c1%2 = 0 
+ then (select sum(c2) from t2 where c2 not in (select c3 from t3)) 
+ else (select sum(c3) from t3 where c3 not in (select c4 from t4)) end) as foo from t1;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice5; segments: 3)  (cost=7.86..11.01 rows=10 width=4)
+   ->  Seq Scan on t1  (cost=7.86..11.01 rows=4 width=4)
+         InitPlan  (slice6)
+           ->  Aggregate  (cost=4.49..4.50 rows=1 width=8)
+                 ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=4.42..4.47 rows=1 width=8)
+                       ->  Aggregate  (cost=4.42..4.43 rows=1 width=8)
+                             ->  Hash Left Anti Semi Join (Not-In)  (cost=2.29..4.41 rows=2 width=4)
+                                   Hash Cond: t2.c2 = "NotIn_SUBQUERY".c3
+                                   ->  Seq Scan on t2  (cost=0.00..2.05 rows=2 width=4)
+                                   ->  Hash  (cost=2.18..2.18 rows=3 width=4)
+                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.18 rows=3 width=4)
+                                               ->  Subquery Scan "NotIn_SUBQUERY"  (cost=0.00..2.06 rows=1 width=4)
+                                                     ->  Seq Scan on t3  (cost=0.00..2.03 rows=1 width=4)
+         InitPlan  (slice7)
+           ->  Aggregate  (cost=3.36..3.37 rows=1 width=8)
+                 ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=3.29..3.34 rows=1 width=8)
+                       ->  Aggregate  (cost=3.29..3.30 rows=1 width=8)
+                             ->  Hash Left Anti Semi Join (Not-In)  (cost=1.20..3.28 rows=2 width=4)
+                                   Hash Cond: notin.t3.c3 = "NotIn_SUBQUERY".c4
+                                   ->  Seq Scan on t3  (cost=0.00..2.03 rows=1 width=4)
+                                   ->  Hash  (cost=1.12..1.12 rows=2 width=4)
+                                         ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..1.12 rows=2 width=4)
+                                               ->  Subquery Scan "NotIn_SUBQUERY"  (cost=0.00..1.04 rows=1 width=4)
+                                                     ->  Seq Scan on t4  (cost=0.00..1.02 rows=1 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(26 rows)
+
 select (case when c1%2 = 0 
  then (select sum(c2) from t2 where c2 not in (select c3 from t3)) 
  else (select sum(c3) from t3 where c3 not in (select c4 from t4)) end) as foo from t1;
@@ -426,6 +720,21 @@ select (case when c1%2 = 0
 --
 --q27
 --
+explain select c1 from t1 where not c1 >= some (select c2 from t2);
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=2.31..8.79 rows=4 width=4)
+   ->  Nested Loop Left Anti Semi Join (Not-In)  (cost=2.31..8.79 rows=2 width=4)
+         Join Filter: t1.c1 >= "NotIn_SUBQUERY".c2
+         ->  Seq Scan on t1  (cost=0.00..3.10 rows=4 width=4)
+         ->  Materialize  (cost=2.31..2.46 rows=5 width=4)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.30 rows=5 width=4)
+                     ->  Subquery Scan "NotIn_SUBQUERY"  (cost=0.00..2.10 rows=2 width=4)
+                           ->  Seq Scan on t2  (cost=0.00..2.05 rows=2 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(10 rows)
+
 select c1 from t1 where not c1 >= some (select c2 from t2);
  c1 
 ----
@@ -434,6 +743,20 @@ select c1 from t1 where not c1 >= some (select c2 from t2);
 --
 --q28
 --
+explain select c2 from t2 where not c2 < all (select c2 from t2);
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=2.27..6.00 rows=9 width=4)
+   ->  Nested Loop EXISTS Join  (cost=2.27..6.00 rows=3 width=4)
+         Join Filter: notin.t2.c2 >= notin.t2.c2
+         ->  Seq Scan on t2  (cost=0.00..2.05 rows=2 width=4)
+         ->  Materialize  (cost=2.27..2.42 rows=5 width=4)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.25 rows=5 width=4)
+                     ->  Seq Scan on t2  (cost=0.00..2.05 rows=2 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(9 rows)
+
 select c2 from t2 where not c2 < all (select c2 from t2);
  c2 
 ----
@@ -447,6 +770,21 @@ select c2 from t2 where not c2 < all (select c2 from t2);
 --
 --q29
 --
+explain select c3 from t3 where not c3 <> any (select c4 from t4);
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=1.13..3.56 rows=4 width=4)
+   ->  Nested Loop Left Anti Semi Join (Not-In)  (cost=1.13..3.56 rows=2 width=4)
+         Join Filter: t3.c3 <> "NotIn_SUBQUERY".c4
+         ->  Seq Scan on t3  (cost=0.00..2.03 rows=1 width=4)
+         ->  Materialize  (cost=1.13..1.19 rows=2 width=4)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.12 rows=2 width=4)
+                     ->  Subquery Scan "NotIn_SUBQUERY"  (cost=0.00..1.04 rows=1 width=4)
+                           ->  Seq Scan on t4  (cost=0.00..1.02 rows=1 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(10 rows)
+
 select c3 from t3 where not c3 <> any (select c4 from t4);
  c3 
 ----
@@ -455,6 +793,30 @@ select c3 from t3 where not c3 <> any (select c4 from t4);
 --
 --q31
 --
+explain select c1 from t1 where c1 not in (select c2 from t2 order by c2 limit 3) order by c1;
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=5.65..5.66 rows=4 width=4)
+   Merge Key: t1.c1
+   ->  Sort  (cost=5.65..5.66 rows=2 width=4)
+         Sort Key: t1.c1
+         ->  Hash Left Anti Semi Join (Not-In)  (cost=2.44..5.62 rows=2 width=4)
+               Hash Cond: t1.c1 = "NotIn_SUBQUERY".c2
+               ->  Seq Scan on t1  (cost=0.00..3.10 rows=4 width=4)
+               ->  Hash  (cost=2.33..2.33 rows=3 width=4)
+                     ->  Broadcast Motion 1:3  (slice2; segments: 1)  (cost=2.11..2.33 rows=9 width=4)
+                           ->  Subquery Scan "NotIn_SUBQUERY"  (cost=2.11..2.21 rows=3 width=4)
+                                 ->  Limit  (cost=2.11..2.18 rows=3 width=4)
+                                       ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=2.11..2.18 rows=3 width=4)
+                                             Merge Key: t2.c2
+                                             ->  Limit  (cost=2.11..2.12 rows=1 width=4)
+                                                   ->  Sort  (cost=2.11..2.12 rows=2 width=4)
+                                                         Sort Key: t2.c2
+                                                         ->  Seq Scan on t2  (cost=0.00..2.05 rows=2 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(19 rows)
+
 select c1 from t1 where c1 not in (select c2 from t2 order by c2 limit 3) order by c1;
  c1 
 ----
@@ -471,6 +833,22 @@ select c1 from t1 where c1 not in (select c2 from t2 order by c2 limit 3) order 
 --
 --q32
 --
+explain select c1 from t1 where c1 =all (select c2 from t2 where c2 > -1 and c2 <= 1);
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=2.13..5.90 rows=9 width=4)
+   ->  Nested Loop Left Anti Semi Join (Not-In)  (cost=2.13..5.90 rows=3 width=4)
+         Join Filter: t1.c1 <> "NotIn_SUBQUERY".c2
+         ->  Seq Scan on t1  (cost=0.00..3.10 rows=4 width=4)
+         ->  Materialize  (cost=2.13..2.16 rows=1 width=4)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.12 rows=1 width=4)
+                     ->  Subquery Scan "NotIn_SUBQUERY"  (cost=0.00..2.08 rows=1 width=4)
+                           ->  Seq Scan on t2  (cost=0.00..2.08 rows=1 width=4)
+                                 Filter: c2 > (-1) AND c2 <= 1
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(11 rows)
+
 select c1 from t1 where c1 =all (select c2 from t2 where c2 > -1 and c2 <= 1);
  c1 
 ----
@@ -480,6 +858,21 @@ select c1 from t1 where c1 =all (select c2 from t2 where c2 > -1 and c2 <= 1);
 --
 --q33
 --
+explain select c1 from t1 where c1 <>all (select c2 from t2);
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=2.49..5.68 rows=4 width=4)
+   ->  Hash Left Anti Semi Join (Not-In)  (cost=2.49..5.68 rows=2 width=4)
+         Hash Cond: t1.c1 = "NotIn_SUBQUERY".c2
+         ->  Seq Scan on t1  (cost=0.00..3.10 rows=4 width=4)
+         ->  Hash  (cost=2.30..2.30 rows=5 width=4)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.30 rows=5 width=4)
+                     ->  Subquery Scan "NotIn_SUBQUERY"  (cost=0.00..2.10 rows=2 width=4)
+                           ->  Seq Scan on t2  (cost=0.00..2.05 rows=2 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(10 rows)
+
 select c1 from t1 where c1 <>all (select c2 from t2);
  c1 
 ----
@@ -493,6 +886,27 @@ select c1 from t1 where c1 <>all (select c2 from t2);
 --
 --q34
 --
+explain select c1 from t1 where c1 <=all (select c2 from t2 where c2 not in (select c1n from t1n));
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=4.99..10.33 rows=4 width=4)
+   ->  Nested Loop Left Anti Semi Join (Not-In)  (cost=4.99..10.33 rows=2 width=4)
+         Join Filter: t1.c1 > "NotIn_SUBQUERY".c2
+         ->  Seq Scan on t1  (cost=0.00..3.10 rows=4 width=4)
+         ->  Materialize  (cost=4.99..5.09 rows=4 width=4)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=2.68..4.98 rows=4 width=4)
+                     ->  Subquery Scan "NotIn_SUBQUERY"  (cost=2.68..4.85 rows=2 width=4)
+                           ->  Hash Left Anti Semi Join (Not-In)  (cost=2.68..4.82 rows=2 width=4)
+                                 Hash Cond: t2.c2 = "NotIn_SUBQUERY".c1n
+                                 ->  Seq Scan on t2  (cost=0.00..2.05 rows=2 width=4)
+                                 ->  Hash  (cost=2.42..2.42 rows=7 width=4)
+                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.42 rows=7 width=4)
+                                             ->  Subquery Scan "NotIn_SUBQUERY"  (cost=0.00..2.14 rows=3 width=4)
+                                                   ->  Seq Scan on t1n  (cost=0.00..2.07 rows=3 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(16 rows)
+
 select c1 from t1 where c1 <=all (select c2 from t2 where c2 not in (select c1n from t1n));
  c1 
 ----
@@ -511,6 +925,25 @@ select c1 from t1 where c1 <=all (select c2 from t2 where c2 not in (select c1n 
 --
 --q35
 --
+explain select c1 from t1 where not c1 =all (select c2 from t2 where not c2 >all (select c3 from t3));
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=5.43..11.91 rows=45 width=4)
+   ->  Nested Loop EXISTS Join  (cost=5.43..11.91 rows=15 width=4)
+         Join Filter: t1.c1 <> t2.c2
+         ->  Seq Scan on t1  (cost=0.00..3.10 rows=4 width=4)
+         ->  Materialize  (cost=5.43..5.58 rows=5 width=8)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=2.05..5.42 rows=5 width=8)
+                     ->  Nested Loop  (cost=2.05..5.22 rows=2 width=8)
+                           Join Filter: t2.c2 <= t3.c3
+                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.15 rows=3 width=4)
+                                 ->  Seq Scan on t3  (cost=0.00..2.03 rows=1 width=4)
+                           ->  Materialize  (cost=2.05..2.10 rows=2 width=4)
+                                 ->  Seq Scan on t2  (cost=0.00..2.05 rows=2 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(14 rows)
+
 select c1 from t1 where not c1 =all (select c2 from t2 where not c2 >all (select c3 from t3));
  c1 
 ----
@@ -529,6 +962,26 @@ select c1 from t1 where not c1 =all (select c2 from t2 where not c2 >all (select
 --
 --q36
 --
+explain select c1 from t1 where not c1 <>all (select c1n from t1n where c1n <all (select c3 from t3 where c3 = c1n));
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=9.27..12.44 rows=4 width=4)
+   ->  Hash EXISTS Join  (cost=9.27..12.44 rows=2 width=4)
+         Hash Cond: t1.c1 = t1n.c1n
+         ->  Seq Scan on t1  (cost=0.00..3.10 rows=4 width=4)
+         ->  Hash  (cost=9.23..9.23 rows=2 width=4)
+               ->  Seq Scan on t1n  (cost=0.00..9.23 rows=2 width=4)
+                     Filter: (subplan)
+                     SubPlan 1
+                       ->  Result  (cost=2.04..2.05 rows=1 width=4)
+                             Filter: t3.c3 = $0
+                             ->  Materialize  (cost=2.04..2.05 rows=1 width=4)
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.04 rows=1 width=4)
+                                         ->  Seq Scan on t3  (cost=0.00..2.04 rows=1 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(15 rows)
+
 select c1 from t1 where not c1 <>all (select c1n from t1n where c1n <all (select c3 from t3 where c3 = c1n));
  c1 
 ----
@@ -540,6 +993,20 @@ select c1 from t1 where not c1 <>all (select c1n from t1n where c1n <all (select
 --
 --q37
 --
+explain select c1 from t1 where not c1 >=all (select c2 from t2 where c2 = c1);
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2.11..5.30 rows=4 width=4)
+   ->  Hash EXISTS Join  (cost=2.11..5.30 rows=2 width=4)
+         Hash Cond: t1.c1 = t2.c2
+         Join Filter: t1.c1 < t2.c2
+         ->  Seq Scan on t1  (cost=0.00..3.10 rows=4 width=4)
+         ->  Hash  (cost=2.05..2.05 rows=2 width=4)
+               ->  Seq Scan on t2  (cost=0.00..2.05 rows=2 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(9 rows)
+
 select c1 from t1 where not c1 >=all (select c2 from t2 where c2 = c1);
  c1 
 ----
@@ -548,6 +1015,20 @@ select c1 from t1 where not c1 >=all (select c2 from t2 where c2 = c1);
 --
 --q38
 --
+explain select c1 from t1 where not exists (select c2 from t2 where c2 = c1);
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2.11..5.28 rows=4 width=4)
+   ->  Hash Left Anti Semi Join  (cost=2.11..5.28 rows=2 width=4)
+         Hash Cond: t1.c1 = t2.c2
+         ->  Seq Scan on t1  (cost=0.00..3.10 rows=4 width=4)
+         ->  Hash  (cost=2.05..2.05 rows=2 width=4)
+               ->  Seq Scan on t2  (cost=0.00..2.05 rows=2 width=4)
+                     Filter: c2 IS NOT NULL
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(9 rows)
+
 select c1 from t1 where not exists (select c2 from t2 where c2 = c1);
  c1 
 ----
@@ -561,6 +1042,26 @@ select c1 from t1 where not exists (select c2 from t2 where c2 = c1);
 --
 --q39
 --
+explain select c1 from t1 where not exists (select c2 from t2 where c2 not in (select c3 from t3) and c2 = c1);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=4.45..7.62 rows=4 width=4)
+   ->  Hash Left Anti Semi Join  (cost=4.45..7.62 rows=2 width=4)
+         Hash Cond: t1.c1 = t2.c2
+         ->  Seq Scan on t1  (cost=0.00..3.10 rows=4 width=4)
+         ->  Hash  (cost=4.41..4.41 rows=2 width=4)
+               ->  Hash Left Anti Semi Join (Not-In)  (cost=2.29..4.41 rows=2 width=4)
+                     Hash Cond: t2.c2 = "NotIn_SUBQUERY".c3
+                     ->  Seq Scan on t2  (cost=0.00..2.05 rows=2 width=4)
+                           Filter: c2 IS NOT NULL
+                     ->  Hash  (cost=2.18..2.18 rows=3 width=4)
+                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.18 rows=3 width=4)
+                                 ->  Subquery Scan "NotIn_SUBQUERY"  (cost=0.00..2.06 rows=1 width=4)
+                                       ->  Seq Scan on t3  (cost=0.00..2.03 rows=1 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(15 rows)
+
 select c1 from t1 where not exists (select c2 from t2 where c2 not in (select c3 from t3) and c2 = c1);
  c1 
 ----
@@ -577,6 +1078,33 @@ select c1 from t1 where not exists (select c2 from t2 where c2 not in (select c3
 --
 --q40
 --
+explain select c1 from t1 where not exists (select c2 from t2 where exists (select c3 from t3) and c2 <>all (select c3 from t3) and c2 = c1);
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=5.16..8.33 rows=4 width=4)
+   ->  Hash Left Anti Semi Join  (cost=5.16..8.33 rows=2 width=4)
+         Hash Cond: t1.c1 = t2.c2
+         InitPlan  (slice4)
+           ->  Limit  (cost=0.00..0.70 rows=1 width=0)
+                 ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..0.70 rows=1 width=0)
+                       ->  Limit  (cost=0.00..0.68 rows=1 width=0)
+                             ->  Seq Scan on t3  (cost=0.00..2.03 rows=1 width=0)
+         ->  Seq Scan on t1  (cost=0.00..3.10 rows=4 width=4)
+         ->  Hash  (cost=4.42..4.42 rows=2 width=4)
+               ->  Result  (cost=2.29..4.42 rows=2 width=4)
+                     One-Time Filter: $0
+                     ->  Hash Left Anti Semi Join (Not-In)  (cost=2.29..4.42 rows=2 width=4)
+                           Hash Cond: t2.c2 = "NotIn_SUBQUERY".c3
+                           ->  Seq Scan on t2  (cost=0.00..2.05 rows=2 width=4)
+                                 Filter: c2 IS NOT NULL
+                           ->  Hash  (cost=2.18..2.18 rows=3 width=4)
+                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.18 rows=3 width=4)
+                                       ->  Subquery Scan "NotIn_SUBQUERY"  (cost=0.00..2.06 rows=1 width=4)
+                                             ->  Seq Scan on t3  (cost=0.00..2.03 rows=1 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(22 rows)
+
 select c1 from t1 where not exists (select c2 from t2 where exists (select c3 from t3) and c2 <>all (select c3 from t3) and c2 = c1);
  c1 
 ----
@@ -619,6 +1147,22 @@ select c1 from t1 where not not not c1 in (select c2 from t2);
 --
 --q43
 --
+explain select c1 from t1 where c1 not in (select c2 from t2 where c2 > 4) and c1 is not null;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2.09..5.25 rows=4 width=4)
+   ->  Hash Left Anti Semi Join (Not-In)  (cost=2.09..5.25 rows=2 width=4)
+         Hash Cond: t1.c1 = "NotIn_SUBQUERY".c2
+         ->  Seq Scan on t1  (cost=0.00..3.10 rows=4 width=4)
+               Filter: c1 IS NOT NULL
+         ->  Hash  (cost=2.08..2.08 rows=1 width=4)
+               ->  Subquery Scan "NotIn_SUBQUERY"  (cost=0.00..2.08 rows=1 width=4)
+                     ->  Seq Scan on t2  (cost=0.00..2.06 rows=1 width=4)
+                           Filter: c2 > 4
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(11 rows)
+
 select c1 from t1 where c1 not in (select c2 from t2 where c2 > 4) and c1 is not null;
  c1 
 ----

--- a/src/test/regress/expected/notin_optimizer.out
+++ b/src/test/regress/expected/notin_optimizer.out
@@ -1,0 +1,1224 @@
+--
+-- NOTIN 
+-- Test NOTIN clauses
+--
+create schema notin;
+set search_path=notin;
+--
+-- generate a bunch of tables
+--
+create table t1 (
+	c1 integer
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t2 (
+	c2 integer
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c2' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t3 (
+	c3 integer
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c3' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t4 (
+	c4 integer
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c4' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t1n (
+	c1n integer
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1n' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table g1 (
+	a integer,
+	b integer,
+	c integer
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table l1 (
+	w integer,
+	x integer,
+	y integer,
+	z integer
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'w' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+--
+-- stick in some values
+--
+insert into t1 values (generate_series (1,10));
+insert into t2 values (generate_series (1,5));
+insert into t3 values (1), (2), (3);
+insert into t4 values (1), (2);
+insert into t1n values (1), (2), (3), (null), (5), (6), (7);
+insert into g1 values
+  (1,1,1),
+  (1,1,2),
+  (1,2,2),
+  (2,2,2),
+  (2,2,3),
+  (2,3,3),
+  (3,3,3),
+  (3,3,3),
+  (3,3,4),
+  (3,4,4),
+  (4,4,4);
+insert into l1 values (generate_series (1,10), generate_series (1,10), generate_series (1,10), generate_series (1,10));
+--
+-- queries
+--
+--
+--q1
+--
+explain select c1 from t1 where c1 not in 
+	(select c2 from t2);
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=4 width=4)
+   ->  Hash Left Anti Semi Join (Not-In)  (cost=0.00..862.00 rows=2 width=4)
+         Hash Cond: t1.c1 = t2.c2
+         ->  Table Scan on t1  (cost=0.00..431.00 rows=4 width=4)
+         ->  Hash  (cost=431.00..431.00 rows=5 width=4)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=5 width=4)
+                     ->  Table Scan on t2  (cost=0.00..431.00 rows=2 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(9 rows)
+
+select c1 from t1 where c1 not in 
+	(select c2 from t2);
+ c1 
+----
+  8
+  9
+ 10
+  6
+  7
+(5 rows)
+
+--
+--q2
+--
+explain select c1 from t1 where c1 not in 
+	(select c2 from t2 where c2 > 2 and c2 not in 
+		(select c3 from t3));
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1293.00 rows=4 width=4)
+   ->  Hash Left Anti Semi Join (Not-In)  (cost=0.00..1293.00 rows=2 width=4)
+         Hash Cond: t1.c1 = t2.c2
+         ->  Table Scan on t1  (cost=0.00..431.00 rows=4 width=4)
+         ->  Hash  (cost=862.00..862.00 rows=1 width=4)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+                     ->  Hash Left Anti Semi Join (Not-In)  (cost=0.00..862.00 rows=1 width=4)
+                           Hash Cond: t2.c2 = t3.c3
+                           ->  Table Scan on t2  (cost=0.00..431.00 rows=1 width=4)
+                                 Filter: c2 > 2
+                           ->  Hash  (cost=431.00..431.00 rows=3 width=4)
+                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
+                                       ->  Table Scan on t3  (cost=0.00..431.00 rows=1 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(15 rows)
+
+select c1 from t1 where c1 not in 
+	(select c2 from t2 where c2 > 2 and c2 not in 
+		(select c3 from t3));
+ c1 
+----
+  3
+  6
+  7
+  1
+  2
+  8
+  9
+ 10
+(8 rows)
+
+	
+--
+--q3
+--
+explain select c1 from t1 where c1 not in 
+	(select c2 from t2 where c2 not in 
+		(select c3 from t3 where c3 not in 
+			(select c4 from t4)));
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1724.00 rows=4 width=4)
+   ->  Hash Left Anti Semi Join (Not-In)  (cost=0.00..1724.00 rows=2 width=4)
+         Hash Cond: t1.c1 = t2.c2
+         ->  Table Scan on t1  (cost=0.00..431.00 rows=4 width=4)
+         ->  Hash  (cost=1293.00..1293.00 rows=2 width=4)
+               ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..1293.00 rows=2 width=4)
+                     ->  Hash Left Anti Semi Join (Not-In)  (cost=0.00..1293.00 rows=1 width=4)
+                           Hash Cond: t2.c2 = t3.c3
+                           ->  Table Scan on t2  (cost=0.00..431.00 rows=2 width=4)
+                           ->  Hash  (cost=862.00..862.00 rows=2 width=4)
+                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=2 width=4)
+                                       ->  Hash Left Anti Semi Join (Not-In)  (cost=0.00..862.00 rows=1 width=4)
+                                             Hash Cond: t3.c3 = t4.c4
+                                             ->  Table Scan on t3  (cost=0.00..431.00 rows=1 width=4)
+                                             ->  Hash  (cost=431.00..431.00 rows=2 width=4)
+                                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
+                                                         ->  Table Scan on t4  (cost=0.00..431.00 rows=1 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(19 rows)
+
+select c1 from t1 where c1 not in 
+	(select c2 from t2 where c2 not in 
+		(select c3 from t3 where c3 not in 
+			(select c4 from t4)));
+ c1 
+----
+  3
+  6
+  7
+  8
+  9
+ 10
+(6 rows)
+
+--
+--q4
+--
+explain select c1 from t1, 
+(select c2 from t2 where c2 not in 
+	(select c3 from t3)) foo 
+	where c1 = foo.c2;
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.00 rows=2 width=4)
+   ->  Hash Join  (cost=0.00..1293.00 rows=1 width=4)
+         Hash Cond: t1.c1 = t2.c2
+         ->  Table Scan on t1  (cost=0.00..431.00 rows=4 width=4)
+         ->  Hash  (cost=862.00..862.00 rows=1 width=4)
+               ->  Hash Left Anti Semi Join (Not-In)  (cost=0.00..862.00 rows=1 width=4)
+                     Hash Cond: t2.c2 = t3.c3
+                     ->  Table Scan on t2  (cost=0.00..431.00 rows=2 width=4)
+                     ->  Hash  (cost=431.00..431.00 rows=3 width=4)
+                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
+                                 ->  Table Scan on t3  (cost=0.00..431.00 rows=1 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(13 rows)
+
+select c1 from t1, 
+(select c2 from t2 where c2 not in 
+	(select c3 from t3)) foo 
+	where c1 = foo.c2;
+ c1 
+----
+  4
+  5
+(2 rows)
+
+--
+--q5
+--
+explain select c1 from t1, 
+(select c2 from t2 where c2 not in 
+	(select c3 from t3) and c2 > 4) foo 
+	where c1 = foo.c2;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Hash Left Anti Semi Join (Not-In)  (cost=0.00..1293.00 rows=1 width=4)
+   Hash Cond: t2.c2 = t3.c3
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+         ->  Hash Join  (cost=0.00..862.00 rows=1 width=8)
+               Hash Cond: t1.c1 = t2.c2
+               ->  Table Scan on t1  (cost=0.00..431.00 rows=2 width=4)
+                     Filter: c1 > 4
+               ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                     ->  Table Scan on t2  (cost=0.00..431.00 rows=1 width=4)
+                           Filter: c2 > 4
+   ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+         ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
+               ->  Table Scan on t3  (cost=0.00..431.00 rows=1 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(15 rows)
+
+select c1 from t1, 
+(select c2 from t2 where c2 not in 
+	(select c3 from t3) and c2 > 4) foo 
+	where c1 = foo.c2;
+ c1 
+----
+  5
+(1 row)
+
+--
+--q6
+--
+explain select c1 from t1 where c1 not in 
+	(select c2 from t2) and c1 > 1;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=4 width=4)
+   ->  Hash Left Anti Semi Join (Not-In)  (cost=0.00..862.00 rows=2 width=4)
+         Hash Cond: t1.c1 = t2.c2
+         ->  Table Scan on t1  (cost=0.00..431.00 rows=3 width=4)
+               Filter: c1 > 1
+         ->  Hash  (cost=431.00..431.00 rows=5 width=4)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=5 width=4)
+                     ->  Table Scan on t2  (cost=0.00..431.00 rows=2 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(10 rows)
+
+select c1 from t1 where c1 not in 
+	(select c2 from t2) and c1 > 1;
+ c1 
+----
+  8
+  9
+ 10
+  6
+  7
+(5 rows)
+
+--
+--q7
+--
+explain select c1 from t1 where c1 > 6 and c1 not in 
+	(select c2 from t2) and c1 < 10;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=2 width=4)
+   ->  Hash Left Anti Semi Join (Not-In)  (cost=0.00..862.00 rows=1 width=4)
+         Hash Cond: t1.c1 = t2.c2
+         ->  Table Scan on t1  (cost=0.00..431.00 rows=2 width=4)
+               Filter: c1 > 6 AND c1 < 10
+         ->  Hash  (cost=431.00..431.00 rows=5 width=4)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=5 width=4)
+                     ->  Table Scan on t2  (cost=0.00..431.00 rows=2 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(10 rows)
+
+select c1 from t1 where c1 > 6 and c1 not in 
+	(select c2 from t2) and c1 < 10;
+ c1 
+----
+  7
+  8
+  9
+(3 rows)
+
+--
+--q8 introduce join
+--
+explain select c1 from t1,t2 where c1 not in 
+	(select c3 from t3) and c1 = c2;
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.00 rows=2 width=4)
+   ->  Hash Join  (cost=0.00..1293.00 rows=1 width=4)
+         Hash Cond: t2.c2 = t1.c1
+         ->  Table Scan on t2  (cost=0.00..431.00 rows=2 width=4)
+         ->  Hash  (cost=862.00..862.00 rows=2 width=4)
+               ->  Hash Left Anti Semi Join (Not-In)  (cost=0.00..862.00 rows=2 width=4)
+                     Hash Cond: t1.c1 = t3.c3
+                     ->  Table Scan on t1  (cost=0.00..431.00 rows=4 width=4)
+                     ->  Hash  (cost=431.00..431.00 rows=3 width=4)
+                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
+                                 ->  Table Scan on t3  (cost=0.00..431.00 rows=1 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(13 rows)
+
+select c1 from t1,t2 where c1 not in 
+	(select c3 from t3) and c1 = c2;
+ c1 
+----
+  4
+  5
+(2 rows)
+
+--
+--q9
+--
+select c1 from t1 where c1 not in 
+	(select c2 from t2 where c2 > 2 and c2 < 5);
+ c1 
+----
+  1
+  2
+  5
+  6
+  7
+  8
+  9
+ 10
+(8 rows)
+
+--
+--q10
+--
+select count(c1) from t1 where c1 not in 
+	(select sum(c2) from t2);
+ count 
+-------
+    10
+(1 row)
+
+--
+--q11
+--
+select c1 from t1 where c1 not in 
+	(select count(*) from t1);
+ c1 
+----
+  3
+  4
+  5
+  6
+  7
+  1
+  2
+  8
+  9
+(9 rows)
+
+--
+--q12
+--
+select a,b from g1 where (a,b) not in
+	(select a,b from g1);
+ a | b 
+---+---
+(0 rows)
+
+--
+--q13
+--
+explain select x,y from l1 where (x,y) not in
+	(select distinct y, sum(x) from l1 group by y having y < 4 order by y) order by 1,2;
+                                                                        QUERY PLAN                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)  (cost=7.44..7.46 rows=10 width=8)
+   Merge Key: notin.l1.x, notin.l1.y
+   ->  Sort  (cost=7.44..7.46 rows=4 width=8)
+         Sort Key: notin.l1.x, notin.l1.y
+         ->  Nested Loop Left Anti Semi Join (Not-In)  (cost=3.42..7.27 rows=4 width=8)
+               Join Filter: notin.l1.x = "NotIn_SUBQUERY".y AND notin.l1.y = "NotIn_SUBQUERY".sum
+               ->  Seq Scan on l1  (cost=0.00..3.10 rows=4 width=8)
+               ->  Materialize  (cost=3.42..3.45 rows=1 width=12)
+                     ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=3.36..3.42 rows=1 width=12)
+                           ->  Subquery Scan "NotIn_SUBQUERY"  (cost=3.36..3.38 rows=1 width=12)
+                                 ->  Unique  (cost=3.36..3.37 rows=1 width=16)
+                                       Group By: notin.l1.y, (pg_catalog.sum((sum(notin.l1.x))))
+                                       ->  Sort  (cost=3.36..3.37 rows=1 width=16)
+                                             Sort Key (Distinct): notin.l1.y, (pg_catalog.sum((sum(notin.l1.x))))
+                                             ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=3.31..3.35 rows=1 width=16)
+                                                   Hash Key: notin.l1.y, (pg_catalog.sum((sum(notin.l1.x))))
+                                                   ->  Unique  (cost=3.31..3.33 rows=1 width=16)
+                                                         Group By: notin.l1.y, (pg_catalog.sum((sum(notin.l1.x))))
+                                                         ->  Sort  (cost=3.31..3.32 rows=1 width=16)
+                                                               Sort Key (Distinct): notin.l1.y, (pg_catalog.sum((sum(notin.l1.x))))
+                                                               ->  HashAggregate  (cost=3.25..3.28 rows=1 width=16)
+                                                                     Group By: notin.l1.y
+                                                                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=3.14..3.20 rows=1 width=12)
+                                                                           Hash Key: notin.l1.y
+                                                                           ->  HashAggregate  (cost=3.14..3.14 rows=1 width=12)
+                                                                                 Group By: notin.l1.y
+                                                                                 ->  Seq Scan on l1  (cost=0.00..3.12 rows=2 width=8)
+                                                                                       Filter: y < 4
+ Settings:  optimizer=on
+ Optimizer status: legacy query optimizer
+(30 rows)
+
+select x,y from l1 where (x,y) not in
+	(select distinct y, sum(x) from l1 group by y having y < 4 order by y) order by 1,2;
+ x  | y  
+----+----
+  4 |  4
+  5 |  5
+  6 |  6
+  7 |  7
+  8 |  8
+  9 |  9
+ 10 | 10
+(7 rows)
+
+--
+--q14
+--
+explain select * from g1 where (a,b,c) not in 
+	(select x,y,z from l1);
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=3.63..14.81 rows=11 width=12)
+   ->  Nested Loop Left Anti Semi Join (Not-In)  (cost=3.63..14.81 rows=4 width=12)
+         Join Filter: g1.a = "NotIn_SUBQUERY".x AND g1.b = "NotIn_SUBQUERY".y AND g1.c = "NotIn_SUBQUERY".z
+         ->  Seq Scan on g1  (cost=0.00..2.11 rows=4 width=12)
+         ->  Materialize  (cost=3.63..3.93 rows=10 width=12)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.60 rows=10 width=12)
+                     ->  Subquery Scan "NotIn_SUBQUERY"  (cost=0.00..3.20 rows=4 width=12)
+                           ->  Seq Scan on l1  (cost=0.00..3.10 rows=4 width=12)
+ Settings:  optimizer=on
+ Optimizer status: legacy query optimizer
+(10 rows)
+
+select * from g1 where (a,b,c) not in 
+	(select x,y,z from l1);
+ a | b | c 
+---+---+---
+ 3 | 3 | 4
+ 3 | 4 | 4
+ 1 | 1 | 2
+ 1 | 2 | 2
+ 2 | 2 | 3
+ 2 | 3 | 3
+(6 rows)
+
+--
+--q15
+--
+explain select c1 from t1, t2 where c1 not in 
+	(select c3 from t3 where c3 = c1) and c1 = c2;
+                                                                                                                                                                  QUERY PLAN                                                                                                                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324465.54 rows=6 width=4)
+   ->  Hash Join  (cost=0.00..1324465.54 rows=2 width=4)
+         Hash Cond: t1.c1 = t2.c2
+         ->  Table Scan on t1  (cost=0.00..1324034.54 rows=4 width=4)
+               Filter: (subplan)
+               SubPlan 1
+                 ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                       ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                             Filter: (CASE WHEN (sum((CASE WHEN $0 = t3.c3 THEN 1 ELSE 0 END))) IS NULL THEN true WHEN (sum((CASE WHEN t3.c3 IS NULL THEN 1 ELSE 0 END))) > 0::bigint THEN NULL::boolean WHEN $0 IS NULL THEN NULL::boolean WHEN (sum((CASE WHEN $0 = t3.c3 THEN 1 ELSE 0 END))) = 0::bigint THEN true ELSE false END) = true
+                             ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                                   ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+                                         ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                               ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                                                     Filter: t3.c3 = $0
+                                                     ->  Materialize  (cost=0.00..431.00 rows=3 width=4)
+                                                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
+                                                                 ->  Table Scan on t3  (cost=0.00..431.00 rows=1 width=4)
+         ->  Hash  (cost=431.00..431.00 rows=2 width=4)
+               ->  Table Scan on t2  (cost=0.00..431.00 rows=2 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(21 rows)
+
+select c1 from t1, t2 where c1 not in 
+	(select c3 from t3 where c3 = c1) and c1 = c2;
+ c1 
+----
+  4
+  5
+(2 rows)
+
+--
+--q17
+-- null test
+--
+select c1 from t1 where c1 not in 
+	(select c1n from t1n);
+ c1 
+----
+(0 rows)
+
+--
+--q18
+-- null test
+--
+select c1 from t1 where c1 not in 
+	(select c2 from t2 where c2 not in 
+		(select c3 from t3 where c3 not in 
+			(select c1n from t1n)));
+ c1 
+----
+  8
+  9
+ 10
+  6
+  7
+(5 rows)
+
+--
+--q19
+--
+select c1 from t1 join t2 on c1 = c2 where c1 not in 
+	(select c3 from t3);
+ c1 
+----
+  4
+  5
+(2 rows)
+
+--
+--q20
+--
+explain select c1 from t1 where c1 not in 
+	(select sum(c2) as s from t2 where c2 > 2 group by c2 having c2 > 3);
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+   ->  Hash Left Anti Semi Join (Not-In)  (cost=0.00..862.00 rows=1 width=4)
+         Hash Cond: t1.c1::bigint = (sum(t2.c2))
+         ->  Table Scan on t1  (cost=0.00..431.00 rows=4 width=4)
+         ->  Hash  (cost=431.00..431.00 rows=2 width=8)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=8)
+                     ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                           ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=8)
+                                 Group By: t2.c2
+                                 ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+                                       Sort Key: t2.c2
+                                       ->  Table Scan on t2  (cost=0.00..431.00 rows=1 width=4)
+                                             Filter: c2 > 2 AND c2 > 3
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(15 rows)
+
+select c1 from t1 where c1 not in 
+	(select sum(c2) as s from t2 where c2 > 2 group by c2 having c2 > 3);
+ c1 
+----
+  1
+  2
+  3
+  6
+  7
+  8
+  9
+ 10
+(8 rows)
+
+--
+--q21
+-- multiple not in in where clause
+--
+select c1 from t1 where c1 not in 
+	(select c2 from t2) and c1 not in 
+	(select c3 from t3);
+ c1 
+----
+  6
+  7
+  8
+  9
+ 10
+(5 rows)
+
+--
+--q22
+-- coexist with joins
+--
+select c1 from t1,t3,t2 where c1 not in 
+	(select c4 from t4) and c1 = c3 and c1 = c2;
+ c1 
+----
+  3
+(1 row)
+
+--
+--q23
+-- union in subselect
+--
+select c1 from t1 where c1 not in 
+	(select c2 from t2 union select c3 from t3);
+ c1 
+----
+  8
+  9
+ 10
+  6
+  7
+(5 rows)
+
+--
+--q24
+--
+select c1 from t1 where c1 not in 
+	(select c2 from t2 union all select c3 from t3);
+ c1 
+----
+  6
+  7
+  8
+  9
+ 10
+(5 rows)
+
+--
+--q25
+--
+select c1 from t1 where c1 not in 
+	(select (case when c1n is null then 1 else c1n end) as c1n from t1n);
+ c1 
+----
+  8
+  9
+ 10
+  4
+(4 rows)
+
+--
+--q26
+--
+explain select (case when c1%2 = 0 
+ then (select sum(c2) from t2 where c2 not in (select c3 from t3)) 
+ else (select sum(c3) from t3 where c3 not in (select c4 from t4)) end) as foo from t1;
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice7; segments: 3)  (cost=0.00..1809071284.19 rows=10 width=8)
+   ->  Result  (cost=0.00..1809071284.19 rows=4 width=8)
+         ->  Nested Loop Left Join  (cost=0.00..1809071284.19 rows=14 width=20)
+               Join Filter: true
+               ->  Nested Loop Left Join  (cost=0.00..1765378.17 rows=7 width=12)
+                     Join Filter: true
+                     ->  Table Scan on t1  (cost=0.00..431.00 rows=4 width=4)
+                     ->  Materialize  (cost=0.00..862.00 rows=1 width=8)
+                           ->  Broadcast Motion 1:3  (slice6)  (cost=0.00..862.00 rows=3 width=8)
+                                 ->  Aggregate  (cost=0.00..862.00 rows=1 width=8)
+                                       ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+                                             ->  Aggregate  (cost=0.00..862.00 rows=1 width=8)
+                                                   ->  Hash Left Anti Semi Join (Not-In)  (cost=0.00..862.00 rows=1 width=4)
+                                                         Hash Cond: t2.c2 = notin.t3.c3
+                                                         ->  Table Scan on t2  (cost=0.00..431.00 rows=2 width=4)
+                                                         ->  Hash  (cost=431.00..431.00 rows=3 width=4)
+                                                               ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
+                                                                     ->  Table Scan on t3  (cost=0.00..431.00 rows=1 width=4)
+               ->  Materialize  (cost=0.00..862.00 rows=1 width=8)
+                     ->  Broadcast Motion 1:3  (slice3)  (cost=0.00..862.00 rows=3 width=8)
+                           ->  Aggregate  (cost=0.00..862.00 rows=1 width=8)
+                                 ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+                                       ->  Aggregate  (cost=0.00..862.00 rows=1 width=8)
+                                             ->  Hash Left Anti Semi Join (Not-In)  (cost=0.00..862.00 rows=1 width=4)
+                                                   Hash Cond: notin.t3.c3 = t4.c4
+                                                   ->  Table Scan on t3  (cost=0.00..431.00 rows=1 width=4)
+                                                   ->  Hash  (cost=431.00..431.00 rows=2 width=4)
+                                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
+                                                               ->  Table Scan on t4  (cost=0.00..431.00 rows=1 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(31 rows)
+
+select (case when c1%2 = 0 
+ then (select sum(c2) from t2 where c2 not in (select c3 from t3)) 
+ else (select sum(c3) from t3 where c3 not in (select c4 from t4)) end) as foo from t1;
+ foo 
+-----
+   3
+   9
+   9
+   3
+   9
+   3
+   9
+   3
+   9
+   3
+(10 rows)
+
+--
+--q27
+--
+explain select c1 from t1 where not c1 >= some (select c2 from t2);
+                                                                                                                                                             QUERY PLAN                                                                                                                                                             
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1324032.88 rows=2 width=4)
+   Filter: (subplan)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=10 width=4)
+         ->  Table Scan on t1  (cost=0.00..431.00 rows=4 width=4)
+   SubPlan 1
+     ->  Result  (cost=0.00..431.00 rows=1 width=1)
+           ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                 Filter: (CASE WHEN (sum((CASE WHEN $0 >= t2.c2 THEN 1 ELSE 0 END))) IS NULL THEN true WHEN (sum((CASE WHEN t2.c2 IS NULL THEN 1 ELSE 0 END))) > 0::bigint THEN NULL::boolean WHEN $0 IS NULL THEN NULL::boolean WHEN (sum((CASE WHEN $0 >= t2.c2 THEN 1 ELSE 0 END))) = 0::bigint THEN true ELSE false END) = true
+                 ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+                             ->  Result  (cost=0.00..431.00 rows=2 width=8)
+                                   ->  Materialize  (cost=0.00..431.00 rows=2 width=4)
+                                         ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=5 width=4)
+                                               ->  Table Scan on t2  (cost=0.00..431.00 rows=2 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(16 rows)
+
+select c1 from t1 where not c1 >= some (select c2 from t2);
+ c1 
+----
+(0 rows)
+
+--
+--q28
+--
+explain select c2 from t2 where not c2 < all (select c2 from t2);
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324033.39 rows=5 width=4)
+   ->  Table Scan on t2  (cost=0.00..1324033.39 rows=2 width=4)
+         Filter: (subplan)
+         SubPlan 1
+           ->  Materialize  (cost=0.00..431.00 rows=5 width=4)
+                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=5 width=4)
+                       ->  Table Scan on t2  (cost=0.00..431.00 rows=2 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(9 rows)
+
+select c2 from t2 where not c2 < all (select c2 from t2);
+ c2 
+----
+  1
+  2
+  3
+  4
+  5
+(5 rows)
+
+--
+--q29
+--
+explain select c3 from t3 where not c3 <> any (select c4 from t4);
+                                                                                                                                                             QUERY PLAN                                                                                                                                                             
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1324032.31 rows=1 width=4)
+   Filter: (subplan)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
+         ->  Table Scan on t3  (cost=0.00..431.00 rows=1 width=4)
+   SubPlan 1
+     ->  Result  (cost=0.00..431.00 rows=1 width=1)
+           ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                 Filter: (CASE WHEN (sum((CASE WHEN $0 <> t4.c4 THEN 1 ELSE 0 END))) IS NULL THEN true WHEN (sum((CASE WHEN t4.c4 IS NULL THEN 1 ELSE 0 END))) > 0::bigint THEN NULL::boolean WHEN $0 IS NULL THEN NULL::boolean WHEN (sum((CASE WHEN $0 <> t4.c4 THEN 1 ELSE 0 END))) = 0::bigint THEN true ELSE false END) = true
+                 ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+                             ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                   ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                                         ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
+                                               ->  Table Scan on t4  (cost=0.00..431.00 rows=1 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(16 rows)
+
+select c3 from t3 where not c3 <> any (select c4 from t4);
+ c3 
+----
+(0 rows)
+
+--
+--q31
+--
+explain select c1 from t1 where c1 not in (select c2 from t2 order by c2 limit 3) order by c1;
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=4 width=4)
+   Merge Key: t1.c1
+   ->  Sort  (cost=0.00..862.00 rows=2 width=4)
+         Sort Key: t1.c1
+         ->  Hash Left Anti Semi Join (Not-In)  (cost=0.00..862.00 rows=2 width=4)
+               Hash Cond: t1.c1 = t2.c2
+               ->  Table Scan on t1  (cost=0.00..431.00 rows=4 width=4)
+               ->  Hash  (cost=431.00..431.00 rows=3 width=4)
+                     ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=9 width=4)
+                           ->  Limit  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
+                                       Merge Key: t2.c2
+                                       ->  Limit  (cost=0.00..431.00 rows=1 width=4)
+                                             ->  Sort  (cost=0.00..431.00 rows=2 width=4)
+                                                   Sort Key: t2.c2
+                                                   ->  Table Scan on t2  (cost=0.00..431.00 rows=2 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(18 rows)
+
+select c1 from t1 where c1 not in (select c2 from t2 order by c2 limit 3) order by c1;
+ c1 
+----
+  4
+  5
+  6
+  7
+  8
+  9
+ 10
+(7 rows)
+
+--quantified/correlated subqueries
+--
+--q32
+--
+explain select c1 from t1 where c1 =all (select c2 from t2 where c2 > -1 and c2 <= 1);
+                                                                                                                                                                QUERY PLAN                                                                                                                                                                
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324032.79 rows=4 width=4)
+   ->  Table Scan on t1  (cost=0.00..1324032.79 rows=2 width=4)
+         Filter: (subplan)
+         SubPlan 1
+           ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                 ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                       Filter: (CASE WHEN (sum((CASE WHEN $0 <> t2.c2 THEN 1 ELSE 0 END))) IS NULL THEN true WHEN (sum((CASE WHEN t2.c2 IS NULL THEN 1 ELSE 0 END))) > 0::bigint THEN NULL::boolean WHEN $0 IS NULL THEN NULL::boolean WHEN (sum((CASE WHEN $0 <> t2.c2 THEN 1 ELSE 0 END))) = 0::bigint THEN true ELSE false END) = true
+                       ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                             ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+                                   ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                         ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                                     ->  Table Scan on t2  (cost=0.00..431.00 rows=1 width=4)
+                                                           Filter: c2 > (-1) AND c2 <= 1
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(16 rows)
+
+select c1 from t1 where c1 =all (select c2 from t2 where c2 > -1 and c2 <= 1);
+ c1 
+----
+  1
+(1 row)
+
+--
+--q33
+--
+explain select c1 from t1 where c1 <>all (select c2 from t2);
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=4 width=4)
+   ->  Hash Left Anti Semi Join (Not-In)  (cost=0.00..862.00 rows=2 width=4)
+         Hash Cond: t1.c1 = t2.c2
+         ->  Table Scan on t1  (cost=0.00..431.00 rows=4 width=4)
+         ->  Hash  (cost=431.00..431.00 rows=5 width=4)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=5 width=4)
+                     ->  Table Scan on t2  (cost=0.00..431.00 rows=2 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(9 rows)
+
+select c1 from t1 where c1 <>all (select c2 from t2);
+ c1 
+----
+  6
+  7
+  8
+  9
+ 10
+(5 rows)
+
+--
+--q34
+--
+explain select c1 from t1 where c1 <=all (select c2 from t2 where c2 not in (select c1n from t1n));
+                                                                                                                                                               QUERY PLAN                                                                                                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1765379.01 rows=4 width=4)
+   ->  Table Scan on t1  (cost=0.00..1765379.01 rows=2 width=4)
+         Filter: (subplan)
+         SubPlan 1
+           ->  Result  (cost=0.00..862.00 rows=1 width=1)
+                 ->  Result  (cost=0.00..862.00 rows=1 width=1)
+                       Filter: (CASE WHEN (sum((CASE WHEN $0 > t2.c2 THEN 1 ELSE 0 END))) IS NULL THEN true WHEN (sum((CASE WHEN t2.c2 IS NULL THEN 1 ELSE 0 END))) > 0::bigint THEN NULL::boolean WHEN $0 IS NULL THEN NULL::boolean WHEN (sum((CASE WHEN $0 > t2.c2 THEN 1 ELSE 0 END))) = 0::bigint THEN true ELSE false END) = true
+                       ->  Result  (cost=0.00..862.00 rows=1 width=1)
+                             ->  Aggregate  (cost=0.00..862.00 rows=1 width=16)
+                                   ->  Result  (cost=0.00..862.00 rows=2 width=8)
+                                         ->  Materialize  (cost=0.00..862.00 rows=2 width=4)
+                                               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=2 width=4)
+                                                     ->  Hash Left Anti Semi Join (Not-In)  (cost=0.00..862.00 rows=1 width=4)
+                                                           Hash Cond: t2.c2 = t1n.c1n
+                                                           ->  Table Scan on t2  (cost=0.00..431.00 rows=2 width=4)
+                                                           ->  Hash  (cost=431.00..431.00 rows=7 width=4)
+                                                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
+                                                                       ->  Table Scan on t1n  (cost=0.00..431.00 rows=3 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(20 rows)
+
+select c1 from t1 where c1 <=all (select c2 from t2 where c2 not in (select c1n from t1n));
+ c1 
+----
+  1
+  2
+  3
+  4
+  5
+  6
+  7
+  8
+  9
+ 10
+(10 rows)
+
+--
+--q35
+--
+explain select c1 from t1 where not c1 =all (select c2 from t2 where not c2 >all (select c3 from t3));
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1356692471.20 rows=10 width=4)
+   ->  Table Scan on t1  (cost=0.00..1356692471.20 rows=4 width=4)
+         Filter: (subplan)
+         SubPlan 2
+           ->  Materialize  (cost=0.00..1324032.99 rows=5 width=4)
+                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1324032.99 rows=5 width=4)
+                       ->  Table Scan on t2  (cost=0.00..1324032.99 rows=2 width=4)
+                             Filter: (subplan)
+                             SubPlan 1
+                               ->  Materialize  (cost=0.00..431.00 rows=3 width=4)
+                                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
+                                           ->  Table Scan on t3  (cost=0.00..431.00 rows=1 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(14 rows)
+
+select c1 from t1 where not c1 =all (select c2 from t2 where not c2 >all (select c3 from t3));
+ c1 
+----
+  3
+  4
+  5
+  6
+  7
+  1
+  2
+  8
+  9
+ 10
+(10 rows)
+
+--
+--q36
+--
+explain select c1 from t1 where not c1 <>all (select c1n from t1n where c1n <all (select c3 from t3 where c3 = c1n));
+                                                                                                                                                                      QUERY PLAN                                                                                                                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324464.88 rows=8 width=4)
+   ->  Hash EXISTS Join  (cost=0.00..1324464.88 rows=3 width=4)
+         Hash Cond: t1.c1 = t1n.c1n
+         ->  Table Scan on t1  (cost=0.00..431.00 rows=4 width=4)
+         ->  Hash  (cost=1324033.87..1324033.87 rows=3 width=4)
+               ->  Table Scan on t1n  (cost=0.00..1324033.87 rows=3 width=4)
+                     Filter: (subplan)
+                     SubPlan 1
+                       ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                             ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                                   Filter: (CASE WHEN (sum((CASE WHEN $0 >= t3.c3 THEN 1 ELSE 0 END))) IS NULL THEN true WHEN (sum((CASE WHEN t3.c3 IS NULL THEN 1 ELSE 0 END))) > 0::bigint THEN NULL::boolean WHEN $0 IS NULL THEN NULL::boolean WHEN (sum((CASE WHEN $0 >= t3.c3 THEN 1 ELSE 0 END))) = 0::bigint THEN true ELSE false END) = true
+                                   ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                                         ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+                                               ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                     ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                                                           Filter: t3.c3 = $0
+                                                           ->  Materialize  (cost=0.00..431.00 rows=3 width=4)
+                                                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
+                                                                       ->  Table Scan on t3  (cost=0.00..431.00 rows=1 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(21 rows)
+
+select c1 from t1 where not c1 <>all (select c1n from t1n where c1n <all (select c3 from t3 where c3 = c1n));
+ c1 
+----
+  5
+  6
+  7
+(3 rows)
+
+--
+--q37
+--
+explain select c1 from t1 where not c1 >=all (select c2 from t2 where c2 = c1);
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=6 width=4)
+   ->  Hash EXISTS Join  (cost=0.00..862.00 rows=2 width=4)
+         Hash Cond: t1.c1 = t2.c2
+         Join Filter: t1.c1 < t2.c2
+         ->  Table Scan on t1  (cost=0.00..431.00 rows=4 width=4)
+         ->  Hash  (cost=431.00..431.00 rows=2 width=4)
+               ->  Table Scan on t2  (cost=0.00..431.00 rows=2 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(9 rows)
+
+select c1 from t1 where not c1 >=all (select c2 from t2 where c2 = c1);
+ c1 
+----
+(0 rows)
+
+--
+--q38
+--
+explain select c1 from t1 where not exists (select c2 from t2 where c2 = c1);
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=4 width=4)
+   ->  Hash Left Anti Semi Join  (cost=0.00..862.00 rows=2 width=4)
+         Hash Cond: t1.c1 = t2.c2
+         ->  Table Scan on t1  (cost=0.00..431.00 rows=4 width=4)
+         ->  Hash  (cost=431.00..431.00 rows=2 width=4)
+               ->  Table Scan on t2  (cost=0.00..431.00 rows=2 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(8 rows)
+
+select c1 from t1 where not exists (select c2 from t2 where c2 = c1);
+ c1 
+----
+  6
+  7
+  8
+  9
+ 10
+(5 rows)
+
+--
+--q39
+--
+explain select c1 from t1 where not exists (select c2 from t2 where c2 not in (select c3 from t3) and c2 = c1);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.00 rows=4 width=4)
+   ->  Hash Left Anti Semi Join  (cost=0.00..1293.00 rows=2 width=4)
+         Hash Cond: t1.c1 = t2.c2
+         ->  Table Scan on t1  (cost=0.00..431.00 rows=4 width=4)
+         ->  Hash  (cost=862.00..862.00 rows=1 width=4)
+               ->  Hash Left Anti Semi Join (Not-In)  (cost=0.00..862.00 rows=1 width=4)
+                     Hash Cond: t2.c2 = t3.c3
+                     ->  Table Scan on t2  (cost=0.00..431.00 rows=2 width=4)
+                     ->  Hash  (cost=431.00..431.00 rows=3 width=4)
+                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
+                                 ->  Table Scan on t3  (cost=0.00..431.00 rows=1 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(13 rows)
+
+select c1 from t1 where not exists (select c2 from t2 where c2 not in (select c3 from t3) and c2 = c1);
+ c1 
+----
+  8
+  9
+ 10
+  3
+  6
+  7
+  1
+  2
+(8 rows)
+
+--
+--q40
+--
+explain select c1 from t1 where not exists (select c2 from t2 where exists (select c3 from t3) and c2 <>all (select c3 from t3) and c2 = c1);
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324894.16 rows=4 width=4)
+   ->  Hash Left Anti Semi Join  (cost=0.00..1324894.16 rows=2 width=4)
+         Hash Cond: t1.c1 = t2.c2
+         ->  Table Scan on t1  (cost=0.00..431.00 rows=4 width=4)
+         ->  Hash  (cost=1324463.16..1324463.16 rows=1 width=4)
+               ->  Hash Left Anti Semi Join (Not-In)  (cost=0.00..1324463.16 rows=1 width=4)
+                     Hash Cond: t2.c2 = notin.t3.c3
+                     ->  Nested Loop EXISTS Join  (cost=0.00..1324032.16 rows=2 width=4)
+                           Join Filter: true
+                           ->  Table Scan on t2  (cost=0.00..431.00 rows=2 width=4)
+                           ->  Materialize  (cost=0.00..431.00 rows=3 width=1)
+                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=1)
+                                       ->  Table Scan on t3  (cost=0.00..431.00 rows=1 width=1)
+                     ->  Hash  (cost=431.00..431.00 rows=3 width=4)
+                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
+                                 ->  Table Scan on t3  (cost=0.00..431.00 rows=1 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(18 rows)
+
+select c1 from t1 where not exists (select c2 from t2 where exists (select c3 from t3) and c2 <>all (select c3 from t3) and c2 = c1);
+ c1 
+----
+  8
+  9
+ 10
+  1
+  2
+  3
+  6
+  7
+(8 rows)
+
+--
+--q41
+--
+select c1 from t1 where c1 not in (select c2 from t2) or c1 = 49;
+ c1 
+----
+  8
+  9
+ 10
+  6
+  7
+(5 rows)
+
+--
+--q42
+--
+select c1 from t1 where not not not c1 in (select c2 from t2);
+ c1 
+----
+  6
+  7
+  8
+  9
+ 10
+(5 rows)
+
+--
+--q43
+--
+explain select c1 from t1 where c1 not in (select c2 from t2 where c2 > 4) and c1 is not null;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=4 width=4)
+   ->  Hash Left Anti Semi Join (Not-In)  (cost=0.00..862.00 rows=2 width=4)
+         Hash Cond: t1.c1 = t2.c2
+         ->  Table Scan on t1  (cost=0.00..431.00 rows=4 width=4)
+               Filter: NOT c1 IS NULL
+         ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Table Scan on t2  (cost=0.00..431.00 rows=1 width=4)
+                           Filter: c2 > 4
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(11 rows)
+
+select c1 from t1 where c1 not in (select c2 from t2 where c2 > 4) and c1 is not null;
+ c1 
+----
+  3
+  4
+  6
+  7
+  8
+  9
+ 10
+  1
+  2
+(9 rows)
+
+--
+--q44
+--
+select c1 from t1 where c1 not in (select c2 from t2 where c2 > 4) and c1 > 2;
+ c1 
+----
+  8
+  9
+ 10
+  3
+  4
+  6
+  7
+(7 rows)
+
+reset search_path;
+drop schema notin cascade;
+NOTICE:  drop cascades to table notin.l1
+NOTICE:  drop cascades to table notin.g1
+NOTICE:  drop cascades to table notin.t1n
+NOTICE:  drop cascades to table notin.t4
+NOTICE:  drop cascades to table notin.t3
+NOTICE:  drop cascades to table notin.t2
+NOTICE:  drop cascades to table notin.t1

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -287,6 +287,42 @@ select A.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i i
 (10 rows)
 
 -- MPP-14222
+explain select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i not in (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
+                                                                     QUERY PLAN                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=99.73..99.95 rows=10 width=12)
+   ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=99.73..99.95 rows=10 width=12)
+         Merge Key: a.i, qp_correlated_query.b.i, qp_correlated_query.c.j
+         ->  Limit  (cost=99.73..99.75 rows=4 width=12)
+               ->  Sort  (cost=99.73..99.86 rows=18 width=12)
+                     Sort Key: a.i, qp_correlated_query.b.i, qp_correlated_query.c.j
+                     ->  Nested Loop  (cost=6.42..98.56 rows=18 width=12)
+                           ->  Nested Loop  (cost=3.10..92.00 rows=3 width=8)
+                                 ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..88.36 rows=1 width=8)
+                                       ->  Seq Scan on a  (cost=0.00..88.32 rows=1 width=8)
+                                             Filter: j = ((subplan))
+                                             SubPlan 2
+                                               ->  Result  (cost=17.05..17.06 rows=1 width=4)
+                                                     Filter: qp_correlated_query.c.j = $2 AND ((subplan))
+                                                     ->  Materialize  (cost=17.05..17.06 rows=1 width=4)
+                                                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..17.05 rows=1 width=4)
+                                                                 ->  Seq Scan on c  (cost=0.00..17.05 rows=1 width=4)
+                                                     SubPlan 1
+                                                       ->  Result  (cost=3.09..3.10 rows=1 width=4)
+                                                             Filter: $0 = qp_correlated_query.b.i
+                                                             ->  Materialize  (cost=3.09..3.10 rows=1 width=4)
+                                                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.09 rows=1 width=4)
+                                                                         ->  Seq Scan on b  (cost=0.00..3.09 rows=1 width=4)
+                                                                               Filter: i <> 10
+                                 ->  Materialize  (cost=3.10..3.19 rows=3 width=4)
+                                       ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
+                           ->  Materialize  (cost=3.32..3.50 rows=6 width=4)
+                                 ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..3.30 rows=6 width=4)
+                                       ->  Seq Scan on b  (cost=0.00..3.06 rows=2 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(31 rows)
+
 select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i not in (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
  i | i  | j  
 ---+----+----
@@ -301,6 +337,42 @@ select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j
  1 | -1 | 62
  1 | -1 | 62
 (10 rows)
+
+explain select A.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i not in (select B.i from B where C.i = B.i and B.i !=10)) order by A.j limit 10;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=99.89..100.11 rows=10 width=4)
+   ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=99.89..100.11 rows=10 width=4)
+         Merge Key: a.j
+         ->  Limit  (cost=99.89..99.91 rows=4 width=4)
+               ->  Sort  (cost=99.89..100.02 rows=18 width=4)
+                     Sort Key: a.j
+                     ->  Nested Loop  (cost=6.79..98.72 rows=18 width=4)
+                           ->  Nested Loop  (cost=3.32..92.00 rows=2 width=4)
+                                 ->  Seq Scan on a  (cost=0.00..88.32 rows=1 width=4)
+                                       Filter: j = ((subplan))
+                                       SubPlan 2
+                                         ->  Result  (cost=17.05..17.06 rows=1 width=4)
+                                               Filter: qp_correlated_query.c.j = $2 AND ((subplan))
+                                               ->  Materialize  (cost=17.05..17.06 rows=1 width=4)
+                                                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..17.05 rows=1 width=4)
+                                                           ->  Seq Scan on c  (cost=0.00..17.05 rows=1 width=4)
+                                               SubPlan 1
+                                                 ->  Result  (cost=3.09..3.10 rows=1 width=4)
+                                                       Filter: $0 = qp_correlated_query.b.i
+                                                       ->  Materialize  (cost=3.09..3.10 rows=1 width=4)
+                                                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.09 rows=1 width=4)
+                                                                   ->  Seq Scan on b  (cost=0.00..3.09 rows=1 width=4)
+                                                                         Filter: i <> 10
+                                 ->  Materialize  (cost=3.32..3.50 rows=6 width=0)
+                                       ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..3.30 rows=6 width=0)
+                                             ->  Seq Scan on b  (cost=0.00..3.06 rows=2 width=0)
+                           ->  Materialize  (cost=3.48..3.75 rows=9 width=0)
+                                 ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..3.45 rows=9 width=0)
+                                       ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=0)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(31 rows)
 
 select A.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i not in (select B.i from B where C.i = B.i and B.i !=10)) order by A.j limit 10;
  j  
@@ -403,6 +475,44 @@ select * from A where A.j = any (select C.j from C,B where C.j = A.j and B.i = a
 -- Planner should fail due to skip-level correlation not supported. ORCA should pass
 select * from A,B where A.j = any (select C.j from C where C.j = A.j and B.i = any (select C.i from C where C.i != 10 and C.i = A.i)) order by 1,2,3,4;
 ERROR:  correlated subquery with skip-level correlations is not supported
+explain select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i = any (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=46.02..46.25 rows=10 width=12)
+   ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=46.02..46.25 rows=10 width=12)
+         Merge Key: a.i, qp_correlated_query.b.i, qp_correlated_query.c.j
+         ->  Limit  (cost=46.02..46.05 rows=4 width=12)
+               ->  Sort  (cost=46.02..46.16 rows=18 width=12)
+                     Sort Key: a.i, qp_correlated_query.b.i, qp_correlated_query.c.j
+                     ->  Nested Loop  (cost=6.42..44.86 rows=18 width=12)
+                           ->  Nested Loop  (cost=3.10..38.30 rows=3 width=8)
+                                 ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..34.66 rows=1 width=8)
+                                       ->  Seq Scan on a  (cost=0.00..34.62 rows=1 width=8)
+                                             Filter: j = ((subplan))
+                                             SubPlan 1
+                                               ->  Hash EXISTS Join  (cost=3.14..6.31 rows=2 width=4)
+                                                     Hash Cond: qp_correlated_query.c.i = qp_correlated_query.b.i
+                                                     ->  Result  (cost=3.14..3.15 rows=1 width=8)
+                                                           Filter: qp_correlated_query.c.j = $0
+                                                           ->  Materialize  (cost=3.14..3.15 rows=1 width=8)
+                                                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.13 rows=1 width=8)
+                                                                       ->  Seq Scan on c  (cost=0.00..3.13 rows=1 width=8)
+                                                                             Filter: i <> 10
+                                                     ->  Hash  (cost=3.08..3.08 rows=2 width=4)
+                                                           ->  Result  (cost=3.08..3.13 rows=2 width=4)
+                                                                 ->  Materialize  (cost=3.08..3.13 rows=2 width=4)
+                                                                       ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..3.08 rows=2 width=4)
+                                                                             ->  Seq Scan on b  (cost=0.00..3.08 rows=2 width=4)
+                                                                                   Filter: i <> 10
+                                 ->  Materialize  (cost=3.10..3.19 rows=3 width=4)
+                                       ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
+                           ->  Materialize  (cost=3.32..3.50 rows=6 width=4)
+                                 ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..3.30 rows=6 width=4)
+                                       ->  Seq Scan on b  (cost=0.00..3.06 rows=2 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(33 rows)
+
 select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i = any (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
  i  | i  |  j  
 ----+----+-----
@@ -418,6 +528,47 @@ select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j
  99 |  1 |  -1
 (10 rows)
 
+explain select A.i, B.i, C.j from A, B, C where A.j = any ( select C.j from C where not exists(select C.i from C,A where C.i = A.i and C.i =10)) order by A.i, B.i, C.j limit 10;
+                                                                     QUERY PLAN                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=43.24..43.47 rows=10 width=12)
+   InitPlan  (slice7)
+     ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..6.18 rows=4 width=4)
+           ->  Nested Loop  (cost=0.00..6.18 rows=2 width=4)
+                 ->  Seq Scan on c  (cost=0.00..3.11 rows=1 width=4)
+                       Filter: i = 10
+                 ->  Seq Scan on a  (cost=0.00..3.06 rows=1 width=4)
+                       Filter: qp_correlated_query.a.i = 10
+   ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=41.38..41.61 rows=10 width=12)
+         Merge Key: qp_correlated_query.a.i, b.i, qp_correlated_query.c.j
+         ->  Limit  (cost=41.38..41.41 rows=4 width=12)
+               ->  Sort  (cost=41.38..42.17 rows=106 width=12)
+                     Sort Key: qp_correlated_query.a.i, b.i, qp_correlated_query.c.j
+                     ->  Result  (cost=9.99..34.55 rows=106 width=12)
+                           One-Time Filter: NOT $0
+                           ->  Nested Loop  (cost=9.99..34.55 rows=106 width=12)
+                                 ->  Nested Loop  (cost=6.52..12.09 rows=12 width=8)
+                                       ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=3.45..6.92 rows=6 width=4)
+                                             ->  Hash Join  (cost=3.45..6.68 rows=2 width=4)
+                                                   Hash Cond: qp_correlated_query.a.j = qp_correlated_query.c.j
+                                                   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.15 rows=2 width=8)
+                                                         Hash Key: qp_correlated_query.a.j
+                                                         ->  Seq Scan on a  (cost=0.00..3.05 rows=2 width=8)
+                                                   ->  Hash  (cost=3.36..3.36 rows=3 width=4)
+                                                         ->  HashAggregate  (cost=3.29..3.36 rows=3 width=4)
+                                                               Group By: qp_correlated_query.c.j
+                                                               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..3.27 rows=3 width=4)
+                                                                     Hash Key: qp_correlated_query.c.j
+                                                                     ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
+                                       ->  Materialize  (cost=3.07..3.13 rows=2 width=4)
+                                             ->  Seq Scan on b  (cost=0.00..3.06 rows=2 width=4)
+                                 ->  Materialize  (cost=3.48..3.75 rows=9 width=4)
+                                       ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..3.45 rows=9 width=4)
+                                             ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(36 rows)
+
 select A.i, B.i, C.j from A, B, C where A.j = any ( select C.j from C where not exists(select C.i from C,A where C.i = A.i and C.i =10)) order by A.i, B.i, C.j limit 10;
  i | i  | j  
 ---+----+----
@@ -432,6 +583,44 @@ select A.i, B.i, C.j from A, B, C where A.j = any ( select C.j from C where not 
  1 | -1 | 62
  1 | -1 | 62
 (10 rows)
+
+explain select A.i, B.i, C.j from A, B, C where A.j = any (select C.j from C where C.j = A.j and not exists (select sum(B.i) from B where C.i = B.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
+                                                                           QUERY PLAN                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=100.41..100.63 rows=10 width=12)
+   ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=100.41..100.63 rows=10 width=12)
+         Merge Key: a.i, qp_correlated_query.b.i, qp_correlated_query.c.j
+         ->  Limit  (cost=100.41..100.43 rows=4 width=12)
+               ->  Sort  (cost=100.41..100.74 rows=45 width=12)
+                     Sort Key: a.i, qp_correlated_query.b.i, qp_correlated_query.c.j
+                     ->  Nested Loop  (cost=6.42..97.49 rows=45 width=12)
+                           ->  Nested Loop  (cost=3.10..86.07 rows=8 width=8)
+                                 ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..81.62 rows=3 width=4)
+                                       ->  Seq Scan on a  (cost=0.00..81.52 rows=1 width=4)
+                                             Filter: (subplan)
+                                             SubPlan 2
+                                               ->  Result  (cost=31.38..31.39 rows=1 width=4)
+                                                     Filter: qp_correlated_query.c.j = $1 AND NOT ((subplan))
+                                                     ->  Materialize  (cost=31.38..31.39 rows=1 width=4)
+                                                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..31.38 rows=1 width=4)
+                                                                 ->  Seq Scan on c  (cost=0.00..31.38 rows=1 width=4)
+                                                     SubPlan 1
+                                                       ->  Aggregate  (cost=3.13..3.14 rows=1 width=8)
+                                                             ->  Result  (cost=0.00..3.08 rows=1 width=4)
+                                                                   One-Time Filter: $0 <> 10
+                                                                   ->  Result  (cost=3.08..3.09 rows=1 width=4)
+                                                                         Filter: $0 = qp_correlated_query.b.i
+                                                                         ->  Materialize  (cost=3.08..3.09 rows=1 width=4)
+                                                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.08 rows=1 width=4)
+                                                                                     ->  Seq Scan on b  (cost=0.00..3.08 rows=1 width=4)
+                                 ->  Materialize  (cost=3.10..3.19 rows=3 width=4)
+                                       ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
+                           ->  Materialize  (cost=3.32..3.50 rows=6 width=4)
+                                 ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..3.30 rows=6 width=4)
+                                       ->  Seq Scan on b  (cost=0.00..3.06 rows=2 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(33 rows)
 
 select A.i, B.i, C.j from A, B, C where A.j = any (select C.j from C where C.j = A.j and not exists (select sum(B.i) from B where C.i = B.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
  i | i | j 
@@ -488,6 +677,49 @@ select * from A,B where exists (select * from C where C.j = A.j and B.i = all (s
 -- Planner should fail due to skip-level correlation not supported. ORCA should pass
 select * from A,B where exists (select * from C where C.j = A.j and B.i = all (select min(C.j) from C where C.j = B.j)) order by 1,2,3,4;
 ERROR:  correlated subquery with skip-level correlations is not supported
+explain select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C where C.j = A.j and C.i = all (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=51.18..51.40 rows=10 width=12)
+   ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=51.18..51.40 rows=10 width=12)
+         Merge Key: a.i, qp_correlated_query.b.i, qp_correlated_query.c.j
+         ->  Limit  (cost=51.18..51.20 rows=4 width=12)
+               ->  Sort  (cost=51.18..51.85 rows=90 width=12)
+                     Sort Key: a.i, qp_correlated_query.b.i, qp_correlated_query.c.j
+                     ->  Nested Loop  (cost=23.92..45.34 rows=90 width=12)
+                           ->  Nested Loop  (cost=20.44..25.66 rows=10 width=8)
+                                 ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=17.37..20.80 rows=5 width=4)
+                                       ->  Hash Join  (cost=17.37..20.60 rows=2 width=4)
+                                             Hash Cond: a.j = qp_correlated_query.c.j
+                                             ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.15 rows=2 width=8)
+                                                   Hash Key: a.j
+                                                   ->  Seq Scan on a  (cost=0.00..3.05 rows=2 width=8)
+                                             ->  Hash  (cost=17.32..17.32 rows=2 width=12)
+                                                   ->  HashAggregate  (cost=17.21..17.28 rows=2 width=12)
+                                                         Filter: qp_correlated_query.c.j = pg_catalog.sum((sum(qp_correlated_query.c.j)))
+                                                         Group By: qp_correlated_query.c.j
+                                                         ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=17.06..17.14 rows=2 width=12)
+                                                               Hash Key: qp_correlated_query.c.j
+                                                               ->  HashAggregate  (cost=17.06..17.06 rows=2 width=12)
+                                                                     Group By: qp_correlated_query.c.j
+                                                                     ->  Seq Scan on c  (cost=0.00..17.03 rows=2 width=4)
+                                                                           Filter: (subplan)
+                                                                           SubPlan 1
+                                                                             ->  Result  (cost=3.09..3.10 rows=1 width=4)
+                                                                                   Filter: $0 = qp_correlated_query.b.i
+                                                                                   ->  Materialize  (cost=3.09..3.10 rows=1 width=4)
+                                                                                         ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..3.09 rows=1 width=4)
+                                                                                               ->  Seq Scan on b  (cost=0.00..3.09 rows=1 width=4)
+                                                                                                     Filter: i <> 10
+                                 ->  Materialize  (cost=3.07..3.13 rows=2 width=4)
+                                       ->  Seq Scan on b  (cost=0.00..3.06 rows=2 width=4)
+                           ->  Materialize  (cost=3.48..3.75 rows=9 width=4)
+                                 ->  Broadcast Motion 3:3  (slice5; segments: 3)  (cost=0.00..3.45 rows=9 width=4)
+                                       ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(38 rows)
+
 select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C where C.j = A.j and C.i = all (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
  i | i  | j  
 ---+----+----
@@ -503,10 +735,85 @@ select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C where C.j 
  1 | -1 | 62
 (10 rows)
 
+explain select A.i, B.i, C.j from A, B, C where A.j < all ( select C.j from C where not exists(select C.i from C,A where C.i = A.i and C.i =10)) order by A.i, B.i, C.j limit 10;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=200.50..200.73 rows=10 width=12)
+   ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=200.50..200.73 rows=10 width=12)
+         Merge Key: qp_correlated_query.a.i, b.i, qp_correlated_query.c.j
+         ->  Limit  (cost=200.50..200.53 rows=4 width=12)
+               ->  Sort  (cost=200.50..200.73 rows=30 width=12)
+                     Sort Key: qp_correlated_query.a.i, b.i, qp_correlated_query.c.j
+                     ->  Nested Loop Left Anti Semi Join (Not-In)  (cost=11.79..198.56 rows=30 width=12)
+                           Join Filter: qp_correlated_query.a.j >= "NotIn_SUBQUERY".j
+                           ->  Nested Loop  (cost=6.36..29.10 rows=90 width=16)
+                                 ->  Nested Loop  (cost=3.10..9.64 rows=18 width=8)
+                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.30 rows=6 width=4)
+                                             ->  Seq Scan on b  (cost=0.00..3.06 rows=2 width=4)
+                                       ->  Materialize  (cost=3.10..3.19 rows=3 width=4)
+                                             ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
+                                 ->  Materialize  (cost=3.27..3.42 rows=5 width=8)
+                                       ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..3.25 rows=5 width=8)
+                                             ->  Seq Scan on a  (cost=0.00..3.05 rows=2 width=8)
+                           ->  Materialize  (cost=5.43..5.70 rows=9 width=4)
+                                 ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=1.86..5.40 rows=9 width=4)
+                                       ->  Subquery Scan "NotIn_SUBQUERY"  (cost=1.86..5.04 rows=3 width=4)
+                                             ->  Result  (cost=1.86..4.95 rows=3 width=4)
+                                                   One-Time Filter: NOT $0
+                                                   InitPlan  (slice6)
+                                                     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..6.18 rows=4 width=4)
+                                                           ->  Nested Loop  (cost=0.00..6.18 rows=2 width=4)
+                                                                 ->  Seq Scan on c  (cost=0.00..3.11 rows=1 width=4)
+                                                                       Filter: i = 10
+                                                                 ->  Seq Scan on a  (cost=0.00..3.06 rows=1 width=4)
+                                                                       Filter: qp_correlated_query.a.i = 10
+                                                   ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(32 rows)
+
 select A.i, B.i, C.j from A, B, C where A.j < all ( select C.j from C where not exists(select C.i from C,A where C.i = A.i and C.i =10)) order by A.i, B.i, C.j limit 10;
  i | i | j 
 ---+---+---
 (0 rows)
+
+explain select A.i, B.i, C.j from A, B, C where A.j = all (select C.j from C where C.j = A.j and not exists (select sum(B.i) from B where C.i = B.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
+                                                                           QUERY PLAN                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=100.41..100.63 rows=10 width=12)
+   ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=100.41..100.63 rows=10 width=12)
+         Merge Key: a.i, qp_correlated_query.b.i, qp_correlated_query.c.j
+         ->  Limit  (cost=100.41..100.43 rows=4 width=12)
+               ->  Sort  (cost=100.41..100.74 rows=45 width=12)
+                     Sort Key: a.i, qp_correlated_query.b.i, qp_correlated_query.c.j
+                     ->  Nested Loop  (cost=6.42..97.49 rows=45 width=12)
+                           ->  Nested Loop  (cost=3.10..86.07 rows=8 width=8)
+                                 ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..81.62 rows=3 width=4)
+                                       ->  Seq Scan on a  (cost=0.00..81.52 rows=1 width=4)
+                                             Filter: (subplan)
+                                             SubPlan 2
+                                               ->  Result  (cost=31.38..31.39 rows=1 width=4)
+                                                     Filter: qp_correlated_query.c.j = $1 AND NOT ((subplan))
+                                                     ->  Materialize  (cost=31.38..31.39 rows=1 width=4)
+                                                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..31.38 rows=1 width=4)
+                                                                 ->  Seq Scan on c  (cost=0.00..31.38 rows=1 width=4)
+                                                     SubPlan 1
+                                                       ->  Aggregate  (cost=3.13..3.14 rows=1 width=8)
+                                                             ->  Result  (cost=0.00..3.08 rows=1 width=4)
+                                                                   One-Time Filter: $0 <> 10
+                                                                   ->  Result  (cost=3.08..3.09 rows=1 width=4)
+                                                                         Filter: $0 = qp_correlated_query.b.i
+                                                                         ->  Materialize  (cost=3.08..3.09 rows=1 width=4)
+                                                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.08 rows=1 width=4)
+                                                                                     ->  Seq Scan on b  (cost=0.00..3.08 rows=1 width=4)
+                                 ->  Materialize  (cost=3.10..3.19 rows=3 width=4)
+                                       ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
+                           ->  Materialize  (cost=3.32..3.50 rows=6 width=4)
+                                 ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..3.30 rows=6 width=4)
+                                       ->  Seq Scan on b  (cost=0.00..3.06 rows=2 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(33 rows)
 
 select A.i, B.i, C.j from A, B, C where A.j = all (select C.j from C where C.j = A.j and not exists (select sum(B.i) from B where C.i = B.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
  i | i  | j  
@@ -743,6 +1050,27 @@ select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j
 ---+---+---
 (0 rows)
 
+explain select C.j from C where not exists (select max(B.i) from B  where C.i = B.i having max(B.i) is not null) order by C.j;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=31.43..31.45 rows=5 width=4)
+   Merge Key: c.j
+   ->  Sort  (cost=31.43..31.45 rows=2 width=4)
+         Sort Key: c.j
+         ->  Seq Scan on c  (cost=0.00..31.39 rows=2 width=4)
+               Filter: NOT ((subplan))
+               SubPlan 1
+                 ->  Aggregate  (cost=3.13..3.14 rows=1 width=4)
+                       Filter: max(b.i) IS NOT NULL
+                       ->  Result  (cost=3.08..3.09 rows=1 width=4)
+                             Filter: $0 = b.i
+                             ->  Materialize  (cost=3.08..3.09 rows=1 width=4)
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.08 rows=1 width=4)
+                                         ->  Seq Scan on b  (cost=0.00..3.08 rows=1 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(16 rows)
+
 select C.j from C where not exists (select max(B.i) from B  where C.i = B.i having max(B.i) is not null) order by C.j;
  j  
 ----
@@ -751,6 +1079,27 @@ select C.j from C where not exists (select max(B.i) from B  where C.i = B.i havi
   7
  62
 (4 rows)
+
+explain select C.j from C where not exists (select max(B.i) from B  where C.i = B.i offset 1000) order by C.j;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=31.39..31.40 rows=5 width=4)
+   Merge Key: c.j
+   ->  Sort  (cost=31.39..31.40 rows=2 width=4)
+         Sort Key: c.j
+         ->  Seq Scan on c  (cost=0.00..31.34 rows=2 width=4)
+               Filter: NOT ((subplan))
+               SubPlan 1
+                 ->  Limit  (cost=3.14..3.14 rows=1 width=4)
+                       ->  Aggregate  (cost=3.13..3.14 rows=1 width=4)
+                             ->  Result  (cost=3.08..3.09 rows=1 width=4)
+                                   Filter: $0 = b.i
+                                   ->  Materialize  (cost=3.08..3.09 rows=1 width=4)
+                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.08 rows=1 width=4)
+                                               ->  Seq Scan on b  (cost=0.00..3.08 rows=1 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(16 rows)
 
 select C.j from C where not exists (select max(B.i) from B  where C.i = B.i offset 1000) order by C.j;
   j  
@@ -765,6 +1114,24 @@ select C.j from C where not exists (select max(B.i) from B  where C.i = B.i offs
  625
  889
 (9 rows)
+
+explain select C.j from C where not exists (select rank() over (order by B.i) from B  where C.i = B.i) order by C.j;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=6.39..6.39 rows=4 width=4)
+   Merge Key: c.j
+   ->  Sort  (cost=6.39..6.39 rows=2 width=4)
+         Sort Key: c.j
+         ->  Hash Left Anti Semi Join  (cost=3.19..6.36 rows=2 width=4)
+               Hash Cond: c.i = "Expr_SUBQUERY".csq_c0
+               ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=8)
+               ->  Hash  (cost=3.12..3.12 rows=2 width=4)
+                     ->  Subquery Scan "Expr_SUBQUERY"  (cost=0.00..3.12 rows=2 width=4)
+                           Filter: "Expr_SUBQUERY".csq_c0 IS NOT NULL
+                           ->  Seq Scan on b  (cost=0.00..3.06 rows=2 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(13 rows)
 
 select C.j from C where not exists (select rank() over (order by B.i) from B  where C.i = B.i) order by C.j;
  j  

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -287,6 +287,52 @@ select A.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i i
 (10 rows)
 
 -- MPP-14222
+explain select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i not in (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
+                                                                                                                                                                                                                               QUERY PLAN                                                                                                                                                                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=0.00..1390613100118.43 rows=4 width=12)
+   ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1390613100118.43 rows=10 width=12)
+         Merge Key: a.i, qp_correlated_query.b.i, qp_correlated_query.c.j
+         ->  Limit  (cost=0.00..1390613100118.43 rows=4 width=12)
+               ->  Sort  (cost=0.00..1390613100118.43 rows=90 width=12)
+                     Sort Key: a.i, qp_correlated_query.b.i, qp_correlated_query.c.j
+                     ->  Nested Loop  (cost=0.00..1390613100118.39 rows=90 width=12)
+                           Join Filter: true
+                           ->  Nested Loop  (cost=0.00..1324033.29 rows=18 width=8)
+                                 Join Filter: true
+                                 ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
+                                       ->  Table Scan on b  (cost=0.00..431.00 rows=2 width=4)
+                                 ->  Table Scan on c  (cost=0.00..431.00 rows=3 width=4)
+                           ->  Materialize  (cost=0.00..1356696141.29 rows=5 width=4)
+                                 ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..1356696141.29 rows=5 width=4)
+                                       ->  Result  (cost=0.00..1356696141.29 rows=2 width=4)
+                                             ->  Table Scan on a  (cost=0.00..1356696141.29 rows=2 width=4)
+                                                   Filter: j = ((subplan))
+                                                   SubPlan 2
+                                                     ->  Result  (cost=0.00..1324036.57 rows=1 width=4)
+                                                           Filter: qp_correlated_query.c.j = $0
+                                                           ->  Materialize  (cost=0.00..1324036.57 rows=9 width=4)
+                                                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1324036.57 rows=9 width=4)
+                                                                       ->  Result  (cost=0.00..1324036.57 rows=3 width=4)
+                                                                             ->  Table Scan on c  (cost=0.00..1324036.57 rows=3 width=4)
+                                                                                   Filter: (subplan)
+                                                                                   SubPlan 1
+                                                                                     ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                                                                                           ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                                                                                                 Filter: (CASE WHEN (sum((CASE WHEN $1 = qp_correlated_query.b.i THEN 1 ELSE 0 END))) IS NULL THEN true WHEN (sum((CASE WHEN qp_correlated_query.b.i IS NULL THEN 1 ELSE 0 END))) > 0::bigint THEN NULL::boolean WHEN $1 IS NULL THEN NULL::boolean WHEN (sum((CASE WHEN $1 = qp_correlated_query.b.i THEN 1 ELSE 0 END))) = 0::bigint THEN true ELSE false END) = true
+                                                                                                 ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                                                                                                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+                                                                                                             ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                                                                                   ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                                                                                                                         Filter: $1 = qp_correlated_query.b.i
+                                                                                                                         ->  Materialize  (cost=0.00..431.00 rows=6 width=4)
+                                                                                                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
+                                                                                                                                     ->  Table Scan on b  (cost=0.00..431.00 rows=2 width=4)
+                                                                                                                                           Filter: i <> 10
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(41 rows)
+
 select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i not in (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
  i | i  | j  
 ---+----+----
@@ -301,6 +347,51 @@ select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j
  1 | -1 | 62
  1 | -1 | 62
 (10 rows)
+
+explain select A.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i not in (select B.i from B where C.i = B.i and B.i !=10)) order by A.j limit 10;
+                                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=0.00..1390613099120.34 rows=4 width=4)
+   ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1390613099120.34 rows=10 width=4)
+         Merge Key: a.j
+         ->  Limit  (cost=0.00..1390613099120.34 rows=4 width=4)
+               ->  Sort  (cost=0.00..1390613099120.34 rows=90 width=4)
+                     Sort Key: a.j
+                     ->  Nested Loop  (cost=0.00..1390613099120.32 rows=90 width=4)
+                           Join Filter: true
+                           ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..1356696141.27 rows=5 width=4)
+                                 ->  Table Scan on a  (cost=0.00..1356696141.27 rows=2 width=4)
+                                       Filter: j = ((subplan))
+                                       SubPlan 2
+                                         ->  Result  (cost=0.00..1324036.57 rows=1 width=4)
+                                               Filter: qp_correlated_query.c.j = $0
+                                               ->  Materialize  (cost=0.00..1324036.57 rows=9 width=4)
+                                                     ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..1324036.57 rows=9 width=4)
+                                                           ->  Result  (cost=0.00..1324036.57 rows=3 width=4)
+                                                                 ->  Table Scan on c  (cost=0.00..1324036.57 rows=3 width=4)
+                                                                       Filter: (subplan)
+                                                                       SubPlan 1
+                                                                         ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                                                                               ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                                                                                     Filter: (CASE WHEN (sum((CASE WHEN $1 = qp_correlated_query.b.i THEN 1 ELSE 0 END))) IS NULL THEN true WHEN (sum((CASE WHEN qp_correlated_query.b.i IS NULL THEN 1 ELSE 0 END))) > 0::bigint THEN NULL::boolean WHEN $1 IS NULL THEN NULL::boolean WHEN (sum((CASE WHEN $1 = qp_correlated_query.b.i THEN 1 ELSE 0 END))) = 0::bigint THEN true ELSE false END) = true
+                                                                                     ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                                                                                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+                                                                                                 ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                                                                       ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                                                                                                             Filter: $1 = qp_correlated_query.b.i
+                                                                                                             ->  Materialize  (cost=0.00..431.00 rows=6 width=4)
+                                                                                                                   ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
+                                                                                                                         ->  Table Scan on b  (cost=0.00..431.00 rows=2 width=4)
+                                                                                                                               Filter: i <> 10
+                           ->  Materialize  (cost=0.00..1324032.34 rows=18 width=1)
+                                 ->  Nested Loop  (cost=0.00..1324032.34 rows=18 width=1)
+                                       Join Filter: true
+                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=6 width=1)
+                                             ->  Table Scan on b  (cost=0.00..431.00 rows=2 width=1)
+                                       ->  Table Scan on c  (cost=0.00..431.00 rows=3 width=1)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(40 rows)
 
 select A.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i not in (select B.i from B where C.i = B.i and B.i !=10)) order by A.j limit 10;
  j  
@@ -410,6 +501,42 @@ select * from A,B where A.j = any (select C.j from C where C.j = A.j and B.i = a
  1 | 1 | 1 | 43
 (4 rows)
 
+explain select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i = any (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
+                                                                                           QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=0.00..3164000295.47 rows=4 width=12)
+   ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..3164000295.47 rows=10 width=12)
+         Merge Key: a.i, qp_correlated_query.b.i, qp_correlated_query.c.j
+         ->  Limit  (cost=0.00..3164000295.47 rows=4 width=12)
+               ->  Sort  (cost=0.00..3164000295.47 rows=90 width=12)
+                     Sort Key: a.i, qp_correlated_query.b.i, qp_correlated_query.c.j
+                     ->  Nested Loop  (cost=0.00..3164000295.43 rows=90 width=12)
+                           Join Filter: true
+                           ->  Nested Loop  (cost=0.00..1324033.29 rows=18 width=8)
+                                 Join Filter: true
+                                 ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
+                                       ->  Table Scan on b  (cost=0.00..431.00 rows=2 width=4)
+                                 ->  Table Scan on c  (cost=0.00..431.00 rows=3 width=4)
+                           ->  Materialize  (cost=0.00..1765379.74 rows=5 width=4)
+                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1765379.74 rows=5 width=4)
+                                       ->  Result  (cost=0.00..1765379.74 rows=2 width=4)
+                                             ->  Table Scan on a  (cost=0.00..1765379.74 rows=2 width=4)
+                                                   Filter: j = ((subplan))
+                                                   SubPlan 1
+                                                     ->  Result  (cost=0.00..862.00 rows=1 width=4)
+                                                           Filter: qp_correlated_query.c.j = $0
+                                                           ->  Materialize  (cost=0.00..862.00 rows=6 width=4)
+                                                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..862.00 rows=6 width=4)
+                                                                       ->  Hash EXISTS Join  (cost=0.00..862.00 rows=2 width=4)
+                                                                             Hash Cond: qp_correlated_query.c.i = qp_correlated_query.b.i AND qp_correlated_query.c.i = qp_correlated_query.b.i
+                                                                             ->  Table Scan on c  (cost=0.00..431.00 rows=3 width=8)
+                                                                             ->  Hash  (cost=431.00..431.00 rows=2 width=4)
+                                                                                   ->  Table Scan on b  (cost=0.00..431.00 rows=2 width=4)
+                                                                                         Filter: i <> 10
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(31 rows)
+
 select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i = any (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
  i  | i  |  j  
 ----+----+-----
@@ -425,6 +552,46 @@ select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j
  99 |  1 |  -1
 (10 rows)
 
+explain select A.i, B.i, C.j from A, B, C where A.j = any ( select C.j from C where not exists(select C.i from C,A where C.i = A.i and C.i =10)) order by A.i, B.i, C.j limit 10;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=0.00..1358457987.42 rows=4 width=12)
+   ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1358457987.42 rows=10 width=12)
+         Merge Key: qp_correlated_query.a.i, b.i, qp_correlated_query.c.j
+         ->  Limit  (cost=0.00..1358457987.42 rows=4 width=12)
+               ->  Sort  (cost=0.00..1358457987.42 rows=90 width=12)
+                     Sort Key: qp_correlated_query.a.i, b.i, qp_correlated_query.c.j
+                     ->  Hash EXISTS Join  (cost=0.00..1358457987.38 rows=90 width=12)
+                           Hash Cond: qp_correlated_query.a.j = qp_correlated_query.c.j
+                           ->  Nested Loop  (cost=0.00..1356692610.50 rows=90 width=16)
+                                 Join Filter: true
+                                 ->  Nested Loop  (cost=0.00..1324033.12 rows=10 width=12)
+                                       Join Filter: true
+                                       ->  Table Scan on a  (cost=0.00..431.00 rows=2 width=8)
+                                       ->  Materialize  (cost=0.00..431.00 rows=6 width=4)
+                                             ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
+                                                   ->  Table Scan on b  (cost=0.00..431.00 rows=2 width=4)
+                                 ->  Materialize  (cost=0.00..431.00 rows=9 width=4)
+                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=9 width=4)
+                                             ->  Table Scan on c  (cost=0.00..431.00 rows=3 width=4)
+                           ->  Hash  (cost=1765376.85..1765376.85 rows=9 width=4)
+                                 ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..1765376.85 rows=9 width=4)
+                                       ->  Nested Loop Left Anti Semi Join  (cost=0.00..1765376.85 rows=3 width=4)
+                                             Join Filter: true
+                                             ->  Table Scan on c  (cost=0.00..431.00 rows=3 width=4)
+                                             ->  Materialize  (cost=0.00..862.00 rows=2 width=1)
+                                                   ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..862.00 rows=2 width=1)
+                                                         ->  Hash Join  (cost=0.00..862.00 rows=1 width=1)
+                                                               Hash Cond: qp_correlated_query.c.i = qp_correlated_query.a.i
+                                                               ->  Table Scan on c  (cost=0.00..431.00 rows=1 width=4)
+                                                                     Filter: i = 10 AND i = 10
+                                                               ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                                                     ->  Table Scan on a  (cost=0.00..431.00 rows=1 width=4)
+                                                                           Filter: i = 10 AND i = 10
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(35 rows)
+
 select A.i, B.i, C.j from A, B, C where A.j = any ( select C.j from C where not exists(select C.i from C,A where C.i = A.i and C.i =10)) order by A.i, B.i, C.j limit 10;
  i | i  | j  
 ---+----+----
@@ -439,6 +606,39 @@ select A.i, B.i, C.j from A, B, C where A.j = any ( select C.j from C where not 
  1 | -1 | 62
  1 | -1 | 62
 (10 rows)
+
+explain select A.i, B.i, C.j from A, B, C where A.j = any (select C.j from C where C.j = A.j and not exists (select sum(B.i) from B where C.i = B.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=0.00..1356692465.22 rows=4 width=12)
+   ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1356692465.22 rows=10 width=12)
+         Merge Key: a.i, b.i, c.j
+         ->  Limit  (cost=0.00..1356692465.22 rows=4 width=12)
+               ->  Sort  (cost=0.00..1356692465.22 rows=18 width=12)
+                     Sort Key: a.i, b.i, c.j
+                     ->  Nested Loop  (cost=0.00..1356692465.22 rows=18 width=12)
+                           Join Filter: true
+                           ->  Nested Loop  (cost=0.00..1324032.98 rows=2 width=8)
+                                 Join Filter: true
+                                 ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                       ->  Hash Join  (cost=0.00..431.00 rows=1 width=4)
+                                             Hash Cond: "outer".j = a.j
+                                             ->  Result  (cost=0.00..0.00 rows=0 width=4)
+                                                   ->  HashAggregate  (cost=0.00..0.00 rows=0 width=4)
+                                                         Group By: NULL::integer
+                                                         ->  Result  (cost=0.00..0.00 rows=0 width=4)
+                                                               One-Time Filter: false
+                                             ->  Hash  (cost=431.00..431.00 rows=2 width=8)
+                                                   ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=2 width=8)
+                                                         Hash Key: a.j
+                                                         ->  Table Scan on a  (cost=0.00..431.00 rows=2 width=8)
+                                 ->  Table Scan on b  (cost=0.00..431.00 rows=2 width=4)
+                           ->  Materialize  (cost=0.00..431.00 rows=9 width=4)
+                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=9 width=4)
+                                       ->  Table Scan on c  (cost=0.00..431.00 rows=3 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(28 rows)
 
 select A.i, B.i, C.j from A, B, C where A.j = any (select C.j from C where C.j = A.j and not exists (select sum(B.i) from B where C.i = B.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
  i | i | j 
@@ -498,6 +698,61 @@ select * from A,B where exists (select * from C where C.j = A.j and B.i = all (s
 ---+---+---+---
 (0 rows)
 
+explain select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C where C.j = A.j and C.i = all (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
+                                                                                                                                                                                                                               QUERY PLAN                                                                                                                                                                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=0.00..2712506063.63 rows=4 width=12)
+   ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..2712506063.63 rows=10 width=12)
+         Merge Key: a.i, qp_correlated_query.b.i, qp_correlated_query.c.j
+         ->  Limit  (cost=0.00..2712506063.63 rows=4 width=12)
+               ->  Sort  (cost=0.00..2712506063.63 rows=90 width=12)
+                     Sort Key: a.i, qp_correlated_query.b.i, qp_correlated_query.c.j
+                     ->  Nested Loop  (cost=0.00..2712506063.59 rows=90 width=12)
+                           Join Filter: true
+                           ->  Hash Join  (cost=0.00..2648069.70 rows=10 width=8)
+                                 Hash Cond: a.j::bigint = (pg_catalog.sum((sum(qp_correlated_query.c.j)))) AND a.j = qp_correlated_query.c.j
+                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1324033.12 rows=10 width=12)
+                                       Hash Key: a.j
+                                       ->  Nested Loop  (cost=0.00..1324033.12 rows=10 width=12)
+                                             Join Filter: true
+                                             ->  Table Scan on a  (cost=0.00..431.00 rows=2 width=8)
+                                             ->  Materialize  (cost=0.00..431.00 rows=6 width=4)
+                                                   ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
+                                                         ->  Table Scan on b  (cost=0.00..431.00 rows=2 width=4)
+                                 ->  Hash  (cost=1324036.57..1324036.57 rows=3 width=12)
+                                       ->  GroupAggregate  (cost=0.00..1324036.57 rows=3 width=12)
+                                             Group By: qp_correlated_query.c.j
+                                             ->  Sort  (cost=0.00..1324036.57 rows=3 width=12)
+                                                   Sort Key: qp_correlated_query.c.j
+                                                   ->  Redistribute Motion 3:3  (slice5; segments: 3)  (cost=0.00..1324036.57 rows=3 width=12)
+                                                         Hash Key: qp_correlated_query.c.j
+                                                         ->  Result  (cost=0.00..1324036.57 rows=3 width=12)
+                                                               ->  GroupAggregate  (cost=0.00..1324036.57 rows=3 width=12)
+                                                                     Group By: qp_correlated_query.c.j
+                                                                     ->  Sort  (cost=0.00..1324036.57 rows=3 width=4)
+                                                                           Sort Key: qp_correlated_query.c.j
+                                                                           ->  Table Scan on c  (cost=0.00..1324036.57 rows=3 width=4)
+                                                                                 Filter: (subplan)
+                                                                                 SubPlan 1
+                                                                                   ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                                                                                         ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                                                                                               Filter: (CASE WHEN (sum((CASE WHEN $0 <> qp_correlated_query.b.i THEN 1 ELSE 0 END))) IS NULL THEN true WHEN (sum((CASE WHEN qp_correlated_query.b.i IS NULL THEN 1 ELSE 0 END))) > 0::bigint THEN NULL::boolean WHEN $0 IS NULL THEN NULL::boolean WHEN (sum((CASE WHEN $0 <> qp_correlated_query.b.i THEN 1 ELSE 0 END))) = 0::bigint THEN true ELSE false END) = true
+                                                                                               ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                                                                                                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+                                                                                                           ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                                                                                 ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                                                                                                                       Filter: $0 = qp_correlated_query.b.i
+                                                                                                                       ->  Materialize  (cost=0.00..431.00 rows=6 width=4)
+                                                                                                                             ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
+                                                                                                                                   ->  Table Scan on b  (cost=0.00..431.00 rows=2 width=4)
+                                                                                                                                         Filter: i <> 10
+                           ->  Materialize  (cost=0.00..431.00 rows=9 width=4)
+                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=9 width=4)
+                                       ->  Table Scan on c  (cost=0.00..431.00 rows=3 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(50 rows)
+
 select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C where C.j = A.j and C.i = all (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
  i | i  | j  
 ---+----+----
@@ -513,10 +768,84 @@ select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C where C.j 
  1 | -1 | 62
 (10 rows)
 
+explain select A.i, B.i, C.j from A, B, C where A.j < all ( select C.j from C where not exists(select C.i from C,A where C.i = A.i and C.i =10)) order by A.i, B.i, C.j limit 10;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=0.00..1391061420469.59 rows=4 width=12)
+   ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1391061420469.59 rows=10 width=12)
+         Merge Key: qp_correlated_query.a.i, b.i, qp_correlated_query.c.j
+         ->  Limit  (cost=0.00..1391061420469.59 rows=4 width=12)
+               ->  Sort  (cost=0.00..1391061420469.59 rows=36 width=12)
+                     Sort Key: qp_correlated_query.a.i, b.i, qp_correlated_query.c.j
+                     ->  Nested Loop Left Anti Semi Join (Not-In)  (cost=0.00..1391061420469.58 rows=36 width=12)
+                           Join Filter: qp_correlated_query.a.j >= qp_correlated_query.c.j
+                           ->  Nested Loop  (cost=0.00..1356692610.50 rows=90 width=16)
+                                 Join Filter: true
+                                 ->  Nested Loop  (cost=0.00..1324033.12 rows=10 width=12)
+                                       Join Filter: true
+                                       ->  Table Scan on a  (cost=0.00..431.00 rows=2 width=8)
+                                       ->  Materialize  (cost=0.00..431.00 rows=6 width=4)
+                                             ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
+                                                   ->  Table Scan on b  (cost=0.00..431.00 rows=2 width=4)
+                                 ->  Materialize  (cost=0.00..431.00 rows=9 width=4)
+                                       ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=9 width=4)
+                                             ->  Table Scan on c  (cost=0.00..431.00 rows=3 width=4)
+                           ->  Materialize  (cost=0.00..1765376.85 rows=9 width=4)
+                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1765376.85 rows=9 width=4)
+                                       ->  Nested Loop Left Anti Semi Join  (cost=0.00..1765376.85 rows=3 width=4)
+                                             Join Filter: true
+                                             ->  Table Scan on c  (cost=0.00..431.00 rows=3 width=4)
+                                             ->  Materialize  (cost=0.00..862.00 rows=2 width=1)
+                                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..862.00 rows=2 width=1)
+                                                         ->  Hash Join  (cost=0.00..862.00 rows=1 width=1)
+                                                               Hash Cond: qp_correlated_query.c.i = qp_correlated_query.a.i
+                                                               ->  Table Scan on c  (cost=0.00..431.00 rows=1 width=4)
+                                                                     Filter: i = 10 AND i = 10
+                                                               ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                                                     ->  Table Scan on a  (cost=0.00..431.00 rows=1 width=4)
+                                                                           Filter: i = 10 AND i = 10
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(35 rows)
+
 select A.i, B.i, C.j from A, B, C where A.j < all ( select C.j from C where not exists(select C.i from C,A where C.i = A.i and C.i =10)) order by A.i, B.i, C.j limit 10;
  i | i | j 
 ---+---+---
 (0 rows)
+
+explain select A.i, B.i, C.j from A, B, C where A.j = all (select C.j from C where C.j = A.j and not exists (select sum(B.i) from B where C.i = B.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
+                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=0.00..2260124027.48 rows=4 width=12)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..2260124027.48 rows=10 width=12)
+         Merge Key: a.i, b.i, c.j
+         ->  Limit  (cost=0.00..2260124027.48 rows=4 width=12)
+               ->  Sort  (cost=0.00..2260124027.48 rows=18 width=12)
+                     Sort Key: a.i, b.i, c.j
+                     ->  Nested Loop  (cost=0.00..2260124027.48 rows=18 width=12)
+                           Join Filter: true
+                           ->  Nested Loop  (cost=0.00..1324033.29 rows=18 width=8)
+                                 Join Filter: true
+                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
+                                       ->  Table Scan on b  (cost=0.00..431.00 rows=2 width=4)
+                                 ->  Table Scan on c  (cost=0.00..431.00 rows=3 width=4)
+                           ->  Materialize  (cost=0.00..882688.08 rows=1 width=4)
+                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..882688.08 rows=1 width=4)
+                                       ->  Result  (cost=0.00..882688.08 rows=1 width=4)
+                                             ->  Table Scan on a  (cost=0.00..882688.08 rows=1 width=4)
+                                                   Filter: (subplan)
+                                                   SubPlan 1
+                                                     ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                                                           ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                                                                 Filter: (CASE WHEN (sum((CASE WHEN $0 <> "outer".j THEN 1 ELSE 0 END))) IS NULL THEN true WHEN (sum((CASE WHEN "outer".j IS NULL THEN 1 ELSE 0 END))) > 0::bigint THEN NULL::boolean WHEN $0 IS NULL THEN NULL::boolean WHEN (sum((CASE WHEN $0 <> "outer".j THEN 1 ELSE 0 END))) = 0::bigint THEN true ELSE false END) = true
+                                                                 ->  Result  (cost=0.00..0.00 rows=0 width=1)
+                                                                       ->  Aggregate  (cost=0.00..0.00 rows=0 width=16)
+                                                                             ->  Result  (cost=0.00..0.00 rows=0 width=8)
+                                                                                   ->  Result  (cost=0.00..0.00 rows=0 width=4)
+                                                                                         One-Time Filter: false
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(29 rows)
 
 select A.i, B.i, C.j from A, B, C where A.j = all (select C.j from C where C.j = A.j and not exists (select sum(B.i) from B where C.i = B.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
  i | i  | j  
@@ -787,6 +1116,28 @@ select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j
 ---+---+---
 (0 rows)
 
+explain select C.j from C where not exists (select max(B.i) from B  where C.i = B.i having max(B.i) is not null) order by C.j;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=4 width=4)
+   Merge Key: c.j
+   ->  Sort  (cost=0.00..862.00 rows=2 width=4)
+         Sort Key: c.j
+         ->  Hash Left Anti Semi Join  (cost=0.00..862.00 rows=2 width=4)
+               Hash Cond: c.i = b.i
+               ->  Table Scan on c  (cost=0.00..431.00 rows=3 width=8)
+               ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                     ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                           Filter: NOT (max(b.i)) IS NULL
+                           ->  GroupAggregate  (cost=0.00..431.00 rows=2 width=8)
+                                 Group By: b.i
+                                 ->  Sort  (cost=0.00..431.00 rows=2 width=4)
+                                       Sort Key: b.i
+                                       ->  Table Scan on b  (cost=0.00..431.00 rows=2 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(17 rows)
+
 select C.j from C where not exists (select max(B.i) from B  where C.i = B.i having max(B.i) is not null) order by C.j;
  j  
 ----
@@ -795,6 +1146,28 @@ select C.j from C where not exists (select max(B.i) from B  where C.i = B.i havi
   7
  62
 (4 rows)
+
+explain select C.j from C where not exists (select max(B.i) from B  where C.i = B.i offset 1000) order by C.j;
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324036.36 rows=9 width=4)
+   Merge Key: c.j
+   ->  Result  (cost=0.00..1324036.36 rows=3 width=4)
+         ->  Sort  (cost=0.00..1324036.36 rows=3 width=4)
+               Sort Key: c.j
+               ->  Table Scan on c  (cost=0.00..1324036.36 rows=3 width=4)
+                     Filter: (subplan)
+                     SubPlan 1
+                       ->  Limit  (cost=0.00..431.00 rows=1 width=4)
+                             ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
+                                   ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                                         Filter: $0 = b.i
+                                         ->  Materialize  (cost=0.00..431.00 rows=6 width=4)
+                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
+                                                     ->  Table Scan on b  (cost=0.00..431.00 rows=2 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(17 rows)
 
 select C.j from C where not exists (select max(B.i) from B  where C.i = B.i offset 1000) order by C.j;
   j  
@@ -809,6 +1182,30 @@ select C.j from C where not exists (select max(B.i) from B  where C.i = B.i offs
  625
  889
 (9 rows)
+
+explain select C.j from C where not exists (select rank() over (order by B.i) from B  where C.i = B.i) order by C.j;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=4 width=4)
+   Merge Key: c.j
+   ->  Sort  (cost=0.00..862.00 rows=2 width=4)
+         Sort Key: c.j
+         ->  Hash Left Anti Semi Join  (cost=0.00..862.00 rows=2 width=4)
+               Hash Cond: c.i = b.i
+               ->  Table Scan on c  (cost=0.00..431.00 rows=3 width=8)
+               ->  Hash  (cost=431.00..431.00 rows=6 width=4)
+                     ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=18 width=4)
+                           ->  Result  (cost=0.00..431.00 rows=2 width=4)
+                                 ->  Window  (cost=0.00..431.00 rows=2 width=4)
+                                       Order By: b.i
+                                       ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
+                                             Merge Key: b.i
+                                             ->  Sort  (cost=0.00..431.00 rows=2 width=4)
+                                                   Sort Key: b.i
+                                                   ->  Table Scan on b  (cost=0.00..431.00 rows=2 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.0
+(19 rows)
 
 select C.j from C where not exists (select rank() over (order by B.i) from B  where C.i = B.i) order by C.j;
  j  

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -1374,3 +1374,265 @@ SELECT bar_s.c FROM bar_s, foo_s WHERE foo_s.b = (SELECT max(i) FROM baz_s WHERE
 DROP TABLE bar_s;
 DROP TABLE foo_s;
 DROP TABLE baz_s;
+--
+-- EXPLAIN tests for queries in subselect.sql to significant plan changes
+--
+-- Set up some simple test tables
+CREATE TABLE SUBSELECT_TBL (
+  f1 integer,
+  f2 integer,
+  f3 float
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO SUBSELECT_TBL VALUES (1, 2, 3);
+INSERT INTO SUBSELECT_TBL VALUES (2, 3, 4);
+INSERT INTO SUBSELECT_TBL VALUES (3, 4, 5);
+INSERT INTO SUBSELECT_TBL VALUES (1, 1, 1);
+INSERT INTO SUBSELECT_TBL VALUES (2, 2, 2);
+INSERT INTO SUBSELECT_TBL VALUES (3, 3, 3);
+INSERT INTO SUBSELECT_TBL VALUES (6, 7, 8);
+INSERT INTO SUBSELECT_TBL VALUES (8, 9, NULL);
+ANALYZE SUBSELECT_TBL;
+-- Uncorrelated subselects
+EXPLAIN SELECT '' AS six, f1 AS "Uncorrelated Field" FROM SUBSELECT_TBL
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL) ORDER BY 2;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=2.12..2.13 rows=4 width=4)
+   Merge Key: subselect_gp.subselect_tbl.f1
+   ->  Sort  (cost=2.12..2.13 rows=2 width=4)
+         Sort Key: subselect_gp.subselect_tbl.f1
+         ->  Hash EXISTS Join  (cost=1.04..2.09 rows=2 width=4)
+               Hash Cond: subselect_gp.subselect_tbl.f1 = subselect_gp.subselect_tbl.f2
+               ->  Seq Scan on subselect_tbl  (cost=0.00..1.01 rows=1 width=4)
+               ->  Hash  (cost=1.03..1.03 rows=1 width=4)
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=4)
+                           Hash Key: subselect_gp.subselect_tbl.f2
+                           ->  Seq Scan on subselect_tbl  (cost=0.00..1.01 rows=1 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(13 rows)
+
+EXPLAIN SELECT '' AS six, f1 AS "Uncorrelated Field" FROM SUBSELECT_TBL
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE
+    f2 IN (SELECT f1 FROM SUBSELECT_TBL)) ORDER BY 2;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10.55..10.60 rows=21 width=4)
+   Merge Key: subselect_gp.subselect_tbl.f1
+   ->  Sort  (cost=10.55..10.60 rows=7 width=4)
+         Sort Key: subselect_gp.subselect_tbl.f1
+         ->  Hash EXISTS Join  (cost=6.74..10.09 rows=7 width=4)
+               Hash Cond: subselect_gp.subselect_tbl.f1 = subselect_gp.subselect_tbl.f2
+               ->  Seq Scan on subselect_tbl  (cost=0.00..3.08 rows=3 width=4)
+               ->  Hash  (cost=6.59..6.59 rows=4 width=8)
+                     ->  Hash Join  (cost=3.18..6.59 rows=4 width=8)
+                           Hash Cond: subselect_gp.subselect_tbl.f2 = subselect_gp.subselect_tbl.f1
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.24 rows=3 width=4)
+                                 Hash Key: subselect_gp.subselect_tbl.f2
+                                 ->  Seq Scan on subselect_tbl  (cost=0.00..3.08 rows=3 width=4)
+                           ->  Hash  (cost=3.08..3.08 rows=3 width=4)
+                                 ->  Seq Scan on subselect_tbl  (cost=0.00..3.08 rows=3 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(19 rows)
+
+EXPLAIN SELECT '' AS three, f1, f2
+  FROM SUBSELECT_TBL
+  WHERE (f1, f2) NOT IN (SELECT f2, CAST(f3 AS int4) FROM SUBSELECT_TBL
+                         WHERE f3 IS NOT NULL) ORDER BY 2,3;
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=2.18..2.19 rows=4 width=8)
+   Merge Key: subselect_gp.subselect_tbl.f1, subselect_gp.subselect_tbl.f2
+   ->  Sort  (cost=2.18..2.19 rows=2 width=8)
+         Sort Key: subselect_gp.subselect_tbl.f1, subselect_gp.subselect_tbl.f2
+         ->  Nested Loop Left Anti Semi Join (Not-In)  (cost=1.07..2.15 rows=2 width=8)
+               Join Filter: subselect_gp.subselect_tbl.f1 = "NotIn_SUBQUERY".f2 AND subselect_gp.subselect_tbl.f2 = "NotIn_SUBQUERY".f3
+               ->  Seq Scan on subselect_tbl  (cost=0.00..1.01 rows=1 width=8)
+               ->  Materialize  (cost=1.07..1.10 rows=1 width=8)
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.06 rows=1 width=8)
+                           ->  Subquery Scan "NotIn_SUBQUERY"  (cost=0.00..1.02 rows=1 width=8)
+                                 ->  Seq Scan on subselect_tbl  (cost=0.00..1.01 rows=1 width=12)
+                                       Filter: f3 IS NOT NULL
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(14 rows)
+
+-- Correlated subselects
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1) ORDER BY 2,3;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2.10..2.11 rows=4 width=8)
+   Merge Key: upper.f1, upper.f2
+   ->  Sort  (cost=2.10..2.11 rows=2 width=8)
+         Sort Key: upper.f1, upper.f2
+         ->  Hash EXISTS Join  (cost=1.02..2.07 rows=2 width=8)
+               Hash Cond: upper.f1 = subselect_tbl.f1
+               ->  Seq Scan on subselect_tbl upper  (cost=0.00..1.01 rows=1 width=8)
+               ->  Hash  (cost=1.01..1.01 rows=1 width=8)
+                     ->  Seq Scan on subselect_tbl  (cost=0.00..1.01 rows=1 width=8)
+                           Filter: f1 = f2
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(12 rows)
+
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f3 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f1 IN
+    (SELECT f2 FROM SUBSELECT_TBL WHERE CAST(upper.f2 AS float) = f3) ORDER BY 2,3;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=2.13..2.14 rows=4 width=12)
+   Merge Key: upper.f1, upper.f3
+   ->  Sort  (cost=2.13..2.14 rows=2 width=12)
+         Sort Key: upper.f1, upper.f3
+         ->  Hash EXISTS Join  (cost=1.04..2.10 rows=2 width=12)
+               Hash Cond: upper.f1 = subselect_tbl.f2 AND upper.f2::double precision = subselect_tbl.f3
+               ->  Seq Scan on subselect_tbl upper  (cost=0.00..1.01 rows=1 width=16)
+               ->  Hash  (cost=1.03..1.03 rows=1 width=12)
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=12)
+                           Hash Key: subselect_tbl.f2
+                           ->  Seq Scan on subselect_tbl  (cost=0.00..1.01 rows=1 width=12)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(13 rows)
+
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f3 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f3 IN (SELECT upper.f1 + f2 FROM SUBSELECT_TBL
+               WHERE f2 = CAST(f3 AS integer)) ORDER BY 2,3;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=2.18..2.19 rows=4 width=12)
+   Merge Key: upper.f1, upper.f3
+   ->  Sort  (cost=2.18..2.19 rows=2 width=12)
+         Sort Key: upper.f1, upper.f3
+         ->  Nested Loop EXISTS Join  (cost=1.06..2.15 rows=2 width=12)
+               Join Filter: (upper.f1 + subselect_tbl.f2)::double precision = upper.f3
+               ->  Seq Scan on subselect_tbl upper  (cost=0.00..1.01 rows=1 width=12)
+               ->  Materialize  (cost=1.06..1.09 rows=1 width=12)
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.05 rows=1 width=12)
+                           ->  Seq Scan on subselect_tbl  (cost=0.00..1.01 rows=1 width=12)
+                                 Filter: f2 = f3::integer
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(13 rows)
+
+EXPLAIN SELECT '' AS five, f1 AS "Correlated Field"
+  FROM SUBSELECT_TBL
+  WHERE (f1, f2) IN (SELECT f2, CAST(f3 AS int4) FROM SUBSELECT_TBL
+                     WHERE f3 IS NOT NULL) ORDER BY 2;
+                                                                            QUERY PLAN                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=2.13..2.14 rows=4 width=4)
+   Merge Key: subselect_gp.subselect_tbl.f1
+   ->  Sort  (cost=2.13..2.14 rows=2 width=4)
+         Sort Key: subselect_gp.subselect_tbl.f1
+         ->  Hash EXISTS Join  (cost=1.04..2.10 rows=2 width=4)
+               Hash Cond: subselect_gp.subselect_tbl.f1 = subselect_gp.subselect_tbl.f2 AND subselect_gp.subselect_tbl.f2 = subselect_gp.subselect_tbl.f3::integer
+               ->  Seq Scan on subselect_tbl  (cost=0.00..1.01 rows=1 width=8)
+               ->  Hash  (cost=1.03..1.03 rows=1 width=12)
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=12)
+                           Hash Key: subselect_gp.subselect_tbl.f2
+                           ->  Seq Scan on subselect_tbl  (cost=0.00..1.01 rows=1 width=12)
+                                 Filter: f3 IS NOT NULL
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(14 rows)
+
+--
+-- Test cases to catch unpleasant interactions between IN-join processing
+-- and subquery pullup.
+--
+EXPLAIN select count(*) from
+  (select 1 from tenk1 a
+   where unique1 IN (select hundred from tenk1 b)) ss;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=752.98..752.99 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=752.91..752.96 rows=1 width=8)
+         ->  Aggregate  (cost=752.91..752.92 rows=1 width=8)
+               ->  Hash Join  (cost=414.79..728.02 rows=3319 width=4)
+                     Hash Cond: a.unique1 = b.hundred
+                     ->  Seq Scan on tenk1 a  (cost=0.00..188.55 rows=3319 width=4)
+                     ->  Hash  (cost=413.54..413.54 rows=34 width=4)
+                           ->  HashAggregate  (cost=412.54..413.54 rows=34 width=4)
+                                 Group By: b.hundred
+                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..387.65 rows=3319 width=4)
+                                       Hash Key: b.hundred
+                                       ->  Seq Scan on tenk1 b  (cost=0.00..188.55 rows=3319 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(14 rows)
+
+EXPLAIN select count(distinct ss.ten) from
+  (select ten from tenk1 a
+   where unique1 IN (select hundred from tenk1 b)) ss;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=952.08..952.09 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=952.01..952.06 rows=1 width=8)
+         ->  Aggregate  (cost=952.01..952.02 rows=1 width=8)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=414.79..927.12 rows=3319 width=8)
+                     Hash Key: a.ten
+                     ->  Hash Join  (cost=414.79..728.02 rows=3319 width=8)
+                           Hash Cond: a.unique1 = b.hundred
+                           ->  Seq Scan on tenk1 a  (cost=0.00..188.55 rows=3319 width=8)
+                           ->  Hash  (cost=413.54..413.54 rows=34 width=4)
+                                 ->  HashAggregate  (cost=412.54..413.54 rows=34 width=4)
+                                       Group By: b.hundred
+                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..387.65 rows=3319 width=4)
+                                             Hash Key: b.hundred
+                                             ->  Seq Scan on tenk1 b  (cost=0.00..188.55 rows=3319 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(16 rows)
+
+EXPLAIN select count(*) from
+  (select 1 from tenk1 a
+   where unique1 IN (select distinct hundred from tenk1 b)) ss;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=752.98..752.99 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=752.91..752.96 rows=1 width=8)
+         ->  Aggregate  (cost=752.91..752.92 rows=1 width=8)
+               ->  Hash Join  (cost=414.79..728.02 rows=3319 width=4)
+                     Hash Cond: a.unique1 = b.hundred
+                     ->  Seq Scan on tenk1 a  (cost=0.00..188.55 rows=3319 width=4)
+                     ->  Hash  (cost=413.54..413.54 rows=34 width=4)
+                           ->  HashAggregate  (cost=412.54..413.54 rows=34 width=4)
+                                 Group By: b.hundred
+                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..387.65 rows=3319 width=4)
+                                       Hash Key: b.hundred
+                                       ->  Seq Scan on tenk1 b  (cost=0.00..188.55 rows=3319 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(14 rows)
+
+EXPLAIN select count(distinct ss.ten) from
+  (select ten from tenk1 a
+   where unique1 IN (select distinct hundred from tenk1 b)) ss;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=952.08..952.09 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=952.01..952.06 rows=1 width=8)
+         ->  Aggregate  (cost=952.01..952.02 rows=1 width=8)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=414.79..927.12 rows=3319 width=8)
+                     Hash Key: a.ten
+                     ->  Hash Join  (cost=414.79..728.02 rows=3319 width=8)
+                           Hash Cond: a.unique1 = b.hundred
+                           ->  Seq Scan on tenk1 a  (cost=0.00..188.55 rows=3319 width=8)
+                           ->  Hash  (cost=413.54..413.54 rows=34 width=4)
+                                 ->  HashAggregate  (cost=412.54..413.54 rows=34 width=4)
+                                       Group By: b.hundred
+                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..387.65 rows=3319 width=4)
+                                             Hash Key: b.hundred
+                                             ->  Seq Scan on tenk1 b  (cost=0.00..188.55 rows=3319 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(16 rows)
+

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -1358,3 +1358,302 @@ SELECT bar_s.c FROM bar_s, foo_s WHERE foo_s.b = (SELECT max(i) FROM baz_s WHERE
 DROP TABLE bar_s;
 DROP TABLE foo_s;
 DROP TABLE baz_s;
+--
+-- EXPLAIN tests for queries in subselect.sql to significant plan changes
+--
+-- Set up some simple test tables
+CREATE TABLE SUBSELECT_TBL (
+  f1 integer,
+  f2 integer,
+  f3 float
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO SUBSELECT_TBL VALUES (1, 2, 3);
+INSERT INTO SUBSELECT_TBL VALUES (2, 3, 4);
+INSERT INTO SUBSELECT_TBL VALUES (3, 4, 5);
+INSERT INTO SUBSELECT_TBL VALUES (1, 1, 1);
+INSERT INTO SUBSELECT_TBL VALUES (2, 2, 2);
+INSERT INTO SUBSELECT_TBL VALUES (3, 3, 3);
+INSERT INTO SUBSELECT_TBL VALUES (6, 7, 8);
+INSERT INTO SUBSELECT_TBL VALUES (8, 9, NULL);
+ANALYZE SUBSELECT_TBL;
+-- Uncorrelated subselects
+EXPLAIN SELECT '' AS six, f1 AS "Uncorrelated Field" FROM SUBSELECT_TBL
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL) ORDER BY 2;
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..862.00 rows=1 width=12)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+         Merge Key: subselect_gp.subselect_tbl.f1
+         ->  Sort  (cost=0.00..862.00 rows=1 width=4)
+               Sort Key: subselect_gp.subselect_tbl.f1
+               ->  Hash EXISTS Join  (cost=0.00..862.00 rows=1 width=4)
+                     Hash Cond: subselect_gp.subselect_tbl.f1 = subselect_gp.subselect_tbl.f2
+                     ->  Table Scan on subselect_tbl  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                 Hash Key: subselect_gp.subselect_tbl.f2
+                                 ->  Table Scan on subselect_tbl  (cost=0.00..431.00 rows=1 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.1
+(14 rows)
+
+EXPLAIN SELECT '' AS six, f1 AS "Uncorrelated Field" FROM SUBSELECT_TBL
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE
+    f2 IN (SELECT f1 FROM SUBSELECT_TBL)) ORDER BY 2;
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1293.00 rows=1 width=12)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.00 rows=1 width=4)
+         Merge Key: subselect_gp.subselect_tbl.f1
+         ->  Sort  (cost=0.00..1293.00 rows=1 width=4)
+               Sort Key: subselect_gp.subselect_tbl.f1
+               ->  Hash Join  (cost=0.00..1293.00 rows=2 width=4)
+                     Hash Cond: subselect_gp.subselect_tbl.f1 = subselect_gp.subselect_tbl.f2
+                     ->  Table Scan on subselect_tbl  (cost=0.00..431.00 rows=3 width=4)
+                     ->  Hash  (cost=862.00..862.00 rows=2 width=4)
+                           ->  GroupAggregate  (cost=0.00..862.00 rows=2 width=4)
+                                 Group By: subselect_gp.subselect_tbl.f2
+                                 ->  Sort  (cost=0.00..862.00 rows=3 width=4)
+                                       Sort Key: subselect_gp.subselect_tbl.f2
+                                       ->  Hash EXISTS Join  (cost=0.00..862.00 rows=3 width=4)
+                                             Hash Cond: subselect_gp.subselect_tbl.f2 = subselect_gp.subselect_tbl.f1
+                                             ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
+                                                   Hash Key: subselect_gp.subselect_tbl.f2
+                                                   ->  Table Scan on subselect_tbl  (cost=0.00..431.00 rows=3 width=4)
+                                             ->  Hash  (cost=431.00..431.00 rows=3 width=4)
+                                                   ->  Table Scan on subselect_tbl  (cost=0.00..431.00 rows=3 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.1
+(22 rows)
+
+EXPLAIN SELECT '' AS three, f1, f2
+  FROM SUBSELECT_TBL
+  WHERE (f1, f2) NOT IN (SELECT f2, CAST(f3 AS int4) FROM SUBSELECT_TBL
+                         WHERE f3 IS NOT NULL) ORDER BY 2,3;
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=2.18..2.19 rows=4 width=8)
+   Merge Key: subselect_gp.subselect_tbl.f1, subselect_gp.subselect_tbl.f2
+   ->  Sort  (cost=2.18..2.19 rows=2 width=8)
+         Sort Key: subselect_gp.subselect_tbl.f1, subselect_gp.subselect_tbl.f2
+         ->  Nested Loop Left Anti Semi Join (Not-In)  (cost=1.07..2.15 rows=2 width=8)
+               Join Filter: subselect_gp.subselect_tbl.f1 = "NotIn_SUBQUERY".f2 AND subselect_gp.subselect_tbl.f2 = "NotIn_SUBQUERY".f3
+               ->  Seq Scan on subselect_tbl  (cost=0.00..1.01 rows=1 width=8)
+               ->  Materialize  (cost=1.07..1.10 rows=1 width=8)
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.06 rows=1 width=8)
+                           ->  Subquery Scan "NotIn_SUBQUERY"  (cost=0.00..1.02 rows=1 width=8)
+                                 ->  Seq Scan on subselect_tbl  (cost=0.00..1.01 rows=1 width=12)
+                                       Filter: f3 IS NOT NULL
+ Settings:  optimizer=on
+ Optimizer status: legacy query optimizer
+(14 rows)
+
+-- Correlated subselects
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1) ORDER BY 2,3;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..862.00 rows=1 width=16)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+         Merge Key: subselect_gp.subselect_tbl.f1, subselect_gp.subselect_tbl.f2
+         ->  Sort  (cost=0.00..862.00 rows=1 width=8)
+               Sort Key: subselect_gp.subselect_tbl.f1, subselect_gp.subselect_tbl.f2
+               ->  Hash EXISTS Join  (cost=0.00..862.00 rows=1 width=8)
+                     Hash Cond: subselect_gp.subselect_tbl.f1 = subselect_gp.subselect_tbl.f1 AND subselect_gp.subselect_tbl.f1 = subselect_gp.subselect_tbl.f2
+                     ->  Table Scan on subselect_tbl  (cost=0.00..431.00 rows=1 width=8)
+                     ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+                           ->  Table Scan on subselect_tbl  (cost=0.00..431.00 rows=1 width=8)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.1
+(12 rows)
+
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f3 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f1 IN
+    (SELECT f2 FROM SUBSELECT_TBL WHERE CAST(upper.f2 AS float) = f3) ORDER BY 2,3;
+                                                                                    QUERY PLAN                                                                                    
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..862.00 rows=1 width=20)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=12)
+         Merge Key: subselect_gp.subselect_tbl.f1, subselect_gp.subselect_tbl.f3
+         ->  Sort  (cost=0.00..862.00 rows=1 width=12)
+               Sort Key: subselect_gp.subselect_tbl.f1, subselect_gp.subselect_tbl.f3
+               ->  Hash EXISTS Join  (cost=0.00..862.00 rows=1 width=12)
+                     Hash Cond: subselect_gp.subselect_tbl.f2::double precision = subselect_gp.subselect_tbl.f3 AND subselect_gp.subselect_tbl.f1 = subselect_gp.subselect_tbl.f2
+                     ->  Table Scan on subselect_tbl  (cost=0.00..431.00 rows=1 width=16)
+                     ->  Hash  (cost=431.00..431.00 rows=1 width=12)
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                                 Hash Key: subselect_gp.subselect_tbl.f2
+                                 ->  Table Scan on subselect_tbl  (cost=0.00..431.00 rows=1 width=12)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.1
+(14 rows)
+
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f3 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f3 IN (SELECT upper.f1 + f2 FROM SUBSELECT_TBL
+               WHERE f2 = CAST(f3 AS integer)) ORDER BY 2,3;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=2.18..2.19 rows=4 width=12)
+   Merge Key: upper.f1, upper.f3
+   ->  Sort  (cost=2.18..2.19 rows=2 width=12)
+         Sort Key: upper.f1, upper.f3
+         ->  Nested Loop EXISTS Join  (cost=1.06..2.15 rows=2 width=12)
+               Join Filter: (upper.f1 + subselect_tbl.f2)::double precision = upper.f3
+               ->  Seq Scan on subselect_tbl upper  (cost=0.00..1.01 rows=1 width=12)
+               ->  Materialize  (cost=1.06..1.09 rows=1 width=12)
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.05 rows=1 width=12)
+                           ->  Seq Scan on subselect_tbl  (cost=0.00..1.01 rows=1 width=12)
+                                 Filter: f2 = f3::integer
+ Settings:  optimizer=on
+ Optimizer status: legacy query optimizer
+(13 rows)
+
+EXPLAIN SELECT '' AS five, f1 AS "Correlated Field"
+  FROM SUBSELECT_TBL
+  WHERE (f1, f2) IN (SELECT f2, CAST(f3 AS int4) FROM SUBSELECT_TBL
+                     WHERE f3 IS NOT NULL) ORDER BY 2;
+                                                                            QUERY PLAN                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=2.13..2.14 rows=4 width=4)
+   Merge Key: subselect_gp.subselect_tbl.f1
+   ->  Sort  (cost=2.13..2.14 rows=2 width=4)
+         Sort Key: subselect_gp.subselect_tbl.f1
+         ->  Hash EXISTS Join  (cost=1.04..2.10 rows=2 width=4)
+               Hash Cond: subselect_gp.subselect_tbl.f1 = subselect_gp.subselect_tbl.f2 AND subselect_gp.subselect_tbl.f2 = subselect_gp.subselect_tbl.f3::integer
+               ->  Seq Scan on subselect_tbl  (cost=0.00..1.01 rows=1 width=8)
+               ->  Hash  (cost=1.03..1.03 rows=1 width=12)
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=12)
+                           Hash Key: subselect_gp.subselect_tbl.f2
+                           ->  Seq Scan on subselect_tbl  (cost=0.00..1.01 rows=1 width=12)
+                                 Filter: f3 IS NOT NULL
+ Settings:  optimizer=on
+ Optimizer status: legacy query optimizer
+(14 rows)
+
+--
+-- Test cases to catch unpleasant interactions between IN-join processing
+-- and subquery pullup.
+--
+EXPLAIN select count(*) from
+  (select 1 from tenk1 a
+   where unique1 IN (select hundred from tenk1 b)) ss;
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..631.98 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..631.98 rows=1 width=8)
+         ->  Aggregate  (cost=0.00..631.98 rows=1 width=8)
+               ->  Nested Loop  (cost=0.00..631.98 rows=34 width=1)
+                     Join Filter: true
+                     ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
+                           Group By: public.tenk1.hundred
+                           ->  Sort  (cost=0.00..431.94 rows=34 width=4)
+                                 Sort Key: public.tenk1.hundred
+                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
+                                       Hash Key: public.tenk1.hundred
+                                       ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                             Group By: public.tenk1.hundred
+                                             ->  Table Scan on tenk1  (cost=0.00..431.51 rows=3319 width=4)
+                     ->  Index Scan using tenk1_unique1 on tenk1  (cost=0.00..200.04 rows=1 width=1)
+                           Index Cond: public.tenk1.unique1 = public.tenk1.hundred
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.1
+(18 rows)
+
+EXPLAIN select count(distinct ss.ten) from
+  (select ten from tenk1 a
+   where unique1 IN (select hundred from tenk1 b)) ss;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..631.98 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..631.98 rows=10 width=4)
+         ->  GroupAggregate  (cost=0.00..631.98 rows=4 width=4)
+               Group By: public.tenk1.ten
+               ->  Sort  (cost=0.00..631.98 rows=4 width=4)
+                     Sort Key: public.tenk1.ten
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..631.98 rows=4 width=4)
+                           Hash Key: public.tenk1.ten
+                           ->  GroupAggregate  (cost=0.00..631.98 rows=4 width=4)
+                                 Group By: public.tenk1.ten
+                                 ->  Sort  (cost=0.00..631.98 rows=34 width=4)
+                                       Sort Key: public.tenk1.ten
+                                       ->  Nested Loop  (cost=0.00..631.98 rows=34 width=4)
+                                             Join Filter: true
+                                             ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                                   Group By: public.tenk1.hundred
+                                                   ->  Sort  (cost=0.00..431.94 rows=34 width=4)
+                                                         Sort Key: public.tenk1.hundred
+                                                         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
+                                                               Hash Key: public.tenk1.hundred
+                                                               ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                                                     Group By: public.tenk1.hundred
+                                                                     ->  Table Scan on tenk1  (cost=0.00..431.51 rows=3319 width=4)
+                                             ->  Index Scan using tenk1_unique1 on tenk1  (cost=0.00..200.04 rows=1 width=4)
+                                                   Index Cond: public.tenk1.unique1 = public.tenk1.hundred
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.1
+(27 rows)
+
+EXPLAIN select count(*) from
+  (select 1 from tenk1 a
+   where unique1 IN (select distinct hundred from tenk1 b)) ss;
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..631.98 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..631.98 rows=1 width=8)
+         ->  Aggregate  (cost=0.00..631.98 rows=1 width=8)
+               ->  Nested Loop  (cost=0.00..631.98 rows=34 width=1)
+                     Join Filter: true
+                     ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
+                           Group By: public.tenk1.hundred
+                           ->  Sort  (cost=0.00..431.94 rows=34 width=4)
+                                 Sort Key: public.tenk1.hundred
+                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
+                                       Hash Key: public.tenk1.hundred
+                                       ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                             Group By: public.tenk1.hundred
+                                             ->  Table Scan on tenk1  (cost=0.00..431.51 rows=3319 width=4)
+                     ->  Index Scan using tenk1_unique1 on tenk1  (cost=0.00..200.04 rows=1 width=1)
+                           Index Cond: public.tenk1.unique1 = public.tenk1.hundred
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.1
+(18 rows)
+
+EXPLAIN select count(distinct ss.ten) from
+  (select ten from tenk1 a
+   where unique1 IN (select distinct hundred from tenk1 b)) ss;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..631.98 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..631.98 rows=10 width=4)
+         ->  GroupAggregate  (cost=0.00..631.98 rows=4 width=4)
+               Group By: public.tenk1.ten
+               ->  Sort  (cost=0.00..631.98 rows=4 width=4)
+                     Sort Key: public.tenk1.ten
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..631.98 rows=4 width=4)
+                           Hash Key: public.tenk1.ten
+                           ->  GroupAggregate  (cost=0.00..631.98 rows=4 width=4)
+                                 Group By: public.tenk1.ten
+                                 ->  Sort  (cost=0.00..631.98 rows=34 width=4)
+                                       Sort Key: public.tenk1.ten
+                                       ->  Nested Loop  (cost=0.00..631.98 rows=34 width=4)
+                                             Join Filter: true
+                                             ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                                   Group By: public.tenk1.hundred
+                                                   ->  Sort  (cost=0.00..431.94 rows=34 width=4)
+                                                         Sort Key: public.tenk1.hundred
+                                                         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
+                                                               Hash Key: public.tenk1.hundred
+                                                               ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                                                     Group By: public.tenk1.hundred
+                                                                     ->  Table Scan on tenk1  (cost=0.00..431.51 rows=3319 width=4)
+                                             ->  Index Scan using tenk1_unique1 on tenk1  (cost=0.00..200.04 rows=1 width=4)
+                                                   Index Cond: public.tenk1.unique1 = public.tenk1.hundred
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.34.1
+(27 rows)
+

--- a/src/test/regress/sql/DML_over_joins.sql
+++ b/src/test/regress/sql/DML_over_joins.sql
@@ -80,8 +80,10 @@ delete from s;
 insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
 insert into s select generate_series(1, 100), generate_series(1, 100) * 4;
 
+explain update s set b = b + 1 where exists (select 1 from r where s.a = r.b);
 update s set b = b + 1 where exists (select 1 from r where s.a = r.b);
 
+explain delete from s where exists (select 1 from r where s.a = r.b);
 delete from s where exists (select 1 from r where s.a = r.b);
 -- ----------------------------------------------------------------------
 -- Test: heap_motion1.sql

--- a/src/test/regress/sql/qp_correlated_query.sql
+++ b/src/test/regress/sql/qp_correlated_query.sql
@@ -104,7 +104,9 @@ select A.i, B.i, C.j from A, B, C where A.j not in (select C.j from C where C.j 
 select A.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i in (select B.i from B where C.i = B.i and B.i !=10)) order by A.j limit 10;
 
 -- MPP-14222
+explain select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i not in (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
 select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i not in (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
+explain select A.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i not in (select B.i from B where C.i = B.i and B.i !=10)) order by A.j limit 10;
 select A.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i not in (select B.i from B where C.i = B.i and B.i !=10)) order by A.j limit 10;
 
 
@@ -128,8 +130,11 @@ select * from A where A.j = any (select C.j from C,B where C.j = A.j and B.i = a
 -- Planner should fail due to skip-level correlation not supported. ORCA should pass
 select * from A,B where A.j = any (select C.j from C where C.j = A.j and B.i = any (select C.i from C where C.i != 10 and C.i = A.i)) order by 1,2,3,4;
 
+explain select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i = any (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
 select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i = any (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
+explain select A.i, B.i, C.j from A, B, C where A.j = any ( select C.j from C where not exists(select C.i from C,A where C.i = A.i and C.i =10)) order by A.i, B.i, C.j limit 10;
 select A.i, B.i, C.j from A, B, C where A.j = any ( select C.j from C where not exists(select C.i from C,A where C.i = A.i and C.i =10)) order by A.i, B.i, C.j limit 10;
+explain select A.i, B.i, C.j from A, B, C where A.j = any (select C.j from C where C.j = A.j and not exists (select sum(B.i) from B where C.i = B.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
 select A.i, B.i, C.j from A, B, C where A.j = any (select C.j from C where C.j = A.j and not exists (select sum(B.i) from B where C.i = B.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
 
 
@@ -148,8 +153,11 @@ select * from A,B where exists (select * from C where C.j = A.j and B.i = all (s
 select * from A,B where exists (select * from C where C.j = A.j and B.i = all (select min(C.j) from C where C.j = 1)) order by 1,2,3,4;
 -- Planner should fail due to skip-level correlation not supported. ORCA should pass
 select * from A,B where exists (select * from C where C.j = A.j and B.i = all (select min(C.j) from C where C.j = B.j)) order by 1,2,3,4;
+explain select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C where C.j = A.j and C.i = all (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
 select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C where C.j = A.j and C.i = all (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
+explain select A.i, B.i, C.j from A, B, C where A.j < all ( select C.j from C where not exists(select C.i from C,A where C.i = A.i and C.i =10)) order by A.i, B.i, C.j limit 10;
 select A.i, B.i, C.j from A, B, C where A.j < all ( select C.j from C where not exists(select C.i from C,A where C.i = A.i and C.i =10)) order by A.i, B.i, C.j limit 10;
+explain select A.i, B.i, C.j from A, B, C where A.j = all (select C.j from C where C.j = A.j and not exists (select sum(B.i) from B where C.i = B.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
 select A.i, B.i, C.j from A, B, C where A.j = all (select C.j from C where C.j = A.j and not exists (select sum(B.i) from B where C.i = B.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
 
 
@@ -202,8 +210,11 @@ select * from A where exists (select * from C,B where C.j = A.j and exists (sele
 
 select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and not exists (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
 select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and not exists (select sum(B.i) from B where C.i = B.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
+explain select C.j from C where not exists (select max(B.i) from B  where C.i = B.i having max(B.i) is not null) order by C.j;
 select C.j from C where not exists (select max(B.i) from B  where C.i = B.i having max(B.i) is not null) order by C.j;
+explain select C.j from C where not exists (select max(B.i) from B  where C.i = B.i offset 1000) order by C.j;
 select C.j from C where not exists (select max(B.i) from B  where C.i = B.i offset 1000) order by C.j;
+explain select C.j from C where not exists (select rank() over (order by B.i) from B  where C.i = B.i) order by C.j;
 select C.j from C where not exists (select rank() over (order by B.i) from B  where C.i = B.i) order by C.j;
 
 


### PR DESCRIPTION
When working on the subselect merge, we noticed that ICG has good coverage for subselect related SQL queries that tests the correctness of the query results. However, ICG currently does not have many tests that check for plan changes. Since the merge brings in tricky planner changes, we want to make sure that there are no severe regressions because of plan diffs.

To capture that, we went through some of the important ICG test for subselect, and added some EXPLAIN tests to go along with regular queries. This has already helped us identify some issues.