### PR TITLE
Fix incorrect struct member in backport

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -1176,8 +1176,7 @@ static struct config_bool ConfigureNamesBool[] =
 			GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE
 		},
 		&data_checksums,
-		false,
-		NULL, NULL, NULL
+		false, NULL, NULL
 	},
 
 	/* End-of-list marker */


### PR DESCRIPTION
The backport of the data checksum catalog changes backported the relevant GUC from a version which has a different boolean GUC struct than GPDB. Fix by removing superfluous NULL.

@asimrp does this look reasonable?