### PR TITLE
hide pgAdmin III topics

### DIFF
--- a/gpdb-doc/dita/admin_guide/access_db/access_db.ditamap
+++ b/gpdb-doc/dita/admin_guide/access_db/access_db.ditamap
@@ -8,6 +8,7 @@
   <topicref href="topics/g-greenplum-database-client-applications.xml"/>
 
  <topicref href="topics/g-connecting-with-psql.xml"/>
+<!--
  <topicref href="topics/g-pgadmin-iii-for-greenplum-database.xml">
   <topicref href="topics/g-installing-pgadmin-iii-for-greenplum-database.xml"/>
   <topicref href="topics/g-documentation-for-pgadmin-iii-for-greenplum-database.xml"/>
@@ -15,6 +16,7 @@
    <topicref href="topics/g-viewing-a-graphical-query-plan.dita"/>
   </topicref>
  </topicref>
+-->
   <topicref href="topics/pgbouncer.xml"/>
  <topicref href="topics/g-database-application-interfaces.xml"/>
  <topicref href="topics/g-troubleshooting-connection-problems.xml"/>

--- a/gpdb-doc/dita/admin_guide/access_db/topics/g-supported-client-applications.xml
+++ b/gpdb-doc/dita/admin_guide/access_db/topics/g-supported-client-applications.xml
@@ -10,6 +10,7 @@
         /> are provided with your Greenplum installation. The
           <codeph>psql</codeph> client application provides an interactive command-line interface to
         Greenplum Database. </li>
+<!--
       <li id="io155276">
         <xref href="g-pgadmin-iii-for-greenplum-database.xml#topic6"/> is an enhanced version of the
         popular management tool pgAdmin III. Since version 1.10.0, the pgAdmin III client available
@@ -17,6 +18,7 @@
         features. Installation packages are available for download from the <xref
           href="https://www.pgadmin.org/download/" scope="external" format="html"> pgAdmin download
           site </xref>.</li>
+-->
       <li id="io141985">Using standard <xref href="g-database-application-interfaces.xml#topic12"/>,
         such as ODBC and JDBC, users can create their own client applications that interface to
         Greenplum Database.</li>

--- a/gpdb-doc/dita/admin_guide/kerberos-win-client.xml
+++ b/gpdb-doc/dita/admin_guide/kerberos-win-client.xml
@@ -221,9 +221,8 @@ kinit</codeblock></li>
         for single sign-on to a Greenplum Database system. </p>
       <p>You configure an AD user account to support logging in with Kerberos authentication. </p>
       <p>With AD single sign-on, a Windows user can use Active Directory credentials with a Windows
-        client application to log into a Greenplum Database system. For example, a Windows user can
-        use Active Directory credentials with PGadmin III to access a Greenplum Database system.
-        Also, for Windows applications that use ODBC, the ODBC driver can use Active Directory
+        client application to log into a Greenplum Database system. 
+        For Windows applications that use ODBC, the ODBC driver can use Active Directory
         credentials to connect to a Greenplum Database system.</p>
       <note>Greenplum Database clients that run on Windows, like <codeph>gpload</codeph>, connect
         with Greenplum Database directly and do not use Active Directory. For information about
@@ -403,15 +402,6 @@ psql -h prod1.example.local -U dev1</codeblock>
         <title>Single Sign-On Examples</title>
         <p>These single sign-on examples that use AD and Kerberos assume that the AD user
             <codeph>dev1</codeph> configured for single sign-on is logged into the Windows desktop. </p>
-        <p>This example connects to Greenplum Database from pgAdmin III with single sign-on. You
-          must specify the fully qualified hostname as the Host and the Windows user ID
-            (<codeph>dev1</codeph>) as the Username when completing the New Server Registration.</p>
-        <p>
-          <image href="graphics/kerb-pgadmin-config.png" placement="break" width="319px"
-            height="327px" id="image_rb2_jfx_tv"/>
-        </p>
-        <p>Also, when you reconnect to the database, pgAdmin III prompts for a password. When
-          prompted, leave the field blank and click OK. </p>
         <p>This example configures Aginity Workbench for Greenplum Database. When using single
           sign-on, you enable Use Integrated Security.</p>
         <p>


### PR DESCRIPTION
hide the pgAdmin III topics:
- commented out references from the appropriate .ditamap
- commented out reference from supported client applications overview
- removed reference and example from configuring kerberos for windows client doc