### PR TITLE
Fix error with statistics restore when statistics already exist

### DIFF
--- a/gpMgmt/bin/gppylib/operations/dump.py
+++ b/gpMgmt/bin/gppylib/operations/dump.py
@@ -1634,13 +1634,18 @@ WHERE relname = '%s' AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspn
             outfile.write("""--
 -- Schema: %s, Table: %s, Attribute: %s
 --
+
+DELETE FROM pg_statistic WHERE starelid = %d AND staattnum = %d;
+
 INSERT INTO pg_statistic VALUES (
     %d::oid,
     %d::smallint,
     %f::real,
     %d::integer,
     %f::real,
-""" % (nspname, relname, attname, starelid, staattnum, stanullfrac, stawidth, stadistinct))
+""" % (nspname, relname, attname,
+       starelid, staattnum,
+       starelid, staattnum, stanullfrac, stawidth, stadistinct))
 
             # If a typname starts with exactly one it describes an array type
             # We can't restore statistics of array columns, so we'll zero and NULL everything out

--- a/gpMgmt/bin/gppylib/operations/restore.py
+++ b/gpMgmt/bin/gppylib/operations/restore.py
@@ -615,6 +615,9 @@ class RestoreDatabase(Operation):
                     if replace_toggle and "::smallint" in line:
                         line = "    %s::smallint,\n" % new_attnum
                         replace_toggle = False
+                    if replace_toggle and "DELETE FROM" in line:
+                        line = re.sub("starelid = (\w+)", "starelid = %s" % new_oid, line)
+                        line = re.sub("staattnum = (\w+)", "staattnum = %s" % new_attnum, line)
                     if print_toggle:
                         outfile.write(line)
 


### PR DESCRIPTION
Previously, if pg_statistic already contained statistics for
a given table column, attempting to insert different statistics
for that column during the restore would give a primary key
error and statistics would not be correctly restored.

Now, existing statistics are deleted just before inserting the
restore statistics, so there is no collision.

Signed-off-by: Jamie McAtamney <jmcatamney@pivotal.io>