### PR TITLE
Implement dumping of MMXLOG records in xlogdump.

### DIFF
--- a/contrib/xlogdump/xlogdump.c
+++ b/contrib/xlogdump/xlogdump.c
@@ -543,6 +543,10 @@ dumpXLogRecord(XLogRecord *record, bool header_only)
 			print_rmgr_seq(curRecPtr, record, info);
 			break;
 
+		case RM_MMXLOG_ID:
+			print_rmgr_mmxlog(curRecPtr, record, info);
+			break;
+
 #ifdef USE_SEGWALREP
 		case RM_APPEND_ONLY_ID:
 			print_rmgr_ao(curRecPtr, record, info);

--- a/contrib/xlogdump/xlogdump_rmgr.h
+++ b/contrib/xlogdump/xlogdump_rmgr.h
@@ -76,6 +76,7 @@ void print_rmgr_hash(XLogRecPtr, XLogRecord *, uint8);
 void print_rmgr_gin(XLogRecPtr, XLogRecord *, uint8);
 void print_rmgr_gist(XLogRecPtr, XLogRecord *, uint8);
 void print_rmgr_seq(XLogRecPtr, XLogRecord *, uint8);
+void print_rmgr_mmxlog(XLogRecPtr, XLogRecord *, uint8);
 
 #ifdef USE_SEGWALREP
 void print_rmgr_ao(XLogRecPtr, XLogRecord *, uint8);


### PR DESCRIPTION
The creation of filespaces, database, tablespaces, and relfilenodes is logged by
a MMXLOG record in the Xlog. Functionality is added in xlogdump to display these
records.