### PR TITLE
Use bytea datatype on the AO blockdir minipage attribute

### DIFF
--- a/contrib/pg_upgrade/aotable.c
+++ b/contrib/pg_upgrade/aotable.c
@@ -147,7 +147,7 @@ restore_aosegment_table(migratorContext *ctx, PGconn *conn, RelInfo *rel)
 
 		appendPQExpBuffer(query,
 						  "INSERT INTO pg_aoseg.pg_aoblkdir_%u (segno, columngroup_no, first_row_no, minipage) "
-						  " VALUES (%d, %d, " INT64_FORMAT ", binary_upgrade.bitmaphack_in(%s))",
+						  " VALUES (%d, %d, " INT64_FORMAT ", %s)",
 						  rel->reloid,
 						  seg->segno,
 						  seg->columngroup_no,

--- a/contrib/pg_upgrade/function.c
+++ b/contrib/pg_upgrade/function.c
@@ -209,11 +209,6 @@ install_system_functions_internal(migratorContext *ctx, char *dbname)
 							  "AS '$libdir/pg_upgrade_support' "
 							  "LANGUAGE C STRICT;"));
 
-	PQclear(executeQueryOrDie(ctx, conn,
-							  "CREATE OR REPLACE FUNCTION binary_upgrade.bitmaphack_in(cstring) "
-							  "RETURNS bit varying "
-							  "LANGUAGE INTERNAL AS 'byteain'"));
-
 	PQfinish(conn);
 }
 

--- a/src/backend/catalog/aoblkdir.c
+++ b/src/backend/catalog/aoblkdir.c
@@ -57,7 +57,7 @@ AlterTableCreateAoBlkdirTable(Oid relOid, bool is_part_child)
 					   -1, 0);
 	TupleDescInitEntry(tupdesc, (AttrNumber) 4,
 					   "minipage",
-					   VARBITOID,
+					   BYTEAOID,
 					   -1, 0);
 
 	/*
@@ -66,10 +66,7 @@ AlterTableCreateAoBlkdirTable(Oid relOid, bool is_part_child)
 	tupdesc->attrs[0]->attstorage = 'p';
 	tupdesc->attrs[1]->attstorage = 'p';
 	tupdesc->attrs[2]->attstorage = 'p';
-    /* TODO (dmeister): In the next line, the index should have been 3. 
-     * Therefore the minipage might be toasted.
-     */
-	tupdesc->attrs[2]->attstorage = 'p'; 
+	tupdesc->attrs[3]->attstorage = 'p';
 
 	/*
 	 * Create index on segno, first_row_no.

--- a/src/backend/catalog/oid_dispatch.c
+++ b/src/backend/catalog/oid_dispatch.c
@@ -576,9 +576,14 @@ GetPreassignedOidForTuple(Relation catalogrel, HeapTuple tuple)
 			{
 				/*
 				 * OIDs of schemas must be preserved. (Only because namespace
-				 * OIDs are part of the key of types and relations.)
+				 * OIDs are part of the key of types and relations.) The only
+				 * exception is pg_temp which we exempt (by definition).
 				 */
-				missing_ok = false;
+				if (strncmp(searchkey.objname, "pg_temp", strlen("pg_temp")) == 0 ||
+					strncmp(searchkey.objname, "pg_toast_temp", strlen("pg_toast_temp")) == 0)
+					missing_ok = true;
+				else
+					missing_ok = false;
 			}
 			else if (RelationGetRelid(catalogrel) == TypeRelationId)
 			{


### PR DESCRIPTION
The minipage attribute was using varbit without actually storing a
varbit datum in it. Change over to bytea since it makes reading the
value back easier, especially for pg_upgrade. This complements the
change in commit dce769fe171ef9aaa which performed the same change
for the visimap attribute of the AO visimap relation.