### PR TITLE
Use non-blocking recv() in internal_cancel()

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -680,7 +680,7 @@ signalQEs(CdbDispatchCmdAsync* pParms)
 		sent = cdbconn_signalQE(segdbDesc, errbuf, waitMode == DISPATCH_WAIT_CANCEL);
 		if (sent)
 			dispatchResult->sentSignal = waitMode;
-		else if (Debug_cancel_print || gp_log_gang >= GPVARS_VERBOSITY_DEBUG)
+		else
 			elog(LOG, "Unable to cancel: %s",
 				 strlen(errbuf) == 0 ? "cannot allocate PGCancel" : errbuf);
 	}

--- a/src/backend/gp_libpq_fe/fe-connect.c
+++ b/src/backend/gp_libpq_fe/fe-connect.c
@@ -2848,7 +2848,7 @@ retry5:
 	 * authentication_timeout and pre_auth_delay. Most likely, it's long enough
 	 * to make sure the process forked by the postmaster on segment is finished.
 	 */
-	pollRet = poll(pollFds, 1, 660 * 1000);
+	pollRet = poll(pollFds, 1, (MAX_AUTHENTICATION_TIMEOUT + MAX_PRE_AUTH_DELAY) * 1000);
 	if (pollRet == 0)
 	{
 		/* timeout */

--- a/src/backend/gp_libpq_fe/fe-connect.c
+++ b/src/backend/gp_libpq_fe/fe-connect.c
@@ -22,6 +22,7 @@
 #include <ctype.h>
 #include <time.h>
 #include <unistd.h>
+#include <poll.h>
 
 #include "gp-libpq-fe.h"
 #include "gp-libpq-int.h"
@@ -2777,12 +2778,15 @@ internal_cancel(SockAddr *raddr, int be_pid, int be_key,
 	int			tmpsock = -1;
 	char		sebuf[256];
 	int			maxlen;
+	struct pollfd	pollFds[1];
+	int				pollRet;
 	struct
 	{
 		uint32		packetlen;
 		CancelRequestPacket cp;
 	}			crp;
 
+retry2:
 	/*
 	 * We need to open a temporary connection to the postmaster. Do this with
 	 * only kernel calls.
@@ -2835,11 +2839,41 @@ retry4:
 	 * read to obtain any data, we are just waiting for EOF to be signaled.
 	 */
 retry5:
+	pollFds[0].fd = tmpsock;
+	pollFds[0].events = POLLIN;
+	pollFds[0].revents = 0;
+
+	/*
+	 * Wait for at most 660 seconds, which is the sum of max values of
+	 * authentication_timeout and pre_auth_delay. Most likely, it's long enough
+	 * to make sure the process forked by the postmaster on segment is finished.
+	 */
+	pollRet = poll(pollFds, 1, 660 * 1000);
+	if (pollRet == 0)
+	{
+		/* timeout */
+		close(tmpsock);
+		tmpsock = -1;
+		goto retry2;
+	}
+	else if (pollRet < 0)
+	{
+		int olderrno = errno;
+		if (olderrno == EAGAIN || olderrno == EINTR)
+			goto retry5;
+
+		/* error */
+		close(tmpsock);
+		tmpsock = -1;
+		goto retry2;
+	}
+
+retry6:
 	if (recv(tmpsock, (char *) &crp, 1, 0) < 0)
 	{
 		if (SOCK_ERRNO == EINTR)
 			/* Interrupted system call - we'll just try again */
-			goto retry5;
+			goto retry6;
 		/* we ignore other error conditions */
 	}
 

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -1551,7 +1551,7 @@ static struct config_int ConfigureNamesInt[] =
 			GUC_UNIT_S
 		},
 		&AuthenticationTimeout,
-		60, 1, 600, NULL, NULL
+		60, 1, MAX_AUTHENTICATION_TIMEOUT, NULL, NULL
 	},
 
 	{
@@ -1562,7 +1562,7 @@ static struct config_int ConfigureNamesInt[] =
 			GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL | GUC_UNIT_S
 		},
 		&PreAuthDelay,
-		0, 0, 60, NULL, NULL
+		0, 0, MAX_PRE_AUTH_DELAY, NULL, NULL
 	},
 
 	{

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -19,6 +19,9 @@
 #include "utils/array.h"
 
 #define MAX_MAX_BACKENDS (INT_MAX / BLCKSZ)
+#define MAX_AUTHENTICATION_TIMEOUT (600)
+#define MAX_PRE_AUTH_DELAY (60)
+
 
 struct StringInfoData;                  /* #include "lib/stringinfo.h" */
 


### PR DESCRIPTION
The issue of hanging on recv() in internal_cancel() are reported
serveral times, the socket status is shown 'ESTABLISHED' on master,
while the peer process on the segment has already exit. We are not
sure how exactly dose this happen, but we are able to simulate this
hang issue by dropping packet or reboot the system on the segment.

This patch use poll() to do non-blocking recv() in internal_cancel();
the timeout of poll() is set to the max value of authentication_timeout
to make sure the process on segment has already exit before attempting
another retry; and we expect retry on connect() can detect network issue.

Signed-off-by: Ning Yu <nyu@pivotal.io>
Signed-off-by: Gang Xiong <gxiong@pivotal.io>