### PR TITLE
Speed up simple queries on AOCS tables, when only a few columns are needed

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -1140,7 +1140,6 @@ aocs_fetch_init(Relation relation,
 	aocsFetchDesc->basepath = basePath;
 
 	Assert(proj);
-	aocsFetchDesc->proj = proj;
 
 	aocsFetchDesc->segmentFileInfo =
 		GetAllAOCSFileSegInfo(relation, appendOnlyMetaDataSnapshot, &aocsFetchDesc->totalSegfiles);

--- a/src/backend/executor/execBitmapAOScan.c
+++ b/src/backend/executor/execBitmapAOScan.c
@@ -124,7 +124,6 @@ BitmapAOScanEnd(ScanState *scanState)
 		}
 		else if (scanState->tableType == TableTypeAOCS)
 		{
-			pfree(((AOCSFetchDesc)node->scanDesc)->proj);
 			aocs_fetch_finish(node->scanDesc);
 		}
 		else

--- a/src/backend/executor/nodeBitmapAppendOnlyscan.c
+++ b/src/backend/executor/nodeBitmapAppendOnlyscan.c
@@ -158,7 +158,6 @@ freeFetchDesc(BitmapAppendOnlyScanState *scanstate)
 	if (scanstate->baos_currentAOCSFetchDesc != NULL)
 	{
 		Assert(!((BitmapAppendOnlyScan *)(scanstate->ss.ps.plan))->isAORow);
-		pfree(scanstate->baos_currentAOCSFetchDesc->proj);
 		aocs_fetch_finish(scanstate->baos_currentAOCSFetchDesc);
 		pfree(scanstate->baos_currentAOCSFetchDesc);
 		scanstate->baos_currentAOCSFetchDesc = NULL;
@@ -167,7 +166,6 @@ freeFetchDesc(BitmapAppendOnlyScanState *scanstate)
 	if (scanstate->baos_currentAOCSLossyFetchDesc != NULL)
 	{
 		Assert(!((BitmapAppendOnlyScan *)(scanstate->ss.ps.plan))->isAORow);
-		pfree(scanstate->baos_currentAOCSLossyFetchDesc->proj);
 		aocs_fetch_finish(scanstate->baos_currentAOCSLossyFetchDesc);
 		pfree(scanstate->baos_currentAOCSLossyFetchDesc);
 		scanstate->baos_currentAOCSLossyFetchDesc = NULL;

--- a/src/include/access/appendonlytid.h
+++ b/src/include/access/appendonlytid.h
@@ -55,11 +55,25 @@ typedef struct AOTupleId
          /* top most 25 bits */           /* 15 bits from bytes_4_5 */
 
 /* ~_Init zeroes the 2 regular fields and sets the always on field to 1. */
-#define AOTupleIdInit_Init(h)                {(h)->bytes_0_1=0;(h)->bytes_2_3=0;(h)->bytes_4_5=0x8000;}
-#define AOTupleIdInit_segmentFileNum(h,e)    {(h)->bytes_0_1|=(((uint16)(0x007F&((uint16)(e))))<<9);}
-#define AOTupleIdInit_rowNum(h,e)            {(h)->bytes_0_1|=((uint16)((INT64CONST(0x000000FFFFFFFFFF)&(e))>>31));\
-											  (h)->bytes_2_3|=((uint16)((INT64CONST(0x000000007FFFFFFF)&(e))>>15));\
-											  (h)->bytes_4_5|=((0x7FFF&((uint16)(e))));}
+static inline void
+AOTupleIdInit_Init(AOTupleId *h)
+{
+	h->bytes_0_1 = 0;
+	h->bytes_2_3 = 0;
+	h->bytes_4_5 = 0x8000;
+}
+static inline void
+AOTupleIdInit_segmentFileNum(AOTupleId *h, uint16 e)
+{
+	h->bytes_0_1 |= ((uint16) (0x007F & e)) << 9;
+}
+static inline void
+AOTupleIdInit_rowNum(AOTupleId *h, uint64 e)
+{
+	h->bytes_0_1 |= (uint16) ((INT64CONST(0x000000FFFFFFFFFF) & e) >> 31);
+	h->bytes_2_3 |= (uint16) ((INT64CONST(0x000000007FFFFFFF) & e) >> 15);
+	h->bytes_4_5 |= 0x7FFF & e;
+}
 
 #define AOTupleId_MaxRowNum            INT64CONST(1099511627775) 		// 40 bits, or 1099511627775 (1099 trillion).
 #define AOTupleId_MaxRowNum_CommaStr  "1,099,511,627,775"

--- a/src/include/cdb/cdbaocsam.h
+++ b/src/include/cdb/cdbaocsam.h
@@ -101,7 +101,10 @@ typedef struct AOCSScanDescData
 
 	struct AOCSFileSegInfo **seginfo;
 	struct DatumStreamRead **ds;
-	bool *proj;
+
+	/* Column numbers (starting from 0) of columns we need to fetch */
+	int		   *proj_atts;
+	int			num_proj_atts;
 
 	/* synthetic system attributes */
 	ItemPointerData cdb_fake_ctid;

--- a/src/include/cdb/cdbaocsam.h
+++ b/src/include/cdb/cdbaocsam.h
@@ -143,7 +143,6 @@ typedef struct AOCSFetchDescData
 
 	int				totalSegfiles;
 	struct AOCSFileSegInfo **segmentFileInfo;
-	bool			*proj;
 
 	char			*segmentFileName;
 	int				segmentFileNameMaxLen;


### PR DESCRIPTION
If you have a query like "SELECT COUNT(col1) FROM wide_table", where the
table has dozens of columns, the overhead in aocs_getnext() just to figure
out which columns need to be fetched becomes noticeable. Optimize it.
