### PR TITLE
Remove unused variable in checkpoint record.

### DIFF
--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -1808,7 +1808,6 @@ void
 redoDtxCheckPoint(TMGXACT_CHECKPOINT *gxact_checkpoint)
 {
 	int committedCount;
-	int segmentCount;
 
 	int i;
 
@@ -1817,9 +1816,7 @@ redoDtxCheckPoint(TMGXACT_CHECKPOINT *gxact_checkpoint)
 	 */
 
 	committedCount = gxact_checkpoint->committedCount;
-	segmentCount = gxact_checkpoint->segmentCount;
-	elog(DTM_DEBUG5, "redoDtxCheckPoint has committedCount = %d, "
-		 "segmentCount = %d", committedCount, segmentCount);
+	elog(DTM_DEBUG5, "redoDtxCheckPoint has committedCount = %d", committedCount);
 	if (Debug_persistent_recovery_print)
 	{
 		elog(PersistentRecovery_DebugPrintLevel(),
@@ -2847,7 +2844,6 @@ getDtxCheckPointInfoAndLock(char **result, int *result_size)
 	}
 
 	gxact_checkpoint->committedCount = actual;
-	gxact_checkpoint->segmentCount = 0;		/* UNDONE: Not used yet. */
 
 	*result = (char*)gxact_checkpoint;
 	*result_size = TMGXACT_CHECKPOINT_BYTES(actual);

--- a/src/include/access/xlogmm.h
+++ b/src/include/access/xlogmm.h
@@ -79,17 +79,12 @@ typedef struct dbdir_map
 	Oid databaseoid;
 } dbdir_map;
 
-
 /*
  * Container of filespaces/tablespaces used to accumulate mappings
  */
 typedef struct fspc_agg_state
 {
-	union
-	{
-		int count;
-		int64 dummy;
-	};
+	int count;
 	fspc_map maps[0]; /* variable length */
 } fspc_agg_state;
 
@@ -98,11 +93,7 @@ typedef struct fspc_agg_state
 
 typedef struct tspc_agg_state
 {
-	union
-	{
-		int count;
-		int64 dummy;
-	};
+	int count;
 	tspc_map maps[0]; /* variable length */
 } tspc_agg_state;
 
@@ -111,11 +102,7 @@ typedef struct tspc_agg_state
 
 typedef struct dbdir_agg_state
 {
-	union
-	{
-		int count;
-		int64 dummy;
-	};
+	int count;
 	dbdir_map maps[0]; /* variable length */
 } dbdir_agg_state;
 

--- a/src/include/cdb/cdbpublic.h
+++ b/src/include/cdb/cdbpublic.h
@@ -36,8 +36,6 @@ struct TMGXACT_LOG
 typedef struct TMGXACT_CHECKPOINT
 {
 	int						committedCount;
-	int						segmentCount;
-
     /* Array [0..committedCount-1] of TMGXACT_LOG structs begins here */
 	TMGXACT_LOG				committedGxactArray[1];
 }	TMGXACT_CHECKPOINT;


### PR DESCRIPTION
segmentCount variable is unused in TMGXACT_CHECKPOINT structure hence loose it
out. Also, removing the union in fspc_agg_state, tspc_agg_state and
dbdir_agg_state structures as don't see reason for having the same.