### PR TITLE
gpssh: Adapt pexpect override to handle delays up to 10 secs

### DIFF
--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpssh.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpssh.py
@@ -9,7 +9,6 @@ from gp_unittest import GpTestCase
 
 
 class GpSshTestCase(GpTestCase):
-
     def setUp(self):
         # because gpssh does not have a .py extension, we have to use imp to import it
         # if we had a gpssh.py, this is equivalent to:
@@ -18,24 +17,20 @@ class GpSshTestCase(GpTestCase):
         gpssh_file = os.path.abspath(os.path.dirname(__file__) + "/../../../gpssh")
         self.subject = imp.load_source('gpssh', gpssh_file)
 
+        sys.argv = []
+
     @patch('sys.exit')
-    def test_when_run_without_args_prints_help_text(self, mock):
-        mock.side_effect = Exception("on purpose")
+    def test_when_run_without_args_prints_help_text(self, sys_exit_mock):
+        sys_exit_mock.side_effect = Exception("on purpose")
         # GOOD_MOCK_EXAMPLE of stdout
         with patch('sys.stdout', new=io.BytesIO()) as mock_stdout:
             with self.assertRaisesRegexp(Exception, "on purpose"):
                 self.subject.main()
-        # assert on what main() was expected to do
-        # in this case, check what was written to sys.stdout?
         self.assertIn('gpssh -- ssh access to multiple hosts at once', mock_stdout.getvalue())
 
-    def test_when_remote_host_cpu_load_causes_bad_prompts_will_retry_and_succeed(self):
-        pass
-        # sys.argv = ['', '-h', 'localhost', 'uptime']
-        # self.subject.main()
-        # assert on what main() was expected to do
-        # in this case, check what was written to sys.stdout?
+    @patch('sys.exit')
+    def test_happy_ssh_to_localhost_succeeds(self, sys_mock):
+        sys.argv = ['', '-h', 'localhost', 'uptime']
 
-    def test_when_remote_host_cpu_load_causes_bad_prompts_will_retry_and_fail(self):
-        pass
-        
+        self.subject.main()
+        sys_mock.assert_called_with(0)

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpssh.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpssh.py
@@ -1,0 +1,41 @@
+import imp
+import os
+import io
+
+import sys
+from mock import patch
+
+from gp_unittest import GpTestCase
+
+
+class GpSshTestCase(GpTestCase):
+
+    def setUp(self):
+        # because gpssh does not have a .py extension, we have to use imp to import it
+        # if we had a gpssh.py, this is equivalent to:
+        #   import gpssh
+        #   self.subject = gpssh
+        gpssh_file = os.path.abspath(os.path.dirname(__file__) + "/../../../gpssh")
+        self.subject = imp.load_source('gpssh', gpssh_file)
+
+    @patch('sys.exit')
+    def test_when_run_without_args_prints_help_text(self, mock):
+        mock.side_effect = Exception("on purpose")
+        # GOOD_MOCK_EXAMPLE of stdout
+        with patch('sys.stdout', new=io.BytesIO()) as mock_stdout:
+            with self.assertRaisesRegexp(Exception, "on purpose"):
+                self.subject.main()
+        # assert on what main() was expected to do
+        # in this case, check what was written to sys.stdout?
+        self.assertIn('gpssh -- ssh access to multiple hosts at once', mock_stdout.getvalue())
+
+    def test_when_remote_host_cpu_load_causes_bad_prompts_will_retry_and_succeed(self):
+        pass
+        # sys.argv = ['', '-h', 'localhost', 'uptime']
+        # self.subject.main()
+        # assert on what main() was expected to do
+        # in this case, check what was written to sys.stdout?
+
+    def test_when_remote_host_cpu_load_causes_bad_prompts_will_retry_and_fail(self):
+        pass
+        

--- a/gpMgmt/bin/gppylib/util/ssh_utils.py
+++ b/gpMgmt/bin/gppylib/util/ssh_utils.py
@@ -15,23 +15,31 @@ from gppylib.commands.unix import Hostname, Echo
 sys.path.insert(1, sys.path[0] + '/lib')
 from pexpect import pxssh
 
+
 class HostNameError(Exception):
-    def __init__(self, msg, lineno = 0):
-        if lineno: self.msg = ('%s at line %d' % (msg, lineno))
-        else: self.msg = msg
+    def __init__(self, msg, lineno=0):
+        if lineno:
+            self.msg = ('%s at line %d' % (msg, lineno))
+        else:
+            self.msg = msg
+
     def __str__(self):
         return self.msg
+
 
 class SSHError(Exception):
     def __init__(self, msg):
         self.msg = msg
+
     def __str__(self):
         return self.msg
+
 
 # Utility Functions
 def ssh_prefix(host):
     ssh = 'ssh -o "BatchMode yes" -o "StrictHostKeyChecking no" ' + host
     return ssh
+
 
 def get_hosts(hostsfile):
     hostlist = HostList()
@@ -40,11 +48,10 @@ def get_hosts(hostsfile):
 
 
 class HostList():
-    
-    def __init__(self): 
+    def __init__(self):
         self.list = []
 
-    def get(self): 
+    def get(self):
         return self.list
 
     def add(self, host, lineno=0):
@@ -78,9 +85,9 @@ class HostList():
         with open(path) as fp:
             for i, line in enumerate(fp):
                 line = line.strip()
-                if not line or line[0] == '#': 
+                if not line or line[0] == '#':
                     continue
-                self.add(line, i+1)
+                self.add(line, i + 1)
         return self.list
 
     def checkSSH(self):
@@ -91,10 +98,9 @@ class HostList():
         for h in self.list:
             cmd = Echo('ssh test', '', ctxt=REMOTE, remoteHost=h)
             pool.addCommand(cmd)
-            
-        pool.join()
-        pool.haltWork()  
 
+        pool.join()
+        pool.haltWork()
 
         for cmd in pool.getCompletedItems():
             if not cmd.get_results().wasSuccessful():
@@ -110,10 +116,10 @@ class HostList():
         for h in self.list:
             cmd = Hostname('hostname', ctxt=REMOTE, remoteHost=h)
             pool.addCommand(cmd)
-            
+
         pool.join()
         pool.haltWork()
-        
+
         for finished_cmd in pool.getCompletedItems():
             hostname = finished_cmd.get_hostname()
             if (not hostname):
@@ -124,18 +130,23 @@ class HostList():
                 unique[hostname] = finished_cmd.remoteHost
 
         self.list = unique.values()
-        
+
         return self.list
+
 
 # Session is a command session, derived from a base class cmd.Cmd
 class Session(cmd.Cmd):
     '''Implements a list of open ssh sessions ready to execute commands'''
-    verbose=False
-    hostList=[]
-    userName=None
-    echoCommand=False
-    class SessionError(StandardError): pass
-    class SessionCmdExit(StandardError): pass
+    verbose = False
+    hostList = []
+    userName = None
+    echoCommand = False
+
+    class SessionError(StandardError):
+        pass
+
+    class SessionCmdExit(StandardError):
+        pass
 
     def __init__(self, hostList=None, userName=None):
         cmd.Cmd.__init__(self)
@@ -145,7 +156,7 @@ class Session(cmd.Cmd):
         if hostList:
             for host in hostList:
                 self.hostList.append(host)
-        if userName: self.userName=userName
+        if userName: self.userName = userName
 
     def peerStringFormat(self):
         if self.peerStringFormatRaw: return self.peerStringFormatRaw
@@ -162,15 +173,15 @@ class Session(cmd.Cmd):
             raise self.SessionError('No host list available to Login method')
         if not (self.userName or userName):
             raise self.SessionError('No user name available to Login method')
-        
-        #Cleanup    
+
+        # Cleanup
         self.clean()
-    
-        if hostList: #We have a new hostlist to use, initialize it
-            self.hostList=[]
+
+        if hostList:  # We have a new hostlist to use, initialize it
+            self.hostList = []
             for host in hostList:
                 self.hostList.append(host)
-        if userName: self.userName=userName  #We have a new userName to use
+        if userName: self.userName = userName  # We have a new userName to use
 
         # MPP-6583.  Save off term type and set to nothing before creating ssh process
         origTERM = os.getenv('TERM', None)
@@ -221,12 +232,12 @@ class Session(cmd.Cmd):
 
     def close(self):
         return self.clean()
-    
+
     def reset(self):
         '''reads from all the ssh connections to make sure we dont have any pending cruft'''
         for s in self.pxssh_list:
             s.readlines()
-                
+
     def clean(self):
         net_return_code = self.closePxsshList(self.pxssh_list)
         self.pxssh_list = []
@@ -235,7 +246,7 @@ class Session(cmd.Cmd):
     def emptyline(self):
         pass
 
-    def escapeLine(self,line):
+    def escapeLine(self, line):
         '''Escape occurrences of \ and $ as needed and package the line as an "eval" shell command'''
         line = line.strip()
         if line == 'EOF' or line == 'exit' or line == 'quit':
@@ -247,75 +258,77 @@ class Session(cmd.Cmd):
         line = line.split('$')
         line = '\\$'.join(line)
         line = 'eval "' + line + '" < /dev/null'
-        
+
         return line
 
-    def executeCommand(self,command):
-        commandoutput=[]
-        
+    def executeCommand(self, command):
+        commandoutput = []
+
         if self.echoCommand:
             escapedCommand = command.replace('"', '\\"')
             command = 'echo "%s"; %s' % (escapedCommand, command)
-            
-        #Execute the command in all of the ssh sessions
+
+        # Execute the command in all of the ssh sessions
         for s in self.pxssh_list:
             s.sendline(command)
-            
-        #Wait for each command and retrieve the output
+
+        # Wait for each command and retrieve the output
         for s in self.pxssh_list:
-            #Wait for each command to finish
-            #!! TODO verify that this is a tight wait loop and find another way to do this
+            # Wait for each command to finish
+            # !! TODO verify that this is a tight wait loop and find another way to do this
             while not s.prompt(120) and s.isalive() and not s.eof(): pass
-            
+
         for s in self.pxssh_list:
-            #Split the output into an array of lines so that we can add text to the beginning of
+            # Split the output into an array of lines so that we can add text to the beginning of
             #    each line
             output = s.before.split('\n')
             output = output[1:-1]
-                
+
             commandoutput.append(output)
-            
+
         return commandoutput.__iter__()
 
-# Interactive command line handler
-#    Override of base class, handles commands that aren't recognized as part of a predefined set
-#    The "command" argument is a command line to be executed on all available command sessions
-#    The output of the command execution is printed to the standard output, prepended with
-#        the hostname of each machine from which the output came
+    # Interactive command line handler
+    #    Override of base class, handles commands that aren't recognized as part of a predefined set
+    #    The "command" argument is a command line to be executed on all available command sessions
+    #    The output of the command execution is printed to the standard output, prepended with
+    #        the hostname of each machine from which the output came
     def default(self, command):
-    
+
         line = self.escapeLine(command)
-    
+
         if self.verbose: print command
-        
-    #Execute the command on our ssh sessions
-        commandoutput=self.executeCommand(command)
+
+        # Execute the command on our ssh sessions
+        commandoutput = self.executeCommand(command)
         self.writeCommandOutput(commandoutput)
 
-    def writeCommandOutput(self,commandoutput):
+    def writeCommandOutput(self, commandoutput):
         '''Takes a list of output lists as an iterator and writes them to standard output,
         formatted with the hostname from which each output array was obtained'''
         for s in self.pxssh_list:
             output = commandoutput.next()
-            #Write the output
+            # Write the output
             if len(output) == 0:
                 print (self.peerStringFormat() % s.x_peer)
             else:
                 for line in output:
                     print (self.peerStringFormat() % s.x_peer), line
-    
-    def closePxsshList(self,list):
+
+    def closePxsshList(self, list):
         lock = threading.Lock()
         return_codes = [0]
-        def closePxsshOne(p, return_codes): 
+
+        def closePxsshOne(p, return_codes):
             p.logout()
             with lock:
                 return_codes.append(p.exitstatus)
+
         th = []
         for p in list:
             t = threading.Thread(target=closePxsshOne, args=(p, return_codes))
             t.start()
             th.append(t)
         for t in th:
-            t.join() 
+            t.join()
         return max(return_codes)

--- a/gpMgmt/bin/gpssh
+++ b/gpMgmt/bin/gpssh
@@ -27,7 +27,6 @@ if sys.version_info < (2, 5, 0):
 '''Error: %s is supported on Python versions 2.5 or greater
 Please upgrade python installed on this machine.''' % progname)
 
-
 import getopt
 import atexit
 import signal
@@ -36,6 +35,7 @@ import time
 import ConfigParser
 from gppylib.util import ssh_utils
 from gppylib.gpparseopts import OptParser
+
 
 #
 # all the command line options
@@ -55,7 +55,9 @@ class __globals__:
     DELAY_BEFORE_SEND = None
     PROMPT_VALIDATION_TIMEOUT = None
 
+
 GV = __globals__()
+
 
 ################
 def usage(exitarg):
@@ -72,6 +74,7 @@ def print_version():
     print '%s version $Revision$' % GV.script_name
     sys.exit(0)
 
+
 #############
 def parseCommandLine():
     try:
@@ -79,20 +82,29 @@ def parseCommandLine():
     except Exception, e:
         usage('Error: ' + str(e))
     for (switch, val) in options:
-        if (switch == '-?'):              usage(0)
-        elif (switch[1] in 'evDs'):    GV.opt[switch] = True
-        elif (switch[1] in 'f'):      GV.opt[switch] = val
-        elif (switch == '-h'):        GV.opt[switch].append(val)
-        elif (switch == '--version'): print_version()
-        elif (switch[1] in 'u'):      GV.USER = val
-        elif (switch == '-d'):        GV.DELAY_BEFORE_SEND = float(val)
-        elif (switch == '-t'):	      GV.PROMPT_VALIDATION_TIMEOUT = float(val)
+        if (switch == '-?'):
+            usage(0)
+        elif (switch[1] in 'evDs'):
+            GV.opt[switch] = True
+        elif (switch[1] in 'f'):
+            GV.opt[switch] = val
+        elif (switch == '-h'):
+            GV.opt[switch].append(val)
+        elif (switch == '--version'):
+            print_version()
+        elif (switch[1] in 'u'):
+            GV.USER = val
+        elif (switch == '-d'):
+            GV.DELAY_BEFORE_SEND = float(val)
+        elif (switch == '-t'):
+            GV.PROMPT_VALIDATION_TIMEOUT = float(val)
     hf = (len(GV.opt['-h']) and 1 or 0) + (GV.opt['-f'] and 1 or 0)
     if hf != 1:
         usage('Error: please specify at least one of -h or -f args, but not both')
 
     if (len(args) >= 1):
         GV.argcmd = " ".join(args)
+
 
 def parseConfigFile():
     if GV.DELAY_BEFORE_SEND is not None and GV.PROMPT_VALIDATION_TIMEOUT is not None:
@@ -128,53 +140,59 @@ def parseConfigFile():
         print 'Using delaybeforesend %s and prompt_validation_timeout %s' % (GV.DELAY_BEFORE_SEND,
                                                                              GV.PROMPT_VALIDATION_TIMEOUT)
 
+
 def sessionCleanup():
     while True:
         try:
             return_code = 0
-            if GV.session: 
-                if GV.session.verbose: print '\n[Cleanup...]'; 
+            if GV.session:
+                if GV.session.verbose: print '\n[Cleanup...]';
                 return_code = GV.session.close()
             GV.session = None
             return return_code
         except KeyboardInterrupt:
             pass
 
+
 sigint_time = 0
+
+
 def sigint_handle(signum, frame):
     global sigint_time
     now = time.time()
-    if now - sigint_time >= 3: 
+    if now - sigint_time >= 3:
         sigint_time = now
         raise KeyboardInterrupt
     signal.signal(signal.SIGINT, signal.SIG_IGN)
     print '\n[Exiting...]'
     sys.exit(1)
 
+
 def sighup_handle(signum, frame):
     sys.exit(1)
+
 
 def interactive():
     try:
         import readline
-        #Read in the saved command history, if any
+        # Read in the saved command history, if any
         histfile = os.path.join(os.environ["HOME"], ".gshist")
         # Set the maximum number of commands to 100
         readline.set_history_length(500)
         try:
-            readline.read_history_file(histfile)            
+            readline.read_history_file(histfile)
         except IOError:
             pass
-        
-        #MPP-4054 - let's check the permissons before we register
+
+        # MPP-4054 - let's check the permissons before we register
         try:
-            f=open(histfile,'a')
+            f = open(histfile, 'a')
             atexit.register(readline.write_history_file, histfile)
-            f.close()                        
+            f.close()
         except IOError:
             print "\n[WARN] Unable to write to gpssh history file: '%s'. Please check permissions." % histfile
-        
-            
+
+
     except Exception, e:
         print "Note: command history unsupported on this machine ..."
 
@@ -185,9 +203,9 @@ def interactive():
         try:
             if not GV.session:
                 GV.session = ssh_utils.Session()
-                GV.session.verbose=GV.opt['-v']
+                GV.session.verbose = GV.opt['-v']
                 GV.session.login(GV.opt['-h'], GV.USER, GV.DELAY_BEFORE_SEND, GV.PROMPT_VALIDATION_TIMEOUT)
-                GV.session.echoCommand=GV.opt['-e']
+                GV.session.echoCommand = GV.opt['-e']
             if GV.opt['-s']:
                 GV.session.executeCommand("source {0}/greenplum_path.sh".format(os.environ["GPHOME"]))
             GV.session.cmdloop()
@@ -205,21 +223,22 @@ def interactive():
             GV.session.reset()
             pass
 
+
 try:
-    #Parse options from the command line
+    # Parse options from the command line
     parseCommandLine()
 
-    #Parse gpssh.conf file
+    # Parse gpssh.conf file
     parseConfigFile()
 
-    #Acquire the list of hosts from command line arguments
+    # Acquire the list of hosts from command line arguments
     hostlist = ssh_utils.HostList()
     for h in GV.opt['-h']:
         hostlist.add(h)
     if GV.opt['-f']:
         hostlist.parseFile(GV.opt['-f'])
 
-    #Filter out non-unique hostnames unless the -D option is provided
+    # Filter out non-unique hostnames unless the -D option is provided
     if not GV.opt['-D']:
         GV.opt['-h'] = hostlist.filterMultiHomedHosts()
     else:
@@ -228,26 +247,26 @@ try:
     if len(GV.opt['-h']) == 0:
         usage('Error: missing hosts in -h and/or -f arguments')
 
-    #If a single command was passed to us, implement a single command session
+    # If a single command was passed to us, implement a single command session
     if GV.argcmd:
-            try:
-                GV.session = ssh_utils.Session()
-                GV.session.verbose=GV.opt['-v']
-                GV.session.login(GV.opt['-h'], GV.USER, GV.DELAY_BEFORE_SEND, GV.PROMPT_VALIDATION_TIMEOUT)
-                GV.session.echoCommand=GV.opt['-e']
-                if GV.opt['-s']:
-                    GV.session.executeCommand("source {0}/greenplum_path.sh".format(os.environ["GPHOME"]))
-                output=GV.session.executeCommand(GV.argcmd)
-                GV.session.writeCommandOutput(output)
-                if GV.session.verbose: print '[INFO] completed successfully'
-                sys.stdout.flush()
-            except ssh_utils.Session.SessionError, e:
-                print 'Error: %s' % e
-                pass
+        try:
+            GV.session = ssh_utils.Session()
+            GV.session.verbose = GV.opt['-v']
+            GV.session.login(GV.opt['-h'], GV.USER, GV.DELAY_BEFORE_SEND, GV.PROMPT_VALIDATION_TIMEOUT)
+            GV.session.echoCommand = GV.opt['-e']
+            if GV.opt['-s']:
+                GV.session.executeCommand("source {0}/greenplum_path.sh".format(os.environ["GPHOME"]))
+            output = GV.session.executeCommand(GV.argcmd)
+            GV.session.writeCommandOutput(output)
+            if GV.session.verbose: print '[INFO] completed successfully'
+            sys.stdout.flush()
+        except ssh_utils.Session.SessionError, e:
+            print 'Error: %s' % e
+            pass
 
-    else: #Otherwise, implement an interactive session
+    else:  # Otherwise, implement an interactive session
         interactive()
-    
+
     return_code = sessionCleanup()
     sys.exit(return_code)
 

--- a/gpMgmt/bin/gpssh
+++ b/gpMgmt/bin/gpssh
@@ -19,13 +19,8 @@ Usage: gpssh [--version] [-?v] [-h host] [-f hostfile] [cmd]
 import os
 import sys
 
-progname = os.path.split(sys.argv[0])[-1]
+# todo is this necessary?
 sys.path.insert(1, sys.path[0] + '/lib')
-
-if sys.version_info < (2, 5, 0):
-    sys.exit(
-'''Error: %s is supported on Python versions 2.5 or greater
-Please upgrade python installed on this machine.''' % progname)
 
 import getopt
 import atexit
@@ -69,13 +64,11 @@ def usage(exitarg):
     sys.exit(exitarg)
 
 
-#############
 def print_version():
     print '%s version $Revision$' % GV.script_name
     sys.exit(0)
 
 
-#############
 def parseCommandLine():
     try:
         (options, args) = getopt.getopt(sys.argv[1:], '?evsh:f:D:u:d:t:', ['version'])
@@ -224,52 +217,63 @@ def interactive():
             pass
 
 
-try:
-    # Parse options from the command line
-    parseCommandLine()
+def main():
+    if sys.version_info < (2, 5, 0):
+        sys.exit(
+            '''Error: %s is supported on Python versions 2.5 or greater
+            Please upgrade python installed on this machine.''' % os.path.split(sys.argv[0])[-1])
 
-    # Parse gpssh.conf file
-    parseConfigFile()
+    try:
+        # Parse options from the command line
+        parseCommandLine()
 
-    # Acquire the list of hosts from command line arguments
-    hostlist = ssh_utils.HostList()
-    for h in GV.opt['-h']:
-        hostlist.add(h)
-    if GV.opt['-f']:
-        hostlist.parseFile(GV.opt['-f'])
+        # Parse gpssh.conf file
+        parseConfigFile()
 
-    # Filter out non-unique hostnames unless the -D option is provided
-    if not GV.opt['-D']:
-        GV.opt['-h'] = hostlist.filterMultiHomedHosts()
-    else:
-        GV.opt['-h'] = hostlist.get()
+        # Acquire the list of hosts from command line arguments
+        hostlist = ssh_utils.HostList()
+        for h in GV.opt['-h']:
+            hostlist.add(h)
+        if GV.opt['-f']:
+            hostlist.parseFile(GV.opt['-f'])
 
-    if len(GV.opt['-h']) == 0:
-        usage('Error: missing hosts in -h and/or -f arguments')
+        # Filter out non-unique hostnames unless the -D option is provided
+        if not GV.opt['-D']:
+            GV.opt['-h'] = hostlist.filterMultiHomedHosts()
+        else:
+            GV.opt['-h'] = hostlist.get()
 
-    # If a single command was passed to us, implement a single command session
-    if GV.argcmd:
-        try:
-            GV.session = ssh_utils.Session()
-            GV.session.verbose = GV.opt['-v']
-            GV.session.login(GV.opt['-h'], GV.USER, GV.DELAY_BEFORE_SEND, GV.PROMPT_VALIDATION_TIMEOUT)
-            GV.session.echoCommand = GV.opt['-e']
-            if GV.opt['-s']:
-                GV.session.executeCommand("source {0}/greenplum_path.sh".format(os.environ["GPHOME"]))
-            output = GV.session.executeCommand(GV.argcmd)
-            GV.session.writeCommandOutput(output)
-            if GV.session.verbose: print '[INFO] completed successfully'
-            sys.stdout.flush()
-        except ssh_utils.Session.SessionError, e:
-            print 'Error: %s' % e
-            pass
+        if len(GV.opt['-h']) == 0:
+            usage('Error: missing hosts in -h and/or -f arguments')
 
-    else:  # Otherwise, implement an interactive session
-        interactive()
+        # If a single command was passed to us, implement a single command session
+        if GV.argcmd:
+            try:
+                GV.session = ssh_utils.Session()
+                GV.session.verbose = GV.opt['-v']
+                GV.session.login(GV.opt['-h'], GV.USER, GV.DELAY_BEFORE_SEND, GV.PROMPT_VALIDATION_TIMEOUT)
+                GV.session.echoCommand = GV.opt['-e']
+                if GV.opt['-s']:
+                    GV.session.executeCommand("source {0}/greenplum_path.sh".format(os.environ["GPHOME"]))
+                output = GV.session.executeCommand(GV.argcmd)
+                GV.session.writeCommandOutput(output)
+                if GV.session.verbose: print '[INFO] completed successfully'
+                sys.stdout.flush()
+            except ssh_utils.Session.SessionError, e:
+                print 'Error: %s' % e
+                pass
 
-    return_code = sessionCleanup()
-    sys.exit(return_code)
+        else:  # Otherwise, implement an interactive session
+            interactive()
 
-except KeyboardInterrupt:
-    sessionCleanup()
-    sys.exit('\nInterrupted...')
+        return_code = sessionCleanup()
+        sys.exit(return_code)
+
+    except KeyboardInterrupt:
+        sessionCleanup()
+        sys.exit('\nInterrupted...')
+
+
+#############
+if __name__ == '__main__':
+    main()

--- a/gpMgmt/bin/gpssh
+++ b/gpMgmt/bin/gpssh
@@ -19,7 +19,8 @@ Usage: gpssh [--version] [-?v] [-h host] [-f hostfile] [cmd]
 import os
 import sys
 
-# todo is this necessary?
+# this inserts the vendored pexpect from gpMgmt/bin/lib/pexpect/  into the path.
+# Note that IDEs may show the local macos version of pexpect, which is NOT THE SAME
 sys.path.insert(1, sys.path[0] + '/lib')
 
 import getopt
@@ -49,7 +50,7 @@ class __globals__:
     session = None
     DELAY_BEFORE_SEND = None
     PROMPT_VALIDATION_TIMEOUT = None
-
+    SYNC_RETRIES = None
 
 GV = __globals__()
 
@@ -112,6 +113,8 @@ def parseConfigFile():
             GV.DELAY_BEFORE_SEND = config.getfloat('gpssh', 'delaybeforesend')
         if GV.PROMPT_VALIDATION_TIMEOUT is None:
             GV.PROMPT_VALIDATION_TIMEOUT = config.getfloat('gpssh', 'prompt_validation_timeout')
+        if GV.SYNC_RETRIES is None:
+            GV.SYNC_RETRIES = config.getint('gpssh', 'sync_retries')
     except Exception:
         if GV.opt['-v']:
             print '[WARN] Reference default values as $MASTER_DATA_DIRECTORY/gpssh.conf could not be found'
@@ -120,6 +123,8 @@ def parseConfigFile():
             GV.DELAY_BEFORE_SEND = 0.05
         if GV.PROMPT_VALIDATION_TIMEOUT is None:
             GV.PROMPT_VALIDATION_TIMEOUT = 1.0
+        if GV.SYNC_RETRIES is None:
+            GV.SYNC_RETRIES = 3
 
     if GV.DELAY_BEFORE_SEND < 0.0:
         print '[ERROR] delaybeforesend cannot be negative'
@@ -127,6 +132,10 @@ def parseConfigFile():
 
     if GV.PROMPT_VALIDATION_TIMEOUT <= 0.0:
         print '[ERROR] prompt_validation_timeout cannot be negative or zero'
+        sys.exit(1)
+
+    if GV.SYNC_RETRIES < 0:
+        print '[ERROR] sync_retries cannot be negative'
         sys.exit(1)
 
     if GV.opt['-v']:
@@ -197,7 +206,7 @@ def interactive():
             if not GV.session:
                 GV.session = ssh_utils.Session()
                 GV.session.verbose = GV.opt['-v']
-                GV.session.login(GV.opt['-h'], GV.USER, GV.DELAY_BEFORE_SEND, GV.PROMPT_VALIDATION_TIMEOUT)
+                GV.session.login(GV.opt['-h'], GV.USER, GV.DELAY_BEFORE_SEND, GV.PROMPT_VALIDATION_TIMEOUT, GV.SYNC_RETRIES)
                 GV.session.echoCommand = GV.opt['-e']
             if GV.opt['-s']:
                 GV.session.executeCommand("source {0}/greenplum_path.sh".format(os.environ["GPHOME"]))
@@ -251,7 +260,7 @@ def main():
             try:
                 GV.session = ssh_utils.Session()
                 GV.session.verbose = GV.opt['-v']
-                GV.session.login(GV.opt['-h'], GV.USER, GV.DELAY_BEFORE_SEND, GV.PROMPT_VALIDATION_TIMEOUT)
+                GV.session.login(GV.opt['-h'], GV.USER, GV.DELAY_BEFORE_SEND, GV.PROMPT_VALIDATION_TIMEOUT, GV.SYNC_RETRIES)
                 GV.session.echoCommand = GV.opt['-e']
                 if GV.opt['-s']:
                     GV.session.executeCommand("source {0}/greenplum_path.sh".format(os.environ["GPHOME"]))

--- a/gpMgmt/bin/gpssh_modules/README.md
+++ b/gpMgmt/bin/gpssh_modules/README.md
@@ -1,0 +1,39 @@
+## gpssh developer notes
+
+This directory contains code that overrides our vendored pexpect module.
+
+In particular, we override the way the ssh command prompt is validated 
+on a remote machine. The original, vendored pexpect tries to match 2 successive prompts 
+from an interactive bash shell.  However, if the target host is slow, because of
+CPU loading or network loading, those prompts may returned to the ssh client with some delay.
+
+In the case of an SSH session with delay, the overriden method in this module retries several times, 
+extending the timeout from the default 0.1 second expectation between characters to up to 16x that.
+
+Experimentally, the retries and extended timeout are enough to tolerate a 1 second delay between characters, at least on a localhost connection using the "tc" tool to delay network on that loopback.
+
+The number of retries can be configured via a configuration setting. 
+ 
+### Testing the retry logic
+
+`tc` itself needs permissions beyond sudo, so it does not seem to work in an
+unprivileged container (i.e., via Concourse).
+
+
+On a Linux VM with root, use the `tc` library to delay network traffic as follows.
+
+First, a delay of 500ms should exercise the retry logic, but still succeed:
+
+```
+sudo tc qdisc add dev lo root netem delay 500ms
+```
+
+To reconfigure the delay, first cancel the existing delay and then set a new one:
+
+```
+sudo tc qdisc del dev lo root
+sudo tc qdisc add dev lo root netem delay 1200ms
+```
+
+
+

--- a/gpMgmt/bin/gpssh_modules/gppxssh_wrapper.py
+++ b/gpMgmt/bin/gpssh_modules/gppxssh_wrapper.py
@@ -1,0 +1,132 @@
+from datetime import datetime
+import time
+import sys
+
+sys.path.insert(1, sys.path[0] + '/lib')
+from pexpect import pxssh, TIMEOUT
+
+CRNL = '\r\n'
+DEBUG_VERBOSE_PRINTING = False
+# experimentally derived that a sequence of tries with delays of
+#  1, 5, 25, 125 secs worked to surmount a 1-second delay (via `tc` test)
+RETRY_EXPONENT = 5
+
+
+class PxsshWrapper(pxssh.pxssh):
+    def __init__(self, delaybeforesend, sync_retries, options):
+        self.sync_retries = sync_retries
+        super(PxsshWrapper, self).__init__(delaybeforesend=delaybeforesend, options=options)
+
+    def sync_original_prompt(self, sync_multiplier=1.0):
+        """
+        override the pxssh method to allow retries with extended timeout intervals
+        """
+        # make two attempts to throw away, perhaps emptying any initial Message Of The Day.
+        # In practice, the first request can take a huge amount of time, compared to subsequent requests,
+        # so give it a 5-second max wait as a special case.
+        self.sendline()
+        self.wait_for_any_response(max_wait_secs=5)
+        self.clear_response_channel()
+
+        self.sendline()
+        self.try_read_prompt(sync_multiplier)
+
+        # Each retry should go more slowly to accommodate possible cpu load, network,
+        # or other issues on the segment host that might delay when we receive the prompt.
+        num_retries = self.sync_retries
+        retry_attempt = 0
+        success = False
+        while (not success) and retry_attempt <= num_retries:
+            # each retry will get an exponentially longer timeout interval
+            sync_multiplier_for_this_retry = sync_multiplier * (RETRY_EXPONENT ** retry_attempt)
+            start = time.time()
+
+            if DEBUG_VERBOSE_PRINTING:
+                sys.stderr.write("\nUsing sync multiplier: %f\n" % sync_multiplier_for_this_retry)
+
+            self.sendline()
+            if DEBUG_VERBOSE_PRINTING:
+                sys.stderr.write("\nstart try read: %s\n" % datetime.now())
+            first_prompt = self.try_read_prompt(sync_multiplier_for_this_retry)
+            if DEBUG_VERBOSE_PRINTING:
+                sys.stderr.write("\nend try read: %s\n" % datetime.now())
+            self.sendline()
+            second_prompt = self.try_read_prompt(sync_multiplier_for_this_retry)
+
+            success = self.are_prompts_similar(first_prompt, second_prompt)
+            if not success:
+                retry_attempt += 1
+                if retry_attempt <= num_retries:
+                    # This attempt has failed to allow enough time.
+                    # We want to "clear the runway" before another attempt.
+                    # The next attempt will have a wait that is exponent times as long.
+                    # To clear the runway, we sleep for about as long as this upcoming retry.
+                    # Thus, the overall duration of this retry cycle becomes
+                    # roughly equivalent to the timeout used by the next attempt
+                    time.sleep(RETRY_EXPONENT * sync_multiplier_for_this_retry)
+                    self.clear_response_channel()
+
+        if DEBUG_VERBOSE_PRINTING:
+            if not success:
+                sys.stderr.write('\nAfter %d retries, prompts failed to be consistent.\n' % num_retries)
+            elif retry_attempt > 0:
+                sys.stderr.write('\nConsistent prompts after extending timeout, with %i retries.\n' % retry_attempt)
+            sys.stderr.flush()
+
+        return success
+
+    def clear_response_channel(self):
+        """remove any readily-available characters. stop as soon as even a little wait time is discovered"""
+        if DEBUG_VERBOSE_PRINTING:
+            sys.stderr.write('\nflushing:\n')
+        prompt = "dummy non empty"
+        while prompt:
+            try:
+                prompt = self.read_nonblocking(size=1, timeout=0.01)
+                if DEBUG_VERBOSE_PRINTING:
+                    sys.stderr.write(prompt)
+            except TIMEOUT:
+                break
+        if DEBUG_VERBOSE_PRINTING:
+            sys.stderr.write('\n')
+
+    def wait_for_any_response(self, max_wait_secs=5):
+        if DEBUG_VERBOSE_PRINTING:
+            sys.stderr.write('\nstart looking for a character at %s\n' % datetime.now())
+        duration = 0
+        while duration < max_wait_secs:
+            start = time.time()
+            try:
+                prompt = self.read_nonblocking(size=1, timeout=0.01)
+                if prompt:
+                    break
+            except TIMEOUT:
+                duration += time.time() - start
+        if DEBUG_VERBOSE_PRINTING:
+            sys.stderr.write('\nFinished wait_for_any_response() at %s\n' % datetime.now())
+
+    def is_prompt_bad(self, prompt_output):
+        return len(prompt_output) == 0 or prompt_output == CRNL
+
+    def are_prompts_similar(self, prompt_one, prompt_two):
+        if self.is_prompt_bad(prompt_one) or self.is_prompt_bad(prompt_two):
+            if DEBUG_VERBOSE_PRINTING:
+                sys.stderr.write('\n[A prompt was bad: ]')
+                sys.stderr.write('\n[first prompt: {0!r}]'.format(prompt_one))
+                sys.stderr.write('\n[second prompt: {0!r}]'.format(prompt_two))
+            return False
+
+        if len(prompt_one) == 0:
+            return False  # it will be used as the denominator of a ratio
+        lev_dist = self.levenshtein_distance(prompt_one, prompt_two)
+        lev_ratio = float(lev_dist) / len(prompt_one)
+
+        if lev_ratio < 0.4:
+            return True
+        else:
+            if DEBUG_VERBOSE_PRINTING:
+                sys.stderr.write('\n[! distance too far: \n{0!r}\n{1!r}]\n'.format(prompt_one, prompt_two))
+                sys.stderr.write('\n[val=%f, ld=%i]\n' % (lev_ratio, lev_dist))
+
+        return False
+

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -848,6 +848,16 @@ delaybeforesend = 0.05
 # value will have a small runtime impact at the beginning of
 # gpssh.
 prompt_validation_timeout = 1.0
+
+# sync_retries specifies how many times to try the pxssh
+# connection verification.
+# Setting this value to 1 means gpssh will immediately pass
+# along pxssh's best effort.
+# Increasing this value will allow for slow network connections,
+# cpu load, or other slowness on the segment host, but will
+# also delay feedback when a connection cannot be established
+# for other reasons
+sync_retries = 3
 _EOF_
         LOG_MSG "[INFO]:-End Function $FUNCNAME"
 }

--- a/gpMgmt/doc/gpssh_help
+++ b/gpMgmt/doc/gpssh_help
@@ -161,6 +161,7 @@ comment. This is an example gpssh.conf file.
     [gpssh]
     delaybeforesend = 0.05
     prompt_validation_timeout = 1.0
+    sync_retries = 3
 
 
 These are the gpssh.conf parameters.
@@ -172,13 +173,25 @@ delaybeforesend = seconds
  cause a long wait time during gpssh startup. The -d option
  overrides this parameter.
 
-
 prompt_validation_timeout = multiplier
 
  A decimal number greater than 0 (zero) that is the multiplier for the
  timeout that gpssh uses when validating the ssh prompt. Increasing this
  value has a small impact during gpssh startup. Default is 1. The -t
  option overrides this parameter.
+
+sync_retry = attempts
+
+ A non-negative integer that specifies the maximum number of retry attempts
+ that gpssh performs to try connecting to a Greenplum Database remote host. The
+ default is 3. If the value is 0, gpssh returns an error if the initial
+ connection attempt fails. This parameter cannot be configured with a
+ command-line option.
+
+ Increasing this value compensates for slow network performance or performance
+ issues such as heavy CPU or I/O load on the segment host. However, when a
+ connection cannot be established, an increased value also increases the delay
+ when an error is returned.
 
 
 

--- a/gpMgmt/test/behave/mgmt_utils/environment.py
+++ b/gpMgmt/test/behave/mgmt_utils/environment.py
@@ -78,3 +78,7 @@ def after_scenario(context, scenario):
 
         if os.path.isdir('%s/gpAdminLogs.bk' % home_dir):
             shutil.move('%s/gpAdminLogs.bk' % home_dir, '%s/gpAdminLogs' % home_dir)
+
+    if 'gpssh' in context.feature.tags:
+        run_command(context, 'sudo tc qdisc del dev lo root netem')
+

--- a/gpMgmt/test/behave/mgmt_utils/gpssh.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpssh.feature
@@ -23,3 +23,11 @@ Feature: gpssh behave tests
         Then gpssh should return a return code of 0
         And gpssh should print "unable to login to localhost" to stdout
         And gpssh should print "could not synchronize with original prompt" to stdout
+
+    Scenario: gpssh succeeds when network has latency
+        When the user runs command "sudo tc qdisc add dev lo root netem delay 4000ms"
+        Then sudo should return a return code of 0
+        When the user runs "gpssh -h localhost echo 'hello I am testing'"
+        Then gpssh should return a return code of 0
+        And gpssh should print "hello I am testing" to stdout
+        # We depend on environment.py#after_scenario() to delete the artificial latency

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpssh.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpssh.xml
@@ -147,7 +147,8 @@
                 example <codeph>gpssh.conf</codeph> file.</p>
             <codeblock>[gpssh]
 delaybeforesend = 0.05
-prompt_validation_timeout = 1.0</codeblock>
+prompt_validation_timeout = 1.0
+sync_retries = 3</codeblock>
             <p>These are the <codeph>gpssh.conf</codeph> parameters.</p>
             <parml>
                 <plentry>
@@ -165,6 +166,21 @@ prompt_validation_timeout = 1.0</codeblock>
                             <codeph>ssh</codeph> prompt. Increasing this value has a small impact
                         during <codeph>gpssh</codeph> startup. Default is <codeph>1</codeph>. The
                             <codeph>-t</codeph> option overrides this parameter.</pd>
+                </plentry>
+                <plentry>
+                    <pt>sync_retries = <varname>attempts</varname></pt>
+                    <pd>A non-negative integer that specifies the maximum
+                        number of retry attempts that <codeph>gpssh</codeph>
+                        performs to try connecting to a Greenplum Database
+                        remote host. The default is 3. If the value is 0,
+                        <codeph>gpssh</codeph> returns an error if the initial
+                        connection attempt fails. This parameter cannot be
+                        configured with a command-line option.</pd>
+                    <pd>Increasing this value compensates for slow network
+                        performance or performance issues such as heavy CPU or
+                        I/O load on the segment host. However, when a
+                        connection cannot be established, an increased value
+                        also increases the delay when an error is returned.</pd>
                 </plentry>
             </parml>
         </section>


### PR DESCRIPTION
Workaround intermittent errors when using gpssh on some nodes that are very cpu-bound.

In particular, we override the way the ssh command prompt is validated on a remote machine, within gpssh. The vendored module 'pexpect' tries to match 2 successive prompts from an interactive bash shell.  However, if the target host is slow from CPU loading or network loading, these prompts may return late.

In that case, the override retries several times, extending the timeout from the default 1 second to up to 125 times that duration (exponentially in 3 retries by default).

Experimentally, these added retries seem to tolerate about 1 second delay, testing with a 'tc' command that slows network traffic artificially.

The number of retries can be configured.

--add unit tests to verify happy path of ssh-ing to localhost
--add module for gpssh, for overriding pexpect (pxxssh)
--add readme to describe testing technique using 'tc' to delay network
--add behave test that introduces a delay on the loopback (lo) interface