### PR TITLE
Fix assert failure in ResGroupSlotAcquire()

### DIFF
--- a/src/test/isolation2/expected/resgroup_concurrency.out
+++ b/src/test/isolation2/expected/resgroup_concurrency.out
@@ -1,39 +1,42 @@
--- create a resource group when gp_resource_manager is queue
-0:CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=2, cpu_rate_limit=20, memory_limit=20);
-CREATE
-0:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
-rsgname            |num_running|num_queueing|num_queued|num_executed
--------------------+-----------+------------+----------+------------
-rg_concurrency_test|0          |0           |0         |0           
-(1 row)
-
 -- test1: test gp_toolkit.gp_resgroup_status and pg_stat_activity
+-- create a resource group when gp_resource_manager is queue
+DROP ROLE IF EXISTS role_concurrency_test;
+DROP
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+DROP
+-- end_ignore
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=2, cpu_rate_limit=20, memory_limit=20);
+CREATE
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+CREATE
+
 -- no query has been assigned to the this group
-1:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
+
+SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
 rsgname            |num_running|num_queueing|num_queued|num_executed
 -------------------+-----------+------------+----------+------------
 rg_concurrency_test|0          |0           |0         |0           
 (1 row)
-1:CREATE role role_concurrency_test RESOURCE GROUP rg_concurrency_test;
-CREATE
-2:SET role role_concurrency_test;
+2:SET ROLE role_concurrency_test;
 SET
 2:BEGIN;
 BEGIN
-3:SET role role_concurrency_test;
+3:SET ROLE role_concurrency_test;
 SET
 3:BEGIN;
 BEGIN
-4:SET role role_concurrency_test;
+4:SET ROLE role_concurrency_test;
 SET
 4&:BEGIN;  <waiting ...>
+
 -- new transaction will be blocked when the concurrency limit of the resource group is reached.
-1:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
+SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
 rsgname            |num_running|num_queueing|num_queued|num_executed
 -------------------+-----------+------------+----------+------------
 rg_concurrency_test|2          |1           |1         |2           
 (1 row)
-1:SELECT waiting_reason, rsgqueueduration > '0'::interval as time from pg_stat_activity where current_query = 'BEGIN;' and rsgname = 'rg_concurrency_test';
+SELECT waiting_reason, rsgqueueduration > '0'::interval as time from pg_stat_activity where current_query = 'BEGIN;' and rsgname = 'rg_concurrency_test';
 waiting_reason|time
 --------------+----
 resgroup      |t   
@@ -46,52 +49,61 @@ END
 BEGIN
 4:END;
 END
-1:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
+2q: ... <quitting>
+3q: ... <quitting>
+4q: ... <quitting>
+SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
 rsgname            |num_running|num_queueing|num_queued|num_executed
 -------------------+-----------+------------+----------+------------
 rg_concurrency_test|0          |0           |1         |3           
 (1 row)
-1:DROP role role_concurrency_test;
+DROP ROLE role_concurrency_test;
 DROP
-1:DROP RESOURCE GROUP rg_concurrency_test;
+DROP RESOURCE GROUP rg_concurrency_test;
 DROP
 
 -- test2: test alter concurrency
 -- Create a resource group with concurrency=2. Prepare 2 running transactions and 1 queueing transactions.
 -- Alter concurrency 2->3, the queueing transaction will be woken up, the 'value' and 'proposed' of pg_resgroupcapability will be set to 3.
-11:CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=2, cpu_rate_limit=20, memory_limit=20);
+DROP ROLE IF EXISTS role_concurrency_test;
+DROP
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+ERROR:  resource group "rg_concurrency_test" does not exist
+-- end_ignore
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=2, cpu_rate_limit=20, memory_limit=20);
 CREATE
-11:CREATE role role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
 CREATE
-12:SET role role_concurrency_test;
+12:SET ROLE role_concurrency_test;
 SET
 12:BEGIN;
 BEGIN
-13:SET role role_concurrency_test;
+13:SET ROLE role_concurrency_test;
 SET
 13:BEGIN;
 BEGIN
-14:SET role role_concurrency_test;
+14:SET ROLE role_concurrency_test;
 SET
 14&:BEGIN;  <waiting ...>
-11:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
+SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
 rsgname            |num_running|num_queueing|num_queued|num_executed
 -------------------+-----------+------------+----------+------------
 rg_concurrency_test|2          |1           |1         |2           
 (1 row)
-11:SELECT concurrency,proposed_concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
+SELECT concurrency,proposed_concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
 concurrency|proposed_concurrency
 -----------+--------------------
 2          |2                   
 (1 row)
-11:ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 3;
+ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 3;
 ALTER
-11:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
+SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
 rsgname            |num_running|num_queueing|num_queued|num_executed
 -------------------+-----------+------------+----------+------------
 rg_concurrency_test|3          |0           |1         |3           
 (1 row)
-11:SELECT concurrency,proposed_concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
+SELECT concurrency,proposed_concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
 concurrency|proposed_concurrency
 -----------+--------------------
 3          |3                   
@@ -104,46 +116,55 @@ END
 BEGIN
 14:END;
 END
-11:DROP role role_concurrency_test;
+12q: ... <quitting>
+13q: ... <quitting>
+14q: ... <quitting>
+DROP ROLE role_concurrency_test;
 DROP
-11:DROP RESOURCE GROUP rg_concurrency_test;
+DROP RESOURCE GROUP rg_concurrency_test;
 DROP
 
 -- test3: test alter concurrency
 -- Create a resource group with concurrency=3. Prepare 3 running transactions, and 1 queueing transaction.
-21:CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=3, cpu_rate_limit=20, memory_limit=20);
+DROP ROLE IF EXISTS role_concurrency_test;
+DROP
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+ERROR:  resource group "rg_concurrency_test" does not exist
+-- end_ignore
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=3, cpu_rate_limit=20, memory_limit=20);
 CREATE
-21:CREATE role role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
 CREATE
-22:SET role role_concurrency_test;
+22:SET ROLE role_concurrency_test;
 SET
 22:BEGIN;
 BEGIN
-23:SET role role_concurrency_test;
+23:SET ROLE role_concurrency_test;
 SET
 23:BEGIN;
 BEGIN
-24:SET role role_concurrency_test;
+24:SET ROLE role_concurrency_test;
 SET
 24:BEGIN;
 BEGIN
-25:SET role role_concurrency_test;
+25:SET ROLE role_concurrency_test;
 SET
 25&:BEGIN;  <waiting ...>
-21:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
+SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
 rsgname            |num_running|num_queueing|num_queued|num_executed
 -------------------+-----------+------------+----------+------------
 rg_concurrency_test|3          |1           |1         |3           
 (1 row)
-21:SELECT concurrency,proposed_concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
+SELECT concurrency,proposed_concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
 concurrency|proposed_concurrency
 -----------+--------------------
 3          |3                   
 (1 row)
 -- Alter concurrency 3->2, the 'proposed' of pg_resgroupcapability will be set to 2.
-21:ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 2;
+ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 2;
 ALTER
-21:SELECT concurrency,proposed_concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
+SELECT concurrency,proposed_concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
 concurrency|proposed_concurrency
 -----------+--------------------
 3          |2                   
@@ -151,14 +172,14 @@ concurrency|proposed_concurrency
 -- When one transaction is finished, queueing transaction won't be woken up. There're 2 running transactions and 1 queueing transaction.
 24:END;
 END
-21:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
+SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
 rsgname            |num_running|num_queueing|num_queued|num_executed
 -------------------+-----------+------------+----------+------------
 rg_concurrency_test|2          |1           |1         |3           
 (1 row)
 -- New transaction will be queued, there're 2 running and 2 queueing transactions.
 24&:BEGIN;  <waiting ...>
-21:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
+SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
 rsgname            |num_running|num_queueing|num_queued|num_executed
 -------------------+-----------+------------+----------+------------
 rg_concurrency_test|2          |2           |2         |3           
@@ -166,15 +187,15 @@ rg_concurrency_test|2          |2           |2         |3
 -- Finish another transaction, one queueing transaction will be woken up, there're 2 running transactions and 1 queueing transaction.
 22:END;
 END
-21:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
+SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
 rsgname            |num_running|num_queueing|num_queued|num_executed
 -------------------+-----------+------------+----------+------------
 rg_concurrency_test|2          |1           |2         |4           
 (1 row)
 -- Alter concurrency 2->2, the 'value' and 'proposed' of pg_resgroupcapability will be set to 2.
-21:ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 2;
+ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 2;
 ALTER
-21:SELECT concurrency,proposed_concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
+SELECT concurrency,proposed_concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
 concurrency|proposed_concurrency
 -----------+--------------------
 2          |2                   
@@ -182,7 +203,7 @@ concurrency|proposed_concurrency
 -- Finish another transaction, one queueing transaction will be woken up, there're 2 running transactions and 0 queueing transaction.
 23:END;
 END
-21:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
+SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
 rsgname            |num_running|num_queueing|num_queued|num_executed
 -------------------+-----------+------------+----------+------------
 rg_concurrency_test|2          |0           |2         |5           
@@ -195,16 +216,26 @@ BEGIN
 END
 24:END;
 END
-21:DROP role role_concurrency_test;
+22q: ... <quitting>
+23q: ... <quitting>
+24q: ... <quitting>
+25q: ... <quitting>
+DROP ROLE role_concurrency_test;
 DROP
-21:DROP RESOURCE GROUP rg_concurrency_test;
+DROP RESOURCE GROUP rg_concurrency_test;
 DROP
 
 -- test4: concurrently drop resource group
 
-31:CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=2, cpu_rate_limit=20, memory_limit=20);
+DROP ROLE IF EXISTS role_concurrency_test;
+DROP
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+ERROR:  resource group "rg_concurrency_test" does not exist
+-- end_ignore
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=2, cpu_rate_limit=20, memory_limit=20);
 CREATE
-31:CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
 CREATE
 
 -- DROP should fail if there're running transactions
@@ -212,16 +243,16 @@ CREATE
 SET
 32:BEGIN;
 BEGIN
-31:BEGIN;
+BEGIN;
 BEGIN
-31:DROP ROLE role_concurrency_test;
+DROP ROLE role_concurrency_test;
 DROP
-31:DROP RESOURCE GROUP rg_concurrency_test;
+DROP RESOURCE GROUP rg_concurrency_test;
 ERROR:  Cannot drop resource group "rg_concurrency_test"
 HINT:   The resource group is currently managing 1 query(ies) and cannot be dropped.
 	Terminate the queries first or try dropping the group later.
 	The view pg_stat_activity tracks the queries managed by resource groups.
-31:END;
+END;
 END
 32:END;
 END
@@ -229,25 +260,20 @@ END
 RESET
 
 -- DROP is abortted
-31:BEGIN;
+BEGIN;
 BEGIN
-31:DROP ROLE role_concurrency_test;
+DROP ROLE role_concurrency_test;
 DROP
-31:DROP RESOURCE GROUP rg_concurrency_test;
+DROP RESOURCE GROUP rg_concurrency_test;
 DROP
-31:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
+SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
 rsgname|num_running|num_queueing|num_queued|num_executed
 -------+-----------+------------+----------+------------
 (0 rows)
-32:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
-rsgname            |num_running|num_queueing|num_queued|num_executed
--------------------+-----------+------------+----------+------------
-rg_concurrency_test|0          |0           |0         |2           
-(1 row)
 32:SET ROLE role_concurrency_test;
 SET
 32&:BEGIN;  <waiting ...>
-31:ABORT;
+ABORT;
 ABORT
 32<:  <... completed>
 BEGIN
@@ -262,32 +288,33 @@ END
 RESET
 
 -- DROP is committed
-31:BEGIN;
+BEGIN;
 BEGIN
-31:DROP ROLE role_concurrency_test;
+DROP ROLE role_concurrency_test;
 DROP
-31:DROP RESOURCE GROUP rg_concurrency_test;
+DROP RESOURCE GROUP rg_concurrency_test;
 DROP
-31:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
+SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
 rsgname|num_running|num_queueing|num_queued|num_executed
 -------+-----------+------------+----------+------------
 (0 rows)
-32:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
-rsgname            |num_running|num_queueing|num_queued|num_executed
--------------------+-----------+------------+----------+------------
-rg_concurrency_test|0          |0           |0         |4           
-(1 row)
 32:SET ROLE role_concurrency_test;
 SET
 32&:BEGIN;  <waiting ...>
-31:END;
+END;
 END
 32<:  <... completed>
-ERROR:  Resource group 49449 was concurrently dropped
-33:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
+ERROR:  Resource group 32935 was concurrently dropped
+32q: ... <quitting>
+SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
 rsgname|num_running|num_queueing|num_queued|num_executed
 -------+-----------+------------+----------+------------
 (0 rows)
+
+DROP ROLE IF EXISTS role_concurrency_test;
+DROP
+DROP RESOURCE GROUP rg_concurrency_test;
+ERROR:  resource group "rg_concurrency_test" does not exist
 
 -- test5: concurrently alter resource group cpu rate limit
 
@@ -346,6 +373,8 @@ BEGIN
 COMMIT
 42<:  <... completed>
 ERROR:  total cpu_rate_limit exceeded the limit of 100
+41q: ... <quitting>
+42q: ... <quitting>
 SELECT g.rsgname, c.cpu_rate_limit FROM gp_toolkit.gp_resgroup_config c, pg_resgroup g WHERE c.groupid=g.oid ORDER BY g.oid;
 rsgname             |cpu_rate_limit
 --------------------+--------------
@@ -358,4 +387,82 @@ rg2_concurrency_test|20
 DROP RESOURCE GROUP rg1_concurrency_test;
 DROP
 DROP RESOURCE GROUP rg2_concurrency_test;
+DROP
+
+
+-- test6: cancel a query that is waiting for a slot
+DROP ROLE IF EXISTS role_concurrency_test;
+DROP
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+ERROR:  resource group "rg_concurrency_test" does not exist
+-- end_ignore
+
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=1, cpu_rate_limit=20, memory_limit=20);
+CREATE
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+CREATE
+51:SET ROLE role_concurrency_test;
+SET
+51:BEGIN;
+BEGIN
+52:SET ROLE role_concurrency_test;
+SET
+52&:BEGIN;  <waiting ...>
+SELECT pg_cancel_backend(procpid) FROM pg_stat_activity WHERE waiting_reason='resgroup' AND rsgname='rg_concurrency_test';
+pg_cancel_backend
+-----------------
+t                
+(1 row)
+52<:  <... completed>
+ERROR:  canceling statement due to user request
+52&:BEGIN;  <waiting ...>
+SELECT pg_cancel_backend(procpid) FROM pg_stat_activity WHERE waiting_reason='resgroup' AND rsgname='rg_concurrency_test';
+pg_cancel_backend
+-----------------
+t 
+(1 row)
+52<:  <... completed>
+ERROR:  canceling statement due to user request
+51q: ... <quitting>
+52q: ... <quitting>
+DROP ROLE role_concurrency_test;
+DROP
+DROP RESOURCE GROUP rg_concurrency_test;
+DROP
+
+-- test7: terminate a query that is waiting for a slot
+DROP ROLE IF EXISTS role_concurrency_test;
+DROP
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+ERROR:  resource group "rg_concurrency_test" does not exist
+-- end_ignore
+
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=1, cpu_rate_limit=20, memory_limit=20);
+CREATE
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+CREATE
+61:SET ROLE role_concurrency_test;
+SET
+61:BEGIN;
+BEGIN
+62:SET ROLE role_concurrency_test;
+SET
+62&:BEGIN;  <waiting ...>
+SELECT pg_terminate_backend(procpid) FROM pg_stat_activity WHERE waiting_reason='resgroup' AND rsgname='rg_concurrency_test';
+pg_terminate_backend
+--------------------
+t                   
+(1 row)
+62<:  <... completed>
+FATAL:  terminating connection due to administrator command
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+61q: ... <quitting>
+62q: ... <quitting>
+DROP ROLE role_concurrency_test;
+DROP
+DROP RESOURCE GROUP rg_concurrency_test;
 DROP

--- a/src/test/isolation2/sql/resgroup_concurrency.sql
+++ b/src/test/isolation2/sql/resgroup_concurrency.sql
@@ -1,130 +1,159 @@
--- create a resource group when gp_resource_manager is queue
-0:CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=2, cpu_rate_limit=20, memory_limit=20);
-0:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
-
 -- test1: test gp_toolkit.gp_resgroup_status and pg_stat_activity
+-- create a resource group when gp_resource_manager is queue
+DROP ROLE IF EXISTS role_concurrency_test;
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+-- end_ignore
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=2, cpu_rate_limit=20, memory_limit=20);
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+
 -- no query has been assigned to the this group
-1:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
-1:CREATE role role_concurrency_test RESOURCE GROUP rg_concurrency_test;
-2:SET role role_concurrency_test;
+
+SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
+2:SET ROLE role_concurrency_test;
 2:BEGIN;
-3:SET role role_concurrency_test;
+3:SET ROLE role_concurrency_test;
 3:BEGIN;
-4:SET role role_concurrency_test;
+4:SET ROLE role_concurrency_test;
 4&:BEGIN;
+
 -- new transaction will be blocked when the concurrency limit of the resource group is reached.
-1:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
-1:SELECT waiting_reason, rsgqueueduration > '0'::interval as time from pg_stat_activity where current_query = 'BEGIN;' and rsgname = 'rg_concurrency_test';
+SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
+SELECT waiting_reason, rsgqueueduration > '0'::interval as time from pg_stat_activity where current_query = 'BEGIN;' and rsgname = 'rg_concurrency_test';
 2:END;
 3:END;
 4<:
 4:END;
-1:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
-1:DROP role role_concurrency_test;
-1:DROP RESOURCE GROUP rg_concurrency_test;
+2q:
+3q:
+4q:
+SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
+DROP ROLE role_concurrency_test;
+DROP RESOURCE GROUP rg_concurrency_test;
 
 -- test2: test alter concurrency
 -- Create a resource group with concurrency=2. Prepare 2 running transactions and 1 queueing transactions.
 -- Alter concurrency 2->3, the queueing transaction will be woken up, the 'value' and 'proposed' of pg_resgroupcapability will be set to 3.
-11:CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=2, cpu_rate_limit=20, memory_limit=20);
-11:CREATE role role_concurrency_test RESOURCE GROUP rg_concurrency_test;
-12:SET role role_concurrency_test;
+DROP ROLE IF EXISTS role_concurrency_test;
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+-- end_ignore
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=2, cpu_rate_limit=20, memory_limit=20);
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+12:SET ROLE role_concurrency_test;
 12:BEGIN;
-13:SET role role_concurrency_test;
+13:SET ROLE role_concurrency_test;
 13:BEGIN;
-14:SET role role_concurrency_test;
+14:SET ROLE role_concurrency_test;
 14&:BEGIN;
-11:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
-11:SELECT concurrency,proposed_concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
-11:ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 3;
-11:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
-11:SELECT concurrency,proposed_concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
+SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
+SELECT concurrency,proposed_concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
+ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 3;
+SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
+SELECT concurrency,proposed_concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
 12:END;
 13:END;
 14<:
 14:END;
-11:DROP role role_concurrency_test;
-11:DROP RESOURCE GROUP rg_concurrency_test;
+12q:
+13q:
+14q:
+DROP ROLE role_concurrency_test;
+DROP RESOURCE GROUP rg_concurrency_test;
 
 -- test3: test alter concurrency
 -- Create a resource group with concurrency=3. Prepare 3 running transactions, and 1 queueing transaction.
-21:CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=3, cpu_rate_limit=20, memory_limit=20);
-21:CREATE role role_concurrency_test RESOURCE GROUP rg_concurrency_test;
-22:SET role role_concurrency_test;
+DROP ROLE IF EXISTS role_concurrency_test;
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+-- end_ignore
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=3, cpu_rate_limit=20, memory_limit=20);
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+22:SET ROLE role_concurrency_test;
 22:BEGIN;
-23:SET role role_concurrency_test;
+23:SET ROLE role_concurrency_test;
 23:BEGIN;
-24:SET role role_concurrency_test;
+24:SET ROLE role_concurrency_test;
 24:BEGIN;
-25:SET role role_concurrency_test;
+25:SET ROLE role_concurrency_test;
 25&:BEGIN;
-21:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
-21:SELECT concurrency,proposed_concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
+SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
+SELECT concurrency,proposed_concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
 -- Alter concurrency 3->2, the 'proposed' of pg_resgroupcapability will be set to 2.
-21:ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 2;
-21:SELECT concurrency,proposed_concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
+ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 2;
+SELECT concurrency,proposed_concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
 -- When one transaction is finished, queueing transaction won't be woken up. There're 2 running transactions and 1 queueing transaction.
 24:END;
-21:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
+SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
 -- New transaction will be queued, there're 2 running and 2 queueing transactions.
 24&:BEGIN;
-21:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
+SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
 -- Finish another transaction, one queueing transaction will be woken up, there're 2 running transactions and 1 queueing transaction.
 22:END;
-21:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
+SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
 -- Alter concurrency 2->2, the 'value' and 'proposed' of pg_resgroupcapability will be set to 2.
-21:ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 2;
-21:SELECT concurrency,proposed_concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
+ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 2;
+SELECT concurrency,proposed_concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
 -- Finish another transaction, one queueing transaction will be woken up, there're 2 running transactions and 0 queueing transaction.
 23:END;
-21:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
+SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
 24<:
 25<:
 25:END;
 24:END;
-21:DROP role role_concurrency_test;
-21:DROP RESOURCE GROUP rg_concurrency_test;
+22q:
+23q:
+24q:
+25q:
+DROP ROLE role_concurrency_test;
+DROP RESOURCE GROUP rg_concurrency_test;
 
 -- test4: concurrently drop resource group
 
-31:CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=2, cpu_rate_limit=20, memory_limit=20);
-31:CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+DROP ROLE IF EXISTS role_concurrency_test;
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+-- end_ignore
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=2, cpu_rate_limit=20, memory_limit=20);
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
 
 -- DROP should fail if there're running transactions
 32:SET ROLE role_concurrency_test;
 32:BEGIN;
-31:BEGIN;
-31:DROP ROLE role_concurrency_test;
-31:DROP RESOURCE GROUP rg_concurrency_test;
-31:END;
+BEGIN;
+DROP ROLE role_concurrency_test;
+DROP RESOURCE GROUP rg_concurrency_test;
+END;
 32:END;
 32:RESET ROLE;
 
 -- DROP is abortted
-31:BEGIN;
-31:DROP ROLE role_concurrency_test;
-31:DROP RESOURCE GROUP rg_concurrency_test;
-31:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
-32:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
+BEGIN;
+DROP ROLE role_concurrency_test;
+DROP RESOURCE GROUP rg_concurrency_test;
+SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
 32:SET ROLE role_concurrency_test;
 32&:BEGIN;
-31:ABORT;
+ABORT;
 32<:
 32:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
 32:END;
 32:RESET ROLE;
 
 -- DROP is committed
-31:BEGIN;
-31:DROP ROLE role_concurrency_test;
-31:DROP RESOURCE GROUP rg_concurrency_test;
-31:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
-32:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
+BEGIN;
+DROP ROLE role_concurrency_test;
+DROP RESOURCE GROUP rg_concurrency_test;
+SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
 32:SET ROLE role_concurrency_test;
 32&:BEGIN;
-31:END;
+END;
 32<:
-33:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
+32q:
+SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
+
+DROP ROLE IF EXISTS role_concurrency_test;
+DROP RESOURCE GROUP rg_concurrency_test;
 
 -- test5: concurrently alter resource group cpu rate limit
 
@@ -157,7 +186,51 @@ CREATE RESOURCE GROUP rg2_concurrency_test WITH (concurrency=2, cpu_rate_limit=2
 42&:ALTER RESOURCE GROUP rg2_concurrency_test SET CPU_RATE_LIMIT 35;
 41:COMMIT;
 42<:
+41q:
+42q:
 SELECT g.rsgname, c.cpu_rate_limit FROM gp_toolkit.gp_resgroup_config c, pg_resgroup g WHERE c.groupid=g.oid ORDER BY g.oid;
 
 DROP RESOURCE GROUP rg1_concurrency_test;
 DROP RESOURCE GROUP rg2_concurrency_test;
+
+
+-- test6: cancel a query that is waiting for a slot
+DROP ROLE IF EXISTS role_concurrency_test;
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+-- end_ignore
+
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=1, cpu_rate_limit=20, memory_limit=20);
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+51:SET ROLE role_concurrency_test;
+51:BEGIN;
+52:SET ROLE role_concurrency_test;
+52&:BEGIN;
+SELECT pg_cancel_backend(procpid) FROM pg_stat_activity WHERE waiting_reason='resgroup' AND rsgname='rg_concurrency_test';
+52<:
+52&:BEGIN;
+SELECT pg_cancel_backend(procpid) FROM pg_stat_activity WHERE waiting_reason='resgroup' AND rsgname='rg_concurrency_test';
+52<:
+51q:
+52q:
+DROP ROLE role_concurrency_test;
+DROP RESOURCE GROUP rg_concurrency_test;
+
+-- test7: terminate a query that is waiting for a slot
+DROP ROLE IF EXISTS role_concurrency_test;
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+-- end_ignore
+
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=1, cpu_rate_limit=20, memory_limit=20);
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+61:SET ROLE role_concurrency_test;
+61:BEGIN;
+62:SET ROLE role_concurrency_test;
+62&:BEGIN;
+SELECT pg_terminate_backend(procpid) FROM pg_stat_activity WHERE waiting_reason='resgroup' AND rsgname='rg_concurrency_test';
+62<:
+61q:
+62q:
+DROP ROLE role_concurrency_test;
+DROP RESOURCE GROUP rg_concurrency_test;


### PR DESCRIPTION
	CREATE RESOURCE GROUP rg1 WITH (concurrency=1, cpu_rate_limit=10, memory_limit=10);
	CREATE ROLE r1 RESOURCE GROUP rg1;

	session 1:
	set role r1;
	BEGIN;

	session 2:
	BEGIN; <--- hang, and then cancel
	BEGIN; <--- assertion failure

Signed-off-by: Ning Yu <nyu@pivotal.io>