### PR TITLE
behave: make select sql longer for gpperfmon test

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gpperfmon.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpperfmon.feature
@@ -108,7 +108,7 @@ Feature: gpperfmon
         """
         When below sql is executed in "gptest" db
         """
-        select count(*) from sales;
+        select count(*),sum(pow(amt,2)) from sales;
         """
         Then wait until the results from boolean sql "SELECT count(*) > 0 FROM queries_history where cpu_elapsed > 1 and query_text like 'select count(*)%'" is "true"
         Then wait until the results from boolean sql "SELECT count(*) > 0 FROM queries_history where skew_cpu > 0.05 and db = 'gptest'" is "true"


### PR DESCRIPTION
Create a more extensive workload for the sql to make it last longer -- We should be around 2 seconds.
The previous sql was completing too fast, so pid no longer exists when the metric pid read
happens. This causes the query_history result to report 0 cpu_elapsed.