### PR TITLE
Add distributed xact info to CommitPrepared xlog record and redo.

### DIFF
--- a/contrib/xlogdump/xlogdump_rmgr.c
+++ b/contrib/xlogdump/xlogdump_rmgr.c
@@ -348,18 +348,24 @@ print_rmgr_xact(XLogRecPtr cur, XLogRecord *record, uint8 info, bool hideTimesta
 
 		memcpy(&xlrec, XLogRecGetData(record), sizeof(xlrec));
 #if PG_VERSION_NUM >= 90000
-		snprintf(buf, sizeof(buf), "commit prepared xid:%d, dbid:%d, spcid:%d, commit at %s",
-			 xlrec.xid,
-			 xlrec.crec.dbId, xlrec.crec.tsId,
-			 str_time(_timestamptz_to_time_t(xlrec.crec.xact_time)));
+		snprintf(buf, sizeof(buf), "commit prepared xid:%d, dxid:%d, dtimeStamp:%d dbid:%d, spcid:%d, commit at %s",
+				 xlrec.xid,
+				 xlrec.distribXid,
+				 xlrec.distribTimeStamp,
+				 xlrec.crec.dbId, xlrec.crec.tsId,
+				 str_time(_timestamptz_to_time_t(xlrec.crec.xact_time)));
 #elif PG_VERSION_NUM >= 80300
-		snprintf(buf, sizeof(buf), "commit prepared xid:%d, commit at %s",
-			 xlrec.xid,
-			 str_time(_timestamptz_to_time_t(xlrec.crec.xact_time)));
+		snprintf(buf, sizeof(buf), "commit prepared xid:%d, dxid:%d, dtimeStamp:%d commit at %s",
+				 xlrec.xid,
+				 xlrec.distribXid,
+				 xlrec.distribTimeStamp,
+				 str_time(_timestamptz_to_time_t(xlrec.crec.xact_time)));
 #else
-		snprintf(buf, sizeof(buf), "commit prepared xid:%d, commit at %s",
-			 xlrec.xid,
-			 str_time(_timestamptz_to_time_t(xlrec.crec.xtime)));
+		snprintf(buf, sizeof(buf), "commit prepared xid:%d, dxid:%d, dtimeStamp:%d commit at %s",
+				 xlrec.xid,
+				 xlrec.distribXid,
+				 xlrec.distribTimeStamp,
+				 str_time(_timestamptz_to_time_t(xlrec.crec.xtime)));
 #endif
 		}
 		break;

--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -2050,8 +2050,16 @@ RecordTransactionCommitPrepared(TransactionId xid,
 	 */
 	Assert(MyProc->inCommit);
 
+	/*
+	 * Crack open the gid to get the DTM start time and distributed
+	 * transaction id.
+	 */
+	dtxCrackOpenGid(gid, &distribTimeStamp, &distribXid);
+
 	/* Emit the XLOG commit record */
 	xlrec.xid = xid;
+	xlrec.distribTimeStamp = distribTimeStamp;
+	xlrec.distribXid = distribXid;
 	xlrec.crec.xtime = time(NULL);
 	xlrec.crec.persistentCommitObjectCount = persistentCommitObjectCount;
 	xlrec.crec.nsubxacts = nchildren;
@@ -2121,12 +2129,6 @@ RecordTransactionCommitPrepared(TransactionId xid,
 
 	if (max_wal_senders > 0)
 		WalSndWakeup();
-
-	/*
-	 * Crack open the gid to get the DTM start time and distributed
-	 * transaction id.
-	 */
-	dtxCrackOpenGid(gid, &distribTimeStamp, &distribXid);
 
 	/* UNDONE: What are the locking issues here? */
 	/*

--- a/src/include/access/xact.h
+++ b/src/include/access/xact.h
@@ -135,6 +135,8 @@ typedef struct xl_xact_abort
 typedef struct xl_xact_commit_prepared
 {
 	TransactionId xid;			/* XID of prepared xact */
+	DistributedTransactionTimeStamp distribTimeStamp;
+	DistributedTransactionId        distribXid;
 	xl_xact_commit crec;		/* COMMIT record */
 	/* MORE DATA FOLLOWS AT END OF STRUCT */
 } xl_xact_commit_prepared;


### PR DESCRIPTION
Currently, CommitPrepared xlog record, `xl_xact_commit_prepared` doesn't store
information for distributed transaction like distributed transaction id or
distributed timestamp. Its extremely helpful to have this information recorded
plus also needed to replay/redo the xlog record.

Currently, redo of CommitPrepared xlog record is not updating the distributed
commit log. Which as of now seems not possing any issues as recovery of primary
or failover to mirror will disconnect all existing connections but for
consistency its better to redo distributedlog commit as well during redo of
CommitPrepared.