### PR TITLE
Replay of AO XLOG records

### DIFF
--- a/src/backend/cdb/cdbmirroredappendonly.c
+++ b/src/backend/cdb/cdbmirroredappendonly.c
@@ -30,6 +30,7 @@
 #include "cdb/cdbpersistentrecovery.h"
 
 #ifdef USE_SEGWALREP
+#include "access/xlogutils.h"
 #include "cdb/cdbappendonlyam.h"
 
 
@@ -2400,10 +2401,8 @@ ao_xlog_insert(XLogRecord *record)
 	file = PathNameOpenFile(path, O_RDWR | PG_BINARY, 0600);
 	if (file < 0)
 	{
-		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("could not open file '%s': %m",
-						path)));
+		XLogAOSegmentFile(xlrec->node, xlrec->segment_filenum);
+		return;
 	}
 
 	seek_offset = FileSeek(file, xlrec->offset, SEEK_SET);

--- a/src/include/access/xlogutils.h
+++ b/src/include/access/xlogutils.h
@@ -26,4 +26,9 @@ extern void XLogTruncateRelation(RelFileNode rnode, BlockNumber nblocks);
 
 extern Buffer XLogReadBuffer(Relation reln, BlockNumber blkno, bool init);
 
+#ifdef USE_SEGWALREP
+extern void XLogAOSegmentFile(RelFileNode rnode, int segmentFileNum);
+extern void XLogAODropSegmentFile(RelFileNode rnode, int segmentFileNum);
+#endif
+
 #endif

--- a/src/include/cdb/cdbappendonlyam.h
+++ b/src/include/cdb/cdbappendonlyam.h
@@ -376,11 +376,11 @@ typedef struct xl_ao_insert
 	/* meta data about the inserted block of AO data*/
 	RelFileNode node;
 	uint		segment_filenum;
-	uint64		offset;
+	int64		offset;
 		/* BLOCK DATA FOLLOWS AT END OF STRUCT */
 } xl_ao_insert;
 
-#define SizeOfAOInsert (offsetof(xl_ao_insert, offset) + sizeof(uint64))
+#define SizeOfAOInsert (offsetof(xl_ao_insert, offset) + sizeof(int64))
 
 extern void appendonly_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record);
 extern void appendonly_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record);

--- a/src/include/cdb/cdbmirroredappendonly.h
+++ b/src/include/cdb/cdbmirroredappendonly.h
@@ -307,6 +307,9 @@ extern int MirroredAppendOnly_Read(
 	
 	int32					bufferLen);
 
+#ifdef USE_SEGWALREP
+extern void
+ao_xlog_insert(XLogRecord *record);
+#endif
+
 #endif   /* CDBMIRROREDAPPENDONLY_H */
-
-


### PR DESCRIPTION
We generate AO XLOG records when --enable-segwalrep is configured. We
should now replay those records on the mirror or during recovery.