### PR TITLE
Upgrade OpenSSL to 1.0.2l

### DIFF
--- a/gpAux/releng/make/dependencies/ivy.xml
+++ b/gpAux/releng/make/dependencies/ivy.xml
@@ -14,16 +14,17 @@
       <dependency org="apache"          name="apr"             rev="1.5.2"          conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64;suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64" />
       <dependency org="apache"          name="apr-util"        rev="1.2.12"         conf="rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64;suse11_x86_64->suse10_x86_64;sles11_x86_64->suse10_x86_64" />
       <dependency org="xerces"          name="xerces-c"        rev="3.1.1-p1"       conf="rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64;suse11_x86_64->suse10_x86_64;sles11_x86_64->suse10_x86_64" />
-      <dependency org="OpenSSL"         name="openssl"         rev="0.9.8zg"        conf="rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64;suse11_x86_64->suse10_x86_64;sles11_x86_64->suse10_x86_64" />
+      <dependency org="OpenSSL"         name="openssl"         rev="1.0.2l"         conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64;suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64" />
       <dependency org="emc"             name="DDBoostSDK"      rev="3.3.0.4-550644" conf="rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64" />
       <dependency org="gnu"             name="libstdc"         rev="6.0.22"         conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64;suse11_x86_64->suse11_x86_64;sles11_x86_64->suse11_x86_64" />
       <dependency org="third-party"     name="ext"             rev="1.1"            conf="win32->win32" />
-      <dependency org="third-party"     name="ext"             rev="gpdb5_ext-3.2"  conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64;suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64" />
+      <dependency org="third-party"     name="ext"             rev="gpdb5_ext-3.3"  conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64;suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64" />
       <dependency org="Hyperic"         name="sigar"           rev="1.6.5"          conf="rhel6_x86_64->rhel6_x86_64;rhel7_x86_64->rhel7_x86_64;suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64" />
       <dependency org="NetBackup"       name="SDK-7.7"         rev="7.7"            conf="rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64" />
       <dependency org="R-Project"       name="R"               rev="3.1.0"          conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64;suse11_x86_64->suse10_x86_64;sles11_x86_64->suse10_x86_64" />
       <dependency org="Python"          name="python"          rev="2.7.12"         conf="rhel6_x86_64->rhel6_x86_64;rhel7_x86_64->rhel6_x86_64;suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64" />
-      <dependency org="cURL"            name="curl"            rev="7.44.0"         conf="rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64;suse11_x86_64->suse10_x86_64;sles11_x86_64->suse10_x86_64" />
+      <dependency org="cURL"            name="curl"            rev="7.54.0"         conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64;suse11_x86_64->suse10_x86_64;sles11_x86_64->suse10_x86_64" />
       <dependency org="Samba"           name="ccache"          rev="3.2.3"          conf="rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64;suse11_x86_64->suse11_x86_64;sles11_x86_64->suse11_x86_64" />
+      <dependency org="OpenLDAP"        name="openldap"        rev="2.4.44"         conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64;suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64" />
     </dependencies>
 </ivy-module>


### PR DESCRIPTION
0.9.8 is EOL, 1.0+ version has many security and performance improvements.