### PR TITLE
Use block number instead of LSN to batch changed blocks in filerep

### DIFF
--- a/src/backend/cdb/cdbfilerepresyncmanager.c
+++ b/src/backend/cdb/cdbfilerepresyncmanager.c
@@ -1681,7 +1681,7 @@ FileRepPrimary_GetResyncEntry(ChangeTrackingRequest **request)
 			{
 				changedPageCount += entry->mirrorBufpoolResyncChangedPageCount;
 				
-				if (changedPageCount > CHANGETRACKING_MAX_RESULT_SIZE )
+				if (changedPageCount > gp_filerep_ct_batch_size )
 				{
 					if (NumberOfRelations == 0)
 					{
@@ -1754,7 +1754,7 @@ FileRepPrimary_GetResyncEntry(ChangeTrackingRequest **request)
 					 * If GetChanges() was called with more than 1 relfilenode/SN at a time AND it sees more than 
 					 * 64K changes it will be an internal error.
 					 */
-					if (entry->mirrorBufpoolResyncChangedPageCount > CHANGETRACKING_MAX_RESULT_SIZE)
+					if (entry->mirrorBufpoolResyncChangedPageCount > gp_filerep_ct_batch_size)
 					{
 						Assert(NumberOfRelations == 1);
 					}

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -303,6 +303,7 @@ int			gp_connection_send_timeout;
 int			gp_filerep_tcp_keepalives_idle;
 int			gp_filerep_tcp_keepalives_interval;
 int			gp_filerep_tcp_keepalives_count;
+int			gp_filerep_ct_batch_size;
 
 int			WalSendClientTimeout = 30000;		/* 30 seconds. */
 
@@ -3651,6 +3652,15 @@ struct config_int ConfigureNamesInt_gp[] =
 		2, 0, INT_MAX, NULL, NULL
 	},
 
+	{
+		{"gp_filerep_ct_batch_size", PGC_USERSET, GP_ARRAY_TUNING,
+			gettext_noop("Maximum number of blocks from changetracking log that"
+						 " a filerep resync worker processes at one time."),
+		 NULL,
+		},
+		&gp_filerep_ct_batch_size,
+		64 * 1024, 1, INT_MAX, NULL, NULL
+	},
 
 	{
 		{"max_resource_queues", PGC_POSTMASTER, RESOURCES_MGM,

--- a/src/include/cdb/cdbresynchronizechangetracking.h
+++ b/src/include/cdb/cdbresynchronizechangetracking.h
@@ -13,6 +13,7 @@
 #include "access/xlog.h"
 #include "access/xlogdefs.h"
 #include "storage/relfilenode.h"
+#include "utils/guc.h"
 #include "utils/pg_crc.h"
 
 #define CHANGETRACKINGDIR  "pg_changetracking"
@@ -20,7 +21,6 @@
 #define CHANGETRACKING_BLCKSZ BLCKSZ
 #define	CHANGETRACKING_XLOGDATASZ (128 * 1024)
 #define CHANGETRACKING_METABUFLEN 128
-#define CHANGETRACKING_MAX_RESULT_SIZE (64 * 1024)
 #define CHANGETRACKING_COMPACT_THRESHOLD (1 * 1024 * 1024 * 1024) /* 1GB */
 
 /*

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -362,6 +362,7 @@ extern int	gp_connection_send_timeout;
 extern int	gp_filerep_tcp_keepalives_idle;
 extern int	gp_filerep_tcp_keepalives_interval;
 extern int	gp_filerep_tcp_keepalives_count;
+extern int	gp_filerep_ct_batch_size;
 
 extern int  WalSendClientTimeout;
 

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/fts/fts_transitions/expected/change_blocks_in_ct.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/fts/fts_transitions/expected/change_blocks_in_ct.ans
@@ -1,0 +1,33 @@
+-- This file should be run when primary is in changetracking.  Number
+-- of blocks changed should be greater than gp_filerep_ct_batch_size.
+show gp_filerep_ct_batch_size;
+ gp_filerep_ct_batch_size 
+--------------------------
+ 3
+(1 row)
+
+-- Change blocks of resync_bug_table in a particular order such that a
+-- higher numbered block has lower LSN.  Schema of resync_bug_table is
+-- such that one block accommodates 901 tuples.  Leverage this to
+-- identify a block.  Change Block 4 first so that it has lower LSN
+-- than blocks 0, 1, 2.
+delete from resync_bug_table where a = 1 and b = 901*5;
+DELETE 1
+-- Block 0
+delete from resync_bug_table where a = 1 and b = 901;
+DELETE 1
+-- Block 1
+delete from resync_bug_table where a = 1 and b = 901*2;
+DELETE 1
+-- Block 2
+delete from resync_bug_table where a = 1 and b = 901*3;
+DELETE 1
+-- Block 3
+delete from resync_bug_table where a = 1 and b = 901*4;
+DELETE 1
+select * from resync_bug_table where a = 1 and
+ b in (901, 901*2, 901*3, 901*4, 901*5);
+ a | b 
+---+---
+(0 rows)
+

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/fts/fts_transitions/expected/resync_bug_setup.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/fts/fts_transitions/expected/resync_bug_setup.ans
@@ -1,0 +1,13 @@
+-- Create table and insert data while cluster is in-sync.
+drop table if exists resync_bug_table;
+DROP TABLE
+create table resync_bug_table(a int, b int) distributed by (a);
+CREATE TABLE
+-- Insert tuples on a single statement.  Insert enough tuples to
+-- occupy 5 blocks on that segment.  About 901 tuples having this
+-- schema can be accommodated on one block.
+insert into resync_bug_table select 1 ,i from generate_series(1,5000)i;
+INSERT 0 5000
+-- Checkpoint isn't really necessary but doesn't harm either.
+checkpoint;
+CHECKPOINT

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/fts/fts_transitions/expected/select_after_rebalance.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/fts/fts_transitions/expected/select_after_rebalance.ans
@@ -1,0 +1,6 @@
+select * from resync_bug_table where a = 1 and
+ b in (901, 901*2, 901*3, 901*4, 901*5);
+ a | b   
+---+---
+(0 rows)
+

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/fts/fts_transitions/sql/change_blocks_in_ct.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/fts/fts_transitions/sql/change_blocks_in_ct.sql
@@ -1,0 +1,21 @@
+-- This file should be run when primary is in changetracking.  Number
+-- of blocks changed should be greater than gp_filerep_ct_batch_size.
+show gp_filerep_ct_batch_size;
+
+-- Change blocks of resync_bug_table in a particular order such that a
+-- higher numbered block has lower LSN.  Schema of resync_bug_table is
+-- such that one block accommodates 901 tuples.  Leverage this to
+-- identify a block.  Change Block 4 first so that it has lower LSN
+-- than blocks 0, 1, 2.
+delete from resync_bug_table where a = 1 and b = 901*5;
+-- Block 0
+delete from resync_bug_table where a = 1 and b = 901;
+-- Block 1
+delete from resync_bug_table where a = 1 and b = 901*2;
+-- Block 2
+delete from resync_bug_table where a = 1 and b = 901*3;
+-- Block 3
+delete from resync_bug_table where a = 1 and b = 901*4;
+
+select * from resync_bug_table where a = 1 and
+ b in (901, 901*2, 901*3, 901*4, 901*5);

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/fts/fts_transitions/sql/ct_log_contents.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/fts/fts_transitions/sql/ct_log_contents.sql
@@ -1,0 +1,12 @@
+-- This file is only to help debugging, in case the test fails.  It
+-- should be executed in utility mode on the segment that is in
+-- changetracking.
+
+-- Flush CT log to disk
+checkpoint;
+
+select * from gp_changetracking_log(0) where rel =
+(select relfilenode from pg_class where relname = 'resync_bug_table')
+and
+db = (select oid from pg_database where datname = current_database())
+order by xlogloc;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/fts/fts_transitions/sql/resync_bug_setup.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/fts/fts_transitions/sql/resync_bug_setup.sql
@@ -1,0 +1,9 @@
+-- Create table and insert data while cluster is in-sync.
+drop table if exists resync_bug_table;
+create table resync_bug_table(a int, b int) distributed by (a);
+-- Insert tuples on a single statement.  Insert enough tuples to
+-- occupy 5 blocks on that segment.  About 901 tuples having this
+-- schema can be accommodated on one block.
+insert into resync_bug_table select 1 ,i from generate_series(1,5000)i;
+-- Checkpoint isn't really necessary but doesn't harm either.
+checkpoint;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/fts/fts_transitions/sql/select_after_rebalance.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/fts/fts_transitions/sql/select_after_rebalance.sql
@@ -1,0 +1,2 @@
+select * from resync_bug_table where a = 1 and
+ b in (901, 901*2, 901*3, 901*4, 901*5);

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/fts/fts_transitions/test_fts_transitions_03.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/fts/fts_transitions/test_fts_transitions_03.py
@@ -16,8 +16,112 @@ limitations under the License.
 """
 
 import os
+from gppylib.commands.base import Command
 import tinctest
+from tinctest.lib import Gpdiff, local_path
 from mpp.gpdb.tests.storage.fts.fts_transitions.fts_transitions import FTSTestCase
+from mpp.lib.config import GPDBConfig
+from mpp.lib.filerep_util import Filerepe2e_Util
+from mpp.lib.gprecoverseg import GpRecover
+from mpp.lib.PSQL import PSQL
+from mpp.models import MPPTestCase
+
+class ResyncBug(MPPTestCase):
+
+    def __init__(self, methodName):
+        super(ResyncBug, self).__init__(methodName)
+
+    def run_sql(self, filename):
+        sql_file = local_path('sql/%s.sql' % filename)
+        ans_file = local_path('expected/%s.ans' % filename)
+        out_file = local_path('output/%s.out' % filename)
+        assert PSQL.run_sql_file(sql_file, out_file), sql_file
+        assert Gpdiff.are_files_equal(out_file, ans_file), out_file
+
+    def test_resync_ct_blocks_per_query(self):
+        '''Catch a bug in resync that manifests only after rebalance.
+        The logic used by a resync worker to obtain changed blocks
+        from CT log had a bug.  The SQL query used to obtain a batch
+        of changed blocks from CT log was incorrectly using LSN to
+        filter out changed blocks.  All of the following must be true
+        for the bug to occur:
+
+         * More than gp_filerep_ct_batch_size blocks of a relation
+           are changed on a segment in changetracking.
+
+         * A block with a higher number is changed earlier (lower
+           LSN) than lower numbered blocks.
+
+         * The first batch of changed blocks obtained by resync worker
+           from CT log for this relation contains only lower
+           (according to block number) blocks.  The higher block with
+           lower LSN is not included in this batch.  Another query
+           must be run against CT log to obtain this block.
+
+         * The SQL query used to obtain next batch of changed blocks
+           for this relation contains incorrect WHERE clause involving
+           a filter based on LSN of previously obtained blocks.  The
+           higher numbered block is missed out - not returned by the
+           query as changed block for the relation.  The block is
+           never shipped from primary to mirror, resulting in data
+           loss.  The test aims to verify that this doesn't happen as
+           the bug is now fixed.
+        '''
+        config = GPDBConfig()
+        assert (config.is_not_insync_segments() &
+                config.is_balanced_segments()), 'cluster not in-sync and balanced'
+
+        # Create table and insert data so that adequate number of
+        # blocks are occupied.
+        self.run_sql('resync_bug_setup')
+        # Bring down primaries and transition mirrors to
+        # changetracking.
+        filerep = Filerepe2e_Util()
+        filerep.inject_fault(y='fault', f='segment_probe_response',
+                             r='primary')
+        # Trigger the fault by running a sql file.
+        PSQL.run_sql_file(local_path('test_ddl.sql'))
+        filerep.wait_till_change_tracking_transition()
+
+        # Set gp_filerep_ct_batch_size = 3.
+        cmd = Command('reduce resync batch size',
+                      'gpconfig -c gp_filerep_ct_batch_size -v 3')
+        cmd.run()
+        assert cmd.get_results().rc == 0, 'gpconfig failed'
+        cmd = Command('load updated config', 'gpstop -au')
+        cmd.run()
+        assert cmd.get_results().rc == 0, '"gpstop -au" failed'
+
+        self.run_sql('change_blocks_in_ct')
+
+        # Capture change tracking log contents from the segment of
+        # interest for debugging, in case the test fails.
+        (host, port) = GPDBConfig().get_hostandport_of_segment(0, 'p')
+        assert PSQL.run_sql_file_utility_mode(
+            sql_file=local_path('sql/ct_log_contents.sql'),
+            out_file=local_path('output/ct_log_contents.out'),
+            host=host, port=port), sql_file
+
+        gprecover = GpRecover(GPDBConfig())
+        gprecover.incremental(False)
+        gprecover.wait_till_insync_transition()
+
+        # Rebalance, so that original primary is back in the role
+        gprecover = GpRecover(GPDBConfig())
+        gprecover.rebalance()
+        gprecover.wait_till_insync_transition()
+
+        # Reset gp_filerep_ct_batch_size
+        cmd = Command('reset resync batch size',
+                      'gpconfig -r gp_filerep_ct_batch_size')
+        cmd.run()
+        assert cmd.get_results().rc == 0, 'gpconfig failed'
+        cmd = Command('load updated config', 'gpstop -au')
+        cmd.run()
+        assert cmd.get_results().rc == 0, '"gpstop -au" failed'
+
+        self.run_sql('select_after_rebalance')
+
 
 class FtsTransitionsPart03(FTSTestCase):
     ''' State of FTS at different fault points
@@ -25,7 +129,7 @@ class FtsTransitionsPart03(FTSTestCase):
     
     def __init__(self, methodName):
         super(FtsTransitionsPart03,self).__init__(methodName)
-    
+
     def test_primary_resync_postmaster_reset_with_faults(self):
         '''
         @data_provider pr_faults


### PR DESCRIPTION
Filerep resync logic to fetch changed blocks from changetracking (CT)
log is changed.  LSN is no longer used to filter out blocks from CT
log.  If a relation's changed blocks falls above the threshold number
of blocks that can be fetched at a time, the last fetched block number
is remembered and used to form subsequent batch.