### PR TITLE
gppkg: Enhance gppkg --migrate & fix exception reporting to user

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -662,7 +662,8 @@ jobs:
     file: gpdb_src/concourse/tasks/behave_gpdb.yml
     image: centos-gpdb-dev-6
     params:
-      BEHAVE_TAGS: gppkg
+      # Disable multinode tests for concourse.
+      BEHAVE_FLAGS: --tags=gppkg --tags=-gppkg_multinode_clean
 
 - name: MM_pt-rebuild
   plan:

--- a/concourse/scripts/behave_gpdb.bash
+++ b/concourse/scripts/behave_gpdb.bash
@@ -8,12 +8,18 @@ source "${CWDIR}/common.bash"
 function gen_env(){
   cat > /opt/run_test.sh <<-EOF
 
+		BEHAVE_TAGS="${BEHAVE_TAGS}"
+		BEHAVE_FLAGS="${BEHAVE_FLAGS}"
+
 		source /usr/local/greenplum-db-devel/greenplum_path.sh
 		cd "\${1}/gpdb_src/gpAux"
 		source gpdemo/gpdemo-env.sh
 		cd "\${1}/gpdb_src/gpMgmt/"
-		# Does this report failures?
-		make -f Makefile.behave behave tags=${BEHAVE_TAGS}
+		if [ ! -z "\${BEHAVE_TAGS}" ]; then
+		    make -f Makefile.behave behave tags=\${BEHAVE_TAGS}
+		else
+		    flags="\${BEHAVE_FLAGS}" make -f Makefile.behave behave
+		fi
 	EOF
 
 	chmod a+x /opt/run_test.sh
@@ -55,8 +61,8 @@ function gpcheck_setup() {
 
 function _main() {
 
-    if [ -z "${BEHAVE_TAGS}" ]; then
-        echo "FATAL: BEHAVE_TAGS is not set"
+    if [ -z "${BEHAVE_TAGS}" ] && [ -z "${BEHAVE_FLAGS}" ]; then
+        echo "FATAL: BEHAVE_TAGS or BEHAVE_FLAGS not set"
         exit 1
     fi
 

--- a/concourse/tasks/behave_gpdb.yml
+++ b/concourse/tasks/behave_gpdb.yml
@@ -7,6 +7,7 @@ inputs:
 outputs:
 params:
   BEHAVE_TAGS: ""
+  BEHAVE_FLAGS: ""
   BLDWRAP_POSTGRES_CONF_ADDONS: ""
   GPCHECK_SETUP: false
 run:

--- a/gpMgmt/bin/gppylib/operations/package.py
+++ b/gpMgmt/bin/gppylib/operations/package.py
@@ -1242,8 +1242,11 @@ class MigratePackages(Operation):
     are actually compatible with the target GPDB.
     """
 
-    def __init__(self, from_gphome, to_gphome):
-        self.from_gphome, self.to_gphome = from_gphome, to_gphome
+    def __init__(self, from_gphome, to_gphome, standby_host, segment_host_list):
+        self.from_gphome = from_gphome
+        self.to_gphome = to_gphome
+        self.standby_host = standby_host
+        self.segment_host_list = segment_host_list
 
     def execute(self):
         if not os.path.samefile(self.to_gphome, GPHOME):
@@ -1271,6 +1274,9 @@ class MigratePackages(Operation):
                 logger.info("%s is already installed." % package)
             except Exception:
                 logger.exception("Failed to migrate %s from %s" % (old_archive_path, package))
+
+        CleanGppkg(self.standby_host, self.segment_host_list).run()
+
         logger.info('The package migration has completed.')
 
 

--- a/gpMgmt/bin/gppylib/operations/package.py
+++ b/gpMgmt/bin/gppylib/operations/package.py
@@ -1221,11 +1221,16 @@ class CleanGppkg(Operation):
 
         ParallelOperation(operations).run()
 
+        err_msgs = 'SyncPackages failed:'
+        exceptions = ""
         for operation in operations:
             try:
                 operation.get_ret()
             except Exception, e:
-                raise ExceptionNoStackTraceNeeded('SyncPackages failed' + str(e))
+                exceptions += '\n'+str(e)
+
+        if exceptions:
+            raise ExceptionNoStackTraceNeeded("%s%s" % (err_msgs, exceptions))
 
         logger.info('Successfully cleaned the cluster')
 

--- a/gpMgmt/bin/gppylib/programs/gppkg.py
+++ b/gpMgmt/bin/gppylib/programs/gppkg.py
@@ -191,11 +191,6 @@ class GpPkgProgram:
             if len(results) != 0 and 'not found' in results:
                 raise ExceptionNoStackTraceNeeded('gppkg requires RPM to be available in PATH')
 
-        if self.migrate:
-            MigratePackages(from_gphome = self.migrate[0],
-                            to_gphome = self.migrate[1]).run()
-            return
-
         # MASTER_DATA_DIRECTORY and PGPORT must not need to be set for
         # --build and --migrate to function properly
         if self.master_datadir is None:
@@ -204,6 +199,14 @@ class GpPkgProgram:
 
         # TODO: AK: Program logic should not drive host decisions.
         self._get_gpdb_host_list()
+
+        if self.migrate:
+            MigratePackages(from_gphome = self.migrate[0],
+                            to_gphome = self.migrate[1],
+                            standby_host = self.standby_host,
+                            segment_host_list = self.segment_host_list
+                            ).run()
+            return
 
         if self.install:
             pkg = Gppkg.from_package_path(self.install)

--- a/gpMgmt/bin/gppylib/programs/gppkg.py
+++ b/gpMgmt/bin/gppylib/programs/gppkg.py
@@ -115,7 +115,7 @@ class GpPkgProgram:
 
     def _get_gpdb_host_list(self):
         """
-        TODO: AK: Get rid of this. Program logic should not be driving host list building .
+        TODO: Perhaps the host list should be produced by gparray instead of here.
 
             This method gets the host names
             of all hosts in the gpdb array.
@@ -127,7 +127,6 @@ class GpPkgProgram:
 
         logger.debug('_get_gpdb_host_list')
 
-        #Get host list
         gparr = GpArray.initFromCatalog(dbconn.DbURL(port = self.master_port), utility = True)
         master_host = None
         standby_host = None
@@ -143,13 +142,13 @@ class GpPkgProgram:
             else:
                 segment_host_list.append(seg.getSegmentHostName())
 
-        #Deduplicate the hosts so that we
-        #dont install multiple times on the same host
+        # Deduplicate the hosts so that we
+        # dont install multiple times on the same host
         segment_host_list = list(set(segment_host_list))
 
-        #Segments might exist on the master host. Since we store the
-        #master host separately in self.master_host, storing the master_host
-        #in the segment_host_list is redundant.
+        # Segments might exist on the master host. Since we store the
+        # master host separately in self.master_host, storing the master_host
+        # in the segment_host_list is redundant.
         for host in segment_host_list:
             if host == master_host or host == standby_host:
                 segment_host_list.remove(host)
@@ -191,13 +190,10 @@ class GpPkgProgram:
             if len(results) != 0 and 'not found' in results:
                 raise ExceptionNoStackTraceNeeded('gppkg requires RPM to be available in PATH')
 
-        # MASTER_DATA_DIRECTORY and PGPORT must not need to be set for
-        # --build and --migrate to function properly
         if self.master_datadir is None:
             self.master_datadir = gp.get_masterdatadir()
         self.master_port = self._get_master_port(self.master_datadir)
 
-        # TODO: AK: Program logic should not drive host decisions.
         self._get_gpdb_host_list()
 
         if self.migrate:

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_package.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_package.py
@@ -1,6 +1,11 @@
 from mock import *
 from gp_unittest import *
-from gppylib.operations.package import IsVersionCompatible, ListPackages
+from gppylib.operations.package import IsVersionCompatible, ListPackages, MigratePackages, AlreadyInstalledError, \
+    ARCHIVE_PATH, GPPKG_ARCHIVE_PATH, SyncPackages, CleanGppkg
+from gppylib.mainUtils import ExceptionNoStackTraceNeeded
+
+import os
+import pickle
 
 
 class IsVersionCompatibleTestCase(GpTestCase):
@@ -79,6 +84,167 @@ class ListPackagesTestCase(GpTestCase):
         self.mock_list_files_by_pattern_run.return_value = ['sample']
         with self.assertRaisesRegexp(Exception, "unable to parse sample as a gppkg"):
             package_name_list = self.subject.execute()
+
+
+class MigratePackagesTestCase(GpTestCase):
+    def setUp(self):
+        self.apply_patches([
+            patch('os.path.samefile'),
+            patch('os.makedirs'),
+            patch('os.listdir'),
+            patch('gppylib.operations.package.InstallPackageLocally'),
+            patch('gppylib.operations.package.CleanGppkg'),
+            patch('gppylib.operations.package.logger', return_value=Mock(spec=['log', 'info', 'debug', 'error'])),
+        ])
+
+        self.mock_install_package_locally = self.get_mock_from_apply_patch('InstallPackageLocally')
+        self.mock_listdir = self.get_mock_from_apply_patch('listdir')
+        self.mock_logger = self.get_mock_from_apply_patch('logger')
+        self.os_path_samefile = self.get_mock_from_apply_patch('samefile')
+        self.os_path_samefile.return_value = True
+
+        self.args = dict(from_gphome="/from/GPHOME",
+                         to_gphome="/to/gphome",
+                         standby_host="standbyhost",
+                         segment_host_list=["remotehost"])
+
+    def test__execute_target_gphome_mismatch_raises(self):
+        self.os_path_samefile.return_value = False
+        self.args['to_gphome'] = '/wrong/gphome'
+        subject = MigratePackages(**self.args)
+
+        expected_raise = "The target GPHOME, %s, must match the current \$GPHOME used to launch gppkg." % self.args['to_gphome']
+        with self.assertRaisesRegexp(ExceptionNoStackTraceNeeded, expected_raise):
+            subject.execute()
+
+    def test__execute_identical_source_target_raises(self):
+        self.args['to_gphome'] = '/from/gphome'
+        subject = MigratePackages(**self.args)
+
+        expected_raise = "The source and target GPHOMEs, %s => %s, must differ for packages to be migrated." % (self.args['from_gphome'], self.args['to_gphome'])
+        with self.assertRaisesRegexp(ExceptionNoStackTraceNeeded, expected_raise):
+            subject.execute()
+
+    def test__execute_finds_no_packages(self):
+        self.os_path_samefile.side_effect = [True, False]
+        subject = MigratePackages(**self.args)
+        subject.execute()
+        self.mock_logger.info.assert_called_with('There are no packages to migrate from %s.' % self.args['from_gphome'])
+
+    def test__execute_finds_some_packages(self):
+        self.os_path_samefile.side_effect = [True, False]
+        self.mock_listdir.return_value = ['sample.gppkg', 'sample2.gppkg', 'another-long-one.gppkg']
+
+        subject = MigratePackages(**self.args)
+        subject.execute()
+
+        log_messages = [args[1][0] for args in self.mock_logger.method_calls]
+        self.assertIn('The following packages will be migrated: %s' % ", ".join(self.mock_listdir.return_value), log_messages)
+        self.assertIn('The package migration has completed.', log_messages)
+
+    def test__execute_catches_AlreadyInstalledError(self):
+        self.os_path_samefile.side_effect = [True, False]
+        self.mock_listdir.return_value = ['sample.gppkg', 'sample2.gppkg', 'another-long-one.gppkg']
+        self.mock_install_package_locally.return_value.run.side_effect = AlreadyInstalledError("sample.gppkg")
+
+        subject = MigratePackages(**self.args)
+        subject.execute()
+        log_messages = [args[1][0] for args in self.mock_logger.method_calls]
+        self.assertIn('The following packages will be migrated: %s' % ", ".join(self.mock_listdir.return_value), log_messages)
+        self.assertIn('sample.gppkg is already installed.', log_messages)
+        self.assertIn('The package migration has completed.', log_messages)
+
+    def test__execute_catches_Exception_failed_to_migrate(self):
+        self.os_path_samefile.side_effect = [True, False]
+        self.mock_listdir.return_value = ['sample.gppkg', 'sample2.gppkg', 'another-long-one.gppkg']
+
+        # Let's make the second package fail/raise an exception
+        self.mock_install_package_locally.return_value.run.side_effect = [None, Exception("foobar something bad"), None]
+
+        subject = MigratePackages(**self.args)
+        subject.execute()
+        log_messages = [args[1][0] for args in self.mock_logger.method_calls]
+        self.assertIn('The following packages will be migrated: %s' % ", ".join(self.mock_listdir.return_value), log_messages)
+        self.assertIn('Failed to migrate %s from %s' % (os.path.join(self.args['from_gphome'], ARCHIVE_PATH),
+                                                        self.mock_listdir.return_value[1]), log_messages)
+        self.assertIn('The package migration has completed.', log_messages)
+
+class SyncPackagesTestCase(GpTestCase):
+    def setUp(self):
+        self.apply_patches([
+            patch('gppylib.operations.package.CheckDir'),
+            patch('gppylib.operations.package.MakeDir'),
+            patch('gppylib.operations.package.CheckRemoteDir'),
+            patch('gppylib.operations.package.MakeRemoteDir'),
+            patch('gppylib.operations.package.Scp'),
+            patch('gppylib.operations.package.RemoteOperation'),
+            patch('gppylib.operations.package.RemoveRemoteFile'),
+            patch('gppylib.operations.package.InstallPackageLocally'),
+            patch('os.listdir'),
+            patch('gppylib.operations.unix.Command'),
+            patch('gppylib.operations.package.logger', return_value=Mock(spec=['log', 'info', 'debug', 'error'])),
+        ])
+
+        self.check_dir_mock = self.get_mock_from_apply_patch('CheckDir')
+        self.make_dir_mock = self.get_mock_from_apply_patch('MakeDir')
+        self.check_remote_dir_mock = self.get_mock_from_apply_patch('CheckRemoteDir')
+        self.make_remote_dir_mock = self.get_mock_from_apply_patch('MakeRemoteDir')
+        self.mock_listdir = self.get_mock_from_apply_patch('listdir')
+        self.mock_command = self.get_mock_from_apply_patch('Command')
+        self.mock_logger = self.get_mock_from_apply_patch('logger')
+        self.mock_scp = self.get_mock_from_apply_patch('Scp')
+        self.mock_install_packages_locally = self.get_mock_from_apply_patch('InstallPackageLocally')
+
+
+    def test__execute_succeeds_when_local_and_remote_match(self):
+        self.check_dir_mock.return_value.run.return_value = False
+        self.check_remote_dir_mock.return_value.run.return_value = False
+        self.make_dir_mock.return_value.run.return_value = None
+        self.mock_listdir.return_value = ['synced.gppkg']
+        self.mock_command.return_value.get_results.return_value.stdout = pickle.dumps(['synced.gppkg'])
+
+        subject = SyncPackages('localhost')
+        subject.execute()
+        self.assertEqual(self.make_dir_mock.call_count, 1)
+        self.assertEqual(self.make_remote_dir_mock.call_count, 1)
+
+        log_messages = [args[1][0] for args in self.mock_logger.method_calls]
+        self.assertIn('The packages on localhost are consistent.', log_messages)
+
+    def test__execute_install_on_segments_when_package_are_missing(self):
+        self.check_dir_mock.return_value.run.return_value = False
+        self.check_remote_dir_mock.return_value.run.return_value = False
+        self.make_dir_mock.return_value.run.return_value = None
+        self.mock_listdir.return_value = ['foo.gppkg', 'bar.gppkg', 'zing.gppkg']
+        self.mock_command.return_value.get_results.return_value.stdout = pickle.dumps(['foo.gppkg'])
+
+        hostname = 'localhost'
+        subject = SyncPackages(hostname)
+        subject.execute()
+        self.assertEqual(self.mock_scp.call_count, 2)
+        self.assertEqual(self.make_dir_mock.call_count, 1)
+        self.assertEqual(self.make_remote_dir_mock.call_count, 1)
+
+        log_messages = [args[1][0] for args in self.mock_logger.method_calls]
+        self.assertNotIn('The packages on %s are consistent.' % hostname, log_messages)
+
+    def test__execute_uninstall_on_segments_when_package_is_missing_on_master(self):
+        self.check_dir_mock.return_value.run.return_value = False
+        self.check_remote_dir_mock.return_value.run.return_value = False
+        self.make_dir_mock.return_value.run.return_value = None
+        self.mock_listdir.return_value = ['ba.gppkg']
+        self.mock_command.return_value.get_results.return_value.stdout = pickle.dumps(['ba.gppkg',
+                                                                                       'zing.gppkg',
+                                                                                       'ga.gppkg'])
+        hostname = 'localhost'
+        subject = SyncPackages(hostname)
+        subject.execute()
+        self.assertEqual(self.make_dir_mock.call_count, 1)
+        self.assertEqual(self.make_remote_dir_mock.call_count, 1)
+
+        log_messages = [args[1][0] for args in self.mock_logger.method_calls]
+        self.assertIn('The following packages will be uninstalled on localhost: zing.gppkg, ga.gppkg', log_messages)
+        self.assertNotIn('The packages on %s are consistent.' % hostname, log_messages)
 
 
 if __name__ == '__main__':

--- a/gpMgmt/test/behave/mgmt_utils/gppkg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gppkg.feature
@@ -73,7 +73,7 @@ Feature: gppkg tests
         And gppkg should print "Uninstalling package sample.gppkg" to stdout
         And gppkg should print "Completed local uninstallation of sample.gppkg" to stdout
         And gppkg should print "sample.gppkg successfully uninstalled" to stdout
-        And "sample" gppkg files does not exist on all hosts
+        And "sample" gppkg files do not exist on any hosts
 
     @gppkg_install_remove
     Scenario: gppkg --remove should report failure when the package is not installed
@@ -94,7 +94,7 @@ Feature: gppkg tests
         And gppkg should print "sample" to stdout
 
     @gppkg_multinode_clean
-    Scenario: gppkg --clean should install to the segment host with no gppkg
+    Scenario: gppkg --clean (which should be named "sync") should install to the segment host that lacks a gppkg found elsewhere
         Given the database is running
         When the user runs "gppkg --install test/behave/mgmt_utils/steps/data/sample.gppkg"
         And gppkg "sample" is removed from a segment host
@@ -104,11 +104,11 @@ Feature: gppkg tests
         And "sample" gppkg files exist on all hosts
 
     @gppkg_multinode_clean
-    Scenario: gppkg --clean should remove on all segment hosts when gppkg does not exist in master
+    Scenario: gppkg --clean (which should be named "sync") should remove on all segment hosts when gppkg does not exist in master
         Given the database is running
         When the user runs "gppkg --install test/behave/mgmt_utils/steps/data/sample.gppkg"
         And gppkg "sample" is removed from master host
         And the user runs "gppkg --clean"
         Then gppkg should return a return code of 0
         And gppkg should print "The following packages will be uninstalled on .*: sample.gppkg" to stdout
-        And "sample" gppkg files does not exist on all hosts
+        And "sample" gppkg files do not exist on any hosts

--- a/gpMgmt/test/behave/mgmt_utils/gppkg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gppkg.feature
@@ -56,6 +56,7 @@ Feature: gppkg tests
         Then gppkg should return a return code of 0
         And gppkg should print "This is a sample message shown after successful installation" to stdout
         And gppkg should print "Completed local installation of sample" to stdout
+        And "sample" gppkg files exist on all segment hosts
 
     @gppkg_install_remove
     Scenario: gppkg --install should report failure because the package is already installed
@@ -72,6 +73,7 @@ Feature: gppkg tests
         And gppkg should print "Uninstalling package sample.gppkg" to stdout
         And gppkg should print "Completed local uninstallation of sample.gppkg" to stdout
         And gppkg should print "sample.gppkg successfully uninstalled" to stdout
+        And "sample" gppkg files does not exist on all segment hosts
 
     @gppkg_install_remove
     Scenario: gppkg --remove should report failure when the package is not installed

--- a/gpMgmt/test/behave/mgmt_utils/gppkg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gppkg.feature
@@ -56,7 +56,7 @@ Feature: gppkg tests
         Then gppkg should return a return code of 0
         And gppkg should print "This is a sample message shown after successful installation" to stdout
         And gppkg should print "Completed local installation of sample" to stdout
-        And "sample" gppkg files exist on all segment hosts
+        And "sample" gppkg files exist on all hosts
 
     @gppkg_install_remove
     Scenario: gppkg --install should report failure because the package is already installed
@@ -73,7 +73,7 @@ Feature: gppkg tests
         And gppkg should print "Uninstalling package sample.gppkg" to stdout
         And gppkg should print "Completed local uninstallation of sample.gppkg" to stdout
         And gppkg should print "sample.gppkg successfully uninstalled" to stdout
-        And "sample" gppkg files does not exist on all segment hosts
+        And "sample" gppkg files does not exist on all hosts
 
     @gppkg_install_remove
     Scenario: gppkg --remove should report failure when the package is not installed
@@ -92,3 +92,23 @@ Feature: gppkg tests
         Then gppkg should return a return code of 0
         And gppkg should print "Starting gppkg with args: --query --all" to stdout
         And gppkg should print "sample" to stdout
+
+    @gppkg_multinode_clean
+    Scenario: gppkg --clean should install to the segment host with no gppkg
+        Given the database is running
+        When the user runs "gppkg --install test/behave/mgmt_utils/steps/data/sample.gppkg"
+        And gppkg "sample" is removed from a segment host
+        And the user runs "gppkg --clean"
+        Then gppkg should return a return code of 0
+        And gppkg should print "The following packages will be installed on .*: sample.gppkg" to stdout
+        And "sample" gppkg files exist on all hosts
+
+    @gppkg_multinode_clean
+    Scenario: gppkg --clean should remove on all segment hosts when gppkg does not exist in master
+        Given the database is running
+        When the user runs "gppkg --install test/behave/mgmt_utils/steps/data/sample.gppkg"
+        And gppkg "sample" is removed from master host
+        And the user runs "gppkg --clean"
+        Then gppkg should return a return code of 0
+        And gppkg should print "The following packages will be uninstalled on .*: sample.gppkg" to stdout
+        And "sample" gppkg files does not exist on all hosts

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -5113,3 +5113,43 @@ def impl(context):
     run_gpcommand(context, command)
     if not context.exception:
         raise Exception("Directory for date %s still exists" % context.full_backup_timestamp[0:8])
+
+@then('"{gppkg_name}" gppkg files exist on all segment hosts')
+def impl(context, gppkg_name):
+    remote_gphome = os.environ.get('GPHOME')
+    gparray = GpArray.initFromCatalog(dbconn.DbURL())
+
+    hostlist = get_all_hostnames_as_list(context, 'template1')
+
+    #We can assume the GPDB is installed at the same location for all hosts
+    rpm_command_list_all = 'rpm -qa --dbpath %s/share/packages/database' % remote_gphome
+
+    for hostname in set(hostlist):
+        cmd = Command(name='check if internal rpm gppkg is installed',
+                      cmdStr=rpm_command_list_all,
+                      ctxt=REMOTE,
+                      remoteHost=hostname)
+        cmd.run(validateAfter=True)
+
+        if not gppkg_name in cmd.get_stdout():
+            raise Exception( '"%s" gppkg is not installed on host: %s. \nInstalled packages: %s' % (gppkg_name, hostname, cmd.get_stdout()))
+
+@then('"{gppkg_name}" gppkg files does not exist on all segment hosts')
+def impl(context, gppkg_name):
+    remote_gphome = os.environ.get('GPHOME')
+    gparray = GpArray.initFromCatalog(dbconn.DbURL())
+
+    hostlist = get_all_hostnames_as_list(context, 'template1')
+
+    #We can assume the GPDB is installed at the same location for all hosts
+    rpm_command_list_all = 'rpm -qa --dbpath %s/share/packages/database' % remote_gphome
+
+    for hostname in set(hostlist):
+        cmd = Command(name='check if internal rpm gppkg is installed',
+                      cmdStr=rpm_command_list_all,
+                      ctxt=REMOTE,
+                      remoteHost=hostname)
+        cmd.run(validateAfter=True)
+
+        if gppkg_name in cmd.get_stdout():
+            raise Exception( '"%s" gppkg is installed on host: %s. \nInstalled packages: %s' % (gppkg_name, hostname, cmd.get_stdout()))

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -5134,7 +5134,7 @@ def impl(context, gppkg_name):
         if not gppkg_name in cmd.get_stdout():
             raise Exception( '"%s" gppkg is not installed on host: %s. \nInstalled packages: %s' % (gppkg_name, hostname, cmd.get_stdout()))
 
-@then('"{gppkg_name}" gppkg files does not exist on all hosts')
+@then('"{gppkg_name}" gppkg files do not exist on any hosts')
 def impl(context, gppkg_name):
     remote_gphome = os.environ.get('GPHOME')
     hostlist = get_all_hostnames_as_list(context, 'template1')


### PR DESCRIPTION
Ensure that gppkg is doing an RPM to all hosts -- this is just a
backfill testing addition.


===========================================
Currently, doing a gppkg --migrate will migrate the gppkgs from one
gphome to another. However, this is not done on the segment hosts as
well. So when a user tries to run a gppkg installed sql function, it
will break.

Fix: sync up the migrated packages from the master gphome to all segments


=========================================
If you have multiple segment hosts with failures during a "sync", we
used to only report the first issue.

Fix: accumulate all the failures before reporting to the user.
Add unit test



====================
Change pipeline to only run the single node tests for behave gppkg
This won't be permanent thing since we're currently working on making gppkg use terraform for gpdb5. The current single node job will be replaced.

We're introducing the BEHAVE_FLAGS argument into the pipeline.yml, this makes it so that you can be more flexible with your behave tagging.
`--tags=gppkg --tags=-gppkg_multinode_clean` this can't be done with our typical behave tag argument.
The behave flags was introduced a while back, but couldn't not be used by the top level pipeline.
