### PR TITLE
Error out when self-ref set operation in recursive term

### DIFF
--- a/src/backend/parser/parse_cte.c
+++ b/src/backend/parser/parse_cte.c
@@ -698,6 +698,58 @@ checkWellFormedRecursion(CteState *cstate)
 }
 
 /*
+ * Check that a child of a set operation in the recursive term does not contain
+ * a self-reference.
+ *
+ * Due to the current limitations about detecting a WorkTableScan in a sub tree
+ * of a plan Path we have opted to initially disallow queries where a motion may
+ * be placed between the RecursiveUnion and the WorkTableScan. Self-reference
+ * set operations in the recursive term are one such category of queries
+ *
+ * Eg.
+ *
+ * This query is not currently supported because the cte 'x' is referenced by
+ * the set operation in the recursive term '(SELECT * FROM x
+ * UNION SELECT * FROM z)'
+ *
+ * WITH RECURSIVE x(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM (SELECT * FROM x
+ * UNION SELECT * FROM z)foo)
+	SELECT * FROM x;
+ */
+static bool
+checkSelfRefInSetOpWalker(Node *node, CteState *cstate) {
+
+	if (node == NULL)
+		return false;
+
+	if (IsA(node, RangeVar))
+	{
+		CommonTableExpr *mycte = cstate->items[cstate->curitem].cte;
+		RangeVar *rv = (RangeVar *) node;
+		if (strcmp(mycte->ctename, rv->relname) == 0)
+			return true;
+	}
+	if (IsA(node, SelectStmt))
+	{
+		SelectStmt *stmt = (SelectStmt *)node;
+		ListCell *lc;
+
+		if (stmt->fromClause == NULL)
+			return false;
+
+		foreach(lc, stmt->fromClause)
+		{
+			if (checkSelfRefInSetOpWalker((Node *) lfirst(lc), cstate))
+				return true;
+		}
+	}
+
+	return raw_expression_tree_walker(node,
+									  checkSelfRefInSetOpWalker,
+									  (void *) cstate);
+}
+
+/*
  * Tree walker function to detect invalid self-references in a recursive query.
  */
 static bool
@@ -760,6 +812,22 @@ checkWellFormedRecursionWalker(Node *node, CteState *cstate)
 	{
 		SelectStmt *stmt = (SelectStmt *) node;
 		ListCell *lc;
+
+		if (stmt->op != SETOP_NONE)
+		{
+			CommonTableExpr *mycte = cstate->items[cstate->curitem].cte;
+			if (cstate->context != RECURSION_NONRECURSIVETERM)
+			{
+				if (checkSelfRefInSetOpWalker(stmt->larg, cstate) || checkSelfRefInSetOpWalker(stmt->rarg, cstate))
+				{
+					ereport(ERROR,
+							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							 errmsg("Self reference of \"%s\" within recursive term not supported", mycte->ctename),
+							 -1));
+					return true;
+				}
+			}
+		}
 
 		if (stmt->withClause)
 		{

--- a/src/test/regress/expected/with.out
+++ b/src/test/regress/expected/with.out
@@ -514,6 +514,27 @@ WITH RECURSIVE x(n) AS (SELECT 1 EXCEPT ALL SELECT n+1 FROM x)
 ERROR:  recursive query "x" does not have the form non-recursive-term UNION ALL recursive-term
 LINE 1: WITH RECURSIVE x(n) AS (SELECT 1 EXCEPT ALL SELECT n+1 FROM ...
                        ^
+-- Set operations within the recursive term with a self-reference.
+-- Currently set operations in the recursive term involving the cte itself must
+-- be prevented. The reason for this is that such a query may lead to a plan
+-- where there is a motion between the RecursiveUnion node and the
+-- WorkTableScan node.
+CREATE TEMPORARY TABLE z(x int primary key);
+NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "z_pkey" for table "z"
+WITH RECURSIVE x(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM (SELECT * FROM x UNION SELECT * FROM z)foo)
+	SELECT * FROM x;
+ERROR:  Self reference of "x" within recursive term not supported
+-- Set operation in recursive term that does not have a self-reference
+-- This is supported
+CREATE TEMPORARY TABLE u(x int primary key);
+NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "u_pkey" for table "u"
+WITH RECURSIVE x(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM (SELECT * from z UNION SELECT * FROM u)foo, x where foo.x = x.n)
+	SELECT * FROM x;
+ n 
+---
+ 1
+(1 row)
+
 -- no non-recursive term
 WITH RECURSIVE x(n) AS (SELECT n FROM x)
 	SELECT * FROM x;
@@ -610,9 +631,7 @@ WITH RECURSIVE foo(i) AS
           UNION ALL
        SELECT i+1 FROM foo WHERE i < 5)
 ) SELECT * FROM foo;
-ERROR:  recursive reference to query "foo" must not appear more than once
-LINE 6:        SELECT i+1 FROM foo WHERE i < 5)
-                               ^
+ERROR:  Self reference of "foo" within recursive term not supported
 WITH RECURSIVE foo(i) AS
     (values (1)
     UNION ALL
@@ -621,9 +640,7 @@ WITH RECURSIVE foo(i) AS
           UNION ALL
        SELECT i+1 FROM foo WHERE i < 5) AS t
 ) SELECT * FROM foo;
-ERROR:  recursive reference to query "foo" must not appear more than once
-LINE 7:        SELECT i+1 FROM foo WHERE i < 5) AS t
-                               ^
+ERROR:  Self reference of "foo" within recursive term not supported
 WITH RECURSIVE foo(i) AS
     (values (1)
     UNION ALL
@@ -631,9 +648,7 @@ WITH RECURSIVE foo(i) AS
           EXCEPT
        SELECT i+1 FROM foo WHERE i < 5)
 ) SELECT * FROM foo;
-ERROR:  recursive reference to query "foo" must not appear within EXCEPT
-LINE 6:        SELECT i+1 FROM foo WHERE i < 5)
-                               ^
+ERROR:  Self reference of "foo" within recursive term not supported
 WITH RECURSIVE foo(i) AS
     (values (1)
     UNION ALL
@@ -641,9 +656,7 @@ WITH RECURSIVE foo(i) AS
           INTERSECT
        SELECT i+1 FROM foo WHERE i < 5)
 ) SELECT * FROM foo;
-ERROR:  recursive reference to query "foo" must not appear more than once
-LINE 6:        SELECT i+1 FROM foo WHERE i < 5)
-                               ^
+ERROR:  Self reference of "foo" within recursive term not supported
 -- Wrong type induced from non-recursive term
 WITH RECURSIVE foo(i) AS
    (SELECT i FROM (VALUES(1),(2)) t(i)


### PR DESCRIPTION
This commit ensures that if there is ever a self reference to a
recursive cte within a set operation in the recursive term an error will
be produced

For example

WITH RECURSIVE foo(i) {
	SELECT 1
	UNION ALL
	SELECT i+1 FROM (SELECT * FROM foo UNION SELECT 0) bar
	)
SELECT * FROM foo LIMIT 5;

Will produce an error, while

WITH RECURSIVE foo(i) {
	SELECT 1
	UNION ALL
	SELECT i+1 FROM (SELECT * FROM bar UNION SELECT 0) car, foo
	where foo.i = bar.a
	)
SELECT * FROM foo LIMIT 5;

Will not because the set operation does not have a self reference to its
cte.