### PR TITLE
Add WALREP mirror information to `gp_segment_configuration`

### DIFF
--- a/gpAux/gpdemo/Makefile
+++ b/gpAux/gpdemo/Makefile
@@ -38,7 +38,7 @@ cluster create-demo-cluster:
 
 create-segwalrep-cluster:
 	@WITH_MIRRORS=false ./demo_cluster.sh
-	@./gpsegwalrep.py init
+	@./gpsegwalrep.py init --host `hostname`
 	@./gpsegwalrep.py start
 	@echo""
 


### PR DESCRIPTION
At `init` time, the `gp_segment_configuration` table needs to be updated with
the mirror information. We use the `gp_add_segment_mirror` and
`gp_remove_segment_mirror` functions to update the catalog directly. The
`start`, `stop` and `destroy` operations can now use the information present in
the catalog instead of having hard coded values.

Signed-off-by: Abhijit Subramanya <asubramanya@pivotal.io>