### PR TITLE
Error out when parsing certain keywords in a recursive CTE

### DIFF
--- a/src/backend/parser/parse_cte.c
+++ b/src/backend/parser/parse_cte.c
@@ -92,6 +92,8 @@ static void checkWellFormedRecursion(CteState *cstate);
 static bool checkWellFormedRecursionWalker(Node *node, CteState *cstate);
 static void checkWellFormedSelectStmt(SelectStmt *stmt, CteState *cstate);
 
+static void checkSelfRefInRangeSubSelect(SelectStmt *stmt, CteState *cstate);
+static void checkWindowFuncInRecursiveTerm(SelectStmt *stmt, CteState *cstate);
 
 /*
  * transformWithClause -
@@ -714,58 +716,6 @@ checkWellFormedRecursion(CteState *cstate)
 }
 
 /*
- * Check that a child of a set operation in the recursive term does not contain
- * a self-reference.
- *
- * Due to the current limitations about detecting a WorkTableScan in a sub tree
- * of a plan Path we have opted to initially disallow queries where a motion may
- * be placed between the RecursiveUnion and the WorkTableScan. Self-reference
- * set operations in the recursive term are one such category of queries
- *
- * Eg.
- *
- * This query is not currently supported because the cte 'x' is referenced by
- * the set operation in the recursive term '(SELECT * FROM x
- * UNION SELECT * FROM z)'
- *
- * WITH RECURSIVE x(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM (SELECT * FROM x
- * UNION SELECT * FROM z)foo)
-	SELECT * FROM x;
- */
-static bool
-checkSelfRefInSetOpWalker(Node *node, CteState *cstate) {
-
-	if (node == NULL)
-		return false;
-
-	if (IsA(node, RangeVar))
-	{
-		CommonTableExpr *mycte = cstate->items[cstate->curitem].cte;
-		RangeVar *rv = (RangeVar *) node;
-		if (strcmp(mycte->ctename, rv->relname) == 0)
-			return true;
-	}
-	if (IsA(node, SelectStmt))
-	{
-		SelectStmt *stmt = (SelectStmt *)node;
-		ListCell *lc;
-
-		if (stmt->fromClause == NULL)
-			return false;
-
-		foreach(lc, stmt->fromClause)
-		{
-			if (checkSelfRefInSetOpWalker((Node *) lfirst(lc), cstate))
-				return true;
-		}
-	}
-
-	return raw_expression_tree_walker(node,
-									  checkSelfRefInSetOpWalker,
-									  (void *) cstate);
-}
-
-/*
  * Tree walker function to detect invalid self-references in a recursive query.
  */
 static bool
@@ -829,21 +779,6 @@ checkWellFormedRecursionWalker(Node *node, CteState *cstate)
 		SelectStmt *stmt = (SelectStmt *) node;
 		ListCell *lc;
 
-		if (stmt->op != SETOP_NONE)
-		{
-			CommonTableExpr *mycte = cstate->items[cstate->curitem].cte;
-			if (cstate->context != RECURSION_NONRECURSIVETERM)
-			{
-				if (checkSelfRefInSetOpWalker(stmt->larg, cstate) || checkSelfRefInSetOpWalker(stmt->rarg, cstate))
-				{
-					ereport(ERROR,
-							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-							 errmsg("Self reference of \"%s\" within recursive term not supported", mycte->ctename),
-							 -1));
-					return true;
-				}
-			}
-		}
 
 		if (stmt->withClause)
 		{
@@ -887,7 +822,28 @@ checkWellFormedRecursionWalker(Node *node, CteState *cstate)
 			}
 		}
 		else
-				checkWellFormedSelectStmt(stmt, cstate);
+			checkWellFormedSelectStmt(stmt, cstate);
+
+		if (cstate->context == RECURSION_OK)
+		{
+			if (stmt->distinctClause)
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						 errmsg("DISTINCT in a recursive query is not implemented"),
+						 parser_errposition(cstate->pstate,
+											exprLocation((Node *) stmt->distinctClause))));
+			if (stmt->groupClause)
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						 errmsg("GROUP BY in a recursive query is not implemented"),
+						 parser_errposition(cstate->pstate,
+											exprLocation((Node *) stmt->groupClause))));
+
+			checkWindowFuncInRecursiveTerm(stmt, cstate);
+		}
+
+		checkSelfRefInRangeSubSelect(stmt, cstate);
+
 		/* We're done examining the SelectStmt */
 		return false;
 	}
@@ -953,6 +909,19 @@ checkWellFormedRecursionWalker(Node *node, CteState *cstate)
 		checkWellFormedRecursionWalker(sl->subselect, cstate);
 		cstate->context = save_context;
 		checkWellFormedRecursionWalker(sl->testexpr, cstate);
+		return false;
+	}
+	if (IsA(node, RangeSubselect))
+	{
+		RangeSubselect *rs = (RangeSubselect *) node;
+
+		/*
+		 * we intentionally override outer context, since subquery is
+		 * independent
+		 */
+		cstate->context = RECURSION_SUBLINK;
+		checkWellFormedRecursionWalker(rs->subquery, cstate);
+		cstate->context = save_context;
 		return false;
 	}
 	return raw_expression_tree_walker(node,
@@ -1028,3 +997,56 @@ checkWellFormedSelectStmt(SelectStmt *stmt, CteState *cstate)
 		}
 	}
 }
+
+/*
+ * Check if a recursive cte is referred to in a RangeSubSelect's SelectStmt.
+ * This is currently not supported and is checked for in the parsing stage
+ */
+static void
+checkSelfRefInRangeSubSelect(SelectStmt *stmt, CteState *cstate)
+{
+	ListCell *lc;
+	RecursionContext cxt = cstate->context;
+
+	foreach(lc, stmt->fromClause)
+	{
+		if (IsA((Node *) lfirst(lc), RangeSubselect))
+		{
+			cstate->context = RECURSION_SUBLINK;
+			RangeSubselect *rs = (RangeSubselect *) lfirst(lc);
+			SelectStmt *subquery = (SelectStmt *) rs->subquery;
+			checkWellFormedSelectStmt(subquery, cstate);
+		}
+	}
+	cstate->context = cxt;
+}
+
+/*
+ * Check if the recursive term of a recursive cte contains a window function.
+ * This is currently not supported and is checked for in the parsting stage
+ */
+static void
+checkWindowFuncInRecursiveTerm(SelectStmt *stmt, CteState *cstate)
+{
+	ListCell *lc;
+	foreach(lc, stmt->targetList)
+	{
+		if (IsA((Node *) lfirst(lc), ResTarget))
+		{
+			ResTarget *rt = (ResTarget *) lfirst(lc);
+			if (IsA(rt->val, FuncCall))
+			{
+				FuncCall *fc = (FuncCall *) rt->val;
+				if (fc->over != NULL)
+				{
+					ereport(ERROR,
+							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							 errmsg("Window Functions in a recursive query is not implemented"),
+							 parser_errposition(cstate->pstate,
+												exprLocation((Node *) fc))));
+				}
+			}
+		}
+	}
+}
+

--- a/src/test/regress/expected/with.out
+++ b/src/test/regress/expected/with.out
@@ -538,6 +538,7 @@ WITH RECURSIVE x(n) AS (SELECT 1 EXCEPT ALL SELECT n+1 FROM x)
 ERROR:  recursive query "x" does not have the form non-recursive-term UNION ALL recursive-term
 LINE 1: WITH RECURSIVE x(n) AS (SELECT 1 EXCEPT ALL SELECT n+1 FROM ...
                        ^
+-- GPDB Specific Error Cases
 -- Set operations within the recursive term with a self-reference.
 -- Currently set operations in the recursive term involving the cte itself must
 -- be prevented. The reason for this is that such a query may lead to a plan
@@ -547,7 +548,9 @@ CREATE TEMPORARY TABLE z(x int primary key);
 NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "z_pkey" for table "z"
 WITH RECURSIVE x(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM (SELECT * FROM x UNION SELECT * FROM z)foo)
 	SELECT * FROM x;
-ERROR:  Self reference of "x" within recursive term not supported
+ERROR:  recursive reference to query "x" must not appear within a subquery
+LINE 1: ...SELECT 1 UNION ALL SELECT n+1 FROM (SELECT * FROM x UNION SE...
+                                                             ^
 -- Set operation in recursive term that does not have a self-reference
 -- This is supported
 CREATE TEMPORARY TABLE u(x int primary key);
@@ -571,7 +574,42 @@ WITH RECURSIVE x(n) AS (SELECT n FROM x UNION ALL SELECT 1)
 ERROR:  recursive reference to query "x" must not appear within its non-recursive term
 LINE 1: WITH RECURSIVE x(n) AS (SELECT n FROM x UNION ALL SELECT 1)
                                               ^
+-- recursive term with a self-reference within a subquery is not allowed
+WITH RECURSIVE cte(level, id) as (
+	SELECT 1, 2
+	UNION ALL
+	SELECT level+1, c FROM (SELECT * FROM cte OFFSET 0) foo, bar)
+SELECT * FROM cte LIMIT 10;
+ERROR:  recursive reference to query "cte" must not appear within a subquery
+LINE 4:  SELECT level+1, c FROM (SELECT * FROM cte OFFSET 0) foo, ba...
+                                               ^
+-- recursive term with a distinct operation is not allowed
+WITH RECURSIVE x(n) AS (SELECT 1 UNION ALL SELECT distinct(n+1) FROM x)
+  SELECT * FROM x;
+ERROR:  DISTINCT in a recursive query is not implemented
+-- recursive term with a group by operation is not allowed
+CREATE TEMPORARY TABLE bar(c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+WITH RECURSIVE x(n) AS (
+	SELECT 1,2
+	UNION ALL
+	SELECT level+1, c FROM x, bar GROUP BY 1,2)
+  SELECT * FROM x LIMIT 10;
+ERROR:  GROUP BY in a recursive query is not implemented
+LINE 4:  SELECT level+1, c FROM x, bar GROUP BY 1,2)
+                                                ^
+WITH RECURSIVE x(n) AS (
+	SELECT 1,2
+	UNION ALL
+	SELECT level+1, row_number() over() FROM x, bar)
+  SELECT * FROM x LIMIT 10;
+ERROR:  Window Functions in a recursive query is not implemented
+LINE 4:  SELECT level+1, row_number() over() FROM x, bar)
+                         ^
 CREATE TEMPORARY TABLE y (a INTEGER);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO y SELECT generate_series(1, 10);
 -- LEFT JOIN
 WITH RECURSIVE x(n) AS (SELECT a FROM y WHERE a = 1
@@ -655,7 +693,9 @@ WITH RECURSIVE foo(i) AS
           UNION ALL
        SELECT i+1 FROM foo WHERE i < 5)
 ) SELECT * FROM foo;
-ERROR:  Self reference of "foo" within recursive term not supported
+ERROR:  recursive reference to query "foo" must not appear more than once
+LINE 6:        SELECT i+1 FROM foo WHERE i < 5)
+                               ^
 WITH RECURSIVE foo(i) AS
     (values (1)
     UNION ALL
@@ -664,7 +704,9 @@ WITH RECURSIVE foo(i) AS
           UNION ALL
        SELECT i+1 FROM foo WHERE i < 5) AS t
 ) SELECT * FROM foo;
-ERROR:  Self reference of "foo" within recursive term not supported
+ERROR:  recursive reference to query "foo" must not appear within a subquery
+LINE 5:        (SELECT i+1 FROM foo WHERE i < 10
+                                ^
 WITH RECURSIVE foo(i) AS
     (values (1)
     UNION ALL
@@ -672,7 +714,9 @@ WITH RECURSIVE foo(i) AS
           EXCEPT
        SELECT i+1 FROM foo WHERE i < 5)
 ) SELECT * FROM foo;
-ERROR:  Self reference of "foo" within recursive term not supported
+ERROR:  recursive reference to query "foo" must not appear within EXCEPT
+LINE 6:        SELECT i+1 FROM foo WHERE i < 5)
+                               ^
 WITH RECURSIVE foo(i) AS
     (values (1)
     UNION ALL
@@ -680,7 +724,9 @@ WITH RECURSIVE foo(i) AS
           INTERSECT
        SELECT i+1 FROM foo WHERE i < 5)
 ) SELECT * FROM foo;
-ERROR:  Self reference of "foo" within recursive term not supported
+ERROR:  recursive reference to query "foo" must not appear more than once
+LINE 6:        SELECT i+1 FROM foo WHERE i < 5)
+                               ^
 -- Wrong type induced from non-recursive term
 WITH RECURSIVE foo(i) AS
    (SELECT i FROM (VALUES(1),(2)) t(i)


### PR DESCRIPTION
Currently Recursive CTE's do not support the following operations in the
recursive term:

- Group By
- Window Functions
- Subqueries with a self-reference
- Distinct

This commit produces an error in the parsing stage whenever any of the
above is found in the recursive term of a CTE definition
