### PR TITLE
Improve partition selection logging

### DIFF
--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -9339,62 +9339,6 @@ DebugPartitionOid(Datum *elements, int n)
 	return str.data;
 }
 
-/**
- * Function that returns partition oids and number of partitions
- * from the partOidHash hash table.
- *
- * partOidHash: a hash table with partition oids
- * partOids: out parameter; returns a palloc'ed array of oid datums
- * partCount: out parameter; returns the length of palloc'ed oid array
- *
- * The partOids are palloc'ed in current memory context. Caller should
- * ensure timely pfree.
- */
-void
-GetSelectedPartitionOids(HTAB *partOidHash, Datum **partOids, long *partCount)
-{
-	if (NULL != partOidHash)
-	{
-		int i = 0;
-		*partCount = hash_get_num_entries(partOidHash);
-		*partOids = (Datum *) palloc(*partCount * sizeof(Datum));
-
-		HASH_SEQ_STATUS pidStatus;
-		hash_seq_init(&pidStatus, partOidHash);
-
-		Oid *pid = NULL;
-		while ((pid = (Oid *) hash_seq_search(&pidStatus)) != NULL)
-		{
-			Assert(i < *partCount);
-			(*partOids)[i++] = ObjectIdGetDatum(*pid);
-		}
-
-		Assert(i == *partCount);
-	}
-	else
-	{
-		*partCount = 0;
-		*partOids = (Datum *) palloc(*partCount * sizeof(Datum));
-	}
-}
-
-
-/**
- * Prints the names of DPE selected partitions from a
- * HTAB (pidIndex) of partition oids.
- */
-void
-LogSelectedPartitionOids(HTAB *pidIndex)
-{
-	Datum *elements = NULL;
-	long numPartitions = 0;
-	GetSelectedPartitionOids(pidIndex, &elements, &numPartitions);
-	Assert(NULL != elements);
-
-	elog(LOG, "DPE matched partitions: %s", DebugPartitionOid(elements, numPartitions));
-	pfree(elements);
-}
-
 /*
  * findPartitionMetadataEntry
  *   Find PartitionMetadata object for a given partition oid from a list.

--- a/src/backend/executor/nodeDynamicIndexscan.c
+++ b/src/backend/executor/nodeDynamicIndexscan.c
@@ -262,11 +262,6 @@ setPidIndex(DynamicIndexScanState *node)
 	Assert(estate->dynamicTableScanInfo->numScans >= plan->scan.partIndex);
 	node->pidxIndex = estate->dynamicTableScanInfo->pidIndexes[plan->scan.partIndex - 1];
 	Assert(node->pidxIndex != NULL);
-
-	if (optimizer_partition_selection_log)
-	{
-		LogSelectedPartitionOids(node->pidxIndex);
-	}
 }
 
 /*

--- a/src/backend/executor/nodeDynamicTableScan.c
+++ b/src/backend/executor/nodeDynamicTableScan.c
@@ -190,11 +190,6 @@ setPidIndex(DynamicTableScanState *node)
 	Assert(estate->dynamicTableScanInfo->numScans >= plan->partIndex);
 	node->pidIndex = estate->dynamicTableScanInfo->pidIndexes[plan->partIndex - 1];
 	Assert(node->pidIndex != NULL);
-
-	if (optimizer_partition_selection_log)
-	{
-		LogSelectedPartitionOids(node->pidIndex);
-	}
 }
 
 TupleTableSlot *

--- a/src/include/cdb/cdbpartition.h
+++ b/src/include/cdb/cdbpartition.h
@@ -232,12 +232,6 @@ extern bool isPartitionSelected(EState *estate, int index, Oid partOid);
 extern char *
 DebugPartitionOid(Datum *elements, int n);
 
-extern void
-GetSelectedPartitionOids(HTAB *partOidHash, Datum **partOids, long *partCount);
-
-extern void
-LogSelectedPartitionOids(HTAB *pidIndex);
-
 extern List *
 all_leaf_partition_relids(PartitionNode *pn);
 


### PR DESCRIPTION
Partition Selection is the process of determining at runtime ("execution
time") which leaf partitions we can skip scanning. Three types of Scan
operators benefit from partition selection: DynamicTableScan,
DynamicIndexScan, and BitmapTableScan.

Currently, there is a minimal amount of logging about what partitions
are selected, but they are scattered between DynamicIndexScan and
DynamicTableScan (and so we missed BitmapTableScan).

This commit moves the logging into the PartitionSelector operator
itself, when it exhausts its inputs. This also brings the nice side
effect of more granular information: the log now attributes the
partition selection to individual partition selectors.