### PR TITLE
Choose segment randomly to server as singleton reader gang

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -706,10 +706,10 @@ subquery_planner(PlannerGlobal *glob, Query *parse,
 	Assert(config);
 	root->config = config;
 
-	if (Gp_role != GP_ROLE_DISPATCH && root->config->cdbpath_segments > 0)
+	if (Gp_role == GP_ROLE_DISPATCH && gp_session_id > -1)
 	{
 		/* Choose a segdb to which our singleton gangs should be dispatched. */
-		gp_singleton_segindex = gp_session_id % root->config->cdbpath_segments;
+		gp_singleton_segindex = gp_session_id % getgpsegmentCount();
 	}
 
 	root->hasRecursion = hasRecursion;


### PR DESCRIPTION
This is a typo issue that cause segment 0 was always assigned
as singleton reader. It existed for a long time with no
functional issue, but may result in performance issue somehow.

Beside, root->config->cdbpath_segments is tuneable by GUC
gp_segments_for_planner, so gp_singleton_segindex may point to
an invalid segment, we use real segment count instead to avoid
mismatch.