### PR TITLE
Implement "COPY ... FROM ... ON SEGMENT' 

### DIFF
--- a/src/backend/access/external/fileam.c
+++ b/src/backend/access/external/fileam.c
@@ -355,7 +355,7 @@ external_endscan(FileScanDesc scan)
 	if (scan->fs_pstate != NULL && scan->fs_pstate->errMode != ALL_OR_NOTHING)
 	{
 		if (Gp_role == GP_ROLE_EXECUTE)
-			SendNumRowsRejected(scan->fs_pstate->cdbsreh->rejectcount);
+			SendNumRowsRejected(scan->fs_pstate->cdbsreh->rejectcount, 0);
 
 		destroyCdbSreh(scan->fs_pstate->cdbsreh);
 	}

--- a/src/backend/access/external/fileam.c
+++ b/src/backend/access/external/fileam.c
@@ -355,7 +355,7 @@ external_endscan(FileScanDesc scan)
 	if (scan->fs_pstate != NULL && scan->fs_pstate->errMode != ALL_OR_NOTHING)
 	{
 		if (Gp_role == GP_ROLE_EXECUTE)
-			SendNumRowsRejected(scan->fs_pstate->cdbsreh->rejectcount, 0);
+			SendNumRows(scan->fs_pstate->cdbsreh->rejectcount, 0);
 
 		destroyCdbSreh(scan->fs_pstate->cdbsreh);
 	}

--- a/src/backend/cdb/cdbsreh.c
+++ b/src/backend/cdb/cdbsreh.c
@@ -310,7 +310,7 @@ void ReportSrehResults(CdbSreh *cdbsreh, int total_rejected)
  * Using this function the QE sends back to the client QD the number 
  * of rows that were rejected in this last data load in SREH mode.
  */
-void SendNumRowsRejected(int numrejected)
+void SendNumRowsRejected(int numrejected, int numcompleted)
 {
 	StringInfoData buf;
 	
@@ -319,6 +319,8 @@ void SendNumRowsRejected(int numrejected)
 
 	pq_beginmessage(&buf, 'j'); /* 'j' is the msg code for rejected records */
 	pq_sendint(&buf, numrejected, 4);
+	if (numcompleted > 0) /* optional send completed num for COPY FROM ON SEGMENT */
+		pq_sendint(&buf, numcompleted, 4);
 	pq_endmessage(&buf);	
 }
 

--- a/src/backend/cdb/cdbsreh.c
+++ b/src/backend/cdb/cdbsreh.c
@@ -304,24 +304,43 @@ void ReportSrehResults(CdbSreh *cdbsreh, int total_rejected)
 	}
 }
 
-/*
- * SendNumRowsRejected
- *
- * Using this function the QE sends back to the client QD the number 
- * of rows that were rejected in this last data load in SREH mode.
- */
-void SendNumRowsRejected(int numrejected, int numcompleted)
+static void
+sendnumrows_internal(int numrejected, int numcompleted)
 {
 	StringInfoData buf;
 	
 	if (Gp_role != GP_ROLE_EXECUTE)
-		elog(FATAL, "SendNumRowsRejected: called outside of execute context.");
+		elog(FATAL, "SendNumRows: called outside of execute context.");
 
 	pq_beginmessage(&buf, 'j'); /* 'j' is the msg code for rejected records */
 	pq_sendint(&buf, numrejected, 4);
 	if (numcompleted > 0) /* optional send completed num for COPY FROM ON SEGMENT */
 		pq_sendint(&buf, numcompleted, 4);
 	pq_endmessage(&buf);	
+}
+
+/*
+ * SendNumRowsRejected
+ *
+ * Using this function the QE sends back to the client QD the number
+ * of rows that were rejected in this last data load in SREH mode.
+ */
+void
+SendNumRowsRejected(int numrejected)
+{
+    sendnumrows_internal(numrejected, 0);
+}
+
+/*
+ * SendNumRows
+ *
+ * Using this function the QE sends back to the client QD the number
+ * of rows that were rejected and completed in this last data load
+ */
+void
+SendNumRows(int numrejected, int numcompleted)
+{
+    sendnumrows_internal(numrejected, numcompleted);
 }
 
 /* Identify the reject limit type */

--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -848,7 +848,7 @@ processResults(CdbDispatchResult * dispatchResult)
 				dispatchResult->numrowsrejected += pRes->numRejected;
 
 			/*
-			 * COPY FROM ON SEGMENT - get the number of rows rejected by QE if any
+			 * COPY FROM ON SEGMENT - get the number of rows completed by QE if any
 			 */
 			if (pRes->numCompleted > 0)
 				dispatchResult->numrowscompleted += pRes->numCompleted;

--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -847,6 +847,12 @@ processResults(CdbDispatchResult * dispatchResult)
 			if (pRes->numRejected > 0)
 				dispatchResult->numrowsrejected += pRes->numRejected;
 
+			/*
+			 * COPY FROM ON SEGMENT - get the number of rows rejected by QE if any
+			 */
+			if (pRes->numCompleted > 0)
+				dispatchResult->numrowscompleted += pRes->numCompleted;
+
 			if (resultStatus == PGRES_COPY_IN ||
 				resultStatus == PGRES_COPY_OUT)
 				return true;

--- a/src/backend/cdb/dispatcher/cdbdisp_thread.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_thread.c
@@ -1110,7 +1110,7 @@ processResults(CdbDispatchResult *dispatchResult)
 				dispatchResult->numrowsrejected += pRes->numRejected;
 
 			/*
-			 * COPY FROM ON SEGMENT - get number of rows rejected by QE if any
+			 * COPY FROM ON SEGMENT - get number of rows completed by QE if any
 			 */
 			if (pRes->numCompleted > 0)
 				dispatchResult->numrowscompleted += pRes->numCompleted;

--- a/src/backend/cdb/dispatcher/cdbdisp_thread.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_thread.c
@@ -1109,6 +1109,12 @@ processResults(CdbDispatchResult *dispatchResult)
 			if (pRes->numRejected > 0)
 				dispatchResult->numrowsrejected += pRes->numRejected;
 
+			/*
+			 * COPY FROM ON SEGMENT - get number of rows rejected by QE if any
+			 */
+			if (pRes->numCompleted > 0)
+				dispatchResult->numrowscompleted += pRes->numCompleted;
+
 			if (resultStatus == PGRES_COPY_IN ||
 				resultStatus == PGRES_COPY_OUT)
 				return true;

--- a/src/backend/cdb/dispatcher/cdbdispatchresult.c
+++ b/src/backend/cdb/dispatcher/cdbdispatchresult.c
@@ -101,6 +101,7 @@ cdbdisp_makeResult(struct CdbDispatchResults *meleeResults,
 	dispatchResult->resultbuf = createPQExpBuffer();
 	dispatchResult->error_message = createPQExpBuffer();
 	dispatchResult->numrowsrejected = 0;
+	dispatchResult->numrowscompleted = 0;
 
 	if (PQExpBufferBroken(dispatchResult->resultbuf) ||
 		PQExpBufferBroken(dispatchResult->error_message))

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -87,6 +87,7 @@ extern void CopyToDispatch(CopyState cstate);
 static void CopyTo(CopyState cstate);
 extern void CopyFromDispatch(CopyState cstate);
 static void CopyFrom(CopyState cstate);
+static void CopyFromProcessDataFileHeader(CopyState cstate, CdbCopy *cdbCopy, bool *pfile_has_oids);
 static char *CopyReadOidAttr(CopyState cstate, bool *isnull);
 static void CopyAttributeOutText(CopyState cstate, char *string);
 static void CopyAttributeOutCSV(CopyState cstate, char *string,
@@ -205,7 +206,7 @@ else \
 	if (!elog_dismiss(DEBUG5)) \
 		PG_RE_THROW(); /* <-- hope to never get here! */ \
 \
-	if (Gp_role == GP_ROLE_DISPATCH)\
+	if (Gp_role == GP_ROLE_DISPATCH || cstate->on_segment)\
 	{\
 		Insist(cstate->err_loc_type == ROWNUM_ORIGINAL);\
 		cstate->cdbsreh->rawdata = (char *) palloc(strlen(cstate->line_buf.data) * \
@@ -1305,6 +1306,13 @@ DoCopyInternal(const CopyStmt *stmt, const char *queryString, CopyState cstate)
 			replaceStringInfoString(&filepath, "<SEGID>", segid_buf);
 
 			cstate->filename = filepath.data;
+			/* Rename filename if error log needed */
+			if (NULL != cstate->cdbsreh)
+			{
+				snprintf(cstate->cdbsreh->filename,
+						 sizeof(cstate->cdbsreh->filename), "%s",
+						 filepath.data);
+			}
 
 			pipe = false;
 		}
@@ -1621,6 +1629,10 @@ DoCopyInternal(const CopyStmt *stmt, const char *queryString, CopyState cstate)
 					(errcode(ERRCODE_GP_FEATURE_NOT_SUPPORTED),
 					 errmsg("COPY single row error handling only available for distributed user tables")));
 
+		if (cstate->on_segment && Gp_role == GP_ROLE_EXECUTE) {
+			pipe = true;
+		}
+
 		if (pipe)
 		{
 			if (whereToSendOutput == DestRemote)
@@ -1631,14 +1643,19 @@ DoCopyInternal(const CopyStmt *stmt, const char *queryString, CopyState cstate)
 		else
 		{
 			struct stat st;
+			char *filename = cstate->filename;
 
-			cstate->copy_file = AllocateFile(cstate->filename, PG_BINARY_R);
+			/* Use dummy file on master for COPY FROM ON SEGMENT */
+			if (cstate->on_segment && Gp_role == GP_ROLE_DISPATCH)
+				filename = "/dev/null";
+
+			cstate->copy_file = AllocateFile(filename, PG_BINARY_R);
 
 			if (cstate->copy_file == NULL)
 				ereport(ERROR,
 						(errcode_for_file_access(),
 						 errmsg("could not open file \"%s\" for reading: %m",
-								cstate->filename)));
+								filename)));
 
 			// Increase buffer size to improve performance  (cmcdevitt)
             setvbuf(cstate->copy_file, NULL, _IOFBF, 393216); // 384 Kbytes
@@ -1647,7 +1664,7 @@ DoCopyInternal(const CopyStmt *stmt, const char *queryString, CopyState cstate)
 			if (S_ISDIR(st.st_mode))
 				ereport(ERROR,
 						(errcode(ERRCODE_WRONG_OBJECT_TYPE),
-						 errmsg("\"%s\" is a directory", cstate->filename)));
+						 errmsg("\"%s\" is a directory", filename)));
 		}
 
 
@@ -2695,6 +2712,76 @@ CopyOneRowTo(CopyState cstate, Oid tupleOid, Datum *values, bool *nulls)
 	MemoryContextSwitchTo(oldcontext);
 }
 
+static void CopyFromProcessDataFileHeader(CopyState cstate, CdbCopy *cdbCopy, bool *pfile_has_oids)
+{
+	if (!cstate->binary)
+	{
+			*pfile_has_oids = cstate->oids;	/* must rely on user to tell us... */
+	}
+	else
+	{
+		/* Read and verify binary header */
+		char		readSig[11];
+		int32		tmp_flags, tmp_extension;
+		int32		tmp;
+
+		/* Signature */
+		if (CopyGetData(cstate, readSig, 11) != 11 ||
+			memcmp(readSig, BinarySignature, 11) != 0)
+			ereport(ERROR,
+					(errcode(ERRCODE_BAD_COPY_FILE_FORMAT),
+					errmsg("COPY file signature not recognized")));
+		/* Flags field */
+		if (!CopyGetInt32(cstate, &tmp_flags))
+			ereport(ERROR,
+					(errcode(ERRCODE_BAD_COPY_FILE_FORMAT),
+					errmsg("invalid COPY file header (missing flags)")));
+		*pfile_has_oids = (tmp_flags & (1 << 16)) != 0;
+		tmp = tmp_flags & ~(1 << 16);
+		if ((tmp >> 16) != 0)
+			ereport(ERROR,
+					(errcode(ERRCODE_BAD_COPY_FILE_FORMAT),
+				errmsg("unrecognized critical flags in COPY file header")));
+		/* Header extension length */
+		if (!CopyGetInt32(cstate, &tmp_extension) ||
+			tmp_extension < 0)
+			ereport(ERROR,
+					(errcode(ERRCODE_BAD_COPY_FILE_FORMAT),
+					errmsg("invalid COPY file header (missing length)")));
+		/* Skip extension header, if present */
+		while (tmp_extension-- > 0)
+		{
+			if (CopyGetData(cstate, readSig, 1) != 1)
+				ereport(ERROR,
+						(errcode(ERRCODE_BAD_COPY_FILE_FORMAT),
+						errmsg("invalid COPY file header (wrong length)")));
+		}
+
+		/* Send binary header to all segments except:
+			* dummy file on master for COPY FROM ON SEGMENT
+			*/
+		if(Gp_role == GP_ROLE_DISPATCH && !cstate->on_segment)
+		{
+			uint32 buf;
+			cdbCopySendDataToAll(cdbCopy, (char *) BinarySignature, 11);
+			buf = htonl((uint32) tmp_flags);
+			cdbCopySendDataToAll(cdbCopy, (char *) &buf, 4);
+			buf = htonl((uint32) 0);
+			cdbCopySendDataToAll(cdbCopy, (char *) &buf, 4);
+		}
+	}
+
+	if (*pfile_has_oids && cstate->binary)
+	{
+		FmgrInfo	oid_in_function;
+		Oid			oid_typioparam;
+		Oid			in_func_oid;
+
+		getTypeBinaryInputInfo(OIDOID,
+							&in_func_oid, &oid_typioparam);
+		fmgr_info(in_func_oid, &oid_in_function);
+	}
+}
 
 /*
  * CopyFromCreateDispatchCommand
@@ -2816,6 +2903,9 @@ static int CopyFromCreateDispatchCommand(CopyState cstate,
 	else
 		appendStringInfo(cdbcopy_cmd, " FROM STDIN WITH");
 
+	if (cstate->on_segment)
+		appendStringInfo(cdbcopy_cmd, " ON SEGMENT");
+
 	if (cstate->oids)
 		appendStringInfo(cdbcopy_cmd, " OIDS");
 
@@ -2842,6 +2932,14 @@ static int CopyFromCreateDispatchCommand(CopyState cstate,
 		if (cstate->csv_mode)
 		{
 			appendStringInfo(cdbcopy_cmd, " CSV");
+
+			/*
+			 * If on_segment, QE needs to write its own CSV header. If not,
+			 * only QD needs to, QE doesn't send CSV header to QD
+			 */
+			if (cstate->on_segment && cstate->header_line)
+				appendStringInfo(cdbcopy_cmd, " HEADER");
+
 			appendStringInfo(cdbcopy_cmd, " QUOTE AS E'%s'", escape_quotes(cstate->quote));
 			appendStringInfo(cdbcopy_cmd, " ESCAPE AS E'%s'", escape_quotes(cstate->escape));
 
@@ -2908,6 +3006,7 @@ CopyFromDispatch(CopyState cstate)
 	bool	   *nulls;
 	int		   *attr_offsets;
 	int			total_rejected_from_qes = 0;
+	int			total_completed_from_qes = 0;
 	bool		isnull;
 	bool	   *isvarlena;
 	ResultRelInfo *resultRelInfo;
@@ -3332,61 +3431,10 @@ CopyFromDispatch(CopyState cstate)
 	 */
 	//ExecBSInsertTriggers(estate, resultRelInfo);
 
-	if (!cstate->binary)
-		file_has_oids = cstate->oids;	/* must rely on user to tell us... */
-	else
+	/* Skip header processing if dummy file on master for COPY FROM ON SEGMENT */
+	if (!cstate->on_segment || Gp_role != GP_ROLE_DISPATCH)
 	{
-		/* Read and verify binary header */
-		char		readSig[11];
-		int32		tmp_flags, tmp_extension;
-		int32		tmp;
-
-		/* Signature */
-		if (CopyGetData(cstate, readSig, 11) != 11 ||
-			memcmp(readSig, BinarySignature, 11) != 0)
-			ereport(ERROR,
-					(errcode(ERRCODE_BAD_COPY_FILE_FORMAT),
-					 errmsg("COPY file signature not recognized")));
-		/* Flags field */
-		if (!CopyGetInt32(cstate, &tmp_flags))
-			ereport(ERROR,
-					(errcode(ERRCODE_BAD_COPY_FILE_FORMAT),
-					 errmsg("invalid COPY file header (missing flags)")));
-		file_has_oids = (tmp_flags & (1 << 16)) != 0;
-		tmp = tmp_flags & ~(1 << 16);
-		if ((tmp >> 16) != 0)
-			ereport(ERROR,
-					(errcode(ERRCODE_BAD_COPY_FILE_FORMAT),
-				 errmsg("unrecognized critical flags in COPY file header")));
-		/* Header extension length */
-		if (!CopyGetInt32(cstate, &tmp_extension) ||
-			tmp_extension < 0)
-			ereport(ERROR,
-					(errcode(ERRCODE_BAD_COPY_FILE_FORMAT),
-					 errmsg("invalid COPY file header (missing length)")));
-		/* Skip extension header, if present */
-		while (tmp_extension-- > 0)
-		{
-			if (CopyGetData(cstate, readSig, 1) != 1)
-				ereport(ERROR,
-						(errcode(ERRCODE_BAD_COPY_FILE_FORMAT),
-						 errmsg("invalid COPY file header (wrong length)")));
-		}
-
-		/* Send binary header to all segments */
-		uint32 buf;
-		cdbCopySendDataToAll(cdbCopy, (char *) BinarySignature, 11);
-		buf = htonl((uint32) tmp_flags);
-		cdbCopySendDataToAll(cdbCopy, (char *) &buf, 4);
-		buf = htonl((uint32) 0);
-		cdbCopySendDataToAll(cdbCopy, (char *) &buf, 4);
-	}
-
-	if (file_has_oids && cstate->binary)
-	{
-		getTypeBinaryInputInfo(OIDOID,
-							   &in_func_oid, &oid_typioparam);
-		fmgr_info(in_func_oid, &oid_in_function);
+		CopyFromProcessDataFileHeader(cstate, cdbCopy, &file_has_oids);
 	}
 
 	values = (Datum *) palloc(num_phys_attrs * sizeof(Datum));
@@ -4062,11 +4110,13 @@ CopyFromDispatch(CopyState cstate)
 				}
 				
 				/* send modified data */
-				cdbCopySendData(cdbCopy,
-								target_seg,
-								line_buf_with_lineno.data,
-								line_buf_with_lineno.len);
-				RESET_LINEBUF_WITH_LINENO;
+				if (!cstate->on_segment) {
+					cdbCopySendData(cdbCopy,
+									target_seg,
+									line_buf_with_lineno.data,
+									line_buf_with_lineno.len);
+					RESET_LINEBUF_WITH_LINENO;
+				}
 
 				cstate->processed++;
 				if (estate->es_result_partitions)
@@ -4098,7 +4148,7 @@ CopyFromDispatch(CopyState cstate)
 	 * databases Now we would like to end the copy command on
 	 * all segment databases across the cluster.
 	 */
-	total_rejected_from_qes = cdbCopyEnd(cdbCopy);
+	total_rejected_from_qes = cdbCopyEndAndFetchRejectNum(cdbCopy, &total_completed_from_qes);
 
 	/*
 	 * If we quit the processing loop earlier due to a
@@ -4167,6 +4217,7 @@ CopyFromDispatch(CopyState cstate)
 		ReportSrehResults(cstate->cdbsreh, total_rejected);
 	}
 
+	cstate->processed += total_completed_from_qes;
 
 	/*
 	 * Done, clean up
@@ -4304,6 +4355,7 @@ CopyFrom(CopyState cstate)
 	num_phys_attrs = tupDesc->natts;
 	attr_count = list_length(cstate->attnumlist);
 	num_defaults = 0;
+	bool		is_segment_data_processed = (cstate->on_segment && Gp_role == GP_ROLE_EXECUTE) ? false : true;
 
 	/*----------
 	 * Check to see if we can avoid writing WAL
@@ -4424,52 +4476,10 @@ CopyFrom(CopyState cstate)
 	 */
 	ExecBSInsertTriggers(estate, resultRelInfo);
 
-	if (!cstate->binary)
-		file_has_oids = cstate->oids;	/* must rely on user to tell us... */
-	else
+	/* Skip header processing if dummy file get from master for COPY FROM ON SEGMENT */
+	if(!cstate->on_segment || Gp_role != GP_ROLE_EXECUTE)
 	{
-		/* Read and verify binary header */
-		char		readSig[11];
-		int32		tmp;
-
-		/* Signature */
-		if (CopyGetData(cstate, readSig, 11) != 11 ||
-			memcmp(readSig, BinarySignature, 11) != 0)
-			ereport(ERROR,
-					(errcode(ERRCODE_BAD_COPY_FILE_FORMAT),
-					 errmsg("COPY file signature not recognized")));
-		/* Flags field */
-		if (!CopyGetInt32(cstate, &tmp))
-			ereport(ERROR,
-					(errcode(ERRCODE_BAD_COPY_FILE_FORMAT),
-					 errmsg("invalid COPY file header (missing flags)")));
-		file_has_oids = (tmp & (1 << 16)) != 0;
-		tmp &= ~(1 << 16);
-		if ((tmp >> 16) != 0)
-			ereport(ERROR,
-					(errcode(ERRCODE_BAD_COPY_FILE_FORMAT),
-				 errmsg("unrecognized critical flags in COPY file header")));
-		/* Header extension length */
-		if (!CopyGetInt32(cstate, &tmp) ||
-			tmp < 0)
-			ereport(ERROR,
-					(errcode(ERRCODE_BAD_COPY_FILE_FORMAT),
-					 errmsg("invalid COPY file header (missing length)")));
-		/* Skip extension header, if present */
-		while (tmp-- > 0)
-		{
-			if (CopyGetData(cstate, readSig, 1) != 1)
-				ereport(ERROR,
-						(errcode(ERRCODE_BAD_COPY_FILE_FORMAT),
-						 errmsg("invalid COPY file header (wrong length)")));
-		}
-	}
-
-	if (file_has_oids && cstate->binary)
-	{
-		getTypeBinaryInputInfo(OIDOID,
-							   &in_func_oid, &oid_typioparam);
-		fmgr_info(in_func_oid, &oid_in_function);
+		CopyFromProcessDataFileHeader(cstate, cdbCopy, &file_has_oids);
 	}
 
 	baseValues = (Datum *) palloc(num_phys_attrs * sizeof(Datum));
@@ -4485,13 +4495,14 @@ CopyFrom(CopyState cstate)
 	errcontext.previous = error_context_stack;
 	error_context_stack = &errcontext;
 
-	if (Gp_role == GP_ROLE_EXECUTE)
+	if (Gp_role == GP_ROLE_EXECUTE && (cstate->on_segment == false))
 		cstate->err_loc_type = ROWNUM_EMBEDDED; /* get original row num from QD COPY */
 	else
 		cstate->err_loc_type = ROWNUM_ORIGINAL; /* we can count rows by ourselves */
 
 	CopyInitDataParser(cstate);
 
+PROCESS_SEGMENT_DATA:
 	do
 	{
 		size_t		bytesread = 0;
@@ -4514,16 +4525,52 @@ CopyFrom(CopyState cstate)
 		 */
 		if (bytesread > 0 || !cstate->fe_eof)
 		{
-			/* handle HEADER, but only if we're in utility mode */
-			if (cstate->header_line)
+			/* handle HEADER, but only if COPY FROM ON SEGMENT */
+			if (cstate->header_line && cstate->on_segment)
 			{
-				cstate->line_done = cstate->csv_mode ?
-					CopyReadLineCSV(cstate, bytesread) :
-					CopyReadLineText(cstate, bytesread);
-				cstate->cur_lineno++;
-				cstate->header_line = false;
+				/* on first time around just throw the header line away */
+				PG_TRY();
+				{
+					cstate->line_done = cstate->csv_mode ?
+						CopyReadLineCSV(cstate, bytesread) :
+						CopyReadLineText(cstate, bytesread);
+				}
+				PG_CATCH();
+				{
+					/*
+					 * TODO: use COPY_HANDLE_ERROR here, but make sure to
+					 * ignore this error per the "note:" below.
+					 */
 
+					/*
+					 * got here? encoding conversion error occured on the
+					 * header line (first row).
+					 */
+					if (cstate->errMode == ALL_OR_NOTHING)
+					{
+						/* re-throw error and abort */
+						cdbCopyEnd(cdbCopy);
+						PG_RE_THROW();
+					}
+					else
+					{
+						/* SREH - release error state */
+						if (!elog_dismiss(DEBUG5))
+							PG_RE_THROW(); /* hope to never get here! */
+
+						/*
+						 * note: we don't bother doing anything special here.
+						 * we are never interested in logging a header line
+						 * error. just continue the workflow.
+						 */
+					}
+				}
+				PG_END_TRY();
+
+				cstate->cur_lineno++;
 				RESET_LINEBUF;
+
+				cstate->header_line = false;
 			}
 
 			while (!cstate->raw_buf_done)
@@ -5030,6 +5077,41 @@ CopyFrom(CopyState cstate)
 		}
 	} while (!no_more_data);
 
+	/*
+	 * After processed data from QD, which is empty and just for workflow, now
+	 * to process the data on segment, only one shot if cstate->on_segment &&
+	 * Gp_role == GP_ROLE_DISPATCH
+	 */
+	if (!is_segment_data_processed) {
+		struct stat st;
+		char *filename = cstate->filename;
+		cstate->copy_file = AllocateFile(filename, PG_BINARY_R);
+
+		if (cstate->copy_file == NULL)
+			ereport(ERROR,
+					(errcode_for_file_access(),
+						errmsg("could not open file \"%s\" for reading: %m",
+							filename)));
+
+		/* Increase buffer size to improve performance (cmcdevitt) */
+		setvbuf(cstate->copy_file, NULL, _IOFBF, 393216); // 384 Kbytes
+
+		fstat(fileno(cstate->copy_file), &st);
+		if (S_ISDIR(st.st_mode))
+			ereport(ERROR,
+					(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+						errmsg("\"%s\" is a directory", filename)));
+		cstate->copy_dest = COPY_FILE;
+
+		is_segment_data_processed = true;
+
+		CopyFromProcessDataFileHeader(cstate, cdbCopy, &file_has_oids);
+		CopyInitDataParser(cstate);
+
+		goto PROCESS_SEGMENT_DATA;
+	}
+
+	elog(DEBUG1, "Segment %u, Copied %lu rows.", GpIdentity.segindex, cstate->processed);
 
 	/* Done, clean up */
 	error_context_stack = errcontext.previous;
@@ -5045,9 +5127,11 @@ CopyFrom(CopyState cstate)
 	/*
 	 * If SREH and in executor mode send the number of rejected
 	 * rows to the client (QD COPY).
+	 * If COPY ... FROM ... ON SEGMENT, then need to send the number of completed
 	 */
-	if(cstate->errMode != ALL_OR_NOTHING && Gp_role == GP_ROLE_EXECUTE)
-		SendNumRowsRejected(cstate->cdbsreh->rejectcount);
+	if ((cstate->on_segment || (cstate->errMode != ALL_OR_NOTHING)) && Gp_role == GP_ROLE_EXECUTE)
+		SendNumRowsRejected((cstate->errMode != ALL_OR_NOTHING) ? cstate->cdbsreh->rejectcount : 0,
+				cstate->on_segment ? cstate->processed : 0);
 
 	if (estate->es_result_partitions && Gp_role == GP_ROLE_EXECUTE)
 		SendAOTupCounts(estate);

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -1629,7 +1629,8 @@ DoCopyInternal(const CopyStmt *stmt, const char *queryString, CopyState cstate)
 					(errcode(ERRCODE_GP_FEATURE_NOT_SUPPORTED),
 					 errmsg("COPY single row error handling only available for distributed user tables")));
 
-		if (cstate->on_segment && Gp_role == GP_ROLE_EXECUTE) {
+		if (cstate->on_segment && Gp_role == GP_ROLE_EXECUTE)
+		{
 			pipe = true;
 		}
 
@@ -2716,7 +2717,7 @@ static void CopyFromProcessDataFileHeader(CopyState cstate, CdbCopy *cdbCopy, bo
 {
 	if (!cstate->binary)
 	{
-			*pfile_has_oids = cstate->oids;	/* must rely on user to tell us... */
+		*pfile_has_oids = cstate->oids;	/* must rely on user to tell us... */
 	}
 	else
 	{
@@ -5082,7 +5083,8 @@ PROCESS_SEGMENT_DATA:
 	 * to process the data on segment, only one shot if cstate->on_segment &&
 	 * Gp_role == GP_ROLE_DISPATCH
 	 */
-	if (!is_segment_data_processed) {
+	if (!is_segment_data_processed)
+	{
 		struct stat st;
 		char *filename = cstate->filename;
 		cstate->copy_file = AllocateFile(filename, PG_BINARY_R);
@@ -5129,8 +5131,9 @@ PROCESS_SEGMENT_DATA:
 	 * rows to the client (QD COPY).
 	 * If COPY ... FROM ... ON SEGMENT, then need to send the number of completed
 	 */
-	if ((cstate->on_segment || (cstate->errMode != ALL_OR_NOTHING)) && Gp_role == GP_ROLE_EXECUTE)
-		SendNumRowsRejected((cstate->errMode != ALL_OR_NOTHING) ? cstate->cdbsreh->rejectcount : 0,
+	if ((cstate->errMode != ALL_OR_NOTHING && Gp_role == GP_ROLE_EXECUTE)
+		|| cstate->on_segment)
+		SendNumRows((cstate->errMode != ALL_OR_NOTHING) ? cstate->cdbsreh->rejectcount : 0,
 				cstate->on_segment ? cstate->processed : 0);
 
 	if (estate->es_result_partitions && Gp_role == GP_ROLE_EXECUTE)

--- a/src/backend/gp_libpq_fe/fe-exec.c
+++ b/src/backend/gp_libpq_fe/fe-exec.c
@@ -176,6 +176,7 @@ PQmakeEmptyPGresult(PGconn *conn, ExecStatusType status)
     result->extraslen = 0;
 	
 	result->numRejected = 0;
+	result->numCompleted = 0;
 	result->naotupcounts = 0;
 	result->aotupcounts = NULL;
 

--- a/src/backend/gp_libpq_fe/fe-protocol3.c
+++ b/src/backend/gp_libpq_fe/fe-protocol3.c
@@ -76,7 +76,8 @@ pqParseInput3(PGconn *conn)
 	char		id;
 	int			msgLength;
 	int			avail;
-	int			numRejected = 0;
+	int			numRejected  = 0;
+	int			numCompleted = 0;
 
 	/*
 	 * Loop to parse successive complete messages available in the buffer.
@@ -477,6 +478,12 @@ pqParseInput3(PGconn *conn)
 						return;
 
 					conn->result->numRejected += numRejected;
+
+					/* Optionally receive completed number when COPY FROM ON SEGMENT */
+					if (msgLength >= 8 && !pqGetInt(&numCompleted, 4, conn)) {
+						conn->result->numCompleted += numCompleted;
+					}
+
 					break;
 				case 'Y':       /* CDB: statistical response from QE to QD */
 					/* for certain queries, the stats may arrive

--- a/src/backend/gp_libpq_fe/fe-protocol3.c
+++ b/src/backend/gp_libpq_fe/fe-protocol3.c
@@ -480,7 +480,8 @@ pqParseInput3(PGconn *conn)
 					conn->result->numRejected += numRejected;
 
 					/* Optionally receive completed number when COPY FROM ON SEGMENT */
-					if (msgLength >= 8 && !pqGetInt(&numCompleted, 4, conn)) {
+					if (msgLength >= 8 && !pqGetInt(&numCompleted, 4, conn))
+					{
 						conn->result->numCompleted += numCompleted;
 					}
 

--- a/src/backend/gp_libpq_fe/gp-libpq-int.h
+++ b/src/backend/gp_libpq_fe/gp-libpq-int.h
@@ -196,6 +196,8 @@ struct pg_result
 
 	/* GPDB: number of rows rejected in SREH (protocol message 'j') */
 	int			numRejected;
+	/* GPDB: number of rows completed when COPY FROM ON SEGMENT */
+	int			numCompleted;
 	/* GPDB: number of processed tuples for each AO partition */
 	int			naotupcounts;
 	PQaoRelTupCount *aotupcounts;

--- a/src/include/cdb/cdbcopy.h
+++ b/src/include/cdb/cdbcopy.h
@@ -64,5 +64,6 @@ void		cdbCopySendDataToAll(CdbCopy *c, const char *buffer, int nbytes);
 void		cdbCopySendData(CdbCopy *c, int target_seg, const char *buffer, int nbytes);
 bool		cdbCopyGetData(CdbCopy *c, bool cancel, uint64 *rows_processed);
 int			cdbCopyEnd(CdbCopy *c);
+int			cdbCopyEndAndFetchRejectNum(CdbCopy *c, int *total_rows_completed);
 
 #endif   /* CDBCOPY_H */

--- a/src/include/cdb/cdbdispatchresult.h
+++ b/src/include/cdb/cdbdispatchresult.h
@@ -108,6 +108,9 @@ typedef struct CdbDispatchResult
 
 	/* num rows rejected in SREH mode */
 	int	numrowsrejected;
+
+	/* num rows completed in COPY FROM ON SEGMENT */
+	int	numrowscompleted;
 } CdbDispatchResult;
 
 /*

--- a/src/include/cdb/cdbsreh.h
+++ b/src/include/cdb/cdbsreh.h
@@ -88,7 +88,7 @@ extern CdbSreh *makeCdbSreh(int rejectlimit, bool is_limit_in_rows,
 extern void destroyCdbSreh(CdbSreh *cdbsreh);
 extern void HandleSingleRowError(CdbSreh *cdbsreh);
 extern void ReportSrehResults(CdbSreh *cdbsreh, int total_rejected);
-extern void SendNumRowsRejected(int numrejected);
+extern void SendNumRowsRejected(int numrejected, int numcompleted);
 extern bool IsErrorTable(Relation rel);
 extern void ErrorIfRejectLimitReached(CdbSreh *cdbsreh, CdbCopy *cdbCopy);
 extern bool ExceedSegmentRejectHardLimit(CdbSreh *cdbsreh);

--- a/src/include/cdb/cdbsreh.h
+++ b/src/include/cdb/cdbsreh.h
@@ -88,7 +88,8 @@ extern CdbSreh *makeCdbSreh(int rejectlimit, bool is_limit_in_rows,
 extern void destroyCdbSreh(CdbSreh *cdbsreh);
 extern void HandleSingleRowError(CdbSreh *cdbsreh);
 extern void ReportSrehResults(CdbSreh *cdbsreh, int total_rejected);
-extern void SendNumRowsRejected(int numrejected, int numcompleted);
+extern void SendNumRows(int numrejected, int numcompleted);
+extern void SendNumRowsRejected(int numrejected);
 extern bool IsErrorTable(Relation rel);
 extern void ErrorIfRejectLimitReached(CdbSreh *cdbsreh, CdbCopy *cdbCopy);
 extern bool ExceedSegmentRejectHardLimit(CdbSreh *cdbsreh);

--- a/src/test/regress/expected/gpcopy.out
+++ b/src/test/regress/expected/gpcopy.out
@@ -665,6 +665,44 @@ SELECT relname, filename, bytenum, errmsg FROM gp_read_error_log('errcopy');
  errcopy | <stdin>  |         | extra data after last expected column
 (2 rows)
 
+-- exceed reject limit  on segment
+DROP TABLE IF EXISTS segment_reject_limit;
+NOTICE:  table "segment_reject_limit" does not exist, skipping
+CREATE TABLE segment_reject_limit (a int,b char) distributed by (a);
+INSERT INTO segment_reject_limit values(1,'1');
+INSERT INTO segment_reject_limit values(1,'2');
+INSERT INTO segment_reject_limit values(1,'a');
+INSERT INTO segment_reject_limit values(1,'b');
+COPY segment_reject_limit TO '/tmp/segment_reject_limit<SEGID>.csv' on segment;
+DROP TABLE IF EXISTS segment_reject_limit_from;
+NOTICE:  table "segment_reject_limit_from" does not exist, skipping
+CREATE TABLE segment_reject_limit_from (a int,b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+COPY segment_reject_limit_from from '/tmp/segment_reject_limit<SEGID>.csv' on segment log errors segment reject limit 2 rows;
+ERROR:  Segment reject limit reached. Aborting operation. Last error was: invalid input syntax for integer: "b", column b  (seg0 172.17.0.2:40000 pid=8318)
+CONTEXT:  COPY segment_reject_limit_from, line 4, column 1
+SELECT * FROM segment_reject_limit_from;
+ a | b 
+---+---
+(0 rows)
+
+SELECT relname, filename, bytenum, errmsg FROM gp_read_error_log('segment_reject_limit_from');
+          relname          |            filename            | bytenum |                     errmsg                      
+---------------------------+--------------------------------+---------+-------------------------------------------------
+ segment_reject_limit_from | /tmp/segment_reject_limit0.csv |         | invalid input syntax for integer: "a", column b
+(1 row)
+
+--not exceed reject limit  on segment
+COPY segment_reject_limit_from from '/tmp/segment_reject_limit<SEGID>.csv' on segment log errors segment reject limit 3 rows;
+NOTICE:  Found 2 data formatting errors (2 or more input rows). Rejected related input data.
+SELECT * FROM segment_reject_limit_from;
+ a | b 
+---+---
+ 1 | 1
+ 1 | 2
+(2 rows)
+
 -- gp_initial_bad_row_limit guc test. This guc allows user to set the initial
 -- number of rows which can contain errors before the database stops loading
 -- the data. If there is a valid row within the first 'n' rows specified by
@@ -745,6 +783,55 @@ SELECT * FROM check_copy_onsegment_withoids;
    3
 (1 row)
 
+CREATE TABLE test_copy_from_on_segment_txt (LIKE test_copy_on_segment);
+COPY test_copy_from_on_segment_txt FROM '/tmp/invalid_filename.txt' ON SEGMENT;
+ERROR:  <SEGID> is required for file name
+COPY test_copy_from_on_segment_txt FROM '/tmp/valid_filename<SEGID>.txt' ON SEGMENT;
+SELECT * FROM test_copy_from_on_segment_txt ORDER BY a;
+ a | b | c 
+---+---+---
+ 1 | s | d
+ 2 | f | g
+ 3 | h | j
+ 4 | i | l
+ 5 | q | w
+(5 rows)
+
+CREATE TABLE test_copy_from_on_segment_binary (LIKE test_copy_on_segment);
+COPY test_copy_from_on_segment_binary FROM '/tmp/valid_filename<SEGID>.bin' ON SEGMENT BINARY;
+SELECT * FROM test_copy_from_on_segment_binary ORDER BY a;
+ a | b | c 
+---+---+---
+ 1 | s | d
+ 2 | f | g
+ 3 | h | j
+ 4 | i | l
+ 5 | q | w
+(5 rows)
+
+CREATE TABLE test_copy_from_on_segment_csv (LIKE test_copy_on_segment);
+COPY test_copy_from_on_segment_csv FROM '/tmp/valid_filename<SEGID>.csv' WITH ON SEGMENT CSV QUOTE '"' ESCAPE E'\\' NULL '\N' DELIMITER ',' HEADER IGNORE EXTERNAL PARTITIONS;
+SELECT * FROM test_copy_from_on_segment_csv ORDER BY a;
+ a | b | c 
+---+---+---
+ 1 | s | d
+ 2 | f | g
+ 3 | h | j
+ 4 | i | l
+ 5 | q | w
+(5 rows)
+
+CREATE TABLE test_copy_from_on_segment_withoids (LIKE test_copy_on_segment_withoids) WITH OIDS;
+NOTICE:  OIDS=TRUE is not recommended for user-created tables. Use OIDS=FALSE to prevent wrap-around of the OID counter
+COPY test_copy_from_on_segment_withoids FROM '/tmp/withoids_valid_filename<SEGID>.csv' WITH ON SEGMENT OIDS CSV QUOTE '"' ESCAPE E'\\' NULL '\N' DELIMITER ',' IGNORE EXTERNAL PARTITIONS;
+SELECT * FROM test_copy_from_on_segment_withoids ORDER BY a;
+ a | b | c 
+---+---+---
+ 1 | s | d
+ 2 | f | g
+ 3 | h | j
+(3 rows)
+
 CREATE TABLE onek_copy_onsegment (
     unique1     int4,
     unique2     int4,
@@ -781,6 +868,15 @@ SELECT * FROM check_onek_copy_onsegment;
  1000
 (1 row)
 
+CREATE TABLE onek_copy_from_onsegment (LIKE onek_copy_onsegment);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+COPY onek_copy_from_onsegment FROM '/tmp/valid_filename_onek_copy_onsegment<SEGID>.txt' ON SEGMENT;
+SELECT count(*) FROM onek_copy_from_onsegment;
+ count 
+-------
+  1000
+(1 row)
+
 CREATE EXTERNAL WEB TABLE rm_copy_onsegment_files (a int)
 EXECUTE E'(rm -rf /tmp/*valid_filename*.*)'
 ON SEGMENT 0
@@ -791,6 +887,12 @@ SELECT * FROM rm_copy_onsegment_files;
 (0 rows)
 
 DROP TABLE IF EXISTS test_copy_on_segment;
+DROP TABLE IF EXISTS test_copy_on_segment_withoids;
+DROP TABLE IF EXISTS test_copy_from_on_segment_txt;
+DROP TABLE IF EXISTS test_copy_from_on_segment_binary;
+DROP TABLE IF EXISTS test_copy_from_on_segment_csv;
+DROP TABLE IF EXISTS test_copy_from_on_segment_withoids;
+DROP TABLE IF EXISTS onek_copy_from_onsegment;
 DROP EXTERNAL TABLE IF EXISTS check_copy_onsegment_txt1;
 DROP EXTERNAL TABLE IF EXISTS check_copy_onsegment_csv1;
 DROP EXTERNAL TABLE IF EXISTS check_onek_copy_onsegment;

--- a/src/test/regress/expected/gpcopy.out
+++ b/src/test/regress/expected/gpcopy.out
@@ -871,6 +871,11 @@ SELECT * FROM check_onek_copy_onsegment;
 CREATE TABLE onek_copy_from_onsegment (LIKE onek_copy_onsegment);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 COPY onek_copy_from_onsegment FROM '/tmp/valid_filename_onek_copy_onsegment<SEGID>.txt' ON SEGMENT;
+SELECT * FROM onek_copy_onsegment EXCEPT SELECT * FROM onek_copy_from_onsegment;
+ unique1 | unique2 | two | four | ten | twenty | hundred | thousand | twothousand | fivethous | tenthous | odd | even | stringu1 | stringu2 | string4 
+---------+---------+-----+------+-----+--------+---------+----------+-------------+-----------+----------+-----+------+----------+----------+---------
+(0 rows)
+
 SELECT count(*) FROM onek_copy_from_onsegment;
  count 
 -------

--- a/src/test/regress/sql/gpcopy.sql
+++ b/src/test/regress/sql/gpcopy.sql
@@ -654,6 +654,26 @@ COPY errcopy from stdin delimiter '/' log errors segment reject limit 3 rows;
 \.
 SELECT relname, filename, bytenum, errmsg FROM gp_read_error_log('errcopy');
 
+-- exceed reject limit  on segment
+DROP TABLE IF EXISTS segment_reject_limit;
+CREATE TABLE segment_reject_limit (a int,b char) distributed by (a);
+INSERT INTO segment_reject_limit values(1,'1');
+INSERT INTO segment_reject_limit values(1,'2');
+INSERT INTO segment_reject_limit values(1,'a');
+INSERT INTO segment_reject_limit values(1,'b');
+
+COPY segment_reject_limit TO '/tmp/segment_reject_limit<SEGID>.csv' on segment;
+
+DROP TABLE IF EXISTS segment_reject_limit_from;
+CREATE TABLE segment_reject_limit_from (a int,b int);
+COPY segment_reject_limit_from from '/tmp/segment_reject_limit<SEGID>.csv' on segment log errors segment reject limit 2 rows;
+
+SELECT * FROM segment_reject_limit_from;
+SELECT relname, filename, bytenum, errmsg FROM gp_read_error_log('segment_reject_limit_from');
+--not exceed reject limit  on segment
+COPY segment_reject_limit_from from '/tmp/segment_reject_limit<SEGID>.csv' on segment log errors segment reject limit 3 rows;
+SELECT * FROM segment_reject_limit_from;
+
 -- gp_initial_bad_row_limit guc test. This guc allows user to set the initial
 -- number of rows which can contain errors before the database stops loading
 -- the data. If there is a valid row within the first 'n' rows specified by
@@ -696,8 +716,15 @@ SELECT COUNT(*) FROM test_first_segment_reject_limit;
 
 -- start_ignore
 DROP TABLE IF EXISTS test_copy_on_segment;
+DROP TABLE IF EXISTS test_copy_on_segment_withoids;
+DROP TABLE IF EXISTS test_copy_from_on_segment_txt;
+DROP TABLE IF EXISTS test_copy_from_on_segment_binary;
+DROP TABLE IF EXISTS test_copy_from_on_segment_csv;
+DROP TABLE IF EXISTS test_copy_from_on_segment_withoids;
+DROP TABLE IF EXISTS onek_copy_from_onsegment;
 DROP EXTERNAL TABLE IF EXISTS check_copy_onsegment_txt1;
 DROP EXTERNAL TABLE IF EXISTS check_copy_onsegment_csv1;
+DROP EXTERNAL TABLE IF EXISTS check_onek_copy_onsegment;
 DROP EXTERNAL TABLE IF EXISTS rm_copy_onsegment_files;
 -- end_ignore
 
@@ -737,6 +764,23 @@ ON SEGMENT 0
 FORMAT 'text';
 SELECT * FROM check_copy_onsegment_withoids;
 
+CREATE TABLE test_copy_from_on_segment_txt (LIKE test_copy_on_segment);
+COPY test_copy_from_on_segment_txt FROM '/tmp/invalid_filename.txt' ON SEGMENT;
+COPY test_copy_from_on_segment_txt FROM '/tmp/valid_filename<SEGID>.txt' ON SEGMENT;
+SELECT * FROM test_copy_from_on_segment_txt ORDER BY a;
+
+CREATE TABLE test_copy_from_on_segment_binary (LIKE test_copy_on_segment);
+COPY test_copy_from_on_segment_binary FROM '/tmp/valid_filename<SEGID>.bin' ON SEGMENT BINARY;
+SELECT * FROM test_copy_from_on_segment_binary ORDER BY a;
+
+CREATE TABLE test_copy_from_on_segment_csv (LIKE test_copy_on_segment);
+COPY test_copy_from_on_segment_csv FROM '/tmp/valid_filename<SEGID>.csv' WITH ON SEGMENT CSV QUOTE '"' ESCAPE E'\\' NULL '\N' DELIMITER ',' HEADER IGNORE EXTERNAL PARTITIONS;
+SELECT * FROM test_copy_from_on_segment_csv ORDER BY a;
+
+CREATE TABLE test_copy_from_on_segment_withoids (LIKE test_copy_on_segment_withoids) WITH OIDS;
+COPY test_copy_from_on_segment_withoids FROM '/tmp/withoids_valid_filename<SEGID>.csv' WITH ON SEGMENT OIDS CSV QUOTE '"' ESCAPE E'\\' NULL '\N' DELIMITER ',' IGNORE EXTERNAL PARTITIONS;
+SELECT * FROM test_copy_from_on_segment_withoids ORDER BY a;
+
 CREATE TABLE onek_copy_onsegment (
     unique1     int4,
     unique2     int4,
@@ -765,6 +809,10 @@ ON SEGMENT 0
 FORMAT 'text';
 SELECT * FROM check_onek_copy_onsegment;
 
+CREATE TABLE onek_copy_from_onsegment (LIKE onek_copy_onsegment);
+COPY onek_copy_from_onsegment FROM '/tmp/valid_filename_onek_copy_onsegment<SEGID>.txt' ON SEGMENT;
+SELECT count(*) FROM onek_copy_from_onsegment;
+
 CREATE EXTERNAL WEB TABLE rm_copy_onsegment_files (a int)
 EXECUTE E'(rm -rf /tmp/*valid_filename*.*)'
 ON SEGMENT 0
@@ -772,6 +820,12 @@ FORMAT 'text';
 SELECT * FROM rm_copy_onsegment_files;
 
 DROP TABLE IF EXISTS test_copy_on_segment;
+DROP TABLE IF EXISTS test_copy_on_segment_withoids;
+DROP TABLE IF EXISTS test_copy_from_on_segment_txt;
+DROP TABLE IF EXISTS test_copy_from_on_segment_binary;
+DROP TABLE IF EXISTS test_copy_from_on_segment_csv;
+DROP TABLE IF EXISTS test_copy_from_on_segment_withoids;
+DROP TABLE IF EXISTS onek_copy_from_onsegment;
 DROP EXTERNAL TABLE IF EXISTS check_copy_onsegment_txt1;
 DROP EXTERNAL TABLE IF EXISTS check_copy_onsegment_csv1;
 DROP EXTERNAL TABLE IF EXISTS check_onek_copy_onsegment;

--- a/src/test/regress/sql/gpcopy.sql
+++ b/src/test/regress/sql/gpcopy.sql
@@ -811,6 +811,7 @@ SELECT * FROM check_onek_copy_onsegment;
 
 CREATE TABLE onek_copy_from_onsegment (LIKE onek_copy_onsegment);
 COPY onek_copy_from_onsegment FROM '/tmp/valid_filename_onek_copy_onsegment<SEGID>.txt' ON SEGMENT;
+SELECT * FROM onek_copy_onsegment EXCEPT SELECT * FROM onek_copy_from_onsegment;
 SELECT count(*) FROM onek_copy_from_onsegment;
 
 CREATE EXTERNAL WEB TABLE rm_copy_onsegment_files (a int)


### PR DESCRIPTION
Support COPY statement that imports the data file on segments directly
parallel. It could be used to import data files generated by "COPY ...
to ... ON SEGMENT'.

This commit also supports all kinds of data file formats which "COPY ...
TO" supports, processes reject limit numbers and logs errors accordingly.

Key workflow:
   a) For COPY FROM, nothing changed by this commit, dispatch modified
   COPY command to segments at first, then read data file on master, and
   dispatch the data to relevant segment to process.

   b) For COPY FROM ON SEGMENT, on QD, read dummy data file, other parts
   keep unchanged, on QE, process the data stream (empty) dispatched
   from QD at first, then re-do the same workflow to read and process
   the local segment data file.

Signed-off-by: Ming LI <mli@pivotal.io>
Signed-off-by: Adam Lee <ali@pivotal.io>
Signed-off-by: Haozhou Wang <hawang@pivotal.io>
Signed-off-by: Xiaoran Wang <xiwang@pivotal.io>