### PR TITLE
Fix rtable index of FunctionScan when translating GPORCA plan.

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -1852,14 +1852,8 @@ CTranslatorDXLToPlStmt::PplanFunctionScanFromDXLTVF
 	// translation context for column mappings
 	CDXLTranslateContextBaseTable dxltrctxbt(m_pmp);
 
-	// we will add the new range table entry as the last element of the range table
-	Index iRel = gpdb::UlListLength(m_pctxdxltoplstmt->PlPrte()) + 1;
-
-	dxltrctxbt.SetIdx(iRel);
-
 	// create function scan node
 	FunctionScan *pfuncscan = MakeNode(FunctionScan);
-	pfuncscan->scan.scanrelid = iRel;
 	Plan *pplan = &(pfuncscan->scan.plan);
 
 	RangeTblEntry *prte = PrteFromDXLTVF(pdxlnTVF, pdxltrctxOut, &dxltrctxbt, pplan);
@@ -1867,6 +1861,11 @@ CTranslatorDXLToPlStmt::PplanFunctionScanFromDXLTVF
 
 	pfuncscan->funcexpr = prte->funcexpr;
 	pfuncscan->funccolnames = prte->eref->colnames;
+
+	// we will add the new range table entry as the last element of the range table
+	Index iRel = gpdb::UlListLength(m_pctxdxltoplstmt->PlPrte()) + 1;
+	dxltrctxbt.SetIdx(iRel);
+	pfuncscan->scan.scanrelid = iRel;
 
 	m_pctxdxltoplstmt->AddRTE(prte);
 

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -10139,6 +10139,17 @@ LOG:  statement: create table foo_ctas(a) as (select generate_series(1,10)) dist
 reset client_min_messages;
 LOG:  statement: reset client_min_messages;
 reset optimizer_enable_ctas;
+-- TVF with a subplan that generates an RTABLE entry
+create table bar(name text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'name' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into bar values('person');
+select * from unnest((select string_to_array(name, ',') from bar)) as a;
+   a    
+--------
+ person
+(1 row)
+
 -- clean up
 drop schema orca cascade;
 NOTICE:  drop cascades to table orca.index_test

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -10198,6 +10198,21 @@ LOG:  Planner produced plan :0
 reset client_min_messages;
 LOG:  statement: reset client_min_messages;
 reset optimizer_enable_ctas;
+-- start_ignore
+drop table bar;
+ERROR:  table "bar" does not exist
+-- end_ignore
+-- TVF with a subplan that generates an RTABLE entry
+create table bar(name text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'name' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into bar values('person');
+select * from unnest((select string_to_array(name, ',') from bar)) as a;
+   a    
+--------
+ person
+(1 row)
+
 -- clean up
 drop schema orca cascade;
 NOTICE:  drop cascades to table orca.index_test

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -1404,6 +1404,14 @@ create table foo_ctas(a) as (select generate_series(1,10)) distributed by (a);
 reset client_min_messages;
 reset optimizer_enable_ctas;
 
+-- start_ignore
+drop table bar;
+-- end_ignore
+-- TVF with a subplan that generates an RTABLE entry
+create table bar(name text);
+insert into bar values('person');
+select * from unnest((select string_to_array(name, ',') from bar)) as a;
+
 -- clean up
 drop schema orca cascade;
 reset optimizer_segments;


### PR DESCRIPTION
Arguments to the function scan can themselve have a subquery that can create new rtable entries. Therefore, first translate all arguments of the FunctionScan before setting scanrelid of the
FunctionScan.