### PR TITLE
Fix resgroup assert failure

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -2249,7 +2249,7 @@ StartTransaction(void)
 			 TransStateAsString(s->state));
 
 	/* Acquire a resource group slot at the beginning of a transaction */
-	if (IsResGroupEnabled() && IsNormalProcessingMode() && Gp_role == GP_ROLE_DISPATCH)
+	if (ShouldAssignResGroupOnMaster())
 		AssignResGroupOnMaster();
 
 	/*
@@ -2837,7 +2837,7 @@ CommitTransaction(void)
 	freeGangsForPortal(NULL);
 
 	/* Release resource group slot at the end of a transaction */
-	if (IsResGroupEnabled() && IsNormalProcessingMode() && Gp_role == GP_ROLE_DISPATCH)
+	if (ShouldAssignResGroupOnMaster())
 		UnassignResGroupOnMaster();
 }
 
@@ -3390,7 +3390,7 @@ CleanupTransaction(void)
 	finishDistributedTransactionContext("CleanupTransaction", true);
 
 	/* Release resource group slot at the end of a transaction */
-	if (IsResGroupEnabled() && IsNormalProcessingMode() && Gp_role == GP_ROLE_DISPATCH)
+	if (ShouldAssignResGroupOnMaster())
 		UnassignResGroupOnMaster();
 }
 

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -1288,10 +1288,22 @@ SwitchResGroupOnSegment(const char *buf, int len)
 
 	if (procInfo->groupId == InvalidOid)
 	{
-		/* FIXME: below Assert() might be wrong */
-		Assert(prevGroupId == InvalidOid);
-		Assert(prevSlotId == InvalidSlotId);
-		Assert(MyResGroupSharedInfo == NULL);
+		prevSharedInfo = MyResGroupSharedInfo;
+		MyResGroupSharedInfo = NULL;
+
+		if (prevSharedInfo)
+		{
+			Assert(prevSharedInfo->groupId == prevGroupId);
+			prevSlot = &prevSharedInfo->slots[prevSlotId];
+			detachFromSlot(prevSharedInfo, prevSlot, procInfo);
+		}
+		else
+		{
+			Assert(prevGroupId == InvalidOid);
+			Assert(prevSlotId == InvalidSlotId);
+			Assert(MyResGroupSharedInfo == NULL);
+		}
+
 		return;
 	}
 

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -29,6 +29,7 @@
 #include "storage/lock.h"
 #include "storage/pg_shmem.h"
 #include "storage/proc.h"
+#include "storage/procsignal.h"
 #include "utils/builtins.h"
 #include "utils/fmgroids.h"
 #include "utils/memutils.h"
@@ -1143,6 +1144,18 @@ DeserializeResGroupInfo(const char *buf, int len)
 	ptr += sizeof(procInfo->config.spillRatio);
 
 	Assert(len == ptr - buf);
+}
+
+/*
+ * Check whether should assign resource group on master.
+ */
+bool
+ShouldAssignResGroupOnMaster(void)
+{
+	return IsResGroupEnabled() &&
+		IsNormalProcessingMode() &&
+		Gp_role == GP_ROLE_DISPATCH &&
+		!AmIInSIGUSR1Handler();
 }
 
 /*

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -165,6 +165,12 @@ static void ResGroupWait(ResGroupData *group, bool isLocked);
 static bool ResGroupCreate(Oid groupId);
 static void AtProcExit_ResGroup(int code, Datum arg);
 static void ResGroupWaitCancel(void);
+static void attachToSlot(ResGroupData *group,
+						 ResGroupSlotData *slot,
+						 ResGroupProcData *self);
+static void detachFromSlot(ResGroupData *group,
+						   ResGroupSlotData *slot,
+						   ResGroupProcData *self);
 static int getFreeSlot(void);
 static int ResGroupSlotAcquire(void);
 static void addTotalQueueDuration(ResGroupData *group);
@@ -829,6 +835,80 @@ ResGroupCreate(Oid groupId)
 	return true;
 }
 
+/*
+ * Attach current proc to a resource group & slot.
+ *
+ * Current proc's memory usage will be added to the group & slot.
+ */
+static void
+attachToSlot(ResGroupData *group,
+			 ResGroupSlotData *slot,
+			 ResGroupProcData *self)
+{
+	int32			slotMemUsage;
+	int32			sharedMemUsage;
+
+	pg_atomic_add_fetch_u32((pg_atomic_uint32 *) &slot->nProcs, 1);
+
+	/* Add proc memory accounting info to memUsage in slot */
+	slotMemUsage = pg_atomic_add_fetch_u32((pg_atomic_uint32 *) &slot->memUsage,
+										   self->memUsage);
+
+	/* Add proc memory accounting info to memSharedUsage in group */
+	sharedMemUsage = slotMemUsage - slot->memQuota;
+	if (sharedMemUsage > 0)
+	{
+		/* Decide how many shared memory is in use by proc */
+		sharedMemUsage = Min(sharedMemUsage, self->memUsage);
+		pg_atomic_add_fetch_u32((pg_atomic_uint32 *) &group->memSharedUsage,
+								sharedMemUsage);
+	}
+
+	/* Add proc memory accounting info to memUsage in group */
+	pg_atomic_add_fetch_u32((pg_atomic_uint32 *) &group->memUsage,
+							self->memUsage);
+}
+
+/*
+ * Detach current proc from a resource group & slot.
+ *
+ * Current proc's memory usage will be substracted from the group & slot.
+ */
+static void
+detachFromSlot(ResGroupData *group,
+			   ResGroupSlotData *slot,
+			   ResGroupProcData *self)
+{
+	int32			value;
+	int32			slotMemUsage;
+	int32			sharedMemUsage;
+
+	/* Sub proc memory accounting info from memUsage in group */
+	value = pg_atomic_sub_fetch_u32((pg_atomic_uint32 *) &group->memUsage,
+									self->memUsage);
+	Assert(value >= 0);
+
+	/* Sub proc memory accounting info from memUsage in slot */
+	slotMemUsage = pg_atomic_fetch_sub_u32((pg_atomic_uint32 *) &slot->memUsage,
+										   self->memUsage);
+	Assert(slotMemUsage >= self->memUsage);
+
+	/* Sub proc memory accounting info from memSharedUsage in group */
+	sharedMemUsage = slotMemUsage - slot->memQuota;
+	if (sharedMemUsage > 0)
+	{
+		/* Decide how many shared memory is in use by proc */
+		int32 returnSize = Min(self->memUsage, sharedMemUsage);
+
+		value = pg_atomic_sub_fetch_u32((pg_atomic_uint32 *) &group->memSharedUsage,
+										returnSize);
+		Assert(value >= 0);
+	}
+
+	value = pg_atomic_sub_fetch_u32((pg_atomic_uint32*)&slot->nProcs, 1);
+	Assert(value >= 0);
+}
+
 static int
 getFreeSlot(void)
 {
@@ -1081,8 +1161,6 @@ AssignResGroupOnMaster(void)
 	int		memoryLimit, sharedQuota, spillRatio;
 	int		slotId;
 	Oid		groupId;
-	int32	slotMemUsage;
-	int32	sharedMemUsage;
 
 	Assert(Gp_role == GP_ROLE_DISPATCH);
 
@@ -1107,7 +1185,6 @@ AssignResGroupOnMaster(void)
 	slot->memLimit = slot->segmentChunks * memoryLimit / 100;
 	slot->memSharedQuota = slot->memLimit * sharedQuota / 100;
 	slot->memQuota = slot->memLimit * (100 - sharedQuota) / concurrency / 100;
-	pg_atomic_add_fetch_u32((pg_atomic_uint32*)&slot->nProcs, 1);
 	Assert(slot->memLimit > 0);
 	Assert(slot->memQuota > 0);
 
@@ -1122,21 +1199,7 @@ AssignResGroupOnMaster(void)
 	Assert(pResGroupControl != NULL);
 	Assert(pResGroupControl->segmentsOnMaster > 0);
 
-	/* Add proc memory accounting info to slot */
-	slotMemUsage = pg_atomic_add_fetch_u32((pg_atomic_uint32*)&slot->memUsage,
-										   procInfo->memUsage);
-
-	/* Add proc memory accounting info to memSharedUsage in sharedInfo */
-	sharedMemUsage = slotMemUsage - slot->memQuota;
-	if (sharedMemUsage > 0)
-	{
-		sharedMemUsage = Min(sharedMemUsage, procInfo->memUsage);
-		pg_atomic_add_fetch_u32((pg_atomic_uint32*)&sharedInfo->memSharedUsage, sharedMemUsage);
-	}
-
-	/* Add proc memory accounting info to memUsage in sharedInfo */
-	pg_atomic_add_fetch_u32((pg_atomic_uint32*)&sharedInfo->memUsage,
-							procInfo->memUsage);
+	attachToSlot(sharedInfo, slot, procInfo);
 
 	/* Start memory limit checking */
 	Assert(procInfo->groupId != InvalidOid);
@@ -1156,8 +1219,6 @@ UnassignResGroupOnMaster(void)
 	ResGroupData		*sharedInfo;
 	ResGroupSlotData	*slot;
 	ResGroupProcData	*procInfo;
-	int32		sharedMemUsage;
-	uint32		oldUsage;
 
 	if (MyResGroupSharedInfo == NULL)
 	{
@@ -1177,26 +1238,7 @@ UnassignResGroupOnMaster(void)
 
 	slot = &sharedInfo->slots[procInfo->slotId];
 
-	/* Sub proc memory accounting info from memUsage in sharedInfo */
-	oldUsage = pg_atomic_fetch_sub_u32((pg_atomic_uint32*)&sharedInfo->memUsage,
-								procInfo->memUsage);
-	Assert(oldUsage >= procInfo->memUsage);
-
-	/* Sub proc memory accounting info from slot */
-	int slotMemUsage = pg_atomic_fetch_sub_u32((pg_atomic_uint32*)&slot->memUsage,
-												  procInfo->memUsage);
-	Assert(slotMemUsage >= procInfo->memUsage);
-
-	/* Sub proc memory accounting info from memSharedUsage in sharedInfo */
-	sharedMemUsage = slotMemUsage - slot->memQuota;
-	if (sharedMemUsage > 0)
-	{
-		int32 returnSize = Min(procInfo->memUsage, sharedMemUsage);
-
-		oldUsage = pg_atomic_fetch_sub_u32((pg_atomic_uint32 *)&sharedInfo->memSharedUsage,
-									returnSize);
-		Assert(oldUsage >= returnSize);
-	}
+	detachFromSlot(sharedInfo, slot, procInfo);
 
 	/* Cleanup procInfo */
 	if (procInfo->memUsage > 10)
@@ -1205,7 +1247,6 @@ UnassignResGroupOnMaster(void)
 	procInfo->slotId = InvalidSlotId;
 
 	/* Cleanup slotInfo */
-	pg_atomic_sub_fetch_u32((pg_atomic_uint32*)&slot->nProcs, 1);
 	slot->inUse = false;
 
 	/* Relesase the slot */
@@ -1287,53 +1328,10 @@ SwitchResGroupOnSegment(const char *buf, int len)
 
 	if (prevSharedInfo != sharedInfo || prevSlot != slot)
 	{
-		int32		slotMemUsage;
-		int32		sharedMemUsage;
+		if (prevSharedInfo)
+			detachFromSlot(prevSharedInfo, prevSlot, procInfo);
 
-		if (prevSharedInfo != NULL)
-		{
-			uint32 oldUsage;
-
-			pg_atomic_sub_fetch_u32((pg_atomic_uint32*)&prevSlot->nProcs, 1);
-
-			/* Sub proc memory accounting info from memUsage in previous sharedInfo */
-			oldUsage = pg_atomic_fetch_sub_u32((pg_atomic_uint32*)&prevSharedInfo->memUsage,
-										procInfo->memUsage);
-			Assert(oldUsage >= procInfo->memUsage);
-
-			/* Sub proc memory accounting info from slot */
-			slotMemUsage = pg_atomic_fetch_sub_u32((pg_atomic_uint32*)&prevSlot->memUsage,
-												   procInfo->memUsage);
-			Assert(slotMemUsage >= procInfo->memUsage);
-
-			/* Sub proc memory accounting info from memSharedUsage in previous sharedInfo */
-			sharedMemUsage = slotMemUsage - prevSlot->memQuota;
-			if (sharedMemUsage > 0)
-			{
-				int32 returnSize = Min(procInfo->memUsage, sharedMemUsage);
-
-				oldUsage = pg_atomic_fetch_sub_u32((pg_atomic_uint32 *)&prevSharedInfo->memSharedUsage,
-											returnSize);
-				Assert(oldUsage >= returnSize);
-			}
-		}
-
-		pg_atomic_add_fetch_u32((pg_atomic_uint32*)&slot->nProcs, 1);
-		/* Add proc memory accounting info to slot */
-		slotMemUsage = pg_atomic_add_fetch_u32((pg_atomic_uint32*)&slot->memUsage,
-											   procInfo->memUsage);
-
-		/* Add proc memory accounting info to memSharedUsage in sharedInfo */
-		sharedMemUsage = slotMemUsage - slot->memQuota;
-		if (sharedMemUsage > 0)
-		{
-			sharedMemUsage = Min(sharedMemUsage, procInfo->memUsage);
-			pg_atomic_add_fetch_u32((pg_atomic_uint32*)&sharedInfo->memSharedUsage, sharedMemUsage);
-		}
-
-		/* Add proc memory accounting info to memUsage in sharedInfo */
-		pg_atomic_add_fetch_u32((pg_atomic_uint32*)&sharedInfo->memUsage,
-								procInfo->memUsage);
+		attachToSlot(sharedInfo, slot, procInfo);
 	}
 
 	MyResGroupSharedInfo = sharedInfo;

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -49,6 +49,7 @@ extern void FreeResGroupEntry(Oid groupId);
 extern void SerializeResGroupInfo(StringInfo str);
 extern void DeserializeResGroupInfo(const char *buf, int len);
 
+extern bool ShouldAssignResGroupOnMaster(void);
 extern void AssignResGroupOnMaster(void);
 extern void UnassignResGroupOnMaster(void);
 extern void SwitchResGroupOnSegment(const char *buf, int len);


### PR DESCRIPTION
    Fix the resgroup assert failure on CREATE INDEX CONCURRENTLY syntax.

    When resgroup is enabled an assertion failure will be encountered with
    below case:

        SET gp_create_index_concurrently TO true;
        DROP TABLE IF EXISTS concur_heap;
        CREATE TABLE concur_heap (f1 text, f2 text, dk text) distributed by (dk);
        CREATE INDEX CONCURRENTLY concur_index1 ON concur_heap(f2,f1);

    The root cause is that we had the assumption on QD that a command is
    dispatched to QEs when assigned to a resgroup, but this is false with
    CREATE INDEX CONCURRENTLY syntax.

    To fix it we have to make necessary check and cleanup on QEs.