### PR TITLE
Set correct errcode for COPY .. ON SEGMENT ereport

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -1304,7 +1304,8 @@ DoCopyInternal(const CopyStmt *stmt, const char *queryString, CopyState cstate)
 
 			if (strstr(stmt->filename, "<SEGID>") == NULL)
 				ereport(ERROR,
-					(0, errmsg("<SEGID> is required for file name")));
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("<SEGID> is required for file name")));
 
 			char segid_buf[8];
 			snprintf(segid_buf, 8, "%d", GpIdentity.segindex);

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -86,10 +86,6 @@ s/Table "pg_temp_\d+.temp/Table "pg_temp_#####/
 m/^\d+.*gpfaultinjector.*-\[INFO\]:-/
 s/^\d+.*gpfaultinjector.*-\[INFO\]:-//
 
-# Mask out line numbers
-m/ERROR:  <SEGID> is required for file name.*/
-s/ERROR:  <SEGID> is required for file name.*/ERROR:  <SEGID> is required for file name/
-
 # Mask out oid in error concurrent drop message
 m/\d+ was concurrently dropped/
 s/\d+ was concurrently dropped/##### was concurrently dropped/


### PR DESCRIPTION
Using errcode 0 will cause `ereport()` to treat it as an internal error and print the filename/line. Since this is a userfacing error it should have a proper errcode to avoid this. This also allow the gpdiff rule to be removed.

Spotted while reviewing #2804 