### PR TITLE
Fix Travis: Install libevent in Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,11 @@ sudo: false
 git:
   submodules: false
 
+addons:
+  apt:
+    packages:
+    - libevent-dev
+
 ## ----------------------------------------------------------------------
 ## Build tools
 ## ----------------------------------------------------------------------
@@ -97,15 +102,6 @@ script:
   - gpssh --version
   - gpmapreduce --version
   - gpfdist --version
-
-## ----------------------------------------------------------------------
-## Before install 
-## install libevent 
-## ----------------------------------------------------------------------
-before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then 
-       brew install libevent;
-    fi
 
 ## ----------------------------------------------------------------------
 ## Notification


### PR DESCRIPTION
Since Travis CI was upgraded to use Ubuntu Trusty as the base Linux [0], libevent-dev is no longer available out of the box. Install it manually with the Apt addon since we don't want to use sudo due to longer instance bootup time. While at it, remove the macOS section since we never actually supported Travis for macOS builds.

[0] https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming