### PR TITLE
Generate a table file during a filtered backup

### DIFF
--- a/gpMgmt/bin/gpcrondump
+++ b/gpMgmt/bin/gpcrondump
@@ -989,9 +989,11 @@ class GpCronDump(Operation):
         file_list = []
         master_file_list = ['cdatabase', 'ao', 'co', 'last_operation', 'report', 'status']
 
-        if self.context.dump_prefix and (self.context.include_dump_tables_file or self.context.exclude_dump_tables_file or \
+        if (self.context.include_dump_tables_file or self.context.exclude_dump_tables_file or \
                                          self.context.include_dump_tables or self.context.exclude_dump_tables):
-            master_file_list.append('filter')
+            if self.context.dump_prefix:
+                master_file_list.append('filter')
+            master_file_list.append('table')
 
         for filetype in master_file_list:
             file_list.append('%s:%s' % (master.getSegmentHostName(), self.context.generate_filename(filetype)))

--- a/gpMgmt/bin/gppylib/operations/backup_utils.py
+++ b/gpMgmt/bin/gppylib/operations/backup_utils.py
@@ -25,7 +25,7 @@ class Context(Values, object):
         "increments": ("dump", "_increments"), "last_operation": ("dump", "_last_operation"), "master_config": ("master_config_files", ".tar"),
         "metadata": ("dump_%(content)d_%(dbid)s", ""), "partition_list": ("dump", "_table_list"), "pipes": ("dump", "_pipes"), "plan": ("restore", "_plan"),
         "postdata": ("dump_%(content)d_%(dbid)s", "_post_data"), "report": ("dump", ".rpt"), "schema": ("dump", "_schema"),
-        "segment_config": ("segment_config_files_%(content)d_%(dbid)s", ".tar"), "stats": ("statistics_%(content)d_%(dbid)s", ""),
+        "segment_config": ("segment_config_files_%(content)d_%(dbid)s", ".tar"), "stats": ("statistics_%(content)d_%(dbid)s", ""), "table": ("dump", "_table"),
         "status": ("dump_status_%(content)d_%(dbid)s", ""),
     }
     defaults = {

--- a/gpMgmt/bin/gppylib/operations/dump.py
+++ b/gpMgmt/bin/gppylib/operations/dump.py
@@ -529,7 +529,8 @@ class DumpDatabase(Operation):
 
         # create filter file based on the include_dump_tables_file before we do formating of contents
         if self.context.dump_prefix and not self.context.incremental:
-            self.create_filter_file()
+            self.create_filter_file("filter")
+        self.create_filter_file("table")
 
         # Format sql strings for all schema and table names
         self.context.include_dump_tables_file = formatSQLString(rel_file=self.context.include_dump_tables_file, isTableName=True)
@@ -563,8 +564,8 @@ class DumpDatabase(Operation):
     # If using -t, copy the filter file over the table list to be passed to the master
     # If using -T, get the intersection of the filter and the table list
     # In either case, the filter file contains the list of tables to include
-    def create_filter_file(self):
-        filter_name = self.context.generate_filename("filter")
+    def create_filter_file(self, filetype):
+        filter_name = self.context.generate_filename(filetype)
         if self.context.include_dump_tables_file:
             shutil.copyfile(self.context.include_dump_tables_file, filter_name)
             if self.context.netbackup_service_host:

--- a/gpMgmt/bin/gppylib/test/unit/test_cluster_gpcrondump.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_cluster_gpcrondump.py
@@ -731,7 +731,7 @@ class GpcrondumpTestCase(unittest.TestCase):
                                'foo1:%s/db_dumps/20130101/gp_dump_20130101010101_last_operation' % self.options.masterDataDirectory,
                                'foo1:%s/db_dumps/20130101/gp_dump_20130101010101.rpt' % self.options.masterDataDirectory,
                                'foo1:%s/db_dumps/20130101/gp_dump_status_-1_1_20130101010101' % self.options.masterDataDirectory]
-        self.assertEqual(files_file_list, expected_files_list)
+        self.assertEqual(sorted(files_file_list), sorted(expected_files_list))
 
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gppylib.operations.backup_utils.Context.get_master_port')
@@ -750,7 +750,7 @@ class GpcrondumpTestCase(unittest.TestCase):
                                'foo2:%s/db_dumps/20130101/gp_dump_20130101010101_last_operation' % self.options.masterDataDirectory,
                                'foo2:%s/db_dumps/20130101/gp_dump_20130101010101.rpt' % self.options.masterDataDirectory,
                                'foo2:%s/db_dumps/20130101/gp_dump_status_-1_1_20130101010101' % self.options.masterDataDirectory]
-        self.assertEqual(files_file_list, expected_files_list)
+        self.assertEqual(sorted(files_file_list), sorted(expected_files_list))
 
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gpcrondump.get_latest_full_dump_timestamp', return_value='20130101000000')
@@ -770,15 +770,15 @@ class GpcrondumpTestCase(unittest.TestCase):
                                'foo1:%s/db_dumps/20130101/gp_dump_20130101010101_ao_state_file' % self.options.masterDataDirectory,
                                'foo1:%s/db_dumps/20130101/gp_dump_20130101010101_co_state_file' % self.options.masterDataDirectory,
                                'foo1:%s/db_dumps/20130101/gp_dump_20130101010101_last_operation' % self.options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/gp_dump_20130101010101.rpt' % self.options.masterDataDirectory,
                                'foo1:%s/db_dumps/20130101/gp_dump_status_-1_1_20130101010101' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/gp_dump_20130101010101.rpt' % self.options.masterDataDirectory,
                                'foo1:%s/db_dumps/20130101/gp_dump_20130101000000_increments' % self.options.masterDataDirectory]
         self.assertEqual(sorted(files_file_list), sorted(expected_files_list))
 
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gppylib.operations.backup_utils.get_latest_full_dump_timestamp', return_value='20130101000000')
     @patch('gppylib.operations.backup_utils.Context.get_master_port')
-    def test_get_files_file_list_with_filter(self, mock1, mock2, mock3, mock4):
+    def test_get_files_file_list_with_filter_and_prefix(self, mock1, mock2, mock3, mock4):
         self.options.timestamp_key = '20130101010101'
         self.options.local_dump_prefix = 'metro'
         self.options.include_dump_tables_file = 'bar'
@@ -795,7 +795,30 @@ class GpcrondumpTestCase(unittest.TestCase):
                                'foo1:%s/db_dumps/20130101/metro_gp_dump_20130101010101_last_operation' % self.options.masterDataDirectory,
                                'foo1:%s/db_dumps/20130101/metro_gp_dump_20130101010101.rpt' % self.options.masterDataDirectory,
                                'foo1:%s/db_dumps/20130101/metro_gp_dump_status_-1_1_20130101010101' % self.options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/metro_gp_dump_20130101010101_filter' % self.options.masterDataDirectory]
+                               'foo1:%s/db_dumps/20130101/metro_gp_dump_20130101010101_filter' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/metro_gp_dump_20130101010101_table' % self.options.masterDataDirectory]
+        self.assertEqual(sorted(files_file_list), sorted(expected_files_list))
+
+    @patch('gpcrondump.validate_current_timestamp')
+    @patch('gppylib.operations.backup_utils.get_latest_full_dump_timestamp', return_value='20130101000000')
+    @patch('gppylib.operations.backup_utils.Context.get_master_port')
+    def test_get_files_file_list_with_filter_no_prefix(self, mock1, mock2, mock3, mock4):
+        self.options.timestamp_key = '20130101010101'
+        self.options.include_dump_tables_file = 'bar'
+        self.options.masterDataDirectory = '/data/foo'
+        gpcd = GpCronDump(self.options, None)
+        master = Mock()
+        master.getSegmentHostName.return_value = 'foo1'
+        gpcd.context.timestamp = '20130101010101'
+        dump_dir = gpcd.context.get_backup_dir()
+        files_file_list = gpcd._get_files_file_list(master)
+        expected_files_list = ['foo1:%s/db_dumps/20130101/gp_cdatabase_-1_1_20130101010101' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/gp_dump_20130101010101_ao_state_file' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/gp_dump_20130101010101_co_state_file' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/gp_dump_20130101010101_last_operation' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/gp_dump_20130101010101.rpt' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/gp_dump_status_-1_1_20130101010101' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/gp_dump_20130101010101_table' % self.options.masterDataDirectory]
         self.assertEqual(sorted(files_file_list), sorted(expected_files_list))
 
     @patch('gpcrondump.validate_current_timestamp')

--- a/gpMgmt/test/behave/mgmt_utils/backup_and_restore_backups.feature
+++ b/gpMgmt/test/behave/mgmt_utils/backup_and_restore_backups.feature
@@ -208,6 +208,7 @@ Feature: Validate command line arguments
 
     @nbupartI
     @ddpartI
+    @skip_for_gpdb_43
     Scenario: 14 Full Backup with option -t and Restore
         Given the backup test is initialized with database "bkdb14"
         And there is a "heap" table "public.heap_table" in "bkdb14" with data
@@ -219,9 +220,11 @@ Feature: Validate command line arguments
         And the temp files "include_dump_tables" are not created in the system
         And the timestamp from gpcrondump is stored
         And verify that the "report" file in " " dir contains "Backup Type: Full"
+        And "table" file should be created under " "
 
     @nbupartI
     @ddpartI
+    @skip_for_gpdb_43
     Scenario: 15 Full Backup with option -T and Restore
         Given the backup test is initialized with database "bkdb15"
         And there is a "heap" table "public.heap_table" in "bkdb15" with data
@@ -232,6 +235,7 @@ Feature: Validate command line arguments
         Then gpcrondump should return a return code of 0
         And the temp files "exclude_dump_tables" are not created in the system
         And the timestamp from gpcrondump is stored
+        And "table" file should be created under " "
 
     @nbupartI
     @ddpartI

--- a/gpMgmt/test/behave/mgmt_utils/backup_and_restore_restores.feature
+++ b/gpMgmt/test/behave/mgmt_utils/backup_and_restore_restores.feature
@@ -123,6 +123,7 @@ Feature: Validate command line arguments
 
     @nbupartI
     @ddpartI
+    @skip_for_gpdb_43
     Scenario: 14 Full Backup with option -t and Restore
         Given the old timestamps are read from json
         When the user runs gpdbrestore -e with the stored timestamp
@@ -132,6 +133,7 @@ Feature: Validate command line arguments
 
     @nbupartI
     @ddpartI
+    @skip_for_gpdb_43
     Scenario: 15 Full Backup with option -T and Restore
         Given the old timestamps are read from json
         When the user runs gpdbrestore -e with the stored timestamp

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1614,6 +1614,8 @@ def impl(context, filetype, directory):
         filename = 'gp_dump_%s_filter' % context.backup_timestamp
     elif filetype == '_schema':
         filename = 'gp_dump_%s_schema' % context.backup_timestamp
+    elif filetype == 'table':
+        filename = 'gp_dump_%s_table' % context.backup_timestamp
     else:
         raise Exception("Unknown filetype '%s' specified" % filetype)
 


### PR DESCRIPTION
This file contains a list of schema-qualified tablenames in the backup
set.  It is not used in the restore process; it is there solely to allow
users to determine which tables were dumped in that backup set.

Signed-off-by: Jamie McAtamney <jmcatamney@pivotal.io>
Signed-off-by: Chris Hajas <chajas@pivotal.io>