### PR TITLE
Fix flaky 'insufficient memory reserved' pipeline issue

### DIFF
--- a/concourse/scripts/common.bash
+++ b/concourse/scripts/common.bash
@@ -39,6 +39,7 @@ function make_cluster() {
   # Currently, the max_concurrency tests in src/test/isolation2
   # require max_connections of at least 129.
   export DEFAULT_QD_MAX_CONNECT=150
+  export STATEMENT_MEM=250MB
   workaround_before_concourse_stops_stripping_suid_bits
   pushd gpdb_src/gpAux/gpdemo
     if [[ $CONFIGURE_FLAGS == *"--enable-segwalrep"* ]]; then

--- a/gpAux/gpdemo/demo_cluster.sh
+++ b/gpAux/gpdemo/demo_cluster.sh
@@ -317,6 +317,12 @@ cat >> $CLUSTER_CONFIG <<-EOF
 
 EOF
 
+if [ -n "${STATEMENT_MEM}" ]; then
+	cat >> $CLUSTER_CONFIG_POSTGRES_ADDONS<<-EOF
+		statement_mem = ${STATEMENT_MEM}
+	EOF
+fi
+
 ## ======================================================================
 ## Create cluster
 ## ======================================================================


### PR DESCRIPTION
The 'insufficient memory reserved' issue existed for a long time, the
root cause is the default statement_mem (125MB) is not enough for
queries using by gpcheckcat script when regression database is huge.

This commit increase statement_mem to 256MB for all ICW test cases.