### PR TITLE
Fix gpinitsystem options of -c and -I

### DIFF
--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -213,8 +213,16 @@ CHK_PARAMS () {
 			ERROR_EXIT "[FATAL]:-Unable to locate initdb" 2
 		fi
 		# Make sure that script has been supplied a config file
-		if [ x"" == x"$CLUSTER_CONFIG" ] && [ x"" == x"$INPUT_CONFIG" ] ; then
-				ERROR_EXIT "[FATAL]:-Greenplum configuration filename [-c] option or [-I] option not provided." 2
+		if [ x"$CLUSTER_CONFIG" = x"" ] && [ x"$INPUT_CONFIG" = x"" ]; then
+			LOG_MSG "[FATAL]:-Please specify either -c or -I as an option." 1
+			USAGE
+			ERROR_EXIT "[FATAL]:-Greenplum configuration filename [-c] option or [-I] option not provided." 2
+		fi
+
+		if [ -n "$CLUSTER_CONFIG" ] && [ -n "$INPUT_CONFIG" ]; then
+			LOG_MSG "[FATAL]:-Option -c and -I cannot be both specified." 1
+			USAGE
+			ERROR_EXIT "[FATAL]:-Received both Greenplum configuration filename options [-c] and [-I]." 2
 		fi
 		
 		if [ x"" != x"$CLUSTER_CONFIG" ] ; then
@@ -1970,10 +1978,6 @@ while getopts ":vaqe:c:l:-:p:m:h:n:s:P:F:b:DB:SI:O:" opt
 				* ) USAGE ;;
 		esac
 done
-
-if [ x"$CLUSTER_CONFIG" = x"" ] && [ x"$INPUT_CONFIG" = x"" ]; then
-		USAGE
-fi
 
 if [ x"" != x"$PG_CONF_ADD_FILE" ]; then
 	CHK_FILE $PG_CONF_ADD_FILE

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpinitsystem.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpinitsystem.py
@@ -1,0 +1,33 @@
+import os
+from mock import *
+from gp_unittest import *
+from StringIO import StringIO
+from subprocess import Popen, PIPE
+
+class GpInitSystemTest(GpTestCase):
+    def setUp(self):
+        # resolve the gpinitsystem path
+        self.gpinitsystem_path = os.path.realpath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../../gpinitsystem'))
+
+    def test_option_cluster_configfile_and_input_configfile_should_error(self):
+        p = Popen([self.gpinitsystem_path, '-c', 'cluster_configfile', '-I', 'input_configfile'], stdout=PIPE)
+        output = p.stdout.read()
+        self.assertIn("[FATAL]:-Option -c and -I cannot be both specified.", output)
+
+    def test_option_without_neither_cluster_configfile_and_input_configfile_should_error(self):
+        p = Popen([self.gpinitsystem_path], stdout=PIPE)
+        output = p.stdout.read()
+        self.assertIn("[FATAL]:-Please specify either -c or -I as an option.", output)
+
+    def test_option_with_input_configfile_should_work(self):
+        p = Popen([self.gpinitsystem_path, '-I', 'input_configfile'], stdout=PIPE)
+        output = p.stdout.read()
+        self.assertIn("[INFO]:-Checking configuration parameters, please wait...", output)
+
+    def test_option_with_cluster_configfile_should_work(self):
+        p = Popen([self.gpinitsystem_path, '-c', 'cluster_configfile'], stdout=PIPE)
+        output = p.stdout.read()
+        self.assertIn("[INFO]:-Checking configuration parameters, please wait...", output)
+
+if __name__ == '__main__':
+    run_tests()


### PR DESCRIPTION
Added tests to make sure only one of them need to be specified for the
gpinisystem to work.

Otherwise, we will see following error 
```
$/usr/local/gpdb/bin/gpinitsystem -a -c clusterConfigFile -I output_file
20170724:16:56:53:008106 gpinitsystem:aspen:pivotal-[INFO]:-Checking configuration parameters, please wait...
20170724:16:56:53:008106 gpinitsystem:aspen:pivotal-[INFO]:-Reading Greenplum configuration file clusterConfigFile
20170724:16:56:53:008106 gpinitsystem:aspen:pivotal-[INFO]:-Locale has not been set in clusterConfigFile, will set to default value
20170724:16:56:53:008106 gpinitsystem:aspen:pivotal-[INFO]:-Locale set to en_US.utf-8
20170724:16:56:53:008106 gpinitsystem:aspen:pivotal-[INFO]:-No DATABASE_NAME set, will exit following template1 updates
20170724:16:56:53:008106 gpinitsystem:aspen:pivotal-[INFO]:-MASTER_MAX_CONNECT not set, will set to default value 25
20170724:16:56:53:gpinitsystem:aspen:pivotal-[FATAL]:-Number of Segment instances's 0 (zero) Script Exiting!
```

Signed-off-by: Marbin Tan <mtan@pivotal.io>