### PR TITLE
Ensure ccp_destroy on debug_sleep

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -1463,4 +1463,5 @@ debug_sleep_anchor: &debug_sleep
       run:
         path: 'sh'
         args: ['-c', 'sleep 6h']
-  - *ccp_destroy
+    ensure:
+      <<: *ccp_destroy


### PR DESCRIPTION
This will allow a user to cancel jobs running the `debug_sleep` task and be ensured the
`ccp_destroy` will still cleanup any created clusters.

