### PR TITLE
Adding HEAP_CHECKSUM

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -140,6 +140,7 @@ installcheck-world:
 	$(MAKE) -C src/test installcheck-good
 	$(MAKE) -C src/test/fsync install && $(MAKE) -C src/test/fsync installcheck
 	$(MAKE) -C src/test/walrep install && $(MAKE) -C src/test/walrep installcheck
+	$(MAKE) -C src/test/heap_checksum install && $(MAKE) -C src/test/heap_checksum installcheck
 	$(MAKE) -C src/test/isolation installcheck
 	$(MAKE) -C src/test/isolation2 installcheck
 	$(MAKE) -C src/pl installcheck

--- a/contrib/pageinspect/rawpage.c
+++ b/contrib/pageinspect/rawpage.c
@@ -164,7 +164,7 @@ page_header(PG_FUNCTION_ARGS)
 	snprintf(lsnchar, sizeof(lsnchar), "%X/%X", lsn.xlogid, lsn.xrecoff);
 
 	values[0] = DirectFunctionCall1(textin, CStringGetDatum(lsnchar));
-	values[1] = UInt16GetDatum(PageGetTLI(page));
+	values[1] = UInt16GetDatum(page->pd_checksum);
 	values[2] = UInt16GetDatum(page->pd_flags);
 	values[3] = UInt16GetDatum(page->pd_lower);
 	values[4] = UInt16GetDatum(page->pd_upper);

--- a/contrib/pg_upgrade/pg_upgrade.h
+++ b/contrib/pg_upgrade/pg_upgrade.h
@@ -240,6 +240,7 @@ typedef struct
 	uint32		toast;
 	bool		date_is_int;
 	bool		float8_pass_by_value;
+	bool		data_checksums;
 	char	   *lc_collate;
 	char	   *lc_ctype;
 	char	   *encoding;

--- a/doc/src/sgml/ref/initdb.sgml
+++ b/doc/src/sgml/ref/initdb.sgml
@@ -148,6 +148,20 @@ PostgreSQL documentation
       </listitem>
      </varlistentry>
 
+     <varlistentry id="app-initdb-data-checksums" xreflabel="data checksums">
+      <term><option>-k</option></term>
+      <term><option>--data-checksums</option></term>
+      <listitem>
+       <para>
+        Use checksums on data pages to help detect corruption by the
+        I/O system that would otherwise be silent. Enabling checksums
+        may incur a noticeable performance penalty. This option can only
+        be set during initialization, and cannot be changed later. If
+        set, checksums are calculated for all objects, in all databases.
+       </para>
+      </listitem>
+     </varlistentry>
+
      <varlistentry>
       <term><option>--locale=<replaceable>locale</replaceable></option></term>
       <listitem>

--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -212,7 +212,7 @@ CHK_PARAMS () {
 		    fi
 		    
 		    # Make sure old CLUSTER_CONFIG settings are not hanging around.
-		    unset PORT_BASE SEG_PREFIX DATA_DIRECTORY REPLICATION_PORT_BASE
+		    unset PORT_BASE SEG_PREFIX DATA_DIRECTORY REPLICATION_PORT_BASE HEAP_CHECKSUM
 
 		    # Make sure it is not a dos file with CTRL M at end of each line
 		    $CAT $CLUSTER_CONFIG|$SED -e 's/$//g' > $TMP_FILE
@@ -262,6 +262,12 @@ CHK_PARAMS () {
 		if [ x"" = x"$DATA_DIRECTORY" ]; then
 			ERROR_EXIT "[FATAL]:-DATA_DIRECTORY not specified in $CLUSTER_CONFIG file, is this the correct instance configuration file." 2
 		fi
+
+		if [ x"" = x"$HEAP_CHECKSUM" ]; then
+			HEAP_CHECKSUM=on
+			LOG_MSG "[INFO]:-Could not find HEAP_CHECKSUM in cluster config, defaulting to on."
+		fi
+
 		if [ x"" == x"$LOCALE_SETTING" ];then
 			LOG_MSG "[INFO]:-Locale has not been set in $CLUSTER_CONFIG, will set to default value" 1
 			LOCALE_SETTING=$DEFAULT_LOCALE_SETTING
@@ -1208,6 +1214,9 @@ CREATE_QD_DB () {
 		cmd="$cmd --max_connections=$MASTER_MAX_CONNECT"
 		cmd="$cmd --shared_buffers=$MASTER_SHARED_BUFFERS"
 		cmd="$cmd --is_filerep_mirrored=no"
+		if [ x"$HEAP_CHECKSUM" == x"on" ]; then
+			cmd="$cmd --data-checksums"
+		fi
 		cmd="$cmd --backend_output=$GP_DIR.initdb"
 
 		LOG_MSG "[INFO]:-Commencing local $cmd"
@@ -1420,7 +1429,7 @@ CREATE_QES_PRIMARY () {
                 HAS_MIRRORS_OPTION=no
             fi
 
-			$GPCREATESEG $FLAG $$ 1 $I IS_PRIMARY $HAS_MIRRORS_OPTION $INST_COUNT  $LOG_FILE \
+			$GPCREATESEG $FLAG $$ 1 $I IS_PRIMARY $HAS_MIRRORS_OPTION $INST_COUNT  $LOG_FILE $HEAP_CHECKSUM \
 `$ECHO ${MASTER_IP_ADDRESS[@]}|$TR ' ' '~'` \
 `$ECHO ${STANDBY_IP_ADDRESS[@]}|$TR ' ' '~'` &
 			PARALLEL_COUNT $BATCH_LIMIT $BATCH_DEFAULT
@@ -1480,7 +1489,7 @@ CREATE_QES_MIRROR () {
 		    FLAG="-p $PG_CONF_ADD_FILE"
 		fi
 
-		$GPCREATESEG $FLAG $$ 1 ${MIRRORS_ORDERED_BY_CONTENT_ID[$I_INDEX]} ${PRIMARIES_ORDERED_BY_CONTENT_ID[$I_INDEX]} no $INST_COUNT  $LOG_FILE \
+		$GPCREATESEG $FLAG $$ 1 ${MIRRORS_ORDERED_BY_CONTENT_ID[$I_INDEX]} ${PRIMARIES_ORDERED_BY_CONTENT_ID[$I_INDEX]} no $INST_COUNT  $LOG_FILE $HEAP_CHECKSUM \
 `$ECHO ${MASTER_IP_ADDRESS[@]}|$TR ' ' '~'` \
 `$ECHO ${STANDBY_IP_ADDRESS[@]}|$TR ' ' '~'` &
 		PARALLEL_COUNT $BATCH_LIMIT $BATCH_DEFAULT

--- a/gpMgmt/bin/lib/gpcreateseg.sh
+++ b/gpMgmt/bin/lib/gpcreateseg.sh
@@ -119,6 +119,9 @@ PROCESS_QE () {
     cmd="$cmd --max_connections=$QE_MAX_CONNECT"
     cmd="$cmd --shared_buffers=$QE_SHARED_BUFFERS"
     cmd="$cmd --is_filerep_mirrored=$IS_FILEREP_MIRRORED_OPTION"
+    if [ x"$HEAP_CHECKSUM" == x"on" ]; then
+        cmd="$cmd --data-checksums"
+    fi
     cmd="$cmd --backend_output=$GP_DIR.initdb"
 
     $TRUSTED_SHELL ${GP_HOSTADDRESS} $cmd >> $LOG_FILE 2>&1
@@ -287,6 +290,7 @@ case $TYPE in
 		LOG_FILE=$1;shift		#Central logging file
 		LOG_MSG "[INFO][$INST_COUNT]:-Start Main"
 		LOG_MSG "[INFO][$INST_COUNT]:-Command line options passed to utility = $*"
+		HEAP_CHECKSUM=$1;shift
 		TMP_MASTER_IP_ADDRESS=$1;shift	#List of IP addresses for the master instance
 		MASTER_IP_ADDRESS=(`$ECHO $TMP_MASTER_IP_ADDRESS|$TR '~' ' '`)
 		TMP_STANDBY_IP_ADDRESS=$1;shift #List of IP addresses for standby master

--- a/src/backend/access/bitmap/bitmaputil.c
+++ b/src/backend/access/bitmap/bitmaputil.c
@@ -823,7 +823,6 @@ _bitmap_log_newpage(Relation rel, uint8 info, Buffer buf)
 	recptr = XLogInsert(RM_BITMAP_ID, info, rdata);
 
 	PageSetLSN(page, recptr);
-	PageSetTLI(page, ThisTimeLineID);
 }
 
 /*
@@ -857,7 +856,6 @@ _bitmap_log_metapage(Relation rel, Page page)
 	recptr = XLogInsert(RM_BITMAP_ID, XLOG_BITMAP_INSERT_META, rdata);
 
 	PageSetLSN(page, recptr);
-	PageSetTLI(page, ThisTimeLineID);
 	pfree(xlMeta);
 }
 
@@ -894,7 +892,6 @@ _bitmap_log_bitmap_lastwords(Relation rel, Buffer lovBuffer,
 						rdata);
 
 	PageSetLSN(BufferGetPage(lovBuffer), recptr);
-	PageSetTLI(BufferGetPage(lovBuffer), ThisTimeLineID);
 }
 
 /*
@@ -935,11 +932,9 @@ _bitmap_log_lovitem(Relation rel, Buffer lovBuffer, OffsetNumber offset,
 		Page metapage = BufferGetPage(metabuf);
 
 		PageSetLSN(metapage, recptr);
-		PageSetTLI(metapage, ThisTimeLineID);
 	}
 
 	PageSetLSN(lovPage, recptr);
-	PageSetTLI(lovPage, ThisTimeLineID);
 
 	elog(DEBUG1, "Insert a new lovItem at (blockno, offset): (%d,%d)",
 		 BufferGetBlockNumber(lovBuffer), offset);
@@ -1023,10 +1018,8 @@ _bitmap_log_bitmapwords(Relation rel, Buffer bitmapBuffer, Buffer lovBuffer,
 	recptr = XLogInsert(RM_BITMAP_ID, XLOG_BITMAP_INSERT_WORDS, rdata);
 
 	PageSetLSN(bitmapPage, recptr);
-	PageSetTLI(bitmapPage, ThisTimeLineID);
 
 	PageSetLSN(lovPage, recptr);
-	PageSetTLI(lovPage, ThisTimeLineID);
 
 	pfree(xlBitmapWords);
 }
@@ -1070,7 +1063,6 @@ _bitmap_log_updateword(Relation rel, Buffer bitmapBuffer, int word_no)
 	recptr = XLogInsert(RM_BITMAP_ID, XLOG_BITMAP_UPDATEWORD, rdata);
 
 	PageSetLSN(bitmapPage, recptr);
-	PageSetTLI(bitmapPage, ThisTimeLineID);
 }
 						
 
@@ -1153,12 +1145,10 @@ _bitmap_log_updatewords(Relation rel,
 	recptr = XLogInsert(RM_BITMAP_ID, XLOG_BITMAP_UPDATEWORDS, rdata);
 
 	PageSetLSN(firstPage, recptr);
-	PageSetTLI(firstPage, ThisTimeLineID);
 
 	if (BufferIsValid(secondBuffer))
 	{
 		PageSetLSN(secondPage, recptr);
-		PageSetTLI(secondPage, ThisTimeLineID);
 	}
 
 	if (new_lastpage)
@@ -1166,7 +1156,6 @@ _bitmap_log_updatewords(Relation rel,
 		Page lovPage = BufferGetPage(lovBuffer);
 
 		PageSetLSN(lovPage, recptr);
-		PageSetTLI(lovPage, ThisTimeLineID);
 	}
 }
 

--- a/src/backend/access/bitmap/bitmapxlog.c
+++ b/src/backend/access/bitmap/bitmapxlog.c
@@ -133,7 +133,6 @@ _bitmap_xlog_newpage(XLogRecPtr lsn, XLogRecord *record)
 		}
 
 		PageSetLSN(page, lsn);
-		PageSetTLI(page, ThisTimeLineID);
 		_bitmap_wrtbuf(buffer);
 	}
 	else
@@ -230,7 +229,6 @@ _bitmap_xlog_insert_lovitem(XLogRecPtr lsn, XLogRecord *record)
 					RelationGetRelationName(reln))));
 
 		PageSetLSN(lovPage, lsn);
-		PageSetTLI(lovPage, ThisTimeLineID);
 
 		_bitmap_wrtbuf(lovBuffer);
 	}
@@ -259,7 +257,6 @@ _bitmap_xlog_insert_lovitem(XLogRecPtr lsn, XLogRecord *record)
  			metapage->bm_lov_lastpage = xlrec->bm_lov_blkno;
  			
  			PageSetLSN(BufferGetPage(metabuf), lsn);
- 			PageSetTLI(BufferGetPage(metabuf), ThisTimeLineID);
 
  			_bitmap_wrtbuf(metabuf);
  		}
@@ -313,7 +310,6 @@ _bitmap_xlog_insert_meta(XLogRecPtr lsn, XLogRecord *record)
 		metapage->bm_lov_lastpage = xlrec->bm_lov_lastpage;
 
 		PageSetLSN(mp, lsn);
-		PageSetTLI(mp, ThisTimeLineID);
 		_bitmap_wrtbuf(metabuf);
 	}
 	else
@@ -372,7 +368,6 @@ _bitmap_xlog_insert_bitmap_lastwords(XLogRecPtr lsn,
 				lovItem->bm_last_tid_location = xlrec->bm_last_tid_location;
 				
 				PageSetLSN(lovPage, lsn);
-				PageSetTLI(lovPage, ThisTimeLineID);
 
 				_bitmap_wrtbuf(lovBuffer);
 			}
@@ -495,7 +490,6 @@ _bitmap_xlog_insert_bitmapwords(XLogRecPtr lsn, XLogRecord *record)
 			_bitmap_init_bitmappage(reln, nextBuffer);
 			
 			PageSetLSN(nextPage, lsn);
-			PageSetTLI(nextPage, ThisTimeLineID);
 
 			_bitmap_wrtbuf(nextBuffer);
 
@@ -503,7 +497,6 @@ _bitmap_xlog_insert_bitmapwords(XLogRecPtr lsn, XLogRecord *record)
 		}
 
 		PageSetLSN(bitmapPage, lsn);
-		PageSetTLI(bitmapPage, ThisTimeLineID);
 
 		_bitmap_wrtbuf(bitmapBuffer);
 
@@ -543,7 +536,6 @@ _bitmap_xlog_insert_bitmapwords(XLogRecPtr lsn, XLogRecord *record)
  			lovItem->bm_lov_head = lovItem->bm_lov_tail;
  		
  		PageSetLSN(lovPage, lsn);
- 		PageSetTLI(lovPage, ThisTimeLineID);
  		
  		_bitmap_wrtbuf(lovBuffer);
  		
@@ -555,7 +547,6 @@ _bitmap_xlog_insert_bitmapwords(XLogRecPtr lsn, XLogRecord *record)
  		lovItem->bm_lov_tail = lovItem->bm_lov_head;
  		
  		PageSetLSN(lovPage, lsn);
- 		PageSetTLI(lovPage, ThisTimeLineID);
  		
  		_bitmap_wrtbuf(lovBuffer);
  	}
@@ -614,7 +605,6 @@ _bitmap_xlog_updateword(XLogRecPtr lsn, XLogRecord *record)
 			bitmap->hwords[xlrec->bm_word_no/BM_HRL_WORD_SIZE] = xlrec->bm_hword;
 
 			PageSetLSN(bitmapPage, lsn);
-			PageSetTLI(bitmapPage, ThisTimeLineID);
 			_bitmap_wrtbuf(bitmapBuffer);
 		}
 
@@ -684,7 +674,6 @@ _bitmap_xlog_updatewords(XLogRecPtr lsn, XLogRecord *record)
 				firstOpaque->bm_bitmap_next = xlrec->bm_next_blkno;
 
 			PageSetLSN(firstPage, lsn);
-			PageSetTLI(firstPage, ThisTimeLineID);
 			_bitmap_wrtbuf(firstBuffer);
 		}
 		else
@@ -714,7 +703,6 @@ _bitmap_xlog_updatewords(XLogRecPtr lsn, XLogRecord *record)
  			secondOpaque->bm_bitmap_next = xlrec->bm_next_blkno;
  			
  			PageSetLSN(secondPage, lsn);
- 			PageSetTLI(secondPage, ThisTimeLineID);
  			_bitmap_wrtbuf(secondBuffer);
  		}
  		
@@ -751,7 +739,6 @@ _bitmap_xlog_updatewords(XLogRecPtr lsn, XLogRecord *record)
  			lovItem->bm_lov_tail = xlrec->bm_second_blkno;
  			
  			PageSetLSN(lovPage, lsn);
- 			PageSetTLI(lovPage, ThisTimeLineID);
  			
  			_bitmap_wrtbuf(lovBuffer);
  		}

--- a/src/backend/access/gin/ginbtree.c
+++ b/src/backend/access/gin/ginbtree.c
@@ -313,7 +313,6 @@ ginInsertValue(GinBtree btree, GinBtreeStack *stack)
 
 				recptr = XLogInsert(RM_GIN_ID, XLOG_GIN_INSERT, rdata);
 				PageSetLSN(page, recptr);
-				PageSetTLI(page, ThisTimeLineID);
 			}
 
 			UnlockReleaseBuffer(stack->buffer);
@@ -374,11 +373,8 @@ ginInsertValue(GinBtree btree, GinBtreeStack *stack)
 
 					recptr = XLogInsert(RM_GIN_ID, XLOG_GIN_SPLIT, rdata);
 					PageSetLSN(page, recptr);
-					PageSetTLI(page, ThisTimeLineID);
 					PageSetLSN(lpage, recptr);
-					PageSetTLI(lpage, ThisTimeLineID);
 					PageSetLSN(rpage, recptr);
-					PageSetTLI(rpage, ThisTimeLineID);
 				}
 
 				UnlockReleaseBuffer(rbuffer);
@@ -413,9 +409,7 @@ ginInsertValue(GinBtree btree, GinBtreeStack *stack)
 
 					recptr = XLogInsert(RM_GIN_ID, XLOG_GIN_SPLIT, rdata);
 					PageSetLSN(lpage, recptr);
-					PageSetTLI(lpage, ThisTimeLineID);
 					PageSetLSN(rpage, recptr);
-					PageSetTLI(rpage, ThisTimeLineID);
 				}
 				UnlockReleaseBuffer(rbuffer);
 				END_CRIT_SECTION();

--- a/src/backend/access/gin/gininsert.c
+++ b/src/backend/access/gin/gininsert.c
@@ -81,8 +81,6 @@ createPostingTree(Relation index, ItemPointerData *items, uint32 nitems)
 
 		recptr = XLogInsert(RM_GIN_ID, XLOG_GIN_CREATE_PTREE, rdata);
 		PageSetLSN(page, recptr);
-		PageSetTLI(page, ThisTimeLineID);
-
 	}
 
 	UnlockReleaseBuffer(buffer);
@@ -301,11 +299,8 @@ ginbuild(PG_FUNCTION_ARGS)
 
 		page = BufferGetPage(buffer);
 
-
 		recptr = XLogInsert(RM_GIN_ID, XLOG_GIN_CREATE_INDEX, &rdata);
 		PageSetLSN(page, recptr);
-		PageSetTLI(page, ThisTimeLineID);
-
 	}
 
 	UnlockReleaseBuffer(buffer);

--- a/src/backend/access/gin/ginvacuum.c
+++ b/src/backend/access/gin/ginvacuum.c
@@ -149,7 +149,6 @@ xlogVacuumPage(Relation index, Buffer buffer)
 
 	recptr = XLogInsert(RM_GIN_ID, XLOG_GIN_VACUUM_PAGE, rdata);
 	PageSetLSN(page, recptr);
-	PageSetTLI(page, ThisTimeLineID);
 }
 
 static bool
@@ -349,14 +348,11 @@ ginDeletePage(GinVacuumState *gvs, BlockNumber deleteBlkno, BlockNumber leftBlkn
 
 		recptr = XLogInsert(RM_GIN_ID, XLOG_GIN_DELETE_PAGE, rdata);
 		PageSetLSN(page, recptr);
-		PageSetTLI(page, ThisTimeLineID);
 		PageSetLSN(parentPage, recptr);
-		PageSetTLI(parentPage, ThisTimeLineID);
 		if (leftBlkno != InvalidBlockNumber)
 		{
 			page = BufferGetPage(lBuffer);
 			PageSetLSN(page, recptr);
-			PageSetTLI(page, ThisTimeLineID);
 		}
 	}
 

--- a/src/backend/access/gin/ginxlog.c
+++ b/src/backend/access/gin/ginxlog.c
@@ -92,7 +92,6 @@ ginRedoCreateIndex(XLogRecPtr lsn, XLogRecord *record)
 	GinInitBuffer(buffer, GIN_LEAF);
 
 	PageSetLSN(page, lsn);
-	PageSetTLI(page, ThisTimeLineID);
 
 	MarkBufferDirty(buffer);
 	UnlockReleaseBuffer(buffer);
@@ -127,7 +126,6 @@ ginRedoCreatePTree(XLogRecPtr lsn, XLogRecord *record)
 	GinPageGetOpaque(page)->maxoff = data->nitem;
 
 	PageSetLSN(page, lsn);
-	PageSetTLI(page, ThisTimeLineID);
 
 	MarkBufferDirty(buffer);
 	UnlockReleaseBuffer(buffer);
@@ -255,7 +253,6 @@ ginRedoInsert(XLogRecPtr lsn, XLogRecord *record)
 		}
 
 		PageSetLSN(page, lsn);
-		PageSetTLI(page, ThisTimeLineID);
 
 		MarkBufferDirty(buffer);
 	}
@@ -355,11 +352,9 @@ ginRedoSplit(XLogRecPtr lsn, XLogRecord *record)
 	}
 
 	PageSetLSN(rpage, lsn);
-	PageSetTLI(rpage, ThisTimeLineID);
 	MarkBufferDirty(rbuffer);
 
 	PageSetLSN(lpage, lsn);
-	PageSetTLI(lpage, ThisTimeLineID);
 	MarkBufferDirty(lbuffer);
 
 	if (!data->isLeaf && data->updateBlkno != InvalidBlockNumber)
@@ -384,7 +379,6 @@ ginRedoSplit(XLogRecPtr lsn, XLogRecord *record)
 		}
 
 		PageSetLSN(rootPage, lsn);
-		PageSetTLI(rootPage, ThisTimeLineID);
 
 		MarkBufferDirty(rootBuf);
 		UnlockReleaseBuffer(rootBuf);
@@ -454,8 +448,6 @@ ginRedoVacuumPage(XLogRecPtr lsn, XLogRecord *record)
 		}
 
 		PageSetLSN(page, lsn);
-		PageSetTLI(page, ThisTimeLineID);
-
 		MarkBufferDirty(buffer);
 	}
 
@@ -492,7 +484,6 @@ ginRedoDeletePage(XLogRecPtr lsn, XLogRecord *record)
 				Assert(GinPageIsData(page));
 				GinPageGetOpaque(page)->flags = GIN_DELETED;
 				PageSetLSN(page, lsn);
-				PageSetTLI(page, ThisTimeLineID);
 				MarkBufferDirty(buffer);
 			}
 			UnlockReleaseBuffer(buffer);
@@ -511,7 +502,6 @@ ginRedoDeletePage(XLogRecPtr lsn, XLogRecord *record)
 				Assert(!GinPageIsLeaf(page));
 				PageDeletePostingItem(page, data->parentOffset);
 				PageSetLSN(page, lsn);
-				PageSetTLI(page, ThisTimeLineID);
 				MarkBufferDirty(buffer);
 			}
 			UnlockReleaseBuffer(buffer);
@@ -529,7 +519,6 @@ ginRedoDeletePage(XLogRecPtr lsn, XLogRecord *record)
 				Assert(GinPageIsData(page));
 				GinPageGetOpaque(page)->rightlink = data->rightLink;
 				PageSetLSN(page, lsn);
-				PageSetTLI(page, ThisTimeLineID);
 				MarkBufferDirty(buffer);
 			}
 			UnlockReleaseBuffer(buffer);

--- a/src/backend/access/gist/gist.c
+++ b/src/backend/access/gist/gist.c
@@ -128,7 +128,6 @@ gistbuild(PG_FUNCTION_ARGS)
 
 		recptr = XLogInsert(RM_GIST_ID, XLOG_GIST_CREATE_INDEX, rdata);
 		PageSetLSN(page, recptr);
-		PageSetTLI(page, ThisTimeLineID);
 	}
 	else
 		PageSetLSN(page, GetXLogRecPtrForTemp());
@@ -429,7 +428,6 @@ gistplacetopage(GISTInsertState *state, GISTSTATE *giststate)
 			for (ptr = dist; ptr; ptr = ptr->next)
 			{
 				PageSetLSN(ptr->page, recptr);
-				PageSetTLI(ptr->page, ThisTimeLineID);
 			}
 		}
 		else
@@ -501,7 +499,6 @@ gistplacetopage(GISTInsertState *state, GISTSTATE *giststate)
 
 			recptr = XLogInsert(RM_GIST_ID, XLOG_GIST_PAGE_UPDATE, rdata);
 			PageSetLSN(state->stack->page, recptr);
-			PageSetTLI(state->stack->page, ThisTimeLineID);
 		}
 		else
 			PageSetLSN(state->stack->page, GetXLogRecPtrForTemp());
@@ -1060,7 +1057,6 @@ gistnewroot(Relation r, Buffer buffer, IndexTuple *itup, int len, ItemPointer ke
 
 		recptr = XLogInsert(RM_GIST_ID, XLOG_GIST_NEW_ROOT, rdata);
 		PageSetLSN(page, recptr);
-		PageSetTLI(page, ThisTimeLineID);
 	}
 	else
 		PageSetLSN(page, GetXLogRecPtrForTemp());

--- a/src/backend/access/gist/gistget.c
+++ b/src/backend/access/gist/gistget.c
@@ -49,7 +49,7 @@ killtuple(Relation r, GISTScanOpaque so, ItemPointer iptr)
 		/* page unchanged, so all is simple */
 		offset = ItemPointerGetOffsetNumber(iptr);
 		ItemIdMarkDead(PageGetItemId(p, offset));
-		SetBufferCommitInfoNeedsSave(so->curbuf);
+		MarkBufferDirtyHint(so->curbuf);
 	}
 	else
 	{
@@ -63,7 +63,7 @@ killtuple(Relation r, GISTScanOpaque so, ItemPointer iptr)
 			{
 				/* found */
 				ItemIdMarkDead(PageGetItemId(p, offset));
-				SetBufferCommitInfoNeedsSave(so->curbuf);
+				MarkBufferDirtyHint(so->curbuf);
 				break;
 			}
 		}

--- a/src/backend/access/gist/gistvacuum.c
+++ b/src/backend/access/gist/gistvacuum.c
@@ -137,7 +137,6 @@ gistDeleteSubtree(GistVacuum *gv, BlockNumber blkno)
 
 		recptr = XLogInsert(RM_GIST_ID, XLOG_GIST_PAGE_DELETE, rdata);
 		PageSetLSN(page, recptr);
-		PageSetTLI(page, ThisTimeLineID);
 	}
 	else
 		PageSetLSN(page, GetXLogRecPtrForTemp());
@@ -255,7 +254,6 @@ vacuumSplitPage(GistVacuum *gv, Page tempPage, Buffer buffer, IndexTuple *addon,
 		for (ptr = dist; ptr; ptr = ptr->next)
 		{
 			PageSetLSN(BufferGetPage(ptr->buffer), recptr);
-			PageSetTLI(BufferGetPage(ptr->buffer), ThisTimeLineID);
 		}
 
 		pfree(xlinfo);
@@ -477,7 +475,6 @@ gistVacuumUpdate(GistVacuum *gv, BlockNumber blkno, bool needunion)
 
 				recptr = XLogInsert(RM_GIST_ID, XLOG_GIST_PAGE_UPDATE, rdata);
 				PageSetLSN(page, recptr);
-				PageSetTLI(page, ThisTimeLineID);
 
 				pfree(xlinfo);
 				pfree(rdata);
@@ -823,7 +820,6 @@ gistbulkdelete(PG_FUNCTION_ARGS)
 
 					recptr = XLogInsert(RM_GIST_ID, XLOG_GIST_PAGE_UPDATE, rdata);
 					PageSetLSN(page, recptr);
-					PageSetTLI(page, ThisTimeLineID);
 
 					pfree(xlinfo);
 					pfree(rdata);

--- a/src/backend/access/gist/gistxlog.c
+++ b/src/backend/access/gist/gistxlog.c
@@ -270,7 +270,6 @@ gistRedoPageUpdateRecord(XLogRecPtr lsn, XLogRecord *record, bool isnewroot)
 
 	GistPageGetOpaque(page)->rightlink = InvalidBlockNumber;
 	PageSetLSN(page, lsn);
-	PageSetTLI(page, ThisTimeLineID);
 	MarkBufferDirty(buffer);
 	UnlockReleaseBuffer(buffer);
 	
@@ -307,7 +306,6 @@ gistRedoPageDeleteRecord(XLogRecPtr lsn, XLogRecord *record)
 	GistPageSetDeleted(page);
 
 	PageSetLSN(page, lsn);
-	PageSetTLI(page, ThisTimeLineID);
 	MarkBufferDirty(buffer);
 	UnlockReleaseBuffer(buffer);
 	
@@ -382,7 +380,6 @@ gistRedoPageSplitRecord(XLogRecPtr lsn, XLogRecord *record)
 		gistfillbuffer(reln, page, newpage->itup, newpage->header->num, FirstOffsetNumber);
 
 		PageSetLSN(page, lsn);
-		PageSetTLI(page, ThisTimeLineID);
 		MarkBufferDirty(buffer);
 		UnlockReleaseBuffer(buffer);
 		
@@ -422,7 +419,6 @@ gistRedoCreateIndex(XLogRecPtr lsn, XLogRecord *record)
 	GISTInitBuffer(buffer, F_LEAF);
 
 	PageSetLSN(page, lsn);
-	PageSetTLI(page, ThisTimeLineID);
 
 	MarkBufferDirty(buffer);
 	UnlockReleaseBuffer(buffer);
@@ -835,7 +831,6 @@ gistContinueInsert(gistIncompleteInsert *insert)
 			for (j = 0; j < numbuffer; j++)
 			{
 				PageSetLSN(pages[j], recptr);
-				PageSetTLI(pages[j], ThisTimeLineID);
 			}
 
 			END_CRIT_SECTION();

--- a/src/backend/access/hash/hash.c
+++ b/src/backend/access/hash/hash.c
@@ -207,11 +207,9 @@ hashgettuple(PG_FUNCTION_ARGS)
 			ItemIdMarkDead(PageGetItemId(page, offnum));
 
 			/*
-			 * Since this can be redone later if needed, it's treated the same
-			 * as a commit-hint-bit status update for heap tuples: we mark the
-			 * buffer dirty but don't make a WAL log entry.
+			 * Since this can be redone later if needed, mark as a hint.
 			 */
-			SetBufferCommitInfoNeedsSave(so->hashso_curbuf);
+			MarkBufferDirtyHint(so->hashso_curbuf);
 		}
 
 		/*

--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -2434,7 +2434,6 @@ heap_insert(Relation relation, HeapTuple tup, CommandId cid,
 			recptr = XLogInsert_OverrideXid(RM_HEAP_ID, info, rdata, FrozenTransactionId);
 
 		PageSetLSN(page, recptr);
-		PageSetTLI(page, ThisTimeLineID);
 	}
 
 	END_CRIT_SECTION();
@@ -2837,7 +2836,6 @@ l1:
 		recptr = XLogInsert_OverrideXid(RM_HEAP_ID, XLOG_HEAP_DELETE, rdata, xid);
 
 		PageSetLSN(dp, recptr);
-		PageSetTLI(dp, ThisTimeLineID);
 	}
 
 	END_CRIT_SECTION();
@@ -3459,10 +3457,8 @@ l2:
 		if (newbuf != buffer)
 		{
 			PageSetLSN(BufferGetPage(newbuf), recptr);
-			PageSetTLI(BufferGetPage(newbuf), ThisTimeLineID);
 		}
 		PageSetLSN(BufferGetPage(buffer), recptr);
-		PageSetTLI(BufferGetPage(buffer), ThisTimeLineID);
 	}
 
 	END_CRIT_SECTION();
@@ -4172,7 +4168,6 @@ l3:
 		recptr = XLogInsert(RM_HEAP_ID, XLOG_HEAP_LOCK, rdata);
 
 		PageSetLSN(dp, recptr);
-		PageSetTLI(dp, ThisTimeLineID);
 	}
 
 	END_CRIT_SECTION();
@@ -4283,7 +4278,6 @@ heap_inplace_update_internal(Relation relation, HeapTuple tuple, bool freeze)
 			recptr = XLogInsert_OverrideXid(RM_HEAP_ID, XLOG_HEAP_INPLACE, rdata, FrozenTransactionId);
 
 		PageSetLSN(page, recptr);
-		PageSetTLI(page, ThisTimeLineID);
 	}
 
 	END_CRIT_SECTION();
@@ -4660,7 +4654,6 @@ log_heap_newpage(Relation rel,
 
 	recptr = XLogInsert(RM_HEAP_ID, XLOG_HEAP_NEWPAGE, rdata);
 	PageSetLSN(page, recptr);
-	PageSetTLI(page, ThisTimeLineID);
 
 	END_CRIT_SECTION();
 }
@@ -4970,7 +4963,6 @@ log_newpage_internal(xl_heap_newpage *xlrec, Page page)
 	if (!PageIsNew(page))
 	{
 		PageSetLSN(page, recptr);
-		PageSetTLI(page, ThisTimeLineID);
 	}
 
 	END_CRIT_SECTION();
@@ -5085,7 +5077,6 @@ heap_xlog_clean(XLogRecPtr lsn, XLogRecord *record, bool clean_move)
 	 */
 
 	PageSetLSN(page, lsn);
-	PageSetTLI(page, ThisTimeLineID);
 	MarkBufferDirty(buffer);
 	UnlockReleaseBuffer(buffer);
 	
@@ -5156,7 +5147,6 @@ heap_xlog_freeze(XLogRecPtr lsn, XLogRecord *record)
 	}
 
 	PageSetLSN(page, lsn);
-	PageSetTLI(page, ThisTimeLineID);
 	MarkBufferDirty(buffer);
 	UnlockReleaseBuffer(buffer);
 	
@@ -5192,13 +5182,12 @@ heap_xlog_newpage(XLogRecPtr lsn, XLogRecord *record)
 	memcpy(page, (char *) xlrec + SizeOfHeapNewpage, BLCKSZ);
 
 	/*
-	 * The page may be uninitialized. If so, we can't set the LSN
-	 * and TLI because that would corrupt the page.
+	 * The page may be uninitialized. If so, we can't set the LSN because that
+	 * would corrupt the page.
 	 */
 	if (!PageIsNew(page))
 	{
 		PageSetLSN(page, lsn);
-		PageSetTLI(page, ThisTimeLineID);
 	}
 
 	MarkBufferDirty(buffer);
@@ -5292,7 +5281,6 @@ heap_xlog_delete(XLogRecPtr lsn, XLogRecord *record)
 	/* Make sure there is no forward chain link in t_ctid */
 	htup->t_ctid = xlrec->target.tid;
 	PageSetLSN(page, lsn);
-	PageSetTLI(page, ThisTimeLineID);
 	MarkBufferDirty(buffer);
 	UnlockReleaseBuffer(buffer);
 	
@@ -5404,7 +5392,6 @@ heap_xlog_insert(XLogRecPtr lsn, XLogRecord *record)
 	if (offnum == InvalidOffsetNumber)
 		elog(PANIC, "heap_insert_redo: failed to add tuple");
 	PageSetLSN(page, lsn);
-	PageSetTLI(page, ThisTimeLineID);
 	MarkBufferDirty(buffer);
 	UnlockReleaseBuffer(buffer);
 	
@@ -5525,7 +5512,6 @@ heap_xlog_update(XLogRecPtr lsn, XLogRecord *record, bool move, bool hot_update)
 	if (samepage)
 		goto newsame;
 	PageSetLSN(page, lsn);
-	PageSetTLI(page, ThisTimeLineID);
 	MarkBufferDirty(buffer);
 	UnlockReleaseBuffer(buffer);
 
@@ -5627,7 +5613,6 @@ newsame:;
 	if (offnum == InvalidOffsetNumber)
 		elog(PANIC, "heap_update_redo: failed to add tuple");
 	PageSetLSN(page, lsn);
-	PageSetTLI(page, ThisTimeLineID);
 	MarkBufferDirty(buffer);
 	UnlockReleaseBuffer(buffer);
 	
@@ -5708,7 +5693,6 @@ heap_xlog_lock(XLogRecPtr lsn, XLogRecord *record)
 	/* Make sure there is no forward chain link in t_ctid */
 	htup->t_ctid = xlrec->target.tid;
 	PageSetLSN(page, lsn);
-	PageSetTLI(page, ThisTimeLineID);
 	MarkBufferDirty(buffer);
 	UnlockReleaseBuffer(buffer);
 	
@@ -5782,7 +5766,6 @@ heap_xlog_inplace(XLogRecPtr lsn, XLogRecord *record)
 		   newlen);
 
 	PageSetLSN(page, lsn);
-	PageSetTLI(page, ThisTimeLineID);
 	MarkBufferDirty(buffer);
 	UnlockReleaseBuffer(buffer);
 	

--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -3288,7 +3288,6 @@ l2:
 
 			recptr = XLogInsert(RM_HEAP_ID, XLOG_HEAP_LOCK, rdata);
 			PageSetLSN(BufferGetPage(buffer), recptr);
-			PageSetTLI(BufferGetPage(buffer), ThisTimeLineID);
 		}
 
 		END_CRIT_SECTION();

--- a/src/backend/access/heap/pruneheap.c
+++ b/src/backend/access/heap/pruneheap.c
@@ -289,7 +289,7 @@ heap_page_prune(Relation relation, Buffer buffer, TransactionId OldestXmin,
 		{
 			((PageHeader) page)->pd_prune_xid = prstate.new_prune_xid;
 			PageClearFull(page);
-			SetBufferCommitInfoNeedsSave(buffer);
+			MarkBufferDirtyHint(buffer);
 		}
 	}
 

--- a/src/backend/access/heap/pruneheap.c
+++ b/src/backend/access/heap/pruneheap.c
@@ -271,7 +271,6 @@ heap_page_prune(Relation relation, Buffer buffer, TransactionId OldestXmin,
 									redirect_move);
 
 			PageSetLSN(BufferGetPage(buffer), recptr);
-			PageSetTLI(BufferGetPage(buffer), ThisTimeLineID);
 		}
 	}
 	else

--- a/src/backend/access/heap/rewriteheap.c
+++ b/src/backend/access/heap/rewriteheap.c
@@ -266,6 +266,8 @@ end_heap_rewrite(RewriteState state)
 	/* Write the last page, if any */
 	if (state->rs_buffer_valid)
 	{
+		PageSetChecksumInplace(state->rs_buffer, state->rs_blockno);
+
 		if (state->rs_use_wal)
 			log_newpage_rel(state->rs_new_rel,state->rs_blockno, state->rs_buffer);
 
@@ -600,6 +602,8 @@ raw_heap_insert(RewriteState state, HeapTuple tup)
 		if (len + saveFreeSpace > pageFreeSpace)
 		{
 			/* Doesn't fit, so write out the existing page */
+
+			PageSetChecksumInplace(page, state->rs_blockno);
 
 			/* XLOG stuff */
 			if (state->rs_use_wal)

--- a/src/backend/access/nbtree/nbtinsert.c
+++ b/src/backend/access/nbtree/nbtinsert.c
@@ -875,11 +875,9 @@ _bt_insertonpg(Relation rel,
 			if (BufferIsValid(metabuf))
 			{
 				PageSetLSN(metapg, recptr);
-				PageSetTLI(metapg, ThisTimeLineID);
 			}
 
 			PageSetLSN(page, recptr);
-			PageSetTLI(page, ThisTimeLineID);
 		}
 
 		END_CRIT_SECTION();
@@ -971,7 +969,6 @@ _bt_split(Relation rel, Buffer buf, OffsetNumber firstright,
 	 * examine these fields and possibly dump them in a page image.
 	 */
 	PageSetLSN(leftpage, PageGetLSN(origpage));
-	PageSetTLI(leftpage, PageGetTLI(origpage));
 
 	/* init btree private data */
 	oopaque = (BTPageOpaque) PageGetSpecialPointer(origpage);
@@ -1356,13 +1353,10 @@ _bt_split(Relation rel, Buffer buf, OffsetNumber firstright,
 		recptr = XLogInsert(RM_BTREE_ID, xlinfo, rdata);
 
 		PageSetLSN(origpage, recptr);
-		PageSetTLI(origpage, ThisTimeLineID);
 		PageSetLSN(rightpage, recptr);
-		PageSetTLI(rightpage, ThisTimeLineID);
 		if (!P_RIGHTMOST(ropaque))
 		{
 			PageSetLSN(spage, recptr);
-			PageSetTLI(spage, ThisTimeLineID);
 		}
 	}
 
@@ -2014,9 +2008,7 @@ _bt_newroot(Relation rel, Buffer lbuf, Buffer rbuf)
 		recptr = XLogInsert(RM_BTREE_ID, XLOG_BTREE_NEWROOT, rdata);
 
 		PageSetLSN(rootpage, recptr);
-		PageSetTLI(rootpage, ThisTimeLineID);
 		PageSetLSN(metapg, recptr);
-		PageSetTLI(metapg, ThisTimeLineID);
 	}
 
 	END_CRIT_SECTION();

--- a/src/backend/access/nbtree/nbtinsert.c
+++ b/src/backend/access/nbtree/nbtinsert.c
@@ -441,9 +441,9 @@ _bt_check_unique(Relation rel, IndexTuple itup, Relation heapRel,
 						opaque->btpo_flags |= BTP_HAS_GARBAGE;
 						/* be sure to mark the proper buffer dirty... */
 						if (nbuf != InvalidBuffer)
-							SetBufferCommitInfoNeedsSave(nbuf);
+							MarkBufferDirtyHint(nbuf);
 						else
-							SetBufferCommitInfoNeedsSave(buf);
+							MarkBufferDirtyHint(buf);
 					}
 				}
 			}

--- a/src/backend/access/nbtree/nbtpage.c
+++ b/src/backend/access/nbtree/nbtpage.c
@@ -246,9 +246,7 @@ _bt_getroot(Relation rel, int access)
 			recptr = XLogInsert(RM_BTREE_ID, XLOG_BTREE_NEWROOT, &rdata);
 
 			PageSetLSN(rootpage, recptr);
-			PageSetTLI(rootpage, ThisTimeLineID);
 			PageSetLSN(metapg, recptr);
-			PageSetTLI(metapg, ThisTimeLineID);
 		}
 
 		END_CRIT_SECTION();
@@ -741,7 +739,6 @@ _bt_delitems(Relation rel, Buffer buf,
 		recptr = XLogInsert(RM_BTREE_ID, XLOG_BTREE_DELETE, rdata);
 
 		PageSetLSN(page, recptr);
-		PageSetTLI(page, ThisTimeLineID);
 	}
 
 	END_CRIT_SECTION();
@@ -1317,22 +1314,17 @@ _bt_pagedel(Relation rel, Buffer buf, BTStack stack, bool vacuum_full)
 		if (BufferIsValid(metabuf))
 		{
 			PageSetLSN(metapg, recptr);
-			PageSetTLI(metapg, ThisTimeLineID);
 		}
 		page = BufferGetPage(pbuf);
 		PageSetLSN(page, recptr);
-		PageSetTLI(page, ThisTimeLineID);
 		page = BufferGetPage(rbuf);
 		PageSetLSN(page, recptr);
-		PageSetTLI(page, ThisTimeLineID);
 		page = BufferGetPage(buf);
 		PageSetLSN(page, recptr);
-		PageSetTLI(page, ThisTimeLineID);
 		if (BufferIsValid(lbuf))
 		{
 			page = BufferGetPage(lbuf);
 			PageSetLSN(page, recptr);
-			PageSetTLI(page, ThisTimeLineID);
 		}
 	}
 

--- a/src/backend/access/nbtree/nbtree.c
+++ b/src/backend/access/nbtree/nbtree.c
@@ -1245,7 +1245,7 @@ restart:
 				opaque->btpo_cycleid == vstate->cycleid)
 			{
 				opaque->btpo_cycleid = 0;
-				SetBufferCommitInfoNeedsSave(buf);
+				MarkBufferDirtyHint(buf);
 			}
 		}
 

--- a/src/backend/access/nbtree/nbtsort.c
+++ b/src/backend/access/nbtree/nbtsort.c
@@ -309,6 +309,7 @@ _bt_blwritepage(BTWriteState *wstate, Page page, BlockNumber blkno)
 		// UNDONE: Unfortunately, I think we write temp relations to the mirror...
 		LWLockAcquire(MirroredLock, LW_SHARED);
 
+		/* don't set checksum for all-zero page */
 		smgrextend(wstate->index->rd_smgr, wstate->btws_pages_written++,
 				   (char *) wstate->btws_zeropage,
 				   true);
@@ -321,6 +322,7 @@ _bt_blwritepage(BTWriteState *wstate, Page page, BlockNumber blkno)
 	// -------- MirroredLock ----------
 	// UNDONE: Unfortunately, I think we write temp relations to the mirror...
 	LWLockAcquire(MirroredLock, LW_SHARED);
+	PageSetChecksumInplace(page, blkno);
 
 	/*
 	 * Now write the page.	We say isTemp = true even if it's not a temp

--- a/src/backend/access/nbtree/nbtsort.c
+++ b/src/backend/access/nbtree/nbtsort.c
@@ -293,12 +293,6 @@ _bt_blwritepage(BTWriteState *wstate, Page page, BlockNumber blkno)
 		log_newpage_rel(wstate->index, blkno, page);
 	}
 
-	else
-	{
-		/* Leave the page LSN zero if not WAL-logged, but set TLI anyway */
-		PageSetTLI(page, ThisTimeLineID);
-	}
-
 	/*
 	 * If we have to write pages nonsequentially, fill in the space with
 	 * zeroes until we come back and overwrite.  This is not logically

--- a/src/backend/access/nbtree/nbtutils.c
+++ b/src/backend/access/nbtree/nbtutils.c
@@ -1169,9 +1169,7 @@ _bt_killitems(IndexScanDesc scan, bool haveLock)
 	}
 
 	/*
-	 * Since this can be redone later if needed, it's treated the same as a
-	 * commit-hint-bit status update for heap tuples: we mark the buffer dirty
-	 * but don't make a WAL log entry.
+	 * Since this can be redone later if needed, mark as dirty hint.
 	 *
 	 * Whenever we mark anything LP_DEAD, we also set the page's
 	 * BTP_HAS_GARBAGE flag, which is likewise just a hint.
@@ -1179,7 +1177,7 @@ _bt_killitems(IndexScanDesc scan, bool haveLock)
 	if (killedsomething)
 	{
 		opaque->btpo_flags |= BTP_HAS_GARBAGE;
-		SetBufferCommitInfoNeedsSave(so->currPos.buf);
+		MarkBufferDirtyHint(so->currPos.buf);
 	}
 
 	if (!haveLock)

--- a/src/backend/access/nbtree/nbtxlog.c
+++ b/src/backend/access/nbtree/nbtxlog.c
@@ -189,7 +189,6 @@ _bt_restore_meta(Relation reln, XLogRecPtr lsn,
 		((char *) md + sizeof(BTMetaPageData)) - (char *) metapg;
 
 	PageSetLSN(metapg, lsn);
-	PageSetTLI(metapg, ThisTimeLineID);
 	MarkBufferDirty(metabuf);
 	UnlockReleaseBuffer(metabuf);
 }
@@ -255,7 +254,6 @@ btree_xlog_insert(bool isleaf, bool ismeta,
 					elog(PANIC, "btree_insert_redo: failed to add item");
 
 				PageSetLSN(page, lsn);
-				PageSetTLI(page, ThisTimeLineID);
 				MarkBufferDirty(buffer);
 				UnlockReleaseBuffer(buffer);
 			}
@@ -376,7 +374,6 @@ btree_xlog_split(bool onleft, bool isroot,
 	}
 
 	PageSetLSN(rpage, lsn);
-	PageSetTLI(rpage, ThisTimeLineID);
 	MarkBufferDirty(rbuf);
 
 	/* don't release the buffer yet; we touch right page's first item below */
@@ -445,7 +442,6 @@ btree_xlog_split(bool onleft, bool isroot,
 				lopaque->btpo_cycleid = 0;
 
 				PageSetLSN(lpage, lsn);
-				PageSetTLI(lpage, ThisTimeLineID);
 				MarkBufferDirty(lbuf);
 			}
 
@@ -472,7 +468,6 @@ btree_xlog_split(bool onleft, bool isroot,
 				pageop->btpo_prev = xlrec->rightsib;
 
 				PageSetLSN(page, lsn);
-				PageSetTLI(page, ThisTimeLineID);
 				MarkBufferDirty(buffer);
 			}
 			UnlockReleaseBuffer(buffer);
@@ -545,7 +540,6 @@ btree_xlog_delete(XLogRecPtr lsn, XLogRecord *record)
 	opaque->btpo_flags &= ~BTP_HAS_GARBAGE;
 
 	PageSetLSN(page, lsn);
-	PageSetTLI(page, ThisTimeLineID);
 	MarkBufferDirty(buffer);
 	UnlockReleaseBuffer(buffer);
 	
@@ -619,7 +613,6 @@ btree_xlog_delete_page(uint8 info, XLogRecPtr lsn, XLogRecord *record)
 				}
 
 				PageSetLSN(page, lsn);
-				PageSetTLI(page, ThisTimeLineID);
 				MarkBufferDirty(buffer);
 				UnlockReleaseBuffer(buffer);
 			}
@@ -645,7 +638,6 @@ btree_xlog_delete_page(uint8 info, XLogRecPtr lsn, XLogRecord *record)
 				pageop->btpo_prev = leftsib;
 
 				PageSetLSN(page, lsn);
-				PageSetTLI(page, ThisTimeLineID);
 				MarkBufferDirty(buffer);
 				UnlockReleaseBuffer(buffer);
 			}
@@ -673,7 +665,6 @@ btree_xlog_delete_page(uint8 info, XLogRecPtr lsn, XLogRecord *record)
 					pageop->btpo_next = rightsib;
 
 					PageSetLSN(page, lsn);
-					PageSetTLI(page, ThisTimeLineID);
 					MarkBufferDirty(buffer);
 					UnlockReleaseBuffer(buffer);
 				}
@@ -696,7 +687,6 @@ btree_xlog_delete_page(uint8 info, XLogRecPtr lsn, XLogRecord *record)
 	pageop->btpo_cycleid = 0;
 
 	PageSetLSN(page, lsn);
-	PageSetTLI(page, ThisTimeLineID);
 	MarkBufferDirty(buffer);
 	UnlockReleaseBuffer(buffer);
 
@@ -768,7 +758,6 @@ btree_xlog_newroot(XLogRecPtr lsn, XLogRecord *record)
 	}
 
 	PageSetLSN(page, lsn);
-	PageSetTLI(page, ThisTimeLineID);
 	MarkBufferDirty(buffer);
 	UnlockReleaseBuffer(buffer);
 

--- a/src/backend/access/transam/README
+++ b/src/backend/access/transam/README
@@ -437,6 +437,8 @@ critical section.)
 
 4. Mark the shared buffer(s) as dirty with MarkBufferDirty().  (This must
 happen before the WAL record is inserted; see notes in SyncOneBuffer().)
+Note that marking a buffer dirty with MarkBufferDirty() should only
+happen iff you write a WAL record; see Writing Hints below.
 
 5. If the relation requires WAL-logging, build a WAL log record and pass it
 to XLogInsert(); then update the page's LSN using the returned XLOG
@@ -542,6 +544,29 @@ replay code has to do the insertion on its own to restore the index to
 consistency.  Such insertions occur after WAL is operational, so they can
 and should write WAL records for the additional generated actions.
 
+Writing Hints
+-------------
+
+In some cases, we write additional information to data blocks without
+writing a preceding WAL record. This should only happen iff the data can
+be reconstructed later following a crash and the action is simply a way
+of optimising for performance. When a hint is written we use
+MarkBufferDirtyHint() to mark the block dirty.
+
+If the buffer is clean and checksums are in use then
+MarkBufferDirtyHint() inserts an XLOG_HINT record to ensure that we
+take a full page image that includes the hint. We do this to avoid
+a partial page write, when we write the dirtied page. WAL is not
+written during recovery, so we simply skip dirtying blocks because
+of hints when in recovery.
+
+If you do decide to optimise away a WAL record, then any calls to
+MarkBufferDirty() must be replaced by MarkBufferDirtyHint(),
+otherwise you will expose the risk of partial page writes.
+
+In GPDB, gp_disable_tuple_hints GUC dictates whether a buffer is marked dirty
+by a hint bit change. If the GUC is on, hint bit changes do not mark a buffer
+dirty.
 
 Asynchronous Commit
 -------------------

--- a/src/backend/access/transam/README
+++ b/src/backend/access/transam/README
@@ -438,13 +438,15 @@ critical section.)
 4. Mark the shared buffer(s) as dirty with MarkBufferDirty().  (This must
 happen before the WAL record is inserted; see notes in SyncOneBuffer().)
 
-5. Build a WAL log record and pass it to XLogInsert(); then update the page's
-LSN and TLI using the returned XLOG location.  For instance,
+5. If the relation requires WAL-logging, build a WAL log record and pass it
+to XLogInsert(); then update the page's LSN using the returned XLOG
+location.  For instance,
 
 		recptr = XLogInsert(rmgr_id, info, rdata);
 
 		PageSetLSN(dp, recptr);
-		PageSetTLI(dp, ThisTimeLineID);
+		// Note that we no longer do PageSetTLI() from 9.3 onwards
+		// since that field on a page has now changed its meaning.
 
 6. END_CRIT_SECTION()
 
@@ -489,7 +491,6 @@ standard replay-routine pattern for this case is
 	... initialize the page ...
 
 	PageSetLSN(page, lsn);
-	PageSetTLI(page, ThisTimeLineID);
 	MarkBufferDirty(buffer);
 	UnlockReleaseBuffer(buffer);
 
@@ -517,7 +518,6 @@ The standard replay-routine pattern for this case is
 	... apply the change ...
 
 	PageSetLSN(page, lsn);
-	PageSetTLI(page, ThisTimeLineID);
 	MarkBufferDirty(buffer);
 	UnlockReleaseBuffer(buffer);
 

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -3407,7 +3407,6 @@ RestoreBkpBlocks(XLogRecord *record, XLogRecPtr lsn)
 		}
 
 		PageSetLSN(page, lsn);
-		PageSetTLI(page, ThisTimeLineID);
 		MarkBufferDirty(buffer);
 		UnlockReleaseBuffer(buffer);
 

--- a/src/backend/commands/dbcommands.c
+++ b/src/backend/commands/dbcommands.c
@@ -318,7 +318,7 @@ static void copy_buffer_pool_files(
 			recptr = XLogInsert(RM_HEAP_ID, XLOG_HEAP_NEWPAGE, rdata);
 		
 			PageSetLSN(buffer, recptr);
-		
+			PageSetChecksumInplace(buffer, blkno);
 			END_CRIT_SECTION();
 
 		}

--- a/src/backend/commands/dbcommands.c
+++ b/src/backend/commands/dbcommands.c
@@ -318,7 +318,6 @@ static void copy_buffer_pool_files(
 			recptr = XLogInsert(RM_HEAP_ID, XLOG_HEAP_NEWPAGE, rdata);
 		
 			PageSetLSN(buffer, recptr);
-			PageSetTLI(buffer, ThisTimeLineID);
 		
 			END_CRIT_SECTION();
 

--- a/src/backend/commands/sequence.c
+++ b/src/backend/commands/sequence.c
@@ -1486,7 +1486,7 @@ read_seq_tuple(SeqTable elm, Relation rel, Buffer *buf, HeapTuple seqtuple)
 		HeapTupleHeaderSetXmax(seqtuple->t_data, InvalidTransactionId);
 		seqtuple->t_data->t_infomask &= ~HEAP_XMAX_COMMITTED;
 		seqtuple->t_data->t_infomask |= HEAP_XMAX_INVALID;
-		SetBufferCommitInfoNeedsSave(*buf);
+		MarkBufferDirtyHint(*buf);
 	}
 
 	seq = (Form_pg_sequence) GETSTRUCT(seqtuple);

--- a/src/backend/commands/sequence.c
+++ b/src/backend/commands/sequence.c
@@ -587,7 +587,6 @@ DefineSequence(CreateSeqStmt *seq)
 		recptr = XLogInsert(RM_SEQ_ID, XLOG_SEQ_LOG, rdata);
 
 		PageSetLSN(page, recptr);
-		PageSetTLI(page, ThisTimeLineID);
 	}
 
 	END_CRIT_SECTION();
@@ -716,7 +715,6 @@ AlterSequence(AlterSeqStmt *stmt)
 		recptr = XLogInsert(RM_SEQ_ID, XLOG_SEQ_LOG, rdata);
 
 		PageSetLSN(page, recptr);
-		PageSetTLI(page, ThisTimeLineID);
 	}
 
 	END_CRIT_SECTION();
@@ -1065,7 +1063,6 @@ cdb_sequence_nextval(SeqTable elm,
 		recptr = XLogInsert(RM_SEQ_ID, XLOG_SEQ_LOG, rdata);
 
 		PageSetLSN(page, recptr);
-		PageSetTLI(page, ThisTimeLineID);
 
 		/* need to update where we've inserted to into shmem so that the QD can flush it
 		 * when necessary
@@ -1291,7 +1288,6 @@ do_setval(Oid relid, int64 next, bool iscalled)
 		recptr = XLogInsert(RM_SEQ_ID, XLOG_SEQ_LOG, rdata);
 
 		PageSetLSN(page, recptr);
-		PageSetTLI(page, ThisTimeLineID);
 	}
 
 	END_CRIT_SECTION();
@@ -1864,7 +1860,6 @@ seq_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record)
 		elog(PANIC, "seq_redo: failed to add item to page");
 
 	PageSetLSN(page, lsn);
-	PageSetTLI(page, ThisTimeLineID);
 	MarkBufferDirty(buffer);
 	UnlockReleaseBuffer(buffer);
 	

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -10272,6 +10272,8 @@ copy_buffer_pool_data(Relation rel, SMgrRelation dst,
 
 		smgrread(src, blkno, buf);
 
+		PageSetChecksumInplace(page, blkno);
+
 		/* XLOG stuff */
 		if (useWal)
 		{

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -3332,7 +3332,6 @@ scan_heap(VRelStats *vacrelstats, Relation onerel,
 				recptr = log_heap_freeze(onerel, buf, FreezeLimit,
 										 frozen, nfrozen);
 				PageSetLSN(page, recptr);
-				PageSetTLI(page, ThisTimeLineID);
 			}
 		}
 
@@ -4482,10 +4481,8 @@ move_chain_tuple(Relation rel,
 		if (old_buf != dst_buf)
 		{
 			PageSetLSN(old_page, recptr);
-			PageSetTLI(old_page, ThisTimeLineID);
 		}
 		PageSetLSN(dst_page, recptr);
-		PageSetTLI(dst_page, ThisTimeLineID);
 	}
 
 	END_CRIT_SECTION();
@@ -4590,9 +4587,7 @@ move_plain_tuple(Relation rel,
 										   dst_buf, &newtup);
 
 		PageSetLSN(old_page, recptr);
-		PageSetTLI(old_page, ThisTimeLineID);
 		PageSetLSN(dst_page, recptr);
-		PageSetTLI(dst_page, ThisTimeLineID);
 	}
 
 	END_CRIT_SECTION();
@@ -4698,7 +4693,6 @@ vacuum_page(Relation onerel, Buffer buffer, VacPage vacpage)
 								vacpage->offsets, vacpage->offsets_free,
 								false);
 		PageSetLSN(page, recptr);
-		PageSetTLI(page, ThisTimeLineID);
 	}
 
 	END_CRIT_SECTION();

--- a/src/backend/commands/vacuumlazy.c
+++ b/src/backend/commands/vacuumlazy.c
@@ -751,7 +751,6 @@ lazy_scan_heap(Relation onerel, LVRelStats *vacrelstats,
 				recptr = log_heap_freeze(onerel, buf, FreezeLimit,
 										 frozen, nfrozen);
 				PageSetLSN(page, recptr);
-				PageSetTLI(page, ThisTimeLineID);
 			}
 		}
 
@@ -955,7 +954,6 @@ lazy_vacuum_page(Relation onerel, BlockNumber blkno, Buffer buffer,
 								unused, uncnt,
 								false);
 		PageSetLSN(page, recptr);
-		PageSetTLI(page, ThisTimeLineID);
 	}
 
 	END_CRIT_SECTION();

--- a/src/backend/storage/page/README
+++ b/src/backend/storage/page/README
@@ -3,6 +3,50 @@ src/backend/storage/page/README
 Checksums
 ---------
 
-Checksums will soon be supported for heap tables in Greenplum by
-pulling in commits from upstream PostgreSQL 9.3.  Append-optimized
-tables are already protected with checksums.
+Checksums on data pages are designed to detect corruption by the I/O system.
+We do not protect buffers against uncorrectable memory errors, since these
+have a very low measured incidence according to research on large server farms,
+http://www.cs.toronto.edu/~bianca/papers/sigmetrics09.pdf, discussed
+2010/12/22 on -hackers list.
+
+Current implementation requires this be enabled system-wide at initdb time.
+
+The checksum is not valid at all times on a data page!!
+The checksum is valid when the page leaves the shared pool and is checked
+when it later re-enters the shared pool as a result of I/O.
+We set the checksum on a buffer in the shared pool immediately before we
+flush the buffer. As a result we implicitly invalidate the page's checksum
+when we modify the page for a data change or even a hint. This means that
+many or even most pages in shared buffers have invalid page checksums,
+so be careful how you interpret the pd_checksum field.
+
+That means that WAL-logged changes to a page do NOT update the page checksum,
+so full page images may not have a valid checksum. But those page images have
+the WAL CRC covering them and so are verified separately from this
+mechanism. WAL replay should not test the checksum of a full-page image.
+
+The best way to understand this is that WAL CRCs protect records entering the
+WAL stream, and data page verification protects blocks entering the shared
+buffer pool. They are similar in purpose, yet completely separate.  Together
+they ensure we are able to detect errors in data re-entering
+PostgreSQL-controlled memory. Note also that the WAL checksum is a 32-bit CRC,
+whereas the page checksum is only 16-bits.
+
+Any write of a data block can cause a torn page if the write is unsuccessful.
+Full page writes protect us from that, which are stored in WAL.  Setting hint
+bits when a page is already dirty is OK because a full page write must already
+have been written for it since the last checkpoint.  Setting hint bits on an
+otherwise clean page can allow torn pages; this doesn't normally matter since
+they are just hints, but when the page has checksums, then losing a few bits
+would cause the checksum to be invalid.  So if we have full_page_writes = on
+and checksums enabled then we must write a WAL record specifically so that we
+record a full page image in WAL.  Hint bits updates should be protected using
+MarkBufferDirtyHint(), which is responsible for writing the full-page image
+when necessary.
+
+New WAL records cannot be written during recovery, so hint bits set during
+recovery must not dirty the page if the buffer is not already dirty, when
+checksums are enabled.  Systems in Hot-Standby mode may benefit from hint bits
+being set, but with checksums enabled, a page cannot be dirtied after setting a
+hint bit (due to the torn page risk). So, it must wait for full-page images
+containing the hint bit updates to arrive from the master.

--- a/src/backend/storage/page/bufpage.c
+++ b/src/backend/storage/page/bufpage.c
@@ -86,7 +86,7 @@ PageIsVerified(Page page, BlockNumber blkno)
 	bool		checksum_failure = false;
 	bool		header_sane = false;
 	bool		all_zeroes = false;
-	uint16		checksum;
+	uint16		checksum = 0;
 
 	/*
 	 * Don't verify page data unless the page passes basic non-zero test

--- a/src/backend/storage/page/bufpage.c
+++ b/src/backend/storage/page/bufpage.c
@@ -16,7 +16,15 @@
 
 #include "access/htup.h"
 #include "storage/bufpage.h"
+#include "access/xlog.h"
+#include "utils/pg_crc.h"
 
+bool ignore_checksum_failure = false;
+
+static char pageCopyData[BLCKSZ];	/* for checksum calculation */
+static Page pageCopy = pageCopyData;
+
+static uint16 PageCalcChecksum16(Page page, BlockNumber blkno);
 
 /* ----------------------------------------------------------------
  *						Page support functions
@@ -26,6 +34,8 @@
 /*
  * PageInit
  *		Initializes the contents of a page.
+ *		Note that we don't calculate an initial checksum here; that's not done
+ *		until it's time to write.
  */
 void
 PageInit(Page page, Size pageSize, Size specialSize)
@@ -40,7 +50,7 @@ PageInit(Page page, Size pageSize, Size specialSize)
 	/* Make sure all fields of page are zero, as well as unused space */
 	MemSet(p, 0, pageSize);
 
-	/* p->pd_flags = 0;								done by above MemSet */
+	p->pd_flags = 0;
 	p->pd_lower = SizeOfPageHeaderData;
 	p->pd_upper = pageSize - specialSize;
 	p->pd_special = pageSize - specialSize;
@@ -50,8 +60,8 @@ PageInit(Page page, Size pageSize, Size specialSize)
 
 
 /*
- * PageHeaderIsValid
- *		Check that the header fields of a page appear valid.
+ * PageIsVerified
+ *		Check that the page header and checksum (if any) appear valid.
  *
  * This is called when a page has just been read in from disk.	The idea is
  * to cheaply detect trashed pages before we go nuts following bogus item
@@ -68,30 +78,77 @@ PageInit(Page page, Size pageSize, Size specialSize)
  * will clean up such a page and make it usable.
  */
 bool
-PageHeaderIsValid(PageHeader page)
+PageIsVerified(Page page, BlockNumber blkno)
 {
+	PageHeader	p = (PageHeader) page;
 	char	   *pagebytes;
 	int			i;
+	bool		checksum_failure = false;
+	bool		header_sane = false;
+	bool		all_zeroes = false;
+	uint16		checksum;
 
-	/* Check normal case */
-	if (PageGetPageSize(page) == BLCKSZ &&
-		PageGetPageLayoutVersion(page) == PG_PAGE_LAYOUT_VERSION &&
-		(page->pd_flags & ~PD_VALID_FLAG_BITS) == 0 &&
-		page->pd_lower >= SizeOfPageHeaderData &&
-		page->pd_lower <= page->pd_upper &&
-		page->pd_upper <= page->pd_special &&
-		page->pd_special <= BLCKSZ &&
-		page->pd_special == MAXALIGN(page->pd_special))
-		return true;
+	/*
+	 * Don't verify page data unless the page passes basic non-zero test
+	 */
+	if (!PageIsNew(page))
+	{
+		if (DataChecksumsEnabled())
+		{
+			checksum = PageCalcChecksum16(page, blkno);
+
+			if (checksum != p->pd_checksum)
+				checksum_failure = true;
+		}
+
+		/*
+		 * The following checks don't prove the header is correct,
+		 * only that it looks sane enough to allow into the buffer pool.
+		 * Later usage of the block can still reveal problems,
+		 * which is why we offer the checksum option.
+		 */
+		if ((p->pd_flags & ~PD_VALID_FLAG_BITS) == 0 &&
+			 p->pd_lower <= p->pd_upper &&
+			 p->pd_upper <= p->pd_special &&
+			 p->pd_special <= BLCKSZ &&
+			 p->pd_special == MAXALIGN(p->pd_special))
+			header_sane = true;
+
+		if (header_sane && !checksum_failure)
+			return true;
+	}
 
 	/* Check all-zeroes case */
+	all_zeroes = true;
 	pagebytes = (char *) page;
 	for (i = 0; i < BLCKSZ; i++)
 	{
 		if (pagebytes[i] != 0)
-			return false;
+		{
+			all_zeroes = false;
+			break;
+		}
 	}
-	return true;
+
+	if (all_zeroes)
+		return true;
+
+	/*
+	 * Throw a WARNING if the checksum fails, but only after we've checked for
+	 * the all-zeroes case.
+	 */
+	if (checksum_failure)
+	{
+		ereport(WARNING,
+				(ERRCODE_DATA_CORRUPTED,
+				 errmsg("page verification failed, calculated checksum %u but expected %u",
+						checksum, p->pd_checksum)));
+
+		if (header_sane && ignore_checksum_failure)
+			return true;
+	}
+
+	return false;
 }
 
 
@@ -807,4 +864,99 @@ PageIndexMultiDelete(Page page, OffsetNumber *itemnos, int nitems)
 	phdr->pd_upper = upper;
 
 	pfree(itemidbase);
+}
+
+/*
+ * Set checksum for page in shared buffers.
+ *
+ * If checksums are disabled, or if the page is not initialized, just return
+ * the input. Otherwise, we must make a copy of the page before calculating the
+ * checksum, to prevent concurrent modifications (e.g. setting hint bits) from
+ * making the final checksum invalid.
+ *
+ * Returns a pointer to the block-sized data that needs to be written. Uses
+ * statically-allocated memory, so the caller must immediately write the
+ * returned page and not refer to it again.
+ */
+char *
+PageSetChecksumCopy(Page page, BlockNumber blkno)
+{
+	if (PageIsNew(page) || !DataChecksumsEnabled())
+		return (char *) page;
+
+	/*
+	 * We make a copy iff we need to calculate a checksum because other
+	 * backends may set hint bits on this page while we write, which
+	 * would mean the checksum differs from the page contents. It doesn't
+	 * matter if we include or exclude hints during the copy, as long
+	 * as we write a valid page and associated checksum.
+	 */
+	memcpy((char *) pageCopy, (char *) page, BLCKSZ);
+	PageSetChecksumInplace(pageCopy, blkno);
+	return (char *) pageCopy;
+}
+
+/*
+ * Set checksum for page in private memory.
+ *
+ * This is a simpler version of PageSetChecksumCopy(). The more explicit API
+ * allows us to more easily see if we're making the correct call and reduces
+ * the amount of additional code specific to page verification.
+ */
+void
+PageSetChecksumInplace(Page page, BlockNumber blkno)
+{
+	if (PageIsNew(page))
+		return;
+
+	if (DataChecksumsEnabled())
+	{
+		PageHeader	p = (PageHeader) page;
+		p->pd_checksum = PageCalcChecksum16(page, blkno);
+	}
+
+	return;
+}
+
+/*
+ * Calculate checksum for a PostgreSQL Page. This includes the block number (to
+ * detect the case when a page is somehow moved to a different location), the
+ * page header (excluding the checksum itself), and the page data.
+ *
+ * Note that if the checksum validation fails we cannot tell the difference
+ * between a transposed block and failure from direct on-block corruption,
+ * though that is better than just ignoring transposed blocks altogether.
+ */
+static uint16
+PageCalcChecksum16(Page page, BlockNumber blkno)
+{
+	pg_crc32    		crc;
+	PageHeader	p = (PageHeader) page;
+
+	/* only calculate the checksum for properly-initialized pages */
+	Assert(!PageIsNew(page));
+
+	INIT_CRC32C(crc);
+
+	/*
+	 * Initialize the checksum calculation with the block number. This helps
+	 * catch corruption from whole blocks being transposed with other whole
+	 * blocks.
+	 */
+	COMP_CRC32C(crc, &blkno, sizeof(blkno));
+
+	/*
+	 * Now add in the LSN, which is always the first field on the page.
+	 */
+	COMP_CRC32C(crc, page, sizeof(p->pd_lsn));
+
+	/*
+	 * Now add the rest of the page, skipping the pd_checksum field.
+	 */
+	COMP_CRC32C(crc, page + sizeof(p->pd_lsn) + sizeof(p->pd_checksum),
+				  BLCKSZ - sizeof(p->pd_lsn) - sizeof(p->pd_checksum));
+
+	FIN_CRC32C(crc);
+
+	return (uint16) crc;
 }

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -113,6 +113,7 @@ extern int	CommitDelay;
 extern int	CommitSiblings;
 extern char *default_tablespace;
 extern char *temp_tablespaces;
+extern bool ignore_checksum_failure;
 extern bool synchronize_seqscans;
 extern bool fullPageWrites;
 extern int	ssl_renegotiation_limit;
@@ -620,6 +621,21 @@ static struct config_bool ConfigureNamesBool[] =
 		},
 		&XactSyncCommit,
 		true, NULL, NULL
+	},
+	{
+		{"ignore_checksum_failure", PGC_SUSET, DEVELOPER_OPTIONS,
+			gettext_noop("Continues processing after a checksum failure."),
+			gettext_noop("Detection of a checksum failure normally causes PostgreSQL to "
+				"report an error, aborting the current transaction. Setting "
+						 "ignore_checksum_failure to true causes the system to ignore the failure "
+						 "(but still report a warning), and continue processing. This "
+						 "behavior could cause crashes or other serious problems. Only "
+						 "has an effect if checksums are enabled."),
+			GUC_NOT_IN_SAMPLE
+		},
+		&ignore_checksum_failure,
+		false,
+		NULL, NULL, NULL
 	},
 	{
 		{"zero_damaged_pages", PGC_SUSET, DEVELOPER_OPTIONS,

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -180,6 +180,7 @@ bool		gp_appendonly_verify_write_block = false;
 bool		gp_appendonly_verify_eof = true;
 bool		gp_appendonly_compaction = true;
 int			gp_appendonly_compaction_threshold = 0;
+bool		gp_heap_verify_checksums_on_mirror = false;
 bool		gp_heap_require_relhasoids_match = true;
 bool		Debug_appendonly_rezero_quicklz_compress_scratch = false;
 bool		Debug_appendonly_rezero_quicklz_decompress_scratch = false;
@@ -1154,6 +1155,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 		},
 		&gp_appendonly_compaction,
 		true, NULL, NULL
+	},
+
+	{
+		{"gp_heap_verify_checksums_on_mirror", PGC_USERSET, DEVELOPER_OPTIONS,
+		 gettext_noop("Verify the heap checksums on mirror after receiving block from primary before writing to disk."),
+		 NULL,
+		 GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL
+		},
+		&gp_heap_verify_checksums_on_mirror,
+		false, NULL, NULL
 	},
 
 	{

--- a/src/backend/utils/time/tqual.c
+++ b/src/backend/utils/time/tqual.c
@@ -6,7 +6,7 @@
  * NOTE: all the HeapTupleSatisfies routines will update the tuple's
  * "hint" status bits if we see that the inserting or deleting transaction
  * has now committed or aborted (and it is safe to set the hint bits).
- * If the hint bits are changed, SetBufferCommitInfoNeedsSave is called on
+ * If the hint bits are changed, MarkBufferDirtyHint is called on
  * the passed-in buffer.  The caller must hold not only a pin, but at least
  * shared buffer content lock on the buffer containing the tuple.
  *
@@ -131,7 +131,7 @@ markDirty(Buffer buffer, Relation relation, HeapTupleHeader tuple, bool isXmin)
 
 	if (!gp_disable_tuple_hints)
 	{
-		SetBufferCommitInfoNeedsSave(buffer);
+		MarkBufferDirtyHint(buffer);
 		return;
 	}
 
@@ -141,14 +141,14 @@ markDirty(Buffer buffer, Relation relation, HeapTupleHeader tuple, bool isXmin)
 	 */
 	if (relation == NULL)
 	{
-		SetBufferCommitInfoNeedsSave(buffer);
+		MarkBufferDirtyHint(buffer);
 		return;
 	}
 
 	if (relation->rd_issyscat)
 	{
 		/* Assume we want to always mark the buffer dirty */
-		SetBufferCommitInfoNeedsSave(buffer);
+		MarkBufferDirtyHint(buffer);
 		return;
 	}
 
@@ -162,7 +162,7 @@ markDirty(Buffer buffer, Relation relation, HeapTupleHeader tuple, bool isXmin)
 
 	if (xid == InvalidTransactionId)
 	{
-		SetBufferCommitInfoNeedsSave(buffer);
+		MarkBufferDirtyHint(buffer);
 		return;
 	}
 
@@ -171,7 +171,7 @@ markDirty(Buffer buffer, Relation relation, HeapTupleHeader tuple, bool isXmin)
 	 */
 	if (CLOGTransactionIsOld(xid))
 	{
-		SetBufferCommitInfoNeedsSave(buffer);
+		MarkBufferDirtyHint(buffer);
 		return;
 	}
 }

--- a/src/bin/pg_controldata/pg_controldata.c
+++ b/src/bin/pg_controldata/pg_controldata.c
@@ -232,6 +232,5 @@ main(int argc, char *argv[])
 		   ControlFile.lc_ctype);
 	printf(_("Data page checksum version:           %u\n"),
 		   ControlFile.data_checksum_version);
-
 	return 0;
 }

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -246,6 +246,7 @@ extern void XLogFileRepFlushCache(
 	XLogRecPtr	*lastChangeTrackingEndLoc);
 
 extern void XLogGetLastRemoved(uint32 *log, uint32 *seg);
+extern XLogRecPtr XLogSaveBufferForHint(Buffer buffer);
 
 extern void xlog_redo(XLogRecPtr beginLoc __attribute__((unused)), XLogRecPtr lsn __attribute__((unused)), XLogRecord *record);
 extern void xlog_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record);

--- a/src/include/catalog/pg_control.h
+++ b/src/include/catalog/pg_control.h
@@ -58,6 +58,7 @@ typedef struct CheckPoint
 #define XLOG_SWITCH						0x40
 #define XLOG_BACKUP_END					0x50
 #define XLOG_NEXTRELFILENODE			0x60
+#define XLOG_HINT						0x70
 
 
 /* System status indicator */

--- a/src/include/storage/bufmgr.h
+++ b/src/include/storage/bufmgr.h
@@ -318,6 +318,7 @@ extern void FlushDatabaseBuffers(Oid dbid);
 extern void DropRelFileNodeBuffers(RelFileNode rnode, bool istemp,
 					   BlockNumber firstDelBlock);
 extern void DropDatabaseBuffers(Oid tbpoid, Oid dbid);
+extern XLogRecPtr BufferGetLSNAtomic(Buffer buffer);
 
 #ifdef NOT_USED
 extern void PrintPinnedBufs(void);
@@ -325,7 +326,7 @@ extern void PrintPinnedBufs(void);
 extern Size BufferShmemSize(void);
 extern RelFileNode BufferGetFileNode(Buffer buffer);
 
-extern void SetBufferCommitInfoNeedsSave(Buffer buffer);
+extern void MarkBufferDirtyHint(Buffer buffer);
 
 extern void UnlockBuffers(void);
 extern void LockBuffer(Buffer buffer, int mode);

--- a/src/include/storage/bufpage.h
+++ b/src/include/storage/bufpage.h
@@ -15,6 +15,7 @@
 #define BUFPAGE_H
 
 #include "storage/bufmgr.h"
+#include "storage/block.h"
 #include "storage/item.h"
 #include "storage/off.h"
 #include "access/xlog.h"
@@ -402,7 +403,7 @@ do { \
  */
 
 extern void PageInit(Page page, Size pageSize, Size specialSize);
-extern bool PageHeaderIsValid(PageHeader page);
+extern bool PageIsVerified(Page page, BlockNumber blkno);
 extern OffsetNumber PageAddItem(Page page, Item item, Size size,
 			OffsetNumber offsetNumber, bool overwrite, bool is_heap);
 extern Page PageGetTempPage(Page page, Size specialSize);
@@ -413,5 +414,7 @@ extern Size PageGetExactFreeSpace(Page page);
 extern Size PageGetHeapFreeSpace(Page page);
 extern void PageIndexTupleDelete(Page page, OffsetNumber offset);
 extern void PageIndexMultiDelete(Page page, OffsetNumber *itemnos, int nitems);
+extern char *PageSetChecksumCopy(Page page, BlockNumber blkno);
+extern void PageSetChecksumInplace(Page page, BlockNumber blkno);
 
 #endif   /* BUFPAGE_H */

--- a/src/include/storage/bufpage.h
+++ b/src/include/storage/bufpage.h
@@ -89,7 +89,7 @@ typedef uint16 LocationIndex;
  * space management information generic to any page
  *
  *		pd_lsn		- identifies xlog record for last change to this page.
- *		pd_tli		- ditto.
+ *		pd_checksum	- page checksum, if set.
  *		pd_flags	- flag bits.
  *		pd_lower	- offset to start of free space.
  *		pd_upper	- offset to end of free space.
@@ -100,9 +100,17 @@ typedef uint16 LocationIndex;
  * The LSN is used by the buffer manager to enforce the basic rule of WAL:
  * "thou shalt write xlog before data".  A dirty buffer cannot be dumped
  * to disk until xlog has been flushed at least as far as the page's LSN.
- * We also store the 16 least significant bits of the TLI for identification
- * purposes (it is not clear that this is actually necessary, but it seems
- * like a good idea).
+ *
+ * pd_checksum stores the page checksum, if it has been set for this page;
+ * zero is a valid value for a checksum. If a checksum is not in use then
+ * we leave the field unset. This will typically mean the field is zero
+ * though non-zero values may also be present if databases have been
+ * pg_upgraded from releases prior to 9.3, when the same byte offset was
+ * used to store the current timelineid when the page was last updated.
+ * Note that there is no indication on a page as to whether the checksum
+ * is valid or not, a deliberate design choice which avoids the problem
+ * of relying on the page contents to decide whether to verify it. Hence
+ * there are no flag bits relating to checksums.
  *
  * pd_prune_xid is a hint field that helps determine whether pruning will be
  * useful.	It is currently unused in index pages.
@@ -125,8 +133,7 @@ typedef struct PageHeaderData
 	/* XXX LSN is member of *any* block, not only page-organized ones */
 	XLogRecPtr	pd_lsn;			/* LSN: next byte after last byte of xlog
 								 * record for last change to this page */
-	uint16		pd_tli;			/* least significant bits of the TimeLineID
-								 * containing the LSN */
+	uint16		pd_checksum;	/* checksum */
 	uint16		pd_flags;		/* flag bits, see below */
 	LocationIndex pd_lower;		/* offset to start of free space */
 	LocationIndex pd_upper;		/* offset to end of free space */
@@ -350,12 +357,6 @@ typedef PageHeaderData *PageHeader;
 	(((PageHeader) (page))->pd_lsn)
 #define PageSetLSN(page, lsn) \
 	(((PageHeader) (page))->pd_lsn = (lsn))
-
-/* NOTE: only the 16 least significant bits are stored */
-#define PageGetTLI(page) \
-	(((PageHeader) (page))->pd_tli)
-#define PageSetTLI(page, tli) \
-	(((PageHeader) (page))->pd_tli = (uint16) (tli))
 
 #define PageHasFreeLinePointers(page) \
 	(((PageHeader) (page))->pd_flags & PD_HAS_FREE_LINES)

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -197,6 +197,7 @@ extern bool gp_appendonly_compaction;
  * 10% of the tuples are hidden.
  */ 
 extern int  gp_appendonly_compaction_threshold;
+extern bool gp_heap_verify_checksums_on_mirror;
 extern bool gp_heap_require_relhasoids_match;
 extern bool	Debug_appendonly_rezero_quicklz_compress_scratch;
 extern bool	Debug_appendonly_rezero_quicklz_decompress_scratch;

--- a/src/test/heap_checksum/.gitignore
+++ b/src/test/heap_checksum/.gitignore
@@ -1,0 +1,4 @@
+# Generated directories and files
+/results/
+/expected/setup.out
+/sql/setup.sql

--- a/src/test/heap_checksum/Makefile
+++ b/src/test/heap_checksum/Makefile
@@ -1,0 +1,13 @@
+MODULES=heap_checksum_helper
+PG_CONFIG=pg_config
+
+REGRESS = setup heap_checksum_corruption
+REGRESS_OPTS = --dbname="heap_checksum_regression"
+
+subdir = src/test/heap_checksum/
+top_builddir = ../../..
+
+include $(top_builddir)/src/Makefile.global
+
+NO_PGXS = 1
+include $(top_srcdir)/src/makefiles/pgxs.mk

--- a/src/test/heap_checksum/expected/heap_checksum_corruption.out
+++ b/src/test/heap_checksum/expected/heap_checksum_corruption.out
@@ -1,0 +1,232 @@
+-- The following test simulates corruption of a heap relation file and
+-- verifies the select behavior on this corrupted table, the related indexes
+-- and toast tables.
+-- Mask out the expected and actual values of the checksums when comparing the
+-- result. All we care about is that they don't match.
+--
+-- start_matchsubs
+-- m/^ERROR:.*invalid page in block.*/
+-- s/invalid page in block.*/invalid page in block/
+-- m/^ERROR:  missing chunk number.*/
+-- s/missing chunk number.*/missing chunk number/
+-- end_matchsubs
+-- Ignore the status messages from the helper function. They're useful for
+-- debugging, but the output is different on every invocation.
+-- start_matchignore
+-- m/^INFO:  corrupting file/
+-- m/^INFO:  skipping non-existent file/
+-- m/^WARNING:  page verification failed, calculated checksum.*/
+-- end_matchignore
+-- start_ignore
+CREATE LANGUAGE plpythonu;
+-- end_ignore
+-- Create our test tables (and functions) in a bespoken schema that we can drop
+-- at the end. We don't want to leave any corrupt files lying around!
+CREATE SCHEMA corrupt_heap_checksum;
+set search_path='corrupt_heap_checksum';
+-- to ignore the CONTEXT from messages from the plpython helpers, and to ignore
+-- DETAILs from the checksum errors.
+\set VERBOSITY terse
+-- Return path to the file holding data for the given table (relative to
+-- $PGDATA).
+--
+CREATE FUNCTION get_relation_path(tbl regclass) returns text as $$
+  (select 'base/' || db.oid || '/' || c.relfilenode from pg_class c, pg_database db where c.oid = $1 AND db.datname = current_database())
+$$ language sql VOLATILE;
+-- Return path to the file holding data for the given table's TOAST table (relative to
+-- $PGDATA).
+--
+CREATE FUNCTION get_toast_path(tbl regclass) returns text as $$
+  (select 'base/' || db.oid || '/' || c.relfilenode from pg_class c, pg_database db where c.oid = ( SELECT reltoastrelid FROM pg_class  WHERE oid = $1) AND db.datname = current_database())
+$$ language sql VOLATILE;
+-- Return name of the given table's TOAST table (relative to
+-- $PGDATA).
+--
+CREATE FUNCTION get_toast_name(tbl regclass) returns text as $$
+  (select relname::text from pg_class where oid = ( SELECT reltoastrelid FROM pg_class  WHERE oid = $1))
+$$ language sql VOLATILE;
+-- Return path to the file holding data for the given table's index (relative to
+-- $PGDATA).
+--
+CREATE FUNCTION get_index_path(tbl regclass) returns text as $$
+  (select 'base/' || db.oid || '/' || c.relfilenode from pg_class c, pg_database db where c.oid = ( SELECT indexrelid FROM pg_index  WHERE indrelid = $1) AND db.datname = current_database())
+$$ language sql VOLATILE;
+-- Corrupt data file at given path (if it exists on this segment)
+--
+-- If corruption_offset is negative, it's an offset from the end of file.
+-- Otherwise it's from the beginning of file.
+--
+-- Returns 0. (That's handy in the way this function is called, because we can
+-- do a SUM() over the return values, and it's always 0, regardless of the
+-- number of segments in the cluster.)
+CREATE FUNCTION corrupt_file(data_file text, corruption_offset int4)
+RETURNS integer as $$
+  import os;
+
+  if not os.path.isfile(data_file):
+    plpy.info('skipping non-existent file %s' % (data_file))
+  else:
+    plpy.info('corrupting file %s at %s' % (data_file, corruption_offset))
+
+    with open(data_file , "rb+") as f:
+      char_location=0
+      write_char='*'  # CONST.CORRUPTION
+
+      if corruption_offset >= 0:
+        f.seek(corruption_offset, 0)
+      else:
+        f.seek(corruption_offset, 2)
+
+      f.write(write_char)
+      f.close()
+
+  return 0
+$$ LANGUAGE plpythonu;
+CREATE OR REPLACE FUNCTION invalidate_buffers_for_rel(tablename text) RETURNS BOOL AS
+$$
+DECLARE
+tablespace Oid;
+database Oid;
+relfile Oid;
+result bool;
+BEGIN
+    SELECT dattablespace, oid INTO tablespace, database FROM pg_database WHERE datname = current_database();
+    SELECT relfilenode INTO relfile FROM pg_class WHERE relname = tablename;
+    SELECT public.invalidate_buffers(tablespace, database, relfile) INTO result;
+    RETURN result;
+END;
+$$ LANGUAGE plpgsql;
+-- Make sure that checksum is enabled
+SHOW data_checksums;
+ data_checksums 
+----------------
+ on
+(1 row)
+
+--  Corrupt a heap table
+create table corrupt_table(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+insert into corrupt_table select i from generate_series(1, 10) i;
+checkpoint;
+select invalidate_buffers_for_rel('corrupt_table') from gp_dist_random('gp_id');
+ invalidate_buffers_for_rel 
+----------------------------
+ t
+ t
+ t
+(3 rows)
+
+-- Verify corruption on heap table
+select SUM(corrupt_file(get_relation_path('corrupt_table'), -50)) from gp_dist_random('gp_id');
+INFO:  corrupting file base/16496/16400 at -50  (seg0 slice1 127.0.0.1:25432 pid=48282)
+INFO:  corrupting file base/16496/16400 at -50  (seg1 slice1 127.0.0.1:25433 pid=48283)
+INFO:  corrupting file base/16496/16400 at -50  (seg2 slice1 127.0.0.1:25434 pid=48284)
+ sum 
+-----
+   0
+(1 row)
+
+SELECT COUNT(*) FROM corrupt_table;
+WARNING:  page verification failed, calculated checksum 12786 but expected 37746  (seg0 slice1 127.0.0.1:25432 pid=48282)
+WARNING:  page verification failed, calculated checksum 3501 but expected 44845  (seg1 slice1 127.0.0.1:25433 pid=48283)
+WARNING:  page verification failed, calculated checksum 26345 but expected 50281  (seg2 slice1 127.0.0.1:25434 pid=48284)
+ERROR:  invalid page in block 0 of relation base/16496/16400  (seg0 slice1 127.0.0.1:25432 pid=48282)
+-- Corrupt a heap table, with toast table 
+create table corrupt_toast_table(a int, comment bytea);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+insert into corrupt_toast_table select i, ("decode"(repeat('a',3000000),'escape')) from generate_series(1,10) i;
+checkpoint;
+select invalidate_buffers_for_rel(get_toast_name('corrupt_toast_table')) from gp_dist_random('gp_id');
+ invalidate_buffers_for_rel 
+----------------------------
+ t
+ t
+ t
+(3 rows)
+
+-- Verify corruption on toast table
+select SUM(corrupt_file(get_toast_path('corrupt_toast_table'), -50)) from gp_dist_random('gp_id');
+INFO:  corrupting file base/16496/16402 at -50  (seg0 slice1 127.0.0.1:25432 pid=48282)
+INFO:  corrupting file base/16496/16402 at -50  (seg1 slice1 127.0.0.1:25433 pid=48283)
+INFO:  corrupting file base/16496/16402 at -50  (seg2 slice1 127.0.0.1:25434 pid=48284)
+ sum 
+-----
+   0
+(1 row)
+
+SELECT md5(comment::text) FROM corrupt_toast_table;
+WARNING:  page verification failed, calculated checksum 53958 but expected 34319  (seg0 slice1 127.0.0.1:25432 pid=48282)
+WARNING:  page verification failed, calculated checksum 46211 but expected 11834  (seg1 slice1 127.0.0.1:25433 pid=48283)
+WARNING:  page verification failed, calculated checksum 50724 but expected 23709  (seg2 slice1 127.0.0.1:25434 pid=48284)
+ERROR:  invalid page in block 2 of relation base/16496/16402  (seg0 slice1 127.0.0.1:25432 pid=48282)
+-- Corrupt a Btree Index
+create table corrupt_btree_index(a int, b char(50)); 
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+create index btree_index on corrupt_btree_index(a);
+insert into corrupt_btree_index select i, 'a' from generate_series(1, 10) i;
+checkpoint;
+select invalidate_buffers_for_rel('btree_index') from gp_dist_random('gp_id');
+ invalidate_buffers_for_rel 
+----------------------------
+ t
+ t
+ t
+(3 rows)
+
+-- Verify corruption on Btree index
+select SUM(corrupt_file(get_index_path('corrupt_btree_index'), -50)) from gp_dist_random('gp_id');
+INFO:  corrupting file base/16496/16405 at -50  (seg0 slice1 127.0.0.1:25432 pid=48282)
+INFO:  corrupting file base/16496/16405 at -50  (seg1 slice1 127.0.0.1:25433 pid=48283)
+INFO:  corrupting file base/16496/16405 at -50  (seg2 slice1 127.0.0.1:25434 pid=48284)
+ sum 
+-----
+   0
+(1 row)
+
+insert into corrupt_btree_index select i, 'a' from generate_series(1, 10) i; -- insert will trigger scan of the index
+WARNING:  page verification failed, calculated checksum 40032 but expected 16096  (seg0 127.0.0.1:25432 pid=48282)
+WARNING:  page verification failed, calculated checksum 44128 but expected 3808  (seg2 127.0.0.1:25434 pid=48284)
+WARNING:  page verification failed, calculated checksum 11666 but expected 36626  (seg1 127.0.0.1:25433 pid=48283)
+ERROR:  invalid page in block 1 of relation base/16496/16405  (seg0 127.0.0.1:25432 pid=48282)
+-- Corrupt a Bitmap Index 
+create table corrupt_bitmap_index(a int, b char(50)); 
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+create index bitmap_index on corrupt_bitmap_index(a);
+insert into corrupt_bitmap_index select i, 'a' from generate_series(1, 10) i;
+checkpoint;
+select invalidate_buffers_for_rel('bitmap_index') from gp_dist_random('gp_id');
+ invalidate_buffers_for_rel 
+----------------------------
+ t
+ t
+ t
+(3 rows)
+
+-- Verify corruption on Bitmap index 
+select SUM(corrupt_file(get_index_path('corrupt_bitmap_index'), -50)) from gp_dist_random('gp_id');
+INFO:  corrupting file base/16496/16407 at -50  (seg0 slice1 127.0.0.1:25432 pid=48282)
+INFO:  corrupting file base/16496/16407 at -50  (seg1 slice1 127.0.0.1:25433 pid=48283)
+INFO:  corrupting file base/16496/16407 at -50  (seg2 slice1 127.0.0.1:25434 pid=48284)
+ sum 
+-----
+   0
+(1 row)
+
+insert into corrupt_bitmap_index select i, 'a' from generate_series(1, 10) i; -- insert will trigger scan of the index
+WARNING:  page verification failed, calculated checksum 25994 but expected 50954  (seg0 127.0.0.1:25432 pid=48282)
+WARNING:  page verification failed, calculated checksum 16646 but expected 58246  (seg1 127.0.0.1:25433 pid=48283)
+WARNING:  page verification failed, calculated checksum 5552 but expected 46896  (seg2 127.0.0.1:25434 pid=48284)
+ERROR:  invalid page in block 1 of relation base/16496/16407  (seg0 127.0.0.1:25432 pid=48282)
+-- Clean up. We don't want to leave the corrupt tables lying around!
+reset search_path;
+DROP SCHEMA corrupt_heap_checksum CASCADE;
+NOTICE:  drop cascades to table corrupt_heap_checksum.corrupt_bitmap_index
+NOTICE:  drop cascades to table corrupt_heap_checksum.corrupt_btree_index
+NOTICE:  drop cascades to table corrupt_heap_checksum.corrupt_toast_table
+NOTICE:  drop cascades to table corrupt_heap_checksum.corrupt_table
+NOTICE:  drop cascades to function corrupt_heap_checksum.invalidate_buffers_for_rel(text)
+NOTICE:  drop cascades to function corrupt_heap_checksum.corrupt_file(text,integer)
+NOTICE:  drop cascades to function corrupt_heap_checksum.get_index_path(regclass)
+NOTICE:  drop cascades to function corrupt_heap_checksum.get_toast_name(regclass)
+NOTICE:  drop cascades to function corrupt_heap_checksum.get_toast_path(regclass)
+NOTICE:  drop cascades to function corrupt_heap_checksum.get_relation_path(regclass)

--- a/src/test/heap_checksum/heap_checksum_helper.c
+++ b/src/test/heap_checksum/heap_checksum_helper.c
@@ -1,0 +1,27 @@
+#include "postgres.h"
+#include "funcapi.h"
+#include "nodes/pg_list.h"
+#include "storage/buf_internals.h"
+#include "storage/bufmgr.h"
+
+#ifdef PG_MODULE_MAGIC
+PG_MODULE_MAGIC;
+#endif
+
+Datum invalidate_buffers(PG_FUNCTION_ARGS);
+
+PG_FUNCTION_INFO_V1(invalidate_buffers);
+Datum
+invalidate_buffers(PG_FUNCTION_ARGS)
+{
+	RelFileNode			rnode;
+
+	rnode.spcNode = PG_GETARG_OID(0);
+	rnode.dbNode  = PG_GETARG_OID(1);
+	rnode.relNode = PG_GETARG_OID(2);
+
+	DropRelFileNodeBuffers(rnode, false, 0);
+
+	PG_RETURN_BOOL(true);
+}
+

--- a/src/test/heap_checksum/input/setup.source
+++ b/src/test/heap_checksum/input/setup.source
@@ -1,0 +1,2 @@
+CREATE OR REPLACE FUNCTION invalidate_buffers(Oid, Oid, Oid) RETURNS BOOL AS '@abs_builddir@/heap_checksum_helper@DLSUFFIX@', 'invalidate_buffers'
+LANGUAGE C VOLATILE STRICT NO SQL;

--- a/src/test/heap_checksum/output/setup.source
+++ b/src/test/heap_checksum/output/setup.source
@@ -1,0 +1,2 @@
+CREATE OR REPLACE FUNCTION invalidate_buffers(Oid, Oid, Oid) RETURNS BOOL AS '@abs_builddir@/heap_checksum_helper@DLSUFFIX@', 'invalidate_buffers'
+LANGUAGE C VOLATILE STRICT NO SQL;

--- a/src/test/heap_checksum/sql/heap_checksum_corruption.sql
+++ b/src/test/heap_checksum/sql/heap_checksum_corruption.sql
@@ -1,0 +1,154 @@
+-- The following test simulates corruption of a heap relation file and
+-- verifies the select behavior on this corrupted table, the related indexes
+-- and toast tables.
+
+-- Mask out the expected and actual values of the checksums when comparing the
+-- result. All we care about is that they don't match.
+--
+-- start_matchsubs
+-- m/^ERROR:.*invalid page in block.*/
+-- s/invalid page in block.*/invalid page in block/
+-- m/^ERROR:  missing chunk number.*/
+-- s/missing chunk number.*/missing chunk number/
+-- end_matchsubs
+
+-- Ignore the status messages from the helper function. They're useful for
+-- debugging, but the output is different on every invocation.
+-- start_matchignore
+-- m/^INFO:  corrupting file/
+-- m/^INFO:  skipping non-existent file/
+-- m/^WARNING:  page verification failed, calculated checksum.*/
+-- end_matchignore
+
+-- start_ignore
+CREATE LANGUAGE plpythonu;
+-- end_ignore
+
+-- Create our test tables (and functions) in a bespoken schema that we can drop
+-- at the end. We don't want to leave any corrupt files lying around!
+CREATE SCHEMA corrupt_heap_checksum;
+set search_path='corrupt_heap_checksum';
+
+-- to ignore the CONTEXT from messages from the plpython helpers, and to ignore
+-- DETAILs from the checksum errors.
+\set VERBOSITY terse
+
+-- Return path to the file holding data for the given table (relative to
+-- $PGDATA).
+--
+CREATE FUNCTION get_relation_path(tbl regclass) returns text as $$
+  (select 'base/' || db.oid || '/' || c.relfilenode from pg_class c, pg_database db where c.oid = $1 AND db.datname = current_database())
+$$ language sql VOLATILE;
+
+-- Return path to the file holding data for the given table's TOAST table (relative to
+-- $PGDATA).
+--
+CREATE FUNCTION get_toast_path(tbl regclass) returns text as $$
+  (select 'base/' || db.oid || '/' || c.relfilenode from pg_class c, pg_database db where c.oid = ( SELECT reltoastrelid FROM pg_class  WHERE oid = $1) AND db.datname = current_database())
+$$ language sql VOLATILE;
+
+-- Return name of the given table's TOAST table (relative to
+-- $PGDATA).
+--
+CREATE FUNCTION get_toast_name(tbl regclass) returns text as $$
+  (select relname::text from pg_class where oid = ( SELECT reltoastrelid FROM pg_class  WHERE oid = $1))
+$$ language sql VOLATILE;
+
+-- Return path to the file holding data for the given table's index (relative to
+-- $PGDATA).
+--
+CREATE FUNCTION get_index_path(tbl regclass) returns text as $$
+  (select 'base/' || db.oid || '/' || c.relfilenode from pg_class c, pg_database db where c.oid = ( SELECT indexrelid FROM pg_index  WHERE indrelid = $1) AND db.datname = current_database())
+$$ language sql VOLATILE;
+
+-- Corrupt data file at given path (if it exists on this segment)
+--
+-- If corruption_offset is negative, it's an offset from the end of file.
+-- Otherwise it's from the beginning of file.
+--
+-- Returns 0. (That's handy in the way this function is called, because we can
+-- do a SUM() over the return values, and it's always 0, regardless of the
+-- number of segments in the cluster.)
+CREATE FUNCTION corrupt_file(data_file text, corruption_offset int4)
+RETURNS integer as $$
+  import os;
+
+  if not os.path.isfile(data_file):
+    plpy.info('skipping non-existent file %s' % (data_file))
+  else:
+    plpy.info('corrupting file %s at %s' % (data_file, corruption_offset))
+
+    with open(data_file , "rb+") as f:
+      char_location=0
+      write_char='*'  # CONST.CORRUPTION
+
+      if corruption_offset >= 0:
+        f.seek(corruption_offset, 0)
+      else:
+        f.seek(corruption_offset, 2)
+
+      f.write(write_char)
+      f.close()
+
+  return 0
+$$ LANGUAGE plpythonu;
+
+CREATE OR REPLACE FUNCTION invalidate_buffers_for_rel(tablename text) RETURNS BOOL AS
+$$
+DECLARE
+tablespace Oid;
+database Oid;
+relfile Oid;
+result bool;
+BEGIN
+    SELECT dattablespace, oid INTO tablespace, database FROM pg_database WHERE datname = current_database();
+    SELECT relfilenode INTO relfile FROM pg_class WHERE relname = tablename;
+    SELECT public.invalidate_buffers(tablespace, database, relfile) INTO result;
+    RETURN result;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Make sure that checksum is enabled
+SHOW data_checksums;
+
+--  Corrupt a heap table
+create table corrupt_table(a int);
+insert into corrupt_table select i from generate_series(1, 10) i;
+checkpoint;
+select invalidate_buffers_for_rel('corrupt_table') from gp_dist_random('gp_id');
+-- Verify corruption on heap table
+select SUM(corrupt_file(get_relation_path('corrupt_table'), -50)) from gp_dist_random('gp_id');
+SELECT COUNT(*) FROM corrupt_table;
+
+-- Corrupt a heap table, with toast table 
+create table corrupt_toast_table(a int, comment bytea);
+insert into corrupt_toast_table select i, ("decode"(repeat('a',3000000),'escape')) from generate_series(1,10) i;
+checkpoint;
+select invalidate_buffers_for_rel(get_toast_name('corrupt_toast_table')) from gp_dist_random('gp_id');
+-- Verify corruption on toast table
+select SUM(corrupt_file(get_toast_path('corrupt_toast_table'), -50)) from gp_dist_random('gp_id');
+SELECT md5(comment::text) FROM corrupt_toast_table;
+
+-- Corrupt a Btree Index
+create table corrupt_btree_index(a int, b char(50)); 
+create index btree_index on corrupt_btree_index(a);
+insert into corrupt_btree_index select i, 'a' from generate_series(1, 10) i;
+checkpoint;
+select invalidate_buffers_for_rel('btree_index') from gp_dist_random('gp_id');
+-- Verify corruption on Btree index
+select SUM(corrupt_file(get_index_path('corrupt_btree_index'), -50)) from gp_dist_random('gp_id');
+insert into corrupt_btree_index select i, 'a' from generate_series(1, 10) i; -- insert will trigger scan of the index
+
+-- Corrupt a Bitmap Index 
+create table corrupt_bitmap_index(a int, b char(50)); 
+create index bitmap_index on corrupt_bitmap_index(a);
+insert into corrupt_bitmap_index select i, 'a' from generate_series(1, 10) i;
+checkpoint;
+select invalidate_buffers_for_rel('bitmap_index') from gp_dist_random('gp_id');
+-- Verify corruption on Bitmap index 
+select SUM(corrupt_file(get_index_path('corrupt_bitmap_index'), -50)) from gp_dist_random('gp_id');
+insert into corrupt_bitmap_index select i, 'a' from generate_series(1, 10) i; -- insert will trigger scan of the index
+
+-- Clean up. We don't want to leave the corrupt tables lying around!
+reset search_path;
+DROP SCHEMA corrupt_heap_checksum CASCADE;


### PR DESCRIPTION
[A previous commit added the GUC `data_checksums`](https://github.com/greenplum-db/gpdb/commit/bc2d9891ccdf28d4711f9555b837aeaaa43ae274).

We build on that by porting additional commits from upstream which verify checksums on file read from disk. We then add bug fixes, GPDB specific changes, and testing. The ported commits are (most recent first)

```
cf8dc9e10c0d954970cbe5ca9be4c6b881cde482 Fix checksums for CLUSTER, VACUUM FULL etc.
4912385b56afe68ef76e47d38df1d61ada0fde2f Suppress uninitialized-variable warning in new checksum code.
9df56f6d91c3d67b23925b8f8b70365636995b71 Add new README file for pages/checksums
96ef3b8ff1cf1950e897fd2f766d4bd9ef0d5d56 Allow I/O reliability checks using 16-bit checksums
bb7cc2623f242ffafae404f8ebbb331b9a7f2b68 Remove PageSetTLI and rename pd_tli to pd_checksum
```

We also provide initial support for the cluster configuration settings in `gpinitsystem` with option `HEAP_CHECKSUM`.