### PR TITLE
Intersect partitions that are selected by multiple partition selectors

### DIFF
--- a/src/backend/executor/nodeDynamicIndexscan.c
+++ b/src/backend/executor/nodeDynamicIndexscan.c
@@ -145,6 +145,9 @@ initNextIndexToScan(DynamicIndexScanState *node)
 	EState *estate = indexState->ss.ps.state;
 	DynamicIndexScan *dynamicIndexScan = (DynamicIndexScan *) indexState->ss.ps.plan;
 	DynamicTableScanInfo *partitionInfo = estate->dynamicTableScanInfo;
+
+	/* 1-based index */
+	Assert(partitionInfo->numScans >= dynamicIndexScan->scan.partIndex);
 	int32 numSelectors = list_nth_int(partitionInfo->numSelectorsPerScanId, dynamicIndexScan->scan.partIndex);
 
 	/* Load new index when the scanning of the previous index is done. */

--- a/src/backend/executor/nodeDynamicIndexscan.c
+++ b/src/backend/executor/nodeDynamicIndexscan.c
@@ -142,17 +142,15 @@ static bool
 initNextIndexToScan(DynamicIndexScanState *node)
 {
 	IndexScanState *indexState = &(node->indexScanState);
-	DynamicIndexScan *dynamicIndexScan = (DynamicIndexScan *) node->indexScanState.ss.ps.plan;
 	EState *estate = indexState->ss.ps.state;
-	DynamicTableScanInfo *partitionInfo = indexState->ss.ps.state->dynamicTableScanInfo;
-
+	DynamicIndexScan *dynamicIndexScan = (DynamicIndexScan *) indexState->ss.ps.plan;
+	DynamicTableScanInfo *partitionInfo = estate->dynamicTableScanInfo;
 	int32 numSelectors = list_nth_int(partitionInfo->numSelectorsPerScanId, dynamicIndexScan->scan.partIndex);
 
 	/* Load new index when the scanning of the previous index is done. */
 	if (indexState->ss.scan_state == SCAN_INIT ||
 		indexState->ss.scan_state == SCAN_DONE)
 	{
-		/* This is the oid of a partition of the table (*not* index) */
 		PartOidEntry *partOidEntry;
 		while ((partOidEntry = hash_seq_search(&node->pidxStatus)) != NULL)
 		{
@@ -160,6 +158,7 @@ initNextIndexToScan(DynamicIndexScanState *node)
 				break;
 		}
 
+		/* This is the oid of a partition of the table (*not* index) */
 		Oid *pid = (Oid *) partOidEntry;
 		if (pid == NULL)
 		{
@@ -184,7 +183,6 @@ initNextIndexToScan(DynamicIndexScanState *node)
 		 * We started at table level, and now we are fetching the oid of an index
 		 * partition.
 		 */
-
 		Relation currentRelation = OpenScanRelationByOid(*pid);
 		indexState->ss.ss_currentRelation = currentRelation;
 

--- a/src/backend/executor/nodeDynamicTableScan.c
+++ b/src/backend/executor/nodeDynamicTableScan.c
@@ -80,6 +80,9 @@ initNextTableToScan(DynamicTableScanState *node)
 	ScanState *scanState = (ScanState *)node;
 	Scan *scan = (Scan *)scanState->ps.plan;
 	DynamicTableScanInfo *partitionInfo = scanState->ps.state->dynamicTableScanInfo;
+
+	/* 1-based index */
+	Assert(partitionInfo->numScans >= scan->partIndex);
 	int32 numSelectors = list_nth_int(partitionInfo->numSelectorsPerScanId, scan->partIndex);
 
 	if (scanState->scan_state == SCAN_INIT ||

--- a/src/test/regress/expected/partition_pruning.out
+++ b/src/test/regress/expected/partition_pruning.out
@@ -3037,4 +3037,44 @@ select get_selected_parts('explain analyze select * from bar where j is distinct
  [0, 0]
 (1 row)
 
+-- Two partition selectors selecting for one dynamic table scan
+DROP TABLE IF EXISTS partition_table;
+NOTICE:  table "partition_table" does not exist, skipping
+CREATE TABLE partition_table (dk int, pk int) DISTRIBUTED BY (dk) PARTITION BY range(pk) (START (0) END (6) EVERY (2));
+NOTICE:  CREATE TABLE will create partition "partition_table_1_prt_1" for table "partition_table"
+NOTICE:  CREATE TABLE will create partition "partition_table_1_prt_2" for table "partition_table"
+NOTICE:  CREATE TABLE will create partition "partition_table_1_prt_3" for table "partition_table"
+INSERT INTO partition_table SELECT j, i FROM generate_series(0, 31) AS t(j) CROSS JOIN generate_series(0, 5) AS i;
+ANALYZE partition_table;
+DROP TABLE IF EXISTS bar;
+DROP TABLE IF EXISTS jazz;
+NOTICE:  table "jazz" does not exist, skipping
+CREATE TABLE bar (c, d) AS SELECT j, i FROM generate_series(0, 3) AS j CROSS JOIN (VALUES (0), (2), (8)) AS t(i) DISTRIBUTED BY (c);
+CREATE TABLE jazz (e, f) AS SELECT j, i FROM generate_series(0, 3) AS j CROSS JOIN (VALUES (0), (4), (8)) AS t(i) DISTRIBUTED BY (e);
+ANALYZE bar;
+ANALYZE jazz;
+SELECT * FROM partition_table JOIN bar ON dk = c AND pk = d JOIN jazz on dk = e AND pk = f;
+ dk | pk | c | d | e | f 
+----+----+---+---+---+---
+  1 |  0 | 1 | 0 | 1 | 0
+  0 |  0 | 0 | 0 | 0 | 0
+  2 |  0 | 2 | 0 | 2 | 0
+  3 |  0 | 3 | 0 | 3 | 0
+(4 rows)
+
+-- Two partition selectors selecting for one dynamic index scan
+SET optimizer_enable_dynamictablescan = off;
+CREATE INDEX pt_idx_pk on partition_table (pk);
+NOTICE:  building index for child partition "partition_table_1_prt_1"
+NOTICE:  building index for child partition "partition_table_1_prt_2"
+NOTICE:  building index for child partition "partition_table_1_prt_3"
+SELECT * FROM partition_table JOIN bar ON dk = c AND pk = d AND pk < 9 JOIN jazz on dk = e AND pk = f;
+ dk | pk | c | d | e | f 
+----+----+---+---+---+---
+  3 |  0 | 3 | 0 | 3 | 0
+  1 |  0 | 1 | 0 | 1 | 0
+  2 |  0 | 2 | 0 | 2 | 0
+  0 |  0 | 0 | 0 | 0 | 0
+(4 rows)
+
 RESET ALL;

--- a/src/test/regress/expected/partition_pruning.out
+++ b/src/test/regress/expected/partition_pruning.out
@@ -3038,8 +3038,6 @@ select get_selected_parts('explain analyze select * from bar where j is distinct
 (1 row)
 
 -- Two partition selectors selecting for one dynamic table scan
-DROP TABLE IF EXISTS partition_table;
-NOTICE:  table "partition_table" does not exist, skipping
 CREATE TABLE partition_table (dk int, pk int) DISTRIBUTED BY (dk) PARTITION BY range(pk) (START (0) END (6) EVERY (2));
 NOTICE:  CREATE TABLE will create partition "partition_table_1_prt_1" for table "partition_table"
 NOTICE:  CREATE TABLE will create partition "partition_table_1_prt_2" for table "partition_table"
@@ -3053,28 +3051,21 @@ CREATE TABLE bar (c, d) AS SELECT j, i FROM generate_series(0, 3) AS j CROSS JOI
 CREATE TABLE jazz (e, f) AS SELECT j, i FROM generate_series(0, 3) AS j CROSS JOIN (VALUES (0), (4), (8)) AS t(i) DISTRIBUTED BY (e);
 ANALYZE bar;
 ANALYZE jazz;
-SELECT * FROM partition_table JOIN bar ON dk = c AND pk = d JOIN jazz on dk = e AND pk = f;
- dk | pk | c | d | e | f 
-----+----+---+---+---+---
-  1 |  0 | 1 | 0 | 1 | 0
-  0 |  0 | 0 | 0 | 0 | 0
-  2 |  0 | 2 | 0 | 2 | 0
-  3 |  0 | 3 | 0 | 3 | 0
-(4 rows)
-
--- Two partition selectors selecting for one dynamic index scan
-SET optimizer_enable_dynamictablescan = off;
-CREATE INDEX pt_idx_pk on partition_table (pk);
-NOTICE:  building index for child partition "partition_table_1_prt_1"
-NOTICE:  building index for child partition "partition_table_1_prt_2"
-NOTICE:  building index for child partition "partition_table_1_prt_3"
-SELECT * FROM partition_table JOIN bar ON dk = c AND pk = d AND pk < 9 JOIN jazz on dk = e AND pk = f;
- dk | pk | c | d | e | f 
-----+----+---+---+---+---
-  3 |  0 | 3 | 0 | 3 | 0
-  1 |  0 | 1 | 0 | 1 | 0
-  2 |  0 | 2 | 0 | 2 | 0
-  0 |  0 | 0 | 0 | 0 | 0
+CREATE OR REPLACE FUNCTION check_partition_selection (pk int) RETURNS INT AS $$
+BEGIN
+	IF pk NOT IN (0, 1) THEN
+		raise exception 'pk: %', pk;
+	END IF;
+	return pk;
+END;
+$$ STABLE LANGUAGE plpgsql;
+SELECT dk, pk, debug, c, d, e, f FROM (SELECT *, check_partition_selection(pk) as debug FROM partition_table) AS pt JOIN bar ON dk = c AND pk = d JOIN jazz on dk = e AND pk = f;
+ dk | pk | debug | c | d | e | f 
+----+----+-------+---+---+---+---
+  3 |  0 |     0 | 3 | 0 | 3 | 0
+  2 |  0 |     0 | 2 | 0 | 2 | 0
+  0 |  0 |     0 | 0 | 0 | 0 | 0
+  1 |  0 |     0 | 1 | 0 | 1 | 0
 (4 rows)
 
 RESET ALL;

--- a/src/test/regress/expected/partition_pruning_optimizer.out
+++ b/src/test/regress/expected/partition_pruning_optimizer.out
@@ -2636,8 +2636,6 @@ select get_selected_parts('explain analyze select * from bar where j is distinct
 (1 row)
 
 -- Two partition selectors selecting for one dynamic table scan
-DROP TABLE IF EXISTS partition_table;
-NOTICE:  table "partition_table" does not exist, skipping
 CREATE TABLE partition_table (dk int, pk int) DISTRIBUTED BY (dk) PARTITION BY range(pk) (START (0) END (6) EVERY (2));
 NOTICE:  CREATE TABLE will create partition "partition_table_1_prt_1" for table "partition_table"
 NOTICE:  CREATE TABLE will create partition "partition_table_1_prt_2" for table "partition_table"
@@ -2651,28 +2649,21 @@ CREATE TABLE bar (c, d) AS SELECT j, i FROM generate_series(0, 3) AS j CROSS JOI
 CREATE TABLE jazz (e, f) AS SELECT j, i FROM generate_series(0, 3) AS j CROSS JOIN (VALUES (0), (4), (8)) AS t(i) DISTRIBUTED BY (e);
 ANALYZE bar;
 ANALYZE jazz;
-SELECT * FROM partition_table JOIN bar ON dk = c AND pk = d JOIN jazz on dk = e AND pk = f;
- dk | pk | c | d | e | f 
-----+----+---+---+---+---
-  1 |  0 | 1 | 0 | 1 | 0
-  0 |  0 | 0 | 0 | 0 | 0
-  2 |  0 | 2 | 0 | 2 | 0
-  3 |  0 | 3 | 0 | 3 | 0
-(4 rows)
-
--- Two partition selectors selecting for one dynamic index scan
-SET optimizer_enable_dynamictablescan = off;
-CREATE INDEX pt_idx_pk on partition_table (pk);
-NOTICE:  building index for child partition "partition_table_1_prt_1"
-NOTICE:  building index for child partition "partition_table_1_prt_2"
-NOTICE:  building index for child partition "partition_table_1_prt_3"
-SELECT * FROM partition_table JOIN bar ON dk = c AND pk = d AND pk < 9 JOIN jazz on dk = e AND pk = f;
- dk | pk | c | d | e | f 
-----+----+---+---+---+---
-  3 |  0 | 3 | 0 | 3 | 0
-  1 |  0 | 1 | 0 | 1 | 0
-  2 |  0 | 2 | 0 | 2 | 0
-  0 |  0 | 0 | 0 | 0 | 0
+CREATE OR REPLACE FUNCTION check_partition_selection (pk int) RETURNS INT AS $$
+BEGIN
+	IF pk NOT IN (0, 1) THEN
+		raise exception 'pk: %', pk;
+	END IF;
+	return pk;
+END;
+$$ STABLE LANGUAGE plpgsql;
+SELECT dk, pk, debug, c, d, e, f FROM (SELECT *, check_partition_selection(pk) as debug FROM partition_table) AS pt JOIN bar ON dk = c AND pk = d JOIN jazz on dk = e AND pk = f;
+ dk | pk | debug | c | d | e | f 
+----+----+-------+---+---+---+---
+  3 |  0 |     0 | 3 | 0 | 3 | 0
+  2 |  0 |     0 | 2 | 0 | 2 | 0
+  0 |  0 |     0 | 0 | 0 | 0 | 0
+  1 |  0 |     0 | 1 | 0 | 1 | 0
 (4 rows)
 
 RESET ALL;

--- a/src/test/regress/expected/partition_pruning_optimizer.out
+++ b/src/test/regress/expected/partition_pruning_optimizer.out
@@ -2635,4 +2635,44 @@ select get_selected_parts('explain analyze select * from bar where j is distinct
  [8, 8]
 (1 row)
 
+-- Two partition selectors selecting for one dynamic table scan
+DROP TABLE IF EXISTS partition_table;
+NOTICE:  table "partition_table" does not exist, skipping
+CREATE TABLE partition_table (dk int, pk int) DISTRIBUTED BY (dk) PARTITION BY range(pk) (START (0) END (6) EVERY (2));
+NOTICE:  CREATE TABLE will create partition "partition_table_1_prt_1" for table "partition_table"
+NOTICE:  CREATE TABLE will create partition "partition_table_1_prt_2" for table "partition_table"
+NOTICE:  CREATE TABLE will create partition "partition_table_1_prt_3" for table "partition_table"
+INSERT INTO partition_table SELECT j, i FROM generate_series(0, 31) AS t(j) CROSS JOIN generate_series(0, 5) AS i;
+ANALYZE partition_table;
+DROP TABLE IF EXISTS bar;
+DROP TABLE IF EXISTS jazz;
+NOTICE:  table "jazz" does not exist, skipping
+CREATE TABLE bar (c, d) AS SELECT j, i FROM generate_series(0, 3) AS j CROSS JOIN (VALUES (0), (2), (8)) AS t(i) DISTRIBUTED BY (c);
+CREATE TABLE jazz (e, f) AS SELECT j, i FROM generate_series(0, 3) AS j CROSS JOIN (VALUES (0), (4), (8)) AS t(i) DISTRIBUTED BY (e);
+ANALYZE bar;
+ANALYZE jazz;
+SELECT * FROM partition_table JOIN bar ON dk = c AND pk = d JOIN jazz on dk = e AND pk = f;
+ dk | pk | c | d | e | f 
+----+----+---+---+---+---
+  1 |  0 | 1 | 0 | 1 | 0
+  0 |  0 | 0 | 0 | 0 | 0
+  2 |  0 | 2 | 0 | 2 | 0
+  3 |  0 | 3 | 0 | 3 | 0
+(4 rows)
+
+-- Two partition selectors selecting for one dynamic index scan
+SET optimizer_enable_dynamictablescan = off;
+CREATE INDEX pt_idx_pk on partition_table (pk);
+NOTICE:  building index for child partition "partition_table_1_prt_1"
+NOTICE:  building index for child partition "partition_table_1_prt_2"
+NOTICE:  building index for child partition "partition_table_1_prt_3"
+SELECT * FROM partition_table JOIN bar ON dk = c AND pk = d AND pk < 9 JOIN jazz on dk = e AND pk = f;
+ dk | pk | c | d | e | f 
+----+----+---+---+---+---
+  3 |  0 | 3 | 0 | 3 | 0
+  1 |  0 | 1 | 0 | 1 | 0
+  2 |  0 | 2 | 0 | 2 | 0
+  0 |  0 | 0 | 0 | 0 | 0
+(4 rows)
+
 RESET ALL;

--- a/src/test/regress/sql/partition_pruning.sql
+++ b/src/test/regress/sql/partition_pruning.sql
@@ -848,6 +848,7 @@ ANALYZE jazz;
 SELECT * FROM partition_table JOIN bar ON dk = c AND pk = d JOIN jazz on dk = e AND pk = f;
 
 -- Two partition selectors selecting for one dynamic index scan
+SET optimizer_enable_dynamictablescan = off;
 CREATE INDEX pt_idx_pk on partition_table (pk);
 SELECT * FROM partition_table JOIN bar ON dk = c AND pk = d AND pk < 9 JOIN jazz on dk = e AND pk = f;
 

--- a/src/test/regress/sql/partition_pruning.sql
+++ b/src/test/regress/sql/partition_pruning.sql
@@ -833,7 +833,6 @@ select get_selected_parts('explain analyze select * from bar where j is distinct
 select get_selected_parts('explain analyze select * from bar where j is distinct from NULL;');
 
 -- Two partition selectors selecting for one dynamic table scan
-DROP TABLE IF EXISTS partition_table;
 CREATE TABLE partition_table (dk int, pk int) DISTRIBUTED BY (dk) PARTITION BY range(pk) (START (0) END (6) EVERY (2));
 INSERT INTO partition_table SELECT j, i FROM generate_series(0, 31) AS t(j) CROSS JOIN generate_series(0, 5) AS i;
 ANALYZE partition_table;

--- a/src/test/regress/sql/partition_pruning.sql
+++ b/src/test/regress/sql/partition_pruning.sql
@@ -832,4 +832,23 @@ select get_selected_parts('explain analyze select * from bar where j is distinct
 -- 8 parts: NULL is shared with others on p1. So, all 8 parts.
 select get_selected_parts('explain analyze select * from bar where j is distinct from NULL;');
 
+-- Two partition selectors selecting for one dynamic table scan
+DROP TABLE IF EXISTS partition_table;
+CREATE TABLE partition_table (dk int, pk int) DISTRIBUTED BY (dk) PARTITION BY range(pk) (START (0) END (6) EVERY (2));
+INSERT INTO partition_table SELECT j, i FROM generate_series(0, 31) AS t(j) CROSS JOIN generate_series(0, 5) AS i;
+ANALYZE partition_table;
+
+DROP TABLE IF EXISTS bar;
+DROP TABLE IF EXISTS jazz;
+CREATE TABLE bar (c, d) AS SELECT j, i FROM generate_series(0, 3) AS j CROSS JOIN (VALUES (0), (2), (8)) AS t(i) DISTRIBUTED BY (c);
+CREATE TABLE jazz (e, f) AS SELECT j, i FROM generate_series(0, 3) AS j CROSS JOIN (VALUES (0), (4), (8)) AS t(i) DISTRIBUTED BY (e);
+ANALYZE bar;
+ANALYZE jazz;
+
+SELECT * FROM partition_table JOIN bar ON dk = c AND pk = d JOIN jazz on dk = e AND pk = f;
+
+-- Two partition selectors selecting for one dynamic index scan
+CREATE INDEX pt_idx_pk on partition_table (pk);
+SELECT * FROM partition_table JOIN bar ON dk = c AND pk = d AND pk < 9 JOIN jazz on dk = e AND pk = f;
+
 RESET ALL;


### PR DESCRIPTION
For dynamic scan (Orca only) that scans partitions selected by multiple partition selectors, executor always the union set of the partitions. e.g. partition selector 1 selects partitions {A, B, C} for dynamic scan DS, but partition selector 2 selects partitions {C, D, E} for dynamic scan DS, the DS always scan partitions {A, B, C, D, E}. In fact, we just need to scan partition C, all the other partitions can be pruned.

In this patch, we fixed this issue by making dynamic scan only scan the intersection of partitions selected by multiple partition selectors.

Reported by: @d Jesse Zhang
Signed-off-by: Melanie Plageman