### PR TITLE
Strengthen gprecoverseg behave test with smarter timeout

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -2660,7 +2660,7 @@ def impl(context):
 
     kill_process(int(pid), seg_host)
 
-    time.sleep(10)
+    has_process_eventually_stopped(pid, seg_host)
 
     pid = get_pid_for_segment(seg_data_dir, seg_host)
     if pid is not None:
@@ -4570,16 +4570,10 @@ def impl(context):
 @then('wait until the process "{proc}" goes down')
 @given('wait until the process "{proc}" goes down')
 def impl(context, proc):
-    start_time = current_time = datetime.now()
-    is_running = False
-    while (current_time - start_time).seconds < 120:
-        is_running = is_process_running(proc)
-        if not is_running:
-            break
-        time.sleep(2)
-        current_time = datetime.now()
-    context.ret_code = 0 if not is_running else 1
-    context.error_message = ''
+    is_stopped = has_process_eventually_stopped(proc)
+    context.ret_code = 0 if is_stopped else 1
+    if not is_stopped:
+        context.error_message = 'The process %s is still running after waiting' % proc
     check_return_code(context, 0)
 
 

--- a/gpMgmt/test/behave_utils/utils.py
+++ b/gpMgmt/test/behave_utils/utils.py
@@ -12,6 +12,7 @@ import difflib
 
 import yaml
 
+from datetime import datetime
 from gppylib.commands.base import Command, ExecutionError, REMOTE
 from gppylib.commands.gp import chk_local_db_running
 from gppylib.db import dbconn
@@ -1294,6 +1295,17 @@ def kill_process(pid, host=None, sig=signal.SIGTERM):
     else:
         os.kill(pid, sig)
 
+def has_process_eventually_stopped(proc, host=None):
+    start_time = current_time = datetime.now()
+    is_running = False
+    while (current_time - start_time).seconds < 120:
+        is_running = is_process_running(proc, host)
+        if not is_running:
+            break
+        time.sleep(2)
+        current_time = datetime.now()
+    return not is_running
+
 
 def get_num_segments(primary=True, mirror=True, master=True, standby=True):
     gparray = GpArray.initFromCatalog(dbconn.DbURL())
@@ -1645,8 +1657,15 @@ def populate_regular_table_data(context, tabletype, table_name, compression_type
                          rowcount=rowcount, with_data=with_data, host=host, port=port, user=user)
 
 
-def is_process_running(proc_name):
-    cmd = Command(name='pgrep for %s' % proc_name, cmdStr="pgrep %s" % proc_name)
+def is_process_running(proc_name, host=None):
+    if host is not None:
+        cmd = Command(name='pgrep for %s' % proc_name,
+                      cmdStr="pgrep %s" % proc_name,
+                      ctxt=REMOTE,
+                      remoteHost=host)
+    else:
+        cmd = Command(name='pgrep for %s' % proc_name,
+                      cmdStr="pgrep %s" % proc_name)
     cmd.run()
     if cmd.get_return_code() > 1:
         raise Exception("unexpected problem with pgrep, return code: %s" % cmd.get_return_code())


### PR DESCRIPTION
Refactor similar usage to share code with gpperfmon behave tests

Confirmed the gprecoverseg test works locally

Had trouble confirming the gpperfmon test locally. We were seeing gpmmon crash and restart every ~8 seconds, and ~~got the following core dump~~ sorry coredump not available:

Can anyone help with local testing of this?

We will look to show a forked pipeline for these two specific test jobs in concourse.

Signed-off-by: Xin Zhang <xzhang@pivotal.io>