### PR TITLE
Log interconnect ports info on DEBUG1 level

### DIFF
--- a/src/backend/cdb/motion/ic_common.c
+++ b/src/backend/cdb/motion/ic_common.c
@@ -240,7 +240,7 @@ InitMotionLayerIPC(void)
 
 	Gp_listener_port = (udp_listener<<16) | tcp_listener;
 
-	elog(LOG, "Interconnect listening on tcp port %d udp port %d (0x%x)", tcp_listener, udp_listener, Gp_listener_port);
+	elog(DEBUG1, "Interconnect listening on tcp port %d udp port %d (0x%x)", tcp_listener, udp_listener, Gp_listener_port);
 }
 
 /* See ml_ipc.h */


### PR DESCRIPTION
This is a mistake introduced by 353a937da9e9 and it
flood the pg_log at a noticeable rate, change it back
to DEBUG1.