### PR TITLE
gprecoverseg: Add debug sleep before destroying terraform cluster

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -1219,7 +1219,7 @@ jobs:
     params:
       BEHAVE_FLAGS: --tags=gprecoverseg
     on_failure:
-      <<: *ccp_destroy
+      <<: *debug_sleep
   - *ccp_destroy
 
 - name: MM_gpexpand


### PR DESCRIPTION
We would like to have the VMs up if there's a failure.