### PR TITLE
Remove gpperfmon test from pr pipeline

### DIFF
--- a/concourse/pipelines/pr_pipeline.yml
+++ b/concourse/pipelines/pr_pipeline.yml
@@ -111,18 +111,6 @@ jobs:
         timeout: 10m
         on_failure: *pr_failure
 
-      - task: gpperfmon
-        file: gpdb_pr/concourse/tasks/behave_gpdb.yml
-        image: centos-gpdb-dev-6
-        input_mapping:
-          gpdb_src: gpdb_pr
-          bin_gpdb: gpdb_artifacts
-        params:
-          BEHAVE_TAGS: gpperfmon
-          BLDWRAP_POSTGRES_CONF_ADDONS: ""
-        timeout: 20m
-        on_failure: *pr_failure
-
     - task: separate_qautils_files_for_rc
       file: gpdb_pr/concourse/tasks/separate_qautils_files_for_rc.yml
       image: centos-gpdb-dev-6


### PR DESCRIPTION
We suspect that the gpperfmon test to be flakey.
This is not acceptable in a PR pipeline.
gpperfmon tests needs more work to be stable.