### PR TITLE
STDIN and STDOUT should be rejected by 'COPY ON SEGMENT'

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -1167,6 +1167,11 @@ DoCopyInternal(const CopyStmt *stmt, const char *queryString, CopyState cstate)
 				(errcode(ERRCODE_SYNTAX_ERROR),
 				 errmsg("cannot specify DELIMITER in BINARY mode")));
 
+	if (cstate->on_segment && stmt->filename==NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_SYNTAX_ERROR),
+				 errmsg("STDIN and STDOUT are not supported by 'COPY ON SEGMENT'")));
+
 	/*
 	 * In PostgreSQL, HEADER is not allowed in text mode either, but in GPDB,
 	 * only forbid it with BINARY.

--- a/src/test/regress/expected/gpcopy.out
+++ b/src/test/regress/expected/gpcopy.out
@@ -703,6 +703,19 @@ SELECT * FROM segment_reject_limit_from;
  1 | 2
 (2 rows)
 
+-- STDIN is not support by copy from on segment
+COPY segment_reject_limit_from from STDIN on segment log errors segment reject limit 3 rows;
+ERROR:  STDIN and STDOUT are not supported by 'COPY ON SEGMENT'
+SELECT * FROM segment_reject_limit_from;
+ a | b
+---+---
+ 1 | 1
+ 1 | 2
+(2 rows)
+
+-- STDOUT is not support by copy to on segment
+COPY segment_reject_limit_from to STDOUT on segment log errors segment reject limit 3 rows;
+ERROR:  STDIN and STDOUT are not supported by 'COPY ON SEGMENT'
 -- gp_initial_bad_row_limit guc test. This guc allows user to set the initial
 -- number of rows which can contain errors before the database stops loading
 -- the data. If there is a valid row within the first 'n' rows specified by

--- a/src/test/regress/sql/gpcopy.sql
+++ b/src/test/regress/sql/gpcopy.sql
@@ -674,6 +674,13 @@ SELECT relname, filename, bytenum, errmsg FROM gp_read_error_log('segment_reject
 COPY segment_reject_limit_from from '/tmp/segment_reject_limit<SEGID>.csv' on segment log errors segment reject limit 3 rows;
 SELECT * FROM segment_reject_limit_from;
 
+-- STDIN is not support by copy from on segment
+COPY segment_reject_limit_from from STDIN on segment log errors segment reject limit 3 rows;
+SELECT * FROM segment_reject_limit_from;
+
+-- STDOUT is not support by copy to on segment
+COPY segment_reject_limit_from to STDOUT on segment log errors segment reject limit 3 rows;
+
 -- gp_initial_bad_row_limit guc test. This guc allows user to set the initial
 -- number of rows which can contain errors before the database stops loading
 -- the data. If there is a valid row within the first 'n' rows specified by


### PR DESCRIPTION
If 'COPY ON SEGMENT', STDIN / STDOUT refers to segments' own STDIN /
STDOUT, which are not available for data stream.

Signed-off-by: Xiaoran Wang <xiwang@pivotal.io>