### PR TITLE
Change python2.7 artifact path to python-gpdb5.

### DIFF
--- a/gpAux/releng/make/dependencies/ivy.xml
+++ b/gpAux/releng/make/dependencies/ivy.xml
@@ -22,7 +22,7 @@
       <dependency org="Hyperic"         name="sigar"           rev="1.6.5"          conf="rhel6_x86_64->rhel6_x86_64;rhel7_x86_64->rhel7_x86_64;suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64" />
       <dependency org="NetBackup"       name="SDK-7.7"         rev="7.7"            conf="rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64" />
       <dependency org="R-Project"       name="R"               rev="3.1.0"          conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64;suse11_x86_64->suse10_x86_64;sles11_x86_64->suse10_x86_64" />
-      <dependency org="Python"          name="python"          rev="2.7.12"         conf="rhel6_x86_64->rhel6_x86_64;rhel7_x86_64->rhel6_x86_64;suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64" />
+      <dependency org="Python"          name="python-gpdb5"    rev="2.7.12"         conf="rhel6_x86_64->rhel6_x86_64;rhel7_x86_64->rhel6_x86_64;suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64" />
       <dependency org="cURL"            name="curl"            rev="7.54.0"         conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64;suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64" />
       <dependency org="Samba"           name="ccache"          rev="3.2.3"          conf="rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64;suse11_x86_64->suse11_x86_64;sles11_x86_64->suse11_x86_64" />
       <dependency org="OpenLDAP"        name="openldap"        rev="2.4.44"         conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64;suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64" />


### PR DESCRIPTION
The original python2.7 tarball is located at Python/python/2.7.12, now changed to Python/python-gpdb5/2.7.12 to be more clear and consistent with pipeline.
