### PR TITLE
Fix gpsegstop and gppkg unittests

### DIFF
--- a/gpMgmt/bin/gppylib/test/unit/test_cluster_gpsegstop.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_cluster_gpsegstop.py
@@ -38,7 +38,8 @@ class SegStopTestCase(unittest.TestCase):
     @patch('gppylib.commands.gp.SegmentIsShutDown.is_shutdown', return_value=True)
     @patch('gpsegstop.unix.kill_9_segment_processes')
     @patch('gpsegstop.pg.ReadPostmasterTempFile.getResults', return_value=(True, 1234, '/tmp/gpseg0'))
-    def test_run(self, mock1, mock2, mock3, mock4, mock5):
+    @patch('gpsegstop.unix.check_pid', return_value=False)
+    def test_run(self, mock1, mock2, mock3, mock4, mock5, mock6):
         self.segstop.db = '/tmp/gpseg0:1234'
         self.segstop.mode = 'smart'
         self.segstop.timeout = '10'
@@ -51,7 +52,8 @@ class SegStopTestCase(unittest.TestCase):
     @patch('gpsegstop.pg.ReadPostmasterTempFile.getResults', return_value=(True, 1234, '/tmp/gpseg0'))
     @patch('gpsegstop.unix.kill_sequence')
     @patch('gpsegstop.unix.kill_9_segment_processes')
-    def test_run_with_error(self, mock1, mock2, mock3, mock4, mock5):
+    @patch('gpsegstop.unix.check_pid', return_value=False)
+    def test_run_with_error(self, mock1, mock2, mock3, mock4, mock5, mock6):
         self.segstop.db = '/tmp/gpseg0:1234'
         self.segstop.mode = 'smart'
         self.segstop.timeout = '10'
@@ -65,7 +67,8 @@ class SegStopTestCase(unittest.TestCase):
     @patch('gpsegstop.pg.ReadPostmasterTempFile.getResults', return_value=(True, 1234, '/tmp/gpseg0'))
     @patch('gpsegstop.unix.kill_sequence')
     @patch('gpsegstop.unix.kill_9_segment_processes')
-    def test_run_with_pg_controldata_error(self, mock1, mock2, mock3, mock4, mock5, mock6):
+    @patch('gpsegstop.unix.check_pid', return_value=False)
+    def test_run_with_pg_controldata_error(self, mock1, mock2, mock3, mock4, mock5, mock6, mock7):
         self.segstop.db = '/tmp/gpseg0:1234'
         self.segstop.mode = 'smart'
         self.segstop.timeout = '10'
@@ -78,7 +81,8 @@ class SegStopTestCase(unittest.TestCase):
     @patch('gppylib.commands.gp.SegmentIsShutDown.is_shutdown', return_value=False)
     @patch('gpsegstop.pg.ReadPostmasterTempFile.getResults', return_value=(True, 1234, '/tmp/gpseg0'))
     @patch('gpsegstop.unix.kill_9_segment_processes')
-    def test_run_with_pg_controldata_error_in_immediate_mode(self, mock1, mock2, mock3, mock4, mock5):
+    @patch('gpsegstop.unix.check_pid', return_value=False)
+    def test_run_with_pg_controldata_error_in_immediate_mode(self, mock1, mock2, mock3, mock4, mock5, mock6):
         self.segstop.db = '/tmp/gpseg0:1234'
         self.segstop.mode = 'immediate'
         self.segstop.timeout = '10'

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gppkg.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gppkg.py
@@ -8,7 +8,6 @@ import sys
 class GpPkgProgramTestCase(GpTestCase):
     def setUp(self):
         self.mock_cmd = Mock()
-        self.mock_list_files_by_pattern = Mock()
         self.mock_gppkg = Mock()
         self.mock_uninstall_package = Mock()
 
@@ -52,7 +51,7 @@ class GpPkgProgramTestCase(GpTestCase):
         self.subject = GpPkgProgram(options, args)
         self.subject.run()
 
-        self.mock_list_files_by_pattern.run.assert_called_once()
+        self.mock_listdir.assert_called_once()
         self.mock_uninstall_package.run.assert_called_once()
 
     def test__input_matches_multiple_packages(self):
@@ -73,8 +72,7 @@ class GpPkgProgramTestCase(GpTestCase):
                                                 "Multiple packages match remove request: \( sample.gppkg, sample2.gppkg \)."):
             self.subject.run()
 
-        self.mock_list_files_by_pattern.run.assert_called_once()
-        self.mock_uninstall_package.run.assert_called_once()
+        self.assertFalse(self.mock_uninstall_package.run.called)
 
     def test__input_exact_match_when_wildcard_would_have_more(self):
         sys.argv = ["gppkg", "--remove", "sample"]
@@ -93,5 +91,5 @@ class GpPkgProgramTestCase(GpTestCase):
 
         self.subject.run()
 
-        self.mock_list_files_by_pattern.run.assert_called_once()
+        self.mock_listdir.assert_called_once()
         self.mock_uninstall_package.run.assert_called_once()


### PR DESCRIPTION
gpsegstop:
It looks like this is passing in concourse, however, this test suite is
having issues running properly. One of the mocks is not returning the
proper behavior causing the test to fail.

gppkg unit-test:
This test was asserting on a higher level mock which wasn't being used.
This commit uses the correct mock and the tests are passing.


Signed-off-by: Nadeem Ghani <nghani@pivotal.io>