### PR TITLE
Fix memory leak while print missing column stats

### DIFF
--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -1205,7 +1205,6 @@ COptTasks::PrintMissingStatsWarning
 				}
 
 				pmdidRel->AddRef();
-				pmdidRel->AddRef();
 				phsmdidRel->FInsert(pmdidRel);
 				oss << pmdrel->Mdname().Pstr()->Wsz();
 			}


### PR DESCRIPTION
Relation metadata reference was added twice due to which
memory leak is detected and PQO fallsback to planner. This patch
removes redundant AddRef for Relation Metadata and fixes fallback.
Before fix:
```
create table t1 (a int, b int);
insert into t1 values (1,1);
insert into t1 values (1,1);
analyze t1(b);
explain select * from t1;
NOTICE:  One or more columns in the following table(s) do not have statistics: t1
HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For partitioned tables, run analyze rootpartition <table_name>(<column_list>). See log for columns missing statistics.
                                 QUERY PLAN
----------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.02 rows=2 width=8)
   ->  Seq Scan on t1  (cost=0.00..1.02 rows=1 width=8)
 Settings:  optimizer=on
 Optimizer status: legacy query optimizer
(4 rows)
```

After fix:
```
bhuvneshchaudhary=# explain select * from  t1;
NOTICE:  One or more columns in the following table(s) do not have statistics: t1
HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For partitioned tables, run analyze rootpartition <table_name>(<column_list>). See log for columns missing statistics.
                                  QUERY PLAN
------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=8)
   ->  Table Scan on t1  (cost=0.00..431.00 rows=1 width=8)
 Settings:  optimizer=on
 Optimizer status: PQO version 2.39.2
```
Signed-off-by: Ekta Khanna <ekhanna@pivotal.io>