### PR TITLE
greenplum_path.sh: Make pythonpath more flexible, if they already have a python path

### DIFF
--- a/gpMgmt/bin/generate-greenplum-path.sh
+++ b/gpMgmt/bin/generate-greenplum-path.sh
@@ -48,13 +48,12 @@ fi
 EOF
 
 #setup PYTHONPATH
-if [ "x${PYTHONPATH}" == "x" ]; then
+cat <<-EOF
+if [ "x\${PYTHONPATH}" == "x" ]; then
     PYTHONPATH="\$GPHOME/lib/python"
 else
-    PYTHONPATH="\$GPHOME/lib/python:${PYTHONPATH}"
+    PYTHONPATH="\$GPHOME/lib/python:\${PYTHONPATH}"
 fi
-cat <<EOF
-PYTHONPATH=${PYTHONPATH}
 EOF
 
 # Solaris needs amd64 in PATH for java to work


### PR DESCRIPTION
This gives a flexibility of sourcing a different product before GPDB.

Signed-off-by: Marbin Tan <mtan@pivotal.io>