### PR TITLE
Add a mock for MakeDir to support macOS platform

### DIFF
--- a/gpMgmt/bin/gppylib/test/unit/test_unit_package.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_package.py
@@ -63,6 +63,7 @@ class ListPackagesTestCase(GpTestCase):
         self.apply_patches([
             patch('gppylib.operations.package.logger', return_value=Mock(spec=['log', 'info', 'debug', 'error'])),
             patch('gppylib.operations.package.ListFilesByPattern.run'),
+            patch('gppylib.operations.package.MakeDir.run'),
         ])
         self.mock_logger = self.get_mock_from_apply_patch('logger')
 


### PR DESCRIPTION
We saw the following on macOS and this mock patch solves it:

`[Errno 13] Permission denied: '/usr/local/gpdb/share/package`

Signed-off-by: C.J. Jameson <cjameson@pivotal.io>