### PR TITLE
Install src/include/cdb server-side dev

### DIFF
--- a/src/Makefile.global.in
+++ b/src/Makefile.global.in
@@ -152,7 +152,6 @@ endif # PGXS
 
 includedir_server = $(pkgincludedir)/server
 includedir_internal = $(pkgincludedir)/internal
-includedir_internal_cdb = $(pkgincludedir)/internal/cdb
 pgxsdir = $(pkglibdir)/pgxs
 
 sqlmansect_dummy = l

--- a/src/backend/cdb/cdbexplain.c
+++ b/src/backend/cdb/cdbexplain.c
@@ -10,6 +10,8 @@
 #include "postgres.h"
 #include "portability/instr_time.h"
 
+#include "gp-libpq-fe.h"
+#include "gp-libpq-int.h"
 #include "cdb/cdbconn.h"		/* SegmentDatabaseDescriptor */
 #include "cdb/cdbdispatchresult.h"		/* CdbDispatchResults */
 #include "cdb/cdbexplain.h"		/* me */
@@ -19,8 +21,6 @@
 #include "executor/executor.h"	/* ExecStateTreeWalker */
 #include "executor/instrument.h"	/* Instrumentation */
 #include "lib/stringinfo.h"		/* StringInfo */
-#include "gp-libpq-fe.h"		/* PGresult; prereq for libpq-int.h */
-#include "gp-libpq-int.h"		/* pg_result */
 #include "libpq/pqformat.h"		/* pq_beginmessage() etc. */
 #include "utils/memutils.h"		/* MemoryContextGetPeakSpace() */
 #include "cdb/memquota.h"

--- a/src/backend/cdb/cdbpgdatabase.c
+++ b/src/backend/cdb/cdbpgdatabase.c
@@ -14,6 +14,8 @@
 #include "catalog/pg_type.h"
 #include "utils/builtins.h"
 #include "cdb/cdbutil.h"
+#include "gp-libpq-fe.h"
+#include "gp-libpq-int.h"
 #include "cdb/cdbfts.h"
 
 Datum		gp_pgdatabase__(PG_FUNCTION_ARGS);

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -28,9 +28,10 @@
 #include "cdb/cdbdtxcontextinfo.h"
 
 #include "cdb/cdbvars.h"
-#include "gp-libpq-fe.h"
 #include "access/transam.h"
 #include "access/xact.h"
+#include "gp-libpq-fe.h"
+#include "gp-libpq-int.h"
 #include "cdb/cdbfts.h"
 #include "lib/stringinfo.h"
 #include "access/twophase.h"

--- a/src/backend/cdb/cdbtmutils.c
+++ b/src/backend/cdb/cdbtmutils.c
@@ -28,9 +28,10 @@
 #include "cdb/cdbdtxcontextinfo.h"
 
 #include "cdb/cdbvars.h"
-#include "gp-libpq-fe.h"
 #include "access/transam.h"
 #include "access/xact.h"
+#include "gp-libpq-fe.h"
+#include "gp-libpq-int.h"
 #include "cdb/cdbfts.h"
 #include "lib/stringinfo.h"
 #include "access/twophase.h"

--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -39,6 +39,8 @@
 #include "cdb/cdbdisp_query.h"
 #include "cdb/ml_ipc.h"			/* listener_setup */
 #include "cdb/cdbtm.h"
+#include "gp-libpq-fe.h"
+#include "gp-libpq-int.h"
 #include "cdb/cdbfts.h"
 #include "libpq/ip.h"
 #include "catalog/indexing.h"

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -18,6 +18,8 @@
 #include "utils/guc.h"
 #include "catalog/gp_segment_config.h"
 #include "cdb/cdbvars.h"
+#include "gp-libpq-fe.h"
+#include "gp-libpq-int.h"
 #include "cdb/cdbfts.h"
 #include "cdb/cdbdisp.h"
 #include "cdb/cdbutil.h"

--- a/src/backend/cdb/dispatcher/cdbdisp.c
+++ b/src/backend/cdb/dispatcher/cdbdisp.c
@@ -19,6 +19,8 @@
 #include "cdb/cdbdisp_thread.h"
 #include "cdb/cdbdisp_async.h"
 #include "cdb/cdbdispatchresult.h"
+#include "gp-libpq-fe.h"
+#include "gp-libpq-int.h"
 #include "cdb/cdbfts.h"
 #include "cdb/cdbgang.h"
 #include "cdb/cdbsreh.h"

--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -25,6 +25,8 @@
 #include "cdb/cdbdisp.h"
 #include "cdb/cdbdisp_async.h"
 #include "cdb/cdbdispatchresult.h"
+#include "gp-libpq-fe.h"
+#include "gp-libpq-int.h"
 #include "cdb/cdbfts.h"
 #include "cdb/cdbgang.h"
 #include "cdb/cdbvars.h"

--- a/src/backend/cdb/dispatcher/cdbdisp_dtx.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_dtx.c
@@ -13,6 +13,8 @@
 #include "postgres.h"
 #include "utils/guc.h"
 #include "utils/memutils.h"
+#include "gp-libpq-fe.h"
+#include "gp-libpq-int.h"
 #include "cdb/cdbconn.h"
 #include "cdb/cdbdisp.h"
 #include "cdb/cdbdisp_dtx.h"
@@ -25,7 +27,6 @@
 #include "utils/palloc.h"
 
 #include "storage/procarray.h"	/* updateSharedLocalSnapshot */
-#include "gp-libpq-fe.h"
 
 /*
  * Parameter structure for DTX protocol commands

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -10,6 +10,8 @@
  */
 
 #include "postgres.h"
+#include "gp-libpq-fe.h"
+#include "gp-libpq-int.h"
 #include "cdb/cdbconn.h"
 #include "cdb/cdbgang.h"
 #include "cdb/cdbutil.h"

--- a/src/backend/cdb/dispatcher/cdbdisp_thread.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_thread.c
@@ -26,6 +26,8 @@
 #include "cdb/cdbdisp.h"
 #include "cdb/cdbdisp_thread.h"
 #include "cdb/cdbdispatchresult.h"
+#include "gp-libpq-fe.h"
+#include "gp-libpq-int.h"
 #include "cdb/cdbfts.h"
 #include "cdb/cdbgang.h"
 #include "cdb/cdbvars.h"

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -28,6 +28,8 @@
 #include "utils/sharedsnapshot.h"
 #include "tcop/pquery.h"
 
+#include "gp-libpq-fe.h"
+#include "gp-libpq-int.h"
 #include "cdb/cdbconn.h"		/* SegmentDatabaseDescriptor */
 #include "cdb/cdbfts.h"
 #include "cdb/cdbdisp_query.h"
@@ -38,8 +40,6 @@
 #include "cdb/cdbutil.h"		/* CdbComponentDatabaseInfo */
 #include "cdb/cdbvars.h"		/* Gp_role, etc. */
 #include "storage/bfz.h"
-#include "gp-libpq-fe.h"
-#include "gp-libpq-int.h"
 #include "libpq/libpq-be.h"
 #include "libpq/ip.h"
 

--- a/src/backend/cdb/dispatcher/cdbgang_async.c
+++ b/src/backend/cdb/dispatcher/cdbgang_async.c
@@ -21,6 +21,8 @@
 
 #include "storage/ipc.h"		/* For proc_exit_inprogress  */
 #include "tcop/tcopprot.h"
+#include "gp-libpq-fe.h"
+#include "gp-libpq-int.h"
 #include "cdb/cdbfts.h"
 #include "cdb/cdbgang.h"
 #include "cdb/cdbvars.h"

--- a/src/backend/cdb/dispatcher/cdbgang_thread.c
+++ b/src/backend/cdb/dispatcher/cdbgang_thread.c
@@ -15,6 +15,8 @@
 
 #include "storage/ipc.h"		/* For proc_exit_inprogress  */
 #include "tcop/tcopprot.h"
+#include "gp-libpq-fe.h"
+#include "gp-libpq-int.h"
 #include "cdb/cdbfts.h"
 #include "cdb/cdbgang.h"
 #include "cdb/cdbvars.h"

--- a/src/backend/cdb/dispatcher/test/cdbgang_test.c
+++ b/src/backend/cdb/dispatcher/test/cdbgang_test.c
@@ -1,6 +1,5 @@
 #include "postgres.h"
 #include "miscadmin.h"
-#include "cdb/cdbconn.h"
 #include "cdb/cdbvars.h"
 #include "libpq/libpq-be.h"
 #include "access/xact.h"
@@ -8,6 +7,8 @@
 #include "storage/proc.h"
 #include "cmockery.h"
 #include "gp-libpq-fe.h"
+#include "gp-libpq-int.h"
+#include "cdb/cdbconn.h"
 
 #include "../cdbgang.c"
 

--- a/src/backend/cdb/motion/cdbmotion.c
+++ b/src/backend/cdb/motion/cdbmotion.c
@@ -13,6 +13,8 @@
 
 #include "miscadmin.h"
 #include "access/htup.h"
+#include "gp-libpq-fe.h"
+#include "gp-libpq-int.h"
 #include "cdb/cdbconn.h"
 #include "nodes/execnodes.h" //SliceTable
 #include "cdb/cdbmotion.h"

--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -23,6 +23,8 @@
 #include "libpq/pqsignal.h"
 #include "miscadmin.h"
 #include "cdb/cdbvars.h"
+#include "gp-libpq-fe.h"
+#include "gp-libpq-int.h"
 #include "cdb/cdbfts.h"
 #include "postmaster/fork_process.h"
 #include "postmaster/postmaster.h"

--- a/src/backend/fts/ftsfilerep.c
+++ b/src/backend/fts/ftsfilerep.c
@@ -11,6 +11,8 @@
  */
 #include "postgres.h"
 
+#include "gp-libpq-fe.h"
+#include "gp-libpq-int.h"
 #include "cdb/cdbfts.h"
 #include "executor/spi.h"
 #include "postmaster/fts.h"

--- a/src/backend/storage/ipc/ipci.c
+++ b/src/backend/storage/ipc/ipci.c
@@ -60,6 +60,8 @@
 #include "utils/sharedsnapshot.h"
 #include "utils/simex.h"
 
+#include "gp-libpq-fe.h"
+#include "gp-libpq-int.h"
 #include "cdb/cdbfts.h"
 #include "cdb/cdbtm.h"
 #include "utils/tqual.h"

--- a/src/include/Makefile
+++ b/src/include/Makefile
@@ -17,8 +17,8 @@ all: pg_config.h pg_config_os.h check_oids
 
 
 # Subdirectories containing headers for server-side dev
-SUBDIRS = access bootstrap catalog codegen commands executor gpmon lib libpq mb \
-	nodes optimizer parser postmaster regex replication rewrite storage tcop \
+SUBDIRS = access bootstrap catalog cdb codegen commands executor gpmon lib libpq \
+	mb nodes optimizer parser postmaster regex replication rewrite storage tcop \
 	snowball snowball/libstemmer tsearch tsearch/dicts utils \
 	port port/atomics port/win32 port/win32_msvc port/win32_msvc/sys \
 	port/win32/arpa port/win32/netinet port/win32/sys \
@@ -48,14 +48,6 @@ install: all installdirs
 	  cp $(srcdir)/$$dir/*.h '$(DESTDIR)$(includedir_server)'/$$dir/ || exit; \
 	  chmod $(INSTALL_DATA_MODE) '$(DESTDIR)$(includedir_server)'/$$dir/*.h  || exit; \
 	done
-# These headers are needed for PGXS
-	$(INSTALL_DATA) $(srcdir)/cdb/cdbpublic.h   $(DESTDIR)$(includedir_internal_cdb)
-	$(INSTALL_DATA) $(srcdir)/cdb/cdbcat.h   $(DESTDIR)$(includedir_internal_cdb)
-	$(INSTALL_DATA) $(srcdir)/cdb/cdbpathlocus.h   $(DESTDIR)$(includedir_internal_cdb)
-	$(INSTALL_DATA) $(srcdir)/cdb/cdbdef.h   $(DESTDIR)$(includedir_internal_cdb)
-	$(INSTALL_DATA) $(srcdir)/cdb/cdbdistributedsnapshot.h   $(DESTDIR)$(includedir_internal_cdb)
-	$(INSTALL_DATA) $(srcdir)/cdb/cdblocaldistribxact.h   $(DESTDIR)$(includedir_internal_cdb)
-	$(INSTALL_DATA) $(srcdir)/cdb/cdbvars.h   $(DESTDIR)$(includedir_internal_cdb)
 ifeq ($(vpath_build),yes)
 	for file in dynloader.h parser/parse.h; do \
 	  cp $$file '$(DESTDIR)$(includedir_server)'/$$file || exit; \
@@ -64,8 +56,7 @@ ifeq ($(vpath_build),yes)
 endif
 
 installdirs:
-	$(MKDIR_P) '$(DESTDIR)$(includedir)/libpq' '$(DESTDIR)$(includedir_internal)/libpq' \
-	    '$(DESTDIR)$(includedir_internal_cdb)'
+	$(MKDIR_P) '$(DESTDIR)$(includedir)/libpq' '$(DESTDIR)$(includedir_internal)/libpq'
 	$(MKDIR_P) $(addprefix '$(DESTDIR)$(includedir_server)'/, $(SUBDIRS))
 
 

--- a/src/include/cdb/cdbconn.h
+++ b/src/include/cdb/cdbconn.h
@@ -11,9 +11,6 @@
 #ifndef CDBCONN_H
 #define CDBCONN_H
 
-#include "gp-libpq-fe.h"               /* prerequisite for libpq-int.h */
-#include "gp-libpq-int.h"              /* PQExpBufferData */
-
 
 /* --------------------------------------------------------------------------------------------------
  * Structure for segment database definition and working values

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -11,10 +11,11 @@
 #ifndef RES_GROUP_H
 #define RES_GROUP_H
 
+#include "cdb/memquota.h"
+
 /*
  * GUC variables.
  */
-typedef enum ResManagerMemoryPolicy ResManagerMemoryPolicy;
 extern ResManagerMemoryPolicy   gp_resgroup_memory_policy;
 extern char                		*gp_resgroup_memory_policy_str;
 extern bool						gp_log_resgroup_memory;

--- a/src/include/utils/resscheduler.h
+++ b/src/include/utils/resscheduler.h
@@ -20,11 +20,11 @@
 #include "nodes/plannodes.h"
 #include "storage/lock.h"
 #include "tcop/dest.h"
+#include "cdb/memquota.h"
 
 /*
  * GUC variables.
  */
-typedef enum ResManagerMemoryPolicy ResManagerMemoryPolicy;
 extern ResManagerMemoryPolicy   gp_resqueue_memory_policy;
 extern char                		*gp_resqueue_memory_policy_str;
 extern bool						gp_log_resqueue_memory;

--- a/src/test/regress/checkinc.py
+++ b/src/test/regress/checkinc.py
@@ -72,6 +72,7 @@ fileset = {
     'sys/times.h':           [],
     'sys/types.h':           [],
     'sys/un.h':              [],
+    'sys/poll.h':            [],
     'unix.h':                [],
     'windows.h':             [],
     'winsock.h':             [],


### PR DESCRIPTION
Formerly in resgroup.h and resscheduler.h, we re-defined some structures from memquota.h to
make checkinc.py pass, however some compilers complaint it as non C standard. To make both
compilers and checkinc.py pass, this commit include memquota.h directly and expose memquota.h
to public under gpdb installation directores.