### PR TITLE
gpinitsystem: supports heap_checksum setting via switches & Fix gpinitsystem -I

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -19,6 +19,7 @@ groups:
   - MM_gpcheck
   - DPM_backup-restore
   - MM_gppkg
+  - MM_gpinitsystem
   - MM_pt-rebuild
   - fts
   - storage
@@ -854,6 +855,25 @@ jobs:
     on_failure:
       <<: *debug_sleep
   - *ccp_destroy
+
+- name: MM_gpinitsystem
+  plan:
+  - aggregate:
+    - get: gpdb_src
+      params:
+        submodules:
+        - gpMgmt/bin/pythonSrc/ext
+      passed: [compile_gpdb_centos6]
+    - get: bin_gpdb
+      resource: bin_gpdb_centos6
+      passed: [compile_gpdb_centos6]
+      trigger: true
+    - get: centos-gpdb-dev-6
+  - task: gpinitsystem
+    file: gpdb_src/concourse/tasks/behave_gpdb.yml
+    image: centos-gpdb-dev-6
+    params:
+      BEHAVE_FLAGS: --tags=gpinitsystem
 
 - name: MM_pt-rebuild
   plan:

--- a/gpAux/gpdemo/demo_cluster.sh
+++ b/gpAux/gpdemo/demo_cluster.sh
@@ -242,7 +242,7 @@ cat >> $CLUSTER_CONFIG <<-EOF
 	CLUSTER_NAME="Demo $HOSTNAME Cluster"
 	
 	# This file must exist in the same directory that you execute gpinitsystem in
-	MACHINE_LIST_FILE=hostfile
+	MACHINE_LIST_FILE=`pwd`/hostfile
 	
 	# This names the data directories for the Segment Instances and the Entry Postmaster
 	SEG_PREFIX=$SEG_PREFIX
@@ -292,6 +292,10 @@ if [ "${WITH_MIRRORS}" == "true" ]; then
 	EOF
 fi
 
+if [ ! -z "${EXTRA_CONFIG}" ]; then
+  echo ${EXTRA_CONFIG} >> $CLUSTER_CONFIG
+fi
+
 cat >> $CLUSTER_CONFIG <<-EOF
 
 	# Path for Greenplum mgmt utils and Greenplum binaries
@@ -321,6 +325,11 @@ if [ -n "${STATEMENT_MEM}" ]; then
 	cat >> $CLUSTER_CONFIG_POSTGRES_ADDONS<<-EOF
 		statement_mem = ${STATEMENT_MEM}
 	EOF
+fi
+
+if [ "${ONLY_PREPARE_CLUSTER_ENV}" == "true" ]; then
+    echo "ONLY_PREPARE_CLUSTER_ENV set, generated clusterConf file: $CLUSTER_CONFIG, exiting"
+    exit 0
 fi
 
 ## ======================================================================

--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -349,12 +349,6 @@ CHK_PARAMS () {
 			fi
 		fi
 
-
-		# Deal with issue of mixed case segment names being created in all lower case on tails but mixed
-		# case in head system tables.
-		LWR_CASE_SEG_PREFIX=`$ECHO $SEG_PREFIX|$TR '[A-Z]' '[a-z]'`
-		SEG_PREFIX=$LWR_CASE_SEG_PREFIX
-
 		# MASTER_PORT
 		if [ x"" = x"$MASTER_PORT" ]; then
 			ERROR_EXIT "[FATAL]:-MASTER_PORT variable not set" 2

--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -1082,6 +1082,7 @@ DISPLAY_CONFIG () {
 		LOG_MSG "[INFO]:-Postgres param file        = $PG_ADD" 1
 		LOG_MSG "[INFO]:-Initdb to be used          = $INITDB" 1
 		LOG_MSG "[INFO]:-GP_LIBRARY_PATH is         = $GP_LIBRARY_PATH" 1
+		LOG_MSG "[INFO]:-HEAP_CHECKSUM is           = $HEAP_CHECKSUM" 1
 		if [ $ULIMIT_WARN -eq 1 ];then
 			LOG_MSG "[WARN]:-Ulimit check               = Warnings generated, see log file $WARN_MARK" 1
 		else
@@ -1676,6 +1677,10 @@ DUMP_OUTPUT_CONFIG () {
     fi
     
     $ECHO "SEG_PREFIX=$SEG_PREFIX" >> $OUTPUT_CONFIG
+
+    if [ x"" != x"$HEAP_CHECKSUM" ] ; then
+	$ECHO "HEAP_CHECKSUM=$HEAP_CHECKSUM" >> $OUTPUT_CONFIG
+    fi
 
     $ECHO "QD_PRIMARY_ARRAY=$QD_PRIMARY_ARRAY" >> $OUTPUT_CONFIG
     $ECHO "declare -a PRIMARY_ARRAY=(" >> $OUTPUT_CONFIG

--- a/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
@@ -1,0 +1,50 @@
+@gpinitsystem
+# This behave test will heavily rely on gpdemo being available
+Feature: gpinitsystem tests
+    @gpinitsystem_checksum_on
+    Scenario: gpinitsystem creates a cluster with data_checksums on
+        Given the database is initialized with checksum "on"
+        When the user runs "gpconfig -s data_checksums"
+        Then gpconfig should return a return code of 0
+        And gpconfig should print "Values on all segments are consistent" to stdout
+        And gpconfig should print "Master  value: on" to stdout
+        And gpconfig should print "Segment value: on" to stdout
+
+    @gpinitsystem_checksum_on
+    Scenario: gpinitsystem generates an output configuration file and then starts cluster with data_checksums on
+        Given the cluster config is generated with data_checksums "on"
+        When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -O /tmp/output_config_file"
+        And gpinitsystem should return a return code of 0
+        Then verify that file "output_config_file" exists under "/tmp"
+        And verify that the file "/tmp/output_config_file" contains "HEAP_CHECKSUM=on"
+        And the user runs "gpinitsystem -a -I /tmp/output_config_file -l /tmp/"
+        Then gpinitsystem should return a return code of 0
+        When the user runs "gpconfig -s data_checksums"
+        Then gpconfig should return a return code of 0
+        And gpconfig should print "Values on all segments are consistent" to stdout
+        And gpconfig should print "Master  value: on" to stdout
+        And gpconfig should print "Segment value: on" to stdout
+
+    @gpinitsystem_checksum_off
+    Scenario: gpinitsystem creates a cluster with data_checksums off
+        Given the database is initialized with checksum "off"
+        When the user runs "gpconfig -s data_checksums"
+        Then gpconfig should return a return code of 0
+        And gpconfig should print "Values on all segments are consistent" to stdout
+        And gpconfig should print "Master  value: off" to stdout
+        And gpconfig should print "Segment value: off" to stdout
+
+    @gpinitsystem_checksum_off
+    Scenario: gpinitsystem generates an output configuration file and then starts cluster with data_checksums off
+        Given the cluster config is generated with data_checksums "off"
+        When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -O /tmp/output_config_file"
+        And gpinitsystem should return a return code of 0
+        Then verify that file "output_config_file" exists under "/tmp"
+        And verify that the file "/tmp/output_config_file" contains "HEAP_CHECKSUM=off"
+        And the user runs "gpinitsystem -a -I /tmp/output_config_file -l /tmp/"
+        Then gpinitsystem should return a return code of 0
+        When the user runs "gpconfig -s data_checksums"
+        Then gpconfig should return a return code of 0
+        And gpconfig should print "Values on all segments are consistent" to stdout
+        And gpconfig should print "Master  value: off" to stdout
+        And gpconfig should print "Segment value: off" to stdout


### PR DESCRIPTION
gpinitsystem did not check for HEAP_CHECKSUM in the cluster configuration file when using the "-c" switch. This PR accepts the  HEAP_CHECKSUM setting, and additionally exports it to an output_configuration_file when specified with the -O switch.

Includes a behave test and a CI task for same.


==============================

We are hitting an issue where gpinitsystem sends a gpstop command that has the data directory in all lower case. This causes an issue in Linux, but is fine with macOS; linux platforms are case sensitive vs macOS is not.  

Remove the lower casing part of the code as it doesn't seem necessary. gpinitsystem -c command eventually overwrites the SEG_PREFIX variable in a different function to use the mixed case, while the gpinitsystem -I does not.

Fix: keep the mixed case segment names


