### PR TITLE
fixes the centos vagrant to build with orca

### DIFF
--- a/src/tools/vagrant/centos/Vagrantfile
+++ b/src/tools/vagrant/centos/Vagrantfile
@@ -25,6 +25,8 @@ Vagrant.configure(2) do |config|
     end
   end
 
+  config.vm.network "forwarded_port", guest: 15432, host: 5433
+
   config.vm.define("gpdb") do |gpdb|
     gpdb.vm.provision "shell", path: "vagrant-setup.sh"
     gpdb.vm.provision "shell", path: "vagrant-configure-os.sh"
@@ -35,6 +37,6 @@ Vagrant.configure(2) do |config|
   config.vm.define("gpdb_without_gporca") do |gpdb_without_gporca|
     gpdb_without_gporca.vm.provision "shell", path: "vagrant-setup.sh"
     gpdb_without_gporca.vm.provision "shell", path: "vagrant-configure-os.sh"
-    gpdb_without_gporca.vm.provision "shell", path: "vagrant-build-gpdb.sh", privileged: false
+    gpdb_without_gporca.vm.provision "shell", path: "vagrant-build-gpdb.sh", privileged: false, args: "--disable-orca"
   end
 end

--- a/src/tools/vagrant/centos/vagrant-build-gpdb.sh
+++ b/src/tools/vagrant/centos/vagrant-build-gpdb.sh
@@ -13,6 +13,9 @@ export CC="ccache cc"
 export CXX="ccache c++"
 export PATH=/usr/local/bin:$PATH
 
+# this is necessary so that configure can find the orca libraries
+export LD_LIBRARY_PATH=/usr/local/lib
+
 rm -rf /usr/local/gpdb
 pushd ~/gpdb
   ./configure --prefix=/usr/local/gpdb $@

--- a/src/tools/vagrant/centos/vagrant-setup.sh
+++ b/src/tools/vagrant/centos/vagrant-setup.sh
@@ -19,6 +19,7 @@ sudo yum -y install htop
 sudo yum -y install perl-Env
 sudo yum -y install ccache
 sudo yum -y install libffi-devel
+sudo yum -y install libxml2-devel
 wget https://bootstrap.pypa.io/get-pip.py
 sudo python get-pip.py
 sudo pip install psutil lockfile paramiko setuptools


### PR DESCRIPTION
to build without orca we have to specify --disable-orca
with orca it is necessary to add /usr/local/lib to LD_LIBRARY_PATH for configure to succeed
the OS also required libxml2-devel to compile GPDB