### PR TITLE
gpinitsystem: don't print usages if there's a -c and -i issue

### DIFF
--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -214,15 +214,11 @@ CHK_PARAMS () {
 		fi
 		# Make sure that script has been supplied a config file
 		if [ x"$CLUSTER_CONFIG" = x"" ] && [ x"$INPUT_CONFIG" = x"" ]; then
-			LOG_MSG "[FATAL]:-Please specify either -c or -I as an option." 1
-			USAGE
-			ERROR_EXIT "[FATAL]:-Greenplum configuration filename [-c] option or [-I] option not provided." 2
+			ERROR_EXIT "[FATAL]:-At least one of two options, [-c] or [-I], is required." 2
 		fi
 
 		if [ -n "$CLUSTER_CONFIG" ] && [ -n "$INPUT_CONFIG" ]; then
-			LOG_MSG "[FATAL]:-Option -c and -I cannot be both specified." 1
-			USAGE
-			ERROR_EXIT "[FATAL]:-Received both Greenplum configuration filename options [-c] and [-I]." 2
+			ERROR_EXIT "[FATAL]:-Options [-c] and [-I] cannot be used at the same time." 2
 		fi
 		
 		if [ x"" != x"$CLUSTER_CONFIG" ] ; then

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpinitsystem.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpinitsystem.py
@@ -12,12 +12,16 @@ class GpInitSystemTest(GpTestCase):
     def test_option_cluster_configfile_and_input_configfile_should_error(self):
         p = Popen([self.gpinitsystem_path, '-c', 'cluster_configfile', '-I', 'input_configfile'], stdout=PIPE)
         output = p.stdout.read()
-        self.assertIn("[FATAL]:-Option -c and -I cannot be both specified.", output)
+        self.assertIn("[FATAL]:-Options [-c] and [-I] cannot be used at the same time.", output)
+        self.assertNotIn("Creates a new Greenplum Database instance", output)
+        self.assertNotIn("Initializes a Greenplum Database system by using configuration", output)
 
     def test_option_without_neither_cluster_configfile_and_input_configfile_should_error(self):
         p = Popen([self.gpinitsystem_path], stdout=PIPE)
         output = p.stdout.read()
-        self.assertIn("[FATAL]:-Please specify either -c or -I as an option.", output)
+        self.assertIn("[FATAL]:-At least one of two options, [-c] or [-I], is required", output)
+        self.assertNotIn("Creates a new Greenplum Database instance", output)
+        self.assertNotIn("Initializes a Greenplum Database system by using configuration", output)
 
     def test_option_with_input_configfile_should_work(self):
         p = Popen([self.gpinitsystem_path, '-I', 'input_configfile'], stdout=PIPE)
@@ -28,6 +32,19 @@ class GpInitSystemTest(GpTestCase):
         p = Popen([self.gpinitsystem_path, '-c', 'cluster_configfile'], stdout=PIPE)
         output = p.stdout.read()
         self.assertIn("[INFO]:-Checking configuration parameters, please wait...", output)
+
+    def test_option_help_prints_docs_usage(self):
+        p = Popen([self.gpinitsystem_path, '--help'], stdout=PIPE)
+        output = p.stdout.read()
+        self.assertIn("Initializes a Greenplum Database system by using configuration", output)
+        self.assertNotIn("Creates a new Greenplum Database instance", output)
+
+    def test_invalid_option_prints_raw_usage(self):
+        p = Popen([self.gpinitsystem_path, '--unknown-option'], stdout=PIPE)
+        output = p.stdout.read()
+        self.assertIn("[ERROR]:-Unknown option --unknown-option", output)
+        self.assertIn("Creates a new Greenplum Database instance", output)
+        self.assertNotIn("Initializes a Greenplum Database system by using configuration", output)
 
 if __name__ == '__main__':
     run_tests()


### PR DESCRIPTION
It's easy to lose log information if we print the usage when we have an
error with the cluster config and input config option.
Make it more direct by just showing the error to the user.