### PR TITLE
\copy command doesn't support on segment option

### DIFF
--- a/src/bin/psql/copy.c
+++ b/src/bin/psql/copy.c
@@ -234,6 +234,48 @@ error:
 }
 
 
+/* \copy command doesn't support on segment option */
+static void
+trim(char *s)
+{
+	int s_len = strlen(s);
+	if (strlen(s) == 0)
+		return;
+	char *read = s + 1;
+	char *write = s;
+	for (int i = 0; i < s_len; i++)
+	{
+		if (*(read) == '\0')
+		{
+			*(++write) = '\0';
+			break;
+		}
+		if (!(isspace(*write) && isspace(*read)))
+		{
+			*(++write) = *(read);
+		}
+		read++;
+	}
+	return;
+}
+
+static bool
+is_on_segment(char * after_tofrom)
+{
+	bool on_segment = false;
+	if (!after_tofrom || strlen(after_tofrom) == 0)
+		return false;
+	char *s = pg_strdup(after_tofrom);
+	trim(s);
+	if (strcasestr(s, "ON SEGMENT"))
+	{
+		on_segment = true;
+	}
+	free(s);
+	return on_segment;
+}
+
+
 /*
  * Execute a \copy command (frontend copy). We have to open a file, then
  * submit a COPY query to the backend and either feed it data from the
@@ -255,6 +297,12 @@ do_copy(const char *args)
 	if (!options)
 		return false;
 
+	if (options->after_tofrom && is_on_segment(options->after_tofrom))
+	{
+		psql_error("\\COPY command doesn't support ON SEGMENT\n");
+		free_copy_options(options);
+		return false;
+	}
 	/* prepare to read or write the target file */
 	if (options->file)
 		canonicalize_path(options->file);

--- a/src/test/regress/expected/gpcopy.out
+++ b/src/test/regress/expected/gpcopy.out
@@ -716,6 +716,26 @@ SELECT * FROM segment_reject_limit_from;
 -- STDOUT is not support by copy to on segment
 COPY segment_reject_limit_from to STDOUT on segment log errors segment reject limit 3 rows;
 ERROR:  STDIN and STDOUT are not supported by 'COPY ON SEGMENT'
+-- \copy from doesn't support on segment
+--on segment lower case
+\COPY segment_reject_limit_from from '/tmp/segment_reject_limit<SEGID>.csv' on segment log errors segment reject limit 3 rows;
+\COPY command doesn't support ON SEGMENT
+--on segment with spaces
+\COPY segment_reject_limit_from from '/tmp/segment_reject_limit<SEGID>.csv' on   segment log errors segment reject limit 3 rows;
+\COPY command doesn't support ON SEGMENT
+--on segment are capital
+\COPY segment_reject_limit_from from '/tmp/segment_reject_limit<SEGID>.csv' ON SEGMENT log errors segment reject limit 3 rows;
+\COPY command doesn't support ON SEGMENT
+-- \copy to doesn't support on segment
+--on segment lower case
+\COPY segment_reject_limit_from to '/tmp/copy_on_segment<SEGID>.csv' on segment log errors segment reject limit 3 rows;
+\COPY command doesn't support ON SEGMENT
+--on segment with spaces
+\COPY segment_reject_limit_from to '/tmp/copy_on_segment<SEGID>.csv' on   segment log errors segment reject limit 3 rows;
+\COPY command doesn't support ON SEGMENT
+--on segment are capital
+\COPY segment_reject_limit_from to '/tmp/copy_on_segment<SEGID>.csv' ON SEGMENT log errors segment reject limit 3 rows;
+\COPY command doesn't support ON SEGMENT
 -- gp_initial_bad_row_limit guc test. This guc allows user to set the initial
 -- number of rows which can contain errors before the database stops loading
 -- the data. If there is a valid row within the first 'n' rows specified by

--- a/src/test/regress/sql/gpcopy.sql
+++ b/src/test/regress/sql/gpcopy.sql
@@ -681,6 +681,22 @@ SELECT * FROM segment_reject_limit_from;
 -- STDOUT is not support by copy to on segment
 COPY segment_reject_limit_from to STDOUT on segment log errors segment reject limit 3 rows;
 
+-- \copy from doesn't support on segment
+--on segment lower case
+\COPY segment_reject_limit_from from '/tmp/segment_reject_limit<SEGID>.csv' on segment log errors segment reject limit 3 rows;
+--on segment with spaces
+\COPY segment_reject_limit_from from '/tmp/segment_reject_limit<SEGID>.csv' on   segment log errors segment reject limit 3 rows;
+--on segment are capital
+\COPY segment_reject_limit_from from '/tmp/segment_reject_limit<SEGID>.csv' ON SEGMENT log errors segment reject limit 3 rows;
+
+-- \copy to doesn't support on segment
+--on segment lower case
+\COPY segment_reject_limit_from to '/tmp/copy_on_segment<SEGID>.csv' on segment log errors segment reject limit 3 rows;
+--on segment with spaces
+\COPY segment_reject_limit_from to '/tmp/copy_on_segment<SEGID>.csv' on   segment log errors segment reject limit 3 rows;
+--on segment are capital
+\COPY segment_reject_limit_from to '/tmp/copy_on_segment<SEGID>.csv' ON SEGMENT log errors segment reject limit 3 rows;
+
 -- gp_initial_bad_row_limit guc test. This guc allows user to set the initial
 -- number of rows which can contain errors before the database stops loading
 -- the data. If there is a valid row within the first 'n' rows specified by


### PR DESCRIPTION
\copy command reads the file from the client filesystem
but 'on segment'  reads file from the segment system
So \copy command and 'on segment' option are incompatible

Signed-off-by: Xiaoran Wang <xiwang@pivotal.io>