### PR TITLE
update gp_singleton_segindex for FLOW_SINGLETON

### DIFF
--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -944,6 +944,8 @@ apply_motion_mutator(Node *node, ApplyMotionState * context)
             if (flow->segindex >= 0 &&
                 context->sliceDepth == 0)
                 flow->segindex = -1;
+            else if (flow->segindex >= 0)
+                flow->segindex = gp_singleton_segindex;
 
             if (flow->numSortCols > 0)
             {


### PR DESCRIPTION
In commit 06f56fe803, we assigned a random segment to server as singleton
QE for load blance. An assertion failure "outputSegIdx[0] == gp_singleton_segindex"
occurs when plan contains initplans because apply_motion_mutator() did
not set segindex of FLOW_SINGLETON to gp_singleton_segindex. Although
segindex field did not affect the creation of singleton gang and also
did not affect QE sending data to the right upstream, we still need
making them consistent to silent the assertion and avoid potential issue.