### PR TITLE
Use latest available apr in travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,8 +57,8 @@ install:
 ## ----------------------------------------------------------------------
 
 env:
-  - APR=apr-1.5.2
-    APR_UTIL=apr-util-1.5.4
+  - APR=apr-1.6.2
+    APR_UTIL=apr-util-1.6.0
     APR_TAR=${APR}.tar.gz
     APR_UTIL_TAR=${APR_UTIL}.tar.gz
 


### PR DESCRIPTION
Error message on Travis was:

```
$ wget http://ftp.jaist.ac.jp/pub/apache/apr/${APR_TAR}
--2017-08-02 06:45:44--  http://ftp.jaist.ac.jp/pub/apache/apr/apr-1.5.2.tar.gz
Resolving ftp.jaist.ac.jp (ftp.jaist.ac.jp)... 150.65.7.130, 2001:df0:2ed:feed::feed
Connecting to ftp.jaist.ac.jp (ftp.jaist.ac.jp)|150.65.7.130|:80... connected.
HTTP request sent, awaiting response... 404 Not Found
2017-08-02 06:45:45 ERROR 404: Not Found.
The command "wget http://ftp.jaist.ac.jp/pub/apache/apr/${APR_TAR}" failed and exited with 8 during .
```