### PR TITLE
[#149699023] Fix for interrupt handling in ORCA

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -1893,9 +1893,10 @@ gpdb::SzMemoryContextStrdup
 // would with ereport(...) in the backend. This could be extended for other
 // fields, but this is all we need at the moment.
 void
-gpdb::RaiseGpdbErrorImpl
+gpdb::GpdbEreportImpl
 	(
 	int xerrcode,
+	int severitylevel,
 	const char *xerrmsg,
 	const char *xerrhint,
 	const char *filename,
@@ -1910,7 +1911,7 @@ gpdb::RaiseGpdbErrorImpl
 		// expanded version of ereport(). It will be caught by the
 		// GP_WRAP_END, and propagated up as a C++ exception, to be
 		// re-thrown as a Postgres error once we leave the C++ land.
-		if (errstart(ERROR, filename, lineno, funcname, TEXTDOMAIN))
+		if (errstart(severitylevel, filename, lineno, funcname, TEXTDOMAIN))
 			errfinish (errcode(xerrcode),
 					   errmsg("%s", xerrmsg),
 					   xerrhint ? errhint("%s", xerrhint) : 0);

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -547,7 +547,8 @@ CTranslatorDXLToPlStmt::MapLocationsFdist
 				 "There are more external files (URLs) than primary segments that can read them. Found %d URLs and %d primary segments.",
 				 ulLocations, ulParticipatingSegments);
 
-		RaiseGpdbError(ERRCODE_INVALID_TABLE_DEFINITION, // errcode
+		GpdbEreport(ERRCODE_INVALID_TABLE_DEFINITION, // errcode
+					   ERROR,
 					   msgbuf, // errmsg
 					   NULL);  // errhint
 	}
@@ -941,7 +942,8 @@ CTranslatorDXLToPlStmt::PlExternalScanUriList
 	if (extentry->iswritable)
 	{
 		// This should match the same error in createplan.c
-		RaiseGpdbError(ERRCODE_WRONG_OBJECT_TYPE, // errcode
+		GpdbEreport(ERRCODE_WRONG_OBJECT_TYPE, // errcode
+					   ERROR,
 					   "cannot read from a WRITABLE external table", // errmsg
 					   "Create the table as READABLE instead."); // errhint
 	}
@@ -971,7 +973,8 @@ CTranslatorDXLToPlStmt::PlExternalScanUriList
 		if (!gp_external_enable_exec)
 		{
 			// This should match the same error in createplan.c
-			RaiseGpdbError(ERRCODE_GP_FEATURE_NOT_CONFIGURED, // errcode
+			GpdbEreport(ERRCODE_GP_FEATURE_NOT_CONFIGURED, // errcode
+						   ERROR,
 						   "Using external tables with OS level commands (EXECUTE clause) is disabled", // errmsg
 						   "To enable set gp_external_enable_exec=on"); // errhint
 		}

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -837,7 +837,10 @@ CTranslatorQueryToDXL::PdxlnCTAS()
 	}
 	else
 	{
-		elog(NOTICE, "Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.");
+		GpdbEreport(ERRCODE_SUCCESSFUL_COMPLETION,
+					   NOTICE,
+					   "Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.",
+					   NULL);
 	}
 	
 	GPOS_ASSERT(IMDRelation::EreldistrMasterOnly != ereldistrpolicy);

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -2314,8 +2314,13 @@ CTranslatorRelcacheToDXL::PimdobjColStats
 		pdrgdatumMCVValues = NULL;
 		pdrgfMCVFrequencies = NULL;
 
-		elog(LOG, "The number of most common values and frequencies do not match on column %ls of table %ls.",
+		char msgbuf[NAMEDATALEN * 2 + 100];
+		snprintf(msgbuf, sizeof(msgbuf), "The number of most common values and frequencies do not match on column %ls of table %ls.",
 				pmdcol->Mdname().Pstr()->Wsz(), pmdrel->Mdname().Pstr()->Wsz());
+		GpdbEreport(ERRCODE_SUCCESSFUL_COMPLETION,
+					   LOG,
+					   msgbuf,
+					   NULL);
 	}
 
 	Form_pg_statistic fpsStats = (Form_pg_statistic) GETSTRUCT(heaptupleStats);

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -1210,18 +1210,27 @@ COptTasks::PrintMissingStatsWarning
 			}
 
 			CMDName mdname = pmdrel->Pmdcol(ulPos)->Mdname();
-			elog(LOG, "Missing statistics for column: %s.%s", SzFromWsz(pmdrel->Mdname().Pstr()->Wsz()), SzFromWsz(mdname.Pstr()->Wsz()));
+
+			char msgbuf[NAMEDATALEN * 2 + 100];
+			snprintf(msgbuf, sizeof(msgbuf), "Missing statistics for column: %s.%s", SzFromWsz(pmdrel->Mdname().Pstr()->Wsz()), SzFromWsz(mdname.Pstr()->Wsz()));
+			GpdbEreport(ERRCODE_SUCCESSFUL_COMPLETION,
+						   LOG,
+						   msgbuf,
+						   NULL);
 		}
 	}
 
 	if (0 < phsmdidRel->UlEntries())
 	{
-		ereport(NOTICE,
-				(errcode(ERRCODE_SUCCESSFUL_COMPLETION),
-				errmsg("One or more columns in the following table(s) do not have statistics: %s", SzFromWsz(str.Wsz())),
-				errhint("For non-partitioned tables, run analyze <table_name>(<column_list>)."
-					" For partitioned tables, run analyze rootpartition <table_name>(<column_list>)."
-					" See log for columns missing statistics.")));
+		int length = NAMEDATALEN * phsmdidRel->UlEntries() + 200;
+		char msgbuf[length];
+		snprintf(msgbuf, sizeof(msgbuf), "One or more columns in the following table(s) do not have statistics: %s", SzFromWsz(str.Wsz()));
+		GpdbEreport(ERRCODE_SUCCESSFUL_COMPLETION,
+					   NOTICE,
+					   msgbuf,
+					   "For non-partitioned tables, run analyze <table_name>(<column_list>)."
+					   " For partitioned tables, run analyze rootpartition <table_name>(<column_list>)."
+					   " See log for columns missing statistics.");
 	}
 
 }

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -418,10 +418,10 @@ namespace gpdb {
 	// create a duplicate of the given string in the given memory context
 	char *SzMemoryContextStrdup(MemoryContext context, const char *string);
 
-	// ereport() an error
-	void RaiseGpdbErrorImpl(int xerrcode, const char *xerrmsg, const char *xerrhint, const char *filename, int lineno, const char *funcname);
-#define RaiseGpdbError(xerrcode, xerrmsg, xerrhint) \
-	gpdb::RaiseGpdbErrorImpl(xerrcode, xerrmsg, xerrhint , __FILE__, __LINE__, PG_FUNCNAME_MACRO)
+	// similar to ereport for logging messages
+	void GpdbEreportImpl(int xerrcode, int severitylevel, const char *xerrmsg, const char *xerrhint, const char *filename, int lineno, const char *funcname);
+#define GpdbEreport(xerrcode, severitylevel, xerrmsg, xerrhint) \
+	gpdb::GpdbEreportImpl(xerrcode, severitylevel, xerrmsg, xerrhint , __FILE__, __LINE__, PG_FUNCNAME_MACRO)
 
 	// string representation of a node
 	char *SzNodeToString(void *obj);


### PR DESCRIPTION
In ORCA, we donot process interrupts during planning stage, however
if there are elog/ereport (which further calls errfinish) statements to
print additional messages we prematurely exit out the planning stage
without cleaning up the memory pools leading to inconsistent memory pool
state. This results in crashes for the subsequent queries.

This commit fixes the issue by disabling interrupts while
printing messages using elog/ereport in ORCA.

Signed-off-by: Ekta Khanna <ekhanna@pivotal.io>