### PR TITLE
Fix intermittent testcase as_alias

### DIFF
--- a/src/test/regress/expected/as_alias.out
+++ b/src/test/regress/expected/as_alias.out
@@ -556,13 +556,13 @@ SELECT count(*) One FROM TIMESTAMP_TBL_AS_TEST WHERE d1 = timestamp without time
 
 -- end_equiv
 -- start_equiv
-SELECT count(*) AS One FROM TIMESTAMP_TBL_AS_TEST WHERE d1 = timestamp(2) without time zone 'now';
+SELECT count(*) AS One FROM TIMESTAMP_TBL_AS_TEST WHERE d1 = timestamp(2) without time zone 'now' + '2 seconds';
  one 
 -----
    0
 (1 row)
 
-SELECT count(*) One FROM TIMESTAMP_TBL_AS_TEST WHERE d1 = timestamp(2) without time zone 'now';
+SELECT count(*) One FROM TIMESTAMP_TBL_AS_TEST WHERE d1 = timestamp(2) without time zone 'now' + '2 seconds';
  one 
 -----
    0

--- a/src/test/regress/sql/as_alias.sql
+++ b/src/test/regress/sql/as_alias.sql
@@ -203,8 +203,8 @@ SELECT count(*) One FROM TIMESTAMP_TBL_AS_TEST WHERE d1 = timestamp without time
 -- end_equiv
 
 -- start_equiv
-SELECT count(*) AS One FROM TIMESTAMP_TBL_AS_TEST WHERE d1 = timestamp(2) without time zone 'now';
-SELECT count(*) One FROM TIMESTAMP_TBL_AS_TEST WHERE d1 = timestamp(2) without time zone 'now';
+SELECT count(*) AS One FROM TIMESTAMP_TBL_AS_TEST WHERE d1 = timestamp(2) without time zone 'now' + '2 seconds';
+SELECT count(*) One FROM TIMESTAMP_TBL_AS_TEST WHERE d1 = timestamp(2) without time zone 'now' + '2 seconds';
 -- end_equiv
 
 DELETE FROM TIMESTAMP_TBL_AS_TEST;


### PR DESCRIPTION
This case assumed that 'now' in bellow queries will produce
different results.
-- insert into xxx values (timestamp(2) without time zone 'now');
-- select timestamp(2) without time zone 'now';
However, the results are undetermined and may be equal on powerful
agents, the test is all about as alias so it's ok to add 2 seconds
to the second 'now' to guarantee they are never equal.

https://gpdb.ci.pivotalci.info/teams/gpdb/pipelines/gpdb_master/jobs/icw_planner_ictcp_centos6/builds/41
