### PR TITLE
Replace special "QE details" protocol message with standard ParameterStatus msg.

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -183,7 +183,7 @@ bool		gp_enable_slow_cursor_testmode = false;
  * backends.  Assigned by initMotionLayerIPC() at process startup.  This port
  * is used for the duration of this process and should never change.
  */
-int			Gp_listener_port;
+uint32		Gp_listener_port;
 
 int			Gp_max_packet_size; /* max Interconnect packet size */
 

--- a/src/backend/cdb/dispatcher/cdbgang_async.c
+++ b/src/backend/cdb/dispatcher/cdbgang_async.c
@@ -158,7 +158,7 @@ create_gang_retry:
 				{
 					case PGRES_POLLING_OK:
 						cdbconn_doConnectComplete(segdbDesc);
-						if (segdbDesc->motionListener == -1 || segdbDesc->motionListener == 0)
+						if (segdbDesc->motionListener == 0)
 							ereport(ERROR, (errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
 									errmsg("failed to acquire resources on one or more segments"),
 									errdetail("Internal error: No motion listener port (%s)", segdbDesc->whoami)));

--- a/src/backend/gp_libpq_fe/fe-connect.c
+++ b/src/backend/gp_libpq_fe/fe-connect.c
@@ -2522,8 +2522,6 @@ freePGconn(PGconn *conn)
 
 	if (conn->gpqeid)			/* CDB */
 		free(conn->gpqeid);
-	if (conn->qe_version)		/* CDB */
-		free(conn->qe_version);
 
 	/* Note that conn->Pfdebug is not ours to close or free */
 	if (conn->last_query)
@@ -4401,16 +4399,6 @@ PQoptions(const PGconn *conn)
 	if (!conn)
 		return NULL;
 	return conn->pgoptions;
-}
-
-/* GPDB function to retrieve QE-backend details (motion listener) */
-int
-PQgetQEdetail(PGconn *conn)
-{
-	if (!conn || (PQstatus(conn) == CONNECTION_BAD))
-		return -1;
-
-	return conn->motion_listener;
 }
 
 ConnStatusType

--- a/src/backend/gp_libpq_fe/fe-protocol3.c
+++ b/src/backend/gp_libpq_fe/fe-protocol3.c
@@ -165,29 +165,6 @@ pqParseInput3(PGconn *conn)
 			if (pqGetErrorNotice3(conn, false))
 				return;
 		}
-		else if (id == 'w')
-		{
-			int version_len=0;
-
-			if (pqGetInt(&(conn->motion_listener), 4, conn))
-				return;
-
-			if (pqGetInt(&version_len, 4, conn))
-				return;
-
-			if (conn->qe_version != NULL && version_len > 0)
-			{
-				free(conn->qe_version);
-				conn->qe_version = NULL;
-			}
-			conn->qe_version = malloc(version_len);
-
-			if (conn->qe_version == NULL)
-				return;
-
-			if (pqGetnchar(conn->qe_version, version_len, conn))
-				return;
-		}
 		else if (id == 'k')
 		{
 			if (pqGetInt64(&(conn->mop_high_watermark), conn))

--- a/src/backend/gp_libpq_fe/gp-libpq-fe.h
+++ b/src/backend/gp_libpq_fe/gp-libpq-fe.h
@@ -319,7 +319,6 @@ extern char *PQhost(const PGconn *conn);
 extern char *PQport(const PGconn *conn);
 extern char *PQtty(const PGconn *conn);
 extern char *PQoptions(const PGconn *conn);
-extern int	PQgetQEdetail(PGconn *conn); /* GPDB -- retrieve QE-backend details. */
 extern ConnStatusType PQstatus(const PGconn *conn);
 extern PGTransactionStatusType PQtransactionStatus(const PGconn *conn);
 extern const char *PQparameterStatus(const PGconn *conn,

--- a/src/backend/gp_libpq_fe/gp-libpq-int.h
+++ b/src/backend/gp_libpq_fe/gp-libpq-int.h
@@ -370,9 +370,7 @@ struct pg_conn
 	int			be_pid;			/* PID of backend --- needed for cancels */
 	int			be_key;			/* key of backend --- needed for cancels */
 	
-	int			motion_listener; /* CDB tcp port for the interconnect listener. */
     int64      mop_high_watermark;   /* highwater mark for mop */
-	char		*qe_version;
 	
 	char		md5Salt[4];		/* password salt received from backend */
 	pgParameterStatus *pstatus; /* ParameterStatus data */

--- a/src/include/cdb/cdbconn.h
+++ b/src/include/cdb/cdbconn.h
@@ -57,7 +57,7 @@ typedef struct SegmentDatabaseDescriptor
      *
      * NB: Use malloc/free, not palloc/pfree, for the items below.
      */
-    int4		            motionListener; /* interconnect listener port */
+    uint32		            motionListener; /* interconnect listener port */
     int4					backendPid;
     char                   *whoami;         /* QE identifier for msgs */
     struct SegmentDatabaseDescriptor * myAgent;

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -1021,7 +1021,7 @@ extern int GpStandbyDbid;
 /* Stores the listener port that this process uses to listen for incoming
  * Interconnect connections from other Motion nodes.
  */
-extern int	Gp_listener_port;
+extern uint32 Gp_listener_port;
 
 
 


### PR DESCRIPTION
This gets rid of the GPDB-specific "QE details" message, that was only sent
once at QE backend startup, to notify the QD about the motion listener port
of the QE backend. Use a standard ParameterStatus message instead, pretending
that there is a GUC called "qe_listener_port". This reduces the difference
between the gp_libpq_fe copy of libpq, and libpq proper. I have a dream that
one day we will start using the standard libpq also for QD-QE communication,
and get rid of the special gp_libpq_fe copy altogether, and this is a small
step in that direction.

In the passing, change the type of Gp_listener_port variable from signed to
unsigned. Gp_listener_port actually holds two values: the TCP and UDP
listener ports, and there is bit-shifting code to store those two 16-bit
port numbers in the single 32-bit integer. But the bit-shifting was a bit
iffy, on a signed integer. Making it unsigned makes it more clear what's
happening.