### PR TITLE
Remove unnecessary use of PQExpBuffer.

### DIFF
--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -12,7 +12,6 @@
 
 #include "postgres.h"
 #include "gp-libpq-fe.h"
-#include "gp-libpq-int.h"
 #include "miscadmin.h"
 #include "cdb/cdbconn.h"
 #include "cdb/cdbcopy.h"

--- a/src/backend/cdb/dispatcher/cdbdisp.c
+++ b/src/backend/cdb/dispatcher/cdbdisp.c
@@ -386,7 +386,6 @@ cdbdisp_makeDispatcherState(CdbDispatcherState *ds,
 /*
  * Free memory in CdbDispatcherState
  *
- * Free the PQExpBufferData allocated in libpq.
  * Free dispatcher memory context.
  */
 void

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -314,17 +314,13 @@ isPrimaryWriterGangAlive(void)
 /*
  * Check the segment failure reason by comparing connection error message.
  */
-bool segment_failure_due_to_recovery(struct PQExpBufferData* error_message)
+bool
+segment_failure_due_to_recovery(const char *error_message)
 {
-	char *fatal = NULL, *message = NULL, *ptr = NULL;
+	char *fatal = NULL, *ptr = NULL;
 	int fatal_len = 0;
 
 	if (error_message == NULL)
-		return false;
-
-	message = error_message->data;
-
-	if (message == NULL)
 		return false;
 
 	fatal = _("FATAL");
@@ -338,14 +334,14 @@ bool segment_failure_due_to_recovery(struct PQExpBufferData* error_message)
 	 * the strings a lot we have to take extreme care with looking at
 	 * the string.
 	 */
-	ptr = strstr(message, fatal);
+	ptr = strstr(error_message, fatal);
 	if ((ptr != NULL) && ptr[fatal_len] == ':')
 	{
-		if (strstr(message, _(POSTMASTER_IN_STARTUP_MSG)))
+		if (strstr(error_message, _(POSTMASTER_IN_STARTUP_MSG)))
 		{
 			return true;
 		}
-		if (strstr(message, _(POSTMASTER_IN_RECOVERY_MSG)))
+		if (strstr(error_message, _(POSTMASTER_IN_RECOVERY_MSG)))
 		{
 			return true;
 		}

--- a/src/backend/cdb/dispatcher/cdbgang_async.c
+++ b/src/backend/cdb/dispatcher/cdbgang_async.c
@@ -179,7 +179,7 @@ create_gang_retry:
 						break;
 
 					case PGRES_POLLING_FAILED:
-						if (segment_failure_due_to_recovery(&segdbDesc->conn->errorMessage))
+						if (segment_failure_due_to_recovery(PQerrorMessage(segdbDesc->conn)))
 						{
 							in_recovery_mode_count++;
 							connStatusDone[i] = true;

--- a/src/backend/cdb/dispatcher/cdbgang_thread.c
+++ b/src/backend/cdb/dispatcher/cdbgang_thread.c
@@ -403,7 +403,7 @@ checkConnectionStatus(Gang* gp, int* countInRecovery, int* countSuccessful, stru
 			ereport(LOG, (errcode(segdbDesc->errcode), errmsg("%s",segdbDesc->error_message.data)));
 
 			/* this connect failed -- but why ? */
-			if (segment_failure_due_to_recovery(&segdbDesc->error_message))
+			if (segment_failure_due_to_recovery(segdbDesc->error_message.data))
 			{
 				elog(LOG, "segment is in recovery mode (%s)", segdbDesc->whoami);
 				(*countInRecovery)++;

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -55,7 +55,6 @@
 #include "utils/typcache.h"
 #include "utils/xml.h"
 #include "gp-libpq-fe.h"
-#include "pqexpbuffer.h"
 
 
 /* ----------

--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -92,7 +92,7 @@ bool isPrimaryWriterGangAlive(void);
 Gang *buildGangDefinition(GangType type, int gang_id, int size, int content);
 void build_gpqeid_param(char *buf, int bufsz, int segIndex, bool is_writer, int gangId, int hostSegs);
 char *makeOptions(void);
-bool segment_failure_due_to_recovery(struct PQExpBufferData *segdbDesc);
+extern bool segment_failure_due_to_recovery(const char *error_message);
 
 /*
  * disconnectAndDestroyIdleReaderGangs()


### PR DESCRIPTION
StringInfo is more appropriate in backend code. (Unless the buffer needs to
be used in a thread.)

In the passing, rename the 'conn' static variable in cdbfilerepconnclient.c.
It seemed overly generic.