### PR TITLE
Fix recent coverity issues and warnings.

### DIFF
--- a/contrib/gp_inject_fault/.gitignore
+++ b/contrib/gp_inject_fault/.gitignore
@@ -1,0 +1,1 @@
+gp_inject_fault.sql

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -10275,11 +10275,8 @@ copy_buffer_pool_data(Relation rel, SMgrRelation dst,
 		if (!PageIsVerified(page, blkno))
 			ereport(ERROR,
 					(errcode(ERRCODE_DATA_CORRUPTED),
-					 errmsg("invalid page in block %u of relation %s/%s/%s",
-							blkno,
-							src->smgr_rnode.spcNode,
-							src->smgr_rnode.dbNode,
-							src->smgr_rnode.relNode)));
+					 errmsg("invalid page in block %u of relation %s",
+							blkno, relpath(src->smgr_rnode))));
 
 		/* XLOG stuff */
 		if (useWal)

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -634,8 +634,7 @@ static struct config_bool ConfigureNamesBool[] =
 			GUC_NOT_IN_SAMPLE
 		},
 		&ignore_checksum_failure,
-		false,
-		NULL, NULL, NULL
+		false, NULL, NULL
 	},
 	{
 		{"zero_damaged_pages", PGC_SUSET, DEVELOPER_OPTIONS,

--- a/src/backend/utils/time/tqual.c
+++ b/src/backend/utils/time/tqual.c
@@ -138,11 +138,7 @@ markDirty(Buffer buffer, Relation relation, HeapTupleHeader tuple, bool isXmin)
 	 * The GUC gp_disable_tuple_hints is on.  Do further evaluation whether we want to write out the
 	 * buffer or not.
 	 */
-	if (relation == NULL)
-	{
-		MarkBufferDirtyHint(buffer, relation);
-		return;
-	}
+	Assert(relation != NULL);
 
 	if (relation->rd_issyscat)
 	{


### PR DESCRIPTION
CID 173910 Dereference after null check. In markDirty: Pointer is checked
against null but then dereferenced anyway. Removed the checking against and
added Assert instead as don't see why relation should be NULL in markDirty().

CID 173667 Printf arg type mismatch. A printf format string does not match the
types of one of the arguments. Fixed to make it only one %s and relpath() to get
the path.

Also, fixing the warning
```
guc.c:643:15: warning: incompatible pointer to integer conversion initializing 'bool' (aka 'char') with an expression of type 'void *' [-Wint-conversion]
                NULL, NULL, NULL
```