### PR TITLE
Fix orca_debug compiler error by removing unused headers

### DIFF
--- a/contrib/orca_debug/orca_debug.cpp
+++ b/contrib/orca_debug/orca_debug.cpp
@@ -17,9 +17,6 @@
 #include "gpos/io/CFileWriter.h"
 #include "gpopt/gpdbwrappers.h"
 
-#include "gpos/version.h"
-#include "gpopt/version.h"
-
 extern "C" {
 
 PG_MODULE_MAGIC_CPP;


### PR DESCRIPTION
The gpos version.h header is no longer installed, and the inclusion thus caused a compiler error. The gpopt header is still available, but the contents of which isn't actually used in orca_debug so remove that as well.