### PR TITLE
\COPY doesn't support ON\tSEGMENT

### DIFF
--- a/src/bin/psql/copy.c
+++ b/src/bin/psql/copy.c
@@ -245,16 +245,21 @@ trim(char *s)
 	char *read = s + 1;
 	char *write = s;
 	*write = toupper(*write);
-	for (int i = 0; i < s_len; i++)
+	if (*write == '\t')
 	{
-		if (*(read) == '\0')
+		*write = ' ';
+	}
+	for (int i = 1; i < s_len; i++)
+	{
+		if (*read == '\0')
 		{
 			*(++write) = '\0';
 			break;
 		}
+
 		if (!(isspace(*write) && isspace(*read)))
 		{
-			*(++write) = toupper(*read);
+			*(++write) = isspace(*read)?' ':toupper(*read);
 		}
 		read++;
 	}

--- a/src/test/regress/input/gpcopy.source
+++ b/src/test/regress/input/gpcopy.source
@@ -683,19 +683,23 @@ COPY segment_reject_limit_from to STDOUT on segment log errors segment reject li
 
 -- \copy from doesn't support on segment
 --on segment lower case
-\COPY segment_reject_limit_from from '/tmp/segment_reject_limit<SEGID>.csv' on segment log errors segment reject limit 3 rows;
+\COPY segment_reject_limit_from from '/tmp/segment_reject_limit<SEGID>.csv' on segment;
 --on segment with spaces
-\COPY segment_reject_limit_from from '/tmp/segment_reject_limit<SEGID>.csv' on   segment log errors segment reject limit 3 rows;
+\COPY segment_reject_limit_from from '/tmp/segment_reject_limit<SEGID>.csv' on   segment;
 --on segment are capital
-\COPY segment_reject_limit_from from '/tmp/segment_reject_limit<SEGID>.csv' ON SEGMENT log errors segment reject limit 3 rows;
+\COPY segment_reject_limit_from from '/tmp/segment_reject_limit<SEGID>.csv' ON SEGMENT;
+--on segment with \t
+\copy segment_reject_limit_from from '/tmp/segment_reject_limit<SEGID>.csv' on	segment;  
 
 -- \copy to doesn't support on segment
 --on segment lower case
-\COPY segment_reject_limit_from to '/tmp/copy_on_segment<SEGID>.csv' on segment log errors segment reject limit 3 rows;
+\COPY segment_reject_limit_from to '/tmp/copy_on_segment<SEGID>.csv' on segment;
 --on segment with spaces
-\COPY segment_reject_limit_from to '/tmp/copy_on_segment<SEGID>.csv' on   segment log errors segment reject limit 3 rows;
+\COPY segment_reject_limit_from to '/tmp/copy_on_segment<SEGID>.csv' on  segment;
 --on segment are capital
-\COPY segment_reject_limit_from to '/tmp/copy_on_segment<SEGID>.csv' ON SEGMENT log errors segment reject limit 3 rows;
+\COPY segment_reject_limit_from to '/tmp/copy_on_segment<SEGID>.csv' ON SEGMENT;
+--on segment with \t
+\copy segment_reject_limit_from from '/tmp/copy_on_segment<SEGID>.csv' on	segment;  
 
 -- gp_initial_bad_row_limit guc test. This guc allows user to set the initial
 -- number of rows which can contain errors before the database stops loading

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -718,23 +718,29 @@ COPY segment_reject_limit_from to STDOUT on segment log errors segment reject li
 ERROR:  STDIN and STDOUT are not supported by 'COPY ON SEGMENT'
 -- \copy from doesn't support on segment
 --on segment lower case
-\COPY segment_reject_limit_from from '/tmp/segment_reject_limit<SEGID>.csv' on segment log errors segment reject limit 3 rows;
+\COPY segment_reject_limit_from from '/tmp/segment_reject_limit<SEGID>.csv' on segment;
 \COPY command doesn't support ON SEGMENT
 --on segment with spaces
-\COPY segment_reject_limit_from from '/tmp/segment_reject_limit<SEGID>.csv' on   segment log errors segment reject limit 3 rows;
+\COPY segment_reject_limit_from from '/tmp/segment_reject_limit<SEGID>.csv' on   segment;
 \COPY command doesn't support ON SEGMENT
 --on segment are capital
-\COPY segment_reject_limit_from from '/tmp/segment_reject_limit<SEGID>.csv' ON SEGMENT log errors segment reject limit 3 rows;
+\COPY segment_reject_limit_from from '/tmp/segment_reject_limit<SEGID>.csv' ON SEGMENT;
+\COPY command doesn't support ON SEGMENT
+--on segment with \t
+\copy segment_reject_limit_from from '/tmp/segment_reject_limit<SEGID>.csv' on  segment;
 \COPY command doesn't support ON SEGMENT
 -- \copy to doesn't support on segment
 --on segment lower case
-\COPY segment_reject_limit_from to '/tmp/copy_on_segment<SEGID>.csv' on segment log errors segment reject limit 3 rows;
+\COPY segment_reject_limit_from to '/tmp/copy_on_segment<SEGID>.csv' on segment;
 \COPY command doesn't support ON SEGMENT
 --on segment with spaces
-\COPY segment_reject_limit_from to '/tmp/copy_on_segment<SEGID>.csv' on   segment log errors segment reject limit 3 rows;
+\COPY segment_reject_limit_from to '/tmp/copy_on_segment<SEGID>.csv' on   segment;
 \COPY command doesn't support ON SEGMENT
 --on segment are capital
-\COPY segment_reject_limit_from to '/tmp/copy_on_segment<SEGID>.csv' ON SEGMENT log errors segment reject limit 3 rows;
+\COPY segment_reject_limit_from to '/tmp/copy_on_segment<SEGID>.csv' ON SEGMENT;
+\COPY command doesn't support ON SEGMENT
+--on segment with \t
+\copy segment_reject_limit_from from '/tmp/copy_on_segment<SEGID>.csv' on       segment;
 \COPY command doesn't support ON SEGMENT
 -- gp_initial_bad_row_limit guc test. This guc allows user to set the initial
 -- number of rows which can contain errors before the database stops loading


### PR DESCRIPTION
When there is \t between 'ON' and 'SEGMENT' , client can give
right error message.

Signed-off-by: Xiaoran Wang <xiwang@pivotal.io>