### PR TITLE
gpconfig: fix unable to run ./gpconfig --help with source code

### DIFF
--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -53,6 +53,7 @@ def parseargs():
     parser.add_option('-M', '--mirrorvalue', type='string')
     parser.add_option('-f', '--file', action='store_true')
     parser.add_option('--file-compare', dest='file_compare', action='store_true')
+    parser.setHelp([])
 
     (options, _) = parser.parse_args()
 


### PR DESCRIPTION
When running gpconfig within the source code, you'll get the following:
$ ./gpMgmt/bin/gpconfig --help
      OptParser instance has no attribute 'helpStr'

fix this by initializing the help string list