### PR TITLE
Introduce LW locks to protect filespace and tablespace hash tables.

### DIFF
--- a/src/backend/cdb/cdbpersistentfilespace.c
+++ b/src/backend/cdb/cdbpersistentfilespace.c
@@ -126,6 +126,8 @@ PersistentFilespace_FindDirUnderLock(
 
 	FilespaceDirEntryKey key;
 
+	Assert(LWLockHeldByMe(FilespaceHashLock));
+
 	if (persistentFilespaceSharedHashTable == NULL)
 		elog(PANIC, "Persistent filespace information shared-memory not setup");
 
@@ -152,6 +154,8 @@ PersistentFilespace_CreateDirUnderLock(
 	FilespaceDirEntry	filespaceDirEntry;
 
 	FilespaceDirEntryKey key;
+
+	Assert(LWLockHeldByMe(FilespaceHashLock));
 
 	if (persistentFilespaceSharedHashTable == NULL)
 		elog(PANIC, "Persistent filespace information shared-memory not setup");
@@ -180,6 +184,8 @@ PersistentFilespace_RemoveDirUnderLock(
 	FilespaceDirEntry	filespaceDirEntry)
 {
 	FilespaceDirEntry	removeFilespaceDirEntry;
+
+	Assert(LWLockHeldByMe(FilespaceHashLock));
 
 	if (persistentFilespaceSharedHashTable == NULL)
 		elog(PANIC, "Persistent filespace information shared-memory not setup");

--- a/src/backend/cdb/cdbpersistentfilespace.c
+++ b/src/backend/cdb/cdbpersistentfilespace.c
@@ -90,7 +90,10 @@ typedef FilespaceDirEntryData *FilespaceDirEntry;
 	}
 
 #define WRITE_FILESPACE_HASH_UNLOCK \
-	LWLockRelease(FilespaceHashLock);
+	{ \
+		Assert(LWLockHeldByMe(PersistentObjLock)); \
+		LWLockRelease(FilespaceHashLock); \
+	}
 /*
  * Global Variables
  */

--- a/src/backend/cdb/cdbpersistentfilespace.c
+++ b/src/backend/cdb/cdbpersistentfilespace.c
@@ -83,11 +83,24 @@ typedef struct FilespaceDirEntryData
 } FilespaceDirEntryData;
 typedef FilespaceDirEntryData *FilespaceDirEntry;
 
+#define WRITE_FILESPACE_HASH_LOCK \
+	{ \
+		Assert(LWLockHeldByMe(PersistentObjLock)); \
+		LWLockAcquire(FilespaceHashLock, LW_EXCLUSIVE); \
+	}
 
+#define WRITE_FILESPACE_HASH_UNLOCK \
+	LWLockRelease(FilespaceHashLock);
 /*
  * Global Variables
  */
 PersistentFilespaceSharedData	*persistentFilespaceSharedData = NULL;
+/*
+ * Reads to the persistentFilespaceSharedHashTable are protected by
+ * FilespaceHashLock alone. To write to persistentFilespaceSharedHashTable,
+ * you must first acquire the PersistentObjLock, and then the
+ * FilespaceHashLock, both in exclusive mode.
+ */
 static HTAB *persistentFilespaceSharedHashTable = NULL;
 
 PersistentFilespaceData	persistentFilespaceData = PersistentFilespaceData_StaticInit;
@@ -226,9 +239,9 @@ static bool PersistentFilespace_ScanTupleCallback(
 									&parentXid,
 									&serialNum);
 
-	filespaceDirEntry =
-			PersistentFilespace_CreateDirUnderLock(
-											filespaceOid);
+	WRITE_FILESPACE_HASH_LOCK;
+
+	filespaceDirEntry =	PersistentFilespace_CreateDirUnderLock(filespaceOid);
 
 	filespaceDirEntry->dbId1 = dbId1;
 	memcpy(filespaceDirEntry->locationBlankPadded1, locationBlankPadded1, FilespaceLocationBlankPaddedWithNullTermLen);
@@ -239,6 +252,8 @@ static bool PersistentFilespace_ScanTupleCallback(
 	filespaceDirEntry->state = state;
 	filespaceDirEntry->persistentSerialNum = serialNum;
 	filespaceDirEntry->persistentTid = *persistentTid;
+
+	WRITE_FILESPACE_HASH_UNLOCK;
 
 	if (Debug_persistent_print)
 		elog(Persistent_DebugPrintLevel(),
@@ -265,71 +280,24 @@ extern void PersistentFilespace_LookupTidAndSerialNum(
 
 	int64			*persistentSerialNum)
 {
-	READ_PERSISTENT_STATE_ORDERED_LOCK_DECLARE;
-
 	FilespaceDirEntry filespaceDirEntry;
 
 	PersistentFilespace_VerifyInitScan();
-
-	READ_PERSISTENT_STATE_ORDERED_LOCK;
-
-	filespaceDirEntry =
-				PersistentFilespace_FindDirUnderLock(
-												filespaceOid);
+	LWLockAcquire(FilespaceHashLock, LW_SHARED);
+	filespaceDirEntry =	PersistentFilespace_FindDirUnderLock(filespaceOid);
 	if (filespaceDirEntry == NULL)
 		elog(ERROR, "Did not find persistent filespace entry %u",
 			 filespaceOid);
 
 	*persistentTid = filespaceDirEntry->persistentTid;
 	*persistentSerialNum = filespaceDirEntry->persistentSerialNum;
-
-	READ_PERSISTENT_STATE_ORDERED_UNLOCK;
+	LWLockRelease(FilespaceHashLock);
 }
 
 
 // -----------------------------------------------------------------------------
 // Helpers
 // -----------------------------------------------------------------------------
-
-static void PersistentFilespace_AddTuple(
-	FilespaceDirEntry filespaceDirEntry,
-
-	int64			createMirrorDataLossTrackingSessionNum,
-
-	MirroredObjectExistenceState mirrorExistenceState,
-
-	int32			reserved,
-
-	TransactionId 	parentXid,
-
-	bool			flushToXLog)
-				/* When true, the XLOG record for this change will be flushed to disk. */
-{
-	Oid filespaceOid = filespaceDirEntry->key.filespaceOid;
-
-	Datum values[Natts_gp_persistent_filespace_node];
-
-	GpPersistentFilespaceNode_SetDatumValues(
-										values,
-										filespaceOid,
-										filespaceDirEntry->dbId1,
-										filespaceDirEntry->locationBlankPadded1,
-										filespaceDirEntry->dbId2,
-										filespaceDirEntry->locationBlankPadded2,
-										filespaceDirEntry->state,
-										createMirrorDataLossTrackingSessionNum,
-										mirrorExistenceState,
-										reserved,
-										parentXid,
-										/* persistentSerialNum */ 0);	// This will be set by PersistentFileSysObj_AddTuple.
-
-	PersistentFileSysObj_AddTuple(
-							PersistentFsObjType_FilespaceDir,
-							values,
-							flushToXLog,
-							&filespaceDirEntry->persistentTid,
-							&filespaceDirEntry->persistentSerialNum);
-}
 
 static void PersistentFilespace_BlankPadCopyLocation(
 	char locationBlankPadded[FilespaceLocationBlankPaddedWithNullTermLen],
@@ -400,50 +368,14 @@ void PersistentFilespace_ConvertBlankPaddedLocation(
 	}
 }
 
-bool PersistentFilespace_TryGetPrimaryAndMirrorUnderLock(
-	Oid 		filespaceOid,
-				/* The filespace OID to lookup. */
-
-	char **primaryFilespaceLocation,
-				/* The primary filespace directory path.  Return NULL for global and base. */
-
-	char **mirrorFilespaceLocation)
-				/* The primary filespace directory path.  Return NULL for global and base.
-				 * Or, returns NULL when mirror not configured. */
+static void
+PersistentFilespace_GetPaths(FilespaceDirEntry filespaceDirEntry,
+							 char **primaryFilespaceLocation,
+							 char **mirrorFilespaceLocation)
 {
-	FilespaceDirEntry filespaceDirEntry;
-
 	int16 primaryDbId;
-
 	char *primaryBlankPadded = NULL;
 	char *mirrorBlankPadded = NULL;
-
-	*primaryFilespaceLocation = NULL;
-	*mirrorFilespaceLocation = NULL;
-
-#ifdef MASTER_MIRROR_SYNC
-	/*
-	 * Can't rely on persistent tables or memory structures on the standby so
-	 * get it from the cache maintained by the master mirror sync code
-	 */
-	if (IsStandbyMode())
-	{
-		return mmxlog_filespace_get_path(
-									filespaceOid,
-									primaryFilespaceLocation);
-	}
-#endif
-
-	/*
-	 * Important to make this call AFTER we check if we are the Standby Master.
-	 */
-	PersistentFilespace_VerifyInitScan();
-
-	filespaceDirEntry =
-				PersistentFilespace_FindDirUnderLock(
-												filespaceOid);
-	if (filespaceDirEntry == NULL)
-		return false;
 
 	/*
 	 * The persistent_filespace_node_table contains the paths for both the
@@ -512,11 +444,109 @@ bool PersistentFilespace_TryGetPrimaryAndMirrorUnderLock(
 											mirrorFilespaceLocation,
 											mirrorBlankPadded,
 											/* isPrimary */ false);
-
-	return true;
 }
 
-void PersistentFilespace_GetPrimaryAndMirrorUnderLock(
+PersistentTablespaceGetFilespaces
+PersistentFilespace_GetFilespaceFromTablespace(Oid tablespaceOid,
+											   char **primaryFilespaceLocation,
+											   char **mirrorFilespaceLocation,
+											   Oid *filespaceOid)
+{
+	bool			found;
+	TablespaceDirEntry	tablespaceDirEntry;
+	TablespaceDirEntryKey tsKey;
+	FilespaceDirEntry	filespaceDirEntry;
+	FilespaceDirEntryKey fsKey;
+	PersistentTablespaceGetFilespaces result;
+
+	if (persistentTablespaceSharedHashTable == NULL)
+		elog(PANIC, "persistent tablespace shared-memory not setup");
+	if (persistentFilespaceSharedHashTable == NULL)
+		elog(PANIC, "persistent filespace shared-memory not setup");
+
+	LWLockAcquire(FilespaceHashLock, LW_SHARED);
+	LWLockAcquire(TablespaceHashLock, LW_SHARED);
+
+	tsKey.tablespaceOid = tablespaceOid;
+	tablespaceDirEntry = (TablespaceDirEntry) hash_search(
+		persistentTablespaceSharedHashTable, (void *) &tsKey,
+		HASH_FIND, &found);
+	if (found)
+	{
+		fsKey.filespaceOid = *filespaceOid = tablespaceDirEntry->filespaceOid;
+		filespaceDirEntry = (FilespaceDirEntry)	hash_search(
+			persistentFilespaceSharedHashTable, (void *) &fsKey,
+			HASH_FIND, &found);
+		if (found)
+		{
+			result = PersistentTablespaceGetFilespaces_Ok;
+		}
+		else
+			result = PersistentTablespaceGetFilespaces_FilespaceNotFound;
+	}
+	else
+		result = PersistentTablespaceGetFilespaces_TablespaceNotFound;
+
+	if (result == PersistentTablespaceGetFilespaces_Ok)
+		PersistentFilespace_GetPaths(filespaceDirEntry,
+									 primaryFilespaceLocation,
+									 mirrorFilespaceLocation);
+	LWLockRelease(TablespaceHashLock);
+	LWLockRelease(FilespaceHashLock);
+
+	return result;
+}
+
+bool PersistentFilespace_TryGetPrimaryAndMirror(
+	Oid 		filespaceOid,
+				/* The filespace OID to lookup. */
+
+	char **primaryFilespaceLocation,
+				/* The primary filespace directory path.  Return NULL for global and base. */
+
+	char **mirrorFilespaceLocation)
+				/* The primary filespace directory path.  Return NULL for global and base.
+				 * Or, returns NULL when mirror not configured. */
+{
+	FilespaceDirEntry filespaceDirEntry;
+	bool result = false;
+
+	*primaryFilespaceLocation = NULL;
+	*mirrorFilespaceLocation = NULL;
+
+#ifdef MASTER_MIRROR_SYNC
+	/*
+	 * Can't rely on persistent tables or memory structures on the standby so
+	 * get it from the cache maintained by the master mirror sync code
+	 */
+	if (IsStandbyMode())
+	{
+		return mmxlog_filespace_get_path(
+									filespaceOid,
+									primaryFilespaceLocation);
+	}
+#endif
+
+	/*
+	 * Important to make this call AFTER we check if we are the Standby Master.
+	 */
+	PersistentFilespace_VerifyInitScan();
+
+	LWLockAcquire(FilespaceHashLock, LW_SHARED);
+	filespaceDirEntry = PersistentFilespace_FindDirUnderLock(filespaceOid);
+	if (filespaceDirEntry)
+	{
+		PersistentFilespace_GetPaths(filespaceDirEntry,
+									 primaryFilespaceLocation,
+									 mirrorFilespaceLocation);
+		result = true;
+	}
+	LWLockRelease(FilespaceHashLock);
+
+	return result;
+}
+
+void PersistentFilespace_GetPrimaryAndMirror(
 	Oid 		filespaceOid,
 				/* The filespace OID to lookup. */
 
@@ -529,11 +559,11 @@ void PersistentFilespace_GetPrimaryAndMirrorUnderLock(
 {
 	/*
 	 * Do not call PersistentFilespace_VerifyInitScan here to allow
-	 * PersistentFilespace_TryGetPrimaryAndMirrorUnderLock to handle the Standby Master
+	 * PersistentFilespace_TryGetPrimaryAndMirror to handle the Standby Master
 	 * special case.
 	 */
 
-	if (!PersistentFilespace_TryGetPrimaryAndMirrorUnderLock(
+	if (!PersistentFilespace_TryGetPrimaryAndMirror(
 													filespaceOid,
 													primaryFilespaceLocation,
 													mirrorFilespaceLocation))
@@ -541,39 +571,6 @@ void PersistentFilespace_GetPrimaryAndMirrorUnderLock(
 		elog(ERROR, "Did not find persistent filespace entry %u",
 			 filespaceOid);
 	}
-}
-
-void PersistentFilespace_GetPrimaryAndMirror(
-	Oid 		filespaceOid,
- 	            /* The filespace OID to lookup */
-
-	char **primaryFilespaceLocation,
-				/* The primary filespace directory path.  Return NULL for global and base. */
-
-	char **mirrorFilespaceLocation)
-				/* The primary filespace directory path.  Return NULL for global and base.
-				 * Or, returns NULL when mirror not configured. */
-{
-	READ_PERSISTENT_STATE_ORDERED_LOCK_DECLARE;
-
-	/*
-	 * Do not call PersistentFilespace_VerifyInitScan here to allow
-	 * PersistentFilespace_TryGetPrimaryAndMirrorUnderLock to handle the Standby Master
-	 * special case.
-	 */
-
-	READ_PERSISTENT_STATE_ORDERED_LOCK;
-
-	if (!PersistentFilespace_TryGetPrimaryAndMirrorUnderLock(
-											filespaceOid,
-											primaryFilespaceLocation,
-											mirrorFilespaceLocation))
-	{
-		elog(ERROR, "Did not find persistent filespace entry %u",
-			 filespaceOid);
-	}
-
-	READ_PERSISTENT_STATE_ORDERED_UNLOCK;
 }
 
 // -----------------------------------------------------------------------------
@@ -624,6 +621,9 @@ void PersistentFilespace_MarkCreatePending(
 
 	FilespaceDirEntry filespaceDirEntry;
 	TransactionId topXid;
+	Datum values[Natts_gp_persistent_filespace_node];
+	char mirrorFilespaceLocationBlankPadded[FilespaceLocationBlankPaddedWithNullTermLen];
+	char primaryFilespaceLocationBlankPadded[FilespaceLocationBlankPaddedWithNullTermLen];
 
 	if (Persistent_BeforePersistenceWork())
 	{
@@ -643,33 +643,55 @@ void PersistentFilespace_MarkCreatePending(
 
 	WRITE_PERSISTENT_STATE_ORDERED_LOCK;
 
-	filespaceDirEntry =
-				PersistentFilespace_CreateDirUnderLock(
-												filespaceOid);
+	PersistentFilespace_BlankPadCopyLocation(
+										primaryFilespaceLocationBlankPadded,
+										primaryFilespaceLocation);
+	
+	PersistentFilespace_BlankPadCopyLocation(
+										mirrorFilespaceLocationBlankPadded,
+										mirrorFilespaceLocation);
+
+	GpPersistentFilespaceNode_SetDatumValues(
+										values,
+										filespaceOid,
+										primaryDbId,
+										primaryFilespaceLocationBlankPadded,
+										mirrorDbId,
+										mirrorFilespaceLocationBlankPadded,
+										PersistentFileSysState_CreatePending,
+										/* createMirrorDataLossTrackingSessionNum */ 0,
+										mirrorExistenceState,
+										/* reserved */ 0,
+										/* parentXid */ topXid,
+										/* persistentSerialNum */ 0);	// This will be set by PersistentFileSysObj_AddTuple.
+
+	PersistentFileSysObj_AddTuple(
+							PersistentFsObjType_FilespaceDir,
+							values,
+							flushToXLog,
+							persistentTid,
+							persistentSerialNum);
+
+
+	WRITE_FILESPACE_HASH_LOCK;
+
+	filespaceDirEntry =	PersistentFilespace_CreateDirUnderLock(filespaceOid);
+
 	Assert(filespaceDirEntry != NULL);
 
 	filespaceDirEntry->dbId1 = primaryDbId;
-	PersistentFilespace_BlankPadCopyLocation(
-										filespaceDirEntry->locationBlankPadded1,
-										primaryFilespaceLocation);
-
+	memcpy(filespaceDirEntry->locationBlankPadded1, primaryFilespaceLocationBlankPadded,
+		   FilespaceLocationBlankPaddedWithNullTermLen);
+	
 	filespaceDirEntry->dbId2 = mirrorDbId;
-	PersistentFilespace_BlankPadCopyLocation(
-										filespaceDirEntry->locationBlankPadded2,
-										mirrorFilespaceLocation);
+	memcpy(filespaceDirEntry->locationBlankPadded2, mirrorFilespaceLocationBlankPadded,
+		   FilespaceLocationBlankPaddedWithNullTermLen);
 
 	filespaceDirEntry->state = PersistentFileSysState_CreatePending;
+	ItemPointerCopy(persistentTid, &filespaceDirEntry->persistentTid);
+	filespaceDirEntry->persistentSerialNum = *persistentSerialNum;
 
-	PersistentFilespace_AddTuple(
-							filespaceDirEntry,
-							/* createMirrorDataLossTrackingSessionNum */ 0,
-							mirrorExistenceState,
-							/* reserved */ 0,
-							/* parentXid */ topXid,
-							flushToXLog);
-
-	*persistentTid = filespaceDirEntry->persistentTid;
-	*persistentSerialNum = filespaceDirEntry->persistentSerialNum;
+	WRITE_FILESPACE_HASH_UNLOCK;
 
 	/*
 	 * This XLOG must be generated under the persistent write-lock.
@@ -749,9 +771,8 @@ void PersistentFilespace_Created(
 
 	WRITE_PERSISTENT_STATE_ORDERED_LOCK;
 
-	filespaceDirEntry =
-				PersistentFilespace_FindDirUnderLock(
-												filespaceOid);
+	WRITE_FILESPACE_HASH_LOCK;
+	filespaceDirEntry =	PersistentFilespace_FindDirUnderLock(filespaceOid);
 	if (filespaceDirEntry == NULL)
 		elog(ERROR, "did not find persistent filespace entry %u",
 			 filespaceOid);
@@ -761,6 +782,9 @@ void PersistentFilespace_Created(
 			 "'Create Pending' state (actual state '%s')",
 			 filespaceOid,
 			 PersistentFileSysObjState_Name(filespaceDirEntry->state));
+
+	filespaceDirEntry->state = PersistentFileSysState_Created;
+	WRITE_FILESPACE_HASH_UNLOCK;
 
 	stateChangeResult =
 		PersistentFileSysObj_StateChange(
@@ -772,8 +796,6 @@ void PersistentFilespace_Created(
 								/* flushToXlog */ false,
 								/* oldState */ NULL,
 								/* verifiedActionCallback */ NULL);
-
-	filespaceDirEntry->state = PersistentFileSysState_Created;
 
 	WRITE_PERSISTENT_STATE_ORDERED_UNLOCK;
 
@@ -833,9 +855,8 @@ PersistentFileSysObjStateChangeResult PersistentFilespace_MarkDropPending(
 
 	WRITE_PERSISTENT_STATE_ORDERED_LOCK;
 
-	filespaceDirEntry =
-				PersistentFilespace_FindDirUnderLock(
-												filespaceOid);
+	WRITE_FILESPACE_HASH_LOCK;
+	filespaceDirEntry =	PersistentFilespace_FindDirUnderLock(filespaceOid);
 	if (filespaceDirEntry == NULL)
 		elog(ERROR, "Did not find persistent filespace entry %u",
 			 filespaceOid);
@@ -845,6 +866,9 @@ PersistentFileSysObjStateChangeResult PersistentFilespace_MarkDropPending(
 		elog(ERROR, "Persistent filespace entry %u expected to be in 'Create Pending' or 'Created' state (actual state '%s')",
 			 filespaceOid,
 			 PersistentFileSysObjState_Name(filespaceDirEntry->state));
+
+	filespaceDirEntry->state = PersistentFileSysState_DropPending;
+	WRITE_FILESPACE_HASH_UNLOCK;
 
 	stateChangeResult =
 		PersistentFileSysObj_StateChange(
@@ -856,8 +880,6 @@ PersistentFileSysObjStateChangeResult PersistentFilespace_MarkDropPending(
 								/* flushToXlog */ false,
 								/* oldState */ NULL,
 								/* verifiedActionCallback */ NULL);
-
-	filespaceDirEntry->state = PersistentFileSysState_DropPending;
 
 	WRITE_PERSISTENT_STATE_ORDERED_UNLOCK;
 
@@ -914,9 +936,8 @@ PersistentFileSysObjStateChangeResult PersistentFilespace_MarkAbortingCreate(
 
 	WRITE_PERSISTENT_STATE_ORDERED_LOCK;
 
-	filespaceDirEntry =
-				PersistentFilespace_FindDirUnderLock(
-												filespaceOid);
+	WRITE_FILESPACE_HASH_LOCK;
+	filespaceDirEntry = PersistentFilespace_FindDirUnderLock(filespaceOid);
 	if (filespaceDirEntry == NULL)
 		elog(ERROR, "Did not find persistent filespace entry %u",
 			 filespaceOid);
@@ -925,6 +946,9 @@ PersistentFileSysObjStateChangeResult PersistentFilespace_MarkAbortingCreate(
 		elog(ERROR, "Persistent filespace entry %u expected to be in 'Create Pending' (actual state '%s')",
 			 filespaceOid,
 			 PersistentFileSysObjState_Name(filespaceDirEntry->state));
+
+	filespaceDirEntry->state = PersistentFileSysState_AbortingCreate;
+	WRITE_FILESPACE_HASH_UNLOCK;
 
 	stateChangeResult =
 		PersistentFileSysObj_StateChange(
@@ -936,8 +960,6 @@ PersistentFileSysObjStateChangeResult PersistentFilespace_MarkAbortingCreate(
 								/* flushToXlog */ false,
 								/* oldState */ NULL,
 								/* verifiedActionCallback */ NULL);
-
-	filespaceDirEntry->state = PersistentFileSysState_AbortingCreate;
 
 	WRITE_PERSISTENT_STATE_ORDERED_UNLOCK;
 
@@ -1029,19 +1051,6 @@ void PersistentFilespace_Dropped(
 
 	WRITE_PERSISTENT_STATE_ORDERED_LOCK;
 
-	filespaceDirEntry =
-				PersistentFilespace_FindDirUnderLock(
-												filespaceOid);
-	if (filespaceDirEntry == NULL)
-		elog(ERROR, "Did not find persistent filespace entry %u",
-			 filespaceOid);
-
-	if (filespaceDirEntry->state != PersistentFileSysState_DropPending &&
-		filespaceDirEntry->state != PersistentFileSysState_AbortingCreate)
-		elog(ERROR, "Persistent filespace entry %u expected to be in 'Drop Pending' or 'Aborting Create' (actual state '%s')",
-			 filespaceOid,
-			 PersistentFileSysObjState_Name(filespaceDirEntry->state));
-
 	stateChangeResult =
 		PersistentFileSysObj_StateChange(
 								&fsObjName,
@@ -1053,9 +1062,21 @@ void PersistentFilespace_Dropped(
 								&oldState,
 								PersistentFilespace_DroppedVerifiedActionCallback);
 
-	filespaceDirEntry->state = PersistentFileSysState_Free;
+	WRITE_FILESPACE_HASH_LOCK;
+	filespaceDirEntry = PersistentFilespace_FindDirUnderLock(filespaceOid);
+	if (filespaceDirEntry == NULL)
+		elog(ERROR, "Did not find persistent filespace entry %u",
+			 filespaceOid);
 
+	if (filespaceDirEntry->state != PersistentFileSysState_DropPending &&
+		filespaceDirEntry->state != PersistentFileSysState_AbortingCreate)
+		elog(ERROR, "Persistent filespace entry %u expected to be in 'Drop Pending' or 'Aborting Create' (actual state '%s')",
+			 filespaceOid,
+			 PersistentFileSysObjState_Name(filespaceDirEntry->state));
+
+	filespaceDirEntry->state = PersistentFileSysState_Free;
 	PersistentFilespace_RemoveDirUnderLock(filespaceDirEntry);
+	WRITE_FILESPACE_HASH_UNLOCK;
 
 	WRITE_PERSISTENT_STATE_ORDERED_UNLOCK;
 
@@ -1083,6 +1104,8 @@ PersistentFilespace_AddMirror(Oid filespace,
 	WRITE_PERSISTENT_STATE_ORDERED_LOCK_DECLARE;
 
 	FilespaceDirEntry fde;
+	ItemPointerData persistentTid;
+	int64 persistentSerialNum;
 
 	if (Persistent_BeforePersistenceWork())
 		elog(ERROR, "persistent table changes forbidden");
@@ -1093,6 +1116,7 @@ PersistentFilespace_AddMirror(Oid filespace,
 
 	WRITE_PERSISTENT_STATE_ORDERED_LOCK;
 
+	LWLockAcquire(FilespaceHashLock, LW_SHARED);
 	fde = PersistentFilespace_FindDirUnderLock(filespace);
 	if (fde == NULL)
 		elog(ERROR, "did not find persistent filespace entry %u",
@@ -1119,9 +1143,13 @@ PersistentFilespace_AddMirror(Oid filespace,
 		Insist(false);
 	}
 
+	ItemPointerCopy(&fde->persistentTid, &persistentTid);
+	persistentSerialNum = fde->persistentSerialNum;
+	LWLockRelease(FilespaceHashLock);
+
 	PersistentFileSysObj_AddMirror(&fsObjName,
-								   &fde->persistentTid,
-								   fde->persistentSerialNum,
+								   &persistentTid,
+								   persistentSerialNum,
 								   pridbid,
 								   mirdbid,
 								   (void *)newpath,
@@ -1151,10 +1179,25 @@ PersistentFilespace_RemoveSegment(int16 dbid, bool ismirror)
 
 	WRITE_PERSISTENT_STATE_ORDERED_LOCK;
 
+	/*
+	 * We release FilespaceHashLock in the middle of the loop and re-acquire
+	 * it after doing persistent table change.  This is needed to prevent
+	 * holding the lock for any purpose other than to protect the filespace
+	 * shared hash table.  Not releasing this lock could result in file I/O
+	 * and potential deadlock due to other LW locks being acquired in the
+	 * process.  Releasing the lock this way is safe because we are still
+	 * holding PersistentObjLock in exclusive mode.  Any change to the
+	 * filespace shared hash table is also protected by PersistentObjLock.
+	 */
+	WRITE_FILESPACE_HASH_LOCK;
 	while ((fde = hash_seq_search(&hstat)) != NULL)
 	{
 		Oid filespace = fde->key.filespaceOid;
 		PersistentFileSysObjName fsObjName;
+		ItemPointerData persistentTid;
+		int64 persistentSerialNum = fde->persistentSerialNum;
+
+		ItemPointerCopy(&fde->persistentTid, &persistentTid);
 
 		PersistentFileSysObjName_SetFilespaceDir(&fsObjName, filespace);
 
@@ -1171,13 +1214,18 @@ PersistentFilespace_RemoveSegment(int16 dbid, bool ismirror)
 										"");
 		}
 
+		WRITE_FILESPACE_HASH_UNLOCK;
+
 		PersistentFileSysObj_RemoveSegment(&fsObjName,
-								   &fde->persistentTid,
-								   fde->persistentSerialNum,
+								   &persistentTid,
+								   persistentSerialNum,
 								   dbid,
 								   ismirror,
 								   /* flushToXlog */ false);
+		WRITE_FILESPACE_HASH_LOCK;
 	}
+	WRITE_FILESPACE_HASH_UNLOCK;
+	
 	WRITE_PERSISTENT_STATE_ORDERED_UNLOCK;
 }
 
@@ -1201,10 +1249,25 @@ PersistentFilespace_ActivateStandby(int16 oldmaster, int16 newmaster)
 
 	WRITE_PERSISTENT_STATE_ORDERED_LOCK;
 
+	/*
+	 * We release FilespaceHashLock in the middle of the loop and re-acquire
+	 * it after doing persistent table change.  This is needed to prevent
+	 * holding the lock for any purpose other than to protect the filespace
+	 * shared hash table.  Not releasing this lock could result in file I/O
+	 * and potential deadlock due to other LW locks being acquired in the
+	 * process.  Releasing the lock this way is safe because we are still
+	 * holding PersistentObjLock in exclusive mode.  Any change to the
+	 * filespace shared hash table is also protected by PersistentObjLock.
+	 */
+	WRITE_FILESPACE_HASH_LOCK;
 	while ((fde = hash_seq_search(&hstat)) != NULL)
 	{
 		Oid filespace = fde->key.filespaceOid;
 		PersistentFileSysObjName fsObjName;
+		ItemPointerData persistentTid;
+		int64 persistentSerialNum = fde->persistentSerialNum;
+
+		ItemPointerCopy(&fde->persistentTid, &persistentTid);
 
 		PersistentFileSysObjName_SetFilespaceDir(&fsObjName, filespace);
 
@@ -1236,14 +1299,17 @@ PersistentFilespace_ActivateStandby(int16 oldmaster, int16 newmaster)
 										fde->locationBlankPadded2,
 										"");
 		}
+		WRITE_FILESPACE_HASH_UNLOCK;
 
 		PersistentFileSysObj_ActivateStandby(&fsObjName,
-								   &fde->persistentTid,
-								   fde->persistentSerialNum,
+								   &persistentTid,
+								   persistentSerialNum,
 								   oldmaster,
 								   newmaster,
 								   /* flushToXlog */ false);
+		WRITE_FILESPACE_HASH_LOCK;
 	}
+	WRITE_FILESPACE_HASH_UNLOCK;
 
 	WRITE_PERSISTENT_STATE_ORDERED_UNLOCK;
 }

--- a/src/backend/cdb/cdbpersistentfilesysobj.c
+++ b/src/backend/cdb/cdbpersistentfilesysobj.c
@@ -2164,7 +2164,7 @@ PersistentFileSysObj_DoMirrorValidation(
 			char *primaryFilespaceLocation = NULL;
 			char *mirrorFilespaceLocation = NULL;
 
-			PersistentFilespace_GetPrimaryAndMirrorUnderLock(
+			PersistentFilespace_GetPrimaryAndMirror(
 													fsObjName->variant.filespaceOid,
 													&primaryFilespaceLocation,
 													&mirrorFilespaceLocation);

--- a/src/backend/cdb/cdbpersistentfilesysobj.c
+++ b/src/backend/cdb/cdbpersistentfilesysobj.c
@@ -627,6 +627,7 @@ static void PersistentFileSysObj_DoInitScan(void)
 
 	Assert(persistentFileSysObjPrivateSharedData->needInitScan);
 
+	LWLockAcquire(PersistentObjLock, LW_SHARED);
 	for (fsObjType = PersistentFsObjType_First;
 		 fsObjType <= PersistentFsObjType_Last;
 		 fsObjType++)
@@ -639,6 +640,7 @@ static void PersistentFileSysObj_DoInitScan(void)
 						 &fileSysObjData->storeData,
 						 &fileSysObjSharedData->storeSharedData);
 	}
+	LWLockRelease(PersistentObjLock);
 
 	 persistentFileSysObjPrivateSharedData->needInitScan = false;
 }

--- a/src/backend/cdb/cdbpersistentfilesysobj.c
+++ b/src/backend/cdb/cdbpersistentfilesysobj.c
@@ -627,7 +627,6 @@ static void PersistentFileSysObj_DoInitScan(void)
 
 	Assert(persistentFileSysObjPrivateSharedData->needInitScan);
 
-	LWLockAcquire(PersistentObjLock, LW_SHARED);
 	for (fsObjType = PersistentFsObjType_First;
 		 fsObjType <= PersistentFsObjType_Last;
 		 fsObjType++)
@@ -640,7 +639,6 @@ static void PersistentFileSysObj_DoInitScan(void)
 						 &fileSysObjData->storeData,
 						 &fileSysObjSharedData->storeSharedData);
 	}
-	LWLockRelease(PersistentObjLock);
 
 	 persistentFileSysObjPrivateSharedData->needInitScan = false;
 }

--- a/src/backend/cdb/cdbpersistenttablespace.c
+++ b/src/backend/cdb/cdbpersistenttablespace.c
@@ -65,7 +65,10 @@ typedef struct PersistentTablespaceData
 	}
 
 #define WRITE_TABLESPACE_HASH_UNLOCK \
-	LWLockRelease(TablespaceHashLock);
+	{ \
+		Assert(LWLockHeldByMe(PersistentObjLock)); \
+		LWLockRelease(TablespaceHashLock); \
+	}
 
 /*
  * Global Variables

--- a/src/backend/cdb/cdbpersistenttablespace.c
+++ b/src/backend/cdb/cdbpersistenttablespace.c
@@ -845,13 +845,8 @@ PersistentTablespace_RemoveSegment(int16 dbid, bool ismirror)
 	 * PersistentObjLock, which is held at this point.  The tablespace hash
 	 * therefore, can be read without acquiring TablespaceHashLock because we
 	 * are not making any change to the hash table in this function.
-	 *
-	 * We will, however, take the lock under debug to provide assert protection
-	 * under PersistentTablespace_FindEntryUnderLock().
 	 */
-#ifdef USE_ASSERT_CHECKING
 	LWLockAcquire(TablespaceHashLock, LW_SHARED);
-#endif
 	while ((tablespaceDirEntry = hash_seq_search(&hstat)) != NULL)
 	{
 		PersistentFileSysObjName fsObjName;
@@ -861,9 +856,7 @@ PersistentTablespace_RemoveSegment(int16 dbid, bool ismirror)
 
 		tablespaceDirEntry = PersistentTablespace_FindEntryUnderLock(tblspc);
 
-#ifdef USE_ASSERT_CHECKING
 		LWLockRelease(TablespaceHashLock);
-#endif
 
 		if (tablespaceDirEntry == NULL)
 			elog(ERROR, "Did not find persistent tablespace entry %u", 
@@ -879,13 +872,9 @@ PersistentTablespace_RemoveSegment(int16 dbid, bool ismirror)
 										   dbid,
 										   ismirror,
 										   /* flushToXlog */ false);
-#ifdef USE_ASSERT_CHECKING
 		LWLockAcquire(TablespaceHashLock, LW_SHARED);
-#endif
 	}
-#ifdef USE_ASSERT_CHECKING
 	LWLockRelease(TablespaceHashLock);
-#endif
 	
 	WRITE_PERSISTENT_STATE_ORDERED_UNLOCK;
 }

--- a/src/backend/cdb/cdbpersistenttablespace.c
+++ b/src/backend/cdb/cdbpersistenttablespace.c
@@ -840,12 +840,6 @@ PersistentTablespace_RemoveSegment(int16 dbid, bool ismirror)
 
 	WRITE_PERSISTENT_STATE_ORDERED_LOCK;
 
-	/*
-	 * Writes to the shared tablespace hash table are protected by
-	 * PersistentObjLock, which is held at this point.  The tablespace hash
-	 * therefore, can be read without acquiring TablespaceHashLock because we
-	 * are not making any change to the hash table in this function.
-	 */
 	LWLockAcquire(TablespaceHashLock, LW_SHARED);
 	while ((tablespaceDirEntry = hash_seq_search(&hstat)) != NULL)
 	{

--- a/src/backend/cdb/cdbpersistenttablespace.c
+++ b/src/backend/cdb/cdbpersistenttablespace.c
@@ -280,12 +280,15 @@ static bool PersistentTablespace_ScanTupleCallback(
 
 void PersistentTablespace_Reset(void)
 {
+	WRITE_PERSISTENT_STATE_ORDERED_LOCK_DECLARE;
+
 	HASH_SEQ_STATUS stat;
 
 	TablespaceDirEntry tablespaceDirEntry;
 
 	hash_seq_init(&stat, persistentTablespaceSharedHashTable);
 
+	WRITE_PERSISTENT_STATE_ORDERED_LOCK;
 	WRITE_TABLESPACE_HASH_LOCK;
 
 	while (true)
@@ -322,6 +325,7 @@ void PersistentTablespace_Reset(void)
 	}
 
 	WRITE_TABLESPACE_HASH_UNLOCK;
+	WRITE_PERSISTENT_STATE_ORDERED_UNLOCK;
 }
 
 extern void PersistentTablespace_LookupTidAndSerialNum(

--- a/src/backend/utils/gp/segadmin.c
+++ b/src/backend/utils/gp/segadmin.c
@@ -567,7 +567,7 @@ static void
 remove_segment_persistent_entries(int16 pridbid, seginfo *i)
 {
 	/*
-	 * Remove filespace entries in pg_filespace_entry and
+	 * Remove filespace references in pg_filespace_entry and
 	 * gp_persistent_filespace_node
 	 */
 	update_filespaces(pridbid, i, false, NULL);
@@ -588,7 +588,7 @@ remove_segment_persistent_entries(int16 pridbid, seginfo *i)
 	update_relations(pridbid, i, false);
 
 	/*
-	 * If we're adding a segment mirror, we need to dispatch to that
+	 * If we're removing a segment mirror, we need to dispatch to that
 	 * segment's primary.
 	 */
 	if (Gp_role == GP_ROLE_DISPATCH && i->db.role == SEGMENT_ROLE_MIRROR)

--- a/src/include/cdb/cdbpersistentfilespace.h
+++ b/src/include/cdb/cdbpersistentfilespace.h
@@ -14,6 +14,7 @@
 #include "cdb/cdbsharedoidsearch.h"
 #include "storage/itemptr.h"
 #include "cdb/cdbpersistentfilesysobj.h"
+#include "cdb/cdbpersistenttablespace.h"
 
 extern void PersistentFilespace_ConvertBlankPaddedLocation(
 	char 		**filespaceLocation,
@@ -31,17 +32,14 @@ extern void PersistentFilespace_LookupTidAndSerialNum(
 
 	int64			*persistentSerialNum);
 
-extern bool PersistentFilespace_TryGetPrimaryAndMirrorUnderLock(
-	Oid 		filespaceOid,
-				/* The filespace OID to lookup. */
 
-	char **primaryFilespaceLocation,
-				/* The primary filespace directory path.  Return NULL for global and base. */
-	
-	char **mirrorFilespaceLocation);
-				/* The primary filespace directory path.  Return NULL for global and base. 
-				 * Or, returns NULL when mirror not configured. */
-extern void PersistentFilespace_GetPrimaryAndMirrorUnderLock(
+extern PersistentTablespaceGetFilespaces
+PersistentFilespace_GetFilespaceFromTablespace(Oid tablespaceOid,
+											   char **primaryFilespaceLocation,
+											   char **mirrorFilespaceLocation,
+											   Oid *filespaceOid);
+
+extern bool PersistentFilespace_TryGetPrimaryAndMirror(
 	Oid 		filespaceOid,
 				/* The filespace OID to lookup. */
 

--- a/src/include/cdb/cdbpersistenttablespace.h
+++ b/src/include/cdb/cdbpersistenttablespace.h
@@ -41,7 +41,26 @@ typedef enum PersistentTablespaceGetFilespaces
 	PersistentTablespaceGetFilespaces_FilespaceNotFound,
 	MaxPersistentTablespaceGetFilespaces /* must always be last */
 } PersistentTablespaceGetFilespaces;
-				
+
+typedef struct TablespaceDirEntryKey
+{
+	Oid	tablespaceOid;
+} TablespaceDirEntryKey;
+
+typedef struct TablespaceDirEntryData
+{
+	TablespaceDirEntryKey	key;
+
+	Oid						filespaceOid;
+
+	PersistentFileSysState	state;
+	int64					persistentSerialNum;
+	ItemPointerData 		persistentTid;
+	
+} TablespaceDirEntryData;
+typedef TablespaceDirEntryData *TablespaceDirEntry;
+extern HTAB *persistentTablespaceSharedHashTable;
+
 extern PersistentTablespaceGetFilespaces PersistentTablespace_TryGetPrimaryAndMirrorFilespaces(
 	Oid 		tablespaceOid,
 				/* The tablespace OID for the create. */

--- a/src/include/storage/lwlock.h
+++ b/src/include/storage/lwlock.h
@@ -99,6 +99,8 @@ typedef enum LWLockId
 	FirstLockMgrLock = FirstBufMappingLock + NUM_BUFFER_PARTITIONS,
 	SessionStateLock = FirstLockMgrLock + NUM_LOCK_PARTITIONS,
 	RelfilenodeGenLock,
+	FilespaceHashLock,
+	TablespaceHashLock,
 
 	/* must be last except for MaxDynamicLWLock: */
 	NumFixedLWLocks,

--- a/src/test/isolation2/Makefile
+++ b/src/test/isolation2/Makefile
@@ -6,6 +6,10 @@ subdir = src/test/isolation2
 top_builddir = ../../..
 include $(top_builddir)/src/Makefile.global
 
+NAME = isolation2_regress
+OBJS = isolation2_regress.o
+include $(top_srcdir)/src/Makefile.shlib
+
 # where to find psql for testing an existing installation
 PSQLDIR = $(bindir)
 
@@ -16,7 +20,7 @@ endif
 override CPPFLAGS := -I$(srcdir) -I$(libpq_srcdir) -I$(srcdir)/../regress $(CPPFLAGS)
 override LDLIBS := $(libpq_pgport) $(LDLIBS)
 
-all: pg_isolation2_regress$(X)
+all: pg_isolation2_regress$(X) all-lib
 
 pg_regress.o:
 	$(MAKE) -C $(top_builddir)/src/test/regress pg_regress.o

--- a/src/test/isolation2/input/pt_io_in_progress_deadlock.source
+++ b/src/test/isolation2/input/pt_io_in_progress_deadlock.source
@@ -1,0 +1,59 @@
+--
+-- Validate that PersistentObjLock is not acquired while io_in_progress lock is
+-- held on a buffer.
+--
+
+create extension if not exists gp_inject_fault;
+
+create function flush_relation_buffers(oid)
+   returns void
+   as '@abs_builddir@/isolation2_regress@DLSUFFIX@'
+   language c immutable strict no sql;
+
+-- We need a user defined filespace because the filespace and tablespace hash
+-- tables are ignored when accessing tables in the default/system tablespace.
+create filespace pt_deadlock_fs @gpfilespace_regressionfs1@;
+create tablespace pt_deadlock_ts filespace pt_deadlock_fs;
+create table pt_deadlock_table (a int, b int) tablespace pt_deadlock_ts;
+
+-- We want to flush a buffer through this test, so suspend checkpointer and
+-- bgwriter processes.
+select gp_inject_fault('checkpoint', 'suspend', dbid) from
+ gp_segment_configuration where role = 'p' and content > -1;
+select gp_inject_fault('fault_in_background_writer_main', 'suspend', dbid)
+ from gp_segment_configuration where role = 'p' and content > -1;
+
+insert into pt_deadlock_table select i,i from generate_series(1,1000)i;
+
+-- By suspending fault_before_pending_delete_relation_entry here, the query
+-- executor will be suspended while holding the PersistentObjLock on the
+-- segments.
+select gp_inject_fault('fault_before_pending_delete_relation_entry', 'suspend', dbid)
+ from gp_segment_configuration where role = 'p' and content > -1;
+
+-- Backend 1 obtains PersistentObjLock and blocks.
+1&: create table acquire_pt_lock_table (a int) distributed by (a);
+
+select gp_inject_fault('fault_before_pending_delete_relation_entry', 'status', dbid)
+ from gp_segment_configuration where role = 'p' and content > -1;
+
+-- Backend 2 flushes the dirty buffers in the pt_deadlock_table, and as a result
+-- will attempt to access the filespace and tablespace hash tables. It will
+-- acquire io_in_progress lock before accessing the hash tables, and will block
+-- if it also attempts to acquire PersistentObjLock.
+2: select flush_relation_buffers(oid) from gp_dist_random('pg_class') where relname = 'pt_deadlock_table';
+
+-- The fact that backend 2 completed flushing the relation buffers indicates
+-- that this test was successful.
+
+-- Clean up faults
+select gp_inject_fault('all', 'reset', dbid)
+ from gp_segment_configuration where role = 'p' and content > -1;
+
+1<:
+
+-- Because filespaces persist through database drop, we need to clean up the
+-- filespace/tablespace explicitly.
+drop table pt_deadlock_table;
+drop tablespace pt_deadlock_ts;
+drop filespace pt_deadlock_fs;

--- a/src/test/isolation2/isolation2_regress.c
+++ b/src/test/isolation2/isolation2_regress.c
@@ -1,0 +1,22 @@
+#include "postgres.h"
+#include "funcapi.h"
+#include "tablefuncapi.h"
+#include "miscadmin.h"
+
+#include "access/heapam.h"
+#include "storage/bufmgr.h"
+
+PG_MODULE_MAGIC;
+
+extern void flush_relation_buffers(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(flush_relation_buffers);
+
+void
+flush_relation_buffers(PG_FUNCTION_ARGS)
+{
+	Oid relid = PG_GETARG_OID(0);
+	Relation r = heap_open(relid, AccessShareLock);
+	FlushRelationBuffers(r);
+	heap_close(r, AccessShareLock);
+}
+

--- a/src/test/isolation2/output/pt_io_in_progress_deadlock.source
+++ b/src/test/isolation2/output/pt_io_in_progress_deadlock.source
@@ -1,0 +1,97 @@
+--
+-- Validate that PersistentObjLock is not acquired while io_in_progress lock is
+-- held on a buffer.
+--
+
+create extension if not exists gp_inject_fault;
+CREATE
+
+create function flush_relation_buffers(oid) returns void as '@abs_builddir@/isolation2_regress@DLSUFFIX@' language c immutable strict no sql;
+CREATE
+
+-- We need a user defined filespace because the filespace and tablespace hash
+-- tables are ignored when accessing tables in the default/system tablespace.
+create filespace pt_deadlock_fs @gpfilespace_regressionfs1@;
+CREATE
+create tablespace pt_deadlock_ts filespace pt_deadlock_fs;
+CREATE
+create table pt_deadlock_table (a int, b int) tablespace pt_deadlock_ts;
+CREATE
+
+-- We want to flush a buffer through this test, so suspend checkpointer and
+-- bgwriter processes.
+select gp_inject_fault('checkpoint', 'suspend', dbid) from gp_segment_configuration where role = 'p' and content > -1;
+gp_inject_fault
+---------------
+t              
+t              
+t              
+(3 rows)
+select gp_inject_fault('fault_in_background_writer_main', 'suspend', dbid) from gp_segment_configuration where role = 'p' and content > -1;
+gp_inject_fault
+---------------
+t              
+t              
+t              
+(3 rows)
+
+insert into pt_deadlock_table select i,i from generate_series(1,1000)i;
+INSERT 1000
+
+-- By suspending fault_before_pending_delete_relation_entry here, the query
+-- executor will be suspended while holding the PersistentObjLock on the
+-- segments.
+select gp_inject_fault('fault_before_pending_delete_relation_entry', 'suspend', dbid) from gp_segment_configuration where role = 'p' and content > -1;
+gp_inject_fault
+---------------
+t              
+t              
+t              
+(3 rows)
+
+-- Backend 1 obtains PersistentObjLock and blocks.
+1&: create table acquire_pt_lock_table (a int) distributed by (a);  <waiting ...>
+
+select gp_inject_fault('fault_before_pending_delete_relation_entry', 'status', dbid) from gp_segment_configuration where role = 'p' and content > -1;
+gp_inject_fault
+---------------
+t              
+t              
+t              
+(3 rows)
+
+-- Backend 2 flushes the dirty buffers in the pt_deadlock_table, and as a result
+-- will attempt to access the filespace and tablespace hash tables. It will
+-- acquire io_in_progress lock before accessing the hash tables, and will block
+-- if it also attempts to acquire PersistentObjLock.
+2: select flush_relation_buffers(oid) from gp_dist_random('pg_class') where relname = 'pt_deadlock_table';
+flush_relation_buffers
+----------------------
+                      
+                      
+                      
+(3 rows)
+
+-- The fact that backend 2 completed flushing the relation buffers indicates
+-- that this test was successful.
+
+-- Clean up faults
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration where role = 'p' and content > -1;
+gp_inject_fault
+---------------
+t              
+t              
+t              
+(3 rows)
+
+1<:  <... completed>
+CREATE
+
+-- Because filespaces persist through database drop, we need to clean up the
+-- filespace/tablespace explicitly.
+drop table pt_deadlock_table;
+DROP
+drop tablespace pt_deadlock_ts;
+DROP
+drop filespace pt_deadlock_fs;
+DROP


### PR DESCRIPTION
    Adds two new LW locks to protect filespace and tablespace hash tables
    to disambiguate them from PersistentObjLock. Previously, PersistentObjLock was
    overloaded to both protect these hash tables along with persistent heap tables.
    If two backends try to flush the same dirty buffer, a deadlock could
    potentially arise in which backend 1 holds PersistentObjLock and requests
    io_in_progress lock of the buffer to be evicted.  Backend 2 holds
    io_in_progress lock on the same buffer and attempts to obtain file path.
    Because the file path is in hash tables protected by PersistentObjLock, backend
    2 requests PersistentObjLock and blocks due to backend 1.