### PR TITLE
gpstart: validate consistent checksum settings

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -1311,7 +1311,6 @@ class GpError(Exception): pass
 
 ######
 def get_user():
-    logger.debug("Checking if LOGNAME or USER env variable is set.")
     username = os.environ.get('LOGNAME') or os.environ.get('USER')
     if not username:
         raise GpError('Environment Variable LOGNAME or USER not set')
@@ -1319,7 +1318,6 @@ def get_user():
 
 
 def get_gphome():
-    logger.debug("Checking if GPHOME env variable is set.")
     gphome=os.getenv('GPHOME',None)
     if not gphome:
         raise GpError('Environment Variable GPHOME not set')
@@ -1328,7 +1326,6 @@ def get_gphome():
 
 ######
 def get_masterdatadir():
-    logger.debug("Checking if MASTER_DATA_DIRECTORY env variable is set.")
     master_datadir = os.environ.get('MASTER_DATA_DIRECTORY')
     if not master_datadir:
         raise GpError("Environment Variable MASTER_DATA_DIRECTORY not set!")

--- a/gpMgmt/bin/gppylib/gplog.py
+++ b/gpMgmt/bin/gppylib/gplog.py
@@ -2,10 +2,10 @@
 #
 # Copyright (c) Greenplum Inc 2008. All Rights Reserved. 
 #
-'''
+"""
 Greenplum logging facilities.
 
-This Module contains some helper functions for setting up the 
+This Module contains some helper functions for setting up the
 python builtin logging module.  Tools and libraries are expected
 to centralize configuration of logging through these functions.
 
@@ -24,13 +24,14 @@ Typical usage:
   logger.info("Start myTool")
   ...
 
-'''
+"""
 import datetime
 import logging
 import os
 import sys
 
-#------------------------------- Public Interface --------------------------------
+
+# ------------------------------- Public Interface --------------------------------
 def get_default_logger():
     """
     Return the singleton default logger.
@@ -54,6 +55,7 @@ def get_default_logger():
         _LOGGER.setLevel(logging.INFO)
     return _LOGGER
 
+
 def get_unittest_logger():
     """
     Returns a singleton logger for use by gppylib unittests:
@@ -70,22 +72,23 @@ def get_unittest_logger():
     global _LOGGER, _SOUT_HANDLER
     if _LOGGER is None:
         _LOGGER = logging.getLogger('default')
-        filename="unittest.log"
+        filename = "unittest.log"
         _set_file_logging(filename)
     return _LOGGER
 
 
-def setup_helper_tool_logging(appName,hostname,userName):
+def setup_helper_tool_logging(appName, hostname, userName):
     """ 
     Returns a singleton logger for use by helper tools:
       - Logs output to stdout
       - Does not log output to a file
     """
     logger = get_default_logger()
-    logger.name="%s:%s" % (hostname,userName)
+    logger.name = "%s:%s" % (hostname, userName)
     return logger
 
-def setup_tool_logging(appName,hostname,userName,logdir=None,nonuser=False):
+
+def setup_tool_logging(appName, hostname, userName, logdir=None, nonuser=False):
     """
     Returns a singleton logger for standard Greenplum tools:
       - Logs output to stdout
@@ -94,12 +97,12 @@ def setup_tool_logging(appName,hostname,userName,logdir=None,nonuser=False):
     global _DEFAULT_FORMATTER
     global _APP_NAME_FOR_DEFAULT_FORMAT
 
-    loggerName ="%s:%s" % (hostname,userName)
+    loggerName = "%s:%s" % (hostname, userName)
     if nonuser:
-        appName=appName + "_" + loggerName
+        appName = appName + "_" + loggerName
     _APP_NAME_FOR_DEFAULT_FORMAT = appName
 
-    _enable_gpadmin_logging(appName,logdir)
+    _enable_gpadmin_logging(appName, logdir)
 
     #
     # now reset the default formatter (someone may have called get_default_logger before calling setup_tool_logging)
@@ -112,6 +115,7 @@ def setup_tool_logging(appName,hostname,userName,logdir=None,nonuser=False):
     _FILE_HANDLER.setFormatter(f)
 
     return logger
+
 
 def enable_verbose_logging():
     """
@@ -128,6 +132,7 @@ def quiet_stdout_logging():
     global _SOUT_HANDLER
     _SOUT_HANDLER.setLevel(logging.WARN)
 
+
 def very_quiet_stdout_logging():
     """ 
     Reduce log level to critical for stdout logging 
@@ -135,12 +140,14 @@ def very_quiet_stdout_logging():
     global _SOUT_HANDLER
     _SOUT_HANDLER.setLevel(logging.CRITICAL)
 
+
 def logging_is_verbose():
     """
     Returns true if the logging level has been set to verbose
     """
-    return _LOGGER.getEffectiveLevel() == logging.DEBUG    
-    
+    return _LOGGER.getEffectiveLevel() == logging.DEBUG
+
+
 def logging_is_quiet():
     """
     Returns true if the logging level has been set to quiet.
@@ -150,12 +157,14 @@ def logging_is_quiet():
     # logging handler.   So typical usage will never return true.
     return _LOGGER.getEffectiveLevel() == logging.WARN
 
+
 def get_logfile():
     """
     Returns the name of the file we are logging to, if any.
     """
     global _FILENAME
     return _FILENAME
+
 
 def log_literal(logger, lvl, msg):
     """
@@ -165,7 +174,7 @@ def log_literal(logger, lvl, msg):
     The intended purpose of this is for logging messages returned from
     remote backends that have already been formatted.
     """
-    
+
     # We assume the logger is using the two global handlers
     global _SOUT_HANDLER
     global _FILE_HANDLER
@@ -180,40 +189,42 @@ def log_literal(logger, lvl, msg):
 
     # Log the message
     logger.log(lvl, msg)
-    
+
     # Restore default formatter
     f = _get_default_formatter()
     _SOUT_HANDLER.setFormatter(f)
     _FILE_HANDLER.setFormatter(f)
-    
+
     return
-    
+
+
 def get_logger_if_verbose():
     if logging_is_verbose():
         return get_default_logger()
     return None
 
-    
-#------------------------------- Private --------------------------------    
 
-#evil global
-_LOGGER=None
-_FILENAME=None
-_DEFAULT_FORMATTER=None
-_LITERAL_FORMATTER=None
-_SOUT_HANDLER=None
-_FILE_HANDLER=None
-_APP_NAME_FOR_DEFAULT_FORMAT=os.path.split(sys.argv[0])[-1]
+# ------------------------------- Private --------------------------------
 
-def _set_file_logging(filename): 
+# evil global
+_LOGGER = None
+_FILENAME = None
+_DEFAULT_FORMATTER = None
+_LITERAL_FORMATTER = None
+_SOUT_HANDLER = None
+_FILE_HANDLER = None
+_APP_NAME_FOR_DEFAULT_FORMAT = os.path.split(sys.argv[0])[-1]
+
+
+def _set_file_logging(filename):
     """
     Establishes a file output HANDLER for the default formatter.
     
     NOTE: internal use only
     """
     global _LOGGER, _SOUT_HANDLER, _FILENAME, _FILE_HANDLER
-    _FILENAME=filename   
-    _FILE_HANDLER = EncodingFileHandler( filename, 'a')
+    _FILENAME = filename
+    _FILE_HANDLER = EncodingFileHandler(filename, 'a')
     _FILE_HANDLER.setFormatter(_get_default_formatter())
     _LOGGER.addHandler(_FILE_HANDLER)
 
@@ -228,12 +239,13 @@ def _get_default_formatter():
     global _DEFAULT_FORMATTER
     global _APP_NAME_FOR_DEFAULT_FORMAT
 
-    if _DEFAULT_FORMATTER == None:
-        formatStr = "%(asctime)s:%(programname)s:%(name)s-[%(levelname)-s]:-%(message)s"
-        appName = _APP_NAME_FOR_DEFAULT_FORMAT.replace("%", "") # to make sure we don't produce a format string
-        formatStr = formatStr.replace("%(programname)s", "%06d %s" % (os.getpid(), appName))
-        _DEFAULT_FORMATTER = logging.Formatter(formatStr,"%Y%m%d:%H:%M:%S")
+    if _DEFAULT_FORMATTER is None:
+        format_str = "%(asctime)s:%(programname)s:%(name)s-[%(levelname)-s]:-%(message)s"
+        appName = _APP_NAME_FOR_DEFAULT_FORMAT.replace("%", "")  # to make sure we don't produce a format string
+        format_str = format_str.replace("%(programname)s", "%06d %s" % (os.getpid(), appName))
+        _DEFAULT_FORMATTER = logging.Formatter(format_str, "%Y%m%d:%H:%M:%S")
     return _DEFAULT_FORMATTER
+
 
 def _get_literal_formatter():
     """
@@ -245,11 +257,12 @@ def _get_literal_formatter():
     NOTE: internal use only
     """
     global _LITERAL_FORMATTER
-    if _LITERAL_FORMATTER == None:
+    if _LITERAL_FORMATTER is None:
         _LITERAL_FORMATTER = logging.Formatter()
     return _LITERAL_FORMATTER
-    
-def _enable_gpadmin_logging(name,logdir=None):
+
+
+def _enable_gpadmin_logging(name, logdir=None):
     """
     Sets up the file output handler for the default logger.
       - if logdir is not specified it uses ~/gpAdminLogs
@@ -258,20 +271,20 @@ def _enable_gpadmin_logging(name,logdir=None):
     NOTE: internal use only
     """
     global _FILE_HANDLER
-        
+
     get_default_logger()
     now = datetime.date.today()
-    
+
     if logdir is None:
-        homeDir=os.path.expanduser("~")
-        gpadmin_logs_dir=homeDir + "/gpAdminLogs"
+        homeDir = os.path.expanduser("~")
+        gpadmin_logs_dir = homeDir + "/gpAdminLogs"
     else:
-        gpadmin_logs_dir=logdir
-    
+        gpadmin_logs_dir = logdir
+
     if not os.path.exists(gpadmin_logs_dir):
         os.mkdir(gpadmin_logs_dir)
-    
-    filename = "%s/%s_%s.log" % (gpadmin_logs_dir,name, now.strftime("%Y%m%d"))
+
+    filename = "%s/%s_%s.log" % (gpadmin_logs_dir, name, now.strftime("%Y%m%d"))
     _set_file_logging(filename)
 
 
@@ -279,30 +292,29 @@ class EncodingFileHandler(logging.FileHandler):
     """This handler makes sure that the encoding of the message is utf-8 before
     passing it along to the FileHandler.  This will prevent encode/decode
     errors later on."""
-    
+
     def __init__(self, filename, mode='a', encoding=None, delay=0):
         logging.FileHandler.__init__(self, filename, mode, encoding, delay)
-        
+
     def emit(self, record):
         if not isinstance(record.msg, str) and not isinstance(record.msg, unicode):
             record.msg = str(record.msg)
-        if not isinstance(record.msg, unicode): 
+        if not isinstance(record.msg, unicode):
             record.msg = unicode(record.msg, 'utf-8')
         logging.FileHandler.emit(self, record)
-            
+
+
 class EncodingStreamHandler(logging.StreamHandler):
     """This handler makes sure that the encoding of the message is utf-8 before
     passing it along to the StreamHandler.  This will prevent encode/decode
     errors later on."""
-    
+
     def __init__(self, strm=None):
         logging.StreamHandler.__init__(self, strm)
-        
+
     def emit(self, record):
         if not isinstance(record.msg, str) and not isinstance(record.msg, unicode):
             record.msg = str(record.msg)
-        if not isinstance(record.msg, unicode): 
+        if not isinstance(record.msg, unicode):
             record.msg = unicode(record.msg, 'utf-8')
         logging.StreamHandler.emit(self, record)
-
-    

--- a/gpMgmt/bin/gppylib/heapchecksum.py
+++ b/gpMgmt/bin/gppylib/heapchecksum.py
@@ -1,0 +1,103 @@
+
+from gppylib.commands.base import REMOTE, WorkerPool
+from gppylib.commands.pg import PgControlData
+
+
+class HeapChecksum:
+    """
+    check whether heap checksum is the same between master and all segments
+    """
+
+    def __init__(self, gparray, num_workers=8, logger=None):
+        self.gparray = gparray
+        self.workers = num_workers
+        self.logger = logger
+
+    def get_master_value(self):
+        """
+        can raise
+        :return: the heap checksum setting (1 or 0) for the master
+        """
+        master_gpdb = self.gparray.master
+        cmd = PgControlData(name='run pg_controldata', datadir=master_gpdb.getSegmentDataDirectory())
+        cmd.run(validateAfter=True)
+        value = cmd.get_value('Data page checksum version')
+        return value
+
+    def get_segments_checksum_settings(self):
+        """
+        :return: two lists of GpDB objects (as defined in gparray) for successes and failures,
+        where successes have successfully reported their checksum values
+        """
+        failures = []
+        successes = []
+        completed = self._get_pgcontrol_data_from_segments()
+        for pg_control_data in completed:
+            result = pg_control_data.get_results()
+            gparray_gpdb = pg_control_data.gparray_gpdb
+            if result.rc == 0:
+                try:
+                    checksum = pg_control_data.get_value('Data page checksum version')
+                    gparray_gpdb.heap_checksum = checksum
+                    successes.append(gparray_gpdb)
+                except Exception as e:
+                    failures.append(gparray_gpdb)
+                    self._logger_warn("cannot access heap checksum from pg_controldata for dbid %s "
+                                      "on host %s; got pgcontrol_data: %s and exception %s" % (
+                                          gparray_gpdb.dbid, gparray_gpdb.getSegmentHostName(),
+                                          pg_control_data, str(e)))
+            else:
+                failures.append(gparray_gpdb)
+                self._logger_warn("cannot access pg_controldata for dbid %s on host %s" % (
+                    gparray_gpdb.dbid, gparray_gpdb.getSegmentHostName()))
+
+        return successes, failures
+
+    def check_segment_consistency(self, successes):
+        """
+        :param successes: list of segments (GpDB objects) for which we successfully determined checksum setting
+        :return: lists of segments that are consistent with master and inconsistent with master, respectively,
+        along with master GpDb itself
+        """
+        master = self.get_master_value()
+        consistent = []
+        inconsistent = []
+
+        for gparray_gpdb in successes:
+            checksum = gparray_gpdb.heap_checksum
+            if checksum == master:
+                consistent.append(gparray_gpdb)
+            else:
+                inconsistent.append(gparray_gpdb)
+
+        return consistent, inconsistent, master
+
+    def are_segments_consistent(self, consistent, inconsistent):
+        """
+        :return: True if there is at least 1 segment that agrees with master and no segments that disagree
+        """
+        return len(consistent) >= 1 and len(inconsistent) == 0
+
+    # private methods #######################################
+    def _get_pgcontrol_data_from_segments(self):
+        pool = WorkerPool(numWorkers=self.workers)
+        try:
+            for seg in self.gparray.getSegmentList():  # iterate for all segments
+                for gparray_gpdb in seg.get_dbs():  # iterate for both primary and mirror
+                    cmd = PgControlData(name='run pg_controldata', datadir=gparray_gpdb.getSegmentDataDirectory(),
+                                        ctxt=REMOTE, remoteHost=gparray_gpdb.getSegmentHostName())
+                    cmd.gparray_gpdb = gparray_gpdb
+                    pool.addCommand(cmd)
+            pool.join()
+        finally:
+            # Make sure that we halt the workers or else we'll hang
+            pool.haltWork()
+            pool.joinWorkers()
+        return pool.getCompletedItems()
+
+    def _logger_warn(self, message):
+        """
+        logger: log only if a logger is provided
+        """
+        if self.logger:
+            self.logger.warn(message)

--- a/gpMgmt/bin/gppylib/test/unit/gp_unittest.py
+++ b/gpMgmt/bin/gppylib/test/unit/gp_unittest.py
@@ -1,5 +1,7 @@
 import unittest
 
+from mock import MagicMock, Mock
+
 
 class GpTestCase(unittest.TestCase):
     def __init__(self, methodName='runTest'):
@@ -17,13 +19,14 @@ class GpTestCase(unittest.TestCase):
         self.__class__.apply_patches_counter += 1
 
     def get_mock_from_apply_patch(self, mock_name):
-        ''' Return None if there is no existing object
+        """ Return None if there is no existing object
             mock name prints out the last "namespace"
             for example "os.path.exists", mock_name will be "exists"
-        '''
+        """
         for mock_obj in self.mock_objs:
-            if mock_name == mock_obj._mock_name:
-                return mock_obj
+            if isinstance(mock_obj, Mock) or isinstance(mock_obj, MagicMock):
+                if mock_name == mock_obj._mock_name:
+                    return mock_obj
         return None
 
     # if you have a tearDown() in your test class,

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gplog.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gplog.py
@@ -2,31 +2,31 @@
 #
 # Copyright (c) Greenplum Inc 2008. All Rights Reserved. 
 #
-
-""" Unittesting for gplog module
-"""
 import logging
-import unittest
 
 import gplog
+from test.unit.gp_unittest import GpTestCase, run_tests
 
-class gplogTestCase(unittest.TestCase):
-    
+
+class GplogTestCase(GpTestCase):
     def test_basics(self):
         logger = gplog.get_default_logger()
         self.assertTrue(logger is not None)
 
     def test_set_loglevels(self):
         logger = gplog.get_default_logger()
-        self.assertLogLevel(logger, logging.INFO)
+        self.assertTrue(logger.getEffectiveLevel() == logging.INFO)
         gplog.enable_verbose_logging()
-        self.assertLogLevel(logger, logging.DEBUG)        
-        
+        self.assertTrue(logger.getEffectiveLevel() == logging.DEBUG)
 
-#------------------------------- non-test helper --------------------------------
-    def assertLogLevel(self, logger, level): 
-        self.assertTrue(logger.getEffectiveLevel() == level)
+    def test_log_to_file_only_is_ok_when_not_initialized(self):
+        gplog._LOGGER = None
+        gplog.log_to_file_only("should not crash")
 
-#------------------------------- Mainline --------------------------------
+    def test_log_to_file_only_is_ok_when_stdout_not_initialized(self):
+        gplog._LOGGER = None
+        gplog.get_unittest_logger()
+        gplog.log_to_file_only("should not crash")
+
 if __name__ == '__main__':
-    unittest.main()
+    run_tests()

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpstart.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpstart.py
@@ -1,9 +1,12 @@
 import imp
+import logging
 import os
 import sys
 
-from gparray import GpDB, GpArray
 from mock import Mock, patch
+
+from gparray import GpDB, GpArray
+from gppylib.operations.startSegments import StartSegmentsResult
 from gppylib.test.unit.gp_unittest import GpTestCase, run_tests
 
 
@@ -16,11 +19,19 @@ class GpStart(GpTestCase):
         #   self.subject = gpstart
         gpstart_file = os.path.abspath(os.path.dirname(__file__) + "/../../../gpstart")
         self.subject = imp.load_source('gpstart', gpstart_file)
-        self.subject.logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal'])
+        self.subject.logger = Mock(
+            spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal', 'warning_to_file_only'])
 
-        self.gparray = self.createGpArrayWith2Primary2Mirrors()
+        self.os_environ = dict(MASTER_DATA_DIRECTORY='/tmp/mdd', GPHOME='/tmp/gphome', GP_MGMT_PROCESS_COUNT=1,
+                               LANGUAGE=None)
+        self.gparray = self._createGpArrayWith2Primary2Mirrors()
+        self.segments_by_content_id = GpArray.getSegmentsByContentId(self.gparray.getSegDbList())
+
+        start_result = StartSegmentsResult()
+        start_result.addSuccess(self.primary0)
 
         self.apply_patches([
+            patch('os.getenv', side_effect=self._get_env),
             patch('gpstart.os.path.exists'),
             patch('gpstart.gp'),
             patch('gpstart.pgconf'),
@@ -28,18 +39,40 @@ class GpStart(GpTestCase):
             patch('gpstart.dbconn.DbURL'),
             patch('gpstart.dbconn.connect'),
             patch('gpstart.GpArray.initFromCatalog', return_value=self.gparray),
-            patch('gpstart.catalog.getCollationSettings', return_value=(None, None, None)),
+            patch('gpstart.GpArray.getSegmentsByContentId', return_value=self.segments_by_content_id),
+            patch('gpstart.GpArray.getSegmentsGroupedByValue',
+                  side_effect=[{2: self.primary0, 3: self.primary1}, [], []]),
+            patch('gpstart.catalog.getCollationSettings', return_value=("x", "x", "x")),
             patch('gpstart.GpDbidFile'),
             patch('gpstart.GpEraFile'),
             patch('gpstart.userinput'),
+            patch('gpstart.HeapChecksum'),
+            patch('gpstart.log_to_file_only'),
+            patch("gpstart.is_filespace_configured", return_value=True),
+            patch("gpstart.CheckFilespaceConsistency"),
+            patch("gpstart.StartSegmentsOperation"),
+            patch("gpstart.base.WorkerPool"),
+            patch("gpstart.gp.MasterStart.local"),
+            patch("gpstart.pg.DbStatus.local"),
+            patch("gpstart.TableLogger"),
         ])
+
+        self.mockFilespaceConsistency = self.get_mock_from_apply_patch("CheckFilespaceConsistency")
+        self.mockFilespaceConsistency.return_value.run.return_value = True
+
+        self.mock_start_result = self.get_mock_from_apply_patch('StartSegmentsOperation')
+        self.mock_start_result.return_value.startSegments.return_value.getSuccessfulSegments.return_value = start_result.getSuccessfulSegments()
 
         self.mock_os_path_exists = self.get_mock_from_apply_patch('exists')
         self.mock_gp = self.get_mock_from_apply_patch('gp')
         self.mock_pgconf = self.get_mock_from_apply_patch('pgconf')
         self.mock_userinput = self.get_mock_from_apply_patch('userinput')
-
+        self.mock_heap_checksum = self.get_mock_from_apply_patch('HeapChecksum')
+        self.mock_heap_checksum.return_value.get_segments_checksum_settings.return_value = ([1], [1])
+        self.mock_heap_checksum.return_value.are_segments_consistent.return_value = True
+        self.mock_heap_checksum.return_value.check_segment_consistency.return_value = ([], [], None)
         self.mock_pgconf.readfile.return_value = Mock()
+        self.mock_gplog_log_to_file_only = self.get_mock_from_apply_patch("log_to_file_only")
 
         self.mock_gp.get_masterdatadir.return_value = 'masterdatadir'
         self.mock_gp.GpCatVersion.local.return_value = 1
@@ -48,19 +81,6 @@ class GpStart(GpTestCase):
 
     def tearDown(self):
         super(GpStart, self).tearDown()
-
-    def createGpArrayWith2Primary2Mirrors(self):
-        master = GpDB.initFromString(
-            "1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
-        primary0 = GpDB.initFromString(
-            "2|0|p|p|s|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
-        primary1 = GpDB.initFromString(
-            "3|1|p|p|s|u|sdw2|sdw2|40001|41001|/data/primary1||/data/primary1/base/10899,/data/primary1/base/1,/data/primary1/base/10898,/data/primary1/base/25780,/data/primary1/base/34782")
-        mirror0 = GpDB.initFromString(
-            "4|0|m|m|s|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
-        mirror1 = GpDB.initFromString(
-            "5|1|m|m|s|u|sdw1|sdw1|50001|51001|/data/mirror1||/data/mirror1/base/10899,/data/mirror1/base/1,/data/mirror1/base/10898,/data/mirror1/base/25780,/data/mirror1/base/34782")
-        return GpArray([master, primary0, primary1, mirror0, mirror1])
 
     def test_option_master_success_without_auto_accept(self):
         sys.argv = ["gpstart", "-m"]
@@ -98,6 +118,117 @@ class GpStart(GpTestCase):
         self.subject.logger.info.assert_any_call('Starting Master instance in admin mode')
         self.subject.logger.info.assert_any_call('Master Started...')
         self.assertEqual(return_code, 0)
+
+    def test_output_to_stdout_and_log_for_master_only_happens_before_heap_checksum(self):
+        sys.argv = ["gpstart", "-m"]
+        self.mock_userinput.ask_yesno.return_value = True
+        self.subject.unix.PgPortIsActive.local.return_value = False
+        self.mock_os_path_exists.side_effect = os_exists_check
+        parser = self.subject.GpStart.createParser()
+        options, args = parser.parse_args()
+        gpstart = self.subject.GpStart.createProgram(options, args)
+
+        return_code = gpstart.run()
+
+        self.assertEqual(return_code, 0)
+        self.assertEqual(self.mock_userinput.ask_yesno.call_count, 1)
+        self.mock_userinput.ask_yesno.assert_called_once_with(None, '\nContinue with master-only startup', 'N')
+        self.subject.logger.info.assert_any_call('Starting Master instance in admin mode')
+        self.subject.logger.info.assert_any_call('Master Started...')
+
+        self.assertEquals(self.mock_gplog_log_to_file_only.call_count, 0)
+
+    def test_output_to_stdout_and_log_differs_for_heap_checksum(self):
+        sys.argv = ["gpstart", "-a"]
+        self.mock_heap_checksum.return_value.are_segments_consistent.return_value = False
+        self.subject.unix.PgPortIsActive.local.return_value = False
+        self.mock_os_path_exists.side_effect = os_exists_check
+        self.primary1.heap_checksum = 0
+        self.master.heap_checksum = '1'
+        self.mock_heap_checksum.return_value.check_segment_consistency.return_value = (
+            [self.primary0], [self.primary1], self.master.heap_checksum)
+        parser = self.subject.GpStart.createParser()
+        options, args = parser.parse_args()
+        gpstart = self.subject.GpStart.createProgram(options, args)
+
+        return_code = gpstart.run()
+
+        self.assertEqual(return_code, 1)
+
+        self.subject.logger.fatal.assert_any_call('Cluster heap checksum setting differences reported.')
+        self.mock_gplog_log_to_file_only.assert_any_call('Failed checksum consistency validation:', logging.WARN)
+        self.mock_gplog_log_to_file_only.assert_any_call('dbid: %s '
+                                                         'checksum set to %s differs from '
+                                                         'master checksum set to %s' %
+                                                         (self.primary1.getSegmentDbId(), 0, 1), logging.WARN)
+        self.subject.logger.fatal.assert_any_call("Shutting down master")
+        self.assertEquals(self.mock_gp.GpStop.call_count, 1)
+
+    def test_failed_to_contact_segments_causes_logging_and_failure(self):
+        sys.argv = ["gpstart", "-a"]
+        self.mock_heap_checksum.return_value.get_segments_checksum_settings.return_value = ([], [1])
+        self.subject.unix.PgPortIsActive.local.return_value = False
+        self.mock_os_path_exists.side_effect = os_exists_check
+        parser = self.subject.GpStart.createParser()
+        options, args = parser.parse_args()
+        gpstart = self.subject.GpStart.createProgram(options, args)
+
+        return_code = gpstart.run()
+
+        self.assertEqual(return_code, 1)
+        self.subject.logger.fatal.assert_any_call(
+            'No segments responded to ssh query for heap checksum. Not starting the array.')
+
+    def test_checksum_consistent(self):
+        sys.argv = ["gpstart", "-a"]
+        self.mock_heap_checksum.return_value.get_segments_checksum_settings.return_value = ([1], [1])
+        self.subject.unix.PgPortIsActive.local.return_value = False
+        self.mock_os_path_exists.side_effect = os_exists_check
+        parser = self.subject.GpStart.createParser()
+        options, args = parser.parse_args()
+        gpstart = self.subject.GpStart.createProgram(options, args)
+
+        return_code = gpstart.run()
+
+        self.assertEqual(return_code, 0)
+
+        self.subject.logger.info.assert_any_call('Heap checksum setting is consistent across the cluster')
+
+    def test_skip_checksum_validation_succeeds(self):
+        sys.argv = ["gpstart", "-a", "--skip-heap-checksum-validation"]
+        self.mock_heap_checksum.return_value.get_segments_checksum_settings.return_value = ([1], [1])
+        self.subject.unix.PgPortIsActive.local.return_value = False
+        self.mock_os_path_exists.side_effect = os_exists_check
+        parser = self.subject.GpStart.createParser()
+        options, args = parser.parse_args()
+        gpstart = self.subject.GpStart.createProgram(options, args)
+
+        return_code = gpstart.run()
+
+        self.assertEqual(return_code, 0)
+        messages = [msg[0][0] for msg in self.subject.logger.info.call_args_list]
+        self.assertNotIn('Heap checksum setting is consistent across the cluster', messages)
+        self.subject.logger.warning.assert_any_call('Because of --skip-heap-checksum-validation, '
+                                                    'the GUC for data_checksums '
+                                                    'will not be checked between master and segments')
+
+    def _createGpArrayWith2Primary2Mirrors(self):
+        self.master = GpDB.initFromString(
+            "1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
+        self.primary0 = GpDB.initFromString(
+            "2|0|p|p|s|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
+        self.primary1 = GpDB.initFromString(
+            "3|1|p|p|s|u|sdw2|sdw2|40001|41001|/data/primary1||/data/primary1/base/10899,/data/primary1/base/1,/data/primary1/base/10898,/data/primary1/base/25780,/data/primary1/base/34782")
+        self.mirror0 = GpDB.initFromString(
+            "4|0|m|m|s|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
+        self.mirror1 = GpDB.initFromString(
+            "5|1|m|m|s|u|sdw1|sdw1|50001|51001|/data/mirror1||/data/mirror1/base/10899,/data/mirror1/base/1,/data/mirror1/base/10898,/data/mirror1/base/25780,/data/mirror1/base/34782")
+        return GpArray([self.master, self.primary0, self.primary1, self.mirror0, self.mirror1])
+
+    def _get_env(self, arg):
+        if arg not in self.os_environ:
+            return None
+        return self.os_environ[arg]
 
 
 def os_exists_check(arg):

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_heapchecksum.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_heapchecksum.py
@@ -1,0 +1,145 @@
+from mock import Mock, patch
+
+from gparray import GpDB, GpArray
+from gppylib.commands.base import CommandResult
+from gppylib.heapchecksum import HeapChecksum
+from gppylib.test.unit.gp_unittest import GpTestCase
+
+
+class GpHeapChecksumTestCase(GpTestCase):
+    def setUp(self):
+        self.gparray = self.createGpArrayWith2Primary2Mirrors()
+        self.subject = HeapChecksum(self.gparray)
+        self.subject.logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal'])
+
+        self.COMMAND_RESULT = """
+pg_control version number:            8330500
+Catalog version number:               301705051
+Database system identifier:           6450200148836071422
+Database cluster state:               in production
+pg_control last modified:             Thu Aug  3 16:56:40 2017
+Latest checkpoint location:           0/4A7CE98
+Prior checkpoint location:            0/4A7C908
+Latest checkpoint's REDO location:    0/4A7CE98
+Latest checkpoint's TimeLineID:       1
+Latest checkpoint's NextXID:          0/704
+Latest checkpoint's NextOID:          12088
+Latest checkpoint's NextRelfilenode:  16384
+Latest checkpoint's NextMultiXactId:  1
+Latest checkpoint's NextMultiOffset:  0
+Time of latest checkpoint:            Thu Aug  3 16:56:39 2017
+Minimum recovery ending location:     0/0
+Backup start location:                0/0
+End-of-backup record required:        no
+Maximum data alignment:               8
+Database block size:                  32768
+Blocks per segment of large relation: 32768
+WAL block size:                       32768
+Bytes per WAL segment:                67108864
+Maximum length of identifiers:        64
+Maximum columns in an index:          32
+Maximum size of a TOAST chunk:        8140
+Date/time type storage:               64-bit integers
+Maximum length of locale name:        128
+LC_COLLATE:                           en_US.utf-8
+LC_CTYPE:                             en_US.utf-8
+Data page checksum version:           1
+"""
+
+        self.apply_patches([
+            patch('gppylib.heapchecksum.WorkerPool'),
+            patch('gppylib.heapchecksum.PgControlData.run'),
+            patch('gppylib.heapchecksum.PgControlData.get_value'),
+        ])
+        self.mock_workerpool = self.get_mock_from_apply_patch('WorkerPool')
+        self.mock_pg_control_data_get_value = self.get_mock_from_apply_patch('get_value')
+        self.mock_pg_control_data_get_value.return_value = '1'  # master checksum value
+
+        self.data_dirs = ['/master', '/seg0', '/seg1', '/seg2']
+        # rc,stdout,stderr,completed,halt
+        self.results = [CommandResult(0, self.COMMAND_RESULT, '', False, True),
+                        CommandResult(0, self.COMMAND_RESULT, '', False, True),
+                        CommandResult(0, self.COMMAND_RESULT, '', False, True),
+                        CommandResult(0, self.COMMAND_RESULT, '', False, True)]
+        self.assertEquals(len(self.data_dirs), len(self.results))
+
+    def tearDown(self):
+        super(GpHeapChecksumTestCase, self).tearDown()
+
+    def createGpArrayWith2Primary2Mirrors(self):
+        master = GpDB.initFromString(
+            "1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
+        primary0 = GpDB.initFromString(
+            "2|0|p|p|s|u|aspen|sdw1|40000|41000|/Users/pivotal/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
+        primary1 = GpDB.initFromString(
+            "3|1|p|p|s|u|sdw2|sdw2|40001|41001|/data/primary1||/data/primary1/base/10899,/data/primary1/base/1,/data/primary1/base/10898,/data/primary1/base/25780,/data/primary1/base/34782")
+        mirror0 = GpDB.initFromString(
+            "4|0|m|m|s|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
+        mirror1 = GpDB.initFromString(
+            "5|1|m|m|s|u|sdw1|sdw1|50001|51001|/data/mirror1||/data/mirror1/base/10899,/data/mirror1/base/1,/data/mirror1/base/10898,/data/mirror1/base/25780,/data/mirror1/base/34782")
+        return GpArray([master, primary0, primary1, mirror0, mirror1])
+
+    def test_consistent_heap_checksum_returns_true(self):
+        get_values = ['1', '1', '1', '1']
+        self.setup_worker_pool(get_values)
+
+        successes, failures = self.subject.get_segments_checksum_settings()
+        consistent, inconsistent, master_checksum = self.subject.check_segment_consistency(successes)
+        self.assertEquals(self.subject.are_segments_consistent(consistent, inconsistent), True)
+
+    def test_inconsistent_heap_checksum_returns_false(self):
+        get_values = ['0', '1', '1', '1']
+        self.setup_worker_pool(get_values)
+
+        successes, failures = self.subject.get_segments_checksum_settings()
+        consistent, inconsistent, master_checksum = self.subject.check_segment_consistency(successes)
+        self.assertEquals(self.subject.are_segments_consistent(consistent, inconsistent), False)
+
+    def test_pg_control_data_raises(self):
+        get_values = ['1', '1', '1', Exception("hi")]
+        mocks = [Mock() for _ in range(len(self.results))]
+
+        for i, mock in enumerate(mocks):
+            mock.get_results.side_effect = [self.results[i]]
+            mock.datadir = self.data_dirs[i]
+            mock.get_value.side_effect = [get_values[i]]
+        self.mock_workerpool.return_value.getCompletedItems.return_value = mocks
+
+        successes, failures = self.subject.get_segments_checksum_settings()
+        consistent, inconsistent, master_checksum = self.subject.check_segment_consistency(successes)
+        self.assertEquals(self.subject.are_segments_consistent(consistent, inconsistent), True)
+
+    def test_pg_control_data_raises_every_segment(self):
+        get_values = [Exception("hi"), Exception("hi"), Exception("hi"), Exception("hi")]
+        mocks = [Mock() for _ in range(len(self.results))]
+
+        for i, mock in enumerate(mocks):
+            mock.get_results.side_effect = [self.results[i]]
+            mock.datadir = self.data_dirs[i]
+            mock.get_value.side_effect = [get_values[i]]
+        self.mock_workerpool.return_value.getCompletedItems.return_value = mocks
+
+        successes, failures = self.subject.get_segments_checksum_settings()
+        consistent, inconsistent, master_checksum = self.subject.check_segment_consistency(successes)
+        self.assertEquals(self.subject.are_segments_consistent(consistent, inconsistent), False)
+
+    def test_are_segments_consistent_zero_consistent_zero_inconsistent(self):
+        self.assertFalse(self.subject.are_segments_consistent([], []))
+
+    def test_are_segments_consistent_zero_consistent_one_inconsistent(self):
+        self.assertFalse(self.subject.are_segments_consistent([], [1]))
+
+    def test_are_segments_consistent_one_consistent_zero_inconsistent(self):
+        self.assertTrue(self.subject.are_segments_consistent([1], []))
+
+    def test_are_segments_consistent_one_consistent_one_inconsistent(self):
+        self.assertFalse(self.subject.are_segments_consistent([1], [1]))
+
+    # ****************** tools ************************
+    def setup_worker_pool(self, values):
+        mocks = [Mock() for _ in range(len(self.results))]
+        for i, mock in enumerate(mocks):
+            mock.get_results.return_value = self.results[i]
+            mock.datadir = self.data_dirs[i]
+            mock.get_value.return_value = values[i]
+        self.mock_workerpool.return_value.getCompletedItems.return_value = mocks

--- a/gpMgmt/bin/gppylib/util/test/test_logging.py
+++ b/gpMgmt/bin/gppylib/util/test/test_logging.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+"""
+test script to provide gplog.feature (behave) test with logging samples.
+"""
+import logging
+
+from gppylib import gplog
+
+logger = gplog.get_default_logger()
+gplog.setup_tool_logging("test_logging", "localhost", "gpadmin")
+logger.warning("foobar to stdout and file")
+gplog.log_to_file_only("blah to file only, not to stdout", logging.WARN)
+gplog.log_to_file_only("another to file only, not to stdout")

--- a/gpMgmt/bin/gpstart
+++ b/gpMgmt/bin/gpstart
@@ -6,12 +6,10 @@
 # THIS IMPORT MUST COME FIRST
 #
 # import mainUtils FIRST to get python version check
+import sys
+from optparse import OptionGroup, SUPPRESS_HELP
+
 from gppylib.mainUtils import *
-
-import os, sys, copy, time
-
-import time
-from optparse import Option, OptionGroup, OptionParser, OptionValueError, SUPPRESS_USAGE, SUPPRESS_HELP
 
 try:
     import pickle
@@ -19,7 +17,7 @@ try:
     from gppylib.db import dbconn
     from gppylib.gpparseopts import OptParser, OptChecker
     from gppylib.gparray import *
-    from gppylib.gplog import *
+    from gppylib.gplog import get_default_logger, log_to_file_only
     from gppylib import gphostcache
     from gppylib import userinput
     from gppylib.db import catalog
@@ -30,6 +28,7 @@ try:
     from gppylib.commands import pg
     from gppylib.commands import dca
     from gppylib import pgconf
+    from gppylib.heapchecksum import HeapChecksum
     from gppylib.commands.pg import PgControlData
     from gppylib.operations.startSegments import *
     from gppylib.utils import TableLogger
@@ -55,7 +54,8 @@ class GpStart:
                  masteronly=False,
                  interactive=False,
                  timeout=SEGMENT_TIMEOUT_DEFAULT,
-                 logfileDirectory=False
+                 logfileDirectory=False,
+                 skip_heap_checksum_validation=False,
                  ):
         assert (specialMode in [None, 'maintenance'])
         self.specialMode = specialMode
@@ -69,10 +69,11 @@ class GpStart:
         self.master_datadir = master_datadir
         self.interactive = interactive
         self.timeout = timeout
-        self.wrapper = wrapper;
-        self.wrapper_args = wrapper_args;
-        self.skip_standby_check = skip_standby_check;
+        self.wrapper = wrapper
+        self.wrapper_args = wrapper_args
+        self.skip_standby_check = skip_standby_check
         self.logfileDirectory = logfileDirectory
+        self.skip_heap_checksum_validation = skip_heap_checksum_validation
 
         #
         # Some variables that are set during execution
@@ -121,6 +122,44 @@ class GpStart:
 
             if self.masteronly:
                 return 0
+
+            if self.skip_heap_checksum_validation:
+                logger.warning("Because of --skip-heap-checksum-validation, the GUC for data_checksums "
+                               "will not be checked between master and segments")
+            else:
+                # check that checksum settings are consistent across the cluster
+                num_workers = min(len(self.gparray.get_hostlist()), self.parallel)
+                heap_checksum = HeapChecksum(gparray=self.gparray, num_workers=num_workers, logger=logger)
+                successes, failures = heap_checksum.get_segments_checksum_settings()
+                if len(successes) == 0:
+                    logger.fatal("No segments responded to ssh query for heap checksum. Not starting the array.")
+                    return 1
+
+                consistent, inconsistent, master_checksum_value = heap_checksum.check_segment_consistency(successes)
+
+                if not heap_checksum.are_segments_consistent(consistent, inconsistent):
+                    logger.fatal("Cluster heap checksum setting differences reported.")
+                    logger.fatal("Shutting down master")
+                    cmd = gp.GpStop("Shutting down master", masterOnly=True,
+                                    fast=True, quiet=logging_is_quiet(),
+                                    verbose=logging_is_verbose(),
+                                    datadir=self.master_datadir,
+                                    logfileDirectory=self.logfileDirectory)
+                    cmd.run()
+
+                    logger.fatal("Heap checksum settings on %d of %d segment instances do not match master <<<<<<<<"
+                                 % (len(inconsistent), len(inconsistent) + len(consistent)))
+                    logger.fatal("Review %s for details" % get_logfile())
+                    log_to_file_only("Failed checksum consistency validation:", logging.WARN)
+                    for gpdb in inconsistent:
+                        segment_id = gpdb.getSegmentDbId()
+                        checksum = gpdb.heap_checksum
+                        log_to_file_only("dbid: %s "
+                                         "checksum set to %s differs from master checksum set to %s" %
+                                         (segment_id, checksum, master_checksum_value), logging.WARN)
+
+                    return 1
+                logger.info("Heap checksum setting is consistent across the cluster")
 
             # Do we have an even-number of recovered segments ?
             if len(self.gparray.recoveredSegmentDbids) > 0 and len(self.gparray.recoveredSegmentDbids) % 2 == 0:
@@ -394,7 +433,7 @@ class GpStart:
                              numContentsInCluster, self.era,
                              wrapper=self.wrapper, wrapper_args=self.wrapper_args,
                              specialMode=self.specialMode, timeout=self.timeout, utilityMode=True
-                             );
+                             )
         cmd.run()
 
         if cmd.get_results().rc != 0:
@@ -649,7 +688,7 @@ class GpStart:
             assert failedFromMirroring == 0
             tableLog.infoOrWarn(failedNotFromMirroring > 0, ["Failed segment starts", "= %d" % failedNotFromMirroring])
 
-        tableLog.infoOrWarn(len(invalidSegments) > 0, \
+        tableLog.infoOrWarn(len(invalidSegments) > 0,
                             ["Skipped segment starts (segments are marked down in configuration)",
                              "= %d" % len(invalidSegments)])
         tableLog.addSeparator()
@@ -706,14 +745,14 @@ class GpStart:
 
     ######
     def _start_final_master(self):
-        ''' Last item in the startup sequence is to start the master.
+        """ Last item in the startup sequence is to start the master.
 
             After starting the master we connect to it.  This is done both as a check that the system is
             actually started but its also done because certain backend processes don't get kickstarted
             until the first connection.  The DTM is an example of this and it allows those initialization
             messages to end up in the gpstart log as opposed to the user's psql session.
             Returns a tuple of (result[bool], message[string])
-        '''
+        """
         restrict_txt = ""
         if self.restricted:
             restrict_txt = "in RESTRICTED mode"
@@ -767,10 +806,10 @@ class GpStart:
 
     ######
     def _start_standby(self):
-        ''' used to start the standbymaster if necessary.
+        """ used to start the standbymaster if necessary.
 
             returns if the standby master was started or not
-        '''
+        """
         if self.start_standby and self.gparray.standbyMaster is not None:
             try:
                 self.attempt_standby_start = True
@@ -819,9 +858,13 @@ class GpStart:
                          help='start in restricted mode. Only users with superuser privilege are allowed to connect.')
         addTo.add_option('-t', '--timeout', dest='timeout', default=SEGMENT_TIMEOUT_DEFAULT, type='int',
                          help='time to wait for segment startup (in seconds)')
-        addTo.add_option('', '--wrapper', dest="wrapper", default=None, type='string');
-        addTo.add_option('', '--wrapper-args', dest="wrapper_args", default=None, type='string');
+        addTo.add_option('', '--wrapper', dest="wrapper", default=None, type='string')
+        addTo.add_option('', '--wrapper-args', dest="wrapper_args", default=None, type='string')
         addTo.add_option('-S', '--skip_standby_check', dest="skip_standby_check", action='store_true', default=False)
+        addTo.add_option('--skip-heap-checksum-validation', dest='skip_heap_checksum_validation',
+                         action='store_true', default=False, help='Skip the validation of data_checksums GUC. '
+                                                                  'Note: Starting up the cluster without this '
+                                                                  'validation could lead to data loss.')
 
         parser.set_defaults(verbose=False, filters=[], slice=(None, None))
 
@@ -853,7 +896,9 @@ class GpStart:
                        wrapper=options.wrapper,
                        wrapper_args=options.wrapper_args,
                        skip_standby_check=options.skip_standby_check,
-                       logfileDirectory=logfileDirectory)
+                       logfileDirectory=logfileDirectory,
+                       skip_heap_checksum_validation=options.skip_heap_checksum_validation
+                       )
 
 
 if __name__ == '__main__':

--- a/gpMgmt/test/behave/mgmt_utils/gplog.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gplog.feature
@@ -1,0 +1,16 @@
+@gplog
+Feature: Test gplog
+    """
+    use a behave test for logging verification because unit tests rigs are fussy about mocking stdout
+    """
+    Scenario: logging to stdout works
+        Given gpAdminLogs directory has no "test_logging" files
+        Given "bin/gppylib/util/test/test_logging.py" is copied to the install directory
+        When the user runs "test_logging.py"
+        Then test_logging should return a return code of 0
+        And test_logging should print "foobar to stdout and file" to stdout
+        And test_logging should print "foobar to stdout and file" to logfile
+        And test_logging should not print "blah to file only, not to stdout" to stdout
+        And test_logging should print "[WARNING]:-foobar to stdout and file" to logfile
+        And test_logging should not print "another to file only, not to stdout" to stdout
+        And test_logging should print "[INFO]:-another to file only, not to stdout" to logfile

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -3179,11 +3179,11 @@ def impl(context, directory, prefix):
     results = cmd.get_stdout().split('\n')
 
     if len(results) == 0:
-        raise Exception('Failed to find dump files %s on the master under %s' % (results, master_dump_dir))
+        raise Exception('Failed to find dump files %s on the master under %s' % (results, dump_dir))
     for filename in results:
         if not os.path.basename(filename).startswith(prefix.strip()):
             raise Exception('Dump file %s on master under %s does not have required prefix %s' % (
-            filename, master_dump_dir, prefix))
+            filename, dump_dir, prefix))
 
 
 @given('the environment variable "{var}" is not set')


### PR DESCRIPTION
- Make sure checksum settings for all segments are same as master; refuse to start if inconsistent, or all segments unreachable.
- Add logging function to allow user to log to file with different messages than stdout 

Edited:
- validate consistent checksum settings
    - Make sure checksum settings for all segments are same as master
    - Add logging proxy to allow logging to file to have different contents
      than stdout
    - Do heap checksum only for when starting up all segments.

- Add option --skip-heap-checksum-validation
    - If this option is provided to gpstart, the cluster will start up without
      checking for matching "data_checksums" GUC between master and segments.

