### PR TITLE
AO, CO and PT should have relfrozenxid as InvalidTransactionId.

### DIFF
--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -1528,7 +1528,17 @@ setNewRelfilenode(Relation relation, TransactionId freezeXid)
 	rd_rel->relfilenode = newrelfilenode;
 	rd_rel->relpages = 0;		/* it's empty until further notice */
 	rd_rel->reltuples = 0;
-	rd_rel->relfrozenxid = freezeXid;
+	if (should_have_valid_relfrozenxid(HeapTupleGetOid(tuple),
+									   rd_rel->relkind,
+									   rd_rel->relstorage))
+	{
+		rd_rel->relfrozenxid = freezeXid;
+	}
+	else
+	{
+		rd_rel->relfrozenxid = InvalidTransactionId;
+	}
+
 	simple_heap_update(pg_class, &tuple->t_self, tuple);
 	CatalogUpdateIndexes(pg_class, tuple);
 

--- a/src/backend/rewrite/rewriteSupport.c
+++ b/src/backend/rewrite/rewriteSupport.c
@@ -22,7 +22,7 @@
 #include "utils/inval.h"
 #include "utils/lsyscache.h"
 #include "utils/syscache.h"
-
+#include "access/transam.h"
 
 /*
  * SetRelationRuleStatus
@@ -65,6 +65,7 @@ SetRelationRuleStatus(Oid relationId, bool relHasRules,
 		{
 			classForm->relkind = RELKIND_VIEW;
 			classForm->relstorage = RELSTORAGE_VIRTUAL;
+			classForm->relfrozenxid = InvalidTransactionId;
 		}
 
 		simple_heap_update(relationRelation, &tuple->t_self, tuple);

--- a/src/include/catalog/heap.h
+++ b/src/include/catalog/heap.h
@@ -150,5 +150,5 @@ extern void MetaTrackDropObject(Oid		classid,
 		|| ((relkind) == RELKIND_VIEW)) 
 
 extern void remove_gp_relation_node_and_schedule_drop(Relation rel);
-
+extern bool should_have_valid_relfrozenxid(Oid oid, char relkind, char relstorage);
 #endif   /* HEAP_H */

--- a/src/test/isolation2/input/uao/vacuum_cleanup.source
+++ b/src/test/isolation2/input/uao/vacuum_cleanup.source
@@ -23,13 +23,13 @@ CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 
 1: set vacuum_freeze_min_age = 0;
 -- Check the age of the table just before vacuum
-1: select age(relfrozenxid) from gp_dist_random('pg_class') where relname = 'ao_@orientation@_vacuum_cleanup2' and gp_segment_id = 0;
+1: select age(relfrozenxid), regexp_replace(replace(relname, 'ao_@orientation@_vacuum_cleanup2'::regclass::oid::text, '<oid>'), 'ao.*seg', '<seg>') from gp_dist_random('pg_class') where relkind in ('r','t','o','b','m') and relstorage not in ('x','f','v') and (relname like '%' || 'ao_@orientation@_vacuum_cleanup2'::regclass::oid || '%') and gp_segment_id = 0;
 1: vacuum ao_@orientation@_vacuum_cleanup2;
 
 -- We expect the age to be 3. This is because all the xids before the first
 -- vacuum will be frozen. The relfrozenxid will be the xid of the last
 -- transaction before the vacuum (in this case it is the update statement)
-1: select age(relfrozenxid) from gp_dist_random('pg_class') where relname = 'ao_@orientation@_vacuum_cleanup2' and gp_segment_id = 0;
+1: select age(relfrozenxid), regexp_replace(replace(relname, 'ao_@orientation@_vacuum_cleanup2'::regclass::oid::text, '<oid>'), 'ao.*seg', '<seg>') from gp_dist_random('pg_class') where relkind in ('r','t','o','b','m') and relstorage not in ('x','f','v') and (relname like '%' || 'ao_@orientation@_vacuum_cleanup2'::regclass::oid || '%') and gp_segment_id = 0;
 
 1: select gp_inject_fault('vacuum_relation_open_relation_during_drop_phase', 'reset', 2);
 2<:
@@ -43,7 +43,7 @@ CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 
 -- Check the age of the table before vacuum to make sure that clean phase gets
 -- performed
-1: select age(relfrozenxid) from gp_dist_random('pg_class') where relname = 'ao_@orientation@_vacuum_cleanup3' and gp_segment_id = 0;
+1: select age(relfrozenxid), regexp_replace(replace(relname, 'ao_@orientation@_vacuum_cleanup3'::regclass::oid::text, '<oid>'), 'ao.*seg', '<seg>') from gp_dist_random('pg_class') where relkind in ('r','t','o','b','m') and relstorage not in ('x','f','v') and (relname like '%' || 'ao_@orientation@_vacuum_cleanup3'::regclass::oid || '%') and gp_segment_id = 0;
 1: select gp_inject_fault('vacuum_relation_open_relation_during_drop_phase', 'suspend', 1);
 1&: vacuum ao_@orientation@_vacuum_cleanup3;
 
@@ -55,7 +55,7 @@ CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 2: select gp_inject_fault('vacuum_relation_open_relation_during_drop_phase', 'reset', 1);
 
 1<:
-1: select age(relfrozenxid) from gp_dist_random('pg_class') where relname = 'ao_@orientation@_vacuum_cleanup3' and gp_segment_id = 0;
+1: select age(relfrozenxid), regexp_replace(replace(relname, 'ao_@orientation@_vacuum_cleanup3'::regclass::oid::text, '<oid>'), 'ao.*seg', '<seg>') from gp_dist_random('pg_class') where relkind in ('r','t','o','b','m') and relstorage not in ('x','f','v') and (relname like '%' || 'ao_@orientation@_vacuum_cleanup3'::regclass::oid || '%') and gp_segment_id = 0;
 
 -- Validate that the drop phase was skipped. segfile 1 should be in state 2
 -- (AWAITING_DROP)

--- a/src/test/isolation2/output/uao/vacuum_cleanup.source
+++ b/src/test/isolation2/output/uao/vacuum_cleanup.source
@@ -39,22 +39,24 @@ t
 1: set vacuum_freeze_min_age = 0;
 SET
 -- Check the age of the table just before vacuum
-1: select age(relfrozenxid) from gp_dist_random('pg_class') where relname = 'ao_@orientation@_vacuum_cleanup2' and gp_segment_id = 0;
-age
----
-5  
-(1 row)
+1: select age(relfrozenxid), regexp_replace(replace(relname, 'ao_@orientation@_vacuum_cleanup2'::regclass::oid::text, '<oid>'), 'ao.*seg', '<seg>') from gp_dist_random('pg_class') where relkind in ('r','t','o','b','m') and relstorage not in ('x','f','v') and (relname like '%' || 'ao_@orientation@_vacuum_cleanup2'::regclass::oid || '%') and gp_segment_id = 0;
+age|regexp_replace    
+---+------------------
+5  |pg_<seg>_<oid>    
+5  |pg_aovisimap_<oid>
+(2 rows)
 1: vacuum ao_@orientation@_vacuum_cleanup2;
 VACUUM
 
 -- We expect the age to be 3. This is because all the xids before the first
 -- vacuum will be frozen. The relfrozenxid will be the xid of the last
 -- transaction before the vacuum (in this case it is the update statement)
-1: select age(relfrozenxid) from gp_dist_random('pg_class') where relname = 'ao_@orientation@_vacuum_cleanup2' and gp_segment_id = 0;
-age
----
-3  
-(1 row)
+1: select age(relfrozenxid), regexp_replace(replace(relname, 'ao_@orientation@_vacuum_cleanup2'::regclass::oid::text, '<oid>'), 'ao.*seg', '<seg>') from gp_dist_random('pg_class') where relkind in ('r','t','o','b','m') and relstorage not in ('x','f','v') and (relname like '%' || 'ao_@orientation@_vacuum_cleanup2'::regclass::oid || '%') and gp_segment_id = 0;
+age|regexp_replace    
+---+------------------
+3  |pg_<seg>_<oid>    
+3  |pg_aovisimap_<oid>
+(2 rows)
 
 1: select gp_inject_fault('vacuum_relation_open_relation_during_drop_phase', 'reset', 2);
 gp_inject_fault
@@ -76,11 +78,12 @@ DELETE 100
 
 -- Check the age of the table before vacuum to make sure that clean phase gets
 -- performed
-1: select age(relfrozenxid) from gp_dist_random('pg_class') where relname = 'ao_@orientation@_vacuum_cleanup3' and gp_segment_id = 0;
-age
----
-3  
-(1 row)
+1: select age(relfrozenxid), regexp_replace(replace(relname, 'ao_@orientation@_vacuum_cleanup3'::regclass::oid::text, '<oid>'), 'ao.*seg', '<seg>') from gp_dist_random('pg_class') where relkind in ('r','t','o','b','m') and relstorage not in ('x','f','v') and (relname like '%' || 'ao_@orientation@_vacuum_cleanup3'::regclass::oid || '%') and gp_segment_id = 0;
+age|regexp_replace    
+---+------------------
+3  |pg_<seg>_<oid>    
+3  |pg_aovisimap_<oid>
+(2 rows)
 1: select gp_inject_fault('vacuum_relation_open_relation_during_drop_phase', 'suspend', 1);
 gp_inject_fault
 ---------------
@@ -110,11 +113,12 @@ t
 
 1<:  <... completed>
 VACUUM
-1: select age(relfrozenxid) from gp_dist_random('pg_class') where relname = 'ao_@orientation@_vacuum_cleanup3' and gp_segment_id = 0;
-age
----
-1  
-(1 row)
+1: select age(relfrozenxid), regexp_replace(replace(relname, 'ao_@orientation@_vacuum_cleanup3'::regclass::oid::text, '<oid>'), 'ao.*seg', '<seg>') from gp_dist_random('pg_class') where relkind in ('r','t','o','b','m') and relstorage not in ('x','f','v') and (relname like '%' || 'ao_@orientation@_vacuum_cleanup3'::regclass::oid || '%') and gp_segment_id = 0;
+age|regexp_replace    
+---+------------------
+1  |pg_<seg>_<oid>    
+1  |pg_aovisimap_<oid>
+(2 rows)
 
 -- Validate that the drop phase was skipped. segfile 1 should be in state 2
 -- (AWAITING_DROP)

--- a/src/test/regress/expected/freeze_aux_tables.out
+++ b/src/test/regress/expected/freeze_aux_tables.out
@@ -26,8 +26,9 @@ CREATE FUNCTION classify_age(age integer) RETURNS text AS $$
 	      ELSE 'old' END; -- not frozen
 $$ LANGUAGE SQL IMMUTABLE STRICT;
 CREATE TYPE rel_ages AS (segid integer, relname text, age integer);
--- Get age(relfrozenxid) of a table, and all its auxiliary tables. On
--- master, and on all segments.
+-- Get age(relfrozenxid) of a table, and all its auxiliary tables. On master,
+-- and on all segments. For AO and CO table relfrozenxid = 0 and should stay
+-- 0. So, essentially base AO / CO tables should not show-up in the results.
 CREATE OR REPLACE FUNCTION aux_rel_ages(testrelid regclass) RETURNS SETOF rel_ages as
 $$
 declare
@@ -37,6 +38,7 @@ begin
     from pg_class
     where relkind in ('r','t','o','b','m') and relstorage not in ('x','f','v')
     and (relname like '%' || testrelid::oid || '%' or oid = testrelid::oid )
+    and not relfrozenxid = 0
   loop
     return next rec;
   end loop;
@@ -45,6 +47,7 @@ begin
     from gp_dist_random('pg_class')
     where relkind in ('r','t','o','b','m') and relstorage not in ('x','f','v')
     and (relname like '%' || testrelid::oid || '%' or oid = testrelid::oid )
+    and not relfrozenxid = 0
   loop
     return next rec;
   end loop;
@@ -106,70 +109,62 @@ group by segid = -1, relname, classify_age(age);
  is_master |          relname           | classify_age 
 -----------+----------------------------+--------------
  f         | pg_toast_<oid>             | old
+ t         | test_table_heap_with_toast | very young
  f         | test_table_heap_with_toast | old
  t         | pg_toast_<oid>             | very young
- t         | test_table_heap_with_toast | very young
 (4 rows)
 
 select segid = -1 as is_master, relname, classify_age(age) from aux_rel_ages('test_table_ao')
 group by segid = -1, relname, classify_age(age);
  is_master |      relname       | classify_age 
 -----------+--------------------+--------------
+ t         | pg_aovisimap_<oid> | very young
+ f         | pg_aovisimap_<oid> | old
  f         | pg_aoblkdir_<oid>  | old
  f         | pg_aoseg_<oid>     | old
- f         | pg_aovisimap_<oid> | old
- f         | test_table_ao      | old
- t         | pg_aoblkdir_<oid>  | very young
  t         | pg_aoseg_<oid>     | very young
- t         | pg_aovisimap_<oid> | very young
- t         | test_table_ao      | very young
-(8 rows)
+ t         | pg_aoblkdir_<oid>  | very young
+(6 rows)
 
 select segid = -1 as is_master, relname, classify_age(age) from aux_rel_ages('test_table_ao_with_toast')
 group by segid = -1, relname, classify_age(age);
- is_master |         relname          | classify_age 
------------+--------------------------+--------------
- f         | pg_aoblkdir_<oid>        | old
- f         | pg_aoseg_<oid>           | old
- f         | pg_aovisimap_<oid>       | old
- f         | pg_toast_<oid>           | old
- f         | test_table_ao_with_toast | old
- t         | pg_aoblkdir_<oid>        | very young
- t         | pg_aoseg_<oid>           | very young
- t         | pg_aovisimap_<oid>       | very young
- t         | pg_toast_<oid>           | very young
- t         | test_table_ao_with_toast | very young
-(10 rows)
+ is_master |      relname       | classify_age 
+-----------+--------------------+--------------
+ f         | pg_toast_<oid>     | old
+ t         | pg_toast_<oid>     | very young
+ t         | pg_aovisimap_<oid> | very young
+ f         | pg_aovisimap_<oid> | old
+ f         | pg_aoblkdir_<oid>  | old
+ f         | pg_aoseg_<oid>     | old
+ t         | pg_aoseg_<oid>     | very young
+ t         | pg_aoblkdir_<oid>  | very young
+(8 rows)
 
 select segid = -1 as is_master, relname, classify_age(age) from aux_rel_ages('test_table_co')
 group by segid = -1, relname, classify_age(age);
  is_master |      relname       | classify_age 
 -----------+--------------------+--------------
- f         | pg_aoblkdir_<oid>  | old
- f         | pg_aocsseg_<oid>   | old
- f         | pg_aovisimap_<oid> | old
- f         | test_table_co      | old
- t         | pg_aoblkdir_<oid>  | very young
  t         | pg_aocsseg_<oid>   | very young
  t         | pg_aovisimap_<oid> | very young
- t         | test_table_co      | very young
-(8 rows)
+ f         | pg_aocsseg_<oid>   | old
+ f         | pg_aovisimap_<oid> | old
+ f         | pg_aoblkdir_<oid>  | old
+ t         | pg_aoblkdir_<oid>  | very young
+(6 rows)
 
 select segid = -1 as is_master, relname, classify_age(age) from aux_rel_ages('test_table_co_with_toast')
 group by segid = -1, relname, classify_age(age);
- is_master |         relname          | classify_age 
------------+--------------------------+--------------
- f         | pg_aoblkdir_<oid>        | old
- f         | pg_aocsseg_<oid>         | old
- f         | pg_aovisimap_<oid>       | old
- f         | pg_toast_<oid>           | old
- f         | test_table_co_with_toast | old
- t         | pg_aoblkdir_<oid>        | very young
- t         | pg_aocsseg_<oid>         | very young
- t         | pg_aovisimap_<oid>       | very young
- t         | pg_toast_<oid>           | very young
- t         | test_table_co_with_toast | very young
-(10 rows)
+ is_master |      relname       | classify_age 
+-----------+--------------------+--------------
+ t         | pg_aocsseg_<oid>   | very young
+ f         | pg_toast_<oid>     | old
+ t         | pg_toast_<oid>     | very young
+ t         | pg_aovisimap_<oid> | very young
+ f         | pg_aocsseg_<oid>   | old
+ f         | pg_aovisimap_<oid> | old
+ f         | pg_aoblkdir_<oid>  | old
+ t         | pg_aoblkdir_<oid>  | very young
+(8 rows)
 
 -- Vacuum. This should advance relfrozenxid on all the tables.
 vacuum test_table_heap;
@@ -191,10 +186,10 @@ select segid = -1 as is_master, relname, classify_age(age) from aux_rel_ages('te
 group by segid = -1, relname, classify_age(age);
  is_master |          relname           | classify_age 
 -----------+----------------------------+--------------
- f         | pg_toast_<oid>             | young
- f         | test_table_heap_with_toast | young
- t         | pg_toast_<oid>             | very young
  t         | test_table_heap_with_toast | very young
+ f         | test_table_heap_with_toast | young
+ f         | pg_toast_<oid>             | young
+ t         | pg_toast_<oid>             | very young
 (4 rows)
 
 select segid = -1 as is_master, relname, classify_age(age) from aux_rel_ages('test_table_ao')
@@ -202,60 +197,52 @@ group by segid = -1, relname, classify_age(age);
  is_master |      relname       | classify_age 
 -----------+--------------------+--------------
  f         | pg_aoblkdir_<oid>  | young
- f         | pg_aoseg_<oid>     | young
  f         | pg_aovisimap_<oid> | young
- f         | test_table_ao      | young
- t         | pg_aoblkdir_<oid>  | very young
- t         | pg_aoseg_<oid>     | very young
  t         | pg_aovisimap_<oid> | very young
- t         | test_table_ao      | very young
-(8 rows)
+ t         | pg_aoseg_<oid>     | very young
+ f         | pg_aoseg_<oid>     | young
+ t         | pg_aoblkdir_<oid>  | very young
+(6 rows)
 
 select segid = -1 as is_master, relname, classify_age(age) from aux_rel_ages('test_table_ao_with_toast')
 group by segid = -1, relname, classify_age(age);
- is_master |         relname          | classify_age 
------------+--------------------------+--------------
- f         | pg_aoblkdir_<oid>        | young
- f         | pg_aoseg_<oid>           | young
- f         | pg_aovisimap_<oid>       | young
- f         | pg_toast_<oid>           | young
- f         | test_table_ao_with_toast | young
- t         | pg_aoblkdir_<oid>        | very young
- t         | pg_aoseg_<oid>           | very young
- t         | pg_aovisimap_<oid>       | very young
- t         | pg_toast_<oid>           | very young
- t         | test_table_ao_with_toast | very young
-(10 rows)
+ is_master |      relname       | classify_age 
+-----------+--------------------+--------------
+ f         | pg_aoblkdir_<oid>  | young
+ f         | pg_toast_<oid>     | young
+ t         | pg_toast_<oid>     | very young
+ f         | pg_aovisimap_<oid> | young
+ t         | pg_aovisimap_<oid> | very young
+ t         | pg_aoseg_<oid>     | very young
+ f         | pg_aoseg_<oid>     | young
+ t         | pg_aoblkdir_<oid>  | very young
+(8 rows)
 
 select segid = -1 as is_master, relname, classify_age(age) from aux_rel_ages('test_table_co')
 group by segid = -1, relname, classify_age(age);
  is_master |      relname       | classify_age 
 -----------+--------------------+--------------
- f         | pg_aoblkdir_<oid>  | young
- f         | pg_aocsseg_<oid>   | young
- f         | pg_aovisimap_<oid> | young
- f         | test_table_co      | young
- t         | pg_aoblkdir_<oid>  | very young
  t         | pg_aocsseg_<oid>   | very young
+ f         | pg_aocsseg_<oid>   | young
+ f         | pg_aoblkdir_<oid>  | young
+ f         | pg_aovisimap_<oid> | young
  t         | pg_aovisimap_<oid> | very young
- t         | test_table_co      | very young
-(8 rows)
+ t         | pg_aoblkdir_<oid>  | very young
+(6 rows)
 
 select segid = -1 as is_master, relname, classify_age(age) from aux_rel_ages('test_table_co_with_toast')
 group by segid = -1, relname, classify_age(age);
- is_master |         relname          | classify_age 
------------+--------------------------+--------------
- f         | pg_aoblkdir_<oid>        | young
- f         | pg_aocsseg_<oid>         | young
- f         | pg_aovisimap_<oid>       | young
- f         | pg_toast_<oid>           | young
- f         | test_table_co_with_toast | young
- t         | pg_aoblkdir_<oid>        | very young
- t         | pg_aocsseg_<oid>         | very young
- t         | pg_aovisimap_<oid>       | very young
- t         | pg_toast_<oid>           | very young
- t         | test_table_co_with_toast | very young
-(10 rows)
+ is_master |      relname       | classify_age 
+-----------+--------------------+--------------
+ t         | pg_aocsseg_<oid>   | very young
+ f         | pg_aocsseg_<oid>   | young
+ f         | pg_aoblkdir_<oid>  | young
+ f         | pg_toast_<oid>     | young
+ t         | pg_toast_<oid>     | very young
+ f         | pg_aovisimap_<oid> | young
+ t         | pg_aovisimap_<oid> | very young
+ t         | pg_aoblkdir_<oid>  | very young
+(8 rows)
 
 -- Repeat the tests on a table that has been inserted to, but all the rows
 -- have been deleted.
@@ -334,9 +321,9 @@ group by segid = -1, relname, classify_age(age);
  is_master |          relname           | classify_age 
 -----------+----------------------------+--------------
  f         | pg_toast_<oid>             | very young
+ t         | test_table_heap_with_toast | very young
  f         | test_table_heap_with_toast | very young
  t         | pg_toast_<oid>             | very young
- t         | test_table_heap_with_toast | very young
 (4 rows)
 
 select segid = -1 as is_master, relname, classify_age(age) from aux_rel_ages('test_table_ao')
@@ -345,57 +332,49 @@ group by segid = -1, relname, classify_age(age);
 -----------+--------------------+--------------
  f         | pg_aoblkdir_<oid>  | very young
  f         | pg_aoseg_<oid>     | very young
- f         | pg_aovisimap_<oid> | very young
- f         | test_table_ao      | very young
- t         | pg_aoblkdir_<oid>  | very young
- t         | pg_aoseg_<oid>     | very young
  t         | pg_aovisimap_<oid> | very young
- t         | test_table_ao      | very young
-(8 rows)
+ t         | pg_aoseg_<oid>     | very young
+ t         | pg_aoblkdir_<oid>  | very young
+ f         | pg_aovisimap_<oid> | very young
+(6 rows)
 
 select segid = -1 as is_master, relname, classify_age(age) from aux_rel_ages('test_table_ao_with_toast')
 group by segid = -1, relname, classify_age(age);
- is_master |         relname          | classify_age 
------------+--------------------------+--------------
- f         | pg_aoblkdir_<oid>        | very young
- f         | pg_aoseg_<oid>           | very young
- f         | pg_aovisimap_<oid>       | very young
- f         | pg_toast_<oid>           | very young
- f         | test_table_ao_with_toast | very young
- t         | pg_aoblkdir_<oid>        | very young
- t         | pg_aoseg_<oid>           | very young
- t         | pg_aovisimap_<oid>       | very young
- t         | pg_toast_<oid>           | very young
- t         | test_table_ao_with_toast | very young
-(10 rows)
+ is_master |      relname       | classify_age 
+-----------+--------------------+--------------
+ f         | pg_toast_<oid>     | very young
+ f         | pg_aoblkdir_<oid>  | very young
+ f         | pg_aoseg_<oid>     | very young
+ t         | pg_toast_<oid>     | very young
+ t         | pg_aovisimap_<oid> | very young
+ t         | pg_aoseg_<oid>     | very young
+ t         | pg_aoblkdir_<oid>  | very young
+ f         | pg_aovisimap_<oid> | very young
+(8 rows)
 
 select segid = -1 as is_master, relname, classify_age(age) from aux_rel_ages('test_table_co')
 group by segid = -1, relname, classify_age(age);
  is_master |      relname       | classify_age 
 -----------+--------------------+--------------
- f         | pg_aoblkdir_<oid>  | very young
- f         | pg_aocsseg_<oid>   | very young
- f         | pg_aovisimap_<oid> | very young
- f         | test_table_co      | very young
- t         | pg_aoblkdir_<oid>  | very young
  t         | pg_aocsseg_<oid>   | very young
+ f         | pg_aoblkdir_<oid>  | very young
  t         | pg_aovisimap_<oid> | very young
- t         | test_table_co      | very young
-(8 rows)
+ f         | pg_aocsseg_<oid>   | very young
+ t         | pg_aoblkdir_<oid>  | very young
+ f         | pg_aovisimap_<oid> | very young
+(6 rows)
 
 select segid = -1 as is_master, relname, classify_age(age) from aux_rel_ages('test_table_co_with_toast')
 group by segid = -1, relname, classify_age(age);
- is_master |         relname          | classify_age 
------------+--------------------------+--------------
- f         | pg_aoblkdir_<oid>        | very young
- f         | pg_aocsseg_<oid>         | very young
- f         | pg_aovisimap_<oid>       | very young
- f         | pg_toast_<oid>           | very young
- f         | test_table_co_with_toast | very young
- t         | pg_aoblkdir_<oid>        | very young
- t         | pg_aocsseg_<oid>         | very young
- t         | pg_aovisimap_<oid>       | very young
- t         | pg_toast_<oid>           | very young
- t         | test_table_co_with_toast | very young
-(10 rows)
+ is_master |      relname       | classify_age 
+-----------+--------------------+--------------
+ t         | pg_aocsseg_<oid>   | very young
+ f         | pg_toast_<oid>     | very young
+ f         | pg_aoblkdir_<oid>  | very young
+ t         | pg_toast_<oid>     | very young
+ t         | pg_aovisimap_<oid> | very young
+ f         | pg_aocsseg_<oid>   | very young
+ t         | pg_aoblkdir_<oid>  | very young
+ f         | pg_aovisimap_<oid> | very young
+(8 rows)
 

--- a/src/test/regress/expected/vacuum_gp.out
+++ b/src/test/regress/expected/vacuum_gp.out
@@ -156,29 +156,27 @@ vacuum ao_age_test;
 -- age value in expected output so as to make the test reliable.
 -- Assuming no other activity, vacuum needs one transaction ID for
 -- each of the three tables.
-select relname, 0 < age(relfrozenxid) as age_positive,
-       age(relfrozenxid) < 100 as age_within_limit
-from pg_class
+-- AO/CO tables should have relfrozenxid = 0.
+select relname, relfrozenxid from pg_class
 where relname like 'ao_age_test%' and relkind = 'r' order by 1;
-       relname        | age_positive | age_within_limit 
-----------------------+--------------+------------------
- ao_age_test          | t            | t
- ao_age_test_1_prt_b1 | t            | t
- ao_age_test_1_prt_b2 | t            | t
+       relname        | relfrozenxid 
+----------------------+--------------
+ ao_age_test          |            0
+ ao_age_test_1_prt_b1 |            0
+ ao_age_test_1_prt_b2 |            0
 (3 rows)
 
--- Vacuum the other two empty tables and verify their age is updated
--- correctly.
+-- Vacuum the other two empty tables and verify the age of auxiliary tables is
+-- updated correctly.
 vacuum ao_empty;
 vacuum aocs_empty;
-select relname, 0 < age(relfrozenxid) as age_positive,
-       age(relfrozenxid) < 100 as age_within_limit
-from pg_class
+-- AO/CO tables should have relfrozenxid = 0.
+select relname, relfrozenxid from pg_class
 where relname in ('ao_empty', 'aocs_empty') order by 1;
-  relname   | age_positive | age_within_limit 
-------------+--------------+------------------
- ao_empty   | t            | t
- aocs_empty | t            | t
+  relname   | relfrozenxid 
+------------+--------------
+ ao_empty   |            0
+ aocs_empty |            0
 (2 rows)
 
 select * from ao_empty;

--- a/src/test/regress/sql/vacuum_gp.sql
+++ b/src/test/regress/sql/vacuum_gp.sql
@@ -119,18 +119,16 @@ vacuum ao_age_test;
 
 -- Assuming no other activity, vacuum needs one transaction ID for
 -- each of the three tables.
-select relname, 0 < age(relfrozenxid) as age_positive,
-       age(relfrozenxid) < 100 as age_within_limit
-from pg_class
+-- AO/CO tables should have relfrozenxid = 0.
+select relname, relfrozenxid from pg_class
 where relname like 'ao_age_test%' and relkind = 'r' order by 1;
 
--- Vacuum the other two empty tables and verify their age is updated
--- correctly.
+-- Vacuum the other two empty tables and verify the age of auxiliary tables is
+-- updated correctly.
 vacuum ao_empty;
 vacuum aocs_empty;
-select relname, 0 < age(relfrozenxid) as age_positive,
-       age(relfrozenxid) < 100 as age_within_limit
-from pg_class
+-- AO/CO tables should have relfrozenxid = 0.
+select relname, relfrozenxid from pg_class
 where relname in ('ao_empty', 'aocs_empty') order by 1;
 select * from ao_empty;
 select * from aocs_empty;


### PR DESCRIPTION
AO and CO tables never store transactionIds and persistent table always have
tuples with FrozenXid only. Hence these tables should not have valid
relfrozenxid, hence also should not matter for age calculation. Persistent
tables are currently skipped internally from `datfrozenxid` calculation but
still contained valid value for relfrozenxid in pg_class. Whereas AO/CO tables
carried valid relfrozenxid and were used for `datfrozenxid` calculation as well.

This commit makes sure only tables involved in `datfrozenxid` calculation,
actually carry valid relfrozenxid in pg_class and others don't. So, externally
someone executing age() function can easily ignore such tables by checking `not
relfrozenxid = 0`.

Fixes #2856.