### PR TITLE
docs:  resource groups sql ref pages - create new, updates to others

### DIFF
--- a/gpdb-doc/dita/GPRefGuide.ditamap
+++ b/gpdb-doc/dita/GPRefGuide.ditamap
@@ -85,6 +85,7 @@
 		<topicref href="ref_guide/sql_commands/ALTER_OPERATOR_CLASS.xml"/>
 		<topicref href="ref_guide/sql_commands/ALTER_OPERATOR_FAMILY.xml"/>
 		<topicref href="ref_guide/sql_commands/ALTER_PROTOCOL.xml"/>
+		<topicref href="ref_guide/sql_commands/ALTER_RESOURCE_GROUP.xml"/>
 		<topicref href="ref_guide/sql_commands/ALTER_RESOURCE_QUEUE.xml"/>
 		<topicref href="ref_guide/sql_commands/ALTER_ROLE.xml"/>
 		<topicref href="ref_guide/sql_commands/ALTER_SCHEMA.xml"/>
@@ -117,6 +118,7 @@
 		<topicref href="ref_guide/sql_commands/CREATE_OPERATOR_CLASS.xml"/>
 		<topicref href="ref_guide/sql_commands/CREATE_OPERATOR_FAMILY.xml"/>
 		<topicref href="ref_guide/sql_commands/CREATE_PROTOCOL.xml"/>
+		<topicref href="ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml"/>
 		<topicref href="ref_guide/sql_commands/CREATE_RESOURCE_QUEUE.xml"/>
 		<topicref href="ref_guide/sql_commands/CREATE_ROLE.xml"/>
 		<topicref href="ref_guide/sql_commands/CREATE_RULE.xml"/>
@@ -150,6 +152,7 @@
 		<topicref href="ref_guide/sql_commands/DROP_OPERATOR_FAMILY.xml"/>
 		<topicref href="ref_guide/sql_commands/DROP_OWNED.xml"/>
 		<topicref href="ref_guide/sql_commands/DROP_PROTOCOL.xml"/>
+		<topicref href="ref_guide/sql_commands/DROP_RESOURCE_GROUP.xml"/>
 		<topicref href="ref_guide/sql_commands/DROP_RESOURCE_QUEUE.xml"/>
 		<topicref href="ref_guide/sql_commands/DROP_ROLE.xml"/>
 		<topicref href="ref_guide/sql_commands/DROP_RULE.xml"/>

--- a/gpdb-doc/dita/ref_guide/GPReferenceSQLSummaryLOP.xml
+++ b/gpdb-doc/dita/ref_guide/GPReferenceSQLSummaryLOP.xml
@@ -114,6 +114,13 @@
 		<codeblock conref="sql_commands/ALTER_PROTOCOL.xml#topic1/sql_command_synopsis"/>
 		<p otherprops="op-html">See <xref href="sql_commands/ALTER_PROTOCOL.xml"/> for more
 			information.</p>
+		<section id="ae19034513">
+			<title>ALTER RESOURCE GROUP</title>
+		</section>
+		<p conref="sql_commands/ALTER_RESOURCE_GROUP.xml#topic1/sql_command_desc"/>
+		<codeblock conref="sql_commands/ALTER_RESOURCE_GROUP.xml#topic1/sql_command_synopsis"/>
+		<p otherprops="op-html">See <xref href="sql_commands/ALTER_RESOURCE_GROUP.xml"/> for more
+			information.</p>
 		<section id="ae1903451">
 			<title>ALTER RESOURCE QUEUE</title>
 		</section>
@@ -333,6 +340,13 @@
 		<p conref="sql_commands/CREATE_PROTOCOL.xml#topic1/sql_command_desc"/>
 		<codeblock conref="sql_commands/CREATE_PROTOCOL.xml#topic1/sql_command_synopsis"/>
 		<p otherprops="op-html">See <xref href="sql_commands/CREATE_PROTOCOL.xml"/> for more
+			information.</p>
+		<section id="ae19043333">
+			<title>CREATE RESOURCE GROUP</title>
+		</section>
+		<p conref="sql_commands/CREATE_RESOURCE_GROUP.xml#topic1/sql_command_desc"/>
+		<codeblock conref="sql_commands/CREATE_RESOURCE_GROUP.xml#topic1/sql_command_synopsis"/>
+		<p otherprops="op-html">See <xref href="sql_commands/CREATE_RESOURCE_GROUP.xml"/> for more
 			information.</p>
 		<section id="ae1904333">
 			<title>CREATE RESOURCE QUEUE</title>
@@ -561,6 +575,13 @@
 		<p conref="sql_commands/DROP_PROTOCOL.xml#topic1/sql_command_desc"/>
 		<codeblock conref="sql_commands/DROP_PROTOCOL.xml#topic1/sql_command_synopsis"/>
 		<p otherprops="op-html">See <xref href="sql_commands/DROP_PROTOCOL.xml"/> for more
+			information.</p>
+		<section id="ae19048993">
+			<title>DROP RESOURCE GROUP</title>
+		</section>
+		<p conref="sql_commands/DROP_RESOURCE_GROUP.xml#topic1/sql_command_desc"/>
+		<codeblock conref="sql_commands/DROP_RESOURCE_GROUP.xml#topic1/sql_command_synopsis"/>
+		<p otherprops="op-html">See <xref href="sql_commands/DROP_RESOURCE_GROUP.xml"/> for more
 			information.</p>
 		<section id="ae1904899">
 			<title>DROP RESOURCE QUEUE</title>

--- a/gpdb-doc/dita/ref_guide/ref_guide.ditamap
+++ b/gpdb-doc/dita/ref_guide/ref_guide.ditamap
@@ -20,6 +20,7 @@
 			<topicref href="sql_commands/ALTER_OPERATOR_CLASS.xml"/>
 			<topicref href="sql_commands/ALTER_OPERATOR_FAMILY.xml"/>
 			<topicref href="sql_commands/ALTER_PROTOCOL.xml"/>
+			<topicref href="sql_commands/ALTER_RESOURCE_GROUP.xml"/>
 			<topicref href="sql_commands/ALTER_RESOURCE_QUEUE.xml"/>
 			<topicref href="sql_commands/ALTER_ROLE.xml"/>
 			<topicref href="sql_commands/ALTER_SCHEMA.xml"/>
@@ -53,6 +54,7 @@
 			<topicref href="sql_commands/CREATE_OPERATOR_CLASS.xml"/>
 			<topicref href="sql_commands/CREATE_OPERATOR_FAMILY.xml"/>
 			<topicref href="sql_commands/CREATE_PROTOCOL.xml"/>
+			<topicref href="sql_commands/CREATE_RESOURCE_GROUP.xml"/>
 			<topicref href="sql_commands/CREATE_RESOURCE_QUEUE.xml"/>
 			<topicref href="sql_commands/CREATE_ROLE.xml"/>
 			<topicref href="sql_commands/CREATE_RULE.xml"/>
@@ -87,6 +89,7 @@
 			<topicref href="sql_commands/DROP_OPERATOR_FAMILY.xml"/>
 			<topicref href="sql_commands/DROP_OWNED.xml"/>
 			<topicref href="sql_commands/DROP_PROTOCOL.xml"/>
+			<topicref href="sql_commands/DROP_RESOURCE_GROUP.xml"/>
 			<topicref href="sql_commands/DROP_RESOURCE_QUEUE.xml"/>
 			<topicref href="sql_commands/DROP_ROLE.xml"/>
 			<topicref href="sql_commands/DROP_RULE.xml"/>

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_RESOURCE_GROUP.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_RESOURCE_GROUP.xml
@@ -51,7 +51,7 @@ ALTER RESOURCE GROUP <varname>name</varname> SET CPU_RATE_LIMIT <varname>integer
       <p>Use <codeph><xref href="./CREATE_ROLE.xml#topic1" type="topic" format="dita"/></codeph> or
             <codeph><xref href="./ALTER_ROLE.xml#topic1" type="topic" format="dita"/></codeph> to
         assign a specific resource group to a role (user).</p>
-      <p>You cannot submit an <codeph>ALTER RESOURCE GROUP</codeph> command in a sub-transaction.</p>
+      <p>You cannot submit an <codeph>ALTER RESOURCE GROUP</codeph> command in an explicit transaction or sub-transaction.</p>
     </section>
     <section id="section6">
       <title>Examples</title>

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_RESOURCE_GROUP.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_RESOURCE_GROUP.xml
@@ -7,8 +7,12 @@
     <p id="sql_command_desc">Changes the limits of a resource group.</p>
     <section id="section2">
       <title>Synopsis</title>
-      <codeblock id="sql_command_synopsis">ALTER RESOURCE GROUP <varname>name</varname> SET CONCURRENCY <varname>integer</varname>
-ALTER RESOURCE GROUP <varname>name</varname> SET CPU_RATE_LIMIT <varname>integer</varname></codeblock>
+      <codeblock id="sql_command_synopsis">ALTER RESOURCE GROUP <varname>name</varname> SET <varname>group_attribute</varname> <varname>value</varname></codeblock>
+<p>where <varname>group_attribute</varname> is one of:</p>
+      <codeblock>CONCURRENCY <varname>integer</varname>
+CPU_RATE_LIMIT <varname>integer</varname>
+MEMORY_LIMIT <varname>integer</varname>
+MEMORY_SHARED_QUOTA <varname>integer</varname></codeblock>
     </section>
     <section id="section3">
       <title>Description</title>
@@ -17,7 +21,9 @@ ALTER RESOURCE GROUP <varname>name</varname> SET CPU_RATE_LIMIT <varname>integer
         <p>You can set or reset the concurrency limit of a resource group to control the maximum
         number of active concurrent statements in that group. You can also reset the CPU rate limit of a
         resource group to control the amount of CPU resources that all queries submitted through
-        the group can consume on each segment host.</p><p>You can alter one limit type in a single <codeph>ALTER RESOURCE GROUP</codeph> call.</p>
+        the group can consume on each segment host.</p>
+        <p>The new resource limit is immediately applied if current resource usage is less than or equal to the new value. If current resource usage exceeds the new limit value, Greenplum Database will defer the new limit assignment until resource usage is within the range of the new value.</p>
+        <p>You can alter one limit type in a single <codeph>ALTER RESOURCE GROUP</codeph> call.</p>
     </section>
     <section id="section4">
       <title>Parameters</title>
@@ -44,6 +50,20 @@ ALTER RESOURCE GROUP <varname>name</varname> SET CPU_RATE_LIMIT <varname>integer
             <codeph>CPU_RATE_LIMIT</codeph>s of all resource groups defined in the
             Greenplum Database cluster must not exceed 100.</pd>
         </plentry>
+        <plentry>
+          <pt>MEMORY_LIMIT <varname>integer</varname></pt>
+          <pd>The percentage of memory resources to allocate to
+            this resource group. The minimum memory percentage for a resource group is 1.
+            The maximum is 100. The sum of the
+            <codeph>MEMORY_LIMIT</codeph>s of all resource groups defined in the
+            Greenplum Database cluster must not exceed 100.</pd>
+        </plentry>
+        <plentry>
+          <pt>MEMORY_SHARED_QUOTA <varname>integer</varname></pt>
+          <pd>The percentage of memory resources to share among transactions in
+            the resource group. The minimum memory shared quota percentage for a
+            resource group is 0.  The maximum is 100.</pd>
+        </plentry>
       </parml>
     </section>
     <section id="section5">
@@ -56,9 +76,9 @@ ALTER RESOURCE GROUP <varname>name</varname> SET CPU_RATE_LIMIT <varname>integer
     <section id="section6">
       <title>Examples</title>
       <p>Change the active transaction limit for a resource group: </p>
-      <codeblock>ALTER RESOURCE GROUP rgroup1 WITH CONCURRENCY 13;</codeblock>
+      <codeblock>ALTER RESOURCE GROUP rgroup1 SET CONCURRENCY 13;</codeblock>
       <p>Update the CPU limit for a resource group: </p>
-      <codeblock>ALTER RESOURCE GROUP rgroup2 WITH CPU_RATE_LIMIT 45;</codeblock>
+      <codeblock>ALTER RESOURCE GROUP rgroup2 SET CPU_RATE_LIMIT 45;</codeblock>
     </section>
     <section id="section7">
       <title>Compatibility</title>

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_RESOURCE_GROUP.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_RESOURCE_GROUP.xml
@@ -15,31 +15,30 @@ ALTER RESOURCE GROUP <varname>name</varname> SET CPU_RATE_LIMIT <varname>integer
       <p><codeph>ALTER RESOURCE GROUP</codeph> changes the limits of a resource group. 
         Only a superuser can alter a resource group.</p>
         <p>You can set or reset the concurrency limit of a resource group to control the maximum
-        number of active concurrent statements. You can also reset the CPU rate limit of a
+        number of active concurrent statements in that group. You can also reset the CPU rate limit of a
         resource group to control the amount of CPU resources that all queries submitted through
-        the group can consume on a segment host.</p><p>You can alter one limit type in a single <codeph>ALTER RESOURCE GROUP</codeph> call.</p>
+        the group can consume on each segment host.</p><p>You can alter one limit type in a single <codeph>ALTER RESOURCE GROUP</codeph> call.</p>
     </section>
     <section id="section4">
       <title>Parameters</title>
       <parml>
         <plentry>
           <pt><varname>name</varname></pt>
-          <pd>The name of the resource group whose limits are to be altered. </pd>
+          <pd>The name of the resource group to alter. </pd>
         </plentry>
         <plentry>
           <pt>CONCURRENCY <varname>integer</varname></pt>
-          <pd>The maximum number of concurrent transactions submitted from users in this resource
-            group allowed on the system at any given time, including active and idle transactions.
+          <pd>The maximum number of concurrent transactions, including active and idle transactions, that are permitted for this resource group.
             Any transactions submitted after the <codeph>CONCURRENCY</codeph> value limit is
-            reached are queued. When a running transaction completes, the earliest pending queued
-            transaction is selected for execution.</pd>
+            reached are queued. When a running transaction completes, the earliest queued
+            transaction is executed.</pd>
           <pd> The <codeph>CONCURRENCY</codeph> value
-            should be an integer in the range [1 .. <codeph>max_connections</codeph>]. The default 
+            must be an integer in the range [1 .. <codeph>max_connections</codeph>]. The default 
             <codeph>CONCURRENCY</codeph> value is 20.</pd>
         </plentry>
         <plentry>
           <pt>CPU_RATE_LIMIT <varname>integer</varname></pt>
-          <pd>Sets the total percentage of CPU resources to allocate to
+          <pd>The percentage of CPU resources to allocate to
             this resource group. The minimum CPU percentage for a resource group is 1.
             The maximum is 100. The sum of the
             <codeph>CPU_RATE_LIMIT</codeph>s of all resource groups defined in the

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_RESOURCE_GROUP.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_RESOURCE_GROUP.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic id="topic1">
+  <title id="au20941">ALTER RESOURCE GROUP</title>
+  <body>
+    <p id="sql_command_desc">Changes the limits of a resource group.</p>
+    <section id="section2">
+      <title>Synopsis</title>
+      <codeblock id="sql_command_synopsis">ALTER RESOURCE GROUP <varname>name</varname> SET CONCURRENCY <varname>integer</varname>
+ALTER RESOURCE GROUP <varname>name</varname> SET CPU_RATE_LIMIT <varname>integer</varname></codeblock>
+    </section>
+    <section id="section3">
+      <title>Description</title>
+      <p><codeph>ALTER RESOURCE GROUP</codeph> changes the limits of a resource group. 
+        Only a superuser can alter a resource group.</p>
+        <p>You can set or reset the concurrency limit of a resource group to control the maximum
+        number of active concurrent statements. You can also reset the CPU rate limit of a
+        resource group to control the amount of CPU resources that all queries submitted through
+        the group can consume on a segment host.</p><p>You can alter one limit type in a single <codeph>ALTER RESOURCE GROUP</codeph> call.</p>
+    </section>
+    <section id="section4">
+      <title>Parameters</title>
+      <parml>
+        <plentry>
+          <pt><varname>name</varname></pt>
+          <pd>The name of the resource group whose limits are to be altered. </pd>
+        </plentry>
+        <plentry>
+          <pt>CONCURRENCY <varname>integer</varname></pt>
+          <pd>The maximum number of concurrent transactions submitted from users in this resource
+            group allowed on the system at any given time, including active and idle transactions.
+            Any transactions submitted after the <codeph>CONCURRENCY</codeph> value limit is
+            reached are queued. When a running transaction completes, the earliest pending queued
+            transaction is selected for execution.</pd>
+          <pd> The <codeph>CONCURRENCY</codeph> value
+            should be an integer in the range [1 .. <codeph>max_connections</codeph>]. The default 
+            <codeph>CONCURRENCY</codeph> value is 20.</pd>
+        </plentry>
+        <plentry>
+          <pt>CPU_RATE_LIMIT <varname>integer</varname></pt>
+          <pd>Sets the total percentage of CPU resources to allocate to
+            this resource group. The minimum CPU percentage for a resource group is 1.
+            The maximum is 100. The sum of the
+            <codeph>CPU_RATE_LIMIT</codeph>s of all resource groups defined in the
+            Greenplum Database cluster must not exceed 100.</pd>
+        </plentry>
+      </parml>
+    </section>
+    <section id="section5">
+      <title>Notes</title>
+      <p>Use <codeph><xref href="./CREATE_ROLE.xml#topic1" type="topic" format="dita"/></codeph> or
+            <codeph><xref href="./ALTER_ROLE.xml#topic1" type="topic" format="dita"/></codeph> to
+        assign a specific resource group to a role (user).</p>
+      <p>You cannot submit an <codeph>ALTER RESOURCE GROUP</codeph> command in a sub-transaction.</p>
+    </section>
+    <section id="section6">
+      <title>Examples</title>
+      <p>Change the active transaction limit for a resource group: </p>
+      <codeblock>ALTER RESOURCE GROUP rgroup1 WITH CONCURRENCY 13;</codeblock>
+      <p>Update the CPU limit for a resource group: </p>
+      <codeblock>ALTER RESOURCE GROUP rgroup2 WITH CPU_RATE_LIMIT 45;</codeblock>
+    </section>
+    <section id="section7">
+      <title>Compatibility</title>
+      <p>The <codeph>ALTER RESOURCE GROUP</codeph> statement is a Greenplum Database extension. This
+        command does not exist in standard PostgreSQL.</p>
+    </section>
+    <section id="section8">
+      <title>See Also</title>
+      <p><codeph><xref href="./CREATE_RESOURCE_GROUP.xml#topic1" type="topic" format="dita"
+          /></codeph>, <codeph><xref href="./DROP_RESOURCE_GROUP.xml#topic1" type="topic"
+            format="dita"/></codeph>, <codeph><xref href="./CREATE_ROLE.xml#topic1" type="topic"
+            format="dita"/></codeph>, <codeph><xref href="./ALTER_ROLE.xml#topic1" type="topic"
+            format="dita"/></codeph></p>
+    </section>
+  </body>
+</topic>

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_ROLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_ROLE.xml
@@ -9,6 +9,8 @@ ALTER ROLE <varname>name</varname> RESET <varname>config_parameter</varname>
 
 ALTER ROLE <varname>name</varname> RESOURCE QUEUE {<varname>queue_name</varname> | NONE}
 
+ALTER ROLE <varname>name</varname> RESOURCE GROUP {<varname>group_name</varname> | NONE}
+
 ALTER ROLE <varname>name</varname> [ [WITH] <varname>option</varname> [ ... ] ]</codeblock><p>where <varname>option</varname> can be:</p><codeblock>      SUPERUSER | NOSUPERUSER
     | CREATEDB | NOCREATEDB
     | CREATEROLE | NOCREATEROLE
@@ -44,7 +46,13 @@ its password if the password is MD5-encrypted.</li><li id="av136604"><b>SET | RE
           role can only belong to one resource queue. For a role without <codeph>LOGIN</codeph>
           privilege, resource queues have no effect. See <codeph><xref
               href="./CREATE_RESOURCE_QUEUE.xml#topic1" type="topic" format="dita"/></codeph> for
-          more information.</li><li id="av137061"><b>WITH <varname>option</varname></b> — Changes many of the role attributes that can be
+          more information.</li><li id="av1370583"><b>RESOURCE GROUP</b> — When resource group-based workload management is configured, assigns a resource group to the role.
+          The role would then be subject to the concurrent transaction, memory, and CPU limits
+          configured for the resource group. You can
+          assign a single resource group to a role, and you can assign a resource group to multiple
+          roles. See <codeph><xref
+              href="./CREATE_RESOURCE_GROUP.xml#topic1" type="topic" format="dita"/></codeph> for
+          additional information.</li><li id="av137061"><b>WITH <varname>option</varname></b> — Changes many of the role attributes that can be
           specified in <codeph><xref href="./CREATE_ROLE.xml#topic1" type="topic" format="dita"
             /></codeph>. Attributes not mentioned in the command retain their previous settings.
           Database superusers can change any of these settings for any role. Roles having
@@ -55,7 +63,9 @@ its password if the password is MD5-encrypted.</li><li id="av136604"><b>SET | RE
             default setting in new sessions. Use <codeph>RESET ALL</codeph> to clear all
             role-specific settings. See <codeph><xref href="./SET.xml#topic1" type="topic"
                 format="dita"/></codeph> and <xref href="../config_params/guc_config.xml" type="topic"
-              format="dita"/> for information about user-settable configuration parameters. </pd></plentry><plentry><pt><varname>queue_name</varname></pt><pd>The name of the resource queue to which the user-level role is to
+              format="dita"/> for information about user-settable configuration parameters. </pd></plentry><plentry><pt><varname>group_name</varname></pt><pd>The name of the resource group to assign to this role.
+Specifying the <varname>group_name</varname> <codeph>NONE</codeph> removes the role's current resource group assignment and assigns a default resource group based on the role's capability. <codeph>SUPERUSER</codeph> roles are assigned the <codeph>admin_group</codeph> resource group, while the <codeph>default_group</codeph> resource group is assigned to non-admin roles.
+</pd></plentry><plentry><pt><varname>queue_name</varname></pt><pd>The name of the resource queue to which the user-level role is to
 be assigned. Only roles with <codeph>LOGIN</codeph> privilege can be
 assigned to a resource queue. To unassign a role from a resource queue
 and put it in the default resource queue, specify <codeph>NONE</codeph>.
@@ -87,9 +97,11 @@ change a role's password. </p><p>It is also possible to tie a session default to
         Role-specific settings override database-specific ones if there is a conflict. See
             <codeph><xref href="ALTER_DATABASE.xml#topic1" type="topic" format="dita"
         /></codeph>.</p></section><section id="section6"><title>Examples</title><p>Change the password for a role: </p><codeblock>ALTER ROLE daria WITH PASSWORD 'passwd123';</codeblock><p>Change a password expiration date:</p><codeblock>ALTER ROLE scott VALID UNTIL 'May 4 12:00:00 2015 +1';</codeblock><p>Make a password valid forever:</p><codeblock>ALTER ROLE luke VALID UNTIL 'infinity';</codeblock><p>Give a role the ability to create other roles and new databases: </p><codeblock>ALTER ROLE joelle CREATEROLE CREATEDB;</codeblock><p>Give a role a non-default setting of the <codeph>maintenance_work_mem</codeph> parameter: </p><codeblock>ALTER ROLE admin SET maintenance_work_mem = 100000;</codeblock><p>Assign a role to a resource queue: </p><codeblock>ALTER ROLE sammy RESOURCE QUEUE poweruser;</codeblock><p>Give a role permission to create writable external tables:</p><codeblock>ALTER ROLE load CREATEEXTTABLE (type='writable');</codeblock><p>Alter a role so it does not allow login access on Sundays:</p><codeblock>ALTER ROLE user3 DENY DAY 'Sunday';</codeblock><p>Alter a role to remove the constraint that does not allow login access
-on Sundays:</p><codeblock>ALTER ROLE user3 DROP DENY FOR DAY 'Sunday';</codeblock></section><section id="section7"><title>Compatibility</title><p>The <codeph>ALTER ROLE</codeph> statement is a Greenplum Database extension.</p></section><section id="section8"><title>See Also</title><p><codeph><xref href="./CREATE_ROLE.xml#topic1" type="topic" format="dita"/></codeph>,
+on Sundays:</p><codeblock>ALTER ROLE user3 DROP DENY FOR DAY 'Sunday';</codeblock><p>Assign a new resource group to a role: </p><codeblock>ALTER ROLE parttime_user RESOURCE GROUP rg_light;</codeblock></section><section id="section7"><title>Compatibility</title><p>The <codeph>ALTER ROLE</codeph> statement is a Greenplum Database extension.</p></section><section id="section8"><title>See Also</title><p><codeph><xref href="./CREATE_ROLE.xml#topic1" type="topic" format="dita"/></codeph>,
             <codeph><xref href="./DROP_ROLE.xml#topic1" type="topic" format="dita"/></codeph>,
             <codeph><xref href="./SET.xml#topic1" type="topic" format="dita"/></codeph>,
+            <codeph><xref href="./CREATE_RESOURCE_GROUP.xml#topic1" type="topic" format="dita"
+          /></codeph>,
             <codeph><xref href="./CREATE_RESOURCE_QUEUE.xml#topic1" type="topic" format="dita"
           /></codeph>, <codeph><xref href="./GRANT.xml#topic1" type="topic" format="dita"
         /></codeph>, <codeph><xref href="./REVOKE.xml#topic1" type="topic" format="dita"

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_ROLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_ROLE.xml
@@ -46,11 +46,10 @@ its password if the password is MD5-encrypted.</li><li id="av136604"><b>SET | RE
           role can only belong to one resource queue. For a role without <codeph>LOGIN</codeph>
           privilege, resource queues have no effect. See <codeph><xref
               href="./CREATE_RESOURCE_QUEUE.xml#topic1" type="topic" format="dita"/></codeph> for
-          more information.</li><li id="av1370583"><b>RESOURCE GROUP</b> — When resource group-based workload management is configured, assigns a resource group to the role.
+          more information.</li><li id="av1370583"><b>RESOURCE GROUP</b> — Assigns a resource group to the role.
           The role would then be subject to the concurrent transaction, memory, and CPU limits
-          configured for the resource group. You can
-          assign a single resource group to a role, and you can assign a resource group to multiple
-          roles. See <codeph><xref
+          configured for the resource group. You can assign a single resource group to one or more roles. 
+          See <codeph><xref
               href="./CREATE_RESOURCE_GROUP.xml#topic1" type="topic" format="dita"/></codeph> for
           additional information.</li><li id="av137061"><b>WITH <varname>option</varname></b> — Changes many of the role attributes that can be
           specified in <codeph><xref href="./CREATE_ROLE.xml#topic1" type="topic" format="dita"

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml
@@ -21,7 +21,7 @@ MEMORY_LIMIT=<varname>integer</varname>
          group is assigned to one or more roles and identifies concurrent transaction, memory,
          and CPU limits for the role when resource group-based workload management is enabled. Only a superuser can create a resource group.</p>
       <p>Greenplum Database pre-defines two default resource groups: <codeph>admin_group</codeph>
-         and <codeph>default_group</codeph>. These group names are reserved, as is the group name <codeph>NONE</codeph>.</p>
+         and <codeph>default_group</codeph>. These group names are reserved.</p>
       <p>The <codeph>max_resource_groups</codeph> server configuration parameter governs the maximum number of resource groups you can create.</p>
       <p>
         To set appropriate limits for resource groups, the Greenplum Database administrator must

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml
@@ -52,15 +52,15 @@ MEMORY_LIMIT=<varname>integer</varname>
         </plentry>
         <plentry>
           <pt>MEMORY_LIMIT <varname>integer</varname></pt>
-          <pd>Required. Sets the total percentage of Greenplum Database memory resources to allocate to all transactions submitted from roles assigned this resource group. The minimum memory percentage you can specify for a resource group is 1. The maximum is 100. The sum of the <codeph>MEMORY_LIMIT</codeph> values specified for all resource groups defined in the Greenplum Database cluster must be less than or equal to 100.</pd>
+          <pd>Required. The total percentage of Greenplum Database memory resources to allocate to this resource group. The minimum memory percentage you can specify for a resource group is 1. The maximum is 100. The sum of the <codeph>MEMORY_LIMIT</codeph> values specified for all resource groups defined in the Greenplum Database cluster must be less than or equal to 100.</pd>
         </plentry>
         <plentry>
           <pt>MEMORY_SHARED_QUOTA <varname>integer</varname></pt>
-          <pd>Resource groups with a <codeph>MEMORY_SHARED_QUOTA</codeph> threshold set aside a percentage of memory allotted to the resource group to share across transactions. A transaction may use none, some, or all of this memory. The minimum memory shared quota percentage you can specify for a resource group is 0. The maximum is 100. The default <codeph>MEMORY_SHARED_QUOTA</codeph> value is 20. The sum of the <codeph>MEMORY_SHARED_QUOTA</codeph> and <codeph>MEMORY_SPILL_RATIO</codeph> values specified for a resource group cannot exceed 100.</pd>
+          <pd>The quota of shared memory in the resource group. Resource groups with a <codeph>MEMORY_SHARED_QUOTA</codeph> threshold set aside a percentage of memory allotted to the resource group to share across transactions. A transaction may use none, some, or all of this memory. The minimum memory shared quota percentage you can specify for a resource group is 0. The maximum is 100. The default <codeph>MEMORY_SHARED_QUOTA</codeph> value is 20. The sum of the <codeph>MEMORY_SHARED_QUOTA</codeph> and <codeph>MEMORY_SPILL_RATIO</codeph> values specified for a resource group cannot exceed 100.</pd>
         </plentry>
         <plentry>
           <pt>MEMORY_SPILL_RATIO <varname>integer</varname></pt>
-          <pd>The <codeph>MEMORY_SPILL_RATIO</codeph> identifies how much more or less memory to allocate to a transaction before spilling to disk. The minimum memory spill ratio percentage you can specify for a resource group is 1. The maximum is 100. The upper limit is (100 - <codeph>MEMORY_SHARED_QUOTA</codeph>). The default <codeph>MEMORY_SPILL_RATIO</codeph> value is 20. The sum of the <codeph>MEMORY_SHARED_QUOTA</codeph> and <codeph>MEMORY_SPILL_RATIO</codeph> values specified for a resource group cannot exceed 100.</pd>
+          <pd>The amount of memory to allocate to a transaction before spilling to disk. The minimum memory spill ratio percentage you can specify for a resource group is 1. The maximum is 100. The upper limit is (100 - <codeph>MEMORY_SHARED_QUOTA</codeph>). The default <codeph>MEMORY_SPILL_RATIO</codeph> value is 20. The sum of the <codeph>MEMORY_SHARED_QUOTA</codeph> and <codeph>MEMORY_SPILL_RATIO</codeph> values specified for a resource group cannot exceed 100.</pd>
         </plentry>
       </parml>
     </section>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml
@@ -11,9 +11,9 @@
       <p>where <varname>group_attribute</varname> is:</p>
       <codeblock>CPU_RATE_LIMIT=<varname>integer</varname>
 MEMORY_LIMIT=<varname>integer</varname>
-    [ CONCURRENCY=<varname>integer</varname> ]
-    [ MEMORY_SHARED_QUOTA=<varname>integer</varname> ]
-    [ MEMORY_SPILL_RATIO=<varname>integer</varname> ]</codeblock>
+[ CONCURRENCY=<varname>integer</varname> ]
+[ MEMORY_SHARED_QUOTA=<varname>integer</varname> ]
+[ MEMORY_SPILL_RATIO=<varname>integer</varname> ]</codeblock>
     </section>
     <section id="section3">
       <title>Description</title>
@@ -42,12 +42,12 @@ MEMORY_LIMIT=<varname>integer</varname>
         </plentry>
         <plentry>
           <pt>CONCURRENCY <varname>integer</varname></pt>
-          <pd>The maximum number of concurrent active and idle transactions submitted from roles assigned this resource group permitted on the system at any given time. The <codeph>CONCURRENCY</codeph> value must be an integer in the range [1 .. <codeph>max_connections</codeph>]. The default <codeph>CONCURRENCY</codeph> value is 20.
+          <pd>The maximum number of concurrent transactions, including active and idle transactions, that are permitted for this resource group. The <codeph>CONCURRENCY</codeph> value must be an integer in the range [1 .. <codeph>max_connections</codeph>]. The default <codeph>CONCURRENCY</codeph> value is 20.
             </pd>
         </plentry>
         <plentry>
           <pt>CPU_RATE_LIMIT <varname>integer</varname></pt>
-          <pd>Required. Sets the total percentage of Greenplum Database CPU resources to allocate to this resource group. The minimum CPU percentage you can specify for a resource group is 1. The maximum is 100. The sum of the <codeph>CPU_RATE_LIMIT</codeph> values specified for all resource groups defined in the Greenplum Database cluster must be less than or equal to 100.
+          <pd>Required. The percentage of CPU resources to allocate to this resource group. The minimum CPU percentage you can specify for a resource group is 1. The maximum is 100. The sum of the <codeph>CPU_RATE_LIMIT</codeph> values specified for all resource groups defined in the Greenplum Database cluster must be less than or equal to 100.
           </pd>
         </plentry>
         <plentry>
@@ -65,7 +65,7 @@ MEMORY_LIMIT=<varname>integer</varname>
       </parml>
     </section>
     <section id="section5"><title>Notes</title>
-        <p>You cannot submit an <codeph>CREATE RESOURCE GROUP</codeph> command in a sub-transaction.</p>
+        <p>You cannot submit a <codeph>CREATE RESOURCE GROUP</codeph> command in a sub-transaction.</p>
         <p>Use the
           <codeph>gp_toolkit.gp_resgroup_config</codeph> system view to display the limit 
         settings of all resource groups:</p><codeblock>SELECT * FROM gp_toolkit.gp_resgroup_config;</codeblock>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml
@@ -27,7 +27,7 @@ MEMORY_LIMIT=<varname>integer</varname>
         To set appropriate limits for resource groups, the Greenplum Database administrator must
         be familiar with the queries typically executed on the system, as well as the users/roles executing those queries.</p>
       <p>
-        After defining a resource group, assign the group to one more more roles using the <codeph><xref
+        After defining a resource group, assign the group to one or more roles using the <codeph><xref
             href="ALTER_ROLE.xml#topic1" type="topic" format="dita"/></codeph> or <codeph><xref
             href="./CREATE_ROLE.xml#topic1" type="topic" format="dita"/></codeph> commands.</p>
     </section>
@@ -56,7 +56,7 @@ MEMORY_LIMIT=<varname>integer</varname>
         </plentry>
         <plentry>
           <pt>MEMORY_SHARED_QUOTA <varname>integer</varname></pt>
-          <pd>The quota of shared memory in the resource group. Resource groups with a <codeph>MEMORY_SHARED_QUOTA</codeph> threshold set aside a percentage of memory allotted to the resource group to share across transactions. This shared memory isallocated on a first-come first-server basis as available. A transaction may use none, some, or all of this memory. The minimum memory shared quota percentage you can specify for a resource group is 0. The maximum is 100. The default <codeph>MEMORY_SHARED_QUOTA</codeph> value is 20. The sum of the <codeph>MEMORY_SHARED_QUOTA</codeph> and <codeph>MEMORY_SPILL_RATIO</codeph> values specified for a resource group cannot exceed 100.</pd>
+          <pd>The quota of shared memory in the resource group. Resource groups with a <codeph>MEMORY_SHARED_QUOTA</codeph> threshold set aside a percentage of memory allotted to the resource group to share across transactions. This shared memory is allocated on a first-come first-server basis as available. A transaction may use none, some, or all of this memory. The minimum memory shared quota percentage you can specify for a resource group is 0. The maximum is 100. The default <codeph>MEMORY_SHARED_QUOTA</codeph> value is 20. The sum of the <codeph>MEMORY_SHARED_QUOTA</codeph> and <codeph>MEMORY_SPILL_RATIO</codeph> values specified for a resource group cannot exceed 100.</pd>
         </plentry>
         <plentry>
           <pt>MEMORY_SPILL_RATIO <varname>integer</varname></pt>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic id="topic1">
+  <title id="by20941">CREATE RESOURCE GROUP</title>
+  <body>
+    <p id="sql_command_desc">Defines a new resource group.</p>
+    <section id="section2">
+      <title>Synopsis</title>
+      <codeblock id="sql_command_synopsis">CREATE RESOURCE GROUP <varname>name</varname> WITH (<varname>group_attribute</varname>=<varname>value</varname> [, ... ])</codeblock>
+      <p>where <varname>group_attribute</varname> is:</p>
+      <codeblock>CPU_RATE_LIMIT=<varname>integer</varname>
+MEMORY_LIMIT=<varname>integer</varname>
+    [ CONCURRENCY=<varname>integer</varname> ]
+    [ MEMORY_SHARED_QUOTA=<varname>integer</varname> ]
+    [ MEMORY_SPILL_RATIO=<varname>integer</varname> ]</codeblock>
+    </section>
+    <section id="section3">
+      <title>Description</title>
+      <p>Creates a new resource group for Greenplum Database workload management. A resource
+         group is assigned to one or more roles and identifies concurrent transaction, memory,
+         and CPU limits for the role when resource group-based workload management is enabled. Only a superuser can create a resource group.</p>
+      <p>Greenplum Database pre-defines two default resource groups: <codeph>admin_group</codeph>
+         and <codeph>default_group</codeph>. These group names are reserved, as is the group name <codeph>NONE</codeph>.</p>
+      <p>The <codeph>max_resource_groups</codeph> server configuration parameter governs the maximum number of resource groups you can create.</p>
+      <p>
+        To set appropriate limits for resource groups, the Greenplum Database administrator must
+        be familiar with the queries typically executed on the system, as well as the users/roles executing those queries.</p>
+      <p>
+        After defining a resource group, assign the group to one more more roles using the <codeph><xref
+            href="ALTER_ROLE.xml#topic1" type="topic" format="dita"/></codeph> or <codeph><xref
+            href="./CREATE_ROLE.xml#topic1" type="topic" format="dita"/></codeph> commands.</p>
+    </section>
+    <section id="section4">
+      <title>Parameters</title>
+      <parml>
+        <plentry>
+          <pt>
+            <varname>name</varname>
+          </pt>
+          <pd>The name of the resource group.</pd>
+        </plentry>
+        <plentry>
+          <pt>CONCURRENCY <varname>integer</varname></pt>
+          <pd>The maximum number of concurrent active and idle transactions submitted from roles assigned this resource group permitted on the system at any given time. The <codeph>CONCURRENCY</codeph> value must be an integer in the range [1 .. <codeph>max_connections</codeph>]. The default <codeph>CONCURRENCY</codeph> value is 20.
+            </pd>
+        </plentry>
+        <plentry>
+          <pt>CPU_RATE_LIMIT <varname>integer</varname></pt>
+          <pd>Required. Sets the total percentage of Greenplum Database CPU resources to allocate to this resource group. The minimum CPU percentage you can specify for a resource group is 1. The maximum is 100. The sum of the <codeph>CPU_RATE_LIMIT</codeph> values specified for all resource groups defined in the Greenplum Database cluster must be less than or equal to 100.
+          </pd>
+        </plentry>
+        <plentry>
+          <pt>MEMORY_LIMIT <varname>integer</varname></pt>
+          <pd>Required. Sets the total percentage of Greenplum Database memory resources to allocate to all transactions submitted from roles assigned this resource group. The minimum memory percentage you can specify for a resource group is 1. The maximum is 100. The sum of the <codeph>MEMORY_LIMIT</codeph> values specified for all resource groups defined in the Greenplum Database cluster must be less than or equal to 100.</pd>
+        </plentry>
+        <plentry>
+          <pt>MEMORY_SHARED_QUOTA <varname>integer</varname></pt>
+          <pd>Resource groups with a <codeph>MEMORY_SHARED_QUOTA</codeph> threshold set aside a percentage of memory allotted to the resource group to share across transactions. A transaction may use none, some, or all of this memory. The minimum memory shared quota percentage you can specify for a resource group is 0. The maximum is 100. The default <codeph>MEMORY_SHARED_QUOTA</codeph> value is 20. The sum of the <codeph>MEMORY_SHARED_QUOTA</codeph> and <codeph>MEMORY_SPILL_RATIO</codeph> values specified for a resource group cannot exceed 100.</pd>
+        </plentry>
+        <plentry>
+          <pt>MEMORY_SPILL_RATIO <varname>integer</varname></pt>
+          <pd>The <codeph>MEMORY_SPILL_RATIO</codeph> identifies how much more or less memory to allocate to a transaction before spilling to disk. The minimum memory spill ratio percentage you can specify for a resource group is 1. The maximum is 100. The upper limit is (100 - <codeph>MEMORY_SHARED_QUOTA</codeph>). The default <codeph>MEMORY_SPILL_RATIO</codeph> value is 20. The sum of the <codeph>MEMORY_SHARED_QUOTA</codeph> and <codeph>MEMORY_SPILL_RATIO</codeph> values specified for a resource group cannot exceed 100.</pd>
+        </plentry>
+      </parml>
+    </section>
+    <section id="section5"><title>Notes</title>
+        <p>You cannot submit an <codeph>CREATE RESOURCE GROUP</codeph> command in a sub-transaction.</p>
+        <p>Use the
+          <codeph>gp_toolkit.gp_resgroup_config</codeph> system view to display the limit 
+        settings of all resource groups:</p><codeblock>SELECT * FROM gp_toolkit.gp_resgroup_config;</codeblock>
+    </section>
+    <section id="section6">
+      <title>Examples</title>
+      <p>Create a resource group with CPU and memory limit percentages of 35: </p>
+      <codeblock>CREATE RESOURCE GROUP rgroup1 WITH (CPU_RATE_LIMIT=35, MEMORY_LIMIT=35);</codeblock>
+      <p>Create a resource group with a concurrent transaction limit of 30, a memory limit of 15, and a CPU limit of 25:</p>
+      <codeblock>CREATE RESOURCE GROUP rgroup2 WITH (CONCURRENCY=20, 
+  MEMORY_LIMIT=15, CPU_RATE_LIMIT=25);</codeblock>
+    </section>
+    <section id="section7">
+      <title>Compatibility</title>
+      <p><codeph>CREATE RESOURCE GROUP</codeph> is a Greenplum Database extension. There is no
+        provision for resource groups or workload management in the SQL standard.</p>
+    </section>
+    <section id="section8">
+      <title>See Also</title>
+      <p><codeph><xref href="ALTER_ROLE.xml#topic1" type="topic" format="dita"/></codeph>,
+            <codeph><xref href="./CREATE_ROLE.xml#topic1" type="topic" format="dita"/></codeph>,
+            <codeph><xref href="ALTER_RESOURCE_GROUP.xml#topic1" type="topic" format="dita"
+          /></codeph>, <codeph><xref href="./DROP_RESOURCE_GROUP.xml#topic1" type="topic"
+            format="dita"/></codeph></p>
+    </section>
+  </body>
+</topic>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml
@@ -65,7 +65,7 @@ MEMORY_LIMIT=<varname>integer</varname>
       </parml>
     </section>
     <section id="section5"><title>Notes</title>
-        <p>You cannot submit a <codeph>CREATE RESOURCE GROUP</codeph> command in a sub-transaction.</p>
+        <p>You cannot submit a <codeph>CREATE RESOURCE GROUP</codeph> command in an explicit transaction or sub-transaction.</p>
         <p>Use the
           <codeph>gp_toolkit.gp_resgroup_config</codeph> system view to display the limit 
         settings of all resource groups:</p><codeblock>SELECT * FROM gp_toolkit.gp_resgroup_config;</codeblock>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml
@@ -56,11 +56,11 @@ MEMORY_LIMIT=<varname>integer</varname>
         </plentry>
         <plentry>
           <pt>MEMORY_SHARED_QUOTA <varname>integer</varname></pt>
-          <pd>The quota of shared memory in the resource group. Resource groups with a <codeph>MEMORY_SHARED_QUOTA</codeph> threshold set aside a percentage of memory allotted to the resource group to share across transactions. A transaction may use none, some, or all of this memory. The minimum memory shared quota percentage you can specify for a resource group is 0. The maximum is 100. The default <codeph>MEMORY_SHARED_QUOTA</codeph> value is 20. The sum of the <codeph>MEMORY_SHARED_QUOTA</codeph> and <codeph>MEMORY_SPILL_RATIO</codeph> values specified for a resource group cannot exceed 100.</pd>
+          <pd>The quota of shared memory in the resource group. Resource groups with a <codeph>MEMORY_SHARED_QUOTA</codeph> threshold set aside a percentage of memory allotted to the resource group to share across transactions. This shared memory isallocated on a first-come first-server basis as available. A transaction may use none, some, or all of this memory. The minimum memory shared quota percentage you can specify for a resource group is 0. The maximum is 100. The default <codeph>MEMORY_SHARED_QUOTA</codeph> value is 20. The sum of the <codeph>MEMORY_SHARED_QUOTA</codeph> and <codeph>MEMORY_SPILL_RATIO</codeph> values specified for a resource group cannot exceed 100.</pd>
         </plentry>
         <plentry>
           <pt>MEMORY_SPILL_RATIO <varname>integer</varname></pt>
-          <pd>The amount of memory to allocate to a transaction before spilling to disk. The minimum memory spill ratio percentage you can specify for a resource group is 1. The maximum is 100. The upper limit is (100 - <codeph>MEMORY_SHARED_QUOTA</codeph>). The default <codeph>MEMORY_SPILL_RATIO</codeph> value is 20. The sum of the <codeph>MEMORY_SHARED_QUOTA</codeph> and <codeph>MEMORY_SPILL_RATIO</codeph> values specified for a resource group cannot exceed 100.</pd>
+          <pd>The memory usage threshold for memory-intensive operators in a transaction. When the transaction reaches this threshold, it spills to disk. The minimum memory spill ratio percentage you can specify for a resource group is 1. The maximum is 100. The upper limit is (100 - <codeph>MEMORY_SHARED_QUOTA</codeph>). The default <codeph>MEMORY_SPILL_RATIO</codeph> value is 20. The sum of the <codeph>MEMORY_SHARED_QUOTA</codeph> and <codeph>MEMORY_SPILL_RATIO</codeph> values specified for a resource group cannot exceed 100.</pd>
         </plentry>
       </parml>
     </section>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_ROLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_ROLE.xml
@@ -158,12 +158,10 @@
                 </plentry>
                 <plentry>
                     <pt>RESOURCE GROUP <varname>group_name</varname></pt>
-                    <pd>When resource group-based workload management is enabled,
-                        the name of the resource group to assign to the the new role.  The role 
+                    <pd> The name of the resource group to assign to the the new role.  The role 
                         will be subject to the concurrent transaction, memory, and CPU limits
                         configured for the resource group.
-                        You can assign a single resource group to a role, and you can assign a
-                        resource group to multiple roles.</pd>
+                        You can assign a single resource group to one or more roles.</pd>
                     <pd>If you do not specify a resource group for a new role, the role is
                         automatically assigned the default resource group for the role's capability,
                         <codeph>admin_group</codeph> for <codeph>SUPERUSER</codeph> roles,

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_ROLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_ROLE.xml
@@ -166,10 +166,8 @@
                         automatically assigned the default resource group for the role's capability,
                         <codeph>admin_group</codeph> for <codeph>SUPERUSER</codeph> roles,
                         <codeph>default_group</codeph> for non-admin roles.</pd>
-                    <pd>You may assign a role with the <codeph>SUPERUSER</codeph> attribute the
-                        <codeph>admin_group</codeph> resource group.</pd>
-                    <pd>You may assign a non-admin role the <codeph>default_group</codeph>
-                        resource group.</pd>
+                    <pd>You can assign the <codeph>admin_group</codeph> resource group to any role having the <codeph>SUPERUSER</codeph> attribute.</pd>
+                    <pd>You can assign the <codeph>default_group</codeph> resource group to any role.</pd>
                 </plentry>
                 <plentry>
                     <pt>RESOURCE QUEUE <varname>queue_name</varname></pt>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_ROLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_ROLE.xml
@@ -26,6 +26,7 @@
     | ROLE <varname>rolename</varname> [, ...]
     | ADMIN <varname>rolename</varname> [, ...]
     | RESOURCE QUEUE <varname>queue_name</varname>
+    | RESOURCE GROUP <varname>group_name</varname>
     | [ DENY <varname>deny_point</varname> ]
     | [ DENY BETWEEN <varname>deny_point</varname> AND <varname>deny_point</varname>]</codeblock>
         </section>
@@ -156,6 +157,23 @@
                         giving them the right to grant membership in this role to others.</pd>
                 </plentry>
                 <plentry>
+                    <pt>RESOURCE GROUP <varname>group_name</varname></pt>
+                    <pd>When resource group-based workload management is enabled,
+                        the name of the resource group to assign to the the new role.  The role 
+                        will be subject to the concurrent transaction, memory, and CPU limits
+                        configured for the resource group.
+                        You can assign a single resource group to a role, and you can assign a
+                        resource group to multiple roles.</pd>
+                    <pd>If you do not specify a resource group for a new role, the role is
+                        automatically assigned the default resource group for the role's capability,
+                        <codeph>admin_group</codeph> for <codeph>SUPERUSER</codeph> roles,
+                        <codeph>default_group</codeph> for non-admin roles.</pd>
+                    <pd>You may assign a role with the <codeph>SUPERUSER</codeph> attribute the
+                        <codeph>admin_group</codeph> resource group.</pd>
+                    <pd>You may assign a non-admin role the <codeph>default_group</codeph>
+                        resource group.</pd>
+                </plentry>
+                <plentry>
                     <pt>RESOURCE QUEUE <varname>queue_name</varname></pt>
                     <pd>The name of the resource queue to which the new user-level role is to be
                         assigned. Only roles with <codeph>LOGIN</codeph> privilege can be assigned
@@ -213,7 +231,8 @@
                 create databases, even if <codeph>INHERIT</codeph> is set. These
                 privileges/attributes are never inherited: <codeph>SUPERUSER</codeph>,
                     <codeph>CREATEDB</codeph>, <codeph>CREATEROLE</codeph>,
-                    <codeph>CREATEEXTTABLE</codeph>, <codeph>LOGIN</codeph>, and <codeph>RESOURCE
+                    <codeph>CREATEEXTTABLE</codeph>, <codeph>LOGIN</codeph>, <codeph>RESOURCE
+                    GROUP</codeph>, and <codeph>RESOURCE
                     QUEUE</codeph>. The attributes must be set on each user-level role.</p>
             <p>The <codeph>INHERIT</codeph> attribute is the default for reasons of backwards
                 compatibility. In prior releases of Greenplum Database, users always had access to
@@ -250,6 +269,8 @@
             <codeblock>CREATE ROLE admin WITH CREATEDB CREATEROLE;</codeblock>
             <p>Create a role that does not allow login access on Sundays:</p>
             <codeblock>CREATE ROLE user3 DENY DAY 'Sunday';</codeblock>
+            <p>Create a role, assigning a resource group:</p>
+            <codeblock>CREATE ROLE bill RESOURCE GROUP rg_light;</codeblock>
         </section>
         <section id="section7">
             <title>Compatibility</title>
@@ -276,6 +297,8 @@
                         type="topic" format="dita"/></codeph>, <codeph><xref
                         href="./REVOKE.xml#topic1" type="topic" format="dita"/></codeph>,
                         <codeph><xref href="CREATE_RESOURCE_QUEUE.xml#topic1" type="topic"
+                        format="dita"/></codeph>
+                        <codeph><xref href="CREATE_RESOURCE_GROUP.xml#topic1" type="topic"
                         format="dita"/></codeph></p>
         </section>
     </body>

--- a/gpdb-doc/dita/ref_guide/sql_commands/DROP_RESOURCE_GROUP.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/DROP_RESOURCE_GROUP.xml
@@ -15,9 +15,9 @@ on the <codeph>pg_roles</codeph> and <codeph>pg_resgroup</codeph> system
 catalog tables:</p><codeblock>SELECT rolname, rsgname 
   FROM pg_roles, pg_resgroup
   WHERE pg_roles.rolresgroup=pg_resgroup.oid;</codeblock></section><section id="section6"><title>Examples</title>
-<p>Remove the resource group named <codeph>adhoc</codeph>:</p><codeblock>DROP RESOURCE GROUP adhoc;</codeblock></section>
 <p>Remove the resource group assigned to a role. This operation then assigns the default
 resource group <codeph>default_group</codeph> to the role:</p><codeblock>ALTER ROLE bob RESOURCE GROUP NONE;</codeblock>
+<p>Remove the resource group named <codeph>adhoc</codeph>:</p><codeblock>DROP RESOURCE GROUP adhoc;</codeblock></section>
 <section id="section7"><title>Compatibility</title><p>The <codeph>DROP RESOURCE GROUP</codeph> statement is a Greenplum Database extension. </p></section><section id="section8"><title>See Also</title><p><codeph><xref href="ALTER_RESOURCE_GROUP.xml#topic1" type="topic" format="dita"/></codeph>,
             <codeph><xref href="CREATE_RESOURCE_GROUP.xml#topic1" type="topic" format="dita"
           /></codeph>, <codeph><xref href="ALTER_ROLE.xml#topic1" type="topic" format="dita"

--- a/gpdb-doc/dita/ref_guide/sql_commands/DROP_RESOURCE_GROUP.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/DROP_RESOURCE_GROUP.xml
@@ -4,7 +4,7 @@
 <topic id="topic1"><title id="dc20941">DROP RESOURCE GROUP</title><body><p id="sql_command_desc">Removes a resource group.</p><section id="section2"><title>Synopsis</title><codeblock id="sql_command_synopsis">DROP RESOURCE GROUP <varname>group_name</varname></codeblock></section><section id="section3"><title>Description</title><p>This command removes a resource group from Greenplum
 Database. Only a superuser
 can drop a resource group.</p><p>To drop a resource group, the group cannot be assigned to any roles,
-nor can it have any statements pending in the group.</p><p>You cannot drop the pre-defined <codeph>admin_group</codeph> and <codeph>default_group</codeph> resource groups.</p>
+nor can it have any statements pending or running in the group.</p><p>You cannot drop the pre-defined <codeph>admin_group</codeph> and <codeph>default_group</codeph> resource groups.</p>
 </section><section id="section4"><title>Parameters</title><parml><plentry><pt><varname>group_name</varname></pt><pd>The name of the resource group to remove.</pd></plentry></parml></section><section id="section5"><title>Notes</title><p>You cannot submit a <codeph>DROP RESOURCE GROUP</codeph> command in an explicit transaction or sub-transaction.</p><p>Use <codeph><xref href="ALTER_ROLE.xml#topic1" type="topic" format="dita"/></codeph> to remove the resource group assigned
         to a specific user/role.</p><p> Perform the following query to view all of the currently active
         queries for all resource groups:</p><codeblock>SELECT usename, current_query, waiting, procpid,

--- a/gpdb-doc/dita/ref_guide/sql_commands/DROP_RESOURCE_GROUP.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/DROP_RESOURCE_GROUP.xml
@@ -5,7 +5,7 @@
 Database. Only a superuser
 can drop a resource group.</p><p>To drop a resource group, the group cannot be assigned to any roles,
 nor can it have any statements pending in the group.</p><p>You cannot drop the pre-defined <codeph>admin_group</codeph> and <codeph>default_group</codeph> resource groups.</p>
-</section><section id="section4"><title>Parameters</title><parml><plentry><pt><varname>group_name</varname></pt><pd>The name of the resource group to remove.</pd></plentry></parml></section><section id="section5"><title>Notes</title><p>You cannot submit a <codeph>DROP RESOURCE GROUP</codeph> command in a sub-transaction.</p><p>Use <codeph><xref href="ALTER_ROLE.xml#topic1" type="topic" format="dita"/></codeph> to remove the resource group assigned
+</section><section id="section4"><title>Parameters</title><parml><plentry><pt><varname>group_name</varname></pt><pd>The name of the resource group to remove.</pd></plentry></parml></section><section id="section5"><title>Notes</title><p>You cannot submit a <codeph>DROP RESOURCE GROUP</codeph> command in an explicit transaction or sub-transaction.</p><p>Use <codeph><xref href="ALTER_ROLE.xml#topic1" type="topic" format="dita"/></codeph> to remove the resource group assigned
         to a specific user/role.</p><p> Perform the following query to view all of the currently active
         queries for all resource groups:</p><codeblock>SELECT usename, current_query, waiting, procpid,
     rsgid, rsgname, rsgqueueduration 

--- a/gpdb-doc/dita/ref_guide/sql_commands/DROP_RESOURCE_GROUP.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/DROP_RESOURCE_GROUP.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic id="topic1"><title id="dc20941">DROP RESOURCE GROUP</title><body><p id="sql_command_desc">Removes a resource group.</p><section id="section2"><title>Synopsis</title><codeblock id="sql_command_synopsis">DROP RESOURCE GROUP <varname>group_name</varname></codeblock></section><section id="section3"><title>Description</title><p>This command removes a resource group from Greenplum
+Database. Only a superuser
+can drop a resource group.</p><p>To drop a resource group, the group cannot be assigned to any roles,
+nor can it have any statements pending in the group.</p><p>You cannot drop the pre-defined <codeph>admin_group</codeph> and <codeph>default_group</codeph> resource groups.</p>
+</section><section id="section4"><title>Parameters</title><parml><plentry><pt><varname>group_name</varname></pt><pd>The name of the resource group to remove.</pd></plentry></parml></section><section id="section5"><title>Notes</title><p>You cannot submit a <codeph>DROP RESOURCE GROUP</codeph> command in a sub-transaction.</p><p>Use <codeph><xref href="ALTER_ROLE.xml#topic1" type="topic" format="dita"/></codeph> to remove the resource group assigned
+        to a specific user/role.</p><p> Perform the following query to view all of the currently active
+        queries for all resource groups:</p><codeblock>SELECT usename, current_query, waiting, procpid,
+    rsgid, rsgname, rsgqueueduration 
+  FROM pg_stat_activity;
+</codeblock><p>To view the resource group assignments, perform the following query
+on the <codeph>pg_roles</codeph> and <codeph>pg_resgroup</codeph> system
+catalog tables:</p><codeblock>SELECT rolname, rsgname 
+  FROM pg_roles, pg_resgroup
+  WHERE pg_roles.rolresgroup=pg_resgroup.oid;</codeblock></section><section id="section6"><title>Examples</title>
+<p>Remove the resource group named <codeph>adhoc</codeph>:</p><codeblock>DROP RESOURCE GROUP adhoc;</codeblock></section>
+<p>Remove the resource group assigned to a role. This operation then assigns the default
+resource group <codeph>default_group</codeph> to the role:</p><codeblock>ALTER ROLE bob RESOURCE GROUP NONE;</codeblock>
+<section id="section7"><title>Compatibility</title><p>The <codeph>DROP RESOURCE GROUP</codeph> statement is a Greenplum Database extension. </p></section><section id="section8"><title>See Also</title><p><codeph><xref href="ALTER_RESOURCE_GROUP.xml#topic1" type="topic" format="dita"/></codeph>,
+            <codeph><xref href="CREATE_RESOURCE_GROUP.xml#topic1" type="topic" format="dita"
+          /></codeph>, <codeph><xref href="ALTER_ROLE.xml#topic1" type="topic" format="dita"
+          /></codeph></p></section></body></topic>

--- a/gpdb-doc/dita/ref_guide/sql_commands/sql_ref.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/sql_ref.xml
@@ -51,6 +51,9 @@
       <li id="ad143363">
         <xref href="./ALTER_PROTOCOL.xml#topic1" type="topic" format="dita"/>
       </li>
+      <li id="ad1433683">
+        <xref href="./ALTER_RESOURCE_GROUP.xml#topic1" type="topic" format="dita"/>
+      </li>
       <li id="ad143368">
         <xref href="./ALTER_RESOURCE_QUEUE.xml#topic1" type="topic" format="dita"/>
       </li>
@@ -147,6 +150,9 @@
       </li>
       <li>
         <xref href="./CREATE_PROTOCOL.xml#topic1" type="topic" format="dita"/>
+      </li>
+      <li id="ad1405713">
+        <xref href="./CREATE_RESOURCE_GROUP.xml#topic1" type="topic" format="dita"/>
       </li>
       <li id="ad140571">
         <xref href="./CREATE_RESOURCE_QUEUE.xml#topic1" type="topic" format="dita"/>
@@ -246,6 +252,9 @@
       </li>
       <li>
         <xref href="./DROP_PROTOCOL.xml#topic1" type="topic" format="dita"/>
+      </li>
+      <li id="ad1407123">
+        <xref href="./DROP_RESOURCE_GROUP.xml#topic1" type="topic" format="dita"/>
       </li>
       <li id="ad140712">
         <xref href="./DROP_RESOURCE_QUEUE.xml#topic1" type="topic" format="dita"/>


### PR DESCRIPTION
first pass at new and updated SQL reference pages for the resource groups feature.

to see nicely formatted versions, here are links to the new/updated SQL ref pages on a review staging site.  (note: this site is a work-in-progress staging area, so please do not use as a go-to source for gpdb 5.0 docs.)
- http://docs-gpdb-review-staging.cfapps.io/500Beta/ref_guide/sql_commands/ALTER_ROLE.html
- http://docs-gpdb-review-staging.cfapps.io/500Beta/ref_guide/sql_commands/CREATE_ROLE.html
- http://docs-gpdb-review-staging.cfapps.io/500Beta/ref_guide/sql_commands/ALTER_RESOURCE_GROUP.html (new)
- http://docs-gpdb-review-staging.cfapps.io/500Beta/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.html (new)
- http://docs-gpdb-review-staging.cfapps.io/500Beta/ref_guide/sql_commands/DROP_RESOURCE_GROUP.html (new)