### PR TITLE
docs - add some resource group GUCs to the reference guide

### DIFF
--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -731,9 +731,6 @@
               <xref href="#resource_cleanup_gangs_on_wait"/>
             </li>
             <li>
-              <xref href="#resource_scheduler"/>
-            </li>
-            <li>
               <xref href="#resource_select_only"/>
             </li>
             <li>
@@ -4719,7 +4716,7 @@
   <topic id="gp_resource_manager">
     <title>gp_resource_manager</title>
     <body>
-      <p>Identifies the workload management scheme currently enabled in the Greenplum Database cluster. The default scheme is workload management using resource queues.</p>
+      <p>Identifies the resource management scheme currently enabled in the Greenplum Database cluster. The default scheme is workload management using resource queues.</p>
       <table id="gp_resource_manager_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>
@@ -8106,33 +8103,6 @@
           <tbody>
             <row>
               <entry colname="col1">Boolean</entry>
-              <entry colname="col2">on</entry>
-              <entry colname="col3">master<p>system</p><p>restart</p></entry>
-            </row>
-          </tbody>
-        </tgroup>
-      </table>
-    </body>
-  </topic>
-  <topic id="resource_scheduler">
-    <title>resource_scheduler</title>
-    <body>
-      <p>Enables or disables resource scheduling and the workload management feature. The <codeph>gp_resource_manager</codeph> server configuration parameter identifies the workload management scheme currently enabled in the Greenplum Database cluster - resource queue-based or resource group-based.</p>
-      <table id="resource_scheduler_table">
-        <tgroup cols="3">
-          <colspec colnum="1" colname="col1" colwidth="1*"/>
-          <colspec colnum="2" colname="col2" colwidth="1*"/>
-          <colspec colnum="3" colname="col3" colwidth="1*"/>
-          <thead>
-            <row>
-              <entry colname="col1">Value Range</entry>
-              <entry colname="col2">Default</entry>
-              <entry colname="col3">Set Classifications</entry>
-            </row>
-          </thead>
-          <tbody>
-            <row>
-              <entry colname="col1">on<p>off</p></entry>
               <entry colname="col2">on</entry>
               <entry colname="col3">master<p>system</p><p>restart</p></entry>
             </row>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -387,6 +387,15 @@
               <xref href="#gp_reraise_signal"/>
             </li>
             <li>
+              <xref href="#gp_resource_group_cpu_limit"/>
+            </li>
+            <li>
+              <xref href="#gp_resource_group_memory_limit"/>
+            </li>
+            <li>
+              <xref href="#gp_resource_manager"/>
+            </li>
+            <li>
               <xref href="#gp_resqueue_memory_policy"/>
             </li>
             <li>
@@ -607,6 +616,9 @@
               <xref href="#max_resource_portals_per_transaction"/>
             </li>
             <li>
+              <xref href="#max_resource_groups"/>
+            </li>
+            <li>
               <xref href="#max_resource_queues"/>
             </li>
             <li>
@@ -717,6 +729,9 @@
             </li>
             <li>
               <xref href="#resource_cleanup_gangs_on_wait"/>
+            </li>
+            <li>
+              <xref href="#resource_scheduler"/>
             </li>
             <li>
               <xref href="#resource_select_only"/>
@@ -4646,6 +4661,89 @@
       </table>
     </body>
   </topic>
+  <topic id="gp_resource_group_cpu_limit">
+    <title>gp_resource_group_cpu_limit</title>
+    <body>
+      <p>When resource group-based workload management is enabled, identifies the maximum 
+          percentage of system CPU resources to allocate to the Greenplum Database segment node.</p>
+      <table id="gp_resource_group_cpu_limit_table">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">0.1 - 1.0</entry>
+              <entry colname="col2">0.9</entry>
+              <entry colname="col3">local<p>system</p><p>restart</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
+  <topic id="gp_resource_group_memory_limit">
+    <title>gp_resource_group_memory_limit</title>
+    <body>
+      <p>When resource group-based workload management is enabled, identifies the maximum 
+          percentage of system memory resources to allocate to the Greenplum Database segment node.</p>
+      <table id="gp_resource_group_memory_limit_table">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">0.1 - 1.0</entry>
+              <entry colname="col2">0.9</entry>
+              <entry colname="col3">local<p>system</p><p>restart</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
+  <topic id="gp_resource_manager">
+    <title>gp_resource_manager</title>
+    <body>
+      <p>Identifies the workload management scheme currently enabled in the Greenplum Database cluster. The default scheme is workload management using resource queues.</p>
+      <table id="gp_resource_manager_table">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">group <p>queue</p></entry>
+              <entry colname="col2">queue</entry>
+              <entry colname="col3">local<p>system</p><p>restart</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
   <topic id="gp_resqueue_memory_policy">
     <title>gp_resqueue_memory_policy</title>
     <body>
@@ -6819,6 +6917,34 @@
       </table>
     </body>
   </topic>
+  <topic id="max_resource_groups">
+    <title>max_resource_groups</title>
+    <body>
+      <p>Sets the maximum number of resource groups that you can create in a Greenplum Database
+        system. Resource groups are defined system-wide.</p>
+      <table id="max_resource_queues_table">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">0 - INT_MAX</entry>
+              <entry colname="col2">9</entry>
+              <entry colname="col3">master<p>system</p><p>restart</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
   <topic id="max_resource_queues">
     <title>max_resource_queues</title>
     <body>
@@ -7981,6 +8107,33 @@
           <tbody>
             <row>
               <entry colname="col1">Boolean</entry>
+              <entry colname="col2">on</entry>
+              <entry colname="col3">master<p>system</p><p>restart</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
+  <topic id="resource_scheduler">
+    <title>resource_scheduler</title>
+    <body>
+      <p>Enables resource scheduling and the workload management feature. The <codeph>gp_resource_manager</codeph> server configuration parameter identifies the workload management scheme currently enabled in the Greenplum Database cluster - resource queue-based or resource group-based.</p>
+      <table id="resource_scheduler_table">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">on<p>off</p></entry>
               <entry colname="col2">on</entry>
               <entry colname="col3">master<p>system</p><p>restart</p></entry>
             </row>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -4664,8 +4664,8 @@
   <topic id="gp_resource_group_cpu_limit">
     <title>gp_resource_group_cpu_limit</title>
     <body>
-      <p>When resource group-based workload management is enabled, identifies the maximum 
-          percentage of system CPU resources to allocate to the Greenplum Database segment node.</p>
+      <p>Identifies the maximum percentage of system CPU resources to allocate to resource
+        groups on each Greenplum Database segment node.</p>
       <table id="gp_resource_group_cpu_limit_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>
@@ -4692,8 +4692,7 @@
   <topic id="gp_resource_group_memory_limit">
     <title>gp_resource_group_memory_limit</title>
     <body>
-      <p>When resource group-based workload management is enabled, identifies the maximum 
-          percentage of system memory resources to allocate to the Greenplum Database segment node.</p>
+      <p>Identifies the maximum percentage of system memory resources to allocate to resource groups on each Greenplum Database segment node.</p>
       <table id="gp_resource_group_memory_limit_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>
@@ -8118,7 +8117,7 @@
   <topic id="resource_scheduler">
     <title>resource_scheduler</title>
     <body>
-      <p>Enables resource scheduling and the workload management feature. The <codeph>gp_resource_manager</codeph> server configuration parameter identifies the workload management scheme currently enabled in the Greenplum Database cluster - resource queue-based or resource group-based.</p>
+      <p>Enables or disables resource scheduling and the workload management feature. The <codeph>gp_resource_manager</codeph> server configuration parameter identifies the workload management scheme currently enabled in the Greenplum Database cluster - resource queue-based or resource group-based.</p>
       <table id="resource_scheduler_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -1204,19 +1204,15 @@
               <xref href="guc-list.xml#gp_resource_group_memory_limit" type="section"
                 >gp_resource_group_memory_limit</xref>
             </p>
+          </stentry>
+          <stentry>
             <p>
               <xref href="guc-list.xml#gp_resource_manager" type="section"
                 >gp_resource_manager</xref>
             </p>
-          </stentry>
-          <stentry>
             <p>
               <xref href="guc-list.xml#max_resource_groups" type="section"
                 >max_resource_groups</xref>
-            </p>
-            <p>
-              <xref href="guc-list.xml#resource_scheduler" type="section"
-                >resource_scheduler</xref>
             </p>
           </stentry>
         </strow>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -41,6 +41,9 @@
       <li id="kh158581">
         <xref href="#topic44" type="topic" format="dita"/>
       </li>
+      <li id="kh1585815">
+        <xref href="#topic444" type="topic" format="dita"/>
+      </li>
       <li id="kh158590">
         <xref href="#topic45" type="topic" format="dita"/>
       </li>
@@ -1122,7 +1125,7 @@
     </body>
   </topic>
   <topic id="topic44" xml:lang="en">
-    <title id="kh155069">Workload Management Parameters</title>
+    <title id="kh155069">Workload Management Parameters (Resource Queues)</title>
     <body>
       <p>The following configuration parameters configure the Greenplum Database workload management
         feature (resource queues), query prioritization, memory utilization and concurrency control. </p>
@@ -1180,6 +1183,41 @@
             </p>
             <p><xref href="guc-list.xml#vmem_process_interrupt" type="section"
                 >vmem_process_interrupt</xref></p>
+          </stentry>
+        </strow>
+      </simpletable>
+    </body>
+  </topic>
+  <topic id="topic444" xml:lang="en">
+    <title id="kh1550694">Workload Management Parameters (Resource Groups)</title>
+    <body>
+      <p>The following parameters configure the Greenplum Database resource group
+        workload management feature. </p>
+      <simpletable id="kh1571613" frame="none">
+        <strow>
+          <stentry>
+            <p>
+              <xref href="guc-list.xml#gp_resource_group_cpu_limit" type="section"
+                >gp_resource_group_cpu_limit</xref>
+            </p>
+            <p>
+              <xref href="guc-list.xml#gp_resource_group_memory_limit" type="section"
+                >gp_resource_group_memory_limit</xref>
+            </p>
+            <p>
+              <xref href="guc-list.xml#gp_resource_manager" type="section"
+                >gp_resource_manager</xref>
+            </p>
+          </stentry>
+          <stentry>
+            <p>
+              <xref href="guc-list.xml#max_resource_groups" type="section"
+                >max_resource_groups</xref>
+            </p>
+            <p>
+              <xref href="guc-list.xml#resource_scheduler" type="section"
+                >resource_scheduler</xref>
+            </p>
           </stentry>
         </strow>
       </simpletable>


### PR DESCRIPTION
document the following resource group-related server configuration parameters in the reference guide:
- gp_resource_group_cpu_limit
- gp_resource_group_memory_limit
- gp_resource_manager
- max_resource_groups
- resource_scheduler

(other resource group-related server configuration parameters will be documented later.)

i wasn't totally sure about the set classifications, please verify those.

also, the resource_scheduler config parameter was not previously documented, though i believe it was also used for resource queues?

links to the relevant sections on work-in-progress review staging site:
- http://docs-gpdb-review-staging.cfapps.io/500Beta/ref_guide/config_params/guc_category-list.html#topic444
- http://docs-gpdb-review-staging.cfapps.io/500Beta/ref_guide/config_params/guc-list.html#gp_resource_group_cpu_limit
- http://docs-gpdb-review-staging.cfapps.io/500Beta/ref_guide/config_params/guc-list.html#gp_resource_group_memory_limit
- http://docs-gpdb-review-staging.cfapps.io/500Beta/ref_guide/config_params/guc-list.html#gp_resource_manager
- http://docs-gpdb-review-staging.cfapps.io/500Beta/ref_guide/config_params/guc-list.html#max_resource_groups
- http://docs-gpdb-review-staging.cfapps.io/500Beta/ref_guide/config_params/guc-list.html#resource_scheduler
