### PR TITLE
Make `keep_wal_segments` consistent across master and segments.

### DIFF
--- a/src/backend/access/transam/test/Makefile
+++ b/src/backend/access/transam/test/Makefile
@@ -15,3 +15,6 @@ xact.t: \
 	$(MOCK_DIR)/backend/storage/lmgr/lwlock_mock.o \
 	$(MOCK_DIR)/backend/access/transam/subtrans_mock.o \
 	$(MOCK_DIR)/backend/utils/error/elog_mock.o
+
+xlog.t: \
+    $(MOCK_DIR)/backend/replication/walsender_mock.o


### PR DESCRIPTION
We also refactor the code out of `CreateCheckPoint()` and make it into
its own function `GetXLogCleanUpTo()`.

Unit test added to verify the new logic works for both master and
segments.

This is hidden under #ifdef USE_SEGWALREP.

Signed-off-by: Asim R P <apraveen@pivotal.io>