### PR TITLE
Primary segment transitions to changetracking when WALrep mirror is down

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -156,8 +156,25 @@ installcheck-world:
 	$(MAKE) -C src/interfaces/gppc installcheck
 	$(MAKE) -C src/test/kerberos installcheck
 	$(MAKE) -C gpMgmt/bin installcheck
+# The mirroring_matching test of gpcheckcat fails on a walrep cluster
+# because management tools do not yet understand the fault strategy
+# 'w'. Currently gpcheckcat does not allow us to exclude a single test
+# so we need to explicitly list all the tests.
+ifeq ($(enable_segwalrep), yes)
+	for test in "unique_index_violation" "duplicate" "missing_extraneous"\
+				"inconsistent" "foreign_key" "acl" "persistent" "pgclass"\
+				"namespace" "distribution_policy" "dependency" "owner"\
+				"part_integrity" "part_constraint" "duplicate_persistent";\
+	do \
+		gpcheckcat -R $$test -A;\
+	done;
+else
 	gpcheckcat -A
 	$(MAKE) -C contrib/pg_upgrade check
+endif
+
+installcheck-walrep:
+	$(MAKE) -C src/test/isolation2 $@
 
 installcheck-resgroup:
 	$(MAKE) -C src/test/isolation2 $@

--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -173,10 +173,7 @@ else
 	$(MAKE) -C contrib/pg_upgrade check
 endif
 
-installcheck-walrep:
-	$(MAKE) -C src/test/isolation2 $@
-
-installcheck-resgroup:
+installcheck-resgroup installcheck-walrep:
 	$(MAKE) -C src/test/isolation2 $@
 
 # Create or destory a demo cluster.

--- a/concourse/pipelines/pipeline_segwalrep.yml
+++ b/concourse/pipelines/pipeline_segwalrep.yml
@@ -122,3 +122,22 @@ jobs:
       TEST_OS: centos
       CONFIGURE_FLAGS: "--enable-segwalrep"
       WITH_MIRRORS: false
+
+- name: fts_walrep
+  plan:
+  - aggregate:
+    - get: gpdb_src
+      passed: [compile_gpdb_centos6]
+    - get: bin_gpdb
+      resource: bin_gpdb_centos6
+      passed: [compile_gpdb_centos6]
+      trigger: true
+    - get: centos-gpdb-dev-6
+  - task: ic_gpdb
+    file: gpdb_src/concourse/tasks/ic_gpdb.yml
+    image: centos-gpdb-dev-6
+    params:
+      MAKE_TEST_COMMAND: installcheck-walrep
+      BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off|gp_fts_probe_interval=15"
+      TEST_OS: centos
+      CONFIGURE_FLAGS: "--enable-segwalrep"

--- a/contrib/pg_upgrade/check.c
+++ b/contrib/pg_upgrade/check.c
@@ -891,16 +891,13 @@ check_fts_fault_strategy(migratorContext *ctx)
 	snprintf(output_path, sizeof(output_path), "%s/fault_strategies.txt",
 			 ctx->cwd);
 
-#ifdef USE_SEGWALREP
-	/* In segment WAL replication, 'f' is removed and replaced with 'w' */
 	snprintf(query, sizeof(query),
 			 "SELECT fault_strategy "
 			 "FROM   pg_catalog.gp_fault_strategy "
+#ifdef USE_SEGWALREP
+			 /* In segment WAL replication, 'f' is removed and replaced with 'w' */
 			 "WHERE  fault_strategy NOT IN ('n','w');");
 #else
-	snprintf(query, sizeof(query),
-			 "SELECT fault_strategy "
-			 "FROM   pg_catalog.gp_fault_strategy "
 			 "WHERE  fault_strategy NOT IN ('n','f');");
 #endif
 

--- a/contrib/pg_upgrade/check.c
+++ b/contrib/pg_upgrade/check.c
@@ -891,10 +891,18 @@ check_fts_fault_strategy(migratorContext *ctx)
 	snprintf(output_path, sizeof(output_path), "%s/fault_strategies.txt",
 			 ctx->cwd);
 
+#ifdef USE_SEGWALREP
+	/* In segment WAL replication, 'f' is removed and replaced with 'w' */
+	snprintf(query, sizeof(query),
+			 "SELECT fault_strategy "
+			 "FROM   pg_catalog.gp_fault_strategy "
+			 "WHERE  fault_strategy NOT IN ('n','w');");
+#else
 	snprintf(query, sizeof(query),
 			 "SELECT fault_strategy "
 			 "FROM   pg_catalog.gp_fault_strategy "
 			 "WHERE  fault_strategy NOT IN ('n','f');");
+#endif
 
 	for (dbnum = 0; dbnum < old_cluster->dbarr.ndbs; dbnum++)
 	{

--- a/gpAux/gpdemo/gpsegwalrep.py
+++ b/gpAux/gpdemo/gpsegwalrep.py
@@ -134,6 +134,10 @@ class StartMirrors():
         for thread in startThreads:
             thread.join()
 
+        set_fault_strategy_cmd = "SET allow_system_table_mods=\"dml\"; UPDATE gp_fault_strategy SET fault_strategy = 'w'"
+        commands = ["PGOPTIONS=\"-c gp_session_role=utility\" psql postgres -c \"%s\"" % set_fault_strategy_cmd]
+        runcommands(commands, "StartMirror Parent Thread", "Set gp_fault_strategy to 'w'")
+
 class StopMirrors():
     ''' Stop the WAL replication mirror segment '''
 

--- a/src/backend/cdb/Makefile
+++ b/src/backend/cdb/Makefile
@@ -60,6 +60,10 @@ OBJS = cdbappendonlystorage.o cdbappendonlystorageformat.o \
 	   cdbpersistentcheck.o \
 	   partitionselection.o
 
+ifeq ($(enable_segwalrep), yes)
+OBJS := $(OBJS) cdbwalrep.o
+endif
+
 ifeq ($(PORTNAME),cygwin)
 .LIBPATTERNS := $(filter-out %.so,$(.LIBPATTERNS))
 endif

--- a/src/backend/cdb/cdbresynchronizechangetracking.c
+++ b/src/backend/cdb/cdbresynchronizechangetracking.c
@@ -21,7 +21,6 @@
 #include "commands/sequence.h"
 #include "executor/spi.h"
 #include "postmaster/primary_mirror_mode.h"
-#include "postmaster/fts.h"
 #include "storage/fd.h"
 #include "storage/lock.h"
 #include "storage/relfilenode.h"

--- a/src/backend/cdb/cdbwalrep.c
+++ b/src/backend/cdb/cdbwalrep.c
@@ -1,0 +1,143 @@
+/*
+ * cdbwalrep.c
+ *
+ * Copyright (c) 2017-Present Pivotal Software, Inc.
+ *
+ */
+
+#include "postgres.h"
+
+#include "cdb/cdbvars.h"
+#include "replication/walsender_private.h"
+#include "cdb/cdbwalrep.h"
+
+static volatile PrimaryWalRepState *primaryWalRepState = NULL;
+static slock_t primaryWalRepStateLock;
+
+void
+primaryWalRepStateShmemInit(void)
+{
+	primaryWalRepState = (PrimaryWalRepState *) ShmemAlloc(sizeof(PrimaryWalRepState));
+	*primaryWalRepState = PRIMARYWALREP_STREAMING;
+	SpinLockInit(&primaryWalRepStateLock);
+}
+
+PrimaryWalRepState
+getPrimaryWalRepState(void)
+{
+	PrimaryWalRepState state;
+	SpinLockAcquire(&primaryWalRepStateLock);
+	state = *primaryWalRepState;
+	SpinLockRelease(&primaryWalRepStateLock);
+	return state;
+}
+
+/*
+ * Get the PrimaryWalRepState converted from WalSndCtl.
+ */
+PrimaryWalRepState
+getPrimaryWalRepStateFromWalSnd(void)
+{
+	WalSnd walsender = WalSndCtl->walsnds[0];
+	PrimaryWalRepState state = PRIMARYWALREP_UNKNOWN;
+
+	SpinLockAcquire(&walsender.mutex);
+	if (WalSndCtl->walsnds[0].pid == 0) /* no WAL sender active */
+		state = PRIMARYWALREP_ARCHIVING;
+	else if (WalSndCtl->walsnds[0].state == WALSNDSTATE_CATCHUP)
+		state =  PRIMARYWALREP_CATCHUP;
+	else if (WalSndCtl->walsnds[0].state == WALSNDSTATE_STREAMING)
+		state =  PRIMARYWALREP_STREAMING;
+	SpinLockRelease(&walsender.mutex);
+
+	return state;
+}
+
+const char *
+getPrimaryWalRepStateLabel(PrimaryWalRepState state)
+{
+	static const char *labels[] = {"Archiving",
+								   "Catchup",
+								   "Streaming",
+								   "Shutdown",
+								   "Fault",
+								   "Unknown"};
+
+	return labels[state];
+}
+
+/*
+ * Shared-memory variable primaryWalRepState should be consistent with the
+ * WalSndState of the WAL sender in WalSndCtl[0].
+ */
+bool
+isPrimaryWalRepStateConsistent(void)
+{
+	PrimaryWalRepState curState;
+	PrimaryWalRepState curWalSenderState;
+
+	SpinLockAcquire(&primaryWalRepStateLock);
+	curWalSenderState = getPrimaryWalRepStateFromWalSnd();
+	curState = *primaryWalRepState;
+	SpinLockRelease(&primaryWalRepStateLock);
+
+	return curWalSenderState == curState;
+}
+
+/*
+ * Set the primaryWalRepState when a transition should happen.
+ */
+void
+setPrimaryWalRepState(PrimaryWalRepState state)
+{
+	SpinLockAcquire(&primaryWalRepStateLock);
+	elog(LOG,
+		 "setPrimaryWalRepState: From %s to %s",
+		 getPrimaryWalRepStateLabel(*primaryWalRepState),
+		 getPrimaryWalRepStateLabel(state));
+
+	*primaryWalRepState = state;
+	SpinLockRelease(&primaryWalRepStateLock);
+}
+
+/*
+ * Block and wait for FTS to update gp_segment_configuration before
+ * moving on.
+ */
+void
+WalWaitForSegmentConfigurationChange(void)
+{
+	while(1)
+	{
+		PrimaryWalRepState state = getPrimaryWalRepState();
+		if (state < PRIMARYWALREP_FAULT)
+		{
+			ereport(LOG,
+					(errmsg("done blocking for FTS with primaryWalRepState changed to %s",
+							getPrimaryWalRepStateLabel(state))));
+			break;
+		}
+		else
+		{
+			ereport(DEBUG1,
+					(errmsg("blocking WAL replication for FTS transition")));
+			pg_usleep(500000L);
+			continue;
+		}
+	}
+}
+
+/*
+ * Update primaryWalRepState and block until we get FTS transition. We check
+ * for MASTER_CONTENT_ID because the master and standby master are not
+ * monitored by FTS.
+ */
+void
+WalUpdateStandbyState(PrimaryWalRepState state)
+{
+	if (GpIdentity.segindex != MASTER_CONTENT_ID)
+	{
+		setPrimaryWalRepState(state);
+		WalWaitForSegmentConfigurationChange();
+	}
+}

--- a/src/backend/fts/Makefile
+++ b/src/backend/fts/Makefile
@@ -11,6 +11,12 @@ top_builddir = ../../..
 include $(top_builddir)/src/Makefile.global
 override CPPFLAGS := -I$(top_srcdir)/src/backend/gp_libpq_fe $(CPPFLAGS)
 
-OBJS = fts.o ftsprobe.o ftsfilerep.o
-       
+OBJS = fts.o ftsprobe.o
+
+ifeq ($(enable_segwalrep), yes)
+OBJS := $(OBJS) ftswalrep.o
+else
+OBJS := $(OBJS) ftsfilerep.o
+endif
+
 include $(top_srcdir)/src/backend/common.mk

--- a/src/backend/fts/ftswalrep.c
+++ b/src/backend/fts/ftswalrep.c
@@ -1,11 +1,10 @@
 /*-------------------------------------------------------------------------
  *
- * ftsfilerep.c
- *	  Implementation of interface for FireRep-specific segment state machine
+ * ftswalrep.c
+ *	  Implementation of interface for WALrep-specific segment state machine
  *	  and transitions
  *
- * Copyright (c) 2005-2010, Greenplum Inc.
- * Copyright (c) 2011, EMC Corp.
+ * Copyright (c) 2017-Present Pivotal Software, Inc.
  *
  *-------------------------------------------------------------------------
  */
@@ -14,9 +13,12 @@
 #include "gp-libpq-fe.h"
 #include "gp-libpq-int.h"
 #include "cdb/cdbfts.h"
+#include "cdb/cdbvars.h"
+#include "libpq/ip.h"
 #include "executor/spi.h"
 #include "postmaster/fts.h"
 #include "postmaster/primary_mirror_mode.h"
+#include "postmaster/primary_mirror_transition_client.h"
 
 #include "cdb/ml_ipc.h" /* gettime_elapsed_ms */
 
@@ -34,51 +36,50 @@
  */
 
 /*
- * primary/mirror valid states for filerep;
+ * primary/mirror valid states for WALrep;
  * we enumerate all possible combined states for two segments
  * before and after state transition, assuming that the first
  * is the old primary and the second is the old mirror;
  * each segment can be:
  *    1) (P)rimary or (M)irror
  *    2) (U)p or (D)own
- *    3) in (S)ync, (R)esync or (C)hangetracking mode -- see filerep's DataState_e
+ *    3) in (S)treaming, (C)atch-up or (A)rchiving mode -- see WALrep's PrimaryState
  */
-enum filerep_segment_pair_state_e
+enum walrep_segment_pair_state_e
 {
-	FILEREP_PUS_MUS = 0,
-	FILEREP_PUR_MUR,
-	FILEREP_PUC_MDX,
-	FILEREP_MDX_PUC,
-
-	FILEREP_SENTINEL
+	WALREP_PUS_MUS = 0,
+	WALREP_PUC_MUC,
+	WALREP_PUA_MDX,
+	WALREP_MDX_PUA,
+	WALREP_SENTINEL
 };
 
  /* we always assume that primary is up */
-#define IS_VALID_OLD_STATE_FILEREP(state) \
-	((unsigned int)(state) <= FILEREP_PUC_MDX)
+#define IS_VALID_OLD_STATE_WALREP(state) \
+	((unsigned int)(state) <= WALREP_PUA_MDX)
 
-#define IS_VALID_NEW_STATE_FILEREP(state) \
-	((unsigned int)(state) < FILEREP_SENTINEL)
+#define IS_VALID_NEW_STATE_WALREP(state) \
+	((unsigned int)(state) < WALREP_SENTINEL)
 
 /*
- * state machine matrix for filerep;
+ * state machine matrix for walrep;
  * we assume that the first segment is the old primary;
  * transitions from "down" to "resync" and from "resync" to "sync" are excluded;
  */
-const uint32 state_machine_filerep[][FILEREP_SENTINEL] =
+const uint32 state_machine_walrep[][WALREP_SENTINEL] =
 {
-/* new: PUS_MUS,   PUR_MUR,               PUC_MDX,   MDX_PUC */
+/* new: PUS_MUS,   PUC_MUC,               PUA_MDX,   MDX_PUA */
 	{         0,         0,             TRANS_U_D, TRANS_D_U },  /* old: PUS_MUS */
-	{         0,         0,             TRANS_U_D,         0 },  /* old: PUR_MUR */
-	{         0,         0,                     0,         0 },  /* old: PUC_MDX */
+	{         0,         0,             TRANS_U_D,         0 },  /* old: PUC_MUC */
+	{         0,         0,                     0,         0 },  /* old: PUA_MDX */
 };
 
-/* filerep transition type */
-typedef enum FilerepModeUpdateLoggingEnum
+/* WALrep transition type */
+typedef enum WALrepModeUpdateLoggingEnum
 {
-	FilerepModeUpdateLoggingEnum_MirrorToChangeTracking,
-	FilerepModeUpdateLoggingEnum_PrimaryToChangeTracking,
-} FilerepModeUpdateLoggingEnum;
+	WALrepModeUpdateLoggingEnum_MirrorToArchiving,
+	WALrepModeUpdateLoggingEnum_PrimaryToArchiving,
+} WALrepModeUpdateLoggingEnum;
 
 
 /*
@@ -93,25 +94,19 @@ static CdbComponentDatabases *cdb_component_dbs = NULL;
  * FUNCTION PROTOTYPES
  */
 
-static void modeUpdate(int dbid, char *mode, char status, FilerepModeUpdateLoggingEnum logMsgToSend);
-static void getHostsByDbid
-	(
-	int dbid,
-	char **hostname_p,
-	int *host_port_p,
-	int *host_filerep_port_p,
-	char **peer_name_p,
-	int *peer_pm_port_p,
-	int *peer_filerep_port_p
-	)
-	;
+static void modeUpdate(int dbid, char *mode, char status, WALrepModeUpdateLoggingEnum logMsgToSend);
+static void getHostsByDbid(int dbid,
+						   char **hostname_p,
+						   int *host_port_p,
+						   char **peer_name_p,
+						   int *peer_pm_port_p);
 
 
 /*
- * Get combined state of primary and mirror for filerep
+ * Get combined state of primary and mirror for WALrep
  */
 uint32
-FtsGetPairStateFilerep(CdbComponentDatabaseInfo *primary, CdbComponentDatabaseInfo *mirror)
+FtsGetPairStateWalRep(CdbComponentDatabaseInfo *primary, CdbComponentDatabaseInfo *mirror)
 {
 	/* check for inconsistent segment state */
 	if (!FTS_STATUS_ISALIVE(primary->dbid, ftsProbeInfo->fts_status) ||
@@ -134,7 +129,7 @@ FtsGetPairStateFilerep(CdbComponentDatabaseInfo *primary, CdbComponentDatabaseIn
 				 primary->dbid, mirror->dbid);
 		}
 
-		return FILEREP_PUS_MUS;
+		return WALREP_PUS_MUS;
 	}
 
 	if (!FTS_STATUS_IS_SYNCED(primary->dbid, ftsProbeInfo->fts_status) &&
@@ -148,7 +143,7 @@ FtsGetPairStateFilerep(CdbComponentDatabaseInfo *primary, CdbComponentDatabaseIn
 				 primary->dbid, mirror->dbid);
 		}
 
-		return FILEREP_PUC_MDX;
+		return WALREP_PUA_MDX;
 	}
 
 	if (!FTS_STATUS_IS_SYNCED(primary->dbid, ftsProbeInfo->fts_status) &&
@@ -163,41 +158,41 @@ FtsGetPairStateFilerep(CdbComponentDatabaseInfo *primary, CdbComponentDatabaseIn
 				 primary->dbid, mirror->dbid);
 		}
 
-		return FILEREP_PUR_MUR;
+		return WALREP_PUC_MUC;
 	}
 
 	/* segments are in inconsistent state */
 	FtsRequestPostmasterShutdown(primary, mirror);
-	return FILEREP_SENTINEL;
+	return WALREP_SENTINEL;
 }
 
 
 /*
- * Get new state for primary and mirror using filerep state machine.
+ * Get new state for primary and mirror using WALrep state machine.
  * In case of an invalid old state, log the old state and do not transition.
  */
 uint32
-FtsTransitionFilerep(uint32 stateOld, uint32 trans)
+FtsTransitionWalRep(uint32 stateOld, uint32 trans)
 {
 	int i = 0;
 
-	if (!(IS_VALID_OLD_STATE_FILEREP(stateOld)))
+	if (!(IS_VALID_OLD_STATE_WALREP(stateOld)))
 		elog(ERROR, "FTS: invalid old state for transition: %d", stateOld);
 
 	/* check state machine for transition */
-	for (i = 0; i < FILEREP_SENTINEL; i++)
+	for (i = 0; i < WALREP_SENTINEL; i++)
 	{
 		if (gp_log_fts >= GPVARS_VERBOSITY_DEBUG)
 		{
 			elog(LOG, "FTS: state machine: row=%d column=%d val=%d trans=%d comp=%d.",
 				 stateOld,
 				 i,
-				 state_machine_filerep[stateOld][i],
+				 state_machine_walrep[stateOld][i],
 				 trans,
-				 state_machine_filerep[stateOld][i] & trans);
+				 state_machine_walrep[stateOld][i] & trans);
 		}
 
-		if ((state_machine_filerep[stateOld][i] & trans) > 0)
+		if ((state_machine_walrep[stateOld][i] & trans) > 0)
 		{
 			if (gp_log_fts >= GPVARS_VERBOSITY_VERBOSE)
 			{
@@ -212,16 +207,16 @@ FtsTransitionFilerep(uint32 stateOld, uint32 trans)
 
 
 /*
- * resolve new filerep state for primary and mirror
+ * resolve new WALrep state for primary and mirror
  */
 void
-FtsResolveStateFilerep(FtsSegmentPairState *pairState)
+FtsResolveStateWalRep(FtsSegmentPairState *pairState)
 {
-	Assert(IS_VALID_NEW_STATE_FILEREP(pairState->stateNew));
+	Assert(IS_VALID_NEW_STATE_WALREP(pairState->stateNew));
 
 	switch (pairState->stateNew)
 	{
-		case (FILEREP_PUC_MDX):
+		case (WALREP_PUA_MDX):
 
 			pairState->statePrimary = ftsProbeInfo->fts_status[pairState->primary->dbid];
 			pairState->stateMirror = ftsProbeInfo->fts_status[pairState->mirror->dbid];
@@ -235,7 +230,7 @@ FtsResolveStateFilerep(FtsSegmentPairState *pairState)
 
 			break;
 
-		case (FILEREP_MDX_PUC):
+		case (WALREP_MDX_PUA):
 
 			Assert(FTS_STATUS_ISALIVE(pairState->mirror->dbid, ftsProbeInfo->fts_status));
 			Assert(FTS_STATUS_IS_SYNCED(pairState->mirror->dbid, ftsProbeInfo->fts_status));
@@ -254,27 +249,27 @@ FtsResolveStateFilerep(FtsSegmentPairState *pairState)
 
 			break;
 
-		case (FILEREP_PUS_MUS):
-		case (FILEREP_PUR_MUR):
+		case (WALREP_PUS_MUS):
+		case (WALREP_PUC_MUC):
 			Assert(!"FTS is not responsible for bringing segments back to life");
 			break;
 
 		default:
-			Assert(!"Invalid transition in filerep state machine");
+			Assert(!"Invalid transition in WALrep state machine");
 	}
 }
 
 
 /*
  * pre-process probe results to take into account some special
- * state-changes that Filerep uses: when the segments have completed
+ * state-changes that WALrep uses: when the segments have completed
  * re-sync, or when they report an explicit fault.
  *
  * NOTE: we examine pairs of primary-mirror segments; this is requiring
  * for reasoning about state changes.
  */
 void
-FtsPreprocessProbeResultsFilerep(CdbComponentDatabases *dbs, uint8 *probe_results)
+FtsPreprocessProbeResultsWalRep(CdbComponentDatabases *dbs, uint8 *probe_results)
 {
 	int i = 0;
 	cdb_component_dbs = dbs;
@@ -292,14 +287,7 @@ FtsPreprocessProbeResultsFilerep(CdbComponentDatabases *dbs, uint8 *probe_result
 
 		primary = segInfo;
 		mirror = FtsGetPeerSegment(primary->segindex, primary->dbid);
-		Assert(mirror != NULL && "mirrors should always be there in filerep mode");
-
-		/* peer segments have completed re-sync if primary reports completion */
-		if (PROBE_IS_RESYNC_COMPLETE(primary))
-		{
-			/* update configuration */
-			FtsMarkSegmentsInSync(primary, mirror);
-		}
+		Assert(mirror != NULL && "mirrors should always be there in WALrep mode");
 
 		/*
 		 * Decide which segments to consider "down"
@@ -337,9 +325,9 @@ FtsPreprocessProbeResultsFilerep(CdbComponentDatabases *dbs, uint8 *probe_result
 			if (PROBE_IS_ALIVE(mirror) && !PROBE_HAS_FAULT_NET(mirror))
 			{
 				elog(LOG, "FTS: primary (dbid=%d) reported networking fault "
-				          "while mirror (dbid=%d) is accessible, "
-				          "primary considered to be down.",
-				     primary->dbid, mirror->dbid);
+						  "while mirror (dbid=%d) is accessible, "
+						  "primary considered to be down.",
+					 primary->dbid, mirror->dbid);
 
 				/* consider primary dead -- case (3) */
 				probe_results[primary->dbid] &= ~PROBE_ALIVE;
@@ -349,9 +337,9 @@ FtsPreprocessProbeResultsFilerep(CdbComponentDatabases *dbs, uint8 *probe_result
 				if (PROBE_IS_ALIVE(primary))
 				{
 					elog(LOG, "FTS: primary (dbid=%d) reported networking fault "
-					          "while mirror (dbid=%d) is unusable, "
-					          "mirror considered to be down.",
-					     primary->dbid, mirror->dbid);
+							  "while mirror (dbid=%d) is unusable, "
+							  "mirror considered to be down.",
+						 primary->dbid, mirror->dbid);
 
 					/* mirror cannot be used, consider mirror dead -- case (2) */
 					probe_results[mirror->dbid] &= ~PROBE_ALIVE;
@@ -384,11 +372,12 @@ FtsPreprocessProbeResultsFilerep(CdbComponentDatabases *dbs, uint8 *probe_result
 }
 
 
+
 /*
  * transition segment to new state
  */
 void
-FtsFailoverFilerep(FtsSegmentStatusChange *changes, int changeCount)
+FtsFailoverWalRep(FtsSegmentStatusChange *changes, int changeCount)
 {
 	int i;
 
@@ -450,24 +439,120 @@ FtsFailoverFilerep(FtsSegmentStatusChange *changes, int changeCount)
 			else if (new_pri && !old_pri)
 			{
 				/* promote mirror to primary */
-				modeUpdate(changes[i].dbid, "primary", 'c', FilerepModeUpdateLoggingEnum_MirrorToChangeTracking);
+				modeUpdate(changes[i].dbid, "primary", 'c', WALrepModeUpdateLoggingEnum_MirrorToArchiving);
 			}
 			else if (old_pri && new_pri)
 			{
 				/* convert primary to changetracking */
-				modeUpdate(changes[i].dbid, "primary", 'c', FilerepModeUpdateLoggingEnum_PrimaryToChangeTracking);
+				modeUpdate(changes[i].dbid, "primary", 'c', WALrepModeUpdateLoggingEnum_PrimaryToArchiving);
 			}
 		}
 	}
 }
 
+static bool
+gpCheckForNeedToExitFn(void)
+{
+	return false;
+}
 
 static void
-modeUpdate(int dbid, char *mode, char status, FilerepModeUpdateLoggingEnum logMsgToSend)
+gpMirrorErrorLogFunction(char *str)
 {
-	char cmd[SYS_CMD_BUF_SIZE];
-	int cmd_status;
+	elog(LOG, "%s\n", str);
+}
 
+static void
+gpMirrorReceivedDataCallbackFunction(char *buf)
+{
+	elog(LOG, "%s\n", buf);
+}
+
+/**
+ * *addrList will be filled in with the address(es) of the host/port when true is returned
+ *
+ * host/port may not be NULL
+ */
+static bool
+determineTargetHost( struct addrinfo **addrList, char *host, int port)
+{
+	struct addrinfo hint;
+	int			ret;
+
+	*addrList = NULL;
+
+	/* Initialize hint structure */
+	MemSet(&hint, 0, sizeof(hint));
+	hint.ai_socktype = SOCK_STREAM;
+	hint.ai_family = AF_UNSPEC;
+
+	/* Using pghost, so we have to look-up the hostname */
+	hint.ai_family = AF_UNSPEC;
+
+	/* convert port to string */
+	char port_string[64];
+	sprintf(port_string, "%d", port);
+
+	/* Use pg_getaddrinfo_all() to resolve the address */
+	ret = pg_getaddrinfo_all(host, port_string, &hint, addrList);
+	if (ret || ! *addrList)
+	{
+		fprintf(stderr,"could not translate host name \"%s\" to address: %s\n", host, gai_strerror(ret));
+		return false;
+	}
+	return true;
+}
+
+/* buffer size for message to segment */
+#define SEGMENT_MSG_BUF_SIZE     4096
+
+static int
+sendTransitionCommand(char *mode, char status, char *seg_addr, int seg_pm_port, int seg_rep_port,
+					  char *peer_addr, int peer_pm_port, int peer_rep_port)
+{
+	struct addrinfo *addrList = NULL;
+	int msgLen = 0;
+	char msgBuffer[SEGMENT_MSG_BUF_SIZE];
+	char *msg = NULL;
+
+	/* build message */
+	msgLen = snprintf(
+			msgBuffer, sizeof(msgBuffer),
+			"%s\n%c\n%s\n%d\n%s\n%d\n%d\n",
+			mode,
+			status,
+			seg_addr,
+			seg_rep_port,
+			peer_addr,
+			peer_rep_port,
+			peer_pm_port
+			);
+
+	msg = msgBuffer;
+
+	/* find the target machine */
+	if (!determineTargetHost(&addrList, seg_addr, seg_pm_port))
+	{
+		return TRANS_ERRCODE_ERROR_HOST_LOOKUP_FAILED;
+	}
+
+	/* check for errors while building the message */
+	if (msg == NULL || msgLen >= sizeof(msgBuffer))
+	{
+		return TRANS_ERRCODE_ERROR_READING_INPUT;
+	}
+
+	/* send the message */
+	PrimaryMirrorTransitionClientInfo client;
+	client.receivedDataCallbackFn = gpMirrorReceivedDataCallbackFunction;
+	client.errorLogFn = gpMirrorErrorLogFunction;
+	client.checkForNeedToExitFn = gpCheckForNeedToExitFn;
+	return sendTransitionMessage(&client, addrList, msg, msgLen, gp_fts_transition_retries, gp_fts_transition_timeout);
+}
+
+static void
+modeUpdate(int dbid, char *mode, char status, WALrepModeUpdateLoggingEnum logMsgToSend)
+{
 	char *seg_addr = NULL;
 	char *peer_addr = NULL;
 	int seg_pm_port = -1;
@@ -475,84 +560,49 @@ modeUpdate(int dbid, char *mode, char status, FilerepModeUpdateLoggingEnum logMs
 	int peer_rep_port = -1;
 	int peer_pm_port = -1;
 
-	char runInBg = '&';
-
 	Assert(dbid >= 0);
 	Assert(mode != NULL);
 
-	getHostsByDbid(dbid, &seg_addr, &seg_pm_port, &seg_rep_port, &peer_addr, &peer_pm_port, &peer_rep_port);
+	getHostsByDbid(dbid, &seg_addr, &seg_pm_port, &peer_addr, &peer_pm_port);
 
 	Assert(seg_addr != NULL);
 	Assert(peer_addr != NULL);
 	Assert(seg_pm_port > 0);
 	Assert(peer_pm_port > 0);
-#ifndef USE_SEGWALREP
-	Assert(seg_rep_port > 0);
-	Assert(peer_rep_port > 0);
-#endif
 
 	switch (logMsgToSend)
 	{
-		case FilerepModeUpdateLoggingEnum_MirrorToChangeTracking:
+		case WALrepModeUpdateLoggingEnum_MirrorToArchiving:
 			ereport(LOG,
-					(errmsg("FTS: mirror (dbid=%d) on %s:%d taking over as primary in change-tracking mode.",
+					(errmsg("FTS: mirror (dbid=%d) on %s:%d taking over as primary in archiving mode.",
 							dbid, seg_addr, seg_pm_port ),
 					 errSendAlert(true)));
 			break;
-		case FilerepModeUpdateLoggingEnum_PrimaryToChangeTracking:
+		case WALrepModeUpdateLoggingEnum_PrimaryToArchiving:
 			ereport(LOG,
-					(errmsg("FTS: primary (dbid=%d) on %s:%d transitioning to change-tracking mode, mirror marked as down.",
+					(errmsg("FTS: primary (dbid=%d) on %s:%d transitioning to archiving mode, mirror marked as down.",
 							dbid, seg_addr, seg_pm_port ),
 					 errSendAlert(true)));
 			break;
 	}
 
-	/* check if parallel segment transition is activated */
-	if (!gp_fts_transition_parallel)
+	int return_code;
+	return_code = sendTransitionCommand(mode, status, seg_addr, seg_pm_port, seg_rep_port, peer_addr, peer_pm_port, peer_rep_port);
+
+	if (return_code == -1)
 	{
-		runInBg = ' ';
+		elog(ERROR, "FTS: failed to execute");
 	}
-
-	/* issue the command to change modes */
-	(void) snprintf
-		(
-		cmd, sizeof(cmd),
-		"gp_primarymirror -m %s -s %c -H %s -P %d -R %d -h %s -p %d -r %d -n %d -t %d %c",
-		mode,
-		status,
-		seg_addr,
-		seg_pm_port,
-		seg_rep_port,
-		peer_addr,
-		peer_pm_port,
-		peer_rep_port,
-		gp_fts_transition_retries,
-		gp_fts_transition_timeout,
-		runInBg
-		)
-		;
-
-	Assert(strlen(cmd) < sizeof(cmd) - 1);
-
-	if (gp_log_fts >= GPVARS_VERBOSITY_DEBUG)
-		elog(LOG, "FTS: gp_primarymirror command is [%s].", cmd);
-
-	cmd_status = system(cmd);
-
-	if (cmd_status == -1)
+	else if (return_code != 0)
 	{
-		elog(ERROR, "FTS: failed to execute command: %s (%m).", cmd);
-	}
-	else if (cmd_status != 0)
-	{
-		elog(ERROR, "FTS: segment transition failed: %s (exit code %d).", cmd, cmd_status);
+		elog(ERROR, "FTS: segment transition failed");
 	}
 }
 
 
 static void
-getHostsByDbid(int dbid, char **hostname_p, int *host_port_p, int *host_filerep_port_p, char **peer_name_p,
-			int *peer_pm_port_p, int *peer_filerep_port_p)
+getHostsByDbid(int dbid, char **hostname_p, int *host_port_p, char **peer_name_p,
+			int *peer_pm_port_p)
 {
 	bool found;
 	int i;
@@ -561,10 +611,8 @@ getHostsByDbid(int dbid, char **hostname_p, int *host_port_p, int *host_filerep_
 	Assert(dbid >= 0);
 	Assert(hostname_p != NULL);
 	Assert(host_port_p != NULL);
-	Assert(host_filerep_port_p != NULL);
 	Assert(peer_name_p != NULL);
 	Assert(peer_pm_port_p != NULL);
-	Assert(peer_filerep_port_p != NULL);
 
 	found = false;
 
@@ -573,7 +621,7 @@ getHostsByDbid(int dbid, char **hostname_p, int *host_port_p, int *host_filerep_
 	 *
 	 * On the first pass we get our dbid, on the second pass we get our mirror-peer.
 	 */
- 	for (i=0; i < cdb_component_dbs->total_segment_dbs; i++)
+	for (i=0; i < cdb_component_dbs->total_segment_dbs; i++)
 	{
 		CdbComponentDatabaseInfo *segInfo = &cdb_component_dbs->segment_db_info[i];
 
@@ -581,7 +629,6 @@ getHostsByDbid(int dbid, char **hostname_p, int *host_port_p, int *host_filerep_
 		{
 			*hostname_p = segInfo->address;
 			*host_port_p = segInfo->port;
-			*host_filerep_port_p = segInfo->filerep_port;
 			content_id = segInfo->segindex;
 			found = true;
 			break;
@@ -596,7 +643,7 @@ getHostsByDbid(int dbid, char **hostname_p, int *host_port_p, int *host_filerep_
 	found = false;
 
 	/* second pass, find the mirror-peer */
- 	for (i=0; i < cdb_component_dbs->total_segment_dbs; i++)
+	for (i=0; i < cdb_component_dbs->total_segment_dbs; i++)
 	{
 		CdbComponentDatabaseInfo *segInfo = &cdb_component_dbs->segment_db_info[i];
 
@@ -604,7 +651,6 @@ getHostsByDbid(int dbid, char **hostname_p, int *host_port_p, int *host_filerep_
 		{
 			*peer_name_p = segInfo->address;
 			*peer_pm_port_p = segInfo->port;
-			*peer_filerep_port_p = segInfo->filerep_port;
 			found = true;
 			break;
 		}
@@ -615,7 +661,6 @@ getHostsByDbid(int dbid, char **hostname_p, int *host_port_p, int *host_filerep_
 		elog(LOG, "FTS: could not find mirror-peer for dbid %d.", dbid);
 		*peer_name_p = NULL;
 		*peer_pm_port_p = -1;
-		*peer_filerep_port_p = -1;
 	}
 }
 

--- a/src/backend/replication/walsender.c
+++ b/src/backend/replication/walsender.c
@@ -69,6 +69,9 @@
 #include "utils/resowner.h"
 #include "utils/timestamp.h"
 
+#ifdef USE_SEGWALREP
+#include "cdb/cdbwalrep.h"
+#endif
 
 /* Array of WalSnds in shared memory */
 WalSndCtlData *WalSndCtl = NULL;
@@ -399,6 +402,9 @@ ProcessRepliesIfAny(void)
 					(errcode(ERRCODE_PROTOCOL_VIOLATION),
 					 errmsg("unexpected EOF on standby connection"),
 					 errSendAlert(true)));
+#ifdef USE_SEGWALREP
+			WalUpdateStandbyState(PRIMARYWALREP_FAULT);
+#endif
 			proc_exit(0);
 		}
 		if (r == 0)
@@ -426,6 +432,9 @@ ProcessRepliesIfAny(void)
 						"walsnd processreply -- "
 						"Received 'X' as first character in reply from standby. "
 						"Standby is closing down the socket, hence exiting.");
+#ifdef USE_SEGWALREP
+				WalUpdateStandbyState(PRIMARYWALREP_FAULT);
+#endif
 				proc_exit(0);
 
 			default:

--- a/src/backend/storage/ipc/ipci.c
+++ b/src/backend/storage/ipc/ipci.c
@@ -71,6 +71,10 @@
 #include "utils/workfile_mgr.h"
 #include "utils/session_state.h"
 
+#ifdef USE_SEGWALREP
+#include "cdb/cdbwalrep.h"
+#endif
+
 shmem_startup_hook_type shmem_startup_hook = NULL;
 
 static Size total_addin_request = 0;
@@ -289,6 +293,9 @@ CreateSharedMemoryAndSemaphores(bool makePrivate, int port)
 	InitShmemIndex();
 
 	primaryMirrorModeShmemInit();
+#ifdef USE_SEGWALREP
+	primaryWalRepStateShmemInit();
+#endif
 
 	/*
 	 * Set up xlog, clog, and buffers

--- a/src/include/cdb/cdbwalrep.h
+++ b/src/include/cdb/cdbwalrep.h
@@ -1,0 +1,28 @@
+/*
+ * cdbwalrep.h
+ *
+ * Copyright (c) 2017-Present Pivotal Software, Inc.
+ *
+ */
+
+#ifndef CDBWALREP_H
+#define CDBWALREP_H
+typedef enum PrimaryWalRepState
+{
+	PRIMARYWALREP_ARCHIVING = 0, /* (a) Synchronized mirror is offline */
+	PRIMARYWALREP_CATCHUP, /* (c) Synchronized mirror is online and catching up */
+	PRIMARYWALREP_STREAMING, /* (s) Synchronized mirror is online and in-sync */
+	PRIMARYWALREP_SHUTDOWN, /* System is shutting down */
+	PRIMARYWALREP_FAULT,
+	PRIMARYWALREP_UNKNOWN
+} PrimaryWalRepState;
+
+extern void primaryWalRepStateShmemInit(void);
+extern PrimaryWalRepState getPrimaryWalRepState(void);
+extern PrimaryWalRepState getPrimaryWalRepStateFromWalSnd(void);
+extern const char *getPrimaryWalRepStateLabel(PrimaryWalRepState state);
+extern bool isPrimaryWalRepStateConsistent(void);
+extern void setPrimaryWalRepState(PrimaryWalRepState state);
+extern void WalWaitForSegmentConfigurationChange(void);
+extern void WalUpdateStandbyState(PrimaryWalRepState state);
+#endif

--- a/src/include/postmaster/fts.h
+++ b/src/include/postmaster/fts.h
@@ -111,7 +111,17 @@ extern void FtsDumpChanges(FtsSegmentStatusChange *changes, int changeEntries);
  */
 extern bool FtsIsActive(void);
 
+#ifdef USE_SEGWALREP
+/*
+ * Interface for WalRep-specific segment state machine and transitions
+ */
+extern uint32 FtsGetPairStateWalRep(CdbComponentDatabaseInfo *primary, CdbComponentDatabaseInfo *mirror);
+extern uint32 FtsTransitionWalRep(uint32 stateOld, uint32 trans);
+extern void FtsResolveStateWalRep(FtsSegmentPairState *pairState);
 
+extern void FtsPreprocessProbeResultsWalRep(CdbComponentDatabases *dbs, uint8 *probe_results);
+extern void FtsFailoverWalRep(FtsSegmentStatusChange *changes, int changeCount);
+#else
 /*
  * Interface for FireRep-specific segment state machine and transitions
  */
@@ -121,7 +131,7 @@ extern void FtsResolveStateFilerep(FtsSegmentPairState *pairState);
 
 extern void FtsPreprocessProbeResultsFilerep(CdbComponentDatabases *dbs, uint8 *probe_results);
 extern void FtsFailoverFilerep(FtsSegmentStatusChange *changes, int changeCount);
-
+#endif
 
 /*
  * Interface for requesting master to shut down

--- a/src/include/postmaster/primary_mirror_mode.h
+++ b/src/include/postmaster/primary_mirror_mode.h
@@ -279,6 +279,12 @@ extern void getFileRepRoleAndState(
 								   DataState_e *dataState,
                                    bool *isInFilerepTransitionOut,
                                    DataState_e *transitionTargetDataStateOut);
+#ifdef USE_SEGWALREP
+extern void getPrimaryMirrorStateTransition(SegmentState_e *segmentStateOut,
+											DataState_e *dataStateOut,
+											bool *isInTransitionOut,
+											DataState_e *transitionTargetDataStateOut);
+#endif
 
 /* functions for the postmaster/filerep interaction */
 extern bool isFullResync(void);

--- a/src/test/isolation2/Makefile
+++ b/src/test/isolation2/Makefile
@@ -48,3 +48,6 @@ installcheck: all gpdiff.pl gpstringsubs.pl
 
 installcheck-resgroup: all gpdiff.pl gpstringsubs.pl
 	./pg_isolation2_regress --init-file=$(top_builddir)/src/test/regress/init_file --init-file=./init_file_resgroup --psqldir='$(PSQLDIR)' --inputdir=$(srcdir) --resgroup-dir=resgroup --dbname=isolation2resgrouptest --schedule=$(srcdir)/isolation2_resgroup_schedule
+
+installcheck-walrep: all gpdiff.pl gpstringsubs.pl
+	./pg_isolation2_regress --init-file=$(top_builddir)/src/test/regress/init_file --psqldir='$(PSQLDIR)' --inputdir=$(srcdir) --dbname=isolation2walrep --schedule=$(srcdir)/isolation2_walrep_schedule

--- a/src/test/isolation2/expected/fts_walrep.out
+++ b/src/test/isolation2/expected/fts_walrep.out
@@ -1,0 +1,78 @@
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+CREATE
+
+create table fts_walrep (a int) distributed by (a);
+CREATE
+
+-- suspend before commit record is sent to mirror to simulate mirror going down at this point
+select gp_inject_fault('twophase_transaction_commit_prepared', 'suspend', 2);
+gp_inject_fault
+---------------
+t              
+(1 row)
+
+-- suspend transition request to check that transactions are blocked
+select gp_inject_fault('segment_transition_request', 'suspend', 2);
+gp_inject_fault
+---------------
+t              
+(1 row)
+
+-- test 1: in-flight write transaction is blocked during transition to changetracking
+1&: insert into fts_walrep select i from generate_series(1,10)i;  <waiting ...>
+
+-- no segment should be in changetracking
+2: select count(*) from gp_segment_configuration where mode = 'c';
+count
+-----
+0    
+(1 row)
+
+-- kill a mirror to put a primary into changetracking
+select kill_postmaster((select fselocation from gp_segment_configuration c, pg_filespace_entry f where c.role='m' and c.content=0 and c.dbid = f.fsedbid));
+kill_postmaster
+---------------
+0              
+(1 row)
+
+-- resume commits but they should hang on transition request
+select gp_inject_fault('twophase_transaction_commit_prepared', 'reset', 2);
+gp_inject_fault
+---------------
+t              
+(1 row)
+
+-- wait for gp_segment_configuration to show a primary in changetracking
+2: select wait_for_changetracking(120, 1);
+wait_for_changetracking
+-----------------------
+t                      
+(1 row)
+
+-- test 2: new write transaction is blocked during transition to changetracking
+2&: insert into fts_walrep select i from generate_series(1,10)i;  <waiting ...>
+
+-- show that gp_segment_configuration is updated and resume transition request
+3: select count(*) from gp_segment_configuration where mode = 'c' and role = 'p' and preferred_role = 'p';
+count
+-----
+1    
+(1 row)
+select gp_inject_fault('segment_transition_request', 'reset', 2);
+gp_inject_fault
+---------------
+t              
+(1 row)
+
+-- resume sessions for test 1 and test 2
+1<:  <... completed>
+INSERT 10
+2<:  <... completed>
+INSERT 10
+
+-- show that a primary is still in changetracking
+3: select count(*) from gp_segment_configuration where mode = 'c' and role = 'p' and preferred_role = 'p';
+count
+-----
+1    
+(1 row)

--- a/src/test/isolation2/expected/setup.out
+++ b/src/test/isolation2/expected/setup.out
@@ -29,3 +29,9 @@ CREATE
 
 CREATE OR REPLACE FUNCTION wait_for_trigger_fault(dbname text, fault text, segno int) RETURNS bool as $$ import subprocess import time cmd = 'psql %s -c "select gp_inject_fault(\'%s\', \'status\', %d)"' % (dbname, fault, segno) for i in range(100): cmd_output = subprocess.Popen(cmd, stderr=subprocess.STDOUT, stdout=subprocess.PIPE, shell=True) if 'triggered' in cmd_output.stdout.read(): return True time.sleep(0.5) return False $$ LANGUAGE plpythonu;
 CREATE
+
+CREATE OR REPLACE FUNCTION kill_postmaster(datadir text) RETURNS int as $$ import os ps_cmd = 'ps uxww | grep "[-]D %s" | awk \'{ print $2 }\' | xargs kill' % datadir return os.system(ps_cmd) $$ LANGUAGE plpythonu;
+CREATE
+
+CREATE OR REPLACE FUNCTION wait_for_changetracking(num_loops int, num_changetracking int) RETURNS boolean AS $$ declare d int;	/* in func */ i int;	/* in func */ begin	/* in func */ i := 0;	/* in func */ loop	/* in func */ select count(*) from gp_segment_configuration where mode = 'c' into d;	/* in func */ if d = $2 then	/* in func */ return true;	/* in func */ end if;	/* in func */ if i >= $1 then	/* in func */ return false;	/* in func */ end if;	/* in func */ perform pg_sleep(.5);	/* in func */ i := i + 1;	/* in func */ end loop;	/* in func */ end;	/* in func */ $$ LANGUAGE plpgsql;
+CREATE

--- a/src/test/isolation2/isolation2_walrep_schedule
+++ b/src/test/isolation2/isolation2_walrep_schedule
@@ -1,0 +1,2 @@
+test: setup
+test: fts_walrep

--- a/src/test/isolation2/sql/fts_walrep.sql
+++ b/src/test/isolation2/sql/fts_walrep.sql
@@ -1,0 +1,39 @@
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+
+create table fts_walrep (a int) distributed by (a);
+
+-- suspend before commit record is sent to mirror to simulate mirror going down at this point
+select gp_inject_fault('twophase_transaction_commit_prepared', 'suspend', 2);
+
+-- suspend transition request to check that transactions are blocked
+select gp_inject_fault('segment_transition_request', 'suspend', 2);
+
+-- test 1: in-flight write transaction is blocked during transition to changetracking
+1&: insert into fts_walrep select i from generate_series(1,10)i;
+
+-- no segment should be in changetracking
+2: select count(*) from gp_segment_configuration where mode = 'c';
+
+-- kill a mirror to put a primary into changetracking
+select kill_postmaster((select fselocation from gp_segment_configuration c, pg_filespace_entry f
+                        where c.role='m' and c.content=0 and c.dbid = f.fsedbid));
+
+-- resume commits but they should hang on transition request
+select gp_inject_fault('twophase_transaction_commit_prepared', 'reset', 2);
+
+-- wait for gp_segment_configuration to show a primary in changetracking
+2: select wait_for_changetracking(120, 1);
+
+-- test 2: new write transaction is blocked during transition to changetracking
+2&: insert into fts_walrep select i from generate_series(1,10)i;
+
+-- show that gp_segment_configuration is updated and resume transition request
+3: select count(*) from gp_segment_configuration where mode = 'c' and role = 'p' and preferred_role = 'p';
+select gp_inject_fault('segment_transition_request', 'reset', 2);
+
+-- resume sessions for test 1 and test 2
+1<:
+2<:
+
+-- show that a primary is still in changetracking
+3: select count(*) from gp_segment_configuration where mode = 'c' and role = 'p' and preferred_role = 'p';

--- a/src/test/isolation2/sql/setup.sql
+++ b/src/test/isolation2/sql/setup.sql
@@ -102,3 +102,32 @@ RETURNS bool as $$
         time.sleep(0.5)
     return False 
 $$ LANGUAGE plpythonu;
+
+CREATE OR REPLACE FUNCTION kill_postmaster(datadir text)
+RETURNS int as $$
+    import os
+    ps_cmd = 'ps uxww | grep "[-]D %s" | awk \'{ print $2 }\' | xargs kill' % datadir
+    return os.system(ps_cmd)
+$$ LANGUAGE plpythonu;
+
+CREATE OR REPLACE FUNCTION wait_for_changetracking(num_loops int, num_changetracking int)
+RETURNS boolean AS
+$$
+declare
+    d int;	/* in func */
+    i int;	/* in func */
+begin	/* in func */
+    i := 0;	/* in func */
+    loop	/* in func */
+        select count(*) from gp_segment_configuration where mode = 'c' into d;	/* in func */
+        if d = $2 then	/* in func */
+            return true;	/* in func */
+        end if;	/* in func */
+        if i >= $1 then	/* in func */
+            return false;	/* in func */
+        end if;	/* in func */
+        perform pg_sleep(.5);	/* in func */
+        i := i + 1;	/* in func */
+  end loop;	/* in func */
+end;	/* in func */
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
When a WAL replication mirror goes down, FTS should update gp_segment_configuration to mark the mirror down and the primary in changetracking (archiving) mode. While waiting for FTS, the primary segment blocks its commits until it receives transition request to changetracking (archiving) mode. Introduce isolation2 test schedule to validate FTS and WAL replication interactions.

This PR also includes changes to isolation2 to use the gp_inject_fault extension since gpfaultinjector will not work with Segment WAL replication due to the change in fault strategy ('f' removed, 'w' added).  A lot of the Python utilities that utilize the gparray.py library may not work actually (e.g. gpstop, gpcheckcat mirror_matching test).  We skip tests that use these for now when --enable-segwalrep configure flag is set.