### PR TITLE
docs - add resource group system views to sys catalog ref guide

### DIFF
--- a/gpdb-doc/dita/ref_guide/ref_guide.ditamap
+++ b/gpdb-doc/dita/ref_guide/ref_guide.ditamap
@@ -154,6 +154,8 @@
 				<topicref href="system_catalogs/gp_persistent_tablespace_node.xml"/>
 				<topicref href="system_catalogs/gp_pgdatabase.xml"/>
 				<topicref href="system_catalogs/gp_relation_node.xml"/>
+				<topicref href="system_catalogs/gp_resgroup_config.xml"/>
+				<topicref href="system_catalogs/gp_resgroup_status.xml"/>
 				<topicref href="system_catalogs/gp_resqueue_status.xml"/>
 				<topicref href="system_catalogs/gp_segment_configuration.xml"/>
 				<topicref href="system_catalogs/gp_transaction_log.xml"/>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/catalog_ref-views.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/catalog_ref-views.xml
@@ -17,6 +17,12 @@
         <xref href="./gp_pgdatabase.xml#topic1" type="topic" format="dita"/>
       </li>
       <li>
+        <xref href="./gp_resgroup_config.xml#topic1" type="topic" format="dita"/>
+      </li>
+      <li>
+        <xref href="./gp_resgroup_status.xml#topic1" type="topic" format="dita"/>
+      </li>
+      <li>
         <xref href="./gp_resqueue_status.xml#topic1" type="topic" format="dita"/>
       </li>
       <li>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/gp_resgroup_config.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/gp_resgroup_config.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic id="topic1" xml:lang="en">
+  <title id="fp141670">gp_resgroup_config</title>
+  <body>
+    <p>The <codeph>gp_toolkit.gp_resgroup_config</codeph> view allows administrators to see the
+      current CPU, memory, and concurrency limits for a workload management resource group. The
+      view also displays proposed limit settings. A proposed limit will differ from a current
+      limit when the limit has been altered, but the new value could not be immediately applied.</p>
+    <table id="fp141982">
+      <title>gp_toolkit.gp_resgroup_config</title>
+      <tgroup cols="4">
+        <colspec colnum="1" colname="col1" colwidth="114pt"/>
+        <colspec colnum="2" colname="col2" colwidth="66pt"/>
+        <colspec colnum="3" colname="col3" colwidth="133.5pt"/>
+        <colspec colnum="4" colname="col4" colwidth="147pt"/>
+        <thead>
+          <row>
+            <entry colname="col1">column</entry>
+            <entry colname="col2">type</entry>
+            <entry colname="col3">references</entry>
+            <entry colname="col4">description</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry colname="col1">
+              <codeph>groupid</codeph>
+            </entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3">pg_resgroup.oid</entry>
+            <entry colname="col4">The ID of the resource group.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>groupname</codeph>
+            </entry>
+            <entry colname="col2">name</entry>
+            <entry colname="col3">pg_resgroup.rsgname</entry>
+            <entry colname="col4">The name of the resource group.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>concurrency</codeph>
+            </entry>
+            <entry colname="col2">text</entry>
+            <entry colname="col3">pg_resgroupcapability.value for pg_resgroupcapability.reslimittype = 1</entry>
+            <entry colname="col4">The concurrency value specified for the resource group.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>proposed_concurrency</codeph>
+            </entry>
+            <entry colname="col2">text</entry>
+            <entry colname="col3">pg_resgroupcapability.proposed for pg_resgroupcapability.reslimittype = 1</entry>
+            <entry colname="col4">The pending concurrency value for the resource group.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>cpu_rate_limit</codeph>
+            </entry>
+            <entry colname="col2">text</entry>
+            <entry colname="col3">pg_resgroupcapability.value for pg_resgroupcapability.reslimittype = 2</entry>
+            <entry colname="col4">The CPU limit value specified for the resource group.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>proposed_cpu_rate_limit</codeph>
+            </entry>
+            <entry colname="col2">text</entry>
+            <entry colname="col3">pg_resgroupcapability.proposed for pg_resgroupcapability.reslimittype = 2</entry>
+            <entry colname="col4">The pending CPU limit value for the resource group.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>memory_limit</codeph>
+            </entry>
+            <entry colname="col2">text</entry>
+            <entry colname="col3">pg_resgroupcapability.value for pg_resgroupcapability.reslimittype = 3</entry>
+            <entry colname="col4">The memory limit value specified for the resource group.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>proposed_memory_limit</codeph>
+            </entry>
+            <entry colname="col2">text</entry>
+            <entry colname="col3">pg_resgroupcapability.proposed for pg_resgroupcapability.reslimittype = 3</entry>
+            <entry colname="col4">The pending memory limit value for the resource group.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>memory_shared_quota</codeph>
+            </entry>
+            <entry colname="col2">text</entry>
+            <entry colname="col3">pg_resgroupcapability.value for pg_resgroupcapability.reslimittype = 4</entry>
+            <entry colname="col4">The shared memory quota value specified for the resource group.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>proposed_memory_shared_quota</codeph>
+            </entry>
+            <entry colname="col2">text</entry>
+            <entry colname="col3">pg_resgroupcapability.proposed for pg_resgroupcapability.reslimittype = 4</entry>
+            <entry colname="col4">The pending shared memory quota value for the resource group.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>memory_spill_ratio</codeph>
+            </entry>
+            <entry colname="col2">text</entry>
+            <entry colname="col3">pg_resgroupcapability.value for pg_resgroupcapability.reslimittype = 5</entry>
+            <entry colname="col4">The memory spill ratio value specified for the resource group.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>proposed_memory_spill_ratio</codeph>
+            </entry>
+            <entry colname="col2">text</entry>
+            <entry colname="col3">pg_resgroupcapability.proposed for pg_resgroupcapability.reslimittype> = 5</entry>
+            <entry colname="col4">The pending memory spill ratio value for the resource group.</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/gp_resgroup_config.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/gp_resgroup_config.xml
@@ -46,7 +46,7 @@
             </entry>
             <entry colname="col2">text</entry>
             <entry colname="col3">pg_resgroupcapability.value for pg_resgroupcapability.reslimittype = 1</entry>
-            <entry colname="col4">The concurrency value specified for the resource group.</entry>
+            <entry colname="col4">The concurrency (<codeph>CONCURRENCY</codeph>) value specified for the resource group.</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -62,7 +62,7 @@
             </entry>
             <entry colname="col2">text</entry>
             <entry colname="col3">pg_resgroupcapability.value for pg_resgroupcapability.reslimittype = 2</entry>
-            <entry colname="col4">The CPU limit value specified for the resource group.</entry>
+            <entry colname="col4">The CPU limit (<codeph>CPU_RATE_LIMIT</codeph>) value specified for the resource group.</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -78,7 +78,7 @@
             </entry>
             <entry colname="col2">text</entry>
             <entry colname="col3">pg_resgroupcapability.value for pg_resgroupcapability.reslimittype = 3</entry>
-            <entry colname="col4">The memory limit value specified for the resource group.</entry>
+            <entry colname="col4">The memory limit (<codeph>MEMORY_LIMIT</codeph>) value specified for the resource group.</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -94,7 +94,7 @@
             </entry>
             <entry colname="col2">text</entry>
             <entry colname="col3">pg_resgroupcapability.value for pg_resgroupcapability.reslimittype = 4</entry>
-            <entry colname="col4">The shared memory quota value specified for the resource group.</entry>
+            <entry colname="col4">The shared memory quota (<codeph>MEMORY_SHARED_QUOTA</codeph>) value specified for the resource group.</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -110,7 +110,7 @@
             </entry>
             <entry colname="col2">text</entry>
             <entry colname="col3">pg_resgroupcapability.value for pg_resgroupcapability.reslimittype = 5</entry>
-            <entry colname="col4">The memory spill ratio value specified for the resource group.</entry>
+            <entry colname="col4">The memory spill ratio (<codeph>MEMORY_SPILL_RATIO</codeph>) value specified for the resource group.</entry>
           </row>
           <row>
             <entry colname="col1">

--- a/gpdb-doc/dita/ref_guide/system_catalogs/gp_resgroup_status.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/gp_resgroup_status.xml
@@ -46,7 +46,7 @@
             </entry>
             <entry colname="col2">integer</entry>
             <entry colname="col3"></entry>
-            <entry colname="col4">The number of transactions running in the resource group.</entry>
+            <entry colname="col4">The number of transactions currently executing in the resource group.</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -54,7 +54,7 @@
             </entry>
             <entry colname="col2">integer</entry>
             <entry colname="col3"></entry>
-            <entry colname="col4">The number of queued transactions for the resource group.</entry>
+            <entry colname="col4">The number of currently queued transactions for the resource group.</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -62,7 +62,7 @@
             </entry>
             <entry colname="col2">integer</entry>
             <entry colname="col3"></entry>
-            <entry colname="col4">The total number of queued transactions for the resource group, excluding the <codeph>num_queueing</codeph>.</entry>
+            <entry colname="col4">The total number of queued transactions for the resource group since the Greenplum Database cluster was last started, excluding the <codeph>num_queueing</codeph>.</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -70,7 +70,7 @@
             </entry>
             <entry colname="col2">integer</entry>
             <entry colname="col3"></entry>
-            <entry colname="col4">The total number of executed transactions in the resource group, excluding the <codeph>num_running</codeph>.</entry>
+            <entry colname="col4">The total number of executed transactions in the resource group since the Greenplum Database cluster was last started, excluding the <codeph>num_running</codeph>.</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -78,7 +78,7 @@
             </entry>
             <entry colname="col2">interval</entry>
             <entry colname="col3"></entry>
-            <entry colname="col4">The total time any transaction was queued.</entry>
+            <entry colname="col4">The total time any transaction was queued since the Greenplum Database cluster was last started.</entry>
           </row>
           <row>
             <entry colname="col1">

--- a/gpdb-doc/dita/ref_guide/system_catalogs/gp_resgroup_status.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/gp_resgroup_status.xml
@@ -86,7 +86,7 @@
             </entry>
             <entry colname="col2">json</entry>
             <entry colname="col3"></entry>
-            <entry colname="col4">The real-time CPU usage of the resource group on each Greenplum Database segment host, averaged over all segments.</entry>
+            <entry colname="col4">The real-time CPU usage of the resource group on each Greenplum Database segment's host.</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -94,7 +94,7 @@
             </entry>
             <entry colname="col2">json</entry>
             <entry colname="col3"></entry>
-            <entry colname="col4">The real-time memory usage of the resource group on each Greenplum Database segment host, averaged over all segments.</entry>
+            <entry colname="col4">The real-time memory usage of the resource group on each Greenplum Database segment's host.</entry>
           </row>
         </tbody>
       </tgroup>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/gp_resgroup_status.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/gp_resgroup_status.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic id="topic1" xml:lang="en">
+  <title id="fp141670">gp_resgroup_status</title>
+  <body>
+    <p>The <codeph>gp_toolkit.gp_resgroup_status</codeph> view allows administrators to see status
+      and activity for a workload management resource group. It shows how many queries are waiting
+      to run and how many queries are currently active in the system for each resource
+      group. The view also displays current memory and CPU usage for the resource group.</p>
+    <table id="fp141982">
+      <title>gp_toolkit.gp_resgroup_status</title>
+      <tgroup cols="4">
+        <colspec colnum="1" colname="col1" colwidth="114pt"/>
+        <colspec colnum="2" colname="col2" colwidth="66pt"/>
+        <colspec colnum="3" colname="col3" colwidth="133.5pt"/>
+        <colspec colnum="4" colname="col4" colwidth="147pt"/>
+        <thead>
+          <row>
+            <entry colname="col1">column</entry>
+            <entry colname="col2">type</entry>
+            <entry colname="col3">references</entry>
+            <entry colname="col4">description</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry colname="col1">
+              <codeph>rsgname</codeph>
+            </entry>
+            <entry colname="col2">name</entry>
+            <entry colname="col3">pg_resgroup.rsgname</entry>
+            <entry colname="col4">The name of the resource group.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>groupid</codeph>
+            </entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3">pg_resgroup.oid</entry>
+            <entry colname="col4">The ID of the resource group.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>num_running</codeph>
+            </entry>
+            <entry colname="col2">integer</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">The number of transactions running in the resource group.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>num_queueing</codeph>
+            </entry>
+            <entry colname="col2">integer</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">The number of queued transactions for the resource group.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>num_queued</codeph>
+            </entry>
+            <entry colname="col2">integer</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">The total number of queued transactions for the resource group, excluding the <codeph>num_queueing</codeph>.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>num_executed</codeph>
+            </entry>
+            <entry colname="col2">integer</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">The total number of executed transactions in the resource group, excluding the <codeph>num_running</codeph>.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>total_queue_duration</codeph>
+            </entry>
+            <entry colname="col2">interval</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">The total time any transaction was queued.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>cpu_usage</codeph>
+            </entry>
+            <entry colname="col2">json</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">The real-time CPU usage of the resource group on each Greenplum Database segment host, averaged over all segments.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>memory_usage</codeph>
+            </entry>
+            <entry colname="col2">json</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">The real-time memory usage of the resource group on each Greenplum Database segment host, averaged over all segments.</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>


### PR DESCRIPTION
document the gp_toolkit gp_resgroup_config and gp_resgroup_status views in the reference guide.  (will add examples using these views to the docs at a later time.)

i obtained the data types via a psql \d VIEWNAME.

please verify the references column - not sure if i represented this correctly in the gp_resgroup_config table.

links to the relevant sections on work-in-progress doc review staging site:
- http://docs-gpdb-review-staging.cfapps.io/500Beta/ref_guide/system_catalogs/gp_resgroup_config.html
- http://docs-gpdb-review-staging.cfapps.io/500Beta/ref_guide/system_catalogs/gp_resgroup_status.html

