### PR TITLE
Use gp_inject_fault extension for isolation2 tests.

### DIFF
--- a/src/test/isolation2/expected/commit_transaction_block_checkpoint.out
+++ b/src/test/isolation2/expected/commit_transaction_block_checkpoint.out
@@ -1,13 +1,14 @@
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+CREATE
+
 -- TEST 1: block checkpoint on segments
 
 -- pause the 2PC after setting inCommit flag
-! gpfaultinjector -f twophase_transaction_commit_prepared -m async -y suspend -o 0 -H ALL -r primary;
-20170303:00:02:12:067930 gpfaultinjector:-[INFO]:-Starting gpfaultinjector with args: -f twophase_transaction_commit_prepared -m async -y suspend -o 0 -H ALL -r primary
-20170303:00:02:12:067930 gpfaultinjector:-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
-20170303:00:02:12:067930 gpfaultinjector:-[INFO]:-Injecting fault on content=1:dbid=3:mode=s:status=u
-20170303:00:02:12:067930 gpfaultinjector:-[INFO]:-Injecting fault on content=2:dbid=4:mode=s:status=u
-20170303:00:02:12:067930 gpfaultinjector:-[INFO]:-DONE
-
+select gp_inject_fault('twophase_transaction_commit_prepared', 'suspend', 3);
+gp_inject_fault
+---------------
+t              
+(1 row)
 
 -- trigger a 2PC, and it will block at commit;
 2: checkpoint;
@@ -22,13 +23,11 @@ CREATE
 3U&: checkpoint;  <waiting ...>
 
 -- resume the 2PC after setting inCommit flag
-! gpfaultinjector -f twophase_transaction_commit_prepared -m async -y reset -o 0 -H ALL -r primary;
-20170303:00:02:14:067954 gpfaultinjector:-[INFO]:-Starting gpfaultinjector with args: -f twophase_transaction_commit_prepared -m async -y reset -o 0 -H ALL -r primary
-20170303:00:02:14:067954 gpfaultinjector:-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
-20170303:00:02:14:067954 gpfaultinjector:-[INFO]:-Injecting fault on content=1:dbid=3:mode=s:status=u
-20170303:00:02:14:067954 gpfaultinjector:-[INFO]:-Injecting fault on content=2:dbid=4:mode=s:status=u
-20170303:00:02:14:067954 gpfaultinjector:-[INFO]:-DONE
-
+select gp_inject_fault('twophase_transaction_commit_prepared', 'reset', 3);
+gp_inject_fault
+---------------
+t              
+(1 row)
 2<:  <... completed>
 COMMIT
 3U<:  <... completed>
@@ -38,11 +37,11 @@ CHECKPOINT
 
 -- pause the CommitTransaction right before persistent table cleanup after
 -- notifyCommittedDtxTransaction()
-! gpfaultinjector -f transaction_commit_pass1_from_drop_in_memory_to_drop_pending -m async -y suspend -o 0 -s 1;
-20170303:00:02:15:067973 gpfaultinjector:-[INFO]:-Starting gpfaultinjector with args: -f transaction_commit_pass1_from_drop_in_memory_to_drop_pending -m async -y suspend -o 0 -s 1
-20170303:00:02:15:067973 gpfaultinjector:-[INFO]:-Injecting fault on content=-1:dbid=1:mode=s:status=u
-20170303:00:02:15:067973 gpfaultinjector:-[INFO]:-DONE
-
+select gp_inject_fault('transaction_commit_pass1_from_drop_in_memory_to_drop_pending', 'suspend', 1);
+gp_inject_fault
+---------------
+t              
+(1 row)
 
 -- trigger a 2PC, and it will block at commit;
 2: checkpoint;
@@ -57,11 +56,11 @@ DROP
 1U&: checkpoint;  <waiting ...>
 
 -- resume the 2PC
-! gpfaultinjector -f transaction_commit_pass1_from_drop_in_memory_to_drop_pending -m async -y reset -o 0 -s 1;
-20170303:00:02:16:067988 gpfaultinjector:-[INFO]:-Starting gpfaultinjector with args: -f transaction_commit_pass1_from_drop_in_memory_to_drop_pending -m async -y reset -o 0 -s 1
-20170303:00:02:16:067988 gpfaultinjector:-[INFO]:-Injecting fault on content=-1:dbid=1:mode=s:status=u
-20170303:00:02:16:067988 gpfaultinjector:-[INFO]:-DONE
-
+select gp_inject_fault('transaction_commit_pass1_from_drop_in_memory_to_drop_pending', 'reset', 1);
+gp_inject_fault
+---------------
+t              
+(1 row)
 2<:  <... completed>
 COMMIT
 1U<:  <... completed>

--- a/src/test/isolation2/expected/deadlock_under_entry_db_singleton.out
+++ b/src/test/isolation2/expected/deadlock_under_entry_db_singleton.out
@@ -1,3 +1,6 @@
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+CREATE
+
 -- Test to validate that ENTRY_DB_SINGLETON reader does not cause a
 -- deadlock.
 --
@@ -32,16 +35,16 @@ CREATE FUNCTION function_volatile(x int) RETURNS int AS $$ /*in func*/ BEGIN /*i
 CREATE
 
 -- inject fault on QD
-! gpfaultinjector -f transaction_start_under_entry_db_singleton -m async -y reset -o 0 -s 1;
-20170616:18:35:17:094847 gpfaultinjector::-[INFO]:-Starting gpfaultinjector with args: -f transaction_start_under_entry_db_singleton -m async -y reset -o 0 -s 1
-20170616:18:35:17:094847 gpfaultinjector::-[INFO]:-Injecting fault on content=-1:dbid=1:mode=s:status=u
-20170616:18:35:17:094847 gpfaultinjector::-[INFO]:-DONE
-
-! gpfaultinjector -f transaction_start_under_entry_db_singleton -m async -y suspend -o 0 -s 1;
-20170616:18:35:18:094859 gpfaultinjector::-[INFO]:-Starting gpfaultinjector with args: -f transaction_start_under_entry_db_singleton -m async -y suspend -o 0 -s 1
-20170616:18:35:18:094859 gpfaultinjector::-[INFO]:-Injecting fault on content=-1:dbid=1:mode=s:status=u
-20170616:18:35:18:094859 gpfaultinjector::-[INFO]:-DONE
-
+select gp_inject_fault('transaction_start_under_entry_db_singleton', 'reset', 1);
+gp_inject_fault
+---------------
+t              
+(1 row)
+select gp_inject_fault('transaction_start_under_entry_db_singleton', 'suspend', 1);
+gp_inject_fault
+---------------
+t              
+(1 row)
 
 -- The QD should already hold RowExclusiveLock and ExclusiveLock on
 -- deadlock_entry_db_singleton_table and the QE ENTRY_DB_SINGLETON
@@ -49,12 +52,11 @@ CREATE
 1&:UPDATE deadlock_entry_db_singleton_table set d = d + 1 FROM (select 1 from deadlock_entry_db_singleton_table, function_volatile(5)) t;  <waiting ...>
 
 -- verify the fault hit
-! gpfaultinjector -f transaction_start_under_entry_db_singleton -m async -y status -o 0 -s 1;
-20170616:18:35:18:094880 gpfaultinjector::-[INFO]:-Starting gpfaultinjector with args: -f transaction_start_under_entry_db_singleton -m async -y status -o 0 -s 1
-20170616:18:35:18:094880 gpfaultinjector::-[INFO]:-Injecting fault on content=-1:dbid=1:mode=s:status=u
-20170616:18:35:18:094880 gpfaultinjector::-[INFO]:-fault name:'transaction_start_under_entry_db_singleton' fault type:'suspend' ddl statement:'' database name:'' table name:'' occurrence:'-1' sleep time:'10' fault injection state:'triggered'  num times hit:'1' 
-20170616:18:35:18:094880 gpfaultinjector::-[INFO]:-DONE
-
+select gp_inject_fault('transaction_start_under_entry_db_singleton', 'status', 1);
+gp_inject_fault
+---------------
+t              
+(1 row)
 
 -- This session will wait for ExclusiveLock on
 -- deadlock_entry_db_singleton_table.
@@ -66,16 +68,16 @@ CREATE
 -- In spite of the waitMask conflict the lock should be granted to
 -- ENTRY_DB_SINGLETON reader because its writer already holds the
 -- lock.  Otherwise, we may have a deadlock.
-! gpfaultinjector -f transaction_start_under_entry_db_singleton -m async -y resume  -o 0 -s 1;
-20170616:18:35:19:094894 gpfaultinjector::-[INFO]:-Starting gpfaultinjector with args: -f transaction_start_under_entry_db_singleton -m async -y resume -o 0 -s 1
-20170616:18:35:19:094894 gpfaultinjector::-[INFO]:-Injecting fault on content=-1:dbid=1:mode=s:status=u
-20170616:18:35:19:094894 gpfaultinjector::-[INFO]:-DONE
-
-! gpfaultinjector -f transaction_start_under_entry_db_singleton -m async -y reset -o 0 -s 1;
-20170616:18:35:19:094906 gpfaultinjector::-[INFO]:-Starting gpfaultinjector with args: -f transaction_start_under_entry_db_singleton -m async -y reset -o 0 -s 1
-20170616:18:35:19:094906 gpfaultinjector::-[INFO]:-Injecting fault on content=-1:dbid=1:mode=s:status=u
-20170616:18:35:19:094906 gpfaultinjector::-[INFO]:-DONE
-
+select gp_inject_fault('transaction_start_under_entry_db_singleton', 'resume', 1);
+gp_inject_fault
+---------------
+t              
+(1 row)
+select gp_inject_fault('transaction_start_under_entry_db_singleton', 'reset', 1);
+gp_inject_fault
+---------------
+t              
+(1 row)
 
 -- verify the deadlock across multiple pids with same mpp session id
 with lock_on_deadlock_entry_db_singleton_table as (select * from pg_locks where relation = 'deadlock_entry_db_singleton_table'::regclass and gp_segment_id = -1) select count(*) as FoundDeadlockProcess from lock_on_deadlock_entry_db_singleton_table where granted = false and mppsessionid in ( select mppsessionid from lock_on_deadlock_entry_db_singleton_table where granted = true );

--- a/src/test/isolation2/expected/setup.out
+++ b/src/test/isolation2/expected/setup.out
@@ -27,5 +27,5 @@ create language plpythonu;
 CREATE
 -- end_ignore
 
-CREATE OR REPLACE FUNCTION wait_for_trigger_fault(fault text, segno int) RETURNS bool as $$ import subprocess import time cmd = 'gpfaultinjector -f %s -y status -s %d | grep -i triggered | wc -l' % (fault, segno) for i in range(100): cmd_output = subprocess.Popen(cmd, stderr=subprocess.STDOUT, stdout=subprocess.PIPE, shell=True) if int(cmd_output.stdout.read()): return True time.sleep(0.5) return False $$ LANGUAGE plpythonu;
+CREATE OR REPLACE FUNCTION wait_for_trigger_fault(dbname text, fault text, segno int) RETURNS bool as $$ import subprocess import time cmd = 'psql %s -c "select gp_inject_fault(\'%s\', \'status\', %d)"' % (dbname, fault, segno) for i in range(100): cmd_output = subprocess.Popen(cmd, stderr=subprocess.STDOUT, stdout=subprocess.PIPE, shell=True) if 'triggered' in cmd_output.stdout.read(): return True time.sleep(0.5) return False $$ LANGUAGE plpythonu;
 CREATE

--- a/src/test/isolation2/input/uao/vacuum_cleanup.source
+++ b/src/test/isolation2/input/uao/vacuum_cleanup.source
@@ -1,6 +1,8 @@
 -- @Description Test that when there is a parallel vacuum going on in drop phase, the age of
 -- the AO/AOCS table gets reduced correctly.
 
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+
 1: create table ao_@orientation@_vacuum_cleanup1(a int, b int) with(appendonly=true, orientation=@orientation@);
 1: insert into ao_@orientation@_vacuum_cleanup1 select 1, i from generate_series(1, 100) i;
 1: update ao_@orientation@_vacuum_cleanup1 set b = b + 1;
@@ -13,11 +15,11 @@
 2: update ao_@orientation@_vacuum_cleanup2 set b = b + 1;
 
 
-1: !gpfaultinjector -f vacuum_relation_open_relation_during_drop_phase -y suspend -s 2;
+1: select gp_inject_fault('vacuum_relation_open_relation_during_drop_phase', 'suspend', 2);
 
 2&: vacuum ao_@orientation@_vacuum_cleanup1;
 
-1: select wait_for_trigger_fault('vacuum_relation_open_relation_during_drop_phase', 2);
+1: select wait_for_trigger_fault((select current_database()), 'vacuum_relation_open_relation_during_drop_phase', 2);
 
 1: set vacuum_freeze_min_age = 0;
 -- Check the age of the table just before vacuum
@@ -29,7 +31,7 @@
 -- transaction before the vacuum (in this case it is the update statement)
 1: select age(relfrozenxid) from gp_dist_random('pg_class') where relname = 'ao_@orientation@_vacuum_cleanup2' and gp_segment_id = 0;
 
-1: !gpfaultinjector -f vacuum_relation_open_relation_during_drop_phase -y reset -s 2;
+1: select gp_inject_fault('vacuum_relation_open_relation_during_drop_phase', 'reset', 2);
 2<:
 
 -- Check that drop phase is skipped, but still the cleanup phase is performed
@@ -42,15 +44,15 @@
 -- Check the age of the table before vacuum to make sure that clean phase gets
 -- performed
 1: select age(relfrozenxid) from gp_dist_random('pg_class') where relname = 'ao_@orientation@_vacuum_cleanup3' and gp_segment_id = 0;
-1: !gpfaultinjector -f vacuum_relation_open_relation_during_drop_phase -y suspend -s 1;
+1: select gp_inject_fault('vacuum_relation_open_relation_during_drop_phase', 'suspend', 1);
 1&: vacuum ao_@orientation@_vacuum_cleanup3;
 
 -- Wait till compaction phase is completed and only then start the serializable
 -- transaction to ensure that only drop phase is skipped
-2: select wait_for_trigger_fault('vacuum_relation_open_relation_during_drop_phase', 1);
+2: select wait_for_trigger_fault((select current_database()), 'vacuum_relation_open_relation_during_drop_phase', 1);
 2: begin isolation level serializable;
 2: select 123;
-2: !gpfaultinjector -f vacuum_relation_open_relation_during_drop_phase -y reset -s 1;
+2: select gp_inject_fault('vacuum_relation_open_relation_during_drop_phase', 'reset', 1);
 
 1<:
 1: select age(relfrozenxid) from gp_dist_random('pg_class') where relname = 'ao_@orientation@_vacuum_cleanup3' and gp_segment_id = 0;

--- a/src/test/isolation2/output/uao/vacuum_cleanup.source
+++ b/src/test/isolation2/output/uao/vacuum_cleanup.source
@@ -1,6 +1,9 @@
 -- @Description Test that when there is a parallel vacuum going on in drop phase, the age of
 -- the AO/AOCS table gets reduced correctly.
 
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+CREATE
+
 1: create table ao_@orientation@_vacuum_cleanup1(a int, b int) with(appendonly=true, orientation=@orientation@);
 CREATE
 1: insert into ao_@orientation@_vacuum_cleanup1 select 1, i from generate_series(1, 100) i;
@@ -19,15 +22,15 @@ INSERT 100
 UPDATE 100
 
 
-1: !gpfaultinjector -f vacuum_relation_open_relation_during_drop_phase -y suspend -s 2;
-20170505:11:00:18:092363 gpfaultinjector:subraa4-mac:abhijits-[INFO]:-Starting gpfaultinjector with args: -f vacuum_relation_open_relation_during_drop_phase -y suspend -s 2
-20170505:11:00:18:092363 gpfaultinjector:subraa4-mac:abhijits-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
-20170505:11:00:18:092363 gpfaultinjector:subraa4-mac:abhijits-[INFO]:-DONE
-
+1: select gp_inject_fault('vacuum_relation_open_relation_during_drop_phase', 'suspend', 2);
+gp_inject_fault
+---------------
+t              
+(1 row)
 
 2&: vacuum ao_@orientation@_vacuum_cleanup1;  <waiting ...>
 
-1: select wait_for_trigger_fault('vacuum_relation_open_relation_during_drop_phase', 2);
+1: select wait_for_trigger_fault((select current_database()), 'vacuum_relation_open_relation_during_drop_phase', 2);
 wait_for_trigger_fault
 ----------------------
 t                     
@@ -53,11 +56,11 @@ age
 3  
 (1 row)
 
-1: !gpfaultinjector -f vacuum_relation_open_relation_during_drop_phase -y reset -s 2;
-20170505:11:00:19:092390 gpfaultinjector:subraa4-mac:abhijits-[INFO]:-Starting gpfaultinjector with args: -f vacuum_relation_open_relation_during_drop_phase -y reset -s 2
-20170505:11:00:19:092390 gpfaultinjector:subraa4-mac:abhijits-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
-20170505:11:00:19:092390 gpfaultinjector:subraa4-mac:abhijits-[INFO]:-DONE
-
+1: select gp_inject_fault('vacuum_relation_open_relation_during_drop_phase', 'reset', 2);
+gp_inject_fault
+---------------
+t              
+(1 row)
 2<:  <... completed>
 VACUUM
 
@@ -78,16 +81,16 @@ age
 ---
 3  
 (1 row)
-1: !gpfaultinjector -f vacuum_relation_open_relation_during_drop_phase -y suspend -s 1;
-20170509:15:52:16:071163 gpfaultinjector:subraa4-mac:abhijits-[INFO]:-Starting gpfaultinjector with args: -f vacuum_relation_open_relation_during_drop_phase -y suspend -s 1
-20170509:15:52:16:071163 gpfaultinjector:subraa4-mac:abhijits-[INFO]:-Injecting fault on content=-1:dbid=1:mode=s:status=u
-20170509:15:52:16:071163 gpfaultinjector:subraa4-mac:abhijits-[INFO]:-DONE
-
+1: select gp_inject_fault('vacuum_relation_open_relation_during_drop_phase', 'suspend', 1);
+gp_inject_fault
+---------------
+t              
+(1 row)
 1&: vacuum ao_@orientation@_vacuum_cleanup3;  <waiting ...>
 
 -- Wait till compaction phase is completed and only then start the serializable
 -- transaction to ensure that only drop phase is skipped
-2: select wait_for_trigger_fault('vacuum_relation_open_relation_during_drop_phase', 1);
+2: select wait_for_trigger_fault((select current_database()), 'vacuum_relation_open_relation_during_drop_phase', 1);
 wait_for_trigger_fault
 ----------------------
 t                     
@@ -99,11 +102,11 @@ BEGIN
 --------
 123     
 (1 row)
-2: !gpfaultinjector -f vacuum_relation_open_relation_during_drop_phase -y reset -s 1;
-20170509:15:52:17:071190 gpfaultinjector:subraa4-mac:abhijits-[INFO]:-Starting gpfaultinjector with args: -f vacuum_relation_open_relation_during_drop_phase -y reset -s 1
-20170509:15:52:17:071190 gpfaultinjector:subraa4-mac:abhijits-[INFO]:-Injecting fault on content=-1:dbid=1:mode=s:status=u
-20170509:15:52:17:071190 gpfaultinjector:subraa4-mac:abhijits-[INFO]:-DONE
-
+2: select gp_inject_fault('vacuum_relation_open_relation_during_drop_phase', 'reset', 1);
+gp_inject_fault
+---------------
+t              
+(1 row)
 
 1<:  <... completed>
 VACUUM

--- a/src/test/isolation2/sql/commit_transaction_block_checkpoint.sql
+++ b/src/test/isolation2/sql/commit_transaction_block_checkpoint.sql
@@ -1,7 +1,9 @@
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+
 -- TEST 1: block checkpoint on segments
 
 -- pause the 2PC after setting inCommit flag
-! gpfaultinjector -f twophase_transaction_commit_prepared -m async -y suspend -o 0 -H ALL -r primary;
+select gp_inject_fault('twophase_transaction_commit_prepared', 'suspend', 3);
 
 -- trigger a 2PC, and it will block at commit;
 2: checkpoint;
@@ -13,7 +15,7 @@
 3U&: checkpoint;
 
 -- resume the 2PC after setting inCommit flag
-! gpfaultinjector -f twophase_transaction_commit_prepared -m async -y reset -o 0 -H ALL -r primary;
+select gp_inject_fault('twophase_transaction_commit_prepared', 'reset', 3);
 2<:
 3U<:
 
@@ -21,7 +23,7 @@
 
 -- pause the CommitTransaction right before persistent table cleanup after
 -- notifyCommittedDtxTransaction()
-! gpfaultinjector -f transaction_commit_pass1_from_drop_in_memory_to_drop_pending -m async -y suspend -o 0 -s 1;
+select gp_inject_fault('transaction_commit_pass1_from_drop_in_memory_to_drop_pending', 'suspend', 1);
 
 -- trigger a 2PC, and it will block at commit;
 2: checkpoint;
@@ -33,7 +35,7 @@
 1U&: checkpoint;
 
 -- resume the 2PC
-! gpfaultinjector -f transaction_commit_pass1_from_drop_in_memory_to_drop_pending -m async -y reset -o 0 -s 1;
+select gp_inject_fault('transaction_commit_pass1_from_drop_in_memory_to_drop_pending', 'reset', 1);
 2<:
 1U<:
 

--- a/src/test/isolation2/sql/setup.sql
+++ b/src/test/isolation2/sql/setup.sql
@@ -90,14 +90,14 @@ SELECT coalesce(
 create language plpythonu;
 -- end_ignore
 
-CREATE OR REPLACE FUNCTION wait_for_trigger_fault(fault text, segno int)
+CREATE OR REPLACE FUNCTION wait_for_trigger_fault(dbname text, fault text, segno int)
 RETURNS bool as $$
     import subprocess 
     import time
-    cmd = 'gpfaultinjector -f %s -y status -s %d | grep -i triggered | wc -l' % (fault, segno)
+    cmd = 'psql %s -c "select gp_inject_fault(\'%s\', \'status\', %d)"' % (dbname, fault, segno)
     for i in range(100):
         cmd_output = subprocess.Popen(cmd, stderr=subprocess.STDOUT, stdout=subprocess.PIPE, shell=True)
-        if int(cmd_output.stdout.read()):
+        if 'triggered' in cmd_output.stdout.read():
             return True
         time.sleep(0.5)
     return False 


### PR DESCRIPTION
We want to stop using gpfaultinjector utility in favor of using the
new gp_inject_fault extension. This commit creates the extension in
each test that requires it and replaces all uses of gpfaultinjector
utility with gp_inject_fault.

Authors: Abhijit Subramanya and Jimmy Yih