### PR TITLE
Create minimal segment WAL replication pipeline

### DIFF
--- a/concourse/pipelines/pipeline_segwalrep.yml
+++ b/concourse/pipelines/pipeline_segwalrep.yml
@@ -1,0 +1,124 @@
+## ======================================================================
+## resources
+## ======================================================================
+
+resources:
+- name: gpdb_src
+  type: git
+  source:
+    branch: {{gpdb-git-branch}}
+    uri: {{gpdb-git-remote}}
+    ignore_paths:
+    - gpdb-doc/*
+    - README*
+
+- name: gpaddon_src
+  type: git
+  source:
+    branch: {{gpaddon-git-branch}}
+    private_key: {{gpaddon-git-key}}
+    uri: {{gpaddon-git-remote}}
+
+- name: centos-gpdb-dev-6
+  type: docker-image
+  source:
+    repository: pivotaldata/centos-gpdb-dev
+    tag: '6-gcc6.2-llvm3.7'
+
+- name: bin_gpdb_centos6
+  type: s3
+  source:
+    access_key_id: {{bucket-access-key-id}}
+    bucket: {{bucket-name}}
+    region_name: {{aws-region}}
+    secret_access_key: {{bucket-secret-access-key}}
+    versioned_file: {{bin_gpdb_centos_versioned_file}}
+
+## ======================================================================
+## jobs
+## ======================================================================
+
+# Stage 1: Build and C Unit Tests
+
+jobs:
+
+- name: compile_gpdb_centos6
+  plan:
+  - aggregate:
+    - get: gpdb_src
+      trigger: true
+    - get: gpaddon_src
+    - get: centos-gpdb-dev-6
+  - task: compile_gpdb
+    file: gpdb_src/concourse/tasks/compile_gpdb.yml
+    image: centos-gpdb-dev-6
+    params:
+      IVYREPO_HOST: {{ivyrepo_host}}
+      IVYREPO_REALM: {{ivyrepo_realm}}
+      IVYREPO_USER: {{ivyrepo_user}}
+      IVYREPO_PASSWD: {{ivyrepo_passwd}}
+      CONFIGURE_FLAGS: "--enable-segwalrep"
+      TARGET_OS: centos
+      TARGET_OS_VERSION: 6
+  - aggregate:
+    - put: bin_gpdb_centos6
+      params:
+        file: gpdb_artifacts/bin_gpdb.tar.gz
+
+- name: icw_gporca_centos6
+  plan:
+  - aggregate:
+    - get: gpdb_src
+      passed: [compile_gpdb_centos6]
+    - get: bin_gpdb
+      resource: bin_gpdb_centos6
+      passed: [compile_gpdb_centos6]
+      trigger: true
+    - get: centos-gpdb-dev-6
+  - task: ic_gpdb
+    file: gpdb_src/concourse/tasks/ic_gpdb.yml
+    image: centos-gpdb-dev-6
+    params:
+      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=on' installcheck-world
+      BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
+      TEST_OS: centos
+      CONFIGURE_FLAGS: "--enable-segwalrep"
+
+- name: icw_planner_centos6
+  plan:
+  - aggregate:
+    - get: gpdb_src
+      passed: [compile_gpdb_centos6]
+    - get: bin_gpdb
+      resource: bin_gpdb_centos6
+      passed: [compile_gpdb_centos6]
+      trigger: true
+    - get: centos-gpdb-dev-6
+  - task: ic_gpdb
+    file: gpdb_src/concourse/tasks/ic_gpdb.yml
+    image: centos-gpdb-dev-6
+    params:
+      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off' installcheck-world
+      BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
+      TEST_OS: centos
+      CONFIGURE_FLAGS: "--enable-segwalrep"
+
+- name: segwalrep_mirrorless_centos6
+  plan:
+  - aggregate:
+    - get: gpdb_src
+      passed: [compile_gpdb_centos6]
+    - get: bin_gpdb
+      resource: bin_gpdb_centos6
+      passed: [compile_gpdb_centos6]
+      trigger: true
+    - get: centos-gpdb-dev-6
+  - task: ic_gpdb
+    file: gpdb_src/concourse/tasks/ic_gpdb.yml
+    image: centos-gpdb-dev-6
+    params:
+      MAKE_TEST_COMMAND: "-C src/test/regress && make -C src/test/walrep install installcheck"
+      BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
+      TEST_OS: centos
+      CONFIGURE_FLAGS: "--enable-segwalrep"
+      WITH_MIRRORS: false

--- a/concourse/scripts/common.bash
+++ b/concourse/scripts/common.bash
@@ -42,11 +42,7 @@ function make_cluster() {
   export STATEMENT_MEM=250MB
   workaround_before_concourse_stops_stripping_suid_bits
   pushd gpdb_src/gpAux/gpdemo
-    if [[ $CONFIGURE_FLAGS == *"--enable-segwalrep"* ]]; then
-      su gpadmin -c "make create-segwalrep-cluster"
-    else
-      su gpadmin -c "make create-demo-cluster"
-    fi
+  su gpadmin -c "make create-demo-cluster"
   popd
 }
 

--- a/concourse/tasks/ic_gpdb.yml
+++ b/concourse/tasks/ic_gpdb.yml
@@ -10,5 +10,6 @@ params:
   BLDWRAP_POSTGRES_CONF_ADDONS: ""
   TEST_OS: ""
   CONFIGURE_FLAGS: ""
+  WITH_MIRRORS:
 run:
   path: gpdb_src/concourse/scripts/ic_gpdb.bash

--- a/gpAux/gpdemo/Makefile
+++ b/gpAux/gpdemo/Makefile
@@ -19,7 +19,10 @@ export with_openssl
 MASTER_PORT ?= 15432
 PORT_BASE ?= 25432
 NUM_PRIMARY_MIRROR_PAIRS ?= 3
-WITH_MIRRORS ?= true
+
+ifeq ($(WITH_MIRRORS), )
+WITH_MIRRORS = true
+endif
 
 export MASTER_DEMO_PORT=$(MASTER_PORT)
 export DEMO_PORT_BASE=$(PORT_BASE)
@@ -33,14 +36,18 @@ all:
 	$(MAKE) probe
 
 cluster create-demo-cluster:
+ifeq ($(enable_segwalrep), yes)
+	@WITH_MIRRORS=false ./demo_cluster.sh # will generate gpdemo-env.sh
+	@if [[ $(WITH_MIRRORS) == true ]]; then \
+	 	. ./gpdemo-env.sh; \
+	 	./gpsegwalrep.py init --host `hostname`; \
+	 	./gpsegwalrep.py start; \
+	 fi
+	@echo ""
+else
 	@./demo_cluster.sh
 	@echo ""
-
-create-segwalrep-cluster:
-	@WITH_MIRRORS=false ./demo_cluster.sh # will generate gpdemo-env.sh
-	@. ./gpdemo-env.sh;./gpsegwalrep.py init --host `hostname`
-	@. ./gpdemo-env.sh;./gpsegwalrep.py start
-	@echo""
+endif
 
 probe:
 	@./probe_config.sh

--- a/src/test/regress/GNUmakefile
+++ b/src/test/regress/GNUmakefile
@@ -164,6 +164,13 @@ includecheck:
 
 pg_regress_call = ./pg_regress --inputdir=$(srcdir) --multibyte=$(MULTIBYTE) $(MAXCONNOPT) $(NOLOCALE) --init-file=$(srcdir)/init_file
 
+# These are currently skipped because they don't work yet for segment wal replication
+# segspace: cannot restart database at the moment
+# filespace: segment wal replication does not handle filespaces yet
+ifeq ($(enable_segwalrep), yes)
+pg_regress_call := $(pg_regress_call) --exclude-tests="segspace_setup segspace segspace_cleanup filespace"
+endif
+
 check: all
 	$(pg_regress_call) --temp-install=./tmp_check --top-builddir=$(top_builddir) --srcdir=$(abs_srcdir) --temp-port=$(TEMP_PORT) --schedule=$(srcdir)/parallel_schedule 
 

--- a/src/test/walrep/Makefile
+++ b/src/test/walrep/Makefile
@@ -6,9 +6,15 @@ top_builddir = ../../..
 
 include $(top_builddir)/src/Makefile.global
 
+WITH_MIRRORS ?= true
 REGRESS = setup walreceiver
+
+# These two tests can only run without mirrors due to limit of 1
+# walsender-walreceiver connection only
 ifeq ($(enable_segwalrep), yes)
+ifeq ($(WITH_MIRRORS), false)
 REGRESS += generate_ao_xlog generate_aoco_xlog
+endif
 endif
 REGRESS_OPTS = --dbname="walrep_regression"
 


### PR DESCRIPTION
As we develop segment WAL replication, we need a green to green CI
pipeline that we can start small and add relative jobs from
gpdb_master as we add more functionality. This commit establishes that
pipeline and omits ICW tests that are currently not supported by
segment WAL replication.

Authors: Abhijit Subramanya and Jimmy Yih