### PR TITLE
gpconfig: change log msg after GUC change

### DIFF
--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -349,9 +349,9 @@ def do_change(options):
     pool.joinWorkers()
 
     if failure:
-        LOGGER.error('finished with errors')
+        LOGGER.error("finished with errors, parameter string '%s'" %(" ".join(sys.argv[1:])))
     else:
-        LOGGER.info("completed successfully")
+        LOGGER.info("completed successfully with parameters '%s'" %(" ".join(sys.argv[1:])))
 
 
 def _is_guc_writeable(options):

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpconfig.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpconfig.py
@@ -219,7 +219,7 @@ class GpConfig(GpTestCase):
 
         self.subject.do_main()
 
-        self.subject.LOGGER.info.assert_called_with("completed successfully")
+        self.subject.LOGGER.info.assert_called_with("completed successfully with parameters '-c my_property_name -v 100 -m 20'")
         self.assertEqual(self.pool.addCommand.call_count, 2)
         segment_command = self.pool.addCommand.call_args_list[0][0][0]
         self.assertTrue("my_property_name" in segment_command.cmdStr)
@@ -240,7 +240,7 @@ class GpConfig(GpTestCase):
 
         self.subject.do_main()
 
-        self.subject.LOGGER.info.assert_called_with("completed successfully")
+        self.subject.LOGGER.info.assert_called_with("completed successfully with parameters '-c my_property_name -v 100 --masteronly'")
         self.assertEqual(self.pool.addCommand.call_count, 1)
         master_command = self.pool.addCommand.call_args_list[0][0][0]
         self.assertTrue(("my_property_name") in master_command.cmdStr)
@@ -260,7 +260,7 @@ class GpConfig(GpTestCase):
         sys.argv = ["gpconfig", "-c", "my_hidden_guc_name", "-v", "100", "--skipvalidation"]
         self.subject.do_main()
 
-        self.subject.LOGGER.info.assert_called_with("completed successfully")
+        self.subject.LOGGER.info.assert_called_with("completed successfully with parameters '-c my_hidden_guc_name -v 100 --skipvalidation'")
         self.assertEqual(self.pool.addCommand.call_count, 2)
         segment_command = self.pool.addCommand.call_args_list[0][0][0]
         self.assertTrue("my_hidden_guc_name" in segment_command.cmdStr)
@@ -386,7 +386,7 @@ class GpConfig(GpTestCase):
                                              'context', 'vartype', 'min_val', 'max_val']])
         self.subject.do_main()
 
-        self.subject.LOGGER.info.assert_called_with("completed successfully")
+        self.subject.LOGGER.info.assert_called_with("completed successfully with parameters '-c my_property_name -v 100 --masteronly'")
         target_warning = "disallowed GUCs file missing: '%s'" % self.guc_disallowed_readonly_file
         self.subject.LOGGER.warning.assert_called_with(target_warning)
 
@@ -397,6 +397,23 @@ class GpConfig(GpTestCase):
         with self.assertRaisesRegexp(Exception, "GPHOME environment variable must be set"):
             self.subject.do_main()
 
+    def test_gpconfig_logs_successful_guc_change(self):
+        sys.argv = ["gpconfig", "-c", 'my_property_name', "-v", "100", "--masteronly"]
+        self.cursor.set_result_for_testing([['my_property_name', 'setting', 'unit', 'short_desc',
+                                             'context', 'vartype', 'min_val', 'max_val']])
+
+        self.subject.do_main()
+
+        self.subject.LOGGER.info.assert_called_with("completed successfully with parameters '-c my_property_name -v 100 --masteronly'")
+
+    def test_gpconfig_logs_unsuccessful_guc_change(self):
+        sys.argv = ["gpconfig", "-c", 'my_property_name', "-v", "100", "--masteronly"]
+        self.cursor.set_result_for_testing([['my_property_name', 'setting', 'unit', 'short_desc',
+                                             'context', 'vartype', 'min_val', 'max_val']])
+        self.segment_read_config.was_successful.return_value = False
+        self.subject.do_main()
+
+        self.subject.LOGGER.error.assert_called_with("finished with errors, parameter string '-c my_property_name -v 100 --masteronly'")
 
 
     @staticmethod

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -4941,16 +4941,15 @@ def impl(context):
                               And wait until the process "gpsmon" is up
                               ''')
 
+
 @given('the setting "{variable_name}" is NOT set in the configuration file "{path_to_file}"')
 @when('the setting "{variable_name}" is NOT set in the configuration file "{path_to_file}"')
 def impl(context, variable_name, path_to_file):
     path = os.path.join(os.getenv("MASTER_DATA_DIRECTORY"), path_to_file)
-    match_start_of_line = '^' + variable_name + '.*'
-    pattern = re.compile(match_start_of_line)
-    with open(path, 'r') as f:
-        for line in f.read().split('\n'):
-            if pattern.match(line):
-                raise Exception('found in file %s the setting: %s' % (line, variable_name))
+    output_file = "/tmp/gpperfmon_temp_config"
+    cmd = Command("sed to remove line", "sed '/^%s/,+1 d' < %s > %s" % (variable_name, path, output_file))
+    cmd.run(validateAfter=True)
+    shutil.move(output_file, path)
 
 
 @given('the setting "{setting_string}" is placed in the configuration file "{path_to_file}"')
@@ -4960,6 +4959,7 @@ def impl(context, setting_string, path_to_file):
     with open(path, 'a') as f:
         f.write(setting_string)
         f.write("\n")
+
 
 @given('the latest gpperfmon gpdb-alert log is copied to a file with a fake (earlier) timestamp')
 @when('the latest gpperfmon gpdb-alert log is copied to a file with a fake (earlier) timestamp')


### PR DESCRIPTION
Updating the log message to display the parameters gpconfig was called
with, both if the GUC was changed successfully or not.

Signed-off-by: Marbin Tan <mtan@pivotal.io>