### PR TITLE
Don't send PartConstraint expression if rel has no indices

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("2.40.", GPORCA_VERSION_STRING, 5);
+return strncmp("2.41.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 2.40.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 2.41.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -12539,7 +12539,7 @@ int
 main ()
 {
 
-return strncmp("2.40.", GPORCA_VERSION_STRING, 5);
+return strncmp("2.41.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -12549,7 +12549,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 2.40.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 2.41.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -121,7 +121,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	@echo "Resolve finished";
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget -O - https://github.com/greenplum-db/gporca/releases/download/v2.40.3/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget -O - https://github.com/greenplum-db/gporca/releases/download/v2.41.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
@@ -319,7 +319,7 @@ namespace gpdxl
 
 			// retrieve part constraint for relation
 			static
-			CMDPartConstraintGPDB *PmdpartcnstrRelation(IMemoryPool *pmp, CMDAccessor *pmda, OID oidRel, DrgPmdcol *pdrgpmdcol);
+			CMDPartConstraintGPDB *PmdpartcnstrRelation(IMemoryPool *pmp, CMDAccessor *pmda, OID oidRel, DrgPmdcol *pdrgpmdcol, BOOL fhasIndex);
 
 			// retrieve part constraint from a GPDB node
 			static


### PR DESCRIPTION
While gathering metadata information about a partitioned relation, the
relcache translator in GPDB constructs and sends partition
constraints in `CMDPartConstraintGPDB` object.
CMDPartConstraintGPDB contains following:
```
1. m_pdrgpulDefaultParts = List of partition levels that have default partitions
2. m_fUnbounded = indicate if the constraint is unbounded
3. m_pdxln = Part Constraint expression
```

When you have more partitioning levels, the part constraint expression
can grow large and we end up spending significant amount of time in
translating this expression to DXL format.
For instance, for the following query, relcache translator spends
`18895.444000 ms` in fetching & translating the metadata information on debug build:
```
DROP TABLE IF EXISTS date_parts;
CREATE TABLE DATE_PARTS (id int, year int, month int, day int, region text)
DISTRIBUTED BY (id) PARTITION BY RANGE (year) SUBPARTITION BY LIST
(month) SUBPARTITION TEMPLATE ( SUBPARTITION Q1 VALUES (1, 2, 3),
SUBPARTITION Q2 VALUES (4 ,5 ,6), SUBPARTITION Q3 VALUES (7, 8, 9),
SUBPARTITION Q4 VALUES (10, 11, 12), DEFAULT SUBPARTITION other_months )
SUBPARTITION BY RANGE(day) SUBPARTITION TEMPLATE ( START (1) END (31)
EVERY (10), DEFAULT SUBPARTITION other_days) ( START (2002) END (2012)
EVERY (1), DEFAULT PARTITION outlying_years );

INSERT INTO date_parts SELECT i, EXTRACT(year FROM dt), EXTRACT(month
FROM dt), EXTRACT(day FROM dt), NULL FROM (SELECT i, '2002-01-01'::DATE
+ i * INTERVAL '1 day' day AS dt FROM GENERATE_SERIES(1, 3650) AS i) AS
t;

EXPLAIN SELECT * FROM date_parts WHERE month BETWEEN 1 AND 4;
```

At ORCA end, however, we do not use this part constraints expression
unless the relation has indices built on it.  This is evident from
CTranslatorDXLToExpr.cpp + L565 (`CTranslatorDXLToExpr::PexprLogicalGet`).
Hence we do not need to send the PartConstraint expression from GPDB
Recache Translator since:
A. It will not be consumed if there are no indices
B. The DXL translation is expensive.

This commit fixes the Relcache Translator to send the Partition Constraint
Expression to ORCA only in the cases listed below :
```
        IsPartTable     Index   DefaultParts   ShouldSendPartConstraint
        NO              -       -              -
        YES             YES     YES/NO         YES
        YES             NO      NO             NO
        YES             NO      YES            YES (but only default levels info)
```
After fix the metadata fetch and translation time is reduced to `87.828000ms`.

We also need changes in ORCA ParseHandler since we will be sending the part
constraint expression in some cases only.
Please refer https://github.com/greenplum-db/gporca/pull/215