### PR TITLE
Allow building with unpatched Xerces-C.

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -4,22 +4,9 @@
 AC_DEFUN([PGAC_CHECK_ORCA_XERCES],
 [
 AC_CHECK_LIB(xerces-c, strnicmp, [],
-  [AC_MSG_ERROR([library xerces-c is required for Pivotal Query Optimizer to build, you can build it from https://github.com/greenplum-db/gp-xerces])]
+  [AC_MSG_ERROR([library xerces-c is required to build with Pivotal Query Optimizer])]
 )
-AC_MSG_CHECKING([[for Greenplum patched Xerces-C]])
-AC_LANG_PUSH([C++])
-AC_LINK_IFELSE([AC_LANG_PROGRAM([[
-#include "xercesc/util/XMemory.hpp"
-#include "xercesc/dom/DOMImplementationList.hpp"
-]],
-[
-xercesc::DOMImplementationList* derived_ptr = NULL;
-xercesc::XMemory* base_ptr = derived_ptr;
-])],
-[AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your Xerces is not patched, you can build it from https://github.com/greenplum-db/gp-xerces])]
-)
-AC_LANG_POP([C++])
+AC_MSG_CHECKING([[for Xerces-C]])
 ])# PGAC_CHECK_ORCA_XERCES
 
 AC_DEFUN([PGAC_CHECK_ORCA_HEADERS],

--- a/configure
+++ b/configure
@@ -12310,50 +12310,12 @@ _ACEOF
   LIBS="-lxerces-c $LIBS"
 
 else
-  as_fn_error $? "library xerces-c is required for Pivotal Query Optimizer to build, you can build it from https://github.com/greenplum-db/gp-xerces" "$LINENO" 5
+  as_fn_error $? "library xerces-c is required to build with Pivotal Query Optimizer" "$LINENO" 5
 
 fi
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for Greenplum patched Xerces-C" >&5
-$as_echo_n "checking for Greenplum patched Xerces-C... " >&6; }
-ac_ext=cpp
-ac_cpp='$CXXCPP $CPPFLAGS'
-ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
-
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-#include "xercesc/util/XMemory.hpp"
-#include "xercesc/dom/DOMImplementationList.hpp"
-
-int
-main ()
-{
-
-xercesc::DOMImplementationList* derived_ptr = NULL;
-xercesc::XMemory* base_ptr = derived_ptr;
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_cxx_try_link "$LINENO"; then :
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
-$as_echo "ok" >&6; }
-else
-  as_fn_error $? "Your Xerces is not patched, you can build it from https://github.com/greenplum-db/gp-xerces" "$LINENO" 5
-
-fi
-rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-ac_ext=c
-ac_cpp='$CPP $CPPFLAGS'
-ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_c_compiler_gnu
-
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for Xerces-C" >&5
+$as_echo_n "checking for Xerces-C... " >&6; }
 
 
 ac_ext=cpp


### PR DESCRIPTION
Per discussion at https://github.com/greenplum-db/gpdb/pull/2379, we don't
really need to use a special, patched, version of Xerces-C. Remove the
check.