### PR TITLE
Enable binary_swap test, since HEAP_CHECKSUM is in.

### DIFF
--- a/concourse/tasks/ic_gpdb_binary_swap.yml
+++ b/concourse/tasks/ic_gpdb_binary_swap.yml
@@ -10,7 +10,7 @@ params:
   MAKE_TEST_COMMAND: ""
   BLDWRAP_POSTGRES_CONF_ADDONS: ""
   TEST_OS: ""
-  TEST_BINARY_SWAP: false
+  TEST_BINARY_SWAP: true
   CONFIGURE_FLAGS: ""
 run:
   path: gpdb_src/concourse/scripts/ic_gpdb.bash


### PR DESCRIPTION
Signed-off-by: Xin Zhang <xzhang@pivotal.io>