### PR TITLE
Change makefile naming to be consistent for gpMgmt/bin

### DIFF
--- a/gpMgmt/Makefile
+++ b/gpMgmt/Makefile
@@ -65,7 +65,7 @@ generate_greenplum_path_file:
 
 install: generate_greenplum_path_file
 	# Generate some python libraries
-	$(MAKE) -C bin all prefix=$(DESTDIR)$(prefix)
+	$(MAKE) -C bin $@ prefix=$(DESTDIR)$(prefix)
 
 	# Copy the management utilities
 	mkdir -p $(DESTDIR)$(prefix)/bin

--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -4,7 +4,7 @@
 # Copyright Greenplum 2006-2011
 ################################################################################
 
-default: all
+default: install
 
 top_builddir=../..
 ifneq "$(wildcard $(top_builddir)/src/Makefile.global)" ""
@@ -32,9 +32,9 @@ core: pygresql subprocess32
 	python gpconfig_modules/parse_guc_metadata.py $(prefix)
 
 ifneq "$(wildcard $(CURDIR)/pythonSrc/ext/*.tar.gz)" ""
-all: core lockfile paramiko pycrypto stream psutil
+install: core lockfile paramiko pycrypto stream psutil
 else
-all: core stream
+install: core stream
 endif
 
 #


### PR DESCRIPTION
Previously, the "all" target was used only by gpMgmt/bin/Makefile in
place of the "install" target used elsewhere. The underlying reason was
because python doesn't need a compile phase (the "all" target).

However, this is inconsistent. Change to use the standard "install"
target, which is also the default on the gpMgmt/bin/Makefile.

Signed-off-by: Larry Hamel <lhamel@pivotal.io>