### PR TITLE
Fix bug: gpconfig change gp_resource_manager fail

### DIFF
--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -141,14 +141,14 @@ class Guc:
                 return "invalid value for max_connections"
 
         elif self.name == "gp_resource_manager":
-            if newval == "group":
+            if newval == "'group'":
                 LOGGER.warn("Managing queries with resource groups is an "
                             "experimental feature. A work-in-progress version is "
                             "enabled.")
                 msg = GpResGroup().validate()
                 if msg is not None:
                     return msg
-            elif newval != "queue":
+            elif newval != "'queue'":
                 return "the value of gp_resource_manager must be 'group' or 'queue'"
 
         elif self.name == 'unix_socket_permissions':


### PR DESCRIPTION
The quote_string(newvalue) will make sure that the value(if type is string)
enclosed by ''. This is introduced in previous commit. We need to make
change of gp_resource_manager meet the logic now.