### PR TITLE
Remove unusued Plan.plan_parent_node_id field.

### DIFF
--- a/src/backend/executor/execGpmon.c
+++ b/src/backend/executor/execGpmon.c
@@ -66,8 +66,6 @@ void InitPlanNodeGpmonPkt(Plan *plan, gpmon_packet_t *gpmon_pkt, EState *estate)
 	gpmon_pkt->u.qexec.key.hash_key.pid = MyProcPid;
 	gpmon_pkt->u.qexec.key.hash_key.nid = plan->plan_node_id;
 
-	gpmon_pkt->u.qexec.pnid = plan->plan_parent_node_id;
-
 	gpmon_pkt->u.qexec.rowsout = 0;
 
 	gpmon_pkt->u.qexec.status = (uint8)PMNS_Initialize;

--- a/src/backend/executor/execProcnode.c
+++ b/src/backend/executor/execProcnode.c
@@ -1006,7 +1006,7 @@ ExecProcNode(PlanState *node)
 #endif   /* CDB_TRACE_EXECUTOR */
 
 	if(node->plan)
-		PG_TRACE5(execprocnode__enter, Gp_segment, currentSliceId, nodeTag(node), node->plan->plan_node_id, node->plan->plan_parent_node_id);
+		PG_TRACE4(execprocnode__enter, Gp_segment, currentSliceId, nodeTag(node), node->plan->plan_node_id);
 
 	if (node->chgParam != NULL) /* something changed */
 		ExecReScan(node, NULL); /* let ReScan handle this */
@@ -1199,7 +1199,7 @@ ExecProcNode(PlanState *node)
 		InstrStopNode(node->instrument, TupIsNull(result) ? 0.0 : 1.0);
 
 	if (node->plan)
-		PG_TRACE5(execprocnode__exit, Gp_segment, currentSliceId, nodeTag(node), node->plan->plan_node_id, node->plan->plan_parent_node_id);
+		PG_TRACE4(execprocnode__exit, Gp_segment, currentSliceId, nodeTag(node), node->plan->plan_node_id);
 
 #ifdef CDB_TRACE_EXECUTOR
 	ExecCdbTraceNode(node, false, result);
@@ -1261,8 +1261,7 @@ MultiExecProcNode(PlanState *node)
 
 	START_MEMORY_ACCOUNT(node->plan->memoryAccountId);
 {
-	PG_TRACE5(execprocnode__enter, Gp_segment, currentSliceId, nodeTag(node), node->plan->plan_node_id,
-			  node->plan->plan_parent_node_id);
+	PG_TRACE4(execprocnode__enter, Gp_segment, currentSliceId, nodeTag(node), node->plan->plan_node_id);
 
 	if (node->chgParam != NULL) /* something changed */
 		ExecReScan(node, NULL); /* let ReScan handle this */
@@ -1295,8 +1294,7 @@ MultiExecProcNode(PlanState *node)
 			break;
 	}
 
-	PG_TRACE5(execprocnode__exit, Gp_segment, currentSliceId, nodeTag(node), node->plan->plan_node_id,
-			  node->plan->plan_parent_node_id);
+	PG_TRACE4(execprocnode__exit, Gp_segment, currentSliceId, nodeTag(node), node->plan->plan_node_id);
 }
 	END_MEMORY_ACCOUNT();
 	return result;

--- a/src/backend/gpopt/translate/CMappingColIdVarPlStmt.cpp
+++ b/src/backend/gpopt/translate/CMappingColIdVarPlStmt.cpp
@@ -47,8 +47,7 @@ CMappingColIdVarPlStmt::CMappingColIdVarPlStmt
 	const CDXLTranslateContextBaseTable *pdxltrctxbt,
 	DrgPdxltrctx *pdrgpdxltrctx,
 	CDXLTranslateContext *pdxltrctxOut,
-	CContextDXLToPlStmt *pctxdxltoplstmt,
-	Plan *pplan
+	CContextDXLToPlStmt *pctxdxltoplstmt
 	)
 	:
 	CMappingColIdVar(pmp),
@@ -57,9 +56,6 @@ CMappingColIdVarPlStmt::CMappingColIdVarPlStmt
 	m_pdxltrctxOut(pdxltrctxOut),
 	m_pctxdxltoplstmt(pctxdxltoplstmt)
 {
-	GPOS_ASSERT(NULL != pplan);
-
-	m_pplan = pplan;
 }
 
 //---------------------------------------------------------------------------
@@ -88,21 +84,6 @@ CDXLTranslateContext *
 CMappingColIdVarPlStmt::PpdxltrctxOut()
 {
 	return m_pdxltrctxOut;
-}
-
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CMappingColIdVarPlStmt::Pplan
-//
-//	@doc:
-//		Returns the plan
-//
-//---------------------------------------------------------------------------
-Plan *
-CMappingColIdVarPlStmt::Pplan()
-{
-	return m_pplan;
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -631,13 +631,6 @@ CTranslatorDXLToScalar::PsubplanFromDXLNodeScSubPlan
 	CDXLNode *pdxlnChild = (*pdxlnSubPlan)[0];
         GPOS_ASSERT(EdxloptypePhysical == pdxlnChild->Pdxlop()->Edxloperatortype());
 
-	Plan *pplan = ((CMappingColIdVarPlStmt*) pmapcidvar)->Pplan();
-
-	if(NULL == pplan)
-	{
-		GPOS_RAISE(gpdxl::ExmaDXL, ExmiDXL2PlStmtMissingPlanForSubPlanTranslation);
-	}
-
 	GPOS_ASSERT(NULL != pdxlnSubPlan);
 	GPOS_ASSERT(EdxlopScalarSubPlan == pdxlnSubPlan->Pdxlop()->Edxlop());
 	GPOS_ASSERT(1 == pdxlnSubPlan->UlArity());
@@ -652,7 +645,7 @@ CTranslatorDXLToScalar::PsubplanFromDXLNodeScSubPlan
 							m_ulSegments
 							);
 	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	Plan *pplanChild = trdxltoplstmt.PplFromDXL(pdxlnChild, &dxltrctxSubplan, pplan, pdrgpdxltrctxPrevSiblings);
+	Plan *pplanChild = trdxltoplstmt.PplFromDXL(pdxlnChild, &dxltrctxSubplan, pdrgpdxltrctxPrevSiblings);
 	pdrgpdxltrctxPrevSiblings->Release();
 
 	GPOS_ASSERT(NULL != pplanChild->targetlist && 1 <= gpdb::UlListLength(pplanChild->targetlist));

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -171,9 +171,7 @@ _copyOidAssignment(OidAssignment *from)
 static void
 CopyPlanFields(Plan *from, Plan *newnode)
 {
-
 	COPY_SCALAR_FIELD(plan_node_id);
-	COPY_SCALAR_FIELD(plan_parent_node_id);
 
 	COPY_SCALAR_FIELD(startup_cost);
 	COPY_SCALAR_FIELD(total_cost);

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -275,7 +275,6 @@ static void
 _outPlanInfo(StringInfo str, Plan *node)
 {
 	WRITE_INT_FIELD(plan_node_id);
-	WRITE_INT_FIELD(plan_parent_node_id);
 
 	WRITE_FLOAT_FIELD(startup_cost, "%.2f");
 	WRITE_FLOAT_FIELD(total_cost, "%.2f");

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -351,7 +351,6 @@ static void
 _outPlanInfo(StringInfo str, Plan *node)
 {
 	WRITE_INT_FIELD(plan_node_id);
-	WRITE_INT_FIELD(plan_parent_node_id);
 
 	WRITE_FLOAT_FIELD(startup_cost, "%.2f");
 	WRITE_FLOAT_FIELD(total_cost, "%.2f");

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -2340,7 +2340,6 @@ void readScanInfo(Scan *local_node)
 void readPlanInfo(Plan *local_node)
 {
 	READ_INT_FIELD(plan_node_id);
-	READ_INT_FIELD(plan_parent_node_id);
 	READ_FLOAT_FIELD(startup_cost);
 	READ_FLOAT_FIELD(total_cost);
 	READ_FLOAT_FIELD(plan_rows);

--- a/src/backend/utils/gpmon/gpmon.c
+++ b/src/backend/utils/gpmon/gpmon.c
@@ -177,11 +177,11 @@ void gpmon_send(gpmon_packet_t* p)
 		if (gp_perfmon_print_packet_info)
 		{
 			elog(LOG,
-				 "Perfmon Executor Packet: (tmid, ssid, ccnt, segid, pid, nid, pnid, status) = "
-				 "(%d, %d, %d, %d, %d, %d, %d, %d)",
+				 "Perfmon Executor Packet: (tmid, ssid, ccnt, segid, pid, nid, status) = "
+				 "(%d, %d, %d, %d, %d, %d, %d)",
 				 p->u.qexec.key.tmid, p->u.qexec.key.ssid, p->u.qexec.key.ccnt,
 				 p->u.qexec.key.hash_key.segid, p->u.qexec.key.hash_key.pid, p->u.qexec.key.hash_key.nid,
-				 p->u.qexec.pnid, p->u.qexec.status);
+				 p->u.qexec.status);
 		}
 	}
 	

--- a/src/include/gpmon/gpmon.h
+++ b/src/include/gpmon/gpmon.h
@@ -198,7 +198,6 @@ typedef struct gpmon_qexeckey_t {
 
 struct gpmon_qexec_t {
 	gpmon_qexeckey_t key;
-	int32  		pnid;	/* plan parent node id */
 	char		_hname[NAMEDATALEN];
 	uint8		status;    /* node status using PerfmonNodeStatus */
 	uint64		_cpu_elapsed; /* CPU elapsed for iter */

--- a/src/include/gpopt/translate/CMappingColIdVarPlStmt.h
+++ b/src/include/gpopt/translate/CMappingColIdVarPlStmt.h
@@ -55,8 +55,6 @@ namespace gpdxl
 
 			CDXLTranslateContext *m_pdxltrctxOut;
 
-			Plan *m_pplan;
-
 			// translator context used to translate initplan and subplans associated
 			// with a param node
 			CContextDXLToPlStmt *m_pctxdxltoplstmt;
@@ -69,8 +67,7 @@ namespace gpdxl
 				const CDXLTranslateContextBaseTable *pdxltrctxbt,
 				DrgPdxltrctx *pdrgpdxltrctx,
 				CDXLTranslateContext *pdxltrctxOut,
-				CContextDXLToPlStmt *pctxdxltoplstmt,
-				Plan *pplan
+				CContextDXLToPlStmt *pctxdxltoplstmt
 				);
 
 			// translate DXL ScalarIdent node into GPDB Var node
@@ -82,9 +79,6 @@ namespace gpdxl
 
 			// get the output translator context
 			CDXLTranslateContext *PpdxltrctxOut();
-
-			// return the parent plan
-			Plan *Pplan();
 
 			// return the context of the DXL->PlStmt translation
 			CContextDXLToPlStmt *Pctxdxltoplstmt();

--- a/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
@@ -87,7 +87,7 @@ namespace gpdxl
 	class CTranslatorDXLToPlStmt
 	{
 		// shorthand for functions for translating DXL operator nodes into planner trees
-		typedef Plan * (CTranslatorDXLToPlStmt::*PfPplan)(const CDXLNode *pdxln, CDXLTranslateContext *pdxltrctxOut, Plan *pplanParent, DrgPdxltrctx *pdrgpdxltrctxPrevSiblings);
+		typedef Plan * (CTranslatorDXLToPlStmt::*PfPplan)(const CDXLNode *pdxln, CDXLTranslateContext *pdxltrctxOut, DrgPdxltrctx *pdrgpdxltrctxPrevSiblings);
 
 		private:
 
@@ -258,7 +258,6 @@ namespace gpdxl
 				(
 				const CDXLNode *pdxln,
 				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent,
 				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
 				);
 
@@ -282,15 +281,11 @@ namespace gpdxl
 			// Set InitPlanVariable in PlannedStmt
 			void SetInitPlanVariables(PlannedStmt *);
 
-			// Returns the id of the plan;
-			INT IPlanId(Plan* pplparent);
-
 			// translate DXL table scan node into a SeqScan node
 			Plan *PtsFromDXLTblScan
 				(
 				const CDXLNode *pdxlnTblScan,
 				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent,
 				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
 				);
 
@@ -299,7 +294,6 @@ namespace gpdxl
 				(
 				const CDXLNode *pdxlnIndexScan,
 				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent,
 				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
 				);
 
@@ -309,7 +303,6 @@ namespace gpdxl
 				const CDXLNode *pdxlnIndexScan,
 				CDXLPhysicalIndexScan *pdxlopIndexScan,
 				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent,
 				BOOL fIndexOnlyScan,
 				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
 				);
@@ -319,7 +312,6 @@ namespace gpdxl
 				(
 				const CDXLNode *pdxlnHJ,
 				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent,
 				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
 				);
 
@@ -328,7 +320,6 @@ namespace gpdxl
 				(
 				const CDXLNode *pdxlnNLJ,
 				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent,
 				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
 				);
 
@@ -337,7 +328,6 @@ namespace gpdxl
 				(
 				const CDXLNode *pdxlnMJ,
 				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent,
 				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
 				);
 
@@ -346,7 +336,6 @@ namespace gpdxl
 				(
 				const CDXLNode *pdxlnMotion,
 				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent,
 				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
 				);
 
@@ -355,7 +344,6 @@ namespace gpdxl
 				(
 				const CDXLNode *pdxlnMotion,
 				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent,
 				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
 				);
 
@@ -365,7 +353,6 @@ namespace gpdxl
 				(
 				const CDXLNode *pdxlnMotion,
 				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent,
 				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
 				);
 
@@ -374,7 +361,6 @@ namespace gpdxl
 				(
 				const CDXLNode *pdxlnMotion,
 				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent,
 				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
 				);
 
@@ -383,7 +369,6 @@ namespace gpdxl
 				(
 				const CDXLNode *pdxlnMotion,
 				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent,
 				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
 				);
 
@@ -401,7 +386,6 @@ namespace gpdxl
 				(
 				const CDXLNode *pdxlnSort,
 				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent,
 				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
 				);
 
@@ -410,7 +394,6 @@ namespace gpdxl
 				(
 				const CDXLNode *pdxln,
 				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent,
 				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
 				);
 
@@ -419,7 +402,6 @@ namespace gpdxl
 				(
 				const CDXLNode *pdxlnLimit,
 				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent,
 				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
 				);
 
@@ -428,7 +410,6 @@ namespace gpdxl
 				(
 				const CDXLNode *pdxlnTVF,
 				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent,
 				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
 				);
 
@@ -436,7 +417,6 @@ namespace gpdxl
 				(
 				const CDXLNode *pdxlnSubqScan,
 				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent,
 				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
 				);
 
@@ -444,7 +424,6 @@ namespace gpdxl
 				(
 				const CDXLNode *pdxlnResult,
 				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent,
 				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
 				);
 
@@ -452,7 +431,6 @@ namespace gpdxl
 				(
 				const CDXLNode *pdxlnAppend,
 				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent,
 				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
 				);
 
@@ -460,7 +438,6 @@ namespace gpdxl
 				(
 				const CDXLNode *pdxlnMaterialize,
 				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent,
 				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
 				);
 
@@ -468,7 +445,6 @@ namespace gpdxl
 				(
 				const CDXLNode *pdxlnSharedScan,
 				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent,
 				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
 				);
 
@@ -477,7 +453,6 @@ namespace gpdxl
 				(
 				const CDXLNode *pdxlnSequence,
 				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent,
 				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
 				);
 
@@ -486,7 +461,6 @@ namespace gpdxl
 				(
 				const CDXLNode *pdxlnDTS,
 				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent,
 				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
 				);	
 			
@@ -495,7 +469,6 @@ namespace gpdxl
 				(
 				const CDXLNode *pdxlnDIS,
 				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent,
 				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
 				);
 			
@@ -504,7 +477,6 @@ namespace gpdxl
 				(
 				const CDXLNode *pdxlnDML,
 				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent,
 				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
 				);
 
@@ -513,7 +485,6 @@ namespace gpdxl
 				(
 				const CDXLNode *pdxlnSplit,
 				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent,
 				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
 				);
 			
@@ -522,7 +493,6 @@ namespace gpdxl
 				(
 				const CDXLNode *pdxlnRowTrigger,
 				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent,
 				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
 				);
 
@@ -531,7 +501,6 @@ namespace gpdxl
 				(
 				const CDXLNode *pdxlnAssert,
 				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent,
 				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
 				);
 
@@ -550,7 +519,6 @@ namespace gpdxl
 				(
 				const CDXLNode *pdxlnCTEProducer,
 				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent,
 				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
 				);
 
@@ -559,7 +527,6 @@ namespace gpdxl
 				(
 				const CDXLNode *pdxlnCTEConsumer,
 				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent,
 				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
 				);
 
@@ -568,7 +535,6 @@ namespace gpdxl
 				(
 				const CDXLNode *pdxlnBitmapScan,
 				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent,
 				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
 				);
 
@@ -577,7 +543,6 @@ namespace gpdxl
 				(
 				const CDXLNode *pdxlnPartitionSelector,
 				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent,
 				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
 				);
 
@@ -586,7 +551,6 @@ namespace gpdxl
 				(
 				const CDXLNode *pdxlnValueScan,
 				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent,
 				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
 				);
 
@@ -596,8 +560,7 @@ namespace gpdxl
 				const CDXLNode *pdxlnFilterList,
 				const CDXLTranslateContextBaseTable *pdxltrctxbt,
 				DrgPdxltrctx *pdrgpdxltrctx,
-				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent
+				CDXLTranslateContext *pdxltrctxOut
 				);
 
 			// create range table entry from a CDXLPhysicalTVF node
@@ -605,8 +568,7 @@ namespace gpdxl
 				(
 				const CDXLNode *pdxlnTVF,
 				CDXLTranslateContext *pdxltrctxOut,
-				CDXLTranslateContextBaseTable *pdxltrctxbt,
-				Plan *pplanParent
+				CDXLTranslateContextBaseTable *pdxltrctxbt
 				);
 
 			// create range table entry from a CDXLPhysicalValueScan node
@@ -614,8 +576,7 @@ namespace gpdxl
 				(
 				const CDXLNode *pdxlnValueScan,
 				CDXLTranslateContext *pdxltrctxOut,
-				CDXLTranslateContextBaseTable *pdxltrctxbt,
-				Plan *pplanParent
+				CDXLTranslateContextBaseTable *pdxltrctxbt
 				);
 
 			// create range table entry from a table descriptor
@@ -633,8 +594,7 @@ namespace gpdxl
 				const CDXLNode *pdxlnPrL,
 				const CDXLTranslateContextBaseTable *pdxltrctxbt,
 				DrgPdxltrctx *pdrgpdxltrctx,
-				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent
+				CDXLTranslateContext *pdxltrctxOut
 				);
 			
 			// insert NULL values for dropped attributes to construct the target list for a DML statement
@@ -654,8 +614,7 @@ namespace gpdxl
 				const CDXLNode *pdxlnFilter,
 				const CDXLTranslateContextBaseTable *pdxltrctxbt,
 				DrgPdxltrctx *pdrgpdxltrctx,
-				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent
+				CDXLTranslateContext *pdxltrctxOut
 				);
 
 
@@ -679,8 +638,7 @@ namespace gpdxl
 				DrgPdxltrctx *pdrgpdxltrctx,
 				List **pplTargetListOut,
 				List **pplQualOut,
-				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent
+				CDXLTranslateContext *pdxltrctxOut
 				);
 
 			// translate the hash expr list of a redistribute motion node
@@ -690,8 +648,7 @@ namespace gpdxl
 				const CDXLTranslateContext *pdxltrctxChild,
 				List **pplHashExprOut,
 				List **pplHashExprTypesOut,
-				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent
+				CDXLTranslateContext *pdxltrctxOut
 				);
 
 			// translate the tree of bitmap index operators that are under a (dynamic) bitmap table scan
@@ -744,8 +701,7 @@ namespace gpdxl
 				const CDXLNode *pdxlnFilter,
 				const CDXLTranslateContextBaseTable *pdxltrctxbt,
 				DrgPdxltrctx *pdrgpdxltrctx,
-				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent
+				CDXLTranslateContext *pdxltrctxOut
 				);
 
 			// parse string value into a Const
@@ -775,7 +731,6 @@ namespace gpdxl
 				CDXLTranslateContext *pdxltrctxOut,
 				CDXLTranslateContextBaseTable *pdxltrctxbt,
 				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings,
-				Plan *pplanParent,
 				List **pplIndexConditions,
 				List **pplIndexOrigConditions,
 				List **pplIndexStratgey,
@@ -788,8 +743,7 @@ namespace gpdxl
 				CDXLNode *pdxlnFilter,
 				CDXLTranslateContext *pdxltrctxOut,
 				CDXLTranslateContextBaseTable *pdxltrctxbt,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings,
-				Plan *pplanParent
+				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
 				);
 			
 			// translate the assert constraints
@@ -797,8 +751,7 @@ namespace gpdxl
 				(
 				CDXLNode *pdxlnFilter,
 				CDXLTranslateContext *pdxltrctxOut,
-				DrgPdxltrctx *pdrgpdxltrctx,
-				Plan *pplanParent
+				DrgPdxltrctx *pdrgpdxltrctx
 				);
 
 			// translate a CTAS operator
@@ -806,7 +759,6 @@ namespace gpdxl
 				(
 				const CDXLNode *pdxlnDML,
 				CDXLTranslateContext *pdxltrctxOut,
-				Plan *pplanParent,
 				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings = NULL // translation contexts of previous siblings
 				);
 			

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -180,9 +180,8 @@ typedef struct Plan
 {
 	NodeTag		type;
 
-	/* Plan node id and parent node id */
-	int 	plan_node_id;
-	int 	plan_parent_node_id;
+	/* Plan node id */
+	int			plan_node_id;	/* unique across entire final plan tree */
 
 	/*
 	 * estimated execution costs for plan (see costsize.c for more info)


### PR DESCRIPTION
This allows removing all the code in CTranslatorDXLToPlStmt that tracked
the parent of each call.

I found the plan node IDs awkward, when I was hacking on
CTranslatorDXLToPlStmt. I tried to make a change where a function would
construct a child Plan node first, and a Result node on top of that, but
only if necessary, depending on the kind of child plan. The parent plan
node IDs made it impossible to construct a part of Plan tree like that, in
a bottom-up fashion, because you always had to pass the parent's ID when
constructing a child node. Now that is possible.