### PR TITLE
Cherry-pick psprintf() function from upstream, and use it.

### DIFF
--- a/src/backend/access/external/fileam.c
+++ b/src/backend/access/external/fileam.c
@@ -508,21 +508,12 @@ external_insert_init(Relation rel)
 
 	if (extentry->command)
 	{
-		/* EXECUTE */
-
-		const char *command = extentry->command;
-		const char *prefix = "execute:";
-		char	   *prefixed_command = NULL;
-
-		/* allocate space for "execute:<cmd>" + 1 for null in sprintf */
-		prefixed_command = (char *) palloc((strlen(prefix) +
-											strlen(command)) *
-										   sizeof(char) + 1);
-
-		/* build the command string - 'execute:command' */
-		sprintf((char *) prefixed_command, "%s%s", prefix, command);
-
-		extInsertDesc->ext_uri = prefixed_command;
+		/*
+		 * EXECUTE
+		 *
+		 * build the command string, 'execute:<command>'
+		 */
+		extInsertDesc->ext_uri = psprintf("execute:%s", extentry->command);
 	}
 	else
 	{
@@ -766,10 +757,7 @@ else \
 	/* set the error message. Use original msg and add column name if availble */ \
 	if (pstate->cur_attname)\
 	{\
-		pstate->cdbsreh->errmsg = (char *) palloc((strlen(edata->message) + \
-												   strlen(pstate->cur_attname) + \
-												   10 + 1) * sizeof(char)); \
-		sprintf(pstate->cdbsreh->errmsg, "%s, column %s", \
+		pstate->cdbsreh->errmsg = psprintf("%s, column %s", \
 				edata->message, \
 				pstate->cur_attname); \
 	}\

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -4546,35 +4546,18 @@ DefineDispatchSavepoint(char *name)
 	/* First we attempt to create on the QEs */
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
-		char	   *cmd = NULL;
-		bool		freecmd;
+		char	   *cmd;
 
-		if (name != NULL)
-		{
-			cmd = palloc(sizeof("SAVEPOINT ") + strlen(name));
-			Assert(cmd != NULL);
-			if (cmd == NULL)
-				elog(ERROR, "Can't define savepoint name too long (%s)", name);
-			sprintf(cmd, "SAVEPOINT %s", name);
-			freecmd = true;
-		}
-		else
-		{
-			cmd = "SAVEPOINT";
-			freecmd = false;
-		}
+		cmd = psprintf("SAVEPOINT %s", name);
 
 		/*
 		 * dispatch a DTX command, in the event of an error, this call
 		 * will either exit via elog()/ereport() or return false
 		 */
 		if (!dispatchDtxCommand(cmd))
-		{
 			elog(ERROR, "Could not create a new savepoint (%s)", cmd);
-		}
 
-		if (freecmd)
-			pfree(cmd);
+		pfree(cmd);
 	}
 
 	DefineSavepoint(name);
@@ -4694,35 +4677,18 @@ ReleaseSavepoint(List *options)
 
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
-		char	   *cmd = NULL;
-		bool		freecmd;
+		char	   *cmd;
 
-		if (name != NULL)
-		{
-			cmd = palloc(sizeof("RELEASE SAVEPOINT ") + strlen(name));
-			Assert(cmd != NULL);
-			if (cmd == NULL)
-				elog(ERROR, "Can't release savepoint name too long (%s)", name);
-			sprintf(cmd, "RELEASE SAVEPOINT %s", name);
-			freecmd = true;
-		}
-		else
-		{
-			cmd = "RELEASE SAVEPOINT";
-			freecmd = false;
-		}
+		cmd = psprintf("RELEASE SAVEPOINT %s", name);
 
 		/*
 		 * dispatch a DTX command, in the event of an error, this call will
 		 * either exit via elog()/ereport() or return false
 		 */
 		if (!dispatchDtxCommand(cmd))
-		{
 			elog(ERROR, "Could not release savepoint (%s)", cmd);
-		}
 
-		if (freecmd)
-			pfree(cmd);
+		pfree(cmd);
 	}
 
 	for (target = s; PointerIsValid(target); target = target->parent)
@@ -4875,34 +4841,20 @@ static void
 DispatchRollbackToSavepoint(char *name)
 {
 	char	   *cmd;
-	bool		freecmd;
 
-	if (name != NULL)
-	{
-		cmd = palloc(sizeof("ROLLBACK TO SAVEPOINT ") + strlen(name));
-		Assert(cmd != NULL);
-		if (cmd == NULL)
-			elog(ERROR, "Can't rollback to savepoint, name too long (%s)", name);
-		sprintf(cmd, "ROLLBACK TO SAVEPOINT %s", name);
-		freecmd = true;
-	}
-	else
-	{
-		cmd = "ROLLBACK TO SAVEPOINT";
-		freecmd = false;
-	}
+	if (!name)
+		elog(ERROR, "could not find savepoint name for ROLLBACK TO SAVEPOINT");
+
+	cmd = psprintf("ROLLBACK TO SAVEPOINT %s", name);
 
 	/*
 	 * dispatch a DTX command, in the event of an error, this call will
 	 * either exit via elog()/ereport() or return false
 	 */
 	if (!dispatchDtxCommand(cmd))
-	{
 		elog(ERROR, "Could not rollback to savepoint (%s)", cmd);
-	}
 
-	if (freecmd)
-		pfree(cmd);
+	pfree(cmd);
 }
 
 /*

--- a/src/backend/commands/tablespace.c
+++ b/src/backend/commands/tablespace.c
@@ -633,9 +633,7 @@ remove_tablespace_directories(Oid tablespaceoid, bool redo, char *phys)
 	/* Now we have removed all of our linkage to the physical
 	 * location; remove the per-segment location that we built at
 	 * CreateTablespace() time */
- 	tempstr = palloc(MAXPGPATH);
-
-	sprintf(tempstr,"%s/seg%d",phys,Gp_segment);
+	tempstr = psprintf("%s/seg%d", phys, Gp_segment);
 
 	if (rmdir(tempstr) < 0)
 		ereport(ERROR,
@@ -1347,9 +1345,7 @@ tblspc_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record)
 						 location)));
 
 		/* Create segment subdirectory. */
-	 	sublocation = palloc(MAXPGPATH);
-
-		sprintf(sublocation,"%s/seg%d",location,Gp_segment);
+		sublocation = psprintf("%s/seg%d", location, Gp_segment);
 
 		if (mkdir(sublocation, 0700) != 0)
 			ereport(ERROR,

--- a/src/backend/utils/fmgr/dfmgr.c
+++ b/src/backend/utils/fmgr/dfmgr.c
@@ -319,12 +319,7 @@ get_magic_product(const Pg_magic_struct *module_magic_data)
 
 		/* Handle Unrecognized product codes */
 		default:
-		{
-			size_t len = sizeof("Product()") + 10 + 1;
-			char *prodname = palloc(len);
-			snprintf(prodname, len, "Product(%d)", module_magic_data->product);
-			return prodname;
-		}
+			return psprintf("Product(%d)", module_magic_data->product);
 	}
 }
 

--- a/src/backend/utils/mmgr/Makefile
+++ b/src/backend/utils/mmgr/Makefile
@@ -14,4 +14,9 @@ include $(top_builddir)/src/Makefile.global
 
 OBJS =  aset.o mcxt.o memaccounting.o mpool.o portalmem.o memprot.o vmem_tracker.o redzone_handler.o runaway_cleaner.o idle_tracker.o event_version.o
 
+# In PostgreSQL, this is under src/common. It has been backported, but because
+# we haven't merged the changes that introduced the src/common directory, it
+# lives here for now.
+OBJS += psprintf.o
+
 include $(top_srcdir)/src/backend/common.mk

--- a/src/backend/utils/mmgr/psprintf.c
+++ b/src/backend/utils/mmgr/psprintf.c
@@ -1,0 +1,190 @@
+/*-------------------------------------------------------------------------
+ *
+ * psprintf.c
+ *		sprintf into an allocated-on-demand buffer
+ *
+ *
+ * Portions Copyright (c) 1996-2017, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ *
+ * IDENTIFICATION
+ *	  src/common/psprintf.c
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef FRONTEND
+
+#include "postgres.h"
+
+#include "utils/memutils.h"
+
+#else
+
+#include "postgres_fe.h"
+
+/* It's possible we could use a different value for this in frontend code */
+#define MaxAllocSize	((Size) 0x3fffffff) /* 1 gigabyte - 1 */
+
+#endif
+
+
+/*
+ * psprintf
+ *
+ * Format text data under the control of fmt (an sprintf-style format string)
+ * and return it in an allocated-on-demand buffer.  The buffer is allocated
+ * with palloc in the backend, or malloc in frontend builds.  Caller is
+ * responsible to free the buffer when no longer needed, if appropriate.
+ *
+ * Errors are not returned to the caller, but are reported via elog(ERROR)
+ * in the backend, or printf-to-stderr-and-exit() in frontend builds.
+ * One should therefore think twice about using this in libpq.
+ */
+char *
+psprintf(const char *fmt,...)
+{
+	size_t		len = 128;		/* initial assumption about buffer size */
+
+	for (;;)
+	{
+		char	   *result;
+		va_list		args;
+		size_t		newlen;
+
+		/*
+		 * Allocate result buffer.  Note that in frontend this maps to malloc
+		 * with exit-on-error.
+		 */
+		result = (char *) palloc(len);
+
+		/* Try to format the data. */
+		va_start(args, fmt);
+		newlen = pvsnprintf(result, len, fmt, args);
+		va_end(args);
+
+		if (newlen < len)
+			return result;		/* success */
+
+		/* Release buffer and loop around to try again with larger len. */
+		pfree(result);
+		len = newlen;
+	}
+}
+
+/*
+ * pvsnprintf
+ *
+ * Attempt to format text data under the control of fmt (an sprintf-style
+ * format string) and insert it into buf (which has length len, len > 0).
+ *
+ * If successful, return the number of bytes emitted, not counting the
+ * trailing zero byte.  This will always be strictly less than len.
+ *
+ * If there's not enough space in buf, return an estimate of the buffer size
+ * needed to succeed (this *must* be more than the given len, else callers
+ * might loop infinitely).
+ *
+ * Other error cases do not return, but exit via elog(ERROR) or exit().
+ * Hence, this shouldn't be used inside libpq.
+ *
+ * This function exists mainly to centralize our workarounds for
+ * non-C99-compliant vsnprintf implementations.  Generally, any call that
+ * pays any attention to the return value should go through here rather
+ * than calling snprintf or vsnprintf directly.
+ *
+ * Note that the semantics of the return value are not exactly C99's.
+ * First, we don't promise that the estimated buffer size is exactly right;
+ * callers must be prepared to loop multiple times to get the right size.
+ * Second, we return the recommended buffer size, not one less than that;
+ * this lets overflow concerns be handled here rather than in the callers.
+ */
+size_t
+pvsnprintf(char *buf, size_t len, const char *fmt, va_list args)
+{
+	int			nprinted;
+
+	Assert(len > 0);
+
+	errno = 0;
+
+	/*
+	 * Assert check here is to catch buggy vsnprintf that overruns the
+	 * specified buffer length.  Solaris 7 in 64-bit mode is an example of a
+	 * platform with such a bug.
+	 */
+#ifdef USE_ASSERT_CHECKING
+	buf[len - 1] = '\0';
+#endif
+
+	nprinted = vsnprintf(buf, len, fmt, args);
+
+	Assert(buf[len - 1] == '\0');
+
+	/*
+	 * If vsnprintf reports an error other than ENOMEM, fail.  The possible
+	 * causes of this are not user-facing errors, so elog should be enough.
+	 */
+	if (nprinted < 0 && errno != 0 && errno != ENOMEM)
+	{
+#ifndef FRONTEND
+		elog(ERROR, "vsnprintf failed: %m");
+#else
+		fprintf(stderr, "vsnprintf failed: %s\n", strerror(errno));
+		exit(EXIT_FAILURE);
+#endif
+	}
+
+	/*
+	 * Note: some versions of vsnprintf return the number of chars actually
+	 * stored, not the total space needed as C99 specifies.  And at least one
+	 * returns -1 on failure.  Be conservative about believing whether the
+	 * print worked.
+	 */
+	if (nprinted >= 0 && (size_t) nprinted < len - 1)
+	{
+		/* Success.  Note nprinted does not include trailing null. */
+		return (size_t) nprinted;
+	}
+
+	if (nprinted >= 0 && (size_t) nprinted > len)
+	{
+		/*
+		 * This appears to be a C99-compliant vsnprintf, so believe its
+		 * estimate of the required space.  (If it's wrong, the logic will
+		 * still work, but we may loop multiple times.)  Note that the space
+		 * needed should be only nprinted+1 bytes, but we'd better allocate
+		 * one more than that so that the test above will succeed next time.
+		 *
+		 * In the corner case where the required space just barely overflows,
+		 * fall through so that we'll error out below (possibly after
+		 * looping).
+		 */
+		if ((size_t) nprinted <= MaxAllocSize - 2)
+			return nprinted + 2;
+	}
+
+	/*
+	 * Buffer overrun, and we don't know how much space is needed.  Estimate
+	 * twice the previous buffer size, but not more than MaxAllocSize; if we
+	 * are already at MaxAllocSize, choke.  Note we use this palloc-oriented
+	 * overflow limit even when in frontend.
+	 */
+	if (len >= MaxAllocSize)
+	{
+#ifndef FRONTEND
+		ereport(ERROR,
+				(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+				 errmsg("out of memory")));
+#else
+		fprintf(stderr, _("out of memory\n"));
+		exit(EXIT_FAILURE);
+#endif
+	}
+
+	if (len >= MaxAllocSize / 2)
+		return MaxAllocSize;
+
+	return len * 2;
+}

--- a/src/include/utils/palloc.h
+++ b/src/include/utils/palloc.h
@@ -155,6 +155,10 @@ extern void MemoryContextStats(MemoryContext context);
 
 extern char *pnstrdup(const char *in, Size len);
 
+/* sprintf into a palloc'd buffer --- these are in psprintf.c */
+extern char *psprintf(const char *fmt,...) __attribute__((format(printf, 1, 2)));
+extern size_t pvsnprintf(char *buf, size_t len, const char *fmt, va_list args)  __attribute__((format(printf, 3, 0)));
+
 #if defined(WIN32) || defined(__CYGWIN__)
 extern void *pgport_palloc(Size sz);
 extern char *pgport_pstrdup(const char *str);


### PR DESCRIPTION
This makes constructing strings a lot simpler, and less scary. I changed
many places in GPDB code to use the new psprintf() function, where it
seemed to make most sense. A lot of code remains that could use it, but
there's no urgency.

I avoided changing upstream code to use it yet, even where it would make
sense, to avoid introducing unnecessary merge conflict.

The biggest changes are In cdbbackup.c, where the code to count the buffer
sizes was most really complex. I also refactored the #ifdef USE_DDBOOST
blocks so that there is less repetition between the USE_DDBOOST and
!USE_DDBOOST blocks, that should make it easier to catch bugs at compilation
time, that affect the !USE_DDBOOST case, when compiling with USE_DDBOOST,
and vice versa. I also switched to using pstrdup instead of strdup() in
a few places, to avoid memory leaks. (Although the way cdbbackup works,
it would only get launched once per connection, so it didn't really matter
in practice.)