### PR TITLE
Increase the default value of default_statistics_target from 10 to 100,

### DIFF
--- a/doc/src/sgml/ref/alter_table.sgml
+++ b/doc/src/sgml/ref/alter_table.sgml
@@ -1,5 +1,5 @@
 <!--
-$PostgreSQL: pgsql/doc/src/sgml/ref/alter_table.sgml,v 1.98 2007/11/28 15:42:31 petere Exp $
+$PostgreSQL: pgsql/doc/src/sgml/ref/alter_table.sgml,v 1.102 2008/12/13 19:13:44 tgl Exp $
 PostgreSQL documentation
 -->
 
@@ -203,7 +203,7 @@ Where column_reference_storage_directive is:
       This form
       sets the per-column statistics-gathering target for subsequent
       <xref linkend="sql-analyze" endterm="sql-analyze-title"> operations.
-      The target can be set in the range 0 to 1000; alternatively, set it
+      The target can be set in the range 0 to 10000; alternatively, set it
       to -1 to revert to using the system default statistics
       target (<xref linkend="guc-default-statistics-target">).
       For more information on the use of statistics by the

--- a/doc/src/sgml/ref/analyze.sgml
+++ b/doc/src/sgml/ref/analyze.sgml
@@ -1,5 +1,5 @@
 <!--
-$PostgreSQL: pgsql/doc/src/sgml/ref/analyze.sgml,v 1.23 2007/10/07 01:16:42 alvherre Exp $
+$PostgreSQL: pgsql/doc/src/sgml/ref/analyze.sgml,v 1.25 2008/12/13 19:13:44 tgl Exp $
 PostgreSQL documentation
 -->
 
@@ -131,10 +131,10 @@ ANALYZE [ VERBOSE ] [ <replaceable class="PARAMETER">table</replaceable> [ ( <re
    will change slightly each time <command>ANALYZE</command> is run,
    even if the actual table contents did not change.  This might result
    in small changes in the planner's estimated costs shown by
-   <xref linkend="sql-explain" endterm="sql-explain-title">. In rare situations, this
-   non-determinism will cause the query optimizer to choose a
-   different query plan between runs of <command>ANALYZE</command>. To
-   avoid this, raise the amount of statistics collected by
+   <xref linkend="sql-explain" endterm="sql-explain-title">.
+   In rare situations, this non-determinism will cause the planner's
+   choices of query plans to change after <command>ANALYZE</command> is run.
+   To avoid this, raise the amount of statistics collected by
    <command>ANALYZE</command>, as described below.
   </para>
 
@@ -147,7 +147,7 @@ ANALYZE [ VERBOSE ] [ <replaceable class="PARAMETER">table</replaceable> [ ( <re
    endterm="sql-altertable-title">).  The target value sets the
    maximum number of entries in the most-common-value list and the
    maximum number of bins in the histogram.  The default target value
-   is 10, but this can be adjusted up or down to trade off accuracy of
+   is 100, but this can be adjusted up or down to trade off accuracy of
    planner estimates against the time taken for
    <command>ANALYZE</command> and the amount of space occupied in
    <literal>pg_statistic</literal>.  In particular, setting the

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -8,7 +8,7 @@
  *
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/commands/analyze.c,v 1.114.2.4 2009/12/09 21:58:16 tgl Exp $
+ *	  $PostgreSQL: pgsql/src/backend/commands/analyze.c,v 1.129 2008/12/13 19:13:44 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -94,7 +94,7 @@ typedef struct RowIndexes
 } RowIndexes;
 
 /* Default statistics target (GUC parameter) */
-int			default_statistics_target = 10;
+int			default_statistics_target = 100;
 
 /* A few variables that don't seem worth passing around as parameters */
 static int	elevel = -1;
@@ -2094,10 +2094,10 @@ std_typanalyze(VacAttrStats *stats)
 		 * error in bin size f, and error probability gamma, the minimum
 		 * random sample size is
 		 *		r = 4 * k * ln(2*n/gamma) / f^2
-		 * Taking f = 0.5, gamma = 0.01, n = 1 million rows, we obtain
+		 * Taking f = 0.5, gamma = 0.01, n = 10^6 rows, we obtain
 		 *		r = 305.82 * k
 		 * Note that because of the log function, the dependence on n is
-		 * quite weak; even at n = 1 billion, a 300*k sample gives <= 0.59
+		 * quite weak; even at n = 10^12, a 300*k sample gives <= 0.66
 		 * bin size error with probability 0.99.  So there's no real need to
 		 * scale for n, which is a good thing because we don't necessarily
 		 * know it at this point.

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -9,7 +9,7 @@
  *
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/commands/tablecmds.c,v 1.215 2007/02/16 22:04:02 tgl Exp $
+ *	  $PostgreSQL: pgsql/src/backend/commands/tablecmds.c,v 1.273 2008/12/13 19:13:44 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -6469,9 +6469,9 @@ ATExecSetStatistics(Relation rel, const char *colName, Node *newValue)
 				 errmsg("statistics target %d is too low",
 						newtarget)));
 	}
-	else if (newtarget > 1000)
+	else if (newtarget > 10000)
 	{
-		newtarget = 1000;
+		newtarget = 10000;
 		ereport(WARNING,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("lowering statistics target to %d",
@@ -10464,7 +10464,6 @@ inherit_parent(Relation parent_rel, Relation child_rel, bool is_partition, List 
 	while (HeapTupleIsValid(inheritsTuple = systable_getnext(scan)))
 	{
 		Form_pg_inherits inh = (Form_pg_inherits) GETSTRUCT(inheritsTuple);
-
 		if (inh->inhparent == RelationGetRelid(parent_rel))
 			ereport(ERROR,
 					(errcode(ERRCODE_DUPLICATE_TABLE),

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -1229,7 +1229,7 @@ static struct config_int ConfigureNamesInt[] =
 				"column-specific target set via ALTER TABLE SET STATISTICS.")
 		},
 		&default_statistics_target,
-		25, 1, 1000, NULL, NULL
+		100, 1, 10000, NULL, NULL
 	},
 	{
 		{"from_collapse_limit", PGC_USERSET, QUERY_TUNING_OTHER,

--- a/src/backend/utils/misc/postgresql.conf.sample
+++ b/src/backend/utils/misc/postgresql.conf.sample
@@ -363,7 +363,7 @@ optimizer_analyze_root_partition = on # stats collection on root partitions
 
 # - ANALYZE Statistics on Database Contents -
 
-#default_statistics_target = 25		# range 1 - 1000 (target # of
+#default_statistics_target = 100	# range 1 - 10000 (target # of
 					# histogram bins)
 #gp_analyze_relative_error = 0.25	# range 0.0 - 1.0 (target relative
 					# error fraction)

--- a/src/test/regress/expected/alter_table_aocs.out
+++ b/src/test/regress/expected/alter_table_aocs.out
@@ -513,20 +513,20 @@ select a, f_renamed from addcol1 where a = 999;
 (1 row)
 
 -- try altering statistics of a column
-alter table addcol1 alter column f_renamed set statistics 1000;
+alter table addcol1 alter column f_renamed set statistics 10000;
 select attstattarget from pg_attribute where attrelid = 'aocs_addcol.addcol1'::regclass and attname = 'f_renamed';
  attstattarget
 ---------------
-          1000
+          10000
 (1 row)
 
 set client_min_messages to error;
-alter table addcol1 alter column f_renamed set statistics 1001; -- should limit to 1000 and give warning
+alter table addcol1 alter column f_renamed set statistics 10001; -- should limit to 10000 and give warning
 set client_min_messages to notice;
 select attstattarget from pg_attribute where attrelid = 'aocs_addcol.addcol1'::regclass and attname = 'f_renamed';
  attstattarget
 ---------------
-          1000
+          10000
 (1 row)
 
 -- test alter distribution policy

--- a/src/test/regress/expected/bfv_statistic.out
+++ b/src/test/regress/expected/bfv_statistic.out
@@ -282,8 +282,8 @@ INSERT INTO foo_numeric SELECT i,i FROM generate_series(1,30) i;
 ANALYZE foo_numeric;
 select histogram_bounds from pg_stats where tablename = 'foo_numeric' and attname = 'b';
                             histogram_bounds                             
--------------------------------------------------------------------------
- {1,2,3,4,5,6,7,9,10,11,12,13,14,16,17,18,19,20,21,23,24,25,26,27,28,30}
+------------------------------------------------------------------------------------
+ {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30}
 (1 row)
 
 select most_common_vals from pg_stats where tablename = 'foo_numeric' and attname = 'b';

--- a/src/test/regress/expected/bfv_statistic_optimizer.out
+++ b/src/test/regress/expected/bfv_statistic_optimizer.out
@@ -282,8 +282,8 @@ INSERT INTO foo_numeric SELECT i,i FROM generate_series(1,30) i;
 ANALYZE foo_numeric;
 select histogram_bounds from pg_stats where tablename = 'foo_numeric' and attname = 'b';
                             histogram_bounds                             
--------------------------------------------------------------------------
- {1,2,3,4,5,6,7,9,10,11,12,13,14,16,17,18,19,20,21,23,24,25,26,27,28,30}
+------------------------------------------------------------------------------------
+ {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30}
 (1 row)
 
 select most_common_vals from pg_stats where tablename = 'foo_numeric' and attname = 'b';

--- a/src/test/regress/sql/alter_table_aocs.sql
+++ b/src/test/regress/sql/alter_table_aocs.sql
@@ -298,10 +298,10 @@ alter table addcol1 add column f_renamed int default 20;
 select a, f_renamed from addcol1 where a = 999;
 
 -- try altering statistics of a column
-alter table addcol1 alter column f_renamed set statistics 1000;
+alter table addcol1 alter column f_renamed set statistics 10000;
 select attstattarget from pg_attribute where attrelid = 'aocs_addcol.addcol1'::regclass and attname = 'f_renamed';
 set client_min_messages to error;
-alter table addcol1 alter column f_renamed set statistics 1001; -- should limit to 1000 and give warning
+alter table addcol1 alter column f_renamed set statistics 10001; -- should limit to 10000 and give warning
 set client_min_messages to notice;
 select attstattarget from pg_attribute where attrelid = 'aocs_addcol.addcol1'::regclass and attname = 'f_renamed';
 


### PR DESCRIPTION
and its maximum value from 1000 to 10000.  ALTER TABLE SET STATISTICS
similarly now allows a value up to 10000.  Per discussion.

Cherry-pick from 65e3ea76417d1baab158fd8305ebed4f43141c7a