### PR TITLE
Resgroup lazy alter memory

### DIFF
--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -89,7 +89,6 @@ static ResourceGroupCallbackItem ResourceGroup_callbacks_head =
 static ResourceGroupCallbackItem *ResourceGroup_callbacks = &ResourceGroup_callbacks_head;
 
 static int str2Int(const char *str, const char *prop);
-static int text2Int(const text *text, const char *prop);
 static ResGroupLimitType getResgroupOptionType(const char* defname);
 static const char * getResgroupOptionName(ResGroupLimitType type);
 static void parseStmtOptions(CreateResourceGroupStmt *stmt, ResGroupOpts *options);
@@ -274,17 +273,17 @@ CreateResourceGroup(CreateResourceGroupStmt *stmt)
 	{
 		Oid			*callbackArg;
 
-		AllocResGroupEntry(groupid);
+		AllocResGroupEntry(groupid, &options);
 
-		/* Create os dependent part for this resource group */
-
-		ResGroupOps_CreateGroup(groupid);
-		ResGroupOps_SetCpuRateLimit(groupid, options.cpuRateLimit);
 
 		/* Argument of callback function should be allocated in heap region */
 		callbackArg = (Oid *)MemoryContextAlloc(TopMemoryContext, sizeof(Oid));
 		*callbackArg = groupid;
 		registerResourceGroupCallback(createResGroupAbortCallback, (void *)callbackArg);
+
+		/* Create os dependent part for this resource group */
+		ResGroupOps_CreateGroup(groupid);
+		ResGroupOps_SetCpuRateLimit(groupid, options.cpuRateLimit);
 	}
 	else if (Gp_role == GP_ROLE_DISPATCH)
 		ereport(WARNING,
@@ -553,11 +552,7 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 	GetResGroupCapabilities(groupid, &caps);
 
 	/* Pick up the effective settings from caps */
-	opts.concurrency = caps.concurrency.proposed;
-	opts.cpuRateLimit = caps.cpuRateLimit.proposed;
-	opts.memLimit = caps.memLimit.proposed;
-	opts.memSharedQuota = caps.memSharedQuota.proposed;
-	opts.memSpillRatio = caps.memSpillRatio.proposed;
+	ResGroupCapsToOpts(&caps, &opts);
 
 	/* Attempt to pick previous 'proposed' as 'value' */
 	ResGroupDecideConcurrencyCaps(groupid, &caps, &opts);
@@ -572,7 +567,7 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 
 		case RESGROUP_LIMIT_TYPE_CPU:
 			opts.cpuRateLimit = cpuRateLimitNew;
-			if (caps.cpuRateLimit.value < cpuRateLimitNew)
+			if (caps.cpuRateLimit.proposed < cpuRateLimitNew)
 				validateCapabilities(pg_resgroupcapability_rel,
 									 groupid, &opts, false);
 
@@ -594,7 +589,7 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 
 		case RESGROUP_LIMIT_TYPE_MEMORY:
 			opts.memLimit = memLimitNew;
-			if (caps.memLimit.value < memLimitNew)
+			if (caps.memLimit.proposed < memLimitNew)
 				validateCapabilities(pg_resgroupcapability_rel,
 									 groupid, &opts, false);
 
@@ -972,6 +967,7 @@ parseStmtOptions(CreateResourceGroupStmt *stmt, ResGroupOpts *options)
 static void
 createResGroupAbortCallback(bool isCommit, void *arg)
 {
+	volatile int savedInterruptHoldoffCount;
 	Oid groupId;
 
 	if (!isCommit)
@@ -982,10 +978,21 @@ createResGroupAbortCallback(bool isCommit, void *arg)
 		 * FreeResGroupEntry would acquire LWLock, since this callback is called
 		 * after LWLockReleaseAll in AbortTransaction, it is safe here
 		 */
+		/* FIXME: don't attempt to lock/unlock */
 		FreeResGroupEntry(groupId);
 
 		/* remove the os dependent part for this resource group */
-		ResGroupOps_DestroyGroup(groupId);
+		PG_TRY();
+		{
+			savedInterruptHoldoffCount = InterruptHoldoffCount;
+			ResGroupOps_DestroyGroup(groupId);
+		}
+		PG_CATCH();
+		{
+			InterruptHoldoffCount = savedInterruptHoldoffCount;
+			elog(LOG, "Fail to remove cgroup dir for resource group %d", groupId);
+		}
+		PG_END_TRY();
 	}
 
 	pfree(arg);
@@ -1000,6 +1007,7 @@ createResGroupAbortCallback(bool isCommit, void *arg)
 static void
 dropResGroupAbortCallback(bool isCommit, void *arg)
 {
+	volatile int savedInterruptHoldoffCount;
 	Oid groupId;
 
 	groupId = *(Oid *)arg;
@@ -1008,7 +1016,17 @@ dropResGroupAbortCallback(bool isCommit, void *arg)
 	if (isCommit)
 	{
 		/* remove the os dependent part for this resource group */
-		ResGroupOps_DestroyGroup(groupId);
+		PG_TRY();
+		{
+			savedInterruptHoldoffCount = InterruptHoldoffCount;
+			ResGroupOps_DestroyGroup(groupId);
+		}
+		PG_CATCH();
+		{
+			InterruptHoldoffCount = savedInterruptHoldoffCount;
+			elog(LOG, "Fail to remove cgroup dir for resource group %d", groupId);
+		}
+		PG_END_TRY();
 	}
 
 	pfree(arg);
@@ -1024,55 +1042,11 @@ dropResGroupAbortCallback(bool isCommit, void *arg)
 static void
 alterResGroupCommitCallback(bool isCommit, void *arg)
 {
-	volatile int savedInterruptHoldoffCount;
 	ResourceGroupAlterCallbackContext *ctx =
 		(ResourceGroupAlterCallbackContext *) arg;
 
-	if (!isCommit)
-	{
-		pfree(arg);
-		return;
-	}
-
-	switch (ctx->limittype)
-	{
-		case RESGROUP_LIMIT_TYPE_CONCURRENCY:
-		case RESGROUP_LIMIT_TYPE_MEMORY_SHARED_QUOTA:
-		case RESGROUP_LIMIT_TYPE_MEMORY:
-			/* wake up */
-			ResGroupAlterCheckForWakeup(ctx->groupid);
-			break;
-
-		case RESGROUP_LIMIT_TYPE_CPU:
-			/*
-			 * Apply the cpu rate limit to cgroup.
-			 *
-			 * This operation can fail in some cases, e.g.:
-			 * 1. BEGIN;
-			 * 2. CREATE RESOURCE GROUP g1 ...;
-			 * 3. ALTER RESOURCE GROUP g1 SET CPU_RATE_LIMIT ...;
-			 * 4. DROP RESOURCE GROUP g1;
-			 * 5. COMMIT; -- or ABORT;
-			 *
-			 * So the error needs to be catched here.
-			 */
-			PG_TRY();
-			{
-				savedInterruptHoldoffCount = InterruptHoldoffCount;
-				ResGroupOps_SetCpuRateLimit(ctx->groupid,
-											ctx->caps.cpuRateLimit.value);
-			}
-			PG_CATCH();
-			{
-				InterruptHoldoffCount = savedInterruptHoldoffCount;
-				elog(LOG, "Fail to set cpu_rate_limit for resource group %d", ctx->groupid);
-			}
-			PG_END_TRY();
-			break;
-
-		default:
-			break;
-	}
+	if (isCommit)
+		ResGroupAlterOnCommit(ctx->groupid, ctx->limittype, &ctx->caps);
 
 	pfree(arg);
 }
@@ -1233,10 +1207,20 @@ validateCapabilities(Relation rel,
 
 	while (HeapTupleIsValid(tuple = systable_getnext(sscan)))
 	{
-		Form_pg_resgroupcapability resgCapability =
-						(Form_pg_resgroupcapability)GETSTRUCT(tuple);
+		Datum				groupIdDatum;
+		Datum				typeDatum;
+		Datum				proposedDatum;
+		ResGroupLimitType	reslimittype;
+		Oid					resgroupid;
+		char				*proposedStr;
+		int					proposed;
+		bool				isNull;
 
-		if (resgCapability->resgroupid == groupid)
+		groupIdDatum = heap_getattr(tuple, Anum_pg_resgroupcapability_resgroupid,
+									rel->rd_att, &isNull);
+		resgroupid = DatumGetObjectId(groupIdDatum);
+
+		if (resgroupid == groupid)
 		{
 			if (!newGroup)
 				continue;
@@ -1246,18 +1230,27 @@ validateCapabilities(Relation rel,
 					errmsg("Find duplicate resoure group id:%d", groupid)));
 		}
 
-		if (resgCapability->reslimittype == RESGROUP_LIMIT_TYPE_CPU)
+		typeDatum = heap_getattr(tuple, Anum_pg_resgroupcapability_reslimittype,
+								 rel->rd_att, &isNull);
+		reslimittype = (ResGroupLimitType) DatumGetInt16(typeDatum);
+
+		proposedDatum = heap_getattr(tuple, Anum_pg_resgroupcapability_proposed,
+									 rel->rd_att, &isNull);
+		proposedStr = DatumGetCString(DirectFunctionCall1(textout, proposedDatum));
+		proposed = str2Int(proposedStr, getResgroupOptionName(reslimittype));
+
+		if (reslimittype == RESGROUP_LIMIT_TYPE_CPU)
 		{
-			totalCpu += text2Int(&resgCapability->value, "cpu_rate_limit");
+			totalCpu += proposed;
 			if (totalCpu > RESGROUP_MAX_CPU_RATE_LIMIT)
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 						errmsg("total cpu_rate_limit exceeded the limit of %d",
 							   RESGROUP_MAX_CPU_RATE_LIMIT)));
 		}
-		else if (resgCapability->reslimittype == RESGROUP_LIMIT_TYPE_MEMORY)
+		else if (reslimittype == RESGROUP_LIMIT_TYPE_MEMORY)
 		{
-			totalMem += text2Int(&resgCapability->value, "memory_limit");
+			totalMem += proposed;
 			if (totalMem > RESGROUP_MAX_MEMORY_LIMIT)
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
@@ -1433,17 +1426,3 @@ str2Int(const char *str, const char *prop)
 	return floor(val);
 }
 
-/*
- * Convert a text to a integer value.
- *
- * @param text  the text
- * @param prop  the property name
- */
-static int
-text2Int(const text *text, const char *prop)
-{
-	char *str = DatumGetCString(DirectFunctionCall1(textout,
-								 PointerGetDatum(text)));
-
-	return str2Int(str, prop);
-}

--- a/src/backend/executor/nodeWindow.c
+++ b/src/backend/executor/nodeWindow.c
@@ -467,10 +467,10 @@ typedef WindowFrameBufferData *WindowFrameBuffer;
 
 static WindowFrameBuffer createRangeFrameBuffer(Datum trail_range,
 					   Datum lead_range,
-					   int bytes);
+					   int64 bytes);
 static WindowFrameBuffer createRowsFrameBuffer(long int trail_rows,
 					  long int lead_rows,
-					  int bytes);
+					  int64 bytes);
 static WindowFrameBuffer resetFrameBuffer(WindowFrameBuffer buffer);
 static void appendToFrameBuffer(WindowStatePerLevel level_state,
 					WindowState * wstate,
@@ -593,7 +593,7 @@ static void setEmptyFrame(WindowStatePerLevel level_state,
  * Create the tuplestore and all accessors.
  */
 static void
-initFrameBuffer(WindowFrameBuffer buffer, int bytes)
+initFrameBuffer(WindowFrameBuffer buffer, int64 bytes)
 {
 	buffer->tuplestore = ntuplestore_create(bytes);
 
@@ -613,7 +613,7 @@ initFrameBuffer(WindowFrameBuffer buffer, int bytes)
  * createRangeFrameBuffer -- create a new WindowFrameBuffer of the RANGE type.
  */
 static WindowFrameBuffer
-createRangeFrameBuffer(Datum trail_range, Datum lead_range, int bytes)
+createRangeFrameBuffer(Datum trail_range, Datum lead_range, int64 bytes)
 {
 	WindowFrameBuffer buffer =
 	(WindowFrameBuffer) palloc0(sizeof(WindowFrameBufferData));
@@ -631,7 +631,7 @@ createRangeFrameBuffer(Datum trail_range, Datum lead_range, int bytes)
  * createRowsFrameBuffer -- create a new WindowFrameBuffer of the ROWS type.
  */
 static WindowFrameBuffer
-createRowsFrameBuffer(long int trail_rows, long int lead_rows, int bytes)
+createRowsFrameBuffer(long int trail_rows, long int lead_rows, int64 bytes)
 {
 	WindowFrameBuffer buffer =
 	(WindowFrameBuffer) palloc0(sizeof(WindowFrameBufferData));
@@ -653,7 +653,7 @@ static void
 createFrameBuffers(WindowState * wstate)
 {
 	int			level;
-	int			bytes;
+	int64		bytes;
 
 	if (wstate->numlevels <= 0)
 		return;

--- a/src/backend/utils/sort/tuplestorenew.c
+++ b/src/backend/utils/sort/tuplestorenew.c
@@ -641,7 +641,7 @@ ntuplestore_destroy(NTupleStore *ts)
 }
 
 NTupleStore *
-ntuplestore_create(int maxBytes)
+ntuplestore_create(int64 maxBytes)
 {
 	NTupleStore *store = (NTupleStore *) palloc(sizeof(NTupleStore));
 	store->mcxt = CurrentMemoryContext;
@@ -690,7 +690,7 @@ ntuplestore_create(int maxBytes)
  *   filename does not include the pgsql_tmp/ prefix
  */
 NTupleStore *
-ntuplestore_create_readerwriter(const char *filename, int maxBytes, bool isWriter)
+ntuplestore_create_readerwriter(const char *filename, int64 maxBytes, bool isWriter)
 {
 	NTupleStore* store = NULL;
 	char filenameprefix[MAXPGPATH];
@@ -783,7 +783,7 @@ ntuplestore_init_reader(NTupleStore *store, int maxBytes)
  * The workSet needs to be initialized by the caller.
  */
 NTupleStore *
-ntuplestore_create_workset(workfile_set *workSet, int maxBytes)
+ntuplestore_create_workset(workfile_set *workSet, int64 maxBytes)
 {
 
 	elog(gp_workfile_caching_loglevel, "Creating tuplestore with workset in directory %s", workSet->path);

--- a/src/include/utils/resscheduler.h
+++ b/src/include/utils/resscheduler.h
@@ -25,6 +25,7 @@
 /*
  * GUC variables.
  */
+extern ResManagerMemoryPolicy   gp_resgroup_memory_policy;
 extern ResManagerMemoryPolicy   gp_resqueue_memory_policy;
 extern char                		*gp_resqueue_memory_policy_str;
 extern bool						gp_log_resqueue_memory;

--- a/src/include/utils/tuplestorenew.h
+++ b/src/include/utils/tuplestorenew.h
@@ -25,9 +25,9 @@ typedef struct NTupleStore NTupleStore;
 void ntuplestore_setinstrument(NTupleStore* ts, struct Instrumentation *ins);
 
 /* Tuple store method */
-extern NTupleStore *ntuplestore_create(int maxBytes);
-extern NTupleStore *ntuplestore_create_readerwriter(const char* filename, int maxBytes, bool isWriter);
-extern NTupleStore *ntuplestore_create_workset(workfile_set *workSet, int maxBytes);
+extern NTupleStore *ntuplestore_create(int64 maxBytes);
+extern NTupleStore *ntuplestore_create_readerwriter(const char* filename, int64 maxBytes, bool isWriter);
+extern NTupleStore *ntuplestore_create_workset(workfile_set *workSet, int64 maxBytes);
 extern bool ntuplestore_is_readerwriter_reader(NTupleStore* nts);
 extern void ntuplestore_reset(NTupleStore *ts);
 extern void ntuplestore_flush(NTupleStore *ts);

--- a/src/test/isolation2/input/resgroup/resgroup_alter_memory.source
+++ b/src/test/isolation2/input/resgroup/resgroup_alter_memory.source
@@ -1,6 +1,8 @@
 -- start_ignore
 DROP ROLE IF EXISTS role1_memory_test;
+DROP ROLE IF EXISTS role2_memory_test;
 DROP RESOURCE GROUP rg1_memory_test;
+DROP RESOURCE GROUP rg2_memory_test;
 -- end_ignore
 
 CREATE OR REPLACE FUNCTION resGroupPalloc(float) RETURNS int AS
@@ -11,14 +13,22 @@ CREATE OR REPLACE FUNCTION hold_memory_by_percent(int, float) RETURNS int AS $$
     SELECT * FROM resGroupPalloc($2)
 $$ LANGUAGE sql;
 
+CREATE OR REPLACE VIEW rg_activity_status AS
+	SELECT rsgname, waiting_reason, current_query
+	FROM pg_stat_activity
+	WHERE rsgname='rg1_memory_test' OR rsgname='rg2_memory_test'
+	ORDER BY sess_id;
+
 CREATE OR REPLACE VIEW rg_mem_status AS
 	SELECT groupname, memory_limit, proposed_memory_limit,
 		   memory_shared_quota, proposed_memory_shared_quota
-	FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg1_memory_test';
+	FROM gp_toolkit.gp_resgroup_config
+	WHERE groupname='rg1_memory_test' OR groupname='rg2_memory_test'
+	ORDER BY groupid;
 
 CREATE RESOURCE GROUP rg1_memory_test
     WITH (concurrency=2, cpu_rate_limit=10,
-          memory_limit=50, memory_shared_quota=0, memory_spill_ratio=20);
+          memory_limit=60, memory_shared_quota=0, memory_spill_ratio=5);
 CREATE ROLE role1_memory_test RESOURCE GROUP rg1_memory_test;
 
 --
@@ -63,6 +73,55 @@ SELECT * FROM rg_mem_status;
 1q:
 
 --
+-- 1.3) alter memory shared quota up and down
+--
+
+ALTER RESOURCE GROUP rg1_memory_test SET CONCURRENCY 2;
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 40;
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_SHARED_QUOTA 60;
+
+SELECT * FROM rg_mem_status;
+
+1: SET ROLE TO role1_memory_test;
+1: BEGIN;
+-- proc1 has a quota of 40%*40%/2=8%
+-- rg1 still have 8% free quota
+
+ALTER RESOURCE GROUP rg1_memory_test SET CONCURRENCY 4;
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_SHARED_QUOTA 70;
+-- rg1 should free some quota, 40%*40%/2*1-40%*30%/4*3=8%-9%=-1%
+-- rg1 now have 40%*20%=8% free quota
+-- each slot in rg1 requires 40%*30%/4=3%
+
+2: SET ROLE TO role1_memory_test;
+2: BEGIN;
+3: SET ROLE TO role1_memory_test;
+3: BEGIN;
+-- proc2&proc3 each requires a quota of 40%*30%/4=3%
+-- rg1 now has 8%-3%*2=2% free quota
+
+4: SET ROLE TO role1_memory_test;
+4&: BEGIN;
+-- proc4 shall be pending
+
+SELECT * FROM rg_mem_status;
+SELECT * FROM rg_activity_status;
+
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_SHARED_QUOTA 40;
+-- rg1 now have 40%*60%-8%-3%*2=10% free quota again
+-- and now proc4 requires a quota of 40%*60%/4=6%,
+-- so it shall be waken up
+
+4<:
+SELECT * FROM rg_mem_status;
+SELECT * FROM rg_activity_status;
+
+1q:
+2q:
+3q:
+4q:
+
+--
 -- 2.1) alter memory limit with low memory usage (and low memory shared usage)
 --
 
@@ -82,7 +141,8 @@ SELECT * FROM rg_mem_status;
 ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 60;
 
 -- now the group has 60%*40%-10%=14% free quota and 60%*60%=36% free shared quota,
--- so memory_limit shall be the new value.
+-- so memory_limit can be the new value, however at the moment we don't update
+-- value when increasing memory_limit, so it's still the old value.
 SELECT * FROM rg_mem_status;
 
 ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 40;
@@ -102,7 +162,7 @@ ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 10;
 SELECT * FROM rg_mem_status;
 
 --
--- 8.3) alter memory limit with high memory usage and high memory shared usage
+-- 2.3) alter memory limit with high memory usage and high memory shared usage
 --
 
 ALTER RESOURCE GROUP rg1_memory_test SET CONCURRENCY 2;
@@ -131,7 +191,302 @@ SELECT * FROM rg_mem_status;
 
 1q:
 
+--
+-- 3.1) decrease one group and increase another, no load
+--
+
+ALTER RESOURCE GROUP rg1_memory_test SET CONCURRENCY 3;
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 30;
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_SHARED_QUOTA 0;
+
+CREATE RESOURCE GROUP rg2_memory_test
+    WITH (concurrency=3, cpu_rate_limit=10,
+          memory_limit=30, memory_shared_quota=0, memory_spill_ratio=5);
+CREATE ROLE role2_memory_test RESOURCE GROUP rg2_memory_test;
+
+-- default_group and admin_group consumed 40% memory_limit,
+-- so with rg1+rg2=60% all memory_limit is already allocated,
+-- so increasing any of them shall fail.
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 31;
+
+SELECT * FROM rg_mem_status;
+
+-- but increase could succeed if another rg is first decreased.
+ALTER RESOURCE GROUP rg2_memory_test SET MEMORY_LIMIT 20;
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 40;
+
+SELECT * FROM rg_mem_status;
+
+--
+-- 3.2) decrease one group and increase another, with load, no pending
+--
+
+ALTER RESOURCE GROUP rg1_memory_test SET CONCURRENCY 3;
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 30;
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_SHARED_QUOTA 0;
+
+ALTER RESOURCE GROUP rg2_memory_test SET CONCURRENCY 2;
+ALTER RESOURCE GROUP rg2_memory_test SET MEMORY_LIMIT 30;
+ALTER RESOURCE GROUP rg2_memory_test SET MEMORY_SHARED_QUOTA 0;
+
+SELECT * FROM rg_mem_status;
+
+11: SET ROLE TO role1_memory_test;
+11: BEGIN;
+-- proc11 gets a quota of 30%/3=10% from rg1
+
+12: SET ROLE TO role1_memory_test;
+12: BEGIN;
+-- proc12 gets a quota of 30%/3=10% from rg1
+
+13: SET ROLE TO role1_memory_test;
+13: BEGIN;
+-- proc13 gets a quota of 30%/3=10% from rg1
+
+-- although all the memory quota is in use,
+-- it's still allowed to decrease memory_limit,
+-- in such a case rg2 won't get the new quota until any query in rg1 ends.
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 15;
+ALTER RESOURCE GROUP rg2_memory_test SET MEMORY_LIMIT 40;
+-- now both rg1 and rg2 still have 30% quota
+
+21: SET ROLE TO role2_memory_test;
+21: BEGIN;
+-- proc21 gets a quota of 40%/2=20% from rg2
+
+SELECT * FROM rg_mem_status;
+SELECT * FROM rg_activity_status;
+
+11q:
+-- proc11 ends, 10%-5%=5% quota is returned to sys
+
+12q:
+-- proc12 ends, 10%-5%=5% quota is returned to sys
+
+SELECT * FROM rg_mem_status;
+SELECT * FROM rg_activity_status;
+
+-- now rg2 shall be able to get 10% free quota from sys
+22: SET ROLE TO role2_memory_test;
+22: BEGIN;
+-- proc22 gets a quota of 40%/2=20% from rg2
+
+SELECT * FROM rg_mem_status;
+SELECT * FROM rg_activity_status;
+
+13q:
+21q:
+22q:
+
+--
+-- 3.3) decrease one group and increase another, with load, with pending,
+--      memory_shared_quota is 0,
+--      waken up by released quota memory from other group
+--
+
+ALTER RESOURCE GROUP rg2_memory_test SET CONCURRENCY 2;
+ALTER RESOURCE GROUP rg2_memory_test SET MEMORY_LIMIT 30;
+ALTER RESOURCE GROUP rg2_memory_test SET MEMORY_SHARED_QUOTA 0;
+
+ALTER RESOURCE GROUP rg1_memory_test SET CONCURRENCY 3;
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 30;
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_SHARED_QUOTA 0;
+
+SELECT * FROM rg_mem_status;
+
+11: SET ROLE TO role1_memory_test;
+11: BEGIN;
+-- proc11 gets a quota of 30%/3=10% from rg1
+
+12: SET ROLE TO role1_memory_test;
+12: BEGIN;
+-- proc12 gets a quota of 30%/3=10% from rg1
+
+13: SET ROLE TO role1_memory_test;
+13: BEGIN;
+-- proc13 gets a quota of 30%/3=10% from rg1
+
+-- although all the memory quota is in use,
+-- it's still allowed to decrease memory_limit,
+-- in such a case rg2 won't get the new quota until any query in rg1 ends.
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 15;
+ALTER RESOURCE GROUP rg2_memory_test SET MEMORY_LIMIT 40;
+-- now both rg1 and rg2 still have 30% quota
+
+21: SET ROLE TO role2_memory_test;
+21: BEGIN;
+
+22: SET ROLE TO role2_memory_test;
+22&: BEGIN;
+
+-- proc21 gets a quota of 40%/2=20% from rg2
+-- proc22 requires a quota of 40%/2=20% from rg2,
+-- but as rg2 only has 30%-20%=10% free quota now,
+-- it shall be pending.
+SELECT * FROM rg_mem_status;
+SELECT * FROM rg_activity_status;
+
+11: END;
+11q:
+-- proc11 ends, 10%-5%=5% quota is returned to sys
+
+SELECT * FROM rg_mem_status;
+SELECT * FROM rg_activity_status;
+
+12: END;
+12q:
+-- proc12 ends, 10%-5%=5% quota is returned to sys
+
+-- now rg2 can get 10% free quota from sys
+-- so proc22 can get enough quota and get executed
+22<:
+SELECT * FROM rg_mem_status;
+SELECT * FROM rg_activity_status;
+
+13q:
+21q:
+22q:
+
+--
+-- 3.4) decrease one group and increase another, with load, with pending,
+--      memory_shared_quota > 0 and can be freed,
+--      waken up by released shared quota memory from other group
+--
+
+ALTER RESOURCE GROUP rg2_memory_test SET CONCURRENCY 2;
+ALTER RESOURCE GROUP rg2_memory_test SET MEMORY_LIMIT 30;
+ALTER RESOURCE GROUP rg2_memory_test SET MEMORY_SHARED_QUOTA 0;
+
+ALTER RESOURCE GROUP rg1_memory_test SET CONCURRENCY 1;
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 30;
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_SHARED_QUOTA 60;
+
+SELECT * FROM rg_mem_status;
+
+11: SET ROLE TO role1_memory_test;
+11: BEGIN;
+-- proc11 gets a quota of 30%*40%=12% from rg1
+-- rg1 also has a shared quota of 30%*60%=18%
+
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 20;
+-- now each slot in rg1 requires a quota of 20%*40%=8%
+-- rg1 has 0% free quota and 20%*60%=12% free shared quota
+-- rg1 should release some shared quota, 30%*60%-20%*60%=6%
+
+ALTER RESOURCE GROUP rg2_memory_test SET CONCURRENCY 4;
+ALTER RESOURCE GROUP rg2_memory_test SET MEMORY_LIMIT 40;
+-- now rg2 has a quota of 30%+6%=36%
+-- now each slot in rg2 requires a quota of 40%/4=10%
+
+21: SET ROLE TO role2_memory_test;
+21: BEGIN;
+22: SET ROLE TO role2_memory_test;
+22: BEGIN;
+23: SET ROLE TO role2_memory_test;
+23: BEGIN;
+-- proc21~proc23 each gets a quota of 40%/4=10%
+-- rg2 still has 36%-10%*3=6% free quota
+
+24: SET ROLE TO role2_memory_test;
+24&: BEGIN;
+-- proc24 shall be pending.
+
+SELECT * FROM rg_mem_status;
+SELECT * FROM rg_activity_status;
+
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_SHARED_QUOTA 30;
+-- now rg1 should release some shared quota, 20%*60%-20%*30%=6%
+-- now rg2 can get at most 6% new quota, but as it already has 36%,
+-- so rg2 actually gets 4% new quota.
+-- now rg2 has 40% quota, the free quota is 40%-30%=10%,
+-- just enough for proc24 to wake up.
+
+24<:
+SELECT * FROM rg_mem_status;
+SELECT * FROM rg_activity_status;
+
+11q:
+21q:
+22q:
+23q:
+24q:
+
+--
+-- 3.5) decrease one group and increase another, with load, with pending
+--      memory_shared_quota > 0 and can not be freed,
+--      waken up by released quota memory from other group
+--
+
+ALTER RESOURCE GROUP rg2_memory_test SET CONCURRENCY 2;
+ALTER RESOURCE GROUP rg2_memory_test SET MEMORY_LIMIT 30;
+ALTER RESOURCE GROUP rg2_memory_test SET MEMORY_SHARED_QUOTA 0;
+
+ALTER RESOURCE GROUP rg1_memory_test SET CONCURRENCY 10;
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 30;
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_SHARED_QUOTA 90;
+
+SELECT * FROM rg_mem_status;
+
+11: SET ROLE TO role1_memory_test;
+11: BEGIN;
+11: SELECT hold_memory_by_percent(1,0.90);
+-- proc11 gets a quota of 30%*10%/10=0.3% from rg1
+-- rg1 has a free quota of 30%*10%-0.3%=2.7%
+-- rg1 has a shared quota of 30%*90%=27%,
+--     free shared quota is 27%-(30%*90%-0.3%)=0.3%
+
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 20;
+-- now each slot in rg1 requires a quota of 20%*10%/10=0.2%
+-- rg1 releases some quota, 0.1%*9=0.9%,
+--     so new quota is 2.1%, new free quota is 2.1%-0.3%=1.8%
+-- rg1 releases some shared quota, 27%-max(20%*90%,26.7%)=0.3%,
+--     so new shared quota is 26.7%, new free shared quota is 0%
+
+ALTER RESOURCE GROUP rg2_memory_test SET CONCURRENCY 4;
+ALTER RESOURCE GROUP rg2_memory_test SET MEMORY_LIMIT 40;
+-- now rg2 has a quota of 30%+1.2%=31.2%
+-- now each slot in rg2 requires a quota of 40%/4=10%
+
+21: SET ROLE TO role2_memory_test;
+21: BEGIN;
+22: SET ROLE TO role2_memory_test;
+22: BEGIN;
+23: SET ROLE TO role2_memory_test;
+23: BEGIN;
+-- proc21~proc23 each gets a quota of 40%/4=10%
+-- rg2 still has 31.2%-10%*3=1.2% free quota
+
+24: SET ROLE TO role2_memory_test;
+24&: BEGIN;
+-- proc24 shall be pending.
+
+SELECT * FROM rg_mem_status;
+SELECT * FROM rg_activity_status;
+
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_SHARED_QUOTA 30;
+-- rg1 can't free any shared quota as all of them are in use by proc11
+
+SELECT * FROM rg_mem_status;
+SELECT * FROM rg_activity_status;
+
+11q:
+-- rg1 releases 0.3%-0.2%=0.1% quota and 26.7%-18%=8.7%
+-- so rg2 gets 8.8% new quota
+-- now rg2 has 40% quota, free quota is 10%
+-- so proc24 shall be waken up
+
+24<:
+SELECT * FROM rg_mem_status;
+SELECT * FROM rg_activity_status;
+
+21q:
+22q:
+23q:
+24q:
+
 -- cleanup
 DROP VIEW rg_mem_status;
 DROP ROLE role1_memory_test;
+DROP ROLE role2_memory_test;
 DROP RESOURCE GROUP rg1_memory_test;
+DROP RESOURCE GROUP rg2_memory_test;

--- a/src/test/isolation2/output/resgroup/resgroup_alter_memory.source
+++ b/src/test/isolation2/output/resgroup/resgroup_alter_memory.source
@@ -1,8 +1,12 @@
 -- start_ignore
 DROP ROLE IF EXISTS role1_memory_test;
 DROP
+DROP ROLE IF EXISTS role2_memory_test;
+DROP
 DROP RESOURCE GROUP rg1_memory_test;
 ERROR:  resource group "rg1_memory_test" does not exist
+DROP RESOURCE GROUP rg2_memory_test;
+ERROR:  resource group "rg2_memory_test" does not exist
 -- end_ignore
 
 CREATE OR REPLACE FUNCTION resGroupPalloc(float) RETURNS int AS '@abs_builddir@/../regress/regress@DLSUFFIX@', 'resGroupPalloc' LANGUAGE C READS SQL DATA;
@@ -11,10 +15,13 @@ CREATE
 CREATE OR REPLACE FUNCTION hold_memory_by_percent(int, float) RETURNS int AS $$ SELECT * FROM resGroupPalloc($2) $$ LANGUAGE sql;
 CREATE
 
-CREATE OR REPLACE VIEW rg_mem_status AS SELECT groupname, memory_limit, proposed_memory_limit, memory_shared_quota, proposed_memory_shared_quota FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg1_memory_test';
+CREATE OR REPLACE VIEW rg_activity_status AS SELECT rsgname, waiting_reason, current_query FROM pg_stat_activity WHERE rsgname='rg1_memory_test' OR rsgname='rg2_memory_test' ORDER BY sess_id;
 CREATE
 
-CREATE RESOURCE GROUP rg1_memory_test WITH (concurrency=2, cpu_rate_limit=10, memory_limit=50, memory_shared_quota=0, memory_spill_ratio=20);
+CREATE OR REPLACE VIEW rg_mem_status AS SELECT groupname, memory_limit, proposed_memory_limit, memory_shared_quota, proposed_memory_shared_quota FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg1_memory_test' OR groupname='rg2_memory_test' ORDER BY groupid;
+CREATE
+
+CREATE RESOURCE GROUP rg1_memory_test WITH (concurrency=2, cpu_rate_limit=10, memory_limit=60, memory_shared_quota=0, memory_spill_ratio=5);
 CREATE
 CREATE ROLE role1_memory_test RESOURCE GROUP rg1_memory_test;
 CREATE
@@ -89,6 +96,95 @@ rg1_memory_test|60          |60                   |70                 |80
 1q: ... <quitting>
 
 --
+-- 1.3) alter memory shared quota up and down
+--
+
+ALTER RESOURCE GROUP rg1_memory_test SET CONCURRENCY 2;
+ALTER
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 40;
+ALTER
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_SHARED_QUOTA 60;
+ALTER
+
+SELECT * FROM rg_mem_status;
+groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
+---------------+------------+---------------------+-------------------+----------------------------
+rg1_memory_test|40          |40                   |60                 |60                          
+(1 row)
+
+1: SET ROLE TO role1_memory_test;
+SET
+1: BEGIN;
+BEGIN
+-- proc1 has a quota of 40%*40%/2=8%
+-- rg1 still have 8% free quota
+
+ALTER RESOURCE GROUP rg1_memory_test SET CONCURRENCY 4;
+ALTER
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_SHARED_QUOTA 70;
+ALTER
+-- rg1 should free some quota, 40%*40%/2*1-40%*30%/4*3=8%-9%=-1%
+-- rg1 now have 40%*20%=8% free quota
+-- each slot in rg1 requires 40%*30%/4=3%
+
+2: SET ROLE TO role1_memory_test;
+SET
+2: BEGIN;
+BEGIN
+3: SET ROLE TO role1_memory_test;
+SET
+3: BEGIN;
+BEGIN
+-- proc2&proc3 each requires a quota of 40%*30%/4=3%
+-- rg1 now has 8%-3%*2=2% free quota
+
+4: SET ROLE TO role1_memory_test;
+SET
+4&: BEGIN;  <waiting ...>
+-- proc4 shall be pending
+
+SELECT * FROM rg_mem_status;
+groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
+---------------+------------+---------------------+-------------------+----------------------------
+rg1_memory_test|40          |40                   |70                 |70                          
+(1 row)
+SELECT * FROM rg_activity_status;
+rsgname        |waiting_reason|current_query        
+---------------+--------------+---------------------
+rg1_memory_test|              |<IDLE> in transaction
+rg1_memory_test|              |<IDLE> in transaction
+rg1_memory_test|              |<IDLE> in transaction
+rg1_memory_test|resgroup      |BEGIN;               
+(4 rows)
+
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_SHARED_QUOTA 40;
+ALTER
+-- rg1 now have 40%*60%-8%-3%*2=10% free quota again
+-- and now proc4 requires a quota of 40%*60%/4=6%,
+-- so it shall be waken up
+
+4<:  <... completed>
+BEGIN
+SELECT * FROM rg_mem_status;
+groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
+---------------+------------+---------------------+-------------------+----------------------------
+rg1_memory_test|40          |40                   |40                 |40                          
+(1 row)
+SELECT * FROM rg_activity_status;
+rsgname        |waiting_reason|current_query        
+---------------+--------------+---------------------
+rg1_memory_test|              |<IDLE> in transaction
+rg1_memory_test|              |<IDLE> in transaction
+rg1_memory_test|              |<IDLE> in transaction
+rg1_memory_test|              |<IDLE> in transaction
+(4 rows)
+
+1q: ... <quitting>
+2q: ... <quitting>
+3q: ... <quitting>
+4q: ... <quitting>
+
+--
 -- 2.1) alter memory limit with low memory usage (and low memory shared usage)
 --
 
@@ -122,11 +218,12 @@ ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 60;
 ALTER
 
 -- now the group has 60%*40%-10%=14% free quota and 60%*60%=36% free shared quota,
--- so memory_limit shall be the new value.
+-- so memory_limit can be the new value, however at the moment we don't update
+-- value when increasing memory_limit, so it's still the old value.
 SELECT * FROM rg_mem_status;
 groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
 ---------------+------------+---------------------+-------------------+----------------------------
-rg1_memory_test|60          |60                   |60                 |60                          
+rg1_memory_test|50          |60                   |60                 |60                          
 (1 row)
 
 ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 40;
@@ -156,7 +253,7 @@ rg1_memory_test|40          |10                   |60                 |60
 (1 row)
 
 --
--- 8.3) alter memory limit with high memory usage and high memory shared usage
+-- 2.3) alter memory limit with high memory usage and high memory shared usage
 --
 
 ALTER RESOURCE GROUP rg1_memory_test SET CONCURRENCY 2;
@@ -206,10 +303,558 @@ rg1_memory_test|40          |30                   |60                 |20
 
 1q: ... <quitting>
 
+--
+-- 3.1) decrease one group and increase another, no load
+--
+
+ALTER RESOURCE GROUP rg1_memory_test SET CONCURRENCY 3;
+ALTER
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 30;
+ALTER
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_SHARED_QUOTA 0;
+ALTER
+
+CREATE RESOURCE GROUP rg2_memory_test WITH (concurrency=3, cpu_rate_limit=10, memory_limit=30, memory_shared_quota=0, memory_spill_ratio=5);
+CREATE
+CREATE ROLE role2_memory_test RESOURCE GROUP rg2_memory_test;
+CREATE
+
+-- default_group and admin_group consumed 40% memory_limit,
+-- so with rg1+rg2=60% all memory_limit is already allocated,
+-- so increasing any of them shall fail.
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 31;
+ERROR:  total memory_limit exceeded the limit of 100
+
+SELECT * FROM rg_mem_status;
+groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
+---------------+------------+---------------------+-------------------+----------------------------
+rg1_memory_test|30          |30                   |0                  |0                           
+rg2_memory_test|30          |30                   |0                  |0                           
+(2 rows)
+
+-- but increase could succeed if another rg is first decreased.
+ALTER RESOURCE GROUP rg2_memory_test SET MEMORY_LIMIT 20;
+ALTER
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 40;
+ALTER
+
+SELECT * FROM rg_mem_status;
+groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
+---------------+------------+---------------------+-------------------+----------------------------
+rg1_memory_test|30          |40                   |0                  |0                           
+rg2_memory_test|20          |20                   |0                  |0                           
+(2 rows)
+
+--
+-- 3.2) decrease one group and increase another, with load, no pending
+--
+
+ALTER RESOURCE GROUP rg1_memory_test SET CONCURRENCY 3;
+ALTER
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 30;
+ALTER
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_SHARED_QUOTA 0;
+ALTER
+
+ALTER RESOURCE GROUP rg2_memory_test SET CONCURRENCY 2;
+ALTER
+ALTER RESOURCE GROUP rg2_memory_test SET MEMORY_LIMIT 30;
+ALTER
+ALTER RESOURCE GROUP rg2_memory_test SET MEMORY_SHARED_QUOTA 0;
+ALTER
+
+SELECT * FROM rg_mem_status;
+groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
+---------------+------------+---------------------+-------------------+----------------------------
+rg1_memory_test|30          |30                   |0                  |0                           
+rg2_memory_test|30          |30                   |0                  |0                           
+(2 rows)
+
+11: SET ROLE TO role1_memory_test;
+SET
+11: BEGIN;
+BEGIN
+-- proc11 gets a quota of 30%/3=10% from rg1
+
+12: SET ROLE TO role1_memory_test;
+SET
+12: BEGIN;
+BEGIN
+-- proc12 gets a quota of 30%/3=10% from rg1
+
+13: SET ROLE TO role1_memory_test;
+SET
+13: BEGIN;
+BEGIN
+-- proc13 gets a quota of 30%/3=10% from rg1
+
+-- although all the memory quota is in use,
+-- it's still allowed to decrease memory_limit,
+-- in such a case rg2 won't get the new quota until any query in rg1 ends.
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 15;
+ALTER
+ALTER RESOURCE GROUP rg2_memory_test SET MEMORY_LIMIT 40;
+ALTER
+-- now both rg1 and rg2 still have 30% quota
+
+21: SET ROLE TO role2_memory_test;
+SET
+21: BEGIN;
+BEGIN
+-- proc21 gets a quota of 40%/2=20% from rg2
+
+SELECT * FROM rg_mem_status;
+groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
+---------------+------------+---------------------+-------------------+----------------------------
+rg1_memory_test|30          |15                   |0                  |0                           
+rg2_memory_test|30          |40                   |0                  |0                           
+(2 rows)
+SELECT * FROM rg_activity_status;
+rsgname        |waiting_reason|current_query        
+---------------+--------------+---------------------
+rg1_memory_test|              |<IDLE> in transaction
+rg1_memory_test|              |<IDLE> in transaction
+rg1_memory_test|              |<IDLE> in transaction
+rg2_memory_test|              |<IDLE> in transaction
+(4 rows)
+
+11q: ... <quitting>
+-- proc11 ends, 10%-5%=5% quota is returned to sys
+
+12q: ... <quitting>
+-- proc12 ends, 10%-5%=5% quota is returned to sys
+
+SELECT * FROM rg_mem_status;
+groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
+---------------+------------+---------------------+-------------------+----------------------------
+rg1_memory_test|30          |15                   |0                  |0                           
+rg2_memory_test|30          |40                   |0                  |0                           
+(2 rows)
+SELECT * FROM rg_activity_status;
+rsgname        |waiting_reason|current_query        
+---------------+--------------+---------------------
+rg1_memory_test|              |<IDLE> in transaction
+rg2_memory_test|              |<IDLE> in transaction
+(2 rows)
+
+-- now rg2 shall be able to get 10% free quota from sys
+22: SET ROLE TO role2_memory_test;
+SET
+22: BEGIN;
+BEGIN
+-- proc22 gets a quota of 40%/2=20% from rg2
+
+SELECT * FROM rg_mem_status;
+groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
+---------------+------------+---------------------+-------------------+----------------------------
+rg1_memory_test|30          |15                   |0                  |0                           
+rg2_memory_test|30          |40                   |0                  |0                           
+(2 rows)
+SELECT * FROM rg_activity_status;
+rsgname        |waiting_reason|current_query        
+---------------+--------------+---------------------
+rg1_memory_test|              |<IDLE> in transaction
+rg2_memory_test|              |<IDLE> in transaction
+rg2_memory_test|              |<IDLE> in transaction
+(3 rows)
+
+13q: ... <quitting>
+21q: ... <quitting>
+22q: ... <quitting>
+
+--
+-- 3.3) decrease one group and increase another, with load, with pending,
+--      memory_shared_quota is 0,
+--      waken up by released quota memory from other group
+--
+
+ALTER RESOURCE GROUP rg2_memory_test SET CONCURRENCY 2;
+ALTER
+ALTER RESOURCE GROUP rg2_memory_test SET MEMORY_LIMIT 30;
+ALTER
+ALTER RESOURCE GROUP rg2_memory_test SET MEMORY_SHARED_QUOTA 0;
+ALTER
+
+ALTER RESOURCE GROUP rg1_memory_test SET CONCURRENCY 3;
+ALTER
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 30;
+ALTER
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_SHARED_QUOTA 0;
+ALTER
+
+SELECT * FROM rg_mem_status;
+groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
+---------------+------------+---------------------+-------------------+----------------------------
+rg1_memory_test|30          |30                   |0                  |0                           
+rg2_memory_test|30          |30                   |0                  |0                           
+(2 rows)
+
+11: SET ROLE TO role1_memory_test;
+SET
+11: BEGIN;
+BEGIN
+-- proc11 gets a quota of 30%/3=10% from rg1
+
+12: SET ROLE TO role1_memory_test;
+SET
+12: BEGIN;
+BEGIN
+-- proc12 gets a quota of 30%/3=10% from rg1
+
+13: SET ROLE TO role1_memory_test;
+SET
+13: BEGIN;
+BEGIN
+-- proc13 gets a quota of 30%/3=10% from rg1
+
+-- although all the memory quota is in use,
+-- it's still allowed to decrease memory_limit,
+-- in such a case rg2 won't get the new quota until any query in rg1 ends.
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 15;
+ALTER
+ALTER RESOURCE GROUP rg2_memory_test SET MEMORY_LIMIT 40;
+ALTER
+-- now both rg1 and rg2 still have 30% quota
+
+21: SET ROLE TO role2_memory_test;
+SET
+21: BEGIN;
+BEGIN
+
+22: SET ROLE TO role2_memory_test;
+SET
+22&: BEGIN;  <waiting ...>
+
+-- proc21 gets a quota of 40%/2=20% from rg2
+-- proc22 requires a quota of 40%/2=20% from rg2,
+-- but as rg2 only has 30%-20%=10% free quota now,
+-- it shall be pending.
+SELECT * FROM rg_mem_status;
+groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
+---------------+------------+---------------------+-------------------+----------------------------
+rg1_memory_test|30          |15                   |0                  |0                           
+rg2_memory_test|30          |40                   |0                  |0                           
+(2 rows)
+SELECT * FROM rg_activity_status;
+rsgname        |waiting_reason|current_query        
+---------------+--------------+---------------------
+rg1_memory_test|              |<IDLE> in transaction
+rg1_memory_test|              |<IDLE> in transaction
+rg1_memory_test|              |<IDLE> in transaction
+rg2_memory_test|              |<IDLE> in transaction
+rg2_memory_test|resgroup      |BEGIN;               
+(5 rows)
+
+11: END;
+END
+11q: ... <quitting>
+-- proc11 ends, 10%-5%=5% quota is returned to sys
+
+SELECT * FROM rg_mem_status;
+groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
+---------------+------------+---------------------+-------------------+----------------------------
+rg1_memory_test|30          |15                   |0                  |0                           
+rg2_memory_test|30          |40                   |0                  |0                           
+(2 rows)
+SELECT * FROM rg_activity_status;
+rsgname        |waiting_reason|current_query        
+---------------+--------------+---------------------
+rg1_memory_test|              |<IDLE> in transaction
+rg1_memory_test|              |<IDLE> in transaction
+rg2_memory_test|              |<IDLE> in transaction
+rg2_memory_test|resgroup      |BEGIN;               
+(4 rows)
+
+12: END;
+END
+12q: ... <quitting>
+-- proc12 ends, 10%-5%=5% quota is returned to sys
+
+-- now rg2 can get 10% free quota from sys
+-- so proc22 can get enough quota and get executed
+22<:  <... completed>
+BEGIN
+SELECT * FROM rg_mem_status;
+groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
+---------------+------------+---------------------+-------------------+----------------------------
+rg1_memory_test|30          |15                   |0                  |0                           
+rg2_memory_test|30          |40                   |0                  |0                           
+(2 rows)
+SELECT * FROM rg_activity_status;
+rsgname        |waiting_reason|current_query        
+---------------+--------------+---------------------
+rg1_memory_test|              |<IDLE> in transaction
+rg2_memory_test|              |<IDLE> in transaction
+rg2_memory_test|              |<IDLE> in transaction
+(3 rows)
+
+13q: ... <quitting>
+21q: ... <quitting>
+22q: ... <quitting>
+
+--
+-- 3.4) decrease one group and increase another, with load, with pending,
+--      memory_shared_quota > 0 and can be freed,
+--      waken up by released shared quota memory from other group
+--
+
+ALTER RESOURCE GROUP rg2_memory_test SET CONCURRENCY 2;
+ALTER
+ALTER RESOURCE GROUP rg2_memory_test SET MEMORY_LIMIT 30;
+ALTER
+ALTER RESOURCE GROUP rg2_memory_test SET MEMORY_SHARED_QUOTA 0;
+ALTER
+
+ALTER RESOURCE GROUP rg1_memory_test SET CONCURRENCY 1;
+ALTER
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 30;
+ALTER
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_SHARED_QUOTA 60;
+ALTER
+
+SELECT * FROM rg_mem_status;
+groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
+---------------+------------+---------------------+-------------------+----------------------------
+rg1_memory_test|30          |30                   |60                 |60                          
+rg2_memory_test|30          |30                   |0                  |0                           
+(2 rows)
+
+11: SET ROLE TO role1_memory_test;
+SET
+11: BEGIN;
+BEGIN
+-- proc11 gets a quota of 30%*40%=12% from rg1
+-- rg1 also has a shared quota of 30%*60%=18%
+
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 20;
+ALTER
+-- now each slot in rg1 requires a quota of 20%*40%=8%
+-- rg1 has 0% free quota and 20%*60%=12% free shared quota
+-- rg1 should release some shared quota, 30%*60%-20%*60%=6%
+
+ALTER RESOURCE GROUP rg2_memory_test SET CONCURRENCY 4;
+ALTER
+ALTER RESOURCE GROUP rg2_memory_test SET MEMORY_LIMIT 40;
+ALTER
+-- now rg2 has a quota of 30%+6%=36%
+-- now each slot in rg2 requires a quota of 40%/4=10%
+
+21: SET ROLE TO role2_memory_test;
+SET
+21: BEGIN;
+BEGIN
+22: SET ROLE TO role2_memory_test;
+SET
+22: BEGIN;
+BEGIN
+23: SET ROLE TO role2_memory_test;
+SET
+23: BEGIN;
+BEGIN
+-- proc21~proc23 each gets a quota of 40%/4=10%
+-- rg2 still has 36%-10%*3=6% free quota
+
+24: SET ROLE TO role2_memory_test;
+SET
+24&: BEGIN;  <waiting ...>
+-- proc24 shall be pending.
+
+SELECT * FROM rg_mem_status;
+groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
+---------------+------------+---------------------+-------------------+----------------------------
+rg1_memory_test|30          |20                   |60                 |60                          
+rg2_memory_test|30          |40                   |0                  |0                           
+(2 rows)
+SELECT * FROM rg_activity_status;
+rsgname        |waiting_reason|current_query        
+---------------+--------------+---------------------
+rg1_memory_test|              |<IDLE> in transaction
+rg2_memory_test|              |<IDLE> in transaction
+rg2_memory_test|              |<IDLE> in transaction
+rg2_memory_test|              |<IDLE> in transaction
+rg2_memory_test|resgroup      |BEGIN;               
+(5 rows)
+
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_SHARED_QUOTA 30;
+ALTER
+-- now rg1 should release some shared quota, 20%*60%-20%*30%=6%
+-- now rg2 can get at most 6% new quota, but as it already has 36%,
+-- so rg2 actually gets 4% new quota.
+-- now rg2 has 40% quota, the free quota is 40%-30%=10%,
+-- just enough for proc24 to wake up.
+
+24<:  <... completed>
+BEGIN
+SELECT * FROM rg_mem_status;
+groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
+---------------+------------+---------------------+-------------------+----------------------------
+rg1_memory_test|20          |20                   |30                 |30                          
+rg2_memory_test|30          |40                   |0                  |0                           
+(2 rows)
+SELECT * FROM rg_activity_status;
+rsgname        |waiting_reason|current_query        
+---------------+--------------+---------------------
+rg1_memory_test|              |<IDLE> in transaction
+rg2_memory_test|              |<IDLE> in transaction
+rg2_memory_test|              |<IDLE> in transaction
+rg2_memory_test|              |<IDLE> in transaction
+rg2_memory_test|              |<IDLE> in transaction
+(5 rows)
+
+11q: ... <quitting>
+21q: ... <quitting>
+22q: ... <quitting>
+23q: ... <quitting>
+24q: ... <quitting>
+
+--
+-- 3.5) decrease one group and increase another, with load, with pending
+--      memory_shared_quota > 0 and can not be freed,
+--      waken up by released quota memory from other group
+--
+
+ALTER RESOURCE GROUP rg2_memory_test SET CONCURRENCY 2;
+ALTER
+ALTER RESOURCE GROUP rg2_memory_test SET MEMORY_LIMIT 30;
+ALTER
+ALTER RESOURCE GROUP rg2_memory_test SET MEMORY_SHARED_QUOTA 0;
+ALTER
+
+ALTER RESOURCE GROUP rg1_memory_test SET CONCURRENCY 10;
+ALTER
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 30;
+ALTER
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_SHARED_QUOTA 90;
+ALTER
+
+SELECT * FROM rg_mem_status;
+groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
+---------------+------------+---------------------+-------------------+----------------------------
+rg1_memory_test|30          |30                   |90                 |90                          
+rg2_memory_test|30          |30                   |0                  |0                           
+(2 rows)
+
+11: SET ROLE TO role1_memory_test;
+SET
+11: BEGIN;
+BEGIN
+11: SELECT hold_memory_by_percent(1,0.90);
+hold_memory_by_percent
+----------------------
+0                     
+(1 row)
+-- proc11 gets a quota of 30%*10%/10=0.3% from rg1
+-- rg1 has a free quota of 30%*10%-0.3%=2.7%
+-- rg1 has a shared quota of 30%*90%=27%,
+--     free shared quota is 27%-(30%*90%-0.3%)=0.3%
+
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 20;
+ALTER
+-- now each slot in rg1 requires a quota of 20%*10%/10=0.2%
+-- rg1 releases some quota, 0.1%*9=0.9%,
+--     so new quota is 2.1%, new free quota is 2.1%-0.3%=1.8%
+-- rg1 releases some shared quota, 27%-max(20%*90%,26.7%)=0.3%,
+--     so new shared quota is 26.7%, new free shared quota is 0%
+
+ALTER RESOURCE GROUP rg2_memory_test SET CONCURRENCY 4;
+ALTER
+ALTER RESOURCE GROUP rg2_memory_test SET MEMORY_LIMIT 40;
+ALTER
+-- now rg2 has a quota of 30%+1.2%=31.2%
+-- now each slot in rg2 requires a quota of 40%/4=10%
+
+21: SET ROLE TO role2_memory_test;
+SET
+21: BEGIN;
+BEGIN
+22: SET ROLE TO role2_memory_test;
+SET
+22: BEGIN;
+BEGIN
+23: SET ROLE TO role2_memory_test;
+SET
+23: BEGIN;
+BEGIN
+-- proc21~proc23 each gets a quota of 40%/4=10%
+-- rg2 still has 31.2%-10%*3=1.2% free quota
+
+24: SET ROLE TO role2_memory_test;
+SET
+24&: BEGIN;  <waiting ...>
+-- proc24 shall be pending.
+
+SELECT * FROM rg_mem_status;
+groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
+---------------+------------+---------------------+-------------------+----------------------------
+rg1_memory_test|30          |20                   |90                 |90                          
+rg2_memory_test|30          |40                   |0                  |0                           
+(2 rows)
+SELECT * FROM rg_activity_status;
+rsgname        |waiting_reason|current_query        
+---------------+--------------+---------------------
+rg1_memory_test|              |<IDLE> in transaction
+rg2_memory_test|              |<IDLE> in transaction
+rg2_memory_test|              |<IDLE> in transaction
+rg2_memory_test|              |<IDLE> in transaction
+rg2_memory_test|resgroup      |BEGIN;               
+(5 rows)
+
+ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_SHARED_QUOTA 30;
+ALTER
+-- rg1 can't free any shared quota as all of them are in use by proc11
+
+SELECT * FROM rg_mem_status;
+groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
+---------------+------------+---------------------+-------------------+----------------------------
+rg1_memory_test|30          |20                   |90                 |30                          
+rg2_memory_test|30          |40                   |0                  |0                           
+(2 rows)
+SELECT * FROM rg_activity_status;
+rsgname        |waiting_reason|current_query        
+---------------+--------------+---------------------
+rg1_memory_test|              |<IDLE> in transaction
+rg2_memory_test|              |<IDLE> in transaction
+rg2_memory_test|              |<IDLE> in transaction
+rg2_memory_test|              |<IDLE> in transaction
+rg2_memory_test|resgroup      |BEGIN;               
+(5 rows)
+
+11q: ... <quitting>
+-- rg1 releases 0.3%-0.2%=0.1% quota and 26.7%-18%=8.7%
+-- so rg2 gets 8.8% new quota
+-- now rg2 has 40% quota, free quota is 10%
+-- so proc24 shall be waken up
+
+24<:  <... completed>
+BEGIN
+SELECT * FROM rg_mem_status;
+groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
+---------------+------------+---------------------+-------------------+----------------------------
+rg1_memory_test|30          |20                   |90                 |30                          
+rg2_memory_test|30          |40                   |0                  |0                           
+(2 rows)
+SELECT * FROM rg_activity_status;
+rsgname        |waiting_reason|current_query        
+---------------+--------------+---------------------
+rg2_memory_test|              |<IDLE> in transaction
+rg2_memory_test|              |<IDLE> in transaction
+rg2_memory_test|              |<IDLE> in transaction
+rg2_memory_test|              |<IDLE> in transaction
+(4 rows)
+
+21q: ... <quitting>
+22q: ... <quitting>
+23q: ... <quitting>
+24q: ... <quitting>
+
 -- cleanup
 DROP VIEW rg_mem_status;
 DROP
 DROP ROLE role1_memory_test;
 DROP
+DROP ROLE role2_memory_test;
+DROP
 DROP RESOURCE GROUP rg1_memory_test;
+DROP
+DROP RESOURCE GROUP rg2_memory_test;
 DROP


### PR DESCRIPTION
memory_limit, memory_shared_quota and concurrency might be altered
concurrently when there're transactions running in the resource group,
these changes cannot take effect immediately.

Release memory 1)at the end of the 'ALTER' transaction 2)when a resource
group slot get freed.

Acquire memory at the beggning of a transaction if the resource group
dosen't have enough memory as configured.

Signed-off-by: Gang Xiong <gxiong@pivotal.io>