### PR TITLE
Teach libpq to decode server version correctly from future servers.

### DIFF
--- a/src/interfaces/libpq/fe-exec.c
+++ b/src/interfaces/libpq/fe-exec.c
@@ -980,14 +980,31 @@ pqSaveParameterStatus(PGconn *conn, const char *name, const char *value)
 
 		cnt = sscanf(value, "%d.%d.%d", &vmaj, &vmin, &vrev);
 
-		if (cnt < 2)
-			conn->sversion = 0; /* unknown */
-		else
+		if (cnt == 3)
 		{
-			if (cnt == 2)
-				vrev = 0;
+			/* old style, e.g. 9.6.1 */
 			conn->sversion = (100 * vmaj + vmin) * 100 + vrev;
 		}
+		else if (cnt == 2)
+		{
+			if (vmaj >= 10)
+			{
+				/* new style, e.g. 10.1 */
+				conn->sversion = 100 * 100 * vmaj + vmin;
+			}
+			else
+			{
+				/* old style without minor version, e.g. 9.6devel */
+				conn->sversion = (100 * vmaj + vmin) * 100;
+			}
+		}
+		else if (cnt == 1)
+		{
+			/* new style without minor version, e.g. 10devel */
+			conn->sversion = 100 * 100 * vmaj;
+		}
+		else
+			conn->sversion = 0; /* unknown */
 	}
 }
 


### PR DESCRIPTION
Beginning with the next development cycle, PG servers will report two-part
not three-part version numbers.  Fix libpq so that it will compute the
correct numeric representation of such server versions for reporting by
PQserverVersion().  It's desirable to get this into the field and
back-patched ASAP, so that older clients are more likely to understand the
new server version numbering by the time any such servers are in the wild.

(The results with an old client would probably not be catastrophic anyway
for a released server; for example "10.1" would be interpreted as 100100
which would be wrong in detail but would not likely cause an old client to
misbehave badly.  But "10devel" or "10beta1" would result in sversion==0
which at best would result in disabling all use of modern features.)

Extracted from a patch by Peter Eisentraut; comments added by me

Patch: <802ec140-635d-ad86-5fdf-d3af0e260c22@2ndquadrant.com>