### PR TITLE
Introduce LW locks to protect filespace and tablespace hash tables.

### DIFF
--- a/src/backend/cdb/cdbpersistentfilespace.c
+++ b/src/backend/cdb/cdbpersistentfilespace.c
@@ -129,6 +129,8 @@ PersistentFilespace_FindDirUnderLock(
 
 	FilespaceDirEntryKey key;
 
+	Assert(LWLockHeldByMe(FilespaceHashLock));
+
 	if (persistentFilespaceSharedHashTable == NULL)
 		elog(PANIC, "Persistent filespace information shared-memory not setup");
 
@@ -155,6 +157,8 @@ PersistentFilespace_CreateDirUnderLock(
 	FilespaceDirEntry	filespaceDirEntry;
 
 	FilespaceDirEntryKey key;
+
+	Assert(LWLockHeldByMe(FilespaceHashLock));
 
 	if (persistentFilespaceSharedHashTable == NULL)
 		elog(PANIC, "Persistent filespace information shared-memory not setup");
@@ -183,6 +187,8 @@ PersistentFilespace_RemoveDirUnderLock(
 	FilespaceDirEntry	filespaceDirEntry)
 {
 	FilespaceDirEntry	removeFilespaceDirEntry;
+
+	Assert(LWLockHeldByMe(FilespaceHashLock));
 
 	if (persistentFilespaceSharedHashTable == NULL)
 		elog(PANIC, "Persistent filespace information shared-memory not setup");

--- a/src/backend/cdb/cdbpersistentfilesysobj.c
+++ b/src/backend/cdb/cdbpersistentfilesysobj.c
@@ -2164,7 +2164,7 @@ PersistentFileSysObj_DoMirrorValidation(
 			char *primaryFilespaceLocation = NULL;
 			char *mirrorFilespaceLocation = NULL;
 
-			PersistentFilespace_GetPrimaryAndMirrorUnderLock(
+			PersistentFilespace_GetPrimaryAndMirror(
 													fsObjName->variant.filespaceOid,
 													&primaryFilespaceLocation,
 													&mirrorFilespaceLocation);

--- a/src/backend/cdb/cdbpersistenttablespace.c
+++ b/src/backend/cdb/cdbpersistenttablespace.c
@@ -57,31 +57,30 @@ typedef struct PersistentTablespaceData
 	PersistentFileSysObjData		fileSysObjData;
 
 } PersistentTablespaceData;
+		
+#define WRITE_TABLESPACE_HASH_LOCK \
+	{ \
+		Assert(LWLockHeldByMe(PersistentObjLock)); \
+		LWLockAcquire(TablespaceHashLock, LW_EXCLUSIVE); \
+	}
 
-typedef struct TablespaceDirEntryKey
-{
-	Oid	tablespaceOid;
-} TablespaceDirEntryKey;
-
-typedef struct TablespaceDirEntryData
-{
-	TablespaceDirEntryKey	key;
-
-	Oid						filespaceOid;
-
-	PersistentFileSysState	state;
-	int64					persistentSerialNum;
-	ItemPointerData 		persistentTid;
-	
-} TablespaceDirEntryData;
-typedef TablespaceDirEntryData *TablespaceDirEntry;
-
+#define WRITE_TABLESPACE_HASH_UNLOCK \
+	{ \
+		Assert(LWLockHeldByMe(PersistentObjLock)); \
+		LWLockRelease(TablespaceHashLock); \
+	}
 
 /*
  * Global Variables
  */
 PersistentTablespaceSharedData	*persistentTablespaceSharedData = NULL;
-static HTAB *persistentTablespaceSharedHashTable = NULL;
+/*
+ * Reads to the persistentTablespaceSharedHashTable are protected by
+ * TablespaceHashLock alone. To write to persistentTablespaceSharedHashTable,
+ * you must first acquire the PersistentObjLock, and then the
+ * TablespaceHashLock, both in exclusive mode.
+ */
+HTAB *persistentTablespaceSharedHashTable = NULL;
 
 PersistentTablespaceData	persistentTablespaceData = PersistentTablespaceData_StaticInit;
 
@@ -155,7 +154,7 @@ PersistentTablespace_CreateEntryUnderLock(
 	tablespaceDirEntry->state = 0;
 	tablespaceDirEntry->persistentSerialNum = 0;
 	MemSet(&tablespaceDirEntry->persistentTid, 0, sizeof(ItemPointerData));
-	
+
 	return tablespaceDirEntry;
 }
 
@@ -183,8 +182,6 @@ PersistentFileSysState
 PersistentTablespace_GetState(
 	Oid		tablespaceOid)
 {
-	READ_PERSISTENT_STATE_ORDERED_LOCK_DECLARE;
-
 	TablespaceDirEntry tablespaceDirEntry;
 
 	PersistentFileSysState	state;
@@ -204,18 +201,15 @@ PersistentTablespace_GetState(
 	// NOTE: Since we are not accessing data in the Buffer Pool, we don't need to
 	// acquire the MirroredLock.
 
-	READ_PERSISTENT_STATE_ORDERED_LOCK;
+	LWLockAcquire(TablespaceHashLock, LW_SHARED);
+	tablespaceDirEntry = PersistentTablespace_FindEntryUnderLock(tablespaceOid);
 
-	tablespaceDirEntry = 
-				PersistentTablespace_FindEntryUnderLock(
-												tablespaceOid);
 	if (tablespaceDirEntry == NULL)
 		elog(ERROR, "Did not find persistent tablespace entry %u", 
 			 tablespaceOid);
 
 	state = tablespaceDirEntry->state;
-
-	READ_PERSISTENT_STATE_ORDERED_UNLOCK;
+	LWLockRelease(TablespaceHashLock);
 
 	return state;
 }
@@ -255,12 +249,20 @@ static bool PersistentTablespace_ScanTupleCallback(
 									&parentXid,
 									&serialNum);
 
-	tablespaceDirEntry = 
+	/*
+	 * Normally we would acquire this lock with the WRITE_TABLESPACE_HASH_LOCK
+	 * macro, however, this particular function can be called during startup.
+	 * During startup, which executes in a single threaded context, no
+	 * PersistentObjLock exists and we cannot assert that we're holding it.
+	 */
+	LWLockAcquire(TablespaceHashLock, LW_EXCLUSIVE);
+	tablespaceDirEntry =
 		PersistentTablespace_CreateEntryUnderLock(filespaceOid, tablespaceOid);
-	
+
 	tablespaceDirEntry->state = state;
 	tablespaceDirEntry->persistentSerialNum = serialNum;
 	tablespaceDirEntry->persistentTid = *persistentTid;
+	LWLockRelease(TablespaceHashLock);
 
 	if (Debug_persistent_print)
 		elog(Persistent_DebugPrintLevel(), 
@@ -278,11 +280,16 @@ static bool PersistentTablespace_ScanTupleCallback(
 
 void PersistentTablespace_Reset(void)
 {
+	WRITE_PERSISTENT_STATE_ORDERED_LOCK_DECLARE;
+
 	HASH_SEQ_STATUS stat;
 
 	TablespaceDirEntry tablespaceDirEntry;
 
 	hash_seq_init(&stat, persistentTablespaceSharedHashTable);
+
+	WRITE_PERSISTENT_STATE_ORDERED_LOCK;
+	WRITE_TABLESPACE_HASH_LOCK;
 
 	while (true)
 	{
@@ -305,6 +312,7 @@ void PersistentTablespace_Reset(void)
 				 tablespaceDirEntry->persistentSerialNum,
 				 ItemPointerToString(&tablespaceDirEntry->persistentTid));
 
+		
 		removeTablespaceDirEntry = 
 					(TablespaceDirEntry) 
 							hash_search(persistentTablespaceSharedHashTable,
@@ -315,6 +323,9 @@ void PersistentTablespace_Reset(void)
 		if (removeTablespaceDirEntry == NULL)
 			elog(ERROR, "Trying to delete entry that does not exist");
 	}
+
+	WRITE_TABLESPACE_HASH_UNLOCK;
+	WRITE_PERSISTENT_STATE_ORDERED_UNLOCK;
 }
 
 extern void PersistentTablespace_LookupTidAndSerialNum(
@@ -326,25 +337,19 @@ extern void PersistentTablespace_LookupTidAndSerialNum(
 
 	int64			*persistentSerialNum)
 {
-	READ_PERSISTENT_STATE_ORDERED_LOCK_DECLARE;
-
 	TablespaceDirEntry tablespaceDirEntry;
 
 	PersistentTablespace_VerifyInitScan();
 
-	READ_PERSISTENT_STATE_ORDERED_LOCK;
-
-	tablespaceDirEntry = 
-				PersistentTablespace_FindEntryUnderLock(
-												tablespaceOid);
+	LWLockAcquire(TablespaceHashLock, LW_SHARED);
+	tablespaceDirEntry = PersistentTablespace_FindEntryUnderLock(tablespaceOid);
 	if (tablespaceDirEntry == NULL)
 		elog(ERROR, "Did not find persistent tablespace entry %u", 
 			 tablespaceOid);
 
 	*persistentTid = tablespaceDirEntry->persistentTid;
 	*persistentSerialNum = tablespaceDirEntry->persistentSerialNum;
-
-	READ_PERSISTENT_STATE_ORDERED_UNLOCK;
+	LWLockRelease(TablespaceHashLock);
 }
 
 // -----------------------------------------------------------------------------
@@ -352,7 +357,11 @@ extern void PersistentTablespace_LookupTidAndSerialNum(
 // -----------------------------------------------------------------------------
 
 static void PersistentTablespace_AddTuple(
-	TablespaceDirEntry tablespaceDirEntry,
+	Oid filespaceOid,
+
+	Oid tablespaceOid,
+
+	PersistentFileSysState state,
 
 	int64			createMirrorDataLossTrackingSessionNum,
 
@@ -362,19 +371,21 @@ static void PersistentTablespace_AddTuple(
 
 	TransactionId 	parentXid,
 
-	bool			flushToXLog)
+	bool			flushToXLog,
+
+	ItemPointer     persistentTid,
+
+	int64          *persistentSerialNum)
+
 				/* When true, the XLOG record for this change will be flushed to disk. */
 {
-	Oid filespaceOid = tablespaceDirEntry->filespaceOid;
-	Oid tablespaceOid = tablespaceDirEntry->key.tablespaceOid;
-
 	Datum values[Natts_gp_persistent_tablespace_node];
 
 	GpPersistentTablespaceNode_SetDatumValues(
 								values,
 								filespaceOid,
 								tablespaceOid,
-								tablespaceDirEntry->state,
+								state,
 								createMirrorDataLossTrackingSessionNum,
 								mirrorExistenceState,
 								reserved,
@@ -385,8 +396,8 @@ static void PersistentTablespace_AddTuple(
 							PersistentFsObjType_TablespaceDir,
 							values,
 							flushToXLog,
-							&tablespaceDirEntry->persistentTid,
-							&tablespaceDirEntry->persistentSerialNum);
+							persistentTid,
+							persistentSerialNum);
 }
 
 PersistentTablespaceGetFilespaces PersistentTablespace_TryGetPrimaryAndMirrorFilespaces(
@@ -402,12 +413,6 @@ PersistentTablespaceGetFilespaces PersistentTablespace_TryGetPrimaryAndMirrorFil
 				 
 	Oid *filespaceOid)
 {
-	READ_PERSISTENT_STATE_ORDERED_LOCK_DECLARE;
-
-	TablespaceDirEntry tablespaceDirEntry;
-
-	PersistentTablespaceGetFilespaces result;
-
 	*primaryFilespaceLocation = NULL;
 	*mirrorFilespaceLocation = NULL;
 	*filespaceOid = InvalidOid;
@@ -474,35 +479,9 @@ PersistentTablespaceGetFilespaces PersistentTablespace_TryGetPrimaryAndMirrorFil
 	 */
 	PersistentTablespace_VerifyInitScan();
 
-	READ_PERSISTENT_STATE_ORDERED_LOCK;
-
-	tablespaceDirEntry =
-		PersistentTablespace_FindEntryUnderLock(
-										tablespaceOid);
-	if (tablespaceDirEntry == NULL)
-	{
-		result = PersistentTablespaceGetFilespaces_TablespaceNotFound;
-	}
-	else
-	{
-		*filespaceOid = tablespaceDirEntry->filespaceOid;
-
-		if (!PersistentFilespace_TryGetPrimaryAndMirrorUnderLock(
-													tablespaceDirEntry->filespaceOid,
-													primaryFilespaceLocation,
-													mirrorFilespaceLocation))
-		{
-			result = PersistentTablespaceGetFilespaces_FilespaceNotFound;			
-		}
-		else
-		{
-			result = PersistentTablespaceGetFilespaces_Ok;
-		}
-	}
-
-	READ_PERSISTENT_STATE_ORDERED_UNLOCK;
-
-	return result;
+	return PersistentFilespace_GetFilespaceFromTablespace(
+		tablespaceOid, primaryFilespaceLocation,
+		mirrorFilespaceLocation, filespaceOid);
 }
 
 void PersistentTablespace_GetPrimaryAndMirrorFilespaces(
@@ -562,8 +541,6 @@ void PersistentTablespace_GetPrimaryAndMirrorFilespaces(
 Oid
 PersistentTablespace_GetFileSpaceOid(Oid tablespaceOid)
 {
-	READ_PERSISTENT_STATE_ORDERED_LOCK_DECLARE;
-
 	TablespaceDirEntry tablespaceDirEntry;
 	Oid filespace = InvalidOid;
 
@@ -578,18 +555,14 @@ PersistentTablespace_GetFileSpaceOid(Oid tablespaceOid)
 
 	PersistentTablespace_VerifyInitScan();
 
-	READ_PERSISTENT_STATE_ORDERED_LOCK;
-
-	tablespaceDirEntry =
-		PersistentTablespace_FindEntryUnderLock(
-										tablespaceOid);
+	LWLockAcquire(TablespaceHashLock, LW_SHARED);
+	tablespaceDirEntry = PersistentTablespace_FindEntryUnderLock(tablespaceOid);
 	if (tablespaceDirEntry == NULL)
 		elog(ERROR, "Did not find persistent tablespace entry %u", 
 			 tablespaceOid);
 
 	filespace = tablespaceDirEntry->filespaceOid;
-
-	READ_PERSISTENT_STATE_ORDERED_UNLOCK;
+	LWLockRelease(TablespaceHashLock);
 
 	return filespace;
 }
@@ -652,25 +625,27 @@ void PersistentTablespace_MarkCreatePending(
 
 	WRITE_PERSISTENT_STATE_ORDERED_LOCK;
 
-	tablespaceDirEntry = 
-				PersistentTablespace_CreateEntryUnderLock(
-												filespaceOid,
-												tablespaceOid);
-	Assert(tablespaceDirEntry != NULL);
-
-	tablespaceDirEntry->state = PersistentFileSysState_CreatePending;
-
 	PersistentTablespace_AddTuple(
-							tablespaceDirEntry,
+							filespaceOid,
+							tablespaceOid,
+							PersistentFileSysState_CreatePending,
 							/* createMirrorDataLossTrackingSessionNum */ 0,
 							mirrorExistenceState,
 							/* reserved */ 0,
 							/* parentXid */ topXid,
-							flushToXLog);
+							flushToXLog,
+							persistentTid,
+							persistentSerialNum);
 
-	*persistentTid = tablespaceDirEntry->persistentTid;
-	*persistentSerialNum = tablespaceDirEntry->persistentSerialNum;
-		
+	WRITE_TABLESPACE_HASH_LOCK;
+	tablespaceDirEntry =
+		PersistentTablespace_CreateEntryUnderLock(filespaceOid, tablespaceOid);
+	Assert(tablespaceDirEntry != NULL);
+	tablespaceDirEntry->state = PersistentFileSysState_CreatePending;
+	ItemPointerCopy(persistentTid, &tablespaceDirEntry->persistentTid);
+	tablespaceDirEntry->persistentSerialNum = *persistentSerialNum;
+	WRITE_TABLESPACE_HASH_UNLOCK;
+
 	/*
 	 * This XLOG must be generated under the persistent write-lock.
 	 */
@@ -744,25 +719,27 @@ void PersistentTablespace_AddCreated(
 	
 	WRITE_PERSISTENT_STATE_ORDERED_LOCK;
 	
-	tablespaceDirEntry = 
-	PersistentTablespace_CreateEntryUnderLock(
-											  filespaceOid,
-											  tablespaceOid);
-	Assert(tablespaceDirEntry != NULL);
-	
-	tablespaceDirEntry->state = PersistentFileSysState_Created;
-	
 	PersistentTablespace_AddTuple(
-								  tablespaceDirEntry,
+								  filespaceOid,
+								  tablespaceOid,
+								  PersistentFileSysState_Created,
 								  /* createMirrorDataLossTrackingSessionNum */ 0,
 								  mirrorExistenceState,
 								  /* reserved */ 0,
 								  InvalidTransactionId,
-								  flushToXLog);
+								  flushToXLog,
+								  &persistentTid,
+								  &persistentSerialNum);
 
-	persistentTid = tablespaceDirEntry->persistentTid;
-	persistentSerialNum = tablespaceDirEntry->persistentSerialNum;
-		
+	WRITE_TABLESPACE_HASH_LOCK;
+	tablespaceDirEntry =
+		PersistentTablespace_CreateEntryUnderLock(filespaceOid, tablespaceOid);
+	Assert(tablespaceDirEntry != NULL);
+	tablespaceDirEntry->state = PersistentFileSysState_Created;
+	ItemPointerCopy(&persistentTid, &tablespaceDirEntry->persistentTid);
+	tablespaceDirEntry->persistentSerialNum = persistentSerialNum;
+	WRITE_TABLESPACE_HASH_UNLOCK;
+
 	WRITE_PERSISTENT_STATE_ORDERED_UNLOCK;
 	
 	if (Debug_persistent_print)
@@ -818,9 +795,8 @@ void PersistentTablespace_Created(
 
 	WRITE_PERSISTENT_STATE_ORDERED_LOCK;
 
-	tablespaceDirEntry = 
-				PersistentTablespace_FindEntryUnderLock(
-												tablespaceOid);
+	WRITE_TABLESPACE_HASH_LOCK;
+	tablespaceDirEntry = PersistentTablespace_FindEntryUnderLock(tablespaceOid);
 	if (tablespaceDirEntry == NULL)
 		elog(ERROR, "Did not find persistent tablespace entry %u", 
 			 tablespaceOid);
@@ -829,6 +805,9 @@ void PersistentTablespace_Created(
 		elog(ERROR, "Persistent tablespace entry %u expected to be in 'Create Pending' state (actual state '%s')", 
 			 tablespaceOid,
 			 PersistentFileSysObjState_Name(tablespaceDirEntry->state));
+
+	tablespaceDirEntry->state = PersistentFileSysState_Created;
+	WRITE_TABLESPACE_HASH_UNLOCK;
 
 	stateChangeResult =
 		PersistentFileSysObj_StateChange(
@@ -840,8 +819,6 @@ void PersistentTablespace_Created(
 								/* flushToXlog */ false,
 								/* oldState */ NULL,
 								/* verifiedActionCallback */ NULL);
-
-	tablespaceDirEntry->state = PersistentFileSysState_Created;
 
 	WRITE_PERSISTENT_STATE_ORDERED_UNLOCK;
 
@@ -870,27 +847,36 @@ PersistentTablespace_RemoveSegment(int16 dbid, bool ismirror)
 
 	WRITE_PERSISTENT_STATE_ORDERED_LOCK;
 
+	/*
+	 * Writes to the shared tablespace hash table are protected by
+	 * PersistentObjLock, which is held at this point.  The tablespace hash
+	 * therefore, can be read without acquiring TablespaceHashLock because we
+	 * are not making any change to the hash table in this function.
+	 */
 	while ((tablespaceDirEntry = hash_seq_search(&hstat)) != NULL)
 	{
 		PersistentFileSysObjName fsObjName;
 		Oid tblspc = tablespaceDirEntry->key.tablespaceOid;
+		ItemPointerData persistentTid;
+		uint64 persistentSerialNum;
 
 		tablespaceDirEntry = PersistentTablespace_FindEntryUnderLock(tblspc);
 
 		if (tablespaceDirEntry == NULL)
 			elog(ERROR, "Did not find persistent tablespace entry %u", 
 				 tblspc);
-
+		persistentSerialNum = tablespaceDirEntry->persistentSerialNum;
+		ItemPointerCopy(&tablespaceDirEntry->persistentTid, &persistentTid);
+		
         PersistentFileSysObjName_SetTablespaceDir(&fsObjName, tblspc);
 
 	    PersistentFileSysObj_RemoveSegment(&fsObjName,
-										   &tablespaceDirEntry->persistentTid,
-										   tablespaceDirEntry->persistentSerialNum,
+										   &persistentTid,
+										   persistentSerialNum,
 										   dbid,
 										   ismirror,
 										   /* flushToXlog */ false);
 	}
-
 	WRITE_PERSISTENT_STATE_ORDERED_UNLOCK;
 }
 
@@ -910,10 +896,13 @@ PersistentTablespace_ActivateStandby(int16 oldmaster, int16 newmaster)
 
 	WRITE_PERSISTENT_STATE_ORDERED_LOCK;
 
+	LWLockAcquire(TablespaceHashLock, LW_SHARED);
 	while ((tablespaceDirEntry = hash_seq_search(&hstat)) != NULL)
 	{
 		PersistentFileSysObjName fsObjName;
 		Oid tblspc = tablespaceDirEntry->key.tablespaceOid;
+		ItemPointerData persistentTid;
+		uint64 persistentSerialNum;
 
 		tablespaceDirEntry = PersistentTablespace_FindEntryUnderLock(tblspc);
 
@@ -921,15 +910,31 @@ PersistentTablespace_ActivateStandby(int16 oldmaster, int16 newmaster)
 			elog(ERROR, "cannot find persistent tablespace entry %u", 
 				 tblspc);
 
+		persistentSerialNum = tablespaceDirEntry->persistentSerialNum;
+		ItemPointerCopy(&tablespaceDirEntry->persistentTid, &persistentTid);
+		/*
+		 * We release TablespaceHashLock in the middle of the loop and re-acquire
+		 * it after doing persistent table change.  This is needed to prevent
+		 * holding the lock for any purpose other than to protect the tablespace
+		 * shared hash table.  Not releasing this lock could result in file I/O
+		 * and potential deadlock due to other LW locks being acquired in the
+		 * process.  Releasing the lock this way is safe because we are still
+		 * holding PersistentObjLock in exclusive mode.  Any change to the
+		 * filespace shared hash table is also protected by PersistentObjLock.
+		 */
+
+		LWLockRelease(TablespaceHashLock);
+
 		PersistentFileSysObjName_SetTablespaceDir(&fsObjName, tblspc);
 		PersistentFileSysObj_ActivateStandby(&fsObjName,
-								   &tablespaceDirEntry->persistentTid,
-								   tablespaceDirEntry->persistentSerialNum,
+								   &persistentTid,
+								   persistentSerialNum,
 								   oldmaster,
 								   newmaster,
 								   /* flushToXlog */ false);
+		LWLockAcquire(TablespaceHashLock, LW_SHARED);
 	}
-
+	LWLockRelease(TablespaceHashLock);
 	WRITE_PERSISTENT_STATE_ORDERED_UNLOCK;
 }
 
@@ -951,10 +956,13 @@ PersistentTablespace_AddMirrorAll(
 
 	WRITE_PERSISTENT_STATE_ORDERED_LOCK;
 
+	LWLockAcquire(TablespaceHashLock, LW_SHARED);
 	while ((tablespaceDirEntry = hash_seq_search(&hstat)) != NULL)
 	{
 		PersistentFileSysObjName fsObjName;
 		Oid tblspc = tablespaceDirEntry->key.tablespaceOid;
+		ItemPointerData persistentTid;
+		uint64 persistentSerialNum;
 
 		tablespaceDirEntry = PersistentTablespace_FindEntryUnderLock(tblspc);
 
@@ -962,18 +970,33 @@ PersistentTablespace_AddMirrorAll(
 			elog(ERROR, "Did not find persistent tablespace entry %u", 
 				 tblspc);
 
+		persistentSerialNum = tablespaceDirEntry->persistentSerialNum;
+		ItemPointerCopy(&tablespaceDirEntry->persistentTid, &persistentTid);
+		/*
+		 * We release TablespaceHashLock in the middle of the loop and re-acquire
+		 * it after doing persistent table change.  This is needed to prevent
+		 * holding the lock for any purpose other than to protect the tablespace
+		 * shared hash table.  Not releasing this lock could result in file I/O
+		 * and potential deadlock due to other LW locks being acquired in the
+		 * process.  Releasing the lock this way is safe because we are still
+		 * holding PersistentObjLock in exclusive mode.  Any change to the
+		 * filespace shared hash table is also protected by PersistentObjLock.
+		 */
+		LWLockRelease(TablespaceHashLock);
+
         PersistentFileSysObjName_SetTablespaceDir(&fsObjName, tblspc);
 
 	    PersistentFileSysObj_AddMirror(&fsObjName,
-    	                               &tablespaceDirEntry->persistentTid,
-        	                           tablespaceDirEntry->persistentSerialNum,
+    	                               &persistentTid,
+        	                           persistentSerialNum,
 									   pridbid,
             	                       mirdbid,
 									   NULL,
 									   true,
                     	               /* flushToXlog */ false);
+		LWLockAcquire(TablespaceHashLock, LW_SHARED);
 	}
-
+	LWLockRelease(TablespaceHashLock);
 	WRITE_PERSISTENT_STATE_ORDERED_UNLOCK;
 }
 
@@ -1024,9 +1047,8 @@ PersistentFileSysObjStateChangeResult PersistentTablespace_MarkDropPending(
 
 	WRITE_PERSISTENT_STATE_ORDERED_LOCK;
 
-	tablespaceDirEntry = 
-				PersistentTablespace_FindEntryUnderLock(
-												tablespaceOid);
+	WRITE_TABLESPACE_HASH_LOCK;
+	tablespaceDirEntry = PersistentTablespace_FindEntryUnderLock(tablespaceOid);
 	if (tablespaceDirEntry == NULL)
 		elog(ERROR, "Did not find persistent tablespace entry %u", 
 			 tablespaceOid);
@@ -1036,6 +1058,9 @@ PersistentFileSysObjStateChangeResult PersistentTablespace_MarkDropPending(
 		elog(ERROR, "Persistent tablespace entry %u expected to be in 'Create Pending' or 'Created' state (actual state '%s')", 
 			 tablespaceOid,
 			 PersistentFileSysObjState_Name(tablespaceDirEntry->state));
+
+	tablespaceDirEntry->state = PersistentFileSysState_DropPending;
+	WRITE_TABLESPACE_HASH_UNLOCK;
 
 	stateChangeResult =
 		PersistentFileSysObj_StateChange(
@@ -1048,8 +1073,6 @@ PersistentFileSysObjStateChangeResult PersistentTablespace_MarkDropPending(
 								/* oldState */ NULL,
 								/* verifiedActionCallback */ NULL);
 
-	tablespaceDirEntry->state = PersistentFileSysState_DropPending;
-	
 	WRITE_PERSISTENT_STATE_ORDERED_UNLOCK;
 
 	if (Debug_persistent_print)
@@ -1104,9 +1127,8 @@ PersistentFileSysObjStateChangeResult PersistentTablespace_MarkAbortingCreate(
 
 	WRITE_PERSISTENT_STATE_ORDERED_LOCK;
 
-	tablespaceDirEntry = 
-				PersistentTablespace_FindEntryUnderLock(
-												tablespaceOid);
+	WRITE_TABLESPACE_HASH_LOCK;
+	tablespaceDirEntry = PersistentTablespace_FindEntryUnderLock(tablespaceOid);
 	if (tablespaceDirEntry == NULL)
 		elog(ERROR, "Did not find persistent tablespace entry %u", 
 			 tablespaceOid);
@@ -1115,6 +1137,9 @@ PersistentFileSysObjStateChangeResult PersistentTablespace_MarkAbortingCreate(
 		elog(ERROR, "Persistent tablespace entry %u expected to be in 'Create Pending' (actual state '%s')", 
 			 tablespaceOid,
 			 PersistentFileSysObjState_Name(tablespaceDirEntry->state));
+
+	tablespaceDirEntry->state = PersistentFileSysState_AbortingCreate;
+	WRITE_TABLESPACE_HASH_UNLOCK;
 
 	stateChangeResult =
 		PersistentFileSysObj_StateChange(
@@ -1127,8 +1152,6 @@ PersistentFileSysObjStateChangeResult PersistentTablespace_MarkAbortingCreate(
 								/* oldState */ NULL,
 								/* verifiedActionCallback */ NULL);
 
-	tablespaceDirEntry->state = PersistentFileSysState_AbortingCreate;
-		
 	WRITE_PERSISTENT_STATE_ORDERED_UNLOCK;
 
 	if (Debug_persistent_print)
@@ -1219,19 +1242,6 @@ void PersistentTablespace_Dropped(
 
 	WRITE_PERSISTENT_STATE_ORDERED_LOCK;
 
-	tablespaceDirEntry = 
-				PersistentTablespace_FindEntryUnderLock(
-												tablespaceOid);
-	if (tablespaceDirEntry == NULL)
-		elog(ERROR, "Did not find persistent tablespace entry %u", 
-			 tablespaceOid);
-
-	if (tablespaceDirEntry->state != PersistentFileSysState_DropPending &&
-		tablespaceDirEntry->state != PersistentFileSysState_AbortingCreate)
-		elog(ERROR, "Persistent tablespace entry %u expected to be in 'Drop Pending' or 'Aborting Create' (actual state '%s')", 
-			 tablespaceOid,
-			 PersistentFileSysObjState_Name(tablespaceDirEntry->state));
-
 	stateChangeResult =
 		PersistentFileSysObj_StateChange(
 								&fsObjName,
@@ -1243,9 +1253,21 @@ void PersistentTablespace_Dropped(
 								&oldState,
 								PersistentTablespace_DroppedVerifiedActionCallback);
 
-	tablespaceDirEntry->state = PersistentFileSysState_Free;
+	WRITE_TABLESPACE_HASH_LOCK;
+	tablespaceDirEntry = PersistentTablespace_FindEntryUnderLock(tablespaceOid);
+	if (tablespaceDirEntry == NULL)
+		elog(ERROR, "Did not find persistent tablespace entry %u", 
+			 tablespaceOid);
 
+	if (tablespaceDirEntry->state != PersistentFileSysState_DropPending &&
+		tablespaceDirEntry->state != PersistentFileSysState_AbortingCreate)
+		elog(ERROR, "Persistent tablespace entry %u expected to be in 'Drop Pending' or 'Aborting Create' (actual state '%s')", 
+			 tablespaceOid,
+			 PersistentFileSysObjState_Name(tablespaceDirEntry->state));
+
+	tablespaceDirEntry->state = PersistentFileSysState_Free;
 	PersistentTablespace_RemoveEntryUnderLock(tablespaceDirEntry);
+	WRITE_TABLESPACE_HASH_UNLOCK;
 
 	WRITE_PERSISTENT_STATE_ORDERED_UNLOCK;
 

--- a/src/backend/utils/gp/segadmin.c
+++ b/src/backend/utils/gp/segadmin.c
@@ -567,7 +567,7 @@ static void
 remove_segment_persistent_entries(int16 pridbid, seginfo *i)
 {
 	/*
-	 * Remove filespace entries in pg_filespace_entry and
+	 * Remove filespace references in pg_filespace_entry and
 	 * gp_persistent_filespace_node
 	 */
 	update_filespaces(pridbid, i, false, NULL);
@@ -588,7 +588,7 @@ remove_segment_persistent_entries(int16 pridbid, seginfo *i)
 	update_relations(pridbid, i, false);
 
 	/*
-	 * If we're adding a segment mirror, we need to dispatch to that
+	 * If we're removing a segment mirror, we need to dispatch to that
 	 * segment's primary.
 	 */
 	if (Gp_role == GP_ROLE_DISPATCH && i->db.role == SEGMENT_ROLE_MIRROR)

--- a/src/include/cdb/cdbpersistentfilespace.h
+++ b/src/include/cdb/cdbpersistentfilespace.h
@@ -14,6 +14,7 @@
 #include "cdb/cdbsharedoidsearch.h"
 #include "storage/itemptr.h"
 #include "cdb/cdbpersistentfilesysobj.h"
+#include "cdb/cdbpersistenttablespace.h"
 
 extern void PersistentFilespace_ConvertBlankPaddedLocation(
 	char 		**filespaceLocation,
@@ -31,17 +32,14 @@ extern void PersistentFilespace_LookupTidAndSerialNum(
 
 	int64			*persistentSerialNum);
 
-extern bool PersistentFilespace_TryGetPrimaryAndMirrorUnderLock(
-	Oid 		filespaceOid,
-				/* The filespace OID to lookup. */
 
-	char **primaryFilespaceLocation,
-				/* The primary filespace directory path.  Return NULL for global and base. */
-	
-	char **mirrorFilespaceLocation);
-				/* The primary filespace directory path.  Return NULL for global and base. 
-				 * Or, returns NULL when mirror not configured. */
-extern void PersistentFilespace_GetPrimaryAndMirrorUnderLock(
+extern PersistentTablespaceGetFilespaces
+PersistentFilespace_GetFilespaceFromTablespace(Oid tablespaceOid,
+											   char **primaryFilespaceLocation,
+											   char **mirrorFilespaceLocation,
+											   Oid *filespaceOid);
+
+extern bool PersistentFilespace_TryGetPrimaryAndMirror(
 	Oid 		filespaceOid,
 				/* The filespace OID to lookup. */
 

--- a/src/include/cdb/cdbpersistenttablespace.h
+++ b/src/include/cdb/cdbpersistenttablespace.h
@@ -41,7 +41,26 @@ typedef enum PersistentTablespaceGetFilespaces
 	PersistentTablespaceGetFilespaces_FilespaceNotFound,
 	MaxPersistentTablespaceGetFilespaces /* must always be last */
 } PersistentTablespaceGetFilespaces;
-				
+
+typedef struct TablespaceDirEntryKey
+{
+	Oid	tablespaceOid;
+} TablespaceDirEntryKey;
+
+typedef struct TablespaceDirEntryData
+{
+	TablespaceDirEntryKey	key;
+
+	Oid						filespaceOid;
+
+	PersistentFileSysState	state;
+	int64					persistentSerialNum;
+	ItemPointerData 		persistentTid;
+	
+} TablespaceDirEntryData;
+typedef TablespaceDirEntryData *TablespaceDirEntry;
+extern HTAB *persistentTablespaceSharedHashTable;
+
 extern PersistentTablespaceGetFilespaces PersistentTablespace_TryGetPrimaryAndMirrorFilespaces(
 	Oid 		tablespaceOid,
 				/* The tablespace OID for the create. */

--- a/src/include/storage/lwlock.h
+++ b/src/include/storage/lwlock.h
@@ -99,6 +99,8 @@ typedef enum LWLockId
 	FirstLockMgrLock = FirstBufMappingLock + NUM_BUFFER_PARTITIONS,
 	SessionStateLock = FirstLockMgrLock + NUM_LOCK_PARTITIONS,
 	RelfilenodeGenLock,
+	FilespaceHashLock,
+	TablespaceHashLock,
 
 	/* must be last except for MaxDynamicLWLock: */
 	NumFixedLWLocks,

--- a/src/test/isolation2/Makefile
+++ b/src/test/isolation2/Makefile
@@ -6,6 +6,10 @@ subdir = src/test/isolation2
 top_builddir = ../../..
 include $(top_builddir)/src/Makefile.global
 
+NAME = isolation2_regress
+OBJS = isolation2_regress.o
+include $(top_srcdir)/src/Makefile.shlib
+
 # where to find psql for testing an existing installation
 PSQLDIR = $(bindir)
 
@@ -16,7 +20,7 @@ endif
 override CPPFLAGS := -I$(srcdir) -I$(libpq_srcdir) -I$(srcdir)/../regress $(CPPFLAGS)
 override LDLIBS := $(libpq_pgport) $(LDLIBS)
 
-all: pg_isolation2_regress$(X)
+all: pg_isolation2_regress$(X) all-lib
 
 pg_regress.o:
 	$(MAKE) -C $(top_builddir)/src/test/regress pg_regress.o

--- a/src/test/isolation2/input/pt_io_in_progress_deadlock.source
+++ b/src/test/isolation2/input/pt_io_in_progress_deadlock.source
@@ -1,0 +1,59 @@
+--
+-- Validate that PersistentObjLock is not acquired while io_in_progress lock is
+-- held on a buffer.
+--
+
+create extension if not exists gp_inject_fault;
+
+create function flush_relation_buffers(oid)
+   returns void
+   as '@abs_builddir@/isolation2_regress@DLSUFFIX@'
+   language c immutable strict no sql;
+
+-- We need a user defined filespace because the filespace and tablespace hash
+-- tables are ignored when accessing tables in the default/system tablespace.
+create filespace pt_deadlock_fs @gpfilespace_regressionfs1@;
+create tablespace pt_deadlock_ts filespace pt_deadlock_fs;
+create table pt_deadlock_table (a int, b int) tablespace pt_deadlock_ts;
+
+-- We want to flush a buffer through this test, so suspend checkpointer and
+-- bgwriter processes.
+select gp_inject_fault('checkpoint', 'suspend', dbid) from
+ gp_segment_configuration where role = 'p' and content > -1;
+select gp_inject_fault('fault_in_background_writer_main', 'suspend', dbid)
+ from gp_segment_configuration where role = 'p' and content > -1;
+
+insert into pt_deadlock_table select i,i from generate_series(1,1000)i;
+
+-- By suspending fault_before_pending_delete_relation_entry here, the query
+-- executor will be suspended while holding the PersistentObjLock on the
+-- segments.
+select gp_inject_fault('fault_before_pending_delete_relation_entry', 'suspend', dbid)
+ from gp_segment_configuration where role = 'p' and content > -1;
+
+-- Backend 1 obtains PersistentObjLock and blocks.
+1&: create table acquire_pt_lock_table (a int) distributed by (a);
+
+select gp_inject_fault('fault_before_pending_delete_relation_entry', 'status', dbid)
+ from gp_segment_configuration where role = 'p' and content > -1;
+
+-- Backend 2 flushes the dirty buffers in the pt_deadlock_table, and as a result
+-- will attempt to access the filespace and tablespace hash tables. It will
+-- acquire io_in_progress lock before accessing the hash tables, and will block
+-- if it also attempts to acquire PersistentObjLock.
+2: select flush_relation_buffers(oid) from gp_dist_random('pg_class') where relname = 'pt_deadlock_table';
+
+-- The fact that backend 2 completed flushing the relation buffers indicates
+-- that this test was successful.
+
+-- Clean up faults
+select gp_inject_fault('all', 'reset', dbid)
+ from gp_segment_configuration where role = 'p' and content > -1;
+
+1<:
+
+-- Because filespaces persist through database drop, we need to clean up the
+-- filespace/tablespace explicitly.
+drop table pt_deadlock_table;
+drop tablespace pt_deadlock_ts;
+drop filespace pt_deadlock_fs;

--- a/src/test/isolation2/isolation2_regress.c
+++ b/src/test/isolation2/isolation2_regress.c
@@ -1,0 +1,22 @@
+#include "postgres.h"
+#include "funcapi.h"
+#include "tablefuncapi.h"
+#include "miscadmin.h"
+
+#include "access/heapam.h"
+#include "storage/bufmgr.h"
+
+PG_MODULE_MAGIC;
+
+extern void flush_relation_buffers(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(flush_relation_buffers);
+
+void
+flush_relation_buffers(PG_FUNCTION_ARGS)
+{
+	Oid relid = PG_GETARG_OID(0);
+	Relation r = heap_open(relid, AccessShareLock);
+	FlushRelationBuffers(r);
+	heap_close(r, AccessShareLock);
+}
+

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -1,3 +1,4 @@
+test: pt_io_in_progress_deadlock
 test: pg_terminate_backend
 test: deadlock_under_entry_db_singleton
 test: starve_case

--- a/src/test/isolation2/output/pt_io_in_progress_deadlock.source
+++ b/src/test/isolation2/output/pt_io_in_progress_deadlock.source
@@ -1,0 +1,97 @@
+--
+-- Validate that PersistentObjLock is not acquired while io_in_progress lock is
+-- held on a buffer.
+--
+
+create extension if not exists gp_inject_fault;
+CREATE
+
+create function flush_relation_buffers(oid) returns void as '@abs_builddir@/isolation2_regress@DLSUFFIX@' language c immutable strict no sql;
+CREATE
+
+-- We need a user defined filespace because the filespace and tablespace hash
+-- tables are ignored when accessing tables in the default/system tablespace.
+create filespace pt_deadlock_fs @gpfilespace_regressionfs1@;
+CREATE
+create tablespace pt_deadlock_ts filespace pt_deadlock_fs;
+CREATE
+create table pt_deadlock_table (a int, b int) tablespace pt_deadlock_ts;
+CREATE
+
+-- We want to flush a buffer through this test, so suspend checkpointer and
+-- bgwriter processes.
+select gp_inject_fault('checkpoint', 'suspend', dbid) from gp_segment_configuration where role = 'p' and content > -1;
+gp_inject_fault
+---------------
+t              
+t              
+t              
+(3 rows)
+select gp_inject_fault('fault_in_background_writer_main', 'suspend', dbid) from gp_segment_configuration where role = 'p' and content > -1;
+gp_inject_fault
+---------------
+t              
+t              
+t              
+(3 rows)
+
+insert into pt_deadlock_table select i,i from generate_series(1,1000)i;
+INSERT 1000
+
+-- By suspending fault_before_pending_delete_relation_entry here, the query
+-- executor will be suspended while holding the PersistentObjLock on the
+-- segments.
+select gp_inject_fault('fault_before_pending_delete_relation_entry', 'suspend', dbid) from gp_segment_configuration where role = 'p' and content > -1;
+gp_inject_fault
+---------------
+t              
+t              
+t              
+(3 rows)
+
+-- Backend 1 obtains PersistentObjLock and blocks.
+1&: create table acquire_pt_lock_table (a int) distributed by (a);  <waiting ...>
+
+select gp_inject_fault('fault_before_pending_delete_relation_entry', 'status', dbid) from gp_segment_configuration where role = 'p' and content > -1;
+gp_inject_fault
+---------------
+t              
+t              
+t              
+(3 rows)
+
+-- Backend 2 flushes the dirty buffers in the pt_deadlock_table, and as a result
+-- will attempt to access the filespace and tablespace hash tables. It will
+-- acquire io_in_progress lock before accessing the hash tables, and will block
+-- if it also attempts to acquire PersistentObjLock.
+2: select flush_relation_buffers(oid) from gp_dist_random('pg_class') where relname = 'pt_deadlock_table';
+flush_relation_buffers
+----------------------
+                      
+                      
+                      
+(3 rows)
+
+-- The fact that backend 2 completed flushing the relation buffers indicates
+-- that this test was successful.
+
+-- Clean up faults
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration where role = 'p' and content > -1;
+gp_inject_fault
+---------------
+t              
+t              
+t              
+(3 rows)
+
+1<:  <... completed>
+CREATE
+
+-- Because filespaces persist through database drop, we need to clean up the
+-- filespace/tablespace explicitly.
+drop table pt_deadlock_table;
+DROP
+drop tablespace pt_deadlock_ts;
+DROP
+drop filespace pt_deadlock_fs;
+DROP


### PR DESCRIPTION
This is the cleaned/squashed/rebased PR based on https://github.com/greenplum-db/gpdb/pull/2919.

Adds two new LW locks to protect filespace and tablespace hash tables
to disambiguate them from `PersistentObjLock`. Previously, `PersistentObjLock` was
overloaded to both protect these hash tables along with persistent heap tables.
If two backends try to flush the same dirty buffer, a deadlock could
potentially arise in which backend 1 holds `PersistentObjLock` and requests
`io_in_progress` lock of the buffer to be evicted.  Backend 2 holds
`io_in_progress` lock on the same buffer and attempts to obtain file path.
Because the file path is in hash tables protected by `PersistentObjLock`, backend
2 requests `PersistentObjLock` and blocks due to backend 1.