### PR TITLE
Silence compiler warning about unused function, 2nd attempt.

### DIFF
--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -4171,7 +4171,7 @@ make_valuesscan(List *qptlist,
 	return node;
 }
 
-static CteScan * pg_attribute_unused()
+static pg_attribute_unused() CteScan *
 make_ctescan(List *qptlist,
 			 List *qpqual,
 			 Index scanrelid,


### PR DESCRIPTION
Commit e40e78fabb9 added the "unused" attribute to the function, but it
didn't have any effect. It seems that for a function that returns a pointer,
the attribute must be placed before the "*" indicating that the return type
is a pointer. Go figure..