### PR TITLE
Fix assertion failure (or incorrect behavior) in a planner corner-case.

### DIFF
--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -2021,7 +2021,7 @@ create_indexscan_plan(PlannerInfo *root,
 			if (best_path->indexinfo->indpred)
 			{
 				if (baserelid != root->parse->resultRelation &&
-					!list_member_int(root->parse->rowMarks, baserelid))
+					get_rowmark(root->parse, baserelid) == NULL)
 					if (predicate_implied_by(clausel,
 											 best_path->indexinfo->indpred))
 						continue;

--- a/src/test/regress/expected/bfv_planner.out
+++ b/src/test/regress/expected/bfv_planner.out
@@ -239,6 +239,22 @@ select * from booltest a, booltest b where (a.b = b.b) is not false;
  t | t
 (4 rows)
 
+-- Lossy index qual, used as a partial index predicate, and same column is
+-- used in FOR SHARE. Once upon a time, this happened to tickle a bug in the
+-- planner at one point.
+create table tstest (t tsvector);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+create index i_tstest on tstest using gist (t) WHERE t @@ 'bar';
+insert into tstest values ('foo');
+insert into tstest values ('bar');
+set enable_bitmapscan =off;
+set enable_seqscan =off;
+select * from tstest where t @@ 'bar' for share of tstest;
+   t   
+-------
+ 'bar'
+(1 row)
+
 -- start_ignore
 drop table if exists bfv_planner_x;
 drop table if exists testbadsql;

--- a/src/test/regress/sql/bfv_planner.sql
+++ b/src/test/regress/sql/bfv_planner.sql
@@ -157,6 +157,18 @@ insert into booltest values ('t');
 insert into booltest values (null);
 select * from booltest a, booltest b where (a.b = b.b) is not false;
 
+-- Lossy index qual, used as a partial index predicate, and same column is
+-- used in FOR SHARE. Once upon a time, this happened to tickle a bug in the
+-- planner at one point.
+create table tstest (t tsvector);
+create index i_tstest on tstest using gist (t) WHERE t @@ 'bar';
+insert into tstest values ('foo');
+insert into tstest values ('bar');
+
+set enable_bitmapscan =off;
+set enable_seqscan =off;
+select * from tstest where t @@ 'bar' for share of tstest;
+
 
 -- start_ignore
 drop table if exists bfv_planner_x;


### PR DESCRIPTION
It almost seems like when we merge with PostgreSQL 8.2 (sic), we missed
this one line from commit 986085a7f0. Before that, the rowMarks list was
a list of integers, but now it's a list of RowMarkClauses.