### PR TITLE
[150314466] fix assertion bug for pxfprotocol test

### DIFF
--- a/gpAux/extensions/pxf/test/pxfprotocol_test.c
+++ b/gpAux/extensions/pxf/test/pxfprotocol_test.c
@@ -107,6 +107,7 @@ test_pxfprotocol_import_first_call(void **state)
 
     /* set mock behavior for uri parsing */
     GPHDUri* gphd_uri = palloc0(sizeof(GPHDUri));
+    gphd_uri->fragments = palloc(sizeof(List));
     expect_string(parseGPHDUri, uri_str, uri_param_segwork);
     will_return(parseGPHDUri, gphd_uri);
 


### PR DESCRIPTION
Fix bug for this issue: https://github.com/greenplum-db/gpdb/issues/2964
Added mock for gphd_uri->fragments so that it won't fail assertion in create_context of pxfprotocol.c