### PR TITLE
Map \dx+ command to \dx, until PostgreSQL 9.1.

### DIFF
--- a/src/bin/psql/describe.c
+++ b/src/bin/psql/describe.c
@@ -4189,6 +4189,17 @@ listExtensionContents(const char *pattern)
 		return true;
 	}
 
+	/*
+	 * GPDB_91_MERGE_FIXME: We don't have the pg_desribe_object function,
+	 * needed for \dx+, in GPDB yet. We will get it when we merge with
+	 * PostgreSQL 9.1 (or if we decide to cherry-pick it earlier). Until
+	 * then, print the same as plain \dx does.
+	 */
+	if (pset.sversion < 90100)
+	{
+		return listExtensions(pattern);
+	}
+
 	initPQExpBuffer(&buf);
 	printfPQExpBuffer(&buf,
 					  "SELECT e.extname, e.oid\n"

--- a/src/test/regress/expected/psql_gp_commands.out
+++ b/src/test/regress/expected/psql_gp_commands.out
@@ -1,4 +1,24 @@
 --
+-- Test \dx and \dx+, to display extensions.
+--
+-- We just use gp_inject_fault as an example of an extension here. We don't
+-- inject any faults.
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+\dx gp_inject*
+                           List of installed extensions
+      Name       | Version | Schema |                 Description                  
+-----------------+---------+--------+----------------------------------------------
+ gp_inject_fault | 1.0     | public | simulate various faults for testing purposes
+(1 row)
+
+\dx+ gp_inject*
+                           List of installed extensions
+      Name       | Version | Schema |                 Description                  
+-----------------+---------+--------+----------------------------------------------
+ gp_inject_fault | 1.0     | public | simulate various faults for testing purposes
+(1 row)
+
+--
 -- Test extended \du flags
 --
 -- https://github.com/greenplum-db/gpdb/issues/1028
@@ -66,7 +86,7 @@ CREATE ROLE test_psql_du_e5 WITH SUPERUSER CREATEEXTTABLE (type = 'readable', pr
  test_psql_du_e5 | Superuser, Ext http Table, Cannot login | {}
 
 DROP ROLE test_psql_du_e5;
--- does dot exist
+-- does not exist
 CREATE ROLE test_psql_du_e6 WITH SUPERUSER CREATEEXTTABLE (type = 'writable', protocol = 'http');
 ERROR:  invalid CREATEEXTTABLE specification. writable http external tables do not exist
 \du test_psql_du_e6

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -179,7 +179,7 @@ test: ao_checksum_corruption AOCO_Compression2 table_statistics
 test: metadata_track
 test: workfile_mgr_test
 
-# Test psql \du output
-test: psql_gpdb_du
+# Test psql backslash commands
+test: psql_gp_commands
 
 # end of tests

--- a/src/test/regress/sql/psql_gp_commands.sql
+++ b/src/test/regress/sql/psql_gp_commands.sql
@@ -1,4 +1,15 @@
 --
+-- Test \dx and \dx+, to display extensions.
+--
+-- We just use gp_inject_fault as an example of an extension here. We don't
+-- inject any faults.
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+
+\dx gp_inject*
+\dx+ gp_inject*
+
+
+--
 -- Test extended \du flags
 --
 -- https://github.com/greenplum-db/gpdb/issues/1028
@@ -40,7 +51,7 @@ CREATE ROLE test_psql_du_e5 WITH SUPERUSER CREATEEXTTABLE (type = 'readable', pr
 \du test_psql_du_e5
 DROP ROLE test_psql_du_e5;
 
--- does dot exist
+-- does not exist
 CREATE ROLE test_psql_du_e6 WITH SUPERUSER CREATEEXTTABLE (type = 'writable', protocol = 'http');
 \du test_psql_du_e6
 DROP ROLE test_psql_du_e6;


### PR DESCRIPTION
The \dx+ command requires pg_describe_object() function, which we don't
have in GPDB yet. Until then, treat \dx+ the same as \dx.

Note that this code is written such that \dx+ can still be used, when
connected to a PostgreSQL 9.1 or later server. Not that we particularly care
about that case, but might as well.

Per github issue #2574.