### PR TITLE
Remove nonexisting, and add required, files to releng lists

### DIFF
--- a/gpAux/releng/NON_PRODUCTION_FILES.txt
+++ b/gpAux/releng/NON_PRODUCTION_FILES.txt
@@ -1,16 +1,8 @@
-bin/UPDATE_INFO
 bin/explain.pl
-bin/gp
-bin/gpaddmirrors.py
-bin/gpdbupgrade
+bin/explain.pm
+bin/gpaddmirrors
 bin/gpfaultinjector
-bin/gpha
-bin/gpma
-bin/gppaxos
-bin/gpprintdbsizes
-bin/gprecoverseg.py
 bin/gptorment.pl
-bin/gpugcluster
 bin/lib/gpgetconfig.py
 bin/lib/gptest.py
 bin/pgbench
@@ -18,4 +10,3 @@ bin/postgresql_conf_gp_additions
 bin/run_operator_tests.pl
 bin/test_fsync
 lib/python/gppylib/programs/clsInjectFault.py
-

--- a/gpAux/releng/QAUTILS_FILES.txt
+++ b/gpAux/releng/QAUTILS_FILES.txt
@@ -1,4 +1,5 @@
 bin/explain.pl
+bin/explain.pm
 bin/gpcheckmirrorseg.pl
 bin/gpfaultinjector
 bin/gptorment.pl


### PR DESCRIPTION
Found while looking at these files for another reason. The releng NON_PRODUCTION_FILES.txt and QAUTILS_FILES.txt were referencing quite a few apps that were removed a long time ago (some of them in the 3.x cycle). Also, the Perl module split in 5.x has made explain in this list not work since it lacked the corresponding module.

This removes the dead files and adds the required ones.

@pivotal-mike 