### PR TITLE
Couple of Persistent table fixes

### DIFF
--- a/src/backend/cdb/cdbpersistentbuild.c
+++ b/src/backend/cdb/cdbpersistentbuild.c
@@ -904,6 +904,7 @@ PersistentBuild_TruncateAllGpRelationNode(void)
 
 		btree_metapage = (Page)palloc(BLCKSZ);
 		_bt_initmetapage(btree_metapage, P_NONE, 0);
+		PageSetChecksumInplace(btree_metapage, 0);
 		smgrwrite(
 			smgrRelation, 
 			/* blockNum */ 0, 

--- a/src/backend/utils/gp/persistentutil.c
+++ b/src/backend/utils/gp/persistentutil.c
@@ -251,6 +251,7 @@ gp_delete_persistent_filespace_node_entry(PG_FUNCTION_ARGS)
 	PersistentFileSysObjData			*fileSysObjData;
 	PersistentFileSysObjSharedData		*fileSysObjSharedData;
 	ItemPointer							 tid;
+	WRITE_PERSISTENT_STATE_ORDERED_LOCK_DECLARE;
 
 	/* Must be super user */
 	if (!superuser())
@@ -267,11 +268,14 @@ gp_delete_persistent_filespace_node_entry(PG_FUNCTION_ARGS)
 	PersistentFileSysObj_GetDataPtrs(fileSysObjType, 
 									 &fileSysObjData, 
 									 &fileSysObjSharedData);
+
+	WRITE_PERSISTENT_STATE_ORDERED_LOCK;
 	PersistentFileSysObj_FreeTuple(fileSysObjData,
 								   fileSysObjSharedData,
 								   fileSysObjType,
 								   tid,
 								   true  /* flushToXLog */);
+	WRITE_PERSISTENT_STATE_ORDERED_UNLOCK;
 
 	PG_RETURN_BOOL(true);
 }
@@ -283,6 +287,7 @@ gp_delete_persistent_tablespace_node_entry(PG_FUNCTION_ARGS)
 	PersistentFileSysObjData			*fileSysObjData;
 	PersistentFileSysObjSharedData		*fileSysObjSharedData;
 	ItemPointer							 tid;
+	WRITE_PERSISTENT_STATE_ORDERED_LOCK_DECLARE;
 
 	/* Must be super user */
 	if (!superuser())
@@ -299,11 +304,14 @@ gp_delete_persistent_tablespace_node_entry(PG_FUNCTION_ARGS)
 	PersistentFileSysObj_GetDataPtrs(fileSysObjType, 
 									 &fileSysObjData, 
 									 &fileSysObjSharedData);
+
+	WRITE_PERSISTENT_STATE_ORDERED_LOCK;
 	PersistentFileSysObj_FreeTuple(fileSysObjData,
 								   fileSysObjSharedData,
 								   fileSysObjType,
 								   tid,
 								   true  /* flushToXLog */);
+	WRITE_PERSISTENT_STATE_ORDERED_UNLOCK;
 
 	PG_RETURN_BOOL(true);
 }
@@ -315,6 +323,7 @@ gp_delete_persistent_database_node_entry(PG_FUNCTION_ARGS)
 	PersistentFileSysObjData			*fileSysObjData;
 	PersistentFileSysObjSharedData		*fileSysObjSharedData;
 	ItemPointer							 tid;
+	WRITE_PERSISTENT_STATE_ORDERED_LOCK_DECLARE;
 
 	/* Must be super user */
 	if (!superuser())
@@ -331,11 +340,14 @@ gp_delete_persistent_database_node_entry(PG_FUNCTION_ARGS)
 	PersistentFileSysObj_GetDataPtrs(fileSysObjType, 
 									 &fileSysObjData, 
 									 &fileSysObjSharedData);
+
+	WRITE_PERSISTENT_STATE_ORDERED_LOCK;
 	PersistentFileSysObj_FreeTuple(fileSysObjData,
 								   fileSysObjSharedData,
 								   fileSysObjType,
 								   tid,
 								   true  /* flushToXLog */);
+	WRITE_PERSISTENT_STATE_ORDERED_UNLOCK;
 
 	PG_RETURN_BOOL(true);
 }
@@ -347,6 +359,7 @@ gp_delete_persistent_relation_node_entry(PG_FUNCTION_ARGS)
 	PersistentFileSysObjData			*fileSysObjData;
 	PersistentFileSysObjSharedData		*fileSysObjSharedData;
 	ItemPointer							 tid;
+	WRITE_PERSISTENT_STATE_ORDERED_LOCK_DECLARE;
 
 	/* Must be super user */
 	if (!superuser())
@@ -363,11 +376,14 @@ gp_delete_persistent_relation_node_entry(PG_FUNCTION_ARGS)
 	PersistentFileSysObj_GetDataPtrs(fileSysObjType, 
 									 &fileSysObjData, 
 									 &fileSysObjSharedData);
+
+	WRITE_PERSISTENT_STATE_ORDERED_LOCK;
 	PersistentFileSysObj_FreeTuple(fileSysObjData,
 								   fileSysObjSharedData,
 								   fileSysObjType,
 								   tid,
 								   true  /* flushToXLog */);
+	WRITE_PERSISTENT_STATE_ORDERED_UNLOCK;
 
 	PG_RETURN_BOOL(true);
 }


### PR DESCRIPTION

    Acquire PersistentObjLock in gp_delete_persistent_*_node_entry()

    gp_delete_persistent_*_node_entry() are currently only used for testing but with
    asserts enabled fail as do not acquire PersistentObjLock. Since they are
    modifying the persistent tables should be protected by `PersistentObjLock`.

-------------------------
    Calculate checksum during persistent table reset_all.

    When `gp_persistent_reset_all()` is called, gp_relation_node index is truncated
    and while writing meta-page checksum calculation was missed. Ideally, following
    `gp_persistent_build_all()` fixes the same and correctly builds the index and
    calculates the checksum file. Better to get proper message like "ERROR: Did not
    find gp_relation_node entry for relation name....." on operations after
    reset_all than page verification failed.