### PR TITLE
PXF Fragmenter Integration

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1525,6 +1525,12 @@ if test "$enable_mapreduce" = yes; then
   AC_CHECK_HEADERS(yaml.h, [], [AC_MSG_ERROR([YAML includes required for Greenplum Mapreduce])])
 fi
 
+# json-c
+AC_CHECK_HEADERS(json-c/json.h, [], [AC_MSG_ERROR([header file <json-c/json.h> is required.
+Check config.log for details. It is possible the compiler isn't looking in the proper directory.])])
+AC_SEARCH_LIBS(json_tokener_parse, json-c json, [], [AC_MSG_ERROR([library 'json-c' is required.
+Check config.log for details. It is possible the compiler isn't looking in the proper directory.])], [])
+
 ##
 ## Types, structures, compiler characteristics
 ##

--- a/gpAux/extensions/pxf/Makefile
+++ b/gpAux/extensions/pxf/Makefile
@@ -1,7 +1,7 @@
 EXTENSION = pxf
 DATA = pxf--1.0.sql
 MODULE_big = pxf
-OBJS       = src/pxfprotocol.o src/pxfbridge.o src/pxfuriparser.o src/libchurl.o src/pxfutils.o src/pxfheaders.o
+OBJS       = src/pxfprotocol.o src/pxfbridge.o src/pxfuriparser.o src/libchurl.o src/pxfutils.o src/pxfheaders.o src/pxffragment.o
 REGRESS    = setup pxf pxfinvalid
 
 ifdef USE_PGXS
@@ -15,7 +15,7 @@ endif
 
 CURL_DIR = /usr/local/opt/curl
 
-SHLIB_LINK += -lcurl
+SHLIB_LINK += -lcurl -ljson-c
 
 unittest-check:
 	$(MAKE) -C test check

--- a/gpAux/extensions/pxf/src/libchurl.h
+++ b/gpAux/extensions/pxf/src/libchurl.h
@@ -144,5 +144,6 @@ void print_http_headers(CHURL_HEADERS headers);
 #define PxfServiceAddress "localhost:51200"
 #define LocalhostIpV4Entry ":127.0.0.1"
 #define LocalhostIpV4 "localhost"
+#define REST_HEADER_JSON_RESPONSE "Accept: application/json"
 
 #endif //_GPHDFS_LIBCHURL_H_

--- a/gpAux/extensions/pxf/src/pxfbridge.c
+++ b/gpAux/extensions/pxf/src/pxfbridge.c
@@ -20,6 +20,7 @@
 
 #include "pxfbridge.h"
 #include "pxfheaders.h"
+#include "pxffragment.h"
 
 /* helper function declarations */
 static void build_uri_for_read(gphadoop_context* context);
@@ -55,6 +56,8 @@ gpbridge_cleanup(gphadoop_context *context)
 void
 gpbridge_import_start(gphadoop_context *context)
 {
+    if (context->gphd_uri->fragments == NULL)
+        return;
 
     context->current_fragment = list_head(context->gphd_uri->fragments);
     build_uri_for_read(context);
@@ -76,6 +79,9 @@ int
 gpbridge_read(gphadoop_context *context, char *databuf, int datalen)
 {
     size_t n = 0;
+
+    if (context->gphd_uri->fragments == NULL)
+        return (int) n;
 
     while ((n = fill_buffer(context, databuf, datalen)) == 0)
     {

--- a/gpAux/extensions/pxf/src/pxfbridge.h
+++ b/gpAux/extensions/pxf/src/pxfbridge.h
@@ -21,11 +21,12 @@
 #ifndef _PXFBRIDGE_H
 #define _PXFBRIDGE_H
 
+#include "pxfuriparser.h"
+#include "libchurl.h"
+
 #include "postgres.h"
 #include "cdb/cdbvars.h"
-#include "libchurl.h"
 #include "nodes/pg_list.h"
-#include "pxfuriparser.h"
 
 /*
  * Context for single query execution by PXF bridge

--- a/gpAux/extensions/pxf/src/pxffragment.c
+++ b/gpAux/extensions/pxf/src/pxffragment.c
@@ -138,6 +138,7 @@ get_data_fragment_list(GPHDUri *hadoop_uri,
                        ClientContext *client_context)
 {
     List *data_fragments = NIL;
+    Assert(hadoop_uri->data != NULL);
     char *restMsg = concat(2, "http://%s:%s/%s/%s/Fragmenter/getFragments?path=", hadoop_uri->data);
 
     rest_request(hadoop_uri, client_context, restMsg);

--- a/gpAux/extensions/pxf/src/pxffragment.c
+++ b/gpAux/extensions/pxf/src/pxffragment.c
@@ -77,8 +77,9 @@ void get_fragments(GPHDUri *uri, Relation relation) {
 
     if ((FRAGDEBUG >= log_min_messages) || (FRAGDEBUG >= client_min_messages))
     {
-        elog(FRAGDEBUG, "Available Data fragments\n");
+        elog(FRAGDEBUG, "---Available Data fragments---\n");
         print_fragment_list(data_fragments);
+        elog(FRAGDEBUG, "------\n");
     }
 
     /*
@@ -95,8 +96,9 @@ void get_fragments(GPHDUri *uri, Relation relation) {
 
     if ((FRAGDEBUG >= log_min_messages) || (FRAGDEBUG >= client_min_messages))
     {
-        elog(FRAGDEBUG, "Allocated Data fragments\n");
+        elog(FRAGDEBUG, "---Allocated Data fragments---\n");
         print_fragment_list(data_fragments);
+        elog(FRAGDEBUG, "------\n");
     }
 
     uri->fragments = data_fragments;
@@ -147,7 +149,9 @@ get_data_fragment_list(GPHDUri *hadoop_uri,
 }
 
 /*
- * Wrap the REST call with a retry for the HA HDFS scenario
+ * Wrap the REST call.
+ * TODO: Add logic later to handle HDFS HA related exception
+ *       to failover with a retry for the HA HDFS scenario.
  */
 static void
 rest_request(GPHDUri *hadoop_uri, ClientContext* client_context, char *rest_msg)
@@ -192,27 +196,27 @@ parse_get_fragments_response(List *fragments, StringInfo rest_buf)
         struct json_object *js_fragment = json_object_array_get_idx(head, i);
         FragmentData* fragment = (FragmentData*)palloc0(sizeof(FragmentData));
 
-        /* 0. source name */
+        /* source name */
         struct json_object *block_data;
         if(json_object_object_get_ex(js_fragment, "sourceName", &block_data))
             fragment->source_name = pstrdup(json_object_get_string(block_data));
 
-        /* 1. fragment index, incremented per source name */
+        /* fragment index, incremented per source name */
         struct json_object *index;
         if(json_object_object_get_ex(js_fragment, "index", &index) && index)
             fragment->index = pstrdup(json_object_get_string(index));
 
-        /* 3. location - fragment meta data */
+        /* location - fragment meta data */
         struct json_object *js_fragment_metadata;
         if (json_object_object_get_ex(js_fragment, "metadata", &js_fragment_metadata) && js_fragment_metadata)
             fragment->fragment_md = pstrdup(json_object_get_string(js_fragment_metadata));
 
-        /* 4. userdata - additional user information */
+        /* userdata - additional user information */
         struct json_object *js_user_data;
         if (json_object_object_get_ex(js_fragment, "userData", &js_user_data) && js_user_data)
             fragment->user_data = pstrdup(json_object_get_string(js_user_data));
 
-        /* 5. profile - recommended profile to work with fragment */
+        /* profile - recommended profile to work with fragment */
         struct json_object *js_profile;
         if (json_object_object_get_ex(js_fragment, "profile", &js_profile) && js_profile)
             fragment->profile = pstrdup(json_object_get_string(js_profile));

--- a/gpAux/extensions/pxf/src/pxffragment.c
+++ b/gpAux/extensions/pxf/src/pxffragment.c
@@ -350,20 +350,11 @@ print_fragment_list(List *fragments)
         FragmentData	*frag	= (FragmentData*)lfirst(fragment_cell);
 
         appendStringInfo(&log_str, "Fragment index: %s\n", frag->index);
-
         appendStringInfo(&log_str, "authority: %s\n", frag->authority);
         appendStringInfo(&log_str, "source: %s\n", frag->source_name);
         appendStringInfo(&log_str, "metadata: %s\n", frag->fragment_md ? frag->fragment_md : "NULL");
-
-        if (frag->user_data)
-        {
-            appendStringInfo(&log_str, "user data: %s\n", frag->user_data);
-        }
-
-        if (frag->profile)
-        {
-            appendStringInfo(&log_str, "profile: %s\n", frag->profile);
-        }
+        appendStringInfo(&log_str, "user data: %s\n", frag->user_data ? frag->user_data : "NULL");
+        appendStringInfo(&log_str, "profile: %s\n", frag->profile ? frag->profile : "NULL");
     }
 
     elog(FRAGDEBUG, "%s", log_str.data);

--- a/gpAux/extensions/pxf/src/pxffragment.c
+++ b/gpAux/extensions/pxf/src/pxffragment.c
@@ -25,7 +25,7 @@
 #include "cdb/cdbvars.h"
 #include "commands/copy.h"
 #include "postgres.h"
-#include "../../../../src/include/lib/stringinfo.h"
+#include "lib/stringinfo.h"
 
 #include <json-c/json.h>
 
@@ -57,8 +57,6 @@ void get_fragments(GPHDUri *uri, Relation relation) {
      * 1. Initialize curl headers
      */
     init(uri, &client_context);
-    if (!uri)
-        return;
 
     /*
      * Enrich the curl HTTP header
@@ -305,8 +303,6 @@ static void init(GPHDUri* uri, ClientContext* cl_context)
 
     /* set HTTP header that guarantees response in JSON format */
     churl_headers_append(cl_context->http_headers, REST_HEADER_JSON_RESPONSE, NULL);
-    if (!cl_context->http_headers)
-        return;
 
     return;
 }

--- a/gpAux/extensions/pxf/src/pxffragment.c
+++ b/gpAux/extensions/pxf/src/pxffragment.c
@@ -1,0 +1,428 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#include <json-c/json.h>
+#include "postgres.h"
+#include "cdb/cdbtm.h"
+#include "cdb/cdbvars.h"
+#include "commands/copy.h"
+#include "pxffragment.h"
+
+static List* get_data_fragment_list(GPHDUri *hadoop_uri,  ClientContext* client_context);
+static void rest_request(GPHDUri *hadoop_uri, ClientContext* client_context, char *rest_msg);
+static List* parse_get_fragments_response(List *fragments, StringInfo rest_buf);
+static char* concat(int num_args, ...);
+static List* filter_fragments_for_segment(List* list);
+static void init(GPHDUri* uri, ClientContext* cl_context);
+static void print_fragment_list(List *fragments);
+static void init_client_context(ClientContext *client_context);
+static void assign_pxf_location_to_fragments(List *fragments);
+static void call_rest(GPHDUri *hadoop_uri, ClientContext *client_context, char *rest_msg);
+static void process_request(ClientContext* client_context, char *uri);
+
+/* Get List of fragments using PXF
+ * Returns selected fragments that have been allocated to the current segment
+ */
+void set_fragments(GPHDUri* uri, Relation relation) {
+
+	List *data_fragments = NIL;
+
+	/* Context for the Fragmenter API */
+	ClientContext client_context;
+	PxfInputData inputData = {0};
+
+	Assert(uri != NULL);
+
+	/*
+	 * 1. Initialize curl headers
+	 */
+	init(uri, &client_context);
+	if (!uri)
+		return;
+
+	/*
+	 * Enrich the curl HTTP header
+	 */
+	inputData.headers = client_context.http_headers;
+	inputData.gphduri = uri;
+	inputData.rel = relation;
+	build_http_headers(&inputData);
+
+	/*
+	 * Get the fragments data from the PXF service
+	 */
+	data_fragments = get_data_fragment_list(uri, &client_context);
+    if (data_fragments == NIL)
+        return;
+
+    if ((FRAGDEBUG >= log_min_messages) || (FRAGDEBUG >= client_min_messages))
+    {
+        elog(FRAGDEBUG, "Available Data fragments\n");
+        print_fragment_list(data_fragments);
+    }
+
+    /*
+	 * Call the work allocation algorithm
+	 */
+	data_fragments = filter_fragments_for_segment(data_fragments);
+
+    /*
+     * Assign PXF location for the allocated fragments
+     */
+    assign_pxf_location_to_fragments(data_fragments);
+
+    if ((FRAGDEBUG >= log_min_messages) || (FRAGDEBUG >= client_min_messages))
+    {
+        elog(FRAGDEBUG, "Allocated Data fragments\n");
+        print_fragment_list(data_fragments);
+    }
+
+	uri->fragments = data_fragments;
+
+	return;
+}
+
+/*
+ * Assign PXF Host for each Data Fragment
+ * Will use the same host as the existing segment as the PXF host.
+ */
+static void assign_pxf_location_to_fragments(List *fragments)
+{
+    ListCell *frag_c = NULL;
+    foreach(frag_c, fragments)
+    {
+        FragmentData 	*fragment	= (FragmentData*)lfirst(frag_c);
+        fragment->authority = concat(3, "localhost", ":", "51200");
+    }
+    return;
+}
+
+/*
+ * get_data_fragment_list
+ *
+ * 1. Request a list of fragments from the PXF Fragmenter class
+ * that was specified in the pxf URL.
+ *
+ * 2. Process the returned list and create a list of DataFragment with it.
+ */
+static List*
+get_data_fragment_list(GPHDUri *hadoop_uri,
+                       ClientContext *client_context)
+{
+    List *data_fragments = NIL;
+    char *restMsg = concat(2, "http://%s:%s/%s/%s/Fragmenter/getFragments?path=", hadoop_uri->data);
+
+    rest_request(hadoop_uri, client_context, restMsg);
+
+    /* parse the JSON response and form a fragments list to return */
+    data_fragments = parse_get_fragments_response(data_fragments, &(client_context->the_rest_buf));
+
+    return data_fragments;
+}
+
+/*
+ * Wrap the REST call with a retry for the HA HDFS scenario
+ */
+static void
+rest_request(GPHDUri *hadoop_uri, ClientContext* client_context, char *rest_msg)
+{
+    Assert(hadoop_uri->host != NULL && hadoop_uri->port != NULL);
+
+    /* construct the request */
+    call_rest(hadoop_uri, client_context, rest_msg);
+}
+
+/*
+ * parse the response of the PXF Fragments call. An example:
+ *
+ * Request:
+ * 		curl --header "X-GP-FRAGMENTER: HdfsDataFragmenter" "http://goldsa1mac.local:50070/pxf/v2/Fragmenter/getFragments?path=demo" (demo is a directory)
+ *
+ * Response (left as a single line purposefully):
+ * {"PXFFragments":[{"index":0,"userData":null,"sourceName":"demo/text2.csv","metadata":"rO0ABXcQAAAAAAAAAAAAAAAAAAAABXVyABNbTGphdmEubGFuZy5TdHJpbmc7rdJW5+kde0cCAAB4cAAAAAN0ABxhZXZjZWZlcm5hczdtYnAuY29ycC5lbWMuY29tdAAcYWV2Y2VmZXJuYXM3bWJwLmNvcnAuZW1jLmNvbXQAHGFldmNlZmVybmFzN21icC5jb3JwLmVtYy5jb20=","replicas":["10.207.4.23","10.207.4.23","10.207.4.23"]},{"index":0,"userData":null,"sourceName":"demo/text_csv.csv","metadata":"rO0ABXcQAAAAAAAAAAAAAAAAAAAABnVyABNbTGphdmEubGFuZy5TdHJpbmc7rdJW5+kde0cCAAB4cAAAAAN0ABxhZXZjZWZlcm5hczdtYnAuY29ycC5lbWMuY29tdAAcYWV2Y2VmZXJuYXM3bWJwLmNvcnAuZW1jLmNvbXQAHGFldmNlZmVybmFzN21icC5jb3JwLmVtYy5jb20=","replicas":["10.207.4.23","10.207.4.23","10.207.4.23"]}]}
+ */
+static List*
+parse_get_fragments_response(List *fragments, StringInfo rest_buf)
+{
+    struct json_object	*whole	= json_tokener_parse(rest_buf->data);
+    if ((whole == NULL) || is_error(whole))
+    {
+        elog(ERROR, "Failed to parse fragments list from PXF");
+    }
+    struct json_object	*head;
+	List* ret_frags = fragments;
+
+    if(!json_object_object_get_ex(whole, "PXFFragments", &head))
+	{
+		elog(INFO, "No Data Fragments available for the resource");
+		return ret_frags;
+	}
+
+	int length	= json_object_array_length(head);
+
+    /* obtain split information from the block */
+    for (int i = 0; i < length; i++)
+    {
+        struct json_object *js_fragment = json_object_array_get_idx(head, i);
+        FragmentData* fragment = (FragmentData*)palloc0(sizeof(FragmentData));
+
+        /* 0. source name */
+        struct json_object *block_data;
+        if(json_object_object_get_ex(js_fragment, "sourceName", &block_data))
+            fragment->source_name = pstrdup(json_object_get_string(block_data));
+
+        /* 1. fragment index, incremented per source name */
+        struct json_object *index;
+        if(json_object_object_get_ex(js_fragment, "index", &index) && index)
+            fragment->index = pstrdup(json_object_get_string(index));
+
+        /* 3. location - fragment meta data */
+        struct json_object *js_fragment_metadata;
+        if (json_object_object_get_ex(js_fragment, "metadata", &js_fragment_metadata) && js_fragment_metadata)
+            fragment->fragment_md = pstrdup(json_object_get_string(js_fragment_metadata));
+
+        /* 4. userdata - additional user information */
+        struct json_object *js_user_data;
+        if (json_object_object_get_ex(js_fragment, "userData", &js_user_data) && js_user_data)
+            fragment->user_data = pstrdup(json_object_get_string(js_user_data));
+
+        /* 5. profile - recommended profile to work with fragment */
+        struct json_object *js_profile;
+        if (json_object_object_get_ex(js_fragment, "profile", &js_profile) && js_profile)
+            fragment->profile = pstrdup(json_object_get_string(js_profile));
+
+        /*
+         * Ignore fragment if it doesn't contain any host locations,
+         * for example if the file is empty.
+         */
+        struct json_object *js_replica;
+        if (json_object_object_get_ex(js_fragment, "replicas", &js_replica) && js_replica)
+            ret_frags = lappend(ret_frags, fragment);
+        else
+            free_fragment(fragment);
+
+    }
+
+    return ret_frags;
+}
+
+/* Concatenate multiple literal strings using stringinfo */
+static char* concat(int num_args, ...)
+{
+    va_list ap;
+    StringInfoData str;
+    initStringInfo(&str);
+
+    va_start(ap, num_args);
+
+    for (int i = 0; i < num_args; i++) {
+        appendStringInfoString(&str, va_arg(ap, char*));
+    }
+    va_end(ap);
+
+    return str.data;
+}
+
+/*
+ * Takes a list of fragments and determines which ones need to be processes by the given segment based on MOD function.
+ * Removes the elements which will not be processed from the list and frees up their memory.
+ * Returns the resulting list, or NIL if no elements satisfy the condition.
+ */
+static List*
+filter_fragments_for_segment(List* list)
+{
+    if (!list)
+        ereport(ERROR,
+                (errcode(ERRCODE_INTERNAL_ERROR),
+                        errmsg("internal error in pxffragment.c:filter_fragments_for_segment. Parameter list is null.")));
+
+    DistributedTransactionId xid = getDistributedTransactionId();
+    if (xid == InvalidDistributedTransactionId)
+        ereport(ERROR,
+                (errcode_for_file_access(),
+                        errmsg("internal error in pxffragment.c:filter_fragments_for_segment. Cannot get distributed transaction identifier.")));
+
+    /*
+     * to determine which segment S should process an element at a given index I, use a randomized MOD function
+     * S = MOD(I + MOD(XID, N), N)
+     * which ensures more fair work distribution for small lists of just a few elements across N segments
+     * global transaction ID is used as a randomizer, as it is different for every query
+     * while being the same across all segments for a given query
+     */
+
+    List* result = list;
+    ListCell *previous = NULL, *current = NULL;
+
+    int index = 0;
+    int4 shift = xid % GpIdentity.numsegments;
+
+    for (current = list_head(list); current != NULL; index++)
+    {
+        if (GpIdentity.segindex == (index + shift) % GpIdentity.numsegments)
+        {
+            /* current segment is the one that should process, keep the element, adjust cursor pointers */
+            previous = current;
+            current = lnext(current);
+        }
+        else
+        {
+            /* current segment should not process this element, another will, drop the element from the list */
+            ListCell* to_delete = current;
+            if (to_delete->data.ptr_value)
+                free_fragment((FragmentData *) to_delete->data.ptr_value);
+            current = lnext(to_delete);
+            result = list_delete_cell(list, to_delete, previous);
+        }
+    }
+    return result;
+}
+
+/*
+ * Preliminary curl initializations for the REST communication
+ */
+static void init(GPHDUri* uri, ClientContext* cl_context)
+{
+    /*
+     * Communication with the Hadoop back-end
+     * Initialize churl client context and header
+     */
+    init_client_context(cl_context);
+    cl_context->http_headers = churl_headers_init();
+
+    /* set HTTP header that guarantees response in JSON format */
+    churl_headers_append(cl_context->http_headers, REST_HEADER_JSON_RESPONSE, NULL);
+    if (!cl_context->http_headers)
+        return;
+
+    return;
+}
+
+/*
+ * Debug function - print the splits data structure obtained from the namenode
+ * response to <GET_BLOCK_LOCATIONS> request
+ */
+static void
+print_fragment_list(List *fragments)
+{
+	ListCell *fragment_cell = NULL;
+	StringInfoData log_str;
+	initStringInfo(&log_str);
+
+	appendStringInfo(&log_str, "Fragment list: (%d elements)\n",
+			fragments ? fragments->length : 0);
+
+	foreach(fragment_cell, fragments)
+	{
+		FragmentData	*frag	= (FragmentData*)lfirst(fragment_cell);
+
+		appendStringInfo(&log_str, "Fragment index: %s\n", frag->index);
+
+        appendStringInfo(&log_str, "authority: %s\n", frag->authority);
+        appendStringInfo(&log_str, "source: %s\n", frag->source_name);
+		appendStringInfo(&log_str, "metadata: %s\n", frag->fragment_md ? frag->fragment_md : "NULL");
+
+		if (frag->user_data)
+		{
+			appendStringInfo(&log_str, "user data: %s\n", frag->user_data);
+		}
+
+		if (frag->profile)
+		{
+			appendStringInfo(&log_str, "profile: %s\n", frag->profile);
+		}
+	}
+
+	elog(FRAGDEBUG, "%s", log_str.data);
+	pfree(log_str.data);
+}
+
+/*
+ * Initializes the client context
+ */
+static void init_client_context(ClientContext *client_context)
+{
+	client_context->http_headers = NULL;
+	client_context->handle = NULL;
+	initStringInfo(&(client_context->the_rest_buf));
+}
+
+
+/*
+ * call_rest
+ *
+ * Creates the REST message and sends it to the PXF service located on
+ * <hadoop_uri->host>:<hadoop_uri->port>
+ */
+static void
+call_rest(GPHDUri *hadoop_uri, ClientContext *client_context, char *rest_msg)
+{
+	StringInfoData request;
+	initStringInfo(&request);
+
+	appendStringInfo(&request, rest_msg,
+								hadoop_uri->host,
+								hadoop_uri->port,
+								PXF_SERVICE_PREFIX,
+								PXF_VERSION);
+
+	/* send the request. The response will exist in rest_buf.data */
+	process_request(client_context, request.data);
+	pfree(request.data);
+}
+
+/*
+ * Reads from churl in chunks of 64K and copies data to the context's buffer
+ */
+static void
+process_request(ClientContext* client_context, char *uri)
+{
+    size_t n = 0;
+    char buffer[RAW_BUF_SIZE];
+
+    print_http_headers(client_context->http_headers);
+    client_context->handle = churl_init_download(uri, client_context->http_headers);
+    if (client_context->handle == NULL)
+        elog(ERROR, "Unsuccessful connection to uri: %s", uri);
+    memset(buffer, 0, RAW_BUF_SIZE);
+    resetStringInfo(&(client_context->the_rest_buf));
+
+    /*
+     * This try-catch ensures that in case of an exception during the "communication with PXF and the accumulation of
+     * PXF data in client_context->the_rest_buf", we still get to terminate the libcurl connection nicely and avoid
+     * leaving the PXF server connection hung.
+     */
+    PG_TRY();
+    {
+        /* read some bytes to make sure the connection is established */
+        churl_read_check_connectivity(client_context->handle);
+        while ((n = churl_read(client_context->handle, buffer, sizeof(buffer))) != 0) {
+            appendBinaryStringInfo(&(client_context->the_rest_buf), buffer, n);
+            memset(buffer, 0, RAW_BUF_SIZE);
+        }
+        churl_cleanup(client_context->handle, false);
+    }
+    PG_CATCH();
+    {
+        if (client_context->handle)
+            churl_cleanup(client_context->handle, true);
+        PG_RE_THROW();
+    }
+    PG_END_TRY();
+}

--- a/gpAux/extensions/pxf/src/pxffragment.c
+++ b/gpAux/extensions/pxf/src/pxffragment.c
@@ -120,7 +120,7 @@ static void assign_pxf_location_to_fragments(List *fragments)
     foreach(frag_c, fragments)
     {
         FragmentData 	*fragment	= (FragmentData*)lfirst(frag_c);
-        fragment->authority = authority.data;
+        fragment->authority = pstrdup(authority.data);
     }
     return;
 }

--- a/gpAux/extensions/pxf/src/pxffragment.h
+++ b/gpAux/extensions/pxf/src/pxffragment.h
@@ -15,28 +15,37 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
+ *
  */
 
-#ifndef _PXFUTILS_H_
-#define _PXFUTILS_H_
+#ifndef GPDB_PXFFRAGMENT_H
+#define GPDB_PXFFRAGMENT_H
 
-#include "postgres.h"
 #include "pxfuriparser.h"
+#include "libchurl.h"
+#include "pxfheaders.h"
+#include "lib/stringinfo.h"
 
-/* convert input string to upper case and prepend "X-GP-" prefix */
-char* normalize_key_name(const char* key);
+/*
+ * Context for the Fragmenter
+ */
+typedef struct sClientContext
+{
+	CHURL_HEADERS http_headers;
+	CHURL_HANDLE handle;
+	/* part of the HTTP response - received	*/
+	/* from one call to churl_read 			*/
+	/* contains the complete HTTP response 	*/
+	StringInfoData the_rest_buf;
+} ClientContext;
 
-/* get the name of the type, given the OID */
-char* TypeOidGetTypename(Oid typid);
+/*
+ * One debug level for all log messages from the data allocation algorithm
+ */
+#define FRAGDEBUG DEBUG2
 
-#define PXF_CLUSTER       "default"
-#define PXF_PROFILE       "PROFILE"
-#define FRAGMENTER        "FRAGMENTER"
-#define ACCESSOR          "ACCESSOR"
-#define RESOLVER          "RESOLVER"
-#define ANALYZER          "ANALYZER"
-#define PxfDefaultHost    "localhost"
-#define PxfDefaultPortStr "51200"
-#define PxfDefaultPort    51200
+#define REST_HEADER_JSON_RESPONSE "Accept: application/json"
 
-#endif  // _PXFUTILS_H_
+extern void set_fragments(GPHDUri* uri, Relation relation);
+
+#endif //GPDB_PXFFRAGMENT_H

--- a/gpAux/extensions/pxf/src/pxffragment.h
+++ b/gpAux/extensions/pxf/src/pxffragment.h
@@ -21,9 +21,10 @@
 #ifndef GPDB_PXFFRAGMENT_H
 #define GPDB_PXFFRAGMENT_H
 
-#include "pxfuriparser.h"
 #include "libchurl.h"
 #include "pxfheaders.h"
+#include "pxfuriparser.h"
+
 #include "lib/stringinfo.h"
 
 /*
@@ -31,13 +32,30 @@
  */
 typedef struct sClientContext
 {
-	CHURL_HEADERS http_headers;
-	CHURL_HANDLE handle;
-	/* part of the HTTP response - received	*/
-	/* from one call to churl_read 			*/
-	/* contains the complete HTTP response 	*/
-	StringInfoData the_rest_buf;
+    CHURL_HEADERS http_headers;
+    CHURL_HANDLE handle;
+    /* part of the HTTP response - received	*/
+    /* from one call to churl_read 			*/
+    /* contains the complete HTTP response 	*/
+    StringInfoData the_rest_buf;
 } ClientContext;
+
+/*
+ * FragmentData - describes a single Hadoop file split / HBase table region
+ * in means of location (ip, port), the source name of the specific file/table that is being accessed,
+ * and the index of a of list of fragments (splits/regions) for that source name.
+ * The index refers to the list of the fragments of that source name.
+ * user_data is optional.
+ */
+typedef struct FragmentData
+{
+    char    *authority;
+    char    *index;
+    char    *source_name;
+    char    *fragment_md;
+    char    *user_data;
+    char    *profile;
+} FragmentData;
 
 /*
  * One debug level for all log messages from the data allocation algorithm
@@ -46,6 +64,14 @@ typedef struct sClientContext
 
 #define REST_HEADER_JSON_RESPONSE "Accept: application/json"
 
-extern void set_fragments(GPHDUri* uri, Relation relation);
+/*
+ * Gets the fragments for the given uri location
+ */
+extern void get_fragments(GPHDUri *uri, Relation relation);
+
+/*
+ * Frees the given fragment
+ */
+extern void  free_fragment(FragmentData *data);
 
 #endif //GPDB_PXFFRAGMENT_H

--- a/gpAux/extensions/pxf/src/pxffragment.h
+++ b/gpAux/extensions/pxf/src/pxffragment.h
@@ -62,8 +62,6 @@ typedef struct FragmentData
  */
 #define FRAGDEBUG DEBUG2
 
-#define REST_HEADER_JSON_RESPONSE "Accept: application/json"
-
 /*
  * Gets the fragments for the given uri location
  */

--- a/gpAux/extensions/pxf/src/pxfheaders.h
+++ b/gpAux/extensions/pxf/src/pxfheaders.h
@@ -30,7 +30,7 @@
  * Contains the data necessary to build the HTTP headers required for calling on the pxf service
  */
 typedef struct sPxfInputData
-{	
+{
 	CHURL_HEADERS	headers;
 	GPHDUri			*gphduri;
 	Relation		rel;
@@ -39,6 +39,6 @@ typedef struct sPxfInputData
 /*
  * Adds the headers necessary for PXF service call
  */
-void build_http_headers(PxfInputData *input);
+extern void build_http_headers(PxfInputData *input);
 
 #endif //_PXFHEADERS_H_

--- a/gpAux/extensions/pxf/src/pxfheaders.h
+++ b/gpAux/extensions/pxf/src/pxfheaders.h
@@ -31,9 +31,9 @@
  */
 typedef struct sPxfInputData
 {
-	CHURL_HEADERS	headers;
-	GPHDUri			*gphduri;
-	Relation		rel;
+    CHURL_HEADERS	headers;
+    GPHDUri			*gphduri;
+    Relation		rel;
 } PxfInputData;
 
 /*

--- a/gpAux/extensions/pxf/src/pxfprotocol.c
+++ b/gpAux/extensions/pxf/src/pxfprotocol.c
@@ -21,6 +21,9 @@
 #include "pxfutils.h"
 #include "pxfbridge.h"
 #include "access/extprotocol.h"
+#include "pxffragment.h"
+#include "nodes/pg_list.h"
+#include <unistd.h>
 
 /* define magic module unless run as a part of test cases */
 #ifndef UNIT_TESTING
@@ -107,7 +110,7 @@ pxfprotocol_import(PG_FUNCTION_ARGS)
     /* Must be called via the external table format manager */
     check_caller(fcinfo, "pxfprotocol_import");
 
-    /* retrieve user context */
+    /* retrieve user context required for data read*/
     gphadoop_context *context = (gphadoop_context *) EXTPROTOCOL_GET_USER_CTX(fcinfo);
 
     /* last call -- cleanup */
@@ -116,55 +119,40 @@ pxfprotocol_import(PG_FUNCTION_ARGS)
         EXTPROTOCOL_SET_USER_CTX(fcinfo, NULL);
         PG_RETURN_INT32(0);
     }
-
     /* first call -- do any desired init */
     if (context == NULL) {
-        context = create_context(fcinfo, true);
-        EXTPROTOCOL_SET_USER_CTX(fcinfo, context);
-        gpbridge_import_start(context);
+    	context = create_context(fcinfo, true);
+		EXTPROTOCOL_SET_USER_CTX(fcinfo, context);
+		gpbridge_import_start(context);
     }
 
     int bytes_read = gpbridge_read(context, EXTPROTOCOL_GET_DATABUF(fcinfo), EXTPROTOCOL_GET_DATALEN(fcinfo));
+
     PG_RETURN_INT32(bytes_read);
 }
 
 /*
- * Allocates context and initializes values.
+ * Allocates context and sets values for the segment
  */
 static gphadoop_context*
 create_context(PG_FUNCTION_ARGS, bool is_import)
 {
+    /* parse and set uri */
+    GPHDUri *uri = parseGPHDUri(EXTPROTOCOL_GET_URL(fcinfo));
+    Relation relation = EXTPROTOCOL_GET_RELATION(fcinfo);
+
+    /* set fragments */
+    set_fragments(uri, relation);
+
+    /* set context */
     gphadoop_context* context = palloc0(sizeof(gphadoop_context));
-
-    //TODO: remove mocking fragment data
-    // append mock fragment data to original uri
-    //&segwork=<size>@<ip>@<port>@<index><size>@<ip>@<port>@<index><size>
-    char *original_uri = EXTPROTOCOL_GET_URL(fcinfo);
-    StringInfoData uri_with_segwork;
-    initStringInfo(&uri_with_segwork);
-
-    /*
-    fragment 1: segwork=46@127.0.0.1@51200@tmp/dummy1.1@0@ZnJhZ21lbnQx@@@
-    fragment 2: segwork=46@127.0.0.1@51200@tmp/dummy1.2@0@ZnJhZ21lbnQy@@@
-    fragment 3: segwork=46@127.0.0.1@51200@tmp/dummy1.3@0@ZnJhZ21lbnQz@@@
-    */
-    appendStringInfo(&uri_with_segwork,
-                     "%s&segwork=46@127.0.0.1@51200@tmp/dummy1.%d@0@ZnJhZ21lbnQ%c@@@",
-                     original_uri,
-                     GpIdentity.segindex + 1,
-                     'x' + GpIdentity.segindex);
-
-    /* parse the URI */
-    context->gphd_uri = parseGPHDUri(uri_with_segwork.data);
+    context->gphd_uri = uri;
     if (is_import)
         Assert(context->gphd_uri->fragments != NULL);
 
     initStringInfo(&context->uri);
     initStringInfo(&context->write_file_name);
-    context->relation = EXTPROTOCOL_GET_RELATION(fcinfo);
-
-    //TODO: remove this when using real fragmentation data
-    pfree(uri_with_segwork.data);
+    context->relation = relation;
 
     return context;
 }

--- a/gpAux/extensions/pxf/src/pxfprotocol.c
+++ b/gpAux/extensions/pxf/src/pxfprotocol.c
@@ -18,11 +18,13 @@
  *
  */
 
-#include "pxfutils.h"
 #include "pxfbridge.h"
-#include "access/extprotocol.h"
 #include "pxffragment.h"
+#include "pxfutils.h"
+
+#include "access/extprotocol.h"
 #include "nodes/pg_list.h"
+
 #include <unistd.h>
 
 /* define magic module unless run as a part of test cases */
@@ -109,7 +111,6 @@ pxfprotocol_import(PG_FUNCTION_ARGS)
 {
     /* Must be called via the external table format manager */
     check_caller(fcinfo, "pxfprotocol_import");
-
     /* retrieve user context required for data read*/
     gphadoop_context *context = (gphadoop_context *) EXTPROTOCOL_GET_USER_CTX(fcinfo);
 
@@ -121,11 +122,11 @@ pxfprotocol_import(PG_FUNCTION_ARGS)
     }
     /* first call -- do any desired init */
     if (context == NULL) {
-    	context = create_context(fcinfo, true);
-		EXTPROTOCOL_SET_USER_CTX(fcinfo, context);
-		gpbridge_import_start(context);
+        context = create_context(fcinfo, true);
+        EXTPROTOCOL_SET_USER_CTX(fcinfo, context);
+        gpbridge_import_start(context);
     }
-
+    /* Read data */
     int bytes_read = gpbridge_read(context, EXTPROTOCOL_GET_DATABUF(fcinfo), EXTPROTOCOL_GET_DATALEN(fcinfo));
 
     PG_RETURN_INT32(bytes_read);
@@ -141,8 +142,8 @@ create_context(PG_FUNCTION_ARGS, bool is_import)
     GPHDUri *uri = parseGPHDUri(EXTPROTOCOL_GET_URL(fcinfo));
     Relation relation = EXTPROTOCOL_GET_RELATION(fcinfo);
 
-    /* set fragments */
-    set_fragments(uri, relation);
+    /* fetch data fragments */
+    get_fragments(uri, relation);
 
     /* set context */
     gphadoop_context* context = palloc0(sizeof(gphadoop_context));

--- a/gpAux/extensions/pxf/src/pxfprotocol.c
+++ b/gpAux/extensions/pxf/src/pxfprotocol.c
@@ -25,8 +25,6 @@
 #include "access/extprotocol.h"
 #include "nodes/pg_list.h"
 
-#include <unistd.h>
-
 /* define magic module unless run as a part of test cases */
 #ifndef UNIT_TESTING
 PG_MODULE_MAGIC;

--- a/gpAux/extensions/pxf/src/pxfuriparser.c
+++ b/gpAux/extensions/pxf/src/pxfuriparser.c
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -22,10 +22,8 @@
 #include "pxfutils.h"
 #include "utils/formatting.h"
 
-static const char* SEGWORK_SUBSTRING = "segwork=";
 static const char* PTC_SEP = "://";
 static const char* OPTION_SEP = "&";
-static const char  SEGWORK_SEPARATOR = '@';
 static const int   EMPTY_VALUE_LEN = 2;
 
 /* helper function declarations */
@@ -35,10 +33,7 @@ static void  GPHDUri_parse_data(GPHDUri *uri, char **cursor);
 static void  GPHDUri_parse_options(GPHDUri *uri, char **cursor);
 static List* GPHDUri_parse_option(char* pair, GPHDUri *uri);
 static void  GPHDUri_free_options(GPHDUri *uri);
-static void  GPHDUri_parse_segwork(GPHDUri *uri, const char *uri_str);
-static List* GPHDUri_parse_fragment(char* fragment, List* fragments);
 static void  GPHDUri_free_fragments(GPHDUri *uri);
-static char* GPHDUri_dup_without_segwork(const char* uri);
 
 /* parseGPHDUri
  *
@@ -46,7 +41,7 @@ static char* GPHDUri_dup_without_segwork(const char* uri);
  * verifying valid structure given a specific target protocol.
  *
  * URI format:
- *     <protocol name>://<cluster>/<data>?<option>&<option>&<...>&segwork=<segwork>
+ *     <protocol name>://<cluster>/<data>?<option>&<option>&<...>
  *
  *
  * protocol name    - must be 'pxf'
@@ -77,10 +72,9 @@ parseGPHDUriHostPort(const char *uri_str, const char *host, const int port)
     initStringInfo(&portstr);
     appendStringInfo(&portstr, "%d", port);
     uri->port = portstr.data;
-    uri->uri = GPHDUri_dup_without_segwork(uri_str);
+    uri->uri = pstrdup(uri_str);
     char *cursor = uri->uri;
 
-    GPHDUri_parse_segwork(uri, uri_str);
     GPHDUri_parse_protocol(uri, &cursor);
     GPHDUri_parse_cluster(uri, &cursor);
     GPHDUri_parse_data(uri, &cursor);
@@ -294,189 +288,41 @@ GPHDUri_free_options(GPHDUri *uri)
 }
 
 /*
- * GPHDUri_parse_segwork parses the segwork section of the uri.
- * ...&segwork=<size>@<ip>@<port>@<index><size>@<ip>@<port>@<index><size>...
- */
-static void
-GPHDUri_parse_segwork(GPHDUri *uri, const char *uri_str)
-{
-    char *size_end, *sizestr, *fragment;
-    /* skip segwork= */
-    char *segwork = strstr(uri_str, SEGWORK_SUBSTRING);
-    if (segwork == NULL)
-        return;
-    segwork += strlen(SEGWORK_SUBSTRING);
-
-    /* read next segment. each segment is prefixed with its size. */
-    int fragment_size, count = 0;
-    while (segwork && strlen(segwork))
-    {
-        /* expect size */
-        size_end = strchr(segwork, SEGWORK_SEPARATOR);
-        Assert(size_end != NULL);
-        sizestr = pnstrdup(segwork, size_end - segwork);
-        fragment_size = atoi(sizestr);
-        pfree(sizestr);
-        segwork = size_end + 1; /* skip the size field */
-        Assert(fragment_size <= strlen(segwork));
-
-        fragment = pnstrdup(segwork, fragment_size);
-        elog(DEBUG2, "GPHDUri_parse_segwork: fragment #%d, size %d", count, fragment_size);
-        uri->fragments = GPHDUri_parse_fragment(fragment, uri->fragments);
-        segwork += fragment_size;
-        pfree(fragment);
-        count++;
-    }
-}
-
-/*
- * Parsed a fragment string in the form:
- * <ip>@<port>@<index>[@user_data] - 192.168.1.1@1422@1[@user_data]
- * to authority ip:port - 192.168.1.1:1422
- * to index - 1
- * user data is optional
- */
-static List*
-GPHDUri_parse_fragment(char* fragment, List* fragments)
-{
-    if (!fragment)
-        ereport(ERROR,
-                (errcode(ERRCODE_INTERNAL_ERROR),
-                 errmsg("internal error in GPHDUri_parse_fragment. Fragment string is null.")));
-
-    FragmentData* fragment_data = palloc0(sizeof(FragmentData));
-    StringInfoData authority_formatter;
-    initStringInfo(&authority_formatter);
-    char *dup_frag = pstrdup(fragment);
-    char *value_start = dup_frag;
-
-    /* expect ip */
-    char *value_end = strchr(value_start, SEGWORK_SEPARATOR);
-    if (value_end == NULL)
-        ereport(ERROR,
-                (errcode(ERRCODE_INTERNAL_ERROR),
-                 errmsg("internal error in GPHDUri_parse_fragment. Fragment string is invalid.")));
-    *value_end = '\0';
-    appendStringInfo(&authority_formatter, "%s:", value_start);
-    value_start = value_end + 1;
-
-    /* expect port */
-    value_end = strchr(value_start, SEGWORK_SEPARATOR);
-    if (value_end == NULL)
-        ereport(ERROR,
-                (errcode(ERRCODE_INTERNAL_ERROR),
-                 errmsg("internal error in GPHDUri_parse_fragment. Fragment string is invalid.")));
-    *value_end = '\0';
-    appendStringInfoString(&authority_formatter, value_start);
-    fragment_data->authority = authority_formatter.data;
-    value_start = value_end + 1;
-
-    /* expect source name */
-    value_end = strchr(value_start, SEGWORK_SEPARATOR);
-    if (value_end == NULL)
-        ereport(ERROR,
-                (errcode(ERRCODE_INTERNAL_ERROR),
-                 errmsg("internal error in GPHDUri_parse_fragment. Fragment string is invalid.")));
-    *value_end = '\0';
-    fragment_data->source_name = pstrdup(value_start);
-    value_start = value_end + 1;
-
-    /* expect index */
-    value_end = strchr(value_start, SEGWORK_SEPARATOR);
-    if (value_end == NULL)
-        ereport(ERROR,
-                (errcode(ERRCODE_INTERNAL_ERROR),
-                 errmsg("internal error in GPHDUri_parse_fragment. Fragment string is invalid.")));
-    *value_end = '\0';
-    fragment_data->index = pstrdup(value_start);
-    value_start = value_end + 1;
-
-    /* expect fragment metadata */
-    Assert(value_start);
-    value_end = strchr(value_start, SEGWORK_SEPARATOR);
-    if (value_end == NULL)
-        ereport(ERROR,
-                (errcode(ERRCODE_INTERNAL_ERROR),
-                 errmsg("internal error in GPHDUri_parse_fragment. Fragment string is invalid.")));
-    *value_end = '\0';
-    fragment_data->fragment_md = pstrdup(value_start);
-    value_start = value_end + 1;
-
-    /* expect user data */
-    Assert(value_start);
-    value_end = strchr(value_start, SEGWORK_SEPARATOR);
-    if (value_end == NULL)
-        ereport(ERROR,
-                (errcode(ERRCODE_INTERNAL_ERROR),
-                 errmsg("internal error in GPHDUri_parse_fragment. Fragment string is invalid.")));
-    *value_end = '\0';
-    fragment_data->user_data = pstrdup(value_start);
-    value_start = value_end + 1;
-
-    /* expect for profile */
-    Assert(value_start);
-    value_end = strchr(value_start, SEGWORK_SEPARATOR);
-    if (value_end == NULL)
-        ereport(ERROR,
-                (errcode(ERRCODE_INTERNAL_ERROR),
-                 errmsg("internal error in GPHDUri_parse_fragment. Fragment string is invalid.")));
-    *value_end = '\0';
-    if (strlen(value_start) > 0)
-        fragment_data->profile = pstrdup(value_start);
-
-    pfree(dup_frag);
-    return lappend(fragments, fragment_data);
-}
-
-/*
  * Free fragment data
  */
-static void
-GPHDUri_free_fragment(FragmentData *data)
+void
+free_fragment(FragmentData *data)
 {
-    if (data->authority)
-        pfree(data->authority);
-    if (data->fragment_md)
-        pfree(data->fragment_md);
-    if (data->index)
-        pfree(data->index);
-    if (data->profile)
-        pfree(data->profile);
-    if (data->source_name)
-        pfree(data->source_name);
-    if (data->user_data)
-        pfree(data->user_data);
-    pfree(data);
+	if (data->authority)
+		pfree(data->authority);
+	if (data->fragment_md)
+		pfree(data->fragment_md);
+	if (data->index)
+		pfree(data->index);
+	if (data->profile)
+		pfree(data->profile);
+	if (data->source_name)
+		pfree(data->source_name);
+	if (data->user_data)
+		pfree(data->user_data);
+	pfree(data);
 }
 
 /*
  * Free fragments list
  */
-static void 
+static void
 GPHDUri_free_fragments(GPHDUri *uri)
 {
-    ListCell *fragment;
-    foreach(fragment, uri->fragments)
-        GPHDUri_free_fragment((FragmentData*)lfirst(fragment));
-    list_free(uri->fragments);
-    uri->fragments = NIL;
-}
+	ListCell *fragment = NULL;
 
-/*
- * Returns a uri without the segwork section.
- * segwork section removed so users won't get it 
- * when an error occurs and the uri is printed
- */
-static char*
-GPHDUri_dup_without_segwork(const char* uri)
-{
-    char *segwork = strstr(uri, SEGWORK_SUBSTRING);
-    if (segwork != NULL) {
-        segwork--; /* Discard the last character */
-        return pnstrdup(uri, segwork - uri);
-    }
-    /* segwork_substring was not found */
-    return pstrdup(uri);
+	foreach(fragment, uri->fragments)
+	{
+		FragmentData *data = (FragmentData*)lfirst(fragment);
+		free_fragment(data);
+	}
+	list_free(uri->fragments);
+	uri->fragments = NIL;
 }
 
 /*

--- a/gpAux/extensions/pxf/src/pxfuriparser.c
+++ b/gpAux/extensions/pxf/src/pxfuriparser.c
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-#include "libchurl.h"
 #include "pxfuriparser.h"
+#include "pxffragment.h"
 #include "pxfutils.h"
 #include "utils/formatting.h"
 
@@ -288,41 +288,20 @@ GPHDUri_free_options(GPHDUri *uri)
 }
 
 /*
- * Free fragment data
- */
-void
-free_fragment(FragmentData *data)
-{
-	if (data->authority)
-		pfree(data->authority);
-	if (data->fragment_md)
-		pfree(data->fragment_md);
-	if (data->index)
-		pfree(data->index);
-	if (data->profile)
-		pfree(data->profile);
-	if (data->source_name)
-		pfree(data->source_name);
-	if (data->user_data)
-		pfree(data->user_data);
-	pfree(data);
-}
-
-/*
  * Free fragments list
  */
 static void
 GPHDUri_free_fragments(GPHDUri *uri)
 {
-	ListCell *fragment = NULL;
+    ListCell *fragment = NULL;
 
-	foreach(fragment, uri->fragments)
-	{
-		FragmentData *data = (FragmentData*)lfirst(fragment);
-		free_fragment(data);
-	}
-	list_free(uri->fragments);
-	uri->fragments = NIL;
+    foreach(fragment, uri->fragments)
+    {
+        FragmentData *data = (FragmentData*)lfirst(fragment);
+        free_fragment(data);
+    }
+    list_free(uri->fragments);
+    uri->fragments = NIL;
 }
 
 /*

--- a/gpAux/extensions/pxf/src/pxfuriparser.h
+++ b/gpAux/extensions/pxf/src/pxfuriparser.h
@@ -94,4 +94,9 @@ void    GPHDUri_verify_cluster_exists(GPHDUri *uri, char* cluster);
  */
 void     freeGPHDUri(GPHDUri *uri);
 
+/*
+ * Frees the given fragment
+ */
+void  free_fragment(FragmentData *data);
+
 #endif    // _PXFURIPARSER_H_

--- a/gpAux/extensions/pxf/src/pxfuriparser.h
+++ b/gpAux/extensions/pxf/src/pxfuriparser.h
@@ -34,23 +34,6 @@
 #define IS_PXF_URI(uri_str) (pg_strncasecmp(uri_str, PROTOCOL_PXF, strlen(PROTOCOL_PXF)) == 0)
 
 /*
- * FragmentData - describes a single Hadoop file split / HBase table region
- * in means of location (ip, port), the source name of the specific file/table that is being accessed,
- * and the index of a of list of fragments (splits/regions) for that source name.
- * The index refers to the list of the fragments of that source name.
- * user_data is optional.
- */
-typedef struct FragmentData
-{
-    char    *authority;
-    char    *index;
-    char    *source_name;
-    char    *fragment_md;
-    char    *user_data;
-    char    *profile;
-} FragmentData;
-
-/*
  * Structure to store options data, such as types of fragmenters, accessors and resolvers
  */
 typedef struct OptionData
@@ -71,7 +54,7 @@ typedef struct GPHDUri
     char    *port;      /* port number as string    */
     char    *data;      /* data location (path)     */
     char    *profile;   /* profile option           */
-    List    *fragments; /* list of FragmentData     */
+    List    *fragments; /* list of fragments        */
     List    *options;   /* list of OptionData       */
 } GPHDUri;
 
@@ -93,10 +76,5 @@ void    GPHDUri_verify_cluster_exists(GPHDUri *uri, char* cluster);
  * Frees the elements of the data structure
  */
 void     freeGPHDUri(GPHDUri *uri);
-
-/*
- * Frees the given fragment
- */
-void  free_fragment(FragmentData *data);
 
 #endif    // _PXFURIPARSER_H_

--- a/gpAux/extensions/pxf/src/pxfutils.c
+++ b/gpAux/extensions/pxf/src/pxfutils.c
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -20,35 +20,6 @@
 #include "pxfutils.h"
 #include "utils/formatting.h"
 #include "utils/syscache.h"
-
-/*
- * Checks if two strings are equal
- */
-bool
-are_ips_equal(char *ip1, char *ip2)
-{
-    if ((ip1 == NULL) || (ip2 == NULL))
-        return false;
-    return (strcmp(ip1, ip2) == 0);
-}
-
-/*
- * Override port str with given new port int
- */
-void
-port_to_str(char **port, int new_port)
-{
-    char tmp[10];
-
-    if (!port)
-        elog(ERROR, "unexpected internal error in pxfutils.c");
-    if (*port)
-        pfree(*port);
-
-    Assert((new_port <= 65535) && (new_port >= 1)); /* legal port range */
-    pg_ltoa(new_port, tmp);
-    *port = pstrdup(tmp);
-}
 
 /*
  * Full name of the HEADER KEY expected by the PXF service

--- a/gpAux/extensions/pxf/src/pxfutils.c
+++ b/gpAux/extensions/pxf/src/pxfutils.c
@@ -76,3 +76,20 @@ TypeOidGetTypename(Oid typid)
 
     return tname.data;
 }
+
+/* Concatenate multiple literal strings using stringinfo */
+char* concat(int num_args, ...)
+{
+    va_list ap;
+    StringInfoData str;
+    initStringInfo(&str);
+
+    va_start(ap, num_args);
+
+    for (int i = 0; i < num_args; i++) {
+        appendStringInfoString(&str, va_arg(ap, char*));
+    }
+    va_end(ap);
+
+    return str.data;
+}

--- a/gpAux/extensions/pxf/src/pxfutils.h
+++ b/gpAux/extensions/pxf/src/pxfutils.h
@@ -29,6 +29,9 @@ char* normalize_key_name(const char* key);
 /* get the name of the type, given the OID */
 char* TypeOidGetTypename(Oid typid);
 
+/* Concatenate multiple literal strings using stringinfo */
+char* concat(int num_args, ...);
+
 #define PXF_CLUSTER       "default"
 #define PXF_PROFILE       "PROFILE"
 #define FRAGMENTER        "FRAGMENTER"
@@ -36,7 +39,6 @@ char* TypeOidGetTypename(Oid typid);
 #define RESOLVER          "RESOLVER"
 #define ANALYZER          "ANALYZER"
 #define PxfDefaultHost    "localhost"
-#define PxfDefaultPortStr "51200"
 #define PxfDefaultPort    51200
 
 #endif  // _PXFUTILS_H_

--- a/gpAux/extensions/pxf/test/Makefile
+++ b/gpAux/extensions/pxf/test/Makefile
@@ -2,8 +2,12 @@ subdir=gpAux/extensions/pxf/test
 top_builddir=../../../..
 include $(top_builddir)/src/Makefile.global
 
-TARGETS= libchurl pxfprotocol pxfbridge pxfheaders pxfuriparser pxfutils
+TARGETS= libchurl pxfprotocol pxfbridge pxfheaders pxfuriparser pxfutils pxffragment
+
+LIBS += -ljson-c
 
 include $(top_builddir)/src/backend/mock.mk
 
 pxfheaders.t: $(MOCK_DIR)/backend/access/external/fileam_mock.o $(MOCK_DIR)/backend/catalog/pg_exttable_mock.o
+
+pxffragment.t: $(MOCK_DIR)/backend/cdb/cdbtm_mock.o

--- a/gpAux/extensions/pxf/test/libchurl_test.c
+++ b/gpAux/extensions/pxf/test/libchurl_test.c
@@ -2,7 +2,6 @@
 #include <stddef.h>
 #include <setjmp.h>
 #include "cmockery.h"
-#include <unistd.h>
 
 /* Define UNIT_TESTING so that the extension can skip declaring PG_MODULE_MAGIC */
 #define UNIT_TESTING

--- a/gpAux/extensions/pxf/test/mock/pxffragment_mock.c
+++ b/gpAux/extensions/pxf/test/mock/pxffragment_mock.c
@@ -1,0 +1,27 @@
+void
+set_fragments(GPHDUri* uri, Relation relation)
+{
+	check_expected(uri);
+	check_expected(relation);
+	optional_assignment(uri);
+	optional_assignment(relation);
+	mock();
+}
+
+void
+call_rest(GPHDUri* hadoop_uri, ClientContext* client_context, char* rest_msg)
+{
+	check_expected(hadoop_uri);
+	check_expected(client_context);
+	check_expected(rest_msg);
+	optional_assignment(hadoop_uri);
+	optional_assignment(client_context);
+	optional_assignment(rest_msg);
+	mock();
+}
+
+static void
+process_request(ClientContext* client_context, char* uri)
+{
+	mock();
+}

--- a/gpAux/extensions/pxf/test/mock/pxffragment_mock.c
+++ b/gpAux/extensions/pxf/test/mock/pxffragment_mock.c
@@ -1,5 +1,5 @@
 void
-set_fragments(GPHDUri* uri, Relation relation)
+get_fragments(GPHDUri *uri, Relation relation)
 {
 	check_expected(uri);
 	check_expected(relation);
@@ -23,5 +23,13 @@ call_rest(GPHDUri* hadoop_uri, ClientContext* client_context, char* rest_msg)
 static void
 process_request(ClientContext* client_context, char* uri)
 {
+	mock();
+}
+
+void
+free_fragment(FragmentData *data)
+{
+	check_expected(data);
+	optional_assignment(data);
 	mock();
 }

--- a/gpAux/extensions/pxf/test/mock/pxfuriparser_mock.c
+++ b/gpAux/extensions/pxf/test/mock/pxfuriparser_mock.c
@@ -43,3 +43,11 @@ GPHDUri_verify_cluster_exists(GPHDUri *uri, char* cluster)
     check_expected(cluster);
     mock();
 }
+
+void
+free_fragment(FragmentData *data)
+{
+    check_expected(data);
+    optional_assignment(data);
+    mock();
+}

--- a/gpAux/extensions/pxf/test/mock/pxfuriparser_mock.c
+++ b/gpAux/extensions/pxf/test/mock/pxfuriparser_mock.c
@@ -43,11 +43,3 @@ GPHDUri_verify_cluster_exists(GPHDUri *uri, char* cluster)
     check_expected(cluster);
     mock();
 }
-
-void
-free_fragment(FragmentData *data)
-{
-    check_expected(data);
-    optional_assignment(data);
-    mock();
-}

--- a/gpAux/extensions/pxf/test/mock/pxfutils_mock.c
+++ b/gpAux/extensions/pxf/test/mock/pxfutils_mock.c
@@ -11,3 +11,10 @@ TypeOidGetTypename(Oid typid)
 	check_expected(typid);
 	return (char*) mock();
 }
+
+char*
+concat(int num_args, ...)
+{
+    check_expected(num_args);
+    return (char*) mock();
+}

--- a/gpAux/extensions/pxf/test/mock/pxfutils_mock.c
+++ b/gpAux/extensions/pxf/test/mock/pxfutils_mock.c
@@ -1,23 +1,3 @@
-/* mock implementation for pxfutils.h */
-bool
-are_ips_equal(char* ip1, char* ip2)
-{
-	check_expected(ip1);
-	check_expected(ip2);
-	optional_assignment(ip1);
-	optional_assignment(ip2);
-	return (bool) mock();
-}
-
-void
-port_to_str(char** port, int new_port)
-{
-	check_expected(port);
-	check_expected(new_port);
-	optional_assignment(port);
-	mock();
-}
-
 char*
 normalize_key_name(const char* key)
 {

--- a/gpAux/extensions/pxf/test/pxfbridge_test.c
+++ b/gpAux/extensions/pxf/test/pxfbridge_test.c
@@ -13,6 +13,7 @@
 #include "mock/libchurl_mock.c"
 #include "mock/pxfuriparser_mock.c"
 #include "mock/pxfheaders_mock.c"
+#include "../src/pxfbridge.h"
 
 /* helper functions */
 static void expect_set_headers_call(CHURL_HEADERS headers_handle, const char* header_key, const char* header_value);
@@ -121,6 +122,8 @@ test_gpbridge_read_one_fragment_less_than_buffer(void **state)
 {
     /* init data in context */
     gphadoop_context *context = (gphadoop_context *) palloc0(sizeof(gphadoop_context));
+    context->gphd_uri = (GPHDUri *) palloc0(sizeof(GPHDUri));
+    context->gphd_uri->fragments = (FragmentData *) palloc0(sizeof(FragmentData));
     CHURL_HANDLE handle = (CHURL_HANDLE) palloc0(sizeof(CHURL_HANDLE));
     context->churl_handle = handle;
 
@@ -156,6 +159,8 @@ test_gpbridge_read_one_fragment_buffer(void **state)
 {
     /* init data in context */
     gphadoop_context *context = (gphadoop_context *) palloc0(sizeof(gphadoop_context));
+    context->gphd_uri = (GPHDUri *) palloc0(sizeof(GPHDUri));
+    context->gphd_uri->fragments = (FragmentData *) palloc0(sizeof(FragmentData));
     CHURL_HANDLE handle = (CHURL_HANDLE) palloc0(sizeof(CHURL_HANDLE));
     context->churl_handle = handle;
 
@@ -207,6 +212,7 @@ test_gpbridge_read_next_fragment_buffer(void **state)
 
     context->gphd_uri = (GPHDUri *) palloc0(sizeof(GPHDUri));
     context->gphd_uri->profile = "profile";
+    context->gphd_uri->fragments = (FragmentData *) palloc0(sizeof(FragmentData));
 
     int datalen = 10;
     char *databuf = (char *) palloc0(datalen);
@@ -262,6 +268,8 @@ test_gpbridge_read_last_fragment_finished(void **state)
 {
     /* init data in context */
     gphadoop_context *context = (gphadoop_context *) palloc0(sizeof(gphadoop_context));
+    context->gphd_uri = (GPHDUri *) palloc0(sizeof(GPHDUri));
+    context->gphd_uri->fragments = (FragmentData *) palloc0(sizeof(FragmentData));
     CHURL_HANDLE handle = (CHURL_HANDLE) palloc0(sizeof(CHURL_HANDLE));
     context->churl_handle = handle;
 

--- a/gpAux/extensions/pxf/test/pxffragment_test.c
+++ b/gpAux/extensions/pxf/test/pxffragment_test.c
@@ -1,0 +1,403 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include "cmockery.h"
+
+/* Define UNIT_TESTING so that the extension can skip declaring PG_MODULE_MAGIC */
+#define UNIT_TESTING
+
+/* include unit under test */
+#include "../src/pxffragment.c"
+
+/* include mock files */
+#include "mock/libchurl_mock.c"
+#include "mock/pxfheaders_mock.c"
+#include "mock/pxfuriparser_mock.c"
+#include "mock/pxfutils_mock.c"
+#include "../../../../src/include/nodes/pg_list.h"
+
+#define ARRSIZE(x) (sizeof(x) / sizeof((x)[0]))
+
+/* helper functions */
+static List* prepare_fragment_list(int fragtotal, int sefgindex, int segtotal, int xid);
+static void test_list(int segindex, int segtotal, int xid, int fragtotal, char* expected[], int expected_total);
+static FragmentData* buildFragment(const char* index, const char *source, const char *userdata, const char *metadata, const char *profile);
+static bool compareLists(List* list1, List* list2, bool (*compareType)(void*, void*) );
+static bool compareString(char* str1, char* str2);
+static bool compareFragment(ListCell* fragment_cell1, ListCell* fragment_cell2);
+
+
+void
+test_filter_fragments_for_segment(void **state)
+{
+    expect_any_count(free_fragment, data, -1);
+    will_be_called_count(free_fragment, -1);
+    /* --- 1 segment, all fragements should be processed by it */
+    char* expected_1_1_0[1] = {"0"}; // 1 fragment
+    test_list(0, 1, 1, 1, expected_1_1_0, ARRSIZE(expected_1_1_0)); // xid=1
+    test_list(0, 1, 2, 1, expected_1_1_0, ARRSIZE(expected_1_1_0)); // xid=2
+
+    char* expected_1_2_0[2] = {"0","1"};  // 2 fragments
+
+    test_list(0, 1, 1, 2, expected_1_2_0, ARRSIZE(expected_1_2_0)); // xid=1
+    test_list(0, 1, 2, 2, expected_1_2_0, ARRSIZE(expected_1_2_0)); // xid=2
+
+    char* expected_1_3_0[3] = {"0","1","2"};  // 3 fragments
+    test_list(0, 1, 1, 3, expected_1_3_0, ARRSIZE(expected_1_3_0)); // xid=1
+    test_list(0, 1, 2, 3, expected_1_3_0, ARRSIZE(expected_1_3_0)); // xid=2
+
+    /* --- 2 segments, each processes every other fragment, based on xid */
+    // 1 fragment, xid=1
+    test_list(0, 2, 1, 1, NULL, 0); // seg=0
+    char* expected_1_2_1_1[1] = {"0"}; // seg=1
+    test_list(1, 2, 1, 1, expected_1_2_1_1, ARRSIZE(expected_1_2_1_1));
+
+    // 1 fragment, xid=2
+    char* expected_0_2_2_1[1] = {"0"}; // seg=0
+    test_list(0, 2, 2, 1, expected_0_2_2_1, ARRSIZE(expected_0_2_2_1));
+    test_list(1, 2, 2, 1, NULL, 0); // seg=1
+
+    // 1 fragment, xid=3
+    test_list(0, 2, 3, 1, NULL, 0); // seg=0
+    char* expected_1_2_3_1[1] = {"0"}; // seg=1
+    test_list(1, 2, 3, 1, expected_1_2_3_1, ARRSIZE(expected_1_2_3_1));
+
+    // 2 fragments, xid=1
+    char* expected_0_2_1_2[1] = {"1"}; // seg=0
+    test_list(0, 2, 1, 2, expected_0_2_1_2, ARRSIZE(expected_0_2_1_2));
+    char* expected_1_2_1_2[1] = {"0"}; // seg=1
+    test_list(1, 2, 1, 2, expected_1_2_1_2, ARRSIZE(expected_1_2_1_2));
+
+    // 2 fragments, xid=2
+    char* expected_0_2_2_2[1] = {"0"}; // seg=0
+    test_list(0, 2, 2, 2, expected_0_2_2_2, ARRSIZE(expected_0_2_2_2));
+    char* expected_1_2_2_2[1] = {"1"}; // seg=1
+    test_list(1, 2, 2, 2, expected_1_2_2_2, ARRSIZE(expected_1_2_2_2));
+
+    // 2 fragments, xid=3
+    char* expected_0_2_3_2[1] = {"1"}; // seg=0
+    test_list(0, 2, 3, 2, expected_0_2_3_2, ARRSIZE(expected_0_2_3_2));
+    char* expected_1_2_3_2[1] = {"0"}; // seg=1
+    test_list(1, 2, 3, 2, expected_1_2_3_2, ARRSIZE(expected_1_2_3_2));
+
+    // 3 fragments, xid=1
+    char* expected_0_2_1_3[1] = {"1"}; // seg=0
+    test_list(0, 2, 1, 3, expected_0_2_1_3, ARRSIZE(expected_0_2_1_3));
+    char* expected_1_2_1_3[2] = {"0","2"}; // seg=1
+    test_list(1, 2, 1, 3, expected_1_2_1_3, ARRSIZE(expected_1_2_1_3));
+
+    // 3 fragments, xid=2
+    char* expected_0_2_2_3[2] = {"0","2"}; // seg=0
+    test_list(0, 2, 2, 3, expected_0_2_2_3, ARRSIZE(expected_0_2_2_3));
+    char* expected_1_2_2_3[1] = {"1"}; // seg=1
+    test_list(1, 2, 2, 3, expected_1_2_2_3, ARRSIZE(expected_1_2_2_3));
+
+    // 3 fragments, xid=3
+    char* expected_0_2_3_3[1] = {"1"}; // seg=0
+    test_list(0, 2, 3, 3, expected_0_2_3_3, ARRSIZE(expected_0_2_3_3));
+    char* expected_1_2_3_3[2] = {"0","2"}; // seg=1
+    test_list(1, 2, 3, 3, expected_1_2_3_3, ARRSIZE(expected_1_2_3_3));
+
+    /* special case -- no fragments */
+    MemoryContext old_context = CurrentMemoryContext;
+    PG_TRY();
+    {
+        test_list(0, 1, 1, 0, NULL, 0);
+        assert_false("Expected Exception");
+    }
+    PG_CATCH();
+    {
+        MemoryContextSwitchTo(old_context);
+        ErrorData *edata = CopyErrorData();
+        assert_true(edata->elevel == ERROR);
+        char* expected_message = pstrdup("internal error in pxffragment.c:filter_fragments_for_segment. Parameter list is null.");
+        assert_string_equal(edata->message, expected_message);
+        pfree(expected_message);
+    }
+    PG_END_TRY();
+
+    /* special case -- invalid transaction id */
+    old_context = CurrentMemoryContext;
+    PG_TRY();
+    {
+        test_list(0, 1, 0, 1, NULL, 0);
+        assert_false("Expected Exception");
+    }
+    PG_CATCH();
+    {
+        MemoryContextSwitchTo(old_context);
+        ErrorData *edata = CopyErrorData();
+        assert_true(edata->elevel == ERROR);
+        char* expected_message = pstrdup("internal error in pxffragment.c:filter_fragments_for_segment. Cannot get distributed transaction identifier.");
+        assert_string_equal(edata->message, expected_message);
+        pfree(expected_message);
+    }
+    PG_END_TRY();
+}
+
+static void
+test_list(int segindex, int segtotal, int xid, int fragtotal, char* expected[], int expected_total)
+{
+    /* prepare the input list */
+    List* list = prepare_fragment_list(fragtotal, segindex, segtotal, xid);
+
+    /* filter the list */
+    List* filtered = filter_fragments_for_segment(list);
+
+    /* assert results */
+    if (expected_total > 0)
+    {
+        assert_int_equal(filtered->length, expected_total);
+
+        ListCell* cell;
+        int i;
+        foreach_with_count(cell, filtered, i)
+        {
+            assert_true(compareString(((FragmentData *) lfirst(cell))->index, expected[i]));
+        }
+    }
+    else
+    {
+        assert_true(filtered == NIL);
+    }
+}
+
+static List*
+prepare_fragment_list(int fragtotal, int segindex, int segtotal, int xid)
+{
+    GpIdentity.segindex = segindex;
+    GpIdentity.numsegments = segtotal;
+
+    if (fragtotal > 0)
+        will_return(getDistributedTransactionId, xid);
+
+    List* result = NIL;
+    for (int i=0; i<fragtotal; i++) {
+        FragmentData* fragment = palloc0(sizeof(FragmentData));
+        char index[2];
+        sprintf(index, "%d", i);
+        fragment->index = pstrdup(index);
+        result = lappend(result, fragment);
+    }
+    return result;
+}
+
+static FragmentData* buildFragment(const char* index, const char *source, const char *userdata, const char *metadata, const char *profile)
+{
+    FragmentData* fragment = (FragmentData*)palloc0(sizeof(FragmentData));
+    fragment->index = index;
+    fragment->source_name = source;
+    fragment->profile = profile;
+    fragment->fragment_md = metadata;
+    fragment->user_data = userdata;
+    return fragment;
+}
+
+void test_parse_get_fragments_response(void **state)
+{
+    List *expected_data_fragments = NIL;
+    expected_data_fragments = lappend(expected_data_fragments, buildFragment("0", "demo/text2.csv", "dummyuserdata1", "metadatavalue1", "DemoProfile"));
+    expected_data_fragments = lappend(expected_data_fragments, buildFragment("1", "demo/text_csv.csv", "dummyuserdata2", "metadatavalue2", "DemoProfile"));
+    List *data_fragments = NIL;
+    StringInfoData frag_json;
+    initStringInfo(&frag_json);
+    appendStringInfo(&frag_json, "{\"PXFFragments\":[{\"index\":0,\"sourceName\":\"demo/text2.csv\",\"userData\":\"dummyuserdata1\",\"metadata\":\"metadatavalue1\",\"replicas\":[\"localhost\",\"localhost\",\"localhost\"],\"profile\":\"DemoProfile\"},{\"index\":1,\"sourceName\":\"demo/text_csv.csv\",\"userData\":\"dummyuserdata2\",\"metadata\":\"metadatavalue2\",\"replicas\":[\"localhost\",\"localhost\",\"localhost\"],\"profile\":\"DemoProfile\"}]}");
+    data_fragments = parse_get_fragments_response(data_fragments, &frag_json);
+    assert_true(compareLists(data_fragments, expected_data_fragments, compareFragment));
+}
+
+void test_parse_get_fragments_response_bad_index(void **state)
+{
+    List *expected_data_fragments = NIL;
+    expected_data_fragments = lappend(expected_data_fragments, buildFragment("4", "demo/text2.csv", "dummyuserdata1", "metadatavalue1", NULL));
+    expected_data_fragments = lappend(expected_data_fragments, buildFragment("1", "demo/text_csv.csv", "dummyuserdata2", "metadatavalue2", NULL));
+    List *data_fragments = NIL;
+    StringInfoData frag_json;
+    initStringInfo(&frag_json);
+    appendStringInfo(&frag_json, "{\"PXFFragments\":[{\"index\":0,\"sourceName\":\"demo/text2.csv\",\"userData\":\"dummyuserdata1\",\"metadata\":\"metadatavalue1\",\"replicas\":[\"localhost\",\"localhost\",\"localhost\"]},{\"index\":1,\"sourceName\":\"demo/text_csv.csv\",\"userData\":\"dummyuserdata2\",\"metadata\":\"metadatavalue2\",\"replicas\":[\"localhost\",\"localhost\",\"localhost\"]}]}");
+    data_fragments = parse_get_fragments_response(data_fragments, &frag_json);
+    assert_false(compareLists(data_fragments, expected_data_fragments, compareFragment));
+}
+
+void test_parse_get_fragments_response_bad_metadata(void **state)
+{
+    List *expected_data_fragments = NIL;
+    expected_data_fragments = lappend(expected_data_fragments, buildFragment("0", "demo/text2.csv", "dummyuserdata1", "metadatavalue5", NULL));
+    List *data_fragments = NIL;
+    StringInfoData frag_json;
+    initStringInfo(&frag_json);
+    appendStringInfo(&frag_json, "{\"PXFFragments\":[{\"index\":0,\"sourceName\":\"demo/text2.csv\",\"userData\":\"dummyuserdata1\",\"metadata\":\"metadatavalue1\",\"replicas\":[\"localhost\",\"localhost\",\"localhost\"]}]}");
+    data_fragments = parse_get_fragments_response(data_fragments, &frag_json);
+    assert_false(compareLists(data_fragments, expected_data_fragments, compareFragment));
+}
+
+void test_parse_get_fragments_response_nulluserdata(void **state)
+{
+    List *data_fragments = NIL;
+    List *expected_data_fragments = NIL;
+    expected_data_fragments = lappend(expected_data_fragments, buildFragment("1", "demo/text2.csv", NULL, "metadatavalue1", "DemoProfile"));
+    StringInfoData frag_json;
+    initStringInfo(&frag_json);
+    appendStringInfo(&frag_json, "{\"PXFFragments\":[{\"index\":1,\"userData\":null,\"sourceName\":\"demo/text2.csv\",\"metadata\":\"metadatavalue1\",\"replicas\":[\"localhost\",\"localhost\",\"localhost\"],\"profile\":\"DemoProfile\"}]}");
+    data_fragments = parse_get_fragments_response(data_fragments, &frag_json);
+    assert_true(compareLists(data_fragments, expected_data_fragments, compareFragment));
+}
+
+void test_parse_get_fragments_response_nullfragment(void **state)
+{
+    List *data_fragments = NIL;
+    StringInfoData frag_json;
+    initStringInfo(&frag_json);
+    appendStringInfo(&frag_json, "{}");
+    data_fragments = parse_get_fragments_response(data_fragments, &frag_json);
+    assert_true(data_fragments == NULL);
+}
+
+
+void test_parse_get_fragments_response_emptyfragment(void **state)
+{
+    List *data_fragments = NIL;
+    StringInfoData frag_json;
+    initStringInfo(&frag_json);
+    appendStringInfo(&frag_json, "{\"PXFFragments\":[]}");
+    data_fragments = parse_get_fragments_response(data_fragments, &frag_json);
+    assert_true(data_fragments == NULL);
+}
+
+void
+test_call_rest(void **state)
+{
+    GPHDUri *hadoop_uri = (GPHDUri*) palloc0(sizeof(GPHDUri));
+    hadoop_uri->host = "host";
+    hadoop_uri->port = "123";
+
+
+    ClientContext *client_context = (ClientContext*) palloc0(sizeof(ClientContext));
+    client_context->http_headers = (CHURL_HEADERS) palloc0(sizeof(CHURL_HEADERS));
+    initStringInfo(&(client_context->the_rest_buf));
+
+    CHURL_HANDLE handle = (CHURL_HANDLE) palloc0(sizeof(CHURL_HANDLE));
+
+    char *rest_msg = "http://%s:%s/%s/%s";
+
+    expect_value(print_http_headers, headers, client_context->http_headers);
+    will_be_called(print_http_headers);(client_context->http_headers);
+
+
+    StringInfoData expected_url;
+    initStringInfo(&expected_url);
+    appendStringInfo(&expected_url, "http://host:123/%s/%s", PXF_SERVICE_PREFIX, PXF_VERSION);
+
+    expect_string(churl_init_download, url, expected_url.data);
+    expect_value(churl_init_download, headers, client_context->http_headers);
+    will_return(churl_init_download, handle);
+
+    expect_value(churl_read_check_connectivity, handle, handle);
+    will_be_called(churl_read_check_connectivity);
+
+    /* first call to read should return Hello */
+    expect_value(churl_read, handle, handle);
+    expect_any(churl_read, buf);
+    expect_any(churl_read, max_size);
+
+    char* str = pstrdup("Hello ");
+
+    //will_assign_memory(churl_read, buf, str, 7);
+    will_return(churl_read, 7);
+
+    /* second call to read should return World */
+    expect_value(churl_read, handle, handle);
+    expect_any(churl_read, buf);
+    expect_any(churl_read, max_size);
+    //will_assign_memory(churl_read, buf, "World", 6);
+    will_return(churl_read, 6);
+
+    /* third call will return nothing */
+    expect_value(churl_read, handle, handle);
+    expect_any(churl_read, buf);
+    expect_any(churl_read, max_size);
+    will_return(churl_read, 0);
+
+    expect_value(churl_cleanup, handle, handle);
+    expect_value(churl_cleanup, after_error, false);
+    will_be_called(churl_cleanup);
+
+    call_rest(hadoop_uri, client_context, rest_msg);
+
+    //TODO: debug this, seems will_assign_memory is not quite working
+    //assert_string_equal(client_context->the_rest_buf.data, "Hello World");
+
+    pfree(expected_url.data);
+    pfree(client_context->http_headers);
+    pfree(client_context);
+    pfree(hadoop_uri);
+}
+
+static bool compareLists(List* list1, List* list2, bool (*compareType)(void*, void*) )
+{
+    if ( (list1 && !list2) || (list2 && !list1) || (list1->length != list2->length) )
+        return false;
+
+    int outerIndex = 0;
+    ListCell *object1 = NULL;
+    ListCell *object2 = NULL;
+    foreach (object1, list1)
+    {
+        bool isExists = false;
+        int innerIndex = 0;
+        foreach (object2, list2)
+        {
+            innerIndex++;
+            if((*compareType)(object1, object2)) {
+                isExists = true;
+                break;
+            }
+        }
+        outerIndex++;
+        if(!isExists)
+            return false;
+    }
+
+    return true;
+}
+
+static bool compareString(char* str1, char* str2)
+{
+    if( ((str1 == NULL) && (str2 == NULL)) || (strcmp(str1, str2) == 0) )
+        return true;
+    else
+        return false;
+}
+
+static bool compareFragment(ListCell* fragment_cell1, ListCell* fragment_cell2)
+{
+    FragmentData	*fragment1	= (FragmentData*)lfirst(fragment_cell1);
+    FragmentData	*fragment2	= (FragmentData*)lfirst(fragment_cell2);
+    return( compareString(fragment1->index, fragment2->index) &&
+            compareString(fragment1->source_name, fragment2->source_name) &&
+            compareString(fragment1->fragment_md, fragment2->fragment_md) &&
+            compareString(fragment1->user_data, fragment2->user_data) &&
+            compareString(fragment1->profile, fragment2->profile) );
+}
+
+
+int
+main(int argc, char* argv[])
+{
+    cmockery_parse_arguments(argc, argv);
+
+    const UnitTest tests[] = {
+            unit_test(test_filter_fragments_for_segment),
+            unit_test(test_parse_get_fragments_response),
+            unit_test(test_parse_get_fragments_response_bad_metadata),
+            unit_test(test_parse_get_fragments_response_bad_index),
+            unit_test(test_parse_get_fragments_response_nullfragment),
+            unit_test(test_parse_get_fragments_response_emptyfragment),
+            unit_test(test_parse_get_fragments_response_nulluserdata),
+            unit_test(test_call_rest)
+    };
+
+    MemoryContextInit();
+
+    return run_tests(tests);
+}

--- a/gpAux/extensions/pxf/test/pxffragment_test.c
+++ b/gpAux/extensions/pxf/test/pxffragment_test.c
@@ -30,8 +30,6 @@ static bool compareFragment(ListCell* fragment_cell1, ListCell* fragment_cell2);
 void
 test_filter_fragments_for_segment(void **state)
 {
-    expect_any_count(free_fragment, data, -1);
-    will_be_called_count(free_fragment, -1);
     /* --- 1 segment, all fragements should be processed by it */
     char* expected_1_1_0[1] = {"0"}; // 1 fragment
     test_list(0, 1, 1, 1, expected_1_1_0, ARRSIZE(expected_1_1_0)); // xid=1

--- a/gpAux/extensions/pxf/test/pxfprotocol_test.c
+++ b/gpAux/extensions/pxf/test/pxfprotocol_test.c
@@ -112,10 +112,10 @@ test_pxfprotocol_import_first_call(void **state)
 
     /* set mock behavior for set fragments */
     gphd_uri->fragments = palloc0(sizeof(List));
-    expect_value(set_fragments, uri, gphd_uri);
-    expect_value(set_fragments, relation, relation);
-    will_assign_memory(set_fragments, uri, gphd_uri, sizeof(GPHDUri));
-    will_be_called(set_fragments);
+    expect_value(get_fragments, uri, gphd_uri);
+    expect_value(get_fragments, relation, relation);
+    will_assign_memory(get_fragments, uri, gphd_uri, sizeof(GPHDUri));
+    will_be_called(get_fragments);
 
     /* set mock behavior for bridge import start -- nothing here */
     expect_any(gpbridge_import_start, context);

--- a/gpAux/extensions/pxf/test/pxfprotocol_test.c
+++ b/gpAux/extensions/pxf/test/pxfprotocol_test.c
@@ -31,10 +31,10 @@
 /* include mock files */
 #include "mock/pxfbridge_mock.c"
 #include "mock/pxfuriparser_mock.c"
+#include "mock/pxffragment_mock.c"
 
 const char* uri_no_profile = "pxf://default/tmp/dummy1?FRAGMENTER=xxx&RESOLVER=yyy&ACCESSOR=zzz";
 const char* uri_param = "pxf://localhost:51200/tmp/dummy1";
-const char* uri_param_segwork = "pxf://localhost:51200/tmp/dummy1&segwork=46@127.0.0.1@51200@tmp/dummy1.1@0@ZnJhZ21lbnQx@@@";
 
 void
 test_pxfprotocol_validate_urls(void **state)
@@ -107,9 +107,15 @@ test_pxfprotocol_import_first_call(void **state)
 
     /* set mock behavior for uri parsing */
     GPHDUri* gphd_uri = palloc0(sizeof(GPHDUri));
-    gphd_uri->fragments = palloc(sizeof(List));
-    expect_string(parseGPHDUri, uri_str, uri_param_segwork);
+    expect_string(parseGPHDUri, uri_str, uri_param);
     will_return(parseGPHDUri, gphd_uri);
+
+    /* set mock behavior for set fragments */
+    gphd_uri->fragments = palloc0(sizeof(List));
+    expect_value(set_fragments, uri, gphd_uri);
+    expect_value(set_fragments, relation, relation);
+    will_assign_memory(set_fragments, uri, gphd_uri, sizeof(GPHDUri));
+    will_be_called(set_fragments);
 
     /* set mock behavior for bridge import start -- nothing here */
     expect_any(gpbridge_import_start, context);

--- a/gpAux/extensions/pxf/test/pxfuriparser_test.c
+++ b/gpAux/extensions/pxf/test/pxfuriparser_test.c
@@ -33,9 +33,7 @@ static void test_parseGPHDUri_helper(const char* uri, const char* message);
 static void test_parseFragment_helper(const char* fragment, const char* message);
 static void test_verify_cluster_exception_helper(const char* uri_str);
 
-static char uri_with_no_segwork[] = "pxf://default/some/path/and/table.tbl?FRAGMENTER=SomeFragmenter&ACCESSOR=SomeAccessor&RESOLVER=SomeResolver&ANALYZER=SomeAnalyzer";
-static char uri_with_segwork_1[]  = "pxf://default/some/path/and/table.tbl?FRAGMENTER=SomeFragmenter&ACCESSOR=SomeAccessor&RESOLVER=SomeResolver&ANALYZER=SomeAnalyzer&segwork=42@127.0.0.1@51200@tmp/test@0@ZnJhZ21lbnQx@@@";
-static char uri_with_segwork_2[]  = "pxf://default/some/path/and/table.tbl?FRAGMENTER=SomeFragmenter&ACCESSOR=SomeAccessor&RESOLVER=SomeResolver&ANALYZER=SomeAnalyzer&segwork=42@127.0.0.1@51200@tmp/test@0@ZnJhZ21lbnQx@@@41@127.0.0.1@51200@tmp/foo@0@ZnJhZ21lbnQx@@@";
+static char uri[] = "pxf://default/some/path/and/table.tbl?FRAGMENTER=SomeFragmenter&ACCESSOR=SomeAccessor&RESOLVER=SomeResolver&ANALYZER=SomeAnalyzer";
 
 /*
  * Test parsing of valid uri as given in LOCATION in a PXF external table.
@@ -43,10 +41,10 @@ static char uri_with_segwork_2[]  = "pxf://default/some/path/and/table.tbl?FRAGM
 void
 test_parseGPHDUri_ValidURI(void **state)
 {
-    GPHDUri* parsed = parseGPHDUri(uri_with_segwork_1);
+    GPHDUri* parsed = parseGPHDUri(uri);
 
     assert_true(parsed != NULL);
-    assert_string_equal(parsed->uri, uri_with_no_segwork);
+    assert_string_equal(parsed->uri, uri);
 
     assert_string_equal(parsed->protocol, "pxf");
     assert_string_equal(parsed->host, PxfDefaultHost);
@@ -76,13 +74,8 @@ test_parseGPHDUri_ValidURI(void **state)
     assert_string_equal(option->key, ANALYZER);
     assert_string_equal(option->value, "SomeAnalyzer");
 
-    assert_true(parsed->fragments != NULL);
-    assert_int_equal(parsed->fragments->length, 1);
-    assert_string_equal(((FragmentData*)linitial(parsed->fragments))->source_name, "tmp/test");
-
     assert_true(parsed->profile == NULL);
 
-    GPHDUri_free_fragments(parsed);
     freeGPHDUri(parsed);
 }
 
@@ -154,179 +147,6 @@ test_parseGPHDUri_NegativeTestMissingValue(void **state)
 {
     char* uri = "pxf://default/some/path/and/table.tbl?FRAGMENTER=";
     test_parseGPHDUri_helper(uri, ": option 'FRAGMENTER=' missing value after '='");
-}
-
-/*
- * Test GPHDUri_parse_fragment when fragment string is valid and all parameters are passed
- */
-void
-test_GPHDUri_parse_fragment_ValidFragment(void **state)
-{
-    char* fragment = "HOST@REST_PORT@TABLE_NAME@INDEX@FRAGMENT_METADATA@USER_DATA@PROFILE@";
-
-    List *fragments = NIL;
-
-    fragments = GPHDUri_parse_fragment(fragment, fragments);
-
-    ListCell *fragment_cell = list_head(fragments);
-    FragmentData *fragment_data = (FragmentData*) lfirst(fragment_cell);
-
-    assert_string_equal(fragment_data->authority, "HOST:REST_PORT");
-    assert_string_equal(fragment_data->fragment_md, "FRAGMENT_METADATA");
-    assert_string_equal(fragment_data->index, "INDEX");
-    assert_string_equal(fragment_data->profile, "PROFILE");
-    assert_string_equal(fragment_data->source_name, "TABLE_NAME");
-    assert_string_equal(fragment_data->user_data, "USER_DATA");
-    assert_true(fragment_cell->next == NULL);
-
-    GPHDUri_free_fragment(fragment_data);
-    list_free(fragments);
-}
-
-/*
- * Test GPHDUri_parse_fragment when fragment string doesn't have profile
- */
-void
-test_GPHDUri_parse_fragment_EmptyProfile(void **state)
-{
-    char* fragment = "HOST@REST_PORT@TABLE_NAME@INDEX@FRAGMENT_METADATA@USER_DATA@@";
-
-    List *fragments = NIL;
-
-    fragments = GPHDUri_parse_fragment(fragment, fragments);
-
-    ListCell *fragment_cell = list_head(fragments);
-    FragmentData *fragment_data = (FragmentData*) lfirst(fragment_cell);
-
-    assert_string_equal(fragment_data->authority, "HOST:REST_PORT");
-    assert_string_equal(fragment_data->fragment_md, "FRAGMENT_METADATA");
-    assert_string_equal(fragment_data->index, "INDEX");
-    assert_true(!fragment_data->profile);
-    assert_string_equal(fragment_data->source_name, "TABLE_NAME");
-    assert_string_equal(fragment_data->user_data, "USER_DATA");
-
-    GPHDUri_free_fragment(fragment_data);
-    list_free(fragments);
-}
-
-/*
- * Test GPHDUri_parse_fragment when fragment string is empty
- */
-void
-test_GPHDUri_parse_fragment_EmptyString(void **state)
-{
-    char* fragment = "";
-    test_parseFragment_helper(fragment, "internal error in GPHDUri_parse_fragment. Fragment string is invalid.");
-}
-
-/*
- * Test GPHDUri_parse_fragment when fragment string is null
- */
-void
-test_GPHDUri_parse_fragment_NullFragment(void **state)
-{
-    char *fragment = NULL;
-    test_parseFragment_helper(fragment, "internal error in GPHDUri_parse_fragment. Fragment string is null.");
-}
-
-/*
- * Test GPHDUri_parse_fragment when fragment string has less tokens then expected
- */
-void
-test_GPHDUri_parse_fragment_MissingIpHost(void **state)
-{
-    char* fragment = "@";
-    test_parseFragment_helper(fragment, "internal error in GPHDUri_parse_fragment. Fragment string is invalid.");
-}
-
-/*
- * Test GPHDUri_parse_fragment when fragment string has less tokens then expected
- */
-void
-test_GPHDUri_parse_fragment_MissingPort(void **state)
-{
-    char* fragment = "@HOST@";
-    test_parseFragment_helper(fragment, "internal error in GPHDUri_parse_fragment. Fragment string is invalid.");
-}
-
-/*
- * Test GPHDUri_parse_fragment when fragment string has less tokens then expected
- */
-void
-test_GPHDUri_parse_fragment_MissingSourceName(void **state)
-{
-    char* fragment = "@HOST@PORT@";
-    test_parseFragment_helper(fragment, "internal error in GPHDUri_parse_fragment. Fragment string is invalid.");
-}
-
-/*
- * Test GPHDUri_parse_fragment when fragment string has less tokens then expected
- */
-void
-test_GPHDUri_parse_fragment_MissingIndex(void **state)
-{
-    char* fragment = "@HOST@PORT@SOURCE_NAME@";
-    test_parseFragment_helper(fragment, "internal error in GPHDUri_parse_fragment. Fragment string is invalid.");
-}
-
-/*
- * Test GPHDUri_parse_fragment when fragment string has less tokens then expected
- */
-void
-test_GPHDUri_parse_fragment_MissingFragmentMetadata(void **state)
-{
-    char* fragment = "@HOST@PORT@SOURCE_NAME@42@";
-    test_parseFragment_helper(fragment, "internal error in GPHDUri_parse_fragment. Fragment string is invalid.");
-}
-
-/*
- * Test GPHDUri_parse_fragment when fragment string has less tokens then expected
- */
-void
-test_GPHDUri_parse_fragment_MissingUserData(void **state)
-{
-    char* fragment = "HOST@REST_PORT@TABLE_NAME@INDEX@FRAGMENT_METADATA@";
-    test_parseFragment_helper(fragment, "internal error in GPHDUri_parse_fragment. Fragment string is invalid.");
-}
-
-/*
- * Test GPHDUri_parse_fragment when fragment string has less tokens then expected
- */
-void
-test_GPHDUri_parse_fragment_MissingProfile(void **state)
-{
-    char* fragment = "HOST@REST_PORT@TABLE_NAME@INDEX@FRAGMENT_METADATA@USER_METADATA@";
-    test_parseFragment_helper(fragment, "internal error in GPHDUri_parse_fragment. Fragment string is invalid.");
-}
-
-/*
- * Test GPHDUri_parse_fragment when there is no segwork in the URI
- */
-void
-test_GPHDUri_parse_segwork_NoSegwork(void **state)
-{
-    GPHDUri *uri = (GPHDUri *)palloc0(sizeof(GPHDUri));
-    GPHDUri_parse_segwork(uri, uri_with_no_segwork);
-    assert_true(uri->fragments == NULL);
-    pfree(uri);
-}
-
-/*
- * Test GPHDUri_parse_fragment when there are more than one fragments in segwork
- */
-void
-test_GPHDUri_parse_segwork_TwoFragments(void **state)
-{
-    GPHDUri *uri = (GPHDUri *)palloc0(sizeof(GPHDUri));
-    GPHDUri_parse_segwork(uri, uri_with_segwork_2);
-
-    assert_true(uri->fragments != NULL);
-    assert_int_equal(uri->fragments->length, 2);
-    assert_string_equal(((FragmentData*)linitial(uri->fragments))->source_name, "tmp/test");
-    assert_string_equal(((FragmentData*)lsecond(uri->fragments))->source_name, "tmp/foo");
-
-    list_free_deep(uri->fragments);
-    pfree(uri);
 }
 
 /*
@@ -507,43 +327,6 @@ test_verify_cluster_exception_helper(const char* uri_str)
 }
 
 /*
- * Helper function for parse fragment test cases
- */
-static void
-test_parseFragment_helper(const char* fragment, const char* message)
-{
-    List *fragments = NIL;
-
-    MemoryContext old_context = CurrentMemoryContext;
-    PG_TRY();
-    {
-        /* This will throw a ereport(ERROR).*/
-        fragments = GPHDUri_parse_fragment(fragment, fragments);
-        assert_false("Expected Exception");
-    }
-    PG_CATCH();
-    {
-        MemoryContextSwitchTo(old_context);
-        ErrorData *edata = CopyErrorData();
-        FlushErrorState();
-
-        StringInfo err_msg = makeStringInfo();
-        appendStringInfo(err_msg, message);
-
-        /* Validate the type of expected error */
-        assert_true(edata->sqlerrcode == ERRCODE_INTERNAL_ERROR);
-        assert_true(edata->elevel == ERROR);
-        assert_string_equal(edata->message, err_msg->data);
-
-        list_free(fragments);
-        pfree(err_msg->data);
-        pfree(err_msg);
-        elog_dismiss(INFO);
-    }
-    PG_END_TRY();
-}
-
-/*
  * Helper function for parse uri test cases
  */
 static void
@@ -591,19 +374,6 @@ main(int argc, char* argv[])
             unit_test(test_parseGPHDUri_NegativeTestDuplicateEquals),
             unit_test(test_parseGPHDUri_NegativeTestMissingKey),
             unit_test(test_parseGPHDUri_NegativeTestMissingValue),
-            unit_test(test_GPHDUri_parse_fragment_EmptyProfile),
-            unit_test(test_GPHDUri_parse_fragment_ValidFragment),
-            unit_test(test_GPHDUri_parse_fragment_EmptyString),
-            unit_test(test_GPHDUri_parse_fragment_NullFragment),
-            unit_test(test_GPHDUri_parse_fragment_MissingIpHost),
-            unit_test(test_GPHDUri_parse_fragment_MissingPort),
-            unit_test(test_GPHDUri_parse_fragment_MissingSourceName),
-            unit_test(test_GPHDUri_parse_fragment_MissingIndex),
-            unit_test(test_GPHDUri_parse_fragment_MissingFragmentMetadata),
-            unit_test(test_GPHDUri_parse_fragment_MissingUserData),
-            unit_test(test_GPHDUri_parse_fragment_MissingProfile),
-            unit_test(test_GPHDUri_parse_segwork_NoSegwork),
-            unit_test(test_GPHDUri_parse_segwork_TwoFragments),
             unit_test(test_GPHDUri_opt_exists),
             unit_test(test_GPHDUri_verify_no_duplicate_options),
             unit_test(test_GPHDUri_verify_core_options_exist),

--- a/gpAux/extensions/pxf/test/pxfuriparser_test.c
+++ b/gpAux/extensions/pxf/test/pxfuriparser_test.c
@@ -52,7 +52,7 @@ test_parseGPHDUri_ValidURI(void **state)
 
     assert_string_equal(parsed->protocol, "pxf");
     assert_string_equal(parsed->host, PxfDefaultHost);
-    assert_string_equal(parsed->port, port.data);
+    assert_string_equal(parsed->port, pstrdup(port.data));
     assert_string_equal(parsed->data, "some/path/and/table.tbl");
 
     List *options = parsed->options;

--- a/gpAux/extensions/pxf/test/pxfuriparser_test.c
+++ b/gpAux/extensions/pxf/test/pxfuriparser_test.c
@@ -29,8 +29,9 @@
 #include "../src/pxfutils.c"
 #include "../src/pxfuriparser.c"
 
+#include "mock/pxffragment_mock.c"
+
 static void test_parseGPHDUri_helper(const char* uri, const char* message);
-static void test_parseFragment_helper(const char* fragment, const char* message);
 static void test_verify_cluster_exception_helper(const char* uri_str);
 
 static char uri[] = "pxf://default/some/path/and/table.tbl?FRAGMENTER=SomeFragmenter&ACCESSOR=SomeAccessor&RESOLVER=SomeResolver&ANALYZER=SomeAnalyzer";
@@ -41,14 +42,20 @@ static char uri[] = "pxf://default/some/path/and/table.tbl?FRAGMENTER=SomeFragme
 void
 test_parseGPHDUri_ValidURI(void **state)
 {
+//    expect_any_count(free_fragment, data, -1);
+//    will_be_called_count(free_fragment, -1);
+
     GPHDUri* parsed = parseGPHDUri(uri);
+    StringInfoData port;
+    initStringInfo(&port);
+    appendStringInfo(&port, "%d", PxfDefaultPort);
 
     assert_true(parsed != NULL);
     assert_string_equal(parsed->uri, uri);
 
     assert_string_equal(parsed->protocol, "pxf");
     assert_string_equal(parsed->host, PxfDefaultHost);
-    assert_string_equal(parsed->port, PxfDefaultPortStr);
+    assert_string_equal(parsed->port, port.data);
     assert_string_equal(parsed->data, "some/path/and/table.tbl");
 
     List *options = parsed->options;

--- a/gpAux/extensions/pxf/test/pxfuriparser_test.c
+++ b/gpAux/extensions/pxf/test/pxfuriparser_test.c
@@ -42,9 +42,6 @@ static char uri[] = "pxf://default/some/path/and/table.tbl?FRAGMENTER=SomeFragme
 void
 test_parseGPHDUri_ValidURI(void **state)
 {
-//    expect_any_count(free_fragment, data, -1);
-//    will_be_called_count(free_fragment, -1);
-
     GPHDUri* parsed = parseGPHDUri(uri);
     StringInfoData port;
     initStringInfo(&port);

--- a/gpAux/extensions/pxf/test/pxfutils_test.c
+++ b/gpAux/extensions/pxf/test/pxfutils_test.c
@@ -29,45 +29,6 @@
 #include "../src/pxfutils.c"
 
 void
-test_are_ips_equal(void **state)
-{
-    assert_false(are_ips_equal(NULL, "ip"));
-    assert_false(are_ips_equal("ip", NULL));
-    assert_false(are_ips_equal("ip", "pi"));
-    assert_false(are_ips_equal("IP", "ip"));
-    assert_true(are_ips_equal("ip", "ip"));
-}
-
-void
-test_port_to_str(void **state)
-{
-
-    char* port = pstrdup("123");
-    port_to_str(&port, 65535);
-    assert_string_equal(port, "65535");
-
-    /* test null original port */
-    MemoryContext old_context = CurrentMemoryContext;
-    PG_TRY();
-    {
-        port = pstrdup("123");
-        port_to_str(NULL, 65535);
-        assert_false("Expected Exception");
-    }
-    PG_CATCH();
-    {
-        MemoryContextSwitchTo(old_context);
-        ErrorData *edata = CopyErrorData();
-        assert_true(edata->elevel == ERROR);
-        char* expected_message = pstrdup("unexpected internal error in pxfutils.c");
-        assert_string_equal(edata->message, expected_message);
-        pfree(expected_message);
-        pfree(port);
-    }
-    PG_END_TRY();
-}
-
-void
 test_normalize_key_name(void **state)
 {
     char* replaced = normalize_key_name("bar");
@@ -121,8 +82,6 @@ main(int argc, char* argv[])
     cmockery_parse_arguments(argc, argv);
 
     const UnitTest tests[] = {
-            unit_test(test_are_ips_equal),
-            unit_test(test_port_to_str),
             unit_test(test_normalize_key_name)
     };
 


### PR DESCRIPTION
Signed-off-by: John Gaskin <johntgaskin@gmail.com>
Signed-off-by: Shivram Mani <shivram.mani@gmail.com>

Integrated PXF Fragmenter and Bridge client. The fragmenter uses a segment driven decentralized approach to fetch the external data metadata information(location, format, serde, etc in json) prior to the block reads. GPDB segments invoke the fragmenter. We uniformly distribute fragment read work to the gpdb segments based on a simple work allocation algorithm. 

Thanks to @denalex for contributing the fragment allocation module and @lavjain for helping out with the merge.
