### PR TITLE
Gprecoverseg respects checksum

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -1446,7 +1446,6 @@ jobs:
       PULSE_PROJECT_NAME: "GPDB-BehaveGPCheckcat"
 
 - name: MM_gprecoverseg
-  max_in_flight: 1
   plan:
   - aggregate:
     - get: gpdb_src

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -19,9 +19,9 @@
 # THIS IMPORT SHOULD COME FIRST
 from gppylib.mainUtils import *
 
-from optparse import Option, OptionGroup, OptionParser, OptionValueError, SUPPRESS_USAGE
-import os, sys, getopt, socket, StringIO, signal, time
-from gppylib import gparray, gplog, pgconf, userinput, utils
+from optparse import OptionGroup
+import os, sys, signal, time
+from gppylib import gparray, gplog, userinput, utils
 from gppylib.util import gp_utils
 from gppylib.commands import base, gp, pg, unix
 from gppylib.db import dbconn
@@ -41,8 +41,6 @@ from gppylib.utils import ParsedConfigFile, ParsedConfigFileRow, writeLinesToFil
 from gppylib.gphostcache import GpInterfaceToHostNameCache
 from gppylib.operations.utils import ParallelOperation
 from gppylib.operations.package import SyncPackages
-
-import gppylib.commands.gp
 
 logger = gplog.get_default_logger()
 
@@ -226,8 +224,9 @@ class GpRecoverSegmentProgram:
                         #
                         # this could be an assertion -- configuration should not allow multiple entries!
                         #
-                        raise Exception(("A segment to recover was found twice in configuration.  " \
-                                         "This segment is described by address:port:directory '%s:%s:%s' on the input line: %s") %
+                        raise Exception(("A segment to recover was found twice in configuration.  "
+                                         "This segment is described by address:port:directory '%s:%s:%s' "
+                                         "on the input line: %s") %
                                         (failedAddress, failedPort, failedDataDirectory, row.getLine()))
                     failedSegment = segment
 
@@ -301,7 +300,7 @@ class GpRecoverSegmentProgram:
 
                 segs_in_change_tracking_disabled.append(peerForFailedSegmentDbId)
             else:
-                segs.append(GpMirrorToBuild(failedSegment, peerForFailedSegment, failoverSegments[index], \
+                segs.append(GpMirrorToBuild(failedSegment, peerForFailedSegment, failoverSegments[index],
                                             self.__options.forceFullResynchronization))
 
         self._output_segments_in_change_tracking_disabled(segs_in_change_tracking_disabled)
@@ -546,10 +545,13 @@ class GpRecoverSegmentProgram:
                              (', '.join(str(seg_id) for seg_id in segs_persistent_mirroring_disabled)))
 
     def is_segment_mirror_state_mismatched(self, gpArray, segment):
-        if gpArray.getFaultStrategy() == gparray.FAULT_STRATEGY_FILE_REPLICATION:  # Determines whether cluster has mirrors
+        if gpArray.getFaultStrategy() == gparray.FAULT_STRATEGY_FILE_REPLICATION:
+            # Determines whether cluster has mirrors
             with dbconn.connect(dbconn.DbURL()) as conn:
                 res = dbconn.execSQL(conn,
-                                     "SELECT mirror_existence_state from gp_dist_random('gp_persistent_relation_node') where gp_segment_id=%s group by 1;" % segment.getSegmentContentId()).fetchall()
+                                     "SELECT mirror_existence_state "
+                                     "from gp_dist_random('gp_persistent_relation_node') "
+                                     "where gp_segment_id=%s group by 1;" % segment.getSegmentContentId()).fetchall()
                 # For a mirrored system, there should not be any mirror_existance_state entries with no mirrors.
                 # If any exist, the segment contains a PT inconsistency.
                 for state in res:
@@ -994,7 +996,8 @@ class GpRecoverSegmentProgram:
         for item in self.__pool.getCompletedItems():
             res = item.get_results()
             if res:
-                self.logger.error('Persistent table check %s failed on host %s:%s.' % (item.qname, item.hostname, item.port))
+                self.logger.error(
+                    'Persistent table check %s failed on host %s:%s.' % (item.qname, item.hostname, item.port))
                 self.logger.debug('Result = %s' % res)
                 persistent_check_failed = True
 
@@ -1134,8 +1137,7 @@ class GpRecoverSegmentProgram:
         if self.__options.rebalanceSegments:
             optionCnt += 1
         if optionCnt > 1:
-            raise ProgramArgumentValidationException( \
-                "Only one of -i, -p, -s, -r, and -S may be specified")
+            raise ProgramArgumentValidationException("Only one of -i, -p, -s, -r, and -S may be specified")
 
         faultProberInterface.getFaultProber().initializeProber(gpEnv.getMasterPort())
 
@@ -1149,7 +1151,7 @@ class GpRecoverSegmentProgram:
         self.check_segment_state_ready_for_recovery(gpArray.getSegDbList(), gpArray.getSegDbMap())
 
         if gpArray.getFaultStrategy() != gparray.FAULT_STRATEGY_FILE_REPLICATION:
-            raise ExceptionNoStackTraceNeeded( \
+            raise ExceptionNoStackTraceNeeded(
                 'GPDB Mirroring replication is not configured for this Greenplum Database instance.')
 
         # We have phys-rep/filerep mirrors.
@@ -1258,7 +1260,6 @@ class GpRecoverSegmentProgram:
             os.remove(pidfile)
         os._exit(0)
 
-
     def cleanup(self):
         if self.__pool:
             self.__pool.haltWork()  # \  MPP-13489, CR-2572
@@ -1333,8 +1334,7 @@ class GpRecoverSegmentProgram:
     @staticmethod
     def createProgram(options, args):
         if len(args) > 0:
-            raise ProgramArgumentValidationException( \
-                "too many arguments: only options may be specified", True)
+            raise ProgramArgumentValidationException("too many arguments: only options may be specified", True)
         return GpRecoverSegmentProgram(options)
 
     @staticmethod

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
@@ -1,0 +1,184 @@
+import os
+import shutil
+import sys
+import tempfile
+
+from mock import *
+
+from gp_unittest import *
+from gparray import GpArray, GpDB, FAULT_STRATEGY_FILE_REPLICATION
+from gppylib.heapchecksum import HeapChecksum
+from gppylib.operations.buildMirrorSegments import GpMirrorToBuild, GpMirrorListToBuild
+from pgconf import gucdict, setting
+from system import faultProberInterface
+from system.configurationInterface import GpConfigurationProvider
+
+
+class Options:
+    def __init__(self):
+        self.newRecoverHosts = None
+        self.spareDataDirectoryFile = ""
+        self.recoveryConfigFile = None
+        self.outputSpareDataDirectoryFile = None
+        self.rebalanceSegments = None
+
+        self.outputSampleConfigFile = None
+        self.parallelDegree = 1
+        self.forceFullResynchronization = None
+        self.persistent_check = None
+        self.quiet = None
+        self.interactive = False
+
+
+class GpRecoversegTestCase(GpTestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.config_file_path = os.path.join(self.temp_dir, "foo")
+        with open(self.config_file_path, "w") as config_file:
+            config_file.write("")
+
+        self.conn = Mock()
+        self.cursor = FakeCursor()
+        self.db_singleton = Mock()
+
+        self.os_env = dict(USER="my_user")
+        self.os_env["MASTER_DATA_DIRECTORY"] = self.temp_dir
+        self.os_env["GPHOME"] = self.temp_dir
+        self.gparray = self._create_gparray_with_2_primary_2_mirrors()
+
+        self.pool = Mock()
+        self.pool.getCompletedItems.return_value = []
+
+        self.pgconf_dict = gucdict()
+        self.pgconf_dict["port"] = setting("port", "123", None, None, None)
+        self.pgconf_dict["max_connection"] = setting("max_connections", "1", None, None, None)
+
+        configProviderMock = MagicMock(spec=GpConfigurationProvider)
+        configProviderMock.initializeProvider.return_value = configProviderMock
+
+        self.gpArrayMock = MagicMock(spec=GpArray)
+        self.gpArrayMock.getDbList.side_effect = [[], [self.primary0], [self.primary0]]
+        self.gpArrayMock.getFaultStrategy.return_value = FAULT_STRATEGY_FILE_REPLICATION
+        self.gpArrayMock.isStandardArray.return_value = (True, None)
+        self.gpArrayMock.master = self.gparray.master
+
+        configProviderMock.loadSystemConfig.return_value = self.gpArrayMock
+
+        self.mirror_to_build = GpMirrorToBuild(self.mirror0, self.primary0, None, False)
+        self.apply_patches([
+            patch('os.environ', new=self.os_env),
+            patch('gppylib.db.dbconn.connect', return_value=self.conn),
+            patch('gppylib.db.dbconn.execSQL', return_value=self.cursor),
+            patch('gppylib.db.dbconn.execSQLForSingletonRow', return_value=["foo"]),
+            patch('gppylib.commands.base.WorkerPool'),
+            patch('gppylib.pgconf.readfile', return_value=self.pgconf_dict),
+            patch('gppylib.commands.gp.GpVersion'),
+            patch('gppylib.db.catalog.getCollationSettings',
+                  return_value=("en_US.utf-8", "en_US.utf-8", "en_US.utf-8")),
+            patch('gppylib.system.faultProberInterface.getFaultProber'),
+            patch('gppylib.system.configurationInterface.getConfigurationProvider', return_value=configProviderMock),
+            patch('gppylib.commands.base.WorkerPool', return_value=self.pool),
+            patch('gppylib.gparray.GpArray.getSegmentsByHostName', return_value={}),
+            patch('gppylib.gplog.get_default_logger'),
+            patch.object(GpMirrorListToBuild, "__init__", return_value=None),
+            patch.object(GpMirrorListToBuild, "buildMirrors"),
+            patch.object(GpMirrorListToBuild, "getAdditionalWarnings"),
+            patch.object(GpMirrorListToBuild, "getMirrorsToBuild"),
+            patch.object(HeapChecksum, "check_segment_consistency"),
+            patch.object(HeapChecksum, "get_segments_checksum_settings"),
+        ])
+
+        self.call_count = 0
+        self.return_one = True
+
+        self.mock_get_mirrors_to_build = self.get_mock_from_apply_patch('getMirrorsToBuild')
+        self.mock_heap_checksum_init = self.get_mock_from_apply_patch("__init__")
+        self.mock_check_segment_consistency = self.get_mock_from_apply_patch('check_segment_consistency')
+        self.mock_get_segments_checksum_settings = self.get_mock_from_apply_patch('get_segments_checksum_settings')
+
+        sys.argv = ["gprecoverseg"]  # reset to relatively empty args list
+
+        # import HERE so that patches are already in place!
+        from programs.clsRecoverSegment import GpRecoverSegmentProgram
+
+        options = Options()
+        options.masterDataDirectory = self.temp_dir
+        options.spareDataDirectoryFile = self.config_file_path
+
+        self.subject = GpRecoverSegmentProgram(options)
+        self.subject.logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal'])
+
+        faultProberInterface.gFaultProber = Mock()
+
+    def _get_test_mirrors(self):
+        if self.return_one:
+            return [self.mirror_to_build]
+
+        if self.call_count == 0:
+            self.call_count += 1
+            return [self.mirror_to_build]
+        else:
+            self.call_count += 1
+            return []
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+        super(GpRecoversegTestCase, self).tearDown()
+
+    def test_when_checksums_mismatch_it_raises(self):
+        self.primary0.heap_checksum = 0
+        self.mock_check_segment_consistency.return_value = ([], [self.primary0], 1)
+        self.mock_get_segments_checksum_settings.return_value = ([self.mirror0], [])
+        self.return_one = True
+        self.mock_get_mirrors_to_build.side_effect = self._get_test_mirrors
+        self.assertTrue(self.gparray.master.isSegmentMaster(True))
+
+        with self.assertRaisesRegexp(Exception, "Heap checksum setting differences reported on segments"):
+            self.subject.run()
+
+        self.mock_get_segments_checksum_settings.assert_called_with([self.primary0])
+        self.subject.logger.fatal.assert_any_call('Heap checksum setting differences reported on segments')
+        self.subject.logger.fatal.assert_any_call('Failed checksum consistency validation:')
+        self.subject.logger.fatal.assert_any_call('sdw1 checksum set to 0 differs from master checksum set to 1')
+
+    @patch.object(HeapChecksum, "__init__", return_value=None)
+    def test_when_cannot_determine_checksums_it_raises(self, mock_heap_checksum_init):
+        self.mock_check_segment_consistency.return_value = ([], [1], True)
+        self.mock_get_segments_checksum_settings.return_value = ([], [])
+        self.mock_get_mirrors_to_build.side_effect = self._get_test_mirrors
+        self.return_one = True
+        self.assertTrue(self.gparray.master.isSegmentMaster(True))
+        with self.assertRaisesRegexp(Exception, "No segments responded to ssh query for heap checksum validation."):
+            self.subject.run()
+
+        self.mock_get_segments_checksum_settings.assert_called_with([self.primary0])
+        mock_heap_checksum_init.assert_called_with(self.gpArrayMock, logger=self.subject.logger, num_workers=1)
+
+    @patch("os._exit")
+    def test_when_no_segments_to_recover_validation_succeeds(self, _):
+        self.mock_get_mirrors_to_build.side_effect = self._get_test_mirrors
+        self.return_one = False
+
+        self.subject.run()
+
+        self.subject.logger.info.assert_any_call('No checksum validation necessary when '
+                                                 'there are no segments to recover.')
+
+
+    def _create_gparray_with_2_primary_2_mirrors(self):
+        master = GpDB.initFromString(
+            "1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
+        self.primary0 = GpDB.initFromString(
+            "2|0|p|p|s|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
+        primary1 = GpDB.initFromString(
+            "3|1|p|p|s|u|sdw2|sdw2|40001|41001|/data/primary1||/data/primary1/base/10899,/data/primary1/base/1,/data/primary1/base/10898,/data/primary1/base/25780,/data/primary1/base/34782")
+        self.mirror0 = GpDB.initFromString(
+            "4|0|m|m|s|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
+        mirror1 = GpDB.initFromString(
+            "5|1|m|m|s|u|sdw1|sdw1|50001|51001|/data/mirror1||/data/mirror1/base/10899,/data/mirror1/base/1,/data/mirror1/base/10898,/data/mirror1/base/25780,/data/mirror1/base/34782")
+        return GpArray([master, self.primary0, primary1, self.mirror0, mirror1])
+
+
+
+if __name__ == '__main__':
+    run_tests()

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_heapchecksum.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_heapchecksum.py
@@ -69,7 +69,7 @@ Data page checksum version:           1
     def createGpArrayWith2Primary2Mirrors(self):
         master = GpDB.initFromString(
             "1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
-        primary0 = GpDB.initFromString(
+        self.primary0 = GpDB.initFromString(
             "2|0|p|p|s|u|aspen|sdw1|40000|41000|/Users/pivotal/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
         primary1 = GpDB.initFromString(
             "3|1|p|p|s|u|sdw2|sdw2|40001|41001|/data/primary1||/data/primary1/base/10899,/data/primary1/base/1,/data/primary1/base/10898,/data/primary1/base/25780,/data/primary1/base/34782")
@@ -77,7 +77,7 @@ Data page checksum version:           1
             "4|0|m|m|s|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
         mirror1 = GpDB.initFromString(
             "5|1|m|m|s|u|sdw1|sdw1|50001|51001|/data/mirror1||/data/mirror1/base/10899,/data/mirror1/base/1,/data/mirror1/base/10898,/data/mirror1/base/25780,/data/mirror1/base/34782")
-        return GpArray([master, primary0, primary1, mirror0, mirror1])
+        return GpArray([master, self.primary0, primary1, mirror0, mirror1])
 
     def test_consistent_heap_checksum_returns_true(self):
         get_values = ['1', '1', '1', '1']
@@ -134,6 +134,25 @@ Data page checksum version:           1
 
     def test_are_segments_consistent_one_consistent_one_inconsistent(self):
         self.assertFalse(self.subject.are_segments_consistent([1], [1]))
+
+    def test_get_segments_checksum_settings_accepts_array(self):
+        get_values = ['1']
+        self.results = [CommandResult(0, self.COMMAND_RESULT, '', False, True)]
+        self.setup_worker_pool(get_values)
+
+        successes, failures = self.subject.get_segments_checksum_settings([self.primary0])
+
+        self.assertEquals(len(successes), 1)
+        self.assertEquals(len(failures), 0)
+
+    def test_get_segments_checksum_settings_uses_gparray(self):
+        get_values = ['1', '1', '1', '1']
+        self.setup_worker_pool(get_values)
+
+        successes, failures = self.subject.get_segments_checksum_settings()
+
+        self.assertEquals(len(successes), 4)
+        self.assertEquals(len(failures), 0)
 
     # ****************** tools ************************
     def setup_worker_pool(self, values):

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -98,6 +98,7 @@ Feature: gprecoverseg tests
         Then gprecoverseg should print "1 segment\(s\) to recover" to stdout
 
     @multinode
+    @fail_on_corrupted_change_tracking
     Scenario: gprecoverseg fails on corrupted change tracking logs, must run full recovery
         Given the database is running
         And the database "gptest1" does not exist
@@ -196,6 +197,7 @@ Feature: gprecoverseg tests
         And user can start transactions
         When the user runs "gprecoverseg -F -a"
         Then gprecoverseg should return a return code of 0
+        And gprecoverseg should print "Heap checksum setting is consistent between master and the segments that are candidates for recoverseg" to stdout
         And all the segments are running
         # validate the the new segment has the correct setting by getting admin connection to that segment
         Then the saved primary segment reports the same value for sql "show data_checksums" db "template1" as was saved


### PR DESCRIPTION
As part of the validation phase of gprecoverseg, before proceeding,
validate that the setting for GUC data_checksums is the same between
master and segments. The validation is done by comparing pg_control file content.
Fail fast if the settings are not the same.

If no segments are able to report their settings, then gprecoverseg
fails. (This failure to report would be unexpected since there is already a check for at least
one segment alive to progress to the validation phase.)