### PR TITLE
Fix tests for NULL values in ROWS PRECEDING/FOLLOWING clause.

### DIFF
--- a/src/backend/executor/nodeWindow.c
+++ b/src/backend/executor/nodeWindow.c
@@ -5655,8 +5655,10 @@ init_frames(WindowState * wstate)
 												  econtext,
 												  &isnull,
 												  NULL);
-
-						Insist(!isnull);
+						if (isnull)
+							ereport(ERROR,
+									(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+									 errmsg("frame starting offset must not be null")));
 					}
 
 					if (frame->trail->kind == WINDOW_BOUND_PRECEDING)
@@ -5686,8 +5688,10 @@ init_frames(WindowState * wstate)
 												  econtext,
 												  &isnull,
 												  NULL);
-
-						Insist(!isnull);
+						if (isnull)
+							ereport(ERROR,
+									(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+									 errmsg("frame ending offset must not be null")));
 					}
 
 					if (frame->lead->kind == WINDOW_BOUND_PRECEDING)

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -156,28 +156,6 @@ transformFromClause(ParseState *pstate, List *frmList)
 	}
 }
 
-static bool
-expr_null_check_walker(Node *node, void *context)
-{
-	if (!node)
-		return false;
-
-	if (IsA(node, Const))
-	{
-		Const *con = (Const *)node;
-
-		if (con->constisnull)
-			return true;
-	}
-	return expression_tree_walker(node, expr_null_check_walker, context);
-}
-
-static bool
-expr_contains_null_const(Expr *expr)
-{
-	return expr_null_check_walker((Node *)expr, NULL);
-}
-
 static void
 transformWindowFrameEdge(ParseState *pstate, WindowFrameEdge *e,
 						 WindowSpec *spec, Query *qry, bool is_rows)
@@ -204,11 +182,6 @@ transformWindowFrameEdge(ParseState *pstate, WindowFrameEdge *e,
 							 errmsg("ROWS parameter cannot be negative"),
 							 parser_errposition(pstate, con->location)));
 			}
-
-			if (expr_contains_null_const((Expr *)e->val))
-				ereport(ERROR,
-						(errcode(ERROR_INVALID_WINDOW_FRAME_PARAMETER),
-						 errmsg("ROWS parameter cannot contain NULL value")));
 		}
 		else
 		{

--- a/src/test/regress/expected/qp_olap_windowerr.out
+++ b/src/test/regress/expected/qp_olap_windowerr.out
@@ -3663,6 +3663,41 @@ FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_ola
 WINDOW win1 as (partition by cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc rows between floor(cf_olap_windowerr_sale.prc-cf_olap_windowerr_sale.pn) preceding and unbounded following );
 ERROR:  ROWS parameter cannot be negative  (seg0 slice2 rahmaf2-mbp:25432 pid=48130)
 -- mvd 3,4,1->2; 
+-- The PRECEDING/FOLLOWING clauses cannot be NULL.
+SELECT sum(g) OVER (ORDER BY g ROWS BETWEEN NULL::int4 PRECEDING AND UNBOUNDED FOLLOWING) from generate_series(1, 5) g;
+ERROR:  frame starting offset must not be null
+SELECT sum(g) OVER (ORDER BY g ROWS BETWEEN UNBOUNDED PRECEDING AND NULL::int4 FOLLOWING) from generate_series(1, 5) g;
+ERROR:  frame ending offset must not be null
+-- Not even an expression that yields NULL at runtime.
+create function retnull() returns int4 as $$ select NULL::int4 $$ language sql volatile;
+SELECT sum(g) OVER (ORDER BY g ROWS BETWEEN retnull() PRECEDING AND UNBOUNDED FOLLOWING) from generate_series(1, 5) g;
+ERROR:  frame starting offset must not be null
+SELECT sum(g) OVER (ORDER BY g ROWS BETWEEN UNBOUNDED PRECEDING AND retnull() FOLLOWING) from generate_series(1, 5) g;
+ERROR:  frame ending offset must not be null
+drop function retnull();
+-- But an expression that contains a NULL, but doesn't return NULL, is OK. (May seem like
+-- an odd case to test, but we used to incorrectly reject expressions that contained
+-- any NULL constants anywhere.)
+SELECT sum(g) OVER (ORDER BY g ROWS BETWEEN (array[1,2, NULL])[1] PRECEDING AND UNBOUNDED FOLLOWING) from generate_series(1, 5) g;
+ sum 
+-----
+  15
+  15
+  14
+  12
+   9
+(5 rows)
+
+SELECT sum(g) OVER (ORDER BY g ROWS BETWEEN UNBOUNDED PRECEDING AND (array[1,2, NULL])[1] FOLLOWING) from generate_series(1, 5) g;
+ sum 
+-----
+   3
+   6
+  10
+  15
+  15
+(5 rows)
+
 -- start_ignore
 CREATE TABLE filter_test (i int, j int) DISTRIBUTED BY (i);
 INSERT INTO filter_test VALUES (1, 1);


### PR DESCRIPTION
There were two problems with the existing NULL check. Firstly, it would
not catch expressions that returned NULL at runtime, only NULL constants.
You got a non-friendly "Unexpected internal error" error instead. Secondly,
it rejected expressions that contained NULL constants anywhere in the
expression, even if the expression as whole returned a non-NULL.

To fix both issues, add a NULL-check with a better error message to the
executor, and remove the parse-time check altogether. I copied the error
message texts from the upstream, so that you get the same error, even
though the implementation is quite different.

Add regression tests for those cases too, we apparently didn't have any.

Fixes github issue #2999.