### PR TITLE
Fix assertion failure in single-user mode.

### DIFF
--- a/src/backend/utils/resource_manager/memquota.c
+++ b/src/backend/utils/resource_manager/memquota.c
@@ -1035,6 +1035,10 @@ ResourceManagerGetQueryMemoryLimit(PlannedStmt* stmt)
 	if (Gp_role != GP_ROLE_DISPATCH)
 		return 0;
 
+	/* no limits in single user mode. */
+	if (!IsUnderPostmaster)
+		return 0;
+
 	Assert(gp_session_id > -1);
 	Assert(ActivePortal != NULL);
 


### PR DESCRIPTION
In single-user mode, MyQueueId isn't set. But there was an assertion for
that in ResourceQueueGetQueryMemoryLimit. To fix, don't apply memory limits
in single-user mode.