### PR TITLE
Add an example of checking external table options

### DIFF
--- a/contrib/extprotocol/expected/exttableext.out
+++ b/contrib/extprotocol/expected/exttableext.out
@@ -1,6 +1,17 @@
 SET search_path TO 'exttableext';
 -- Test 3: create RET and WET using created protocol
     -- Create external RET and WET
+    DROP EXTERNAL TABLE IF EXISTS exttabtest_options_r;
+NOTICE:  table "exttabtest_options_r" does not exist, skipping
+    CREATE READABLE EXTERNAL TABLE exttabtest_options_r(like exttabtest)
+        LOCATION('demoprot://exttabtest.txt') 
+    FORMAT 'text'
+    OPTIONS (database 'redplum');
+    SELECT * FROM exttabtest_options_r
+    EXCEPT ALL
+    SELECT * FROM exttabtest;
+ERROR:  This is greenplum. (gpextprotocol.c:54)
+DETAIL:  External table exttabtest_options_r, file demoprot://exttabtest.txt
     DROP EXTERNAL TABLE IF EXISTS exttabtest_w;
 NOTICE:  table "exttabtest_w" does not exist, skipping
     CREATE WRITABLE EXTERNAL TABLE exttabtest_w(like exttabtest)
@@ -11,7 +22,8 @@ NOTICE:  table "exttabtest_w" does not exist, skipping
 NOTICE:  table "exttabtest_r" does not exist, skipping
     CREATE READABLE EXTERNAL TABLE exttabtest_r(like exttabtest)
         LOCATION('demoprot://exttabtest.txt') 
-    FORMAT 'text';
+    FORMAT 'text'
+    OPTIONS (database 'greenplum', foo 'bar');
     -- Checking pg_exttable for new created RET and WET
     select urilocation,fmttype,fmtopts,encoding,writable from pg_exttable 
     where reloid='exttabtest_r'::regclass 
@@ -52,6 +64,7 @@ select max(cnt) - min(cnt)  > 20 from t;
     DROP PROTOCOL IF EXISTS demoprot CASCADE;
 NOTICE:  drop cascades to external table exttabtest_r
 NOTICE:  drop cascades to external table exttabtest_w
+NOTICE:  drop cascades to external table exttabtest_options_r
     CREATE PROTOCOL demoprot (
         writefunc = write_to_file_stable
     );
@@ -1618,7 +1631,7 @@ ERROR:  protocol "demoprot" does not exist  (seg0 slice1 rh55-qavm55:7532 pid=18
     -- However demoprot implementation prevents using any other protocol name than "demoprot"
     -- therefore the error is expected.
     select count(*) from exttabtest_r_new;
-ERROR:  internal error: demoprot called with a different protocol (demoprot_new) (gpextprotocol.c:87)  (seg0 slice1 rh55-qavm55:7532 pid=18394) (cdbdisp.c:1453)
+ERROR:  internal error: demoprot called with a different protocol (demoprot_new) (gpextprotocol.c:106)  (seg0 slice1 rh55-qavm55:7532 pid=18394) (cdbdisp.c:1453)
 DETAIL:  External table exttabtest_r_new, file demoprot_new://exttabtest.txt
     -- Rename protocol name back to demoprot
     ALTER PROTOCOL demoprot_new RENAME to demoprot;

--- a/contrib/extprotocol/sql/exttableext.sql
+++ b/contrib/extprotocol/sql/exttableext.sql
@@ -2,6 +2,16 @@ SET search_path TO 'exttableext';
 -- Test 3: create RET and WET using created protocol
 
     -- Create external RET and WET
+    DROP EXTERNAL TABLE IF EXISTS exttabtest_options_r;
+    CREATE READABLE EXTERNAL TABLE exttabtest_options_r(like exttabtest)
+        LOCATION('demoprot://exttabtest.txt') 
+    FORMAT 'text'
+    OPTIONS (database 'redplum');
+
+    SELECT * FROM exttabtest_options_r
+    EXCEPT ALL
+    SELECT * FROM exttabtest;
+
     DROP EXTERNAL TABLE IF EXISTS exttabtest_w;
     CREATE WRITABLE EXTERNAL TABLE exttabtest_w(like exttabtest)
         LOCATION('demoprot://exttabtest.txt') 
@@ -11,7 +21,8 @@ SET search_path TO 'exttableext';
     DROP EXTERNAL TABLE IF EXISTS exttabtest_r;
     CREATE READABLE EXTERNAL TABLE exttabtest_r(like exttabtest)
         LOCATION('demoprot://exttabtest.txt') 
-    FORMAT 'text';
+    FORMAT 'text'
+    OPTIONS (database 'greenplum', foo 'bar');
 
     -- Checking pg_exttable for new created RET and WET
     select urilocation,fmttype,fmtopts,encoding,writable from pg_exttable 


### PR DESCRIPTION
    commit c5d2bc315cee72484e35e34fc04ba666ba723e5a
    Author: Haozhou Wang <hawang@pivotal.io>
    Date:   Mon Jan 2 22:37:20 2017 -0500

        Support 'OPTIONS' keyword in GPDB external table

        In case user wanna specify parameters with OPTIONS other than config
        file in LOCATION, it provides flexible and friendly grammar.

        Usage:
        CREATE EXTERNAL TABLE xxx LOCATION xxx FORMAT xxx
        [OPTIONS ( [option_key 'option_value' [, ...]] )]
        xxx;