### PR TITLE
Backport: Clarify when to use PageSetLSN/PageGetLSN().

### DIFF
--- a/src/backend/access/transam/README
+++ b/src/backend/access/transam/README
@@ -531,6 +531,14 @@ associated with the n'th distinct buffer ID seen in the "rdata" array, and
 per the above discussion, fully-rewritable buffers shouldn't be mentioned in
 "rdata".)
 
+Note that we must only use PageSetLSN/PageGetLSN() when we know the action
+is serialised. Only Startup process may modify data blocks during recovery,
+so Startup process may execute PageGetLSN() without fear of serialisation
+problems. All other processes must only call PageSet/GetLSN when holding
+either an exclusive buffer lock or a shared lock plus buffer header lock,
+or be writing the data block directly rather than through shared buffers
+while holding AccessExclusiveLock on the relation.
+
 Due to all these constraints, complex changes (such as a multilevel index
 insertion) normally need to be described by a series of atomic-action WAL
 records.  What do you do if the intermediate states are not self-consistent?


### PR DESCRIPTION
Per [this ML discussion](https://groups.google.com/a/greenplum.org/d/msg/gpdb-dev/Z7Ylf_4x-BI/NTkC90vmBgAJ), document our overloading of the buffer header spinlock when we access a page's LSN.