### PR TITLE
Enforce locking contract for page LSN:

### DIFF
--- a/src/backend/access/gist/gist.c
+++ b/src/backend/access/gist/gist.c
@@ -562,7 +562,7 @@ gistfindleaf(GISTInsertState *state, GISTSTATE *giststate)
 		state->stack->page = (Page) BufferGetPage(state->stack->buffer);
 		opaque = GistPageGetOpaque(state->stack->page);
 
-		state->stack->lsn = PageGetLSN(state->stack->page);
+		state->stack->lsn = BufferGetLSNAtomic(state->stack->buffer);
 		Assert(state->r->rd_istemp || !XLogRecPtrIsInvalid(state->stack->lsn));
 
 		if (state->stack->blkno != GIST_ROOT_BLKNO &&
@@ -699,7 +699,7 @@ gistFindPath(Relation r, BlockNumber child)
 			break;
 		}
 
-		top->lsn = PageGetLSN(page);
+		top->lsn = BufferGetLSNAtomic(buffer);
 
 		if (top->parent && XLByteLT(top->parent->lsn, GistPageGetOpaque(page)->nsn) &&
 			GistPageGetOpaque(page)->rightlink != InvalidBlockNumber /* sanity check */ )

--- a/src/backend/access/gist/gistget.c
+++ b/src/backend/access/gist/gistget.c
@@ -43,7 +43,7 @@ killtuple(Relation r, GISTScanOpaque so, ItemPointer iptr)
 	gistcheckpage(r, so->curbuf);
 	p = (Page) BufferGetPage(so->curbuf);
 
-	if (XLByteEQ(so->stack->lsn, PageGetLSN(p)))
+	if (XLByteEQ(so->stack->lsn, BufferGetLSNAtomic(so->curbuf)))
 	{
 		/* page unchanged, so all is simple */
 		offset = ItemPointerGetOffsetNumber(iptr);
@@ -240,7 +240,7 @@ gistnext(IndexScanDesc scan, ScanDirection dir, ItemPointer tids,
 		opaque = GistPageGetOpaque(p);
 
 		/* remember lsn to identify page changed for tuple's killing */
-		so->stack->lsn = PageGetLSN(p);
+		so->stack->lsn = BufferGetLSNAtomic(so->curbuf);
 
 		/* check page split, occured from last visit or visit to parent */
 		if (!XLogRecPtrIsInvalid(so->stack->parentlsn) &&

--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -5241,11 +5241,6 @@ heap_xlog_delete(XLogRecPtr lsn, XLogRecord *record)
 
 	if (XLByteLE(lsn, PageGetLSN(page)))		/* changes are applied */
 	{
-		UnlockReleaseBuffer(buffer);
-		
-		MIRROREDLOCK_BUFMGR_UNLOCK;
-		// -------- MirroredLock ----------
-		
 		if (Debug_print_qd_mirroring)
 		{
 			elog(LOG, "delete already appplied: lsn (%X,%X), page (%X,%X)",
@@ -5254,6 +5249,12 @@ heap_xlog_delete(XLogRecPtr lsn, XLogRecord *record)
 				 PageGetLSN(page).xlogid,
 				 PageGetLSN(page).xrecoff);
 		}
+
+		UnlockReleaseBuffer(buffer);
+
+		MIRROREDLOCK_BUFMGR_UNLOCK;
+		// -------- MirroredLock ----------
+
 		return;
 	}
 

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -1538,7 +1538,7 @@ XLogCheckBuffer(XLogRecData *rdata, bool holdsExclusiveLock,
 	 * an exclusive lock on the page and/or the relation.
 	 */
 	if (holdsExclusiveLock)
-		*lsn = PageGetLSN(page);
+		*lsn = PageGetLSN((Page) page);
 	else
 		*lsn = BufferGetLSNAtomic(rdata->buffer);
 

--- a/src/backend/storage/buffer/bufmgr.c
+++ b/src/backend/storage/buffer/bufmgr.c
@@ -2131,7 +2131,8 @@ BufferGetLSNAtomic(Buffer buffer)
 	/* Make sure we've got a real buffer, and that we hold a pin on it. */
 	Assert(BufferIsValid(buffer));
 	Assert(BufferIsPinned(buffer));
-
+	/* Caller should hold share lock on the buffer contents. */
+	Assert(LWLockHeldByMe(bufHdr->content_lock));
 	LockBufHdr(bufHdr);
 	lsn = PageGetLSN(page);
 	UnlockBufHdr(bufHdr);

--- a/src/include/storage/bufpage.h
+++ b/src/include/storage/bufpage.h
@@ -352,10 +352,40 @@ typedef PageHeaderData *PageHeader;
 	  / sizeof(ItemIdData)))
 
 /*
+ * Retrieving LSN of a shared buffer is safe only if: (1) exclusive lock on the
+ * buffer's contents is held OR (2) shared lock on the buffer's contents and
+ * the buffer header spinlock is held.  The Assert() validates that a shared
+ * buffer's contents are locked.  That is not sufficient but there is no easy
+ * interface to determine if a spinlock is held or whether a LW lock is held in
+ * shared/exclusive mode.  The assert applies only to shared buffers because
+ * local buffers do not need to worry about concurrency.
+ *
+ */
+static inline XLogRecPtr
+PageGetLSN(Page page)
+{
+#ifdef USE_ASSERT_CHECKING
+	extern PGDLLIMPORT char *BufferBlocks; /* duplicates bufmgr.h */
+	char *pagePtr = page;
+
+	/*
+	 * We only want to assert that we hold a lock on the page contents if the
+	 * page is shared (i.e. it is one of the BufferBlocks).
+	 */
+	if (BufferBlocks <= pagePtr &&
+		pagePtr < (BufferBlocks + NBuffers * BLCKSZ))
+	{
+		BufferDesc *hdr = &BufferDescriptors[(pagePtr - BufferBlocks) / BLCKSZ];
+		Assert(LWLockHeldByMe(hdr->content_lock));
+	}
+#endif
+
+	return ((PageHeader) page)->pd_lsn;
+}
+
+/*
  * Additional macros for access to page headers
  */
-#define PageGetLSN(page) \
-	(((PageHeader) (page))->pd_lsn)
 #define PageSetLSN(page, lsn) \
 	(((PageHeader) (page))->pd_lsn = (lsn))
 


### PR DESCRIPTION
The locking contract to access LSN of a page is:
1. Content lock must be held in exclusive mode,
OR
2. Content lock must be held in shared mode and buffer header spinlock must be
held.

Signed-off-by: Asim R P <apraveen@pivotal.io>