### PR TITLE
docs - misc edits

### DIFF
--- a/gpdb-doc/dita/admin_guide/perf_troubleshoot.xml
+++ b/gpdb-doc/dita/admin_guide/perf_troubleshoot.xml
@@ -72,7 +72,7 @@
                     session holding or waiting to hold a lock. For example:</p>
                 <p>
                     <codeblock>SELECT locktype, database, c.relname, l.relation, 
-l.transactionid, l.transaction, l.pid, l.mode, l.granted, 
+l.transactionid, l.pid, l.mode, l.granted, 
 a.current_query 
         FROM pg_locks l, pg_class c, pg_stat_activity a 
         WHERE l.relation=c.oid AND l.pid=a.procpid 

--- a/gpdb-doc/dita/ref_guide/sql_commands/DROP_RESOURCE_QUEUE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/DROP_RESOURCE_QUEUE.xml
@@ -7,7 +7,7 @@ to it, nor can it have any statements waiting in the queue. Only a superuser
 can drop a resource queue.</p></section><section id="section4"><title>Parameters</title><parml><plentry><pt><varname>queue_name</varname></pt><pd>The name of a resource queue to remove.</pd></plentry></parml></section><section id="section5"><title>Notes</title><p>Use <codeph><xref href="ALTER_ROLE.xml#topic1" type="topic" format="dita"/></codeph> to remove a
         user from a resource queue.</p><p>To see all the currently active queries for all resource queues, perform
 the following query of the <codeph>pg_locks</codeph> table joined with
-the <codeph>pg_roles</codeph> and <codeph>pg_resqueue</codeph> tables:</p><codeblock>SELECT rolname, rsqname, locktype, objid, transaction, pid, 
+the <codeph>pg_roles</codeph> and <codeph>pg_resqueue</codeph> tables:</p><codeblock>SELECT rolname, rsqname, locktype, objid, pid, 
 mode, granted FROM pg_roles, pg_resqueue, pg_locks WHERE 
 pg_roles.rolresqueue=pg_locks.objid AND 
 pg_locks.objid=pg_resqueue.oid;</codeblock><p>To see the roles assigned to a resource queue, perform the following query

--- a/gpdb-doc/dita/ref_guide/sql_commands/LOCK.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/LOCK.xml
@@ -131,7 +131,7 @@
                                     EXCLUSIVE</codeph>). This mode guarantees that the holder is the
                                 only transaction accessing the table in any way. Acquired
                                 automatically by the <codeph>ALTER TABLE</codeph>, <codeph>DROP
-                                    TABLE</codeph>, <codeph>REINDEX</codeph>,
+                                    TABLE</codeph>, <codeph>TRUNCATE</codeph>, <codeph>REINDEX</codeph>,
                                     <codeph>CLUSTER</codeph>, and <codeph>VACUUM FULL</codeph>
                                 commands. This is the default lock mode for <codeph>LOCK
                                     TABLE</codeph> statements that do not specify a mode explicitly.

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_locks.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_locks.xml
@@ -4,11 +4,11 @@
 <topic id="topic1" xml:lang="en"><title id="gv141670">pg_locks</title><body><p>The <codeph>pg_locks</codeph> view provides access to information about the locks held by open
       transactions within Greenplum Database.</p><p><codeph>pg_locks</codeph> contains one row per active lockable object,
 requested lock mode, and relevant transaction. Thus, the same lockable
-object may appear many times, if multiple transactions are holding or
-waiting for locks on it. However, an object that currently has no locks
-on it will not appear at all. </p><p>There are several distinct types of lockable objects: whole relations
+object may appear many times if multiple transactions are holding or
+waiting for locks on it. An object with no current locks
+it will not appear at all. </p><p>There are several distinct types of lockable objects: whole relations
 (such as tables), individual pages of relations, individual tuples of
-relations, transaction IDs, and general database objects. Also, the right
+relations, transaction IDs (both virtual and permanent IDs), and general database objects. Also, the right
 to extend a relation is represented as a separate lockable object.</p><table id="gv141982"><title>pg_catalog.pg_locks</title><tgroup cols="4"><colspec colnum="1" colname="col1" colwidth="131pt"/><colspec colnum="2" colname="col2" colwidth="86pt"/><colspec colnum="3" colname="col3" colwidth="85pt"/><colspec colnum="4" colname="col4" colwidth="147pt"/><thead><row><entry colname="col1">column</entry><entry colname="col2">type</entry><entry colname="col3">references</entry><entry colname="col4">description</entry></row></thead><tbody><row><entry colname="col1"><codeph>locktype</codeph></entry><entry colname="col2">text</entry><entry colname="col3"/><entry colname="col4">Type of the lockable object: <codeph>relation</codeph>,
 <codeph>extend</codeph>, <codeph>page</codeph>, <codeph>tuple</codeph>,
 <codeph>transactionid</codeph>, <codeph>object</codeph>, <codeph>userlock</codeph>,
@@ -17,13 +17,14 @@ zero if the object is a shared object, or NULL if the object is a transaction
 ID</entry></row><row><entry colname="col1"><codeph>relation</codeph></entry><entry colname="col2">oid</entry><entry colname="col3">pg_class.oid</entry><entry colname="col4">OID of the relation, or NULL if the object is
 not a relation or part of a relation</entry></row><row><entry colname="col1"><codeph>page </codeph></entry><entry colname="col2">integer</entry><entry colname="col3"/><entry colname="col4">Page number within the relation, or NULL if
 the object is not a tuple or relation page</entry></row><row><entry colname="col1"><codeph>tuple </codeph></entry><entry colname="col2">smallint</entry><entry colname="col3"/><entry colname="col4">Tuple number within the page, or NULL if the
-object is not a tuple</entry></row><row><entry colname="col1"><codeph>transactionid </codeph></entry><entry colname="col2">xid</entry><entry colname="col3"/><entry colname="col4">ID of a transaction, or NULL if the object is
+object is not a tuple</entry></row><row><entry colname="col1"><codeph>virtualxid </codeph></entry><entry colname="col2">text</entry><entry colname="col3"/><entry colname="col4">Virtual ID of a transaction, or NULL if the object is
+not a virtual transaction ID</entry></row><row><entry colname="col1"><codeph>transactionid </codeph></entry><entry colname="col2">xid</entry><entry colname="col3"/><entry colname="col4">ID of a transaction, or NULL if the object is
 not a transaction ID</entry></row><row><entry colname="col1"><codeph>classid</codeph></entry><entry colname="col2">oid</entry><entry colname="col3">pg_class.oid</entry><entry colname="col4">OID of the system catalog containing the object,
 or NULL if the object is not a general database object</entry></row><row><entry colname="col1"><codeph>objid </codeph></entry><entry colname="col2">oid</entry><entry colname="col3">any OID column</entry><entry colname="col4">OID of the object within its system catalog,
 or NULL if the object is not a general database object</entry></row><row><entry colname="col1"><codeph>objsubid </codeph></entry><entry colname="col2">smallint</entry><entry colname="col3"/><entry colname="col4">For a table column, this is the column number
 (the classid and objid refer to the table itself).
 For all other object types, this column is zero. NULL if the object is
-not a general database object</entry></row><row><entry colname="col1"><codeph>transaction</codeph></entry><entry colname="col2">xid</entry><entry colname="col3"/><entry colname="col4">ID of the transaction that is holding or awaiting
+not a general database object</entry></row><row><entry colname="col1"><codeph>virtualtransaction</codeph></entry><entry colname="col2">text</entry><entry colname="col3"/><entry colname="col4">Virtual ID of the transaction that is holding or awaiting
 this lock</entry></row><row><entry colname="col1"><codeph>pid</codeph></entry><entry colname="col2">integer</entry><entry colname="col3"/><entry colname="col4">Process ID of the server process holding or
 awaiting this lock. NULL if the lock is held by a prepared transaction</entry></row><row><entry colname="col1"><codeph>mode</codeph></entry><entry colname="col2">text</entry><entry colname="col3"/><entry colname="col4">Name of the lock mode held or desired by this
 process</entry></row><row><entry colname="col1"><codeph>granted</codeph></entry><entry colname="col2">boolean</entry><entry colname="col3"/><entry colname="col4">True if lock is held, false if lock is awaited.</entry></row><row><entry colname="col1"><codeph>mppsessionid</codeph></entry><entry colname="col2">integer</entry><entry colname="col3"/><entry colname="col4">The id of the client session associated with

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_locks.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_locks.xml
@@ -6,7 +6,7 @@
 requested lock mode, and relevant transaction. Thus, the same lockable
 object may appear many times if multiple transactions are holding or
 waiting for locks on it. An object with no current locks
-it will not appear at all. </p><p>There are several distinct types of lockable objects: whole relations
+on it will not appear in the view at all. </p><p>There are several distinct types of lockable objects: whole relations
 (such as tables), individual pages of relations, individual tuples of
 relations, transaction IDs (both virtual and permanent IDs), and general database objects. Also, the right
 to extend a relation is represented as a separate lockable object.</p><table id="gv141982"><title>pg_catalog.pg_locks</title><tgroup cols="4"><colspec colnum="1" colname="col1" colwidth="131pt"/><colspec colnum="2" colname="col2" colwidth="86pt"/><colspec colnum="3" colname="col3" colwidth="85pt"/><colspec colnum="4" colname="col4" colwidth="147pt"/><thead><row><entry colname="col1">column</entry><entry colname="col2">type</entry><entry colname="col3">references</entry><entry colname="col4">description</entry></row></thead><tbody><row><entry colname="col1"><codeph>locktype</codeph></entry><entry colname="col2">text</entry><entry colname="col3"/><entry colname="col4">Type of the lockable object: <codeph>relation</codeph>,

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_proc.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_proc.xml
@@ -75,6 +75,14 @@
           </row>
           <row>
             <entry colname="col1">
+              <codeph>prorows</codeph>
+            </entry>
+            <entry colname="col2">float4</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Estimated number of result rows (zero if not proretset)</entry>
+          </row>
+          <row>
+            <entry colname="col1">
               <codeph>provariadic</codeph>
             </entry>
             <entry colname="col2">oid</entry>


### PR DESCRIPTION
a few miscellaneous doc updates:
- pg_proc system catalog table - add missing prorows column
- pg_locks system catalog table - add missing virtualxid column, transaction column now named virtualtransaction
- update a few queries to remove reference to transaction column
- LOCK sql command page - add TRUNCATE to ACCESS RESTRICTIVE command list

link to docs on review staging site:
- http://docs-gpdb-review-staging.cfapps.io/500Beta/ref_guide/system_catalogs/pg_proc.html
- http://docs-gpdb-review-staging.cfapps.io/500Beta/ref_guide/system_catalogs/pg_locks.html
- http://docs-gpdb-review-staging.cfapps.io/500Beta/ref_guide/sql_commands/LOCK.html

are the queries on these pages still meaningful without the transaction column?
- http://docs-gpdb-review-staging.cfapps.io/500Beta/admin_guide/perf_troubleshoot.html#topic5
- http://docs-gpdb-review-staging.cfapps.io/500Beta/ref_guide/sql_commands/DROP_RESOURCE_QUEUE.html
