### PR TITLE
 Check distribution key restriction for `COPY FROM ON SEGMEN`

### DIFF
--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -89,7 +89,7 @@ makeCdbCopy(bool is_copy_in)
  * may pg_throw via elog/ereport.
  */
 void
-cdbCopyStart(CdbCopy *c, char *copyCmd)
+cdbCopyStart(CdbCopy *c, char *copyCmd, struct GpPolicy *policy)
 {
 	int			seg;
 	MemoryContext oldcontext;
@@ -166,7 +166,20 @@ cdbCopyStart(CdbCopy *c, char *copyCmd)
 	((CopyStmt *)q->utilityStmt)->ao_segnos = c->ao_segnos;
 
 	((CopyStmt *)q->utilityStmt)->skip_ext_partition = c->skip_ext_partition;
-	
+
+	if (policy)
+	{
+		((CopyStmt *)q->utilityStmt)->nattrs = policy->nattrs;
+		((CopyStmt *)q->utilityStmt)->ptype = policy->ptype;
+		((CopyStmt *)q->utilityStmt)->distribution_attrs = policy->attrs;
+	}
+	else
+	{
+		((CopyStmt *)q->utilityStmt)->nattrs = 0;
+		((CopyStmt *)q->utilityStmt)->ptype = 0;
+		((CopyStmt *)q->utilityStmt)->distribution_attrs = NULL;
+	}
+
 	MemoryContextSwitchTo(oldcontext);
 
 	CdbDispatchUtilityStatement((Node *) q->utilityStmt,

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -54,7 +54,6 @@
 
 #include "cdb/cdbvars.h"
 #include "cdb/cdbcopy.h"
-#include "cdb/cdbhash.h"
 #include "cdb/cdbsreh.h"
 #include "postmaster/autostats.h"
 
@@ -1686,6 +1685,11 @@ DoCopyInternal(const CopyStmt *stmt, const char *queryString, CopyState cstate)
 
 			if (rel_is_partitioned(relid))
 			{
+				if (cstate->on_segment && !partition_policies_equal(cstate->rel->rd_cdbpolicy, RelationBuildPartitionDesc(cstate->rel, false)))
+				{
+					elog(ERROR, "COPY FROM ON SEGMENT doesn't support checking distribution key restriction when the distribution policy of the partition table is different from the main table.");
+					return cstate->processed;
+				}
 				PartitionNode *pn = RelationBuildPartitionDesc(cstate->rel, false);
 				all_relids = list_concat(all_relids, all_partition_relids(pn));
 			}
@@ -1727,6 +1731,16 @@ DoCopyInternal(const CopyStmt *stmt, const char *queryString, CopyState cstate)
 		else
 		{
 			/* data needs to get inserted locally */
+			if (cstate->on_segment)
+			{
+				MemoryContext oldcxt;
+				oldcxt = MemoryContextSwitchTo(CacheMemoryContext);
+				cstate->rel->rd_cdbpolicy = palloc(sizeof(GpPolicy) + sizeof(AttrNumber) * stmt->nattrs);
+				cstate->rel->rd_cdbpolicy->nattrs = stmt->nattrs;
+				cstate->rel->rd_cdbpolicy->ptype = stmt->ptype;
+				memcpy(cstate->rel->rd_cdbpolicy->attrs, stmt->distribution_attrs, sizeof(AttrNumber) * stmt->nattrs);
+				MemoryContextSwitchTo(oldcxt);
+			}
 			CopyFrom(cstate);
 		}
 
@@ -2102,7 +2116,7 @@ CopyToDispatch(CopyState cstate)
 
 	PG_TRY();
 	{
-		cdbCopyStart(cdbCopy, cdbcopy_cmd.data);
+		cdbCopyStart(cdbCopy, cdbcopy_cmd.data, NULL);
 	}
 	PG_CATCH();
 	{
@@ -3394,7 +3408,7 @@ CopyFromDispatch(CopyState cstate)
 	elog(DEBUG5, "COPY command sent to segdbs: %s", cdbcopy_cmd.data);
 	PG_TRY();
 	{
-		cdbCopyStart(cdbCopy, cdbcopy_cmd.data);
+		cdbCopyStart(cdbCopy, cdbcopy_cmd.data, cstate->rel->rd_cdbpolicy);
 	}
 	PG_CATCH();
 	{
@@ -4299,6 +4313,155 @@ CopyFromDispatch(CopyState cstate)
 	FreeExecutorState(estate);
 }
 
+static GpDistributionData
+initDistributionData(CopyState cstate, Form_pg_attribute *attr,AttrNumber num_phys_attrs)
+{
+	/*
+	 * Variables for cdbpolicy
+	 */
+	GpPolicy *policy;	/* the partitioning policy for this table */
+	AttrNumber p_nattrs; /* num of attributes in the distribution policy */
+	Oid *p_attr_types;   /* types for each policy attribute */
+
+	CdbHash *cdbHash = NULL;
+	AttrNumber h_attnum; /* hash key attribute number */
+	int p_index;
+	int total_segs = getgpsegmentCount();
+	int i = 0;
+
+	policy = GpPolicyCopy(CurrentMemoryContext, cstate->rel->rd_cdbpolicy);
+
+	if (policy)
+		p_nattrs = policy->nattrs; /* number of partitioning keys */
+	else
+		p_nattrs = 0;
+	/* Create hash API reference */
+	cdbHash = makeCdbHash(total_segs);
+
+	/*
+	 * Extract types for each partition key from the tuple descriptor,
+	 * and convert them when necessary. We don't want to do this
+	 * for each tuple since get_typtype() is quite expensive when called
+	 * lots of times.
+	 * The array key for p_attr_types is the attribute number of the attribute
+	 * in question.
+ 	 */	
+	p_attr_types = (Oid *)palloc0(num_phys_attrs * sizeof(Oid));
+
+	for (i = 0; i < p_nattrs; i++)
+	{
+		h_attnum = policy->attrs[i];
+
+		/*
+		 * get the data type of this attribute. If it's an
+		 * array type use anyarray, or else just use as is.
+		 */
+		if (attr[h_attnum - 1]->attndims > 0)
+			p_attr_types[h_attnum - 1] = ANYARRAYOID;
+		else
+		{
+			/* If this type is a domain type, get its base type. */
+			p_attr_types[h_attnum - 1] = attr[h_attnum - 1]->atttypid;
+			if (get_typtype(p_attr_types[h_attnum - 1]) == 'd')
+				p_attr_types[h_attnum - 1] =
+					getBaseType(p_attr_types[h_attnum - 1]);
+		}
+	}
+
+	/*
+	 * for optimized parsing - get the last field number in the
+	 * file that we need to parse to have all values for the hash keys.
+	 * (If the table has an empty distribution policy, then we don't need
+	 * to parse any attributes really... just send the row away using
+	 * a special cdbhash function designed for this purpose).
+	 */
+	cstate->last_hash_field = 0;
+
+	for (p_index = 0; p_index < p_nattrs; p_index++)
+	{
+		i = 1;
+
+		/*
+		 * for this partitioning key, search for its location in the attr list.
+		 * (note that fields may be out of order).
+		 */
+		ListCell *cur;
+		foreach (cur, cstate->attnumlist)
+		{
+			int attnum = lfirst_int(cur);
+
+			if (attnum == policy->attrs[p_index])
+			{
+				if (i > cstate->last_hash_field)
+					cstate->last_hash_field = i;
+			}
+			i++;
+		}
+	}
+	GpDistributionData distData;
+	distData.policy = policy;
+	distData.p_nattrs = p_nattrs;
+	distData.p_attr_types = p_attr_types;
+	distData.cdbHash = cdbHash;
+	return distData;
+}
+
+static unsigned int
+get_target_seg(GpDistributionData distData, Datum *baseValues, bool *baseNulls)
+{
+	unsigned int target_seg = 0;
+	CdbHash *cdbHash = distData.cdbHash;
+	GpPolicy *policy = distData.policy;		 /* the partitioning policy for this table */
+	AttrNumber p_nattrs = distData.p_nattrs; /* num of attributes in the distribution policy */
+	Oid *p_attr_types = distData.p_attr_types;
+
+	if (!policy)
+	{
+		elog(FATAL, "Bad or undefined policy. (%p)", policy);
+	}
+
+	/*
+	 * At this point in the code, baseValues[x] is final for this
+	 * data row -- either the input data, a null or a default
+	 * value is in there, and constraints applied.
+	 *
+	 * Perform a cdbhash on this data row. Perform a hash operation
+	 * on each attribute.
+	 */
+	Assert(PointerIsValid(cdbHash));
+	/* Assert does not activate in production build */
+	if (!cdbHash)
+	{
+		elog(FATAL, "Bad cdb_hash: %p", cdbHash);
+	}
+	cdbhashinit(cdbHash);
+
+	AttrNumber h_attnum;
+	Datum h_key;
+	for (int i = 0; i < p_nattrs; i++)
+	{
+		/* current attno from the policy */
+		h_attnum = policy->attrs[i];
+
+		h_key = baseValues[h_attnum - 1]; /* value of this attr */
+		if (!baseNulls[h_attnum - 1])
+			cdbhash(cdbHash, h_key, p_attr_types[h_attnum - 1]);
+		else
+			cdbhashnull(cdbHash);
+	}
+
+	/*
+	 * If this is a relation with an empty policy, there is no
+	 * hash key to use, therefore use cdbhashnokey() to pick a
+	 * hash value for us.
+	 */
+	if (p_nattrs == 0)
+		cdbhashnokey(cdbHash);
+
+	target_seg = cdbhashreduce(cdbHash); /* hash result segment */
+	return target_seg;
+}
+
 /*
  * Copy FROM file to relation.
  */
@@ -4350,6 +4513,9 @@ CopyFrom(CopyState cstate)
 	attr_count = list_length(cstate->attnumlist);
 	num_defaults = 0;
 	bool		is_segment_data_processed = (cstate->on_segment && Gp_role == GP_ROLE_EXECUTE) ? false : true;
+	bool		is_check_distkey = (cstate->on_segment && Gp_role == GP_ROLE_EXECUTE) ? true : false;
+	GpDistributionData	distData; /* distribution data used to compute target seg */
+	unsigned int	target_seg = 0; /* result segment of cdbhash */
 
 	/*----------
 	 * Check to see if we can avoid writing WAL
@@ -4457,6 +4623,12 @@ CopyFrom(CopyState cstate)
 				num_defaults++;
 			}
 		}
+	}
+
+	/* prepare distribuion data for computing target seg*/
+	if (is_check_distkey)
+	{
+		distData = initDistributionData(cstate, attr,num_phys_attrs);
 	}
 
 	/* Prepare to catch AFTER triggers. */
@@ -4572,7 +4744,6 @@ PROCESS_SEGMENT_DATA:
 				bool		skip_tuple;
 				Oid			loaded_oid = InvalidOid;
 				char		relstorage;
-				
 				CHECK_FOR_INTERRUPTS();
 
 				/* Reset the per-tuple exprcontext */
@@ -4913,6 +5084,14 @@ PROCESS_SEGMENT_DATA:
 				{
 					values = baseValues;
 					nulls = baseNulls;
+				}
+
+				if (is_check_distkey)
+				{
+					target_seg = get_target_seg(distData, values, nulls);
+					/*check distribution key if COPY FROM ON SEGMENT*/
+					if (GpIdentity.segindex != target_seg)
+						elog(ERROR, "Value of distribution key doesn't belong to segment with ID %d, it belongs to segment with ID %d.", GpIdentity.segindex, target_seg);
 				}
 
 				if (relstorage == RELSTORAGE_AOROWS)

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -3145,7 +3145,9 @@ _copyCopyStmt(CopyStmt *from)
 	COPY_STRING_FIELD(filename);
 	COPY_NODE_FIELD(options);
 	COPY_NODE_FIELD(sreh);
-
+	COPY_SCALAR_FIELD(nattrs);
+	COPY_SCALAR_FIELD(ptype);
+	COPY_POINTER_FIELD(distribution_attrs,from->nattrs * sizeof(AttrNumber));
 	return newnode;
 }
 

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -1148,8 +1148,9 @@ _equalCopyStmt(CopyStmt *a, CopyStmt *b)
 	COMPARE_STRING_FIELD(filename);
 	COMPARE_NODE_FIELD(options);
 	COMPARE_NODE_FIELD(sreh);
-
-
+	COMPARE_SCALAR_FIELD(nattrs);
+	COMPARE_SCALAR_FIELD(ptype);
+	COMPARE_POINTER_FIELD(distribution_attrs,a->nattrs * sizeof(AttrNumber));
 	return true;
 }
 

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -360,6 +360,24 @@ outLogicalIndexInfo(StringInfo str, LogicalIndexInfo *node)
 }
 
 static void
+_outCopyStmt(StringInfo str, CopyStmt *node)
+{
+	WRITE_NODE_TYPE("COPYSTMT");
+	WRITE_NODE_FIELD(relation);
+	WRITE_NODE_FIELD(attlist);
+	WRITE_BOOL_FIELD(is_from);
+	WRITE_BOOL_FIELD(skip_ext_partition);
+	WRITE_STRING_FIELD(filename);
+	WRITE_NODE_FIELD(options);
+	WRITE_NODE_FIELD(sreh);
+	WRITE_NODE_FIELD(partitions);
+	WRITE_NODE_FIELD(ao_segnos);
+	WRITE_INT_FIELD(nattrs);
+	WRITE_ENUM_FIELD(ptype, GpPolicyType);
+	WRITE_INT_ARRAY(distribution_attrs, node->nattrs, AttrNumber);
+}
+
+static void
 _outSubqueryScan(StringInfo str, SubqueryScan *node)
 {
 	WRITE_NODE_TYPE("SUBQUERYSCAN");

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -3059,6 +3059,7 @@ _outSingleRowErrorDesc(StringInfo str, SingleRowErrorDesc *node)
 	WRITE_BOOL_FIELD(into_file);
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outCopyStmt(StringInfo str, CopyStmt *node)
 {
@@ -3072,7 +3073,16 @@ _outCopyStmt(StringInfo str, CopyStmt *node)
 	WRITE_NODE_FIELD(sreh);
 	WRITE_NODE_FIELD(partitions);
 	WRITE_NODE_FIELD(ao_segnos);
+	WRITE_INT_FIELD(nattrs);
+	WRITE_ENUM_FIELD(ptype, GpPolicyType);
+	appendStringInfoLiteral(str, " :distribution_attrs");
+	for (int i = 0; i < node->nattrs; i++)
+	{
+		appendStringInfo(str, " %d", node->distribution_attrs[i]);
+	}
+
 }
+#endif/* COMPILING_BINARY_FUNCS */
 
 
 static void

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -1391,7 +1391,9 @@ _readCopyStmt(void)
 	READ_NODE_FIELD(sreh);
 	READ_NODE_FIELD(partitions);
 	READ_NODE_FIELD(ao_segnos);
-
+	READ_INT_FIELD(nattrs);
+	READ_ENUM_FIELD(ptype, GpPolicyType);
+	READ_INT_ARRAY(distribution_attrs, local_node->nattrs, AttrNumber);
 	READ_DONE();
 
 }

--- a/src/include/cdb/cdbcopy.h
+++ b/src/include/cdb/cdbcopy.h
@@ -59,7 +59,7 @@ typedef struct CdbCopy
 
 /* global function declarations */
 CdbCopy    *makeCdbCopy(bool copy_in);
-void		cdbCopyStart(CdbCopy *cdbCopy, char *copyCmd);
+void		cdbCopyStart(CdbCopy *cdbCopy, char *copyCmd, struct GpPolicy *policy);
 void		cdbCopySendDataToAll(CdbCopy *c, const char *buffer, int nbytes);
 void		cdbCopySendData(CdbCopy *c, int target_seg, const char *buffer, int nbytes);
 bool		cdbCopyGetData(CdbCopy *c, bool cancel, uint64 *rows_processed);

--- a/src/include/commands/copy.h
+++ b/src/include/commands/copy.h
@@ -18,7 +18,7 @@
 #include "nodes/parsenodes.h"
 #include "tcop/dest.h"
 #include "executor/executor.h"
-
+#include "cdb/cdbhash.h"
 
 /*
  * Represents the different source/dest cases we need to worry about at
@@ -291,5 +291,13 @@ extern void truncateEol(StringInfo buf, EolType	eol_type);
 extern void truncateEolStr(char *str, EolType eol_type);
 extern void setEncodingConversionProc(CopyState cstate, int client_encoding, bool iswritable);
 extern void CopyEolStrToType(CopyState cstate);
+
+typedef struct GpDistributionData
+{
+	GpPolicy *policy;	/* the partitioning policy for this table */
+	AttrNumber p_nattrs; /* num of attributes in the distribution policy */
+	Oid *p_attr_types;   /* types for each policy attribute */
+	CdbHash *cdbHash;
+} GpDistributionData;
 
 #endif   /* COPY_H */

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -23,6 +23,7 @@
 #include "nodes/bitmapset.h"
 #include "nodes/primnodes.h"
 #include "nodes/value.h"
+#include "catalog/gp_policy.h"
 
 typedef struct PartitionNode PartitionNode; /* see relation.h */
 
@@ -1422,6 +1423,9 @@ typedef struct CopyStmt
 	/* Convenient location for dispatch of misc meta data */
 	PartitionNode *partitions;
 	List		*ao_segnos;		/* AO segno map */
+	int			nattrs;
+	GpPolicyType	ptype;
+	AttrNumber	*distribution_attrs;
 } CopyStmt;
 
 /* ----------------------

--- a/src/test/regress/input/gpcopy.source
+++ b/src/test/regress/input/gpcopy.source
@@ -771,7 +771,7 @@ INSERT INTO test_copy_on_segment_array VALUES ('{666,2,1}', 'hj');
 INSERT INTO test_copy_on_segment_array VALUES ('{3,555,1}', 'hj');
 COPY test_copy_on_segment_array TO '/tmp/valid_filename_array<SEGID>.txt' ON SEGMENT;
 
-CREATE TABLE test_copy_on_segment_array_1 (LIKE test_copy_on_segment_array) DISTRIBUTED BY (a);
+CREATE TABLE test_copy_on_segment_array_1 (a int[], b text) DISTRIBUTED BY (a);
 COPY test_copy_on_segment_array_1 FROM '/tmp/valid_filename_array<SEGID>.txt' ON SEGMENT;
 SELECT * FROM test_copy_on_segment_array EXCEPT SELECT * FROM test_copy_on_segment_array_1;
 
@@ -784,7 +784,7 @@ INSERT INTO test_copy_on_segment_2dim_array VALUES ('{{1,233,3},{2,5,9}}');
 INSERT INTO test_copy_on_segment_2dim_array VALUES ('{{1,666,3},{2,555,9}}');
 COPY test_copy_on_segment_2dim_array TO '/tmp/valid_filename_2dim_array<SEGID>.txt' ON SEGMENT;
 
-CREATE TABLE test_copy_on_segment_2dim_array_1 (LIKE test_copy_on_segment_2dim_array) DISTRIBUTED BY (a);
+CREATE TABLE test_copy_on_segment_2dim_array_1 (a int[][]) DISTRIBUTED BY (a);
 COPY test_copy_on_segment_2dim_array_1 FROM '/tmp/valid_filename_2dim_array<SEGID>.txt' ON SEGMENT;
 SELECT * FROM test_copy_on_segment_2dim_array EXCEPT SELECT * FROM test_copy_on_segment_2dim_array_1;
 
@@ -908,6 +908,65 @@ SELECT * FROM LINEITEM EXCEPT SELECT * FROM LINEITEM_1;
 COPY LINEITEM_2 FROM '/tmp/lineitem_s<SEGID>.csv' ON SEGMENT CSV;
 SELECT COUNT(*) FROM LINEITEM_2;
 SELECT * FROM LINEITEM EXCEPT SELECT * FROM LINEITEM_2;
+
+--Test for `COPY FROM ON SEGMENT` checking the distribution key restriction 
+-- start_matchsubs
+-- m/^ERROR:  Value of distribution key doesn't belong to segment with ID \d, it belongs to segment with ID \d.*$/
+-- s/^ERROR:  Value of distribution key doesn't belong to segment with ID \d, it belongs to segment with ID \d.*$/ERROR:  Value of distribution key doesn't belong to segment/
+-- m/^ERROR:  COPY FROM ON SEGMENT doesn't support checking distribution key restriction when the distribution policy of the partition table is different from the main table.*$/
+-- s/^ERROR:  COPY FROM ON SEGMENT doesn't support checking distribution key restriction when the distribution policy of the partition table is different from the main table.*$/ERROR:  COPY FROM ON SEGMENT doesn't support checking distribution key restriction when the distribution policy of the partition table is different from the main table./
+-- m/^CONTEXT:  COPY .*, line \d*: .*$/
+-- s/^CONTEXT:  COPY .*, line \d*: .*$/CONTEXT:  COPY xxxxx line x: xxx/
+-- end_matchsubs
+-- start_ignore
+DROP TABLE IF EXISTS COPY_ON_SEGMENT_CHECK_DISTKEY;
+DROP TABLE IF EXISTS COPY_ON_SEGMENT_CHECK_TOW_DSITKEY;
+DROP TABLE IF EXISTS COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED;
+DROP TABLE IF EXISTS COPY_ON_SEGMENT_CHECK_DISTKEY_SUBPARTITION;
+-- end_ignore
+CREATE TABLE COPY_ON_SEGMENT_CHECK_DISTKEY(a int)DISTRIBUTED BY(a);
+INSERT INTO COPY_ON_SEGMENT_CHECK_DISTKEY SELECT generate_series(0,10);
+COPY COPY_ON_SEGMENT_CHECK_DISTKEY to '/tmp/COPY_ON_SEGMENT_CHECK_DISTKEY<SEGID>.csv' ON SEGMENT CSV;
+COPY COPY_ON_SEGMENT_CHECK_DISTKEY to '/tmp/COPY_ON_SEGMENT_CHECK_DISTKEY0.csv' CSV;
+COPY COPY_ON_SEGMENT_CHECK_DISTKEY FROM '/tmp/COPY_ON_SEGMENT_CHECK_DISTKEY<SEGID>.csv' ON SEGMENT CSV;
+
+CREATE TABLE COPY_ON_SEGMENT_CHECK_TOW_DSITKEY(a int,b int)DISTRIBUTED BY(a,b);
+INSERT INTO COPY_ON_SEGMENT_CHECK_TOW_DSITKEY SELECT generate_series(0,10),generate_series(0,10);
+COPY COPY_ON_SEGMENT_CHECK_TOW_DSITKEY to '/tmp/COPY_ON_SEGMENT_CHECK_TOW_DSITKEY<SEGID>.csv' ON SEGMENT CSV;
+COPY COPY_ON_SEGMENT_CHECK_TOW_DSITKEY to '/tmp/COPY_ON_SEGMENT_CHECK_TOW_DSITKEY0.csv' CSV;
+COPY COPY_ON_SEGMENT_CHECK_TOW_DSITKEY FROM '/tmp/COPY_ON_SEGMENT_CHECK_TOW_DSITKEY<SEGID>.csv' ON SEGMENT CSV;
+
+--`COPY FROM ON SEGMENT` partitoned table
+CREATE TABLE COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED(a int) DISTRIBUTED BY (a) PARTITION BY range(a) ( START (0) END (10) EVERY (5));
+INSERT INTO COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED SELECT generate_series(0,9);
+COPY COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED to '/tmp/COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED<SEGID>.csv' ON SEGMENT CSV;
+COPY COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED FROM '/tmp/COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED<SEGID>.csv' ON SEGMENT CSV;
+SELECT COUNT(*) FROM COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED;
+
+COPY COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED to '/tmp/COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED0.csv' CSV;
+COPY COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED FROM '/tmp/COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED<SEGID>.csv' ON SEGMENT CSV;
+SELECT COUNT(*) FROM COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED;
+
+ALTER table copy_on_segment_check_distkey_partioned_1_prt_1 set DISTRIBUTED RANDOMLY ;
+COPY COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED FROM '/tmp/COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED<SEGID>.csv' ON SEGMENT CSV;
+
+--`COPY FROM ON SEGMENT` SUBPARTITION table
+CREATE TABLE COPY_ON_SEGMENT_CHECK_DISTKEY_SUBPARTITION(a int,b int) DISTRIBUTED BY (a) PARTITION BY range(a) 
+ SUBPARTITION BY RANGE (b)
+    SUBPARTITION TEMPLATE (
+       START (0) END (10) EVERY (3)
+    )
+( START (0) END (10) EVERY (5));
+INSERT INTO COPY_ON_SEGMENT_CHECK_DISTKEY_SUBPARTITION SELECT generate_series(0,9),generate_series(0,9);
+COPY COPY_ON_SEGMENT_CHECK_DISTKEY_SUBPARTITION to '/tmp/COPY_ON_SEGMENT_CHECK_DISTKEY_SUBPARTITION<SEGID>.csv' ON SEGMENT CSV;
+COPY COPY_ON_SEGMENT_CHECK_DISTKEY_SUBPARTITION FROM '/tmp/COPY_ON_SEGMENT_CHECK_DISTKEY_SUBPARTITION<SEGID>.csv' ON SEGMENT CSV;
+SELECT COUNT(*) FROM COPY_ON_SEGMENT_CHECK_DISTKEY_SUBPARTITION;
+
+COPY COPY_ON_SEGMENT_CHECK_DISTKEY_SUBPARTITION to '/tmp/COPY_ON_SEGMENT_CHECK_DISTKEY_SUBPARTITION0.csv'  CSV;
+COPY COPY_ON_SEGMENT_CHECK_DISTKEY_SUBPARTITION FROM '/tmp/COPY_ON_SEGMENT_CHECK_DISTKEY_SUBPARTITION<SEGID>.csv' ON SEGMENT CSV;
+
+ALTER table copy_on_segment_check_distkey_subpartition_1_prt_1_2_prt_1 set DISTRIBUTED RANDOMLY ;
+COPY COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED FROM '/tmp/COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED<SEGID>.csv' ON SEGMENT CSV;
 -- start_ignore
 DROP TABLE IF EXISTS LINEITEM;
 DROP TABLE IF EXISTS LINEITEM_1;

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -783,7 +783,7 @@ INSERT INTO test_copy_on_segment_array VALUES ('{233,2,1}', 'hj');
 INSERT INTO test_copy_on_segment_array VALUES ('{666,2,1}', 'hj');
 INSERT INTO test_copy_on_segment_array VALUES ('{3,555,1}', 'hj');
 COPY test_copy_on_segment_array TO '/tmp/valid_filename_array<SEGID>.txt' ON SEGMENT;
-CREATE TABLE test_copy_on_segment_array_1 (LIKE test_copy_on_segment_array) DISTRIBUTED BY (a);
+CREATE TABLE test_copy_on_segment_array_1 (a int[], b text) DISTRIBUTED BY (a);
 COPY test_copy_on_segment_array_1 FROM '/tmp/valid_filename_array<SEGID>.txt' ON SEGMENT;
 SELECT * FROM test_copy_on_segment_array EXCEPT SELECT * FROM test_copy_on_segment_array_1;
  a | b 
@@ -798,7 +798,7 @@ INSERT INTO test_copy_on_segment_2dim_array VALUES ('{{1,3,3},{2,6,9}}');
 INSERT INTO test_copy_on_segment_2dim_array VALUES ('{{1,233,3},{2,5,9}}');
 INSERT INTO test_copy_on_segment_2dim_array VALUES ('{{1,666,3},{2,555,9}}');
 COPY test_copy_on_segment_2dim_array TO '/tmp/valid_filename_2dim_array<SEGID>.txt' ON SEGMENT;
-CREATE TABLE test_copy_on_segment_2dim_array_1 (LIKE test_copy_on_segment_2dim_array) DISTRIBUTED BY (a);
+CREATE TABLE test_copy_on_segment_2dim_array_1 (a int[][]) DISTRIBUTED BY (a);
 COPY test_copy_on_segment_2dim_array_1 FROM '/tmp/valid_filename_2dim_array<SEGID>.txt' ON SEGMENT;
 SELECT * FROM test_copy_on_segment_2dim_array EXCEPT SELECT * FROM test_copy_on_segment_2dim_array_1;
  a 
@@ -990,6 +990,86 @@ SELECT * FROM LINEITEM EXCEPT SELECT * FROM LINEITEM_2;
 ------------+-----------+-----------+--------------+------------+-----------------+------------+-------+--------------+--------------+------------+--------------+---------------+----------------+------------+-----------
 (0 rows)
 
+--Test for `COPY FROM ON SEGMENT` checking the distribution key restriction 
+-- start_matchsubs
+-- m/^ERROR:  Value of distribution key doesn't belong to segment with ID \d, it belongs to segment with ID \d.*$/
+-- s/^ERROR:  Value of distribution key doesn't belong to segment with ID \d, it belongs to segment with ID \d.*$/ERROR:  Value of distribution key doesn't belong to segment/
+-- m/^ERROR:  COPY FROM ON SEGMENT doesn't support checking distribution key restriction when the distribution policy of the partition table is different from the main table.*$/
+-- s/^ERROR:  COPY FROM ON SEGMENT doesn't support checking distribution key restriction when the distribution policy of the partition table is different from the main table.*$/ERROR:  COPY FROM ON SEGMENT doesn't support checking distribution key restriction when the distribution policy of the partition table is different from the main table./
+-- m/^CONTEXT:  COPY .*, line \d*: .*$/
+-- s/^CONTEXT:  COPY .*, line \d*: .*$/CONTEXT:  COPY xxxxx line x: xxx/
+-- end_matchsubs
+-- start_ignore
+DROP TABLE IF EXISTS COPY_ON_SEGMENT_CHECK_DISTKEY;
+NOTICE:  table "copy_on_segment_check_distkey" does not exist, skipping
+DROP TABLE IF EXISTS COPY_ON_SEGMENT_CHECK_TOW_DSITKEY;
+NOTICE:  table "copy_on_segment_check_tow_dsitkey" does not exist, skipping
+DROP TABLE IF EXISTS COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED;
+NOTICE:  table "copy_on_segment_check_distkey_partioned" does not exist, skipping
+DROP TABLE IF EXISTS COPY_ON_SEGMENT_CHECK_DISTKEY_SUBPARTITION;
+NOTICE:  table "copy_on_segment_check_distkey_subpartition" does not exist, skipping
+-- end_ignore
+CREATE TABLE COPY_ON_SEGMENT_CHECK_DISTKEY(a int)DISTRIBUTED BY(a);
+INSERT INTO COPY_ON_SEGMENT_CHECK_DISTKEY SELECT generate_series(0,10);
+COPY COPY_ON_SEGMENT_CHECK_DISTKEY to '/tmp/COPY_ON_SEGMENT_CHECK_DISTKEY<SEGID>.csv' ON SEGMENT CSV;
+COPY COPY_ON_SEGMENT_CHECK_DISTKEY to '/tmp/COPY_ON_SEGMENT_CHECK_DISTKEY0.csv' CSV;
+COPY COPY_ON_SEGMENT_CHECK_DISTKEY FROM '/tmp/COPY_ON_SEGMENT_CHECK_DISTKEY<SEGID>.csv' ON SEGMENT CSV;
+ERROR:  Value of distribution key doesn't belong to segment with ID 0, it belongs to segment with ID 1. (copy.c:5049)  (seg0 172.17.0.2:40000 pid=13551)
+CONTEXT:  COPY copy_on_segment_check_distkey, line 2: "0"
+CREATE TABLE COPY_ON_SEGMENT_CHECK_TOW_DSITKEY(a int,b int)DISTRIBUTED BY(a,b);
+INSERT INTO COPY_ON_SEGMENT_CHECK_TOW_DSITKEY SELECT generate_series(0,10),generate_series(0,10);
+COPY COPY_ON_SEGMENT_CHECK_TOW_DSITKEY to '/tmp/COPY_ON_SEGMENT_CHECK_TOW_DSITKEY<SEGID>.csv' ON SEGMENT CSV;
+COPY COPY_ON_SEGMENT_CHECK_TOW_DSITKEY to '/tmp/COPY_ON_SEGMENT_CHECK_TOW_DSITKEY0.csv' CSV;
+COPY COPY_ON_SEGMENT_CHECK_TOW_DSITKEY FROM '/tmp/COPY_ON_SEGMENT_CHECK_TOW_DSITKEY<SEGID>.csv' ON SEGMENT CSV;
+ERROR:  Value of distribution key doesn't belong to segment with ID 0, it belongs to segment with ID 1. (copy.c:5049)  (seg0 172.17.0.2:40000 pid=13551)
+CONTEXT:  COPY copy_on_segment_check_tow_dsitkey, line 1: "0,0"
+--`COPY FROM ON SEGMENT` partitoned table
+CREATE TABLE COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED(a int) DISTRIBUTED BY (a) PARTITION BY range(a) ( START (0) END (10) EVERY (5));
+INSERT INTO COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED SELECT generate_series(0,9);
+COPY COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED to '/tmp/COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED<SEGID>.csv' ON SEGMENT CSV;
+COPY COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED FROM '/tmp/COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED<SEGID>.csv' ON SEGMENT CSV;
+SELECT COUNT(*) FROM COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED;
+ count 
+-------
+    20
+(1 row)
+
+COPY COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED to '/tmp/COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED0.csv' CSV;
+COPY COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED FROM '/tmp/COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED<SEGID>.csv' ON SEGMENT CSV;
+ERROR:  Value of distribution key doesn't belong to segment with ID 1, it belongs to segment with ID 2. (copy.c:5049)  (seg1 172.17.0.2:40000 pid=13551)
+CONTEXT:  COPY copy_on_segment_check_distkey_partioned, line 1: "0"
+SELECT COUNT(*) FROM COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED;
+ count 
+-------
+    20
+(1 row)
+
+ALTER table copy_on_segment_check_distkey_partioned_1_prt_1 set DISTRIBUTED RANDOMLY ;
+COPY COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED FROM '/tmp/COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED<SEGID>.csv' ON SEGMENT CSV;
+ERROR:  COPY FROM ON SEGMENT doesn't support checking distribution key restriction when the distribution policy of the partition table is different from the main table. (copy.c:1691)
+--`COPY FROM ON SEGMENT` SUBPARTITION table
+CREATE TABLE COPY_ON_SEGMENT_CHECK_DISTKEY_SUBPARTITION(a int,b int) DISTRIBUTED BY (a) PARTITION BY range(a) 
+ SUBPARTITION BY RANGE (b)
+    SUBPARTITION TEMPLATE (
+       START (0) END (10) EVERY (3)
+    )
+( START (0) END (10) EVERY (5));
+INSERT INTO COPY_ON_SEGMENT_CHECK_DISTKEY_SUBPARTITION SELECT generate_series(0,9),generate_series(0,9);
+COPY COPY_ON_SEGMENT_CHECK_DISTKEY_SUBPARTITION to '/tmp/COPY_ON_SEGMENT_CHECK_DISTKEY_SUBPARTITION<SEGID>.csv' ON SEGMENT CSV;
+COPY COPY_ON_SEGMENT_CHECK_DISTKEY_SUBPARTITION FROM '/tmp/COPY_ON_SEGMENT_CHECK_DISTKEY_SUBPARTITION<SEGID>.csv' ON SEGMENT CSV;
+SELECT COUNT(*) FROM COPY_ON_SEGMENT_CHECK_DISTKEY_SUBPARTITION;
+ count 
+-------
+    20
+(1 row)
+
+COPY COPY_ON_SEGMENT_CHECK_DISTKEY_SUBPARTITION to '/tmp/COPY_ON_SEGMENT_CHECK_DISTKEY_SUBPARTITION0.csv'  CSV;
+COPY COPY_ON_SEGMENT_CHECK_DISTKEY_SUBPARTITION FROM '/tmp/COPY_ON_SEGMENT_CHECK_DISTKEY_SUBPARTITION<SEGID>.csv' ON SEGMENT CSV;
+ERROR:  Value of distribution key doesn't belong to segment with ID 0, it belongs to segment with ID 1. (copy.c:5049)  (seg0 172.17.0.2:40000 pid=20583)
+CONTEXT:  COPY copy_on_segment_check_distkey_subpartition, line 2: "0,0"
+ALTER table copy_on_segment_check_distkey_subpartition_1_prt_1_2_prt_1 set DISTRIBUTED RANDOMLY ;
+COPY COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED FROM '/tmp/COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED<SEGID>.csv' ON SEGMENT CSV;
+ERROR:  COPY FROM ON SEGMENT doesn't support checking distribution key restriction when the distribution policy of the partition table is different from the main table. (copy.c:1692)
 -- start_ignore
 DROP TABLE IF EXISTS LINEITEM;
 DROP TABLE IF EXISTS LINEITEM_1;


### PR DESCRIPTION
    When use command `COPY FROM ON SEGMENT`, we copy data from
    local file to the table on the segment directly. When copying
    data, we need to apply the distribution policy on the record to compute
    the target segment. If the target segment ID isn't equal to
    current segment ID, we will report error to keep the distribution
    key restriction.

    Because the segment has no meta data info about table distribution policy and
    partition policy,we copy the distribution policy of main table from
    master to segment in the query plan. When the parent table and partitioned sub table has different
    distribution policy, it is difficult to check all the distribution key
    restriction in all sub tables. In this case , we will report error.

    In case of the partitioned table's distribution policy is
    RANDOMLY and different from the parent table, user can use GUC value
    `gp_enable_segment_copy_checking` to disable this check.

    Check the distribution key restriction as follows:

    1) Table isn't partioned :
        Compute the data target segment.If the data doesn't belong the
        segment, will report error.

    2) Table is partitioned and the distribution policy of partitioned table
    as same as the main table:
        Compute the data target segment.If the data doesn't belong
        the segment, will report error.

    3) Table is partitioned and the distribution policy of partitioned
    table is different from main table:
        Not support to check ,report error.

Signed-off-by: Xiaoran Wang <xiwang@pivotal.io>
Signed-off-by: Ming LI <mli@apache.org>
Signed-off-by: Adam Lee <ali@pivotal.io>