### PR TITLE
Copy parse location of ArrayExpr.

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -1788,7 +1788,7 @@ _copyArrayExpr(ArrayExpr *from)
 	COPY_SCALAR_FIELD(element_typeid);
 	COPY_NODE_FIELD(elements);
 	COPY_SCALAR_FIELD(multidims);
-	/* COPY_LOCATION_FIELD(location); */
+	COPY_LOCATION_FIELD(location);
 
 	return newnode;
 }
@@ -2352,7 +2352,7 @@ _copyWindowSpec(WindowSpec *from)
 	COPY_NODE_FIELD(partition);
 	COPY_NODE_FIELD(order);
 	COPY_NODE_FIELD(frame);
-	COPY_SCALAR_FIELD(location);
+	COPY_LOCATION_FIELD(location);
 
 	return newnode;
 }
@@ -2394,7 +2394,7 @@ _copyPercentileExpr(PercentileExpr *from)
 	COPY_NODE_FIELD(sortTargets);
 	COPY_NODE_FIELD(pcExpr);
 	COPY_NODE_FIELD(tcExpr);
-	COPY_SCALAR_FIELD(location);
+	COPY_LOCATION_FIELD(location);
 
 	return newnode;
 }
@@ -2415,11 +2415,11 @@ static WithClause *
 _copyWithClause(WithClause *from)
 {
 	WithClause *newnode = makeNode(WithClause);
-	
+
 	COPY_NODE_FIELD(ctes);
 	COPY_SCALAR_FIELD(recursive);
-	COPY_SCALAR_FIELD(location);
-	
+	COPY_LOCATION_FIELD(location);
+
 	return newnode;
 }
 
@@ -2427,11 +2427,11 @@ static CommonTableExpr *
 _copyCommonTableExpr(CommonTableExpr *from)
 {
 	CommonTableExpr *newnode = makeNode(CommonTableExpr);
-	
+
 	COPY_STRING_FIELD(ctename);
 	COPY_NODE_FIELD(aliascolnames);
 	COPY_NODE_FIELD(ctequery);
-	COPY_SCALAR_FIELD(location);
+	COPY_LOCATION_FIELD(location);
 	COPY_SCALAR_FIELD(cterecursive);
 	COPY_SCALAR_FIELD(cterefcount);
 	COPY_NODE_FIELD(ctecolnames);
@@ -2472,7 +2472,7 @@ _copyParamRef(ParamRef *from)
 	ParamRef   *newnode = makeNode(ParamRef);
 
 	COPY_SCALAR_FIELD(number);
-	COPY_SCALAR_FIELD(location);    /*CDB*/
+	COPY_LOCATION_FIELD(location);
 
 	return newnode;
 }
@@ -2504,7 +2504,7 @@ _copyAConst(A_Const *from)
 	}
 
 	COPY_NODE_FIELD(typeName);
-	COPY_SCALAR_FIELD(location);    /*CDB*/
+	COPY_LOCATION_FIELD(location);
 
 	return newnode;
 }
@@ -2599,7 +2599,7 @@ _copySortBy(SortBy *from)
 	COPY_SCALAR_FIELD(sortby_nulls);
 	COPY_NODE_FIELD(useOp);
 	COPY_NODE_FIELD(node);
-	COPY_SCALAR_FIELD(location);
+	COPY_LOCATION_FIELD(location);
 
 	return newnode;
 }
@@ -3198,7 +3198,7 @@ _copyPartitionBy(PartitionBy *from)
 	COPY_SCALAR_FIELD(partDepth);
 	COPY_NODE_FIELD(parentRel);
 	COPY_SCALAR_FIELD(partQuiet);
-	COPY_SCALAR_FIELD(location);
+	COPY_LOCATION_FIELD(location);
 
 	return newnode;
 }
@@ -3212,7 +3212,7 @@ _copyPartitionSpec(PartitionSpec *from)
 	COPY_NODE_FIELD(subSpec);
 	COPY_SCALAR_FIELD(istemplate);
 	COPY_NODE_FIELD(enc_clauses);
-	COPY_SCALAR_FIELD(location);
+	COPY_LOCATION_FIELD(location);
 
 	return newnode;
 }
@@ -3223,7 +3223,7 @@ _copyPartitionValuesSpec(PartitionValuesSpec *from)
 	PartitionValuesSpec *newnode = makeNode(PartitionValuesSpec);
 
 	COPY_NODE_FIELD(partValues);
-	COPY_SCALAR_FIELD(location);
+	COPY_LOCATION_FIELD(location);
 
 	return newnode;
 }
@@ -3241,7 +3241,7 @@ _copyPartitionElem(PartitionElem *from)
 	COPY_SCALAR_FIELD(partno);
 	COPY_SCALAR_FIELD(rrand);
 	COPY_NODE_FIELD(colencs);
-	COPY_SCALAR_FIELD(location);
+	COPY_LOCATION_FIELD(location);
 
 	return newnode;
 }
@@ -3253,7 +3253,7 @@ _copyPartitionRangeItem(PartitionRangeItem *from)
 
 	COPY_NODE_FIELD(partRangeVal);
 	COPY_SCALAR_FIELD(partedge);
-	COPY_SCALAR_FIELD(location);
+	COPY_LOCATION_FIELD(location);
 
 	return newnode;
 }
@@ -3266,7 +3266,7 @@ _copyPartitionBoundSpec(PartitionBoundSpec *from)
 	COPY_NODE_FIELD(partStart);
 	COPY_NODE_FIELD(partEnd);
 	COPY_NODE_FIELD(partEvery);
-	COPY_SCALAR_FIELD(location);
+	COPY_LOCATION_FIELD(location);
 
 	return newnode;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -1161,14 +1161,14 @@ _outRangeVar(StringInfo str, RangeVar *node)
 	WRITE_ENUM_FIELD(inhOpt, InhOption);
 	WRITE_BOOL_FIELD(istemp);
 	WRITE_NODE_FIELD(alias);
-    WRITE_LOCATION_FIELD(location);
+	WRITE_LOCATION_FIELD(location);
 }
 
 static void
 _outIntoClause(StringInfo str, IntoClause *node)
 {
 	WRITE_NODE_TYPE("INTOCLAUSE");
-	
+
 	WRITE_NODE_FIELD(rel);
 	WRITE_NODE_FIELD(colNames);
 	WRITE_NODE_FIELD(options);
@@ -2746,7 +2746,7 @@ _outPartitionBy(StringInfo str, PartitionBy *node)
 	WRITE_NODE_FIELD(partSpec);
 	WRITE_INT_FIELD(partDepth);
 	WRITE_INT_FIELD(partQuiet);
-	WRITE_INT_FIELD(location);
+	WRITE_LOCATION_FIELD(location);
 }
 
 #ifndef COMPILING_BINARY_FUNCS
@@ -2757,7 +2757,7 @@ _outPartitionSpec(StringInfo str, PartitionSpec *node)
 	WRITE_NODE_FIELD(partElem);
 	WRITE_NODE_FIELD(subSpec);
 	WRITE_BOOL_FIELD(istemplate);
-	WRITE_INT_FIELD(location);
+	WRITE_LOCATION_FIELD(location);
 }
 #endif /* COMPILING_BINARY_FUNCS */
 
@@ -2773,7 +2773,7 @@ _outPartitionElem(StringInfo str, PartitionElem *node)
 	WRITE_INT_FIELD(partno);
 	WRITE_LONG_FIELD(rrand);
 	WRITE_NODE_FIELD(colencs);
-	WRITE_INT_FIELD(location);
+	WRITE_LOCATION_FIELD(location);
 }
 
 static void
@@ -2782,7 +2782,7 @@ _outPartitionRangeItem(StringInfo str, PartitionRangeItem *node)
 	WRITE_NODE_TYPE("PARTITIONRANGEITEM");
 	WRITE_NODE_FIELD(partRangeVal);
 	WRITE_ENUM_FIELD(partedge, PartitionEdgeBounding);
-	WRITE_INT_FIELD(location);
+	WRITE_LOCATION_FIELD(location);
 }
 
 #ifndef COMPILING_BINARY_FUNCS
@@ -2795,7 +2795,7 @@ _outPartitionBoundSpec(StringInfo str, PartitionBoundSpec *node)
 	WRITE_NODE_FIELD(partEvery);
 	WRITE_NODE_FIELD(everyGenList);
 	WRITE_STRING_FIELD(pWithTnameStr);
-	WRITE_INT_FIELD(location);
+	WRITE_LOCATION_FIELD(location);
 }
 #endif /* COMPILING_BINARY_FUNCS */
 
@@ -2804,7 +2804,7 @@ _outPartitionValuesSpec(StringInfo str, PartitionValuesSpec *node)
 {
 	WRITE_NODE_TYPE("PARTITIONVALUESSPEC");
 	WRITE_NODE_FIELD(partValues);
-	WRITE_INT_FIELD(location);
+	WRITE_LOCATION_FIELD(location);
 }
 
 #ifndef COMPILING_BINARY_FUNCS
@@ -3567,7 +3567,7 @@ _outWindowSpec(StringInfo str, WindowSpec *node)
 	WRITE_NODE_FIELD(partition);
 	WRITE_NODE_FIELD(order);
 	WRITE_NODE_FIELD(frame);
-    WRITE_INT_FIELD(location);
+	WRITE_LOCATION_FIELD(location);
 }
 
 static void
@@ -3603,7 +3603,7 @@ _outPercentileExpr(StringInfo str, PercentileExpr *node)
 	WRITE_NODE_FIELD(sortTargets);
 	WRITE_NODE_FIELD(pcExpr);
 	WRITE_NODE_FIELD(tcExpr);
-	WRITE_INT_FIELD(location);
+	WRITE_LOCATION_FIELD(location);
 }
 
 static void
@@ -3620,21 +3620,21 @@ static void
 _outWithClause(StringInfo str, WithClause *node)
 {
 	WRITE_NODE_TYPE("WITHCLAUSE");
-	
+
 	WRITE_NODE_FIELD(ctes);
 	WRITE_BOOL_FIELD(recursive);
-	WRITE_INT_FIELD(location);
+	WRITE_LOCATION_FIELD(location);
 }
 
 static void
 _outCommonTableExpr(StringInfo str, CommonTableExpr *node)
 {
 	WRITE_NODE_TYPE("COMMONTABLEEXPR");
-	
-    WRITE_STRING_FIELD(ctename);
+
+	WRITE_STRING_FIELD(ctename);
 	WRITE_NODE_FIELD(aliascolnames);
 	WRITE_NODE_FIELD(ctequery);
-	WRITE_INT_FIELD(location);
+	WRITE_LOCATION_FIELD(location);
 	WRITE_BOOL_FIELD(cterecursive);
 	WRITE_INT_FIELD(cterefcount);
 	WRITE_NODE_FIELD(ctecolnames);
@@ -3844,7 +3844,7 @@ _outParamRef(StringInfo str, ParamRef *node)
 	WRITE_NODE_TYPE("PARAMREF");
 
 	WRITE_INT_FIELD(number);
-	WRITE_INT_FIELD(location);  /*CDB*/
+	WRITE_LOCATION_FIELD(location);
 }
 
 #ifndef COMPILING_BINARY_FUNCS
@@ -3913,7 +3913,7 @@ _outSortBy(StringInfo str, SortBy *node)
 	WRITE_INT_FIELD(sortby_nulls);
 	WRITE_NODE_FIELD(useOp);
 	WRITE_NODE_FIELD(node);
-	WRITE_INT_FIELD(location);
+	WRITE_LOCATION_FIELD(location);
 }
 
 #ifndef COMPILING_BINARY_FUNCS

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -1174,7 +1174,7 @@ _readPartitionBy(void)
 	READ_NODE_FIELD(partSpec);
 	READ_INT_FIELD(partDepth);
 	READ_INT_FIELD(partQuiet);
-	READ_INT_FIELD(location);
+	READ_LOCATION_FIELD(location);
 
 	READ_DONE();
 }
@@ -1187,7 +1187,7 @@ _readPartitionSpec(void)
 	READ_NODE_FIELD(partElem);
 	READ_NODE_FIELD(subSpec);
 	READ_BOOL_FIELD(istemplate);
-	READ_INT_FIELD(location);
+	READ_LOCATION_FIELD(location);
 	READ_NODE_FIELD(enc_clauses);
 
 	READ_DONE();
@@ -1206,7 +1206,7 @@ _readPartitionElem(void)
 	READ_INT_FIELD(partno);
 	READ_LONG_FIELD(rrand);
 	READ_NODE_FIELD(colencs);
-	READ_INT_FIELD(location);
+	READ_LOCATION_FIELD(location);
 
 	READ_DONE();
 }
@@ -1218,7 +1218,7 @@ _readPartitionRangeItem(void)
 
 	READ_NODE_FIELD(partRangeVal);
 	READ_ENUM_FIELD(partedge, PartitionEdgeBounding);
-	READ_INT_FIELD(location);
+	READ_LOCATION_FIELD(location);
 
 	READ_DONE();
 }
@@ -1231,7 +1231,7 @@ _readPartitionBoundSpec(void)
 	READ_NODE_FIELD(partStart);
 	READ_NODE_FIELD(partEnd);
 	READ_NODE_FIELD(partEvery);
-	READ_INT_FIELD(location);
+	READ_LOCATION_FIELD(location);
 
 	READ_DONE();
 }
@@ -1242,7 +1242,7 @@ _readPartitionValuesSpec(void)
 	READ_LOCALS(PartitionValuesSpec);
 
 	READ_NODE_FIELD(partValues);
-	READ_INT_FIELD(location);
+	READ_LOCATION_FIELD(location);
 
 	READ_DONE();
 }

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -493,7 +493,7 @@ _readWindowSpec(void)
 	READ_NODE_FIELD(partition);
 	READ_NODE_FIELD(order);
 	READ_NODE_FIELD(frame);
-	READ_INT_FIELD(location);
+	READ_LOCATION_FIELD(location);
 
 	READ_DONE();
 }
@@ -535,7 +535,7 @@ _readPercentileExpr(void)
 	READ_NODE_FIELD(sortTargets);
 	READ_NODE_FIELD(pcExpr);
 	READ_NODE_FIELD(tcExpr);
-	READ_INT_FIELD(location);
+	READ_LOCATION_FIELD(location);
 
 	READ_DONE();
 }
@@ -561,7 +561,7 @@ _readWithClause(void)
 
 	READ_NODE_FIELD(ctes);
 	READ_BOOL_FIELD(recursive);
-	READ_INT_FIELD(location);
+	READ_LOCATION_FIELD(location);
 
 	READ_DONE();
 }
@@ -574,7 +574,7 @@ _readCommonTableExpr(void)
 	READ_STRING_FIELD(ctename);
 	READ_NODE_FIELD(aliascolnames);
 	READ_NODE_FIELD(ctequery);
-	READ_INT_FIELD(location);
+	READ_LOCATION_FIELD(location);
 	READ_BOOL_FIELD(cterecursive);
 	READ_INT_FIELD(cterefcount);
 	READ_NODE_FIELD(ctecolnames);
@@ -1989,7 +1989,7 @@ _readSortBy(void)
 	READ_INT_FIELD(sortby_nulls);
 	READ_NODE_FIELD(useOp);
 	READ_NODE_FIELD(node);
-	READ_INT_FIELD(location);
+	READ_LOCATION_FIELD(location);
 
 	READ_DONE();
 }


### PR DESCRIPTION
As part of the 8.3 merge, we backported the addition of the location field.
from 8.4, but accidentally left the copy support for it commented out.

Also, be more pedantic about using COPY/READ/WRITE_LOCATION_FIELD macros
to deal with location fields, rather than the *_INT_FIELD macros. This is
purely cosmetic, but hopefully reduces merge conflicts a bit. I didn't touch
the few places where we already had the location field in 8.3, those will
be changed as part of the 8.4 merge.