### PR TITLE
Allow REPEATABLE READ isolation level.

### DIFF
--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -1651,12 +1651,12 @@ mppTxnOptions(bool needTwoPhase)
 int
 mppTxOptions_IsoLevel(int txnOptions)
 {
-	if (txnOptions & GP_OPT_READ_COMMITTED)
-		return XACT_READ_COMMITTED;
-	else if (txnOptions & GP_OPT_SERIALIZABLE)
+	if ((txnOptions & GP_OPT_SERIALIZABLE) == GP_OPT_SERIALIZABLE)
 		return XACT_SERIALIZABLE;
-	else if (txnOptions & GP_OPT_REPEATABLE_READ)
+	else if ((txnOptions & GP_OPT_REPEATABLE_READ) == GP_OPT_REPEATABLE_READ)
 		return XACT_REPEATABLE_READ;
+	else if ((txnOptions & GP_OPT_READ_COMMITTED) == GP_OPT_READ_COMMITTED)
+		return XACT_READ_COMMITTED;
 	else
 		return XACT_READ_UNCOMMITTED;
 }

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -664,13 +664,17 @@ makeOptions(void)
 	 */
 	if (DefaultXactIsoLevel != XACT_READ_COMMITTED)
 	{
-		if (DefaultXactIsoLevel == XACT_SERIALIZABLE)
+		if (DefaultXactIsoLevel == XACT_REPEATABLE_READ)
+			appendStringInfo(&string, " -c default_transaction_isolation=repeatable\\ read");
+		else if (DefaultXactIsoLevel == XACT_SERIALIZABLE)
 			appendStringInfo(&string, " -c default_transaction_isolation=serializable");
 	}
 
 	if (XactIsoLevel != XACT_READ_COMMITTED)
 	{
-		if (XactIsoLevel == XACT_SERIALIZABLE)
+		if (XactIsoLevel == XACT_REPEATABLE_READ)
+			appendStringInfo(&string, " -c transaction_isolation=repeatable\\ read");
+		else if (XactIsoLevel == XACT_SERIALIZABLE)
 			appendStringInfo(&string, " -c transaction_isolation=serializable");
 	}
 

--- a/src/backend/commands/variable.c
+++ b/src/backend/commands/variable.c
@@ -558,9 +558,6 @@ assign_XactIsoLevel(const char *value, bool doit, GucSource source)
 	}
 	else if (strcmp(value, "repeatable read") == 0)
 	{
-		if (doit)
-			elog(ERROR, "Greenplum Database does not support REPEATABLE READ transactions.");
-
 		newXactIsoLevel = XACT_REPEATABLE_READ;
 	}
 	else if (strcmp(value, "read committed") == 0)

--- a/src/test/isolation/expected/ao-repeatable-read.out
+++ b/src/test/isolation/expected/ao-repeatable-read.out
@@ -1,0 +1,22 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s2begin s2select s1insert s1select s2select s2insert s2select
+step s2begin: BEGIN ISOLATION LEVEL REPEATABLE READ;
+step s2select: select count(*) from ao;
+count          
+
+0              
+step s1insert: insert into ao select i, i from generate_series(0, 99) i;
+step s1select: select count(*) from ao;
+count          
+
+100            
+step s2select: select count(*) from ao;
+count          
+
+0              
+step s2insert: insert into ao select i, i from generate_series(0, 99) i;
+step s2select: select count(*) from ao;
+count          
+
+100            

--- a/src/test/isolation/expected/heap-repeatable-read.out
+++ b/src/test/isolation/expected/heap-repeatable-read.out
@@ -1,0 +1,22 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s2begin s2select s1insert s1select s2select s2insert s2select
+step s2begin: BEGIN ISOLATION LEVEL REPEATABLE READ;
+step s2select: select count(*) from heap;
+count          
+
+0              
+step s1insert: insert into heap select i, i from generate_series(0, 99) i;
+step s1select: select count(*) from heap;
+count          
+
+100            
+step s2select: select count(*) from heap;
+count          
+
+0              
+step s2insert: insert into heap select i, i from generate_series(0, 99) i;
+step s2select: select count(*) from heap;
+count          
+
+100            

--- a/src/test/isolation/isolation_schedule
+++ b/src/test/isolation/isolation_schedule
@@ -5,4 +5,4 @@ test: heap-serializable-vacuum
 test: ao-serializable-read
 test: ao-serializable-vacuum
 
-test: ao-insert-eof create_index_hot udf-insert-deadlock
+test: ao-insert-eof create_index_hot udf-insert-deadlock heap-repeatable-read ao-repeatable-read

--- a/src/test/isolation/specs/ao-repeatable-read.spec
+++ b/src/test/isolation/specs/ao-repeatable-read.spec
@@ -1,0 +1,23 @@
+# Test reading an AO-table in REPEATABLE READ mode.
+
+setup
+{
+    create table ao (i int, j int) with (appendonly=true);
+}
+
+teardown
+{
+    drop table if exists ao;
+}
+
+session "s1"
+step "s1insert"	{ insert into ao select i, i from generate_series(0, 99) i; }
+step "s1select"	{ select count(*) from ao; }
+
+session "s2"
+step "s2begin"	{ BEGIN ISOLATION LEVEL REPEATABLE READ; }
+step "s2select"	{ select count(*) from ao; }
+step "s2insert"	{ insert into ao select i, i from generate_series(0, 99) i; }
+teardown	{ abort; }
+
+permutation "s2begin" "s2select" "s1insert" "s1select" "s2select" "s2insert" "s2select"

--- a/src/test/isolation/specs/heap-repeatable-read.spec
+++ b/src/test/isolation/specs/heap-repeatable-read.spec
@@ -1,0 +1,22 @@
+# Test reading a heap table in REPEATABLE READ mode.
+setup
+{
+    create table heap (i int, j int);
+}
+
+teardown
+{
+    drop table if exists heap;
+}
+
+session "s1"
+step "s1insert"	{ insert into heap select i, i from generate_series(0, 99) i; }
+step "s1select"	{ select count(*) from heap; }
+
+session "s2"
+step "s2begin"	{ BEGIN ISOLATION LEVEL REPEATABLE READ; }
+step "s2select"	{ select count(*) from heap; }
+step "s2insert"	{ insert into heap select i, i from generate_series(0, 99) i; }
+teardown	{ abort; }
+
+permutation "s2begin" "s2select" "s1insert" "s1select" "s2select" "s2insert" "s2select"


### PR DESCRIPTION
Forbidding REPEATABLE READ, but allowing SERIALIZABLE, never made much
sense to me. The tragedy in the current situation is that people might
write their applications using SERIALIZABLE, even if plain REPEATABLE READ
is sufficient. They're the same at the moment, but starting with version
9.1, PostgreSQL has a "true" serializable mode that's different, and much
slower, than repeatable read. We don't want applications to use the true
serializable mode in the future, just because we decided to forbid
REPEATABLE READ.

This was discussed on the gpdb-dev mailing list back in 2015, but it didn't
lead to any action then.

Discussion: https://groups.google.com/a/greenplum.org/d/msg/gpdb-dev/_gk7LC4rCE8/jaW84dppCAAJ