### PR TITLE
Ensure directory cleanup in workfile manager

### DIFF
--- a/src/backend/utils/workfile_manager/workfile_mgr.c
+++ b/src/backend/utils/workfile_manager/workfile_mgr.c
@@ -231,11 +231,12 @@ workfile_mgr_create_set(enum ExecWorkFileType type, bool can_be_reused, PlanStat
 
 	if (NULL == newEntry)
 	{
-		/* Could not acquire another entry from the cache - we filled it up */
-		elog(ERROR, "could not create workfile manager entry: exceeded number of concurrent spilling queries");
-
 		/* Clean up the directory we created. */
 		workfile_mgr_delete_set_directory(dir_path);
+
+		/* Could not acquire another entry from the cache - we filled it up */
+		ereport(ERROR,
+				(errmsg("could not create workfile manager entry: exceeded number of concurrent spilling queries")));
 	}
 
 	/* Path has now been copied to the workfile_set. We can free it */


### PR DESCRIPTION
Calling `elog(ERROR ..)` will exit the current context, so the cleanup function would never run. Shift around to ensure the cleanup is called. That being said, since this hasn't been running I'm not sure it's needed/good to do so, but I'll leave that call to the CI pipeline and the workfile developers.