### PR TITLE
Extend pg_resetxlog to handle data checksum

### DIFF
--- a/src/bin/pg_resetxlog/pg_resetxlog.c
+++ b/src/bin/pg_resetxlog/pg_resetxlog.c
@@ -582,6 +582,7 @@ GuessControlValues(void)
 	ControlFile.enableIntTimes = FALSE;
 #endif
 	ControlFile.localeBuflen = LOCALE_NAME_BUFLEN;
+	ControlFile.data_checksum_version = PG_DATA_CHECKSUM_VERSION;
 
 	localeptr = setlocale(LC_COLLATE, "");
 	if (!localeptr)

--- a/src/test/regress/expected/pg_resetxlog.out
+++ b/src/test/regress/expected/pg_resetxlog.out
@@ -1,0 +1,33 @@
+-- setup
+\! mkdir -p /tmp/test_pg_resetxlog/global /tmp/test_pg_resetxlog/pg_xlog
+\! touch /tmp/test_pg_resetxlog/global/pg_control
+-- negative test:
+-- missing argument
+\! pg_resetxlog -k -n /tmp/test_pg_resetxlog
+pg_resetxlog: invalid argument for option -k
+Try "pg_resetxlog --help" for more information.
+-- wrong argument
+\! pg_resetxlog -k wrong_version -n /tmp/test_pg_resetxlog
+pg_resetxlog: invalid argument for option -k
+Try "pg_resetxlog --help" for more information.
+-- lower than 0
+\! pg_resetxlog -k -1 -n /tmp/test_pg_resetxlog
+pg_resetxlog: data_checksum_version (-k) must be within 0..1
+-- greater than PG_DATA_CHECKSUM_VERSION
+\! pg_resetxlog -k 2 -n /tmp/test_pg_resetxlog
+pg_resetxlog: data_checksum_version (-k) must be within 0..1
+-- positive test:
+-- disable the data checksum
+\! pg_resetxlog -k 0 -n /tmp/test_pg_resetxlog | grep "Data page checksum version"
+pg_resetxlog: pg_control exists but is broken or unknown version; ignoring it
+Data page checksum version:           0
+-- enable the data checksum
+\! pg_resetxlog -k 1 -n /tmp/test_pg_resetxlog | grep "Data page checksum version"
+pg_resetxlog: pg_control exists but is broken or unknown version; ignoring it
+Data page checksum version:           1
+-- default the checksum should be on
+\! pg_resetxlog -n /tmp/test_pg_resetxlog | grep "Data page checksum version"
+pg_resetxlog: pg_control exists but is broken or unknown version; ignoring it
+Data page checksum version:           1
+-- cleanup
+\! rm -fr /tmp/test_pg_resetxlog

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -181,7 +181,6 @@ test: ao_checksum_corruption AOCO_Compression2 table_statistics
 test: metadata_track
 test: workfile_mgr_test
 
-# Test psql backslash commands
-test: psql_gp_commands
+test: psql_gp_commands pg_resetxlog
 
 # end of tests

--- a/src/test/regress/sql/pg_resetxlog.sql
+++ b/src/test/regress/sql/pg_resetxlog.sql
@@ -1,0 +1,24 @@
+-- setup
+\! mkdir -p /tmp/test_pg_resetxlog/global /tmp/test_pg_resetxlog/pg_xlog
+\! touch /tmp/test_pg_resetxlog/global/pg_control
+
+-- negative test:
+-- missing argument
+\! pg_resetxlog -k -n /tmp/test_pg_resetxlog
+-- wrong argument
+\! pg_resetxlog -k wrong_version -n /tmp/test_pg_resetxlog
+-- lower than 0
+\! pg_resetxlog -k -1 -n /tmp/test_pg_resetxlog
+-- greater than PG_DATA_CHECKSUM_VERSION
+\! pg_resetxlog -k 2 -n /tmp/test_pg_resetxlog
+
+-- positive test:
+-- disable the data checksum
+\! pg_resetxlog -k 0 -n /tmp/test_pg_resetxlog | grep "Data page checksum version"
+-- enable the data checksum
+\! pg_resetxlog -k 1 -n /tmp/test_pg_resetxlog | grep "Data page checksum version"
+-- default the checksum should be on
+\! pg_resetxlog -n /tmp/test_pg_resetxlog | grep "Data page checksum version"
+
+-- cleanup
+\! rm -fr /tmp/test_pg_resetxlog


### PR DESCRIPTION
Two things we did:
- make default behavior of `pg_resetxlog` to guess the data_checksum_version is 1, so that it will be consistent with `gpinitsystem` default.
- similar to `initdb` `-k` option for enable HEAP_CHECKSUM, we added `-k` to `pg_resetxlog`, so that the checksum setting can be updated directly.