### PR TITLE
WorkerPool: Error out if numWorkers is 0 or less.

### DIFF
--- a/gpMgmt/bin/gppylib/commands/base.py
+++ b/gpMgmt/bin/gppylib/commands/base.py
@@ -52,6 +52,8 @@ class WorkerPool(object):
 
     halt_command='halt command'
     def __init__(self,numWorkers=16,items=None,daemonize=False):
+        if numWorkers <= 0:
+            raise Exception("WorkerPool(): numWorkers should be greater than 0.")
         self.workers=[]
         self.should_stop=False
         self.work_queue=Queue()

--- a/gpMgmt/bin/gppylib/commands/test/unit/test_unit_base.py
+++ b/gpMgmt/bin/gppylib/commands/test/unit/test_unit_base.py
@@ -41,3 +41,7 @@ class WorkerPoolTestCase(unittest.TestCase):
         cmd = Command("dummy name", "echo 'foo'")
         self.subject.execute(cmd)
         self.assertIn(". other/gphome/greenplum_path.sh;", cmd.cmdStr)
+
+    def test_no_workders_in_WorkerPool(self):
+        with self.assertRaises(Exception):
+            w = WorkerPool(numWorkers=0)


### PR DESCRIPTION
Currently, its possible to create a workerpool with 0 workers, which is good for killing time but not much else. (hang forever).

Now we'll fail fast with the worker pool guard.

Signed-off-by: Shoaib Lari <slari@pivotal.io>