### PR TITLE
Fix bug: resgroup decrease concurrency_limit not work correctly

### DIFF
--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -1381,19 +1381,28 @@ groupApplyMemCaps(ResGroupData *group, const ResGroupCaps *caps)
 
 	/* memStocksAvailable is the total free non-shared quota */
 	memStocksAvailable = group->memQuotaGranted - group->memQuotaUsed;
-	/*
-	 * memStocksNeeded is the total non-shared quota needed
-	 * by all the free slots
-	 */
-	memStocksNeeded = slotGetMemQuotaExpected(caps) *
-		(caps->concurrency.proposed - group->nRunning);
 
-	/*
-	 * if memStocksToFree > 0 then we can safely release these
-	 * non-shared quota and still have enough quota to run
-	 * all the free slots.
-	 */
-	memStocksToFree = memStocksAvailable - memStocksNeeded;
+	if (caps->concurrency.proposed > group->nRunning)
+	{
+		/*
+		 * memStocksNeeded is the total non-shared quota needed
+		 * by all the free slots
+		 */
+		memStocksNeeded = slotGetMemQuotaExpected(caps) *
+			(caps->concurrency.proposed - group->nRunning);
+
+		/*
+		 * if memStocksToFree > 0 then we can safely release these
+		 * non-shared quota and still have enough quota to run
+		 * all the free slots.
+		 */
+		memStocksToFree = memStocksAvailable - memStocksNeeded;
+	}
+	else
+	{
+		memStocksToFree = Min(memStocksAvailable,
+							  group->memQuotaGranted - groupGetMemQuotaExpected(caps));
+	}
 
 	/* TODO: optimize the free logic */
 	if (memStocksToFree > 0)
@@ -1647,16 +1656,30 @@ wakeupGroups(Oid skipGroupId)
 static bool 
 groupReleaseMemQuota(ResGroupData *group, ResGroupSlotData *slot, const ResGroupCaps *caps)
 {
-	int32		memQuotaExpected;
-	int32		memQuotaToFree;
+	int32		memQuotaNeedFree;
 	int32		memSharedNeeded;
+	int32		memQuotaToFree;
 	int32		memSharedToFree;
+	int32       memQuotaExpected;
 
 	Assert(LWLockHeldExclusiveByMe(ResGroupLock));
 
 	/* Return the over used memory quota to sys */
-	memQuotaExpected = slotGetMemQuotaExpected(caps);
-	memQuotaToFree = slot->memQuota - memQuotaExpected;
+	memQuotaNeedFree = group->memQuotaGranted - groupGetMemQuotaExpected(caps);
+	memQuotaToFree = memQuotaNeedFree > 0 ? Min(memQuotaNeedFree, slot->memQuota) : 0;
+
+	if (caps->concurrency.proposed >= group->nRunning)
+	{
+		/*
+		 * Under this situation, when this slot is released,
+		 * others will not be blocked by concurrency limit if
+		 * they come to acquire this slot. So we could decide
+		 * not to give all the memory to syspool even if we could.
+		 */
+		memQuotaExpected = slotGetMemQuotaExpected(caps);
+		if (memQuotaToFree > memQuotaExpected)
+			memQuotaToFree -= memQuotaExpected;
+	}
 
 	if (memQuotaToFree > 0)
 	{

--- a/src/test/isolation2/expected/resgroup/resgroup_alter_concurrency.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_alter_concurrency.out
@@ -14,7 +14,7 @@ CREATE OR REPLACE VIEW rg_activity_status AS SELECT rsgname, waiting_reason, cur
 CREATE
 
 --
--- increase concurrency after pending queries
+-- 1. increase concurrency after pending queries
 --
 
 ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 1;
@@ -71,7 +71,7 @@ rsgname|waiting_reason|current_query
 (0 rows)
 
 --
--- increase concurrency before pending queries
+-- 2. increase concurrency before pending queries
 --
 
 ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 1;
@@ -128,7 +128,7 @@ rsgname|waiting_reason|current_query
 (0 rows)
 
 --
--- increase both concurrency & memory_shared_quota after pending queries
+-- 3. increase both concurrency & memory_shared_quota after pending queries
 --
 
 ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 1;
@@ -199,7 +199,7 @@ rsgname|waiting_reason|current_query
 (0 rows)
 
 --
--- increase both concurrency & memory_shared_quota before pending queries
+-- 4. increase both concurrency & memory_shared_quota before pending queries
 --
 
 ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 1;
@@ -259,7 +259,7 @@ rsgname|waiting_reason|current_query
 (0 rows)
 
 --
--- increase both concurrency & memory_limit after pending queries
+-- 5. increase both concurrency & memory_limit after pending queries
 --
 
 ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 1;
@@ -350,7 +350,7 @@ rsgname|waiting_reason|current_query
 (0 rows)
 
 --
--- increase both concurrency & memory_limit before pending queries
+-- 6. increase both concurrency & memory_limit before pending queries
 --
 
 ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 1;
@@ -426,6 +426,49 @@ SELECT * FROM rg_activity_status;
 rsgname|waiting_reason|current_query
 -------+--------------+-------------
 (0 rows)
+
+--
+-- 7. decrease concurrency
+--
+ALTER RESOURCE GROUP rg_concurrency_test SET MEMORY_LIMIT 50;
+ALTER
+ALTER RESOURCE GROUP rg_concurrency_test SET MEMORY_SHARED_QUOTA 0;
+ALTER
+ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 10;
+ALTER
+11:SET ROLE role_concurrency_test;
+SET
+11:BEGIN;
+BEGIN
+
+12:SET ROLE role_concurrency_test;
+SET
+12:BEGIN;
+BEGIN
+
+13:SET ROLE role_concurrency_test;
+SET
+13:BEGIN;
+BEGIN
+
+14:SET ROLE role_concurrency_test;
+SET
+14:BEGIN;
+BEGIN
+
+15:SET ROLE role_concurrency_test;
+SET
+15:BEGIN;
+BEGIN
+
+ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 1;
+ALTER
+
+11q: ... <quitting>
+12q: ... <quitting>
+13q: ... <quitting>
+14q: ... <quitting>
+15q: ... <quitting>
 
 -- cleanup
 DROP VIEW rg_activity_status;

--- a/src/test/isolation2/sql/resgroup/resgroup_alter_concurrency.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_alter_concurrency.sql
@@ -13,7 +13,7 @@ CREATE OR REPLACE VIEW rg_activity_status AS
 	WHERE rsgname='rg_concurrency_test';
 
 --
--- increase concurrency after pending queries
+-- 1. increase concurrency after pending queries
 --
 
 ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 1;
@@ -45,7 +45,7 @@ SELECT * FROM rg_activity_status;
 SELECT * FROM rg_activity_status;
 
 --
--- increase concurrency before pending queries
+-- 2. increase concurrency before pending queries
 --
 
 ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 1;
@@ -77,7 +77,7 @@ SELECT * FROM rg_activity_status;
 SELECT * FROM rg_activity_status;
 
 --
--- increase both concurrency & memory_shared_quota after pending queries
+-- 3. increase both concurrency & memory_shared_quota after pending queries
 --
 
 ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 1;
@@ -115,7 +115,7 @@ SELECT * FROM rg_activity_status;
 SELECT * FROM rg_activity_status;
 
 --
--- increase both concurrency & memory_shared_quota before pending queries
+-- 4. increase both concurrency & memory_shared_quota before pending queries
 --
 
 ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 1;
@@ -148,7 +148,7 @@ SELECT * FROM rg_activity_status;
 SELECT * FROM rg_activity_status;
 
 --
--- increase both concurrency & memory_limit after pending queries
+-- 5. increase both concurrency & memory_limit after pending queries
 --
 
 ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 1;
@@ -198,7 +198,7 @@ SELECT * FROM rg_activity_status;
 SELECT * FROM rg_activity_status;
 
 --
--- increase both concurrency & memory_limit before pending queries
+-- 6. increase both concurrency & memory_limit before pending queries
 --
 
 ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 1;
@@ -242,6 +242,35 @@ SELECT * FROM rg_activity_status;
 22q:
 
 SELECT * FROM rg_activity_status;
+
+--
+-- 7. decrease concurrency
+--
+ALTER RESOURCE GROUP rg_concurrency_test SET MEMORY_LIMIT 50;
+ALTER RESOURCE GROUP rg_concurrency_test SET MEMORY_SHARED_QUOTA 0;
+ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 10;
+11:SET ROLE role_concurrency_test;
+11:BEGIN;
+
+12:SET ROLE role_concurrency_test;
+12:BEGIN;
+
+13:SET ROLE role_concurrency_test;
+13:BEGIN;
+
+14:SET ROLE role_concurrency_test;
+14:BEGIN;
+
+15:SET ROLE role_concurrency_test;
+15:BEGIN;
+
+ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 1;
+
+11q:
+12q:
+13q:
+14q:
+15q:
 
 -- cleanup
 DROP VIEW rg_activity_status;


### PR DESCRIPTION
In previous code, when user decreases resgroup concurrency_limit
to a value that less than the number of current running jobs in
that resgroup, the calculation of memory that need to return to
SYSPOOL is not correct and might cause assert fail.

We add code that takes into account this situation. And the logic
here is that when we decide to return some memory to SYSPOOL, we
only return `Min(total_memory_should_return, max_mem_can_return)`.

And since alter-memory command has gradually-effect semantic, when
a job is just before ending and it finds out that its ending could
provide free slot for others(not blocked by concurrency_limit), it
will try not to return all the memory it could but reserve some to
make sure that new job would not be blocked because of memory_quota.

Signed-off-by: Gang Xiong <gxiong@pivotal.io>