### PR TITLE
 Perform resource group operations only when it's initialized

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -997,7 +997,7 @@ buildGpQueryString(struct CdbDispatcherState *ds,
 	char zero = 0;
 
 	initStringInfo(&resgroupInfo);
-	if (IsResGroupEnabled())
+	if (IsResGroupActivated())
 		SerializeResGroupInfo(&resgroupInfo);
 
 	total_query_len = 1 /* 'M' */ +

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -268,7 +268,7 @@ CreateResourceGroup(CreateResourceGroupStmt *stmt)
 	heap_close(pg_resgroup_rel, NoLock);
 
 	/* Add this group into shared memory */
-	if (IsResGroupEnabled())
+	if (IsResGroupActivated())
 	{
 		Oid			*callbackArg;
 
@@ -396,7 +396,7 @@ DropResourceGroup(DropResourceGroupStmt *stmt)
 									NULL);
 	}
 
-	if (IsResGroupEnabled())
+	if (IsResGroupActivated())
 	{
 		ResGroupCheckForDrop(groupid, stmt->name);
 
@@ -644,7 +644,7 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 	/* Bump command counter to make this change visible in the callback function alterResGroupCommitCallback() */
 	CommandCounterIncrement();
 
-	if (IsResGroupEnabled())
+	if (IsResGroupActivated())
 	{
 		callbackCtx->caps = caps;
 		registerResourceGroupCallback(alterResGroupCommitCallback, (void *)callbackCtx);

--- a/src/backend/commands/user.c
+++ b/src/backend/commands/user.c
@@ -518,14 +518,14 @@ CreateRole(CreateRoleStmt *stmt)
 					 errmsg("only superuser can be assigned to admin resgroup")));
 
 		new_record[Anum_pg_authid_rolresgroup - 1] = ObjectIdGetDatum(rsgid);
-		if (!IsResGroupEnabled() && Gp_role == GP_ROLE_DISPATCH)
+		if (!IsResGroupActivated() && Gp_role == GP_ROLE_DISPATCH)
 			ereport(WARNING,
 					(errmsg("resource group is disabled"),
 					 errhint("To enable set resource_scheduler=on and gp_resource_manager=group")));
 	}
 	else if (issuper)
 	{
-		if (IsResGroupEnabled() && Gp_role == GP_ROLE_DISPATCH)
+		if (IsResGroupActivated() && Gp_role == GP_ROLE_DISPATCH)
 		{
 			ereport(NOTICE,
 					(errmsg("resource group required -- using admin resource group \"admin_group\"")));
@@ -535,7 +535,7 @@ CreateRole(CreateRoleStmt *stmt)
 	}
 	else
 	{
-		if (IsResGroupEnabled() && Gp_role == GP_ROLE_DISPATCH)
+		if (IsResGroupActivated() && Gp_role == GP_ROLE_DISPATCH)
 		{
 			ereport(NOTICE,
 					(errmsg("resource group required -- using default resource group \"default_group\"")));
@@ -1133,7 +1133,7 @@ AlterRole(AlterRoleStmt *stmt)
 			else
 				resgroup = pstrdup("default_group");
 
-			if (IsResGroupEnabled() && Gp_role == GP_ROLE_DISPATCH)
+			if (IsResGroupActivated() && Gp_role == GP_ROLE_DISPATCH)
 				ereport(NOTICE,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						 errmsg("resource group required -- "
@@ -1155,7 +1155,7 @@ AlterRole(AlterRoleStmt *stmt)
 			ObjectIdGetDatum(rsgid);
 		new_record_repl[Anum_pg_authid_rolresgroup - 1] = true;
 
-		if (!IsResGroupEnabled() && Gp_role == GP_ROLE_DISPATCH)
+		if (!IsResGroupActivated() && Gp_role == GP_ROLE_DISPATCH)
 		{
 			ereport(WARNING,
 					(errmsg("resource group is disabled"),

--- a/src/backend/storage/ipc/ipci.c
+++ b/src/backend/storage/ipc/ipci.c
@@ -325,9 +325,9 @@ CreateSharedMemoryAndSemaphores(bool makePrivate, int port)
 		Persistent_PostDTMRecv_ShmemInit();
 
 	/*
-	 * Set up resource schedular
+	 * Set up resource manager 
 	 */
-	InitResManager();
+	ResManagerShmemInit();
 
 	if (!IsUnderPostmaster)
 	{

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -5151,7 +5151,7 @@ PostgresMain(int argc, char *argv[],
 
 					elog((Debug_print_full_dtm ? LOG : DEBUG5), "MPP dispatched stmt from QD: %s.",query_string);
 
-					if (IsResGroupEnabled())
+					if (IsResGroupActivated() && resgroupInfoLen > 0)
 						SwitchResGroupOnSegment(resgroupInfoBuf, resgroupInfoLen);
 
 					if (suid > 0)

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -95,7 +95,6 @@
 #include "postmaster/backoff.h"
 #include <pthread.h>
 #include "utils/resource_manager.h"
-#include "utils/resgroup-ops.h"
 #include "pgstat.h"
 #include "executor/nodeFunctionscan.h"
 #include "cdb/cdbfilerep.h"
@@ -4656,17 +4655,9 @@ PostgresMain(int argc, char *argv[],
 	SetProcessingMode(NormalProcessing);
 
 	/*
-	 * Initialize resource scheduler hash structure.
+	 * Initialize resource manager.
 	 */
-	if (IsResQueueEnabled() && Gp_role == GP_ROLE_DISPATCH && !am_walsender)
-	{
-		InitResQueues();
-	}
-	else if (IsResGroupEnabled() && (Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_EXECUTE) && !am_walsender)
-	{
-		InitResGroups();
-		ResGroupOps_AdjustGUCs();
-	}
+	InitResManager();
 
 	/*
 	 * Now all GUC states are fully set up.  Report them to client if

--- a/src/backend/utils/resgroup/resgroup_helper.c
+++ b/src/backend/utils/resgroup/resgroup_helper.c
@@ -236,7 +236,7 @@ pg_resgroup_get_status(PG_FUNCTION_ARGS)
 
 		funcctx->tuple_desc = BlessTupleDesc(tupdesc);
 
-		if (IsResGroupEnabled())
+		if (IsResGroupActivated())
 		{
 			Relation	pg_resgroup_rel;
 			SysScanDesc	sscan;

--- a/src/backend/utils/resource_manager/memquota.c
+++ b/src/backend/utils/resource_manager/memquota.c
@@ -1044,7 +1044,7 @@ ResourceManagerGetQueryMemoryLimit(PlannedStmt* stmt)
 
 	if (IsResQueueEnabled())
 		return ResourceQueueGetQueryMemoryLimit(stmt, ActivePortal->queueId);
-	if (IsResGroupEnabled())
+	if (IsResGroupActivated())
 		return ResourceGroupGetQueryMemoryLimit();
 
 	return 0;

--- a/src/include/utils/resource_manager.h
+++ b/src/include/utils/resource_manager.h
@@ -32,6 +32,8 @@ extern ResourceManagerPolicy Gp_resource_manager_policy;
 extern bool IsResQueueEnabled(void);
 extern bool IsResGroupEnabled(void);
 
+extern bool IsResGroupActivated(void);
+
 extern void ResManagerShmemInit(void);
 extern void InitResManager(void);
 

--- a/src/include/utils/resource_manager.h
+++ b/src/include/utils/resource_manager.h
@@ -32,6 +32,7 @@ extern ResourceManagerPolicy Gp_resource_manager_policy;
 extern bool IsResQueueEnabled(void);
 extern bool IsResGroupEnabled(void);
 
+extern void ResManagerShmemInit(void);
 extern void InitResManager(void);
 
 #endif   /* RESOURCEMANAGER_H */

--- a/src/test/regress/regress.c
+++ b/src/test/regress/regress.c
@@ -2880,7 +2880,7 @@ resGroupPalloc(PG_FUNCTION_ARGS)
 	int count;
 	int i;
 
-	if (!IsResGroupEnabled())
+	if (!IsResGroupActivated())
 		PG_RETURN_INT32(0);
 
 	ResGroupGetMemInfo(&memLimit, &slotQuota, &sharedQuota);


### PR DESCRIPTION
The resource group is enabled but not initialized on auxiliary processes
and special backends like ftsprobe and filerep, previously we performed
resource group operations no matter resource group is initialized or not
which leads to some unexpected error.