### PR TITLE
Remove obsolete FIXME comments.

### DIFF
--- a/src/backend/commands/alter.c
+++ b/src/backend/commands/alter.c
@@ -183,7 +183,7 @@ ExecRenameStmt(RenameStmt *stmt)
 									DF_CANCEL_ON_ERROR|
 									DF_WITH_SNAPSHOT|
 									DF_NEED_TWO_PHASE,
-									NIL, /* FIXME */
+									NIL,
 									NULL);
 	}
 
@@ -249,7 +249,7 @@ ExecAlterObjectSchemaStmt(AlterObjectSchemaStmt *stmt)
 									DF_CANCEL_ON_ERROR|
 									DF_WITH_SNAPSHOT|
 									DF_NEED_TWO_PHASE,
-									NIL, /* FIXME */
+									NIL,
 									NULL);
 	}
 }

--- a/src/backend/commands/comment.c
+++ b/src/backend/commands/comment.c
@@ -201,7 +201,7 @@ CommentObject(CommentStmt *stmt)
 									DF_CANCEL_ON_ERROR|
 									DF_WITH_SNAPSHOT|
 									DF_NEED_TWO_PHASE,
-									NIL, /* FIXME */
+									NIL,
 									NULL);
 	}
 }

--- a/src/backend/commands/functioncmds.c
+++ b/src/backend/commands/functioncmds.c
@@ -1280,7 +1280,7 @@ RemoveFunction(RemoveFuncStmt *stmt)
 									DF_CANCEL_ON_ERROR|
 									DF_WITH_SNAPSHOT|
 									DF_NEED_TWO_PHASE,
-									NIL, /* FIXME */
+									NIL,
 									NULL);
 	}
 }
@@ -1717,7 +1717,7 @@ AlterFunction(AlterFunctionStmt *stmt)
 									DF_CANCEL_ON_ERROR|
 									DF_WITH_SNAPSHOT|
 									DF_NEED_TWO_PHASE,
-									NIL, /* FIXME */
+									NIL,
 									NULL);
 	}
 }
@@ -2106,7 +2106,7 @@ DropCast(DropCastStmt *stmt)
 									DF_CANCEL_ON_ERROR|
 									DF_WITH_SNAPSHOT|
 									DF_NEED_TWO_PHASE,
-									NIL, /* FIXME */
+									NIL,
 									NULL);
 	}
 }

--- a/src/backend/commands/lockcmds.c
+++ b/src/backend/commands/lockcmds.c
@@ -82,7 +82,7 @@ LockTableCommand(LockStmt *lockstmt)
 									DF_CANCEL_ON_ERROR|
 									DF_WITH_SNAPSHOT|
 									DF_NEED_TWO_PHASE,
-									NIL, /* FIXME */
+									NIL,
 									NULL);
 	}
 }

--- a/src/backend/commands/queue.c
+++ b/src/backend/commands/queue.c
@@ -1404,7 +1404,7 @@ AlterQueue(AlterQueueStmt *stmt)
 									DF_CANCEL_ON_ERROR|
 									DF_WITH_SNAPSHOT|
 									DF_NEED_TWO_PHASE,
-									NIL, /* FIXME */
+									NIL,
 									NULL);
 		MetaTrackUpdObject(ResQueueRelationId,
 						   queueid,
@@ -1544,7 +1544,7 @@ DropQueue(DropQueueStmt *stmt)
 									DF_CANCEL_ON_ERROR|
 									DF_WITH_SNAPSHOT|
 									DF_NEED_TWO_PHASE,
-									NIL, /* FIXME */
+									NIL,
 									NULL);
 	}
 	/* MPP-6929, MPP-7583: metadata tracking */

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -392,7 +392,7 @@ DropResourceGroup(DropResourceGroupStmt *stmt)
 									DF_CANCEL_ON_ERROR|
 									DF_WITH_SNAPSHOT|
 									DF_NEED_TWO_PHASE,
-									NIL, /* FIXME */
+									NIL,
 									NULL);
 	}
 
@@ -637,7 +637,7 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 									DF_CANCEL_ON_ERROR|
 									DF_WITH_SNAPSHOT|
 									DF_NEED_TWO_PHASE,
-									GetAssignedOidsForDispatch(), /* FIXME */
+									GetAssignedOidsForDispatch(),
 									NULL);
 	}
 

--- a/src/backend/commands/sequence.c
+++ b/src/backend/commands/sequence.c
@@ -766,7 +766,7 @@ AlterSequence(AlterSeqStmt *stmt)
 									DF_CANCEL_ON_ERROR|
 									DF_WITH_SNAPSHOT|
 									DF_NEED_TWO_PHASE,
-									NIL, /* FIXME */
+									NIL,
 									NULL);
 
 		if (!bSeqIsTemp)

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -3667,7 +3667,7 @@ AfterTriggerSetState(ConstraintsSetStmt *stmt)
 									DF_CANCEL_ON_ERROR|
 									DF_WITH_SNAPSHOT|
 									DF_NEED_TWO_PHASE,
-									NIL, /* FIXME */
+									NIL,
 									NULL);
 	}
 }

--- a/src/backend/commands/tsearchcmds.c
+++ b/src/backend/commands/tsearchcmds.c
@@ -845,7 +845,7 @@ AlterTSDictionary(AlterTSDictionaryStmt *stmt)
 									DF_CANCEL_ON_ERROR |
 									DF_NEED_TWO_PHASE |
 									DF_WITH_SNAPSHOT,
-									NIL, /* FIXME */
+									NIL,
 									NULL);
 }
 
@@ -1749,7 +1749,7 @@ AlterTSConfiguration(AlterTSConfigurationStmt *stmt)
 									DF_CANCEL_ON_ERROR |
 									DF_NEED_TWO_PHASE |
 									DF_WITH_SNAPSHOT,
-									NIL, /* FIXME */
+									NIL,
 									NULL);
 }
 

--- a/src/backend/commands/typecmds.c
+++ b/src/backend/commands/typecmds.c
@@ -543,7 +543,7 @@ DefineType(List *names, List *parameters)
 									DF_CANCEL_ON_ERROR|
 									DF_WITH_SNAPSHOT|
 									DF_NEED_TWO_PHASE,
-									GetAssignedOidsForDispatch(), /* FIXME */
+									GetAssignedOidsForDispatch(),
 									NULL);
 	}
 }
@@ -2950,7 +2950,7 @@ AlterType(AlterTypeStmt *stmt)
 									DF_CANCEL_ON_ERROR|
 									DF_WITH_SNAPSHOT|
 									DF_NEED_TWO_PHASE,
-									NIL, /* FIXME */
+									NIL,
 									NULL);
 }
 

--- a/src/backend/commands/user.c
+++ b/src/backend/commands/user.c
@@ -1263,7 +1263,7 @@ AlterRole(AlterRoleStmt *stmt)
 									DF_CANCEL_ON_ERROR|
 									DF_WITH_SNAPSHOT|
 									DF_NEED_TWO_PHASE,
-									NIL, /* FIXME */
+									NIL,
 									NULL);
 	}
 }
@@ -1398,7 +1398,7 @@ AlterRoleSet(AlterRoleSetStmt *stmt)
 									DF_CANCEL_ON_ERROR|
 									DF_WITH_SNAPSHOT|
 									DF_NEED_TWO_PHASE,
-									NIL, /* FIXME */
+									NIL,
 									NULL);
 }
 
@@ -1583,7 +1583,7 @@ DropRole(DropRoleStmt *stmt)
 									DF_CANCEL_ON_ERROR|
 									DF_WITH_SNAPSHOT|
 									DF_NEED_TWO_PHASE,
-									NIL, /* FIXME */
+									NIL,
 									NULL);
 
 	}
@@ -1791,7 +1791,7 @@ GrantRole(GrantRoleStmt *stmt)
 									DF_CANCEL_ON_ERROR|
 									DF_WITH_SNAPSHOT|
 									DF_NEED_TWO_PHASE,
-									NIL, /* FIXME */
+									NIL,
 									NULL);
 
 }
@@ -1824,7 +1824,7 @@ DropOwnedObjects(DropOwnedStmt *stmt)
 									DF_CANCEL_ON_ERROR|
 									DF_WITH_SNAPSHOT|
 									DF_NEED_TWO_PHASE,
-									NIL, /* FIXME */
+									NIL,
 									NULL);
     }
     
@@ -1869,7 +1869,7 @@ ReassignOwnedObjects(ReassignOwnedStmt *stmt)
 									DF_CANCEL_ON_ERROR|
 									DF_WITH_SNAPSHOT|
 									DF_NEED_TWO_PHASE,
-									NIL, /* FIXME */
+									NIL,
 									NULL);
     }
 

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -1109,7 +1109,7 @@ ProcessUtility(Node *parsetree,
 														DF_CANCEL_ON_ERROR|
 														DF_WITH_SNAPSHOT|
 														DF_NEED_TWO_PHASE,
-														NIL, /* FIXME */
+														NIL,
 														NULL);
 						}
 					}
@@ -1624,7 +1624,7 @@ ProcessUtility(Node *parsetree,
 												DF_CANCEL_ON_ERROR|
 												DF_WITH_SNAPSHOT|
 												DF_NEED_TWO_PHASE,
-												NIL, /* FIXME */
+												NIL,
 												NULL);
 				}
 			}


### PR DESCRIPTION
When the new OID-dispatching mechanism was introduced (commit f9016da2a6),
a lot of FIXME comments were left in calls to CdbDispatchUtilityStatement.
These were places where I wasn't sure if the command that was executed
might create new objects, with new OIDs assigned to them, that would need
to be dispatched to the QE. I've now skimmed through the call sites, and
checked that they are all for ALTER or DROP commands that should not create
new OIDs, so remove the FIXME comments.