### PR TITLE
Use ereport, rather than elog, for performance.

### DIFF
--- a/src/backend/access/transam/test/Makefile
+++ b/src/backend/access/transam/test/Makefile
@@ -13,8 +13,7 @@ distributedlog.t: \
 xact.t: \
 	$(MOCK_DIR)/backend/access/transam/slru_mock.o \
 	$(MOCK_DIR)/backend/storage/lmgr/lwlock_mock.o \
-	$(MOCK_DIR)/backend/access/transam/subtrans_mock.o \
-	$(MOCK_DIR)/backend/utils/error/elog_mock.o
+	$(MOCK_DIR)/backend/access/transam/subtrans_mock.o
 
 xlog.t: \
     $(MOCK_DIR)/backend/replication/walsender_mock.o

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -674,9 +674,9 @@ HasDropTransaction(bool allDbs)
 		{
 			if (proc->inDropTransaction && proc != MyProc)
 			{
-				elog((Debug_print_snapshot_dtm ? LOG : DEBUG3), "Found drop transaction: "
-					"database %d, pid %d, xid %d, xmin %d",
-					proc->databaseId, proc->pid, proc->xid, proc->xmin);
+				ereport((Debug_print_snapshot_dtm ? LOG : DEBUG3),
+						(errmsg("Found drop transaction: database %d, pid %d, xid %d, xmin %d",
+								proc->databaseId, proc->pid, proc->xid, proc->xmin)));
 				result = true;
 			}
 		}
@@ -713,9 +713,9 @@ HasSerializableBackends(bool allDbs)
 		{
 			if (proc->serializableIsoLevel && proc != MyProc)
 			{
-				elog((Debug_print_snapshot_dtm ? LOG : DEBUG3), "Found serializable transaction: "
-					"database %d, pid %d, xid %d, xmin %d",
-					proc->databaseId, proc->pid, proc->xid, proc->xmin);
+				ereport((Debug_print_snapshot_dtm ? LOG : DEBUG3),
+						(errmsg("Found serializable transaction: database %d, pid %d, xid %d, xmin %d",
+								proc->databaseId, proc->pid, proc->xid, proc->xmin)));
 				result = true;
 			}
 		}
@@ -811,13 +811,13 @@ updateSharedLocalSnapshot(DtxContextInfo *dtxContextInfo, Snapshot snapshot, cha
 
 	Assert(snapshot != NULL);
 
-	elog((Debug_print_full_dtm ? LOG : DEBUG5),
-		 "updateSharedLocalSnapshot for DistributedTransactionContext = '%s' passed local snapshot (xmin: %u xmax: %u xcnt: %u) curcid: %d", 
-		 DtxContextToString(DistributedTransactionContext),
-		 snapshot->xmin,
-		 snapshot->xmax,
-		 snapshot->xcnt,
-		 snapshot->curcid);
+	ereport((Debug_print_full_dtm ? LOG : DEBUG5),
+			(errmsg("updateSharedLocalSnapshot for DistributedTransactionContext = '%s' passed local snapshot (xmin: %u xmax: %u xcnt: %u) curcid: %d",
+					DtxContextToString(DistributedTransactionContext),
+					snapshot->xmin,
+					snapshot->xmax,
+					snapshot->xcnt,
+					snapshot->curcid)));
 
 	LWLockAcquire(SharedLocalSnapshotSlot->slotLock, LW_EXCLUSIVE);
 
@@ -829,7 +829,9 @@ updateSharedLocalSnapshot(DtxContextInfo *dtxContextInfo, Snapshot snapshot, cha
 	{
 		Assert(snapshot->xip != NULL);
 
-		elog((Debug_print_full_dtm ? LOG : DEBUG5),"updateSharedLocalSnapshot count of in-doubt ids %u", SharedLocalSnapshotSlot->snapshot.xcnt);
+		ereport((Debug_print_full_dtm ? LOG : DEBUG5),
+				(errmsg("updateSharedLocalSnapshot count of in-doubt ids %u",
+						SharedLocalSnapshotSlot->snapshot.xcnt)));
 
 		memcpy(SharedLocalSnapshotSlot->snapshot.xip, snapshot->xip, snapshot->xcnt * sizeof(TransactionId));
 	}
@@ -843,9 +845,9 @@ updateSharedLocalSnapshot(DtxContextInfo *dtxContextInfo, Snapshot snapshot, cha
 
 	SharedLocalSnapshotSlot->snapshot.curcid = snapshot->curcid;
 
-	elog((Debug_print_full_dtm ? LOG : DEBUG5),
-		 "updateSharedLocalSnapshot: combocidsize is now %d max %d segmateSync %d->%d",
-		 combocidSize, MaxComboCids, SharedLocalSnapshotSlot->segmateSync, dtxContextInfo->segmateSync);
+	ereport((Debug_print_full_dtm ? LOG : DEBUG5),
+			(errmsg("updateSharedLocalSnapshot: combocidsize is now %d max %d segmateSync %d->%d",
+					combocidSize, MaxComboCids, SharedLocalSnapshotSlot->segmateSync, dtxContextInfo->segmateSync)));
 
 	SetSharedTransactionId_writer();
 	
@@ -856,25 +858,26 @@ updateSharedLocalSnapshot(DtxContextInfo *dtxContextInfo, Snapshot snapshot, cha
 
 	SharedLocalSnapshotSlot->segmateSync = dtxContextInfo->segmateSync;
 
-	elog((Debug_print_full_dtm ? LOG : DEBUG5),
-		 "updateSharedLocalSnapshot for DistributedTransactionContext = '%s' setting shared local snapshot xid = %u (xmin: %u xmax: %u xcnt: %u) curcid: %d, QDxid = %u, QDcid = %u", 
-		 DtxContextToString(DistributedTransactionContext),
-		 SharedLocalSnapshotSlot->xid,
-		 SharedLocalSnapshotSlot->snapshot.xmin,
-		 SharedLocalSnapshotSlot->snapshot.xmax,
-		 SharedLocalSnapshotSlot->snapshot.xcnt,
-		 SharedLocalSnapshotSlot->snapshot.curcid,
-		 SharedLocalSnapshotSlot->QDxid,
-		 SharedLocalSnapshotSlot->QDcid);
+	ereport((Debug_print_full_dtm ? LOG : DEBUG5),
+			(errmsg("updateSharedLocalSnapshot for DistributedTransactionContext = '%s' setting shared local snapshot xid = %u (xmin: %u xmax: %u xcnt: %u) curcid: %d, QDxid = %u, QDcid = %u",
+					DtxContextToString(DistributedTransactionContext),
+					SharedLocalSnapshotSlot->xid,
+					SharedLocalSnapshotSlot->snapshot.xmin,
+					SharedLocalSnapshotSlot->snapshot.xmax,
+					SharedLocalSnapshotSlot->snapshot.xcnt,
+					SharedLocalSnapshotSlot->snapshot.curcid,
+					SharedLocalSnapshotSlot->QDxid,
+					SharedLocalSnapshotSlot->QDcid)));
 
-	elog((Debug_print_snapshot_dtm ? LOG : DEBUG5), "[Distributed Snapshot #%u] *Writer Set Shared* gxid %u, currcid %d (gxid = %u, slot #%d, '%s', '%s')", 
-		QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
-		SharedLocalSnapshotSlot->QDxid,
-		SharedLocalSnapshotSlot->QDcid,
-		getDistributedTransactionId(),
-		SharedLocalSnapshotSlot->slotid,
-		debugCaller,
-		DtxContextToString(DistributedTransactionContext));
+	ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
+			(errmsg("[Distributed Snapshot #%u] *Writer Set Shared* gxid %u, currcid %d (gxid = %u, slot #%d, '%s', '%s')",
+					QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
+					SharedLocalSnapshotSlot->QDxid,
+					SharedLocalSnapshotSlot->QDcid,
+					getDistributedTransactionId(),
+					SharedLocalSnapshotSlot->slotid,
+					debugCaller,
+					DtxContextToString(DistributedTransactionContext))));
 	LWLockRelease(SharedLocalSnapshotSlot->slotLock);
 }
 
@@ -918,10 +921,10 @@ GetDistributedSnapshotMaxCount(void)
 static void
 FillInDistributedSnapshot(Snapshot snapshot)
 {
-	elog((Debug_print_full_dtm ? LOG : DEBUG5),
-	     "FillInDistributedSnapshot DTX Context = '%s'", 
-	     DtxContextToString(DistributedTransactionContext));
-	
+	ereport((Debug_print_full_dtm ? LOG : DEBUG5),
+			(errmsg("FillInDistributedSnapshot DTX Context = '%s'",
+					DtxContextToString(DistributedTransactionContext))));
+
 	switch (DistributedTransactionContext)
 	{
 	case DTX_CONTEXT_LOCAL_ONLY:
@@ -941,9 +944,9 @@ FillInDistributedSnapshot(Snapshot snapshot)
 		Assert(snapshot->distribSnapshotWithLocalMapping.ds.inProgressXidArray != NULL);
 		snapshot->haveDistribSnapshot = createDtxSnapshot(&snapshot->distribSnapshotWithLocalMapping);
 		
-		elog((Debug_print_full_dtm ? LOG : DEBUG5),
-			 "Got distributed snapshot from DistributedSnapshotWithLocalXids_Create = %s",
-			 (snapshot->haveDistribSnapshot ? "true" : "false"));
+		ereport((Debug_print_full_dtm ? LOG : DEBUG5),
+				(errmsg("Got distributed snapshot from DistributedSnapshotWithLocalXids_Create = %s",
+						(snapshot->haveDistribSnapshot ? "true" : "false"))));
 		break;
 
 	case DTX_CONTEXT_QE_TWO_PHASE_EXPLICIT_WRITER:
@@ -1099,10 +1102,10 @@ GetSnapshotData(Snapshot snapshot, bool serializable)
 	/*
 	 * GP: Distributed snapshot.
 	 */
-	elog((Debug_print_full_dtm ? LOG : DEBUG5),
-		 "GetSnapshotData maxCount %d, inProgressEntryArray %p", 
-		 snapshot->distribSnapshotWithLocalMapping.ds.maxCount,
-		 snapshot->distribSnapshotWithLocalMapping.ds.inProgressXidArray);
+	ereport((Debug_print_full_dtm ? LOG : DEBUG5),
+			(errmsg("GetSnapshotData maxCount %d, inProgressEntryArray %p",
+					snapshot->distribSnapshotWithLocalMapping.ds.maxCount,
+					snapshot->distribSnapshotWithLocalMapping.ds.inProgressXidArray)));
 
 	if (snapshot->distribSnapshotWithLocalMapping.ds.inProgressXidArray == NULL)
 	{
@@ -1174,11 +1177,12 @@ GetSnapshotData(Snapshot snapshot, bool serializable)
 			return snapshot;
 		}
 
-		elog((Debug_print_snapshot_dtm ? LOG : DEBUG5),"[Distributed Snapshot #%u] *Start Reader Match* gxid = %u and currcid %d (%s)", 
-			 QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
-			 QEDtxContextInfo.distributedXid,
-			 QEDtxContextInfo.curcid,
-			 DtxContextToString(DistributedTransactionContext));
+		ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
+				(errmsg("[Distributed Snapshot #%u] *Start Reader Match* gxid = %u and currcid %d (%s)",
+						QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
+						QEDtxContextInfo.distributedXid,
+						QEDtxContextInfo.curcid,
+						DtxContextToString(DistributedTransactionContext))));
 
 		/*
 		 * This is the second phase of the handshake we started in
@@ -1238,19 +1242,20 @@ GetSnapshotData(Snapshot snapshot, bool serializable)
 
 				LWLockRelease(SharedLocalSnapshotSlot->slotLock);
 
-				elog((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-					 "Reader qExec usedComboCids: %d shared %d segmateSync %d",
-					 usedComboCids, comboCidCnt, segmateSync);
-				
+				ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
+						(errmsg("Reader qExec usedComboCids: %d shared %d segmateSync %d",
+								usedComboCids, comboCidCnt, segmateSync)));
+
 				SetSharedTransactionId_reader(SharedLocalSnapshotSlot->xid,
 											  SharedLocalSnapshotSlot->snapshot.curcid);
 
-				elog((Debug_print_snapshot_dtm ? LOG : DEBUG5), "Reader qExec setting shared local snapshot to: xmin: %d xmax: %d curcid: %d",
-					 snapshot->xmin, snapshot->xmax, snapshot->curcid);
+				ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
+						(errmsg("Reader qExec setting shared local snapshot to: xmin: %d xmax: %d curcid: %d",
+								snapshot->xmin, snapshot->xmax, snapshot->curcid)));
 
-				elog((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-					 "GetSnapshotData(): READER currentcommandid %d curcid %d segmatesync %d",
-					 GetCurrentCommandId(false), snapshot->curcid, segmateSync);
+				ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
+						(errmsg("GetSnapshotData(): READER currentcommandid %d curcid %d segmatesync %d",
+								GetCurrentCommandId(false), snapshot->curcid, segmateSync)));
 
 				return snapshot;
 			}
@@ -1277,13 +1282,13 @@ GetSnapshotData(Snapshot snapshot, bool serializable)
 							(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
 							 errmsg("GetSnapshotData timed out waiting for Writer to set the shared snapshot."),
 							 errdetail("We are waiting for the shared snapshot to have XID: %d but the value "
-									   "is currently: %d." 
+									   "is currently: %d."
 									   " waiting for cid to be %d but is currently %d.  ready=%d."
 									   "DistributedTransactionContext = %s. "
 									   " Our slotindex is: %d \n"
 									   "Dump of all sharedsnapshots in shmem: %s",
 									   QEDtxContextInfo.distributedXid, SharedLocalSnapshotSlot->QDxid,
-									   QEDtxContextInfo.curcid, 
+									   QEDtxContextInfo.curcid,
 									   SharedLocalSnapshotSlot->QDcid, SharedLocalSnapshotSlot->ready,
 									   DtxContextToString(DistributedTransactionContext),
 									   SharedLocalSnapshotSlot->slotindex, SharedSnapshotDump())));
@@ -1293,28 +1298,30 @@ GetSnapshotData(Snapshot snapshot, bool serializable)
 					/*
 					 * Every second issue warning.
 					 */
-					elog((Debug_print_snapshot_dtm ? LOG : DEBUG5),"[Distributed Snapshot #%u] *No Match* gxid %u = %u and currcid %d = %d (%s)", 
-						 QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
-						 QEDtxContextInfo.distributedXid,
-						 SharedLocalSnapshotSlot->QDxid,
-						 QEDtxContextInfo.curcid,
-						 SharedLocalSnapshotSlot->QDcid,
-						 DtxContextToString(DistributedTransactionContext));
+					ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
+							(errmsg("[Distributed Snapshot #%u] *No Match* gxid %u = %u and currcid %d = %d (%s)",
+									QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
+									QEDtxContextInfo.distributedXid,
+									SharedLocalSnapshotSlot->QDxid,
+									QEDtxContextInfo.curcid,
+									SharedLocalSnapshotSlot->QDcid,
+									DtxContextToString(DistributedTransactionContext))));
 
 
-					elog(LOG,"GetSnapshotData did not find shared local snapshot information. "
-						 "We are waiting for the shared snapshot to have XID: %d/%u but the value "
-						 "is currently: %d/%u." 
-						 " waiting for cid to be %d but is currently %d.  ready=%d."
-						 " Our slotindex is: %d \n"
-						 "DistributedTransactionContext = %s.",
-						 QEDtxContextInfo.distributedXid, QEDtxContextInfo.segmateSync,
-						 SharedLocalSnapshotSlot->QDxid, SharedLocalSnapshotSlot->segmateSync,
-						 QEDtxContextInfo.curcid,
-						 SharedLocalSnapshotSlot->QDcid,
-						 SharedLocalSnapshotSlot->ready,
-						 SharedLocalSnapshotSlot->slotindex,
-						 DtxContextToString(DistributedTransactionContext));
+					ereport(LOG,
+							(errmsg("GetSnapshotData did not find shared local snapshot information. "
+									"We are waiting for the shared snapshot to have XID: %d/%u but the value "
+									"is currently: %d/%u."
+									" waiting for cid to be %d but is currently %d.  ready=%d."
+									" Our slotindex is: %d \n"
+									"DistributedTransactionContext = %s.",
+									QEDtxContextInfo.distributedXid, QEDtxContextInfo.segmateSync,
+									SharedLocalSnapshotSlot->QDxid, SharedLocalSnapshotSlot->segmateSync,
+									QEDtxContextInfo.curcid,
+									SharedLocalSnapshotSlot->QDcid,
+									SharedLocalSnapshotSlot->ready,
+									SharedLocalSnapshotSlot->slotindex,
+									DtxContextToString(DistributedTransactionContext))));
 					warning_sleep_time_us = 0;
 				}
 
@@ -1329,10 +1336,10 @@ GetSnapshotData(Snapshot snapshot, bool serializable)
 	Assert(DistributedTransactionContext != DTX_CONTEXT_QE_ENTRY_DB_SINGLETON);
 
 	/* Serializable snapshot must be computed before any other... */
-	elog((Debug_print_full_dtm ? LOG : DEBUG5),
-		 "GetSnapshotData serializable %s, xmin %u", 
-	 	 (serializable ? "true" : "false"),
-	 	 MyProc->xmin);
+	ereport((Debug_print_full_dtm ? LOG : DEBUG5),
+			(errmsg("GetSnapshotData serializable %s, xmin %u",
+					(serializable ? "true" : "false"),
+					MyProc->xmin)));
 	Assert(serializable ?
 		   !TransactionIdIsValid(MyProc->xmin) :
 		   TransactionIdIsValid(MyProc->xmin));
@@ -1351,9 +1358,9 @@ GetSnapshotData(Snapshot snapshot, bool serializable)
 	/* initialize xmin calculation with xmax */
 	globalxmin = xmin = xmax;
 
-	elog((Debug_print_full_dtm ? LOG : DEBUG5),
-		 "GetSnapshotData setting globalxmin and xmin to %u", 
-	 	 xmin);
+	ereport((Debug_print_full_dtm ? LOG : DEBUG5),
+			(errmsg("GetSnapshotData setting globalxmin and xmin to %u",
+					xmin)));
 
 	/*
 	 * Get the distributed snapshot if needed and copy it into the field 
@@ -1480,9 +1487,9 @@ GetSnapshotData(Snapshot snapshot, bool serializable)
 	{
 		MyProc->serializableIsoLevel = true;
 
-		elog((Debug_print_snapshot_dtm ? LOG : DEBUG3), "Got serializable snapshot: "
-			"database %d, pid %d, xid %d, xmin %d",
-			MyProc->databaseId, MyProc->pid, MyProc->xid, MyProc->xmin);
+		ereport((Debug_print_snapshot_dtm ? LOG : DEBUG3),
+				(errmsg("Got serializable snapshot: database %d, pid %d, xid %d, xmin %d",
+						MyProc->databaseId, MyProc->pid, MyProc->xid, MyProc->xmin)));
 	}
 
 	LWLockRelease(ProcArrayLock);
@@ -1520,9 +1527,9 @@ GetSnapshotData(Snapshot snapshot, bool serializable)
 		updateSharedLocalSnapshot(&QEDtxContextInfo, snapshot, "GetSnapshotData");
 	}
 
-	elog((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-		 "GetSnapshotData(): WRITER currentcommandid %d curcid %d segmatesync %d",
-		 GetCurrentCommandId(false), snapshot->curcid, QEDtxContextInfo.segmateSync);
+	ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
+			(errmsg("GetSnapshotData(): WRITER currentcommandid %d curcid %d segmatesync %d",
+					GetCurrentCommandId(false), snapshot->curcid, QEDtxContextInfo.segmateSync)));
 
 	return snapshot;
 }
@@ -1643,28 +1650,29 @@ void UpdateSerializableCommandId(void)
 
 		if (SharedLocalSnapshotSlot->QDxid != QEDtxContextInfo.distributedXid)
 		{
-			elog((Debug_print_snapshot_dtm ? LOG : DEBUG5),"[Distributed Snapshot #%u] *Can't Update Serializable Command Id* QDxid = %u (gxid = %u, '%s')", 
-			 	  QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
-			 	  SharedLocalSnapshotSlot->QDxid,
-			 	  getDistributedTransactionId(),
-			 	  DtxContextToString(DistributedTransactionContext));
+			ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
+					(errmsg("[Distributed Snapshot #%u] *Can't Update Serializable Command Id* QDxid = %u (gxid = %u, '%s')",
+							QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
+							SharedLocalSnapshotSlot->QDxid,
+							getDistributedTransactionId(),
+							DtxContextToString(DistributedTransactionContext))));
 			LWLockRelease(SharedLocalSnapshotSlot->slotLock);
 			return;
 		}
 
-		elog((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-			 "[Distributed Snapshot #%u] *Update Serializable Command Id* segment currcid = %d, QDcid = %d, SerializableSnapshot currcid = %d, Shared currcid = %d (gxid = %u, '%s')", 
-			 QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
-		 	  QEDtxContextInfo.curcid,
-		 	  SharedLocalSnapshotSlot->QDcid,
-		 	  SerializableSnapshot->curcid,
-		 	  SharedLocalSnapshotSlot->snapshot.curcid,
-		 	  getDistributedTransactionId(),
-		 	  DtxContextToString(DistributedTransactionContext));
+		ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
+				(errmsg("[Distributed Snapshot #%u] *Update Serializable Command Id* segment currcid = %d, QDcid = %d, SerializableSnapshot currcid = %d, Shared currcid = %d (gxid = %u, '%s')",
+						QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
+						QEDtxContextInfo.curcid,
+						SharedLocalSnapshotSlot->QDcid,
+						SerializableSnapshot->curcid,
+						SharedLocalSnapshotSlot->snapshot.curcid,
+						getDistributedTransactionId(),
+						DtxContextToString(DistributedTransactionContext))));
 
-		elog((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-			 "serializable writer updating combocid: used combocids %d shared %d",
-			 usedComboCids, SharedLocalSnapshotSlot->combocidcnt);
+		ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
+				(errmsg("serializable writer updating combocid: used combocids %d shared %d",
+						usedComboCids, SharedLocalSnapshotSlot->combocidcnt)));
 
 		combocidSize = ((usedComboCids < MaxComboCids) ? usedComboCids : MaxComboCids );
 

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -4999,7 +4999,8 @@ PostgresMain(int argc, char *argv[],
 		if (ignore_till_sync && firstchar != EOF)
 			continue;
 
-		elog((Debug_print_full_dtm ? LOG : DEBUG5), "First char: '%c'; gp_role = '%s'.",firstchar,role_to_string(Gp_role));
+		ereport((Debug_print_full_dtm ? LOG : DEBUG5),
+				(errmsg_internal("First char: '%c'; gp_role = '%s'.", firstchar, role_to_string(Gp_role))));
 
 		switch (firstchar)
 		{


### PR DESCRIPTION
ereport() has one subtle but important difference to elog: it doesn't
evaluate its arguments, if the log level says that the message doesn't
need to be printed. This makes a small but measurable difference in
performance, if the arguments contain more complicated expressions, like
function calls.

While performance testing a workload with very short queries, I saw some
CPU time being used in DtxContextToString. Those calls were coming from the
arguments to elog() statements, and the result was always thrown away,
because the log level was not high enough to actually log anything. Turn
those elog()s into ereport()s, for speed.

The problematic case here was a few elogs containing DtxContextToString
calls, in hot codepaths, but I changed a few surrounding ones too, for
consistency.