### PR TITLE
gpinitsystem: instantiate standby after master

### DIFF
--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -58,6 +58,7 @@ GP_FAILOVER_CONFIG_TBL=gp_fault_strategy
 unset PG_CONF_ADD_FILE
 #unset QD_PRIMARY_ARRAY QE_PRIMARY_ARRAY QE_MIRROR_ARRAY
 EXIT_STATUS=0
+STANDBY_FATAL_RET_CODE=2 # copied from gpinitstandby
 # SED_PG_CONF search text values
 PORT_TXT="#port"
 LOG_STATEMENT_TXT="#log_statement ="
@@ -78,6 +79,7 @@ SINGLE_HOST_BATCH_LIMIT=4
 INPUT_CONFIG=""
 OUTPUT_CONFIG=""
 GPHOSTCACHELOOKUP=$WORKDIR/lib/gphostcachelookup.py
+STANDBY_RET_CODE=0
 
 #******************************************************************************
 # DCA Specific Variables
@@ -233,7 +235,7 @@ CHK_PARAMS () {
 		    unset PORT_BASE SEG_PREFIX DATA_DIRECTORY REPLICATION_PORT_BASE HEAP_CHECKSUM
 
 		    # Make sure it is not a dos file with CTRL M at end of each line
-		    $CAT $CLUSTER_CONFIG|$SED -e 's/$//g' > $TMP_FILE
+		    $TR -d '\r' < $CLUSTER_CONFIG > $TMP_FILE
 		    $MV $TMP_FILE $CLUSTER_CONFIG
 		    LOG_MSG "[INFO]:-Dumping $CLUSTER_CONFIG to logfile for reference"
 		    $CAT $CLUSTER_CONFIG|$GREP -v "^#" >> $LOG_FILE
@@ -310,7 +312,7 @@ CHK_PARAMS () {
 		    do
 			CHK_FILE $FILE
 			if [ $EXISTS -ne 0 ]; then
-			    ERROR_EXIT "[FATAL]:-Problem with $FILE file" 2
+			    ERROR_EXIT "[FATAL]:-Expected file \"$FILE\" not found" 2
 			else
 			    LOG_MSG "[INFO]:-Completed check of file $FILE"
 			fi
@@ -1541,6 +1543,7 @@ CREATE_STANDBY_QD () {
 	LOG_MSG "[INFO]:-Start Function $FUNCNAME"
 	if [ ! -f $INIT_STANDBY_PROG ]; then
 		LOG_MSG "[WARN]:-Unable to locate $INIT_STANDBY_PROG, hence unable to initialize standby master $STANDBY_HOSTNAME"
+		STANDBY_RET_CODE=${STANDBY_FATAL_RET_CODE}
 		EXIT_STATUS=1
 	else
 		LOG_MSG "[INFO]:-Starting initialization of standby master $STANDBY_HOSTNAME" 1
@@ -1552,11 +1555,11 @@ CREATE_STANDBY_QD () {
 			INIT_STANDBY_ARGS+=" -F $STANDBY_FILESPACES"
 		fi
 		export MASTER_DATA_DIRECTORY=${MASTER_DIRECTORY}/${SEG_PREFIX}-1;$INIT_STANDBY_PROG -s $STANDBY_HOSTNAME $INIT_STANDBY_ARGS -a
-		RETCODE=$?
-		case $RETCODE in
+		STANDBY_RET_CODE=$?
+		case ${STANDBY_RET_CODE} in
 			0) LOG_MSG "[INFO]:-Successfully completed standby master initialization" 1 ;;
 			1) LOG_MSG "[WARN]:-Non-fatal issue with standby master initialization, check gpstate -f output" 1 ;;
-			*) ERROR_EXIT "[FATAL]:-Initialization of standby master failed"
+			*) LOG_MSG "[WARN]:-Failed to complete standby master initialization" 1
 		esac
 		BACKOUT_COMMAND "$TRUSTED_SHELL ${STANDBY_HOSTNAME} \"$RM -Rf ${QD_DIR}\""
 		BACKOUT_COMMAND "$ECHO \"Removing standby directory ${QD_DIR} on $STANDBY_HOSTNAME\""
@@ -1636,7 +1639,7 @@ SCAN_LOG () {
 	LOG_MSG "[INFO]:-Start Function $FUNCNAME"
 	LOG_MSG "[INFO]:-Scanning utility log file for any warning messages" 1
 	SCAN_STRING="\[WARN\]|invalid|warning:|fatal|error"
-	if [ `$EGREP -i "$SCAN_STRING" $LOG_FILE|$GREP -v "\[INFO\]"|$GREP -v "[Start|End] Function ERROR_CHK"|$GREP -v "WARNING: enabling \"trust\" authentication for local connections"|$WC -l` -ne 0 ];then
+	if [ `$EGREP -i "$SCAN_STRING" $LOG_FILE|$GREP -v "\[INFO\]"|$GREP -v "[Start|End] Function ERROR_CHK"|$GREP -v "WARNING: enabling \"trust\" authentication for local connections"|$GREP -v "to the list of known hosts"|$WC -w` -ne 0 ];then
 		LOG_MSG "[WARN]:-*******************************************************" 1
 		LOG_MSG "[WARN]:-Scan of log file indicates that some warnings or errors" 1
 		LOG_MSG "[WARN]:-were generated during the array creation" 1
@@ -1719,7 +1722,7 @@ READ_INPUT_CONFIG () {
     fi
 
     # Make sure it is not a dos file with CTRL M at end of each line
-    $CAT $INPUT_CONFIG|$SED -e 's/$//g' > $TMP_FILE
+    $TR -d '\r' < $INPUT_CONFIG > $TMP_FILE
     $MV $TMP_FILE $INPUT_CONFIG
     LOG_MSG "[INFO]:-Dumping $INPUT_CONFIG to logfile for reference"
     $CAT $INPUT_CONFIG|$GREP -v "^#" >> $LOG_FILE
@@ -2069,10 +2072,6 @@ else
 	LOG_MSG "[INFO]:-No errors generated from parallel processes" 1
 fi
 
-if [ x"" != x"$STANDBY_HOSTNAME" ];then
-	CREATE_STANDBY_QD
-fi
-
 if [ -f $DCA_VERSION_FILE ]; then
 	SET_DCA_CONFIG_SETTINGS	
 fi
@@ -2087,6 +2086,10 @@ fi
 
 SET_GP_USER_PW
 
+if [ x"" != x"$STANDBY_HOSTNAME" ];then
+	CREATE_STANDBY_QD
+fi
+
 SCAN_LOG
 LOG_MSG "[INFO]:-Greenplum Database instance successfully created" 1
 LOG_MSG "[INFO]:-------------------------------------------------------" 1
@@ -2099,14 +2102,20 @@ LOG_MSG "[INFO]:-   or, use -d ${MASTER_DIRECTORY}/${SEG_PREFIX}-1 option for th
 LOG_MSG "[INFO]:-   Example gpstate -d ${MASTER_DIRECTORY}/${SEG_PREFIX}-1" 1
 LOG_MSG "[INFO]:-Script log file = $LOG_FILE" 1
 LOG_MSG "[INFO]:-To remove instance, run gpdeletesystem utility" 1
+
 if [ x"" != x"$STANDBY_HOSTNAME" ];then
-LOG_MSG "[INFO]:-Standby Master $STANDBY_HOSTNAME has been configured" 1
-LOG_MSG "[INFO]:-To activate the Standby Master Segment in the event of Master" 1
-LOG_MSG "[INFO]:-failure review options for gpactivatestandby" 1
+	case $STANDBY_RET_CODE in
+		0|1)
+			LOG_MSG "[INFO]:-Standby Master $STANDBY_HOSTNAME has been configured" 1
+			LOG_MSG "[INFO]:-To activate the Standby Master Segment in the event of Master" 1
+			LOG_MSG "[INFO]:-failure review options for gpactivatestandby" 1 ;;
+		*) LOG_MSG "[WARN]:-Standby Master failed to initialize" 1
+	esac
 else
-LOG_MSG "[INFO]:-To initialize a Standby Master Segment for this Greenplum instance" 1
-LOG_MSG "[INFO]:-Review options for gpinitstandby" 1
+    LOG_MSG "[INFO]:-To initialize a Standby Master Segment for this Greenplum instance" 1
+    LOG_MSG "[INFO]:-Review options for gpinitstandby" 1
 fi
+
 LOG_MSG "[INFO]:-------------------------------------------------------" 1
 LOG_MSG "[INFO]:-The Master ${MASTER_DATA_DIRECTORY}/$PG_HBA post gpinitsystem" 1
 LOG_MSG "[INFO]:-has been configured to allow all hosts within this new" 1
@@ -2115,5 +2124,14 @@ LOG_MSG "[INFO]:-new array must be explicitly added to this file" 1
 LOG_MSG "[INFO]:-Refer to the Greenplum Admin support guide which is" 1
 LOG_MSG "[INFO]:-located in the $GPHOME/docs directory" 1
 LOG_MSG "[INFO]:-------------------------------------------------------" 1
+
+# Make sure that the user sees that there's an error with the standby
+if [ $STANDBY_RET_CODE -ne 0 ] && [ $STANDBY_RET_CODE -ne 1 ]; then
+	LOG_MSG "[WARN]:-*******************************************************" 1
+	LOG_MSG "[WARN]:-Cluster setup finished, but Standby Master failed to initialize. Review contents of log files for errors." 1
+	LOG_MSG "[INFO]:-Use gpinitstandby to create a Standby Master" 1
+	LOG_MSG "[WARN]:-*******************************************************" 1
+fi
+
 LOG_MSG "[INFO]:-End Main"
 exit $EXIT_STATUS

--- a/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
@@ -48,3 +48,33 @@ Feature: gpinitsystem tests
         And gpconfig should print "Values on all segments are consistent" to stdout
         And gpconfig should print "Master  value: off" to stdout
         And gpconfig should print "Segment value: off" to stdout
+
+    @gpinitsystem_standby_failure_is_only_warning
+    Scenario: gpinitsystem should warn but not fail when standby cannot be instantiated
+        Given the database is running
+        And all the segments are running
+        And the segments are synchronized
+        And the standby is not initialized
+        And the user runs command "rm -rf /tmp/gpinitsystemtest && mkdir /tmp/gpinitsystemtest"
+        # stop db and make sure cluster config exists so that we can manually initialize standby
+        And the cluster config is generated with data_checksums "1"
+        When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -l /tmp/gpinitsystemtest -s localhost -P 21100 -F intentional_nonexistent_filespace:/wrong/path -h ../gpAux/gpdemo/hostfile"
+        Then gpinitsystem should return a return code of 1
+        And gpinitsystem should not print "To activate the Standby Master Segment in the event of Master" to stdout
+        And gpinitsystem should print "Cluster setup finished, but Standby Master failed to initialize. Review contents of log files for errors." to stdout
+        And sql "select * from gp_toolkit.__gp_user_namespaces" is executed in "postgres" db
+
+    @gpinitsystem_standby_added
+    Scenario: gpinitsystem should warn but not fail when standby cannot be instantiated
+        Given the database is running
+        And all the segments are running
+        And the segments are synchronized
+        And the standby is not initialized
+        And the user runs command "rm -rf $MASTER_DATA_DIRECTORY/newstandby"
+        And the user runs command "rm -rf /tmp/gpinitsystemtest && mkdir /tmp/gpinitsystemtest"
+        And the cluster config is generated with data_checksums "1"
+        When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -l /tmp/gpinitsystemtest -s localhost -P 21100 -F pg_system:$MASTER_DATA_DIRECTORY/newstandby -h ../gpAux/gpdemo/hostfile"
+        Then gpinitsystem should return a return code of 0
+        And gpinitsystem should print "Log file scan check passed" to stdout
+        And sql "select * from gp_toolkit.__gp_user_namespaces" is executed in "postgres" db
+

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -3302,6 +3302,7 @@ def impl(context, dbname):
 
 
 @when('sql "{sql}" is executed in "{dbname}" db')
+@then('sql "{sql}" is executed in "{dbname}" db')
 def impl(context, sql, dbname):
     execute_sql(dbname, sql)
 


### PR DESCRIPTION
Previously, during gpinitsystem, the standby was instantiated in the middle of
setting up the master. This ordering caused problems because
initializing the standby could cause an exit when an error
occurred. As a result of this early exit, the gp_toolkit and DCA gucs
were not set properly.

Instead, initialize the standby after the master is finished.

------------------------------------------
Previously the exit return code for gpinitsystem was always non-zero. Now, it is non-zero only in an error or warning case.

The issue was due to SCAN_LOG interpretation of an empty string as a line count of one.
Fixed by changing to word count.

------------------------------------------
Initializing a standby can no longer cause gpinitsystem to exit early.
Added extra logging/output about standby master status.
Tell user at the end of gpinitsystem if gpinitstandby failed.

------------------------------------------