### PR TITLE
Basic FTS probe response for segment WAL replication

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -161,8 +161,22 @@ installcheck-world:
 	$(MAKE) -C src/interfaces/gppc installcheck
 	$(MAKE) -C src/test/kerberos installcheck
 	$(MAKE) -C gpMgmt/bin installcheck
+# The mirroring_matching test of gpcheckcat fails on a walrep cluster
+# because management tools do not yet understand the fault strategy
+# 'w'. Currently gpcheckcat does not allow us to exclude a single test
+# so we need to explicitly list all the tests.
+ifeq ($(enable_segwalrep), yes)
+	for test in "unique_index_violation" "duplicate" "missing_extraneous"\
+				"inconsistent" "foreign_key" "acl" "persistent" "pgclass"\
+				"namespace" "distribution_policy" "dependency" "owner"\
+				"part_integrity" "part_constraint" "duplicate_persistent";\
+	do \
+		gpcheckcat -R $$test -A;\
+	done;
+else
 	gpcheckcat -A
 	$(MAKE) -C contrib/pg_upgrade check
+endif
 
 installcheck-resgroup:
 	$(MAKE) -C src/test/isolation2 $@

--- a/contrib/pg_upgrade/check.c
+++ b/contrib/pg_upgrade/check.c
@@ -894,7 +894,12 @@ check_fts_fault_strategy(migratorContext *ctx)
 	snprintf(query, sizeof(query),
 			 "SELECT fault_strategy "
 			 "FROM   pg_catalog.gp_fault_strategy "
+#ifdef USE_SEGWALREP
+			 /* In segment WAL replication, 'f' is removed and replaced with 'w' */
+			 "WHERE  fault_strategy NOT IN ('n','w');");
+#else
 			 "WHERE  fault_strategy NOT IN ('n','f');");
+#endif
 
 	for (dbnum = 0; dbnum < old_cluster->dbarr.ndbs; dbnum++)
 	{

--- a/src/backend/catalog/Makefile
+++ b/src/backend/catalog/Makefile
@@ -20,7 +20,7 @@ OBJS = catalog.o dependency.o heap.o index.o indexing.o namespace.o aclchk.o \
        pg_type.o toasting.o \
        pg_exttable.o pg_extprotocol.o \
        pg_proc_callback.o \
-       aoseg.o aoblkdir.o gp_fastsequence.o \
+       aoseg.o aoblkdir.o gp_fastsequence.o gp_fault_strategy.o \
        pg_attribute_encoding.o pg_compression.o aovisimap.o \
        gp_global_sequence.o gp_persistent.o pg_appendonly.o \
        oid_dispatch.o aocatalog.o $(QUICKLZ_COMPRESSION)

--- a/src/backend/catalog/gp_fault_strategy.c
+++ b/src/backend/catalog/gp_fault_strategy.c
@@ -1,0 +1,86 @@
+/*
+ * gp_fault_strategy.c
+ *
+ * Copyright (c) 2017-Present Pivotal Software, Inc.
+ *
+ */
+
+#include "postgres.h"
+
+#include "catalog/gp_fault_strategy.h"
+#include "access/genam.h"
+#include "access/heapam.h"
+
+/*
+ * Get the gp_fault_strategy entry
+ */
+char
+get_gp_fault_strategy(void)
+{
+	Relation rel;
+	HeapTuple tuple;
+	SysScanDesc sscan;
+	Datum strategy_datum;
+	char strategy;
+
+	rel = heap_open(GpFaultStrategyRelationId, AccessShareLock);
+
+	/* SELECT * FROM gp_fault_strategy */
+	sscan = systable_beginscan(rel, InvalidOid, false, SnapshotNow, 0, NULL);
+
+	/* there should only be one row in table */
+	tuple = systable_getnext(sscan);
+
+	if (!HeapTupleIsValid(tuple))
+		ereport(ERROR, (errmsg("could not read gp_fault_strategy")));
+
+	strategy_datum = heap_getattr(tuple, Anum_gp_fault_strategy_fault_strategy, RelationGetDescr(rel), NULL);
+	strategy = DatumGetChar(strategy_datum);
+
+	systable_endscan(sscan);
+	heap_close(rel, AccessShareLock);
+
+#ifdef USE_SEGWALREP
+	Assert(strategy == GpFaultStrategyMirrorLess || strategy == GpFaultStrategyWalRepMirrored);
+#else
+	Assert(strategy == GpFaultStrategyMirrorLess || strategy == GpFaultStrategyFileRepMirrored);
+#endif
+
+	return strategy;
+}
+
+#ifdef USE_SEGWALREP
+/*
+ * Update the gp_fault_strategy if needed
+ */
+void
+update_gp_fault_strategy(char fault_strategy)
+{
+	Relation rel;
+	HeapTuple tuple;
+	SysScanDesc sscan;
+	Form_gp_fault_strategy form;
+
+	rel = heap_open(GpFaultStrategyRelationId, AccessExclusiveLock);
+
+	sscan = systable_beginscan(rel, InvalidOid, false, SnapshotNow, 0, NULL);
+
+	/* there should only be one row in table */
+	tuple = systable_getnext(sscan);
+
+	if (!HeapTupleIsValid(tuple))
+		ereport(ERROR, (errmsg("could not update gp_fault_strategy")));
+
+	tuple = heap_copytuple(tuple);
+	systable_endscan(sscan);
+
+	form = ((Form_gp_fault_strategy)GETSTRUCT(tuple));
+	if (form->fault_strategy != fault_strategy)
+	{
+		form->fault_strategy = fault_strategy;
+		simple_heap_update(rel, &tuple->t_self, tuple);
+	}
+
+	heap_close(rel, AccessExclusiveLock);
+}
+#endif

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -3574,6 +3574,19 @@ processPrimaryMirrorTransitionRequest(Port *port, void *pkt)
 	}
 }
 
+#ifdef USE_SEGWALREP
+static void
+sendPrimaryMirrorTransitionQuery()
+{
+	StringInfoData buf;
+
+	initStringInfo(&buf);
+
+	pq_beginmessage(&buf, '\0');
+	pq_endmessage(&buf);
+	pq_flush();
+}
+#else
 static void
 sendPrimaryMirrorTransitionQuery(uint32 mode, uint32 segstate, uint32 datastate, uint32 faulttype)
 {
@@ -3591,6 +3604,7 @@ sendPrimaryMirrorTransitionQuery(uint32 mode, uint32 segstate, uint32 datastate,
 	pq_endmessage(&buf);
 	pq_flush();
 }
+#endif
 
 /**
  * Called during startup packet processing.
@@ -3601,6 +3615,10 @@ sendPrimaryMirrorTransitionQuery(uint32 mode, uint32 segstate, uint32 datastate,
 static void
 processPrimaryMirrorTransitionQuery(Port *port, void *pkt)
 {
+#ifdef USE_SEGWALREP
+	/* Send FTS probe response */
+	sendPrimaryMirrorTransitionQuery();
+#else
 	PrimaryMirrorTransitionPacket *transition = (PrimaryMirrorTransitionPacket *) pkt;
 	int length;
 
@@ -3683,6 +3701,7 @@ processPrimaryMirrorTransitionQuery(Port *port, void *pkt)
 	sendPrimaryMirrorTransitionQuery((uint32)pm_mode, (uint32)s_state, (uint32)d_state, (uint32)f_type);
 
 	return;
+#endif
 }
 
 /*

--- a/src/backend/utils/gp/segadmin.c
+++ b/src/backend/utils/gp/segadmin.c
@@ -28,6 +28,10 @@
 #include "utils/builtins.h"
 #include "utils/fmgroids.h"
 
+#ifdef USE_SEGWALREP
+#include "catalog/gp_fault_strategy.h"
+#endif
+
 #define MASTER_ONLY 0x1
 #define UTILITY_MODE 0x2
 #define SUPERUSER 0x4
@@ -87,6 +91,47 @@ standby_exists()
 {
 	return segment_has_mirror(MASTER_CONTENT_ID);
 }
+
+#ifdef USE_SEGWALREP
+/*
+ * Tell the caller whether any segment mirrors exist.
+ */
+static bool
+segment_mirrors_exist()
+{
+	bool mirrors_exist;
+	Relation rel;
+	ScanKeyData scankey[2];
+	SysScanDesc scan;
+	HeapTuple tuple;
+
+	rel = heap_open(GpSegmentConfigRelationId, AccessShareLock);
+
+	/*
+	 * SELECT dbid FROM gp_segment_configuration
+	 * WHERE content != :1 AND role = :2
+	 */
+	ScanKeyInit(&scankey[0],
+				Anum_gp_segment_configuration_content,
+				BTEqualStrategyNumber, F_INT2NE,
+				Int16GetDatum(MASTER_CONTENT_ID));
+	ScanKeyInit(&scankey[1],
+				Anum_gp_segment_configuration_role,
+				BTEqualStrategyNumber, F_CHAREQ,
+				CharGetDatum('m'));
+
+	scan = systable_beginscan(rel, InvalidOid, false,
+							  SnapshotNow, 2, scankey);
+
+	tuple = systable_getnext(scan);
+	mirrors_exist = HeapTupleIsValid(tuple);
+
+	systable_endscan(scan);
+	heap_close(rel, AccessShareLock);
+
+	return mirrors_exist;
+}
+#endif
 
 /*
  * Get the highest dbid defined in the system. We AccessExclusiveLock
@@ -887,6 +932,11 @@ gp_add_segment_mirror(PG_FUNCTION_ARGS)
 
 	heap_close(rel, NoLock);
 
+#ifdef USE_SEGWALREP
+	/* update the gp_fault_strategy */
+	update_gp_fault_strategy(GpFaultStrategyWalRepMirrored);
+#endif
+
 	PG_RETURN_INT16(new.db.dbid);
 }
 
@@ -933,6 +983,15 @@ gp_remove_segment_mirror(PG_FUNCTION_ARGS)
 	remove_segment(pridbid, mirdbid);
 
 	heap_close(rel, NoLock);
+
+#ifdef USE_SEGWALREP
+	/* Increment so we can see the change when checking if any mirrors still exist */
+	CommandCounterIncrement();
+
+	/* If we removed the last segment mirror, update the gp_fault_strategy */
+	if (!segment_mirrors_exist())
+		update_gp_fault_strategy(GpFaultStrategyMirrorLess);
+#endif
 
 	PG_RETURN_BOOL(true);
 }

--- a/src/include/catalog/gp_fault_strategy.h
+++ b/src/include/catalog/gp_fault_strategy.h
@@ -10,6 +10,8 @@
 #ifndef _GP_FAULT_STRATEGY_H_
 #define _GP_FAULT_STRATEGY_H_
 
+#include "catalog/genbki.h"
+
 /*
  * Defines for gp_fault_strategy table.
  */
@@ -23,8 +25,11 @@
 #define GpFaultStrategyRelationId	5039
 
 #define GpFaultStrategyMirrorLess		'n'
-#define GpFaultStrategyFileRepMirrorred	'f'
-
+#ifdef USE_SEGWALREP
+#define GpFaultStrategyWalRepMirrored	'w'
+#else
+#define GpFaultStrategyFileRepMirrored	'f'
+#endif
 
 CATALOG(gp_fault_strategy,5039) BKI_SHARED_RELATION BKI_WITHOUT_OIDS
 {
@@ -47,5 +52,10 @@ typedef FormData_gp_fault_strategy *Form_gp_fault_strategy;
  */
 #define Natts_gp_fault_strategy					1
 #define Anum_gp_fault_strategy_fault_strategy	1
+
+extern char get_gp_fault_strategy(void);
+#ifdef USE_SEGWALREP
+extern void update_gp_fault_strategy(char fault_strategy);
+#endif
 
 #endif /* _GP_FAULT_STRATEGY_ */


### PR DESCRIPTION
Current FTS probe relies on file replication data structures mostly
found in pmModuleState.  This commit establishes an empty FTS probe
response packet that primaries using segment WAL replication can fill
out later.

We also introduce the 'w' fault_strategy (WAL replication) to replace
the 'f' fault_strategy (file replication).

This commit is carved and modified from a previously closed PR:
https://github.com/greenplum-db/gpdb/pull/2936

Authors: Abhijit Subramanya and Jimmy Yih