### PR TITLE
Add client and loader support for aix7_ppc_64 platform

### DIFF
--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -151,7 +151,7 @@ DEFPORT=5432
 ORCA_CONFIG=--enable-orca
 ifneq "$(findstring $(BLD_ARCH),win32 win64)" ""
 APR_CONFIG=--with-apr-config=$(GPPGDIR)/src/bin/gpfdist/ext/bin/apr-1-config
-OPENSSL=openssl-0.9.8ze
+OPENSSL=openssl-1.0.2l
 BLD_THIRDPARTY_OPENSSL_INCLUDES=-I$(GPPGDIR)/src/bin/gpfdist/ext/$(OPENSSL)/include
 else
 APR_CONFIG=--with-apr-config=$(BLD_THIRDPARTY_BIN_DIR)/apr-1-config
@@ -159,6 +159,7 @@ endif
 
 APU_CONFIG=--with-apu-config=$(BLD_THIRDPARTY_BIN_DIR)/apu-1-config
 
+aix7_ppc_64_CONFIGFLAGS=--disable-gpcloud --without-readline --without-libcurl --disable-orca $(APR_CONFIG)
 win32_CONFIGFLAGS=--with-gssapi --without-libcurl --disable-orca --disable-gpcloud $(APR_CONFIG)
 sol10_x86_64_CONFIGFLAGS=--enable-snmp --with-libxml $(APR_CONFIG)
 rhel5_x86_32_CONFIGFLAGS=--host=i686-pc-linux-gnu --enable-snmp --enable-ddboost --with-gssapi --enable-netbackup --with-libxml $(APR_CONFIG)
@@ -180,7 +181,7 @@ CONFIGFLAGS+= $(CONFIGURE_FLAGS)
 endif
 
 # PL/Python does not compile on Tiger, skipping it on AIX
-ifneq "$(findstring $(BLD_ARCH),aix5_ppc_64 aix5_ppc_32)" ""
+ifneq "$(findstring $(BLD_ARCH),aix7_ppc_64 aix5_ppc_64 aix5_ppc_32)" ""
 PG_LANG=false
 endif
 
@@ -198,12 +199,12 @@ endif
 # Configure in the extra path AIX requires for pthread support
 aix5_ppc_64_PTHREADS_LIB_DIR=/usr/lib/threads
 aix5_ppc_32_PTHREADS_LIB_DIR=/usr/lib/threads
+aix7_ppc_64_PTHREADS_LIB_DIR=/usr/lib/threads
 BLD_PTHREADS_LIB_DIR=$($(BLD_ARCH)_PTHREADS_LIB_DIR)
 
 ifdef ADDON_DIR
 ADDON_CONFIG_INCLUDES=$(BLD_TOP)/$(ADDON_DIR)/src/include
 endif
-
 # Configure in thirdparty libraries from the ext/ directory
 CONFIG_INCLUDES=$(BLD_THIRDPARTY_INCLUDE_DIR) $(BLD_THIRDPARTY_INCLUDE_DIR)/libxml2 $(ADDON_CONFIG_INCLUDES)
 CONFIG_LIBRARIES=$(strip $(BLD_THIRDPARTY_LIB_DIR) $(BLD_CXX_LIB_DIR) $(BLD_PTHREADS_LIB_DIR))
@@ -211,22 +212,23 @@ CONFIGFLAGS+= --with-includes="$(CONFIG_INCLUDES)" --with-libraries="$(CONFIG_LI
 
 # Configure in "authlibs"...
 # ...without an ext/ dir copy of curl-config on Tiger or AIX
-ifeq "$(findstring $(BLD_ARCH),aix5_ppc_64 aix5_ppc_32)" ""
+ifeq "$(findstring $(BLD_ARCH),aix7_ppc_64 aix5_ppc_64 aix5_ppc_32)" ""
 BLD_CURL_CONFIG=CURL_CONFIG=$(BLD_THIRDPARTY_BIN_DIR)/curl-config
 endif
 # ...and do not include the authlibs on Windows or AIX
-ifeq "$(findstring $(BLD_ARCH),aix5_ppc_64 win32 win64)" ""
+ifeq "$(findstring $(BLD_ARCH),aix7_ppc_64 aix5_ppc_64 win32 win64)" ""
 CONFIGFLAGS+= --with-openssl --with-pam --with-krb5 --with-ldap $(BLD_CURL_CONFIG) $(APR_CONFIG)
 endif
 
 # ...but do include some of the authlibs on AIX
-ifneq "$(findstring $(BLD_ARCH),aix5_ppc_32 aix5_ppc_64)" ""
+ifneq "$(findstring $(BLD_ARCH),aix7_ppc_64 ix5_ppc_32 aix5_ppc_64)" ""
 CONFIGFLAGS+= --with-openssl --with-pam --without-krb5 --with-ldap $(BLD_CURL_CONFIG)
 endif
 
 # Platform-specific config flags
 aix5_ppc_64_CONFIG_ADDITIONS=LDFLAGS="-Wl,-bbigtoc -L/usr/lib/threads"
 aix5_ppc_32_CONFIG_ADDITIONS=LDFLAGS="-L/usr/lib/threads"
+aix7_ppc_64_CONFIG_ADDITIONS=LDFLAGS="-Wl,-bbigtoc -L/usr/lib/threads"
 hpux_ia64_CONFIG_ADDITIONS=--without-readline --without-ldap
 
 win32_GPFDIST_LDFLAGS += -L/usr/i686-pc-mingw32/sys-root/mingw/lib -L$(GPPGDIR)/src/bin/gpfdist/ext/lib
@@ -255,8 +257,8 @@ RECONFIG :
 # avoid AIX's restricted shell
 aix5_ppc_64_CONFIG_SHELL=/usr/bin/bash
 aix5_ppc_32_CONFIG_SHELL=/usr/bin/bash
+aix7_ppc_64_CONFIG_SHELL=/usr/bin/bash
 BLD_CONFIG_SHELL=$($(BLD_ARCH)_CONFIG_SHELL)
-
 $(GPPGDIR)/GNUmakefile : $(GPPGDIR)/configure  env.sh
 	rm -rf $(INSTLOC)
 	mkdir -p $(GPPGDIR)
@@ -317,6 +319,7 @@ hpux_ia64_GPDB_BUILDSET=partial
 rhel5_x86_32_GPDB_BUILDSET=partial
 aix5_ppc_64_GPDB_BUILDSET=partial
 aix5_ppc_32_GPDB_BUILDSET=partial
+aix7_ppc_64_GPDB_BUILDSET=aix_subset
 sol10_x86_64_GPDB_BUILDSET=partial
 sol10_x86_32_GPDB_BUILDSET=partial
 sol10_sparc_32_GPDB_BUILDSET=partial
@@ -352,14 +355,28 @@ endef
 ifeq "$(BLD_GPDB_BUILDSET)" "aix_subset"
 define BUILD_STEPS
 	rm -rf $(INSTLOC)
+	cd $(BUILDDIR)/gpMgmt/ && $(MAKE) generate_greenplum_path_file
+	cd $(BUILDDIR)/src/backend/ && $(MAKE) ../../src/include/parser/gram.h
+	cd $(BUILDDIR)/src/backend/ && $(MAKE) ../../src/include/utils/fmgroids.h
 	cd $(BUILDDIR)/src/include/ && $(MAKE) install
+	cd $(BUILDDIR)/src/interfaces/libpq/ && $(MAKE) install
+	cd $(BUILDDIR)/src/bin/pg_config/ && $(MAKE) install
+	cd $(BUILDDIR)/src/bin/psql/ && $(MAKE) install
+	cd $(BUILDDIR)/src/bin/pg_dump/ && $(MAKE) install
+	cd $(BUILDDIR)/src/bin/gpfdist && $(MAKE) install
 	@$(MAKE) mgmtcopy INSTLOC=$(INSTLOC)
 	@$(MAKE) copylibs INSTLOC=$(INSTLOC)
+	@$(MAKE) clients INSTLOC=$(INSTLOC) CLIENTINSTLOC=$(CLIENTINSTLOC)
+	@$(MAKE) set_scripts_version INSTLOC=$(CLIENTINSTLOC)
+	if [ "$(findstring hpux_ia64,$(BLD_ARCH))" = "hpux_ia64" ]; then \
+	  cd $(GPMGMT)/bin && $(MAKE) pygresql LDFLAGS="" INSTLOC=$(INSTLOC) ; \
+	elif [ "$(findstring win,$(BLD_ARCH))" != "win" ]; then \
+	  cd $(GPMGMT)/bin && $(MAKE) pygresql INSTLOC=$(INSTLOC) ; \
+	fi
 	@$(MAKE) loaders INSTLOC=$(INSTLOC) LOADERSINSTLOC=$(LOADERSINSTLOC)
 	@$(MAKE) set_scripts_version INSTLOC=$(LOADERSINSTLOC)
 endef
 endif
-
 ifeq "$(BLD_GPDB_BUILDSET)" "partial"
 define BUILD_STEPS
 	rm -rf $(INSTLOC)
@@ -434,6 +451,9 @@ devel : gccVersionCheck HOMEDEP $(ISCONFIG)
 endif
 	$(BUILD_STEPS)
 
+ifneq "$(findstring $(BLD_GPDB_BUILDSET),partial aix_subset)" ""
+	@$(MAKE) qautils-tarball INSTLOC=$(INSTLOC)
+endif
 #---------------------------------------------------------------------
 # Release builds
 #---------------------------------------------------------------------
@@ -451,9 +471,6 @@ else
 dist : gccVersionCheck GPROOTDEP RECONFIG $(ISCONFIG)
 endif
 	$(BUILD_STEPS)
-ifneq "$(BLD_GPDB_BUILDSET)" "partial"
-	@$(MAKE) qautils-tarball INSTLOC=$(INSTLOC)
-endif
 
 dist_prof : INSTCFLAGS=$(PROFFLAGS)
 dist_prof : INSTLOC=$(DISTPATH)
@@ -565,6 +582,7 @@ LOADERS_FILESET_BINEXT = $(strip $(tmpLOADERS_FILESET_BINEXT))
 BLD_PYTHON_FILESET=.
 aix5_ppc_32_PYTHON_FILESET=bin/python* lib/python* include/python*
 aix5_ppc_64_PYTHON_FILESET=bin/python* lib/python* include/python*
+aix7_ppc_64_PYTHON_FILESET=bin/python_64 lib/python* lib64/python* include/python*
 ifneq "$($(BLD_ARCH)_PYTHON_FILESET)" ""
 BLD_PYTHON_FILESET=$($(BLD_ARCH)_PYTHON_FILESET)
 endif
@@ -593,9 +611,14 @@ FILESET_LIB_GCC_LOC=$($(BLD_ARCH)_LOADERS_LIBS_GCC_LOC)
 
 aix5_ppc_32_LOADERS_LIBS_PERZL=libz.a
 aix5_ppc_64_LOADERS_LIBS_PERZL=libz.so libz.so.1 libz.so.1.2.4 libcrypto.so libcrypto.so.0.9.8 libssl.so libssl.so.0.9.8
+aix7_ppc_64_LOADERS_LIBS_PERZL=libcrypto.a libssl.a
 
 aix5_ppc_32_LOADERS_LIBS_PERZL_LOC=/opt/freeware/lib
 aix5_ppc_64_LOADERS_LIBS_PERZL_LOC=/opt/pware64/lib
+aix7_ppc_64_LOADERS_LIBS_PERZL_LOC=$(BLD_TOP)/ext/aix7_ppc_64/lib
+
+aix7_ppc_64_LOADERS_LIBS_PERZL=libcrypto.a libssl.a
+aix7_ppc_64_LOADERS_LIBS_PERZL_LOC=$(BLD_TOP)/ext/aix7_ppc_64/lib
 
 LOADERS_FILESET_LIB_PERZL=$($(BLD_ARCH)_LOADERS_LIBS_PERZL)
 LOADERS_FILESET_LIB_PERZL_LOC=$($(BLD_ARCH)_LOADERS_LIBS_PERZL_LOC)
@@ -904,9 +927,7 @@ ifeq "$(findstring $(BLD_ARCH),$(GPPKG_PLATFORMS))" ""
 	rm -f $(INSTLOC)/bin/gppkg
 endif
 	cp -rp $(GPMGMT)/sbin/* $(INSTLOC)/sbin/.
-	cp -p extensions/gpfdist/gpfdist$(EXE_EXT) $(INSTLOC)/bin/
 	cp $(GPPGDIR)/src/test/regress/*.pl $(INSTLOC)/bin
-	cp $(GPPGDIR)/src/test/regress/*.pm $(INSTLOC)/bin
 	if [ ! -d ${INSTLOC}/docs ] ; then mkdir ${INSTLOC}/docs ; fi
 	if [ -d $(GPMGMT)/doc ]; then cp -rp $(GPMGMT)/doc $(INSTLOC)/docs/cli_help; fi
 	if [ -d $(GPMGMT)/demo/gpmapreduce ]; then \
@@ -990,7 +1011,7 @@ copylibs : thirdparty-dist copy-nbu-libs
 	fi
 	mkdir -p $(INSTLOC)/etc
 	mkdir -p $(INSTLOC)/include
-ifeq "$(findstring $(BLD_ARCH),aix5_ppc_32 aix5_ppc_64 win32 win64)" ""
+ifeq "$(findstring $(BLD_ARCH),aix5_ppc_32 aix5_ppc_64 aix7_ppc_64 win32 win64)" ""
 	# Copy curl header file
 	cp -rp $(BLD_THIRDPARTY_INCLUDE_DIR)/curl $(INSTLOC)/include/
 endif
@@ -1006,8 +1027,10 @@ else
 endif
 endif
 
+ifneq "$(BLD_ARCH)" "aix7_ppc_64"
 	# Copy glider stack trace capture tool
 	-cp -rp $(BLD_THIRDPARTY_BIN_DIR)/glider $(INSTLOC)/sbin/
+endif
 
 ifeq "$(BLD_ARCH)" "win32"
 	# Copy kfw dlls

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -221,7 +221,7 @@ CONFIGFLAGS+= --with-openssl --with-pam --with-krb5 --with-ldap $(BLD_CURL_CONFI
 endif
 
 # ...but do include some of the authlibs on AIX
-ifneq "$(findstring $(BLD_ARCH),aix7_ppc_64 ix5_ppc_32 aix5_ppc_64)" ""
+ifneq "$(findstring $(BLD_ARCH),aix7_ppc_64 aix5_ppc_32 aix5_ppc_64)" ""
 CONFIGFLAGS+= --with-openssl --with-pam --without-krb5 --with-ldap $(BLD_CURL_CONFIG)
 endif
 
@@ -582,7 +582,7 @@ LOADERS_FILESET_BINEXT = $(strip $(tmpLOADERS_FILESET_BINEXT))
 BLD_PYTHON_FILESET=.
 aix5_ppc_32_PYTHON_FILESET=bin/python* lib/python* include/python*
 aix5_ppc_64_PYTHON_FILESET=bin/python* lib/python* include/python*
-aix7_ppc_64_PYTHON_FILESET=bin/python_64 lib/python* lib64/python* include/python*
+aix7_ppc_64_PYTHON_FILESET=bin/python* lib/python* lib64/python* include/python*
 ifneq "$($(BLD_ARCH)_PYTHON_FILESET)" ""
 BLD_PYTHON_FILESET=$($(BLD_ARCH)_PYTHON_FILESET)
 endif

--- a/gpAux/Makefile.global
+++ b/gpAux/Makefile.global
@@ -15,6 +15,7 @@ endif
 BLD_WHERE_THE_LIBRARY_THINGS_ARE=LD_LIBRARY_PATH
 aix5_ppc_64_WHERE_THE_LIBRARY_THINGS_ARE=LIBPATH
 aix5_ppc_32_WHERE_THE_LIBRARY_THINGS_ARE=LIBPATH
+aix7_ppc_64_WHERE_THE_LIBRARY_THINGS_ARE=LIBPATH
 osx106_x86_WHERE_THE_LIBRARY_THINGS_ARE=DYLD_LIBRARY_PATH
 ifneq "$($(BLD_ARCH)_WHERE_THE_LIBRARY_THINGS_ARE)" ""
 BLD_WHERE_THE_LIBRARY_THINGS_ARE=$($(BLD_ARCH)_WHERE_THE_LIBRARY_THINGS_ARE)
@@ -54,6 +55,7 @@ endif
 ifneq "$(BLD_PATH_FIXED)" "true"
 aix5_ppc_64_PATH_PREPEND=/opt/freeware/bin
 aix5_ppc_32_PATH_PREPEND=/opt/freeware/bin
+aix7_ppc_64_PATH_PREPEND=/opt/freeware/bin
 osx106_x86_PATH_PREPEND=$(BLD_THIRDPARTY_BIN_DIR)
 sol10_x86_32_PATH_PREPEND=/opt/python32-2.5.1/bin
 sol10_sparc_64_PATH_PREPEND=/opt/gcc-4.1.1/bin
@@ -68,6 +70,7 @@ endif
 # take over the library search path
 aix5_ppc_64_LD_LIBRARY_PATH_PREPEND=/opt/freeware/lib
 aix5_ppc_32_LD_LIBRARY_PATH_PREPEND=/opt/freeware/lib
+aix7_ppc_64_LD_LIBRARY_PATH_PREPEND=/opt/freeware/lib
 ifneq "$(BLD_LD_LIBRARY_PATH_FIXED)" "true"
 sol10_x86_32_LD_LIBRARY_PATH_PREPEND=/opt/python32-2.5.1/lib
 sol10_sparc_32_LD_LIBRARY_PATH_PREPEND=/opt/python32-2.5.1/lib
@@ -81,6 +84,7 @@ export BLD_LD_LIBRARY_PATH_FIXED=true
 # specify python version to use for build-time and run-time
 aix5_ppc_32_PYTHONHOME=/opt/pware
 aix5_ppc_64_PYTHONHOME=/opt/pware64
+aix7_ppc_64_PYTHONHOME=/opt/freeware
 hpux_ia64_PYTHONHOME=$(BLD_THIRDPARTY_DIR)/python-2.5.6
 osx106_x86_PYTHONHOME=$(BLD_THIRDPARTY_DIR)/python-2.7.12
 rhel5_x86_32_PYTHONHOME=$(BLD_THIRDPARTY_DIR)/python-2.7.12
@@ -103,6 +107,7 @@ ifneq "$(PYTHONHOME)" ""
 export PYTHON=$(PYTHONHOME)/bin/python
 aix5_ppc_32_PYTHON=$(PYTHONHOME)/bin/python2.7
 aix5_ppc_64_PYTHON=$(PYTHONHOME)/bin/python2.7_64
+aix7_ppc_64_PYTHON=$(PYTHONHOME)/bin/python2.7_64
 ifneq "$($(BLD_ARCH)_PYTHON)" ""
 export PYTHON=$($(BLD_ARCH)_PYTHON)
 endif
@@ -110,7 +115,7 @@ endif
 
 # if PYTHONHOME was specified above, use it for the build
 ifneq "$(PYTHONHOME)" ""
-ifeq "$(findstring $(BLD_ARCH),aix5_ppc_32 aix5_ppc_64)" ""
+ifeq "$(findstring $(BLD_ARCH),aix5_ppc_32 aix5_ppc_64 aix7_ppc_64)" ""
 tmpPATH=$(PYTHONHOME)/bin:$(PATH)
 export PATH:=$(tmpPATH)
 tmpLD_LIBRARY_PATH=$(PYTHONHOME)/lib:$($(BLD_WHERE_THE_LIBRARY_THINGS_ARE))
@@ -158,15 +163,17 @@ sles11_x86_64_BLD_CFLAGS=-m64
 win64_BLD_CFLAGS=-m64
 win32_BLD_CFLAGS=-m32
 aix5_ppc_64_BLD_CFLAGS=-maix64
+aix7_ppc_64_BLD_CFLAGS=-maix64
 aix5_ppc_32_BLD_CFLAGS=
 BLD_CFLAGS=$($(BLD_ARCH)_BLD_CFLAGS)
 
 aix5_ppc_64_BLD_LDFLAGS=-maix64 -Wl,-bbigtoc
+aix7_ppc_64_BLD_LDFLAGS=-maix64 -Wl,-bbigtoc
 rhel5_x86_32_BLD_LDFLAGS=-m32
 BLD_LDFLAGS=$($(BLD_ARCH)_BLD_LDFLAGS)
 
 # See http://www.postgresql.org/docs/faqs.FAQ_AIX.html for an explanation of this
-ifeq "$(BLD_ARCH)" "aix5_ppc_64"
+ifeq "$(findstring $(BLD_ARCH), aix5_ppc_64 aix7_ppc_64)" ""
 export OBJECT_MODE=64
 export CONFIG_SHELL=/usr/bin/bash
 endif
@@ -181,6 +188,7 @@ sol10_sparc_BLD_BITS=64
 osx106_x86_BLD_BITS=32
 aix5_ppc_64_BLD_BITS=64
 aix5_ppc_32_BLD_BITS=32
+aix7_ppc_64_BLD_BITS=64
 BLD_BITS=$($(BLD_ARCH)_BLD_BITS)
 endif
 
@@ -196,6 +204,7 @@ endif
 GREP=grep
 aix5_ppc_64_GREP=/opt/freeware/bin/grep
 aix5_ppc_32_GREP=/opt/freeware/bin/grep
+aix7_ppc_64_GREP=/opt/freeware/bin/grep
 sol10_x86_64_GREP=ggrep
 sol10_x86_32_GREP=ggrep
 sol10_sparc_64_GREP=ggrep
@@ -209,6 +218,7 @@ endif
 TAR=tar
 aix5_ppc_32_TAR=gtar
 aix5_ppc_64_TAR=gtar
+aix7_ppc_64_TAR=gtar
 sol10_x86_32_TAR=gtar
 sol10_x86_64_TAR=gtar
 sol10_sparc_TAR=gtar
@@ -221,6 +231,7 @@ endif
 # awk by platform
 aix5_ppc_32_AWK=gawk
 aix5_ppc_64_AWK=gawk
+aix7_ppc_64_AWK=gawk
 sol10_x86_32_AWK=nawk
 sol10_x86_64_AWK=nawk
 sol10_sparc_AWK=nawk

--- a/gpAux/Makefile.global
+++ b/gpAux/Makefile.global
@@ -173,7 +173,7 @@ rhel5_x86_32_BLD_LDFLAGS=-m32
 BLD_LDFLAGS=$($(BLD_ARCH)_BLD_LDFLAGS)
 
 # See http://www.postgresql.org/docs/faqs.FAQ_AIX.html for an explanation of this
-ifeq "$(findstring $(BLD_ARCH), aix5_ppc_64 aix7_ppc_64)" ""
+ifneq "$(findstring $(BLD_ARCH), aix5_ppc_64 aix7_ppc_64)" ""
 export OBJECT_MODE=64
 export CONFIG_SHELL=/usr/bin/bash
 endif

--- a/gpAux/Makefile.thirdparty
+++ b/gpAux/Makefile.thirdparty
@@ -15,7 +15,9 @@ ifeq "$(BLD_THIRDPARTY_DIR)" ""
 
 # calculate BLD_TOP in absolute path form
 BLD_TOP_ABSOLUTE:=$(shell cd $(BLD_TOP) && pwd)
-
+ifeq ($(BLD_ARCH),aix7_ppc_64)
+ADDON_DIR=../../gpaddon_src
+endif
 BLD_THIRDPARTY:=$(BLD_TOP_ABSOLUTE)/ext
 ifeq "$(BLD_ARCH)" ""
 BLD_ARCH:=$(shell $(BLD_TOP)/releng/set_bld_arch.sh)
@@ -23,6 +25,7 @@ endif
 
 aix5_ppc_64_BLD_BITS=64
 aix5_ppc_32_BLD_BITS=32
+aix7_ppc_64_BLD_BITS=64
 rhel6_x86_64_BLD_BITS=64
 rhel7_x86_64_BLD_BITS=64
 rhel5_x86_64_BLD_BITS=64

--- a/gpAux/releng/make/dependencies/ivy.xml
+++ b/gpAux/releng/make/dependencies/ivy.xml
@@ -8,13 +8,14 @@
       <conf name="suse11_x86_64"  visibility="public"/>
       <conf name="sles11_x86_64"  visibility="public"/>
       <conf name="win32"          visibility="public"/>
+      <conf name="aix7_ppc_64"    visibility="public"/>
     </configurations>
 
     <dependencies>
       <dependency org="apache"          name="apr"             rev="1.5.2"          conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64;suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64" />
       <dependency org="apache"          name="apr-util"        rev="1.2.12"         conf="rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64;suse11_x86_64->suse10_x86_64;sles11_x86_64->suse10_x86_64" />
       <dependency org="xerces"          name="xerces-c"        rev="3.1.1-p1"       conf="rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64;suse11_x86_64->suse10_x86_64;sles11_x86_64->suse10_x86_64" />
-      <dependency org="OpenSSL"         name="openssl"         rev="1.0.2l"         conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64;suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64" />
+      <dependency org="OpenSSL"         name="openssl"         rev="1.0.2l"         conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64;suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64;aix7_ppc_64->aix7_ppc_64" />
       <dependency org="emc"             name="DDBoostSDK"      rev="3.3.0.4-550644" conf="rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64" />
       <dependency org="gnu"             name="libstdc"         rev="6.0.22"         conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64;suse11_x86_64->suse11_x86_64;sles11_x86_64->suse11_x86_64" />
       <dependency org="third-party"     name="ext"             rev="1.1"            conf="win32->win32" />
@@ -26,5 +27,13 @@
       <dependency org="cURL"            name="curl"            rev="7.54.0"         conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64;suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64" />
       <dependency org="Samba"           name="ccache"          rev="3.2.3"          conf="rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64;suse11_x86_64->suse11_x86_64;sles11_x86_64->suse11_x86_64" />
       <dependency org="OpenLDAP"        name="openldap"        rev="2.4.44"         conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64;suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64" />
+      <dependency org="OpenLDAP"        name="openldap"        rev="2.4.45"         conf="aix7_ppc_64->aix7_ppc_64" />
+      <dependency org="PyYAML"          name="yaml"            rev="0.1.7"          conf="aix7_ppc_64->aix7_ppc_64" />
+      <dependency org="apache"          name="apr"             rev="1.6.2"          conf="aix7_ppc_64->aix7_ppc_64" />
+      <dependency org="apache"          name="apr-util"        rev="1.6.0"          conf="aix7_ppc_64->aix7_ppc_64" />
+      <dependency org="bzip"            name="bzip2"           rev="1.0.6"          conf="aix7_ppc_64->aix7_ppc_64" />
+      <dependency org="libevent"        name="libevent"        rev="2.1.8"          conf="aix7_ppc_64->aix7_ppc_64" />
+      <dependency org="mit"             name="krb5"            rev="1.15.1"         conf="aix7_ppc_64->aix7_ppc_64" />
+      <dependency org="zlib"            name="zlib"            rev="1.2.11"         conf="aix7_ppc_64->aix7_ppc_64" />
     </dependencies>
 </ivy-module>

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -120,7 +120,9 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" resolve);
 	@echo "Resolve finished";
 
+ifeq "$(findstring aix,$(BLD_ARCH))" ""
 	LD_LIBRARY_PATH='' wget -O - https://github.com/greenplum-db/gporca/releases/download/v2.40.3/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+endif
 
 clean_tools: opt_write_test
 	@cd releng/make/dependencies; \

--- a/gpAux/releng/set_bld_arch.sh
+++ b/gpAux/releng/set_bld_arch.sh
@@ -32,7 +32,7 @@ case "`uname -s`" in
     ;;
 
     AIX)
-    BLD_ARCH_HOST="aix`uname -v`_`prtconf | grep 'Processor Type' | awk '{print $3}' | perl -p -i -e 's,PowerPC_POWER5,ppc,'`_`prtconf -k | perl -p -i -e 's,Kernel Type: (\d+)-bit,\1,'`"
+    BLD_ARCH_HOST="aix`uname -v`_`prtconf | grep 'Processor Type' | awk '{print $3}' | perl -p -i -e 's,PowerPC_POWER.,ppc,'`_`prtconf -k | perl -p -i -e 's,Kernel Type: (\d+)-bit,\1,'`"
     ;;
 
     *)

--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -61,6 +61,8 @@ pygresql:
 	. $(prefix)/greenplum_path.sh && unset PYTHONHOME && \
 	if [ `uname -s` = 'HP-UX' ]; then \
 	    cd $(PYLIB_SRC)/$(PYGRESQL_DIR) && DESTDIR="$(DESTDIR)" CC="$(CC)" LDFLAGS="-L../../../../gpAux/ext/hpux_ia64/python-2.5.6/lib" python setup.py build; \
+	elif [ $(BLD_ARCH) = 'aix7_ppc_64' ]; then \
+	    cd $(PYLIB_SRC)/$(PYGRESQL_DIR) && DESTDIR="$(DESTDIR)" CC="$(CC)" python_64 setup.py build; \
 	else \
 	    cd $(PYLIB_SRC)/$(PYGRESQL_DIR) && DESTDIR="$(DESTDIR)" CC="$(CC)" python setup.py build; \
 	fi
@@ -68,6 +70,8 @@ pygresql:
 	mkdir -p $(PYLIB_DIR)/pygresql
 	if [ `uname -s` = 'Darwin' ]; then \
 	  cp -r $(PYLIB_SRC)/$(PYGRESQL_DIR)/build/lib.macosx*/* $(PYLIB_DIR)/pygresql; \
+	elif [ `uname -s` = 'AIX' ]; then \
+	  cp -r $(PYLIB_SRC)/$(PYGRESQL_DIR)/build/lib.aix*/* $(PYLIB_DIR)/pygresql; \
 	else \
 	  cp -r $(PYLIB_SRC)/$(PYGRESQL_DIR)/build/lib.linux*/* $(PYLIB_DIR)/pygresql; \
 	fi
@@ -118,9 +122,24 @@ PYCRYPTO_DIR=pycrypto-$(PYCRYPTO_VERSION)
 
 pycrypto:
 	@echo "--- pycrypto"
+ifeq "$(findstring $(BLD_ARCH),aix7_ppc_64 )" ""
 	cd $(PYLIB_SRC_EXT)/ && $(TAR) xzf $(PYCRYPTO_DIR).tar.gz
 	cd $(PYLIB_SRC_EXT)/$(PYCRYPTO_DIR)/ && CC="$(CC)" python setup.py build
 	cp -r $(PYLIB_SRC_EXT)/$(PYCRYPTO_DIR)/build/lib.*/Crypto $(PYLIB_DIR)
+endif
+
+#
+# PSI
+PSI_DIR=PSI-$(PSI_VERSION)
+
+ psi:
+	@echo "--- psi"
+ifeq "$(findstring $(BLD_ARCH),aix7_ppc_64 )" ""
+	cd $(PYLIB_SRC)/ && $(TAR) xzf $(PSI_DIR).tar.gz
+	cd $(PYLIB_SRC)/$(PSI_DIR)/ && CC="$(CC)" python setup.py build
+	cp -r $(PYLIB_SRC)/$(PSI_DIR)/build/lib.*/psi $(PYLIB_DIR)
+endif
+
 
 #
 # PSUTIL
@@ -130,10 +149,11 @@ PSUTIL_DIR=psutil-$(PSUTIL_VERSION)
 
 psutil:
 	@echo "--- psutil"
+ifeq "$(findstring $(BLD_ARCH),aix7_ppc_64 )" ""
 	cd $(PYLIB_SRC_EXT)/ && $(TAR) xzf $(PSUTIL_DIR).tar.gz
 	cd $(PYLIB_SRC_EXT)/$(PSUTIL_DIR)/ && CC="$(CC)" python setup.py build
 	cp -r $(PYLIB_SRC_EXT)/$(PSUTIL_DIR)/build/lib.*/psutil $(PYLIB_DIR)
-
+endif
 
 #
 # PYLINT

--- a/gpMgmt/bin/gpload
+++ b/gpMgmt/bin/gpload
@@ -5,10 +5,10 @@ fi
 if [ ! -z "$GPHOME_LOADERS" ]; then
     . $GPHOME_LOADERS/greenplum_loaders_path.sh
 fi
-if [ `uname -s` = "AIX" -a ! -z "$GP_LIBPATH_FOR_PYTHON" ]; then
+if [ `uname -s` = "AIX" ]; then
     LIBPATH=$GP_LIBPATH_FOR_PYTHON:$LIBPATH
     export LIBPATH
+    python_64 `which gpload.py` $*
+else
+    exec gpload.py $*
 fi
-
-
-exec gpload.py $*

--- a/src/bin/gpfdist/Makefile
+++ b/src/bin/gpfdist/Makefile
@@ -16,6 +16,10 @@ OBJS = gpfdist.o gpfdist_helper.o fstream.o gfile.o
 # need to link with unnecessary libraries.
 GPFDIST_LIBS =-levent
 
+ifeq ($(PORTNAME),aix)
+  GPFDIST_LIBS += -lbz2 -lbsd
+endif
+
 ifeq ($(have_yaml),yes)
   GPFDIST_LIBS += -lyaml
   OBJS += transform.o

--- a/src/bin/pg_dump/Makefile
+++ b/src/bin/pg_dump/Makefile
@@ -17,7 +17,7 @@ include $(top_builddir)/src/Makefile.global
 # The frontend doesn't need everything that's in LIBS, some are backend only
 LIBS := $(filter-out -lresolv, $(LIBS))
 # This program isn't interactive, so doesn't need these
-LIBS := $(filter-out -lreadline -ledit -ltermcap -lncurses -lcurses -lcurl -lssl -lcrypto, $(LIBS))
+LIBS := $(filter-out -lreadline -ledit -ltermcap -lncurses -lcurses -lcurl , $(LIBS))
 
 
 # the use of tempnam in pg_backup_tar.c causes a warning when using newer versions of GCC
@@ -45,13 +45,17 @@ pg_dumpall: pg_dumpall.o dumputils.o $(KEYWRDOBJS) $(libpq_builddir)/libpq.a
 	$(CC) $(CFLAGS) pg_dumpall.o dumputils.o $(KEYWRDOBJS) $(WIN32RES) $(libpq_pgport) $(LDFLAGS) $(LIBS) -o $@$(X)
 
 submake-cdb:
+ifneq ($(PORTNAME), aix)
 	$(MAKE) -C cdb all
+    endif
 
 install: all installdirs
 	$(INSTALL_PROGRAM) pg_dump$(X) '$(DESTDIR)$(bindir)'/pg_dump$(X)
 	$(INSTALL_PROGRAM) pg_restore$(X) '$(DESTDIR)$(bindir)'/pg_restore$(X)
 	$(INSTALL_PROGRAM) pg_dumpall$(X) '$(DESTDIR)$(bindir)'/pg_dumpall$(X)
+ifneq ($(PORTNAME), aix)
 	$(MAKE) -C cdb install
+endif
 
 installdirs:
 	$(MKDIR_P) '$(DESTDIR)$(bindir)'

--- a/src/template/aix
+++ b/src/template/aix
@@ -16,3 +16,4 @@ fi
 # 	AIX 5.1 and 5.2, XLC 6.0 (IBM's cc)
 # 	AIX 5.3 ML3, gcc 4.0.1
 MEMSET_LOOP_LIMIT=0
+EXTRA_LDAP_LIBS="-llber -lssl -lcrypto"


### PR DESCRIPTION
1. Add dependency packages to Ivy
2. Modify set_bld_arch.sh to correctly recongize aix7
3. Disable unsupported python libraries on aix7.
4. Disable gpmapreduce for aix7
5. Set ADDON_DIR for aix7
   Signed-off-by: Peifeng Qiu pqiu@pivotal.io