### PR TITLE
Refactor window function grammar rules, to reduce diff vs. upstream.

### DIFF
--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -689,13 +689,10 @@ transformWindowClause(ParseState *pstate, Query *qry)
 				nf->lead = e;
 			}
 
-			ParseCallbackState pcbstate;
-			setup_parser_errposition_callback(&pcbstate, pstate, newspec->location);
 			transformWindowFrameEdge(pstate, nf->trail, newspec, qry,
 									 nf->is_rows);
 			transformWindowFrameEdge(pstate, nf->lead, newspec, qry,
 									 nf->is_rows);
-			cancel_parser_errposition_callback(&pcbstate);
 			newspec->frame = nf;
 		}
 

--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -1164,7 +1164,7 @@ transformFuncCall(ParseState *pstate, FuncCall *fn)
 							 fn->agg_distinct,
 							 fn->func_variadic,
 							 false,
-							 (WindowSpec *)fn->over,
+							 fn->over,
 							 fn->location, 
 							 fn->agg_filter);
 }

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -321,7 +321,7 @@ typedef struct FuncCall
 	bool		agg_distinct;	/* arguments were labeled DISTINCT */
 	bool		func_variadic;	/* last argument was labeled VARIADIC */
 	int			location;		/* token location, or -1 if unknown */
-	Node	   *over;			/* over clause */
+	struct WindowSpec *over;	/* OVER clause, if any */
     Node       *agg_filter;     /* aggregation filter clause */
 } FuncCall;
 

--- a/src/test/regress/expected/olap_window_seq.out
+++ b/src/test/regress/expected/olap_window_seq.out
@@ -1593,6 +1593,8 @@ sum(count(*)) over (range between 1 preceding and 1 following)
 from sale
 group by cn;
 ERROR:  window specifications with a framing clause must have an ORDER BY clause
+LINE 2: sum(count(*)) over (range between 1 preceding and 1 followin...
+                           ^
 -- test for issue which reopened MPP-1762
 -- We allow the user to specify DESC sort order
 SELECT sale.cn,sale.vn,AVG(cast (sale.vn as int)) OVER(order by ord desc,sale.cn desc) as avg from sale_ord as sale;

--- a/src/test/regress/expected/olap_window_seq_optimizer.out
+++ b/src/test/regress/expected/olap_window_seq_optimizer.out
@@ -1594,6 +1594,8 @@ sum(count(*)) over (range between 1 preceding and 1 following)
 from sale
 group by cn;
 ERROR:  window specifications with a framing clause must have an ORDER BY clause
+LINE 2: sum(count(*)) over (range between 1 preceding and 1 followin...
+                           ^
 -- test for issue which reopened MPP-1762
 -- We allow the user to specify DESC sort order
 SELECT sale.cn,sale.vn,AVG(cast (sale.vn as int)) OVER(order by ord desc,sale.cn desc) as avg from sale_ord as sale;

--- a/src/test/regress/expected/qp_misc.out
+++ b/src/test/regress/expected/qp_misc.out
@@ -13121,6 +13121,8 @@ group by
 f1,f2,f3,f4,f5
 ) Q ) P;
 ERROR:  window specifications with a framing clause must have an ORDER BY clause
+LINE 12: select rnum, c1, c2, c3, avg( c3 ) over(partition by c1 rows...
+                                                ^
 -- OlapCoreCountMultiplePartitions_p1
 select 'OlapCoreCountMultiplePartitions_p1' test_name_part, case when c = 1 then 1 else 0 end pass_ind from (
 select count(distinct c) c from (
@@ -13185,6 +13187,8 @@ group by
 f1,f2,f3,f4,f5
 ) Q ) P;
 ERROR:  window specifications with a framing clause must have an ORDER BY clause
+LINE 12: select rnum, c1, c2, c3, count( c3 ) over(partition by c1 ro...
+                                                  ^
 -- OlapCoreCountStar_p1
 select 'OlapCoreCountStar_p1' test_name_part, case when c = 1 then 1 else 0 end pass_ind from (
 select count(distinct c) c from (


### PR DESCRIPTION
As a pleasent side-effect, the window specification in a
"func_expr OVER (window_spec)" rule now gets its parse location set
correctly. Thanks to that, a few error messages now give a user-friendly
error location line.