### PR TITLE
Change a few error messages to match upstream again.

### DIFF
--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -14114,7 +14114,7 @@ insertSelectOptions(SelectStmt *stmt,
 		if (stmt->sortClause)
 			ereport(ERROR,
 					(errcode(ERRCODE_SYNTAX_ERROR),
-					 errmsg("syntax error at or near \"ORDER BY\""),
+					 errmsg("multiple ORDER BY clauses not allowed"),
 					 scanner_errposition(exprLocation((Node *) sortClause))));
 		stmt->sortClause = sortClause;
 	}
@@ -14125,7 +14125,7 @@ insertSelectOptions(SelectStmt *stmt,
 		if (stmt->limitOffset)
 			ereport(ERROR,
 					(errcode(ERRCODE_SYNTAX_ERROR),
-					 errmsg("syntax error at or near \"OFFSET\""),
+					 errmsg("multiple OFFSET clauses not allowed"),
 					 scanner_errposition(exprLocation(limitOffset))));
 		stmt->limitOffset = limitOffset;
 	}
@@ -14134,7 +14134,7 @@ insertSelectOptions(SelectStmt *stmt,
 		if (stmt->limitCount)
 			ereport(ERROR,
 					(errcode(ERRCODE_SYNTAX_ERROR),
-					 errmsg("syntax error at or near \"LIMIT\""),
+					 errmsg("multiple LIMIT clauses not allowed"),
 					 scanner_errposition(exprLocation(limitCount))));
 		stmt->limitCount = limitCount;
 	}


### PR DESCRIPTION
I don't understand why these were modified in GPDB in the first place.
I dug into the old git history, from before Greenplum was open sourced, and
traced the change to a massive commit from 2011, which added support for
(non-recursive) WITH clause. I think the change was just collateral damage
in that patch; I don't see any relationship between WITH clause support and
these error messages.

These errors can be reproduced with queries like this:

    (select 'foobar' order by 1) order by 1;
    (select 'foobar' limit 1) limit 2;
    (select 'foobar' offset 1) offset 2;