### PR TITLE
Remove winlevelsup field, to the extent possible without catalog change.

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -514,7 +514,6 @@ CTranslatorDXLToScalar::PwindowrefFromDXLNodeScWindowRef
 	WindowRef *pwindowref = MakeNode(WindowRef);
 	pwindowref->winfnoid = CMDIdGPDB::PmdidConvert(pdxlop->PmdidFunc())->OidObjectId();
 	pwindowref->windistinct = pdxlop->FDistinct();
-	pwindowref->winlevelsup = 0;
 	pwindowref->location = -1;
 	pwindowref->winlevel = 0;
 	pwindowref->winspec = pdxlop->UlWinSpecPos();

--- a/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
@@ -1578,10 +1578,6 @@ CTranslatorScalarToDXL::PdxlnScWindowref
 	}
 
 	GPOS_ASSERT(EdxlwinstageSentinel != edxlwinstage && "Invalid window stage");
-	if (0 != pwindowref->winlevelsup)
-	{
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("Window functions with outer references"));
-	}
 
 	CDXLScalarWindowRef *pdxlopWinref = GPOS_NEW(m_pmp) CDXLScalarWindowRef
 													(

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -1471,7 +1471,6 @@ _copyWindowRef(WindowRef *from)
 	COPY_SCALAR_FIELD(winfnoid);
 	COPY_SCALAR_FIELD(restype);
 	COPY_NODE_FIELD(args);
-	COPY_SCALAR_FIELD(winlevelsup);
 	COPY_SCALAR_FIELD(windistinct);
 	COPY_SCALAR_FIELD(winspec);
 	COPY_SCALAR_FIELD(winindex);

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -227,7 +227,6 @@ _equalWindowRef(WindowRef *a, WindowRef *b)
 	COMPARE_SCALAR_FIELD(winfnoid);
 	COMPARE_SCALAR_FIELD(restype);
 	COMPARE_NODE_FIELD(args);
-	COMPARE_SCALAR_FIELD(winlevelsup);
 	COMPARE_SCALAR_FIELD(windistinct);
 	COMPARE_SCALAR_FIELD(winspec);
 	COMPARE_SCALAR_FIELD(winindex);

--- a/src/backend/optimizer/plan/planwindow.c
+++ b/src/backend/optimizer/plan/planwindow.c
@@ -3020,7 +3020,7 @@ static List *make_rowkey_targets()
 	row->winfnoid = ROW_NUMBER_OID;
 	row->restype = ROW_NUMBER_TYPE;
 	row->args = NIL;
-	row->winlevelsup = row->winspec = row->winindex = 0;
+	row->winspec = row->winindex = 0;
 	row->winstage = WINSTAGE_ROWKEY; /* so setrefs doesn't get confused  */
 	row->winlevel = 0;
 	

--- a/src/backend/rewrite/rewriteManip.c
+++ b/src/backend/rewrite/rewriteManip.c
@@ -596,14 +596,6 @@ IncrementVarSublevelsUp_walker(Node *node,
 			agg->agglevelsup += context->delta_sublevels_up;
 		/* fall through to recurse into argument */
 	}
-	if (IsA(node, WindowRef))
-	{
-		WindowRef	   *wref = (WindowRef *) node;
-
-		if (wref->winlevelsup >= context->min_sublevels_up)
-			wref->winlevelsup += context->delta_sublevels_up;
-		/* fall through to recurse into argument */
-	}
 	if (IsA(node, RangeTblEntry))
 	{
 		RangeTblEntry *rte = (RangeTblEntry *) node;

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -336,7 +336,7 @@ typedef struct WindowRef
 	Oid			winfnoid;		/* pg_proc Oid of the window function */
 	Oid			restype;		/* type Oid of result of the window function */
 	List	   *args;			/* arguments */	
-	Index		winlevelsup;	/* > 0 if win belongs to outer query  */
+	Index		winlevelsup;	/* FIXME: unused, but we cannot remove it right now because that would require a catalog change */
 	bool		windistinct;	/* TRUE if it's agg(DISTINCT ...) */
 	Index		winspec;		/* index into Query window clause */
 	


### PR DESCRIPTION
The winlevelsup field isn't used. The reason it's not needed can be summed
up by this comment in PostgreSQL 8.4's transformWindowFunc function:

>  * Unlike aggregates, only the most closely nested pstate level need be
>  * considered --- there are no "outer window functions" per SQL spec.

Second line of reasoning is that the winlevelsup field was always
initialized to 0, and only incremented in the IncrementVarSublevelsUp
function. But that function is only used during planning, so winlevelsup
was always 0 in the parse and parse analysis stage. However, the field was
read only in the parse analysis phase, which means that it was always 0
when it was read.

Third line of reasoning is that the regression tests are happy without it,
and there was a check in the ORCA translator too, that would've thrown
an error if it was ever non-zero.

I left the field in place in the struct, to avoid a catalog change, but it
is now unsued. WindowRef nodes can be stored in catalogs, as part of views,
I believe.