### PR TITLE
Avoid side effects in assertions

### DIFF
--- a/src/backend/cdb/cdbsubselect.c
+++ b/src/backend/cdb/cdbsubselect.c
@@ -1248,7 +1248,7 @@ add_notin_subquery_rte(Query *parse, Query *subselect)
 
 	/* assume new rte is at end */
 	subq_indx = list_length(parse->rtable);
-	Assert(subq_rte = rt_fetch(subq_indx, parse->rtable));
+	Assert(subq_rte == rt_fetch(subq_indx, parse->rtable));
 
 	return subq_indx;
 }
@@ -1290,7 +1290,7 @@ add_expr_subquery_rte(Query *parse, Query *subselect)
 
 	/* assume new rte is at end */
 	subq_indx = list_length(parse->rtable);
-	Assert(subq_rte = rt_fetch(subq_indx, parse->rtable));
+	Assert(subq_rte == rt_fetch(subq_indx, parse->rtable));
 
 	return subq_indx;
 }

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -2573,12 +2573,12 @@ void AssertSliceTableIsValid(SliceTable *st, struct PlannedStmt *pstmt)
 
 	Assert(maxIndex == list_length(st->slices));
 
-	foreach (lc, st->slices)
+	foreach_with_count(lc, st->slices, i)
 	{
 		Slice *s = (Slice *) lfirst(lc);
 
 		/* The n-th slice entry has sliceIndex of n */
-		Assert(s->sliceIndex == i++ && "slice index incorrect");
+		Assert(s->sliceIndex == i && "slice index incorrect");
 
 		/* The root index of a slice is either 0 or is a slice corresponding to an init plan */
 		Assert((s->rootIndex == 0) || (s->rootIndex > st->nMotions && s->rootIndex < maxIndex));

--- a/src/backend/executor/nodeMotion.c
+++ b/src/backend/executor/nodeMotion.c
@@ -674,10 +674,14 @@ execMotionSortedReceiver(MotionState * node)
      */
     else
 	{
-        /* Old element is still at the head of the pq. */
-        AssertState(NULL != (tupHeapInfo = CdbHeap_Min(CdbTupleHeapInfo, hp)) &&
-                    tupHeapInfo->tuple == NULL &&
-                    tupHeapInfo->sourceRouteId == node->routeIdNext);
+#ifdef USE_ASSERT_CHECKING
+		CdbTupleHeapInfo		*t;
+
+		/* Old element is still at the head of the pq. */
+		t = CdbHeap_Min(CdbTupleHeapInfo, hp);
+		Assert(t);
+		AssertState(t->tuple == NULL && t->sourceRouteId == node->routeIdNext);
+#endif
 
         /* Receive the successor of the tuple that we returned last time. */
         recvRC = RecvTupleFrom(node->ps.state->motionlayer_context,


### PR DESCRIPTION
An assertion with a side effect may alter the main codepath when the tree is built with `--enable-cassert`, which in turn may lead to subtle differences due compiler optimizations and/or straight
bugs in the side effect. Rewrite the assertions without side effects to leave the main codepath intact.

This runs green in ICW locally for me with assertions turned on, the PR pipeline will show how it's doing with assertions off.