### PR TITLE
Add new GPDB_EXTRA_COL mechanism to process_col_defaults.pl

### DIFF
--- a/src/backend/catalog/process_col_defaults.pl
+++ b/src/backend/catalog/process_col_defaults.pl
@@ -84,7 +84,7 @@ while (<>)
 	# Parse the DATA line enough to extract the middle part containing
 	# the columns. This leaves the "insert OID = part" in $begin, and
 	# the "));"  in $end.
-	if (m/^(DATA\(.*?\()(.*)(\)\s*\))/) {
+	if (m/^(DATA\(.*?\()(.*)(\)\s*\).*)/) {
 	    my $begin = $1;
 	    my $middle = $2;
 	    my $end = $3;

--- a/src/include/catalog/README.modifying_catalogs
+++ b/src/include/catalog/README.modifying_catalogs
@@ -84,3 +84,6 @@ upstream. You can simply set a default for the additional column,
 and only include the additional column in DATA rows that need a
 non-default value. GPDB_COLUMN_DEFAULTs are processed by
 process_col_defaults.pl script, before generating postgres.bki.
+If you need to provide non-default values for the GPDB-added
+attributes for some rows, you can do so with the GPDB_EXTRA_COL
+macro.

--- a/src/include/catalog/genbki.h
+++ b/src/include/catalog/genbki.h
@@ -35,6 +35,7 @@
 
 /* for process_col_defaults.pl */
 #define GPDB_COLUMN_DEFAULT(col, default) extern int no_such_variable
+#define GPDB_EXTRA_COL(x) extern int no_such_variable
 
 /* for process_foreign_keys.pl */
 #define FOREIGN_KEY(x) extern int no_such_variable

--- a/src/include/catalog/pg_am.h
+++ b/src/include/catalog/pg_am.h
@@ -104,6 +104,7 @@ typedef FormData_pg_am *Form_pg_am;
 #define Anum_pg_am_amstorage			10
 #define Anum_pg_am_amclusterable		11
 #define Anum_pg_am_amcanshrink			12
+GPDB_COLUMN_DEFAULT(pg_am_amcanshrink, t);
 #define Anum_pg_am_aminsert				13
 #define Anum_pg_am_ambeginscan			14
 #define Anum_pg_am_amgettuple			15
@@ -123,18 +124,20 @@ typedef FormData_pg_am *Form_pg_am;
  * ----------------
  */
 
-DATA(insert OID = 403 (  btree	5 1 t t t t t t f t t btinsert btbeginscan btgettuple btgetmulti btrescan btendscan btmarkpos btrestrpos btbuild btbulkdelete btvacuumcleanup btcostestimate btoptions ));
+DATA(insert OID = 403 (  btree	5 1 t t t t t t f t btinsert btbeginscan btgettuple btgetmulti btrescan btendscan btmarkpos btrestrpos btbuild btbulkdelete btvacuumcleanup btcostestimate btoptions ));
 DESCR("b-tree index access method");
 #define BTREE_AM_OID 403
-DATA(insert OID = 405 (  hash	1 1 f f f f f f f f t hashinsert hashbeginscan hashgettuple hashgetmulti hashrescan hashendscan hashmarkpos hashrestrpos hashbuild hashbulkdelete hashvacuumcleanup hashcostestimate hashoptions ));
+DATA(insert OID = 405 (  hash	1 1 f f f f f f f f hashinsert hashbeginscan hashgettuple hashgetmulti hashrescan hashendscan hashmarkpos hashrestrpos hashbuild hashbulkdelete hashvacuumcleanup hashcostestimate hashoptions ));
 DESCR("hash index access method");
 #define HASH_AM_OID 405
-DATA(insert OID = 783 (  gist	0 7 f f t t t t t t t gistinsert gistbeginscan gistgettuple gistgetmulti gistrescan gistendscan gistmarkpos gistrestrpos gistbuild gistbulkdelete gistvacuumcleanup gistcostestimate gistoptions ));
+DATA(insert OID = 783 (  gist	0 7 f f t t t t t t gistinsert gistbeginscan gistgettuple gistgetmulti gistrescan gistendscan gistmarkpos gistrestrpos gistbuild gistbulkdelete gistvacuumcleanup gistcostestimate gistoptions ));
 DESCR("GiST index access method");
 #define GIST_AM_OID 783
-DATA(insert OID = 2742 (  gin	0 4 f f f f f f t f t gininsert ginbeginscan gingettuple gingetmulti ginrescan ginendscan ginmarkpos ginrestrpos ginbuild ginbulkdelete ginvacuumcleanup gincostestimate ginoptions ));
+DATA(insert OID = 2742 (  gin	0 4 f f f f f f t f gininsert ginbeginscan gingettuple gingetmulti ginrescan ginendscan ginmarkpos ginrestrpos ginbuild ginbulkdelete ginvacuumcleanup gincostestimate ginoptions ));
 DESCR("GIN index access method");
 #define GIN_AM_OID 2742
+
+GPDB_EXTRA_COL(pg_am_amcanshrink = f);
 DATA(insert OID = 3013 (  bitmap	5 1 f f t t t f f f f bminsert bmbeginscan bmgettuple bmgetmulti bmrescan bmendscan bmmarkpos bmrestrpos bmbuild bmbulkdelete bmvacuumcleanup bmcostestimate bmoptions ));
 DESCR("bitmap index access method");
 #define BITMAP_AM_OID 3013

--- a/src/include/catalog/pg_proc.h
+++ b/src/include/catalog/pg_proc.h
@@ -1422,7 +1422,7 @@ DATA(insert OID = 1143 (  time_in		   PGNSP PGUID 12 1 0 f f t f s 3 1083 "2275 
 DESCR("I/O");
 DATA(insert OID = 1144 (  time_out		   PGNSP PGUID 12 1 0 f f t f i 1 2275 "1083" _null_ _null_ _null_	time_out - _null_ _null_ ));
 DESCR("I/O");
-DATA(insert OID = 2909 (  timetypmodin   	PGNSP PGUID 12 1 0 f f t f i 1 23 "1263" _null_ _null_ _null_	timetypmodin - _null_ _null_ ));
+DATA(insert OID = 2909 (  timetypmodin		PGNSP PGUID 12 1 0 f f t f i 1 23 "1263" _null_ _null_ _null_	timetypmodin - _null_ _null_ ));
 DESCR("I/O typmod");
 DATA(insert OID = 2910 (  timetypmodout		PGNSP PGUID 12 1 0 f f t f i 1 2275 "23" _null_ _null_ _null_	timetypmodout - _null_ _null_ ));
 DESCR("I/O typmod");
@@ -1442,7 +1442,7 @@ DATA(insert OID = 1150 (  timestamptz_in   PGNSP PGUID 12 1 0 f f t f s 3 1184 "
 DESCR("I/O");
 DATA(insert OID = 1151 (  timestamptz_out  PGNSP PGUID 12 1 0 f f t f s 1 2275 "1184" _null_ _null_ _null_	timestamptz_out - _null_ _null_ ));
 DESCR("I/O");
-DATA(insert OID = 2907 (  timestamptztypmodin   	PGNSP PGUID 12 1 0 f f t f i 1 23 "1263" _null_ _null_ _null_	timestamptztypmodin - _null_ _null_));
+DATA(insert OID = 2907 (  timestamptztypmodin		PGNSP PGUID 12 1 0 f f t f i 1 23 "1263" _null_ _null_ _null_	timestamptztypmodin - _null_ _null_ ));
 DESCR("I/O typmod");
 DATA(insert OID = 2908 (  timestamptztypmodout		PGNSP PGUID 12 1 0 f f t f i 1 2275 "23" _null_ _null_ _null_	timestamptztypmodout - _null_ _null_ ));
 DESCR("I/O typmod");
@@ -1458,7 +1458,8 @@ DATA(insert OID = 1156 (  timestamptz_ge   PGNSP PGUID 12 1 0 f f t f i 2 16 "11
 DESCR("greater-than-or-equal");
 DATA(insert OID = 1157 (  timestamptz_gt   PGNSP PGUID 12 1 0 f f t f i 2 16 "1184 1184" _null_ _null_ _null_ timestamp_gt - _null_ _null_ ));
 DESCR("greater-than");
-DATA(insert OID = 1158 (  to_timestamp	   PGNSP PGUID 14 1 0 0 f f t f i 1 0 1184 f "701" _null_ _null_ _null_ _null_ "select (''epoch''::pg_catalog.timestamptz + $1 * ''1 second''::pg_catalog.interval)" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 1158 (  to_timestamp	   PGNSP PGUID 14 1 0 f f t f i 1 1184 "701" _null_ _null_ _null_ "select (''epoch''::pg_catalog.timestamptz + $1 * ''1 second''::pg_catalog.interval)" - _null_ _null_ ));
 DESCR("convert UNIX epoch to timestamptz");
 DATA(insert OID = 1159 (  timezone		   PGNSP PGUID 12 1 0 f f t f i 2 1114 "25 1184" _null_ _null_ _null_  timestamptz_zone - _null_ _null_ ));
 DESCR("adjust timestamp to new time zone");
@@ -1467,7 +1468,7 @@ DATA(insert OID = 1160 (  interval_in	   PGNSP PGUID 12 1 0 f f t f s 3 1186 "22
 DESCR("I/O");
 DATA(insert OID = 1161 (  interval_out	   PGNSP PGUID 12 1 0 f f t f i 1 2275 "1186" _null_ _null_ _null_	interval_out - _null_ _null_ ));
 DESCR("I/O");
-DATA(insert OID = 2903 (  intervaltypmodin   	PGNSP PGUID 12 1 0 f f t f i 1 23 "1263" _null_ _null_ _null_	intervaltypmodin - _null_ _null_ ));
+DATA(insert OID = 2903 (  intervaltypmodin		PGNSP PGUID 12 1 0 f f t f i 1 23 "1263" _null_ _null_ _null_	intervaltypmodin - _null_ _null_ ));
 DESCR("I/O typmod");
 DATA(insert OID = 2904 (  intervaltypmodout		PGNSP PGUID 12 1 0 f f t f i 1 2275 "23" _null_ _null_ _null_	intervaltypmodout - _null_ _null_ ));
 DESCR("I/O typmod");
@@ -1503,7 +1504,8 @@ DATA(insert OID = 1175 (  justify_hours    PGNSP PGUID 12 1 0 f f t f i 1 1186 "
 DESCR("promote groups of 24 hours to numbers of days");
 DATA(insert OID = 1295 (  justify_days	   PGNSP PGUID 12 1 0 f f t f i 1 1186 "1186" _null_ _null_ _null_	interval_justify_days - _null_ _null_ ));
 DESCR("promote groups of 30 days to numbers of months");
-DATA(insert OID = 1176 (  timestamptz	   PGNSP PGUID 14 1 0 0 f f t f s 2 0 1184 f "1082 1083" _null_ _null_ _null_ _null_ "select cast(($1 + $2) as timestamp with time zone)" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 1176 (  timestamptz	   PGNSP PGUID 14 1 0 f f t f s 2 1184 "1082 1083" _null_ _null_ _null_ "select cast(($1 + $2) as timestamp with time zone)" - _null_ _null_ ));
 DESCR("convert date and time to timestamp with time zone");
 DATA(insert OID = 1177 (  interval		   PGNSP PGUID 12 1 0 f f t f i 1 1186 "703" _null_ _null_ _null_ reltime_interval - _null_ _null_ ));
 DESCR("convert reltime to interval");
@@ -1540,11 +1542,14 @@ DESCR("date difference preserving months and years");
 DATA(insert OID = 1200 (  interval			PGNSP PGUID 12 1 0 f f t f i 2 1186 "1186 23" _null_ _null_ _null_	interval_scale - _null_ _null_ ));
 DESCR("adjust interval precision");
 
-DATA(insert OID = 1215 (  obj_description		   PGNSP PGUID 14 100 0 0 f f t f s 2 0 25 f "26 19" _null_ _null_ _null_ _null_ "select description from pg_catalog.pg_description where objoid = $1 and classoid = (select oid from pg_catalog.pg_class where relname = $2 and relnamespace = PGNSP) and objsubid = 0" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 1215 (  obj_description	PGNSP PGUID 14 100 0 f f t f s 2	25 "26 19" _null_ _null_ _null_ "select description from pg_catalog.pg_description where objoid = $1 and classoid = (select oid from pg_catalog.pg_class where relname = $2 and relnamespace = PGNSP) and objsubid = 0" - _null_ _null_ ));
 DESCR("get description for object id and catalog name");
-DATA(insert OID = 1216 (  col_description		   PGNSP PGUID 14 100 0 0 f f t f s 2 0 25 f "26 23" _null_ _null_ _null_ _null_ "select description from pg_catalog.pg_description where objoid = $1 and classoid = ''pg_catalog.pg_class''::pg_catalog.regclass and objsubid = $2" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 1216 (  col_description	PGNSP PGUID 14 100 0 f f t f s 2	25 "26 23" _null_ _null_ _null_ "select description from pg_catalog.pg_description where objoid = $1 and classoid = ''pg_catalog.pg_class''::pg_catalog.regclass and objsubid = $2" - _null_ _null_ ));
 DESCR("get description for table column");
-DATA(insert OID = 1993 (  shobj_description		   PGNSP PGUID 14 100 0 0 f f t f s 2 0 25 f "26 19" _null_ _null_ _null_ _null_ "select description from pg_catalog.pg_shdescription where objoid = $1 and classoid = (select oid from pg_catalog.pg_class where relname = $2 and relnamespace = PGNSP)" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 1993 ( shobj_description	PGNSP PGUID 14 100 0 f f t f s 2	25 "26 19" _null_ _null_ _null_ "select description from pg_catalog.pg_shdescription where objoid = $1 and classoid = (select oid from pg_catalog.pg_class where relname = $2 and relnamespace = PGNSP)" - _null_ _null_ ));
 DESCR("get description for object id and shared catalog name");
 
 DATA(insert OID = 1217 (  date_trunc	   PGNSP PGUID 12 1 0 f f t f s 2 1184 "25 1184" _null_ _null_ _null_ timestamptz_trunc - _null_ _null_ ));
@@ -1629,11 +1634,13 @@ DESCR("larger of two");
 DATA(insert OID = 2796 ( tidsmaller		   PGNSP PGUID 12 1 0 f f t f i 2 27 "27 27" _null_ _null_ _null_ tidsmaller - _null_ _null_ ));
 DESCR("smaller of two");
 
-DATA(insert OID = 1296 (  timedate_pl	   PGNSP PGUID 14 1 0 0 f f t f i 2 0 1114 f "1083 1082" _null_ _null_ _null_ _null_ "select ($2 + $1)" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 1296 (  timedate_pl	   PGNSP PGUID 14 1 0 f f t f i 2 1114 "1083 1082" _null_ _null_ _null_ "select ($2 + $1)" - _null_ _null_ ));
 DESCR("convert time and date to timestamp");
 DATA(insert OID = 1297 (  datetimetz_pl    PGNSP PGUID 12 1 0 f f t f i 2 1184 "1082 1266" _null_ _null_ _null_ datetimetz_timestamptz - _null_ _null_ ));
 DESCR("convert date and time with time zone to timestamp with time zone");
-DATA(insert OID = 1298 (  timetzdate_pl	   PGNSP PGUID 14 1 0 0 f f t f i 2 0 1184 f "1266 1082" _null_ _null_ _null_ _null_ "select ($2 + $1)" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 1298 (  timetzdate_pl    PGNSP PGUID 14 1 0 f f t f i 2 1184 "1266 1082" _null_ _null_ _null_ "select ($2 + $1)" - _null_ _null_ ));
 DESCR("convert time with time zone and date to timestamp with time zone");
 DATA(insert OID = 1299 (  now			   PGNSP PGUID 12 1 0 f f t f s 0 1184 "" _null_ _null_ _null_	now - _null_ _null_ ));
 DESCR("current transaction time");
@@ -1657,27 +1664,33 @@ DESCR("join selectivity for containment comparison operators");
 
 DATA(insert OID = 1304 ( overlaps			 PGNSP PGUID 12 1 0 f f f f i 4 16 "1184 1184 1184 1184" _null_ _null_ _null_ overlaps_timestamp - _null_ _null_ ));
 DESCR("intervals overlap?");
-DATA(insert OID = 1305 ( overlaps			 PGNSP PGUID 14 1 0 0 f f f f s 4 0 16 f "1184 1186 1184 1186" _null_ _null_ _null_ _null_ "select ($1, ($1 + $2)) overlaps ($3, ($3 + $4))" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 1305 ( overlaps			 PGNSP PGUID 14 1 0 f f f f s 4 16 "1184 1186 1184 1186" _null_ _null_ _null_ "select ($1, ($1 + $2)) overlaps ($3, ($3 + $4))" - _null_ _null_ ));
 DESCR("intervals overlap?");
-DATA(insert OID = 1306 ( overlaps			 PGNSP PGUID 14 1 0 0 f f f f s 4 0 16 f "1184 1184 1184 1186" _null_ _null_ _null_ _null_ "select ($1, $2) overlaps ($3, ($3 + $4))" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 1306 ( overlaps			 PGNSP PGUID 14 1 0 f f f f s 4 16 "1184 1184 1184 1186" _null_ _null_ _null_ "select ($1, $2) overlaps ($3, ($3 + $4))" - _null_ _null_ ));
 DESCR("intervals overlap?");
-DATA(insert OID = 1307 ( overlaps			 PGNSP PGUID 14 1 0 0 f f f f s 4 0 16 f "1184 1186 1184 1184" _null_ _null_ _null_ _null_ "select ($1, ($1 + $2)) overlaps ($3, $4)" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 1307 ( overlaps			 PGNSP PGUID 14 1 0 f f f f s 4 16 "1184 1186 1184 1184" _null_ _null_ _null_ "select ($1, ($1 + $2)) overlaps ($3, $4)" - _null_ _null_ ));
 DESCR("intervals overlap?");
 
 DATA(insert OID = 1308 ( overlaps			 PGNSP PGUID 12 1 0 f f f f i 4 16 "1083 1083 1083 1083" _null_ _null_ _null_ overlaps_time - _null_ _null_ ));
 DESCR("intervals overlap?");
-DATA(insert OID = 1309 ( overlaps			 PGNSP PGUID 14 1 0 0 f f f f i 4 0 16 f "1083 1186 1083 1186" _null_ _null_ _null_ _null_ "select ($1, ($1 + $2)) overlaps ($3, ($3 + $4))" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 1309 ( overlaps			 PGNSP PGUID 14 1 0 f f f f i 4 16 "1083 1186 1083 1186" _null_ _null_ _null_ "select ($1, ($1 + $2)) overlaps ($3, ($3 + $4))" - _null_ _null_ ));
 DESCR("intervals overlap?");
-DATA(insert OID = 1310 ( overlaps			 PGNSP PGUID 14 1 0 0 f f f f i 4 0 16 f "1083 1083 1083 1186" _null_ _null_ _null_ _null_ "select ($1, $2) overlaps ($3, ($3 + $4))" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 1310 ( overlaps			 PGNSP PGUID 14 1 0 f f f f i 4 16 "1083 1083 1083 1186" _null_ _null_ _null_ "select ($1, $2) overlaps ($3, ($3 + $4))" - _null_ _null_ ));
 DESCR("intervals overlap?");
-DATA(insert OID = 1311 ( overlaps			 PGNSP PGUID 14 1 0 0 f f f f i 4 0 16 f "1083 1186 1083 1083" _null_ _null_ _null_ _null_ "select ($1, ($1 + $2)) overlaps ($3, $4)" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 1311 ( overlaps			 PGNSP PGUID 14 1 0 f f f f i 4 16 "1083 1186 1083 1083" _null_ _null_ _null_ "select ($1, ($1 + $2)) overlaps ($3, $4)" - _null_ _null_ ));
 DESCR("intervals overlap?");
 
 DATA(insert OID = 1312 (  timestamp_in		 PGNSP PGUID 12 1 0 f f t f s 3 1114 "2275 26 23" _null_ _null_ _null_ timestamp_in - _null_ _null_ ));
 DESCR("I/O");
 DATA(insert OID = 1313 (  timestamp_out		 PGNSP PGUID 12 1 0 f f t f s 1 2275 "1114" _null_ _null_ _null_ timestamp_out - _null_ _null_ ));
 DESCR("I/O");
-DATA(insert OID = 2905 (  timestamptypmodin   	PGNSP PGUID 12 1 0 f f t f i 1 23 "1263" _null_ _null_ _null_	timestamptypmodin - _null_ _null_ ));
+DATA(insert OID = 2905 (  timestamptypmodin		PGNSP PGUID 12 1 0 f f t f i 1 23 "1263" _null_ _null_ _null_	timestamptypmodin - _null_ _null_ ));
 DESCR("I/O typmod");
 DATA(insert OID = 2906 (  timestamptypmodout	PGNSP PGUID 12 1 0 f f t f i 1 2275 "23" _null_ _null_ _null_	timestamptypmodout - _null_ _null_ ));
 DESCR("I/O typmod");
@@ -1724,7 +1737,8 @@ DESCR("exponential");
  * This form of obj_description is now deprecated, since it will fail if
  * OIDs are not unique across system catalogs.	Use the other forms instead.
  */
-DATA(insert OID = 1348 (  obj_description	 PGNSP PGUID 14 100 0 0 f f t f s 1 0 25 f "26" _null_ _null_ _null_ _null_	"select description from pg_catalog.pg_description where objoid = $1 and objsubid = 0" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 1348 (  obj_description	 PGNSP PGUID 14 100 0 f f t f s 1 25 "26" _null_ _null_ _null_	"select description from pg_catalog.pg_description where objoid = $1 and objsubid = 0" - _null_ _null_ ));
 DESCR("get description for object id (deprecated)");
 DATA(insert OID = 1349 (  oidvectortypes	 PGNSP PGUID 12 1 0 f f t f s 1 25 "30" _null_ _null_ _null_	oidvectortypes - _null_ _null_ ));
 DESCR("print type names of oidvector field");
@@ -1734,7 +1748,7 @@ DATA(insert OID = 1350 (  timetz_in		   PGNSP PGUID 12 1 0 f f t f s 3 1266 "227
 DESCR("I/O");
 DATA(insert OID = 1351 (  timetz_out	   PGNSP PGUID 12 1 0 f f t f i 1 2275 "1266" _null_ _null_ _null_	timetz_out - _null_ _null_ ));
 DESCR("I/O");
-DATA(insert OID = 2911 (  timetztypmodin   	PGNSP PGUID 12 1 0 f f t f i 1 23 "1263" _null_ _null_ _null_	timetztypmodin - _null_ _null_ ));
+DATA(insert OID = 2911 (  timetztypmodin	PGNSP PGUID 12 1 0 f f t f i 1 23 "1263" _null_ _null_ _null_	timetztypmodin - _null_ _null_ ));
 DESCR("I/O typmod");
 DATA(insert OID = 2912 (  timetztypmodout	PGNSP PGUID 12 1 0 f f t f i 1 2275 "23" _null_ _null_ _null_	timetztypmodout - _null_ _null_ ));
 DESCR("I/O typmod");
@@ -1755,7 +1769,8 @@ DESCR("less-equal-greater");
 DATA(insert OID = 1359 (  timestamptz	   PGNSP PGUID 12 1 0 f f t f i 2 1184 "1082 1266" _null_ _null_ _null_ datetimetz_timestamptz - _null_ _null_ ));
 DESCR("convert date and time with time zone to timestamp with time zone");
 
-DATA(insert OID = 1364 (  time			   PGNSP PGUID 14 1 0 0 f f t f s 1 0 1083 f "702" _null_ _null_ _null_ _null_ "select cast(cast($1 as timestamp without time zone) as pg_catalog.time)" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 1364 (  time			   PGNSP PGUID 14 1 0 f f t f s 1 1083 "702" _null_ _null_ _null_  "select cast(cast($1 as timestamp without time zone) as pg_catalog.time)" - _null_ _null_ ));
 DESCR("convert abstime to time");
 
 DATA(insert OID = 1367 (  character_length	PGNSP PGUID 12 1 0 f f t f i 1	23 "1042" _null_ _null_ _null_	bpcharlen - _null_ _null_ ));
@@ -1784,15 +1799,19 @@ DESCR("smaller of two");
 DATA(insert OID = 1381 (  char_length	   PGNSP PGUID 12 1 0 f f t f i 1 23 "25" _null_ _null_ _null_	textlen - _null_ _null_ ));
 DESCR("character length");
 
-DATA(insert OID = 1382 (  date_part 	PGNSP PGUID 14 1 0 0 f f t f s 2 0 701 f "25 702" _null_ _null_ _null_ _null_ "select pg_catalog.date_part($1, cast($2 as timestamp with time zone))" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 1382 (  date_part    PGNSP PGUID 14 1 0 f f t f s 2  701 "25 702" _null_ _null_ _null_	"select pg_catalog.date_part($1, cast($2 as timestamp with time zone))" - _null_ _null_ ));
 DESCR("extract field from abstime");
-DATA(insert OID = 1383 (  date_part 	PGNSP PGUID 14 1 0 0 f f t f s 2 0 701 f "25 703" _null_ _null_ _null_ _null_ "select pg_catalog.date_part($1, cast($2 as pg_catalog.interval))" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 1383 (  date_part    PGNSP PGUID 14 1 0 f f t f s 2  701 "25 703" _null_ _null_ _null_	"select pg_catalog.date_part($1, cast($2 as pg_catalog.interval))" - _null_ _null_ ));
 DESCR("extract field from reltime");
-DATA(insert OID = 1384 (  date_part 	PGNSP PGUID 14 1 0 0 f f t f i 2 0 701 f "25 1082" _null_ _null_ _null_ _null_ "select pg_catalog.date_part($1, cast($2 as timestamp without time zone))" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 1384 (  date_part    PGNSP PGUID 14 1 0 f f t f i 2  701 "25 1082" _null_ _null_ _null_ "select pg_catalog.date_part($1, cast($2 as timestamp without time zone))" - _null_ _null_ ));
 DESCR("extract field from date");
 DATA(insert OID = 1385 (  date_part    PGNSP PGUID 12 1 0 f f t f i 2  701 "25 1083" _null_ _null_ _null_  time_part - _null_ _null_ ));
 DESCR("extract field from time");
-DATA(insert OID = 1386 (  age		   PGNSP PGUID 14 1 0 0 f f t f s 1 0 1186 f "1184" _null_ _null_ _null_ _null_ "select pg_catalog.age(cast(current_date as timestamp with time zone), $1)" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 1386 (  age		   PGNSP PGUID 14 1 0 f f t f s 1 1186 "1184" _null_ _null_ _null_	"select pg_catalog.age(cast(current_date as timestamp with time zone), $1)" - _null_ _null_ ));
 DESCR("date difference from today preserving months and years");
 
 DATA(insert OID = 1388 (  timetz	   PGNSP PGUID 12 1 0 f f t f s 1 1266 "1184" _null_ _null_ _null_	timestamptz_timetz - _null_ _null_ ));
@@ -1829,9 +1848,11 @@ DESCR("current schema name");
 DATA(insert OID = 1403 (  current_schemas	PGNSP PGUID 12 1 0 f f t f s 1	1003 "16" _null_ _null_ _null_	current_schemas - _null_ _null_ ));
 DESCR("current schema search list");
 
-DATA(insert OID = 1404 (  overlay			PGNSP PGUID 14 1 0 0 f f t f i 4 0 25 f "25 25 23 23" _null_ _null_ _null_ _null_ "select pg_catalog.substring($1, 1, ($3 - 1)) || $2 || pg_catalog.substring($1, ($3 + $4))" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 1404 (  overlay			PGNSP PGUID 14 1 0 f f t f i 4 25 "25 25 23 23" _null_ _null_ _null_	"select pg_catalog.substring($1, 1, ($3 - 1)) || $2 || pg_catalog.substring($1, ($3 + $4))" - _null_ _null_ ));
 DESCR("substitute portion of string");
-DATA(insert OID = 1405 (  overlay			PGNSP PGUID 14 1 0 0 f f t f i 3 0 25 f "25 25 23" _null_ _null_ _null_ _null_ "select pg_catalog.substring($1, 1, ($3 - 1)) || $2 || pg_catalog.substring($1, ($3 + pg_catalog.char_length($2)))" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 1405 (  overlay			PGNSP PGUID 14 1 0 f f t f i 3 25 "25 25 23" _null_ _null_ _null_  "select pg_catalog.substring($1, 1, ($3 - 1)) || $2 || pg_catalog.substring($1, ($3 + pg_catalog.char_length($2)))" - _null_ _null_ ));
 DESCR("substitute portion of string");
 
 DATA(insert OID = 1406 (  isvertical		PGNSP PGUID 12 1 0 f f t f i 2	16 "600 600" _null_ _null_ _null_  point_vert - _null_ _null_ ));
@@ -1870,7 +1891,8 @@ DATA(insert OID = 1424 (  box_mul			PGNSP PGUID 12 1 0 f f t f i 2 603 "603 600"
 DESCR("multiply box by point (scale)");
 DATA(insert OID = 1425 (  box_div			PGNSP PGUID 12 1 0 f f t f i 2 603 "603 600" _null_ _null_ _null_ box_div - _null_ _null_ ));
 DESCR("divide box by point (scale)");
-DATA(insert OID = 1426 (  path_contain_pt	PGNSP PGUID 14 1 0 0 f f t f i 2 0 16 f "602 600" _null_ _null_ _null_ _null_ "select pg_catalog.on_ppath($2, $1)" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 1426 (  path_contain_pt	PGNSP PGUID 14 1 0 f f t f i 2	16 "602 600" _null_ _null_ _null_  "select pg_catalog.on_ppath($2, $1)" - _null_ _null_ ));
 DESCR("path contains point?");
 DATA(insert OID = 1428 (  poly_contain_pt	PGNSP PGUID 12 1 0 f f t f i 2	16 "604 600" _null_ _null_ _null_  poly_contain_pt - _null_ _null_ ));
 DESCR("polygon contains point?");
@@ -2050,7 +2072,8 @@ DATA(insert OID = 1542 (  center			PGNSP PGUID 12 1 0 f f t f i 1 600 "603" _nul
 DESCR("center of");
 DATA(insert OID = 1543 (  center			PGNSP PGUID 12 1 0 f f t f i 1 600 "718" _null_ _null_ _null_ circle_center - _null_ _null_ ));
 DESCR("center of");
-DATA(insert OID = 1544 (  polygon			PGNSP PGUID 14 1 0 0 f f t f i 1 0 604 f "718" _null_ _null_ _null_ _null_ "select pg_catalog.polygon(12, $1)" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 1544 (  polygon			PGNSP PGUID 14 1 0 f f t f i 1 604 "718" _null_ _null_ _null_ "select pg_catalog.polygon(12, $1)" - _null_ _null_ ));
 DESCR("convert circle to 12-vertex polygon");
 DATA(insert OID = 1545 (  npoints			PGNSP PGUID 12 1 0 f f t f i 1	23 "602" _null_ _null_ _null_  path_npoints - _null_ _null_ ));
 DESCR("number of points in path");
@@ -2061,7 +2084,7 @@ DATA(insert OID = 1564 (  bit_in			PGNSP PGUID 12 1 0 f f t f i 3 1560 "2275 26 
 DESCR("I/O");
 DATA(insert OID = 1565 (  bit_out			PGNSP PGUID 12 1 0 f f t f i 1 2275 "1560" _null_ _null_ _null_ bit_out - _null_ _null_ ));
 DESCR("I/O");
-DATA(insert OID = 2919 (  bittypmodin   	PGNSP PGUID 12 1 0 f f t f i 1 23 "1263" _null_ _null_ _null_	bittypmodin - _null_ _null_ ));
+DATA(insert OID = 2919 (  bittypmodin		PGNSP PGUID 12 1 0 f f t f i 1 23 "1263" _null_ _null_ _null_	bittypmodin - _null_ _null_ ));
 DESCR("I/O typmod");
 DATA(insert OID = 2920 (  bittypmodout		PGNSP PGUID 12 1 0 f f t f i 1 2275 "23" _null_ _null_ _null_	bittypmodout - _null_ _null_ ));
 DESCR("I/O typmod");
@@ -2090,7 +2113,7 @@ DATA(insert OID = 1579 (  varbit_in			PGNSP PGUID 12 1 0 f f t f i 3 1562 "2275 
 DESCR("I/O");
 DATA(insert OID = 1580 (  varbit_out		PGNSP PGUID 12 1 0 f f t f i 1 2275 "1562" _null_ _null_ _null_ varbit_out - _null_ _null_ ));
 DESCR("I/O");
-DATA(insert OID = 2902 (  varbittypmodin   	PGNSP PGUID 12 1 0 f f t f i 1 23 "1263" _null_ _null_ _null_	varbittypmodin - _null_ _null_ ));
+DATA(insert OID = 2902 (  varbittypmodin	PGNSP PGUID 12 1 0 f f t f i 1 23 "1263" _null_ _null_ _null_	varbittypmodin - _null_ _null_ ));
 DESCR("I/O typmod");
 DATA(insert OID = 2921 (  varbittypmodout	PGNSP PGUID 12 1 0 f f t f i 1 2275 "23" _null_ _null_ _null_	varbittypmodout - _null_ _null_ ));
 DESCR("I/O typmod");
@@ -2208,9 +2231,11 @@ DATA(insert OID =  877 (  substr	   PGNSP PGUID 12 1 0 f f t f i 3 25 "25 23 23"
 DESCR("return portion of string");
 DATA(insert OID =  878 (  translate    PGNSP PGUID 12 1 0 f f t f i 3 25 "25 25 25" _null_ _null_ _null_	translate - _null_ _null_ ));
 DESCR("map a set of character appearing in string");
-DATA(insert OID =  879 (  lpad		   PGNSP PGUID 14 1 0 0 f f t f i 2 0 25 f "25 23" _null_ _null_ _null_ _null_ "select pg_catalog.lpad($1, $2, '' '')" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID =  879 (  lpad		   PGNSP PGUID 14 1 0 f f t f i 2 25 "25 23" _null_ _null_ _null_ "select pg_catalog.lpad($1, $2, '' '')" - _null_ _null_ ));
 DESCR("left-pad string to length");
-DATA(insert OID =  880 (  rpad		   PGNSP PGUID 14 1 0 0 f f t f i 2 0 25 f "25 23" _null_ _null_ _null_ _null_ "select pg_catalog.rpad($1, $2, '' '')" - _null_  _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID =  880 (  rpad		   PGNSP PGUID 14 1 0 f f t f i 2 25 "25 23" _null_ _null_ _null_ "select pg_catalog.rpad($1, $2, '' '')" - _null_ _null_ ));
 DESCR("right-pad string to length");
 DATA(insert OID =  881 (  ltrim		   PGNSP PGUID 12 1 0 f f t f i 1 25 "25" _null_ _null_ _null_	ltrim1 - _null_ _null_ ));
 DESCR("trim spaces from left end of string");
@@ -2318,29 +2343,41 @@ DESCR("identity argument list of a function");
 
 
 /* Generic referential integrity constraint triggers */
-DATA(insert OID = 1644 (  RI_FKey_check_ins		PGNSP PGUID 12 1 0 0 f f t f v 0 0 2279 f "" _null_ _null_ _null_ _null_ RI_FKey_check_ins - _null_ _null_ m ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = m);
+DATA(insert OID = 1644 (  RI_FKey_check_ins		PGNSP PGUID 12 1 0 f f t f v 0 2279 "" _null_ _null_ _null_ RI_FKey_check_ins - _null_ _null_ ));
 DESCR("referential integrity FOREIGN KEY ... REFERENCES");
-DATA(insert OID = 1645 (  RI_FKey_check_upd		PGNSP PGUID 12 1 0 0 f f t f v 0 0 2279 f "" _null_ _null_ _null_ _null_ RI_FKey_check_upd - _null_ _null_ m ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = m);
+DATA(insert OID = 1645 (  RI_FKey_check_upd		PGNSP PGUID 12 1 0 f f t f v 0 2279 "" _null_ _null_ _null_ RI_FKey_check_upd - _null_ _null_ ));
 DESCR("referential integrity FOREIGN KEY ... REFERENCES");
-DATA(insert OID = 1646 (  RI_FKey_cascade_del	PGNSP PGUID 12 1 0 0 f f t f v 0 0 2279 f "" _null_ _null_ _null_ _null_ RI_FKey_cascade_del - _null_ _null_ m ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = m);
+DATA(insert OID = 1646 (  RI_FKey_cascade_del	PGNSP PGUID 12 1 0 f f t f v 0 2279 "" _null_ _null_ _null_ RI_FKey_cascade_del - _null_ _null_ ));
 DESCR("referential integrity ON DELETE CASCADE");
-DATA(insert OID = 1647 (  RI_FKey_cascade_upd	PGNSP PGUID 12 1 0 0 f f t f v 0 0 2279 f "" _null_ _null_ _null_ _null_ RI_FKey_cascade_upd - _null_ _null_ m ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = m);
+DATA(insert OID = 1647 (  RI_FKey_cascade_upd	PGNSP PGUID 12 1 0 f f t f v 0 2279 "" _null_ _null_ _null_ RI_FKey_cascade_upd - _null_ _null_ ));
 DESCR("referential integrity ON UPDATE CASCADE");
-DATA(insert OID = 1648 (  RI_FKey_restrict_del	PGNSP PGUID 12 1 0 0 f f t f v 0 0 2279 f "" _null_ _null_ _null_ _null_ RI_FKey_restrict_del - _null_ _null_ m ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = m);
+DATA(insert OID = 1648 (  RI_FKey_restrict_del	PGNSP PGUID 12 1 0 f f t f v 0 2279 "" _null_ _null_ _null_ RI_FKey_restrict_del - _null_ _null_ ));
 DESCR("referential integrity ON DELETE RESTRICT");
-DATA(insert OID = 1649 (  RI_FKey_restrict_upd	PGNSP PGUID 12 1 0 0 f f t f v 0 0 2279 f "" _null_ _null_ _null_ _null_ RI_FKey_restrict_upd - _null_ _null_ m ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = m);
+DATA(insert OID = 1649 (  RI_FKey_restrict_upd	PGNSP PGUID 12 1 0 f f t f v 0 2279 "" _null_ _null_ _null_ RI_FKey_restrict_upd - _null_ _null_ ));
 DESCR("referential integrity ON UPDATE RESTRICT");
-DATA(insert OID = 1650 (  RI_FKey_setnull_del	PGNSP PGUID 12 1 0 0 f f t f v 0 0 2279 f "" _null_ _null_ _null_ _null_ RI_FKey_setnull_del - _null_ _null_ m ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = m);
+DATA(insert OID = 1650 (  RI_FKey_setnull_del	PGNSP PGUID 12 1 0 f f t f v 0 2279 "" _null_ _null_ _null_ RI_FKey_setnull_del - _null_ _null_ ));
 DESCR("referential integrity ON DELETE SET NULL");
-DATA(insert OID = 1651 (  RI_FKey_setnull_upd	PGNSP PGUID 12 1 0 0 f f t f v 0 0 2279 f "" _null_ _null_ _null_ _null_ RI_FKey_setnull_upd - _null_ _null_ m ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = m);
+DATA(insert OID = 1651 (  RI_FKey_setnull_upd	PGNSP PGUID 12 1 0 f f t f v 0 2279 "" _null_ _null_ _null_ RI_FKey_setnull_upd - _null_ _null_ ));
 DESCR("referential integrity ON UPDATE SET NULL");
-DATA(insert OID = 1652 (  RI_FKey_setdefault_del PGNSP PGUID 12 1 0 0 f f t f v 0 0 2279 f "" _null_ _null_ _null_ _null_ RI_FKey_setdefault_del - _null_ _null_ m ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = m);
+DATA(insert OID = 1652 (  RI_FKey_setdefault_del PGNSP PGUID 12 1 0 f f t f v 0 2279 "" _null_ _null_ _null_ RI_FKey_setdefault_del - _null_ _null_ ));
 DESCR("referential integrity ON DELETE SET DEFAULT");
-DATA(insert OID = 1653 (  RI_FKey_setdefault_upd PGNSP PGUID 12 1 0 0 f f t f v 0 0 2279 f "" _null_ _null_ _null_ _null_ RI_FKey_setdefault_upd - _null_ _null_ m ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = m);
+DATA(insert OID = 1653 (  RI_FKey_setdefault_upd PGNSP PGUID 12 1 0 f f t f v 0 2279 "" _null_ _null_ _null_ RI_FKey_setdefault_upd - _null_ _null_ ));
 DESCR("referential integrity ON UPDATE SET DEFAULT");
-DATA(insert OID = 1654 (  RI_FKey_noaction_del PGNSP PGUID 12 1 0 0 f f t f v 0 0 2279 f "" _null_ _null_ _null_ _null_ RI_FKey_noaction_del - _null_ _null_ m ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = m);
+DATA(insert OID = 1654 (  RI_FKey_noaction_del PGNSP PGUID 12 1 0 f f t f v 0 2279 "" _null_ _null_ _null_	RI_FKey_noaction_del - _null_ _null_ ));
 DESCR("referential integrity ON DELETE NO ACTION");
-DATA(insert OID = 1655 (  RI_FKey_noaction_upd PGNSP PGUID 12 1 0 0 f f t f v 0 0 2279 f "" _null_ _null_ _null_ _null_ RI_FKey_noaction_upd - _null_ _null_ m ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = m);
+DATA(insert OID = 1655 (  RI_FKey_noaction_upd PGNSP PGUID 12 1 0 f f t f v 0 2279 "" _null_ _null_ _null_	RI_FKey_noaction_upd - _null_ _null_ ));
 DESCR("referential integrity ON UPDATE NO ACTION");
 
 DATA(insert OID = 1666 (  varbiteq			PGNSP PGUID 12 1 0 f f t f i 2 16 "1562 1562" _null_ _null_ _null_	biteq - _null_ _null_ ));
@@ -2390,7 +2427,8 @@ DESCR("adjust varbit() to typmod length");
 
 DATA(insert OID = 1698 (  position		   PGNSP PGUID 12 1 0 f f t f i 2 23 "1560 1560" _null_ _null_ _null_ bitposition - _null_ _null_ ));
 DESCR("return position of sub-bitstring");
-DATA(insert OID = 1699 (  substring			PGNSP PGUID 14 1 0 0 f f t f i 2 0 1560 f "1560 23" _null_ _null_ _null_ _null_ "select pg_catalog.substring($1, $2, -1)" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 1699 (  substring			PGNSP PGUID 14 1 0 f f t f i 2 1560 "1560 23" _null_ _null_ _null_	"select pg_catalog.substring($1, $2, -1)" - _null_ _null_ ));
 DESCR("return portion of bitstring");
 
 
@@ -2499,7 +2537,8 @@ DATA(insert OID = 2629 (  inetor			PGNSP PGUID 12 1 0 f f t f i 2 869 "869 869" 
 DESCR("bitwise or");
 DATA(insert OID = 2630 (  inetpl			PGNSP PGUID 12 1 0 f f t f i 2 869 "869 20" _null_ _null_ _null_	inetpl - _null_ _null_ ));
 DESCR("add integer to inet value");
-DATA(insert OID = 2631 (  int8pl_inet		PGNSP PGUID 14 1 0 0 f f t f i 2 0 869 f "20 869" _null_ _null_ _null_ _null_	"select $2 + $1" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 2631 (  int8pl_inet		PGNSP PGUID 14 1 0 f f t f i 2 869 "20 869" _null_ _null_ _null_	"select $2 + $1" - _null_ _null_ ));
 DESCR("add integer to inet value");
 DATA(insert OID = 2632 (  inetmi_int8		PGNSP PGUID 12 1 0 f f t f i 2 869 "869 20" _null_ _null_ _null_	inetmi_int8 - _null_ _null_ ));
 DESCR("subtract integer from inet value");
@@ -2529,7 +2568,7 @@ DATA(insert OID = 1701 ( numeric_in				PGNSP PGUID 12 1 0 f f t f i 3 1700 "2275
 DESCR("I/O");
 DATA(insert OID = 1702 ( numeric_out			PGNSP PGUID 12 1 0 f f t f i 1 2275 "1700" _null_ _null_ _null_ numeric_out - _null_ _null_ ));
 DESCR("I/O");
-DATA(insert OID = 2917 (  numerictypmodin   	PGNSP PGUID 12 1 0 f f t f i 1 23 "1263" _null_ _null_ _null_	numerictypmodin - _null_ _null_ ));
+DATA(insert OID = 2917 (  numerictypmodin		PGNSP PGUID 12 1 0 f f t f i 1 23 "1263" _null_ _null_ _null_	numerictypmodin - _null_ _null_ ));
 DESCR("I/O typmod");
 DATA(insert OID = 2918 (  numerictypmodout		PGNSP PGUID 12 1 0 f f t f i 1 2275 "23" _null_ _null_ _null_	numerictypmodout - _null_ _null_ ));
 DESCR("I/O typmod");
@@ -2543,11 +2582,13 @@ DATA(insert OID = 1706 ( sign					PGNSP PGUID 12 1 0 f f t f i 1 1700 "1700" _nu
 DESCR("sign of value");
 DATA(insert OID = 1707 ( round					PGNSP PGUID 12 1 0 f f t f i 2 1700 "1700 23" _null_ _null_ _null_	numeric_round - _null_ _null_ ));
 DESCR("value rounded to 'scale'");
-DATA(insert OID = 1708 ( round					PGNSP PGUID 14 1 0 0 f f t f i 1 0 1700 f "1700" _null_ _null_ _null_ _null_ "select pg_catalog.round($1,0)" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 1708 ( round					PGNSP PGUID 14 1 0 f f t f i 1 1700 "1700" _null_ _null_ _null_ "select pg_catalog.round($1,0)" - _null_ _null_ ));
 DESCR("value rounded to 'scale' of zero");
 DATA(insert OID = 1709 ( trunc					PGNSP PGUID 12 1 0 f f t f i 2 1700 "1700 23" _null_ _null_ _null_	numeric_trunc - _null_ _null_ ));
 DESCR("value truncated to 'scale'");
-DATA(insert OID = 1710 ( trunc					PGNSP PGUID 14 1 0 0 f f t f i 1 0 1700 f "1700" _null_ _null_ _null_ _null_ "select pg_catalog.trunc($1,0)" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 1710 ( trunc					PGNSP PGUID 14 1 0 f f t f i 1 1700 "1700" _null_ _null_ _null_ "select pg_catalog.trunc($1,0)" - _null_ _null_ ));
 DESCR("value truncated to 'scale' of zero");
 DATA(insert OID = 1711 ( ceil					PGNSP PGUID 12 1 0 f f t f i 1 1700 "1700" _null_ _null_ _null_ numeric_ceil - _null_ _null_ ));
 DESCR("smallest integer >= value");
@@ -2603,7 +2644,8 @@ DATA(insert OID = 1739 ( numeric_power			PGNSP PGUID 12 1 0 f f t f i 2 1700 "17
 DESCR("m raised to the power of n");
 DATA(insert OID = 1740 ( numeric				PGNSP PGUID 12 1 0 f f t f i 1 1700 "23" _null_ _null_ _null_ int4_numeric - _null_ _null_ ));
 DESCR("(internal)");
-DATA(insert OID = 1741 ( log					PGNSP PGUID 14 1 0 0 f f t f i 1 0 1700 f "1700" _null_ _null_ _null_ _null_ "select pg_catalog.log(10, $1)" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 1741 ( log					PGNSP PGUID 14 1 0 f f t f i 1 1700 "1700" _null_ _null_ _null_ "select pg_catalog.log(10, $1)" - _null_ _null_ ));
 DESCR("logarithm base 10 of n");
 DATA(insert OID = 1742 ( numeric				PGNSP PGUID 12 1 0 f f t f i 1 1700 "700" _null_ _null_ _null_	float4_numeric - _null_ _null_ ));
 DESCR("(internal)");
@@ -2685,11 +2727,14 @@ DATA(insert OID = 1799 (  oidout		   PGNSP PGUID 12 1 0 f f t f i 1 2275 "26" _n
 DESCR("I/O");
 
 
-DATA(insert OID = 1810 (  bit_length	   PGNSP PGUID 14 1 0 0 f f t f i 1 0 23 f "17" _null_ _null_ _null_ _null_ "select pg_catalog.octet_length($1) * 8" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 1810 (  bit_length	   PGNSP PGUID 14 1 0 f f t f i 1 23 "17" _null_ _null_ _null_ "select pg_catalog.octet_length($1) * 8" - _null_ _null_ ));
 DESCR("length in bits");
-DATA(insert OID = 1811 (  bit_length	   PGNSP PGUID 14 1 0 0 f f t f i 1 0 23 f "25" _null_ _null_ _null_ _null_ "select pg_catalog.octet_length($1) * 8" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 1811 (  bit_length	   PGNSP PGUID 14 1 0 f f t f i 1 23 "25" _null_ _null_ _null_ "select pg_catalog.octet_length($1) * 8" - _null_ _null_ ));
 DESCR("length in bits");
-DATA(insert OID = 1812 (  bit_length	   PGNSP PGUID 14 1 0 0 f f t f i 1 0 23 f "1560" _null_ _null_ _null_ _null_ "select pg_catalog.length($1)" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 1812 (  bit_length	   PGNSP PGUID 14 1 0 f f t f i 1 23 "1560" _null_ _null_ _null_ "select pg_catalog.length($1)" - _null_ _null_ ));
 DESCR("length in bits");
 
 /* Selectivity estimators for LIKE and related operators */
@@ -2806,7 +2851,8 @@ DESCR("encode text from encoding to ASCII text");
 DATA(insert OID = 1847 ( to_ascii	PGNSP PGUID 12 1 0 f f t f i 2	25 "25 19" _null_ _null_ _null_ to_ascii_encname - _null_ _null_ ));
 DESCR("encode text from encoding to ASCII text");
 
-DATA(insert OID = 1848 ( interval_pl_time	PGNSP PGUID 14 1 0 0 f f t f i 2 0 1083 f "1186 1083" _null_ _null_ _null_ _null_	"select $2 + $1" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 1848 ( interval_pl_time	PGNSP PGUID 14 1 0 f f t f i 2 1083 "1186 1083" _null_ _null_ _null_	"select $2 + $1" - _null_ _null_ ));
 DESCR("plus");
 
 DATA(insert OID = 1850 (  int28eq		   PGNSP PGUID 12 1 0 f f t f i 2 16 "21 20" _null_ _null_ _null_ int28eq - _null_ _null_ ));
@@ -3100,11 +3146,14 @@ DATA(insert OID = 2039 (  timestamp_hash	PGNSP PGUID 12 1 0 f f t f i 1	23 "1114
 DESCR("hash");
 DATA(insert OID = 2041 ( overlaps			PGNSP PGUID 12 1 0 f f f f i 4 16 "1114 1114 1114 1114" _null_ _null_ _null_	overlaps_timestamp - _null_ _null_ ));
 DESCR("intervals overlap?");
-DATA(insert OID = 2042 ( overlaps			PGNSP PGUID 14 1 0 0 f f f f i 4 0 16 f "1114 1186 1114 1186" _null_ _null_ _null_ _null_	"select ($1, ($1 + $2)) overlaps ($3, ($3 + $4))" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 2042 ( overlaps			PGNSP PGUID 14 1 0 f f f f i 4 16 "1114 1186 1114 1186" _null_ _null_ _null_	"select ($1, ($1 + $2)) overlaps ($3, ($3 + $4))" - _null_ _null_ ));
 DESCR("intervals overlap?");
-DATA(insert OID = 2043 ( overlaps			PGNSP PGUID 14 1 0 0 f f f f i 4 0 16 f "1114 1114 1114 1186" _null_ _null_ _null_ _null_	"select ($1, $2) overlaps ($3, ($3 + $4))" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 2043 ( overlaps			PGNSP PGUID 14 1 0 f f f f i 4 16 "1114 1114 1114 1186" _null_ _null_ _null_	"select ($1, $2) overlaps ($3, ($3 + $4))" - _null_ _null_ ));
 DESCR("intervals overlap?");
-DATA(insert OID = 2044 ( overlaps			PGNSP PGUID 14 1 0 0 f f f f i 4 0 16 f "1114 1186 1114 1114" _null_ _null_ _null_ _null_	"select ($1, ($1 + $2)) overlaps ($3, $4)" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 2044 ( overlaps			PGNSP PGUID 14 1 0 f f f f i 4 16 "1114 1186 1114 1114" _null_ _null_ _null_	"select ($1, ($1 + $2)) overlaps ($3, $4)" - _null_ _null_ ));
 DESCR("intervals overlap?");
 DATA(insert OID = 2045 (  timestamp_cmp		PGNSP PGUID 12 1 0 f f t f i 2	23 "1114 1114" _null_ _null_ _null_ timestamp_cmp - _null_ _null_ ));
 DESCR("less-equal-greater");
@@ -3130,7 +3179,8 @@ DATA(insert OID = 2057 (  timestamp_gt		PGNSP PGUID 12 1 0 f f t f i 2 16 "1114 
 DESCR("greater-than");
 DATA(insert OID = 2058 (  age				PGNSP PGUID 12 1 0 f f t f i 2 1186 "1114 1114" _null_ _null_ _null_	timestamp_age - _null_ _null_ ));
 DESCR("date difference preserving months and years");
-DATA(insert OID = 2059 (  age				PGNSP PGUID 14 1 0 0 f f t f s 1 0 1186 f "1114" _null_ _null_ _null_ _null_ "select pg_catalog.age(cast(current_date as timestamp without time zone), $1)" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 2059 (  age				PGNSP PGUID 14 1 0 f f t f s 1 1186 "1114" _null_ _null_ _null_ "select pg_catalog.age(cast(current_date as timestamp without time zone), $1)" - _null_ _null_ ));
 DESCR("date difference from today preserving months and years");
 
 DATA(insert OID = 2069 (  timezone			PGNSP PGUID 12 1 0 f f t f i 2 1184 "25 1114" _null_ _null_ _null_	timestamp_zone - _null_ _null_ ));
@@ -3144,7 +3194,8 @@ DESCR("subtract");
 
 DATA(insert OID = 2073 (  substring			PGNSP PGUID 12 1 0 f f t f i 2 25 "25 25" _null_ _null_ _null_	textregexsubstr - _null_ _null_ ));
 DESCR("extracts text matching regular expression");
-DATA(insert OID = 2074 (  substring			PGNSP PGUID 14 1 0 0 f f t f i 3 0 25 f "25 25 25" _null_ _null_ _null_ _null_ "select pg_catalog.substring($1, pg_catalog.similar_escape($2, $3))" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 2074 (  substring			PGNSP PGUID 14 1 0 f f t f i 3 25 "25 25 25" _null_ _null_ _null_ "select pg_catalog.substring($1, pg_catalog.similar_escape($2, $3))" - _null_ _null_ ));
 DESCR("extracts text matching SQL99 regular expression");
 
 DATA(insert OID = 2075 (  bit				PGNSP PGUID 12 1 0 f f t f i 2 1560 "20 23" _null_ _null_ _null_	bitfromint8 - _null_ _null_ ));
@@ -3158,7 +3209,8 @@ DATA(insert OID = 2078 (  set_config		PGNSP PGUID 12 1 0 f f f f v 3 25 "25 25 1
 DESCR("SET X as a function");
 DATA(insert OID = 2084 (  pg_show_all_settings	PGNSP PGUID 12 1 1000 f f t t s 0 2249 "" _null_ _null_ _null_ show_all_settings - _null_ _null_ ));
 DESCR("SHOW ALL as a function");
-DATA(insert OID = 1371 (  pg_lock_status   PGNSP PGUID 12 1 1000 0 f f t t v 0 0 2249 f "" _null_ _null_ _null_ _null_ pg_lock_status - _null_ _null_ r ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = r);
+DATA(insert OID = 1371 (  pg_lock_status   PGNSP PGUID 12 1 1000 f f t t v 0 2249 "" _null_ _null_ _null_ pg_lock_status - _null_ _null_ ));
 DESCR("view system lock information");
 DATA(insert OID = 1065 (  pg_prepared_xact PGNSP PGUID 12 1 1000 f f t t v 0 2249 "" _null_ _null_ _null_ pg_prepared_xact - _null_ _null_ ));
 DESCR("view two-phase transactions");
@@ -3939,11 +3991,16 @@ DATA(insert OID = 2243 ( bit_or						   PGNSP PGUID 12 1 0 t f f f i 1 1560 "156
 DESCR("bitwise-or bit aggregate");
 
 /* formerly-missing interval + datetime operators */
-DATA(insert OID = 2546 ( interval_pl_date			PGNSP PGUID 14 1 0 0 f f t f i 2 0 1114 f "1186 1082" _null_ _null_ _null_ _null_ "select $2 + $1" - _null_ _null_ c ));
-DATA(insert OID = 2547 ( interval_pl_timetz			PGNSP PGUID 14 1 0 0 f f t f i 2 0 1266 f "1186 1266" _null_ _null_ _null_ _null_ "select $2 + $1" - _null_ _null_ c ));
-DATA(insert OID = 2548 ( interval_pl_timestamp			PGNSP PGUID 14 1 0 0 f f t f i 2 0 1114 f "1186 1114" _null_ _null_ _null_ _null_ "select $2 + $1" - _null_ _null_ c ));
-DATA(insert OID = 2549 ( interval_pl_timestamptz			PGNSP PGUID 14 1 0 0 f f t f s 2 0 1184 f "1186 1184" _null_ _null_ _null_ _null_ "select $2 + $1" - _null_ _null_ c ));
-DATA(insert OID = 2550 ( integer_pl_date			PGNSP PGUID 14 1 0 0 f f t f i 2 0 1082 f "23 1082" _null_ _null_ _null_ _null_ "select $2 + $1" - _null_ _null_ c ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 2546 ( interval_pl_date			PGNSP PGUID 14 1 0 f f t f i 2 1114 "1186 1082" _null_ _null_ _null_	"select $2 + $1" - _null_ _null_ ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 2547 ( interval_pl_timetz			PGNSP PGUID 14 1 0 f f t f i 2 1266 "1186 1266" _null_ _null_ _null_	"select $2 + $1" - _null_ _null_ ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 2548 ( interval_pl_timestamp		PGNSP PGUID 14 1 0 f f t f i 2 1114 "1186 1114" _null_ _null_ _null_	"select $2 + $1" - _null_ _null_ ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 2549 ( interval_pl_timestamptz	PGNSP PGUID 14 1 0 f f t f s 2 1184 "1186 1184" _null_ _null_ _null_	"select $2 + $1" - _null_ _null_ ));
+GPDB_EXTRA_COL(pg_proc_prodataaccess = c);
+DATA(insert OID = 2550 ( integer_pl_date			PGNSP PGUID 14 1 0 f f t f i 2 1082 "23 1082" _null_ _null_ _null_	"select $2 + $1" - _null_ _null_ ));
 
 DATA(insert OID = 2556 ( pg_tablespace_databases	PGNSP PGUID 12 1 1000 f f t t s 1 26 "26" _null_ _null_ _null_ pg_tablespace_databases - _null_ _null_ ));
 DESCR("returns database oids in a tablespace");
@@ -4086,7 +4143,7 @@ DATA(insert OID = 2895 (  xmlcomment	   PGNSP PGUID 12 1 0 f f t f i 1 142 "25" 
 DESCR("generate an XML comment");
 DATA(insert OID = 2896 (  xml			   PGNSP PGUID 12 1 0 f f t f i 1 142 "25" _null_ _null_ _null_ texttoxml - _null_ _null_ ));
 DESCR("perform a non-validating parse of a character string to produce an XML value");
-DATA(insert OID = 2987 (  xmlvalidate 	   PGNSP PGUID 12 1 0 f f t f i 2 16 "142 25" _null_ _null_ _null_ xmlvalidate - _null_ _null_ ));
+DATA(insert OID = 2987 (  xmlvalidate	   PGNSP PGUID 12 1 0 f f t f i 2 16 "142 25" _null_ _null_ _null_ xmlvalidate - _null_ _null_ ));
 DESCR("validate an XML value");
 DATA(insert OID = 2898 (  xml_recv		   PGNSP PGUID 12 1 0 f f t f s 1 142 "2281" _null_ _null_ _null_	xml_recv - _null_ _null_ ));
 DESCR("I/O");


### PR DESCRIPTION
This allows setting one of the GPDB-added attributes on a line, without
modifying the original line. This reduces the diff of pg_proc.h from
upstream.

This has no effect on the resulting BKI file, except for whitespace. IOW,
there are no catalog changes in this commit. I checked that by diffing the
resulting BKI file, before and after this patch, with "diff -w".

I still left the TODO comment in pg_proc.h in place, which pointed out
that it'd be nice if we could automatically use prodataaccess = 'c' as the
default for SQL-language columns, and 'n' for others. I actually wrote a
more flexible prototype at first that could do that. In that prototype, you
could provide an arbitrary perl expression that was evaluated on every row,
and could compute a value based on other columns. But that was more
complicated, and at the same time, not as flexible, because you could still
not specify particular values for just one row. So I think this is better
in the end.

Also, I noticed that we haven't actually marked all SQL-language functions
with prodataaccess = 'c'. Tsk tsk. It's too late for catalog changes, so
not fixing that now. At some point, we should discuss whether we should
do something different with prodataaccess, like change the code so that
it's ignored for SQL language functions altogether. Or perhaps just remove
the column, the only useful value for it is the magic 's' value, which
can only be used in built-in functions because there's no DDL syntax for
it. But that's a whole different story.
