### PR TITLE
Sub-partition exchange with wrong schema throws

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -13412,8 +13412,8 @@ ATPExecPartExchange(AlteredTableInfo *tab, Relation rel, AlterPartitionCmd *pc)
 		char			*oldname;
 		Relation		 newrel;
 		Relation		 oldrel;
-		AttrMap			*newmap;
-		AttrMap			*oldmap;
+		AttrMap			*newmap; /* used for compatability check below only */
+		AttrMap			*oldmap; /* used for compatability check below only */
 		List			*newcons;
 		bool			 ok;
 		bool			 validate	= intVal(pc2->arg1) ? true : false;
@@ -13443,9 +13443,9 @@ ATPExecPartExchange(AlteredTableInfo *tab, Relation rel, AlterPartitionCmd *pc)
 		newname = pstrdup(RelationGetRelationName(newrel));
 		oldname = pstrdup(RelationGetRelationName(oldrel));
 		
-		ok = map_part_attrs(rel, newrel, &newmap, FALSE);
+		ok = map_part_attrs(rel, newrel, &newmap, TRUE);
 		Assert(ok);
-		ok = map_part_attrs(rel, oldrel, &oldmap, FALSE);
+		ok = map_part_attrs(rel, oldrel, &oldmap, TRUE);
 		Assert(ok);
 
 		newcons = cdb_exchange_part_constraints(

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -193,6 +193,23 @@ alter table foo_p exchange partition for(rank(6)) with table bar_p;
 ERROR:  relation "bar_p" must have the same column names and column order as "foo_p"
 drop table foo_p;
 drop table bar_p;
+-- still different schema, but more than one level partitioning
+CREATE TABLE two_level_pt(a int, b int, c int)
+DISTRIBUTED BY (a)
+PARTITION BY RANGE (b)
+      SUBPARTITION BY RANGE (c)
+      SUBPARTITION TEMPLATE (
+      START (11) END (12) EVERY (1))
+      ( START (1) END (2) EVERY (1));
+NOTICE:  CREATE TABLE will create partition "two_level_pt_1_prt_1" for table "two_level_pt"
+NOTICE:  CREATE TABLE will create partition "two_level_pt_1_prt_1_2_prt_1" for table "two_level_pt_1_prt_1"
+CREATE TABLE candidate_for_leaf(a int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- should fail
+ALTER TABLE two_level_pt ALTER PARTITION FOR (1)
+      EXCHANGE PARTITION FOR (11) WITH TABLE candidate_for_leaf;
+ERROR:  relation "candidate_for_leaf" must have the same column names and column order as "two_level_pt"
 -- different owner 
 create role part_role;
 NOTICE:  resource queue required -- using default resource queue "pg_default"

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -193,6 +193,23 @@ alter table foo_p exchange partition for(rank(6)) with table bar_p;
 ERROR:  relation "bar_p" must have the same column names and column order as "foo_p"
 drop table foo_p;
 drop table bar_p;
+-- still different schema, but more than one level partitioning
+CREATE TABLE two_level_pt(a int, b int, c int)
+DISTRIBUTED BY (a)
+PARTITION BY RANGE (b)
+      SUBPARTITION BY RANGE (c)
+      SUBPARTITION TEMPLATE (
+      START (11) END (12) EVERY (1))
+      ( START (1) END (2) EVERY (1));
+NOTICE:  CREATE TABLE will create partition "two_level_pt_1_prt_1" for table "two_level_pt"
+NOTICE:  CREATE TABLE will create partition "two_level_pt_1_prt_1_2_prt_1" for table "two_level_pt_1_prt_1"
+CREATE TABLE candidate_for_leaf(a int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- should fail
+ALTER TABLE two_level_pt ALTER PARTITION FOR (1)
+      EXCHANGE PARTITION FOR (11) WITH TABLE candidate_for_leaf;
+ERROR:  relation "candidate_for_leaf" must have the same column names and column order as "two_level_pt"
 -- different owner 
 create role part_role;
 NOTICE:  resource queue required -- using default resource queue "pg_default"

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -107,6 +107,22 @@ alter table foo_p exchange partition for(rank(6)) with table bar_p;
 drop table foo_p;
 drop table bar_p;
 
+-- still different schema, but more than one level partitioning
+CREATE TABLE two_level_pt(a int, b int, c int)
+DISTRIBUTED BY (a)
+PARTITION BY RANGE (b)
+      SUBPARTITION BY RANGE (c)
+      SUBPARTITION TEMPLATE (
+      START (11) END (12) EVERY (1))
+      ( START (1) END (2) EVERY (1));
+
+CREATE TABLE candidate_for_leaf(a int, c int);
+
+-- should fail
+ALTER TABLE two_level_pt ALTER PARTITION FOR (1)
+      EXCHANGE PARTITION FOR (11) WITH TABLE candidate_for_leaf;
+
+
 -- different owner 
 create role part_role;
 create table foo_p (i int, j int) distributed by (i)


### PR DESCRIPTION
Partition exchange for a partition table with sub-partitions should
throw an error as soon as the incompatability is schemas between the
partition table and the candidate table to exchange is found.