### PR TITLE
Eliminate '#include "utils/resowner.h"' from lock.h

### DIFF
--- a/gpAux/extensions/gpcloud/src/gpcloud.cpp
+++ b/gpAux/extensions/gpcloud/src/gpcloud.cpp
@@ -14,6 +14,7 @@ extern "C" {
 #include "utils/array.h"
 #include "utils/builtins.h"
 #include "utils/memutils.h"
+#include "utils/resowner.h"
 }
 
 #include "gpreader.h"

--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -25,6 +25,7 @@
 #include "cdb/cdbutil.h"
 #include "miscadmin.h"
 #include "utils/guc.h"
+#include "utils/resowner.h"
 #include "utils/uri.h"
 
 /*

--- a/src/backend/access/external/url_execute.c
+++ b/src/backend/access/external/url_execute.c
@@ -21,6 +21,7 @@
 #include "cdb/cdbtimer.h"
 #include "cdb/cdbvars.h"
 #include "libpq/pqsignal.h"
+#include "utils/resowner.h"
 
 #define EXEC_DATA_P 0 /* index to data pipe */
 #define EXEC_ERR_P 1 /* index to error pipe  */

--- a/src/backend/cdb/cdbfilerepservice.c
+++ b/src/backend/cdb/cdbfilerepservice.c
@@ -35,6 +35,7 @@
 #include "utils/guc.h"
 #include "utils/memutils.h"
 #include "utils/ps_status.h"
+#include "utils/resowner.h"
 #include "utils/syscache.h"
 
 /*

--- a/src/backend/cdb/dispatcher/cdbgang_async.c
+++ b/src/backend/cdb/dispatcher/cdbgang_async.c
@@ -27,6 +27,7 @@
 #include "cdb/cdbgang.h"
 #include "cdb/cdbvars.h"
 #include "miscadmin.h"
+#include "utils/resowner.h"
 
 static int getPollTimeout(const struct timeval* startTS);
 static Gang *createGang_async(GangType type, int gang_id, int size, int content);

--- a/src/backend/cdb/dispatcher/cdbgang_thread.c
+++ b/src/backend/cdb/dispatcher/cdbgang_thread.c
@@ -21,6 +21,7 @@
 #include "cdb/cdbgang.h"
 #include "cdb/cdbvars.h"
 #include "miscadmin.h"
+#include "utils/resowner.h"
 /*
  * Parameter structure for the DoConnect threads
  */

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -34,6 +34,7 @@
 #include "utils/resgroup.h"
 #include "utils/resgroup-ops.h"
 #include "utils/resource_manager.h"
+#include "utils/resowner.h"
 #include "utils/syscache.h"
 
 #define RESGROUP_DEFAULT_CONCURRENCY (20)

--- a/src/backend/postmaster/seqserver.c
+++ b/src/backend/postmaster/seqserver.c
@@ -41,6 +41,7 @@
 #include "tcop/tcopprot.h"
 #include "utils/ps_status.h"
 #include "storage/backendid.h"
+#include "utils/resowner.h"
 #include "utils/syscache.h"
 
 #include "tcop/tcopprot.h"

--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -40,6 +40,7 @@
 #include "pgstat.h"
 #include "utils/memutils.h"
 #include "utils/ps_status.h"
+#include "utils/resowner.h"
 #include "utils/testutils.h"
 #include "executor/execdesc.h"
 #include "utils/resscheduler.h"

--- a/src/backend/utils/resscheduler/resqueue.c
+++ b/src/backend/utils/resscheduler/resqueue.c
@@ -1446,7 +1446,6 @@ ResIncrementAdd(ResPortalIncrement *incSet, PROCLOCK *proclock, ResourceOwner ow
 	{
 		incrementSet->pid = incSet->pid;
 		incrementSet->portalId = incSet->portalId;
-		incrementSet->owner = owner;
 		incrementSet->isHold = incSet->isHold;
 		incrementSet->isCommitted = false;
 		for (i = 0; i < NUM_RES_LIMIT_TYPES; i++)

--- a/src/backend/utils/time/sharedsnapshot.c
+++ b/src/backend/utils/time/sharedsnapshot.c
@@ -160,6 +160,7 @@
 #include "utils/builtins.h"
 #include "utils/guc.h"
 #include "utils/memutils.h"
+#include "utils/resowner.h"
 #include "utils/sharedsnapshot.h"
 
 /*

--- a/src/include/storage/lock.h
+++ b/src/include/storage/lock.h
@@ -19,7 +19,6 @@
 #include "storage/itemptr.h"
 #include "storage/lwlock.h"
 #include "storage/shmem.h"
-#include "utils/resowner.h"
 
 
 /* struct PGPROC is declared in proc.h, but must forward-reference it */
@@ -467,7 +466,7 @@ typedef struct LOCALLOCK
 
 /* Waiter global locallock. (needed by resource queuing). */
 extern LOCALLOCK *awaitedLock;
-extern ResourceOwner awaitedOwner;
+extern struct ResourceOwnerData *awaitedOwner;
 
 /*
  * This struct holds information passed from lmgr internals to the lock

--- a/src/include/utils/resscheduler.h
+++ b/src/include/utils/resscheduler.h
@@ -94,7 +94,6 @@ typedef struct ResPortalIncrement
 {
 	int			pid;					/* Process this increment is for. */
 	uint32		portalId;				/* Portal Id */
-	ResourceOwner	owner;				/* Resource Owner. */
 	bool		isHold;					/* Holdable cursor? */
 	bool		isCommitted;			/* 1st commit complete? */
 	SHM_QUEUE	portalLink;				/* List link in PROCLOCKS list 

--- a/src/include/utils/workfile_mgr.h
+++ b/src/include/utils/workfile_mgr.h
@@ -17,6 +17,7 @@
 #include "utils/sharedcache.h"
 #include "nodes/execnodes.h"
 #include "utils/timestamp.h"
+#include "utils/resowner.h"
 
 /*
  * Workfile management default parameters


### PR DESCRIPTION
It was getting in the way of backporting commit 9b1b9446f5 from PostgreSQL,
which added an '#include "storage/lock.h"' to resowner.h, forming a cycle.

The include was only needed for the decalaration of awaitedOwner global
variable. Replace "ResourceOwner" with the equivalent "struct
ResourceOwnerData *" to avoid it.

This revealed a bunch of other files that were relying on resowner.h
being indirectly included through lock.h. Include resowner.h directly
in those files.

The ResPortalIncrement.owner field was not used for anything, so instead
of including resowner.h in that file, just remove the field that needed
it.