### PR TITLE
Re-add unnecessary version checks to pg_dump, to reduce diff vs. upstream.

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -1000,8 +1000,8 @@ help(const char *progname)
 	printf(_("  -b, --blobs                 include large objects in dump\n"));
 	printf(_("  -c, --clean                 clean (drop) schema prior to create\n"));
 	printf(_("  -C, --create                include commands to create database in dump\n"));
-	printf(_("  -d, --inserts            dump data as INSERT, rather than COPY, commands\n"));
-	printf(_("  -D, --column-inserts     dump data as INSERT commands with column names\n"));
+	printf(_("  -d, --inserts               dump data as INSERT commands, rather than COPY\n"));
+	printf(_("  -D, --column-inserts        dump data as INSERT commands with column names\n"));
 	printf(_("  -E, --encoding=ENCODING     dump the data in encoding ENCODING\n"));
 	printf(_("  -n, --schema=SCHEMA         dump the named schema(s) only\n"));
 	printf(_("  -N, --exclude-schema=SCHEMA do NOT dump the named schema(s)\n"));


### PR DESCRIPTION
GPDB's pg_dump only supports dumping from server versions based on
PostgreSQL 8.2 and above, while PostgreSQL's pg_dump supports much older
versions. In GPDB's version, many of the version checks to deal with
older versions had been removed, but that caused a lot of diffs against
upstream, because of changed indentation.

To reduce our diff footprint, put back those versions checks. But actually
trying to deal with very old server versions seems futile, so instead of
resurrecting all the code, just put an error message into the branches
where upstream e.g. constructs queries that work with older versions. The
version checks should never actually fail, because we check the server
version once at the beginning of pg_dump. But it's nice to have something
in those branches, to document the fact that there was more code there in
the upstream, and to keep the formatting the same as in upstream.