### PR TITLE
Remove over-zealous Assertion in workfile manager.

### DIFF
--- a/src/backend/utils/workfile_manager/workfile_mgr.c
+++ b/src/backend/utils/workfile_manager/workfile_mgr.c
@@ -70,7 +70,6 @@ workfile_set_free_callback(ResourceReleasePhase phase,
 	if (phase != RESOURCE_RELEASE_AFTER_LOCKS)
 		return;
 
-
 	next = open_workfile_sets;
 	while (next)
 	{
@@ -84,7 +83,6 @@ workfile_set_free_callback(ResourceReleasePhase phase,
 			workfile_mgr_close_set(curr);
 		}
 	}
-	AssertImply(isTopLevel, open_workfile_sets == NULL);
 }
 
 


### PR DESCRIPTION
During abort processing, AbortTransaction releases the resources in each
resource owner, one resource owner at a time. It's true that after having
processed all of them, there should not be any open workfile sets left,
which is what this assertion tried to test. But it only holds after having
released all resource owners.

I just happened to trip this assertion while hacking on something else.