### PR TITLE
Use ereport() rather than elog(), for "expected" ERRORs.

### DIFF
--- a/src/bin/gpfdist/regress/output/exttab1.source
+++ b/src/bin/gpfdist/regress/output/exttab1.source
@@ -628,13 +628,13 @@ create external table bad_location1 (a int4, b text)
 location ('gpfdist://@hostname@:7070/exttab1/non_existent_dir/*' )
 format 'csv';
 select count(*) from bad_location1;
-ERROR:  http response code 404 from gpfdist (gpfdist://@hostname@:7070/exttab1/non_existent_dir/*): HTTP/1.0 404 file not found (url_curl.c:467)
+ERROR:  http response code 404 from gpfdist (gpfdist://@hostname@:7070/exttab1/non_existent_dir/*): HTTP/1.0 404 file not found
 drop external table bad_location1;
 create external table bad_location2 (a int4, b text)
 location ('gpfdist://@hostname@:7070/exttab1/non_existent_file.txt' )
 format 'csv';
 select count(*) from bad_location2;
-ERROR:  http response code 404 from gpfdist (gpfdist://@hostname@:7070/exttab1/non_existent_file.txt): HTTP/1.0 404 file not found (url_curl.c:467)
+ERROR:  http response code 404 from gpfdist (gpfdist://@hostname@:7070/exttab1/non_existent_file.txt): HTTP/1.0 404 file not found
 drop external table bad_location2;
 --
 -- WET tests

--- a/src/bin/gpfdist/regress/output/gpfdist2.source
+++ b/src/bin/gpfdist/regress/output/gpfdist2.source
@@ -411,7 +411,7 @@ FORMAT 'text'
 )
 ;
 SELECT count(*) FROM ext_lineitem;
-ERROR:  http response code 404 from gpfdist (gpfdist://@hostname@:7070/gpfdist2/invalid_filename.txt): HTTP/1.0 404 file not found (url_curl.c:467)  (seg0 slice1 172.17.0.4:25432 pid=36415)
+ERROR:  http response code 404 from gpfdist (gpfdist://@hostname@:7070/gpfdist2/invalid_filename.txt): HTTP/1.0 404 file not found  (seg0 slice1 172.17.0.4:25432 pid=36415)
 DROP EXTERNAL TABLE ext_lineitem;
 -- test 12
 CREATE EXTERNAL TABLE ext_lineitem (
@@ -548,7 +548,7 @@ FORMAT 'text'
 )
 ;
 SELECT DISTINCT L_ORDERKEY FROM ext_lineitem WHERE L_ORDERKEY > 10 GROUP BY L_ORDERKEY ORDER BY L_ORDERKEY LIMIT 10 OFFSET 2;
-ERROR:  http response code 404 from gpfdist (gpfdist://@hostname@:7070/gpfdist2/data/lineitem.tbl): HTTP/1.0 404 file not found (url_curl.c:467)  (seg0 slice1 172.17.0.4:25432 pid=36454)
+ERROR:  http response code 404 from gpfdist (gpfdist://@hostname@:7070/gpfdist2/data/lineitem.tbl): HTTP/1.0 404 file not found  (seg0 slice1 172.17.0.4:25432 pid=36454)
 DROP EXTERNAL TABLE ext_lineitem;
 -- test 16
 CREATE EXTERNAL TABLE ext_lineitem (
@@ -958,7 +958,7 @@ FORMAT 'text'
 )
 ;
 SELECT count(*) FROM ext_test;
-ERROR:  gpfdist error - line too long in file @abs_srcdir@/data/gpfdist2/longline.txt near (0 bytes) (url_curl.c:1505)  (seg1 slice1 172.17.0.4:25433 pid=36416)
+ERROR:  gpfdist error - line too long in file @abs_srcdir@/data/gpfdist2/longline.txt near (0 bytes)  (seg1 slice1 172.17.0.4:25433 pid=36416)
 DETAIL:  External table ext_test, file gpfdist://@hostname@:7070/gpfdist2/longline.txt
 DROP EXTERNAL TABLE ext_test;
 CREATE EXTERNAL TABLE ext_test1 (
@@ -975,7 +975,7 @@ FORMAT 'csv'
 )
 ;
 SELECT count(*) FROM ext_test1;
-ERROR:  gpfdist error - line too long in file @abs_srcdir@/data/gpfdist2/longline.csv near (0 bytes) (url_curl.c:1505)  (seg0 slice1 172.17.0.4:25432 pid=36415)
+ERROR:  gpfdist error - line too long in file @abs_srcdir@/data/gpfdist2/longline.csv near (0 bytes)  (seg0 slice1 172.17.0.4:25432 pid=36415)
 DETAIL:  External table ext_test1, file gpfdist://@hostname@:7070/gpfdist2/longline.csv
 DROP EXTERNAL TABLE ext_test1;
 CREATE EXTERNAL TABLE ext_lineitem (


### PR DESCRIPTION
Use ereport(), with a proper error code, for errors that are "expected" to
happen sometimes, like missing configuration files, or network failure.

That's nicer in general, but the reason I bumped into this is that internal
error messages include a source file name and line number in GPDB, and if
those error messages are included in the expected output of regression
tests, those tests will fail any time you do change the file, so that the
elog() moves around and the line number changes.