### PR TITLE
Disable broken \ef psql command.

### DIFF
--- a/src/bin/psql/command.c
+++ b/src/bin/psql/command.c
@@ -524,7 +524,13 @@ exec_command(const char *cmd,
 	 */
 	else if (strcmp(cmd, "ef") == 0)
 	{
-		if (!query_buf)
+		if (pset.sversion < 80400)
+		{
+			psql_error("The server (version %d.%d) does not support editing function source.\n",
+					   pset.sversion / 10000, (pset.sversion / 100) % 100);
+			status = PSQL_CMD_ERROR;
+		}
+		else if (!query_buf)
 		{
 			psql_error("no query buffer\n");
 			status = PSQL_CMD_ERROR;


### PR DESCRIPTION
GPDB 5 doesn't have the pg_get_functiondef server function needed by \ef,
so it doesn't work.

Fixes github issue #3076.

This is a backport of an upstream commit that conveniently fixes this:

commit 2463f5da3ccd67b266ee7a9b8c0906221a501b9e
Author: Tom Lane <tgl@sss.pgh.pa.us>
Date:   Thu Nov 10 18:37:05 2011 -0500

    Throw nice error if server is too old to support psql's \ef or \sf command.

    Previously, you'd get "function pg_catalog.pg_get_functiondef(integer) does
    not exist", which is at best rather unprofessional-looking.  Back-patch
    to 8.4 where \ef was introduced.

    Josh Kupershmidt