### PR TITLE
gpstart: Fix standby master pg_controldata heap checksum validation

### DIFF
--- a/gpMgmt/bin/gppylib/heapchecksum.py
+++ b/gpMgmt/bin/gppylib/heapchecksum.py
@@ -30,7 +30,8 @@ class HeapChecksum:
         :return: the heap checksum setting (1 or 0) for the standby master
         """
         standbyMaster_gpdb = self.gparray.standbyMaster
-        cmd = PgControlData(name='run pg_controldata', datadir=standbyMaster_gpdb.getSegmentDataDirectory())
+        cmd = PgControlData(name='run pg_controldata', datadir=standbyMaster_gpdb.getSegmentDataDirectory(),
+                            ctxt=REMOTE, remoteHost=standbyMaster_gpdb.getSegmentHostName())
         cmd.run(validateAfter=True)
         value = cmd.get_value('Data page checksum version')
         return value


### PR DESCRIPTION
Previously, we were only checking localhost for standby heap checksum in
gpstart. This is not the case as the standby is usually on a remote host.
gpstart raises an error due to not finding the pg_control file of standby locally.

Fixed by always doing a remote host call for the standby master.

Signed-off-by: Marbin Tan <mtan@pivotal.io>