### PR TITLE
 unix.RemoveDirectories: optimize and isolate cases

### DIFF
--- a/gpMgmt/bin/gpdeletesystem
+++ b/gpMgmt/bin/gpdeletesystem
@@ -242,8 +242,8 @@ def delete_cluster(options):
         for (oid, filespace) in filespaces:
             logger.debug('Queueing up command to remove %s:%s' % (segdb.getSegmentHostName(),
                                                                   filespace))
-            cmd = unix.RemoveFiles('remove fs dir', filespace, ctxt=base.REMOTE,
-                                   remoteHost=segdb.getSegmentHostName())
+            cmd = unix.RemoveDirectory('remove fs dir', filespace, ctxt=base.REMOTE,
+                                       remoteHost=segdb.getSegmentHostName())
             pool.addCommand(cmd)
 
     logger.info('Waiting for worker threads to complete...')

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -579,9 +579,9 @@ class GpExpandStatus():
         if os.path.exists(self._status_standby_filename):
             os.unlink(self._status_standby_filename)
         if self._master_mirror:
-            RemoveFiles.remote('gpexpand master mirror status file cleanup',
-                               self._master_mirror.getSegmentHostName(),
-                               self._status_filename)
+            RemoveFile.remote('gpexpand master mirror status file cleanup',
+                              self._master_mirror.getSegmentHostName(),
+                              self._status_filename)
 
     def remove_segment_configuration_backup_file(self):
         """ Remove the segment configuration backup file """
@@ -851,29 +851,29 @@ class SegmentTemplate:
                     cpCmd.run(validateAfter=True)
 
         # Don't need log files and gpperfmon files in template.
-        rmCmd = RemoveFiles('gpexpand remove gppermfon data from template',
-                            self.tempDir + '/gpperfmon/data')
+        rmCmd = RemoveDirectory('gpexpand remove gppermfon data from template',
+                                self.tempDir + '/gpperfmon/data')
         rmCmd.run(validateAfter=True)
-        rmCmd = RemoveFiles('gpexpand remove logs from template',
-                            self.tempDir + '/pg_log/*')
+        rmCmd = RemoveDirectoryContents('gpexpand remove logs from template',
+                                        self.tempDir + '/pg_log')
         rmCmd.run(validateAfter=True)
 
         # other files not needed
-        rmCmd = RemoveFiles('gpexpand remove postmaster.opt from template',
+        rmCmd = RemoveFile('gpexpand remove postmaster.opt from template',
                             self.tempDir + '/postmaster.opts')
         rmCmd.run(validateAfter=True)
-        rmCmd = RemoveFiles('gpexpand remove postmaster.pid from template',
+        rmCmd = RemoveFile('gpexpand remove postmaster.pid from template',
                             self.tempDir + '/postmaster.pid')
         rmCmd.run(validateAfter=True)
-        rmCmd = RemoveFiles('gpexpand remove gpexpand files from template',
+        rmCmd = RemoveGlob('gpexpand remove gpexpand files from template',
                             self.tempDir + '/gpexpand.*')
         rmCmd.run(validateAfter=True)
 
         # We dont need the flat files
-        rmCmd = RemoveFiles('gpexpand remove transaction flat file from template',
+        rmCmd = RemoveFile('gpexpand remove transaction flat file from template',
                             self.tempDir + '/' + GP_TRANSACTION_FILES_FILESPACE)
         rmCmd.run(validateAfter=True)
-        rmCmd = RemoveFiles('gpexpand remove temporary flat file from template',
+        rmCmd = RemoveFile('gpexpand remove temporary flat file from template',
                             self.tempDir + '/' + GP_TEMPORARY_FILES_FILESPACE)
         rmCmd.run(validateAfter=True)
 
@@ -911,9 +911,9 @@ class SegmentTemplate:
     def cleanup_build_segment_template(tarFile, tempDir):
         """Reverts the work done by build_segment_template.  Deletes the temp
         directory and local tar file"""
-        rmCmd = RemoveFiles('gpexpand remove temp dir: %s' % tempDir, tempDir)
+        rmCmd = RemoveDirectory('gpexpand remove temp dir: %s' % tempDir, tempDir)
         rmCmd.run(validateAfter=True)
-        rmCmd = RemoveFiles('gpexpand remove segment template file', tarFile)
+        rmCmd = RemoveFile('gpexpand remove segment template file', tarFile)
         rmCmd.run(validateAfter=True)
 
     @staticmethod
@@ -928,8 +928,8 @@ class SegmentTemplate:
 
         # Remove template tar file
         for host in hosts:
-            rmCmd = RemoveFiles('gpexpand remove segment template file on host: %s' % host,
-                                tarFile, ctxt=REMOTE, remoteHost=host)
+            rmCmd = RemoveFile('gpexpand remove segment template file on host: %s' % host,
+                               tarFile, ctxt=REMOTE, remoteHost=host)
             pool.addCommand(rmCmd)
 
         if removeDataDirs:
@@ -938,8 +938,8 @@ class SegmentTemplate:
                 filespaces = seg.getSegmentFilespaces()
                 for oid in filespaces:
                     datadir = filespaces[oid]
-                    rmCmd = RemoveFiles('gpexpand remove new segment data directory: %s:%s' % (hostname, datadir),
-                                        datadir, ctxt=REMOTE, remoteHost=hostname)
+                    rmCmd = RemoveDirectory('gpexpand remove new segment data directory: %s:%s' % (hostname, datadir),
+                                            datadir, ctxt=REMOTE, remoteHost=hostname)
                     pool.addCommand(rmCmd)
         pool.join()
         pool.check_results()

--- a/gpMgmt/bin/gpinitstandby
+++ b/gpMgmt/bin/gpinitstandby
@@ -322,9 +322,9 @@ def remove_standby_filespace_dirs(array):
         pool = base.WorkerPool(numWorkers=DEFAULT_BATCH_SIZE)
         
         for fs_dir in fs_dirs:
-            cmd = unix.RemoveFiles('delete standby filespace dir',
-                                   fs_dir, ctxt=base.REMOTE,
-                                   remoteHost=array.standbyMaster.getSegmentHostName())
+            cmd = unix.RemoveDirectory('delete standby filespace dir',
+                                       fs_dir, ctxt=base.REMOTE,
+                                       remoteHost=array.standbyMaster.getSegmentHostName())
             pool.addCommand(cmd)
         
         pool.join()
@@ -607,10 +607,10 @@ def cleanup_pg_hba_conf_backup(array):
     standby_data_dir = array.standbyMaster.getSegmentDataDirectory()
     
     try:
-        unix.RemoveFiles.local('cleanup master pg_hba.conf backup', '%s/%s' % (master_data_dir, PG_HBA_BACKUP))
-        unix.RemoveFiles.remote('cleanup standby pg_hba.conf backup',
-                                array.standbyMaster.getSegmentHostName(),
-                                '%s/%s' % (standby_data_dir, PG_HBA_BACKUP))
+        unix.RemoveFile.local('cleanup master pg_hba.conf backup', '%s/%s' % (master_data_dir, PG_HBA_BACKUP))
+        unix.RemoveFile.remote('cleanup standby pg_hba.conf backup',
+                               array.standbyMaster.getSegmentHostName(),
+                               '%s/%s' % (standby_data_dir, PG_HBA_BACKUP))
     except:
         # ignore...
         pass

--- a/gpMgmt/bin/gpmovemirrors
+++ b/gpMgmt/bin/gpmovemirrors
@@ -409,21 +409,15 @@ try:
         pool = WorkerPool(numWorkers=numberOfWorkers)
         for mirror in newConfig.oldMirrorList:
             logger.info("About to remove old mirror segment directory: " + mirror.dataDirectory)
-            cmd = RemoveFiles("remove old mirror segment directories"
-                              , mirror.dataDirectory
-                              , ctxt=REMOTE
-                              , remoteHost=mirror.address
-                              )
+            cmd = RemoveDirectory("remove old mirror segment directories", mirror.dataDirectory, ctxt=REMOTE,
+                                  remoteHost=mirror.address)
             pool.addCommand(cmd)
             for filespaceName in mirror.filespaces.keys():
                 logger.info(
                     "About to remove old mirror filespace directory: " + filespaceName + " : " + mirror.filespaces[
                         filespaceName])
-                cmd = RemoveFiles("remove old mirror segment directories"
-                                  , mirror.filespaces[filespaceName]
-                                  , ctxt=REMOTE
-                                  , remoteHost=mirror.address
-                                  )
+                cmd = RemoveDirectory("remove old mirror segment directories", mirror.filespaces[filespaceName],
+                                      ctxt=REMOTE, remoteHost=mirror.address)
                 pool.addCommand(cmd)
 
         # Wait for the segments to finish

--- a/gpMgmt/bin/gppylib/commands/base.py
+++ b/gpMgmt/bin/gppylib/commands/base.py
@@ -414,6 +414,7 @@ class LocalExecutionContext(ExecutionContext):
                                        stdin=subprocess.PIPE,
                                        stderr=subprocess.PIPE,
                                        stdout=subprocess.PIPE, close_fds=True)
+        cmd.pid = self.proc.pid
         if wait:
             (rc, stdout_value, stderr_value) = self.proc.communicate2(input=self.stdin)
             self.completed = True

--- a/gpMgmt/bin/gppylib/commands/unix.py
+++ b/gpMgmt/bin/gppylib/commands/unix.py
@@ -51,26 +51,18 @@ class CommandNotFoundException(Exception):
         return "Could not locate command: '%s' in this set of paths: %s" % (self.cmd, repr(self.paths))
 
 
-def findCmdInPath(cmd, additionalPaths=[], printError=True):
+def findCmdInPath(cmd):
     global CMD_CACHE
 
     if cmd not in CMD_CACHE:
-        # Search additional paths and don't add to cache.
-        for p in additionalPaths:
-            f = os.path.join(p, cmd)
-            if os.path.exists(f):
-                return f
-
         for p in CMDPATH:
             f = os.path.join(p, cmd)
             if os.path.exists(f):
                 CMD_CACHE[cmd] = f
                 return f
 
-        if printError:
-            logger.critical('Command %s not found' % cmd)
+        logger.critical('Command %s not found' % cmd)
         search_path = CMDPATH[:]
-        search_path.extend(additionalPaths)
         raise CommandNotFoundException(cmd, search_path)
     else:
         return CMD_CACHE[cmd]

--- a/gpMgmt/bin/gppylib/commands/unix.py
+++ b/gpMgmt/bin/gppylib/commands/unix.py
@@ -4,41 +4,36 @@
 #
 """
 Set of Classes for executing unix commands.
-
-
 """
 import os
 import psutil
 import platform
 import socket
-import sys
 import signal
 
 from gppylib.gplog import *
 from gppylib.commands.base import *
 
-
 logger = gplog.get_default_logger()
 
-#---------------platforms--------------------
-#global variable for our platform
-SYSTEM="unknown"
+# ---------------platforms--------------------
+# global variable for our platform
+SYSTEM = "unknown"
 
-SUNOS="sunos"
-LINUX="linux"
-DARWIN="darwin"
-FREEBSD="freebsd"
-platform_list = [SUNOS,LINUX,DARWIN,FREEBSD]
+SUNOS = "sunos"
+LINUX = "linux"
+DARWIN = "darwin"
+FREEBSD = "freebsd"
+platform_list = [SUNOS, LINUX, DARWIN, FREEBSD]
 
 curr_platform = platform.uname()[0].lower()
 
-GPHOME=os.environ.get('GPHOME', None)
+GPHOME = os.environ.get('GPHOME', None)
 
+# ---------------command path--------------------
 
-#---------------command path--------------------
-
-CMDPATH = ['/usr/kerberos/bin', '/usr/sfw/bin', '/opt/sfw/bin', '/bin', '/usr/local/bin', 
-               '/usr/bin', '/sbin', '/usr/sbin', '/usr/ucb', '/sw/bin', '/opt/Navisphere/bin']
+CMDPATH = ['/usr/kerberos/bin', '/usr/sfw/bin', '/opt/sfw/bin', '/bin', '/usr/local/bin',
+           '/usr/bin', '/sbin', '/usr/sbin', '/usr/ucb', '/sw/bin', '/opt/Navisphere/bin']
 
 if GPHOME:
     CMDPATH.append(GPHOME)
@@ -46,16 +41,15 @@ if GPHOME:
 CMD_CACHE = {}
 
 
-#----------------------------------
-
+# ----------------------------------
 class CommandNotFoundException(Exception):
-    def __init__(self,cmd,paths):
-        self.cmd=cmd
-        self.paths=paths
+    def __init__(self, cmd, paths):
+        self.cmd = cmd
+        self.paths = paths
+
     def __str__(self):
-        return "Could not locate command: '%s' in this set of paths: %s" % (self.cmd,repr(self.paths))
-    
-    
+        return "Could not locate command: '%s' in this set of paths: %s" % (self.cmd, repr(self.paths))
+
 
 def findCmdInPath(cmd, additionalPaths=[], printError=True):
     global CMD_CACHE
@@ -66,32 +60,34 @@ def findCmdInPath(cmd, additionalPaths=[], printError=True):
             f = os.path.join(p, cmd)
             if os.path.exists(f):
                 return f
-            
+
         for p in CMDPATH:
             f = os.path.join(p, cmd)
             if os.path.exists(f):
                 CMD_CACHE[cmd] = f
                 return f
-            
+
         if printError:
             logger.critical('Command %s not found' % cmd)
         search_path = CMDPATH[:]
         search_path.extend(additionalPaths)
-        raise CommandNotFoundException(cmd,search_path)
+        raise CommandNotFoundException(cmd, search_path)
     else:
         return CMD_CACHE[cmd]
-    
-    
-#For now we'll leave some generic functions outside of the Platform framework    
+
+
+# For now we'll leave some generic functions outside of the Platform framework
 def getLocalHostname():
     return socket.gethostname().split('.')[0]
+
 
 def getUserName():
     return os.environ.get('LOGNAME') or os.environ.get('USER')
 
+
 def check_pid_on_remotehost(pid, host):
     """ Check For the existence of a unix pid on remote host. """
-    
+
     if pid == 0:
         return False
 
@@ -102,18 +98,20 @@ def check_pid_on_remotehost(pid, host):
 
     return False
 
-def check_pid(pid):        
+
+def check_pid(pid):
     """ Check For the existence of a unix pid. """
-    
+
     if pid == 0:
         return False
-    
+
     try:
         os.kill(int(pid), signal.SIG_DFL)
     except OSError:
         return False
     else:
         return True
+
 
 """
 Given the data directory, port and pid for a segment, 
@@ -125,9 +123,11 @@ E.g postgres: port 45002, logger process
     postgres: port 45002, sweeper process
     postgres: port 45002, checkpoint process
 """
+
+
 def kill_9_segment_processes(datadir, port, pid):
     logger.info('Terminating processes for segment %s' % datadir)
-        
+
     pid_list = []
 
     # pid is the pid of the postgres process.
@@ -135,7 +135,8 @@ def kill_9_segment_processes(datadir, port, pid):
     if pid != -1:
         pid_list = [pid]
 
-    cmd = Command('get a list of processes to kill -9', cmdStr='ps ux | grep "[p]ostgres:\s*port\s*%s" | awk \'{print $2}\'' % (port))
+    cmd = Command('get a list of processes to kill -9',
+                  cmdStr='ps ux | grep "[p]ostgres:\s*port\s*%s" | awk \'{print $2}\'' % (port))
 
     try:
         cmd.run(validateAfter=True)
@@ -145,7 +146,7 @@ def kill_9_segment_processes(datadir, port, pid):
 
     results = cmd.get_results()
     results = results.stdout.strip().split('\n')
-    
+
     for result in results:
         if result:
             pid_list.append(int(result))
@@ -158,11 +159,12 @@ def kill_9_segment_processes(datadir, port, pid):
         except Exception as e:
             logger.error('Failed to kill processes for segment %s: (%s)' % (datadir, str(e)))
 
+
 def logandkill(pid, sig):
     msgs = {
         signal.SIGCONT: "Sending SIGSCONT to %d",
         signal.SIGTERM: "Sending SIGTERM to %d (smart shutdown)",
-        signal.SIGINT:  "Sending SIGINT to %d (fast shutdown)",
+        signal.SIGINT: "Sending SIGINT to %d (fast shutdown)",
         signal.SIGQUIT: "Sending SIGQUIT to %d (immediate shutdown)",
         signal.SIGABRT: "Sending SIGABRT to %d"
     }
@@ -180,35 +182,34 @@ def kill_sequence(pid):
     logandkill(pid, signal.SIGTERM)
 
     # give process a few seconds to exit
-    for i in range(0,3):
+    for i in range(0, 3):
         time.sleep(1)
-        if not check_pid(pid): 
+        if not check_pid(pid):
             return
 
     # next try SIGINT (fast shutdown)
     logandkill(pid, signal.SIGINT)
 
     # give process a few more seconds to exit
-    for i in range(0,3):
+    for i in range(0, 3):
         time.sleep(1)
-        if not check_pid(pid): 
+        if not check_pid(pid):
             return
 
     # next try SIGQUIT (immediate shutdown)
     logandkill(pid, signal.SIGQUIT)
 
     # give process a final few seconds to exit
-    for i in range(0,5):
+    for i in range(0, 5):
         time.sleep(1)
-        if not check_pid(pid): 
+        if not check_pid(pid):
             return
 
     # all else failed - try SIGABRT
     logandkill(pid, signal.SIGABRT)
 
 
-
-#---------------Platform Framework--------------------
+# ---------------Platform Framework--------------------
 
 """ The following platform framework is used to handle any differences between
     the platform's we support.  The GenericPlatform class is the base class
@@ -217,26 +218,24 @@ def kill_sequence(pid):
     
     TODO:  should the platform stuff be broken out to separate module?
 """
+
+
 class GenericPlatform():
-
-
     def getName(self):
         "unsupported"
-        
-    
+
     def getDefaultLocale(self):
         return 'en_US.utf-8'
-    
-    
+
     def get_machine_arch_cmd(self):
         return 'uname -i'
-    
+
     def getPingOnceCmd(self):
         pass
-    
+
     def getDiskFreeCmd(self):
-        return findCmdInPath('df') + " -k"  
-    
+        return findCmdInPath('df') + " -k"
+
     def getTarCmd(self):
         return findCmdInPath('tar')
 
@@ -245,24 +244,24 @@ class GenericPlatform():
 
     def getSadcCmd(self, interval, outfilename):
         return None
-    
+
     def getIfconfigCmd(self):
         return findCmdInPath('ifconfig')
-    
+
     def getMountDevFirst(self):
         return True
-        
+
+
 class LinuxPlatform(GenericPlatform):
-    
     def __init__(self):
         pass
-    
+
     def getName(self):
         return "linux"
-    
+
     def getDefaultLocale(self):
         return 'en_US.utf8'
-    
+
     def getDiskFreeCmd(self):
         # -P is for POSIX formatting.  Prevents error 
         # on lines that would wrap
@@ -271,27 +270,27 @@ class LinuxPlatform(GenericPlatform):
     def getSadcCmd(self, interval, outfilename):
         cmd = "/usr/lib64/sa/sadc -F -d " + str(interval) + " " + outfilename
         return cmd
-            
+
     def getMountDevFirst(self):
         return True
-    
+
     def getPing6(self):
         return findCmdInPath('ping6')
 
+
 class SolarisPlatform(GenericPlatform):
-    
     def __init__(self):
         pass
-    
+
     def getName(self):
         return "sunos"
 
     def getDefaultLocale(self):
         return 'en_US.UTF-8'
-    
+
     def getDiskFreeCmd(self):
         return findCmdInPath('df') + " -bk"
-    
+
     def getTarCmd(self):
         return findCmdInPath('gtar')
 
@@ -301,45 +300,42 @@ class SolarisPlatform(GenericPlatform):
 
     def getIfconfigCmd(self):
         return findCmdInPath('ifconfig') + ' -a inet'
-    
+
     def getMountDevFirst(self):
         return False
 
+
 class DarwinPlatform(GenericPlatform):
-    
     def __init__(self):
         pass
-    
+
     def getName(self):
         return "darwin"
-    
+
     def get_machine_arch_cmd(self):
         return 'uname -m'
 
     def getMountDevFirst(self):
         return True
-    
+
     def getPing6(self):
         return findCmdInPath('ping6')
 
-    
-class FreeBsdPlatform(GenericPlatform):
 
+class FreeBsdPlatform(GenericPlatform):
     def __init__(self):
         pass
-    
+
     def getName(self):
         return "freebsd"
-    
+
     def get_machine_arch_cmd(self):
         return 'uname -m'
 
     def getMountDevFirst(self):
-        return True    
+        return True
 
 
-    
-        
 """ if self.SYSTEM == 'sunos':
             self.PS_TXT='ef'
             self.LIB_TYPE='LD_LIBRARY_PATH'
@@ -375,12 +371,13 @@ class FreeBsdPlatform(GenericPlatform):
             self.DF='%s -P' % findCmdInPath('df')
             self.DU_TXT='-c'
 """
-        
-#---------------ping--------------------
+
+
+# ---------------ping--------------------
 class Ping(Command):
-    def __init__(self,name,hostToPing,ctxt=LOCAL,remoteHost=None,obj=None):        
-        self.hostToPing=hostToPing
-        self.obj=obj
+    def __init__(self, name, hostToPing, ctxt=LOCAL, remoteHost=None, obj=None):
+        self.hostToPing = hostToPing
+        self.obj = obj
         pingToUse = findCmdInPath('ping')
 
         if curr_platform == LINUX or curr_platform == DARWIN:
@@ -389,85 +386,86 @@ class Ping(Command):
             addrinfo = socket.getaddrinfo(hostToPing, None)
             if addrinfo and addrinfo[0] and addrinfo[0][0] == socket.AF_INET6:
                 pingToUse = SYSTEM.getPing6()
-                
-        cmdStr = "%s -c 1 %s" % (pingToUse,hostToPing)        
-        Command.__init__(self,name,cmdStr,ctxt,remoteHost)
-    
-    @staticmethod    
-    def ping_list(host_list):        
-        for host in host_list:
-            yield Ping("ping",host,ctxt=LOCAL,remoteHost=None)
-    
-    @staticmethod
-    def local(name,hostToPing):        
-        p=Ping(name,hostToPing)
-        p.run(validateAfter=True)
-    
-    @staticmethod
-    def remote(name,hostToPing,hostToPingFrom):
-        p=Ping(name,hostToPing,ctxt=REMOTE,remoteHost=hostToPingFrom)
-        p.run(validateAfter=True)    
 
-        
-#---------------du--------------------
-class DiskUsage(Command):    
-    def __init__(self,name,directory,ctxt=LOCAL,remoteHost=None):        
-        self.directory=directory
-        if remoteHost:
-            cmdStr="ls -l -R %s | %s ^- | %s '{t+=\$5;} END{print t}'" % (directory,findCmdInPath('grep'), findCmdInPath('awk'))
-        else:
-            cmdStr="ls -l -R %s | %s ^- | %s '{t+=$5;} END{print t}'" % (directory,findCmdInPath('grep'), findCmdInPath('awk'))
-        Command.__init__(self,name,cmdStr,ctxt,remoteHost)
-    
+        cmdStr = "%s -c 1 %s" % (pingToUse, hostToPing)
+        Command.__init__(self, name, cmdStr, ctxt, remoteHost)
+
     @staticmethod
-    def get_size(name,remote_host,directory):
-        duCmd=DiskUsage(name,directory,ctxt=REMOTE,remoteHost=remote_host)
+    def ping_list(host_list):
+        for host in host_list:
+            yield Ping("ping", host, ctxt=LOCAL, remoteHost=None)
+
+    @staticmethod
+    def local(name, hostToPing):
+        p = Ping(name, hostToPing)
+        p.run(validateAfter=True)
+
+    @staticmethod
+    def remote(name, hostToPing, hostToPingFrom):
+        p = Ping(name, hostToPing, ctxt=REMOTE, remoteHost=hostToPingFrom)
+        p.run(validateAfter=True)
+
+        # ---------------du--------------------
+
+
+class DiskUsage(Command):
+    def __init__(self, name, directory, ctxt=LOCAL, remoteHost=None):
+        self.directory = directory
+        if remoteHost:
+            cmdStr = "ls -l -R %s | %s ^- | %s '{t+=\$5;} END{print t}'" % (
+                directory, findCmdInPath('grep'), findCmdInPath('awk'))
+        else:
+            cmdStr = "ls -l -R %s | %s ^- | %s '{t+=$5;} END{print t}'" % (
+                directory, findCmdInPath('grep'), findCmdInPath('awk'))
+        Command.__init__(self, name, cmdStr, ctxt, remoteHost)
+
+    @staticmethod
+    def get_size(name, remote_host, directory):
+        duCmd = DiskUsage(name, directory, ctxt=REMOTE, remoteHost=remote_host)
         duCmd.run(validateAfter=True)
         return duCmd.get_bytes_used()
-            
-                        
-    def get_bytes_used(self):   
 
-        rawIn=self.results.stdout.split('\t')[0].strip()
+    def get_bytes_used(self):
 
-        #TODO: revisit this idea of parsing '' and making it a 0. seems dangerous.
+        rawIn = self.results.stdout.split('\t')[0].strip()
+
+        # TODO: revisit this idea of parsing '' and making it a 0. seems dangerous.
         if rawIn == '':
             return 0
 
         if rawIn[0] == 'd':
             raise ExecutionError("du command could not find directory: cmd: %s"
-                                 "resulted in stdout: '%s' stderr: '%s'" % 
-                                 (self.cmdStr, self.results.stdout, 
+                                 "resulted in stdout: '%s' stderr: '%s'" %
+                                 (self.cmdStr, self.results.stdout,
                                   self.results.stderr),
                                  self)
         else:
-            dirBytes=int(rawIn)
+            dirBytes = int(rawIn)
             return dirBytes
-    
 
-#-------------df----------------------
+
+# -------------df----------------------
 class DiskFree(Command):
-    
-    def __init__(self,name,directory,ctxt=LOCAL,remoteHost=None):        
-        self.directory=directory
-        cmdStr="%s %s" % (SYSTEM.getDiskFreeCmd(),directory) 
-        Command.__init__(self,name,cmdStr,ctxt,remoteHost)
-    
+    def __init__(self, name, directory, ctxt=LOCAL, remoteHost=None):
+        self.directory = directory
+        cmdStr = "%s %s" % (SYSTEM.getDiskFreeCmd(), directory)
+        Command.__init__(self, name, cmdStr, ctxt, remoteHost)
+
     @staticmethod
-    def get_size(name,remote_host,directory):
-        dfCmd=DiskFree(name,directory,ctxt=REMOTE,remoteHost=remote_host)
+    def get_size(name, remote_host, directory):
+        dfCmd = DiskFree(name, directory, ctxt=REMOTE, remoteHost=remote_host)
         dfCmd.run(validateAfter=True)
         return dfCmd.get_bytes_free()
-    
+
     @staticmethod
     def get_size_local(name, directory):
-        dfCmd=DiskFree(name,directory)
+        dfCmd = DiskFree(name, directory)
         dfCmd.run(validateAfter=True)
         return dfCmd.get_bytes_free()
 
     @staticmethod
     def get_disk_free_info_local(name, directory):
-        dfCmd = DiskFree(name,directory)
+        dfCmd = DiskFree(name, directory)
         dfCmd.run(validateAfter=True)
         return dfCmd.get_disk_free_output()
 
@@ -480,187 +478,188 @@ class DiskFree(Command):
            ['/dev/disk0s2', '194699744', '158681544', '35506200', '82%', '/']
         '''
         rawIn = self.results.stdout.split('\n')[1]
-        return rawIn.split();
+        return rawIn.split()
 
     def get_bytes_free(self):
         disk_free = self.get_disk_free_output()
-        bytesFree = int(disk_free[3])*1024
+        bytesFree = int(disk_free[3]) * 1024
         return bytesFree
 
-   
 
-#-------------mkdir------------------
+# -------------mkdir------------------
 class MakeDirectory(Command):
-    
-    def __init__(self,name,directory,ctxt=LOCAL,remoteHost=None):        
-        self.directory=directory
-        cmdStr="%s -p %s" % (findCmdInPath('mkdir'),directory)
-        Command.__init__(self,name,cmdStr,ctxt,remoteHost)
-    
+    def __init__(self, name, directory, ctxt=LOCAL, remoteHost=None):
+        self.directory = directory
+        cmdStr = "%s -p %s" % (findCmdInPath('mkdir'), directory)
+        Command.__init__(self, name, cmdStr, ctxt, remoteHost)
+
     @staticmethod
-    def local(name,directory):    
-        mkdirCmd=MakeDirectory(name,directory)
+    def local(name, directory):
+        mkdirCmd = MakeDirectory(name, directory)
         mkdirCmd.run(validateAfter=True)
-            
+
     @staticmethod
-    def remote(name,remote_host,directory):
-        mkdirCmd=MakeDirectory(name,directory,ctxt=REMOTE,remoteHost=remote_host)
+    def remote(name, remote_host, directory):
+        mkdirCmd = MakeDirectory(name, directory, ctxt=REMOTE, remoteHost=remote_host)
         mkdirCmd.run(validateAfter=True)
-   
-#-------------mv------------------   
+
+
+# -------------mv------------------
 class MoveDirectory(Command):
-    def __init__(self,name,srcDirectory,dstDirectory,ctxt=LOCAL,remoteHost=None):
-        self.srcDirectory=srcDirectory
-        self.dstDirectory=dstDirectory        
-        cmdStr="%s -f %s %s" % (findCmdInPath('mv'),srcDirectory,dstDirectory)
-        Command.__init__(self,name,cmdStr,ctxt,remoteHost)   
-        
-        
-#-------------append------------------
+    def __init__(self, name, srcDirectory, dstDirectory, ctxt=LOCAL, remoteHost=None):
+        self.srcDirectory = srcDirectory
+        self.dstDirectory = dstDirectory
+        cmdStr = "%s -f %s %s" % (findCmdInPath('mv'), srcDirectory, dstDirectory)
+        Command.__init__(self, name, cmdStr, ctxt, remoteHost)
+
+        # -------------append------------------
+
+
 class AppendTextToFile(Command):
-    
-    def __init__(self,name,file,text,ctxt=LOCAL,remoteHost=None):    
-        cmdStr="echo '%s' >> %s" %  (text, file)
-        Command.__init__(self,name,cmdStr,ctxt,remoteHost)
+    def __init__(self, name, file, text, ctxt=LOCAL, remoteHost=None):
+        cmdStr = "echo '%s' >> %s" % (text, file)
+        Command.__init__(self, name, cmdStr, ctxt, remoteHost)
 
-#-------------inline perl replace------
+
+# -------------inline perl replace------
 class InlinePerlReplace(Command):
-    
-    def __init__(self, name, fromStr, toStr, file, ctxt=LOCAL,remoteHost=None):    
-        cmdStr="%s -pi.bak -e's/%s/%s/g' %s" % (findCmdInPath('perl'), fromStr, toStr, file)
-        Command.__init__(self,name,cmdStr,ctxt,remoteHost)
+    def __init__(self, name, fromStr, toStr, file, ctxt=LOCAL, remoteHost=None):
+        cmdStr = "%s -pi.bak -e's/%s/%s/g' %s" % (findCmdInPath('perl'), fromStr, toStr, file)
+        Command.__init__(self, name, cmdStr, ctxt, remoteHost)
 
 
-#-------------rmdir------------------
+# -------------rmdir------------------
 class RemoveDirectory(Command):
-    
-    def __init__(self,name,directory,ctxt=LOCAL,remoteHost=None):
-        self.directory=directory
-        cmdStr="%s %s" % (findCmdInPath('rmdir'),directory)
-        Command.__init__(self,name,cmdStr,ctxt,remoteHost)
+    def __init__(self, name, directory, ctxt=LOCAL, remoteHost=None):
+        self.directory = directory
+        cmdStr = "%s %s" % (findCmdInPath('rmdir'), directory)
+        Command.__init__(self, name, cmdStr, ctxt, remoteHost)
 
     @staticmethod
-    def local(name,directory):
-        rmCmd=RemoveDirectory(name,directory)
-        rmCmd.run(validateAfter=True) 
-        
-    
-    @staticmethod
-    def remote(name,remote_host,directory):
-        rmCmd=RemoveDirectory(name,directory,ctxt=REMOTE,remoteHost=remote_host)
-        rmCmd.run(validateAfter=True) 
-        
+    def local(name, directory):
+        rmCmd = RemoveDirectory(name, directory)
+        rmCmd.run(validateAfter=True)
 
-    
-#-------------rm -rf ------------------
-class RemoveFiles(Command):
-    
-    def __init__(self,name,directory,ctxt=LOCAL,remoteHost=None):        
-        self.directory=directory
-        cmdStr="%s -rf %s" % (findCmdInPath('rm'),directory)
-        Command.__init__(self,name,cmdStr,ctxt,remoteHost)
-    
     @staticmethod
-    def remote(name,remote_host,directory):
-        rmCmd=RemoveFiles(name,directory,ctxt=REMOTE,remoteHost=remote_host)
-        rmCmd.run(validateAfter=True) 
-    
-    @staticmethod
-    def local(name,directory):
-        rmCmd=RemoveFiles(name,directory)
+    def remote(name, remote_host, directory):
+        rmCmd = RemoveDirectory(name, directory, ctxt=REMOTE, remoteHost=remote_host)
         rmCmd.run(validateAfter=True)
 
 
-#-------------file and dir existence -------------
-class PathIsDirectory(Command):
-    def __init__(self,name,directory,ctxt=LOCAL,remoteHost=None):
-        self.directory=directory
-        
-        cmdStr="""python -c "import os; print os.path.isdir('%s')" """ % directory
-        Command.__init__(self,name,cmdStr,ctxt,remoteHost)
-        
+# -------------rm -rf ------------------
+class RemoveFiles(Command):
+    def __init__(self, name, directory, ctxt=LOCAL, remoteHost=None):
+        self.directory = directory
+        cmdStr = "%s -rf %s" % (findCmdInPath('rm'), directory)
+        Command.__init__(self, name, cmdStr, ctxt, remoteHost)
+
     @staticmethod
-    def remote(name,remote_host,directory):
-        cmd=PathIsDirectory(name,directory,ctxt=REMOTE,remoteHost=remote_host)
-        cmd.run(validateAfter=True) 
-        return cmd.isDir() 
+    def remote(name, remote_host, directory):
+        rmCmd = RemoveFiles(name, directory, ctxt=REMOTE, remoteHost=remote_host)
+        rmCmd.run(validateAfter=True)
+
+    @staticmethod
+    def local(name, directory):
+        rmCmd = RemoveFiles(name, directory)
+        rmCmd.run(validateAfter=True)
+
+
+# -------------file and dir existence -------------
+class PathIsDirectory(Command):
+    def __init__(self, name, directory, ctxt=LOCAL, remoteHost=None):
+        self.directory = directory
+
+        cmdStr = """python -c "import os; print os.path.isdir('%s')" """ % directory
+        Command.__init__(self, name, cmdStr, ctxt, remoteHost)
+
+    @staticmethod
+    def remote(name, remote_host, directory):
+        cmd = PathIsDirectory(name, directory, ctxt=REMOTE, remoteHost=remote_host)
+        cmd.run(validateAfter=True)
+        return cmd.isDir()
 
     def isDir(self):
-        return bool (self.results.stdout.strip())
+        return bool(self.results.stdout.strip())
 
-#--------------------------
+
+# --------------------------
 
 
 class FileDirExists(Command):
-    def __init__(self,name,directory,ctxt=LOCAL,remoteHost=None):
-        self.directory=directory
-        cmdStr="""python  -c "import os; print os.path.exists('%s')" """ % directory
-        Command.__init__(self,name,cmdStr,ctxt,remoteHost)
-    
+    def __init__(self, name, directory, ctxt=LOCAL, remoteHost=None):
+        self.directory = directory
+        cmdStr = """python  -c "import os; print os.path.exists('%s')" """ % directory
+        Command.__init__(self, name, cmdStr, ctxt, remoteHost)
+
     @staticmethod
-    def remote(name,remote_host,directory):
-        cmd=FileDirExists(name,directory,ctxt=REMOTE,remoteHost=remote_host)
+    def remote(name, remote_host, directory):
+        cmd = FileDirExists(name, directory, ctxt=REMOTE, remoteHost=remote_host)
         cmd.run(validateAfter=True)
         return cmd.filedir_exists()
-    
+
     def filedir_exists(self):
-        return self.results.stdout.strip().upper()=='TRUE'
-    
+        return self.results.stdout.strip().upper() == 'TRUE'
+
+
 class CreateDirIfNecessary(Command):
-    def __init__(self,name,directory,ctxt=LOCAL,remoteHost=None):
-        self.directory=directory
-        cmdStr="""python -c "import sys, os, errno; 
+    def __init__(self, name, directory, ctxt=LOCAL, remoteHost=None):
+        self.directory = directory
+        cmdStr = """python -c "import sys, os, errno; 
 try:
 	os.mkdir('%s')
 except OSError, ex:
 	if ex.errno != errno.EEXIST:
 		raise
 " """ % (directory)
-        Command.__init__(self,name,cmdStr,ctxt,remoteHost)
-        
+        Command.__init__(self, name, cmdStr, ctxt, remoteHost)
+
     @staticmethod
-    def remote(name,remote_host,directory):
-        cmd=CreateDirIfNecessary(name,directory,ctxt=REMOTE,remoteHost=remote_host)
+    def remote(name, remote_host, directory):
+        cmd = CreateDirIfNecessary(name, directory, ctxt=REMOTE, remoteHost=remote_host)
         cmd.run(validateAfter=True)
-                
-                
+
+
 class DirectoryIsEmpty(Command):
-    def __init__(self,name,directory,ctxt=LOCAL,remoteHost=None):
-        self.directory=directory
-        cmdStr="""python -c "import os;
+    def __init__(self, name, directory, ctxt=LOCAL, remoteHost=None):
+        self.directory = directory
+        cmdStr = """python -c "import os;
 for root, dirs, files in os.walk('%s'):
     print (len(dirs) != 0 or len(files) != 0)
 " """ % self.directory
-        Command.__init__(self,name,cmdStr,ctxt,remoteHost)
-    
+        Command.__init__(self, name, cmdStr, ctxt, remoteHost)
+
     @staticmethod
-    def remote(name,remote_host,directory):
-        cmd=DirectoryIsEmpty(name,directory,ctxt=REMOTE,remoteHost=remote_host)
+    def remote(name, remote_host, directory):
+        cmd = DirectoryIsEmpty(name, directory, ctxt=REMOTE, remoteHost=remote_host)
         cmd.run(validateAfter=True)
         return cmd.isEmpty()
-    
-    def isEmpty(self):
-        return bool (self.results.stdout.strip())    
-             
-        
-#-------------scp------------------
 
-# MPP-13617                                                                                                                          
+    def isEmpty(self):
+        return bool(self.results.stdout.strip())
+
+        # -------------scp------------------
+
+
+# MPP-13617
 def canonicalize(addr):
     if ':' not in addr: return addr
     if '[' in addr: return addr
     return '[' + addr + ']'
 
+
 class RemoteCopy(Command):
-    def __init__(self,name,srcDirectory,dstHost,dstDirectory,ctxt=LOCAL,remoteHost=None):
-        self.srcDirectory=srcDirectory
-        self.dstHost=dstHost
-        self.dstDirectory=dstDirectory        
-        cmdStr="%s -o 'StrictHostKeyChecking no' -r %s %s:%s" % (findCmdInPath('scp'),srcDirectory,canonicalize(dstHost),dstDirectory)
-        Command.__init__(self,name,cmdStr,ctxt,remoteHost)
+    def __init__(self, name, srcDirectory, dstHost, dstDirectory, ctxt=LOCAL, remoteHost=None):
+        self.srcDirectory = srcDirectory
+        self.dstHost = dstHost
+        self.dstDirectory = dstDirectory
+        cmdStr = "%s -o 'StrictHostKeyChecking no' -r %s %s:%s" % (
+            findCmdInPath('scp'), srcDirectory, canonicalize(dstHost), dstDirectory)
+        Command.__init__(self, name, cmdStr, ctxt, remoteHost)
+
 
 class Scp(Command):
-    def __init__(self,name,srcFile, dstFile, srcHost=None, dstHost=None,recursive=False,ctxt=LOCAL,remoteHost=None):
+    def __init__(self, name, srcFile, dstFile, srcHost=None, dstHost=None, recursive=False, ctxt=LOCAL,
+                 remoteHost=None):
         cmdStr = findCmdInPath('scp') + " "
 
         if recursive:
@@ -674,124 +673,126 @@ class Scp(Command):
             cmdStr = cmdStr + canonicalize(dstHost) + ":"
         cmdStr = cmdStr + dstFile
 
-        Command.__init__(self,name,cmdStr,ctxt,remoteHost)
+        Command.__init__(self, name, cmdStr, ctxt, remoteHost)
 
 
-
-#-------------local copy------------------
+# -------------local copy------------------
 class LocalDirCopy(Command):
-    def __init__(self,name,srcDirectory,dstDirectory):
+    def __init__(self, name, srcDirectory, dstDirectory):
         # tar is much faster than cp for directories with lots of files
-        self.srcDirectory=srcDirectory
-        self.dstDirectory=dstDirectory
+        self.srcDirectory = srcDirectory
+        self.dstDirectory = dstDirectory
         tarCmd = SYSTEM.getTarCmd()
-        cmdStr="%s -cf - -C %s . | %s -xf - -C %s" % (tarCmd,srcDirectory,tarCmd,dstDirectory)
-        Command.__init__(self,name,cmdStr,LOCAL, None)
+        cmdStr = "%s -cf - -C %s . | %s -xf - -C %s" % (tarCmd, srcDirectory, tarCmd, dstDirectory)
+        Command.__init__(self, name, cmdStr, LOCAL, None)
 
-#-------------local copy------------------
+
+# -------------local copy------------------
 class LocalCopy(Command):
-    def __init__(self,name,srcFile,dstFile):
+    def __init__(self, name, srcFile, dstFile):
         # tar is much faster than cp for directories with lots of files
         cpCmd = SYSTEM.getCpCmd()
-        cmdStr="%s %s %s" % (cpCmd,srcFile,dstFile)
-        Command.__init__(self,name,cmdStr,LOCAL, None)
+        cmdStr = "%s %s %s" % (cpCmd, srcFile, dstFile)
+        Command.__init__(self, name, cmdStr, LOCAL, None)
 
-#------------ ssh + tar ------------------
-#TODO:  impl this.
-#tar czf - srcDir/ | ssh user@dstHost tar xzf - -C dstDir
 
-   
-#-------------create tar------------------
+# ------------ ssh + tar ------------------
+# TODO:  impl this.
+# tar czf - srcDir/ | ssh user@dstHost tar xzf - -C dstDir
+
+
+# -------------create tar------------------
 class CreateTar(Command):
-    def __init__(self,name,srcDirectory,dstTarFile,ctxt=LOCAL,remoteHost=None):
-        self.srcDirectory=srcDirectory
-        self.dstTarFile=dstTarFile
+    def __init__(self, name, srcDirectory, dstTarFile, ctxt=LOCAL, remoteHost=None):
+        self.srcDirectory = srcDirectory
+        self.dstTarFile = dstTarFile
         tarCmd = SYSTEM.getTarCmd()
-        cmdStr="%s cvPf %s -C %s  ." % (tarCmd, self.dstTarFile,srcDirectory)
-        Command.__init__(self,name,cmdStr,ctxt,remoteHost)
+        cmdStr = "%s cvPf %s -C %s  ." % (tarCmd, self.dstTarFile, srcDirectory)
+        Command.__init__(self, name, cmdStr, ctxt, remoteHost)
 
-    
-        
-#-------------extract tar---------------------
+
+# -------------extract tar---------------------
 class ExtractTar(Command):
-    def __init__(self,name,srcTarFile,dstDirectory,ctxt=LOCAL,remoteHost=None):        
-        self.srcTarFile=srcTarFile
-        self.dstDirectory=dstDirectory        
-        tarCmd = SYSTEM.getTarCmd()       
-        cmdStr="%s -C %s -xf %s" % (tarCmd, dstDirectory, srcTarFile)
-        Command.__init__(self,name,cmdStr,ctxt,remoteHost)
+    def __init__(self, name, srcTarFile, dstDirectory, ctxt=LOCAL, remoteHost=None):
+        self.srcTarFile = srcTarFile
+        self.dstDirectory = dstDirectory
+        tarCmd = SYSTEM.getTarCmd()
+        cmdStr = "%s -C %s -xf %s" % (tarCmd, dstDirectory, srcTarFile)
+        Command.__init__(self, name, cmdStr, ctxt, remoteHost)
 
-        
 
-#--------------kill ----------------------
+# --------------kill ----------------------
 class Kill(Command):
-    def __init__(self,name,pid,signal,ctxt=LOCAL,remoteHost=None):
-        self.pid=pid
-        self.signal=signal
-        cmdStr="%s -s %s %s" % (findCmdInPath('kill'), signal, pid)
-        Command.__init__(self,name,cmdStr,ctxt,remoteHost)
+    def __init__(self, name, pid, signal, ctxt=LOCAL, remoteHost=None):
+        self.pid = pid
+        self.signal = signal
+        cmdStr = "%s -s %s %s" % (findCmdInPath('kill'), signal, pid)
+        Command.__init__(self, name, cmdStr, ctxt, remoteHost)
 
     @staticmethod
-    def local(name,pid,signal):
-        cmd=Kill(name,pid,signal)
+    def local(name, pid, signal):
+        cmd = Kill(name, pid, signal)
         cmd.run(validateAfter=True)
-            
-    @staticmethod
-    def remote(name,pid,signal,remote_host):
-        cmd=Kill(name,pid,signal,ctxt=REMOTE,remoteHost=remote_host)        
-        cmd.run(validateAfter=True) 
-     
 
-#--------------kill children--------------
+    @staticmethod
+    def remote(name, pid, signal, remote_host):
+        cmd = Kill(name, pid, signal, ctxt=REMOTE, remoteHost=remote_host)
+        cmd.run(validateAfter=True)
+
+        # --------------kill children--------------
+
+
 class KillChildren(Command):
-    def __init__(self,name,pid,signal,ctxt=LOCAL,remoteHost=None):
-        self.pid=pid
-        self.signal=signal
-        cmdStr="%s -%s -P %s" % (findCmdInPath('pkill'), signal, pid)
-        Command.__init__(self,name,cmdStr,ctxt,remoteHost)
+    def __init__(self, name, pid, signal, ctxt=LOCAL, remoteHost=None):
+        self.pid = pid
+        self.signal = signal
+        cmdStr = "%s -%s -P %s" % (findCmdInPath('pkill'), signal, pid)
+        Command.__init__(self, name, cmdStr, ctxt, remoteHost)
 
     @staticmethod
-    def local(name,pid,signal):
-        cmd=KillChildren(name,pid,signal)
+    def local(name, pid, signal):
+        cmd = KillChildren(name, pid, signal)
         cmd.run(validateAfter=True)
-            
+
     @staticmethod
-    def remote(name,pid,signal,remote_host):
-        cmd=KillChildren(name,pid,signal,ctxt=REMOTE,remoteHost=remote_host)        
-        cmd.run(validateAfter=True) 
+    def remote(name, pid, signal, remote_host):
+        cmd = KillChildren(name, pid, signal, ctxt=REMOTE, remoteHost=remote_host)
+        cmd.run(validateAfter=True)
 
-#--------------pkill----------------------
+        # --------------pkill----------------------
+
+
 class Pkill(Command):
-    def __init__(self,name,processname,signal=signal.SIGTERM,ctxt=LOCAL,remoteHost=None):
-        cmdStr="%s -%s %s" % (findCmdInPath('pkill'), signal, processname)
-        Command.__init__(self,name,cmdStr,ctxt,remoteHost)
+    def __init__(self, name, processname, signal=signal.SIGTERM, ctxt=LOCAL, remoteHost=None):
+        cmdStr = "%s -%s %s" % (findCmdInPath('pkill'), signal, processname)
+        Command.__init__(self, name, cmdStr, ctxt, remoteHost)
 
 
-#--------------sadc-----------------------
+# --------------sadc-----------------------
 class Sadc(Command):
-    def __init__(self,name, outfilename, interval=5, background=False, ctxt=LOCAL, remoteHost=None):
-
+    def __init__(self, name, outfilename, interval=5, background=False, ctxt=LOCAL, remoteHost=None):
         cmdStr = SYSTEM.getSadcCmd(interval, outfilename)
         if background:
             cmdStr = "rm " + outfilename + "; nohup " + cmdStr + " < /dev/null > /dev/null 2>&1 &"
 
-        Command.__init__(self,name,cmdStr,ctxt,remoteHost)
+        Command.__init__(self, name, cmdStr, ctxt, remoteHost)
 
     @staticmethod
     def local(name, outfilename, interval, background):
-        cmd=Sadc(name, outfilename, interval, background)
+        cmd = Sadc(name, outfilename, interval, background)
         cmd.run(validateAfter=True)
-            
+
     @staticmethod
     def remote(name, outfilename, interval, background, remote_host):
-        cmd=Sadc(name, outfilename, interval, background, ctxt=REMOTE, remoteHost=remote_host)        
-        cmd.run(validateAfter=True) 
-     
+        cmd = Sadc(name, outfilename, interval, background, ctxt=REMOTE, remoteHost=remote_host)
+        cmd.run(validateAfter=True)
 
-#--------------hostname ----------------------
+        # --------------hostname ----------------------
+
+
 class Hostname(Command):
     def __init__(self, name, ctxt=LOCAL, remoteHost=None):
-        self.remotehost=remoteHost        
+        self.remotehost = remoteHost
         Command.__init__(self, name, findCmdInPath('hostname'), ctxt, remoteHost)
 
     def get_hostname(self):
@@ -799,98 +800,101 @@ class Hostname(Command):
             raise Exception, 'Command not yet executed'
         return self.results.stdout.strip()
 
-    
+
 class InterfaceAddrs(Command):
     """Returns list of interface IP Addresses.  List does not include loopback."""
+
     def __init__(self, name, ctxt=LOCAL, remoteHost=None):
         ifconfig = SYSTEM.getIfconfigCmd()
         grep = findCmdInPath('grep')
         awk = findCmdInPath('awk')
         cut = findCmdInPath('cut')
         cmdStr = '%s|%s "inet "|%s -v "127.0.0"|%s \'{print \$2}\'|%s -d: -f2' % (ifconfig, grep, grep, awk, cut)
-        Command.__init__(self,name,cmdStr,ctxt,remoteHost)
-        
+        Command.__init__(self, name, cmdStr, ctxt, remoteHost)
+
     @staticmethod
     def local(name):
-        cmd=InterfaceAddrs(name)
+        cmd = InterfaceAddrs(name)
         cmd.run(validateAfter=True)
         return cmd.get_results().stdout.split()
-    
+
     @staticmethod
     def remote(name, remoteHost):
-        cmd=InterfaceAddrs(name, ctxt=REMOTE, remoteHost=remoteHost)
+        cmd = InterfaceAddrs(name, ctxt=REMOTE, remoteHost=remoteHost)
         cmd.run(validateAfter=True)
         return cmd.get_results().stdout.split()
-        
 
-class FileContainsTerm(Command):    
+
+class FileContainsTerm(Command):
     def __init__(self, name, search_term, file, ctxt=LOCAL, remoteHost=None):
-        self.search_term=search_term
-        self.file=file
-        cmdStr="%s -c %s %s" % (findCmdInPath('grep'),search_term,file)
-        Command.__init__(self,name,cmdStr,ctxt,remoteHost)
+        self.search_term = search_term
+        self.file = file
+        cmdStr = "%s -c %s %s" % (findCmdInPath('grep'), search_term, file)
+        Command.__init__(self, name, cmdStr, ctxt, remoteHost)
 
     def contains_term(self):
         if not self.results:
             raise Exception, 'Command not yet executed'
-        count=int(self.results.stdout.strip())
+        count = int(self.results.stdout.strip())
         if count == 0:
             return False
         else:
             return True
-#--------------tcp port is active -----------------------
+
+
+# --------------tcp port is active -----------------------
 class PgPortIsActive(Command):
-    def __init__(self,name,port,file,ctxt=LOCAL, remoteHost=None):
-        self.port=port
-        cmdStr="%s -an 2>/dev/null | %s %s | %s '{print $NF}'" %\
-                (findCmdInPath('netstat'),findCmdInPath('grep'),file,findCmdInPath('awk'))
-        Command.__init__(self,name,cmdStr,ctxt,remoteHost) 
-    
+    def __init__(self, name, port, file, ctxt=LOCAL, remoteHost=None):
+        self.port = port
+        cmdStr = "%s -an 2>/dev/null | %s %s | %s '{print $NF}'" % \
+                 (findCmdInPath('netstat'), findCmdInPath('grep'), file, findCmdInPath('awk'))
+        Command.__init__(self, name, cmdStr, ctxt, remoteHost)
+
     def contains_port(self):
-        rows=self.results.stdout.strip().split()
-        
+        rows = self.results.stdout.strip().split()
+
         if len(rows) == 0:
             return False
-        
+
         for r in rows:
             val = r.split('.')
-            netstatport = int(val[ len(val) - 1 ])
+            netstatport = int(val[len(val) - 1])
             if netstatport == self.port:
                 return True
-            
+
         return False
-            
+
     @staticmethod
-    def local(name,file,port):
-        cmd=PgPortIsActive(name,port,file)
+    def local(name, file, port):
+        cmd = PgPortIsActive(name, port, file)
         cmd.run(validateAfter=True)
         return cmd.contains_port()
-            
+
     @staticmethod
-    def remote(name,file,port,remoteHost):
-        cmd=PgPortIsActive(name,port,file,ctxt=REMOTE,remoteHost=remoteHost)        
+    def remote(name, file, port, remoteHost):
+        cmd = PgPortIsActive(name, port, file, ctxt=REMOTE, remoteHost=remoteHost)
         cmd.run(validateAfter=True)
         return cmd.contains_port()
-        
-        
-    
-#--------------chmod ----------------------
+
+
+# --------------chmod ----------------------
 class Chmod(Command):
     def __init__(self, name, dir, perm, ctxt=LOCAL, remoteHost=None):
         cmdStr = '%s %s %s' % (findCmdInPath('chmod'), perm, dir)
         Command.__init__(self, name, cmdStr, ctxt, remoteHost)
-    
+
     @staticmethod
     def local(name, dir, perm):
-        cmd=Chmod(name, dir, perm)
+        cmd = Chmod(name, dir, perm)
         cmd.run(validateAfter=True)
-        
+
     @staticmethod
     def remote(name, hostname, dir, perm):
-        cmd=Chmod(name, dir, perm, ctxt=REMOTE, remoteHost=hostname)
+        cmd = Chmod(name, dir, perm, ctxt=REMOTE, remoteHost=hostname)
         cmd.run(validateAfter=True)
-        
-#--------------echo ----------------------
+
+
+# --------------echo ----------------------
 class Echo(Command):
     def __init__(self, name, echoString, ctxt=LOCAL, remoteHost=None):
         cmdStr = '%s "%s"' % (findCmdInPath('echo'), echoString)
@@ -901,18 +905,20 @@ class Echo(Command):
         cmd = Echo(name, echoString, ctxt=REMOTE, remoteHost=hostname)
         cmd.run(validateAfter=True)
 
-#--------------touch ----------------------
+
+# --------------touch ----------------------
 class Touch(Command):
     def __init__(self, name, file, ctxt=LOCAL, remoteHost=None):
         cmdStr = '%s %s' % (findCmdInPath('touch'), file)
         Command.__init__(self, name, cmdStr, ctxt, remoteHost)
-        
+
     @staticmethod
     def remote(name, file, hostname):
         cmd = Touch(name, file, ctxt=REMOTE, remoteHost=hostname)
         cmd.run(validateAfter=True)
 
-#--------------get user id ----------------------
+
+# --------------get user id ----------------------
 class UserId(Command):
     def __init__(self, name, ctxt=LOCAL, remoteHost=None):
         idCmd = findCmdInPath('id')
@@ -920,48 +926,50 @@ class UserId(Command):
         awkCmd = findCmdInPath('awk')
         cmdStr = "%s|%s '(' ' '|%s ')' ' '|%s '{print $2}'" % (idCmd, trCmd, trCmd, awkCmd)
         Command.__init__(self, name, cmdStr, ctxt, remoteHost)
-    
+
     @staticmethod
     def local(name):
-        cmd=UserId(name)
+        cmd = UserId(name)
         cmd.run(validateAfter=True)
         return cmd.results.stdout.strip()
 
-#-------------- test file for setuid bit ----------------------
+
+# -------------- test file for setuid bit ----------------------
 class FileTestSuid(Command):
-    def __init__(self,name,filename,ctxt=LOCAL,remoteHost=None):
-        cmdStr="""python -c "import os; import stat; testRes = os.stat('%s'); print (testRes.st_mode & stat.S_ISUID) == stat.S_ISUID" """ % filename
-        Command.__init__(self,name,cmdStr,ctxt,remoteHost)
-    
+    def __init__(self, name, filename, ctxt=LOCAL, remoteHost=None):
+        cmdStr = """python -c "import os; import stat; testRes = os.stat('%s'); print (testRes.st_mode & stat.S_ISUID) == stat.S_ISUID" """ % filename
+        Command.__init__(self, name, cmdStr, ctxt, remoteHost)
+
     @staticmethod
-    def remote(name,remote_host,filename):
-        cmd=FileTestSuid(name,filename,ctxt=REMOTE,remoteHost=remote_host)
+    def remote(name, remote_host, filename):
+        cmd = FileTestSuid(name, filename, ctxt=REMOTE, remoteHost=remote_host)
         cmd.run(validateAfter=True)
         return cmd.file_is_suid()
 
     def file_is_suid(self):
-        return self.results.stdout.strip().upper()=='TRUE'
+        return self.results.stdout.strip().upper() == 'TRUE'
 
-#-------------- get file owner ----------------------
+
+# -------------- get file owner ----------------------
 class FileGetOwnerUid(Command):
-    def __init__(self,name,filename,ctxt=LOCAL,remoteHost=None):
-        cmdStr="""python -c "import os; import stat; testRes = os.stat('%s'); print testRes.st_uid " """ % filename
-        Command.__init__(self,name,cmdStr,ctxt,remoteHost)
-    
+    def __init__(self, name, filename, ctxt=LOCAL, remoteHost=None):
+        cmdStr = """python -c "import os; import stat; testRes = os.stat('%s'); print testRes.st_uid " """ % filename
+        Command.__init__(self, name, cmdStr, ctxt, remoteHost)
+
     @staticmethod
-    def remote(name,remote_host,filename):
-        cmd=FileGetOwnerUid(name,filename,ctxt=REMOTE,remoteHost=remote_host)
+    def remote(name, remote_host, filename):
+        cmd = FileGetOwnerUid(name, filename, ctxt=REMOTE, remoteHost=remote_host)
         cmd.run(validateAfter=True)
         return cmd.file_uid()
 
     def file_uid(self):
         return int(self.results.stdout.strip().upper())
-    
-    
-#--------------get list of desecendant processes -------------------
+
+
+# --------------get list of desecendant processes -------------------
 
 def getDescendentProcesses(pid):
-    ''' return all process pids which are descendant from the given processid ''' 
+    ''' return all process pids which are descendant from the given processid '''
 
     children_pids = []
 
@@ -969,10 +977,10 @@ def getDescendentProcesses(pid):
         if p.is_running():
             children_pids.append(p.pid)
 
-    return children_pids 
+    return children_pids
 
-        
-#--------------global variable initialization ----------------------
+
+# --------------global variable initialization ----------------------
 
 if curr_platform == SUNOS:
     SYSTEM = SolarisPlatform()
@@ -983,5 +991,4 @@ elif curr_platform == DARWIN:
 elif curr_platform == FREEBSD:
     SYSTEM = FreeBsdPlatform()
 else:
-    raise Exception("Platform %s is not supported.  Supported platforms are:"\
-                    " %s", SYSTEM, str(platform_list))
+    raise Exception("Platform %s is not supported.  Supported platforms are: %s", SYSTEM, str(platform_list))

--- a/gpMgmt/bin/gppylib/gparray.py
+++ b/gpMgmt/bin/gppylib/gparray.py
@@ -463,7 +463,7 @@ class GpDB:
                 res = cpCmd.get_results()
 
             # Remove the gp_dbid file from the data dir
-            RemoveFiles.local('Remove gp_dbid file', os.path.normpath(dstDir + '/gp_dbid'))
+            RemoveFile.local('Remove gp_dbid file', os.path.normpath(dstDir + '/gp_dbid'))
             logger.info("Cleaning up catalog for schema only copy on destination")
             # We need 700 permissions or postgres won't start
             Chmod.local('set template permissions', dstDir, '0700')

--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -674,13 +674,13 @@ class GpMirrorListToBuild:
         logger.info('Cleaning files')
         cmds = []
         for hostName, segments in destSegmentByHost.iteritems():
-            cmds.append(unix.RemoveFiles('remove tar file', tarFileName, ctxt=gp.REMOTE, remoteHost=hostName))
+            cmds.append(unix.RemoveFile('remove tar file', tarFileName, ctxt=gp.REMOTE, remoteHost=hostName))
         self.__runWaitAndCheckWorkerPoolForErrorsAndClear(cmds, "cleaning up tar file on segment hosts")
 
         #
         # clean up the local temp directory
         #
-        unix.RemoveFiles.local('remove temp directory', tempDir)
+        unix.RemoveDirectory.local('remove temp directory', tempDir)
 
     def _get_running_postgres_segments(self, segments):
         running_segments = []

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_unix.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_unix.py
@@ -3,12 +3,14 @@
 # Copyright (c) Greenplum Inc 2014. All Rights Reserved. 
 #
 
-import unittest
 from gppylib.commands.base import CommandResult
-from gppylib.operations.unix import RemoteOperation, CleanSharedMem
+from gppylib.operations.unix import CleanSharedMem
 from mock import Mock, MagicMock, patch
 
-class CleanSharedMemTestCase(unittest.TestCase):
+from test.unit.gp_unittest import GpTestCase, run_tests
+
+
+class CleanSharedMemTestCase(GpTestCase):
     def _get_mock_segment(self, name, datadir, port, hostname, address):
         m = Mock()
         m.name = name
@@ -38,7 +40,7 @@ class CleanSharedMemTestCase(unittest.TestCase):
 
     @patch('os.path.isfile', return_value=True)
     @patch('gppylib.operations.unix.Command.get_results', return_value=CommandResult(1, '', '', False, False))
-    def test_run_with_invalid_pid_file(self, mock1, mock2): 
+    def test_run_with_invalid_pid_file(self, mock1, mock2):
         segments = [self._get_mock_segment('seg1', '/tmp/gpseg1', 1234, 'host1', 'host1')]
         c = CleanSharedMem(segments)
         file_contents = 'asdfadsasdfasdf'.split()
@@ -51,7 +53,7 @@ class CleanSharedMemTestCase(unittest.TestCase):
     @patch('os.path.isfile', return_value=True)
     @patch('gppylib.operations.unix.Command.run')
     @patch('gppylib.operations.unix.Command.get_results', return_value=CommandResult(1, '', '', False, False))
-    def test_run_with_error_in_workerpool(self, mock1, mock2, mock3): 
+    def test_run_with_error_in_workerpool(self, mock1, mock2, mock3):
         segments = [self._get_mock_segment('seg1', '/tmp/gpseg1', 1234, 'host1', 'host1')]
         c = CleanSharedMem(segments)
         file_contents = 'asdfads\nasdfsd asdfadsf\n12345 23456'.split()
@@ -60,3 +62,7 @@ class CleanSharedMemTestCase(unittest.TestCase):
         with patch('__builtin__.open', m, create=True):
             with self.assertRaisesRegexp(Exception, 'Unable to clean up shared memory'):
                 c.run()
+
+
+if __name__ == '__main__':
+    run_tests()

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_command.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_command.py
@@ -1,6 +1,7 @@
 from commands.base import Command, CommandResult, REMOTE, GPHOME
 from gp_unittest import *
 
+
 class CommandTest(GpTestCase):
     def setUp(self):
         self.subject = Command("my name", "my command string")
@@ -49,6 +50,12 @@ class CommandTest(GpTestCase):
     def test_create_command_with_custom_gphome(self):
         self.subject = Command("my name", "my command string", ctxt=REMOTE, remoteHost="someHost", gphome="/new/gphome")
         self.assertIn("/new/gphome", self.subject.exec_context.gphome)
+
+    def test_running_command_remembers_pid(self):
+        self.subject = Command("my name", "ls")
+        self.subject.pid = -1
+        self.subject.run()
+        self.assertTrue(self.subject.pid > 0)
 
 if __name__ == '__main__':
     run_tests()

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_commands_unix.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_commands_unix.py
@@ -1,0 +1,103 @@
+import os
+
+from mock import patch
+
+from commands.unix import RemoveFile, RemoveDirectory, RemoveDirectoryContents, RemoveGlob
+from gp_unittest import *
+
+
+class CommandsUnix(GpTestCase):
+    def setUp(self):
+        self.dir = "/tmp/command_unix_test"
+        if not os.path.exists(self.dir):
+            os.mkdir(self.dir)
+        self.filepath = self.dir + "/foo"
+
+        self.apply_patches([
+            patch("uuid.uuid4", return_value="Patched"),
+        ])
+        open(self.filepath, 'a').close()
+
+    def tearDown(self):
+        RemoveDirectory.local("", self.dir)
+        super(CommandsUnix, self).tearDown()
+
+    def test_RemoveFile_for_file_succeeds_locally(self):
+        RemoveFile.local("testing", self.filepath)
+        self.assertFalse(os.path.exists(self.filepath))
+        self.assertTrue(os.path.exists(self.dir))
+
+    def test_RemoveFile_for_file_with_nonexistent_file_succeeds(self):
+        RemoveFile.local("testing", "/doesnotexist")
+        self.assertTrue(os.path.exists(self.filepath))
+        self.assertTrue(os.path.exists(self.dir))
+
+
+    def test_RemoveDirectory_succeeds_locally(self):
+        RemoveDirectory.local("testing", self.dir)
+        self.assertFalse(os.path.exists(self.dir))
+        self.assertFalse(os.path.exists("/tmp/emptyForRemovePatched"))
+
+    def test_RemoveDirectory_with_nonexistent_dir_succeeds(self):
+        RemoveDirectory.local("testing", "/doesnotexist")
+        self.assertTrue(os.path.exists(self.dir))
+
+    def test_RemoveDirectory_succeeds_with_slash(self):
+        RemoveDirectory.local("testing", self.dir + "/")
+        self.assertFalse(os.path.exists(self.dir))
+        self.assertFalse(os.path.exists("/tmp/emptyForRemovePatched"))
+
+    def test_RemoveDirectoryContents_succeeds_locally(self):
+        RemoveDirectoryContents.local("testing", self.dir)
+        self.assertTrue(os.path.exists(self.dir))
+        self.assertFalse(os.path.exists(self.filepath))
+        self.assertFalse(os.path.exists("/tmp/emptyForRemovePatched"))
+
+    def test_RemoveDirectoryContents_with_nonexistent_dir_succeeds(self):
+        RemoveDirectoryContents.local("testing", "/doesnotexist")
+        self.assertTrue(os.path.exists(self.dir))
+        self.assertFalse(os.path.exists("/tmp/emptyForRemovePatched"))
+
+    def test_RemoveDirectoryContents_with_slash(self):
+        RemoveDirectoryContents.local("testing", self.dir + "/")
+        self.assertTrue(os.path.exists(self.dir))
+        self.assertFalse(os.path.exists(self.filepath))
+        self.assertFalse(os.path.exists("/tmp/emptyForRemovePatched"))
+
+    def test_RemoveGlob_succeeds_locally(self):
+        RemoveGlob.local("testing", self.dir + "/f*")
+        self.assertFalse(os.path.exists(self.filepath))
+        self.assertTrue(os.path.exists(self.dir))
+
+    def test_RemoveGlob_with_nonexistent_succeeds(self):
+        RemoveGlob.local("testing", "/doesnotexist")
+        self.assertTrue(os.path.exists(self.filepath))
+        self.assertTrue(os.path.exists(self.dir))
+
+    # Note: remote tests use ssh to localhost, which is not really something that should be done in a true unit test.
+    # we leave them here, commented out, for development usage only.
+
+    # def test_RemoveFile_for_file_succeeds_remotely(self):
+    #     RemoveFile.remote("testing", "localhost", self.filepath)
+    #     self.assertFalse(os.path.exists(self.filepath))
+    #     self.assertTrue(os.path.exists(self.dir))
+
+    # def test_RemoveDirectory_succeeds_remotely(self):
+    #     RemoveDirectory.remote("testing", "localhost", self.dir)
+    #     self.assertFalse(os.path.exists(self.dir))
+    #     self.assertFalse(os.path.exists("/tmp/emptyForRemovePatched"))
+
+    # def test_RemoveDirectoryContents_succeeds_remotely(self):
+    #     RemoveDirectoryContents.remote("testing", "localhost", self.dir)
+    #     self.assertTrue(os.path.exists(self.dir))
+    #     self.assertFalse(os.path.exists(self.filepath))
+    #     self.assertFalse(os.path.exists("/tmp/emptyForRemovePatched"))
+
+    # def test_RemoveGlob_succeeds_remotely(self):
+    #     RemoveGlob.remote("testing", "localhost", self.dir + "/f*")
+    #     self.assertFalse(os.path.exists(self.filepath))
+    #     self.assertTrue(os.path.exists(self.dir))
+
+
+if __name__ == '__main__':
+    run_tests()

--- a/gpMgmt/bin/gptransfer
+++ b/gpMgmt/bin/gptransfer
@@ -13,8 +13,8 @@
 # it is provided by or on behalf of Pivotal Software, Inc.
 
 """
-gptransfer utility is for tranfering one GPDB system to another. Currently
-only table data or the entire system can be transfered.  In the future this
+gptransfer utility is for transferring one GPDB system to another. Currently
+only table data or the entire system can be transferred.  In the future this
 transfer will include dependent roles, UDFs, UDTs, views, resource queues,
 and possibly a subset of system configuration of specified tables.
 """
@@ -36,20 +36,15 @@ from gppylib.gpversion import GpVersion
 from gptransfer_modules.partition_comparators import PartitionComparatorFactory
 
 try:
-    from gppylib.mainUtils import simple_main, addStandardLoggingAndHelpOptions, \
-        ProgramArgumentValidationException
+    from gppylib.mainUtils import simple_main, addStandardLoggingAndHelpOptions, ProgramArgumentValidationException
     from gppylib.gplog import get_default_logger
     from gppylib.gpparseopts import OptParser, OptChecker
-    from gppylib.commands.base import Command, LOCAL, REMOTE, WorkerPool, \
-        ExecutionError, CommandResult
-    from gppylib.commands.unix import MakeDirectory, RemoveDirectory, \
-        RemoveFiles, FileDirExists, Scp, LINUX, curr_platform
+    from gppylib.commands.base import Command, LOCAL, REMOTE, WorkerPool, ExecutionError, CommandResult
+    from gppylib.commands.unix import MakeDirectory, RemoveDirectory, FileDirExists, RemoveGlob
     from gppylib.commands.gp import get_gphome
     from gppylib.db import dbconn
-    from gppylib.db.dbconn import connect, DbURL, execSQL, \
-        execSQLForSingletonRow, UnexpectedRowsError
-    from gppylib.db.catalog import getUserDatabaseList, doesSchemaExist, \
-        dropSchemaIfExist
+    from gppylib.db.dbconn import connect, DbURL, execSQL, execSQLForSingletonRow
+    from gppylib.db.catalog import getUserDatabaseList, doesSchemaExist, dropSchemaIfExist
     from gppylib.gparray import GpArray
     from gppylib.userinput import ask_yesno
     from gppylib.operations.backup_utils import escapeDoubleQuoteInSQLString
@@ -2251,18 +2246,18 @@ FROM (
 
         for host in self._host_map.keys():
             address = iter(self._host_map[host]).next()
-            cmd = RemoveFiles('remove dir for table %s'
+            cmd = RemoveDirectory('remove dir for table %s'
                               % self._table_pair.source,
                               os.path.dirname(self._pipe),
                               REMOTE, address)
             self._pool.addCommand(cmd)
 
-        cmd = RemoveFiles('remove dir for table %s'
+        cmd = RemoveDirectory('remove dir for table %s'
                           % self._table_pair.source,
                           os.path.dirname(self._pipe),
                           REMOTE, self._dest_host)
         self._pool.addCommand(cmd)
-        cmd = RemoveFiles('remove dir for table %s'
+        cmd = RemoveDirectory('remove dir for table %s'
                           % self._table_pair.source,
                           os.path.dirname(self._pipe),
                           REMOTE, self._src_host)
@@ -2788,8 +2783,8 @@ class GpTransfer(object):
 
             for host in self._host_map.keys():
                 address = iter(self._host_map[host]).next()
-                cmd = RemoveFiles('stopping gpfdist on %s' % address,
-                                os.path.join(self._work_dir, '*.pid' ), REMOTE, address)
+                cmd = RemoveGlob('stopping gpfdist on %s' % address,
+                                 os.path.join(self._work_dir, '*.pid' ), REMOTE, address)
                 self._pool.addCommand(cmd)
             # We join() here so that all pid files are removed before directories,
             # ensuring that empty directories are removed

--- a/gpMgmt/bin/lib/gpconfigurenewsegment
+++ b/gpMgmt/bin/lib/gpconfigurenewsegment
@@ -126,7 +126,7 @@ class ConfExpSegCmd(Command):
                 targetDir = self.filespaceDirs[i]
                 cpCmd = unix.LocalDirCopy("copy filespace from %s to %s" % (sourceDir, targetDir), sourceDir, targetDir)
                 cpCmd.run(validateAfter=True)
-            unix.RemoveFiles.local("remove filespace template after copy to proper location", filespaceDataDir)
+            unix.RemoveDirectory.local("remove filespace template after copy to proper location", filespaceDataDir)
         except Exception, e:
             self.set_results(CommandResult(1, '', e, True, False))
             raise

--- a/gpMgmt/sbin/gpcleansegmentdir.py
+++ b/gpMgmt/sbin/gpcleansegmentdir.py
@@ -40,9 +40,9 @@ class GpCleanSegmentDirectoryProgram:
 
             for toClean in gDatabaseDirectories:
                 if toClean != "pg_log":
-                    unix.RemoveFiles('clean segment', os.path.join(dir, toClean)).run( validateAfter=True )
+                    unix.RemoveDirectory('clean segment', os.path.join(dir, toClean)).run(validateAfter=True)
             for toClean in gDatabaseFiles:
-                unix.RemoveFiles('clean segment', os.path.join(dir, toClean)).run( validateAfter=True )
+                unix.RemoveFile('clean segment', os.path.join(dir, toClean)).run(validateAfter=True)
 
         for segment in segments:
             for filespaceOid, dir in segment.getSegmentFilespaces().iteritems():
@@ -50,7 +50,7 @@ class GpCleanSegmentDirectoryProgram:
                     #
                     # delete entire filespace directory -- filerep code on server will recreate it
                     #
-                    unix.RemoveFiles('clean segment filespace dir', dir ).run( validateAfter=True )
+                    unix.RemoveDirectory('clean segment filespace dir', dir).run(validateAfter=True)
 
     def cleanup(self):
         pass

--- a/gpMgmt/sbin/gprepairmirrorseg.py
+++ b/gpMgmt/sbin/gprepairmirrorseg.py
@@ -484,8 +484,8 @@ try:
             cmd.run(validateAfter=True)
             logger.info(str(cmd))
         if action == DELETE:
-            cmd = RemoveFiles(name="gprepairmirrorseg remove extra file", directory=sourceFile, ctxt=LOCAL,
-                              remoteHost=sourceHost)
+            cmd = RemoveFile(name="gprepairmirrorseg remove extra file", directory=sourceFile, ctxt=LOCAL,
+                             remoteHost=sourceHost)
             cmd.run(validateAfter=True)
             logger.info(str(cmd))
         if action == NO_ACTION:

--- a/gpMgmt/sbin/gprepairmirrorseg.py
+++ b/gpMgmt/sbin/gprepairmirrorseg.py
@@ -18,11 +18,8 @@ import tempfile
 import threading
 import traceback
 
-
-
 sys.path.append(os.path.join(os.path.dirname(__file__), "../bin"))
 sys.path.append(os.path.join(os.path.dirname(__file__), "../bin/lib"))
-
 
 try:
     from pysync import *
@@ -44,7 +41,7 @@ except ImportError, e:
 #
 
 EXECNAME = os.path.split(__file__)[-1]
-FULL_EXECNAME = os.path.abspath( __file__ )
+FULL_EXECNAME = os.path.abspath(__file__)
 
 HOME_DIRECTORY = os.path.expanduser("~")
 
@@ -54,12 +51,12 @@ PID_FILE = GPADMINLOGS_DIRECTORY + '/gprepairmirrorseg.pid'
 
 DESCRIPTION = ("""Repair utility to re-sync primary and mirror files.""")
 
-_help  = [""" TODO add help """]
+_help = [""" TODO add help """]
 
 _usage = """ TODO add usage """
 
 TEN_MEG = 10485760
-ONE_GIG = 128  * TEN_MEG
+ONE_GIG = 128 * TEN_MEG
 TEN_GIG = 1024 * TEN_MEG
 
 PID_FILE = "gprepairmirrorseg.pid"
@@ -67,53 +64,52 @@ PID_FILE = "gprepairmirrorseg.pid"
 # Keep the value of the name/value dictionary entry the same length for printing.
 categoryAction = {}
 
-COPY       = 'COPY     '
-DELETE     = 'DELETE   '
-NO_ACTION  = 'NO ACTION'
+COPY = 'COPY     '
+DELETE = 'DELETE   '
+NO_ACTION = 'NO ACTION'
 
-categoryAction['ao:']              = COPY
-categoryAction['heap:']            = COPY
-categoryAction['btree:']           = COPY
-categoryAction['extra_p:']         = COPY
-categoryAction['extra_m:']         = DELETE
+categoryAction['ao:'] = COPY
+categoryAction['heap:'] = COPY
+categoryAction['btree:'] = COPY
+categoryAction['extra_p:'] = COPY
+categoryAction['extra_m:'] = DELETE
 categoryAction['missing_topdir_p:'] = COPY
 categoryAction['missing_topdir_m:'] = COPY
-categoryAction['unknown:']         = NO_ACTION
+categoryAction['unknown:'] = NO_ACTION
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 def prettyPrintFiles(resyncFile):
-  
-  fileIndex = 0
-  fileListLength = len(resyncFile.fileList)
-  
-  for fileIndex in range(fileListLength):
-      category = resyncFile.getCategory(fileIndex)
-      action   = categoryAction[category]
-      logger.info("")
-      logger.info("  Resync file number %d" % (fileIndex + 1))
-      if action == COPY:
-         logger.info("    Copy source to target" )
-         logger.info("    " + "Source Host = " + resyncFile.getSourceHost(fileIndex))
-         logger.info("    " + "Source File = " + resyncFile.getSourceFile(fileIndex))
-         logger.info("    " + "Target Host = " + resyncFile.getTargetHost(fileIndex))
-         logger.info("    " + "Target File = " + resyncFile.getTargetFile(fileIndex))
-         logger.info("")
-      if action == DELETE:
-         logger.info("    Delete file")
-         logger.info("    " + "Host = " + resyncFile.getSourceHost(fileIndex))
-         logger.info("    " + "File = " + resyncFile.getSourceFile(fileIndex))
-      if action == NO_ACTION:
-         logger.info("    Unknown file type. No action will be taken.")
-         logger.info("    " + "Source Host = " + resyncFile.getSourceHost(fileIndex))
-         logger.info("    " + "Source File = " + resyncFile.getSourceFile(fileIndex))
-         logger.info("    " + "Target Host = " + resyncFile.getTargetHost(fileIndex))
-         logger.info("    " + "Target File = " + resyncFile.getTargetFile(fileIndex))
-  
-  logger.info("")
+    fileIndex = 0
+    fileListLength = len(resyncFile.fileList)
+
+    for fileIndex in range(fileListLength):
+        category = resyncFile.getCategory(fileIndex)
+        action = categoryAction[category]
+        logger.info("")
+        logger.info("  Resync file number %d" % (fileIndex + 1))
+        if action == COPY:
+            logger.info("    Copy source to target")
+            logger.info("    " + "Source Host = " + resyncFile.getSourceHost(fileIndex))
+            logger.info("    " + "Source File = " + resyncFile.getSourceFile(fileIndex))
+            logger.info("    " + "Target Host = " + resyncFile.getTargetHost(fileIndex))
+            logger.info("    " + "Target File = " + resyncFile.getTargetFile(fileIndex))
+            logger.info("")
+        if action == DELETE:
+            logger.info("    Delete file")
+            logger.info("    " + "Host = " + resyncFile.getSourceHost(fileIndex))
+            logger.info("    " + "File = " + resyncFile.getSourceFile(fileIndex))
+        if action == NO_ACTION:
+            logger.info("    Unknown file type. No action will be taken.")
+            logger.info("    " + "Source Host = " + resyncFile.getSourceHost(fileIndex))
+            logger.info("    " + "Source File = " + resyncFile.getSourceFile(fileIndex))
+            logger.info("    " + "Target Host = " + resyncFile.getTargetHost(fileIndex))
+            logger.info("    " + "Target File = " + resyncFile.getTargetFile(fileIndex))
+
+    logger.info("")
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 def sshBusy(cmd):
     """ 
       This function will check the results of a Command to see if ssh was too busy.
@@ -124,17 +120,16 @@ def sshBusy(cmd):
     results = cmd.get_results()
     resultStr = results.printResult()
     if results.rc != 0:
-       if resultStr.find("ssh_exchange_identification: Connection closed by remote host") != -1:
-          retValue = True
-       else:
-          retValue = False
+        if resultStr.find("ssh_exchange_identification: Connection closed by remote host") != -1:
+            retValue = True
+        else:
+            retValue = False
     else:
-       retValue = False
+        retValue = False
     return retValue
 
 
-
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 def runAndCheckCommandComplete(cmd):
     """ 
       This function will run a Command and return False if ssh was too busy.
@@ -142,44 +137,42 @@ def runAndCheckCommandComplete(cmd):
       if ssh wasn't busy. 
     """
     retValue = True
-    cmd.run(validateAfter = False)
+    cmd.run(validateAfter=False)
     if sshBusy(cmd) == True:
-       """ Couldn't make the connection. put in a delay, and return"""
-       self.logger.debug("gprepairmirrorseg ssh is busy... need to retry the command: " + str(cmd))
-       time.sleep(1)
-       retValue = False
+        """ Couldn't make the connection. put in a delay, and return"""
+        self.logger.debug("gprepairmirrorseg ssh is busy... need to retry the command: " + str(cmd))
+        time.sleep(1)
+        retValue = False
     else:
-       retValue = True
+        retValue = True
     return retValue
 
 
-#-------------------------------------------------------------------------------                                                             
+# -------------------------------------------------------------------------------
 def parseargs():
-    parser = OptParser( option_class = OptChecker
-                      , description  = ' '.join(DESCRIPTION.split())
-                      , version      = '%prog version $Revision: #12 $'
-                      )
+    parser = OptParser(option_class=OptChecker
+                       , description=' '.join(DESCRIPTION.split())
+                       , version='%prog version $Revision: #12 $'
+                       )
     parser.setHelp(_help)
     parser.set_usage('%prog ' + _usage)
     parser.remove_option('-h')
 
     parser.add_option('-f', '--file', default='',
                       help='the name of a file containing the re-sync file list.')
-    parser.add_option('-v','--verbose', action='store_true',
+    parser.add_option('-v', '--verbose', action='store_true',
                       help='debug output.', default=False)
     parser.add_option('-h', '-?', '--help', action='help',
-                        help='show this help message and exit.', default=False)
-    parser.add_option('--usage', action="briefhelp")    
+                      help='show this help message and exit.', default=False)
+    parser.add_option('--usage', action="briefhelp")
     parser.add_option('-d', '--master_data_directory', type='string',
-                        dest="masterDataDirectory",
-                        metavar="<master data directory>",
-                        help="Optional. The master host data directory. If not specified, the value set for $MASTER_DATA_DIRECTORY will be used.",
-                        default=get_masterdatadir()
-                     )
+                      dest="masterDataDirectory",
+                      metavar="<master data directory>",
+                      help="Optional. The master host data directory. If not specified, the value set for $MASTER_DATA_DIRECTORY will be used.",
+                      default=get_masterdatadir()
+                      )
     parser.add_option('-a', help='don\'t ask to confirm repairs',
                       dest='confirm', default=True, action='store_false')
-
-
 
     """
      Parse the command line arguments
@@ -192,7 +185,8 @@ def parseargs():
 
     return options, args
 
-#-------------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------------
 def sig_handler(sig, arg):
     print "Handling signal..."
     signal.signal(signal.SIGTERM, signal.SIG_DFL)
@@ -202,7 +196,7 @@ def sig_handler(sig, arg):
     os.kill(os.getpid(), sig)
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 def create_pid_file():
     """Creates gprepairmirrorseg pid file"""
     try:
@@ -214,7 +208,7 @@ def create_pid_file():
         if fp: fp.close()
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 def remove_pid_file():
     """Removes upgrademirror pid file"""
     try:
@@ -223,7 +217,7 @@ def remove_pid_file():
         pass
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 def is_gprepairmirrorseg_running():
     """Checks if there is another instance of gprepairmirrorseg running"""
     is_running = False
@@ -239,29 +233,30 @@ def is_gprepairmirrorseg_running():
 
     return is_running
 
-#-------------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------------
 def check_master_running():
     logger.debug("Check if Master is running...")
     if os.path.exists(options.masterDataDirectory + '/postmaster.pid'):
-       logger.warning("postmaster.pid file exists on Master")
-       logger.warning("The database must not be running during gprepairmirrorseg.")
+        logger.warning("postmaster.pid file exists on Master")
+        logger.warning("The database must not be running during gprepairmirrorseg.")
 
-       # Would be nice to check the standby master as well, but if the system is down, we can't find it.
-       raise Exception("Unable to continue gprepairmirrorseg")
+        # Would be nice to check the standby master as well, but if the system is down, we can't find it.
+        raise Exception("Unable to continue gprepairmirrorseg")
 
 
-#-------------------------------------------------------------------------------
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 class InvalidStatusError(Exception): pass
 
 
-#-------------------------------------------------------------------------------
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 class ValidationError(Exception): pass
 
 
-#-------------------------------------------------------------------------------
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 class GPResyncFile:
     """ 
       This class represents the information stored in the resync file.
@@ -279,19 +274,18 @@ class GPResyncFile:
         extra_m  - An extra file on the mirror, which is the same as the <bad-segment>
        
     """
-    
 
     def __init__(self, filename):
         self.filename = filename
         self.fileList = []
         self.readfile()
 
-    #-------------------------------------------------------------------------------
+    # -------------------------------------------------------------------------------
     def __str__(self):
-       tempStr = "self.filename = " + str(self.filename) + '\n'
-       return tempStr
+        tempStr = "self.filename = " + str(self.filename) + '\n'
+        return tempStr
 
-    #-------------------------------------------------------------------------------                                                     
+    # -------------------------------------------------------------------------------
     def readfile(self):
         try:
             file = None
@@ -308,66 +302,67 @@ class GPResyncFile:
             raise Exception("Unable to read file: %s" % self.filename)
         finally:
             if file != None:
-               file.close()
+                file.close()
 
-    #-------------------------------------------------------------------------------
+    # -------------------------------------------------------------------------------
     def getEntry(self, index):
         logger.debug("Entering getEntry, index = %s" % str(index))
         return self.fileList[index]
 
-    #-------------------------------------------------------------------------------                                                     
+    # -------------------------------------------------------------------------------
     def getCategory(self, index):
         return self.fileList[index][0]
 
-    #-------------------------------------------------------------------------------
+    # -------------------------------------------------------------------------------
     def getSourceHost(self, index):
         return str(self.fileList[index][1])
 
-    #-------------------------------------------------------------------------------
+    # -------------------------------------------------------------------------------
     def getSourceFile(self, index):
         return str(self.fileList[index][2])
-    
-    #-------------------------------------------------------------------------------
-    def getTargetHost(self, index):
-        return str(self.fileList[index][3])    
 
-    #-------------------------------------------------------------------------------
+    # -------------------------------------------------------------------------------
+    def getTargetHost(self, index):
+        return str(self.fileList[index][3])
+
+        # -------------------------------------------------------------------------------
+
     def getTargetFile(self, index):
         return str(self.fileList[index][4])
 
 
-#------------------------------------------------------------------------
-#-------------------------------------------------------------------------                    
+# ------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class RemoteCopyPreserve(Command):
-    def __init__( self
-                , name
-                , srcDirectory
-                , dstHost
-                , dstDirectory
-                , ctxt = LOCAL
-                , remoteHost = None
-                ):
+    def __init__(self
+                 , name
+                 , srcDirectory
+                 , dstHost
+                 , dstDirectory
+                 , ctxt=LOCAL
+                 , remoteHost=None
+                 ):
         self.srcDirectory = srcDirectory
         self.dstHost = dstHost
-        self.dstDirectory = dstDirectory        
-        cmdStr="%s -rp %s %s:%s" % (findCmdInPath('scp'),srcDirectory,dstHost,dstDirectory)
-        Command.__init__(self,name,cmdStr,ctxt,remoteHost)
+        self.dstDirectory = dstDirectory
+        cmdStr = "%s -rp %s %s:%s" % (findCmdInPath('scp'), srcDirectory, dstHost, dstDirectory)
+        Command.__init__(self, name, cmdStr, ctxt, remoteHost)
 
 
-#-------------------------------------------------------------------------
-#-------------------------------------------------------------------------                                                       
+# -------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class MoveDirectoryContents(Command):
     """ This class moves the contents of a local directory."""
 
-    def __init__( self
-                , name
-                , srcDirectory
-                , dstDirectory
-                , ctxt = LOCAL
-                , remoteHost = None
-                ):
+    def __init__(self
+                 , name
+                 , srcDirectory
+                 , dstDirectory
+                 , ctxt=LOCAL
+                 , remoteHost=None
+                 ):
         self.srcDirectory = srcDirectory
-        self.srcDirectoryFiles = self.srcDirectory + "." + 'dirfilelist' 
+        self.srcDirectoryFiles = self.srcDirectory + "." + 'dirfilelist'
         self.dstDirectory = dstDirectory
         ls = findCmdInPath("ls")
         cat = findCmdInPath("cat")
@@ -377,25 +372,25 @@ class MoveDirectoryContents(Command):
         cmdStr = cmdStr + ";%s %s" % (cat, self.srcDirectoryFiles)
         cmdStr = cmdStr + " | %s -I xxx %s %s/xxx %s" % (xargs, mv, self.srcDirectory, self.dstDirectory)
         cmdStr = cmdStr + "; rm %s" % (self.srcDirectoryFiles)
-        Command.__init__(self,name,cmdStr,ctxt,remoteHost)
-        
+        Command.__init__(self, name, cmdStr, ctxt, remoteHost)
 
-#-------------------------------------------------------------------------
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class PySyncPlus(PySync):
     """
     This class is really just PySync but it records all the parameters passed in.
     """
 
-    def __init__( self
-                , name
-                , srcDir
-                , dstHost
-                , dstDir
-                , ctxt = LOCAL
-                , remoteHost = None
-                , options = None
-                ):
+    def __init__(self
+                 , name
+                 , srcDir
+                 , dstHost
+                 , dstDir
+                 , ctxt=LOCAL
+                 , remoteHost=None
+                 , options=None
+                 ):
         self.namePlus = name
         self.srcDirPlus = srcDir
         self.dstHostPlus = dstHost
@@ -403,127 +398,128 @@ class PySyncPlus(PySync):
         self.ctxtPlus = ctxt
         self.remoteHostPlus = remoteHost
         self.optionsPlus = options
-        PySync.__init__( self
-                       , name = name
-                       , srcDir = srcDir
-                       , dstHost = dstHost
-                       , dstDir = dstDir
-                       , ctxt = ctxt
-                       , remoteHost = remoteHost
-                       , options = options 
-                       )
+        PySync.__init__(self
+                        , name=name
+                        , srcDir=srcDir
+                        , dstHost=dstHost
+                        , dstDir=dstDir
+                        , ctxt=ctxt
+                        , remoteHost=remoteHost
+                        , options=options
+                        )
         self.destinationHost = dstHost
 
 
-#-------------------------------------------------------------------------------
-#--------------------------------- Main ----------------------------------------
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
+# --------------------------------- Main ----------------------------------------
+# -------------------------------------------------------------------------------
 """ 
    This the the main body of code for gprepairmirrorseg.
 """
 
-
-
 try:
-  # setup signal handlers so we can clean up correctly
-  signal.signal(signal.SIGTERM, sig_handler)
-  signal.signal(signal.SIGHUP, sig_handler)
-  
-  logger = get_default_logger()
-  applicationName = EXECNAME
-  setup_tool_logging( appName = applicationName
-                    , hostname = getLocalHostname()
-                    , userName = getUserName()
-                    )
+    # setup signal handlers so we can clean up correctly
+    signal.signal(signal.SIGTERM, sig_handler)
+    signal.signal(signal.SIGHUP, sig_handler)
 
-  options, args = parseargs()
-  
-  check_master_running()
+    logger = get_default_logger()
+    applicationName = EXECNAME
+    setup_tool_logging(appName=applicationName
+                       , hostname=getLocalHostname()
+                       , userName=getUserName()
+                       )
 
-  if options.file == None or len(options.file) == 0:
-     logger.error('The --file command line argument is required')
-     raise Exception("Unable to continue")
+    options, args = parseargs()
 
-  if options.verbose:
-     enable_verbose_logging()
+    check_master_running()
 
-  if is_gprepairmirrorseg_running():
-     logger.error('gprepairmirrorseg is already running.  Only one instance')
-     logger.error('of gprepairmirrorseg is allowed at a time.')
-     remove_pid = False
-     sys.exit(1)
-  else:
-     create_pid_file()
+    if options.file == None or len(options.file) == 0:
+        logger.error('The --file command line argument is required')
+        raise Exception("Unable to continue")
 
-  resyncFiles = GPResyncFile(options.file)  
-  logger.info("gprepairmirrorseg will attempt to repair the following files:")
-  prettyPrintFiles(resyncFiles)
+    if options.verbose:
+        enable_verbose_logging()
 
-  if options.confirm == True:
-     msg = "Do you wish to continue with re-sync of these files"
-     ans = ask_yesno(None,msg,'N')
-     if not ans:
-        logger.info("User abort requested, Exiting...")
-        sys.exit(4)
-     
-     msg = "Are you sure you wish to continue"
-     ans = ask_yesno(None,msg,'N')
-     if not ans:
-        logger.info("User abort requested, Exiting...")
-        sys.exit(4)
+    if is_gprepairmirrorseg_running():
+        logger.error('gprepairmirrorseg is already running.  Only one instance')
+        logger.error('of gprepairmirrorseg is allowed at a time.')
+        remove_pid = False
+        sys.exit(1)
+    else:
+        create_pid_file()
 
-  syncListLength = len(resyncFiles.fileList)
-  
-  for index in range(syncListLength):
-      category = resyncFiles.getCategory(index)
-      action   = categoryAction[category]
-      sourceHost = resyncFiles.getSourceHost(index)
-      sourceFile = resyncFiles.getSourceFile(index)
-      sourceDir, sf = os.path.split(sourceFile)
-      targetHost = resyncFiles.getTargetHost(index)
-      targetFile = resyncFiles.getTargetFile(index)
-      targetDir, tf = os.path.split(targetFile)
-      
-      syncOptions = " -i " + sf
-      
-      if action == COPY:
-         cmd = PySyncPlus( name = "gprepairsegment sync %s:%s to %s:%s" % (sourceHost, sourceFile, targetHost, targetFile)
-                         , srcDir = sourceDir
-                         , dstHost = targetHost
-                         , dstDir = targetDir
-                         , ctxt = REMOTE
-                         , remoteHost = sourceHost
-                         , options = syncOptions
-                         )
-         cmd.run(validateAfter = True)
-         logger.info(str(cmd))
-      if action == DELETE:
-         cmd = RemoveFiles(name = "gprepairmirrorseg remove extra file", directory = sourceFile, ctxt = LOCAL, remoteHost = sourceHost)
-         cmd.run(validateAfter = True)
-         logger.info(str(cmd))
-      if action == NO_ACTION:
-         logger.warn("No action will be taken for %s:%s and %s:%s" % (sourceHost, sourceFile, targetHost, targetFile))
+    resyncFiles = GPResyncFile(options.file)
+    logger.info("gprepairmirrorseg will attempt to repair the following files:")
+    prettyPrintFiles(resyncFiles)
 
-  sys.exit(0)
+    if options.confirm == True:
+        msg = "Do you wish to continue with re-sync of these files"
+        ans = ask_yesno(None, msg, 'N')
+        if not ans:
+            logger.info("User abort requested, Exiting...")
+            sys.exit(4)
 
-except Exception,e:
-    logger.error("gprepairmirrorseg failed: %s \n\nExiting..." % str(e) )
+        msg = "Are you sure you wish to continue"
+        ans = ask_yesno(None, msg, 'N')
+        if not ans:
+            logger.info("User abort requested, Exiting...")
+            sys.exit(4)
+
+    syncListLength = len(resyncFiles.fileList)
+
+    for index in range(syncListLength):
+        category = resyncFiles.getCategory(index)
+        action = categoryAction[category]
+        sourceHost = resyncFiles.getSourceHost(index)
+        sourceFile = resyncFiles.getSourceFile(index)
+        sourceDir, sf = os.path.split(sourceFile)
+        targetHost = resyncFiles.getTargetHost(index)
+        targetFile = resyncFiles.getTargetFile(index)
+        targetDir, tf = os.path.split(targetFile)
+
+        syncOptions = " -i " + sf
+
+        if action == COPY:
+            cmd = PySyncPlus(
+                name="gprepairsegment sync %s:%s to %s:%s" % (sourceHost, sourceFile, targetHost, targetFile)
+                , srcDir=sourceDir
+                , dstHost=targetHost
+                , dstDir=targetDir
+                , ctxt=REMOTE
+                , remoteHost=sourceHost
+                , options=syncOptions
+                )
+            cmd.run(validateAfter=True)
+            logger.info(str(cmd))
+        if action == DELETE:
+            cmd = RemoveFiles(name="gprepairmirrorseg remove extra file", directory=sourceFile, ctxt=LOCAL,
+                              remoteHost=sourceHost)
+            cmd.run(validateAfter=True)
+            logger.info(str(cmd))
+        if action == NO_ACTION:
+            logger.warn(
+                "No action will be taken for %s:%s and %s:%s" % (sourceHost, sourceFile, targetHost, targetFile))
+
+    sys.exit(0)
+
+except Exception, e:
+    logger.error("gprepairmirrorseg failed: %s \n\nExiting..." % str(e))
     traceback.print_exc()
     sys.exit(3)
 
 except KeyboardInterrupt:
     # Disable SIGINT while we shutdown.
-    signal.signal(signal.SIGINT,signal.SIG_IGN)
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
 
     # Re-enabled SIGINT
-    signal.signal(signal.SIGINT,signal.default_int_handler)
+    signal.signal(signal.SIGINT, signal.default_int_handler)
 
     sys.exit('\nUser Interrupted')
 
 except Exception, e:
-  print "FATAL Exception: " + str(e)
-  traceback.print_exc()
-  sys.exit(1)
+    print "FATAL Exception: " + str(e)
+    traceback.print_exc()
+    sys.exit(1)
 
 
 finally:
@@ -533,6 +529,3 @@ finally:
     except Exception:
         pass
     logger.info("gprepairmirrorseg exit")
-
-
-    


### PR DESCRIPTION
Previously, RemoveDirectories and RemoveFiles used the unix command
"rm -rf", but this is inefficient for huge numbers of files.
Also, these functions accepted any globbed path.

Instead, use "rsync" to optimize deletion of files in a directory.
On a DCA using 1 million files, this increased speed by about 3x.

Also, this commit breaks up the different use-cases of deletion into
separate methods, adding methods RemoveDirectoryContents() and RemoveFile()
and RemoveGlob() to help isolate the assumptions of each case and
optimize for them.