### PR TITLE
Use ereport for user facing errors

### DIFF
--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/queries/basic/external_partition/expected/alter_table_truncate_partition.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/queries/basic/external_partition/expected/alter_table_truncate_partition.ans
@@ -48,9 +48,9 @@ drop table ret;
 DROP TABLE
 --end_ignore
 alter table pt_ext truncate partition for (5); 
-psql:/path/sql_file:1: ERROR:  Cannot truncate external partition (tablecmds.c:17373)
+psql:/path/sql_file:1: ERROR:  cannot truncate external partition
 alter table pt_ext truncate partition part1;
-psql:/path/sql_file:1: ERROR:  Cannot truncate external partition (tablecmds.c:17373)
+psql:/path/sql_file:1: ERROR:  cannot truncate external partition
 select count(*) from pt_ext;
  count 
 -------

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/queries/basic/external_partition/expected/truncate.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/queries/basic/external_partition/expected/truncate.ans
@@ -49,7 +49,7 @@ psql:/path/sql_file:1: ERROR:  "pt_ext_1_prt_part1" is an external relation and 
 truncate pt_ext_1_prt_part2;
 TRUNCATE TABLE
 truncate pt_ext;
-psql:/path/sql_file:1: ERROR:  Cannot truncate table having external partition:"pt_ext_1_prt_part1". (tablecmds.c:1834)
+psql:/path/sql_file:1: ERROR:  cannot truncate table having external partition: "pt_ext_1_prt_part1"
 select count(*) from pt_ext; 
  count 
 -------

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/queries/basic/external_partition/expected/validation.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/queries/basic/external_partition/expected/validation.ans
@@ -37,6 +37,7 @@ create readable external table ret(like pt_ext) location('file://mdw/tmp/exttab_
 CREATE EXTERNAL TABLE
 --end_ignore 
 alter table pt_ext exchange partition part1 with table ret;
-psql:/path/sql_file:1: ERROR:  Validation of external tables not supported. Use WITHOUT VALIDATION. (tablecmds.c:15218)
+psql:/path/sql_file:1: ERROR:  validation of external tables not supported
+HINT:  Use WITHOUT VALIDATION.
 drop external table ret;
 DROP EXTERNAL TABLE


### PR DESCRIPTION
Any error that the user is expected to see should be using the ereport macro rather than its older cousing elog. Seeing PR #3075 by @hlinnaka made me remember that I've been carrying this diff locally for quite some time never really getting around to submitting it. So here goes.