### PR TITLE
Donot install package if segment list is empty.

### DIFF
--- a/gpMgmt/bin/gppylib/operations/package.py
+++ b/gpMgmt/bin/gppylib/operations/package.py
@@ -862,10 +862,11 @@ class InstallPackage(Operation):
         # distribute package to segments
         srcFile = self.gppkg.abspath
         dstFile = os.path.join(GPHOME, self.gppkg.pkg)
-        GpScp(srcFile, dstFile, self.segment_host_list).run()
 
         # install package on segments
-        HostOperation(InstallPackageLocally(dstFile), self.segment_host_list).run()
+        if self.segment_host_list:
+            GpScp(srcFile, dstFile, self.segment_host_list).run()
+            HostOperation(InstallPackageLocally(dstFile), self.segment_host_list).run()
 
         # install package on standby
         if self.standby_host:


### PR DESCRIPTION
This commit fixed the regression introduced by commit
WorkerPool: Error out if numWorkers is 0 or less.
Details in https://github.com/greenplum-db/gpdb/pull/3036

How to reproduce regression:
1 install gpdb master and segment on the same host (this will lead to segment_host_list to be empty)
2 gppkg -i -plr-2.3.0-gp5-rhel6-x86_64.gppkg (any gppkg)

Signed-off-by: Xiang Sheng <stanly.sxiang@gmail.com>