### PR TITLE
Record dependency for external protocol in an extension.

### DIFF
--- a/gpAux/extensions/pxf/expected/setup.out
+++ b/gpAux/extensions/pxf/expected/setup.out
@@ -2,6 +2,11 @@
 -- PXF Extension Creation
 ------------------------------------------------------------------
 CREATE EXTENSION pxf;
+-- Also test dropping the extension. This may seem a bit random, but we
+-- currently don't have any other tests for dropping an extension that
+-- contains an external protocol.
+DROP EXTENSION pxf;
+CREATE EXTENSION pxf;
 CREATE EXTERNAL TABLE pxf_read_test (a TEXT, b TEXT, c TEXT)
 LOCATION ('pxf://default/tmp/dummy1'
 '?FRAGMENTER=org.apache.hawq.pxf.api.examples.DemoFragmenter'

--- a/gpAux/extensions/pxf/sql/setup.sql
+++ b/gpAux/extensions/pxf/sql/setup.sql
@@ -4,6 +4,13 @@
 
 CREATE EXTENSION pxf;
 
+-- Also test dropping the extension. This may seem a bit random, but we
+-- currently don't have any other tests for dropping an extension that
+-- contains an external protocol.
+DROP EXTENSION pxf;
+
+CREATE EXTENSION pxf;
+
 CREATE EXTERNAL TABLE pxf_read_test (a TEXT, b TEXT, c TEXT)
 LOCATION ('pxf://default/tmp/dummy1'
 '?FRAGMENTER=org.apache.hawq.pxf.api.examples.DemoFragmenter'

--- a/src/backend/catalog/pg_extprotocol.c
+++ b/src/backend/catalog/pg_extprotocol.c
@@ -175,6 +175,8 @@ ExtProtocolCreate(const char *protocolName,
 
 	/* dependency on owner */
 	recordDependencyOnOwner(ExtprotocolRelationId, protOid, GetUserId());
+	/* dependency on extension */
+	recordDependencyOnCurrentExtension(&myself, false);
 
 	return protOid;
 }


### PR DESCRIPTION
When extensions were introduced in PostgreSQL, a call to
recordDependencyOnCurrentExtension() was added in the creation codepath
of all the object types. However, external protocols is a GPDB-specific
object type, and we missed making that change there.

Fixes guthub issue #2942.