### PR TITLE
Fix gpcloud extension's Makefile rule

### DIFF
--- a/gpAux/extensions/Makefile
+++ b/gpAux/extensions/Makefile
@@ -32,7 +32,7 @@ mapreduce:
 gpcloud:
 	@if [ "$(enable_gpcloud)" = "yes" ]; then \
 		echo "gpcloud enabled"; \
-		$(MAKE) -C gpcloud; \
+		$(MAKE) -C gpcloud && \
 		$(MAKE) -C gpcloud/bin/gpcheckcloud; \
 	fi
 
@@ -47,7 +47,7 @@ install:
 		$(MAKE) -C gpmapreduce install; \
 	fi
 	@if [ "$(enable_gpcloud)" = "yes" ]; then \
-		$(MAKE) -C gpcloud install; \
+		$(MAKE) -C gpcloud install && \
 		$(MAKE) -C gpcloud/bin/gpcheckcloud install; \
 	fi
 	@if [ "$(with_pxf)" = "yes" ]; then \


### PR DESCRIPTION
Failures when building/installing gpcloud weren't being bubbled up to the top level. This patch chains the make invocations to fix that.

A good followup might be to get rid of the `if [ "$enable_xxx" = "yes" ]` stuff and move to Makefile conditionals, or perhaps a `ENABLED_GPEXTENSIONS` variable, so that it's harder to accidentally write recipes incorrectly.