### PR TITLE
WorkerPool: protect against batch size 0

### DIFF
--- a/gpMgmt/bin/analyzedb
+++ b/gpMgmt/bin/analyzedb
@@ -355,9 +355,8 @@ class AnalyzeDb(Operation):
             if not self.silent and not userinput.ask_yesno(None, "\nContinue with Analyze", 'N'):
                 raise UserAbortedException()
 
-            num_workers = min(self.parallel_level, len(ordered_candidates))
-            logger.info("Starting analyze with %d workers..." % num_workers)
-            pool = AnalyzeWorkerPool(numWorkers=num_workers)
+            logger.info("Starting analyze with %d workers..." % self.parallel_level)
+            pool = AnalyzeWorkerPool(numWorkers=self.parallel_level)
             for can in ordered_candidates:
                 can_schema, can_table = can[0], can[1]
                 if can in candidates:

--- a/gpMgmt/bin/gpdbrestore
+++ b/gpMgmt/bin/gpdbrestore
@@ -60,6 +60,9 @@ class GpdbRestore(Operation):
         if options.list_backup and options.drop_db:
             raise ProgramArgumentValidationException("Cannot specify --list-backup and -e together")
 
+        if self.context.batch_default <= 0:
+            raise ProgramArgumentValidationException("-B <parallel processes> must be greater than 0")
+
         if not options.masterDataDirectory:
             options.masterDataDirectory = gp.get_masterdatadir()
 

--- a/gpMgmt/bin/gpmovemirrors
+++ b/gpMgmt/bin/gpmovemirrors
@@ -6,13 +6,10 @@
 #
 from gppylib.mainUtils import SimpleMainLock, ExceptionNoStackTraceNeeded
 
-import copy
-import datetime
 import os
 import sys
-import socket
 import signal
-from time import strftime, sleep
+from time import strftime
 
 try:
     from gppylib.commands.unix import *
@@ -171,7 +168,7 @@ def sig_handler(sig, arg):
 def lookupGpdb(address, port, dataDirectory):
     """ Look up the segment gpdb by address, port, and dataDirectory """
 
-    gpdbList = gparray.getDbList()
+    gpdbList = gpArrayInstance.getDbList()
     for gpdb in gpdbList:
         if address == str(gpdb.getSegmentAddress()) and port == str(gpdb.getSegmentPort()) and dataDirectory == str(
                 gpdb.getSegmentDataDirectory()):
@@ -195,13 +192,12 @@ def lookupFilespaces(gpdb):
     """ Look up the segment's filespaces, and return map of filespace name : location. """
 
     retValue = {}
-    gpFilespaceObjList = gparray.getFilespaces(includeSystemFilespace=False)
     gpdbFilespaceDict = gpdb.getSegmentFilespaces()
 
     for oid in gpdbFilespaceDict:
         if oid == SYSTEM_FILESPACE:
             continue
-        name = gparray.getFileSpaceName(oid)
+        name = gpArrayInstance.getFileSpaceName(oid)
         location = gpdbFilespaceDict[oid]
         retValue[name] = location
     return retValue
@@ -329,13 +325,13 @@ pidfilepid = None  # pid of the process which has the lock
 locktorelease = None
 sml = None  # sml (simple main lock)
 
+logger = get_default_logger()
+
 try:
 
     # setup signal handlers so we can clean up correctly
     signal.signal(signal.SIGTERM, sig_handler)
     signal.signal(signal.SIGHUP, sig_handler)
-
-    logger = get_default_logger()
 
     options, args = parseargs()
 
@@ -361,7 +357,7 @@ try:
 
     # Get array configuration
     try:
-        gparray = GpArray.initFromCatalog(dburl, utility=True)
+        gpArrayInstance = GpArray.initFromCatalog(dburl, utility=True)
     except DatabaseError, ex:
         logger.error('Failed to connect to database.  Make sure the')
         logger.error('Greenplum instance is running, and that')
@@ -403,7 +399,7 @@ try:
 
     """ Delete old mirror directories. """
     try:
-        fileSpacesObjList = gparray.getFilespaces(includeSystemFilespace=False)
+        fileSpacesObjList = gpArrayInstance.getFilespaces(includeSystemFilespace=False)
         totalDirsToDelete = len(newConfig.oldMirrorList) + len(fileSpacesObjList)
         numberOfWorkers = min(totalDirsToDelete, options.batch_size)
         pool = WorkerPool(numWorkers=numberOfWorkers)

--- a/gpMgmt/bin/gpmovemirrors
+++ b/gpMgmt/bin/gpmovemirrors
@@ -398,10 +398,10 @@ try:
     cmd.run(validateAfter=True)
 
     """ Delete old mirror directories. """
-    try:
-        fileSpacesObjList = gpArrayInstance.getFilespaces(includeSystemFilespace=False)
-        totalDirsToDelete = len(newConfig.oldMirrorList) + len(fileSpacesObjList)
-        numberOfWorkers = min(totalDirsToDelete, options.batch_size)
+    fileSpacesObjList = gpArrayInstance.getFilespaces(includeSystemFilespace=False)
+    totalDirsToDelete = len(newConfig.oldMirrorList) + len(fileSpacesObjList)
+    numberOfWorkers = min(totalDirsToDelete, options.batch_size)
+    if numberOfWorkers > 1:
         pool = WorkerPool(numWorkers=numberOfWorkers)
         for mirror in newConfig.oldMirrorList:
             logger.info("About to remove old mirror segment directory: " + mirror.dataDirectory)
@@ -443,9 +443,6 @@ try:
             logging.error("Although the system is in the process of recovering the mirrors to their new location,")
             logging.error("There was an issue removing the old mirror segment directories.")
             raise Exception("Unable to complete removal of old mirror segment directories.")
-
-    except Exception, e:
-        raise e
 
 except Exception, e:
     if options is not None and options.verbose:

--- a/gpMgmt/bin/gppylib/heapchecksum.py
+++ b/gpMgmt/bin/gppylib/heapchecksum.py
@@ -9,6 +9,8 @@ class HeapChecksum:
     """
 
     def __init__(self, gparray, num_workers=8, logger=None):
+        if num_workers <= 0:
+            raise Exception("number of workers must be greater than 0")
         self.gparray = gparray
         self.workers = num_workers
         self.logger = logger

--- a/gpMgmt/bin/gppylib/operations/restore.py
+++ b/gpMgmt/bin/gppylib/operations/restore.py
@@ -290,6 +290,9 @@ class RestoreDatabase(Operation):
         self.context = context
 
     def execute(self):
+        if self.context.batch_default <= 0:
+            raise Exception("-B <parallel processes> must be greater than 0")
+
         if self.context.redirected_restore_db:
             self.context.target_db = self.context.redirected_restore_db
 

--- a/gpMgmt/bin/gppylib/operations/utils.py
+++ b/gpMgmt/bin/gppylib/operations/utils.py
@@ -54,22 +54,26 @@ class RemoteOperation(Operation):
     def __str__(self):
         return "Remote(%s)" % str(self.operation)
 
+
 class ParallelOperation(Operation):
     """ 
-    Caveat: The execute always returns None. It is the caller's responsiblity to introspect operations.
+    Caveat: execute returns None. It is the caller's responsibility to introspect operations.
     """
     def __init__(self, operations, max_parallelism=DEFAULT_NUM_WORKERS):
         super(ParallelOperation, self).__init__()
         self.operations = operations        
         self.parallelism = min(len(operations), max_parallelism)
-    def execute(self):        
-        """TODO: Make Command a subclass of Operation. Then, make WorkerPool work with Operation objects."""
+
+    def execute(self):
+        if not self.operations or len(self.operations) == 0:
+            return
         pool = OperationWorkerPool(numWorkers=self.parallelism, operations=self.operations)
         pool.join()
         pool.haltWork()
-        return None
+
     def __str__(self):
         return "Parallel(%d)" % len(self.operations)
+
 
 class SerialOperation(Operation):
     """ 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_heapchecksum.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_heapchecksum.py
@@ -168,6 +168,10 @@ Data page checksum version:           1
         self.assertEquals(len(successes), 4)
         self.assertEquals(len(failures), 0)
 
+    def test_0_workers_in_WorkerPool_raises(self):
+        with self.assertRaises(Exception):
+            HeapChecksum(None, 0)
+
     # ****************** tools ************************
     def setup_worker_pool(self, values):
         mocks = [Mock() for _ in range(len(self.results))]

--- a/gpMgmt/bin/lib/gpconfigurenewsegment
+++ b/gpMgmt/bin/lib/gpconfigurenewsegment
@@ -256,7 +256,7 @@ def parseargs():
 
     if options.batch_size <= 0:
         logger.warn('batch_size was less than zero.  Setting to 1.')
-        batch_size = 1
+        options.batch_size = 1
 
     if options.newsegments and not options.tarfile:
         raise Exception('-n option requires -t option to be specified')


### PR DESCRIPTION
As part of a previous commit, the WorkerPool of threads will raise if
the number of workers is set to 0. This prevents a coding error from
resulting in no work, where work was expected.

This commit reaches through code to protect against the numWorkers
parameter being 0.

In several cases, the number of workers is set to the number of segments
or the number of databases. We do not protect those with the expectation
that something is more significantly wrong if those sums are 0, and that
an exception would be fitting in those cases.

This commit follows and is related to #3036 #3085