### PR TITLE
Handle the failure in AssignResGroupOnMaster()

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsInjectFault.py
+++ b/gpMgmt/bin/gppylib/programs/clsInjectFault.py
@@ -426,6 +426,7 @@ class GpInjectFaultProgram:
 			      "fsync_counter (inject fault to count buffers fsync'ed by checkpoint process), " \
 			      "bg_buffer_sync_default_logic (inject fault to 'skip' in order to flush all buffers in BgBufferSync()), " \
                   "finish_prepared_after_record_commit_prepared (inject fault in FinishPreparedTransaction() after recording the commit prepared record), " \
+                  "resgroup_assigned_on_master (inject fault in AssignResGroupOnMaster() after slot is assgined), " \
 			      "all (affects all faults injected, used for 'status' and 'reset'), ") 
         addTo.add_option("-c", "--ddl_statement", dest="ddlStatement", type="string",
                          metavar="ddlStatement",

--- a/gpMgmt/bin/gppylib/programs/clsInjectFault.py
+++ b/gpMgmt/bin/gppylib/programs/clsInjectFault.py
@@ -426,7 +426,7 @@ class GpInjectFaultProgram:
 			      "fsync_counter (inject fault to count buffers fsync'ed by checkpoint process), " \
 			      "bg_buffer_sync_default_logic (inject fault to 'skip' in order to flush all buffers in BgBufferSync()), " \
                   "finish_prepared_after_record_commit_prepared (inject fault in FinishPreparedTransaction() after recording the commit prepared record), " \
-                  "resgroup_assigned_on_master (inject fault in AssignResGroupOnMaster() after slot is assgined), " \
+                  "resgroup_assigned_on_master (inject fault in AssignResGroupOnMaster() after slot is assigned), " \
 			      "all (affects all faults injected, used for 'status' and 'reset'), ") 
         addTo.add_option("-c", "--ddl_statement", dest="ddlStatement", type="string",
                          metavar="ddlStatement",

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -2236,7 +2236,15 @@ StartTransaction(void)
 		SIMPLE_FAULT_INJECTOR(TransactionStartUnderEntryDbSingleton);
 	}
 
-	/* Acquire a resource group slot at the beginning of a transaction */
+	/*
+	 * Acquire a resource group slot.
+	 *
+	 * AssignResGroupOnMaster() might throw error, so call it before touch
+	 * transaction state.
+	 * Slot is successfully acquired when AssignResGroupOnMaster() is returned,
+	 * this slot will be release when transaction is committed or abortted,
+	 * so don't error out before transaction state is set to TRANS_START.
+	 */
 	if (ShouldAssignResGroupOnMaster())
 		AssignResGroupOnMaster();
 

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -2236,6 +2236,10 @@ StartTransaction(void)
 		SIMPLE_FAULT_INJECTOR(TransactionStartUnderEntryDbSingleton);
 	}
 
+	/* Acquire a resource group slot at the beginning of a transaction */
+	if (ShouldAssignResGroupOnMaster())
+		AssignResGroupOnMaster();
+
 	/*
 	 * Let's just make sure the state stack is empty
 	 */
@@ -2248,11 +2252,6 @@ StartTransaction(void)
 	if (s->state != TRANS_DEFAULT)
 		elog(WARNING, "StartTransaction while in %s state",
 			 TransStateAsString(s->state));
-
-	/* Acquire a resource group slot at the beginning of a transaction */
-	if (ShouldAssignResGroupOnMaster())
-		AssignResGroupOnMaster();
-
 	/*
 	 * set the current transaction state information appropriately during
 	 * start processing

--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -1018,7 +1018,7 @@ hostSegsHashTableInit(void)
 
 	/* Set key and entry sizes. */
 	MemSet(&info, 0, sizeof(info));
-	info.keysize = sizeof(INET6_ADDRSTRLEN);
+	info.keysize = INET6_ADDRSTRLEN;
 	info.entrysize = sizeof(HostSegsEntry);
 
 	return hash_create("HostSegs", 32, &info, HASH_ELEM);

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -105,7 +105,7 @@ static void registerResourceGroupCallback(ResourceGroupCallback callback, void *
  * Register callback functions for resource group related operations.
  *
  * At transaction end, the callback occurs post-commit or post-abort, so the
- * callback functions can only do noncritical cleanup.
+ * callback functions can only do non-critical cleanup.
  */
 static void
 registerResourceGroupCallback(ResourceGroupCallback callback, void *arg)
@@ -366,7 +366,6 @@ DropResourceGroup(DropResourceGroupStmt *stmt)
 
 	systable_endscan(authid_scan);
 	heap_close(authIdRel, RowExclusiveLock);
-
 
 	/*
 	 * Delete the resource group from the catalog.
@@ -671,7 +670,7 @@ GetResGroupCapabilities(Oid groupId, ResGroupCaps *resgroupCaps)
 	ResourceOwner owner = NULL;
 	/*
 	 * We maintain a bit mask to track which resgroup limit capability types
-	 * have been retrived, when mask is 0 then no limit capability is found
+	 * have been retrieved, when mask is 0 then no limit capability is found
 	 * for the given groupId.
 	 */
 	int			mask = 0;
@@ -1060,7 +1059,7 @@ dropResGroupAbortCallback(bool isCommit, void *arg)
 /*
  * Resource group call back function
  *
- * When ALTER RESOURCE GROUP SET CONCURRENCY commits, some queueing
+ * When ALTER RESOURCE GROUP SET CONCURRENCY commits, some queuing
  * transaction of this resource group may need to be woke up.
  *
  */
@@ -1140,7 +1139,7 @@ updateResgroupCapabilities(Oid groupid, const ResGroupCaps *resgroupCaps)
 	const ResGroupCap	*caps = (ResGroupCap *) resgroupCaps;
 	/*
 	 * We maintain a bit mask to track which resgroup limit capability types
-	 * have been retrived, when mask is 0 then no limit capability is found
+	 * have been retrieved, when mask is 0 then no limit capability is found
 	 * for the given groupid.
 	 */
 	int			mask = 0;

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -329,6 +329,8 @@ FaultInjectorIdentifierEnumToString[] = {
 		/* inject fault in FinishPreparedTransaction() after recording the commit prepared record */
 	_("gang_created"),
 		/* inject fault to report ERROR just after creating Gang */
+	_("resgroup_assgined_on_master"),
+		/* inject fault to report ERROR just after resource group is assigned on master */
 	_("not recognized"),
 };
 

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -329,7 +329,7 @@ FaultInjectorIdentifierEnumToString[] = {
 		/* inject fault in FinishPreparedTransaction() after recording the commit prepared record */
 	_("gang_created"),
 		/* inject fault to report ERROR just after creating Gang */
-	_("resgroup_assgined_on_master"),
+	_("resgroup_assigned_on_master"),
 		/* inject fault to report ERROR just after resource group is assigned on master */
 	_("not recognized"),
 };

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -141,8 +141,8 @@ typedef struct ResGroupControl
 	 */
 	bool			loaded;
 
-	int32			totalChunks;	/* total memory chuncks on this segment */
-	int32			freeChunks;		/* memory chuncks not allocated to any group */
+	int32			totalChunks;	/* total memory chunks on this segment */
+	int32			freeChunks;		/* memory chunks not allocated to any group */
 
 	int				nGroups;
 	ResGroupData	groups[1];
@@ -355,8 +355,8 @@ InitResGroups(void)
 	Relation			relResGroupCapability;
 
 	/*
-	 * On master, the postmaster does the initializtion
-	 * On segments, the first QE does the initializtion
+	 * On master, the postmaster does the initialization
+	 * On segments, the first QE does the initialization
 	 */
 	if (Gp_role == GP_ROLE_DISPATCH && GpIdentity.segindex != MASTER_CONTENT_ID)
 		return;
@@ -483,7 +483,7 @@ ResGroupCheckForDrop(Oid groupId, char *name)
 
 /*
  * Wake up the backends in the wait queue when DROP RESOURCE GROUP finishes.
- * Unlock the resource group if the transaction is abortted.
+ * Unlock the resource group if the transaction is aborted.
  * Remove the resource group entry in shared memory if the transaction is committed.
  *
  * This function is called in the callback function of DROP RESOURCE GROUP.
@@ -1054,7 +1054,7 @@ attachToSlot(ResGroupData *group,
 /*
  * Detach current proc from a resource group & slot.
  *
- * Current proc's memory usage will be substracted from the group & slot.
+ * Current proc's memory usage will be subtracted from the group & slot.
  */
 static void
 detachFromSlot(ResGroupData *group,
@@ -1573,6 +1573,7 @@ groupGetMemSpillTotal(const ResGroupCaps *caps)
 static int32
 slotGetMemQuotaExpected(const ResGroupCaps *caps)
 {
+	Assert(caps->concurrency.proposed != 0);
 	return Max(1, groupGetMemQuotaExpected(caps) / caps->concurrency.proposed);
 }
 
@@ -1582,6 +1583,7 @@ slotGetMemQuotaExpected(const ResGroupCaps *caps)
 static int32
 slotGetMemSpill(const ResGroupCaps *caps)
 {
+	Assert(caps->concurrency.proposed != 0);
 	return groupGetMemSpillTotal(caps) / caps->concurrency.proposed;
 }
 
@@ -1767,7 +1769,7 @@ ResGroupSlotRelease(void)
 	MyProc->resSlotId = InvalidSlotId;
 
 	/*
-	 * My slot is put back, then how many queueing queries should I wake up?
+	 * My slot is put back, then how many queuing queries should I wake up?
 	 * Maybe zero, maybe one, maybe more, depends on how the resgroup's
 	 * configuration were changed during our execution.
 	 */
@@ -1991,7 +1993,7 @@ UnassignResGroupOnMaster(void)
 	/* Cleanup slotInfo */
 	pg_atomic_sub_fetch_u32((pg_atomic_uint32*)&slot->nProcs, 1);
 
-	/* Relesase the slot */
+	/* Release the slot */
 	ResGroupSlotRelease();
 
 	/* Cleanup sharedInfo */
@@ -2281,7 +2283,7 @@ AtProcExit_ResGroup(int code, Datum arg)
  * The proc may wait on the queue for a slot, or wait for the
  * DROP transaction to finish. In the first case, at the same time
  * we get interrupted (SIGINT or SIGTERM), we could have been
- * grantted a slot or not. In the second case, there's no running
+ * granted a slot or not. In the second case, there's no running
  * transaction in the group. If the DROP transaction is finished
  * (commit or abort) at the same time as we get interrupted,
  * MyProc should have been removed from the wait queue, and the

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -223,6 +223,7 @@ typedef enum FaultInjectorIdentifier_e {
 
 	GangCreated,
 
+	ResGroupAssignedOnMaster,
 	/* INSERT has to be done before that line */
 	FaultInjectorIdMax,
 	

--- a/src/test/isolation2/expected/resgroup/resgroup_assign_slot_fail.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_assign_slot_fail.out
@@ -7,7 +7,7 @@ DROP ROLE IF EXISTS role_test;
 DROP
 -- start_ignore
 DROP RESOURCE GROUP rg_test;
-DROP
+ERROR:  resource group "rg_test" does not exist
 -- end_ignore
 CREATE RESOURCE GROUP rg_test WITH (concurrency=2, cpu_rate_limit=10, memory_limit=10);
 CREATE
@@ -20,10 +20,20 @@ SET
 BEGIN
 2: SET ROLE role_test;
 SET
-SELECT gp_inject_fault('resgroup_assgined_on_master', 'error', 1);
-ERROR:  Failure: could not insert fault injection, entry already exists (gp_inject_fault.c:67)
+-- start_ignore
+SELECT gp_inject_fault('resgroup_assigned_on_master', 'reset', 1);
+gp_inject_fault
+---------------
+t              
+(1 row)
+SELECT gp_inject_fault('resgroup_assigned_on_master', 'error', 1);
+gp_inject_fault
+---------------
+t              
+(1 row)
+-- end_ignore
 2: BEGIN;
-BEGIN
+ERROR:  fault triggered, fault name:'resgroup_assigned_on_master' fault type:'error'
 2: BEGIN;
 BEGIN
 1: END;

--- a/src/test/isolation2/expected/resgroup/resgroup_assign_slot_fail.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_assign_slot_fail.out
@@ -1,0 +1,40 @@
+-- If the function AssignResGroupOnMaster() fails after getting a slot,
+-- test the slot will be unassigned correctly.
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+CREATE
+
+DROP ROLE IF EXISTS role_test;
+DROP
+-- start_ignore
+DROP RESOURCE GROUP rg_test;
+DROP
+-- end_ignore
+CREATE RESOURCE GROUP rg_test WITH (concurrency=2, cpu_rate_limit=10, memory_limit=10);
+CREATE
+CREATE ROLE role_test RESOURCE GROUP rg_test;
+CREATE
+
+1: SET ROLE role_test;
+SET
+1: BEGIN;
+BEGIN
+2: SET ROLE role_test;
+SET
+SELECT gp_inject_fault('resgroup_assgined_on_master', 'error', 1);
+ERROR:  Failure: could not insert fault injection, entry already exists (gp_inject_fault.c:67)
+2: BEGIN;
+BEGIN
+2: BEGIN;
+BEGIN
+1: END;
+END
+2: END;
+END
+1q: ... <quitting>
+2q: ... <quitting>
+
+--clean up
+DROP ROLE role_test;
+DROP
+DROP RESOURCE GROUP rg_test;
+DROP

--- a/src/test/isolation2/isolation2_resgroup_schedule
+++ b/src/test/isolation2/isolation2_resgroup_schedule
@@ -31,4 +31,7 @@ test: resgroup/resgroup_recreate
 test: resgroup/restore_default_resgroup
 test: resgroup/resgroup_parallel_queries
 
+# fault injection tests
+test: resgroup/resgroup_assign_slot_fail
+
 test: resgroup/disable_resgroup

--- a/src/test/isolation2/sql/resgroup/resgroup_assign_slot_fail.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_assign_slot_fail.sql
@@ -12,7 +12,10 @@ CREATE ROLE role_test RESOURCE GROUP rg_test;
 1: SET ROLE role_test;
 1: BEGIN;
 2: SET ROLE role_test;
-SELECT gp_inject_fault('resgroup_assgined_on_master', 'error', 1);
+-- start_ignore
+SELECT gp_inject_fault('resgroup_assigned_on_master', 'reset', 1);
+SELECT gp_inject_fault('resgroup_assigned_on_master', 'error', 1);
+-- end_ignore
 2: BEGIN;
 2: BEGIN;
 1: END;

--- a/src/test/isolation2/sql/resgroup/resgroup_assign_slot_fail.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_assign_slot_fail.sql
@@ -1,0 +1,25 @@
+-- If the function AssignResGroupOnMaster() fails after getting a slot,
+-- test the slot will be unassigned correctly.
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+
+DROP ROLE IF EXISTS role_test;
+-- start_ignore
+DROP RESOURCE GROUP rg_test;
+-- end_ignore
+CREATE RESOURCE GROUP rg_test WITH (concurrency=2, cpu_rate_limit=10, memory_limit=10);
+CREATE ROLE role_test RESOURCE GROUP rg_test;
+
+1: SET ROLE role_test;
+1: BEGIN;
+2: SET ROLE role_test;
+SELECT gp_inject_fault('resgroup_assgined_on_master', 'error', 1);
+2: BEGIN;
+2: BEGIN;
+1: END;
+2: END;
+1q:
+2q:
+
+--clean up
+DROP ROLE role_test;
+DROP RESOURCE GROUP rg_test;


### PR DESCRIPTION
As AssignResGroupOnMaster() is called before the transaction is
actually started, so the failure won't cause transaction abort,
we need handle the error to prevent slot leaking.

Signed-off-by: Zhenghua Lyu <zlv@pivotal.io>