### PR TITLE
Set resWaiting under ResGroupLock to avoid race condition

### DIFF
--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -1786,13 +1786,8 @@ ResGroupSlotRelease(void)
 		waitQueue->size--;
 		waitProc->resGranted = true;
 		waitProc->resSlotId = slotId;	/* pass the slot to new query */
-		/* TODO: why we need to release the lock here? */
-		LWLockRelease(ResGroupLock);
-
 		waitProc->resWaiting = false;
 		SetLatch(&waitProc->procLatch);
-
-		LWLockAcquire(ResGroupLock, LW_EXCLUSIVE);
 	}
 
 	AssertImply(waitQueue->size == 0,


### PR DESCRIPTION
Previously in ResGroupSlotRelease(), we mark the resWaiting flag to
false out of the ResGroupLock, a race condition can happen as that
the waitProc that meant to be wake up is canceled just before it's
resWaiting is set to false and in the window resWaiting is set, the
waitProc run another query and wait for a free slot again, then
resWaiting is set and the waitProc will get another unexpected free slot.

eg: rg1 has concurrency = 1

s1: BEGIN;
s2: BEGIN; -- blocked
s1: END; -- set breakpoint just before resWaiting is set in ResGroupSlotRelease()
s2: cancel it;
s3: BEGIN; -- will get a free slot.
s2: BEGIN; -- run begin again and be blocked.
s1: continue;
s2: s2 will got unexpected free slot

To avoid leak of resgroup slot, we set resWaiting under ResGroupLock so the
waitProc have no window to re-fetch the slot before resWaiting is set.
It's hard to add a regression test, adding breakpoint in ResGroupSlotRelease
may block all other operations because it holds the ResGroupLock.