### PR TITLE
Decrease the max_connections to adopt weak agents

### DIFF
--- a/src/test/isolation2/expected/resgroup/resgroup_parallel_queries.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_parallel_queries.out
@@ -45,9 +45,6 @@ CREATE FUNCTION
 
 -- end_ignore
 
-alter resource group admin_group set concurrency 30;
-ALTER
-
 -- This function execute commands N times.
 -- % in command will be replaced by number specified by range1 sequentially
 -- # in command will be replaced by number specified by range2 randomly
@@ -128,6 +125,44 @@ exec_commands_n
 60             
 (1 row)
 
+1: select dblink_disconnect('dblink_rg_test1');
+dblink_disconnect
+-----------------
+OK               
+(1 row)
+2: select dblink_disconnect('dblink_rg_test2');
+dblink_disconnect
+-----------------
+OK               
+(1 row)
+3: select dblink_disconnect('dblink_rg_test3');
+dblink_disconnect
+-----------------
+OK               
+(1 row)
+4: select dblink_disconnect('dblink_rg_test4');
+dblink_disconnect
+-----------------
+OK               
+(1 row)
+5: select dblink_disconnect('dblink_rg_test5');
+dblink_disconnect
+-----------------
+OK               
+(1 row)
+6: select dblink_disconnect('dblink_rg_test6');
+dblink_disconnect
+-----------------
+OK               
+(1 row)
+
+
+1q: ... <quitting>
+2q: ... <quitting>
+3q: ... <quitting>
+4q: ... <quitting>
+5q: ... <quitting>
+6q: ... <quitting>
 --
 -- DDLs vs DMLs
 --
@@ -423,6 +458,20 @@ dblink_disconnect
 OK               
 (1 row)
 
+21q: ... <quitting>
+22q: ... <quitting>
+23q: ... <quitting>
+24q: ... <quitting>
+25q: ... <quitting>
+26q: ... <quitting>
+31q: ... <quitting>
+32q: ... <quitting>
+33q: ... <quitting>
+34q: ... <quitting>
+41q: ... <quitting>
+42q: ... <quitting>
+43q: ... <quitting>
+
 select groupname, concurrency::int < 7, cpu_rate_limit::int < 7 from gp_toolkit.gp_resgroup_config where groupname like 'rg_test_g%' order by groupname;
 groupname |?column?|?column?
 ----------+--------+--------
@@ -527,21 +576,25 @@ exec_commands_n
 100            
 (1 row)
 
-51:select dblink_disconnect('dblink_rg_test51');
+51: select dblink_disconnect('dblink_rg_test51');
 dblink_disconnect
 -----------------
 OK               
 (1 row)
-52:select dblink_disconnect('dblink_rg_test52');
+52: select dblink_disconnect('dblink_rg_test52');
 dblink_disconnect
 -----------------
 OK               
 (1 row)
-53:select dblink_disconnect('dblink_rg_test53');
+53: select dblink_disconnect('dblink_rg_test53');
 dblink_disconnect
 -----------------
 OK               
 (1 row)
+
+51q: ... <quitting>
+52q: ... <quitting>
+53q: ... <quitting>
 
 -- num_executed and num_queued must be zero
 select num_queued, num_executed from gp_toolkit.gp_resgroup_status where rsgname = 'rg_test_g8';
@@ -555,11 +608,9 @@ drop resource group rg_test_g8;
 DROP
 
 -- clean up
-alter resource group admin_group set concurrency 20;
-ALTER
 select * from gp_toolkit.gp_resgroup_config;
 groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
 -------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
 6437   |default_group|20         |20                  |30            |30          |30                   |50                 |50                          |20                |20                         
-6438   |admin_group  |20         |20                  |10            |10          |10                   |50                 |50                          |20                |20                         
+6438   |admin_group  |40         |40                  |10            |10          |10                   |50                 |50                          |20                |20                         
 (2 rows)

--- a/src/test/isolation2/expected/resgroup/restore_default_resgroup.out
+++ b/src/test/isolation2/expected/resgroup/restore_default_resgroup.out
@@ -1,46 +1,53 @@
 -- enable resource group and restart cluster.
 -- start_ignore
 ! gpconfig -c gp_resource_group_cpu_limit -v 0.9;
-20170816:22:31:43:177045 gpconfig:sdw6:gpadmin-[INFO]:-completed successfully
+20170830:00:35:08:440358 gpconfig:sdw6:gpadmin-[INFO]:-completed successfully with parameters '-c gp_resource_group_cpu_limit -v 0.9'
 
 ! gpconfig -c gp_resource_group_memory_limit -v 0.9;
-20170816:22:31:44:177128 gpconfig:sdw6:gpadmin-[INFO]:-completed successfully
+20170830:00:35:09:440440 gpconfig:sdw6:gpadmin-[INFO]:-completed successfully with parameters '-c gp_resource_group_memory_limit -v 0.9'
 
-! gpconfig -c max_connections -v 600 -m 150;
-20170816:22:31:45:177210 gpconfig:sdw6:gpadmin-[INFO]:-completed successfully
+! gpconfig -c gp_resource_manager -v group;
+20170830:00:35:09:440522 gpconfig:sdw6:gpadmin-[WARNING]:-Managing queries with resource groups is an experimental feature. A work-in-progress version is enabled.
+20170830:00:35:10:440522 gpconfig:sdw6:gpadmin-[INFO]:-completed successfully with parameters '-c gp_resource_manager -v group'
+
+! gpconfig -c max_resource_groups -v 40;
+20170830:00:35:11:440642 gpconfig:sdw6:gpadmin-[INFO]:-completed successfully with parameters '-c max_resource_groups -v 40'
+
+! gpconfig -c max_connections -v 100 -m 40;
+20170830:00:35:11:440726 gpconfig:sdw6:gpadmin-[INFO]:-completed successfully with parameters '-c max_connections -v 100 -m 40'
 
 ! gpstop -rai;
-20170816:22:31:45:177292 gpstop:sdw6:gpadmin-[INFO]:-Starting gpstop with args: -rai
-20170816:22:31:45:177292 gpstop:sdw6:gpadmin-[INFO]:-Gathering information and validating the environment...
-20170816:22:31:45:177292 gpstop:sdw6:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
-20170816:22:31:45:177292 gpstop:sdw6:gpadmin-[INFO]:-Obtaining Segment details from master...
-20170816:22:31:45:177292 gpstop:sdw6:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 5.0.0-beta.7+dev.71.gb28abc3 build dev'
-20170816:22:31:45:177292 gpstop:sdw6:gpadmin-[INFO]:-There are 0 connections to the database
-20170816:22:31:45:177292 gpstop:sdw6:gpadmin-[INFO]:-Commencing Master instance shutdown with mode='immediate'
-20170816:22:31:45:177292 gpstop:sdw6:gpadmin-[INFO]:-Master host=sdw6
-20170816:22:31:45:177292 gpstop:sdw6:gpadmin-[INFO]:-Commencing Master instance shutdown with mode=immediate
-20170816:22:31:45:177292 gpstop:sdw6:gpadmin-[INFO]:-Master segment instance directory=/data1/tpz/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
-20170816:22:31:46:177292 gpstop:sdw6:gpadmin-[INFO]:-Attempting forceful termination of any leftover master process
-20170816:22:31:46:177292 gpstop:sdw6:gpadmin-[INFO]:-Terminating processes for segment /data1/tpz/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
-20170816:22:31:46:177292 gpstop:sdw6:gpadmin-[INFO]:-No standby master host configured
-20170816:22:31:46:177292 gpstop:sdw6:gpadmin-[INFO]:-Commencing parallel primary segment instance shutdown, please wait...
-20170816:22:31:46:177292 gpstop:sdw6:gpadmin-[INFO]:-0.00% of jobs completed
-20170816:22:31:56:177292 gpstop:sdw6:gpadmin-[INFO]:-100.00% of jobs completed
-20170816:22:31:56:177292 gpstop:sdw6:gpadmin-[INFO]:-Commencing parallel mirror segment instance shutdown, please wait...
-20170816:22:31:56:177292 gpstop:sdw6:gpadmin-[INFO]:-0.00% of jobs completed
-20170816:22:32:06:177292 gpstop:sdw6:gpadmin-[INFO]:-100.00% of jobs completed
-20170816:22:32:06:177292 gpstop:sdw6:gpadmin-[INFO]:-----------------------------------------------------
-20170816:22:32:06:177292 gpstop:sdw6:gpadmin-[INFO]:-   Segments stopped successfully      = 6
-20170816:22:32:06:177292 gpstop:sdw6:gpadmin-[INFO]:-   Segments with errors during stop   = 0
-20170816:22:32:06:177292 gpstop:sdw6:gpadmin-[INFO]:-----------------------------------------------------
-20170816:22:32:06:177292 gpstop:sdw6:gpadmin-[INFO]:-Successfully shutdown 6 of 6 segment instances 
-20170816:22:32:06:177292 gpstop:sdw6:gpadmin-[INFO]:-Database successfully shutdown with no errors reported
-20170816:22:32:06:177292 gpstop:sdw6:gpadmin-[INFO]:-Cleaning up leftover gpmmon process
-20170816:22:32:06:177292 gpstop:sdw6:gpadmin-[INFO]:-No leftover gpmmon process found
-20170816:22:32:06:177292 gpstop:sdw6:gpadmin-[INFO]:-Cleaning up leftover gpsmon processes
-20170816:22:32:06:177292 gpstop:sdw6:gpadmin-[INFO]:-No leftover gpsmon processes on some hosts. not attempting forceful termination on these hosts
-20170816:22:32:06:177292 gpstop:sdw6:gpadmin-[INFO]:-Cleaning up leftover shared memory
-20170816:22:32:06:177292 gpstop:sdw6:gpadmin-[INFO]:-Restarting System...
+20170830:00:35:12:440808 gpstop:sdw6:gpadmin-[INFO]:-Starting gpstop with args: -rai
+20170830:00:35:12:440808 gpstop:sdw6:gpadmin-[INFO]:-Gathering information and validating the environment...
+20170830:00:35:12:440808 gpstop:sdw6:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
+20170830:00:35:12:440808 gpstop:sdw6:gpadmin-[INFO]:-Obtaining Segment details from master...
+20170830:00:35:12:440808 gpstop:sdw6:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 5.0.0-beta.9+dev.45.g52ba809 build dev'
+20170830:00:35:12:440808 gpstop:sdw6:gpadmin-[INFO]:-There are 0 connections to the database
+20170830:00:35:12:440808 gpstop:sdw6:gpadmin-[INFO]:-Commencing Master instance shutdown with mode='immediate'
+20170830:00:35:12:440808 gpstop:sdw6:gpadmin-[INFO]:-Master host=sdw6
+20170830:00:35:12:440808 gpstop:sdw6:gpadmin-[INFO]:-Commencing Master instance shutdown with mode=immediate
+20170830:00:35:12:440808 gpstop:sdw6:gpadmin-[INFO]:-Master segment instance directory=/data1/tpz/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20170830:00:35:13:440808 gpstop:sdw6:gpadmin-[INFO]:-Attempting forceful termination of any leftover master process
+20170830:00:35:13:440808 gpstop:sdw6:gpadmin-[INFO]:-Terminating processes for segment /data1/tpz/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20170830:00:35:13:440808 gpstop:sdw6:gpadmin-[INFO]:-No standby master host configured
+20170830:00:35:13:440808 gpstop:sdw6:gpadmin-[INFO]:-Commencing parallel primary segment instance shutdown, please wait...
+20170830:00:35:13:440808 gpstop:sdw6:gpadmin-[INFO]:-0.00% of jobs completed
+20170830:00:35:23:440808 gpstop:sdw6:gpadmin-[INFO]:-100.00% of jobs completed
+20170830:00:35:23:440808 gpstop:sdw6:gpadmin-[INFO]:-Commencing parallel mirror segment instance shutdown, please wait...
+20170830:00:35:23:440808 gpstop:sdw6:gpadmin-[INFO]:-0.00% of jobs completed
+20170830:00:35:33:440808 gpstop:sdw6:gpadmin-[INFO]:-100.00% of jobs completed
+20170830:00:35:33:440808 gpstop:sdw6:gpadmin-[INFO]:-----------------------------------------------------
+20170830:00:35:33:440808 gpstop:sdw6:gpadmin-[INFO]:-   Segments stopped successfully      = 6
+20170830:00:35:33:440808 gpstop:sdw6:gpadmin-[INFO]:-   Segments with errors during stop   = 0
+20170830:00:35:33:440808 gpstop:sdw6:gpadmin-[INFO]:-----------------------------------------------------
+20170830:00:35:33:440808 gpstop:sdw6:gpadmin-[INFO]:-Successfully shutdown 6 of 6 segment instances 
+20170830:00:35:33:440808 gpstop:sdw6:gpadmin-[INFO]:-Database successfully shutdown with no errors reported
+20170830:00:35:33:440808 gpstop:sdw6:gpadmin-[INFO]:-Cleaning up leftover gpmmon process
+20170830:00:35:33:440808 gpstop:sdw6:gpadmin-[INFO]:-No leftover gpmmon process found
+20170830:00:35:33:440808 gpstop:sdw6:gpadmin-[INFO]:-Cleaning up leftover gpsmon processes
+20170830:00:35:33:440808 gpstop:sdw6:gpadmin-[INFO]:-No leftover gpsmon processes on some hosts. not attempting forceful termination on these hosts
+20170830:00:35:33:440808 gpstop:sdw6:gpadmin-[INFO]:-Cleaning up leftover shared memory
+20170830:00:35:33:440808 gpstop:sdw6:gpadmin-[INFO]:-Restarting System...
 
 -- end_ignore
 
@@ -62,10 +69,10 @@ gp_resource_group_memory_limit
 show max_connections;
 max_connections
 ---------------
-150            
+40             
 (1 row)
 
 -- by default admin_group has concurrency set to -1 which leads to
 -- very small memory quota for each resgroup slot, correct it.
-ALTER RESOURCE GROUP admin_group SET concurrency 150;
+ALTER RESOURCE GROUP admin_group SET concurrency 40;
 ALTER

--- a/src/test/isolation2/sql/resgroup/resgroup_parallel_queries.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_parallel_queries.sql
@@ -6,8 +6,6 @@
 ! psql -d isolation2resgrouptest -f ./sql/resgroup/dblink.sql;
 -- end_ignore
 
-alter resource group admin_group set concurrency 30;
-
 -- This function execute commands N times. 
 -- % in command will be replaced by number specified by range1 sequentially
 -- # in command will be replaced by number specified by range2 randomly 
@@ -96,6 +94,20 @@ LANGUAGE 'plpgsql';
 5<:
 6<:
 
+1: select dblink_disconnect('dblink_rg_test1');
+2: select dblink_disconnect('dblink_rg_test2');
+3: select dblink_disconnect('dblink_rg_test3');
+4: select dblink_disconnect('dblink_rg_test4');
+5: select dblink_disconnect('dblink_rg_test5');
+6: select dblink_disconnect('dblink_rg_test6');
+
+
+1q:
+2q:
+3q:
+4q:
+5q:
+6q:
 --
 -- DDLs vs DMLs
 --
@@ -203,6 +215,20 @@ select groupname, concurrency, cpu_rate_limit from gp_toolkit.gp_resgroup_config
 41: select dblink_disconnect('dblink_rg_test41');
 42: select dblink_disconnect('dblink_rg_test42');
 
+21q:
+22q:
+23q:
+24q:
+25q:
+26q:
+31q:
+32q:
+33q:
+34q:
+41q:
+42q:
+43q:
+
 select groupname, concurrency::int < 7, cpu_rate_limit::int < 7 from gp_toolkit.gp_resgroup_config where groupname like 'rg_test_g%' order by groupname;
 
 -- Beacuse concurrency of each resource group is changed between 1..6, so the num_queued must be larger than 0
@@ -240,9 +266,13 @@ create role rg_test_r8 login resource group rg_test_g8;
 53>:select exec_commands_n('dblink_rg_test53', 'select 1', 'begin', 'abort', 100, '', '', true);
 53<:
 
-51:select dblink_disconnect('dblink_rg_test51');
-52:select dblink_disconnect('dblink_rg_test52');
-53:select dblink_disconnect('dblink_rg_test53');
+51: select dblink_disconnect('dblink_rg_test51');
+52: select dblink_disconnect('dblink_rg_test52');
+53: select dblink_disconnect('dblink_rg_test53');
+
+51q:
+52q:
+53q:
 
 -- num_executed and num_queued must be zero
 select num_queued, num_executed from gp_toolkit.gp_resgroup_status where rsgname = 'rg_test_g8';
@@ -250,5 +280,4 @@ drop role rg_test_r8;
 drop resource group rg_test_g8;
 
 -- clean up
-alter resource group admin_group set concurrency 20;
 select * from gp_toolkit.gp_resgroup_config;

--- a/src/test/isolation2/sql/resgroup/restore_default_resgroup.sql
+++ b/src/test/isolation2/sql/resgroup/restore_default_resgroup.sql
@@ -2,8 +2,12 @@
 -- start_ignore
 ! gpconfig -c gp_resource_group_cpu_limit -v 0.9;
 ! gpconfig -c gp_resource_group_memory_limit -v 0.9;
-! gpconfig -c max_resource_groups -v 100;
-! gpconfig -c max_connections -v 600 -m 150;
+! gpconfig -c gp_resource_manager -v group;
+
+-- 40 should be enough for the following cases and some
+-- weak test agents may not adopt a higher max_connections
+! gpconfig -c max_resource_groups -v 40;
+! gpconfig -c max_connections -v 100 -m 40;
 ! gpstop -rai;
 -- end_ignore
 
@@ -14,4 +18,4 @@ show max_connections;
 
 -- by default admin_group has concurrency set to -1 which leads to
 -- very small memory quota for each resgroup slot, correct it.
-ALTER RESOURCE GROUP admin_group SET concurrency 150;
+ALTER RESOURCE GROUP admin_group SET concurrency 40;


### PR DESCRIPTION
In some weak test agents, the shared semaphore is two small to support large
max_connections like 150, so refine test cases to make it work with
40 max_connections.