### PR TITLE
Remove remnants of "EXCLUDE [CURRENT ROW|GROUP|TIES|NO OTHERS]" syntax.

### DIFF
--- a/src/backend/executor/nodeWindow.c
+++ b/src/backend/executor/nodeWindow.c
@@ -5455,15 +5455,13 @@ init_frames(WindowState * wstate)
 			 */
 			if (funcstate->isAgg && frame && frame->is_rows &&
 				frame->trail->kind == WINDOW_UNBOUND_PRECEDING &&
-				frame->lead->kind == WINDOW_CURRENT_ROW &&
-				frame->exclude == WINDOW_EXCLUSION_NULL)
+				frame->lead->kind == WINDOW_CURRENT_ROW)
 			{
 				funcstate->trivial_frame = true;
 			}
 			else if (funcstate->isAgg && frame && !frame->is_rows &&
 					 frame->trail->kind == WINDOW_UNBOUND_PRECEDING &&
-					 frame->lead->kind == WINDOW_CURRENT_ROW &&
-					 frame->exclude == WINDOW_EXCLUSION_NULL)
+					 frame->lead->kind == WINDOW_CURRENT_ROW)
 			{
 				funcstate->cumul_frame = true;
 			}

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -2358,7 +2358,11 @@ CTranslatorDXLToPlStmt::Pwindowframe
 	}
 	pwindowframe->is_between = true;
 
-	pwindowframe->exclude = CTranslatorUtils::Windowexclusion(pdxlwf->Edxlfes());
+	if (pdxlwf->Edxlfes() != EdxlfesNulls)
+	{
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
+			   GPOS_WSZ_LIT("EXCLUDE clause in window frame"));
+	}
 
 	// translate the CDXLNodes representing the leading and trailing edge
 	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);

--- a/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
@@ -1439,27 +1439,9 @@ CTranslatorScalarToDXL::Pdxlwf
 	EdxlFrameBoundary edxlfbLead = Edxlfb(pwindowframe->lead->kind, pwindowframe->lead->val);
 	EdxlFrameBoundary edxlfbTrail = Edxlfb(pwindowframe->trail->kind, pwindowframe->trail->val);
 
-	static ULONG rgrgulExclusionMapping[][2] =
-			{
-			{WINDOW_EXCLUSION_NULL, EdxlfesNulls},
-			{WINDOW_EXCLUSION_CUR_ROW, EdxlfesCurrentRow},
-			{WINDOW_EXCLUSION_GROUP, EdxlfesGroup},
-			{WINDOW_EXCLUSION_TIES, EdxlfesTies},
-			{WINDOW_EXCLUSION_NO_OTHERS, EdxlfesNone},
-			};
-
-	const ULONG ulArityExclusion = GPOS_ARRAY_SIZE(rgrgulExclusionMapping);
-	EdxlFrameExclusionStrategy edxlfes = EdxlfesSentinel;
-	for (ULONG ul = 0; ul < ulArityExclusion; ul++)
-	{
-		ULONG *pulElem = rgrgulExclusionMapping[ul];
-		if ((ULONG) pwindowframe->exclude == pulElem[0])
-		{
-			edxlfes = (EdxlFrameExclusionStrategy) pulElem[1];
-			break;
-		}
-	}
-	GPOS_ASSERT(EdxlfesSentinel != edxlfes && "Invalid window frame exclusion");
+	// We don't support non-default EXCLUDE [CURRENT ROW | GROUP | TIES |
+	// NO OTHERS] options.
+	EdxlFrameExclusionStrategy edxlfes = EdxlfesNulls;
 
 	CDXLNode *pdxlnLeadEdge = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLScalarWindowFrameEdge(m_pmp, true /* fLeading */, edxlfbLead));
 	CDXLNode *pdxlnTrailEdge = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLScalarWindowFrameEdge(m_pmp, false /* fLeading */, edxlfbTrail));

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -1018,46 +1018,6 @@ CTranslatorUtils::Edxlsetop
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::Windowexclusion
-//
-//	@doc:
-//		Return the GPDB frame exclusion strategy from its corresponding
-//		DXL representation
-//
-//---------------------------------------------------------------------------
-WindowExclusion
-CTranslatorUtils::Windowexclusion
-	(
-	EdxlFrameExclusionStrategy edxlfes
-	)
-{
-	GPOS_ASSERT(EdxlfesSentinel > edxlfes);
-	ULONG rgrgulMapping[][2] =
-		{
-		{EdxlfesNulls, WINDOW_EXCLUSION_NULL},
-		{EdxlfesCurrentRow, WINDOW_EXCLUSION_CUR_ROW},
-		{EdxlfesGroup, WINDOW_EXCLUSION_GROUP},
-		{EdxlfesTies, WINDOW_EXCLUSION_TIES}
-		};
-
-	const ULONG ulArity = GPOS_ARRAY_SIZE(rgrgulMapping);
-	WindowExclusion we = WINDOW_EXCLUSION_NO_OTHERS;
-
-	for (ULONG ul = 0; ul < ulArity; ul++)
-	{
-		ULONG *pulElem = rgrgulMapping[ul];
-		if ((ULONG) edxlfes == pulElem[0])
-		{
-			we = (WindowExclusion) pulElem[1];
-			break;
-		}
-	}
-	return we;
-}
-
-
-//---------------------------------------------------------------------------
-//	@function:
 //		CTranslatorUtils::Windowboundkind
 //
 //	@doc:

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -2365,7 +2365,6 @@ _copyWindowFrame(WindowFrame *from)
 	COPY_SCALAR_FIELD(is_between);
 	COPY_NODE_FIELD(trail);
 	COPY_NODE_FIELD(lead);
-	COPY_SCALAR_FIELD(exclude);
 
 	return newnode;
 }

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -2319,7 +2319,6 @@ _equalWindowFrame(WindowFrame *a, WindowFrame *b)
 	COMPARE_SCALAR_FIELD(is_between);
 	COMPARE_NODE_FIELD(trail);
 	COMPARE_NODE_FIELD(lead);
-	COMPARE_SCALAR_FIELD(exclude);
 
 	return true;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -3583,7 +3583,6 @@ _outWindowFrame(StringInfo str, WindowFrame *node)
 	WRITE_BOOL_FIELD(is_between);
 	WRITE_NODE_FIELD(trail);
 	WRITE_NODE_FIELD(lead);
-	WRITE_ENUM_FIELD(exclude, WindowExclusion);
 }
 
 static void

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -508,7 +508,6 @@ _readWindowFrame(void)
 	READ_BOOL_FIELD(is_between);
 	READ_NODE_FIELD(trail);
 	READ_NODE_FIELD(lead);
-	READ_ENUM_FIELD(exclude, WindowExclusion);
 
 	READ_DONE();
 }

--- a/src/backend/optimizer/plan/planwindow.c
+++ b/src/backend/optimizer/plan/planwindow.c
@@ -1188,11 +1188,6 @@ static int compare_frame(WindowFrame *a, WindowFrame *b)
 	if ( n != 0 )
 		return n;
 	
-	if ( a->exclude < b->exclude )
-		return -1;
-	else if ( a->exclude > b->exclude )
-		return 1;
-	
 	return 0;
 }
 

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -5476,27 +5476,6 @@ get_windowspec_expr(WindowSpec *spec, deparse_context *context)
 				get_windowedge_expr(f->trail, context);
 			}
 		}
-
-		/* exclusion statement */
-		switch(f->exclude)
-		{
-			case WINDOW_EXCLUSION_NULL:
-				break;
-			case WINDOW_EXCLUSION_CUR_ROW:
-				appendStringInfo(buf, " EXCLUDE CURRENT ROW");
-		   		break;
-			case WINDOW_EXCLUSION_GROUP:
-				appendStringInfo(buf, " EXCLUDE GROUP");
-				break;
-			case WINDOW_EXCLUSION_TIES:
-				appendStringInfo(buf, " EXCLUDE TIES");
-				break;
-			case WINDOW_EXCLUSION_NO_OTHERS:
-				appendStringInfo(buf, " EXCLUDE NO OTHERS");
-				break;
-			default:
-				elog(ERROR, "invalid exclusion type: %i", f->exclude);
-		}
 	}
 	appendStringInfoChar(buf, ')');
 }

--- a/src/include/gpopt/translate/CTranslatorUtils.h
+++ b/src/include/gpopt/translate/CTranslatorUtils.h
@@ -212,10 +212,6 @@ namespace gpdxl
 			static
 			EdxlSetOpType Edxlsetop(SetOperation setop, BOOL fAll);
 
-			// return the GPDB frame exclusion strategy from its corresponding DXL representation
-			static
-			WindowExclusion Windowexclusion(EdxlFrameExclusionStrategy edxlfes);
-
 			// return the GPDB frame boundary kind from its corresponding DXL representation
 			static
 			WindowBoundingKind Windowboundkind(EdxlFrameBoundary edxlfb);

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -1379,16 +1379,6 @@ typedef enum GroupingType
 	GROUPINGTYPE_GROUPING_SETS   /* GROUPING SETS grouping extension */
 } GroupingType;
 
-typedef enum WindowExclusion
-{
-	WINDOW_EXCLUSION_NULL = 0,
-	WINDOW_EXCLUSION_CUR_ROW, /* exclude current row */
-	WINDOW_EXCLUSION_GROUP, /* exclude rows matching us */
-	WINDOW_EXCLUSION_TIES, /* exclude rows matching us, and current row */
-	WINDOW_EXCLUSION_NO_OTHERS /* don't exclude -- distinct from EMPTY so
-								* that we may dump */
-} WindowExclusion;
-
 typedef enum WindowBoundingKind
 {
 	WINDOW_UNBOUND_PRECEDING,
@@ -1419,7 +1409,6 @@ typedef struct WindowFrame
 	 */
 	WindowFrameEdge *trail; /* trailing edge of the frame */
 	WindowFrameEdge *lead; /* leading edge of the frame */
-	WindowExclusion exclude; /* exclusion clause */
 } WindowFrame;
 
 


### PR DESCRIPTION
It hasn't been implemented, but there is basic support in the grammar,
just enough to detect the syntax and throw an error or ignore it. All the
rest was dead code.