### PR TITLE
Enable ORCA to use IndexScan on Leaf Partitions

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("2.41.", GPORCA_VERSION_STRING, 5);
+return strncmp("2.42.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 2.41.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 2.42.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -12540,7 +12540,7 @@ int
 main ()
 {
 
-return strncmp("2.41.", GPORCA_VERSION_STRING, 5);
+return strncmp("2.42.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -12550,7 +12550,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 2.41.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 2.42.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -121,7 +121,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	@echo "Resolve finished";
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget -O - https://github.com/greenplum-db/gporca/releases/download/v2.41.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget -O - https://github.com/greenplum-db/gporca/releases/download/v2.42.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
@@ -293,9 +293,9 @@ namespace gpdxl
 			static
 			BOOL FIndexSupported(Relation relIndex);
 			
-			// collect oids of indexes on partitioned table
+			// retrieve index info list of partitioned table
 			static
-			List *PlIndexOidsPartTable(Relation rel);
+			List *PlIndexInfoPartTable(Relation rel);
 			 
 			// compute the array of included columns
 			static
@@ -337,10 +337,18 @@ namespace gpdxl
 			static
 			CMDName *PmdnameRel(IMemoryPool *pmp, Relation rel);
 
-			// return the indexes defined on the given relation
+			// return the index info list defined on the given relation
 			static
-			DrgPmdid *PdrgpmdidRelIndexes(IMemoryPool *pmp, Relation rel);
-			
+			DrgPmdIndexInfo *PdrgpmdRelIndexInfo(IMemoryPool *pmp, Relation rel);
+
+			// return index info list of indexes defined on a partitoned table
+			static
+			DrgPmdIndexInfo *PdrgpmdRelIndexInfoPartTable(IMemoryPool *pmp, Relation relRoot);
+
+			// return index info list of indexes defined on regular, external tables or leaf partitions
+			static
+			DrgPmdIndexInfo *PdrgpmdRelIndexInfoNonPartTable(IMemoryPool *pmp, Relation rel);
+
 			// retrieve an index over a partitioned table from the relcache
 			static
 			IMDIndex *PmdindexPartTable(IMemoryPool *pmp, CMDAccessor *pmda, IMDId *pmdidIndex, const IMDRelation *pmdrel, LogicalIndexes *plind);


### PR DESCRIPTION
Currently ORCA does not support index scan on leaf partitions. It only supports
index scan if we query the root table. This PR along with the corresponding
[ORCA PR](https://github.com/greenplum-db/gporca/pull/219) adds a support for using indexes when leaf partitions are queried
directly.

When a root table that has indexes (either homogenous/complete or
heterogenous/partial) is queried; the Relcache Translator sends index
information to ORCA.  This enables ORCA to generate an alternative plan with
Dynamic Index Scan on all partitions (in case of homogenous index) or a plan
with partial scan i.e. Dynamic Table Scan on leaf partitions that  don’t have
indexes + Dynamic Index Scan on leaf partitions with indexes (in case of
heterogeneous index).

This is a two step process in Relcache Translator as described below:

Step 1 - Get list of all index oids

`CTranslatorRelcacheToDXL::PdrgpmdidRelIndexes()` performs this step and it
only retrieves indexes on root and regular tables; for leaf partitions it bails
out.

Now for root, list of index oids is nothing but index oids on its leaf
partitions. For instance:

```
CREATE TABLE foo ( a int, b int, c int, d int) DISTRIBUTED by (a) PARTITION
BY RANGE(b) (PARTITION p1 START (1) END (10) INCLUSIVE, PARTITION p2 START (11)
END (20) INCLUSIVE);

CREATE INDEX complete_c on foo USING btree (c); CREATE INDEX partial_d on
foo_1_prt_p2 using btree(d);
```
The index list will look like = { complete_c_1_prt_p1, partial_d }

For a complete index, the index oid of the first leaf partitions is retrieved.
If there are partial indexes, all the partial index oids are retrieved.

Step 2 - Construct Index Metadata object

`CTranslatorRelcacheToDXL::Pmdindex()` performs this step.

For each index oid retrieved in Step #1 above; construct an Index Metadata
object (CMDIndexGPDB) to be stored in metadata cache such that ORCA can get all
the information about the index.
Along with all other information about the index, `CMDIndexGPDB` also contains
a flag `fPartial` which denotes if the given index is homogenous (ORCA
will apply it to all partitions selected by partition selector) or heterogenous
(the index will be applied to only appropriate partitions).
The process is as follows:
```
	Foreach oid in index oid list :
		Get index relation (rel)
		If rel is a leaf partition :
			Get the root rel of the leaf partition
			Get all	the indexes on the root (this will be same list as step #1)
			Determine if the current index oid is homogenous or heterogenous
			Construct CMDIndexGPDB based appropriately (with fPartial, part constraint,
			defaultlevels info)
		Else:
			Construct a normal CMDIndexGPDB object.
```

Now for leaf partitions, there is no notion of homogenous or heterogenous
indexes since a leaf partition is like a regular table. Hence in `Pmdindex()`
we should not got for checking if index is complete or not.

Additionally, If a given index is homogenous or heterogenous needs to be
decided from the perspective of relation we are querying(such as root or a
leaf).

Hence the right place of `fPartial` flag is in the relation metadata object
(CMDRelationGPDB) and not the independent Index metadata object (CMDIndexGPDB).
This commit makes following changes to support index scan on leaf partitions
along with partial scans :

Relcache Translator:

In Step1, retrieve the index information on the leaf partition and create a
list of CMDIndexInfo object which contain the index oid and `fPartial` flag.
Step 1 is the place where we know what relation we are querying which enable us
to determine whether or not the index is homogenous from the context of the
relation.

The relation metadata tag will look like following after this change:

Before:
```
	<dxl:Indexes>
		<dxl:Index Mdid="0.17159874.1.0"/>
		<dxl:Index Mdid="0.17159920.1.0"/>
	</dxl:Indexes>
```

After:
```
	<dxl:IndexInfoList>
		<dxl:IndexInfo Mdid="0.17159874.1.0" IsPartial="true"/>
		<dxl:IndexInfo Mdid="0.17159920.1.0" IsPartial="false"/>
	</dxl:IndexInfoList>

```

A new class `CMDIndexInfo` has been created in ORCA which contains index mdid
and `fPartial` flag.  For external tables, normal tables and leaf partitions;
the `fPartial` flag will always be false.

Hence at the end, relcache translator will provide list of indexes defined on
leaf partitions when they are queried directly with `fPartial` being false
always. And when root table is queried; the `fPartial` will be set
appropriately based on the completeness of the index.  ORCA will refer to
Relation Metadata for fPartial information and not to the indepedent Index
Metadata Object.

[Ref ##120303669]