### PR TITLE
Cherry pick upstream commit: dcd647d

### DIFF
--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -8,7 +8,7 @@
  * Portions Copyright (c) 1994, Regents of the University of California
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/optimizer/plan/subselect.c,v 1.148 2009/04/05 19:59:40 tgl Exp $
+ *	  $PostgreSQL: pgsql/src/backend/optimizer/plan/subselect.c,v 1.150.2.2 2010/01/18 18:17:52 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -1360,6 +1360,17 @@ convert_EXISTS_sublink_to_join(PlannerInfo *root, SubLink *sublink,
 	Assert(IsA(subselect, Query));
 
 	if (has_correlation_in_funcexpr_rte(subselect->rtable))
+		return NULL;
+
+	/*
+	 * Can't flatten if it contains WITH.  (We could arrange to pull up the
+	 * WITH into the parent query's cteList, but that risks changing the
+	 * semantics, since a WITH ought to be executed once per associated query
+	 * call.)  Note that convert_ANY_sublink_to_join doesn't have to reject
+	 * this case, since it just produces a subquery RTE that doesn't have to
+	 * get flattened into the parent query.
+	 */
+	if (subselect->cteList)
 		return NULL;
 
 	/*


### PR DESCRIPTION
commit dcd647d7cf98e3393f919135f6e113e896781f60
    Author: Tom Lane <tgl@sss.pgh.pa.us>
    Date:   Mon Jan 18 18:17:52 2010 +0000

        Fix an oversight in convert_EXISTS_sublink_to_join: we can't convert an
        EXISTS that contains a WITH clause.  This would usually lead to a
        "could not find CTE" error later in planning, because the WITH wouldn't
        get processed at all.  Noted while playing with an example from Ken Marshall.