### PR TITLE
fix travis with --disable-pxf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ before_script:
 
 script:
   - cd ${TRAVIS_BUILD_DIR}
-  - ./configure --with-openssl --with-ldap --with-libcurl --prefix=${TRAVIS_BUILD_DIR}/gpsql --with-apr-config=${TRAVIS_BUILD_DIR}/tools/bin/apr-1-config --disable-orca --disable-gpcloud
+  - ./configure --with-openssl --with-ldap --with-libcurl --prefix=${TRAVIS_BUILD_DIR}/gpsql --with-apr-config=${TRAVIS_BUILD_DIR}/tools/bin/apr-1-config --disable-orca --disable-gpcloud --disable-pxf
 
   - make
   - make install


### PR DESCRIPTION
Fix Travis by adding --disable-pxf to configure command.  We could always just add json-c-devel package and see if it works... but we need to determine if we want Travis to compile pxf or not first.  We currently have Travis set up to not compile gpAux/extensions so this PR just adds to the current setup.