### PR TITLE
Fix floating-point exception when defining index concurrently under resource group

### DIFF
--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -2030,7 +2030,7 @@ SwitchResGroupOnSegment(const char *buf, int len)
 			prevSlot = &prevSharedInfo->slots[prevSlotId];
 			detachFromSlot(prevSharedInfo, prevSlot, procInfo);
 
-			groupReleaseMemQuota(prevSharedInfo, prevSlot, &caps);
+			groupReleaseMemQuota(prevSharedInfo, prevSlot, &prevSharedInfo->caps);
 		}
 		else
 		{

--- a/src/test/isolation2/expected/resgroup/resgroup_transaction.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_transaction.out
@@ -234,6 +234,23 @@ DROP
 DROP FUNCTION rg_drop_func();
 DROP
 
+-- ----------------------------------------------------------------------
+-- Test: Create index concurrently under the control of resource group
+-- ----------------------------------------------------------------------
+-- GPDB will commit a transaction and restart a transaction when defining
+-- index concurrently. We need to verify resource group can handle this
+-- case.
+CREATE TABLE concur_table (f1 text, f2 text, dk text) distributed by (dk);
+CREATE
+SET gp_create_index_concurrently = TRUE;
+SET
+CREATE INDEX CONCURRENTLY idx_concur_table ON concur_table(f2,f1);
+CREATE
+DROP INDEX idx_concur_table;
+DROP
+DROP TABLE concur_table;
+DROP
+
 -- cleanup
 DROP VIEW rg_test_monitor;
 DROP

--- a/src/test/isolation2/sql/resgroup/resgroup_transaction.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_transaction.sql
@@ -132,5 +132,17 @@ DROP FUNCTION rg_create_func();
 DROP FUNCTION rg_alter_func();
 DROP FUNCTION rg_drop_func();
 
+-- ----------------------------------------------------------------------
+-- Test: Create index concurrently under the control of resource group
+-- ----------------------------------------------------------------------
+-- GPDB will commit a transaction and restart a transaction when defining
+-- index concurrently. We need to verify resource group can handle this
+-- case.
+CREATE TABLE concur_table (f1 text, f2 text, dk text) distributed by (dk);
+SET gp_create_index_concurrently = TRUE;
+CREATE INDEX CONCURRENTLY idx_concur_table ON concur_table(f2,f1);
+DROP INDEX idx_concur_table;
+DROP TABLE concur_table;
+
 -- cleanup
 DROP VIEW rg_test_monitor;


### PR DESCRIPTION
When define index concurrently, DefineIndex() commits current transaction and
dispatch a command to segments without resource group info, therefore, QE get
a capability info with zero configured, the problem is groupReleaseMemQuota()
use the empty capability info wrong and caused a floating-point exception.

According to the code, it should use prevSharedInfo->caps instead