### PR TITLE
gpaddmirror: add test coverage

### DIFF
--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpaddmirrors.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpaddmirrors.py
@@ -1,19 +1,25 @@
 import os
-import imp
 import sys
 
+import StringIO
 from mock import *
 from gp_unittest import *
-from gppylib.programs.clsAddMirrors import GpAddMirrorsProgram
+from gppylib.programs.clsAddMirrors import GpAddMirrorsProgram, ProgramArgumentValidationException
 from gparray import GpDB, GpArray
 from gppylib.system.environment import GpMasterEnvironment
 from gppylib.system.configurationInterface import GpConfigurationProvider
 
+
 class GpAddMirrorsTest(GpTestCase):
     def setUp(self):
-        self.subject = GpAddMirrorsProgram
-        self.gparrayMock = self.createGpArrayWith2Primary2Mirrors()
-
+        # because gpaddmirrors does not have a .py extension,
+        # we have to use imp to import it
+        # if we had a gpaddmirrors.py, this is equivalent to:
+        #   import gpaddmirrors
+        #   self.subject = gpaddmirrors
+        self.subject = GpAddMirrorsProgram(None)
+        self.gparrayMock = self._createGpArrayWith2Primary2Mirrors()
+        self.gparray_get_segments_by_hostname = dict(sdw1=[self.primary0])
         self.apply_patches([
             patch('gppylib.programs.clsAddMirrors.base.WorkerPool'),
             patch('gppylib.programs.clsAddMirrors.logger', return_value=Mock(spec=['log', 'info', 'debug', 'error'])),
@@ -22,33 +28,39 @@ class GpAddMirrorsTest(GpTestCase):
             patch('gppylib.system.faultProberInterface.getFaultProber'),
             patch('gppylib.programs.clsAddMirrors.configInterface.getConfigurationProvider', return_value=Mock()),
             patch('gppylib.programs.clsAddMirrors.heapchecksum.HeapChecksum'),
+            patch('gppylib.gparray.GpArray.getSegmentsByHostName', return_value=self.gparray_get_segments_by_hostname),
+
         ])
         self.mock_logger = self.get_mock_from_apply_patch('logger')
         self.gpMasterEnvironmentMock = self.get_mock_from_apply_patch("GpMasterEnvironment")
         self.gpMasterEnvironmentMock.return_value.getMasterPort.return_value = 123456
         self.getConfigProviderFunctionMock = self.get_mock_from_apply_patch('getConfigurationProvider')
-        configProviderMock = Mock(spec=GpConfigurationProvider)
-        self.getConfigProviderFunctionMock.return_value = configProviderMock
-        configProviderMock.initializeProvider.return_value = configProviderMock
-        configProviderMock.loadSystemConfig.return_value = self.gparrayMock
+        config_provider_mock = Mock(spec=GpConfigurationProvider)
+        self.getConfigProviderFunctionMock.return_value = config_provider_mock
+        config_provider_mock.initializeProvider.return_value = config_provider_mock
+        config_provider_mock.loadSystemConfig.return_value = self.gparrayMock
         self.mock_heap_checksum = self.get_mock_from_apply_patch('HeapChecksum')
         self.mock_heap_checksum.return_value.get_master_value.return_value = 1
         self.mock_heap_checksum.return_value.get_segments_checksum_settings.return_value = ([1], [0])
         self.mock_heap_checksum.return_value.are_segments_consistent.return_value = False
-        self.mock_heap_checksum.return_value.check_segment_consistency.return_value = ([1], [1], 1)
+        self.master.heap_checksum = 1
+        self.mock_heap_checksum.return_value.check_segment_consistency.return_value = (
+            [self.primary0], [], self.master.heap_checksum)
+        self.mdd = os.getenv("MASTER_DATA_DIRECTORY")
+        if not self.mdd:
+            self.mdd = "/Users/pivotal/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1"
+            os.environ["MASTER_DATA_DIRECTORY"] = self.mdd
+
+        self.parser = GpAddMirrorsProgram.createParser()
 
     def tearDown(self):
         super(GpAddMirrorsTest, self).tearDown()
 
-    def test_validate_heap_checksum_throws_if_cluster_inconsistent(self):
-        with self.assertRaises(Exception):
-            self.subject.validate_heap_checksums(self.subject(None), self.gparrayMock)
-
-    def test_validate_heap_checksum_succeds_if_cluster_consistent(self):
+    def test_validate_heap_checksum_succeeds_if_cluster_consistent(self):
         self.mock_heap_checksum.return_value.get_segments_checksum_settings.return_value = ([1], [1])
         self.mock_heap_checksum.return_value.are_segments_consistent.return_value = True
         self.mock_heap_checksum.return_value.check_segment_consistency.return_value = ([2], [], 1)
-        self.subject.validate_heap_checksums(self.subject(None), self.gparrayMock)
+        self.subject.validate_heap_checksums(self.gparrayMock)
         self.mock_logger.info.assert_any_call("Heap checksum setting consistent across cluster")
 
     def test_run_calls_validate_heap_checksum(self):
@@ -58,17 +70,62 @@ class GpAddMirrorsTest(GpTestCase):
         self.mock_heap_checksum.return_value.check_segment_consistency.return_value = (
             [self.primary0], [self.primary1], self.master.heap_checksum)
         sys.argv = ['gpaddmirrors', '-a']
-        parser = self.subject.createParser()
-        options, args = parser.parse_args()
+        options, args = self.parser.parse_args()
         command_obj = self.subject.createProgram(options, args)
         with self.assertRaisesRegexp(Exception, 'Segments have heap_checksum set inconsistently to master'):
             command_obj.run()
 
-    def createGpArrayWith2Primary2Mirrors(self):
+    def test_option_batch_of_size_0_will_raise(self):
+        sys.argv = ['gpaddmirrors', '-B', '0']
+        options, _ = self.parser.parse_args()
+        self.subject = GpAddMirrorsProgram(options)
+        with self.assertRaises(ProgramArgumentValidationException):
+            self.subject.run()
+
+    @patch('sys.stdout', new_callable=StringIO.StringIO)
+    def test_option_version(self, mock_stdout):
+        sys.argv = ['gpaddmirrors', '--version']
+        with self.assertRaises(SystemExit) as cm:
+            options, _ = self.parser.parse_args()
+
+        self.assertIn("gpaddmirrors version $Revision$", mock_stdout.getvalue())
+        self.assertEquals(cm.exception.code, 0)
+
+    def test_generated_file_contains_default_port_offsets(self):
+        datadir_config = _write_datadir_config(self.mdd)
+        mirror_config_output_file = "/tmp/test_gpaddmirrors.config"
+        sys.argv = ['gpaddmirrors', '-o', mirror_config_output_file, '-m', datadir_config]
+        options, _ = self.parser.parse_args()
+        subject = GpAddMirrorsProgram(options)
+        subject.run()
+
+        with open(mirror_config_output_file, 'r') as fp:
+            result = fp.readlines()
+
+        self.assertIn("41000", result[1])
+        self.assertIn("42000", result[1])
+        self.assertIn("43000", result[1])
+
+    def test_generated_file_contains_port_offsets(self):
+        datadir_config = _write_datadir_config(self.mdd)
+        mirror_config_output_file = "/tmp/test_gpaddmirrors.config"
+        sys.argv = ['gpaddmirrors', '-p', '5000', '-o', mirror_config_output_file, '-m', datadir_config]
+        options, _ = self.parser.parse_args()
+        subject = GpAddMirrorsProgram(options)
+        subject.run()
+
+        with open(mirror_config_output_file, 'r') as fp:
+            result = fp.readlines()
+
+        self.assertIn("45000", result[1])
+        self.assertIn("50000", result[1])
+        self.assertIn("55000", result[1])
+
+    def _createGpArrayWith2Primary2Mirrors(self):
         self.master = GpDB.initFromString(
             "1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
         self.primary0 = GpDB.initFromString(
-            "2|0|p|p|s|u|aspen|sdw1|40000|41000|/Users/pivotal/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
+            "2|0|p|p|s|u|sdw1|sdw1|40000|41000|/Users/pivotal/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
         self.primary1 = GpDB.initFromString(
             "3|1|p|p|s|u|sdw2|sdw2|40001|41001|/data/primary1||/data/primary1/base/10899,/data/primary1/base/1,/data/primary1/base/10898,/data/primary1/base/25780,/data/primary1/base/34782")
         mirror0 = GpDB.initFromString(
@@ -77,6 +134,21 @@ class GpAddMirrorsTest(GpTestCase):
             "5|1|m|m|s|u|sdw1|sdw1|50001|51001|/data/mirror1||/data/mirror1/base/10899,/data/mirror1/base/1,/data/mirror1/base/10898,/data/mirror1/base/25780,/data/mirror1/base/34782")
 
         return GpArray([self.master, self.primary0, self.primary1, mirror0, mirror1])
+
+
+def _write_datadir_config(mdd):
+    mdd_parent_parent = os.path.realpath(mdd + "../../../")
+    mirror_data_dir = os.path.join(mdd_parent_parent, 'mirror')
+    if not os.path.exists(mirror_data_dir):
+        os.mkdir(mirror_data_dir)
+    datadir_config = '/tmp/gpaddmirrors_datadir_config'
+    contents = \
+"""
+{0}
+""".format(mirror_data_dir)
+    with open(datadir_config, 'w') as fp:
+        fp.write(contents)
+    return datadir_config
 
 
 if __name__ == '__main__':

--- a/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
@@ -1,0 +1,13 @@
+@gpaddmirrors
+Feature: Tests for gpaddmirrors
+
+    Scenario: gpaddmirrors with a default master data directory
+        Given the database is initialized with no mirrored segments in the configuration
+        And gpaddmirrors adds mirrors
+        Then verify the database has mirrors
+
+    @gpaddmirrors_temp_directory
+    Scenario: gpaddmirrors with a given master data directory [-d <master datadir>]
+        Given the database is initialized with no mirrored segments in the configuration
+        And gpaddmirrors adds mirrors with temporary data dir
+        Then verify the database has mirrors

--- a/gpMgmt/test/behave/mgmt_utils/steps/addmirrors_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/addmirrors_mgmt_utils.py
@@ -1,0 +1,91 @@
+from behave import given, then
+
+from test.behave_utils.utils import *
+
+
+def _get_mirror_count():
+    with dbconn.connect(dbconn.DbURL(dbname='template1')) as conn:
+        sql = """SELECT count(*) FROM gp_segment_configuration WHERE role='m'"""
+        count_row = dbconn.execSQL(conn, sql).fetchone()
+        return count_row[0]
+
+
+def _generate_input_config():
+    datadir_config = _write_datadir_config()
+
+    mirror_config_output_file = "/tmp/test_gpaddmirrors.config"
+    cmd_str = 'gpaddmirrors -o %s -m %s' % (mirror_config_output_file, datadir_config)
+    Command('generate mirror_config file', cmd_str).run(validateAfter=True)
+
+    return mirror_config_output_file
+
+
+def _write_datadir_config():
+    mdd_parent_parent = os.path.realpath(os.getenv("MASTER_DATA_DIRECTORY") + "../../../")
+    mirror_data_dir = os.path.join(mdd_parent_parent, 'mirror')
+    if not os.path.exists(mirror_data_dir):
+        os.mkdir(mirror_data_dir)
+    datadir_config = '/tmp/gpaddmirrors_datadir_config'
+    contents = """
+{0}
+{0}
+{0}
+""".format(mirror_data_dir)
+    with open(datadir_config, 'w') as fp:
+        fp.write(contents)
+    return datadir_config
+
+
+@given('the database is initialized with no mirrored segments in the configuration')
+def impl(context):
+    is_db_up = check_database_is_running(context)
+    if is_db_up and _get_mirror_count() == 0:
+        return
+
+    # sad path
+    if is_db_up:
+        stop_database(context)
+
+    cmd = """
+    cd ../gpAux/gpdemo && \
+        export NUM_PRIMARY_MIRROR_PAIRS=3 && \
+        export MASTER_DEMO_PORT={master_port} && \
+        export DEMO_PORT_BASE={port_base} && \
+        export WITH_MIRRORS=false && \
+        ./demo_cluster.sh -d && \
+        ./demo_cluster.sh -c && \
+        ./demo_cluster.sh
+    """.format(master_port=os.getenv('MASTER_PORT', 15432),
+               port_base=os.getenv('PORT_BASE', 25432),
+               )
+
+    run_command(context, cmd)
+
+    if context.ret_code != 0:
+        raise Exception('%s, stdout: %s' % (context.error_message, context.stdout_message))
+
+
+@then('verify the database has mirrors')
+def impl(context):
+    if _get_mirror_count() == 0:
+        raise Exception('No mirrors found')
+
+
+@given('gpaddmirrors adds mirrors')
+def impl(context):
+    context.mirror_config = _generate_input_config()
+
+    cmd = Command('gpaddmirrors ', 'gpaddmirrors -a -i %s ' % context.mirror_config)
+    cmd.run(validateAfter=True)
+
+
+@given('gpaddmirrors adds mirrors with temporary data dir')
+def impl(context):
+    context.mirror_config = _generate_input_config()
+    mdd = os.getenv('MASTER_DATA_DIRECTORY', "")
+    del os.environ['MASTER_DATA_DIRECTORY']
+    try:
+        cmd = Command('gpaddmirrors ', 'gpaddmirrors -a -i %s -d %s' % (context.mirror_config, mdd))
+        cmd.run(validateAfter=True)
+    finally:
+        os.environ['MASTER_DATA_DIRECTORY'] = mdd

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -3886,6 +3886,7 @@ def impl(context, seg):
 def impl(context, to_file):
     write_lines = []
     BLDWRAP_TOP = os.environ.get('BLDWRAP_TOP')
+    # this file is the output of the pulse system, where gpinit has been run
     from_file = BLDWRAP_TOP + '/sys_mgmt_test/test/general/cluster_conf.out'
     with open(from_file) as fr:
         lines = fr.readlines()

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/utilities/gpaddmirrors/test_gpaddmirrors.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/utilities/gpaddmirrors/test_gpaddmirrors.py
@@ -339,61 +339,8 @@ class GpAddmirrorsTests(GPAddmirrorsTestCase):
         super(GpAddmirrorsTests, self).tearDown()
 
 
-    def test_version(self):
-        """
-        check the version of the gpadmirror to see if it reflects the same as database version
-        """
-        res = {'rc': 0, 'stdout' : '', 'stderr': ''}
-        run_shell_command("gpaddmirrors --version", 'run gpaddmirrros --version', res)
-        self.assertEqual(0, res['rc'])
-        version_build_info = res['stdout'].split('gpaddmirrors version')[1].strip()
-        gpdb_version_build_info = PSQL.run_sql_command('SELECT VERSION();', flags = '-q -t', dbname = 'template1')
-        self.assertIn(version_build_info, gpdb_version_build_info)
-
-    def test_help(self):
-        """
-        check the help option of gpaddmirrors
-        """
-        help_doc = local_path('data/help_doc')
-        help_output = local_path('data/help_output')
-        Command('output the help information', 'gpaddmirrors --help > %s' % help_output).run(validateAfter=True)
-        self.assertTrue(Gpdiff.are_files_equal(help_output, help_doc))
-
-
-    def test_option_h(self):
-        """
-        check the -h option of the gpaddmirrors
-        """
-        help_doc = local_path('data/help_doc')
-        help_output = local_path('data/help_output')
-        Command('output the help information', 'gpaddmirrors -h > %s' % help_output).run(validateAfter=True)
-        self.assertTrue(Gpdiff.are_files_equal(help_output, help_doc))
-
-
-    def test_question_mark_help_option(self):
-        """
-        check the question mark option -? of gpaddmirrors
-        """
-        help_doc = local_path('data/help_doc')
-        help_output = local_path('data/help_output')
-        Command('output the help information', 'gpaddmirrors -? > %s' % help_output).run(validateAfter=True)
-        self.assertTrue(Gpdiff.are_files_equal(help_output, help_doc))
-
-
-    def test_option_d(self):
-        """
-        check the -d option of gpaddmirrors
-        """
-        gprecover = GpRecover()
-        self._setup_gpaddmirrors()
-        self._cleanup_segment_data_dir(self.host_file, self.mirror_data_dir)
-        del os.environ['MASTER_DATA_DIRECTORY']
-        Command('run gpaddmirrors -i -d', 'gpaddmirrors -a -i %s -d %s' % (self.mirror_config_file, self.mdd)).run(validateAfter=True)
-        os.environ['MASTER_DATA_DIRECTORY']=self.mdd
-        gprecover.wait_till_insync_transition()
-        self.verify_config_file_with_gp_config()
-        self.check_mirror_seg() 
-
+# The following test should not be ported because the gpaddmirror functionality is already tested by other tests, and
+# this test in particular is only testing if worker pool can handle a batch size of 4.
 
     def test_batch_size_4(self):
         """
@@ -420,39 +367,7 @@ class GpAddmirrorsTests(GPAddmirrorsTestCase):
         self.check_mirror_seg()
 
 
-    def test_option_port_offset(self):
-        """
-	primary port + offset = mirror database port
-	primary port + (2 * offset) = mirror replication port
-	primary port + (3 * offset) = primary replication port
-        """
-        gprecover = GpRecover()
-        port_offset = 500
-        self._setup_gpaddmirrors(port_offset = port_offset)
-        self._cleanup_segment_data_dir(self.host_file, self.mirror_data_dir)
-
-        res = {'rc': 0, 'stdout' : '', 'stderr': ''}
-        run_shell_command("gpaddmirrors -a -i %s -d %s --verbose" % (self.mirror_config_file, self.mdd), 'run gpaddmirrros with non default port_offset', res)
-        self.assertEqual(0, res['rc'])
-        query_ports = 'SELECT port, replication_port FROM gp_segment_configuration WHERE content = 0 ORDER BY preferred_role DESC;'
-        result = PSQL.run_sql_command(query_ports, flags='-q -t', dbname='template1')
-        ports = result.strip().split('\n')
-        primary_ports = ports[0]
-        mirror_ports = ports[1]
-        primary_ports = primary_ports.split('|')
-        primary_ports = [port.strip() for port in primary_ports]
-        primary_db_port = int(primary_ports[0])
-        primary_replic_port = int(primary_ports[1])
-        mirror_ports = mirror_ports.split('|')
-        mirror_ports = [port.strip() for port in mirror_ports]
-        mirror_db_port = int(mirror_ports[0])
-        mirror_replic_port = int(mirror_ports[1])  
-        self.assertEqual(primary_db_port + port_offset, mirror_db_port)
-        self.assertEqual(primary_db_port + 2*port_offset, mirror_replic_port)
-        self.assertEqual(primary_db_port + 3*port_offset, primary_replic_port)
-        gprecover.wait_till_insync_transition()
-        self.verify_config_file_with_gp_config()
-        self.check_mirror_seg()
+#The following tests need to be ported to Behave.
 
     def test_mirror_spread(self):
         """


### PR DESCRIPTION
We are porting Tinc test_gpaddmirrors.py to Behave.  We have added unit tests as needed and commented out the corresponding tests in test_gaddmirrors.py.