### PR TITLE
Make blocking for commits independent of walsender existence (same as upstream).

### DIFF
--- a/src/backend/postmaster/checkpointer.c
+++ b/src/backend/postmaster/checkpointer.c
@@ -41,6 +41,7 @@
 #include "miscadmin.h"
 #include "pgstat.h"
 #include "postmaster/bgwriter.h"
+#include "replication/syncrep.h"
 #include "storage/fd.h"
 #include "storage/freespace.h"
 #include "storage/ipc.h"
@@ -344,6 +345,9 @@ CheckpointerMain(void)
 	 */
 	PG_SETMASK(&UnBlockSig);
 
+	/* update global shmem state for sync rep */
+	SyncRepUpdateSyncStandbysDefined();
+
 	/*
 	 * Loop forever
 	 */
@@ -370,6 +374,9 @@ CheckpointerMain(void)
 		{
 			got_SIGHUP = false;
 			ProcessConfigFile(PGC_SIGHUP);
+
+			/* update global shmem state for sync rep */
+			SyncRepUpdateSyncStandbysDefined();
 		}
 		if (checkpoint_requested)
 		{

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -53,6 +53,7 @@
 #include "postmaster/bgwriter.h"
 #include "postmaster/postmaster.h"
 #include "postmaster/syslogger.h"
+#include "replication/syncrep.h"
 #include "replication/walsender.h"
 #include "replication/walreceiver.h"
 #include "postmaster/walwriter.h"
@@ -2635,6 +2636,17 @@ static struct config_string ConfigureNamesString[] =
 		},
 		&pgstat_temp_directory,
 		"pg_stat_tmp", assign_pgstat_temp_directory, NULL
+	},
+
+	{
+		{"synchronous_standby_names", PGC_SIGHUP, WAL_REPLICATION,
+			gettext_noop("List of names of potential synchronous standbys."),
+			NULL,
+			GUC_LIST_INPUT
+		},
+		&SyncRepStandbyNames,
+		"",
+		check_synchronous_standby_names, NULL, NULL
 	},
 
 	{

--- a/src/include/replication/syncrep.h
+++ b/src/include/replication/syncrep.h
@@ -16,8 +16,8 @@
 #include "access/xlogdefs.h"
 #include "utils/guc.h"
 
-/*#define SyncRepRequested() \
-//	(max_wal_senders > 0 && synchronous_commit > SYNCHRONOUS_COMMIT_LOCAL_FLUSH)*/
+#define SyncRepRequested() \
+	(max_wal_senders > 0)
 
 /* SyncRepWaitMode */
 #define SYNC_REP_NO_WAIT		-1
@@ -32,6 +32,9 @@
 #define SYNC_REP_WAITING			1
 #define SYNC_REP_WAIT_COMPLETE		2
 
+/* user-settable parameters for synchronous replication */
+extern char *SyncRepStandbyNames;
+
 /* called by user backend */
 extern void SyncRepWaitForLSN(XLogRecPtr XactCommitLSN);
 
@@ -42,13 +45,12 @@ extern void SyncRepCleanupAtProcExit(void);
 extern void SyncRepInitConfig(void);
 extern void SyncRepReleaseWaiters(void);
 
-/* called by wal writer */
-//extern void SyncRepUpdateSyncStandbysDefined(void);
+/* called by checkpointer */
+extern void SyncRepUpdateSyncStandbysDefined(void);
 
 /* called by various procs */
-extern int	SyncRepWakeQueue(bool all, int mode);
+extern int     SyncRepWakeQueue(bool all, int mode);
 
-//extern bool check_synchronous_standby_names(char **newval, void **extra, GucSource source);
-//extern void assign_synchronous_commit(int newval, void *extra);
+extern const char *check_synchronous_standby_names(const char *newval, bool doit, GucSource source);
 
 #endif   /* _SYNCREP_H */


### PR DESCRIPTION
When walrep was ported to GPDB, it was modified to only block for sync
replication if wal sender exist. In absence of wal sender, commits didn't
block. This patch brings back the upstream way of blocking the commits based on
GUC `synchronous_standby_names` for segments. Behavior for master is still
unchanged, as current focus to have things rolling for segments, without
impacting master replication.

Further modifications based on discussion here (https://groups.google.com/a/greenplum.org/d/msg/gpdb-dev/Qg9J1Kq1U7k/dwuYpg98AwAJ) will be made to adopt the same for FTS integration, but this bring up close to upstream to leverage it for integration.