### PR TITLE
Cherry pick upstream commit: c4ac2ff

### DIFF
--- a/src/backend/optimizer/prep/prepjointree.c
+++ b/src/backend/optimizer/prep/prepjointree.c
@@ -21,7 +21,7 @@
  *
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/optimizer/prep/prepjointree.c,v 1.57 2008/10/21 20:42:53 tgl Exp $
+ *	  $PostgreSQL: pgsql/src/backend/optimizer/prep/prepjointree.c,v 1.66.2.2 2010/06/21 00:14:54 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -1268,6 +1268,7 @@ pullup_replace_vars_callback(Var *var,
 		List	   *colnames;
 		List	   *fields;
 		bool		save_need_phvs = rcon->need_phvs;
+		int			save_sublevelsup = context->sublevels_up;
 
 		/*
 		 * If generating an expansion for a var of a named rowtype (ie, this
@@ -1285,9 +1286,12 @@ pullup_replace_vars_callback(Var *var,
 				  &colnames, &fields);
 		/* Adjust the generated per-field Vars, but don't insert PHVs */
 		rcon->need_phvs = false;
+		context->sublevels_up = 0; /* to match the expandRTE output */
 		fields = (List *) replace_rte_variables_mutator((Node *) fields,
 														context);
 		rcon->need_phvs = save_need_phvs;
+		context->sublevels_up = save_sublevelsup;
+
 		rowexpr = makeNode(RowExpr);
 		rowexpr->args = fields;
 		rowexpr->row_typeid = var->vartype;

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -537,6 +537,36 @@ group by f1,f2,fs;
 (0 rows)
 
 --
+-- Test case for bug #5514 (mishandling of whole-row Vars in subselects)
+--
+create temp table table_a(id integer);
+insert into table_a values (42);
+create temp view view_a as select * from table_a;
+select view_a from view_a;
+ view_a 
+--------
+ (42)
+(1 row)
+
+select (select view_a) from view_a;
+ ?column? 
+----------
+ (42)
+(1 row)
+
+select (select (select view_a)) from view_a;
+ ?column? 
+----------
+ (42)
+(1 row)
+
+select (select (a.*)::text) from view_a a;
+ ?column? 
+----------
+ (42)
+(1 row)
+
+--
 -- Check that whole-row Vars reading the result of a subselect don't include
 -- any junk columns therein
 --

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -548,6 +548,36 @@ group by f1,f2,fs;
 (0 rows)
 
 --
+-- Test case for bug #5514 (mishandling of whole-row Vars in subselects)
+--
+create temp table table_a(id integer);
+insert into table_a values (42);
+create temp view view_a as select * from table_a;
+select view_a from view_a;
+ view_a 
+--------
+ (42)
+(1 row)
+
+select (select view_a) from view_a;
+ ?column? 
+----------
+ (42)
+(1 row)
+
+select (select (select view_a)) from view_a;
+ ?column? 
+----------
+ (42)
+(1 row)
+
+select (select (a.*)::text) from view_a a;
+ ?column? 
+----------
+ (42)
+(1 row)
+
+--
 -- Check that whole-row Vars reading the result of a subselect don't include
 -- any junk columns therein
 --

--- a/src/test/regress/sql/subselect.sql
+++ b/src/test/regress/sql/subselect.sql
@@ -321,6 +321,20 @@ select * from
 group by f1,f2,fs;
 
 --
+-- Test case for bug #5514 (mishandling of whole-row Vars in subselects)
+--
+
+create temp table table_a(id integer);
+insert into table_a values (42);
+
+create temp view view_a as select * from table_a;
+
+select view_a from view_a;
+select (select view_a) from view_a;
+select (select (select view_a)) from view_a;
+select (select (a.*)::text) from view_a a;
+
+--
 -- Check that whole-row Vars reading the result of a subselect don't include
 -- any junk columns therein
 --


### PR DESCRIPTION
commit c4ac2ff765d9b68a3ff2a3461804489721770d06
Author: Tom Lane <tgl@sss.pgh.pa.us>
Date:   Mon Jun 21 00:14:54 2010 +0000

    Fix mishandling of whole-row Vars referencing a view or sub-select.
    If such a Var appeared within a nested sub-select, we failed to translate it
    correctly during pullup of the view, because the recursive call to
    replace_rte_variables_mutator was looking for the wrong sublevels_up value.
    Bug was introduced during the addition of the PlaceHolderVar mechanism.
    Per bug #5514 from Marcos Castedo.