### PR TITLE
DOCS: COPY cmd. - remove reference to ALTER TABLE clause WITH REORGANIZE

### DIFF
--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -3614,12 +3614,11 @@
                 the root table. </li>
             </ul></li>
         </ul></p>
-      <p>If the value is <codeph>false</codeph>, the distribution policy not checked. The data added
-        to the table might violate the table distribution policy for the segment instance. Manual
-        redistribution of table data might be required. See the <codeph>ALTER TABLE</codeph> clause
-          <codeph>WITH REORGANIZE</codeph>.</p>
-      <p>This parameter can be set for a database system, an individual database, or a session or
-        query.</p>
+      <p>If the value is <codeph>false</codeph>, the distribution policy is not checked. The data
+        added to the table might violate the table distribution policy for the segment instance.
+        Manual redistribution of table data might be required. </p>
+      <p>The parameter can be set for a database system or a session. The parameter cannot be set
+        for a specific database.</p>
       <table id="table_gxf_hpm_z1b">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>

--- a/gpdb-doc/dita/ref_guide/sql_commands/COPY.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/COPY.xml
@@ -378,8 +378,7 @@ COPY {table [(<varname>column</varname> [, ...])] | (<varname>query</varname>)} 
           <codeph>COPY FROM...ON SEGMENT</codeph> was run.</p>
       <note>If you run <codeph>COPY FROM...ON SEGMENT</codeph>and the server configuration parameter
           <codeph>gp_enable_segment_copy_checking</codeph> is <codeph>false</codeph>, manual
-        redistribution of table data might be required. See the <codeph>ALTER TABLE</codeph> clause
-          <codeph>WITH REORGANIZE</codeph>.</note>
+        redistribution of table data might be required.</note>
       <p>When you specify the <codeph>LOG ERRORS</codeph> clause, Greenplum Database captures errors
         that occur while reading the external table data. You can view and manage the captured error
         log data. </p>


### PR DESCRIPTION
Due to issues with reorganizing table data with the ALTER TABLE command.