### PR TITLE
Resource group function test: concurrency waiting

### DIFF
--- a/src/test/isolation2/expected/resgroup/resgroup_func_concurrency.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_func_concurrency.out
@@ -1,0 +1,515 @@
+-- test1: cancel a query that is waiting for a slot
+DROP ROLE IF EXISTS role_concurrency_test;
+DROP
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+ERROR:  resource group "rg_concurrency_test" does not exist
+-- end_ignore
+
+CREATE OR REPLACE VIEW rg_concurrency_view AS SELECT waiting, waiting_reason, current_query, rsgname FROM pg_stat_activity WHERE rsgname='rg_concurrency_test';
+CREATE
+
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=1, cpu_rate_limit=20, memory_limit=20);
+CREATE
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+CREATE
+1:SET ROLE role_concurrency_test;
+SET
+1:BEGIN;
+BEGIN
+2:SET ROLE role_concurrency_test;
+SET
+2&:BEGIN;  <waiting ...>
+3:SET ROLE role_concurrency_test;
+SET
+3&:BEGIN;  <waiting ...>
+4:SET ROLE role_concurrency_test;
+SET
+4&:BEGIN;  <waiting ...>
+5:SET ROLE role_concurrency_test;
+SET
+5&:BEGIN;  <waiting ...>
+6:SET ROLE role_concurrency_test;
+SET
+6&:BEGIN;  <waiting ...>
+7:SET ROLE role_concurrency_test;
+SET
+7&:BEGIN;  <waiting ...>
+8:SET ROLE role_concurrency_test;
+SET
+8&:BEGIN;  <waiting ...>
+9:SET ROLE role_concurrency_test;
+SET
+9&:BEGIN;  <waiting ...>
+10:SET ROLE role_concurrency_test;
+SET
+10&:BEGIN;  <waiting ...>
+11:SET ROLE role_concurrency_test;
+SET
+11&:BEGIN;  <waiting ...>
+SELECT * FROM rg_concurrency_view;
+waiting|waiting_reason|current_query        |rsgname            
+-------+--------------+---------------------+-------------------
+f      |              |<IDLE> in transaction|rg_concurrency_test
+t      |resgroup      |BEGIN;               |rg_concurrency_test
+t      |resgroup      |BEGIN;               |rg_concurrency_test
+t      |resgroup      |BEGIN;               |rg_concurrency_test
+t      |resgroup      |BEGIN;               |rg_concurrency_test
+t      |resgroup      |BEGIN;               |rg_concurrency_test
+t      |resgroup      |BEGIN;               |rg_concurrency_test
+t      |resgroup      |BEGIN;               |rg_concurrency_test
+t      |resgroup      |BEGIN;               |rg_concurrency_test
+t      |resgroup      |BEGIN;               |rg_concurrency_test
+t      |resgroup      |BEGIN;               |rg_concurrency_test
+(11 rows)
+SELECT pg_cancel_backend(procpid) FROM pg_stat_activity WHERE waiting_reason='resgroup' AND rsgname='rg_concurrency_test';
+pg_cancel_backend
+-----------------
+t                
+t                
+t                
+t                
+t                
+t                
+t                
+t                
+t                
+t                
+(10 rows)
+2<:  <... completed>
+ERROR:  canceling statement due to user request
+3<:  <... completed>
+ERROR:  canceling statement due to user request
+4<:  <... completed>
+ERROR:  canceling statement due to user request
+5<:  <... completed>
+ERROR:  canceling statement due to user request
+6<:  <... completed>
+ERROR:  canceling statement due to user request
+7<:  <... completed>
+ERROR:  canceling statement due to user request
+8<:  <... completed>
+ERROR:  canceling statement due to user request
+9<:  <... completed>
+ERROR:  canceling statement due to user request
+10<:  <... completed>
+ERROR:  canceling statement due to user request
+11<:  <... completed>
+ERROR:  canceling statement due to user request
+SELECT * FROM rg_concurrency_view;
+waiting|waiting_reason|current_query        |rsgname            
+-------+--------------+---------------------+-------------------
+f      |              |<IDLE> in transaction|rg_concurrency_test
+f      |              |<IDLE>               |rg_concurrency_test
+f      |              |<IDLE>               |rg_concurrency_test
+f      |              |<IDLE>               |rg_concurrency_test
+f      |              |<IDLE>               |rg_concurrency_test
+f      |              |<IDLE>               |rg_concurrency_test
+f      |              |<IDLE>               |rg_concurrency_test
+f      |              |<IDLE>               |rg_concurrency_test
+f      |              |<IDLE>               |rg_concurrency_test
+f      |              |<IDLE>               |rg_concurrency_test
+f      |              |<IDLE>               |rg_concurrency_test
+(11 rows)
+1q: ... <quitting>
+2q: ... <quitting>
+3q: ... <quitting>
+4q: ... <quitting>
+5q: ... <quitting>
+6q: ... <quitting>
+7q: ... <quitting>
+8q: ... <quitting>
+9q: ... <quitting>
+10q: ... <quitting>
+11q: ... <quitting>
+DROP ROLE role_concurrency_test;
+DROP
+DROP RESOURCE GROUP rg_concurrency_test;
+DROP
+
+-- test2: terminate a query that is waiting for a slot
+DROP ROLE IF EXISTS role_concurrency_test;
+DROP
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+ERROR:  resource group "rg_concurrency_test" does not exist
+-- end_ignore
+
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=1, cpu_rate_limit=20, memory_limit=20);
+CREATE
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+CREATE
+1:SET ROLE role_concurrency_test;
+SET
+1:BEGIN;
+BEGIN
+2:SET ROLE role_concurrency_test;
+SET
+2&:BEGIN;  <waiting ...>
+3:SET ROLE role_concurrency_test;
+SET
+3&:BEGIN;  <waiting ...>
+4:SET ROLE role_concurrency_test;
+SET
+4&:BEGIN;  <waiting ...>
+5:SET ROLE role_concurrency_test;
+SET
+5&:BEGIN;  <waiting ...>
+6:SET ROLE role_concurrency_test;
+SET
+6&:BEGIN;  <waiting ...>
+7:SET ROLE role_concurrency_test;
+SET
+7&:BEGIN;  <waiting ...>
+8:SET ROLE role_concurrency_test;
+SET
+8&:BEGIN;  <waiting ...>
+9:SET ROLE role_concurrency_test;
+SET
+9&:BEGIN;  <waiting ...>
+10:SET ROLE role_concurrency_test;
+SET
+10&:BEGIN;  <waiting ...>
+11:SET ROLE role_concurrency_test;
+SET
+11&:BEGIN;  <waiting ...>
+SELECT * FROM rg_concurrency_view;
+waiting|waiting_reason|current_query        |rsgname            
+-------+--------------+---------------------+-------------------
+f      |              |<IDLE> in transaction|rg_concurrency_test
+t      |resgroup      |BEGIN;               |rg_concurrency_test
+t      |resgroup      |BEGIN;               |rg_concurrency_test
+t      |resgroup      |BEGIN;               |rg_concurrency_test
+t      |resgroup      |BEGIN;               |rg_concurrency_test
+t      |resgroup      |BEGIN;               |rg_concurrency_test
+t      |resgroup      |BEGIN;               |rg_concurrency_test
+t      |resgroup      |BEGIN;               |rg_concurrency_test
+t      |resgroup      |BEGIN;               |rg_concurrency_test
+t      |resgroup      |BEGIN;               |rg_concurrency_test
+t      |resgroup      |BEGIN;               |rg_concurrency_test
+(11 rows)
+SELECT pg_terminate_backend(procpid) FROM pg_stat_activity WHERE waiting_reason='resgroup' AND rsgname='rg_concurrency_test';
+pg_terminate_backend
+--------------------
+t                   
+t                   
+t                   
+t                   
+t                   
+t                   
+t                   
+t                   
+t                   
+t                   
+(10 rows)
+2<:  <... completed>
+FATAL:  terminating connection due to administrator command
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+3<:  <... completed>
+FATAL:  terminating connection due to administrator command
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+4<:  <... completed>
+FATAL:  terminating connection due to administrator command
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+5<:  <... completed>
+FATAL:  terminating connection due to administrator command
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+6<:  <... completed>
+FATAL:  terminating connection due to administrator command
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+7<:  <... completed>
+FATAL:  terminating connection due to administrator command
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+8<:  <... completed>
+FATAL:  terminating connection due to administrator command
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+9<:  <... completed>
+FATAL:  terminating connection due to administrator command
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+10<:  <... completed>
+FATAL:  terminating connection due to administrator command
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+11<:  <... completed>
+FATAL:  terminating connection due to administrator command
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+SELECT * FROM rg_concurrency_view;
+waiting|waiting_reason|current_query        |rsgname            
+-------+--------------+---------------------+-------------------
+f      |              |<IDLE> in transaction|rg_concurrency_test
+(1 row)
+1q: ... <quitting>
+2q: ... <quitting>
+3q: ... <quitting>
+4q: ... <quitting>
+5q: ... <quitting>
+6q: ... <quitting>
+7q: ... <quitting>
+8q: ... <quitting>
+9q: ... <quitting>
+10q: ... <quitting>
+11q: ... <quitting>
+DROP ROLE role_concurrency_test;
+DROP
+DROP RESOURCE GROUP rg_concurrency_test;
+DROP
+
+-- test3: cancel a query that is running
+DROP ROLE IF EXISTS role_concurrency_test;
+DROP
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+ERROR:  resource group "rg_concurrency_test" does not exist
+-- end_ignore
+
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=5, cpu_rate_limit=20, memory_limit=20);
+CREATE
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+CREATE
+1:SET ROLE role_concurrency_test;
+SET
+1&:SELECT pg_sleep(10000);  <waiting ...>
+2:SET ROLE role_concurrency_test;
+SET
+2&:SELECT pg_sleep(10000);  <waiting ...>
+3:SET ROLE role_concurrency_test;
+SET
+3&:SELECT pg_sleep(10000);  <waiting ...>
+4:SET ROLE role_concurrency_test;
+SET
+4&:SELECT pg_sleep(10000);  <waiting ...>
+5:SET ROLE role_concurrency_test;
+SET
+5&:SELECT pg_sleep(10000);  <waiting ...>
+6:SET ROLE role_concurrency_test;
+SET
+6&:BEGIN;  <waiting ...>
+7:SET ROLE role_concurrency_test;
+SET
+7&:BEGIN;  <waiting ...>
+8:SET ROLE role_concurrency_test;
+SET
+8&:BEGIN;  <waiting ...>
+9:SET ROLE role_concurrency_test;
+SET
+9&:BEGIN;  <waiting ...>
+10:SET ROLE role_concurrency_test;
+SET
+10&:BEGIN;  <waiting ...>
+SELECT * FROM rg_concurrency_view;
+waiting|waiting_reason|current_query          |rsgname            
+-------+--------------+-----------------------+-------------------
+f      |              |SELECT pg_sleep(10000);|rg_concurrency_test
+f      |              |SELECT pg_sleep(10000);|rg_concurrency_test
+f      |              |SELECT pg_sleep(10000);|rg_concurrency_test
+f      |              |SELECT pg_sleep(10000);|rg_concurrency_test
+f      |              |SELECT pg_sleep(10000);|rg_concurrency_test
+t      |resgroup      |BEGIN;                 |rg_concurrency_test
+t      |resgroup      |BEGIN;                 |rg_concurrency_test
+t      |resgroup      |BEGIN;                 |rg_concurrency_test
+t      |resgroup      |BEGIN;                 |rg_concurrency_test
+t      |resgroup      |BEGIN;                 |rg_concurrency_test
+(10 rows)
+SELECT pg_cancel_backend(procpid) FROM pg_stat_activity WHERE waiting='f' AND rsgname='rg_concurrency_test';
+pg_cancel_backend
+-----------------
+t                
+t                
+t                
+t                
+t                
+(5 rows)
+1<:  <... completed>
+ERROR:  canceling statement due to user request
+2<:  <... completed>
+ERROR:  canceling statement due to user request
+3<:  <... completed>
+ERROR:  canceling statement due to user request
+4<:  <... completed>
+ERROR:  canceling statement due to user request
+5<:  <... completed>
+ERROR:  canceling statement due to user request
+6<:  <... completed>
+BEGIN
+7<:  <... completed>
+BEGIN
+8<:  <... completed>
+BEGIN
+9<:  <... completed>
+BEGIN
+10<:  <... completed>
+BEGIN
+SELECT * FROM rg_concurrency_view;
+waiting|waiting_reason|current_query        |rsgname            
+-------+--------------+---------------------+-------------------
+f      |              |<IDLE>               |rg_concurrency_test
+f      |              |<IDLE>               |rg_concurrency_test
+f      |              |<IDLE>               |rg_concurrency_test
+f      |              |<IDLE>               |rg_concurrency_test
+f      |              |<IDLE>               |rg_concurrency_test
+f      |              |<IDLE> in transaction|rg_concurrency_test
+f      |              |<IDLE> in transaction|rg_concurrency_test
+f      |              |<IDLE> in transaction|rg_concurrency_test
+f      |              |<IDLE> in transaction|rg_concurrency_test
+f      |              |<IDLE> in transaction|rg_concurrency_test
+(10 rows)
+1q: ... <quitting>
+2q: ... <quitting>
+3q: ... <quitting>
+4q: ... <quitting>
+5q: ... <quitting>
+6q: ... <quitting>
+7q: ... <quitting>
+8q: ... <quitting>
+9q: ... <quitting>
+10q: ... <quitting>
+DROP ROLE role_concurrency_test;
+DROP
+DROP RESOURCE GROUP rg_concurrency_test;
+DROP
+
+-- test4: terminate a query that is running
+DROP ROLE IF EXISTS role_concurrency_test;
+DROP
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+ERROR:  resource group "rg_concurrency_test" does not exist
+-- end_ignore
+
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=5, cpu_rate_limit=20, memory_limit=20);
+CREATE
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+CREATE
+1:SET ROLE role_concurrency_test;
+SET
+1&:SELECT pg_sleep(10000);  <waiting ...>
+2:SET ROLE role_concurrency_test;
+SET
+2&:SELECT pg_sleep(10000);  <waiting ...>
+3:SET ROLE role_concurrency_test;
+SET
+3&:SELECT pg_sleep(10000);  <waiting ...>
+4:SET ROLE role_concurrency_test;
+SET
+4&:SELECT pg_sleep(10000);  <waiting ...>
+5:SET ROLE role_concurrency_test;
+SET
+5&:SELECT pg_sleep(10000);  <waiting ...>
+6:SET ROLE role_concurrency_test;
+SET
+6&:BEGIN;  <waiting ...>
+7:SET ROLE role_concurrency_test;
+SET
+7&:BEGIN;  <waiting ...>
+8:SET ROLE role_concurrency_test;
+SET
+8&:BEGIN;  <waiting ...>
+9:SET ROLE role_concurrency_test;
+SET
+9&:BEGIN;  <waiting ...>
+10:SET ROLE role_concurrency_test;
+SET
+10&:BEGIN;  <waiting ...>
+SELECT * FROM rg_concurrency_view;
+waiting|waiting_reason|current_query          |rsgname            
+-------+--------------+-----------------------+-------------------
+f      |              |SELECT pg_sleep(10000);|rg_concurrency_test
+f      |              |SELECT pg_sleep(10000);|rg_concurrency_test
+f      |              |SELECT pg_sleep(10000);|rg_concurrency_test
+f      |              |SELECT pg_sleep(10000);|rg_concurrency_test
+f      |              |SELECT pg_sleep(10000);|rg_concurrency_test
+t      |resgroup      |BEGIN;                 |rg_concurrency_test
+t      |resgroup      |BEGIN;                 |rg_concurrency_test
+t      |resgroup      |BEGIN;                 |rg_concurrency_test
+t      |resgroup      |BEGIN;                 |rg_concurrency_test
+t      |resgroup      |BEGIN;                 |rg_concurrency_test
+(10 rows)
+SELECT pg_terminate_backend(procpid) FROM pg_stat_activity WHERE waiting='f' AND rsgname='rg_concurrency_test';
+pg_terminate_backend
+--------------------
+t                   
+t                   
+t                   
+t                   
+t                   
+(5 rows)
+1<:  <... completed>
+FATAL:  terminating connection due to administrator command
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+2<:  <... completed>
+FATAL:  terminating connection due to administrator command
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+3<:  <... completed>
+FATAL:  terminating connection due to administrator command
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+4<:  <... completed>
+FATAL:  terminating connection due to administrator command
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+5<:  <... completed>
+FATAL:  terminating connection due to administrator command
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+6<:  <... completed>
+BEGIN
+7<:  <... completed>
+BEGIN
+8<:  <... completed>
+BEGIN
+9<:  <... completed>
+BEGIN
+10<:  <... completed>
+BEGIN
+SELECT * FROM rg_concurrency_view;
+waiting|waiting_reason|current_query        |rsgname            
+-------+--------------+---------------------+-------------------
+f      |              |<IDLE> in transaction|rg_concurrency_test
+f      |              |<IDLE> in transaction|rg_concurrency_test
+f      |              |<IDLE> in transaction|rg_concurrency_test
+f      |              |<IDLE> in transaction|rg_concurrency_test
+f      |              |<IDLE> in transaction|rg_concurrency_test
+(5 rows)
+1q: ... <quitting>
+2q: ... <quitting>
+3q: ... <quitting>
+4q: ... <quitting>
+5q: ... <quitting>
+6q: ... <quitting>
+7q: ... <quitting>
+8q: ... <quitting>
+9q: ... <quitting>
+10q: ... <quitting>
+DROP ROLE role_concurrency_test;
+DROP
+DROP RESOURCE GROUP rg_concurrency_test;
+DROP
+
+DROP VIEW rg_concurrency_view;
+DROP

--- a/src/test/isolation2/isolation2_resgroup_schedule
+++ b/src/test/isolation2/isolation2_resgroup_schedule
@@ -14,6 +14,7 @@ test: resgroup/resgroup_alter_memory
 test: resgroup/resgroup_cpu_rate_limit
 test: resgroup/resgroup_alter_memory_spill_ratio
 test: resgroup/resgroup_set_memory_spill_ratio
+test: resgroup/resgroup_func_concurrency
 
 # memory spill tests
 test: resgroup/resgroup_memory_hashagg_spill

--- a/src/test/isolation2/sql/resgroup/resgroup_func_concurrency.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_func_concurrency.sql
@@ -1,0 +1,228 @@
+-- test1: cancel a query that is waiting for a slot
+DROP ROLE IF EXISTS role_concurrency_test;
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+-- end_ignore
+
+CREATE OR REPLACE VIEW rg_concurrency_view AS
+	SELECT waiting, waiting_reason, current_query, rsgname
+	FROM pg_stat_activity
+	WHERE rsgname='rg_concurrency_test';
+
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=1, cpu_rate_limit=20, memory_limit=20);
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+1:SET ROLE role_concurrency_test;
+1:BEGIN;
+2:SET ROLE role_concurrency_test;
+2&:BEGIN;
+3:SET ROLE role_concurrency_test;
+3&:BEGIN;
+4:SET ROLE role_concurrency_test;
+4&:BEGIN;
+5:SET ROLE role_concurrency_test;
+5&:BEGIN;
+6:SET ROLE role_concurrency_test;
+6&:BEGIN;
+7:SET ROLE role_concurrency_test;
+7&:BEGIN;
+8:SET ROLE role_concurrency_test;
+8&:BEGIN;
+9:SET ROLE role_concurrency_test;
+9&:BEGIN;
+10:SET ROLE role_concurrency_test;
+10&:BEGIN;
+11:SET ROLE role_concurrency_test;
+11&:BEGIN;
+SELECT * FROM rg_concurrency_view;
+SELECT pg_cancel_backend(procpid) FROM pg_stat_activity WHERE waiting_reason='resgroup' AND rsgname='rg_concurrency_test';
+2<:
+3<:
+4<:
+5<:
+6<:
+7<:
+8<:
+9<:
+10<:
+11<:
+SELECT * FROM rg_concurrency_view;
+1q:
+2q:
+3q:
+4q:
+5q:
+6q:
+7q:
+8q:
+9q:
+10q:
+11q:
+DROP ROLE role_concurrency_test;
+DROP RESOURCE GROUP rg_concurrency_test;
+
+-- test2: terminate a query that is waiting for a slot
+DROP ROLE IF EXISTS role_concurrency_test;
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+-- end_ignore
+
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=1, cpu_rate_limit=20, memory_limit=20);
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+1:SET ROLE role_concurrency_test;
+1:BEGIN;
+2:SET ROLE role_concurrency_test;
+2&:BEGIN;
+3:SET ROLE role_concurrency_test;
+3&:BEGIN;
+4:SET ROLE role_concurrency_test;
+4&:BEGIN;
+5:SET ROLE role_concurrency_test;
+5&:BEGIN;
+6:SET ROLE role_concurrency_test;
+6&:BEGIN;
+7:SET ROLE role_concurrency_test;
+7&:BEGIN;
+8:SET ROLE role_concurrency_test;
+8&:BEGIN;
+9:SET ROLE role_concurrency_test;
+9&:BEGIN;
+10:SET ROLE role_concurrency_test;
+10&:BEGIN;
+11:SET ROLE role_concurrency_test;
+11&:BEGIN;
+SELECT * FROM rg_concurrency_view;
+SELECT pg_terminate_backend(procpid) FROM pg_stat_activity WHERE waiting_reason='resgroup' AND rsgname='rg_concurrency_test';
+2<:
+3<:
+4<:
+5<:
+6<:
+7<:
+8<:
+9<:
+10<:
+11<:
+SELECT * FROM rg_concurrency_view;
+1q:
+2q:
+3q:
+4q:
+5q:
+6q:
+7q:
+8q:
+9q:
+10q:
+11q:
+DROP ROLE role_concurrency_test;
+DROP RESOURCE GROUP rg_concurrency_test;
+
+-- test3: cancel a query that is running
+DROP ROLE IF EXISTS role_concurrency_test;
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+-- end_ignore
+
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=5, cpu_rate_limit=20, memory_limit=20);
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+1:SET ROLE role_concurrency_test;
+1&:SELECT pg_sleep(10000);
+2:SET ROLE role_concurrency_test;
+2&:SELECT pg_sleep(10000);
+3:SET ROLE role_concurrency_test;
+3&:SELECT pg_sleep(10000);
+4:SET ROLE role_concurrency_test;
+4&:SELECT pg_sleep(10000);
+5:SET ROLE role_concurrency_test;
+5&:SELECT pg_sleep(10000);
+6:SET ROLE role_concurrency_test;
+6&:BEGIN;
+7:SET ROLE role_concurrency_test;
+7&:BEGIN;
+8:SET ROLE role_concurrency_test;
+8&:BEGIN;
+9:SET ROLE role_concurrency_test;
+9&:BEGIN;
+10:SET ROLE role_concurrency_test;
+10&:BEGIN;
+SELECT * FROM rg_concurrency_view;
+SELECT pg_cancel_backend(procpid) FROM pg_stat_activity WHERE waiting='f' AND rsgname='rg_concurrency_test';
+1<:
+2<:
+3<:
+4<:
+5<:
+6<:
+7<:
+8<:
+9<:
+10<:
+SELECT * FROM rg_concurrency_view;
+1q:
+2q:
+3q:
+4q:
+5q:
+6q:
+7q:
+8q:
+9q:
+10q:
+DROP ROLE role_concurrency_test;
+DROP RESOURCE GROUP rg_concurrency_test;
+
+-- test4: terminate a query that is running
+DROP ROLE IF EXISTS role_concurrency_test;
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+-- end_ignore
+
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=5, cpu_rate_limit=20, memory_limit=20);
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+1:SET ROLE role_concurrency_test;
+1&:SELECT pg_sleep(10000);
+2:SET ROLE role_concurrency_test;
+2&:SELECT pg_sleep(10000);
+3:SET ROLE role_concurrency_test;
+3&:SELECT pg_sleep(10000);
+4:SET ROLE role_concurrency_test;
+4&:SELECT pg_sleep(10000);
+5:SET ROLE role_concurrency_test;
+5&:SELECT pg_sleep(10000);
+6:SET ROLE role_concurrency_test;
+6&:BEGIN;
+7:SET ROLE role_concurrency_test;
+7&:BEGIN;
+8:SET ROLE role_concurrency_test;
+8&:BEGIN;
+9:SET ROLE role_concurrency_test;
+9&:BEGIN;
+10:SET ROLE role_concurrency_test;
+10&:BEGIN;
+SELECT * FROM rg_concurrency_view;
+SELECT pg_terminate_backend(procpid) FROM pg_stat_activity WHERE waiting='f' AND rsgname='rg_concurrency_test';
+1<:
+2<:
+3<:
+4<:
+5<:
+6<:
+7<:
+8<:
+9<:
+10<:
+SELECT * FROM rg_concurrency_view;
+1q:
+2q:
+3q:
+4q:
+5q:
+6q:
+7q:
+8q:
+9q:
+10q:
+DROP ROLE role_concurrency_test;
+DROP RESOURCE GROUP rg_concurrency_test;
+
+DROP VIEW rg_concurrency_view;


### PR DESCRIPTION
Add test cases to test cancelling/terminating concurrency queries waiting in resource group.