### PR TITLE
Update time zone data files to tzdata release 2016a

### DIFF
--- a/src/timezone/data/asia
+++ b/src/timezone/data/asia
@@ -131,7 +131,8 @@ Zone	Asia/Yerevan	2:58:00 -	LMT	1924 May  2
 # Azerbaijan
 # From Rustam Aliyev of the Azerbaijan Internet Forum (2005-10-23):
 # According to the resolution of Cabinet of Ministers, 1997
-# Resolution available at: http://aif.az/docs/daylight_res.pdf
+# From Paul Eggert (2015-09-17): It was Resolution No. 21 (1997-03-17).
+# http://code.az/files/daylight_res.pdf
 # Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
 Rule	Azer	1997	max	-	Mar	lastSun	 4:00	1:00	S
 Rule	Azer	1997	max	-	Oct	lastSun	 5:00	0	-
@@ -873,6 +874,15 @@ Zone	Asia/Dili	8:22:20 -	LMT	1912 Jan  1
 			9:00	-	TLT
 
 # India
+
+# From Ian P. Beacock, in "A brief history of (modern) time", The Atlantic
+# http://www.theatlantic.com/technology/archive/2015/12/the-creation-of-modern-time/421419/
+# (2015-12-22):
+# In January 1906, several thousand cotton-mill workers rioted on the
+# outskirts of Bombay....  They were protesting the proposed abolition of
+# local time in favor of Indian Standard Time....  Journalists called this
+# dispute the "Battle of the Clocks."  It lasted nearly half a century.
+
 # Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Kolkata	5:53:28 -	LMT	1880        # Kolkata
 			5:53:20	-	HMT	1941 Oct    # Howrah Mean Time?
@@ -1083,8 +1093,15 @@ Rule	Iran	2032	2033	-	Mar	21	0:00	1:00	D
 Rule	Iran	2032	2033	-	Sep	21	0:00	0	S
 Rule	Iran	2034	2035	-	Mar	22	0:00	1:00	D
 Rule	Iran	2034	2035	-	Sep	22	0:00	0	S
-Rule	Iran	2036	2037	-	Mar	21	0:00	1:00	D
-Rule	Iran	2036	2037	-	Sep	21	0:00	0	S
+#
+# The following rules are approximations starting in the year 2038.
+# These are the best post-2037 approximations available, given the
+# restrictions of a single rule using a Gregorian-based data format.
+# At some point this table will need to be extended, though quite
+# possibly Iran will change the rules first.
+Rule	Iran	2036	max	-	Mar	21	0:00	1:00	D
+Rule	Iran	2036	max	-	Sep	21	0:00	0	S
+
 # Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Tehran	3:25:44	-	LMT	1916
 			3:25:44	-	TMT	1946     # Tehran Mean Time
@@ -1717,11 +1734,12 @@ Rule	ROK	1987	1988	-	Oct	Sun>=8	3:00	0	S
 # the 8:30 time zone on August 15, one example:
 # http://www.bbc.com/news/world-asia-33815049
 #
-# From Paul Eggert (2015-08-07):
-# No transition time is specified; assume 00:00.
+# From Paul Eggert (2015-08-15):
+# Bells rang out midnight (00:00) Friday as part of the celebrations.  See:
+# Talmadge E. North Korea celebrates new time zone, 'Pyongyang Time'
+# http://news.yahoo.com/north-korea-celebrates-time-zone-pyongyang-time-164038128.html
 # There is no common English-language abbreviation for this time zone.
-# Use %z rather than invent one.  We can't assume %z works everywhere yet,
-# so for now substitute its output manually.
+# Use KST, as that's what we already use for 1954-1961 in ROK.
 
 # Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Seoul	8:27:52	-	LMT	1908 Apr  1
@@ -1735,7 +1753,7 @@ Zone	Asia/Pyongyang	8:23:00 -	LMT	1908 Apr  1
 			8:30	-	KST	1912 Jan  1
 			9:00	-	JCST	1937 Oct  1
 			9:00	-	JST	1945 Aug 24
-			9:00	-	KST	2015 Aug 15
+			9:00	-	KST	2015 Aug 15 00:00
 			8:30	-	KST
 
 ###############################################################################
@@ -2109,8 +2127,8 @@ Zone	Asia/Kathmandu	5:41:16 -	LMT	1920
 # http://www.app.com.pk/en_/index.php?option=com_content&task=view&id=99374&Itemid=2
 
 # Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule Pakistan	2002	only	-	Apr	Sun>=2	0:01	1:00	S
-Rule Pakistan	2002	only	-	Oct	Sun>=2	0:01	0	-
+Rule Pakistan	2002	only	-	Apr	Sun>=2	0:00	1:00	S
+Rule Pakistan	2002	only	-	Oct	Sun>=2	0:00	0	-
 Rule Pakistan	2008	only	-	Jun	1	0:00	1:00	S
 Rule Pakistan	2008	2009	-	Nov	1	0:00	0	-
 Rule Pakistan	2009	only	-	Apr	15	0:00	1:00	S

--- a/src/timezone/data/australasia
+++ b/src/timezone/data/australasia
@@ -335,10 +335,17 @@ Zone	Indian/Cocos	6:27:40	-	LMT	1900
 # DST will start Nov. 2 this year.
 # http://www.fiji.gov.fj/Media-Center/Press-Releases/DAYLIGHT-SAVING-STARTS-ON-SUNDAY,-NOVEMBER-2ND.aspx
 
-# From Paul Eggert (2014-10-20):
+# From a government order dated 2015-08-26 and published as Legal Notice No. 77
+# in the Government of Fiji Gazette Supplement No. 24 (2015-08-28),
+# via Ken Rylander (2015-09-02):
+# the daylight saving period is 1 hour in advance of the standard time
+# commencing at 2.00 am on Sunday 1st November, 2015 and ending at
+# 3.00 am on Sunday 17th January, 2016.
+
+# From Paul Eggert (2015-09-01):
 # For now, guess DST from 02:00 the first Sunday in November to
-# 03:00 the first Sunday on or after January 18.  Although ad hoc, it
-# matches this year's plan and seems more likely to match future
+# 03:00 the third Sunday in January.  Although ad hoc, it matches
+# transitions since late 2014 and seems more likely to match future
 # practice than guessing no DST.
 
 # Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
@@ -351,7 +358,7 @@ Rule	Fiji	2011	only	-	Mar	Sun>=1	3:00	0	-
 Rule	Fiji	2012	2013	-	Jan	Sun>=18	3:00	0	-
 Rule	Fiji	2014	only	-	Jan	Sun>=18	2:00	0	-
 Rule	Fiji	2014	max	-	Nov	Sun>=1	2:00	1:00	S
-Rule	Fiji	2015	max	-	Jan	Sun>=18	3:00	0	-
+Rule	Fiji	2015	max	-	Jan	Sun>=15	3:00	0	-
 # Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
 Zone	Pacific/Fiji	11:55:44 -	LMT	1915 Oct 26 # Suva
 			12:00	Fiji	FJ%sT	# Fiji Time
@@ -510,7 +517,10 @@ Zone	Pacific/Niue	-11:19:40 -	LMT	1901        # Alofi
 # Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
 Zone	Pacific/Norfolk	11:11:52 -	LMT	1901 # Kingston
 			11:12	-	NMT	1951 # Norfolk Mean Time
-			11:30	-	NFT	# Norfolk Time
+			11:30	-	NFT	1974 Oct 27 02:00 # Norfolk T.
+			11:30	1:00	NFST	1975 Mar  2 02:00
+			11:30	-	NFT	2015 Oct  4 02:00
+			11:00	-	NFT
 
 # Palau (Belau)
 # Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
@@ -1550,6 +1560,20 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # started DST on June 3.  Possibly DST was observed other years
 # in Midway, but we have no record of it.
 
+# Norfolk
+
+# From Alexander Krivenyshev (2015-09-23):
+# Norfolk Island will change ... from +1130 to +1100:
+# https://www.comlaw.gov.au/Details/F2015L01483/Explanatory%20Statement/Text
+# ... at 12.30 am (by legal time in New South Wales) on 4 October 2015.
+# http://www.norfolkisland.gov.nf/nia/MediaRelease/Media%20Release%20Norfolk%20Island%20Standard%20Time%20Change.pdf
+
+# From Paul Eggert (2015-09-23):
+# Transitions before 2015 are from timeanddate.com, which consulted
+# the Norfolk Island Museum and the Australian Bureau of Meteorology's
+# Norfolk Island station, and found no record of Norfolk observing DST
+# other than in 1974/5.  See:
+# http://www.timeanddate.com/time/australia/norfolk-island.html
 
 # Pitcairn
 

--- a/src/timezone/data/backward
+++ b/src/timezone/data/backward
@@ -23,6 +23,7 @@ Link	America/Argentina/Mendoza	America/Mendoza
 Link	America/Toronto		America/Montreal
 Link	America/Rio_Branco	America/Porto_Acre
 Link	America/Argentina/Cordoba	America/Rosario
+Link	America/Tijuana		America/Santa_Isabel
 Link	America/Denver		America/Shiprock
 Link	America/Port_of_Spain	America/Virgin
 Link	Pacific/Auckland	Antarctica/South_Pole

--- a/src/timezone/data/europe
+++ b/src/timezone/data/europe
@@ -2593,13 +2593,20 @@ Zone Asia/Irkutsk	 6:57:05 -	LMT	1880
 # Note: Effective 2008-03-01, (75) Chita Oblast and (80) Agin-Buryat
 # Autonomous Okrug merged to form (92, RU-ZAB) Zabaykalsky Krai.
 
+# From Alexander Krivenyshev (2016-01-02):
+# [The] time zone in the Trans-Baikal Territory (Zabaykalsky Krai) -
+# Asia/Chita [is changing] from UTC+8 to UTC+9.  Effective date will
+# be March 27, 2016 at 2:00am....
+# http://publication.pravo.gov.ru/Document/View/000120151230010
+
 Zone Asia/Chita	 7:33:52 -	LMT	1919 Dec 15
 			 8:00	-	YAKT	1930 Jun 21 # Yakutsk Time
 			 9:00	Russia	YAK%sT	1991 Mar 31  2:00s
 			 8:00	Russia	YAK%sT	1992 Jan 19  2:00s
 			 9:00	Russia	YAK%sT	2011 Mar 27  2:00s
 			10:00	-	YAKT	2014 Oct 26  2:00s
-			 8:00	-	IRKT
+			 8:00	-	IRKT	2016 Mar 27  2:00
+			 9:00	-	YAKT
 
 
 # From Tim Parenti (2014-07-03), per Oscar van Vlijmen (2009-11-29):
@@ -3150,6 +3157,17 @@ Zone	Europe/Zurich	0:34:08 -	LMT	1853 Jul 16 # See above comment.
 # http://www.balkaneu.com/eventful-elections-turkey/ 2014-03-30.
 # I guess the best we can do is document the official time.
 
+# From Fatih (2015-09-29):
+# It's officially announced now by the Ministry of Energy.
+# Turkey delays winter time to 8th of November 04:00
+# http://www.aa.com.tr/tr/turkiye/yaz-saati-uygulamasi-8-kasimda-sona-erecek/362217
+#
+# From BBC News (2015-10-25):
+# Confused Turks are asking "what's the time?" after automatic clocks defied a
+# government decision ... "For the next two weeks #Turkey is on EEST... Erdogan
+# Engineered Standard Time," said Twitter user @aysekarahasan.
+# http://www.bbc.com/news/world-europe-34631326
+
 # Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
 Rule	Turkey	1916	only	-	May	 1	0:00	1:00	S
 Rule	Turkey	1916	only	-	Oct	 1	0:00	0	-
@@ -3219,6 +3237,8 @@ Zone	Europe/Istanbul	1:55:52 -	LMT	1880
 			2:00	-	EET	2011 Mar 28  1:00u
 			2:00	EU	EE%sT	2014 Mar 30  1:00u
 			2:00	-	EET	2014 Mar 31  1:00u
+			2:00	EU	EE%sT	2015 Oct 25  1:00u
+			2:00	1:00	EEST	2015 Nov  8  1:00u
 			2:00	EU	EE%sT
 Link	Europe/Istanbul	Asia/Istanbul	# Istanbul is in both continents.
 

--- a/src/timezone/data/northamerica
+++ b/src/timezone/data/northamerica
@@ -325,6 +325,16 @@ Zone America/New_York	-4:56:02 -	LMT	1883 Nov 18 12:03:58
 # Statue 175 closer in synch with the US Congress' intent....
 # http://www.legis.state.wi.us/2007/data/acts/07Act3.pdf
 
+# From an email administrator of the City of Fort Pierre, SD (2015-12-21):
+# Fort Pierre is technically located in the Mountain time zone as is
+# the rest of Stanley County.  Most of Stanley County and Fort Pierre
+# uses the Central time zone due to doing most of their business in
+# Pierre so it simplifies schedules.  I have lived in Stanley County
+# all my life and it has been that way since I can remember.  (43 years!)
+#
+# From Paul Eggert (2015-12-25):
+# Assume this practice predates 1970, so Fort Pierre can use America/Chicago.
+
 # Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER
 Rule	Chicago	1920	only	-	Jun	13	2:00	1:00	D
 Rule	Chicago	1920	1921	-	Oct	lastSun	2:00	0	S
@@ -481,6 +491,12 @@ Zone America/Los_Angeles -7:52:58 -	LMT	1883 Nov 18 12:07:02
 # For lack of better information, assume that Metlakatla's
 # abandonment of use of daylight saving resulted from the 1983 vote.
 
+# From Steffen Thorsen (2015-11-09):
+# It seems Metlakatla did go off PST on Sunday, November 1, changing
+# their time to AKST and are going to follow Alaska's DST, switching
+# between AKST and AKDT from now on....
+# http://www.krbd.org/2015/10/30/annette-island-times-they-are-a-changing/
+
 # Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
 Zone America/Juneau	 15:02:19 -	LMT	1867 Oct 18
 			 -8:57:41 -	LMT	1900 Aug 20 12:00
@@ -506,7 +522,8 @@ Zone America/Metlakatla	 15:13:42 -	LMT	1867 Oct 18
 			 -8:00	US	P%sT	1946
 			 -8:00	-	PST	1969
 			 -8:00	US	P%sT	1983 Oct 30  2:00
-			 -8:00	-	PST
+			 -8:00	-	PST	2015 Nov  1  2:00
+			 -9:00	US	AK%sT
 Zone America/Yakutat	 14:41:05 -	LMT	1867 Oct 18
 			 -9:18:55 -	LMT	1900 Aug 20 12:00
 			 -9:00	-	YST	1942
@@ -1826,6 +1843,22 @@ Zone America/Edmonton	-7:33:52 -	LMT	1906 Sep
 
 # The transition dates (and times) are guesses.
 
+# From Matt Johnson (2015-09-21):
+# Fort Nelson, BC, Canada will cancel DST this year.  So while previously they
+# were aligned with America/Vancouver, they're now aligned with
+# America/Dawson_Creek.
+# http://www.northernrockies.ca/EN/meta/news/archives/2015/northern-rockies-time-change.html
+#
+# From Tim Parenti (2015-09-23):
+# This requires a new zone for the Northern Rockies Regional Municipality,
+# America/Fort_Nelson.  The resolution of 2014-12-08 was reached following a
+# 2014-11-15 poll with nearly 75% support.  Effectively, the municipality has
+# been on MST (-0700) like Dawson Creek since it advanced its clocks on
+# 2015-03-08.
+#
+# From Paul Eggert (2015-09-23):
+# Shanks says Fort Nelson did not observe DST in 1946, unlike Vancouver.
+
 # Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
 Rule	Vanc	1918	only	-	Apr	14	2:00	1:00	D
 Rule	Vanc	1918	only	-	Oct	27	2:00	0	S
@@ -1843,6 +1876,12 @@ Zone America/Vancouver	-8:12:28 -	LMT	1884
 Zone America/Dawson_Creek -8:00:56 -	LMT	1884
 			-8:00	Canada	P%sT	1947
 			-8:00	Vanc	P%sT	1972 Aug 30  2:00
+			-7:00	-	MST
+Zone America/Fort_Nelson	-8:10:47 -	LMT	1884
+			-8:00	Vanc	P%sT	1946
+			-8:00	-	PST	1947
+			-8:00	Vanc	P%sT	1987
+			-8:00	Canada	P%sT	2015 Mar  8  2:00
 			-7:00	-	MST
 Zone America/Creston	-7:46:04 -	LMT	1884
 			-7:00	-	MST	1916 Oct 1
@@ -2565,25 +2604,6 @@ Zone America/Tijuana	-7:48:04 -	LMT	1922 Jan  1  0:11:56
 			-8:00	US	P%sT	2002 Feb 20
 			-8:00	Mexico	P%sT	2010
 			-8:00	US	P%sT
-# Baja California (away from US border)
-Zone America/Santa_Isabel	-7:39:28 -	LMT	1922 Jan  1  0:20:32
-			-7:00	-	MST	1924
-			-8:00	-	PST	1927 Jun 10 23:00
-			-7:00	-	MST	1930 Nov 15
-			-8:00	-	PST	1931 Apr  1
-			-8:00	1:00	PDT	1931 Sep 30
-			-8:00	-	PST	1942 Apr 24
-			-8:00	1:00	PWT	1945 Aug 14 23:00u
-			-8:00	1:00	PPT	1945 Nov 12 # Peace
-			-8:00	-	PST	1948 Apr  5
-			-8:00	1:00	PDT	1949 Jan 14
-			-8:00	-	PST	1954
-			-8:00	CA	P%sT	1961
-			-8:00	-	PST	1976
-			-8:00	US	P%sT	1996
-			-8:00	Mexico	P%sT	2001
-			-8:00	US	P%sT	2002 Feb 20
-			-8:00	Mexico	P%sT
 # From Paul Eggert (2006-03-22):
 # Formerly there was an America/Ensenada zone, which differed from
 # America/Tijuana only in that it did not observe DST from 1976
@@ -2595,6 +2615,13 @@ Zone America/Santa_Isabel	-7:39:28 -	LMT	1922 Jan  1  0:20:32
 # data after 1970 so most likely there should be at least one Zone
 # other than America/Tijuana for Baja, but it's not clear yet what its
 # name or contents should be.
+#
+# From Paul Eggert (2015-10-08):
+# Formerly there was an America/Santa_Isabel zone, but this appears to
+# have come from a misreading of
+# http://dof.gob.mx/nota_detalle.php?codigo=5127480&fecha=06/01/2010
+# It has been moved to the 'backward' file.
+#
 #
 # Revillagigedo Is
 # no information
@@ -2670,17 +2697,7 @@ Zone Atlantic/Bermuda	-4:19:18 -	LMT	1930 Jan  1  2:00 # Hamilton
 			-4:00	US	A%sT
 
 # Cayman Is
-
-# From Paul Eggert (2015-05-15):
-# The Cayman government has decided to introduce DST in 2016, the idea being
-# to keep in sync with New York.  The legislation hasn't passed but the change
-# seems quite likely.  See: Meade B. Cayman 27.
-# http://www.cayman27.com.ky/2015/05/15/clock-ticks-toward-daylight-saving-time-in-cayman
-
-Zone	America/Cayman	-5:25:32 -	LMT	1890     # Georgetown
-			-5:07:11 -	KMT	1912 Feb # Kingston Mean Time
-			-5:00	-	EST	2016
-			-5:00	US	E%sT
+# See America/Panama.
 
 # Costa Rica
 
@@ -3203,6 +3220,7 @@ Zone	America/Managua	-5:45:08 -	LMT	1890
 Zone	America/Panama	-5:18:08 -	LMT	1890
 			-5:19:36 -	CMT	1908 Apr 22 # Colón Mean Time
 			-5:00	-	EST
+Link America/Panama America/Cayman
 
 # Puerto Rico
 # There are too many San Juans elsewhere, so we'll use 'Puerto_Rico'.

--- a/src/timezone/data/zone.tab
+++ b/src/timezone/data/zone.tab
@@ -129,6 +129,7 @@ CA	+6227-11421	America/Yellowknife	Mountain Time - central Northwest Territories
 CA	+682059-1334300	America/Inuvik	Mountain Time - west Northwest Territories
 CA	+4906-11631	America/Creston	Mountain Standard Time - Creston, British Columbia
 CA	+5946-12014	America/Dawson_Creek	Mountain Standard Time - Dawson Creek & Fort Saint John, British Columbia
+CA	+5848-12242	America/Fort_Nelson	Mountain Standard Time - Fort Nelson, British Columbia
 CA	+4916-12307	America/Vancouver	Pacific Time - west British Columbia
 CA	+6043-13503	America/Whitehorse	Pacific Time - south Yukon
 CA	+6404-13925	America/Dawson	Pacific Time - north Yukon
@@ -282,8 +283,7 @@ MX	+2313-10625	America/Mazatlan	Mountain Time - S Baja, Nayarit, Sinaloa
 MX	+2838-10605	America/Chihuahua	Mexican Mountain Time - Chihuahua away from US border
 MX	+2934-10425	America/Ojinaga	US Mountain Time - Chihuahua near US border
 MX	+2904-11058	America/Hermosillo	Mountain Standard Time - Sonora
-MX	+3232-11701	America/Tijuana	US Pacific Time - Baja California near US border
-MX	+3018-11452	America/Santa_Isabel	Mexican Pacific Time - Baja California away from US border
+MX	+3232-11701	America/Tijuana	US Pacific Time - Baja California state
 MX	+2048-10515	America/Bahia_Banderas	Mexican Central Time - Bahia de Banderas
 MY	+0310+10142	Asia/Kuala_Lumpur	peninsular Malaysia
 MY	+0133+11020	Asia/Kuching	Sabah & Sarawak
@@ -413,10 +413,10 @@ US	+394421-1045903	America/Denver	Mountain Time
 US	+433649-1161209	America/Boise	Mountain Time - south Idaho & east Oregon
 US	+332654-1120424	America/Phoenix	Mountain Standard Time - Arizona (except Navajo)
 US	+340308-1181434	America/Los_Angeles	Pacific Time
-US	+550737-1313435	America/Metlakatla	Pacific Standard Time - Annette Island, Alaska
 US	+611305-1495401	America/Anchorage	Alaska Time
 US	+581807-1342511	America/Juneau	Alaska Time - Alaska panhandle
 US	+571035-1351807	America/Sitka	Alaska Time - southeast Alaska panhandle
+US	+550737-1313435	America/Metlakatla	Alaska Time - Annette Island
 US	+593249-1394338	America/Yakutat	Alaska Time - Alaska panhandle neck
 US	+643004-1652423	America/Nome	Alaska Time - west Alaska
 US	+515248-1763929	America/Adak	Aleutian Islands

--- a/src/timezone/tznames/Africa.txt
+++ b/src/timezone/tznames/Africa.txt
@@ -142,10 +142,11 @@ GMT         0    # Greenwich Mean Time
                  #     (Etc/GMT)
                  #     (Europe/Dublin)
                  #     (Europe/London)
+# CONFLICT! SAST is not unique
+# Other timezones:
+#  - SAST South Australian Standard Time (not in zic)
 SAST     7200    # South Africa Standard Time
-                 # Australian South Standard Time
-                 #     (Africa/Maseru)
-                 #     (Africa/Mbabane)
+                 #     (Africa/Johannesburg)
 WAST     7200 D  # West Africa Summer Time
                  #     (Africa/Windhoek)
 WAT      3600    # West Africa Time

--- a/src/timezone/tznames/America.txt
+++ b/src/timezone/tznames/America.txt
@@ -14,13 +14,8 @@ ACT    -18000    # Acre Time
                  #     (America/Rio_Branco)
 # CONFLICT! ACST is not unique
 # Other timezones:
-#  - ACST: Central Australia Standard Time (Australia)
-ACST   -14400 D  # Acre Summer Time (not in zic)
-                 #     (America/Eirunepe)
-                 #     (America/Rio_Branco)
-# CONFLICT! ADT is not unique
-# Other timezones:
-#  - ADT: Arabic Daylight Time (Asia)
+#  - ACST: Australian Central Standard Time
+ACST   -14400 D  # Acre Summer Time (obsolete, not in zic)
 ADT    -10800 D  # Atlantic Daylight Time
                  #     (America/Glace_Bay)
                  #     (America/Goose_Bay)
@@ -52,7 +47,7 @@ AMT    -14400    # Amazon Time
                  #     (America/Cuiaba)
                  #     (America/Manaus)
                  #     (America/Porto_Velho)
-ART    -10800    # Argentina Time
+ART    America/Argentina/Buenos_Aires  # Argentina Time
                  #     (America/Argentina/Buenos_Aires)
                  #     (America/Argentina/Cordoba)
                  #     (America/Argentina/Tucuman)
@@ -63,7 +58,7 @@ ART    -10800    # Argentina Time
                  #     (America/Argentina/Mendoza)
                  #     (America/Argentina/Rio_Gallegos)
                  #     (America/Argentina/Ushuaia)
-ARST    -7200 D  # Argentina Summer Time
+ARST    America/Argentina/Buenos_Aires  # Argentina Summer Time
 # CONFLICT! AST is not unique
 # Other timezones:
 #  - AST: Arabic Standard Time (Asia)
@@ -121,7 +116,6 @@ CDT    -14400 D  # Cuba Central Daylight Time
 #  - CDT: Cuba Central Daylight Time (America)
 #  - CDT: Canada Central Daylight Time (America)
 CDT    -18000 D  # Central Daylight Time
-                 #     (America/Cancun)
                  #     (America/Chicago)
                  #     (America/Menominee)
                  #     (America/Merida)
@@ -131,10 +125,10 @@ CDT    -18000 D  # Central Daylight Time
                  #     (America/Rainy_River)
                  #     (America/Rankin_Inlet)
                  #     (America/Winnipeg)
-CLST   -10800 D  # Chile Summer Time
+CLST   -10800 D  # Chile Summer Time (obsolete)
                  #     (America/Santiago)
                  #     (Antarctica/Palmer)
-CLT    -14400    # Chile Time
+CLT    America/Santiago  # Chile Time
                  #     (America/Santiago)
                  #     (Antarctica/Palmer)
 COT    -18000    # Columbia Time (not in zic)
@@ -142,14 +136,15 @@ COT    -18000    # Columbia Time (not in zic)
 # Other timezones:
 #  - CST: Central Standard Time (Australia)
 #  - CST: Central Standard Time (America)
+#  - CST: China Standard Time (Asia)
 CST    -18000    # Cuba Central Standard Time (America)
                  #     (America/Havana)
 # CONFLICT! CST is not unique
 # Other timezones:
 #  - CST: Central Standard Time (Australia)
+#  - CST: China Standard Time (Asia)
 #  - CST: Cuba Central Standard Time (America)
 CST    -21600    # Central Standard Time (America)
-                 #     (America/Cancun)
                  #     (America/Chicago)
                  #     (America/Menominee)
                  #     (America/Merida)
@@ -189,6 +184,7 @@ EGT     -3600    # East Greenland Time (Svalbard & Jan Mayen)
 # Other timezones:
 #  - EST: Eastern Standard Time (Australia)
 EST    -18000    # Eastern Standard Time (America)
+                 #     (America/Cancun)
                  #     (America/Cayman)
                  #     (America/Coral_Harbour)
                  #     (America/Detroit)
@@ -233,11 +229,13 @@ GMT         0    # Greenwich Mean Time
                  #     (Etc/GMT)
                  #     (Europe/Dublin)
                  #     (Europe/London)
-GYT    -14400    # Guyana Time
+GYT    America/Guyana  # Guyana Time
                  #     (America/Guyana)
-HADT   -32400 D  # Hawaii-Aleutain Daylight Time
+HADT   -32400 D  # Hawaii-Aleutian Daylight Time (obsolete abbreviation)
                  #     (America/Adak)
-HAST   -36000    # Hawaii-Aleutain Standard Time
+HAST   -36000    # Hawaii-Aleutian Standard Time (obsolete abbreviation)
+                 #     (America/Adak)
+HDT    -32400 D  # Hawaiian-Aleutian Daylight Time
                  #     (America/Adak)
 MDT    -21600 D  # Mexico Mountain Daylight Time
                  # Mountain Daylight Time
@@ -290,13 +288,15 @@ PST    -28800    # Pacific Standard Time
                  #     (Pacific/Pitcairn)
 PYST   -10800 D  # Paraguay Summer Time
                  #     (America/Asuncion)
-PYT    -14400    # Paraguay Time
+PYT    America/Asuncion  # Paraguay Time
                  #     (America/Asuncion)
-SRT    -10800    # Suriname Time
+SRT    America/Paramaribo  # Suriname Time
                  #     (America/Paramaribo)
-UYST    -7200 D  # Uruguay Summer Time (not in zic)
-UYT    -10800    # Uruguay Time (not in zic)
-VET    -16200    # Venezuela Time (caution: this used to mean -14400)
+UYST    -7200 D  # Uruguay Summer Time (obsolete)
+                 #     (America/Montevideo)
+UYT    -10800    # Uruguay Time
+                 #     (America/Montevideo)
+VET    America/Caracas  # Venezuela Time
                  #     (America/Caracas)
 WGST    -7200 D  # Western Greenland Summer Time
                  #     (America/Godthab)

--- a/src/timezone/tznames/Antarctica.txt
+++ b/src/timezone/tznames/Antarctica.txt
@@ -7,17 +7,20 @@
 # src/timezone/tznames/Antarctica.txt
 #
 
-CLST   -10800 D  # Chile Summer Time
+AWST    28800    # Australian Western Standard Time
+                 #     (Antarctica/Casey)
+                 #     (Australia/Perth)
+CLST   -10800 D  # Chile Summer Time (obsolete)
                  #     (America/Santiago)
                  #     (Antarctica/Palmer)
-CLT    -14400    # Chile Time
+CLT    America/Santiago  # Chile Time
                  #     (America/Santiago)
                  #     (Antarctica/Palmer)
-DAVT    25200    # Davis Time (Antarctica)
+DAVT    Antarctica/Davis  # Davis Time (Antarctica)
                  #     (Antarctica/Davis)
 DDUT    36000    # Dumont-d`Urville Time (Antarctica)
                  #     (Antarctica/DumontDUrville)
-MAWT    18000    # Mawson Time (Antarctica) (caution: this used to mean 21600)
+MAWT    Antarctica/Mawson  # Mawson Time (Antarctica)
                  #     (Antarctica/Mawson)
 MIST    39600    # Macquarie Island Time
                  #     (Antarctica/Macquarie)
@@ -33,9 +36,3 @@ SYOT    10800    # Syowa Time
                  #     (Antarctica/Syowa)
 VOST    21600    # Vostok time
                  #     (Antarctica/Vostok)
-# CONFLICT! WST is not unique
-# Other timezones:
-#  - WST: West Samoa Time
-WST     28800    # Western Standard Time (Australia)
-                 #     (Antarctica/Casey)
-                 #     (Australia/Perth)

--- a/src/timezone/tznames/Asia.txt
+++ b/src/timezone/tznames/Asia.txt
@@ -4,38 +4,30 @@
 #   a template for timezones you could need.  See the `Date/Time Support'
 #   appendix in the PostgreSQL documentation for more information.
 #
-# $PostgreSQL: pgsql/src/timezone/tznames/Asia.txt,v 1.3.2.2 2010/05/11 22:37:05 tgl Exp $
+# src/timezone/tznames/Asia.txt
 #
 
-# CONFLICT! ADT is not unique
-# Other timezones:
-# - ADT: Atlantic Daylight Time (America)
-ADT     14400 D  # Arabia Daylight Time
-                 #     (Asia/Baghdad)
 AFT     16200    # Afghanistan Time
                  #     (Asia/Kabul)
-ALMST   25200 D  # Alma-Ata Summer Time
-                 #     (Asia/Almaty)
+ALMST   25200 D  # Alma-Ata Summer Time (obsolete)
 ALMT    21600    # Alma-Ata Time
                  #     (Asia/Almaty)
 # CONFLICT! AMST is not unique
 # Other timezones:
 #  - AMST: Amazon Summer Time (America)
-AMST    18000 D  # Armenia Summer Time
+AMST    Asia/Yerevan  # Armenia Summer Time
                  #     (Asia/Yerevan)
 # CONFLICT! AMT is not unique
 # Other timezones:
 #  - AMT: Amazon Time (America)
-AMT     14400    # Armenia Time
+AMT     Asia/Yerevan  # Armenia Time
                  #     (Asia/Yerevan)
-ANAST   46800 D  # Anadyr Summer Time
+ANAST   Asia/Anadyr  # Anadyr Summer Time (obsolete)
+ANAT    Asia/Anadyr  # Anadyr Time
                  #     (Asia/Anadyr)
-ANAT    43200    # Anadyr Time
-                 #     (Asia/Anadyr)
-AQTT    18000    # Aqtau Time
-                 # Aqtobe Time
+AQTST   Asia/Aqtau  # Aqtau Summer Time (obsolete)
+AQTT    Asia/Aqtau  # Aqtau Time
                  #     (Asia/Aqtau)
-                 #     (Asia/Aqtobe)
 # CONFLICT! AST is not unique
 # Other timezones:
 #  - AST: Atlantic Standard Time (America)
@@ -51,9 +43,9 @@ AST     10800    # Arabia Standard Time
                  #     (Asia/Kuwait)
                  #     (Asia/Qatar)
                  #     (Asia/Riyadh)
-AZST    18000 D  # Azerbaijan Summer Time
+AZST    Asia/Baku  # Azerbaijan Summer Time
                  #     (Asia/Baku)
-AZT     14400    # Azerbaijan Time
+AZT     Asia/Baku  # Azerbaijan Time
                  #     (Asia/Baku)
 BDT     21600    # Bangladesh Time
                  #     (Asia/Dhaka)
@@ -63,11 +55,20 @@ BORT    28800    # Borneo Time (Indonesia) (not in zic)
 BTT     21600    # Bhutan Time
                  #     (Asia/Thimphu)
 CCT     28800    # China Coastal Time (not in zic)
-CHOST   36000 D  # Choibalsan Summer Time (obsolete)
+CHOST   Asia/Choibalsan  # Choibalsan Summer Time
                  #     (Asia/Choibalsan)
-CHOT    28800    # Choibalsan Time (caution: this used to mean 32400)
+CHOT    Asia/Choibalsan  # Choibalsan Time
                  #     (Asia/Choibalsan)
 CIT     28800    # Central Indonesia Time (obsolete, WITA is now preferred)
+# CONFLICT! CST is not unique
+# Other timezones:
+#  - CST: Central Standard Time (Australia)
+#  - CST: Central Standard Time (America)
+#  - CST: Cuba Central Standard Time (America)
+CST     28800    # China Standard Time
+                 #     (Asia/Macau)
+                 #     (Asia/Shanghai)
+                 #     (Asia/Taipei)
 EEST    10800 D  # East-Egypt Summer Time
                  # Eastern Europe Summer Time
                  #     (Africa/Cairo)
@@ -116,9 +117,8 @@ EET      7200    # East-Egypt Time
                  #     (Europe/Vilnius)
                  #     (Europe/Zaporozhye)
 EIT     32400    # East Indonesia Time (obsolete, WIT is now preferred)
-GEST    14400 D  # Georgia Summer Time (obsolete)
-                 #     (Asia/Tbilisi)
-GET     14400    # Georgia Time (caution: this used to mean 10800)
+GEST    Asia/Tbilisi  # Georgia Summer Time (obsolete)
+GET     Asia/Tbilisi  # Georgia Time
                  #     (Asia/Tbilisi)
 # CONFLICT! GST is not unique
 # Other timezones:
@@ -129,7 +129,7 @@ GST     14400    # Gulf Standard Time
 HKT     28800    # Hong Kong Time (not in zic)
 HOVST   28800 D  # Hovd Summer Time
                  #     (Asia/Hovd)
-HOVT    25200    # Hovd Time
+HOVT    Asia/Hovd  # Hovd Time
                  #     (Asia/Hovd)
 ICT     25200    # Indochina Time
                  #     (Asia/Bangkok)
@@ -137,13 +137,13 @@ ICT     25200    # Indochina Time
                  #     (Asia/Saigon)
                  #     (Asia/Vientiane)
 IDT     10800 D  # Israel Daylight Time
-IRDT    16200 D  # Iran Daylight Time
+                 #     (Asia/Jerusalem)
+IRDT    Asia/Tehran  # Iran Daylight Time
                  #     (Asia/Tehran)
-IRKST   32400 D  # Irkutsk Summer Time (obsolete)
+IRKST   Asia/Irkutsk  # Irkutsk Summer Time (obsolete)
+IRKT    Asia/Irkutsk  # Irkutsk Time
                  #     (Asia/Irkutsk)
-IRKT    32400    # Irkutsk Time (caution: this used to mean 28800)
-                 #     (Asia/Irkutsk)
-IRST    12600    # Iran Standard Time
+IRST    Asia/Tehran  # Iran Standard Time
                  #     (Asia/Tehran)
 IRT     12600    # Iran Time (not in zic)
 # CONFLICT! IST is not unique
@@ -157,69 +157,67 @@ IST     19800    # Indian Standard Time
 # - IST: Irish Summer Time (Europe)
 # - IST: Indian Standard Time (Asia)
 IST      7200    # Israel Standard Time
+                 #     (Asia/Jerusalem)
 JAYT    32400    # Jayapura Time (Indonesia) (not in zic)
 JST     32400    # Japan Standard Time
                  #     (Asia/Tokyo)
 KDT     36000 D  # Korean Daylight Time (not in zic)
 KGST    21600 D  # Kyrgyzstan Summer Time (obsolete)
+KGT     Asia/Bishkek  # Kyrgyzstan Time
                  #     (Asia/Bishkek)
-KGT     21600    # Kyrgyzstan Time (caution: this used to mean 18000)
-                 #     (Asia/Bishkek)
-KRAST   28800 D  # Krasnoyarsk Summer Time (obsolete)
+KRAST   Asia/Krasnoyarsk  # Krasnoyarsk Summer Time (obsolete)
+KRAT    Asia/Krasnoyarsk  # Krasnoyarsk Time
                  #     (Asia/Krasnoyarsk)
-KRAT    28800    # Krasnoyarsk Time (caution: this used to mean 25200)
-                 #     (Asia/Krasnoyarsk)
-KST     32400    # Korean Standard Time
+KST     Asia/Pyongyang    # Korean Standard Time
                  #     (Asia/Pyongyang)
-LKT     21600    # Lanka Time
-                 #     (Asia/Colombo)
-MAGST   43200 D  # Magadan Summer Time (obsolete)
-                 #     (Asia/Magadan)
-MAGT    43200    # Magadan Time (caution: this used to mean 39600)
+KST     32400    # Korean Standard Time
+                 #     (Asia/Seoul)
+LKT     Asia/Colombo  # Lanka Time (obsolete)
+MAGST   Asia/Magadan  # Magadan Summer Time (obsolete)
+MAGT    Asia/Magadan  # Magadan Time
                  #     (Asia/Magadan)
 MMT     23400    # Myanmar Time
                  #     (Asia/Rangoon)
 MYT     28800    # Malaysia Time
                  #     (Asia/Kuala_Lumpur)
                  #     (Asia/Kuching)
-NOVST   25200 D  # Novosibirsk Summer Time (obsolete)
-                 #     (Asia/Novosibirsk)
-NOVT    25200    # Novosibirsk Time (caution: this used to mean 21600)
+NOVST   Asia/Novosibirsk  # Novosibirsk Summer Time (obsolete)
+NOVT    Asia/Novosibirsk  # Novosibirsk Time
                  #     (Asia/Novosibirsk)
 NPT     20700    # Nepal Time
                  #     (Asia/Katmandu)
-OMSST   25200 D  # Omsk Summer Time (obsolete)
+OMSST   Asia/Omsk  # Omsk Summer Time (obsolete)
+OMST    Asia/Omsk  # Omsk Time
                  #     (Asia/Omsk)
-OMST    25200    # Omsk Time (caution: this used to mean 21600)
-                 #     (Asia/Omsk)
-ORAT    18000    # Oral Time
+ORAT    Asia/Oral  # Oral Time
                  #     (Asia/Oral)
-PETST   46800 D  # Petropavlovsk-Kamchatski Summer Time
+PETST   Asia/Kamchatka  # Petropavlovsk-Kamchatski Summer Time (obsolete)
+PETT    Asia/Kamchatka  # Petropavlovsk-Kamchatski Time
                  #     (Asia/Kamchatka)
-PETT    43200    # Petropavlovsk-Kamchatski Time
-                 #     (Asia/Kamchatka)
-PHT     28800    # Philippine Time (not in zic)
+PHT     28800    # Philippine Time
+                 #     (Asia/Manila)
 PKT     18000    # Pakistan Time
                  #     (Asia/Karachi)
 PKST    21600 D  # Pakistan Summer Time
                  #     (Asia/Karachi)
 QYZT    21600    # Kizilorda Time
                  #     (Asia/Qyzylorda)
-SAKST   39600 D  # Sakhalin Summer Time
+SAKST   Asia/Sakhalin  # Sakhalin Summer Time (obsolete)
+SAKT    Asia/Sakhalin  # Sakhalin Time
                  #     (Asia/Sakhalin)
-SAKT    36000    # Sakhalin Time
-                 #     (Asia/Sakhalin)
-SGT     28800    # Singapore Time
+SGT     Asia/Singapore  # Singapore Time
                  #     (Asia/Singapore)
+SRET    39600    # Srednekolymsk Time
+                 #     (Asia/Srednekolymsk)
 TJT     18000    # Tajikistan Time
                  #     (Asia/Dushanbe)
 TLT     32400    # East Timor Time
                  #     (Asia/Dili)
-TMT     18000    # Turkmenistan Time
+TMT     Asia/Ashgabat  # Turkmenistan Time
                  #     (Asia/Ashgabat)
 ULAST   32400 D  # Ulan Bator Summer Time
                  #     (Asia/Ulaanbaatar)
-ULAT    28800    # Ulan Bator Time
+ULAT    Asia/Ulaanbaatar  # Ulan Bator Time
                  #     (Asia/Ulaanbaatar)
 UZST    21600 D  # Uzbekistan Summer Time
                  #     (Asia/Samarkand)
@@ -227,9 +225,8 @@ UZST    21600 D  # Uzbekistan Summer Time
 UZT     18000    # Uzbekistan Time
                  #     (Asia/Samarkand)
                  #     (Asia/Tashkent)
-VLAST   39600 D  # Vladivostok Summer Time (obsolete)
-                 #     (Asia/Vladivostok)
-VLAT    39600    # Vladivostok Time (caution: this used to mean 36000)
+VLAST   Asia/Vladivostok  # Vladivostok Summer Time (obsolete)
+VLAT    Asia/Vladivostok  # Vladivostok Time
                  #     (Asia/Vladivostok)
 WIB     25200    # Waktu Indonesia Barat
                  #     (Asia/Jakarta)
@@ -238,11 +235,11 @@ WIT     32400    # Waktu Indonesia Timur (caution: this used to mean 25200)
                  #     (Asia/Jayapura)
 WITA    28800    # Waktu Indonesia Tengah
                  #     (Asia/Makassar)
-YAKST   36000 D  # Yakutsk Summer Time (obsolete)
-                 #     (Asia/Yakutsk)
-YAKT    36000    # Yakutsk Time (caution: this used to mean 32400)
+XJT     21600    # Xinjiang Time
+                 #     (Asia/Urumqi)
+YAKST   Asia/Yakutsk  # Yakutsk Summer Time (obsolete)
+YAKT    Asia/Yakutsk  # Yakutsk Time
                  #     (Asia/Yakutsk)
 YEKST   21600 D  # Yekaterinburg Summer Time (obsolete)
-                 #     (Asia/Yekaterinburg)
-YEKT    21600    # Yekaterinburg Time (caution: this used to mean 18000)
+YEKT    Asia/Yekaterinburg  # Yekaterinburg Time
                  #     (Asia/Yekaterinburg)

--- a/src/timezone/tznames/Atlantic.txt
+++ b/src/timezone/tznames/Atlantic.txt
@@ -7,9 +7,6 @@
 # src/timezone/tznames/Atlantic.txt
 #
 
-# CONFLICT! ADT is not unique
-# Other timezones:
-#  - ADT: Arabic Daylight Time (Asia)
 ADT    -10800 D  # Atlantic Daylight Time
                  #     (America/Glace_Bay)
                  #     (America/Goose_Bay)
@@ -51,12 +48,11 @@ AZOST       0 D  # Azores Summer Time
                  #     (Atlantic/Azores)
 AZOT    -3600    # Azores Time
                  #     (Atlantic/Azores)
-CVT     -3600    # Cape Verde Time
+CVT     Atlantic/Cape_Verde  # Cape Verde Time
                  #     (Atlantic/Cape_Verde)
-FKST   -10800 D  # Falkland Islands Summer Time
+FKST    Atlantic/Stanley  # Falkland Islands Summer/Standard Time
                  #     (Atlantic/Stanley)
-FKT    -14400    # Falkland Islands Time
-                 #     (Atlantic/Stanley)
+FKT     Atlantic/Stanley  # Falkland Islands Time (obsolete)
 GMT         0    # Greenwich Mean Time
                  #     (Africa/Abidjan)
                  #     (Africa/Bamako)

--- a/src/timezone/tznames/Australia
+++ b/src/timezone/tznames/Australia
@@ -1,5 +1,9 @@
 # Time zone configuration file for set "Australia"
 
+# The abbreviations set up by this file are no longer in widespread use,
+# and should be avoided when possible.  Use this file if you need backwards
+# compatibility with old applications or data.
+
 # In order to use this file, you need to set the run-time parameter
 # timezone_abbreviations to 'Australia'.  See the `Date/Time Support'
 #   appendix in the PostgreSQL documentation for more information.
@@ -15,21 +19,9 @@
 # in case of a conflict.
 @OVERRIDE
 
-ACST    34200    # Central Australia Standard Time (not in zic)
-CST     34200    # Central Standard Time (Australia)
-                 #     (Australia/Adelaide)
-                 #     (Australia/Broken_Hill)
-EAST    36000    # East Australian Standard Time (Australia) (not in zic)
-EST     36000    # Eastern Standard Time (Australia)
-                 #     (Australia/Currie)
-                 #     (Australia/Hobart)
-                 #     (Australia/Melbourne)
-                 #     (Australia/Sydney)
-                 #     (Australia/Currie)
-                 #     (Australia/Hobart)
-                 #     (Australia/Melbourne)
-                 #     (Australia/Sydney)
+CST     34200    # Central Standard Time (not in zic)
+EAST    36000    # East Australian Standard Time (not in zic)
+EST     36000    # Eastern Standard Time (not in zic)
+SAST    34200    # South Australian Standard Time (not in zic)
 SAT     34200    # South Australian Standard Time (not in zic)
-WST     28800    # Western Standard Time (Australia)
-                 #     (Antarctica/Casey)
-                 #     (Australia/Perth)
+WST     28800    # Western Standard Time (not in zic)

--- a/src/timezone/tznames/Australia.txt
+++ b/src/timezone/tznames/Australia.txt
@@ -8,25 +8,43 @@
 #
 
 ACSST   37800 D  # Central Australia (not in zic)
-# CONFLICT! ACST is not unique
-# Other timezones:
-#  - ACST: Acre Summer Time (America)
-ACST    34200    # Central Australia Standard Time (not in zic)
+ACDT    37800 D  # Australian Central Daylight Time
+                 #     (Australia/Adelaide)
+                 #     (Australia/Broken_Hill)
+                 #     (Australia/Darwin)
+ACST    34200    # Australian Central Standard Time
+                 #     (Australia/Adelaide)
+                 #     (Australia/Broken_Hill)
+                 #     (Australia/Darwin)
+ACWST   31500    # Australian Central Western Standard Time
+                 #     (Australia/Eucla)
 AESST   39600 D  # Australia Eastern Summer Standard Time (not in zic)
-AEST    36000    # Australia Eastern Standard Time (not in zic)
+AEDT    39600 D  # Australian Eastern Daylight Time
+                 #     (Australia/Brisbane)
+                 #     (Australia/Currie)
+                 #     (Australia/Hobart)
+                 #     (Australia/Lindeman)
+                 #     (Australia/Melbourne)
+                 #     (Australia/Sydney)
+AEST    36000    # Australian Eastern Standard Time
+                 #     (Australia/Brisbane)
+                 #     (Australia/Currie)
+                 #     (Australia/Hobart)
+                 #     (Australia/Lindeman)
+                 #     (Australia/Melbourne)
+                 #     (Australia/Sydney)
 AWSST   32400 D  # Australia Western Summer Standard Time (not in zic)
-AWST    28800    # Australia Western Standard Time (not in zic)
+AWST    28800    # Australian Western Standard Time
+                 #     (Australia/Perth)
 CADT    37800 D  # Central Australia Daylight-Saving Time (not in zic)
 CAST    34200    # Central Australia Standard Time (not in zic)
 # CONFLICT! CST is not unique
 # Other timezones:
 #  - CST: Central Standard Time (America)
+#  - CST: China Standard Time (Asia)
 #  - CST: Cuba Central Standard Time (America)
-CST     34200    # Central Standard Time (Australia)
-                 #     (Australia/Adelaide)
-                 #     (Australia/Broken_Hill)
-CWST    31500    # Central Western Standard Time (Australia)
-                 #     (Australia/Eucla)
+CST     34200    # Central Standard Time (not in zic)
+CWST    31500    # Central Western Standard Time (not in zic)
 # CONFLICT! EAST is not unique
 # Other timezones:
 #  - EAST: Easter Island Time (Chile) (Pacific)
@@ -34,21 +52,17 @@ EAST    36000    # East Australian Standard Time (not in zic)
 # CONFLICT! EST is not unique
 # Other timezones:
 #  - EST: Eastern Standard Time (America)
-EST     36000    # Eastern Standard Time (Australia)
-                 #     (Australia/Currie)
-                 #     (Australia/Hobart)
-                 #     (Australia/Melbourne)
-                 #     (Australia/Sydney)
-                 #     (Australia/Currie)
-                 #     (Australia/Hobart)
-                 #     (Australia/Melbourne)
-                 #     (Australia/Sydney)
-LHDT    39600 D  # Lord Howe Daylight Time, Australia (not in zic)
-LHST    37800    # Lord Howe Standard Time (Australia)
+EST     36000    # Eastern Standard Time (not in zic)
+LHDT    Australia/Lord_Howe  # Lord Howe Daylight Time
+                 #     (Australia/Lord_Howe)
+LHST    37800    # Lord Howe Standard Time
                  #     (Australia/Lord_Howe)
 LIGT    36000    # Melbourne, Australia (not in zic)
 NZT     43200    # New Zealand Time (not in zic)
 SADT    37800 D  # South Australian Daylight-Saving Time (not in zic)
+# CONFLICT! SAST is not unique
+# Other timezones:
+#  - SAST South Africa Standard Time
 SAST    34200    # South Australian Standard Time (not in zic)
 SAT     34200    # South Australian Standard Time (not in zic)
 WADT    28800 D  # West Australian Daylight-Saving Time (not in zic)
@@ -57,7 +71,4 @@ WDT     32400 D  # West Australian Daylight-Saving Time (not in zic)
 # CONFLICT! WST is not unique
 # Other timezones:
 #  - WST: West Samoa Time
-WST     28800    # Western Standard Time (Australia)
-                 #     (Antarctica/Casey)
-                 #     (Australia/Perth)
-
+WST     28800    # Western Standard Time (not in zic)

--- a/src/timezone/tznames/Default
+++ b/src/timezone/tznames/Default
@@ -4,7 +4,7 @@
 # timezone_abbreviations to 'Default'.  See the `Date/Time Support'
 # appendix in the PostgreSQL documentation for more information.
 #
-# $PostgreSQL: pgsql/src/timezone/tznames/Default,v 1.4.2.5 2010/08/26 19:59:08 tgl Exp $
+# src/timezone/tznames/Default
 
 
 #################### AFRICA ####################
@@ -21,6 +21,8 @@ EAT     10800    # East Africa Time
                  #     (Indian/Antananarivo)
                  #     (Indian/Comoro)
                  #     (Indian/Mayotte)
+SAST     7200    # South Africa Standard Time
+                 #     (Africa/Johannesburg)
 WAT      3600    # West Africa Time
                  #     (Africa/Bangui)
                  #     (Africa/Brazzaville)
@@ -42,9 +44,6 @@ WAT      3600    # West Africa Time
 ACT    -18000    # Acre Time
                  #     (America/Eirunepe)
                  #     (America/Rio_Branco)
-ACST   -14400 D  # Acre Summer Time
-                 #     (America/Eirunepe)
-                 #     (America/Rio_Branco)
 AKDT   -28800 D  # Alaska Daylight Time
                  #     (America/Anchorage)
                  #     (America/Juneau)
@@ -55,7 +54,7 @@ AKST   -32400    # Alaska Standard Time
                  #     (America/Juneau)
                  #     (America/Nome)
                  #     (America/Yakutat)
-ART    -10800    # Argentina Time
+ART    America/Argentina/Buenos_Aires  # Argentina Time
                  #     (America/Argentina/Buenos_Aires)
                  #     (America/Argentina/Cordoba)
                  #     (America/Argentina/Tucuman)
@@ -66,7 +65,7 @@ ART    -10800    # Argentina Time
                  #     (America/Argentina/Mendoza)
                  #     (America/Argentina/Rio_Gallegos)
                  #     (America/Argentina/Ushuaia)
-ARST    -7200 D  # Argentina Summer Time
+ARST    America/Argentina/Buenos_Aires  # Argentina Summer Time
 BOT    -14400    # Bolivia Time
                  #     (America/La_Paz)
 BRA    -10800    # Brazil Time (not in zic)
@@ -87,7 +86,6 @@ COT    -18000    # Columbia Time (not in zic)
 #  - CDT: Cuba Central Daylight Time (America)
 #  - CDT: Canada Central Daylight Time (America)
 CDT    -18000 D  # Central Daylight Time
-                 #     (America/Cancun)
                  #     (America/Chicago)
                  #     (America/Menominee)
                  #     (America/Merida)
@@ -97,18 +95,18 @@ CDT    -18000 D  # Central Daylight Time
                  #     (America/Rainy_River)
                  #     (America/Rankin_Inlet)
                  #     (America/Winnipeg)
-CLST   -10800 D  # Chile Summer Time
+CLST   -10800 D  # Chile Summer Time (obsolete)
                  #     (America/Santiago)
                  #     (Antarctica/Palmer)
-CLT    -14400    # Chile Time
+CLT    America/Santiago  # Chile Time
                  #     (America/Santiago)
                  #     (Antarctica/Palmer)
 # CONFLICT! CST is not unique
 # Other timezones:
 #  - CST: Central Standard Time (Australia)
+#  - CST: China Standard Time (Asia)
 #  - CST: Cuba Central Standard Time (America)
 CST    -21600    # Central Standard Time (America)
-                 #     (America/Cancun)
                  #     (America/Chicago)
                  #     (America/Menominee)
                  #     (America/Merida)
@@ -145,6 +143,7 @@ EGT     -3600    # East Greenland Time (Svalbard & Jan Mayen)
 # Other timezones:
 #  - EST: Eastern Standard Time (Australia)
 EST    -18000    # Eastern Standard Time (America)
+                 #     (America/Cancun)
                  #     (America/Cayman)
                  #     (America/Coral_Harbour)
                  #     (America/Detroit)
@@ -171,7 +170,7 @@ FNST    -3600 D  # Fernando de Noronha Summer Time (not in zic)
                  #     (America/Noronha)
 GFT    -10800    # French Guiana Time
                  #     (America/Cayenne)
-GYT    -14400    # Guyana Time
+GYT    America/Guyana  # Guyana Time
                  #     (America/Guyana)
 MDT    -21600 D  # Mexico Mountain Daylight Time
                  # Mountain Daylight Time
@@ -220,11 +219,13 @@ PST    -28800    # Pacific Standard Time
                  #     (Pacific/Pitcairn)
 PYST   -10800 D  # Paraguay Summer Time
                  #     (America/Asuncion)
-PYT    -14400    # Paraguay Time
+PYT    America/Asuncion  # Paraguay Time
                  #     (America/Asuncion)
-UYST    -7200 D  # Uruguay Summer Time (not in zic)
-UYT    -10800    # Uruguay Time (not in zic)
-VET    -16200    # Venezuela Time (caution: this used to mean -14400)
+UYST    -7200 D  # Uruguay Summer Time (obsolete)
+                 #     (America/Montevideo)
+UYT    -10800    # Uruguay Time
+                 #     (America/Montevideo)
+VET    America/Caracas  # Venezuela Time
                  #     (America/Caracas)
 WGST    -7200 D  # Western Greenland Summer Time
                  #     (America/Godthab)
@@ -233,13 +234,13 @@ WGT    -10800    # West Greenland Time
 
 #################### ANTARCTICA ####################
 
-DAVT    25200    # Davis Time (Antarctica)
+DAVT    Antarctica/Davis  # Davis Time (Antarctica)
                  #     (Antarctica/Davis)
 DDUT    36000    # Dumont-d'Urville Time (Antarctica)
                  #     (Antarctica/DumontDUrville)
                  #     (Antarctica/Palmer)
                  #     (America/Santiago)
-MAWT    18000    # Mawson Time (Antarctica) (caution: this used to mean 21600)
+MAWT    Antarctica/Mawson  # Mawson Time (Antarctica)
                  #     (Antarctica/Mawson)
 
 #################### ASIA ####################
@@ -248,22 +249,23 @@ AFT     16200    # Afghanistan Time
                  #     (Asia/Kabul)
 ALMT    21600    # Alma-Ata Time
                  #     (Asia/Almaty)
-ALMST   25200 D  # Alma-Ata Summer Time
-                 #     (Asia/Almaty)
-AMST    18000 D  # Armenia Summer Time
+ALMST   25200 D  # Alma-Ata Summer Time (obsolete)
+# CONFLICT! AMST is not unique
+# Other timezones:
+#  - AMST: Amazon Summer Time (America)
+AMST    Asia/Yerevan  # Armenia Summer Time
                  #     (Asia/Yerevan)
 # CONFLICT! AMT is not unique
 # Other timezones:
 #  - AMT: Amazon Time (America)
-AMT     14400    # Armenia Time
+AMT     Asia/Yerevan  # Armenia Time
                  #     (Asia/Yerevan)
-ANAST   46800 D  # Anadyr Summer Time
+ANAST   Asia/Anadyr  # Anadyr Summer Time (obsolete)
+ANAT    Asia/Anadyr  # Anadyr Time
                  #     (Asia/Anadyr)
-ANAT    43200    # Anadyr Time
-                 #     (Asia/Anadyr)
-AZST    18000 D  # Azerbaijan Summer Time
+AZST    Asia/Baku  # Azerbaijan Summer Time
                  #     (Asia/Baku)
-AZT     14400    # Azerbaijan Time
+AZT     Asia/Baku  # Azerbaijan Time
                  #     (Asia/Baku)
 BDT     21600    # Bangladesh Time
                  #     (Asia/Dhaka)
@@ -273,9 +275,8 @@ BORT    28800    # Borneo Time (Indonesia) (not in zic)
 BTT     21600    # Bhutan Time
                  #     (Asia/Thimphu)
 CCT     28800    # China Coastal Time (not in zic)
-GEST    14400 D  # Georgia Summer Time (obsolete)
-                 #     (Asia/Tbilisi)
-GET     14400    # Georgia Time (caution: this used to mean 10800)
+GEST    Asia/Tbilisi  # Georgia Summer Time (obsolete)
+GET     Asia/Tbilisi  # Georgia Time
                  #     (Asia/Tbilisi)
 HKT     28800    # Hong Kong Time (not in zic)
 ICT     25200    # Indochina Time
@@ -284,69 +285,64 @@ ICT     25200    # Indochina Time
                  #     (Asia/Saigon)
                  #     (Asia/Vientiane)
 IDT     10800 D  # Israel Daylight Time
-IRKST   32400 D  # Irkutsk Summer Time (obsolete)
-                 #     (Asia/Irkutsk)
-IRKT    32400    # Irkutsk Time (caution: this used to mean 28800)
+                 #     (Asia/Jerusalem)
+IRKST   Asia/Irkutsk  # Irkutsk Summer Time (obsolete)
+IRKT    Asia/Irkutsk  # Irkutsk Time
                  #     (Asia/Irkutsk)
 IRT     12600    # Iran Time (not in zic)
 # CONFLICT! IST is not unique
 # Other timezones:
 # - IST: Irish Summer Time (Europe)
 # - IST: Indian Standard Time (Asia)
-IST      7200    # Israel Standard Time (not in zic)
+IST      7200    # Israel Standard Time
+                 #     (Asia/Jerusalem)
 JAYT    32400    # Jayapura Time (Indonesia) (not in zic)
 JST     32400    # Japan Standard Time
                  #     (Asia/Tokyo)
 KDT     36000 D  # Korean Daylight Time (not in zic)
 KGST    21600 D  # Kyrgyzstan Summer Time (obsolete)
+KGT     Asia/Bishkek  # Kyrgyzstan Time
                  #     (Asia/Bishkek)
-KGT     21600    # Kyrgyzstan Time (caution: this used to mean 18000)
-                 #     (Asia/Bishkek)
-KRAST   28800 D  # Krasnoyarsk Summer Time (obsolete)
-                 #     (Asia/Krasnoyarsk)
-KRAT    28800    # Krasnoyarsk Time (caution: this used to mean 25200)
+KRAST   Asia/Krasnoyarsk  # Krasnoyarsk Summer Time (obsolete)
+KRAT    Asia/Krasnoyarsk  # Krasnoyarsk Time
                  #     (Asia/Krasnoyarsk)
 KST     32400    # Korean Standard Time
-                 #     (Asia/Pyongyang)
-LKT     21600    # Lanka Time
-                 #     (Asia/Colombo)
-MAGST   43200 D  # Magadan Summer Time (obsolete)
-                 #     (Asia/Magadan)
-MAGT    43200    # Magadan Time (caution: this used to mean 39600)
+                 #     (Asia/Seoul)
+LKT     Asia/Colombo  # Lanka Time (obsolete)
+MAGST   Asia/Magadan  # Magadan Summer Time (obsolete)
+MAGT    Asia/Magadan  # Magadan Time
                  #     (Asia/Magadan)
 MMT     23400    # Myanmar Time
                  #     (Asia/Rangoon)
 MYT     28800    # Malaysia Time
                  #     (Asia/Kuala_Lumpur)
                  #     (Asia/Kuching)
-NOVST   25200 D  # Novosibirsk Summer Time (obsolete)
-                 #     (Asia/Novosibirsk)
-NOVT    25200    # Novosibirsk Time (caution: this used to mean 21600)
+NOVST   Asia/Novosibirsk  # Novosibirsk Summer Time (obsolete)
+NOVT    Asia/Novosibirsk  # Novosibirsk Time
                  #     (Asia/Novosibirsk)
 NPT     20700    # Nepal Time
                  #     (Asia/Katmandu)
-OMSST   25200 D  # Omsk Summer Time (obsolete)
+OMSST   Asia/Omsk  # Omsk Summer Time (obsolete)
+OMST    Asia/Omsk  # Omsk Time
                  #     (Asia/Omsk)
-OMST    25200    # Omsk Time (caution: this used to mean 21600)
-                 #     (Asia/Omsk)
-PETST   46800 D  # Petropavlovsk-Kamchatski Summer Time
+PETST   Asia/Kamchatka  # Petropavlovsk-Kamchatski Summer Time (obsolete)
+PETT    Asia/Kamchatka  # Petropavlovsk-Kamchatski Time
                  #     (Asia/Kamchatka)
-PETT    43200    # Petropavlovsk-Kamchatski Time
-                 #     (Asia/Kamchatka)
-PHT     28800    # Philippine Time (not in zic)
+PHT     28800    # Philippine Time
+                 #     (Asia/Manila)
 PKT     18000    # Pakistan Time
                  #     (Asia/Karachi)
 PKST    21600 D  # Pakistan Summer Time
                  #     (Asia/Karachi)
-SGT     28800    # Singapore Time
+SGT     Asia/Singapore  # Singapore Time
                  #     (Asia/Singapore)
 TJT     18000    # Tajikistan Time
                  #     (Asia/Dushanbe)
-TMT     18000    # Turkmenistan Time
+TMT     Asia/Ashgabat  # Turkmenistan Time
                  #     (Asia/Ashgabat)
 ULAST   32400 D  # Ulan Bator Summer Time
                  #     (Asia/Ulaanbaatar)
-ULAT    28800    # Ulan Bator Time
+ULAT    Asia/Ulaanbaatar  # Ulan Bator Time
                  #     (Asia/Ulaanbaatar)
 UZST    21600 D  # Uzbekistan Summer Time
                  #     (Asia/Samarkand)
@@ -354,24 +350,20 @@ UZST    21600 D  # Uzbekistan Summer Time
 UZT     18000    # Uzbekistan Time
                  #     (Asia/Samarkand)
                  #     (Asia/Tashkent)
-VLAST   39600 D  # Vladivostok Summer Time (obsolete)
+VLAST   Asia/Vladivostok  # Vladivostok Summer Time (obsolete)
+VLAT    Asia/Vladivostok  # Vladivostok Time
                  #     (Asia/Vladivostok)
-VLAT    39600    # Vladivostok Time (caution: this used to mean 36000)
-                 #     (Asia/Vladivostok)
-YAKST   36000 D  # Yakutsk Summer Time (obsolete)
-                 #     (Asia/Yakutsk)
-YAKT    36000    # Yakutsk Time (caution: this used to mean 32400)
+XJT     21600    # Xinjiang Time
+                 #     (Asia/Urumqi)
+YAKST   Asia/Yakutsk  # Yakutsk Summer Time (obsolete)
+YAKT    Asia/Yakutsk  # Yakutsk Time
                  #     (Asia/Yakutsk)
 YEKST   21600 D  # Yekaterinburg Summer Time (obsolete)
-                 #     (Asia/Yekaterinburg)
-YEKT    21600    # Yekaterinburg Time (caution: this used to mean 18000)
+YEKT    Asia/Yekaterinburg  # Yekaterinburg Time
                  #     (Asia/Yekaterinburg)
 
 #################### ATLANTIC ####################
 
-# CONFLICT! ADT is not unique
-# Other timezones:
-#  - ADT: Arabic Daylight Time (Asia)
 ADT    -10800 D  # Atlantic Daylight Time
                  #     (America/Glace_Bay)
                  #     (America/Goose_Bay)
@@ -413,27 +405,50 @@ AZOST       0 D  # Azores Summer Time
                  #     (Atlantic/Azores)
 AZOT    -3600    # Azores Time
                  #     (Atlantic/Azores)
-FKST   -10800 D  # Falkland Islands Summer Time
+FKST    Atlantic/Stanley  # Falkland Islands Summer/Standard Time
                  #     (Atlantic/Stanley)
-FKT    -14400    # Falkland Islands Time
-                 #     (Atlantic/Stanley)
+FKT     Atlantic/Stanley  # Falkland Islands Time (obsolete)
 
 #################### AUSTRALIA ####################
 
-ACSST   37800 D  # Central Australia (not in zic)
-AESST   39600 D  # Australia Eastern Summer Standard Time (not in zic)
-AEST    36000    # Australia Eastern Standard Time (not in zic)
+ACSST   37800 D  # Australian Central Summer Standard Time (not in zic)
+ACDT    37800 D  # Australian Central Daylight Time
+                 #     (Australia/Adelaide)
+                 #     (Australia/Broken_Hill)
+                 #     (Australia/Darwin)
+ACST    34200    # Australian Central Standard Time
+                 #     (Australia/Adelaide)
+                 #     (Australia/Broken_Hill)
+                 #     (Australia/Darwin)
+ACWST   31500    # Australian Central Western Standard Time
+                 #     (Australia/Eucla)
+AESST   39600 D  # Australian Eastern Summer Standard Time (not in zic)
+AEDT    39600 D  # Australian Eastern Daylight Time
+                 #     (Australia/Brisbane)
+                 #     (Australia/Currie)
+                 #     (Australia/Hobart)
+                 #     (Australia/Lindeman)
+                 #     (Australia/Melbourne)
+                 #     (Australia/Sydney)
+AEST    36000    # Australian Eastern Standard Time
+                 #     (Australia/Brisbane)
+                 #     (Australia/Currie)
+                 #     (Australia/Hobart)
+                 #     (Australia/Lindeman)
+                 #     (Australia/Melbourne)
+                 #     (Australia/Sydney)
 AWSST   32400 D  # Australia Western Summer Standard Time (not in zic)
-AWST    28800    # Australia Western Standard Time (not in zic)
+AWST    28800    # Australian Western Standard Time
+                 #     (Australia/Perth)
 CADT    37800 D  # Central Australia Daylight-Saving Time (not in zic)
 CAST    34200    # Central Australia Standard Time (not in zic)
-LHDT    39600 D  # Lord Howe Daylight Time, Australia (not in zic)
-LHST    37800    # Lord Howe Standard Time (Australia)
+LHDT    Australia/Lord_Howe  # Lord Howe Daylight Time
+                 #     (Australia/Lord_Howe)
+LHST    37800    # Lord Howe Standard Time
                  #     (Australia/Lord_Howe)
 LIGT    36000    # Melbourne, Australia (not in zic)
 NZT     43200    # New Zealand Time (not in zic)
 SADT    37800 D  # South Australian Daylight-Saving Time (not in zic)
-SAST    34200    # South Australian Standard Time (not in zic)
 WADT    28800 D  # West Australian Daylight-Saving Time (not in zic)
 WAST    25200    # West Australian Standard Time (not in zic)
 WDT     32400 D  # West Australian Daylight-Saving Time (not in zic)
@@ -467,9 +482,10 @@ ZULU        0    # Zulu
 
 #################### EUROPE ####################
 
+# CONFLICT! BST is not unique
+# Other timezones:
+#  - BST: Bougainville Standard Time (Papua New Guinea)
 BST      3600 D  # British Summer Time
-                 # Brazil Standard Time
-                 # Bering Summer Time
                  #     (Europe/London)
 BDST     7200 D  # British Double Summer Time
 CEST     7200 D  # Central Europe Summer Time
@@ -615,7 +631,7 @@ EETDST  10800 D  # East-Egypt Summertime
                  #     (Europe/Uzhgorod)
                  #     (Europe/Vilnius)
                  #     (Europe/Zaporozhye)
-FET     10800    # Further-eastern European Time
+FET     10800    # Further-eastern European Time (obsolete)
                  #     (Europe/Kaliningrad)
                  #     (Europe/Minsk)
 MEST     7200 D  # Middle Europe Summer Time (not in zic)
@@ -623,11 +639,10 @@ MET      3600    # Middle Europe Time (not in zic)
 METDST   7200 D  # Middle Europe Summer Time (not in zic)
 MEZ      3600    # Mitteleuropaeische Zeit (German) (not in zic)
 MSD     14400 D  # Moscow Daylight Time (obsolete)
+MSK     Europe/Moscow  # Moscow Time
                  #     (Europe/Moscow)
-MSK     14400    # Moscow Time (caution: this used to mean 10800)
-                 #     (Europe/Moscow)
-VOLT    14400    # Volgograd Time
                  #     (Europe/Volgograd)
+VOLT    Europe/Volgograd  # Volgograd Time (obsolete)
 WET         0    # Western Europe Time
                  #     (Africa/Casablanca)
                  #     (Africa/El_Aaiun)
@@ -645,7 +660,7 @@ WETDST   3600 D  # Western Europe Summer Time
 
 CXT     25200    # Christmas Island Time (Indian Ocean)
                  #     (Indian/Christmas)
-IOT     21600    # British Indian Ocean Territory (Chagos) (there was a timezone change recently in 1996)
+IOT     Indian/Chagos  # British Indian Ocean Territory (Chagos)
                  #     (Indian/Chagos)
 MUT     14400    # Mauritius Island Time
                  #     (Indian/Mauritius)
@@ -668,13 +683,16 @@ CHAST   45900    # Chatham Standard Time (New Zealand)
                  #     (Pacific/Chatham)
 CHUT    36000    # Chuuk Time
                  #     (Pacific/Chuuk)
-CKT     43200    # Cook Islands Time (not in zic)
-EASST  -18000 D  # Easter Island Summer Time (Chile)
+CKT     Pacific/Rarotonga  # Cook Islands Time
+                 #     (Pacific/Rarotonga)
+EASST   Pacific/Easter  # Easter Island Summer Time (obsolete)
                  #     (Pacific/Easter)
-EAST   -21600    # Easter Island Time (Chile)
+EAST    Pacific/Easter  # Easter Island Time (Chile)
                  #     (Pacific/Easter)
-FJST   -46800 D  # Fiji Summer Time (not in zic)
-FJT    -43200    # Fiji Time (not in zic)
+FJST    46800 D  # Fiji Summer Time
+                 #     (Pacific/Fiji)
+FJT     43200    # Fiji Time
+                 #     (Pacific/Fiji)
 GALT   -21600    # Galapagos Time
                  #     (Pacific/Galapagos)
 GAMT   -32400    # Gambier Time
@@ -684,9 +702,9 @@ GILT    43200    # Gilbert Islands Time
 HST    -36000    # Hawaiian Standard Time
                  #     (Pacific/Honolulu)
                  #     (Pacific/Johnston)
-KOST    39600    # Kosrae Time
+KOST    Pacific/Kosrae  # Kosrae Time
                  #     (Pacific/Kosrae)
-LINT    50400    # Line Islands Time (Kiribati)
+LINT    Pacific/Kiritimati  # Line Islands Time (Kiribati)
                  #     (Pacific/Kiritimati)
 MART   -34200    # Marquesas Time
                  #     (Pacific/Marquesas)
@@ -698,7 +716,7 @@ MPT     36000    # North Mariana Islands Time (not in zic)
 # Other timezones:
 #  - NFT: Norfolk Time (Pacific)
 NFT    -12600    # Newfoundland Time (not in zic)
-NUT    -39600    # Niue Time
+NUT     Pacific/Niue  # Niue Time
                  #     (Pacific/Niue)
 NZDT    46800 D  # New Zealand Daylight Time
                  #     (Antarctica/McMurdo)
@@ -708,7 +726,7 @@ NZST    43200    # New Zealand Standard Time
                  #     (Pacific/Auckland)
 PGT     36000    # Papua New Guinea Time
                  #     (Pacific/Port_Moresby)
-PHOT    46800    # Phoenix Islands Time (Kiribati)
+PHOT    Pacific/Enderbury  # Phoenix Islands Time (Kiribati)
                  #     (Pacific/Enderbury)
 PONT    39600    # Ponape Time (Micronesia)
                  #     (Pacific/Ponape)
@@ -716,17 +734,18 @@ PWT     32400    # Palau Time
                  #     (Pacific/Palau)
 TAHT   -36000    # Tahiti Time (zic says "TAHT", other sources "THAT")
                  #     (Pacific/Tahiti)
-TKT     46800    # Tokelau Time (caution: this used to mean -36000)
+TKT     Pacific/Fakaofo  # Tokelau Time
                  #     (Pacific/Fakaofo)
-TOT     46800    # Tonga Time (not in zic)
+TOT     46800    # Tonga Time
+                 #     (Pacific/Tongatapu)
 TRUT    36000    # Truk Time (zic used to say "TRUT", other sources say "TRUK")
                  #     (Pacific/Truk)
 TVT     43200    # Tuvalu Time
                  #     (Pacific/Funafuti)
-VUT     39600    # Vanuata Time (not in zic)
+VUT     39600    # Vanuata Time
+                 #     (Pacific/Efate)
 WAKT    43200    # Wake Time
                  #     (Pacific/Wake)
 WFT     43200    # Wallis and Futuna Time
                  #     (Pacific/Wallis)
 YAPT    36000    # Yap Time (Micronesia) (not in zic)
-

--- a/src/timezone/tznames/Etc.txt
+++ b/src/timezone/tznames/Etc.txt
@@ -32,4 +32,3 @@ UTC         0    # Coordinated Universal Time
                  #     (Etc/UTC)
 Z           0    # Zulu
 ZULU        0    # Zulu
-

--- a/src/timezone/tznames/Europe.txt
+++ b/src/timezone/tznames/Europe.txt
@@ -7,9 +7,10 @@
 # src/timezone/tznames/Europe.txt
 #
 
+# CONFLICT! BST is not unique
+# Other timezones:
+#  - BST: Bougainville Standard Time (Papua New Guinea)
 BST      3600 D  # British Summer Time
-                 # Brazil Standard Time
-                 # Bering Summer Time
                  #     (Europe/London)
 CEST     7200 D  # Central Europe Summer Time
                  #     (Africa/Ceuta)
@@ -154,7 +155,7 @@ EETDST  10800 D  # East-Egypt Summertime
                  #     (Europe/Uzhgorod)
                  #     (Europe/Vilnius)
                  #     (Europe/Zaporozhye)
-FET     10800    # Further-eastern European Time
+FET     10800    # Further-eastern European Time (obsolete)
                  #     (Europe/Kaliningrad)
                  #     (Europe/Minsk)
 GMT         0    # Greenwich Mean Time
@@ -186,15 +187,13 @@ MET      3600    # Middle Europe Time (not in zic)
 METDST   7200 D  # Middle Europe Summer Time (not in zic)
 MEZ      3600    # Mitteleuropäische Zeit (German) (not in zic)
 MSD     14400 D  # Moscow Daylight Time (obsolete)
+MSK     Europe/Moscow  # Moscow Time
                  #     (Europe/Moscow)
-MSK     14400    # Moscow Time (caution: this used to mean 10800)
-                 #     (Europe/Moscow)
-SAMST   18000 D  # Samara Summer Time (obsolete)
-                 #     (Europe/Samara)
-SAMT    14400    # Samara Time
-                 #     (Europe/Samara)
-VOLT    14400    # Volgograd Time
                  #     (Europe/Volgograd)
+SAMST   Europe/Samara  # Samara Summer Time (obsolete)
+SAMT    Europe/Samara  # Samara Time
+                 #     (Europe/Samara)
+VOLT    Europe/Volgograd  # Volgograd Time (obsolete)
 WEST     3600 D  # Western Europe Summer Time
                  #     (Africa/Casablanca)
                  #     (Atlantic/Canary)

--- a/src/timezone/tznames/Indian.txt
+++ b/src/timezone/tznames/Indian.txt
@@ -23,7 +23,7 @@ EAT     10800    # East Africa Time
                  #     (Indian/Antananarivo)
                  #     (Indian/Comoro)
                  #     (Indian/Mayotte)
-IOT     21600    # British Indian Ocean Territory (Chagos) (there was a timezone change recently in 1996)
+IOT     Indian/Chagos  # British Indian Ocean Territory (Chagos)
                  #     (Indian/Chagos)
 MUT     14400    # Mauritius Island Time
                  #     (Indian/Mauritius)

--- a/src/timezone/tznames/Pacific.txt
+++ b/src/timezone/tznames/Pacific.txt
@@ -7,6 +7,11 @@
 # src/timezone/tznames/Pacific.txt
 #
 
+# CONFLICT! BST is not unique
+# Other timezones:
+#  - BST: British Summer Time
+BST     39600    # Bougainville Standard Time (Papua New Guinea)
+                 #     (Pacific/Bougainville)
 CHADT   49500 D  # Chatham Daylight Time (New Zealand)
                  #     (Pacific/Chatham)
 CHAST   45900    # Chatham Standard Time (New Zealand)
@@ -16,16 +21,19 @@ ChST    36000    # Chamorro Standard Time (lower case "h" is as in zic)
                  #     (Pacific/Saipan)
 CHUT    36000    # Chuuk Time
                  #     (Pacific/Chuuk)
-CKT     43200    # Cook Islands Time (not in zic)
-EASST  -18000 D  # Easter Island Summer Time (Chile)
+CKT     Pacific/Rarotonga  # Cook Islands Time
+                 #     (Pacific/Rarotonga)
+EASST   Pacific/Easter  # Easter Island Summer Time (obsolete)
                  #     (Pacific/Easter)
 # CONFLICT! EAST is not unique
 # Other timezones:
 #  - EAST: East Australian Standard Time (Australia)
-EAST   -21600    # Easter Island Time (Chile)
+EAST    Pacific/Easter  # Easter Island Time (Chile)
                  #     (Pacific/Easter)
-FJST   -46800 D  # Fiji Summer Time (not in zic)
-FJT    -43200    # Fiji Time (not in zic)
+FJST    46800 D  # Fiji Summer Time (caution: this used to mean -46800)
+                 #     (Pacific/Fiji)
+FJT     43200    # Fiji Time (caution: this used to mean -43200)
+                 #     (Pacific/Fiji)
 GALT   -21600    # Galapagos Time
                  #     (Pacific/Galapagos)
 GAMT   -32400    # Gambier Time
@@ -35,9 +43,9 @@ GILT    43200    # Gilbert Islands Time
 HST    -36000    # Hawaiian Standard Time
                  #     (Pacific/Honolulu)
                  #     (Pacific/Johnston)
-KOST    39600    # Kosrae Time
+KOST    Pacific/Kosrae  # Kosrae Time
                  #     (Pacific/Kosrae)
-LINT    50400    # Line Islands Time (Kiribati)
+LINT    Pacific/Kiritimati  # Line Islands Time (Kiribati)
                  #     (Pacific/Kiritimati)
 MART   -34200    # Marquesas Time
                  #     (Pacific/Marquesas)
@@ -45,15 +53,16 @@ MHT     43200    # Kwajalein Time
                  #     (Pacific/Kwajalein)
                  #     (Pacific/Majuro)
 MPT     36000    # North Mariana Islands Time (not in zic)
-NCT     39600    # New Caledonia Time (not in zic)
+NCT     39600    # New Caledonia Time
+                 #     (Pacific/Noumea)
 # CONFLICT! NFT is not unique
 # Other timezones:
 #  - NFT: Newfoundland Time (America)
-NFT     41400    # Norfolk Time
+NFT     Pacific/Norfolk  # Norfolk Time
                  #     (Pacific/Norfolk)
-NRT     43200    # Nauru Time
+NRT     Pacific/Nauru  # Nauru Time
                  #     (Pacific/Nauru)
-NUT    -39600    # Niue Time
+NUT     Pacific/Niue  # Niue Time
                  #     (Pacific/Niue)
 NZDT    46800 D  # New Zealand Daylight Time
                  #     (Antarctica/McMurdo)
@@ -63,7 +72,7 @@ NZST    43200    # New Zealand Standard Time
                  #     (Pacific/Auckland)
 PGT     36000    # Papua New Guinea Time
                  #     (Pacific/Port_Moresby)
-PHOT    46800    # Phoenix Islands Time (Kiribati)
+PHOT    Pacific/Enderbury  # Phoenix Islands Time (Kiribati)
                  #     (Pacific/Enderbury)
 PONT    39600    # Ponape Time (Micronesia)
                  #     (Pacific/Ponape)
@@ -83,23 +92,26 @@ SST    -39600    # South Sumatran Time
                  #     (Pacific/Pago_Pago)
 TAHT   -36000    # Tahiti Time (zic says "TAHT", other sources "THAT")
                  #     (Pacific/Tahiti)
-TKT     46800    # Tokelau Time (caution: this used to mean -36000)
+TKT     Pacific/Fakaofo  # Tokelau Time
                  #     (Pacific/Fakaofo)
-TOT     46800    # Tonga Time (not in zic)
+TOT     46800    # Tonga Time
+                 #     (Pacific/Tongatapu)
 TRUT    36000    # Truk Time (zic used to say "TRUT", other sources say "TRUK")
                  #     (Pacific/Truk)
 TVT     43200    # Tuvalu Time
                  #     (Pacific/Funafuti)
-VUT     39600    # Vanuata Time (not in zic)
+VUT     39600    # Vanuata Time
+                 #     (Pacific/Efate)
 WAKT    43200    # Wake Time
                  #     (Pacific/Wake)
 WFT     43200    # Wallis and Futuna Time
                  #     (Pacific/Wallis)
+WSDT    50400 D  # West Samoa Daylight Time
+                 #     (Pacific/Apia)
+WSST    46800    # West Samoa Standard Time
+                 #     (Pacific/Apia)
 # CONFLICT! WST is not unique
 # Other timezones:
 #  - WST: Western Standard Time (Australia)
-WSDT    50400 D  # West Samoa Daylight Time
-                 #     (Pacific/Apia)
-WST     46800    # West Samoa Time (caution: this used to mean -39600)
-                 #     (Pacific/Apia)
+WST     46800    # West Samoa Time (caution: this used to mean -39600) (not in zic)
 YAPT    36000    # Yap Time (Micronesia) (not in zic)

--- a/src/timezone/tznames/README
+++ b/src/timezone/tznames/README
@@ -6,26 +6,29 @@ tznames
 This directory contains files with timezone sets for PostgreSQL.  The problem
 is that time zone abbreviations are not unique throughout the world and you
 might find out that a time zone abbreviation in the `Default' set collides
-with the one you wanted to use.  All other files except for `Default' are
-intended to override values from the `Default' set.  So you might already have
-a file here that serves your needs.  If not, you can create your own.
+with the one you wanted to use.  This can be fixed by selecting a timezone
+set that defines the abbreviation the way you want it.  There might already
+be a file here that serves your needs.  If not, you can create your own.
 
 In order to use one of these files, you need to set
 
    timezone_abbreviations = 'xyz'
 
 in any of the usual ways for setting a parameter, where xyz is the filename
-that contains the desired time zone names.
+that contains the desired time zone abbreviations.
 
-If you do not find an appropriate set of time zone names for your geographic
+If you do not find an appropriate set of abbreviations for your geographic
 location supplied here, please report this to <pgsql-hackers@postgresql.org>.
-Your set of time zone names can then be included in future releases.
+Your set of time zone abbreviations can then be included in future releases.
 For the time being you can always add your own set.
+
+Typically a custom abbreviation set is made by including the `Default' set
+and then adding or overriding abbreviations as necessary.  For examples,
+see the `Australia' and `India' files.
 
 The files named Africa.txt, etc, are not intended to be used directly as
 time zone abbreviation files. They contain reference definitions of time zone
-names that can be copied into a custom abbreviation file as needed.
-
-Note that these files (*.txt) are already a subset of the zic timezone
-database files: we tried to list only those time zones that (according to
-the zic timezone database) appear to be still in use.
+abbreviations that can be copied into a custom abbreviation file as needed.
+Note that these files (*.txt) are already a subset of the IANA timezone
+database files: we tried to list only those time zone abbreviations that
+(according to the IANA timezone database) appear to be still in use.


### PR DESCRIPTION
This puts on on par with upstream PostgreSQL 9.1.20, released on 2016-02-11, for tzdata and the below referenced commit. The reason for not updating further is that there are tzdata format changes in 9.1.21, 2016a is the last release we can import without merging code changes as well (and changes to time code should've been in by now given the short time before release). This puts in a much better place than being synced with 8.3.23 though (3 years worth of tzdata content) so still worth the import.
```
  commit 6887d72d06a2f36508d5be9cca316088d4c60b26
  Author: Tom Lane <tgl@sss.pgh.pa.us>
  Date:   Fri Feb 5 10:59:09 2016 -0500

    Update time zone data files to tzdata release 2016a.

    DST law changes in Cayman Islands, Metlakatla, Trans-Baikal Territory
    (Zabaykalsky Krai).  Historical corrections for Pakistan.
```