### PR TITLE
BufferGetLSNAtomic: fix Coverity complaint about negative array index

### DIFF
--- a/src/backend/storage/buffer/bufmgr.c
+++ b/src/backend/storage/buffer/bufmgr.c
@@ -2119,7 +2119,7 @@ RelationTruncate(Relation rel, BlockNumber nblocks, bool markPersistentAsPhysica
 XLogRecPtr
 BufferGetLSNAtomic(Buffer buffer)
 {
-	volatile BufferDesc *bufHdr = &BufferDescriptors[buffer - 1];
+	volatile BufferDesc *bufHdr;
 	char				*page = BufferGetPage(buffer);
 	XLogRecPtr			 lsn;
 
@@ -2132,8 +2132,11 @@ BufferGetLSNAtomic(Buffer buffer)
 	/* Make sure we've got a real buffer, and that we hold a pin on it. */
 	Assert(BufferIsValid(buffer));
 	Assert(BufferIsPinned(buffer));
+
 	/* Caller should hold share lock on the buffer contents. */
+	bufHdr = &BufferDescriptors[buffer - 1];
 	Assert(LWLockHeldByMe(bufHdr->content_lock));
+
 	LockBufHdr(bufHdr);
 	lsn = PageGetLSN(page);
 	UnlockBufHdr(bufHdr);


### PR DESCRIPTION
BufferGetLSNAtomic accepts local (negative) buffer values, and simply
exits early if it sees one. But it does index into the BufferDescriptors
array using this invalid negative value, which makes Coverity complain.

We're taking the address of the invalid location and not using it in the
local case, so this likely doesn't have any real ramifications. But I
can't find a clear statement that &array[invalid_index] is actually
well-defined across all platforms/compilers, and someone in the future
might miss that bufHdr isn't always pointing to something sane, so it
seems prudent to just fix this.