### PR TITLE
Disable binary swap tests on Concourse master pipeline

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -672,6 +672,7 @@ jobs:
       MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off' installcheck-world
       BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
       TEST_OS: centos
+      TEST_BINARY_SWAP: false
       CONFIGURE_FLAGS: {{configure_flags}}
 
 - name: icw_gporca_centos6


### PR DESCRIPTION
Now that catalog updates are allowed, we should disable binary swap
validation.  Once the next catalog freeze comes, someone can flip this
back.