### PR TITLE
Refactor code that selects a common type for columns in a UNION query.

### DIFF
--- a/src/backend/parser/parse_node.c
+++ b/src/backend/parser/parse_node.c
@@ -47,9 +47,6 @@ make_parsestate(ParseState *parentParseState)
 
 	pstate->parentParseState = parentParseState;
 
-	/* disable propagateSetopTypes by default */
-	pstate->p_propagateSetopTypes = false;
-
 	/* Fill in fields that don't start at null/false/zero */
 	pstate->p_next_resno = 1;
 
@@ -57,11 +54,6 @@ make_parsestate(ParseState *parentParseState)
 	{
 		pstate->p_sourcetext = parentParseState->p_sourcetext;
 		pstate->p_variableparams = parentParseState->p_variableparams;
-		if (parentParseState->p_propagateSetopTypes)
-		{
-			pstate->p_setopTypes = parentParseState->p_setopTypes;
-			pstate->p_setopTypmods = parentParseState->p_setopTypmods;
-		}
 	}
 
 	return pstate;

--- a/src/include/parser/parse_node.h
+++ b/src/include/parser/parse_node.h
@@ -96,9 +96,6 @@ typedef struct ParseState
 	struct HTAB *p_namecache;  /* parse state object name cache */
 	bool        p_hasTblValueExpr;
 	bool        p_hasDynamicFunction; /* function w/unstable return type */
-	List	   *p_setopTypes;		/* predicated types on Setop */
-	List	   *p_setopTypmods;		/* predicated typmods on Setop */
-	bool        p_propagateSetopTypes;      /* if possible to propagate types on Setop */
 } ParseState;
 
 /* Support for parser_errposition_callback function */

--- a/src/test/regress/expected/union_gp.out
+++ b/src/test/regress/expected/union_gp.out
@@ -164,7 +164,7 @@ select 1 union (select distinct 10 from (select 1, 3.0 union select distinct 2, 
 (2 rows)
 
 select 1 union (select distinct '10' from (select 1, 3.0 union select distinct 2, null::integer) as foo);
-ERROR:  UNION/INTERSECT/EXCEPT could not convert type text to integer
+ERROR:  UNION types integer and text cannot be matched
 select distinct a from (select 'A' union select 'B') as foo(a);
  a 
 ---


### PR DESCRIPTION
The big difference is that each leaf query is now transformed in one go,
like it's done in the upstream, instead of transforming the target list
and FROM list first. That partial transformation was causing trouble for
another refactoring that I'm working on, which ill change the way window
functions are handled in parse analysis.

This two-pass code is GPDB-specific, PostgreSQL uses a simpler algorithm
that works bottom-up, one setop node at a time, to select the column types.