### PR TITLE
Further refactoring of ParseFuncOrColumn and func_get_detail.

### DIFF
--- a/src/include/parser/parse_func.h
+++ b/src/include/parser/parse_func.h
@@ -37,6 +37,7 @@ typedef enum
 	FUNCDETAIL_MULTIPLE,		/* too many matching functions */
 	FUNCDETAIL_NORMAL,			/* found a matching regular function */
 	FUNCDETAIL_AGGREGATE,		/* found a matching aggregate function */
+	FUNCDETAIL_WINDOWFUNC,		/* found a matching window function */
 	FUNCDETAIL_COERCION			/* it's a type coercion request */
 } FuncDetailCode;
 

--- a/src/test/regress/expected/aggregates.out
+++ b/src/test/regress/expected/aggregates.out
@@ -817,11 +817,11 @@ LINE 1: SELECT nosuchagg(a order by a) FROM aggtest;
                ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT lag(a order by a) from aggtest;       -- window function (no window clause)
-ERROR:  ORDER BY specified, but lag is not an ordered aggregate function
+ERROR:  window function call requires an OVER clause
 LINE 1: SELECT lag(a order by a) from aggtest;
                ^
 SELECT lag(a order by a) over (order by a) FROM aggtest;  -- window function
-ERROR:  ORDER BY specified, but lag is not an ordered aggregate function
+ERROR:  aggregate ORDER BY is not implemented for window functions
 LINE 1: SELECT lag(a order by a) over (order by a) FROM aggtest;
                ^
 SELECT count(a order by a) over (order by a) FROM aggtest;  -- window derived aggregate

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -823,11 +823,11 @@ LINE 1: SELECT nosuchagg(a order by a) FROM aggtest;
                ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT lag(a order by a) from aggtest;       -- window function (no window clause)
-ERROR:  ORDER BY specified, but lag is not an ordered aggregate function
+ERROR:  window function call requires an OVER clause
 LINE 1: SELECT lag(a order by a) from aggtest;
                ^
 SELECT lag(a order by a) over (order by a) FROM aggtest;  -- window function
-ERROR:  ORDER BY specified, but lag is not an ordered aggregate function
+ERROR:  aggregate ORDER BY is not implemented for window functions
 LINE 1: SELECT lag(a order by a) over (order by a) FROM aggtest;
                ^
 SELECT count(a order by a) over (order by a) FROM aggtest;  -- window derived aggregate

--- a/src/test/regress/expected/filter.out
+++ b/src/test/regress/expected/filter.out
@@ -482,7 +482,7 @@ select i, ntile(3) over (order by i) from filter_test ORDER BY i;
 (10 rows)
 
 select i, ntile(3) filter (where true) over (order by i) from filter_test ORDER BY i;
-ERROR:  filter clause specified, but ntile is not an aggregate function
+ERROR:  window function "ntile" can not be used with a filter clause
 LINE 1: select i, ntile(3) filter (where true) over (order by i) fro...
                   ^
 select i, ntile(4-j) over (partition by j order by i) 
@@ -501,7 +501,7 @@ FROM filter_test where j < 4 ORDER BY j, i;
 
 select i, ntile(4-j) filter (where true) over (partition by j order by i) 
 from filter_test where j < 4 ORDER BY j, i;
-ERROR:  filter clause specified, but ntile is not an aggregate function
+ERROR:  window function "ntile" can not be used with a filter clause
 LINE 1: select i, ntile(4-j) filter (where true) over (partition by ...
                   ^
 -- TEST against non aggregate function => should error

--- a/src/test/regress/expected/olap_window_seq.out
+++ b/src/test/regress/expected/olap_window_seq.out
@@ -2134,7 +2134,9 @@ select p.proname, p.proargtypes from pg_window w, pg_proc p, pg_proc p2 where w.
 (105 rows)
 
 select lead(cn) from sale;
-ERROR:  function lead(integer) may only be called as a window function  (seg1 slice1 localhost:10002 pid=57055)
+ERROR:  window function call requires an OVER clause
+LINE 1: select lead(cn) from sale;
+               ^
 select cn, cname, lead(cname, -1) over (order by cn) from customer;
 ERROR:  LEAD offset cannot be negative
 -- actual LEAD tests

--- a/src/test/regress/expected/olap_window_seq_optimizer.out
+++ b/src/test/regress/expected/olap_window_seq_optimizer.out
@@ -2135,7 +2135,9 @@ select p.proname, p.proargtypes from pg_window w, pg_proc p, pg_proc p2 where w.
 (105 rows)
 
 select lead(cn) from sale;
-ERROR:  function lead(integer) may only be called as a window function
+ERROR:  window function call requires an OVER clause
+LINE 1: select lead(cn) from sale;
+               ^
 select cn, cname, lead(cname, -1) over (order by cn) from customer;
 ERROR:  ROWS parameter cannot be negative
 -- actual LEAD tests

--- a/src/test/regress/output/table_functions.source
+++ b/src/test/regress/output/table_functions.source
@@ -2059,7 +2059,7 @@ ERROR:  table functions must be invoked in FROM clause
 SELECT multiset_3( TABLE(SELECT a from example) );  -- not in the from clause
 ERROR:  table functions must be invoked in FROM clause
 SELECT multiset_5( TABLE(SELECT * from example) ) over (order by 1);
-ERROR:  window functions may not return sets
+ERROR:  OVER specified, but multiset_5 is not a window function nor an aggregate function
 LINE 1: SELECT multiset_5( TABLE(SELECT * from example) ) over (orde...
                ^
 SELECT * from example where 3 = multiset_scalar_value( TABLE(select a from example) ); -- not in from

--- a/src/test/regress/output/table_functions_optimizer.source
+++ b/src/test/regress/output/table_functions_optimizer.source
@@ -2060,7 +2060,7 @@ ERROR:  table functions must be invoked in FROM clause
 SELECT multiset_3( TABLE(SELECT a from example) );  -- not in the from clause
 ERROR:  table functions must be invoked in FROM clause
 SELECT multiset_5( TABLE(SELECT * from example) ) over (order by 1);
-ERROR:  window functions may not return sets
+ERROR:  OVER specified, but multiset_5 is not a window function nor an aggregate function
 LINE 1: SELECT multiset_5( TABLE(SELECT * from example) ) over (orde...
                ^
 SELECT * from example where 3 = multiset_scalar_value( TABLE(select a from example) ); -- not in from


### PR DESCRIPTION
This backports the new FUNCDETAIL_WINDOWFUNC return code from PostgreSQL
8.4, and refactors the code to match upstream, as much as feasible. A few
error scenarios now give better error messages.