### PR TITLE
Remove overly-complicated SzAllocate function.

### DIFF
--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -334,49 +334,6 @@ COptTasks::SOptimizeMinidumpContext::PoptmdpConvert
 
 //---------------------------------------------------------------------------
 //	@function:
-//		SzAllocate
-//
-//	@doc:
-//		Allocate string buffer with protection against OOM
-//
-//---------------------------------------------------------------------------
-CHAR *
-COptTasks::SzAllocate
-	(
-	IMemoryPool *pmp,
-	ULONG ulSize
-	)
-{
-	CHAR *sz = NULL;
-	GPOS_TRY
-	{
-		// allocation of string buffer may happen outside gpos_exec() function,
-		// we must guard against system OOM here
-#ifdef FAULT_INJECTOR
-		gpdb::OptTasksFaultInjector(OptTaskAllocateStringBuffer);
-#endif // FAULT_INJECTOR
-
-		if (NULL == pmp)
-		{
-			sz = (CHAR *) gpdb::GPDBAlloc(ulSize);
-		}
-		else
-		{
-			sz = GPOS_NEW_ARRAY(pmp, CHAR, ulSize);
-		}
-	}
-	GPOS_CATCH_EX(ex)
-	{
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiNoAvailableMemory);
-	}
-	GPOS_CATCH_END;
-
-	return sz;
-}
-
-
-//---------------------------------------------------------------------------
-//	@function:
 //		SzFromWsz
 //
 //	@doc:
@@ -395,7 +352,7 @@ COptTasks::SzFromWsz
 	const ULONG ulWCHARSize = GPOS_SIZEOF(WCHAR);
 	const ULONG ulMaxLength = (ulInputLength + 1) * ulWCHARSize;
 
-	CHAR *sz = SzAllocate(NULL, ulMaxLength);
+	CHAR *sz = (CHAR *) gpdb::GPDBAlloc(ulMaxLength);
 
 	gpos::clib::LWcsToMbs(sz, const_cast<WCHAR *>(wsz), ulMaxLength);
 	sz[ulMaxLength - 1] = '\0';

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -313,8 +313,6 @@ FaultInjectorIdentifierEnumToString[] = {
 		/* pause FTS process before committing changes, until shutdown */
 	_("runaway_cleanup"),
 		/* inject fault before cleaning up a runaway query */		
-	_("opt_task_allocate_string_buffer"),
-		/* inject fault while allocating string buffer */
 	_("opt_relcache_translator_catalog_access"),
 		/* inject fault while translating relcache entries */
 	_("send_qe_details_init_backend"),
@@ -1128,7 +1126,6 @@ FaultInjector_NewHashEntry(
 		case DtmBroadcastCommitPrepared:
 		case DtmBroadcastAbortPrepared:
 		case DtmXLogDistributedCommit:
-		case OptTaskAllocateStringBuffer:
 		case OptRelcacheTranslatorCatalogAccess:
 			
 			if (fileRepRole != FileRepNoRoleConfigured)

--- a/src/include/gpopt/utils/COptTasks.h
+++ b/src/include/gpopt/utils/COptTasks.h
@@ -221,10 +221,6 @@ class COptTasks
 		static
 		DrgPss *PdrgPssLoad(IMemoryPool *pmp, char *szPath);
 
-		// allocate memory for string
-		static
-		CHAR *SzAllocate(IMemoryPool *pmp, ULONG ulSize);
-
 		// helper for converting wide character string to regular string
 		static
 		CHAR *SzFromWsz(const WCHAR *wsz);

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -205,7 +205,6 @@ typedef enum FaultInjectorIdentifier_e {
 
 	RunawayCleanup,
 
-	OptTaskAllocateStringBuffer,
 	OptRelcacheTranslatorCatalogAccess,
 
 	SendQEDetailsInitBackend,


### PR DESCRIPTION
There was only one caller, and it provided no memory pool. The fault
injection was also unused AFAICS.