### PR TITLE
Rename checkExprHasWindFuncs to checkExprHasWindowFuncs to match upstream.

### DIFF
--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -36,11 +36,11 @@
 #include "mb/pg_wchar.h"
 #include "miscadmin.h"
 #include "optimizer/clauses.h"
-#include "parser/parse_agg.h"
 #include "parser/parse_coerce.h"
 #include "parser/parse_expr.h"
 #include "parser/parse_func.h"
 #include "parser/parsetree.h"
+#include "rewrite/rewriteManip.h"
 #include "storage/proc.h"
 #include "storage/procarray.h"
 #include "utils/acl.h"
@@ -931,7 +931,7 @@ CheckPredicate(Expr *predicate)
 		ereport(ERROR,
 				(errcode(ERRCODE_GROUPING_ERROR),
 				 errmsg("cannot use aggregate in index predicate")));
-	if (checkExprHasWindFuncs((Node *)predicate))
+	if (checkExprHasWindowFuncs((Node *)predicate))
 		ereport(ERROR,
 				(errcode(ERRCODE_SYNTAX_ERROR),
 				 errmsg("cannot use window function in index predicate")));
@@ -1033,7 +1033,7 @@ ComputeIndexAttrs(IndexInfo *indexInfo,
 				ereport(ERROR,
 						(errcode(ERRCODE_GROUPING_ERROR),
 				errmsg("cannot use aggregate function in index expression")));
-			if (checkExprHasWindFuncs(attribute->expr))
+			if (checkExprHasWindowFuncs(attribute->expr))
 				ereport(ERROR,
 						(errcode(ERRCODE_SYNTAX_ERROR),
 						 errmsg("cannot use window function in index expression")));

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -955,7 +955,7 @@ transformGroupedWindows(Query *qry)
 	/* Check if there is a window function in the join tree. If so
 	 * we must mark hasWindowFuncs in the sub query as well.
 	 */
-	if (checkExprHasWindFuncs((Node *)subq->jointree))
+	if (checkExprHasWindowFuncs((Node *)subq->jointree))
 		subq->hasWindowFuncs = true;
 
 	/* Make the single range table entry for the outer query Q' as

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -457,7 +457,7 @@ transformWindowClause(ParseState *pstate, Query *qry)
 
 		clauseno++;
 
-		if (checkExprHasWindFuncs((Node *)ws))
+		if (checkExprHasWindowFuncs((Node *)ws))
 			ereport(ERROR,
 					(errcode(ERRCODE_SYNTAX_ERROR),
 					 errmsg("cannot use window function in a window specification"),

--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -2267,7 +2267,7 @@ transformPercentileExpr(ParseState *pstate, PercentileExpr *p)
 				 errmsg("argument of percentile function must not contain aggregates"),
 				 parser_errposition(pstate,
 									locate_agg_of_level(arg, 0))));
-	if (checkExprHasWindFuncs(arg))
+	if (checkExprHasWindowFuncs(arg))
 		ereport(ERROR,
 				(errcode(ERRCODE_GROUPING_ERROR),
 				 errmsg("argument of percentile function must not contain window functions"),
@@ -2475,7 +2475,7 @@ transformPercentileExpr(ParseState *pstate, PercentileExpr *p)
 					 errmsg("argument of percentile function must not contain aggregates"),
 					 parser_errposition(pstate,
 										locate_agg_of_level((Node *) p->sortTargets, 0))));
-		if (checkExprHasWindFuncs((Node *) p->sortTargets))
+		if (checkExprHasWindowFuncs((Node *) p->sortTargets))
 			ereport(ERROR,
 					(errcode(ERRCODE_GROUPING_ERROR),
 					 errmsg("argument of percentile function must not contain window functions"),

--- a/src/include/parser/parse_agg.h
+++ b/src/include/parser/parse_agg.h
@@ -39,7 +39,6 @@ extern void build_aggregate_fnexprs(Oid *agg_input_types,
 						Expr **invtransfnexpr,
 						Expr **invprelimfnexpr);
 
-extern bool checkExprHasWindFuncs(Node *node);
 extern bool checkExprHasGroupExtFuncs(Node *node);
 
 #endif   /* PARSE_AGG_H */

--- a/src/include/rewrite/rewriteManip.h
+++ b/src/include/rewrite/rewriteManip.h
@@ -39,6 +39,7 @@ extern void AddInvertedQual(Query *parsetree, Node *qual);
 
 extern int	locate_agg_of_level(Node *node, int levelsup);
 extern bool checkExprHasAggs(Node *node);
+extern bool checkExprHasWindowFuncs(Node *node);
 extern bool checkExprHasSubLink(Node *node);
 
 extern Node *map_variable_attnos(Node *node,


### PR DESCRIPTION
Also move the function to where it is in the upstream.

To reduce our diff footprint.