### PR TITLE
Cherry-pick locate_windowfunc() from PostgreSQL 8.4.

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -812,7 +812,9 @@ transformInsertStmt(ParseState *pstate, InsertStmt *stmt)
 	if (pstate->p_hasWindowFuncs)
 		ereport(ERROR,
 				(errcode(ERRCODE_WINDOWING_ERROR),
-				 errmsg("cannot use window function in VALUES")));
+				 errmsg("cannot use window function in VALUES"),
+				 parser_errposition(pstate,
+									locate_windowfunc((Node *) qry))));
 
 	return qry;
 }
@@ -1885,7 +1887,9 @@ transformValuesClause(ParseState *pstate, SelectStmt *stmt)
 	if (pstate->p_hasWindowFuncs)
 		ereport(ERROR,
 				(errcode(ERRCODE_WINDOWING_ERROR),
-				 errmsg("cannot use window function in VALUES")));
+				 errmsg("cannot use window function in VALUES"),
+				 parser_errposition(pstate,
+								locate_windowfunc((Node *) newExprsLists))));
 
 	return qry;
 }
@@ -2747,7 +2751,9 @@ transformUpdateStmt(ParseState *pstate, UpdateStmt *stmt)
 	if (pstate->p_hasWindowFuncs)
 		ereport(ERROR,
 				(errcode(ERRCODE_WINDOWING_ERROR),
-				 errmsg("cannot use window function in UPDATE")));
+				 errmsg("cannot use window function in UPDATE"),
+				 parser_errposition(pstate,
+									locate_windowfunc((Node *) qry))));
 
 	/*
 	 * Now we are done with SELECT-like processing, and can get on with
@@ -2855,9 +2861,10 @@ transformReturningList(ParseState *pstate, List *returningList)
 
 	if (pstate->p_hasWindowFuncs)
 		ereport(ERROR,
-				(errcode(ERRCODE_SYNTAX_ERROR),
-				 errmsg("cannot use window function in RETURNING")));
-
+				(errcode(ERRCODE_WINDOWING_ERROR),
+				 errmsg("cannot use window function in RETURNING"),
+				 parser_errposition(pstate,
+									locate_windowfunc((Node *) rlist))));
 
 	/* no new relation references please */
 	if (list_length(pstate->p_rtable) != length_rtable)

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -457,11 +457,12 @@ transformWindowClause(ParseState *pstate, Query *qry)
 
 		clauseno++;
 
-		if (checkExprHasWindowFuncs((Node *)ws))
+		if (checkExprHasWindowFuncs((Node *) ws))
 			ereport(ERROR,
-					(errcode(ERRCODE_SYNTAX_ERROR),
+					(errcode(ERRCODE_WINDOWING_ERROR),
 					 errmsg("cannot use window function in a window specification"),
-					 parser_errposition(pstate, ws->location)));
+					 parser_errposition(pstate,
+										locate_windowfunc((Node *) ws))));
 
 		/*
 		 * Loop through those clauses we've already processed to

--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -2271,7 +2271,8 @@ transformPercentileExpr(ParseState *pstate, PercentileExpr *p)
 		ereport(ERROR,
 				(errcode(ERRCODE_GROUPING_ERROR),
 				 errmsg("argument of percentile function must not contain window functions"),
-				 parser_errposition(pstate, exprLocation(arg))));
+				 parser_errposition(pstate,
+									locate_windowfunc(arg))));
 	if (checkExprHasGroupExtFuncs(arg))
 		ereport(ERROR,
 				(errcode(ERRCODE_GROUPING_ERROR),
@@ -2479,7 +2480,8 @@ transformPercentileExpr(ParseState *pstate, PercentileExpr *p)
 			ereport(ERROR,
 					(errcode(ERRCODE_GROUPING_ERROR),
 					 errmsg("argument of percentile function must not contain window functions"),
-					 parser_errposition(pstate, exprLocation((Node *) p->sortTargets))));
+					 parser_errposition(pstate,
+										locate_windowfunc((Node *) p->sortTargets))));
 		if (checkExprHasGroupExtFuncs((Node *) p->sortTargets))
 			ereport(ERROR,
 					(errcode(ERRCODE_GROUPING_ERROR),

--- a/src/include/rewrite/rewriteManip.h
+++ b/src/include/rewrite/rewriteManip.h
@@ -38,6 +38,7 @@ extern void AddQual(Query *parsetree, Node *qual);
 extern void AddInvertedQual(Query *parsetree, Node *qual);
 
 extern int	locate_agg_of_level(Node *node, int levelsup);
+extern int	locate_windowfunc(Node *node);
 extern bool checkExprHasAggs(Node *node);
 extern bool checkExprHasWindowFuncs(Node *node);
 extern bool checkExprHasSubLink(Node *node);

--- a/src/test/regress/expected/olap_window_seq.out
+++ b/src/test/regress/expected/olap_window_seq.out
@@ -7643,6 +7643,8 @@ ERROR:  cannot use window function in transform expression
 insert into wintest_for_window_seq values(1);
 update wintest_for_window_seq set i = count(*) over (order by i);
 ERROR:  cannot use window function in UPDATE
+LINE 1: update wintest_for_window_seq set i = count(*) over (order b...
+                                              ^
 -- domain suport
 create domain wintestd as int default count(*) over ();
 ERROR:  cannot use window function in default expression

--- a/src/test/regress/expected/olap_window_seq_optimizer.out
+++ b/src/test/regress/expected/olap_window_seq_optimizer.out
@@ -7645,6 +7645,8 @@ ERROR:  cannot use window function in transform expression
 insert into wintest_for_window_seq values(1);
 update wintest_for_window_seq set i = count(*) over (order by i);
 ERROR:  cannot use window function in UPDATE
+LINE 1: update wintest_for_window_seq set i = count(*) over (order b...
+                                              ^
 -- domain suport
 create domain wintestd as int default count(*) over ();
 ERROR:  cannot use window function in default expression

--- a/src/test/regress/expected/percentile.out
+++ b/src/test/regress/expected/percentile.out
@@ -1038,11 +1038,11 @@ LINE 1: select count(median(a)) from perct;
 select median(count(*)) from perct;
 ERROR:  argument of percentile function must not contain aggregates
 LINE 1: select median(count(*)) from perct;
-               ^
+                      ^
 select percentile_cont(0.2) within group (order by count(*) over()) from perct;
 ERROR:  argument of percentile function must not contain window functions
-LINE 1: select percentile_cont(0.2) within group (order by count(*) ...
-               ^
+LINE 1: ...elect percentile_cont(0.2) within group (order by count(*) o...
+                                                             ^
 select percentile_disc(0.1) within group (order by group_id()) from perct;
 ERROR:  argument of percentile function must not contain grouping(), or group_id()
 LINE 1: select percentile_disc(0.1) within group (order by group_id(...

--- a/src/test/regress/expected/qp_functions_idf.out
+++ b/src/test/regress/expected/qp_functions_idf.out
@@ -676,8 +676,8 @@ ERROR:  window OVER clause can only be used with an aggregate
 -- SQL with IDF , aggregate func and over clause within IDF : ERROR
 select percentile_cont(0.2) within group (order by stddev(b) over() ) from perct;
 ERROR:  argument of percentile function must not contain window functions
-LINE 1: select percentile_cont(0.2) within group (order by stddev(b)...
-               ^
+LINE 1: ...elect percentile_cont(0.2) within group (order by stddev(b) ...
+                                                             ^
 select median(avg(a) over()) from perct;
 ERROR:  argument of percentile function must not contain window functions
 LINE 1: select median(avg(a) over()) from perct;


### PR DESCRIPTION
This allows having error positions for more syntax errors, and reduces
the diff footprint of our window functions implementation against the
one in PostgreSQL 8.4.