### PR TITLE
Replace redundant functions with contain_window_function() from PG 8.4

### DIFF
--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -1551,7 +1551,7 @@ qual_contains_winref(Query *topquery,
 										 subquery->targetList,
 										 CMD_SELECT, 0);
 
-		result = contain_windowref(qualNew, NULL);
+		result = contain_window_function(qualNew);
 		pfree(qualNew);
 	}
 

--- a/src/backend/optimizer/path/equivclass.c
+++ b/src/backend/optimizer/path/equivclass.c
@@ -468,7 +468,7 @@ get_eclass_for_sort_expr(PlannerInfo *root,
 		if (newec->ec_has_volatile ||
 			expression_returns_set((Node *) expr) ||
 			contain_agg_clause((Node *) expr) ||
-			contain_window_functions((Node *) expr))
+			contain_window_function((Node *) expr))
 		{
 			newec->ec_has_const = false;
 			newem->em_is_const = false;

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -1351,7 +1351,7 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 													  true);
 	}
 	else if ( parse->windowClause && parse->targetList &&
-			  contain_windowref((Node *)parse->targetList, NULL) )
+			  contain_window_function((Node *) parse->targetList) )
 	{
 		if (extract_nodes(NULL, (Node *) tlist, T_PercentileExpr) != NIL)
 		{

--- a/src/backend/optimizer/plan/planwindow.c
+++ b/src/backend/optimizer/plan/planwindow.c
@@ -4097,23 +4097,6 @@ Query *copy_common_subquery(Query *original, List *targetList)
 }
 
 /*
- * Return true if a node contains WindowRefs.
- *
- * 'context' is not used in this function.
- */
-bool
-contain_windowref(Node *node, void *context)
-{
-	if (node == NULL)
-		return false;
-	
-	if (IsA(node, WindowRef))
-		return true;
-	
-	return expression_tree_walker(node, contain_windowref, NULL);
-}
-
-/*
  * Does the given window frame edge contains an expression that must be
  * evaluated at run time (i.e., may contain a Var)?
  */

--- a/src/include/optimizer/clauses.h
+++ b/src/include/optimizer/clauses.h
@@ -17,6 +17,7 @@
 #include "nodes/relation.h"
 #include "optimizer/walkers.h"
 
+
 #define is_opclause(clause)		((clause) != NULL && IsA(clause, OpExpr))
 #define is_funcclause(clause)	((clause) != NULL && IsA(clause, FuncExpr))
 #define is_subplan(clause)		((clause) != NULL && IsA(clause, SubPlan))
@@ -71,6 +72,8 @@ extern List *make_ands_implicit(Expr *clause);
 extern bool contain_agg_clause(Node *clause);
 extern void count_agg_clauses(Node *clause, AggClauseCounts *counts);
 
+extern bool contain_window_function(Node *clause);
+
 extern bool expression_returns_set(Node *clause);
 extern double expression_returns_set_rows(Node *clause);
 
@@ -78,7 +81,6 @@ extern bool contain_subplans(Node *clause);
 
 extern bool contain_mutable_functions(Node *clause);
 extern bool contain_volatile_functions(Node *clause);
-extern bool contain_window_functions(Node *clause);
 extern bool contain_nonstrict_functions(Node *clause);
 extern Relids find_nonnullable_rels(Node *clause);
 

--- a/src/include/optimizer/planmain.h
+++ b/src/include/optimizer/planmain.h
@@ -100,7 +100,6 @@ extern Plan *make_distinctaggs_for_rollup(PlannerInfo *root, bool is_agg,
 extern Plan *window_planner(PlannerInfo *root, double tuple_fraction, List **pathkeys_ptr);
 extern RangeTblEntry *package_plan_as_rte(Query *query, Plan *plan, Alias *eref, List *pathkeys);
 extern Value *get_tle_name(TargetEntry *tle, List* rtable, const char *default_name);
-extern bool contain_windowref(Node *node, void *context);
 extern bool window_edge_is_delayed(WindowFrameEdge *edge);
 extern Plan *wrap_plan(PlannerInfo *root, Plan *plan, Query *query, List **p_pathkeys,
        const char *alias_name, List *col_names, Query **query_p);


### PR DESCRIPTION
We don't need two different functions to check whether an expression
contains a window function. Replace both with the variant used in
the upstream, contain_window_function().