### PR TITLE
resgroup: Allow concurrency to be zero.

### DIFF
--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -1147,8 +1147,6 @@ getSlot(ResGroupData *group)
 	caps = &group->caps;
 
 	/* First check if the concurrency limit is reached */
-	Assert(caps->concurrency.proposed > 0);
-
 	if (group->nRunning >= caps->concurrency.proposed)
 		return InvalidSlotId;
 
@@ -1255,11 +1253,21 @@ ResGroupSlotAcquire(void)
 
 	Assert(self->groupId == InvalidOid);
 
-	groupId = GetResGroupIdForRole(GetUserId());
-	if (groupId == InvalidOid)
-		groupId = superuser() ? ADMINRESGROUP_OID : DEFAULTRESGROUP_OID;
-
 retry:
+	/* always find out the up-to-date resgroup id */
+	PG_TRY();
+	{
+		groupId = GetResGroupIdForRole(GetUserId());
+		if (groupId == InvalidOid)
+			groupId = superuser() ? ADMINRESGROUP_OID : DEFAULTRESGROUP_OID;
+	}
+	PG_CATCH();
+	{
+		MyResGroupSharedInfo = NULL;
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
+
 	LWLockAcquire(ResGroupLock, LW_EXCLUSIVE);
 
 	group = ResGroupHashFind(groupId);
@@ -1287,6 +1295,7 @@ retry:
 	{
 		Assert(group->nRunning == 0);
 		ResGroupWait(group, true);
+		Assert(MyProc->resSlotId == InvalidSlotId);
 
 		/* retry if the drop resource group transaction is finished */
 		retried = true;
@@ -1301,35 +1310,32 @@ retry:
 
 		/* so try to get one directly */
 		MyProc->resSlotId = getSlot(group);
-
-		/* if can't get one */
-		if (MyProc->resSlotId == InvalidSlotId)
-		{
-			/* then wait one from some others */
-			ResGroupWait(group, true);
-			LWLockAcquire(ResGroupLock, LW_EXCLUSIVE);
-
-			Assert(MyProc->resSlotId != InvalidSlotId);
-		}
-
-		group->totalExecuted++;
-		LWLockRelease(ResGroupLock);
-		pgstat_report_resgroup(0, group->groupId);
-		Assert(MyProc->resSlotId != InvalidSlotId);
-		return MyProc->resSlotId;
 	}
 
-	/* We have to wait for the slot */
-	ResGroupWait(group, false);
+	/* if can't get one */
+	if (MyProc->resSlotId == InvalidSlotId)
+	{
+		/* then wait one from some others */
+		ResGroupWait(group, false);
+		LWLockAcquire(ResGroupLock, LW_EXCLUSIVE);
+		addTotalQueueDuration(group);
+	}
+
+	if (MyProc->resSlotId == InvalidSlotId)
+	{
+		/* the resource group might be dropped, retry */
+		LWLockRelease(ResGroupLock);
+		retried = true;
+		goto retry;
+	}
 
 	/*
 	 * The waking process has granted us the slot.
 	 * Update the statistic information of the resource group.
 	 */
-	LWLockAcquire(ResGroupLock, LW_EXCLUSIVE);
 	group->totalExecuted++;
-	addTotalQueueDuration(group);
 	LWLockRelease(ResGroupLock);
+	pgstat_report_resgroup(0, group->groupId);
 	Assert(MyProc->resSlotId != InvalidSlotId);
 	return MyProc->resSlotId;
 }
@@ -1684,7 +1690,7 @@ groupReleaseMemQuota(ResGroupData *group, ResGroupSlotData *slot)
 	memQuotaNeedFree = group->memQuotaGranted - groupGetMemQuotaExpected(caps);
 	memQuotaToFree = memQuotaNeedFree > 0 ? Min(memQuotaNeedFree, slot->memQuota) : 0;
 
-	if (caps->concurrency.proposed >= group->nRunning)
+	if (caps->concurrency.proposed > 0)
 	{
 		/*
 		 * Under this situation, when this slot is released,
@@ -2356,7 +2362,7 @@ ResGroupGetMemInfo(int *memLimit, int *slotQuota, int *sharedQuota)
 	const ResGroupCaps *caps = &self->caps;
 
 	*memLimit = groupGetMemExpected(caps);
-	*slotQuota = slotGetMemQuotaExpected(caps);
+	*slotQuota = caps->concurrency.proposed ? slotGetMemQuotaExpected(caps) : -1;
 	*sharedQuota = groupGetMemSharedExpected(caps);
 }
 

--- a/src/test/isolation2/expected/resgroup/resgroup_alter_concurrency.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_alter_concurrency.out
@@ -470,10 +470,214 @@ ALTER
 14q: ... <quitting>
 15q: ... <quitting>
 
+--
+-- 8. increase concurrency from 0
+--
+DROP ROLE role_concurrency_test;
+DROP
+DROP RESOURCE GROUP rg_concurrency_test;
+DROP
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=0, cpu_rate_limit=20, memory_limit=60, memory_shared_quota=0, memory_spill_ratio=10);
+CREATE
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+CREATE
+
+11:SET ROLE role_concurrency_test;
+SET
+11&:BEGIN;  <waiting ...>
+SELECT * FROM rg_activity_status;
+rsgname            |waiting_reason|current_query
+-------------------+--------------+-------------
+rg_concurrency_test|resgroup      |BEGIN;       
+(1 row)
+
+ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 1;
+ALTER
+
+11<:  <... completed>
+BEGIN
+SELECT * FROM rg_activity_status;
+rsgname            |waiting_reason|current_query        
+-------------------+--------------+---------------------
+rg_concurrency_test|              |<IDLE> in transaction
+(1 row)
+
+11:END;
+END
+11q: ... <quitting>
+
+--
+-- 9.1 decrease concurrency to 0,
+-- without running queries,
+-- without pending queries.
+--
+
+ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 1;
+ALTER
+SELECT * FROM rg_activity_status;
+rsgname|waiting_reason|current_query
+-------+--------------+-------------
+(0 rows)
+
+ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 0;
+ALTER
+SELECT * FROM rg_activity_status;
+rsgname|waiting_reason|current_query
+-------+--------------+-------------
+(0 rows)
+
+--
+-- 9.2 decrease concurrency to 0,
+-- with running queries,
+-- without pending queries.
+--
+
+ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 1;
+ALTER
+SELECT * FROM rg_activity_status;
+rsgname|waiting_reason|current_query
+-------+--------------+-------------
+(0 rows)
+
+11:SET ROLE role_concurrency_test;
+SET
+11:BEGIN;
+BEGIN
+SELECT * FROM rg_activity_status;
+rsgname            |waiting_reason|current_query        
+-------------------+--------------+---------------------
+rg_concurrency_test|              |<IDLE> in transaction
+(1 row)
+
+ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 0;
+ALTER
+SELECT * FROM rg_activity_status;
+rsgname            |waiting_reason|current_query        
+-------------------+--------------+---------------------
+rg_concurrency_test|              |<IDLE> in transaction
+(1 row)
+
+11:END;
+END
+11q: ... <quitting>
+
+--
+-- 9.3 decrease concurrency to 0,
+-- with running queries,
+-- with pending queries.
+--
+
+ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 1;
+ALTER
+SELECT * FROM rg_activity_status;
+rsgname|waiting_reason|current_query
+-------+--------------+-------------
+(0 rows)
+
+11:SET ROLE role_concurrency_test;
+SET
+11:BEGIN;
+BEGIN
+12:SET ROLE role_concurrency_test;
+SET
+12&:BEGIN;  <waiting ...>
+SELECT * FROM rg_activity_status;
+rsgname            |waiting_reason|current_query        
+-------------------+--------------+---------------------
+rg_concurrency_test|              |<IDLE> in transaction
+rg_concurrency_test|resgroup      |BEGIN;               
+(2 rows)
+
+ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 0;
+ALTER
+SELECT * FROM rg_activity_status;
+rsgname            |waiting_reason|current_query        
+-------------------+--------------+---------------------
+rg_concurrency_test|              |<IDLE> in transaction
+rg_concurrency_test|resgroup      |BEGIN;               
+(2 rows)
+
+11:END;
+END
+11q: ... <quitting>
+SELECT * FROM rg_activity_status;
+rsgname            |waiting_reason|current_query
+-------------------+--------------+-------------
+rg_concurrency_test|resgroup      |BEGIN;       
+(1 row)
+
+SELECT pg_cancel_backend(procpid) FROM pg_stat_activity WHERE waiting_reason='resgroup' AND rsgname='rg_concurrency_test';
+pg_cancel_backend
+-----------------
+t                
+(1 row)
+12<:  <... completed>
+ERROR:  canceling statement due to user request
+12q: ... <quitting>
+SELECT * FROM rg_activity_status;
+rsgname|waiting_reason|current_query
+-------+--------------+-------------
+(0 rows)
+
+-- 10: drop a resgroup with concurrency=0 and pending queries
+DROP ROLE IF EXISTS role_concurrency_test;
+DROP
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+DROP
+-- end_ignore
+
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=0, cpu_rate_limit=20, memory_limit=20);
+CREATE
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+CREATE
+61:SET ROLE role_concurrency_test;
+SET
+61&:BEGIN;  <waiting ...>
+
+ALTER ROLE role_concurrency_test RESOURCE GROUP none;
+ALTER
+DROP RESOURCE GROUP rg_concurrency_test;
+DROP
+
+61<:  <... completed>
+BEGIN
+61:END;
+END
+61q: ... <quitting>
+
+-- 11: drop a role with concurrency=0 and pending queries
+DROP ROLE IF EXISTS role_concurrency_test;
+DROP
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+ERROR:  resource group "rg_concurrency_test" does not exist
+-- end_ignore
+
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=0, cpu_rate_limit=20, memory_limit=20);
+CREATE
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+CREATE
+61:SET ROLE role_concurrency_test;
+SET
+61&:BEGIN;  <waiting ...>
+
+DROP ROLE role_concurrency_test;
+DROP
+DROP RESOURCE GROUP rg_concurrency_test;
+DROP
+
+61<:  <... completed>
+ERROR:  Role with Oid 213301 was dropped
+HINT:  Cannot execute commands anymore, please terminate this session.
+61q: ... <quitting>
+
 -- cleanup
+-- start_ignore
 DROP VIEW rg_activity_status;
 DROP
 DROP ROLE role_concurrency_test;
 DROP
 DROP RESOURCE GROUP rg_concurrency_test;
-DROP
+ERROR:  resource group "rg_concurrency_test" does not exist
+-- end_ignore

--- a/src/test/isolation2/expected/resgroup/resgroup_concurrency.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_concurrency.out
@@ -338,6 +338,34 @@ DROP
 DROP RESOURCE GROUP rg_concurrency_test;
 DROP
 
+-- test8: create a resgroup with concurrency=0
+DROP ROLE IF EXISTS role_concurrency_test;
+DROP
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+ERROR:  resource group "rg_concurrency_test" does not exist
+-- end_ignore
+
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=0, cpu_rate_limit=20, memory_limit=20);
+CREATE
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+CREATE
+61:SET ROLE role_concurrency_test;
+SET
+61&:BEGIN;  <waiting ...>
+SELECT pg_cancel_backend(procpid) FROM pg_stat_activity WHERE waiting_reason='resgroup' AND rsgname='rg_concurrency_test';
+pg_cancel_backend
+-----------------
+t                
+(1 row)
+61<:  <... completed>
+ERROR:  canceling statement due to user request
+61q: ... <quitting>
+DROP ROLE role_concurrency_test;
+DROP
+DROP RESOURCE GROUP rg_concurrency_test;
+DROP
+
 --
 -- Test cursors, pl/* functions only take one slot.
 --

--- a/src/test/isolation2/expected/resgroup/resgroup_parallel_queries.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_parallel_queries.out
@@ -171,6 +171,10 @@ create table rg_test_foo as select i as c1, i as c2 from generate_series(1,1000)
 CREATE 1000
 create table rg_test_bar as select i as c1, i as c2 from generate_series(1,1000) i;
 CREATE 1000
+grant all on rg_test_foo to public;
+GRANT
+grant all on rg_test_bar to public;
+GRANT
 
 -- start_ignore
 select dblink_connect('dblink_rg_test', 'dbname=isolation2resgrouptest');
@@ -285,7 +289,7 @@ dblink_connect
 --------------
 OK            
 (1 row)
-31>: select exec_commands_n('dblink_rg_test31', 'alter resource group rg_test_g% set concurrency #', '', '', 1000, '1-6', '1-5', true);  <waiting ...>
+31>: select exec_commands_n('dblink_rg_test31', 'alter resource group rg_test_g% set concurrency #', 'select 1 from pg_sleep(0.1)', '', 1000, '1-6', '0-5', true);  <waiting ...>
 
 -- start a new session to alter cpu_rate_limit randomly
 32: select dblink_connect('dblink_rg_test32', 'dbname=isolation2resgrouptest');
@@ -293,7 +297,7 @@ dblink_connect
 --------------
 OK            
 (1 row)
-32>: select exec_commands_n('dblink_rg_test32', 'alter resource group rg_test_g% set cpu_rate_limit #', '', '', 1000, '1-6', '1-6', true);  <waiting ...>
+32>: select exec_commands_n('dblink_rg_test32', 'alter resource group rg_test_g% set cpu_rate_limit #', 'select 1 from pg_sleep(0.1)', '', 1000, '1-6', '1-6', true);  <waiting ...>
 
 -- start a new session to alter memory_limit randomly
 33: select dblink_connect('dblink_rg_test33', 'dbname=isolation2resgrouptest');
@@ -301,7 +305,7 @@ dblink_connect
 --------------
 OK            
 (1 row)
-33>: select exec_commands_n('dblink_rg_test33', 'alter resource group rg_test_g% set memory_limit #', '', '', 1000, '1-6', '1-7', true);  <waiting ...>
+33>: select exec_commands_n('dblink_rg_test33', 'alter resource group rg_test_g% set memory_limit #', 'select 1 from pg_sleep(0.1)', '', 1000, '1-6', '1-7', true);  <waiting ...>
 
 -- start a new session to alter memory_shared_quota randomly
 34: select dblink_connect('dblink_rg_test34', 'dbname=isolation2resgrouptest');
@@ -309,7 +313,7 @@ dblink_connect
 --------------
 OK            
 (1 row)
-34>: select exec_commands_n('dblink_rg_test34', 'alter resource group rg_test_g% set memory_shared_quota #', '', '', 1000, '1-6', '1-80', true);  <waiting ...>
+34>: select exec_commands_n('dblink_rg_test34', 'alter resource group rg_test_g% set memory_shared_quota #', 'select 1 from pg_sleep(0.1)', '', 1000, '1-6', '1-80', true);  <waiting ...>
 
 --
 -- 4* : CREATE/DROP tables & groups
@@ -330,8 +334,16 @@ OK
 (1 row)
 42>: select exec_commands_n('dblink_rg_test42', 'create resource group rg_test_g7 with (cpu_rate_limit=1, memory_limit=1)', 'drop resource group rg_test_g7', '', 1000, '', '', true);  <waiting ...>
 
--- start a new session to drop a resource group with running queries, it will failed because a role is associated with the resource group.
-43>: drop resource group rg_test_g3;  <waiting ...>
+31<:  <... completed>
+exec_commands_n
+---------------
+1000           
+(1 row)
+31: select exec_commands_n('dblink_rg_test31', 'alter resource group rg_test_g% set concurrency #', 'select 1 from pg_sleep(0.1)', '', 6, '1-6', '1-5', true);
+exec_commands_n
+---------------
+6              
+(1 row)
 
 -- start a new session to acquire the status of resource groups
 44: select dblink_connect('dblink_rg_test44', 'dbname=isolation2resgrouptest');
@@ -372,11 +384,6 @@ exec_commands_n
 ---------------
 6000           
 (1 row)
-31<:  <... completed>
-exec_commands_n
----------------
-1000           
-(1 row)
 32<:  <... completed>
 exec_commands_n
 ---------------
@@ -402,8 +409,6 @@ exec_commands_n
 ---------------
 1000           
 (1 row)
-43<:  <... completed>
-ERROR:  resource group "rg_test_g3" is used by at least one role
 44<:  <... completed>
 exec_commands_n
 ---------------
@@ -488,7 +493,6 @@ OK
 34q: ... <quitting>
 41q: ... <quitting>
 42q: ... <quitting>
-43q: ... <quitting>
 
 select groupname, concurrency::int < 7, cpu_rate_limit::int < 7 from gp_toolkit.gp_resgroup_config where groupname like 'rg_test_g%' order by groupname;
 groupname |?column?|?column?

--- a/src/test/isolation2/expected/resgroup/resgroup_syntax.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_syntax.out
@@ -166,13 +166,9 @@ CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=1.9);
 ERROR:  invalid input syntax for integer: "1.9"
 -- negative: concurrency should be in [1, max_connections]
 CREATE RESOURCE GROUP rg_test_group WITH (concurrency=-1, cpu_rate_limit=10, memory_limit=10);
-ERROR:  concurrency range is [1, 'max_connections']
-CREATE RESOURCE GROUP rg_test_group WITH (concurrency=0, cpu_rate_limit=10, memory_limit=10);
-ERROR:  concurrency range is [1, 'max_connections']
+ERROR:  concurrency range is [0, 'max_connections']
 CREATE RESOURCE GROUP rg_test_group WITH (concurrency=26, cpu_rate_limit=10, memory_limit=10);
-ERROR:  concurrency range is [1, 'max_connections']
-CREATE RESOURCE GROUP rg_test_group WITH (concurrency=26, cpu_rate_limit=10, memory_limit=10);
-ERROR:  concurrency range is [1, 'max_connections']
+ERROR:  concurrency range is [0, 'max_connections']
 
 -- memory_spill_ratio range is [0, 100]
 -- no limit on the sum of memory_shared_quota and memory_spill_ratio
@@ -206,7 +202,11 @@ CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=1);
 CREATE
 DROP RESOURCE GROUP rg_test_group;
 DROP
--- positive: concurrency should be in [1, max_connections]
+-- positive: concurrency should be in [0, max_connections]
+CREATE RESOURCE GROUP rg_test_group WITH (concurrency=0, cpu_rate_limit=10, memory_limit=10);
+CREATE
+DROP RESOURCE GROUP rg_test_group;
+DROP
 CREATE RESOURCE GROUP rg_test_group WITH (concurrency=1, cpu_rate_limit=10, memory_limit=10);
 CREATE
 DROP RESOURCE GROUP rg_test_group;
@@ -267,10 +267,10 @@ CREATE
 
 -- ALTER RESOURCE GROUP SET CONCURRENCY N
 -- negative: concurrency should be in [1, max_connections]
-ALTER RESOURCE GROUP rg_test_group SET CONCURRENCY 0;
-ERROR:  concurrency limit cannot be less than 1
+ALTER RESOURCE GROUP admin_group SET CONCURRENCY 0;
+ERROR:  admin_group must have at least one concurrency
 ALTER RESOURCE GROUP rg_test_group SET CONCURRENCY -1;
-ERROR:  concurrency limit cannot be less than 1
+ERROR:  concurrency limit cannot be less than 0
 ALTER RESOURCE GROUP rg_test_group SET CONCURRENCY 26;
 ERROR:  concurrency limit cannot be greater than 'max_connections'
 ALTER RESOURCE GROUP rg_test_group SET CONCURRENCY -0.5;
@@ -294,6 +294,8 @@ ERROR:  syntax error at or near "'1'"
 LINE 1: ALTER RESOURCE GROUP rg_test_group SET CONCURRENCY '1';
                                                            ^
 -- positive: concurrency should be in [1, max_connections]
+ALTER RESOURCE GROUP rg_test_group SET CONCURRENCY 0;
+ALTER
 ALTER RESOURCE GROUP rg_test_group SET CONCURRENCY 1;
 ALTER
 ALTER RESOURCE GROUP rg_test_group SET CONCURRENCY 2;

--- a/src/test/isolation2/init_file_resgroup
+++ b/src/test/isolation2/init_file_resgroup
@@ -14,4 +14,7 @@ s/group [0-9]+ was/group OID was/
 
 m/^ERROR:  Out of memory  (seg\d slice\d \d+.\d+.\d+.\d+:\d+ pid=\d+)$/
 s/(seg\d+ slice\d+ \d+.\d+.\d+.\d+:\d+ pid=\d+)/(SEG SLICE ADDR:PORT pid=PID)/
+
+m/^ERROR:  Role with Oid \d+ was dropped$/
+s/Oid \d+ was/Oid OID was/
 -- end_matchsubs

--- a/src/test/isolation2/sql/resgroup/resgroup_concurrency.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_concurrency.sql
@@ -171,6 +171,22 @@ SELECT pg_terminate_backend(procpid) FROM pg_stat_activity WHERE waiting_reason=
 DROP ROLE role_concurrency_test;
 DROP RESOURCE GROUP rg_concurrency_test;
 
+-- test8: create a resgroup with concurrency=0
+DROP ROLE IF EXISTS role_concurrency_test;
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+-- end_ignore
+
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=0, cpu_rate_limit=20, memory_limit=20);
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+61:SET ROLE role_concurrency_test;
+61&:BEGIN;
+SELECT pg_cancel_backend(procpid) FROM pg_stat_activity WHERE waiting_reason='resgroup' AND rsgname='rg_concurrency_test';
+61<:
+61q:
+DROP ROLE role_concurrency_test;
+DROP RESOURCE GROUP rg_concurrency_test;
+
 --
 -- Test cursors, pl/* functions only take one slot.
 --

--- a/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
@@ -89,8 +89,6 @@ CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0.9);
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=1.9);
 -- negative: concurrency should be in [1, max_connections]
 CREATE RESOURCE GROUP rg_test_group WITH (concurrency=-1, cpu_rate_limit=10, memory_limit=10);
-CREATE RESOURCE GROUP rg_test_group WITH (concurrency=0, cpu_rate_limit=10, memory_limit=10);
-CREATE RESOURCE GROUP rg_test_group WITH (concurrency=26, cpu_rate_limit=10, memory_limit=10);
 CREATE RESOURCE GROUP rg_test_group WITH (concurrency=26, cpu_rate_limit=10, memory_limit=10);
 
 -- memory_spill_ratio range is [0, 100]
@@ -111,7 +109,9 @@ CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=1, memory_limit=10);
 DROP RESOURCE GROUP rg_test_group;
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=1);
 DROP RESOURCE GROUP rg_test_group;
--- positive: concurrency should be in [1, max_connections]
+-- positive: concurrency should be in [0, max_connections]
+CREATE RESOURCE GROUP rg_test_group WITH (concurrency=0, cpu_rate_limit=10, memory_limit=10);
+DROP RESOURCE GROUP rg_test_group;
 CREATE RESOURCE GROUP rg_test_group WITH (concurrency=1, cpu_rate_limit=10, memory_limit=10);
 DROP RESOURCE GROUP rg_test_group;
 CREATE RESOURCE GROUP rg_test_group WITH (concurrency=25, cpu_rate_limit=10, memory_limit=10);
@@ -147,7 +147,7 @@ CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=5, memory_limit=5);
 
 -- ALTER RESOURCE GROUP SET CONCURRENCY N
 -- negative: concurrency should be in [1, max_connections]
-ALTER RESOURCE GROUP rg_test_group SET CONCURRENCY 0;
+ALTER RESOURCE GROUP admin_group SET CONCURRENCY 0;
 ALTER RESOURCE GROUP rg_test_group SET CONCURRENCY -1;
 ALTER RESOURCE GROUP rg_test_group SET CONCURRENCY 26;
 ALTER RESOURCE GROUP rg_test_group SET CONCURRENCY -0.5;
@@ -156,6 +156,7 @@ ALTER RESOURCE GROUP rg_test_group SET CONCURRENCY a;
 ALTER RESOURCE GROUP rg_test_group SET CONCURRENCY 'abc';
 ALTER RESOURCE GROUP rg_test_group SET CONCURRENCY '1';
 -- positive: concurrency should be in [1, max_connections]
+ALTER RESOURCE GROUP rg_test_group SET CONCURRENCY 0;
 ALTER RESOURCE GROUP rg_test_group SET CONCURRENCY 1;
 ALTER RESOURCE GROUP rg_test_group SET CONCURRENCY 2;
 ALTER RESOURCE GROUP rg_test_group SET CONCURRENCY 25;


### PR DESCRIPTION
Allow CREATE RESOURCE GROUP and ALTER RESOURCE GROUP to set concurrency
to 0, so there will eventually be no running queries after some time, so
the resource group can be dropped. On drop all pending queries will be
canceled.

Signed-off-by: Ning Yu <nyu@pivotal.io>