### PR TITLE
Simplify tuple serialization in Motion nodes.

### DIFF
--- a/src/include/cdb/tupser.h
+++ b/src/include/cdb/tupser.h
@@ -21,19 +21,6 @@
 #include "cdb/tupleremap.h"
 
 
-/* Define this to pack the NULLs-mask into the minimum number of bytes
- * possible.  If undefined, the NULLs-sequence is sent as one character per
- * attribute.
- */
-#undef TUPSER_BITPACK_NULLMASK
-
-/* Define this to allocate scratch-space for varlena attribute-values, so that
- * tuple-deserialization doesn't have to allocate space if the varlena's value
- * is smaller than the scratch size.
- */
-#undef TUPSER_SCRATCH_SPACE
-#define VARLEN_SCRATCH_SIZE 500
-
 typedef struct MotionConn MotionConn;
 
 /*
@@ -53,21 +40,8 @@ typedef struct MotionConn MotionConn;
 typedef struct SerAttrInfo
 {
 	Oid			atttypid;		/* Oid of the attribute's data-type. */
-	bool		typisvarlena;	/* is type varlena (ie possibly toastable)? */
-
-	Oid			typsend;		/* Oid for the type's binary output fn */
-	Oid			send_typio_param;		/* param to pass to the output fn */
-	FmgrInfo	send_finfo;		/* Precomputed call info for output fn */
-
-	Oid			typrecv;		/* Oid for the type's binary input fn */
-	Oid			recv_typio_param;		/* param to pass to the input fn */
-	FmgrInfo	recv_finfo;		/* Precomputed call info for output fn */
-
-#ifdef TUPSER_SCRATCH_SPACE
-	void	   *pv_varlen_scratch;		/* For deserializing varlena
-										 * attributes. */
-	int			varlen_scratch_size;	/* Size of varlena scratch space. */
-#endif
+	int16		typlen;
+	bool		typbyval;
 }	SerAttrInfo;
 
 /* The information for sending and receiving tuples that match a particular

--- a/src/test/regress/expected/tuple_serialization.out
+++ b/src/test/regress/expected/tuple_serialization.out
@@ -1,0 +1,32 @@
+-- Check if motion layer correctly serialize & deserialize tuples in particular cases
+CREATE TYPE incomplete_type;
+CREATE FUNCTION incomplete_type_in(cstring)
+   RETURNS incomplete_type
+   AS 'textin'
+   LANGUAGE internal IMMUTABLE STRICT;
+NOTICE:  return type incomplete_type is only a shell
+CREATE FUNCTION incomplete_type_out(incomplete_type)
+   RETURNS cstring
+   AS 'textout'
+   LANGUAGE internal IMMUTABLE STRICT;
+NOTICE:  argument type incomplete_type is only a shell
+CREATE TYPE incomplete_type (
+   internallength = variable,
+   input = incomplete_type_in,
+   output = incomplete_type_out,
+   alignment = double,
+   storage = EXTENDED,
+   default = 'zippo'
+);
+CREATE TABLE table_with_incomplete_type (id int, incomplete incomplete_type);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO table_with_incomplete_type(id, incomplete) VALUES(1, repeat('abcde', 1000000)::incomplete_type);
+-- Turn off output temporarily as the output is quite large
+\o /dev/null
+SELECT * FROM table_with_incomplete_type;
+\o
+DROP TABLE table_with_incomplete_type;
+DROP TYPE incomplete_type CASCADE;
+NOTICE:  drop cascades to function incomplete_type_out(incomplete_type)
+NOTICE:  drop cascades to function incomplete_type_in(cstring)

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -105,6 +105,8 @@ test: aggregate_with_groupingsets
 test: nested_case_null sort bb_mpph
 test: bb_memory_quota memconsumption
 
+test: tuple_serialization
+
 # NOTE: The bfv_temp test assumes that there are no temporary tables in
 # other sessions. Therefore the other tests in this group mustn't create
 # temp tables

--- a/src/test/regress/sql/tuple_serialization.sql
+++ b/src/test/regress/sql/tuple_serialization.sql
@@ -1,0 +1,31 @@
+-- Check if motion layer correctly serialize & deserialize tuples in particular cases
+CREATE TYPE incomplete_type;
+
+CREATE FUNCTION incomplete_type_in(cstring)
+   RETURNS incomplete_type
+   AS 'textin'
+   LANGUAGE internal IMMUTABLE STRICT;
+CREATE FUNCTION incomplete_type_out(incomplete_type)
+   RETURNS cstring
+   AS 'textout'
+   LANGUAGE internal IMMUTABLE STRICT;
+
+CREATE TYPE incomplete_type (
+   internallength = variable,
+   input = incomplete_type_in,
+   output = incomplete_type_out,
+   alignment = double,
+   storage = EXTENDED,
+   default = 'zippo'
+);
+
+CREATE TABLE table_with_incomplete_type (id int, incomplete incomplete_type);
+INSERT INTO table_with_incomplete_type(id, incomplete) VALUES(1, repeat('abcde', 1000000)::incomplete_type);
+
+-- Turn off output temporarily as the output is quite large
+\o /dev/null
+SELECT * FROM table_with_incomplete_type;
+\o
+
+DROP TABLE table_with_incomplete_type;
+DROP TYPE incomplete_type CASCADE;


### PR DESCRIPTION
* Simplify tuple serialization in Motion nodes.

There is a fast-path for tuples that contain no toasted attributes,
which writes the raw tuple almost as is. However, the slow path is
significantly more complicated, calling each attribute's binary
send/receive functions (although there's a fast-path for a few
built-in datatypes). I don't see any need for calling I/O functions
here. We can just write the raw Datum on the wire. If that works
for tuples with no toasted attributes, it should work for all tuples,
if we just detoast any toasted attributes first.

This makes the code a lot simpler, and also fixes a bug with data
types that don't have a binary send/receive routines. We used to
call the regular (text) I/O functions in that case, but didn't handle
the resulting cstring correctly.

Diagnosis and test case by Foyzur Rahman.

Signed-off-by: Haisheng Yuan <hyuan@pivotal.io>
Signed-off-by: Ning Yu <nyu@pivotal.io>