### PR TITLE
Refactor the way seqserver host and port are stored.

### DIFF
--- a/src/backend/cdb/motion/ic_common.c
+++ b/src/backend/cdb/motion/ic_common.c
@@ -62,9 +62,9 @@ int		TCP_listenerFd;
 int		UDP_listenerFd;
 
 /* Socket file descriptor for the sequence server. */
-int		savedSeqServerFd = -1;
-char	*savedSeqServerHost = NULL;
-uint16	savedSeqServerPort = 0;
+static int	savedSeqServerFd = -1;
+static char *savedSeqServerHost = NULL;
+static uint16 savedSeqServerPort = 0;
 
 /*=========================================================================
  * FUNCTIONS PROTOTYPES

--- a/src/backend/commands/portalcmds.c
+++ b/src/backend/commands/portalcmds.c
@@ -37,8 +37,6 @@
 #include "cdb/cdbvars.h"
 #include "postmaster/backoff.h"
 
-extern char *savedSeqServerHost;
-extern int savedSeqServerPort;
 
 /*
  * PerformCursorOpen
@@ -169,8 +167,7 @@ PerformCursorOpen(PlannedStmt *stmt, ParamListInfo params,
 	/*
 	 * Start execution, inserting parameters if any.
 	 */
-	PortalStart(portal, params, ActiveSnapshot,
-				savedSeqServerHost, savedSeqServerPort, NULL);
+	PortalStart(portal, params, ActiveSnapshot, NULL);
 
 	Assert(portal->strategy == PORTAL_ONE_SELECT);
 

--- a/src/backend/commands/prepare.c
+++ b/src/backend/commands/prepare.c
@@ -35,9 +35,6 @@
 #include "utils/builtins.h"
 #include "utils/memutils.h"
 
-extern char *savedSeqServerHost;
-extern int savedSeqServerPort;
-
 /*
  * The hash table in which prepared queries are stored. This is
  * per-backend: query plans are not shared between backends.
@@ -299,8 +296,7 @@ ExecuteQuery(ExecuteStmt *stmt, const char *queryString,
 	/*
 	 * Run the portal to completion.
 	 */
-	PortalStart(portal, paramLI, ActiveSnapshot,
-				savedSeqServerHost, savedSeqServerPort, NULL);
+	PortalStart(portal, paramLI, ActiveSnapshot, NULL);
 
 	(void) PortalRun(portal, FETCH_ALL, false, dest, dest, completionTag);
 

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -31,9 +31,6 @@
 #include "executor/functions.h"
 #include "cdb/memquota.h"
 
-extern char *savedSeqServerHost;
-extern int savedSeqServerPort;
-
 /*
  * Update the legacy 32-bit processed counter, but handle overflow.
  */
@@ -1275,8 +1272,7 @@ SPI_cursor_open_internal(const char *name, SPIPlanPtr plan,
 	/*
 	 * Start portal execution.
 	 */
-	PortalStart(portal, paramLI, snapshot,
-				savedSeqServerHost, savedSeqServerPort, NULL);
+	PortalStart(portal, paramLI, snapshot, NULL);
 
 	Assert(portal->strategy != PORTAL_MULTI_QUERY);
 

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -104,9 +104,6 @@
 extern int	optind;
 extern char *optarg;
 
-extern char *savedSeqServerHost;
-extern int savedSeqServerPort;
-
 /* ----------------
  *		global variables
  * ----------------
@@ -1355,11 +1352,13 @@ exec_mpp_query(const char *query_string,
 						  list_make1(plan ? (Node*)plan : (Node*)utilityStmt),
 						  NULL);
 
+		/* Set up the sequence server */
+		SetupSequenceServer(seqServerHost, seqServerPort);
+
 		/*
 		 * Start the portal.
 		 */
-		PortalStart(portal, paramLI, InvalidSnapshot,
-					seqServerHost, seqServerPort, ddesc);
+		PortalStart(portal, paramLI, InvalidSnapshot, ddesc);
 
 		/*
 		 * Select text output format, the default.
@@ -1766,11 +1765,13 @@ exec_simple_query(const char *query_string, const char *seqServerHost, int seqSe
 						  plantree_list,
 						  NULL);
 
+		/* Set up the sequence server */
+		SetupSequenceServer(seqServerHost, seqServerPort);
+
 		/*
 		 * Start the portal.  No parameters here.
 		 */
-		PortalStart(portal, NULL, InvalidSnapshot,
-					seqServerHost, seqServerPort, NULL);
+		PortalStart(portal, NULL, InvalidSnapshot, NULL);
 
 		/*
 		 * Select the appropriate output format: text unless we are doing a
@@ -2590,8 +2591,7 @@ exec_bind_message(StringInfo input_message)
 	/*
 	 * And we're ready to start portal execution.
 	 */
-	PortalStart(portal, params, InvalidSnapshot,
-				savedSeqServerHost, savedSeqServerPort, NULL);
+	PortalStart(portal, params, InvalidSnapshot, NULL);
 
 	/*
 	 * Apply the result format requests to the portal.

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -574,7 +574,7 @@ FetchStatementTargetList(Node *stmt)
  */
 void
 PortalStart(Portal portal, ParamListInfo params, Snapshot snapshot,
-			const char *seqServerHost, int seqServerPort, QueryDispatchDesc *ddesc)
+			QueryDispatchDesc *ddesc)
 {
 	Portal		saveActivePortal;
 	Snapshot	saveActiveSnapshot;
@@ -586,9 +586,6 @@ PortalStart(Portal portal, ParamListInfo params, Snapshot snapshot,
 
 	AssertArg(PortalIsValid(portal));
 	AssertState(portal->status == PORTAL_DEFINED);
-
-	/* Set up the sequence server */
-	SetupSequenceServer(seqServerHost, seqServerPort);
 
 	portal->releaseResLock = false;
     

--- a/src/include/tcop/pquery.h
+++ b/src/include/tcop/pquery.h
@@ -29,7 +29,6 @@ extern List *FetchStatementTargetList(Node *stmt);
 
 extern void PortalStart(Portal portal, ParamListInfo params,
 						Snapshot snapshot,
-						const char *seqServerHost, int seqServerPort,
 						QueryDispatchDesc *ddesc);
 
 extern void PortalSetResultFormat(Portal portal, int nFormats,


### PR DESCRIPTION
They're not really per-portal settings, so it doesn't make much sense
to pass them to PortalStart. And most of the callers were passing
savedSeqServerHost/Port anyway. Instead, set the "current" host and port
in postgres.c, when we receive them from the QD.