### PR TITLE
WIP: Backport FILTER implementation, from PostgreSQL 9.4 (commit b560ec1b0d).

### DIFF
--- a/doc/src/sgml/ref/select.sgml
+++ b/doc/src/sgml/ref/select.sgml
@@ -535,6 +535,11 @@ GROUP BY <replaceable class="parameter">expression</replaceable> [, ...]
     making up each group, producing a separate value for each group
     (whereas without <literal>GROUP BY</literal>, an aggregate
     produces a single value computed across all the selected rows).
+    The set of rows fed to the aggregate function can be further filtered by
+    attaching a <literal>FILTER</literal> clause to the aggregate function
+    call; see <xref linkend="syntax-aggregates"> for more information.  When
+    a <literal>FILTER</literal> clause is present, only those rows matching it
+    are included.
     When <literal>GROUP BY</literal> is present, it is not valid for
     the <command>SELECT</command> list expressions to refer to
     ungrouped columns except within aggregate functions, since there

--- a/src/backend/executor/execQual.c
+++ b/src/backend/executor/execQual.c
@@ -5224,6 +5224,7 @@ ExecInitExpr(Expr *node, PlanState *parent)
 			state->evalfunc = ExecEvalCaseTestExpr;
 			break;
 		case T_Aggref:
+
 			{
 				Aggref	   *aggref = (Aggref *) node;
 				AggrefExprState *astate = makeNode(AggrefExprState);
@@ -5249,6 +5250,8 @@ ExecInitExpr(Expr *node, PlanState *parent)
 							combineAggrefArgs(aggref, &astate->inputSortClauses);
 					astate->args = (List *) ExecInitExpr((Expr *) astate->inputTargets,
 														 parent);
+					astate->aggfilter = ExecInitExpr(aggref->aggfilter,
+													 parent);
 
 					/*
 					 * Complain if the aggregate's arguments contain any
@@ -5309,6 +5312,9 @@ ExecInitExpr(Expr *node, PlanState *parent)
 
 					wfstate->args = (List *) ExecInitExpr((Expr *) wfunc->args,
 														  parent);
+					wfstate->aggfilter = ExecInitExpr(wfunc->aggfilter,
+													  parent);
+
 					/*
 					 * Complain if the windowfunc's arguments contain any
 					 * windowfuncs; nested window functions are semantically

--- a/src/backend/executor/nodeWindow.c
+++ b/src/backend/executor/nodeWindow.c
@@ -2952,6 +2952,19 @@ add_tuple_to_trans(WindowStatePerFunction funcstate, WindowState * wstate,
 {
 	int			argno;
 	FunctionCallInfoData fcinfo;
+	ExprState  *filter = funcstate->wfuncstate->aggfilter;
+
+	/* Skip anything FILTERed out */
+	if (filter)
+	{
+		bool		isnull;
+		Datum		res;
+
+		res = ExecEvalExprSwitchContext(filter, econtext,
+										&isnull, NULL);
+		if (isnull || !DatumGetBool(res))
+			return;
+	}
 
 	/* Evaluate function arguments, save in fcinfo. */
 	argno = initFcinfo(funcstate->wfuncstate, &fcinfo, funcstate, econtext, check_nulls);

--- a/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
@@ -1340,6 +1340,12 @@ CTranslatorScalarToDXL::PdxlnScAggrefFromAggref
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLError, GPOS_WSZ_LIT("Aggregate functions with outer references"));
 	}
 
+	// ORCA doesn't support the FILTER clause yet.
+	if (paggref->aggfilter)
+	{
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("Aggregate functions with FILTER"));
+	}
+
 	IMDId *pmdidRetType = CScalarAggFunc::PmdidLookupReturnType(pmdidAgg, (EdxlaggstageNormal == edxlaggstage), m_pmda);
 	IMDId *pmdidResolvedRetType = NULL;
 	if (m_pmda->Pmdtype(pmdidRetType)->FAmbiguous())
@@ -1513,6 +1519,12 @@ CTranslatorScalarToDXL::PdxlnScWindowFunc
 		{WINSTAGE_PRELIMINARY, EdxlwinstagePreliminary},
 		{WINSTAGE_ROWKEY, EdxlwinstageRowKey},
 		};
+
+	// ORCA doesn't support the FILTER clause yet.
+	if (pwindowfunc->aggfilter)
+	{
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("Aggregate functions with FILTER"));
+	}
 
 	const ULONG ulArity = GPOS_ARRAY_SIZE(rgrgulMapping);
 	EdxlWinStage edxlwinstage = EdxlwinstageSentinel;

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -1424,11 +1424,12 @@ _copyAggref(Aggref *from)
 	COPY_SCALAR_FIELD(aggfnoid);
 	COPY_SCALAR_FIELD(aggtype);
 	COPY_NODE_FIELD(args);
-	COPY_SCALAR_FIELD(agglevelsup);
-	COPY_SCALAR_FIELD(aggstar);
+	COPY_NODE_FIELD(aggorder);
 	COPY_SCALAR_FIELD(aggdistinct);
+	COPY_NODE_FIELD(aggfilter);
+	COPY_SCALAR_FIELD(aggstar);
 	COPY_SCALAR_FIELD(aggstage);
-    COPY_NODE_FIELD(aggorder);
+	COPY_SCALAR_FIELD(agglevelsup);
 	COPY_LOCATION_FIELD(location);
 
 	return newnode;
@@ -1460,6 +1461,7 @@ _copyWindowFunc(WindowFunc *from)
 	COPY_SCALAR_FIELD(winfnoid);
 	COPY_SCALAR_FIELD(wintype);
 	COPY_NODE_FIELD(args);
+	COPY_NODE_FIELD(aggfilter);
 	COPY_SCALAR_FIELD(winref);
 	COPY_SCALAR_FIELD(winstar);
 	COPY_SCALAR_FIELD(winagg);

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -203,11 +203,13 @@ _equalAggref(Aggref *a, Aggref *b)
 	COMPARE_SCALAR_FIELD(aggfnoid);
 	COMPARE_SCALAR_FIELD(aggtype);
 	COMPARE_NODE_FIELD(args);
-	COMPARE_SCALAR_FIELD(agglevelsup);
-	COMPARE_SCALAR_FIELD(aggstar);
+	COMPARE_NODE_FIELD(aggorder);
 	COMPARE_SCALAR_FIELD(aggdistinct);
+	COMPARE_NODE_FIELD(aggfilter);
+	COMPARE_SCALAR_FIELD(aggstar);
 	COMPARE_SCALAR_FIELD(aggstage);
-    COMPARE_NODE_FIELD(aggorder);
+	COMPARE_SCALAR_FIELD(agglevelsup);
+	COMPARE_LOCATION_FIELD(location);
 
 	return true;
 }
@@ -228,6 +230,7 @@ _equalWindowFunc(WindowFunc *a, WindowFunc *b)
 	COMPARE_SCALAR_FIELD(winfnoid);
 	COMPARE_SCALAR_FIELD(wintype);
 	COMPARE_NODE_FIELD(args);
+	COMPARE_NODE_FIELD(aggfilter);
 	COMPARE_SCALAR_FIELD(winref);
 	COMPARE_SCALAR_FIELD(winstar);
 	COMPARE_SCALAR_FIELD(winagg);

--- a/src/backend/nodes/makefuncs.c
+++ b/src/backend/nodes/makefuncs.c
@@ -391,6 +391,7 @@ makeAggrefByOid(Oid aggfnoid, List *args)
 	aggref->aggdistinct = false;
 	aggref->aggstage = AGGSTAGE_NORMAL;
 	aggref->aggorder = NULL;
+	aggref->aggfilter = NULL;
 	aggref->location = -1;
 
 	return aggref;

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -569,6 +569,7 @@ _outAggref(StringInfo str, Aggref *node)
 	WRITE_UINT_FIELD(agglevelsup);
 	WRITE_BOOL_FIELD(aggstar);
 	WRITE_BOOL_FIELD(aggdistinct);
+	WRITE_NODE_FIELD(aggfilter);
 
 	WRITE_ENUM_FIELD(aggstage, AggStage);
     WRITE_NODE_FIELD(aggorder);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -1227,6 +1227,7 @@ _outAggref(StringInfo str, Aggref *node)
 	WRITE_UINT_FIELD(agglevelsup);
 	WRITE_BOOL_FIELD(aggstar);
 	WRITE_BOOL_FIELD(aggdistinct);
+	WRITE_NODE_FIELD(aggfilter);
 	WRITE_ENUM_FIELD(aggstage, AggStage);
 	WRITE_NODE_FIELD(aggorder);
 }
@@ -1250,6 +1251,7 @@ _outWindowFunc(StringInfo str, WindowFunc *node)
 	WRITE_OID_FIELD(winfnoid);
 	WRITE_OID_FIELD(wintype);
 	WRITE_NODE_FIELD(args);
+	WRITE_NODE_FIELD(aggfilter);
 	WRITE_UINT_FIELD(winref);
 	WRITE_BOOL_FIELD(winstar);
 	WRITE_BOOL_FIELD(winagg);

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -802,6 +802,7 @@ _readAggref(void)
 	READ_UINT_FIELD(agglevelsup);
 	READ_BOOL_FIELD(aggstar);
 	READ_BOOL_FIELD(aggdistinct);
+	READ_NODE_FIELD(aggfilter);
 	READ_ENUM_FIELD(aggstage, AggStage);
     READ_NODE_FIELD(aggorder);
 

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -1292,6 +1292,7 @@ _readAggref(void)
 	READ_UINT_FIELD(agglevelsup);
 	READ_BOOL_FIELD(aggstar);
 	READ_BOOL_FIELD(aggdistinct);
+	READ_NODE_FIELD(aggfilter);
 	READ_ENUM_FIELD(aggstage, AggStage);
 	READ_NODE_FIELD(aggorder);
 
@@ -1325,6 +1326,7 @@ _readWindowFunc(void)
 	READ_OID_FIELD(winfnoid);
 	READ_OID_FIELD(wintype);
 	READ_NODE_FIELD(args);
+	READ_NODE_FIELD(aggfilter);
 	READ_UINT_FIELD(winref);
 	READ_BOOL_FIELD(winstar);
 	READ_BOOL_FIELD(winagg);

--- a/src/backend/optimizer/plan/planagg.c
+++ b/src/backend/optimizer/plan/planagg.c
@@ -251,6 +251,14 @@ find_minmax_aggs_walker(Node *node, List **context)
 			return true;		/* it couldn't be MIN/MAX */
 		/* note: we do not care if DISTINCT is mentioned ... */
 
+		/*
+		 * We might implement the optimization when a FILTER clause is present
+		 * by adding the filter to the quals of the generated subquery.  For
+		 * now, just punt.
+		 */
+		if (aggref->aggfilter != NULL)
+			return true;
+
 		aggsortop = fetch_agg_sort_op(aggref->aggfnoid);
 		if (!OidIsValid(aggsortop))
 			return true;		/* not a MIN/MAX aggregate */

--- a/src/backend/optimizer/plan/planwindow.c
+++ b/src/backend/optimizer/plan/planwindow.c
@@ -3075,6 +3075,7 @@ static Aggref* makeWindowAggref(WindowFunc *winref)
 	aggref->aggstar = false; /* at this point in processing, doesn't matter */
 	aggref->aggdistinct = winref->windistinct;
 	aggref->aggstage = AGGSTAGE_NORMAL;
+	aggref->aggfilter = winref->aggfilter;
 	aggref->location = -1;
 
 	return aggref;
@@ -3710,9 +3711,14 @@ static Node * translate_upper_vars_sequential_mutator(Node *node, xuv_context *c
 		if ( ! ctxt->is_top_level )
 			elog(ERROR, "nested window reference invalid");		
 		ctxt->is_top_level = false;
-		
-		ref->args = (List*)expression_tree_mutator((Node*)ref->args, translate_upper_vars_sequential_mutator, (void*) ctxt);
-		
+
+		ref->args = (List *)expression_tree_mutator((Node *) ref->args,
+													translate_upper_vars_sequential_mutator,
+													ctxt);
+		ref->aggfilter = (Expr *) expression_tree_mutator((Node *) ref->aggfilter,
+														  translate_upper_vars_sequential_mutator,
+														  ctxt);
+
 		ctxt->is_top_level = true;
 		return (Node*)ref;
 	}

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -565,7 +565,8 @@ count_agg_clauses_walker(Node *node, AggClauseCounts *counts)
 
 		/*
 		 * Complain if the aggregate's arguments contain any aggregates;
-		 * nested agg functions are semantically nonsensical.
+		 * nested agg functions are semantically nonsensical.  Aggregates in
+		 * the FILTER clause are detected in transformAggregateCall().
 		 */
 		if (contain_agg_clause((Node *) aggref->args) ||
 			contain_agg_clause((Node *) aggref->aggorder))
@@ -4321,6 +4322,7 @@ expression_tree_mutator(Node *node,
 				FLATCOPY(newnode, aggref, Aggref);
 				MUTATE(newnode->args, aggref->args, List *);
 				MUTATE(newnode->aggorder, aggref->aggorder, AggOrder*);
+				MUTATE(newnode->aggfilter, aggref->aggfilter, Expr *);
 				return (Node *) newnode;
 			}
 			break;
@@ -4331,6 +4333,7 @@ expression_tree_mutator(Node *node,
 
 				FLATCOPY(newnode, wfunc, WindowFunc);
 				MUTATE(newnode->args, wfunc->args, List *);
+				MUTATE(newnode->aggfilter, wfunc->aggfilter, Expr *);
 				return (Node *) newnode;
 			}
 			break;

--- a/src/backend/optimizer/util/var.c
+++ b/src/backend/optimizer/util/var.c
@@ -570,12 +570,21 @@ find_minimum_var_level_cbAggref(Aggref *aggref,
 	}
 
     /* visit aggregate's args */
-	return cdb_walk_vars((Node *)aggref->args,
-                         find_minimum_var_level_cbVar,
-                         find_minimum_var_level_cbAggref,
-                         NULL,
-                         ctx,
-                         sublevelsup);
+	if (cdb_walk_vars((Node *)aggref->args,
+					  find_minimum_var_level_cbVar,
+					  find_minimum_var_level_cbAggref,
+					  NULL,
+					  ctx,
+					  sublevelsup))
+		return true;
+	if (cdb_walk_vars((Node *)aggref->aggfilter,
+					  find_minimum_var_level_cbVar,
+					  find_minimum_var_level_cbAggref,
+					  NULL,
+					  ctx,
+					  sublevelsup))
+		return true;
+	return false;
 }
 
 int

--- a/src/backend/optimizer/util/walkers.c
+++ b/src/backend/optimizer/util/walkers.c
@@ -159,6 +159,8 @@ expression_tree_walker(Node *node,
 				if (expression_tree_walker((Node *) expr->aggorder,
 										   walker, context))
 					return true;
+				if (walker((Node *) expr->aggfilter, context))
+					return true;
 			}
 			break;
 		case T_AggOrder:
@@ -181,6 +183,8 @@ expression_tree_walker(Node *node,
 				/* recurse directly on explicit arg List */
 				if (expression_tree_walker((Node *) expr->args,
 										   walker, context))
+					return true;
+				if (walker((Node *) expr->aggfilter, context))
 					return true;
 				/* don't recurse on implicit args under winspec */
 			}
@@ -1629,6 +1633,8 @@ raw_expression_tree_walker(Node *node, bool (*walker) (), void *context)
 				FuncCall *fcall = (FuncCall *) node;
 
 				if (walker(fcall->args, context))
+					return true;
+				if (walker(fcall->agg_filter, context))
 					return true;
 				/* function name is deemed uninteresting */
 			}

--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -462,8 +462,8 @@ transformIndirection(ParseState *pstate, Node *basenode, List *indirection)
 			result = ParseFuncOrColumn(pstate,
 									   list_make1(n),
 									   list_make1(result),
-                                       NIL, false, false, false, true,
-                                       NULL, -1, NULL);
+                                       NIL, NULL, false, false, false, true,
+                                       NULL, -1);
 		}
 	}
 	/* process trailing subscripts, if any */
@@ -585,8 +585,8 @@ transformColumnRef(ParseState *pstate, ColumnRef *cref)
 					node = ParseFuncOrColumn(pstate,
 											 list_make1(makeString(name2)),
 											 list_make1(node),
-											 NIL, false, false, false, true, NULL,
-											 cref->location, NULL);
+											 NIL, NULL, false, false, false, true, NULL,
+											 cref->location);
 				}
 				break;
 			}
@@ -615,8 +615,8 @@ transformColumnRef(ParseState *pstate, ColumnRef *cref)
 					node = ParseFuncOrColumn(pstate,
 											 list_make1(makeString(name3)),
 											 list_make1(node),
-											 NIL, false, false, false, true, NULL,
-											 cref->location, NULL);
+											 NIL, NULL, false, false, false, true, NULL,
+											 cref->location);
 				}
 				break;
 			}
@@ -656,8 +656,8 @@ transformColumnRef(ParseState *pstate, ColumnRef *cref)
 					node = ParseFuncOrColumn(pstate,
 											 list_make1(makeString(name4)),
 											 list_make1(node),
-											 NIL, false, false, false, true, NULL,
-											 cref->location, NULL);
+											 NIL, NULL, false, false, false, true, NULL,
+											 cref->location);
 				}
 				break;
 			}
@@ -1160,13 +1160,13 @@ transformFuncCall(ParseState *pstate, FuncCall *fn)
 							 fn->funcname,
 							 targs,
                              fn->agg_order,
+							 (Expr *) fn->agg_filter,
 							 fn->agg_star,
 							 fn->agg_distinct,
 							 fn->func_variadic,
 							 false,
 							 fn->over,
-							 fn->location, 
-							 fn->agg_filter);
+							 fn->location);
 }
 
 /*

--- a/src/backend/parser/parse_func.c
+++ b/src/backend/parser/parse_func.c
@@ -61,35 +61,6 @@ static bool
 checkTableFunctions_walker(Node *node, check_table_func_context *context);
 
 static bool
-trans_fn_is_strict(Oid funcid)
-{
-	Form_pg_aggregate aggform;
-	HeapTuple	ftup;
-	Oid			transfn;
-
-	/*
-	 * All built in aggregations are strict except for int2_sum,
-	 * int4_sum, and int8_sum, all of which are logically strict, but are
-	 * simply defined as non-strict to bootstrap their calculations.
-	 * Since they are logically strict we will not change their results
-	 * by including extra nulls in the calculation so the rewrite won't
-	 * produce incorrect results.
-	 */
-	if (funcid >= SUM_OID_MIN && funcid <= SUM_OID_MAX)
-		return true;
-
-	ftup = SearchSysCache1(AGGFNOID,
-						   ObjectIdGetDatum(funcid));
-	if (!HeapTupleIsValid(ftup))	/* should not happen */
-		elog(ERROR, "cache lookup failed for aggregate %u", funcid);
-	aggform = (Form_pg_aggregate) GETSTRUCT(ftup);
-	transfn = aggform->aggtransfn;
-	ReleaseSysCache(ftup);
-
-	return func_strict(transfn);
-}
-
-static bool
 agg_is_ordered(Oid funcid)
 {
 	HeapTuple	ftup;
@@ -138,10 +109,11 @@ agg_is_ordered(Oid funcid)
  */
 Node *
 ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
-				  List *agg_order, bool agg_star, bool agg_distinct,
+				  List *agg_order, Expr *agg_filter,
+				  bool agg_star, bool agg_distinct,
 				  bool func_variadic, bool is_column,
 				  WindowDef *over,
-				  int location, Node *agg_filter)
+				  int location)
 {
 	Oid			rettype;
 	Oid			funcid;
@@ -159,6 +131,13 @@ ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
 	FuncDetailCode fdresult;
 
 	/*
+	 * If there's an aggregate filter, transform it using transformWhereClause
+	 */
+	if (agg_filter != NULL)
+		agg_filter = (Expr *) transformWhereClause(pstate, (Node *) agg_filter,
+												   "FILTER");
+
+	/*
 	 * Most of the rest of the parser just assumes that functions do not have
 	 * more than FUNC_MAX_ARGS parameters.	We have to test here to protect
 	 * against array overruns, etc.  Of course, this may not be a function,
@@ -170,74 +149,6 @@ ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
 				 errmsg("cannot pass more than %d arguments to a function",
 						FUNC_MAX_ARGS),
 				 parser_errposition(pstate, location)));
-
-	/* 
-	 * Perform the FILTER -> CASE transform.
-	 *    FUNC(expr) FILTER (WHERE cond)  =>  FUNC(CASE WHEN cond THEN expr END)
-	 * This must be done for every parameter of the function and special handling
-	 * is needed for FUNC(*).  
-	 *
-	 * For this to be a valid transform we must assume that NULLs passed into
-	 * the function will not change the result.  This assumption is not valid
-	 * for count(*), which is why we need special processing for this case.  If
-	 * it is not a valid assumption for other cases we may need to rethink how
-	 * we implement FILTER.
-	 */
-	if (agg_filter) 
-	{
-		List *newfargs = NULL;
-
-		if (agg_star || !fargs)
-		{
-			/*
-			 * FUNC(*) => assume that datatype doesn't matter 
-			 * By converting agg_star into a conditional constant boolean 
-			 * expression we get the correct results for count(*) since it
-			 * will then supress the NULLs returned by the CASE statement.
-			 */
-			CaseExpr  *c = makeNode(CaseExpr);
-			CaseWhen  *w = makeNode(CaseWhen);
-			A_Const   *a = makeNode(A_Const);
-			a->val.type  = T_Integer;
-			a->val.val.ival = 1;    /* Actual value shouldn't matter */
-			w->expr      = (Expr *) agg_filter;
-			w->result    = (Expr *) a;
-			c->casetype  = InvalidOid;  /* will analyze in a moment */
-			c->arg       = (Expr *) NULL;
-			c->defresult = (Expr *) NULL;
-			c->args      = list_make1(w);
-			newfargs     = list_make1(c);
-		
-			/* 
-			 * Since we haven't checked the compatability of our function with
-			 * agg_star we can not clear the local bit yet, otherwise we would
-			 * loose track of the fact that this was an agg_star operation prior
-			 * to transformation.
-			 */
-		}
-		else
-		{
-			Assert(fargs && list_length(fargs) > 0);
-
-			foreach(l, fargs)
-			{
-				CaseExpr  *c = makeNode(CaseExpr);
-				CaseWhen  *w = makeNode(CaseWhen);
-				w->expr      = (Expr *) agg_filter;
-				w->result    = (Expr *) lfirst(l);
-				c->casetype  = InvalidOid;  /* will analyze in a moment */
-				c->arg       = (Expr *) NULL;
-				c->defresult = (Expr *) NULL;
-				c->args      = list_make1(w);
-
-				if (newfargs)
-					lappend(newfargs, c);
-				else
-					newfargs = list_make1(c);
-			}
-		}
-		fargs = transformExpressionList(pstate, newfargs);
-	}
 
 	/*
 	 * Extract arg type info in preparation for function lookup.
@@ -277,8 +188,8 @@ ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
 	 * the "function call" could be a projection.  We also check that there
 	 * wasn't any aggregate or variadic decoration.
 	 */
-	if (nargs == 1 && agg_order == NIL && !agg_star && !agg_distinct &&
-		!func_variadic && !agg_filter && list_length(funcname) == 1)
+	if (nargs == 1 && agg_order == NIL && agg_filter == NULL && !agg_star &&
+		!agg_distinct && !func_variadic && !agg_filter && list_length(funcname) == 1)
 	{
 		Oid			argtype = actual_arg_types[0];
 
@@ -349,10 +260,9 @@ ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
 							NameListToString(funcname)),
 					 parser_errposition(pstate, location)));
 		if (agg_filter)
-		    ereport(ERROR,
+			ereport(ERROR,
 					(errcode(ERRCODE_WRONG_OBJECT_TYPE),
-					 errmsg("filter clause specified, but "
-							"%s is not an aggregate function",
+					 errmsg("FILTER specified, but %s is not an aggregate function",
 							NameListToString(funcname)),
 					 parser_errposition(pstate, location)));
 
@@ -401,21 +311,6 @@ ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
 					 errhint("No function matches the given name and argument types. "
 							 "You might need to add explicit type casts."),
 					 parser_errposition(pstate, location)));
-	}
-
-	/*
-	 * The agg_filter rewrite in the case of agg_star is only valid for count(*)
-	 * otherwise we need to throw an error.
-	 */
-	if (agg_star && agg_filter && funcid != COUNT_ANY_OID)
-	{
-	    ereport(ERROR,
-				(errcode(ERRCODE_UNDEFINED_FUNCTION),
-				 errmsg("function %s() does not exist",
-						NameListToString(funcname)),
-				 errhint("No function matches the given name and argument types. "
-						 "You might need to add explicit type casts."),
-				 parser_errposition(pstate, location)));
 	}
 
 	/*
@@ -504,37 +399,6 @@ ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
 		Aggref	   *aggref;
 
 		/* 
-		 * We only support FILTER clauses over STRICT aggegation functions.
-		 *
-		 * All built in aggregations are strict except for int2_sum, 
-         * int4_sum, and int8_sum, all of which are logically strict, but are
-		 * simply defined as non-strict to bootstrap their calculations.  
-		 * Since they are logically strict we will not change their results 
-		 * by including extra nulls in the calculation so the rewrite won't 
-		 * produce incorrect results.
-		 *
-		 * For user defined functions we must enforce this restriction since
-		 * passing "extra" nulls back to a non-strict function may cause it
-		 * to return an incorrect answer, eg: count_null(i) filter (...) 
-		 * wouldn't differeniate between data nulls vs filtered values.
-		 */
-		if (agg_filter && !trans_fn_is_strict(funcid))
-		    ereport(ERROR,
-					(errcode(ERRCODE_GP_FEATURE_NOT_SUPPORTED),
-					 errmsg("function %s is not defined as STRICT",
-							func_signature_string(funcname, nargs, 
-												  actual_arg_types)),
-					 errhint("The filter clause is only supported over functions "
-							 "defined as STRICT."),
-					 parser_errposition(pstate, location)));
-
-		if (retset)
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_FUNCTION_DEFINITION),
-					 errmsg("aggregates cannot return sets"),
-					 parser_errposition(pstate, location)));
-
-		/* 
 		 * If this is not an ordered aggregate, but it was called with an
 		 * aggregate order by specification then we must raise an error.
 		 */
@@ -564,17 +428,9 @@ ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
 		aggref = makeNode(Aggref);
 		aggref->aggfnoid = funcid;
 		aggref->aggtype = rettype;
+		aggref->aggfilter = agg_filter;
+		aggref->aggstar = agg_star;
 		aggref->args = fargs;
-
-		/*
-		 * If we had a FILTER clause with a star, we replaced the star with
-		 * a CASE WHEN expression above. Set 'aggstar' accordingly.
-		 */
-		if (agg_filter && agg_star)
-			aggref->aggstar = false;
-		else
-			aggref->aggstar = agg_star;
-
 		aggref->aggdistinct = agg_distinct;
 		aggref->location = location;
 
@@ -596,24 +452,25 @@ ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
 					 errmsg("window function call requires an OVER clause"),
 					 parser_errposition(pstate, location)));
 
-		if (retset)
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_FUNCTION_DEFINITION),
-					 errmsg("window functions may not return sets"),
-					 parser_errposition(pstate, location)));
-
 		if (agg_order)
 			ereport(ERROR,
 					(errcode(ERRCODE_WRONG_OBJECT_TYPE),
 					 errmsg("aggregate ORDER BY is not implemented for window functions"),
 					 parser_errposition(pstate, location)));
 
-		if (fdresult == FUNCDETAIL_WINDOWFUNC && agg_filter)
+		/*
+		 * FILTER is not yet supported with true window functions
+		 */
+		if (fdresult != FUNCDETAIL_AGGREGATE && agg_filter)
 			ereport(ERROR,
-					(errcode(ERRCODE_WRONG_OBJECT_TYPE),
-					 errmsg("window function \"%s\" can not be used with a "
-							"filter clause",
-							NameListToString(funcname)),
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("FILTER is not implemented for non-aggregate window functions"),
+					 parser_errposition(pstate, location)));
+
+		if (retset)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_FUNCTION_DEFINITION),
+					 errmsg("window functions may not return sets"),
 					 parser_errposition(pstate, location)));
 
 		/*
@@ -628,6 +485,7 @@ ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
 		/* winref will be set by transformWindowFuncCall */
 		wfunc->winstar = agg_star;
 		wfunc->winagg = (fdresult == FUNCDETAIL_AGGREGATE);
+		wfunc->aggfilter = agg_filter;
 		wfunc->windistinct = agg_distinct;
 		wfunc->location = location;
 

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -5421,6 +5421,13 @@ get_agg_expr(Aggref *aggref, deparse_context *context)
                           context, 
                           " ORDER BY ");
     }
+
+	if (aggref->aggfilter != NULL)
+	{
+		appendStringInfoString(buf, ") FILTER (WHERE ");
+		get_rule_expr((Node *) aggref->aggfilter, context, false);
+	}
+
 	appendStringInfoChar(buf, ')');
 }
 
@@ -5508,6 +5515,13 @@ get_windowfunc_expr(WindowFunc *wfunc, deparse_context *context)
 		appendStringInfoChar(buf, '*');
 	else
 		get_rule_expr((Node *) wfunc->args, context, true);
+
+	if (wfunc->aggfilter != NULL)
+	{
+		appendStringInfoString(buf, ") FILTER (WHERE ");
+		get_rule_expr((Node *) wfunc->aggfilter, context, false);
+	}
+
 	appendStringInfoString(buf, ") OVER ");
 
 	foreach(l, context->windowClause)

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -835,6 +835,7 @@ typedef struct AggrefExprState
 {
 	ExprState	xprstate;
 	List	   *args;			/* states of argument expressions */
+	ExprState  *aggfilter;		/* FILTER expression */
 	List	   *inputTargets;	/* combined TargetList */
 	List	   *inputSortClauses; /* list of SortClause */
 	int			aggno;			/* ID number for agg within its plan node */
@@ -861,6 +862,7 @@ typedef struct WindowFuncExprState
 	ExprState	xprstate;
 	struct WindowState *windowstate; /* reflect parent window state */
 	List	   *args;			/* states of argument expressions */
+	ExprState  *aggfilter;		/* FILTER expression */
 	bool	   *argtypbyval;	/* pg_type.typbyval for each argument */
 	int16	   *argtyplen;		/* pg_type.typlen of each argument */
 	int			funcno;			/* index in window state's func_state array */

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -310,8 +310,8 @@ typedef struct TypeCast
  * agg_star indicates we saw a 'foo(*)' construct, while agg_distinct
  * indicates we saw 'foo(DISTINCT ...)'.  In either case, the construct
  * *must* be an aggregate call.  Otherwise, it might be either an
- * aggregate or some other kind of function.  However, if OVER is present
- * it had better be an aggregate or window function.
+ * aggregate or some other kind of function.  However, if FILTER or OVER is
+ * present it had better be an aggregate or window function.
  */
 typedef struct FuncCall
 {

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -253,6 +253,7 @@ typedef struct Aggref
 	Index		agglevelsup;	/* > 0 if agg belongs to outer query */
 	bool		aggstar;		/* TRUE if argument list was really '*' */
 	bool		aggdistinct;	/* TRUE if it's agg(DISTINCT ...) */
+	Expr	   *aggfilter;		/* FILTER expression, if any */
 	AggStage	aggstage;		/* MPP: 2-stage? If so, which stage */
     AggOrder   *aggorder;       /* Ordered aggregate definition */
 	int			location;		/* token location, or -1 if unknown */
@@ -336,6 +337,7 @@ typedef struct WindowFunc
 	Oid			winfnoid;		/* pg_proc Oid of the function */
 	Oid			wintype;		/* type Oid of result of the window function */
 	List	   *args;			/* arguments to the window function */
+	Expr	   *aggfilter;		/* FILTER expression, if any */
 	Index		winref;			/* index of associated WindowClause */
 	bool		winstar;		/* TRUE if argument list was really '*' */
 	bool		winagg;			/* is function a simple aggregate? */

--- a/src/include/parser/parse_func.h
+++ b/src/include/parser/parse_func.h
@@ -42,11 +42,11 @@ typedef enum
 } FuncDetailCode;
 
 
-extern Node *ParseFuncOrColumn(ParseState *pstate,
-				  List *funcname, List *fargs, List *agg_order,
+extern Node *ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
+				  List *agg_order, Expr *agg_filter,
 				  bool agg_star, bool agg_distinct, bool func_variadic,
 				  bool is_column,
-				  WindowDef *over, int location, Node *agg_filter);
+				  WindowDef *over, int location);
 
 extern FuncDetailCode func_get_detail(List *funcname, List *fargs,
 				int nargs, Oid *argtypes,

--- a/src/test/regress/expected/aggregates.out
+++ b/src/test/regress/expected/aggregates.out
@@ -1020,3 +1020,94 @@ reset enable_hashagg;
 reset enable_hashjoin;
 reset enable_mergejoin;
 drop table l, ps;
+-- FILTER tests
+select min(unique1) filter (where unique1 > 100) from tenk1;
+ min 
+-----
+ 101
+(1 row)
+
+select ten, sum(distinct four) filter (where four::text ~ '123') from onek a
+group by ten;
+ ten | sum 
+-----+-----
+   0 |    
+   1 |    
+   2 |    
+   3 |    
+   4 |    
+   5 |    
+   6 |    
+   7 |    
+   8 |    
+   9 |    
+(10 rows)
+
+select ten, sum(distinct four) filter (where four > 10) from onek a
+group by ten
+having exists (select 1 from onek b where sum(distinct a.four) = b.four);
+ ten | sum 
+-----+-----
+   0 |    
+   2 |    
+   4 |    
+   6 |    
+   8 |    
+(5 rows)
+
+select max(foo COLLATE "C") filter (where (bar collate "POSIX") > '0')
+from (values ('a', 'b')) AS v(foo,bar);
+ERROR:  syntax error at or near "COLLATE"
+LINE 1: select max(foo COLLATE "C") filter (where (bar collate "POSI...
+                       ^
+-- outer reference in FILTER (PostgreSQL extension)
+select (select count(*)
+        from (values (1)) t0(inner_c))
+from (values (2),(3)) t1(outer_c); -- inner query is aggregation query
+ ?column? 
+----------
+        1
+        1
+(2 rows)
+
+select (select count(*) filter (where outer_c <> 0)
+        from (values (1)) t0(inner_c))
+from (values (2),(3)) t1(outer_c); -- outer query is aggregation query
+ ?column? 
+----------
+        2
+(1 row)
+
+select (select count(inner_c) filter (where outer_c <> 0)
+        from (values (1)) t0(inner_c))
+from (values (2),(3)) t1(outer_c); -- inner query is aggregation query
+ ?column? 
+----------
+        1
+        1
+(2 rows)
+
+select
+  (select max((select i.unique2 from tenk1 i where i.unique1 = o.unique1))
+     filter (where o.unique1 < 10))
+from tenk1 o;					-- outer query is aggregation query
+ ?column? 
+----------
+     9998
+(1 row)
+
+-- subquery in FILTER clause (PostgreSQL extension)
+select sum(unique1) FILTER (WHERE
+  unique1 IN (SELECT unique1 FROM onek where unique1 < 100)) FROM tenk1;
+ sum  
+------
+ 4950
+(1 row)
+
+-- exercise lots of aggregate parts with FILTER
+select aggfns(distinct a,b,c order by a,c using ~<~,b) filter (where a > 1)
+    from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
+    generate_series(1,2) i;
+ERROR:  ORDER BY and DISTINCT are mutually exclusive
+LINE 1: select aggfns(distinct a,b,c order by a,c using ~<~,b) filte...
+               ^

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -1026,3 +1026,94 @@ reset enable_hashagg;
 reset enable_hashjoin;
 reset enable_mergejoin;
 drop table l, ps;
+-- FILTER tests
+select min(unique1) filter (where unique1 > 100) from tenk1;
+ min 
+-----
+ 101
+(1 row)
+
+select ten, sum(distinct four) filter (where four::text ~ '123') from onek a
+group by ten;
+ ten | sum 
+-----+-----
+   0 |    
+   1 |    
+   2 |    
+   3 |    
+   4 |    
+   5 |    
+   6 |    
+   7 |    
+   8 |    
+   9 |    
+(10 rows)
+
+select ten, sum(distinct four) filter (where four > 10) from onek a
+group by ten
+having exists (select 1 from onek b where sum(distinct a.four) = b.four);
+ ten | sum 
+-----+-----
+   0 |    
+   2 |    
+   4 |    
+   6 |    
+   8 |    
+(5 rows)
+
+select max(foo COLLATE "C") filter (where (bar collate "POSIX") > '0')
+from (values ('a', 'b')) AS v(foo,bar);
+ERROR:  syntax error at or near "COLLATE"
+LINE 1: select max(foo COLLATE "C") filter (where (bar collate "POSI...
+                       ^
+-- outer reference in FILTER (PostgreSQL extension)
+select (select count(*)
+        from (values (1)) t0(inner_c))
+from (values (2),(3)) t1(outer_c); -- inner query is aggregation query
+ ?column? 
+----------
+        1
+        1
+(2 rows)
+
+select (select count(*) filter (where outer_c <> 0)
+        from (values (1)) t0(inner_c))
+from (values (2),(3)) t1(outer_c); -- outer query is aggregation query
+ ?column? 
+----------
+        2
+(1 row)
+
+select (select count(inner_c) filter (where outer_c <> 0)
+        from (values (1)) t0(inner_c))
+from (values (2),(3)) t1(outer_c); -- inner query is aggregation query
+ ?column? 
+----------
+        1
+        1
+(2 rows)
+
+select
+  (select max((select i.unique2 from tenk1 i where i.unique1 = o.unique1))
+     filter (where o.unique1 < 10))
+from tenk1 o;					-- outer query is aggregation query
+ ?column? 
+----------
+     9998
+(1 row)
+
+-- subquery in FILTER clause (PostgreSQL extension)
+select sum(unique1) FILTER (WHERE
+  unique1 IN (SELECT unique1 FROM onek where unique1 < 100)) FROM tenk1;
+ sum  
+------
+ 4950
+(1 row)
+
+-- exercise lots of aggregate parts with FILTER
+select aggfns(distinct a,b,c order by a,c using ~<~,b) filter (where a > 1)
+    from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
+    generate_series(1,2) i;
+ERROR:  ORDER BY and DISTINCT are mutually exclusive
+LINE 1: select aggfns(distinct a,b,c order by a,c using ~<~,b) filte...
+               ^

--- a/src/test/regress/expected/filter.out
+++ b/src/test/regress/expected/filter.out
@@ -442,10 +442,9 @@ select i, j, row_number() over (partition by j order by i) from filter_test ORDE
 
 select i, j, row_number() filter (WHERE i % 2 = 1) over (partition by j order by i) 
 FROM filter_test ORDER BY j, i;
-ERROR:  function row_number(integer) does not exist
+ERROR:  FILTER is not implemented for non-aggregate window functions
 LINE 1: select i, j, row_number() filter (WHERE i % 2 = 1) over (par...
                      ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 select i, rank() over (order by i) from filter_test ORDER BY i;
  i  | rank 
 ----+------
@@ -462,10 +461,9 @@ select i, rank() over (order by i) from filter_test ORDER BY i;
 (10 rows)
 
 select i, rank() filter (where true) over (order by i) from filter_test ORDER BY i;
-ERROR:  function rank(integer) does not exist
+ERROR:  FILTER is not implemented for non-aggregate window functions
 LINE 1: select i, rank() filter (where true) over (order by i) from ...
                   ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 select i, ntile(3) over (order by i) from filter_test ORDER BY i;
  i  | ntile 
 ----+-------
@@ -482,7 +480,7 @@ select i, ntile(3) over (order by i) from filter_test ORDER BY i;
 (10 rows)
 
 select i, ntile(3) filter (where true) over (order by i) from filter_test ORDER BY i;
-ERROR:  window function "ntile" can not be used with a filter clause
+ERROR:  FILTER is not implemented for non-aggregate window functions
 LINE 1: select i, ntile(3) filter (where true) over (order by i) fro...
                   ^
 select i, ntile(4-j) over (partition by j order by i) 
@@ -501,7 +499,7 @@ FROM filter_test where j < 4 ORDER BY j, i;
 
 select i, ntile(4-j) filter (where true) over (partition by j order by i) 
 from filter_test where j < 4 ORDER BY j, i;
-ERROR:  window function "ntile" can not be used with a filter clause
+ERROR:  FILTER is not implemented for non-aggregate window functions
 LINE 1: select i, ntile(4-j) filter (where true) over (partition by ...
                   ^
 -- TEST against non aggregate function => should error
@@ -521,7 +519,7 @@ select i, lower('Hello') from filter_test order by i;
 (10 rows)
 
 select i, lower('Hello') filter (where i < 5) from filter_test order by i;
-ERROR:  filter clause specified, but lower is not an aggregate function
+ERROR:  FILTER specified, but lower is not an aggregate function
 LINE 1: select i, lower('Hello') filter (where i < 5) from filter_te...
                   ^
 -- TEST against function like projection => should error
@@ -625,10 +623,11 @@ SELECT maxodd(i) FROM filter_test;
 (1 row)
 
 SELECT maxodd(i) FILTER (WHERE TRUE) from filter_test;
-ERROR:  function maxodd(integer) is not defined as STRICT
-LINE 1: SELECT maxodd(i) FILTER (WHERE TRUE) from filter_test;
-               ^
-HINT:  The filter clause is only supported over functions defined as STRICT.
+ maxodd 
+--------
+      9
+(1 row)
+
 SELECT j, maxodd(i) FROM filter_test group by j order by j;
  j | maxodd 
 ---+--------
@@ -639,16 +638,20 @@ SELECT j, maxodd(i) FROM filter_test group by j order by j;
 (4 rows)
 
 SELECT j, maxodd(i) FILTER (WHERE TRUE) from filter_test group by j order by j;
-ERROR:  function maxodd(integer) is not defined as STRICT
-LINE 1: SELECT j, maxodd(i) FILTER (WHERE TRUE) from filter_test gro...
-                  ^
-HINT:  The filter clause is only supported over functions defined as STRICT.
+ j | maxodd 
+---+--------
+ 1 |      3
+ 2 |      0
+ 3 |      9
+   |      0
+(4 rows)
+
 -- TEST view deparsing of FILTER expressions.
 CREATE VIEW filter_view AS SELECT count(*) FILTER (WHERE TRUE) FROM filter_test;
 SELECT definition from pg_views WHERE viewname='filter_view';
-                                      definition                                       
----------------------------------------------------------------------------------------
- SELECT count(CASE WHEN true THEN 1 ELSE NULL::integer END) AS count FROM filter_test;
+                           definition                           
+----------------------------------------------------------------
+ SELECT count(*) FILTER (WHERE true) AS count FROM filter_test;
 (1 row)
 
 drop aggregate maxodd(int);

--- a/src/test/regress/sql/aggregates.sql
+++ b/src/test/regress/sql/aggregates.sql
@@ -461,3 +461,41 @@ reset enable_hashjoin;
 reset enable_mergejoin;
 
 drop table l, ps;
+
+-- FILTER tests
+
+select min(unique1) filter (where unique1 > 100) from tenk1;
+
+select ten, sum(distinct four) filter (where four::text ~ '123') from onek a
+group by ten;
+
+select ten, sum(distinct four) filter (where four > 10) from onek a
+group by ten
+having exists (select 1 from onek b where sum(distinct a.four) = b.four);
+
+select max(foo COLLATE "C") filter (where (bar collate "POSIX") > '0')
+from (values ('a', 'b')) AS v(foo,bar);
+
+-- outer reference in FILTER (PostgreSQL extension)
+select (select count(*)
+        from (values (1)) t0(inner_c))
+from (values (2),(3)) t1(outer_c); -- inner query is aggregation query
+select (select count(*) filter (where outer_c <> 0)
+        from (values (1)) t0(inner_c))
+from (values (2),(3)) t1(outer_c); -- outer query is aggregation query
+select (select count(inner_c) filter (where outer_c <> 0)
+        from (values (1)) t0(inner_c))
+from (values (2),(3)) t1(outer_c); -- inner query is aggregation query
+select
+  (select max((select i.unique2 from tenk1 i where i.unique1 = o.unique1))
+     filter (where o.unique1 < 10))
+from tenk1 o;					-- outer query is aggregation query
+
+-- subquery in FILTER clause (PostgreSQL extension)
+select sum(unique1) FILTER (WHERE
+  unique1 IN (SELECT unique1 FROM onek where unique1 < 100)) FROM tenk1;
+
+-- exercise lots of aggregate parts with FILTER
+select aggfns(distinct a,b,c order by a,c using ~<~,b) filter (where a > 1)
+    from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
+    generate_series(1,2) i;


### PR DESCRIPTION
We had a very simplistic implementation in parse-analysis already, which
converted the FILTER WHERE clause into a CASE-WHEN expression. That did
not work for non-strict aggregates, and didn't deparse back into a FILTER
expression nicely, to name a few problems with it. Replace it with the
PostgreSQL implementation.

TODO:

* ORCA support. It now falls back to the Postgres planner.
* I disabled the three-stage DQA plan types if there are any FILTERs