### PR TITLE
Fix gprecoverseg recursive behavior

### DIFF
--- a/gpMgmt/bin/gppylib/operations/rebalanceSegments.py
+++ b/gpMgmt/bin/gppylib/operations/rebalanceSegments.py
@@ -1,21 +1,20 @@
+import sys
+import signal
 from gppylib.gparray import GpArray
 from gppylib.db import dbconn
 from gppylib.commands.gp import GpSegStopCmd, GpRecoverseg
-from gppylib.commands.base import WorkerPool, SQLCommand, REMOTE
+from gppylib.commands import base
 from gppylib import gplog
-import signal
-
-logger = gplog.get_default_logger()
 
 
-class ReconfigDetectionSQLQueryCommand(SQLCommand):
+class ReconfigDetectionSQLQueryCommand(base.SQLCommand):
     """A distributed query that will cause the system to detect
     the reconfiguration of the system"""
 
     query = "SELECT * FROM gp_dist_random('gp_id')"
 
     def __init__(self, conn):
-        SQLCommand.__init__(self, "Reconfig detection sql query")
+        base.SQLCommand.__init__(self, "Reconfig detection sql query")
         self.cancel_conn = conn
 
     def run(self):
@@ -26,28 +25,28 @@ class GpSegmentRebalanceOperation:
     def __init__(self, gpEnv, gpArray):
         self.gpEnv = gpEnv
         self.gpArray = gpArray
+        self.logger = gplog.get_default_logger()
 
     def rebalance(self):
         # Get the unbalanced primary segments grouped by hostname
         # These segments are what we will shutdown.
-        logger.info("Getting unbalanced segments")
+        self.logger.info("Getting unbalanced segments")
         unbalanced_primary_segs = GpArray.getSegmentsByHostName(self.gpArray.get_unbalanced_primary_segdbs())
-        pool = WorkerPool()
-
+        pool = base.WorkerPool()
         count = 0
 
         try:
             # Disable ctrl-c
             signal.signal(signal.SIGINT, signal.SIG_IGN)
 
-            logger.info("Stopping unbalanced primary segments...")
+            self.logger.info("Stopping unbalanced primary segments...")
             for hostname in unbalanced_primary_segs.keys():
                 cmd = GpSegStopCmd("stop unbalanced primary segs",
                                    self.gpEnv.getGpHome(),
                                    self.gpEnv.getGpVersion(),
                                    'fast',
                                    unbalanced_primary_segs[hostname],
-                                   ctxt=REMOTE,
+                                   ctxt=base.REMOTE,
                                    remoteHost=hostname,
                                    timeout=600)
                 pool.addCommand(cmd)
@@ -61,19 +60,21 @@ class GpSegmentRebalanceOperation:
                 if not res.get_results().wasSuccessful():
                     failed_count += 1
 
-            if failed_count > 0:
-                logger.warn("%d segments failed to stop.  A full rebalance of the")
-                logger.warn("system is not possible at this time.  Please check the")
-                logger.warn("log files, correct the problem, and run gprecoverseg -r")
-                logger.warn("again.")
-                logger.info("gprecoverseg will continue with a partial rebalance.")
+            allSegmentsStopped = (failed_count == 0)
+
+            if not allSegmentsStopped:
+                self.logger.warn("%d segments failed to stop.  A full rebalance of the")
+                self.logger.warn("system is not possible at this time.  Please check the")
+                self.logger.warn("log files, correct the problem, and run gprecoverseg -r")
+                self.logger.warn("again.")
+                self.logger.info("gprecoverseg will continue with a partial rebalance.")
 
             pool.empty_completed_items()
             # issue a distributed query to make sure we pick up the fault
             # that we just caused by shutting down segments
             conn = None
             try:
-                logger.info("Triggering segment reconfiguration")
+                self.logger.info("Triggering segment reconfiguration")
                 dburl = dbconn.DbURL()
                 conn = dbconn.connect(dburl)
                 cmd = ReconfigDetectionSQLQueryCommand(conn)
@@ -87,21 +88,37 @@ class GpSegmentRebalanceOperation:
                     conn.close()
 
             # Final step is to issue a recoverseg operation to resync segments
-            logger.info("Starting segment synchronization")
-            cmd = GpRecoverseg("rebalance recoverseg")
-            pool.addCommand(cmd)
-            pool.wait_and_printdots(1, False)
+            self.logger.info("Starting segment synchronization")
+            original_sys_args = sys.argv[:]
+            try:
+                self.logger.info("=============================START ANOTHER RECOVER=========================================")
+                # import here because GpRecoverSegmentProgram and GpSegmentRebalanceOperation have a circular dependency
+                from gppylib.programs.clsRecoverSegment import GpRecoverSegmentProgram
+                sys.argv = ['gprecoverseg', '-a']
+                local_parser = GpRecoverSegmentProgram.createParser()
+                local_options, args = local_parser.parse_args()
+                cmd = GpRecoverSegmentProgram.createProgram(local_options, args)
+                cmd.run()
+
+            except SystemExit as e:
+                if e.code != 0:
+                    self.logger.error("Failed to start the synchronization step of the segment rebalance.")
+                    self.logger.error("Check the gprecoverseg log file, correct any problems, and re-run")
+                    self.logger.error("'gprecoverseg -a'.")
+                    raise Exception("Error synchronizing.\nError: %s" % str(e))
+            finally:
+                if cmd:
+                    cmd.cleanup()
+                sys.argv = original_sys_args
+                self.logger.info("==============================END ANOTHER RECOVER==========================================")
+
         except Exception, ex:
             raise ex
         finally:
+            pool.join()
             pool.haltWork()
+            pool.joinWorkers()
             signal.signal(signal.SIGINT, signal.default_int_handler)
 
-        # check that recoverseg was successful
-        completed = pool.getCompletedItems()
-        if not completed[0].get_results().wasSuccessful():
-            logger.error("Failed to start the synchronization step of the segment rebalance.")
-            logger.error("Check the gprecoverseg log file, correct any problems, and re-run")
-            logger.error("'gprecoverseg -a'.")
-            logger.error(completed[0].get_results())
-            raise Exception("Error synchronizing.")
+        return allSegmentsStopped # if all segments stopped, then a full rebalance was done
+

--- a/gpMgmt/bin/gppylib/programs/clsAddMirrors.py
+++ b/gpMgmt/bin/gppylib/programs/clsAddMirrors.py
@@ -663,7 +663,8 @@ class GpAddMirrorsProgram:
                     raise UserAbortedException()
 
             gpArray.setFaultStrategy(gparray.FAULT_STRATEGY_FILE_REPLICATION)
-            mirrorBuilder.buildMirrors("add", gpEnv, gpArray)
+            if not mirrorBuilder.buildMirrors("add", gpEnv, gpArray):
+                return 1
 
             logger.info("******************************************************************")
             logger.info("Mirror segments have been added; data synchronization is in progress.")

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -23,7 +23,8 @@ from optparse import OptionGroup
 import os, sys, signal, time
 from gppylib import gparray, gplog, userinput, utils
 from gppylib.util import gp_utils
-from gppylib.commands import base, gp, pg, unix
+from gppylib.commands import gp, pg, unix
+from gppylib.commands.base import Command, WorkerPool
 from gppylib.db import dbconn
 from gppylib.gpparseopts import OptParser, OptChecker
 from gppylib.operations.startSegments import *
@@ -34,10 +35,9 @@ from gppylib.programs.clsAddMirrors import validateFlexibleHeadersListAllFilespa
 from gppylib.system import configurationInterface as configInterface
 from gppylib.system.environment import GpMasterEnvironment
 from gppylib.testold.testUtils import *
-from gppylib.parseutils import line_reader, parse_filespace_order, parse_gprecoverseg_line, \
-    canonicalize_address
+from gppylib.parseutils import line_reader, parse_filespace_order, parse_gprecoverseg_line, canonicalize_address
 from gppylib.utils import ParsedConfigFile, ParsedConfigFileRow, writeLinesToFile, \
-    normalizeAndValidateInputPath, TableLogger
+     normalizeAndValidateInputPath, TableLogger
 from gppylib.gphostcache import GpInterfaceToHostNameCache
 from gppylib.operations.utils import ParallelOperation
 from gppylib.operations.package import SyncPackages
@@ -100,7 +100,7 @@ class PortAssigner:
 
 # -------------------------------------------------------------------------
 
-class RemoteQueryCommand(base.Command):
+class RemoteQueryCommand(Command):
     def __init__(self, qname, query, hostname, port, dbname=None):
         self.qname = qname
         self.query = query
@@ -1122,7 +1122,7 @@ class GpRecoverSegmentProgram:
             raise ProgramArgumentValidationException(
                 "Invalid parallelDegree provided with -B argument: %d" % self.__options.parallelDegree)
 
-        self.__pool = base.WorkerPool(self.__options.parallelDegree)
+        self.__pool = WorkerPool(self.__options.parallelDegree)
         gpEnv = GpMasterEnvironment(self.__options.masterDataDirectory, True)
 
         # verify "where to recover" options
@@ -1216,10 +1216,13 @@ class GpRecoverSegmentProgram:
                     if not userinput.ask_yesno(None, "\nContinue with segment rebalance procedure", 'N'):
                         raise UserAbortedException()
 
-                mirrorBuilder.rebalance()
-
+                fullRebalanceDone = mirrorBuilder.rebalance()
                 self.logger.info("******************************************************************")
-                self.logger.info("The rebalance operation has completed successfully.")
+                if fullRebalanceDone:
+                    self.logger.info("The rebalance operation has completed successfully.")
+                else:
+                    self.logger.info("The rebalance operation has completed with WARNINGS."
+                                     " Please review the output in the gprecoverseg log.")
                 self.logger.info("There is a resynchronization running in the background to bring all")
                 self.logger.info("segments in sync.")
                 self.logger.info("")
@@ -1245,7 +1248,8 @@ class GpRecoverSegmentProgram:
             if new_hosts:
                 self.syncPackages(new_hosts)
 
-            mirrorBuilder.buildMirrors("recover", gpEnv, gpArray)
+            if not mirrorBuilder.buildMirrors("recover", gpEnv, gpArray):
+                sys.exit(1)
 
             confProvider.sendPgElogFromMaster("Recovery of %d segment(s) has been started." % \
                                               len(mirrorBuilder.getMirrorsToBuild()), True)
@@ -1257,10 +1261,7 @@ class GpRecoverSegmentProgram:
             self.logger.info("Use  gpstate -s  to check the resynchronization progress.")
             self.logger.info("******************************************************************")
 
-        pidfile = os.path.join(gpEnv.getMasterDataDir(), 'gprecoverseg.pid')
-        if os.path.exists(pidfile):
-            os.remove(pidfile)
-        os._exit(0)
+        sys.exit(0)
 
     def validate_heap_checksum_consistency(self, gpArray, mirrorBuilder):
         live_segments = [target.getLiveSegment() for target in mirrorBuilder.getMirrorsToBuild()]

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
@@ -6,12 +6,14 @@ import tempfile
 from mock import *
 
 from gp_unittest import *
-from gparray import GpArray, GpDB, FAULT_STRATEGY_FILE_REPLICATION
+from gppylib.gparray import GpArray, GpDB, FAULT_STRATEGY_FILE_REPLICATION
 from gppylib.heapchecksum import HeapChecksum
 from gppylib.operations.buildMirrorSegments import GpMirrorToBuild, GpMirrorListToBuild
-from pgconf import gucdict, setting
-from system import faultProberInterface
-from system.configurationInterface import GpConfigurationProvider
+from gppylib.pgconf import gucdict, setting
+from gppylib.system import faultProberInterface
+from gppylib.system.configurationInterface import GpConfigurationProvider
+from gppylib.operations.rebalanceSegments import GpSegmentRebalanceOperation
+from gppylib.utils import TableLogger
 
 
 class Options:
@@ -53,8 +55,8 @@ class GpRecoversegTestCase(GpTestCase):
         self.pgconf_dict["port"] = setting("port", "123", None, None, None)
         self.pgconf_dict["max_connection"] = setting("max_connections", "1", None, None, None)
 
-        config_provider_mock = MagicMock(spec=GpConfigurationProvider)
-        config_provider_mock.initializeProvider.return_value = config_provider_mock
+        self.config_provider_mock = MagicMock(spec=GpConfigurationProvider)
+        self.config_provider_mock.initializeProvider.return_value = self.config_provider_mock
 
         self.gpArrayMock = MagicMock(spec=GpArray)
         self.gpArrayMock.getDbList.side_effect = [[], [self.primary0], [self.primary0]]
@@ -62,7 +64,7 @@ class GpRecoversegTestCase(GpTestCase):
         self.gpArrayMock.isStandardArray.return_value = (True, None)
         self.gpArrayMock.master = self.gparray.master
 
-        config_provider_mock.loadSystemConfig.return_value = self.gpArrayMock
+        self.config_provider_mock.loadSystemConfig.return_value = self.gpArrayMock
 
         self.mirror_to_build = GpMirrorToBuild(self.mirror0, self.primary0, None, False)
         self.apply_patches([
@@ -75,7 +77,7 @@ class GpRecoversegTestCase(GpTestCase):
             patch('gppylib.db.catalog.getCollationSettings',
                   return_value=("en_US.utf-8", "en_US.utf-8", "en_US.utf-8")),
             patch('gppylib.system.faultProberInterface.getFaultProber'),
-            patch('gppylib.system.configurationInterface.getConfigurationProvider', return_value=config_provider_mock),
+            patch('gppylib.system.configurationInterface.getConfigurationProvider', return_value=self.config_provider_mock),
             patch('gppylib.commands.base.WorkerPool', return_value=self.pool),
             patch('gppylib.gparray.GpArray.getSegmentsByHostName', return_value={}),
             patch('gppylib.gplog.get_default_logger'),
@@ -90,6 +92,7 @@ class GpRecoversegTestCase(GpTestCase):
         self.call_count = 0
         self.return_one = True
 
+        self.mock_build_mirrors = self.get_mock_from_apply_patch("buildMirrors")
         self.mock_get_mirrors_to_build = self.get_mock_from_apply_patch('getMirrorsToBuild')
         self.mock_heap_checksum_init = self.get_mock_from_apply_patch("__init__")
         self.mock_check_segment_consistency = self.get_mock_from_apply_patch('check_segment_consistency')
@@ -97,13 +100,12 @@ class GpRecoversegTestCase(GpTestCase):
 
         sys.argv = ["gprecoverseg"]  # reset to relatively empty args list
 
-        # import HERE so that patches are already in place!
-        from programs.clsRecoverSegment import GpRecoverSegmentProgram
-
         options = Options()
         options.masterDataDirectory = self.temp_dir
         options.spareDataDirectoryFile = self.config_file_path
 
+        # import HERE so that patches are already in place!
+        from programs.clsRecoverSegment import GpRecoverSegmentProgram
         self.subject = GpRecoverSegmentProgram(options)
         self.subject.logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal'])
 
@@ -158,10 +160,95 @@ class GpRecoversegTestCase(GpTestCase):
         self.mock_get_mirrors_to_build.side_effect = self._get_test_mirrors
         self.return_one = False
 
-        self.subject.run()
+        with self.assertRaises(SystemExit):
+            self.subject.run()
 
         self.subject.logger.info.assert_any_call('No checksum validation necessary when '
                                                  'there are no segments to recover.')
+
+    @patch.object(TableLogger, "info")
+    @patch.object(GpSegmentRebalanceOperation, "rebalance", return_value=True)
+    @patch("os._exit")
+    def test_successful_rebalance(self, _, __, ___):
+        self.gpArrayMock.get_unbalanced_segdbs.return_value = [self.primary0]
+        options = Options()
+        options.masterDataDirectory = self.temp_dir
+        options.rebalanceSegments = True
+        options.spareDataDirectoryFile = None
+        # import HERE so that patches are already in place!
+        from programs.clsRecoverSegment import GpRecoverSegmentProgram
+        self.subject = GpRecoverSegmentProgram(options)
+        self.subject.logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal'])
+
+        with self.assertRaises(SystemExit):
+          self.subject.run()
+
+        self.subject.logger.info.assert_any_call('The rebalance operation has completed successfully.')
+
+    @patch.object(TableLogger, "info")
+    @patch.object(GpSegmentRebalanceOperation, "rebalance", return_value=False)
+    @patch("os._exit")
+    def test_failed_rebalance(self, _, __, ___):
+        self.gpArrayMock.get_unbalanced_segdbs.return_value = [self.primary0]
+        options = Options()
+        options.masterDataDirectory = self.temp_dir
+        options.rebalanceSegments = True
+        options.spareDataDirectoryFile = None
+        # import HERE so that patches are already in place!
+        from programs.clsRecoverSegment import GpRecoverSegmentProgram
+        self.subject = GpRecoverSegmentProgram(options)
+        self.subject.logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal'])
+
+        with self.assertRaises(SystemExit) as cm:
+                self.subject.run()
+
+        self.assertEqual(cm.exception.code, 0)
+        self.subject.logger.info.assert_any_call('The rebalance operation has completed with WARNINGS. '
+                                                 'Please review the output in the gprecoverseg log.')
+
+    @patch.object(TableLogger, "info")
+    def test_failed_recover(self, _):
+        self.gpArrayMock.get_unbalanced_segdbs.return_value = [self.primary0]
+        options = Options()
+        options.masterDataDirectory = self.temp_dir
+        options.spareDataDirectoryFile = None
+        # import HERE so that patches are already in place!
+        from programs.clsRecoverSegment import GpRecoverSegmentProgram
+        self.subject = GpRecoverSegmentProgram(options)
+        self.subject.logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal'])
+        self.mock_get_mirrors_to_build.side_effect = self._get_test_mirrors
+        self.primary0.heap_checksum = 1
+        self.mock_check_segment_consistency.return_value = ([self.primary0], [], 1)
+        self.mock_get_segments_checksum_settings.return_value = ([self.mirror0], [])
+        self.return_one = True
+        self.mock_build_mirrors.return_value = False
+
+        with self.assertRaises(SystemExit) as cm:
+            self.subject.run()
+
+        self.assertEqual(cm.exception.code, 1)
+
+    @patch.object(TableLogger, "info")
+    def test_successful_recover(self, _):
+        self.gpArrayMock.get_unbalanced_segdbs.return_value = [self.primary0]
+        options = Options()
+        options.masterDataDirectory = self.temp_dir
+        options.spareDataDirectoryFile = None
+        # import HERE so that patches are already in place!
+        from programs.clsRecoverSegment import GpRecoverSegmentProgram
+        self.subject = GpRecoverSegmentProgram(options)
+        self.subject.logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal'])
+        self.mock_get_mirrors_to_build.side_effect = self._get_test_mirrors
+        self.primary0.heap_checksum = 1
+        self.mock_check_segment_consistency.return_value = ([self.primary0], [], 1)
+        self.mock_get_segments_checksum_settings.return_value = ([self.mirror0], [])
+        self.return_one = True
+        self.mock_build_mirrors.return_value = True
+
+        with self.assertRaises(SystemExit) as cm:
+            self.subject.run()
+
+        self.assertEqual(cm.exception.code, 0)
 
     def _create_gparray_with_2_primary_2_mirrors(self):
         master = GpDB.initFromString(

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
@@ -53,8 +53,8 @@ class GpRecoversegTestCase(GpTestCase):
         self.pgconf_dict["port"] = setting("port", "123", None, None, None)
         self.pgconf_dict["max_connection"] = setting("max_connections", "1", None, None, None)
 
-        configProviderMock = MagicMock(spec=GpConfigurationProvider)
-        configProviderMock.initializeProvider.return_value = configProviderMock
+        config_provider_mock = MagicMock(spec=GpConfigurationProvider)
+        config_provider_mock.initializeProvider.return_value = config_provider_mock
 
         self.gpArrayMock = MagicMock(spec=GpArray)
         self.gpArrayMock.getDbList.side_effect = [[], [self.primary0], [self.primary0]]
@@ -62,7 +62,7 @@ class GpRecoversegTestCase(GpTestCase):
         self.gpArrayMock.isStandardArray.return_value = (True, None)
         self.gpArrayMock.master = self.gparray.master
 
-        configProviderMock.loadSystemConfig.return_value = self.gpArrayMock
+        config_provider_mock.loadSystemConfig.return_value = self.gpArrayMock
 
         self.mirror_to_build = GpMirrorToBuild(self.mirror0, self.primary0, None, False)
         self.apply_patches([
@@ -70,13 +70,12 @@ class GpRecoversegTestCase(GpTestCase):
             patch('gppylib.db.dbconn.connect', return_value=self.conn),
             patch('gppylib.db.dbconn.execSQL', return_value=self.cursor),
             patch('gppylib.db.dbconn.execSQLForSingletonRow', return_value=["foo"]),
-            patch('gppylib.commands.base.WorkerPool'),
             patch('gppylib.pgconf.readfile', return_value=self.pgconf_dict),
             patch('gppylib.commands.gp.GpVersion'),
             patch('gppylib.db.catalog.getCollationSettings',
                   return_value=("en_US.utf-8", "en_US.utf-8", "en_US.utf-8")),
             patch('gppylib.system.faultProberInterface.getFaultProber'),
-            patch('gppylib.system.configurationInterface.getConfigurationProvider', return_value=configProviderMock),
+            patch('gppylib.system.configurationInterface.getConfigurationProvider', return_value=config_provider_mock),
             patch('gppylib.commands.base.WorkerPool', return_value=self.pool),
             patch('gppylib.gparray.GpArray.getSegmentsByHostName', return_value={}),
             patch('gppylib.gplog.get_default_logger'),
@@ -164,7 +163,6 @@ class GpRecoversegTestCase(GpTestCase):
         self.subject.logger.info.assert_any_call('No checksum validation necessary when '
                                                  'there are no segments to recover.')
 
-
     def _create_gparray_with_2_primary_2_mirrors(self):
         master = GpDB.initFromString(
             "1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
@@ -177,7 +175,6 @@ class GpRecoversegTestCase(GpTestCase):
         mirror1 = GpDB.initFromString(
             "5|1|m|m|s|u|sdw1|sdw1|50001|51001|/data/mirror1||/data/mirror1/base/10899,/data/mirror1/base/1,/data/mirror1/base/10898,/data/mirror1/base/25780,/data/mirror1/base/34782")
         return GpArray([master, self.primary0, primary1, self.mirror0, mirror1])
-
 
 
 if __name__ == '__main__':

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_rebalance_segment.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_rebalance_segment.py
@@ -1,0 +1,76 @@
+from mock import *
+
+from gp_unittest import *
+from gppylib.gparray import GpArray, GpDB
+from gppylib.commands.base import CommandResult
+from gppylib.operations.rebalanceSegments import GpSegmentRebalanceOperation
+
+
+class RebalanceSegmentsTestCase(GpTestCase):
+    def setUp(self):
+        self.pool = Mock()
+        self.pool.getCompletedItems.return_value = []
+
+        self.apply_patches([
+            patch("gppylib.commands.base.WorkerPool.__init__", return_value=None),
+            patch("gppylib.commands.base.WorkerPool", return_value=self.pool),
+            patch('gppylib.programs.clsRecoverSegment.GpRecoverSegmentProgram'),
+        ])
+
+        self.mock_gp_recover_segment_prog_class = self.get_mock_from_apply_patch('GpRecoverSegmentProgram')
+        self.mock_parser = Mock()
+        self.mock_gp_recover_segment_prog_class.createParser.return_value = self.mock_parser
+        self.mock_parser.parse_args.return_value = (Mock(), Mock())
+        self.mock_gp_recover_segment_prog = Mock()
+        self.mock_gp_recover_segment_prog_class.createProgram.return_value = self.mock_gp_recover_segment_prog
+
+        self.failure_command_mock = Mock()
+        self.failure_command_mock.get_results.return_value = CommandResult(
+            1, "stdout failure text", "stderr text", True, False)
+
+        self.success_command_mock = Mock()
+        self.success_command_mock.get_results.return_value = CommandResult(
+            0, "stdout success text", "stderr text", True, False)
+
+        self.subject = GpSegmentRebalanceOperation(Mock(), self._create_gparray_with_2_primary_2_mirrors())
+        self.subject.logger = Mock()
+
+    def tearDown(self):
+        super(RebalanceSegmentsTestCase, self).tearDown()
+
+    def test_rebalance_returns_success(self):
+        self.pool.getCompletedItems.return_value = [self.success_command_mock]
+
+        result = self.subject.rebalance()
+
+        self.assertTrue(result)
+
+    def test_rebalance_raises(self):
+        self.pool.getCompletedItems.return_value = [self.failure_command_mock]
+        self.mock_gp_recover_segment_prog.run.side_effect = SystemExit(1)
+
+        with self.assertRaisesRegexp(Exception, "Error synchronizing."):
+            self.subject.rebalance()
+
+    def test_rebalance_returns_failure(self):
+        self.pool.getCompletedItems.side_effect = [[self.failure_command_mock], [self.success_command_mock]]
+
+        result = self.subject.rebalance()
+        self.assertFalse(result)
+
+    def _create_gparray_with_2_primary_2_mirrors(self):
+        master = GpDB.initFromString(
+            "1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
+        self.primary0 = GpDB.initFromString(
+            "2|0|p|p|s|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
+        primary1 = GpDB.initFromString(
+            "3|1|p|p|s|u|sdw2|sdw2|40001|41001|/data/primary1||/data/primary1/base/10899,/data/primary1/base/1,/data/primary1/base/10898,/data/primary1/base/25780,/data/primary1/base/34782")
+        self.mirror0 = GpDB.initFromString(
+            "4|0|m|m|s|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
+        mirror1 = GpDB.initFromString(
+            "5|1|m|m|s|u|sdw1|sdw1|50001|51001|/data/mirror1||/data/mirror1/base/10899,/data/mirror1/base/1,/data/mirror1/base/10898,/data/mirror1/base/25780,/data/mirror1/base/34782")
+        return GpArray([master, self.primary0, primary1, self.mirror0, mirror1])
+
+
+if __name__ == '__main__':
+    run_tests()


### PR DESCRIPTION
gprecoverseg called itself during a rebalance, through a Command object.
But this command didn't signal failures through a non-zero ret-code. So
the top-level gprecoverseg didn't check its stdout/stderr for error
messages and didn't echo them to its own stdout, though they were being
logged.

This commit changes behavior so gprecoverseg make another object and
invokes its run() method. Any errors are now shown to the user and
logged.