### PR TITLE
GPDB builds PXF only with enable-pxf configure option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ before_script:
 
 script:
   - cd ${TRAVIS_BUILD_DIR}
-  - ./configure --with-openssl --with-ldap --with-libcurl --prefix=${TRAVIS_BUILD_DIR}/gpsql --with-apr-config=${TRAVIS_BUILD_DIR}/tools/bin/apr-1-config --disable-orca --disable-gpcloud --disable-pxf
+  - ./configure --with-openssl --with-ldap --with-libcurl --prefix=${TRAVIS_BUILD_DIR}/gpsql --with-apr-config=${TRAVIS_BUILD_DIR}/tools/bin/apr-1-config --disable-orca --disable-gpcloud
 
   - make
   - make install

--- a/README.md
+++ b/README.md
@@ -201,14 +201,16 @@ make distclean
 ./configure --disable-orca --with-perl --with-python --with-libxml --prefix=/usr/local/gpdb
 ```
 
-### Building GPDB without PXF
-PXF is an extension framework for GPDB to enable access to external hadoop datasets.
+### Building GPDB with PXF
+PXF is an extension framework for GPDB to enable fast access to external hadoop datasets.
 Refer to [PXF extension](https://github.com/greenplum-db/gpdb/tree/master/gpAux/extensions/pxf) for more information.
-Currently, GPDPB is built with PXF by default.
-PXF requires curl version > 7.21.3. On most centos6 environments with curl version 7.19 compilation will fail due to this dependancy.
-You can either try upgrading your curl version, or simply disable pxf during build.
-If you don't need PXF, use --disable-pxf flag with configure.
-
+Currently, GPDPB isn't built with PXF by default.
+PXF requires curl version >= 7.21.3 and also has an additional dependancy on json-c library
+In order to build GPDB with pxf, simply change `configure` with additional option `--enable-pxf`.
+```
+# Configure build environment to build/install PXF at /usr/local/gpdb
+./configure --with-perl --with-python --with-libxml --prefix=/usr/local/gpdb --enable-pxf 
+```
 
 ### Building GPDB with code generation enabled
 

--- a/concourse/scripts/builds/GpBuild.py
+++ b/concourse/scripts/builds/GpBuild.py
@@ -14,7 +14,6 @@ class GpBuild(GpdbBuildBase):
                                 "--with-libxml",
                                 "--with-python",
                                 "--disable-gpcloud",
-                                "--disable-pxf",
                                 "--prefix=/usr/local/gpdb"], cwd="gpdb_src")
 
     def icg(self):

--- a/concourse/scripts/common.bash
+++ b/concourse/scripts/common.bash
@@ -26,9 +26,9 @@ function configure() {
       # on these options for deciding what to test. Since we don't ship
       # Perl on SLES we must also skip GPMapreduce as it uses pl/perl.
       if [ "$TEST_OS" == "sles" ]; then
-        ./configure --prefix=/usr/local/greenplum-db-devel --with-python --with-libxml --disable-orca --disable-pxf ${CONFIGURE_FLAGS}
+        ./configure --prefix=/usr/local/greenplum-db-devel --with-python --with-libxml --disable-orca ${CONFIGURE_FLAGS}
       else
-        ./configure --prefix=/usr/local/greenplum-db-devel --with-perl --with-python --with-libxml --enable-mapreduce --disable-orca ${CONFIGURE_FLAGS}
+        ./configure --prefix=/usr/local/greenplum-db-devel --with-perl --with-python --with-libxml --enable-mapreduce --disable-orca --enable-pxf ${CONFIGURE_FLAGS}
       fi
   popd
 }

--- a/concourse/scripts/compile_gpdb_open_source.bash
+++ b/concourse/scripts/compile_gpdb_open_source.bash
@@ -47,7 +47,7 @@ function build_gpdb() {
   pushd gpdb_src
     source /opt/gcc_env.sh
     CC=$(which gcc) CXX=$(which g++) ./configure --enable-mapreduce --with-perl --with-libxml \
-	--disable-orca --with-python --disable-gpfdist --disable-pxf --prefix=${GREENPLUM_INSTALL_DIR}
+	--disable-orca --with-python --disable-gpfdist --prefix=${GREENPLUM_INSTALL_DIR}
     # Use -j4 to speed up the build. (Doesn't seem worth trying to guess a better
     # value based on number of CPUs or anything like that. Going above -j4 wouldn't
     # make it much faster, and -j4 is small enough to not hurt too badly even on

--- a/configure
+++ b/configure
@@ -1527,7 +1527,7 @@ Optional Features:
   --disable-spinlocks     do not use spinlocks
   --disable-atomics       do not use atomic operations
   --disable-gpfdist       do not use gpfdist
-  --disable-pxf           do not use pxf
+  --enable-pxf            build with pxf
   --enable-gpperfmon      build with gpperfmon
   --enable-debug          build with debugging symbols (-g)
   --enable-profiling      build with profiling enabled
@@ -3582,7 +3582,7 @@ if test "${enable_pxf+set}" = set; then :
   esac
 
 else
-  enable_pxf=yes
+  enable_pxf=no
 
 fi
 

--- a/configure.in
+++ b/configure.in
@@ -234,8 +234,8 @@ AC_SUBST(enable_gpfdist)
 #
 # pxf
 #
-PGAC_ARG_BOOL(enable, pxf, yes,
-             [  --disable-pxf           do not use pxf])
+PGAC_ARG_BOOL(enable, pxf, no,
+             [  --enable-pxf            build with pxf])
 AC_SUBST(enable_pxf)
 
 #

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -159,16 +159,16 @@ endif
 
 APU_CONFIG=--with-apu-config=$(BLD_THIRDPARTY_BIN_DIR)/apu-1-config
 
-aix7_ppc_64_CONFIGFLAGS=--disable-gpcloud --without-readline --without-libcurl --disable-pxf --disable-orca $(APR_CONFIG)
-win32_CONFIGFLAGS=--with-gssapi --without-libcurl --disable-pxf --disable-pxf --disable-orca --disable-gpcloud $(APR_CONFIG)
+aix7_ppc_64_CONFIGFLAGS=--disable-gpcloud --without-readline --without-libcurl --disable-orca $(APR_CONFIG)
+win32_CONFIGFLAGS=--with-gssapi --without-libcurl --disable-orca --disable-gpcloud $(APR_CONFIG)
 sol10_x86_64_CONFIGFLAGS=--enable-snmp --with-libxml $(APR_CONFIG)
-rhel5_x86_32_CONFIGFLAGS=--host=i686-pc-linux-gnu --enable-snmp --enable-ddboost --with-gssapi --enable-netbackup --with-libxml $(APR_CONFIG)
-rhel5_x86_64_CONFIGFLAGS=--enable-snmp --enable-gpperfmon --enable-ddboost --with-gssapi --enable-netbackup ${ORCA_CONFIG} --with-libxml $(APR_CONFIG) $(APU_CONFIG)
-rhel6_x86_64_CONFIGFLAGS=--enable-snmp --enable-tap-tests --enable-gpperfmon --enable-ddboost --with-gssapi --enable-netbackup --enable-mapreduce ${ORCA_CONFIG} --with-libxml $(APR_CONFIG) $(APU_CONFIG)
-rhel7_x86_64_CONFIGFLAGS=--enable-snmp --enable-tap-tests --enable-gpperfmon --enable-ddboost --disable-pxf --with-gssapi --enable-netbackup --enable-mapreduce ${ORCA_CONFIG} --with-libxml $(APR_CONFIG) $(APU_CONFIG)
-suse10_x86_64_CONFIGFLAGS=--enable-snmp --enable-ddboost --enable-gpperfmon --disable-pxf --with-gssapi ${ORCA_CONFIG} --with-libxml $(APR_CONFIG) $(APU_CONFIG)
-suse11_x86_64_CONFIGFLAGS=--enable-snmp --enable-ddboost  --enable-gpperfmon --disable-pxf --with-gssapi ${ORCA_CONFIG} --with-libxml $(APR_CONFIG) $(APU_CONFIG)
-sles11_x86_64_CONFIGFLAGS=--enable-snmp --enable-ddboost  --enable-gpperfmon --disable-pxf --with-gssapi ${ORCA_CONFIG} --with-libxml $(APR_CONFIG) $(APU_CONFIG)
+rhel5_x86_32_CONFIGFLAGS=--host=i686-pc-linux-gnu --enable-snmp --enable-ddboost --with-gssapi --enable-netbackup --enable-pxf --with-libxml $(APR_CONFIG)
+rhel5_x86_64_CONFIGFLAGS=--enable-snmp --enable-gpperfmon --enable-ddboost --with-gssapi --enable-netbackup ${ORCA_CONFIG} --enable-pxf --with-libxml $(APR_CONFIG) $(APU_CONFIG)
+rhel6_x86_64_CONFIGFLAGS=--enable-snmp --enable-tap-tests --enable-gpperfmon --enable-ddboost --with-gssapi --enable-netbackup --enable-mapreduce ${ORCA_CONFIG} --enable-pxf --with-libxml $(APR_CONFIG) $(APU_CONFIG)
+rhel7_x86_64_CONFIGFLAGS=--enable-snmp --enable-tap-tests --enable-gpperfmon --enable-ddboost --with-gssapi --enable-netbackup --enable-mapreduce ${ORCA_CONFIG} --enable-pxf --with-libxml $(APR_CONFIG) $(APU_CONFIG)
+suse10_x86_64_CONFIGFLAGS=--enable-snmp --enable-ddboost --enable-gpperfmon --with-gssapi ${ORCA_CONFIG} --with-libxml $(APR_CONFIG) $(APU_CONFIG)
+suse11_x86_64_CONFIGFLAGS=--enable-snmp --enable-ddboost  --enable-gpperfmon --with-gssapi ${ORCA_CONFIG} --with-libxml $(APR_CONFIG) $(APU_CONFIG)
+sles11_x86_64_CONFIGFLAGS=--enable-snmp --enable-ddboost  --enable-gpperfmon --with-gssapi ${ORCA_CONFIG} --with-libxml $(APR_CONFIG) $(APU_CONFIG)
 linux_x86_64_CONFIGFLAGS=--enable-snmp ${ORCA_CONFIG} --with-libxml $(APR_CONFIG)
 osx106_x86_CONFIGFLAGS=--enable-snmp ${ORCA_CONFIG} --with-libxml $(APR_CONFIG)
 


### PR DESCRIPTION
Modified the behavior of gpconfigure to not build PXF by default. --enable-pxf option needs to be used to build the package. The change is due to the additional dependancies on json-c library and a minimum curl version dependancy.