### PR TITLE
Refactor window function syntax checks to match upstream.

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -395,6 +395,9 @@ transformDeleteStmt(ParseState *pstate, DeleteStmt *stmt)
 		parseCheckAggregates(pstate, qry);
 	if (pstate->p_hasTblValueExpr)
 		parseCheckTableFunctions(pstate, qry);
+	qry->hasWindowFuncs = pstate->p_hasWindowFuncs;
+	if (pstate->p_hasWindowFuncs)
+		parseCheckWindowFuncs(pstate, qry);
 
 	return qry;
 }
@@ -1607,8 +1610,7 @@ transformSelectStmt(ParseState *pstate, SelectStmt *stmt)
 
 	qry->hasWindowFuncs = pstate->p_hasWindowFuncs;
 	if (pstate->p_hasWindowFuncs)
-		parseProcessWindFuncs(pstate, qry);
-
+		parseCheckWindowFuncs(pstate, qry);
 
 	foreach(l, stmt->lockingClause)
 	{
@@ -2080,6 +2082,10 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 
 	if (pstate->p_hasTblValueExpr)
 		parseCheckTableFunctions(pstate, qry);
+
+	qry->hasWindowFuncs = pstate->p_hasWindowFuncs;
+	if (pstate->p_hasWindowFuncs)
+		parseCheckWindowFuncs(pstate, qry);
 
 	foreach(l, lockingClause)
 	{

--- a/src/include/parser/parse_agg.h
+++ b/src/include/parser/parse_agg.h
@@ -20,7 +20,7 @@ extern void transformAggregateCall(ParseState *pstate, Aggref *agg,
 extern void transformWindowFuncCall(ParseState *pstate, WindowRef *wind, WindowSpec *over);
 
 extern void parseCheckAggregates(ParseState *pstate, Query *qry);
-extern void parseProcessWindFuncs(ParseState *pstate, Query *qry);
+extern void parseCheckWindowFuncs(ParseState *pstate, Query *qry);
 extern void transformWindowSpec(ParseState *pstate, WindowSpec *spec);
 extern void transformWindowSpecExprs(ParseState *pstate);
 

--- a/src/test/regress/expected/olap_window_seq.out
+++ b/src/test/regress/expected/olap_window_seq.out
@@ -7615,44 +7615,11 @@ select ord, cn,vn,sum(vn) over (order by ord rows between 3 following and floor(
   12 |  4 | 40 |    
 (12 rows)
 
--- Test use of window functions in places they shouldn't be allowed: MPP-2382
--- CHECK constraints
-CREATE TABLE wintest_for_window_seq (i int check (i < count(*) over (order by i)));
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-ERROR:  cannot use window function in check constraint
-CREATE TABLE wintest_for_window_seq (i int default count(*) over (order by i));
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-ERROR:  cannot use window function in default expression
--- index expression and function
-CREATE TABLE wintest_for_window_seq (i int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-CREATE INDEX wintest_idx_for_window_seq on wintest_for_window_seq (i) where i < count(*) over (order by i);
-ERROR:  cannot use window function in index predicate
-CREATE INDEX wintest_idx_for_window_seq on wintest_for_window_seq (sum(i) over (order by i));
-ERROR:  syntax error at or near "("
-LINE 1: ...window_seq on wintest_for_window_seq (sum(i) over (order by ...
-                                                             ^
--- alter table
-ALTER TABLE wintest_for_window_seq alter i set default count(*) over (order by i);
-ERROR:  cannot use window function in default expression
-alter table wintest_for_window_seq alter column i type float using count(*) over (order by
-i)::float;
-ERROR:  cannot use window function in transform expression
--- update
-insert into wintest_for_window_seq values(1);
-update wintest_for_window_seq set i = count(*) over (order by i);
-ERROR:  cannot use window function in UPDATE
-LINE 1: update wintest_for_window_seq set i = count(*) over (order b...
-                                              ^
 -- domain suport
 create domain wintestd as int default count(*) over ();
 ERROR:  cannot use window function in default expression
 create domain wintestd as int check (value < count(*) over ());
 ERROR:  cannot use window function in check constraint
-drop table wintest_for_window_seq;
 -- MPP-3295
 -- begin equivalent
 select cn,vn,rank() over (partition by cn order by vn) as rank

--- a/src/test/regress/expected/olap_window_seq_optimizer.out
+++ b/src/test/regress/expected/olap_window_seq_optimizer.out
@@ -7617,44 +7617,11 @@ select ord, cn,vn,sum(vn) over (order by ord rows between 3 following and floor(
   12 |  4 | 40 |    
 (12 rows)
 
--- Test use of window functions in places they shouldn't be allowed: MPP-2382
--- CHECK constraints
-CREATE TABLE wintest_for_window_seq (i int check (i < count(*) over (order by i)));
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-ERROR:  cannot use window function in check constraint
-CREATE TABLE wintest_for_window_seq (i int default count(*) over (order by i));
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-ERROR:  cannot use window function in default expression
--- index expression and function
-CREATE TABLE wintest_for_window_seq (i int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-CREATE INDEX wintest_idx_for_window_seq on wintest_for_window_seq (i) where i < count(*) over (order by i);
-ERROR:  cannot use window function in index predicate
-CREATE INDEX wintest_idx_for_window_seq on wintest_for_window_seq (sum(i) over (order by i));
-ERROR:  syntax error at or near "("
-LINE 1: ...window_seq on wintest_for_window_seq (sum(i) over (order by ...
-                                                             ^
--- alter table
-ALTER TABLE wintest_for_window_seq alter i set default count(*) over (order by i);
-ERROR:  cannot use window function in default expression
-alter table wintest_for_window_seq alter column i type float using count(*) over (order by
-i)::float;
-ERROR:  cannot use window function in transform expression
--- update
-insert into wintest_for_window_seq values(1);
-update wintest_for_window_seq set i = count(*) over (order by i);
-ERROR:  cannot use window function in UPDATE
-LINE 1: update wintest_for_window_seq set i = count(*) over (order b...
-                                              ^
 -- domain suport
 create domain wintestd as int default count(*) over ();
 ERROR:  cannot use window function in default expression
 create domain wintestd as int check (value < count(*) over ());
 ERROR:  cannot use window function in check constraint
-drop table wintest_for_window_seq;
 -- MPP-3295
 -- begin equivalent
 select cn,vn,rank() over (partition by cn order by vn) as rank

--- a/src/test/regress/expected/qp_olap_windowerr.out
+++ b/src/test/regress/expected/qp_olap_windowerr.out
@@ -3404,9 +3404,60 @@ ERROR:  argument value out of range
 HINT:  NTILE expects a positive integer argument.
 -- start_ignore
 DROP TABLE filter_test;
+-- end_ignore
+-- Test use of window functions in places they shouldn't be allowed: MPP-2382
+-- CHECK constraints
+CREATE TABLE wintest_for_window_seq (i int check (i < count(*) over (order by i)));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+ERROR:  cannot use window function in check constraint
+CREATE TABLE wintest_for_window_seq (i int default count(*) over (order by i));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+ERROR:  cannot use window function in default expression
+-- index expression and function
+CREATE TABLE wintest_for_window_seq (i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into wintest_for_window_seq values(1);
+CREATE INDEX wintest_idx_for_window_seq on wintest_for_window_seq (i) where i < count(*) over (order by i);
+ERROR:  cannot use window function in index predicate
+CREATE INDEX wintest_idx_for_window_seq on wintest_for_window_seq (sum(i) over (order by i));
+ERROR:  syntax error at or near "("
+LINE 1: ...window_seq on wintest_for_window_seq (sum(i) over (order by ...
+                                                             ^
+CREATE INDEX wintest_idx_for_window_seq on wintest_for_window_seq ((sum(i) over (order by i)));
+ERROR:  cannot use window function in index expression
+-- alter table
+ALTER TABLE wintest_for_window_seq alter i set default count(*) over (order by i);
+ERROR:  cannot use window function in default expression
+alter table wintest_for_window_seq alter column i type float using count(*) over (order by
+i)::float;
+ERROR:  cannot use window function in transform expression
+-- select
+select * from wintest_for_window_seq where count(*) over (order by i) > 0;
+ERROR:  window functions not allowed in WHERE clause
+LINE 1: select * from wintest_for_window_seq where count(*) over (or...
+                                                   ^
+-- update
+update wintest_for_window_seq set i = count(*) over (order by i);
+ERROR:  cannot use window function in UPDATE
+LINE 1: update wintest_for_window_seq set i = count(*) over (order b...
+                                              ^
+update wintest_for_window_seq set i = 1 where count(*) over (order by i) > 0;
+ERROR:  cannot use window function in UPDATE
+LINE 1: update wintest_for_window_seq set i = 1 where count(*) over ...
+                                                      ^
+-- delete
+delete from wintest_for_window_seq where count(*) over (order by i) > 0;
+ERROR:  window functions not allowed in WHERE clause
+LINE 1: delete from wintest_for_window_seq where count(*) over (orde...
+                                                 ^
+drop table wintest_for_window_seq;
 --
 -- STANDARD DATA FOR olap_* TESTS.
 --
+-- start_ignore
 drop table cf_olap_windowerr_customer;
 drop table cf_olap_windowerr_vendor;
 drop table cf_olap_windowerr_product;

--- a/src/test/regress/sql/olap_window_seq.sql
+++ b/src/test/regress/sql/olap_window_seq.sql
@@ -1317,30 +1317,9 @@ select ord, pn,cn,vn,sum(vn) over (order by ord, pn rows between cn following an
 -- MPP-2323
 select ord, cn,vn,sum(vn) over (order by ord rows between 3 following and floor(cn) following ) from sale_ord;
 
--- Test use of window functions in places they shouldn't be allowed: MPP-2382
--- CHECK constraints
-CREATE TABLE wintest_for_window_seq (i int check (i < count(*) over (order by i)));
-
-CREATE TABLE wintest_for_window_seq (i int default count(*) over (order by i));
-
--- index expression and function
-CREATE TABLE wintest_for_window_seq (i int);
-CREATE INDEX wintest_idx_for_window_seq on wintest_for_window_seq (i) where i < count(*) over (order by i);
-CREATE INDEX wintest_idx_for_window_seq on wintest_for_window_seq (sum(i) over (order by i));
--- alter table
-ALTER TABLE wintest_for_window_seq alter i set default count(*) over (order by i);
-alter table wintest_for_window_seq alter column i type float using count(*) over (order by
-i)::float;
-
--- update
-insert into wintest_for_window_seq values(1);
-update wintest_for_window_seq set i = count(*) over (order by i);
-
 -- domain suport
 create domain wintestd as int default count(*) over ();
 create domain wintestd as int check (value < count(*) over ());
-
-drop table wintest_for_window_seq;
 
 -- MPP-3295
 -- begin equivalent


### PR DESCRIPTION
Mostly, move the responsibilities of the check_call() function to the
callers, transformAggregateCall() and transformWindowFuncCall().

This fixes one long-standing, albeit harmless, bug. Previously, you got an
"Unexpected internal error", if you tried to use a window function in the
WHERE clause of a DELETE statement, instead of a user-friendly syntax
error. Add a test case for that.

Move a few similar tests from 'olap_window_seq' to 'qp_olap_windowerr'.
Seems like a more appropriate place for them. Also, 'olap_window_seq' has
an alternative expected output file for ORCA, so it's nice to keep tests
that produce the same output with or without ORCA out of there. Also add a
test query for creating an index on an expression containing a window
function. There was a test for that already, but it was missing parens
around the expression, and therefore produced an error already in the
grammar.