### PR TITLE
Force a stand-alone backend to run in utility mode.

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -516,6 +516,16 @@ assign_gp_session_role(const char *newval, bool doit, GucSource source __attribu
 		return NULL;
 	}
 
+	/* Force utility mode in a stand-alone backend. */
+	if (!IsPostmasterEnvironment && newrole != GP_ROLE_UTILITY)
+	{
+		if (source != PGC_S_DEFAULT)
+			elog(WARNING, "gp_session_role forced to 'utility' in single-user mode");
+
+		newval = strdup("utility");
+		newrole = GP_ROLE_UTILITY;
+	}
+
 	if (doit)
 	{
 		Gp_session_role = newrole;


### PR DESCRIPTION
In a stand-alone backend ("postgres --single"), you cannot realistically
expect any of the infrastructure needed for MPP processing to be present.
Let's force a stand-alone backend to run in utility mode, to make sure
that we don't try to dispatch queries, participate in distributed
transactions, or anything like that, in a stand-alone backend.

Fixes github issue #3172, which was one such case where we tried to
dispatch a SET command in single-user mode, and got all confused.