### PR TITLE
Add missing subselect test case with CTE [#150338742]

### DIFF
--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -540,7 +540,19 @@ group by f1,f2,fs;
 -- Check that whole-row Vars reading the result of a subselect don't include
 -- any junk columns therein
 --
-select q from (select max(f1) as max from int4_tbl group by f1 order by f1) q order by max;
+select q from (select max(f1) from int4_tbl group by f1 order by f1) q
+  order by max;
+       q       
+---------------
+ (-2147483647)
+ (-123456)
+ (0)
+ (123456)
+ (2147483647)
+(5 rows)
+
+with q as (select max(f1) from int4_tbl group by f1 order by f1)
+  select q from q;
        q       
 ---------------
  (-2147483647)

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -551,7 +551,19 @@ group by f1,f2,fs;
 -- Check that whole-row Vars reading the result of a subselect don't include
 -- any junk columns therein
 --
-select q from (select max(f1) as max from int4_tbl group by f1 order by f1) q order by max;
+select q from (select max(f1) from int4_tbl group by f1 order by f1) q
+  order by max;
+       q
+---------------
+ (-2147483647)
+ (-123456)
+ (0)
+ (123456)
+ (2147483647)
+(5 rows)
+
+with q as (select max(f1) from int4_tbl group by f1 order by f1)
+  select q from q;
        q       
 ---------------
  (-2147483647)

--- a/src/test/regress/sql/subselect.sql
+++ b/src/test/regress/sql/subselect.sql
@@ -325,7 +325,10 @@ group by f1,f2,fs;
 -- any junk columns therein
 --
 
-select q from (select max(f1) as max from int4_tbl group by f1 order by f1) q order by max;
+select q from (select max(f1) from int4_tbl group by f1 order by f1) q
+  order by max;
+with q as (select max(f1) from int4_tbl group by f1 order by f1)
+  select q from q;
 
 --
 -- Test case for sublinks pushed down into subselects via join alias expansion


### PR DESCRIPTION
Commit 038c36b6bb71c177502fda6a6c2cc7aecfe3efe0 from Postgres 8.3 was
merged into Greenplum in a453004ea1. Commit 038c36b6 is a partial back
port of commit 688aafa1 from Postgres 8.4. What's partial about 038c36b6
is the omission of a test case containing CTE: a whole-row variable can
refer to either an aliased `FROM` clause, or it can refer to a CTE. The
CTE case was omitted because upstream 8.3 didn't have CTE.

The non-CTE test case was slightly modified to add an `ORDER BY` clause
because atmsort is confused by the `ORDER BY` inside the subselect:
semantically we expect the differ to canonicalize (sort) the output
before comparison, because sorted order of a subselect is not preserved
according to SQL standard, but in this case atmsort believes the output
is already sorted (by virtue of the presence of `ORDER BY`, even though
it's within the subselect).

Original commit message of 688aafa1 is enclosed:

> Fix whole-row Var evaluation to cope with resjunk columns (again).
>
> When a whole-row Var is reading the result of a subquery, we need it to
> ignore any "resjunk" columns that the subquery might have evaluated for
> GROUP BY or ORDER BY purposes.  We've hacked this area before, in commit
> 68e40998d058c1f6662800a648ff1e1ce5d99cba, but that fix only covered
> whole-row Vars of named composite types, not those of RECORD type; and it
> was mighty klugy anyway, since it just assumed without checking that any
> extra columns in the result must be resjunk.  A proper fix requires getting
> hold of the subquery's targetlist so we can actually see which columns are
> resjunk (whereupon we can use a JunkFilter to get rid of them).  So bite
> the bullet and add some infrastructure to make that possible.
>
> Per report from Andrew Dunstan and additional testing by Merlin Moncure.
> Back-patch to all supported branches.  In 8.3, also back-patch commit
> 292176a118da6979e5d368a4baf27f26896c99a5, which for some reason I had
> not done at the time, but it's a prerequisite for this change.

(cherry picked from commit 688aafa15d8d83077c686d2b5b88226528e29840)