### PR TITLE
Reduce the number of join orders considered by GPORCA

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4631,7 +4631,7 @@ struct config_int ConfigureNamesInt_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_join_arity_for_associativity_commutativity,
-		INT_MAX, 0, INT_MAX, NULL, NULL
+		7, 0, INT_MAX, NULL, NULL
 	},
 
 	{


### PR DESCRIPTION
Previously we were setting the value of
`optimizer_join_arity_for_associativity_commutativity` to a very large
number and so ORCA would spend a very long time evaluating all possible n_way_join
combinations to come up with the cheapest join tree to use in the final plan it produced.

We are reducing this value to `7` as it does not prove to be beneficial
to spend the additional time and resources to evaluate any more than `7_way_joins` in
trying to find the cheapest join tree. [#150717406]