### PR TITLE
Fix a few compiler warnings introduced by the recursive CTEs patch.

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -2067,7 +2067,6 @@ show_grouping_keys(Plan        *plan,
     appendStringInfo(str, "  %s: ", qlabel);
 
     Node *outerPlan = (Node *) outerPlan(subplan);
-    Node *innerPlan = (Node *) innerPlan(subplan);
 
 	/*
 	 * Dig the child nodes of the subplan. This logic should match that in
@@ -2079,10 +2078,10 @@ show_grouping_keys(Plan        *plan,
 		outerPlan = (Node *) llast(((Sequence *) subplan)->subplans);
 
 	/* Set up deparse context */
-	context = deparse_context_for_plan(subplan,
+	context = deparse_context_for_plan((Node *) subplan,
 									   outerPlan,
-										   es->rtable,
-										   es->pstmt->subplans);
+									   es->rtable,
+									   es->pstmt->subplans);
 
 	if (IsA(plan, Agg))
 	{

--- a/src/backend/optimizer/prep/prepunion.c
+++ b/src/backend/optimizer/prep/prepunion.c
@@ -291,8 +291,6 @@ generate_recursion_plan(SetOperationStmt *setOp, PlannerInfo *root,
 	Plan	   *lplan;
 	Plan	   *rplan;
 	List	   *tlist;
-	bool		enableHashJoin;
-	bool		enableNestLoop;
 
 	/* Parser should have rejected other cases */
 	if (setOp->op != SETOP_UNION || !setOp->all)

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -3689,12 +3689,8 @@ get_name_for_var_field(Var *var, int fieldno,
 														attnum);
 
 					if (ste == NULL || ste->resjunk)
-					{
-						ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
-											errmsg_internal(ERROR, "subquery %s does not have attribute %d",
-											rte->eref->aliasname, attnum);
-					}
-
+						elog(ERROR, "subquery %s does not have attribute %d",
+							 rte->eref->aliasname, attnum);
 					expr = (Node *) ste->expr;
 					if (IsA(expr, Var))
 					{


### PR DESCRIPTION
* In ruleutils.c, the ereport() was broken. Use elog() instead, like in
  the upstream. (elog() is fine for "can't happen" kind of sanity checks)

* Remove a few unused local variables.

* Add a missing cast from Plan * to Node *.