### PR TITLE
Fix few compiler warnings seen with clang.

### DIFF
--- a/contrib/hstore/hstore_op.c
+++ b/contrib/hstore/hstore_op.c
@@ -618,7 +618,7 @@ each(PG_FUNCTION_ARGS)
 		HEntry	   *ptr = &(ARRPTR(st->hs)[st->i]);
 		Datum		res,
 					dvalues[2];
-		char		nulls[] = {' ', ' '};
+		bool        nulls[2] = {false, false};
 		text	   *item;
 		HeapTuple	tuple;
 
@@ -630,7 +630,7 @@ each(PG_FUNCTION_ARGS)
 		if (ptr->valisnull)
 		{
 			dvalues[1] = (Datum) 0;
-			nulls[1] = 'n';
+			nulls[1] = true;
 		}
 		else
 		{
@@ -643,11 +643,11 @@ each(PG_FUNCTION_ARGS)
 		}
 		st->i++;
 
-		tuple = heap_formtuple(funcctx->attinmeta->tupdesc, dvalues, nulls);
+		tuple = heap_form_tuple(funcctx->attinmeta->tupdesc, dvalues, nulls);
 		res = HeapTupleGetDatum(tuple);
 
 		pfree(DatumGetPointer(dvalues[0]));
-		if (nulls[1] != 'n')
+		if (!nulls[1])
 			pfree(DatumGetPointer(dvalues[1]));
 
 		SRF_RETURN_NEXT(funcctx, res);

--- a/gpAux/extensions/gpcloud/src/s3key_reader.cpp
+++ b/gpAux/extensions/gpcloud/src/s3key_reader.cpp
@@ -144,7 +144,7 @@ uint64_t ChunkBuffer::fill() {
     return (this->isError()) ? -1 : readLen;
 }
 
-void* DownloadThreadFunc(void* data) {
+static void* DownloadThreadFunc(void* data) {
     MaskThreadSignals();
 
     ChunkBuffer* buffer = static_cast<ChunkBuffer*>(data);

--- a/gpAux/extensions/gpcloud/src/s3log.cpp
+++ b/gpAux/extensions/gpcloud/src/s3log.cpp
@@ -12,7 +12,7 @@ void write_log(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
 }
 #endif
 
-void _LogMessage(const char* fmt, va_list args) {
+static void _LogMessage(const char* fmt, va_list args) {
     char buf[MAX_MESSAGE_LINE_LENGTH];
     vsnprintf(buf, sizeof(buf), fmt, args);
 #ifdef S3_STANDALONE
@@ -22,7 +22,7 @@ void _LogMessage(const char* fmt, va_list args) {
 #endif
 }
 
-void _send_to_remote(const char* fmt, va_list args) {
+static void _send_to_remote(const char* fmt, va_list args) {
     char buf[MAX_MESSAGE_LINE_LENGTH];
     size_t len = vsnprintf(buf, sizeof(buf), fmt, args);
     sendto(s3ext_logsock_udp, buf, len, 0, (struct sockaddr*)&s3ext_logserveraddr,

--- a/gpAux/extensions/gpcloud/src/s3restful_service.cpp
+++ b/gpAux/extensions/gpcloud/src/s3restful_service.cpp
@@ -39,7 +39,7 @@ S3RESTfulService::~S3RESTfulService() {
 }
 
 // curl's write function callback.
-size_t RESTfulServiceWriteFuncCallback(char *ptr, size_t size, size_t nmemb, void *userp) {
+static size_t RESTfulServiceWriteFuncCallback(char *ptr, size_t size, size_t nmemb, void *userp) {
     if (S3QueryIsAbortInProgress()) {
         return 0;
     }
@@ -52,7 +52,7 @@ size_t RESTfulServiceWriteFuncCallback(char *ptr, size_t size, size_t nmemb, voi
 
 // cURL's write function callback, only used by DELETE request when query is canceled.
 // It shouldn't be interrupted.
-size_t RESTfulServiceAbortFuncCallback(char *ptr, size_t size, size_t nmemb, void *userp) {
+static size_t RESTfulServiceAbortFuncCallback(char *ptr, size_t size, size_t nmemb, void *userp) {
     size_t realsize = size * nmemb;
     Response *resp = (Response *)userp;
     resp->appendDataBuffer(ptr, realsize);
@@ -60,7 +60,7 @@ size_t RESTfulServiceAbortFuncCallback(char *ptr, size_t size, size_t nmemb, voi
 }
 
 // curl's headers write function callback.
-size_t RESTfulServiceHeadersWriteFuncCallback(char *ptr, size_t size, size_t nmemb, void *userp) {
+static size_t RESTfulServiceHeadersWriteFuncCallback(char *ptr, size_t size, size_t nmemb, void *userp) {
     if (S3QueryIsAbortInProgress()) {
         return 0;
     }
@@ -72,7 +72,7 @@ size_t RESTfulServiceHeadersWriteFuncCallback(char *ptr, size_t size, size_t nme
 }
 
 // curl's reading function callback.
-size_t RESTfulServiceReadFuncCallback(char *ptr, size_t size, size_t nmemb, void *userp) {
+static size_t RESTfulServiceReadFuncCallback(char *ptr, size_t size, size_t nmemb, void *userp) {
     if (S3QueryIsAbortInProgress()) {
         return CURL_READFUNC_ABORT;
     }

--- a/gpAux/extensions/gpcloud/src/s3utils.cpp
+++ b/gpAux/extensions/gpcloud/src/s3utils.cpp
@@ -77,21 +77,6 @@ bool sha256hmac_hex(const char *str, char out_hash_hex[65], const char *secret, 
     return true;
 }
 
-CURL *CreateCurlHandler(const char *path) {
-    CURL *curl = NULL;
-    if (!path) {
-        return NULL;
-    } else {
-        curl = curl_easy_init();
-    }
-
-    if (curl) {
-        curl_easy_setopt(curl, CURLOPT_URL, path);
-        // curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
-    }
-    return curl;
-}
-
 /*
  * It would be more efficient to use a variation of KMP to
  * benefit from the failure function.

--- a/gpAux/extensions/gpcloud/test/s3utils_test.cpp
+++ b/gpAux/extensions/gpcloud/test/s3utils_test.cpp
@@ -3,14 +3,6 @@
 #include "http_parser.cpp"
 #include "ini.cpp"
 
-TEST(Utils, simplecurl) {
-    CURL *c = CreateCurlHandler(NULL);
-    EXPECT_EQ(c, (void *)NULL);
-    c = CreateCurlHandler("www.google.com");
-    EXPECT_NE(c, (void *)NULL);
-    curl_easy_cleanup(c);
-}
-
 TEST(Utils, nth) {
     const char *teststr = "aaabbbcccaaatttaaa";
 

--- a/src/backend/access/common/memtuple.c
+++ b/src/backend/access/common/memtuple.c
@@ -625,7 +625,7 @@ MemTuple memtuple_form_to(
 				if (old_values == NULL)
 					old_values = (Datum *)palloc0(pbind->tupdesc->natts * sizeof(Datum));
 				old_values[i] = values[i];
-				values[i] = PointerGetDatum(heap_tuple_fetch_attr(DatumGetPointer(values[i])));
+				values[i] = PointerGetDatum(heap_tuple_fetch_attr((struct varlena *)DatumGetPointer(values[i])));
 
 				if (old_values[i] == values[i])
 					old_values[i] = 0;

--- a/src/backend/access/common/reloptions.c
+++ b/src/backend/access/common/reloptions.c
@@ -873,7 +873,7 @@ parseRelOptions(Datum options, int numkeywords, const char *const * keywords,
 		return;
 
 	array = DatumGetArrayTypeP(options);
-	isArrayToBeFreed = (array != DatumGetPointer(options));
+	isArrayToBeFreed = (array != (ArrayType *)DatumGetPointer(options));
 
 	Assert(ARR_ELEMTYPE(array) == TEXTOID);
 

--- a/src/backend/catalog/aclchk.c
+++ b/src/backend/catalog/aclchk.c
@@ -735,7 +735,7 @@ ExecGrant_Relation(InternalGrant *istmt)
 				char *aclstr = strVal(lfirst(lc));
 				AclItem *newai;
 
-				newai = DatumGetPointer(DirectFunctionCall1(aclitemin,
+				newai = (AclItem *)DatumGetPointer(DirectFunctionCall1(aclitemin,
 											CStringGetDatum(aclstr)));
 
 				aip->ai_grantee = newai->ai_grantee;

--- a/src/backend/catalog/pg_compression.c
+++ b/src/backend/catalog/pg_compression.c
@@ -179,7 +179,7 @@ callCompressionConstructor(PGFunction constructor,
 						   StorageAttributes *sa,
 						   bool is_compress)
 {
-  return DatumGetPointer(DirectFunctionCall3(constructor,
+	return (CompressionState *) DatumGetPointer(DirectFunctionCall3(constructor,
 											 PointerGetDatum(tupledesc),
 											 PointerGetDatum(sa),
 											 BoolGetDatum(is_compress)));
@@ -226,7 +226,7 @@ zlib_constructor(PG_FUNCTION_ARGS)
 	/* PG_GETARG_POINTER(0) is TupleDesc that is currently unused.
 	 * It is passed as NULL */
 
-	StorageAttributes *sa = PG_GETARG_POINTER(1);
+	StorageAttributes *sa = (StorageAttributes *) PG_GETARG_POINTER(1);
 	CompressionState *cs	   = palloc0(sizeof(CompressionState));
 	zlib_state	   *state	= palloc0(sizeof(zlib_state));
 	bool			  compress = PG_GETARG_BOOL(2);
@@ -251,7 +251,7 @@ zlib_constructor(PG_FUNCTION_ARGS)
 Datum
 zlib_destructor(PG_FUNCTION_ARGS)
 {
-	CompressionState *cs = PG_GETARG_POINTER(0);
+	CompressionState *cs = (CompressionState *) PG_GETARG_POINTER(0);
 
 	if (cs != NULL && cs->opaque != NULL)
  	{
@@ -268,7 +268,7 @@ zlib_compress(PG_FUNCTION_ARGS)
 	int32			 src_sz   = PG_GETARG_INT32(1);
 	void			 *dst	  = PG_GETARG_POINTER(2);
 	int32			 dst_sz   = PG_GETARG_INT32(3);
-	int32			*dst_used = PG_GETARG_POINTER(4);
+	int32			*dst_used = (int32 *) PG_GETARG_POINTER(4);
 	CompressionState *cs	   = (CompressionState *) PG_GETARG_POINTER(5);
 	zlib_state	   *state	= (zlib_state *) cs->opaque;
 	int				last_error;
@@ -317,7 +317,7 @@ zlib_decompress(PG_FUNCTION_ARGS)
 	int32			src_sz = PG_GETARG_INT32(1);
 	void		   *dst	= PG_GETARG_POINTER(2);
 	int32			dst_sz = PG_GETARG_INT32(3);
-	int32		   *dst_used = PG_GETARG_POINTER(4);
+	int32		   *dst_used = (int32 *) PG_GETARG_POINTER(4);
 	CompressionState *cs = (CompressionState *) PG_GETARG_POINTER(5);
 	zlib_state	   *state = (zlib_state *) cs->opaque;
 	int				last_error;

--- a/src/backend/cdb/cdbhash.c
+++ b/src/backend/cdb/cdbhash.c
@@ -311,7 +311,7 @@ hashDatum(Datum datum, Oid type, datumHashFunction hashFn, void *clientData)
              * If we did a pg_detoast_datum, we need to remember to pfree, 
              * or we will leak memory.  Because of the 1-byte varlena header stuff.
              */
-            if (num != DatumGetPointer(datum)) 
+            if (num != (Numeric) DatumGetPointer(datum)) 
                 tofree = num;
 
 			break;

--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -2156,11 +2156,11 @@ partMakePartition(HeapTuple tuple)
 	p->paristemplate = partrow->paristemplate;
 	p->parnatts = partrow->parnatts;
 
-	atts = DatumGetPointer(SysCacheGetAttr(PARTOID, tuple,
+	atts = (int2vector *) DatumGetPointer(SysCacheGetAttr(PARTOID, tuple,
 										   Anum_pg_partition_paratts,
 										   &isnull));
 	Assert(!isnull);
-	oids = DatumGetPointer(SysCacheGetAttr(PARTOID, tuple,
+	oids = (oidvector *) DatumGetPointer(SysCacheGetAttr(PARTOID, tuple,
 										   Anum_pg_partition_parclass,
 										   &isnull));
 	Assert(!isnull);
@@ -2373,8 +2373,9 @@ get_partition_key_bitmapset(Oid relid)
 			continue;  /* no interest in template parts */
 
 		natts = partrow->parnatts;
-		atts = DatumGetPointer(heap_getattr(tuple, Anum_pg_partition_paratts,
-											tupledesc, &isnull));
+		atts = (int2vector *) DatumGetPointer(
+			heap_getattr(tuple, Anum_pg_partition_paratts,
+						 tupledesc, &isnull));
 		Insist(!isnull);
 
 		for ( i = 0; i < natts; i++ )

--- a/src/backend/cdb/cdbresynchronizechangetracking.c
+++ b/src/backend/cdb/cdbresynchronizechangetracking.c
@@ -1428,7 +1428,8 @@ ChangeTracking_GetIncrementalChangeList(void)
 					result = ChangeTracking_InitIncrementalChangeList(proc);
 				
 				/* convert to desired data type */
-				persistentTid = DatumGetPointer(DirectFunctionCall1(tidin, CStringGetDatum(str_tid)));
+				persistentTid = (ItemPointer) DatumGetPointer(
+					DirectFunctionCall1(tidin, CStringGetDatum(str_tid)));
 				persistentSerialNum = DatumGetInt64(DirectFunctionCall1(int8in, CStringGetDatum(str_sn)));
 				numblocks = DatumGetInt64(DirectFunctionCall1(int8in, CStringGetDatum(str_numb)));
 				
@@ -3178,7 +3179,8 @@ int ChangeTracking_CompactLogFile(CTFType source, CTFType dest, XLogRecPtr*	upto
 				relfile.relNode = DatumGetObjectId(DirectFunctionCall1(oidin, CStringGetDatum(str_rel)));
 				blocknum = DatumGetUInt32(DirectFunctionCall1(int4in, CStringGetDatum(str_blocknum)));
 				endlsn = (XLogRecPtr*) DatumGetPointer(DirectFunctionCall1(gpxloglocin, CStringGetDatum(str_endlsn)));
-				persistentTid = DatumGetPointer(DirectFunctionCall1(tidin, CStringGetDatum(str_tid)));
+				persistentTid = (ItemPointer) DatumGetPointer(
+					DirectFunctionCall1(tidin, CStringGetDatum(str_tid)));
 				persistentSerialNum = DatumGetInt64(DirectFunctionCall1(int8in, CStringGetDatum(str_sn)));
 
 				SIMPLE_FAULT_INJECTOR(FileRepChangeTrackingCompacting);

--- a/src/backend/cdb/motion/tupser.c
+++ b/src/backend/cdb/motion/tupser.c
@@ -82,42 +82,6 @@ skipPadding(StringInfo serialTup)
 	serialTup->cursor = TYPEALIGN(TUPLE_CHUNK_ALIGN,serialTup->cursor);
 }
 
-/*
- * stringInfoGetInt32
- *
- * Pull a 4-byte integer out of str, at the current cursor location.  The
- * cursor is then incremented by 4.  If there is not 4 bytes left between the
- * cursor and the end of the string, an error is reported.
- *
- * The input is expected to be in the current architecture's byte-ordering.
- *
- * Hopefully this is faster than the stuff in stringinfo.c or pqformat.c!
- */
-static inline int32
-stringInfoGetInt32(StringInfo str)
-{
-	int32		res;
-
-	/* Make sure there are enough bytes left. */
-	if (str->len - str->cursor < 4)
-	{
-		ereport(ERROR, (errcode(ERRCODE_PROTOCOL_VIOLATION),
-						errmsg("deserialize data underflow")));
-	}
-
-	/*
-	 * Pull out the int32.	We cast the pointer to the next part of the data
-	 * to an int32 pointer, and just retrieve the integer from that location
-	 * in the array.
-	 */
-	res = *((int32 *) (str->data + str->cursor));
-
-	/* Update the cursor. */
-	str->cursor += 4;
-
-	return res;
-}
-
 /* Look up all of the information that SerializeTuple() and DeserializeTuple()
  * need to perform their jobs quickly.	Also, scratchpad space is allocated
  * for serialization and desrialization of datum values, and for formation/

--- a/src/backend/executor/tstoreReceiver.c
+++ b/src/backend/executor/tstoreReceiver.c
@@ -141,7 +141,7 @@ tstoreReceiveSlot_detoast(TupleTableSlot *slot, DestReceiver *self)
 			if (VARATT_IS_EXTERNAL(DatumGetPointer(val)))
 			{
 				val = PointerGetDatum(heap_tuple_fetch_attr(
-														DatumGetPointer(val)));
+										  (struct varlena *) DatumGetPointer(val)));
 				myState->tofree[nfree++] = val;
 			}
 		}

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -74,7 +74,7 @@
 	do { \
 		if (from->fldname) \
 		{ \
-			newnode->fldname = DatumGetPointer( \
+			newnode->fldname = (bytea *) DatumGetPointer( \
 					datumCopy(PointerGetDatum(from->fldname), false, len)); \
 		} \
 	} while (0)

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -127,7 +127,7 @@
 
 /* Read a bytea field */
 #define READ_BYTEA_FIELD(fldname) \
-	local_node->fldname = DatumGetPointer(readDatum(false))
+	local_node->fldname = (bytea *) DatumGetPointer(readDatum(false))
 
 /* Read a dummy field */
 #define READ_DUMMY_FIELD(fldname,fldvalue) \

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -155,7 +155,7 @@ inline static char extended_char(char* token, size_t length)
 
 /* Read a bytea field */
 #define READ_BYTEA_FIELD(fldname) \
-	local_node->fldname = DatumGetPointer(readDatum(false))
+	local_node->fldname = (bytea *) DatumGetPointer(readDatum(false))
 
 /* Set field to a given value, ignoring the value read from the input */
 #define READ_DUMMY_FIELD(fldname,fldvalue)  READ_SCALAR_FIELD(fldname, fldvalue)

--- a/src/backend/utils/datumstream/datumstream.c
+++ b/src/backend/utils/datumstream/datumstream.c
@@ -1090,7 +1090,8 @@ datumstreamwrite_lob(DatumStreamWrite * acc,
 	 */
 	if (VARATT_IS_EXTERNAL(DatumGetPointer(d)))
 	{
-		d = PointerGetDatum(heap_tuple_fetch_attr(DatumGetPointer(d)));
+		d = PointerGetDatum(heap_tuple_fetch_attr(
+								(struct varlena *) DatumGetPointer(d)));
 	}
 
 	p = (uint8 *) DatumGetPointer(d);

--- a/src/backend/utils/datumstream/datumstreamblock.c
+++ b/src/backend/utils/datumstream/datumstreamblock.c
@@ -1162,7 +1162,7 @@ DatumStreamBlockWrite_PrintInputVarlenaInfo(
 {
 	uint8	   *p;
 
-	p = DatumGetPointer(originalDatum);
+	p = (uint8 *) DatumGetPointer(originalDatum);
 
 	ereport(LOG,
 		  (errmsg("Write input varlena input <%s> (nth %d, was extended %s)",

--- a/src/backend/utils/misc/guc-file.l
+++ b/src/backend/utils/misc/guc-file.l
@@ -498,8 +498,6 @@ ParseConfigFile(const char *config_file, const char *calling_file,
 			 * An include directive isn't a variable and should be processed
 			 * immediately.
 			 */
-			unsigned int save_ConfigFileLineno = ConfigFileLineno;
-
 			if (!ParseConfigFile(opt_value, config_file,
 								 depth + 1, context, elevel,
 								 head_p, tail_p))

--- a/src/backend/utils/sort/tuplesort.c
+++ b/src/backend/utils/sort/tuplesort.c
@@ -978,7 +978,7 @@ tuplesort_putdatum(Tuplesortstate *state, Datum val, bool isNull)
 	{
 		stup.datum1 = datumCopy(val, false, state->datumTypeLen);
 		stup.isnull1 = false;
-		stup.tuple = DatumGetPointer(stup.datum1);
+		stup.tuple = (MemTuple) DatumGetPointer(stup.datum1);
 		USEMEM(state, GetMemoryChunkSpace(DatumGetPointer(stup.datum1))); 
 	}
 

--- a/src/include/postgres.h
+++ b/src/include/postgres.h
@@ -359,8 +359,19 @@ static inline Datum TransactionIdGetDatum(TransactionId tid) { return (Datum) ti
 static inline CommandId DatumGetCommandId(Datum d) { return (CommandId) d; } 
 static inline Datum CommandIdGetDatum(CommandId cid) { return (Datum) cid; } 
 
-static inline void *DatumGetPointer(Datum d) { Datum_U du; du.d = d; return du.ptr; }
-static inline Datum PointerGetDatum(const void *p) { Datum_U du; du.d = 0; du.ptr = (void *)p; return du.d; }
+/*
+ * DatumGetPointer
+ *		Returns pointer value of a datum.
+ */
+
+#define DatumGetPointer(X) ((Pointer) (X))
+
+/*
+ * PointerGetDatum
+ *		Returns datum representation for a pointer.
+ */
+
+#define PointerGetDatum(X) ((Datum) (X))
 
 static inline char *DatumGetCString(Datum d) { return (char* ) DatumGetPointer(d); } 
 static inline Datum CStringGetDatum(const char *p) { return PointerGetDatum(p); }

--- a/src/include/utils/datetime.h
+++ b/src/include/utils/datetime.h
@@ -305,7 +305,7 @@ extern int DecodeISO8601Interval(char *str,
 			   int *dtype, struct pg_tm * tm, fsec_t *fsec);
 
 extern void DateTimeParseError(int dterr, const char *str,
-				   const char *datatype);
+				   const char *datatype) __attribute__((noreturn));
 
 extern int	DetermineTimeZoneOffset(struct pg_tm * tm, pg_tz *tzp);
 

--- a/src/pl/plperl/plperl.c
+++ b/src/pl/plperl/plperl.c
@@ -1777,7 +1777,7 @@ plperl_inline_handler(PG_FUNCTION_ARGS)
 	/* Set up a callback for error reporting */
 	pl_error_context.callback = plperl_inline_callback;
 	pl_error_context.previous = error_context_stack;
-	pl_error_context.arg = (Datum) 0;
+	pl_error_context.arg = NULL;
 	error_context_stack = &pl_error_context;
 
 	/*


### PR DESCRIPTION
PR attempts to fix few compiler warnings seen with Clang, still not down to zero goal which we wish to reach soonish to help day-to-day development. Has couple of backports from upstream and other changes based on discussion on mailing list (https://groups.google.com/a/greenplum.org/d/msg/gpdb-dev/6fgKvN9QpV4/zjysjqIZAgAJ)

Note:
Didn't convert all the *GetDatum() and DatumGet*() inline functions into macros as needs lot more work than just converting to macros. New config flags needs to be pulled in along with palloc'd version of functions for float and int64.
