### PR TITLE
behave: error out when no flags or tags gets passed

### DIFF
--- a/gpMgmt/Makefile.behave
+++ b/gpMgmt/Makefile.behave
@@ -21,4 +21,5 @@ behave: $(BEHAVE_BIN)
 		PYTHONPATH=$(PYTHONSRC_INSTALL_PYTHON_PATH):$(GPMGMT_SRC):$(PEXPECT_LIB) python $(BEHAVE_BIN) $(GPMGMT_SRC)/test/behave/* -s -k --tags=$(tags) 2>&1 ; \
 	else \
 		echo "Please specify tags=tagname or flags=[behave flags]"; \
+		exit 1; \
 	fi


### PR DESCRIPTION
There are times where the flags/tags are not passed in the pipeline
configuration but the jobs shows as green anwyays (false positive).
This is due to the return code being 0 event though we don't do
anything.

Force an error when we don't specify flags/tags when running behave
with the makefile.