### PR TITLE
Remove dead code hasModifyingCTE

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -2841,7 +2841,6 @@ _copyQuery(Query *from)
 	COPY_NODE_FIELD(scatterClause);
 	COPY_NODE_FIELD(cteList);
 	COPY_SCALAR_FIELD(hasRecursive);
-	COPY_SCALAR_FIELD(hasModifyingCTE);
 	COPY_NODE_FIELD(limitOffset);
 	COPY_NODE_FIELD(limitCount);
 	COPY_NODE_FIELD(rowMarks);

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -856,7 +856,6 @@ _equalQuery(Query *a, Query *b)
 	COMPARE_NODE_FIELD(scatterClause);
 	COMPARE_NODE_FIELD(cteList);
 	COMPARE_SCALAR_FIELD(hasRecursive);
-	COMPARE_SCALAR_FIELD(hasModifyingCTE);
 	COMPARE_NODE_FIELD(limitOffset);
 	COMPARE_NODE_FIELD(limitCount);
 	COMPARE_NODE_FIELD(rowMarks);

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -910,7 +910,6 @@ _outQuery(StringInfo str, Query *node)
 	WRITE_NODE_FIELD(scatterClause);
 	WRITE_NODE_FIELD(cteList);
 	WRITE_BOOL_FIELD(hasRecursive);
-	WRITE_BOOL_FIELD(hasModifyingCTE);
 	WRITE_NODE_FIELD(limitOffset);
 	WRITE_NODE_FIELD(limitCount);
 	WRITE_NODE_FIELD(rowMarks);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -3502,7 +3502,6 @@ _outQuery(StringInfo str, Query *node)
 	WRITE_NODE_FIELD(scatterClause);
 	WRITE_NODE_FIELD(cteList);
 	WRITE_BOOL_FIELD(hasRecursive);
-	WRITE_BOOL_FIELD(hasModifyingCTE);
 	WRITE_NODE_FIELD(limitOffset);
 	WRITE_NODE_FIELD(limitCount);
 	WRITE_NODE_FIELD(rowMarks);

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -243,7 +243,6 @@ _readQuery(void)
 	READ_NODE_FIELD(scatterClause);
 	READ_NODE_FIELD(cteList);
 	READ_BOOL_FIELD(hasRecursive);
-	READ_BOOL_FIELD(hasModifyingCTE);
 	READ_NODE_FIELD(limitOffset);
 	READ_NODE_FIELD(limitCount);
 	READ_NODE_FIELD(rowMarks);

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -337,7 +337,6 @@ _readQuery(void)
 	READ_NODE_FIELD(scatterClause);
 	READ_NODE_FIELD(cteList);
 	READ_BOOL_FIELD(hasRecursive);
-	READ_BOOL_FIELD(hasModifyingCTE);
 	READ_NODE_FIELD(limitOffset);
 	READ_NODE_FIELD(limitCount);
 	READ_NODE_FIELD(rowMarks);

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -580,7 +580,6 @@ transformInsertStmt(ParseState *pstate, InsertStmt *stmt)
 		{
 			qry->hasRecursive = selectStmt->withClause->recursive;
 			qry->cteList = transformWithClause(pstate, selectStmt->withClause);
-			qry->hasModifyingCTE = pstate->p_hasModifyingCTE;
 		}
 
 		foreach(lc, selectStmt->valuesLists)
@@ -681,7 +680,6 @@ transformInsertStmt(ParseState *pstate, InsertStmt *stmt)
 		{
 			qry->hasRecursive = selectStmt->withClause->recursive;
 			qry->cteList = transformWithClause(pstate, selectStmt->withClause);
-			qry->hasModifyingCTE = pstate->p_hasModifyingCTE;
 		}
 
 		/* Do basic expression transformation (same as a ROW() expr) */
@@ -1497,7 +1495,6 @@ transformSelectStmt(ParseState *pstate, SelectStmt *stmt)
 	{
 		qry->hasRecursive = stmt->withClause->recursive;
 		qry->cteList = transformWithClause(pstate, stmt->withClause);
-		qry->hasModifyingCTE = pstate->p_hasModifyingCTE;
 	}
 
 	/* process the FROM clause */
@@ -1667,7 +1664,6 @@ transformValuesClause(ParseState *pstate, SelectStmt *stmt)
 	{
 		qry->hasRecursive = stmt->withClause->recursive;
 		qry->cteList = transformWithClause(pstate, stmt->withClause);
-		qry->hasModifyingCTE = pstate->p_hasModifyingCTE;
 	}
 
 	/*
@@ -1931,7 +1927,6 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 	{
 		qry->hasRecursive = stmt->withClause->recursive;
 		qry->cteList = transformWithClause(pstate, stmt->withClause);
-		qry->hasModifyingCTE = pstate->p_hasModifyingCTE;
 	}
 
 	/*

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -160,7 +160,6 @@ typedef struct Query
 	List	   *cteList;		/* a list of CommonTableExprs in WITH clause */
 	bool		hasRecursive;	/* Whether this query has a recursive WITH
 								 * clause */
-	bool		hasModifyingCTE;	/* has INSERT/UPDATE/DELETE in WITH clause */
 
 	Node	   *limitOffset;	/* # of result tuples to skip (int8 expr) */
 	Node	   *limitCount;		/* # of result tuples to return (int8 expr) */

--- a/src/include/parser/parse_node.h
+++ b/src/include/parser/parse_node.h
@@ -86,7 +86,6 @@ typedef struct ParseState
 	bool		p_hasAggs;
 	bool		p_hasWindowFuncs;
 	bool		p_hasSubLinks;
-	bool		p_hasModifyingCTE;
 	bool		p_is_insert;
 	bool		p_is_update;
 	Relation	p_target_relation;


### PR DESCRIPTION
This commit removes `Query::hasModifyingCTE` and
`ParseState::p_hasModifyingCTE` because they are dead code.

This change impacts reading and writing `pg_rewrite` rules, which is how
views are implemented, and hence won't be backported to 5.0 or ealier. A
`pg_upgrade` from 5 to 6 will still work because this change has no DDL
surface.