### PR TITLE
ATExecSetDistributedBy: Fix ALTER TABLE ... SET (REORGANIZE)

### DIFF
--- a/src/test/regress/expected/alter_table_set.out
+++ b/src/test/regress/expected/alter_table_set.out
@@ -1,0 +1,54 @@
+-- https://github.com/greenplum-db/gpdb/issues/1109
+--
+-- ALTER TABLE ... SET WITH (REORGANIZE = true); should always redistribute the
+-- data even with matching distribution policy
+create table ats_dist_by_c (c int, d int) distributed by (c);
+create table ats_dist_by_d (c int, d int) distributed by (d);
+insert into ats_dist_by_c select i, 0 from generate_series(1, 47) i;
+copy ats_dist_by_c to '/tmp/ats_dist_by_c<SEGID>' on segment;
+-- load the data back from the segment file, but wrong distribution
+set gp_enable_segment_copy_checking = false;
+show gp_enable_segment_copy_checking;
+ gp_enable_segment_copy_checking 
+---------------------------------
+ off
+(1 row)
+
+copy ats_dist_by_d from '/tmp/ats_dist_by_c<SEGID>' on segment;
+-- try to use the reorganize = true to fix it
+alter table ats_dist_by_d set with (reorganize = true);
+-- construct expected table
+create table ats_expected_by_d (c int, d int) distributed by (d);
+insert into ats_expected_by_d select * from ats_dist_by_c;
+-- expect to see data distributed in the same way as the freshly constructed
+-- table
+select count(*) = 0 as has_same_distribution from
+(select gp_segment_id, * from ats_dist_by_d except
+	select gp_segment_id, * from ats_expected_by_d) t;
+ has_same_distribution 
+-----------------------
+ t
+(1 row)
+
+-- reload for random distribution test
+truncate table ats_dist_by_d;
+copy ats_dist_by_d from '/tmp/ats_dist_by_c<SEGID>' on segment;
+-- we expect the new random distribution to differ from both the
+-- distributed-by-c table and the distributed-by-d table
+alter table ats_dist_by_d set with (reorganize = true) distributed randomly;
+select count(*) > 0 as has_different_distribution from
+(select gp_segment_id, * from ats_dist_by_d except
+	select gp_segment_id, * from ats_dist_by_c) t;
+ has_different_distribution 
+----------------------------
+ t
+(1 row)
+
+select count(*) > 0 as has_different_distribution from
+(select gp_segment_id, * from ats_dist_by_d except
+	select gp_segment_id, * from ats_expected_by_d) t;
+ has_different_distribution 
+----------------------------
+ t
+(1 row)
+

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -68,7 +68,7 @@ test: sreh
 
 ignore: gp_portal_error
 test: external_table external_table_create_privs column_compression eagerfree gpdtm_plpgsql alter_table_aocs alter_table_aocs2 alter_distribution_policy ic aoco_privileges aocs
-test: alter_table_gp alter_table_ao ao_create_alter_valid_table subtransaction_visibility oid_consistency udf_exception_blocks
+test: alter_table_set alter_table_gp alter_table_ao ao_create_alter_valid_table subtransaction_visibility oid_consistency udf_exception_blocks
 ignore: icudp_full
 
 test: resource_queue

--- a/src/test/regress/sql/alter_table_set.sql
+++ b/src/test/regress/sql/alter_table_set.sql
@@ -1,0 +1,39 @@
+-- https://github.com/greenplum-db/gpdb/issues/1109
+--
+-- ALTER TABLE ... SET WITH (REORGANIZE = true); should always redistribute the
+-- data even with matching distribution policy
+create table ats_dist_by_c (c int, d int) distributed by (c);
+create table ats_dist_by_d (c int, d int) distributed by (d);
+
+insert into ats_dist_by_c select i, 0 from generate_series(1, 47) i;
+copy ats_dist_by_c to '/tmp/ats_dist_by_c<SEGID>' on segment;
+
+-- load the data back from the segment file, but wrong distribution
+set gp_enable_segment_copy_checking = false;
+show gp_enable_segment_copy_checking;
+copy ats_dist_by_d from '/tmp/ats_dist_by_c<SEGID>' on segment;
+
+-- try to use the reorganize = true to fix it
+alter table ats_dist_by_d set with (reorganize = true);
+-- construct expected table
+create table ats_expected_by_d (c int, d int) distributed by (d);
+insert into ats_expected_by_d select * from ats_dist_by_c;
+-- expect to see data distributed in the same way as the freshly constructed
+-- table
+select count(*) = 0 as has_same_distribution from
+(select gp_segment_id, * from ats_dist_by_d except
+	select gp_segment_id, * from ats_expected_by_d) t;
+
+-- reload for random distribution test
+truncate table ats_dist_by_d;
+copy ats_dist_by_d from '/tmp/ats_dist_by_c<SEGID>' on segment;
+
+-- we expect the new random distribution to differ from both the
+-- distributed-by-c table and the distributed-by-d table
+alter table ats_dist_by_d set with (reorganize = true) distributed randomly;
+select count(*) > 0 as has_different_distribution from
+(select gp_segment_id, * from ats_dist_by_d except
+	select gp_segment_id, * from ats_dist_by_c) t;
+select count(*) > 0 as has_different_distribution from
+(select gp_segment_id, * from ats_dist_by_d except
+	select gp_segment_id, * from ats_expected_by_d) t;


### PR DESCRIPTION
Originally, if the REORGANIZE option is used, and the source and target
tables got same partition distribution policy, then the redistribute is
skipped. This is due to the nature of planner optimizer will skip
reshuffle if the source and target distribution policy match.

However, if both source and target distribution policies are random,
then planner will generate a redistribution motion to balance the tuples
across the cluster.

Leveraging that thought, we added new code path to temporarily set the
source table's distribution policy to random while executing the CTAS
query, and hence the optimizer can generate the proper query plan with
`redistribute motion`. We restore the policy after creating the
temporary table.

Test cases are added to show case the scenario where a table is loaded
with data inconsistent with its distribution policy when using
COPY ... ON SEGMENT. The second case catches a regression when using
SET WITH (REORGANIZE = TRUE) DISTRIBUTED RANDOMLY.

Signed-off-by: Jacob Champion <pchampion@pivotal.io>