### PR TITLE
Make gp_resgroup_status work with concurrently resgroup drops.

### DIFF
--- a/src/test/isolation2/expected/resgroup/resgroup_parallel_queries.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_parallel_queries.out
@@ -298,6 +298,14 @@ OK
 -- start a new session to drop a resource group with running queries, it will failed because a role is associated with the resource group.
 43>: drop resource group rg_test_g3;  <waiting ...>
 
+-- start a new session to acquire the status of resource groups
+44: select dblink_connect('dblink_rg_test44', 'dbname=isolation2resgrouptest');
+dblink_connect
+--------------
+OK            
+(1 row)
+44>: select exec_commands_n('dblink_rg_test44', 'select count(*) from gp_toolkit.gp_resgroup_status;', '', '', 100, '', '', true);  <waiting ...>
+
 -- wait all sessions to finish
 21<:  <... completed>
 exec_commands_n
@@ -361,6 +369,11 @@ exec_commands_n
 (1 row)
 43<:  <... completed>
 ERROR:  resource group "rg_test_g3" is used by at least one role
+44<:  <... completed>
+exec_commands_n
+---------------
+100            
+(1 row)
 
 21: select dblink_disconnect('dblink_rg_test21');
 dblink_disconnect
@@ -418,6 +431,11 @@ dblink_disconnect
 OK               
 (1 row)
 42: select dblink_disconnect('dblink_rg_test42');
+dblink_disconnect
+-----------------
+OK               
+(1 row)
+44: select dblink_disconnect('dblink_rg_test44');
 dblink_disconnect
 -----------------
 OK               

--- a/src/test/isolation2/sql/resgroup/resgroup_parallel_queries.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_parallel_queries.sql
@@ -175,6 +175,10 @@ select groupname, concurrency, cpu_rate_limit from gp_toolkit.gp_resgroup_config
 -- start a new session to drop a resource group with running queries, it will failed because a role is associated with the resource group. 
 43>: drop resource group rg_test_g3;
 
+-- start a new session to acquire the status of resource groups
+44: select dblink_connect('dblink_rg_test44', 'dbname=isolation2resgrouptest');
+44>: select exec_commands_n('dblink_rg_test44', 'select count(*) from gp_toolkit.gp_resgroup_status;', '', '', 100, '', '', true);
+
 -- wait all sessions to finish
 21<:
 22<:
@@ -189,6 +193,7 @@ select groupname, concurrency, cpu_rate_limit from gp_toolkit.gp_resgroup_config
 41<:
 42<:
 43<:
+44<:
 
 21: select dblink_disconnect('dblink_rg_test21');
 22: select dblink_disconnect('dblink_rg_test22');
@@ -202,6 +207,7 @@ select groupname, concurrency, cpu_rate_limit from gp_toolkit.gp_resgroup_config
 34: select dblink_disconnect('dblink_rg_test34');
 41: select dblink_disconnect('dblink_rg_test41');
 42: select dblink_disconnect('dblink_rg_test42');
+44: select dblink_disconnect('dblink_rg_test44');
 
 select groupname, concurrency::int < 7, cpu_rate_limit::int < 7 from gp_toolkit.gp_resgroup_config where groupname like 'rg_test_g%' order by groupname;
 


### PR DESCRIPTION
The view gp_toolkit.gp_resgroup_status collect resgroup status
information on both QD and QEs, also before and after a 300ms delay to
measure the cpu usage. When there is concurrently resgroup drops it
might fail due to missing resgroups.

This is fixed by holding ExclusiveLock which blocks the drop operations.

Signed-off-by: Ning Yu <nyu@pivotal.io>