### PR TITLE
Qualify mocker.py with full path

### DIFF
--- a/src/Makefile.mock
+++ b/src/Makefile.mock
@@ -7,7 +7,7 @@ override CPPFLAGS+= -I$(CMOCKERY_DIR)
 
 $(MOCK_DIR)/%_mock.c: $(abs_top_srcdir)/src/%.c
 	@echo mocking $<
-	@(cd $(MOCK_DIR) && PYTHONPATH=$(python_libdir) $(PYTHON) mocker.py $<)
+	@(cd $(MOCK_DIR) && PYTHONPATH=$(python_libdir) $(PYTHON) $(top_builddir)/src/test/unit/mock/mocker.py $<)
 
 # For some reason, mock.o files are intermediate files sometimes.
 # Mark them as secondary in order not to be deleted automatically.


### PR DESCRIPTION
Invoking mocker.py will fail unless in the right directory, add the full path in the tree to the file to allow invocation from elsehwere.

The PXF unittests fail for me without this, perhaps I'm missing something in my setup but this seem sane either way.