### PR TITLE
pysync: replace md5 by sha256

### DIFF
--- a/gpMgmt/bin/gppylib/test/unit/test_unit_pysync.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_pysync.py
@@ -1,0 +1,39 @@
+import os, tempfile, hashlib
+from gp_unittest import *
+from lib.pysync import LocalPysync
+
+CONTENT = 'To be or not to be.'
+
+class LocalPySyncTestCase(GpTestCase):
+
+    def setUp(self):
+        self.subject = LocalPysync(['pysync', '/tmp', 'localhost:/tmp'])
+
+    def tearDown(self):
+        super(LocalPySyncTestCase, self).tearDown()
+
+    def test_doCommand_getDigest(self):
+        filename = ''
+        try:
+            filename, filesize = createTempFileWithContent(CONTENT)
+            doCommand_digest = self.subject.doCommand(['getDigest', filename, 0, filesize])
+            m = hashlib.sha256()
+            m.update(CONTENT)
+            self.assertTrue(m.digest() == doCommand_digest)
+        finally:
+            os.unlink(filename)
+
+def createTempFileWithContent(content):
+    fd = tempfile.NamedTemporaryFile(delete=False)
+    fd.write(content)
+    filename = fd.name
+    fd.close()
+    filesize = os.stat(filename).st_size
+
+    return filename, filesize
+
+
+
+if __name__ == '__main__':
+    run_tests()
+

--- a/gpMgmt/bin/lib/pysync.py
+++ b/gpMgmt/bin/lib/pysync.py
@@ -429,7 +429,7 @@ class LocalPysync:
         -i name: Only transfer named file or directory. Don't be too
             creative with the name.  For example, "directory/./file" will not
             work--use "directory/file".  Name is relative to sourcedir.
-        --insecure: Do not check MD5 digest after transfering data.
+        --insecure: Do not check SHA256 digest after transfering data.
             This makes pysync.py run faster, but a bad guy can forge TCP
             packets and put junk of his choice into your files.
         --delete: Delete things in dst that do not exist in src.
@@ -521,7 +521,7 @@ class LocalPysync:
         elif what[0] == 'getList':
             return self.getList()
         elif what[0] == 'getDigest':
-            m = hashlib.md5()
+            m = hashlib.sha256()
             m.update(self.readFile(what[1], what[2], what[3]))
             return m.digest()
         elif what[0] == 'getData':

--- a/gpMgmt/bin/lib/pysync.py
+++ b/gpMgmt/bin/lib/pysync.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 
-import os,sys
-if sys.hexversion<0x2040400:
+import os, sys
+
+if sys.hexversion < 0x2040400:
     sys.stderr.write("pysync.py needs python version at least 2.4.4.\n")
-    sys.stderr.write("You are using %s\n"%sys.version)
+    sys.stderr.write("You are using %s\n" % sys.version)
     sys.stderr.write("Here is a guess at where the python executable is--\n")
     os.system("/bin/sh -c 'type python>&2'");
     sys.exit(1)
@@ -24,12 +25,14 @@ from gppylib.commands.gp import PySync
 
 # MPP-13617
 import re
-RE1=re.compile('\\[([^]]+)\\]:(.+)')
 
-bootstrapSource="""
+RE1 = re.compile('\\[([^]]+)\\]:(.+)')
+
+bootstrapSource = """
 import os,sys
 exec(sys.stdin.read(int(sys.stdin.readline())))
 """
+
 
 class PysyncProxy:
     '''
@@ -77,7 +80,7 @@ class PysyncProxy:
         progressTimestamp - indicates whether or not RemotePysync should include the
                 observation timestamp on messages it creates.
         '''
-        
+
         self.ppid = 0
         self.sourceHost = sourceHost
         self.sourceDir = sourceDir
@@ -85,7 +88,7 @@ class PysyncProxy:
         self.destDir = destDir
         self.recordProgressCallback = recordProgressCallback
         self.recordRawProgressCallback = recordRawProgressCallback
-        
+
         self.syncOptions = syncOptions
         if verbose:
             self.syncOptions += ["-v"]
@@ -93,11 +96,11 @@ class PysyncProxy:
             self.syncOptions += ["--progress-bytes", progressBytes]
         if progressTime:
             self.syncOptions += ["--progress-time", progressTime]
-        
+
         self.syncOptions += ["--proxy"]
         if not progressTimestamp:
             self.syncOptions += ["--omit-progress-timestamp"]
-            
+
         self.stderr = []
         self.stdout = []
         self.cmd = None
@@ -111,11 +114,11 @@ class PysyncProxy:
         to the self.stdout list.  Progress messages are written to stdout unless a 
         callback is set.
         '''
-        
+
         pysyncCmd = PySync('pysync', self.sourceDir, self.destHost, self.destDir,
-                              options=' '.join(self.syncOptions))
+                           options=' '.join(self.syncOptions))
         self.cmd = '. %s/greenplum_path.sh && %s' % (os.environ.get('GPHOME'), pysyncCmd.cmdStr)
-        
+
         # save of ppid to allow the process to be stopped.
         self.ppid = os.getppid()
         pidFilename = '/tmp/pysync.py.%s.%s.ppid' % (self.destHost, self.destDir.replace('/', '_'))
@@ -172,30 +175,30 @@ class PysyncProxy:
             except:
                 # parent gone, exit
                 return 2
-            
+
             # Get the length of the next serialized command
             a = self.p.stdout.readline()
-            if len(a)==0:
+            if len(a) == 0:
                 # End the command loop if EOF
                 self.stderr.append("[FATAL]:-Unexpected EOF on LocalPysync output stream")
                 return 3
-            
+
             # If not a pickled command object, just record it
             if not a.startswith("pKl:"):
                 self.stdout.append(a.rstrip())
                 continue
-            
+
             size = int(a[4:])
-            
+
             # Read the serialized command and process it.
             data = self.p.stdout.read(size)
-            assert len(data)==size
+            assert len(data) == size
             try:
                 self._doCommand(cPickle.loads(data))
             except PysyncProxy._Quit, e:
                 return e.code
 
-    def _doCommand(self,what):
+    def _doCommand(self, what):
         '''
         Perform the command requested by the remote side and prepare any
         result.
@@ -204,15 +207,15 @@ class PysyncProxy:
             if self.recordProgressCallback:
                 self.recordProgressCallback(what[1].rstrip())
             return None
-        
+
         elif what[0] == 'recordRawProgress':
             if self.recordRawProgressCallback:
                 self.recordRawProgressCallback(what[1])
             return None
-        
-        elif what[0]=='quit':
+
+        elif what[0] == 'quit':
             raise PysyncProxy._Quit(what[1])
-        
+
         else:
             assert 0
 
@@ -221,13 +224,13 @@ class ReaderThread(threading.Thread):
     '''
     Appends all output read from a file handle to the lines buffer.
     '''
-    
+
     def __init__(self, name, file, lines):
         self.file = file
         self.lines = lines
         threading.Thread.__init__(self, name=name)
         self.setDaemon(True)
-        
+
     def run(self):
         for line in self.file:
             self.lines.append(line.rstrip())
@@ -245,7 +248,7 @@ class LocalPysync:
     representing status information from this LocalPysync instance.
     '''
 
-    NUMBER_SCALES = { 'M':1024*1024, 'G':1024*1024*1024, 'T':1024*1024*1024*1024 }
+    NUMBER_SCALES = {'M': 1024 * 1024, 'G': 1024 * 1024 * 1024, 'T': 1024 * 1024 * 1024 * 1024}
 
     class _Quit(SystemExit):
         def __init__(self, *info):
@@ -279,47 +282,47 @@ class LocalPysync:
         if self.recordRawProgressCallback:
             self.options.sendRawProgress = True
         self.options.progressTimestamp = progressTimestamp
-        
+
         a = argv[1:]
         while a:
-            if a[0]=='-v':
+            if a[0] == '-v':
                 self.options.verbose = True
-            
-            elif a[0]=='-?':
+
+            elif a[0] == '-?':
                 self.usage(argv)
-            
-            elif a[0]=='-compress':
+
+            elif a[0] == '-compress':
                 self.options.compress = True
-            
-            elif a[0]=='-n':
+
+            elif a[0] == '-n':
                 self.options.minusn = True
-            
-            elif a[0]=='--insecure':
+
+            elif a[0] == '--insecure':
                 self.options.insecure = True
-            
-            elif a[0]=='--ssharg':
+
+            elif a[0] == '--ssharg':
                 a.pop(0)
                 self.sshargs.append(a[0])
-            
-            elif a[0]=='--delete':
+
+            elif a[0] == '--delete':
                 self.options.delete = True
-            
-            elif a[0]=='-x':
+
+            elif a[0] == '-x':
                 a.pop(0)
                 name = a[0]
-                if name[0]=='/':
+                if name[0] == '/':
                     raise Exception('Please do not use absolute path with -x.')
-                if name[0:2]!='./':
-                    name = os.path.join('.',name)
+                if name[0:2] != './':
+                    name = os.path.join('.', name)
                 self.exclude.add(name)
-            
-            elif a[0]=='-i':
+
+            elif a[0] == '-i':
                 a.pop(0)
                 name = a[0]
-                if name[0]=='/':
+                if name[0] == '/':
                     raise Exception('Please do not use absolute path with -i.')
-                if name[0:2]!='./':
-                    name = os.path.join('.',name)
+                if name[0:2] != './':
+                    name = os.path.join('.', name)
                 self.include.add(name)
 
             elif a[0] == '--progress-bytes':
@@ -340,9 +343,12 @@ class LocalPysync:
                         self.options.progressBytes = self.options.progressBytes
                 except ValueError:
                     raise ValueError("--progress-bytes value is not supported", a[0])
-                if type(self.options.progressBytes) != str and progressBytes < pysync_remote.SyncProgress.MINIMUM_VOLUME_INTERVAL:
-                    raise ValueError("--progress-bytes value must be at least %d" % pysync_remote.SyncProgress.MINIMUM_VOLUME_INTERVAL, a[0])
-            
+                if type(
+                        self.options.progressBytes) != str and progressBytes < pysync_remote.SyncProgress.MINIMUM_VOLUME_INTERVAL:
+                    raise ValueError(
+                        "--progress-bytes value must be at least %d" % pysync_remote.SyncProgress.MINIMUM_VOLUME_INTERVAL,
+                        a[0])
+
             elif a[0] == '--progress-time':
                 a.pop(0)
                 try:
@@ -351,24 +357,25 @@ class LocalPysync:
                 except ValueError:
                     raise ValueError("--progress-time value is not supported", a[0])
                 if progressSeconds < pysync_remote.SyncProgress.MINIMUM_TIME_INTERVAL:
-                    raise ValueError("--progress-time value must be at least %f" % (pysync_remote.SyncProgress.MINIMUM_TIME_INTERVAL / 60))
-            
+                    raise ValueError("--progress-time value must be at least %f" % (
+                        pysync_remote.SyncProgress.MINIMUM_TIME_INTERVAL / 60))
+
             elif a[0] == '--proxy':
                 self.usingProxy = True
                 self.options.sendProgress = True
                 self.recordProgressCallback = self._recordProgress
                 self.options.sendRawProgress = True
                 self.recordRawProgressCallback = self._recordRawProgress
-            
+
             elif a[0] == '--omit-progress-timestamp':
                 self.options.progressTimestamp = False
-            
+
             else:
                 break
             a.pop(0)
-        if len(a)!=2:
+        if len(a) != 2:
             self.usage(argv)
-            
+
         self.sourceDir = os.path.abspath(a[0])
         if not os.path.exists(self.sourceDir):
             raise ValueError("Source path \"%s\" not found" % self.sourceDir)
@@ -376,7 +383,7 @@ class LocalPysync:
             raise ValueError("Source path \"%s\" is not a directory" % self.sourceDir)
         if not os.access(self.sourceDir, os.F_OK | os.R_OK | os.X_OK):
             raise ValueError("Source path) \"%s\" is not accessible" % self.sourceDir)
-        
+
         dest = a[1]
 
         # MPP-13617
@@ -387,26 +394,26 @@ class LocalPysync:
             i = dest.find(':')
             if i == -1:
                 self.usage(argv)
-            self.userAndHost, self.destDir = dest[:i], dest[i+1:]
+            self.userAndHost, self.destDir = dest[:i], dest[i + 1:]
 
         self.connectAddress = None
         self.sendData = None
-        
-        hostname = self.userAndHost[self.userAndHost.find('@')+1:]
+
+        hostname = self.userAndHost[self.userAndHost.find('@') + 1:]
         try:
             addrinfo = socket.getaddrinfo(hostname, None)
         except:
             print 'dest>>%s<<' % dest, ' hostname>>%s<<' % hostname
             raise
-        
+
         if addrinfo:
             self.options.addrinfo = addrinfo[0]
         else:
             raise Exception("Unable to determine address for %s" % self.userAndHost)
 
-    def usage(self,argv):
+    def usage(self, argv):
         sys.stderr.write("""usage:
-    python """+argv[0]+""" [-v] [-?] [-n] 
+    python """ + argv[0] + """ [-v] [-?] [-n] 
                 [--ssharg arg] [-x exclude_file] [-i include_file] [--insecure] [--delete]
                 [--progress-time seconds] [--progress-bytes { n[.n]{% | G | T} }
                 [--proxy] [--omit-progress-timestamp]
@@ -440,23 +447,23 @@ class LocalPysync:
 """)
         sys.exit(1)
 
-    def readFile(self,filename,offset,size):
+    def readFile(self, filename, offset, size):
         '''
         Read a chunk of the specified size at the specified offset from the
         file identified.  The last chunk read is cached for possible re-reading.
         
         The file is opened only for the duration of the seek and read operations.
         '''
-        key = (filename,offset,size)
-        if self.cache[0]==key:
+        key = (filename, offset, size)
+        if self.cache[0] == key:
             return self.cache[1]
         absfilename = os.path.join(self.sourceDir, filename)
-        f = open(absfilename,'rb')
+        f = open(absfilename, 'rb')
         f.seek(offset)
         a = f.read(size)
         f.close()
-        assert len(a)==size
-        self.cache = (key,a)
+        assert len(a) == size
+        self.cache = (key, a)
         return a
 
     def getList(self):
@@ -468,59 +475,59 @@ class LocalPysync:
         '''
         list = dict()
         inomap = dict()
-        for root,dirs,files in os.walk(self.sourceDir):
-            for i in dirs+files:
+        for root, dirs, files in os.walk(self.sourceDir):
+            for i in dirs + files:
                 absname = os.path.join(root, i)
                 relname = '.' + absname[len(self.sourceDir):]
-                if relname in self.exclude: 
+                if relname in self.exclude:
                     if i in dirs:
                         dirs.remove(i)
                     continue
                 if len(self.include) > 0:
-                   """ Check if the file or dir is in the include list """
-                   if relname in self.include:
-                      pass
-                   else:
-                      """ Make sure we include any files or dirs under a dir in the include list."""
-                      foundPrefix = False
-                      for j in self.include:
-                         if relname.startswith(j + '/') == True:
-                            foundPrefix = True
+                    """ Check if the file or dir is in the include list """
+                    if relname in self.include:
+                        pass
+                    else:
+                        """ Make sure we include any files or dirs under a dir in the include list."""
+                        foundPrefix = False
+                        for j in self.include:
+                            if relname.startswith(j + '/') == True:
+                                foundPrefix = True
+                                continue
+                        if foundPrefix == False:
+                            if i in dirs:
+                                dirs.remove(i)
                             continue
-                      if foundPrefix == False:
-                         if i in dirs:
-                            dirs.remove(i) 
-                         continue
 
                 s = os.lstat(absname)
                 if s.st_ino in inomap:
-                    list[relname] = ('L',inomap[s.st_ino])
+                    list[relname] = ('L', inomap[s.st_ino])
                     continue
                 inomap[s.st_ino] = relname
-                list[relname] = statToTuple(s,absname)
+                list[relname] = statToTuple(s, absname)
         return list
 
-    def doCommand(self,what):
+    def doCommand(self, what):
         '''
         Perform the command requested by the remote side and prepare any
         result.
         '''
-        if what[0]=='connect':
+        if what[0] == 'connect':
             self.connectAddress = what[1]
-        elif what[0]=='getOptions':
+        elif what[0] == 'getOptions':
             return self.options
-        elif what[0]=='getDestDir':
+        elif what[0] == 'getDestDir':
             return self.destDir
-        elif what[0]=='getList':
+        elif what[0] == 'getList':
             return self.getList()
-        elif what[0]=='getDigest':
+        elif what[0] == 'getDigest':
             m = hashlib.md5()
-            m.update(self.readFile(what[1],what[2],what[3]))
+            m.update(self.readFile(what[1], what[2], what[3]))
             return m.digest()
-        elif what[0]=='getData':
-            self.sendData = self.readFile(what[1],what[2],what[3])
+        elif what[0] == 'getData':
+            self.sendData = self.readFile(what[1], what[2], what[3])
             if self.options.compress:
-                self.sendData = zlib.compress(self.sendData,1)
+                self.sendData = zlib.compress(self.sendData, 1)
             return len(self.sendData)
         elif what[0] == 'recordProgress':
             if self.recordProgressCallback:
@@ -536,11 +543,10 @@ class LocalPysync:
                 sys.stdout.write("raw: " + str(what[1]))
                 sys.stdout.write('\n')
             return None
-        elif what[0]=='quit':
+        elif what[0] == 'quit':
             raise LocalPysync._Quit(what[1])
         else:
             assert 0
-
 
     def _recordProgress(self, message):
         '''
@@ -563,7 +569,7 @@ class LocalPysync:
         instance.
         '''
         a = cPickle.dumps(args)
-        sys.stdout.write('pKl:%d\n%s'%(len(a),a))
+        sys.stdout.write('pKl:%d\n%s' % (len(a), a))
         sys.stdout.flush()
 
     def work(self):
@@ -583,37 +589,37 @@ class LocalPysync:
             except:
                 # parent gone, exit
                 return 2
-            
+
             # Get the length of the next serialized command
             a = self.p.stdout.readline()
-            if len(a)==0:
+            if len(a) == 0:
                 # End the command loop if EOF
                 print >> sys.stderr, "[FATAL]:-Unexpected EOF on RemotePysync output stream"
                 return 3
             size = int(a)
-            
+
             # Read the serialized command and process it.
             data = self.p.stdout.read(size)
-            assert len(data)==size
+            assert len(data) == size
             try:
                 answer = cPickle.dumps(self.doCommand(cPickle.loads(data)))
             except LocalPysync._Quit, e:
                 return e.code
-            
+
             # Send the serialized command response
-            self.p.stdin.write("%d\n%s"%(len(answer),answer))
+            self.p.stdin.write("%d\n%s" % (len(answer), answer))
             self.p.stdin.flush()
-            
+
             # If the command was a connect order, open a socket to
             # the remote side for data transfer
-            if self.connectAddress!=None:
+            if self.connectAddress != None:
                 self.socket = socket.socket(self.options.addrinfo[0])
                 self.socket.connect(self.connectAddress)
                 self.connectAddress = None
-                
+
             # If the command was a getData order, send the prepared
             # data over the socket.
-            if self.sendData!=None:
+            if self.sendData != None:
                 self.socket.sendall(self.sendData)
                 self.sendData = None
 
@@ -626,9 +632,9 @@ class LocalPysync:
         os.system('echo %d > /tmp/pysync.py.%s.ppid' % (os.getppid(), self.destDir.replace('/', '_')))
         PATH = os.environ.get('PATH') or '.'
         LIBPATH = os.environ.get('LD_LIBRARY_PATH') or '.'
-        
-        cmd = ('''. %s/greenplum_path.sh && bash -c "python -u -c '%s'"''' 
-               % (os.environ.get('GPHOME'),  
+
+        cmd = ('''. %s/greenplum_path.sh && bash -c "python -u -c '%s'"'''
+               % (os.environ.get('GPHOME'),
                   bootstrapSource))
         args = []
         args.append('ssh')
@@ -643,13 +649,13 @@ class LocalPysync:
             try:
                 pysyncSource = inspect.getsource(pysync_remote)
                 self.p = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
-                self.p.stdin.write("%d\n%s"%(len(pysyncSource),pysyncSource))
+                self.p.stdin.write("%d\n%s" % (len(pysyncSource), pysyncSource))
                 code = self.work()
             except OSError, e:
                 sys.stderr.write(str(e))
                 raise
         finally:
-            os.remove('/tmp/pysync.py.%s.ppid' % (self.destDir.replace('/','_')))
+            os.remove('/tmp/pysync.py.%s.ppid' % (self.destDir.replace('/', '_')))
             if self.p:
                 timer = threading.Timer(2.0, (lambda: os.kill(self.p.pid, signal.SIGHUP)))
                 timer.start()
@@ -658,8 +664,9 @@ class LocalPysync:
 
         if self.usingProxy:
             self._sendCommand('quit', code)
-        
+
         return code
+
 
 if os.environ.get('GPHOME') is None:
     print >> sys.stderr, '[FATAL]:- Please specify environment variable GPHOME'

--- a/gpMgmt/bin/lib/pysync_remote.py
+++ b/gpMgmt/bin/lib/pysync_remote.py
@@ -3,11 +3,11 @@ The pysync_remote module is a companion to the pysync module containing the
 components required for the remote end of a synchronization pair.
 '''
 from __future__ import with_statement
-import sys,os
+import sys, os
 
-if sys.hexversion<0x2040400:
+if sys.hexversion < 0x2040400:
     sys.stderr.write("pysync_remote.py needs python version at least 2.4.4 on the remote computer.\n")
-    sys.stderr.write("You are using %s\n"%sys.version)
+    sys.stderr.write("You are using %s\n" % sys.version)
     sys.stderr.write("Here is a guess at where the python executable is--\n")
     os.system("/bin/sh -c 'type python>&2'");
     sys.exit(1)
@@ -16,7 +16,7 @@ import copy
 import cPickle
 from datetime import datetime
 import errno
-import hashlib 
+import hashlib
 import socket
 import stat
 import threading
@@ -29,9 +29,10 @@ if __name__ == '__main__':
     sys.modules['pysync_remote'] = sys.modules['__main__']
 
 # The number of file bytes processed at a time
-CHUNK_SIZE=4000000
+CHUNK_SIZE = 4000000
 
-class Progress: 
+
+class Progress:
     def __init__(self, byteMax, fileMax):
         self.status = '';
         self.fname = '';
@@ -45,12 +46,12 @@ class Progress:
         pct = 0
         if self.byteMax > 0: pct = int(self.byteNow * 100 / self.byteMax);
         sys.stderr.write('[%s %d%%] %s %s byte:%d/%d file:%d/%d\n' % (
-                          datetime.now().isoformat(' '), 
-                          pct, self.status, self.fname, self.byteNow, 
-                          self.byteMax, self.fileNow, self.fileMax))
+            datetime.now().isoformat(' '),
+            pct, self.status, self.fname, self.byteNow,
+            self.byteMax, self.fileNow, self.fileMax))
 
     def update(self, status, fname, byteNow, fileNow):
-        changed = (status != self.status 
+        changed = (status != self.status
                    or fname != self.fname
                    or fileNow != self.fileNow
                    or (time.time() - self.tstamp > 5))
@@ -58,7 +59,7 @@ class Progress:
         self.fname = fname
         self.byteNow = byteNow
         self.fileNow = fileNow
-        if changed: 
+        if changed:
             self.tstamp = time.time()
             self._printStatus()
 
@@ -67,6 +68,7 @@ class Options:
     '''
     A container for the options collected by LocalPysync and use by RemotePysync.
     '''
+
     def __init__(self):
         self.compress = False
         self.verbose = False
@@ -81,8 +83,7 @@ class Options:
         self.addrinfo = None
 
 
-
-def statToTuple(s,name):
+def statToTuple(s, name):
     '''
     Converts the os.stat() structure to a tuple used internally.  The tuple
     content varies by type but is generally of the form:
@@ -101,20 +102,20 @@ def statToTuple(s,name):
     These entry types are coordinated with code in RemotePysync.createFiles().
     '''
     if stat.S_ISREG(s.st_mode):
-        return ['-',s.st_mode,s.st_size,None]
+        return ['-', s.st_mode, s.st_size, None]
     if stat.S_ISLNK(s.st_mode):
-        return ('l',0,os.readlink(name))
+        return ('l', 0, os.readlink(name))
     if stat.S_ISDIR(s.st_mode):
-        return ('d',s.st_mode)
+        return ('d', s.st_mode)
     if stat.S_ISCHR(s.st_mode):
-        return ('c',s.st_mode,s.st_rdev)
+        return ('c', s.st_mode, s.st_rdev)
     if stat.S_ISBLK(s.st_mode):
-        return ('b',s.st_mode,s.st_rdev)
+        return ('b', s.st_mode, s.st_rdev)
     if stat.S_ISFIFO(s.st_mode):
-        return ('p',s.st_mode)
+        return ('p', s.st_mode)
     if stat.S_ISSOCK(s.st_mode):
-        return ('s',s.st_mode)
-    raise Exception('Pysync can not handle %s.'%name)
+        return ('s', s.st_mode)
+    raise Exception('Pysync can not handle %s.' % name)
 
 
 def formatSiBinary(number):
@@ -143,25 +144,25 @@ class ProgressUpdate():
     A container used to report raw synchronization progress information collected
     by SyncProgress and RemotePysync to LocalPysync.
     '''
+
     def __init__(self, isFinal=False, totalExpectedBytes=0, totalExpectedFiles=0, progressCounters=None):
-        
         # An indication of whether or not this ProgressUpdate is the final
         self.isFinal = isFinal
-        
+
         # The total number of file bytes expected to be processed
         self.totalExpectedBytes = totalExpectedBytes
-        
+
         # The total number of files expected to be processed
         self.totalExpectedFiles = totalExpectedFiles
-        
+
         # ProgressCounters for this update
         self.progressCounters = copy.copy(progressCounters)
 
     def __str__(self):
         return ("ProgressUpdate(isFinal=%s, totalExpectedBytes=%d, totalExpectedFiles=%d, progressCounters=%s)"
-                % (self.isFinal, 
-                   self.totalExpectedBytes, 
-                   self.totalExpectedFiles, 
+                % (self.isFinal,
+                   self.totalExpectedBytes,
+                   self.totalExpectedFiles,
                    self.progressCounters))
 
 
@@ -169,25 +170,25 @@ class ProgressCounters():
     '''
     A structure used to track the progress reported to SyncProgress.
     '''
+
     def __init__(self, updateTime=None, bytesProcessed=0, filesProcessed=0, processingFile=None):
-        
         # The time (from time.time()) this instance was last updated
         self.updateTime = updateTime
-        
+
         # The cumulative number of bytes processed as of the last update
         self.bytesProcessed = bytesProcessed
-        
+
         # The cumulative number of files *completed* as of the last update
         self.filesProcessed = filesProcessed
-        
+
         # The file being processed during the last update
         self.processingFile = processingFile
 
     def __str__(self):
-        return ("ProgressCounters(updateTime=%f, bytesProcessed=%d, filesProcessed=%d, processingFile=\"%s\"))" 
-                % (self.updateTime, 
-                   self.bytesProcessed, 
-                   self.filesProcessed, 
+        return ("ProgressCounters(updateTime=%f, bytesProcessed=%d, filesProcessed=%d, processingFile=\"%s\"))"
+                % (self.updateTime,
+                   self.bytesProcessed,
+                   self.filesProcessed,
                    self.processingFile))
 
 
@@ -199,16 +200,16 @@ class SyncProgress(threading.Thread):
     information to this instance; the stop() method should be called when the sync
     operation is complete so a final report can be issued.
     '''
-    
+
     # The minimum allowed reporting interval based on time (in seconds)
     MINIMUM_TIME_INTERVAL = 2 * 60.0
     DEFAULT_TIME_INTERVAL = 10 * 60.0
-    
+
     # The minimum allowed reporting interval based on byte volume
     MINIMUM_VOLUME_INTERVAL = 512 * 1024 * 1024
     DEFAULT_VOLUME_INTERVAL = "5.0%"
-    
-    def __init__(self, list, reportInterval=0, reportBytes=0, 
+
+    def __init__(self, list, reportInterval=0, reportBytes=0,
                  recordProgressCallback=None, recordRawProgressCallback=None,
                  progressTimestamp=False):
         '''
@@ -237,13 +238,13 @@ class SyncProgress(threading.Thread):
         progressTimestamp - indicates whether or not the observation timestamp is
                 included in progress messages emitted by this SyncProgress instance.
         '''
-        
+
         self._final = False
         self._totalBytes = 0
         self._totalFiles = 0
         self.processingChunk = 0
         self.progressTimestamp = progressTimestamp
-        
+
         # Calculate the total number of files and bytes that could be 
         # processed.  Only regular files contribute to the total byte 
         # count.
@@ -251,14 +252,14 @@ class SyncProgress(threading.Thread):
             if desc[0] == '-':
                 self._totalBytes += desc[2]
                 self._totalFiles += 1
-        
+
         # Indicates the time, in seconds, of the progress reporting interval.
         if reportInterval == 0:
             reportInterval = SyncProgress.DEFAULT_TIME_INTERVAL
         elif reportInterval < SyncProgress.MINIMUM_TIME_INTERVAL:
             raise ValueError("reportInterval must be at least %d" % SyncProgress.MINIMUM_TIME_INTERVAL, reportInterval)
         self.progressInterval = reportInterval
-        
+
         # Indicates the amount, in bytes, of the data processed before a progress report is forced.
         if reportBytes == 0:
             reportBytes = SyncProgress.DEFAULT_VOLUME_INTERVAL
@@ -273,29 +274,29 @@ class SyncProgress(threading.Thread):
             else:
                 raise ValueError("reportBytes must be numeric or a string in the form \"n.n%\"", reportBytes)
         self.progressBytes = reportBytes
-        
+
         # Method to call for recording progress details
         self.recordProgressCallback = recordProgressCallback
-        
+
         # Method to call for recording raw progress data
         self.recordRawProgressCallback = recordRawProgressCallback
-        
+
         # Active ProgressCounters instance
         self.progressCounters = ProgressCounters()
         # Access synchronization lock for self.progressCounters
         self.progressCountersLock = threading.Lock()
-        
+
         # Last time progress was reported
         self.lastReportTime = None
         # Copy of ProgressCounters at self.lastReportTime
         self.lastReportProgressCounters = None
         # Access synchronization lock for self.lastReportTime and self.lastReportProgressCounters
         self.progressReportLock = threading.Lock()
-        
+
         # threading.Event instance used to run the interval timer;
         # setting this Event terminates the reporting loop.
         self.timerEvent = None
-        
+
         threading.Thread.__init__(self, name="ProgressTimer")
         self.daemon = True
 
@@ -313,11 +314,11 @@ class SyncProgress(threading.Thread):
         if not progressCounters:
             with self.progressCountersLock:
                 progressCounters = copy.copy(self.progressCounters)
-        
+
         currentReportTime = time.time()
         with self.progressReportLock:
             lastReportTime = self.lastReportTime
-            
+
             if timedReport:
                 # If the last report was more recent than the desired reporting interval,
                 # suppress this report and return the amount of time remaining until the
@@ -325,11 +326,11 @@ class SyncProgress(threading.Thread):
                 lastReportInterval = currentReportTime - lastReportTime
                 if lastReportInterval < self.progressInterval:
                     return self.progressInterval - lastReportInterval
-            
+
             lastReportProgressCounters = self.lastReportProgressCounters
             self.lastReportTime = currentReportTime
             self.lastReportProgressCounters = progressCounters
-        
+
         if self._final:
             bytesMoved = progressCounters.bytesProcessed
             processingInterval = currentReportTime - self.collectionStartTime
@@ -338,26 +339,26 @@ class SyncProgress(threading.Thread):
             bytesMoved = progressCounters.bytesProcessed - lastReportProgressCounters.bytesProcessed if lastReportProgressCounters else 0
             processingInterval = progressCounters.updateTime - lastReportProgressCounters.updateTime if lastReportProgressCounters else 0.0
             byteRate = bytesMoved / processingInterval if processingInterval else 0.0
-        
-        message = ("%sProcessed %sB of %sB (%d%%); %sB processed at %sBps; %d of %d files processed" 
-                   % ('*' if timedReport else ' ', 
-                      formatSiBinary(progressCounters.bytesProcessed), 
-                      formatSiBinary(self._totalBytes), 
-                      100 * progressCounters.bytesProcessed / self._totalBytes if self._totalBytes !=0 else 1, 
-                      formatSiBinary(bytesMoved), 
-                      formatSiBinary(byteRate), 
-                      progressCounters.filesProcessed, 
+
+        message = ("%sProcessed %sB of %sB (%d%%); %sB processed at %sBps; %d of %d files processed"
+                   % ('*' if timedReport else ' ',
+                      formatSiBinary(progressCounters.bytesProcessed),
+                      formatSiBinary(self._totalBytes),
+                      100 * progressCounters.bytesProcessed / self._totalBytes if self._totalBytes != 0 else 1,
+                      formatSiBinary(bytesMoved),
+                      formatSiBinary(byteRate),
+                      progressCounters.filesProcessed,
                       self._totalFiles))
-        
+
         if self.progressTimestamp:
             message = "[%s]%s" % (datetime.fromtimestamp(currentReportTime).isoformat(' '), message)
-        
+
         if self.recordProgressCallback:
             self.recordProgressCallback(message)
         else:
             sys.stderr.write(message)
             sys.stderr.write("\n")
-        
+
         return self.progressInterval
 
     def update(self, fileBytesProcessed=0, processingFile=None):
@@ -376,27 +377,27 @@ class SyncProgress(threading.Thread):
         '''
         progressUpdate = None
         progressCounters = None
-        
+
         with self.progressCountersLock:
             self.progressCounters.updateTime = time.time()
             self.progressCounters.bytesProcessed += fileBytesProcessed
-            
+
             if self.progressCounters.processingFile != processingFile:
                 if self.progressCounters.processingFile:
                     self.progressCounters.filesProcessed += 1
                 self.progressCounters.processingFile = processingFile
-                
+
             processingChunk = self.progressCounters.bytesProcessed // self.progressBytes if self.progressBytes != 0 else 1
             if self._final or processingChunk > self.processingChunk:
                 self.processingChunk = processingChunk
                 progressCounters = copy.copy(self.progressCounters)
-            
+
             if self.recordRawProgressCallback:
                 progressUpdate = ProgressUpdate(self._final, self._totalBytes, self._totalFiles, self.progressCounters)
-        
+
         if progressUpdate:
             self.recordRawProgressCallback(progressUpdate)
-        
+
         if progressCounters:
             self._emitProgress(progressCounters, False)
 
@@ -411,18 +412,18 @@ class SyncProgress(threading.Thread):
         self.collectionStartTime = self.lastReportTime = self.progressCounters.updateTime = time.time()
         self.lastReportProgressCounters = copy.copy(self.progressCounters)
         self.timerEvent = threading.Event()
-        
+
         waitInterval = self.progressInterval
         while not self.timerEvent.isSet():
             self.timerEvent.wait(waitInterval)
             if self.timerEvent.isSet():
                 break
             waitInterval = self._emitProgress()
-        
+
         # Close out statistics and emit the final report
         self._final = True
         self.update()
-        
+
         self.timerEvent = None
 
     def stop(self):
@@ -451,16 +452,16 @@ class RemotePysync:
     '''
 
     def __init__(self):
-        
+
         # The SyncProgress instance used to track progress of the directory 
         # synchronization managed by this RemotePysync instance.
         self.syncProgress = None
-        
+
         # Synchronization lock to prevent interleaved communications using
         # self.sendCommand() and self.getAnswer().
         self.commLock = threading.RLock()
 
-    def sendCommand(self,*args):
+    def sendCommand(self, *args):
         '''
         Serialize the command & arguments using cPickle and send write to stdout.
         
@@ -468,7 +469,7 @@ class RemotePysync:
         not be released until the getAnswer() method is called to obtain the results.
         '''
         a = cPickle.dumps(args)
-        sys.stdout.write('%d\n%s'%(len(a),a))
+        sys.stdout.write('%d\n%s' % (len(a), a))
         sys.stdout.flush()
 
     def getAnswer(self):
@@ -485,10 +486,10 @@ class RemotePysync:
         '''
         size = int(sys.stdin.readline())
         data = sys.stdin.read(size)
-        assert size==len(data)
+        assert size == len(data)
         return cPickle.loads(data)
 
-    def doCommand(self,*args):
+    def doCommand(self, *args):
         '''
         Sends the command represented by args to the local peer of this
         RemotePysync and returns with the answer.
@@ -514,7 +515,7 @@ class RemotePysync:
         if progressUpdate:
             self.doCommand('recordRawProgress', progressUpdate)
 
-    def removeJunk(self,list):
+    def removeJunk(self, list):
         '''
         Trim the current directory of files and directories not in list
         (if options.delete is True) and files and directories in list if
@@ -523,32 +524,32 @@ class RemotePysync:
         Existing files of the expected type may be altered or removed in
         self.createFiles().
         '''
-        for root,dirs,files in os.walk('.',False):
-            os.chmod(root,0700)
-            for i in dirs+files:
-                name = os.path.join(root,i)
-                t = statToTuple(os.lstat(name),name)
-                if name not in list and self.options.delete or name in list and list[name][0]!=t[0]:
-                    if t[0]=='d':
+        for root, dirs, files in os.walk('.', False):
+            os.chmod(root, 0700)
+            for i in dirs + files:
+                name = os.path.join(root, i)
+                t = statToTuple(os.lstat(name), name)
+                if name not in list and self.options.delete or name in list and list[name][0] != t[0]:
+                    if t[0] == 'd':
                         os.rmdir(name)
                     else:
                         os.remove(name)
 
-    def createDirs(self,list):
+    def createDirs(self, list):
         '''
         Create all directories identified in list.
         '''
         for name in sorted(list.keys()):
             value = list[name]
-            if value[0]=='d':
+            if value[0] == 'd':
                 try:
-                    os.mkdir(name,0700)
+                    os.mkdir(name, 0700)
                 except OSError, err:
                     if err.errno != errno.EEXIST:
                         raise
-                    # Ignoring creation error for existing directory
+                        # Ignoring creation error for existing directory
 
-    def createFiles(self,list):
+    def createFiles(self, list):
         '''
         Create all files identified in the list.
         
@@ -556,12 +557,12 @@ class RemotePysync:
         this method.  Hard links (entry type = 'L') are not processed by this 
         method.
         '''
-        for name,value in list.iteritems():
-            
+        for name, value in list.iteritems():
+
             # If a directory or hard link, skip it.
-            if value[0]=='d' or value[0]=='L':
+            if value[0] == 'd' or value[0] == 'L':
                 continue
-            
+
             # If the file already exists, process according to its existing
             # type:
             #    1) If the existing type and the expected/desired type
@@ -579,41 +580,41 @@ class RemotePysync:
             #       same or file processing was not skipped above, remove the
             #       existing file and continue processing.
             if os.path.lexists(name):
-                t = statToTuple(os.lstat(name),name)
-                if value[0]==t[0]:
-                    if value[0]!='l':
-                        os.chmod(name,0700)
-                    if value[0]=='-':
+                t = statToTuple(os.lstat(name), name)
+                if value[0] == t[0]:
+                    if value[0] != 'l':
+                        os.chmod(name, 0700)
+                    if value[0] == '-':
                         value[3] = t[2]
-                        if t[2]>value[2]:
-                            f = open(name,'r+b')
+                        if t[2] > value[2]:
+                            f = open(name, 'r+b')
                             f.truncate(value[2])
                             f.close()
                         continue
-                    if value[2:]==t[2:]:
+                    if value[2:] == t[2:]:
                         continue
                 os.remove(name)
-            
+
             # Create the file entry based on the desired type.
             # For regular files, an empty (zero-length) file is created.
-            if value[0]=='-':
-                open(name,'w+b').close()
-            elif value[0]=='l':
-                os.symlink(value[2],name)
-            elif value[0]=='c':
-                os.mknod(name,0700|stat.S_IFCHR,value[2])
-            elif value[0]=='b':
-                os.mknod(name,0700|stat.S_IFBLK,value[2])
-            elif value[0]=='p':
-                os.mkfifo(name,0700)
-            elif value[0]=='s':
+            if value[0] == '-':
+                open(name, 'w+b').close()
+            elif value[0] == 'l':
+                os.symlink(value[2], name)
+            elif value[0] == 'c':
+                os.mknod(name, 0700 | stat.S_IFCHR, value[2])
+            elif value[0] == 'b':
+                os.mknod(name, 0700 | stat.S_IFBLK, value[2])
+            elif value[0] == 'p':
+                os.mkfifo(name, 0700)
+            elif value[0] == 's':
                 f = socket.socket(socket.AF_UNIX)
                 f.bind(name)
                 f.close()
             else:
                 assert 0
 
-    def linkLinks(self,list):
+    def linkLinks(self, list):
         '''
         Create hard links identified in the list.  An existing file
         having the same name as the link is removed before the link
@@ -623,83 +624,83 @@ class RemotePysync:
         files must be created by calling self.createFiles() before calling
         this method.
         '''
-        for name,value in list.iteritems():
-            if value[0]=='L':
+        for name, value in list.iteritems():
+            if value[0] == 'L':
                 if os.path.lexists(name):
                     os.remove(name)
-                os.link(value[1],name)
+                os.link(value[1], name)
 
-    def getData(self,name,offset,size):
+    def getData(self, name, offset, size):
         if not self.socket:
             ss = socket.socket(self.options.addrinfo[0])
             ss.bind(self.options.addrinfo[4])
             ss.listen(1)
-            self.doCommand('connect',ss.getsockname())
+            self.doCommand('connect', ss.getsockname())
             self.socket = ss.accept()[0]
             ss.close()
-        s = self.doCommand('getData',name,offset,size)
+        s = self.doCommand('getData', name, offset, size)
         o = 0
         sb = []
-        while o<s:
-            a = self.socket.recv(min(s-o,65536))
-            if len(a)==0:
+        while o < s:
+            a = self.socket.recv(min(s - o, 65536))
+            if len(a) == 0:
                 raise IOError('EOF')
             sb.append(a)
             o += len(a)
         data = "".join(sb)
         if self.options.compress:
             data = zlib.decompress(data)
-        assert len(data)==size
+        assert len(data) == size
         return data
 
-    def copyData(self,list):
+    def copyData(self, list):
         fileMax = 0
         byteMax = 0
-        for name,value in list.iteritems():
-            if value[0]=='-':
+        for name, value in list.iteritems():
+            if value[0] == '-':
                 fileMax += 1
                 byteMax += value[2]
-        progress = Progress(byteMax,fileMax)
+        progress = Progress(byteMax, fileMax)
         fileNow = 0
         byteNow = 0
         bytesTotal = 0
         unchanged = 0
-        for name,value in list.iteritems():
-            if value[0]=='-':
+        for name, value in list.iteritems():
+            if value[0] == '-':
                 f = None
                 if self.options.minusn:
                     if os.path.lexists(name) and stat.S_ISREG(os.lstat(name).st_mode):
-                        f = open(name,'rb')
+                        f = open(name, 'rb')
                 else:
-                    f = open(name,'r+b')
+                    f = open(name, 'r+b')
                 localSize = 0
                 if f:
-                    f.seek(0,2)
+                    f.seek(0, 2)
                     localSize = f.tell()
                 offset = 0
                 bytesFile = 0
-                changed = value[2]!=value[3]
+                changed = value[2] != value[3]
                 if not value[2]:
                     # Zero-length files require little work
                     if not self.options.minusn:
                         self.syncProgress.update(processingFile=name)
                 else:
-                    while offset<value[2]:
+                    while offset < value[2]:
                         if self.options.verbose:
-                            progress.update('',name,byteNow,fileNow)
-                        size = min(value[2]-offset,CHUNK_SIZE)
+                            progress.update('', name, byteNow, fileNow)
+                        size = min(value[2] - offset, CHUNK_SIZE)
                         digest = None
-                        if offset+size<=localSize:
+                        if offset + size <= localSize:
                             with self.commLock:
-                                self.sendCommand('getDigest',name,offset,size)
+                                self.sendCommand('getDigest', name, offset, size)
                                 f.seek(offset)
                                 b = f.read(size)
-                                assert len(b)==size
+                                assert len(b) == size
                                 m = hashlib.md5()
                                 m.update(b)
                                 a = m.digest()
                                 digest = self.getAnswer()
-                            if a==digest:
+                            if a == digest:
                                 if not self.options.minusn:
                                     self.syncProgress.update(fileBytesProcessed=size, processingFile=name)
                                 offset += size
@@ -707,13 +708,13 @@ class RemotePysync:
                                 continue
                         changed = True
                         if not self.options.minusn:
-                            data = self.getData(name,offset,size)
+                            data = self.getData(name, offset, size)
                             if not self.options.insecure:
-                                if digest==None:
-                                    digest = self.doCommand('getDigest',name,offset,size)
+                                if digest == None:
+                                    digest = self.doCommand('getDigest', name, offset, size)
                                 m = hashlib.md5()
                                 m.update(data)
-                                if m.digest()!=digest:
+                                if m.digest() != digest:
                                     raise Exception('Digest did not match.')
                             f.seek(offset)
                             f.write(data)
@@ -725,60 +726,63 @@ class RemotePysync:
                 if f:
                     f.close()
                 if self.options.minusn and self.options.verbose:
-                    sys.stderr.write('%s %d\n'%(name,bytesFile))
+                    sys.stderr.write('%s %d\n' % (name, bytesFile))
                 if not changed:
                     if self.options.verbose:
-                        sys.stderr.write('%s is the same\n'%name)
+                        sys.stderr.write('%s is the same\n' % name)
                     unchanged += 1
                 fileNow += 1
         if self.options.verbose:
-            progress.update('','',byteNow,fileNow)
+            progress.update('', '', byteNow, fileNow)
         updated = fileMax - unchanged
         if self.options.minusn or self.options.verbose:
-            sys.stderr.write('%d out of %d file(s) updated.\n'%(updated, fileMax))
+            sys.stderr.write('%d out of %d file(s) updated.\n' % (updated, fileMax))
         if self.options.minusn:
-            sys.stderr.write('Total--%d byte%s\n'%(bytesTotal,bytesTotal!=1 and 's' or ''))
+            sys.stderr.write('Total--%d byte%s\n' % (bytesTotal, bytesTotal != 1 and 's' or ''))
 
-    def fixPermissions(self,list):
+    def fixPermissions(self, list):
         '''
         Set the permission bits of the non-link files and directories to
         the expected value.
         '''
-        for name,value in list.iteritems():
-            if value[0]!='L' and value[0]!='l':
-                os.chmod(name,value[1]&01777)
+        for name, value in list.iteritems():
+            if value[0] != 'L' and value[0] != 'l':
+                os.chmod(name, value[1] & 01777)
 
     def run(self):
         self.socket = None
         self.options = self.doCommand('getOptions')
-        
+
         # TODO: Add a safety check for destDir
         os.chdir(self.doCommand('getDestDir'))
-        
+
         list = self.doCommand('getList')
-        
+
         if self.options.minusn:
             self.copyData(list)
         else:
-            self.syncProgress = SyncProgress(list, 
+            self.syncProgress = SyncProgress(list,
                                              reportInterval=self.options.progressTime,
                                              reportBytes=self.options.progressBytes,
-                                             recordProgressCallback=(self._recordProgress if self.options.sendProgress else None),
-                                             recordRawProgressCallback=(self._recordRawProgress if self.options.sendRawProgress else None),
+                                             recordProgressCallback=(
+                                             self._recordProgress if self.options.sendProgress else None),
+                                             recordRawProgressCallback=(
+                                             self._recordRawProgress if self.options.sendRawProgress else None),
                                              progressTimestamp=self.options.progressTimestamp)
             self.syncProgress.start()
-            
+
             self.removeJunk(list)
             self.createDirs(list)
             self.createFiles(list)
             self.linkLinks(list)
             self.copyData(list)
             self.fixPermissions(list)
-            
+
             self.syncProgress.stop()
 
         with self.commLock:
             self.sendCommand('quit', 0)
+
 
 if __name__ == '__main__':
     RemotePysync().run()

--- a/gpMgmt/bin/lib/pysync_remote.py
+++ b/gpMgmt/bin/lib/pysync_remote.py
@@ -696,7 +696,7 @@ class RemotePysync:
                                 f.seek(offset)
                                 b = f.read(size)
                                 assert len(b) == size
-                                m = hashlib.md5()
+                                m = hashlib.sha256()
                                 m.update(b)
                                 a = m.digest()
                                 digest = self.getAnswer()
@@ -712,7 +712,7 @@ class RemotePysync:
                             if not self.options.insecure:
                                 if digest == None:
                                     digest = self.doCommand('getDigest', name, offset, size)
-                                m = hashlib.md5()
+                                m = hashlib.sha256()
                                 m.update(data)
                                 if m.digest() != digest:
                                     raise Exception('Digest did not match.')


### PR DESCRIPTION
This utility used to confirm data transfered by doing a md5 digest. This
commit changes behavior to use sha256 instead.

Signed-off-by: Nadeem Ghani <nghani@pivotal.io>