### PR TITLE
buildMirrors: Do not error out if nothing to do.

### DIFF
--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -286,7 +286,7 @@ class GpMirrorListToBuild:
 
         if len(self.__mirrorsToBuild) == 0:
             self.__logger.info("No segments to " + actionName)
-            return False    # as we don't want caller to print any success messages
+            return True
 
         self.checkForPortAndDirectoryConflicts(gpArray)
 


### PR DESCRIPTION
In GpMirrorListToBuild.buildMirrors() if there are no mirrors to
build, then return True, so that gprecoverseg returns a return code
of 0.

Signed-off-by: Shoaib Lari <slari@pivotal.io>
Signed-off-by: Nadeem Ghani <nghani@pivotal.io>