### PR TITLE
FaultInjector_UpdateHashEntry() should use FaultInjector_LookupHashEn…

### DIFF
--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -1284,17 +1284,14 @@ FaultInjector_UpdateHashEntry(
 {
 	
 	FaultInjectorEntry_s	*entryLocal;
-	bool					exists;
 	int						status = STATUS_OK;
 
 	FiLockAcquire();
 
-	entryLocal = FaultInjector_InsertHashEntry(entry->faultInjectorIdentifier, &exists);
+	entryLocal = FaultInjector_LookupHashEntry(entry->faultInjectorIdentifier);
 	
-	/* entry should be found since fault has not been injected yet */			
-	Assert(entryLocal != NULL);
-	
-	if (!exists) {
+	if (entryLocal == NULL)
+	{
 		FiLockRelease();
 		status = STATUS_ERROR;
 		ereport(WARNING,


### PR DESCRIPTION
…try().

FaultInjector_UpdateHashEntry() was using FaultInjector_InsertHashEntry(), which
ends-up adding entry if not present without incrementing
`faultInjectorShmem->faultInjectorSlots`. This causes inconsistency, plus also
sometimes encounters "FailedAssertion(""!(faultInjectorShmem->faultInjectorSlots
== 0)""," during fault inject reset, as goes negative. Fixing the same by using
FaultInjector_LookupHashEntry() instead as that's what
FaultInjector_UpdateHashEntry() needs.

Scenario the Assertion was hitting:
gpfaultinjector -f all -m async -y resume -r primary -H ALL
gpfaultinjector -f all -m async -y reset -r primary -H ALL