### PR TITLE
Remove pessimization of trivial SubqueryScans over Window nodes.

### DIFF
--- a/src/backend/optimizer/plan/setrefs.c
+++ b/src/backend/optimizer/plan/setrefs.c
@@ -1056,9 +1056,6 @@ trivial_subqueryscan(SubqueryScan *plan)
 		list_length(plan->subplan->targetlist))
 		return false;			/* tlists not same length */
 
-	if ( IsA(plan->subplan, Window) )
-		return false;
-
 	attrno = 1;
 	forboth(lp, plan->scan.plan.targetlist, lc, plan->subplan->targetlist)
 	{

--- a/src/test/regress/expected/olap_window_seq.out
+++ b/src/test/regress/expected/olap_window_seq.out
@@ -7806,16 +7806,17 @@ order by 1,2,3;
  Plain     | Donuts    | 500 | 1 |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |    
 (8 rows)
 
--- MPP-4840
+-- Once upon a time, there was a bug in deparsing a Window node with EXPLAIN
+-- that this query triggered (MPP-4840)
 explain select n from ( select row_number() over () from (values (0)) as t(x) ) as r(n) group by n;
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
- HashAggregate  (cost=0.03..0.04 rows=1 width=8)
-   Group By: n
-   ->  Subquery Scan r  (cost=0.00..0.02 rows=2 width=8)
-         ->  Window  (cost=0.00..0.01 rows=0 width=0)
-               ->  Values Scan on "*VALUES*"  (cost=0.00..0.01 rows=0 width=0)
- Settings:  gp_enable_sequential_window_plans=on
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ HashAggregate  (cost=0.02..0.03 rows=1 width=8)
+   Group By: pg_catalog.row_number()
+   ->  Window  (cost=0.00..0.01 rows=1 width=0)
+         ->  Values Scan on "*VALUES*"  (cost=0.00..0.01 rows=1 width=0)
+ Settings:  gp_enable_sequential_window_plans=on; optimizer=off
+ Optimizer status: legacy query optimizer
 (6 rows)
 
 -- Test for MPP-11645
@@ -8021,19 +8022,19 @@ create table redundant_sort_check (i int, j int, k int) distributed by (i);
 explain select count(*) over (order by i), count(*) over (partition by i order by j) from redundant_sort_check;
                                                QUERY PLAN                                               
 --------------------------------------------------------------------------------------------------------
- Subquery Scan coplan  (cost=0.01..0.06 rows=1 width=8)
-   ->  Window  (cost=0.01..0.05 rows=1 width=8)
-         Order By: coplan.i
-         ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.01..0.05 rows=1 width=8)
-               Merge Key: coplan.i, coplan.j
-               ->  Subquery Scan coplan  (cost=0.01..0.03 rows=1 width=8)
-                     ->  Window  (cost=0.01..0.02 rows=1 width=8)
-                           Partition By: redundant_sort_check.i
-                           Order By: redundant_sort_check.j
-                           ->  Sort  (cost=0.01..0.02 rows=1 width=8)
-                                 Sort Key: redundant_sort_check.i, redundant_sort_check.j
-                                 ->  Seq Scan on redundant_sort_check  (cost=0.00..0.00 rows=1 width=8)
- Settings:  gp_enable_sequential_window_plans=on
+ Subquery Scan coplan  (cost=7208.12..11103.12 rows=77900 width=8)
+   ->  Window  (cost=7208.12..10324.12 rows=77900 width=8)
+         Order By: redundant_sort_check.i
+         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=7208.12..10129.37 rows=77900 width=8)
+               Merge Key: redundant_sort_check.i, redundant_sort_check.j
+               ->  Window  (cost=7208.12..7792.37 rows=25967 width=8)
+                     Partition By: redundant_sort_check.i
+                     Order By: redundant_sort_check.j
+                     ->  Sort  (cost=7208.12..7402.87 rows=25967 width=8)
+                           Sort Key: redundant_sort_check.i, redundant_sort_check.j
+                           ->  Seq Scan on redundant_sort_check  (cost=0.00..879.00 rows=25967 width=8)
+ Settings:  gp_enable_sequential_window_plans=on; optimizer=off
+ Optimizer status: legacy query optimizer
 (13 rows)
 
 -- End of MPP-13710

--- a/src/test/regress/expected/olap_window_seq_optimizer.out
+++ b/src/test/regress/expected/olap_window_seq_optimizer.out
@@ -7808,7 +7808,8 @@ order by 1,2,3;
  Plain     | Donuts    | 500 | 1 |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |    
 (8 rows)
 
--- MPP-4840
+-- Once upon a time, there was a bug in deparsing a Window node with EXPLAIN
+-- that this query triggered (MPP-4840)
 explain select n from ( select row_number() over () from (values (0)) as t(x) ) as r(n) group by n;
                                      QUERY PLAN                                      
 -------------------------------------------------------------------------------------

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -1271,7 +1271,7 @@ FROM t_mpp_20470 b;
 explain SELECT  cc, sum(nn) over() FROM v1_mpp_20470;
                                                      QUERY PLAN                                                      
 ---------------------------------------------------------------------------------------------------------------------
- Nested Loop  (cost=8184.20..128107063.42 rows=93400 width=28)
+ Nested Loop  (cost=8184.20..128107296.92 rows=93400 width=28)
    ->  Aggregate  (cost=4154.80..4154.81 rows=1 width=0)
          ->  Shared Scan (share slice:id 0:0)  (cost=4029.40..4154.80 rows=93400 width=28)
                ->  Materialize  (cost=3095.40..4029.40 rows=93400 width=28)
@@ -1279,9 +1279,8 @@ explain SELECT  cc, sum(nn) over() FROM v1_mpp_20470;
                            ->  Append  (cost=0.00..1134.00 rows=31134 width=28)
                                  ->  Seq Scan on t_mpp_20470_ptr1 b  (cost=0.00..567.00 rows=15567 width=28)
                                  ->  Seq Scan on t_mpp_20470_ptr2 b  (cost=0.00..567.00 rows=15567 width=28)
-   ->  Subquery Scan coplan  (cost=4029.40..5088.80 rows=93400 width=28)
-         ->  Window  (cost=4029.40..4154.80 rows=93400 width=28)
-               ->  Shared Scan (share slice:id 0:0)  (cost=4029.40..4154.80 rows=93400 width=28)
+   ->  Window  (cost=4029.40..4154.80 rows=93400 width=28)
+         ->  Shared Scan (share slice:id 0:0)  (cost=4029.40..4154.80 rows=93400 width=28)
    SubPlan 1
      ->  Aggregate  (cost=1371.47..1371.48 rows=1 width=8)
            ->  Result  (cost=0.00..1367.50 rows=32 width=4)
@@ -1296,9 +1295,9 @@ explain SELECT  cc, sum(nn) over() FROM v1_mpp_20470;
                              ->  Materialize  (cost=683.80..684.26 rows=16 width=4)
                                    ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..683.75 rows=47 width=4)
                                          ->  Seq Scan on t_mpp_20470_ptr2 a  (cost=0.00..683.75 rows=16 width=4)
- Settings:  optimizer_segments=3
+ Settings:  optimizer=off; optimizer_nestloop_factor=1; optimizer_segments=3
  Optimizer status: legacy query optimizer
-(27 rows)
+(26 rows)
 
 drop view v1_mpp_20470;
 drop table t_mpp_20470;

--- a/src/test/regress/sql/olap_window_seq.sql
+++ b/src/test/regress/sql/olap_window_seq.sql
@@ -1394,8 +1394,11 @@ from product
 window w as (partition by pcolor order by pname)
 order by 1,2,3;
 
--- MPP-4840
+-- Once upon a time, there was a bug in deparsing a Window node with EXPLAIN
+-- that this query triggered (MPP-4840)
 explain select n from ( select row_number() over () from (values (0)) as t(x) ) as r(n) group by n;
+
+
 -- Test for MPP-11645
 
 create table olap_window_r (a int, b int, x int,  y int,  z int ) distributed by (b);


### PR DESCRIPTION
This hack, to refrain from removing a trivial SubqueryScan if the subnode
was a Window node, was added back in 2009 along with the test case. I'm
not sure what the problem was, but this must've been just a quick band-aid
over whatever the real problem was. It doesn't seem to be needed anymore,
as everything works without it.

Expand the comment in the test case a little bit to explain what the point
of the query is. The original commit message said just "Fix MPP-4840", so
this is all the information I could find about it, unfortunately.