### PR TITLE
gpcheckcloud: append new line to files who miss it

### DIFF
--- a/gpAux/extensions/gpcloud/bin/gpcheckcloud/gpcheckcloud.cpp
+++ b/gpAux/extensions/gpcloud/bin/gpcheckcloud/gpcheckcloud.cpp
@@ -2,7 +2,7 @@
 
 bool hasHeader;
 
-char eolString[EOL_CHARS_MAX_LEN + 1] = "";  // meaningless for gpcheckcloud
+char eolString[EOL_CHARS_MAX_LEN + 1] = "\n";  // LF by default
 
 string s3extErrorMessage;
 
@@ -138,6 +138,8 @@ static void validateCommandLineArgs(map<char, string> &optionPairs) {
 static void printTemplate() {
     printf(
         "[default]\n"
+        "version = \"\"\n"
+        "proxy = \"\"\n"
         "secret = \"aws secret\"\n"
         "accessid = \"aws access id\"\n"
         "threadnum = 4\n"
@@ -146,7 +148,10 @@ static void printTemplate() {
         "low_speed_time = 60\n"
         "encryption = true\n"
         "autocompress = true\n"
-        "proxy = \"\"\n");
+        "verifycert = true\n"
+        "server_side_encryption = \"none\"\n"
+        "# gpcheckcloud config\n"
+        "gpcheckcloud_newline = \"\\n\"\n");
 }
 
 static void printBucketContents(const ListBucketResult &result) {
@@ -200,6 +205,8 @@ static bool downloadS3(const char *urlWithOptions) {
     if (!reader) {
         return false;
     }
+
+    strcpy(eolString, reader->getParams().getGpcheckcloud_newline().c_str());
 
     do {
         data_len = BUF_SIZE;

--- a/gpAux/extensions/gpcloud/include/gpreader.h
+++ b/gpAux/extensions/gpcloud/include/gpreader.h
@@ -30,6 +30,10 @@ class GPReader : public Reader {
         return bucketReader.getKeyList();
     }
 
+    const S3Params &getParams() {
+        return params;
+    }
+
    protected:
     S3Params params;
     S3BucketReader bucketReader;

--- a/gpAux/extensions/gpcloud/include/s3params.h
+++ b/gpAux/extensions/gpcloud/include/s3params.h
@@ -137,6 +137,14 @@ class S3Params {
         this->proxy = proxy;
     }
 
+    const string& getGpcheckcloud_newline() const {
+        return gpcheckcloud_newline;
+    }
+
+    void setGpcheckcloud_newline(string gpcheckcloud_newline) {
+        this->gpcheckcloud_newline = gpcheckcloud_newline;
+    }
+
    private:
     S3Url s3Url;  // original url to read/write.
 
@@ -160,6 +168,8 @@ class S3Params {
     S3SSEType sseType;
 
     S3MemoryContext memoryContext;
+
+    string gpcheckcloud_newline;  // newline LF, CRLF, CR
 };
 
 inline void PrepareS3MemContext(const S3Params& params) {

--- a/gpAux/extensions/gpcloud/include/s3utils.h
+++ b/gpAux/extensions/gpcloud/include/s3utils.h
@@ -31,7 +31,7 @@ bool sha256hmac_hex(const char* str, char out_hash_hex[SHA256_DIGEST_STRING_LENG
 size_t find_Nth(const string& str,  // where to work
                 unsigned N,         // N'th occurrence
                 const string& find  // what to 'find'
-                );
+);
 
 class MD5Calc {
    public:

--- a/gpAux/extensions/gpcloud/regress/gpcheckcloud_regress.sh
+++ b/gpAux/extensions/gpcloud/regress/gpcheckcloud_regress.sh
@@ -10,6 +10,8 @@ RANDOM_PREFIX=gpcheckcloud-$(date +%Y%m%d)-$(cat /dev/urandom | env LC_CTYPE=C t
 echo "Preparing data to upload..."
 dd if=/dev/urandom of=/tmp/gpcheckcloud.small bs=6 count=1 &> /dev/null
 dd if=/dev/urandom of=/tmp/gpcheckcloud.large bs=78MB count=1 &> /dev/null
+echo -ne "\n" >> /tmp/gpcheckcloud.small
+echo -ne "\n" >> /tmp/gpcheckcloud.large
 
 MD5SUM_SMALL=`cat /tmp/gpcheckcloud.small |openssl md5 |cut -d ' ' -f 2`
 MD5SUM_LARGE=`cat /tmp/gpcheckcloud.large |openssl md5 |cut -d ' ' -f 2`
@@ -45,6 +47,7 @@ CHECK_CASES=(
 "s3://s3-us-east-1.amazonaws.com/us-east-1.s3test.pivotal.io/regress/small17/ 138fc555074671912125ba692c678246"
 "s3://s3-us-west-2.amazonaws.com/s3test.pivotal.io/regress/gzipped/ 7b2260e9a3a3f26e84aa28dc2124f68f"
 "s3://s3-us-west-2.amazonaws.com/s3test.pivotal.io/regress/gzipped_normal1/ eacb7b210d3f7703ee06d16f520b103e"
+"s3://s3-us-west-2.amazonaws.com/s3test.pivotal.io/regress/gpcheckcloud_newline/ d9331ecb3dc71b9bfca469654d26ec5f"
 )
 
 startTimer

--- a/gpAux/extensions/gpcloud/src/s3conf.cpp
+++ b/gpAux/extensions/gpcloud/src/s3conf.cpp
@@ -107,6 +107,8 @@ S3Params InitConfig(const string& urlWithOptions) {
 
     params.setProxy(s3Cfg.Get(configSection, "proxy", ""));
 
+    params.setGpcheckcloud_newline(s3Cfg.Get(configSection, "gpcheckcloud_newline", "\n"));
+
     params.setVerifyCert(verifyCert);
 
     CheckEssentialConfig(params);
@@ -125,5 +127,11 @@ void CheckEssentialConfig(const S3Params& params) {
 
     if (s3ext_segnum <= 0) {
         S3_CHECK_OR_DIE(false, S3ConfigError, "\"FATAL: segment info is invalid\"", "segment");
+    }
+
+    string newline = params.getGpcheckcloud_newline();
+    if (newline.compare("\n") && newline.compare("\r\n") && newline.compare("\r")) {
+        S3_CHECK_OR_DIE(false, S3ConfigError, "\"FATAL: gpcheckcloud_newline is invalid\"\"",
+                        "gpcheckcloud_newline");
     }
 }

--- a/gpAux/extensions/gpcloud/src/s3restful_service.cpp
+++ b/gpAux/extensions/gpcloud/src/s3restful_service.cpp
@@ -60,7 +60,8 @@ static size_t RESTfulServiceAbortFuncCallback(char *ptr, size_t size, size_t nme
 }
 
 // curl's headers write function callback.
-static size_t RESTfulServiceHeadersWriteFuncCallback(char *ptr, size_t size, size_t nmemb, void *userp) {
+static size_t RESTfulServiceHeadersWriteFuncCallback(char *ptr, size_t size, size_t nmemb,
+                                                     void *userp) {
     if (S3QueryIsAbortInProgress()) {
         return 0;
     }

--- a/gpAux/extensions/gpcloud/src/s3utils.cpp
+++ b/gpAux/extensions/gpcloud/src/s3utils.cpp
@@ -86,7 +86,7 @@ bool sha256hmac_hex(const char *str, char out_hash_hex[65], const char *secret, 
 size_t find_Nth(const string &str,  // where to work
                 unsigned N,         // N'th occurrence
                 const string &find  // what to 'find'
-                ) {
+) {
     if (0 == N) {
         return string::npos;
     }

--- a/gpAux/extensions/gpcloud/test/data/s3test.conf
+++ b/gpAux/extensions/gpcloud/test/data/s3test.conf
@@ -76,3 +76,13 @@ accessid = "accessid_test"
 secret = "secret_test"
 accessid = "accessid_test"
 proxy = "https://127.0.0.1:8080"
+
+[gpcheckcloud_newline]
+secret = "secret_test"
+accessid = "accessid_test"
+gpcheckcloud_newline = "\r\n"
+
+[gpcheckcloud_newline_error]
+secret = "secret_test"
+accessid = "accessid_test"
+gpcheckcloud_newline = "a"

--- a/gpAux/extensions/gpcloud/test/s3conf_test.cpp
+++ b/gpAux/extensions/gpcloud/test/s3conf_test.cpp
@@ -101,3 +101,15 @@ TEST(Config, Proxy) {
     S3Params params = InitConfig("s3://abc/a config=data/s3test.conf section=proxy");
     EXPECT_EQ("https://127.0.0.1:8080", params.getProxy());
 }
+
+TEST(Config, Gpcheckcloud_eol) {
+    S3Params params = InitConfig("s3://abc/a config=data/s3test.conf section=default");
+    EXPECT_EQ("\n", params.getGpcheckcloud_newline());
+
+    params = InitConfig("s3://abc/a config=data/s3test.conf section=gpcheckcloud_newline");
+    EXPECT_EQ("\r\n", params.getGpcheckcloud_newline());
+
+    EXPECT_THROW(
+        InitConfig("s3://abc/a config=data/s3test.conf section=gpcheckcloud_newline_error"),
+        S3ConfigError);
+}


### PR DESCRIPTION
gpcheckcloud will append new line to file who misses it
,so that the ending line won't concatenated with the
first line of next file.

Signed-off-by: Xiaoran Wang <xiwang@pivotal.io>