### PR TITLE
pxf: Use autoconf for resolving library dependency

### DIFF
--- a/configure
+++ b/configure
@@ -3541,7 +3541,8 @@ if test "${enable_pxf+set}" = set; then :
   enableval=$enable_pxf;
   case $enableval in
     yes)
-      :
+      $as_echo "#define with_libcurl \"yes\"" >>confdefs.h
+
       ;;
     no)
       :
@@ -7951,6 +7952,10 @@ fi
 
 
 
+
+if test "$with_libcurl" = "no" && test "$enable_pxf" = "yes"; then
+  as_fn_error $? "libcurl is required by PXF" "$LINENO" 5
+fi
 
 #
 # libapr. Used for gpfdist and gpperfmon

--- a/configure.in
+++ b/configure.in
@@ -223,7 +223,8 @@ AC_SUBST(enable_gpfdist)
 # pxf
 #
 PGAC_ARG_BOOL(enable, pxf, no,
-             [  --enable-pxf            build with pxf])
+             [  --enable-pxf            build with pxf],
+			 [AC_DEFINE([with_libcurl], "yes")])
 AC_SUBST(enable_pxf)
 
 #
@@ -1031,6 +1032,10 @@ AC_SUBST(with_rt)
 PGAC_ARG_BOOL(with, libcurl, yes,
               [  --without-libcurl       do not use libcurl])
 AC_SUBST(with_libcurl)
+
+if test "$with_libcurl" = "no" && test "$enable_pxf" = "yes"; then
+  AC_MSG_ERROR([libcurl is required by PXF])
+fi
 
 #
 # libapr. Used for gpfdist and gpperfmon

--- a/gpAux/extensions/pxf/Makefile
+++ b/gpAux/extensions/pxf/Makefile
@@ -13,8 +13,6 @@ else
 	include $(top_srcdir)/contrib/contrib-global.mk
 endif
 
-CURL_DIR = /usr/local/opt/curl
-
 SHLIB_LINK += -lcurl
 
 unittest-check:
@@ -22,26 +20,6 @@ unittest-check:
 
 unittest-clean:
 	$(MAKE) -C test clean
-
-install: copy-curl
-
-# for Dev env on MacOS copy updated curl to gpdb install location
-copy-curl:
-    ifeq ($(PORTNAME), darwin)
-        ifeq "$(wildcard $(CURL_DIR))" ""
-			$(error System curl incompatible. Please run "brew install curl")
-        endif
-		cp -rf $(CURL_DIR)/lib/lib* ${libdir}
-		(cd ${libdir} && rm -rf libcurl.dylib && ln -s libcurl.4.dylib libcurl.dylib)
-    endif
-
-uninstall: remove-curl
-
-# for Dev env on MacOS remove updated curl from gpdb install location
-remove-curl:
-    ifeq ($(PORTNAME), darwin)
-		rm -rf ${libdir}/libcurl*
-    endif
 
 clean: unittest-clean
 


### PR DESCRIPTION
Leverage the core autoconf scaffolding for resolving the dependency on libcurl. Enabling PXF in autoconf now forces libcurl to be found and the version check has been updated to handle both versions. Anyone with a too old version in PATH will have to use `--with-libraries` to point to a newer one as per any other library, we clearly don't want to risk linking against two different versions of libcurl.

This does imply that `--without-libcurl` doesn't work with `--enable-pxf`, but there is no way around that. What we can do is to replace `--without-libcurl` with what that option really means: `--without-email-notifications`, question is if anyone has ever built with curl disabled?

This fixes #3168 