### PR TITLE
gpdbrestore will no longer analyze schemas not included in schema-include option

### DIFF
--- a/gpMgmt/bin/gppylib/operations/restore.py
+++ b/gpMgmt/bin/gppylib/operations/restore.py
@@ -374,9 +374,9 @@ class RestoreDatabase(Operation):
                 update_ao_statistics(self.context, self.context.restore_tables, self.context.restore_schemas, restore_all=restore_all)
 
         if not self.context.metadata_only:
-            if (not self.context.no_analyze) and len(self.context.restore_tables) == 0:
+            if (not self.context.no_analyze) and len(self.context.restore_tables) == 0 and len(self.context.restore_schemas) == 0:
                 self._analyze(self.context)
-            elif (not self.context.no_analyze) and len(self.context.restore_tables) > 0:
+            elif (not self.context.no_analyze) and (len(self.context.restore_tables) > 0 or len(self.context.restore_schemas) > 0):
                 self._analyze_restore_tables()
         if self.context.restore_stats:
             self._restore_stats()

--- a/gpMgmt/test/behave/mgmt_utils/backup_and_restore_restores.feature
+++ b/gpMgmt/test/behave/mgmt_utils/backup_and_restore_restores.feature
@@ -935,12 +935,17 @@ Feature: Validate command line arguments
     Scenario: 96 gpdbrestore runs ANALYZE on restored table only
         Given the old timestamps are read from json
         And the backup test is initialized with database "bkdb96"
+        And schema "testschema" exists in "bkdb96"
         And there is a "heap" table "public.heap_table" in "bkdb96" with data
+        And there is a "heap" table "testschema.heap_table" in "bkdb96" with data
         When the user runs gpdbrestore without -e with the stored timestamp and options "-T public.ao_index_table"
         Then gpdbrestore should return a return code of 0
         And verify that there is a "ao" table "public.ao_index_table" in "bkdb96" with data
         And verify that the restored table "public.ao_index_table" in database "bkdb96" is analyzed
         And verify that the table "public.heap_table" in database "bkdb96" is not analyzed
+        When the user runs gpdbrestore without -e with the stored timestamp and options "-S public"
+        And verify that the restored table "public.heap_table" in database "bkdb96" is analyzed
+        And verify that the table "testschema.heap_table" in database "bkdb96" is not analyzed
 
     @nbupartIII
     @ddpartII


### PR DESCRIPTION
Previously, gpdbrestore would analyze all schemas in the database during
a schema-only restore. Now, only those schemas that were restored will
be analyzed.

Signed-off-by: Chris Hajas <chajas@pivotal.io>