### PR TITLE
Backport to 5X_STABLE: gp_era: change usage from md5 to sha256

### DIFF
--- a/gpMgmt/bin/gppylib/gp_era.py
+++ b/gpMgmt/bin/gppylib/gp_era.py
@@ -109,7 +109,7 @@ class GpEraFile:
         """
         Write a new era based on the specified values
         """
-        m = hashlib.md5()
+        m = hashlib.sha256()
         m.update(str(host))
         m.update(str(port))
         m.update(str(self.datadir))

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gp_era.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gp_era.py
@@ -1,0 +1,34 @@
+import os
+import shutil
+import tempfile
+
+from gp_unittest import *
+from mock import *
+
+from gppylib.gp_era import GpEraFile
+
+class GpEraTestCase(GpTestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        os.mkdir(os.path.join(self.tmpdir, 'pg_log'))
+
+        self.apply_patches([
+            patch('os.path.exists'),
+        ])
+        self.mock_path_exists = self.get_mock_from_apply_patch('exists')
+
+        self.subject = GpEraFile(self.tmpdir)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+        super(GpEraTestCase, self).tearDown()
+
+    def test_creates_new_era_file_successfully(self):
+        self.mock_path_exists.return_value = False
+        self.subject.new_era(host='host', port='port', time='time')
+        gp_era_path = os.path.join(self.tmpdir, 'pg_log', 'gp_era')
+        self.assertTrue(os.path.isfile(gp_era_path))
+
+
+if __name__ == '__main__':
+    run_tests()


### PR DESCRIPTION
This PR is for bakcporting https://github.com/greenplum-db/gpdb/commit/c13a9177ccb243620e449e0a35efb509e3ec6e37 to 5X_STABLE.

Original commit message below.

There is a bug with python 2.7 where you can't use hashlib.md5() with a
system that has fips mode on. python 2.7 will segfault if you run the
following
`python -c "import ssl; import hashlib; m = hashlib.md5(); m.update('abc');"`

Use sha256 instead as a workaround of the python 2.7 md5 issue.

gp_era saves the hashed value into a file which gets read when creating
a new mirror. It's mainly used to see if any segments gets out of
synced with the new era file.