### PR TITLE
Reinstate Ninja in README

### DIFF
--- a/README.linux.md
+++ b/README.linux.md
@@ -1,5 +1,6 @@
-1. ORCA require [CMake](https://cmake.org), make sure you have it installed.
-   Installation instructions vary, please check the CMake website.
+1. ORCA requires [CMake](https://cmake.org) and
+   [Ninja](https://ninja-build.org/), make sure you have them installed.
+   Installation instructions vary, please check the CMake and Ninja websites.
    
 1. Install needed python modules
 

--- a/README.macOS.bash
+++ b/README.macOS.bash
@@ -10,6 +10,7 @@ fi
 brew install bash-completion
 brew install conan
 brew install cmake # gporca
+brew install ninja # gporca
 brew install libyaml   # enables `--enable-mapreduce`
 brew install libevent # gpfdist
 brew install apr # gpperfmon

--- a/README.md
+++ b/README.md
@@ -51,9 +51,8 @@ building, see the README in the
     git clone https://github.com/greenplum-db/gporca
     mkdir gporca/build
     cd gporca/build
-    cmake ../
-    make
-    make install
+    cmake -GNinja ..
+    ninja install
     cd ../..
     ```
     **Note**: Get the latest ORCA `git pull --ff-only` if you see an error message like below:


### PR DESCRIPTION
On a typical 2-year-old iMac, a no-op `make` takes at least 5 seconds,
whereas a `ninja` build takes 40 milliseconds. It's an obvious trade off
if you value fast feedback.

Saying ORCA doesn't require Ninja is like saying you don't need a car in
the Bay Area. It's technically not false, but you would just be going
out of your way to experience the pain. And it's understandable that
there are scenarios where not having to install one extra package is
more preferable than having 125 times faster builds, but that audience
is almost always way savvier than the intended audience of our README.

This reverts commit ba7f52e811078681a6bc42fb95fe80aa67987b60.

Signed-off-by: Jesse Zhang <sbjesse@gmail.com>