### PR TITLE
Cherry-pick upstream commits f3f0f370 (full) and 0dec322 (partial)

### DIFF
--- a/src/backend/cdb/cdbsubselect.c
+++ b/src/backend/cdb/cdbsubselect.c
@@ -631,7 +631,7 @@ convert_EXPR_to_join(PlannerInfo *root, OpExpr *opexp)
 
 /* check if NOT IN conversion to antijoin is possible */
 static bool
-safe_to_convert_NOTIN(SubLink *sublink)
+safe_to_convert_NOTIN(SubLink *sublink, Relids available_rels)
 {
 	Query	   *subselect = (Query *) sublink->subselect;
 	Relids		left_varnos;
@@ -657,6 +657,12 @@ safe_to_convert_NOTIN(SubLink *sublink)
 	/* Left-hand expressions must contain some Vars of the current */
 	left_varnos = pull_varnos(sublink->testexpr);
 	if (bms_is_empty(left_varnos))
+		return false;
+
+	/*
+	 * However, it can't refer to anything outside available_rels.
+	 */
+	if (!bms_is_subset(left_varnos, available_rels))
 		return false;
 
 	/* Correlation - subquery referencing Vars of parent not handled */
@@ -1268,12 +1274,13 @@ is_targetlist_nullable(Query *subq)
  * in a top-level where clause (or through a series of inner joins).
  */
 JoinExpr*
-convert_IN_to_antijoin(PlannerInfo *root, SubLink *sublink)
+convert_IN_to_antijoin(PlannerInfo *root, SubLink *sublink,
+						Relids available_rels)
 {
 	Query	   *parse = root->parse;
 	Query	   *subselect = (Query *) sublink->subselect;
 
-	if (safe_to_convert_NOTIN(sublink))
+	if (safe_to_convert_NOTIN(sublink, available_rels))
 	{
 		Assert(list_length(parse->jointree->fromlist) == 1);
 

--- a/src/backend/cdb/cdbsubselect.c
+++ b/src/backend/cdb/cdbsubselect.c
@@ -36,8 +36,6 @@ static Node *make_lasj_quals(PlannerInfo *root, SubLink *sublink, int subquery_i
 
 static Node *add_null_match_clause(Node *clause);
 
-static Node *not_null_inner_vars(Node *clause);
-
 typedef struct NonNullableVarsContext
 {
 	Query	   *query;			/* Query in question. */

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -2046,7 +2046,6 @@ _copyJoinExpr(JoinExpr *from)
 	COPY_NODE_FIELD(quals);
 	COPY_NODE_FIELD(alias);
 	COPY_SCALAR_FIELD(rtindex);
-	COPY_NODE_FIELD(subqfromlist);          /*CDB*/
 
 	return newnode;
 }

--- a/src/backend/nodes/nodeFuncs.c
+++ b/src/backend/nodes/nodeFuncs.c
@@ -1577,7 +1577,6 @@ expression_tree_mutator(Node *node,
 				FLATCOPY(newnode, join, JoinExpr);
 				MUTATE(newnode->larg, join->larg, Node *);
 				MUTATE(newnode->rarg, join->rarg, Node *);
-				MUTATE(newnode->subqfromlist, join->subqfromlist, List *);  /*CDB*/
 				MUTATE(newnode->quals, join->quals, Node *);
 				/* We do not mutate alias or using by default */
 				return (Node *) newnode;

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -1676,8 +1676,6 @@ _outJoinExpr(StringInfo str, JoinExpr *node)
 	WRITE_BOOL_FIELD(isNatural);
 	WRITE_NODE_FIELD(larg);
 	WRITE_NODE_FIELD(rarg);
-    if (node->subqfromlist)                     /*CDB*/
-        WRITE_NODE_FIELD(subqfromlist);         /*CDB*/
 	WRITE_NODE_FIELD_AS(usingClause, using);    /*CDB*/
 	WRITE_NODE_FIELD(quals);
 	WRITE_NODE_FIELD(alias);

--- a/src/backend/optimizer/path/costsize.c
+++ b/src/backend/optimizer/path/costsize.c
@@ -3219,9 +3219,12 @@ set_rel_width(PlannerInfo *root, RelOptInfo *rel)
 			int32		item_width;
 			
 			Assert(var->varno == rel->relid);
-			Assert(var->varattno >= rel->min_attr);
-			Assert(var->varattno <= rel->max_attr);
-			
+			/*
+			 * Postgres Upstream asserts for var->varattno >= rel->min_attr and
+			 * var->varattno <= rel->max_attr are not valid in GPDB since GPDB
+			 * also handles cases for virtual columns.
+			 */
+
 			/* Virtual column? */
 			if (var->varattno <= FirstLowInvalidHeapAttributeNumber)
 			{

--- a/src/backend/optimizer/path/joinrels.c
+++ b/src/backend/optimizer/path/joinrels.c
@@ -33,7 +33,6 @@ cdb_add_subquery_join_paths(PlannerInfo    *root,
 					        RelOptInfo     *rel1,
 					        RelOptInfo     *rel2,
 					        JoinType        jointype,
-					        JoinType        swapjointype,
 					        List           *restrictlist,
 							SpecialJoinInfo *sjinfo);
 static bool has_join_restriction(PlannerInfo *root, RelOptInfo *rel);
@@ -641,16 +640,38 @@ make_join_rel(PlannerInfo *root, RelOptInfo *rel1, RelOptInfo *rel2)
         (rel2->dedup_info && rel2->dedup_info->later_dedup_pathlist))
 	{
 		/* Reversed jointype is useful when rel2 becomes outer and rel1 is inner. */
-		JoinType    swapjointype;
+		JoinType jointype = sjinfo->jointype;
 
-		if (sjinfo->jointype == JOIN_LEFT)
-			swapjointype = JOIN_RIGHT;
-		else if (sjinfo->jointype == JOIN_RIGHT)
-			swapjointype = JOIN_LEFT;
-		else
-			swapjointype = sjinfo->jointype;
-		cdb_add_subquery_join_paths(root, joinrel, rel1, rel2,
-									sjinfo->jointype, swapjointype, restrictlist, sjinfo);
+		switch(jointype)
+		{
+			case JOIN_ANTI:
+			case JOIN_LASJ_NOTIN:
+				cdb_add_subquery_join_paths(root, joinrel, rel1, rel2, jointype,
+											restrictlist, sjinfo);
+				break;
+			case JOIN_LEFT:
+				cdb_add_subquery_join_paths(root, joinrel, rel1, rel2, jointype,
+											restrictlist, sjinfo);
+				cdb_add_subquery_join_paths(root, joinrel, rel2, rel1, JOIN_RIGHT,
+											restrictlist, sjinfo);
+				break;
+			case JOIN_RIGHT:
+				cdb_add_subquery_join_paths(root, joinrel, rel1, rel2, jointype,
+											restrictlist, sjinfo);
+				cdb_add_subquery_join_paths(root, joinrel, rel2, rel1, JOIN_LEFT,
+											restrictlist, sjinfo);
+				break;
+			case JOIN_INNER:
+			case JOIN_FULL:
+				cdb_add_subquery_join_paths(root, joinrel, rel1, rel2, jointype,
+											restrictlist, sjinfo);
+				cdb_add_subquery_join_paths(root, joinrel, rel2, rel1, jointype,
+											restrictlist, sjinfo);
+				break;
+			default:
+				elog(ERROR, "unrecognized join type: %d", (int) sjinfo->jointype);
+				break;
+		}
 		bms_free(joinrelids);
 		return joinrel;
 	}
@@ -741,96 +762,107 @@ cdb_add_subquery_join_paths(PlannerInfo    *root,
 					        RelOptInfo     *rel1,
 					        RelOptInfo     *rel2,
 					        JoinType        jointype,
-					        JoinType        swapjointype,
 					        List           *restrictlist,
-							SpecialJoinInfo *sjinfo
-							)
+							SpecialJoinInfo *sjinfo)
 {
-    CdbRelDedupInfo    *dedup1 = rel1->dedup_info;
-    CdbRelDedupInfo    *dedup2 = rel2->dedup_info;
-    List               *save1_pathlist;
-    Path               *save1_cheapest_startup;
-    Path               *save1_cheapest_total;
-    List               *save2_pathlist;
-    Path               *save2_cheapest_startup;
-    Path               *save2_cheapest_total;
+	CdbRelDedupInfo    *dedup1 = rel1->dedup_info;
+	CdbRelDedupInfo    *dedup2 = rel2->dedup_info;
+	List               *save1_pathlist;
+	Path               *save1_cheapest_startup;
+	Path               *save1_cheapest_total;
+	List               *save2_pathlist;
+	Path               *save2_cheapest_startup;
+	Path               *save2_cheapest_total;
+	bool				consider_rel1_later_path, consider_rel2_later_path;
 
-    /* If only one input's later_dedup_pathlist is nonempty, let it be rel2. */
-    if (!dedup2 ||
-        !dedup2->later_dedup_pathlist)
-    {
-        CdbSwap(RelOptInfo*, rel1, rel2);
-        CdbSwap(CdbRelDedupInfo*, dedup1, dedup2);
-        CdbSwap(JoinType, jointype, swapjointype);
-        Assert(dedup2 && dedup2->later_dedup_pathlist);
-    }
+	consider_rel1_later_path = dedup1 && dedup1->later_dedup_pathlist;
+	consider_rel2_later_path = dedup2 && dedup2->later_dedup_pathlist;
 
-    /* Consider joins between rel1's main paths and rel2's main paths. */
-    if (rel1->pathlist && rel2->pathlist)
-    {
-        add_paths_to_joinrel(root, joinrel, rel1, rel2, jointype, sjinfo, restrictlist);
-        add_paths_to_joinrel(root, joinrel, rel2, rel1, swapjointype, sjinfo, restrictlist);
-    }
+	/* Consider joins between rel1's main paths and rel2's main paths always */
+	if (rel1->pathlist && rel2->pathlist)
+	{
+		add_paths_to_joinrel(root, joinrel, rel1, rel2, jointype, sjinfo, restrictlist);
+	}
 
-    /* Save rel2's main pathlist ptrs. */
-    save2_pathlist = rel2->pathlist;
-    save2_cheapest_startup = rel2->cheapest_startup_path;
-    save2_cheapest_total = rel2->cheapest_total_path;
+	/* Consider joins between rel2's main paths and rel1's later_dedup paths. */
+	if (rel2->pathlist && consider_rel1_later_path)
+	{
+		/* Save rel1's main pathlist ptrs. */
+		save1_pathlist = rel1->pathlist;
+		save1_cheapest_startup = rel1->cheapest_startup_path;
+		save1_cheapest_total = rel1->cheapest_total_path;
 
-    /* Swap in rel2's later_dedup_pathlist. */
-    rel2->pathlist = dedup2->later_dedup_pathlist;
-    rel2->cheapest_startup_path = dedup2->cheapest_startup_path;
-    rel2->cheapest_total_path = dedup2->cheapest_total_path;
+		/* Swap in rel1's later_dedup_pathlist. */
+		rel1->pathlist = dedup1->later_dedup_pathlist;
+		rel1->cheapest_startup_path = dedup1->cheapest_startup_path;
+		rel1->cheapest_total_path = dedup1->cheapest_total_path;
 
-    /* Consider joins between rel1's main paths and rel2's later_dedup paths. */
-    if (rel1->pathlist)
-    {
-        add_paths_to_joinrel(root, joinrel, rel1, rel2, jointype, sjinfo, restrictlist);
-        add_paths_to_joinrel(root, joinrel, rel2, rel1, swapjointype, sjinfo, restrictlist);
-    }
+		add_paths_to_joinrel(root, joinrel, rel1, rel2, jointype, sjinfo, restrictlist);
 
-    /* Finished if rel1 doesn't have later_dedup paths. */
-    if (!dedup1 ||
-        !dedup1->later_dedup_pathlist)
-    {
-        /* Restore rel2's main pathlist ptrs. */
-        rel2->pathlist = save2_pathlist;
-        rel2->cheapest_startup_path = save2_cheapest_startup;
-        rel2->cheapest_total_path = save2_cheapest_total;
-        return;
-    }
+		/* Restore rel1's main pathlist ptrs. */
+		rel1->pathlist = save1_pathlist;
+		rel1->cheapest_startup_path = save1_cheapest_startup;
+		rel1->cheapest_total_path = save1_cheapest_total;
+	}
 
-    /* Save rel1's main pathlist ptrs. */
-    save1_pathlist = rel1->pathlist;
-    save1_cheapest_startup = rel1->cheapest_startup_path;
-    save1_cheapest_total = rel1->cheapest_total_path;
+	/* Consider joins between rel1's main paths and rel2's later_dedup paths. */
+	if (rel1->pathlist && consider_rel2_later_path)
+	{
+		/* Save rel2's main pathlist ptrs. */
+		save2_pathlist = rel2->pathlist;
+		save2_cheapest_startup = rel2->cheapest_startup_path;
+		save2_cheapest_total = rel2->cheapest_total_path;
 
-    /* Swap in rel1's later_dedup_pathlist. */
-    rel1->pathlist = dedup1->later_dedup_pathlist;
-    rel1->cheapest_startup_path = dedup1->cheapest_startup_path;
-    rel1->cheapest_total_path = dedup1->cheapest_total_path;
+		/* Swap in rel2's later_dedup_pathlist. */
+		rel2->pathlist = dedup2->later_dedup_pathlist;
+		rel2->cheapest_startup_path = dedup2->cheapest_startup_path;
+		rel2->cheapest_total_path = dedup2->cheapest_total_path;
 
-    /* Consider joins between later_dedup paths of both rel1 and rel2. */
-    add_paths_to_joinrel(root, joinrel, rel1, rel2, jointype, sjinfo, restrictlist);
-    add_paths_to_joinrel(root, joinrel, rel2, rel1, swapjointype, sjinfo, restrictlist);
+		add_paths_to_joinrel(root, joinrel, rel1, rel2, jointype, sjinfo, restrictlist);
 
-    /* Restore rel2's main pathlist ptrs. */
-    rel2->pathlist = save2_pathlist;
-    rel2->cheapest_startup_path = save2_cheapest_startup;
-    rel2->cheapest_total_path = save2_cheapest_total;
+		/* Restore rel2's main pathlist ptrs. */
+		rel2->pathlist = save2_pathlist;
+		rel2->cheapest_startup_path = save2_cheapest_startup;
+		rel2->cheapest_total_path = save2_cheapest_total;
+	}
 
-    /* Consider joins between rel1's later_dedup paths and rel2's main paths. */
-    if (rel2->pathlist)
-    {
-        add_paths_to_joinrel(root, joinrel, rel1, rel2, jointype, sjinfo, restrictlist);
-        add_paths_to_joinrel(root, joinrel, rel2, rel1, swapjointype, sjinfo, restrictlist);
-    }
+	/* Consider joins between later_dedup paths of both rel1 and rel2. */
+	if (consider_rel1_later_path && consider_rel2_later_path)
+	{
+		/* Save rel1's main pathlist ptrs. */
+		save1_pathlist = rel1->pathlist;
+		save1_cheapest_startup = rel1->cheapest_startup_path;
+		save1_cheapest_total = rel1->cheapest_total_path;
 
-    /* Restore rel1's main pathlist ptrs. */
-    rel1->pathlist = save1_pathlist;
-    rel1->cheapest_startup_path = save1_cheapest_startup;
-    rel1->cheapest_total_path = save1_cheapest_total;
-}                               /* cdb_add_subquery_join_paths */
+		/* Swap in rel1's later_dedup_pathlist. */
+		rel1->pathlist = dedup1->later_dedup_pathlist;
+		rel1->cheapest_startup_path = dedup1->cheapest_startup_path;
+		rel1->cheapest_total_path = dedup1->cheapest_total_path;
+
+		/* Save rel2's main pathlist ptrs. */
+		save2_pathlist = rel2->pathlist;
+		save2_cheapest_startup = rel2->cheapest_startup_path;
+		save2_cheapest_total = rel2->cheapest_total_path;
+
+		/* Swap in rel2's later_dedup_pathlist. */
+		rel2->pathlist = dedup2->later_dedup_pathlist;
+		rel2->cheapest_startup_path = dedup2->cheapest_startup_path;
+		rel2->cheapest_total_path = dedup2->cheapest_total_path;
+
+		/* Consider joins between later_dedup paths of both rel1 and rel2. */
+		add_paths_to_joinrel(root, joinrel, rel1, rel2, jointype, sjinfo, restrictlist);
+
+		/* Restore rel1's main pathlist ptrs. */
+		rel1->pathlist = save1_pathlist;
+		rel1->cheapest_startup_path = save1_cheapest_startup;
+		rel1->cheapest_total_path = save1_cheapest_total;
+
+		/* Restore rel2's main pathlist ptrs. */
+		rel2->pathlist = save2_pathlist;
+		rel2->cheapest_startup_path = save2_cheapest_startup;
+		rel2->cheapest_total_path = save2_cheapest_total;
+	}
+}
 
 
 /*

--- a/src/backend/optimizer/plan/initsplan.c
+++ b/src/backend/optimizer/plan/initsplan.c
@@ -118,13 +118,9 @@ add_base_rels_to_query(PlannerInfo *root, Node *jtnode)
 	else if (IsA(jtnode, JoinExpr))
 	{
 		JoinExpr   *j = (JoinExpr *) jtnode;
-		ListCell   *l;
 
 		add_base_rels_to_query(root, j->larg);
 		add_base_rels_to_query(root, j->rarg);
-
-        foreach(l, j->subqfromlist)
-			add_base_rels_to_query(root, lfirst(l));
 	}
 	else
 		elog(ERROR, "unrecognized node type: %d",
@@ -431,7 +427,6 @@ deconstruct_recurse(PlannerInfo *root, Node *jtnode, bool below_outer_join,
 		List	   *leftjoinlist,
 				   *rightjoinlist;
 		SpecialJoinInfo *sjinfo;
-        ListCell   *cell;
 		ListCell   *l;
 		List *child_postponed_quals = NIL;
 		/*
@@ -488,6 +483,7 @@ deconstruct_recurse(PlannerInfo *root, Node *jtnode, bool below_outer_join,
 													&child_postponed_quals);
 				*qualscope = bms_union(leftids, rightids);
 				*inner_join_rels = bms_union(left_inners, right_inners);
+				*inner_join_rels = bms_add_members(*inner_join_rels, rightids);
 				/* Semi join adds no restrictions for quals */
 				nonnullable_rels = NULL;
  				break;
@@ -513,46 +509,6 @@ deconstruct_recurse(PlannerInfo *root, Node *jtnode, bool below_outer_join,
 				leftjoinlist = rightjoinlist = NIL;
 				break;
 		}
-
-        /*
-         * CDB: If subqueries from the JOIN...ON search condition were
-         * flattened, 'subqfromlist' is a list of jointree nodes to be
-         * included in the cross product with larg and rarg.
-         *
-         * For left or right joins, the flattened subquery tables must be
-         * associated with the null-augmented side (right side of LEFT JOIN).
-         * For inner joins either side is ok.  For full outer joins the
-         * subqfromlist is not used at present.
-         */
-        foreach(cell, j->subqfromlist)
-        {
-            List       *sub_joinlist;
-		    Relids		sub_qualscope = NULL;
-            Relids      sub_inners;
-
-		    sub_joinlist = deconstruct_recurse(root, lfirst(cell),
-                                               below_outer_join ||
-                                                    (j->jointype != JOIN_INNER),
-										       &sub_qualscope,
-                                               &sub_inners,
-											   &child_postponed_quals
-                                               );
-		    rightids = bms_add_members(rightids, sub_qualscope);
-            *qualscope = bms_add_members(*qualscope, sub_qualscope);
-            *inner_join_rels = bms_add_members(*inner_join_rels, rightids);
-            switch (j->jointype)
-            {
-                case JOIN_INNER:
-                case JOIN_LEFT:
-                    rightjoinlist = list_concat(rightjoinlist, sub_joinlist);
-                    break;
-                case JOIN_RIGHT:
-                    leftjoinlist = list_concat(leftjoinlist, sub_joinlist);
-                    break;
-                default:
-                    Assert(0);
-            }
-        }
 
 		/*
 		 * For an OJ, form the SpecialJoinInfo now, because we need the OJ's

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -912,13 +912,9 @@ preprocess_qual_conditions(PlannerInfo *root, Node *jtnode)
 	else if (IsA(jtnode, JoinExpr))
 	{
 		JoinExpr   *j = (JoinExpr *) jtnode;
-		ListCell   *l;
 
 		preprocess_qual_conditions(root, j->larg);
 		preprocess_qual_conditions(root, j->rarg);
-
-		foreach(l, j->subqfromlist)
-			preprocess_qual_conditions(root, lfirst(l));
 
 		j->quals = preprocess_expression(root, j->quals, EXPRKIND_QUAL);
 	}

--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -1128,6 +1128,11 @@ SS_process_ctes(PlannerInfo *root)
  * (Notionally, we replace the SubLink with a constant TRUE, then elide the
  * redundant constant from the qual.)
  *
+ * On success, the caller is also responsible for recursively applying
+ * pull_up_sublinks processing to the rarg and quals of the returned JoinExpr.
+ * (On failure, there is no need to do anything, since pull_up_sublinks will
+ * be applied when we recursively plan the sub-select.)
+ *
  * Side effects of a successful conversion include adding the SubLink's
  * subselect to the query's rangetable, so that it can be referenced in
  * the JoinExpr's rarg.

--- a/src/backend/optimizer/plan/transform.c
+++ b/src/backend/optimizer/plan/transform.c
@@ -143,7 +143,6 @@ static Node* normalize_query_jointree(Node *node)
 					join->rarg = rarg;
 					join->quals = NULL; /* Cross product */
 					join->rtindex = 0;
-					join->subqfromlist = NIL;
 					join->usingClause = NIL;
 					result = (Node *) join;
 				}

--- a/src/backend/optimizer/prep/prepjointree.c
+++ b/src/backend/optimizer/prep/prepjointree.c
@@ -64,9 +64,6 @@ static Node *pull_up_sublinks_jointree_recurse(PlannerInfo *root, Node *jtnode,
 								  Relids *relids);
 static Node *pull_up_sublinks_qual_recurse(PlannerInfo *root, Node *node,
 							  Relids available_rels, Node **jtlink);
-static void pull_up_fromlist_subqueries(PlannerInfo    *root,
-                                        List          **inout_fromlist,
-				                        bool            below_outer_join);
 static Node *pull_up_simple_subquery(PlannerInfo *root, Node *jtnode,
 						RangeTblEntry *rte,
 						JoinExpr *lowest_outer_join,
@@ -605,55 +602,12 @@ pull_up_subqueries(PlannerInfo *root, Node *jtnode,
 					 (int) j->jointype);
 				break;
 		}
-
-        /*
-         * CDB: If subqueries from the JOIN...ON search condition were
-         * flattened, 'subqfromlist' is a list of RangeTblRef nodes to be
-         * included in the cross product with larg and rarg.  Try to pull up
-         * the referenced subqueries.  For outer joins, let below_outer_join
-         * be true, because the subquery tables belong in the null-augmented
-         * side of the JOIN (right side of LEFT JOIN).
-         */
-		ListCell   *l;
-        if (j->subqfromlist)
-			foreach(l, j->subqfromlist)
-			{
-				if(lowest_outer_join != NULL)
-					lfirst(l) = pull_up_subqueries(root, lfirst(l), lowest_outer_join, NULL);
-				else if(j->jointype != JOIN_INNER)
-					lfirst(l) = pull_up_subqueries(root, lfirst(l), j, NULL);
-				else
-					lfirst(l) = pull_up_subqueries(root, lfirst(l), NULL, NULL);
-			}
 	}
 	else
 		elog(ERROR, "unrecognized node type: %d",
 			 (int) nodeTag(jtnode));
 	return jtnode;
 }
-
-
-/*
- * GPDB_84_MERGE_FIXME: Check if can be removed
- * pull_up_fromlist_subqueries
- *		Attempt to pull up subqueries in a List of jointree nodes.
- */
-static void
-pull_up_fromlist_subqueries(PlannerInfo    *root,
-                            List          **inout_fromlist,
-				            bool            below_outer_join)
-{
-    ListCell   *l;
-
-    foreach(l, *inout_fromlist)
-    {
-        Node   *oldkid = (Node *)lfirst(l);
-        Node   *newkid = pull_up_subqueries(root, oldkid,
-											below_outer_join, false);
-
-        lfirst(l) = newkid;
-    }
-}                               /* pull_up_fromlist_subqueries */
 
 
 /*
@@ -1239,9 +1193,6 @@ replace_vars_in_jointree(Node *jtnode, pullup_replace_vars_context *context,
 		replace_vars_in_jointree(j->larg, context, lowest_outer_join);
 		replace_vars_in_jointree(j->rarg, context, lowest_outer_join);
 
-		foreach(l, j->subqfromlist)
-			replace_vars_in_jointree(lfirst(l), context, lowest_outer_join);
-
 		j->quals = pullup_replace_vars(j->quals, context);
 
 		/*
@@ -1551,15 +1502,6 @@ reduce_outer_joins_pass1(Node *jtnode)
 										 sub_state->relids);
 		result->contains_outer |= sub_state->contains_outer;
 		result->sub_states = lappend(result->sub_states, sub_state);
-
-		foreach(l, j->subqfromlist)
-		{
-			sub_state = reduce_outer_joins_pass1(lfirst(l));
-			result->relids = bms_add_members(result->relids,
-											 sub_state->relids);
-			result->contains_outer |= sub_state->contains_outer;
-			result->sub_states = lappend(result->sub_states, sub_state);
-		}
 	}
 	else
 		elog(ERROR, "unrecognized node type: %d",
@@ -1585,9 +1527,6 @@ reduce_outer_joins_pass2(Node *jtnode,
 						 List *nonnullable_vars,
 						 List *forced_null_vars)
 {
-	ListCell   *l;
-	ListCell   *s;
-
 	/*
 	 * pass 2 should never descend as far as an empty subnode or base rel,
 	 * because it's only called on subtrees marked as contains_outer.
@@ -1638,7 +1577,6 @@ reduce_outer_joins_pass2(Node *jtnode,
 		JoinType	jointype = j->jointype;
 		reduce_outer_joins_state *left_state = linitial(state->sub_states);
 		reduce_outer_joins_state *right_state = lsecond(state->sub_states);
-		reduce_outer_joins_state *sub_state;
 		List       *local_nonnullable_vars = NIL;
 		bool        computed_local_nonnullable_vars = false;
 
@@ -1844,25 +1782,6 @@ reduce_outer_joins_pass2(Node *jtnode,
 										 pass_forced_null_vars);
 			}
 
-            /*
-             * CDB: Simplify outer joins pulled up from flattened subqueries.
-             * For a left or right outer join, the subqfromlist items belong
-             * to the null-augmented side; so we pass local_nonnullable down
-             * regardless of the jointype.  (For FULL JOIN, subqfromlist is
-             * always empty.)
-             */
-            s = lnext(lnext(list_head(state->sub_states)));
-            foreach(l, j->subqfromlist)
-            {
-                sub_state = (reduce_outer_joins_state *)lfirst(s);
-                if (sub_state->contains_outer)
-				    reduce_outer_joins_pass2(lfirst(l), sub_state, root,
-											 pass_nonnullable_rels,
-											 pass_nonnullable_vars,
-											 pass_forced_null_vars);
-                s = lnext(s);
-            }
-
 			bms_free(local_nonnullable_rels);
 		}
 	}
@@ -2015,10 +1934,6 @@ get_relids_in_jointree(Node *jtnode, bool include_joins)
 
 		if (include_joins && j->rtindex)
 			result = bms_add_member(result, j->rtindex);
-
-		/* GPDB_84_MERGE_FIXME: Not present upstream; is this really needed? */
-		foreach(l, j->subqfromlist)
-			result = bms_join(result, get_relids_in_jointree((Node *)lfirst(l), include_joins));
 	}
 	else
 		elog(ERROR, "unrecognized node type: %d",
@@ -2083,13 +1998,6 @@ find_jointree_node_for_rel(Node *jtnode, int relid)
 		jtnode = find_jointree_node_for_rel(j->rarg, relid);
 		if (jtnode)
 			return jtnode;
-
-		foreach(l, j->subqfromlist)
-		{
-			jtnode = find_jointree_node_for_rel(lfirst(l), relid);
-			if (jtnode)
-				return jtnode;
-		}
 	}
 	else
 		elog(ERROR, "unrecognized node type: %d",

--- a/src/backend/optimizer/prep/prepjointree.c
+++ b/src/backend/optimizer/prep/prepjointree.c
@@ -297,9 +297,7 @@ pull_up_sublinks_qual_recurse(PlannerInfo *root, Node *node,
 				j->rarg = pull_up_sublinks_jointree_recurse(root,
 															j->rarg,
 															&child_rels);
-				/* Pulled-up ANY/EXISTS quals can use those rels too */
-				child_rels = bms_add_members(child_rels, available_rels);
-				/* ... and any inserted joins get stacked onto j->rarg */
+				/* Any inserted joins get stacked onto j->rarg */
 				j->quals = pull_up_sublinks_qual_recurse(root,
 														 j->quals,
 														 child_rels,
@@ -322,9 +320,7 @@ pull_up_sublinks_qual_recurse(PlannerInfo *root, Node *node,
 				j->rarg = pull_up_sublinks_jointree_recurse(root,
 															j->rarg,
 															&child_rels);
-				/* Pulled-up ANY/EXISTS quals can use those rels too */
-				child_rels = bms_add_members(child_rels, available_rels);
-				/* ... and any inserted joins get stacked onto j->rarg */
+				/* Any inserted joins get stacked onto j->rarg */
 				j->quals = pull_up_sublinks_qual_recurse(root,
 														 j->quals,
 														 child_rels,
@@ -348,9 +344,7 @@ pull_up_sublinks_qual_recurse(PlannerInfo *root, Node *node,
 				j->rarg = pull_up_sublinks_jointree_recurse(root,
 															j->rarg,
 															&child_rels);
-				/* Pulled-up ANY/EXISTS quals can use those rels too */
-				child_rels = bms_add_members(child_rels, available_rels);
-				/* ... and any inserted joins get stacked onto j->rarg */
+				/* Any inserted joins get stacked onto j->rarg */
 				j->quals = pull_up_sublinks_qual_recurse(root,
 														 j->quals,
 														 child_rels,
@@ -386,9 +380,7 @@ pull_up_sublinks_qual_recurse(PlannerInfo *root, Node *node,
 					j->rarg = pull_up_sublinks_jointree_recurse(root,
 																j->rarg,
 																&child_rels);
-					/* Pulled-up ANY/EXISTS quals can use those rels too */
-					child_rels = bms_add_members(child_rels, available_rels);
-					/* ... and any inserted joins get stacked onto j->rarg */
+					/* Any inserted joins get stacked onto j->rarg */
 					j->quals = pull_up_sublinks_qual_recurse(root,
 															 j->quals,
 															 child_rels,

--- a/src/backend/optimizer/prep/prepjointree.c
+++ b/src/backend/optimizer/prep/prepjointree.c
@@ -336,8 +336,7 @@ pull_up_sublinks_qual_recurse(PlannerInfo *root, Node *node,
 		}
 		else if (sublink->subLinkType == ALL_SUBLINK)
 		{
-			/* GPDB_84_MERGE_FIXME: Should convert_IN_to_antijoin() also use available_rels ? */
-			j = convert_IN_to_antijoin(root, sublink);
+			j = convert_IN_to_antijoin(root, sublink, available_rels);
 			if (j)
 			{
 				/* Yes; recursively process what we pulled up */
@@ -474,7 +473,6 @@ pull_up_sublinks_qual_recurse(PlannerInfo *root, Node *node,
 
 			if (IsA(rarg, SubLink))
 			{
-				/* GPDB_84_MERGE_FIXME: Should convert_EXPR_to_join() also use available_rels ? */
 				j = convert_EXPR_to_join(root, opexp);
 				if (j)
 				{

--- a/src/backend/optimizer/util/walkers.c
+++ b/src/backend/optimizer/util/walkers.c
@@ -398,8 +398,6 @@ expression_tree_walker(Node *node,
 					return true;
 				if (walker(join->rarg, context))
 					return true;
-				if (walker(join->subqfromlist, context))    /*CDB*/
-					return true;                            /*CDB*/
 				if (walker(join->quals, context))
 					return true;
 

--- a/src/backend/rewrite/rewriteManip.c
+++ b/src/backend/rewrite/rewriteManip.c
@@ -672,6 +672,7 @@ IncrementVarSublevelsUp(Node *node, int delta_sublevels_up,
 
 	context.delta_sublevels_up = delta_sublevels_up;
 	context.min_sublevels_up = min_sublevels_up;
+	context.ignore_min_sublevels_up = false;
 
 	/*
 	 * Must be prepared to start with a Query or a bare expression tree; if
@@ -715,6 +716,7 @@ IncrementVarSublevelsUp_rtable(List *rtable, int delta_sublevels_up,
 
 	context.delta_sublevels_up = delta_sublevels_up;
 	context.min_sublevels_up = min_sublevels_up;
+	context.ignore_min_sublevels_up = false;
 
 	range_table_walker(rtable,
 					   IncrementVarSublevelsUp_walker,

--- a/src/include/cdb/cdbsubselect.h
+++ b/src/include/cdb/cdbsubselect.h
@@ -18,6 +18,6 @@ extern void cdbsubselect_drop_orderby(Query *subselect);
 extern void cdbsubselect_drop_distinct(Query *subselect);
 extern bool has_correlation_in_funcexpr_rte(List *rtable);
 extern bool is_simple_subquery(PlannerInfo *root, Query *subquery);
-extern JoinExpr *convert_IN_to_antijoin(PlannerInfo *root, SubLink *sublink);
+extern JoinExpr *convert_IN_to_antijoin(PlannerInfo *root, SubLink *sublink, Relids available_rels);
 
 #endif   /* CDBSUBSELECT_H */

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -1294,10 +1294,6 @@ typedef struct RangeTblRef
  * be created that refer to the outputs of the join.  The planner sometimes
  * generates JoinExprs internally; these can have rtindex = 0 if there are
  * no join alias variables referencing such joins.
- *
- * CDB: When the planner flattens sublinks in the JOIN...ON clause, it may
- * attach a list of RangeTblRef nodes ('subqfromlist') which are to be
- * included in the cross product along with 'larg' and 'rarg'.
  *----------
  */
 typedef struct JoinExpr
@@ -1311,8 +1307,6 @@ typedef struct JoinExpr
 	Node	   *quals;			/* qualifiers on join, if any */
 	Alias	   *alias;			/* user-written alias clause, if any */
 	int			rtindex;		/* RT index assigned for join, or 0 */
-    List       *subqfromlist;   /* CDB: List of join subtrees resulting from
-                                 *  flattening of sublinks */
 } JoinExpr;
 
 /*----------

--- a/src/test/regress/expected/notin.out
+++ b/src/test/regress/expected/notin.out
@@ -1006,22 +1006,21 @@ select c1 from t1 where not exists (select c2 from t2 where c2 = c1);
 
 --
 --q39
--- GPDB_90_MERGE_FIXME: Pull up nested sublinks.
 --
 explain select c1 from t1 where not exists (select c2 from t2 where c2 not in (select c3 from t3) and c2 = c1);
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=4.13..7.30 rows=4 width=4)
-   ->  Hash Anti Join  (cost=4.13..7.30 rows=2 width=4)
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=4.42..7.59 rows=4 width=4)
+   ->  Hash Anti Join  (cost=4.42..7.59 rows=2 width=4)
          Hash Cond: t1.c1 = t2.c2
          ->  Seq Scan on t1  (cost=0.00..3.10 rows=4 width=4)
-         ->  Hash  (cost=4.10..4.10 rows=1 width=4)
-               ->  Seq Scan on t2  (cost=2.04..4.10 rows=1 width=4)
-                     Filter: NOT ((hashed subplan))
-                     SubPlan 1
-                       ->  Materialize  (cost=2.03..2.06 rows=1 width=4)
-                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.03 rows=1 width=4)
-                                   ->  Seq Scan on t3  (cost=0.00..2.03 rows=1 width=4)
+         ->  Hash  (cost=4.38..4.38 rows=2 width=4)
+               ->  Hash Left Anti Semi Join (Not-In)  (cost=2.26..4.38 rows=2 width=4)
+                     Hash Cond: t2.c2 = t3.c3
+                     ->  Seq Scan on t2  (cost=0.00..2.05 rows=2 width=4)
+                     ->  Hash  (cost=2.15..2.15 rows=3 width=4)
+                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.15 rows=3 width=4)
+                                 ->  Seq Scan on t3  (cost=0.00..2.03 rows=1 width=4)
  Settings:  optimizer=off
  Optimizer status: legacy query optimizer
 (15 rows)
@@ -1041,30 +1040,31 @@ select c1 from t1 where not exists (select c2 from t2 where c2 not in (select c3
 
 --
 --q40
--- GPDB_90_MERGE_FIXME: Pull up nested sublinks.
 -- GPDB_90_MERGE_FIXME: We should be able to push down join filter on param $0 to a result node on top of LASJ (Not in)
 --
 explain select c1 from t1 where not exists (select c2 from t2 where exists (select c3 from t3) and c2 <>all (select c3 from t3) and c2 = c1);
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=7.86..11.09 rows=10 width=4)
-   ->  Hash Anti Join  (cost=7.86..11.09 rows=4 width=4)
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=5.12..8.35 rows=10 width=4)
+   ->  Hash Anti Join  (cost=5.12..8.35 rows=4 width=4)
          Hash Cond: t1.c1 = t2.c2
          Join Filter: $0
          InitPlan 1 (returns $0)  (slice4)
-           ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..2.03 rows=3 width=0)
-                 ->  Seq Scan on t3  (cost=0.00..2.03 rows=1 width=0)
+           ->  Limit  (cost=0.00..0.70 rows=1 width=0)
+                 ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..0.70 rows=1 width=0)
+                       ->  Limit  (cost=0.00..0.68 rows=1 width=0)
+                             ->  Seq Scan on t3  (cost=0.00..2.03 rows=1 width=0)
          ->  Seq Scan on t1  (cost=0.00..3.10 rows=4 width=4)
-         ->  Hash  (cost=7.16..7.16 rows=1 width=4)
-               ->  Seq Scan on t2  (cost=0.00..7.16 rows=1 width=4)
-                     Filter: (subplan)
-                     SubPlan 2
-                       ->  Materialize  (cost=2.03..2.06 rows=1 width=4)
-                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.03 rows=1 width=4)
-                                   ->  Seq Scan on t3  (cost=0.00..2.03 rows=1 width=4)
+         ->  Hash  (cost=4.38..4.38 rows=2 width=4)
+               ->  Hash Left Anti Semi Join (Not-In)  (cost=2.26..4.38 rows=2 width=4)
+                     Hash Cond: t2.c2 = notin.t3.c3
+                     ->  Seq Scan on t2  (cost=0.00..2.05 rows=2 width=4)
+                     ->  Hash  (cost=2.15..2.15 rows=3 width=4)
+                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.15 rows=3 width=4)
+                                 ->  Seq Scan on t3  (cost=0.00..2.03 rows=1 width=4)
  Settings:  optimizer=off
  Optimizer status: legacy query optimizer
-(17 rows)
+(19 rows)
 
 select c1 from t1 where not exists (select c2 from t2 where exists (select c3 from t3) and c2 <>all (select c3 from t3) and c2 = c1);
  c1 

--- a/src/test/regress/expected/notin_optimizer.out
+++ b/src/test/regress/expected/notin_optimizer.out
@@ -1067,7 +1067,6 @@ select c1 from t1 where not exists (select c2 from t2 where c2 = c1);
 
 --
 --q39
--- GPDB_90_MERGE_FIXME: Pull up nested sublinks.
 --
 explain select c1 from t1 where not exists (select c2 from t2 where c2 not in (select c3 from t3) and c2 = c1);
                                                   QUERY PLAN                                                   
@@ -1102,7 +1101,6 @@ select c1 from t1 where not exists (select c2 from t2 where c2 not in (select c3
 
 --
 --q40
--- GPDB_90_MERGE_FIXME: Pull up nested sublinks.
 -- GPDB_90_MERGE_FIXME: We should be able to push down join filter on param $0 to a result node on top of LASJ (Not in)
 --
 explain select c1 from t1 where not exists (select c2 from t2 where exists (select c3 from t3) and c2 <>all (select c3 from t3) and c2 = c1);

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -587,42 +587,32 @@ select A.i, B.i, C.j from A, B, C where A.j = any ( select C.j from C where not 
 (10 rows)
 
 explain select A.i, B.i, C.j from A, B, C where A.j = any (select C.j from C where C.j = A.j and not exists (select sum(B.i) from B where C.i = B.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
-                                                                           QUERY PLAN                                                                            
------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Limit  (cost=100.41..100.63 rows=10 width=12)
-   ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=100.41..100.63 rows=10 width=12)
-         Merge Key: a.i, qp_correlated_query.b.i, qp_correlated_query.c.j
-         ->  Limit  (cost=100.41..100.43 rows=4 width=12)
-               ->  Sort  (cost=100.41..100.74 rows=45 width=12)
-                     Sort Key: a.i, qp_correlated_query.b.i, qp_correlated_query.c.j
-                     ->  Nested Loop  (cost=6.42..97.49 rows=45 width=12)
-                           ->  Nested Loop  (cost=3.10..86.07 rows=8 width=8)
-                                 ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..81.62 rows=3 width=4)
-                                       ->  Seq Scan on a  (cost=0.00..81.52 rows=1 width=4)
-                                             Filter: (subplan)
-                                             SubPlan 2
-                                               ->  Result  (cost=31.38..31.39 rows=1 width=4)
-                                                     Filter: qp_correlated_query.c.j = $1 AND NOT ((subplan))
-                                                     ->  Materialize  (cost=31.38..31.39 rows=1 width=4)
-                                                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..31.38 rows=1 width=4)
-                                                                 ->  Seq Scan on c  (cost=0.00..31.38 rows=1 width=4)
-                                                     SubPlan 1
-                                                       ->  Aggregate  (cost=3.13..3.14 rows=1 width=8)
-                                                             ->  Result  (cost=0.00..3.08 rows=1 width=4)
-                                                                   One-Time Filter: $0 <> 10
-                                                                   ->  Result  (cost=3.08..3.09 rows=1 width=4)
-                                                                         Filter: $0 = qp_correlated_query.b.i
-                                                                         ->  Materialize  (cost=3.08..3.09 rows=1 width=4)
-                                                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.08 rows=1 width=4)
-                                                                                     ->  Seq Scan on b  (cost=0.00..3.08 rows=1 width=4)
-                                 ->  Materialize  (cost=3.10..3.19 rows=3 width=4)
-                                       ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
-                           ->  Materialize  (cost=3.32..3.50 rows=6 width=4)
-                                 ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..3.30 rows=6 width=4)
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=21.64..21.86 rows=10 width=12)
+   ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=21.64..21.86 rows=10 width=12)
+         Merge Key: a.i, b.i, qp_correlated_query.c.j
+         ->  Limit  (cost=21.64..21.66 rows=4 width=12)
+               ->  Sort  (cost=21.64..21.97 rows=45 width=12)
+                     Sort Key: a.i, b.i, qp_correlated_query.c.j
+                     ->  Nested Loop  (cost=6.56..18.72 rows=45 width=12)
+                           ->  Nested Loop  (cost=3.08..7.14 rows=5 width=8)
+                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.01..3.18 rows=3 width=4)
+                                       ->  Seq Scan on a  (cost=0.01..3.08 rows=1 width=4)
+                                             Filter: (hashed SubPlan 1)
+                                             SubPlan 1
+                                               ->  Materialize  (cost=0.01..0.02 rows=1 width=0)
+                                                     ->  Broadcast Motion 1:3  (slice1; segments: 1)  (cost=0.00..0.01 rows=1 width=0)
+                                                           ->  Result  (cost=0.00..0.01 rows=1 width=0)
+                                                                 One-Time Filter: false
+                                 ->  Materialize  (cost=3.07..3.13 rows=2 width=4)
                                        ->  Seq Scan on b  (cost=0.00..3.06 rows=2 width=4)
+                           ->  Materialize  (cost=3.48..3.75 rows=9 width=4)
+                                 ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..3.45 rows=9 width=4)
+                                       ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
  Settings:  optimizer=off
  Optimizer status: legacy query optimizer
-(33 rows)
+(23 rows)
 
 select A.i, B.i, C.j from A, B, C where A.j = any (select C.j from C where C.j = A.j and not exists (select sum(B.i) from B where C.i = B.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
  i | i | j 
@@ -781,41 +771,32 @@ select A.i, B.i, C.j from A, B, C where A.j < all ( select C.j from C where not 
 (0 rows)
 
 explain select A.i, B.i, C.j from A, B, C where A.j = all (select C.j from C where C.j = A.j and not exists (select sum(B.i) from B where C.i = B.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
-                                                                           QUERY PLAN                                                                            
------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Limit  (cost=100.41..100.63 rows=10 width=12)
-   ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=100.41..100.63 rows=10 width=12)
-         Merge Key: a.i, qp_correlated_query.b.i, qp_correlated_query.c.j
-         ->  Limit  (cost=100.41..100.43 rows=4 width=12)
-               ->  Sort  (cost=100.41..100.74 rows=45 width=12)
-                     Sort Key: a.i, qp_correlated_query.b.i, qp_correlated_query.c.j
-                     ->  Nested Loop  (cost=6.42..97.49 rows=45 width=12)
-                           ->  Nested Loop  (cost=3.10..86.07 rows=8 width=8)
-                                 ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..81.62 rows=3 width=4)
-                                       ->  Seq Scan on a  (cost=0.00..81.52 rows=1 width=4)
-                                             Filter: (subplan)
-                                             SubPlan 2
-                                               ->  Result  (cost=31.38..31.39 rows=1 width=4)
-                                                     Filter: qp_correlated_query.c.j = $1 AND NOT ((subplan))
-                                                     ->  Materialize  (cost=31.38..31.39 rows=1 width=4)
-                                                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..31.38 rows=1 width=4)
-                                                                 ->  Seq Scan on c  (cost=0.00..31.38 rows=1 width=4)
-                                                     SubPlan 1
-                                                       ->  Aggregate  (cost=3.13..3.14 rows=1 width=8)
-                                                             ->  Result  (cost=0.00..3.08 rows=1 width=4)
-                                                                   One-Time Filter: $0 <> 10
-                                                                   ->  Result  (cost=3.08..3.09 rows=1 width=4)
-                                                                         Filter: $0 = qp_correlated_query.b.i
-                                                                         ->  Materialize  (cost=3.08..3.09 rows=1 width=4)
-                                                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.08 rows=1 width=4)
-                                                                                     ->  Seq Scan on b  (cost=0.00..3.08 rows=1 width=4)
-                                 ->  Materialize  (cost=3.10..3.19 rows=3 width=4)
-                                       ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
-                           ->  Materialize  (cost=3.32..3.50 rows=6 width=4)
-                                 ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..3.30 rows=6 width=4)
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=21.65..21.88 rows=10 width=12)
+   ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=21.65..21.88 rows=10 width=12)
+         Merge Key: a.i, b.i, qp_correlated_query.c.j
+         ->  Limit  (cost=21.65..21.68 rows=4 width=12)
+               ->  Sort  (cost=21.65..21.99 rows=45 width=12)
+                     Sort Key: a.i, b.i, qp_correlated_query.c.j
+                     ->  Nested Loop  (cost=6.54..18.74 rows=45 width=12)
+                           ->  Nested Loop  (cost=3.07..7.16 rows=5 width=8)
+                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..3.19 rows=3 width=4)
+                                       ->  Seq Scan on a  (cost=0.00..3.09 rows=1 width=4)
+                                             Filter: (SubPlan 1)
+                                             SubPlan 1
+                                               ->  Materialize  (cost=0.01..0.02 rows=1 width=0)
+                                                     ->  Broadcast Motion 1:3  (slice1; segments: 1)  (cost=0.00..0.01 rows=1 width=0)
+                                                           ->  Result  (cost=0.00..0.01 rows=1 width=0)
+                                                                 One-Time Filter: false
+                                 ->  Materialize  (cost=3.07..3.13 rows=2 width=4)
                                        ->  Seq Scan on b  (cost=0.00..3.06 rows=2 width=4)
+                           ->  Materialize  (cost=3.48..3.75 rows=9 width=4)
+                                 ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..3.45 rows=9 width=4)
+                                       ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
+ Settings:  optimizer=off
  Optimizer status: legacy query optimizer
-(32 rows)
+(23 rows)
 
 select A.i, B.i, C.j from A, B, C where A.j = all (select C.j from C where C.j = A.j and not exists (select sum(B.i) from B where C.i = B.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
  i | i  | j  
@@ -1053,25 +1034,20 @@ select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j
 (0 rows)
 
 explain select C.j from C where not exists (select max(B.i) from B  where C.i = B.i having max(B.i) is not null) order by C.j;
-                                                     QUERY PLAN                                                      
----------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=31.43..31.45 rows=5 width=4)
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=6.33..6.33 rows=4 width=4)
    Merge Key: c.j
-   ->  Sort  (cost=31.43..31.45 rows=2 width=4)
+   ->  Sort  (cost=6.33..6.33 rows=2 width=4)
          Sort Key: c.j
-         ->  Seq Scan on c  (cost=0.00..31.39 rows=2 width=4)
-               Filter: NOT ((subplan))
-               SubPlan 1
-                 ->  Aggregate  (cost=3.13..3.14 rows=1 width=4)
-                       Filter: max(b.i) IS NOT NULL
-                       ->  Result  (cost=3.08..3.09 rows=1 width=4)
-                             Filter: $0 = b.i
-                             ->  Materialize  (cost=3.08..3.09 rows=1 width=4)
-                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.08 rows=1 width=4)
-                                         ->  Seq Scan on b  (cost=0.00..3.08 rows=1 width=4)
+         ->  Hash Anti Join  (cost=3.14..6.30 rows=2 width=4)
+               Hash Cond: c.i = b.i
+               ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=8)
+               ->  Hash  (cost=3.06..3.06 rows=2 width=4)
+                     ->  Seq Scan on b  (cost=0.00..3.06 rows=2 width=4)
  Settings:  optimizer=off
  Optimizer status: legacy query optimizer
-(16 rows)
+(11 rows)
 
 select C.j from C where not exists (select max(B.i) from B  where C.i = B.i having max(B.i) is not null) order by C.j;
  j  
@@ -1083,25 +1059,16 @@ select C.j from C where not exists (select max(B.i) from B  where C.i = B.i havi
 (4 rows)
 
 explain select C.j from C where not exists (select max(B.i) from B  where C.i = B.i offset 1000) order by C.j;
-                                                        QUERY PLAN                                                         
----------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=31.39..31.40 rows=5 width=4)
-   Merge Key: c.j
-   ->  Sort  (cost=31.39..31.40 rows=2 width=4)
-         Sort Key: c.j
-         ->  Seq Scan on c  (cost=0.00..31.34 rows=2 width=4)
-               Filter: NOT ((subplan))
-               SubPlan 1
-                 ->  Limit  (cost=3.14..3.14 rows=1 width=4)
-                       ->  Aggregate  (cost=3.13..3.14 rows=1 width=4)
-                             ->  Result  (cost=3.08..3.09 rows=1 width=4)
-                                   Filter: $0 = b.i
-                                   ->  Materialize  (cost=3.08..3.09 rows=1 width=4)
-                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.08 rows=1 width=4)
-                                               ->  Seq Scan on b  (cost=0.00..3.08 rows=1 width=4)
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=3.23..3.26 rows=9 width=4)
+   Merge Key: j
+   ->  Sort  (cost=3.23..3.26 rows=3 width=4)
+         Sort Key: j
+         ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
  Settings:  optimizer=off
  Optimizer status: legacy query optimizer
-(16 rows)
+(7 rows)
 
 select C.j from C where not exists (select max(B.i) from B  where C.i = B.i offset 1000) order by C.j;
   j  
@@ -1117,27 +1084,21 @@ select C.j from C where not exists (select max(B.i) from B  where C.i = B.i offs
  889
 (9 rows)
 
--- GPDB_90_MERGE_FIXME: Pull up nested sublinks.
 explain select C.j from C where not exists (select rank() over (order by B.i) from B  where C.i = B.i) order by C.j;
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=6.39..6.39 rows=4 width=4)
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=6.33..6.33 rows=4 width=4)
    Merge Key: c.j
-   ->  Sort  (cost=6.39..6.39 rows=2 width=4)
+   ->  Sort  (cost=6.33..6.33 rows=2 width=4)
          Sort Key: c.j
-         ->  Seq Scan on c  (cost=0.00..26.35 rows=2 width=4)
-               Filter: NOT ((subplan))
-               SubPlan 1
-                 ->  Window  (cost=0.00..3.10 rows=1 width=4)
-                       Order By: b.i
-                       ->  Result  (cost=3.08..3.09 rows=1 width=4)
-                             Filter: $0 = b.i
-                             ->  Materialize  (cost=3.08..3.09 rows=1 width=4)
-                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.08 rows=1 width=4)
-                                         ->  Seq Scan on b  (cost=0.00..3.08 rows=1 width=4)
+         ->  Hash Anti Join  (cost=3.14..6.30 rows=2 width=4)
+               Hash Cond: c.i = b.i
+               ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=8)
+               ->  Hash  (cost=3.06..3.06 rows=2 width=4)
+                     ->  Seq Scan on b  (cost=0.00..3.06 rows=2 width=4)
  Settings:  optimizer=off
  Optimizer status: legacy query optimizer
-(13 rows)
+(11 rows)
 
 select C.j from C where not exists (select rank() over (order by B.i) from B  where C.i = B.i) order by C.j;
  j  

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -1148,6 +1148,64 @@ select C.j from C where not exists (select rank() over (order by B.i) from B  wh
  62
 (4 rows)
 
+explain select A.i from A where not exists (select B.i from B where B.i in (select C.i from C) and B.i = A.i);
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=6.44..9.55 rows=4 width=4)
+   ->  Hash Anti Join  (cost=6.44..9.55 rows=2 width=4)
+         Hash Cond: a.i = b.i
+         ->  Seq Scan on a  (cost=0.00..3.05 rows=2 width=4)
+         ->  Hash  (cost=6.36..6.36 rows=3 width=4)
+               ->  Hash Semi Join  (cost=3.20..6.36 rows=3 width=4)
+                     Hash Cond: b.i = c.i
+                     ->  Seq Scan on b  (cost=0.00..3.06 rows=2 width=4)
+                     ->  Hash  (cost=3.09..3.09 rows=3 width=4)
+                           ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(12 rows)
+
+select A.i from A where not exists (select B.i from B where B.i in (select C.i from C) and B.i = A.i);
+ i  
+----
+ 99
+ 78
+ 19
+(3 rows)
+
+explain select * from B where not exists (select * from C,A where C.i in (select C.i from C where C.i = A.i and C.i != 10) AND B.i = C.i);
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=9.58..12.69 rows=4 width=8)
+   ->  Hash Anti Join  (cost=9.58..12.69 rows=2 width=8)
+         Hash Cond: b.i = qp_correlated_query.c.i
+         ->  Seq Scan on b  (cost=0.00..3.06 rows=2 width=8)
+         ->  Hash  (cost=9.52..9.52 rows=2 width=4)
+               ->  Hash Semi Join  (cost=6.34..9.52 rows=2 width=4)
+                     Hash Cond: qp_correlated_query.c.i = qp_correlated_query.c.i
+                     ->  Seq Scan on c  (cost=0.00..3.11 rows=3 width=4)
+                           Filter: i <> 10
+                     ->  Hash  (cost=6.29..6.29 rows=2 width=8)
+                           ->  Hash Join  (cost=3.11..6.29 rows=2 width=8)
+                                 Hash Cond: qp_correlated_query.c.i = a.i
+                                 ->  Seq Scan on c  (cost=0.00..3.11 rows=3 width=4)
+                                       Filter: i <> 10
+                                 ->  Hash  (cost=3.06..3.06 rows=2 width=4)
+                                       ->  Seq Scan on a  (cost=0.00..3.06 rows=2 width=4)
+                                             Filter: i <> 10
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(19 rows)
+
+select * from B where not exists (select * from C,A where C.i in (select C.i from C where C.i = A.i and C.i != 10) AND B.i = C.i);
+ i  | j  
+----+----
+ 88 |  1
+ -1 | 62
+  2 |  7
+ 32 |  5
+(4 rows)
+
 -- ----------------------------------------------------------------------
 -- Test:  Correlated Subquery: CSQ using DML (Heap) 
 -- ----------------------------------------------------------------------

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -1206,6 +1206,40 @@ select * from B where not exists (select * from C,A where C.i in (select C.i fro
  32 |  5
 (4 rows)
 
+explain select * from A where A.i in (select C.j from C,B where B.i in (select i from C));
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)  (cost=7.81..11.26 rows=39 width=8)
+   ->  Hash Join  (cost=7.81..11.26 rows=13 width=8)
+         Hash Cond: a.i = qp_correlated_query.c.j
+         ->  Seq Scan on a  (cost=0.00..3.05 rows=2 width=8)
+         ->  Hash  (cost=7.72..7.72 rows=3 width=4)
+               ->  HashAggregate  (cost=7.65..7.72 rows=3 width=4)
+                     Group By: qp_correlated_query.c.j
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=3.14..7.50 rows=20 width=4)
+                           Hash Key: qp_correlated_query.c.j
+                           ->  Nested Loop  (cost=3.14..6.33 rows=20 width=4)
+                                 ->  Broadcast Motion 1:3  (slice2; segments: 1)  (cost=3.14..3.16 rows=1 width=0)
+                                       ->  Limit  (cost=3.14..3.14 rows=1 width=0)
+                                             ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=3.14..3.16 rows=1 width=0)
+                                                   ->  Limit  (cost=3.14..3.14 rows=1 width=0)
+                                                         ->  Hash Semi Join  (cost=3.14..6.33 rows=3 width=0)
+                                                               Hash Cond: qp_correlated_query.c.i = b.i
+                                                               ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
+                                                               ->  Hash  (cost=3.06..3.06 rows=2 width=4)
+                                                                     ->  Seq Scan on b  (cost=0.00..3.06 rows=2 width=4)
+                                 ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(22 rows)
+
+select * from A where A.i in (select C.j from C,B where B.i in (select i from C));
+ i | j 
+---+---
+ 1 | 1
+ 1 | 1
+(2 rows)
+
 -- ----------------------------------------------------------------------
 -- Test:  Correlated Subquery: CSQ using DML (Heap) 
 -- ----------------------------------------------------------------------

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -1277,6 +1277,46 @@ select * from B where not exists (select * from C,A where C.i in (select C.i fro
   2 |  7
 (4 rows)
 
+explain select * from A where A.i in (select C.j from C,B where B.i in (select i from C));
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1324895.30 rows=5 width=8)
+   ->  Hash Join  (cost=0.00..1324895.30 rows=2 width=8)
+         Hash Cond: a.i = qp_correlated_query.c.j
+         ->  Table Scan on a  (cost=0.00..431.00 rows=2 width=8)
+         ->  Hash  (cost=1324464.30..1324464.30 rows=3 width=4)
+               ->  GroupAggregate  (cost=0.00..1324464.30 rows=3 width=4)
+                     Group By: qp_correlated_query.c.j
+                     ->  Sort  (cost=0.00..1324464.30 rows=3 width=4)
+                           Sort Key: qp_correlated_query.c.j
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1324464.30 rows=3 width=4)
+                                 Hash Key: qp_correlated_query.c.j
+                                 ->  GroupAggregate  (cost=0.00..1324464.30 rows=3 width=4)
+                                       Group By: qp_correlated_query.c.j
+                                       ->  Sort  (cost=0.00..1324464.30 rows=18 width=4)
+                                             Sort Key: qp_correlated_query.c.j
+                                             ->  Hash Semi Join  (cost=0.00..1324464.30 rows=18 width=4)
+                                                   Hash Cond: b.i = qp_correlated_query.c.i
+                                                   ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1324033.29 rows=18 width=8)
+                                                         Hash Key: b.i
+                                                         ->  Nested Loop  (cost=0.00..1324033.29 rows=18 width=8)
+                                                               Join Filter: true
+                                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
+                                                                     ->  Table Scan on b  (cost=0.00..431.00 rows=2 width=4)
+                                                               ->  Table Scan on c  (cost=0.00..431.00 rows=3 width=4)
+                                                   ->  Hash  (cost=431.00..431.00 rows=3 width=4)
+                                                         ->  Table Scan on c  (cost=0.00..431.00 rows=3 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.40.3
+(28 rows)
+
+select * from A where A.i in (select C.j from C,B where B.i in (select i from C));
+ i | j 
+---+---
+ 1 | 1
+ 1 | 1
+(2 rows)
+
 -- ----------------------------------------------------------------------
 -- Test:  Correlated Subquery: CSQ using DML (Heap) 
 -- ----------------------------------------------------------------------

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -1217,6 +1217,66 @@ select C.j from C where not exists (select rank() over (order by B.i) from B  wh
  62
 (4 rows)
 
+explain select A.i from A where not exists (select B.i from B where B.i in (select C.i from C) and B.i = A.i);
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=2 width=4)
+   ->  Hash Anti Join  (cost=0.00..1293.00 rows=1 width=4)
+         Hash Cond: a.i = b.i
+         ->  Table Scan on a  (cost=0.00..431.00 rows=2 width=4)
+         ->  Hash  (cost=862.00..862.00 rows=2 width=4)
+               ->  Hash Semi Join  (cost=0.00..862.00 rows=2 width=4)
+                     Hash Cond: b.i = c.i
+                     ->  Table Scan on b  (cost=0.00..431.00 rows=2 width=4)
+                     ->  Hash  (cost=431.00..431.00 rows=3 width=4)
+                           ->  Table Scan on c  (cost=0.00..431.00 rows=3 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.40.3
+(12 rows)
+
+select A.i from A where not exists (select B.i from B where B.i in (select C.i from C) and B.i = A.i);
+ i  
+----
+ 19
+ 99
+ 78
+(3 rows)
+
+explain select * from B where not exists (select * from C,A where C.i in (select C.i from C where C.i = A.i and C.i != 10) AND B.i = C.i);
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1324895.10 rows=1 width=8)
+   ->  Hash Anti Join  (cost=0.00..1324895.10 rows=1 width=8)
+         Hash Cond: b.i = qp_correlated_query.c.i
+         ->  Table Scan on b  (cost=0.00..431.00 rows=2 width=8)
+         ->  Hash  (cost=1324464.10..1324464.10 rows=13 width=4)
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1324464.10 rows=13 width=4)
+                     Hash Key: qp_correlated_query.c.i
+                     ->  Hash Semi Join  (cost=0.00..1324464.10 rows=13 width=4)
+                           Hash Cond: a.i = qp_correlated_query.c.i AND qp_correlated_query.c.i = qp_correlated_query.c.i
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1324033.09 rows=15 width=8)
+                                 Hash Key: a.i
+                                 ->  Nested Loop  (cost=0.00..1324033.09 rows=15 width=8)
+                                       Join Filter: true
+                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=5 width=4)
+                                             ->  Table Scan on a  (cost=0.00..431.00 rows=2 width=4)
+                                       ->  Table Scan on c  (cost=0.00..431.00 rows=3 width=4)
+                           ->  Hash  (cost=431.00..431.00 rows=3 width=4)
+                                 ->  Table Scan on c  (cost=0.00..431.00 rows=3 width=4)
+                                       Filter: i <> 10
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.40.3
+(21 rows)
+
+select * from B where not exists (select * from C,A where C.i in (select C.i from C where C.i = A.i and C.i != 10) AND B.i = C.i);
+ i  | j  
+----+----
+ 88 |  1
+ 32 |  5
+ -1 | 62
+  2 |  7
+(4 rows)
+
 -- ----------------------------------------------------------------------
 -- Test:  Correlated Subquery: CSQ using DML (Heap) 
 -- ----------------------------------------------------------------------

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -1183,7 +1183,6 @@ select C.j from C where not exists (select max(B.i) from B  where C.i = B.i offs
  889
 (9 rows)
 
--- GPDB_90_MERGE_FIXME: Pull up nested sublinks.
 explain select C.j from C where not exists (select rank() over (order by B.i) from B  where C.i = B.i) order by C.j;
                                                        QUERY PLAN                                                       
 ------------------------------------------------------------------------------------------------------------------------

--- a/src/test/regress/sql/notin.sql
+++ b/src/test/regress/sql/notin.sql
@@ -344,14 +344,12 @@ select c1 from t1 where not exists (select c2 from t2 where c2 = c1);
 
 --
 --q39
--- GPDB_90_MERGE_FIXME: Pull up nested sublinks.
 --
 explain select c1 from t1 where not exists (select c2 from t2 where c2 not in (select c3 from t3) and c2 = c1);
 select c1 from t1 where not exists (select c2 from t2 where c2 not in (select c3 from t3) and c2 = c1);
 
 --
 --q40
--- GPDB_90_MERGE_FIXME: Pull up nested sublinks.
 -- GPDB_90_MERGE_FIXME: We should be able to push down join filter on param $0 to a result node on top of LASJ (Not in)
 --
 explain select c1 from t1 where not exists (select c2 from t2 where exists (select c3 from t3) and c2 <>all (select c3 from t3) and c2 = c1);

--- a/src/test/regress/sql/qp_correlated_query.sql
+++ b/src/test/regress/sql/qp_correlated_query.sql
@@ -214,7 +214,6 @@ explain select C.j from C where not exists (select max(B.i) from B  where C.i = 
 select C.j from C where not exists (select max(B.i) from B  where C.i = B.i having max(B.i) is not null) order by C.j;
 explain select C.j from C where not exists (select max(B.i) from B  where C.i = B.i offset 1000) order by C.j;
 select C.j from C where not exists (select max(B.i) from B  where C.i = B.i offset 1000) order by C.j;
--- GPDB_90_MERGE_FIXME: Pull up nested sublinks.
 explain select C.j from C where not exists (select rank() over (order by B.i) from B  where C.i = B.i) order by C.j;
 select C.j from C where not exists (select rank() over (order by B.i) from B  where C.i = B.i) order by C.j;
 explain select A.i from A where not exists (select B.i from B where B.i in (select C.i from C) and B.i = A.i);

--- a/src/test/regress/sql/qp_correlated_query.sql
+++ b/src/test/regress/sql/qp_correlated_query.sql
@@ -221,6 +221,8 @@ explain select A.i from A where not exists (select B.i from B where B.i in (sele
 select A.i from A where not exists (select B.i from B where B.i in (select C.i from C) and B.i = A.i);
 explain select * from B where not exists (select * from C,A where C.i in (select C.i from C where C.i = A.i and C.i != 10) AND B.i = C.i);
 select * from B where not exists (select * from C,A where C.i in (select C.i from C where C.i = A.i and C.i != 10) AND B.i = C.i);
+explain select * from A where A.i in (select C.j from C,B where B.i in (select i from C));
+select * from A where A.i in (select C.j from C,B where B.i in (select i from C));
 
 
 -- ----------------------------------------------------------------------

--- a/src/test/regress/sql/qp_correlated_query.sql
+++ b/src/test/regress/sql/qp_correlated_query.sql
@@ -217,6 +217,10 @@ select C.j from C where not exists (select max(B.i) from B  where C.i = B.i offs
 -- GPDB_90_MERGE_FIXME: Pull up nested sublinks.
 explain select C.j from C where not exists (select rank() over (order by B.i) from B  where C.i = B.i) order by C.j;
 select C.j from C where not exists (select rank() over (order by B.i) from B  where C.i = B.i) order by C.j;
+explain select A.i from A where not exists (select B.i from B where B.i in (select C.i from C) and B.i = A.i);
+select A.i from A where not exists (select B.i from B where B.i in (select C.i from C) and B.i = A.i);
+explain select * from B where not exists (select * from C,A where C.i in (select C.i from C where C.i = A.i and C.i != 10) AND B.i = C.i);
+select * from B where not exists (select * from C,A where C.i in (select C.i from C where C.i = A.i and C.i != 10) AND B.i = C.i);
 
 
 -- ----------------------------------------------------------------------


### PR DESCRIPTION
We have tried our best to put corresponding regress test cases and changes with each commit. So looking at this PR commit-by-commit would make it easier to follow.

In summary, these commits re-enable pull-up of nested sublinks without which we were producing sub-optimal plans compared to master. Along the way, we fixed other issues in the merge branch because of regression test failures, cleaned up dead code and removed unnecessarily strict restrictions which we brought in from upstream.

There are also 2 bug-fixes for wrong results in master. They aren't as easy to cherry-pick. So we'll be creating separate PRs for them in master. This concerns:

1. Incorrect commuting of JOIN_ANTI and JOIN_LASJ_NOTIN
2. Incorrect results when running NOT EXISTS subqueries with aggregates and limits.

So overall there are many plan changes for the better!

-Shreedhar & Dhanashree