### PR TITLE
Fix wrong results for NOT-EXISTS sublinks with aggs & LIMIT

### DIFF
--- a/src/backend/rewrite/rewriteManip.c
+++ b/src/backend/rewrite/rewriteManip.c
@@ -776,6 +776,7 @@ IncrementVarSublevelsUp(Node *node, int delta_sublevels_up,
 
 	context.delta_sublevels_up = delta_sublevels_up;
 	context.min_sublevels_up = min_sublevels_up;
+	context.ignore_min_sublevels_up = false;
 
 	/*
 	 * Must be prepared to start with a Query or a bare expression tree; if
@@ -819,6 +820,7 @@ IncrementVarSublevelsUp_rtable(List *rtable, int delta_sublevels_up,
 
 	context.delta_sublevels_up = delta_sublevels_up;
 	context.min_sublevels_up = min_sublevels_up;
+	context.ignore_min_sublevels_up = false;
 
 	range_table_walker(rtable,
 					   IncrementVarSublevelsUp_walker,

--- a/src/include/catalog/pg_operator.h
+++ b/src/include/catalog/pg_operator.h
@@ -157,6 +157,7 @@ DATA(insert OID = 410 ( "="		   PGNSP PGUID b t t	20	20	16 410 411 int8eq eqsel 
 #define Int8EqualOperator 410
 DATA(insert OID = 411 ( "<>"	   PGNSP PGUID b f f	20	20	16 411 410 int8ne neqsel neqjoinsel ));
 DATA(insert OID = 412 ( "<"		   PGNSP PGUID b f f	20	20	16 413 415 int8lt scalarltsel scalarltjoinsel ));
+#define Int8LessOperator	412
 DATA(insert OID = 413 ( ">"		   PGNSP PGUID b f f	20	20	16 412 414 int8gt scalargtsel scalargtjoinsel ));
 DATA(insert OID = 414 ( "<="	   PGNSP PGUID b f f	20	20	16 415 413 int8le scalarltsel scalarltjoinsel ));
 DATA(insert OID = 415 ( ">="	   PGNSP PGUID b f f	20	20	16 414 412 int8ge scalargtsel scalargtjoinsel ));

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -1050,6 +1050,81 @@ select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j
 ---+---+---
 (0 rows)
 
+select * from A where not exists (select sum(C.i) from C where C.i = A.i);
+ i | j 
+---+---
+(0 rows)
+
+explain select * from A where not exists (select sum(C.i) from C where C.i = A.i limit 0);
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.05 rows=5 width=8)
+   ->  Seq Scan on a  (cost=0.00..3.05 rows=2 width=8)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(4 rows)
+
+select * from A where not exists (select sum(C.i) from C where C.i = A.i limit 0);
+ i  | j  
+----+----
+ 19 |  5
+ 99 | 62
+ 78 | -1
+  1 |  1
+  1 |  1
+(5 rows)
+
+explain select * from A where not exists (select sum(C.i) from C where C.i = A.i limit 5 offset 3);
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..18.91 rows=3 width=8)
+   ->  Seq Scan on a  (cost=0.00..18.91 rows=1 width=8)
+         Filter: NOT ((subplan))
+         SubPlan 1
+           ->  Limit  (cost=3.17..3.17 rows=1 width=8)
+                 ->  Aggregate  (cost=3.16..3.17 rows=1 width=8)
+                       ->  Result  (cost=3.11..3.12 rows=1 width=4)
+                             Filter: c.i = $0
+                             ->  Materialize  (cost=3.11..3.12 rows=1 width=4)
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.11 rows=1 width=4)
+                                         ->  Seq Scan on c  (cost=0.00..3.11 rows=1 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(13 rows)
+
+select * from A where not exists (select sum(C.i) from C where C.i = A.i limit 5 offset 3);
+ i  | j  
+----+----
+ 19 |  5
+  1 |  1
+  1 |  1
+ 99 | 62
+ 78 | -1
+(5 rows)
+
+explain select * from A where not exists (select sum(C.i) from C where C.i = A.i limit 1 offset 0);
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..18.91 rows=3 width=8)
+   ->  Seq Scan on a  (cost=0.00..18.91 rows=1 width=8)
+         Filter: NOT ((subplan))
+         SubPlan 1
+           ->  Limit  (cost=3.16..3.17 rows=1 width=8)
+                 ->  Aggregate  (cost=3.16..3.17 rows=1 width=8)
+                       ->  Result  (cost=3.11..3.12 rows=1 width=4)
+                             Filter: c.i = $0
+                             ->  Materialize  (cost=3.11..3.12 rows=1 width=4)
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.11 rows=1 width=4)
+                                         ->  Seq Scan on c  (cost=0.00..3.11 rows=1 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(13 rows)
+
+select * from A where not exists (select sum(C.i) from C where C.i = A.i limit 1 offset 0);
+ i | j 
+---+---
+(0 rows)
+
 explain select C.j from C where not exists (select max(B.i) from B  where C.i = B.i having max(B.i) is not null) order by C.j;
                                                      QUERY PLAN                                                      
 ---------------------------------------------------------------------------------------------------------------------
@@ -1141,6 +1216,26 @@ select C.j from C where not exists (select rank() over (order by B.i) from B  wh
   7
  62
 (4 rows)
+
+explain select * from A where not exists (select sum(C.i) from C where C.i = A.i group by a.i);
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=3.20..6.31 rows=4 width=8)
+   ->  Hash Left Anti Semi Join  (cost=3.20..6.31 rows=2 width=8)
+         Hash Cond: a.i = c.i
+         ->  Seq Scan on a  (cost=0.00..3.05 rows=2 width=8)
+         ->  Hash  (cost=3.09..3.09 rows=3 width=4)
+               ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
+                     Filter: i IS NOT NULL
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(9 rows)
+
+select * from A where not exists (select sum(C.i) from C where C.i = A.i group by a.i);
+ i  | j 
+----+---
+ 19 | 5
+(1 row)
 
 -- ----------------------------------------------------------------------
 -- Test:  Correlated Subquery: CSQ using DML (Heap) 

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -1116,6 +1116,87 @@ select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j
 ---+---+---
 (0 rows)
 
+select * from A where not exists (select sum(C.i) from C where C.i = A.i);
+ i | j 
+---+---
+(0 rows)
+
+explain select * from A where not exists (select sum(C.i) from C where C.i = A.i limit 0);
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..882688.12 rows=5 width=8)
+   ->  Nested Loop Left Anti Semi Join  (cost=0.00..882688.12 rows=2 width=8)
+         Join Filter: true
+         ->  Table Scan on a  (cost=0.00..431.00 rows=2 width=8)
+         ->  Result  (cost=0.00..0.00 rows=0 width=1)
+               One-Time Filter: false
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.42.0
+(8 rows)
+
+select * from A where not exists (select sum(C.i) from C where C.i = A.i limit 0);
+ i  | j  
+----+----
+ 19 |  5
+ 99 | 62
+ 78 | -1
+  1 |  1
+  1 |  1
+(5 rows)
+
+explain select * from A where not exists (select sum(C.i) from C where C.i = A.i limit 5 offset 3);
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1324035.78 rows=2 width=8)
+   Filter: (subplan)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=5 width=8)
+         ->  Table Scan on a  (cost=0.00..431.00 rows=2 width=8)
+   SubPlan 1
+     ->  Limit  (cost=0.00..431.00 rows=1 width=8)
+           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                 ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                       Filter: c.i = $0
+                       ->  Materialize  (cost=0.00..431.00 rows=3 width=4)
+                             ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=9 width=4)
+                                   ->  Table Scan on c  (cost=0.00..431.00 rows=3 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.42.0
+(14 rows)
+
+select * from A where not exists (select sum(C.i) from C where C.i = A.i limit 5 offset 3);
+ i  | j  
+----+----
+ 99 | 62
+ 78 | -1
+  1 |  1
+  1 |  1
+ 19 |  5
+(5 rows)
+
+explain select * from A where not exists (select sum(C.i) from C where C.i = A.i limit 1 offset 0);
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1324035.78 rows=2 width=8)
+   Filter: (subplan)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=5 width=8)
+         ->  Table Scan on a  (cost=0.00..431.00 rows=2 width=8)
+   SubPlan 1
+     ->  Limit  (cost=0.00..431.00 rows=1 width=8)
+           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                 ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                       Filter: c.i = $0
+                       ->  Materialize  (cost=0.00..431.00 rows=3 width=4)
+                             ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=9 width=4)
+                                   ->  Table Scan on c  (cost=0.00..431.00 rows=3 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.42.0
+(14 rows)
+
+select * from A where not exists (select sum(C.i) from C where C.i = A.i limit 1 offset 0);
+ i | j 
+---+---
+(0 rows)
+
 explain select C.j from C where not exists (select max(B.i) from B  where C.i = B.i having max(B.i) is not null) order by C.j;
                                           QUERY PLAN                                           
 -----------------------------------------------------------------------------------------------
@@ -1215,6 +1296,24 @@ select C.j from C where not exists (select rank() over (order by B.i) from B  wh
   7
  62
 (4 rows)
+
+-- start_ignore
+-- FIXME: ORCA produces the wrong plan and results for subselects with a grouping clause
+-- end_ignore
+explain select * from A where not exists (select sum(C.i) from C where C.i = A.i group by a.i);
+                   QUERY PLAN                   
+------------------------------------------------
+ Result  (cost=0.00..0.00 rows=0 width=8)
+   ->  Result  (cost=0.00..0.00 rows=0 width=8)
+         One-Time Filter: false
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.42.3
+(5 rows)
+
+select * from A where not exists (select sum(C.i) from C where C.i = A.i group by a.i);
+ i | j 
+---+---
+(0 rows)
 
 -- ----------------------------------------------------------------------
 -- Test:  Correlated Subquery: CSQ using DML (Heap) 

--- a/src/test/regress/sql/qp_correlated_query.sql
+++ b/src/test/regress/sql/qp_correlated_query.sql
@@ -210,12 +210,21 @@ select * from A where exists (select * from C,B where C.j = A.j and exists (sele
 
 select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and not exists (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
 select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and not exists (select sum(B.i) from B where C.i = B.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
+select * from A where not exists (select sum(C.i) from C where C.i = A.i);
+explain select * from A where not exists (select sum(C.i) from C where C.i = A.i limit 0);
+select * from A where not exists (select sum(C.i) from C where C.i = A.i limit 0);
+explain select * from A where not exists (select sum(C.i) from C where C.i = A.i limit 5 offset 3);
+select * from A where not exists (select sum(C.i) from C where C.i = A.i limit 5 offset 3);
+explain select * from A where not exists (select sum(C.i) from C where C.i = A.i limit 1 offset 0);
+select * from A where not exists (select sum(C.i) from C where C.i = A.i limit 1 offset 0);
 explain select C.j from C where not exists (select max(B.i) from B  where C.i = B.i having max(B.i) is not null) order by C.j;
 select C.j from C where not exists (select max(B.i) from B  where C.i = B.i having max(B.i) is not null) order by C.j;
 explain select C.j from C where not exists (select max(B.i) from B  where C.i = B.i offset 1000) order by C.j;
 select C.j from C where not exists (select max(B.i) from B  where C.i = B.i offset 1000) order by C.j;
 explain select C.j from C where not exists (select rank() over (order by B.i) from B  where C.i = B.i) order by C.j;
 select C.j from C where not exists (select rank() over (order by B.i) from B  where C.i = B.i) order by C.j;
+explain select * from A where not exists (select sum(C.i) from C where C.i = A.i group by a.i);
+select * from A where not exists (select sum(C.i) from C where C.i = A.i group by a.i);
 
 
 -- ----------------------------------------------------------------------


### PR DESCRIPTION
During NOT EXISTS sublink pullup, we create a one-time false filter when
the sublink contains aggregates without checking for limitcount. However
in situations where the sublink contains an aggregate with limit 0, we
should not generate such filter as it produces incorrect results.

Added regress test.

Also, initialize all the members of IncrementVarSublevelsUp_context
properly.

Signed-off-by: Dhanashree Kashid <dkashid@pivotal.io>