### PR TITLE
Optimize away DISTINCT and ORDER BY in a NOT IN (...) subselect.

### DIFF
--- a/src/test/regress/expected/notin.out
+++ b/src/test/regress/expected/notin.out
@@ -411,39 +411,29 @@ select a,b from g1 where (a,b) not in
 --
 explain select x,y from l1 where (x,y) not in
 	(select distinct y, sum(x) from l1 group by y having y < 4 order by y) order by 1,2;
-                                                                        QUERY PLAN                                                                         
------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice4; segments: 3)  (cost=7.44..7.46 rows=10 width=8)
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=8.96..8.98 rows=10 width=8)
    Merge Key: notin.l1.x, notin.l1.y
-   ->  Sort  (cost=7.44..7.46 rows=4 width=8)
+   ->  Sort  (cost=8.96..8.98 rows=4 width=8)
          Sort Key: notin.l1.x, notin.l1.y
-         ->  Nested Loop Left Anti Semi Join (Not-In)  (cost=3.42..7.27 rows=4 width=8)
+         ->  Nested Loop Left Anti Semi Join (Not-In)  (cost=3.44..8.79 rows=4 width=8)
                Join Filter: notin.l1.x = "NotIn_SUBQUERY".y AND notin.l1.y = "NotIn_SUBQUERY".sum
                ->  Seq Scan on l1  (cost=0.00..3.10 rows=4 width=8)
-               ->  Materialize  (cost=3.42..3.45 rows=1 width=12)
-                     ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=3.36..3.42 rows=1 width=12)
-                           ->  Subquery Scan "NotIn_SUBQUERY"  (cost=3.36..3.38 rows=1 width=12)
-                                 ->  Unique  (cost=3.36..3.37 rows=1 width=16)
-                                       Group By: notin.l1.y, (pg_catalog.sum((sum(notin.l1.x))))
-                                       ->  Sort  (cost=3.36..3.37 rows=1 width=16)
-                                             Sort Key (Distinct): notin.l1.y, (pg_catalog.sum((sum(notin.l1.x))))
-                                             ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=3.31..3.35 rows=1 width=16)
-                                                   Hash Key: notin.l1.y, (pg_catalog.sum((sum(notin.l1.x))))
-                                                   ->  Unique  (cost=3.31..3.33 rows=1 width=16)
-                                                         Group By: notin.l1.y, (pg_catalog.sum((sum(notin.l1.x))))
-                                                         ->  Sort  (cost=3.31..3.32 rows=1 width=16)
-                                                               Sort Key (Distinct): notin.l1.y, (pg_catalog.sum((sum(notin.l1.x))))
-                                                               ->  HashAggregate  (cost=3.25..3.28 rows=1 width=16)
-                                                                     Group By: notin.l1.y
-                                                                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=3.14..3.20 rows=1 width=12)
-                                                                           Hash Key: notin.l1.y
-                                                                           ->  HashAggregate  (cost=3.14..3.14 rows=1 width=12)
-                                                                                 Group By: notin.l1.y
-                                                                                 ->  Seq Scan on l1  (cost=0.00..3.12 rows=2 width=8)
-                                                                                       Filter: y < 4
+               ->  Materialize  (cost=3.44..3.53 rows=3 width=12)
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=3.25..3.43 rows=3 width=12)
+                           ->  Subquery Scan "NotIn_SUBQUERY"  (cost=3.25..3.31 rows=1 width=12)
+                                 ->  HashAggregate  (cost=3.25..3.28 rows=1 width=16)
+                                       Group By: notin.l1.y
+                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=3.14..3.20 rows=1 width=12)
+                                             Hash Key: notin.l1.y
+                                             ->  HashAggregate  (cost=3.14..3.14 rows=1 width=12)
+                                                   Group By: notin.l1.y
+                                                   ->  Seq Scan on l1  (cost=0.00..3.12 rows=2 width=8)
+                                                         Filter: y < 4
  Settings:  optimizer=off
  Optimizer status: legacy query optimizer
-(30 rows)
+(20 rows)
 
 select x,y from l1 where (x,y) not in
 	(select distinct y, sum(x) from l1 group by y having y < 4 order by y) order by 1,2;

--- a/src/test/regress/expected/notin_optimizer.out
+++ b/src/test/regress/expected/notin_optimizer.out
@@ -401,39 +401,29 @@ select a,b from g1 where (a,b) not in
 --
 explain select x,y from l1 where (x,y) not in
 	(select distinct y, sum(x) from l1 group by y having y < 4 order by y) order by 1,2;
-                                                                        QUERY PLAN                                                                         
------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice4; segments: 3)  (cost=7.44..7.46 rows=10 width=8)
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=8.96..8.98 rows=10 width=8)
    Merge Key: notin.l1.x, notin.l1.y
-   ->  Sort  (cost=7.44..7.46 rows=4 width=8)
+   ->  Sort  (cost=8.96..8.98 rows=4 width=8)
          Sort Key: notin.l1.x, notin.l1.y
-         ->  Nested Loop Left Anti Semi Join (Not-In)  (cost=3.42..7.27 rows=4 width=8)
+         ->  Nested Loop Left Anti Semi Join (Not-In)  (cost=3.44..8.79 rows=4 width=8)
                Join Filter: notin.l1.x = "NotIn_SUBQUERY".y AND notin.l1.y = "NotIn_SUBQUERY".sum
                ->  Seq Scan on l1  (cost=0.00..3.10 rows=4 width=8)
-               ->  Materialize  (cost=3.42..3.45 rows=1 width=12)
-                     ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=3.36..3.42 rows=1 width=12)
-                           ->  Subquery Scan "NotIn_SUBQUERY"  (cost=3.36..3.38 rows=1 width=12)
-                                 ->  Unique  (cost=3.36..3.37 rows=1 width=16)
-                                       Group By: notin.l1.y, (pg_catalog.sum((sum(notin.l1.x))))
-                                       ->  Sort  (cost=3.36..3.37 rows=1 width=16)
-                                             Sort Key (Distinct): notin.l1.y, (pg_catalog.sum((sum(notin.l1.x))))
-                                             ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=3.31..3.35 rows=1 width=16)
-                                                   Hash Key: notin.l1.y, (pg_catalog.sum((sum(notin.l1.x))))
-                                                   ->  Unique  (cost=3.31..3.33 rows=1 width=16)
-                                                         Group By: notin.l1.y, (pg_catalog.sum((sum(notin.l1.x))))
-                                                         ->  Sort  (cost=3.31..3.32 rows=1 width=16)
-                                                               Sort Key (Distinct): notin.l1.y, (pg_catalog.sum((sum(notin.l1.x))))
-                                                               ->  HashAggregate  (cost=3.25..3.28 rows=1 width=16)
-                                                                     Group By: notin.l1.y
-                                                                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=3.14..3.20 rows=1 width=12)
-                                                                           Hash Key: notin.l1.y
-                                                                           ->  HashAggregate  (cost=3.14..3.14 rows=1 width=12)
-                                                                                 Group By: notin.l1.y
-                                                                                 ->  Seq Scan on l1  (cost=0.00..3.12 rows=2 width=8)
-                                                                                       Filter: y < 4
+               ->  Materialize  (cost=3.44..3.53 rows=3 width=12)
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=3.25..3.43 rows=3 width=12)
+                           ->  Subquery Scan "NotIn_SUBQUERY"  (cost=3.25..3.31 rows=1 width=12)
+                                 ->  HashAggregate  (cost=3.25..3.28 rows=1 width=16)
+                                       Group By: notin.l1.y
+                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=3.14..3.20 rows=1 width=12)
+                                             Hash Key: notin.l1.y
+                                             ->  HashAggregate  (cost=3.14..3.14 rows=1 width=12)
+                                                   Group By: notin.l1.y
+                                                   ->  Seq Scan on l1  (cost=0.00..3.12 rows=2 width=8)
+                                                         Filter: y < 4
  Settings:  optimizer=on
  Optimizer status: legacy query optimizer
-(30 rows)
+(20 rows)
 
 select x,y from l1 where (x,y) not in
 	(select distinct y, sum(x) from l1 group by y having y < 4 order by y) order by 1,2;


### PR DESCRIPTION
It occurred to me while looking at PR #1460 that when there's a DISTINCT or
an ORDER BY in a subselect NOT IN (...) subselect won't make any difference
to the overall result, so we can strip it off and safe the effort. In its
current form, PR #1460 would pessimize that case slightly more, by forcing
the subselect's resul to be gathered to a singled node for deduplication or
final ordering, while before, we would do only a local ordering /
deduplication on each segment. But it is a waste of effort to do that
even within each segment, and this PR gets rid of that.