### PR TITLE
Fix calculation of Motion nodes in initplans plan

### DIFF
--- a/src/test/regress/expected/update_gp.out
+++ b/src/test/regress/expected/update_gp.out
@@ -69,3 +69,115 @@ NOTICE:  dropped partition "extra" for relation "target"
 update target set b = 10 where c = 10;
 drop table todelete;
 drop table target;
+--
+-- Explicit Distribution motion must be added if any of the child nodes
+-- contains any motion excluding the motions in initplans.
+-- These test cases and expectation are applicable for GPDB planner not for ORCA.
+--
+SET gp_autostats_mode = NONE;
+CREATE TABLE keo1 ( user_vie_project_code_pk character varying(24), user_vie_fiscal_year_period_sk character varying(24), user_vie_act_cntr_marg_cum character varying(24)) DISTRIBUTED RANDOMLY;
+INSERT INTO keo1 VALUES ('1', '1', '1');
+CREATE TABLE keo2 ( projects_pk character varying(24)) DISTRIBUTED RANDOMLY;
+INSERT INTO keo2 VALUES ('1');
+CREATE TABLE keo3 ( sky_per character varying(24), bky_per character varying(24)) DISTRIBUTED BY (sky_per);
+INSERT INTO keo3 VALUES ('1', '1');
+CREATE TABLE keo4 ( keo_para_required_period character varying(6), keo_para_budget_date character varying(24)) DISTRIBUTED RANDOMLY;
+INSERT INTO keo4 VALUES ('1', '1');
+-- Explicit Redistribution motion should be added in case of GPDB Planner (test case not applicable for ORCA)
+EXPLAIN UPDATE keo1 SET user_vie_act_cntr_marg_cum = 234.682 FROM
+    ( SELECT a.user_vie_project_code_pk FROM keo1 a INNER JOIN keo2 b 
+        ON b.projects_pk=a.user_vie_project_code_pk
+        WHERE a.user_vie_fiscal_year_period_sk =
+          (SELECT MAX (sky_per) FROM keo3 WHERE bky_per =
+             (SELECT keo4.keo_para_required_period FROM keo4 WHERE keo_para_budget_date =
+                (SELECT min (keo4.keo_para_budget_date) FROM keo4)))
+    ) t1
+WHERE t1.user_vie_project_code_pk = keo1.user_vie_project_code_pk;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Update (slice0; segments: 3)  (rows=2325 width=142)
+   ->  Explicit Redistribute Motion 3:3  (slice6; segments: 3)  (cost=1790.74..2439.02 rows=2325 width=142)
+         ->  Hash Join  (cost=1790.74..2439.02 rows=2325 width=142)
+               Hash Cond: b.projects_pk::text = keo1.user_vie_project_code_pk::text
+               InitPlan  (slice9)
+                 ->  Aggregate  (cost=1212.70..1212.71 rows=1 width=32)
+                       InitPlan  (slice8)
+                         ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=430.08..860.08 rows=27 width=28)
+                               ->  Seq Scan on keo4  (cost=430.08..860.08 rows=9 width=28)
+                                     Filter: keo_para_budget_date::text = $0
+                                     InitPlan  (slice7)
+                                       ->  Aggregate  (cost=430.07..430.08 rows=1 width=32)
+                                             ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=430.00..430.05 rows=1 width=32)
+                                                   ->  Aggregate  (cost=430.00..430.01 rows=1 width=32)
+                                                         ->  Seq Scan on keo4  (cost=0.00..364.00 rows=8800 width=66)
+                       ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=352.55..352.60 rows=1 width=32)
+                             ->  Aggregate  (cost=352.55..352.56 rows=1 width=32)
+                                   ->  Seq Scan on keo3  (cost=0.00..352.50 rows=7 width=66)
+                                         Filter: bky_per::text = $1::text
+               ->  Seq Scan on keo2 b  (cost=0.00..441.00 rows=11367 width=66)
+               ->  Hash  (cost=570.37..570.37 rows=205 width=208)
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=279.86..570.37 rows=205 width=208)
+                           ->  Hash Join  (cost=279.86..562.19 rows=69 width=208)
+                                 Hash Cond: keo1.user_vie_project_code_pk::text = a.user_vie_project_code_pk::text
+                                 ->  Seq Scan on keo1  (cost=0.00..243.00 rows=4767 width=142)
+                                 ->  Hash  (cost=279.32..279.32 rows=15 width=66)
+                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..279.32 rows=15 width=66)
+                                             ->  Seq Scan on keo1 a  (cost=0.00..278.75 rows=5 width=66)
+                                                   Filter: user_vie_fiscal_year_period_sk::text = $2
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(31 rows)
+
+UPDATE keo1 SET user_vie_act_cntr_marg_cum = 234.682 FROM
+    ( SELECT a.user_vie_project_code_pk FROM keo1 a INNER JOIN keo2 b 
+        ON b.projects_pk=a.user_vie_project_code_pk
+        WHERE a.user_vie_fiscal_year_period_sk =
+          (SELECT MAX (sky_per) FROM keo3 WHERE bky_per =
+             (SELECT keo4.keo_para_required_period FROM keo4 WHERE keo_para_budget_date =
+                (SELECT min (keo4.keo_para_budget_date) FROM keo4)))
+    ) t1
+WHERE t1.user_vie_project_code_pk = keo1.user_vie_project_code_pk;
+SELECT user_vie_act_cntr_marg_cum FROM keo1;
+ user_vie_act_cntr_marg_cum 
+----------------------------
+ 234.682
+(1 row)
+
+-- Explicit Redistribution motion should not be added in case of GPDB Planner (test case not applicable to ORCA)
+CREATE TABLE keo5 (x int, y int) DISTRIBUTED BY (x);
+INSERT INTO keo5 VALUES (1,1);
+EXPLAIN DELETE FROM keo5 WHERE x IN (SELECT x FROM keo5 WHERE EXISTS (SELECT x FROM keo5 WHERE x < 2));
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Delete (slice0; segments: 3)  (rows=2471070 width=10)
+   ->  Result  (cost=1198.81..76722.41 rows=2471070 width=10)
+         One-Time Filter: $0
+         InitPlan  (slice2)
+           ->  Limit  (cost=0.00..0.06 rows=1 width=0)
+                 ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..0.06 rows=1 width=0)
+                       ->  Limit  (cost=0.00..0.04 rows=1 width=0)
+                             ->  Seq Scan on keo5  (cost=0.00..1176.25 rows=9567 width=0)
+                                   Filter: x < 2
+         ->  Hash Join  (cost=1198.75..76722.35 rows=2471070 width=10)
+               Hash Cond: public.keo5.x = public.keo5.x
+               ->  Seq Scan on keo5  (cost=0.00..961.00 rows=28700 width=14)
+               ->  Hash  (cost=1186.25..1186.25 rows=334 width=4)
+                     ->  HashAggregate  (cost=1176.25..1186.25 rows=334 width=4)
+                           Group By: public.keo5.x
+                           ->  Seq Scan on keo5  (cost=0.00..961.00 rows=28700 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(18 rows)
+
+DELETE FROM keo5 WHERE x IN (SELECT x FROM keo5 WHERE EXISTS (SELECT x FROM keo5 WHERE x < 2));
+SELECT x FROM keo5;
+ x 
+---
+(0 rows)
+
+RESET gp_autostats_mode;
+DROP TABLE keo1;
+DROP TABLE keo2;
+DROP TABLE keo3;
+DROP TABLE keo4;
+DROP TABLE keo5;

--- a/src/test/regress/expected/update_gp_optimizer.out
+++ b/src/test/regress/expected/update_gp_optimizer.out
@@ -1,0 +1,192 @@
+-- Test DELETE and UPDATE on an inherited table.
+-- The special aspect of this table is that the inherited table has
+-- a different distribution key. 'p' table's distribution key matches
+-- that of 'r', but 'p2's doesn't. Test that the planner adds a Motion
+-- node correctly for p2.
+create table todelete (a int) distributed by (a);
+create table parent (a int, b int, c int) distributed by (a);
+create table child (a int, b int, c int) inherits (parent) distributed by (b);
+NOTICE:  merging column "a" with inherited definition
+NOTICE:  merging column "b" with inherited definition
+NOTICE:  merging column "c" with inherited definition
+insert into parent select g, g, g from generate_series(1,5) g;
+insert into child select g, g, g from generate_series(6,10) g;
+insert into todelete select generate_series(3,4);
+delete from parent using todelete where parent.a = todelete.a;
+insert into todelete select generate_series(5,7);
+update parent set c=c+100 from todelete where parent.a = todelete.a;
+select * from parent;
+ a  | b  |  c  
+----+----+-----
+  1 |  1 |   1
+  2 |  2 |   2
+  8 |  8 |   8
+  9 |  9 |   9
+ 10 | 10 |  10
+  5 |  5 | 105
+  6 |  6 | 106
+  7 |  7 | 107
+(8 rows)
+
+drop table todelete;
+drop table child;
+drop table parent;
+-- This is similar to the above, but with a partitioned table (which is
+-- implemented by inheritance) rather than an explicitly inherited table.
+-- The scans on some of the partitions degenerate into Result nodes with
+-- False one-time filter, which don't need a Motion node.
+create table todelete (a int, b int) distributed by (a);
+create table target (a int, b int, c int)
+        distributed by (a)
+        partition by range (c) (start(1) end(5) every(1), default partition extra);
+NOTICE:  CREATE TABLE will create partition "target_1_prt_extra" for table "target"
+NOTICE:  CREATE TABLE will create partition "target_1_prt_2" for table "target"
+NOTICE:  CREATE TABLE will create partition "target_1_prt_3" for table "target"
+NOTICE:  CREATE TABLE will create partition "target_1_prt_4" for table "target"
+NOTICE:  CREATE TABLE will create partition "target_1_prt_5" for table "target"
+insert into todelete select g, g % 4 from generate_series(1, 10) g;
+insert into target select g, 0, 3 from generate_series(1, 5) g;
+insert into target select g, 0, 1 from generate_series(1, 5) g;
+delete from target where c = 3 and a in (select b from todelete);
+insert into todelete values (1, 5);
+update target set b=target.b+100 where c = 3 and a in (select b from todelete);
+select * from target;
+ a |  b  | c 
+---+-----+---
+ 1 |   0 | 1
+ 2 |   0 | 1
+ 4 |   0 | 3
+ 5 | 100 | 3
+ 3 |   0 | 1
+ 4 |   0 | 1
+ 5 |   0 | 1
+(7 rows)
+
+-- Also test an update with a qual that doesn't match any partition. The
+-- Append degenerates into a dummy Result with false One-Time Filter.
+alter table target drop default partition;
+NOTICE:  dropped partition "extra" for relation "target"
+update target set b = 10 where c = 10;
+drop table todelete;
+drop table target;
+--
+-- Explicit Distribution motion must be added if any of the child nodes
+-- contains any motion excluding the motions in initplans.
+-- These test cases and expectation are applicable for GPDB planner not for ORCA.
+--
+SET gp_autostats_mode = NONE;
+CREATE TABLE keo1 ( user_vie_project_code_pk character varying(24), user_vie_fiscal_year_period_sk character varying(24), user_vie_act_cntr_marg_cum character varying(24)) DISTRIBUTED RANDOMLY;
+INSERT INTO keo1 VALUES ('1', '1', '1');
+CREATE TABLE keo2 ( projects_pk character varying(24)) DISTRIBUTED RANDOMLY;
+INSERT INTO keo2 VALUES ('1');
+CREATE TABLE keo3 ( sky_per character varying(24), bky_per character varying(24)) DISTRIBUTED BY (sky_per);
+INSERT INTO keo3 VALUES ('1', '1');
+CREATE TABLE keo4 ( keo_para_required_period character varying(6), keo_para_budget_date character varying(24)) DISTRIBUTED RANDOMLY;
+INSERT INTO keo4 VALUES ('1', '1');
+-- Explicit Redistribution motion should be added in case of GPDB Planner (test case not applicable for ORCA)
+EXPLAIN UPDATE keo1 SET user_vie_act_cntr_marg_cum = 234.682 FROM
+    ( SELECT a.user_vie_project_code_pk FROM keo1 a INNER JOIN keo2 b 
+        ON b.projects_pk=a.user_vie_project_code_pk
+        WHERE a.user_vie_fiscal_year_period_sk =
+          (SELECT MAX (sky_per) FROM keo3 WHERE bky_per =
+             (SELECT keo4.keo_para_required_period FROM keo4 WHERE keo_para_budget_date =
+                (SELECT min (keo4.keo_para_budget_date) FROM keo4)))
+    ) t1
+WHERE t1.user_vie_project_code_pk = keo1.user_vie_project_code_pk;
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Update  (cost=0.00..2586.11 rows=1 width=1)
+   ->  Result  (cost=0.00..2586.00 rows=1 width=42)
+         ->  Explicit Redistribute Motion 1:3  (slice7)  (cost=0.00..2586.00 rows=2 width=38)
+               ->  Result  (cost=0.00..2586.00 rows=1 width=38)
+                     ->  Split  (cost=0.00..2586.00 rows=1 width=38)
+                           ->  Result  (cost=0.00..2586.00 rows=1 width=42)
+                                 ->  Hash Join  (cost=0.00..2586.00 rows=1 width=34)
+                                       Hash Cond: public.keo1.user_vie_project_code_pk::text = public.keo1.user_vie_project_code_pk::text
+                                       ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=34)
+                                             ->  Table Scan on keo1  (cost=0.00..431.00 rows=1 width=34)
+                                       ->  Hash  (cost=2155.00..2155.00 rows=1 width=8)
+                                             ->  Hash Join  (cost=0.00..2155.00 rows=1 width=8)
+                                                   Hash Cond: public.keo1.user_vie_fiscal_year_period_sk::text = (max(keo3.sky_per::text))
+                                                   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=16)
+                                                         ->  Hash Join  (cost=0.00..862.00 rows=1 width=16)
+                                                               Hash Cond: public.keo1.user_vie_project_code_pk::text = keo2.projects_pk::text
+                                                               ->  Table Scan on keo1  (cost=0.00..431.00 rows=1 width=16)
+                                                               ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+                                                                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                           ->  Table Scan on keo2  (cost=0.00..431.00 rows=1 width=8)
+                                                   ->  Hash  (cost=1293.00..1293.00 rows=1 width=8)
+                                                         ->  Aggregate  (cost=0.00..1293.00 rows=1 width=8)
+                                                               ->  Hash Join  (cost=0.00..1293.00 rows=1 width=8)
+                                                                     Hash Cond: keo3.bky_per::text = public.keo4.keo_para_required_period::text
+                                                                     ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
+                                                                           ->  Table Scan on keo3  (cost=0.00..431.00 rows=1 width=16)
+                                                                     ->  Hash  (cost=862.00..862.00 rows=1 width=8)
+                                                                           ->  Assert  (cost=0.00..862.00 rows=1 width=8)
+                                                                                 Assert Cond: (pg_catalog.row_number()) = 1
+                                                                                 ->  Window  (cost=0.00..862.00 rows=1 width=16)
+                                                                                       ->  Hash Join  (cost=0.00..862.00 rows=1 width=8)
+                                                                                             Hash Cond: public.keo4.keo_para_budget_date::text = (min((min(public.keo4.keo_para_budget_date::text))))
+                                                                                             ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
+                                                                                                   ->  Table Scan on keo4  (cost=0.00..431.00 rows=1 width=16)
+                                                                                             ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+                                                                                                   ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                                         ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                                                               ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                                                     ->  Table Scan on keo4  (cost=0.00..431.00 rows=1 width=8)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.42.3
+(41 rows)
+
+UPDATE keo1 SET user_vie_act_cntr_marg_cum = 234.682 FROM
+    ( SELECT a.user_vie_project_code_pk FROM keo1 a INNER JOIN keo2 b 
+        ON b.projects_pk=a.user_vie_project_code_pk
+        WHERE a.user_vie_fiscal_year_period_sk =
+          (SELECT MAX (sky_per) FROM keo3 WHERE bky_per =
+             (SELECT keo4.keo_para_required_period FROM keo4 WHERE keo_para_budget_date =
+                (SELECT min (keo4.keo_para_budget_date) FROM keo4)))
+    ) t1
+WHERE t1.user_vie_project_code_pk = keo1.user_vie_project_code_pk;
+SELECT user_vie_act_cntr_marg_cum FROM keo1;
+ user_vie_act_cntr_marg_cum 
+----------------------------
+ 234.682
+(1 row)
+
+-- Explicit Redistribution motion should not be added in case of GPDB Planner (test case not applicable to ORCA)
+CREATE TABLE keo5 (x int, y int) DISTRIBUTED BY (x);
+INSERT INTO keo5 VALUES (1,1);
+EXPLAIN DELETE FROM keo5 WHERE x IN (SELECT x FROM keo5 WHERE EXISTS (SELECT x FROM keo5 WHERE x < 2));
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Delete  (cost=0.00..1324463.20 rows=1 width=1)
+   ->  Result  (cost=0.00..1324463.17 rows=1 width=22)
+         ->  Hash EXISTS Join  (cost=0.00..1324463.17 rows=1 width=18)
+               Hash Cond: public.keo5.x = public.keo5.x
+               ->  Table Scan on keo5  (cost=0.00..431.00 rows=1 width=18)
+               ->  Hash  (cost=1324032.17..1324032.17 rows=1 width=4)
+                     ->  Nested Loop EXISTS Join  (cost=0.00..1324032.17 rows=1 width=4)
+                           Join Filter: true
+                           ->  Table Scan on keo5  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+                                 ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=1)
+                                       ->  Limit  (cost=0.00..431.00 rows=1 width=1)
+                                             ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+                                                   ->  Table Scan on keo5  (cost=0.00..431.00 rows=1 width=1)
+                                                         Filter: x < 2
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.42.3
+(17 rows)
+
+DELETE FROM keo5 WHERE x IN (SELECT x FROM keo5 WHERE EXISTS (SELECT x FROM keo5 WHERE x < 2));
+SELECT x FROM keo5;
+ x 
+---
+(0 rows)
+
+RESET gp_autostats_mode;
+DROP TABLE keo1;
+DROP TABLE keo2;
+DROP TABLE keo3;
+DROP TABLE keo4;
+DROP TABLE keo5;

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -80,7 +80,7 @@ ignore: random
 # ----------
 # Another group of parallel tests
 # ----------
-test: select_into select_distinct select_distinct_on select_implicit select_having subselect union case join aggregates random portals arrays btree_index hash_index update delete lock
+test: select_into select_distinct select_distinct_on select_implicit select_having subselect union case join aggregates random portals arrays btree_index hash_index update update_gp delete lock
 
 # In PostgreSQL, namespace test is run as part of the fourth group, but there
 # are some GPDB additions in it that will show diff if concurrent tests use


### PR DESCRIPTION
After the plan is created and motion nodes are applied to the plan as per the flow requirement in apply_motion and apply_motion_mutator functions. If as per the flow, explicit distribution is required, it is only applied if the number of motion node in the plan excluding the motion nodes in initplan is greater than 0. 
Currently, nMotionNodes field in the plan is used to calculate the number of Motion nodes in the plans referred by initplans, however if an initplan refers to a plan which also contains an initplan we append all nMotionNodes in the initplans found and it results in incorrect number of motion nodes in initplan. However only nMotionNode from the top level plan referred by initplan is required.

In the plan below, the actual motion count is as below:
  1. Number of Total Motions = 5 (3 Gather Motion + 2 BroadCast Motion)
  2. Number of Motions in InitPlan = 3 Gather Motion

if `Number of Total Motions` - `Number of Motions in InitPlan ` then apply explicit distribution if requested.
 
Current Calculation: nMotionNodes in Initplan`(InitPlan (slice8) = 3, Initplan (slice 7) = 2, Initplan (slice 6) = 1)`  = `3+2+1` = `6`
Thus the number of motions in initplan is calculated as 6. So `5(Total Motion) - 6(Number of motion in initplan) < 0`, and an `explicit distribution is not applied` and we result in an incorrect plan.

Such incorrect plan may result in attempting to update tuples with invalid tid on a segment as the redistribution of the tuples was not performed and will result in errors like depending on debug or retail build. 

`attempted to update invisible tuple`, 
`sql:reproquery2.sql:13: ERROR:  Unexpected internal error (heapam.c:2714)  (seg0 bhuviMac.local:25432 pid=76809)
DETAIL:  FailedAssertion("!(( ((void) ((bool) ((! assert_enabled) || ! (!(((void*)(lp) != ((void*)0)))) || (ExceptionalCondition("!(((void*)(lp) != ((void*)0)))", ("FailedAssertion"), "heapam.c", 2714))))), (bool) (((lp)->lp_flags & 0x01) != 0) ))", File: "heapam.c", Line: 2714)
ERROR:  could not temporarily connect to one or more segments (cdbgang.c:1681)`
`
`ERROR:  could not read block 0 of relation 1663/49403/49184: read only 0 of 32768 bytes`

Plan
```
 Update (slice0; segments: 3)  (rows=5 width=16)
   ->  Hash Join  (cost=751.45..10082.00 rows=5 width=16)
         Hash Cond: b.projects_pk = keo_user_views.user_vie_project_code_pk
         InitPlan  (slice8)
           ->  Aggregate  (cost=170.10..170.11 rows=1 width=8)
                 InitPlan  (slice7)
                   ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=51.26..102.38 rows=1 width=7)
                         ->  Seq Scan on keo_para_update_date  (cost=51.26..102.38 rows=1 width=7)
                               Filter: keo_para_budget_date = $0
                               InitPlan  (slice6)
                                 ->  Aggregate  (cost=51.25..51.26 rows=1 width=8)
                                       ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=51.19..51.24 rows=1 width=8)
                                             ->  Aggregate  (cost=51.19..51.20 rows=1 width=8)
                                                   ->  Seq Scan on keo_para_update_date  (cost=0.00..51.11 rows=10 width=8)
                                                         Filter: keo_para_budget_date >= '2017-09-06 12:36:20.995034-07'::timestamp with time zone
                 ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=67.66..67.71 rows=1 width=8)
                       ->  Aggregate  (cost=67.66..67.67 rows=1 width=8)
                             ->  Seq Scan on keo_period  (cost=0.00..67.65 rows=1 width=8)
                                   Filter: bky_per::text = $1::text
         ->  Seq Scan on keo_projects b  (cost=0.00..9115.27 rows=28676 width=4)
         ->  Hash  (cost=580.88..580.88 rows=13 width=20)
               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=296.57..580.88 rows=13 width=20)
                     ->  Hash Join  (cost=296.57..580.39 rows=5 width=20)
                           Hash Cond: keo_user_views.user_vie_project_code_pk = a.user_vie_project_code_pk
                           ->  Seq Scan on keo_user_views  (cost=0.00..271.12 rows=1671 width=16)
                           ->  Hash  (cost=296.38..296.38 rows=6 width=4)
                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..296.38 rows=6 width=4)
                                       ->  Seq Scan on keo_user_views a  (cost=0.00..296.18 rows=2 width=4)
                                             Filter: user_vie_fiscal_year_period_sk::double precision = $2
```


Signed-off-by: Ekta Khanna <ekhanna@pivotal.io>