### PR TITLE
Added handling for winstar & winagg fields

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("2.42.", GPORCA_VERSION_STRING, 5);
+return strncmp("2.43.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 2.42.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 2.43.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -12540,7 +12540,7 @@ int
 main ()
 {
 
-return strncmp("2.42.", GPORCA_VERSION_STRING, 5);
+return strncmp("2.43.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -12550,7 +12550,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 2.42.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 2.43.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -121,7 +121,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	@echo "Resolve finished";
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget -O - https://github.com/greenplum-db/gporca/releases/download/v2.42.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget -O - https://github.com/greenplum-db/gporca/releases/download/v2.43.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/backend/executor/nodeWindow.c
+++ b/src/backend/executor/nodeWindow.c
@@ -2471,11 +2471,6 @@ initWindowFuncState(WindowState * wstate, Window * node)
 				 winref->winfnoid);
 		proform = (Form_pg_proc) GETSTRUCT(heap_tuple);
 
-		/*
-		 * NOTE: We cannot trust the WindowRef->winagg field to be set correctly,
-		 * because that flag is lost in the translation when ORCA is used.
-		 * Hence we must look up that information from the syscache here.
-		 */
 		isAgg = proform->proisagg;
 		isWin = proform->proiswindow;
 		isSet = proform->proretset;
@@ -2485,6 +2480,7 @@ initWindowFuncState(WindowState * wstate, Window * node)
 		ReleaseSysCache(heap_tuple);
 
 		Assert(isAgg != isWin);
+		Assert(isAgg == winref->winagg);
 		Assert(!isSet);
 
 		/*

--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -518,23 +518,8 @@ CTranslatorDXLToScalar::PwindowrefFromDXLNodeScWindowRef
 	pwindowref->winlevel = 0;
 	pwindowref->winspec = pdxlop->UlWinSpecPos();
 	pwindowref->restype = CMDIdGPDB::PmdidConvert(pdxlop->PmdidRetType())->OidObjectId();
-
-	/*
-	 * ORCA doesn't have a field correpsonding to 'windstar', that
-	 * information was already lost in the translation from the parse
-	 * tree's WindowRef to DXL WindowRef node. Fortunately, it's only
-	 * used for deparsing, and a plan tree is only deparsed for EXPLAIN
-	 * purposes, so it's not critical.
-	 */
-	pwindowref->winstar = false;
-
-	/*
-	 * XXX: ORCA's WindowRef object doesn't have a 'winagg' field either.
-	 * Currently, that's also not used in the executor, the executor
-	 * node it will look up that information from the syscache by
-	 * itself. But this we ought to fix someday.
-	 */
-	pwindowref->winagg = false;
+	pwindowref->winstar = pdxlop->FStarArg();
+	pwindowref->winagg = pdxlop->FSimpleAgg();
 
 	EdxlWinStage edxlwinstage = pdxlop->Edxlwinstage();
 	GPOS_ASSERT(edxlwinstage != EdxlwinstageSentinel);

--- a/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
@@ -1571,6 +1571,8 @@ CTranslatorScalarToDXL::PdxlnScWindowref
 													GPOS_NEW(m_pmp) CMDIdGPDB(pwindowref->winfnoid),
 													GPOS_NEW(m_pmp) CMDIdGPDB(pwindowref->restype),
 													pwindowref->windistinct,
+													pwindowref->winstar,
+													pwindowref->winagg,
 													edxlwinstage,
 													ulWinSpecPos
 													);


### PR DESCRIPTION
With commit 387c485d62955fba79c9a376820aade32047eb45 winstar and winagg
fields were added in WindowRef Node, so this commit adds handling for
them in ORCA.

For GPDB4, since these fields does not exist in WindowRef, will set them as false in translator.