### PR TITLE
Remove unused code to handle 's' message in the QD/QE protocol.

### DIFF
--- a/src/backend/gp_libpq_fe/fe-exec.c
+++ b/src/backend/gp_libpq_fe/fe-exec.c
@@ -169,9 +169,6 @@ PQmakeEmptyPGresult(PGconn *conn, ExecStatusType status)
 	result->curOffset = 0;
 	result->spaceLeft = 0;
     result->cdbstats = NULL;            /*CDB*/
-    result->Standby_HaveInfo = false;
-    result->Standby_xlogid = 0;
-    result->Standby_xrecoff = 0;
 	
     result->extras = NULL;
     result->extraslen = 0;
@@ -186,13 +183,6 @@ PQmakeEmptyPGresult(PGconn *conn, ExecStatusType status)
 		/* copy connection data we might need for operations on PGresult */
 		result->noticeHooks = conn->noticeHooks;
 		result->client_encoding = conn->client_encoding;
-
-		if (conn->Standby_HaveInfo)
-		{
-			result->Standby_HaveInfo = true;
-			result->Standby_xlogid = conn->Standby_xlogid;
-			result->Standby_xrecoff = conn->Standby_xrecoff;
-		}
 
 		/* consider copying conn's errorMessage */
 		switch (status)
@@ -615,10 +605,6 @@ PQclear(PGresult *res)
 	res->errFields = NULL;
 	/* res->curBlock was zeroed out earlier */
 
-	res->Standby_HaveInfo = false;
-	res->Standby_xlogid = 0;
-	res->Standby_xrecoff = 0;
-	
 	if (res->extras)
 		free(res->extras);
 	res->extraslen = 0;

--- a/src/backend/gp_libpq_fe/gp-libpq-int.h
+++ b/src/backend/gp_libpq_fe/gp-libpq-int.h
@@ -162,11 +162,6 @@ struct pg_result
 	PGNoticeHooks noticeHooks;
 	int			client_encoding;	/* encoding id */
 
-	/* XLOG passed from Standby Master to Primary */
-	bool						Standby_HaveInfo;
-	uint32						Standby_xlogid;		/* log file #, 0 based */
-	uint32						Standby_xrecoff;	/* byte offset of location in log file */
-	
 	/*
 	 * Error information (all NULL if not an error result).  errMsg is the
 	 * "overall" error message returned by PQresultErrorMessage.  If we have
@@ -329,12 +324,7 @@ struct pg_conn
 	PGTransactionStatusType xactStatus; /* never changes to ACTIVE */
 
 	bool						utility_mode;
-	
-	/* XLOG passed from Standby Master to Primary */
-	bool						Standby_HaveInfo;
-	uint32						Standby_xlogid;		/* log file #, 0 based */
-	uint32						Standby_xrecoff;	/* byte offset of location in log file */
-		
+
 	PGQueryClass queryclass;
 	char	   *last_query;		/* last SQL command, or NULL if unknown */
 	char		last_sqlstate[6];		/* last reported SQLSTATE */


### PR DESCRIPTION
I don't know what this was used for, but I don't see any code that would
send these messages anymore.