### PR TITLE
Allow restoring of backups with different path in report file

### DIFF
--- a/gpMgmt/bin/gppylib/operations/backup_utils.py
+++ b/gpMgmt/bin/gppylib/operations/backup_utils.py
@@ -86,7 +86,7 @@ class Context(Values, object):
         if timestamp is None:
             timestamp = self.timestamp
 
-        if directory:
+        if directory is not None:
             use_dir = directory
         elif dbid == 1:
             use_dir = self.get_backup_dir(timestamp)
@@ -158,7 +158,9 @@ class Context(Values, object):
         if not report_file:
             raise Exception("Unable to locate report file for timestamp %s" % timestamp)
         report_contents = get_lines_from_file(report_file)
-        old_metadata = self.generate_filename("metadata", timestamp=timestamp, use_old_format=True, use_compress=False)
+        # We specify directory='' because we only care about matching the
+        # filename and not the full path
+        old_metadata = self.generate_filename("metadata", timestamp=timestamp, use_old_format=True, use_compress=False, directory='')
         old_format = False
         for line in report_contents:
             if old_metadata in line:
@@ -1021,4 +1023,4 @@ def validate_netbackup_params(param_dict):
     for label, param in param_dict.iteritems():
         if param and len(param) > max_len:
             raise Exception("Netbackup {0} ({1}) exceeds the maximum length of {2} characters".format(label, param, max_len))
-    
+

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_backup_utils.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_backup_utils.py
@@ -204,6 +204,13 @@ class BackupUtilsTestCase(GpTestCase):
     def test_is_timestamp_in_old_format_empty_report_file(self, mock1, mock2, mock3):
         self.assertFalse(self.context.is_timestamp_in_old_format())
 
+    @patch('os.path.exists', side_effect=[True])
+    @patch('gppylib.operations.backup_utils.Context.get_dump_dirs', return_value=['/tmp/db_dumps/20160101'])
+    @patch('gppylib.operations.backup_utils.get_lines_from_file',
+         return_value=['BackupFile /backup/DCA/20160101/gp_dump_1_1_20160101010101.gz: Succeeded'])
+    def test_is_timestamp_in_old_format_wrong_path(self, mock1, mock2, mock3):
+        self.assertTrue(self.context.is_timestamp_in_old_format())
+
     @patch('glob.glob', return_value=['/data/master/db_dumps/20160101/gp_dump_-1_1_20160101010101.gz'])
     def test_get_filename_for_content_master_exists(self, mock1):
         filename = get_filename_for_content(self.context, "metadata", -1)


### PR DESCRIPTION
Some backups with Data Domain contained an incorrect path in their
report file. When checking whether the backup timestamp was in a pre or
post content-id format, restore would fail since the path in the report
file didn't match the expected pattern. Instead, we now check for the
timestamp format in a more generalized way to account for this discrepancy.

Signed-off-by: Chris Hajas <chajas@pivotal.io>