### PR TITLE
Allow "agg() OVER window" syntax, without parens.

### DIFF
--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -5535,7 +5535,7 @@ get_windowref_expr(WindowRef *wref, deparse_context *context)
 		if (wc->winref == wref->winref)
 		{
 			if (wc->name)
-				appendStringInfo(buf, "(%s)", quote_identifier(wc->name));
+				appendStringInfoString(buf, quote_identifier(wc->name));
 			else
 				get_rule_windowspec(wc, context->windowTList, context);
 			break;

--- a/src/test/regress/expected/qp_misc.out
+++ b/src/test/regress/expected/qp_misc.out
@@ -14162,9 +14162,11 @@ select rnum, c1, c2, sum(c3) over w1, sum (c3) over w2 from tolap  window w1 as 
 group by
 f1,f2,f3,f4,f5
 ) Q ) P;
-ERROR:  syntax error at or near "w1"
-LINE 12: select rnum, c1, c2, sum(c3) over w1, sum (c3) over w2 from ...
-                                           ^
+             test_name_part             | pass_ind 
+----------------------------------------+----------
+ OlapCoreWindowFrameWindowDefinition_p1 |        1
+(1 row)
+
 -- OperatorAnd_p1
 select 'OperatorAnd_p1' test_name_part, case when c = 1 then 1 else 0 end pass_ind from (
 select count(distinct c) c from (

--- a/src/test/regress/expected/window_views.out
+++ b/src/test/regress/expected/window_views.out
@@ -36,9 +36,9 @@ create view v4 as
   select avg(a) over (w)
   from testtab window w as ();
 select pg_get_viewdef('v4');
-                           pg_get_viewdef                           
---------------------------------------------------------------------
- SELECT avg(testtab.a) OVER (w) AS avg FROM testtab WINDOW w AS ();
+                          pg_get_viewdef                          
+------------------------------------------------------------------
+ SELECT avg(testtab.a) OVER w AS avg FROM testtab WINDOW w AS ();
 (1 row)
 
 create view v5 as
@@ -63,27 +63,27 @@ create view v7 as
   select avg(a) over (w)
   from testtab window w as (order by a);
 select pg_get_viewdef('v7');
-                                    pg_get_viewdef                                    
---------------------------------------------------------------------------------------
- SELECT avg(testtab.a) OVER (w) AS avg FROM testtab WINDOW w AS (ORDER BY testtab.a);
+                                   pg_get_viewdef                                   
+------------------------------------------------------------------------------------
+ SELECT avg(testtab.a) OVER w AS avg FROM testtab WINDOW w AS (ORDER BY testtab.a);
 (1 row)
 
 create view v8 as
   select avg(a) over (w)
   from testtab window w as (order by a rows between unbounded preceding and unbounded following);
 select pg_get_viewdef('v8');
-                                                                 pg_get_viewdef                                                                  
--------------------------------------------------------------------------------------------------------------------------------------------------
- SELECT avg(testtab.a) OVER (w) AS avg FROM testtab WINDOW w AS (ORDER BY testtab.a ROWS BETWEEN  UNBOUNDED PRECEDING AND  UNBOUNDED FOLLOWING);
+                                                                pg_get_viewdef                                                                 
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ SELECT avg(testtab.a) OVER w AS avg FROM testtab WINDOW w AS (ORDER BY testtab.a ROWS BETWEEN  UNBOUNDED PRECEDING AND  UNBOUNDED FOLLOWING);
 (1 row)
 
 create view v9 as
   select avg(a) over (w)
   from testtab window w as (order by a rows between 1 preceding and 1 following);
 select pg_get_viewdef('v9');
-                                                                  pg_get_viewdef                                                                   
----------------------------------------------------------------------------------------------------------------------------------------------------
- SELECT avg(testtab.a) OVER (w) AS avg FROM testtab WINDOW w AS (ORDER BY testtab.a ROWS BETWEEN (1)::bigint PRECEDING AND (1)::bigint FOLLOWING);
+                                                                 pg_get_viewdef                                                                  
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ SELECT avg(testtab.a) OVER w AS avg FROM testtab WINDOW w AS (ORDER BY testtab.a ROWS BETWEEN (1)::bigint PRECEDING AND (1)::bigint FOLLOWING);
 (1 row)
 
 create view v10 as


### PR DESCRIPTION
This is the spec-compliant spelling, but GPDB has only allowed
"agg OVER (window)" so far. With this commit, the parens are still allowed,
for backwards-compatibility.

Change deparsing code to also use the non-parens syntax in view definitions
and EXPLAIN. Adjust expected output of regression tests accordingly.