### PR TITLE
Move extended grouping processing to after transforming window functions.

### DIFF
--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -520,7 +520,7 @@ _equalArrayExpr(ArrayExpr *a, ArrayExpr *b)
 	COMPARE_SCALAR_FIELD(element_typeid);
 	COMPARE_NODE_FIELD(elements);
 	COMPARE_SCALAR_FIELD(multidims);
-	/* COMPARE_LOCATION_FIELD(location); */
+	COMPARE_LOCATION_FIELD(location);
 
 	return true;
 }
@@ -2027,7 +2027,7 @@ _equalAExpr(A_Expr *a, A_Expr *b)
 	COMPARE_NODE_FIELD(name);
 	COMPARE_NODE_FIELD(lexpr);
 	COMPARE_NODE_FIELD(rexpr);
-	COMPARE_SCALAR_FIELD(location);
+	COMPARE_LOCATION_FIELD(location);
 
 	return true;
 }
@@ -2036,7 +2036,7 @@ static bool
 _equalColumnRef(ColumnRef *a, ColumnRef *b)
 {
 	COMPARE_NODE_FIELD(fields);
-	COMPARE_SCALAR_FIELD(location);
+	COMPARE_LOCATION_FIELD(location);
 
 	return true;
 }
@@ -2072,7 +2072,7 @@ _equalFuncCall(FuncCall *a, FuncCall *b)
 	COMPARE_SCALAR_FIELD(agg_distinct);
 	COMPARE_SCALAR_FIELD(func_variadic);
 	COMPARE_NODE_FIELD(over);
-	COMPARE_SCALAR_FIELD(location);
+	COMPARE_LOCATION_FIELD(location);
 
 	return true;
 }
@@ -2110,7 +2110,7 @@ _equalResTarget(ResTarget *a, ResTarget *b)
 	COMPARE_STRING_FIELD(name);
 	COMPARE_NODE_FIELD(indirection);
 	COMPARE_NODE_FIELD(val);
-	COMPARE_SCALAR_FIELD(location);
+	COMPARE_LOCATION_FIELD(location);
 
 	return true;
 }
@@ -2126,7 +2126,7 @@ _equalTypeName(TypeName *a, TypeName *b)
 	COMPARE_NODE_FIELD(typmods);
 	COMPARE_SCALAR_FIELD(typemod);
 	COMPARE_NODE_FIELD(arrayBounds);
-	COMPARE_SCALAR_FIELD(location);
+	COMPARE_LOCATION_FIELD(location);
 
 	return true;
 }
@@ -2381,7 +2381,7 @@ _equalWithClause(WithClause *a, WithClause *b)
 {
 	COMPARE_NODE_FIELD(ctes);
 	COMPARE_SCALAR_FIELD(recursive);
-	COMPARE_SCALAR_FIELD(location);
+	COMPARE_LOCATION_FIELD(location);
 	
 	return true;
 }
@@ -2392,7 +2392,7 @@ _equalCommonTableExpr(CommonTableExpr *a, CommonTableExpr *b)
 	COMPARE_STRING_FIELD(ctename);
 	COMPARE_NODE_FIELD(aliascolnames);
 	COMPARE_NODE_FIELD(ctequery);
-	COMPARE_SCALAR_FIELD(location);
+	COMPARE_LOCATION_FIELD(location);
 	COMPARE_SCALAR_FIELD(cterecursive);
 	COMPARE_SCALAR_FIELD(cterefcount);
 	COMPARE_NODE_FIELD(ctecolnames);

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -1503,9 +1503,6 @@ transformSelectStmt(ParseState *pstate, SelectStmt *stmt)
 	/* process the FROM clause */
 	transformFromClause(pstate, stmt->fromClause);
 
-	/* tidy up expressions in window clauses */
-	transformWindowDefExprs(pstate);
-
 	/* transform targetlist */
 	qry->targetList = transformTargetList(pstate, stmt->targetList);
 
@@ -1518,7 +1515,7 @@ transformSelectStmt(ParseState *pstate, SelectStmt *stmt)
 	/*
 	 * Initial processing of HAVING clause is just like WHERE clause.
 	 */
-	pstate->having_qual = transformWhereClause(pstate, stmt->havingClause,
+	qry->havingQual = transformWhereClause(pstate, stmt->havingClause,
 										   "HAVING");
 
     /*
@@ -1559,10 +1556,6 @@ transformSelectStmt(ParseState *pstate, SelectStmt *stmt)
 												stmt->scatterClause,
 												&qry->targetList);
 
-    /* Having clause */
-	qry->havingQual = pstate->having_qual;
-	pstate->having_qual = NULL;
-
 	qry->distinctClause = transformDistinctClause(pstate,
 												  stmt->distinctClause,
 												  &qry->targetList,
@@ -1578,6 +1571,8 @@ transformSelectStmt(ParseState *pstate, SelectStmt *stmt)
 	qry->windowClause = transformWindowDefinitions(pstate,
 												   pstate->p_windowdefs,
 												   &qry->targetList);
+
+	processExtendedGrouping(pstate, qry->havingQual, qry->windowClause, qry->targetList);
 
 	/* handle any SELECT INTO/CREATE TABLE AS spec */
 	qry->intoClause = NULL;

--- a/src/include/parser/parse_agg.h
+++ b/src/include/parser/parse_agg.h
@@ -22,8 +22,6 @@ extern void transformWindowFuncCall(ParseState *pstate, WindowRef *wind,
 
 extern void parseCheckAggregates(ParseState *pstate, Query *qry);
 extern void parseCheckWindowFuncs(ParseState *pstate, Query *qry);
-extern void transformWindowDef(ParseState *pstate, WindowDef *spec);
-extern void transformWindowDefExprs(ParseState *pstate);
 
 extern void build_aggregate_fnexprs(Oid *agg_input_types,
 						int agg_num_inputs,

--- a/src/include/parser/parse_clause.h
+++ b/src/include/parser/parse_clause.h
@@ -41,6 +41,8 @@ extern List *transformDistinctClause(ParseState *pstate, List *distinctlist,
 						List **targetlist, List **sortClause, List **groupClause);
 extern List *transformScatterClause(ParseState *pstate, List *scatterlist,
 									List **targetlist);
+extern void processExtendedGrouping(ParseState *pstate, Node *havingQual,
+									List *windowClause, List *targetlist);
 
 extern List *addAllTargetsToSortList(ParseState *pstate,
 						List *sortlist, List *targetlist,

--- a/src/include/parser/parse_node.h
+++ b/src/include/parser/parse_node.h
@@ -97,10 +97,11 @@ typedef struct ParseState
 	bool		p_is_update;
 	Relation	p_target_relation;
 	RangeTblEntry *p_target_rangetblentry;
-	Node       *having_qual; /* Having clause */
 	struct HTAB *p_namecache;  /* parse state object name cache */
 	bool        p_hasTblValueExpr;
 	bool        p_hasDynamicFunction; /* function w/unstable return type */
+
+	List	   *p_grp_tles;
 } ParseState;
 
 /* Support for parser_errposition_callback function */


### PR DESCRIPTION
This way we don't need the weird half-transformation of WindowDef's. Makes
things simpler.
