### PR TITLE
Fix assign_wal_consistency_checking function

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -7449,8 +7449,6 @@ assign_wal_consistency_checking(const char *newval, bool doit, GucSource source)
 		return NULL;
 	}
 
-	free(rawstring);
-
 	foreach(l, elemlist)
 	{
 		char	   *tok = (char *) lfirst(l);
@@ -7485,6 +7483,7 @@ assign_wal_consistency_checking(const char *newval, bool doit, GucSource source)
 		/* If a valid resource manager is found, check for the next one. */
 		if (!found)
 		{
+			free(rawstring);
 			list_free(elemlist);
 
 			ereport(GUC_complaint_elevel(source),
@@ -7494,6 +7493,7 @@ assign_wal_consistency_checking(const char *newval, bool doit, GucSource source)
 		}
 	}
 
+	free(rawstring);
 	list_free(elemlist);
 
 	if (doit)


### PR DESCRIPTION
It was noticed in CentOS 6 that the entries in the char* list would
become blank after freeing the raw string that is obtained from
setting the GUC wal_consistency_checking. We should free this string
only after we finish using it.

Authors: Jimmy Yih and Taylor Vesely