### PR TITLE
Using fault name instead of enum as the key of fault hash table

### DIFF
--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -3251,7 +3251,7 @@ static void processTransitionRequest_getFaultInjectStatus(void * buf, int *offse
 		return;
 	}
 
-	if (FaultInjector_IsFaultInjected(FaultInjectorIdentifierStringToEnum(faultName))) {
+	if (FaultInjector_IsFaultInjected(faultName)) {
 		isDone = true;
 	}
 
@@ -3289,9 +3289,10 @@ processTransitionRequest_faultInject(void * inputBuf, int *offsetPtr, int length
 	elog(DEBUG1, "FAULT INJECTED: Name %s Type %s, DDL %s, DB %s, Table %s, NumOccurrences %d  SleepTime %d",
 		 faultName, type, ddlStatement, databaseName, tableName, numOccurrences, sleepTimeSeconds );
 
+	strncpy(faultInjectorEntry.faultName, faultName, sizeof(faultInjectorEntry.faultName));
+	faultInjectorEntry.faultName[FAULT_NAME_MAX_LENGTH-1] = '\0';
 	faultInjectorEntry.faultInjectorIdentifier = FaultInjectorIdentifierStringToEnum(faultName);
-	if (faultInjectorEntry.faultInjectorIdentifier == FaultInjectorIdNotSpecified ||
-		faultInjectorEntry.faultInjectorIdentifier == FaultInjectorIdMax) {
+	if (faultInjectorEntry.faultInjectorIdentifier == FaultInjectorIdNotSpecified) {
 		ereport(COMMERROR, (errcode(ERRCODE_PROTOCOL_VIOLATION),
 							errmsg("could not recognize fault name")));
 

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -3289,8 +3289,7 @@ processTransitionRequest_faultInject(void * inputBuf, int *offsetPtr, int length
 	elog(DEBUG1, "FAULT INJECTED: Name %s Type %s, DDL %s, DB %s, Table %s, NumOccurrences %d  SleepTime %d",
 		 faultName, type, ddlStatement, databaseName, tableName, numOccurrences, sleepTimeSeconds );
 
-	strncpy(faultInjectorEntry.faultName, faultName, sizeof(faultInjectorEntry.faultName));
-	faultInjectorEntry.faultName[FAULT_NAME_MAX_LENGTH-1] = '\0';
+	strlcpy(faultInjectorEntry.faultName, faultName, sizeof(faultInjectorEntry.faultName));
 	faultInjectorEntry.faultInjectorIdentifier = FaultInjectorIdentifierStringToEnum(faultName);
 	if (faultInjectorEntry.faultInjectorIdentifier == FaultInjectorIdNotSpecified) {
 		ereport(COMMERROR, (errcode(ERRCODE_PROTOCOL_VIOLATION),

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -65,10 +65,10 @@ static void FiLockAcquire(void);
 static void FiLockRelease(void);
 
 static FaultInjectorEntry_s* FaultInjector_LookupHashEntry(
-								FaultInjectorIdentifier_e identifier);
+								const char* faultName);
 
 static FaultInjectorEntry_s* FaultInjector_InsertHashEntry(
-								FaultInjectorIdentifier_e identifier, 
+								const char* faultName,
 								bool	*exists);
 
 static int FaultInjector_NewHashEntry(
@@ -78,7 +78,7 @@ static int FaultInjector_UpdateHashEntry(
 								FaultInjectorEntry_s	*entry);
 
 static bool FaultInjector_RemoveHashEntry(
-								FaultInjectorIdentifier_e identifier);
+								const char* faultName);
 
 /*
  * NB: This list needs to be kept in sync with:
@@ -487,9 +487,9 @@ FaultInjector_ShmemInit(void)
 	faultInjectorShmem->faultInjectorSlots = 0;
 	
 	MemSet(&hash_ctl, 0, sizeof(hash_ctl));
-	hash_ctl.keysize = sizeof(int32);
+	hash_ctl.keysize = FAULT_NAME_MAX_LENGTH;
 	hash_ctl.entrysize = sizeof(FaultInjectorEntry_s);
-	hash_ctl.hash = int32_hash;
+	hash_ctl.hash = string_hash;
 	
 	faultInjectorShmem->hash = ShmemInitHash("fault injector hash",
 								   FAULTINJECTOR_MAX_SLOTS,
@@ -513,7 +513,22 @@ FaultInjector_InjectFaultIfSet(
 							   const char*					 databaseName,
 							   const char*					 tableName)
 {
+	return FaultInjector_InjectFaultNameIfSet(
+			FaultInjectorIdentifierEnumToString[identifier],
+			ddlStatement,
+			databaseName,
+			tableName);
 	
+}
+
+FaultInjectorType_e
+FaultInjector_InjectFaultNameIfSet(
+							   const char*				 faultName,
+							   DDLStatement_e			 ddlStatement,
+							   const char*				 databaseName,
+							   const char*				 tableName)
+{
+
 	FaultInjectorEntry_s   *entryShared, localEntry,
 						   *entryLocal = &localEntry;
 	char					databaseNameLocal[NAMEDATALEN];
@@ -543,7 +558,7 @@ FaultInjector_InjectFaultIfSet(
 
 	FiLockAcquire();
 
-	entryShared = FaultInjector_LookupHashEntry(identifier);
+	entryShared = FaultInjector_LookupHashEntry(faultName);
 
 	do
 	{
@@ -600,7 +615,7 @@ FaultInjector_InjectFaultIfSet(
 			ereport(LOG,
 					(errcode(ERRCODE_FAULT_INJECT),
 					 errmsg("fault triggered, fault name:'%s' fault type:'%s' ",
-							FaultInjectorIdentifierEnumToString[entryLocal->faultInjectorIdentifier],
+							entryLocal->faultName,
 							FaultInjectorTypeEnumToString[entryLocal->faultInjectorType])));	
 			
 			pg_usleep(entryLocal->sleepTime * 1000000L);
@@ -642,7 +657,7 @@ FaultInjector_InjectFaultIfSet(
 			ereport(LOG, 
 					(errcode(ERRCODE_FAULT_INJECT),
 					 errmsg("fault triggered, fault name:'%s' fault type:'%s' ",
-							FaultInjectorIdentifierEnumToString[entryLocal->faultInjectorIdentifier],
+							entryLocal->faultName,
 							FaultInjectorTypeEnumToString[entryLocal->faultInjectorType])));	
 			
 			break;
@@ -662,7 +677,7 @@ FaultInjector_InjectFaultIfSet(
 			ereport(FATAL, 
 					(errcode(ERRCODE_FAULT_INJECT),
 					 errmsg("fault triggered, fault name:'%s' fault type:'%s' ",
-							FaultInjectorIdentifierEnumToString[entryLocal->faultInjectorIdentifier],
+							entryLocal->faultName,
 							FaultInjectorTypeEnumToString[entryLocal->faultInjectorType])));	
 
 			break;
@@ -682,7 +697,7 @@ FaultInjector_InjectFaultIfSet(
 			ereport(PANIC, 
 					(errcode(ERRCODE_FAULT_INJECT),
 					 errmsg("fault triggered, fault name:'%s' fault type:'%s' ",
-							FaultInjectorIdentifierEnumToString[entryLocal->faultInjectorIdentifier],
+							entryLocal->faultName,
 							FaultInjectorTypeEnumToString[entryLocal->faultInjectorType])));	
 
 			break;
@@ -702,14 +717,14 @@ FaultInjector_InjectFaultIfSet(
 			ereport(ERROR, 
 					(errcode(ERRCODE_FAULT_INJECT),
 					 errmsg("fault triggered, fault name:'%s' fault type:'%s' ",
-							FaultInjectorIdentifierEnumToString[entryLocal->faultInjectorIdentifier],
+							entryLocal->faultName,
 							FaultInjectorTypeEnumToString[entryLocal->faultInjectorType])));	
 			break;
 		case FaultInjectorTypeInfiniteLoop:
 			ereport(LOG, 
 					(errcode(ERRCODE_FAULT_INJECT),
 					 errmsg("fault triggered, fault name:'%s' fault type:'%s' ",
-							FaultInjectorIdentifierEnumToString[entryLocal->faultInjectorIdentifier],
+							entryLocal->faultName,
 							FaultInjectorTypeEnumToString[entryLocal->faultInjectorType])));
 			if (entryLocal->faultInjectorIdentifier == FileRepImmediateShutdownRequested)
 				cnt = entryLocal->sleepTime;
@@ -734,7 +749,7 @@ FaultInjector_InjectFaultIfSet(
 			ereport(LOG, 
 					(errcode(ERRCODE_FAULT_INJECT),
 					 errmsg("fault triggered, fault name:'%s' fault type:'%s' ",
-							FaultInjectorIdentifierEnumToString[entryLocal->faultInjectorIdentifier],
+							entryLocal->faultName,
 							FaultInjectorTypeEnumToString[entryLocal->faultInjectorType])));							
 			break;
 			
@@ -745,10 +760,10 @@ FaultInjector_InjectFaultIfSet(
 			ereport(LOG, 
 					(errcode(ERRCODE_FAULT_INJECT),
 					 errmsg("fault triggered, fault name:'%s' fault type:'%s' ",
-							FaultInjectorIdentifierEnumToString[entryLocal->faultInjectorIdentifier],
+							entryLocal->faultName,
 							FaultInjectorTypeEnumToString[entryLocal->faultInjectorType])));	
 			
-			while ((entry = FaultInjector_LookupHashEntry(entryLocal->faultInjectorIdentifier)) != NULL &&
+			while ((entry = FaultInjector_LookupHashEntry(entryLocal->faultName)) != NULL &&
 				   entry->faultInjectorType != FaultInjectorTypeResume)
 			{
 				pg_usleep(1000000L);  // 1 sec
@@ -759,7 +774,7 @@ FaultInjector_InjectFaultIfSet(
 				ereport(LOG, 
 						(errcode(ERRCODE_FAULT_INJECT),
 						 errmsg("fault triggered, fault name:'%s' fault type:'%s' ",
-							FaultInjectorIdentifierEnumToString[entryLocal->faultInjectorIdentifier],
+							entryLocal->faultName,
 							FaultInjectorTypeEnumToString[entry->faultInjectorType])));	
 			}
 			else
@@ -767,7 +782,7 @@ FaultInjector_InjectFaultIfSet(
 				ereport(LOG, 
 						(errcode(ERRCODE_FAULT_INJECT),
 						 errmsg("fault 'NULL', fault name:'%s'  ",
-								FaultInjectorIdentifierEnumToString[entryLocal->faultInjectorIdentifier])));				
+								entryLocal->faultName)));
 
 				/*
 				 * Since the entry is gone already, we should NOT update
@@ -783,7 +798,7 @@ FaultInjector_InjectFaultIfSet(
 			ereport(LOG, 
 					(errcode(ERRCODE_FAULT_INJECT),
 					 errmsg("fault triggered, fault name:'%s' fault type:'%s' ",
-							FaultInjectorIdentifierEnumToString[entryLocal->faultInjectorIdentifier],
+							entryLocal->faultName,
 							FaultInjectorTypeEnumToString[entryLocal->faultInjectorType])));							
 			break;
 			
@@ -794,7 +809,7 @@ FaultInjector_InjectFaultIfSet(
 			ereport(LOG, 
 					(errcode(ERRCODE_FAULT_INJECT),
 					 errmsg("fault triggered, fault name:'%s' fault type:'%s' ",
-							FaultInjectorIdentifierEnumToString[entryLocal->faultInjectorIdentifier],
+							entryLocal->faultName,
 							FaultInjectorTypeEnumToString[entryLocal->faultInjectorType])));	
 
 			buffer = (char*) palloc(BLCKSZ);
@@ -812,7 +827,7 @@ FaultInjector_InjectFaultIfSet(
 			ereport(LOG, 
 					(errcode(ERRCODE_FAULT_INJECT),
 					 errmsg("unexpected error, fault triggered, fault name:'%s' fault type:'%s' ",
-							FaultInjectorIdentifierEnumToString[entryLocal->faultInjectorIdentifier],
+							entryLocal->faultName,
 							FaultInjectorTypeEnumToString[entryLocal->faultInjectorType])));	
 			
 			Assert(0);
@@ -836,7 +851,7 @@ FaultInjector_InjectFaultIfSet(
 			ereport(LOG,
 					(errcode(ERRCODE_FAULT_INJECT),
 					 errmsg("fault triggered, fault name:'%s' fault type:'%s' ",
-							FaultInjectorIdentifierEnumToString[entryLocal->faultInjectorIdentifier],
+							entryLocal->faultName,
 							FaultInjectorTypeEnumToString[entryLocal->faultInjectorType])));
 
 			InterruptPending = true;
@@ -849,7 +864,7 @@ FaultInjector_InjectFaultIfSet(
 			ereport(LOG,
 					(errcode(ERRCODE_FAULT_INJECT),
 					 errmsg("fault triggered, fault name:'%s' fault type:'%s' ",
-							FaultInjectorIdentifierEnumToString[entryLocal->faultInjectorIdentifier],
+							entryLocal->faultName,
 							FaultInjectorTypeEnumToString[entryLocal->faultInjectorType])));
 			QueryFinishPending = true;
 			break;
@@ -867,7 +882,7 @@ FaultInjector_InjectFaultIfSet(
 			ereport(PANIC,
 					(errcode(ERRCODE_FAULT_INJECT),
 					 errmsg("fault triggered, fault name:'%s' fault type:'%s' ",
-							FaultInjectorIdentifierEnumToString[entryLocal->faultInjectorIdentifier],
+							entryLocal->faultName,
 							FaultInjectorTypeEnumToString[entryLocal->faultInjectorType])));
 			break;
 		}
@@ -877,7 +892,7 @@ FaultInjector_InjectFaultIfSet(
 			ereport(LOG, 
 					(errcode(ERRCODE_FAULT_INJECT),
 					 errmsg("unexpected error, fault triggered, fault name:'%s' fault type:'%s' ",
-							FaultInjectorIdentifierEnumToString[entryLocal->faultInjectorIdentifier],
+							entryLocal->faultName,
 							FaultInjectorTypeEnumToString[entryLocal->faultInjectorType])));	
 			
 			Assert(0);
@@ -899,22 +914,21 @@ FaultInjector_InjectFaultIfSet(
  */
 static FaultInjectorEntry_s*
 FaultInjector_LookupHashEntry(
-							  FaultInjectorIdentifier_e identifier)
+							  const char* faultName)
 {
 	FaultInjectorEntry_s	*entry;
 	
 	Assert(faultInjectorShmem->hash != NULL);
-	
 	entry = (FaultInjectorEntry_s *) hash_search(
 												  faultInjectorShmem->hash, 
-												  (void *) &identifier, // key 
+												  (void *) faultName, // key
 												  HASH_FIND, 
 												  NULL);
 	
 	if (entry == NULL) {
 		ereport(DEBUG5,
 				(errmsg("FaultInjector_LookupHashEntry() could not find fault injection hash entry identifier:'%d' ",
-						identifier)));
+						FaultInjectorIdentifierStringToEnum(faultName))));
 	} 
 	
 	return entry;
@@ -925,7 +939,7 @@ FaultInjector_LookupHashEntry(
  */ 
 static FaultInjectorEntry_s*
 FaultInjector_InsertHashEntry(
-							FaultInjectorIdentifier_e identifier, 
+							const char* faultName,
 							bool	*exists)
 {
 	
@@ -933,13 +947,12 @@ FaultInjector_InsertHashEntry(
 	FaultInjectorEntry_s	*entry;
 
 	Assert(faultInjectorShmem->hash != NULL);
-	
 	entry = (FaultInjectorEntry_s *) hash_search(
 												  faultInjectorShmem->hash, 
-												  (void *) &identifier, // key
-												  HASH_ENTER_NULL, 
+												  (void *) faultName, // key
+												  HASH_ENTER_NULL,
 												  &foundPtr);
-	
+
 	if (entry == NULL) {
 		*exists = FALSE;
 		return entry;
@@ -953,7 +966,7 @@ FaultInjector_InsertHashEntry(
 	} else {
 		*exists = FALSE;
 	}
-	
+
 	return entry;
 }
 
@@ -962,17 +975,16 @@ FaultInjector_InsertHashEntry(
  */
 static bool
 FaultInjector_RemoveHashEntry(
-							  FaultInjectorIdentifier_e identifier)
+							  const char* faultName)
 {	
 	
 	FaultInjectorEntry_s	*entry;
 	bool					isRemoved = FALSE;
 	
 	Assert(faultInjectorShmem->hash != NULL);
-	
 	entry = (FaultInjectorEntry_s *) hash_search(
 												  faultInjectorShmem->hash, 
-												  (void *) &identifier, // key
+												  (void *) faultName, // key
 												  HASH_REMOVE, 
 												  NULL);
 	
@@ -980,7 +992,7 @@ FaultInjector_RemoveHashEntry(
 	{
 		ereport(LOG, 
 				(errmsg("fault removed, fault name:'%s' fault type:'%s' ",
-						FaultInjectorIdentifierEnumToString[entry->faultInjectorIdentifier],
+						entry->faultName,
 						FaultInjectorTypeEnumToString[entry->faultInjectorType])));							
 		
 		isRemoved = TRUE;
@@ -1009,7 +1021,7 @@ FaultInjector_NewHashEntry(
 		ereport(WARNING,
 				(errmsg("could not insert fault injection, no slots available"
 						"fault name:'%s' fault type:'%s' ",
-						FaultInjectorIdentifierEnumToString[entry->faultInjectorIdentifier],
+						entry->faultName,
 						FaultInjectorTypeEnumToString[entry->faultInjectorType])));
 		snprintf(entry->bufOutput, sizeof(entry->bufOutput), 
 				 "could not insert fault injection, max slots:'%d' reached",
@@ -1054,7 +1066,7 @@ FaultInjector_NewHashEntry(
 				ereport(WARNING,
 						(errmsg("could not insert fault injection, fault type not supported"
 								"fault name:'%s' fault type:'%s' ",
-								FaultInjectorIdentifierEnumToString[entry->faultInjectorIdentifier],
+								entry->faultName,
 								FaultInjectorTypeEnumToString[entry->faultInjectorType])));
 				snprintf(entry->bufOutput, sizeof(entry->bufOutput), 
 						 "could not insert fault injection, fault type not supported");
@@ -1093,7 +1105,7 @@ FaultInjector_NewHashEntry(
 				ereport(WARNING,
 						(errmsg("could not insert fault injection entry into table, segment not in primary role"
 								"fault name:'%s' fault type:'%s' ",
-								FaultInjectorIdentifierEnumToString[entry->faultInjectorIdentifier],
+								entry->faultName,
 								FaultInjectorTypeEnumToString[entry->faultInjectorType])));
 				snprintf(entry->bufOutput, sizeof(entry->bufOutput), 
 						 "could not insert fault injection, segment not in primary role");
@@ -1114,7 +1126,7 @@ FaultInjector_NewHashEntry(
 						(errmsg("could not insert fault injection entry into table, "
 								"segment not in primary or mirror role, "
 								"fault name:'%s' fault type:'%s' ",
-								FaultInjectorIdentifierEnumToString[entry->faultInjectorIdentifier],
+								entry->faultName,
 								FaultInjectorTypeEnumToString[entry->faultInjectorType])));
 				snprintf(entry->bufOutput, sizeof(entry->bufOutput), 
 						 "could not insert fault injection, segment not in primary or mirror role");
@@ -1138,7 +1150,7 @@ FaultInjector_NewHashEntry(
 						(errmsg("could not insert fault injection entry into table, "
 								"segment not in master role, "
 								"fault name:'%s' fault type:'%s' ",
-								FaultInjectorIdentifierEnumToString[entry->faultInjectorIdentifier],
+								entry->faultName,
 								FaultInjectorTypeEnumToString[entry->faultInjectorType])));
 				snprintf(entry->bufOutput, sizeof(entry->bufOutput), 
 						 "could not insert fault injection, segment not in master role");
@@ -1200,7 +1212,7 @@ FaultInjector_NewHashEntry(
 						(errmsg("could not insert fault injection entry into table, "
 								"segment not in primary or master role, "
 								"fault name:'%s' fault type:'%s' ",
-								FaultInjectorIdentifierEnumToString[entry->faultInjectorIdentifier],
+								entry->faultName,
 								FaultInjectorTypeEnumToString[entry->faultInjectorType])));
 				snprintf(entry->bufOutput, sizeof(entry->bufOutput), 
 						 "could not insert fault injection, segment not in primary or master role");
@@ -1212,7 +1224,7 @@ FaultInjector_NewHashEntry(
 		default:
 			break;
 	}
-	entryLocal = FaultInjector_InsertHashEntry(entry->faultInjectorIdentifier, &exists);
+	entryLocal = FaultInjector_InsertHashEntry(entry->faultName, &exists);
 		
 	if (entryLocal == NULL) {
 		FiLockRelease();
@@ -1220,7 +1232,7 @@ FaultInjector_NewHashEntry(
 		ereport(WARNING,
 				(errmsg("could not insert fault injection entry into table, no memory, "
 						"fault name:'%s' fault type:'%s' ",
-						FaultInjectorIdentifierEnumToString[entry->faultInjectorIdentifier],
+						entry->faultName,
 						FaultInjectorTypeEnumToString[entry->faultInjectorType])));
 		snprintf(entry->bufOutput, sizeof(entry->bufOutput), 
 				 "could not insert fault injection, no memory");
@@ -1235,7 +1247,7 @@ FaultInjector_NewHashEntry(
 				(errmsg("could not insert fault injection entry into table, "
 						"entry already exists, "
 						"fault name:'%s' fault type:'%s' ",
-						FaultInjectorIdentifierEnumToString[entry->faultInjectorIdentifier],
+						entry->faultName,
 						FaultInjectorTypeEnumToString[entry->faultInjectorType])));
 		snprintf(entry->bufOutput, sizeof(entry->bufOutput), 
 				 "could not insert fault injection, entry already exists");
@@ -1244,7 +1256,9 @@ FaultInjector_NewHashEntry(
 	}
 		
 	entryLocal->faultInjectorType = entry->faultInjectorType;
-	
+	entryLocal->faultInjectorIdentifier = entry->faultInjectorIdentifier;
+	strncpy(entryLocal->faultName, entry->faultName, sizeof(entryLocal->faultName));
+
 	entryLocal->sleepTime = entry->sleepTime;
 	entryLocal->ddlStatement = entry->ddlStatement;
 	
@@ -1268,7 +1282,7 @@ FaultInjector_NewHashEntry(
 	FiLockRelease();
 	
 	elog(DEBUG1, "FaultInjector_NewHashEntry() identifier:'%s'", 
-		 FaultInjectorIdentifierEnumToString[entry->faultInjectorIdentifier]);
+		 entry->faultName);
 	
 exit:
 		
@@ -1288,7 +1302,7 @@ FaultInjector_UpdateHashEntry(
 
 	FiLockAcquire();
 
-	entryLocal = FaultInjector_LookupHashEntry(entry->faultInjectorIdentifier);
+	entryLocal = FaultInjector_LookupHashEntry(entry->faultName);
 	
 	if (entryLocal == NULL)
 	{
@@ -1298,7 +1312,7 @@ FaultInjector_UpdateHashEntry(
 				(errmsg("could not update fault injection hash entry with fault injection status, "
 						"no entry found, "
 						"fault name:'%s' fault type:'%s' ",
-						FaultInjectorIdentifierEnumToString[entry->faultInjectorIdentifier],
+						entry->faultName,
 						FaultInjectorTypeEnumToString[entry->faultInjectorType])));
 		goto exit;
 	}
@@ -1318,7 +1332,7 @@ FaultInjector_UpdateHashEntry(
 	ereport(DEBUG1,
 			(errmsg("LOG(fault injector): update fault injection hash entry "
 					"identifier:'%s' state:'%s' occurrence:'%d' ",
-					FaultInjectorIdentifierEnumToString[entry->faultInjectorIdentifier], 
+					entry->faultName,
 					FaultInjectorStateEnumToString[entryLocal->faultInjectorState],
 					entry->occurrence)));
 	
@@ -1352,7 +1366,7 @@ FaultInjector_SetFaultInjection(
 				FiLockAcquire();
 				
 				while ((entryLocal = (FaultInjectorEntry_s *) hash_seq_search(&hash_status)) != NULL) {
-					isRemoved = FaultInjector_RemoveHashEntry(entryLocal->faultInjectorIdentifier);
+					isRemoved = FaultInjector_RemoveHashEntry(entryLocal->faultName);
 					if (isRemoved == TRUE) {
 						faultInjectorShmem->faultInjectorSlots--;
 					}					
@@ -1363,7 +1377,7 @@ FaultInjector_SetFaultInjection(
 			else
 			{
 				FiLockAcquire();
-				isRemoved = FaultInjector_RemoveHashEntry(entry->faultInjectorIdentifier);
+				isRemoved = FaultInjector_RemoveHashEntry(entry->faultName);
 				if (isRemoved == TRUE) {
 					faultInjectorShmem->faultInjectorSlots--;
 				}
@@ -1374,7 +1388,7 @@ FaultInjector_SetFaultInjection(
 				ereport(DEBUG1,
 						(errmsg("LOG(fault injector): could not remove fault injection from hash"
 								"identifier:'%s' ",
-								FaultInjectorIdentifierEnumToString[entry->faultInjectorIdentifier])));
+								entry->faultName)));
 			}			
 			
 			break;
@@ -1414,7 +1428,7 @@ FaultInjector_SetFaultInjection(
 							"sleep time:'%d' "
 							"fault injection state:'%s' "
 							"num times hit:'%d' ",
-							FaultInjectorIdentifierEnumToString[entryLocal->faultInjectorIdentifier],
+							entryLocal->faultName,
 							FaultInjectorTypeEnumToString[entryLocal->faultInjectorType],
 							FaultInjectorDDLEnumToString[entryLocal->ddlStatement],
 							entryLocal->databaseName,
@@ -1437,7 +1451,7 @@ FaultInjector_SetFaultInjection(
 									  "sleep time:'%d' "
 									  "fault injection state:'%s'  "
 									  "num times hit:'%d' \n",
-									  FaultInjectorIdentifierEnumToString[entryLocal->faultInjectorIdentifier],
+									  entryLocal->faultName,
 									  FaultInjectorTypeEnumToString[entryLocal->faultInjectorType],
 									  FaultInjectorDDLEnumToString[entryLocal->ddlStatement],
 									  entryLocal->databaseName,
@@ -1452,7 +1466,7 @@ FaultInjector_SetFaultInjection(
 			if (found == FALSE) {
 				snprintf(entry->bufOutput, sizeof(entry->bufOutput), "Failure: "
 						 "fault name:'%s' not set",
-						 FaultInjectorIdentifierEnumToString[entry->faultInjectorIdentifier]);
+						 entry->faultName);
 			}
 			break;
 		}
@@ -1460,7 +1474,7 @@ FaultInjector_SetFaultInjection(
 			ereport(LOG, 
 					(errcode(ERRCODE_FAULT_INJECT),
 					 errmsg("fault triggered, fault name:'%s' fault type:'%s' ",
-							FaultInjectorIdentifierEnumToString[entry->faultInjectorIdentifier],
+							entry->faultName,
 							FaultInjectorTypeEnumToString[entry->faultInjectorType])));	
 			
 			FaultInjector_UpdateHashEntry(entry);	
@@ -1479,7 +1493,7 @@ FaultInjector_SetFaultInjection(
  */
 bool
 FaultInjector_IsFaultInjected(
-							  FaultInjectorIdentifier_e identifier)
+							  char* faultName)
 {
 	FaultInjectorEntry_s	*entry = NULL;
 	bool					isCompleted = FALSE;
@@ -1488,7 +1502,7 @@ FaultInjector_IsFaultInjected(
 		
 	FiLockAcquire();
 		
-	entry = FaultInjector_LookupHashEntry(identifier);
+	entry = FaultInjector_LookupHashEntry(faultName);
 		
 	if (entry == NULL) {
 		retval = TRUE;
@@ -1510,13 +1524,13 @@ FaultInjector_IsFaultInjected(
 		case FaultInjectorStateFailed:
 			
 			isCompleted = TRUE;
-			isRemoved = FaultInjector_RemoveHashEntry(identifier);
+			isRemoved = FaultInjector_RemoveHashEntry(faultName);
 			
 			if (isRemoved == FALSE) {
 				ereport(DEBUG1,
 						(errmsg("LOG(fault injector): could not remove fault injection from hash"
 								"identifier:'%s' ",
-								FaultInjectorIdentifierEnumToString[identifier])));
+								faultName)));
 			} else {
 				faultInjectorShmem->faultInjectorSlots--;
 			}
@@ -1532,7 +1546,7 @@ exit:
 	if ((isCompleted == TRUE) && (retval == FALSE)) {
 		ereport(WARNING,
 				(errmsg("could not complete fault injection, fault name:'%s' fault type:'%s' ",
-						FaultInjectorIdentifierEnumToString[identifier],
+						faultName,
 						FaultInjectorTypeEnumToString[entry->faultInjectorType])));
 	}
 	return isCompleted;

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -1257,7 +1257,7 @@ FaultInjector_NewHashEntry(
 		
 	entryLocal->faultInjectorType = entry->faultInjectorType;
 	entryLocal->faultInjectorIdentifier = entry->faultInjectorIdentifier;
-	strncpy(entryLocal->faultName, entry->faultName, sizeof(entryLocal->faultName));
+	strlcpy(entryLocal->faultName, entry->faultName, sizeof(entryLocal->faultName));
 
 	entryLocal->sleepTime = entry->sleepTime;
 	entryLocal->ddlStatement = entry->ddlStatement;

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -13,6 +13,8 @@
 
 #define FAULTINJECTOR_MAX_SLOTS	16
 
+#define FAULT_NAME_MAX_LENGTH	256
+
 /*
  *
  */
@@ -332,6 +334,8 @@ typedef enum FaultInjectorState_e {
  */
 typedef struct FaultInjectorEntry_s {
 	
+	char						faultName[FAULT_NAME_MAX_LENGTH];
+
 	FaultInjectorIdentifier_e	faultInjectorIdentifier;
 	
 	FaultInjectorType_e		faultInjectorType;
@@ -368,6 +372,12 @@ extern Size FaultInjector_ShmemSize(void);
 
 extern void FaultInjector_ShmemInit(void);
 
+extern FaultInjectorType_e FaultInjector_InjectFaultNameIfSet(
+							   const char*				 faultName,
+							   DDLStatement_e			 ddlStatement,
+							   const char*				 databaseName,
+							   const char*				 tableName);
+
 extern FaultInjectorType_e FaultInjector_InjectFaultIfSet(
 							   FaultInjectorIdentifier_e identifier,
 							   DDLStatement_e			 ddlStatement,
@@ -379,15 +389,17 @@ extern int FaultInjector_SetFaultInjection(
 
 
 extern bool FaultInjector_IsFaultInjected(
-							FaultInjectorIdentifier_e identifier);
+							char* faultName);
 
 
 #ifdef FAULT_INJECTOR
-#define SIMPLE_FAULT_INJECTOR(FaultName) \
-	FaultInjector_InjectFaultIfSet(FaultName, DDLNotSpecified, "", "")
-
+#define SIMPLE_FAULT_INJECTOR(FaultIdentifier) \
+	FaultInjector_InjectFaultIfSet(FaultIdentifier, DDLNotSpecified, "", "")
+#define SIMPLE_FAULT_NAME_INJECTOR(FaultName) \
+	FaultInjector_InjectFaultNameIfSet(FaultName, DDLNotSpecified, "", "")
 #else
-#define SIMPLE_FAULT_INJECTOR(FaultName)
+#define SIMPLE_FAULT_INJECTOR(FaultIdentifier)
+#define SIMPLE_FAULT_NAME_INJECTOR(FaultName)
 #endif
 
 #endif	/* FAULTINJECTOR_H */


### PR DESCRIPTION
GPDB fault injector uses fault enum as the key of fault hash table.
If someone wants to inject fault into gpdb extensions(a separate repo),
she has to hard code the extension related fault enums into gpdb core
code, this is not a good practice.
So we simply use fault name as the hash key to remove the need of hard
code the fault enum. Note that fault injector API doesn't change.