### PR TITLE
support AIX7 gpload regression tests

### DIFF
--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -366,6 +366,7 @@ define BUILD_STEPS
 	cd $(BUILDDIR)/src/bin/gpfdist && $(MAKE) install
 	@$(MAKE) mgmtcopy INSTLOC=$(INSTLOC)
 	@$(MAKE) copylibs INSTLOC=$(INSTLOC)
+	@$(MAKE) copydocs INSTLOC=$(INSTLOC)
 	@$(MAKE) clients INSTLOC=$(INSTLOC) CLIENTINSTLOC=$(CLIENTINSTLOC)
 	@$(MAKE) set_scripts_version INSTLOC=$(CLIENTINSTLOC)
 	if [ "$(findstring hpux_ia64,$(BLD_ARCH))" = "hpux_ia64" ]; then \
@@ -928,6 +929,7 @@ ifeq "$(findstring $(BLD_ARCH),$(GPPKG_PLATFORMS))" ""
 endif
 	cp -rp $(GPMGMT)/sbin/* $(INSTLOC)/sbin/.
 	cp $(GPPGDIR)/src/test/regress/*.pl $(INSTLOC)/bin
+	cp $(GPPGDIR)/src/test/regress/*.pm $(INSTLOC)/bin
 	if [ ! -d ${INSTLOC}/docs ] ; then mkdir ${INSTLOC}/docs ; fi
 	if [ -d $(GPMGMT)/doc ]; then cp -rp $(GPMGMT)/doc $(INSTLOC)/docs/cli_help; fi
 	if [ -d $(GPMGMT)/demo/gpmapreduce ]; then \

--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -62,7 +62,7 @@ pygresql:
 	if [ `uname -s` = 'HP-UX' ]; then \
 	    cd $(PYLIB_SRC)/$(PYGRESQL_DIR) && DESTDIR="$(DESTDIR)" CC="$(CC)" LDFLAGS="-L../../../../gpAux/ext/hpux_ia64/python-2.5.6/lib" python setup.py build; \
 	elif [ $(BLD_ARCH) = 'aix7_ppc_64' ]; then \
-	    cd $(PYLIB_SRC)/$(PYGRESQL_DIR) && DESTDIR="$(DESTDIR)" CC="$(CC)" python_64 setup.py build; \
+	    unset PYTHONPATH && cd $(PYLIB_SRC)/$(PYGRESQL_DIR) && DESTDIR="$(DESTDIR)" CC="$(CC)" python_64 setup.py build; \
 	else \
 	    cd $(PYLIB_SRC)/$(PYGRESQL_DIR) && DESTDIR="$(DESTDIR)" CC="$(CC)" python setup.py build; \
 	fi

--- a/gpMgmt/bin/generate-greenplum-path.sh
+++ b/gpMgmt/bin/generate-greenplum-path.sh
@@ -89,6 +89,18 @@ EOF
     fi
 fi
 
+# AIX uses yet another library path variable
+# Also, Python on AIX requires special copies of some libraries.  Hence, lib/pware.
+if [ "${PLAT}" = "AIX" ]; then
+cat <<EOF
+PYTHONPATH=\${GPHOME}/ext/python/lib/python2.7:\${PYTHONPATH}
+LIBPATH=\${GPHOME}/lib/pware:\${GPHOME}/lib:\${GPHOME}/ext/python/lib:/usr/lib/threads:\${LIBPATH}
+export LIBPATH
+GP_LIBPATH_FOR_PYTHON=\${GPHOME}/lib/pware
+export GP_LIBPATH_FOR_PYTHON
+EOF
+fi
+
 # openssl configuration file path
 cat <<EOF
 OPENSSL_CONF=\$GPHOME/etc/openssl.cnf


### PR DESCRIPTION
1. copy *test/regress/*.pm file to install locaiton to support
regression test diff
2. set LIBPATH and GP_LIBPATH_FOR_PYTHON env for AIX

Signed-off-by: Peifeng Qiu <pqiu@pivotal.io>