### PR TITLE
psql command `\dE` should show external tables only

### DIFF
--- a/src/bin/psql/command.c
+++ b/src/bin/psql/command.c
@@ -368,7 +368,7 @@ exec_command(const char *cmd,
 					success = describeTableDetails(pattern, show_verbose, show_system);
 				else
 					/* standard listing of interesting things */
-					success = listTables("tvsxr", NULL, show_verbose, show_system);
+					success = listTables("tvsEr", NULL, show_verbose, show_system);
 				break;
 			case 'a':
 				success = describeAggregates(pattern, show_verbose, show_system);

--- a/src/bin/psql/describe.c
+++ b/src/bin/psql/describe.c
@@ -3157,7 +3157,7 @@ listTables(const char *tabtypes, const char *pattern, bool verbose, bool showSys
 	bool		showIndexes = strchr(tabtypes, 'i') != NULL;
 	bool		showViews = strchr(tabtypes, 'v') != NULL;
 	bool		showSeq = strchr(tabtypes, 's') != NULL;
-	bool		showExternal = strchr(tabtypes, 'x') != NULL;
+	bool		showExternal = strchr(tabtypes, 'E') != NULL;
 
 	PQExpBufferData buf;
 	PGresult   *res;


### PR DESCRIPTION
'x' is eXtensions, 'E' is the External tables with the relstorage 'x'.