### PR TITLE
Shrink CI badges so mobile devices see more relevant content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-## Travis [![Travis Build Status](https://travis-ci.org/greenplum-db/gpdb.svg?branch=master)](https://travis-ci.org/greenplum-db/gpdb)
-
-## Concourse [![Concourse Build Status](https://gpdb.ci.pivotalci.info/api/v1/teams/gpdb/pipelines/gpdb_master/jobs/gpdb_rc_packaging_centos/badge)](https://gpdb.ci.pivotalci.info/teams/gpdb)
+**Concourse Pipeline** [![Concourse Build Status](https://gpdb.ci.pivotalci.info/api/v1/teams/gpdb/pipelines/gpdb_master/jobs/gpdb_rc_packaging_centos/badge)](https://gpdb.ci.pivotalci.info/teams/gpdb) |
+**Travis Build** [![Travis Build Status](https://travis-ci.org/greenplum-db/gpdb.svg?branch=master)](https://travis-ci.org/greenplum-db/gpdb)
 
 ----------------------------------------------------------------------
 


### PR DESCRIPTION
When I look at this repo on my phone, I don't see any relevant content in the preview of the readme because the CI badges took up the whole visual real-estate.

![screenshot_20170912-103228](https://user-images.githubusercontent.com/6885889/30340517-a03f2f5a-97a7-11e7-947b-35235d88b831.png)
