### PR TITLE
Fix Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,16 +59,14 @@ install:
 env:
   - APR=apr-1.6.2
     APR_UTIL=apr-util-1.6.0
-    APR_TAR=${APR}.tar.gz
-    APR_UTIL_TAR=${APR_UTIL}.tar.gz
 
 before_script:
   - export PATH=${TRAVIS_BUILD_DIR}/tools/bin:$PATH
   - cd ${TRAVIS_BUILD_DIR}
-  - wget http://ftp.jaist.ac.jp/pub/apache/apr/${APR_TAR}
-  - wget http://ftp.jaist.ac.jp/pub/apache/apr/${APR_UTIL_TAR}
-  - tar xf ${APR_TAR}
-  - tar xf ${APR_UTIL_TAR}
+  - wget http://ftp.jaist.ac.jp/pub/apache/apr/${APR}.tar.gz
+  - wget http://ftp.jaist.ac.jp/pub/apache/apr/${APR_UTIL}.tar.gz
+  - tar xf ${APR}.tar.gz
+  - tar xf ${APR_UTIL}.tar.gz
   - cd ${TRAVIS_BUILD_DIR}/${APR}
   - ./configure --prefix=${TRAVIS_BUILD_DIR}/tools
   - make install


### PR DESCRIPTION
It seems that we can no longer use ${} in the env var fields so remove
them to get our Travis builds green again.

Reference:
https://github.com/travis-ci/travis-build/commit/a6779473124442fa748795fa9fd47afc529fc9d4