### PR TITLE
Fix psql -l

### DIFF
--- a/src/bin/psql/describe.c
+++ b/src/bin/psql/describe.c
@@ -774,12 +774,15 @@ listAllDbs(bool verbose)
 					  gettext_noop("Name"),
 					  gettext_noop("Owner"),
 					  gettext_noop("Encoding"));
+/* GPDB_84_MERGE_FIXME: datcollate and datctype have not been added yet */
+#if 0
 	if (pset.sversion >= 80400)
 		appendPQExpBuffer(&buf,
 						  "       d.datcollate as \"%s\",\n"
 						  "       d.datctype as \"%s\",\n",
 						  gettext_noop("Collation"),
 						  gettext_noop("Ctype"));
+#endif
 	appendPQExpBuffer(&buf, "       ");
 	printACLColumn(&buf, "d.datacl");
 	if (verbose && pset.sversion >= 80200)


### PR DESCRIPTION
We are now on postgres 8.4 which apparently activated some conditional
statements in describe.c. This one was missed from the first 8.4 merge
chunk which makes psql -l currently error out.

Reported by Brian Lu in the Greenplum Developers mailing list:
https://groups.google.com/a/greenplum.org/forum/#!topic/gpdb-dev/5l7J2j5yla8