### PR TITLE
Backport gprecoverseg warnings 150458993 2

### DIFF
--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -286,7 +286,7 @@ class GpMirrorListToBuild:
 
         if len(self.__mirrorsToBuild) == 0:
             self.__logger.info("No segments to " + actionName)
-            return False    # as we don't want caller to print any success messages
+            return True
 
         self.checkForPortAndDirectoryConflicts(gpArray)
 

--- a/gpMgmt/bin/gppylib/programs/clsAddMirrors.py
+++ b/gpMgmt/bin/gppylib/programs/clsAddMirrors.py
@@ -663,7 +663,8 @@ class GpAddMirrorsProgram:
                     raise UserAbortedException()
 
             gpArray.setFaultStrategy(gparray.FAULT_STRATEGY_FILE_REPLICATION)
-            mirrorBuilder.buildMirrors("add", gpEnv, gpArray)
+            if not mirrorBuilder.buildMirrors("add", gpEnv, gpArray):
+                return 1
 
             logger.info("******************************************************************")
             logger.info("Mirror segments have been added; data synchronization is in progress.")

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -23,7 +23,8 @@ from optparse import OptionGroup
 import os, sys, signal, time
 from gppylib import gparray, gplog, userinput, utils
 from gppylib.util import gp_utils
-from gppylib.commands import base, gp, pg, unix
+from gppylib.commands import gp, pg, unix
+from gppylib.commands.base import Command, WorkerPool
 from gppylib.db import dbconn
 from gppylib.gpparseopts import OptParser, OptChecker
 from gppylib.operations.startSegments import *
@@ -34,10 +35,9 @@ from gppylib.programs.clsAddMirrors import validateFlexibleHeadersListAllFilespa
 from gppylib.system import configurationInterface as configInterface
 from gppylib.system.environment import GpMasterEnvironment
 from gppylib.testold.testUtils import *
-from gppylib.parseutils import line_reader, parse_filespace_order, parse_gprecoverseg_line, \
-    canonicalize_address
+from gppylib.parseutils import line_reader, parse_filespace_order, parse_gprecoverseg_line, canonicalize_address
 from gppylib.utils import ParsedConfigFile, ParsedConfigFileRow, writeLinesToFile, \
-    normalizeAndValidateInputPath, TableLogger
+     normalizeAndValidateInputPath, TableLogger
 from gppylib.gphostcache import GpInterfaceToHostNameCache
 from gppylib.operations.utils import ParallelOperation
 from gppylib.operations.package import SyncPackages
@@ -100,7 +100,7 @@ class PortAssigner:
 
 # -------------------------------------------------------------------------
 
-class RemoteQueryCommand(base.Command):
+class RemoteQueryCommand(Command):
     def __init__(self, qname, query, hostname, port, dbname=None):
         self.qname = qname
         self.query = query
@@ -1122,7 +1122,7 @@ class GpRecoverSegmentProgram:
             raise ProgramArgumentValidationException(
                 "Invalid parallelDegree provided with -B argument: %d" % self.__options.parallelDegree)
 
-        self.__pool = base.WorkerPool(self.__options.parallelDegree)
+        self.__pool = WorkerPool(self.__options.parallelDegree)
         gpEnv = GpMasterEnvironment(self.__options.masterDataDirectory, True)
 
         # verify "where to recover" options
@@ -1216,10 +1216,13 @@ class GpRecoverSegmentProgram:
                     if not userinput.ask_yesno(None, "\nContinue with segment rebalance procedure", 'N'):
                         raise UserAbortedException()
 
-                mirrorBuilder.rebalance()
-
+                fullRebalanceDone = mirrorBuilder.rebalance()
                 self.logger.info("******************************************************************")
-                self.logger.info("The rebalance operation has completed successfully.")
+                if fullRebalanceDone:
+                    self.logger.info("The rebalance operation has completed successfully.")
+                else:
+                    self.logger.info("The rebalance operation has completed with WARNINGS."
+                                     " Please review the output in the gprecoverseg log.")
                 self.logger.info("There is a resynchronization running in the background to bring all")
                 self.logger.info("segments in sync.")
                 self.logger.info("")
@@ -1245,7 +1248,8 @@ class GpRecoverSegmentProgram:
             if new_hosts:
                 self.syncPackages(new_hosts)
 
-            mirrorBuilder.buildMirrors("recover", gpEnv, gpArray)
+            if not mirrorBuilder.buildMirrors("recover", gpEnv, gpArray):
+                sys.exit(1)
 
             confProvider.sendPgElogFromMaster("Recovery of %d segment(s) has been started." % \
                                               len(mirrorBuilder.getMirrorsToBuild()), True)
@@ -1257,10 +1261,7 @@ class GpRecoverSegmentProgram:
             self.logger.info("Use  gpstate -s  to check the resynchronization progress.")
             self.logger.info("******************************************************************")
 
-        pidfile = os.path.join(gpEnv.getMasterDataDir(), 'gprecoverseg.pid')
-        if os.path.exists(pidfile):
-            os.remove(pidfile)
-        os._exit(0)
+        sys.exit(0)
 
     def validate_heap_checksum_consistency(self, gpArray, mirrorBuilder):
         live_segments = [target.getLiveSegment() for target in mirrorBuilder.getMirrorsToBuild()]

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_rebalance_segment.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_rebalance_segment.py
@@ -1,0 +1,76 @@
+from mock import *
+
+from gp_unittest import *
+from gppylib.gparray import GpArray, GpDB
+from gppylib.commands.base import CommandResult
+from gppylib.operations.rebalanceSegments import GpSegmentRebalanceOperation
+
+
+class RebalanceSegmentsTestCase(GpTestCase):
+    def setUp(self):
+        self.pool = Mock()
+        self.pool.getCompletedItems.return_value = []
+
+        self.apply_patches([
+            patch("gppylib.commands.base.WorkerPool.__init__", return_value=None),
+            patch("gppylib.commands.base.WorkerPool", return_value=self.pool),
+            patch('gppylib.programs.clsRecoverSegment.GpRecoverSegmentProgram'),
+        ])
+
+        self.mock_gp_recover_segment_prog_class = self.get_mock_from_apply_patch('GpRecoverSegmentProgram')
+        self.mock_parser = Mock()
+        self.mock_gp_recover_segment_prog_class.createParser.return_value = self.mock_parser
+        self.mock_parser.parse_args.return_value = (Mock(), Mock())
+        self.mock_gp_recover_segment_prog = Mock()
+        self.mock_gp_recover_segment_prog_class.createProgram.return_value = self.mock_gp_recover_segment_prog
+
+        self.failure_command_mock = Mock()
+        self.failure_command_mock.get_results.return_value = CommandResult(
+            1, "stdout failure text", "stderr text", True, False)
+
+        self.success_command_mock = Mock()
+        self.success_command_mock.get_results.return_value = CommandResult(
+            0, "stdout success text", "stderr text", True, False)
+
+        self.subject = GpSegmentRebalanceOperation(Mock(), self._create_gparray_with_2_primary_2_mirrors())
+        self.subject.logger = Mock()
+
+    def tearDown(self):
+        super(RebalanceSegmentsTestCase, self).tearDown()
+
+    def test_rebalance_returns_success(self):
+        self.pool.getCompletedItems.return_value = [self.success_command_mock]
+
+        result = self.subject.rebalance()
+
+        self.assertTrue(result)
+
+    def test_rebalance_raises(self):
+        self.pool.getCompletedItems.return_value = [self.failure_command_mock]
+        self.mock_gp_recover_segment_prog.run.side_effect = SystemExit(1)
+
+        with self.assertRaisesRegexp(Exception, "Error synchronizing."):
+            self.subject.rebalance()
+
+    def test_rebalance_returns_failure(self):
+        self.pool.getCompletedItems.side_effect = [[self.failure_command_mock], [self.success_command_mock]]
+
+        result = self.subject.rebalance()
+        self.assertFalse(result)
+
+    def _create_gparray_with_2_primary_2_mirrors(self):
+        master = GpDB.initFromString(
+            "1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
+        self.primary0 = GpDB.initFromString(
+            "2|0|p|p|s|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
+        primary1 = GpDB.initFromString(
+            "3|1|p|p|s|u|sdw2|sdw2|40001|41001|/data/primary1||/data/primary1/base/10899,/data/primary1/base/1,/data/primary1/base/10898,/data/primary1/base/25780,/data/primary1/base/34782")
+        self.mirror0 = GpDB.initFromString(
+            "4|0|m|m|s|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
+        mirror1 = GpDB.initFromString(
+            "5|1|m|m|s|u|sdw1|sdw1|50001|51001|/data/mirror1||/data/mirror1/base/10899,/data/mirror1/base/1,/data/mirror1/base/10898,/data/mirror1/base/25780,/data/mirror1/base/34782")
+        return GpArray([master, self.primary0, primary1, self.mirror0, mirror1])
+
+
+if __name__ == '__main__':
+    run_tests()


### PR DESCRIPTION
This PR is to backport the following Pull Requests to 5X_STABLE:

https://github.com/greenplum-db/gpdb/pull/3165

https://github.com/greenplum-db/gpdb/pull/3203

Original commit messages are:

 Fix gprecoverseg recursive behavior (#3165)
    * whitespace reformat
    * gprecverseg unit test: remove redundancy
    * Fix gprecoverseg recursive behavior

    gprecoverseg called itself during a rebalance, through a Command object.
    But this command didn't signal failures through a non-zero ret-code. So
    the top-level gprecoverseg didn't check its stdout/stderr for error
    messages and didn't echo them to its own stdout, though they were being
    logged.

    This commit changes behavior so gprecoverseg make another object and
    invokes its run() method. Any errors are now shown to the user and
    logged.


buildMirrors: Do not error out if nothing to do.(#3203)

    In GpMirrorListToBuild.buildMirrors() if there are no mirrors to
    build, then return True, so that gprecoverseg returns a return code
    of 0.