### PR TITLE
Map GPOS severity level to GPDB Severity Levels

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("2.45.", GPORCA_VERSION_STRING, 5);
+return strncmp("2.46.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 2.45.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 2.46.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -12533,7 +12533,7 @@ int
 main ()
 {
 
-return strncmp("2.45.", GPORCA_VERSION_STRING, 5);
+return strncmp("2.46.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -12543,7 +12543,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 2.45.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 2.46.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -121,7 +121,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	@echo "Resolve finished";
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget -O - https://github.com/greenplum-db/gporca/releases/download/v2.45.1/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget -O - https://github.com/greenplum-db/gporca/releases/download/v2.46.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -156,7 +156,10 @@ CTranslatorUtils::Pdxltabdesc
 			// the fact that catalog tables (master-only) are not analyzed often and will result in Orca producing
 			// inferior plans.
 
-			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("Queries on master-only tables"));
+			GPOS_THROW_EXCEPTION(gpdxl::ExmaDXL, // ulMajor
+								 gpdxl::ExmiQuery2DXLUnsupportedFeature, // ulMinor
+								 CException::ExsevDebug1, // ulSeverityLevel mapped to GPDB severity level
+								 GPOS_WSZ_LIT("Queries on master-only tables"));
 		}
 
 	// add columns from md cache relation object to table descriptor

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -521,19 +521,27 @@ COptTasks::Execute
 	}
 	GPOS_CATCH_EX(ex)
 	{
-		LogErrorAndDelete(err_buf);
+		LogExceptionMessageAndDelete(err_buf, ex.UlSeverityLevel());
 		GPOS_RETHROW(ex);
 	}
 	GPOS_CATCH_END;
-	LogErrorAndDelete(err_buf);
+	LogExceptionMessageAndDelete(err_buf);
 }
 
 void
-COptTasks::LogErrorAndDelete(CHAR* err_buf) {
+COptTasks::LogExceptionMessageAndDelete(CHAR* err_buf, ULONG ulSeverityLevel)
+{
 
 	if ('\0' != err_buf[0])
 	{
-		elog(LOG, "%s", SzFromWsz((WCHAR *)err_buf));
+		int ulGpdbSeverityLevel;
+
+		if (ulSeverityLevel == CException::ExsevDebug1)
+			ulGpdbSeverityLevel = DEBUG1;
+		else
+			ulGpdbSeverityLevel = LOG;
+
+		elog(ulGpdbSeverityLevel, "%s", SzFromWsz((WCHAR *)err_buf));
 	}
 
 	pfree(err_buf);

--- a/src/include/gpopt/utils/COptTasks.h
+++ b/src/include/gpopt/utils/COptTasks.h
@@ -169,9 +169,9 @@ class COptTasks
 		static
 		void Execute ( void *(*pfunc) (void *), void *pfuncArg);
 
-		// print error and delete the given error buffer
+		// map GPOS log severity level to GPDB, print error and delete the given error buffer
 		static
-		void LogErrorAndDelete(CHAR* err_buf);
+		void LogExceptionMessageAndDelete(CHAR* err_buf, ULONG ulSeverityLevel=CException::ExsevInvalid);
 
 		// task that does the translation from xml to dxl to pplstmt
 		static


### PR DESCRIPTION
GPOS raises exception with different severity level, but
they were being logged to GPDB logs at LOG severity level.
This disabled users to not turn off logging for GPOS exceptions, unless
GPDB log setting was changed higher than LOG severity level.

This is the initial commit which introduces the functionality. If an
exception is created without the GPDB severity level, it will default to
LOG severity level in GPDB.

Signed-off-by: Jemish Patel <jpatel@pivotal.io>