### PR TITLE
Fix Bug: spi_execute assert fail when there's no query mem

### DIFF
--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -2063,7 +2063,10 @@ _SPI_assign_query_mem(QueryDesc * queryDesc)
 		{
 			queryDesc->plannedstmt->query_mem = SPI_GetMemoryReservation();
 		}
-		Assert(queryDesc->plannedstmt->query_mem > 0);
+		/*
+		 * queryDesc->plannedstmt->query_mem(uint64) can be 0 here.
+		 * And in such cases it will use work_mem to run the query.
+		 * */
 	}
 }
 

--- a/src/test/isolation2/expected/resgroup/resgroup_zero_workmem.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_zero_workmem.out
@@ -1,0 +1,36 @@
+CREATE TABLE test_zero_workmem(c int);
+CREATE
+INSERT INTO test_zero_workmem SELECT generate_series(1, 100);
+INSERT 100
+
+--This test intends to build a situation that query_mem = 0
+--and verify under such condition work_mem will be used.
+--It is designed to pass the test on concourse(3G RAM) and dev docker.
+CREATE RESOURCE GROUP rg_zero_workmem WITH (concurrency=25, cpu_rate_limit=10, memory_limit=1, memory_shared_quota=0, memory_spill_ratio=1);
+CREATE
+
+CREATE ROLE role_zero_workmem SUPERUSER RESOURCE GROUP rg_zero_workmem;
+CREATE
+SET ROLE TO role_zero_workmem;
+SET
+
+--test query that will use spi
+ANALYZE test_zero_workmem;
+ANALYZE
+
+--test normal DML
+SELECT count(*) FROM test_zero_workmem;
+count
+-----
+100  
+(1 row)
+
+--clean env
+SET ROLE to gpadmin;
+SET
+DROP TABLE test_zero_workmem;
+DROP
+DROP ROLE role_zero_workmem;
+DROP
+DROP RESOURCE GROUP rg_zero_workmem;
+DROP

--- a/src/test/isolation2/isolation2_resgroup_schedule
+++ b/src/test/isolation2/isolation2_resgroup_schedule
@@ -17,6 +17,7 @@ test: resgroup/resgroup_set_memory_spill_ratio
 test: resgroup/resgroup_func_concurrency
 
 # memory spill tests
+test: resgroup/resgroup_zero_workmem
 #test: resgroup/resgroup_memory_hashagg_spill
 #test: resgroup/resgroup_memory_hashjoin_spill
 test: resgroup/resgroup_memory_materialize_spill

--- a/src/test/isolation2/sql/resgroup/resgroup_zero_workmem.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_zero_workmem.sql
@@ -1,0 +1,23 @@
+CREATE TABLE test_zero_workmem(c int);
+INSERT INTO test_zero_workmem SELECT generate_series(1, 100);
+
+--This test intends to build a situation that query_mem = 0
+--and verify under such condition work_mem will be used.
+--It is designed to pass the test on concourse(3G RAM) and dev docker.
+CREATE RESOURCE GROUP rg_zero_workmem WITH
+(concurrency=25, cpu_rate_limit=10, memory_limit=1, memory_shared_quota=0, memory_spill_ratio=1);
+
+CREATE ROLE role_zero_workmem SUPERUSER RESOURCE GROUP rg_zero_workmem;
+SET ROLE TO role_zero_workmem;
+
+--test query that will use spi
+ANALYZE test_zero_workmem;
+
+--test normal DML
+SELECT count(*) FROM test_zero_workmem;
+
+--clean env
+SET ROLE to gpadmin;
+DROP TABLE test_zero_workmem;
+DROP ROLE role_zero_workmem;
+DROP RESOURCE GROUP rg_zero_workmem;


### PR DESCRIPTION
The user can config resgroup to make some query's query memory is zero.
In such cases, it will use work memory. We simply remove this assertion.