### PR TITLE
Fixed crash at copy report unexpected message type error

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -7105,9 +7105,12 @@ extract_line_buf(CopyState cstate)
 			lineno_delim = memchr(line_start, COPY_METADATA_DELIM,
 								  Min(32, cstate->line_buf.len));
 
-			value_len = lineno_delim - line_start + 1;
-			line_start += value_len;
-			line_buf = line_start;
+			if (lineno_delim && (lineno_delim != line_start))
+			{
+				value_len = lineno_delim - line_start + 1;
+				line_start += value_len;
+				line_buf = line_start;
+			}
 		}
 	}
 


### PR DESCRIPTION
Copied data will be transferred from master to segment with related line number meta info prefix. The valid format should be "{original_lineno_for_qe}^{line_buf_converted}^{line_buf.data}". However 
some error which is not related to copy operation may occurs during copy at this code point, the data stream includes one '^', it will lead to crash because search the second '^' return NULL pointer.

Because we can't reproduce this crash, and also it is hard to write a automatic test for it.