### PR TITLE
Rewrite the way a DTM initialization error is logged, to retain file & lineno.

### DIFF
--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -1478,18 +1478,13 @@ initTM(void)
 			}
 			PG_CATCH();
 			{
-				ErrorData *edata;
-
 				MemoryContextSwitchTo(oldcontext);
-				edata = CopyErrorData();
 
 				elog(LOG, "DTM initialization, caught exception: "
 						  "looking for failed segments.");
-				ereport(LOG,
-						(edata->message ? errmsg("%s", edata->message) : 0,
-						 edata->detail ? errdetail("%s", edata->detail) : 0,
-						 edata->hint ? errhint("%s", edata->hint) : 0));
-				FreeErrorData(edata);
+
+				/* Log the error. */
+				EmitErrorReport();
 				FlushErrorState();
 
 				/*


### PR DESCRIPTION
While working on the 8.4 merge, I had a bug that tripped an Insist inside
the PG_TRY-CATCH. That was very difficult to track down, because the way
the error is logged here. Using ereport() includes filename and line
number where it's re-emitted, not the original place. So all I got was
"Unexpected internal error" in the log, with meaningless filename & lineno.

This rewrites the way the error is reported so that it preserves the
original filename and line number. It will also use the original error
level and will preserve all the other fields.