### PR TITLE
Stop supporting SQL type aliases in ALTER TYPE SET DEFAULT ENCODING.

### DIFF
--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -7640,7 +7640,7 @@ opt_force:	FORCE									{  $$ = TRUE; }
  *
  * Used to set storage parameter defaults for types.
  */
-AlterTypeStmt: ALTER TYPE_P SimpleTypename SET DEFAULT ENCODING definition
+AlterTypeStmt: ALTER TYPE_P any_name SET DEFAULT ENCODING definition
 				{
 					AlterTypeStmt *n = makeNode(AlterTypeStmt);
 
@@ -7921,11 +7921,11 @@ AlterObjectSchemaStmt:
 					n->newschema = $6;
 					$$ = (Node *)n;
 				}
-			| ALTER TYPE_P SimpleTypename SET SCHEMA name
+			| ALTER TYPE_P any_name SET SCHEMA name
 				{
 					AlterObjectSchemaStmt *n = makeNode(AlterObjectSchemaStmt);
 					n->objectType = OBJECT_TYPE;
-					n->object = $3->names;
+					n->object = $3;
 					n->newschema = $6;
 					$$ = (Node *)n;
 				}
@@ -8030,11 +8030,11 @@ AlterOwnerStmt: ALTER AGGREGATE func_name aggr_args OWNER TO RoleId
 					n->newowner = $6;
 					$$ = (Node *)n;
 				}
-			| ALTER TYPE_P SimpleTypename OWNER TO RoleId
+			| ALTER TYPE_P any_name OWNER TO RoleId
 				{
 					AlterOwnerStmt *n = makeNode(AlterOwnerStmt);
 					n->objectType = OBJECT_TYPE;
-					n->object = $3->names;
+					n->object = $3;
 					n->newowner = $6;
 					$$ = (Node *)n;
 				}

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -2423,7 +2423,7 @@ typedef struct AlterOwnerStmt
 typedef struct AlterTypeStmt
 {
 	NodeTag		type;
-	TypeName   *typeName;
+	List	   *typeName;
 	List	   *encoding;
 } AlterTypeStmt;
 

--- a/src/test/regress/expected/column_compression.out
+++ b/src/test/regress/expected/column_compression.out
@@ -1768,9 +1768,13 @@ execute ccddlcheck;
 (1 row)
 
 drop table ccddl;
--- Ensure that we can handle the SQL types that are recognized by the parser
--- but are not represented in the catalog.
+-- We used to accept SQL standard aliases for the built-in types,
+-- like "character varying", "integer", before GPDB 6, but not anymore.
 alter type character varying set default encoding (compresstype=zlib);
+ERROR:  syntax error at or near "varying"
+LINE 1: alter type character varying set default encoding (compresst...
+                             ^
+alter type varchar set default encoding (compresstype=zlib);
 select typoptions from pg_type t, pg_type_encoding e where
   t.typname = 'varchar' and t.oid = e.typid;
                      typoptions                      
@@ -1779,6 +1783,8 @@ select typoptions from pg_type t, pg_type_encoding e where
 (1 row)
 
 alter type character set default encoding (compresstype=zlib);
+ERROR:  type "character" does not exist
+alter type bpchar set default encoding (compresstype=zlib);
 select typoptions from pg_type t, pg_type_encoding e where
   t.typname = 'bpchar' and t.oid = e.typid;
                      typoptions                      
@@ -1787,6 +1793,10 @@ select typoptions from pg_type t, pg_type_encoding e where
 (1 row)
 
 alter type timestamp with time zone set default encoding(compresstype=zlib);
+ERROR:  syntax error at or near "time"
+LINE 1: alter type timestamp with time zone set default encoding(com...
+                                  ^
+alter type timestamptz set default encoding (compresstype=zlib);
 select typoptions from pg_type t, pg_type_encoding e where
   t.typname = 'timestamptz' and t.oid = e.typid;
                      typoptions                      
@@ -1809,7 +1819,9 @@ select typoptions from pg_type t, pg_type_encoding e where
 -----------------------------------------------------------------------
 -- We should reject any extraneous type information during alter type
 alter type numeric(10, 2) set default encoding(compresstype=zlib);
-ERROR:  type precision cannot be specified when setting DEFAULT ENCODING
+ERROR:  syntax error at or near "("
+LINE 1: alter type numeric(10, 2) set default encoding(compresstype=...
+                          ^
 alter type int[2][3] set default encoding(compresstype=RLE_TYPE);
 ERROR:  syntax error at or near "["
 LINE 1: alter type int[2][3] set default encoding(compresstype=RLE_T...

--- a/src/test/regress/sql/column_compression.sql
+++ b/src/test/regress/sql/column_compression.sql
@@ -570,18 +570,23 @@ compresstype=none);
 execute ccddlcheck;
 drop table ccddl;
 
--- Ensure that we can handle the SQL types that are recognized by the parser
--- but are not represented in the catalog.
+-- We used to accept SQL standard aliases for the built-in types,
+-- like "character varying", "integer", before GPDB 6, but not anymore.
 alter type character varying set default encoding (compresstype=zlib);
+alter type varchar set default encoding (compresstype=zlib);
 
 select typoptions from pg_type t, pg_type_encoding e where
   t.typname = 'varchar' and t.oid = e.typid;
 
 alter type character set default encoding (compresstype=zlib);
+alter type bpchar set default encoding (compresstype=zlib);
+
 select typoptions from pg_type t, pg_type_encoding e where
   t.typname = 'bpchar' and t.oid = e.typid;
 
 alter type timestamp with time zone set default encoding(compresstype=zlib);
+alter type timestamptz set default encoding (compresstype=zlib);
+
 select typoptions from pg_type t, pg_type_encoding e where
   t.typname = 'timestamptz' and t.oid = e.typid;
 


### PR DESCRIPTION
This is a bit unfortunate, in case someone is using them. But as it happens,
we haven't even mentioned the ALTER TYPE SET DEFAULT ENCODING command
in the documentation, so there probably aren't many people using them,
and you can achieve the same thing by using the normal, non-alias, names
like "varchar" instead of "character varying".