### PR TITLE
Fix CURRENT OF to work with PL/pgSQL cursors.

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -249,7 +249,7 @@ CdbDispatchPlan(struct QueryDesc *queryDesc,
 		memcpy(stmt, queryDesc->plannedstmt, sizeof(PlannedStmt));
 		stmt->subplans = list_copy(stmt->subplans);
 
-		stmt->planTree = (Plan *) exec_make_plan_constant(stmt, is_SRI, &cursors);
+		stmt->planTree = (Plan *) exec_make_plan_constant(stmt, queryDesc->estate, is_SRI, &cursors);
 		queryDesc->plannedstmt = stmt;
 
 		queryDesc->ddesc->cursorPositions = (List *) copyObject(cursors);

--- a/src/backend/commands/portalcmds.c
+++ b/src/backend/commands/portalcmds.c
@@ -117,14 +117,6 @@ PerformCursorOpen(PlannedStmt *stmt, ParamListInfo params,
 
 	portal->is_extended_query = true; /* cursors run in extended query mode */
 
-	/* 
-	 * DeclareCursorStmt is a hybrid utility/select statement. Above, we've nullified
-	 * the utilityStmt within PlannedStmt so this appears like plain SELECT. As a consequence,
-	 * we lose access to the DeclareCursorStmt. To cope, we simply cover over the 
-	 * is_simply_updatable calculation for consumption by CURRENT OF constant folding.
-	 */
-	portal->is_simply_updatable = cstmt->is_simply_updatable;
-
 	/*----------
 	 * Also copy the outer portal's parameter list into the inner portal's
 	 * memory context.	We want to pass down the parameter values in case we

--- a/src/backend/executor/execCurrent.c
+++ b/src/backend/executor/execCurrent.c
@@ -90,7 +90,7 @@ execCurrentOf(CurrentOfExpr *cexpr,
 	else
 	{
 		getCurrentOf(cexpr, econtext, table_oid, current_tid,
-					 &current_gp_segment_id, &current_table_oid);
+					 &current_gp_segment_id, &current_table_oid, NULL);
 	}
 
 	/*
@@ -120,7 +120,8 @@ getCurrentOf(CurrentOfExpr *cexpr,
 			 Oid table_oid,
 			 ItemPointer current_tid,
 			 int *current_gp_segment_id,
-			 Oid *current_table_oid)
+			 Oid *current_table_oid,
+			 char **p_cursor_name)
 {
 	char	   *cursor_name;
 	char	   *table_name;
@@ -146,7 +147,7 @@ getCurrentOf(CurrentOfExpr *cexpr,
 		cursor_name = cexpr->cursor_name;
 	else
 	{
-		if (!econtext)
+		if (!econtext->ecxt_param_list_info)
 			elog(ERROR, "no cursor name information found");
 
 		cursor_name = fetch_param_value(econtext, cexpr->cursor_param);
@@ -186,7 +187,7 @@ getCurrentOf(CurrentOfExpr *cexpr,
 	 * cursor. This flag assures us that gp_segment_id, ctid, and tableoid (if necessary)
 	 * will be available as junk metadata, courtesy of preprocess_targetlist.
 	 */
-	if (!portal->is_simply_updatable)
+	if (!queryDesc->plannedstmt->simplyUpdatable)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_CURSOR_STATE),
 				 errmsg("cursor \"%s\" is not a simply updatable scan of table \"%s\"",
@@ -283,6 +284,9 @@ getCurrentOf(CurrentOfExpr *cexpr,
 					 errmsg("%s is not updatable",
 							get_rel_name_partition(*current_table_oid))));
 	}
+
+	if (p_cursor_name)
+		*p_cursor_name = pstrdup(cursor_name);
 }
 
 /*

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -102,6 +102,7 @@ _copyPlannedStmt(PlannedStmt *from)
 	COPY_SCALAR_FIELD(canSetTag);
 	COPY_SCALAR_FIELD(transientPlan);
 	COPY_SCALAR_FIELD(oneoffPlan);
+	COPY_SCALAR_FIELD(simplyUpdatable);
 	COPY_NODE_FIELD(planTree);
 	COPY_NODE_FIELD(rtable);
 	COPY_NODE_FIELD(resultRelations);
@@ -1982,8 +1983,9 @@ _copyCurrentOfExpr(CurrentOfExpr *from)
 {
 	CurrentOfExpr *newnode = makeNode(CurrentOfExpr);
 
-	COPY_STRING_FIELD(cursor_name);
 	COPY_SCALAR_FIELD(cvarno);
+	COPY_STRING_FIELD(cursor_name);
+	COPY_SCALAR_FIELD(cursor_param);
 	COPY_SCALAR_FIELD(target_relid);
 
 	return newnode;
@@ -3091,7 +3093,6 @@ _copyDeclareCursorStmt(DeclareCursorStmt *from)
 	COPY_STRING_FIELD(portalname);
 	COPY_SCALAR_FIELD(options);
 	COPY_NODE_FIELD(query);
-	COPY_SCALAR_FIELD(is_simply_updatable);
 
 	return newnode;
 }

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -671,9 +671,9 @@ _equalSetToDefault(SetToDefault *a, SetToDefault *b)
 static bool
 _equalCurrentOfExpr(CurrentOfExpr *a, CurrentOfExpr *b)
 {
+	COMPARE_SCALAR_FIELD(cvarno);
 	COMPARE_STRING_FIELD(cursor_name);
 	COMPARE_SCALAR_FIELD(cursor_param);
-	COMPARE_SCALAR_FIELD(cvarno);
 	COMPARE_SCALAR_FIELD(target_relid);
 
 	/* some attributes omitted as they're bound only just before executor dispatch */
@@ -1108,7 +1108,6 @@ _equalDeclareCursorStmt(DeclareCursorStmt *a, DeclareCursorStmt *b)
 	COMPARE_STRING_FIELD(portalname);
 	COMPARE_SCALAR_FIELD(options);
 	COMPARE_NODE_FIELD(query);
-	COMPARE_SCALAR_FIELD(is_simply_updatable);
 
 	return true;
 }

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -315,6 +315,7 @@ _outPlannedStmt(StringInfo str, PlannedStmt *node)
 	WRITE_BOOL_FIELD(canSetTag);
 	WRITE_BOOL_FIELD(transientPlan);
 	WRITE_BOOL_FIELD(oneoffPlan);
+	WRITE_BOOL_FIELD(simplyUpdatable);
 
 	WRITE_NODE_FIELD(planTree);
 
@@ -621,8 +622,9 @@ _outCurrentOfExpr(StringInfo str, CurrentOfExpr *node)
 {
 	WRITE_NODE_TYPE("CURRENTOFEXPR");
 
-	WRITE_STRING_FIELD(cursor_name);
 	WRITE_UINT_FIELD(cvarno);
+	WRITE_STRING_FIELD(cursor_name);
+	WRITE_INT_FIELD(cursor_param);
 	WRITE_OID_FIELD(target_relid);
 }
 

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -294,6 +294,7 @@ _outPlannedStmt(StringInfo str, PlannedStmt *node)
 	WRITE_BOOL_FIELD(canSetTag);
 	WRITE_BOOL_FIELD(transientPlan);
 	WRITE_BOOL_FIELD(oneoffPlan);
+	WRITE_BOOL_FIELD(simplyUpdatable);
 	WRITE_NODE_FIELD(planTree);
 	WRITE_NODE_FIELD(rtable);
 	WRITE_NODE_FIELD(resultRelations);
@@ -1631,8 +1632,9 @@ _outCurrentOfExpr(StringInfo str, CurrentOfExpr *node)
 {
 	WRITE_NODE_TYPE("CURRENTOFEXPR");
 
-	WRITE_STRING_FIELD(cursor_name);
 	WRITE_INT_FIELD(cvarno);
+	WRITE_STRING_FIELD(cursor_name);
+	WRITE_INT_FIELD(cursor_param);
 	WRITE_OID_FIELD(target_relid);
 
 	/* some attributes omitted as they're bound only just before executor dispatch */
@@ -3045,7 +3047,6 @@ _outDeclareCursorStmt(StringInfo str, DeclareCursorStmt *node)
 	WRITE_STRING_FIELD(portalname);
 	WRITE_INT_FIELD(options);
 	WRITE_NODE_FIELD(query);
-	WRITE_BOOL_FIELD(is_simply_updatable);
 }
 
 static void

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -261,8 +261,9 @@ _readCurrentOfExpr(void)
 {
 	READ_LOCALS(CurrentOfExpr);
 
-	READ_STRING_FIELD(cursor_name);
 	READ_UINT_FIELD(cvarno);
+	READ_STRING_FIELD(cursor_name);
+	READ_INT_FIELD(cursor_param);
 	READ_OID_FIELD(target_relid);
 
 	READ_DONE();
@@ -1429,6 +1430,7 @@ _readPlannedStmt(void)
 	READ_BOOL_FIELD(canSetTag);
 	READ_BOOL_FIELD(transientPlan);
 	READ_BOOL_FIELD(oneoffPlan);
+	READ_BOOL_FIELD(simplyUpdatable);
 	READ_NODE_FIELD(planTree);
 	READ_NODE_FIELD(rtable);
 	READ_NODE_FIELD(resultRelations);

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -373,7 +373,6 @@ _readDeclareCursorStmt(void)
 	READ_STRING_FIELD(portalname);
 	READ_INT_FIELD(options);
 	READ_NODE_FIELD(query);
-	READ_BOOL_FIELD(is_simply_updatable);
 
 	READ_DONE();
 }
@@ -387,9 +386,9 @@ _readCurrentOfExpr(void)
 {
 	READ_LOCALS(CurrentOfExpr);
 
+	READ_INT_FIELD(cvarno);
 	READ_STRING_FIELD(cursor_name);
 	READ_INT_FIELD(cursor_param);
-	READ_INT_FIELD(cvarno);
 	READ_OID_FIELD(target_relid);
 
 	/* some attributes omitted as they're bound only just before executor dispatch */

--- a/src/include/cdb/cdbmutate.h
+++ b/src/include/cdb/cdbmutate.h
@@ -15,6 +15,7 @@
 #ifndef CDBMUTATE_H
 #define CDBMUTATE_H
 
+#include "nodes/execnodes.h"
 #include "nodes/plannodes.h"
 #include "nodes/params.h"
 #include "nodes/relation.h"
@@ -58,8 +59,8 @@ extern void remove_unused_subplans(PlannerInfo *root, SubPlanWalkerContext *cont
 extern int32 cdbhash_const(Const *pconst, int iSegments);
 extern int32 cdbhash_const_list(List *plConsts, int iSegments);
 
-extern Node *exec_make_plan_constant(struct PlannedStmt *stmt, bool is_SRI, List **cursorPositions);
-extern Node *planner_make_plan_constant(struct PlannerInfo *root, Node *n, bool is_SRI);
+extern Node *exec_make_plan_constant(struct PlannedStmt *stmt, EState *estate,
+						bool is_SRI, List **cursorPositions);
 extern void remove_subquery_in_RTEs(Node *node);
 extern void fixup_subplans(Plan *plan, PlannerInfo *root, SubPlanWalkerContext *context);
 #endif   /* CDBMUTATE_H */

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -94,7 +94,8 @@ extern void getCurrentOf(CurrentOfExpr *cexpr,
 			  Oid table_oid,
 			  ItemPointer current_tid,
 			  int *current_gp_segment_id,
-			  Oid *current_table_oid);
+			  Oid *current_table_oid,
+			  char **cursor_name_p);
 extern bool execCurrentOf(CurrentOfExpr *cexpr,
 			  ExprContext *econtext,
 			  Oid table_oid,

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -2200,13 +2200,18 @@ typedef struct CommentStmt
 #define CURSOR_OPT_HOLD			0x0010	/* WITH HOLD */
 #define CURSOR_OPT_FAST_PLAN	0x0020	/* prefer fast-start plan */
 
+/*
+ * This is used to request the planner to create a plan that's updatable with
+ * CURRENT OF. It can be passed to SPI_prepare_cursor.
+ */
+#define CURSOR_OPT_UPDATABLE	0x0040	/* updateable with CURRENT OF, if possible */
+
 typedef struct DeclareCursorStmt
 {
 	NodeTag		type;
 	char	   *portalname;		/* name of the portal (cursor) */
 	int			options;		/* bitmask of options (see above) */
 	Node	   *query;			/* the raw SELECT query */
-	bool		is_simply_updatable;
 } DeclareCursorStmt;
 
 /* ----------------------

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -73,6 +73,8 @@ typedef struct PlannedStmt
 	bool		transientPlan;	/* redo plan when TransactionXmin changes? */
 	bool		oneoffPlan;		/* redo plan on every execution? */
 
+	bool		simplyUpdatable; /* can be used with CURRENT OF? */
+
 	struct Plan *planTree;		/* tree of Plan nodes */
 
 	List	   *rtable;			/* list of RangeTblEntry nodes */

--- a/src/include/nodes/relation.h
+++ b/src/include/nodes/relation.h
@@ -110,6 +110,7 @@ typedef struct PlannerGlobal
 
 	bool		transientPlan;	/* redo plan when TransactionXmin changes? */
 	bool		oneoffPlan;		/* redo plan on every execution? */
+	bool		simplyUpdatable; /* can be used with CURRENT OF? */
 
 	ApplyShareInputContext share;	/* workspace for GPDB plan sharing */
 

--- a/src/include/utils/portal.h
+++ b/src/include/utils/portal.h
@@ -188,7 +188,6 @@ typedef struct PortalData
 
 	/* MPP: is this portal a CURSOR, or protocol level portal? */
 	bool		is_extended_query; /* simple or extended query protocol? */
-	bool		is_simply_updatable;
 } PortalData;
 
 /*

--- a/src/pl/plpgsql/src/pl_exec.c
+++ b/src/pl/plpgsql/src/pl_exec.c
@@ -3124,7 +3124,7 @@ exec_stmt_open(PLpgSQL_execstate *estate, PLpgSQL_stmt_open *stmt)
 		 */
 		query = stmt->query;
 		if (query->plan == NULL)
-			exec_prepare_plan(estate, query, stmt->cursor_options);
+			exec_prepare_plan(estate, query, stmt->cursor_options | CURSOR_OPT_UPDATABLE);
 	}
 	else if (stmt->dynquery != NULL)
 	{
@@ -3161,7 +3161,7 @@ exec_stmt_open(PLpgSQL_execstate *estate, PLpgSQL_stmt_open *stmt)
 		 * Now we prepare a query plan for it and open a cursor
 		 * ----------
 		 */
-		curplan = SPI_prepare_cursor(querystr, 0, NULL, stmt->cursor_options);
+		curplan = SPI_prepare_cursor(querystr, 0, NULL, stmt->cursor_options | CURSOR_OPT_UPDATABLE);
 		if (curplan == NULL)
 			elog(ERROR, "SPI_prepare_cursor failed for \"%s\": %s",
 				 querystr, SPI_result_code_string(SPI_result));
@@ -3230,7 +3230,7 @@ exec_stmt_open(PLpgSQL_execstate *estate, PLpgSQL_stmt_open *stmt)
 
 		query = curvar->cursor_explicit_expr;
 		if (query->plan == NULL)
-			exec_prepare_plan(estate, query, curvar->cursor_options);
+			exec_prepare_plan(estate, query, curvar->cursor_options | CURSOR_OPT_UPDATABLE);
 	}
 
 	/* ----------

--- a/src/test/regress/expected/portals_updatable.out
+++ b/src/test/regress/expected/portals_updatable.out
@@ -808,3 +808,38 @@ DECLARE c CURSOR FOR SELECT * FROM aocotest;
 DELETE FROM aocotest WHERE CURRENT OF c;
 ERROR:  "aocotest" is not simply updatable
 ROLLBACK;
+--
+-- PL/pgSQL cursors
+--
+-- Test that cursors opened in PL/pgSQL can also be updated.
+-- (Not supported by ORCA, as of this writing.)
+create temp table uctest3 as
+  select n as i, n as j from generate_series(1, 5) n distributed randomly;
+create or replace function plpgsql_uc_test() returns void as $$
+declare
+  c cursor for select * from uctest3 where i = 3;
+  r record;
+begin
+  open c;
+  fetch c into r;
+  raise notice '%, %', r.i, r.j;
+  update uctest3 set i = i * 100, j = r.j * 2 where current of c;
+end;
+$$ language plpgsql;
+select plpgsql_uc_test();
+NOTICE:  3, 3
+ plpgsql_uc_test 
+-----------------
+ 
+(1 row)
+
+select * from uctest3;
+  i  | j 
+-----+---
+   4 | 4
+   5 | 5
+   2 | 2
+   1 | 1
+ 300 | 6
+(5 rows)
+

--- a/src/test/regress/expected/portals_updatable_optimizer.out
+++ b/src/test/regress/expected/portals_updatable_optimizer.out
@@ -808,3 +808,36 @@ DECLARE c CURSOR FOR SELECT * FROM aocotest;
 DELETE FROM aocotest WHERE CURRENT OF c;
 ERROR:  "aocotest" is not simply updatable
 ROLLBACK;
+--
+-- PL/pgSQL cursors
+--
+-- Test that cursors opened in PL/pgSQL can also be updated.
+-- (Not supported by ORCA, as of this writing.)
+create temp table uctest3 as
+  select n as i, n as j from generate_series(1, 5) n distributed randomly;
+create or replace function plpgsql_uc_test() returns void as $$
+declare
+  c cursor for select * from uctest3 where i = 3;
+  r record;
+begin
+  open c;
+  fetch c into r;
+  raise notice '%, %', r.i, r.j;
+  update uctest3 set i = i * 100, j = r.j * 2 where current of c;
+end;
+$$ language plpgsql;
+select plpgsql_uc_test();
+NOTICE:  3, 3
+ERROR:  cursor "c" is not a simply updatable scan of table "uctest3"
+CONTEXT:  SQL statement "update uctest3 set i = i * 100, j =  $1  * 2 where current of  $2 "
+PL/pgSQL function "plpgsql_uc_test" line 8 at SQL statement
+select * from uctest3;
+ i | j 
+---+---
+ 1 | 1
+ 3 | 3
+ 4 | 4
+ 5 | 5
+ 2 | 2
+(5 rows)
+


### PR DESCRIPTION
It only worked for cursors declared with DECLARE CURSOR, before. You got
an "there is no parameter $0" error if you tried. This moves the decision
on whether a plan is "simply updatable", from the parser to the planner.
Doing it in the parser was awkward, because we only want to do it for
queries that are used in a cursor, and for SPI queries, we don't know it
at that time yet.

For some reason, the copy, out, read-functions of CurrentOfExpr were missing
the cursor_param field. While we're at it, reorder the code to match
upstream.

This only makes the required changes to the Postgres planner. I'm not sure
what ORCA would need here, although all the existing test cases seem to
pass with ORCA too. Which is actually a bit surprising, since I don't see
how the simplyUpdatable flag can ever get set for ORCA-planned queries now,
nor do I see any code to tell ORCA to add the gp_segment_id and ctid junk
columns to the query. But ah well, if it works, that's good.

Fixes github issue #3292.