### PR TITLE
Incorrect Decorrelation results in wrong plan

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("2.44.", GPORCA_VERSION_STRING, 5);
+return strncmp("2.45.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 2.44.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 2.45.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -12533,7 +12533,7 @@ int
 main ()
 {
 
-return strncmp("2.44.", GPORCA_VERSION_STRING, 5);
+return strncmp("2.45.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -12543,7 +12543,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 2.44.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 2.45.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -121,7 +121,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	@echo "Resolve finished";
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget -O - https://github.com/greenplum-db/gporca/releases/download/v2.44.1/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget -O - https://github.com/greenplum-db/gporca/releases/download/v2.45.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -1265,27 +1265,27 @@ select C.j from C where not exists (select max(B.i) from B  where C.i = B.i offs
 (9 rows)
 
 explain select C.j from C where not exists (select rank() over (order by B.i) from B  where C.i = B.i) order by C.j;
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=4 width=4)
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324036.36 rows=9 width=4)
    Merge Key: c.j
-   ->  Sort  (cost=0.00..862.00 rows=2 width=4)
-         Sort Key: c.j
-         ->  Hash Left Anti Semi Join  (cost=0.00..862.00 rows=2 width=4)
-               Hash Cond: c.i = b.i
-               ->  Table Scan on c  (cost=0.00..431.00 rows=3 width=8)
-               ->  Hash  (cost=431.00..431.00 rows=6 width=4)
-                     ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=18 width=4)
-                           ->  Result  (cost=0.00..431.00 rows=2 width=4)
-                                 ->  Window  (cost=0.00..431.00 rows=2 width=4)
-                                       Order By: b.i
-                                       ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
-                                             Merge Key: b.i
-                                             ->  Sort  (cost=0.00..431.00 rows=2 width=4)
-                                                   Sort Key: b.i
-                                                   ->  Table Scan on b  (cost=0.00..431.00 rows=2 width=4)
- Settings:  optimizer=on
- Optimizer status: PQO version 2.34.0
+   ->  Result  (cost=0.00..1324036.36 rows=3 width=4)
+         ->  Sort  (cost=0.00..1324036.36 rows=3 width=4)
+               Sort Key: c.j
+               ->  Table Scan on c  (cost=0.00..1324036.36 rows=3 width=4)
+                     Filter: (subplan)
+                     SubPlan 1
+                       ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                             ->  Window  (cost=0.00..431.00 rows=1 width=4)
+                                   Order By: b.i
+                                   ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+                                         Sort Key: b.i
+                                         ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                                               Filter: $0 = b.i
+                                               ->  Materialize  (cost=0.00..431.00 rows=6 width=4)
+                                                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
+                                                           ->  Table Scan on b  (cost=0.00..431.00 rows=2 width=4)
+ Optimizer status: PQO version 2.44.0
 (19 rows)
 
 select C.j from C where not exists (select rank() over (order by B.i) from B  where C.i = B.i) order by C.j;


### PR DESCRIPTION
While attempting to decorrelate the subquery, we were
incorrectly pulling up the join before calculating the window function
of the results of the join. In cases where we have subqueries with
window function and the subquery has outer references we should not
attempt decorrelating it.

There are further optimization which can be done in case of existential
queries but this PR fixes the plan.

Signed-off-by: Jemish Patel <jpatel@pivotal.io>