### PR TITLE
Fix stanullfrac computation on column with all-wide values.

### DIFF
--- a/src/test/regress/expected/analyze.out
+++ b/src/test/regress/expected/analyze.out
@@ -791,6 +791,9 @@ select * from pg_stats where tablename like 'p3_sales%' order by tablename, attn
  public     | p3_sales  | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
 (5 rows)
 
+-- start_ignore
+DROP TABLE IF EXISTS p3_sales;
+-- end_ignore
 --
 -- Test statistics collection on very large datums. In the current implementation,
 -- they are left out of the sample, to avoid running out of memory for the main relation
@@ -823,6 +826,20 @@ SELECT schemaname, tablename, attname, null_frac, avg_width, n_distinct, most_co
  (1 row)
 
 DROP TABLE IF EXISTS foo_stats;
--- start_ignore
-DROP TABLE IF EXISTS p3_sales;
--- end_ignore
+-- Test the case that every value in a column is "very large".
+CREATE TABLE foo_stats (a text, b bytea, c varchar, d int) DISTRIBUTED RANDOMLY;
+alter table foo  alter column t set storage external;
+ERROR:  relation "foo" does not exist
+INSERT INTO foo_stats values (repeat('a', 100000), 'bbbbb2', 'cccc2', 3);
+INSERT INTO foo_stats values (repeat('b', 100000), 'bbbbb2', 'cccc2', 3);
+ANALYZE foo_stats;
+SELECT schemaname, tablename, attname, null_frac, avg_width, n_distinct, most_common_vals, most_common_freqs, histogram_bounds FROM pg_stats WHERE tablename='foo_stats' ORDER BY attname;
+ schemaname | tablename | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds 
+------------+-----------+---------+-----------+-----------+------------+------------------+-------------------+------------------
+ public     | foo_stats | a       |         0 |      1024 |          0 |                  |                   | 
+ public     | foo_stats | b       |         0 |         7 |       -0.5 | {bbbbb2}         | {1}               | 
+ public     | foo_stats | c       |         0 |         6 |       -0.5 | {cccc2}          | {1}               | 
+ public     | foo_stats | d       |         0 |         4 |       -0.5 | {3}              | {1}               | 
+(4 rows)
+
+DROP TABLE IF EXISTS foo_stats;

--- a/src/test/regress/sql/analyze.sql
+++ b/src/test/regress/sql/analyze.sql
@@ -364,6 +364,10 @@ analyze rootpartition p3_sales;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
 select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
 
+-- start_ignore
+DROP TABLE IF EXISTS p3_sales;
+-- end_ignore
+
 --
 -- Test statistics collection on very large datums. In the current implementation,
 -- they are left out of the sample, to avoid running out of memory for the main relation 
@@ -384,6 +388,11 @@ SELECT schemaname, tablename, attname, null_frac, avg_width, n_distinct, most_co
 SELECT schemaname, tablename, attname, null_frac, avg_width, n_distinct, most_common_vals, most_common_freqs, histogram_bounds FROM pg_stats WHERE tablename='expression_idx_foo_stats' ORDER BY attname;
 DROP TABLE IF EXISTS foo_stats;
 
--- start_ignore
-DROP TABLE IF EXISTS p3_sales;
--- end_ignore
+-- Test the case that every value in a column is "very large".
+CREATE TABLE foo_stats (a text, b bytea, c varchar, d int) DISTRIBUTED RANDOMLY;
+alter table foo  alter column t set storage external;
+INSERT INTO foo_stats values (repeat('a', 100000), 'bbbbb2', 'cccc2', 3);
+INSERT INTO foo_stats values (repeat('b', 100000), 'bbbbb2', 'cccc2', 3);
+ANALYZE foo_stats;
+SELECT schemaname, tablename, attname, null_frac, avg_width, n_distinct, most_common_vals, most_common_freqs, histogram_bounds FROM pg_stats WHERE tablename='foo_stats' ORDER BY attname;
+DROP TABLE IF EXISTS foo_stats;


### PR DESCRIPTION
If a the sample of a column consists entirely of "too wide" values, which
are left out of the sample when it's passed to the compute_stats function,
we pass an empty sample to it. The default compute_stats gets confused by
that, and computes the null fraction as 0 / 0 = NaN, so we end up storing
NaN as stanullfrac.

If all the values in the sample are wide values, then they're surely not
NULLs, so the right thing to do is to store stanullfrac = 0. That is a
bit non-linear with the normal compute_stats function, which effectively
treats too wide values as not existing at all, which artificially inflates
the null fraction. Another non-linear thing is that we store stawidth=1024
in this special case, but the normal computation again ignores the wide
values in computing stawidth. If we wanted to do something about that, we
should adjust the normal computation to take those wide values better into
account, but that's a different story, and now we at least won't store NaN
in stanullfrac any longer.

Fixes github issue #3259.