### PR TITLE
Create separate pipeline for NBU and DDBoost pipeline jobs

### DIFF
--- a/concourse/pipelines/nbu_ddboost_pipeline.yml
+++ b/concourse/pipelines/nbu_ddboost_pipeline.yml
@@ -1,0 +1,512 @@
+groups:
+- name: all
+  jobs:
+  - compile_gpdb_centos6
+  - compile_gpdb_centos7
+  - MU_check_centos
+  - gpdb_rc_packaging_centos
+  - DPM_netbackup77
+  - DPM_backup-restore-ddboost
+
+## ======================================================================
+## resources
+## ======================================================================
+
+resources:
+- name: gpdb_src
+  type: git
+  source:
+    branch: {{gpdb-git-branch}}
+    uri: {{gpdb-git-remote}}
+    ignore_paths:
+    - gpdb-doc/*
+    - README*
+
+- name: gpaddon_src
+  type: git
+  source:
+    branch: {{gpaddon-git-branch}}
+    private_key: {{gpaddon-git-key}}
+    uri: {{gpaddon-git-remote}}
+
+- name: pxf_src
+  type: git
+  source:
+    branch: {{pxf-git-branch}}
+    private_key: {{pxf-git-key}}
+    uri: {{pxf-git-remote}}
+
+- name: centos-gpdb-dev-6
+  type: docker-image
+  source:
+    repository: pivotaldata/centos-gpdb-dev
+    tag: '6-gcc6.2-llvm3.7'
+
+- name: centos-gpdb-dev-7
+  type: docker-image
+  source:
+    repository: pivotaldata/centos-gpdb-dev
+    tag: 7-gcc6.2-llvm3.7
+
+- name: bin_gpdb_centos6
+  type: s3
+  source:
+    access_key_id: {{bucket-access-key-id}}
+    bucket: {{bucket-name}}
+    region_name: {{aws-region}}
+    secret_access_key: {{bucket-secret-access-key}}
+    versioned_file: {{bin_gpdb_centos_versioned_file}}
+
+- name: bin_gpdb_centos7
+  type: s3
+  source:
+    access_key_id: {{bucket-access-key-id}}
+    bucket: {{bucket-name}}
+    region_name: {{aws-region}}
+    secret_access_key: {{bucket-secret-access-key}}
+    versioned_file: {{bin_gpdb_centos7_versioned_file}}
+
+- name: installer_rhel6_gpdb_rc
+  type: s3
+  source:
+    access_key_id: {{bucket-access-key-id}}
+    bucket: {{bucket-name}}
+    region_name: {{aws-region}}
+    secret_access_key: {{bucket-secret-access-key}}
+    regexp: deliverables/software_only_installer/greenplum-db-(.*)-rhel6-x86_64.zip
+
+- name: installer_rhel6_gpdb_rc_sha256
+  type: s3
+  source:
+    access_key_id: {{bucket-access-key-id}}
+    bucket: {{bucket-name}}
+    region_name: {{aws-region}}
+    secret_access_key: {{bucket-secret-access-key}}
+    regexp: deliverables/software_only_installer/greenplum-db-(.*)-rhel6-x86_64.zip.sha256
+
+- name: installer_rhel7_gpdb_rc
+  type: s3
+  source:
+    access_key_id: {{bucket-access-key-id}}
+    bucket: {{bucket-name}}
+    region_name: {{aws-region}}
+    secret_access_key: {{bucket-secret-access-key}}
+    regexp: deliverables/software_only_installer/greenplum-db-(.*)-rhel7-x86_64.zip
+
+- name: installer_rhel7_gpdb_rc_sha256
+  type: s3
+  source:
+    access_key_id: {{bucket-access-key-id}}
+    bucket: {{bucket-name}}
+    region_name: {{aws-region}}
+    secret_access_key: {{bucket-secret-access-key}}
+    regexp: deliverables/software_only_installer/greenplum-db-(.*)-rhel7-x86_64.zip.sha256
+
+- name: installer_appliance_rhel6_gpdb_rc
+  type: s3
+  source:
+    access_key_id: {{bucket-access-key-id}}
+    bucket: {{bucket-name}}
+    region_name: {{aws-region}}
+    secret_access_key: {{bucket-secret-access-key}}
+    regexp: deliverables/appliance_installer/greenplum-db-appliance-(.*)-rhel6-x86_64.zip
+
+- name: installer_appliance_rhel6_gpdb_rc_sha256
+  type: s3
+  source:
+    access_key_id: {{bucket-access-key-id}}
+    bucket: {{bucket-name}}
+    region_name: {{aws-region}}
+    secret_access_key: {{bucket-secret-access-key}}
+    regexp: deliverables/appliance_installer/greenplum-db-appliance-(.*)-rhel6-x86_64.zip.sha256
+
+- name: installer_rhel6_gpdb_clients
+  type: s3
+  source:
+    access_key_id: {{bucket-access-key-id}}
+    bucket: {{bucket-name}}
+    region_name: {{aws-region}}
+    secret_access_key: {{bucket-secret-access-key}}
+    regexp: deliverables/greenplum-clients-5.(.*)-rhel6-x86_64.zip
+
+- name: installer_rhel6_gpdb_loaders
+  type: s3
+  source:
+    access_key_id: {{bucket-access-key-id}}
+    bucket: {{bucket-name}}
+    region_name: {{aws-region}}
+    secret_access_key: {{bucket-secret-access-key}}
+    regexp: deliverables/greenplum-loaders-5.(.*)-rhel6-x86_64.zip
+
+- name: installer_appliance_rhel7_gpdb_rc
+  type: s3
+  source:
+    access_key_id: {{bucket-access-key-id}}
+    bucket: {{bucket-name}}
+    region_name: {{aws-region}}
+    secret_access_key: {{bucket-secret-access-key}}
+    regexp: deliverables/appliance_installer/greenplum-db-appliance-(.*)-rhel7-x86_64.zip
+
+- name: installer_appliance_rhel7_gpdb_rc_sha256
+  type: s3
+  source:
+    access_key_id: {{bucket-access-key-id}}
+    bucket: {{bucket-name}}
+    region_name: {{aws-region}}
+    secret_access_key: {{bucket-secret-access-key}}
+    regexp: deliverables/appliance_installer/greenplum-db-appliance-(.*)-rhel7-x86_64.zip.sha256
+
+- name: installer_rhel7_gpdb_clients
+  type: s3
+  source:
+    access_key_id: {{bucket-access-key-id}}
+    bucket: {{bucket-name}}
+    region_name: {{aws-region}}
+    secret_access_key: {{bucket-secret-access-key}}
+    regexp: deliverables/greenplum-clients-5.(.*)-rhel7-x86_64.zip
+
+- name: installer_rhel7_gpdb_loaders
+  type: s3
+  source:
+    access_key_id: {{bucket-access-key-id}}
+    bucket: {{bucket-name}}
+    region_name: {{aws-region}}
+    secret_access_key: {{bucket-secret-access-key}}
+    regexp: deliverables/greenplum-loaders-5.(.*)-rhel7-x86_64.zip
+
+- name: qautils_rhel6_tarball
+  type: s3
+  source:
+    access_key_id: {{bucket-access-key-id}}
+    bucket: {{bucket-name}}
+    region_name: {{aws-region}}
+    secret_access_key: {{bucket-secret-access-key}}
+    versioned_file: deliverables/QAUtils-rhel6-x86_64.tar.gz
+
+- name: qautils_rhel7_tarball
+  type: s3
+  source:
+    access_key_id: {{bucket-access-key-id}}
+    bucket: {{bucket-name}}
+    region_name: {{aws-region}}
+    secret_access_key: {{bucket-secret-access-key}}
+    versioned_file: deliverables/QAUtils-rhel7-x86_64.tar.gz
+
+- name: gpdb_src_tinc_tarball
+  type: s3
+  source:
+    access_key_id: {{bucket-access-key-id}}
+    bucket: {{bucket-name}}
+    region_name: {{aws-region}}
+    secret_access_key: {{bucket-secret-access-key}}
+    regexp: deliverables/greenplum-db-(.*)-src.tar.gz
+
+- name: gpdb_src_behave_tarball
+  type: s3
+  source:
+    access_key_id: {{bucket-access-key-id}}
+    bucket: {{bucket-name}}
+    region_name: {{aws-region}}
+    secret_access_key: {{bucket-secret-access-key}}
+    regexp: deliverables/greenplum-db-(.*)-behave.tar.gz
+
+- name: nightly-trigger
+  type: time
+  source:
+    location: America/Los_Angeles
+    days: [Sunday, Monday, Tuesday, Wednesday, Thursday, Friday]
+    start: 6:00 AM
+    stop: 7:00 AM
+
+## ======================================================================
+## jobs
+## ======================================================================
+
+# Stage 1: Build and C Unit Tests
+
+jobs:
+
+- name: compile_gpdb_centos6
+  plan:
+  - aggregate:
+    - get: nightly-trigger
+      trigger: true
+    - get: gpdb_src
+    - get: gpaddon_src
+    - get: pxf_src
+    - get: centos-gpdb-dev-6
+  - task: compile_gpdb
+    file: gpdb_src/concourse/tasks/compile_gpdb.yml
+    image: centos-gpdb-dev-6
+    params:
+      IVYREPO_HOST: {{ivyrepo_host}}
+      IVYREPO_REALM: {{ivyrepo_realm}}
+      IVYREPO_USER: {{ivyrepo_user}}
+      IVYREPO_PASSWD: {{ivyrepo_passwd}}
+      CONFIGURE_FLAGS: {{configure_flags}}
+      TARGET_OS: centos
+      TARGET_OS_VERSION: 6
+      BLD_TARGETS: "clients loaders"
+  - aggregate:
+    - put: bin_gpdb_centos6
+      params:
+        file: gpdb_artifacts/bin_gpdb.tar.gz
+    - put: installer_rhel6_gpdb_clients
+      params:
+        file: gpdb_artifacts/greenplum-clients-*-rhel6-x86_64.zip
+    - put: installer_rhel6_gpdb_loaders
+      params:
+        file: gpdb_artifacts/greenplum-loaders-*-rhel6-x86_64.zip
+
+- name: compile_gpdb_centos7
+  plan:
+  - aggregate:
+    - get: nightly-trigger
+      trigger: true
+    - get: gpdb_src
+    - get: gpaddon_src
+    - get: pxf_src
+    - get: centos-gpdb-dev-7
+  - task: compile_gpdb
+    image: centos-gpdb-dev-7
+    file: gpdb_src/concourse/tasks/compile_gpdb.yml
+    params:
+      IVYREPO_HOST: {{ivyrepo_host}}
+      IVYREPO_REALM: {{ivyrepo_realm}}
+      IVYREPO_USER: {{ivyrepo_user}}
+      IVYREPO_PASSWD: {{ivyrepo_passwd}}
+      CONFIGURE_FLAGS: {{configure_flags}}
+      TARGET_OS: centos
+      TARGET_OS_VERSION: 7
+      BLD_TARGETS: "clients loaders"
+  - aggregate:
+    - put: bin_gpdb_centos7
+      params:
+        file: gpdb_artifacts/bin_gpdb.tar.gz
+    - put: installer_rhel7_gpdb_clients
+      params:
+        file: gpdb_artifacts/greenplum-clients-*-rhel7-x86_64.zip
+    - put: installer_rhel7_gpdb_loaders
+      params:
+        file: gpdb_artifacts/greenplum-loaders-*-rhel7-x86_64.zip
+
+- name: MU_check_centos
+  plan:
+  - aggregate:
+    - get: gpdb_src
+      passed: [compile_gpdb_centos6]
+    - get: bin_gpdb
+      resource: bin_gpdb_centos6
+      passed: [compile_gpdb_centos6]
+      trigger: true
+    - get: centos-gpdb-dev-6
+  - task: MU_check_centos
+    file: gpdb_src/concourse/tasks/gpMgmt_check_gpdb.yml
+    image: centos-gpdb-dev-6
+    params:
+      TEST_OS: centos
+
+# Stage 2b: Packaging
+
+- name: gpdb_rc_packaging_centos
+  plan:
+  - aggregate:
+    - get: gpdb_src
+      passed:
+      - compile_gpdb_centos6
+      - compile_gpdb_centos7
+    - get: gpaddon_src
+      passed: [compile_gpdb_centos6]
+    - get: bin_gpdb_centos6
+      passed: [compile_gpdb_centos6]
+      trigger: true
+    - get: bin_gpdb_centos7
+      passed: [compile_gpdb_centos7]
+      trigger: true
+    - get: centos-gpdb-dev-6
+    - get: centos-gpdb-dev-7
+  - task: separate_qautils_files_for_rc_centos6
+    file: gpdb_src/concourse/tasks/separate_qautils_files_for_rc.yml
+    image: centos-gpdb-dev-6
+    input_mapping:
+      bin_gpdb: bin_gpdb_centos6
+    output_mapping:
+      rc_bin_gpdb: rc_bin_gpdb_rhel6
+    params:
+      QAUTILS_TARBALL: rc_bin_gpdb/QAUtils-rhel6-x86_64.tar.gz
+
+  - task: separate_qautils_files_for_rc_centos7
+    file: gpdb_src/concourse/tasks/separate_qautils_files_for_rc.yml
+    image: centos-gpdb-dev-7
+    input_mapping:
+      bin_gpdb: bin_gpdb_centos7
+    output_mapping:
+      rc_bin_gpdb: rc_bin_gpdb_rhel7
+    params:
+      QAUTILS_TARBALL: rc_bin_gpdb/QAUtils-rhel7-x86_64.tar.gz
+
+  - task: gpdb_src_tinc_packaging
+    file: gpdb_src/concourse/tasks/gpdb_src_tinc_packaging.yml
+    image: centos-gpdb-dev-6
+    input_mapping:
+      bin_gpdb: bin_gpdb_centos6
+    output_mapping:
+      rc_bin_gpdb: packaged_gpdb_src_tinc
+    params:
+      GPDB_SRC_TAR_GZ: rc_bin_gpdb/greenplum-db-@GP_VERSION@-src.tar.gz
+
+  - task: gpdb_src_behave_packaging
+    file: gpdb_src/concourse/tasks/gpdb_src_behave_packaging.yml
+    image: centos-gpdb-dev-6
+    input_mapping:
+      bin_gpdb: bin_gpdb_centos6
+    output_mapping:
+      rc_bin_gpdb: packaged_gpdb_src_behave
+    params:
+      GPDB_SRC_TAR_GZ: rc_bin_gpdb/greenplum-db-@GP_VERSION@-behave.tar.gz
+
+  - aggregate:
+    - task: gpdb_rc_packaging_centos6
+      file: gpdb_src/concourse/tasks/gpdb_packaging.yml
+      image: centos-gpdb-dev-6
+      input_mapping:
+        bin_gpdb: rc_bin_gpdb_rhel6
+      output_mapping:
+        packaged_gpdb: packaged_gpdb_rc_centos6
+      params:
+        INSTALL_SCRIPT_SRC: gpdb_src/gpAux/addon/license/installer-header-rhel-gpdb.sh
+        INSTALLER_ZIP: packaged_gpdb/greenplum-db-@GP_VERSION@-rhel6-x86_64.zip
+        ADD_README_INSTALL: true
+    - task: gpdb_appliance_rhel6_rc_packaging
+      file: gpdb_src/concourse/tasks/gpdb_packaging.yml
+      image: centos-gpdb-dev-6
+      input_mapping:
+        bin_gpdb: rc_bin_gpdb_rhel6
+      output_mapping:
+        packaged_gpdb: packaged_gpdb_appliance_rc_centos6
+      params:
+        INSTALL_SCRIPT_SRC: gpdb_src/gpAux/addon/license/installer-appliance-header-rhel-gpdb.sh
+        INSTALLER_ZIP: packaged_gpdb/greenplum-db-appliance-@GP_VERSION@-rhel6-x86_64.zip
+
+    - task: gpdb_rc_packaging_centos7
+      file: gpdb_src/concourse/tasks/gpdb_packaging.yml
+      image: centos-gpdb-dev-7
+      input_mapping:
+        bin_gpdb: rc_bin_gpdb_rhel7
+      output_mapping:
+        packaged_gpdb: packaged_gpdb_rc_centos7
+      params:
+        INSTALL_SCRIPT_SRC: gpdb_src/gpAux/addon/license/installer-header-rhel-gpdb.sh
+        INSTALLER_ZIP: packaged_gpdb/greenplum-db-@GP_VERSION@-rhel7-x86_64.zip
+        ADD_README_INSTALL: true
+    - task: gpdb_appliance_rhel7_rc_packaging
+      file: gpdb_src/concourse/tasks/gpdb_packaging.yml
+      image: centos-gpdb-dev-7
+      input_mapping:
+        bin_gpdb: rc_bin_gpdb_rhel7
+      output_mapping:
+        packaged_gpdb: packaged_gpdb_appliance_rc_centos7
+      params:
+        INSTALL_SCRIPT_SRC: gpdb_src/gpAux/addon/license/installer-appliance-header-rhel-gpdb.sh
+        INSTALLER_ZIP: packaged_gpdb/greenplum-db-appliance-@GP_VERSION@-rhel7-x86_64.zip
+  - aggregate:
+    # RHEL 6
+    - put: installer_rhel6_gpdb_rc
+      params:
+        file: packaged_gpdb_rc_centos6/greenplum-db-*-rhel6-x86_64.zip
+    - put: installer_rhel6_gpdb_rc_sha256
+      params:
+        file: packaged_gpdb_rc_centos6/greenplum-db-*-rhel6-x86_64.zip.sha256
+    - put: installer_appliance_rhel6_gpdb_rc
+      params:
+        file: packaged_gpdb_appliance_rc_centos6/greenplum-db-appliance-*-rhel6-x86_64.zip
+    - put: installer_appliance_rhel6_gpdb_rc_sha256
+      params:
+        file: packaged_gpdb_appliance_rc_centos6/greenplum-db-appliance-*-rhel6-x86_64.zip.sha256
+    - put: qautils_rhel6_tarball
+      params:
+        file: rc_bin_gpdb_rhel6/QAUtils-rhel6-x86_64.tar.gz
+
+    # RHEL 7
+    - put: installer_rhel7_gpdb_rc
+      params:
+        file: packaged_gpdb_rc_centos7/greenplum-db-*-rhel7-x86_64.zip
+    - put: installer_rhel7_gpdb_rc_sha256
+      params:
+        file: packaged_gpdb_rc_centos7/greenplum-db-*-rhel7-x86_64.zip.sha256
+    - put: installer_appliance_rhel7_gpdb_rc
+      params:
+        file: packaged_gpdb_appliance_rc_centos7/greenplum-db-appliance-*-rhel7-x86_64.zip
+    - put: installer_appliance_rhel7_gpdb_rc_sha256
+      params:
+        file: packaged_gpdb_appliance_rc_centos7/greenplum-db-appliance-*-rhel7-x86_64.zip.sha256
+    - put: qautils_rhel7_tarball
+      params:
+        file: rc_bin_gpdb_rhel7/QAUtils-rhel7-x86_64.tar.gz
+
+    # Source
+    - put: gpdb_src_tinc_tarball
+      params:
+        file: packaged_gpdb_src_tinc/greenplum-db-*-src.tar.gz
+    - put: gpdb_src_behave_tarball
+      params:
+        file: packaged_gpdb_src_behave/greenplum-db-*-behave.tar.gz
+
+# Stage 3: Trigger jobs that rely on packaging
+
+- name: DPM_netbackup77
+  plan:
+  - aggregate: &post_packaging_gets_trigger_true
+    - get: gpdb_src
+      params: {submodules: none}
+      tags: ["gpdb5-pulse-worker"]
+      passed: [gpdb_rc_packaging_centos]
+      trigger: true
+    - get: gpdb_src_tinc_tarball
+      tags: ["gpdb5-pulse-worker"]
+      passed: [gpdb_rc_packaging_centos]
+    - get: installer_rhel6_gpdb_rc
+      tags: ["gpdb5-pulse-worker"]
+      passed: [gpdb_rc_packaging_centos]
+    - get: qautils_rhel6_tarball
+      tags: ["gpdb5-pulse-worker"]
+      passed: [gpdb_rc_packaging_centos]
+    - get: gpdb_src_behave_tarball
+      tags: ["gpdb5-pulse-worker"]
+      passed: [gpdb_rc_packaging_centos]
+  - task: trigger_pulse
+    tags: ["gpdb5-pulse-worker"]
+    file: gpdb_src/ci/pulse/api/trigger_pulse.yml
+    input_mapping: &input_mappings
+      gpdb_src_archive: gpdb_src_tinc_tarball
+      installer_gpdb_rc: installer_rhel6_gpdb_rc
+      qautils_tarball: qautils_rhel6_tarball
+      gpdb_src_behave_tarball: gpdb_src_behave_tarball
+    params: &pulse_properties
+      PULSE_URL: {{pulse_url}}
+      PULSE_PROJECT_NAME: "GPDB-BehaveNetBackup77"
+      PULSE_USERNAME: {{pulse_username}}
+      PULSE_PASSWORD: {{pulse_password}}
+  - task: monitor_pulse
+    attempts: 2
+    tags: ["gpdb5-pulse-worker"]
+    file: gpdb_src/ci/pulse/api/monitor_pulse.yml
+    params: *pulse_properties
+
+- name: DPM_backup-restore-ddboost
+  plan:
+  - aggregate: *post_packaging_gets_trigger_true
+  - task: trigger_pulse
+    tags: ["gpdb5-pulse-worker"]
+    file: gpdb_src/ci/pulse/api/trigger_pulse.yml
+    input_mapping: *input_mappings
+    params:
+      <<: *pulse_properties
+      PULSE_PROJECT_NAME: "GPDB-BehaveBackupRestore_HarmonizeDDBoost"
+  - task: monitor_pulse
+    attempts: 2
+    tags: ["gpdb5-pulse-worker"]
+    file: gpdb_src/ci/pulse/api/monitor_pulse.yml
+    params:
+      <<: *pulse_properties
+      PULSE_PROJECT_NAME: "GPDB-BehaveBackupRestore_HarmonizeDDBoost"

--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -32,8 +32,6 @@ groups:
   - regression_tests_pxf_centos
   - gpdb_rc_packaging_centos
   - gpdb_rc_packaging_sles
-  - DPM_netbackup77
-  - DPM_backup-restore-ddboost
   - DPM_backup_43_restore_5
   - MM_gpcheckcat
   - MM_gprecoverseg
@@ -55,8 +53,6 @@ groups:
 
 - name: Remaining Pulse
   jobs:
-  - DPM_netbackup77
-  - DPM_backup-restore-ddboost
   - MM_gpcheckcat
   - MM_gpexpand
   - DPM_gptransfer-43x-to-5x
@@ -1458,69 +1454,6 @@ jobs:
     params:
       file: rc_bin_gpdb/QAUtils-sles11-x86_64.tar.gz
 
-# Stage 3: Trigger jobs that rely on packaging
-
-- name: DPM_netbackup77
-  plan:
-  - get: nightly-trigger
-    trigger: {{nightly-trigger-flag}}
-  - aggregate: &post_packaging_gets_trigger_based_on_flag
-    - get: gpdb_src
-      params: {submodules: none}
-      tags: ["gpdb5-pulse-worker"]
-      passed: [gpdb_rc_packaging_centos]
-      trigger: {{reduced-frequency-trigger-flag}}
-    - get: gpdb_src_tinc_tarball
-      tags: ["gpdb5-pulse-worker"]
-      passed: [gpdb_rc_packaging_centos]
-    - get: installer_rhel6_gpdb_rc
-      tags: ["gpdb5-pulse-worker"]
-      passed: [gpdb_rc_packaging_centos]
-    - get: qautils_rhel6_tarball
-      tags: ["gpdb5-pulse-worker"]
-      passed: [gpdb_rc_packaging_centos]
-    - get: gpdb_src_behave_tarball
-      tags: ["gpdb5-pulse-worker"]
-      passed: [gpdb_rc_packaging_centos]
-  - task: trigger_pulse
-    tags: ["gpdb5-pulse-worker"]
-    file: gpdb_src/ci/pulse/api/trigger_pulse.yml
-    input_mapping: &input_mappings
-      gpdb_src_archive: gpdb_src_tinc_tarball
-      installer_gpdb_rc: installer_rhel6_gpdb_rc
-      qautils_tarball: qautils_rhel6_tarball
-      gpdb_src_behave_tarball: gpdb_src_behave_tarball
-    params: &pulse_properties
-      PULSE_URL: {{pulse_url}}
-      PULSE_PROJECT_NAME: "GPDB-BehaveNetBackup77"
-      PULSE_USERNAME: {{pulse_username}}
-      PULSE_PASSWORD: {{pulse_password}}
-  - task: monitor_pulse
-    attempts: 2
-    tags: ["gpdb5-pulse-worker"]
-    file: gpdb_src/ci/pulse/api/monitor_pulse.yml
-    params: *pulse_properties
-
-- name: DPM_backup-restore-ddboost
-  plan:
-  - get: nightly-trigger
-    trigger: {{nightly-trigger-flag}}
-  - aggregate: *post_packaging_gets_trigger_based_on_flag
-  - task: trigger_pulse
-    tags: ["gpdb5-pulse-worker"]
-    file: gpdb_src/ci/pulse/api/trigger_pulse.yml
-    input_mapping: *input_mappings
-    params:
-      <<: *pulse_properties
-      PULSE_PROJECT_NAME: "GPDB-BehaveBackupRestore_HarmonizeDDBoost"
-  - task: monitor_pulse
-    attempts: 2
-    tags: ["gpdb5-pulse-worker"]
-    file: gpdb_src/ci/pulse/api/monitor_pulse.yml
-    params:
-      <<: *pulse_properties
-      PULSE_PROJECT_NAME: "GPDB-BehaveBackupRestore_HarmonizeDDBoost"
-
 - name: MM_gpcheckcat
   plan:
   - aggregate:
@@ -1581,25 +1514,47 @@ jobs:
       <<: *debug_sleep
   - *ccp_destroy
 
+# Stage 3: Trigger jobs that rely on packaging
 - name: MM_gpexpand
   plan:
   - get: nightly-trigger
     trigger: {{nightly-trigger-flag}}
-  - aggregate: *post_packaging_gets_trigger_based_on_flag
+  - aggregate: &post_packaging_gets_trigger_based_on_flag
+    - get: gpdb_src
+      params: {submodules: none}
+      tags: ["gpdb5-pulse-worker"]
+      passed: [gpdb_rc_packaging_centos]
+      trigger: {{reduced-frequency-trigger-flag}}
+    - get: gpdb_src_tinc_tarball
+      tags: ["gpdb5-pulse-worker"]
+      passed: [gpdb_rc_packaging_centos]
+    - get: installer_rhel6_gpdb_rc
+      tags: ["gpdb5-pulse-worker"]
+      passed: [gpdb_rc_packaging_centos]
+    - get: qautils_rhel6_tarball
+      tags: ["gpdb5-pulse-worker"]
+      passed: [gpdb_rc_packaging_centos]
+    - get: gpdb_src_behave_tarball
+      tags: ["gpdb5-pulse-worker"]
+      passed: [gpdb_rc_packaging_centos]
   - task: trigger_pulse
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/trigger_pulse.yml
-    input_mapping: *input_mappings
-    params:
-      <<: *pulse_properties
+    input_mapping: &input_mappings
+      gpdb_src_archive: gpdb_src_tinc_tarball
+      installer_gpdb_rc: installer_rhel6_gpdb_rc
+      qautils_tarball: qautils_rhel6_tarball
+      gpdb_src_behave_tarball: gpdb_src_behave_tarball
+    params: &pulse_properties
+      PULSE_URL: {{pulse_url}}
       PULSE_PROJECT_NAME: "GPDB-gpexpand-parallel"
+      PULSE_USERNAME: {{pulse_username}}
+      PULSE_PASSWORD: {{pulse_password}}
   - task: monitor_pulse
     attempts: 2
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/monitor_pulse.yml
-    params:
-      <<: *pulse_properties
-      PULSE_PROJECT_NAME: "GPDB-gpexpand-parallel"
+    params: *pulse_properties
 
 - name: DPM_gptransfer-43x-to-5x
   plan:
@@ -1845,8 +1800,6 @@ jobs:
     - regression_tests_pxf_centos
     - gpdb_rc_packaging_centos
     - gpdb_rc_packaging_sles
-    - DPM_netbackup77
-    - DPM_backup-restore-ddboost
     - DPM_backup_43_restore_5
     - MM_gpcheckcat
     - MM_gprecoverseg


### PR DESCRIPTION
Since NetBackup and DDBoost both run against a single server, these tests have been suffering from load issues when the jobs are triggered multiple times simultaneously or when they run in cloned pipelines from master. Pulling them out into a separate pipeline will mean they have less potential to be triggered in other pipelines and overload our servers. This pipeline will run once a day against master.