### PR TITLE
Check for backported GPDB version in checksum test

### DIFF
--- a/contrib/pg_upgrade/controldata.c
+++ b/contrib/pg_upgrade/controldata.c
@@ -128,8 +128,12 @@ get_control_data(migratorContext *ctx, ClusterInfo *cluster, bool live_check)
 		got_float8_pass_by_value = true;
 	}
 
-	/* Only in <= 9.2 */
-	if (GET_MAJOR_VERSION(cluster->major_version) <= 902)
+	/*
+	 * In PostgreSQL, checksums were introduced in 9.3 so the test for checksum
+	 * version applies to <= 9.2. Greenplum backported checksums into 5.x which
+	 * is based on PostgreSQL 8.3 so this test need to go on <= 8.2 instead.
+	 */
+	if (GET_MAJOR_VERSION(cluster->major_version) <= 802)
 	{
 		cluster->controldata.data_checksums = false;
 		got_data_checksums = true;


### PR DESCRIPTION
The checksum feature was backported from PostgreSQL 9.3, so the version test in pg_upgrade must match the underlying PostgreSQL version of GPDB5 rather than the upstream <= 9.2 version.