### PR TITLE
Add check for hash partitioned tables in pg_upgrade.

### DIFF
--- a/contrib/pg_upgrade/check.c
+++ b/contrib/pg_upgrade/check.c
@@ -20,6 +20,7 @@ static void check_for_isn_and_int8_passing_mismatch(migratorContext *ctx,
 static void check_for_reg_data_type_usage(migratorContext *ctx, Cluster whichCluster);
 static void check_external_partition(migratorContext *ctx);
 static void check_covering_aoindex(migratorContext *ctx);
+static void check_hash_partition_usage(migratorContext *ctx, Cluster whichCluster);
 
 
 /*
@@ -103,6 +104,7 @@ check_old_cluster(migratorContext *ctx, bool live_check,
 	check_for_isn_and_int8_passing_mismatch(ctx, CLUSTER_OLD);
 	check_external_partition(ctx);
 	check_covering_aoindex(ctx);
+	check_hash_partition_usage(ctx, CLUSTER_OLD);
 
 	/* old = PG 8.3 checks? */
 	/*
@@ -986,4 +988,87 @@ check_covering_aoindex(migratorContext *ctx)
 	{
 		check_ok(ctx);
 	}
+}
+
+/*
+ *	check_hash_partition_usage()
+ *	8.3 -> 8.4
+ *	The hash algorithm was changed in 8.4, so upgrading is impossible. This
+ *	is basically the same problem as with hash indexes in PostgreSQL. Hash
+ *	partitioning was not officially supported in GPDB5, but better check just
+ *	in case someone has found the hidden GUC and used them anyway.
+ *
+ *	XXX: Actually, pg_dump outright fails on hash partitioned tables, so we
+ *	cannot support hash partitioned tables even on a same-version upgrade.
+ */
+void
+check_hash_partition_usage(migratorContext *ctx, Cluster whichCluster)
+{
+	ClusterInfo *active_cluster = (whichCluster == CLUSTER_OLD) ?
+	&ctx->old : &ctx->new;
+	int			dbnum;
+	FILE	   *script = NULL;
+	bool		found = false;
+	char		output_path[MAXPGPATH];
+
+	prep_status(ctx, "Checking for hash partitioned tables");
+
+	snprintf(output_path, sizeof(output_path), "%s/hash_partitioned_tables.txt",
+			 ctx->cwd);
+
+	for (dbnum = 0; dbnum < active_cluster->dbarr.ndbs; dbnum++)
+	{
+		PGresult   *res;
+		bool		db_used = false;
+		int			ntups;
+		int			rowno;
+		int			i_nspname,
+					i_relname;
+		DbInfo	   *active_db = &active_cluster->dbarr.dbs[dbnum];
+		PGconn	   *conn = connectToServer(ctx, active_db->db_name, whichCluster);
+
+		res = executeQueryOrDie(ctx, conn,
+								"SELECT n.nspname, c.relname "
+								"FROM pg_catalog.pg_partition p, pg_catalog.pg_class c, pg_catalog.pg_namespace n "
+								"WHERE p.parrelid = c.oid AND c.relnamespace = n.oid "
+								"AND parkind = 'h'");
+
+		ntups = PQntuples(res);
+		i_nspname = PQfnumber(res, "nspname");
+		i_relname = PQfnumber(res, "relname");
+		for (rowno = 0; rowno < ntups; rowno++)
+		{
+			found = true;
+			if (script == NULL && (script = fopen(output_path, "w")) == NULL)
+				pg_log(ctx, PG_FATAL, "Could not create necessary file:  %s\n", output_path);
+			if (!db_used)
+			{
+				fprintf(script, "Database:  %s\n", active_db->db_name);
+				db_used = true;
+			}
+			fprintf(script, "  %s.%s\n",
+					PQgetvalue(res, rowno, i_nspname),
+					PQgetvalue(res, rowno, i_relname));
+		}
+
+		PQclear(res);
+
+		PQfinish(conn);
+	}
+
+	if (found)
+	{
+		fclose(script);
+		pg_log(ctx, PG_REPORT, "fatal\n");
+		pg_log(ctx, PG_FATAL,
+			   "| Your installation contains hash partitioned tables.\n"
+			   "| Upgrading hash partitioned tables is not supported,\n"
+			   "| so this cluster cannot currently be upgraded.  You\n"
+			   "| can remove the problem tables and restart the\n"
+			   "| migration.  A list of the problem tables is in the\n"
+			   "| file:\n"
+			   "| \t%s\n\n", output_path);
+	}
+	else
+		check_ok(ctx);
 }


### PR DESCRIPTION
I was about to add this as part of the PostgreSQL 8.4 merge, as a check
when upgrading from 8.3 to 8.4, because the hash algorithm was changed
in 8.4. However, turns out that pg_dump doesn't support hash partitioned
tables at all, so pg_upgrade won't work on a database that contains any
hash partitioned tables, even on a same-version upgrade. Hence, let's
add this check unconditionally on all server versions.

There are comments talking about the hash function change, because of that
devleopment history. I think that's useful documentation, just in case
we ever start to support hash partitions in pg_dump, so I left it there.