### PR TITLE
Fix CREATE TABLE AS VALUES ... DISTRIBUTED BY

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -1780,9 +1780,6 @@ transformValuesClause(ParseState *pstate, SelectStmt *stmt)
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 			 errmsg("SELECT FOR UPDATE/SHARE cannot be applied to VALUES")));
 
-	if (stmt->distributedBy && Gp_role == GP_ROLE_DISPATCH)
-		setQryDistributionPolicy(stmt, qry);
-
 	/* handle any CREATE TABLE AS spec */
 	qry->intoClause = NULL;
 	if (stmt->intoClause)
@@ -1791,6 +1788,9 @@ transformValuesClause(ParseState *pstate, SelectStmt *stmt)
 		if (stmt->intoClause->colNames)
 			applyColumnNames(qry->targetList, stmt->intoClause->colNames);
 	}
+
+	if (stmt->distributedBy && Gp_role == GP_ROLE_DISPATCH)
+		setQryDistributionPolicy(stmt, qry);
 
 	/*
 	 * There mustn't have been any table references in the expressions, else

--- a/src/test/regress/expected/gpctas.out
+++ b/src/test/regress/expected/gpctas.out
@@ -128,3 +128,5 @@ $$ LANGUAGE plpgsql;
 create table ctas_output as select ctas_inputArray()::int[] as x;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'x' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Test CTAS with VALUES.
+CREATE TEMP TABLE yolo(i, j, k) AS (VALUES (0,0,0), (1, NULL, 0), (2, NULL, 0), (3, NULL, 0)) DISTRIBUTED BY (i);

--- a/src/test/regress/sql/gpctas.sql
+++ b/src/test/regress/sql/gpctas.sql
@@ -58,3 +58,8 @@ END;
 $$ LANGUAGE plpgsql;
 
 create table ctas_output as select ctas_inputArray()::int[] as x;
+
+
+-- Test CTAS with VALUES.
+
+CREATE TEMP TABLE yolo(i, j, k) AS (VALUES (0,0,0), (1, NULL, 0), (2, NULL, 0), (3, NULL, 0)) DISTRIBUTED BY (i);


### PR DESCRIPTION
Should call setQryDistributionPolicy() after applyColumnNames(), otherwise
the column names specified in the CREATE TABLE cannot be used in the
DISTRIBUTED BY clause. Add test case.

Fixes github issue #3285.