### PR TITLE
Add pipeline support for AIX clients and loaders

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -1874,11 +1874,13 @@ jobs:
     - compile_gpdb_centos7
     - compile_gpdb_sles11
     - compile_gpdb_windows_cl
+    - compile_gpdb_aix7_remote
     - icw_planner_centos6
     - icw_gporca_centos6
     - icw_gporca_centos7
     - icw_gporca_sles11
     - icw_planner_ictcp_centos6
+    - client_loader_remote_test_aix
     - mpp_resource_group_centos6
     - MU_check_centos
     - MM_analyzedb

--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -675,8 +675,9 @@ jobs:
   serial: true
   plan:
   - aggregate:
-    - get: gpdb_src
+    - get: nightly-trigger
       trigger: true
+    - get: gpdb_src
     - get: gpaddon_src
     - get: centos-gpdb-dev-6
   - task: compile_gpdb_aix7_remote

--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -7,11 +7,13 @@ groups:
   - compile_gpdb_centos7
   - compile_gpdb_sles11
   - compile_gpdb_windows_cl
+  - compile_gpdb_aix7_remote
   - icw_planner_centos6
   - icw_gporca_centos6
   - icw_gporca_centos7
   - icw_gporca_sles11
   - icw_planner_ictcp_centos6
+  - client_loader_remote_test_aix
   - mpp_resource_group_centos6
   - MU_check_centos
   - MM_gpperfmon
@@ -369,6 +371,24 @@ resources:
     secret_access_key: {{bucket-secret-access-key}}
     regexp: deliverables/greenplum-loaders-5.(.*)-rhel7-x86_64.zip
 
+- name: installer_aix7_gpdb_clients
+  type: s3
+  source:
+    access_key_id: {{bucket-access-key-id}}
+    bucket: {{bucket-name}}
+    region_name: {{aws-region}}
+    secret_access_key: {{bucket-secret-access-key}}
+    regexp: deliverables/greenplum-clients-5.(.*)-aix7_ppc_64.zip
+
+- name: installer_aix7_gpdb_loaders
+  type: s3
+  source:
+    access_key_id: {{bucket-access-key-id}}
+    bucket: {{bucket-name}}
+    region_name: {{aws-region}}
+    secret_access_key: {{bucket-secret-access-key}}
+    regexp: deliverables/greenplum-loaders-5.(.*)-aix7_ppc_64.zip
+
 - name: qautils_rhel6_tarball
   type: s3
   source:
@@ -648,6 +668,40 @@ jobs:
       params:
         file: gpdb_artifacts/greenplum-loaders-*-WinXP-x86_32.msi
 
+# Compile gpdb on a remote AIX machine, triggered by concourse.
+# We need to serialize this job to avoid overwhelming workload
+# on remote machine.
+- name: compile_gpdb_aix7_remote
+  serial: true
+  plan:
+  - aggregate:
+    - get: gpdb_src
+      trigger: true
+    - get: gpaddon_src
+    - get: centos-gpdb-dev-6
+  - task: compile_gpdb_aix7_remote
+    file: gpdb_src/concourse/tasks/compile_gpdb_remote.yml
+    image: centos-gpdb-dev-6
+    params:
+      REMOTE_HOST: {{remote_host}}
+      REMOTE_PORT: {{remote_port}}
+      REMOTE_USER: {{remote_user}}
+      REMOTE_KEY: {{remote_key}}
+
+      IVYREPO_HOST: {{ivyrepo_host}}
+      IVYREPO_REALM: {{ivyrepo_realm}}
+      IVYREPO_USER: {{ivyrepo_user}}
+      IVYREPO_PASSWD: {{ivyrepo_passwd}}
+
+      BLD_TARGETS: "clients loaders"
+  - aggregate:
+    - put: installer_aix7_gpdb_clients
+      params:
+        file: gpdb_artifacts/greenplum-clients-*-aix7_ppc_64.zip
+    - put: installer_aix7_gpdb_loaders
+      params:
+        file: gpdb_artifacts/greenplum-loaders-*-aix7_ppc_64.zip
+
 # This acts like a cache as this job will only be run once to get a
 # binary to use for our binary swap compatibility tests. Setting a new
 # tag or branch for the gpdb_src_binary_swap resource via set-pipeline
@@ -778,6 +832,31 @@ jobs:
       MAKE_TEST_COMMAND: PGOPTIONS='-c gp_interconnect_type=tcp -c optimizer=off' installcheck-world
       BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
       TEST_OS: centos
+
+- name: client_loader_remote_test_aix
+  serial: true
+  plan:
+  - aggregate:
+    - get: gpdb_src
+      passed: [compile_gpdb_aix7_remote]
+    - get: installer_aix7_gpdb_clients
+      passed: [compile_gpdb_aix7_remote]
+    - get: installer_aix7_gpdb_loaders
+      passed: [compile_gpdb_aix7_remote]
+      trigger: true
+    - get: bin_gpdb
+      passed: [compile_gpdb_centos6]
+      resource: bin_gpdb_centos6
+    - get: centos-gpdb-dev-6
+  - task: ic_gpdb_cl
+    file: gpdb_src/concourse/tasks/ic_gpdb_remote.yml
+    image: centos-gpdb-dev-6
+    params:
+      BLD_TARGETS: "clients loaders"
+      REMOTE_HOST: {{remote_host}}
+      REMOTE_PORT: {{remote_port}}
+      REMOTE_USER: {{remote_user}}
+      REMOTE_KEY: {{remote_key}}
 
 - name: mpp_resource_group_centos6
   plan:

--- a/concourse/scripts/compile_gpdb_remote.bash
+++ b/concourse/scripts/compile_gpdb_remote.bash
@@ -5,7 +5,7 @@ ROOT_DIR=`pwd`
 
 # Get ssh private key from REMOTE_KEY, which is assumed to
 # be encode in base64. We can't pass the key content directly
-# since newline doesn't not work well for env variable.
+# since newline doesn't work well for env variable.
 function setup_ssh_keys() {
     # Setup ssh keys
     echo -n $REMOTE_KEY | base64 -d > ~/remote.key
@@ -55,7 +55,7 @@ EOF
     cd ..
 }
 
-# Since we're cloning in a different machine, changes are that
+# Since we're cloning in a different machine, maybe there's 
 # new commit pushed to the same repo. We need to reset to the
 # same commit to current concourse build.
 function remote_clone() {

--- a/concourse/scripts/compile_gpdb_remote.bash
+++ b/concourse/scripts/compile_gpdb_remote.bash
@@ -1,0 +1,111 @@
+#! /bin/bash
+set -eo pipefail
+
+ROOT_DIR=`pwd`
+
+# Get ssh private key from REMOTE_KEY, which is assumed to
+# be encode in base64. We can't pass the key content directly
+# since newline doesn't not work well for env variable.
+function setup_ssh_keys() {
+    # Setup ssh keys
+    echo -n $REMOTE_KEY | base64 -d > ~/remote.key
+    chmod 400 ~/remote.key
+
+    eval `ssh-agent -s`
+    ssh-add ~/remote.key
+
+    # Scan for target server's public key, append port number
+    ssh-keyscan -p $REMOTE_PORT $REMOTE_HOST > pubkey
+    awk '{printf "[%s]:", $1 }' pubkey > tmp
+    echo -n $REMOTE_PORT >> tmp
+    awk '{$1 = ""; print $0; }' pubkey >> tmp
+
+    mkdir ~/.ssh
+    cat tmp >> ~/.ssh/known_hosts
+}
+
+
+function remote_setup() {
+    # Get a session id for different commit builds.
+    SESSION_ID=`ssh -T -p $REMOTE_PORT $REMOTE_USER@$REMOTE_HOST 'echo \$\$'`
+
+    # Create working directory on remote machine.
+    ssh -T -p $REMOTE_PORT $REMOTE_USER@$REMOTE_HOST > dir <<- EOF
+    mkdir -p gpdb-compile/$SESSION_ID
+    cd gpdb-compile/$SESSION_ID
+    echo \$PWD
+EOF
+
+    GPDB_DIR=`cat dir`
+
+    # Setup environment variables needed on remote machine.
+    cat >env.sh <<- EOF
+    export IVYREPO_HOST="$IVYREPO_HOST"
+    export IVYREPO_REALM="$IVYREPO_REALM"
+    export IVYREPO_USER="$IVYREPO_USER"
+    export IVYREPO_PASSWD="$IVYREPO_PASSWD"
+EOF
+    scp -P $REMOTE_PORT env.sh $REMOTE_USER@$REMOTE_HOST:$GPDB_DIR/env.sh
+
+    # Get git information from local repo(concourse gpdb_src input)
+    cd gpdb_src
+    GIT_URI=`git config --get remote.origin.url`
+    GIT_BRANCH=`git show -s --pretty=%d HEAD | cut -d / -f 2 | cut -d , -f 1`
+    GIT_COMMIT=`git rev-parse HEAD`
+    cd ..
+}
+
+# Since we're cloning in a different machine, changes are that
+# new commit pushed to the same repo. We need to reset to the
+# same commit to current concourse build.
+function remote_clone() {
+    ssh -A -T -p $REMOTE_PORT $REMOTE_USER@$REMOTE_HOST <<- EOF
+    cd $GPDB_DIR
+    git clone --recursive -b $GIT_BRANCH $GIT_URI gpdb_src
+    cd gpdb_src
+    git reset --hard $GIT_COMMIT
+EOF
+    scp -P $REMOTE_PORT -r gpaddon_src $REMOTE_USER@$REMOTE_HOST:$GPDB_DIR/
+}
+
+function remote_compile() {
+    # .profile is not automatically sourced when ssh -T to AIX
+    ssh -T -p $REMOTE_PORT $REMOTE_USER@$REMOTE_HOST <<- EOF
+    . .profile
+    cd $GPDB_DIR
+    . env.sh
+    cd gpdb_src/gpAux
+    make sync_tools
+    make GPROOT="$GPDB_DIR" BLD_TARGETS="$BLD_TARGETS" dist
+    mv *.zip $GPDB_DIR/
+EOF
+}
+
+function download() {
+    scp -P $REMOTE_PORT $REMOTE_USER@$REMOTE_HOST:$GPDB_DIR/*.zip $ROOT_DIR/gpdb_artifacts/
+}
+
+# Since we are cloning and building on remote machine,
+# files won't be deleted as concourse container destroys.
+# We have to clean everything for success build.
+function cleanup() {
+    ssh -T -p $REMOTE_PORT $REMOTE_USER@$REMOTE_HOST <<- EOF
+    rm -rf $GPDB_DIR
+EOF
+}
+
+function _main() {
+
+    if [ -z "$REMOTE_PORT" ]; then
+        REMOTE_PORT=22
+    fi
+
+    time setup_ssh_keys
+    time remote_setup
+    time remote_clone
+    time remote_compile
+    time download
+    time cleanup
+}
+
+_main "$@"

--- a/concourse/scripts/ic_gpdb_remote.bash
+++ b/concourse/scripts/ic_gpdb_remote.bash
@@ -1,0 +1,121 @@
+#!/bin/bash -l
+
+set -eo pipefail
+
+CWDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${CWDIR}/common.bash"
+
+function setup_gpadmin_user() {
+    ./gpdb_src/concourse/scripts/setup_gpadmin_user.bash "$TEST_OS"
+}
+
+# Get ssh private key from REMOTE_KEY, which is assumed to
+# be encode in base64. We can't pass the key content directly
+# since newline doesn't not work well for env variable.
+function import_remote_key() {
+    echo -n $REMOTE_KEY | base64 -d > ~/remote.key
+    chmod 400 ~/remote.key
+
+    eval `ssh-agent -s`
+    ssh-add ~/remote.key
+
+    ssh-keyscan -p $REMOTE_PORT $REMOTE_HOST > pubkey
+    awk '{printf "[%s]:", $1 }' pubkey > tmp
+    echo -n $REMOTE_PORT >> tmp
+    awk '{$1 = ""; print $0; }' pubkey >> tmp
+
+    cat tmp >> ~/.ssh/known_hosts
+}
+
+# Simulate actual clients package installation, and try to
+# connect with psql.
+# SSH tunnel will forward the port of gpdemo cluster on concourse
+# worker to remote machine.
+function run_clients_test() {
+    unzip installer_aix7_gpdb_clients/*.zip
+    scp -P $REMOTE_PORT *clients*.bin $REMOTE_USER@$REMOTE_HOST:$GPDB_DIR/
+    ssh -T -p $REMOTE_PORT $REMOTE_USER@$REMOTE_HOST "$GPDB_DIR/*clients*.bin" <<-EOF
+    yes
+    $GPDB_DIR/install
+    yes
+    yes
+EOF
+
+    ssh -T -R$PGPORT:127.0.0.1:$PGPORT -p $REMOTE_PORT $REMOTE_USER@$REMOTE_HOST <<- EOF
+    export PGPORT=$PGPORT
+    . $GPDB_DIR/install/greenplum_clients_path.sh
+    psql -h 127.0.0.1 -c 'select version();' postgres
+EOF
+}
+
+# Simulate actual loaders package installation. Loader
+# tests need psql as well, so install to same location
+# as clients.
+# SSH tunnel will forward gpdb cluster port to remote
+# machine and gpfdist port to concourse worker.
+function run_loaders_test() {
+    unzip installer_aix7_gpdb_loaders/*.zip
+    scp -P $REMOTE_PORT *loaders*.bin $REMOTE_USER@$REMOTE_HOST:$GPDB_DIR/
+    ssh -T -p $REMOTE_PORT $REMOTE_USER@$REMOTE_HOST "$GPDB_DIR/*loaders*.bin" <<-EOF
+    yes
+    $GPDB_DIR/install
+    yes
+    yes
+EOF
+
+    # copy test suites and diff utils to remote
+    scp -P $REMOTE_PORT -r ./gpdb_src/gpMgmt/bin/gpload_test/gpload2 $REMOTE_USER@$REMOTE_HOST:$GPDB_DIR/
+    scp -P $REMOTE_PORT ./gpdb_src/src/test/regress/*.pl $REMOTE_USER@$REMOTE_HOST:$GPDB_DIR/install/bin/
+    scp -P $REMOTE_PORT ./gpdb_src/src/test/regress/*.pm $REMOTE_USER@$REMOTE_HOST:$GPDB_DIR/install/bin/
+
+    ssh -T -R$PGPORT:127.0.0.1:$PGPORT -L8081:127.0.0.1:8081 -L8082:127.0.0.1:8082 -p $REMOTE_PORT $REMOTE_USER@$REMOTE_HOST <<- EOF
+    export PGPORT=$PGPORT
+    export PGUSER=gpadmin
+    export PGHOST=127.0.0.1
+    . $GPDB_DIR/install/greenplum_loaders_path.sh
+    cd $GPDB_DIR/gpload2
+    python_64 TEST_REMOTE.py
+EOF
+}
+
+function run_remote_test() {
+    source ./gpdb_src/gpAux/gpdemo/gpdemo-env.sh
+    # Get a session id for different commit builds.
+    SESSION_ID=`ssh -T -p $REMOTE_PORT $REMOTE_USER@$REMOTE_HOST 'echo \$\$'`
+
+    # Create working directory on remote machine.
+    ssh -T -p $REMOTE_PORT $REMOTE_USER@$REMOTE_HOST > dir <<-EOF
+    mkdir -p gpdb-compile/$SESSION_ID
+    cd gpdb-compile/$SESSION_ID
+    echo \$PWD
+EOF
+
+    GPDB_DIR=`cat dir`
+    run_clients_test
+    run_loaders_test
+}
+
+# Since we are cloning and building on remote machine,
+# files won't be deleted as concourse container destroys.
+# We have to clean everything for success build.
+function cleanup() {
+    ssh -T -p $REMOTE_PORT $REMOTE_USER@$REMOTE_HOST <<- EOF
+    rm -rf $GPDB_DIR
+EOF
+}
+function _main() {
+
+    if [ -z "$REMOTE_PORT" ]; then
+        REMOTE_PORT=22
+    fi
+
+    time configure
+    time install_gpdb
+    time setup_gpadmin_user
+    time make_cluster
+    time import_remote_key
+    time run_remote_test
+    time cleanup
+}
+
+_main "$@"

--- a/concourse/scripts/ic_gpdb_remote.bash
+++ b/concourse/scripts/ic_gpdb_remote.bash
@@ -11,7 +11,7 @@ function setup_gpadmin_user() {
 
 # Get ssh private key from REMOTE_KEY, which is assumed to
 # be encode in base64. We can't pass the key content directly
-# since newline doesn't not work well for env variable.
+# since newline doesn't work well for env variable.
 function import_remote_key() {
     echo -n $REMOTE_KEY | base64 -d > ~/remote.key
     chmod 400 ~/remote.key

--- a/concourse/tasks/compile_gpdb_remote.yml
+++ b/concourse/tasks/compile_gpdb_remote.yml
@@ -1,0 +1,20 @@
+platform: linux
+image_resource:
+  type: docker-image
+inputs:
+  - name: gpdb_src
+  - name: gpaddon_src
+outputs:
+  - name: gpdb_artifacts
+run:
+  path: gpdb_src/concourse/scripts/compile_gpdb_remote.bash
+params:
+  TARGET_OS:
+  TARGET_OS_VERSION:
+  BLD_TARGETS:
+  OUTPUT_ARTIFACT_DIR: gpdb_artifacts
+  IVYREPO_HOST:
+  IVYREPO_REALM:
+  IVYREPO_USER:
+  IVYREPO_PASSWD:
+  CONFIGURE_FLAGS:

--- a/concourse/tasks/ic_gpdb_remote.yml
+++ b/concourse/tasks/ic_gpdb_remote.yml
@@ -1,0 +1,17 @@
+platform: linux
+image_resource:
+  type: docker-image
+inputs:
+  - name: installer_aix7_gpdb_clients
+  - name: installer_aix7_gpdb_loaders
+  - name: bin_gpdb
+  - name: gpdb_src
+outputs:
+params:
+  BLD_TARGETS:
+  REMOTE_HOST:
+  REMOTE_PORT:
+  REMOTE_USER:
+  REMOTE_KEY:
+run:
+  path: gpdb_src/concourse/scripts/ic_gpdb_remote.bash

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -593,7 +593,7 @@ BLD_OS=Windows
 else
 BLD_OS:=$(shell uname -s)
 endif
-AIX_LOADERS_LIBS=libbz2.a libz.a libpq.a liblber*.a libldap*.a libyaml*.a
+AIX_LOADERS_LIBS=libbz2.a libz.a libpq.a liblber*.a libldap*.a libyaml*.a libcrypto.so*
 Darwin_LOADERS_LIBS=libcrypto.*.dylib libssl.*.dylib libpq.*.dylib* libkrb5.*.dylib libcom_err.*.dylib libldap_r-*.dylib libk5crypto.*.dylib libkrb5support.*.dylib liblber-*.dylib libyaml*.dylib
 HP-UX_LOADERS_LIBS=libcrypto.so* libssl.so.* libz.so* libpq.so* libapr* libyaml*so*
 Linux_LOADERS_LIBS=libcrypto.so* libssl.so.*  libpq.so* libkrb5.so* libcom_err.so* libk5crypto.so* libkrb5support.so* liblber*.so* libldap_r-*so* libgssapi_krb5.so* libyaml*so*

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_REMOTE.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_REMOTE.py
@@ -26,7 +26,6 @@ def ensure_env(name):
     if v == None:
         print "Environment variable " + name + " is required"
         sys.exit(1)
-    print name + ": " + v
     return v
 
 DBNAME = "postgres"
@@ -201,7 +200,6 @@ def run(cmd):
             function, so you can theoretically pass any value that is
             valid for the second parameter of open().
     """
-    print cmd
     p = subprocess.Popen(cmd,shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE)
     out = p.communicate()[0]
     ret = []
@@ -381,6 +379,18 @@ class GPLoad_FormatOpts_TestCase(unittest.TestCase):
         write_config_file(reuse_flag='true',formatOpts='text',file='data_file.txt',table='texttable',delimiter="E'\u0009'")
         self.doTest(4)
 
+    def test_05_gpload_formatOpts_delimiter(self):
+        "5  gpload formatOpts delimiter E'\\'' with reuse"
+        copy_data('external_file_03.txt','data_file.txt')
+        write_config_file(reuse_flag='true',formatOpts='text',file='data_file.txt',table='texttable',delimiter="E'\''")
+        self.doTest(5)
+
+    def test_06_gpload_formatOpts_delimiter(self):
+        "6  gpload formatOpts delimiter \"'\" with reuse"
+        copy_data('external_file_03.txt','data_file.txt')
+        write_config_file(reuse_flag='true',formatOpts='text',file='data_file.txt',table='texttable',delimiter="\"'\"")
+        self.doTest(6)
+
     def test_07_gpload_reuse_table_insert_mode_without_reuse(self):
         "7  gpload insert mode without reuse"
         runfile(mkpath('setup.sql'))
@@ -419,6 +429,25 @@ class GPLoad_FormatOpts_TestCase(unittest.TestCase):
         copy_data('external_file_08.txt','data_file.txt')
         write_config_file('merge','true',file='data_file.txt')
         self.doTest(12)
+
+    def test_13_gpload_reuse_table_merge_mode_with_different_columns_number_in_DB(self):
+        "13  gpload merge mode with reuse (RERUN with different columns number in DB table) "
+        preTest = mkpath('pre_test_13.sql')
+        psql_run(preTest, dbname='reuse_gptest')
+        copy_data('external_file_09.txt','data_file.txt')
+        write_config_file('merge','true',file='data_file.txt')
+        self.doTest(13)
+
+    def test_14_gpload_reuse_table_update_mode_with_reuse_RERUN(self):
+        "14 gpload update mode with reuse (RERUN) "
+        write_config_file('update','true',file='data_file.txt')
+        self.doTest(14)
+
+    def test_15_gpload_reuse_table_merge_mode_with_different_columns_order(self):
+        "15 gpload merge mode with different columns' order "
+        copy_data('external_file_10.txt','data/data_file.tbl')
+        write_config_file('merge','true',file='data/data_file.tbl',columns_flag='1',mapping='1')
+        self.doTest(15)
 
     def test_16_gpload_formatOpts_quote(self):
         "16  gpload formatOpts quote unspecified in CSV with reuse "


### PR DESCRIPTION
Concourse doesn't support AIX natively, we need to clone the repo
with the correspond commit on remote machine, compile the packages,
and download them back to concourse container as output.

Testing client and loader for platform without gpdb server is
another challenge. We setup GPDB server on concourse container just
like most installcheck tests, and use SSH tunnel to forward ports
from and to the remote host. This way both CL tools and GPDB server
feel they are on the same machine, and the test can run normally.