### PR TITLE
Resource group test for concurrent query cancellation/termination.

### DIFF
--- a/src/test/isolation2/expected/resgroup/resgroup_cancel_terminate_concurrency.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_cancel_terminate_concurrency.out
@@ -1,0 +1,251 @@
+-- test1: cancel a query that is waiting for a slot
+DROP ROLE IF EXISTS role_concurrency_test;
+DROP
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+ERROR:  resource group "rg_concurrency_test" does not exist
+-- end_ignore
+
+CREATE OR REPLACE VIEW rg_concurrency_view AS SELECT waiting, waiting_reason, current_query, rsgname FROM pg_stat_activity WHERE rsgname='rg_concurrency_test';
+CREATE
+
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=1, cpu_rate_limit=20, memory_limit=20);
+CREATE
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+CREATE
+1:SET ROLE role_concurrency_test;
+SET
+1:BEGIN;
+BEGIN
+2:SET ROLE role_concurrency_test;
+SET
+2&:BEGIN;  <waiting ...>
+3:SET ROLE role_concurrency_test;
+SET
+3&:BEGIN;  <waiting ...>
+SELECT * FROM rg_concurrency_view;
+waiting|waiting_reason|current_query        |rsgname            
+-------+--------------+---------------------+-------------------
+f      |              |<IDLE> in transaction|rg_concurrency_test
+t      |resgroup      |BEGIN;               |rg_concurrency_test
+t      |resgroup      |BEGIN;               |rg_concurrency_test
+(3 rows)
+SELECT pg_cancel_backend(procpid) FROM pg_stat_activity WHERE waiting_reason='resgroup' AND rsgname='rg_concurrency_test';
+pg_cancel_backend
+-----------------
+t                
+t                
+(2 rows)
+1:END;
+END
+2<:  <... completed>
+ERROR:  canceling statement due to user request
+3<:  <... completed>
+ERROR:  canceling statement due to user request
+SELECT * FROM rg_concurrency_view;
+waiting|waiting_reason|current_query|rsgname            
+-------+--------------+-------------+-------------------
+f      |              |<IDLE>       |rg_concurrency_test
+f      |              |<IDLE>       |rg_concurrency_test
+f      |              |<IDLE>       |rg_concurrency_test
+(3 rows)
+1q: ... <quitting>
+2q: ... <quitting>
+3q: ... <quitting>
+DROP ROLE role_concurrency_test;
+DROP
+DROP RESOURCE GROUP rg_concurrency_test;
+DROP
+
+-- test2: terminate a query that is waiting for a slot
+DROP ROLE IF EXISTS role_concurrency_test;
+DROP
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+ERROR:  resource group "rg_concurrency_test" does not exist
+-- end_ignore
+
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=1, cpu_rate_limit=20, memory_limit=20);
+CREATE
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+CREATE
+1:SET ROLE role_concurrency_test;
+SET
+1:BEGIN;
+BEGIN
+2:SET ROLE role_concurrency_test;
+SET
+2&:BEGIN;  <waiting ...>
+3:SET ROLE role_concurrency_test;
+SET
+3&:BEGIN;  <waiting ...>
+SELECT * FROM rg_concurrency_view;
+waiting|waiting_reason|current_query        |rsgname            
+-------+--------------+---------------------+-------------------
+f      |              |<IDLE> in transaction|rg_concurrency_test
+t      |resgroup      |BEGIN;               |rg_concurrency_test
+t      |resgroup      |BEGIN;               |rg_concurrency_test
+(3 rows)
+SELECT pg_terminate_backend(procpid) FROM pg_stat_activity WHERE waiting_reason='resgroup' AND rsgname='rg_concurrency_test';
+pg_terminate_backend
+--------------------
+t                   
+t                   
+(2 rows)
+1:END;
+END
+2<:  <... completed>
+FATAL:  terminating connection due to administrator command
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+3<:  <... completed>
+FATAL:  terminating connection due to administrator command
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+SELECT * FROM rg_concurrency_view;
+waiting|waiting_reason|current_query|rsgname            
+-------+--------------+-------------+-------------------
+f      |              |<IDLE>       |rg_concurrency_test
+(1 row)
+1q: ... <quitting>
+2q: ... <quitting>
+3q: ... <quitting>
+DROP ROLE role_concurrency_test;
+DROP
+DROP RESOURCE GROUP rg_concurrency_test;
+DROP
+
+-- test3: cancel a query that is running
+DROP ROLE IF EXISTS role_concurrency_test;
+DROP
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+ERROR:  resource group "rg_concurrency_test" does not exist
+-- end_ignore
+
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=2, cpu_rate_limit=20, memory_limit=20);
+CREATE
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+CREATE
+1:SET ROLE role_concurrency_test;
+SET
+1&:SELECT pg_sleep(10000);  <waiting ...>
+2:SET ROLE role_concurrency_test;
+SET
+2&:SELECT pg_sleep(10000);  <waiting ...>
+6:SET ROLE role_concurrency_test;
+SET
+6&:BEGIN;  <waiting ...>
+7:SET ROLE role_concurrency_test;
+SET
+7&:BEGIN;  <waiting ...>
+SELECT * FROM rg_concurrency_view;
+waiting|waiting_reason|current_query          |rsgname            
+-------+--------------+-----------------------+-------------------
+f      |              |SELECT pg_sleep(10000);|rg_concurrency_test
+f      |              |SELECT pg_sleep(10000);|rg_concurrency_test
+t      |resgroup      |BEGIN;                 |rg_concurrency_test
+t      |resgroup      |BEGIN;                 |rg_concurrency_test
+(4 rows)
+SELECT pg_cancel_backend(procpid) FROM pg_stat_activity WHERE waiting='f' AND rsgname='rg_concurrency_test';
+pg_cancel_backend
+-----------------
+t                
+t                
+(2 rows)
+1<:  <... completed>
+ERROR:  canceling statement due to user request
+2<:  <... completed>
+ERROR:  canceling statement due to user request
+6<:  <... completed>
+BEGIN
+7<:  <... completed>
+BEGIN
+SELECT * FROM rg_concurrency_view;
+waiting|waiting_reason|current_query        |rsgname            
+-------+--------------+---------------------+-------------------
+f      |              |<IDLE>               |rg_concurrency_test
+f      |              |<IDLE>               |rg_concurrency_test
+f      |              |<IDLE> in transaction|rg_concurrency_test
+f      |              |<IDLE> in transaction|rg_concurrency_test
+(4 rows)
+1q: ... <quitting>
+2q: ... <quitting>
+6q: ... <quitting>
+7q: ... <quitting>
+DROP ROLE role_concurrency_test;
+DROP
+DROP RESOURCE GROUP rg_concurrency_test;
+DROP
+
+-- test4: terminate a query that is running
+DROP ROLE IF EXISTS role_concurrency_test;
+DROP
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+ERROR:  resource group "rg_concurrency_test" does not exist
+-- end_ignore
+
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=2, cpu_rate_limit=20, memory_limit=20);
+CREATE
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+CREATE
+1:SET ROLE role_concurrency_test;
+SET
+1&:SELECT pg_sleep(10000);  <waiting ...>
+2:SET ROLE role_concurrency_test;
+SET
+2&:SELECT pg_sleep(10000);  <waiting ...>
+6:SET ROLE role_concurrency_test;
+SET
+6&:BEGIN;  <waiting ...>
+7:SET ROLE role_concurrency_test;
+SET
+7&:BEGIN;  <waiting ...>
+SELECT * FROM rg_concurrency_view;
+waiting|waiting_reason|current_query          |rsgname            
+-------+--------------+-----------------------+-------------------
+f      |              |SELECT pg_sleep(10000);|rg_concurrency_test
+f      |              |SELECT pg_sleep(10000);|rg_concurrency_test
+t      |resgroup      |BEGIN;                 |rg_concurrency_test
+t      |resgroup      |BEGIN;                 |rg_concurrency_test
+(4 rows)
+SELECT pg_terminate_backend(procpid) FROM pg_stat_activity WHERE waiting='f' AND rsgname='rg_concurrency_test';
+pg_terminate_backend
+--------------------
+t                   
+t                   
+(2 rows)
+1<:  <... completed>
+FATAL:  terminating connection due to administrator command
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+2<:  <... completed>
+FATAL:  terminating connection due to administrator command
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+6<:  <... completed>
+BEGIN
+7<:  <... completed>
+BEGIN
+SELECT * FROM rg_concurrency_view;
+waiting|waiting_reason|current_query        |rsgname            
+-------+--------------+---------------------+-------------------
+f      |              |<IDLE> in transaction|rg_concurrency_test
+f      |              |<IDLE> in transaction|rg_concurrency_test
+(2 rows)
+1q: ... <quitting>
+2q: ... <quitting>
+6q: ... <quitting>
+7q: ... <quitting>
+DROP ROLE role_concurrency_test;
+DROP
+DROP RESOURCE GROUP rg_concurrency_test;
+DROP
+
+DROP VIEW rg_concurrency_view;
+DROP

--- a/src/test/isolation2/isolation2_resgroup_schedule
+++ b/src/test/isolation2/isolation2_resgroup_schedule
@@ -15,6 +15,7 @@ test: resgroup/resgroup_cpu_rate_limit
 test: resgroup/resgroup_alter_memory_spill_ratio
 test: resgroup/resgroup_set_memory_spill_ratio
 test: resgroup/resgroup_unlimit_memory_spill_ratio
+test: resgroup/resgroup_cancel_terminate_concurrency
 
 # memory spill tests
 #test: resgroup/resgroup_memory_hashagg_spill

--- a/src/test/isolation2/sql/resgroup/resgroup_cancel_terminate_concurrency.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_cancel_terminate_concurrency.sql
@@ -1,0 +1,118 @@
+-- test1: cancel a query that is waiting for a slot
+DROP ROLE IF EXISTS role_concurrency_test;
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+-- end_ignore
+
+CREATE OR REPLACE VIEW rg_concurrency_view AS
+	SELECT waiting, waiting_reason, current_query, rsgname
+	FROM pg_stat_activity
+	WHERE rsgname='rg_concurrency_test';
+
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=1, cpu_rate_limit=20, memory_limit=20);
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+1:SET ROLE role_concurrency_test;
+1:BEGIN;
+2:SET ROLE role_concurrency_test;
+2&:BEGIN;
+3:SET ROLE role_concurrency_test;
+3&:BEGIN;
+SELECT * FROM rg_concurrency_view;
+SELECT pg_cancel_backend(procpid) FROM pg_stat_activity WHERE waiting_reason='resgroup' AND rsgname='rg_concurrency_test';
+1:END;
+2<:
+3<:
+SELECT * FROM rg_concurrency_view;
+1q:
+2q:
+3q:
+DROP ROLE role_concurrency_test;
+DROP RESOURCE GROUP rg_concurrency_test;
+
+-- test2: terminate a query that is waiting for a slot
+DROP ROLE IF EXISTS role_concurrency_test;
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+-- end_ignore
+
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=1, cpu_rate_limit=20, memory_limit=20);
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+1:SET ROLE role_concurrency_test;
+1:BEGIN;
+2:SET ROLE role_concurrency_test;
+2&:BEGIN;
+3:SET ROLE role_concurrency_test;
+3&:BEGIN;
+SELECT * FROM rg_concurrency_view;
+SELECT pg_terminate_backend(procpid) FROM pg_stat_activity WHERE waiting_reason='resgroup' AND rsgname='rg_concurrency_test';
+1:END;
+2<:
+3<:
+SELECT * FROM rg_concurrency_view;
+1q:
+2q:
+3q:
+DROP ROLE role_concurrency_test;
+DROP RESOURCE GROUP rg_concurrency_test;
+
+-- test3: cancel a query that is running
+DROP ROLE IF EXISTS role_concurrency_test;
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+-- end_ignore
+
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=2, cpu_rate_limit=20, memory_limit=20);
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+1:SET ROLE role_concurrency_test;
+1&:SELECT pg_sleep(10000);
+2:SET ROLE role_concurrency_test;
+2&:SELECT pg_sleep(10000);
+6:SET ROLE role_concurrency_test;
+6&:BEGIN;
+7:SET ROLE role_concurrency_test;
+7&:BEGIN;
+SELECT * FROM rg_concurrency_view;
+SELECT pg_cancel_backend(procpid) FROM pg_stat_activity WHERE waiting='f' AND rsgname='rg_concurrency_test';
+1<:
+2<:
+6<:
+7<:
+SELECT * FROM rg_concurrency_view;
+1q:
+2q:
+6q:
+7q:
+DROP ROLE role_concurrency_test;
+DROP RESOURCE GROUP rg_concurrency_test;
+
+-- test4: terminate a query that is running
+DROP ROLE IF EXISTS role_concurrency_test;
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+-- end_ignore
+
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=2, cpu_rate_limit=20, memory_limit=20);
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+1:SET ROLE role_concurrency_test;
+1&:SELECT pg_sleep(10000);
+2:SET ROLE role_concurrency_test;
+2&:SELECT pg_sleep(10000);
+6:SET ROLE role_concurrency_test;
+6&:BEGIN;
+7:SET ROLE role_concurrency_test;
+7&:BEGIN;
+SELECT * FROM rg_concurrency_view;
+SELECT pg_terminate_backend(procpid) FROM pg_stat_activity WHERE waiting='f' AND rsgname='rg_concurrency_test';
+1<:
+2<:
+6<:
+7<:
+SELECT * FROM rg_concurrency_view;
+1q:
+2q:
+6q:
+7q:
+DROP ROLE role_concurrency_test;
+DROP RESOURCE GROUP rg_concurrency_test;
+
+DROP VIEW rg_concurrency_view;


### PR DESCRIPTION
This is to test cancel/terminate queries concurrently while they are running or waiting in resource group.