### PR TITLE
Turn fsync off for terraform behave tests

### DIFF
--- a/concourse/scripts/run_behave_test.sh
+++ b/concourse/scripts/run_behave_test.sh
@@ -7,5 +7,7 @@ export PGPORT=5432
 export MASTER_DATA_DIRECTORY=/data/gpdata/master/gpseg-1
 export PGDATABASE=gptest
 createdb gptest
+gpconfig --skipvalidation -c fsync -v off
+gpstop -u
 cd /home/gpadmin/gpdb_src/gpMgmt
 make -f Makefile.behave behave flags="$BEHAVE_FLAGS"


### PR DESCRIPTION
This should speed up the tests a bit, since they are currently spending a significant amount of time in createdb statements.