### PR TITLE
Developer version of gpstart for WALRep

### DIFF
--- a/gpAux/gpdemo/gpsegwalrep.py
+++ b/gpAux/gpdemo/gpsegwalrep.py
@@ -102,9 +102,10 @@ class InitMirrors():
         commands.append("gpstop -u");
         runcommands(commands, "Main Mirror Init", "Notified primaries of mirror addition")
 
+
         initThreads = []
         for segconfig in self.segconfigs:
-            if segconfig[4] == 'p':
+            if segconfig[4] == 'p' and segconfig[1] != -1:
                 thread = threading.Thread(target=self.initThread, args=(segconfig, user))
                 thread.start()
                 initThreads.append(thread)
@@ -112,32 +113,78 @@ class InitMirrors():
         for thread in initThreads:
             thread.join()
 
-class StartMirrors():
-    ''' Start the WAL replication mirror segment '''
+class StartInstances():
+    ''' Start a greenplum segment '''
 
-    def __init__(self, segconfigs, host):
+    def __init__(self, segconfigs, host, segment_type='all', wait=False):
         self.segconfigs = segconfigs
-        self.num_contents = len(segconfigs)
         self.host = host
+        self.segment_type = segment_type
+        self.wait = wait
+        self.__num_contents = None
 
     def startThread(self, segconfig):
         commands = []
-        mirror_contentid = segconfig[1]
-        mirror_port = segconfig[2]
-        mirror_dir = segconfig[3]
+        waitstring = ''
+        dbid = segconfig[0]
+        contentid = segconfig[1]
+        segment_port = segconfig[2]
+        segment_dir = segconfig[3]
+        segment_role = self.getRole(contentid)
 
-        opts = "-p %d --gp_dbid=0 --silent-mode=true -i -M mirrorless --gp_contentid=%d --gp_num_contents_in_cluster=%d" % (mirror_port, mirror_contentid, self.num_contents)
-        commands.append("pg_ctl -D %s -o '%s' start" % (mirror_dir, opts))
-        commands.append("pg_ctl -D %s status" % mirror_dir)
+        # Need to set the dbid to 0 on segments to prevent use in mmxlog records
+        if contentid != -1:
+            dbid = 0
 
-        thread_name = 'Mirror content %d' % mirror_contentid
-        command_finish = 'Started mirror with content %d and port %d at %s' % (mirror_contentid, mirror_port, mirror_dir)
+        opts = "-p %d --gp_dbid=%d --silent-mode=true -i -M %s --gp_contentid=%d --gp_num_contents_in_cluster=%d" % \
+                                                    (segment_port, dbid, segment_role, contentid, self.num_contents)
+
+        # Arguments for the master. -x sets the dbid for the standby master. Hardcoded to 0 for now, but may need to be
+        # refactored when we start to focus on the standby master.
+        #
+        # -E echos internal commands to the  terminal. Set here mostly to maintain parity with gpstart behavior.
+        if contentid == -1:
+            opts += " -x 0 -E"
+
+        if self.wait:
+            waitstring = "-w -t 180"
+
+        commands.append("pg_ctl -D %s %s -o '%s' start" % (segment_dir, waitstring, opts))
+        commands.append("pg_ctl -D %s status" % segment_dir)
+
+        if contentid == -1:
+            segment_label = 'master'
+        elif segconfig[4] == 'p':
+            segment_label = 'primary'
+        else:
+            segment_label = 'mirror'
+
+        thread_name = 'Segment %s content %d' % (segment_label, contentid)
+        command_finish = 'Started %s segment with content %d and port %d at %s' % (segment_label, contentid, segment_port, segment_dir)
         runcommands(commands, thread_name, command_finish)
+
+    @property
+    def num_contents(self):
+        if self.__num_contents == None:
+            self.__num_contents = 0
+            for segconfig in self.segconfigs:
+                # Count primary segments
+                if segconfig[4] == 'p' and segconfig[1] != -1:
+                    self.__num_contents += 1
+
+        return self.__num_contents
+
+
+    def getRole(self, contentid):
+        if contentid == -1:
+            return 'master'
+        else:
+            return 'mirrorless'
 
     def run(self):
         startThreads = []
         for segconfig in self.segconfigs:
-            if segconfig[4] == 'm':
+            if self.segment_type == 'all' or segconfig[4] == self.segment_type:
                 thread = threading.Thread(target=self.startThread, args=(segconfig,))
                 thread.start()
                 startThreads.append(thread)
@@ -145,28 +192,62 @@ class StartMirrors():
         for thread in startThreads:
             thread.join()
 
+class ColdStartMaster(StartInstances):
+    ''' Start the greenplum master segment'''
 
-class StopMirrors():
-    ''' Stop the WAL replication mirror segment '''
+    def __init__(self, host, port, master_directory, num_contents=3):
+        self.segconfigs = [[0]*5]
+        self.segconfigs[0][0] = 1  # dbid
+        self.segconfigs[0][1] = -1 # content
+        self.segconfigs[0][2] = port
+        self.segconfigs[0][3] = master_directory
+        self.segconfigs[0][4] = 'p' # preferred role
+        self.num_contents = num_contents
+        self.host = host
+        self.segment_type = 'p'
+        self.wait = True
 
-    def __init__(self, segconfigs):
+class StopInstances():
+    ''' Stop all segments'''
+
+    def __init__(self, segconfigs, segment_type='all'):
         self.segconfigs = segconfigs
+        self.segment_type = segment_type
 
     def stopThread(self, segconfig):
         commands = []
-        mirror_contentid = segconfig[1]
-        mirror_dir = segconfig[3]
+        segment_contentid = segconfig[1]
+        segment_dir = segconfig[3]
 
-        commands.append("pg_ctl -D %s stop" % mirror_dir)
+        if segment_contentid == -1:
+            segment_type = 'master'
+        elif segconfig[4] == 'p':
+            segment_type = 'primary'
+        else:
+            segment_type = 'mirror'
 
-        thread_name = 'Mirror content %d' % mirror_contentid
-        command_finish = 'Stopped mirror at %s' % mirror_dir
+        commands.append("pg_ctl -D %s stop" % segment_dir)
+
+        thread_name = 'Segment %s content %d' % (segment_type, segment_contentid)
+        command_finish = 'Stopped %s segment at %s' % (segment_type, segment_dir)
         runcommands(commands, thread_name, command_finish)
+
+    def shouldTerminate(self, segconfig):
+        if self.segment_type == 'all':
+            return True
+
+        if self.segment_type == 'master' and segconfig[1] == -1:
+            return True
+
+        if segconfig[4] == self.segment_type:
+            return True
+
+        return False
 
     def run(self):
         stopThreads = []
         for segconfig in self.segconfigs:
-            if segconfig[4] == 'm':
+            if self.shouldTerminate(segconfig):
                 thread = threading.Thread(target=self.stopThread, args=(segconfig,))
                 thread.start()
                 stopThreads.append(thread)
@@ -218,7 +299,7 @@ class DestroyMirrors():
         runcommands(commands, "Main Mirror Destroy", "Notified primaries of mirror removal")
 
 def getSegInfo(hostname, port, dbname):
-    query = "SELECT dbid, content, port, fselocation, preferred_role FROM gp_segment_configuration s, pg_filespace_entry f WHERE s.content != -1 AND s.dbid = fsedbid"
+    query = "SELECT dbid, content, port, fselocation, preferred_role FROM gp_segment_configuration s, pg_filespace_entry f WHERE s.dbid = fsedbid"
     dburl = dbconn.DbURL(hostname, port, dbname)
 
     try:
@@ -236,9 +317,11 @@ def defargs():
                         help='Master host to get segment config information from')
     parser.add_argument('--port', type=str, required=False, default=os.getenv('PGPORT', '15432'),
                         help='Master port to get segment config information from')
+    parser.add_argument('--master-directory', type=str, required=False, default=os.getenv('MASTER_DATA_DIRECTORY'),
+                        help='Master port to get segment config information from')
     parser.add_argument('--database', type=str, required=False, default='postgres',
                         help='Database name to get segment config information from')
-    parser.add_argument('operation', type=str, choices=['init', 'start', 'stop', 'destroy'])
+    parser.add_argument('operation', type=str, choices=['init', 'clusterstart', 'start', 'stop', 'destroy'])
 
     return parser.parse_args()
 
@@ -246,15 +329,24 @@ if __name__ == "__main__":
     # Get parsed args
     args = defargs()
 
-    # Get information on all primary segments
+    # If we are starting the cluster, we need to start the master before we get the segment info
+    if args.operation == 'clusterstart':
+        ColdStartMaster(args.host, int(args.port), args.master_directory).run()
+
+    # Get information on all segments
     segconfigs = getSegInfo(args.host, args.port, args.database)
+
+    if args.operation == 'clusterstart':
+        StopInstances(segconfigs, 'master').run()
 
     # Execute the chosen operation
     if args.operation == 'init':
         InitMirrors(segconfigs, args.host).run()
+    elif args.operation == 'clusterstart':
+        StartInstances(segconfigs, args.host).run()
     elif args.operation == 'start':
-        StartMirrors(segconfigs, args.host).run()
+        StartInstances(segconfigs, args.host, 'm').run()
     elif args.operation == 'stop':
-        StopMirrors(segconfigs).run()
+        StopInstances(segconfigs, 'm').run()
     elif args.operation == 'destroy':
         DestroyMirrors(segconfigs).run()


### PR DESCRIPTION
Adds a clusterstart command to gpsegwalrep.py allow a user to start a
cluster with WALRep configured. This is a developer utility that assumes
all cluster replicas are present on localhost, and thus is not intended
for production use.