### PR TITLE
Dump more detailed info for memory usage in gp_resgroup_status

### DIFF
--- a/src/backend/utils/resgroup/resgroup_helper.c
+++ b/src/backend/utils/resgroup/resgroup_helper.c
@@ -151,8 +151,8 @@ getResUsage(ResGroupStatCtx *ctx, Oid inGroupId)
 					Datum d = ResGroupGetStat(groupId, RES_GROUP_STAT_MEM_USAGE);
 
 					row->groupId = groupId;
-					appendStringInfo(row->memUsage, "{\"%d\":%d",
-									 GpIdentity.segindex, DatumGetInt32(d));
+					appendStringInfo(row->memUsage, "{\"%d\":%s",
+									 GpIdentity.segindex, DatumGetCString(d));
 
 					appendStringInfo(row->cpuUsage, "{");
 					calcCpuUsage(row->cpuUsage, ncores, usages[j], timestamps[j],
@@ -186,8 +186,8 @@ getResUsage(ResGroupStatCtx *ctx, Oid inGroupId)
 			Oid groupId = DatumGetObjectId(row->groupId);
 			Datum d = ResGroupGetStat(groupId, RES_GROUP_STAT_MEM_USAGE);
 
-			appendStringInfo(row->memUsage, "\"%d\":%d",
-							 GpIdentity.segindex, DatumGetInt32(d));
+			appendStringInfo(row->memUsage, "\"%d\":%s",
+							 GpIdentity.segindex, DatumGetCString(d));
 
 			calcCpuUsage(row->cpuUsage, ncores, usages[j], timestamps[j],
 						 ResGroupOps_GetCpuUsage(groupId),

--- a/src/test/isolation2/expected/resgroup/resgroup_parallel_queries.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_parallel_queries.out
@@ -518,7 +518,7 @@ t
 (6 rows)
 
 -- After all queries finished in each resource group, the memory_usage should be zero, no memory leak
-with t_1 as ( select rsgname, row_to_json(json_each(memory_usage::json)) as j from gp_toolkit.gp_resgroup_status where rsgname like 'rg_test_g%' order by rsgname ) select rsgname, sum((j->'value')::text::int) from t_1 group by rsgname ;
+with t_1 as ( select rsgname, row_to_json(json_each(memory_usage::json)) as j from gp_toolkit.gp_resgroup_status where rsgname like 'rg_test_g%' order by rsgname ) select rsgname, sum(((j->'value')->>'used')::int) from t_1 group by rsgname ;
 rsgname   |sum
 ----------+---
 rg_test_g1|0  

--- a/src/test/isolation2/input/resgroup/resgroup_memory_statistic.source
+++ b/src/test/isolation2/input/resgroup/resgroup_memory_statistic.source
@@ -41,7 +41,7 @@ CREATE VIEW memory_result AS
 	FROM(
 		SELECT rsgname,
 		       CASE (j->'key')::text WHEN '"-1"'::text THEN 1 ELSE 0 END AS ismaster,
-		       (j->'value')::text::int AS memory_usage
+		       ((j->'value')->>'used')::int AS memory_usage
 		FROM(
 			SELECT rsgname, row_to_json(json_each(memory_usage::json)) AS j FROM
 			gp_toolkit.gp_resgroup_status

--- a/src/test/isolation2/output/resgroup/resgroup_memory_statistic.source
+++ b/src/test/isolation2/output/resgroup/resgroup_memory_statistic.source
@@ -27,7 +27,7 @@ CREATE
 CREATE FUNCTION round_test(float, integer) RETURNS float AS $$ SELECT round($1 / $2) * $2 $$ LANGUAGE sql;
 CREATE
 
-CREATE VIEW memory_result AS SELECT rsgname, ismaster, round_test(avg(memory_usage), 10) AS avg_mem FROM( SELECT rsgname, CASE (j->'key')::text WHEN '"-1"'::text THEN 1 ELSE 0 END AS ismaster, (j->'value')::text::int AS memory_usage FROM( SELECT rsgname, row_to_json(json_each(memory_usage::json)) AS j FROM gp_toolkit.gp_resgroup_status WHERE rsgname='rg1_memory_test' OR rsgname='rg2_memory_test' )a )b GROUP BY (rsgname, ismaster) ORDER BY rsgname, ismaster;
+CREATE VIEW memory_result AS SELECT rsgname, ismaster, round_test(avg(memory_usage), 10) AS avg_mem FROM( SELECT rsgname, CASE (j->'key')::text WHEN '"-1"'::text THEN 1 ELSE 0 END AS ismaster, ((j->'value')->>'used')::int AS memory_usage FROM( SELECT rsgname, row_to_json(json_each(memory_usage::json)) AS j FROM gp_toolkit.gp_resgroup_status WHERE rsgname='rg1_memory_test' OR rsgname='rg2_memory_test' )a )b GROUP BY (rsgname, ismaster) ORDER BY rsgname, ismaster;
 CREATE
 
 CREATE RESOURCE GROUP rg1_memory_test WITH (concurrency=2, cpu_rate_limit=10, memory_limit=30);

--- a/src/test/isolation2/sql/resgroup/resgroup_parallel_queries.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_parallel_queries.sql
@@ -244,7 +244,7 @@ with t_1 as
 (
 	select rsgname, row_to_json(json_each(memory_usage::json)) as j from gp_toolkit.gp_resgroup_status where rsgname like 'rg_test_g%' order by rsgname
 )
-select rsgname, sum((j->'value')::text::int) from t_1 group by rsgname ;
+select rsgname, sum(((j->'value')->>'used')::int) from t_1 group by rsgname ;
 
 -- start_ignore
 drop table rg_test_foo;


### PR DESCRIPTION
In this commit, we add more detailed memory metrics to the 'memory_usage'
column of gp_resgroup_status include current/available memory usage in
a group, current/available memory usage for a slot, current/available
memory usage for the shared part.