### PR TITLE
Fix warning of passing const to non-const parameter.

### DIFF
--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -927,8 +927,8 @@ FaultInjector_LookupHashEntry(
 	
 	if (entry == NULL) {
 		ereport(DEBUG5,
-				(errmsg("FaultInjector_LookupHashEntry() could not find fault injection hash entry identifier:'%d' ",
-						FaultInjectorIdentifierStringToEnum(faultName))));
+				(errmsg("FaultInjector_LookupHashEntry() could not find fault injection hash entry:'%s' ",
+						faultName)));
 	} 
 	
 	return entry;


### PR DESCRIPTION
Function FaultInjectorIdentifierStringToEnum(faultName) pass a const
string to a non-const parameter, which cause a build warnig. But on the
second thought, we have supported injecting fault by fault name without
corresponding fault identifier, so it's better to use faultname instead
of fault enum identifier in the ereport.