### PR TITLE
Improve stability of some flaky resource group test cases.

### DIFF
--- a/src/test/isolation2/expected/resgroup/resgroup_alter_concurrency.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_alter_concurrency.out
@@ -51,6 +51,12 @@ BEGIN
 22<:  <... completed>
 BEGIN
 
+SELECT pg_sleep(0.5);
+pg_sleep
+--------
+        
+(1 row)
+
 SELECT * FROM rg_activity_status;
 rsgname            |waiting_reason|current_query        
 -------------------+--------------+---------------------
@@ -64,6 +70,12 @@ END
 END
 21q: ... <quitting>
 22q: ... <quitting>
+
+SELECT pg_sleep(0.5);
+pg_sleep
+--------
+        
+(1 row)
 
 SELECT * FROM rg_activity_status;
 rsgname|waiting_reason|current_query
@@ -108,6 +120,12 @@ BEGIN
 22<:  <... completed>
 BEGIN
 
+SELECT pg_sleep(0.5);
+pg_sleep
+--------
+        
+(1 row)
+
 SELECT * FROM rg_activity_status;
 rsgname            |waiting_reason|current_query        
 -------------------+--------------+---------------------
@@ -121,6 +139,12 @@ END
 END
 21q: ... <quitting>
 22q: ... <quitting>
+
+SELECT pg_sleep(0.5);
+pg_sleep
+--------
+        
+(1 row)
 
 SELECT * FROM rg_activity_status;
 rsgname|waiting_reason|current_query
@@ -179,6 +203,12 @@ END
 22<:  <... completed>
 BEGIN
 
+SELECT pg_sleep(0.5);
+pg_sleep
+--------
+        
+(1 row)
+
 SELECT * FROM rg_activity_status;
 rsgname            |waiting_reason|current_query        
 -------------------+--------------+---------------------
@@ -192,6 +222,12 @@ END
 END
 21q: ... <quitting>
 22q: ... <quitting>
+
+SELECT pg_sleep(0.5);
+pg_sleep
+--------
+        
+(1 row)
 
 SELECT * FROM rg_activity_status;
 rsgname|waiting_reason|current_query
@@ -239,6 +275,12 @@ END
 22<:  <... completed>
 BEGIN
 
+SELECT pg_sleep(0.5);
+pg_sleep
+--------
+        
+(1 row)
+
 SELECT * FROM rg_activity_status;
 rsgname            |waiting_reason|current_query        
 -------------------+--------------+---------------------
@@ -252,6 +294,12 @@ END
 END
 21q: ... <quitting>
 22q: ... <quitting>
+
+SELECT pg_sleep(0.5);
+pg_sleep
+--------
+        
+(1 row)
 
 SELECT * FROM rg_activity_status;
 rsgname|waiting_reason|current_query
@@ -330,6 +378,12 @@ END
 22<:  <... completed>
 BEGIN
 
+SELECT pg_sleep(0.5);
+pg_sleep
+--------
+        
+(1 row)
+
 SELECT * FROM rg_activity_status;
 rsgname            |waiting_reason|current_query        
 -------------------+--------------+---------------------
@@ -343,6 +397,12 @@ END
 END
 21q: ... <quitting>
 22q: ... <quitting>
+
+SELECT pg_sleep(0.5);
+pg_sleep
+--------
+        
+(1 row)
 
 SELECT * FROM rg_activity_status;
 rsgname|waiting_reason|current_query
@@ -408,6 +468,12 @@ END
 22<:  <... completed>
 BEGIN
 
+SELECT pg_sleep(0.5);
+pg_sleep
+--------
+        
+(1 row)
+
 SELECT * FROM rg_activity_status;
 rsgname            |waiting_reason|current_query        
 -------------------+--------------+---------------------
@@ -421,6 +487,12 @@ END
 END
 21q: ... <quitting>
 22q: ... <quitting>
+
+SELECT pg_sleep(0.5);
+pg_sleep
+--------
+        
+(1 row)
 
 SELECT * FROM rg_activity_status;
 rsgname|waiting_reason|current_query

--- a/src/test/isolation2/input/resgroup/resgroup_alter_memory.source
+++ b/src/test/isolation2/input/resgroup/resgroup_alter_memory.source
@@ -263,6 +263,8 @@ SELECT * FROM rg_activity_status;
 12q:
 -- proc12 ends, 10%-5%=5% quota is returned to sys
 
+SELECT pg_sleep(0.5);
+
 SELECT * FROM rg_mem_status;
 SELECT * FROM rg_activity_status;
 
@@ -330,12 +332,16 @@ SELECT * FROM rg_activity_status;
 11q:
 -- proc11 ends, 10%-5%=5% quota is returned to sys
 
+SELECT pg_sleep(0.5);
+
 SELECT * FROM rg_mem_status;
 SELECT * FROM rg_activity_status;
 
 12: END;
 12q:
 -- proc12 ends, 10%-5%=5% quota is returned to sys
+
+SELECT pg_sleep(0.5);
 
 -- now rg2 can get 10% free quota from sys
 -- so proc22 can get enough quota and get executed
@@ -474,6 +480,8 @@ SELECT * FROM rg_activity_status;
 -- so rg2 gets 8.8% new quota
 -- now rg2 has 40% quota, free quota is 10%
 -- so proc24 shall be waken up
+
+SELECT pg_sleep(0.5);
 
 24<:
 SELECT * FROM rg_mem_status;

--- a/src/test/isolation2/output/resgroup/resgroup_alter_memory.source
+++ b/src/test/isolation2/output/resgroup/resgroup_alter_memory.source
@@ -424,6 +424,12 @@ rg2_memory_test|              |<IDLE> in transaction
 12q: ... <quitting>
 -- proc12 ends, 10%-5%=5% quota is returned to sys
 
+SELECT pg_sleep(0.5);
+pg_sleep
+--------
+        
+(1 row)
+
 SELECT * FROM rg_mem_status;
 groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
 ---------------+------------+---------------------+-------------------+----------------------------
@@ -550,6 +556,12 @@ END
 11q: ... <quitting>
 -- proc11 ends, 10%-5%=5% quota is returned to sys
 
+SELECT pg_sleep(0.5);
+pg_sleep
+--------
+        
+(1 row)
+
 SELECT * FROM rg_mem_status;
 groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
 ---------------+------------+---------------------+-------------------+----------------------------
@@ -569,6 +581,12 @@ rg2_memory_test|resgroup      |BEGIN;
 END
 12q: ... <quitting>
 -- proc12 ends, 10%-5%=5% quota is returned to sys
+
+SELECT pg_sleep(0.5);
+pg_sleep
+--------
+        
+(1 row)
 
 -- now rg2 can get 10% free quota from sys
 -- so proc22 can get enough quota and get executed
@@ -824,6 +842,12 @@ rg2_memory_test|resgroup      |BEGIN;
 -- so rg2 gets 8.8% new quota
 -- now rg2 has 40% quota, free quota is 10%
 -- so proc24 shall be waken up
+
+SELECT pg_sleep(0.5);
+pg_sleep
+--------
+        
+(1 row)
 
 24<:  <... completed>
 BEGIN

--- a/src/test/isolation2/sql/resgroup/resgroup_alter_concurrency.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_alter_concurrency.sql
@@ -35,12 +35,16 @@ SELECT * FROM rg_activity_status;
 21<:
 22<:
 
+SELECT pg_sleep(0.5);
+
 SELECT * FROM rg_activity_status;
 
 21:END;
 22:END;
 21q:
 22q:
+
+SELECT pg_sleep(0.5);
 
 SELECT * FROM rg_activity_status;
 
@@ -67,12 +71,16 @@ SELECT * FROM rg_activity_status;
 21<:
 22<:
 
+SELECT pg_sleep(0.5);
+
 SELECT * FROM rg_activity_status;
 
 21:END;
 22:END;
 21q:
 22q:
+
+SELECT pg_sleep(0.5);
 
 SELECT * FROM rg_activity_status;
 
@@ -105,12 +113,16 @@ SELECT * FROM rg_activity_status;
 11q:
 22<:
 
+SELECT pg_sleep(0.5);
+
 SELECT * FROM rg_activity_status;
 
 21:END;
 22:END;
 21q:
 22q:
+
+SELECT pg_sleep(0.5);
 
 SELECT * FROM rg_activity_status;
 
@@ -138,12 +150,16 @@ SELECT * FROM rg_activity_status;
 11q:
 22<:
 
+SELECT pg_sleep(0.5);
+
 SELECT * FROM rg_activity_status;
 
 21:END;
 22:END;
 21q:
 22q:
+
+SELECT pg_sleep(0.5);
 
 SELECT * FROM rg_activity_status;
 
@@ -188,12 +204,16 @@ SELECT * FROM rg_activity_status;
 11q:
 22<:
 
+SELECT pg_sleep(0.5);
+
 SELECT * FROM rg_activity_status;
 
 21:END;
 22:END;
 21q:
 22q:
+
+SELECT pg_sleep(0.5);
 
 SELECT * FROM rg_activity_status;
 
@@ -234,12 +254,16 @@ SELECT * FROM rg_activity_status;
 11q:
 22<:
 
+SELECT pg_sleep(0.5);
+
 SELECT * FROM rg_activity_status;
 
 21:END;
 22:END;
 21q:
 22q:
+
+SELECT pg_sleep(0.5);
 
 SELECT * FROM rg_activity_status;
 


### PR DESCRIPTION
In resource group test cases we verify that pending queries can be waken
up when free slot and/or memory quota is released by a finished query,
we use the isolation2 test framework to quit an old query and use
pg_stat_activity to check the pending status.

One problem is that the 'q' flag provided by the test framework only
ensure that the connection is closed, however the backends can still be
alive for a short time, if we query pg_stat_activity quick enough then
we may see the old query, which is expected to quit already, appears in
the output of pg_stat_activity. This doesn's always happen, but it does
happen now and then and makes the tests flaky.

As a workaround we put a short sleep in such cases to improve the
stability of these test cases.