### PR TITLE
Fix multistage aggregation plan targetlists

### DIFF
--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -3487,9 +3487,14 @@ Node* deconstruct_expr_mutator(Node *node, MppGroupContext *ctx)
 	/* If the given expression is a grouping expression, replace it with
 	 * a Var node referring to the (lower) preliminary aggregation's
 	 * target list.
+	 *
+	 * While building subplan targetlist we flatten (deduplicate) the
+	 * targetlist ignoring RelabelType node.
+	 * Including RelabelType will cause inconsistent top level target list
+	 * and final target list for aggregation plans.
 	 */
-	tle = tlist_member(node, ctx->grps_tlist);
-	if ( tle != NULL )
+	tle = tlist_member_ignore_relabel(node, ctx->grps_tlist);
+	if( tle != NULL )
 	{
 		return  (Node*) makeVar(grp_varno, tle->resno,
 								exprType((Node*)tle->expr),

--- a/src/test/regress/expected/bfv_aggregate.out
+++ b/src/test/regress/expected/bfv_aggregate.out
@@ -1468,6 +1468,24 @@ from mtup1 where c0 = 'foo' group by c0, c1 limit 10;
  foo | 2015-09-1.1 |         5670
 (1 row)
 
+-- MPP-29042 Multistage aggregation plans should have consistent targetlists in
+-- case of same column aliases and grouping on them.
+DROP TABLE IF EXISTS t1;
+NOTICE:  table "t1" does not exist, skipping
+CREATE TABLE t1 (a varchar) DISTRIBUTED RANDOMLY;
+INSERT INTO t1 VALUES ('aaaaaaa');
+INSERT INTO t1 VALUES ('aaaaaaa');
+INSERT INTO t1 VALUES ('bbbbbbb');
+INSERT INTO t1 VALUES ('bbbbbbb');
+INSERT INTO t1 VALUES ('bbbbb');
+SELECT substr(a, 1) as a FROM (SELECT ('-'||a)::varchar as a FROM (SELECT a FROM t1) t2) t3 GROUP BY a ORDER BY a;
+    a     
+----------
+ -aaaaaaa
+ -bbbbb
+ -bbbbbbb
+(3 rows)
+
 -- CLEANUP
 set client_min_messages='warning';
 drop schema bfv_aggregate cascade;

--- a/src/test/regress/expected/bfv_aggregate_optimizer.out
+++ b/src/test/regress/expected/bfv_aggregate_optimizer.out
@@ -1467,6 +1467,24 @@ from mtup1 where c0 = 'foo' group by c0, c1 limit 10;
  foo | 2015-09-1.1 |         5670
 (1 row)
 
+-- MPP-29042 Multistage aggregation plans should have consistent targetlists in
+-- case of same column aliases and grouping on them.
+DROP TABLE IF EXISTS t1;
+NOTICE:  table "t1" does not exist, skipping
+CREATE TABLE t1 (a varchar) DISTRIBUTED RANDOMLY;
+INSERT INTO t1 VALUES ('aaaaaaa');
+INSERT INTO t1 VALUES ('aaaaaaa');
+INSERT INTO t1 VALUES ('bbbbbbb');
+INSERT INTO t1 VALUES ('bbbbbbb');
+INSERT INTO t1 VALUES ('bbbbb');
+SELECT substr(a, 1) as a FROM (SELECT ('-'||a)::varchar as a FROM (SELECT a FROM t1) t2) t3 GROUP BY a ORDER BY a;
+    a     
+----------
+ -aaaaaaa
+ -bbbbb
+ -bbbbbbb
+(3 rows)
+
 -- CLEANUP
 set client_min_messages='warning';
 drop schema bfv_aggregate cascade;

--- a/src/test/regress/sql/bfv_aggregate.sql
+++ b/src/test/regress/sql/bfv_aggregate.sql
@@ -1351,6 +1351,16 @@ select c0, c1, array_length(ARRAY[
  SUM(c4 % 5670), SUM(c4 % 5671)], 1)
 from mtup1 where c0 = 'foo' group by c0, c1 limit 10;
 
+-- MPP-29042 Multistage aggregation plans should have consistent targetlists in
+-- case of same column aliases and grouping on them.
+DROP TABLE IF EXISTS t1;
+CREATE TABLE t1 (a varchar) DISTRIBUTED RANDOMLY;
+INSERT INTO t1 VALUES ('aaaaaaa');
+INSERT INTO t1 VALUES ('aaaaaaa');
+INSERT INTO t1 VALUES ('bbbbbbb');
+INSERT INTO t1 VALUES ('bbbbbbb');
+INSERT INTO t1 VALUES ('bbbbb');
+SELECT substr(a, 1) as a FROM (SELECT ('-'||a)::varchar as a FROM (SELECT a FROM t1) t2) t3 GROUP BY a ORDER BY a;
 
 -- CLEANUP
 set client_min_messages='warning';


### PR DESCRIPTION
If there are aggregation queries with column aliases same as the table actual
columns and they are propagated further from subqueries and grouping is
applied on the column alias it may result in inconsistent targetlists
for aggregation plans causing crash.
```sql
	CREATE TABLE t1 (a int) DISTRIBUTED RANDOMLY;
	SELECT substr(a, 2) as a
	FROM
		(SELECT ('-'||a)::varchar as a
			FROM (SELECT a FROM t1) t2
		) t3
	GROUP BY a;
        ERROR: Unexpected failure of multi-phase aggregation planning
        in some cases crash.
```
While building multistage aggregation plan we build flattened sub plan target lists ignoring relabel node types in `make_subplan_tlist`, however while building the final target list in `deconstruct_agg_info` for the aggregation plans we don't ignore relabel types which causes inconsistent final target list and top target list.