### PR TITLE
Fix bug in handling re-scan of a hash join.

### DIFF
--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -1380,7 +1380,6 @@ ExecHashJoinReloadHashTable(HashJoinState *hjstate)
 			 * possible for hashtable->nbatch to be increased here!
 			 */
 			ExecHashTableInsert(hashState, hashtable, slot, hashvalue);
-			hashtable->totalTuples += 1;
 		}
 
 		/*

--- a/src/include/executor/nodeHash.h
+++ b/src/include/executor/nodeHash.h
@@ -29,7 +29,7 @@ extern void ExecReScanHash(HashState *node, ExprContext *exprCtxt);
 
 extern HashJoinTable ExecHashTableCreate(HashState *hashState, HashJoinState *hjstate, List *hashOperators, uint64 operatorMemKB);
 extern void ExecHashTableDestroy(HashState *hashState, HashJoinTable hashtable);
-extern void ExecHashTableInsert(HashState *hashState, HashJoinTable hashtable,
+extern bool ExecHashTableInsert(HashState *hashState, HashJoinTable hashtable,
 					struct TupleTableSlot *slot,
 					uint32 hashvalue);
 extern bool ExecHashGetHashValue(HashState *hashState, HashJoinTable hashtable,


### PR DESCRIPTION
The WITH RECURSIVE test case in 'join_gp' would miss some rows, if
the hash algorithm (src/backend/access/hash/hashfunc.c) was replaced
with the one from PostgreSQL 8.4, or if statement_mem was lowered from
1000 kB to 700 kB. This is what happened:

1. A tuple belongs to batch 0, and is kept in memory during processing
   batch 0.

2. The outer scan finishes, and we spill the inner batch 0 from memory
   to a file, with SpillFirstBatch, and start processing tuple 1

3. While processing batch 1, the number of batches is increased, and
   the tuple that belonged to batch 0, and was already written to the
   batch 0's file, is moved, to a later batch.

4. After the first scan is complete, the hash join is re-scanned

5. We reload the batch file 0 into memory. While reloading, we encounter
   the tuple that now doesn't seem to belong to batch 0, and throw it
   away.

6. We perform the rest of the re-scan. We have missed any matches to the
   tuple that was thrown away. It was not part of the later batch files,
   because in the first pass, it was handled as part of batch 0. But in
   the re-scan, it was not handled as part of batch 0, because nbatch was
   now larger, so it didn't belong there.

To fix, when reloading a batch file we see a tuple that actually belongs
to a later batch file, we write it to that later file. To avoid adding
it there multiple times, if the hash join is re-scanned multiple times,
if any tuples are moved when reloading a batch file, destroy the batch
file and re-create it with just the remaining tuples.

Fixes github issue #3284