### PR TITLE
Remove now-unnecessary code from gp_read_error_log to dispatch the call.

### DIFF
--- a/src/backend/cdb/cdbsreh.c
+++ b/src/backend/cdb/cdbsreh.c
@@ -56,11 +56,6 @@ typedef struct ReadErrorLogContext
 {
 	FILE	   *fp;					/* file pointer to the error log */
 	char		filename[MAXPGPATH];/* filename of fp */
-	int			numTuples;			/* number of total tuples when dispatch */
-	PGresult  **segResults;			/* dispatch results */
-	int			numSegResults;		/* number of segResults */
-	int			currentResult;		/* current index in segResults to read */
-	int			currentRow;			/* current row in current result */
 } ReadErrorLogContext;
 
 typedef enum RejectLimitCode
@@ -688,19 +683,27 @@ ResultToDatum(PGresult *result, int row, AttrNumber attnum, PGFunction func, boo
 Datum
 gp_read_error_log(PG_FUNCTION_ARGS)
 {
-	FuncCallContext	   *funcctx;
+	FuncCallContext *funcctx;
 	ReadErrorLogContext *context;
-	HeapTuple			tuple;
-	Datum				result;
+	HeapTuple	tuple;
+	Datum		result;
+
+	/*
+	 * This function is marked as EXECUTE ON ALL SEGMENTS, so we
+	 * should not get here in the dispatcher.
+	 */
+	Assert (Gp_role != GP_ROLE_DISPATCH);
 
 	/*
 	 * First call setup
 	 */
 	if (SRF_IS_FIRSTCALL())
 	{
-		MemoryContext	oldcontext;
-		FILE	   *fp;
+		MemoryContext oldcontext;
 		text	   *relname;
+		RangeVar   *relrv;
+		Oid			relid;
+		AclResult	aclresult;
 
 		funcctx = SRF_FIRSTCALL_INIT();
 
@@ -713,81 +716,25 @@ gp_read_error_log(PG_FUNCTION_ARGS)
 		funcctx->tuple_desc = BlessTupleDesc(GetErrorTupleDesc());
 
 		/*
-		 * Though this function is usually executed on segment, we dispatch
-		 * the execution if it happens to be on QD, and combine the results
-		 * into one set.
+		 * Open the error log file.
 		 */
-		if (Gp_role == GP_ROLE_DISPATCH)
+
+		relrv = makeRangeVarFromNameList(textToQualifiedNameList(relname));
+		relid = RangeVarGetRelid(relrv, true);
+
+		/* If the relation has gone, silently return no tuples. */
+		if (OidIsValid(relid))
 		{
-			struct CdbPgResults cdb_pgresults = {NULL, 0};
-			StringInfoData sql;
+			/* Requires SELECT priv to read error log. */
+			aclresult = pg_class_aclcheck(relid, GetUserId(), ACL_SELECT);
+			if (aclresult != ACLCHECK_OK)
+				aclcheck_error(aclresult, ACL_KIND_CLASS, relrv->relname);
 
-			int		i;
-
-			initStringInfo(&sql);
-			/*
-			 * construct SQL
-			 */
-			appendStringInfo(&sql,
-					"SELECT * FROM pg_catalog.gp_read_error_log(%s) ",
-							 quote_literal_internal(text_to_cstring(relname)));
-
-			CdbDispatchCommand(sql.data, DF_WITH_SNAPSHOT, &cdb_pgresults);
-
-			for (i = 0; i < cdb_pgresults.numResults; i++)
-			{
-				if (PQresultStatus(cdb_pgresults.pg_results[i]) != PGRES_TUPLES_OK)
-				{
-					cdbdisp_clearCdbPgResults(&cdb_pgresults);
-					elog(ERROR, "unexpected result from segment: %d",
-								PQresultStatus(cdb_pgresults.pg_results[i]));
-				}
-				context->numTuples += PQntuples(cdb_pgresults.pg_results[i]);
-			}
-
-			pfree(sql.data);
-
-			context->segResults = cdb_pgresults.pg_results;
-			context->numSegResults = cdb_pgresults.numResults;
-		}
-		else
-		{
-			/*
-			 * In QE, read the error log.
-			 */
-			RangeVar	   *relrv;
-			Oid				relid;
-
-			relrv = makeRangeVarFromNameList(textToQualifiedNameList(relname));
-			relid = RangeVarGetRelid(relrv, true);
-
-			/*
-			 * If the relation has gone, silently return no tuples.
-			 */
-			if (OidIsValid(relid))
-			{
-				AclResult aclresult;
-
-				/*
-				 * Requires SELECT priv to read error log.
-				 */
-				aclresult = pg_class_aclcheck(relid, GetUserId(), ACL_SELECT);
-				if (aclresult != ACLCHECK_OK)
-					aclcheck_error(aclresult, ACL_KIND_CLASS, relrv->relname);
-
-				ErrorLogFileName(context->filename, MyDatabaseId, relid);
-				fp = AllocateFile(context->filename, "r");
-				context->fp = fp;
-			}
+			ErrorLogFileName(context->filename, MyDatabaseId, relid);
+			context->fp = AllocateFile(context->filename, "r");
 		}
 
 		MemoryContextSwitchTo(oldcontext);
-
-		if (Gp_role != GP_ROLE_DISPATCH && !context->fp)
-		{
-			pfree(context);
-			SRF_RETURN_DONE(funcctx);
-		}
 	}
 
 	funcctx = SRF_PERCALL_SETUP();
@@ -835,52 +782,6 @@ gp_read_error_log(PG_FUNCTION_ARGS)
 			result = HeapTupleGetDatum(tuple);
 			SRF_RETURN_NEXT(funcctx, result);
 		}
-	}
-
-	/*
-	 * If we got results from dispatch, return all the tuples.
-	 */
-	while (context->currentResult < context->numSegResults)
-	{
-		Datum		values[NUM_ERRORTABLE_ATTR];
-		bool		isnull[NUM_ERRORTABLE_ATTR];
-		PGresult   *segres = context->segResults[context->currentResult];
-		int			row = context->currentRow;
-
-		if (row >= PQntuples(segres))
-		{
-			context->currentRow = 0;
-			context->currentResult++;
-			continue;
-		}
-		context->currentRow++;
-
-		MemSet(isnull, false, sizeof(isnull));
-
-		values[0] = ResultToDatum(segres, row, 0, timestamptz_in, &isnull[0]);
-		values[1] = ResultToDatum(segres, row, 1, textin, &isnull[1]);
-		values[2] = ResultToDatum(segres, row, 2, textin, &isnull[2]);
-		values[3] = ResultToDatum(segres, row, 3, int4in, &isnull[3]);
-		values[4] = ResultToDatum(segres, row, 4, int4in, &isnull[4]);
-		values[5] = ResultToDatum(segres, row, 5, textin, &isnull[5]);
-		values[6] = ResultToDatum(segres, row, 6, textin, &isnull[6]);
-		values[7] = ResultToDatum(segres, row, 7, byteain, &isnull[7]);
-
-		tuple = heap_form_tuple(funcctx->tuple_desc, values, isnull);
-		result = HeapTupleGetDatum(tuple);
-
-		SRF_RETURN_NEXT(funcctx, result);
-	}
-
-	if (context->segResults != NULL)
-	{
-		int		i;
-
-		for (i = 0; i < context->numSegResults; i++)
-			PQclear(context->segResults[i]);
-
-		/* XXX: better to copy to palloc'ed area */
-		free(context->segResults);
 	}
 
 	/*


### PR DESCRIPTION
There was code in gp_read_error_log(), to "manually" dispatch the call to
all the segments, if it was executed in the dispatcher. This was
previously necessary, because even though the function was marked with
prodataaccess='s', the planner did not guarantee that it's executed in the
segments, when called in the targetlist like "SELECT
gp_read_error_log('tab')". Now that we have the EXECUTE ON ALL SEGMENTS
syntax, and are more rigorous about enforcing that in the planner, this
hack is no longer required.