### PR TITLE
Fix Coverity Scan Issue for PLJAVA

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -5605,7 +5605,14 @@ assign_pljava_classpath_insecure(bool newval, bool doit, GucSource source)
 	if ( newval == true )
 	{
 		struct config_generic *pljava_cp = find_option("pljava_classpath", false, ERROR);
-		pljava_cp->context = PGC_USERSET;
+		if (pljava_cp != NULL)
+		{
+			pljava_cp->context = PGC_USERSET;
+		}
+		else
+		{
+			elog(ERROR, "Failed to set insecure PLJAVA classpath");
+		}
 	}
 	return true;
 }


### PR DESCRIPTION
A PL/JAVA NULL point reference has been reported by coverity scan.
The issue is located in guc.c for a pljava guc option
"pljava_classpath_insecure" and fixed in this commit.