### PR TITLE
Resgroup refactor (part 03)

### DIFF
--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -1405,6 +1405,8 @@ retry:
 /*
  * Wake up the backends in the wait queue when 'concurrency' is increased.
  * This function is called in the callback function of ALTER RESOURCE GROUP.
+ *
+ * Return TRUE if any memory quota or shared quota is returned to syspool.
  */
 /*
  * XXX
@@ -1510,9 +1512,11 @@ groupApplyMemCaps(ResGroupData *group, const ResGroupCaps *caps)
 	 *
 	 * now we alter rg1 memory_limit to 40 in another session,
 	 * apparently both memory quota and shared quota are expected to increase,
-	 * our as our design is to let them increase on new queries,
+	 * however as our design is to let them increase on new queries,
 	 * then for session1 it won't see memory shared quota being increased
 	 * until new queries being executed in rg1.
+	 *
+	 * so we should try to acquire the new quota immediately.
 	 */
 	groupAcquireMemQuota(group, caps);
 #endif

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -89,7 +89,7 @@ struct ResGroupProcData
 
 	ResGroupCaps	caps;
 
-	uint32	memUsage;			/* memory usage of current proc */
+	int32	memUsage;			/* memory usage of current proc */
 	bool	doMemCheck;			/* whether to do memory limit check */
 };
 
@@ -797,8 +797,8 @@ ResGroupReserveMemory(int32 memoryChunks, int32 overuseChunks, bool *waiverUsed)
 		groupDecMemUsage(group, slot, memoryChunks);
 
 		/* also revert in proc */
-		Assert(self->memUsage >= memoryChunks);
 		self->memUsage -= memoryChunks;
+		Assert(self->memUsage >= 0);
 
 		if (overuseChunks == 0)
 			ResGroupDumpMemoryInfo();

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -185,7 +185,7 @@ static bool localResWaiting = false;
 static bool groupApplyMemCaps(ResGroupData *group, const ResGroupCaps *caps);
 static int32 getChunksFromPool(Oid groupId, int32 chunks);
 static void returnChunksToPool(Oid groupId, int32 chunks);
-static void groupAssginChunks(ResGroupData *group,
+static void groupAssignChunks(ResGroupData *group,
 							  int32 chunks,
 							  const ResGroupCaps *caps);
 static int32 getSegmentChunks(void);
@@ -1023,7 +1023,7 @@ ResGroupCreate(Oid groupId, const ResGroupCaps *caps)
 	group->memExpected = groupGetMemExpected(caps);
 
 	chunks = getChunksFromPool(groupId, group->memExpected);
-	groupAssginChunks(group, chunks, caps);
+	groupAssignChunks(group, chunks, caps);
 
 	return group;
 }
@@ -1570,7 +1570,7 @@ returnChunksToPool(Oid groupId, int32 chunks)
  * part of the group, the amount is calculated from caps.
  */
 static void
-groupAssginChunks(ResGroupData *group, int32 chunks, const ResGroupCaps *caps)
+groupAssignChunks(ResGroupData *group, int32 chunks, const ResGroupCaps *caps)
 {
 	int32 delta;
 	int32 memQuotaGranted = groupGetMemQuotaExpected(caps);
@@ -1811,7 +1811,7 @@ groupAcquireMemQuota(ResGroupData *group, const ResGroupCaps *caps)
 	if (neededMemStocks > 0)
 	{
 		int32 chunks = getChunksFromPool(group->groupId, neededMemStocks);
-		groupAssginChunks(group, chunks, caps);
+		groupAssignChunks(group, chunks, caps);
 	}
 }
 

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -2311,12 +2311,17 @@ ResGroupWaitCancel(void)
 
 		groupWaitQueueErase(group, MyProc);
 	}
-	else if (selfHasSlot())
+	else if (MyProc->resSlotId)
 	{
 		/* Woken up by a slot holder */
 
 		Assert(!procIsInWaitQueue(MyProc));
+
+		/* First complete the slot's transfer from MyProc to self */
+		selfSetSlot(MyProc->resSlotId);
 		Assert(selfIsAssignedValidGroup());
+
+		/* Then run the normal cleanup process */
 		putSlot();
 		Assert(!selfHasSlot());
 

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -2395,10 +2395,11 @@ ResGroupWaitCancel(void)
 
 		groupWaitQueueErase(group, MyProc);
 	}
-	else if (!procIsInWaitQueue(MyProc) && selfHasSlot())
+	else if (selfHasSlot())
 	{
 		/* Woken up by a slot holder */
 
+		Assert(!procIsInWaitQueue(MyProc));
 		Assert(selfIsAssignedValidGroup());
 		putSlot();
 		Assert(!selfHasSlot());
@@ -2418,6 +2419,8 @@ ResGroupWaitCancel(void)
 		 * The transaction of DROP RESOURCE GROUP is finished,
 		 * ResGroupSlotAcquire will do the retry.
 		 */
+		Assert(!procIsInWaitQueue(MyProc));
+		Assert(!selfHasSlot());
 	}
 
 	LWLockRelease(ResGroupLock);

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -35,10 +35,19 @@ typedef struct ResGroupCap
  * for a resource group.
  *
  * The properties must be in the same order as ResGroupLimitType.
+ *
+ * This struct can also be converted to an array of ResGroupCap so the fields
+ * can be accessed via index and iterated with loop.
+ *
+ *     ResGroupCaps caps;
+ *     ResGroupCap *array = (ResGroupCap *) &caps;
+ *     caps.concurrency.value = 1;
+ *     array[RESGROUP_LIMIT_TYPE_CONCURRENCY] = 2;
+ *     Assert(caps.concurrency.value == 2);
  */
 typedef struct ResGroupCaps
 {
-	ResGroupCap		__unknown;
+	ResGroupCap		__unknown;			/* placeholder, do not use it */
 	ResGroupCap		concurrency;
 	ResGroupCap		cpuRateLimit;
 	ResGroupCap		memLimit;
@@ -53,10 +62,19 @@ typedef struct ResGroupCaps
  * or the new settings from ALTER RESOURCE GROUP syntax.
  *
  * The properties must be in the same order as ResGroupLimitType.
+ *
+ * This struct can also be converted to an array of int32 so the fields
+ * can be accessed via index and iterated with loop.
+ *
+ *     ResGroupOpts opts;
+ *     int32 *array = (int32 *) &opts;
+ *     opts.concurrency = 1;
+ *     array[RESGROUP_LIMIT_TYPE_CONCURRENCY] = 2;
+ *     Assert(opts.concurrency == 2);
  */
 typedef struct ResGroupOpts
 {
-	int32			__unknown;
+	int32			__unknown;			/* placeholder, do not use it */
 	int32			concurrency;
 	int32			cpuRateLimit;
 	int32			memLimit;

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -95,8 +95,6 @@ extern int MaxResourceGroups;
 extern double gp_resource_group_cpu_limit;
 extern double gp_resource_group_memory_limit;
 
-struct ResGroupConfigSnapshot;
-
 /* Type of statistic infomation */
 typedef enum
 {
@@ -141,11 +139,6 @@ extern void SwitchResGroupOnSegment(const char *buf, int len);
 /* Retrieve statistic information of type from resource group */
 extern Datum ResGroupGetStat(Oid groupId, ResGroupStatType type);
 
-extern int32 ResGroupCalcMemStocksExpected(const ResGroupCaps *caps);
-extern int32 ResGroupCalcMemQuotaStocks(const ResGroupCaps *caps);
-extern int32 ResGroupCalcMemSharedStocks(const ResGroupCaps *caps);
-extern int32 ResGroupCalcMemSpillStocks(const ResGroupCaps *caps);
-
 extern void ResGroupOptsToCaps(const ResGroupOpts *optsIn, ResGroupCaps *capsOut);
 extern void ResGroupCapsToOpts(const ResGroupCaps *capsIn, ResGroupOpts *optsOut);
 extern void ResGroupDumpMemoryInfo(void);
@@ -160,8 +153,6 @@ extern void ResGroupAlterOnCommit(Oid groupId,
 								  const ResGroupCaps *caps);
 extern void ResGroupDropCheckForWakeup(Oid groupId, bool isCommit);
 extern void ResGroupCheckForDrop(Oid groupId, char *name);
-extern int32 ResGroupAllocStocks(Oid groupId, int32 stocks);
-extern void ResGroupFreeStocks(Oid groupId, int32 stocks);
 extern void ResGroupDecideMemoryCaps(int groupId,
 									 ResGroupCaps *caps,
 									 const ResGroupOpts *opts);
@@ -173,7 +164,6 @@ extern void ResGroupDecideConcurrencyCaps(Oid groupId,
 extern void ResGroupGetMemInfo(int *memLimit, int *slotQuota, int *sharedQuota);
 
 extern int64 ResourceGroupGetQueryMemoryLimit(void);
-extern int32 ResGroupGetMemStocks(Oid groupId);
 
 #define LOG_RESGROUP_DEBUG(...) \
 	do {if (Debug_resource_group) elog(__VA_ARGS__); } while(false);


### PR DESCRIPTION
This is the third part for resgroup refactor, previous parts were tracked in #3246 and #3282.

In this part we abstract more frequently used or complex operations into helper functions. We also simplified the QE switch logic.