### PR TITLE
Convert GPDB-specific GUCs to the new "enum" type

### DIFF
--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -5135,9 +5135,9 @@ choose_deduplicate(PlannerInfo *root, List *sortExprs,
 		*numGroups = num_distinct;
 
 	/* we need some calculates above even if the flag is off */
-	if (pg_strcasecmp(gp_idf_deduplicate_str, "force") == 0)
+	if (gp_idf_deduplicate == IDF_DEDUPLICATE_FORCE)
 		return true;
-	if (pg_strcasecmp(gp_idf_deduplicate_str, "none") == 0)
+	if (gp_idf_deduplicate == IDF_DEDUPLICATE_NONE)
 		return false;
 
 	return dedup_cost < naive_cost;

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -70,33 +70,14 @@
  * Assign/Show hook functions defined in this module
  */
 static const char *assign_gp_workfile_compress_algorithm(const char *newval, bool doit, GucSource source);
-static const char *assign_gp_workfile_type_hashjoin(const char *newval, bool doit, GucSource source);
-static const char *assign_optimizer_log_failure(const char *newval,
-							 bool doit, GucSource source);
 static const char *assign_optimizer_minidump(const char *newval,
 						  bool doit, GucSource source);
 static bool assign_optimizer(bool newval, bool doit, GucSource source);
 static bool assign_codegen(bool newval, bool doit, GucSource source);
-static const char *assign_codegen_optimization_level(const char *newval,
-                                                     bool doit, GucSource source);
-static const char *assign_optimizer_cost_model(const char *newval,
-							bool doit, GucSource source);
-static const char *assign_system_cache_flush_force(const char *newval, bool doit,
-								GucSource source);
-static const char *assign_gp_idf_deduplicate(const char *newval, bool doit,
-						  GucSource source);
-static const char *assign_explain_memory_verbosity(const char *newval, bool doit, GucSource source);
+static bool assign_codegen_optimization_level(int newval, bool doit,
+							GucSource source);
 static bool assign_dispatch_log_stats(bool newval, bool doit, GucSource source);
 static bool assign_gp_hashagg_default_nbatches(int newval, bool doit, GucSource source);
-
-static const char *assign_debug_dtm_action(const char *newval,
-						bool doit, GucSource source);
-static const char *assign_debug_dtm_action_target(const char *newval,
-							   bool doit, GucSource source);
-static const char *assign_debug_dtm_action_protocol(const char *newval,
-								 bool doit, GucSource source);
-static const char *assign_gp_log_format(const char *value, bool doit,
-					 GucSource source);
 
 /* Helper function for guc setter */
 extern const char *gpvars_assign_gp_resqueue_priority_default_value(const char *newval,
@@ -122,9 +103,6 @@ List	   *gp_guc_list_for_explain;
 List	   *gp_guc_list_for_no_plan;
 
 char	   *Debug_dtm_action_sql_command_tag;
-char	   *Debug_dtm_action_str;
-char	   *Debug_dtm_action_target_str;
-char	   *Debug_dtm_action_protocol_str;
 
 bool		Debug_print_full_dtm = false;
 bool		Debug_print_snapshot_dtm = false;
@@ -334,12 +312,7 @@ static char *gp_resource_manager_str;
  * and is kept in sync by assign_hooks.
  */
 static char *gp_workfile_compress_algorithm_str;
-static char *gp_workfile_type_hashjoin_str;
-static char *optimizer_log_failure_str;
 static char *optimizer_minidump_str;
-static char *optimizer_cost_model_str;
-static char *gp_log_format_string;
-static char *explain_memory_verbosity_str;
 
 /* Backoff-related GUCs */
 bool		gp_enable_resqueue_priority;
@@ -412,7 +385,6 @@ PasswdHashAlg password_hash_algorithm = PASSWORD_HASH_MD5;
 
 /* system cache invalidation mode*/
 int			gp_test_system_cache_flush_force = SysCacheFlushForce_Off;
-static char *gp_test_system_cache_flush_force_str;
 
 /* include file/line information to stack traces */
 bool		gp_log_stack_trace_lines;
@@ -424,7 +396,7 @@ bool		gp_log_stack_trace_lines;
  */
 bool		dml_ignore_target_partition_check = false;
 
-char	   *gp_idf_deduplicate_str;
+int			gp_idf_deduplicate;
 
 bool		fts_diskio_check = false;
 
@@ -568,7 +540,6 @@ bool		codegen_exec_eval_expr;
 bool		codegen_advance_aggregate;
 int		codegen_varlen_tolerance;
 int		codegen_optimization_level;
-static char 	*codegen_optimization_level_str = NULL;
 
 /* System Information */
 static int	gp_server_version_num;
@@ -586,6 +557,103 @@ bool		gp_enable_segment_copy_checking = true;
 char	   *gp_default_storage_options = NULL;
 
 int			writable_external_table_bufsize = 64;
+
+static const struct config_enum_entry gp_log_format_options[] = {
+	{"text", 0},
+	{"csv", 1},
+	{NULL, 0}
+};
+
+static const struct config_enum_entry debug_dtm_action_protocol_options[] = {
+	{"none", DTX_PROTOCOL_COMMAND_NONE},
+	{"abort_no_prepared", DTX_PROTOCOL_COMMAND_ABORT_NO_PREPARED},
+	{"prepare", DTX_PROTOCOL_COMMAND_PREPARE},
+	{"abort_some_prepared", DTX_PROTOCOL_COMMAND_ABORT_SOME_PREPARED},
+	{"commit_prepared", DTX_PROTOCOL_COMMAND_COMMIT_PREPARED},
+	{"abort_prepared", DTX_PROTOCOL_COMMAND_ABORT_PREPARED},
+	{"retry_commit_prepared", DTX_PROTOCOL_COMMAND_RETRY_COMMIT_PREPARED},
+	{"retry_abort_prepared", DTX_PROTOCOL_COMMAND_RETRY_ABORT_PREPARED},
+	{"recovery_commit_prepared", DTX_PROTOCOL_COMMAND_RECOVERY_COMMIT_PREPARED},
+	{"recovery_abort_prepared", DTX_PROTOCOL_COMMAND_RECOVERY_ABORT_PREPARED},
+	{"subtransaction_begin", DTX_PROTOCOL_COMMAND_SUBTRANSACTION_BEGIN_INTERNAL},
+	{"subtransaction_release", DTX_PROTOCOL_COMMAND_SUBTRANSACTION_RELEASE_INTERNAL},
+	{"subtransaction_rollback", DTX_PROTOCOL_COMMAND_SUBTRANSACTION_ROLLBACK_INTERNAL},
+	{NULL, 0}
+};
+
+static const struct config_enum_entry optimizer_log_failure_options[] = {
+	{"all", OPTIMIZER_ALL_FAIL},
+	{"unexpected", OPTIMIZER_UNEXPECTED_FAIL},
+	{"expected", OPTIMIZER_EXPECTED_FAIL},
+	{NULL, 0}
+};
+
+static const struct config_enum_entry codegen_optimization_level_options[] = {
+	/*
+	 * GPDB_84_MERGE_FIXME
+	 *
+	 * We've introduced this "unset" value to handle the case where USE_CODEGEN
+	 * is not set. Revisit: do we really want to do this?
+	 *
+	 * If we choose to keep it, we should eventually mark it as hidden, but the
+	 * hidden field will be added later in REL8_4_STABLE.
+	 */
+	{"", CODEGEN_OPTIMIZATION_LEVEL_UNSET},
+	{"none", CODEGEN_OPTIMIZATION_LEVEL_NONE},
+	{"less", CODEGEN_OPTIMIZATION_LEVEL_LESS},
+	{"default", CODEGEN_OPTIMIZATION_LEVEL_DEFAULT},
+	{"aggressive", CODEGEN_OPTIMIZATION_LEVEL_AGGRESSIVE},
+	{NULL, 0}
+};
+
+static const struct config_enum_entry optimizer_cost_model_options[] = {
+	{"legacy", OPTIMIZER_GPDB_LEGACY},
+	{"calibrated", OPTIMIZER_GPDB_CALIBRATED},
+	{NULL, 0}
+};
+
+static const struct config_enum_entry explain_memory_verbosity_options[] = {
+	{"suppress", EXPLAIN_MEMORY_VERBOSITY_SUPPRESS},
+	{"summary", EXPLAIN_MEMORY_VERBOSITY_SUMMARY},
+	{"detail", EXPLAIN_MEMORY_VERBOSITY_DETAIL},
+	{NULL, 0}
+};
+
+static const struct config_enum_entry system_cache_flush_force_options[] = {
+	{"off", SysCacheFlushForce_Off},
+	{"recursive", SysCacheFlushForce_Recursive},
+	{"plain", SysCacheFlushForce_NonRecursive},
+	{NULL, 0}
+};
+
+static const struct config_enum_entry gp_idf_deduplicate_options[] = {
+	{"auto", IDF_DEDUPLICATE_AUTO},
+	{"none", IDF_DEDUPLICATE_NONE},
+	{"force", IDF_DEDUPLICATE_FORCE},
+	{NULL, 0}
+};
+
+static const struct config_enum_entry debug_dtm_action_options[] = {
+	{"none", DEBUG_DTM_ACTION_NONE},
+	{"delay", DEBUG_DTM_ACTION_DELAY},
+	{"fail_begin_command", DEBUG_DTM_ACTION_FAIL_BEGIN_COMMAND},
+	{"fail_end_command", DEBUG_DTM_ACTION_FAIL_END_COMMAND},
+	{"panic_begin_command", DEBUG_DTM_ACTION_PANIC_BEGIN_COMMAND},
+	{NULL, 0}
+};
+
+static const struct config_enum_entry debug_dtm_action_target_options[] = {
+	{"none", DEBUG_DTM_ACTION_TARGET_NONE},
+	{"protocol", DEBUG_DTM_ACTION_TARGET_PROTOCOL},
+	{"sql", DEBUG_DTM_ACTION_TARGET_SQL},
+	{NULL, 0}
+};
+
+static const struct config_enum_entry gp_workfile_type_hashjoin_options[] = {
+	{"bfz", BFZ},
+	{"buffile", BUFFILE},
+	{NULL, 0}
+};
 
 IndexCheckType gp_indexcheck_insert = INDEX_CHECK_NONE;
 IndexCheckType gp_indexcheck_vacuum = INDEX_CHECK_NONE;
@@ -4926,32 +4994,12 @@ struct config_string ConfigureNamesString_gp[] =
 	},
 
 	{
-		{"gp_workfile_type_hashjoin", PGC_USERSET, QUERY_TUNING_OTHER,
-			gettext_noop("Specify the type of work files to use for executing hash join plans."),
-			gettext_noop("Valid values are \"BFZ\", \"BUFFILE\"."),
-			GUC_GPDB_ADDOPT | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&gp_workfile_type_hashjoin_str,
-		"bfz", assign_gp_workfile_type_hashjoin, NULL
-	},
-
-	{
 		{"gpperfmon_log_alert_level", PGC_USERSET, LOGGING,
 			gettext_noop("Specify the log alert level used by gpperfmon."),
 			gettext_noop("Valid values are 'none', 'warning', 'error', 'fatal', 'panic'.")
 		},
 		&gpperfmon_log_alert_level_str,
 		"none", gpvars_assign_gp_gpperfmon_log_alert_level, gpvars_show_gp_gpperfmon_log_alert_level
-	},
-
-	{
-		{"explain_memory_verbosity", PGC_USERSET, RESOURCES_MEM,
-			gettext_noop("Experimental feature: show memory account usage in EXPLAIN ANALYZE."),
-			gettext_noop("Valid values are SUPPRESS, SUMMARY, and DETAIL."),
-			GUC_GPDB_ADDOPT
-		},
-		&explain_memory_verbosity_str,
-		"suppress", assign_explain_memory_verbosity, NULL
 	},
 
 	{
@@ -4985,16 +5033,6 @@ struct config_string ConfigureNamesString_gp[] =
 	},
 
 	{
-		{"optimizer_log_failure", PGC_USERSET, LOGGING_WHEN,
-			gettext_noop("Sets which optimizer failures are logged."),
-			gettext_noop("Valid values are unexpected, expected, all"),
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&optimizer_log_failure_str,
-		"all", assign_optimizer_log_failure, NULL
-	},
-
-	{
 		{"optimizer_minidump", PGC_USERSET, LOGGING_WHEN,
 			gettext_noop("Generate optimizer minidump."),
 			gettext_noop("Valid values are onerror, always"),
@@ -5003,15 +5041,6 @@ struct config_string ConfigureNamesString_gp[] =
 		"onerror", assign_optimizer_minidump, NULL
 	},
 
-	{
-		{"optimizer_cost_model", PGC_USERSET, DEVELOPER_OPTIONS,
-			gettext_noop("Set optimizer cost model."),
-			gettext_noop("Valid values are legacy, calibrated"),
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&optimizer_cost_model_str,
-		"calibrated", assign_optimizer_cost_model, NULL
-	},
 	{
 		{"gp_session_role", PGC_BACKEND, GP_WORKER_IDENTITY,
 			gettext_noop("Reports the default role for the session."),
@@ -5100,36 +5129,6 @@ struct config_string ConfigureNamesString_gp[] =
 		},
 		&qdHostname,
 		"", NULL, NULL
-	},
-
-	{
-		{"debug_dtm_action", PGC_SUSET, DEVELOPER_OPTIONS,
-			gettext_noop("Sets the debug DTM action."),
-			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&Debug_dtm_action_str,
-		"none", assign_debug_dtm_action, NULL
-	},
-
-	{
-		{"debug_dtm_action_target", PGC_SUSET, DEVELOPER_OPTIONS,
-			gettext_noop("Sets the debug DTM action target."),
-			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&Debug_dtm_action_target_str,
-		"none", assign_debug_dtm_action_target, NULL
-	},
-
-	{
-		{"debug_dtm_action_protocol", PGC_SUSET, DEVELOPER_OPTIONS,
-			gettext_noop("Sets the debug DTM action protocol."),
-			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&Debug_dtm_action_protocol_str,
-		"none", assign_debug_dtm_action_protocol, NULL
 	},
 
 	{
@@ -5300,16 +5299,6 @@ struct config_string ConfigureNamesString_gp[] =
 	},
 
 	{
-		{"gp_test_system_cache_flush_force", PGC_USERSET, GP_ERROR_HANDLING,
-			gettext_noop("Force invalidation of system caches on each access"),
-			gettext_noop("Valid values are OFF, PLAIN and RECURSIVE."),
-			GUC_GPDB_ADDOPT | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&gp_test_system_cache_flush_force_str,
-		"off", assign_system_cache_flush_force, NULL
-	},
-
-	{
 		{"gp_hadoop_connector_jardir", PGC_USERSET, CUSTOM_OPTIONS,
 			gettext_noop("The directory of the Hadoop connector JAR, relative to $GPHOME."),
 			NULL,
@@ -5359,14 +5348,6 @@ struct config_string ConfigureNamesString_gp[] =
 		"MD5", assign_password_hash_algorithm, NULL
 	},
 
-	{
-		{"gp_idf_deduplicate", PGC_USERSET, QUERY_TUNING_METHOD,
-			gettext_noop("Sets the mode to control inverse distribution function's de-duplicate strategy."),
-			gettext_noop("Valid values are AUTO, NONE, and FORCE.")
-		},
-		&gp_idf_deduplicate_str,
-		"auto", assign_gp_idf_deduplicate, NULL
-	},
 
 	{
 		{"optimizer_search_strategy_path", PGC_USERSET, QUERY_TUNING_METHOD,
@@ -5385,30 +5366,6 @@ struct config_string ConfigureNamesString_gp[] =
 			GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&gp_default_storage_options, "", assign_gp_default_storage_options, NULL
-	},
-
-	{
-		{"gp_log_format", PGC_POSTMASTER, LOGGING_WHERE,
-			gettext_noop("Sets the format for log files."),
-			gettext_noop("Valid values are TEXT, CSV.")
-		},
-		&gp_log_format_string,
-		"csv", assign_gp_log_format, NULL
-	},
-
-	{
-		{"codegen_optimization_level", PGC_USERSET, DEVELOPER_OPTIONS,
-			gettext_noop("Sets optimizer level to use when compiling generated code."),
-			gettext_noop("Valid values are none, less, default, aggressive."),
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
-		},
-		&codegen_optimization_level_str,
-#ifdef USE_CODEGEN
-		"default",
-#else
-		"",
-#endif
-		assign_codegen_optimization_level, NULL
 	},
 
 	{
@@ -5524,129 +5481,124 @@ struct config_enum ConfigureNamesEnum_gp[] =
 		ERROR, message_level_options, NULL, NULL
 	},
 
+	{
+		{"gp_log_format", PGC_POSTMASTER, LOGGING_WHERE,
+			gettext_noop("Sets the format for log files."),
+			gettext_noop("Valid values are TEXT, CSV.")
+		},
+		&gp_log_format,
+		1, gp_log_format_options, NULL, NULL
+	},
+
+	{
+		{"debug_dtm_action_protocol", PGC_SUSET, DEVELOPER_OPTIONS,
+			gettext_noop("Sets the debug DTM action protocol."),
+			NULL,
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&Debug_dtm_action_protocol,
+		DTX_PROTOCOL_COMMAND_NONE, debug_dtm_action_protocol_options, NULL, NULL
+	},
+
+	{
+		{"optimizer_log_failure", PGC_USERSET, LOGGING_WHEN,
+			gettext_noop("Sets which optimizer failures are logged."),
+			gettext_noop("Valid values are unexpected, expected, all"),
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_log_failure,
+		OPTIMIZER_ALL_FAIL, optimizer_log_failure_options, NULL, NULL
+	},
+
+	{
+		{"codegen_optimization_level", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Sets optimizer level to use when compiling generated code."),
+			gettext_noop("Valid values are none, less, default, aggressive."),
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+		},
+		&codegen_optimization_level,
+#ifdef USE_CODEGEN
+		CODEGEN_OPTIMIZATION_LEVEL_DEFAULT,
+#else
+		CODEGEN_OPTIMIZATION_LEVEL_UNSET,
+#endif
+		codegen_optimization_level_options, assign_codegen_optimization_level, NULL
+	},
+
+	{
+		{"optimizer_cost_model", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Set optimizer cost model."),
+			gettext_noop("Valid values are legacy, calibrated"),
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_cost_model,
+		OPTIMIZER_GPDB_CALIBRATED, optimizer_cost_model_options, NULL, NULL
+	},
+
+	{
+		{"explain_memory_verbosity", PGC_USERSET, RESOURCES_MEM,
+			gettext_noop("Experimental feature: show memory account usage in EXPLAIN ANALYZE."),
+			gettext_noop("Valid values are SUPPRESS, SUMMARY, and DETAIL."),
+			GUC_GPDB_ADDOPT
+		},
+		&explain_memory_verbosity,
+		EXPLAIN_MEMORY_VERBOSITY_SUPPRESS, explain_memory_verbosity_options, NULL, NULL
+	},
+
+	{
+		{"gp_test_system_cache_flush_force", PGC_USERSET, GP_ERROR_HANDLING,
+			gettext_noop("Force invalidation of system caches on each access"),
+			gettext_noop("Valid values are OFF, PLAIN and RECURSIVE."),
+			GUC_GPDB_ADDOPT | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&gp_test_system_cache_flush_force,
+		SysCacheFlushForce_Off, system_cache_flush_force_options, NULL, NULL
+	},
+
+	{
+		{"gp_idf_deduplicate", PGC_USERSET, QUERY_TUNING_METHOD,
+			gettext_noop("Sets the mode to control inverse distribution function's de-duplicate strategy."),
+			gettext_noop("Valid values are AUTO, NONE, and FORCE.")
+		},
+		&gp_idf_deduplicate,
+		IDF_DEDUPLICATE_AUTO, gp_idf_deduplicate_options, NULL, NULL
+	},
+
+	{
+		{"debug_dtm_action", PGC_SUSET, DEVELOPER_OPTIONS,
+			gettext_noop("Sets the debug DTM action."),
+			NULL,
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&Debug_dtm_action,
+		DEBUG_DTM_ACTION_NONE, debug_dtm_action_options, NULL, NULL
+	},
+
+	{
+		{"debug_dtm_action_target", PGC_SUSET, DEVELOPER_OPTIONS,
+			gettext_noop("Sets the debug DTM action target."),
+			NULL,
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&Debug_dtm_action_target,
+		DEBUG_DTM_ACTION_TARGET_NONE, debug_dtm_action_target_options, NULL, NULL
+	},
+
+	{
+		{"gp_workfile_type_hashjoin", PGC_USERSET, QUERY_TUNING_OTHER,
+			gettext_noop("Specify the type of work files to use for executing hash join plans."),
+			gettext_noop("Valid values are \"BFZ\", \"BUFFILE\"."),
+			GUC_GPDB_ADDOPT | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&gp_workfile_type_hashjoin,
+		BFZ, gp_workfile_type_hashjoin_options, NULL, NULL
+	},
+
 	/* End-of-list marker */
 	{
 		{NULL, 0, 0, NULL, NULL}, NULL, 0, NULL, NULL, NULL
 	}
 };
-
-static const char *
-assign_gp_log_format(const char *value, bool doit, GucSource source)
-{
-	int			log_format = 0;
-
-	if (pg_strcasecmp(value, "text") == 0)
-		log_format = 0;
-	else if (pg_strcasecmp(value, "csv") == 0)
-		log_format = 1;
-	else
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("unrecognized \"gp_log_format\" key word: \"%s\"",
-						value)));
-	if (doit)
-		gp_log_format = log_format;
-
-	return value;
-}
-
-
-static const char *
-assign_debug_dtm_action_protocol(const char *newval,
-								 bool doit, GucSource source)
-{
-	if (pg_strcasecmp(newval, "none") == 0)
-	{
-		if (doit)
-			Debug_dtm_action_protocol = DTX_PROTOCOL_COMMAND_NONE;
-	}
-	else if (pg_strcasecmp(newval, "abort_no_prepared") == 0)
-	{
-		if (doit)
-			Debug_dtm_action_protocol = DTX_PROTOCOL_COMMAND_ABORT_NO_PREPARED;
-	}
-	else if (pg_strcasecmp(newval, "prepare") == 0)
-	{
-		if (doit)
-			Debug_dtm_action_protocol = DTX_PROTOCOL_COMMAND_PREPARE;
-	}
-	else if (pg_strcasecmp(newval, "abort_some_prepared") == 0)
-	{
-		if (doit)
-			Debug_dtm_action_protocol = DTX_PROTOCOL_COMMAND_ABORT_SOME_PREPARED;
-	}
-	else if (pg_strcasecmp(newval, "commit_prepared") == 0)
-	{
-		if (doit)
-			Debug_dtm_action_protocol = DTX_PROTOCOL_COMMAND_COMMIT_PREPARED;
-	}
-	else if (pg_strcasecmp(newval, "abort_prepared") == 0)
-	{
-		if (doit)
-			Debug_dtm_action_protocol = DTX_PROTOCOL_COMMAND_ABORT_PREPARED;
-	}
-	else if (pg_strcasecmp(newval, "retry_commit_prepared") == 0)
-	{
-		if (doit)
-			Debug_dtm_action_protocol = DTX_PROTOCOL_COMMAND_RETRY_COMMIT_PREPARED;
-	}
-	else if (pg_strcasecmp(newval, "retry_abort_prepared") == 0)
-	{
-		if (doit)
-			Debug_dtm_action_protocol = DTX_PROTOCOL_COMMAND_RETRY_ABORT_PREPARED;
-	}
-	else if (pg_strcasecmp(newval, "recovery_commit_prepared") == 0)
-	{
-		if (doit)
-			Debug_dtm_action_protocol = DTX_PROTOCOL_COMMAND_RECOVERY_COMMIT_PREPARED;
-	}
-	else if (pg_strcasecmp(newval, "recovery_abort_prepared") == 0)
-	{
-		if (doit)
-			Debug_dtm_action_protocol = DTX_PROTOCOL_COMMAND_RECOVERY_ABORT_PREPARED;
-	}
-	else if (pg_strcasecmp(newval, "subtransaction_begin") == 0)
-	{
-		if (doit)
-			Debug_dtm_action_protocol = DTX_PROTOCOL_COMMAND_SUBTRANSACTION_BEGIN_INTERNAL;
-	}
-	else if (pg_strcasecmp(newval, "subtransaction_release") == 0)
-	{
-		if (doit)
-			Debug_dtm_action_protocol = DTX_PROTOCOL_COMMAND_SUBTRANSACTION_RELEASE_INTERNAL;
-	}
-	else if (pg_strcasecmp(newval, "subtransaction_rollback") == 0)
-	{
-		if (doit)
-			Debug_dtm_action_protocol = DTX_PROTOCOL_COMMAND_SUBTRANSACTION_ROLLBACK_INTERNAL;
-	}
-	else
-		return NULL;			/* fail */
-	return newval;				/* OK */
-}
-
-static const char *
-assign_optimizer_log_failure(const char *val, bool assign, GucSource source)
-{
-	if (pg_strcasecmp(val, "all") == 0 && assign)
-	{
-		optimizer_log_failure = OPTIMIZER_ALL_FAIL;
-	}
-	else if (pg_strcasecmp(val, "unexpected") == 0 && assign)
-	{
-		optimizer_log_failure = OPTIMIZER_UNEXPECTED_FAIL;
-	}
-	else if (pg_strcasecmp(val, "expected") == 0 && assign)
-	{
-		optimizer_log_failure = OPTIMIZER_EXPECTED_FAIL;
-	}
-	else
-	{
-		return NULL;			/* fail */
-	}
-
-	return val;
-}
 
 static bool
 assign_pljava_classpath_insecure(bool newval, bool doit, GucSource source)
@@ -5659,40 +5611,20 @@ assign_pljava_classpath_insecure(bool newval, bool doit, GucSource source)
 	return true;
 }
 
-static const char*
-assign_codegen_optimization_level(const char *val, bool assign, GucSource source) {
+static bool
+assign_codegen_optimization_level(int val, bool assign, GucSource source) {
 #ifndef USE_CODEGEN
-	if (val && pg_strcasecmp(val, "") != 0)
+	if (val != CODEGEN_OPTIMIZATION_LEVEL_UNSET)
+	{
 		ereport(ERROR,
 			(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				errmsg("Code generation is not supported by this build")));
-#else
-
-	if (pg_strcasecmp(val, "none") == 0 && assign)
-	{
-		codegen_optimization_level = CODEGEN_OPTIMIZATION_LEVEL_NONE;
-	}
-	else if (pg_strcasecmp(val, "less") == 0 && assign)
-	{
-		codegen_optimization_level = CODEGEN_OPTIMIZATION_LEVEL_LESS;
-	}
-	else if (pg_strcasecmp(val, "default") == 0 && assign)
-	{
-		codegen_optimization_level = CODEGEN_OPTIMIZATION_LEVEL_DEFAULT;
-	}
-	else if (pg_strcasecmp(val, "aggressive") == 0 && assign)
-	{
-		codegen_optimization_level = CODEGEN_OPTIMIZATION_LEVEL_AGGRESSIVE;
-	}
-	else
-	{
-		return NULL;      /* fail */
+		return false;
 	}
 #endif
 
-	return val;
+	return true;
 }
-
 
 static const char *
 assign_optimizer_minidump(const char *val, bool assign, GucSource source)
@@ -5711,77 +5643,6 @@ assign_optimizer_minidump(const char *val, bool assign, GucSource source)
 	}
 
 	return val;
-}
-
-static const char *
-assign_optimizer_cost_model(const char *val, bool assign, GucSource source)
-{
-	if (pg_strcasecmp(val, "legacy") == 0 && assign)
-	{
-		optimizer_cost_model = OPTIMIZER_GPDB_LEGACY;
-	}
-	else if (pg_strcasecmp(val, "calibrated") == 0 && assign)
-	{
-		optimizer_cost_model = OPTIMIZER_GPDB_CALIBRATED;
-	}
-	else
-	{
-		return NULL;			/* fail */
-	}
-	return val;
-}
-
-static const char *
-assign_explain_memory_verbosity(const char *newval, bool doit, GucSource source)
-{
-	if (pg_strcasecmp(newval, "suppress") == 0)
-	{
-		if (doit)
-			explain_memory_verbosity = EXPLAIN_MEMORY_VERBOSITY_SUPPRESS;
-	}
-	else if (pg_strcasecmp(newval, "summary") == 0)
-	{
-		if (doit)
-			explain_memory_verbosity = EXPLAIN_MEMORY_VERBOSITY_SUMMARY;
-	}
-	else if (pg_strcasecmp(newval, "detail") == 0)
-	{
-		if (doit)
-			explain_memory_verbosity = EXPLAIN_MEMORY_VERBOSITY_DETAIL;
-	}
-	else
-	{
-		printf("Unknown memory verbosity.");
-		return NULL;
-	}
-
-	return newval;
-}
-
-static const char *
-assign_system_cache_flush_force(const char *newval, bool doit, GucSource source)
-{
-	if (pg_strcasecmp(newval, "off") == 0)
-	{
-		if (doit)
-			gp_test_system_cache_flush_force = SysCacheFlushForce_Off;
-	}
-	else if (pg_strcasecmp(newval, "recursive") == 0)
-	{
-		if (doit)
-			gp_test_system_cache_flush_force = SysCacheFlushForce_Recursive;
-	}
-	else if (pg_strcasecmp(newval, "plain") == 0)
-	{
-		if (doit)
-			gp_test_system_cache_flush_force = SysCacheFlushForce_NonRecursive;
-	}
-	else
-	{
-		return NULL;
-	}
-
-	return newval;
 }
 
 static const char *
@@ -5804,18 +5665,6 @@ assign_password_hash_algorithm(const char *newval, bool doit, GucSource source)
 }
 
 static const char *
-assign_gp_idf_deduplicate(const char *newval, bool doit, GucSource source)
-{
-	if (pg_strcasecmp(newval, "auto") == 0 ||
-		pg_strcasecmp(newval, "none") == 0 ||
-		pg_strcasecmp(newval, "force") == 0)
-	{
-		return newval;
-	}
-	return NULL;
-}
-
-static const char *
 assign_gp_workfile_compress_algorithm(const char *newval, bool doit, GucSource source)
 {
 	int			i = bfz_string_to_compression(newval);
@@ -5825,27 +5674,6 @@ assign_gp_workfile_compress_algorithm(const char *newval, bool doit, GucSource s
 	if (doit)
 		gp_workfile_compress_algorithm = i;
 	return newval;				/* OK */
-}
-
-static const char *
-assign_gp_workfile_type_hashjoin(const char *newval, bool doit, GucSource source)
-{
-	ExecWorkFileType newtype = BFZ;
-
-	if (!pg_strcasecmp(newval, "bfz"))
-	{
-		newtype = BFZ;
-	}
-	else if (!pg_strcasecmp(newval, "buffile"))
-	{
-		newtype = BUFFILE;
-	}
-	else
-		return NULL;
-	if (doit)
-		gp_workfile_type_hashjoin = newtype;
-
-	return newval;
 }
 
 static bool
@@ -5929,64 +5757,6 @@ assign_gp_hashagg_default_nbatches(int newval, bool doit, GucSource source)
 					(int) newval)));
 	}
 	return true; /* OK */
-}
-
-static const char *
-assign_debug_dtm_action(const char *newval,
-						bool doit, GucSource source)
-{
-	if (pg_strcasecmp(newval, "none") == 0)
-	{
-		if (doit)
-			Debug_dtm_action = DEBUG_DTM_ACTION_NONE;
-	}
-	else if (pg_strcasecmp(newval, "delay") == 0)
-	{
-		if (doit)
-			Debug_dtm_action = DEBUG_DTM_ACTION_DELAY;
-	}
-	else if (pg_strcasecmp(newval, "fail_begin_command") == 0)
-	{
-		if (doit)
-			Debug_dtm_action = DEBUG_DTM_ACTION_FAIL_BEGIN_COMMAND;
-	}
-	else if (pg_strcasecmp(newval, "fail_end_command") == 0)
-	{
-		if (doit)
-			Debug_dtm_action = DEBUG_DTM_ACTION_FAIL_END_COMMAND;
-	}
-	else if (pg_strcasecmp(newval, "panic_begin_command") == 0)
-	{
-		if (doit)
-			Debug_dtm_action = DEBUG_DTM_ACTION_PANIC_BEGIN_COMMAND;
-	}
-	else
-		return NULL;			/* fail */
-	return newval;				/* OK */
-}
-
-static const char *
-assign_debug_dtm_action_target(const char *newval,
-							   bool doit, GucSource source)
-{
-	if (pg_strcasecmp(newval, "none") == 0)
-	{
-		if (doit)
-			Debug_dtm_action_target = DEBUG_DTM_ACTION_TARGET_NONE;
-	}
-	else if (pg_strcasecmp(newval, "protocol") == 0)
-	{
-		if (doit)
-			Debug_dtm_action_target = DEBUG_DTM_ACTION_TARGET_PROTOCOL;
-	}
-	else if (pg_strcasecmp(newval, "sql") == 0)
-	{
-		if (doit)
-			Debug_dtm_action_target = DEBUG_DTM_ACTION_TARGET_SQL;
-	}
-	else
-		return NULL;			/* fail */
-	return newval;				/* OK */
 }
 
 /*

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -586,16 +586,6 @@ static const struct config_enum_entry optimizer_log_failure_options[] = {
 };
 
 static const struct config_enum_entry codegen_optimization_level_options[] = {
-	/*
-	 * GPDB_84_MERGE_FIXME
-	 *
-	 * We've introduced this "unset" value to handle the case where USE_CODEGEN
-	 * is not set. Revisit: do we really want to do this?
-	 *
-	 * If we choose to keep it, we should eventually mark it as hidden, but the
-	 * hidden field will be added later in REL8_4_STABLE.
-	 */
-	{"", CODEGEN_OPTIMIZATION_LEVEL_UNSET},
 	{"none", CODEGEN_OPTIMIZATION_LEVEL_NONE},
 	{"less", CODEGEN_OPTIMIZATION_LEVEL_LESS},
 	{"default", CODEGEN_OPTIMIZATION_LEVEL_DEFAULT},
@@ -5523,7 +5513,7 @@ struct config_enum ConfigureNamesEnum_gp[] =
 #ifdef USE_CODEGEN
 		CODEGEN_OPTIMIZATION_LEVEL_DEFAULT,
 #else
-		CODEGEN_OPTIMIZATION_LEVEL_UNSET,
+		CODEGEN_OPTIMIZATION_LEVEL_NONE,
 #endif
 		codegen_optimization_level_options, assign_codegen_optimization_level, NULL
 	},
@@ -5617,7 +5607,7 @@ assign_pljava_classpath_insecure(bool newval, bool doit, GucSource source)
 static bool
 assign_codegen_optimization_level(int val, bool assign, GucSource source) {
 #ifndef USE_CODEGEN
-	if (val != CODEGEN_OPTIMIZATION_LEVEL_UNSET)
+	if (val != CODEGEN_OPTIMIZATION_LEVEL_NONE)
 	{
 		ereport(ERROR,
 			(errcode(ERRCODE_INVALID_PARAMETER_VALUE),

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -1065,7 +1065,11 @@ extern void increment_command_count(void);
 /*
  * switch to control inverse distribution function strategy.
  */
-extern char *gp_idf_deduplicate_str;
+extern int gp_idf_deduplicate;
+
+#define IDF_DEDUPLICATE_AUTO	0
+#define IDF_DEDUPLICATE_NONE	1
+#define IDF_DEDUPLICATE_FORCE	2
 
 /* default to RANDOM distribution for CREATE TABLE without DISTRIBUTED BY */
 extern bool gp_create_table_random_default_distribution;

--- a/src/include/libpq/password_hash.h
+++ b/src/include/libpq/password_hash.h
@@ -26,6 +26,6 @@ typedef enum
 	PASSWORD_HASH_SHA_256
 } PasswdHashAlg;
 
-extern PasswdHashAlg password_hash_algorithm;
+extern int password_hash_algorithm;
 
 #endif

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -361,7 +361,6 @@ extern char *application_name;
 extern char *Debug_dtm_action_sql_command_tag;
 extern char *Debug_dtm_action_str;
 extern char *Debug_dtm_action_target_str;
-extern char *Debug_dtm_action_protocol_str;
 
 /* Enable check for compatibility of encoding and locale in createdb */
 extern bool gp_encoding_check_locale_compatibility;
@@ -507,6 +506,7 @@ extern bool optimizer_analyze_midlevel_partition;
 /**
  * GUCs related to code generation.
  **/
+#define CODEGEN_OPTIMIZATION_LEVEL_UNSET         -1
 #define CODEGEN_OPTIMIZATION_LEVEL_NONE          0
 #define CODEGEN_OPTIMIZATION_LEVEL_LESS          1
 #define CODEGEN_OPTIMIZATION_LEVEL_DEFAULT       2

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -506,7 +506,6 @@ extern bool optimizer_analyze_midlevel_partition;
 /**
  * GUCs related to code generation.
  **/
-#define CODEGEN_OPTIMIZATION_LEVEL_UNSET         -1
 #define CODEGEN_OPTIMIZATION_LEVEL_NONE          0
 #define CODEGEN_OPTIMIZATION_LEVEL_LESS          1
 #define CODEGEN_OPTIMIZATION_LEVEL_DEFAULT       2


### PR DESCRIPTION
Several GUCs are simply enumerated strings that are parsed into integer
types behind the scenes. As of 8.4, the GUC system recognizes a new
type, enum, which will do this for us. Move as many as we can to the new
system.

As part of this,
- gp_idf_deduplicate was changed from a char* string to an int, and new
  IDF_DEDUPLICATE_* macros were added for each option
- A new CODEGEN_OPTIMIZATION_LEVEL_UNSET option was added for the case
  where USE_CODEGEN is not defined. (XXX note that this allows a user to
  manually set codegen_optimization_level to the empty string, which
  may cause the system to fail...!)

A couple of GUCs that *could* be represented as enums
(optimizer_minidump, gp_workfile_compress_algorithm) have been
purposefully kept with the prior system because they require the GUC
variable to be something other than an integer anyway.

Signed-off-by: Jacob Champion <pchampion@pivotal.io>