### PR TITLE
Add gp_stat_replication view

### DIFF
--- a/src/test/walrep/Makefile
+++ b/src/test/walrep/Makefile
@@ -13,7 +13,9 @@ REGRESS = setup walreceiver
 # walsender-walreceiver connection only
 ifeq ($(enable_segwalrep), yes)
 ifeq ($(WITH_MIRRORS), false)
-REGRESS += generate_ao_xlog generate_aoco_xlog
+REGRESS += generate_ao_xlog generate_aoco_xlog replication_views_mirrorless
+else
+REGRESS += replication_views_mirrored
 endif
 endif
 REGRESS_OPTS = --dbname="walrep_regression"

--- a/src/test/walrep/expected/replication_views_mirrored.out
+++ b/src/test/walrep/expected/replication_views_mirrored.out
@@ -1,0 +1,22 @@
+-- Check how many WAL replication mirrors are up and synced
+SELECT count(*) FROM gp_segment_configuration where preferred_role='m' and mode='s';
+ count 
+-------
+     3
+(1 row)
+
+-- Check pg_stat_replication view (this assumes standby master has not been created)
+SELECT * FROM pg_stat_replication;
+ procpid | usesysid | usename | application_name | client_addr | client_port | backend_start | state | sent_location | write_location | flush_location | replay_location | sync_priority | sync_state 
+---------+----------+---------+------------------+-------------+-------------+---------------+-------+---------------+----------------+----------------+-----------------+---------------+------------
+(0 rows)
+
+-- Check pg_stat_replication view of master and primary segments
+SELECT gp_segment_id, application_name, state, sync_state FROM gp_stat_replication;
+ gp_segment_id | application_name |   state   | sync_state 
+---------------+------------------+-----------+------------
+             0 | walreceiver      | streaming | sync
+             1 | walreceiver      | streaming | sync
+             2 | walreceiver      | streaming | sync
+(3 rows)
+

--- a/src/test/walrep/expected/replication_views_mirrorless.out
+++ b/src/test/walrep/expected/replication_views_mirrorless.out
@@ -1,0 +1,19 @@
+-- Check how many WAL replication mirrors are up and synced
+SELECT count(*) FROM gp_segment_configuration where preferred_role='m' and mode='s';
+ count 
+-------
+     0
+(1 row)
+
+-- Check pg_stat_replication view (this assumes standby master has not been created)
+SELECT * FROM pg_stat_replication;
+ procpid | usesysid | usename | application_name | client_addr | client_port | backend_start | state | sent_location | write_location | flush_location | replay_location | sync_priority | sync_state 
+---------+----------+---------+------------------+-------------+-------------+---------------+-------+---------------+----------------+----------------+-----------------+---------------+------------
+(0 rows)
+
+-- Check pg_stat_replication view of master and primary segments
+SELECT gp_segment_id, application_name, state, sync_state FROM gp_stat_replication;
+ gp_segment_id | application_name | state | sync_state 
+---------------+------------------+-------+------------
+(0 rows)
+

--- a/src/test/walrep/sql/replication_views_mirrored.sql
+++ b/src/test/walrep/sql/replication_views_mirrored.sql
@@ -1,0 +1,8 @@
+-- Check how many WAL replication mirrors are up and synced
+SELECT count(*) FROM gp_segment_configuration where preferred_role='m' and mode='s';
+
+-- Check pg_stat_replication view (this assumes standby master has not been created)
+SELECT * FROM pg_stat_replication;
+
+-- Check pg_stat_replication view of master and primary segments
+SELECT gp_segment_id, application_name, state, sync_state FROM gp_stat_replication;

--- a/src/test/walrep/sql/replication_views_mirrorless.sql
+++ b/src/test/walrep/sql/replication_views_mirrorless.sql
@@ -1,0 +1,8 @@
+-- Check how many WAL replication mirrors are up and synced
+SELECT count(*) FROM gp_segment_configuration where preferred_role='m' and mode='s';
+
+-- Check pg_stat_replication view (this assumes standby master has not been created)
+SELECT * FROM pg_stat_replication;
+
+-- Check pg_stat_replication view of master and primary segments
+SELECT gp_segment_id, application_name, state, sync_state FROM gp_stat_replication;


### PR DESCRIPTION
In order to view the primary segments' replication stream data from
their pg_stat_replication view, we currently need to connect to the
primary segment individually via utility mode. To make life easier, we
introduce a function that will fetch each primary segment's
replication stream data and wrap it with a view named
gp_stat_replication. It will now be possible to view all the cluster
replication information from the master in a regular psql session.

Authors: Taylor Vesely and Jimmy Yih