### PR TITLE
docs - resgroup concurrency can be 0 but not for admin_group

### DIFF
--- a/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
@@ -255,6 +255,7 @@ gpstart
 =# ALTER RESOURCE GROUP <i>exec</i> SET MEMORY_LIMIT 25;
 </codeblock>
         </p>
+        <note>You cannot set or alter the <codeph>CONCURRENCY</codeph> value for the <codeph>admin_group</codeph> to zero (0).</note>
         <p>The <codeph><xref href="../ref_guide/sql_commands/DROP_RESOURCE_GROUP.xml#topic1" type="topic" format="dita"/></codeph> command drops a resource group. To drop a resource group, the group cannot be assigned to any role, nor can there be any transactions active or waiting in the resource group.
           To drop a resource group:</p>
         <p>

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_RESOURCE_GROUP.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_RESOURCE_GROUP.xml
@@ -41,8 +41,9 @@ MEMORY_SPILL_RATIO <varname>integer</varname></codeblock>
             reached are queued. When a running transaction completes, the earliest queued
             transaction is executed.</pd>
           <pd> The <codeph>CONCURRENCY</codeph> value
-            must be an integer in the range [1 .. <codeph>max_connections</codeph>]. The default 
+            must be an integer in the range [0 .. <codeph>max_connections</codeph>]. The default 
             <codeph>CONCURRENCY</codeph> value is 20.</pd>
+            <pd><note>You cannot set the <codeph>CONCURRENCY</codeph> value for the <codeph>admin_group</codeph> to zero (0).</note></pd>
         </plentry>
         <plentry>
           <pt>CPU_RATE_LIMIT <varname>integer</varname></pt>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml
@@ -43,8 +43,9 @@ MEMORY_LIMIT=<varname>integer</varname>
         </plentry>
         <plentry>
           <pt>CONCURRENCY <varname>integer</varname></pt>
-          <pd>The maximum number of concurrent transactions, including active and idle transactions, that are permitted for this resource group. The <codeph>CONCURRENCY</codeph> value must be an integer in the range [1 .. <codeph>max_connections</codeph>]. The default <codeph>CONCURRENCY</codeph> value is 20.
+          <pd>The maximum number of concurrent transactions, including active and idle transactions, that are permitted for this resource group. The <codeph>CONCURRENCY</codeph> value must be an integer in the range [0 .. <codeph>max_connections</codeph>]. The default <codeph>CONCURRENCY</codeph> value is 20.
             </pd>
+          <pd><note>You cannot set the <codeph>CONCURRENCY</codeph> value for the <codeph>admin_group</codeph> to zero (0).</note></pd>
         </plentry>
         <plentry>
           <pt>CPU_RATE_LIMIT <varname>integer</varname></pt>


### PR DESCRIPTION
corrected the value range, added note to:
- ALTER and CREATE RESOURCE GROUP sql ref pages
- "using" page, "Creating Resource Groups" section.

links to updated doc review staging site:
- http://docs-gpdb-review-staging.cfapps.io/500/ref_guide/sql_commands/ALTER_RESOURCE_GROUP.html
- http://docs-gpdb-review-staging.cfapps.io/500/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.html
- http://docs-gpdb-review-staging.cfapps.io/500/admin_guide/workload_mgmt_resgroups.html#topic10
