### PR TITLE
Add new primary/mirror as not-in-sync

### DIFF
--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -53,7 +53,7 @@ GP_USER=$USER_NAME
 # System table names
 GP_TBL=gp_id
 GP_CONFIG_TBL=gp_segment_configuration
-PG_SYSTEM_FILESPACE=3052
+PG_SYSTEM_FILESPACE_NAME="pg_system"
 unset PG_CONF_ADD_FILE
 #unset QD_PRIMARY_ARRAY QE_PRIMARY_ARRAY QE_MIRROR_ARRAY
 EXIT_STATUS=0
@@ -1346,13 +1346,9 @@ UPDATE_GPCONFIG () {
 		CHK_COUNT=`env PGOPTIONS="-c gp_session_role=utility" $PSQL -p $MASTER_PORT -d "$U_DB" -A -t -c "SELECT count(*) FROM $GP_CONFIG_TBL WHERE content=${U_CONTENT} AND preferred_role='${U_ROLE}';" 2>/dev/null` >> $LOG_FILE 2>&1
 		ERROR_CHK $? "obtain psql count Master $GP_CONFIG_TBL" 2
 		if [ $CHK_COUNT -eq 0 ]; then
-				LOG_MSG "[INFO]:-Adding $U_CONTENT on $U_HOSTNAME $U_DIR to system configuration table"
-				env PGOPTIONS="-c gp_session_role=utility" $PSQL -p $MASTER_PORT -d "$U_DB" -c "INSERT INTO $GP_CONFIG_TBL (dbid, content, role, preferred_role, mode, status, hostname, address, port, replication_port) VALUES (${U_DBID}, ${U_CONTENT}, '${U_ROLE}', '${U_ROLE}', 's', 'u', '${U_HOSTNAME}', '${U_ADDRESS}', ${U_PORT}, ${U_REPLICATION_PORT});" >> $LOG_FILE 2>&1
-				ERROR_CHK $? "add $U_CONTENT on $U_HOSTNAME to Master gp_segment_configuration" 2
-
-				LOG_MSG "[INFO]:-Adding $U_CONTENT on $U_HOSTNAME $U_DIR to Master gp_filespace_entry"
-				env PGOPTIONS="-c gp_session_role=utility" $PSQL -p $MASTER_PORT -d "$U_DB" -c "insert into pg_filespace_entry (fsefsoid, fsedbid, fselocation) values (${PG_SYSTEM_FILESPACE}, ${U_DBID}, '${U_DIR}');" >> $LOG_FILE 2>&1
-				ERROR_CHK $? "add $U_CONTENT on $U_HOSTNAME $U_DIR to Master pg_filespace_entry" 2
+				LOG_MSG "[INFO]:-Adding $U_CONTENT on $U_HOSTNAME to Master gp_segment_configuration and $U_DIR to gp_filespace_entry"
+				env PGOPTIONS="-c gp_session_role=utility" $PSQL -p $MASTER_PORT -d "$U_DB" -c "SELECT pg_catalog.gp_add_segment(${U_DBID}::int2, ${U_CONTENT}::int2, '${U_ROLE}', '${U_ROLE}', 's', 'u', ${U_PORT}, '${U_HOSTNAME}', '${U_ADDRESS}', ${U_REPLICATION_PORT}, '{${PG_SYSTEM_FILESPACE_NAME}, ${U_DIR}}');" >> $LOG_FILE 2>&1
+				ERROR_CHK $? "add $U_CONTENT on $U_HOSTNAME to Master gp_segment_configuration and $U_DIR to pg_filespace_entry" 2
 		else
 				LOG_MSG "[INFO]:-Content $U_CONTENT already exists in gp_segment_configuration system table"
 		fi

--- a/gpMgmt/bin/gppylib/system/ComputeCatalogUpdate.py
+++ b/gpMgmt/bin/gppylib/system/ComputeCatalogUpdate.py
@@ -27,7 +27,7 @@ class ComputeCatalogUpdate:
 
     mirror_to_remove	     - to be removed (e.g. via gp_remove_segment_mirror())
     primary_to_remove	     - to be removed (e.g. via gp_remove_segment())
-    primary_to_add	     - to be added (e.g. via gp_add_segment())
+    primary_to_add	     - to be added (e.g. via gp_add_segment_primary())
     mirror_to_add	     - to be added (e.g. via gp_add_segment_mirror())
     mirror_to_remove_and_add - change or force list requires this mirror
                                 to be removed and then added back

--- a/gpMgmt/bin/gppylib/system/configurationImplGpdb.py
+++ b/gpMgmt/bin/gppylib/system/configurationImplGpdb.py
@@ -207,12 +207,12 @@ class GpConfigurationProviderUsingGpdbCatalog(GpConfigurationProvider) :
 
         # get the newly added segment's content id
         # MPP-12393 et al WARNING: there is an unusual side effect going on here.  
-        # Although gp_add_segment() executed by __callSegmentAdd() above returns 
+        # Although gp_add_segment_primary() executed by __callSegmentAdd() above returns
         # the dbId of the new row in gp_segment_configuration, the following
         # select from gp_segment_configuration can return 0 rows if the updates
         # done by __updateSegmentModeStatus() and/or __updateSegmentReplicationPort()
         # are not done first.  Don't change the order of these operations unless you 
-        # understand why gp_add_segment() behaves as it does.
+        # understand why gp_add_segment_primary() behaves as it does.
         sql = "select content from pg_catalog.gp_segment_configuration where dbId = %s" % self.__toSqlIntValue(seg.getSegmentDbId())
         logger.debug(sql)
         sqlResult = self.__fetchSingleOutputRow(conn, sql)
@@ -291,13 +291,13 @@ class GpConfigurationProviderUsingGpdbCatalog(GpConfigurationProvider) :
 
     def __callSegmentAdd(self, conn, gpArray, seg):
         """
-        Call gp_add_segment() to add the primary.
+        Call gp_add_segment_primary() to add the primary.
         Return the new segment's dbid.
         """
         logger.debug('callSegmentAdd %s' % repr(seg))
         filespaceMapStr = self.__toSqlFilespaceMapStr(gpArray, seg)
 
-        sql = "SELECT gp_add_segment(%s, %s, %s, %s)" \
+        sql = "SELECT gp_add_segment_primary(%s, %s, %s, %s)" \
             % (
                 self.__toSqlTextValue(seg.getSegmentHostName()), 
                 self.__toSqlTextValue(seg.getSegmentAddress()), 

--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -1093,7 +1093,7 @@ master_standby_dbid(void)
 
 	/*
 	 * SELECT * FROM gp_segment_configuration
-	 *  WHERE content = -1 AND role = 'm'
+	 *  WHERE content = -1 AND role = GP_SEGMENT_CONFIGURATION_ROLE_MIRROR
 	 */
 	rel = heap_open(GpSegmentConfigRelationId, AccessShareLock);
 	ScanKeyInit(&scankey[0],
@@ -1103,7 +1103,7 @@ master_standby_dbid(void)
 	ScanKeyInit(&scankey[1],
 				Anum_gp_segment_configuration_role,
 				BTEqualStrategyNumber, F_CHAREQ,
-				CharGetDatum('m'));
+				CharGetDatum(GP_SEGMENT_CONFIGURATION_ROLE_MIRROR));
 	/* no index */
 	scan = systable_beginscan(rel, InvalidOid, false,
 							  SnapshotNow, 2, scankey);

--- a/src/backend/utils/gp/segadmin.c
+++ b/src/backend/utils/gp/segadmin.c
@@ -760,8 +760,8 @@ gp_add_segment(PG_FUNCTION_ARGS)
 	new.db.address = address;
 	new.db.port = port;
 	new.db.filerep_port = -1;
-	new.db.mode = 's';
-	new.db.status = 'u';
+	new.db.mode = GP_SEGMENT_CONFIGURATION_MODE_INSYNC;
+	new.db.status = GP_SEGMENT_CONFIGURATION_STATUS_UP;
 	new.db.role = SEGMENT_ROLE_PRIMARY;
 	new.db.preferred_role = SEGMENT_ROLE_PRIMARY;
 
@@ -885,8 +885,8 @@ gp_add_segment_mirror(PG_FUNCTION_ARGS)
 	new.db.address = address;
 	new.db.port = port;
 	new.db.filerep_port = rep_port;
-	new.db.mode = 's';
-	new.db.status = 'u';
+	new.db.mode = GP_SEGMENT_CONFIGURATION_MODE_INSYNC;
+	new.db.status = GP_SEGMENT_CONFIGURATION_STATUS_UP;
 	new.db.role = SEGMENT_ROLE_MIRROR;
 	new.db.preferred_role = preferredPrimaryDbId == 0 ? SEGMENT_ROLE_PRIMARY : SEGMENT_ROLE_MIRROR;
 
@@ -999,7 +999,7 @@ gp_add_master_standby(PG_FUNCTION_ARGS)
 
 	/*
 	 * Don't reference GpIdentity.dbid, as it is legitimate to set -1
-	 * for -b option in utility mode.  Content ID = -1 AND role = 'p' is
+	 * for -b option in utility mode.  Content ID = -1 AND role = GP_SEGMENT_CONFIGURATION_ROLE_PRIMARY is
 	 * the definition of primary master.
 	 */
 	master_dbid = contentid_get_dbid(MASTER_CONTENT_ID,
@@ -1010,8 +1010,8 @@ gp_add_master_standby(PG_FUNCTION_ARGS)
 	new.db.dbid = maxdbid + 1;
 	new.db.role = SEGMENT_ROLE_MIRROR;
 	new.db.preferred_role = SEGMENT_ROLE_MIRROR;
-	new.db.mode = 's';
-	new.db.status = 'u';
+	new.db.mode = GP_SEGMENT_CONFIGURATION_MODE_INSYNC;
+	new.db.status = GP_SEGMENT_CONFIGURATION_STATUS_UP;
 
 	new.db.hostname = DatumGetCString(DirectFunctionCall1(textout,
 									  PointerGetDatum(PG_GETARG_TEXT_P(0))));

--- a/src/backend/utils/gp/segadmin.c
+++ b/src/backend/utils/gp/segadmin.c
@@ -782,7 +782,11 @@ gp_add_segment_primary(PG_FUNCTION_ARGS)
 	new.db.dbid = get_availableDbId();
 	new.db.role = SEGMENT_ROLE_PRIMARY;
 	new.db.preferred_role = SEGMENT_ROLE_PRIMARY;
+#ifdef USE_SEGWALREP
+	new.db.mode = GP_SEGMENT_CONFIGURATION_MODE_NOTINSYNC;
+#else
 	new.db.mode = GP_SEGMENT_CONFIGURATION_MODE_INSYNC;
+#endif
 	new.db.status = GP_SEGMENT_CONFIGURATION_STATUS_UP;
 	new.db.filerep_port = -1;
 
@@ -852,6 +856,11 @@ gp_add_segment(PG_FUNCTION_ARGS)
 	fsmap = PG_GETARG_ARRAYTYPE_P(10);
 
 	mirroring_sanity_check(MASTER_ONLY | SUPERUSER, "gp_add_segment");
+
+#ifdef USE_SEGWALREP
+	new.db.mode = GP_SEGMENT_CONFIGURATION_MODE_NOTINSYNC;
+	elog(NOTICE, "mode is changed to GP_SEGMENT_CONFIGURATION_MODE_NOTINSYNC under walrep.");
+#endif
 
 	add_segment(new, fsmap);
 
@@ -941,7 +950,11 @@ gp_add_segment_mirror(PG_FUNCTION_ARGS)
 	mirroring_sanity_check(MASTER_ONLY | SUPERUSER, "gp_add_segment_mirror");
 
 	new.db.dbid = get_availableDbId();
+#ifdef USE_SEGWALREP
+	new.db.mode = GP_SEGMENT_CONFIGURATION_MODE_NOTINSYNC;
+#else
 	new.db.mode = GP_SEGMENT_CONFIGURATION_MODE_INSYNC;
+#endif
 	new.db.status = GP_SEGMENT_CONFIGURATION_STATUS_UP;
 	new.db.role = SEGMENT_ROLE_MIRROR;
 	new.db.preferred_role = SEGMENT_ROLE_MIRROR;

--- a/src/include/catalog/gp_segment_config.h
+++ b/src/include/catalog/gp_segment_config.h
@@ -26,6 +26,19 @@
 #define MASTER_CONTENT_ID (-1)
 #define InvalidDbid 0
 
+#define GP_SEGMENT_CONFIGURATION_ROLE_PRIMARY 'p'
+#define GP_SEGMENT_CONFIGURATION_ROLE_MIRROR 'm'
+
+#define GP_SEGMENT_CONFIGURATION_STATUS_UP 'u'
+#define GP_SEGMENT_CONFIGURATION_STATUS_DOWN 'd'
+
+#define GP_SEGMENT_CONFIGURATION_MODE_INSYNC 's'
+#define GP_SEGMENT_CONFIGURATION_MODE_NOTINSYNC 'n'
+
+#define GP_SEGMENT_CONFIGURATION_MODE_CHANGETRACKING 'c'
+#define GP_SEGMENT_CONFIGURATION_MODE_RESYNC 'r'
+
+
 /* ----------------
  *		gp_segment_configuration definition.  cpp turns this into
  *		typedef struct FormData_gp_segment_configuration

--- a/src/include/catalog/pg_proc.sql
+++ b/src/include/catalog/pg_proc.sql
@@ -1554,11 +1554,13 @@
 
  CREATE FUNCTION gp_remove_master_standby() RETURNS bool LANGUAGE internal VOLATILE AS 'gp_remove_master_standby' WITH (OID=5047, DESCRIPTION="Remove a master standby from the system catalog");
 
+ CREATE FUNCTION gp_add_segment_primary(text, text, int4, _text) RETURNS int2 LANGUAGE internal VOLATILE AS 'gp_add_segment_primary' WITH (OID=5039, DESCRIPTION="Perform the catalog operations necessary for adding a new primary segment");
+
  CREATE FUNCTION gp_add_segment_mirror(int2, text, text, int4, int4, _text) RETURNS int2 LANGUAGE internal VOLATILE AS 'gp_add_segment_mirror' WITH (OID=5048, DESCRIPTION="Perform the catalog operations necessary for adding a new segment mirror");
 
  CREATE FUNCTION gp_remove_segment_mirror(int2) RETURNS bool LANGUAGE internal VOLATILE AS 'gp_remove_segment_mirror' WITH (OID=5049, DESCRIPTION="Remove a segment mirror from the system catalog");
 
- CREATE FUNCTION gp_add_segment(text, text, int4, _text) RETURNS int2 LANGUAGE internal VOLATILE AS 'gp_add_segment' WITH (OID=5050, DESCRIPTION="Perform the catalog operations necessary for adding a new primary segment");
+ CREATE FUNCTION gp_add_segment(int2, int2, "char", "char", "char", "char", int4, text, text, int4, _text) RETURNS int2 LANGUAGE internal VOLATILE AS 'gp_add_segment' WITH (OID=5050, DESCRIPTION="Perform the catalog operations necessary for adding a new segment");
 
  CREATE FUNCTION gp_remove_segment(int2) RETURNS bool LANGUAGE internal VOLATILE AS 'gp_remove_segment' WITH (OID=5051, DESCRIPTION="Remove a primary segment from the system catalog");
 

--- a/src/include/catalog/pg_proc_gp.h
+++ b/src/include/catalog/pg_proc_gp.h
@@ -2504,11 +2504,11 @@ DESCR("list priorities of backends");
 
 
 /* Functions to deal with SREH error logs */
-/* gp_read_error_log(exttable text, OUT cmdtime timestamptz, OUT relname text, OUT filename text, OUT linenum int4, OUT bytenum int4, OUT errmsg text, OUT rawdata text, OUT rawbytes bytea) => SETOF record */ 
+/* gp_read_error_log(exttable text, OUT cmdtime timestamptz, OUT relname text, OUT filename text, OUT linenum int4, OUT bytenum int4, OUT errmsg text, OUT rawdata text, OUT rawbytes bytea) => SETOF record */
 DATA(insert OID = 3000 ( gp_read_error_log  PGNSP PGUID 12 1 1000 0 f f f t t v 1 0 2249 "25" "{25,1184,25,25,23,23,25,25,17}" "{i,o,o,o,o,o,o,o,o}" "{exttable,cmdtime,relname,filename,linenum,bytenum,errmsg,rawdata,rawbytes}" _null_ gp_read_error_log _null_ _null_ _null_ n s ));
 DESCR("read the error log for the specified external table");
 
-/* gp_truncate_error_log(text) => bool */ 
+/* gp_truncate_error_log(text) => bool */
 DATA(insert OID = 3069 ( gp_truncate_error_log  PGNSP PGUID 12 1 0 0 f f f t f v 1 0 16 "25" _null_ _null_ _null_ _null_ gp_truncate_error_log _null_ _null_ _null_ n a ));
 DESCR("truncate the error log for the specified external table");
 
@@ -2536,17 +2536,21 @@ DESCR("Perform the catalog operations necessary for adding a new standby");
 DATA(insert OID = 5047 ( gp_remove_master_standby  PGNSP PGUID 12 1 0 0 f f f f f v 0 0 16 "" _null_ _null_ _null_ _null_ gp_remove_master_standby _null_ _null_ _null_ n a ));
 DESCR("Remove a master standby from the system catalog");
 
-/* gp_add_segment_mirror(int2, text, text, int4, int4, _text) => int2 */ 
+/* gp_add_segment_primary(text, text, int4, _text) => int2 */
+DATA(insert OID = 5039 ( gp_add_segment_primary  PGNSP PGUID 12 1 0 0 f f f f f v 4 0 21 "25 25 23 1009" _null_ _null_ _null_ _null_ gp_add_segment_primary _null_ _null_ _null_ n a ));
+DESCR("Perform the catalog operations necessary for adding a new primary segment");
+
+/* gp_add_segment_mirror(int2, text, text, int4, int4, _text) => int2 */
 DATA(insert OID = 5048 ( gp_add_segment_mirror  PGNSP PGUID 12 1 0 0 f f f f f v 6 0 21 "21 25 25 23 23 1009" _null_ _null_ _null_ _null_ gp_add_segment_mirror _null_ _null_ _null_ n a ));
 DESCR("Perform the catalog operations necessary for adding a new segment mirror");
 
-/* gp_remove_segment_mirror(int2) => bool */ 
+/* gp_remove_segment_mirror(int2) => bool */
 DATA(insert OID = 5049 ( gp_remove_segment_mirror  PGNSP PGUID 12 1 0 0 f f f f f v 1 0 16 "21" _null_ _null_ _null_ _null_ gp_remove_segment_mirror _null_ _null_ _null_ n a ));
 DESCR("Remove a segment mirror from the system catalog");
 
-/* gp_add_segment(text, text, int4, _text) => int2 */ 
-DATA(insert OID = 5050 ( gp_add_segment  PGNSP PGUID 12 1 0 0 f f f f f v 4 0 21 "25 25 23 1009" _null_ _null_ _null_ _null_ gp_add_segment _null_ _null_ _null_ n a ));
-DESCR("Perform the catalog operations necessary for adding a new primary segment");
+/* gp_add_segment(int2, int2, "char", "char", "char", "char", int4, text, text, int4, _text) => int2 */
+DATA(insert OID = 5050 ( gp_add_segment  PGNSP PGUID 12 1 0 0 f f f f f v 11 0 21 "21 21 18 18 18 18 23 25 25 23 1009" _null_ _null_ _null_ _null_ gp_add_segment _null_ _null_ _null_ n a ));
+DESCR("Perform the catalog operations necessary for adding a new segment");
 
 /* gp_remove_segment(int2) => bool */ 
 DATA(insert OID = 5051 ( gp_remove_segment  PGNSP PGUID 12 1 0 0 f f f f f v 1 0 16 "21" _null_ _null_ _null_ _null_ gp_remove_segment _null_ _null_ _null_ n a ));

--- a/src/include/utils/builtins.h
+++ b/src/include/utils/builtins.h
@@ -1135,6 +1135,7 @@ extern Datum gp_add_master_standby(PG_FUNCTION_ARGS);
 extern Datum gp_remove_master_standby(PG_FUNCTION_ARGS);
 extern Datum gp_activate_standby(PG_FUNCTION_ARGS);
 
+extern Datum gp_add_segment_primary(PG_FUNCTION_ARGS);
 extern Datum gp_add_segment_mirror(PG_FUNCTION_ARGS);
 extern Datum gp_remove_segment_mirror(PG_FUNCTION_ARGS);
 extern Datum gp_add_segment(PG_FUNCTION_ARGS);

--- a/src/test/regress/expected/opr_sanity.out
+++ b/src/test/regress/expected/opr_sanity.out
@@ -280,7 +280,8 @@ WHERE pronargs > 8 and prolang = 12 AND
 					'gp_add_persistent_database_node_entry',
 					'gp_add_persistent_tablespace_node_entry',
 					'gp_update_persistent_database_node_entry',
-					'gp_update_persistent_tablespace_node_entry') AND
+					'gp_update_persistent_tablespace_node_entry',
+					'gp_add_segment') AND
     NOT proisagg AND 
     NOT proiswindow;
  proname | pronargs 

--- a/src/test/regress/sql/opr_sanity.sql
+++ b/src/test/regress/sql/opr_sanity.sql
@@ -224,7 +224,8 @@ WHERE pronargs > 8 and prolang = 12 AND
 					'gp_add_persistent_database_node_entry',
 					'gp_add_persistent_tablespace_node_entry',
 					'gp_update_persistent_database_node_entry',
-					'gp_update_persistent_tablespace_node_entry') AND
+					'gp_update_persistent_tablespace_node_entry',
+					'gp_add_segment') AND
     NOT proisagg AND 
     NOT proiswindow;
 


### PR DESCRIPTION
For SEGWALREP, when first primary and mirror added to the cluster, their state should be `n` means not-in-sync, instead of `s` (means in-sync) when using filerep.

In order to do it, we refactor the existing `gp_add_segment()` `gp_add_segment_primary()` and `gp_add_segment_mirror()` to reflect the new value `n` for the mode.