### PR TITLE
Fix filename validation when restoring pre-content-id backups

### DIFF
--- a/gpMgmt/bin/gppylib/operations/backup_utils.py
+++ b/gpMgmt/bin/gppylib/operations/backup_utils.py
@@ -99,19 +99,18 @@ class Context(Values, object):
         format_str =  "%s/%sgp_%s_%s%s" % (use_dir, self.dump_prefix, "%s", timestamp, "%s")
         filename = format_str % (self.filename_dict[filetype][0], self.filename_dict[filetype][1])
         if "%(content)d_%(dbid)s" in filename:
-            if use_old_format:
-                if content is not None: # Doesn't use "if not content" because 0 is a valid content id
-                    dbids = ["%d" % id for id in self.content_map if self.content_map[id] == content]
-                    filename = filename % {"content": 1 if content == -1 else 0, "dbid": "[%s]" % ("|".join(dbids))}
-                elif dbid == 1:
-                    filename = filename % {"content": 1, "dbid": 1}
-                else:
-                    filename = filename % {"content": 0, "dbid": dbid}
+            content_num = -2
+            dbid_str = ""
+            if content is not None: # Doesn't use "if not content" because 0 is a valid content id
+                content_num = content
+                dbids = ["%d" % id for id in self.content_map if self.content_map[id] == content]
+                dbid_str = "(%s)" % ("|".join(dbids))
             else:
-                if content is not None:
-                    filename = filename % {"content": content, "dbid": "*"}
-                else:
-                    filename = filename % {"content": self.content_map[dbid], "dbid": dbid}
+                content_num = self.content_map[dbid]
+                dbid_str = dbid
+            if use_old_format:
+                content_num = 1 if content_num == -1 else 0
+            filename = filename % {"content": content_num, "dbid": dbid_str}
         if self.compress and filetype in ["metadata", "dump", "postdata"] and use_compress:
             filename += ".gz"
         return filename
@@ -292,16 +291,18 @@ def get_filename_for_content(context, filetype, content, remote_directory=None, 
         if not host:
             raise Exception("Must supply name of remote host to check for %s file" % filetype)
         cmd = Command(name = "Find file of type %s for content %d on host %s" % (filetype, content, host),
-                cmdStr = 'python -c "import glob; print glob.glob(\'%s\')[0]"' % filetype_glob, ctxt = REMOTE, remoteHost = host)
+                cmdStr = 'echo "import glob, re\nfor f in glob.glob(\'%s/*\'):\n    if re.match(\'%s\', f):\n        print f\n        break" | python'
+                            % (remote_directory, filetype_glob), ctxt = REMOTE, remoteHost = host)
         cmd.run()
 
         if cmd.get_results().rc == 0 and cmd.get_results().stdout:
             return cmd.get_results().stdout
         return None
     else:
-        filenames = glob.glob(filetype_glob)
-        if filenames and len(filenames) > 0:
-            return filenames[0]
+        filenames = glob.glob("%s/*" % context.get_backup_dir())
+        for filename in filenames:
+            if re.match(filetype_glob, filename):
+                return filename
         return None
 
 def expand_partitions_and_populate_filter_file(context, partition_list, file_prefix):

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_backup_utils.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_backup_utils.py
@@ -47,26 +47,54 @@ class BackupUtilsTestCase(GpTestCase):
         output = self.context.generate_filename("dump", dbid=dbid)
         self.assertEquals(output, expected_output)
 
-    def test_generate_filename_content_master_new_format(self):
-        expected_output = '/data/master/db_dumps/20160101/gp_dump_-1_*_20160101010101.gz'
+    def test_generate_filename_content_master_new_format_no_standby(self):
+        expected_output = '/data/master/db_dumps/20160101/gp_dump_-1_(1)_20160101010101.gz'
         output = self.context.generate_filename("dump", content=-1)
         self.assertEquals(output, expected_output)
 
-    def test_generate_filename_content_segment_new_format(self):
+    def test_generate_filename_content_segment_new_format_no_mirror(self):
         content = 1
-        expected_output = '/data/master/db_dumps/20160101/gp_dump_1_*_20160101010101.gz'
+        expected_output = '/data/master/db_dumps/20160101/gp_dump_1_(3)_20160101010101.gz'
+        del self.context.content_map[5]
         output = self.context.generate_filename("dump", content=content)
         self.assertEquals(output, expected_output)
 
-    def test_generate_filename_content_master_old_format(self):
-        expected_output = '/data/master/db_dumps/20160101/gp_dump_1_[1]_20160101010101.gz'
+    def test_generate_filename_content_master_new_format_with_standby(self):
+        expected_output = '/data/master/db_dumps/20160101/gp_dump_-1_(1|10)_20160101010101.gz'
+        self.context.content_map[10] = -1
+        output = self.context.generate_filename("dump", content=-1)
+        self.assertEquals(output, expected_output)
+
+    def test_generate_filename_content_segment_new_format_with_mirror(self):
+        content = 1
+        expected_output = '/data/master/db_dumps/20160101/gp_dump_1_(3|5)_20160101010101.gz'
+        output = self.context.generate_filename("dump", content=content)
+        self.assertEquals(output, expected_output)
+
+    def test_generate_filename_content_master_old_format_no_standby(self):
+        expected_output = '/data/master/db_dumps/20160101/gp_dump_1_(1)_20160101010101.gz'
         self.context.use_old_filename_format = True
         output = self.context.generate_filename("dump", content=-1)
         self.assertEquals(output, expected_output)
 
-    def test_generate_filename_content_segment_old_format(self):
+    def test_generate_filename_content_segment_old_format_no_mirror(self):
         content = 1
-        expected_output = '/data/master/db_dumps/20160101/gp_dump_0_[3|5]_20160101010101.gz'
+        expected_output = '/data/master/db_dumps/20160101/gp_dump_0_(3)_20160101010101.gz'
+        self.context.use_old_filename_format = True
+        del self.context.content_map[5]
+        output = self.context.generate_filename("dump", content=content)
+        self.assertEquals(output, expected_output)
+
+    def test_generate_filename_content_master_old_format_with_standby(self):
+        expected_output = '/data/master/db_dumps/20160101/gp_dump_1_(1|10)_20160101010101.gz'
+        self.context.use_old_filename_format = True
+        self.context.content_map[10] = -1
+        output = self.context.generate_filename("dump", content=-1)
+        self.assertEquals(output, expected_output)
+
+    def test_generate_filename_content_segment_old_format_with_mirror(self):
+        content = 1
+        expected_output = '/data/master/db_dumps/20160101/gp_dump_0_(3|5)_20160101010101.gz'
         self.context.use_old_filename_format = True
         output = self.context.generate_filename("dump", content=content)
         self.assertEquals(output, expected_output)
@@ -211,8 +239,15 @@ class BackupUtilsTestCase(GpTestCase):
     def test_is_timestamp_in_old_format_wrong_path(self, mock1, mock2, mock3):
         self.assertTrue(self.context.is_timestamp_in_old_format())
 
+    @patch('glob.glob', return_value=['/data/master/db_dumps/20160101/gp_dump_1_1_20160101010101.gz'])
+    def test_get_filename_for_content_old_format_master_exists(self, mock1):
+        self.context.use_old_filename_format=True
+        filename = get_filename_for_content(self.context, "metadata", -1)
+        self.assertEquals(filename, '/data/master/db_dumps/20160101/gp_dump_1_1_20160101010101.gz')
+
     @patch('glob.glob', return_value=['/data/master/db_dumps/20160101/gp_dump_-1_1_20160101010101.gz'])
-    def test_get_filename_for_content_master_exists(self, mock1):
+    def test_get_filename_for_content_new_format_master_exists(self, mock1):
+        self.context.use_old_filename_format=False
         filename = get_filename_for_content(self.context, "metadata", -1)
         self.assertEquals(filename, '/data/master/db_dumps/20160101/gp_dump_-1_1_20160101010101.gz')
 


### PR DESCRIPTION
The glob syntax used to validate filenames for segment dump filenames
in the "old" backup format is only correct for single-digit dbids, as
it assumes the use of regex syntax that glob doesn't actually support.

This commit modifies get_filename_for_content to glob for all dump
files present and then explicitly match the expected filenames with a
regular expression.

It also modifies generate_filename to account for files created on a
standby master, which was not correctly handled previously.


This commit will be backported to 5X_STABLE and 4.3_STABLE.