### PR TITLE
dblink: check number of arguments passed to function dblink_connect

### DIFF
--- a/contrib/dblink/dblink.c
+++ b/contrib/dblink/dblink.c
@@ -251,8 +251,15 @@ dblink_connect(PG_FUNCTION_ARGS)
 		connname = text_to_cstring(PG_GETARG_TEXT_PP(0));
 	}
 	else if (PG_NARGS() == 1)
+	{
 		connstr = text_to_cstring(PG_GETARG_TEXT_PP(0));
-
+	}
+	else
+	{
+		ereport(ERROR,
+			(errcode(ERRCODE_CONNECTION_EXCEPTION),
+			 errmsg("could not establish connection")));
+	}
 	if (connname)
 		rconn = (remoteConn *) MemoryContextAlloc(TopMemoryContext,
 												  sizeof(remoteConn));


### PR DESCRIPTION
report error when there are more than 2 arguments passed to function
dblink_connect

Signed-off-by: Xiaoran Wang <xiwang@pivotal.io>