### PR TITLE
Use oidin function (strtoul) for converting reflfile nodes to OIDs

### DIFF
--- a/src/backend/utils/gp/test/Makefile
+++ b/src/backend/utils/gp/test/Makefile
@@ -1,0 +1,12 @@
+subdir=src/backend/utils/gp
+top_builddir=../../../../..
+include $(top_builddir)/src/Makefile.global
+
+TARGETS=persistentutil
+
+include $(top_builddir)/src/backend/mock.mk
+
+persistentutil.t: \
+	$(MOCK_DIR)/backend/storage/file/fd_mock.o \
+	$(MOCK_DIR)/backend/access/heap/heapam_mock.o \
+	$(MOCK_DIR)/backend/utils/fmgr/funcapi_mock.o

--- a/src/backend/utils/gp/test/persistentutil_test.c
+++ b/src/backend/utils/gp/test/persistentutil_test.c
@@ -1,0 +1,37 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include "cmockery.h"
+
+#include "postgres.h"
+#include "../persistentutil.c"
+
+typedef struct dirent dirent;
+
+void
+test__strToRelfilenode_converts_larger_than_max_signed_int(void **state)
+{
+	/* Purposely adding an extra dot to make the strToRelfilenode believe that
+	 * we don't have correct segument number to return false */
+	char * d_name = "2147483648.1.1"; /*2147483647 is the
+										MAX_INT limit for a
+										signed int */
+	Oid relfilenode = InvalidOid;
+	int32 segmentnum = -1;
+	bool ret = strToRelfilenode(d_name, &relfilenode, &segmentnum);
+
+	assert_true(relfilenode == 2147483648);
+	assert_true(segmentnum == 1);
+	assert_false(ret);
+}
+
+int
+main(int argc, char* argv[])
+{
+	cmockery_parse_arguments(argc, argv);
+	const UnitTest tests[] = {
+		unit_test(test__strToRelfilenode_converts_larger_than_max_signed_int),
+	};
+
+	return run_tests(tests);
+}


### PR DESCRIPTION
The gp_persistent_relation_node_check() UDF implementation used pg_atoi() to convert relefile nodes to OIDs. This overflows a signed integer value when the relfile nodes exceed 2^31 (2 billion plus).  We have changed this to use strtoul() instead.  

----------------------

Add unittest for gp_strtoul and gp_persistent_relation_node_check

Add test coverage for converting string to unsigned value.
Previously, we were converting with pg_atoi, signed int, which failed on
values greater than equal to 2^31.

Add cmockery test for gp_persistent_relation_node_check that will hit
the conversion path.
Add a functional test to call the conversion directly.


------------------------------------------

This will get backported to 5X_STABLE.