### PR TITLE
Surface ORCA Memory Account info in EXPLAIN (#3354)

### DIFF
--- a/src/backend/cdb/cdbexplain.c
+++ b/src/backend/cdb/cdbexplain.c
@@ -2168,6 +2168,10 @@ cdbexplain_showExecStatsEnd(struct PlannedStmt *stmt,
 	{
 		appendStringInfoString(str, "Statement statistics:\n");
 		appendStringInfo(str, "  Memory used: %.0fK bytes", ceil((double) stmt->query_mem / 1024.0));
+		if (optimizer && explain_memory_verbosity == EXPLAIN_MEMORY_VERBOSITY_SUMMARY )
+		{
+			MemoryAccounting_ExplainAppendCurrentOptimizerAccountInfo(str);
+		}
 
 		if (showstatctx->workmemwanted_max > 0)
 		{

--- a/src/backend/utils/mmgr/memaccounting.c
+++ b/src/backend/utils/mmgr/memaccounting.c
@@ -512,6 +512,29 @@ MemoryAccounting_SaveToLog()
 	}
 }
 
+/*
+ * Get string output of the current Optimizer Memory account. This is used only in
+ */
+void
+MemoryAccounting_ExplainAppendCurrentOptimizerAccountInfo(StringInfoData *str)
+{
+
+	MemoryAccountIdType shortLivingCount = shortLivingMemoryAccountArray->accountCount;
+
+	for (MemoryAccountIdType shortLivingArrayIdx = 0; shortLivingArrayIdx < shortLivingCount; ++shortLivingArrayIdx)
+	{
+		MemoryAccount *shortLivingAccount = shortLivingMemoryAccountArray->allAccounts[shortLivingArrayIdx];
+		if (shortLivingAccount->ownerType == MEMORY_OWNER_TYPE_Optimizer)
+		{
+			appendStringInfo(str, "\n  ORCA Memory used: peak %.0fK bytes  allocated %.0fK bytes  freed %.0fK bytes ",
+							 ceil((double) shortLivingAccount->peak / 1024L),
+							 ceil((double) shortLivingAccount->allocated / 1024L),
+							 ceil((double) shortLivingAccount->freed / 1024L));
+			break;
+		}
+	}
+}
+
 /*****************************************************************************
  *	  PRIVATE ROUTINES FOR MEMORY ACCOUNTING								 *
  *****************************************************************************/

--- a/src/backend/utils/mmgr/test/memaccounting_test.c
+++ b/src/backend/utils/mmgr/test/memaccounting_test.c
@@ -242,6 +242,27 @@ test__CreateMemoryAccountImpl__ActiveVsParent(void **state)
 	assert_true(tempChildAccount->parentId != ActiveMemoryAccountId);
 }
 
+void
+test__MemoryAccounting_Optimizer_Oustanding_Balance_Rollover(void **state)
+{
+	MemoryAccountIdType optimizerAccountId = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Optimizer, ActiveMemoryAccountId);
+	MemoryAccountIdType tempParentAccountId = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_Hash, optimizerAccountId);
+
+	MemoryAccounting_SwitchAccount(optimizerAccountId);
+	void *ptr = Ext_OptimizerAlloc(1);
+	assert_true(GetOptimizerOutstandingMemoryBalance()==1);
+
+	MemoryAccounting_SwitchAccount(tempParentAccountId);
+	MemoryAccount *currentAccount = MemoryAccounting_ConvertIdToAccount(tempParentAccountId);
+	assert_true(currentAccount->allocated == 0);
+
+	MemoryAccountIdType optimizerAccountId2 = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Optimizer, tempParentAccountId);
+	MemoryAccounting_SwitchAccount(optimizerAccountId2);
+	currentAccount = MemoryAccounting_ConvertIdToAccount(optimizerAccountId2);
+	assert_true(currentAccount->allocated == GetOptimizerOutstandingMemoryBalance() );
+
+}
+
 /*
  * Checks whether the regular account creation charges the overhead
  * in the MemoryAccountMemoryAccount and SharedChunkHeadersMemoryAccount.
@@ -1398,6 +1419,7 @@ main(int argc, char* argv[])
 		unit_test_setup_teardown(test__MemoryAccounting_CombinedAccountArrayToString__Validate, SetupMemoryDataStructures, TeardownMemoryDataStructures),
 		unit_test_setup_teardown(test__ConvertIdToUniversalArrayIndex__Validate, SetupMemoryDataStructures, TeardownMemoryDataStructures),
 		unit_test_setup_teardown(test__MemoryAccounting_GetAccountCurrentBalance__ResetPeakBalance, SetupMemoryDataStructures, TeardownMemoryDataStructures),
+		unit_test_setup_teardown(test__MemoryAccounting_Optimizer_Oustanding_Balance_Rollover, SetupMemoryDataStructures, TeardownMemoryDataStructures),
 	};
 
 	return run_tests(tests);

--- a/src/include/utils/memaccounting.h
+++ b/src/include/utils/memaccounting.h
@@ -233,4 +233,13 @@ MemoryAccounting_SaveToLog(void);
 extern void
 MemoryAccounting_PrettyPrint(void);
 
+extern uint64
+MemoryAccounting_DeclareDone();
+
+extern uint64
+MemoryAccounting_RequestQuotaIncrease();
+
+extern void
+MemoryAccounting_ExplainAppendCurrentOptimizerAccountInfo(StringInfoData *str);
+
 #endif   /* MEMACCOUNTING_H */


### PR DESCRIPTION
This commit will display the contents of the Optimizer Mem Account when
the optimizer GUC is on and explain_memory_verbosity is set to
'summary'.

Signed-off-by: Sambitesh Dash <sdash@pivotal.io>