### PR TITLE
Fix gpdb issue #3333

### DIFF
--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -3521,6 +3521,35 @@ select rnum, c1, c2 from qp_tjoin2 where 20 > all ( select c1 from qp_tjoin1) or
 ------+----+----
 (0 rows)
 
+-- start_ignore
+DROP TABLE IF EXISTS foo;
+NOTICE:  table "foo" does not exist, skipping
+DROP TABLE IF EXISTS bar;
+NOTICE:  table "bar" does not exist, skipping
+CREATE TABLE foo(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE bar(c int, d int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- end_ignore
+EXPLAIN SELECT a FROM foo f1 LEFT JOIN bar on a=c WHERE NOT EXISTS(SELECT 1 FROM foo f2 WHERE f1.a = f2.a);
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=4074.50..1712216.48 rows=7414 width=4)
+   ->  Hash Anti Join  (cost=4074.50..1712216.48 rows=2472 width=4)
+         Hash Cond: f1.a = f2.a
+         ->  Hash Left Join  (cost=2037.25..95878.62 rows=2471070 width=4)
+               Hash Cond: f1.a = bar.c
+               ->  Seq Scan on foo f1  (cost=0.00..961.00 rows=28700 width=4)
+               ->  Hash  (cost=961.00..961.00 rows=28700 width=4)
+                     ->  Seq Scan on bar  (cost=0.00..961.00 rows=28700 width=4)
+         ->  Hash  (cost=961.00..961.00 rows=28700 width=4)
+               ->  Seq Scan on foo f2  (cost=0.00..961.00 rows=28700 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(12 rows)
+
 -- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -3665,6 +3665,36 @@ select rnum, c1, c2 from qp_tjoin2 where 20 > all ( select c1 from qp_tjoin1) or
 ------+----+----
 (0 rows)
 
+-- start_ignore
+DROP TABLE IF EXISTS foo;
+NOTICE:  table "foo" does not exist, skipping
+DROP TABLE IF EXISTS bar;
+NOTICE:  table "bar" does not exist, skipping
+CREATE TABLE foo(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE bar(c int, d int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- end_ignore
+EXPLAIN SELECT a FROM foo f1 LEFT JOIN bar on a=c WHERE NOT EXISTS(SELECT 1 FROM foo f2 WHERE f1.a = f2.a);
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=2 width=4)
+   ->  Hash Left Join  (cost=0.00..1293.00 rows=1 width=4)
+         Hash Cond: qp_correlated_query.foo.a = bar.c
+         ->  Hash Anti Join  (cost=0.00..862.00 rows=1 width=4)
+               Hash Cond: qp_correlated_query.foo.a = qp_correlated_query.foo.a
+               ->  Table Scan on foo  (cost=0.00..431.00 rows=1 width=4)
+               ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                     ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Table Scan on foo  (cost=0.00..431.00 rows=1 width=4)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+               ->  Table Scan on bar  (cost=0.00..431.00 rows=1 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.46.2
+(13 rows)
+
 -- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------

--- a/src/test/regress/sql/qp_correlated_query.sql
+++ b/src/test/regress/sql/qp_correlated_query.sql
@@ -821,6 +821,16 @@ select rnum, c1, c2 from qp_tjoin2 where 75 > all ( select c2 from qp_tjoin1) or
 
 select rnum, c1, c2 from qp_tjoin2 where 20 > all ( select c1 from qp_tjoin1) order by rnum;
 
+-- start_ignore
+DROP TABLE IF EXISTS foo;
+DROP TABLE IF EXISTS bar;
+
+CREATE TABLE foo(a int, b int);
+CREATE TABLE bar(c int, d int);
+-- end_ignore
+
+EXPLAIN SELECT a FROM foo f1 LEFT JOIN bar on a=c WHERE NOT EXISTS(SELECT 1 FROM foo f2 WHERE f1.a = f2.a);
+
 -- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------


### PR DESCRIPTION
This issue exists only on subselect_merge branch and got introduced during merge.
In master, cdbsubselect_flatten_sublink() recurses into the quals only for JOIN_INNER and skips the outer joins.
During the merge; we kept the same behavior by not recursing into outer joins; however that introduced issue #3333 wherein we do not collect correct left and right relids for outer joins.

Upstream 8.4_STABLE also bans recursing into quals for outer joins and takes care of updating the relids appropriately.

This PR cherry-picks that commit which resolves this issue and maintains the same behavior as master.