### PR TITLE
Implement slot pool shared by all resource groups.

### DIFF
--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -1194,6 +1194,7 @@ initSlot(ResGroupSlotData *slot, ResGroupCaps *caps, Oid groupId, int sessionId)
 	slot->memQuota = slotGetMemQuotaExpected(caps);
 	slot->memUsage = 0;
 }
+
 /*
  * Alloc a slot from shared slot pool
  */
@@ -1214,6 +1215,8 @@ slotPoolAlloc(void)
 	slot = &pResGroupControl->slots[ret];
 	Assert(!slotIsInUse(slot));
 	pResGroupControl->freeSlot = slot->next;
+
+	slot->next = InvalidSlotId;
 
 	return ret;
 }

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -219,6 +219,7 @@ static void selfAttachToSlot(ResGroupData *group, ResGroupSlotData *slot);
 static void selfDetachSlot(ResGroupData *group, ResGroupSlotData *slot);
 static int slotPoolAlloc(void);
 static void slotPoolFree(int slotId);
+static void slotPoolInitSlot(int slotId, int next);
 static int getSlot(ResGroupData *group);
 static void putSlot(void);
 static void ResGroupSlotAcquire(void);
@@ -343,8 +344,8 @@ ResGroupControlInit(void)
 
 	MemSet(pResGroupControl->slots, 0, slots_size);
 	for (i = 0; i < RESGROUP_MAX_SLOTS - 1; i++)
-		pResGroupControl->slots[i].next = i + 1;
-	pResGroupControl->slots[RESGROUP_MAX_SLOTS - 1].next = InvalidSlotId;
+		slotPoolInitSlot(i, i + 1);
+	slotPoolInitSlot(RESGROUP_MAX_SLOTS - 1, InvalidSlotId);
 
 	pResGroupControl->freeSlot = 0;
 
@@ -1233,6 +1234,19 @@ slotPoolFree(int slotId)
 	slot->groupId = InvalidOid;
 	slot->next = pResGroupControl->freeSlot;
 	pResGroupControl->freeSlot = slotId;
+}
+
+/*
+ * Initialize slot when initializing slot pool
+ */
+static void
+slotPoolInitSlot(int slotId, int next)
+{
+	ResGroupSlotData *slot;
+
+	slot = &pResGroupControl->slots[slotId];
+	slot->next = next;
+	slot->groupId = InvalidOid;
 }
 
 /*


### PR DESCRIPTION
Previously every resource group has its own slot pool, each with size of 'MaxConnection'.
In order to reduce memory usage, implement a slot pool shared by all resource groups.

In addition, free slots in the slot pool are organized as a free list to optimize alloc/free
operations. 