### PR TITLE
Change NodeTag enum value to avoid range overlap

### DIFF
--- a/src/include/nodes/nodes.h
+++ b/src/include/nodes/nodes.h
@@ -527,7 +527,7 @@ typedef enum NodeTag
 	T_SelectedParts,            /* in executor/nodePartitionSelector.h */
 	
     /* CDB: tags for random other stuff */
-    T_CdbExplain_StatHdr = 950,             /* in cdb/cdbexplain.c */
+    T_CdbExplain_StatHdr = 1000,             /* in cdb/cdbexplain.c */
 
 } NodeTag;
 


### PR DESCRIPTION
Resolves issue #3374 Reported by Feng Tian .