### PR TITLE
Add need_timer to Instrumentation, to allow eliminating of timing overhead

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -1580,7 +1580,7 @@ DoCopyInternal(const CopyStmt *stmt, const char *queryString, CopyState cstate)
 		/* Create a QueryDesc requesting no output */
 		cstate->queryDesc = CreateQueryDesc(plan, queryString,
 											ActiveSnapshot, InvalidSnapshot,
-											dest, NULL, false);
+											dest, NULL, 0);
 
 		if (gp_enable_gpperfmon && Gp_role == GP_ROLE_DISPATCH)
 		{

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -377,6 +377,10 @@ ExplainOnePlan(PlannedStmt *plannedstmt, ParamListInfo params,
 	int			eflags;
 	char	   *settings;
 	MemoryContext explaincxt = CurrentMemoryContext;
+	int			instrument_option = 0;
+
+	if (stmt->analyze)
+		instrument_option |= INSTRUMENT_TIMER;
 
 	/*
 	 * Update snapshot command ID to ensure this query sees results of any
@@ -392,7 +396,7 @@ ExplainOnePlan(PlannedStmt *plannedstmt, ParamListInfo params,
 								queryString,
 								ActiveSnapshot, InvalidSnapshot,
 								None_Receiver, params,
-								stmt->analyze);
+								instrument_option);
 
 	if (gp_enable_gpperfmon && Gp_role == GP_ROLE_DISPATCH)
 	{

--- a/src/backend/commands/extension.c
+++ b/src/backend/commands/extension.c
@@ -737,7 +737,7 @@ execute_sql_string(const char *sql, const char *filename)
 				qdesc = CreateQueryDesc((PlannedStmt *) stmt,
 										sql,
 										ActiveSnapshot, NULL,
-										dest, NULL, false);
+										dest, NULL, 0);
 
 				ExecutorStart(qdesc, 0);
 				ExecutorRun(qdesc, ForwardScanDirection, 0);

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -1244,7 +1244,7 @@ ExecuteTruncate(TruncateStmt *stmt)
 						  rel,
 						  0,			/* dummy rangetable index */
 						  CMD_DELETE,	/* don't need any index info */
-						  false);
+						  0);
 		resultRelInfo++;
 	}
 	estate->es_result_relations = resultRelInfos;
@@ -11387,7 +11387,7 @@ build_ctas_with_dist(Relation rel, List *dist_clause,
 	/* Create a QueryDesc requesting no output */
 	queryDesc = CreateQueryDesc(stmt,  pstrdup("(internal SELECT INTO query)"),
 								ActiveSnapshot, InvalidSnapshot,
-								dest, NULL, false);
+								dest, NULL, 0);
 	return queryDesc;
 }
 

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -373,7 +373,7 @@ ExecutorStart(QueryDesc *queryDesc, int eflags)
 	 */
 	estate->es_snapshot = queryDesc->snapshot;
 	estate->es_crosscheck_snapshot = queryDesc->crosscheck_snapshot;
-	estate->es_instrument = queryDesc->doInstrument;
+	estate->es_instrument = queryDesc->instrument_options;
 	estate->showstatctx = queryDesc->showstatctx;
 
 	/*
@@ -432,7 +432,7 @@ ExecutorStart(QueryDesc *queryDesc, int eflags)
 		}
 
 		/* Pass EXPLAIN ANALYZE flag to qExecs. */
-		estate->es_sliceTable->doInstrument = queryDesc->doInstrument;
+		estate->es_sliceTable->instrument_options = queryDesc->instrument_options;
 
 		/* set our global sliceid variable for elog. */
 		currentSliceId = LocallyExecutingSliceIndex(estate);
@@ -488,8 +488,8 @@ ExecutorStart(QueryDesc *queryDesc, int eflags)
 			currentSliceId = LocallyExecutingSliceIndex(estate);
 
 			/* Should we collect statistics for EXPLAIN ANALYZE? */
-			estate->es_instrument = sliceTable->doInstrument;
-			queryDesc->doInstrument = sliceTable->doInstrument;
+			estate->es_instrument = sliceTable->instrument_options;
+			queryDesc->instrument_options = sliceTable->instrument_options;
 		}
 
 		/* InitPlan() will acquire locks by walking the entire plan
@@ -926,7 +926,7 @@ ExecutorRun(QueryDesc *queryDesc,
 	{
         /* If EXPLAIN ANALYZE, let qExec try to return stats to qDisp. */
         if (estate->es_sliceTable &&
-            estate->es_sliceTable->doInstrument &&
+            estate->es_sliceTable->instrument_options &&
             Gp_role == GP_ROLE_EXECUTE)
         {
             PG_TRY();
@@ -1015,7 +1015,7 @@ ExecutorEnd(QueryDesc *queryDesc)
      * If EXPLAIN ANALYZE, qExec returns stats to qDisp now.
      */
     if (estate->es_sliceTable &&
-        estate->es_sliceTable->doInstrument &&
+        estate->es_sliceTable->instrument_options &&
         Gp_role == GP_ROLE_EXECUTE)
         cdbexplain_sendExecStats(queryDesc);
 
@@ -2173,7 +2173,7 @@ InitResultRelInfo(ResultRelInfo *resultRelInfo,
 				  Relation resultRelationDesc,
 				  Index resultRelationIndex,
 				  CmdType operation,
-				  bool doInstrument)
+				  int instrument_options)
 {
 	/*
 	 * Check valid relkind ... parser and/or planner should have noticed this
@@ -2248,10 +2248,8 @@ InitResultRelInfo(ResultRelInfo *resultRelInfo,
 
 		resultRelInfo->ri_TrigFunctions = (FmgrInfo *)
 			palloc0(n * sizeof(FmgrInfo));
-		if (doInstrument)
-			resultRelInfo->ri_TrigInstrument = InstrAlloc(n);
-		else
-			resultRelInfo->ri_TrigInstrument = NULL;
+		if (instrument_options)
+			resultRelInfo->ri_TrigInstrument = InstrAlloc(n, instrument_options);
 	}
 	else
 	{

--- a/src/backend/executor/execProcnode.c
+++ b/src/backend/executor/execProcnode.c
@@ -830,7 +830,7 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 
 	/* Set up instrumentation for this node if requested */
 	if (estate->es_instrument && result != NULL)
-		result->instrument = InstrAlloc(1);
+		result->instrument = InstrAlloc(1, estate->es_instrument);
 
 	if (result != NULL)
 	{

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -1378,7 +1378,7 @@ InitSliceTable(EState *estate, int nMotions, int nSubplans)
 	table->nMotions = nMotions;
 	table->nInitPlans = nSubplans;
 	table->slices = NIL;
-    table->doInstrument = false;
+    table->instrument_options = 0;
 
 	/* Each slice table has a unique-id. */
 	table->ic_instance_id = ++gp_interconnect_id;

--- a/src/backend/executor/functions.c
+++ b/src/backend/executor/functions.c
@@ -446,7 +446,7 @@ postquel_start(execution_state *es, SQLFunctionCachePtr fcache)
 								 fcache->src,
 								 snapshot, InvalidSnapshot,
 								 None_Receiver,
-								 fcache->paramLI, false);
+								 fcache->paramLI, 0);
 
 		if (gp_enable_gpperfmon 
 			&& Gp_role == GP_ROLE_DISPATCH 

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -1891,7 +1891,7 @@ _SPI_execute_plan(SPIPlanPtr plan, ParamListInfo paramLI,
 											ActiveSnapshot,
 											crosscheck_snapshot,
 											dest,
-											paramLI, false);
+											paramLI, 0);
 
                     if (gp_enable_gpperfmon 
                     		&& Gp_role == GP_ROLE_DISPATCH 

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -4327,8 +4327,8 @@ _copySliceTable(SliceTable *from)
 	COPY_SCALAR_FIELD(nInitPlans);
 	COPY_SCALAR_FIELD(localSlice);
 	COPY_NODE_FIELD(slices);
-    COPY_SCALAR_FIELD(doInstrument);
-    COPY_SCALAR_FIELD(ic_instance_id);
+	COPY_SCALAR_FIELD(instrument_options);
+	COPY_SCALAR_FIELD(ic_instance_id);
 
 	return newnode;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -4064,7 +4064,7 @@ _outSliceTable(StringInfo str, SliceTable *node)
 	WRITE_INT_FIELD(nInitPlans);
 	WRITE_INT_FIELD(localSlice);
 	WRITE_NODE_FIELD(slices); /* List of int */
-    WRITE_BOOL_FIELD(doInstrument);
+	WRITE_INT_FIELD(instrument_options);
 	WRITE_INT_FIELD(ic_instance_id);
 }
 

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -2723,7 +2723,7 @@ _readSliceTable(void)
 	READ_INT_FIELD(nInitPlans);
 	READ_INT_FIELD(localSlice);
 	READ_NODE_FIELD(slices); /* List of Slice* */
-    READ_BOOL_FIELD(doInstrument);
+	READ_INT_FIELD(instrument_options);
 	READ_INT_FIELD(ic_instance_id);
 
 	READ_DONE();

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -79,7 +79,7 @@ CreateQueryDesc(PlannedStmt *plannedstmt,
 				Snapshot crosscheck_snapshot,
 				DestReceiver *dest,
 				ParamListInfo params,
-				bool doInstrument)
+				int instrument_options)
 {
 	QueryDesc  *qd = (QueryDesc *) palloc(sizeof(QueryDesc));
 
@@ -91,7 +91,7 @@ CreateQueryDesc(PlannedStmt *plannedstmt,
 	qd->crosscheck_snapshot = crosscheck_snapshot;		/* RI check snapshot */
 	qd->dest = dest;			/* output dest */
 	qd->params = params;		/* parameter values passed into query */
-	qd->doInstrument = doInstrument;	/* instrumentation wanted? */
+	qd->instrument_options = instrument_options;	/* instrumentation wanted? */
 
 	/* null these fields until set by ExecutorStart */
 	qd->tupDesc = NULL;
@@ -145,7 +145,7 @@ CreateUtilityQueryDesc(Node *utilitystmt,
 	qd->crosscheck_snapshot = InvalidSnapshot;	/* RI check snapshot */
 	qd->dest = dest;			/* output dest */
 	qd->params = params;		/* parameter values passed into query */
-	qd->doInstrument = false;	/* uninteresting for utilities */
+	qd->instrument_options = 0;	/* uninteresting for utilities */
 
 	/* null these fields until set by ExecutorStart */
 	qd->tupDesc = NULL;
@@ -219,11 +219,11 @@ ProcessQuery(Portal portal,
 	if (portal->sourceTag == T_SelectStmt && gp_select_invisible)
 		queryDesc = CreateQueryDesc(stmt, portal->sourceText,
 									SnapshotAny, InvalidSnapshot,
-									dest, params, false);
+									dest, params, 0);
 	else
 		queryDesc = CreateQueryDesc(stmt, portal->sourceText,
 									ActiveSnapshot, InvalidSnapshot,
-									dest, params, false);
+									dest, params, 0);
 	queryDesc->ddesc = portal->ddesc;
 
 	if (gp_enable_gpperfmon && Gp_role == GP_ROLE_DISPATCH)
@@ -638,7 +638,7 @@ PortalStart(Portal portal, ParamListInfo params, Snapshot snapshot,
 											InvalidSnapshot,
 											None_Receiver,
 											params,
-											false);
+											0);
 				queryDesc->ddesc = ddesc;
 				
 				if (gp_enable_gpperfmon && Gp_role == GP_ROLE_DISPATCH)

--- a/src/include/executor/execdesc.h
+++ b/src/include/executor/execdesc.h
@@ -132,7 +132,7 @@ typedef struct SliceTable
 	int			nInitPlans;		/* The number of initplan slices allocated */
 	int			localSlice;		/* Index of the slice to execute. */
 	List	   *slices;			/* List of slices */
-	bool		doInstrument;	/* true => collect stats for EXPLAIN ANALYZE */
+	int			instrument_options;	/* OR of InstrumentOption flags */
 	uint32		ic_instance_id;
 } SliceTable;
 
@@ -232,7 +232,7 @@ typedef struct QueryDesc
 	Snapshot	crosscheck_snapshot;	/* crosscheck for RI update/delete */
 	DestReceiver *dest;			/* the destination for tuple output */
 	ParamListInfo params;		/* param values being passed in */
-	bool		doInstrument;	/* TRUE requests runtime instrumentation */
+	int			instrument_options;		/* OR of InstrumentOption flags */
 
 	/* These fields are set by ExecutorStart */
 	TupleDesc	tupDesc;		/* descriptor for result tuples */
@@ -265,7 +265,7 @@ extern QueryDesc *CreateQueryDesc(PlannedStmt *plannedstmt,
 				Snapshot crosscheck_snapshot,
 				DestReceiver *dest,
 				ParamListInfo params,
-				bool doInstrument);
+				int instrument_options);
 
 extern QueryDesc *CreateUtilityQueryDesc(Node *utilitystmt,
 										 const char *sourceText,

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -230,7 +230,7 @@ extern void InitResultRelInfo(ResultRelInfo *resultRelInfo,
 				  Relation resultRelationDesc,
 				  Index resultRelationIndex,
 				  CmdType operation,
-				  bool doInstrument);
+				  int instrument_options);
 extern ResultRelInfo *ExecGetTriggerResultRel(EState *estate, Oid relid);
 extern bool ExecContextForcesOids(PlanState *planstate, bool *hasoids);
 extern void ExecConstraints(ResultRelInfo *resultRelInfo,

--- a/src/include/executor/instrument.h
+++ b/src/include/executor/instrument.h
@@ -19,9 +19,19 @@
 
 struct CdbExplain_NodeSummary;          /* private def in cdb/cdbexplain.c */
 
+/* Flag bits included in InstrAlloc's instrument_options bitmask */
+typedef enum InstrumentOption
+{
+	INSTRUMENT_TIMER = 1 << 0,	/* needs timer (and row counts) */
+	INSTRUMENT_BUFFERS = 1 << 1,	/* needs buffer usage (not implemented yet) */
+	INSTRUMENT_ROWS = 1 << 2,	/* needs row count */
+	INSTRUMENT_ALL = PG_INT32_MAX
+} InstrumentOption;
 
 typedef struct Instrumentation
 {
+	/* Parameters set at node creation: */
+	bool		need_timer;	    /* TRUE if we need timer data */
 	/* Info about current plan cycle: */
 	bool		running;		/* TRUE if we've completed first tuple */
 	instr_time	starttime;		/* Start time of current iteration of node */
@@ -45,7 +55,7 @@ typedef struct Instrumentation
     struct CdbExplain_NodeSummary  *cdbNodeSummary; /* stats from all qExecs */
 } Instrumentation;
 
-extern Instrumentation *InstrAlloc(int n);
+extern Instrumentation *InstrAlloc(int n, int instrument_options);
 extern void InstrStartNode(Instrumentation *instr);
 extern void InstrStopNode(Instrumentation *instr, double nTuples);
 extern void InstrEndLoop(Instrumentation *instr);

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -562,7 +562,7 @@ typedef struct EState
 	Oid			es_lastoid;		/* last oid processed (by INSERT) */
 	List	   *es_rowMarks;	/* not good place, but there is no other */
 
-	bool		es_instrument;	/* true requests runtime instrumentation */
+	int			es_instrument;	/* OR of InstrumentOption flags */
 	bool		es_select_into; /* true if doing SELECT INTO */
 	bool		es_into_oids;	/* true to generate OIDs in SELECT INTO */
 


### PR DESCRIPTION
This patch is to make Instrumentation more useful for counting number of tuples without paying the cost of timing every node entry/exit.
The related commit in PG9.2 are [TIMING](https://github.com/postgres/postgres/commit/af7914c6627bcf0b0ca614e9ce95d3f8056602bf) and [BUFUSAGE](https://github.com/postgres/postgres/commit/cddca5ec13d27017281422124cae0480cddfb663)
BufUsage commit introduced "instrument_options (int)" to replace "doInstrument (bool)" in CreateQueryDesc argument. This option help control what Instrumentation data to collect/skip, better than "doInstrument" just turn on/off everything.
Based on "instrument_options", this patch backported from TIMING commit, makes the TIMING calculation be skipped if "instrument_options" sets so.

For current EXPLAIN or EXPLAIN ANALYZE behavior, no changes by this patch.
 - EXPLAIN will not turn on instrumentation
 - EXPLAIN ANALYZE will count both tuple count and timing
Will submit more use case in recent future that only collects tulpe count.

Notice that this patch does not backport all codes from above two commits. We exclucded
1. changes to EXPLAIN syntax to support BUFFER/TIMING option
   - Because [dependent commits](https://github.com/postgres/postgres/commit/d4382c4ae7ea1e272f4fee388aac8ff99421471a) allowing EXPLAIN have options are not yet in gpdb
2. changes to storage to collect buffer usage metrics
   - Not yet necessary, may be a separate PR in future