### PR TITLE
Preserve env variables in run_test part of Concourse ic_gpdb task

### DIFF
--- a/concourse/scripts/common.bash
+++ b/concourse/scripts/common.bash
@@ -53,5 +53,5 @@ workaround_before_concourse_stops_stripping_suid_bits() {
 function run_test() {
   # is this particular python version giving us trouble?
   ln -s "$(pwd)/gpdb_src/gpAux/ext/rhel6_x86_64/python-2.7.12" /opt
-  su - gpadmin -c "bash /opt/run_test.sh $(pwd)"
+  su gpadmin -c "bash /opt/run_test.sh $(pwd)"
 }


### PR DESCRIPTION
Some environment variables passed through the pipeline YAML were not
being passed to the test run (e.g. WITH_MIRRORS=false). Removing the
full login flag of su fixes the issue.