### PR TITLE
Fix unintentional fallthrough for SpecialJoinInfo

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -2195,6 +2195,8 @@ _copySpecialJoinInfo(SpecialJoinInfo *from)
 	COPY_NODE_FIELD(join_quals);
 	COPY_SCALAR_FIELD(try_join_unique);	/* CDB */
 	COPY_SCALAR_FIELD(consider_dedup);	/* CDB */
+	COPY_NODE_FIELD(semi_operators);
+	COPY_NODE_FIELD(semi_rhs_exprs);
 
 	return newnode;
 }
@@ -4876,6 +4878,7 @@ copyObject(void *from)
 			break;
 		case T_SpecialJoinInfo:
 			retval = _copySpecialJoinInfo(from);
+			break;
 		case T_AppendRelInfo:
 			retval = _copyAppendRelInfo(from);
 			break;

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -834,6 +834,8 @@ _equalSpecialJoinInfo(SpecialJoinInfo *a, SpecialJoinInfo *b)
 	COMPARE_NODE_FIELD(join_quals);
 	COMPARE_SCALAR_FIELD(try_join_unique);	/* CDB */
 	COMPARE_SCALAR_FIELD(consider_dedup);		/* CDB */
+	COMPARE_NODE_FIELD(semi_operators);
+	COMPARE_NODE_FIELD(semi_rhs_exprs);
 
 	return true;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -2227,6 +2227,8 @@ _outSpecialJoinInfo(StringInfo str, SpecialJoinInfo *node)
 	WRITE_NODE_FIELD(join_quals);
 	WRITE_BOOL_FIELD(try_join_unique);	/*CDB*/
 	WRITE_BOOL_FIELD(consider_dedup);	/*CDB*/
+	WRITE_NODE_FIELD(semi_operators);
+	WRITE_NODE_FIELD(semi_rhs_exprs);
 }
 
 static void

--- a/src/backend/optimizer/path/joinrels.c
+++ b/src/backend/optimizer/path/joinrels.c
@@ -600,6 +600,8 @@ make_join_rel(PlannerInfo *root, RelOptInfo *rel1, RelOptInfo *rel2)
 		sjinfo->lhs_strict = false;
 		sjinfo->delay_upper_joins = false;
 		sjinfo->join_quals = NIL;
+		sjinfo->semi_operators = NIL;
+		sjinfo->semi_rhs_exprs = NIL;
 	}
 
 	/*

--- a/src/include/nodes/relation.h
+++ b/src/include/nodes/relation.h
@@ -232,7 +232,7 @@ typedef struct PlannerInfo
 	List	   *full_join_clauses;		/* list of RestrictInfos for
 										 * mergejoinable full join clauses */
 
-	List	   *join_info_list; /* list of SpecialJoinInfos */
+	List	   *join_info_list;     /* list of SpecialJoinInfos */
 
 	List	   *append_rel_list;	/* list of AppendRelInfos */
 	


### PR DESCRIPTION
In copyFuncs(), the fallthrough for SpecialJoinInfo was unintentionally
done as a part of subselect merge.  This commit fixes that along with
adding support for new fields in copyFuncs(), outFunc() and equalFunc().

[Ref #151491231]