### PR TITLE
Disallows self-reference within non-recursive CTE

### DIFF
--- a/src/test/regress/expected/with.out
+++ b/src/test/regress/expected/with.out
@@ -599,6 +599,21 @@ WITH RECURSIVE x(n) AS (
 ERROR:  GROUP BY in a recursive query is not implemented
 LINE 4:  SELECT level+1, c FROM x, bar GROUP BY 1,2)
                                                 ^
+-- self-reference inside nested non-recursive CTE is not allowed
+WITH RECURSIVE r AS (
+  SELECT 1 AS a
+  UNION ALL
+  (
+    WITH w AS (
+      SELECT * FROM r
+    )
+    SELECT * FROM w
+  )
+)
+SELECT * FROM r;
+ERROR:  self-reference to "r" in a non-recursive CTE is not implemented
+LINE 6:       SELECT * FROM r
+                            ^
 WITH RECURSIVE x(n) AS (
 	SELECT 1,2
 	UNION ALL

--- a/src/test/regress/sql/with.sql
+++ b/src/test/regress/sql/with.sql
@@ -330,6 +330,19 @@ WITH RECURSIVE x(n) AS (
 	SELECT level+1, c FROM x, bar GROUP BY 1,2)
   SELECT * FROM x LIMIT 10;
 
+-- self-reference inside nested non-recursive CTE is not allowed
+WITH RECURSIVE r AS (
+  SELECT 1 AS a
+  UNION ALL
+  (
+    WITH w AS (
+      SELECT * FROM r
+    )
+    SELECT * FROM w
+  )
+)
+SELECT * FROM r;
+
 WITH RECURSIVE x(n) AS (
 	SELECT 1,2
 	UNION ALL


### PR DESCRIPTION
In Greenplum, a reference to a common table expression (CTE) in the FROM
clause can be implemented by:

  - Sharing: a Shared Scan writer executes the CTE plan and materializes
  the output; and a Shared Scan reader -- potentially in a different
  process (cross-slice) -- can then consume this materialized relation;
  - Inlining: a subtree planned for the CTE plan will be directly
  executed in-line. This avoids the overhead of a tuple store (in
  scenarios where we consume significantly less than we produce, or when
  we have only one reference to the CTE), but it might spend more time
  executing the same plan more than once.

Both approaches are designed with idempotent expressions in mind: we get
the correct result regardless of whether we re-execute the plan or just
store it and re-use that.

This assumption is broken

  - when a CTE contains an outer reference (PARAM); or
  - when a CTE contains a self-reference to a recursive (enclosing) CTE

We can not inline such a CTE because a WorkTableScan is tightly paired
with a RecursiveUnion: a plan with two `WorkTableScan`s correponding to
the same `RecursiveUnion` will produce the wrong result.

We cannot simply materialize such a CTE with a Shared Scan because we
cannot re-use the output from one execution to the next -- the PARAM
would have changed.

Before we get around implementing them, this commit identifies queries
where a non-recursive CTE contains self-references to an enclosing
recursive CTE, and bans them outright.

[#147799865]