### PR TITLE
Ignore running ICW with GPOS as a release candidate

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -10,7 +10,6 @@ groups:
   - compile_gpdb_aix7_remote
   - icw_planner_centos6
   - icw_gporca_centos6
-  - icw_gporca_centos6_gpos_memory
   - icw_gporca_centos7
   - icw_gporca_sles11
   - icw_planner_ictcp_centos6
@@ -76,6 +75,10 @@ groups:
   - MM_gppkg
   - MM_gprecoverseg
   - DPM_backup_43_restore_5
+
+- name: Experimental Tests
+  jobs:
+  - icw_gporca_centos6_gpos_memory
 
 ## ======================================================================
 ## resource types

--- a/concourse/scripts/validate_pipeline_release_jobs.py
+++ b/concourse/scripts/validate_pipeline_release_jobs.py
@@ -5,7 +5,7 @@ import re
 import yaml
 
 RELEASE_VALIDATOR_JOB = ['Release_Candidate']
-JOBS_THAT_SHOULD_NOT_BLOCK_RELEASE = ['compile_gpdb_binary_swap_centos6'] + RELEASE_VALIDATOR_JOB
+JOBS_THAT_SHOULD_NOT_BLOCK_RELEASE = ['compile_gpdb_binary_swap_centos6', 'icw_gporca_centos6_gpos_memory'] + RELEASE_VALIDATOR_JOB
 
 pipeline_raw = open(os.environ['PIPELINE_FILE'],'r').read()
 pipeline_buffer_cleaned = re.sub('{{', '', re.sub('}}', '', pipeline_raw)) # ignore concourse v2.x variable interpolation


### PR DESCRIPTION
GPOS using GPDB for memory allocation is still a feature hidden behind a
GUC and requires more performance testing to be considered for the
default allocation behavior of GPOS. For now it can be ignored from
determing if a build of GPDB is release worthy