### PR TITLE
Decouple GUC max_resource_groups and max_connections.

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -1276,24 +1276,6 @@ gpvars_show_gp_resource_manager_policy(void)
 }
 
 /*
- * gpvars_assign_max_resource_groups
- */
-bool
-gpvars_assign_max_resource_groups(int newval, bool doit, GucSource source __attribute__((unused)))
-{
-	if (doit)
-	{
-		if (newval > MaxConnections)
-			elog(ERROR, "Invalid input for max_resource_groups. Must be no larger than max_connections(%d).", MaxConnections);
-
-		MaxResourceGroups = newval;
-	}
-
-	return true;
-}
-
-
-/*
  * gpvars_assign_gp_resqueue_memory_policy
  * gpvars_show_gp_resqueue_memory_policy
  */

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -206,8 +206,7 @@ CreateResourceGroup(CreateResourceGroupStmt *stmt)
 	if (nResGroups >= MaxResourceGroups)
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_RESOURCES),
-				 errmsg("insufficient resource groups available"),
-				 errhint("Increase max_resource_groups")));
+				 errmsg("insufficient resource groups available")));
 
 	/*
 	 * Check the pg_resgroup relation to be certain the group doesn't already

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -3760,7 +3760,7 @@ struct config_int ConfigureNamesInt_gp[] =
 			NULL
 		},
 		&MaxResourceGroups,
-		9, 0, INT_MAX, gpvars_assign_max_resource_groups, NULL
+		9, 0, 100, NULL, NULL
 	},
 
 	{

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -3755,15 +3755,6 @@ struct config_int ConfigureNamesInt_gp[] =
 	},
 
 	{
-		{"max_resource_groups", PGC_POSTMASTER, RESOURCES_MGM,
-			gettext_noop("Maximum number of resource groups."),
-			NULL
-		},
-		&MaxResourceGroups,
-		9, 0, 100, NULL, NULL
-	},
-
-	{
 		{"max_resource_portals_per_transaction", PGC_POSTMASTER, RESOURCES_MGM,
 			gettext_noop("Maximum number of resource queues."),
 			NULL

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -168,9 +168,6 @@ struct ResGroupControl
 	ResGroupData	groups[1];
 };
 
-/* GUC */
-int		MaxResourceGroups;
-
 /* static variables */
 
 static ResGroupControl *pResGroupControl = NULL;

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -1048,8 +1048,6 @@ extern const char *gpvars_assign_gp_resource_manager_policy(const char *newval, 
 
 extern const char *gpvars_show_gp_resource_manager_policy(void);
 
-extern bool gpvars_assign_max_resource_groups(int newval, bool doit, GucSource source __attribute__((unused)));
-
 extern const char *gpvars_assign_gp_resqueue_memory_policy(const char *newval, bool doit, GucSource source __attribute__((unused)) );
 
 extern const char *gpvars_show_gp_resqueue_memory_policy(void);

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -20,6 +20,11 @@
 #include "catalog/pg_resgroup.h"
 
 /*
+ * The max number of resource groups.
+ */
+#define MaxResourceGroups 100
+
+/*
  * Resource group capability.
  */
 typedef struct ResGroupCap
@@ -91,7 +96,6 @@ extern int						gp_resgroup_memory_policy_auto_fixed_mem;
 extern bool						gp_resgroup_print_operator_memory_limits;
 extern int						memory_spill_ratio;
 
-extern int MaxResourceGroups;
 extern double gp_resource_group_cpu_limit;
 extern double gp_resource_group_memory_limit;
 

--- a/src/test/isolation2/expected/resgroup/resgroup_verify_guc.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_verify_guc.out
@@ -1,38 +1,44 @@
 -- start_ignore
-! gpconfig -c max_statement_mem -v 20GB ! gpconfig -c statement_mem -v 10GB ! gpstop -rai;
-20170830:02:23:03:300931 gpconfig:ad3e397dc7b9:gpadmin-[INFO]:-completed successfully with parameters '-c max_statement_mem -v 20GB'
-20170830:02:23:04:301007 gpconfig:ad3e397dc7b9:gpadmin-[INFO]:-completed successfully with parameters '-c statement_mem -v 10GB'
-20170830:02:23:04:301083 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Starting gpstop with args: -rai
-20170830:02:23:04:301083 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Gathering information and validating the environment...
-20170830:02:23:04:301083 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
-20170830:02:23:04:301083 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Obtaining Segment details from master...
-20170830:02:23:04:301083 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 5.0.0-beta.9+dev.48.gdf8d694 build dev'
-20170830:02:23:04:301083 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-There are 0 connections to the database
-20170830:02:23:04:301083 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Commencing Master instance shutdown with mode='immediate'
-20170830:02:23:04:301083 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Master host=ad3e397dc7b9
-20170830:02:23:04:301083 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Commencing Master instance shutdown with mode=immediate
-20170830:02:23:04:301083 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Master segment instance directory=/home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
-20170830:02:23:05:301083 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Attempting forceful termination of any leftover master process
-20170830:02:23:05:301083 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Terminating processes for segment /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
-20170830:02:23:05:301083 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-No standby master host configured
-20170830:02:23:05:301083 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Commencing parallel primary segment instance shutdown, please wait...
-20170830:02:23:05:301083 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-0.00% of jobs completed
-20170830:02:23:15:301083 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-100.00% of jobs completed
-20170830:02:23:15:301083 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Commencing parallel mirror segment instance shutdown, please wait...
-20170830:02:23:15:301083 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-0.00% of jobs completed
-20170830:02:23:25:301083 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-100.00% of jobs completed
-20170830:02:23:25:301083 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-----------------------------------------------------
-20170830:02:23:25:301083 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-   Segments stopped successfully      = 6
-20170830:02:23:25:301083 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-   Segments with errors during stop   = 0
-20170830:02:23:25:301083 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-----------------------------------------------------
-20170830:02:23:25:301083 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Successfully shutdown 6 of 6 segment instances 
-20170830:02:23:25:301083 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Database successfully shutdown with no errors reported
-20170830:02:23:25:301083 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Cleaning up leftover gpmmon process
-20170830:02:23:25:301083 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-No leftover gpmmon process found
-20170830:02:23:25:301083 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Cleaning up leftover gpsmon processes
-20170830:02:23:25:301083 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-No leftover gpsmon processes on some hosts. not attempting forceful termination on these hosts
-20170830:02:23:25:301083 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Cleaning up leftover shared memory
-20170830:02:23:25:301083 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Restarting System...
+! gpconfig -c max_statement_mem -v 20GB ! gpconfig -c statement_mem -v 10GB ! gpconfig -c max_resource_groups -v 80;
+20170928:02:48:57:198256 gpconfig:ad3e397dc7b9:gpadmin-[INFO]:-completed successfully with parameters '-c max_statement_mem -v 20GB'
+20170928:02:49:10:198344 gpconfig:ad3e397dc7b9:gpadmin-[INFO]:-completed successfully with parameters '-c statement_mem -v 10GB'
+20170928:02:49:22:198451 gpconfig:ad3e397dc7b9:gpadmin-[INFO]:-completed successfully with parameters '-c max_resource_groups -v 80'
+
+! gpconfig -c max_connections -v 100 -m 40;
+20170928:02:49:34:198539 gpconfig:ad3e397dc7b9:gpadmin-[INFO]:-completed successfully with parameters '-c max_connections -v 100 -m 40'
+
+! gpstop -rai;
+20170928:02:49:34:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Starting gpstop with args: -rai
+20170928:02:49:34:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Gathering information and validating the environment...
+20170928:02:49:34:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
+20170928:02:49:34:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Obtaining Segment details from master...
+20170928:02:49:36:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 5.0.0-beta.10+dev.814.g06f2d5f build dev'
+20170928:02:49:36:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-There are 0 connections to the database
+20170928:02:49:36:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Commencing Master instance shutdown with mode='immediate'
+20170928:02:49:36:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Master host=ad3e397dc7b9
+20170928:02:49:36:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Commencing Master instance shutdown with mode=immediate
+20170928:02:49:36:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Master segment instance directory=/home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20170928:02:49:38:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Attempting forceful termination of any leftover master process
+20170928:02:49:38:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Terminating processes for segment /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20170928:02:49:39:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-No standby master host configured
+20170928:02:49:40:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Commencing parallel primary segment instance shutdown, please wait...
+20170928:02:49:40:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-0.00% of jobs completed
+20170928:02:49:50:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-100.00% of jobs completed
+20170928:02:49:50:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Commencing parallel mirror segment instance shutdown, please wait...
+20170928:02:49:50:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-0.00% of jobs completed
+20170928:02:50:00:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-100.00% of jobs completed
+20170928:02:50:00:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-----------------------------------------------------
+20170928:02:50:00:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-   Segments stopped successfully      = 6
+20170928:02:50:00:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-   Segments with errors during stop   = 0
+20170928:02:50:00:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-----------------------------------------------------
+20170928:02:50:00:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Successfully shutdown 6 of 6 segment instances 
+20170928:02:50:00:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Database successfully shutdown with no errors reported
+20170928:02:50:00:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Cleaning up leftover gpmmon process
+20170928:02:50:01:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-No leftover gpmmon process found
+20170928:02:50:01:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Cleaning up leftover gpsmon processes
+20170928:02:50:02:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-No leftover gpsmon processes on some hosts. not attempting forceful termination on these hosts
+20170928:02:50:02:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Cleaning up leftover shared memory
+20170928:02:50:03:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Restarting System...
 
 -- end_ignore
 
@@ -45,4 +51,14 @@ show statement_mem;
 statement_mem
 -------------
 10GB         
+(1 row)
+show max_resource_groups;
+max_resource_groups
+-------------------
+80                 
+(1 row)
+show max_connections;
+max_connections
+---------------
+40             
 (1 row)

--- a/src/test/isolation2/expected/resgroup/resgroup_verify_guc.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_verify_guc.out
@@ -1,44 +1,38 @@
 -- start_ignore
-! gpconfig -c max_statement_mem -v 20GB ! gpconfig -c statement_mem -v 10GB ! gpconfig -c max_resource_groups -v 80;
-20170928:02:48:57:198256 gpconfig:ad3e397dc7b9:gpadmin-[INFO]:-completed successfully with parameters '-c max_statement_mem -v 20GB'
-20170928:02:49:10:198344 gpconfig:ad3e397dc7b9:gpadmin-[INFO]:-completed successfully with parameters '-c statement_mem -v 10GB'
-20170928:02:49:22:198451 gpconfig:ad3e397dc7b9:gpadmin-[INFO]:-completed successfully with parameters '-c max_resource_groups -v 80'
-
-! gpconfig -c max_connections -v 100 -m 40;
-20170928:02:49:34:198539 gpconfig:ad3e397dc7b9:gpadmin-[INFO]:-completed successfully with parameters '-c max_connections -v 100 -m 40'
-
-! gpstop -rai;
-20170928:02:49:34:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Starting gpstop with args: -rai
-20170928:02:49:34:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Gathering information and validating the environment...
-20170928:02:49:34:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
-20170928:02:49:34:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Obtaining Segment details from master...
-20170928:02:49:36:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 5.0.0-beta.10+dev.814.g06f2d5f build dev'
-20170928:02:49:36:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-There are 0 connections to the database
-20170928:02:49:36:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Commencing Master instance shutdown with mode='immediate'
-20170928:02:49:36:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Master host=ad3e397dc7b9
-20170928:02:49:36:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Commencing Master instance shutdown with mode=immediate
-20170928:02:49:36:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Master segment instance directory=/home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
-20170928:02:49:38:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Attempting forceful termination of any leftover master process
-20170928:02:49:38:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Terminating processes for segment /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
-20170928:02:49:39:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-No standby master host configured
-20170928:02:49:40:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Commencing parallel primary segment instance shutdown, please wait...
-20170928:02:49:40:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-0.00% of jobs completed
-20170928:02:49:50:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-100.00% of jobs completed
-20170928:02:49:50:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Commencing parallel mirror segment instance shutdown, please wait...
-20170928:02:49:50:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-0.00% of jobs completed
-20170928:02:50:00:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-100.00% of jobs completed
-20170928:02:50:00:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-----------------------------------------------------
-20170928:02:50:00:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-   Segments stopped successfully      = 6
-20170928:02:50:00:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-   Segments with errors during stop   = 0
-20170928:02:50:00:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-----------------------------------------------------
-20170928:02:50:00:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Successfully shutdown 6 of 6 segment instances 
-20170928:02:50:00:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Database successfully shutdown with no errors reported
-20170928:02:50:00:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Cleaning up leftover gpmmon process
-20170928:02:50:01:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-No leftover gpmmon process found
-20170928:02:50:01:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Cleaning up leftover gpsmon processes
-20170928:02:50:02:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-No leftover gpsmon processes on some hosts. not attempting forceful termination on these hosts
-20170928:02:50:02:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Cleaning up leftover shared memory
-20170928:02:50:03:198627 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Restarting System...
+! gpconfig -c max_statement_mem -v 20GB ! gpconfig -c statement_mem -v 10GB ! gpstop -rai;
+20170929:03:24:11:381552 gpconfig:ad3e397dc7b9:gpadmin-[INFO]:-completed successfully with parameters '-c max_statement_mem -v 20GB'
+20170929:03:24:23:381640 gpconfig:ad3e397dc7b9:gpadmin-[INFO]:-completed successfully with parameters '-c statement_mem -v 10GB'
+20170929:03:24:23:381729 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Starting gpstop with args: -rai
+20170929:03:24:23:381729 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Gathering information and validating the environment...
+20170929:03:24:23:381729 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
+20170929:03:24:23:381729 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Obtaining Segment details from master...
+20170929:03:24:25:381729 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 5.0.0-beta.10+dev.814.g6e61528 build dev'
+20170929:03:24:25:381729 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-There are 0 connections to the database
+20170929:03:24:25:381729 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Commencing Master instance shutdown with mode='immediate'
+20170929:03:24:25:381729 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Master host=ad3e397dc7b9
+20170929:03:24:25:381729 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Commencing Master instance shutdown with mode=immediate
+20170929:03:24:25:381729 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Master segment instance directory=/home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20170929:03:24:26:381729 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Attempting forceful termination of any leftover master process
+20170929:03:24:27:381729 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Terminating processes for segment /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20170929:03:24:28:381729 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-No standby master host configured
+20170929:03:24:28:381729 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Commencing parallel primary segment instance shutdown, please wait...
+20170929:03:24:28:381729 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-0.00% of jobs completed
+20170929:03:24:38:381729 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-100.00% of jobs completed
+20170929:03:24:38:381729 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Commencing parallel mirror segment instance shutdown, please wait...
+20170929:03:24:38:381729 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-0.00% of jobs completed
+20170929:03:24:48:381729 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-100.00% of jobs completed
+20170929:03:24:48:381729 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-----------------------------------------------------
+20170929:03:24:48:381729 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-   Segments stopped successfully      = 6
+20170929:03:24:48:381729 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-   Segments with errors during stop   = 0
+20170929:03:24:48:381729 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-----------------------------------------------------
+20170929:03:24:48:381729 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Successfully shutdown 6 of 6 segment instances 
+20170929:03:24:48:381729 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Database successfully shutdown with no errors reported
+20170929:03:24:48:381729 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Cleaning up leftover gpmmon process
+20170929:03:24:49:381729 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-No leftover gpmmon process found
+20170929:03:24:49:381729 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Cleaning up leftover gpsmon processes
+20170929:03:24:50:381729 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-No leftover gpsmon processes on some hosts. not attempting forceful termination on these hosts
+20170929:03:24:50:381729 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Cleaning up leftover shared memory
+20170929:03:24:51:381729 gpstop:ad3e397dc7b9:gpadmin-[INFO]:-Restarting System...
 
 -- end_ignore
 
@@ -51,14 +45,4 @@ show statement_mem;
 statement_mem
 -------------
 10GB         
-(1 row)
-show max_resource_groups;
-max_resource_groups
--------------------
-80                 
-(1 row)
-show max_connections;
-max_connections
----------------
-40             
 (1 row)

--- a/src/test/isolation2/expected/resgroup/restore_default_resgroup.out
+++ b/src/test/isolation2/expected/resgroup/restore_default_resgroup.out
@@ -10,9 +10,6 @@
 20170830:00:35:09:440522 gpconfig:sdw6:gpadmin-[WARNING]:-Managing queries with resource groups is an experimental feature. A work-in-progress version is enabled.
 20170830:00:35:10:440522 gpconfig:sdw6:gpadmin-[INFO]:-completed successfully with parameters '-c gp_resource_manager -v group'
 
-! gpconfig -c max_resource_groups -v 40;
-20170830:00:35:11:440642 gpconfig:sdw6:gpadmin-[INFO]:-completed successfully with parameters '-c max_resource_groups -v 40'
-
 ! gpconfig -c max_connections -v 100 -m 40;
 20170830:00:35:11:440726 gpconfig:sdw6:gpadmin-[INFO]:-completed successfully with parameters '-c max_connections -v 100 -m 40'
 

--- a/src/test/isolation2/sql/resgroup/resgroup_verify_guc.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_verify_guc.sql
@@ -1,12 +1,8 @@
 -- start_ignore
 ! gpconfig -c max_statement_mem -v 20GB
 ! gpconfig -c statement_mem -v 10GB
-! gpconfig -c max_resource_groups -v 80;
-! gpconfig -c max_connections -v 100 -m 40;
 ! gpstop -rai;
 -- end_ignore
 
 show max_statement_mem;
 show statement_mem;
-show max_resource_groups;
-show max_connections;

--- a/src/test/isolation2/sql/resgroup/resgroup_verify_guc.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_verify_guc.sql
@@ -1,8 +1,12 @@
 -- start_ignore
 ! gpconfig -c max_statement_mem -v 20GB
 ! gpconfig -c statement_mem -v 10GB
+! gpconfig -c max_resource_groups -v 80;
+! gpconfig -c max_connections -v 100 -m 40;
 ! gpstop -rai;
 -- end_ignore
 
 show max_statement_mem;
 show statement_mem;
+show max_resource_groups;
+show max_connections;

--- a/src/test/isolation2/sql/resgroup/restore_default_resgroup.sql
+++ b/src/test/isolation2/sql/resgroup/restore_default_resgroup.sql
@@ -6,7 +6,6 @@
 
 -- 40 should be enough for the following cases and some
 -- weak test agents may not adopt a higher max_connections
-! gpconfig -c max_resource_groups -v 40;
 ! gpconfig -c max_connections -v 100 -m 40;
 ! gpstop -rai;
 -- end_ignore


### PR DESCRIPTION
Previously there is a restriction on GUC 'max_resource_groups'
that it cannot be larger than 'max_connections'.
This restriction may cause gpdb fail to start if the two GUCs
are not set properly.
We decide to decouple these two GUCs and set a hard limit
of 100 for 'max_resource_groups'.