### PR TITLE
Fix dblink panic when connecting as a non-superuser

### DIFF
--- a/contrib/dblink/Makefile
+++ b/contrib/dblink/Makefile
@@ -1,9 +1,8 @@
 # $PostgreSQL: pgsql/contrib/dblink/Makefile,v 1.15 2007/11/10 23:59:50 momjian Exp $
 
 MODULE_big = dblink
-PG_CPPFLAGS = -I$(libpq_srcdir)
+PG_CPPFLAGS = -I$(top_srcdir)/src/backend/gp_libpq_fe
 OBJS	= dblink.o
-SHLIB_LINK = $(libpq)
 
 DATA_built = dblink.sql 
 DATA = uninstall_dblink.sql 

--- a/contrib/dblink/dblink.c
+++ b/contrib/dblink/dblink.c
@@ -34,7 +34,9 @@
 
 #include <limits.h>
 
-#include "libpq-fe.h"
+/* dblink is QD to QD, using built-in libpq-fe */
+#include "gp-libpq-fe.h"
+
 #include "fmgr.h"
 #include "funcapi.h"
 #include "access/genam.h"
@@ -94,7 +96,7 @@ static int	get_attnum_pk_pos(int *pkattnums, int pknumatts, int key);
 static HeapTuple get_tuple_of_interest(Relation rel, int *pkattnums, int pknumatts, char **src_pkattvals);
 static Relation get_rel_from_relname(text *relname_text, LOCKMODE lockmode, AclMode aclmode);
 static char *generate_relation_name(Relation rel);
-static void dblink_connstr_check(const char *connstr);
+static char *dblink_connstr_check(const char *connstr);
 static void dblink_security_check(PGconn *conn, remoteConn *rconn);
 static void dblink_res_error(const char *conname, PGresult *res, const char *dblink_context_msg, bool fail);
 static void dblink_security_check(PGconn *conn, remoteConn *rconn);
@@ -192,8 +194,7 @@ typedef struct remoteConnHashEnt
 			} \
 			else \
 			{ \
-				connstr = conname_or_str; \
-				dblink_connstr_check(connstr); \
+				connstr = dblink_connstr_check(conname_or_str); \
 				conn = PQconnectdb(connstr); \
 				if (PQstatus(conn) == CONNECTION_BAD) \
 				{ \
@@ -258,7 +259,7 @@ dblink_connect(PG_FUNCTION_ARGS)
 												  sizeof(remoteConn));
 
 	/* check password in connection string if not superuser */
-	dblink_connstr_check(connstr);
+	connstr = dblink_connstr_check(connstr);
 	conn = PQconnectdb(connstr);
 
 	if (PQstatus(conn) == CONNECTION_BAD)
@@ -2271,32 +2272,71 @@ dblink_security_check(PGconn *conn, remoteConn *rconn)
  * prevents a password from being picked up from .pgpass, a service file,
  * the environment, etc.  We don't want the postgres user's passwords
  * to be accessible to non-superusers.
+ *
+ * For Greenplum, dblink uses built libpq to construct conninfo, whose user is
+ * environment variable PGUSER, which is wrong, modifies this function to add
+ * the session's username into connstr.
+ *
  */
-static void
+static char *
 dblink_connstr_check(const char *connstr)
 {
+	char	*connstr_modified = (char *) connstr;
+
 	if (!superuser())
 	{
 		PQconninfoOption   *options;
 		PQconninfoOption   *option;
 		bool				connstr_gives_password = false;
+		bool				username_is_set = false;
+		bool				host_is_set = false;
 
 		options = PQconninfoParse(connstr, NULL);
 		if (options)
 		{
 			for (option = options; option->keyword != NULL; option++)
 			{
+				if (strcmp(option->keyword, "host") == 0)
+				{
+					if (option->val != NULL && option->val[0] != '\0')
+					{
+						host_is_set = true;
+					}
+				}
+
+				if (strcmp(option->keyword, "user") == 0)
+				{
+					if (option->val == NULL || option->val[0] == '\0')
+					{
+						char *username = GetUserNameFromId(GetUserId());
+
+						/* 7 is strlen("user= ") + length of '\0' */
+						connstr_modified = palloc0(7 + strlen(username) + strlen(connstr));
+						sprintf(connstr_modified, "user=%s %s", username, connstr);
+					}
+
+					username_is_set = true;
+				}
+
 				if (strcmp(option->keyword, "password") == 0)
 				{
 					if (option->val != NULL && option->val[0] != '\0')
 					{
 						connstr_gives_password = true;
-						break;
 					}
 				}
+
+				if (host_is_set && username_is_set && connstr_gives_password)
+					break;
 			}
 			PQconninfoFree(options);
 		}
+
+		if (!host_is_set)
+			ereport(ERROR,
+					(errcode(ERRCODE_S_R_E_PROHIBITED_SQL_STATEMENT_ATTEMPTED),
+					 errmsg("host is required"),
+					 errdetail("Non-superusers must provide a host in the connection string.")));
 
 		if (!connstr_gives_password)
 			ereport(ERROR,
@@ -2304,6 +2344,8 @@ dblink_connstr_check(const char *connstr)
 					 errmsg("password is required"),
 					 errdetail("Non-superusers must provide a password in the connection string.")));
 	}
+
+	return connstr_modified;
 }
 
 static void


### PR DESCRIPTION
1, dblink is QD to QD, using built-in gp-libpq-fe, whose size of
PQconninfoOption is different with libpq-fe's, including wrong header
file will cause dereferencing panic.

2, QD to QD's connection user is environment variable PGUSER, we need to
set it to session user in dblink.

3, QD to QD's unix domain socket connection doesn't require any
authentication, request non-superuser to provide host to use TCP/UDP
connections.

Signed-off-by: Adam Lee <ali@pivotal.io>
Signed-off-by: Xiaoran Wang <xiwang@pivotal.io>