### PR TITLE
docs - 0 memory_spill_ratio, no relation to memory_shared_quota

### DIFF
--- a/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
@@ -91,8 +91,7 @@
     <section id="topic833sp" xml:lang="en">
      <title>Spill to Disk</title>
       <p><codeph>MEMORY_SPILL_RATIO</codeph> identifies the memory usage threshold for memory-intensive operators in a transaction. When the transaction reaches this memory threshold, it spills to disk. Greenplum Database uses the <codeph>MEMORY_SPILL_RATIO</codeph> to determine the initial memory to allocate to a transaction.</p>
-      <p> The minimum <codeph>MEMORY_SPILL_RATIO</codeph> percentage you can specify for a resource group is 1. The maximum is 100. The upper limit of this ratio is (100 - <codeph>MEMORY_SHARED_QUOTA</codeph>). The default <codeph>MEMORY_SPILL_RATIO</codeph> is 20.</p>
-      <p>The sum of <codeph>MEMORY_SHARED_QUOTA</codeph> and <codeph>MEMORY_SPILL_RATIO</codeph> must not exceed 100.</p>
+      <p> The minimum <codeph>MEMORY_SPILL_RATIO</codeph> percentage you can specify for a resource group is 0. The maximum is 100. The default <codeph>MEMORY_SPILL_RATIO</codeph> is 20.</p>
       <p>You define the <codeph>MEMORY_SPILL_RATIO</codeph> when you create a resource group. You can selectively set this limit on a per-query basis at the session level with the <codeph><xref href="../ref_guide/config_params/guc-list.xml#memory_spill_ratio" type="section"/></codeph> server configuration parameter.</p>
     </section>
  

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -7372,7 +7372,7 @@
           </thead>
           <tbody>
             <row>
-              <entry colname="col1">1 - 100</entry>
+              <entry colname="col1">0 - 100</entry>
               <entry colname="col2">20</entry>
               <entry colname="col3">master<p>session</p><p>reload</p></entry>
             </row>

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_RESOURCE_GROUP.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_RESOURCE_GROUP.xml
@@ -72,7 +72,7 @@ MEMORY_SPILL_RATIO <varname>integer</varname></codeblock>
           <pt>MEMORY_SPILL_RATIO <varname>integer</varname></pt>
           <pd>The memory usage threshold for memory-intensive operators in a transaction
             issued in the resource group. The minimum memory spill ratio percentage for a
-            resource group is 1. The maximum is 100. The default
+            resource group is 0. The maximum is 100. The default
             <codeph>MEMORY_SPILL_RATIO</codeph> value is 20.</pd>
         </plentry>
       </parml>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml
@@ -58,11 +58,11 @@ MEMORY_LIMIT=<varname>integer</varname>
         </plentry>
         <plentry>
           <pt>MEMORY_SHARED_QUOTA <varname>integer</varname></pt>
-          <pd>The quota of shared memory in the resource group. Resource groups with a <codeph>MEMORY_SHARED_QUOTA</codeph> threshold set aside a percentage of memory allotted to the resource group to share across transactions. This shared memory is allocated on a first-come, first-served basis as available. A transaction may use none, some, or all of this memory. The minimum memory shared quota percentage you can specify for a resource group is 0. The maximum is 100. The default <codeph>MEMORY_SHARED_QUOTA</codeph> value is 20. The sum of the <codeph>MEMORY_SHARED_QUOTA</codeph> and <codeph>MEMORY_SPILL_RATIO</codeph> values specified for a resource group cannot exceed 100.</pd>
+          <pd>The quota of shared memory in the resource group. Resource groups with a <codeph>MEMORY_SHARED_QUOTA</codeph> threshold set aside a percentage of memory allotted to the resource group to share across transactions. This shared memory is allocated on a first-come, first-served basis as available. A transaction may use none, some, or all of this memory. The minimum memory shared quota percentage you can specify for a resource group is 0. The maximum is 100. The default <codeph>MEMORY_SHARED_QUOTA</codeph> value is 20.</pd>
         </plentry>
         <plentry>
           <pt>MEMORY_SPILL_RATIO <varname>integer</varname></pt>
-          <pd>The memory usage threshold for memory-intensive operators in a transaction. When the transaction reaches this threshold, it spills to disk. The minimum memory spill ratio percentage you can specify for a resource group is 1. The maximum is 100. The upper limit is (100 - <codeph>MEMORY_SHARED_QUOTA</codeph>). The default <codeph>MEMORY_SPILL_RATIO</codeph> value is 20. The sum of the <codeph>MEMORY_SHARED_QUOTA</codeph> and <codeph>MEMORY_SPILL_RATIO</codeph> values specified for a resource group cannot exceed 100.</pd>
+          <pd>The memory usage threshold for memory-intensive operators in a transaction. When the transaction reaches this threshold, it spills to disk. The minimum memory spill ratio percentage you can specify for a resource group is 0. The maximum is 100. The default <codeph>MEMORY_SPILL_RATIO</codeph> value is 20.</pd>
         </plentry>
       </parml>
     </section>


### PR DESCRIPTION
- updated memory_spill_ratio lower limit to 0 on ALTER/CREATE RESOURCE GROUP sql ref pages, memory_spill_ratio GUC description page, and "using resource groups" admin guide page
- removed the restriction that memory_spill_ratio + memory_shared_quota must not exceed 100

links to docs on review staging site:
- http://docs-gpdb-review-staging.cfapps.io/500/ref_guide/sql_commands/ALTER_RESOURCE_GROUP.html
- http://docs-gpdb-review-staging.cfapps.io/500/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.html
- http://docs-gpdb-review-staging.cfapps.io/500/ref_guide/config_params/guc-list.html#memory_spill_ratio
- http://docs-gpdb-review-staging.cfapps.io/500/admin_guide/workload_mgmt_resgroups.html#topic8339717
