### PR TITLE
Force Runaway Query test restarts

### DIFF
--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_detector/test_runaway_detector.py
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_detector/test_runaway_detector.py
@@ -18,7 +18,7 @@ def _set_VLIM_SLIM_REDZONEPERCENT(vlimMB, slimMB, activationPercent):
 
     # Restart DB
     Command('Restart database for GUCs to take effect', 
-            'source $GPHOME/greenplum_path.sh && gpstop -ar').run(validateAfter=True)
+            'source $GPHOME/greenplum_path.sh && gpstop -air').run(validateAfter=True)
 
 def _reset_VLIM_SLIM_REDZONEPERCENT():
 
@@ -32,7 +32,7 @@ def _reset_VLIM_SLIM_REDZONEPERCENT():
             'source $GPHOME/greenplum_path.sh;gpconfig -r runaway_detector_activation_percent --skipvalidation').run(validateAfter=True)
     # Restart DB
     Command('Restart database for GUCs to take effect', 
-            'source $GPHOME/greenplum_path.sh && gpstop -ar').run(validateAfter=True)
+            'source $GPHOME/greenplum_path.sh && gpstop -air').run(validateAfter=True)
 
 class RunawayDetectorTestCase(SQLIsolationTestCase):
     """

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/test_runaway_query.py
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/test_runaway_query.py
@@ -18,7 +18,7 @@ def _set_VLIM_SLIM_REDZONEPERCENT(vlimMB, slimMB, activationPercent):
 
     # Restart DB
     Command('Restart database for GUCs to take effect', 
-            'source $GPHOME/greenplum_path.sh && gpstop -ar').run(validateAfter=True)
+            'source $GPHOME/greenplum_path.sh && gpstop -air').run(validateAfter=True)
 
 def _reset_VLIM_SLIM_REDZONEPERCENT():
 
@@ -32,7 +32,7 @@ def _reset_VLIM_SLIM_REDZONEPERCENT():
             'source $GPHOME/greenplum_path.sh;gpconfig -r runaway_detector_activation_percent --skipvalidation').run(validateAfter=True)
     # Restart DB
     Command('Restart database for GUCs to take effect', 
-            'source $GPHOME/greenplum_path.sh && gpstop -ar').run(validateAfter=True)
+            'source $GPHOME/greenplum_path.sh && gpstop -air').run(validateAfter=True)
 
 
 class RunawayQueryTestCase(SQLTestCase):

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/test_runaway_multisession.py
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/test_runaway_multisession.py
@@ -18,7 +18,7 @@ def _set_VLIM_SLIM_REDZONEPERCENT(vlimMB, slimMB, activationPercent):
 
     # Restart DB
     Command('Restart database for GUCs to take effect', 
-            'source $GPHOME/greenplum_path.sh && gpstop -ar').run(validateAfter=True)
+            'source $GPHOME/greenplum_path.sh && gpstop -air').run(validateAfter=True)
 
 def _reset_VLIM_SLIM_REDZONEPERCENT():
 
@@ -32,7 +32,7 @@ def _reset_VLIM_SLIM_REDZONEPERCENT():
             'source $GPHOME/greenplum_path.sh;gpconfig -r runaway_detector_activation_percent --skipvalidation').run(validateAfter=True)
     # Restart DB
     Command('Restart database for GUCs to take effect', 
-            'source $GPHOME/greenplum_path.sh && gpstop -ar').run(validateAfter=True)
+            'source $GPHOME/greenplum_path.sh && gpstop -air').run(validateAfter=True)
 
 
 class RunawayMultiSessionTestCase(SQLIsolationTestCase):

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/__init__.py
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/__init__.py
@@ -16,7 +16,7 @@ def _set_VLIM_SLIM_REDZONEPERCENT(vlimMB, slimMB, activationPercent):
 
     # Restart DB
     Command('Restart database for GUCs to take effect', 
-            'source $GPHOME/greenplum_path.sh && gpstop -ar').run(validateAfter=True)
+            'source $GPHOME/greenplum_path.sh && gpstop -air').run(validateAfter=True)
 
 def _reset_VLIM_SLIM_REDZONEPERCENT():
 
@@ -30,7 +30,7 @@ def _reset_VLIM_SLIM_REDZONEPERCENT():
             'source $GPHOME/greenplum_path.sh;gpconfig -r runaway_detector_activation_percent --skipvalidation').run(validateAfter=True)
     # Restart DB
     Command('Restart database for GUCs to take effect', 
-            'source $GPHOME/greenplum_path.sh && gpstop -ar').run(validateAfter=True)
+            'source $GPHOME/greenplum_path.sh && gpstop -air').run(validateAfter=True)
 
 class RQTBaseScenarioTestCase(ScenarioTestCase):
     

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_vmem_memoryaccounting/test_runaway_query_vmem_memoryaccounting.py
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_vmem_memoryaccounting/test_runaway_query_vmem_memoryaccounting.py
@@ -17,7 +17,7 @@ def _set_VLIM_SLIM(vlimMB, slimMB):
 
     # Restart DB
     Command('Restart database for GUCs to take effect', 
-            'source $GPHOME/greenplum_path.sh && gpstop -ar').run(validateAfter=True)
+            'source $GPHOME/greenplum_path.sh && gpstop -air').run(validateAfter=True)
 
 def _reset_VLIM_SLIM():
 
@@ -30,7 +30,7 @@ def _reset_VLIM_SLIM():
     
     # Restart DB
     Command('Restart database for GUCs to take effect', 
-            'source $GPHOME/greenplum_path.sh && gpstop -ar').run(validateAfter=True)
+            'source $GPHOME/greenplum_path.sh && gpstop -air').run(validateAfter=True)
 
 
 class RQTMemoryAccountingTestCase(SQLIsolationTestCase):


### PR DESCRIPTION
The runaway query TINC tests occasionally encounter issues where a
gpstop -ar is not successfull because of open connections. This commit
ensures that at the least gpstop will always restart gpdb.

Signed-off-by: Ekta Khanna <ekhanna@pivotal.io>