### PR TITLE
Dump resource group related objects in pg_dumpall

### DIFF
--- a/doc/src/sgml/ref/pg_dumpall.sgml
+++ b/doc/src/sgml/ref/pg_dumpall.sgml
@@ -206,6 +206,16 @@ PostgreSQL documentation
      </varlistentry>
 
      <varlistentry>
+      <term><option>--resource-groups</option></term>
+      <listitem>
+       <para>
+        Dump <literal>resource groups</literal> and <literal>role</literal>
+        to <literal>resource groups</literal> associations.
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry>
       <term><option>--no-tablespaces</option></term>
       <listitem>
        <para>

--- a/gpdb-doc/dita/utility_guide/client_utilities/pg_dumpall.xml
+++ b/gpdb-doc/dita/utility_guide/client_utilities/pg_dumpall.xml
@@ -179,6 +179,10 @@
                         <pd>Dump resource queue definitions.</pd>
                     </plentry>
                     <plentry>
+                        <pt>--resource-groups</pt>
+                        <pd>Dump resource group definitions.</pd>
+                    </plentry>
+                    <plentry>
                         <pt>--roles-only</pt>
                         <pd>Dump only roles, not databases, tablespaces, or filespaces.</pd>
                     </plentry>

--- a/src/bin/pg_dump/pg_dumpall.c
+++ b/src/bin/pg_dump/pg_dumpall.c
@@ -41,6 +41,7 @@ static const char *progname;
 static void help(void);
 
 static void dumpResQueues(PGconn *conn);
+static void dumpResGroups(PGconn *conn);
 static void dumpRoles(PGconn *conn);
 static void dumpRoleMembership(PGconn *conn);
 static void dumpRoleConstraints(PGconn *conn);
@@ -69,6 +70,7 @@ static bool ignoreVersion = false;
 static bool filespaces = false;
 
 static int	resource_queues = 0;
+static int	resource_groups = 0;
 static int	roles_only = 0;
 static int	disable_dollar_quoting = 0;
 static int	disable_triggers = 0;
@@ -133,6 +135,7 @@ main(int argc, char *argv[])
 		{"disable-dollar-quoting", no_argument, &disable_dollar_quoting, 1},
 		{"disable-triggers", no_argument, &disable_triggers, 1},
 		{"resource-queues", no_argument, &resource_queues, 1},
+		{"resource-groups", no_argument, &resource_groups, 1},
 		{"roles-only", no_argument, &roles_only, 1},
 		{"no-tablespaces", no_argument, &no_tablespaces, 1},
 		{"use-set-session-authorization", no_argument, &use_setsessauth, 1},
@@ -347,6 +350,7 @@ main(int argc, char *argv[])
 				appendPQExpBuffer(pgdumpopts, " --gp-syntax");
 				gp_syntax = true;
 				resource_queues = 1; /* --resource-queues is implied by --gp-syntax */
+				resource_groups = 1; /* --resource-groups is implied by --gp-syntax */
 				break;
 			case 2:
 				/* no-gp-format */
@@ -505,6 +509,10 @@ main(int argc, char *argv[])
 			if (resource_queues)
 				dumpResQueues(conn);
 
+			/* Dump Resource Groups */
+			if (resource_groups)
+				dumpResGroups(conn);
+
 			/* Dump roles (users) */
 			dumpRoles(conn);
 
@@ -576,6 +584,7 @@ help(void)
 			 "                           disable dollar quoting, use SQL standard quoting\n"));
 	printf(_("  --disable-triggers       disable triggers during data-only restore\n"));
 	printf(_("  --resource-queues        dump resource queue data\n"));
+	printf(_("  --resource-groups        dump resource group data\n"));
 	printf(_("  --roles-only             dump only roles, no databases or tablespaces\n"));
 	printf(_("  --no-tablespaces         do not dump tablespace assignments\n"));
 	printf(_("  --use-set-session-authorization\n"
@@ -612,6 +621,102 @@ buildWithClause(const char *resname, const char *ressetting, PQExpBuffer buf)
 		appendPQExpBuffer(buf, " %s=%s", resname, ressetting);
 }
 
+/*
+ * Dump resource group
+ */
+static void
+dumpResGroups(PGconn *conn)
+{
+	PQExpBuffer buf = createPQExpBuffer();
+	PGresult   *res;
+	int		i;
+	int		i_groupname,
+			i_cpu_rate_limit,
+			i_concurrency,
+			i_memory_limit,
+			i_memory_shared_quota,
+			i_memory_spill_ratio;
+
+	printfPQExpBuffer(buf, "SELECT groupname, cpu_rate_limit, "
+					  "proposed_concurrency as concurrency, "
+					  "proposed_memory_limit as memory_limit, "
+					  "proposed_memory_shared_quota as memory_shared_quota, "
+					  "proposed_memory_spill_ratio as memory_spill_ratio "
+					  "from gp_toolkit.gp_resgroup_config;");
+
+	res = executeQuery(conn, buf->data);
+
+	i_groupname = PQfnumber(res, "groupname");
+	i_cpu_rate_limit = PQfnumber(res, "cpu_rate_limit");
+	i_concurrency = PQfnumber(res, "concurrency");
+	i_memory_limit = PQfnumber(res, "memory_limit");
+	i_memory_shared_quota = PQfnumber(res, "memory_shared_quota");
+	i_memory_spill_ratio = PQfnumber(res, "memory_spill_ratio");
+
+	if (PQntuples(res) > 0)
+		fprintf(OPF, "--\n-- Resource Group\n--\n\n");
+
+	/*
+	 * total cpu_rate_limit and memory_limit should less than 100, so clean
+	 * them before we seting new memory_limit and cpu_rate_limit.
+	 */
+	fprintf(OPF, "ALTER RESOURCE GROUP admin_group SET cpu_rate_limit 1;\n");
+	fprintf(OPF, "ALTER RESOURCE GROUP default_group SET cpu_rate_limit 1;\n");
+	fprintf(OPF, "ALTER RESOURCE GROUP admin_group SET memory_limit 1;\n");
+	fprintf(OPF, "ALTER RESOURCE GROUP default_group SET memory_limit 1;\n");
+
+	for (i = 0; i < PQntuples(res); i++)
+	{
+		const char *groupname;
+		const char *cpu_rate_limit;
+		const char *concurrency;
+		const char *memory_limit;
+		const char *memory_shared_quota;
+		const char *memory_spill_ratio;
+
+		groupname = PQgetvalue(res, i, i_groupname);
+		cpu_rate_limit = PQgetvalue(res, i, i_cpu_rate_limit);
+		concurrency = PQgetvalue(res, i, i_concurrency);
+		memory_limit = PQgetvalue(res, i, i_memory_limit);
+		memory_shared_quota = PQgetvalue(res, i, i_memory_shared_quota);
+		memory_spill_ratio = PQgetvalue(res, i, i_memory_spill_ratio);
+
+		resetPQExpBuffer(buf);
+
+		/* DROP or CREATE default group, so ALTER it  */
+		if (0 == strcmp(groupname, "default_group") || 0 == strcmp(groupname, "admin_group"))
+		{
+			appendPQExpBuffer(buf, "ALTER RESOURCE GROUP %s SET concurrency %s;\n",
+							  groupname, concurrency);
+			appendPQExpBuffer(buf, "ALTER RESOURCE GROUP %s SET cpu_rate_limit %s;\n",
+							  groupname, cpu_rate_limit);
+			appendPQExpBuffer(buf, "ALTER RESOURCE GROUP %s SET memory_limit %s;\n",
+							  groupname, memory_limit);
+			appendPQExpBuffer(buf, "ALTER RESOURCE GROUP %s SET memory_shared_quota %s;\n",
+							  groupname, memory_shared_quota);
+			appendPQExpBuffer(buf, "ALTER RESOURCE GROUP %s SET memory_spill_ratio %s;\n",
+							  groupname, memory_spill_ratio);
+		}
+		else
+		{
+			printfPQExpBuffer(buf, "CREATE RESOURCE GROUP %s WITH ("
+							  "concurrency=%s, cpu_rate_limit=%s, "
+							  "memory_limit=%s, memory_shared_quota=%s, "
+							  "memory_spill_ratio=%s);",
+							  groupname, concurrency, cpu_rate_limit,
+							  memory_limit, memory_shared_quota,
+							  memory_spill_ratio);
+		}
+
+		fprintf(OPF, "%s", buf->data);
+	}
+
+	PQclear(res);
+
+	destroyPQExpBuffer(buf);
+
+	fprintf(OPF, "\n\n");
+}
 
 /*
  * Dump resource queues
@@ -693,12 +798,10 @@ dumpResQueues(PGconn *conn)
 		const char *rsqname;
 		const char *resname;
 		const char *ressetting;
-		Oid			rqoid;
 
 		rsqname = PQgetvalue(res, i, i_rsqname);
 		resname = PQgetvalue(res, i, i_resname);
 		ressetting = PQgetvalue(res, i, i_ressetting);
-		rqoid = atooid(PQgetvalue(res, i, i_rqoid));
 
 		/* if first CREATE statement, or name changed... */
 		if (!prev_rsqname || (0 != strcmp(rsqname, prev_rsqname)))
@@ -818,6 +921,7 @@ dumpRoles(PGconn *conn)
 				i_rolcomment,
 				i_oid,
 				i_rolqueuename = -1,	/* keep compiler quiet */
+				i_rolgroupname = -1,	/* keep compiler quiet */
 				i_rolcreaterextgpfd = -1,
 				i_rolcreaterexthttp = -1,
 				i_rolcreatewextgpfd = -1,
@@ -828,6 +932,8 @@ dumpRoles(PGconn *conn)
 	bool		hdfs_auth = (server_version >= 80215);
 	char	   *resq_col = resource_queues ? ", (SELECT rsqname FROM pg_resqueue WHERE "
 	"  pg_resqueue.oid = rolresqueue) AS rolqueuename " : "";
+	char	   *resgroup_col = resource_groups ? ", (SELECT rsgname FROM pg_resgroup WHERE "
+	"  pg_resgroup.oid = rolresgroup) AS rolgroupname " : "";
 	char	   *extauth_col = exttab_auth ? ", rolcreaterextgpfd, rolcreaterexthttp, rolcreatewextgpfd" : "";
 	char	   *hdfs_col = hdfs_auth ? ", rolcreaterexthdfs, rolcreatewexthdfs " : "";
 
@@ -843,10 +949,10 @@ dumpRoles(PGconn *conn)
 					  "rolcanlogin, rolconnlimit, rolpassword, "
 					  "rolvaliduntil, "
 					  "pg_catalog.shobj_description(oid, 'pg_authid') as rolcomment "
-					  " %s %s %s"
+					  " %s %s %s %s"
 					  "FROM pg_authid "
 					  "ORDER BY 1",
-					  resq_col, extauth_col, hdfs_col);
+					  resq_col, resgroup_col, extauth_col, hdfs_col);
 
 	res = executeQuery(conn, buf->data);
 
@@ -865,6 +971,9 @@ dumpRoles(PGconn *conn)
 
 	if (resource_queues)
 		i_rolqueuename = PQfnumber(res, "rolqueuename");
+
+	if (resource_groups)
+		i_rolgroupname = PQfnumber(res, "rolgroupname");
 
 	if (exttab_auth)
 	{
@@ -947,6 +1056,13 @@ dumpRoles(PGconn *conn)
 			if (!PQgetisnull(res, i, i_rolqueuename))
 				appendPQExpBuffer(buf, " RESOURCE QUEUE %s",
 								  PQgetvalue(res, i, i_rolqueuename));
+		}
+
+		if (resource_groups)
+		{
+			if (!PQgetisnull(res, i, i_rolgroupname))
+				appendPQExpBuffer(buf, " RESOURCE GROUP %s",
+								  PQgetvalue(res, i, i_rolgroupname));
 		}
 
 		if (exttab_auth)

--- a/src/bin/pg_dump/pg_dumpall.c
+++ b/src/bin/pg_dump/pg_dumpall.c
@@ -639,7 +639,7 @@ dumpResGroups(PGconn *conn)
 
 	printfPQExpBuffer(buf, "SELECT g.rsgname AS groupname, "
 					  "t1.proposed AS concurrency, "
-					  "t2.value AS cpu_rate_limit, "
+					  "t2.proposed AS cpu_rate_limit, "
 					  "t3.proposed AS memory_limit, "
 					  "t4.proposed AS memory_shared_quota, "
 					  "t5.proposed AS memory_spill_ratio "

--- a/src/test/regress/expected/resource_group.out
+++ b/src/test/regress/expected/resource_group.out
@@ -1,0 +1,23 @@
+--
+-- Test: create objects for pg_dumpall/pg_upgrade
+--
+-- this test creates resource group objects and roles associated with
+-- resource groups so pg_dumpall/pg_upgrade can dump those objects at
+-- the end of ICW.
+-- 
+-- NOTE: please always put this test in the end of this file and do not
+-- drop them.
+-- start_ignore
+DROP ROLE IF EXISTS role_dump_test1;
+DROP ROLE IF EXISTS role_dump_test2;
+DROP ROLE IF EXISTS role_dump_test3;
+DROP RESOURCE GROUP rg_dump_test1;
+DROP RESOURCE GROUP rg_dump_test2;
+DROP RESOURCE GROUP rg_dump_test3;
+-- end_ignore
+CREATE RESOURCE GROUP rg_dump_test1 WITH (concurrency=2, cpu_rate_limit=5, memory_limit=5);
+CREATE RESOURCE GROUP rg_dump_test2 WITH (concurrency=2, cpu_rate_limit=5, memory_limit=5);
+CREATE RESOURCE GROUP rg_dump_test3 WITH (concurrency=2, cpu_rate_limit=5, memory_limit=5);
+CREATE ROLE role_dump_test1 RESOURCE GROUP rg_dump_test1;
+CREATE ROLE role_dump_test2 RESOURCE GROUP rg_dump_test2;
+CREATE ROLE role_dump_test3 RESOURCE GROUP rg_dump_test3;

--- a/src/test/regress/sql/resource_group.sql
+++ b/src/test/regress/sql/resource_group.sql
@@ -1,0 +1,27 @@
+--
+-- Test: create objects for pg_dumpall/pg_upgrade
+--
+-- this test creates resource group objects and roles associated with
+-- resource groups so pg_dumpall/pg_upgrade can dump those objects at
+-- the end of ICW.
+-- 
+-- NOTE: please always put this test in the end of this file and do not
+-- drop them.
+
+-- start_ignore
+DROP ROLE IF EXISTS role_dump_test1;
+DROP ROLE IF EXISTS role_dump_test2;
+DROP ROLE IF EXISTS role_dump_test3;
+
+DROP RESOURCE GROUP rg_dump_test1;
+DROP RESOURCE GROUP rg_dump_test2;
+DROP RESOURCE GROUP rg_dump_test3;
+-- end_ignore
+
+CREATE RESOURCE GROUP rg_dump_test1 WITH (concurrency=2, cpu_rate_limit=5, memory_limit=5);
+CREATE RESOURCE GROUP rg_dump_test2 WITH (concurrency=2, cpu_rate_limit=5, memory_limit=5);
+CREATE RESOURCE GROUP rg_dump_test3 WITH (concurrency=2, cpu_rate_limit=5, memory_limit=5);
+
+CREATE ROLE role_dump_test1 RESOURCE GROUP rg_dump_test1;
+CREATE ROLE role_dump_test2 RESOURCE GROUP rg_dump_test2;
+CREATE ROLE role_dump_test3 RESOURCE GROUP rg_dump_test3;


### PR DESCRIPTION
This commit adds support for resource group in pg_dumpall to dump
created resource groups and the mapping info between the resource group
and roles.