### PR TITLE
docs - remove max_resource_groups guc

### DIFF
--- a/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
@@ -238,6 +238,7 @@ gpstart
     <title id="iz139857">Creating Resource Groups</title>
     <body>
       <p>When you create a resource group, you provide a name, CPU limit, and memory limit. You can optionally provide a concurrent transaction limit and memory shared quota and spill ratio.  Use the <codeph><xref href="../ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml#topic1" type="topic" format="dita"/></codeph> command to create a new resource group. </p>
+      <p> You must have <codeph>SUPERUSER</codeph> privileges to create a resource group. The maximum number of resource groups allowed in your Greenplum Database cluster is 100.</p>
       <p id="iz152723">When you create a resource group, you must provide <codeph>CPU_RATE_LIMIT</codeph> and <codeph>MEMORY_LIMIT</codeph> limit values.
           These limits identify the percentage of Greenplum Database resources
           to allocate to this resource group. For example, to create a resource group named

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -631,9 +631,6 @@
               <xref href="#max_resource_portals_per_transaction"/>
             </li>
             <li>
-              <xref href="#max_resource_groups"/>
-            </li>
-            <li>
               <xref href="#max_resource_queues"/>
             </li>
             <li>
@@ -7219,44 +7216,13 @@
       </table>
     </body>
   </topic>
-  <topic id="max_resource_groups">
-    <title>max_resource_groups</title>
-    <body>
-      <note type="warning">Resource groups are an experimental feature and
-        are not intended for use in a production environment. Experimental features are subject to
-        change without notice in future releases.</note>
-      <p>Sets the maximum number of resource groups that you can create in a Greenplum Database
-        system. Resource groups are defined system-wide.</p>
-      <table id="max_resource_queues_table">
-        <tgroup cols="3">
-          <colspec colnum="1" colname="col1" colwidth="1*"/>
-          <colspec colnum="2" colname="col2" colwidth="1*"/>
-          <colspec colnum="3" colname="col3" colwidth="1*"/>
-          <thead>
-            <row>
-              <entry colname="col1">Value Range</entry>
-              <entry colname="col2">Default</entry>
-              <entry colname="col3">Set Classifications</entry>
-            </row>
-          </thead>
-          <tbody>
-            <row>
-              <entry colname="col1">0 - INT_MAX</entry>
-              <entry colname="col2">9</entry>
-              <entry colname="col3">master<p>system</p><p>restart</p></entry>
-            </row>
-          </tbody>
-        </tgroup>
-      </table>
-    </body>
-  </topic>
   <topic id="max_resource_queues">
     <title>max_resource_queues</title>
     <body>
       <p>Sets the maximum number of resource queues that can be created in a Greenplum Database
         system. Note that resource queues are system-wide (as are roles) so they apply to all
         databases in the system.</p>
-      <table id="max_resource_groups_table">
+      <table id="max_resource_queues_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>
           <colspec colnum="2" colname="col2" colwidth="1*"/>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -1215,10 +1215,6 @@
                 >gp_resource_manager</xref>
             </p>
             <p>
-              <xref href="guc-list.xml#max_resource_groups" type="section"
-                >max_resource_groups</xref>
-            </p>
-            <p>
               <xref href="guc-list.xml#memory_spill_ratio" type="section"
                 >memory_spill_ratio</xref>
             </p>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml
@@ -20,15 +20,15 @@ MEMORY_LIMIT=<varname>integer</varname>
       <title>Description</title>
       <p>Creates a new resource group for Greenplum Database resource management. A resource
          group is assigned to one or more roles and identifies concurrent transaction, memory,
-         and CPU limits for the role when resource groups are enabled. Only a superuser can create a resource group.</p>
+         and CPU limits for the role when resource groups are enabled.</p>
+      <p>You must have <codeph>SUPERUSER</codeph> privileges to create a resource group. The maximum number of resource groups allowed in your Greenplum Database cluster is 100.</p>
       <p>Greenplum Database pre-defines two default resource groups: <codeph>admin_group</codeph>
          and <codeph>default_group</codeph>. These group names are reserved.</p>
-      <p>The <codeph>max_resource_groups</codeph> server configuration parameter governs the maximum number of resource groups you can create.</p>
       <p>
         To set appropriate limits for resource groups, the Greenplum Database administrator must
         be familiar with the queries typically executed on the system, as well as the users/roles executing those queries.</p>
       <p>
-        After defining a resource group, assign the group to one or more roles using the <codeph><xref
+        After creating a resource group, assign the group to one or more roles using the <codeph><xref
             href="ALTER_ROLE.xml#topic1" type="topic" format="dita"/></codeph> or <codeph><xref
             href="./CREATE_ROLE.xml#topic1" type="topic" format="dita"/></codeph> commands.</p>
     </section>


### PR DESCRIPTION
docs changes for removal of max_resource_groups GUC:
- remove references from server config parameter categories and GUC list
- remove references from CREATE RESOURCE GROUPS page, add SUPERUSER requirement and 100 hard limit
- "using resource groups" admin guide page, "creating resource groups" section - add SUPERUSER requirement and 100 hard limit

links to doc review staging site:
- http://docs-gpdb-review-staging.cfapps.io/500/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.html
- http://docs-gpdb-review-staging.cfapps.io/500/admin_guide/workload_mgmt_resgroups.html#topic10