### PR TITLE
Migrate DDBoost backup/restore tests to terraform in 5X_STABLE branch

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -47,7 +47,9 @@ groups:
   - gpdb_rc_packaging_centos
   - gpdb_rc_packaging_sles
   - DPM_netbackup77
-  - DPM_backup-restore-ddboost
+  - DPM_backup-restore_ddboost_part1
+  - DPM_backup-restore_ddboost_part2
+  - DPM_backup-restore_ddboost_part3
   - DPM_backup_43_restore_5
   - MM_gpcheckcat
   - MM_gprecoverseg
@@ -68,7 +70,6 @@ groups:
 - name: Remaining Pulse
   jobs:
   - DPM_netbackup77
-  - DPM_backup-restore-ddboost
   - MM_gpcheckcat
   - MM_gpexpand
   - DPM_gptransfer-43x-to-5x
@@ -99,6 +100,9 @@ groups:
   - MM_gppkg
   - MM_gprecoverseg
   - DPM_backup_43_restore_5
+  - DPM_backup-restore_ddboost_part1
+  - DPM_backup-restore_ddboost_part2
+  - DPM_backup-restore_ddboost_part3
 
 ## ======================================================================
 ## resource types
@@ -149,6 +153,21 @@ resources:
       #     bucket_path: dev/[Team Name]/                       #
       #                                                         #
       ###########################################################
+      bucket_path: {{tf-bucket-path}}
+
+- name: terraform_gpdb4
+  type: terraform
+  source:
+    env:
+      AWS_ACCESS_KEY_ID: {{gpdb4-tf-machine-access-key-id}}
+      AWS_SECRET_ACCESS_KEY: {{gpdb4-tf-machine-secret-access-key}}
+    storage:
+      access_key_id: {{gpdb4-tf-machine-access-key-id}}
+      secret_access_key: {{gpdb4-tf-machine-secret-access-key}}
+      region_name: {{aws-region}}
+      # This is not parameterized, on purpose. All tfstates will go to this spot,
+      # and different teams will place there clusters' tfstate files under different paths
+      bucket: pivotal-pa-toolsmiths-pipeline-dynamic-terraform
       bucket_path: {{tf-bucket-path}}
 
 - name: aix_environments
@@ -543,12 +562,30 @@ ccp_destroy_anchor: &ccp_destroy
   get_params:
     action: destroy
 
+ccp_destroy_anchor_gpdb4: &ccp_destroy_gpdb4
+  put: terraform_gpdb4
+  params:
+    action: destroy
+    env_name_file: terraform_gpdb4/name
+    terraform_source: ccp_src/aws-pivotal-pa-toolsmiths/
+    vars:
+      aws_instance-node-instance_type: t2.micro #t2.micro is ignored in destroy, but aws_instance-node-instance_type is required.
+  get_params:
+    action: destroy
+
 ccp_gen_cluster_default_params_anchor: &ccp_gen_cluster_default_params
   AWS_ACCESS_KEY_ID: {{tf-machine-access-key-id}}
   AWS_SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
   AWS_DEFAULT_REGION: {{aws-region}}
   BUCKET_PATH: {{tf-bucket-path}}
   BUCKET_NAME: {{tf-bucket-name}}
+
+ccp_gpdb4_gen_cluster_default_params_anchor: &ccp_gpdb4_gen_cluster_default_params
+  AWS_ACCESS_KEY_ID: {{gpdb4-tf-machine-access-key-id}}
+  AWS_SECRET_ACCESS_KEY: {{gpdb4-tf-machine-secret-access-key}}
+  AWS_DEFAULT_REGION: {{aws-region}}
+  BUCKET_PATH: {{tf-bucket-path}}
+  BUCKET_NAME: pivotal-pa-toolsmiths-pipeline-dynamic-terraform
 
 debug_sleep_anchor: &debug_sleep
   do:
@@ -566,6 +603,21 @@ debug_sleep_anchor: &debug_sleep
     ensure:
       <<: *ccp_destroy
 
+debug_sleep_anchor_gpdb4: &debug_sleep_gpdb4
+  do:
+  - task: debug_sleep
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: alpine
+          tag: latest
+      run:
+        path: 'sh'
+        args: ['-c', 'sleep 6h']
+    ensure:
+      <<: *ccp_destroy_gpdb4
 ## ======================================================================
 ## jobs
 ## ======================================================================
@@ -1095,36 +1147,11 @@ jobs:
       vars:
         <<: *ccp_default_vars
   - task: setup_gpdb4
+    file: ccp_src/ci/tasks/gen_cluster.yml
     params:
       <<: *ccp_gen_cluster_default_params
-      platform: centos6
-    config:
-      platform: linux
-      image_resource:
-        type: docker-image
-        source:
-          repository: centos
-          tag: "7"
-      inputs:
-      - name: terraform
-      - name: gpdb4_binary
-      - name: ccp_src
-      - name: gpdb_src
-      outputs:
-      - name: cluster_env_files
-      run:
-        path: bash
-        args:
-        - -c
-        - |
-          set -ex
-          ccp_src/aws/setup_software.sh
-          ccp_src/aws/download_tf_state.sh
-          ccp_src/aws/generate_env_files.sh 2 || exit 1
-          ccp_src/aws/generate_ssh_files.sh 2 || exit 1
-          ccp_src/aws/preinstall_gpdb.sh 2 || exit 1
-          ccp_src/aws/install_gpdb.sh 2 gpdb4_binary
-          ccp_src/aws/run_inspec.sh 2
+    input_mapping:
+      gpdb_binary: gpdb4_binary
     on_failure:
       <<: *ccp_destroy
   - task: run_backup_tests
@@ -1135,35 +1162,10 @@ jobs:
     on_failure:
       <<: *debug_sleep
   - task: setup_gpdb5
+    file: gpdb_src/concourse/tasks/setup_new_gpdb_for_backup_restore.yml
     params:
       <<: *ccp_gen_cluster_default_params
-      platform: centos6
-    config:
-      platform: linux
-      image_resource:
-        type: docker-image
-        source:
-          repository: centos
-          tag: "7"
-      inputs:
-      - name: terraform
-      - name: gpdb_binary
-      - name: ccp_src
-      - name: gpdb_src
-      - name: cluster_env_files
-      run:
-        path: bash
-        args:
-        - -c
-        - |
-          set -ex
-          ccp_src/aws/setup_software.sh
-          ccp_src/aws/setup_ssh_to_cluster.sh
-          scp cluster_env_files/hostfile_all mdw:/home/gpadmin/hostfile_all
-          ssh -t mdw "source /home/gpadmin/gpdb_src/concourse/scripts/backup_utils.sh; copy_backup_files"
-          ssh -t mdw "source /home/gpadmin/gpdb_src/concourse/scripts/backup_utils.sh; destroy_gpdb"
-          ccp_src/aws/install_gpdb.sh 2 gpdb_binary
-          ssh -t mdw "source /home/gpadmin/gpdb_src/concourse/scripts/backup_utils.sh; restore_backup_files"
+    image: centos-gpdb-dev-6
     on_failure:
       <<: *debug_sleep
   - task: run_restore_tests
@@ -2068,25 +2070,137 @@ jobs:
     file: gpdb_src/ci/pulse/api/monitor_pulse.yml
     params: *pulse_properties
 
-- name: DPM_backup-restore-ddboost
+- name: DPM_backup-restore_ddboost_part1
   plan:
   - get: nightly-trigger
     trigger: true
-  - aggregate: *post_packaging_gets_trigger_false
-  - task: trigger_pulse
-    tags: ["gpdb5-pulse-worker"]
-    file: gpdb_src/ci/pulse/api/trigger_pulse.yml
-    input_mapping: *input_mappings
+  - aggregate:
+    - get: ccp_src
+      tags: ["gpdb4_ccp_external_worker_in_gpdb5"]
+    - get: gpdb_src
+      tags: ["gpdb4_ccp_external_worker_in_gpdb5"]
+      passed: [compile_gpdb_centos6]
+    - get: gpdb_binary
+      tags: ["gpdb4_ccp_external_worker_in_gpdb5"]
+      resource: bin_gpdb_centos6
+      passed: [compile_gpdb_centos6]
+    - get: centos-gpdb-dev-6
+      tags: ["gpdb4_ccp_external_worker_in_gpdb5"]
+  - put: terraform_gpdb4
     params:
-      <<: *pulse_properties
-      PULSE_PROJECT_NAME: "GPDB-BehaveBackupRestore_HarmonizeDDBoost"
-  - task: monitor_pulse
-    attempts: 2
-    tags: ["gpdb5-pulse-worker"]
-    file: gpdb_src/ci/pulse/api/monitor_pulse.yml
+      <<: *ccp_default_params
+      terraform_source: ccp_src/aws-pivotal-pa-toolsmiths/
+      vars:
+        <<: *ccp_default_vars
+    tags: ["gpdb4_ccp_external_worker_in_gpdb5"]
+  - task: gen_cluster
+    input_mapping:
+      terraform: terraform_gpdb4
+    tags: ["gpdb4_ccp_external_worker_in_gpdb5"]
+    file: ccp_src/ci/tasks/gen_cluster.yml
     params:
-      <<: *pulse_properties
-      PULSE_PROJECT_NAME: "GPDB-BehaveBackupRestore_HarmonizeDDBoost"
+      <<: *ccp_gpdb4_gen_cluster_default_params
+    on_failure:
+      <<: *ccp_destroy_gpdb4
+  - task: run_tests
+    tags: ["gpdb4_ccp_external_worker_in_gpdb5"]
+    file: gpdb_src/concourse/tasks/run_behave.yml
+    image: centos-gpdb-dev-6
+    params:
+      BEHAVE_FLAGS: --tags=ddboostsetup,ddpartI
+      CUSTOM_ENV: export DD_SOURCE_HOST={{datadomain_source_host}}; export DD_DEST_HOST={{datadomain_dest_host}}; export DD_USER={{datadomain_user}}; export DD_PASSWORD={{datadomain_password}};
+      PRE_TEST_SCRIPT: "source /home/gpadmin/gpdb_src/concourse/scripts/backup_utils.sh; setup_ddboost"
+    on_failure:
+      <<: *debug_sleep_gpdb4
+  - *ccp_destroy_gpdb4
+
+- name: DPM_backup-restore_ddboost_part2
+  plan:
+  - get: nightly-trigger
+    trigger: true
+  - aggregate:
+    - get: ccp_src
+      tags: ["gpdb4_ccp_external_worker_in_gpdb5"]
+    - get: gpdb_src
+      tags: ["gpdb4_ccp_external_worker_in_gpdb5"]
+      passed: [compile_gpdb_centos6]
+    - get: gpdb_binary
+      tags: ["gpdb4_ccp_external_worker_in_gpdb5"]
+      resource: bin_gpdb_centos6
+      passed: [compile_gpdb_centos6]
+    - get: centos-gpdb-dev-6
+      tags: ["gpdb4_ccp_external_worker_in_gpdb5"]
+  - put: terraform_gpdb4
+    params:
+      <<: *ccp_default_params
+      terraform_source: ccp_src/aws-pivotal-pa-toolsmiths/
+      vars:
+        <<: *ccp_default_vars
+    tags: ["gpdb4_ccp_external_worker_in_gpdb5"]
+  - task: gen_cluster
+    input_mapping:
+      terraform: terraform_gpdb4
+    tags: ["gpdb4_ccp_external_worker_in_gpdb5"]
+    file: ccp_src/ci/tasks/gen_cluster.yml
+    params:
+      <<: *ccp_gpdb4_gen_cluster_default_params
+    on_failure:
+      <<: *ccp_destroy_gpdb4
+  - task: run_tests
+    tags: ["gpdb4_ccp_external_worker_in_gpdb5"]
+    file: gpdb_src/concourse/tasks/run_behave.yml
+    image: centos-gpdb-dev-6
+    params:
+      BEHAVE_FLAGS: --tags=ddboostsetup,ddpartII
+      CUSTOM_ENV: export DD_SOURCE_HOST={{datadomain_source_host}}; export DD_DEST_HOST={{datadomain_dest_host}}; export DD_USER={{datadomain_user}}; export DD_PASSWORD={{datadomain_password}};
+      PRE_TEST_SCRIPT: "source /home/gpadmin/gpdb_src/concourse/scripts/backup_utils.sh; setup_ddboost"
+    on_failure:
+      <<: *debug_sleep_gpdb4
+  - *ccp_destroy_gpdb4
+
+- name: DPM_backup-restore_ddboost_part3
+  plan:
+  - get: nightly-trigger
+    trigger: true
+  - aggregate:
+    - get: ccp_src
+      tags: ["gpdb4_ccp_external_worker_in_gpdb5"]
+    - get: gpdb_src
+      tags: ["gpdb4_ccp_external_worker_in_gpdb5"]
+      passed: [compile_gpdb_centos6]
+    - get: gpdb_binary
+      tags: ["gpdb4_ccp_external_worker_in_gpdb5"]
+      resource: bin_gpdb_centos6
+      passed: [compile_gpdb_centos6]
+    - get: centos-gpdb-dev-6
+      tags: ["gpdb4_ccp_external_worker_in_gpdb5"]
+  - put: terraform_gpdb4
+    params:
+      <<: *ccp_default_params
+      terraform_source: ccp_src/aws-pivotal-pa-toolsmiths/
+      vars:
+        <<: *ccp_default_vars
+    tags: ["gpdb4_ccp_external_worker_in_gpdb5"]
+  - task: gen_cluster
+    input_mapping:
+      terraform: terraform_gpdb4
+    tags: ["gpdb4_ccp_external_worker_in_gpdb5"]
+    file: ccp_src/ci/tasks/gen_cluster.yml
+    params:
+      <<: *ccp_gpdb4_gen_cluster_default_params
+    on_failure:
+      <<: *ccp_destroy_gpdb4
+  - task: run_tests
+    tags: ["gpdb4_ccp_external_worker_in_gpdb5"]
+    file: gpdb_src/concourse/tasks/run_behave.yml
+    image: centos-gpdb-dev-6
+    params:
+      BEHAVE_FLAGS: --tags=ddboostsetup,ddpartIII
+      CUSTOM_ENV: export DD_SOURCE_HOST={{datadomain_source_host}}; export DD_DEST_HOST={{datadomain_dest_host}}; export DD_USER={{datadomain_user}}; export DD_PASSWORD={{datadomain_password}};
+      PRE_TEST_SCRIPT: "source /home/gpadmin/gpdb_src/concourse/scripts/backup_utils.sh; setup_ddboost"
+    on_failure:
+      <<: *debug_sleep_gpdb4
+  - *ccp_destroy_gpdb4
 
 - name: MM_gpcheckcat
   plan:
@@ -2396,7 +2510,9 @@ jobs:
     - gpdb_rc_packaging_centos
     - gpdb_rc_packaging_sles
     - DPM_netbackup77
-    - DPM_backup-restore-ddboost
+    - DPM_backup-restore_ddboost_part1
+    - DPM_backup-restore_ddboost_part2
+    - DPM_backup-restore_ddboost_part3
     - DPM_backup_43_restore_5
     - MM_gpcheckcat
     - MM_gprecoverseg

--- a/concourse/scripts/backup_utils.sh
+++ b/concourse/scripts/backup_utils.sh
@@ -25,3 +25,13 @@ destroy_gpdb() {
     yes|gpdeletesystem -f -d $MASTER_DATA_DIRECTORY
     rm -rf $GPHOME/*
 }
+
+setup_ddboost() {
+    ssh centos@mdw "sudo rpm -ivh https://discuss.pivotal.io/hc/en-us/article_attachments/201458518/compat-libstdc__-33-3.2.3-69.el6.x86_64.rpm"
+    ssh centos@mdw "echo \"$DD_SOURCE_HOST source-dd\" | sudo tee -a /etc/hosts"
+    ssh centos@mdw "echo \"$DD_DEST_HOST dest-dd\" | sudo tee -a /etc/hosts"
+
+    ssh centos@sdw1 "sudo rpm -ivh https://discuss.pivotal.io/hc/en-us/article_attachments/201458518/compat-libstdc__-33-3.2.3-69.el6.x86_64.rpm"
+    ssh centos@sdw1 "echo \"$DD_SOURCE_HOST source-dd\" | sudo tee -a /etc/hosts"
+    ssh centos@sdw1 "echo \"$DD_DEST_HOST dest-dd\" | sudo tee -a /etc/hosts"
+}

--- a/concourse/tasks/run_behave.yml
+++ b/concourse/tasks/run_behave.yml
@@ -9,5 +9,9 @@ run:
   - |
     set -ex
     ccp_src/aws/setup_ssh_to_cluster.sh
+    scp cluster_env_files/terraform/name mdw:/tmp/terraform_name
     ssh centos@mdw "sudo bash -c \"yum install -y valgrind mailx\""
-    ssh -t mdw "bash /home/gpadmin/gpdb_src/concourse/scripts/run_behave_test.sh \"$BEHAVE_FLAGS\""
+    if [ -n "$PRE_TEST_SCRIPT" ]; then
+        ssh -t mdw "$CUSTOM_ENV $PRE_TEST_SCRIPT"
+    fi
+    ssh -t mdw "$CUSTOM_ENV bash /home/gpadmin/gpdb_src/concourse/scripts/run_behave_test.sh \"$BEHAVE_FLAGS\""

--- a/concourse/tasks/setup_new_gpdb_for_backup_restore.yml
+++ b/concourse/tasks/setup_new_gpdb_for_backup_restore.yml
@@ -1,0 +1,26 @@
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: centos
+    tag: "7"
+inputs:
+- name: terraform
+- name: gpdb_binary
+- name: ccp_src
+- name: gpdb_src
+- name: cluster_env_files
+run:
+  path: bash
+  args:
+  - -c
+  - |
+    set -ex
+    ccp_src/aws/setup_software.sh
+    ccp_src/aws/setup_ssh_to_cluster.sh
+    scp cluster_env_files/hostfile_all mdw:/home/gpadmin/hostfile_all
+    ssh -t mdw "source /home/gpadmin/gpdb_src/concourse/scripts/backup_utils.sh; copy_backup_files"
+    ssh -t mdw "source /home/gpadmin/gpdb_src/concourse/scripts/backup_utils.sh; destroy_gpdb"
+    ccp_src/aws/install_gpdb.sh 2 gpdb_binary || exit 1
+    ssh -t mdw "source /home/gpadmin/gpdb_src/concourse/scripts/backup_utils.sh; restore_backup_files"
+

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -5074,9 +5074,9 @@ def ddboost_config_setup(context, storage_unit=None):
 
     cmd_config
     local = pexpect.spawn(cmd_config)
-    local.expect('Password: ')
+    local.expect('Password: ', timeout=60)
     local.sendline(context._root['local_ddboost_password'])
-    local.expect(pexpect.EOF)
+    local.expect(pexpect.EOF, timeout=60)
     local.close()
 
     cmd_config = "gpcrondump --ddboost-host %s --ddboost-user %s --ddboost-backupdir %s --ddboost-remote" % \
@@ -5089,9 +5089,9 @@ def ddboost_config_setup(context, storage_unit=None):
 
     cmd_config
     local = pexpect.spawn(cmd_config)
-    local.expect('Password: ')
+    local.expect('Password: ', timeout=60)
     local.sendline(context._root['remote_ddboost_password'])
-    local.expect(pexpect.EOF)
+    local.expect(pexpect.EOF, timeout=60)
     local.close()
 
 def _copy_nbu_lib_files(context, ver, gphome):
@@ -5142,16 +5142,15 @@ def impl(context, ver):
 @given('the test suite is initialized for DDBoost')
 def impl(context):
     os.environ["DDBOOST"] = "TRUE"
-    DDBOOSTDICT = defaultdict(dict)
-    DDBOOSTDICT['DDBOOSTINFO'] = parse_config_params()
-    context._root['local_ddboost_host'] = DDBOOSTDICT['DDBOOSTINFO']['DDBOOST_HOST_1']
-    context._root['local_ddboost_user'] = DDBOOSTDICT['DDBOOSTINFO']['DDBOOST_USER_1']
-    context._root['local_ddboost_password'] = DDBOOSTDICT['DDBOOSTINFO']['DDBOOST_PASSWORD_1']
-    context._root['remote_ddboost_host'] = DDBOOSTDICT['DDBOOSTINFO']['DDBOOST_HOST_2']
-    context._root['remote_ddboost_user'] = DDBOOSTDICT['DDBOOSTINFO']['DDBOOST_USER_2']
-    context._root['remote_ddboost_password'] = DDBOOSTDICT['DDBOOSTINFO']['DDBOOST_PASSWORD_2']
+    context._root['local_ddboost_host'] = os.environ["DD_SOURCE_HOST"]
+    context._root['local_ddboost_user'] = os.environ["DD_USER"]
+    context._root['local_ddboost_password'] = os.environ["DD_PASSWORD"]
+    context._root['remote_ddboost_host'] = os.environ["DD_DEST_HOST"]
+    context._root['remote_ddboost_user'] = os.environ["DD_USER"]
+    context._root['remote_ddboost_password'] = os.environ["DD_PASSWORD"]
     if 'ddboost_backupdir' not in context._root:
-        directory = os.getenv('PULSE_PROJECT', default='GPDB') + os.getenv('PULSE_BUILD_VERSION', default='') + os.getenv('PULSE_STAGE', default='') + '_DIR'
+        with open("/tmp/terraform_name", 'r') as tf_name_file:
+            directory = "GPDB-" + tf_name_file.readline() + "-DIR"
         context._root['ddboost_backupdir'] = directory
     ddboost_config_setup(context, storage_unit="GPDB")
 


### PR DESCRIPTION
This is for the 5X pipeline, as this involved a fair amount of changes compared to our changes in master. 

We copied a few of the anchors (create, destroy, sleep), as they referenced different paths in terraform source. Is there a better way to do this instead of copy/pasting these blocks?