### PR TITLE
Use TextDatumGetCString/CStringGetTextDatum to convert text/cstrings.

### DIFF
--- a/src/backend/access/appendonly/aosegfiles.c
+++ b/src/backend/access/appendonly/aosegfiles.c
@@ -1157,8 +1157,6 @@ gp_aoseg_history(PG_FUNCTION_ARGS)
 	SRF_RETURN_DONE(funcctx);
 }
 
-#define GET_STR(textp) DatumGetCString(DirectFunctionCall1(textout, PointerGetDatum(textp)))
-
 static Datum
 gp_update_aorow_master_stats_internal(Relation parentrel, Snapshot appendOnlyMetaDataSnapshot)
 {

--- a/src/backend/access/transam/gp_distributed_log.c
+++ b/src/backend/access/transam/gp_distributed_log.c
@@ -123,16 +123,12 @@ gp_distributed_log(PG_FUNCTION_ARGS)
 		
 		Assert(strlen(distribId) < TMGIDSIZE);
 
-		values[3] = 
-			DirectFunctionCall1(textin,
-				                CStringGetDatum(distribId));
+		values[3] = CStringGetTextDatum(distribId);
 
 		/*
 		 * For now, we only log committed distributed transactions.
 		 */
-		values[4] = 
-			DirectFunctionCall1(textin,
-				                CStringGetDatum("Committed"));
+		values[4] = CStringGetTextDatum("Committed");
 
 		values[5] = TransactionIdGetDatum(context->indexXid);
 

--- a/src/backend/access/transam/gp_transaction_log.c
+++ b/src/backend/access/transam/gp_transaction_log.c
@@ -121,11 +121,9 @@ gp_transaction_log(PG_FUNCTION_ARGS)
 		else
 			elog(ERROR, "Unexpected transaction status %d",
 			     status);
-		
-		values[3] = 
-			DirectFunctionCall1(textin,
-				                CStringGetDatum(statusStr));
-		
+
+		values[3] = CStringGetTextDatum(statusStr);
+
 		tuple = heap_form_tuple(funcctx->tuple_desc, values, nulls);
 		result = HeapTupleGetDatum(tuple);
 		SRF_RETURN_NEXT(funcctx, result);

--- a/src/backend/catalog/pg_exttable.c
+++ b/src/backend/catalog/pg_exttable.c
@@ -86,7 +86,7 @@ InsertExtTableEntry(Oid 	tbloid,
 		/* EXECUTE type table - store command and command location */
 
 		values[Anum_pg_exttable_command - 1] =
-		DirectFunctionCall1(textin, CStringGetDatum(commandString));
+			CStringGetTextDatum(commandString);
 		values[Anum_pg_exttable_execlocation - 1] = locationExec;
 		nulls[Anum_pg_exttable_urilocation - 1] = true;
 	}
@@ -158,7 +158,7 @@ InsertExtTableEntry(Oid 	tbloid,
 			char	   *protocol;
 			Size		position;
 
-			location = DatumGetCString(DirectFunctionCall1(textout, elems[i]));
+			location = TextDatumGetCString(elems[i]);
 			position = strchr(location, ':') - location;
 			protocol = pnstrdup(location, position);
 
@@ -355,7 +355,7 @@ GetExtTableEntryIfExists(Oid relid)
 
 		for (i = 0; i < nelems; i++)
 		{
-			loc_str = DatumGetCString(DirectFunctionCall1(textout, elems[i]));
+			loc_str = TextDatumGetCString(elems[i]);
 
 			/* append to a list of Value nodes, size nelems */
 			extentry->urilocations = lappend(extentry->urilocations, makeString(pstrdup(loc_str)));
@@ -372,7 +372,7 @@ GetExtTableEntryIfExists(Oid relid)
 
 		for (i = 0; i < nelems; i++)
 		{
-			loc_str = DatumGetCString(DirectFunctionCall1(textout, elems[i]));
+			loc_str = TextDatumGetCString(elems[i]);
 
 			/* append to a list of Value nodes, size nelems */
 			extentry->execlocations = lappend(extentry->execlocations, makeString(pstrdup(loc_str)));
@@ -397,9 +397,8 @@ GetExtTableEntryIfExists(Oid relid)
 	}
 	else
 	{
-		extentry->command = DatumGetCString(DirectFunctionCall1(textout, command));
+		extentry->command = TextDatumGetCString(command);
 	}
-	
 
 	/* get the format code */
 	fmtcode = heap_getattr(tuple, 
@@ -420,7 +419,7 @@ GetExtTableEntryIfExists(Oid relid)
 						   &isNull);
 	
 	Insist(!isNull);
-	extentry->fmtopts = DatumGetCString(DirectFunctionCall1(textout, fmtopts));
+	extentry->fmtopts = TextDatumGetCString(fmtopts);
 	
     /* get the external table options string */
     options = heap_getattr(tuple,
@@ -438,7 +437,7 @@ GetExtTableEntryIfExists(Oid relid)
 		Datum	   *elems;
 		int			nelems;
 		int			i;
-		char*		option_str = NULL;
+		char	   *option_str;
 
 		deconstruct_array(DatumGetArrayTypeP(options),
 						  TEXTOID, -1, false, 'i',
@@ -446,10 +445,10 @@ GetExtTableEntryIfExists(Oid relid)
 
 		for (i = 0; i < nelems; i++)
 		{
-			option_str = DatumGetCString(DirectFunctionCall1(textout, elems[i]));
+			option_str = TextDatumGetCString(elems[i]);
 
 			/* append to a list of Value nodes, size nelems */
-			extentry->options = lappend(extentry->options, makeString(pstrdup(option_str)));
+			extentry->options = lappend(extentry->options, makeString(option_str));
 		}
 	}
 

--- a/src/backend/cdb/cdbbackup.c
+++ b/src/backend/cdb/cdbbackup.c
@@ -33,9 +33,6 @@
 
 #define EXIT_CODE_BACKUP_RESTORE_ERROR 127
 
-/* general utility copied from cdblink.c */
-#define GET_STR(textp) DatumGetCString(DirectFunctionCall1(textout, PointerGetDatum(textp)))
-
 /* static helper functions */
 static bool createBackupDirectory(char *pszPathName);
 static char *findAcceptableBackupFilePathName(char *pszBackupDirectory, char *pszBackupKey, int instid, int segid);
@@ -198,22 +195,22 @@ gp_backup_launch__(PG_FUNCTION_ARGS)
 
 	if (!PG_ARGISNULL(0))
 	{
-		pszBackupDirectory = GET_STR(PG_GETARG_TEXT_P(0));
+		pszBackupDirectory = TextDatumGetCString(PG_GETARG_TEXT_P(0));
 		if (*pszBackupDirectory == '\0')
 			pszBackupDirectory = "./";
 	}
 
 	if (!PG_ARGISNULL(1))
-		pszBackupKey = GET_STR(PG_GETARG_TEXT_P(1));
+		pszBackupKey = TextDatumGetCString(PG_GETARG_TEXT_P(1));
 
 	if (!PG_ARGISNULL(2))
-		pszCompressionProgram = GET_STR(PG_GETARG_TEXT_P(2));
+		pszCompressionProgram = TextDatumGetCString(PG_GETARG_TEXT_P(2));
 
 	if (!PG_ARGISNULL(3))
-		pszPassThroughParameters = GET_STR(PG_GETARG_TEXT_P(3));
+		pszPassThroughParameters = TextDatumGetCString(PG_GETARG_TEXT_P(3));
 
 	if (!PG_ARGISNULL(4))
-		pszPassThroughCredentials = GET_STR(PG_GETARG_TEXT_P(4));
+		pszPassThroughCredentials = TextDatumGetCString(PG_GETARG_TEXT_P(4));
 
 	/*
 	 * dump_prefix must be allocated in TopMemoryContext, because it is
@@ -708,7 +705,7 @@ gp_backup_launch__(PG_FUNCTION_ARGS)
 
 	Assert(pszSaveBackupfileName != NULL && pszSaveBackupfileName[0] != '\0');
 
-	return DirectFunctionCall1(textin, CStringGetDatum(pszSaveBackupfileName));
+	return CStringGetTextDatum(pszSaveBackupfileName);
 }
 
 
@@ -762,25 +759,25 @@ gp_restore_launch__(PG_FUNCTION_ARGS)
 
 	if (!PG_ARGISNULL(0))
 	{
-		pszBackupDirectory = GET_STR(PG_GETARG_TEXT_P(0));
+		pszBackupDirectory = TextDatumGetCString(PG_GETARG_TEXT_P(0));
 		if (*pszBackupDirectory == '\0')
 			pszBackupDirectory = "./";
 	}
 
 	if (!PG_ARGISNULL(1))
-		pszBackupKey = GET_STR(PG_GETARG_TEXT_P(1));
+		pszBackupKey = TextDatumGetCString(PG_GETARG_TEXT_P(1));
 
 	if (!PG_ARGISNULL(2))
-		pszCompressionProgram = GET_STR(PG_GETARG_TEXT_P(2));
+		pszCompressionProgram = TextDatumGetCString(PG_GETARG_TEXT_P(2));
 
 	if (!PG_ARGISNULL(3))
-		pszPassThroughParameters = GET_STR(PG_GETARG_TEXT_P(3));
+		pszPassThroughParameters = TextDatumGetCString(PG_GETARG_TEXT_P(3));
 
 	if (!PG_ARGISNULL(4))
-		pszPassThroughCredentials = GET_STR(PG_GETARG_TEXT_P(4));
+		pszPassThroughCredentials = TextDatumGetCString(PG_GETARG_TEXT_P(4));
 
 	if (!PG_ARGISNULL(5))
-		pszPassThroughTargetInfo = GET_STR(PG_GETARG_TEXT_P(5));
+		pszPassThroughTargetInfo = TextDatumGetCString(PG_GETARG_TEXT_P(5));
 
 	if (!PG_ARGISNULL(6))
 		target_dbid = PG_GETARG_INT32(6);
@@ -1071,7 +1068,7 @@ gp_restore_launch__(PG_FUNCTION_ARGS)
 
 	Assert(pszBackupFileName != NULL && pszBackupFileName[0] != '\0');
 
-	return DirectFunctionCall1(textin, CStringGetDatum(pszBackupFileName));
+	return CStringGetTextDatum(pszBackupFileName);
 }
 
 /*
@@ -1093,13 +1090,13 @@ gp_read_backup_file__(PG_FUNCTION_ARGS)
 
 	if (!PG_ARGISNULL(0))
 	{
-		pszBackupDirectory = GET_STR(PG_GETARG_TEXT_P(0));
+		pszBackupDirectory = TextDatumGetCString(PG_GETARG_TEXT_P(0));
 		if (*pszBackupDirectory == '\0')
 			pszBackupDirectory = "./";
 	}
 
 	if (!PG_ARGISNULL(1))
-		pszBackupKey = GET_STR(PG_GETARG_TEXT_P(1));
+		pszBackupKey = TextDatumGetCString(PG_GETARG_TEXT_P(1));
 
 	if (!PG_ARGISNULL(2))
 		fileType = PG_GETARG_INT32(2);
@@ -1175,7 +1172,7 @@ gp_read_backup_file__(PG_FUNCTION_ARGS)
 	f = NULL;
 	pszFullStatus[info.st_size] = '\0';
 
-	return DirectFunctionCall1(textin, CStringGetDatum(positionToError(pszFullStatus)));
+	return CStringGetTextDatum(positionToError(pszFullStatus));
 }
 
 /*
@@ -1210,16 +1207,16 @@ gp_write_backup_file__(PG_FUNCTION_ARGS)
 
 	if (!PG_ARGISNULL(0))
 	{
-		pszBackupDirectory = GET_STR(PG_GETARG_TEXT_P(0));
+		pszBackupDirectory = TextDatumGetCString(PG_GETARG_TEXT_P(0));
 		if (*pszBackupDirectory == '\0')
 			pszBackupDirectory = "./";
 	}
 
 	if (!PG_ARGISNULL(1))
-		pszBackupKey = GET_STR(PG_GETARG_TEXT_P(1));
+		pszBackupKey = TextDatumGetCString(PG_GETARG_TEXT_P(1));
 
 	if (!PG_ARGISNULL(2))
-		pszBackup = GET_STR(PG_GETARG_TEXT_P(2));
+		pszBackup = TextDatumGetCString(PG_GETARG_TEXT_P(2));
 
 	/*
 	 * if BackupDirectory is relative, make it absolute based on the directory
@@ -1260,7 +1257,7 @@ gp_write_backup_file__(PG_FUNCTION_ARGS)
 
 	Assert(pszFileName != NULL && pszFileName[0] != '\0');
 
-	return DirectFunctionCall1(textin, CStringGetDatum(pszFileName));
+	return CStringGetTextDatum(pszFileName);
 }
 
 /*

--- a/src/backend/cdb/cdbdistributedxacts.c
+++ b/src/backend/cdb/cdbdistributedxacts.c
@@ -91,10 +91,8 @@ gp_distributed_xacts__(PG_FUNCTION_ARGS)
 		MemSet(nulls, false, sizeof(nulls));
 
 		values[0] = TransactionIdGetDatum(distributedXactStatus->gxid);
-		values[1] = DirectFunctionCall1(textin,
-					  CStringGetDatum(distributedXactStatus->gid));
-		values[2] = DirectFunctionCall1(textin,
-					  CStringGetDatum(DtxStateToString(distributedXactStatus->state)));
+		values[1] = CStringGetTextDatum(distributedXactStatus->gid);
+		values[2] = CStringGetTextDatum(DtxStateToString(distributedXactStatus->state));
 
 		values[3] = UInt32GetDatum(distributedXactStatus->sessionId);
 		values[4] = TransactionIdGetDatum(distributedXactStatus->xminDistributedSnapshot);

--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -1429,17 +1429,13 @@ add_partition_rule(PartitionRule *rule)
 							BoolGetDatum(rule->parrangeendincl);
 
 	values[Anum_pg_partition_rule_parrangestart - 1] =
-			DirectFunctionCall1(textin,
-						CStringGetDatum(nodeToString(rule->parrangestart)));
+		CStringGetTextDatum(nodeToString(rule->parrangestart));
 	values[Anum_pg_partition_rule_parrangeend - 1] =
-			DirectFunctionCall1(textin,
-						CStringGetDatum(nodeToString(rule->parrangeend)));
+			CStringGetTextDatum(nodeToString(rule->parrangeend));
 	values[Anum_pg_partition_rule_parrangeevery - 1] =
-			DirectFunctionCall1(textin,
-						CStringGetDatum(nodeToString(rule->parrangeevery)));
+			CStringGetTextDatum(nodeToString(rule->parrangeevery));
 	values[Anum_pg_partition_rule_parlistvalues - 1] =
-			DirectFunctionCall1(textin,
-						CStringGetDatum(nodeToString(rule->parlistvalues)));
+			CStringGetTextDatum(nodeToString(rule->parlistvalues));
 	if (rule->parreloptions)
 		values[Anum_pg_partition_rule_parreloptions - 1] =
 				transformRelOptions((Datum) 0, rule->parreloptions, true, false);
@@ -2007,7 +2003,6 @@ ruleMakePartitionRule(HeapTuple tuple)
 {
 	Form_pg_partition_rule rule_desc =
 	(Form_pg_partition_rule)GETSTRUCT(tuple);
-	text *rule_text;
 	char *rule_str;
 	Datum rule_datum;
 	bool isnull;
@@ -2032,9 +2027,7 @@ ruleMakePartitionRule(HeapTuple tuple)
 								 Anum_pg_partition_rule_parrangestart,
 								 &isnull);
 	Assert(!isnull);
-	rule_text = DatumGetTextP(rule_datum);
-	rule_str = DatumGetCString(DirectFunctionCall1(textout,
-												   PointerGetDatum(rule_text)));
+	rule_str = TextDatumGetCString(rule_datum);
 
 	rule->parrangestart = stringToNode(rule_str);
 
@@ -2045,9 +2038,7 @@ ruleMakePartitionRule(HeapTuple tuple)
 								 Anum_pg_partition_rule_parrangeend,
 								 &isnull);
 	Assert(!isnull);
-	rule_text = DatumGetTextP(rule_datum);
-	rule_str = DatumGetCString(DirectFunctionCall1(textout,
-												   PointerGetDatum(rule_text)));
+	rule_str = TextDatumGetCString(rule_datum);
 
 	rule->parrangeend = stringToNode(rule_str);
 
@@ -2058,9 +2049,7 @@ ruleMakePartitionRule(HeapTuple tuple)
 								 Anum_pg_partition_rule_parrangeevery,
 								 &isnull);
 	Assert(!isnull);
-	rule_text = DatumGetTextP(rule_datum);
-	rule_str = DatumGetCString(DirectFunctionCall1(textout,
-												   PointerGetDatum(rule_text)));
+	rule_str = TextDatumGetCString(rule_datum);
 
 	rule->parrangeevery = stringToNode(rule_str);
 
@@ -2069,9 +2058,7 @@ ruleMakePartitionRule(HeapTuple tuple)
 								 Anum_pg_partition_rule_parlistvalues,
 								 &isnull);
 	Assert(!isnull);
-	rule_text = DatumGetTextP(rule_datum);
-	rule_str = DatumGetCString(DirectFunctionCall1(textout,
-												   PointerGetDatum(rule_text)));
+	rule_str = TextDatumGetCString(rule_datum);
 
 	rule->parlistvalues = stringToNode(rule_str);
 
@@ -2104,9 +2091,9 @@ ruleMakePartitionRule(HeapTuple tuple)
 		/* key/value pairs for storage clause */
 		for (i = 0; i < noptions; i++)
 		{
-			char *n = DatumGetCString(DirectFunctionCall1(textout, options[i]));
-			Value *v = NULL;
-			char *s;
+			char	   *n = TextDatumGetCString(options[i]);
+			Value	   *v = NULL;
+			char	   *s;
 
 			s = strchr(n, '=');
 
@@ -8377,7 +8364,7 @@ constraint_apply_mapped(HeapTuple tuple, AttrMap *map, Relation cand,
 					   RelationGetDescr(pgcon), &isnull);
 	if ( !isnull )
 	{
-		conbin = DatumGetCString(DirectFunctionCall1(textout, val));
+		conbin = TextDatumGetCString(val);
 		conexpr = stringToNode(conbin);
 		conexpr = attrMapExpr(map, conexpr);
 		conbin = nodeToString(conexpr);
@@ -8394,7 +8381,7 @@ constraint_apply_mapped(HeapTuple tuple, AttrMap *map, Relation cand,
 					   RelationGetDescr(pgcon), &isnull);
 	if (!isnull)
 	{
-		consrc = DatumGetCString(DirectFunctionCall1(textout, val));
+		consrc = TextDatumGetCString(val);
 	}
 	else
 	{

--- a/src/backend/cdb/cdbsreh.c
+++ b/src/backend/cdb/cdbsreh.c
@@ -241,7 +241,7 @@ FormErrorTuple(CdbSreh *cdbsreh)
 	if(cdbsreh->is_server_enc)
 	{
 		/* raw data */
-		values[errtable_rawdata - 1] = DirectFunctionCall1(textin, CStringGetDatum(cdbsreh->rawdata));
+		values[errtable_rawdata - 1] = CStringGetTextDatum(cdbsreh->rawdata);
 		nulls[errtable_rawdata - 1] = false;
 	}
 	else
@@ -253,15 +253,15 @@ FormErrorTuple(CdbSreh *cdbsreh)
 	}
 
 	/* file name */
-	values[errtable_filename - 1] = DirectFunctionCall1(textin, CStringGetDatum(cdbsreh->filename));
+	values[errtable_filename - 1] = CStringGetTextDatum(cdbsreh->filename);
 	nulls[errtable_filename - 1] = false;
 
 	/* relation name */
-	values[errtable_relname - 1] = DirectFunctionCall1(textin, CStringGetDatum(cdbsreh->relname));
+	values[errtable_relname - 1] = CStringGetTextDatum(cdbsreh->relname);
 	nulls[errtable_relname - 1] = false;
 	
 	/* error message */
-	values[errtable_errmsg - 1] = DirectFunctionCall1(textin, CStringGetDatum(cdbsreh->errmsg));
+	values[errtable_errmsg - 1] = CStringGetTextDatum(cdbsreh->errmsg);
 	nulls[errtable_errmsg - 1] = false;
 	
 	

--- a/src/backend/commands/filespace.c
+++ b/src/backend/commands/filespace.c
@@ -1192,7 +1192,7 @@ add_catalog_filespace_entry(Relation rel, Oid fsoid, int16 dbid, char *location)
 
 	evalues[Anum_pg_filespace_entry_fsedbid - 1] = Int16GetDatum(dbid);
 	evalues[Anum_pg_filespace_entry_fselocation - 1] =
-				DirectFunctionCall1(textin, CStringGetDatum(location));
+		CStringGetTextDatum(location);
 
 	tuple = heap_form_tuple(RelationGetDescr(rel), evalues, enulls);
 

--- a/src/backend/commands/queue.c
+++ b/src/backend/commands/queue.c
@@ -355,10 +355,9 @@ AlterResqueueCapabilityEntry(Oid queueid,
 
 			while (HeapTupleIsValid(tuple = systable_getnext(sscan)))
 			{
-				text	*shutoff_text	  = NULL;
-				char	*shutoff_str	  = NULL;
-				Datum	 shutoff_datum;
-				bool	 isnull			  = false;
+				char	   *shutoff_str;
+				Datum		shutoff_datum;
+				bool		isnull = false;
 				Form_pg_resourcetype rtyp = 
 						(Form_pg_resourcetype)GETSTRUCT(tuple);
 
@@ -399,15 +398,10 @@ AlterResqueueCapabilityEntry(Oid queueid,
 									 tupdesc,
 									 &isnull);
 				Assert(!isnull);
-				shutoff_text = DatumGetTextP(shutoff_datum);
-				shutoff_str = 
-						DatumGetCString(
-								DirectFunctionCall1(
-										textout,
-										PointerGetDatum(shutoff_text)));
+				shutoff_str = TextDatumGetCString(shutoff_datum);
 
 				pStrVal = makeString(shutoff_str);
-					
+
 				break;
 			} /* end while heaptuple is valid */
 			systable_endscan(sscan);
@@ -465,12 +459,11 @@ AlterResqueueCapabilityEntry(Oid queueid,
 		sscan = systable_beginscan(rel, InvalidOid, false, SnapshotNow, 0, NULL);
 		while (HeapTupleIsValid(tuple = systable_getnext(sscan)))
 		{
-			List	*pentry			  = NIL;
-			Value	*pResnameVal	  = NULL;
-			text	*default_text	  = NULL;
-			char	*default_str	  = NULL;
-			Datum	 default_datum;
-			bool	 isnull			  = false;
+			List	   *pentry;
+			Value	   *pResnameVal;
+			char	   *default_str;
+			Datum		default_datum;
+			bool		isnull = false;
 			Form_pg_resourcetype rtyp = 
 					(Form_pg_resourcetype)GETSTRUCT(tuple);
 
@@ -503,12 +496,7 @@ AlterResqueueCapabilityEntry(Oid queueid,
 								 tupdesc,
 								 &isnull);
 			Assert(!isnull);
-			default_text = DatumGetTextP(default_datum);
-			default_str = 
-					DatumGetCString(
-							DirectFunctionCall1(
-									textout,
-									PointerGetDatum(default_text)));
+			default_str = TextDatumGetCString(default_datum);
 
 			/* add the new entry to dupcheck and WITH elems */
 			dupcheck = lappend(dupcheck, pResnameVal);
@@ -675,12 +663,11 @@ GetResqueueCapabilityEntry(Oid  queueid)
 	{
 		if (HeapTupleIsValid(tuple))
 		{
-			List		*pentry		 = NIL;
-			int			 resTypeInt	 = 0;
-			text		*resSet_text = NULL;
-			Datum		 resSet_datum;
-			char		*resSetting	 = NULL;
-			bool		 isnull		 = false;
+			List	   *pentry;
+			int			resTypeInt;
+			Datum		resSet_datum;
+			char	   *resSetting;
+			bool		isnull = false;
 
 			resTypeInt =
 					((Form_pg_resqueuecapability) GETSTRUCT(tuple))->restypid;
@@ -690,9 +677,7 @@ GetResqueueCapabilityEntry(Oid  queueid)
 										tupdesc,
 										&isnull);
 			Assert(!isnull);
-			resSet_text = DatumGetTextP(resSet_datum);
-			resSetting = DatumGetCString(DirectFunctionCall1(textout,
-					PointerGetDatum(resSet_text)));
+			resSetting = TextDatumGetCString(resSet_datum);
 
 			pentry = list_make2(
 					makeInteger(resTypeInt),

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -713,11 +713,11 @@ GetResGroupCapabilities(Oid groupId, ResGroupCaps *resgroupCaps)
 		mask |= 1 << type;
 
 		valueDatum = heap_getattr(tuple, Anum_pg_resgroupcapability_value, relResGroupCapability->rd_att, &isNull);
-		value = DatumGetCString(DirectFunctionCall1(textout, valueDatum));
+		value = TextDatumGetCString(valueDatum);
 		caps[type].value = str2Int(value, getResgroupOptionName(type));
 
 		proposedDatum = heap_getattr(tuple, Anum_pg_resgroupcapability_proposed, relResGroupCapability->rd_att, &isNull);
-		proposed = DatumGetCString(DirectFunctionCall1(textout, proposedDatum));
+		proposed = TextDatumGetCString(proposedDatum);
 		caps[type].proposed = str2Int(proposed, getResgroupOptionName(type));
 	}
 
@@ -1251,7 +1251,7 @@ validateCapabilities(Relation rel,
 
 		proposedDatum = heap_getattr(tuple, Anum_pg_resgroupcapability_proposed,
 									 rel->rd_att, &isNull);
-		proposedStr = DatumGetCString(DirectFunctionCall1(textout, proposedDatum));
+		proposedStr = TextDatumGetCString(proposedDatum);
 		proposed = str2Int(proposedStr, getResgroupOptionName(reslimittype));
 
 		if (reslimittype == RESGROUP_LIMIT_TYPE_CPU)

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -6805,9 +6805,9 @@ reloptions_to_string(Datum reloptions)
 	 * array_to_text() relies on flinfo to be valid.  So use
 	 * OidFunctionCall2.
 	 */
-	sep = DirectFunctionCall1(textin, CStringGetDatum(", "));
+	sep = CStringGetTextDatum(", ");
 	txt = OidFunctionCall2(F_ARRAY_TO_TEXT, reloptions, sep);
-	result = DatumGetCString(DirectFunctionCall1(textout, txt));
+	result = TextDatumGetCString(txt);
 
 	return result;
 }

--- a/src/backend/utils/gp/segadmin.c
+++ b/src/backend/utils/gp/segadmin.c
@@ -330,7 +330,7 @@ catalog_filespaces(Relation fsentryrel, int16 dbid, ArrayType *map)
 	/* need to check that this is an array of name, value pairs */
 	for (i = 0; i < n; i += 2)
 	{
-		char	   *fsname = DatumGetCString(DirectFunctionCall1(textout, d[i]));
+		char	   *fsname = TextDatumGetCString(d[i]);
 		char	   *path;
 		Oid			fsoid;
 
@@ -340,7 +340,7 @@ catalog_filespaces(Relation fsentryrel, int16 dbid, ArrayType *map)
 			elog(ERROR, "filespace \"%s\" does not exist", fsname);
 
 		Insist(i + 1 < n);
-		path = DatumGetCString(DirectFunctionCall1(textout, d[i + 1]));
+		path = TextDatumGetCString(d[i + 1]);
 
 		add_catalog_filespace_entry(fsentryrel, fsoid, dbid, path);
 	}
@@ -364,7 +364,7 @@ persist_all_filespaces(int16 pridbid, int16 mirdbid, ArrayType *fsmap)
 	/* need to check that this is an array of name, value pairs */
 	for (i = 0; i < n; i += 2)
 	{
-		char	   *fsname = DatumGetCString(DirectFunctionCall1(textout, d[i]));
+		char	   *fsname = TextDatumGetCString(d[i]);
 		char	   *path;
 		Oid			fsoid;
 		bool		set_mirror_existence;
@@ -378,7 +378,7 @@ persist_all_filespaces(int16 pridbid, int16 mirdbid, ArrayType *fsmap)
 			elog(ERROR, "filespace \"%s\" does not exist", fsname);
 
 		Insist(i + 1 < n);
-		path = DatumGetCString(DirectFunctionCall1(textout, d[i + 1]));
+		path = TextDatumGetCString(d[i + 1]);
 
 		/* only set the mirror existence on segments */
 		set_mirror_existence = (pridbid != MASTER_DBID);
@@ -1095,11 +1095,9 @@ gp_add_master_standby(PG_FUNCTION_ARGS)
 	new.db.mode = GP_SEGMENT_CONFIGURATION_MODE_INSYNC;
 	new.db.status = GP_SEGMENT_CONFIGURATION_STATUS_UP;
 
-	new.db.hostname = DatumGetCString(DirectFunctionCall1(textout,
-														  PointerGetDatum(PG_GETARG_TEXT_P(0))));
+	new.db.hostname = TextDatumGetCString(PG_GETARG_TEXT_P(0));
 
-	new.db.address = DatumGetCString(DirectFunctionCall1(textout,
-														 PointerGetDatum(PG_GETARG_TEXT_P(1))));
+	new.db.address = TextDatumGetCString(PG_GETARG_TEXT_P(1));
 
 	/* Use the new port number if specified */
 	if (PG_NARGS() > 3 && !PG_ARGISNULL(3))

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -7543,7 +7543,7 @@ GUCArrayReset(ArrayType *array)
 
 		if (isnull)
 			continue;
-		val = DatumGetCString(DirectFunctionCall1(textout, d));
+		val = TextDatumGetCString(d);
 
 		eqsgn = strchr(val, '=');
 		*eqsgn = '\0';


### PR DESCRIPTION
Upstream commit 220db7ccd8 replaced all the idiomatic DirectFunctionCalls
of textin/textout, to use these new handy macros instead. Do the same
for all the remaining such calls in GPDB-specific code.