### PR TITLE
docs: gpcrondump/gpdbrestore - include language with schema level ope…

### DIFF
--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpcrondump.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpcrondump.xml
@@ -68,9 +68,9 @@
       <p>If you specify an option to back up schemas, such as <codeph>-s</codeph>, or
           <codeph>-S</codeph>, all procedural languages that are defined in the database are also
         backed up even though they are not schema specific. The languages are backed up to support
-        any functions that might be backed up.  External items such as shared libraries that are
-        used by a language are not backed up. Also, languages are not backed up if you specify an
-        option to back up tables, such as <codeph>-t</codeph>, <codeph>-T</codeph>. </p>
+        any functions that might be backed up. External items such as shared libraries that are used
+        by a language are not backed up. Also, languages are not backed up if you specify an option
+        to back up only tables, such as <codeph>-t</codeph>, <codeph>-T</codeph>. </p>
       <p>After a backup operation completes, the utility checks the <codeph>gpcrondump</codeph>
         status file for SQL execution errors and displays a warning if an error is found. The
         default location of the backup status files are in the

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpcrondump.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpcrondump.xml
@@ -65,6 +65,12 @@
           <codeph>search_path</codeph>. The settings are restored when you restore the database with
         the <codeph>gpdbrestore</codeph> utility and specify the <codeph>-e</codeph> option to
         create an empty target database before performing a restore operation.</p>
+      <p>If you specify an option to back up schemas, such as <codeph>-s</codeph>, or
+          <codeph>-S</codeph>, all procedural languages that are defined in the database are also
+        backed up even though they are not schema specific. The languages are backed up to support
+        any functions that might be backed up.  External items such as shared libraries that are
+        used by a language are not backed up. Also, languages are not backed up if you specify an
+        option to back up tables, such as <codeph>-t</codeph>, <codeph>-T</codeph>. </p>
       <p>After a backup operation completes, the utility checks the <codeph>gpcrondump</codeph>
         status file for SQL execution errors and displays a warning if an error is found. The
         default location of the backup status files are in the

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpdbrestore.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpdbrestore.xml
@@ -358,6 +358,9 @@
             the backup set of the database being restored. To replace the data in the schema tables
             with the data from backup, you can specify the <codeph>--truncate</codeph> option. The
             schema tables are truncated before the data is restored.</pd>
+          <pd>To support functions that might be restored, all procedural languages that are in the
+            backup are also restored even though they are not schema specific. External items such
+            as shared libraries that are used by a language are not included in a backup.</pd>
           <pd>The <codeph>-S</codeph> option cannot be specified with the
               <codeph>--change-schema</codeph> option.</pd>
         </plentry>


### PR DESCRIPTION
…ration.
Backup/restore of schema level opteration includes languages.

--add information to for both backup and restore
--mention external items such as shared libraries are not included.

will be backported to 5X_STABLE

See PR https://github.com/greenplum-db/gpdb/pull/3438