### PR TITLE
Concourse: remove support for old task.yml name

### DIFF
--- a/concourse/tasks/compile_gpdb_open_source.yml
+++ b/concourse/tasks/compile_gpdb_open_source.yml
@@ -1,1 +1,0 @@
-compile_gpdb_open_source_centos.yml


### PR DESCRIPTION
Using a symlink to make the file-renaming smoother on the PR pipeline
was not a good idea... Concourse maybe doesn't support following
symlinks in the `build_plan.task.file` part of a pipeline.yml

Signed-off-by: C.J. Jameson <cjameson@pivotal.io>