### PR TITLE
Concourse: run /usr/sbin/sshd in simple, consistent way

### DIFF
--- a/concourse/scripts/setup_gpadmin_user.bash
+++ b/concourse/scripts/setup_gpadmin_user.bash
@@ -91,13 +91,7 @@ setup_sshd() {
 
   setup_ssh_for_user root
 
-  # Test that sshd can start
-  if [ -x /etc/init.d/sshd ]; then
-    /etc/init.d/sshd start
-  elif [ -x /etc/init.d/ssh ]; then
-    # Ubuntu uses ssh instead of sshd
-    /etc/init.d/ssh start
-  fi
+  /usr/sbin/sshd
 
   ssh_keyscan_for_user root
   ssh_keyscan_for_user gpadmin


### PR DESCRIPTION
This is good for  CentOS, and SLES -- we shouldn't have needed to
change it in 48f0c70. This PR takes the place of #3433 

For Ubuntu, there can be an issue with setting up a `/var/run/ssh` directory.
We will take that change in the Ubuntu's ICW PR #3421 

Signed-off-by: Goutam Tadi <gtadi@pivotal.io>