### PR TITLE
Adopt CCP for gpexpand test

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -2680,11 +2680,7 @@ jobs:
   - task: gen_cluster
     file: ccp_src/ci/tasks/gen_cluster.yml
     params:
-      AWS_ACCESS_KEY_ID: {{tf-machine-access-key-id}}
-      AWS_SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
-      AWS_DEFAULT_REGION: {{aws-region}}
-      BUCKET_PATH: {{tf-bucket-path}}
-      BUCKET_NAME: gpdb5-pipeline-dynamic-terraform
+      <<: *ccp_gen_cluster_default_params
     on_failure:
       <<: *ccp_destroy
   - task: run_tests
@@ -2719,11 +2715,7 @@ jobs:
   - task: gen_cluster
     file: ccp_src/ci/tasks/gen_cluster.yml
     params:
-      AWS_ACCESS_KEY_ID: {{tf-machine-access-key-id}}
-      AWS_SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
-      AWS_DEFAULT_REGION: {{aws-region}}
-      BUCKET_PATH: {{tf-bucket-path}}
-      BUCKET_NAME: gpdb5-pipeline-dynamic-terraform
+      <<: *ccp_gen_cluster_default_params
     on_failure:
       <<: *ccp_destroy
   - task: run_tests

--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -72,7 +72,8 @@ groups:
 ################################
   - gate_nightly_start
   - DPM_backup_43_restore_5
-  - MM_gpexpand
+  - MM_gpexpand_1
+  - MM_gpexpand_2
   - DPM_gptransfer-43x-to-5x
   - cs_aoco_compression_large_01
   - cs_aoco_compression_large_02
@@ -109,7 +110,6 @@ groups:
 - name: Remaining Pulse
   jobs:
   - MM_gpcheckcat
-  - MM_gpexpand
   - mpp_interconnect
 
 - name: Adopted CCP
@@ -145,6 +145,8 @@ groups:
   - DPM_gptransfer-43x-to-5x
   - DPM_gptransfer-5x-to-5x
   - MM_gpcheckcat
+  - MM_gpexpand_1
+  - MM_gpexpand_2
   - MM_gppkg
   - MM_gprecoverseg
   - DPM_backup_43_restore_5
@@ -230,7 +232,8 @@ groups:
   jobs:
   - gate_nightly_start
   - DPM_backup_43_restore_5
-  - MM_gpexpand
+  - MM_gpexpand_1
+  - MM_gpexpand_2
   - DPM_gptransfer-43x-to-5x
   - cs_aoco_compression_large_01
   - cs_aoco_compression_large_02
@@ -2655,42 +2658,84 @@ jobs:
     on_failure:
       <<: *debug_sleep
   - *ccp_destroy
-- name: MM_gpexpand
+- name: MM_gpexpand_1
   plan:
   - get: nightly-trigger
-    trigger: ((nightly-trigger-flag))
-  - aggregate: &post_packaging_gets_trigger_based_on_flag
+    trigger: {{nightly-trigger-flag}}
+  - aggregate:
     - get: gpdb_src
-      params: {submodules: none}
-      tags: ["gpdb5-pulse-worker"]
       passed: [gate_nightly_start]
-      trigger: ((reduced-frequency-trigger-flag))
-    - get: gpdb_src_tinc_tarball
-      tags: ["gpdb5-pulse-worker"]
+    - get: gpdb_binary
+      resource: bin_gpdb_centos6
       passed: [gate_nightly_start]
-    - get: installer_rhel6_gpdb_rc
-      tags: ["gpdb5-pulse-worker"]
-      passed: [gate_nightly_start]
-    - get: qautils_rhel6_tarball
-      tags: ["gpdb5-pulse-worker"]
-      passed: [gate_nightly_start]
-    - get: gpdb_src_behave_tarball
-      tags: ["gpdb5-pulse-worker"]
-      passed: [gate_nightly_start]
-  - task: trigger_pulse
-    tags: ["gpdb5-pulse-worker"]
-    file: gpdb_src/ci/pulse/api/trigger_pulse.yml
-    input_mapping: *input_mappings
+      trigger: true
+    - get: ccp_src
+    - get: centos-gpdb-dev-6
+  - put: terraform
     params:
-      <<: *pulse_properties
-      PULSE_PROJECT_NAME: "GPDB-gpexpand-parallel"
-  - task: monitor_pulse
-    attempts: 2
-    tags: ["gpdb5-pulse-worker"]
-    file: gpdb_src/ci/pulse/api/monitor_pulse.yml
+      <<: *ccp_default_params
+      vars:
+        <<: *ccp_default_vars
+        number_of_nodes: 5
+  - task: gen_cluster
+    file: ccp_src/ci/tasks/gen_cluster.yml
     params:
-      <<: *pulse_properties
-      PULSE_PROJECT_NAME: "GPDB-gpexpand-parallel"
+      AWS_ACCESS_KEY_ID: {{tf-machine-access-key-id}}
+      AWS_SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
+      AWS_DEFAULT_REGION: {{aws-region}}
+      BUCKET_PATH: {{tf-bucket-path}}
+      BUCKET_NAME: gpdb5-pipeline-dynamic-terraform
+    on_failure:
+      <<: *ccp_destroy
+  - task: run_tests
+    file: gpdb_src/concourse/tasks/run_tinc.yml
+    image: centos-gpdb-dev-6
+    params:
+      TINC_TARGET: gpexpand_1
+      CUSTOM_ENV: HOST1=mdw HOST2=sdw1 HOST3=sdw2 HOST4=sdw3 HOST5=sdw4
+      PRE_TEST_SCRIPT: bash -c 'ssh-keygen -f ~/.ssh/id_rsa -y > ~/.ssh/id_rsa.pub; for i in mdw sdw{1..4}; do ssh centos@$i "sudo chmod 777 /usr/local"; done'
+    on_failure:
+      <<: *debug_sleep
+  - *ccp_destroy
+- name: MM_gpexpand_2
+  plan:
+  - get: nightly-trigger
+    trigger: {{nightly-trigger-flag}}
+  - aggregate:
+    - get: gpdb_src
+      passed: [gate_nightly_start]
+    - get: gpdb_binary
+      resource: bin_gpdb_centos6
+      passed: [gate_nightly_start]
+      trigger: true
+    - get: ccp_src
+    - get: centos-gpdb-dev-6
+  - put: terraform
+    params:
+      <<: *ccp_default_params
+      vars:
+        <<: *ccp_default_vars
+        number_of_nodes: 5
+  - task: gen_cluster
+    file: ccp_src/ci/tasks/gen_cluster.yml
+    params:
+      AWS_ACCESS_KEY_ID: {{tf-machine-access-key-id}}
+      AWS_SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
+      AWS_DEFAULT_REGION: {{aws-region}}
+      BUCKET_PATH: {{tf-bucket-path}}
+      BUCKET_NAME: gpdb5-pipeline-dynamic-terraform
+    on_failure:
+      <<: *ccp_destroy
+  - task: run_tests
+    file: gpdb_src/concourse/tasks/run_tinc.yml
+    image: centos-gpdb-dev-6
+    params:
+      TINC_TARGET: gpexpand_2
+      CUSTOM_ENV: HOST1=mdw HOST2=sdw1 HOST3=sdw2 HOST4=sdw3 HOST5=sdw4
+      PRE_TEST_SCRIPT: bash -c 'ssh-keygen -f ~/.ssh/id_rsa -y > ~/.ssh/id_rsa.pub; for i in mdw sdw{1..4}; do ssh centos@$i "sudo chmod 777 /usr/local"; done'
+    on_failure:
+      <<: *debug_sleep
+  - *ccp_destroy
 - name: DPM_gptransfer-43x-to-5x
   plan:
   - get: nightly-trigger
@@ -2931,7 +2976,8 @@ jobs:
       trigger: true
       passed:
       - DPM_backup_43_restore_5
-      - MM_gpexpand
+      - MM_gpexpand_1
+      - MM_gpexpand_2
       - cs_aoco_compression_large_01
       - cs_aoco_compression_large_02
       - cs_aoco_compression_large_03
@@ -3478,7 +3524,8 @@ jobs:
     - DPM_backup_43_restore_5
     - MM_gpcheckcat
     - MM_gprecoverseg
-    - MM_gpexpand
+    - MM_gpexpand_1
+    - MM_gpexpand_2
     - MM_gpinitstandby
     - DPM_gptransfer-43x-to-5x
     - DPM_gptransfer-5x-to-5x

--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -2661,7 +2661,7 @@ jobs:
 - name: MM_gpexpand_1
   plan:
   - get: nightly-trigger
-    trigger: {{nightly-trigger-flag}}
+    trigger: ((nightly-trigger-flag))
   - aggregate:
     - get: gpdb_src
       passed: [gate_nightly_start]
@@ -2696,7 +2696,7 @@ jobs:
 - name: MM_gpexpand_2
   plan:
   - get: nightly-trigger
-    trigger: {{nightly-trigger-flag}}
+    trigger: ((nightly-trigger-flag))
   - aggregate:
     - get: gpdb_src
       passed: [gate_nightly_start]

--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -219,6 +219,8 @@ groups:
   - gate_mm_misc_start
   - MM_gppkg
   - MM_gprecoverseg
+  - MM_gpexpand_1
+  - MM_gpexpand_2
   - MM_gpcheck
   - MM_analyzedb
   - MM_gpperfmon

--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -2662,30 +2662,38 @@ jobs:
   - *ccp_destroy
 - name: MM_gpexpand_1
   plan:
-  - get: nightly-trigger
-    trigger: ((nightly-trigger-flag))
   - aggregate:
     - get: gpdb_src
-      passed: [gate_nightly_start]
+      tags: ["gpdb5_ccp_external_worker"]
+      params:
+        submodules:
+        - gpMgmt/bin/pythonSrc/ext
+      passed: [gate_mm_misc_start]
     - get: gpdb_binary
+      tags: ["gpdb5_ccp_external_worker"]
       resource: bin_gpdb_centos6
-      passed: [gate_nightly_start]
+      passed: [gate_mm_misc_start]
       trigger: true
     - get: ccp_src
+      tags: ["gpdb5_ccp_external_worker"]
     - get: centos-gpdb-dev-6
+      tags: ["gpdb5_ccp_external_worker"]
   - put: terraform
+    tags: ["gpdb5_ccp_external_worker"]
     params:
       <<: *ccp_default_params
       vars:
         <<: *ccp_default_vars
         number_of_nodes: 5
   - task: gen_cluster
+    tags: ["gpdb5_ccp_external_worker"]
     file: ccp_src/ci/tasks/gen_cluster.yml
     params:
       <<: *ccp_gen_cluster_default_params
     on_failure:
       <<: *ccp_destroy
   - task: run_tests
+    tags: ["gpdb5_ccp_external_worker"]
     file: gpdb_src/concourse/tasks/run_tinc.yml
     image: centos-gpdb-dev-6
     params:
@@ -2697,30 +2705,38 @@ jobs:
   - *ccp_destroy
 - name: MM_gpexpand_2
   plan:
-  - get: nightly-trigger
-    trigger: ((nightly-trigger-flag))
   - aggregate:
     - get: gpdb_src
-      passed: [gate_nightly_start]
+      tags: ["gpdb5_ccp_external_worker"]
+      params:
+        submodules:
+        - gpMgmt/bin/pythonSrc/ext
+      passed: [gate_mm_misc_start]
     - get: gpdb_binary
+      tags: ["gpdb5_ccp_external_worker"]
       resource: bin_gpdb_centos6
-      passed: [gate_nightly_start]
+      passed: [gate_mm_misc_start]
       trigger: true
     - get: ccp_src
+      tags: ["gpdb5_ccp_external_worker"]
     - get: centos-gpdb-dev-6
+      tags: ["gpdb5_ccp_external_worker"]
   - put: terraform
+    tags: ["gpdb5_ccp_external_worker"]
     params:
       <<: *ccp_default_params
       vars:
         <<: *ccp_default_vars
         number_of_nodes: 5
   - task: gen_cluster
+    tags: ["gpdb5_ccp_external_worker"]
     file: ccp_src/ci/tasks/gen_cluster.yml
     params:
       <<: *ccp_gen_cluster_default_params
     on_failure:
       <<: *ccp_destroy
   - task: run_tests
+    tags: ["gpdb5_ccp_external_worker"]
     file: gpdb_src/concourse/tasks/run_tinc.yml
     image: centos-gpdb-dev-6
     params:

--- a/concourse/tasks/run_tinc.yml
+++ b/concourse/tasks/run_tinc.yml
@@ -9,4 +9,7 @@ run:
   - |
     set -ex
     ccp_src/aws/setup_ssh_to_cluster.sh
-    ssh -t mdw "bash /home/gpadmin/gpdb_src/concourse/scripts/run_tinc_test.sh \"$TINC_TARGET\""
+    if [ -n "$PRE_TEST_SCRIPT" ]; then
+      ssh -t mdw "$CUSTOM_ENV $PRE_TEST_SCRIPT"
+    fi
+    ssh -t mdw "$CUSTOM_ENV bash /home/gpadmin/gpdb_src/concourse/scripts/run_tinc_test.sh \"$TINC_TARGET\""

--- a/src/test/tinc/Makefile
+++ b/src/test/tinc/Makefile
@@ -271,3 +271,14 @@ memory_accounting:
 	$(TESTER) \
 		resource_management.memory_accounting.test_oom.OOMTestCase \
 		resource_management.memory_accounting.too_many_exec_accounts.test_exec_accounts
+
+# gpexpand test
+gpexpand_1:
+	$(TESTER) $(DISCOVER) \
+	-s mpp/gpdb/tests/utilities/gpexpand \
+	-q tags=part1
+
+gpexpand_2:
+	$(TESTER) $(DISCOVER) \
+	-s mpp/gpdb/tests/utilities/gpexpand \
+	-q tags=part2

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/utilities/gpexpand/scenarios/workloads/pre_expected/create_parallel_expansion_workload.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/utilities/gpexpand/scenarios/workloads/pre_expected/create_parallel_expansion_workload.ans
@@ -15,8 +15,8 @@ psql:/path/sql_file:1: NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit 
 CREATE TABLE
 ALTER TABLE users_dur_pkey set TABLESPACE test_ts;
 ALTER TABLE
-INSERT INTO users_dur_pkey select i, 'name'||i, i%50+1 from generate_series(1,10000000) i;
-INSERT 0 10000000
+INSERT INTO users_dur_pkey select i, 'name'||i, i%50+1 from generate_series(1,100000) i;
+INSERT 0 100000
 DROP TABLE IF EXISTS users_duration_4;
 psql:/path/sql_file:1: NOTICE:  table "users_duration_4" does not exist, skipping
 DROP TABLE
@@ -30,8 +30,8 @@ distributed by (a);
 CREATE TABLE
 INSERT INTO users_duration_4  
 SELECT i, (i * 10) % 100, i::text, '2013-09-01 03:04:05'
-FROM generate_series(1, 10000000)i;
-INSERT 0 10000000
+FROM generate_series(1, 100000)i;
+INSERT 0 100000
 DROP TABLE IF EXISTS users_duration_5;
 psql:/path/sql_file:1: NOTICE:  table "users_duration_5" does not exist, skipping
 DROP TABLE
@@ -45,8 +45,8 @@ distributed by (a);
 CREATE TABLE
 INSERT INTO users_duration_5  
 SELECT i, (i * 10) % 100, i::text, '2013-09-01 03:04:05'
-FROM generate_series(1, 10000000)i;
-INSERT 0 10000000
+FROM generate_series(1, 100000)i;
+INSERT 0 100000
 DROP TABLE IF EXISTS users_duration_6;
 psql:/path/sql_file:1: NOTICE:  table "users_duration_6" does not exist, skipping
 DROP TABLE
@@ -60,6 +60,6 @@ distributed by (a);
 CREATE TABLE
 INSERT INTO users_duration_6  
 SELECT i, (i * 10) % 100, i::text, '2013-09-01 03:04:05'
-FROM generate_series(1, 10000000)i;
-INSERT 0 10000000
+FROM generate_series(1, 100000)i;
+INSERT 0 100000
 

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/utilities/gpexpand/scenarios/workloads/pre_sql/create_parallel_expansion_workload.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/utilities/gpexpand/scenarios/workloads/pre_sql/create_parallel_expansion_workload.sql
@@ -7,7 +7,7 @@ CREATE TABLE users_dur_pkey (
     age   INT4
 );
 ALTER TABLE users_dur_pkey set TABLESPACE test_ts;
-INSERT INTO users_dur_pkey select i, 'name'||i, i%50+1 from generate_series(1,10000000) i;
+INSERT INTO users_dur_pkey select i, 'name'||i, i%50+1 from generate_series(1,100000) i;
 
 DROP TABLE IF EXISTS users_duration_4;
 CREATE TABLE users_duration_4(
@@ -19,7 +19,7 @@ CREATE TABLE users_duration_4(
 distributed by (a);
 INSERT INTO users_duration_4  
 SELECT i, (i * 10) % 100, i::text, '2013-09-01 03:04:05'
-FROM generate_series(1, 10000000)i;
+FROM generate_series(1, 100000)i;
 
 DROP TABLE IF EXISTS users_duration_5;
 CREATE TABLE users_duration_5(
@@ -31,7 +31,7 @@ CREATE TABLE users_duration_5(
 distributed by (a);
 INSERT INTO users_duration_5  
 SELECT i, (i * 10) % 100, i::text, '2013-09-01 03:04:05'
-FROM generate_series(1, 10000000)i;
+FROM generate_series(1, 100000)i;
 
 DROP TABLE IF EXISTS users_duration_6;
 CREATE TABLE users_duration_6(
@@ -43,5 +43,5 @@ CREATE TABLE users_duration_6(
 distributed by (a);
 INSERT INTO users_duration_6  
 SELECT i, (i * 10) % 100, i::text, '2013-09-01 03:04:05'
-FROM generate_series(1, 10000000)i;
+FROM generate_series(1, 100000)i;
 

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/utilities/gpexpand/test_gpexpand.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/utilities/gpexpand/test_gpexpand.py
@@ -85,7 +85,7 @@ class GpSegInstall(Command):
         run_shell_command('gpssh-exkeys -f %s' %self.hostfile, 'gpssh-exkeys', res)
 
         if res['rc'] > 0:
-            raise Exception("Failed to do gpssh-exkeys: %s" %res[stderr])
+            raise Exception("Failed to do gpssh-exkeys: %s" %res['stderr'])
 
         res = {'rc':0, 'stderr':'', 'stdout':''}
         run_shell_command("gpssh -f %s -e 'mkdir -p %s'" %(self.hostfile, self.gphome), 'gpssh-exkeys', res)


### PR DESCRIPTION
Migrating gpexpand test from using pulse to terraform. This uses a new
feature added in CCP "NUMBER_OF_NODES" which deploys a specific amount
of VMs for the cluster.

Add CUSTOM_ENV and PRE_TEST_SCRIPT properties in order to run tests
with specific expectations.


----------------------------------------

Change query to reduce memory consumption

Terraform deployed machines uses less memory compared to pulse, so the
query that uses a lot of memory was getting killed by the kernel OOM
manager.

------------------------

misc fix

--------------------------


Currently we've removed `the tag_filter` for `ccp` so that we can use the `NUMBER_OF_NODES` feature. Ideally, this should be tagged and we could just use the new changes as is.