### PR TITLE
Fix crash with a ROLLUP query.

### DIFF
--- a/src/include/optimizer/planmain.h
+++ b/src/include/optimizer/planmain.h
@@ -141,15 +141,13 @@ extern Sort *make_sort_from_sortclauses(PlannerInfo *root, List *sortcls,
 extern Sort *make_sort_from_groupcols(PlannerInfo *root, List *groupcls,
 									  AttrNumber *grpColIdx, bool appendGrouping,
 									  Plan *lefttree);
-extern Sort *make_sort_from_pathkeys_and_groupingcol(PlannerInfo *root,
-										Plan *lefttree,
-										List *pathkeys,
-										TargetEntry *grouping,
-										TargetEntry *groupid);
 extern List *reconstruct_group_clause(List *orig_groupClause, List *tlist,
 						 AttrNumber *grpColIdx, int numcols);
 
 extern Motion *make_motion(PlannerInfo *root, Plan *lefttree, List *sortPathKeys, bool useExecutorVarFormat);
+extern Sort *make_sort(PlannerInfo *root, Plan *lefttree, int numCols,
+		  AttrNumber *sortColIdx, Oid *sortOperators, bool *nullsFirst,
+		  double limit_tuples);
 
 extern Agg *make_agg(PlannerInfo *root, List *tlist, List *qual,
 					 AggStrategy aggstrategy, bool streaming,

--- a/src/test/regress/expected/bfv_olap.out
+++ b/src/test/regress/expected/bfv_olap.out
@@ -1,8 +1,62 @@
+-- Tests for old bugs related to OLAP queries.
+-- First create a schema to contain the test tables, and few common test
+-- tables that are shared by several test queries.
+create schema bfv_olap;
+set search_path=bfv_olap;
+create table customer
+(
+  cn int not null,
+  cname text not null,
+  cloc text,
+  primary key (cn)
+) distributed by (cn);
+NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "customer_pkey" for table "customer"
+insert into customer values
+  ( 1, 'Macbeth', 'Inverness'),
+  ( 2, 'Duncan', 'Forres'),
+  ( 3, 'Lady Macbeth', 'Inverness'),
+  ( 4, 'Witches, Inc', 'Lonely Heath');
+create table vendor
+(
+  vn int not null,
+  vname text not null,
+  vloc text,
+  primary key (vn)
+) distributed by (vn);
+NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "vendor_pkey" for table "vendor"
+insert into vendor values
+  ( 10, 'Witches, Inc', 'Lonely Heath'),
+  ( 20, 'Lady Macbeth', 'Inverness'),
+  ( 30, 'Duncan', 'Forres'),
+  ( 40, 'Macbeth', 'Inverness'),
+  ( 50, 'Macduff', 'Fife');
+create table sale
+(
+  cn int not null,
+  vn int not null,
+  pn int not null,
+  dt date not null,
+  qty int not null,
+  prc float not null,
+  primary key (cn, vn, pn)
+) distributed by (cn,vn,pn);
+NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "sale_pkey" for table "sale"
+insert into sale values
+  ( 2, 40, 100, '1401-1-1', 1100, 2400),
+  ( 1, 10, 200, '1401-3-1', 1, 0),
+  ( 3, 40, 200, '1401-4-1', 1, 0),
+  ( 1, 20, 100, '1401-5-1', 1, 0),
+  ( 1, 30, 300, '1401-5-2', 1, 0),
+  ( 1, 50, 400, '1401-6-1', 1, 0),
+  ( 2, 50, 400, '1401-6-1', 1, 0),
+  ( 1, 30, 500, '1401-6-1', 12, 5),
+  ( 3, 30, 500, '1401-6-1', 12, 5),
+  ( 3, 30, 600, '1401-6-1', 12, 5),
+  ( 4, 40, 700, '1401-6-1', 1, 1),
+  ( 4, 40, 800, '1401-6-1', 1, 1);
 --
 -- Test case errors out when we define aggregates without preliminary functions and use it as an aggregate derived window function.
 --
-create schema bfv_olap;
-set search_path=bfv_olap;
 -- SETUP
 -- start_ignore
 drop table if exists toy;
@@ -355,50 +409,6 @@ drop table if exists t;
 --
 -- Passing through distribution matching type in default implementation
 --
--- SETUP
--- start_ignore
-drop table if exists customer;
-NOTICE:  table "customer" does not exist, skipping
-drop table if exists sale;
-NOTICE:  table "sale" does not exist, skipping
--- end_ignore
-create table customer
-(
-	cn int not null,
-	cname text not null,
-	cloc text,
-	primary key (cn)
-) distributed by (cn);
-NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "customer_pkey" for table "customer"
-insert into customer values
-  ( 1, 'Macbeth', 'Inverness'),
-  ( 2, 'Duncan', 'Forres'),
-  ( 3, 'Lady Macbeth', 'Inverness'),
-  ( 4, 'Witches, Inc', 'Lonely Heath');
-create table sale
-(
-	cn int not null,
-	vn int not null,
-	pn int not null,
-	dt date not null,
-	qty int not null,
-	prc float not null,
-	primary key (cn, vn, pn)
-) distributed by (cn,vn,pn);
-NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "sale_pkey" for table "sale"
-insert into sale values
-  ( 2, 40, 100, '1401-1-1', 1100, 2400),
-  ( 1, 10, 200, '1401-3-1', 1, 0),
-  ( 3, 40, 200, '1401-4-1', 1, 0),
-  ( 1, 20, 100, '1401-5-1', 1, 0),
-  ( 1, 30, 300, '1401-5-2', 1, 0),
-  ( 1, 50, 400, '1401-6-1', 1, 0),
-  ( 2, 50, 400, '1401-6-1', 1, 0),
-  ( 1, 30, 500, '1401-6-1', 12, 5),
-  ( 3, 30, 500, '1401-6-1', 12, 5),
-  ( 3, 30, 600, '1401-6-1', 12, 5),
-  ( 4, 40, 700, '1401-6-1', 1, 1),
-  ( 4, 40, 800, '1401-6-1', 1, 1);
   
 -- TEST
 select cname,
@@ -422,13 +432,8 @@ order by 1, 2;
  Witches, Inc |    1
 (12 rows)
 
--- CLEANUP
--- start_ignore
-drop table if exists customer;
-drop table if exists sale;
--- end_ignore
 --
--- Optimzier query crashing for logical window with no window functions
+-- Optimizer query crashing for logical window with no window functions
 --
 -- SETUP
 create table mpp23240(a int, b int, c int, d int, e int, f int);
@@ -452,9 +457,10 @@ from (select * from mpp23240 where f > 10) x;
 -- CLEANUP
 -- start_ignore
 drop table mpp23240;
-drop schema if exists bfv_olap;
 -- end_ignore
+--
 -- Test for the bug reported at https://github.com/greenplum-db/gpdb/issues/2236
+--
 create table test1 (x int, y int, z double precision);
 insert into test1 select a, b, a*10 + b from generate_series(1, 5) a, generate_series(1, 5) b;
 select sum(z) over (partition by x) as sumx, sum(z) over (partition by y) as sumy from test1;
@@ -488,8 +494,10 @@ select sum(z) over (partition by x) as sumx, sum(z) over (partition by y) as sum
 (25 rows)
 
 drop table test1;
+--
 -- This failed at one point because of an over-zealous syntax check, with
 -- "window functions not allowed in WHERE clause" error.
+--
 select sum(g) from generate_series(1, 5) g
 where g in (
   select rank() over (order by x) from generate_series(1,5) x
@@ -498,6 +506,65 @@ where g in (
 -----
   15
 (1 row)
+
+--
+-- This caused a crash in ROLLUP planning at one point.
+--
+SELECT sale.vn
+FROM sale,vendor
+WHERE sale.vn=vendor.vn
+GROUP BY ROLLUP( (sale.dt,sale.cn),(sale.pn),(sale.vn));
+ vn 
+----
+ 40
+   
+   
+ 20
+   
+   
+ 30
+   
+   
+   
+ 10
+ 40
+   
+   
+ 50
+   
+   
+ 30
+   
+   
+ 40
+   
+   
+   
+   
+   
+   
+ 30
+   
+ 50
+   
+ 30
+ 40
+   
+(34 rows)
+
+SELECT DISTINCT sale.vn
+FROM sale,vendor
+WHERE sale.vn=vendor.vn
+GROUP BY ROLLUP( (sale.dt,sale.cn),(sale.pn),(sale.vn));
+ vn 
+----
+ 10
+ 20
+ 30
+ 40
+ 50
+   
+(6 rows)
 
 -- CLEANUP
 -- start_ignore


### PR DESCRIPTION
This was broken by commit 7e268107f3, which refactored the code that deals
with path keys and sorts in plangroupext.c. The new function
make_sort_from_pathkeys_and_groupingcol(), which replaced the old
make_sort_from_reordered_groupcols() function, didn't work quite the same
as the old function. I'm not sure what exactly went wrong there, but the
caller already has the column number and operator information at hand, so
we can use it to construct the Sort directly, without trying to re-find the
original target list entries of the sort columns.

Commit 7e268107f3 also neglected the comments in
make_sort_from_pathkeys_and_groupingcol(), but this commit removes the whole
function.

Fixes github issue #3447.