### PR TITLE
Changes to protect the limited resources of AIX VMs

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -132,6 +132,14 @@ resources:
       ###########################################################
       bucket_path: {{tf-bucket-path}}
 
+- name: aix_environments
+  type: pool
+  source:
+    uri: {{concourse-resource-pools-git-remote}}
+    branch: master
+    pool: client_loader_remote_aix
+    private_key: {{concourse-resource-pools-git-key}}
+
 - name: gpdb_src
   type: git
   source:
@@ -900,6 +908,8 @@ jobs:
       passed: [compile_gpdb_centos6]
       resource: bin_gpdb_centos6
     - get: centos-gpdb-dev-6
+    - put: aix_environments
+      params: {acquire: true}
   - task: ic_gpdb_cl
     file: gpdb_src/concourse/tasks/ic_gpdb_remote.yml
     image: centos-gpdb-dev-6
@@ -909,6 +919,18 @@ jobs:
       REMOTE_PORT: {{remote_port}}
       REMOTE_USER: {{remote_user}}
       REMOTE_KEY: {{remote_key}}
+    ensure:
+      do:
+      - task: cleanup_aix
+        file: gpdb_src/concourse/tasks/aix_remote_cleanup.yml
+        image: centos-gpdb-dev-6
+        params:
+          REMOTE_HOST: {{remote_host}}
+          REMOTE_PORT: {{remote_port}}
+          REMOTE_USER: {{remote_user}}
+          REMOTE_KEY: {{remote_key}}
+      - put: aix_environments
+        params: {release: aix_environments}
 
 - name: mpp_resource_group_centos6
   plan:

--- a/concourse/scripts/aix_remote_cleanup.bash
+++ b/concourse/scripts/aix_remote_cleanup.bash
@@ -1,0 +1,52 @@
+#!/bin/bash -l
+
+set -eo pipefail
+
+function setup_gpadmin_user() {
+    ./gpdb_src/concourse/scripts/setup_gpadmin_user.bash "$TEST_OS"
+}
+
+# Get ssh private key from REMOTE_KEY, which is assumed to
+# be encode in base64. We can't pass the key content directly
+# since newline doesn't work well for env variable.
+function import_remote_key() {
+    echo -n $REMOTE_KEY | base64 -d > ~/remote.key
+    chmod 400 ~/remote.key
+
+    eval `ssh-agent -s`
+    ssh-add ~/remote.key
+
+    ssh-keyscan -p $REMOTE_PORT $REMOTE_HOST > pubkey
+    awk '{printf "[%s]:", $1 }' pubkey > tmp
+    echo -n $REMOTE_PORT >> tmp
+    awk '{$1 = ""; print $0; }' pubkey >> tmp
+
+    cat tmp >> ~/.ssh/known_hosts
+}
+
+# Since we are cloning and building on remote machine,
+# files won't be deleted as concourse container destroys.
+# We have to clean everything for success build.
+function cleanup() {
+    local SESSION_ID=$1
+    ssh -T -p $REMOTE_PORT $REMOTE_USER@$REMOTE_HOST <<- EOF
+    rm -rf $GPDB_DIR
+    rm -rf gpdb-compile/$SESSION_ID
+EOF
+}
+
+function _main() {
+
+    if [ -z "$REMOTE_PORT" ]; then
+        REMOTE_PORT=22
+    fi
+
+    # Get session id from previous test task
+    SESSION_ID=$(cat session_id/session_id)
+
+    time setup_gpadmin_user
+    time import_remote_key
+    time cleanup $SESSION_ID
+}
+
+_main "$@"

--- a/concourse/scripts/ic_gpdb_remote.bash
+++ b/concourse/scripts/ic_gpdb_remote.bash
@@ -83,6 +83,11 @@ function run_remote_test() {
     # Get a session id for different commit builds.
     SESSION_ID=`ssh -T -p $REMOTE_PORT $REMOTE_USER@$REMOTE_HOST 'echo \$\$'`
 
+    # Save the session ID for next task in the job
+    #  this dir/file is a volume to be exported
+    #  from the task
+    echo $SESSION_ID > session_id/session_id
+
     # Create working directory on remote machine.
     ssh -T -p $REMOTE_PORT $REMOTE_USER@$REMOTE_HOST > dir <<-EOF
     mkdir -p gpdb-compile/$SESSION_ID
@@ -95,14 +100,6 @@ EOF
     run_loaders_test
 }
 
-# Since we are cloning and building on remote machine,
-# files won't be deleted as concourse container destroys.
-# We have to clean everything for success build.
-function cleanup() {
-    ssh -T -p $REMOTE_PORT $REMOTE_USER@$REMOTE_HOST <<- EOF
-    rm -rf $GPDB_DIR
-EOF
-}
 function _main() {
 
     if [ -z "$REMOTE_PORT" ]; then
@@ -115,7 +112,6 @@ function _main() {
     time make_cluster
     time import_remote_key
     time run_remote_test
-    time cleanup
 }
 
 _main "$@"

--- a/concourse/tasks/aix_remote_cleanup.yml
+++ b/concourse/tasks/aix_remote_cleanup.yml
@@ -6,13 +6,10 @@ image_resource:
   type: docker-image
 
 inputs:
-- name: installer_aix7_gpdb_clients
-- name: installer_aix7_gpdb_loaders
-- name: bin_gpdb
 - name: gpdb_src
+- name: session_id
 
 outputs:
-- name: session_id
 
 params:
   BLD_TARGETS:
@@ -22,4 +19,4 @@ params:
   REMOTE_KEY:
 
 run:
-  path: gpdb_src/concourse/scripts/ic_gpdb_remote.bash
+  path: gpdb_src/concourse/scripts/aix_remote_cleanup.bash


### PR DESCRIPTION
Build artifacts filled up the disk, so for now we will clean up no
matter what.

The AIX test appears to have issues if there are concurrent pipelines
going against it. The resource pool protects this failure case.

Signed-off-by: Kris Macoskey <kmacoskey@pivotal.io>