### PR TITLE
Add -r RELFILENODE to pg_resetxlog --help output

### DIFF
--- a/src/bin/pg_resetxlog/pg_resetxlog.c
+++ b/src/bin/pg_resetxlog/pg_resetxlog.c
@@ -1142,6 +1142,7 @@ usage(void)
 	printf(_("  -m XID          set next multitransaction ID\n"));
 	printf(_("  -n              no update, just show extracted control values (for testing)\n"));
 	printf(_("  -o OID          set next OID\n"));
+	printf(_("  -r RELFILENODE  set next RELFILENODE\n"));
 	printf(_("  -O OFFSET       set next multitransaction offset\n"));
 	printf(_("  -x XID          set next transaction ID\n"));
 	printf(_("  --help          show this help, then exit\n"));


### PR DESCRIPTION
In Greenplum 5.0, OID and relfilenode were decoupled. Each QD and QE
segment was given its own relfilenode counter (similar to the nextOid
counter) which users could manually set (with extreme caution!) by
using pg_resetxlog tool. The pg_resetxlog --help output did not
display the flag to set the relfilenode counter which was missed from
that patch. Now it should properly display as an available option.

Reference:
https://github.com/greenplum-db/gpdb/commit/1fd11387d2b9f250c14f0ccb893c0956b1bf1487

Thanks to Marbin Tan for reporting this issue.

This patch will also be backported to the 5X_STABLE branch after merging into master.