### PR TITLE
Fix multistage aggregation final target list

### DIFF
--- a/src/test/regress/expected/bfv_aggregate.out
+++ b/src/test/regress/expected/bfv_aggregate.out
@@ -1472,12 +1472,12 @@ from mtup1 where c0 = 'foo' group by c0, c1 limit 10;
 -- case of same column aliases and grouping on them.
 DROP TABLE IF EXISTS t1;
 NOTICE:  table "t1" does not exist, skipping
-CREATE TABLE t1 (a varchar) DISTRIBUTED RANDOMLY;
-INSERT INTO t1 VALUES ('aaaaaaa');
-INSERT INTO t1 VALUES ('aaaaaaa');
-INSERT INTO t1 VALUES ('bbbbbbb');
-INSERT INTO t1 VALUES ('bbbbbbb');
-INSERT INTO t1 VALUES ('bbbbb');
+CREATE TABLE t1 (a varchar, b character varying) DISTRIBUTED RANDOMLY;
+INSERT INTO t1 VALUES ('aaaaaaa', 'cccccccccc');
+INSERT INTO t1 VALUES ('aaaaaaa', 'ddddd');
+INSERT INTO t1 VALUES ('bbbbbbb', 'eeee');
+INSERT INTO t1 VALUES ('bbbbbbb', 'eeef');
+INSERT INTO t1 VALUES ('bbbbb', 'dfafa');
 SELECT substr(a, 1) as a FROM (SELECT ('-'||a)::varchar as a FROM (SELECT a FROM t1) t2) t3 GROUP BY a ORDER BY a;
     a     
 ----------
@@ -1486,9 +1486,15 @@ SELECT substr(a, 1) as a FROM (SELECT ('-'||a)::varchar as a FROM (SELECT a FROM
  -bbbbbbb
 (3 rows)
 
+SELECT array_agg(f)  FROM (SELECT b::text as f FROM t1 GROUP BY b ORDER BY b) q;
+             array_agg              
+------------------------------------
+ {cccccccccc,ddddd,dfafa,eeee,eeef}
+(1 row)
+
 -- Check that ORDER BY NULLS FIRST/LAST in an aggregate is respected (these are
 -- variants of similar query in PostgreSQL's aggregates test)
-create temporary table aggordertest (a int4, b int4);
+create temporary table aggordertest (a int4, b int4) distributed by (a);
 insert into aggordertest values (1,1), (2,2), (1,3), (3,4), (null,5), (2,null);
 select array_agg(a order by a nulls first) from aggordertest;
     array_agg     

--- a/src/test/regress/expected/bfv_aggregate_optimizer.out
+++ b/src/test/regress/expected/bfv_aggregate_optimizer.out
@@ -1471,12 +1471,12 @@ from mtup1 where c0 = 'foo' group by c0, c1 limit 10;
 -- case of same column aliases and grouping on them.
 DROP TABLE IF EXISTS t1;
 NOTICE:  table "t1" does not exist, skipping
-CREATE TABLE t1 (a varchar) DISTRIBUTED RANDOMLY;
-INSERT INTO t1 VALUES ('aaaaaaa');
-INSERT INTO t1 VALUES ('aaaaaaa');
-INSERT INTO t1 VALUES ('bbbbbbb');
-INSERT INTO t1 VALUES ('bbbbbbb');
-INSERT INTO t1 VALUES ('bbbbb');
+CREATE TABLE t1 (a varchar, b character varying) DISTRIBUTED RANDOMLY;
+INSERT INTO t1 VALUES ('aaaaaaa', 'cccccccccc');
+INSERT INTO t1 VALUES ('aaaaaaa', 'ddddd');
+INSERT INTO t1 VALUES ('bbbbbbb', 'eeee');
+INSERT INTO t1 VALUES ('bbbbbbb', 'eeef');
+INSERT INTO t1 VALUES ('bbbbb', 'dfafa');
 SELECT substr(a, 1) as a FROM (SELECT ('-'||a)::varchar as a FROM (SELECT a FROM t1) t2) t3 GROUP BY a ORDER BY a;
     a     
 ----------
@@ -1485,9 +1485,15 @@ SELECT substr(a, 1) as a FROM (SELECT ('-'||a)::varchar as a FROM (SELECT a FROM
  -bbbbbbb
 (3 rows)
 
+SELECT array_agg(f)  FROM (SELECT b::text as f FROM t1 GROUP BY b ORDER BY b) q;
+             array_agg              
+------------------------------------
+ {cccccccccc,ddddd,dfafa,eeee,eeef}
+(1 row)
+
 -- Check that ORDER BY NULLS FIRST/LAST in an aggregate is respected (these are
 -- variants of similar query in PostgreSQL's aggregates test)
-create temporary table aggordertest (a int4, b int4);
+create temporary table aggordertest (a int4, b int4) distributed by (a);
 insert into aggordertest values (1,1), (2,2), (1,3), (3,4), (null,5), (2,null);
 select array_agg(a order by a nulls first) from aggordertest;
     array_agg     

--- a/src/test/regress/sql/bfv_aggregate.sql
+++ b/src/test/regress/sql/bfv_aggregate.sql
@@ -1354,18 +1354,19 @@ from mtup1 where c0 = 'foo' group by c0, c1 limit 10;
 -- MPP-29042 Multistage aggregation plans should have consistent targetlists in
 -- case of same column aliases and grouping on them.
 DROP TABLE IF EXISTS t1;
-CREATE TABLE t1 (a varchar) DISTRIBUTED RANDOMLY;
-INSERT INTO t1 VALUES ('aaaaaaa');
-INSERT INTO t1 VALUES ('aaaaaaa');
-INSERT INTO t1 VALUES ('bbbbbbb');
-INSERT INTO t1 VALUES ('bbbbbbb');
-INSERT INTO t1 VALUES ('bbbbb');
+CREATE TABLE t1 (a varchar, b character varying) DISTRIBUTED RANDOMLY;
+INSERT INTO t1 VALUES ('aaaaaaa', 'cccccccccc');
+INSERT INTO t1 VALUES ('aaaaaaa', 'ddddd');
+INSERT INTO t1 VALUES ('bbbbbbb', 'eeee');
+INSERT INTO t1 VALUES ('bbbbbbb', 'eeef');
+INSERT INTO t1 VALUES ('bbbbb', 'dfafa');
 SELECT substr(a, 1) as a FROM (SELECT ('-'||a)::varchar as a FROM (SELECT a FROM t1) t2) t3 GROUP BY a ORDER BY a;
+SELECT array_agg(f)  FROM (SELECT b::text as f FROM t1 GROUP BY b ORDER BY b) q;
 
 
 -- Check that ORDER BY NULLS FIRST/LAST in an aggregate is respected (these are
 -- variants of similar query in PostgreSQL's aggregates test)
-create temporary table aggordertest (a int4, b int4);
+create temporary table aggordertest (a int4, b int4) distributed by (a);
 insert into aggordertest values (1,1), (2,2), (1,3), (3,4), (null,5), (2,null);
 
 select array_agg(a order by a nulls first) from aggordertest;


### PR DESCRIPTION
If a target list entry is found under a relabelnode, the newly created
var node should be nested inside the relabelnode if the vartype
of the var node is different than the resulttype of the relablenode.
Otherwise, the cast information is lost and executor will complain type mismatch
```sql
	CREATE TABLE t1 (a varchar, b character varying) DISTRIBUTED RANDOMLY;
	SELECT array_agg(f)  FROM (SELECT b::text as f FROM t1 GROUP BY b) q;
	ERROR:  attribute 1 has wrong type (execQual.c:763)  (seg0 slice2 127.0.0.1:25432 pid=7064)
	DETAIL:  Table has type character varying, but query expects text.
```