### PR TITLE
Improve terraform run_*_test.sh scripts for easier debugging

### DIFF
--- a/concourse/scripts/run_behave_test.sh
+++ b/concourse/scripts/run_behave_test.sh
@@ -2,10 +2,16 @@
 
 BEHAVE_FLAGS=$@
 
-source /usr/local/greenplum-db-devel/greenplum_path.sh
-export PGPORT=5432
-export MASTER_DATA_DIRECTORY=/data/gpdata/master/gpseg-1
-export PGDATABASE=gptest
+cat > ~/gpdb-env.sh << EOF
+  source /usr/local/greenplum-db-devel/greenplum_path.sh
+  export PGPORT=5432
+  export MASTER_DATA_DIRECTORY=/data/gpdata/master/gpseg-1
+  export PGDATABASE=gptest
+
+  alias mdd='cd \$MASTER_DATA_DIRECTORY'
+EOF
+source ~/gpdb-env.sh
+
 createdb gptest
 gpconfig --skipvalidation -c fsync -v off
 gpstop -u

--- a/concourse/scripts/run_tinc_test.sh
+++ b/concourse/scripts/run_tinc_test.sh
@@ -1,13 +1,21 @@
 #!/bin/bash
 
-TINC_TARGET=$@
+TINC_TARGET="$@"
+TINC_DIR=/home/gpadmin/gpdb_src/src/test/tinc
 
-source /usr/local/greenplum-db-devel/greenplum_path.sh
-export PGPORT=5432
-export MASTER_DATA_DIRECTORY=/data/gpdata/master/gpseg-1
-export PGDATABASE=gptest
+cat > ~/gpdb-env.sh << EOF
+  source /usr/local/greenplum-db-devel/greenplum_path.sh
+  export PGPORT=5432
+  export MASTER_DATA_DIRECTORY=/data/gpdata/master/gpseg-1
+  export PGDATABASE=gptest
+
+  alias mdd='cd \$MASTER_DATA_DIRECTORY'
+  alias tinc='cd ${TINC_DIR}'
+EOF
+source ~/gpdb-env.sh
+
 createdb gptest
 createdb gpadmin
-cd /home/gpadmin/gpdb_src/src/test/tinc
+cd ${TINC_DIR}
 source tinc_env.sh
-make $@
+make ${TINC_TARGET}


### PR DESCRIPTION
We add a gpdb-env.sh file that sets up the test environment.
This will be backported to 5X_STABLE.

These changes were already present in the gpdb4 repo, so this brings the two into parity.