### PR TITLE
Remove unused tags in gptransfer test suite

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gptransfer.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gptransfer.feature
@@ -7,13 +7,11 @@ Feature: gptransfer tests
         And the user runs "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -f test/behave/mgmt_utils/steps/data/gptransfer_setup.sql -d template1"
         Then psql should return a return code of 0
 
-    @T339833
     Scenario: gptransfer full, source cluster -> source cluster
         Given the gptransfer test is initialized
         And the user runs "gptransfer --full --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_SOURCE_USER --dest-port $GPTRANSFER_SOURCE_PORT --dest-host $GPTRANSFER_SOURCE_HOST --source-map-file $GPTRANSFER_MAP_FILE --batch-size=10"
         Then gptransfer should return a return code of 2
 
-    @T339831
     Scenario: gptransfer full no validator
         Given the gptransfer test is initialized
         And the user runs "gptransfer --full --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --batch-size=10"
@@ -27,8 +25,6 @@ Feature: gptransfer tests
         And verify that table "one_row_table" in "gptransfer_testdb4" has "1" rows
         And verify that table "wide_rows" in "gptransfer_testdb5" has "10" rows
 
-    @T339889
-    @T339913
     Scenario: gptransfer full md5 validator in TEXT format with '\010' delimiter
         Given the gptransfer test is initialized
         And the user runs "gptransfer --full --delimiter '\010' --format text --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --validate md5 --batch-size=10"
@@ -61,8 +57,6 @@ Feature: gptransfer tests
         And verify that table "one_row_table" in "gptransfer_testdb4" has "1" rows
         And verify that table "wide_rows" in "gptransfer_testdb5" has "10" rows
 
-    @T339888
-    @T339914
     Scenario: gptransfer full count validator in TEXT format with '\010' delimiter
         Given the gptransfer test is initialized
         And the user runs "gptransfer --full --delimiter '\010' --format text --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --validate count --batch-size=10"
@@ -75,7 +69,6 @@ Feature: gptransfer tests
         And verify that table "one_row_table" in "gptransfer_testdb4" has "1" rows
         And verify that table "wide_rows" in "gptransfer_testdb5" has "10" rows
 
-    @T439914
     Scenario: gptransfer full md5 validator in CSV format
         Given the gptransfer test is initialized
         And the user runs "gptransfer --full --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --validate md5 --format=csv --batch-size=10"
@@ -101,7 +94,6 @@ Feature: gptransfer tests
         And verify that table "one_row_table" in "gptransfer_testdb4" has "1" rows
         And verify that table "wide_rows" in "gptransfer_testdb5" has "10" rows
 
-    @T439915
     Scenario: gptransfer full count validator in CSV format
         Given the gptransfer test is initialized
         And the user runs "gptransfer --full --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --validate count --format=csv --batch-size=10"
@@ -114,28 +106,24 @@ Feature: gptransfer tests
         And verify that table "one_row_table" in "gptransfer_testdb4" has "1" rows
         And verify that table "wide_rows" in "gptransfer_testdb5" has "10" rows
 
-    @T339915
     Scenario: gptransfer full with drop
         Given the gptransfer test is initialized
         And the user runs "psql -p $GPTRANSFER_DEST_PORT -h $GPTRANSFER_DEST_HOST -U $GPTRANSFER_DEST_USER -f test/behave/mgmt_utils/steps/data/gptransfer_setup.sql -d template1"
         And the user runs "gptransfer --full --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --drop --batch-size=10"
         Then gptransfer should return a return code of 2
 
-    @T339916
     Scenario: gptransfer full with skip
         Given the gptransfer test is initialized
         And the user runs "psql -p $GPTRANSFER_DEST_PORT -h $GPTRANSFER_DEST_HOST -U $GPTRANSFER_DEST_USER -f test/behave/mgmt_utils/steps/data/gptransfer_setup.sql -d template1"
         And the user runs "gptransfer --full --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --skip-existing --batch-size=10"
         Then gptransfer should return a return code of 2
 
-    @T339917
     Scenario: gptransfer full with truncate
         Given the gptransfer test is initialized
         And the user runs "psql -p $GPTRANSFER_DEST_PORT -h $GPTRANSFER_DEST_HOST -U $GPTRANSFER_DEST_USER -f test/behave/mgmt_utils/steps/data/gptransfer_setup.sql -d template1"
         And the user runs "gptransfer --full --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --truncate --batch-size=10"
         Then gptransfer should return a return code of 2
 
-    @T339947
     Scenario: gptransfer single table with drop
         Given the gptransfer test is initialized
         And the user runs "psql -p $GPTRANSFER_DEST_PORT -h $GPTRANSFER_DEST_HOST -U $GPTRANSFER_DEST_USER -f test/behave/mgmt_utils/steps/data/gptransfer_setup.sql -d template1"
@@ -143,7 +131,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 0
         And verify that table "t0" in "gptransfer_testdb1" has "100" rows
 
-    @T506755
     Scenario: gptransfer invisible delimiter
         Given the gptransfer test is initialized
         And the user runs "psql -p $GPTRANSFER_DEST_PORT -h $GPTRANSFER_DEST_HOST -U $GPTRANSFER_DEST_USER -f test/behave/mgmt_utils/steps/data/gptransfer_setup.sql -d template1"
@@ -151,28 +138,24 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 0
         And verify that table "t0" in "gptransfer_testdb1" has "100" rows
 
-    @T886744
     Scenario: gptransfer -T exclude with --full
         Given the gptransfer test is initialized
         And the user runs "gptransfer --full -T 'non_existdb.public./.?/1' --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE -a --batch-size=10"
         Then gptransfer should return a return code of 2
         And gptransfer should print "Cannot specify -T and --full options together" to stdout
 
-    @T886745
     Scenario: gptransfer -F exclude with --full
         Given the gptransfer test is initialized
         And the user runs "gptransfer --full -F test/behave/mgmt_utils/steps/data/gptransfer_wildcard_infile --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE -a --batch-size=10"
         Then gptransfer should return a return code of 2
         And gptransfer should print "Cannot specify -F and --full options together" to stdout
 
-    @T886746
     Scenario: gptransfer -T exclude non exist objects
         Given the gptransfer test is initialized
         And the user runs "gptransfer -d gptransfer_testdb1 -T 'non_existdb.public./.?/1' -T 'gptransfer_testdb1.public.non_exist_table' --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE -a --batch-size=10"
         Then gptransfer should return a return code of 0
         And gptransfer should print "Found no tables to exclude from transfer table list" to stdout
 
-    @T886747
     Scenario: gptransfer -T table level wildcard
         Given the gptransfer test is initialized
         And the user runs "gptransfer -d gptransfer_testdb1 -T 'gptransfer_testdb1.public./.?/1' -T 'gptransfer_testdb1.public./.*/0' --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE -a --batch-size=10"
@@ -181,7 +164,6 @@ Feature: gptransfer tests
         And verify that there is no table "t1" in "gptransfer_testdb1"
         And verify that table "t2" in "gptransfer_testdb1" has "300" rows
 
-    @T886749
     Scenario: gptransfer -T schema level wildcard
         Given the gptransfer test is initialized
         And the user runs "gptransfer -d gptransfer_testdb1 -T 'gptransfer_testdb1.pu/.?/lic.t1' -T 'gptransfer_testdb1.pub/.*/.t0' --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE -a --batch-size=10"
@@ -193,7 +175,6 @@ Feature: gptransfer tests
         And verify that there is no table "s1.t0" in "gptransfer_testdb3"
         And verify that there is no table "s2.t0" in "gptransfer_testdb3"
 
-    @T886750
     Scenario: gptransfer -T database level wildcard
         Given the gptransfer test is initialized
         And the user runs "gptransfer -d gptransfer_testdb1 -T 'gptransfer_testdb1/|/gptransfer_testdb3.public.t0' -T '/.?/ptransfer_testdb1.public.t1' --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE -a --batch-size=10"
@@ -202,7 +183,6 @@ Feature: gptransfer tests
         And verify that there is no table "t1" in "gptransfer_testdb1"
         And verify that table "t2" in "gptransfer_testdb1" has "300" rows
 
-    @T506747
     Scenario: gptransfer -t table level wildcard
         Given the gptransfer test is initialized
         And the user runs "gptransfer -t 'gptransfer_testdb1.public./.*/0' --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE -a --batch-size=10"
@@ -215,7 +195,6 @@ Feature: gptransfer tests
         And verify that table "t2" in "gptransfer_testdb1" has "300" rows
         And verify that table "t0" in "gptransfer_testdb3" has "700" rows
 
-    @T506749
     Scenario: gptransfer -t schema level wildcard
         Given the gptransfer test is initialized
         And the user runs "gptransfer -t 'gptransfer_testdb1.pub/.*/.t0' --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE -a --batch-size=10"
@@ -229,7 +208,6 @@ Feature: gptransfer tests
         And verify that table "s1.t0" in "gptransfer_testdb3" has "800" rows
         And verify that table "s2.t0" in "gptransfer_testdb3" has "900" rows
 
-    @T506750
     Scenario: gptransfer -t database level wildcard
         Given the gptransfer test is initialized
         And the user runs "gptransfer -t 'gptransfer_testdb1/|/gptransfer_testdb3.public.t0' --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE -a --batch-size=10"
@@ -245,7 +223,6 @@ Feature: gptransfer tests
         And verify that table "s1.t0" in "gptransfer_testdb3" has "800" rows
         And verify that table "s2.t0" in "gptransfer_testdb3" has "900" rows
 
-    @T339948
     Scenario: gptransfer single table with skip
         Given the gptransfer test is initialized
         And the user runs "psql -p $GPTRANSFER_DEST_PORT -h $GPTRANSFER_DEST_HOST -U $GPTRANSFER_DEST_USER -f test/behave/mgmt_utils/steps/data/gptransfer_setup.sql -d template1"
@@ -253,7 +230,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 0
         And gptransfer should print "Found no tables to transfer" to stdout
 
-    @T339949
     Scenario: gptransfer single table with truncate
         Given the gptransfer test is initialized
         And the user runs "psql -p $GPTRANSFER_DEST_PORT -h $GPTRANSFER_DEST_HOST -U $GPTRANSFER_DEST_USER -f test/behave/mgmt_utils/steps/data/gptransfer_setup.sql -d template1"
@@ -261,8 +237,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 0
         And verify that table "t0" in "gptransfer_testdb1" has "100" rows
 
-    @T339842
-    @T339950
     Scenario: gptransfer single database with md5 validation
         Given the gptransfer test is initialized
         And the user runs "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -c "CREATE TABLE my_random_dist_table(i int) DISTRIBUTED RANDOMLY;" -d gptransfer_testdb1"
@@ -275,14 +249,12 @@ Feature: gptransfer tests
         Then psql should print "Distributed randomly" to stdout 1 times
         And the user runs "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -c "DROP TABLE my_random_dist_table;" -d gptransfer_testdb1"
 
-    @T339951
     Scenario: gptransfer single table with md5 validation
         Given the gptransfer test is initialized
         And the user runs "gptransfer -t gptransfer_testdb1.public.t0 --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --validate md5 --batch-size=10"
         Then gptransfer should return a return code of 0
         And verify that table "t0" in "gptransfer_testdb1" has "100" rows
 
-    @T339952
     Scenario: gptransfer input file with md5 validation
         Given the gptransfer test is initialized
         And the user runs "gptransfer --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --validate md5 -f test/behave/mgmt_utils/steps/data/gptransfer_infile --batch-size=1"
@@ -304,7 +276,6 @@ Feature: gptransfer tests
         Then psql should print "Distributed randomly" to stdout 1 times
         And the user runs "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -c "DROP TABLE my_random_dist_table;" -d gptransfer_testdb1"
 
-    @T339951
     @skip_source_43
     Scenario: gptransfer single table with sha256 validation
         Given the gptransfer test is initialized
@@ -312,7 +283,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 0
         And verify that table "t0" in "gptransfer_testdb1" has "100" rows
 
-    @T339952
     @skip_source_43
     Scenario: gptransfer input file with sha256 validation
         Given the gptransfer test is initialized
@@ -322,7 +292,6 @@ Feature: gptransfer tests
         And verify that table "t0" in "gptransfer_testdb1" has "100" rows
         And verify that table "t0" in "gptransfer_testdb3" has "700" rows
 
-    @T886748
     Scenario: gptransfer -F exclude input file
         Given the gptransfer test is initialized
         And the user runs "gptransfer -d gptransfer_testdb1 -d gptransfer_testdb3 --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --validate md5 -F test/behave/mgmt_utils/steps/data/gptransfer_wildcard_infile --batch-size=10"
@@ -330,15 +299,12 @@ Feature: gptransfer tests
         And verify that database "gptransfer_testdb1" does not exist
         And verify that database "gptransfer_testdb3" does not exist
 
-    @T339953
     Scenario: gptransfer input file to destination database with conflict
         Given the gptransfer test is initialized
         And the user runs "gptransfer --dest-database gptransfer_destdb --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --validate md5 -f test/behave/mgmt_utils/steps/data/gptransfer_infile --batch-size=10"
         Then gptransfer should return a return code of 2
         And gptransfer should print "Multiple tables map to gptransfer_destdb.public.t0.  Remove one of the tables from the list or do not use the --dest-database option." to stdout
 
-    @T339897
-    @T339918
     Scenario: gptransfer multiple databases to single destination database
         Given the gptransfer test is initialized
         And the user runs "gptransfer -d gptransfer_testdb1 -d gptransfer_testdb4 --dest-database gptransfer_destdb --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --validate md5 --batch-size=10"
@@ -349,21 +315,18 @@ Feature: gptransfer tests
         And verify that table "empty_table" in "gptransfer_destdb" has "0" rows
         And verify that table "one_row_table" in "gptransfer_destdb" has "1" rows
 
-    @T339919
     Scenario: gptransfer multiple databases to single destination database with conflict
         Given the gptransfer test is initialized
         And the user runs "gptransfer -d gptransfer_testdb1 -d gptransfer_testdb3 --dest-database gptransfer_destdb --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --validate md5 --batch-size=10"
         Then gptransfer should return a return code of 2
         And gptransfer should print "Multiple tables map to gptransfer_destdb.public.t0.  Remove one of the tables from the list or do not use the --dest-database option." to stdout
 
-    @T339920
     Scenario: gptransfer multiple tables to single destination database with conflict
         Given the gptransfer test is initialized
         And the user runs "gptransfer -t gptransfer_testdb1.public.t0 -t gptransfer_testdb3.public.t0 --dest-database gptransfer_destdb --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --validate md5 --batch-size=10"
         Then gptransfer should return a return code of 2
         And gptransfer should print "Multiple tables map to gptransfer_destdb.public.t0.  Remove one of the tables from the list or do not use the --dest-database option." to stdout
 
-    @T339955
     Scenario: gptransfer database where source database does not exist
         Given the gptransfer test is initialized
         And the user runs "gptransfer -d bad_db --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --batch-size=10"
@@ -371,15 +334,12 @@ Feature: gptransfer tests
         And gptransfer should print "Find no user databases matching "bad_db" in source system" to stdout
         And gptransfer should print "Found no tables to transfer" to stdout
 
-    @T339956
     Scenario: gptransfer database where source table does not exist
         Given the gptransfer test is initialized
         And the user runs "gptransfer -t gptransfer_testdb1.public.bad_table --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --batch-size=10"
         Then gptransfer should return a return code of 0
         And gptransfer should print "Found no tables to transfer" to stdout
 
-    @T339851
-    @T339957
     Scenario: gptransfer single table with analyze
         Given the gptransfer test is initialized
         And the user runs "gptransfer -t gptransfer_testdb1.public.t0 --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --analyze --batch-size=10"
@@ -387,7 +347,6 @@ Feature: gptransfer tests
         And gptransfer should print "Analyzing destination table" to stdout
         And verify that table "t0" in "gptransfer_testdb1" has "100" rows
 
-    @T339958
     Scenario: gptransfer single table with exclusive lock
         Given the gptransfer test is initialized
         And the user runs "gptransfer -t gptransfer_testdb1.public.t0 --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE -x --batch-size=10"
@@ -395,9 +354,6 @@ Feature: gptransfer tests
         And gptransfer should print "Exclusive locks will be used during table transfers" to stdout
         And verify that table "t0" in "gptransfer_testdb1" has "100" rows
 
-    @T339895
-    @T339959
-    @T339921
     Scenario: gptransfer single table to different database on same system
         Given the gptransfer test is initialized
         And the user runs "psql -p $GPTRANSFER_DEST_PORT -h $GPTRANSFER_DEST_HOST -U $GPTRANSFER_DEST_USER -f test/behave/mgmt_utils/steps/data/gptransfer_setup.sql -d template1"
@@ -405,7 +361,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 0
         And verify that table "t0" in "gptransfer_destdb" has "100" rows
 
-    @T339960
     Scenario: gptransfer single table with bad fqn
         Given the gptransfer test is initialized
         And the user runs "gptransfer -t gptransfer_testdb1.t0 --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --batch-size=10"
@@ -414,7 +369,6 @@ Feature: gptransfer tests
 
     # this test creates an incomplete map file by *removing* the first line from the source map file.
     # If you have only 1 segment, you will be left with an empty hosts map, and this test will fail
-    @T339837
     Scenario: gptransfer incomplete map file
         Given the gptransfer test is initialized
         And an incomplete map file is created
@@ -422,7 +376,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "missing from map file" to stdout
 
-    @T339840
     Scenario: gptransfer invalid work-base-dir
         Given the gptransfer test is initialized
         And an incomplete map file is created
@@ -430,7 +383,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "Permission denied" to stdout
 
-    @T339841
     Scenario: gptransfer with dependent database object
         Given the gptransfer test is initialized
         And there is a table "dependent_table" dependent on function "test_function" in database "gptransfer_testdb1" on the source system
@@ -439,8 +391,6 @@ Feature: gptransfer tests
         And verify that function "test_function" exists in database "gptransfer_testdb1"
         And the user runs "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -c 'drop table dependent_table; drop function test_function(int);' -d gptransfer_testdb1"
 
-    @T339838
-    @T339961
     Scenario: gptransfer bad map file
         Given the gptransfer test is initialized
         And the user runs "gptransfer -t gptransfer_testdb1.public.t0 --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file test/behave/mgmt_utils/steps/data/gptransfer_bad_map_file --batch-size=10"
@@ -476,50 +426,42 @@ Feature: gptransfer tests
         And gptransfer should print "Found unsupported identifiers" to stdout
         And the user runs "dropdb -U $GPTRANSFER_SOURCE_USER -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST Bad*\$#@DB"
 
-    @T339962
     Scenario: gptransfer should not allow --full and --dest-database option
         Given the gptransfer test is initialized
         And the user runs "gptransfer --full --dest-database gptransferdestdb --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --batch-size=10"
         Then gptransfer should return a return code of 2
         And gptransfer should print "--dest-database option cannot be used with the --full option" to stdout
 
-    @T339857
-    @T339963
     Scenario: gptransfer should not allow --batch-size > 10
         Given the gptransfer test is initialized
         And the user runs "gptransfer --full --batch-size 11 --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE"
         Then gptransfer should return a return code of 2
         And gptransfer should print "Invalid value for --batch-size.  --batch-size must be greater than 0 and less than 10" to stdout
 
-    @T339856
     Scenario: gptransfer should not allow --batch-size < 1
         Given the gptransfer test is initialized
         And the user runs "gptransfer --full --batch-size 0 --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE"
         Then gptransfer should return a return code of 2
         And gptransfer should print "Invalid value for --batch-size.  --batch-size must be greater than 0 and less than 10" to stdout
 
-    @T339967
     Scenario: gptransfer should not allow --truncate and --skip-existing
         Given the gptransfer test is initialized
         And the user runs "gptransfer -d gptransfer_testdb1 --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --truncate --skip-existing --batch-size=10"
         Then gptransfer should return a return code of 2
         And gptransfer should print "Cannot specify --truncate and --skip-existing together" to stdout
 
-    @T339968
     Scenario: gptransfer should not allow --truncate and --drop
         Given the gptransfer test is initialized
         And the user runs "gptransfer -d gptransfer_testdb1 --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --truncate --drop --batch-size=10"
         Then gptransfer should return a return code of 2
         And gptransfer should print "Cannot specify --truncate and --drop together" to stdout
 
-    @T339969
     Scenario: gptransfer should not allow --drop and --skip-existing
         Given the gptransfer test is initialized
         And the user runs "gptransfer -d gptransfer_testdb1 --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --drop --skip-existing --batch-size=10"
         Then gptransfer should return a return code of 2
         And gptransfer should print "Cannot specify --drop and --skip-existing together" to stdout
 
-    @T99999999
     Scenario: gptransfer should not allow --full, -f, -t, or -d to be called together
         Given the gptransfer test is initialized
         And the user runs "gptransfer -d gptransfer_testdb1 -t gptransfer_testdb1.public.temp_table --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --validate=md5 --batch-size=10"
@@ -538,7 +480,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "Only one of --full, -f, -t, or -d can be specified" to stdout
 
-    @T339970
     Scenario: gptransfer missing one of --full, -f, -t or -d
         Given the gptransfer test is initialized
         And the user runs "gptransfer --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --batch-size=10"
@@ -557,8 +498,6 @@ Feature: gptransfer tests
         And the user runs "gptransfer -a -t gptransfer_testdb1.public.t0 --source-port --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --batch-size=10"
         Then gptransfer should return a return code of 2
 
-    @T339844
-    @T339896
     Scenario:   gptransfer with -f options without --skip-existing, --truncate, or --drop option when dest system already has some of the tables
         Given the gptransfer test is initialized
         And the user runs "createdb -U $GPTRANSFER_DEST_USER -p $GPTRANSFER_DEST_PORT -h $GPTRANSFER_DEST_HOST gptransfer_testdb1"
@@ -567,7 +506,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "Table gptransfer_testdb1.public.t0 exists in database gptransfer_testdb1" to stdout
 
-    @T339845
     Scenario: gptransfer with -t without --skip-existing, --truncate, or --drop option when dest system already has the table
         Given the gptransfer test is initialized
         And the user runs "createdb -U $GPTRANSFER_DEST_USER -p $GPTRANSFER_DEST_PORT -h $GPTRANSFER_DEST_HOST gptransfer_testdb1"
@@ -576,7 +514,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "Table gptransfer_testdb1.public.t0 exists in database gptransfer_testdb1" to stdout
 
-    @T339849
     Scenario: gptransfer with -a
         Given the gptransfer test is initialized
         And the user runs "createdb -U $GPTRANSFER_DEST_USER -p $GPTRANSFER_DEST_PORT -h $GPTRANSFER_DEST_HOST gptransfer_testdb1"
@@ -585,14 +522,12 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 0
         And gptransfer should not print "Do you want to continue? Yy|Nn" to stdout
 
-    @T339852
     Scenario: gptransfer using default port 8000
         Given the gptransfer test is initialized
         And the user runs "gptransfer -t gptransfer_testdb1.public.t0 --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE -v --batch-size=10"
         Then gptransfer should return a return code of 0
         And gptransfer should print "gptransfer_testdb1.public.t0 -p 8000" to stdout
 
-    @T339853
     Scenario: gptransfer using already-occupied port
         Given the gptransfer test is initialized
         And the gpfdists occupying port 21100 on host "GPTRANSFER_MAP_FILE"
@@ -600,7 +535,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 0
         And the gpfdists running on port 21100 get cleaned up from host "GPTRANSFER_MAP_FILE"
 
-    @T339854
     Scenario: gptransfer with batch-size of 2
         Given the gptransfer test is initialized
         When the user runs the command "test/behave/mgmt_utils/steps/scripts/test_gptransfer_batch_size.sh /tmp/batch_size" in the background
@@ -611,7 +545,6 @@ Feature: gptransfer tests
         And gptransfer should print "Using batch size of 2" to stdout
         And the user runs "kill -9 `ps aux | grep test_gptransfer_batch_size.sh | awk '{print $2}'`"
 
-    @T339903
     Scenario:  gptransfer with --dry-run
         Given the gptransfer test is initialized
         And the user runs "createdb -U $GPTRANSFER_DEST_USER -p $GPTRANSFER_DEST_PORT -h $GPTRANSFER_DEST_HOST gptransfer_testdb1"
@@ -620,14 +553,12 @@ Feature: gptransfer tests
         And gptransfer should print "The following tables will be transfered:" to stdout
         And verify that there is no table "public.t0" in "gptransfer_testdb1"
 
-    @T339904
     Scenario:   gptransfer with -f options, source system does not have tables, should error out for them
         Given the gptransfer test is initialized
         And the user runs "gptransfer -f test/behave/mgmt_utils/steps/data/gptransfer_bad_infile --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --batch-size=10"
         Then gptransfer should return a return code of 0
         And gptransfer should print "Found no tables to transfer" to stdout
 
-    @T339850
     Scenario:   gptransfer --analyze option, do not specify as by default
         Given the gptransfer test is initialized
         And the user runs "gptransfer -t gptransfer_testdb1.public.t0 --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --batch-size=10"
@@ -635,7 +566,6 @@ Feature: gptransfer tests
         And verify that table "t0" in "gptransfer_testdb1" has "100" rows
         And gptransfer should not print "Analyzing destination table gptransfer_testdb1.public.t0" to stdout
 
-    @T339859
     Scenario:  gptransfer -d, dest system already has the database
         Given the gptransfer test is initialized
         And the user runs "createdb -U $GPTRANSFER_DEST_USER -p $GPTRANSFER_DEST_PORT -h $GPTRANSFER_DEST_HOST gptransfer_testdb1"
@@ -645,14 +575,12 @@ Feature: gptransfer tests
         And verify that table "t1" in "gptransfer_testdb1" has "200" rows
         And verify that table "t2" in "gptransfer_testdb1" has "300" rows
 
-    @T339899
     Scenario:   gptransfer --dest-database option not specified within the same system, should error out
         Given the gptransfer test is initialized
         And the user runs "gptransfer -d gptransfer_testdb1 --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_SOURCE_USER --dest-port $GPTRANSFER_SOURCE_PORT --dest-host $GPTRANSFER_SOURCE_HOST --source-map-file $GPTRANSFER_MAP_FILE --batch-size=10"
         Then gptransfer should return a return code of 2
         And gptransfer should print "Source and destination systems cannot be the same unless --dest-database or --partition-transfer option is set" to stdout
 
-    @T339900
     Scenario:  gptransfer --dest-database option specified to a different name within the same system, should succeed
         Given the gptransfer test is initialized
         And the user runs "gptransfer -d gptransfer_testdb1 --dest-database gptransfer_destdb --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_SOURCE_USER --dest-port $GPTRANSFER_SOURCE_PORT --dest-host $GPTRANSFER_SOURCE_HOST --source-map-file $GPTRANSFER_MAP_FILE --batch-size=10"
@@ -660,7 +588,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 0
         And psql should print "{100,200,300}" to stdout
 
-    @T339886
     Scenario:   gptransfer -x, test the lock from source system
         Given the database is running
         And the database "gptransfer_destdb" does not exist
@@ -672,25 +599,21 @@ Feature: gptransfer tests
         And the user runs "psql -U $GPTRANSFER_SOURCE_USER -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -c 'INSERT INTO tlock_test SELECT generate_series FROM generate_series(1,100), pg_sleep(120)' gptransfer_testdb1 & gptransfer -x -t gptransfer_testdb1.public.tlock_test --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE"
         Then verify that table "tlock_test" in "gptransfer_testdb1" has "100" rows
 
-    @T339902
     Scenario: gptransfer within the same system with --dest-host not specified
         Given the gptransfer test is initialized
         And the user runs "gptransfer --full --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --source-map-file $GPTRANSFER_MAP_FILE --batch-size=10"
         Then gptransfer should return a return code of 0
 
-    @T339861
     Scenario: gptransfer with --dest-port not specified
         Given the gptransfer test is initialized
         And the user runs "gptransfer --full --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --batch-size=10"
         Then gptransfer should return a return code of 0
 
-    @T339863
     Scenario: gptransfer with --dest-user not specified to use default system user
         Given the gptransfer test is initialized
         And the user runs "gptransfer --full --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --batch-size=10"
         Then gptransfer should return a return code of 0
 
-    @T432109
     Scenario: gptransfer --full with user database exist in destination system
         Given the gptransfer test is initialized
         And database "gptransfer_destdb" exists
@@ -698,33 +621,28 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "--full option specified but databases exist in destination system" to stdout
 
-    @T339864
     Scenario: gptransfer with --dest-user root
         Given the gptransfer test is initialized
         And the user runs "gptransfer --full --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user root --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --batch-size=10"
         Then gptransfer should return a return code of 2
 
-    @T339865
     Scenario: gptransfer with log in ~/gpAdminLogs
         Given the gptransfer test is initialized
         And the user runs "gptransfer --full --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --batch-size=10"
         Then gptransfer should return a return code of 0
         And verify that a log was created by gptransfer in the user's "gpAdminLogs" directory
 
-    @T339866
     Scenario: gptransfer with log in /tmp
         Given the gptransfer test is initialized
         And the user runs "gptransfer --full --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE -l /tmp --batch-size=10"
         Then gptransfer should return a return code of 0
         And verify that a log was created by gptransfer in the "/tmp" directory
 
-    @T339867
     Scenario: gptransfer with log in nonexistent directory
         Given the gptransfer test is initialized
         And the user runs "gptransfer --full --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE -l ~/gpAdminLogs/gpAdminLogs --batch-size=10"
         Then gptransfer should return a return code of 0
 
-    @T339872
     Scenario: gptransfer --schema-only
         Given the gptransfer test is initialized
         And database "gptransfer_testdb1" exists
@@ -733,14 +651,12 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 0
         And verify that the schema "test_schema" exists in "gptransfer_testdb1"
 
-    @T339908
     Scenario: gptransfer --schema-only conflicts with --truncate
         Given the gptransfer test is initialized
         And the user runs "gptransfer --schema-only -t gptransfer_testdb1.public.t0 --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --truncate --batch-size=10"
         Then gptransfer should return a return code of 2
         And gptransfer should print "Cannot specify --schema-only and --truncate together" to stdout
 
-    @T339907
     Scenario: gptransfer -q
         Given the gptransfer test is initialized
         And the user runs "gptransfer -t gptransfer_testdb1.public.t0 -q --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --batch-size=10"
@@ -748,49 +664,42 @@ Feature: gptransfer tests
         And gptransfer should not print "Transfering" to stdout
         And verify that a log was created by gptransfer in the user's "gpAdminLogs" directory
 
-    @T339873
     Scenario: gptransfer --skip-existing conflicts with --full
         Given the gptransfer test is initialized
         And the user runs "gptransfer --skip-existing --full --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --batch-size=10"
         Then gptransfer should return a return code of 2
         And gptransfer should print "Cannot specify --drop, --truncate or --skip-existing with --full option" to stdout
 
-    @T339877
     Scenario: gptransfer with default source user
         Given the gptransfer test is initialized
         And the user runs "gptransfer -t gptransfer_testdb1.public.t0 --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --batch-size=10"
         Then gptransfer should return a return code of 0
         And verify that there is a "heap" table "public.t0" in "gptransfer_testdb1"
 
-    @T339878
     Scenario: gptransfer with parallelism 25
         Given the gptransfer test is initialized
         And the user runs "gptransfer -t gptransfer_testdb1.public.t0 --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --enable-test "
         Then gptransfer should return a return code of 0
         And gptransfer should print "Using sub-batch size of 25" to stdout
 
-    @T339879
     Scenario: gptransfer with parallelism 10
         Given the gptransfer test is initialized
         And the user runs "gptransfer -t gptransfer_testdb1.public.t0 --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE -v --sub-batch-size 10 --enable-test --batch-size=10"
         Then gptransfer should return a return code of 0
         And gptransfer should print "Using sub-batch size of 10" to stdout
 
-    @T339880
     Scenario: gptransfer with sub batch size too large
         Given the gptransfer test is initialized
         And the user runs "gptransfer -t gptransfer_testdb1.public.t0 --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --sub-batch-size 1000"
         Then gptransfer should return a return code of 2
         And gptransfer should print "Invalid value for --sub-batch-size.  Must be greater than 0 and less than 50" to stdout
 
-    @T339881
     Scenario: gptransfer with sub batch size too small
         Given the gptransfer test is initialized
         And the user runs "gptransfer -t gptransfer_testdb1.public.t0 --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --sub-batch-size 0 --batch-size=10"
         Then gptransfer should return a return code of 2
         And gptransfer should print "Invalid value for --sub-batch-size.  Must be greater than 0 and less than 50" to stdout
 
-    @T339882
     Scenario: gptransfer -t db.public.table where table does not exist in destination system
         Given the gptransfer test is initialized
         And database "gptransfer_testdb1" exists
@@ -799,28 +708,24 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 0
         And verify that there is a "heap" table "public.t0" in "gptransfer_testdb1"
 
-    @T339883
     Scenario: gptransfer -t db.schema.table where db does not exist in destination system
         Given the gptransfer test is initialized
         And the user runs "gptransfer -t gptransfer_testdb1.public.t0 --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE -a --batch-size=10"
         Then gptransfer should return a return code of 0
         And verify that there is a "heap" table "public.t0" in "gptransfer_testdb1"
 
-    @T339838
     Scenario: gptransfer invalid map file
         Given the gptransfer test is initialized
         And the user runs "gptransfer -t gptransfer_testdb1.public.t0 --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE -a --batch-size=10"
         Then gptransfer should return a return code of 0
         And verify that there is a "heap" table "public.t0" in "gptransfer_testdb1"
 
-    @T339911
     Scenario: gptransfer --verbose
         Given the gptransfer test is initialized
         And the user runs "gptransfer --full --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --verbose --batch-size=10"
         Then gptransfer should return a return code of 0
         And gptransfer should print "\[DEBUG\]" to stdout
 
-    @T439911
     Scenario: gptransfer full in CSV format with final count validation
         Given the gptransfer test is initialized
         And the user runs "gptransfer --full --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --format=csv > /tmp/gptransfer_stdout.txt --batch-size=10"
@@ -834,14 +739,12 @@ Feature: gptransfer tests
         And verify that table "one_row_table" in "gptransfer_testdb4" has "1" rows
         And verify that table "wide_rows" in "gptransfer_testdb5" has "10" rows
 
-    @T439912
     Scenario: gptransfer full with --no-final-count option
         Given the gptransfer test is initialized
         And the user runs "gptransfer --full --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --no-final-count > /tmp/gptransfer_stdout.txt --batch-size=10"
         Then gptransfer should return a return code of 0
         And verify that the file "/tmp/gptransfer_stdout.txt" does not contain "Running final table row count validation on destination tables"
 
-    @T339830
     Scenario: gptransfer full with all types of database objects created
         Given the gptransfer test is initialized
         And the user runs "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -f test/behave/mgmt_utils/steps/data/gptransfer/teardown.sql -d template1"
@@ -862,7 +765,6 @@ Feature: gptransfer tests
         And the user runs "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -f test/behave/mgmt_utils/steps/data/gptransfer/teardown.sql -d template1"
         And the user runs "psql -p $GPTRANSFER_DEST_PORT -h $GPTRANSFER_DEST_HOST -U $GPTRANSFER_DEST_USER -f test/behave/mgmt_utils/steps/data/gptransfer/teardown.sql -d template1"
 
-    @T339824
     Scenario: gptransfer full with all ddl, dml and filespace
         Given the gptransfer test is initialized
         And the user runs "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -f test/behave/mgmt_utils/steps/data/gptransfer/teardown.sql -d template1"
@@ -884,7 +786,6 @@ Feature: gptransfer tests
         And the user runs "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -f test/behave/mgmt_utils/steps/data/gptransfer/teardown.sql -d template1"
         And the user runs "psql -p $GPTRANSFER_DEST_PORT -h $GPTRANSFER_DEST_HOST -U $GPTRANSFER_DEST_USER -f test/behave/mgmt_utils/steps/data/gptransfer/teardown.sql -d template1"
 
-    @T339821
     Scenario: gptransfer full in change tracking
         Given the gptransfer test is initialized
         And the user puts cluster on "GPTRANSFER_SOURCE_HOST" "GPTRANSFER_SOURCE_PORT" "GPTRANSFER_SOURCE_USER" in "ct"
@@ -892,7 +793,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 0
         And the user puts cluster on "GPTRANSFER_SOURCE_HOST" "GPTRANSFER_SOURCE_PORT" "GPTRANSFER_SOURCE_USER" in "sync"
 
-    @T339821
     Scenario: gptransfer in resync
         Given the gptransfer test is initialized
         And the user puts cluster on "GPTRANSFER_SOURCE_HOST" "GPTRANSFER_SOURCE_PORT" "GPTRANSFER_SOURCE_USER" in "resync"
@@ -900,7 +800,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 0
         And the user puts cluster on "GPTRANSFER_SOURCE_HOST" "GPTRANSFER_SOURCE_PORT" "GPTRANSFER_SOURCE_USER" in "sync"
 
-    @T439821
     Scenario: gptransfer filespace exists test with --full -t and -d options
         Given the gptransfer test is initialized
         And the user "GPTRANSFER_SOURCE_USER" creates filespace_config file for "fs" on host "GPTRANSFER_SOURCE_HOST" with gpdb port "GPTRANSFER_SOURCE_PORT" and config "gpfilespace_config_src" in "HOME" directory
@@ -919,7 +818,6 @@ Feature: gptransfer tests
         And the user runs "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -f test/behave/mgmt_utils/steps/data/gptransfer/filespace_exists_test_teardown.sql -d template1"
         And psql should return a return code of 0
 
-    @T339870
     Scenario: gptransfer with max-line-length of 16KB
         Given the gptransfer test is initialized
         And a table is created containing rows of length "16384" with connection "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -d gptransfer_testdb5"
@@ -990,8 +888,6 @@ Feature: gptransfer tests
        And verify that the file "/tmp/gptransfer_stdout.txt" contains "Removing existing gptransfer schema on source system"
        And verify that the file "/tmp/gptransfer_stdout.txt" contains "Removing existing gptransfer schema on destination system"
 
-    @partition_transfer
-    @prt_transfer_1
     Scenario: gptransfer leaf partition -> leaf partition basic transfer
         Given the gptransfer test is initialized
         And database "gptest" exists
@@ -1004,8 +900,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 0
         And verify that table "public.employee_1_prt_1" in database "gptest" of source system has same data with table "public.employee_1_prt_1" in database "gptest" of destination system with options "-q"
 
-    @partition_transfer
-    @prt_transfer_2
     Scenario: gptransfer leaf partition -> root partition
         Given the gptransfer test is initialized
         And database "gptest" exists
@@ -1017,8 +911,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "Destination table gptest.public.employee is not a leaf partition table" to stdout
 
-    @partition_transfer
-    @prt_transfer_3
     Scenario: gptransfer leaf partition -> sub partition
         Given the gptransfer test is initialized
         And database "gptest" exists
@@ -1030,8 +922,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "Destination table gptest.public.sales_1_prt_2 is not a leaf partition table" to stdout
 
-    @partition_transfer
-    @prt_transfer_4
     Scenario: gptransfer sub partition -> sub partition
         Given the gptransfer test is initialized
         And database "gptest" exists
@@ -1043,8 +933,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "Source table gptest.public.sales_1_prt_2 is not a leaf partition table" to stdout
 
-    @partition_transfer
-    @prt_transfer_5
     Scenario: gptransfer root partition -> leaf partition
         Given the gptransfer test is initialized
         And database "gptest" exists
@@ -1056,8 +944,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "Source table gptest.public.employee is not a leaf partition table" to stdout
 
-    @partition_transfer
-    @prt_transfer_6
     Scenario: gptransfer sub partition -> leaf partition
         Given the gptransfer test is initialized
         And database "gptest" exists
@@ -1069,8 +955,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "Source table gptest.public.sales_1_prt_2 is not a leaf partition table" to stdout
 
-    @partition_transfer
-    @prt_transfer_7
     Scenario: gptransfer leaf partition -> non exist db
         Given the gptransfer test is initialized
         And database "gptest" is created if not exists on host "GPTRANSFER_SOURCE_HOST" with port "GPTRANSFER_SOURCE_PORT" with user "GPTRANSFER_SOURCE_USER"
@@ -1080,8 +964,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "Table gptest.public.sales_1_prt_p1_2_prt_1 does not exist in destination database when transferring from partition tables" to stdout
 
-    @partition_transfer
-    @prt_transfer_8
     Scenario: gptransfer leaf partition -> non exist schema
         Given the gptransfer test is initialized
         And database "gptest" exists
@@ -1092,8 +974,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "Table gptest.nonexist_schema.sales_1_prt_p1_2_prt_1 does not exist in destination database when transferring from partition tables" to stdout
 
-    @partition_transfer
-    @prt_transfer_9
     Scenario: gptransfer leaf partition -> non exist table
         Given the gptransfer test is initialized
         And database "gptest" exists
@@ -1104,8 +984,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "Table gptest.public.nonexist_table does not exist in destination database when transferring from partition tables" to stdout
 
-    @partition_transfer
-    @prt_transfer_10
     Scenario: gptransfer non exist db -> leaf partition
         Given the gptransfer test is initialized
         And the database "nongptest" does not exist on host "GPTRANSFER_SOURCE_HOST" with port "GPTRANSFER_SOURCE_PORT" with user "GPTRANSFER_SOURCE_USER"
@@ -1116,8 +994,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "FATAL:  database "nongptest" does not exist" to stdout
 
-    @partition_transfer
-    @prt_transfer_11
     Scenario: gptransfer non exist schema -> leaf partition
         Given the gptransfer test is initialized
         And database "gptest" exists
@@ -1128,8 +1004,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 0
         And gptransfer should print "Found no tables to transfer" to stdout
 
-    @partition_transfer
-    @prt_transfer_12
     Scenario: gptransfer non exist table -> leaf partition
         Given the gptransfer test is initialized
         And database "gptest" exists
@@ -1140,8 +1014,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 0
         And gptransfer should print "Found no tables to transfer" to stdout
 
-    @partition_transfer
-    @prt_transfer_13
     Scenario: gptransfer list partition -> range partition
         Given the gptransfer test is initialized
         And database "gptest" exists
@@ -1153,8 +1025,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "Partition type is different" to stdout
 
-    @partition_transfer
-    @prt_transfer_14
     Scenario: gptransfer one level leaf partition -> zero level leaf partition
         Given the gptransfer test is initialized
         And database "gptest" exists
@@ -1166,8 +1036,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "Max level of partition is not same" to stdout
 
-    @partition_transfer
-    @prt_transfer_15
     Scenario: gptransfer leaf partition, more columns table -> less columns table
         Given the gptransfer test is initialized
         And database "gptest" exists
@@ -1179,8 +1047,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "has different column layout or types" to stdout
 
-    @partition_transfer
-    @prt_transfer_16
     Scenario: gptransfer leaf partition, same partition type using different column as partition key
         Given the gptransfer test is initialized
         And database "gptest" exists
@@ -1192,8 +1058,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "Partition column attributes are different" to stdout
 
-    @partition_transfer
-    @prt_transfer_17
     Scenario: gptransfer same leaf partition with different parent partition
         Given the gptransfer test is initialized
         And database "gptest" exists
@@ -1205,8 +1069,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "Partition column attributes are different" to stdout
 
-    @partition_transfer
-    @prt_transfer_18
     Scenario: gptransfer same leaf partition column key, with different partition value
         Given the gptransfer test is initialized
         And database "gptest" exists
@@ -1218,8 +1080,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "partition value is different" to stdout
 
-    @partition_transfer
-    @prt_transfer_19
     Scenario: gptransfer same leaf partition column key, with different parent partition value
         Given the gptransfer test is initialized
         And database "gptest" exists
@@ -1231,8 +1091,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "Partition column attributes are different" to stdout
 
-    @partition_transfer
-    @prt_transfer_20
     Scenario: gptransfer leaf partition, with different table and column name
         Given the gptransfer test is initialized
         And database "gptest" exists
@@ -1247,8 +1105,6 @@ Feature: gptransfer tests
         And verify that table "public.employee_1_prt_1" in database "gptest" of source system has same data with table "public.e_employee_1_prt_1" in database "gptest" of destination system with options "-t"
         And verify that table "public.e_employee_1_prt_1" in database "gptest" of source system has same data with table "public.employee_1_prt_1" in database "gptest" of destination system with options "-t"
 
-    @partition_transfer
-    @prt_transfer_21
     Scenario: gptransfer normal heap table to a leaf partition
         Given the gptransfer test is initialized
         And database "gptest" exists
@@ -1260,8 +1116,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "Source table gptest.public.heap_employee is not a leaf partition table" to stdout
 
-    @partition_transfer
-    @prt_transfer_22
     Scenario: gptransfer ao partition table to co partition table
         Given the gptransfer test is initialized
         And database "gptest" exists
@@ -1274,8 +1128,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 0
         And verify that table "public.employee_1_prt_other" in database "gptest" of source system has same data with table "public.employee_1_prt_other" in database "gptest" of destination system with options "-t"
 
-    @partition_transfer
-    @prt_transfer_23
     Scenario: gptransfer with --truncate option
         Given the gptransfer test is initialized
         And database "gptest" exists
@@ -1289,8 +1141,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 0
         And verify that table "public.employee_1_prt_boys" in database "gptest" of source system has same data with table "public.employee_1_prt_boys" in database "gptest" of destination system with options "-t"
 
-    @partition_transfer
-    @prt_transfer_24
     Scenario: gptransfer with --skip-existing option
         Given the gptransfer test is initialized
         And database "gptest" exists
@@ -1303,8 +1153,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 0
         And verify that table "public.employee_1_prt_boys" in "gptest" has "1" rows
 
-    @partition_transfer
-    @prt_transfer_25
     Scenario: gptransfer, multi columns partition key to single column partition key
         Given the gptransfer test is initialized
         And database "gptest" exists
@@ -1316,8 +1164,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "Number of partition columns is different" to stdout
 
-    @partition_transfer
-    @prt_transfer_26
     Scenario: gptransfer, with multi columns partition key reversed between source and destination
         Given the gptransfer test is initialized
         And database "gptest" exists
@@ -1328,8 +1174,6 @@ Feature: gptransfer tests
         When the user runs "gptransfer -f input_file --partition-transfer --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE -a --batch-size=10"
         Then gptransfer should return a return code of 0
 
-    @partition_transfer
-    @prt_transfer_27
     Scenario: gptransfer, --partition-transfer can not be used with --full option
         Given the gptransfer test is initialized
         And there is a file "input_file" with tables "gptest.public.tbl, gptest.public.tbl"
@@ -1337,8 +1181,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "--partition-transfer option cannot be used with --full option" to stdout
 
-    @partition_transfer
-    @prt_transfer_28
     Scenario: gptransfer, --partition-transfer can not be used with -d option
         Given the gptransfer test is initialized
         And there is a file "input_file" with tables "gptest.public.tbl, gptest.public.tbl"
@@ -1346,8 +1188,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "--partition-transfer option cannot be used with -d option" to stdout
 
-    @partition_transfer
-    @prt_transfer_29
     Scenario: gptransfer, --partition-transfer can not be used with --drop option
         Given the gptransfer test is initialized
         And there is a file "input_file" with tables "gptest.public.tbl, gptest.public.tbl"
@@ -1355,8 +1195,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "--partition-transfer option cannot be used with --drop option" to stdout
 
-    @partition_transfer
-    @prt_transfer_30
     Scenario: gptransfer, --partition-transfer can not be used with -t option
         Given the gptransfer test is initialized
         And there is a file "input_file" with tables "gptest.public.tbl, gptest.public.tbl"
@@ -1364,8 +1202,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "--partition-transfer option cannot be used with -t option" to stdout
 
-    @partition_transfer
-    @prt_transfer_31
     Scenario: gptransfer, --partition-transfer can not be used with --schema-only option
         Given the gptransfer test is initialized
         And there is a file "input_file" with tables "gptest.public.tbl, gptest.public.tbl"
@@ -1373,8 +1209,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "--partition-transfer option cannot be used with --schema-only option" to stdout
 
-    @partition_transfer
-    @prt_transfer_32
     Scenario: gptransfer, --partition-transfer can not be used with -T option
         Given the gptransfer test is initialized
         And there is a file "input_file" with tables "gptest.public.tbl, gptest.public.tbl"
@@ -1382,8 +1216,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "--partition-transfer option cannot be used with any exclude table option" to stdout
 
-    @partition_transfer
-    @prt_transfer_33
     Scenario: gptransfer, --partition-transfer can not be used with -F option
         Given the gptransfer test is initialized
         And there is a file "input_file" with tables "gptest.public.tbl, gptest.public.tbl"
@@ -1391,8 +1223,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "--partition-transfer option cannot be used with any exclude table option" to stdout
 
-    @partition_transfer
-    @prt_transfer_34
     Scenario: gptransfer with public schema to non public schema
         Given the gptransfer test is initialized
         And database "gptest" exists
@@ -1405,8 +1235,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 0
         And verify that table "schema1.employee_1_prt_boys" in "gptest" has "1" rows
 
-    @partition_transfer
-    @prt_transfer_35
     Scenario: gptransfer with non public schema to public schema
         Given the gptransfer test is initialized
         And database "gptest" exists
@@ -1419,8 +1247,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 0
         And verify that table "public.employee_1_prt_boys" in "gptest" has "1" rows
 
-    @partition_transfer
-    @prt_transfer_36
     Scenario: gptransfer gives warnings on duplicated entries
         Given the gptransfer test is initialized
         And database "gptest" exists
@@ -1434,8 +1260,6 @@ Feature: gptransfer tests
         And gptransfer should print "Duplicate entries found" to stdout
         And verify that table "public.employee_1_prt_boys" in "gptest" has "1" rows
 
-    @partition_transfer
-    @prt_transfer_37
     Scenario: gptransfer won't allow transferring between same partition table
         Given the gptransfer test is initialized
         And database "gptest" exists
@@ -1445,8 +1269,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "Cannot transfer between same partition table" to stdout
 
-    @partition_transfer
-    @prt_transfer_38
     Scenario: gptransfer won't restrict if one pair is having any extra partition tables
         Given the gptransfer test is initialized
         And database "gptest" exists
@@ -1459,8 +1281,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 0
         And verify that table "public.sales_1_prt_asia_2_prt_2" in "gptest" has "1" rows
 
-    @partition_transfer
-    @prt_transfer_39
     Scenario: gptransfer, --partition-transfer can not be used with --dest-database option
         Given the gptransfer test is initialized
         And there is a file "input_file" with tables "gptest.public.tbl, gptest.public.tbl1"
@@ -1468,8 +1288,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "--partition-transfer option cannot be used with --dest-database option" to stdout
 
-    @partition_transfer
-    @prt_transfer_40
     Scenario: gptransfer, --partition-transfer ingores blank lines in input file
         Given the gptransfer test is initialized
         And there is a file "input_file" with tables " "
@@ -1477,8 +1295,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 0
         And gptransfer should print "Skipping blank lines" to stdout
 
-    @partition_transfer
-    @prt_transfer_41
     Scenario: gptransfer, --partition-transfer pre-checks source and destination pair format
         Given the gptransfer test is initialized
         And there is a file "input_file" with tables "gptest.public.tbl ,, gptest.public.tbl1"
@@ -1486,8 +1302,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "Wrong format found for table transfer pair" to stdout
 
-    @partition_transfer
-    @prt_transfer_42
     Scenario: gptransfer, --partition-transfer pre-checks empty source table name
         Given the gptransfer test is initialized
         And there is a file "input_file" with tables ", gptest.public.tbl1"
@@ -1495,8 +1309,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "Cannot specify empty source table name" to stdout
 
-    @partition_transfer
-    @prt_transfer_43
     Scenario: gptransfer, --partition-transfer pre-checks empty destination table name
         Given the gptransfer test is initialized
         And there is a file "input_file" with tables "gptest.public.tbl,"
@@ -1504,8 +1316,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "Cannot specify empty destination table name" to stdout
 
-    @partition_transfer
-    @prt_transfer_44
     Scenario: gptransfer, --partition-transfer pre-checks full qualified format of source table name
         Given the gptransfer test is initialized
         And there is a file "input_file" with tables "gptest.public.tbl.extra_tablename, gptest.public.tbl"
@@ -1513,8 +1323,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "Source table name "gptest.public.tbl.extra_tablename" isn't fully qualified format" to stdout
 
-    @partition_transfer
-    @prt_transfer_45
     Scenario: gptransfer, --partition-transfer pre-checks full qualified format of destination table name
         Given the gptransfer test is initialized
         And there is a file "input_file" with tables "gptest.public.tbl, gptest.public.tbl.extra_tablename"
@@ -1522,8 +1330,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "Destination table name "gptest.public.tbl.extra_tablename" isn't fully qualified format" to stdout
 
-    @partition_transfer
-    @prt_transfer_46
     Scenario: gptransfer partition with batch size 1, tables transferred in sequential order
         Given the gptransfer test is initialized
         And database "gptest" exists
@@ -1535,15 +1341,13 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 0
         And verify that gptransfer is in order of "input_file" when partition transfer is "True"
 
-    @partition_transfer
-    @prt_transfer_47
     Scenario: gptransfer leaf partition -> leaf partition drop and readd column before transfer
         Given the gptransfer test is initialized
         And database "gptest" exists
         And database "gptest" is created if not exists on host "GPTRANSFER_SOURCE_HOST" with port "GPTRANSFER_SOURCE_PORT" with user "GPTRANSFER_SOURCE_USER"
         And the user runs "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -f test/behave/mgmt_utils/steps/data/gptransfer/two_level_range_list_prt_1.sql -d gptest"
         And the user runs "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -f test/behave/mgmt_utils/steps/data/gptransfer/drop_and_readd_column.sql -d gptest"
-		And the user runs "pg_dump -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -t public.sales -s gptest  > /tmp/mytab.sql"
+        And the user runs "pg_dump -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -t public.sales -s gptest  > /tmp/mytab.sql"
         And the user runs "psql -p $GPTRANSFER_DEST_PORT -h $GPTRANSFER_DEST_HOST -U $GPTRANSFER_DEST_USER -c "DROP TABLE IF EXISTS sales" -d gptest"
         And the user runs "psql -p $GPTRANSFER_DEST_PORT -h $GPTRANSFER_DEST_HOST -U $GPTRANSFER_DEST_USER -f /tmp/mytab.sql -d gptest"
         And the user runs "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -f test/behave/mgmt_utils/steps/data/gptransfer/insert_into_sales_columns_reordered.sql -d gptest"
@@ -1552,8 +1356,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 0
         And verify that table "public.sales_1_prt_2_2_prt_asia" in database "gptest" of source system has same data with table "public.sales_1_prt_2_2_prt_asia" in database "gptest" of destination system with options "-q"
 
-    @partition_transfer
-    @prt_transfer_48
     Scenario: gptransfer leaf partition -> leaf partition different column order
         Given the gptransfer test is initialized
         And database "gptest" exists
@@ -1570,7 +1372,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print "Partition column attributes are different at level" to stdout
 
-    @distribution_key
     Scenario: gptransfer is run with distribution key that has upper case characters
         Given the gptransfer test is initialized
         And database "gptest" exists
@@ -1579,7 +1380,6 @@ Feature: gptransfer tests
         And the user runs "gptransfer -t gptest.public.caps -t gptest.public.caps_with_dquote -t gptest.public.caps_with_dquote2 -t gptest.public.caps_with_dquote3 -t gptest.public.caps_with_dquote4 -t gptest.public.caps_with_squote -t gptest.public.randomkey --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --truncate -a --batch-size=10"
         Then gptransfer should return a return code of 0
 
-    @distribution_key
     Scenario: gptransfer is run with multiple distribution keys
         Given the gptransfer test is initialized
         And database "gptest" exists
@@ -1592,7 +1392,6 @@ Feature: gptransfer tests
         And the user runs "psql gptest -c '\d+ reverse_table_distribution'"
         Then psql should print "Distributed by: (id2 crazy"', id1," )" to stdout 1 times
 
-    @gptransfer_help
     Scenario: use gptransfer --help with another gptransfer process already running.
         Given the gptransfer test is initialized
         And a table is created containing rows of length "10" with connection "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -d gptransfer_testdb5"
@@ -1602,9 +1401,6 @@ Feature: gptransfer tests
         And gptransfer should not print "An instance of gptransfer is already running" to stdout
         And the user waits for "gptransfer" to finish running
 
-    @partition-transfer-non-partition-target
-    @partition_transfer
-    @prt_transfer_49
     Scenario: transfer multiple partition leaves to same non-partition table
         Given the gptransfer test is initialized
         And database "gptest" exists


### PR DESCRIPTION
These tags were never used. This will be backported to 5X_STABLE.