### PR TITLE
updated key for pxf_automation git resource

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -188,7 +188,7 @@ resources:
   type: git
   source:
     branch: {{pxf_automation-git-branch}}
-    private_key: {{pxf-git-key}}
+    private_key: {{pxf_automation-git-key}}
     uri: {{pxf_automation-git-remote}}
 
 - name: centos-gpdb-dev-6


### PR DESCRIPTION
This PR must be merged along with the corresponding PR for pipeline secrets that introduces the new git key.