### PR TITLE
Hide the two tuplesort implementations behind a common facade.

### DIFF
--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -49,7 +49,6 @@
 #include "utils/pg_rusage.h"
 #include "utils/syscache.h"
 #include "utils/tuplesort.h"
-#include "utils/tuplesort_mk.h"
 #include "utils/tqual.h"
 
 /*

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -37,9 +37,8 @@
 #include "utils/json.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"             /* AllocSetContextCreate() */
-#include "utils/snapmgr.h"
 #include "utils/tuplesort.h"
-#include "utils/tuplesort_mk.h"
+#include "utils/snapmgr.h"
 
 #include "cdb/cdbdisp.h"                /* CheckDispatchResult() */
 #include "cdb/cdbexplain.h"             /* cdbexplain_recvExecStats */

--- a/src/backend/executor/nodeMotion.c
+++ b/src/backend/executor/nodeMotion.c
@@ -30,7 +30,6 @@
 #include "parser/parsetree.h"
 #include "utils/lsyscache.h"
 #include "utils/tuplesort.h"
-#include "utils/tuplesort_mk.h"
 #include "utils/tuplesort_mk_details.h"
 #include "miscadmin.h"
 #include "nodes/makefuncs.h"

--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -36,7 +36,6 @@
 #include "utils/faultinjector.h"
 #include "utils/gp_alloc.h"
 #include "utils/tuplesort.h"
-#include "utils/tuplesort_mk.h"
 #include "utils/tuplestorenew.h"
 
 typedef struct ShareInput_Lk_Context
@@ -118,55 +117,30 @@ init_tuplestore_state(ShareInputScanState *node)
 		shareinput_create_bufname_prefix(rwfile_prefix, sizeof(rwfile_prefix), sisc->share_id);
 		node->ts_state = palloc0(sizeof(GenericTupStore));
 
-		if(gp_enable_mk_sort)
-		{
-			node->ts_state->sortstore_mk = tuplesort_begin_heap_file_readerwriter_mk(
-				&node->ss,
-				rwfile_prefix, false,
-				NULL,
-				0, NULL,
-				NULL, NULL,
-				PlanStateOperatorMemKB((PlanState *) node), true);
+		node->ts_state->sortstore = tuplesort_begin_heap_file_readerwriter(
+			&node->ss,
+			rwfile_prefix, false,
+			NULL,
+			0, NULL,
+			NULL, NULL,
+			PlanStateOperatorMemKB((PlanState *) node), true);
 
-			tuplesort_begin_pos_mk(node->ts_state->sortstore_mk, (TuplesortPos_mk **)(&node->ts_pos));
-			tuplesort_rescan_pos_mk(node->ts_state->sortstore_mk, (TuplesortPos_mk *)node->ts_pos);
-		}
-		else
-		{
-			node->ts_state->sortstore = tuplesort_begin_heap_file_readerwriter(
-				rwfile_prefix, false,
-				NULL,
-				0, NULL,
-				NULL, NULL,
-				PlanStateOperatorMemKB((PlanState *) node), true);
-
-			tuplesort_begin_pos(node->ts_state->sortstore, (TuplesortPos **)(&node->ts_pos));
-			tuplesort_rescan_pos(node->ts_state->sortstore, (TuplesortPos *)node->ts_pos);
-		}
+		tuplesort_begin_pos(node->ts_state->sortstore, (TuplesortPos **)(&node->ts_pos));
+		tuplesort_rescan_pos(node->ts_state->sortstore, (TuplesortPos *)node->ts_pos);
 	}
 	else 
 	{
 		Assert(sisc->share_type == SHARE_SORT);
 		Assert(snState != NULL);
 
-		if(gp_enable_mk_sort)
-		{
-			node->ts_state = ((SortState *)snState)->tuplesortstate;
-			Assert(NULL != node->ts_state->sortstore_mk);
-			tuplesort_begin_pos_mk(node->ts_state->sortstore_mk, (TuplesortPos_mk **)(&node->ts_pos));
-			tuplesort_rescan_pos_mk(node->ts_state->sortstore_mk, (TuplesortPos_mk *)node->ts_pos);
-		}
-		else
-		{
-			node->ts_state = ((SortState *)snState)->tuplesortstate;
-			Assert(NULL != node->ts_state->sortstore);
-			tuplesort_begin_pos(node->ts_state->sortstore, (TuplesortPos **)(&node->ts_pos));
-			tuplesort_rescan_pos(node->ts_state->sortstore, (TuplesortPos *)node->ts_pos);
-		}
+		node->ts_state = ((SortState *)snState)->tuplesortstate;
+		Assert(NULL != node->ts_state->sortstore);
+		tuplesort_begin_pos(node->ts_state->sortstore, (TuplesortPos **)(&node->ts_pos));
+		tuplesort_rescan_pos(node->ts_state->sortstore, (TuplesortPos *)node->ts_pos);
 	}
 
 	Assert(NULL != node->ts_state);
-	Assert(NULL != node->ts_state->matstore || NULL != node->ts_state->sortstore || NULL != node->ts_state->sortstore_mk);
+	Assert(NULL != node->ts_state->matstore || NULL != node->ts_state->sortstore);
 }
 
 
@@ -216,14 +190,7 @@ ShareInputNext(ShareInputScanState *node)
 		}
 		else
 		{
-			if(gp_enable_mk_sort)
-			{
-				gotOK = tuplesort_gettupleslot_pos_mk(node->ts_state->sortstore_mk, (TuplesortPos_mk *)node->ts_pos, forward, slot, CurrentMemoryContext);
-			}
-			else
-			{
-				gotOK = tuplesort_gettupleslot_pos(node->ts_state->sortstore, (TuplesortPos *)node->ts_pos, forward, slot, CurrentMemoryContext);
-			}
+			gotOK = tuplesort_gettupleslot_pos(node->ts_state->sortstore, (TuplesortPos *)node->ts_pos, forward, slot, CurrentMemoryContext);
 		}
 
 		if(!gotOK)
@@ -404,16 +371,8 @@ void ExecShareInputScanReScan(ShareInputScanState *node, ExprContext *exprCtxt)
 	}
 	else if (sisc->share_type == SHARE_SORT || sisc->share_type == SHARE_SORT_XSLICE)
 	{
-		if(gp_enable_mk_sort)
-		{
-			Assert(NULL != node->ts_state->sortstore_mk);
-			tuplesort_rescan_pos_mk(node->ts_state->sortstore_mk, (TuplesortPos_mk *) node->ts_pos);
-		}
-		else
-		{
-			Assert(NULL != node->ts_state->sortstore);
-			tuplesort_rescan_pos(node->ts_state->sortstore, (TuplesortPos *) node->ts_pos);
-		}
+		Assert(NULL != node->ts_state->sortstore);
+		tuplesort_rescan_pos(node->ts_state->sortstore, (TuplesortPos *) node->ts_pos);
 	}
 	else
 	{

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -39,11 +39,9 @@
 #include "cdb/cdbmutate.h"		/* cdbmutate_warn_ctid_without_segid */
 #include "cdb/cdbpath.h"		/* cdbpath_rows() */
 
-// TODO: these planner/executor gucs need to be refactored into PlannerConfig.
+// TODO: these planner gucs need to be refactored into PlannerConfig.
 bool		gp_enable_sort_limit = FALSE;
 bool		gp_enable_sort_distinct = FALSE;
-bool		gp_enable_mk_sort = true;
-bool		gp_enable_motion_mk_sort = true;
 
 /* Hook for plugins to replace standard_join_search() */
 join_search_hook_type join_search_hook = NULL;

--- a/src/backend/optimizer/path/costsize.c
+++ b/src/backend/optimizer/path/costsize.c
@@ -78,7 +78,6 @@
 #include "utils/lsyscache.h"
 #include "utils/selfuncs.h"
 #include "utils/tuplesort.h"
-#include "utils/tuplesort_mk.h"
 
 #include "cdb/cdbpath.h"        /* cdbpath_rows() */
 #include "cdb/cdbvars.h"

--- a/src/backend/optimizer/plan/planmain.c
+++ b/src/backend/optimizer/plan/planmain.c
@@ -541,8 +541,6 @@ PlannerConfig *DefaultPlannerConfig(void)
 	c1->gp_enable_groupext_distinct_gather = gp_enable_groupext_distinct_gather;
 	c1->gp_enable_sort_limit = gp_enable_sort_limit;
 	c1->gp_enable_sort_distinct = gp_enable_sort_distinct;
-	c1->gp_enable_mk_sort = gp_enable_mk_sort;
-	c1->gp_enable_motion_mk_sort = gp_enable_motion_mk_sort;
 
 	c1->gp_enable_direct_dispatch = gp_enable_direct_dispatch;
 	c1->gp_dynamic_partition_pruning = gp_dynamic_partition_pruning;

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -556,6 +556,10 @@ char	   *gp_default_storage_options = NULL;
 
 int			writable_external_table_bufsize = 64;
 
+/* Executor */
+bool		gp_enable_mk_sort = true;
+bool		gp_enable_motion_mk_sort = true;
+
 static const struct config_enum_entry gp_log_format_options[] = {
 	{"text", 0},
 	{"csv", 1},

--- a/src/backend/utils/sort/tuplesort_mk.c
+++ b/src/backend/utils/sort/tuplesort_mk.c
@@ -204,6 +204,9 @@ typedef struct TupsortMergeReadCtxt
  */
 struct Tuplesortstate_mk
 {
+	/* MUST BE FIRST, to match switcheroo_Tuplesortstate */
+	bool		is_mk_tuplesortstate;
+
 	TupSortStatus status;		/* enumerated value as shown above */
 	int			nKeys;			/* number of columns in sort key */
 	bool		randomAccess;	/* did caller request random access? */

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2283,8 +2283,7 @@ typedef struct HashJoinState
 typedef union GenericTupStore
 {
 	struct NTupleStore        *matstore;     /* Used by Materialize */
-	struct Tuplesortstate_mk  *sortstore_mk; /* Used by Sort when gp_enable_mk_sort = true */
-	struct Tuplesortstate     *sortstore;    /* Used by Sort when gp_enable_mk_sort = false */
+	void	   *sortstore;	/* Used by Sort */
 } GenericTupStore;
 
 /* ----------------

--- a/src/include/nodes/plannerconfig.h
+++ b/src/include/nodes/plannerconfig.h
@@ -44,8 +44,6 @@ typedef struct PlannerConfig
 	bool        gp_enable_groupext_distinct_gather;
 	bool		gp_enable_sort_limit;
 	bool		gp_enable_sort_distinct;
-	bool		gp_enable_mk_sort;
-	bool		gp_enable_motion_mk_sort;
 
 	bool		gp_enable_direct_dispatch;
 	bool		gp_dynamic_partition_pruning;

--- a/src/include/utils/tuplesort.h
+++ b/src/include/utils/tuplesort.h
@@ -10,6 +10,24 @@
  * amounts are sorted using temporary files and a standard external sort
  * algorithm.
  *
+ * GPDB has two implemntations of sorting. One is inherited from PostgreSQL,
+ * and lives in tuplesort.c. The other one lives in tuplesort_mk.c. Both
+ * provide the same API, and have the same set of functions, just with a
+ * different suffix.
+ *
+ * The rest of the system uses functions named tuplesort_*(), to perform
+ * sorting. But there are actually three versions of each of these functions:
+ *
+ * tuplesort_*_pg			- the Postgres implementation
+ * tuplesort_*_mk			- the Multi-Key implementation
+ * switcheroo_tuplesort_*	- wrapper that calls one of the above.
+ *
+ * This system is fairly robust, even if new functions are added in the
+ * upstream, and we merge that code in. If you don't add the #defines
+ * for the new functions, you will get compiler warnings from any callers
+ * of them, as the callers will pass a switcheroo_Tuplesortstate struct
+ * as the argument, instead of Tuplesortstate_pk.
+ *
  * Portions Copyright (c) 2007-2008, Greenplum inc
  * Portions Copyright (c) 2012-Present Pivotal Software, Inc.
  * Portions Copyright (c) 1996-2008, PostgreSQL Global Development Group
@@ -21,6 +39,49 @@
  */
 #ifndef TUPLESORT_H
 #define TUPLESORT_H
+
+/*
+ * First, declare the prototypes for the tuplesort_*_pg functions. In order to
+ * keeping this file unchanged from the upstream, the extern declarations
+ * use just tuplesort_*(), but we map them with #define to tuplesort_*_pg().
+ *
+ * The tuplesort_*_mk() functions are declare normally, without #defines,
+ * in tuplesort_mk.h
+ */
+
+/* these are in tuplesort.h */
+#define Tuplesortstate Tuplesortstate_pg
+
+#define tuplesort_begin_heap tuplesort_begin_heap_pg
+#define tuplesort_begin_index_btree tuplesort_begin_index_btree_pg
+#define tuplesort_begin_index_hash tuplesort_begin_index_hash_pg
+#define tuplesort_begin_datum tuplesort_begin_datum_pg
+#define tuplesort_set_bound tuplesort_set_bound_pg
+#define tuplesort_puttupleslot tuplesort_puttupleslot_pg
+#define tuplesort_putindextuple tuplesort_putindextuple_pg
+#define tuplesort_putdatum tuplesort_putdatum_pg
+#define tuplesort_performsort tuplesort_performsort_pg
+#define tuplesort_gettupleslot tuplesort_gettupleslot_pg
+#define tuplesort_getindextuple tuplesort_getindextuple_pg
+#define tuplesort_getdatum tuplesort_getdatum_pg
+#define tuplesort_end tuplesort_end_pg
+/* tuplesort_merge_order not switched */
+#define tuplesort_rescan tuplesort_rescan_pg
+#define tuplesort_markpos tuplesort_markpos_pg
+#define tuplesort_restorepos tuplesort_restorepos_pg
+
+/* these are in tuplesort_gp.h */
+#define tuplesort_begin_heap_file_readerwriter tuplesort_begin_heap_file_readerwriter_pg
+#define cdb_tuplesort_init cdb_tuplesort_init_pg
+#define tuplesort_begin_pos tuplesort_begin_pos_pg
+#define tuplesort_gettupleslot_pos tuplesort_gettupleslot_pos_pg
+#define tuplesort_flush tuplesort_flush_pg
+#define tuplesort_finalize_stats tuplesort_finalize_stats_pg
+#define tuplesort_rescan_pos tuplesort_rescan_pos_pg
+#define tuplesort_markpos_pos tuplesort_markpos_pos_pg
+#define tuplesort_restorepos_pos tuplesort_restorepos_pos_pg
+#define tuplesort_set_instrument tuplesort_set_instrument_pg
+#define tuplesort_set_gpmon tuplesort_set_gpmon_pg
 
 #include "access/itup.h"
 #include "executor/tuptable.h"
@@ -52,7 +113,7 @@ typedef struct Tuplesortstate Tuplesortstate;
  * Yet another slightly different interface supports sorting bare Datums.
  */
 
-extern Tuplesortstate *tuplesort_begin_heap(TupleDesc tupDesc,
+extern Tuplesortstate *tuplesort_begin_heap(ScanState *ss, TupleDesc tupDesc,
 					 int nkeys, AttrNumber *attNums,
 					 Oid *sortOperators, bool *nullsFirstFlags,
 					 int workMem, bool randomAccess);
@@ -62,7 +123,7 @@ extern Tuplesortstate *tuplesort_begin_index_btree(Relation indexRel,
 extern Tuplesortstate *tuplesort_begin_index_hash(Relation indexRel,
 							uint32 hash_mask,
 							int workMem, bool randomAccess);
-extern Tuplesortstate *tuplesort_begin_datum(Oid datumType,
+extern Tuplesortstate *tuplesort_begin_datum(ScanState *ss, Oid datumType,
 					  Oid sortOperator, bool nullsFirstFlag,
 					  int workMem, bool randomAccess);
 
@@ -112,5 +173,420 @@ extern void SelectSortFunction(Oid sortOperator, bool nulls_first,
 extern int32 ApplySortFunction(FmgrInfo *sortFunction, int sortFlags,
 				  Datum datum1, bool isNull1,
 				  Datum datum2, bool isNull2);
+
+
+/*
+ * We have now declared the protoypes for all the *_pg functions. If we're
+ * compiling tuplesort.c itself, continue compilation with #define's in
+ * place, so that the functions in tuplesort.c get defined as *_pg.
+ *
+ * If we're compiling anything else, define switcheroo_* functions that check
+ * which implementation should be used, and redefine tuplesort_* to point to
+ * the switcheroo-functions. This way, all callers of tuplesort_* get either
+ * the Postgres or MK-implementation, depending on the gp_enable_mk_sort
+ * GUC.
+ */
+#ifndef COMPILING_TUPLESORT_C
+
+#undef tuplesort_begin_heap
+#undef tuplesort_begin_index_btree
+#undef tuplesort_begin_index_hash
+#undef tuplesort_begin_datum
+#undef tuplesort_set_bound
+#undef tuplesort_puttupleslot
+#undef tuplesort_putindextuple
+#undef tuplesort_putdatum
+#undef tuplesort_performsort
+#undef tuplesort_gettupleslot
+#undef tuplesort_getindextuple
+#undef tuplesort_getdatum
+#undef tuplesort_end
+#undef tuplesort_rescan
+#undef tuplesort_markpos
+#undef tuplesort_restorepos
+#undef tuplesort_begin_heap_file_readerwriter
+#undef cdb_tuplesort_init
+#undef tuplesort_begin_pos
+#undef tuplesort_gettupleslot_pos
+#undef tuplesort_flush
+#undef tuplesort_finalize_stats
+#undef tuplesort_rescan_pos
+#undef tuplesort_markpos_pos
+#undef tuplesort_restorepos_pos
+#undef tuplesort_set_instrument
+#undef tuplesort_set_gpmon
+
+#include "tuplesort_mk.h"
+
+extern bool gp_enable_mk_sort;
+
+/*
+ * Common header between the regular and MK tuplesort state. We store
+ * a flag indicating which one this is, at the beginning, so that
+ * the functions that operate on an existing tuplesort are redirected
+ * correctly, even if gp_enable_mk_sort changes on the fly.
+ */
+struct switcheroo_Tuplesortstate
+{
+	bool		is_mk_tuplesortstate;
+};
+
+typedef struct switcheroo_Tuplesortstate switcheroo_Tuplesortstate;
+
+static inline switcheroo_Tuplesortstate *
+switcheroo_tuplesort_begin_heap(ScanState *ss, TupleDesc tupDesc,
+					 int nkeys, AttrNumber *attNums,
+					 Oid *sortOperators, bool *nullsFirstFlags,
+					 int workMem, bool randomAccess)
+{
+	switcheroo_Tuplesortstate *state;
+
+	if (gp_enable_mk_sort)
+	{
+		state = (switcheroo_Tuplesortstate *)
+			tuplesort_begin_heap_mk(ss, tupDesc, nkeys, attNums,
+									sortOperators, nullsFirstFlags,
+									workMem, randomAccess);
+	}
+	else
+	{
+		state = (switcheroo_Tuplesortstate *)
+			tuplesort_begin_heap_pg(ss, tupDesc, nkeys, attNums,
+									sortOperators, nullsFirstFlags,
+									workMem, randomAccess);
+	}
+	state->is_mk_tuplesortstate = gp_enable_mk_sort;
+	return state;
+}
+
+static inline switcheroo_Tuplesortstate *
+switcheroo_tuplesort_begin_index_btree(Relation indexRel,
+							bool enforceUnique,
+							int workMem, bool randomAccess)
+{
+	switcheroo_Tuplesortstate *state;
+
+	if (gp_enable_mk_sort)
+	{
+		state = (switcheroo_Tuplesortstate *)
+			tuplesort_begin_index_mk(indexRel, enforceUnique, workMem, randomAccess);
+	}
+	else
+	{
+		state = (switcheroo_Tuplesortstate *)
+			tuplesort_begin_index_btree_pg(indexRel, enforceUnique, workMem, randomAccess);
+	}
+	state->is_mk_tuplesortstate = gp_enable_mk_sort;
+	return state;
+}
+static inline switcheroo_Tuplesortstate *
+switcheroo_tuplesort_begin_index_hash(Relation indexRel,
+							uint32 hash_mask,
+							int workMem, bool randomAccess)
+{
+	switcheroo_Tuplesortstate *state;
+
+	/* There is no MK variant of this */
+	state = (switcheroo_Tuplesortstate *)
+		tuplesort_begin_index_hash_pg(indexRel, hash_mask, workMem, randomAccess);
+	state->is_mk_tuplesortstate = false;
+	return state;
+}
+
+static inline switcheroo_Tuplesortstate *
+switcheroo_tuplesort_begin_datum(ScanState *ss, Oid datumType,
+					  Oid sortOperator, bool nullsFirstFlag,
+					  int workMem, bool randomAccess)
+{
+	switcheroo_Tuplesortstate *state;
+
+	if (gp_enable_mk_sort)
+	{
+		state = (switcheroo_Tuplesortstate *)
+			tuplesort_begin_datum_mk(ss, datumType, sortOperator, nullsFirstFlag, workMem, randomAccess);
+	}
+	else
+	{
+		state = (switcheroo_Tuplesortstate *)
+			tuplesort_begin_datum_pg(ss, datumType, sortOperator, nullsFirstFlag, workMem, randomAccess);
+	}
+	state->is_mk_tuplesortstate = gp_enable_mk_sort;
+	return state;
+}
+
+static inline void
+switcheroo_tuplesort_set_bound(switcheroo_Tuplesortstate *state, int64 bound)
+{
+	if (state->is_mk_tuplesortstate)
+		tuplesort_set_bound_mk((Tuplesortstate_mk *) state, bound);
+	else
+		tuplesort_set_bound_pg((Tuplesortstate_pg *) state, bound);
+}
+
+static inline void
+switcheroo_tuplesort_puttupleslot(switcheroo_Tuplesortstate *state, TupleTableSlot *slot)
+{
+	if (state->is_mk_tuplesortstate)
+		tuplesort_puttupleslot_mk((Tuplesortstate_mk *) state, slot);
+	else
+		tuplesort_puttupleslot_pg((Tuplesortstate_pg *) state, slot);
+}
+
+static inline void
+switcheroo_tuplesort_putindextuple(switcheroo_Tuplesortstate *state, IndexTuple tuple)
+{
+	if (state->is_mk_tuplesortstate)
+		tuplesort_putindextuple_mk((Tuplesortstate_mk *) state, tuple);
+	else
+		tuplesort_putindextuple_pg((Tuplesortstate_pg *) state, tuple);
+}
+
+static inline void
+switcheroo_tuplesort_putdatum(switcheroo_Tuplesortstate *state, Datum val, bool isNull)
+{
+	if (state->is_mk_tuplesortstate)
+		tuplesort_putdatum_mk((Tuplesortstate_mk *) state, val, isNull);
+	else
+		tuplesort_putdatum_pg((Tuplesortstate_pg *) state, val, isNull);
+}
+
+static inline void
+switcheroo_tuplesort_performsort(switcheroo_Tuplesortstate *state)
+{
+	if (state->is_mk_tuplesortstate)
+		tuplesort_performsort_mk((Tuplesortstate_mk *) state);
+	else
+		tuplesort_performsort_pg((Tuplesortstate_pg *) state);
+}
+
+static inline bool
+switcheroo_tuplesort_gettupleslot(switcheroo_Tuplesortstate *state, bool forward,
+								   TupleTableSlot *slot)
+{
+	if (state->is_mk_tuplesortstate)
+		return tuplesort_gettupleslot_mk((Tuplesortstate_mk *) state, forward, slot);
+	else
+		return tuplesort_gettupleslot_pg((Tuplesortstate_pg *) state, forward, slot);
+}
+
+static inline IndexTuple
+switcheroo_tuplesort_getindextuple(switcheroo_Tuplesortstate *state, bool forward, bool *should_free)
+{
+	if (state->is_mk_tuplesortstate)
+		return tuplesort_getindextuple_mk((Tuplesortstate_mk *) state, forward, should_free);
+	else
+		return tuplesort_getindextuple_pg((Tuplesortstate_pg *) state, forward, should_free);
+}
+
+static inline bool
+switcheroo_tuplesort_getdatum(switcheroo_Tuplesortstate *state, bool forward, Datum *val, bool *isNull)
+{
+	if (state->is_mk_tuplesortstate)
+		return tuplesort_getdatum_mk((Tuplesortstate_mk *) state, forward, val, isNull);
+	else
+		return tuplesort_getdatum_pg((Tuplesortstate_pg *) state, forward, val, isNull);
+}
+
+static inline void
+switcheroo_tuplesort_end(switcheroo_Tuplesortstate *state)
+{
+	if (state->is_mk_tuplesortstate)
+		tuplesort_end_mk((Tuplesortstate_mk *) state);
+	else
+		tuplesort_end_pg((Tuplesortstate_pg *) state);
+}
+
+static inline void
+switcheroo_tuplesort_rescan(switcheroo_Tuplesortstate *state)
+{
+	if (state->is_mk_tuplesortstate)
+		tuplesort_rescan_mk((Tuplesortstate_mk *) state);
+	else
+		tuplesort_rescan_pg((Tuplesortstate_pg *) state);
+}
+
+static inline void
+switcheroo_tuplesort_markpos(switcheroo_Tuplesortstate *state)
+{
+	if (state->is_mk_tuplesortstate)
+		tuplesort_markpos_mk((Tuplesortstate_mk *) state);
+	else
+		tuplesort_markpos_pg((Tuplesortstate_pg *) state);
+}
+
+
+static inline void
+switcheroo_tuplesort_restorepos(switcheroo_Tuplesortstate *state)
+{
+	if (state->is_mk_tuplesortstate)
+		tuplesort_restorepos_mk((Tuplesortstate_mk *) state);
+	else
+		tuplesort_restorepos_pg((Tuplesortstate_pg *) state);
+}
+
+static inline switcheroo_Tuplesortstate *
+switcheroo_tuplesort_begin_heap_file_readerwriter(
+		ScanState * ss,
+		const char* rwfile_prefix, bool isWriter,
+		TupleDesc tupDesc,
+		int nkeys, AttrNumber *attNums,
+		Oid *sortOperators, bool *nullsFirstFlags,
+		int workMem, bool randomAccess)
+{
+	switcheroo_Tuplesortstate *state;
+
+	if (gp_enable_mk_sort)
+	{
+		state = (switcheroo_Tuplesortstate *)
+			tuplesort_begin_heap_file_readerwriter_mk(ss, rwfile_prefix, isWriter,
+													  tupDesc, nkeys, attNums,
+													  sortOperators, nullsFirstFlags,
+													  workMem, randomAccess);
+	}
+	else
+	{
+		state = (switcheroo_Tuplesortstate *)
+			tuplesort_begin_heap_file_readerwriter_pg(ss, rwfile_prefix, isWriter,
+													  tupDesc, nkeys, attNums,
+													  sortOperators, nullsFirstFlags,
+													  workMem, randomAccess);
+	}
+	state->is_mk_tuplesortstate = gp_enable_mk_sort;
+	return state;
+}
+
+static inline void
+switcheroo_cdb_tuplesort_init(switcheroo_Tuplesortstate *state, int unique,
+							  int sort_flags,
+							  int64 maxdistinct)
+{
+	if (state->is_mk_tuplesortstate)
+		cdb_tuplesort_init_mk((Tuplesortstate_mk *) state, unique, sort_flags, maxdistinct);
+	else
+		cdb_tuplesort_init_pg((Tuplesortstate_pg *) state, unique, sort_flags, maxdistinct);
+}
+
+static inline void
+switcheroo_tuplesort_begin_pos(switcheroo_Tuplesortstate *state, TuplesortPos **pos)
+{
+	if (state->is_mk_tuplesortstate)
+		tuplesort_begin_pos_mk((Tuplesortstate_mk *) state, (TuplesortPos_mk **) pos);
+	else
+		tuplesort_begin_pos_pg((Tuplesortstate_pg *) state, pos);
+}
+
+static inline bool
+switcheroo_tuplesort_gettupleslot_pos(switcheroo_Tuplesortstate *state, TuplesortPos *pos,
+                          bool forward, TupleTableSlot *slot, MemoryContext mcontext)
+{
+	if (state->is_mk_tuplesortstate)
+		return tuplesort_gettupleslot_pos_mk((Tuplesortstate_mk *) state, (TuplesortPos_mk *) pos, forward, slot, mcontext);
+	else
+		return tuplesort_gettupleslot_pos_pg((Tuplesortstate_pg *) state, pos, forward, slot, mcontext);
+}
+
+static inline void
+switcheroo_tuplesort_flush(switcheroo_Tuplesortstate *state)
+{
+	if (state->is_mk_tuplesortstate)
+		tuplesort_flush_mk((Tuplesortstate_mk *) state);
+	else
+		tuplesort_flush_pg((Tuplesortstate_pg *) state);
+}
+
+static inline void
+switcheroo_tuplesort_finalize_stats(switcheroo_Tuplesortstate *state)
+{
+	if (state->is_mk_tuplesortstate)
+		tuplesort_finalize_stats_mk((Tuplesortstate_mk *) state);
+	else
+		tuplesort_finalize_stats_pg((Tuplesortstate_pg *) state);
+}
+
+static inline void
+switcheroo_tuplesort_rescan_pos(switcheroo_Tuplesortstate *state, TuplesortPos *pos)
+{
+	if (state->is_mk_tuplesortstate)
+		tuplesort_rescan_pos_mk((Tuplesortstate_mk *) state, (TuplesortPos_mk *) pos);
+	else
+		tuplesort_rescan_pos_pg((Tuplesortstate_pg *) state, pos);
+}
+
+static inline void
+switcheroo_tuplesort_markpos_pos(switcheroo_Tuplesortstate *state, TuplesortPos *pos)
+{
+	if (state->is_mk_tuplesortstate)
+		tuplesort_markpos_pos_mk((Tuplesortstate_mk *) state, (TuplesortPos_mk *) pos);
+	else
+		tuplesort_markpos_pos_pg((Tuplesortstate_pg *) state, pos);
+}
+
+static inline void
+switcheroo_tuplesort_restorepos_pos(switcheroo_Tuplesortstate *state, TuplesortPos *pos)
+{
+	if (state->is_mk_tuplesortstate)
+		tuplesort_restorepos_pos_mk((Tuplesortstate_mk *) state, (TuplesortPos_mk *) pos);
+	else
+		tuplesort_restorepos_pos_pg((Tuplesortstate_pg *) state, pos);
+}
+
+static inline void
+switcheroo_tuplesort_set_instrument(switcheroo_Tuplesortstate *state,
+									struct Instrumentation *instrument,
+									struct StringInfoData *explainbuf)
+{
+	if (state->is_mk_tuplesortstate)
+		tuplesort_set_instrument_mk((Tuplesortstate_mk *) state, instrument, explainbuf);
+	else
+		tuplesort_set_instrument_pg((Tuplesortstate_pg *) state, instrument, explainbuf);
+}
+
+static inline void
+switcheroo_tuplesort_set_gpmon(switcheroo_Tuplesortstate *state,
+							   gpmon_packet_t *gpmon_pkt,
+							   int *gpmon_tick)
+{
+	if (state->is_mk_tuplesortstate)
+		tuplesort_set_gpmon_mk((Tuplesortstate_mk *) state, gpmon_pkt, gpmon_tick);
+	else
+		tuplesort_set_gpmon_pg((Tuplesortstate_pg *) state, gpmon_pkt, gpmon_tick);
+}
+
+/* these are in tuplesort.h */
+#undef Tuplesortstate
+#define Tuplesortstate switcheroo_Tuplesortstate
+
+#define tuplesort_begin_heap switcheroo_tuplesort_begin_heap
+#define tuplesort_begin_index_btree switcheroo_tuplesort_begin_index_btree
+#define tuplesort_begin_index_hash switcheroo_tuplesort_begin_index_hash
+#define tuplesort_begin_datum switcheroo_tuplesort_begin_datum
+#define tuplesort_set_bound switcheroo_tuplesort_set_bound
+#define tuplesort_puttupleslot switcheroo_tuplesort_puttupleslot
+#define tuplesort_putindextuple switcheroo_tuplesort_putindextuple
+#define tuplesort_putdatum switcheroo_tuplesort_putdatum
+#define tuplesort_performsort switcheroo_tuplesort_performsort
+#define tuplesort_gettupleslot switcheroo_tuplesort_gettupleslot
+#define tuplesort_getindextuple switcheroo_tuplesort_getindextuple
+#define tuplesort_getdatum switcheroo_tuplesort_getdatum
+#define tuplesort_end switcheroo_tuplesort_end
+#define tuplesort_rescan switcheroo_tuplesort_rescan
+#define tuplesort_markpos switcheroo_tuplesort_markpos
+#define tuplesort_restorepos switcheroo_tuplesort_restorepos
+
+/* these are in tuplesort_gp.h */
+#define tuplesort_begin_heap_file_readerwriter switcheroo_tuplesort_begin_heap_file_readerwriter
+#define cdb_tuplesort_init switcheroo_cdb_tuplesort_init
+#define tuplesort_begin_pos switcheroo_tuplesort_begin_pos
+#define tuplesort_gettupleslot_pos switcheroo_tuplesort_gettupleslot_pos
+#define tuplesort_flush switcheroo_tuplesort_flush
+#define tuplesort_finalize_stats switcheroo_tuplesort_finalize_stats
+#define tuplesort_rescan_pos switcheroo_tuplesort_rescan_pos
+#define tuplesort_markpos_pos switcheroo_tuplesort_markpos_pos
+#define tuplesort_restorepos_pos switcheroo_tuplesort_restorepos_pos
+#define tuplesort_set_instrument switcheroo_tuplesort_set_instrument
+#define tuplesort_set_gpmon switcheroo_tuplesort_set_gpmon
+
+#endif
+
 
 #endif   /* TUPLESORT_H */

--- a/src/include/utils/tuplesort_gp.h
+++ b/src/include/utils/tuplesort_gp.h
@@ -8,6 +8,10 @@
  *    on top of the upstream entries from tuplesort.h:
  *    - Support for reader-writer tuplesort
  *
+ * NB: This should not be #included directly, only from tuplesort.h!
+ * The switcheroo magic to switch between the normal and MK tuplesorts
+ * might get confused otherwise.
+ *
  * Portions Copyright (c) 2007-2008, Greenplum inc
  * Portions Copyright (c) 2012-Present Pivotal Software, Inc.
  *
@@ -20,6 +24,7 @@
 #ifndef TUPLESORT_GP_H
 #define TUPLESORT_GP_H
 
+#include "utils/tuplesort.h"
 #include "nodes/execnodes.h"
 #include "utils/workfile_mgr.h"
 #include "gpmon/gpmon.h"
@@ -41,6 +46,7 @@ struct Tuplesortstate;
 
 
 extern struct Tuplesortstate *tuplesort_begin_heap_file_readerwriter(
+		ScanState * ss,
 		const char* rwfile_prefix, bool isWriter,
 		TupleDesc tupDesc, 
 		int nkeys, AttrNumber *attNums,


### PR DESCRIPTION
We have two implementations of tuplesort: the "regular" one inherited
from upstream, in tuplesort.c, and a GPDB-specific tuplesort_mk.c. We had
modified all the callers to check the gp_enable_mk_sort GUC, and deal with
both of them. However, that makes merging with upstream difficult, and
litters the code with the boilerplate to check the GUC and call one of
the two implementations.

Simplify the callers, by providing a single API that hides the two
implementations from the rest of the system. The API is the tuplesort_*
functions, as in upstream. This requires some preprocessor trickery,
so that tuplesort.c can use the tuplesort_* function names as is, but in
the rest of the codebase, calling tuplesort_*() will call a "switcheroo"
function that decides which implementation to actually call. While this
is more lines of code overall, it keeps all the ugliness confined in
tuplesort.h, not littered throughout the codebase.