### PR TITLE
Refactor to use AOCS totalbyte code

### DIFF
--- a/src/backend/storage/buffer/bufmgr.c
+++ b/src/backend/storage/buffer/bufmgr.c
@@ -2027,13 +2027,15 @@ RelationGetNumberOfBlocks(Relation relation)
 	 */
 	if (RelationIsAoRows(relation))
 	{
-		FileSegTotals *fstotal = GetSegFilesTotals(relation, SnapshotNow);
-		return ((BlockNumber)RelationGuessNumberOfBlocks(fstotal->totalbytes));
+		int64		totalbytes;
+
+		totalbytes = GetAOTotalBytes(relation, SnapshotNow);
+		return ((BlockNumber) RelationGuessNumberOfBlocks(totalbytes));
 	}
 	
 	if (RelationIsAoCols(relation))
 	{
-		int64 totalBytes = GetAOCSTotalBytes(relation, SnapshotNow);
+		int64 totalBytes = GetAOCSTotalBytes(relation, SnapshotNow, true);
 		return ((BlockNumber)RelationGuessNumberOfBlocks(totalBytes));
   	}
 	

--- a/src/backend/utils/adt/dbsize.c
+++ b/src/backend/utils/adt/dbsize.c
@@ -425,7 +425,7 @@ calculate_relation_size(Relation rel)
 	else if (RelationIsAoRows(rel))
 		totalsize = GetAOTotalBytes(rel, SnapshotNow);
 	else if (RelationIsAoCols(rel))
-		totalsize = GetAOCSTotalBytes(rel, SnapshotNow);
+		totalsize = GetAOCSTotalBytes(rel, SnapshotNow, false);
            
     /* RELSTORAGE_VIRTUAL has no space usage */
     return totalsize;

--- a/src/include/access/aocssegfiles.h
+++ b/src/include/access/aocssegfiles.h
@@ -178,7 +178,8 @@ extern void FreeAllAOCSSegFileInfo(AOCSFileSegInfo **allAOCSSegInfo, int totalSe
 
 extern int64 GetAOCSTotalBytes(
 				  Relation parentrel,
-				  Snapshot appendOnlyMetaDataSnapshot);
+				  Snapshot appendOnlyMetaDataSnapshot,
+				  bool compressed);
 extern FileSegTotals *GetAOCSSSegFilesTotals(Relation parentrel,
 					   Snapshot appendOnlyMetaDataSnapshot);
 


### PR DESCRIPTION
We had code for getting the total bytes consumed by an AOCS table,
as well as code implementing the very same asking for a common
function. Extend GetAOCSTotalBytes() to deal with uncompressed or
compressed data and refactor callsites to use this function.

This also removes the need for a memory allocation in the codepaths
which only want to know the number of bytes.