### PR TITLE
data integrity problem during write pipe operation.

### DIFF
--- a/src/backend/access/external/url_execute.c
+++ b/src/backend/access/external/url_execute.c
@@ -404,8 +404,10 @@ url_execute_fwrite(void *ptr, size_t size, URL_FILE *file, CopyState pstate)
 
     size_t n;
     /* ensure all data in buffer is send out to pipe*/
-    while((n = pipewrite(fd,p,size - offset)) < size - offset)
+    while(size > offset)
     {
+        n = pipewrite(fd,p,size - offset);
+
         if(n == -1) return -1;
 
         if(n == 0) break;

--- a/src/backend/access/external/url_execute.c
+++ b/src/backend/access/external/url_execute.c
@@ -314,8 +314,8 @@ url_execute_fclose(URL_FILE *file, bool failOnError, const char *relname)
 
 	cleanup_execute_handle(efile->handle);
 	efile->handle = NULL;
-	
-	url = pstrdup(file->url);	
+
+	url = pstrdup(file->url);
 	if (ret == 0)
 	{
 		/* pclose() ended successfully; no errors to reflect */
@@ -397,9 +397,26 @@ url_execute_fread(void *ptr, size_t size, URL_FILE *file, CopyState pstate)
 size_t
 url_execute_fwrite(void *ptr, size_t size, URL_FILE *file, CopyState pstate)
 {
-	URL_EXECUTE_FILE *efile = (URL_EXECUTE_FILE *) file;
+    URL_EXECUTE_FILE *efile = (URL_EXECUTE_FILE *) file;
+    int fd = efile->handle->pipes[EXEC_DATA_P];
+    size_t offset = 0;
+    const char* p = (const char* ) ptr;
 
-	return pipewrite(efile->handle->pipes[EXEC_DATA_P], ptr, size);
+    size_t n;
+    /* ensure all data in buffer is send out to pipe*/
+    while((n = pipewrite(fd,p,size - offset)) < size - offset)
+    {
+        if(n == -1) return -1;
+
+        if(n == 0) break;
+
+        offset += n;
+        p = (const char*)ptr + offset;
+    }
+
+    if(offset < size) elog(WARNING,"partial write, expected %lu, written %lu", size, offset);
+
+    return offset;
 }
 
 /*
@@ -593,7 +610,7 @@ popen_with_stderr(int *pipes, const char *exe, bool forwrite)
 	int data[2];	/* pipe to send data child <--> parent */
 	int err[2];		/* pipe to send errors child --> parent */
 	int pid = -1;
-	
+
 	const int READ = 0;
 	const int WRITE = 1;
 
@@ -609,7 +626,7 @@ popen_with_stderr(int *pipes, const char *exe, bool forwrite)
 #ifndef WIN32
 
 	pid = fork();
-	
+
 	if (pid > 0) /* parent */
 	{
 
@@ -623,16 +640,16 @@ popen_with_stderr(int *pipes, const char *exe, bool forwrite)
 		{
 			/* parent reads from child */
 			close(data[WRITE]);
-			pipes[EXEC_DATA_P] = data[READ]; 			
+			pipes[EXEC_DATA_P] = data[READ];
 		}
-		
+
 		close(err[WRITE]);
 		pipes[EXEC_ERR_P] = err[READ];
-		
+
 		return pid;
 	}
 	else if (pid == 0) /* child */
-	{		
+	{
 
 		/*
 		 * set up the data pipe
@@ -641,7 +658,7 @@ popen_with_stderr(int *pipes, const char *exe, bool forwrite)
 		{
 			close(data[WRITE]);
 			close(fileno(stdin));
-			
+
 			/* assign pipes to parent to stdin */
 			if (dup2(data[READ], fileno(stdin)) < 0)
 			{
@@ -650,13 +667,13 @@ popen_with_stderr(int *pipes, const char *exe, bool forwrite)
 			}
 
 			/* no longer needed after the duplication */
-			close(data[READ]);			
+			close(data[READ]);
 		}
 		else
 		{
 			close(data[READ]);
 			close(fileno(stdout));
-			
+
 			/* assign pipes to parent to stdout */
 			if (dup2(data[WRITE], fileno(stdout)) < 0)
 			{
@@ -667,26 +684,26 @@ popen_with_stderr(int *pipes, const char *exe, bool forwrite)
 			/* no longer needed after the duplication */
 			close(data[WRITE]);
 		}
-		
+
 		/*
 		 * now set up the error pipe
 		 */
 		close(err[READ]);
 		close(fileno(stderr));
-		
+
 		if (dup2(err[WRITE], fileno(stderr)) < 0)
 		{
 			if(forwrite)
 				close(data[WRITE]);
 			else
 				close(data[READ]);
-			
+
 			perror("dup2 error");
-			exit(EXIT_FAILURE);			
+			exit(EXIT_FAILURE);
 		}
 
 		close(err[WRITE]);
-				
+
 		/* go ahead and execute the user command */
 		execl("/bin/sh", "sh", "-c", exe, NULL);
 
@@ -707,8 +724,8 @@ popen_with_stderr(int *pipes, const char *exe, bool forwrite)
 		}
 		close(err[READ]);
 		close(err[WRITE]);
-		
-		return -1;		
+
+		return -1;
 	}
 #endif
 
@@ -759,10 +776,10 @@ int
 pclose_with_stderr(int pid, int *pipes, StringInfo sinfo)
 {
 	int status;
-	
+
 	/* close the data pipe. we can now read from error pipe without being blocked */
 	close(pipes[EXEC_DATA_P]);
-	
+
 	read_err_msg(pipes[EXEC_ERR_P], sinfo);
 
 	close(pipes[EXEC_ERR_P]);


### PR DESCRIPTION
the kernel does not provide IO pipe API that force sends data completeness in once invocation.
We need to evaluate whether should go on do IO after once return