### PR TITLE
Add set returning functions check in simplify_exists

### DIFF
--- a/src/test/regress/expected/bfv_subquery.out
+++ b/src/test/regress/expected/bfv_subquery.out
@@ -453,3 +453,40 @@ select * from foo where foo.a = (select min(bar.c) from bar where foo.b || bar.d
 (1 row)
 
 drop table foo, bar;
+--
+-- subqueries with unnest in projectlist
+--
+-- start_ignore
+DROP TABLE IF EXISTS A;
+NOTICE:  table "a" does not exist, skipping
+CREATE TABLE A AS SELECT ARRAY[1,2,3] AS X;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'x' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO A VALUES(NULL::int4[]);
+-- end_ignore
+SELECT (NOT EXISTS (SELECT UNNEST(X))) AS B FROM A;
+ b 
+---
+ f
+ t
+(2 rows)
+
+SELECT (EXISTS (SELECT UNNEST(X))) AS B FROM A;
+ b 
+---
+ t
+ f
+(2 rows)
+
+EXPLAIN SELECT (EXISTS (SELECT UNNEST(X))) AS B FROM A;
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.02 rows=1 width=33)
+   ->  Seq Scan on a  (cost=0.00..1.02 rows=1 width=33)
+         SubPlan 1
+           ->  Result  (cost=0.00..0.01 rows=1 width=0)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(6 rows)
+
+DROP TABLE A;

--- a/src/test/regress/expected/bfv_subquery_optimizer.out
+++ b/src/test/regress/expected/bfv_subquery_optimizer.out
@@ -448,3 +448,42 @@ select * from foo where foo.a = (select min(bar.c) from bar where foo.b || bar.d
 (1 row)
 
 drop table foo, bar;
+--
+-- subqueries with unnest in projectlist
+--
+-- start_ignore
+DROP TABLE IF EXISTS A;
+NOTICE:  table "a" does not exist, skipping
+CREATE TABLE A AS SELECT ARRAY[1,2,3] AS X;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+INSERT INTO A VALUES(NULL::int4[]);
+-- end_ignore
+SELECT (NOT EXISTS (SELECT UNNEST(X))) AS B FROM A;
+ b 
+---
+ f
+ t
+(2 rows)
+
+SELECT (EXISTS (SELECT UNNEST(X))) AS B FROM A;
+ b 
+---
+ t
+ f
+(2 rows)
+
+EXPLAIN SELECT (EXISTS (SELECT UNNEST(X))) AS B FROM A;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..882690.51 rows=1 width=1)
+   ->  Result  (cost=0.00..882690.51 rows=1 width=1)
+         ->  Table Scan on a  (cost=0.00..882690.51 rows=334 width=1)
+         SubPlan 1
+           ->  Result  (cost=0.00..0.00 rows=1 width=6)
+                 ->  Result  (cost=0.00..0.00 rows=1 width=6)
+                       ->  Result  (cost=0.00..0.00 rows=1 width=1)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.46.3
+(9 rows)
+
+DROP TABLE A;

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -1064,7 +1064,7 @@ explain select * from A where not exists (select sum(C.i) from C where C.i = A.i
    ->  Seq Scan on a  (cost=0.00..3.05 rows=2 width=8)
  Settings:  optimizer=off
  Optimizer status: legacy query optimizer
-(13 rows)
+(4 rows)
 
 select * from A where not exists (select sum(C.i) from C where C.i = A.i limit 5 offset 3);
  i  | j  
@@ -1083,7 +1083,7 @@ explain select * from A where not exists (select sum(C.i) from C where C.i = A.i
    One-Time Filter: false
  Settings:  optimizer=off
  Optimizer status: legacy query optimizer
-(13 rows)
+(4 rows)
 
 select * from A where not exists (select sum(C.i) from C where C.i = A.i limit 1 offset 0);
  i | j 
@@ -1091,20 +1091,25 @@ select * from A where not exists (select sum(C.i) from C where C.i = A.i limit 1
 (0 rows)
 
 explain select C.j from C where not exists (select max(B.i) from B  where C.i = B.i having max(B.i) is not null) order by C.j;
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=6.33..6.33 rows=4 width=4)
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=31.43..31.45 rows=5 width=4)
    Merge Key: c.j
-   ->  Sort  (cost=6.33..6.33 rows=2 width=4)
+   ->  Sort  (cost=31.43..31.45 rows=2 width=4)
          Sort Key: c.j
-         ->  Hash Anti Join  (cost=3.14..6.30 rows=2 width=4)
-               Hash Cond: c.i = b.i
-               ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=8)
-               ->  Hash  (cost=3.06..3.06 rows=2 width=4)
-                     ->  Seq Scan on b  (cost=0.00..3.06 rows=2 width=4)
+         ->  Seq Scan on c  (cost=0.00..31.39 rows=2 width=4)
+               Filter: NOT ((SubPlan 1))
+               SubPlan 1
+                 ->  Aggregate  (cost=3.13..3.14 rows=1 width=4)
+                       Filter: max(b.i) IS NOT NULL
+                       ->  Result  (cost=3.08..3.09 rows=1 width=4)
+                             Filter: $0 = b.i
+                             ->  Materialize  (cost=3.08..3.09 rows=1 width=4)
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.08 rows=1 width=4)
+                                         ->  Seq Scan on b  (cost=0.00..3.08 rows=1 width=4)
  Settings:  optimizer=off
  Optimizer status: legacy query optimizer
-(11 rows)
+(16 rows)
 
 select C.j from C where not exists (select max(B.i) from B  where C.i = B.i having max(B.i) is not null) order by C.j;
  j  

--- a/src/test/regress/sql/bfv_subquery.sql
+++ b/src/test/regress/sql/bfv_subquery.sql
@@ -271,3 +271,18 @@ select * from foo where not exists (select * from bar where foo.b = foo.b || 'a'
 select * from foo where foo.a = (select min(bar.c) from bar where foo.b || bar.d = 'bb');
 
 drop table foo, bar;
+
+--
+-- subqueries with unnest in projectlist
+--
+-- start_ignore
+DROP TABLE IF EXISTS A;
+CREATE TABLE A AS SELECT ARRAY[1,2,3] AS X;
+INSERT INTO A VALUES(NULL::int4[]);
+-- end_ignore
+
+SELECT (NOT EXISTS (SELECT UNNEST(X))) AS B FROM A;
+SELECT (EXISTS (SELECT UNNEST(X))) AS B FROM A;
+EXPLAIN SELECT (EXISTS (SELECT UNNEST(X))) AS B FROM A;
+
+DROP TABLE A;


### PR DESCRIPTION
This function had diverged a lot from upstream; post subselect merge. One of the main reason is that upstream has lot of restrictive checks which prevent pull-up of EXISTS/NOT EXISTS. GPDB handles them differently; thus producing a join/initplan or a one-time filter.

For following queries, Postgres 8.4 bails out during pull-up (because of relevant checks in `simplify_EXISTS_query()`) and produces a plan with subplan.

GPDB on the other hand, has some optimizations and creates a join, initplan or one-time filter. We have thus kept the GPDB behavior and removed those checks from `simplify_EXISTS_query()`.

- Limit with AGG
```
explain select * from A where not exists (select sum(C.i) from C where C.i = A.i limit 0);
```

- AGG with Group by Without HAVING
```
explain select * from A where not exists (select sum(C.i) from C where C.i = A.i group by a.i);
```

- AGG without HAVING and GROUP BY
```
explain select * from A where not exists (select sum(C.i) from C where C.i = A.i);
```

- HAVING with No AGG
```
explain select * from A where not exists (select sum(C.i) from C where C.i = A.i group by C.i having C.i > 3);
```

- Window Functions
```
explain select * from A where not exists (select rank() over(order by C.i) from C where C.i = A.i);
```

For other conditions, we bail out as upstream. 

Hence we have removed some of the checks from upstream in `simplify_EXISTS_query()` and added CDB specific checks 

Signed-off-by: Ekta Khanna <ekhanna@pivotal.io>

This PR fixes https://github.com/greenplum-db/gpdb/issues/3473