### PR TITLE
Fix planner bug in handling LIMIT without an ORDER BY.

### DIFF
--- a/src/test/regress/expected/bfv_planner.out
+++ b/src/test/regress/expected/bfv_planner.out
@@ -319,6 +319,19 @@ T1.a=T2.g and T1.c=T2.f;
      2
 (1 row)
 
+-- This produced a "could not find pathkey item to sort" error at one point.
+-- The problem was that we stripped out column b from the SubqueryScan's
+-- target list, as it's not needed in the final result, but we tried to
+-- maintain the ordering (a,b) in the Gather Motion node, which would have
+-- required column b to be present, at least as a junk column.
+create table bfv_planner_t3 (a int4, b int4);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+select a from (select * from bfv_planner_t3 order by a, b) as x limit 1;
+ a 
+---
+(0 rows)
+
 -- start_ignore
 drop table if exists bfv_planner_x;
 drop table if exists testbadsql;

--- a/src/test/regress/sql/bfv_planner.sql
+++ b/src/test/regress/sql/bfv_planner.sql
@@ -213,6 +213,15 @@ on
 T1.a=T2.g and T1.c=T2.f;
 
 
+-- This produced a "could not find pathkey item to sort" error at one point.
+-- The problem was that we stripped out column b from the SubqueryScan's
+-- target list, as it's not needed in the final result, but we tried to
+-- maintain the ordering (a,b) in the Gather Motion node, which would have
+-- required column b to be present, at least as a junk column.
+create table bfv_planner_t3 (a int4, b int4);
+select a from (select * from bfv_planner_t3 order by a, b) as x limit 1;
+
+
 -- start_ignore
 drop table if exists bfv_planner_x;
 drop table if exists testbadsql;


### PR DESCRIPTION
This bug was introduced in commit 7e268107f3, which changed the way we
track the "current" ordering in the planner.