### PR TITLE
Added tag filter to pxf_src.

### DIFF
--- a/concourse/pipelines/dev_generate_installer.yml
+++ b/concourse/pipelines/dev_generate_installer.yml
@@ -21,6 +21,7 @@ resources:
   type: git
   source:
     branch: {{pxf-git-branch}}
+    tag_filter: {{pxf-git-filter}}
     private_key: {{pxf-git-key}}
     uri: {{pxf-git-remote}}
 

--- a/concourse/pipelines/nbu_ddboost_pipeline.yml
+++ b/concourse/pipelines/nbu_ddboost_pipeline.yml
@@ -81,6 +81,7 @@ resources:
   type: git
   source:
     branch: {{pxf-git-branch}}
+    tag_filter: {{pxf-git-filter}}
     private_key: {{pxf-git-key}}
     uri: {{pxf-git-remote}}
 

--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -307,6 +307,7 @@ resources:
   type: git
   source:
     branch: {{pxf-git-branch}}
+    tag_filter: {{pxf-git-filter}}
     private_key: {{pxf-git-key}}
     uri: {{pxf-git-remote}}
 

--- a/concourse/pipelines/pipeline_segwalrep.yml
+++ b/concourse/pipelines/pipeline_segwalrep.yml
@@ -23,6 +23,7 @@ resources:
   type: git
   source:
     branch: {{pxf-git-branch}}
+    tag_filter: {{pxf-git-filter}}
     private_key: {{pxf-git-key}}
     uri: {{pxf-git-remote}}
 

--- a/concourse/pipelines/pr_pipeline.yml
+++ b/concourse/pipelines/pr_pipeline.yml
@@ -25,6 +25,7 @@ resources:
     type: git
     source:
       branch: {{pxf-git-branch}}
+      tag_filter: {{pxf-git-filter}}
       private_key: {{pxf-git-key}}
       uri: {{pxf-git-remote}}
 


### PR DESCRIPTION
As for now we are using internal mirror of Apache HAWQ for PXF source code.
For master pipelines it's fine to checking out master, but for release pipeline we want to be able to build and release of some specific tag.
This PR enables to checkout any specific tag(for release) or master of PXF repo.