### PR TITLE
git rid of git sha value from default installation path

### DIFF
--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -164,7 +164,6 @@ function _main() {
         ;;
   esac
 
-  generate_build_number
   make_sync_tools
   case "$TARGET_OS" in
     sles) link_tools_for_sles ;;

--- a/gpAux/releng/bin/assemble-installer-gpdb.sh
+++ b/gpAux/releng/bin/assemble-installer-gpdb.sh
@@ -375,7 +375,7 @@ generate-applicance-installer-header(){
 	cat <<-EOF_HEADER
 		#!/bin/sh
 
-		installPath=/usr/local/GP-$VERSION-${BUILD_NUMBER}
+		installPath=/usr/local/GP-$VERSION
 		install_log=\$( pwd )/install-\$( date +%d%m%y-%H%M%S ).log
 
 		cat > \${install_log} <<-EOF
@@ -386,7 +386,6 @@ generate-applicance-installer-header(){
 			Timestamp ......... : \$( date )
 			Product Installer.. : $INSTALLER_NAME
 			Product Version ... : $VERSION
-			Build Number ...... : ${BUILD_NUMBER}
 			Install Dir ....... : \${installPath}
 			Install Log file .. : \${install_log}
 			======================================================================

--- a/gpAux/releng/bin/rc-generate-installer-hdr.sh
+++ b/gpAux/releng/bin/rc-generate-installer-hdr.sh
@@ -424,7 +424,6 @@ generate_applicance_installer_header(){
 			Timestamp ......... : \$( date )
 			Product Installer.. : $INSTALLER_NAME
 			Product Version ... : $VERSION
-			Build Number ...... : ${BUILD_NUMBER}
 			Install Dir ....... : \${installPath}
 			Install Log file .. : \${install_log}
 			======================================================================


### PR DESCRIPTION
"commit:${git-sha-value}" was appended to the default installation path. It contains a ":", and it is not escaped correctly in the PATH environment of greenplum_path.sh