### PR TITLE
Allow using libpq and gp-libpq in the same process

### DIFF
--- a/src/backend/cdb/dispatcher/test/cdbgang_test.c
+++ b/src/backend/cdb/dispatcher/test/cdbgang_test.c
@@ -115,25 +115,25 @@ mockLibpq(PGconn *pgConn, uint32 motionListener, int qePid)
 
 	snprintf(motionListener_str, sizeof(motionListener_str), "%u", motionListener);
 
-	expect_any_count(PQconnectdbParams, keywords, -1);
-	expect_any_count(PQconnectdbParams, values, -1);
-	expect_any_count(PQconnectdbParams, expand_dbname, -1);
-	will_return_count(PQconnectdbParams, pgConn, TOTOAL_SEGMENTS);
+	expect_any_count(gp_PQconnectdbParams, keywords, -1);
+	expect_any_count(gp_PQconnectdbParams, values, -1);
+	expect_any_count(gp_PQconnectdbParams, expand_dbname, -1);
+	will_return_count(gp_PQconnectdbParams, pgConn, TOTOAL_SEGMENTS);
 
-	expect_value_count(PQstatus, conn, pgConn, -1);
-	will_return_count(PQstatus, CONNECTION_OK, -1);
+	expect_value_count(gp_PQstatus, conn, pgConn, -1);
+	will_return_count(gp_PQstatus, CONNECTION_OK, -1);
 
-	expect_value_count(PQsetNoticeReceiver, conn, pgConn, -1);
-	expect_any_count(PQsetNoticeReceiver, proc, -1);
-	expect_any_count(PQsetNoticeReceiver, arg, -1);
-	will_return_count(PQsetNoticeReceiver, CONNECTION_OK, -1);
+	expect_value_count(gp_PQsetNoticeReceiver, conn, pgConn, -1);
+	expect_any_count(gp_PQsetNoticeReceiver, proc, -1);
+	expect_any_count(gp_PQsetNoticeReceiver, arg, -1);
+	will_return_count(gp_PQsetNoticeReceiver, CONNECTION_OK, -1);
 
-	expect_value_count(PQparameterStatus, conn, pgConn, -1);
-	expect_string_count(PQparameterStatus, paramName, "qe_listener_port", -1);
-	will_return_count(PQparameterStatus, motionListener_str, -1);
+	expect_value_count(gp_PQparameterStatus, conn, pgConn, -1);
+	expect_string_count(gp_PQparameterStatus, paramName, "qe_listener_port", -1);
+	will_return_count(gp_PQparameterStatus, motionListener_str, -1);
 
-	expect_value_count(PQbackendPID, conn, pgConn, -1);
-	will_return_count(PQbackendPID, qePid, -1);
+	expect_value_count(gp_PQbackendPID, conn, pgConn, -1);
+	will_return_count(gp_PQbackendPID, qePid, -1);
 }
 
 static void

--- a/src/backend/gp_libpq_fe/README
+++ b/src/backend/gp_libpq_fe/README
@@ -1,0 +1,26 @@
+What is gp-libpq-fe?
+
+It's Greenplum modified libpq-fe.
+
+
+Why it's needed?
+
+Greenplum is a MPP system unlike PostgreSQL, it has communications between QD
+and QEs other than clients to server. This requires libpq to carry more
+information, and ignore some workflows such as authentication via unix domain
+socket connection. And at the same time we must keep the standard libpq for
+clients. So we have libpq-fe and gp-libpq-fe at the same time.
+
+
+How this works?
+
+1, gp-libpq-fe is built in server, libpq-fe is in the libpq.so.
+2, we use gp-libpq-use.h and gp-libpq-unuse.h to rename structs, typedefs and
+functions in this directory, which keeps tracks with upstream libpq and allows
+using libpq and gp-libpq in the same process (think about dblink).
+
+
+Please note:
+
+List all the libpq-fe structs, typedefs and functions in gp-libpq-use.h and
+gp-libpq-unuse.h, otherwise you will get warnings / errors while linking.

--- a/src/backend/gp_libpq_fe/fe-auth.c
+++ b/src/backend/gp_libpq_fe/fe-auth.c
@@ -49,6 +49,7 @@
 #include "gp-fe-auth.h"
 #include "libpq/md5.h"
 
+#include "gp-libpq-use.h"
 
 /*
  * Respond to AUTH_REQ_SCM_CREDS challenge.

--- a/src/backend/gp_libpq_fe/fe-connect.c
+++ b/src/backend/gp_libpq_fe/fe-connect.c
@@ -67,6 +67,8 @@
 #include "libpq/ip.h"
 #include "mb/pg_wchar.h"
 
+#include "gp-libpq-use.h"
+
 #ifndef FD_CLOEXEC
 #define FD_CLOEXEC 1
 #endif

--- a/src/backend/gp_libpq_fe/fe-exec.c
+++ b/src/backend/gp_libpq_fe/fe-exec.c
@@ -33,6 +33,8 @@
 #include <unistd.h>
 #endif
 
+#include "gp-libpq-use.h"
+
 #ifndef libpq_gettext
 #define libpq_gettext(x) gettext(x)
 #endif

--- a/src/backend/gp_libpq_fe/fe-misc.c
+++ b/src/backend/gp_libpq_fe/fe-misc.c
@@ -65,6 +65,8 @@
 #include "nodes/pg_list.h"
 #include "cdb/cdbpartition.h"
 
+#include "gp-libpq-use.h"
+
 static int pqPutMsgBytes(const void *buf, size_t len, PGconn *conn);
 static int pqSendSome(PGconn *conn, int len);
 static int pqSocketCheck(PGconn *conn, int forRead, int forWrite, time_t end_time);

--- a/src/backend/gp_libpq_fe/fe-protocol3.c
+++ b/src/backend/gp_libpq_fe/fe-protocol3.c
@@ -36,6 +36,7 @@
 #include <arpa/inet.h>
 #endif
 
+#include "gp-libpq-use.h"
 
 /*
  * This macro lists the backend message types that could be "long" (more

--- a/src/backend/gp_libpq_fe/gp-fe-auth.h
+++ b/src/backend/gp_libpq_fe/gp-fe-auth.h
@@ -19,7 +19,11 @@
 #include "gp-libpq-fe.h"
 #include "gp-libpq-int.h"
 
+#include "gp-libpq-use.h"
+
 extern int	pg_fe_sendauth(AuthRequest areq, PGconn *conn);
 extern char *pg_fe_getauthname(PQExpBuffer errorMessage);
+
+#include "gp-libpq-unuse.h"
 
 #endif   /* FE_AUTH_H */

--- a/src/backend/gp_libpq_fe/gp-libpq-fe.h
+++ b/src/backend/gp_libpq_fe/gp-libpq-fe.h
@@ -32,6 +32,8 @@ extern		"C"
  */
 #include "postgres_ext.h"
 
+#include "gp-libpq-use.h"
+
 /*
  * Option flags for PQcopyResult
  */

--- a/src/backend/gp_libpq_fe/gp-libpq-int.h
+++ b/src/backend/gp_libpq_fe/gp-libpq-int.h
@@ -45,6 +45,8 @@
 /* include stuff found in fe only */
 #include "pqexpbuffer.h"
 
+#include "gp-libpq-use.h"
+
 /*
  * POSTGRES backend dependent Constants.
  */

--- a/src/backend/gp_libpq_fe/gp-libpq-unuse.h
+++ b/src/backend/gp_libpq_fe/gp-libpq-unuse.h
@@ -1,0 +1,214 @@
+/*
+ * undef gp-libpq functions' names to allow using it with libpq in the same
+ * process, check the README
+ */
+
+#ifdef GP_LIBPQ_USE_H
+/*
+ * gp-libpq-fe.h
+ */
+
+/* structs and typedefs */
+#undef PGnotify
+#undef PQprintOpt
+#undef PQconninfoOption
+#undef PQArgBlock
+#undef PGresAttDesc
+#undef PQaoRelTupCount
+
+/* functions */
+#undef PQconnectStart
+#undef PQconnectStartParams
+#undef PQconnectPoll
+#undef PQconnectdb
+#undef PQconnectdbParams
+#undef PQsetdbLogin
+#undef PQfinish
+#undef PQconndefaults
+#undef PQconninfoParse
+#undef PQconninfoFree
+#undef PQresetStart
+#undef PQresetPoll
+#undef PQreset
+#undef PQgetCancel
+#undef PQfreeCancel
+#undef PQcancel
+#undef PQrequestFinish
+#undef PQrequestCancel
+#undef PQdb
+#undef PQuser
+#undef PQpass
+#undef PQhost
+#undef PQport
+#undef PQtty
+#undef PQoptions
+#undef PQstatus
+#undef PQtransactionStatus
+#undef PQparameterStatus
+#undef PQprotocolVersion
+#undef PQserverVersion
+#undef PQerrorMessage
+#undef PQsocket
+#undef PQbackendPID
+#undef PQconnectionNeedsPassword
+#undef PQconnectionUsedPassword
+#undef PQclientEncoding
+#undef PQsetClientEncoding
+#undef PQsetErrorVerbosity
+#undef PQtrace
+#undef PQuntrace
+#undef PQsetNoticeReceiver
+#undef PQsetNoticeProcessor
+#undef PQregisterThreadLock
+#undef PQexec
+#undef PQexecParams
+#undef PQprepare
+#undef PQexecPrepared
+#undef PQsendGpQuery_shared
+#undef PQsendQuery
+#undef PQsendQueryParams
+#undef PQsendPrepare
+#undef PQsendQueryPrepared
+#undef PQsetSingleRowMode
+#undef PQgetResult
+#undef PQisBusy
+#undef PQconsumeInput
+#undef PQnotifies
+#undef PQputCopyData
+#undef PQputCopyEnd
+#undef PQgetCopyData
+#undef PQgetline
+#undef PQputline
+#undef PQgetlineAsync
+#undef PQputnbytes
+#undef PQendcopy
+#undef PQsetnonblocking
+#undef PQisnonblocking
+#undef PQisthreadsafe
+#undef PQping
+#undef PQpingParams
+#undef PQflush
+#undef PQfn
+#undef PQresultStatus
+#undef PQresStatus
+#undef PQresultErrorMessage
+#undef PQresultErrorField
+#undef PQntuples
+#undef PQnfields
+#undef PQbinaryTuples
+#undef PQfname
+#undef PQfnumber
+#undef PQftable
+#undef PQftablecol
+#undef PQfformat
+#undef PQftype
+#undef PQfsize
+#undef PQfmod
+#undef PQcmdStatus
+#undef PQoidStatus
+#undef PQoidValue
+#undef PQcmdTuples
+#undef PQgetvalue
+#undef PQgetlength
+#undef PQgetisnull
+#undef PQnparams
+#undef PQparamtype
+#undef PQdescribePrepared
+#undef PQdescribePortal
+#undef PQsendDescribePrepared
+#undef PQsendDescribePortal
+#undef PQclear
+#undef PQfreemem
+#undef PQmakeEmptyPGresult
+#undef PQcopyResult
+#undef PQsetResultAttrs
+#undef PQresultAlloc
+#undef PQsetvalue
+#undef PQescapeStringConn
+#undef PQescapeLiteral
+#undef PQescapeIdentifier
+#undef PQescapeByteaConn
+#undef PQunescapeBytea
+#undef PQescapeString
+#undef PQescapeBytea
+#undef PQprint
+#undef PQdisplayTuples
+#undef PQprintTuples
+#undef lo_open
+#undef lo_close
+#undef lo_read
+#undef lo_write
+#undef lo_lseek
+#undef lo_creat
+#undef lo_create
+#undef lo_tell
+#undef lo_truncate
+#undef lo_unlink
+#undef lo_import
+#undef lo_import_with_oid
+#undef lo_export
+#undef PQmblen
+#undef PQdsplen
+#undef PQenv2encoding
+#undef PQprocessAoTupCounts
+#undef PQencryptPassword
+
+
+/*
+ * gp-libpq-int.h
+ */
+
+/* structs and typedefs */
+#undef pgCdbStatCell
+#undef PQEnvironmentOption
+
+/* functions */
+#undef pqPacketSend
+#undef pqGetHomeDirectory
+#undef pqSetResultError
+#undef pqCatenateResultError
+#undef pqResultAlloc
+#undef pqResultStrdup
+#undef pqClearAsyncResult
+#undef pqSaveErrorResult
+#undef pqPrepareAsyncResult
+#undef pqInternalNotice
+#undef pqSaveMessageField
+#undef pqSaveParameterStatus
+#undef pqRowProcessor
+#undef pqHandleSendFailure
+#undef pqBuildStartupPacket3
+#undef pqParseInput3
+#undef pqGetErrorNotice3
+#undef pqGetCopyData3
+#undef pqGetline3
+#undef pqGetlineAsync3
+#undef pqEndcopy3
+#undef pqFunctionCall3
+#undef pqCheckOutBufferSpace
+#undef pqCheckInBufferSpace
+#undef pqGetc
+#undef pqPutc
+#undef pqGets
+#undef pqGets_append
+#undef pqPuts
+#undef pqGetnchar
+#undef pqSkipnchar
+#undef pqPutnchar
+#undef pqGetInt
+#undef pqGetInt64
+#undef pqPutInt
+#undef pqPutMsgStart
+#undef pqPutMsgEnd
+#undef pqPutMsgEndNoAutoFlush
+#undef pqReadData
+#undef pqFlush
+#undef pqFlushNonBlocking
+#undef pqWait
+#undef pqWaitTimed
+#undef pqWaitTimeout
+#undef pqReadReady
+#undef pqWriteReady
+
+#undef GP_LIBPQ_USE_H
+#endif

--- a/src/backend/gp_libpq_fe/gp-libpq-use.h
+++ b/src/backend/gp_libpq_fe/gp-libpq-use.h
@@ -1,0 +1,215 @@
+/*
+ * define libpq functions' names to allow using it with gp-libpq in the same
+ * process, check the README
+ */
+
+#ifndef GP_LIBPQ_USE_H
+#define GP_LIBPQ_USE_H
+
+/*
+ * gp-libpq-fe.h
+ */
+
+/* structs and typedefs */
+#define PGnotify		gp_PGnotify
+#define PQprintOpt		gp_PQprintOpt
+#define PQconninfoOption		gp_PQconninfoOption
+#define PQArgBlock		gp_PQArgBlock
+#define PGresAttDesc		gp_PGresAttDesc
+#define PQaoRelTupCount		gp_PQaoRelTupCount
+
+/* functions */
+#define PQconnectStart		gp_PQconnectStart
+#define PQconnectStartParams		gp_PQconnectStartParams
+#define PQconnectPoll		gp_PQconnectPoll
+#define PQconnectdb		gp_PQconnectdb
+#define PQconnectdbParams		gp_PQconnectdbParams
+#define PQsetdbLogin		gp_PQsetdbLogin
+#define PQfinish		gp_PQfinish
+#define PQconndefaults		gp_PQconndefaults
+#define PQconninfoParse		gp_PQconninfoParse
+#define PQconninfoFree		gp_PQconninfoFree
+#define PQresetStart		gp_PQresetStart
+#define PQresetPoll		gp_PQresetPoll
+#define PQreset		gp_PQreset
+#define PQgetCancel		gp_PQgetCancel
+#define PQfreeCancel		gp_PQfreeCancel
+#define PQcancel		gp_PQcancel
+#define PQrequestFinish		gp_PQrequestFinish
+#define PQrequestCancel		gp_PQrequestCancel
+#define PQdb		gp_PQdb
+#define PQuser		gp_PQuser
+#define PQpass		gp_PQpass
+#define PQhost		gp_PQhost
+#define PQport		gp_PQport
+#define PQtty		gp_PQtty
+#define PQoptions		gp_PQoptions
+#define PQstatus		gp_PQstatus
+#define PQtransactionStatus		gp_PQtransactionStatus
+#define PQparameterStatus		gp_PQparameterStatus
+#define PQprotocolVersion		gp_PQprotocolVersion
+#define PQserverVersion		gp_PQserverVersion
+#define PQerrorMessage		gp_PQerrorMessage
+#define PQsocket		gp_PQsocket
+#define PQbackendPID		gp_PQbackendPID
+#define PQconnectionNeedsPassword		gp_PQconnectionNeedsPassword
+#define PQconnectionUsedPassword		gp_PQconnectionUsedPassword
+#define PQclientEncoding		gp_PQclientEncoding
+#define PQsetClientEncoding		gp_PQsetClientEncoding
+#define PQsetErrorVerbosity		gp_PQsetErrorVerbosity
+#define PQtrace		gp_PQtrace
+#define PQuntrace		gp_PQuntrace
+#define PQsetNoticeReceiver		gp_PQsetNoticeReceiver
+#define PQsetNoticeProcessor		gp_PQsetNoticeProcessor
+#define PQregisterThreadLock		gp_PQregisterThreadLock
+#define PQexec		gp_PQexec
+#define PQexecParams		gp_PQexecParams
+#define PQprepare		gp_PQprepare
+#define PQexecPrepared		gp_PQexecPrepared
+#define PQsendGpQuery_shared		gp_PQsendGpQuery_shared
+#define PQsendQuery		gp_PQsendQuery
+#define PQsendQueryParams		gp_PQsendQueryParams
+#define PQsendPrepare		gp_PQsendPrepare
+#define PQsendQueryPrepared		gp_PQsendQueryPrepared
+#define PQsetSingleRowMode		gp_PQsetSingleRowMode
+#define PQgetResult		gp_PQgetResult
+#define PQisBusy		gp_PQisBusy
+#define PQconsumeInput		gp_PQconsumeInput
+#define PQnotifies		gp_PQnotifies
+#define PQputCopyData		gp_PQputCopyData
+#define PQputCopyEnd		gp_PQputCopyEnd
+#define PQgetCopyData		gp_PQgetCopyData
+#define PQgetline		gp_PQgetline
+#define PQputline		gp_PQputline
+#define PQgetlineAsync		gp_PQgetlineAsync
+#define PQputnbytes		gp_PQputnbytes
+#define PQendcopy		gp_PQendcopy
+#define PQsetnonblocking		gp_PQsetnonblocking
+#define PQisnonblocking		gp_PQisnonblocking
+#define PQisthreadsafe		gp_PQisthreadsafe
+#define PQping		gp_PQping
+#define PQpingParams		gp_PQpingParams
+#define PQflush		gp_PQflush
+#define PQfn		gp_PQfn
+#define PQresultStatus		gp_PQresultStatus
+#define PQresStatus		gp_PQresStatus
+#define PQresultErrorMessage		gp_PQresultErrorMessage
+#define PQresultErrorField		gp_PQresultErrorField
+#define PQntuples		gp_PQntuples
+#define PQnfields		gp_PQnfields
+#define PQbinaryTuples		gp_PQbinaryTuples
+#define PQfname		gp_PQfname
+#define PQfnumber		gp_PQfnumber
+#define PQftable		gp_PQftable
+#define PQftablecol		gp_PQftablecol
+#define PQfformat		gp_PQfformat
+#define PQftype		gp_PQftype
+#define PQfsize		gp_PQfsize
+#define PQfmod		gp_PQfmod
+#define PQcmdStatus		gp_PQcmdStatus
+#define PQoidStatus		gp_PQoidStatus
+#define PQoidValue		gp_PQoidValue
+#define PQcmdTuples		gp_PQcmdTuples
+#define PQgetvalue		gp_PQgetvalue
+#define PQgetlength		gp_PQgetlength
+#define PQgetisnull		gp_PQgetisnull
+#define PQnparams		gp_PQnparams
+#define PQparamtype		gp_PQparamtype
+#define PQdescribePrepared		gp_PQdescribePrepared
+#define PQdescribePortal		gp_PQdescribePortal
+#define PQsendDescribePrepared		gp_PQsendDescribePrepared
+#define PQsendDescribePortal		gp_PQsendDescribePortal
+#define PQclear		gp_PQclear
+#define PQfreemem		gp_PQfreemem
+#define PQmakeEmptyPGresult		gp_PQmakeEmptyPGresult
+#define PQcopyResult		gp_PQcopyResult
+#define PQsetResultAttrs		gp_PQsetResultAttrs
+#define PQresultAlloc		gp_PQresultAlloc
+#define PQsetvalue		gp_PQsetvalue
+#define PQescapeStringConn		gp_PQescapeStringConn
+#define PQescapeLiteral		gp_PQescapeLiteral
+#define PQescapeIdentifier		gp_PQescapeIdentifier
+#define PQescapeByteaConn		gp_PQescapeByteaConn
+#define PQunescapeBytea		gp_PQunescapeBytea
+#define PQescapeString		gp_PQescapeString
+#define PQescapeBytea		gp_PQescapeBytea
+#define PQprint		gp_PQprint
+#define PQdisplayTuples		gp_PQdisplayTuples
+#define PQprintTuples		gp_PQprintTuples
+#define lo_open		gp_lo_open
+#define lo_close		gp_lo_close
+#define lo_read		gp_lo_read
+#define lo_write		gp_lo_write
+#define lo_lseek		gp_lo_lseek
+#define lo_creat		gp_lo_creat
+#define lo_create		gp_lo_create
+#define lo_tell		gp_lo_tell
+#define lo_truncate		gp_lo_truncate
+#define lo_unlink		gp_lo_unlink
+#define lo_import		gp_lo_import
+#define lo_import_with_oid		gp_lo_import_with_oid
+#define lo_export		gp_lo_export
+#define PQmblen		gp_PQmblen
+#define PQdsplen		gp_PQdsplen
+#define PQenv2encoding		gp_PQenv2encoding
+#define PQprocessAoTupCounts		gp_PQprocessAoTupCounts
+#define PQencryptPassword		gp_PQencryptPassword
+
+
+/*
+ * gp-libpq-int.h
+ */
+
+/* structs and typedefs */
+#define pgCdbStatCell		gp_pgCdbStatCell
+#define PQEnvironmentOption		gp_PQEnvironmentOption
+
+/* functions */
+#define pqPacketSend		gp_pqPacketSend
+#define pqGetHomeDirectory		gp_pqGetHomeDirectory
+#define pqSetResultError		gp_pqSetResultError
+#define pqCatenateResultError		gp_pqCatenateResultError
+#define pqResultAlloc		gp_pqResultAlloc
+#define pqResultStrdup		gp_pqResultStrdup
+#define pqClearAsyncResult		gp_pqClearAsyncResult
+#define pqSaveErrorResult		gp_pqSaveErrorResult
+#define pqPrepareAsyncResult		gp_pqPrepareAsyncResult
+#define pqInternalNotice		gp_pqInternalNotice
+#define pqSaveMessageField		gp_pqSaveMessageField
+#define pqSaveParameterStatus		gp_pqSaveParameterStatus
+#define pqRowProcessor		gp_pqRowProcessor
+#define pqHandleSendFailure		gp_pqHandleSendFailure
+#define pqBuildStartupPacket3		gp_pqBuildStartupPacket3
+#define pqParseInput3		gp_pqParseInput3
+#define pqGetErrorNotice3		gp_pqGetErrorNotice3
+#define pqGetCopyData3		gp_pqGetCopyData3
+#define pqGetline3		gp_pqGetline3
+#define pqGetlineAsync3		gp_pqGetlineAsync3
+#define pqEndcopy3		gp_pqEndcopy3
+#define pqFunctionCall3		gp_pqFunctionCall3
+#define pqCheckOutBufferSpace		gp_pqCheckOutBufferSpace
+#define pqCheckInBufferSpace		gp_pqCheckInBufferSpace
+#define pqGetc		gp_pqGetc
+#define pqPutc		gp_pqPutc
+#define pqGets		gp_pqGets
+#define pqGets_append		gp_pqGets_append
+#define pqPuts		gp_pqPuts
+#define pqGetnchar		gp_pqGetnchar
+#define pqSkipnchar		gp_pqSkipnchar
+#define pqPutnchar		gp_pqPutnchar
+#define pqGetInt		gp_pqGetInt
+#define pqGetInt64		gp_pqGetInt64
+#define pqPutInt		gp_pqPutInt
+#define pqPutMsgStart		gp_pqPutMsgStart
+#define pqPutMsgEnd		gp_pqPutMsgEnd
+#define pqPutMsgEndNoAutoFlush		gp_pqPutMsgEndNoAutoFlush
+#define pqReadData		gp_pqReadData
+#define pqFlush		gp_pqFlush
+#define pqFlushNonBlocking		gp_pqFlushNonBlocking
+#define pqWait		gp_pqWait
+#define pqWaitTimed		gp_pqWaitTimed
+#define pqWaitTimeout		gp_pqWaitTimeout
+#define pqReadReady		gp_pqReadReady
+#define pqWriteReady		gp_pqWriteReady
+
+#endif

--- a/src/backend/gp_libpq_fe/pqexpbuffer.c
+++ b/src/backend/gp_libpq_fe/pqexpbuffer.c
@@ -38,6 +38,7 @@
 #include "win32.h"
 #endif
 
+#include "gp-libpq-use.h"
 
 /* All "broken" PQExpBuffers point to this string. */
 static const char oom_buffer[1] = "";

--- a/src/backend/gp_libpq_fe/pqexpbuffer.h
+++ b/src/backend/gp_libpq_fe/pqexpbuffer.h
@@ -31,6 +31,8 @@
 #ifndef PQEXPBUFFER_H
 #define PQEXPBUFFER_H
 
+#include "gp-libpq-use.h"
+
 /*-------------------------
  * PQExpBufferData holds information about an extensible string.
  *		data	is the current buffer for the string (allocated with malloc).
@@ -199,5 +201,7 @@ extern void appendPQExpBufferChar(PQExpBuffer str, char ch);
  */
 extern void appendBinaryPQExpBuffer(PQExpBuffer str,
 						const char *data, size_t datalen);
+
+#include "gp-libpq-unuse.h"
 
 #endif   /* PQEXPBUFFER_H */

--- a/src/backend/gp_libpq_fe/win32.c
+++ b/src/backend/gp_libpq_fe/win32.c
@@ -32,6 +32,8 @@
 
 #include "win32.h"
 
+#include "gp-libpq-use.h"
+
 /* Declared here to avoid pulling in all includes, which causes name collissions */
 #ifdef ENABLE_NLS
 extern char *

--- a/src/backend/gp_libpq_fe/win32.h
+++ b/src/backend/gp_libpq_fe/win32.h
@@ -4,6 +4,8 @@
 #ifndef __win32_h_included
 #define __win32_h_included
 
+#include "gp-libpq-use.h"
+
 /*
  * Some compatibility functions
  */
@@ -33,5 +35,7 @@
  * support for handling Windows Socket errors
  */
 extern const char *winsock_strerror(int err, char *strerrbuf, size_t buflen);
+
+#include "gp-libpq-unuse.h"
 
 #endif

--- a/src/interfaces/libpq/libpq-fe.h
+++ b/src/interfaces/libpq/libpq-fe.h
@@ -28,6 +28,10 @@ extern		"C"
  */
 #include "postgres_ext.h"
 
+#ifdef GP_LIBPQ_USE_H
+#include "../../backend/gp_libpq_fe/gp-libpq-unuse.h"
+#endif
+
 /*
  * Option flags for PQcopyResult
  */

--- a/src/interfaces/libpq/libpq-int.h
+++ b/src/interfaces/libpq/libpq-int.h
@@ -45,6 +45,10 @@
 /* include stuff found in fe only */
 #include "pqexpbuffer.h"
 
+#ifdef GP_LIBPQ_USE_H
+#include "../../backend/gp_libpq_fe/gp-libpq-unuse.h"
+#endif
+
 #ifdef ENABLE_GSS
 #if defined(HAVE_GSSAPI_H)
 #include <gssapi.h>

--- a/src/test/regress/checkinc.py
+++ b/src/test/regress/checkinc.py
@@ -83,7 +83,9 @@ fileset = {
     'machine/sys/inline.h':  [],
     # snowball/libstemmer/header.h includes "api.h", without specifying
     # a path. Don't be alarmed by that.
-    'api.h': []
+    'api.h': [],
+    # check src/backend/gp_libpq_fe/README
+    '../../backend/gp_libpq_fe/gp-libpq-unuse.h':  []
 }
 
 


### PR DESCRIPTION
dblink is QD to QD, supposed to use the standard libpq, otherwise
the conflicts between defintions and declarations will cause
dereferencing panic.

This commit allows dblink to use standard libpq communicating from QD to
QD.