### PR TITLE
Port numbers used by GPDB should be below kernel's ephemeral port range

### DIFF
--- a/gpMgmt/doc/gpconfigs/gpinitsystem_config
+++ b/gpMgmt/doc/gpconfigs/gpinitsystem_config
@@ -14,7 +14,7 @@ SEG_PREFIX=gpseg
 
 #### Base number by which primary segment port numbers 
 #### are calculated.
-PORT_BASE=40000
+PORT_BASE=20000
 
 #### File system location(s) where primary segment data directories 
 #### will be created. The number of locations in the list dictate
@@ -49,15 +49,15 @@ ENCODING=UNICODE
 
 #### Base number by which mirror segment port numbers 
 #### are calculated.
-#MIRROR_PORT_BASE=50000
+#MIRROR_PORT_BASE=21000
 
 #### Base number by which primary file replication port 
 #### numbers are calculated.
-#REPLICATION_PORT_BASE=41000
+#REPLICATION_PORT_BASE=22000
 
 #### Base number by which mirror file replication port 
 #### numbers are calculated. 
-#MIRROR_REPLICATION_PORT_BASE=51000
+#MIRROR_REPLICATION_PORT_BASE=23000
 
 #### File system location(s) where mirror segment data directories 
 #### will be created. The number of mirror locations must equal the

--- a/gpMgmt/doc/gpconfigs/gpinitsystem_singlenode
+++ b/gpMgmt/doc/gpconfigs/gpinitsystem_singlenode
@@ -40,7 +40,7 @@ SEG_PREFIX=gpsne
 # started on a segment host. The base port number will be 
 # incremented by one for each segment instance started on a host. 
 
-PORT_BASE=40000
+PORT_BASE=20000
 
 
 # This specifies the data storage location(s) where the script will 


### PR DESCRIPTION
The ephemeral port range is given by net.ipv4.ip_local_port_range kernel
parameter. It is set to 32768 --> 60999. If GPDB uses port numbers in this
range, FTS probe request may not get a response, resulting in FTS incorrectly
marking a primary down.

We change the example configuration files to lower the port number to proper
range.

Signed-off-by: Asim R P <apraveen@pivotal.io>