### PR TITLE
Add bool variable validate_reloptions to QueryDispatchDesc

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -400,6 +400,11 @@ ExecutorStart(QueryDesc *queryDesc, int eflags)
 		ddesc = makeNode(QueryDispatchDesc);
 		queryDesc->ddesc = ddesc;
 
+		if (queryDesc->dest->mydest == DestIntoRel)
+			queryDesc->ddesc->validate_reloptions = false;
+		else
+			queryDesc->ddesc->validate_reloptions = true;
+
 		/*
 		 * If this is an extended query (normally cursor or bind/exec) - before
 		 * starting the portal, we need to make sure that the shared snapshot is
@@ -4802,12 +4807,12 @@ OpenIntoRel(QueryDesc *queryDesc)
 									 false);
 
 	/* get the relstorage (heap or AO tables) */
-	stdRdOptions = (StdRdOptions*) heap_reloptions(relkind, reloptions, true);
+	stdRdOptions = (StdRdOptions*) heap_reloptions(relkind, reloptions, queryDesc->ddesc->validate_reloptions);
 	if(stdRdOptions->appendonly)
 		relstorage = stdRdOptions->columnstore ? RELSTORAGE_AOCOLS : RELSTORAGE_AOROWS;
 	else
 		relstorage = RELSTORAGE_HEAP;
-	
+
 	/* have to copy the actual tupdesc to get rid of any constraints */
 	tupdesc = CreateTupleDescCopy(queryDesc->tupDesc);
 
@@ -4839,7 +4844,7 @@ OpenIntoRel(QueryDesc *queryDesc)
 											  targetPolicy,  	/* MPP */
 											  reloptions,
 											  allowSystemTableModsDDL,
-											  /* valid_opts */false,
+											  /* valid_opts */ !queryDesc->ddesc->validate_reloptions,
 						 					  &persistentTid,
 						 					  &persistentSerialNum);
 

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -144,6 +144,7 @@ _copyQueryDispatchDesc(QueryDispatchDesc *from)
 	COPY_NODE_FIELD(sliceTable);
 	COPY_NODE_FIELD(oidAssignments);
 	COPY_NODE_FIELD(cursorPositions);
+	COPY_SCALAR_FIELD(validate_reloptions);
 
 	return newnode;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -331,6 +331,7 @@ _outQueryDispatchDesc(StringInfo str, QueryDispatchDesc *node)
 	WRITE_NODE_FIELD(oidAssignments);
 	WRITE_NODE_FIELD(sliceTable);
 	WRITE_NODE_FIELD(cursorPositions);
+	WRITE_BOOL_FIELD(validate_reloptions);
 }
 
 static void

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -1484,6 +1484,7 @@ _readQueryDispatchDesc(void)
 	READ_NODE_FIELD(oidAssignments);
 	READ_NODE_FIELD(sliceTable);
 	READ_NODE_FIELD(cursorPositions);
+	READ_BOOL_FIELD(validate_reloptions);
 	READ_DONE();
 }
 

--- a/src/include/executor/execdesc.h
+++ b/src/include/executor/execdesc.h
@@ -186,6 +186,16 @@ typedef struct QueryDispatchDesc
 	SliceTable *sliceTable;
 
 	List	   *cursorPositions;
+
+	/*
+	 * Set to true for CTAS and SELECT INTO. Set to false for ALTER TABLE
+	 * REORGANIZE. This is mainly used to track if the dispatched query is
+	 * meant for internal rewrite on QE segments or just for holding data from
+	 * a SELECT for a new relation. If DestIntoRel is set in the QD's
+	 * queryDesc->dest, use the original table's reloptions. If DestRemote is
+	 * set, use default reloptions + gp_default_storage_options.
+	 */
+	bool validate_reloptions;
 } QueryDispatchDesc;
 
 /*

--- a/src/test/regress/expected/dsp.out
+++ b/src/test/regress/expected/dsp.out
@@ -911,6 +911,65 @@ SELECT DISTINCT relname, reloptions FROM gp_dist_random('pg_class') WHERE relnam
 (1 row)
 
 RESET gp_vmem_idle_resource_timeout;
+-- Make sure ALTER TABLE REORGANIZE does not change the table type due
+-- to gp_default_storage_options GUC
+set gp_default_storage_options='appendonly=false,blocksize=32768';
+create table alter_table_reorg_heap (a int, b text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+select relname, relstorage, reloptions from pg_class where relname='alter_table_reorg_heap';
+        relname         | relstorage | reloptions 
+------------------------+------------+------------
+ alter_table_reorg_heap | h          | 
+(1 row)
+
+set gp_default_storage_options='appendonly=true,blocksize=32768,orientation=column';
+alter table alter_table_reorg_heap set with (reorganize=true);
+select relname, relstorage, reloptions from pg_class where relname='alter_table_reorg_heap';
+        relname         | relstorage | reloptions 
+------------------------+------------+------------
+ alter_table_reorg_heap | h          | 
+(1 row)
+
+set gp_default_storage_options='appendonly=true,blocksize=32768,orientation=column';
+create table alter_table_reorg_aoco (a int, b text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+select relname, relstorage, reloptions from pg_class where relname='alter_table_reorg_aoco';
+        relname         | relstorage |              reloptions              
+------------------------+------------+--------------------------------------
+ alter_table_reorg_aoco | c          | {appendonly=true,orientation=column}
+(1 row)
+
+set gp_default_storage_options='appendonly=false,blocksize=32768';
+alter table alter_table_reorg_aoco set with (reorganize=true);
+select relname, relstorage, reloptions from pg_class where relname='alter_table_reorg_aoco';
+        relname         | relstorage |              reloptions              
+------------------------+------------+--------------------------------------
+ alter_table_reorg_aoco | c          | {appendonly=true,orientation=column}
+(1 row)
+
+-- Make sure SELECT INTO uses gp_default_storage_options GUC
+create table select_into_heap_from (a int, b text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into select_into_heap_from select i, 'aaa' from generate_series(1,50)i;
+set gp_default_storage_options='appendonly=true,blocksize=32768,orientation=column';
+select * into select_into_heap_to from select_into_heap_from;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+select relname, relstorage, reloptions from pg_class where relname='select_into_heap_to';
+       relname       | relstorage |              reloptions              
+---------------------+------------+--------------------------------------
+ select_into_heap_to | c          | {appendonly=true,orientation=column}
+(1 row)
+
+select count(*) from select_into_heap_to;
+ count
+-------
+   50
+(1 row)
+
 -- cleanup
 \c postgres
 drop database dsp1;


### PR DESCRIPTION
When the gp_default_storage_options GUC was set and a table was
rewritten with ALTER TABLE REORGANIZE, the temp table generated would
take the storage options of the GUC instead of from the original
table. We should not be looking at default storage options when doing
internal queries. To prevent this, we add a boolean variable called
internal to the QueryDispatchDesc so that QE segments will know
whether or not to use the default storage options.

Authors: Jimmy Yih and Abhijit Subramanya

This will be backported to 5X_STABLE as well.