### PR TITLE
Fix crash for query with cube and having clause

### DIFF
--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -1339,6 +1339,10 @@ agg_retrieve_direct(AggState *aggstate)
 			if (!node->lastAgg && is_middle_rollup_agg)
 				return outerslot;
 
+			/* At this point we are done scanning the agg state because a null outerslot was produced above */
+			if(aggstate->agg_done)
+				return NULL;
+
 			/*
 			 * For the top-level of a rollup, we need to finalize
 			 * the aggregate value. First, we reset the context,


### PR DESCRIPTION
We were not handling the case when a NULL outerslot was produced in agg_retrieve_direct.

Below query was already crashing out 

```
SELECT 1 FROM (VALUES (1,1)) src(issuer_name, currency)  GROUP BY cube(ISSUER_NAME, CURRENCY) HAVING ISSUER_NAME IS NOT NULL;
```

Because in ```agg_retrieve_direct``` we were not handling the case where outer plan produced no tuples at all.  The NULL tuple was passed around which led to a crash. 