### PR TITLE
docs - resgroup gp_resgroup_memory_policy GUC, show/set limit bypass

### DIFF
--- a/gpdb-doc/dita/admin_guide/wlmgmt.xml
+++ b/gpdb-doc/dita/admin_guide/wlmgmt.xml
@@ -72,7 +72,7 @@
             <row>
               <entry colname="col1">Limit Bypass</entry>
               <entry colname="col2">Limits are not enforced for <codeph>SUPERUSER</codeph> roles and certain operators and functions</entry>
-              <entry colname="col3">No limit bypass cases</entry>
+              <entry colname="col3">Limits are not enforced on <codeph>SET</codeph> and <codeph>SHOW</codeph> commands</entry>
             </row>
           </tbody>
         </tgroup>

--- a/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
@@ -44,7 +44,7 @@
           </tbody>
         </tgroup>
       </table>
-
+      <note>Resource limits are not enforced on <codeph>SET</codeph> and <codeph>SHOW</codeph> commands.</note>
   </body>
 
   <topic id="topic8339717179" xml:lang="en">
@@ -89,7 +89,9 @@
       <p>When a query's memory usage exceeds the fixed per-transaction memory usage amount, Greenplum Database allocates available resource group shared memory to the query. The maximum amount of resource group memory available to a specific transaction slot is the sum of the transaction's fixed memory and the full resource group shared memory allotment.</p>
 
     <section id="topic833sp" xml:lang="en">
-     <title>Spill to Disk</title>
+     <title>Query Operator Memory</title>
+      <p>Most query operators are non-memory-intensive; that is, during processing, Greenplum Database can hold their data in allocated memory. When memory-intensive query operators such as join and sort process more data than can be held in memory, data is spilled to disk.</p>
+      <p>The <codeph><xref href="../ref_guide/config_params/guc-list.xml#gp_resgroup_memory_policy" type="section"/></codeph> server configuration parameter governs the memory allocation and distribution algorithm for all query operators. Greenplum Database supports <codeph>eager-free</codeph> (the default) and <codeph>auto</codeph> memory policies for resource groups. When you specify the <codeph>auto</codeph> policy, Greenplum Database uses resource group memory limits to distribute memory across query operators, allocating a fixed size of memory to non-memory-intensive operators and the rest to memory-intensive operators. When the <codeph>eager_free</codeph> policy is in place, Greenplum Database distributes memory among operators more optimally by re-allocating memory released by operators that have completed their processing to operators in a later query stage.</p>
       <p><codeph>MEMORY_SPILL_RATIO</codeph> identifies the memory usage threshold for memory-intensive operators in a transaction. When the transaction reaches this memory threshold, it spills to disk. Greenplum Database uses the <codeph>MEMORY_SPILL_RATIO</codeph> to determine the initial memory to allocate to a transaction.</p>
       <p> The minimum <codeph>MEMORY_SPILL_RATIO</codeph> percentage you can specify for a resource group is 0. The maximum is 100. The default <codeph>MEMORY_SPILL_RATIO</codeph> is 20.</p>
       <p>You define the <codeph>MEMORY_SPILL_RATIO</codeph> when you create a resource group. You can selectively set this limit on a per-query basis at the session level with the <codeph><xref href="../ref_guide/config_params/guc-list.xml#memory_spill_ratio" type="section"/></codeph> server configuration parameter.</p>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -398,6 +398,9 @@
               <xref href="#gp_reraise_signal"/>
             </li>
             <li>
+              <xref href="#gp_resgroup_memory_policy"/>
+            </li>
+            <li>
               <xref href="#gp_resource_group_cpu_limit"/>
             </li>
             <li>
@@ -4869,6 +4872,38 @@
               <entry colname="col1">Boolean</entry>
               <entry colname="col2">on</entry>
               <entry colname="col3">master<p>session</p><p>reload</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
+  <topic id="gp_resgroup_memory_policy">
+    <title>gp_resgroup_memory_policy</title>
+    <body>
+      <note type="warning">Resource groups are an experimental feature and
+        are not intended for use in a production environment. Experimental features are subject to
+        change without notice in future releases.</note>
+      <p>Used by a resource group to manage memory allocation to query operators.</p>
+      <p>When set to <codeph>auto</codeph>, Greenplum Database uses resource group memory limits to distribute memory across query operators, allocating a fixed size of memory to non-memory-intensive operators and the rest to memory-intensive operators.</p>
+      <p>When you specify <codeph>eager_free</codeph>, Greenplum Database distributes memory among operators more optimally by re-allocating memory released by operators that have completed their processing to operators in a later query stage.</p>
+      <table id="gp_resgroup_memory_policy_table">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">auto, eager_free</entry>
+              <entry colname="col2">eager_free</entry>
+              <entry colname="col3">local<p>system</p><p>superuser</p><p>restart/reload</p></entry>
             </row>
           </tbody>
         </tgroup>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -1201,6 +1201,10 @@
         <strow>
           <stentry>
             <p>
+              <xref href="guc-list.xml#gp_resgroup_memory_policy" type="section"
+                >gp_resgroup_memory_policy</xref>
+            </p>
+            <p>
               <xref href="guc-list.xml#gp_resource_group_cpu_limit" type="section"
                 >gp_resource_group_cpu_limit</xref>
             </p>


### PR DESCRIPTION
in this PR:
- add gp_resgroup_memory_policy GUC to "Resource Groups" category
- add gp_resgroup_memory_policy GUC description 
- "Using Resource Groups" page:
    - add a note that resource group limits are not enforced on SET/SHOW commands (unrelated)
    - change "Spill to Disk" section name to "Query Operator Memory" and add discussion of operators and gp_resgroup_memory_policy
- "Managing Resources" page - comparison table, "Bypass" row - identify that resource group limits are not enforced on SET/SHOW commands
    