### PR TITLE
Mark join assoiativity & commutativity GUC visible

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4669,7 +4669,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"optimizer_join_arity_for_associativity_commutativity", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Maximum number of children n-ary-join have without disabling commutativity and associativity transform"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_join_arity_for_associativity_commutativity,
 		7, 0, INT_MAX, NULL, NULL


### PR DESCRIPTION
Allow GUC optimizer_join_arity_for_associativity_commutativity
to be visible to regular database users.