### PR TITLE
Back-patch libpq support for TLS versions beyond v1

### DIFF
--- a/src/backend/libpq/be-secure.c
+++ b/src/backend/libpq/be-secure.c
@@ -768,6 +768,13 @@ initialize_SSL(void)
 #endif
 		SSL_library_init();
 		SSL_load_error_strings();
+
+		/*
+		 * We use SSLv23_method() because it can negotiate use of the highest
+		 * mutually supported protocol version, while alternatives like
+		 * TLSv1_2_method() permit only one specific version.  Note that we
+		 * don't actually allow SSL v2, only v3 and TLS protocols (see below).
+		 */
 		SSL_context = SSL_CTX_new(SSLv23_method());
 		if (!SSL_context)
 			ereport(FATAL,

--- a/src/interfaces/libpq/fe-secure.c
+++ b/src/interfaces/libpq/fe-secure.c
@@ -961,7 +961,13 @@ init_ssl_system(PGconn *conn)
 			SSL_load_error_strings();
 		}
 
-		SSL_context = SSL_CTX_new(TLSv1_method());
+		/*
+		 * We use SSLv23_method() because it can negotiate use of the highest
+		 * mutually supported protocol version, while alternatives like
+		 * TLSv1_2_method() permit only one specific version.  Note that we
+		 * don't actually allow SSL v2 or v3, only TLS protocols (see below).
+		 */
+		SSL_context = SSL_CTX_new(SSLv23_method());
 		if (!SSL_context)
 		{
 			char	   *err = SSLerrmessage();
@@ -975,6 +981,9 @@ init_ssl_system(PGconn *conn)
 #endif
 			return -1;
 		}
+
+		/* Disable old protocol versions */
+		SSL_CTX_set_options(SSL_context, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3);
 
 		/*
 		 * Disable OpenSSL's moving-write-buffer sanity check, because it


### PR DESCRIPTION
This backports the frontend parts of TLSv1+ support from upstream, we already have the backend portions from an unrelated backport into libpq.
```
  commit 4dddf8552801ef013c40b22915928559a6fb22a0
  Author: Tom Lane <tgl@sss.pgh.pa.us>
  Date:   Thu May 21 20:41:55 2015 -0400

    Back-patch libpq support for TLS versions beyond v1.

    Since 7.3.2, libpq has been coded in such a way that the only SSL protocol
    it would allow was TLS v1.  That approach is looking increasingly obsolete.
    In commit 820f08cabdcbb899 we fixed it to allow TLS >= v1, but did not
    back-patch the change at the time, partly out of caution and partly because
    the question was confused by a contemporary server-side change to reject
    the now-obsolete SSL protocol v3.  9.4 has now been out long enough that
    it seems safe to assume the change is OK; hence, back-patch into 9.0-9.3.

    (I also chose to back-patch some relevant comments added by commit
    326e1d73c476a0b5, but did *not* change the server behavior; hence, pre-9.4
    servers will continue to allow SSL v3, even though no remotely modern
    client will request it.)

    Per gripe from Jan Bilek.
```