### PR TITLE
Add gp_query_tags GUC

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -326,6 +326,8 @@ bool		gp_debug_resqueue_priority = false;
 double		gp_resource_group_cpu_limit;
 double		gp_resource_group_memory_limit;
 
+char		*gp_query_tags;
+
 /* Perfmon segment GUCs */
 int			gp_perfmon_segment_interval;
 static char *gpperfmon_log_alert_level_str;
@@ -5366,6 +5368,16 @@ struct config_string ConfigureNamesString_gp[] =
 		},
 		&gp_server_version_string,
 		GP_VERSION, NULL, NULL
+	},
+
+	{
+		{"gp_query_tags", PGC_USERSET, LOGGING_WHAT,
+			gettext_noop("Sets the query tags for queries in this session."),
+			gettext_noop("See the Greenplum Database documentation for details."),
+			GUC_NOT_IN_SAMPLE
+		},
+		&gp_query_tags,
+		"", NULL, NULL
 	},
 
 	/* End-of-list marker */


### PR DESCRIPTION
Currently, this GUC has no effect. In the future, it will be used by
applications to identify their sessions to tools that integrate with
Greenplum.

Signed-off-by: Ben Christel <bchristel@pivotal.io>
Signed-off-by: Amil Khanzada <akhanzada@pivotal.io>

We're looking for feedback on a couple of points:

- Should we use `GUC_NOT_IN_SAMPLE` for this?
- How should we test this? Where can we find examples of tests for other GUCs?