### PR TITLE
Add xlogging for AO truncate

### DIFF
--- a/contrib/xlogdump/xlogdump_rmgr.c
+++ b/contrib/xlogdump/xlogdump_rmgr.c
@@ -1487,41 +1487,36 @@ print_rmgr_ao(XLogRecPtr cur, XLogRecord *record, uint8 info)
 	char relName[NAMEDATALEN];
 	char buf[1024];
 
+	xl_ao_target target;
+
+	memcpy(&target, XLogRecGetData(record), sizeof(target));
+
+	getSpaceName(target.node.spcNode, spaceName, sizeof(spaceName));
+	getDbName(target.node.dbNode, dbName, sizeof(dbName));
+	getRelName(target.node.relNode, relName, sizeof(relName));
+
 	switch (info)
 	{
 		case XLOG_APPENDONLY_INSERT:
 			{
-				xl_ao_insert xlrec;
 				uint64       len;
 
-				memcpy(&xlrec, XLogRecGetData(record), sizeof(xlrec));
 				len = record->xl_len - SizeOfAOInsert;
-
-				getSpaceName(xlrec.node.spcNode, spaceName, sizeof(spaceName));
-				getDbName(xlrec.node.dbNode, dbName, sizeof(dbName));
-				getRelName(xlrec.node.relNode, relName, sizeof(relName));
 
 				snprintf(
 					buf, sizeof(buf),
 					"insert: s/d/r:%s/%s/%s segfile/off:%u/" INT64_FORMAT ", len:%lu",
 					spaceName, dbName, relName,
-					xlrec.segment_filenum, xlrec.offset, len);
+					target.segment_filenum, target.offset, len);
 			}
 			break;
 		case XLOG_APPENDONLY_TRUNCATE:
 			{
-				xl_ao_truncate xlrec;
-				memcpy(&xlrec, XLogRecGetData(record), sizeof(xlrec));
-
-				getSpaceName(xlrec.node.spcNode, spaceName, sizeof(spaceName));
-				getDbName(xlrec.node.dbNode, dbName, sizeof(dbName));
-				getRelName(xlrec.node.relNode, relName, sizeof(relName));
-
 				snprintf(
 					buf, sizeof(buf),
 					"truncate: s/d/r:%s/%s/%s segfile/off:%u/" INT64_FORMAT,
 					spaceName, dbName, relName,
-					xlrec.segment_filenum, xlrec.offset);
+					target.segment_filenum, target.offset);
 			}
 			break;
 		default:

--- a/src/backend/access/aocs/aocs_compaction.c
+++ b/src/backend/access/aocs/aocs_compaction.c
@@ -481,16 +481,11 @@ AOCSDrop(Relation aorel,
 		/* Re-fetch under the write lock to get latest committed eof. */
 		fsinfo = GetAOCSFileSegInfo(aorel, SnapshotNow, segno);
 
-		/* drop not planned, try at least eof truncation */
 		if (fsinfo->state == AOSEG_STATE_AWAITING_DROP)
 		{
 			Assert(HasLockForSegmentFileDrop(aorel));
 			AOCSCompaction_DropSegmentFile(aorel, segno);
 			ClearAOCSFileSegInfo(aorel, segno, AOSEG_STATE_DEFAULT);
-		}
-		else
-		{
-			AOCSSegmentFileTruncateToEOF(aorel, fsinfo);
 		}
 		pfree(fsinfo);
 	}
@@ -599,11 +594,6 @@ AOCSCompact(Relation aorel,
 											   fsinfo->segno, fsinfo->total_tupcount, isFull))
 		{
 			AOCSSegmentFileFullCompaction(aorel, insertDesc, fsinfo);
-		}
-		else
-		{
-			/* compaction is skipped: Try eof truncation */
-			AOCSSegmentFileTruncateToEOF(aorel, fsinfo);
 		}
 
 		pfree(fsinfo);

--- a/src/backend/access/aocs/aocs_compaction.c
+++ b/src/backend/access/aocs/aocs_compaction.c
@@ -132,7 +132,7 @@ AOCSSegmentFileTruncateToEOF(Relation aorel,
 
 		if (OpenAOSegmentFile(aorel, filenamepath, fileSegNo, segeof, &mirroredOpened))
 		{
-			TruncateAOSegmentFile(&mirroredOpened, aorel, segeof, ERROR);
+			TruncateAOSegmentFile(&mirroredOpened, aorel, segeof);
 			CloseAOSegmentFile(&mirroredOpened);
 
 			elogif(Debug_appendonly_print_compaction, LOG,

--- a/src/backend/access/appendonly/aomd.c
+++ b/src/backend/access/appendonly/aomd.c
@@ -224,6 +224,8 @@ TruncateAOSegmentFile(MirroredAppendOnlyOpen *mirroredOpen, Relation rel, int64 
 				(errmsg("\"%s\": failed to truncate data after eof: %s", 
 					    relname,
 					    strerror(primaryError))));
-	
+#ifdef USE_SEGWALREP
+	if (!rel->rd_istemp)
+		xlog_ao_truncate(mirroredOpen, offset);
+#endif
 }
-

--- a/src/backend/access/appendonly/aomd.c
+++ b/src/backend/access/appendonly/aomd.c
@@ -200,7 +200,7 @@ CloseAOSegmentFile(MirroredAppendOnlyOpen *mirroredOpen)
  * Truncate all bytes from offset to end of file.
  */
 void
-TruncateAOSegmentFile(MirroredAppendOnlyOpen *mirroredOpen, Relation rel, int64 offset, int elevel)
+TruncateAOSegmentFile(MirroredAppendOnlyOpen *mirroredOpen, Relation rel, int64 offset)
 {
 	int primaryError;
 	bool mirrorDataLossOccurred;	// We'll look at this at close time.
@@ -220,7 +220,7 @@ TruncateAOSegmentFile(MirroredAppendOnlyOpen *mirroredOpen, Relation rel, int64 
 							&primaryError,
 							&mirrorDataLossOccurred);
 	if (primaryError != 0)
-		ereport(elevel,
+		ereport(ERROR,
 				(errmsg("\"%s\": failed to truncate data after eof: %s", 
 					    relname,
 					    strerror(primaryError))));

--- a/src/backend/access/appendonly/appendonly_compaction.c
+++ b/src/backend/access/appendonly/appendonly_compaction.c
@@ -232,7 +232,7 @@ AppendOnlySegmentFileTruncateToEOF(Relation aorel,
 
 	if (OpenAOSegmentFile(aorel, filenamepath, fileSegNo, segeof, &mirroredOpened))
 	{
-		TruncateAOSegmentFile(&mirroredOpened, aorel, segeof, ERROR);
+		TruncateAOSegmentFile(&mirroredOpened, aorel, segeof);
 		CloseAOSegmentFile(&mirroredOpened);
 
 		elogif(Debug_appendonly_print_compaction, LOG,

--- a/src/backend/access/transam/xlogutils.c
+++ b/src/backend/access/transam/xlogutils.c
@@ -204,7 +204,7 @@ forget_invalid_pages_db(Oid tblspc, Oid dbid)
 #ifdef USE_SEGWALREP
 /* Forget an invalid AO/AOCO segment file */
 static void
-forget_invalid_segment_file(RelFileNode rnode, int32 segmentFileNum)
+forget_invalid_segment_file(RelFileNode rnode, uint32 segmentFileNum)
 {
 	xl_invalid_page_key key;
 	bool		found;
@@ -358,7 +358,7 @@ XLogReadBuffer(Relation reln, BlockNumber blkno, bool init)
  * relfilenode.
  */
 void
-XLogAOSegmentFile(RelFileNode rnode, int32 segmentFileNum)
+XLogAOSegmentFile(RelFileNode rnode, uint32 segmentFileNum)
 {
 	log_invalid_page(rnode, segmentFileNum, false);
 }
@@ -708,7 +708,7 @@ XLogDropRelation(RelFileNode rnode)
 #ifdef USE_SEGWALREP
 /* Drop an AO/CO segment file from the invalid_page_tab hash table */
 void
-XLogAODropSegmentFile(RelFileNode rnode, int32 segmentFileNum)
+XLogAODropSegmentFile(RelFileNode rnode, uint32 segmentFileNum)
 {
 	forget_invalid_segment_file(rnode, segmentFileNum);
 }

--- a/src/backend/cdb/cdbappendonlystorage.c
+++ b/src/backend/cdb/cdbappendonlystorage.c
@@ -83,9 +83,9 @@ appendonly_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record)
 				appendStringInfo(
 					buf,
 					"insert: rel %u/%u/%u seg/offset:%u/" INT64_FORMAT " len:%lu",
-					xlrec->node.spcNode, xlrec->node.dbNode,
-					xlrec->node.relNode, xlrec->segment_filenum,
-					xlrec->offset, record->xl_len - SizeOfAOInsert);
+					xlrec->target.node.spcNode, xlrec->target.node.dbNode,
+					xlrec->target.node.relNode, xlrec->target.segment_filenum,
+					xlrec->target.offset, record->xl_len - SizeOfAOInsert);
 			}
 			break;
 		case XLOG_APPENDONLY_TRUNCATE:
@@ -95,9 +95,9 @@ appendonly_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record)
 				appendStringInfo(
 					buf,
 					"truncate: rel %u/%u/%u seg/offset:%u/" INT64_FORMAT,
-					xlrec->node.spcNode, xlrec->node.dbNode,
-					xlrec->node.relNode, xlrec->segment_filenum,
-					xlrec->offset);
+					xlrec->target.node.spcNode, xlrec->target.node.dbNode,
+					xlrec->target.node.relNode, xlrec->target.segment_filenum,
+					xlrec->target.offset);
 			}
 			break;
 		default:

--- a/src/include/access/aomd.h
+++ b/src/include/access/aomd.h
@@ -47,10 +47,10 @@ extern bool OpenAOSegmentFile(
 extern void CloseAOSegmentFile(
 				   struct MirroredAppendOnlyOpen *mirroredOpen);
 
-extern void TruncateAOSegmentFile(
-					  struct MirroredAppendOnlyOpen *mirroredOpen,
-					  Relation rel,
-					  int64 offset,
-					  int elevel);
+extern void
+TruncateAOSegmentFile(
+					  struct MirroredAppendOnlyOpen *mirroredOpen, 
+					  Relation rel, 
+					  int64 offset);
 
 #endif							/* AOMD_H */

--- a/src/include/access/xlogutils.h
+++ b/src/include/access/xlogutils.h
@@ -27,8 +27,8 @@ extern void XLogTruncateRelation(RelFileNode rnode, BlockNumber nblocks);
 extern Buffer XLogReadBuffer(Relation reln, BlockNumber blkno, bool init);
 
 #ifdef USE_SEGWALREP
-extern void XLogAOSegmentFile(RelFileNode rnode, int segmentFileNum);
-extern void XLogAODropSegmentFile(RelFileNode rnode, int segmentFileNum);
+extern void XLogAOSegmentFile(RelFileNode rnode, uint32 segmentFileNum);
+extern void XLogAODropSegmentFile(RelFileNode rnode, uint32 segmentFileNum);
 #endif
 
 #endif

--- a/src/include/cdb/cdbappendonlyam.h
+++ b/src/include/cdb/cdbappendonlyam.h
@@ -379,7 +379,7 @@ extern HTSU_Result appendonly_update(
 typedef struct
 {
 	RelFileNode node;
-	uint		segment_filenum;
+	uint32		segment_filenum;
 	int64		offset;
 } xl_ao_target;
 

--- a/src/include/cdb/cdbappendonlyam.h
+++ b/src/include/cdb/cdbappendonlyam.h
@@ -376,23 +376,28 @@ extern HTSU_Result appendonly_update(
 #define XLOG_APPENDONLY_INSERT    0x00
 #define XLOG_APPENDONLY_TRUNCATE  0x10
 
-typedef struct xl_ao_insert
+typedef struct
+{
+	RelFileNode node;
+	uint		segment_filenum;
+	int64		offset;
+} xl_ao_target;
+
+#define SizeOfAOTarget (offsetof(xl_ao_target, offset) + sizeof(int64))
+
+typedef struct
 {
 	/* meta data about the inserted block of AO data*/
-	RelFileNode node;
-	uint		segment_filenum;
-	int64		offset;
-		/* BLOCK DATA FOLLOWS AT END OF STRUCT */
+	xl_ao_target target;
+	/* BLOCK DATA FOLLOWS AT END OF STRUCT */
 } xl_ao_insert;
 
-#define SizeOfAOInsert (offsetof(xl_ao_insert, offset) + sizeof(int64))
+#define SizeOfAOInsert (offsetof(xl_ao_insert, target) + SizeOfAOTarget)
 
-typedef struct xl_ao_truncate
+typedef struct
 {
 	/* meta data about the truncated AO/CO file*/
-	RelFileNode node;
-	uint		segment_filenum;
-	int64		offset;
+	xl_ao_target target;
 } xl_ao_truncate;
 
 extern void appendonly_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record);

--- a/src/include/cdb/cdbappendonlyam.h
+++ b/src/include/cdb/cdbappendonlyam.h
@@ -374,6 +374,7 @@ extern HTSU_Result appendonly_update(
 
 #ifdef USE_SEGWALREP
 #define XLOG_APPENDONLY_INSERT    0x00
+#define XLOG_APPENDONLY_TRUNCATE  0x10
 
 typedef struct xl_ao_insert
 {
@@ -385,6 +386,14 @@ typedef struct xl_ao_insert
 } xl_ao_insert;
 
 #define SizeOfAOInsert (offsetof(xl_ao_insert, offset) + sizeof(int64))
+
+typedef struct xl_ao_truncate
+{
+	/* meta data about the truncated AO/CO file*/
+	RelFileNode node;
+	uint		segment_filenum;
+	int64		offset;
+} xl_ao_truncate;
 
 extern void appendonly_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record);
 extern void appendonly_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record);

--- a/src/include/cdb/cdbmirroredappendonly.h
+++ b/src/include/cdb/cdbmirroredappendonly.h
@@ -314,7 +314,13 @@ extern int MirroredAppendOnly_Read(
 
 #ifdef USE_SEGWALREP
 extern void
-ao_xlog_insert(XLogRecord *record);
+ao_insert_replay(XLogRecord *record);
+
+extern void
+xlog_ao_truncate(MirroredAppendOnlyOpen *open, int64 offset);
+
+extern void
+ao_truncate_replay(XLogRecord *record);
 #endif
 
 #endif   /* CDBMIRROREDAPPENDONLY_H */

--- a/src/test/walrep/expected/generate_ao_xlog.out
+++ b/src/test/walrep/expected/generate_ao_xlog.out
@@ -1,44 +1,59 @@
 -- Test AO XLogging
-CREATE OR REPLACE FUNCTION get_ao_eof(tablename TEXT) RETURNS BIGINT[] AS
-$$
-DECLARE
-eofval BIGINT[];
-eof_scalar BIGINT;
-BEGIN
-   SELECT eof INTO eof_scalar FROM gp_toolkit.__gp_aoseg_name(tablename);
-   eofval[0] := eof_scalar;
-   RETURN eofval;
-END;
-$$ LANGUAGE plpgsql;
 CREATE TABLE generate_ao_xlog_table(a INT, b INT) WITH (APPENDONLY=TRUE);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- Store the location of xlog in a temporary table so that we can
 -- use it to request walsender to start streaming from this point
-CREATE TEMP TABLE tmp(startpoint TEXT);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'startpoint' as the Greenplum Database data distribution key for this table.
+CREATE TEMP TABLE tmp(dbid int, startpoint TEXT);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'dbid' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-INSERT INTO tmp SELECT pg_current_xlog_location() FROM
-gp_dist_random('gp_id') WHERE gp_segment_id = 0;
+INSERT INTO tmp SELECT gp_execution_segment(),pg_current_xlog_location()
+FROM gp_dist_random('gp_id');
 -- Generate some xlog records for AO
-INSERT INTO generate_ao_xlog_table VALUES(1, 10);
--- Verify that AO xlog record was received
-SELECT test_xlog_ao((SELECT 'port=' || port FROM gp_segment_configuration
-       		     WHERE dbid=2),
-		    (SELECT startpoint FROM tmp),
-                    (SELECT oid FROM pg_tablespace WHERE spcname = 'pg_default'),
-                    (SELECT oid FROM pg_database
-		     WHERE datname = current_database()),
-                    (SELECT relfilenode FROM gp_dist_random('pg_class')
-		     WHERE relname = 'generate_ao_xlog_table'
-		     AND gp_segment_id = 0),
-		    (SELECT get_ao_eof('generate_ao_xlog_table')
-		     FROM gp_dist_random('gp_id')
-		     WHERE gp_segment_id = 0),
-		    false) FROM
-gp_dist_random('gp_id') WHERE gp_segment_id = 0;
- test_xlog_ao 
---------------
-            1
-(1 row)
+INSERT INTO generate_ao_xlog_table VALUES(1, 10), (8, 10), (3, 10);
+-- Verify that the insert AO xlog record was received
+SELECT gp_segment_id, relname, record_type, segment_filenum, recordlen, file_offset
+  FROM test_xlog_ao_wrapper(
+    (SELECT array_agg(startpoint) FROM 
+       (SELECT startpoint from tmp order by dbid) t
+    )
+  ) 
+WHERE spcNode = (SELECT oid FROM pg_tablespace WHERE spcname = 'pg_default')
+AND dbNode = (SELECT oid FROM pg_database WHERE datname = current_database())
+ORDER BY gp_segment_id, xrecoff;
+ gp_segment_id |        relname         |      record_type       | segment_filenum | recordlen | file_offset 
+---------------+------------------------+------------------------+-----------------+-----------+-------------
+             0 | generate_ao_xlog_table | XLOG_APPENDONLY_INSERT |               1 |        64 |           0
+             1 | generate_ao_xlog_table | XLOG_APPENDONLY_INSERT |               1 |        64 |           0
+             2 | generate_ao_xlog_table | XLOG_APPENDONLY_INSERT |               1 |        64 |           0
+(3 rows)
+
+-- Store the latest xlog offset
+DELETE FROM tmp;
+INSERT INTO tmp SELECT gp_execution_segment(),pg_current_xlog_location() 
+FROM gp_dist_random('gp_id');
+-- Generate a truncate XLOG entry for generate_ao_xlog_table.
+BEGIN;
+INSERT INTO generate_ao_xlog_table SELECT i,i FROM generate_series(1,10)i;
+ABORT;
+VACUUM generate_ao_xlog_table;
+-- Verify that truncate AO xlog record was received
+SELECT gp_segment_id, relname, record_type, segment_filenum, recordlen, file_offset
+  FROM test_xlog_ao_wrapper(
+    (SELECT array_agg(startpoint) FROM 
+       (SELECT startpoint from tmp order by dbid) t
+    )
+  ) 
+WHERE spcNode = (SELECT oid FROM pg_tablespace WHERE spcname = 'pg_default')
+AND dbNode = (SELECT oid FROM pg_database WHERE datname = current_database())
+ORDER BY gp_segment_id, xrecoff;
+ gp_segment_id |        relname         |       record_type        | segment_filenum | recordlen | file_offset 
+---------------+------------------------+--------------------------+-----------------+-----------+-------------
+             0 | generate_ao_xlog_table | XLOG_APPENDONLY_INSERT   |               1 |        96 |          40
+             0 | generate_ao_xlog_table | XLOG_AYPENDONLY_TRUNCATE |               1 |        24 |          40
+             1 | generate_ao_xlog_table | XLOG_APPENDONLY_INSERT   |               1 |       152 |          40
+             1 | generate_ao_xlog_table | XLOG_AYPENDONLY_TRUNCATE |               1 |        24 |          40
+             2 | generate_ao_xlog_table | XLOG_APPENDONLY_INSERT   |               1 |       112 |          40
+             2 | generate_ao_xlog_table | XLOG_AYPENDONLY_TRUNCATE |               1 |        24 |          40
+(6 rows)
 

--- a/src/test/walrep/expected/generate_aoco_xlog.out
+++ b/src/test/walrep/expected/generate_aoco_xlog.out
@@ -1,49 +1,68 @@
 -- Test AOCO XLogging
-CREATE OR REPLACE FUNCTION get_aoco_eofs(tablename TEXT) RETURNS BIGINT[] AS
-$$
-DECLARE
-eofvals BIGINT[];
-i      INT;
-result    RECORD;
-BEGIN
-   i := 0;
-   FOR result IN SELECT * FROM gp_toolkit.__gp_aocsseg_name(tablename)
-   LOOP
-	eofvals[i] := result.eof;
-	i := i + 1;
-   END LOOP;
-   RETURN eofvals;
-END;
-$$ LANGUAGE plpgsql;
 CREATE TABLE generate_aoco_xlog_table(a INT, b INT) WITH (APPENDONLY=TRUE, ORIENTATION=COLUMN);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- Store the location of xlog in a temporary table so that we can
 -- use it to request walsender to start streaming from this point
-CREATE TEMP TABLE tmp(startpoint TEXT);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'startpoint' as the Greenplum Database data distribution key for this table.
+CREATE TEMP TABLE tmp(dbid int, startpoint TEXT);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'dbid' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-INSERT INTO tmp SELECT pg_current_xlog_location() FROM
-gp_dist_random('gp_id') WHERE gp_segment_id = 0;
+INSERT INTO tmp SELECT gp_execution_segment(),pg_current_xlog_location() FROM
+gp_dist_random('gp_id');
 -- Generate some xlog records for AOCO
-INSERT INTO generate_aoco_xlog_table VALUES(1, 10);
--- Verify that AOCO xlog record was received
-SELECT test_xlog_ao((SELECT 'port=' || port FROM gp_segment_configuration
-                     WHERE dbid=2),
-		    (SELECT startpoint FROM tmp),
-                    (SELECT oid FROM pg_tablespace WHERE spcname = 'pg_default'),
-                    (SELECT oid FROM pg_database
-		     WHERE datname = current_database()),
-                    (SELECT relfilenode FROM gp_dist_random('pg_class')
-		     WHERE relname = 'generate_aoco_xlog_table'
-		     AND gp_segment_id = 0),
-		    (SELECT get_aoco_eofs('generate_aoco_xlog_table')
-		     FROM gp_dist_random('gp_id')
-		     WHERE gp_segment_id = 0),
-		    true) FROM
-gp_dist_random('gp_id') WHERE gp_segment_id = 0;
- test_xlog_ao 
---------------
-            2
-(1 row)
+INSERT INTO generate_aoco_xlog_table VALUES(1, 10), (8, 10), (3, 10);
+-- Verify that AO xlog record was received
+SELECT gp_segment_id, relname, record_type, segment_filenum, recordlen, file_offset
+  FROM test_xlog_ao_wrapper(
+    (SELECT array_agg(startpoint) FROM 
+       (SELECT startpoint from tmp order by dbid) t
+    )
+  ) 
+WHERE spcNode = (SELECT oid FROM pg_tablespace WHERE spcname = 'pg_default')
+AND dbNode = (SELECT oid FROM pg_database WHERE datname = current_database())
+ORDER BY gp_segment_id, xrecoff;
+ gp_segment_id |         relname          |      record_type       | segment_filenum | recordlen | file_offset 
+---------------+--------------------------+------------------------+-----------------+-----------+-------------
+             0 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT |               1 |        72 |           0
+             0 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT |             129 |        72 |           0
+             1 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT |               1 |        72 |           0
+             1 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT |             129 |        72 |           0
+             2 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT |               1 |        72 |           0
+             2 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT |             129 |        72 |           0
+(6 rows)
+
+-- Store the latest xlog offset
+DELETE FROM tmp;
+INSERT INTO tmp SELECT gp_execution_segment(),pg_current_xlog_location() 
+FROM gp_dist_random('gp_id');
+-- Generate a truncate XLOG entry for generate_ao_xlog_table.
+BEGIN;
+INSERT INTO generate_aoco_xlog_table SELECT i,i FROM generate_series(1,10)i;
+ABORT;
+VACUUM generate_aoco_xlog_table;
+-- Verify that truncate AO xlog record was received
+SELECT gp_segment_id, relname, record_type, segment_filenum, recordlen, file_offset
+  FROM test_xlog_ao_wrapper(
+    (SELECT array_agg(startpoint) FROM 
+       (SELECT startpoint from tmp order by dbid) t
+    )
+  ) 
+WHERE spcNode = (SELECT oid FROM pg_tablespace WHERE spcname = 'pg_default')
+AND dbNode = (SELECT oid FROM pg_database WHERE datname = current_database())
+ORDER BY gp_segment_id, xrecoff;
+ gp_segment_id |         relname          |       record_type        | segment_filenum | recordlen | file_offset 
+---------------+--------------------------+--------------------------+-----------------+-----------+-------------
+             0 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT   |               1 |        72 |          48
+             0 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT   |             129 |        72 |          48
+             0 | generate_aoco_xlog_table | XLOG_AYPENDONLY_TRUNCATE |               1 |        24 |          48
+             0 | generate_aoco_xlog_table | XLOG_AYPENDONLY_TRUNCATE |             129 |        24 |          48
+             1 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT   |               1 |        88 |          48
+             1 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT   |             129 |        88 |          48
+             1 | generate_aoco_xlog_table | XLOG_AYPENDONLY_TRUNCATE |               1 |        24 |          48
+             1 | generate_aoco_xlog_table | XLOG_AYPENDONLY_TRUNCATE |             129 |        24 |          48
+             2 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT   |               1 |        80 |          48
+             2 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT   |             129 |        80 |          48
+             2 | generate_aoco_xlog_table | XLOG_AYPENDONLY_TRUNCATE |               1 |        24 |          48
+             2 | generate_aoco_xlog_table | XLOG_AYPENDONLY_TRUNCATE |             129 |        24 |          48
+(12 rows)
 

--- a/src/test/walrep/gplibpq.c
+++ b/src/test/walrep/gplibpq.c
@@ -470,11 +470,11 @@ check_ao_record_present(unsigned char type, char *buf, Oid spc_node,
 			else
 				segfilenum = 1;
 
-			if (xlaoinsert->node.spcNode == spc_node &&
-				xlaoinsert->node.dbNode == db_node &&
-				xlaoinsert->node.relNode == rel_node &&
-				xlaoinsert->segment_filenum == segfilenum &&
-				xlaoinsert->offset == 0 &&
+			if (xlaoinsert->target.node.spcNode == spc_node &&
+				xlaoinsert->target.node.dbNode == db_node &&
+				xlaoinsert->target.node.relNode == rel_node &&
+				xlaoinsert->target.segment_filenum == segfilenum &&
+				xlaoinsert->target.offset == 0 &&
 				xlrec->xl_len - SizeOfAOInsert == eof[num_found])
 				num_found++;
 			else
@@ -482,9 +482,9 @@ check_ao_record_present(unsigned char type, char *buf, Oid spc_node,
 				elog(INFO, "Expected values: relfile %u/%u/%u segfile/offset %u/%u eof %lu",
 					 spc_node, db_node, rel_node, segfilenum, 0, eof[num_found]);
 				elog(INFO, "Actual values: relfile %u/%u/%u segfile/offset %u/%lu eof %lu",
-					 xlaoinsert->node.spcNode, xlaoinsert->node.dbNode,
-					 xlaoinsert->node.relNode, xlaoinsert->segment_filenum,
-					 xlaoinsert->offset, xlrec->xl_len - SizeOfAOInsert);
+					 xlaoinsert->target.node.spcNode, xlaoinsert->target.node.dbNode,
+					 xlaoinsert->target.node.relNode, xlaoinsert->target.segment_filenum,
+					 xlaoinsert->target.offset, xlrec->xl_len - SizeOfAOInsert);
 			}
 		}
 		else

--- a/src/test/walrep/input/setup.source
+++ b/src/test/walrep/input/setup.source
@@ -13,8 +13,35 @@ create or replace function test_send() RETURNS bool AS
 create or replace function test_receive_and_verify(text, text) RETURNS bool AS
  '@abs_builddir@/gplibpq@DLSUFFIX@' LANGUAGE C VOLATILE STRICT NO SQL;
 
-create or replace function test_xlog_ao(IN text, IN text, IN oid, IN oid,
-       	  	  	   		IN oid, IN bigint[], IN bool,
-					OUT insert_count INT, OUT truncate_count INT)
+create or replace function test_xlog_ao(IN text, IN text, OUT xrecoff INT, OUT record_type TEXT, 
+                                        OUT recordlen INT, OUT spcNode OID, OUT dbNode OID, 
+                                        OUT relNode OID, OUT segment_filenum INT, OUT file_offset BIGINT)
  RETURNS SETOF record AS
  '@abs_builddir@/gplibpq@DLSUFFIX@' LANGUAGE C VOLATILE STRICT NO SQL;
+
+CREATE OR REPLACE FUNCTION test_xlog_ao_wrapper(IN startpoints TEXT[])
+RETURNS TABLE (gp_segment_id INT, oid OID, relname name, 
+	       xrecoff TEXT, record_type TEXT, recordlen INT,
+	       spcNode OID, dbNode OID, relNode OID, segment_filenum INT,
+	       file_offset BIGINT) 
+EXECUTE ON ALL SEGMENTS AS
+$func$
+DECLARE
+port TEXT;
+startpoint TEXT;
+myseg INT;
+BEGIN
+	myseg := gp_execution_segment();
+	startpoint := startpoints[myseg + 1];
+	select 'port=' || setting INTO port from pg_settings where name = 'port';
+	RAISE DEBUG 'port %, startpoint % current_xlog_location %',
+	port, startpoint, pg_current_xlog_location();
+
+	RETURN QUERY
+	SELECT gp_execution_segment(), pg.oid, pg.relname, upper('0/' || to_hex(t.xrecoff)), t.record_type, 
+	  t.recordlen, t.spcNode, t.dbNode, t.relNode, t.segment_filenum, t.file_offset 
+        FROM test_xlog_ao(port, startpoint) t
+	LEFT JOIN pg_class pg ON t.relnode = pg.relfilenode;
+END;
+$func$ LANGUAGE plpgsql;
+

--- a/src/test/walrep/input/setup.source
+++ b/src/test/walrep/input/setup.source
@@ -13,6 +13,8 @@ create or replace function test_send() RETURNS bool AS
 create or replace function test_receive_and_verify(text, text) RETURNS bool AS
  '@abs_builddir@/gplibpq@DLSUFFIX@' LANGUAGE C VOLATILE STRICT NO SQL;
 
-create or replace function test_xlog_ao(text, text, oid, oid, oid, bigint[], bool)
- RETURNS int AS
+create or replace function test_xlog_ao(IN text, IN text, IN oid, IN oid,
+       	  	  	   		IN oid, IN bigint[], IN bool,
+					OUT insert_count INT, OUT truncate_count INT)
+ RETURNS SETOF record AS
  '@abs_builddir@/gplibpq@DLSUFFIX@' LANGUAGE C VOLATILE STRICT NO SQL;

--- a/src/test/walrep/output/setup.source
+++ b/src/test/walrep/output/setup.source
@@ -8,8 +8,33 @@ create or replace function test_send() RETURNS bool AS
  '@abs_builddir@/gplibpq@DLSUFFIX@' LANGUAGE C VOLATILE STRICT NO SQL;
 create or replace function test_receive_and_verify(text, text) RETURNS bool AS
  '@abs_builddir@/gplibpq@DLSUFFIX@' LANGUAGE C VOLATILE STRICT NO SQL;
-create or replace function test_xlog_ao(IN text, IN text, IN oid, IN oid,
-       	  	  	   		IN oid, IN bigint[], IN bool,
-					OUT insert_count INT, OUT truncate_count INT)
+create or replace function test_xlog_ao(IN text, IN text, OUT xrecoff INT, OUT record_type TEXT, 
+                                        OUT recordlen INT, OUT spcNode OID, OUT dbNode OID, 
+                                        OUT relNode OID, OUT segment_filenum INT, OUT file_offset BIGINT)
  RETURNS SETOF record AS
  '@abs_builddir@/gplibpq@DLSUFFIX@' LANGUAGE C VOLATILE STRICT NO SQL;
+CREATE OR REPLACE FUNCTION test_xlog_ao_wrapper(IN startpoints TEXT[])
+RETURNS TABLE (gp_segment_id INT, oid OID, relname name, 
+	       xrecoff TEXT, record_type TEXT, recordlen INT,
+	              spcNode OID, dbNode OID, relNode OID, segment_filenum INT,
+		             file_offset BIGINT) 
+EXECUTE ON ALL SEGMENTS AS
+$func$
+DECLARE
+port TEXT;
+startpoint TEXT;
+myseg INT;
+BEGIN
+	myseg := gp_execution_segment();
+	startpoint := startpoints[myseg + 1];
+	select 'port=' || setting INTO port from pg_settings where name = 'port';
+	RAISE DEBUG 'port %, startpoint % current_xlog_location %',
+	port, startpoint, pg_current_xlog_location();
+
+	RETURN QUERY
+	SELECT gp_execution_segment(), pg.oid, pg.relname, upper('0/' || to_hex(t.xrecoff)), t.record_type, 
+	  t.recordlen, t.spcNode, t.dbNode, t.relNode, t.segment_filenum, t.file_offset 
+        FROM test_xlog_ao(port, startpoint) t
+	LEFT JOIN pg_class pg ON t.relnode = pg.relfilenode;
+END;
+$func$ LANGUAGE plpgsql;

--- a/src/test/walrep/output/setup.source
+++ b/src/test/walrep/output/setup.source
@@ -8,6 +8,8 @@ create or replace function test_send() RETURNS bool AS
  '@abs_builddir@/gplibpq@DLSUFFIX@' LANGUAGE C VOLATILE STRICT NO SQL;
 create or replace function test_receive_and_verify(text, text) RETURNS bool AS
  '@abs_builddir@/gplibpq@DLSUFFIX@' LANGUAGE C VOLATILE STRICT NO SQL;
-create or replace function test_xlog_ao(text, text, oid, oid, oid, bigint[], bool)
- RETURNS int AS
+create or replace function test_xlog_ao(IN text, IN text, IN oid, IN oid,
+       	  	  	   		IN oid, IN bigint[], IN bool,
+					OUT insert_count INT, OUT truncate_count INT)
+ RETURNS SETOF record AS
  '@abs_builddir@/gplibpq@DLSUFFIX@' LANGUAGE C VOLATILE STRICT NO SQL;

--- a/src/test/walrep/sql/generate_ao_xlog.sql
+++ b/src/test/walrep/sql/generate_ao_xlog.sql
@@ -1,58 +1,44 @@
 -- Test AO XLogging
-
-CREATE OR REPLACE FUNCTION get_ao_eof(tablename TEXT) RETURNS BIGINT[] AS
-$$
-DECLARE
-eofval BIGINT[];
-eof_scalar BIGINT;
-BEGIN
-   SELECT eof INTO eof_scalar FROM gp_toolkit.__gp_aoseg_name(tablename);
-   eofval[0] := eof_scalar;
-   RAISE NOTICE 'eof %', eofval[0];
-   RETURN eofval;
-END;
-$$ LANGUAGE plpgsql;
-
-CREATE OR REPLACE FUNCTION test_xlog_ao_wrapper(IN tablespace_oid oid, IN database_oid oid,
-    	  	   			   IN tablename TEXT, IN startpoints TEXT[])
-RETURNS TABLE (insert_cnt INT, truncate_cnt INT) EXECUTE ON ALL SEGMENTS AS
-$func$
-DECLARE
-port TEXT;
-relnode INT;
-startpoint TEXT;
-myseg INT;
-BEGIN
-	SELECT relfilenode INTO relnode FROM pg_class where relname = tablename;
-	myseg := gp_execution_segment();
-	startpoint := startpoints[myseg + 1];
-	select 'port=' || setting INTO port from pg_settings where name = 'port';
-	RAISE NOTICE 'port %, relfilenode % tablename % startpoint % current_xlog_location %',
-	port, relnode, tablename, startpoint, pg_current_xlog_location();
-
-
-	RETURN QUERY
-	select insert_count, truncate_count from test_xlog_ao(port,
-			startpoint, tablespace_oid, database_oid, relnode,
-			(SELECT get_ao_eof(tablename)), false);
-END;
-$func$ LANGUAGE plpgsql;
-
-drop table generate_ao_xlog_table;
 CREATE TABLE generate_ao_xlog_table(a INT, b INT) WITH (APPENDONLY=TRUE);
 
 -- Store the location of xlog in a temporary table so that we can
 -- use it to request walsender to start streaming from this point
 CREATE TEMP TABLE tmp(dbid int, startpoint TEXT);
-INSERT INTO tmp SELECT gp_execution_segment(),pg_current_xlog_location() FROM
-gp_dist_random('gp_id');
-create TEMP table xlog_startpoint as select array_agg(startpoint) startpoints from (select startpoint from tmp order by dbid) tt;
+INSERT INTO tmp SELECT gp_execution_segment(),pg_current_xlog_location()
+FROM gp_dist_random('gp_id');
 
 -- Generate some xlog records for AO
 INSERT INTO generate_ao_xlog_table VALUES(1, 10), (8, 10), (3, 10);
 
--- Verify that AO xlog record was received
-SELECT * from test_xlog_ao_wrapper((SELECT oid FROM pg_tablespace WHERE spcname = 'pg_default'),
-       	      		(SELECT oid FROM pg_database WHERE datname = current_database()),
-		     'generate_ao_xlog_table',
-		     (SELECT startpoints FROM xlog_startpoint));
+-- Verify that the insert AO xlog record was received
+SELECT gp_segment_id, relname, record_type, segment_filenum, recordlen, file_offset
+  FROM test_xlog_ao_wrapper(
+    (SELECT array_agg(startpoint) FROM 
+       (SELECT startpoint from tmp order by dbid) t
+    )
+  ) 
+WHERE spcNode = (SELECT oid FROM pg_tablespace WHERE spcname = 'pg_default')
+AND dbNode = (SELECT oid FROM pg_database WHERE datname = current_database())
+ORDER BY gp_segment_id, xrecoff;
+
+-- Store the latest xlog offset
+DELETE FROM tmp;
+INSERT INTO tmp SELECT gp_execution_segment(),pg_current_xlog_location() 
+FROM gp_dist_random('gp_id');
+
+-- Generate a truncate XLOG entry for generate_ao_xlog_table.
+BEGIN;
+INSERT INTO generate_ao_xlog_table SELECT i,i FROM generate_series(1,10)i;
+ABORT;
+VACUUM generate_ao_xlog_table;
+
+-- Verify that truncate AO xlog record was received
+SELECT gp_segment_id, relname, record_type, segment_filenum, recordlen, file_offset
+  FROM test_xlog_ao_wrapper(
+    (SELECT array_agg(startpoint) FROM 
+       (SELECT startpoint from tmp order by dbid) t
+    )
+  ) 
+WHERE spcNode = (SELECT oid FROM pg_tablespace WHERE spcname = 'pg_default')
+AND dbNode = (SELECT oid FROM pg_database WHERE datname = current_database())
+ORDER BY gp_segment_id, xrecoff;

--- a/src/test/walrep/sql/generate_ao_xlog.sql
+++ b/src/test/walrep/sql/generate_ao_xlog.sql
@@ -8,34 +8,51 @@ eof_scalar BIGINT;
 BEGIN
    SELECT eof INTO eof_scalar FROM gp_toolkit.__gp_aoseg_name(tablename);
    eofval[0] := eof_scalar;
+   RAISE NOTICE 'eof %', eofval[0];
    RETURN eofval;
 END;
 $$ LANGUAGE plpgsql;
 
+CREATE OR REPLACE FUNCTION test_xlog_ao_wrapper(IN tablespace_oid oid, IN database_oid oid,
+    	  	   			   IN tablename TEXT, IN startpoints TEXT[])
+RETURNS TABLE (insert_cnt INT, truncate_cnt INT) EXECUTE ON ALL SEGMENTS AS
+$func$
+DECLARE
+port TEXT;
+relnode INT;
+startpoint TEXT;
+myseg INT;
+BEGIN
+	SELECT relfilenode INTO relnode FROM pg_class where relname = tablename;
+	myseg := gp_execution_segment();
+	startpoint := startpoints[myseg + 1];
+	select 'port=' || setting INTO port from pg_settings where name = 'port';
+	RAISE NOTICE 'port %, relfilenode % tablename % startpoint % current_xlog_location %',
+	port, relnode, tablename, startpoint, pg_current_xlog_location();
+
+
+	RETURN QUERY
+	select insert_count, truncate_count from test_xlog_ao(port,
+			startpoint, tablespace_oid, database_oid, relnode,
+			(SELECT get_ao_eof(tablename)), false);
+END;
+$func$ LANGUAGE plpgsql;
+
+drop table generate_ao_xlog_table;
 CREATE TABLE generate_ao_xlog_table(a INT, b INT) WITH (APPENDONLY=TRUE);
 
 -- Store the location of xlog in a temporary table so that we can
 -- use it to request walsender to start streaming from this point
-CREATE TEMP TABLE tmp(startpoint TEXT);
-INSERT INTO tmp SELECT pg_current_xlog_location() FROM
-gp_dist_random('gp_id') WHERE gp_segment_id = 0;
+CREATE TEMP TABLE tmp(dbid int, startpoint TEXT);
+INSERT INTO tmp SELECT gp_execution_segment(),pg_current_xlog_location() FROM
+gp_dist_random('gp_id');
+create TEMP table xlog_startpoint as select array_agg(startpoint) startpoints from (select startpoint from tmp order by dbid) tt;
 
 -- Generate some xlog records for AO
-INSERT INTO generate_ao_xlog_table VALUES(1, 10);
+INSERT INTO generate_ao_xlog_table VALUES(1, 10), (8, 10), (3, 10);
 
 -- Verify that AO xlog record was received
-SELECT test_xlog_ao((SELECT 'port=' || port FROM gp_segment_configuration
-       		     WHERE dbid=2),
-		    (SELECT startpoint FROM tmp),
-                    (SELECT oid FROM pg_tablespace WHERE spcname = 'pg_default'),
-                    (SELECT oid FROM pg_database
-		     WHERE datname = current_database()),
-                    (SELECT relfilenode FROM gp_dist_random('pg_class')
-		     WHERE relname = 'generate_ao_xlog_table'
-		     AND gp_segment_id = 0),
-		    (SELECT get_ao_eof('generate_ao_xlog_table')
-		     FROM gp_dist_random('gp_id')
-		     WHERE gp_segment_id = 0),
-		    false) FROM
-gp_dist_random('gp_id') WHERE gp_segment_id = 0;
-
+SELECT * from test_xlog_ao_wrapper((SELECT oid FROM pg_tablespace WHERE spcname = 'pg_default'),
+       	      		(SELECT oid FROM pg_database WHERE datname = current_database()),
+		     'generate_ao_xlog_table',
+		     (SELECT startpoints FROM xlog_startpoint));

--- a/src/test/walrep/sql/generate_aoco_xlog.sql
+++ b/src/test/walrep/sql/generate_aoco_xlog.sql
@@ -1,46 +1,45 @@
 -- Test AOCO XLogging
-
-CREATE OR REPLACE FUNCTION get_aoco_eofs(tablename TEXT) RETURNS BIGINT[] AS
-$$
-DECLARE
-eofvals BIGINT[];
-i      INT;
-result    RECORD;
-BEGIN
-   i := 0;
-   FOR result IN SELECT * FROM gp_toolkit.__gp_aocsseg_name(tablename)
-   LOOP
-	eofvals[i] := result.eof;
-	i := i + 1;
-   END LOOP;
-   RETURN eofvals;
-END;
-$$ LANGUAGE plpgsql;
-
 CREATE TABLE generate_aoco_xlog_table(a INT, b INT) WITH (APPENDONLY=TRUE, ORIENTATION=COLUMN);
 
 -- Store the location of xlog in a temporary table so that we can
 -- use it to request walsender to start streaming from this point
-CREATE TEMP TABLE tmp(startpoint TEXT);
-INSERT INTO tmp SELECT pg_current_xlog_location() FROM
-gp_dist_random('gp_id') WHERE gp_segment_id = 0;
+CREATE TEMP TABLE tmp(dbid int, startpoint TEXT);
+INSERT INTO tmp SELECT gp_execution_segment(),pg_current_xlog_location() FROM
+gp_dist_random('gp_id');
 
 -- Generate some xlog records for AOCO
-INSERT INTO generate_aoco_xlog_table VALUES(1, 10);
+INSERT INTO generate_aoco_xlog_table VALUES(1, 10), (8, 10), (3, 10);
 
--- Verify that AOCO xlog record was received
-SELECT test_xlog_ao((SELECT 'port=' || port FROM gp_segment_configuration
-                     WHERE dbid=2),
-		    (SELECT startpoint FROM tmp),
-                    (SELECT oid FROM pg_tablespace WHERE spcname = 'pg_default'),
-                    (SELECT oid FROM pg_database
-		     WHERE datname = current_database()),
-	            (SELECT relfilenode FROM gp_dist_random('pg_class')
-		     WHERE relname = 'generate_aoco_xlog_table'
-		     AND gp_segment_id = 0),
-		    (SELECT get_aoco_eofs('generate_aoco_xlog_table')
-		     FROM gp_dist_random('gp_id')
-		     WHERE gp_segment_id = 0),
-		    true) FROM
-gp_dist_random('gp_id') WHERE gp_segment_id = 0;
+-- Verify that AO xlog record was received
+SELECT gp_segment_id, relname, record_type, segment_filenum, recordlen, file_offset
+  FROM test_xlog_ao_wrapper(
+    (SELECT array_agg(startpoint) FROM 
+       (SELECT startpoint from tmp order by dbid) t
+    )
+  ) 
+WHERE spcNode = (SELECT oid FROM pg_tablespace WHERE spcname = 'pg_default')
+AND dbNode = (SELECT oid FROM pg_database WHERE datname = current_database())
+ORDER BY gp_segment_id, xrecoff;
+
+-- Store the latest xlog offset
+DELETE FROM tmp;
+INSERT INTO tmp SELECT gp_execution_segment(),pg_current_xlog_location() 
+FROM gp_dist_random('gp_id');
+
+-- Generate a truncate XLOG entry for generate_ao_xlog_table.
+BEGIN;
+INSERT INTO generate_aoco_xlog_table SELECT i,i FROM generate_series(1,10)i;
+ABORT;
+VACUUM generate_aoco_xlog_table;
+
+-- Verify that truncate AO xlog record was received
+SELECT gp_segment_id, relname, record_type, segment_filenum, recordlen, file_offset
+  FROM test_xlog_ao_wrapper(
+    (SELECT array_agg(startpoint) FROM 
+       (SELECT startpoint from tmp order by dbid) t
+    )
+  ) 
+WHERE spcNode = (SELECT oid FROM pg_tablespace WHERE spcname = 'pg_default')
+AND dbNode = (SELECT oid FROM pg_database WHERE datname = current_database())
+ORDER BY gp_segment_id, xrecoff;
 


### PR DESCRIPTION
Vacuum truncates AO/CO files if a insert transaction has been
aborted. The truncate for walrep needs to be communicated to mirror
segmnets via xlog. For filerep this was communicated via filrep
messages, hence AO/CO truncate was not xlogged. So, adding to xlog
truncate operation for walreplication and its only replayed in standby
mode.

Simplify walrep tests to be more generic/explicit

Instead of passing in arguments to do validation inside a C function, we get
the values from the C function and use normal sql inputs to perform validations
of XLOG_APPENDONLY_* records. This also adds the ability to test
XLOG_APPENDONLY_TRUNCATE records, rather than specifically looking at
XLOG_APPENDONLY_INSERT records.