### PR TITLE
A bunch of fixes for writable external table issues.

### DIFF
--- a/contrib/formatter/gpformatter.c
+++ b/contrib/formatter/gpformatter.c
@@ -335,6 +335,9 @@ formatter_import(PG_FUNCTION_ARGS)
 				if (nextlen)
 					memcpy(&len, data_buf + data_cur, sizeof(len));
 
+				if  (len < 0)
+					elog(ERROR, "invalid length of varlen datatype: %d", len);
+
 				/* if len or data bytes don't exist in this buffer, return */
 				if (!nextlen || (nextlen && (remaining - sizeof(len) < len)))
 				{

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -3163,7 +3163,11 @@ ExecInsert(TupleTableSlot *slot,
 		}
 		else
 		{
-			tuple = ExecFetchSlotHeapTuple(partslot);
+			/*
+			 * Make a modifiable copy, since external_insert() takes the
+			 * liberty to modify the tuple.
+			 */
+			tuple = ExecCopySlotHeapTuple(partslot);
 		}
 	}
 	else


### PR DESCRIPTION
* Add a sanity check in formatter_import() for invalid lengths.

* In fileam.c, set the length-field of the HeapTupleHeader passed as Datum
correctly. Otherwise, if ExecInsert passes a tuple that came directly from
a table, and was not materialized in the tupletable slot, it will not have
the length set correctly.

* In ExecInsert, since external_insert() apparently takes the liberty to
modify the tuple it's passed, make sure we make a copy of it. Otherwise,
we might scribble over a tuple pointer that points directly at an on-disk
buffer.

* In externalgettup_custom(), don't go into an infinite loop if we reach
end-of-file prematurely, while the custom formatter says that it still
needs more data.

I bumped into these while trying to merge 8.4 commits. I'm not sure what
changed, but in the contrib/extprotocol regression tests, external_insert()
was now being passed a tuple that was already in HeapTuple format in the
tuple slot. That resulted in the infinite loop, because the custom formatter
read the length of the tuple incorrectly, and expected more data even though
EOF had already been reached. I'm not sure why that doesn't currently happen
on 'master', but I suspect it might be possible to devise a test case to
trigger it even there.