### PR TITLE
Add support for "order none" directive to atmsort.

### DIFF
--- a/src/test/regress/atmsort.pl
+++ b/src/test/regress/atmsort.pl
@@ -217,7 +217,7 @@ or
 
 The supported commands are:
 
-=over 12
+=over 13
 
 =item -- order column number[, column number...]
 
@@ -226,6 +226,14 @@ The supported commands are:
   output.  The specified columns are assumed 
   to be ordered, and the  remaining columns are 
   sorted to allow for deterministic comparison.
+
+=item -- order none
+
+  The order none directive can be used to specify that the SELECT's
+  output is not ordered. This can be necessary if the default
+  heuristic that checks if there is an ORDER BY in the query gets
+  fooled, e.g by an ORDER BY in a subquery that doesn't force the
+  overall result to be ordered.
 
 =item -- ignore
 

--- a/src/test/regress/atmsort.pm
+++ b/src/test/regress/atmsort.pm
@@ -1289,7 +1289,7 @@ sub atmsort_bigloop
 			# each command has a unique first character. This allows us to
 			# use fewer regular expression matches in this hot section.
 			if ($has_comment &&
-				$ini =~ m/\-\-\s*((force_explain)\s*(operator)?\s*$|(ignore)\s*$|(order)\s+\d+.*$|(mvd)\s+\d+.*$)/)
+				$ini =~ m/\-\-\s*((force_explain)\s*(operator)?\s*$|(ignore)\s*$|(order)\s+(\d+|none).*$|(mvd)\s+\d+.*$)/)
 			{
 				my $cmd = substr($1, 0, 1);
 				if ($cmd eq 'i')
@@ -1300,7 +1300,14 @@ sub atmsort_bigloop
 				{
 					my $olist = $ini;
 					$olist =~ s/^.*\-\-\s*order//;
-					$directive->{order} = $olist;
+					if ($olist =~ /none/)
+					{
+						$directive->{order_none} = 1;
+					}
+					else
+					{
+						$directive->{order} = $olist;
+					}
 				}
 				elsif ($cmd eq 'f')
 				{
@@ -1424,6 +1431,7 @@ sub atmsort_bigloop
 
                 if (defined($sql_statement)
                     && length($sql_statement)
+                    && !defined($directive->{order_none})
                     # multiline match
                     && ($sql_statement =~ m/select.*order.*by/is))
                 {

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -2229,7 +2229,7 @@ select distinct 1, sum(x1) from orca.foo;
         1 |  55
 (1 row)
 
-select distinct x1, rank() over(order by x1) from (select x1 from orca.foo order by x1) x;
+select distinct x1, rank() over(order by x1) from (select x1 from orca.foo order by x1) x; --order none
  x1 | rank 
 ----+------
   1 |    1

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -2230,7 +2230,7 @@ select distinct 1, sum(x1) from orca.foo;
         1 |  55
 (1 row)
 
-select distinct x1, rank() over(order by x1) from (select x1 from orca.foo order by x1) x;
+select distinct x1, rank() over(order by x1) from (select x1 from orca.foo order by x1) x; --order none
  x1 | rank 
 ----+------
   1 |    1

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -100,7 +100,7 @@ SELECT x1 AS one FROM orca.foo having 1 < 2;
 select distinct 1, null;
 select distinct 1, null from orca.foo;
 select distinct 1, sum(x1) from orca.foo;
-select distinct x1, rank() over(order by x1) from (select x1 from orca.foo order by x1) x;
+select distinct x1, rank() over(order by x1) from (select x1 from orca.foo order by x1) x; --order none
 select distinct x1, sum(x3) from orca.foo group by x1,x2;
 select distinct s from (select sum(x2) s from orca.foo group by x1) x;
 select * from orca.foo a where a.x1 = (select distinct sum(b.x1)+avg(b.x1) sa from orca.bar1 b group by b.x3 order by sa limit 1);


### PR DESCRIPTION
This allows overriding the heuristic on whether a query has an ORDER BY.

Use the directive in one of the queries in the 'gporca' test, which
contains a subquery with an ORDER BY that fools the atmsort's usual
heuristic. The overall order of the query is not well-defined, even though
there is an ORDER BY in the subquery. The current implementation of
DISTINCT in fact always also sorts the output, which is why this test
is passing, but that is about to be relaxed soon, when we merge upstream
commit 63247bec28.