### PR TITLE
Remove unused fields from VacuumStatsContext, and move it to vacuum.c.

### DIFF
--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -188,6 +188,11 @@ typedef struct ExecContextData
 
 typedef ExecContextData *ExecContext;
 
+typedef struct VacuumStatsContext
+{
+	List	   *updated_stats;
+} VacuumStatsContext;
+
 /*
  * State information used during the (full)
  * vacuum of indexes on append-only tables
@@ -1266,10 +1271,7 @@ vacuumStatement_Relation(VacuumStmt *vacstmt, Oid relid,
 			bool 		has_bitmap = false;
 			Relation   *i_rel = NULL;
 
-			stats_context.ctx = vac_context;
-			stats_context.onerel = onerel;
 			stats_context.updated_stats = NIL;
-			stats_context.vac_stats = NULL;
 
 			vac_open_indexes(onerel, AccessShareLock, &nindexes, &i_rel);
 			if (i_rel != NULL)

--- a/src/include/commands/vacuum.h
+++ b/src/include/commands/vacuum.h
@@ -107,14 +107,6 @@ typedef struct VacAttrStats
 	int			rowstride;
 } VacAttrStats;
 
-typedef struct VacuumStatsContext
-{
-	MemoryContext ctx;
-	Relation onerel;
-	List *updated_stats;
-	VacAttrStats **vac_stats;
-} VacuumStatsContext;
-
 /*
  * VPgClassStats is used to hold the stats information that are stored in
  * pg_class. It is sent from QE to QD in a special libpq message , when a


### PR DESCRIPTION
It's only used within vacuum.c, so let's have it there rather than pollute
the headers.