### PR TITLE
resgroup: filter out '<IDLE>' sessions in two cases.

### DIFF
--- a/src/test/isolation2/expected/resgroup/resgroup_alter_concurrency.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_alter_concurrency.out
@@ -10,7 +10,11 @@ CREATE
 CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
 CREATE
 
-CREATE OR REPLACE VIEW rg_activity_status AS SELECT rsgname, waiting_reason, current_query FROM pg_stat_activity WHERE rsgname='rg_concurrency_test';
+-- After a 'q' command the client connection is disconnected but the
+-- QD may still be alive, if we then query pg_stat_activity quick enough
+-- we might still see this session with current_query '<IDLE>'.
+-- A filter is put to filter out this kind of quitted sessions.
+CREATE OR REPLACE VIEW rg_activity_status AS SELECT rsgname, waiting_reason, current_query FROM pg_stat_activity WHERE rsgname='rg_concurrency_test' AND current_query <> '<IDLE>';
 CREATE
 
 --

--- a/src/test/isolation2/input/resgroup/resgroup_alter_memory.source
+++ b/src/test/isolation2/input/resgroup/resgroup_alter_memory.source
@@ -13,10 +13,15 @@ CREATE OR REPLACE FUNCTION hold_memory_by_percent(int, float) RETURNS int AS $$
     SELECT * FROM resGroupPalloc($2)
 $$ LANGUAGE sql;
 
+-- After a 'q' command the client connection is disconnected but the
+-- QD may still be alive, if we then query pg_stat_activity quick enough
+-- we might still see this session with current_query '<IDLE>'.
+-- A filter is put to filter out this kind of quitted sessions.
 CREATE OR REPLACE VIEW rg_activity_status AS
 	SELECT rsgname, waiting_reason, current_query
 	FROM pg_stat_activity
-	WHERE rsgname='rg1_memory_test' OR rsgname='rg2_memory_test'
+	WHERE rsgname in ('rg1_memory_test', 'rg2_memory_test')
+	  AND current_query <> '<IDLE>'
 	ORDER BY sess_id;
 
 CREATE OR REPLACE VIEW rg_mem_status AS

--- a/src/test/isolation2/output/resgroup/resgroup_alter_memory.source
+++ b/src/test/isolation2/output/resgroup/resgroup_alter_memory.source
@@ -9,13 +9,17 @@ DROP RESOURCE GROUP rg2_memory_test;
 ERROR:  resource group "rg2_memory_test" does not exist
 -- end_ignore
 
-CREATE OR REPLACE FUNCTION resGroupPalloc(float) RETURNS int AS '@abs_builddir@/../regress/regress@DLSUFFIX@', 'resGroupPalloc' LANGUAGE C READS SQL DATA;
+CREATE OR REPLACE FUNCTION resGroupPalloc(float) RETURNS int AS '/home/gpadmin/src/gpdb.git/src/test/isolation2/../regress/regress.so', 'resGroupPalloc' LANGUAGE C READS SQL DATA;
 CREATE
 
 CREATE OR REPLACE FUNCTION hold_memory_by_percent(int, float) RETURNS int AS $$ SELECT * FROM resGroupPalloc($2) $$ LANGUAGE sql;
 CREATE
 
-CREATE OR REPLACE VIEW rg_activity_status AS SELECT rsgname, waiting_reason, current_query FROM pg_stat_activity WHERE rsgname='rg1_memory_test' OR rsgname='rg2_memory_test' ORDER BY sess_id;
+-- After a 'q' command the client connection is disconnected but the
+-- QD may still be alive, if we then query pg_stat_activity quick enough
+-- we might still see this session with current_query '<IDLE>'.
+-- A filter is put to filter out this kind of quitted sessions.
+CREATE OR REPLACE VIEW rg_activity_status AS SELECT rsgname, waiting_reason, current_query FROM pg_stat_activity WHERE rsgname in ('rg1_memory_test', 'rg2_memory_test') AND current_query <> '<IDLE>' ORDER BY sess_id;
 CREATE
 
 CREATE OR REPLACE VIEW rg_mem_status AS SELECT groupname, memory_limit, proposed_memory_limit, memory_shared_quota, proposed_memory_shared_quota FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg1_memory_test' OR groupname='rg2_memory_test' ORDER BY groupid;

--- a/src/test/isolation2/output/resgroup/resgroup_alter_memory.source
+++ b/src/test/isolation2/output/resgroup/resgroup_alter_memory.source
@@ -9,7 +9,7 @@ DROP RESOURCE GROUP rg2_memory_test;
 ERROR:  resource group "rg2_memory_test" does not exist
 -- end_ignore
 
-CREATE OR REPLACE FUNCTION resGroupPalloc(float) RETURNS int AS '/home/gpadmin/src/gpdb.git/src/test/isolation2/../regress/regress.so', 'resGroupPalloc' LANGUAGE C READS SQL DATA;
+CREATE OR REPLACE FUNCTION resGroupPalloc(float) RETURNS int AS '@abs_builddir@/../regress/regress@DLSUFFIX@', 'resGroupPalloc' LANGUAGE C READS SQL DATA;
 CREATE
 
 CREATE OR REPLACE FUNCTION hold_memory_by_percent(int, float) RETURNS int AS $$ SELECT * FROM resGroupPalloc($2) $$ LANGUAGE sql;


### PR DESCRIPTION
In resgroup_alter_concurrency and resgroup_alter_memory cases we query
pg_stat_activity to verify pending queries get executed after quitting
of old sessions. Old sessions are quitted with the 'q' command of the
isolation2 test framework, however this only disconnect the client but
the QD may still be alive and if we then query pg_stat_activity quick
enough then we might still see this old session occasionly.

To get rid of this kind of __quitted__ sessions we added a filter to not
list `<IDLE>` sessions. So we can always get a stable output in these
two test cases.