### PR TITLE
Polish warning message that indicates resource queue in disabled.

### DIFF
--- a/src/backend/commands/queue.c
+++ b/src/backend/commands/queue.c
@@ -959,8 +959,8 @@ CreateQueue(CreateQueueStmt *stmt)
 		else
 		{
 				ereport(WARNING,
-						(errmsg("resource scheduling is disabled"),
-						 errhint("To enable set resource_scheduler=on and gp_resource_manager=queue")));
+						(errmsg("resource queue is disabled"),
+						 errhint("To enable set gp_resource_manager=queue")));
 		}
 	}
 
@@ -1377,8 +1377,8 @@ AlterQueue(AlterQueueStmt *stmt)
 		else
 		{
 			ereport(WARNING,
-					(errmsg("resource scheduling is disabled"),
-					 errhint("To enable set resource_scheduler=on and gp_resource_manager=queue")));
+					(errmsg("resource queue is disabled"),
+					 errhint("To enable set gp_resource_manager=queue")));
 		}
 	}
 
@@ -1515,8 +1515,8 @@ DropQueue(DropQueueStmt *stmt)
 		else
 		{
 			ereport(WARNING,
-					(errmsg("resource scheduling is disabled"),
-					 errhint("To enable set resource_scheduler=on and gp_resource_manager=queue")));
+					(errmsg("resource queue is disabled"),
+					 errhint("To enable set gp_resource_manager=queue")));
 		}
 	}
 

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -288,7 +288,7 @@ CreateResourceGroup(CreateResourceGroupStmt *stmt)
 	else if (Gp_role == GP_ROLE_DISPATCH)
 		ereport(WARNING,
 				(errmsg("resource group is disabled"),
-				 errhint("To enable set resource_scheduler=on and gp_resource_manager=group")));
+				 errhint("To enable set gp_resource_manager=group")));
 }
 
 /*

--- a/src/backend/commands/user.c
+++ b/src/backend/commands/user.c
@@ -475,8 +475,8 @@ CreateRole(CreateRoleStmt *stmt)
 		 */
 		if (!IsResQueueEnabled() && !issuper)
 			ereport(WARNING,
-					(errmsg("resource scheduling is disabled"),
-					 errhint("To enable set resource_scheduler=on and gp_resource_manager=queue")));
+					(errmsg("resource queue is disabled"),
+					 errhint("To enable set gp_resource_manager=queue")));
 	}
 	else
 	{
@@ -513,7 +513,7 @@ CreateRole(CreateRoleStmt *stmt)
 		if (!IsResGroupActivated() && Gp_role == GP_ROLE_DISPATCH)
 			ereport(WARNING,
 					(errmsg("resource group is disabled"),
-					 errhint("To enable set resource_scheduler=on and gp_resource_manager=group")));
+					 errhint("To enable set gp_resource_manager=group")));
 	}
 	else if (issuper)
 	{
@@ -1108,8 +1108,8 @@ AlterRole(AlterRoleStmt *stmt)
 			 * who doesn't use the queue 
 			 */
 			ereport(WARNING,
-					(errmsg("resource scheduling is disabled"),
-					 errhint("To enable set resource_scheduler=on and gp_resource_manager=queue")));
+					(errmsg("resource queue is disabled"),
+					 errhint("To enable set gp_resource_manager=queue")));
 		}
 	}
 
@@ -1151,7 +1151,7 @@ AlterRole(AlterRoleStmt *stmt)
 		{
 			ereport(WARNING,
 					(errmsg("resource group is disabled"),
-					 errhint("To enable set resource_scheduler=on and gp_resource_manager=group")));
+					 errhint("To enable set gp_resource_manager=group")));
 		}
 	}
 

--- a/src/test/regress/expected/gp_toolkit_resgroup.out
+++ b/src/test/regress/expected/gp_toolkit_resgroup.out
@@ -599,18 +599,18 @@ select * from gp_toolkit.gp_pgdatabase_invalid;
 -- reflected in the pg_stat_resqueues view
 set stats_queue_level=on;
 create resource queue q with (active_statements = 10);
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 create user resqueuetest with resource queue q;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 NOTICE:  resource group required -- using default resource group "default_group"
-WARNING:  resource scheduling is disabled  (seg0 172.17.0.2:25432 pid=10507)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg1 172.17.0.2:25433 pid=10508)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg2 172.17.0.2:25434 pid=10509)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg0 172.17.0.2:25432 pid=10507)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg1 172.17.0.2:25433 pid=10508)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg2 172.17.0.2:25434 pid=10509)
+HINT:  To enable set gp_resource_manager=queue
 set role resqueuetest;
 select 1;
  ?column? 
@@ -627,8 +627,8 @@ select n_queries_exec from pg_stat_resqueues where queuename = 'q';
 reset role;
 drop role resqueuetest;
 drop resource queue q;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 -- GP Readable Data Table
 -- Check that the tables created above are present in gp_toolkit.__gp_user_data_tables_readable
 -- view.

--- a/src/test/regress/expected/resource_queue_resgroup.out
+++ b/src/test/regress/expected/resource_queue_resgroup.out
@@ -1,7 +1,7 @@
 -- SQL coverage of RESOURCE QUEUE
 CREATE RESOURCE QUEUE regressq ACTIVE THRESHOLD 1;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 SELECT * FROM pg_resqueue WHERE rsqname='regressq';
  rsqname  | rsqcountlimit | rsqcostlimit | rsqovercommit | rsqignorecostlimit 
 ----------+---------------+--------------+---------------+--------------------
@@ -9,8 +9,8 @@ SELECT * FROM pg_resqueue WHERE rsqname='regressq';
 (1 row)
 
 ALTER RESOURCE QUEUE regressq ACTIVE THRESHOLD 2 COST THRESHOLD 2000.00;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 SELECT * FROM pg_resqueue WHERE rsqname='regressq';
  rsqname  | rsqcountlimit | rsqcostlimit | rsqovercommit | rsqignorecostlimit 
 ----------+---------------+--------------+---------------+--------------------
@@ -18,8 +18,8 @@ SELECT * FROM pg_resqueue WHERE rsqname='regressq';
 (1 row)
 
 ALTER RESOURCE QUEUE regressq COST THRESHOLD 3000.00 OVERCOMMIT;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 SELECT * FROM pg_resqueue WHERE rsqname='regressq';
  rsqname  | rsqcountlimit | rsqcostlimit | rsqovercommit | rsqignorecostlimit 
 ----------+---------------+--------------+---------------+--------------------
@@ -27,8 +27,8 @@ SELECT * FROM pg_resqueue WHERE rsqname='regressq';
 (1 row)
 
 ALTER RESOURCE QUEUE regressq COST THRESHOLD 4e+3 NOOVERCOMMIT;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 SELECT * FROM pg_resqueue WHERE rsqname='regressq';
  rsqname  | rsqcountlimit | rsqcostlimit | rsqovercommit | rsqignorecostlimit 
 ----------+---------------+--------------+---------------+--------------------
@@ -36,8 +36,8 @@ SELECT * FROM pg_resqueue WHERE rsqname='regressq';
 (1 row)
 
 DROP RESOURCE QUEUE regressq;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 SELECT * FROM pg_resqueue WHERE rsqname='regressq';
  rsqname | rsqcountlimit | rsqcostlimit | rsqovercommit | rsqignorecostlimit 
 ---------+---------------+--------------+---------------+--------------------
@@ -45,8 +45,8 @@ SELECT * FROM pg_resqueue WHERE rsqname='regressq';
 
 -- more coverage
 CREATE RESOURCE QUEUE regressq ACTIVE THRESHOLD 1 WITH (max_cost=2000);
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 SELECT * FROM pg_resqueue WHERE rsqname='regressq';
  rsqname  | rsqcountlimit | rsqcostlimit | rsqovercommit | rsqignorecostlimit 
 ----------+---------------+--------------+---------------+--------------------
@@ -54,8 +54,8 @@ SELECT * FROM pg_resqueue WHERE rsqname='regressq';
 (1 row)
 
 ALTER RESOURCE QUEUE regressq ACTIVE THRESHOLD 1 WITHOUT (max_cost);
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 SELECT * FROM pg_resqueue WHERE rsqname='regressq';
  rsqname  | rsqcountlimit | rsqcostlimit | rsqovercommit | rsqignorecostlimit 
 ----------+---------------+--------------+---------------+--------------------
@@ -67,8 +67,8 @@ WITHOUT (overcommit); -- negative
 ERROR:  option "overcommit" is not a valid resource type
 ALTER RESOURCE QUEUE regressq ACTIVE THRESHOLD 1 WITH (max_cost=2000)
 WITHOUT (cost_overcommit); -- works
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 SELECT * FROM pg_resqueue WHERE rsqname='regressq';
  rsqname  | rsqcountlimit | rsqcostlimit | rsqovercommit | rsqignorecostlimit 
 ----------+---------------+--------------+---------------+--------------------
@@ -76,8 +76,8 @@ SELECT * FROM pg_resqueue WHERE rsqname='regressq';
 (1 row)
 
 ALTER RESOURCE QUEUE regressq OVERCOMMIT WITH (max_cost=2000);
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 SELECT * FROM pg_resqueue WHERE rsqname='regressq';
  rsqname  | rsqcountlimit | rsqcostlimit | rsqovercommit | rsqignorecostlimit 
 ----------+---------------+--------------+---------------+--------------------
@@ -85,8 +85,8 @@ SELECT * FROM pg_resqueue WHERE rsqname='regressq';
 (1 row)
 
 ALTER RESOURCE QUEUE regressq IGNORE THRESHOLD 1 WITHOUT (max_cost);
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 SELECT * FROM pg_resqueue WHERE rsqname='regressq';
  rsqname  | rsqcountlimit | rsqcostlimit | rsqovercommit | rsqignorecostlimit 
 ----------+---------------+--------------+---------------+--------------------
@@ -94,8 +94,8 @@ SELECT * FROM pg_resqueue WHERE rsqname='regressq';
 (1 row)
 
 ALTER RESOURCE QUEUE regressq WITH (priority=high);
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 SELECT * FROM pg_resqueue_attributes WHERE rsqname='regressq';
  rsqname  |      resname      | ressetting | restypid 
 ----------+-------------------+------------+----------
@@ -108,8 +108,8 @@ SELECT * FROM pg_resqueue_attributes WHERE rsqname='regressq';
 (6 rows)
 
 ALTER RESOURCE QUEUE regressq WITH (priority='MeDiUm');
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 SELECT * FROM pg_resqueue_attributes WHERE rsqname='regressq';
  rsqname  |      resname      | ressetting | restypid 
 ----------+-------------------+------------+----------
@@ -124,8 +124,8 @@ SELECT * FROM pg_resqueue_attributes WHERE rsqname='regressq';
 ALTER RESOURCE QUEUE regressq;
 ERROR:  at least one threshold, overcommit or ignore limit must be specified
 DROP RESOURCE QUEUE regressq;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 SELECT * FROM pg_resqueue WHERE rsqname='regressq';
  rsqname | rsqcountlimit | rsqcostlimit | rsqovercommit | rsqignorecostlimit 
 ---------+---------------+--------------+---------------+--------------------
@@ -138,8 +138,8 @@ CREATE RESOURCE QUEUE none ACTIVE THRESHOLD 2;
 ERROR:  resource queue name "none" is reserved
 ;
 CREATE RESOURCE QUEUE regressq2 ACTIVE THRESHOLD 2;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 ALTER RESOURCE QUEUE regressq2 ACTIVE THRESHOLD -10;
 ERROR:  active threshold cannot be less than -1 or equal to 0
 ALTER RESOURCE QUEUE regressq2 COST THRESHOLD -1000.00;
@@ -151,8 +151,8 @@ ERROR:  Invalid parameter value "funky" for resource type "PRIORITY"
 ALTER RESOURCE QUEUE regressq2 WITHOUT(PRIORITY);
 ERROR:  option "priority" cannot be disabled
 DROP RESOURCE QUEUE regressq2;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 CREATE RESOURCE QUEUE regressq2 ACTIVE THRESHOLD -10;
 ERROR:  active threshold cannot be less than -1 or equal to 0
 CREATE RESOURCE QUEUE regressq2 COST THRESHOLD -1000.00;
@@ -172,8 +172,8 @@ ERROR:  conflicting or redundant options
 CREATE RESOURCE QUEUE regressq2 WITH (WITHLISTSTART=funky);
 ERROR:  option "withliststart" is not a valid resource type
 CREATE RESOURCE QUEUE regressq2 ACTIVE THRESHOLD 2;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 ALTER RESOURCE QUEUE regressq2 ACTIVE THRESHOLD 2 ACTIVE THRESHOLD 2;
 ERROR:  conflicting or redundant options
 ALTER RESOURCE QUEUE regressq2 COST THRESHOLD 2 COST THRESHOLD 2;
@@ -187,12 +187,12 @@ ERROR:  conflicting or redundant options
 ALTER RESOURCE QUEUE none IGNORE THRESHOLD 1 ;
 ERROR:  resource queue "none" does not exist
 DROP RESOURCE QUEUE regressq2;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 -- Create resource queue with cost_overcommit=true
 create resource queue t3_test_q with (active_statements = 6,max_cost=5e+06 ,cost_overcommit=true, min_cost=50000);
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 select * from pg_resqueue where rsqname='t3_test_q';
   rsqname  | rsqcountlimit | rsqcostlimit | rsqovercommit | rsqignorecostlimit 
 -----------+---------------+--------------+---------------+--------------------
@@ -200,8 +200,8 @@ select * from pg_resqueue where rsqname='t3_test_q';
 (1 row)
 
 drop resource queue t3_test_q;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 -- Resource Queue should not be created inside Transaction block the error is the expected behavior
 begin;
 CREATE RESOURCE QUEUE db_resque_new1 ACTIVE THRESHOLD 2 COST THRESHOLD 2000.00;
@@ -217,45 +217,45 @@ create resource queue test_rq with (max_cost=2000000, memory_limit='0'); -- shou
 ERROR:  Invalid parameter value "0" for resource type "MEMORY_LIMIT". Value must be at least 10240kB
 -- Creates and drops
 create resource queue test_rq with (active_statements=2);
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 drop resource queue test_rq;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 create resource queue test_rq with (active_statements=2, memory_limit='1024MB');
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 -- Alters
 alter resource queue test_rq with (memory_limit='1024mb');
 ERROR:  Invalid parameter value "1024mb" for resource type "MEMORY_LIMIT". Value must be in kB, MB or GB.
 alter resource queue test_rq with (memory_limit='1024Kb');
 ERROR:  Invalid parameter value "1024Kb" for resource type "MEMORY_LIMIT". Value must be in kB, MB or GB.
 alter resource queue test_rq with (memory_limit='2GB');
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 alter resource queue test_rq without (memory_limit);
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 drop resource queue test_rq;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 -- SQL coverage of ROLE -> RESOURCE QUEUE
 CREATE RESOURCE QUEUE reg_activeq ACTIVE THRESHOLD 2;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 CREATE RESOURCE QUEUE reg_costq COST THRESHOLD 30000.00;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 CREATE USER reg_u1 RESOURCE QUEUE reg_costq;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 NOTICE:  resource group required -- using default resource group "default_group"
-WARNING:  resource scheduling is disabled  (seg0 172.17.0.2:25432 pid=10385)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg1 172.17.0.2:25433 pid=10386)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg2 172.17.0.2:25434 pid=10387)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg0 172.17.0.2:25432 pid=10385)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg1 172.17.0.2:25433 pid=10386)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg2 172.17.0.2:25434 pid=10387)
+HINT:  To enable set gp_resource_manager=queue
 GRANT SELECT ON tenk1 TO reg_u1;
 SELECT u.rolname, u.rolsuper, r.rsqname FROM pg_roles as u, pg_resqueue as r WHERE u.rolresqueue=r.oid and rolname='reg_u1';
  rolname | rolsuper |  rsqname  
@@ -264,14 +264,14 @@ SELECT u.rolname, u.rolsuper, r.rsqname FROM pg_roles as u, pg_resqueue as r WHE
 (1 row)
 
 ALTER USER reg_u1 RESOURCE QUEUE reg_activeq;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg0 172.17.0.2:25432 pid=10385)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg1 172.17.0.2:25433 pid=10386)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg2 172.17.0.2:25434 pid=10387)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg0 172.17.0.2:25432 pid=10385)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg1 172.17.0.2:25433 pid=10386)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg2 172.17.0.2:25434 pid=10387)
+HINT:  To enable set gp_resource_manager=queue
 SELECT u.rolname, u.rolsuper, r.rsqname FROM pg_roles as u, pg_resqueue as r WHERE u.rolresqueue=r.oid and rolname='reg_u1';
  rolname | rolsuper |   rsqname   
 ---------+----------+-------------
@@ -279,15 +279,15 @@ SELECT u.rolname, u.rolsuper, r.rsqname FROM pg_roles as u, pg_resqueue as r WHE
 (1 row)
 
 CREATE USER reg_u2 RESOURCE QUEUE reg_activeq;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 NOTICE:  resource group required -- using default resource group "default_group"
-WARNING:  resource scheduling is disabled  (seg0 172.17.0.2:25432 pid=10385)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg2 172.17.0.2:25434 pid=10387)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg1 172.17.0.2:25433 pid=10386)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg0 172.17.0.2:25432 pid=10385)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg2 172.17.0.2:25434 pid=10387)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg1 172.17.0.2:25433 pid=10386)
+HINT:  To enable set gp_resource_manager=queue
 GRANT SELECT ON tenk1 TO reg_u2;
 SELECT u.rolname, u.rolsuper, r.rsqname FROM pg_roles as u, pg_resqueue as r WHERE u.rolresqueue=r.oid and r.rsqname='reg_activeq';
  rolname | rolsuper |   rsqname   
@@ -332,14 +332,14 @@ END;
 -- switch to a cost-limited queue
 RESET SESSION AUTHORIZATION;
 ALTER USER reg_u2 RESOURCE QUEUE reg_costq;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg0 172.17.0.2:25432 pid=10385)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg1 172.17.0.2:25433 pid=10386)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg2 172.17.0.2:25434 pid=10387)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg0 172.17.0.2:25432 pid=10385)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg1 172.17.0.2:25433 pid=10386)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg2 172.17.0.2:25434 pid=10387)
+HINT:  To enable set gp_resource_manager=queue
 SET SESSION AUTHORIZATION reg_u2;
 BEGIN;
 DECLARE c1 CURSOR FOR SELECT * FROM tenk1;
@@ -411,26 +411,26 @@ DROP OWNED BY reg_u1, reg_u2 CASCADE;
 DROP USER reg_u1;
 DROP USER reg_u2;
 DROP RESOURCE QUEUE reg_activeq;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 DROP RESOURCE QUEUE reg_costq;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 -- Followup additional tests.
 -- MPP-7474
 CREATE RESOURCE QUEUE rq_test_q ACTIVE THRESHOLD 1;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 CREATE USER rq_test_u RESOURCE QUEUE rq_test_q;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 NOTICE:  resource group required -- using default resource group "default_group"
-WARNING:  resource scheduling is disabled  (seg1 172.17.0.2:25433 pid=10386)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg0 172.17.0.2:25432 pid=10385)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg2 172.17.0.2:25434 pid=10387)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg1 172.17.0.2:25433 pid=10386)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg0 172.17.0.2:25432 pid=10385)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg2 172.17.0.2:25434 pid=10387)
+HINT:  To enable set gp_resource_manager=queue
 create table rq_product (
 	pn int not null,
 	pname text not null,
@@ -671,6 +671,6 @@ RESET SESSION_AUTHORIZATION;
 DROP OWNED BY rq_test_u CASCADE;
 DROP USER rq_test_u;
 DROP RESOURCE QUEUE rq_test_q;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 DROP TABLE rq_product;

--- a/src/test/regress/expected/wrkloadadmin_resgroup.out
+++ b/src/test/regress/expected/wrkloadadmin_resgroup.out
@@ -2,8 +2,8 @@
 
 -- create resource queue
 CREATE RESOURCE QUEUE adhoc11 ACTIVE THRESHOLD 1;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 
 -- select from pg_resqueue table
 select * from pg_resqueue where rsqname='adhoc11';
@@ -15,15 +15,15 @@ select * from pg_resqueue where rsqname='adhoc11';
 
 --create role and assign role to resource queue
 CREATE ROLE role11 with LOGIN RESOURCE QUEUE adhoc11;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 NOTICE:  resource group required -- using default resource group "default_group"
-WARNING:  resource scheduling is disabled  (seg0 172.17.0.2:25432 pid=10482)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg1 172.17.0.2:25433 pid=10483)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg2 172.17.0.2:25434 pid=10484)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg0 172.17.0.2:25432 pid=10482)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg1 172.17.0.2:25433 pid=10483)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg2 172.17.0.2:25434 pid=10484)
+HINT:  To enable set gp_resource_manager=queue
 
 -- select role, resource queue details from pg_roles and pg_resqueue tables
 SELECT rolname, rsqname FROM pg_roles AS r,pg_resqueue AS q WHERE r.rolresqueue=q.oid and rolname='role11';
@@ -38,14 +38,14 @@ DROP ROLE role11;
 
 -- drop resource queue
 DROP RESOURCE QUEUE adhoc11;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 -- Test Workload Administration and Resource queuing
 
 -- create resource queue
 CREATE RESOURCE QUEUE adhoc12 ACTIVE THRESHOLD 2;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 
 -- select from pg_resqueue table
 select * from pg_resqueue where rsqname='adhoc12';
@@ -57,8 +57,8 @@ select * from pg_resqueue where rsqname='adhoc12';
 
 -- drop resource queue
 DROP RESOURCE QUEUE adhoc12;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 
 -- select from pg_resqueue table
 --select * from pg_resqueue;
@@ -66,11 +66,11 @@ HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
 
 -- create resource queue
 CREATE RESOURCE QUEUE adhoc13 ACTIVE THRESHOLD 2;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 CREATE RESOURCE QUEUE adhoc14 ACTIVE THRESHOLD 3;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 
 -- select from pg_resqueue table
 select * from pg_resqueue where rsqname='adhoc13' and rsqname='adhoc14';
@@ -81,25 +81,25 @@ select * from pg_resqueue where rsqname='adhoc13' and rsqname='adhoc14';
 
 --create role and assign role to resource queue
 CREATE ROLE role13 with LOGIN RESOURCE QUEUE adhoc13;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 NOTICE:  resource group required -- using default resource group "default_group"
-WARNING:  resource scheduling is disabled  (seg0 172.17.0.2:25432 pid=10482)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg1 172.17.0.2:25433 pid=10483)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg2 172.17.0.2:25434 pid=10484)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg0 172.17.0.2:25432 pid=10482)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg1 172.17.0.2:25433 pid=10483)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg2 172.17.0.2:25434 pid=10484)
+HINT:  To enable set gp_resource_manager=queue
 CREATE ROLE role14 with LOGIN RESOURCE QUEUE adhoc14;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 NOTICE:  resource group required -- using default resource group "default_group"
-WARNING:  resource scheduling is disabled  (seg0 172.17.0.2:25432 pid=10482)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg1 172.17.0.2:25433 pid=10483)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg2 172.17.0.2:25434 pid=10484)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg0 172.17.0.2:25432 pid=10482)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg1 172.17.0.2:25433 pid=10483)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg2 172.17.0.2:25434 pid=10484)
+HINT:  To enable set gp_resource_manager=queue
 
 -- select role, resource queue details from pg_roles and pg_resqueue tables
 SELECT rolname, rsqname FROM pg_roles AS r,pg_resqueue AS q WHERE r.rolresqueue=q.oid and rolname in ('role13','role14');
@@ -116,23 +116,23 @@ DROP ROLE IF EXISTS role14;
 
 -- drop resource queue
 DROP RESOURCE QUEUE adhoc13;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 DROP RESOURCE QUEUE adhoc14;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 -- Test Workload Administration and Resource queuing
 
 -- create resource queue
 CREATE RESOURCE QUEUE adhoc1 ACTIVE THRESHOLD 1;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 CREATE RESOURCE QUEUE adhoc2 ACTIVE THRESHOLD 2;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 CREATE RESOURCE QUEUE adhoc3 ACTIVE THRESHOLD 3;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 --CREATE RESOURCE QUEUE adhoc4 ACTIVE THRESHOLD 4;
 
 -- select from pg_resqueue table
@@ -140,14 +140,14 @@ HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
 
 -- drop resource queue
 DROP RESOURCE QUEUE adhoc1;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 DROP RESOURCE QUEUE adhoc2;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 DROP RESOURCE QUEUE adhoc3;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 --DROP RESOURCE QUEUE adhoc4;
 
 -- select from pg_resqueue table
@@ -157,14 +157,14 @@ HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
 
 -- create resource queue
 CREATE RESOURCE QUEUE adhoc1 ACTIVE THRESHOLD 1;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 CREATE RESOURCE QUEUE webuser1 ACTIVE THRESHOLD 3;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 CREATE RESOURCE QUEUE mgmtuser1 ACTIVE THRESHOLD 5;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 
 -- select from pg_resqueue table
 select * from pg_resqueue where rsqname in ('adhoc1','webuser1','mgmtuser1');
@@ -178,14 +178,14 @@ select * from pg_resqueue where rsqname in ('adhoc1','webuser1','mgmtuser1');
 
 -- drop resource queue
 DROP RESOURCE QUEUE adhoc1;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 DROP RESOURCE QUEUE webuser1;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 DROP RESOURCE QUEUE mgmtuser1;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 
 
 -- select from pg_resqueue table
@@ -195,29 +195,29 @@ HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
 -- create resource queue and assuming that 8 is the maximum limit for the resource queue and 1 resource queue is already present in the table
 -- it will give error if it crosses the maximum limit of resource queue
 CREATE RESOURCE QUEUE adhoc1 ACTIVE THRESHOLD 1;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 CREATE RESOURCE QUEUE webuser1 ACTIVE THRESHOLD 3;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 CREATE RESOURCE QUEUE mgmtuser1 ACTIVE THRESHOLD 5;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 CREATE RESOURCE QUEUE mgmtuser2 ACTIVE THRESHOLD 7;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 CREATE RESOURCE QUEUE mgmtuser3 ACTIVE THRESHOLD 9;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 CREATE RESOURCE QUEUE mgmtuser4 ACTIVE THRESHOLD 8;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 CREATE RESOURCE QUEUE mgmtuser5 ACTIVE THRESHOLD 6;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 CREATE RESOURCE QUEUE mgmtuser6 ACTIVE THRESHOLD 2;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 
 -- select from pg_resqueue table
 select * from pg_resqueue;
@@ -237,29 +237,29 @@ select * from pg_resqueue;
 
 -- drop resource queue
 DROP RESOURCE QUEUE adhoc1;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 DROP RESOURCE QUEUE webuser1;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 DROP RESOURCE QUEUE mgmtuser1;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 DROP RESOURCE QUEUE mgmtuser2;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 DROP RESOURCE QUEUE mgmtuser3;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 DROP RESOURCE QUEUE mgmtuser4;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 DROP RESOURCE QUEUE mgmtuser5;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 DROP RESOURCE QUEUE mgmtuser6;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 
 -- select from pg_resqueue table
 select * from pg_resqueue;
@@ -272,8 +272,8 @@ select * from pg_resqueue;
 
 -- create resource queue
 CREATE RESOURCE QUEUE bob ACTIVE THRESHOLD 1;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 
 -- select from pg_resqueue table
 select * from pg_resqueue where rsqname='bob';
@@ -285,8 +285,8 @@ select * from pg_resqueue where rsqname='bob';
 
 -- ALTER Resource Queue
 ALTER RESOURCE QUEUE bob ACTIVE THRESHOLD 7;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 
 -- select from pg_resqueue table
 select * from pg_resqueue where rsqname='bob';
@@ -298,8 +298,8 @@ select * from pg_resqueue where rsqname='bob';
 
 -- drop resource queue
 DROP RESOURCE QUEUE bob;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 
 -- select from pg_resqueue table
 -- select * from pg_resqueue;
@@ -307,8 +307,8 @@ HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
 
 -- create resource queue
 CREATE RESOURCE QUEUE sameera ACTIVE THRESHOLD 2;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 
 -- select from pg_resqueue table
 select * from pg_resqueue where rsqname='sameera';
@@ -320,26 +320,26 @@ select * from pg_resqueue where rsqname='sameera';
 
 --create role and assign role to resource queue
 CREATE ROLE aryan with LOGIN RESOURCE QUEUE sameera;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 NOTICE:  resource group required -- using default resource group "default_group"
-WARNING:  resource scheduling is disabled  (seg0 172.17.0.2:25432 pid=10482)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg1 172.17.0.2:25433 pid=10483)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg2 172.17.0.2:25434 pid=10484)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg0 172.17.0.2:25432 pid=10482)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg1 172.17.0.2:25433 pid=10483)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg2 172.17.0.2:25434 pid=10484)
+HINT:  To enable set gp_resource_manager=queue
 
 -- ALTER Resource Queue
 ALTER ROLE aryan RESOURCE QUEUE none;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg1 172.17.0.2:25433 pid=10483)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg0 172.17.0.2:25432 pid=10482)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg2 172.17.0.2:25434 pid=10484)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg1 172.17.0.2:25433 pid=10483)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg0 172.17.0.2:25432 pid=10482)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg2 172.17.0.2:25434 pid=10484)
+HINT:  To enable set gp_resource_manager=queue
 
 -- select role, resource queue details from pg_roles and pg_resqueue tables
 SELECT rolname, rsqname FROM pg_roles AS r,pg_resqueue AS q WHERE r.rolresqueue=q.oid and rolname='aryan';
@@ -354,8 +354,8 @@ DROP ROLE aryan;
 
 -- drop resource queue
 DROP RESOURCE QUEUE sameera;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 
 -- select from pg_resqueue table
 --select * from pg_resqueue;
@@ -363,8 +363,8 @@ HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
 
 -- create resource queue
 CREATE RESOURCE QUEUE ram ACTIVE THRESHOLD 1;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 
 -- select from pg_resqueue table
 select * from pg_resqueue where rsqname='ram';
@@ -376,45 +376,45 @@ select * from pg_resqueue where rsqname='ram';
 
 --create role and assign role to resource queue
 CREATE ROLE sita with LOGIN RESOURCE QUEUE ram;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 NOTICE:  resource group required -- using default resource group "default_group"
-WARNING:  resource scheduling is disabled  (seg0 172.17.0.2:25432 pid=10482)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg1 172.17.0.2:25433 pid=10483)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg2 172.17.0.2:25434 pid=10484)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg0 172.17.0.2:25432 pid=10482)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg1 172.17.0.2:25433 pid=10483)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg2 172.17.0.2:25434 pid=10484)
+HINT:  To enable set gp_resource_manager=queue
 CREATE ROLE samrat with LOGIN RESOURCE QUEUE ram;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 NOTICE:  resource group required -- using default resource group "default_group"
-WARNING:  resource scheduling is disabled  (seg1 172.17.0.2:25433 pid=10483)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg0 172.17.0.2:25432 pid=10482)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg2 172.17.0.2:25434 pid=10484)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg1 172.17.0.2:25433 pid=10483)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg0 172.17.0.2:25432 pid=10482)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg2 172.17.0.2:25434 pid=10484)
+HINT:  To enable set gp_resource_manager=queue
 
 -- ALTER ROLE
 ALTER ROLE sita RESOURCE QUEUE ram;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg0 172.17.0.2:25432 pid=10482)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg1 172.17.0.2:25433 pid=10483)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg2 172.17.0.2:25434 pid=10484)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg0 172.17.0.2:25432 pid=10482)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg1 172.17.0.2:25433 pid=10483)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg2 172.17.0.2:25434 pid=10484)
+HINT:  To enable set gp_resource_manager=queue
 ALTER ROLE samrat RESOURCE QUEUE ram;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg0 172.17.0.2:25432 pid=10482)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg1 172.17.0.2:25433 pid=10483)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg2 172.17.0.2:25434 pid=10484)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg0 172.17.0.2:25432 pid=10482)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg1 172.17.0.2:25433 pid=10483)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg2 172.17.0.2:25434 pid=10484)
+HINT:  To enable set gp_resource_manager=queue
 
 -- select role, resource queue details from pg_roles and pg_resqueue tables
 SELECT rolname, rsqname FROM pg_roles AS r,pg_resqueue AS q WHERE r.rolresqueue=q.oid and rsqname='ram';
@@ -432,17 +432,17 @@ DROP ROLE samrat;
 
 -- drop resource queue
 DROP RESOURCE QUEUE ram;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 -- Test Workload Administration and Resource queuing
 
 -- create resource queue
 CREATE RESOURCE QUEUE camy11 COST THRESHOLD 200.0;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 CREATE RESOURCE QUEUE camy22 COST THRESHOLD 500.0;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 
 
 -- select from pg_resqueue table
@@ -454,45 +454,45 @@ select * from pg_resqueue_status where rsqname in ('camy11','camy22');
 
 --create role and assign role to resource queue
 CREATE ROLE creig11 with LOGIN RESOURCE QUEUE camy11;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 NOTICE:  resource group required -- using default resource group "default_group"
-WARNING:  resource scheduling is disabled  (seg1 172.17.0.2:25433 pid=10483)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg2 172.17.0.2:25434 pid=10484)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg0 172.17.0.2:25432 pid=10482)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg1 172.17.0.2:25433 pid=10483)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg2 172.17.0.2:25434 pid=10484)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg0 172.17.0.2:25432 pid=10482)
+HINT:  To enable set gp_resource_manager=queue
 CREATE ROLE creig22 with LOGIN RESOURCE QUEUE camy22;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 NOTICE:  resource group required -- using default resource group "default_group"
-WARNING:  resource scheduling is disabled  (seg0 172.17.0.2:25432 pid=10482)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg1 172.17.0.2:25433 pid=10483)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg2 172.17.0.2:25434 pid=10484)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg0 172.17.0.2:25432 pid=10482)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg1 172.17.0.2:25433 pid=10483)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg2 172.17.0.2:25434 pid=10484)
+HINT:  To enable set gp_resource_manager=queue
 
 -- ALTER Resource Queue
 ALTER ROLE creig11 RESOURCE QUEUE camy11;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg0 172.17.0.2:25432 pid=10482)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg1 172.17.0.2:25433 pid=10483)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg2 172.17.0.2:25434 pid=10484)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg0 172.17.0.2:25432 pid=10482)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg1 172.17.0.2:25433 pid=10483)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg2 172.17.0.2:25434 pid=10484)
+HINT:  To enable set gp_resource_manager=queue
 ALTER ROLE creig22 RESOURCE QUEUE camy22;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg0 172.17.0.2:25432 pid=10482)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg1 172.17.0.2:25433 pid=10483)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg2 172.17.0.2:25434 pid=10484)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg0 172.17.0.2:25432 pid=10482)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg1 172.17.0.2:25433 pid=10483)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg2 172.17.0.2:25434 pid=10484)
+HINT:  To enable set gp_resource_manager=queue
 
 -- drop role
 DROP ROLE creig11;
@@ -500,11 +500,11 @@ DROP ROLE creig22;
 
 -- drop resource queue
 DROP RESOURCE QUEUE camy11;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 DROP RESOURCE QUEUE camy22;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 
 -- select from pg_resqueue_status table
 --select * from pg_resqueue_status;
@@ -512,13 +512,13 @@ HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
 
 -- create resource queue
 CREATE RESOURCE QUEUE tom ACTIVE THRESHOLD 20;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 
 -- ALTER RESOURCE QUEUE
 ALTER RESOURCE QUEUE tom COST THRESHOLD 100.0;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 
 -- select from pg_resqueue table
 select * from pg_resqueue_status where rsqname='tom';
@@ -529,8 +529,8 @@ select * from pg_resqueue_status where rsqname='tom';
 
 -- drop resource queue
 DROP RESOURCE QUEUE tom;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 
 -- select from pg_resqueue_status table
 --select * from pg_resqueue_status;
@@ -541,16 +541,16 @@ HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
 
 -- create resource queue
 CREATE RESOURCE QUEUE myq11 ACTIVE THRESHOLD 10;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 
 -- ALTER RESOURCE QUEUE
 ALTER RESOURCE QUEUE myq11 COST THRESHOLD 50.0;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 ALTER RESOURCE QUEUE myq11 COST THRESHOLD 3e+7;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 
 -- select from pg_resqueue table
 select * from pg_resqueue_status where rsqname='myq11';
@@ -561,8 +561,8 @@ select * from pg_resqueue_status where rsqname='myq11';
 
 -- drop resource queue
 DROP RESOURCE QUEUE myq11;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 
 -- select from pg_resqueue_status table
 --select * from pg_resqueue_status;
@@ -573,16 +573,16 @@ HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
 
 -- create resource queue
 CREATE RESOURCE QUEUE myq21 ACTIVE THRESHOLD 7;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 
 -- ALTER RESOURCE QUEUE
 ALTER RESOURCE QUEUE myq21 COST THRESHOLD 70.0;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 ALTER RESOURCE QUEUE myq21 COST THRESHOLD 3e+9 NOOVERCOMMIT;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 
 -- select from pg_resqueue table
 select * from pg_resqueue_status where rsqname='myq21';
@@ -593,8 +593,8 @@ select * from pg_resqueue_status where rsqname='myq21';
 
 -- drop resource queue
 DROP RESOURCE QUEUE myq21;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 
 -- select from pg_resqueue_status table
 --select * from pg_resqueue_status;
@@ -605,20 +605,20 @@ HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
 
 -- create resource queue
 CREATE RESOURCE QUEUE tom11 ACTIVE THRESHOLD 20;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 
 --create role and assign role to resource queue
 CREATE ROLE shaun11 with LOGIN RESOURCE QUEUE tom11;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 NOTICE:  resource group required -- using default resource group "default_group"
-WARNING:  resource scheduling is disabled  (seg0 172.17.0.2:25432 pid=10482)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg1 172.17.0.2:25433 pid=10483)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg2 172.17.0.2:25434 pid=10484)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg0 172.17.0.2:25432 pid=10482)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg1 172.17.0.2:25433 pid=10483)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg2 172.17.0.2:25434 pid=10484)
+HINT:  To enable set gp_resource_manager=queue
 
 -- select from pg_resqueue, pg_roles table
 SELECT rolname, rsqname FROM pg_roles, pg_resqueue WHERE pg_roles.rolresqueue=pg_resqueue.oid and rolname='shaun11';
@@ -644,8 +644,8 @@ DROP ROLE shaun11;
 
 -- drop resource queue
 DROP RESOURCE QUEUE tom11;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 
 -- select from view
 --select * from role2que;
@@ -657,20 +657,20 @@ DROP VIEW role2que;
 
 -- create resource queue
 CREATE RESOURCE QUEUE tom55 ACTIVE THRESHOLD 10;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 
 --create role and assign role to resource queue
 CREATE ROLE shaun55 with LOGIN RESOURCE QUEUE tom55;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 NOTICE:  resource group required -- using default resource group "default_group"
-WARNING:  resource scheduling is disabled  (seg1 172.17.0.2:25433 pid=10483)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg2 172.17.0.2:25434 pid=10484)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg0 172.17.0.2:25432 pid=10482)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg1 172.17.0.2:25433 pid=10483)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg2 172.17.0.2:25434 pid=10484)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg0 172.17.0.2:25432 pid=10482)
+HINT:  To enable set gp_resource_manager=queue
 
 -- select from pg_resqueue, pg_role table
 SELECT rolname, rsqname, pid, granted, current_query,datname FROM pg_roles, pg_resqueue, pg_locks, pg_stat_activity WHERE pg_roles.rolresqueue=pg_locks.objid AND pg_locks.objid=pg_resqueue.oid AND pg_stat_activity.procpid=pg_locks.pid;
@@ -694,8 +694,8 @@ DROP ROLE shaun55;
 
 -- drop resource queue
 DROP RESOURCE QUEUE tom55;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 
 -- select from view
 --select * from resq_procs;

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -74,11 +74,11 @@ m/^NOTICE:.*ANALYZE detected all empty sample pages for table .*, please run VAC
 m/^WARNING:  could not close temporary file .*: No such file or directory/
 
 # Messages when resource group is enabled:
-# WARNING:  resource scheduling is disabled
-# HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+# WARNING:  resource queue is disabled
+# HINT:  To enable set gp_resource_manager=queue
 # NOTICE:  resource group required -- using default resource group "default_group"
-m/^WARNING:  resource scheduling is disabled$/
-m/^HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue$/
+m/^WARNING:  resource queue is disabled$/
+m/^HINT:  To enable set gp_resource_manager=queue$/
 m/^NOTICE:  resource group required -- using .* resource group ".*"$/
 -- end_matchignore
 

--- a/src/test/regress/output/resource_queue_function_resgroup.source
+++ b/src/test/regress/output/resource_queue_function_resgroup.source
@@ -6,18 +6,18 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 INSERT INTO test_table values(1, 2);
 -- MPP-17240
 CREATE RESOURCE QUEUE test_q WITH (ACTIVE_STATEMENTS = 1, MEMORY_LIMIT='10MB');
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 CREATE ROLE test_role WITH RESOURCE QUEUE test_q;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 NOTICE:  resource group required -- using default resource group "default_group"
-WARNING:  resource scheduling is disabled  (seg0 172.17.0.2:25432 pid=10465)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg1 172.17.0.2:25433 pid=10466)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg2 172.17.0.2:25434 pid=10467)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg0 172.17.0.2:25432 pid=10465)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg1 172.17.0.2:25433 pid=10466)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg2 172.17.0.2:25434 pid=10467)
+HINT:  To enable set gp_resource_manager=queue
 GRANT SELECT ON test_table TO test_role;
 SET STATEMENT_MEM = '125MB';
 -- should return true
@@ -48,22 +48,22 @@ RESET STATEMENT_MEM;
 REVOKE SELECT ON test_table FROM test_role;
 DROP ROLE test_role; 
 DROP RESOURCE QUEUE test_q;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 -- MPP-15992
 CREATE RESOURCE QUEUE test_q WITH (ACTIVE_STATEMENTS = 1, MEMORY_LIMIT='8GB');
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 CREATE ROLE test_role WITH RESOURCE QUEUE test_q;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 NOTICE:  resource group required -- using default resource group "default_group"
-WARNING:  resource scheduling is disabled  (seg0 172.17.0.2:25432 pid=10465)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg1 172.17.0.2:25433 pid=10466)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
-WARNING:  resource scheduling is disabled  (seg2 172.17.0.2:25434 pid=10467)
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg0 172.17.0.2:25432 pid=10465)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg1 172.17.0.2:25433 pid=10466)
+HINT:  To enable set gp_resource_manager=queue
+WARNING:  resource queue is disabled  (seg2 172.17.0.2:25434 pid=10467)
+HINT:  To enable set gp_resource_manager=queue
 GRANT SELECT ON test_table TO test_role;
 SET ROLE test_role; 
 -- should return result 
@@ -75,8 +75,8 @@ SELECT count(*) FROM test_table;
 
 RESET ROLE;
 ALTER RESOURCE QUEUE test_q WITH (ACTIVE_STATEMENTS = 1, MEMORY_LIMIT='10GB');
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 SET ROLE test_role; 
 -- should return result 
 SELECT count(*) FROM test_table; 
@@ -94,8 +94,8 @@ select checkResourceQueueMemoryLimits('test_q');
 (1 row)
 
 ALTER RESOURCE QUEUE test_q WITH (ACTIVE_STATEMENTS = 1, MEMORY_LIMIT='7GB');
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 SET ROLE test_role; 
 -- should return result 
 SELECT count(*) FROM test_table; 
@@ -116,6 +116,6 @@ REVOKE SELECT ON test_table FROM test_role;
 DROP TABLE test_table;
 DROP ROLE test_role; 
 DROP RESOURCE QUEUE test_q;
-WARNING:  resource scheduling is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=queue
+WARNING:  resource queue is disabled
+HINT:  To enable set gp_resource_manager=queue
 DROP FUNCTION checkResourceQueueMemoryLimits(cstring);


### PR DESCRIPTION
Use 'resource queue is disabled' instead of
'resource scheduling is disabled'.