### PR TITLE
Fix assertion failure when gp_enable_gpperfmon is on

### DIFF
--- a/src/backend/commands/queue.c
+++ b/src/backend/commands/queue.c
@@ -1570,6 +1570,9 @@ GetResqueueName(Oid resqueueOid)
 	HeapTuple	tuple;
 	char	   *result;
 
+	if (resqueueOid == InvalidOid)
+		return pstrdup("Unknown");
+
 	/* SELECT rsqname FROM pg_resqueue WHERE oid = :1 */
 	rel = heap_open(ResQueueRelationId, AccessShareLock);
 
@@ -1602,7 +1605,10 @@ GetResqueueName(Oid resqueueOid)
  */
 char *GetResqueuePriority(Oid queueId)
 {
-	return GetResqueueCapability(queueId, PG_RESRCTYPE_PRIORITY);
+	if (queueId == InvalidOid)
+		return pstrdup("Unknown");
+	else
+		return GetResqueueCapability(queueId, PG_RESRCTYPE_PRIORITY);
 }
 
 /**

--- a/src/backend/utils/resscheduler/resscheduler.c
+++ b/src/backend/utils/resscheduler/resscheduler.c
@@ -65,7 +65,7 @@ bool	ResourceCleanupIdleGangs;				/* Cleanup idle gangs? */
  * Global variables
  */
 ResSchedulerData	*ResScheduler;	/* Resource Scheduler (shared) data .*/
-Oid				MyQueueId;			/* resource queue for current role. */
+Oid				MyQueueId = InvalidOid;	/* resource queue for current role. */
 static uint32	portalId = 0;		/* id of portal, for tracking cursors. */
 static int32	numHoldPortals = 0;	/* # of holdable cursors tracked. */
 


### PR DESCRIPTION
While resource queue is disabled, the resource queue related
fields in gpmon packet should be set to 'unknown'.