### PR TITLE
When dispatching, send ActiveSnapshot along, not some random snapshot.

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -3036,44 +3036,38 @@ def missingEntryQuery(max_content, catname, pkey, castedPkey):
     # =================
     #  Missing / Extra
     # =================
-    #   Cross product
-    #       (all unique {primary_key} present on any segment)
-    #       (all unique segment_ids in the system)
-    #   Left join
-    #       (actual ({primary_key}, segment_id) present in the catalog)
     #
-    #   Count number not null vs number null in the join:
-    #     If the nulls are <= 1/2 the result report those segments as "missing"
-    #     If the non-nulls are <= 1/2 the result report those segments as "extra"
+    # (Fetch all the entries from segments. For each entry, collect the
+    #  segment IDs of all the segments where the entry is present, in an array)
+    #
+    # Full outer join
+    #
+    # (Fetch all entries in master)
+    #
+    #
+    # The WHERE clause at the bottom filters out all the boring rows, leaving
+    # only rows that are missing from one of the segments, or from the master.
 
     catalog_exclude = MISSING_ENTRY_EXCLUDE.get(catname, "")
-    qry = """
-          SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 
-          -- distribute catalog table from master, so that we can avoid to gather
-          CREATE TEMPORARY TABLE _tmp_master ON COMMIT DROP AS
-              SELECT gp_segment_id segid, {primary_key} FROM {catalog} {catalog_exclude};
-          SELECT {oidcasted_pk}, exists, array_agg(segid order by segid) as segids
+    qry = """
+          SELECT {primary_key},
+                 case when master is null then segids
+                      when segids is null then array[master.segid]
+                      else master.segid || segids end as segids
           FROM
           (
-            SELECT ideal.*,
-                   case when actual.segid is null then 'missing' else 'extra' end as exists,
-                   count(*) over (partition by {primary_key}, actual.segid is null) as subcount
-            FROM (
-                 SELECT segid, {primary_key}
-                 FROM(  SELECT distinct {primary_key} FROM _tmp_master
-                        UNION
-                        SELECT distinct {primary_key} FROM gp_dist_random('{catalog}') ) all_pks,
-                      ( SELECT distinct content as segid from gp_segment_configuration) all_segs
-               ) ideal
-               LEFT OUTER JOIN
-               ( SELECT segid, {primary_key} FROM _tmp_master
-                 UNION ALL
-                 SELECT gp_segment_id as segid, {primary_key} FROM gp_dist_random('{catalog}') {catalog_exclude}
-               ) actual USING (segid, {primary_key})
-          ) missing_extra
-          WHERE subcount <= ({max_content}+2)/2.0
-          GROUP BY {oidcasted_pk}, exists;
+            SELECT {primary_key}, array_agg(gp_segment_id order by gp_segment_id) as segids
+            FROM gp_dist_random('{catalog}') {catalog_exclude} GROUP BY {primary_key}
+          ) as seg
+          FULL OUTER JOIN
+          (
+            SELECT gp_segment_id as segid, {primary_key} FROM {catalog} {catalog_exclude}
+          ) as master
+          USING ({primary_key})
+          WHERE master.segid is null
+             OR segids is null
+             OR NOT segids @> (select array_agg(content::int4) from gp_segment_configuration WHERE content >= 0)
           """.format(oidcasted_pk=','.join(castedPkey),
                      primary_key=','.join(pkey),
                      catalog=catname,
@@ -4003,10 +3997,10 @@ def getResourceTypeOid(oid):
 def processMissingDuplicateEntryResult(catname, colname, allValues, type):
     # type = {"missing" | "duplicate"}
     '''
-    colname:       proname | pronamespace | proargtypes | exists  | segids
-    allValues:         add | 2200         | 23 23       | extra   | {2,3}
-                     scube | 2200         | 1700        | missing | {2}
-               scube_accum | 2200         | 1700 1700   | missing | {2}
+    colname:       proname | pronamespace | proargtypes | segids
+    allValues:         add | 2200         | 23 23       | {2,3}
+                     scube | 2200         | 1700        | {-1,0,1,3}
+               scube_accum | 2200         | 1700 1700   | {-1,0,1,3}
 
     colname:        oid | total | segids
     allValues:    18853 | 2     | {-1,1}
@@ -4048,8 +4042,28 @@ def processMissingDuplicateEntryResult(catname, colname, allValues, type):
         gpObj = getGPObject(oid, rowObjName)
 
         if type == "missing":
-            issue = CatMissingIssue(catname, pkeys, segids, row[-2])
-            gpObj.addMissingIssue(issue)
+
+            # In how many segments (counting master as segment -1) was the
+            # entry present?
+            #
+            # If it was present in half or more, then report the ones that
+            # it was *not* present as 'missing'. If it was presenet in half
+            # or less, then report the ones that it was present as 'extra'
+            # Note that if it was present in exactly half of the segments,
+            # we will report it as both missing and extra.
+
+            ids = [int(i) for i in segids[1:-1].split(',')]
+
+            if len(ids) <= (GV.max_content + 2) / 2:
+                issue = CatMissingIssue(catname, pkeys, ids, 'extra')
+                gpObj.addMissingIssue(issue)
+
+            if len(ids) >= (GV.max_content + 2) / 2:
+                allids = [int(i) for i in range(-1, GV.max_content+1)]
+                diffids = set(allids) - set(ids)
+                issue = CatMissingIssue(catname, pkeys, diffids, 'missing')
+                gpObj.addMissingIssue(issue)
+
         else:
             assert (type == "duplicate")
             issue = CatDuplicateIssue(catname, pkeys, segids, row[-2])
@@ -4286,12 +4300,11 @@ class CatMissingIssue:
 
     def report(self):
 
-        ids = [int(i) for i in self.segids[1:-1].split(',')]
         idstr = ''
-        if len(ids) == len(GV.report_cfg):
+        if len(self.segids) == len(GV.report_cfg):
             idstr = 'all segments'
         else:
-            for i in ids:
+            for i in self.segids:
                 idstr += '%s (%s:%d) ' % \
                          (GV.report_cfg[i]['segname'], GV.report_cfg[i]['hostname'],
                           GV.report_cfg[i]['port'])

--- a/src/backend/cdb/cdbdtxcontextinfo.c
+++ b/src/backend/cdb/cdbdtxcontextinfo.c
@@ -302,8 +302,7 @@ DtxContextInfo_Copy(
 	target->cursorContext = source->cursorContext;
 
 	if (source->haveDistributedSnapshot)
-		DistributedSnapshot_Copy(
-								 &target->distributedSnapshot,
+		DistributedSnapshot_Copy(&target->distributedSnapshot,
 								 &source->distributedSnapshot);
 
 	target->distributedTxnOptions = source->distributedTxnOptions;

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -2386,8 +2386,7 @@ DistributedSnapshotMappedEntry_Compare(const void *p1, const void *p2)
 }
 
 bool
-createDtxSnapshot(
-				  DistributedSnapshotWithLocalMapping *distribSnapshotWithLocalMapping)
+CreateDistributedSnapshot(DistributedSnapshotWithLocalMapping *distribSnapshotWithLocalMapping)
 {
 	int			globalCount;
 	int			i;
@@ -2403,7 +2402,7 @@ createDtxSnapshot(
 
 	if (currentGxact == NULL)
 	{
-		elog(DTM_DEBUG5, "createDtxSnapshot found currentGxact is NULL");
+		elog(DTM_DEBUG5, "CreateDistributedSnapshot found currentGxact is NULL");
 		return false;
 	}
 
@@ -2519,7 +2518,7 @@ createDtxSnapshot(
 		count++;
 
 		elog(DTM_DEBUG5,
-			 "createDtxSnapshot added inProgressDistributedXid = %u to snapshot",
+			 "CreateDistributedSnapshot added inProgressDistributedXid = %u to snapshot",
 			 ds->inProgressXidArray[count]);
 	}
 
@@ -2559,7 +2558,7 @@ createDtxSnapshot(
 		currentGxact->xminDistributedSnapshot = xmin;
 
 	elog(DTM_DEBUG5,
-		 "createDtxSnapshot distributed snapshot has xmin = %u, count = %u, xmax = %u.",
+		 "CreateDistributedSnapshot distributed snapshot has xmin = %u, count = %u, xmax = %u.",
 		 xmin, count, xmax);
 	elog((Debug_print_snapshot_dtm ? LOG : DEBUG5),
 		 "[Distributed Snapshot #%u] *Create* (gxid = %u, '%s')",

--- a/src/backend/cdb/test/cdbtm_test.c
+++ b/src/backend/cdb/test/cdbtm_test.c
@@ -32,7 +32,7 @@ void setup(TmControlBlock *controlBlock, TMGXACT *gxact_array)
 }
 
 void
-test__createDtxSnapshot(void **state)
+test__CreateDistributedSnapshot(void **state)
 {
 	TMGXACT gxact_array[5];
 	TmControlBlock controlBlock;
@@ -66,7 +66,7 @@ test__createDtxSnapshot(void **state)
 	 * Basic case, no other in progress transaction in system
 	 */
 	memset(ds->inProgressXidArray, 0, SIZE_OF_IN_PROGRESS_ARRAY);
-	createDtxSnapshot(&distribSnapshotWithLocalMapping);
+	CreateDistributedSnapshot(&distribSnapshotWithLocalMapping);
 
 	/* perform all the validations */
 	assert_true(ds->xminAllDistributedSnapshots == 20);
@@ -92,7 +92,7 @@ test__createDtxSnapshot(void **state)
 	(*shmNumGxacts)++;
 
 	memset(ds->inProgressXidArray, 0, SIZE_OF_IN_PROGRESS_ARRAY);
-	createDtxSnapshot(&distribSnapshotWithLocalMapping);
+	CreateDistributedSnapshot(&distribSnapshotWithLocalMapping);
 
 	/* perform all the validations */
 	assert_true(ds->xminAllDistributedSnapshots == 5);
@@ -116,7 +116,7 @@ test__createDtxSnapshot(void **state)
 	(*shmNumGxacts)++;
 
 	memset(ds->inProgressXidArray, 0, SIZE_OF_IN_PROGRESS_ARRAY);
-	createDtxSnapshot(&distribSnapshotWithLocalMapping);
+	CreateDistributedSnapshot(&distribSnapshotWithLocalMapping);
 
 	/* perform all the validations */
 	assert_true(ds->xminAllDistributedSnapshots == 5);
@@ -141,7 +141,7 @@ main(int argc, char* argv[])
 
 	const UnitTest tests[] =
 	{
-		unit_test(test__createDtxSnapshot)
+		unit_test(test__CreateDistributedSnapshot)
 	};
 
 	MemoryContextInit();

--- a/src/backend/commands/lockcmds.c
+++ b/src/backend/commands/lockcmds.c
@@ -80,7 +80,6 @@ LockTableCommand(LockStmt *lockstmt)
 	{
 		CdbDispatchUtilityStatement((Node *) lockstmt,
 									DF_CANCEL_ON_ERROR|
-									DF_WITH_SNAPSHOT|
 									DF_NEED_TWO_PHASE,
 									NIL,
 									NULL);

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -5170,10 +5170,6 @@ PostgresMain(int argc, char *argv[],
 					if (ouid > 0 && ouid != GetSessionUserId())
 						SetCurrentRoleId(ouid, ouid_is_super); /* Set the outer UserId */
 
-					// UNDONE: Make this more official...
-					if (TempDtxContextInfo.distributedSnapshot.maxCount == 0)
-						TempDtxContextInfo.distributedSnapshot.maxCount = max_prepared_xacts;
-
 					setupQEDtxContext(&TempDtxContextInfo);
 
 					if (cuid > 0)

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -1737,7 +1737,7 @@ ProcessUtility(Node *parsetree,
 
 			if (Gp_role == GP_ROLE_DISPATCH)
 			{
-				CdbDispatchCommand("CHECKPOINT", DF_WITH_SNAPSHOT, NULL);
+				CdbDispatchCommand("CHECKPOINT", 0, NULL);
 			}
 			RequestCheckpoint(CHECKPOINT_IMMEDIATE | CHECKPOINT_FORCE | CHECKPOINT_WAIT);
 			break;

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -5896,7 +5896,7 @@ ExecSetVariableStmt(VariableSetStmt *stmt)
 			else
 				appendStringInfo(&buffer, "RESET %s", stmt->name);
 
-			CdbDispatchCommand(buffer.data, DF_WITH_SNAPSHOT, NULL);
+			CdbDispatchCommand(buffer.data, 0, NULL);
 		}
 	}
 }
@@ -6016,7 +6016,7 @@ DispatchSetPGVariable(const char *name, List *args, bool is_local)
 		}
 	}
 
-	CdbDispatchSetCommand( buffer.data, false, /*no txn*/ false );
+	CdbDispatchSetCommand(buffer.data, false);
 }
 
 /*
@@ -6069,9 +6069,7 @@ set_config_by_name(PG_FUNCTION_ARGS)
 			if (is_local)
 					appendStringInfo(&buffer, "LOCAL ");
 			appendStringInfo(&buffer, "%s TO '%s'", name, value);
-			CdbDispatchSetCommand(buffer.data,
-								   false /* cancelOnError */,
-								   false /* no two phase commit */);
+			CdbDispatchSetCommand(buffer.data, false /* cancelOnError */);
     }
 
 	/* get the new current value */

--- a/src/backend/utils/time/snapmgr.c
+++ b/src/backend/utils/time/snapmgr.c
@@ -181,9 +181,8 @@ CopySnapshot(Snapshot snapshot)
 			   snapshot->distribSnapshotWithLocalMapping.ds.count *
 			   sizeof(DistributedTransactionId));
 
-		/* Update the maxCount as memory was only allocated equal to count */
-		newsnap->distribSnapshotWithLocalMapping.ds.maxCount =
-			snapshot->distribSnapshotWithLocalMapping.ds.count;
+		/* Store -1 as the maxCount, to indicate that the array was not malloc'd */
+		newsnap->distribSnapshotWithLocalMapping.ds.maxCount = -1;
 
 		/*
 		 * Increment offset to point to next chunk of memory allocated for

--- a/src/include/cdb/cdbdisp_query.h
+++ b/src/include/cdb/cdbdisp_query.h
@@ -66,7 +66,7 @@ CdbDispatchPlan(struct QueryDesc *queryDesc,
  * gangs, both reader and writer
  */
 void
-CdbDispatchSetCommand(const char *strCommand, bool cancelOnError, bool needTwoPhase);
+CdbDispatchSetCommand(const char *strCommand, bool cancelOnError);
 
 /*
  * CdbDispatchCommand

--- a/src/include/cdb/cdbdistributedsnapshot.h
+++ b/src/include/cdb/cdbdistributedsnapshot.h
@@ -21,37 +21,27 @@
 
 typedef struct DistributedSnapshot
 {
-	DistributedTransactionTimeStamp		distribTransactionTimeStamp;
-										/*
-										 * The unique timestamp for this
-										 * start of the DTM.  It applies to
-										 * all of the distributed transactions
-										 * in this snapshot.
-										 */
+	/*
+	 * The unique timestamp for this start of the DTM.  It applies to all of
+	 * the distributed transactions in this snapshot.
+	 */
+	DistributedTransactionTimeStamp	distribTransactionTimeStamp;
 
-	DistributedTransactionId		xminAllDistributedSnapshots;
-										/*
-										 * The lowest distributed transaction
-										 * being used for distributed snapshots.
-										 */
-	
-	DistributedSnapshotId			distribSnapshotId;
-										/* 
-										 * Unique number identifying this
-										 * particular distributed snapshot.
-										 */
-										   
-	DistributedTransactionId 	xmin;	/* XID < xmin are visible to me */
-	DistributedTransactionId 	xmax;	/* XID >= xmax are invisible to me */
-	int32						count;	/* 
-										 * Count of distributed transactions
-										 * in inProgress*Array. 
-										 */
-	int32						maxCount;
-										/*
-										 * Max entry count for 
-										 * inProgress*Array.
-										 */
+	/*
+	 * The lowest distributed transaction being used for distributed snapshots.
+	 */
+	DistributedTransactionId xminAllDistributedSnapshots;
+
+	/*
+	 * Unique number identifying this particular distributed snapshot.
+	 */
+	DistributedSnapshotId distribSnapshotId;
+
+	DistributedTransactionId xmin;	/* XID < xmin are visible to me */
+	DistributedTransactionId xmax;	/* XID >= xmax are invisible to me */
+	int32		count;		/*  # of distributed xids in inProgressXidArray */
+	int32		maxCount;	/* allocated size of inProgressXidArray, or -1
+							 * if it's not malloc'd */
 
 	/* Array of distributed transactions in progress. */
 	DistributedTransactionId        *inProgressXidArray;

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -282,7 +282,7 @@ extern DistributedTransactionId getDistributedTransactionId(void);
 extern bool getDistributedTransactionIdentifier(char *id);
 
 extern void createDtx(DistributedTransactionId	*distribXid);
-extern bool createDtxSnapshot(DistributedSnapshotWithLocalMapping *distribSnapshotWithLocalMapping);
+extern bool CreateDistributedSnapshot(DistributedSnapshotWithLocalMapping *distribSnapshotWithLocalMapping);
 extern void	prepareDtxTransaction(void);
 extern bool isPreparedDtxTransaction(void);
 extern void getDtxLogInfo(TMGXACT_LOG *gxact_log);


### PR DESCRIPTION
If the caller specifies DF_WITH_SNAPSHOT, so that the command is dispatched
to the segments with a snapshot, but it currently has no active snapshot in
the QD itself, that seems like a mistake.

In qdSerializeDtxContextInfo(), the comment talked about which snapshot to
use when the transaction has already been aborted. I didn't quite
understand that. I don't think the function is used to dispatch the "ABORT"
statement itself, and we shouldn't be dispatching anything else in an
already-aborted transaction.

This makes it more clear which snapshot is dispatched along with the command.
In theory, the latest or serializable snapshot can be different from the one
being used when the command is dispatched, although I'm not sure if there
are any such cases in practice.

In the upcoming 8.4 merge, there are more changes coming up to snapshot
management, which make it more difficult to get hold of the latest acquired
snapshot in the transaction, so changing this now will ease the pain of
merging that.

I'm not sure why, but after making the change in qdSerializeDtxContextInfo(),
I started to get a lot of "Too many distributed transactions for snapshot
(maxCount %d, count %d)" errors. Looking at the code, I don't understand
how it ever worked. I don't see any no guarantee that the array in
TempQDDtxContextInfo or TempDtxContextInfo was pre-allocated correctly.
Or maybe it got allocated big enough to hold max_prepared_xacts, which
was always large enough, but it seemed rather haphazard to me. So in
the spirit of "if you don't understand it, rewrite it until you do", I
changed the way the allocation of the inProgressXidArray array works.
In statically allocated snapshots, i.e. SerializableSnapshot and
LatestSnapshot, the array is malloc'd. In a snapshot copied with
CopySnapshot(), it is points to a part of the palloc'd space for the
snapshot. Nothing new so far, but I changed CopySnapshot() to set "maxCount"
to -1 to indicate that it's not malloc'd. Then I modified
DistributedSnapshot_Copy and DistributedSnapshot_Deserialize to not give up
if the target array is not large enough, but enlarge it as needed. Finally,
I made a little optimization in GetSnapshotData() when running in a QE, to
move the copying of the distributed snapshot data to outside the section
guarded by ProcArrayLock. ProcArrayLock can be heavily contended, so that's
a nice little optimization anyway, but especially now that
DistributedSnapshot_Copy() might need to realloc the array.