### PR TITLE
readme.md: add configure flag for gssapi for ICW

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Follow the directions in the [ORCA README](https://github.com/greenplum-db/gporc
 
 ```
 # Configure build environment to install at /usr/local/gpdb
-./configure --with-perl --with-python --with-libxml --prefix=/usr/local/gpdb
+./configure --with-perl --with-python --with-libxml --with-gssapi --prefix=/usr/local/gpdb
 
 # Compile and install
 make -j8


### PR DESCRIPTION
The installcheck-world target requires gssapi, so add it to configuration mentioned in the README.