### PR TITLE
Remove flaky runaway query termination test job

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -73,7 +73,6 @@ groups:
 ################################
   - gate_general_misc_start
   - MM_gpcheckcat
-  - QP_runaway-query
   - QP_memory-accounting
   - QP_optimizer-functional
   - regression_tests_pxf_hdp
@@ -206,7 +205,6 @@ groups:
   jobs:
   - gate_general_misc_start
   - MM_gpcheckcat
-  - QP_runaway-query
   - QP_memory-accounting
   - QP_optimizer-functional
   - regression_tests_pxf_hdp
@@ -2466,24 +2464,6 @@ jobs:
     on_failure:
       <<: *debug_sleep
   - *ccp_destroy
-- name: QP_runaway-query
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      passed: [gate_general_misc_start]
-      trigger: true
-    - get: bin_gpdb
-      passed: [gate_general_misc_start]
-      resource: bin_gpdb_centos6
-    - get: centos-gpdb-dev-6
-  - task: runaway-query
-    timeout: 3h
-    file: gpdb_src/concourse/tasks/tinc_gpdb.yml
-    image: centos-gpdb-dev-6
-    params:
-      MAKE_TEST_COMMAND: runaway_query
-      TEST_OS: "centos"
-      CONFIGURE_FLAGS: {{configure_flags}}
 - name: QP_memory-accounting
   plan:
   - aggregate:
@@ -2698,7 +2678,6 @@ jobs:
     - regression_tests_gphdfs_centos
     - regression_tests_pxf_hdp
     - regression_tests_pxf_cdh
-    - QP_runaway-query
     - QP_optimizer-functional
     - MM_gpcheckcat
     trigger: true
@@ -2709,7 +2688,6 @@ jobs:
     - regression_tests_gphdfs_centos
     - regression_tests_pxf_hdp
     - regression_tests_pxf_cdh
-    - QP_runaway-query
     - QP_optimizer-functional
     - MM_gpcheckcat
     trigger: true
@@ -2962,7 +2940,6 @@ jobs:
     - cs-filerep-schema-topology-crashrecov
     - cs-aoco-compression
     - mpp_interconnect
-    - QP_runaway-query
     - QP_optimizer-functional
     - validate_pipeline
 


### PR DESCRIPTION
The runaway-query test is inconsistent and proper investigation into its
flakiness needs to be done. For the time being, since this feature is
stable and unchanging, we will remove this test job.