### PR TITLE
readme: add info about configure flag for gssapi for ICW

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,12 @@ Follow [these linux steps](README.linux.md) for getting your system ready for GP
 ### Build the optimizer
 #### Automatically with Conan dependency manager
 
-    cd depends
-    conan remote add conan-gpdb https://api.bintray.com/conan/greenplum-db/gpdb-oss
-    conan install --build
-    cd ..
+```bash
+cd depends
+conan remote add conan-gpdb https://api.bintray.com/conan/greenplum-db/gpdb-oss
+conan install --build
+cd ..
+```
 
 #### Manually
 Follow the directions in the [ORCA README](https://github.com/greenplum-db/gporca).
@@ -57,7 +59,7 @@ Follow the directions in the [ORCA README](https://github.com/greenplum-db/gporc
 
 ```
 # Configure build environment to install at /usr/local/gpdb
-./configure --with-perl --with-python --with-libxml --prefix=/usr/local/gpdb
+./configure --with-perl --with-python --with-libxml --with-gssapi --prefix=/usr/local/gpdb
 
 # Compile and install
 make -j8


### PR DESCRIPTION
The installcheck-world target requires gssapi, so add it to default configuration
Also, add a sample line to build orca with conan using a different C/C++
compiler chain.