### PR TITLE
Fix mpp6979 TINC test to enforce consistent ordering

### DIFF
--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/partition/expected/mpp6979.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/partition/expected/mpp6979.ans
@@ -65,12 +65,12 @@ select * from pg_partitions where schemaname like 'mpp6979%';
  mpp6979_parent | ad_impsn_fact_xnewx | mpp6979_parent      | ad_impsn_fact_xnewx_1_prt_p1 | p1            |                          |                     | range         |              0 |             1 |                 1 |                     | '2007-10-01 00:00:00'::timestamp without time zone | t                       | '2007-11-01 00:00:00'::timestamp without time zone | f                     |                      | f                  | PARTITION p1 START ('2007-10-01 00:00:00'::timestamp without time zone) END ('2007-11-01 00:00:00'::timestamp without time zone) | pg_default       | pg_default
 (1 row)
 
-select schemaname, tablename from pg_tables where schemaname like 'mpp6979%' order by 1;
+select schemaname, tablename from pg_tables where schemaname like 'mpp6979%' order by 1, 2;
    schemaname   |               tablename                
 ----------------+----------------------------------------
  mpp6979_child  | ad_impsn_fact2_c_d_1_m_1_1610396_month
+ mpp6979_parent | ad_impsn_fact
  mpp6979_parent | ad_impsn_fact_xnewx
  mpp6979_parent | ad_impsn_fact_xnewx_1_prt_p1
- mpp6979_parent | ad_impsn_fact
 (4 rows)
 

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/partition/sql/mpp6979.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/partition/sql/mpp6979.sql
@@ -45,4 +45,4 @@ ALTER TABLE mpp6979_parent.ad_impsn_fact_XnewX EXCHANGE PARTITION p1 WITH TABLE 
 ALTER TABLE mpp6979_child.ad_impsn_fact2_c_d_1_m_1_1610396_month  INHERIT mpp6979_parent.ad_impsn_fact ;
 
 select * from pg_partitions where schemaname like 'mpp6979%';
-select schemaname, tablename from pg_tables where schemaname like 'mpp6979%' order by 1;
+select schemaname, tablename from pg_tables where schemaname like 'mpp6979%' order by 1, 2;


### PR DESCRIPTION
This issue caused the storage test to fail one time. This should resolve the issue.