### PR TITLE
Refactor gpmon counters

### DIFF
--- a/gpAux/gpperfmon/src/gpmon/gpmon_agg.c
+++ b/gpAux/gpperfmon/src/gpmon/gpmon_agg.c
@@ -47,7 +47,7 @@ typedef struct mmon_query_seginfo_t
 	gpmon_query_seginfo_key_t	key;
 	apr_int64_t					final_rowsout;
 	apr_uint64_t				sum_cpu_elapsed;
-	apr_uint64_t				sum_measures_rows_in;
+	apr_uint64_t				sum_measures_rows_out;
 } mmon_query_seginfo_t;  //The agg value at segment level for query
 
 typedef struct qdnode_t {
@@ -253,7 +253,7 @@ static apr_status_t agg_put_queryseg(agg_t* agg, const gpmon_query_seginfo_t* me
 	if (rec) {
 		rec->final_rowsout = met->final_rowsout;
 		rec->sum_cpu_elapsed += met->sum_cpu_elapsed;
-		rec->sum_measures_rows_in += met->sum_measures_rows_in;
+		rec->sum_measures_rows_out += met->sum_measures_rows_out;
 	}
 	else {
 		/* not found, make new hash entry */
@@ -265,7 +265,7 @@ static apr_status_t agg_put_queryseg(agg_t* agg, const gpmon_query_seginfo_t* me
 		memcpy(&rec->key, &met->key, sizeof(gpmon_query_seginfo_key_t));
 		rec->final_rowsout = met->final_rowsout;
 		rec->sum_cpu_elapsed = met->sum_cpu_elapsed;
-		rec->sum_measures_rows_in = met->sum_measures_rows_in;
+		rec->sum_measures_rows_out = met->sum_measures_rows_out;
 
 		apr_hash_set(dp->query_seginfo_hash, &rec->key.segid, sizeof(rec->key.segid), rec);
 	}
@@ -1265,7 +1265,7 @@ static double get_row_skew(qdnode_t* qdnode)
 			seg_row_out_sum = apr_palloc(tmp_pool, sizeof(apr_int64_t));
 			*seg_row_out_sum = 0;
 		}
-		*seg_row_out_sum += rec->sum_measures_rows_in;
+		*seg_row_out_sum += rec->sum_measures_rows_out;
 		apr_hash_set(segtab, &rec->key.segid, sizeof(rec->key.segid), seg_row_out_sum);
 	}
 

--- a/gpAux/gpperfmon/src/gpmon/gpsmon.c
+++ b/gpAux/gpperfmon/src/gpmon/gpsmon.c
@@ -1015,7 +1015,7 @@ static apr_uint32_t create_qexec_packet(const gpmon_qexec_t* qexec, gp_smon_to_m
 {
 	// Copy over needed values
 	memcpy(&pkt->u.qexec_packet.data.key, &qexec->key, sizeof(gpmon_qexeckey_t));
-	pkt->u.qexec_packet.data.measures_rows_in = qexec->rowsin;
+	pkt->u.qexec_packet.data.measures_rows_in = qexec->rowsout;
 	pkt->u.qexec_packet.data._cpu_elapsed = qexec->_cpu_elapsed;
 	pkt->u.qexec_packet.data.rowsout = qexec->rowsout;
 
@@ -1046,7 +1046,7 @@ static void extract_segments_exec(gpmon_packet_t* pkt)
 	if (rec)
 	{
 		rec->u.queryseg.sum_cpu_elapsed += pidrec->cpu_elapsed;
-		rec->u.queryseg.sum_measures_rows_in += p->rowsin;
+		rec->u.queryseg.sum_measures_rows_out += p->rowsout;
 		if (p->key.hash_key.segid == -1 && p->key.hash_key.nid == 1)
 		{
 			rec->u.queryseg.final_rowsout = p->rowsout;
@@ -1068,7 +1068,7 @@ static void extract_segments_exec(gpmon_packet_t* pkt)
 			rec->u.queryseg.final_rowsout = -1;
 		}
 		rec->u.queryseg.sum_cpu_elapsed = pidrec->cpu_elapsed;
-		rec->u.queryseg.sum_measures_rows_in = p->rowsin;
+		rec->u.queryseg.sum_measures_rows_out = p->rowsout;
 		apr_hash_set(gx.querysegtab, &rec->u.queryseg.key, sizeof(rec->u.queryseg.key), rec);
 	}
 }

--- a/src/backend/executor/execAmi.c
+++ b/src/backend/executor/execAmi.c
@@ -288,6 +288,9 @@ ExecReScan(PlanState *node, ExprContext *exprCtxt)
 		bms_free(node->chgParam);
 		node->chgParam = NULL;
 	}
+
+	/* Now would be a good time to also send an update to gpmon */
+	CheckSendPlanStateGpmonPkt(node);
 }
 
 /*
@@ -427,6 +430,9 @@ ExecRestrPos(PlanState *node)
 			elog(ERROR, "unrecognized node type: %d", (int) nodeTag(node));
 			break;
 	}
+
+	/* Now would be a good time to also send an update to gpmon */
+	CheckSendPlanStateGpmonPkt(node);
 }
 
 /*

--- a/src/backend/executor/execBitmapTableScan.c
+++ b/src/backend/executor/execBitmapTableScan.c
@@ -207,17 +207,6 @@ fetchNextBitmapPage(BitmapTableScanState *scanState)
 }
 
 /*
- * Initializes perfmon details for BitmapTableScan node.
- */
-void
-initGpmonPktForBitmapTableScan(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate)
-{
-	Assert(planNode != NULL && gpmon_pkt != NULL && IsA(planNode, BitmapTableScan));
-
-	InitPlanNodeGpmonPkt(planNode, gpmon_pkt, estate);
-}
-
-/*
  * Checks eligibility of a tuple.
  *
  * Note, a tuple may fail to meet visibility requirement. Moreover,

--- a/src/backend/executor/execHHashagg.c
+++ b/src/backend/executor/execHHashagg.c
@@ -869,8 +869,6 @@ agg_hash_initial_pass(AggState *aggstate)
 			break;
 		}
 
-		Gpmon_Incr_Rows_In(GpmonPktFromAggState(aggstate));
-
 		if (aggstate->hashslot->tts_tupleDescriptor == NULL)
 		{
 			int size;

--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -1138,8 +1138,6 @@ agg_retrieve_direct(AggState *aggstate)
 				 * comparison (in group mode) and for projection.
 				 */
 
-				Gpmon_Incr_Rows_In(GpmonPktFromAggState(aggstate));
-				CheckSendPlanStateGpmonPkt(&aggstate->ss.ps);
 				slot_getallattrs(outerslot);
 				aggstate->grp_firstTuple = memtuple_form_to(firstSlot->tts_mt_bind,
 						slot_get_values(outerslot),
@@ -1258,8 +1256,6 @@ agg_retrieve_direct(AggState *aggstate)
 						break;
 					}
 
-					Gpmon_Incr_Rows_In(GpmonPktFromAggState(aggstate));
-					CheckSendPlanStateGpmonPkt(&aggstate->ss.ps);
 					/* set up for next advance aggregates call */
 					tmpcontext->ecxt_outertuple = outerslot;
 

--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -1478,9 +1478,6 @@ agg_retrieve_direct(AggState *aggstate)
 			 * and the representative input tuple.	Note we do not support
 			 * aggregates returning sets ...
 			 */
-			Gpmon_Incr_Rows_Out(GpmonPktFromAggState(aggstate));
-			CheckSendPlanStateGpmonPkt(&aggstate->ss.ps);
-
 			return ExecProject(projInfo, NULL);
 		}
 	}
@@ -1594,8 +1591,6 @@ agg_retrieve_hash_table(AggState *aggstate)
 			 * and the representative input tuple.	Note we do not support
 			 * aggregates returning sets ...
 			 */
-			Gpmon_Incr_Rows_Out(GpmonPktFromAggState(aggstate));
-			CheckSendPlanStateGpmonPkt(&aggstate->ss.ps);
 			return ExecProject(projInfo, NULL);
 		}
 	}
@@ -2351,8 +2346,6 @@ ExecInitAgg(Agg *node, EState *estate, int eflags)
 	aggstate->mem_manager.manager = aggstate->aggcontext;
 	aggstate->mem_manager.realloc_ratio = 1;
 
-	initGpmonPktForAgg((Plan *) node, &aggstate->ss.ps.gpmon_pkt, estate);
-
 	return aggstate;
 }
 
@@ -2626,14 +2619,6 @@ get_grouping_groupid(TupleTableSlot *slot, int grping_attno)
 	grouping = DatumGetInt64(grping_datum);
 
 	return grouping;
-}
-
-void
-initGpmonPktForAgg(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate)
-{
-	Assert(planNode != NULL && gpmon_pkt != NULL && IsA(planNode, Agg));
-
-	InitPlanNodeGpmonPkt(planNode, gpmon_pkt, estate);
 }
 
 /*

--- a/src/backend/executor/nodeAppend.c
+++ b/src/backend/executor/nodeAppend.c
@@ -368,8 +368,6 @@ ExecAppend(AppendState *node)
 		else
 			node->as_whichplan--;
 
-		CheckSendPlanStateGpmonPkt(&node->ps);
-
 		if (!exec_append_initialize_next(node))
 			return ExecClearTuple(node->ps.ps_ResultTupleSlot);
 

--- a/src/backend/executor/nodeBitmapAnd.c
+++ b/src/backend/executor/nodeBitmapAnd.c
@@ -91,8 +91,6 @@ ExecInitBitmapAnd(BitmapAnd *node, EState *estate, int eflags)
 		i++;
 	}
 
-	initGpmonPktForBitmapAnd((Plan *) node, &bitmapandstate->ps.gpmon_pkt, estate);
-
 	return bitmapandstate;
 }
 
@@ -291,12 +289,4 @@ ExecReScanBitmapAnd(BitmapAndState *node, ExprContext *exprCtxt)
 		 */
 		ExecReScan(subnode, exprCtxt);
 	}
-}
-
-void
-initGpmonPktForBitmapAnd(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate)
-{
-	Assert(planNode != NULL && gpmon_pkt != NULL && IsA(planNode, BitmapAnd));
-
-    InitPlanNodeGpmonPkt(planNode, gpmon_pkt, estate);
 }

--- a/src/backend/executor/nodeBitmapIndexscan.c
+++ b/src/backend/executor/nodeBitmapIndexscan.c
@@ -153,8 +153,6 @@ ExecBitmapIndexReScan(BitmapIndexScanState *node, ExprContext *exprCtxt)
 		tbm_bitmap_free(node->bitmap);
 		node->bitmap = NULL;
 	}
-
-	CheckSendPlanStateGpmonPkt(&scanState->ss.ps);
 }
 
 /* ----------------------------------------------------------------
@@ -224,8 +222,6 @@ ExecInitBitmapIndexScan(BitmapIndexScan *node, EState *estate, int eflags)
 	 */
 	Assert(NULL == scanState->ss.ss_currentRelation);
 
-	initGpmonPktForBitmapIndexScan((Plan *)node, &scanState->ss.ps.gpmon_pkt, estate);
-
 	return indexstate;
 }
 
@@ -234,13 +230,4 @@ ExecCountSlotsBitmapIndexScan(BitmapIndexScan *node)
 {
 	return ExecCountSlotsNode(outerPlan((Plan *) node)) +
 		ExecCountSlotsNode(innerPlan((Plan *) node)) + BITMAPINDEXSCAN_NSLOTS;
-}
-
-
-void
-initGpmonPktForBitmapIndexScan(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate)
-{
-	Assert(NULL != planNode && NULL != gpmon_pkt && IsA(planNode, BitmapIndexScan));
-
-	InitPlanNodeGpmonPkt(planNode, gpmon_pkt, estate);
 }

--- a/src/backend/executor/nodeBitmapOr.c
+++ b/src/backend/executor/nodeBitmapOr.c
@@ -90,8 +90,6 @@ ExecInitBitmapOr(BitmapOr *node, EState *estate, int eflags)
 		bitmapplanstates[i] = ExecInitNode(initNode, estate, eflags);
 		i++;
 	}
-
-	initGpmonPktForBitmapOr((Plan *)node, &bitmaporstate->ps.gpmon_pkt, estate);
 	
 	return bitmaporstate;
 }
@@ -256,12 +254,4 @@ ExecReScanBitmapOr(BitmapOrState *node, ExprContext *exprCtxt)
 		 */
 		ExecReScan(subnode, exprCtxt);
 	}
-}
-
-void
-initGpmonPktForBitmapOr(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate)
-{
-	Assert(planNode != NULL && gpmon_pkt != NULL && IsA(planNode, BitmapOr));
-
-	InitPlanNodeGpmonPkt(planNode, gpmon_pkt, estate);
 }

--- a/src/backend/executor/nodeDML.c
+++ b/src/backend/executor/nodeDML.c
@@ -197,8 +197,6 @@ ExecInitDML(DML *node, EState *estate, int eflags)
 	        dmlstate->ps.cdbexplainfun = ExecDMLExplainEnd;
 	}
 
-	initGpmonPktForDML((Plan *)node, &dmlstate->ps.gpmon_pkt, estate);
-	
 	return dmlstate;
 }
 
@@ -221,15 +219,6 @@ int
 ExecCountSlotsDML(DML *node)
 {
 	return ExecCountSlotsNode(outerPlan(node)) + DML_NSLOTS;
-}
-
-/* Tracing execution for GP Monitor. */
-void
-initGpmonPktForDML(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate)
-{
-	Assert(planNode != NULL && gpmon_pkt != NULL && IsA(planNode, DML));
-
-	InitPlanNodeGpmonPkt(planNode, gpmon_pkt, estate);
 }
 
 /* EOF */

--- a/src/backend/executor/nodeFunctionscan.c
+++ b/src/backend/executor/nodeFunctionscan.c
@@ -112,17 +112,11 @@ FunctionNext(FunctionScanState *node)
 		}
 	}
 
-	if (!TupIsNull(slot))
-	{
-		Gpmon_Incr_Rows_Out(GpmonPktFromFuncScanState(node));
-		CheckSendPlanStateGpmonPkt(&node->ss.ps);
-	}
-
-	else if (!node->ss.ps.delayEagerFree)
+	if (TupIsNull(slot) && !node->ss.ps.delayEagerFree)
 	{
 		ExecEagerFreeFunctionScan((FunctionScanState *)(&node->ss.ps));
 	}
-	
+
 	return slot;
 }
 
@@ -266,8 +260,6 @@ ExecInitFunctionScan(FunctionScan *node, EState *estate, int eflags)
 	 */
 	ExecAssignResultTypeFromTL(&scanstate->ss.ps);
 	ExecAssignScanProjectionInfo(&scanstate->ss);
-
-	initGpmonPktForFunctionScan((Plan *)node, &scanstate->ss.ps.gpmon_pkt, estate);
 	
 	if (!IsResManagerMemoryPolicyNone())
 	{
@@ -357,14 +349,6 @@ ExecFunctionReScan(FunctionScanState *node, ExprContext *exprCtxt)
 	}
 	else
 		tuplestore_rescan(node->tuplestorestate);
-}
-
-void
-initGpmonPktForFunctionScan(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate)
-{
-	Assert(planNode != NULL && gpmon_pkt != NULL && IsA(planNode, FunctionScan));
-
-	InitPlanNodeGpmonPkt(planNode, gpmon_pkt, estate);
 }
 
 void

--- a/src/backend/executor/nodeHash.c
+++ b/src/backend/executor/nodeHash.c
@@ -125,8 +125,6 @@ MultiExecHash(HashState *node)
 		if (TupIsNull(slot))
 			break;
 
-		Gpmon_Incr_Rows_In(GpmonPktFromHashState(node));
-		CheckSendPlanStateGpmonPkt(&node->ps);
 		/* We have to compute the hash value */
 		econtext->ecxt_innertuple = slot;
 		bool hashkeys_null = false;

--- a/src/backend/executor/nodeHash.c
+++ b/src/backend/executor/nodeHash.c
@@ -223,8 +223,6 @@ ExecInitHash(Hash *node, EState *estate, int eflags)
 	ExecAssignResultTypeFromTL(&hashstate->ps);
 	hashstate->ps.ps_ProjInfo = NULL;
 
-	initGpmonPktForHash((Plan *) node, &hashstate->ps.gpmon_pkt, estate);
-
 	return hashstate;
 }
 
@@ -1661,10 +1659,3 @@ ExecHashTableExplainBatchEnd(HashState *hashState, HashJoinTable hashtable)
     }
     END_MEMORY_ACCOUNT();
 }                               /* ExecHashTableExplainBatchEnd */
-
-void
-initGpmonPktForHash(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate)
-{
-	Assert(planNode != NULL && gpmon_pkt != NULL && IsA(planNode, Hash));
-	InitPlanNodeGpmonPkt(planNode, gpmon_pkt, estate);
-}

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -292,8 +292,6 @@ ExecHashJoin(HashJoinState *node)
 				return NULL;
 			}
 
-			Gpmon_Incr_Rows_In(GpmonPktFromHashJoinState(node));
-			CheckSendPlanStateGpmonPkt(&node->js.ps);
 			node->js.ps.ps_OuterTupleSlot = outerTupleSlot;
 			econtext->ecxt_outertuple = outerTupleSlot;
 			node->hj_NeedNewOuter = false;

--- a/src/backend/executor/nodeLimit.c
+++ b/src/backend/executor/nodeLimit.c
@@ -232,11 +232,6 @@ ExecLimit(LimitState *node)
 	/* Return the current tuple */
 	Assert(!TupIsNull(slot));
 
-        if (!TupIsNull(slot))
-        {
-            Gpmon_Incr_Rows_Out(GpmonPktFromLimitState(node));
-            CheckSendPlanStateGpmonPkt(&node->ps); 
-        }
 	return slot;
 }
 
@@ -405,8 +400,6 @@ ExecInitLimit(Limit *node, EState *estate, int eflags)
 	 */
 	ExecAssignResultTypeFromTL(&limitstate->ps);
 	limitstate->ps.ps_ProjInfo = NULL;
-
-	initGpmonPktForLimit((Plan *)node, &limitstate->ps.gpmon_pkt, estate);
 	
 	return limitstate;
 }
@@ -452,12 +445,4 @@ ExecReScanLimit(LimitState *node, ExprContext *exprCtxt)
 	 */
 	if (((PlanState *) node)->lefttree->chgParam == NULL)
 		ExecReScan(((PlanState *) node)->lefttree, exprCtxt);
-}
-
-void
-initGpmonPktForLimit(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate)
-{
-	Assert(planNode != NULL && gpmon_pkt != NULL && IsA(planNode, Limit));
-
-	InitPlanNodeGpmonPkt(planNode, gpmon_pkt, estate);
 }

--- a/src/backend/executor/nodeMaterial.c
+++ b/src/backend/executor/nodeMaterial.c
@@ -145,7 +145,6 @@ ExecMaterial(MaterialState *node)
 
 				break;
 			}
-			Gpmon_Incr_Rows_In(GpmonPktFromMaterialState(node));
 
 			ntuplestore_acc_put_tupleslot(tsa, outerslot);
 		}
@@ -233,8 +232,6 @@ ExecMaterial(MaterialState *node)
 
 			return NULL;
 		}
-
-		Gpmon_Incr_Rows_In(GpmonPktFromMaterialState(node));
 
 		if (tsa)
 			ntuplestore_acc_put_tupleslot(tsa, outerslot);

--- a/src/backend/executor/nodeMaterial.c
+++ b/src/backend/executor/nodeMaterial.c
@@ -194,11 +194,6 @@ ExecMaterial(MaterialState *node)
 	if(tsa != NULL && ntuplestore_acc_tell(tsa, NULL))
 	{
 		ntuplestore_acc_current_tupleslot(tsa, slot);
-		if (!TupIsNull(slot))
-		{
-			Gpmon_Incr_Rows_Out(GpmonPktFromMaterialState(node));
-			CheckSendPlanStateGpmonPkt(&node->ss.ps);
-		}
 		return slot;
 	}
 
@@ -239,8 +234,6 @@ ExecMaterial(MaterialState *node)
 		/*
 		 * We can just return the subplan's returned tuple, without copying.
 		 */
-		Gpmon_Incr_Rows_Out(GpmonPktFromMaterialState(node));
-		CheckSendPlanStateGpmonPkt(&node->ss.ps);
 		return outerslot;
 	}
 
@@ -374,8 +367,6 @@ ExecInitMaterial(Material *node, EState *estate, int eflags)
 		snEntry->sharePlan = (Node *) node;
 		snEntry->shareState = (Node *) matstate;
 	}
-
-	initGpmonPktForMaterial((Plan *)node, &matstate->ss.ps.gpmon_pkt, estate);
 
 	return matstate;
 }
@@ -544,10 +535,8 @@ ExecChildRescan(MaterialState *node, ExprContext *exprCtxt)
 	 * first ExecProcNode. Otherwise, we need to rescan subplan here
 	 */
 	if (((PlanState *) node)->lefttree->chgParam == NULL)
-	{
-		CheckSendPlanStateGpmonPkt(&node->ss.ps);
 		ExecReScan(((PlanState *) node)->lefttree, exprCtxt);
-	}
+
 	node->eof_underlying = false;
 }
 
@@ -608,14 +597,6 @@ ExecMaterialReScan(MaterialState *node, ExprContext *exprCtxt)
 		/* In this case we are just passing on the subquery's output */
 		ExecChildRescan(node, exprCtxt);
 	}
-}
-
-void
-initGpmonPktForMaterial(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate)
-{
-	Assert(planNode != NULL && gpmon_pkt != NULL && IsA(planNode, Material));
-
-	InitPlanNodeGpmonPkt(planNode, gpmon_pkt, estate);
 }
 
 void

--- a/src/backend/executor/nodeMergejoin.c
+++ b/src/backend/executor/nodeMergejoin.c
@@ -658,10 +658,6 @@ ExecMergeJoin(MergeJoinState *node)
 	if (node->prefetch_inner)
 	{
 		innerTupleSlot = ExecProcNode(innerPlan);
-          	if (!TupIsNull(innerTupleSlot))
-          	{
-          		Gpmon_Incr_Rows_In(GpmonPktFromMergeJoinState(node));
-          	}
 		node->mj_InnerTupleSlot = innerTupleSlot;
 
 		ExecReScan(innerPlan, econtext);
@@ -1461,10 +1457,6 @@ ExecMergeJoin(MergeJoinState *node)
 						ExecEagerFreeMergeJoin(node);
 
 					return NULL;
-				}
-				else
-				{
-					Gpmon_Incr_Rows_In(GpmonPktFromMergeJoinState(node));
 				}
 
 				/* Else remain in ENDOUTER state and process next tuple. */

--- a/src/backend/executor/nodeMergejoin.c
+++ b/src/backend/executor/nodeMergejoin.c
@@ -673,7 +673,6 @@ ExecMergeJoin(MergeJoinState *node)
 	for (;;)
 	{
 		MJ_dump(node);
-		CheckSendPlanStateGpmonPkt(&node->js.ps);
 
 		/*
 		 * get the current state of the join and do things accordingly.
@@ -1484,11 +1483,7 @@ ExecMergeJoin(MergeJoinState *node)
 
 					result = MJFillOuter(node);
 					if (result)
-					{
-						Gpmon_Incr_Rows_Out(GpmonPktFromMergeJoinState(node));
-                               	CheckSendPlanStateGpmonPkt(&node->js.ps);
 						return result;
-					}
 				}
 
 				/*
@@ -1708,8 +1703,6 @@ ExecInitMergeJoin(MergeJoin *node, EState *estate, int eflags)
 	 */
 	MJ1_printf("ExecInitMergeJoin: %s\n",
 			   "node initialized");
-
-	initGpmonPktForMergeJoin((Plan *)node, &mergestate->js.ps.gpmon_pkt, estate);
 	
 	return mergestate;
 }
@@ -1778,13 +1771,6 @@ ExecReScanMergeJoin(MergeJoinState *node, ExprContext *exprCtxt)
 	if (((PlanState *) node)->righttree->chgParam == NULL)
 		ExecReScan(((PlanState *) node)->righttree, exprCtxt);
 
-}
-void
-initGpmonPktForMergeJoin(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate)
-{
-	Assert(planNode != NULL && gpmon_pkt != NULL && IsA(planNode, MergeJoin));
-	
-	InitPlanNodeGpmonPkt(planNode, gpmon_pkt, estate);
 }
 
 void

--- a/src/backend/executor/nodeMotion.c
+++ b/src/backend/executor/nodeMotion.c
@@ -164,23 +164,6 @@ bool isMotionGather(const Motion *m)
 			&& m->numOutputSegs == 1);
 }
 
-/*
- * Set the statistic info in gpmon packet.
- */
-static void
-setMotionStatsForGpmon(MotionState *node)
-{
-	ChunkTransportState *transportStates = node->ps.state->interconnect_context;
-	int motionId = ((Motion *) node->ps.plan)->motionID;
-
-	ChunkTransportStateEntry *transportEntry = NULL;
-	getChunkTransportState(transportStates, motionId, &transportEntry);
-	uint64 avgAckTime = 0;
-	if (transportEntry->stat_count_acks > 0)
-		avgAckTime = transportEntry->stat_total_ack_time / transportEntry->stat_count_acks;
-}
-
-
 /* ----------------------------------------------------------------
  *		ExecMotion
  * ----------------------------------------------------------------
@@ -245,7 +228,6 @@ ExecMotion(MotionState * node)
 		{
 			Gpmon_Incr_Rows_In(GpmonPktFromMotionState(node));
 			Gpmon_Incr_Rows_Out(GpmonPktFromMotionState(node));
-			setMotionStatsForGpmon(node);
 		}
 #ifdef MEASURE_MOTION_TIME
 		gettimeofday(&stopTime, NULL);
@@ -335,7 +317,6 @@ execMotionSender(MotionState * node)
 			/* doSendTuple() may have set node->stopRequested as a side-effect */
 
 			Gpmon_Incr_Rows_Out(GpmonPktFromMotionState(node));
-			setMotionStatsForGpmon(node);
 			CheckSendPlanStateGpmonPkt(&node->ps);
 
 			if (node->stopRequested)

--- a/src/backend/executor/nodeMotion.c
+++ b/src/backend/executor/nodeMotion.c
@@ -226,7 +226,6 @@ ExecMotion(MotionState * node)
 			node->ps.state->active_recv_id = -1;
 		else
 		{
-			Gpmon_Incr_Rows_In(GpmonPktFromMotionState(node));
 			Gpmon_Incr_Rows_Out(GpmonPktFromMotionState(node));
 		}
 #ifdef MEASURE_MOTION_TIME
@@ -247,7 +246,6 @@ ExecMotion(MotionState * node)
 			node->motionTime.tv_sec++;
 		}
 #endif
-		CheckSendPlanStateGpmonPkt(&node->ps);
 		return tuple;
 	}
 	else if(node->mstype == MOTIONSTATE_SEND)

--- a/src/backend/executor/nodeNestloop.c
+++ b/src/backend/executor/nodeNestloop.c
@@ -226,7 +226,6 @@ ExecNestLoop(NestLoopState *node)
 		ENL1_printf("getting new inner tuple");
 
 		innerTupleSlot = ExecProcNode(innerPlan);
-		CheckSendPlanStateGpmonPkt(&node->js.ps);
 
 		node->reset_inner = true;
 		econtext->ecxt_innertuple = innerTupleSlot;
@@ -267,8 +266,6 @@ ExecNestLoop(NestLoopState *node)
 					 */
 					ENL1_printf("qualification succeeded, projecting tuple");
 
-					Gpmon_Incr_Rows_Out(GpmonPktFromNLJState(node));
-                          	CheckSendPlanStateGpmonPkt(&node->js.ps);
 					return ExecProject(node->js.ps.ps_ProjInfo, NULL);
 				}
 			}
@@ -334,9 +331,6 @@ ExecNestLoop(NestLoopState *node)
 					 */
 					ENL1_printf("qualification succeeded, projecting tuple");
 
-					Gpmon_Incr_Rows_Out(GpmonPktFromNLJState(node));
-
-					CheckSendPlanStateGpmonPkt(&node->js.ps);
 					return ExecProject(node->js.ps.ps_ProjInfo, NULL);
 				}
 			}
@@ -502,8 +496,6 @@ ExecInitNestLoop(NestLoop *node, EState *estate, int eflags)
 
 	NL1_printf("ExecInitNestLoop: %s\n",
 			   "node initialized");
-
-	initGpmonPktForNestLoop((Plan *)node, &nlstate->js.ps.gpmon_pkt, estate);
 	
 	return nlstate;
 }
@@ -575,14 +567,6 @@ ExecReScanNestLoop(NestLoopState *node, ExprContext *exprCtxt)
 	node->nl_MatchedOuter = false;
 	node->nl_innerSideScanned = false;
 	/* CDB: We intentionally leave node->nl_innerSquelchNeeded unchanged on ReScan */
-}
-
-void
-initGpmonPktForNestLoop(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate)
-{
-	Assert(planNode != NULL && gpmon_pkt != NULL && IsA(planNode, NestLoop));
-
-    InitPlanNodeGpmonPkt(planNode, gpmon_pkt, estate);
 }
 
 /* ----------------------------------------------------------------

--- a/src/backend/executor/nodeNestloop.c
+++ b/src/backend/executor/nodeNestloop.c
@@ -110,8 +110,6 @@ ExecNestLoop(NestLoopState *node)
 	if (node->prefetch_inner)
 	{
 		innerTupleSlot = ExecProcNode(innerPlan);
-		Gpmon_Incr_Rows_In(GpmonPktFromNLJState(node));
-
 		node->reset_inner = true;
 		econtext->ecxt_innertuple = innerTupleSlot;
 
@@ -166,7 +164,6 @@ ExecNestLoop(NestLoopState *node)
 		{
 			ENL1_printf("getting new outer tuple");
 			outerTupleSlot = ExecProcNode(outerPlan);
-			Gpmon_Incr_Rows_In(GpmonPktFromNLJState(node));
 
 			/*
 			 * if there are no more outer tuples, then the join is complete..

--- a/src/backend/executor/nodeRepeat.c
+++ b/src/backend/executor/nodeRepeat.c
@@ -70,8 +70,6 @@ ExecRepeat(RepeatState *repeatstate)
 				/* Check the qual until we find one output tuple. */
 				if (ExecQual(repeatstate->ps.qual, econtext, false))
 				{
-					Gpmon_Incr_Rows_Out(GpmonPktFromRepeatState(repeatstate));
-					CheckSendPlanStateGpmonPkt(&repeatstate->ps);
 					return ExecProject(repeatstate->ps.ps_ProjInfo, NULL);
 				}
 			} while (repeatstate->repeat_count > 0);
@@ -121,8 +119,6 @@ ExecRepeat(RepeatState *repeatstate)
 			/* Check the qual until we find one output tuple. */
 			if (ExecQual(repeatstate->ps.qual, econtext, false))
 			{
-				Gpmon_Incr_Rows_Out(GpmonPktFromRepeatState(repeatstate));
-				CheckSendPlanStateGpmonPkt(&repeatstate->ps);
 				return ExecProject(repeatstate->ps.ps_ProjInfo, NULL);
 			}
 		} while (repeatstate->repeat_count > 0);
@@ -174,9 +170,7 @@ ExecInitRepeat(Repeat *node, EState *estate, int eflags)
 	ExecAssignProjectionInfo(&repeatstate->ps, NULL);
 
 	init_RepeatState(repeatstate);
-	
-	initGpmonPktForRepeat((Plan *)node, &repeatstate->ps.gpmon_pkt, estate);
-	
+
 	return repeatstate;
 }
 
@@ -226,12 +220,4 @@ init_RepeatState(RepeatState *repeatstate)
 	repeatstate->repeat_done = false;
 	repeatstate->slot = NULL;
 	repeatstate->repeat_count = 0;
-}
-
-void
-initGpmonPktForRepeat(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate)
-{
-	Assert(planNode != NULL && gpmon_pkt != NULL && IsA(planNode, Repeat));
-
-	InitPlanNodeGpmonPkt(planNode, gpmon_pkt, estate);
 }

--- a/src/backend/executor/nodeResult.c
+++ b/src/backend/executor/nodeResult.c
@@ -431,8 +431,6 @@ ExecInitResult(Result *node, EState *estate, int eflags)
 		SPI_ReserveMemory(((Plan *)node)->operatorMemKB * 1024L);
 	}
 
-	initGpmonPktForResult((Plan *)node, &resstate->ps.gpmon_pkt, estate);
-
 	return resstate;
 }
 
@@ -486,12 +484,4 @@ ExecReScanResult(ResultState *node, ExprContext *exprCtxt)
 	if (node->ps.lefttree &&
 		(node->ps.lefttree->chgParam == NULL || exprCtxt != NULL))
 		ExecReScan(node->ps.lefttree, exprCtxt);
-}
-
-void
-initGpmonPktForResult(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate)
-{
-	Assert(planNode != NULL && gpmon_pkt != NULL && IsA(planNode, Result));
-
-	InitPlanNodeGpmonPkt(planNode, gpmon_pkt, estate);
 }

--- a/src/backend/executor/nodeSetOp.c
+++ b/src/backend/executor/nodeSetOp.c
@@ -93,8 +93,6 @@ ExecSetOp(SetOpState *node)
 				ExecProcNode(outerPlan);
 			if (TupIsNull(node->ps.ps_OuterTupleSlot))
 				node->subplan_done = true;
-			else
-				Gpmon_Incr_Rows_In(GpmonPktFromSetOpState(node));
 		}
 		inputTupleSlot = node->ps.ps_OuterTupleSlot;
 

--- a/src/backend/executor/nodeSetOp.c
+++ b/src/backend/executor/nodeSetOp.c
@@ -203,10 +203,6 @@ ExecSetOp(SetOpState *node)
 	 */
 	Assert(node->numOutput > 0);
 	node->numOutput--;
-
-	Gpmon_Incr_Rows_Out(GpmonPktFromSetOpState(node));
-	CheckSendPlanStateGpmonPkt(&node->ps);
-
 	return resultTupleSlot;
 }
 
@@ -274,8 +270,6 @@ ExecInitSetOp(SetOp *node, EState *estate, int eflags)
 		execTuplesMatchPrepare(node->numCols,
 							   node->dupOperators);
 
-	initGpmonPktForSetOp((Plan *)node, &setopstate->ps.gpmon_pkt, estate);
-
 	return setopstate;
 }
 
@@ -323,12 +317,4 @@ ExecReScanSetOp(SetOpState *node, ExprContext *exprCtxt)
 	 */
 	if (((PlanState *) node)->lefttree->chgParam == NULL)
 		ExecReScan(((PlanState *) node)->lefttree, exprCtxt);
-}
-
-void
-initGpmonPktForSetOp(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate)
-{
-	Assert(planNode != NULL && gpmon_pkt != NULL && IsA(planNode, SetOp));
-
-	InitPlanNodeGpmonPkt(planNode, gpmon_pkt, estate);
 }

--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -196,9 +196,6 @@ ShareInputNext(ShareInputScanState *node)
 		if(!gotOK)
 			return NULL;
 
-		Gpmon_Incr_Rows_Out(GpmonPktFromShareInputState(node));
-		CheckSendPlanStateGpmonPkt(&node->ss.ps);
-
 		SIMPLE_FAULT_INJECTOR(ExecShareInputNext);
 
 		return slot;
@@ -285,8 +282,6 @@ ExecInitShareInputScan(ShareInputScan *node, EState *estate, int eflags)
 		ShareNodeEntry *snEntry = ExecGetShareNodeEntry(estate, node->share_id, true);
 		snEntry->refcount++;
 	}
-
-	initGpmonPktForShareInputScan((Plan *)node, &sisstate->ss.ps.gpmon_pkt, estate);
 	
 	return sisstate;
 }
@@ -378,8 +373,6 @@ void ExecShareInputScanReScan(ShareInputScanState *node, ExprContext *exprCtxt)
 	{
 		Assert(!"ExecShareInputScanReScan: invalid share type ");
 	}
-
-	CheckSendPlanStateGpmonPkt(&node->ss.ps);
 }
 
 /*************************************************************************
@@ -889,14 +882,6 @@ shareinput_writer_waitdone(void *ctxt, int share_id, int nsharer_xslice)
 
 	shareinput_clean_lk_ctxt(ctxt);
 	UnregisterXactCallbackOnce(XCallBack_ShareInput_FIFO, (void *) ctxt);
-}
-
-void
-initGpmonPktForShareInputScan(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate)
-{
-	Assert(planNode != NULL && gpmon_pkt != NULL && IsA(planNode, ShareInputScan));
-
-	InitPlanNodeGpmonPkt(planNode, gpmon_pkt, estate);
 }
 
 /*

--- a/src/backend/executor/nodeSort.c
+++ b/src/backend/executor/nodeSort.c
@@ -185,7 +185,6 @@ ExecSort(SortState *node)
 				break;
 			}
 
-			CheckSendPlanStateGpmonPkt(&node->ss.ps);
 			tuplesort_puttupleslot(tuplesortstate, slot);
 		}
 
@@ -393,8 +392,6 @@ ExecInitSort(Sort *node, EState *estate, int eflags)
 	SO1_printf("ExecInitSort: %s\n",
 			   "sort node initialized");
 
-	initGpmonPktForSort((Plan *)node, &sortstate->ss.ps.gpmon_pkt, estate);
-
 	return sortstate;
 }
 
@@ -533,14 +530,6 @@ ExecSortExplainEnd(PlanState *planstate, struct StringInfoData *buf)
 	}
 
 }                               /* ExecSortExplainEnd */
-
-void
-initGpmonPktForSort(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate)
-{
-	Assert(planNode != NULL && gpmon_pkt != NULL && IsA(planNode, Sort));
-	
-	InitPlanNodeGpmonPkt(planNode, gpmon_pkt, estate);
-}
 
 void
 ExecEagerFreeSort(SortState *node)

--- a/src/backend/executor/nodeSubqueryscan.c
+++ b/src/backend/executor/nodeSubqueryscan.c
@@ -77,12 +77,6 @@ SubqueryNext(SubqueryScanState *node)
     	slot_set_ctid_from_fake(slot, &node->cdb_fake_ctid);
     }
 
-    if (!TupIsNull(slot))
-    {
-        Gpmon_Incr_Rows_Out(GpmonPktFromSubqueryScanState(node));
-        CheckSendPlanStateGpmonPkt(&node->ss.ps);
-    }
-
 	return slot;
 }
 
@@ -186,8 +180,6 @@ ExecInitSubqueryScan(SubqueryScan *node, EState *estate, int eflags)
 	ExecAssignResultTypeFromTL(&subquerystate->ss.ps);
 	ExecAssignScanProjectionInfo(&subquerystate->ss);
 
-	initGpmonPktForSubqueryScan((Plan *)node, &subquerystate->ss.ps.gpmon_pkt, estate);
-
 	return subquerystate;
 }
 
@@ -266,11 +258,4 @@ ExecSubqueryReScan(SubqueryScanState *node, ExprContext *exprCtxt)
 	/*node->ss.ps.ps_TupFromTlist = false;*/
 
 	CheckSendPlanStateGpmonPkt(&node->ss.ps);
-}
-	
-void
-initGpmonPktForSubqueryScan(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate)
-{
-	Assert(planNode != NULL && gpmon_pkt != NULL && IsA(planNode, SubqueryScan));
-	InitPlanNodeGpmonPkt(planNode, gpmon_pkt, estate);
 }

--- a/src/backend/executor/nodeTableFunction.c
+++ b/src/backend/executor/nodeTableFunction.c
@@ -49,7 +49,6 @@
 
 static void setupFunctionArguments(TableFunctionState *node);
 static TupleTableSlot *TableFunctionNext(TableFunctionState *node);
-static gpmon_packet_t *GpmonPktFromTableFunctionState(TableFunctionState *node);
 static void initGpmonPktForTableFunction(Plan *planNode,
 										 gpmon_packet_t *gpmon_pkt, 
 										 EState *estate);
@@ -254,14 +253,6 @@ TableFunctionNext(TableFunctionState *node)
 	Assert(!TupIsNull(slot));
 
 	node->ss.ss_ScanTupleSlot = slot;
-
-	/* Update gpmon statistics */
-	if (!TupIsNull(slot))
-	{
-		Gpmon_Incr_Rows_Out(GpmonPktFromTableFunctionState(node));
-		CheckSendPlanStateGpmonPkt(&node->ss.ps);
-	}
-
 	return slot;
 }
 
@@ -495,12 +486,6 @@ initGpmonPktForTableFunction(Plan *planNode,
 	Assert(IsA(planNode, TableFunctionScan));
 
 	InitPlanNodeGpmonPkt(planNode, gpmon_pkt, estate);
-}
-
-gpmon_packet_t *
-GpmonPktFromTableFunctionState(TableFunctionState *node)
-{
-	return &node->ss.ps.gpmon_pkt;
 }
 
 

--- a/src/backend/executor/nodeTidscan.c
+++ b/src/backend/executor/nodeTidscan.c
@@ -297,11 +297,6 @@ TidNext(TidScanState *node)
 
 		/* Flag for the next call that no more tuples */
 		estate->es_evTupleNull[scanrelid - 1] = true;
-          	if (!TupIsNull(slot))
-                {
-          		Gpmon_Incr_Rows_Out(GpmonPktFromTidScanState(node));
-                        CheckSendPlanStateGpmonPkt(&node->ss.ps);
-                }
 		return slot;
 	}
 
@@ -588,8 +583,6 @@ ExecInitTidScan(TidScan *node, EState *estate, int eflags)
 	ExecAssignResultTypeFromTL(&tidstate->ss.ps);
 	ExecAssignScanProjectionInfo(&tidstate->ss);
 
-	initGpmonPktForTidScan((Plan *)node, &tidstate->ss.ps.gpmon_pkt, estate);
-
 	/*
 	 * all done.
 	 */
@@ -601,12 +594,4 @@ ExecCountSlotsTidScan(TidScan *node)
 {
 	return ExecCountSlotsNode(outerPlan((Plan *) node)) +
 		ExecCountSlotsNode(innerPlan((Plan *) node)) + TIDSCAN_NSLOTS;
-}
-
-void
-initGpmonPktForTidScan(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate)
-{
-	Assert(planNode != NULL && gpmon_pkt != NULL && IsA(planNode, TidScan));
-	
-	InitPlanNodeGpmonPkt(planNode, gpmon_pkt, estate);
 }

--- a/src/backend/executor/nodeUnique.c
+++ b/src/backend/executor/nodeUnique.c
@@ -99,12 +99,6 @@ ExecUnique(UniqueState *node)
 	 * won't guarantee that this source tuple is still accessible after
 	 * fetching the next source tuple.
 	 */
-   	if (!TupIsNull(slot))
-    	{
-  		Gpmon_Incr_Rows_Out(GpmonPktFromUniqueState(node));
-   		CheckSendPlanStateGpmonPkt(&node->ps);
-    	}
-
 	return ExecCopySlot(resultTupleSlot, slot);
 }
 
@@ -169,8 +163,6 @@ ExecInitUnique(Unique *node, EState *estate, int eflags)
 	uniquestate->eqfunctions =
 		execTuplesMatchPrepare(node->numCols,
 							   node->uniqOperators);
-
-	initGpmonPktForUnique((Plan *)node, &uniquestate->ps.gpmon_pkt, estate);
 	
 	return uniquestate;
 }
@@ -216,12 +208,4 @@ ExecReScanUnique(UniqueState *node, ExprContext *exprCtxt)
 	 */
 	if (((PlanState *) node)->lefttree->chgParam == NULL)
 		ExecReScan(((PlanState *) node)->lefttree, exprCtxt);
-}
-
-void
-initGpmonPktForUnique(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate)
-{
-	Assert(planNode != NULL && gpmon_pkt != NULL && IsA(planNode, Unique));
-
-	InitPlanNodeGpmonPkt(planNode, gpmon_pkt, estate);
 }

--- a/src/backend/executor/nodeUnique.c
+++ b/src/backend/executor/nodeUnique.c
@@ -75,8 +75,6 @@ ExecUnique(UniqueState *node)
 			return NULL;
 		}
 
-		Gpmon_Incr_Rows_In(GpmonPktFromUniqueState(node));
-
 		/*
 		 * Always return the first tuple from the subplan.
 		 */

--- a/src/backend/executor/nodeValuesscan.c
+++ b/src/backend/executor/nodeValuesscan.c
@@ -277,8 +277,6 @@ ExecInitValuesScan(ValuesScan *node, EState *estate, int eflags)
 	 */
 	ExecAssignResultTypeFromTL(&scanstate->ss.ps);
 	ExecAssignScanProjectionInfo(&scanstate->ss);
-
-	initGpmonPktForValuesScan((Plan *)node, &scanstate->ss.ps.gpmon_pkt, estate);
 	
 	return scanstate;
 }
@@ -353,15 +351,4 @@ ExecValuesReScan(ValuesScanState *node, ExprContext *exprCtxt)
 	/*node->ss.ps.ps_TupFromTlist = false;*/
 
 	node->curr_idx = -1;
-}
-
-void
-initGpmonPktForValuesScan(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate)
-{
-	RangeTblEntry *rte;
-	Assert(planNode != NULL && gpmon_pkt != NULL);
-
-	rte = rt_fetch(((ValuesScan *)planNode)->scan.scanrelid, estate->es_range_table);
-
-	InitPlanNodeGpmonPkt(planNode, gpmon_pkt, estate);
 }

--- a/src/backend/executor/nodeWindow.c
+++ b/src/backend/executor/nodeWindow.c
@@ -4549,16 +4549,8 @@ ExecWindow(WindowState * wstate)
 	 */
 	resultSlot = ExecProject(wstate->ps.ps_ProjInfo, &isDone);
 
-	if (!TupIsNull(resultSlot))
-	{
-		Gpmon_Incr_Rows_Out(GpmonPktFromWindowState(wstate));
-		CheckSendPlanStateGpmonPkt(&wstate->ps);
-	}
-
-	else
-	{
+	if (TupIsNull(resultSlot))
 		ExecEagerFreeWindow(wstate);
-	}
 
 	return resultSlot;
 }
@@ -5822,8 +5814,6 @@ ExecInitWindow(WindowAgg * node, EState *estate, int eflags)
 	/* Frame initialisation can take place now */
 	init_frames(wstate);
 
-	initGpmonPktForWindow((Plan *) node, &wstate->ps.gpmon_pkt, estate);
-
 	return wstate;
 }
 
@@ -6760,14 +6750,6 @@ first_value_generic(PG_FUNCTION_ARGS)
 		PG_RETURN_NULL();
 
 	return d;
-}
-
-void
-initGpmonPktForWindow(Plan * planNode, gpmon_packet_t * gpmon_pkt, EState *estate)
-{
-	Assert(planNode != NULL && gpmon_pkt != NULL && IsA(planNode, WindowAgg));
-
-	InitPlanNodeGpmonPkt(planNode, gpmon_pkt, estate);
 }
 
 void

--- a/src/backend/executor/nodeWindow.c
+++ b/src/backend/executor/nodeWindow.c
@@ -4218,8 +4218,6 @@ fetchCurrentRow(WindowState * wstate)
 		if (TupIsNull(slot))
 			return NULL;
 
-		Gpmon_Incr_Rows_In(GpmonPktFromWindowState(wstate));
-		CheckSendPlanStateGpmonPkt(&wstate->ps);
 		if (buffer == NULL)
 		{
 			initializePartition(wstate);
@@ -4410,8 +4408,6 @@ fetchTupleSlotThroughBuf(WindowState * wstate)
 			return NULL;
 		}
 
-		Gpmon_Incr_Rows_In(GpmonPktFromWindowState(wstate));
-		CheckSendPlanStateGpmonPkt(&wstate->ps);
 		/* Put the new tuple into the input buffer */
 		ntuplestore_acc_put_tupleslot(buffer->writer, slot);
 		buffer->num_tuples++;

--- a/src/backend/utils/sort/tuplesort.c
+++ b/src/backend/utils/sort/tuplesort.c
@@ -1056,10 +1056,6 @@ puttuple_common(Tuplesortstate *state, SortTuple *tuple)
 
 	state->totalNumTuples++;
 
-	/* gpmon */
-	if(state->gpmon_pkt)
-		Gpmon_Incr_Rows_In(state->gpmon_pkt);
-
 	switch (state->status)
 	{
 		case TSS_INITIAL:

--- a/src/backend/utils/sort/tuplesort_mk.c
+++ b/src/backend/utils/sort/tuplesort_mk.c
@@ -1252,9 +1252,6 @@ puttuple_common(Tuplesortstate_mk *state, MKEntry *e)
 	Assert(is_under_sort_or_exec_ctxt(state));
 	state->totalNumTuples++;
 
-	if (state->gpmon_pkt)
-		Gpmon_Incr_Rows_In(state->gpmon_pkt);
-
 	bool		growSucceed = true;
 
 	switch (state->status)

--- a/src/include/executor/nodeAgg.h
+++ b/src/include/executor/nodeAgg.h
@@ -195,11 +195,6 @@ extern Datum datumCopyWithMemManager(Datum oldvalue, Datum value, bool typByVal,
 									 MemoryManagerContainer *mem_manager);
 extern void ExecEagerFreeAgg(AggState *aggstate);
 
-static inline gpmon_packet_t * GpmonPktFromAggState(AggState *node)
-{
-	return &node->ss.ps.gpmon_pkt;
-}
-
 extern List *combineAggrefArgs(Aggref *aggref, List **sort_clauses);
 extern List *combinePercentileArgs(PercentileExpr *p);
 

--- a/src/include/executor/nodeAppend.h
+++ b/src/include/executor/nodeAppend.h
@@ -22,9 +22,4 @@ extern TupleTableSlot *ExecAppend(AppendState *node);
 extern void ExecEndAppend(AppendState *node);
 extern void ExecReScanAppend(AppendState *node, ExprContext *exprCtxt);
 
-static inline gpmon_packet_t * GpmonPktFromAppendState(AppendState *node)
-{
-	return &node->ps.gpmon_pkt;
-}
-
 #endif   /* NODEAPPEND_H */

--- a/src/include/executor/nodeBitmapAnd.h
+++ b/src/include/executor/nodeBitmapAnd.h
@@ -22,9 +22,4 @@ extern Node *MultiExecBitmapAnd(BitmapAndState *node);
 extern void ExecEndBitmapAnd(BitmapAndState *node);
 extern void ExecReScanBitmapAnd(BitmapAndState *node, ExprContext *exprCtxt);
 
-static inline gpmon_packet_t *GpmonPktFromBitmapAndState(BitmapAndState *node)
-{
-	return &node->ps.gpmon_pkt;
-}
-
 #endif   /* NODEBITMAPAND_H */

--- a/src/include/executor/nodeBitmapAppendOnlyscan.h
+++ b/src/include/executor/nodeBitmapAppendOnlyscan.h
@@ -27,10 +27,5 @@ extern void ExecEndBitmapAppendOnlyScan(BitmapAppendOnlyScanState *node);
 extern void ExecBitmapAppendOnlyReScan(BitmapAppendOnlyScanState *node, ExprContext *exprCtxt);
 extern void ExecEagerFreeBitmapAppendOnlyScan(BitmapAppendOnlyScanState *node);
 
-static inline gpmon_packet_t * GpmonPktFromBitmapAppendOnlyScanState(BitmapAppendOnlyScanState *node)
-{
-	return &node->ss.ps.gpmon_pkt;
-}
-
 #endif   /* NODEBITMAPAPPENDONLYSCAN_H */
 

--- a/src/include/executor/nodeBitmapHeapscan.h
+++ b/src/include/executor/nodeBitmapHeapscan.h
@@ -25,9 +25,4 @@ extern void ExecEagerFreeBitmapHeapScan(BitmapHeapScanState *node);
 
 extern void bitgetpage(HeapScanDesc scan, TBMIterateResult *tbmres);
 
-static inline gpmon_packet_t * GpmonPktFromBitmapHeapScanState(BitmapHeapScanState *node)
-{
-	return &node->ss.ps.gpmon_pkt;
-}
-
 #endif   /* NODEBITMAPHEAPSCAN_H */

--- a/src/include/executor/nodeBitmapIndexscan.h
+++ b/src/include/executor/nodeBitmapIndexscan.h
@@ -22,9 +22,4 @@ extern Node *MultiExecBitmapIndexScan(BitmapIndexScanState *node);
 extern void ExecEndBitmapIndexScan(BitmapIndexScanState *node);
 extern void ExecBitmapIndexReScan(BitmapIndexScanState *node, ExprContext *exprCtxt);
 
-static inline gpmon_packet_t * GpmonPktFromBitmapIndexScanState(BitmapIndexScanState *node)
-{
-	return &((IndexScanState*)node)->ss.ps.gpmon_pkt;
-}
-
 #endif   /* NODEBITMAPINDEXSCAN_H */

--- a/src/include/executor/nodeBitmapOr.h
+++ b/src/include/executor/nodeBitmapOr.h
@@ -22,8 +22,4 @@ extern Node *MultiExecBitmapOr(BitmapOrState *node);
 extern void ExecEndBitmapOr(BitmapOrState *node);
 extern void ExecReScanBitmapOr(BitmapOrState *node, ExprContext *exprCtxt);
 
-static inline gpmon_packet_t * GpmonPktFromBitmapOrState(BitmapOrState *node)
-{
-	return &node->ps.gpmon_pkt;
-}
 #endif   /* NODEBITMAPOR_H */

--- a/src/include/executor/nodeBitmapTableScan.h
+++ b/src/include/executor/nodeBitmapTableScan.h
@@ -29,10 +29,4 @@ extern void BitmapTableScanEndPartition(ScanState *node);
 extern void BitmapTableScanReScanPartition(ScanState *node);
 extern TupleTableSlot *BitmapTableScanFetchNext(ScanState *node);
 
-
-static inline gpmon_packet_t * GpmonPktFromBitmapTableScanState(BitmapTableScanState *node)
-{
-	return &node->ss.ps.gpmon_pkt;
-}
-
 #endif   /* NODEBITMAPTABLESCAN_H */

--- a/src/include/executor/nodeDynamicTableScan.h
+++ b/src/include/executor/nodeDynamicTableScan.h
@@ -24,8 +24,4 @@ extern void ExecDynamicTableMarkPos(DynamicTableScanState *node);
 extern void ExecDynamicTableRestrPos(DynamicTableScanState *node);
 extern void ExecDynamicTableReScan(DynamicTableScanState *node, ExprContext *exprCtxt);
 
-static inline gpmon_packet_t * GpmonPktFromDynamicTableScanState(DynamicTableScanState *node)
-{
-	return &node->tableScanState.ss.ps.gpmon_pkt;
-}
 #endif

--- a/src/include/executor/nodeExternalscan.h
+++ b/src/include/executor/nodeExternalscan.h
@@ -24,10 +24,4 @@ extern void ExecStopExternalScan(ExternalScanState *node);
 extern void ExecExternalReScan(ExternalScanState *node, ExprContext *exprCtxt);
 extern void ExecEagerFreeExternalScan(ExternalScanState *node);
 
-static inline gpmon_packet_t *GpmonPktFromExtScanState(ExternalScanState *node)
-{
-	return &node->ss.ps.gpmon_pkt;
-}
-
-
 #endif   /* NODEEXTERNALSCAN_H */

--- a/src/include/executor/nodeFunctionscan.h
+++ b/src/include/executor/nodeFunctionscan.h
@@ -23,9 +23,4 @@ extern void ExecEndFunctionScan(FunctionScanState *node);
 extern void ExecFunctionReScan(FunctionScanState *node, ExprContext *exprCtxt);
 extern void ExecEagerFreeFunctionScan(FunctionScanState *node);
 
-static inline gpmon_packet_t * GpmonPktFromFuncScanState(FunctionScanState *node)
-{
-	return &node->ss.ps.gpmon_pkt;
-}
-
 #endif   /* NODEFUNCTIONSCAN_H */

--- a/src/include/executor/nodeHash.h
+++ b/src/include/executor/nodeHash.h
@@ -50,11 +50,6 @@ extern void ExecHashTableExplainInit(HashState *hashState, HashJoinState *hjstat
                                      HashJoinTable  hashtable);
 extern void ExecHashTableExplainBatchEnd(HashState *hashState, HashJoinTable hashtable);
 
-static inline gpmon_packet_t * GpmonPktFromHashState(HashState *node)
-{
-	return &node->ps.gpmon_pkt;
-}
-
 static inline int
 ExecHashRowSize(int tupwidth)
 {

--- a/src/include/executor/nodeHashjoin.h
+++ b/src/include/executor/nodeHashjoin.h
@@ -31,9 +31,4 @@ extern void ExecHashJoinSaveTuple(PlanState *ps, MemTuple tuple, uint32 hashvalu
 								  MemoryContext bfCxt);
 extern void ExecEagerFreeHashJoin(HashJoinState *node);
 
-static inline gpmon_packet_t * GpmonPktFromHashJoinState(HashJoinState *s)
-{
-	return &s->js.ps.gpmon_pkt;
-}
-
 #endif   /* NODEHASHJOIN_H */

--- a/src/include/executor/nodeIndexscan.h
+++ b/src/include/executor/nodeIndexscan.h
@@ -39,8 +39,4 @@ extern bool ExecIndexAdvanceArrayKeys(IndexArrayKeyInfo *arrayKeys, int numArray
 
 extern TupleTableSlot *IndexNext(IndexScanState *node);
 
-static inline gpmon_packet_t * GpmonPktFromIndexScanState(IndexScanState *node)
-{
-	return &node->ss.ps.gpmon_pkt;
-}
 #endif   /* NODEINDEXSCAN_H */

--- a/src/include/executor/nodeLimit.h
+++ b/src/include/executor/nodeLimit.h
@@ -22,9 +22,4 @@ extern TupleTableSlot *ExecLimit(LimitState *node);
 extern void ExecEndLimit(LimitState *node);
 extern void ExecReScanLimit(LimitState *node, ExprContext *exprCtxt);
 
-static inline gpmon_packet_t * GpmonPktFromLimitState(LimitState *node)
-{
-	return &node->ps.gpmon_pkt;
-}
-
 #endif   /* NODELIMIT_H */

--- a/src/include/executor/nodeMaterial.h
+++ b/src/include/executor/nodeMaterial.h
@@ -25,9 +25,4 @@ extern void ExecMaterialRestrPos(MaterialState *node);
 extern void ExecMaterialReScan(MaterialState *node, ExprContext *exprCtxt);
 extern void ExecEagerFreeMaterial(MaterialState *node);
 
-static inline gpmon_packet_t * GpmonPktFromMaterialState(MaterialState *node)
-{
-	return &node->ss.ps.gpmon_pkt;
-}
-
 #endif   /* NODEMATERIAL_H */

--- a/src/include/executor/nodeMergejoin.h
+++ b/src/include/executor/nodeMergejoin.h
@@ -23,8 +23,4 @@ extern void ExecEndMergeJoin(MergeJoinState *node);
 extern void ExecReScanMergeJoin(MergeJoinState *node, ExprContext *exprCtxt);
 extern void ExecEagerFreeMergeJoin(MergeJoinState *node);
 
-static inline gpmon_packet_t *GpmonPktFromMergeJoinState(MergeJoinState *node)
-{
-	return &node->js.ps.gpmon_pkt;
-}
 #endif   /* NODEMERGEJOIN_H */

--- a/src/include/executor/nodeMotion.h
+++ b/src/include/executor/nodeMotion.h
@@ -27,9 +27,4 @@ extern void ExecStopMotion(MotionState *node);
 
 extern bool isMotionGather(const Motion *m);
 
-static inline gpmon_packet_t * GpmonPktFromMotionState(MotionState *node)
-{
-	return &node->ps.gpmon_pkt;
-}
-
 #endif   /* NODEMOTION_H */

--- a/src/include/executor/nodeNestloop.h
+++ b/src/include/executor/nodeNestloop.h
@@ -22,9 +22,4 @@ extern TupleTableSlot *ExecNestLoop(NestLoopState *node);
 extern void ExecEndNestLoop(NestLoopState *node);
 extern void ExecReScanNestLoop(NestLoopState *node, ExprContext *exprCtxt);
 
-static inline gpmon_packet_t * GpmonPktFromNLJState(NestLoopState *node)
-{
-	return &node->js.ps.gpmon_pkt;
-}
-
 #endif   /* NODENESTLOOP_H */

--- a/src/include/executor/nodeRepeat.h
+++ b/src/include/executor/nodeRepeat.h
@@ -23,9 +23,4 @@ extern int ExecCountSlotsRepeat(Repeat *node);
 extern void ExecEndRepeat(RepeatState *node);
 extern void ExecReScanRepeat(RepeatState *node, ExprContext *exprCtxt);
 
-static inline gpmon_packet_t * GpmonPktFromRepeatState(RepeatState *node)
-{
-	return &node->ps.gpmon_pkt;
-}
-
 #endif

--- a/src/include/executor/nodeResult.h
+++ b/src/include/executor/nodeResult.h
@@ -24,8 +24,4 @@ extern void ExecResultMarkPos(ResultState *node);
 extern void ExecResultRestrPos(ResultState *node);
 extern void ExecReScanResult(ResultState *node, ExprContext *exprCtxt);
 
-static inline gpmon_packet_t * GpmonPktFromResultState(ResultState *node)
-{
-	return &node->ps.gpmon_pkt;
-}
 #endif   /* NODERESULT_H */

--- a/src/include/executor/nodeSequence.h
+++ b/src/include/executor/nodeSequence.h
@@ -24,9 +24,4 @@ extern void ExecReScanSequence(SequenceState *node, ExprContext *exprCtxt);
 extern void ExecEndSequence(SequenceState *node);
 extern int ExecCountSlotsSequence(Sequence *node);
 
-static inline gpmon_packet_t * GpmonPktFromSequenceState(SequenceState *node)
-{
-	return &node->ps.gpmon_pkt;
-}
-
 #endif

--- a/src/include/executor/nodeSetOp.h
+++ b/src/include/executor/nodeSetOp.h
@@ -22,9 +22,4 @@ extern TupleTableSlot *ExecSetOp(SetOpState *node);
 extern void ExecEndSetOp(SetOpState *node);
 extern void ExecReScanSetOp(SetOpState *node, ExprContext *exprCtxt);
 
-static inline gpmon_packet_t * GpmonPktFromSetOpState(SetOpState *node)
-{
-	return &node->ps.gpmon_pkt;
-}
-
 #endif   /* NODESETOP_H */

--- a/src/include/executor/nodeShareInputScan.h
+++ b/src/include/executor/nodeShareInputScan.h
@@ -26,9 +26,4 @@ extern void ExecEagerFreeShareInputScan(ShareInputScanState *node);
 
 extern void ExecSliceDependencyShareInputScan(ShareInputScanState *node);
 
-static inline gpmon_packet_t * GpmonPktFromShareInputState(ShareInputScanState *node)
-{
-	return &node->ss.ps.gpmon_pkt;
-}
-
 #endif   /* NODESHAREINPUTSCAN_H */

--- a/src/include/executor/nodeSort.h
+++ b/src/include/executor/nodeSort.h
@@ -25,9 +25,4 @@ extern void ExecSortRestrPos(SortState *node);
 extern void ExecReScanSort(SortState *node, ExprContext *exprCtxt);
 extern void ExecEagerFreeSort(SortState *node);
 
-static inline gpmon_packet_t * GpmonPktFromSortState(SortState *node)
-{
-	return &node->ss.ps.gpmon_pkt;
-}
-
 #endif   /* NODESORT_H */

--- a/src/include/executor/nodeSubqueryscan.h
+++ b/src/include/executor/nodeSubqueryscan.h
@@ -22,10 +22,4 @@ extern TupleTableSlot *ExecSubqueryScan(SubqueryScanState *node);
 extern void ExecEndSubqueryScan(SubqueryScanState *node);
 extern void ExecSubqueryReScan(SubqueryScanState *node, ExprContext *exprCtxt);
 
-static inline gpmon_packet_t * GpmonPktFromSubqueryScanState(SubqueryScanState *node)
-{
-	return &node->ss.ps.gpmon_pkt;
-}
-
-
 #endif   /* NODESUBQUERYSCAN_H */

--- a/src/include/executor/nodeTableScan.h
+++ b/src/include/executor/nodeTableScan.h
@@ -25,9 +25,4 @@ extern void ExecTableRestrPos(TableScanState *node);
 extern void ExecTableReScan(TableScanState *node, ExprContext *exprCtxt);
 extern void ExecEagerFreeTableScan(TableScanState *node);
 
-static inline gpmon_packet_t * GpmonPktFromTableScanState(TableScanState *node)
-{
-	return &node->ss.ps.gpmon_pkt;
-}
-
 #endif

--- a/src/include/executor/nodeTidscan.h
+++ b/src/include/executor/nodeTidscan.h
@@ -24,8 +24,4 @@ extern void ExecTidMarkPos(TidScanState *node);
 extern void ExecTidRestrPos(TidScanState *node);
 extern void ExecTidReScan(TidScanState *node, ExprContext *exprCtxt);
 
-static inline gpmon_packet_t * GpmonPktFromTidScanState(TidScanState *node)
-{
-	return &node->ss.ps.gpmon_pkt;
-}
 #endif   /* NODETIDSCAN_H */

--- a/src/include/executor/nodeUnique.h
+++ b/src/include/executor/nodeUnique.h
@@ -22,8 +22,4 @@ extern TupleTableSlot *ExecUnique(UniqueState *node);
 extern void ExecEndUnique(UniqueState *node);
 extern void ExecReScanUnique(UniqueState *node, ExprContext *exprCtxt);
 
-static inline gpmon_packet_t * GpmonPktFromUniqueState(UniqueState *node)
-{
-	return &node->ps.gpmon_pkt;
-}
 #endif   /* NODEUNIQUE_H */

--- a/src/include/executor/nodeValuesscan.h
+++ b/src/include/executor/nodeValuesscan.h
@@ -24,8 +24,4 @@ extern void ExecValuesMarkPos(ValuesScanState *node);
 extern void ExecValuesRestrPos(ValuesScanState *node);
 extern void ExecValuesReScan(ValuesScanState *node, ExprContext *exprCtxt);
 
-static inline gpmon_packet_t * GpmonPktFromValueScanState(ValuesScanState *node)
-{
-	return &node->ss.ps.gpmon_pkt;
-}
 #endif   /* NODEVALUESSCAN_H */

--- a/src/include/executor/nodeWindow.h
+++ b/src/include/executor/nodeWindow.h
@@ -48,9 +48,4 @@ extern Datum last_value_generic(PG_FUNCTION_ARGS);
 extern Datum first_value_generic(PG_FUNCTION_ARGS);
 extern Datum lag_generic(PG_FUNCTION_ARGS);
 
-static inline gpmon_packet_t * GpmonPktFromWindowState(WindowState *node)
-{
-	return &node->ps.gpmon_pkt;
-}
-
 #endif   /* NODEWINDOW_H */

--- a/src/include/gpmon/gpmon.h
+++ b/src/include/gpmon/gpmon.h
@@ -139,7 +139,7 @@ struct gpmon_query_seginfo_t
 	 */
 	int64				final_rowsout;
 	uint64				sum_cpu_elapsed;
-	uint64				sum_measures_rows_in;
+	uint64				sum_measures_rows_out;
 };
 
 /* process metrics ... filled in by gpsmon */
@@ -203,7 +203,6 @@ struct gpmon_qexec_t {
 	uint64		_cpu_elapsed; /* CPU elapsed for iter */
 	gpmon_proc_metrics_t 	_p_metrics;
 	uint64 		rowsout;
-	uint64 		rowsin;
 };
 
 /*

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -1423,10 +1423,6 @@ extern void InitPlanNodeGpmonPkt(Plan* plan, gpmon_packet_t *gpmon_pkt, EState *
 
 extern uint64 PlanStateOperatorMemKB(const PlanState *ps);
 
-static inline void Gpmon_Incr_Rows_In(gpmon_packet_t *pkt)
-{
-    ++pkt->u.qexec.rowsin;
-}
 static inline void Gpmon_Incr_Rows_Out(gpmon_packet_t *pkt)
 {
     ++pkt->u.qexec.rowsout;

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2705,39 +2705,4 @@ typedef struct PartitionSelectorState
 	ProjectionInfo *partTabProj;
 } PartitionSelectorState;
 
-extern void initGpmonPktForResult(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-extern void initGpmonPktForAppend(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-extern void initGpmonPktForSequence(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-extern void initGpmonPktForBitmapAnd(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-extern void initGpmonPktForBitmapOr(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-extern void initGpmonPktForTableScan(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-extern void initGpmonPktForDynamicTableScan(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-extern void initGpmonPktForExternalScan(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-extern void initGpmonPktForIndexScan(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-extern void initGpmonPktForDynamicIndexScan(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-extern void initGpmonPktForBitmapIndexScan(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-extern void initGpmonPktForBitmapHeapScan(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-extern void initGpmonPktForBitmapAppendOnlyScan(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-extern void initGpmonPktForTidScan(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-extern void initGpmonPktForSubqueryScan(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-extern void initGpmonPktForFunctionScan(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-extern void initGpmonPktForValuesScan(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-extern void initGpmonPktForNestLoop(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-extern void initGpmonPktForMergeJoin(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-extern void initGpmonPktForHashJoin(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-extern void initGpmonPktForMaterial(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-extern void initGpmonPktForSort(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-extern void initGpmonPktForGroup(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-extern void initGpmonPktForAgg(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-extern void initGpmonPktForUnique(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-extern void initGpmonPktForHash(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-extern void initGpmonPktForSetOp(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-extern void initGpmonPktForLimit(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-extern void initGpmonPktForMotion(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-extern void initGpmonPktForShareInputScan(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-extern void initGpmonPktForWindow(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-extern void initGpmonPktForRepeat(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-extern void initGpmonPktForDML(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-extern void initGpmonPktForPartitionSelector(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-
 #endif   /* EXECNODES_H */

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -1416,19 +1416,6 @@ typedef struct PlanState
 	gpmon_packet_t gpmon_pkt;
 } PlanState;
 
-typedef struct Gpmon_NameUnit_MaxVal
-{
-	char	   *name;
-	char	   *unit;
-	int64		maxval;
-} Gpmon_NameUnit_MaxVal;
-
-typedef struct Gpmon_NameVal_Text
-{
-	char	   *name;
-	char	   *value;
-} Gpmon_NameVal_Text;
-
 /* Gpperfmon helper functions defined in execGpmon.c */
 extern void CheckSendPlanStateGpmonPkt(PlanState *ps);
 extern void EndPlanStateGpmonPkt(PlanState *ps);


### PR DESCRIPTION
Refactor the way gpmon counters are updated in the executor, to reduce our diff footprint vs. upstream.

See commit messages.
