### PR TITLE
minor resource group doc updates

### DIFF
--- a/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
@@ -528,14 +528,16 @@ gpstart
     </topic>
 
     <topic id="topic27" xml:lang="en">
-      <title id="iz153732">Canceling a Queued Transaction in a Resource Group</title>
+      <title id="iz153732">Cancelling a Running or Queued Transaction in a Resource Group</title>
       <body>
-        <p>There may be cases when you want to cancel a queued transaction in a resource group. For
+        <p>There may be cases when you want to cancel a running or queued transaction in a
+          resource group. For
           example, you may want to remove a query that is waiting in the resource group queue but
           has not yet been executed. Or, you may want to stop a running query that is taking too
           long to execute, or one that is sitting idle in a transaction and taking up resource group
           transaction slots that are needed by other users.</p>
-        <p>To cancel a queued transaction, you must first determine the process id (pid) associated
+        <p>To cancel a running or queued transaction, you must first determine the process
+          id (pid) associated
           with the transaction. Once you have obtained the process id, you can invoke
             <codeph>pg_cancel_backend()</codeph> to end that process, as shown below.</p>
         <p>For example, to view the process information associated with all statements currently

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml
@@ -23,7 +23,7 @@ MEMORY_LIMIT=<varname>integer</varname>
          and CPU limits for the role when resource groups are enabled.</p>
       <p>You must have <codeph>SUPERUSER</codeph> privileges to create a resource group. The maximum number of resource groups allowed in your Greenplum Database cluster is 100.</p>
       <p>Greenplum Database pre-defines two default resource groups: <codeph>admin_group</codeph>
-         and <codeph>default_group</codeph>. These group names are reserved.</p>
+         and <codeph>default_group</codeph>. These group names, as well as the group name <codeph>none</codeph>, are reserved.</p>
       <p>
         To set appropriate limits for resource groups, the Greenplum Database administrator must
         be familiar with the queries typically executed on the system, as well as the users/roles executing those queries.</p>


### PR DESCRIPTION
- can cancel a running or queued query
- resource group name "none" is also reserved