### PR TITLE
resgroup: adjust segment vmem limit and disable runaway detection when resgroup is enabled.

### DIFF
--- a/src/backend/postmaster/perfmon_segmentinfo.c
+++ b/src/backend/postmaster/perfmon_segmentinfo.c
@@ -53,9 +53,6 @@ static volatile bool isSenderProcess = false;
 /* Static gpmon_seginfo_t item, (re)used for sending UDP packets. */
 static gpmon_packet_t seginfopkt;
 
-/* Maximum dynamic memory allocation in bytes */
-static uint64 mem_alloc_max;
-
 /* GpmonPkt-related routines */
 static void InitSegmentInfoGpmonPkt(gpmon_packet_t *gpmon_pkt);
 static void UpdateSegmentInfoGpmonPkt(gpmon_packet_t *gpmon_pkt);
@@ -173,12 +170,6 @@ NON_EXEC_STATIC void SegmentInfoSenderMain(int argc, char *argv[])
 
 	MyBackendId = InvalidBackendId;
 
-	/*
-	 * Save gp_vmem_protect_limit value in bytes.
-	 * This value cannot change after starting the server.
-	 */
-	mem_alloc_max = VmemTracker_GetVmemLimitBytes();
-
 	/* Init gpmon connection */
 	gpmon_init();
 
@@ -269,8 +260,8 @@ UpdateSegmentInfoGpmonPkt(gpmon_packet_t *gpmon_pkt)
 	Assert(gpmon_pkt);
 	Assert(GPMON_PKTTYPE_SEGINFO == gpmon_pkt->pkttype);
 
-	uint64 mem_alloc_used = VmemTracker_GetVmemLimitBytes() - VmemTracker_GetAvailableVmemBytes();
-	uint64 mem_alloc_available = mem_alloc_max - mem_alloc_used;
-	gpmon_pkt->u.seginfo.dynamic_memory_used = mem_alloc_used;
+	uint64 mem_alloc_available = VmemTracker_GetAvailableVmemBytes();
+	uint64 mem_alloc_limit = VmemTracker_GetVmemLimitBytes();
+	gpmon_pkt->u.seginfo.dynamic_memory_used = mem_alloc_limit - mem_alloc_available;
 	gpmon_pkt->u.seginfo.dynamic_memory_available =	mem_alloc_available;
 }

--- a/src/backend/utils/mmgr/vmem_tracker.c
+++ b/src/backend/utils/mmgr/vmem_tracker.c
@@ -52,7 +52,7 @@ static int32 maxVmemChunksTracked = 0;
 static int64 trackedBytes = 0;
 
 /* Vmem quota in chunk unit */
-static int32 vmemChunksQuota;
+static int32 vmemChunksQuota = 0;
 /*
  * Chunk size in bits. By default a chunk is 1MB, but it can be larger
  * depending on the vmem quota.
@@ -316,7 +316,7 @@ static int32
 VmemTracker_GetNonNegativeAvailableVmemChunks()
 {
 	int32 usedChunks = *segmentVmemChunks;
-	if (vmemTrackerInited && vmemChunksQuota > usedChunks)
+	if (vmemChunksQuota > usedChunks)
 	{
 		return vmemChunksQuota - usedChunks;
 	}
@@ -334,7 +334,7 @@ static int32
 VmemTracker_GetNonNegativeAvailableQueryChunks()
 {
 	int32 curSessionVmem = MySessionState->sessionVmem;
-	if (vmemTrackerInited && maxChunksPerQuery > curSessionVmem)
+	if (maxChunksPerQuery > curSessionVmem)
 	{
 		return maxChunksPerQuery - curSessionVmem;
 	}
@@ -446,14 +446,7 @@ VmemTracker_GetReservedVmemBytes(void)
 int64
 VmemTracker_GetAvailableVmemBytes()
 {
-	if (vmemTrackerInited)
-	{
-		return CHUNKS_TO_BYTES(VmemTracker_GetNonNegativeAvailableVmemChunks());
-	}
-	else
-	{
-		return 0;
-	}
+	return CHUNKS_TO_BYTES(VmemTracker_GetNonNegativeAvailableVmemChunks());
 }
 
 /*
@@ -462,14 +455,7 @@ VmemTracker_GetAvailableVmemBytes()
 int32
 VmemTracker_GetAvailableVmemMB()
 {
-	if (vmemTrackerInited)
-	{
-		return CHUNKS_TO_MB(VmemTracker_GetNonNegativeAvailableVmemChunks());
-	}
-	else
-	{
-		return 0;
-	}
+	return CHUNKS_TO_MB(VmemTracker_GetNonNegativeAvailableVmemChunks());
 }
 
 /*
@@ -478,14 +464,7 @@ VmemTracker_GetAvailableVmemMB()
 int32
 VmemTracker_GetAvailableQueryVmemMB()
 {
-	if (vmemTrackerInited)
-	{
-		return CHUNKS_TO_MB(VmemTracker_GetNonNegativeAvailableQueryChunks());
-	}
-	else
-	{
-		return 0;
-	}
+	return CHUNKS_TO_MB(VmemTracker_GetNonNegativeAvailableQueryChunks());
 }
 
 /*

--- a/src/backend/utils/resgroup/resgroup-ops-linux.c
+++ b/src/backend/utils/resgroup/resgroup-ops-linux.c
@@ -797,7 +797,7 @@ ResGroupOps_GetCpuCores(void)
 }
 
 /*
- * Get the total memory on the system.
+ * Get the total memory on the system in MB.
  * Read from sysinfo and cgroup to get correct ram and swap.
  * (total RAM * overcommit_ratio + total Swap)
  */
@@ -829,5 +829,5 @@ ResGroupOps_GetTotalMemory(void)
 	 * memoery outside and the memsw of the container.
 	 */
 	total = Min(outTotal, swap + ram); 
-	return total >> VmemTracker_GetChunkSizeInBits();
+	return total >> BITS_IN_MB;
 }

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -752,25 +752,30 @@ DumpResGroupMemUsage(ResGroupData *group)
 
 	appendStringInfo(&memUsage, "{");
 	appendStringInfo(&memUsage, "\"used\":%d, ",
-					 group->memUsage);
+					 VmemTracker_ConvertVmemChunksToMB(group->memUsage));
 	appendStringInfo(&memUsage, "\"available\":%d, ",
-					 group->memQuotaGranted + group->memSharedGranted - group->memUsage);
+					 VmemTracker_ConvertVmemChunksToMB(
+						group->memQuotaGranted + group->memSharedGranted - group->memUsage));
 	appendStringInfo(&memUsage, "\"quota_used\":%d, ",
-					 slotUsage);
+					 VmemTracker_ConvertVmemChunksToMB(slotUsage));
 	appendStringInfo(&memUsage, "\"quota_available\":%d, ",
-					 group->memQuotaGranted - group->memQuotaUsed);
+					 VmemTracker_ConvertVmemChunksToMB(
+						group->memQuotaGranted - group->memQuotaUsed));
 	appendStringInfo(&memUsage, "\"quota_granted\":%d, ",
-					 group->memQuotaGranted);
+					 VmemTracker_ConvertVmemChunksToMB(group->memQuotaGranted));
 	appendStringInfo(&memUsage, "\"quota_proposed\":%d, ",
-					 groupGetMemQuotaExpected(&group->caps));
+					 VmemTracker_ConvertVmemChunksToMB(
+						groupGetMemQuotaExpected(&group->caps)));
 	appendStringInfo(&memUsage, "\"shared_used\":%d, ",
-					 group->memSharedUsage);
+					 VmemTracker_ConvertVmemChunksToMB(group->memSharedUsage));
 	appendStringInfo(&memUsage, "\"shared_available\":%d, ",
-					 group->memSharedGranted - group->memSharedUsage);
+					 VmemTracker_ConvertVmemChunksToMB(
+						group->memSharedGranted - group->memSharedUsage));
 	appendStringInfo(&memUsage, "\"shared_granted\":%d, ",
-					 group->memSharedGranted);
+					 VmemTracker_ConvertVmemChunksToMB(group->memSharedGranted));
 	appendStringInfo(&memUsage, "\"shared_proposed\":%d",
-					 groupGetMemSharedExpected(&group->caps));
+					 VmemTracker_ConvertVmemChunksToMB(
+						groupGetMemSharedExpected(&group->caps)));
 	appendStringInfo(&memUsage, "}");
 
 	return memUsage.data;

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -164,6 +164,10 @@ extern void ResGroupDecideConcurrencyCaps(Oid groupId,
 										  ResGroupCaps *caps,
 										  const ResGroupOpts *opts);
 
+extern int32 ResGroupGetVmemLimitChunks(void);
+extern int32 ResGroupGetVmemChunkSizeInBits(void);
+extern int32 ResGroupGetMaxChunksPerQuery(void);
+
 /* test helper function */
 extern void ResGroupGetMemInfo(int *memLimit, int *slotQuota, int *sharedQuota);
 

--- a/src/include/utils/vmem_tracker.h
+++ b/src/include/utils/vmem_tracker.h
@@ -16,6 +16,8 @@
 
 #include "nodes/nodes.h"
 
+#define BITS_IN_MB 20
+
 /*
  * The cleanupCountdown in the SessionState determines how many
  * processes we need to cleanup to declare a session clean. If it
@@ -72,5 +74,6 @@ extern void RedZoneHandler_LogVmemUsageOfAllSessions(void);
 
 extern void IdleTracker_ActivateProcess(void);
 extern void IdleTracker_DeactivateProcess(void);
+extern bool VmemTrackerIsActivated(void);
 
 #endif   /* VMEMTRACKER_H */


### PR DESCRIPTION
* fix gpperfmon dynamic memory usage bug
* adjust the memory limit that a segment can use
* disable runaway detection when resgroup is enabled
* display memory usage in MB for gp_resgroup_status