### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*.[chy]]
+indent_style = tab
+indent_size = 4
+
+[{GNUmakefile,Makefile}*]
+indent_style = tab
+indent_size = 4
+
+[*.mk]
+indent_style = tab
+indent_size = 4
+
+[*.py]
+indent_style = space
+indent_size = 4
+


### PR DESCRIPTION
This was discussed in https://github.com/greenplum-db/gpdb/issues/3571, by putting a `.editorconfig` file we could set default tabstop width to 4 on github.