### PR TITLE
recognize timezone 'CST' correctly in China

### DIFF
--- a/src/backend/utils/misc/postgresql.conf.sample
+++ b/src/backend/utils/misc/postgresql.conf.sample
@@ -441,6 +441,7 @@ log_autostats=off	# print additional autostats information
 					#   Default
 					#   Australia
 					#   India
+					#   Asia
 					# You can create your own file in
 					# share/timezonesets/.
 #extra_float_digits = 0			# min -15, max 2

--- a/src/timezone/tznames/America.txt
+++ b/src/timezone/tznames/America.txt
@@ -142,11 +142,13 @@ COT    -18000    # Columbia Time (not in zic)
 # Other timezones:
 #  - CST: Central Standard Time (Australia)
 #  - CST: Central Standard Time (America)
+#  - CST: China Standard Time (Asia)
 CST    -18000    # Cuba Central Standard Time (America)
                  #     (America/Havana)
 # CONFLICT! CST is not unique
 # Other timezones:
 #  - CST: Central Standard Time (Australia)
+#  - CST: China Standard Time (Asia)
 #  - CST: Cuba Central Standard Time (America)
 CST    -21600    # Central Standard Time (America)
                  #     (America/Cancun)

--- a/src/timezone/tznames/Asia
+++ b/src/timezone/tznames/Asia
@@ -1,0 +1,64 @@
+# Time zone configuration file for set "Asia"
+
+# In order to use this file, you need to set the run-time parameter
+# timezone_abbreviations to 'Asia'.  See the `Date/Time Support'
+#   appendix in the PostgreSQL documentation for more information.
+#
+# src/timezone/tznames/Asia
+
+
+# include the default set
+@INCLUDE Default
+
+# most timezones are already defined in the default set. With the OVERRIDE
+# option, PostgreSQL will use the new definitions instead of throwing an error
+# in case of a conflict.
+@OVERRIDE
+
+AQTT    18000    # Aqtau Time
+                 # Aqtobe Time
+                 #     (Asia/Aqtau)
+                 #     (Asia/Aqtobe)
+AST     10800    # Arabia Standard Time
+                 #     (Asia/Aden)
+                 #     (Asia/Baghdad)
+                 #     (Asia/Bahrain)
+                 #     (Asia/Kuwait)
+                 #     (Asia/Qatar)
+                 #     (Asia/Riyadh)
+CHOST   36000 D  # Choibalsan Summer Time
+                 #     (Asia/Choibalsan)
+CHOT    32400    # Choibalsan Time
+                 #     (Asia/Choibalsan)
+CIT     28800    # Central Indonesia Time (obsolete, WITA is now preferred)
+CST     28800    # China Standard Time
+                 #     (Asia/Macau)
+                 #     (Asia/Shanghai)
+                 #     (Asia/Taipei)
+EIT     32400    # East Indonesia Time
+                 #     (Asia/Jayapura)
+GST     14400    # Gulf Standard Time
+                 #     (Asia/Dubai)
+                 #     (Asia/Muscat)
+HOVST   28800 D  # Hovd Summer Time
+                 #     (Asia/Hovd)
+HOVT    25200    # Hovd Time
+                 #     (Asia/Hovd)
+IRDT    16200 D  # Iran Daylight Time
+                 #     (Asia/Tehran)
+IST     19800    # Indian Standard Time
+                 #     (Asia/Calcutta)
+ORAT    18000    # Oral Time
+                 #     (Asia/Oral)
+QYZT    21600    # Kizilorda Time
+                 #     (Asia/Qyzylorda)
+SAKST   39600 D  # Sakhalin Summer Time
+                 #     (Asia/Sakhalin)
+SAKT    36000    # Sakhalin Time
+                 #     (Asia/Sakhalin)
+TLT     32400    # East Timor Time
+                 #     (Asia/Dili)
+WIT     25200    # Waktu Indonesia Timur
+                 # West Indonesia Time
+                 #     (Asia/Jakarta)
+                 #     (Asia/Pontianak)

--- a/src/timezone/tznames/Asia.txt
+++ b/src/timezone/tznames/Asia.txt
@@ -68,6 +68,15 @@ CHOST   36000 D  # Choibalsan Summer Time (obsolete)
 CHOT    28800    # Choibalsan Time (caution: this used to mean 32400)
                  #     (Asia/Choibalsan)
 CIT     28800    # Central Indonesia Time (obsolete, WITA is now preferred)
+# CONFLICT! CST is not unique
+# Other timezones:
+#  - CST: Central Standard Time (Australia)
+#  - CST: Central Standard Time (America)
+#  - CST: Cuba Central Standard Time (America)
+CST     28800    # China Standard Time
+                 #     (Asia/Macau)
+                 #     (Asia/Shanghai)
+                 #     (Asia/Taipei)
 EEST    10800 D  # East-Egypt Summer Time
                  # Eastern Europe Summer Time
                  #     (Africa/Cairo)

--- a/src/timezone/tznames/Australia.txt
+++ b/src/timezone/tznames/Australia.txt
@@ -21,6 +21,7 @@ CAST    34200    # Central Australia Standard Time (not in zic)
 # CONFLICT! CST is not unique
 # Other timezones:
 #  - CST: Central Standard Time (America)
+#  - CST: China Standard Time (Asia)
 #  - CST: Cuba Central Standard Time (America)
 CST     34200    # Central Standard Time (Australia)
                  #     (Australia/Adelaide)

--- a/src/timezone/tznames/Default
+++ b/src/timezone/tznames/Default
@@ -106,6 +106,7 @@ CLT    -14400    # Chile Time
 # CONFLICT! CST is not unique
 # Other timezones:
 #  - CST: Central Standard Time (Australia)
+#  - CST: China Standard Time (Asia)
 #  - CST: Cuba Central Standard Time (America)
 CST    -21600    # Central Standard Time (America)
                  #     (America/Cancun)

--- a/src/timezone/tznames/Makefile
+++ b/src/timezone/tznames/Makefile
@@ -16,7 +16,7 @@ TZNAMES_TEMPLATES = Africa.txt America.txt Antarctica.txt Asia.txt \
 	Atlantic.txt Australia.txt Etc.txt Europe.txt Indian.txt Pacific.txt
 TZNAMES_TEMPLATES_FILES = $(TZNAMES_TEMPLATES:%=$(srcdir)/%)
 
-TZNAMES_SETS = Default Australia India
+TZNAMES_SETS = Default Australia India Asia
 TZNAMES_SETS_FILES = $(TZNAMES_SETS:%=$(srcdir)/%)
 
 install: installdirs


### PR DESCRIPTION
On some platforms, for example, Linux will use CST (China Standard Time)
as time string suffix of GMT+8, hence the external log tables in may be
parsed incorrectly for users in China. Issue #3574.

I tracked that change in Postgres to this commit firstly:

   commit e8dac6f1e09e5bc7604caa6f111d6c80a8b98295
   Author: Tom Lane <tgl@sss.pgh.pa.us>
   Date:   Wed Dec 24 16:35:23 2014 -0500

       Add CST (China Standard Time) to our lists of timezone abbreviations.

       For some reason this seems to have been missed when the lists in
       src/timezone/tznames/ were first constructed.  We can't put it in Default
       because of the conflict with US CST, but we should certainly list it among
       the alternative entries in Asia.txt.  (I checked for other oversights, but
       all the other abbreviations that are in current use according to the IANA
       files seem to be accounted for.)  Noted while responding to bug #12326.

Then add a standard timezone 'Asia' in OVERRIDE mode, and expose it in default list.

With it, we may "set timezone_abbreviations = 'Asia'" to recognize CST naturally,
and also correctly.