### PR TITLE
Fix distribution of rows in CREATE TABLE AS and ORDER BY.

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -2052,12 +2052,17 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 		 * GPDB has also done a partial sort, separately on each node. So
 		 * keep that behavior for now.
 		 *
+		 * A SELECT INTO or CREATE TABLE AS is similar to a subquery: the
+		 * order doesn't really matter, but let's keep the partial order
+		 * anyway.
+		 *
 		 * In a TABLE function's input subquery, a partial order is the
 		 * documented behavior, so in that case that's definitely what we
 		 * want.
 		 */
 		if (result_plan->flow->flotype != FLOW_SINGLETON &&
 			(root->config->honor_order_by || !root->parent_root) &&
+			!parse->intoClause &&
 			!parse->isTableValueSelect &&
 			!parse->limitCount && !parse->limitOffset)
 		{

--- a/src/test/regress/expected/gpctas.out
+++ b/src/test/regress/expected/gpctas.out
@@ -130,3 +130,34 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'x'
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- Test CTAS with VALUES.
 CREATE TEMP TABLE yolo(i, j, k) AS (VALUES (0,0,0), (1, NULL, 0), (2, NULL, 0), (3, NULL, 0)) DISTRIBUTED BY (i);
+--
+-- Test that the rows are distributed correctly in CTAS, even if the query
+-- has an ORDER BY. This used to tickle a bug at one point.
+--
+DROP TABLE IF EXISTS ctas_src, ctas_dst;
+CREATE TABLE ctas_src(
+col1 int4,
+col2 decimal,
+col3 char,
+col4 boolean,
+col5 int
+) DISTRIBUTED by(col4);
+-- I'm not sure why, but dropping a column was crucial to tickling the
+-- original bug.
+ALTER TABLE ctas_src DROP COLUMN col2;
+INSERT INTO ctas_src(col1, col3,col4,col5)
+    SELECT g, 'a',True,g from generate_series(1,5) g;
+CREATE TABLE ctas_dst as SELECT col1,col3,col4,col5 FROM ctas_src order by 1;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'col4' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- This will fail to find some of the rows, if they're distributed incorrectly.
+SELECT * FROM ctas_src, ctas_dst WHERE ctas_src.col1 = ctas_dst.col1
+ col1 | col3 | col4 | col5 | col1 | col3 | col4 | col5 
+------+------+------+------+------+------+------+------
+    1 | a    | t    |    1 |    1 | a    | t    |    1
+    2 | a    | t    |    2 |    2 | a    | t    |    2
+    3 | a    | t    |    3 |    3 | a    | t    |    3
+    4 | a    | t    |    4 |    4 | a    | t    |    4
+    5 | a    | t    |    5 |    5 | a    | t    |    5
+(5 rows)
+


### PR DESCRIPTION
If a CREATE TABLE AS query contained an ORDER BY, the planner put a Motion
node on top of the plan that focuses all the rows to a single node.
However, that was messed up with the re-distribute motion that CREATE TABLE
AS that is supposed to go to the top, to distribute the rows according to
the DISTRIBUTED BY of the table. This used to work before commit
7e268107f3, because we used to not add an explicit Motion node on top of the
plan for ORDER BY, but we just changed the sort-order information in the
Flow.

I have a nagging feeling that the apply_motion code isn't dealing with
Motion on top of a Motion node correctly, because I would've expected to
get a plan like that without this fix. Perhaps apply_motion silentlye
refuses to add a Motion node on top of an existing Motion? That'd be a
silly plan, of course, and the planner doesn't fortunately create such
plans, so I'm not going to dig deeper into that right now.

The test case is a simplified version from one of the
"mpp21090_drop_col_oids_dml_*" TINC tests. I noticed this while moving
those tests over from TINC to the main suite. We only run those tests
in the concourse pipeline with "set optimizer=on", so it didn't catch
this issue with optimizer=off.

Fixes github issue #3577.