### PR TITLE
Remove empty function.

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -393,7 +393,6 @@ aocs_beginrangescan(Relation relation,
 	AOCSFileSegInfo **seginfo;
 	int			i;
 
-	ValidateAppendOnlyMetaDataSnapshot(&appendOnlyMetaDataSnapshot);
 	RelationIncrementReferenceCount(relation);
 
 	seginfo = palloc0(sizeof(AOCSFileSegInfo *) * segfile_count);
@@ -421,7 +420,6 @@ aocs_beginscan(Relation relation,
 	AOCSFileSegInfo **seginfo;
 	int			total_seg;
 
-	ValidateAppendOnlyMetaDataSnapshot(&appendOnlyMetaDataSnapshot);
 	RelationIncrementReferenceCount(relation);
 
 	seginfo = GetAllAOCSFileSegInfo(relation, appendOnlyMetaDataSnapshot, &total_seg);
@@ -1155,9 +1153,6 @@ aocs_fetch_init(Relation relation,
 	char	   *basePath = relpath(relation->rd_node);
 	TupleDesc	tupleDesc = RelationGetDescr(relation);
 	StdRdOptions **opts = RelationGetAttributeOptions(relation);
-
-	ValidateAppendOnlyMetaDataSnapshot(&appendOnlyMetaDataSnapshot);
-
 
 	/*
 	 * increment relation ref count while scanning relation

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -1648,8 +1648,6 @@ appendonly_beginrangescan_internal(Relation relation,
 
 	StringInfoData titleBuf;
 
-	ValidateAppendOnlyMetaDataSnapshot(&appendOnlyMetaDataSnapshot);
-
 	/*
 	 * increment relation ref count while scanning relation
 	 *
@@ -2173,8 +2171,7 @@ appendonly_fetch_init(Relation relation,
 
 	AppendOnlyStorageAttributes *attr;
 
-	ValidateAppendOnlyMetaDataSnapshot(&appendOnlyMetaDataSnapshot);
-	PGFunction *fns = NULL;
+	PGFunction *fns;
 
 	StringInfoData titleBuf;
 

--- a/src/backend/access/appendonly/appendonlywriter.c
+++ b/src/backend/access/appendonly/appendonlywriter.c
@@ -2049,10 +2049,3 @@ AtEOXact_AppendOnly(void)
 
 	appendOnlyInsertXact = false;
 }
-
-void
-ValidateAppendOnlyMetaDataSnapshot(
-								   Snapshot *appendOnlyMetaDataSnapshot)
-{
-	/* Placeholder. */
-}

--- a/src/include/access/appendonlywriter.h
+++ b/src/include/access/appendonlywriter.h
@@ -231,7 +231,4 @@ extern void AtCommit_AppendOnly(void);
 extern void AtAbort_AppendOnly(void);
 extern void AtEOXact_AppendOnly(void);
 
-extern void ValidateAppendOnlyMetaDataSnapshot(
-								   Snapshot *appendOnlyMetaDataSnapshot);
-
 #endif							/* APPENDONLYWRITER_H */


### PR DESCRIPTION
I have no idea what it was a placeholder for. But it's surely useless in
its current form.