### PR TITLE
Set optimizer GUC explicitly in the test to avoid warnings on missing…

### DIFF
--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/commit_create_tests/post_sql/expected/commit_subt_create_table_ao_post.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/commit_create_tests/post_sql/expected/commit_subt_create_table_ao_post.ans
@@ -1,7 +1,7 @@
 -- start_ignore
 -- end_ignore
-analyze;
-ANALYZE
+set optimizer_print_missing_stats=off;
+SET
 select count (*) from commit_subt_tab_distby_ao1 ;
  count 
 -------

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/commit_create_tests/post_sql/sql/commit_subt_create_table_ao_post.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/commit_create_tests/post_sql/sql/commit_subt_create_table_ao_post.sql
@@ -1,4 +1,4 @@
-analyze;
+set optimizer_print_missing_stats=off;
 select count (*) from commit_subt_tab_distby_ao1 ;
 select count (*) from commit_subt_tab_distby_ao2 ;
 select count (*) from commit_subt_tab_distby_ao3 ;


### PR DESCRIPTION
… stats.

The select count(*) queries would cause missing stats warnings causing diffs.
One way to fix this was to build stats by running analyze.  But this SQL query
is run concurrently with drop table on paritioned tables.  Concurrently running
drop and analyze is found to cause intermittent failures such as "could not get
estimated number of tuples and pages for relation <OID>".  We fix this instead
by explicitly turning optimizer_print_missing_stats GUC off in the SQL file.

Signed-off-by: Asim R P <apraveen@pivotal.io>