### PR TITLE
Resgroup: Add hook for resource group assignment

### DIFF
--- a/src/backend/utils/resgroup/test/Makefile
+++ b/src/backend/utils/resgroup/test/Makefile
@@ -1,0 +1,12 @@
+subdir=src/backend/utils/resgroup
+top_builddir=../../../../..
+include $(top_builddir)/src/Makefile.global
+
+TARGETS=resgroup
+
+include $(top_builddir)/src/backend/mock.mk
+
+resgroup.t: \
+	$(MOCK_DIR)/backend/commands/resgroupcmds_mock.o \
+	$(MOCK_DIR)/backend/utils/init/miscinit_mock.o \
+	$(MOCK_DIR)/backend/utils/misc/superuser_mock.o

--- a/src/backend/utils/resgroup/test/resgroup_test.c
+++ b/src/backend/utils/resgroup/test/resgroup_test.c
@@ -1,0 +1,77 @@
+#include "../resgroup.c"
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include "cmockery.h"
+
+#define test_with_setup_and_teardown(test_func) \
+	unit_test_setup_teardown(test_func, setup, teardown)
+
+void
+setup(void **state)
+{
+	/* reset the hook function pointer to avoid test pollution. */
+	resgroup_assign_hook = NULL;
+}
+
+void
+teardown(void **state)
+{
+	/* No-op for now. This is just to make CMockery happy. */
+}
+
+Oid decide_resource_group_fake_rv = InvalidOid;
+
+Oid
+decide_resource_group_fake()
+{
+	return decide_resource_group_fake_rv;
+}
+
+void
+test__decideResGroupId_when_resgroup_assign_hook_is_not_set(void **state)
+{
+	will_return(GetUserId, 1);
+
+	expect_value(GetResGroupIdForRole, roleid, 1);
+	will_return(GetResGroupIdForRole, 9);
+
+	assert_int_equal(decideResGroupId(), 9);
+}
+
+void
+test__decideResGroupId_when_resgroup_assign_hook_is_set(void **state)
+{
+	decide_resource_group_fake_rv = (Oid) 5;
+	resgroup_assign_hook = decide_resource_group_fake;
+	assert_int_equal(decideResGroupId(), 5);
+}
+
+void
+test__decideResGroupId_when_resgroup_assign_hook_returns_InvalidOid(void **state)
+{
+	decide_resource_group_fake_rv = InvalidOid;
+	resgroup_assign_hook = decide_resource_group_fake;
+
+	will_return(GetUserId, 2);
+
+	expect_value(GetResGroupIdForRole, roleid, 2);
+	will_return(GetResGroupIdForRole, 3);
+
+	assert_int_equal(decideResGroupId(), 3);
+}
+
+int
+main(int argc, char *argv[])
+{
+	cmockery_parse_arguments(argc, argv);
+
+	const UnitTest tests[] = {
+			test_with_setup_and_teardown(test__decideResGroupId_when_resgroup_assign_hook_is_not_set),
+			test_with_setup_and_teardown(test__decideResGroupId_when_resgroup_assign_hook_is_set),
+			test_with_setup_and_teardown(test__decideResGroupId_when_resgroup_assign_hook_returns_InvalidOid),
+	};
+
+	run_tests(tests);
+}

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -100,7 +100,16 @@ extern int gp_resource_group_cpu_priority;
 extern double gp_resource_group_cpu_limit;
 extern double gp_resource_group_memory_limit;
 
-/* Type of statistic infomation */
+/*
+ * Resource Group assignment hook.
+ *
+ * This hook can be set by an extension to control how queries are assigned to
+ * a resource group.
+ */
+typedef Oid (*resgroup_assign_hook_type)(void);
+extern PGDLLIMPORT resgroup_assign_hook_type resgroup_assign_hook;
+
+/* Type of statistic information */
 typedef enum
 {
 	RES_GROUP_STAT_UNKNOWN = -1,


### PR DESCRIPTION
If set, resgroup_assign_hook is called during transaction setup to allow
an extension to change how a transaction is assigned to a resource group
from the default behavior of assigning based on pg_authid.rolresgroup.