### PR TITLE
Set optimizer GUC explicitly in the test to avoid warnings on missing…

### DIFF
--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/abort_abort_create_needed_tests/post_sql/test_postsqls.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/abort_abort_create_needed_tests/post_sql/test_postsqls.py
@@ -21,7 +21,7 @@ Post sqls for commit_create tests
 '''
 class TestPostSQLClass(SQLTestCase):
     """
-    @gucs gp_create_table_random_default_distribution=off
+    @gucs gp_create_table_random_default_distribution=off;optimizer_print_missing_stats=off
     """
 
     sql_dir = 'sql/'

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/abort_abort_create_needed_tests/pre_sql/test_pre_sqls.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/abort_abort_create_needed_tests/pre_sql/test_pre_sqls.py
@@ -21,7 +21,7 @@ Pre sqls for commit_create test
 '''
 class TestPreSQLClass(SQLTestCase):
     """
-    @gucs gp_create_table_random_default_distribution=off
+    @gucs gp_create_table_random_default_distribution=off;optimizer_print_missing_stats=off
     """
 
     sql_dir = 'sql/'

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/abort_abort_create_needed_tests/trigger_sql/test_triggersqls.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/abort_abort_create_needed_tests/trigger_sql/test_triggersqls.py
@@ -22,7 +22,7 @@ Trigger sqls for create_commit tests
 class TestTriggerSQLClass(SQLTestCase):
     '''
     This class contains all the sqls that are part of the trigger phase
-    @gucs gp_create_table_random_default_distribution=off
+    @gucs gp_create_table_random_default_distribution=off;optimizer_print_missing_stats=off
     The sqls in here will get suspended by one of the faults that are triggered in the main run
 
     @gpdiff False

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/abort_create_needed_tests/post_sql/test_postsqls.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/abort_create_needed_tests/post_sql/test_postsqls.py
@@ -21,7 +21,7 @@ Post sqls for commit_create tests
 '''
 class TestPostSQLClass(SQLTestCase):
     """
-    @gucs gp_create_table_random_default_distribution=off
+    @gucs gp_create_table_random_default_distribution=off;optimizer_print_missing_stats=off
     """
 
     sql_dir = 'sql/'

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/abort_create_needed_tests/pre_sql/test_pre_sqls.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/abort_create_needed_tests/pre_sql/test_pre_sqls.py
@@ -21,7 +21,7 @@ Pre sqls for commit_create test
 '''
 class TestPreSQLClass(SQLTestCase):
     """
-    @gucs gp_create_table_random_default_distribution=off
+    @gucs gp_create_table_random_default_distribution=off;optimizer_print_missing_stats=off
     """
 
     sql_dir = 'sql/'

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/abort_create_needed_tests/trigger_sql/test_triggersqls.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/abort_create_needed_tests/trigger_sql/test_triggersqls.py
@@ -23,7 +23,7 @@ class TestTriggerSQLClass(SQLTestCase):
     '''
     This class contains all the sqls that are part of the trigger phase
     The sqls in here will get suspended by one of the faults that are triggered in the main run
-    @gucs gp_create_table_random_default_distribution=off
+    @gucs gp_create_table_random_default_distribution=off;optimizer_print_missing_stats=off
     @gpdiff False
     '''
     sql_dir = 'sql/'

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/abort_create_tests/post_sql/test_postsqls.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/abort_create_tests/post_sql/test_postsqls.py
@@ -21,7 +21,7 @@ Post sqls for commit_create tests
 '''
 class TestPostSQLClass(SQLTestCase):
     """
-    @gucs gp_create_table_random_default_distribution=off
+    @gucs gp_create_table_random_default_distribution=off;optimizer_print_missing_stats=off
     """
 
     sql_dir = 'sql/'

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/abort_create_tests/pre_sql/test_pre_sqls.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/abort_create_tests/pre_sql/test_pre_sqls.py
@@ -21,7 +21,7 @@ Pre sqls for commit_create test
 '''
 class TestPreSQLClass(SQLTestCase):
     """
-    @gucs gp_create_table_random_default_distribution=off
+    @gucs gp_create_table_random_default_distribution=off;optimizer_print_missing_stats=off
     """
 
     sql_dir = 'sql/'

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/abort_create_tests/trigger_sql/test_triggersqls.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/abort_create_tests/trigger_sql/test_triggersqls.py
@@ -23,7 +23,7 @@ class TestTriggerSQLClass(SQLTestCase):
     '''
     This class contains all the sqls that are part of the trigger phase
     The sqls in here will get suspended by one of the faults that are triggered in the main run
-    @gucs gp_create_table_random_default_distribution=off
+    @gucs gp_create_table_random_default_distribution=off;optimizer_print_missing_stats=off
     @gpdiff False
     '''
     sql_dir = 'sql/'

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/commit_create_tests/post_sql/expected/commit_subt_create_table_ao_post.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/commit_create_tests/post_sql/expected/commit_subt_create_table_ao_post.ans
@@ -1,7 +1,5 @@
 -- start_ignore
 -- end_ignore
-analyze;
-ANALYZE
 select count (*) from commit_subt_tab_distby_ao1 ;
  count 
 -------

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/commit_create_tests/post_sql/sql/commit_subt_create_table_ao_post.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/commit_create_tests/post_sql/sql/commit_subt_create_table_ao_post.sql
@@ -1,4 +1,3 @@
-analyze;
 select count (*) from commit_subt_tab_distby_ao1 ;
 select count (*) from commit_subt_tab_distby_ao2 ;
 select count (*) from commit_subt_tab_distby_ao3 ;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/commit_create_tests/post_sql/test_postsqls.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/commit_create_tests/post_sql/test_postsqls.py
@@ -21,7 +21,7 @@ Post sqls for commit_create tests
 '''
 class TestPostSQLClass(SQLTestCase):
     """
-    @gucs gp_create_table_random_default_distribution=off
+    @gucs gp_create_table_random_default_distribution=off;optimizer_print_missing_stats=off
     """
 
     sql_dir = 'sql/'

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/commit_create_tests/pre_sql/test_pre_sqls.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/commit_create_tests/pre_sql/test_pre_sqls.py
@@ -21,7 +21,7 @@ Pre sqls for commit_create test
 '''
 class TestPreSQLClass(SQLTestCase):
     """
-    @gucs gp_create_table_random_default_distribution=off
+    @gucs gp_create_table_random_default_distribution=off;optimizer_print_missing_stats=off
     """
 
     sql_dir = 'sql/'

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/commit_create_tests/trigger_sql/test_triggersqls.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/commit_create_tests/trigger_sql/test_triggersqls.py
@@ -23,7 +23,7 @@ class TestTriggerSQLClass(SQLTestCase):
     '''
     This class contains all the sqls that are part of the trigger phase
     The sqls in here will get suspended by one of the faults that are triggered in the main run
-    @gucs gp_create_table_random_default_distribution=off
+    @gucs gp_create_table_random_default_distribution=off;optimizer_print_missing_stats=off
     @gpdiff False
     '''
     sql_dir = 'sql/'

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/commit_drop_tests/post_sql/test_postsqls.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/commit_drop_tests/post_sql/test_postsqls.py
@@ -21,7 +21,7 @@ Post sqls for commit_create tests
 '''
 class TestPostSQLClass(SQLTestCase):
     """
-    @gucs gp_create_table_random_default_distribution=off
+    @gucs gp_create_table_random_default_distribution=off;optimizer_print_missing_stats=off
     """
 
     sql_dir = 'sql/'

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/commit_drop_tests/pre_sql/test_pre_sqls.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/commit_drop_tests/pre_sql/test_pre_sqls.py
@@ -21,7 +21,7 @@ Pre sqls for commit_create test
 '''
 class TestPreSQLClass(SQLTestCase):
     """
-    @gucs gp_create_table_random_default_distribution=off
+    @gucs gp_create_table_random_default_distribution=off;optimizer_print_missing_stats=off
     """
 
     sql_dir = 'sql/'

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/commit_drop_tests/trigger_sql/test_triggersqls.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/commit_drop_tests/trigger_sql/test_triggersqls.py
@@ -23,7 +23,7 @@ class TestTriggerSQLClass(SQLTestCase):
     '''
     This class contains all the sqls that are part of the trigger phase
     The sqls in here will get suspended by one of the faults that are triggered in the main run
-    @gucs gp_create_table_random_default_distribution=off
+    @gucs gp_create_table_random_default_distribution=off;optimizer_print_missing_stats=off
     @gpdiff False
     '''
     sql_dir = 'sql/'

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/test_crash_recovery_schema_topology.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/test_crash_recovery_schema_topology.py
@@ -25,7 +25,7 @@ from mpp.gpdb.tests.storage.lib import Database
 
 class CrashRecoverySchemaTopologyTestCase(ScenarioTestCase):
     """
-    @gucs gp_create_table_random_default_distribution=off
+    @gucs gp_create_table_random_default_distribution=off;optimizer_print_missing_stats=off
     """
 
     def __init__(self, methodName):

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/test_suspendcheckpoint_crashrecovery_04_to_10.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/test_suspendcheckpoint_crashrecovery_04_to_10.py
@@ -27,7 +27,7 @@ from mpp.lib.filerep_util import Filerepe2e_Util
 class SuspendcheckpointCrashrecoveryTestCase(ScenarioTestCase):
     ''' 
     Testing state of prepared transactions upon crash-recovery
-    @gucs gp_create_table_random_default_distribution=off
+    @gucs gp_create_table_random_default_distribution=off;optimizer_print_missing_stats=off
     '''
 
     def __init__(self, methodName):

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/test_suspendcheckpoint_crashrecovery_11_to_20.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/test_suspendcheckpoint_crashrecovery_11_to_20.py
@@ -28,7 +28,7 @@ class SuspendcheckpointCrashrecoveryTestCase(ScenarioTestCase):
 
     '''
     Testing state of prepared transactions upon crash-recovery
-    @gucs gp_create_table_random_default_distribution=off
+    @gucs gp_create_table_random_default_distribution=off;optimizer_print_missing_stats=off
     '''
 
     def __init__(self, methodName):

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/test_suspendcheckpoint_crashrecovery_21_to_30.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/test_suspendcheckpoint_crashrecovery_21_to_30.py
@@ -27,7 +27,7 @@ from mpp.lib.filerep_util import Filerepe2e_Util
 class SuspendcheckpointCrashrecoveryTestCase(ScenarioTestCase):
     '''
      Testing state of prepared transactions upon crash-recovery
-    @gucs gp_create_table_random_default_distribution=off
+    @gucs gp_create_table_random_default_distribution=off;optimizer_print_missing_stats=off
     '''
 
     def __init__(self, methodName):

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/test_suspendcheckpoint_crashrecovery_31_to_42.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/test_suspendcheckpoint_crashrecovery_31_to_42.py
@@ -27,7 +27,7 @@ from mpp.lib.filerep_util import Filerepe2e_Util
 class SuspendcheckpointCrashrecoveryTestCase(ScenarioTestCase):
     '''
     Testing state of prepared transactions upon crash-recovery
-    @gucs gp_create_table_random_default_distribution=off
+    @gucs gp_create_table_random_default_distribution=off;optimizer_print_missing_stats=off
     '''
 
     def __init__(self, methodName):


### PR DESCRIPTION
… stats.

The select count(*) queries would cause missing stats warnings causing diffs.
One way to fix this was to build stats by running analyze.  But this SQL query
is run concurrently with drop table on paritioned tables.  Concurrently running
drop and analyze is found to cause intermittent failures such as "could not get
estimated number of tuples and pages for relation <OID>".  We fix this instead
by explicitly turning optimizer_print_missing_stats GUC off in python test
files.

Signed-off-by: Asim R P <apraveen@pivotal.io>