### PR TITLE
 Fix python unit-test test pollution

### DIFF
--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_utils.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_utils.py
@@ -2,6 +2,7 @@
 #
 # Copyright (c) Greenplum Inc 2008. All Rights Reserved.
 #
+import sys
 
 from gppylib.commands.base import ExecutionError
 from gppylib.operations.utils import RemoteOperation, ParallelOperation
@@ -15,6 +16,13 @@ class UtilsTestCase(GpTestCase):
     """
     Requires GPHOME set. Does actual ssh to localhost.
     """
+
+    def setUp(self):
+        self.old_sys_argv = sys.argv
+        sys.argv = ['utils.py']
+
+    def tearDown(self):
+        sys.argv = self.old_sys_argv
 
     def test_Remote_basic(self):
         """ Basic RemoteOperation test """

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_utils.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (c) Greenplum Inc 2008. All Rights Reserved. 
+# Copyright (c) Greenplum Inc 2008. All Rights Reserved.
 #
 
 from gppylib.commands.base import ExecutionError
@@ -71,7 +71,7 @@ class UtilsTestCase(GpTestCase):
         except ExecutionError, e:
             self.assertTrue(e.cmd.get_results().stderr.strip().endswith("raise pg.DatabaseError()"))
         else:
-            self.fail("""A pg.DatabaseError should have been raised remotely, and because it cannot 
+            self.fail("""A pg.DatabaseError should have been raised remotely, and because it cannot
                          be pickled cleanly (due to a strange import in pickle.py),
                          an ExecutionError should have ultimately been caused.""")
             # TODO: Check logs on disk. With gplogfilter?

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpexpand.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpexpand.py
@@ -19,6 +19,7 @@ class GpExpand(GpTestCase):
         #   self.subject = gpexpand
         gpexpand_file = os.path.abspath(os.path.dirname(__file__) + "/../../../gpexpand")
         self.subject = imp.load_source('gpexpand', gpexpand_file)
+        self.old_sys_argv = sys.argv
         sys.argv = []  # We need to do this otherwise, the parser will read the command line as the default arguments.
         self.options, self.args, self.parser = self.subject.parseargs()
 
@@ -64,6 +65,7 @@ class GpExpand(GpTestCase):
 
     def tearDown(self):
         os.environ['MASTER_DATA_DIRECTORY'] = self.previous_master_data_directory
+        sys.argv = self.old_sys_argv
         super(GpExpand, self).tearDown()
 
     def test_PrepFileSpaces_issues_correct_postgres_command(self):

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpssh.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpssh.py
@@ -17,7 +17,11 @@ class GpSshTestCase(GpTestCase):
         gpssh_file = os.path.abspath(os.path.dirname(__file__) + "/../../../gpssh")
         self.subject = imp.load_source('gpssh', gpssh_file)
 
+        self.old_sys_argv = sys.argv
         sys.argv = []
+
+    def tearDown(self):
+        sys.argv = self.old_sys_argv
 
     @patch('sys.exit')
     def test_when_run_without_args_prints_help_text(self, sys_exit_mock):


### PR DESCRIPTION
There are tests that rely on sys.argv and some tests reset this variable.
Ensure that we are saving the old value and resetting it at tear down.

Signed-off-by: Karen Huddleston <khuddleston@pivotal.io>

This will be back-ported to 5.X branch.