### PR TITLE
Remove unstable test UPDATE.

### DIFF
--- a/src/test/regress/expected/qp_dml_joins.out
+++ b/src/test/regress/expected/qp_dml_joins.out
@@ -2189,9 +2189,6 @@ ERROR:  Cannot parallelize an UPDATE statement that updates the distribution col
 -- test4: Negative test - Update moving tuple across partition .also violates the check constraint
 UPDATE dml_heap_check_s SET a = 110 + dml_heap_check_s.a FROM dml_heap_check_r WHERE dml_heap_check_r.a = dml_heap_check_s.a ; 
 ERROR:  moving tuple from partition "dml_heap_check_s_1_prt_2" to partition "dml_heap_check_s_1_prt_def" not supported  (seg0 127.0.0.1:40000 pid=18972)
--- test5: Negative test - Update violates multiple check constraint
-UPDATE dml_heap_check_s SET a = 110 + dml_heap_check_s.a, b = NULL  FROM dml_heap_check_r WHERE dml_heap_check_r.b = dml_heap_check_s.b;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 -- test4: Delete with generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_s;

--- a/src/test/regress/expected/qp_dml_joins_optimizer.out
+++ b/src/test/regress/expected/qp_dml_joins_optimizer.out
@@ -2189,9 +2189,6 @@ ERROR:  new row for relation "dml_heap_check_s_1_prt_5" violates check constrain
 -- test4: Negative test - Update moving tuple across partition .also violates the check constraint
 UPDATE dml_heap_check_s SET a = 110 + dml_heap_check_s.a FROM dml_heap_check_r WHERE dml_heap_check_r.a = dml_heap_check_s.a;
 ERROR:  new row for relation "dml_heap_check_s_1_prt_def" violates check constraint "dml_heap_check_s_a_check"
--- test5: Negative test - Update violates multiple check constraint
-UPDATE dml_heap_check_s SET a = 110 + dml_heap_check_s.a, b = NULL  FROM dml_heap_check_r WHERE dml_heap_check_r.b = dml_heap_check_s.b;
-ERROR:  new row for relation "dml_heap_check_s_1_prt_def" violates check constraint "scheck_b"
 -- test4: Delete with generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_s;

--- a/src/test/regress/sql/qp_dml_joins.sql
+++ b/src/test/regress/sql/qp_dml_joins.sql
@@ -969,9 +969,6 @@ UPDATE dml_heap_check_s SET b = NULL FROM dml_heap_check_r WHERE dml_heap_check_
 -- test4: Negative test - Update moving tuple across partition .also violates the check constraint
 UPDATE dml_heap_check_s SET a = 110 + dml_heap_check_s.a FROM dml_heap_check_r WHERE dml_heap_check_r.a = dml_heap_check_s.a;
 
--- test5: Negative test - Update violates multiple check constraint
-UPDATE dml_heap_check_s SET a = 110 + dml_heap_check_s.a, b = NULL  FROM dml_heap_check_r WHERE dml_heap_check_r.b = dml_heap_check_s.b;
-
 -- test4: Delete with generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_s;


### PR DESCRIPTION
This test UPDATE violates two constraints, and it's arbitrary which one it
fails on first. That's problematic, because the error message depends on
which constraint happens to be checked first.

We have tests for testing each failure individually, so testing a case that
fails them both doesn't seem very interesting. We will never reach the
actualy failure of both at the same time, because we bail out on first
error. So to make the output stable, remove the offending UPDATE.