### PR TITLE
pipeline: remove gpcheckcat from remaining pulse tab

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -109,7 +109,6 @@ groups:
 
 - name: Remaining Pulse
   jobs:
-  - MM_gpcheckcat
   - mpp_interconnect
 
 - name: Adopted CCP


### PR DESCRIPTION
gpcheckcat is already on terraform.
This change was missed when moving gpcheckcat from pulse to terraform.

This will be back-ported to 5X_STABLE.