### PR TITLE
Remove insert test to validate duplicate row constraint

### DIFF
--- a/src/test/regress/expected/qp_dml_joins.out
+++ b/src/test/regress/expected/qp_dml_joins.out
@@ -254,7 +254,7 @@ INSERT INTO dml_heap_pt_p VALUES(NULL,1,'pn',NULL),(1,NULL,'pn',0),(NULL,NULL,'p
 INSERT INTO dml_heap_pt_s SELECT generate_series(1,100), generate_series(1,100) * 3,'s', generate_series(1,100) % 6;
 INSERT INTO dml_heap_pt_s VALUES(generate_series(1,10),NULL,'sn',NULL);
 INSERT INTO dml_heap_pt_s VALUES(NULL,1,'sn',NULL),(1,NULL,'sn',0),(NULL,NULL,'sn',0),(0,1,'sn',NULL),(NULL,NULL,'sn',NULL);
--- test1: Insert data that satisfy the check constraints
+--Insert data that satisfy the check constraints
 begin;
 SELECT COUNT(*) FROM dml_ao_check_s;
  count 
@@ -276,7 +276,7 @@ SELECT COUNT(*) FROM dml_ao_check_s;
 (1 row)
 
 rollback;
--- test2: Negative test - Insert default value violates check constraint
+--Negative test - Insert default value violates check constraint
 SELECT COUNT(*) FROM dml_ao_check_p;
  count 
 -------
@@ -291,7 +291,7 @@ SELECT COUNT(*) FROM dml_ao_check_p;
    105
 (1 row)
 
--- test3: Negative test - Insert default value violates NOT NULL constraint
+--Negative test - Insert default value violates NOT NULL constraint
 SELECT COUNT(*) FROM dml_ao_check_s;
  count 
 -------
@@ -306,28 +306,7 @@ SELECT COUNT(*) FROM dml_ao_check_s;
    105
 (1 row)
 
--- test4: Negative test - Insert with joins where the result tuples violate the user defined check constraint
-SELECT COUNT(*) FROM dml_ao_check_r;
- count 
--------
-   105
-(1 row)
-
-SELECT COUNT(*) FROM (SELECT dml_ao_check_r.a + 110 , dml_ao_check_r.b, dml_ao_check_r.c, dml_ao_check_r.d FROM dml_ao_check_r, dml_ao_check_s WHERE dml_ao_check_r.a = dml_ao_check_s.a)foo;
- count 
--------
-   107
-(1 row)
-
-INSERT INTO dml_ao_check_r SELECT dml_ao_check_r.a + 110 , dml_ao_check_r.b, dml_ao_check_r.c, dml_ao_check_r.d FROM dml_ao_check_r, dml_ao_check_s WHERE dml_ao_check_r.a = dml_ao_check_s.a AND dml_ao_check_r.b > 10;
-ERROR:  new row for relation "dml_ao_check_r_1_prt_def" violates check constraint "dml_ao_check_r_a_check"  (seg0 127.0.0.1:40000 pid=18972)
-SELECT COUNT(*) FROM dml_ao_check_r;
- count 
--------
-   105
-(1 row)
-
--- test5: Insert with joins where the result tuples violate violates multiple check constraints
+--Insert with joins where the result tuples violate violates multiple check constraints
 SELECT COUNT(*) FROM dml_ao_check_r;
  count 
 -------
@@ -348,7 +327,7 @@ SELECT COUNT(*) FROM dml_ao_check_r;
    105
 (1 row)
 
--- test4: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_r;
  count 
@@ -370,7 +349,7 @@ SELECT COUNT(*) FROM dml_ao_pt_r;
 (1 row)
 
 rollback;
--- test5: Insert with generate_series and NULL
+--Insert with generate_series and NULL
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_r;
  count 
@@ -404,7 +383,7 @@ SELECT COUNT(*) FROM dml_ao_pt_r;
 (1 row)
 
 rollback;
--- test6: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_r;
  count 
@@ -442,7 +421,7 @@ SELECT COUNT(*) FROM dml_ao_pt_r;
 (1 row)
 
 rollback;
--- test7: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_r;
  count 
@@ -464,7 +443,7 @@ SELECT COUNT(*) FROM dml_ao_pt_r;
 (1 row)
 
 rollback;
--- test8: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_r;
  count 
@@ -480,7 +459,7 @@ SELECT COUNT(*) FROM dml_ao_pt_r;
 (1 row)
 
 rollback;
--- test9: Join on the non-distribution key of target table
+--Join on the non-distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_r;
  count 
@@ -502,7 +481,7 @@ SELECT COUNT(*) FROM dml_ao_pt_r;
 (1 row)
 
 rollback;
--- test10: Join on the distribution key of target table
+--Join on the distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_s;
  count 
@@ -524,7 +503,7 @@ SELECT COUNT(*) FROM dml_ao_pt_s;
 (1 row)
 
 rollback;
--- test11: Join on distribution key of target table
+--Join on distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_r;
  count 
@@ -546,7 +525,7 @@ SELECT COUNT(*) FROM dml_ao_pt_r;
 (1 row)
 
 rollback;
--- test12: Join on the distribution key of target table. Insert Large number of rows
+--Join on the distribution key of target table. Insert Large number of rows
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_s;
  count 
@@ -568,7 +547,7 @@ SELECT COUNT(*) FROM dml_ao_pt_s;
 (1 row)
 
 rollback;
--- test13: Join with different column order 
+--Join with different column order 
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_r;
  count 
@@ -590,7 +569,7 @@ SELECT COUNT(*) FROM dml_ao_pt_r;
 (1 row)
 
 rollback;
--- test14: Join with Aggregate
+--Join with Aggregate
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_r;
  count 
@@ -613,7 +592,7 @@ SELECT COUNT(*) FROM dml_ao_pt_r;
 (1 row)
 
 rollback;
--- test15: Join with DISTINCT
+--Join with DISTINCT
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_s;
  count 
@@ -635,7 +614,7 @@ SELECT COUNT(*) FROM dml_ao_pt_s;
 (1 row)
 
 rollback;
--- test16: Insert NULL with Joins
+--Insert NULL with Joins
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_r;
  count 
@@ -657,7 +636,7 @@ SELECT COUNT(*) FROM dml_ao_pt_r;
 (1 row)
 
 rollback;
--- test18: Insert 0 rows
+--Insert 0 rows
 SELECT COUNT(*) FROM dml_ao_pt_r;
  count 
 -------
@@ -671,7 +650,7 @@ SELECT COUNT(*) FROM dml_ao_pt_r;
    100
 (1 row)
 
--- test19: Insert 0 rows
+--Insert 0 rows
 SELECT COUNT(*) FROM dml_ao_pt_r;
  count 
 -------
@@ -685,7 +664,7 @@ SELECT COUNT(*) FROM dml_ao_pt_r;
    100
 (1 row)
 
--- test20: Negative tests Insert column of different data type
+--Negative tests Insert column of different data type
 SELECT COUNT(*) FROM dml_ao_pt_r;
  count 
 -------
@@ -706,7 +685,7 @@ SELECT COUNT(*) FROM dml_ao_pt_r;
    100
 (1 row)
 
--- test21: Negative test case. INSERT has more expressions than target columns
+--Negative test case. INSERT has more expressions than target columns
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_s;
  count 
@@ -728,7 +707,7 @@ SELECT COUNT(*) FROM dml_ao_pt_s;
 (1 row)
 
 rollback;
--- test22: Insert with join on the partition key
+--Insert with join on the partition key
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_r;
  count 
@@ -750,7 +729,7 @@ SELECT COUNT(*) FROM dml_ao_pt_r;
 (1 row)
 
 rollback;
--- test24: Negative test - Insert NULL value to a table without default partition
+--Negative test - Insert NULL value to a table without default partition
 SELECT COUNT(*) FROM dml_ao_pt_r;
  count 
 -------
@@ -771,7 +750,7 @@ SELECT COUNT(*) FROM dml_ao_pt_r;
    100
 (1 row)
 
--- test25: Negative test - Insert out of partition range values for table without default partition
+--Negative test - Insert out of partition range values for table without default partition
 SELECT COUNT(*) FROM dml_ao_pt_r;
  count 
 -------
@@ -792,7 +771,7 @@ SELECT COUNT(*) FROM dml_ao_pt_r;
    100
 (1 row)
 
--- test4: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_ao_r;
  count 
@@ -814,7 +793,7 @@ SELECT COUNT(*) FROM dml_ao_r;
 (1 row)
 
 rollback;
--- test5: Insert with generate_series and NULL
+--Insert with generate_series and NULL
 begin;
 SELECT COUNT(*) FROM dml_ao_r;
  count 
@@ -845,7 +824,7 @@ SELECT COUNT(*) FROM dml_ao_r;
 (1 row)
 
 rollback;
--- test6: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_ao_r;
  count 
@@ -877,7 +856,7 @@ SELECT COUNT(*) FROM dml_ao_r;
 (1 row)
 
 rollback;
--- test7: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_ao_r;
  count 
@@ -899,7 +878,7 @@ SELECT COUNT(*) FROM dml_ao_r;
 (1 row)
 
 rollback;
--- test8: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_ao_r;
  count 
@@ -915,7 +894,7 @@ SELECT COUNT(*) FROM dml_ao_r;
 (1 row)
 
 rollback;
--- test9: Join on the non-distribution key of target table
+--Join on the non-distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_ao_r;
  count 
@@ -937,7 +916,7 @@ SELECT COUNT(*) FROM dml_ao_r;
 (1 row)
 
 rollback;
--- test10: Join on the distribution key of target table
+--Join on the distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_ao_s;
  count 
@@ -959,7 +938,7 @@ SELECT COUNT(*) FROM dml_ao_s;
 (1 row)
 
 rollback;
--- test11: Join on distribution key of target table
+--Join on distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_ao_r;
  count 
@@ -981,7 +960,7 @@ SELECT COUNT(*) FROM dml_ao_r;
 (1 row)
 
 rollback;
--- test12: Join on the distribution key of target table. Insert Large number of rows
+--Join on the distribution key of target table. Insert Large number of rows
 begin;
 SELECT COUNT(*) FROM dml_ao_s;
  count 
@@ -1003,7 +982,7 @@ SELECT COUNT(*) FROM dml_ao_s;
 (1 row)
 
 rollback;
--- test13: Join with different column order 
+--Join with different column order 
 begin;
 SELECT COUNT(*) FROM dml_ao_r;
  count 
@@ -1025,7 +1004,7 @@ SELECT COUNT(*) FROM dml_ao_r;
 (1 row)
 
 rollback;
--- test14: Join with Aggregate
+--Join with Aggregate
 begin;
 SELECT COUNT(*) FROM dml_ao_r;
  count 
@@ -1047,7 +1026,7 @@ SELECT COUNT(*) FROM dml_ao_r;
 (1 row)
 
 rollback;
--- test15: Join with DISTINCT
+--Join with DISTINCT
 begin;
 SELECT COUNT(*) FROM dml_ao_s;
  count 
@@ -1069,7 +1048,7 @@ SELECT COUNT(*) FROM dml_ao_s;
 (1 row)
 
 rollback;
--- test16: Insert NULL with Joins
+--Insert NULL with Joins
 begin;
 SELECT COUNT(*) FROM dml_ao_r;
  count 
@@ -1091,7 +1070,7 @@ SELECT COUNT(*) FROM dml_ao_r;
 (1 row)
 
 rollback;
--- test17: Insert and CASE
+--Insert and CASE
 begin;
 SELECT COUNT(*) FROM dml_ao_r;
  count 
@@ -1113,7 +1092,7 @@ SELECT COUNT(*) FROM dml_ao_r;
 (1 row)
 
 rollback;
--- test18: Insert 0 rows
+--Insert 0 rows
 SELECT COUNT(*) FROM dml_ao_r;
  count 
 -------
@@ -1127,7 +1106,7 @@ SELECT COUNT(*) FROM dml_ao_r;
    113
 (1 row)
 
--- test19: Insert 0 rows
+--Insert 0 rows
 SELECT COUNT(*) FROM dml_ao_r;
  count 
 -------
@@ -1141,7 +1120,7 @@ SELECT COUNT(*) FROM dml_ao_r;
    113
 (1 row)
 
--- test21: Negative test case. INSERT has more expressions than target columns
+--Negative test case. INSERT has more expressions than target columns
 SELECT COUNT(*) FROM dml_ao_s;
  count 
 -------
@@ -1162,7 +1141,7 @@ SELECT COUNT(*) FROM dml_ao_s;
    113
 (1 row)
 
--- test1: Insert data that satisfy the check constraints 
+--Insert data that satisfy the check constraints 
 begin;
 SELECT COUNT(*) FROM dml_co_check_s;
  count 
@@ -1184,7 +1163,7 @@ SELECT COUNT(*) FROM dml_co_check_s;
 (1 row)
 
 rollback;
--- test2: Negative test - Insert default value violates check constraint
+--Negative test - Insert default value violates check constraint
 SELECT COUNT(*) FROM dml_co_check_p;
  count 
 -------
@@ -1199,7 +1178,7 @@ SELECT COUNT(*) FROM dml_co_check_p;
    105
 (1 row)
 
--- test3: Negative test - Insert default value violates NOT NULL constraint
+--Negative test - Insert default value violates NOT NULL constraint
 SELECT COUNT(*) FROM dml_co_check_s;
  count 
 -------
@@ -1214,7 +1193,7 @@ SELECT COUNT(*) FROM dml_co_check_s;
    105
 (1 row)
 
--- test4: Negative test - Insert with joins where the result tuples violate the user defined check constraint
+--Negative test - Insert with joins where the result tuples violate the user defined check constraint
 SELECT COUNT(*) FROM dml_co_check_r;
  count 
 -------
@@ -1235,7 +1214,7 @@ SELECT COUNT(*) FROM dml_co_check_r;
    105
 (1 row)
 
--- test5: Insert with joins where the result tuples violate violates multiple check constraints
+--Insert with joins where the result tuples violate violates multiple check constraints
 SELECT COUNT(*) FROM dml_co_check_r;
  count 
 -------
@@ -1256,7 +1235,7 @@ SELECT COUNT(*) FROM dml_co_check_r;
    105
 (1 row)
 
--- test4: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_co_pt_r;
  count 
@@ -1278,7 +1257,7 @@ SELECT COUNT(*) FROM dml_co_pt_r;
 (1 row)
 
 rollback;
--- test5: Insert with generate_series and NULL
+--Insert with generate_series and NULL
 begin;
 SELECT COUNT(*) FROM dml_co_pt_r;
  count 
@@ -1312,7 +1291,7 @@ SELECT COUNT(*) FROM dml_co_pt_r;
 (1 row)
 
 rollback;
--- test6: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_co_pt_r;
  count 
@@ -1350,7 +1329,7 @@ SELECT COUNT(*) FROM dml_co_pt_r;
 (1 row)
 
 rollback;
--- test7: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_co_pt_r;
  count 
@@ -1372,7 +1351,7 @@ SELECT COUNT(*) FROM dml_co_pt_r;
 (1 row)
 
 rollback;
--- test8: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_co_pt_r;
  count 
@@ -1388,7 +1367,7 @@ SELECT COUNT(*) FROM dml_co_pt_r;
 (1 row)
 
 rollback;
--- test9: Join on the non-distribution key of target table
+--Join on the non-distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_co_pt_r;
  count 
@@ -1410,7 +1389,7 @@ SELECT COUNT(*) FROM dml_co_pt_r;
 (1 row)
 
 rollback;
--- test10: Join on the distribution key of target table
+--Join on the distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_co_pt_s;
  count 
@@ -1432,7 +1411,7 @@ SELECT COUNT(*) FROM dml_co_pt_s;
 (1 row)
 
 rollback;
--- test11: Join on distribution key of target table
+--Join on distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_co_pt_r;
  count 
@@ -1454,7 +1433,7 @@ SELECT COUNT(*) FROM dml_co_pt_r;
 (1 row)
 
 rollback;
--- test12: Join on the distribution key of target table. Insert Large number of rows
+--Join on the distribution key of target table. Insert Large number of rows
 begin;
 SELECT COUNT(*) FROM dml_co_pt_s;
  count 
@@ -1476,7 +1455,7 @@ SELECT COUNT(*) FROM dml_co_pt_s;
 (1 row)
 
 rollback;
--- test13: Join with different column order 
+--Join with different column order 
 begin;
 SELECT COUNT(*) FROM dml_co_pt_r;
  count 
@@ -1498,7 +1477,7 @@ SELECT COUNT(*) FROM dml_co_pt_r;
 (1 row)
 
 rollback;
--- test14: Join with Aggregate
+--Join with Aggregate
 begin;
 SELECT COUNT(*) FROM dml_co_pt_r;
  count 
@@ -1521,7 +1500,7 @@ SELECT COUNT(*) FROM dml_co_pt_r;
 (1 row)
 
 rollback;
--- test15: Join with DISTINCT
+--Join with DISTINCT
 begin;
 SELECT COUNT(*) FROM dml_co_pt_s;
  count 
@@ -1543,7 +1522,7 @@ SELECT COUNT(*) FROM dml_co_pt_s;
 (1 row)
 
 rollback;
--- test16: Insert NULL with Joins
+--Insert NULL with Joins
 begin;
 SELECT COUNT(*) FROM dml_co_pt_r;
  count 
@@ -1565,7 +1544,7 @@ SELECT COUNT(*) FROM dml_co_pt_r;
 (1 row)
 
 rollback;
--- test18: Insert 0 rows
+--Insert 0 rows
 SELECT COUNT(*) FROM dml_co_pt_r;
  count 
 -------
@@ -1579,7 +1558,7 @@ SELECT COUNT(*) FROM dml_co_pt_r;
    100
 (1 row)
 
--- test19: Insert 0 rows
+--Insert 0 rows
 SELECT COUNT(*) FROM dml_co_pt_r;
  count 
 -------
@@ -1593,7 +1572,7 @@ SELECT COUNT(*) FROM dml_co_pt_r;
    100
 (1 row)
 
--- test21: Negative test case. INSERT has more expressions than target columns
+--Negative test case. INSERT has more expressions than target columns
 begin;
 SELECT COUNT(*) FROM dml_co_pt_s;
  count 
@@ -1615,7 +1594,7 @@ SELECT COUNT(*) FROM dml_co_pt_s;
 (1 row)
 
 rollback;
--- test22: Insert with join on the partition key
+--Insert with join on the partition key
 begin;
 SELECT COUNT(*) FROM dml_co_pt_r;
  count 
@@ -1637,7 +1616,7 @@ SELECT COUNT(*) FROM dml_co_pt_r;
 (1 row)
 
 rollback;
--- test24: Negative test - Insert NULL value to a table without default partition
+--Negative test - Insert NULL value to a table without default partition
 SELECT COUNT(*) FROM dml_co_pt_r;
  count 
 -------
@@ -1658,7 +1637,7 @@ SELECT COUNT(*) FROM dml_co_pt_r;
    100
 (1 row)
 
--- test25: Negative test - Insert out of partition range values for table without default partition
+--Negative test - Insert out of partition range values for table without default partition
 SELECT COUNT(*) FROM dml_co_pt_r;
  count 
 -------
@@ -1673,7 +1652,7 @@ SELECT COUNT(*) FROM dml_co_pt_r;
    100
 (1 row)
 
--- test4: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_co_r;
  count 
@@ -1695,7 +1674,7 @@ SELECT COUNT(*) FROM dml_co_r;
 (1 row)
 
 rollback;
--- test5: Insert with generate_series and NULL
+--Insert with generate_series and NULL
 begin;
 SELECT COUNT(*) FROM dml_co_r;
  count 
@@ -1726,7 +1705,7 @@ SELECT COUNT(*) FROM dml_co_r;
 (1 row)
 
 rollback;
--- test6: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_co_r;
  count 
@@ -1764,7 +1743,7 @@ SELECT COUNT(*) FROM dml_co_r;
 (1 row)
 
 rollback;
--- test7: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_co_r;
  count 
@@ -1786,7 +1765,7 @@ SELECT COUNT(*) FROM dml_co_r;
 (1 row)
 
 rollback;
--- test8: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_co_r;
  count 
@@ -1802,7 +1781,7 @@ SELECT COUNT(*) FROM dml_co_r;
 (1 row)
 
 rollback;
--- test9: Join on the non-distribution key of target table
+--Join on the non-distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_co_r;
  count 
@@ -1824,7 +1803,7 @@ SELECT COUNT(*) FROM dml_co_r;
 (1 row)
 
 rollback;
--- test10: Join on the distribution key of target table
+--Join on the distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_co_s;
  count 
@@ -1846,7 +1825,7 @@ SELECT COUNT(*) FROM dml_co_s;
 (1 row)
 
 rollback;
--- test11: Join on distribution key of target table
+--Join on distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_co_r;
  count 
@@ -1868,7 +1847,7 @@ SELECT COUNT(*) FROM dml_co_r;
 (1 row)
 
 rollback;
--- test12: Join on the distribution key of target table. Insert Large number of rows
+--Join on the distribution key of target table. Insert Large number of rows
 begin;
 SELECT COUNT(*) FROM dml_co_s;
  count 
@@ -1890,7 +1869,7 @@ SELECT COUNT(*) FROM dml_co_s;
 (1 row)
 
 rollback;
--- test13: Join with different column order 
+--Join with different column order 
 begin;
 SELECT COUNT(*) FROM dml_co_r;
  count 
@@ -1912,7 +1891,7 @@ SELECT COUNT(*) FROM dml_co_r;
 (1 row)
 
 rollback;
--- test14: Join with Aggregate
+--Join with Aggregate
 begin;
 SELECT COUNT(*) FROM dml_co_r;
  count 
@@ -1934,7 +1913,7 @@ SELECT COUNT(*) FROM dml_co_r;
 (1 row)
 
 rollback;
--- test15: Join with DISTINCT
+--Join with DISTINCT
 begin;
 SELECT COUNT(*) FROM dml_co_s;
  count 
@@ -1956,7 +1935,7 @@ SELECT COUNT(*) FROM dml_co_s;
 (1 row)
 
 rollback;
--- test16: Insert NULL with Joins
+--Insert NULL with Joins
 begin;
 SELECT COUNT(*) FROM dml_co_r;
  count 
@@ -1978,7 +1957,7 @@ SELECT COUNT(*) FROM dml_co_r;
 (1 row)
 
 rollback;
--- test17: Insert and CASE
+--Insert and CASE
 begin;
 SELECT COUNT(*) FROM dml_co_r;
  count 
@@ -2000,7 +1979,7 @@ SELECT COUNT(*) FROM dml_co_r;
 (1 row)
 
 rollback;
--- test18: Insert 0 rows
+--Insert 0 rows
 SELECT COUNT(*) FROM dml_co_r;
  count 
 -------
@@ -2014,7 +1993,7 @@ SELECT COUNT(*) FROM dml_co_r;
    113
 (1 row)
 
--- test19: Insert 0 rows
+--Insert 0 rows
 SELECT COUNT(*) FROM dml_co_r;
  count 
 -------
@@ -2028,7 +2007,7 @@ SELECT COUNT(*) FROM dml_co_r;
    113
 (1 row)
 
--- test20: Negative tests Insert column of different data type
+--Negative tests Insert column of different data type
 SELECT COUNT(*) FROM dml_co_r;
  count 
 -------
@@ -2049,7 +2028,7 @@ SELECT COUNT(*) FROM dml_co_r;
    113
 (1 row)
 
--- test21: Negative test case. INSERT has more expressions than target columns
+--Negative test case. INSERT has more expressions than target columns
 SELECT COUNT(*) FROM dml_co_s;
  count 
 -------
@@ -2070,7 +2049,7 @@ SELECT COUNT(*) FROM dml_co_s;
    113
 (1 row)
 
--- test1: Insert data that satisfy the check constraints 
+--Insert data that satisfy the check constraints 
 begin;
 SELECT COUNT(*) FROM dml_heap_check_s;
  count 
@@ -2092,7 +2071,7 @@ SELECT COUNT(*) FROM dml_heap_check_s;
 (1 row)
 
 rollback;
--- test2: Negative test - Insert default value violates check constraint
+--Negative test - Insert default value violates check constraint
 SELECT COUNT(*) FROM dml_heap_check_p;
  count 
 -------
@@ -2107,7 +2086,7 @@ SELECT COUNT(*) FROM dml_heap_check_p;
    105
 (1 row)
 
--- test3: Negative test - Insert default value violates NOT NULL constraint
+--Negative test - Insert default value violates NOT NULL constraint
 SELECT COUNT(*) FROM dml_heap_check_s;
  count 
 -------
@@ -2122,7 +2101,7 @@ SELECT COUNT(*) FROM dml_heap_check_s;
    105
 (1 row)
 
--- test4: Negative test - Insert with joins where the result tuples violate the user defined check constraint
+--Negative test - Insert with joins where the result tuples violate the user defined check constraint
 SELECT COUNT(*) FROM dml_heap_check_r;
  count 
 -------
@@ -2143,7 +2122,7 @@ SELECT COUNT(*) FROM dml_heap_check_r;
    105
 (1 row)
 
--- test5: Insert with joins where the result tuples violate violates multiple check constraints
+--Insert with joins where the result tuples violate violates multiple check constraints
 SELECT COUNT(*) FROM dml_heap_check_r;
  count 
 -------
@@ -2164,7 +2143,7 @@ SELECT COUNT(*) FROM dml_heap_check_r;
    105
 (1 row)
 
--- test1: Update data that satisfy the check constraints 
+--Update data that satisfy the check constraints 
 begin;
 SELECT SUM(d) FROM dml_heap_check_s;
  sum 
@@ -2180,16 +2159,16 @@ SELECT SUM(d) FROM dml_heap_check_s;
 (1 row)
 
 rollback;
--- test2: Negative test: Update data that does not satisfy the check constraints
+--Negative test: Update data that does not satisfy the check constraints
 UPDATE dml_heap_check_s SET a = 100 + dml_heap_check_s.a FROM dml_heap_check_r WHERE dml_heap_check_r.a = dml_heap_check_s.a AND dml_heap_check_s.a = 99;
 ERROR:  moving tuple from partition "dml_heap_check_s_1_prt_11" to partition "dml_heap_check_s_1_prt_def" not supported  (seg0 127.0.0.1:40000 pid=18972)
--- test3: Negative test - Update violates check constraint(not NULL constraint)
+--Negative test - Update violates check constraint(not NULL constraint)
 UPDATE dml_heap_check_s SET b = NULL FROM dml_heap_check_r WHERE dml_heap_check_r.a = dml_heap_check_s.b and dml_heap_check_s.b = 99;
 ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
--- test4: Negative test - Update moving tuple across partition .also violates the check constraint
+--Negative test - Update moving tuple across partition .also violates the check constraint
 UPDATE dml_heap_check_s SET a = 110 + dml_heap_check_s.a FROM dml_heap_check_r WHERE dml_heap_check_r.a = dml_heap_check_s.a ; 
 ERROR:  moving tuple from partition "dml_heap_check_s_1_prt_2" to partition "dml_heap_check_s_1_prt_def" not supported  (seg0 127.0.0.1:40000 pid=18972)
--- test4: Delete with generate_series
+--Delete with generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_s;
  count 
@@ -2205,7 +2184,7 @@ SELECT COUNT(*) FROM dml_heap_s;
 (1 row)
 
 rollback;
--- test5: Delete with join on distcol
+--Delete with join on distcol
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
  count 
@@ -2221,7 +2200,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test6: Delete with join on non-distribution column
+--Delete with join on non-distribution column
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
  count 
@@ -2237,7 +2216,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test7: Delete with join on non-distribution column
+--Delete with join on non-distribution column
 begin;
 SELECT COUNT(*) FROM dml_heap_s;
  count 
@@ -2253,7 +2232,7 @@ SELECT COUNT(*) FROM dml_heap_s;
 (1 row)
 
 rollback;
--- test8: Delete and using  
+--Delete and using  
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
  count 
@@ -2269,7 +2248,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test9: Delete and using (with no rows)
+--Delete and using (with no rows)
 begin;
 TRUNCATE TABLE dml_heap_s;
 SELECT COUNT(*) FROM dml_heap_r;
@@ -2286,7 +2265,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test10: Delete with join in using
+--Delete with join in using
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
  count 
@@ -2302,7 +2281,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test11: Delete with join in USING (Delete all rows )
+--Delete with join in USING (Delete all rows )
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
  count 
@@ -2318,7 +2297,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test12: Delete with join in using
+--Delete with join in using
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
  count 
@@ -2334,7 +2313,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test13: Delete with multiple joins
+--Delete with multiple joins
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
  count 
@@ -2350,7 +2329,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test14: Delete on table with composite distcol
+--Delete on table with composite distcol
 begin;
 SELECT COUNT(*) FROM dml_heap_p;
  count 
@@ -2366,7 +2345,7 @@ SELECT COUNT(*) FROM dml_heap_p;
 (1 row)
 
 rollback;
--- test15: Delete with PREPARE plan
+--Delete with PREPARE plan
 begin;
 SELECT COUNT(*) FROM (SELECT dml_heap_r.b FROM dml_heap_r,dml_heap_s WHERE dml_heap_r.b = dml_heap_s.b) foo;
  count 
@@ -2389,7 +2368,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test16: Delete with PREPARE plan
+--Delete with PREPARE plan
 begin;
 SELECT COUNT(*) FROM (SELECT dml_heap_r.b FROM dml_heap_r,dml_heap_s WHERE dml_heap_r.a = dml_heap_s.a)foo;
  count 
@@ -2412,7 +2391,7 @@ SELECT COUNT(*) FROM dml_heap_s;
 (1 row)
 
 rollback;
--- test17: Delete with sub-query
+--Delete with sub-query
 SELECT COUNT(*) FROM dml_heap_s;
  count 
 -------
@@ -2427,7 +2406,7 @@ SELECT COUNT(*) FROM dml_heap_s;
    113
 (1 row)
 
--- test1: Delete from table
+--Delete from table
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_s; 
  count 
@@ -2443,7 +2422,7 @@ SELECT COUNT(*) FROM dml_heap_pt_s;
 (1 row)
 
 rollback;
--- test2: Delete with predicate
+--Delete with predicate
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_s;
  count 
@@ -2471,7 +2450,7 @@ SELECT COUNT(*) FROM dml_heap_pt_s WHERE a > 100;
 (1 row)
 
 rollback;
--- test3: Delete with predicate
+--Delete with predicate
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_s;
  count 
@@ -2493,7 +2472,7 @@ SELECT COUNT(*) FROM dml_heap_pt_s;
 (1 row)
 
 rollback;
--- test4: Delete with generate_series
+--Delete with generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_s;
  count 
@@ -2509,7 +2488,7 @@ SELECT COUNT(*) FROM dml_heap_pt_s;
 (1 row)
 
 rollback;
--- test5: Delete with join on distcol
+--Delete with join on distcol
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
@@ -2525,7 +2504,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test6: Delete with join on non-distribution column
+--Delete with join on non-distribution column
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
@@ -2541,7 +2520,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test7: Delete with join on non-distribution column
+--Delete with join on non-distribution column
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_s;
  count 
@@ -2557,7 +2536,7 @@ SELECT COUNT(*) FROM dml_heap_pt_s;
 (1 row)
 
 rollback;
--- test8: Delete and using  
+--Delete and using  
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
@@ -2573,7 +2552,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test9: Delete and using (with no rows)
+--Delete and using (with no rows)
 begin;
 TRUNCATE TABLE dml_heap_pt_s;
 SELECT COUNT(*) FROM dml_heap_pt_r;
@@ -2590,7 +2569,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test10: Delete with join in using
+--Delete with join in using
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
@@ -2606,7 +2585,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test11: Delete with join in USING (Delete all rows )
+--Delete with join in USING (Delete all rows )
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
@@ -2622,7 +2601,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test12: Delete with join in using
+--Delete with join in using
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
@@ -2638,7 +2617,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test13: Delete with multiple joins
+--Delete with multiple joins
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
@@ -2654,7 +2633,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test14: Delete on table with composite distcol
+--Delete on table with composite distcol
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_p;
  count 
@@ -2670,7 +2649,7 @@ SELECT COUNT(*) FROM dml_heap_pt_p;
 (1 row)
 
 rollback;
--- test15: Delete with PREPARE plan
+--Delete with PREPARE plan
 begin;
 SELECT COUNT(*) FROM (SELECT dml_heap_pt_r.b FROM dml_heap_pt_r,dml_heap_pt_s WHERE dml_heap_pt_r.b = dml_heap_pt_s.b) foo;
  count 
@@ -2693,7 +2672,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test16: Delete with PREPARE plan
+--Delete with PREPARE plan
 begin;
 SELECT COUNT(*) FROM (SELECT dml_heap_pt_r.b FROM dml_heap_pt_r,dml_heap_pt_s WHERE dml_heap_pt_r.a = dml_heap_pt_s.a)foo;
  count 
@@ -2716,7 +2695,7 @@ SELECT COUNT(*) FROM dml_heap_pt_s;
 (1 row)
 
 rollback;
--- test17: Delete with sub-query
+--Delete with sub-query
 SELECT COUNT(*) FROM dml_heap_pt_s;
  count 
 -------
@@ -2731,7 +2710,7 @@ SELECT COUNT(*) FROM dml_heap_pt_s;
    115
 (1 row)
 
--- test4: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
@@ -2753,7 +2732,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test5: Insert with generate_series and NULL
+--Insert with generate_series and NULL
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
@@ -2787,7 +2766,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test6: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
@@ -2825,7 +2804,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test7: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
@@ -2847,7 +2826,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test8: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
@@ -2863,7 +2842,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test9: Join on the non-distribution key of target table
+--Join on the non-distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
@@ -2885,7 +2864,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test10: Join on the distribution key of target table
+--Join on the distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_s;
  count 
@@ -2907,7 +2886,7 @@ SELECT COUNT(*) FROM dml_heap_pt_s;
 (1 row)
 
 rollback;
--- test11: Join on distribution key of target table
+--Join on distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
@@ -2929,7 +2908,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test12: Join on the distribution key of target table. Insert Large number of rows
+--Join on the distribution key of target table. Insert Large number of rows
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_s;
  count 
@@ -2951,7 +2930,7 @@ SELECT COUNT(*) FROM dml_heap_pt_s;
 (1 row)
 
 rollback;
--- test13: Join with different column order 
+--Join with different column order 
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
@@ -2973,7 +2952,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test14: Join with Aggregate
+--Join with Aggregate
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
@@ -2998,7 +2977,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 ALTER TABLE dml_heap_pt_r DROP DEFAULT partition;
 NOTICE:  dropped partition "def" for relation "dml_heap_pt_r"
 rollback;
--- test15: Join with DISTINCT
+--Join with DISTINCT
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_s;
  count 
@@ -3020,7 +2999,7 @@ SELECT COUNT(*) FROM dml_heap_pt_s;
 (1 row)
 
 rollback;
--- test16: Insert NULL with Joins
+--Insert NULL with Joins
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
@@ -3042,7 +3021,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test18: Insert 0 rows
+--Insert 0 rows
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
 -------
@@ -3056,7 +3035,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
    100
 (1 row)
 
--- test19: Insert 0 rows
+--Insert 0 rows
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
 -------
@@ -3070,7 +3049,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
    100
 (1 row)
 
--- test20: Negative tests Insert column of different data type
+--Negative tests Insert column of different data type
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
 -------
@@ -3091,7 +3070,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
    100
 (1 row)
 
--- test21: Negative test case. INSERT has more expressions than target columns
+--Negative test case. INSERT has more expressions than target columns
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_s;
  count 
@@ -3113,7 +3092,7 @@ SELECT COUNT(*) FROM dml_heap_pt_s;
 (1 row)
 
 rollback;
--- test22: Insert with join on the partition key
+--Insert with join on the partition key
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
@@ -3135,7 +3114,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test24: Negative test - Insert NULL value to a table without default partition
+--Negative test - Insert NULL value to a table without default partition
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
 -------
@@ -3150,7 +3129,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
    100
 (1 row)
 
--- test25: Negative test - Insert out of partition range values for table without default partition
+--Negative test - Insert out of partition range values for table without default partition
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
 -------
@@ -3165,7 +3144,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
    100
 (1 row)
 
--- update_test1: Update to constant value
+--Update to constant value
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE c ='text';
  count 
@@ -3181,7 +3160,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r WHERE c ='text';
 (1 row)
 
 rollback;
--- update_test2: Update and set distribution key to constant
+--Update and set distribution key to constant
 begin;
 SELECT COUNT(*) FROM (SELECT DISTINCT(b) FROM dml_heap_pt_s)foo;
  count 
@@ -3194,7 +3173,7 @@ ERROR:  Cannot parallelize an UPDATE statement that updates the distribution col
 SELECT COUNT(*) FROM (SELECT DISTINCT(b) FROM dml_heap_pt_s)foo;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
--- update_test3: Update to default value
+--Update to default value
 begin;
 SELECT SUM(a) FROM dml_heap_pt_r;
  sum  
@@ -3207,7 +3186,7 @@ ERROR:  Cannot parallelize an UPDATE statement that updates the distribution col
 SELECT SUM(a) FROM dml_heap_pt_r;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
--- update_test4: Update to default value
+--Update to default value
 begin;
 SELECT SUM(a) FROM dml_heap_pt_r;
  sum  
@@ -3229,7 +3208,7 @@ ERROR:  current transaction is aborted, commands ignored until end of transactio
 SELECT SUM(b) FROM dml_heap_pt_r;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
--- update_test5: Update and reset the value
+--Update and reset the value
 begin;
 SELECT COUNT(*) FROM (SELECT DISTINCT(a) FROM dml_heap_pt_r)foo;
  count 
@@ -3245,7 +3224,7 @@ SELECT COUNT(*) FROM (SELECT DISTINCT(a) FROM dml_heap_pt_r)foo;
 (1 row)
 
 rollback;
--- update_test6: Update and generate_series
+--Update and generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE a = 1;
  count 
@@ -3266,7 +3245,7 @@ ERROR:  current transaction is aborted, commands ignored until end of transactio
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE a = 1;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
--- update_test7: Update distcol where join on target table non dist key
+--Update distcol where join on target table non dist key
 begin;
 SELECT SUM(a) FROM dml_heap_pt_r;
  sum  
@@ -3279,7 +3258,7 @@ ERROR:  Cannot parallelize an UPDATE statement that updates the distribution col
 SELECT SUM(a) FROM dml_heap_pt_r;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
--- update_test8: Update and from values
+--Update and from values
 begin;
 SELECT * FROM dml_heap_pt_r WHERE b = 20 ORDER BY 1;
  a | b | c | d 
@@ -3291,7 +3270,7 @@ ERROR:  Cannot parallelize an UPDATE statement that updates the distribution col
 SELECT * FROM dml_heap_pt_r WHERE b = 20 ORDER BY 1;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
--- update_test9: Update with Joins and set to constant value
+--Update with Joins and set to constant value
 SELECT COUNT(*) FROM dml_heap_pt_s WHERE b = 10;
  count 
 -------
@@ -3306,12 +3285,12 @@ SELECT COUNT(*) FROM dml_heap_pt_s WHERE b = 10;
      0
 (1 row)
 
--- update_test10: Update distcol with predicate in subquery
+--Update distcol with predicate in subquery
 begin;
 UPDATE dml_heap_pt_r SET a = dml_heap_pt_r.a + 1 FROM dml_heap_pt_s WHERE dml_heap_pt_r.b = dml_heap_pt_s.a and dml_heap_pt_s.b in (SELECT dml_heap_pt_s.b + dml_heap_pt_r.a FROM dml_heap_pt_s,dml_heap_pt_r WHERE dml_heap_pt_r.a > 10);
 ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 rollback;
--- update_test11: Update with aggregate in subquery
+--Update with aggregate in subquery
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_s WHERE b = (SELECT COUNT(*) FROM dml_heap_pt_s);
  count 
@@ -3330,7 +3309,7 @@ ERROR:  Cannot parallelize an UPDATE statement that updates the distribution col
 SELECT COUNT(*) FROM dml_heap_pt_s WHERE b = (SELECT COUNT(*) FROM dml_heap_pt_s);
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
--- update_test12: Update and limit in subquery
+--Update and limit in subquery
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE a = 1;
  count 
 -------
@@ -3351,7 +3330,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r WHERE a = 1;
      1
 (1 row)
 
--- update_test13: Update multiple columns
+--Update multiple columns
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE b is NULL;
  count 
@@ -3381,7 +3360,7 @@ ERROR:  current transaction is aborted, commands ignored until end of transactio
 ALTER TABLE dml_heap_pt_r DROP DEFAULT partition;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
--- update_test14: Update multiple columns
+--Update multiple columns
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE c='z';
  count 
 -------
@@ -3410,14 +3389,14 @@ SELECT COUNT(*) FROM dml_heap_pt_r WHERE c='z';
 
 ALTER TABLE dml_heap_pt_r DROP DEFAULT partition;
 NOTICE:  dropped partition "def" for relation "dml_heap_pt_r"
--- update_test15: Update with prepare plans
+--Update with prepare plans
 begin;
 PREPARE plan_upd as UPDATE dml_heap_pt_r SET a = dml_heap_pt_s.a +1 FROM dml_heap_pt_s WHERE dml_heap_pt_r.a = dml_heap_pt_s.b ;
 ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 EXECUTE plan_upd;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
--- update_test16: Update and case
+--Update and case
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE a = 20 ;
  count 
@@ -3430,7 +3409,7 @@ ERROR:  Cannot parallelize an UPDATE statement that updates the distribution col
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE a = 20 ;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
--- update_test17: Negative test - Update with sub-query returning more than one row
+--Negative test - Update with sub-query returning more than one row
 SELECT SUM(a) FROM dml_heap_pt_r;
  sum  
 ------
@@ -3445,7 +3424,7 @@ SELECT SUM(a) FROM dml_heap_pt_r;
  5050
 (1 row)
 
--- update_test18: Negative test - Update with sub-query returning more than one row
+--Negative test - Update with sub-query returning more than one row
 SELECT SUM(b) FROM dml_heap_pt_r;
   sum  
 -------
@@ -3460,7 +3439,7 @@ SELECT SUM(b) FROM dml_heap_pt_r;
  15150
 (1 row)
 
--- update_test20: Negative test - Update WHERE join returns more than one tuple with different values.
+--Negative test - Update WHERE join returns more than one tuple with different values.
 CREATE TABLE dml_heap_pt_u as SELECT i as a, i as b  FROM generate_series(1,10)i;
 CREATE TABLE dml_heap_pt_v as SELECT i as a, i as b FROM generate_series(1,10)i;
 SELECT SUM(a) FROM dml_heap_pt_v;
@@ -3477,7 +3456,7 @@ SELECT SUM(a) FROM dml_heap_pt_v;
   55
 (1 row)
 
--- update_test21: Update with joins on multiple table
+--Update with joins on multiple table
 begin;
 SELECT SUM(a) FROM dml_heap_pt_r;
  sum  
@@ -3490,7 +3469,7 @@ ERROR:  Cannot parallelize an UPDATE statement that updates the distribution col
 SELECT SUM(a) FROM dml_heap_pt_r;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
--- update_test22: Update on table with composite distribution key
+--Update on table with composite distribution key
 -- This currently falls back to planner, even if ORCA is enabled. And planner can't
 -- produce plans that update distribution key columns.
 SELECT SUM(a) FROM dml_heap_pt_r;
@@ -3507,7 +3486,7 @@ SELECT SUM(a) FROM dml_heap_pt_r;
  5050
 (1 row)
 
--- update_test23: Update on table with composite distribution key
+--Update on table with composite distribution key
 begin;
 SELECT SUM(b) FROM dml_heap_pt_p;
   sum  
@@ -3520,7 +3499,7 @@ ERROR:  Cannot parallelize an UPDATE statement that updates the distribution col
 SELECT SUM(b) FROM dml_heap_pt_p;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
--- test24: Update the partition key and move tuples across partitions( moving tuple to default partition)
+--Update the partition key and move tuples across partitions( moving tuple to default partition)
 begin;
 SELECT SUM(a) FROM dml_heap_pt_s;
  sum  
@@ -3533,7 +3512,7 @@ ERROR:  moving tuple from partition "dml_heap_pt_s_1_prt_2" to partition "dml_he
 SELECT SUM(a) FROM dml_heap_pt_s;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
--- test25: Negative test update partition key (no default partition)
+--Negative test update partition key (no default partition)
 SELECT SUM(b) FROM dml_heap_pt_r;
   sum  
 -------
@@ -3548,7 +3527,7 @@ SELECT SUM(b) FROM dml_heap_pt_r;
  15150
 (1 row)
 
--- test4: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
  count 
@@ -3570,7 +3549,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test5: Insert with generate_series and NULL
+--Insert with generate_series and NULL
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
  count 
@@ -3601,7 +3580,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test6: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
  count 
@@ -3639,7 +3618,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test7: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
  count 
@@ -3661,7 +3640,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test8: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
  count 
@@ -3677,7 +3656,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test9: Join on the non-distribution key of target table
+--Join on the non-distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
  count 
@@ -3699,7 +3678,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test10: Join on the distribution key of target table
+--Join on the distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_heap_s;
  count 
@@ -3721,7 +3700,7 @@ SELECT COUNT(*) FROM dml_heap_s;
 (1 row)
 
 rollback;
--- test11: Join on distribution key of target table
+--Join on distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
  count 
@@ -3743,7 +3722,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test12: Join on the distribution key of target table. Insert Large number of rows
+--Join on the distribution key of target table. Insert Large number of rows
 begin;
 SELECT COUNT(*) FROM dml_heap_s;
  count 
@@ -3765,7 +3744,7 @@ SELECT COUNT(*) FROM dml_heap_s;
 (1 row)
 
 rollback;
--- test13: Join with different column order 
+--Join with different column order 
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
  count 
@@ -3787,7 +3766,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test14: Join with Aggregate
+--Join with Aggregate
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
  count 
@@ -3809,7 +3788,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test15: Join with DISTINCT
+--Join with DISTINCT
 begin;
 SELECT COUNT(*) FROM dml_heap_s;
  count 
@@ -3831,7 +3810,7 @@ SELECT COUNT(*) FROM dml_heap_s;
 (1 row)
 
 rollback;
--- test16: Insert NULL with Joins
+--Insert NULL with Joins
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
  count 
@@ -3853,7 +3832,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test17: Insert and CASE
+--Insert and CASE
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
  count 
@@ -3875,7 +3854,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test18: Insert 0 rows
+--Insert 0 rows
 SELECT COUNT(*) FROM dml_heap_r;
  count 
 -------
@@ -3889,7 +3868,7 @@ SELECT COUNT(*) FROM dml_heap_r;
    113
 (1 row)
 
--- test19: Insert 0 rows
+--Insert 0 rows
 SELECT COUNT(*) FROM dml_heap_r;
  count 
 -------
@@ -3903,7 +3882,7 @@ SELECT COUNT(*) FROM dml_heap_r;
    113
 (1 row)
 
--- test20: Negative tests Insert column of different data type
+--Negative tests Insert column of different data type
 SELECT COUNT(*) FROM dml_heap_r;
  count 
 -------
@@ -3924,7 +3903,7 @@ SELECT COUNT(*) FROM dml_heap_r;
    113
 (1 row)
 
--- test21: Negative test case. INSERT has more expressions than target columns
+--Negative test case. INSERT has more expressions than target columns
 SELECT COUNT(*) FROM dml_heap_s;
  count 
 -------
@@ -3945,7 +3924,7 @@ SELECT COUNT(*) FROM dml_heap_s;
    113
 (1 row)
 
--- update_test6: Update and generate_series
+--Update and generate_series
 begin;
 SELECT SUM(a) FROM dml_heap_r WHERE a = 1;
  sum 
@@ -3966,7 +3945,7 @@ ERROR:  current transaction is aborted, commands ignored until end of transactio
 SELECT SUM(a) FROM dml_heap_r WHERE a = 1;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
--- update_test7: Update distcol where join on target table non dist key
+--Update distcol where join on target table non dist key
 begin;
 SELECT SUM(a) FROM dml_heap_r WHERE a = 1;
  sum 
@@ -3979,7 +3958,7 @@ ERROR:  Cannot parallelize an UPDATE statement that updates the distribution col
 SELECT SUM(a) FROM dml_heap_r WHERE a = 1;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
--- update_test8: Update and from values
+--Update and from values
 begin;
 SELECT SUM(b) FROM dml_heap_r WHERE b = 20;
  sum 
@@ -3992,7 +3971,7 @@ ERROR:  Cannot parallelize an UPDATE statement that updates the distribution col
 SELECT SUM(b) FROM dml_heap_r WHERE b = 20;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
--- update_test9: Update with Joins and set to constant value
+--Update with Joins and set to constant value
 begin;
 SELECT COUNT(*) FROM dml_heap_s WHERE b = 10;
  count 
@@ -4005,12 +3984,12 @@ ERROR:  Cannot parallelize an UPDATE statement that updates the distribution col
 SELECT COUNT(*) FROM dml_heap_s WHERE b = 10;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
--- update_test10: Update distcol with predicate in subquery
+--Update distcol with predicate in subquery
 begin;
 UPDATE dml_heap_r SET a = dml_heap_r.a + 1 FROM dml_heap_s WHERE dml_heap_r.b = dml_heap_s.a and dml_heap_s.b in (SELECT dml_heap_s.b + dml_heap_r.a FROM dml_heap_s,dml_heap_r WHERE dml_heap_r.a > 10);
 ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 rollback;
--- update_test11: Update with aggregate in subquery
+--Update with aggregate in subquery
 begin;
 SELECT COUNT(*) FROM dml_heap_s WHERE b = (SELECT COUNT(*) FROM dml_heap_s);
  count 
@@ -4023,7 +4002,7 @@ ERROR:  Cannot parallelize an UPDATE statement that updates the distribution col
 SELECT COUNT(*) FROM dml_heap_s WHERE b = (SELECT COUNT(*) FROM dml_heap_s);
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
--- update_test12: Update and limit in subquery
+--Update and limit in subquery
 begin;
 SELECT COUNT(*) FROM dml_heap_r WHERE a = 1;
  count 
@@ -4036,7 +4015,7 @@ ERROR:  Cannot parallelize an UPDATE statement that updates the distribution col
 SELECT COUNT(*) FROM dml_heap_r WHERE a = 1;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
--- update_test13: Update multiple columns
+--Update multiple columns
 begin;
 SELECT COUNT(*) FROM dml_heap_r WHERE b is NULL;
  count 
@@ -4063,7 +4042,7 @@ ERROR:  current transaction is aborted, commands ignored until end of transactio
 SELECT COUNT(*) FROM dml_heap_r WHERE b is NULL;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
--- update_test14: Update multiple columns
+--Update multiple columns
 begin;
 SELECT COUNT(*) FROM dml_heap_r WHERE c='z';
  count 
@@ -4084,14 +4063,14 @@ ERROR:  current transaction is aborted, commands ignored until end of transactio
 SELECT COUNT(*) FROM dml_heap_r WHERE c='z';
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
--- update_test15: Update with prepare plans
+--Update with prepare plans
 begin;
 PREPARE plan_upd_2 as UPDATE dml_heap_r SET a = dml_heap_s.a +1 FROM dml_heap_s WHERE dml_heap_r.a = dml_heap_s.b ;
 ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 EXECUTE plan_upd_2;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
--- update_test16: Update and case
+--Update and case
 begin;
 SELECT COUNT(*) FROM dml_heap_r WHERE a = 100 ;
  count 
@@ -4104,7 +4083,7 @@ ERROR:  Cannot parallelize an UPDATE statement that updates the distribution col
 SELECT COUNT(*) FROM dml_heap_r WHERE a = 100 ;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
--- update_test17: Negative test - Update with sub-query returning more than one row
+--Negative test - Update with sub-query returning more than one row
 SELECT SUM(a) FROM dml_heap_r;
  sum  
 ------
@@ -4119,7 +4098,7 @@ SELECT SUM(a) FROM dml_heap_r;
  5106
 (1 row)
 
--- update_test18: Negative test - Update with sub-query returning more than one row
+--Negative test - Update with sub-query returning more than one row
 SELECT SUM(b) FROM dml_heap_r;
  sum  
 ------
@@ -4134,7 +4113,7 @@ SELECT SUM(b) FROM dml_heap_r;
  5050
 (1 row)
 
--- update_test19: Negative test - Update with aggregates 
+--Negative test - Update with aggregates 
 SELECT SUM(b) FROM dml_heap_r;
  sum  
 ------
@@ -4151,7 +4130,7 @@ SELECT SUM(b) FROM dml_heap_r;
  5050
 (1 row)
 
--- update_test20: Negative test - Update WHERE join returns more than one tuple with different values.
+--Negative test - Update WHERE join returns more than one tuple with different values.
 CREATE TABLE dml_heap_u as SELECT i as a, 1 as b  FROM generate_series(1,10)i;
 CREATE TABLE dml_heap_v as SELECT i as a ,i as b FROM generate_series(1,10)i;
 SELECT SUM(a) FROM dml_heap_v;
@@ -4168,12 +4147,12 @@ SELECT SUM(a) FROM dml_heap_v;
   55
 (1 row)
 
--- update_test21: Update with joins on multiple table
+--Update with joins on multiple table
 UPDATE dml_heap_r SET a = dml_heap_r.b+1 FROM dml_heap_p,dml_heap_s WHERE dml_heap_r.b = dml_heap_s.b and dml_heap_r.a = dml_heap_p.b+1;
 ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
--- update_test22: Update on table with composite distribution key
+--Update on table with composite distribution key
 UPDATE dml_heap_p SET a = dml_heap_p.b % 2 FROM dml_heap_r WHERE dml_heap_p.b::int = dml_heap_r.b::int and dml_heap_p.a = dml_heap_r.a;
 ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
--- update_test23: Update on table with composite distribution key
+--Update on table with composite distribution key
 UPDATE dml_heap_p SET b = (dml_heap_p.b * 1.1)::int FROM dml_heap_r WHERE dml_heap_p.b = dml_heap_r.a and dml_heap_p.b = dml_heap_r.b;
 ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns

--- a/src/test/regress/expected/qp_dml_joins_optimizer.out
+++ b/src/test/regress/expected/qp_dml_joins_optimizer.out
@@ -254,7 +254,7 @@ INSERT INTO dml_heap_pt_p VALUES(NULL,1,'pn',NULL),(1,NULL,'pn',0),(NULL,NULL,'p
 INSERT INTO dml_heap_pt_s SELECT generate_series(1,100), generate_series(1,100) * 3,'s', generate_series(1,100) % 6;
 INSERT INTO dml_heap_pt_s VALUES(generate_series(1,10),NULL,'sn',NULL);
 INSERT INTO dml_heap_pt_s VALUES(NULL,1,'sn',NULL),(1,NULL,'sn',0),(NULL,NULL,'sn',0),(0,1,'sn',NULL),(NULL,NULL,'sn',NULL);
--- test1: Insert data that satisfy the check constraints
+--Insert data that satisfy the check constraints
 begin;
 SELECT COUNT(*) FROM dml_ao_check_s;
  count 
@@ -276,7 +276,7 @@ SELECT COUNT(*) FROM dml_ao_check_s;
 (1 row)
 
 rollback;
--- test2: Negative test - Insert default value violates check constraint
+--Negative test - Insert default value violates check constraint
 SELECT COUNT(*) FROM dml_ao_check_p;
  count 
 -------
@@ -284,14 +284,14 @@ SELECT COUNT(*) FROM dml_ao_check_p;
 (1 row)
 
 INSERT INTO dml_ao_check_p select generate_series(1,100),'p', generate_series(1,100);
-ERROR:  new row for relation "dml_ao_check_p" violates check constraint "dml_ao_check_p_check"
+ERROR:  new row for relation "dml_ao_check_p" violates check constraint "dml_ao_check_p_check"  (seg0 127.0.0.1:25432 pid=87948)
 SELECT COUNT(*) FROM dml_ao_check_p;
  count 
 -------
    105
 (1 row)
 
--- test3: Negative test - Insert default value violates NOT NULL constraint
+--Negative test - Insert default value violates NOT NULL constraint
 SELECT COUNT(*) FROM dml_ao_check_s;
  count 
 -------
@@ -306,28 +306,7 @@ SELECT COUNT(*) FROM dml_ao_check_s;
    105
 (1 row)
 
--- test4: Negative test - Insert with joins where the result tuples violate the user defined check constraint
-SELECT COUNT(*) FROM dml_ao_check_r;
- count 
--------
-   105
-(1 row)
-
-SELECT COUNT(*) FROM (SELECT dml_ao_check_r.a + 110 , dml_ao_check_r.b, dml_ao_check_r.c, dml_ao_check_r.d FROM dml_ao_check_r, dml_ao_check_s WHERE dml_ao_check_r.a = dml_ao_check_s.a)foo;
- count 
--------
-   107
-(1 row)
-
-INSERT INTO dml_ao_check_r SELECT dml_ao_check_r.a + 110 , dml_ao_check_r.b, dml_ao_check_r.c, dml_ao_check_r.d FROM dml_ao_check_r, dml_ao_check_s WHERE dml_ao_check_r.a = dml_ao_check_s.a AND dml_ao_check_r.b > 10;
-ERROR:  new row for relation "dml_ao_check_r_1_prt_def" violates check constraint "dml_ao_check_r_a_check"
-SELECT COUNT(*) FROM dml_ao_check_r;
- count 
--------
-   105
-(1 row)
-
--- test5: Insert with joins where the result tuples violate violates multiple check constraints
+--Insert with joins where the result tuples violate violates multiple check constraints
 SELECT COUNT(*) FROM dml_ao_check_r;
  count 
 -------
@@ -348,7 +327,7 @@ SELECT COUNT(*) FROM dml_ao_check_r;
    105
 (1 row)
 
--- test4: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_r;
  count 
@@ -370,7 +349,7 @@ SELECT COUNT(*) FROM dml_ao_pt_r;
 (1 row)
 
 rollback;
--- test5: Insert with generate_series and NULL
+--Insert with generate_series and NULL
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_r;
  count 
@@ -404,7 +383,7 @@ SELECT COUNT(*) FROM dml_ao_pt_r;
 (1 row)
 
 rollback;
--- test6: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_r;
  count 
@@ -442,7 +421,7 @@ SELECT COUNT(*) FROM dml_ao_pt_r;
 (1 row)
 
 rollback;
--- test7: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_r;
  count 
@@ -464,7 +443,7 @@ SELECT COUNT(*) FROM dml_ao_pt_r;
 (1 row)
 
 rollback;
--- test8: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_r;
  count 
@@ -480,7 +459,7 @@ SELECT COUNT(*) FROM dml_ao_pt_r;
 (1 row)
 
 rollback;
--- test9: Join on the non-distribution key of target table
+--Join on the non-distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_r;
  count 
@@ -502,7 +481,7 @@ SELECT COUNT(*) FROM dml_ao_pt_r;
 (1 row)
 
 rollback;
--- test10: Join on the distribution key of target table
+--Join on the distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_s;
  count 
@@ -524,7 +503,7 @@ SELECT COUNT(*) FROM dml_ao_pt_s;
 (1 row)
 
 rollback;
--- test11: Join on distribution key of target table
+--Join on distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_r;
  count 
@@ -546,7 +525,7 @@ SELECT COUNT(*) FROM dml_ao_pt_r;
 (1 row)
 
 rollback;
--- test12: Join on the distribution key of target table. Insert Large number of rows
+--Join on the distribution key of target table. Insert Large number of rows
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_s;
  count 
@@ -568,7 +547,7 @@ SELECT COUNT(*) FROM dml_ao_pt_s;
 (1 row)
 
 rollback;
--- test13: Join with different column order 
+--Join with different column order 
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_r;
  count 
@@ -590,7 +569,7 @@ SELECT COUNT(*) FROM dml_ao_pt_r;
 (1 row)
 
 rollback;
--- test14: Join with Aggregate
+--Join with Aggregate
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_r;
  count 
@@ -613,7 +592,7 @@ SELECT COUNT(*) FROM dml_ao_pt_r;
 (1 row)
 
 rollback;
--- test15: Join with DISTINCT
+--Join with DISTINCT
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_s;
  count 
@@ -635,7 +614,7 @@ SELECT COUNT(*) FROM dml_ao_pt_s;
 (1 row)
 
 rollback;
--- test16: Insert NULL with Joins
+--Insert NULL with Joins
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_r;
  count 
@@ -657,7 +636,7 @@ SELECT COUNT(*) FROM dml_ao_pt_r;
 (1 row)
 
 rollback;
--- test18: Insert 0 rows
+--Insert 0 rows
 SELECT COUNT(*) FROM dml_ao_pt_r;
  count 
 -------
@@ -671,7 +650,7 @@ SELECT COUNT(*) FROM dml_ao_pt_r;
    100
 (1 row)
 
--- test19: Insert 0 rows
+--Insert 0 rows
 SELECT COUNT(*) FROM dml_ao_pt_r;
  count 
 -------
@@ -685,7 +664,7 @@ SELECT COUNT(*) FROM dml_ao_pt_r;
    100
 (1 row)
 
--- test20: Negative tests Insert column of different data type
+--Negative tests Insert column of different data type
 SELECT COUNT(*) FROM dml_ao_pt_r;
  count 
 -------
@@ -706,7 +685,7 @@ SELECT COUNT(*) FROM dml_ao_pt_r;
    100
 (1 row)
 
--- test21: Negative test case. INSERT has more expressions than target columns
+--Negative test case. INSERT has more expressions than target columns
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_s;
  count 
@@ -728,7 +707,7 @@ SELECT COUNT(*) FROM dml_ao_pt_s;
 (1 row)
 
 rollback;
--- test22: Insert with join on the partition key
+--Insert with join on the partition key
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_r;
  count 
@@ -750,7 +729,7 @@ SELECT COUNT(*) FROM dml_ao_pt_r;
 (1 row)
 
 rollback;
--- test24: Negative test - Insert NULL value to a table without default partition
+--Negative test - Insert NULL value to a table without default partition
 SELECT COUNT(*) FROM dml_ao_pt_r;
  count 
 -------
@@ -771,7 +750,7 @@ SELECT COUNT(*) FROM dml_ao_pt_r;
    100
 (1 row)
 
--- test25: Negative test - Insert out of partition range values for table without default partition
+--Negative test - Insert out of partition range values for table without default partition
 SELECT COUNT(*) FROM dml_ao_pt_r;
  count 
 -------
@@ -792,7 +771,7 @@ SELECT COUNT(*) FROM dml_ao_pt_r;
    100
 (1 row)
 
--- test4: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_ao_r;
  count 
@@ -814,7 +793,7 @@ SELECT COUNT(*) FROM dml_ao_r;
 (1 row)
 
 rollback;
--- test5: Insert with generate_series and NULL
+--Insert with generate_series and NULL
 begin;
 SELECT COUNT(*) FROM dml_ao_r;
  count 
@@ -845,7 +824,7 @@ SELECT COUNT(*) FROM dml_ao_r;
 (1 row)
 
 rollback;
--- test6: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_ao_r;
  count 
@@ -877,7 +856,7 @@ SELECT COUNT(*) FROM dml_ao_r;
 (1 row)
 
 rollback;
--- test7: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_ao_r;
  count 
@@ -899,7 +878,7 @@ SELECT COUNT(*) FROM dml_ao_r;
 (1 row)
 
 rollback;
--- test8: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_ao_r;
  count 
@@ -915,7 +894,7 @@ SELECT COUNT(*) FROM dml_ao_r;
 (1 row)
 
 rollback;
--- test9: Join on the non-distribution key of target table
+--Join on the non-distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_ao_r;
  count 
@@ -937,7 +916,7 @@ SELECT COUNT(*) FROM dml_ao_r;
 (1 row)
 
 rollback;
--- test10: Join on the distribution key of target table
+--Join on the distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_ao_s;
  count 
@@ -959,7 +938,7 @@ SELECT COUNT(*) FROM dml_ao_s;
 (1 row)
 
 rollback;
--- test11: Join on distribution key of target table
+--Join on distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_ao_r;
  count 
@@ -981,7 +960,7 @@ SELECT COUNT(*) FROM dml_ao_r;
 (1 row)
 
 rollback;
--- test12: Join on the distribution key of target table. Insert Large number of rows
+--Join on the distribution key of target table. Insert Large number of rows
 begin;
 SELECT COUNT(*) FROM dml_ao_s;
  count 
@@ -1003,7 +982,7 @@ SELECT COUNT(*) FROM dml_ao_s;
 (1 row)
 
 rollback;
--- test13: Join with different column order 
+--Join with different column order 
 begin;
 SELECT COUNT(*) FROM dml_ao_r;
  count 
@@ -1025,7 +1004,7 @@ SELECT COUNT(*) FROM dml_ao_r;
 (1 row)
 
 rollback;
--- test14: Join with Aggregate
+--Join with Aggregate
 begin;
 SELECT COUNT(*) FROM dml_ao_r;
  count 
@@ -1047,7 +1026,7 @@ SELECT COUNT(*) FROM dml_ao_r;
 (1 row)
 
 rollback;
--- test15: Join with DISTINCT
+--Join with DISTINCT
 begin;
 SELECT COUNT(*) FROM dml_ao_s;
  count 
@@ -1069,7 +1048,7 @@ SELECT COUNT(*) FROM dml_ao_s;
 (1 row)
 
 rollback;
--- test16: Insert NULL with Joins
+--Insert NULL with Joins
 begin;
 SELECT COUNT(*) FROM dml_ao_r;
  count 
@@ -1091,7 +1070,7 @@ SELECT COUNT(*) FROM dml_ao_r;
 (1 row)
 
 rollback;
--- test17: Insert and CASE
+--Insert and CASE
 begin;
 SELECT COUNT(*) FROM dml_ao_r;
  count 
@@ -1113,7 +1092,7 @@ SELECT COUNT(*) FROM dml_ao_r;
 (1 row)
 
 rollback;
--- test18: Insert 0 rows
+--Insert 0 rows
 SELECT COUNT(*) FROM dml_ao_r;
  count 
 -------
@@ -1127,7 +1106,7 @@ SELECT COUNT(*) FROM dml_ao_r;
    113
 (1 row)
 
--- test19: Insert 0 rows
+--Insert 0 rows
 SELECT COUNT(*) FROM dml_ao_r;
  count 
 -------
@@ -1141,7 +1120,7 @@ SELECT COUNT(*) FROM dml_ao_r;
    113
 (1 row)
 
--- test21: Negative test case. INSERT has more expressions than target columns
+--Negative test case. INSERT has more expressions than target columns
 SELECT COUNT(*) FROM dml_ao_s;
  count 
 -------
@@ -1162,7 +1141,7 @@ SELECT COUNT(*) FROM dml_ao_s;
    113
 (1 row)
 
--- test1: Insert data that satisfy the check constraints 
+--Insert data that satisfy the check constraints 
 begin;
 SELECT COUNT(*) FROM dml_co_check_s;
  count 
@@ -1184,7 +1163,7 @@ SELECT COUNT(*) FROM dml_co_check_s;
 (1 row)
 
 rollback;
--- test2: Negative test - Insert default value violates check constraint
+--Negative test - Insert default value violates check constraint
 SELECT COUNT(*) FROM dml_co_check_p;
  count 
 -------
@@ -1199,7 +1178,7 @@ SELECT COUNT(*) FROM dml_co_check_p;
    105
 (1 row)
 
--- test3: Negative test - Insert default value violates NOT NULL constraint
+--Negative test - Insert default value violates NOT NULL constraint
 SELECT COUNT(*) FROM dml_co_check_s;
  count 
 -------
@@ -1214,7 +1193,7 @@ SELECT COUNT(*) FROM dml_co_check_s;
    105
 (1 row)
 
--- test4: Negative test - Insert with joins where the result tuples violate the user defined check constraint
+--Negative test - Insert with joins where the result tuples violate the user defined check constraint
 SELECT COUNT(*) FROM dml_co_check_r;
  count 
 -------
@@ -1235,7 +1214,7 @@ SELECT COUNT(*) FROM dml_co_check_r;
    105
 (1 row)
 
--- test5: Insert with joins where the result tuples violate violates multiple check constraints
+--Insert with joins where the result tuples violate violates multiple check constraints
 SELECT COUNT(*) FROM dml_co_check_r;
  count 
 -------
@@ -1256,7 +1235,7 @@ SELECT COUNT(*) FROM dml_co_check_r;
    105
 (1 row)
 
--- test4: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_co_pt_r;
  count 
@@ -1278,7 +1257,7 @@ SELECT COUNT(*) FROM dml_co_pt_r;
 (1 row)
 
 rollback;
--- test5: Insert with generate_series and NULL
+--Insert with generate_series and NULL
 begin;
 SELECT COUNT(*) FROM dml_co_pt_r;
  count 
@@ -1312,7 +1291,7 @@ SELECT COUNT(*) FROM dml_co_pt_r;
 (1 row)
 
 rollback;
--- test6: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_co_pt_r;
  count 
@@ -1350,7 +1329,7 @@ SELECT COUNT(*) FROM dml_co_pt_r;
 (1 row)
 
 rollback;
--- test7: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_co_pt_r;
  count 
@@ -1372,7 +1351,7 @@ SELECT COUNT(*) FROM dml_co_pt_r;
 (1 row)
 
 rollback;
--- test8: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_co_pt_r;
  count 
@@ -1388,7 +1367,7 @@ SELECT COUNT(*) FROM dml_co_pt_r;
 (1 row)
 
 rollback;
--- test9: Join on the non-distribution key of target table
+--Join on the non-distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_co_pt_r;
  count 
@@ -1410,7 +1389,7 @@ SELECT COUNT(*) FROM dml_co_pt_r;
 (1 row)
 
 rollback;
--- test10: Join on the distribution key of target table
+--Join on the distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_co_pt_s;
  count 
@@ -1432,7 +1411,7 @@ SELECT COUNT(*) FROM dml_co_pt_s;
 (1 row)
 
 rollback;
--- test11: Join on distribution key of target table
+--Join on distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_co_pt_r;
  count 
@@ -1454,7 +1433,7 @@ SELECT COUNT(*) FROM dml_co_pt_r;
 (1 row)
 
 rollback;
--- test12: Join on the distribution key of target table. Insert Large number of rows
+--Join on the distribution key of target table. Insert Large number of rows
 begin;
 SELECT COUNT(*) FROM dml_co_pt_s;
  count 
@@ -1476,7 +1455,7 @@ SELECT COUNT(*) FROM dml_co_pt_s;
 (1 row)
 
 rollback;
--- test13: Join with different column order 
+--Join with different column order 
 begin;
 SELECT COUNT(*) FROM dml_co_pt_r;
  count 
@@ -1498,7 +1477,7 @@ SELECT COUNT(*) FROM dml_co_pt_r;
 (1 row)
 
 rollback;
--- test14: Join with Aggregate
+--Join with Aggregate
 begin;
 SELECT COUNT(*) FROM dml_co_pt_r;
  count 
@@ -1521,7 +1500,7 @@ SELECT COUNT(*) FROM dml_co_pt_r;
 (1 row)
 
 rollback;
--- test15: Join with DISTINCT
+--Join with DISTINCT
 begin;
 SELECT COUNT(*) FROM dml_co_pt_s;
  count 
@@ -1543,7 +1522,7 @@ SELECT COUNT(*) FROM dml_co_pt_s;
 (1 row)
 
 rollback;
--- test16: Insert NULL with Joins
+--Insert NULL with Joins
 begin;
 SELECT COUNT(*) FROM dml_co_pt_r;
  count 
@@ -1565,7 +1544,7 @@ SELECT COUNT(*) FROM dml_co_pt_r;
 (1 row)
 
 rollback;
--- test18: Insert 0 rows
+--Insert 0 rows
 SELECT COUNT(*) FROM dml_co_pt_r;
  count 
 -------
@@ -1579,7 +1558,7 @@ SELECT COUNT(*) FROM dml_co_pt_r;
    100
 (1 row)
 
--- test19: Insert 0 rows
+--Insert 0 rows
 SELECT COUNT(*) FROM dml_co_pt_r;
  count 
 -------
@@ -1593,7 +1572,7 @@ SELECT COUNT(*) FROM dml_co_pt_r;
    100
 (1 row)
 
--- test21: Negative test case. INSERT has more expressions than target columns
+--Negative test case. INSERT has more expressions than target columns
 begin;
 SELECT COUNT(*) FROM dml_co_pt_s;
  count 
@@ -1615,7 +1594,7 @@ SELECT COUNT(*) FROM dml_co_pt_s;
 (1 row)
 
 rollback;
--- test22: Insert with join on the partition key
+--Insert with join on the partition key
 begin;
 SELECT COUNT(*) FROM dml_co_pt_r;
  count 
@@ -1637,7 +1616,7 @@ SELECT COUNT(*) FROM dml_co_pt_r;
 (1 row)
 
 rollback;
--- test24: Negative test - Insert NULL value to a table without default partition
+--Negative test - Insert NULL value to a table without default partition
 SELECT COUNT(*) FROM dml_co_pt_r;
  count 
 -------
@@ -1658,7 +1637,7 @@ SELECT COUNT(*) FROM dml_co_pt_r;
    100
 (1 row)
 
--- test25: Negative test - Insert out of partition range values for table without default partition
+--Negative test - Insert out of partition range values for table without default partition
 SELECT COUNT(*) FROM dml_co_pt_r;
  count 
 -------
@@ -1673,7 +1652,7 @@ SELECT COUNT(*) FROM dml_co_pt_r;
    100
 (1 row)
 
--- test4: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_co_r;
  count 
@@ -1695,7 +1674,7 @@ SELECT COUNT(*) FROM dml_co_r;
 (1 row)
 
 rollback;
--- test5: Insert with generate_series and NULL
+--Insert with generate_series and NULL
 begin;
 SELECT COUNT(*) FROM dml_co_r;
  count 
@@ -1726,7 +1705,7 @@ SELECT COUNT(*) FROM dml_co_r;
 (1 row)
 
 rollback;
--- test6: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_co_r;
  count 
@@ -1764,7 +1743,7 @@ SELECT COUNT(*) FROM dml_co_r;
 (1 row)
 
 rollback;
--- test7: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_co_r;
  count 
@@ -1786,7 +1765,7 @@ SELECT COUNT(*) FROM dml_co_r;
 (1 row)
 
 rollback;
--- test8: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_co_r;
  count 
@@ -1802,7 +1781,7 @@ SELECT COUNT(*) FROM dml_co_r;
 (1 row)
 
 rollback;
--- test9: Join on the non-distribution key of target table
+--Join on the non-distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_co_r;
  count 
@@ -1824,7 +1803,7 @@ SELECT COUNT(*) FROM dml_co_r;
 (1 row)
 
 rollback;
--- test10: Join on the distribution key of target table
+--Join on the distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_co_s;
  count 
@@ -1846,7 +1825,7 @@ SELECT COUNT(*) FROM dml_co_s;
 (1 row)
 
 rollback;
--- test11: Join on distribution key of target table
+--Join on distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_co_r;
  count 
@@ -1868,7 +1847,7 @@ SELECT COUNT(*) FROM dml_co_r;
 (1 row)
 
 rollback;
--- test12: Join on the distribution key of target table. Insert Large number of rows
+--Join on the distribution key of target table. Insert Large number of rows
 begin;
 SELECT COUNT(*) FROM dml_co_s;
  count 
@@ -1890,7 +1869,7 @@ SELECT COUNT(*) FROM dml_co_s;
 (1 row)
 
 rollback;
--- test13: Join with different column order 
+--Join with different column order 
 begin;
 SELECT COUNT(*) FROM dml_co_r;
  count 
@@ -1912,7 +1891,7 @@ SELECT COUNT(*) FROM dml_co_r;
 (1 row)
 
 rollback;
--- test14: Join with Aggregate
+--Join with Aggregate
 begin;
 SELECT COUNT(*) FROM dml_co_r;
  count 
@@ -1934,7 +1913,7 @@ SELECT COUNT(*) FROM dml_co_r;
 (1 row)
 
 rollback;
--- test15: Join with DISTINCT
+--Join with DISTINCT
 begin;
 SELECT COUNT(*) FROM dml_co_s;
  count 
@@ -1956,7 +1935,7 @@ SELECT COUNT(*) FROM dml_co_s;
 (1 row)
 
 rollback;
--- test16: Insert NULL with Joins
+--Insert NULL with Joins
 begin;
 SELECT COUNT(*) FROM dml_co_r;
  count 
@@ -1978,7 +1957,7 @@ SELECT COUNT(*) FROM dml_co_r;
 (1 row)
 
 rollback;
--- test17: Insert and CASE
+--Insert and CASE
 begin;
 SELECT COUNT(*) FROM dml_co_r;
  count 
@@ -2000,7 +1979,7 @@ SELECT COUNT(*) FROM dml_co_r;
 (1 row)
 
 rollback;
--- test18: Insert 0 rows
+--Insert 0 rows
 SELECT COUNT(*) FROM dml_co_r;
  count 
 -------
@@ -2014,7 +1993,7 @@ SELECT COUNT(*) FROM dml_co_r;
    113
 (1 row)
 
--- test19: Insert 0 rows
+--Insert 0 rows
 SELECT COUNT(*) FROM dml_co_r;
  count 
 -------
@@ -2028,7 +2007,7 @@ SELECT COUNT(*) FROM dml_co_r;
    113
 (1 row)
 
--- test20: Negative tests Insert column of different data type
+--Negative tests Insert column of different data type
 SELECT COUNT(*) FROM dml_co_r;
  count 
 -------
@@ -2049,7 +2028,7 @@ SELECT COUNT(*) FROM dml_co_r;
    113
 (1 row)
 
--- test21: Negative test case. INSERT has more expressions than target columns
+--Negative test case. INSERT has more expressions than target columns
 SELECT COUNT(*) FROM dml_co_s;
  count 
 -------
@@ -2070,7 +2049,7 @@ SELECT COUNT(*) FROM dml_co_s;
    113
 (1 row)
 
--- test1: Insert data that satisfy the check constraints 
+--Insert data that satisfy the check constraints 
 begin;
 SELECT COUNT(*) FROM dml_heap_check_s;
  count 
@@ -2092,7 +2071,7 @@ SELECT COUNT(*) FROM dml_heap_check_s;
 (1 row)
 
 rollback;
--- test2: Negative test - Insert default value violates check constraint
+--Negative test - Insert default value violates check constraint
 SELECT COUNT(*) FROM dml_heap_check_p;
  count 
 -------
@@ -2107,7 +2086,7 @@ SELECT COUNT(*) FROM dml_heap_check_p;
    105
 (1 row)
 
--- test3: Negative test - Insert default value violates NOT NULL constraint
+--Negative test - Insert default value violates NOT NULL constraint
 SELECT COUNT(*) FROM dml_heap_check_s;
  count 
 -------
@@ -2122,7 +2101,7 @@ SELECT COUNT(*) FROM dml_heap_check_s;
    105
 (1 row)
 
--- test4: Negative test - Insert with joins where the result tuples violate the user defined check constraint
+--Negative test - Insert with joins where the result tuples violate the user defined check constraint
 SELECT COUNT(*) FROM dml_heap_check_r;
  count 
 -------
@@ -2143,7 +2122,7 @@ SELECT COUNT(*) FROM dml_heap_check_r;
    105
 (1 row)
 
--- test5: Insert with joins where the result tuples violate violates multiple check constraints
+--Insert with joins where the result tuples violate violates multiple check constraints
 SELECT COUNT(*) FROM dml_heap_check_r;
  count 
 -------
@@ -2164,7 +2143,7 @@ SELECT COUNT(*) FROM dml_heap_check_r;
    105
 (1 row)
 
--- test1: Update data that satisfy the check constraints 
+--Update data that satisfy the check constraints 
 begin;
 SELECT SUM(d) FROM dml_heap_check_s;
  sum 
@@ -2180,16 +2159,16 @@ SELECT SUM(d) FROM dml_heap_check_s;
 (1 row)
 
 rollback;
--- test2: Negative test: Update data that does not satisfy the check constraints
+--Negative test: Update data that does not satisfy the check constraints
 UPDATE dml_heap_check_s SET a = 100 + dml_heap_check_s.a FROM dml_heap_check_r WHERE dml_heap_check_r.a = dml_heap_check_s.a AND dml_heap_check_s.a = 99;
 ERROR:  new row for relation "dml_heap_check_s_1_prt_def" violates check constraint "dml_heap_check_s_a_check"
--- test3: Negative test - Update violates check constraint(not NULL constraint)
+--Negative test - Update violates check constraint(not NULL constraint)
 UPDATE dml_heap_check_s SET b = NULL FROM dml_heap_check_r WHERE dml_heap_check_r.a = dml_heap_check_s.b and dml_heap_check_s.b = 99;
 ERROR:  new row for relation "dml_heap_check_s_1_prt_5" violates check constraint "scheck_b"
--- test4: Negative test - Update moving tuple across partition .also violates the check constraint
+--Negative test - Update moving tuple across partition .also violates the check constraint
 UPDATE dml_heap_check_s SET a = 110 + dml_heap_check_s.a FROM dml_heap_check_r WHERE dml_heap_check_r.a = dml_heap_check_s.a;
 ERROR:  new row for relation "dml_heap_check_s_1_prt_def" violates check constraint "dml_heap_check_s_a_check"
--- test4: Delete with generate_series
+--Delete with generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_s;
  count 
@@ -2205,7 +2184,7 @@ SELECT COUNT(*) FROM dml_heap_s;
 (1 row)
 
 rollback;
--- test5: Delete with join on distcol
+--Delete with join on distcol
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
  count 
@@ -2221,7 +2200,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test6: Delete with join on non-distribution column
+--Delete with join on non-distribution column
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
  count 
@@ -2237,7 +2216,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test7: Delete with join on non-distribution column
+--Delete with join on non-distribution column
 begin;
 SELECT COUNT(*) FROM dml_heap_s;
  count 
@@ -2253,7 +2232,7 @@ SELECT COUNT(*) FROM dml_heap_s;
 (1 row)
 
 rollback;
--- test8: Delete and using  
+--Delete and using  
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
  count 
@@ -2269,7 +2248,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test9: Delete and using (with no rows)
+--Delete and using (with no rows)
 begin;
 TRUNCATE TABLE dml_heap_s;
 SELECT COUNT(*) FROM dml_heap_r;
@@ -2286,7 +2265,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test10: Delete with join in using
+--Delete with join in using
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
  count 
@@ -2302,7 +2281,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test11: Delete with join in USING (Delete all rows )
+--Delete with join in USING (Delete all rows )
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
  count 
@@ -2318,7 +2297,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test12: Delete with join in using
+--Delete with join in using
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
  count 
@@ -2334,7 +2313,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test13: Delete with multiple joins
+--Delete with multiple joins
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
  count 
@@ -2350,7 +2329,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test14: Delete on table with composite distcol
+--Delete on table with composite distcol
 begin;
 SELECT COUNT(*) FROM dml_heap_p;
  count 
@@ -2366,7 +2345,7 @@ SELECT COUNT(*) FROM dml_heap_p;
 (1 row)
 
 rollback;
--- test15: Delete with PREPARE plan
+--Delete with PREPARE plan
 begin;
 SELECT COUNT(*) FROM (SELECT dml_heap_r.b FROM dml_heap_r,dml_heap_s WHERE dml_heap_r.b = dml_heap_s.b) foo;
  count 
@@ -2389,7 +2368,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test16: Delete with PREPARE plan
+--Delete with PREPARE plan
 begin;
 SELECT COUNT(*) FROM (SELECT dml_heap_r.b FROM dml_heap_r,dml_heap_s WHERE dml_heap_r.a = dml_heap_s.a)foo;
  count 
@@ -2412,7 +2391,7 @@ SELECT COUNT(*) FROM dml_heap_s;
 (1 row)
 
 rollback;
--- test17: Delete with sub-query
+--Delete with sub-query
 SELECT COUNT(*) FROM dml_heap_s;
  count 
 -------
@@ -2428,7 +2407,7 @@ SELECT COUNT(*) FROM dml_heap_s;
    113
 (1 row)
 
--- test1: Delete from table
+--Delete from table
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_s; 
  count 
@@ -2444,7 +2423,7 @@ SELECT COUNT(*) FROM dml_heap_pt_s;
 (1 row)
 
 rollback;
--- test2: Delete with predicate
+--Delete with predicate
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_s;
  count 
@@ -2472,7 +2451,7 @@ SELECT COUNT(*) FROM dml_heap_pt_s WHERE a > 100;
 (1 row)
 
 rollback;
--- test3: Delete with predicate
+--Delete with predicate
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_s;
  count 
@@ -2494,7 +2473,7 @@ SELECT COUNT(*) FROM dml_heap_pt_s;
 (1 row)
 
 rollback;
--- test4: Delete with generate_series
+--Delete with generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_s;
  count 
@@ -2510,7 +2489,7 @@ SELECT COUNT(*) FROM dml_heap_pt_s;
 (1 row)
 
 rollback;
--- test5: Delete with join on distcol
+--Delete with join on distcol
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
@@ -2526,7 +2505,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test6: Delete with join on non-distribution column
+--Delete with join on non-distribution column
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
@@ -2542,7 +2521,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test7: Delete with join on non-distribution column
+--Delete with join on non-distribution column
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_s;
  count 
@@ -2558,7 +2537,7 @@ SELECT COUNT(*) FROM dml_heap_pt_s;
 (1 row)
 
 rollback;
--- test8: Delete and using  
+--Delete and using  
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
@@ -2574,7 +2553,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test9: Delete and using (with no rows)
+--Delete and using (with no rows)
 begin;
 TRUNCATE TABLE dml_heap_pt_s;
 SELECT COUNT(*) FROM dml_heap_pt_r;
@@ -2591,7 +2570,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test10: Delete with join in using
+--Delete with join in using
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
@@ -2607,7 +2586,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test11: Delete with join in USING (Delete all rows )
+--Delete with join in USING (Delete all rows )
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
@@ -2623,7 +2602,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test12: Delete with join in using
+--Delete with join in using
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
@@ -2639,7 +2618,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test13: Delete with multiple joins
+--Delete with multiple joins
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
@@ -2655,7 +2634,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test14: Delete on table with composite distcol
+--Delete on table with composite distcol
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_p;
  count 
@@ -2671,7 +2650,7 @@ SELECT COUNT(*) FROM dml_heap_pt_p;
 (1 row)
 
 rollback;
--- test15: Delete with PREPARE plan
+--Delete with PREPARE plan
 begin;
 SELECT COUNT(*) FROM (SELECT dml_heap_pt_r.b FROM dml_heap_pt_r,dml_heap_pt_s WHERE dml_heap_pt_r.b = dml_heap_pt_s.b) foo;
  count 
@@ -2694,7 +2673,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test16: Delete with PREPARE plan
+--Delete with PREPARE plan
 begin;
 SELECT COUNT(*) FROM (SELECT dml_heap_pt_r.b FROM dml_heap_pt_r,dml_heap_pt_s WHERE dml_heap_pt_r.a = dml_heap_pt_s.a)foo;
  count 
@@ -2717,7 +2696,7 @@ SELECT COUNT(*) FROM dml_heap_pt_s;
 (1 row)
 
 rollback;
--- test17: Delete with sub-query
+--Delete with sub-query
 SELECT COUNT(*) FROM dml_heap_pt_s;
  count 
 -------
@@ -2733,7 +2712,7 @@ SELECT COUNT(*) FROM dml_heap_pt_s;
    115
 (1 row)
 
--- test4: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
@@ -2755,7 +2734,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test5: Insert with generate_series and NULL
+--Insert with generate_series and NULL
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
@@ -2789,7 +2768,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test6: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
@@ -2827,7 +2806,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test7: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
@@ -2849,7 +2828,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test8: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
@@ -2865,7 +2844,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test9: Join on the non-distribution key of target table
+--Join on the non-distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
@@ -2887,7 +2866,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test10: Join on the distribution key of target table
+--Join on the distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_s;
  count 
@@ -2909,7 +2888,7 @@ SELECT COUNT(*) FROM dml_heap_pt_s;
 (1 row)
 
 rollback;
--- test11: Join on distribution key of target table
+--Join on distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
@@ -2931,7 +2910,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test12: Join on the distribution key of target table. Insert Large number of rows
+--Join on the distribution key of target table. Insert Large number of rows
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_s;
  count 
@@ -2953,7 +2932,7 @@ SELECT COUNT(*) FROM dml_heap_pt_s;
 (1 row)
 
 rollback;
--- test13: Join with different column order 
+--Join with different column order 
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
@@ -2975,7 +2954,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test14: Join with Aggregate
+--Join with Aggregate
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
@@ -3000,7 +2979,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 ALTER TABLE dml_heap_pt_r DROP DEFAULT partition;
 NOTICE:  dropped partition "def" for relation "dml_heap_pt_r"
 rollback;
--- test15: Join with DISTINCT
+--Join with DISTINCT
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_s;
  count 
@@ -3022,7 +3001,7 @@ SELECT COUNT(*) FROM dml_heap_pt_s;
 (1 row)
 
 rollback;
--- test16: Insert NULL with Joins
+--Insert NULL with Joins
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
@@ -3044,7 +3023,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test18: Insert 0 rows
+--Insert 0 rows
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
 -------
@@ -3058,7 +3037,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
    100
 (1 row)
 
--- test19: Insert 0 rows
+--Insert 0 rows
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
 -------
@@ -3072,7 +3051,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
    100
 (1 row)
 
--- test20: Negative tests Insert column of different data type
+--Negative tests Insert column of different data type
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
 -------
@@ -3093,7 +3072,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
    100
 (1 row)
 
--- test21: Negative test case. INSERT has more expressions than target columns
+--Negative test case. INSERT has more expressions than target columns
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_s;
  count 
@@ -3115,7 +3094,7 @@ SELECT COUNT(*) FROM dml_heap_pt_s;
 (1 row)
 
 rollback;
--- test22: Insert with join on the partition key
+--Insert with join on the partition key
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
@@ -3137,7 +3116,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- test24: Negative test - Insert NULL value to a table without default partition
+--Negative test - Insert NULL value to a table without default partition
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
 -------
@@ -3152,7 +3131,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
    100
 (1 row)
 
--- test25: Negative test - Insert out of partition range values for table without default partition
+--Negative test - Insert out of partition range values for table without default partition
 SELECT COUNT(*) FROM dml_heap_pt_r;
  count 
 -------
@@ -3167,7 +3146,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
    100
 (1 row)
 
--- update_test1: Update to constant value
+--Update to constant value
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE c ='text';
  count 
@@ -3183,7 +3162,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r WHERE c ='text';
 (1 row)
 
 rollback;
--- update_test2: Update and set distribution key to constant
+--Update and set distribution key to constant
 begin;
 SELECT COUNT(*) FROM (SELECT DISTINCT(b) FROM dml_heap_pt_s)foo;
  count 
@@ -3199,7 +3178,7 @@ SELECT COUNT(*) FROM (SELECT DISTINCT(b) FROM dml_heap_pt_s)foo;
 (1 row)
 
 rollback;
--- update_test3: Update to default value
+--Update to default value
 begin;
 SELECT SUM(a) FROM dml_heap_pt_r;
  sum  
@@ -3215,7 +3194,7 @@ SELECT SUM(a) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- update_test4: Update to default value
+--Update to default value
 begin;
 SELECT SUM(a) FROM dml_heap_pt_r;
  sum  
@@ -3244,7 +3223,7 @@ SELECT SUM(b) FROM dml_heap_pt_r;
 (1 row)
 
 rollback;
--- update_test5: Update and reset the value
+--Update and reset the value
 begin;
 SELECT COUNT(*) FROM (SELECT DISTINCT(a) FROM dml_heap_pt_r)foo;
  count 
@@ -3260,7 +3239,7 @@ SELECT COUNT(*) FROM (SELECT DISTINCT(a) FROM dml_heap_pt_r)foo;
 (1 row)
 
 rollback;
--- update_test6: Update and generate_series
+--Update and generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE a = 1;
  count 
@@ -3281,7 +3260,7 @@ ERROR:  current transaction is aborted, commands ignored until end of transactio
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE a = 1;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
--- update_test7: Update distcol where join on target table non dist key
+--Update distcol where join on target table non dist key
 begin;
 SELECT SUM(a) FROM dml_heap_pt_r;
  sum  
@@ -3294,7 +3273,7 @@ ERROR:  multiple updates to a row by the same query is not allowed
 SELECT SUM(a) FROM dml_heap_pt_r;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
--- update_test8: Update and from values
+--Update and from values
 begin;
 SELECT * FROM dml_heap_pt_r WHERE b = 20 ORDER BY 1;
  a | b | c | d 
@@ -3308,7 +3287,7 @@ SELECT * FROM dml_heap_pt_r WHERE b = 20 ORDER BY 1;
 (0 rows)
 
 rollback;
--- update_test9: Update with Joins and set to constant value
+--Update with Joins and set to constant value
 SELECT COUNT(*) FROM dml_heap_pt_s WHERE b = 10;
  count 
 -------
@@ -3322,11 +3301,11 @@ SELECT COUNT(*) FROM dml_heap_pt_s WHERE b = 10;
     36
 (1 row)
 
--- update_test10: Update distcol with predicate in subquery
+--Update distcol with predicate in subquery
 begin;
 UPDATE dml_heap_pt_r SET a = dml_heap_pt_r.a + 1 FROM dml_heap_pt_s WHERE dml_heap_pt_r.b = dml_heap_pt_s.a and dml_heap_pt_s.b in (SELECT dml_heap_pt_s.b + dml_heap_pt_r.a FROM dml_heap_pt_s,dml_heap_pt_r WHERE dml_heap_pt_r.a > 10);
 rollback;
--- update_test11: Update with aggregate in subquery
+--Update with aggregate in subquery
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_s WHERE b = (SELECT COUNT(*) FROM dml_heap_pt_s);
  count 
@@ -3348,7 +3327,7 @@ SELECT COUNT(*) FROM dml_heap_pt_s WHERE b = (SELECT COUNT(*) FROM dml_heap_pt_s
 (1 row)
 
 rollback;
--- update_test12: Update and limit in subquery
+--Update and limit in subquery
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE a = 1;
  count 
 -------
@@ -3369,7 +3348,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r WHERE a = 1;
      1
 (1 row)
 
--- update_test13: Update multiple columns
+--Update multiple columns
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE b is NULL;
  count 
@@ -3399,7 +3378,7 @@ ERROR:  current transaction is aborted, commands ignored until end of transactio
 ALTER TABLE dml_heap_pt_r DROP DEFAULT partition;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
--- update_test14: Update multiple columns
+--Update multiple columns
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE c='z';
  count 
 -------
@@ -3428,13 +3407,13 @@ SELECT COUNT(*) FROM dml_heap_pt_r WHERE c='z';
 
 ALTER TABLE dml_heap_pt_r DROP DEFAULT partition;
 NOTICE:  dropped partition "def" for relation "dml_heap_pt_r"
--- update_test15: Update with prepare plans
+--Update with prepare plans
 begin;
 PREPARE plan_upd as UPDATE dml_heap_pt_r SET a = dml_heap_pt_s.a +1 FROM dml_heap_pt_s WHERE dml_heap_pt_r.a = dml_heap_pt_s.b ;
 EXECUTE plan_upd;
 ERROR:  multiple updates to a row by the same query is not allowed
 rollback;
--- update_test16: Update and case
+--Update and case
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE a = 20 ;
  count 
@@ -3450,7 +3429,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r WHERE a = 20 ;
 (1 row)
 
 rollback;
--- update_test17: Negative test - Update with sub-query returning more than one row
+--Negative test - Update with sub-query returning more than one row
 SELECT SUM(a) FROM dml_heap_pt_r;
  sum  
 ------
@@ -3466,7 +3445,7 @@ SELECT SUM(a) FROM dml_heap_pt_r;
  5050
 (1 row)
 
--- update_test18: Negative test - Update with sub-query returning more than one row
+--Negative test - Update with sub-query returning more than one row
 SELECT SUM(b) FROM dml_heap_pt_r;
   sum  
 -------
@@ -3482,7 +3461,7 @@ SELECT SUM(b) FROM dml_heap_pt_r;
  15150
 (1 row)
 
--- update_test20: Negative test - Update WHERE join returns more than one tuple with different values.
+--Negative test - Update WHERE join returns more than one tuple with different values.
 CREATE TABLE dml_heap_pt_u as SELECT i as a, i as b  FROM generate_series(1,10)i;
 CREATE TABLE dml_heap_pt_v as SELECT i as a, i as b FROM generate_series(1,10)i;
 SELECT SUM(a) FROM dml_heap_pt_v;
@@ -3498,7 +3477,7 @@ SELECT SUM(a) FROM dml_heap_pt_v;
   55
 (1 row)
 
--- update_test21: Update with joins on multiple table
+--Update with joins on multiple table
 begin;
 SELECT SUM(a) FROM dml_heap_pt_r;
  sum  
@@ -3511,7 +3490,7 @@ ERROR:  Cannot parallelize an UPDATE statement that updates the distribution col
 SELECT SUM(a) FROM dml_heap_pt_r;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
--- update_test22: Update on table with composite distribution key
+--Update on table with composite distribution key
 -- This currently falls back to planner, even if ORCA is enabled. And planner can't
 -- produce plans that update distribution key columns.
 SELECT SUM(a) FROM dml_heap_pt_r;
@@ -3528,7 +3507,7 @@ SELECT SUM(a) FROM dml_heap_pt_r;
  5050
 (1 row)
 
--- update_test23: Update on table with composite distribution key
+--Update on table with composite distribution key
 begin;
 SELECT SUM(b) FROM dml_heap_pt_p;
   sum  
@@ -3541,7 +3520,7 @@ ERROR:  Cannot parallelize an UPDATE statement that updates the distribution col
 SELECT SUM(b) FROM dml_heap_pt_p;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
--- test24: Update the partition key and move tuples across partitions( moving tuple to default partition)
+--Update the partition key and move tuples across partitions( moving tuple to default partition)
 begin;
 SELECT SUM(a) FROM dml_heap_pt_s;
  sum  
@@ -3557,7 +3536,7 @@ SELECT SUM(a) FROM dml_heap_pt_s;
 (1 row)
 
 rollback;
--- test25: Negative test update partition key (no default partition)
+--Negative test update partition key (no default partition)
 SELECT SUM(b) FROM dml_heap_pt_r;
   sum  
 -------
@@ -3572,7 +3551,7 @@ SELECT SUM(b) FROM dml_heap_pt_r;
  15150
 (1 row)
 
--- test4: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
  count 
@@ -3594,7 +3573,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test5: Insert with generate_series and NULL
+--Insert with generate_series and NULL
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
  count 
@@ -3625,7 +3604,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test6: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
  count 
@@ -3663,7 +3642,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test7: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
  count 
@@ -3685,7 +3664,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test8: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
  count 
@@ -3701,7 +3680,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test9: Join on the non-distribution key of target table
+--Join on the non-distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
  count 
@@ -3723,7 +3702,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test10: Join on the distribution key of target table
+--Join on the distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_heap_s;
  count 
@@ -3745,7 +3724,7 @@ SELECT COUNT(*) FROM dml_heap_s;
 (1 row)
 
 rollback;
--- test11: Join on distribution key of target table
+--Join on distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
  count 
@@ -3767,7 +3746,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test12: Join on the distribution key of target table. Insert Large number of rows
+--Join on the distribution key of target table. Insert Large number of rows
 begin;
 SELECT COUNT(*) FROM dml_heap_s;
  count 
@@ -3789,7 +3768,7 @@ SELECT COUNT(*) FROM dml_heap_s;
 (1 row)
 
 rollback;
--- test13: Join with different column order 
+--Join with different column order 
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
  count 
@@ -3811,7 +3790,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test14: Join with Aggregate
+--Join with Aggregate
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
  count 
@@ -3833,7 +3812,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test15: Join with DISTINCT
+--Join with DISTINCT
 begin;
 SELECT COUNT(*) FROM dml_heap_s;
  count 
@@ -3855,7 +3834,7 @@ SELECT COUNT(*) FROM dml_heap_s;
 (1 row)
 
 rollback;
--- test16: Insert NULL with Joins
+--Insert NULL with Joins
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
  count 
@@ -3877,7 +3856,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test17: Insert and CASE
+--Insert and CASE
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
  count 
@@ -3899,7 +3878,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 (1 row)
 
 rollback;
--- test18: Insert 0 rows
+--Insert 0 rows
 SELECT COUNT(*) FROM dml_heap_r;
  count 
 -------
@@ -3913,7 +3892,7 @@ SELECT COUNT(*) FROM dml_heap_r;
    113
 (1 row)
 
--- test19: Insert 0 rows
+--Insert 0 rows
 SELECT COUNT(*) FROM dml_heap_r;
  count 
 -------
@@ -3927,7 +3906,7 @@ SELECT COUNT(*) FROM dml_heap_r;
    113
 (1 row)
 
--- test20: Negative tests Insert column of different data type
+--Negative tests Insert column of different data type
 SELECT COUNT(*) FROM dml_heap_r;
  count 
 -------
@@ -3948,7 +3927,7 @@ SELECT COUNT(*) FROM dml_heap_r;
    113
 (1 row)
 
--- test21: Negative test case. INSERT has more expressions than target columns
+--Negative test case. INSERT has more expressions than target columns
 SELECT COUNT(*) FROM dml_heap_s;
  count 
 -------
@@ -3969,7 +3948,7 @@ SELECT COUNT(*) FROM dml_heap_s;
    113
 (1 row)
 
--- update_test6: Update and generate_series
+--Update and generate_series
 begin;
 SELECT SUM(a) FROM dml_heap_r WHERE a = 1;
  sum 
@@ -3990,7 +3969,7 @@ ERROR:  current transaction is aborted, commands ignored until end of transactio
 SELECT SUM(a) FROM dml_heap_r WHERE a = 1;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
--- update_test7: Update distcol where join on target table non dist key
+--Update distcol where join on target table non dist key
 begin;
 SELECT SUM(a) FROM dml_heap_r WHERE a = 1;
  sum 
@@ -4006,7 +3985,7 @@ SELECT SUM(a) FROM dml_heap_r WHERE a = 1;
 (1 row)
 
 rollback;
--- update_test8: Update and from values
+--Update and from values
 begin;
 SELECT SUM(b) FROM dml_heap_r WHERE b = 20;
  sum 
@@ -4022,7 +4001,7 @@ SELECT SUM(b) FROM dml_heap_r WHERE b = 20;
 (1 row)
 
 rollback;
--- update_test9: Update with Joins and set to constant value
+--Update with Joins and set to constant value
 begin;
 SELECT COUNT(*) FROM dml_heap_s WHERE b = 10;
  count 
@@ -4038,11 +4017,11 @@ SELECT COUNT(*) FROM dml_heap_s WHERE b = 10;
 (1 row)
 
 rollback;
--- update_test10: Update distcol with predicate in subquery
+--Update distcol with predicate in subquery
 begin;
 UPDATE dml_heap_r SET a = dml_heap_r.a + 1 FROM dml_heap_s WHERE dml_heap_r.b = dml_heap_s.a and dml_heap_s.b in (SELECT dml_heap_s.b + dml_heap_r.a FROM dml_heap_s,dml_heap_r WHERE dml_heap_r.a > 10);
 rollback;
--- update_test11: Update with aggregate in subquery
+--Update with aggregate in subquery
 begin;
 SELECT COUNT(*) FROM dml_heap_s WHERE b = (SELECT COUNT(*) FROM dml_heap_s);
  count 
@@ -4055,7 +4034,7 @@ ERROR:  multiple updates to a row by the same query is not allowed
 SELECT COUNT(*) FROM dml_heap_s WHERE b = (SELECT COUNT(*) FROM dml_heap_s);
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
--- update_test12: Update and limit in subquery
+--Update and limit in subquery
 begin;
 SELECT COUNT(*) FROM dml_heap_r WHERE a = 1;
  count 
@@ -4071,7 +4050,7 @@ SELECT COUNT(*) FROM dml_heap_r WHERE a = 1;
 (1 row)
 
 rollback;
--- update_test13: Update multiple columns
+--Update multiple columns
 begin;
 SELECT COUNT(*) FROM dml_heap_r WHERE b is NULL;
  count 
@@ -4105,7 +4084,7 @@ SELECT COUNT(*) FROM dml_heap_r WHERE b is NULL;
 (1 row)
 
 rollback;
--- update_test14: Update multiple columns
+--Update multiple columns
 begin;
 SELECT COUNT(*) FROM dml_heap_r WHERE c='z';
  count 
@@ -4126,13 +4105,13 @@ ERROR:  current transaction is aborted, commands ignored until end of transactio
 SELECT COUNT(*) FROM dml_heap_r WHERE c='z';
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
--- update_test15: Update with prepare plans
+--Update with prepare plans
 begin;
 PREPARE plan_upd_2 as UPDATE dml_heap_r SET a = dml_heap_s.a +1 FROM dml_heap_s WHERE dml_heap_r.a = dml_heap_s.b ;
 EXECUTE plan_upd_2;
 ERROR:  multiple updates to a row by the same query is not allowed
 rollback;
--- update_test16: Update and case
+--Update and case
 begin;
 SELECT COUNT(*) FROM dml_heap_r WHERE a = 100 ;
  count 
@@ -4148,7 +4127,7 @@ SELECT COUNT(*) FROM dml_heap_r WHERE a = 100 ;
 (1 row)
 
 rollback;
--- update_test17: Negative test - Update with sub-query returning more than one row
+--Negative test - Update with sub-query returning more than one row
 SELECT SUM(a) FROM dml_heap_r;
  sum  
 ------
@@ -4164,7 +4143,7 @@ SELECT SUM(a) FROM dml_heap_r;
  5106
 (1 row)
 
--- update_test18: Negative test - Update with sub-query returning more than one row
+--Negative test - Update with sub-query returning more than one row
 SELECT SUM(b) FROM dml_heap_r;
  sum  
 ------
@@ -4180,7 +4159,7 @@ SELECT SUM(b) FROM dml_heap_r;
  5050
 (1 row)
 
--- update_test19: Negative test - Update with aggregates 
+--Negative test - Update with aggregates 
 SELECT SUM(b) FROM dml_heap_r;
  sum  
 ------
@@ -4197,7 +4176,7 @@ SELECT SUM(b) FROM dml_heap_r;
  5050
 (1 row)
 
--- update_test20: Negative test - Update WHERE join returns more than one tuple with different values.
+--Negative test - Update WHERE join returns more than one tuple with different values.
 CREATE TABLE dml_heap_u as SELECT i as a, 1 as b  FROM generate_series(1,10)i;
 CREATE TABLE dml_heap_v as SELECT i as a ,i as b FROM generate_series(1,10)i;
 SELECT SUM(a) FROM dml_heap_v;
@@ -4214,10 +4193,10 @@ SELECT SUM(a) FROM dml_heap_v;
   55
 (1 row)
 
--- update_test21: Update with joins on multiple table
+--Update with joins on multiple table
 UPDATE dml_heap_r SET a = dml_heap_r.b+1 FROM dml_heap_p,dml_heap_s WHERE dml_heap_r.b = dml_heap_s.b and dml_heap_r.a = dml_heap_p.b+1;
 ERROR:  multiple updates to a row by the same query is not allowed
--- update_test22: Update on table with composite distribution key
+--Update on table with composite distribution key
 UPDATE dml_heap_p SET a = dml_heap_p.b % 2 FROM dml_heap_r WHERE dml_heap_p.b::int = dml_heap_r.b::int and dml_heap_p.a = dml_heap_r.a;
--- update_test23: Update on table with composite distribution key
+--Update on table with composite distribution key
 UPDATE dml_heap_p SET b = (dml_heap_p.b * 1.1)::int FROM dml_heap_r WHERE dml_heap_p.b = dml_heap_r.a and dml_heap_p.b = dml_heap_r.b;

--- a/src/test/regress/sql/qp_dml_joins.sql
+++ b/src/test/regress/sql/qp_dml_joins.sql
@@ -302,7 +302,7 @@ INSERT INTO dml_heap_pt_s VALUES(generate_series(1,10),NULL,'sn',NULL);
 INSERT INTO dml_heap_pt_s VALUES(NULL,1,'sn',NULL),(1,NULL,'sn',0),(NULL,NULL,'sn',0),(0,1,'sn',NULL),(NULL,NULL,'sn',NULL);
 
 
--- test1: Insert data that satisfy the check constraints
+--Insert data that satisfy the check constraints
 begin;
 SELECT COUNT(*) FROM dml_ao_check_s;
 SELECT COUNT(*) FROM (SELECT dml_ao_check_s.a, dml_ao_check_s.b, 'text', dml_ao_check_s.d FROM dml_ao_check_r, dml_ao_check_s WHERE dml_ao_check_r.a = dml_ao_check_s.b)foo;
@@ -310,29 +310,23 @@ INSERT INTO dml_ao_check_s SELECT dml_ao_check_s.a, dml_ao_check_s.b, 'text', dm
 SELECT COUNT(*) FROM dml_ao_check_s;
 rollback;
 
--- test2: Negative test - Insert default value violates check constraint
+--Negative test - Insert default value violates check constraint
 SELECT COUNT(*) FROM dml_ao_check_p;
 INSERT INTO dml_ao_check_p select generate_series(1,100),'p', generate_series(1,100);
 SELECT COUNT(*) FROM dml_ao_check_p;
 
--- test3: Negative test - Insert default value violates NOT NULL constraint
+--Negative test - Insert default value violates NOT NULL constraint
 SELECT COUNT(*) FROM dml_ao_check_s;
 INSERT INTO dml_ao_check_s values(default,1,'nn',1.0000);
 SELECT COUNT(*) FROM dml_ao_check_s;
 
--- test4: Negative test - Insert with joins where the result tuples violate the user defined check constraint
-SELECT COUNT(*) FROM dml_ao_check_r;
-SELECT COUNT(*) FROM (SELECT dml_ao_check_r.a + 110 , dml_ao_check_r.b, dml_ao_check_r.c, dml_ao_check_r.d FROM dml_ao_check_r, dml_ao_check_s WHERE dml_ao_check_r.a = dml_ao_check_s.a)foo;
-INSERT INTO dml_ao_check_r SELECT dml_ao_check_r.a + 110 , dml_ao_check_r.b, dml_ao_check_r.c, dml_ao_check_r.d FROM dml_ao_check_r, dml_ao_check_s WHERE dml_ao_check_r.a = dml_ao_check_s.a AND dml_ao_check_r.b > 10;
-SELECT COUNT(*) FROM dml_ao_check_r;
-
--- test5: Insert with joins where the result tuples violate violates multiple check constraints
+--Insert with joins where the result tuples violate violates multiple check constraints
 SELECT COUNT(*) FROM dml_ao_check_r;
 SELECT COUNT(*) FROM (SELECT dml_ao_check_r.a + 110 , 0, dml_ao_check_r.c, NULL FROM dml_ao_check_r, dml_ao_check_s WHERE dml_ao_check_r.a = dml_ao_check_s.a)foo;
 INSERT INTO dml_ao_check_r SELECT dml_ao_check_r.a + 110 , 0, dml_ao_check_r.c, NULL FROM dml_ao_check_r, dml_ao_check_s WHERE dml_ao_check_r.a = dml_ao_check_s.a;
 SELECT COUNT(*) FROM dml_ao_check_r;
 
--- test4: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_r;
 INSERT INTO dml_ao_pt_r values(generate_series(1,10), generate_series(1,100), 'text');
@@ -340,7 +334,7 @@ SELECT COUNT(*) FROM dml_ao_pt_r WHERE c ='text';
 SELECT COUNT(*) FROM dml_ao_pt_r;
 rollback;
 
--- test5: Insert with generate_series and NULL
+--Insert with generate_series and NULL
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_r;
 ALTER TABLE dml_ao_pt_r ADD DEFAULT partition def;
@@ -350,7 +344,7 @@ ALTER TABLE dml_ao_pt_r DROP DEFAULT partition;
 SELECT COUNT(*) FROM dml_ao_pt_r;
 rollback;
 
--- test6: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_r;
 TRUNCATE TABLE dml_ao_pt_r;
@@ -360,7 +354,7 @@ SELECT COUNT(*) FROM dml_ao_pt_r;
 SELECT COUNT(*) FROM dml_ao_pt_r;
 rollback;
 
--- test7: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_r;
 INSERT INTO dml_ao_pt_r SELECT generate_series(1,10), generate_series(1,10),'text';
@@ -368,14 +362,14 @@ SELECT COUNT(*) FROM dml_ao_pt_r WHERE c ='text';
 SELECT COUNT(*) FROM dml_ao_pt_r;
 rollback;
 
--- test8: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_r;
 INSERT INTO dml_ao_pt_r SELECT *,1 from generate_series(1,10);
 SELECT COUNT(*) FROM dml_ao_pt_r;
 rollback;
 
--- test9: Join on the non-distribution key of target table
+--Join on the non-distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_r;
 SELECT COUNT(*) FROM (SELECT dml_ao_pt_r.* FROM dml_ao_pt_r,dml_ao_pt_s  WHERE dml_ao_pt_r.b = dml_ao_pt_s.a)foo;
@@ -383,7 +377,7 @@ INSERT INTO dml_ao_pt_r SELECT dml_ao_pt_r.* FROM dml_ao_pt_r,dml_ao_pt_s  WHERE
 SELECT COUNT(*) FROM dml_ao_pt_r;
 rollback;
 
--- test10: Join on the distribution key of target table
+--Join on the distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_s;
 SELECT COUNT(*) FROM (SELECT dml_ao_pt_s.* FROM dml_ao_pt_r,dml_ao_pt_s WHERE dml_ao_pt_s.a = dml_ao_pt_r.a)foo;
@@ -391,7 +385,7 @@ INSERT INTO dml_ao_pt_s SELECT dml_ao_pt_s.* FROM dml_ao_pt_r,dml_ao_pt_s WHERE 
 SELECT COUNT(*) FROM dml_ao_pt_s;
 rollback;
 
--- test11: Join on distribution key of target table
+--Join on distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_r;
 SELECT COUNT(*) FROM (SELECT dml_ao_pt_r.a,dml_ao_pt_r.b,dml_ao_pt_s.c FROM dml_ao_pt_s INNER JOIN dml_ao_pt_r on dml_ao_pt_r.a = dml_ao_pt_s.a)foo;
@@ -399,7 +393,7 @@ INSERT INTO dml_ao_pt_r SELECT dml_ao_pt_r.a,dml_ao_pt_r.b,dml_ao_pt_s.c FROM dm
 SELECT COUNT(*) FROM dml_ao_pt_r;
 rollback;
 
--- test12: Join on the distribution key of target table. Insert Large number of rows
+--Join on the distribution key of target table. Insert Large number of rows
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_s;
 SELECT COUNT(*) FROM (SELECT dml_ao_pt_r.a,dml_ao_pt_r.b,dml_ao_pt_s.c FROM dml_ao_pt_s INNER JOIN dml_ao_pt_r on dml_ao_pt_r.b = dml_ao_pt_s.b)foo;
@@ -407,7 +401,7 @@ INSERT INTO dml_ao_pt_s SELECT dml_ao_pt_r.a,dml_ao_pt_r.b,dml_ao_pt_s.c FROM dm
 SELECT COUNT(*) FROM dml_ao_pt_s;
 rollback;
 
--- test13: Join with different column order
+--Join with different column order
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_r;
 SELECT COUNT(*) FROM (SELECT dml_ao_pt_s.a,dml_ao_pt_r.b,'text' FROM dml_ao_pt_r,dml_ao_pt_s  WHERE dml_ao_pt_r.b = dml_ao_pt_s.b)foo;
@@ -415,7 +409,7 @@ INSERT INTO dml_ao_pt_r(b,a,c) SELECT dml_ao_pt_s.a,dml_ao_pt_r.b,'text' FROM dm
 SELECT COUNT(*) FROM dml_ao_pt_r;
 rollback;
 
--- test14: Join with Aggregate
+--Join with Aggregate
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_r;
 ALTER TABLE dml_ao_pt_r ADD DEFAULT partition def;
@@ -424,7 +418,7 @@ INSERT INTO dml_ao_pt_r SELECT COUNT(*) + dml_ao_pt_s.a, dml_ao_pt_r.b + dml_ao_
 SELECT COUNT(*) FROM dml_ao_pt_r;
 rollback;
 
--- test15: Join with DISTINCT
+--Join with DISTINCT
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_s;
 SELECT COUNT(*) FROM (SELECT DISTINCT dml_ao_pt_r.a,dml_ao_pt_r.b,dml_ao_pt_s.c FROM dml_ao_pt_s INNER JOIN dml_ao_pt_r on dml_ao_pt_s.a = dml_ao_pt_r.a)foo;
@@ -432,7 +426,7 @@ INSERT INTO dml_ao_pt_s SELECT DISTINCT dml_ao_pt_r.a,dml_ao_pt_r.b,dml_ao_pt_s.
 SELECT COUNT(*) FROM dml_ao_pt_s;
 rollback;
 
--- test16: Insert NULL with Joins
+--Insert NULL with Joins
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_r;
 SELECT COUNT(*) FROM (SELECT NULL,dml_ao_pt_r.b,'text' FROM dml_ao_pt_r,dml_ao_pt_s WHERE dml_ao_pt_r.b = dml_ao_pt_s.b)foo;
@@ -440,23 +434,23 @@ INSERT INTO dml_ao_pt_r SELECT NULL,dml_ao_pt_r.b,'text' FROM dml_ao_pt_r,dml_ao
 SELECT COUNT(*) FROM dml_ao_pt_r;
 rollback;
 
--- test18: Insert 0 rows
+--Insert 0 rows
 SELECT COUNT(*) FROM dml_ao_pt_r;
 INSERT INTO dml_ao_pt_r SELECT dml_ao_pt_r.* FROM dml_ao_pt_r,dml_ao_pt_s WHERE dml_ao_pt_r.b = dml_ao_pt_s.a LIMIT 0;
 SELECT COUNT(*) FROM dml_ao_pt_r;
 
--- test19: Insert 0 rows
+--Insert 0 rows
 SELECT COUNT(*) FROM dml_ao_pt_r;
 INSERT INTO dml_ao_pt_r SELECT dml_ao_pt_r.* FROM dml_ao_pt_r,dml_ao_pt_s WHERE dml_ao_pt_r.b = dml_ao_pt_s.a and false;
 SELECT COUNT(*) FROM dml_ao_pt_r;
 
--- test20: Negative tests Insert column of different data type
+--Negative tests Insert column of different data type
 SELECT COUNT(*) FROM dml_ao_pt_r;
 SELECT COUNT(*) FROM (SELECT ('a')::int, dml_ao_pt_r.b,10 FROM dml_ao_pt_s WHERE dml_ao_pt_r.b = dml_ao_pt_s.b)foo;
 INSERT INTO dml_ao_pt_r SELECT ('a')::int, dml_ao_pt_r.b,10 FROM dml_ao_pt_s WHERE dml_ao_pt_r.b = dml_ao_pt_s.b;
 SELECT COUNT(*) FROM dml_ao_pt_r;
 
--- test21: Negative test case. INSERT has more expressions than target columns
+--Negative test case. INSERT has more expressions than target columns
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_s;
 SELECT COUNT(*) FROM (SELECT COUNT(*) as a, dml_ao_pt_r.b, dml_ao_pt_r.c, dml_ao_pt_r.d FROM dml_ao_pt_r, dml_ao_pt_s WHERE dml_ao_pt_s.a = dml_ao_pt_r.a GROUP BY dml_ao_pt_r.a, dml_ao_pt_r.b, dml_ao_pt_r.c, dml_ao_pt_r.d)foo;
@@ -464,7 +458,7 @@ INSERT INTO dml_ao_pt_s SELECT COUNT(*) as a, dml_ao_pt_r.b, dml_ao_pt_r.c, dml_
 SELECT COUNT(*) FROM dml_ao_pt_s;
 rollback;
 
--- test22: Insert with join on the partition key
+--Insert with join on the partition key
 begin;
 SELECT COUNT(*) FROM dml_ao_pt_r;
 SELECT COUNT(*) FROM (SELECT dml_ao_pt_r.* FROM dml_ao_pt_r, dml_ao_pt_s WHERE dml_ao_pt_r.b = dml_ao_pt_s.b)foo;
@@ -472,19 +466,19 @@ INSERT INTO dml_ao_pt_r SELECT dml_ao_pt_r.* FROM dml_ao_pt_r, dml_ao_pt_s WHERE
 SELECT COUNT(*) FROM dml_ao_pt_r;
 rollback;
 
--- test24: Negative test - Insert NULL value to a table without default partition
+--Negative test - Insert NULL value to a table without default partition
 SELECT COUNT(*) FROM dml_ao_pt_r;
 SELECT COUNT(*) FROM (SELECT dml_ao_pt_r.b, NULL, dml_ao_pt_r.c FROM dml_ao_pt_r, dml_ao_pt_s WHERE dml_ao_pt_r.b = dml_ao_pt_s.b)foo;
 INSERT INTO dml_ao_pt_r SELECT dml_ao_pt_r.b, NULL, dml_ao_pt_r.c FROM dml_ao_pt_r, dml_ao_pt_s WHERE dml_ao_pt_r.b = dml_ao_pt_s.b;
 SELECT COUNT(*) FROM dml_ao_pt_r;
 
--- test25: Negative test - Insert out of partition range values for table without default partition
+--Negative test - Insert out of partition range values for table without default partition
 SELECT COUNT(*) FROM dml_ao_pt_r;
 SELECT COUNT(*) FROM (SELECT dml_ao_pt_r.b ,dml_ao_pt_r.a + dml_ao_pt_s.a + 100, dml_ao_pt_r.c FROM dml_ao_pt_r, dml_ao_pt_s WHERE dml_ao_pt_r.a = dml_ao_pt_s.b)foo;
 INSERT INTO dml_ao_pt_r SELECT dml_ao_pt_r.b ,dml_ao_pt_r.a + dml_ao_pt_s.a + 100, dml_ao_pt_r.c FROM dml_ao_pt_r, dml_ao_pt_s WHERE dml_ao_pt_r.a = dml_ao_pt_s.b;
 SELECT COUNT(*) FROM dml_ao_pt_r;
 
--- test4: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_ao_r;
 INSERT INTO dml_ao_r values(generate_series(1,10), generate_series(1,100), 'text');
@@ -492,7 +486,7 @@ SELECT COUNT(*) FROM dml_ao_r WHERE c ='text';
 SELECT COUNT(*) FROM dml_ao_r;
 rollback;
 
--- test5: Insert with generate_series and NULL
+--Insert with generate_series and NULL
 begin;
 SELECT COUNT(*) FROM dml_ao_r;
 INSERT INTO dml_ao_r values(generate_series(1,10),NULL,'text');
@@ -500,7 +494,7 @@ SELECT * FROM dml_ao_r WHERE c ='text' ORDER BY 1;
 SELECT COUNT(*) FROM dml_ao_r;
 rollback;
 
--- test6: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_ao_r;
 TRUNCATE TABLE dml_ao_r;
@@ -509,7 +503,7 @@ SELECT * FROM dml_ao_r ORDER BY 1;
 SELECT COUNT(*) FROM dml_ao_r;
 rollback;
 
--- test7: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_ao_r;
 INSERT INTO dml_ao_r SELECT generate_series(1,10), generate_series(1,10),'text';
@@ -517,14 +511,14 @@ SELECT COUNT(*) FROM dml_ao_r WHERE c ='text';
 SELECT COUNT(*) FROM dml_ao_r;
 rollback;
 
--- test8: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_ao_r;
 INSERT INTO dml_ao_r SELECT * from generate_series(1,10);
 SELECT COUNT(*) FROM dml_ao_r;
 rollback;
 
--- test9: Join on the non-distribution key of target table
+--Join on the non-distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_ao_r;
 SELECT COUNT(*) FROM (SELECT dml_ao_r.* FROM dml_ao_r,dml_ao_s  WHERE dml_ao_r.b = dml_ao_s.b)foo;
@@ -532,7 +526,7 @@ INSERT INTO dml_ao_r SELECT dml_ao_r.* FROM dml_ao_r,dml_ao_s  WHERE dml_ao_r.b 
 SELECT COUNT(*) FROM dml_ao_r;
 rollback;
 
--- test10: Join on the distribution key of target table
+--Join on the distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_ao_s;
 SELECT COUNT(*) FROM (SELECT dml_ao_s.* FROM dml_ao_r,dml_ao_s WHERE dml_ao_s.a = dml_ao_r.a)foo;
@@ -540,7 +534,7 @@ INSERT INTO dml_ao_s SELECT dml_ao_s.* FROM dml_ao_r,dml_ao_s WHERE dml_ao_s.a =
 SELECT COUNT(*) FROM dml_ao_s;
 rollback;
 
--- test11: Join on distribution key of target table
+--Join on distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_ao_r;
 SELECT COUNT(*) FROM (SELECT dml_ao_r.a,dml_ao_r.b,dml_ao_s.c FROM dml_ao_s INNER JOIN dml_ao_r on dml_ao_r.a = dml_ao_s.a)foo;
@@ -548,7 +542,7 @@ INSERT INTO dml_ao_r SELECT dml_ao_r.a,dml_ao_r.b,dml_ao_s.c FROM dml_ao_s INNER
 SELECT COUNT(*) FROM dml_ao_r;
 rollback;
 
--- test12: Join on the distribution key of target table. Insert Large number of rows
+--Join on the distribution key of target table. Insert Large number of rows
 begin;
 SELECT COUNT(*) FROM dml_ao_s;
 SELECT COUNT(*) FROM (SELECT dml_ao_r.a,dml_ao_r.b,dml_ao_s.c FROM dml_ao_s INNER JOIN dml_ao_r on dml_ao_r.b <> dml_ao_s.b )foo;
@@ -556,7 +550,7 @@ INSERT INTO dml_ao_s SELECT dml_ao_r.a,dml_ao_r.b,dml_ao_s.c FROM dml_ao_s INNER
 SELECT COUNT(*) FROM dml_ao_s;
 rollback;
 
--- test13: Join with different column order
+--Join with different column order
 begin;
 SELECT COUNT(*) FROM dml_ao_r;
 SELECT COUNT(*) FROM (SELECT dml_ao_s.a,dml_ao_r.b,'text' FROM dml_ao_r,dml_ao_s  WHERE dml_ao_r.b = dml_ao_s.b)foo;
@@ -564,7 +558,7 @@ INSERT INTO dml_ao_r(b,a,c) SELECT dml_ao_s.a,dml_ao_r.b,'text' FROM dml_ao_r,dm
 SELECT COUNT(*) FROM dml_ao_r;
 rollback;
 
--- test14: Join with Aggregate
+--Join with Aggregate
 begin;
 SELECT COUNT(*) FROM dml_ao_r;
 SELECT COUNT(*) FROM (SELECT COUNT(*) + dml_ao_s.a, dml_ao_r.b + dml_ao_r.a ,'text' FROM dml_ao_r, dml_ao_s WHERE dml_ao_r.b = dml_ao_s.b GROUP BY dml_ao_s.a,dml_ao_r.b,dml_ao_r.a)foo;
@@ -572,7 +566,7 @@ INSERT INTO dml_ao_r SELECT COUNT(*) + dml_ao_s.a, dml_ao_r.b + dml_ao_r.a ,'tex
 SELECT COUNT(*) FROM dml_ao_r;
 rollback;
 
--- test15: Join with DISTINCT
+--Join with DISTINCT
 begin;
 SELECT COUNT(*) FROM dml_ao_s;
 SELECT COUNT(*) FROM (SELECT DISTINCT dml_ao_r.a,dml_ao_r.b,dml_ao_s.c FROM dml_ao_s INNER JOIN dml_ao_r on dml_ao_s.a = dml_ao_r.a)foo;
@@ -580,7 +574,7 @@ INSERT INTO dml_ao_s SELECT DISTINCT dml_ao_r.a,dml_ao_r.b,dml_ao_s.c FROM dml_a
 SELECT COUNT(*) FROM dml_ao_s;
 rollback;
 
--- test16: Insert NULL with Joins
+--Insert NULL with Joins
 begin;
 SELECT COUNT(*) FROM dml_ao_r;
 SELECT COUNT(*) FROM (SELECT NULL,dml_ao_r.b,'text' FROM dml_ao_r,dml_ao_s WHERE dml_ao_r.b = dml_ao_s.b)foo;
@@ -588,7 +582,7 @@ INSERT INTO dml_ao_r SELECT NULL,dml_ao_r.b,'text' FROM dml_ao_r,dml_ao_s WHERE 
 SELECT COUNT(*) FROM dml_ao_r;
 rollback;
 
--- test17: Insert and CASE
+--Insert and CASE
 begin;
 SELECT COUNT(*) FROM dml_ao_r;
 SELECT COUNT(*) FROM (SELECT A,B, case when c ='s' then C  else NULL end as C FROM (SELECT sum(dml_ao_p.a) as A, dml_ao_p.a as B, dml_ao_s.c as C FROM dml_ao_p, dml_ao_s WHERE dml_ao_p.a = dml_ao_s.a GROUP BY dml_ao_p.a,dml_ao_s.c)as x GROUP BY A,B,C)foo;
@@ -596,24 +590,24 @@ INSERT INTO dml_ao_r SELECT A,B, case when c ='s' then C  else NULL end as C FRO
 SELECT COUNT(*) FROM dml_ao_r;
 rollback;
 
--- test18: Insert 0 rows
+--Insert 0 rows
 SELECT COUNT(*) FROM dml_ao_r;
 INSERT INTO dml_ao_r SELECT dml_ao_r.* FROM dml_ao_r,dml_ao_s WHERE dml_ao_r.b = dml_ao_s.a LIMIT 0;
 SELECT COUNT(*) FROM dml_ao_r;
 
--- test19: Insert 0 rows
+--Insert 0 rows
 SELECT COUNT(*) FROM dml_ao_r;
 INSERT INTO dml_ao_r SELECT dml_ao_r.* FROM dml_ao_r,dml_ao_s WHERE dml_ao_r.b = dml_ao_s.a and false;
 SELECT COUNT(*) FROM dml_ao_r;
 
--- test21: Negative test case. INSERT has more expressions than target columns
+--Negative test case. INSERT has more expressions than target columns
 SELECT COUNT(*) FROM dml_ao_s;
 SELECT COUNT(*) FROM (SELECT COUNT(*) as a, dml_ao_r.* FROM dml_ao_r, dml_ao_s WHERE dml_ao_s.a = dml_ao_r.a GROUP BY dml_ao_r.a, dml_ao_r.b, dml_ao_r.c)foo;
 INSERT INTO dml_ao_s SELECT COUNT(*) as a, dml_ao_r.* FROM dml_ao_r, dml_ao_s WHERE dml_ao_s.a = dml_ao_r.a GROUP BY dml_ao_r.a, dml_ao_r.b, dml_ao_r.c;
 SELECT COUNT(*) FROM dml_ao_s;
 
 
--- test1: Insert data that satisfy the check constraints
+--Insert data that satisfy the check constraints
 begin;
 SELECT COUNT(*) FROM dml_co_check_s;
 SELECT COUNT(*) FROM (SELECT dml_co_check_s.a, dml_co_check_s.b, 'text', dml_co_check_s.d FROM dml_co_check_r, dml_co_check_s WHERE dml_co_check_r.a = dml_co_check_s.b)foo;
@@ -621,29 +615,29 @@ INSERT INTO dml_co_check_s SELECT dml_co_check_s.a, dml_co_check_s.b, 'text', dm
 SELECT COUNT(*) FROM dml_co_check_s;
 rollback;
 
--- test2: Negative test - Insert default value violates check constraint
+--Negative test - Insert default value violates check constraint
 SELECT COUNT(*) FROM dml_co_check_p;
 INSERT INTO dml_co_check_p select generate_series(1,100),'p', generate_series(1,100);
 SELECT COUNT(*) FROM dml_co_check_p;
 
--- test3: Negative test - Insert default value violates NOT NULL constraint
+--Negative test - Insert default value violates NOT NULL constraint
 SELECT COUNT(*) FROM dml_co_check_s;
 INSERT INTO dml_co_check_s values(default,1,'nn',1.0000);
 SELECT COUNT(*) FROM dml_co_check_s;
 
--- test4: Negative test - Insert with joins where the result tuples violate the user defined check constraint
+--Negative test - Insert with joins where the result tuples violate the user defined check constraint
 SELECT COUNT(*) FROM dml_co_check_r;
 SELECT COUNT(*) FROM (SELECT dml_co_check_r.a + 110 , dml_co_check_r.b, dml_co_check_r.c, dml_co_check_r.d FROM dml_co_check_r, dml_co_check_s WHERE dml_co_check_r.a = dml_co_check_s.a)foo;
 INSERT INTO dml_co_check_r SELECT dml_co_check_r.a + 110 , dml_co_check_r.b, dml_co_check_r.c, dml_co_check_r.d FROM dml_co_check_r, dml_co_check_s WHERE dml_co_check_r.a = dml_co_check_s.a AND dml_co_check_r.b > 10;
 SELECT COUNT(*) FROM dml_co_check_r;
 
--- test5: Insert with joins where the result tuples violate violates multiple check constraints
+--Insert with joins where the result tuples violate violates multiple check constraints
 SELECT COUNT(*) FROM dml_co_check_r;
 SELECT COUNT(*) FROM (SELECT dml_co_check_r.a + 110 , 0, dml_co_check_r.c, NULL FROM dml_co_check_r, dml_co_check_s WHERE dml_co_check_r.a = dml_co_check_s.a)foo;
 INSERT INTO dml_co_check_r SELECT dml_co_check_r.a + 110 , 0, dml_co_check_r.c, NULL FROM dml_co_check_r, dml_co_check_s WHERE dml_co_check_r.a = dml_co_check_s.a;
 SELECT COUNT(*) FROM dml_co_check_r;
 
--- test4: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_co_pt_r;
 INSERT INTO dml_co_pt_r values(generate_series(1,10), generate_series(1,100), 'text');
@@ -651,7 +645,7 @@ SELECT COUNT(*) FROM dml_co_pt_r WHERE c ='text';
 SELECT COUNT(*) FROM dml_co_pt_r;
 rollback;
 
--- test5: Insert with generate_series and NULL
+--Insert with generate_series and NULL
 begin;
 SELECT COUNT(*) FROM dml_co_pt_r;
 ALTER TABLE dml_co_pt_r ADD DEFAULT partition def;
@@ -661,7 +655,7 @@ ALTER TABLE dml_co_pt_r DROP DEFAULT partition;
 SELECT COUNT(*) FROM dml_co_pt_r;
 rollback;
 
--- test6: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_co_pt_r;
 TRUNCATE TABLE dml_co_pt_r;
@@ -671,7 +665,7 @@ SELECT COUNT(*) FROM dml_co_pt_r;
 SELECT COUNT(*) FROM dml_co_pt_r;
 rollback;
 
--- test7: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_co_pt_r;
 INSERT INTO dml_co_pt_r SELECT generate_series(1,10), generate_series(1,10),'text';
@@ -679,14 +673,14 @@ SELECT COUNT(*) FROM dml_co_pt_r WHERE c ='text';
 SELECT COUNT(*) FROM dml_co_pt_r;
 rollback;
 
--- test8: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_co_pt_r;
 INSERT INTO dml_co_pt_r SELECT *,1 from generate_series(1,10);
 SELECT COUNT(*) FROM dml_co_pt_r;
 rollback;
 
--- test9: Join on the non-distribution key of target table
+--Join on the non-distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_co_pt_r;
 SELECT COUNT(*) FROM (SELECT dml_co_pt_r.* FROM dml_co_pt_r,dml_co_pt_s  WHERE dml_co_pt_r.b = dml_co_pt_s.a)foo;
@@ -694,7 +688,7 @@ INSERT INTO dml_co_pt_r SELECT dml_co_pt_r.* FROM dml_co_pt_r,dml_co_pt_s  WHERE
 SELECT COUNT(*) FROM dml_co_pt_r;
 rollback;
 
--- test10: Join on the distribution key of target table
+--Join on the distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_co_pt_s;
 SELECT COUNT(*) FROM (SELECT dml_co_pt_s.* FROM dml_co_pt_r,dml_co_pt_s WHERE dml_co_pt_s.a = dml_co_pt_r.a)foo;
@@ -702,7 +696,7 @@ INSERT INTO dml_co_pt_s SELECT dml_co_pt_s.* FROM dml_co_pt_r,dml_co_pt_s WHERE 
 SELECT COUNT(*) FROM dml_co_pt_s;
 rollback;
 
--- test11: Join on distribution key of target table
+--Join on distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_co_pt_r;
 SELECT COUNT(*) FROM (SELECT dml_co_pt_r.a,dml_co_pt_r.b,dml_co_pt_s.c FROM dml_co_pt_s INNER JOIN dml_co_pt_r on dml_co_pt_r.a = dml_co_pt_s.a)foo;
@@ -710,7 +704,7 @@ INSERT INTO dml_co_pt_r SELECT dml_co_pt_r.a,dml_co_pt_r.b,dml_co_pt_s.c FROM dm
 SELECT COUNT(*) FROM dml_co_pt_r;
 rollback;
 
--- test12: Join on the distribution key of target table. Insert Large number of rows
+--Join on the distribution key of target table. Insert Large number of rows
 begin;
 SELECT COUNT(*) FROM dml_co_pt_s;
 SELECT COUNT(*) FROM (SELECT dml_co_pt_r.a,dml_co_pt_r.b,dml_co_pt_s.c FROM dml_co_pt_s INNER JOIN dml_co_pt_r on dml_co_pt_r.b = dml_co_pt_s.b)foo;
@@ -718,7 +712,7 @@ INSERT INTO dml_co_pt_s SELECT dml_co_pt_r.a,dml_co_pt_r.b,dml_co_pt_s.c FROM dm
 SELECT COUNT(*) FROM dml_co_pt_s;
 rollback;
 
--- test13: Join with different column order
+--Join with different column order
 begin;
 SELECT COUNT(*) FROM dml_co_pt_r;
 SELECT COUNT(*) FROM (SELECT dml_co_pt_s.a,dml_co_pt_r.b,'text' FROM dml_co_pt_r,dml_co_pt_s  WHERE dml_co_pt_r.b = dml_co_pt_s.b)foo;
@@ -726,7 +720,7 @@ INSERT INTO dml_co_pt_r(b,a,c) SELECT dml_co_pt_s.a,dml_co_pt_r.b,'text' FROM dm
 SELECT COUNT(*) FROM dml_co_pt_r;
 rollback;
 
--- test14: Join with Aggregate
+--Join with Aggregate
 begin;
 SELECT COUNT(*) FROM dml_co_pt_r;
 ALTER TABLE dml_co_pt_r ADD DEFAULT partition def;
@@ -735,7 +729,7 @@ INSERT INTO dml_co_pt_r SELECT COUNT(*) + dml_co_pt_s.a, dml_co_pt_r.b + dml_co_
 SELECT COUNT(*) FROM dml_co_pt_r;
 rollback;
 
--- test15: Join with DISTINCT
+--Join with DISTINCT
 begin;
 SELECT COUNT(*) FROM dml_co_pt_s;
 SELECT COUNT(*) FROM (SELECT DISTINCT dml_co_pt_r.a,dml_co_pt_r.b,dml_co_pt_s.c FROM dml_co_pt_s INNER JOIN dml_co_pt_r on dml_co_pt_s.a = dml_co_pt_r.a)foo;
@@ -743,7 +737,7 @@ INSERT INTO dml_co_pt_s SELECT DISTINCT dml_co_pt_r.a,dml_co_pt_r.b,dml_co_pt_s.
 SELECT COUNT(*) FROM dml_co_pt_s;
 rollback;
 
--- test16: Insert NULL with Joins
+--Insert NULL with Joins
 begin;
 SELECT COUNT(*) FROM dml_co_pt_r;
 SELECT COUNT(*) FROM (SELECT NULL,dml_co_pt_r.b,'text' FROM dml_co_pt_r,dml_co_pt_s WHERE dml_co_pt_r.b = dml_co_pt_s.b)foo;
@@ -751,17 +745,17 @@ INSERT INTO dml_co_pt_r SELECT NULL,dml_co_pt_r.b,'text' FROM dml_co_pt_r,dml_co
 SELECT COUNT(*) FROM dml_co_pt_r;
 rollback;
 
--- test18: Insert 0 rows
+--Insert 0 rows
 SELECT COUNT(*) FROM dml_co_pt_r;
 INSERT INTO dml_co_pt_r SELECT dml_co_pt_r.* FROM dml_co_pt_r,dml_co_pt_s WHERE dml_co_pt_r.b = dml_co_pt_s.a LIMIT 0;
 SELECT COUNT(*) FROM dml_co_pt_r;
 
--- test19: Insert 0 rows
+--Insert 0 rows
 SELECT COUNT(*) FROM dml_co_pt_r;
 INSERT INTO dml_co_pt_r SELECT dml_co_pt_r.* FROM dml_co_pt_r,dml_co_pt_s WHERE dml_co_pt_r.b = dml_co_pt_s.a and false;
 SELECT COUNT(*) FROM dml_co_pt_r;
 
--- test21: Negative test case. INSERT has more expressions than target columns
+--Negative test case. INSERT has more expressions than target columns
 begin;
 SELECT COUNT(*) FROM dml_co_pt_s;
 SELECT COUNT(*) FROM (SELECT COUNT(*) as a, dml_co_pt_r.b, dml_co_pt_r.c, dml_co_pt_r.d FROM dml_co_pt_r, dml_co_pt_s WHERE dml_co_pt_s.a = dml_co_pt_r.a GROUP BY dml_co_pt_r.a, dml_co_pt_r.b, dml_co_pt_r.c, dml_co_pt_r.d)foo;
@@ -769,7 +763,7 @@ INSERT INTO dml_co_pt_s SELECT COUNT(*) as a, dml_co_pt_r.b, dml_co_pt_r.c, dml_
 SELECT COUNT(*) FROM dml_co_pt_s;
 rollback;
 
--- test22: Insert with join on the partition key
+--Insert with join on the partition key
 begin;
 SELECT COUNT(*) FROM dml_co_pt_r;
 SELECT COUNT(*) FROM (SELECT dml_co_pt_r.* FROM dml_co_pt_r, dml_co_pt_s WHERE dml_co_pt_r.b = dml_co_pt_s.b)foo;
@@ -777,18 +771,18 @@ INSERT INTO dml_co_pt_r SELECT dml_co_pt_r.* FROM dml_co_pt_r, dml_co_pt_s WHERE
 SELECT COUNT(*) FROM dml_co_pt_r;
 rollback;
 
--- test24: Negative test - Insert NULL value to a table without default partition
+--Negative test - Insert NULL value to a table without default partition
 SELECT COUNT(*) FROM dml_co_pt_r;
 SELECT COUNT(*) FROM (SELECT dml_co_pt_r.b, NULL, dml_co_pt_r.c FROM dml_co_pt_r, dml_co_pt_s WHERE dml_co_pt_r.b = dml_co_pt_s.b)foo;
 INSERT INTO dml_co_pt_r SELECT dml_co_pt_r.b, NULL, dml_co_pt_r.c FROM dml_co_pt_r, dml_co_pt_s WHERE dml_co_pt_r.b = dml_co_pt_s.b;
 SELECT COUNT(*) FROM dml_co_pt_r;
 
--- test25: Negative test - Insert out of partition range values for table without default partition
+--Negative test - Insert out of partition range values for table without default partition
 SELECT COUNT(*) FROM dml_co_pt_r;
 INSERT INTO dml_co_pt_r SELECT dml_co_pt_r.b ,dml_co_pt_r.a + dml_co_pt_s.a + 100, dml_co_pt_r.c FROM dml_co_pt_r, dml_co_pt_s WHERE dml_co_pt_r.a = dml_co_pt_s.b;
 SELECT COUNT(*) FROM dml_co_pt_r;
 
--- test4: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_co_r;
 INSERT INTO dml_co_r values(generate_series(1,10), generate_series(1,100), 'text');
@@ -796,7 +790,7 @@ SELECT COUNT(*) FROM dml_co_r WHERE c ='text';
 SELECT COUNT(*) FROM dml_co_r;
 rollback;
 
--- test5: Insert with generate_series and NULL
+--Insert with generate_series and NULL
 begin;
 SELECT COUNT(*) FROM dml_co_r;
 INSERT INTO dml_co_r values(generate_series(1,10),NULL,'text');
@@ -804,7 +798,7 @@ SELECT * FROM dml_co_r WHERE c ='text' ORDER BY 1;
 SELECT COUNT(*) FROM dml_co_r;
 rollback;
 
--- test6: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_co_r;
 TRUNCATE TABLE dml_co_r;
@@ -814,7 +808,7 @@ SELECT COUNT(*) FROM dml_co_r;
 SELECT COUNT(*) FROM dml_co_r;
 rollback;
 
--- test7: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_co_r;
 INSERT INTO dml_co_r SELECT generate_series(1,10), generate_series(1,10),'text';
@@ -822,14 +816,14 @@ SELECT COUNT(*) FROM dml_co_r WHERE c ='text';
 SELECT COUNT(*) FROM dml_co_r;
 rollback;
 
--- test8: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_co_r;
 INSERT INTO dml_co_r SELECT * from generate_series(1,10);
 SELECT COUNT(*) FROM dml_co_r;
 rollback;
 
--- test9: Join on the non-distribution key of target table
+--Join on the non-distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_co_r;
 SELECT COUNT(*) FROM (SELECT dml_co_r.* FROM dml_co_r,dml_co_s  WHERE dml_co_r.b = dml_co_s.b)foo;
@@ -837,7 +831,7 @@ INSERT INTO dml_co_r SELECT dml_co_r.* FROM dml_co_r,dml_co_s  WHERE dml_co_r.b 
 SELECT COUNT(*) FROM dml_co_r;
 rollback;
 
--- test10: Join on the distribution key of target table
+--Join on the distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_co_s;
 SELECT COUNT(*) FROM (SELECT dml_co_s.* FROM dml_co_r,dml_co_s WHERE dml_co_s.a = dml_co_r.a)foo;
@@ -845,7 +839,7 @@ INSERT INTO dml_co_s SELECT dml_co_s.* FROM dml_co_r,dml_co_s WHERE dml_co_s.a =
 SELECT COUNT(*) FROM dml_co_s;
 rollback;
 
--- test11: Join on distribution key of target table
+--Join on distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_co_r;
 SELECT COUNT(*) FROM (SELECT dml_co_r.a,dml_co_r.b,dml_co_s.c FROM dml_co_s INNER JOIN dml_co_r on dml_co_r.a = dml_co_s.a)foo;
@@ -853,7 +847,7 @@ INSERT INTO dml_co_r SELECT dml_co_r.a,dml_co_r.b,dml_co_s.c FROM dml_co_s INNER
 SELECT COUNT(*) FROM dml_co_r;
 rollback;
 
--- test12: Join on the distribution key of target table. Insert Large number of rows
+--Join on the distribution key of target table. Insert Large number of rows
 begin;
 SELECT COUNT(*) FROM dml_co_s;
 SELECT COUNT(*) FROM (SELECT dml_co_r.a,dml_co_r.b,dml_co_s.c FROM dml_co_s INNER JOIN dml_co_r on dml_co_r.b <> dml_co_s.b )foo;
@@ -861,7 +855,7 @@ INSERT INTO dml_co_s SELECT dml_co_r.a,dml_co_r.b,dml_co_s.c FROM dml_co_s INNER
 SELECT COUNT(*) FROM dml_co_s;
 rollback;
 
--- test13: Join with different column order
+--Join with different column order
 begin;
 SELECT COUNT(*) FROM dml_co_r;
 SELECT COUNT(*) FROM (SELECT dml_co_s.a,dml_co_r.b,'text' FROM dml_co_r,dml_co_s  WHERE dml_co_r.b = dml_co_s.b)foo;
@@ -869,7 +863,7 @@ INSERT INTO dml_co_r(b,a,c) SELECT dml_co_s.a,dml_co_r.b,'text' FROM dml_co_r,dm
 SELECT COUNT(*) FROM dml_co_r;
 rollback;
 
--- test14: Join with Aggregate
+--Join with Aggregate
 begin;
 SELECT COUNT(*) FROM dml_co_r;
 SELECT COUNT(*) FROM (SELECT COUNT(*) + dml_co_s.a, dml_co_r.b + dml_co_r.a ,'text' FROM dml_co_r, dml_co_s WHERE dml_co_r.b = dml_co_s.b GROUP BY dml_co_s.a,dml_co_r.b,dml_co_r.a)foo;
@@ -877,7 +871,7 @@ INSERT INTO dml_co_r SELECT COUNT(*) + dml_co_s.a, dml_co_r.b + dml_co_r.a ,'tex
 SELECT COUNT(*) FROM dml_co_r;
 rollback;
 
--- test15: Join with DISTINCT
+--Join with DISTINCT
 begin;
 SELECT COUNT(*) FROM dml_co_s;
 SELECT COUNT(*) FROM (SELECT DISTINCT dml_co_r.a,dml_co_r.b,dml_co_s.c FROM dml_co_s INNER JOIN dml_co_r on dml_co_s.a = dml_co_r.a)foo;
@@ -885,7 +879,7 @@ INSERT INTO dml_co_s SELECT DISTINCT dml_co_r.a,dml_co_r.b,dml_co_s.c FROM dml_c
 SELECT COUNT(*) FROM dml_co_s;
 rollback;
 
--- test16: Insert NULL with Joins
+--Insert NULL with Joins
 begin;
 SELECT COUNT(*) FROM dml_co_r;
 SELECT COUNT(*) FROM (SELECT NULL,dml_co_r.b,'text' FROM dml_co_r,dml_co_s WHERE dml_co_r.b = dml_co_s.b)foo;
@@ -893,7 +887,7 @@ INSERT INTO dml_co_r SELECT NULL,dml_co_r.b,'text' FROM dml_co_r,dml_co_s WHERE 
 SELECT COUNT(*) FROM dml_co_r;
 rollback;
 
--- test17: Insert and CASE
+--Insert and CASE
 begin;
 SELECT COUNT(*) FROM dml_co_r;
 SELECT COUNT(*) FROM (SELECT A,B, case when c ='s' then C  else NULL end as C FROM (SELECT sum(dml_co_p.a) as A, dml_co_p.a as B, dml_co_s.c as C FROM dml_co_p, dml_co_s WHERE dml_co_p.a = dml_co_s.a GROUP BY dml_co_p.a,dml_co_s.c)as x GROUP BY A,B,C)foo;
@@ -901,29 +895,29 @@ INSERT INTO dml_co_r SELECT A,B, case when c ='s' then C  else NULL end as C FRO
 SELECT COUNT(*) FROM dml_co_r;
 rollback;
 
--- test18: Insert 0 rows
+--Insert 0 rows
 SELECT COUNT(*) FROM dml_co_r;
 INSERT INTO dml_co_r SELECT dml_co_r.* FROM dml_co_r,dml_co_s WHERE dml_co_r.b = dml_co_s.a LIMIT 0;
 SELECT COUNT(*) FROM dml_co_r;
 
--- test19: Insert 0 rows
+--Insert 0 rows
 SELECT COUNT(*) FROM dml_co_r;
 INSERT INTO dml_co_r SELECT dml_co_r.* FROM dml_co_r,dml_co_s WHERE dml_co_r.b = dml_co_s.a and false;
 SELECT COUNT(*) FROM dml_co_r;
 
--- test20: Negative tests Insert column of different data type
+--Negative tests Insert column of different data type
 SELECT COUNT(*) FROM dml_co_r;
 SELECT COUNT(*) FROM ( SELECT ('a')::int, dml_co_r.b,10 FROM dml_co_s WHERE dml_co_r.b = dml_co_s.b)foo;
 INSERT INTO dml_co_r SELECT ('a')::int, dml_co_r.b,10 FROM dml_co_s WHERE dml_co_r.b = dml_co_s.b;
 SELECT COUNT(*) FROM dml_co_r;
 
--- test21: Negative test case. INSERT has more expressions than target columns
+--Negative test case. INSERT has more expressions than target columns
 SELECT COUNT(*) FROM dml_co_s;
 SELECT COUNT(*) FROM (SELECT COUNT(*) as a, dml_co_r.* FROM dml_co_r, dml_co_s WHERE dml_co_s.a = dml_co_r.a GROUP BY dml_co_r.a, dml_co_r.b, dml_co_r.c)foo;
 INSERT INTO dml_co_s SELECT COUNT(*) as a, dml_co_r.* FROM dml_co_r, dml_co_s WHERE dml_co_s.a = dml_co_r.a GROUP BY dml_co_r.a, dml_co_r.b, dml_co_r.c;
 SELECT COUNT(*) FROM dml_co_s;
 
--- test1: Insert data that satisfy the check constraints
+--Insert data that satisfy the check constraints
 begin;
 SELECT COUNT(*) FROM dml_heap_check_s;
 SELECT COUNT(*) FROM (SELECT dml_heap_check_s.a, dml_heap_check_s.b, 'text', dml_heap_check_s.d FROM dml_heap_check_r, dml_heap_check_s WHERE dml_heap_check_r.a = dml_heap_check_s.b )foo;
@@ -931,80 +925,80 @@ INSERT INTO dml_heap_check_s SELECT dml_heap_check_s.a, dml_heap_check_s.b, 'tex
 SELECT COUNT(*) FROM dml_heap_check_s;
 rollback;
 
--- test2: Negative test - Insert default value violates check constraint
+--Negative test - Insert default value violates check constraint
 SELECT COUNT(*) FROM dml_heap_check_p;
 INSERT INTO dml_heap_check_p select generate_series(1,100),'p', generate_series(1,100);
 SELECT COUNT(*) FROM dml_heap_check_p;
 
--- test3: Negative test - Insert default value violates NOT NULL constraint
+--Negative test - Insert default value violates NOT NULL constraint
 SELECT COUNT(*) FROM dml_heap_check_s;
 INSERT INTO dml_heap_check_s values(default,1,'nn',1.0000);
 SELECT COUNT(*) FROM dml_heap_check_s;
 
--- test4: Negative test - Insert with joins where the result tuples violate the user defined check constraint
+--Negative test - Insert with joins where the result tuples violate the user defined check constraint
 SELECT COUNT(*) FROM dml_heap_check_r;
 SELECT COUNT(*) FROM (SELECT dml_heap_check_r.a + 110 , dml_heap_check_r.b, dml_heap_check_r.c, dml_heap_check_r.d FROM dml_heap_check_r, dml_heap_check_s WHERE dml_heap_check_r.a = dml_heap_check_s.a)foo;
 INSERT INTO dml_heap_check_r SELECT dml_heap_check_r.a + 110 , dml_heap_check_r.b, dml_heap_check_r.c, dml_heap_check_r.d FROM dml_heap_check_r, dml_heap_check_s WHERE dml_heap_check_r.a = dml_heap_check_s.a AND dml_heap_check_r.b > 10;
 SELECT COUNT(*) FROM dml_heap_check_r;
 
--- test5: Insert with joins where the result tuples violate violates multiple check constraints
+--Insert with joins where the result tuples violate violates multiple check constraints
 SELECT COUNT(*) FROM dml_heap_check_r;
 SELECT COUNT(*) FROM (SELECT dml_heap_check_r.a + 110 , 0, dml_heap_check_r.c, NULL FROM dml_heap_check_r, dml_heap_check_s WHERE dml_heap_check_r.a = dml_heap_check_s.a)foo;
 INSERT INTO dml_heap_check_r SELECT dml_heap_check_r.a + 110 , 0, dml_heap_check_r.c, NULL FROM dml_heap_check_r, dml_heap_check_s WHERE dml_heap_check_r.a = dml_heap_check_s.a;
 SELECT COUNT(*) FROM dml_heap_check_r;
 
--- test1: Update data that satisfy the check constraints
+--Update data that satisfy the check constraints
 begin;
 SELECT SUM(d) FROM dml_heap_check_s;
 UPDATE dml_heap_check_s SET d = dml_heap_check_s.d * 1 FROM dml_heap_check_r WHERE dml_heap_check_r.a = dml_heap_check_s.b;
 SELECT SUM(d) FROM dml_heap_check_s;
 rollback;
 
--- test2: Negative test: Update data that does not satisfy the check constraints
+--Negative test: Update data that does not satisfy the check constraints
 UPDATE dml_heap_check_s SET a = 100 + dml_heap_check_s.a FROM dml_heap_check_r WHERE dml_heap_check_r.a = dml_heap_check_s.a AND dml_heap_check_s.a = 99;
 
--- test3: Negative test - Update violates check constraint(not NULL constraint)
+--Negative test - Update violates check constraint(not NULL constraint)
 UPDATE dml_heap_check_s SET b = NULL FROM dml_heap_check_r WHERE dml_heap_check_r.a = dml_heap_check_s.b and dml_heap_check_s.b = 99;
 
--- test4: Negative test - Update moving tuple across partition .also violates the check constraint
+--Negative test - Update moving tuple across partition .also violates the check constraint
 UPDATE dml_heap_check_s SET a = 110 + dml_heap_check_s.a FROM dml_heap_check_r WHERE dml_heap_check_r.a = dml_heap_check_s.a;
 
--- test4: Delete with generate_series
+--Delete with generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_s;
 DELETE FROM dml_heap_s USING generate_series(1,10);
 SELECT COUNT(*) FROM dml_heap_s;
 rollback;
 
--- test5: Delete with join on distcol
+--Delete with join on distcol
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
 DELETE FROM dml_heap_r USING dml_heap_s WHERE dml_heap_r.a = dml_heap_s.a;
 SELECT COUNT(*) FROM dml_heap_r;
 rollback;
 
--- test6: Delete with join on non-distribution column
+--Delete with join on non-distribution column
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
 DELETE FROM dml_heap_r USING dml_heap_s WHERE dml_heap_r.b = dml_heap_s.b;
 SELECT COUNT(*) FROM dml_heap_r;
 rollback;
 
--- test7: Delete with join on non-distribution column
+--Delete with join on non-distribution column
 begin;
 SELECT COUNT(*) FROM dml_heap_s;
 DELETE FROM dml_heap_s USING dml_heap_r WHERE dml_heap_s.a = dml_heap_r.a;
 SELECT COUNT(*) FROM dml_heap_s;
 rollback;
 
--- test8: Delete and using
+--Delete and using
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
 DELETE FROM dml_heap_r USING dml_heap_s;
 SELECT COUNT(*) FROM dml_heap_r;
 rollback;
 
--- test9: Delete and using (with no rows)
+--Delete and using (with no rows)
 begin;
 TRUNCATE TABLE dml_heap_s;
 SELECT COUNT(*) FROM dml_heap_r;
@@ -1012,42 +1006,42 @@ DELETE FROM dml_heap_r USING dml_heap_s;
 SELECT COUNT(*) FROM dml_heap_r;
 rollback;
 
--- test10: Delete with join in using
+--Delete with join in using
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
 DELETE FROM dml_heap_r USING (SELECT dml_heap_r.a FROM dml_heap_r, dml_heap_s WHERE dml_heap_r.a = dml_heap_s.a)foo WHERE dml_heap_r.a = foo.a;
 SELECT COUNT(*) FROM dml_heap_r;
 rollback;
 
--- test11: Delete with join in USING (Delete all rows )
+--Delete with join in USING (Delete all rows )
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
 DELETE FROM dml_heap_r USING (SELECT 1)foo;
 SELECT COUNT(*) FROM dml_heap_r;
 rollback;
 
--- test12: Delete with join in using
+--Delete with join in using
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
 DELETE FROM dml_heap_r USING (SELECT 1 as t) foo WHERE foo.t = dml_heap_r.a;
 SELECT COUNT(*) FROM dml_heap_r;
 rollback;
 
--- test13: Delete with multiple joins
+--Delete with multiple joins
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
 DELETE FROM dml_heap_r USING dml_heap_s,dml_heap_p WHERE dml_heap_r.a = dml_heap_s.b and dml_heap_r.b = dml_heap_p.a;
 SELECT COUNT(*) FROM dml_heap_r;
 rollback;
 
--- test14: Delete on table with composite distcol
+--Delete on table with composite distcol
 begin;
 SELECT COUNT(*) FROM dml_heap_p;
 DELETE FROM dml_heap_p USING dml_heap_r WHERE dml_heap_p.b::int = dml_heap_r.b::int and dml_heap_p.a = dml_heap_r.a;
 SELECT COUNT(*) FROM dml_heap_p;
 rollback;
 
--- test15: Delete with PREPARE plan
+--Delete with PREPARE plan
 begin;
 SELECT COUNT(*) FROM (SELECT dml_heap_r.b FROM dml_heap_r,dml_heap_s WHERE dml_heap_r.b = dml_heap_s.b) foo;
 SELECT COUNT(*) FROM dml_heap_r;
@@ -1056,7 +1050,7 @@ EXECUTE plan_del;
 SELECT COUNT(*) FROM dml_heap_r;
 rollback;
 
--- test16: Delete with PREPARE plan
+--Delete with PREPARE plan
 begin;
 SELECT COUNT(*) FROM (SELECT dml_heap_r.b FROM dml_heap_r,dml_heap_s WHERE dml_heap_r.a = dml_heap_s.a)foo;
 SELECT COUNT(*) FROM dml_heap_s;
@@ -1065,19 +1059,19 @@ EXECUTE plan_del_2;
 SELECT COUNT(*) FROM dml_heap_s;
 rollback;
 
--- test17: Delete with sub-query
+--Delete with sub-query
 SELECT COUNT(*) FROM dml_heap_s;
 DELETE FROM dml_heap_s WHERE a = (SELECT dml_heap_r.a FROM dml_heap_r,dml_heap_s WHERE dml_heap_r.a = dml_heap_s.a);
 SELECT COUNT(*) FROM dml_heap_s;
 
--- test1: Delete from table
+--Delete from table
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_s;
 DELETE FROM dml_heap_pt_s;
 SELECT COUNT(*) FROM dml_heap_pt_s;
 rollback;
 
--- test2: Delete with predicate
+--Delete with predicate
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_s;
 SELECT COUNT(*) FROM dml_heap_pt_s WHERE a > 100;
@@ -1086,7 +1080,7 @@ SELECT COUNT(*) FROM dml_heap_pt_s;
 SELECT COUNT(*) FROM dml_heap_pt_s WHERE a > 100;
 rollback;
 
--- test3: Delete with predicate
+--Delete with predicate
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_s;
 SELECT COUNT(*) FROM dml_heap_pt_s WHERE a is NULL;
@@ -1094,42 +1088,42 @@ DELETE FROM dml_heap_pt_s WHERE a is NULL;
 SELECT COUNT(*) FROM dml_heap_pt_s;
 rollback;
 
--- test4: Delete with generate_series
+--Delete with generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_s;
 DELETE FROM dml_heap_pt_s USING generate_series(1,10);
 SELECT COUNT(*) FROM dml_heap_pt_s;
 rollback;
 
--- test5: Delete with join on distcol
+--Delete with join on distcol
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
 DELETE FROM dml_heap_pt_r USING dml_heap_pt_s WHERE dml_heap_pt_r.a = dml_heap_pt_s.a;
 SELECT COUNT(*) FROM dml_heap_pt_r;
 rollback;
 
--- test6: Delete with join on non-distribution column
+--Delete with join on non-distribution column
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
 DELETE FROM dml_heap_pt_r USING dml_heap_pt_s WHERE dml_heap_pt_r.b = dml_heap_pt_s.b;
 SELECT COUNT(*) FROM dml_heap_pt_r;
 rollback;
 
--- test7: Delete with join on non-distribution column
+--Delete with join on non-distribution column
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_s;
 DELETE FROM dml_heap_pt_s USING dml_heap_pt_r WHERE dml_heap_pt_s.a = dml_heap_pt_r.a;
 SELECT COUNT(*) FROM dml_heap_pt_s;
 rollback;
 
--- test8: Delete and using
+--Delete and using
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
 DELETE FROM dml_heap_pt_r USING dml_heap_pt_s;
 SELECT COUNT(*) FROM dml_heap_pt_r;
 rollback;
 
--- test9: Delete and using (with no rows)
+--Delete and using (with no rows)
 begin;
 TRUNCATE TABLE dml_heap_pt_s;
 SELECT COUNT(*) FROM dml_heap_pt_r;
@@ -1137,42 +1131,42 @@ DELETE FROM dml_heap_pt_r USING dml_heap_pt_s;
 SELECT COUNT(*) FROM dml_heap_pt_r;
 rollback;
 
--- test10: Delete with join in using
+--Delete with join in using
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
 DELETE FROM dml_heap_pt_r USING (SELECT dml_heap_pt_r.a FROM dml_heap_pt_r, dml_heap_pt_s WHERE dml_heap_pt_r.a = dml_heap_pt_s.a)foo WHERE dml_heap_pt_r.a = foo.a;
 SELECT COUNT(*) FROM dml_heap_pt_r;
 rollback;
 
--- test11: Delete with join in USING (Delete all rows )
+--Delete with join in USING (Delete all rows )
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
 DELETE FROM dml_heap_pt_r USING (SELECT 1)foo;
 SELECT COUNT(*) FROM dml_heap_pt_r;
 rollback;
 
--- test12: Delete with join in using
+--Delete with join in using
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
 DELETE FROM dml_heap_pt_r USING (SELECT 1 as t) foo WHERE foo.t = dml_heap_pt_r.a;
 SELECT COUNT(*) FROM dml_heap_pt_r;
 rollback;
 
--- test13: Delete with multiple joins
+--Delete with multiple joins
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
 DELETE FROM dml_heap_pt_r USING dml_heap_pt_s,dml_heap_pt_p WHERE dml_heap_pt_r.a = dml_heap_pt_s.b and dml_heap_pt_r.b = dml_heap_pt_p.a;
 SELECT COUNT(*) FROM dml_heap_pt_r;
 rollback;
 
--- test14: Delete on table with composite distcol
+--Delete on table with composite distcol
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_p;
 DELETE FROM dml_heap_pt_p USING dml_heap_pt_r WHERE dml_heap_pt_p.b::int = dml_heap_pt_r.b::int and dml_heap_pt_p.a = dml_heap_pt_r.a;
 SELECT COUNT(*) FROM dml_heap_pt_p;
 rollback;
 
--- test15: Delete with PREPARE plan
+--Delete with PREPARE plan
 begin;
 SELECT COUNT(*) FROM (SELECT dml_heap_pt_r.b FROM dml_heap_pt_r,dml_heap_pt_s WHERE dml_heap_pt_r.b = dml_heap_pt_s.b) foo;
 SELECT COUNT(*) FROM dml_heap_pt_r;
@@ -1181,7 +1175,7 @@ EXECUTE plan_del_3;
 SELECT COUNT(*) FROM dml_heap_pt_r;
 rollback;
 
--- test16: Delete with PREPARE plan
+--Delete with PREPARE plan
 begin;
 SELECT COUNT(*) FROM (SELECT dml_heap_pt_r.b FROM dml_heap_pt_r,dml_heap_pt_s WHERE dml_heap_pt_r.a = dml_heap_pt_s.a)foo;
 SELECT COUNT(*) FROM dml_heap_pt_s;
@@ -1190,12 +1184,12 @@ EXECUTE plan_del_4;
 SELECT COUNT(*) FROM dml_heap_pt_s;
 rollback;
 
--- test17: Delete with sub-query
+--Delete with sub-query
 SELECT COUNT(*) FROM dml_heap_pt_s;
 DELETE FROM dml_heap_pt_s WHERE a = (SELECT dml_heap_pt_r.a FROM dml_heap_pt_r,dml_heap_pt_s WHERE dml_heap_pt_r.a = dml_heap_pt_s.a);
 SELECT COUNT(*) FROM dml_heap_pt_s;
 
--- test4: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
 INSERT INTO dml_heap_pt_r values(generate_series(1,10), generate_series(1,100), 'text');
@@ -1203,7 +1197,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r WHERE c ='text';
 SELECT COUNT(*) FROM dml_heap_pt_r;
 rollback;
 
--- test5: Insert with generate_series and NULL
+--Insert with generate_series and NULL
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
 ALTER TABLE dml_heap_pt_r ADD DEFAULT partition def;
@@ -1213,7 +1207,7 @@ ALTER TABLE dml_heap_pt_r DROP DEFAULT partition;
 SELECT COUNT(*) FROM dml_heap_pt_r;
 rollback;
 
--- test6: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
 TRUNCATE TABLE dml_heap_pt_r;
@@ -1223,7 +1217,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 SELECT COUNT(*) FROM dml_heap_pt_r;
 rollback;
 
--- test7: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
 INSERT INTO dml_heap_pt_r SELECT generate_series(1,10), generate_series(1,10),'text';
@@ -1231,14 +1225,14 @@ SELECT COUNT(*) FROM dml_heap_pt_r WHERE c ='text';
 SELECT COUNT(*) FROM dml_heap_pt_r;
 rollback;
 
--- test8: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
 INSERT INTO dml_heap_pt_r SELECT *,1 from generate_series(1,10);
 SELECT COUNT(*) FROM dml_heap_pt_r;
 rollback;
 
--- test9: Join on the non-distribution key of target table
+--Join on the non-distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
 SELECT COUNT(*) FROM (SELECT dml_heap_pt_r.* FROM dml_heap_pt_r,dml_heap_pt_s  WHERE dml_heap_pt_r.b = dml_heap_pt_s.a)foo;
@@ -1246,7 +1240,7 @@ INSERT INTO dml_heap_pt_r SELECT dml_heap_pt_r.* FROM dml_heap_pt_r,dml_heap_pt_
 SELECT COUNT(*) FROM dml_heap_pt_r;
 rollback;
 
--- test10: Join on the distribution key of target table
+--Join on the distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_s;
 SELECT COUNT(*) FROM (SELECT dml_heap_pt_s.* FROM dml_heap_pt_r,dml_heap_pt_s WHERE dml_heap_pt_s.a = dml_heap_pt_r.a)foo;
@@ -1254,7 +1248,7 @@ INSERT INTO dml_heap_pt_s SELECT dml_heap_pt_s.* FROM dml_heap_pt_r,dml_heap_pt_
 SELECT COUNT(*) FROM dml_heap_pt_s;
 rollback;
 
--- test11: Join on distribution key of target table
+--Join on distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
 SELECT COUNT(*) FROM (SELECT dml_heap_pt_r.a,dml_heap_pt_r.b,dml_heap_pt_s.c FROM dml_heap_pt_s INNER JOIN dml_heap_pt_r on dml_heap_pt_r.a = dml_heap_pt_s.a)foo;
@@ -1262,7 +1256,7 @@ INSERT INTO dml_heap_pt_r SELECT dml_heap_pt_r.a,dml_heap_pt_r.b,dml_heap_pt_s.c
 SELECT COUNT(*) FROM dml_heap_pt_r;
 rollback;
 
--- test12: Join on the distribution key of target table. Insert Large number of rows
+--Join on the distribution key of target table. Insert Large number of rows
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_s;
 SELECT COUNT(*) FROM (SELECT dml_heap_pt_r.a,dml_heap_pt_r.b,dml_heap_pt_s.c FROM dml_heap_pt_s INNER JOIN dml_heap_pt_r on dml_heap_pt_r.b = dml_heap_pt_s.b)foo;
@@ -1270,7 +1264,7 @@ INSERT INTO dml_heap_pt_s SELECT dml_heap_pt_r.a,dml_heap_pt_r.b,dml_heap_pt_s.c
 SELECT COUNT(*) FROM dml_heap_pt_s;
 rollback;
 
--- test13: Join with different column order
+--Join with different column order
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
 SELECT COUNT(*) FROM (SELECT dml_heap_pt_s.a,dml_heap_pt_r.b,'text' FROM dml_heap_pt_r,dml_heap_pt_s  WHERE dml_heap_pt_r.b = dml_heap_pt_s.b)foo;
@@ -1278,7 +1272,7 @@ INSERT INTO dml_heap_pt_r(b,a,c) SELECT dml_heap_pt_s.a,dml_heap_pt_r.b,'text' F
 SELECT COUNT(*) FROM dml_heap_pt_r;
 rollback;
 
--- test14: Join with Aggregate
+--Join with Aggregate
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
 ALTER TABLE dml_heap_pt_r ADD DEFAULT partition def;
@@ -1288,7 +1282,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r;
 ALTER TABLE dml_heap_pt_r DROP DEFAULT partition;
 rollback;
 
--- test15: Join with DISTINCT
+--Join with DISTINCT
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_s;
 SELECT COUNT(*) FROM (SELECT DISTINCT dml_heap_pt_r.a,dml_heap_pt_r.b,dml_heap_pt_s.c FROM dml_heap_pt_s INNER JOIN dml_heap_pt_r on dml_heap_pt_s.a = dml_heap_pt_r.a)foo;
@@ -1296,7 +1290,7 @@ INSERT INTO dml_heap_pt_s SELECT DISTINCT dml_heap_pt_r.a,dml_heap_pt_r.b,dml_he
 SELECT COUNT(*) FROM dml_heap_pt_s;
 rollback;
 
--- test16: Insert NULL with Joins
+--Insert NULL with Joins
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
 SELECT COUNT(*) FROM (SELECT NULL,dml_heap_pt_r.b,'text' FROM dml_heap_pt_r,dml_heap_pt_s WHERE dml_heap_pt_r.b = dml_heap_pt_s.b)foo;
@@ -1304,23 +1298,23 @@ INSERT INTO dml_heap_pt_r SELECT NULL,dml_heap_pt_r.b,'text' FROM dml_heap_pt_r,
 SELECT COUNT(*) FROM dml_heap_pt_r;
 rollback;
 
--- test18: Insert 0 rows
+--Insert 0 rows
 SELECT COUNT(*) FROM dml_heap_pt_r;
 INSERT INTO dml_heap_pt_r SELECT dml_heap_pt_r.* FROM dml_heap_pt_r,dml_heap_pt_s WHERE dml_heap_pt_r.b = dml_heap_pt_s.a LIMIT 0;
 SELECT COUNT(*) FROM dml_heap_pt_r;
 
--- test19: Insert 0 rows
+--Insert 0 rows
 SELECT COUNT(*) FROM dml_heap_pt_r;
 INSERT INTO dml_heap_pt_r SELECT dml_heap_pt_r.* FROM dml_heap_pt_r,dml_heap_pt_s WHERE dml_heap_pt_r.b = dml_heap_pt_s.a and false;
 SELECT COUNT(*) FROM dml_heap_pt_r;
 
--- test20: Negative tests Insert column of different data type
+--Negative tests Insert column of different data type
 SELECT COUNT(*) FROM dml_heap_pt_r;
 SELECT COUNT(*) FROM (SELECT ('a')::int, dml_heap_pt_r.b,10 FROM dml_heap_pt_s WHERE dml_heap_pt_r.b = dml_heap_pt_s.b)foo;
 INSERT INTO dml_heap_pt_r SELECT ('a')::int, dml_heap_pt_r.b,10 FROM dml_heap_pt_s WHERE dml_heap_pt_r.b = dml_heap_pt_s.b;
 SELECT COUNT(*) FROM dml_heap_pt_r;
 
--- test21: Negative test case. INSERT has more expressions than target columns
+--Negative test case. INSERT has more expressions than target columns
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_s;
 SELECT COUNT(*) FROM (SELECT COUNT(*) as a, dml_heap_pt_r.b, dml_heap_pt_r.c, dml_heap_pt_r.d FROM dml_heap_pt_r, dml_heap_pt_s WHERE dml_heap_pt_s.a = dml_heap_pt_r.a GROUP BY dml_heap_pt_r.a, dml_heap_pt_r.b, dml_heap_pt_r.c, dml_heap_pt_r.d)foo;
@@ -1328,7 +1322,7 @@ INSERT INTO dml_heap_pt_s SELECT COUNT(*) as a, dml_heap_pt_r.b, dml_heap_pt_r.c
 SELECT COUNT(*) FROM dml_heap_pt_s;
 rollback;
 
--- test22: Insert with join on the partition key
+--Insert with join on the partition key
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r;
 SELECT COUNT(*) FROM (SELECT dml_heap_pt_r.* FROM dml_heap_pt_r, dml_heap_pt_s WHERE dml_heap_pt_r.b = dml_heap_pt_s.b)foo;
@@ -1336,39 +1330,39 @@ INSERT INTO dml_heap_pt_r SELECT dml_heap_pt_r.* FROM dml_heap_pt_r, dml_heap_pt
 SELECT COUNT(*) FROM dml_heap_pt_r;
 rollback;
 
--- test24: Negative test - Insert NULL value to a table without default partition
+--Negative test - Insert NULL value to a table without default partition
 SELECT COUNT(*) FROM dml_heap_pt_r;
 INSERT INTO dml_heap_pt_r SELECT dml_heap_pt_r.b, NULL, dml_heap_pt_r.c FROM dml_heap_pt_r, dml_heap_pt_s WHERE dml_heap_pt_r.b = dml_heap_pt_s.b;
 SELECT COUNT(*) FROM dml_heap_pt_r;
 
--- test25: Negative test - Insert out of partition range values for table without default partition
+--Negative test - Insert out of partition range values for table without default partition
 SELECT COUNT(*) FROM dml_heap_pt_r;
 INSERT INTO dml_heap_pt_r SELECT dml_heap_pt_r.b ,dml_heap_pt_r.a + dml_heap_pt_s.a + 100, dml_heap_pt_r.c FROM dml_heap_pt_r, dml_heap_pt_s WHERE dml_heap_pt_r.a = dml_heap_pt_s.b;
 SELECT COUNT(*) FROM dml_heap_pt_r;
 
 
--- update_test1: Update to constant value
+--Update to constant value
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE c ='text';
 UPDATE dml_heap_pt_r SET c = 'text';
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE c ='text';
 rollback;
 
--- update_test2: Update and set distribution key to constant
+--Update and set distribution key to constant
 begin;
 SELECT COUNT(*) FROM (SELECT DISTINCT(b) FROM dml_heap_pt_s)foo;
 UPDATE dml_heap_pt_s SET b = 10;
 SELECT COUNT(*) FROM (SELECT DISTINCT(b) FROM dml_heap_pt_s)foo;
 rollback;
 
--- update_test3: Update to default value
+--Update to default value
 begin;
 SELECT SUM(a) FROM dml_heap_pt_r;
 UPDATE dml_heap_pt_r SET a = DEFAULT;
 SELECT SUM(a) FROM dml_heap_pt_r;
 rollback;
 
--- update_test4: Update to default value
+--Update to default value
 begin;
 SELECT SUM(a) FROM dml_heap_pt_r;
 SELECT SUM(b) FROM dml_heap_pt_r;
@@ -1378,14 +1372,14 @@ SELECT SUM(a) FROM dml_heap_pt_r;
 SELECT SUM(b) FROM dml_heap_pt_r;
 rollback;
 
--- update_test5: Update and reset the value
+--Update and reset the value
 begin;
 SELECT COUNT(*) FROM (SELECT DISTINCT(a) FROM dml_heap_pt_r)foo;
 UPDATE dml_heap_pt_r SET a = a;
 SELECT COUNT(*) FROM (SELECT DISTINCT(a) FROM dml_heap_pt_r)foo;
 rollback;
 
--- update_test6: Update and generate_series
+--Update and generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE a = 1;
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE c ='n';
@@ -1394,31 +1388,31 @@ SELECT COUNT(*) FROM dml_heap_pt_r WHERE c ='n';
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE a = 1;
 rollback;
 
--- update_test7: Update distcol where join on target table non dist key
+--Update distcol where join on target table non dist key
 begin;
 SELECT SUM(a) FROM dml_heap_pt_r;
 UPDATE dml_heap_pt_r SET a = dml_heap_pt_r.a + 1 FROM dml_heap_pt_s WHERE dml_heap_pt_r.a = dml_heap_pt_s.a;
 SELECT SUM(a) FROM dml_heap_pt_r;
 rollback;
 
--- update_test8: Update and from values
+--Update and from values
 begin;
 SELECT * FROM dml_heap_pt_r WHERE b = 20 ORDER BY 1;
 UPDATE dml_heap_pt_r SET a = v.i + 1 FROM (VALUES(100, 20)) as v(i, j) WHERE dml_heap_pt_r.b = v.j;
 SELECT * FROM dml_heap_pt_r WHERE b = 20 ORDER BY 1;
 rollback;
 
--- update_test9: Update with Joins and set to constant value
+--Update with Joins and set to constant value
 SELECT COUNT(*) FROM dml_heap_pt_s WHERE b = 10;
 UPDATE dml_heap_pt_s SET b = 10 FROM dml_heap_pt_r WHERE dml_heap_pt_r.b = dml_heap_pt_s.a;
 SELECT COUNT(*) FROM dml_heap_pt_s WHERE b = 10;
 
--- update_test10: Update distcol with predicate in subquery
+--Update distcol with predicate in subquery
 begin;
 UPDATE dml_heap_pt_r SET a = dml_heap_pt_r.a + 1 FROM dml_heap_pt_s WHERE dml_heap_pt_r.b = dml_heap_pt_s.a and dml_heap_pt_s.b in (SELECT dml_heap_pt_s.b + dml_heap_pt_r.a FROM dml_heap_pt_s,dml_heap_pt_r WHERE dml_heap_pt_r.a > 10);
 rollback;
 
--- update_test11: Update with aggregate in subquery
+--Update with aggregate in subquery
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_s WHERE b = (SELECT COUNT(*) FROM dml_heap_pt_s);
 SELECT COUNT(*) FROM dml_heap_pt_s;
@@ -1426,13 +1420,13 @@ UPDATE dml_heap_pt_s SET b = (SELECT COUNT(*) FROM dml_heap_pt_s) FROM dml_heap_
 SELECT COUNT(*) FROM dml_heap_pt_s WHERE b = (SELECT COUNT(*) FROM dml_heap_pt_s);
 rollback;
 
--- update_test12: Update and limit in subquery
+--Update and limit in subquery
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE a = 1;
 SELECT DISTINCT(b) FROM dml_heap_pt_s ORDER BY 1 LIMIT 1;
 UPDATE dml_heap_pt_r SET a = (SELECT DISTINCT(b) FROM dml_heap_pt_s ORDER BY 1 LIMIT 1) FROM dml_heap_pt_s WHERE dml_heap_pt_r.b = dml_heap_pt_s.a;
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE a = 1;
 
--- update_test13: Update multiple columns
+--Update multiple columns
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE b is NULL;
 SELECT dml_heap_pt_s.a + 10 FROM dml_heap_pt_r,dml_heap_pt_s WHERE dml_heap_pt_r.a = dml_heap_pt_s.a ORDER BY 1 LIMIT 1;
@@ -1444,7 +1438,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r WHERE b is NULL;
 ALTER TABLE dml_heap_pt_r DROP DEFAULT partition;
 rollback;
 
--- update_test14: Update multiple columns
+--Update multiple columns
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE c='z';
 SELECT dml_heap_pt_s.a ,dml_heap_pt_s.b,'z' FROM dml_heap_pt_r,dml_heap_pt_s WHERE dml_heap_pt_r.a = dml_heap_pt_s.b ORDER BY 1,2 LIMIT 1;
 ALTER TABLE dml_heap_pt_r ADD DEFAULT partition def;
@@ -1453,70 +1447,70 @@ SELECT * FROM dml_heap_pt_r WHERE c='z' ORDER BY 1 LIMIT 1;
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE c='z';
 ALTER TABLE dml_heap_pt_r DROP DEFAULT partition;
 
--- update_test15: Update with prepare plans
+--Update with prepare plans
 begin;
 PREPARE plan_upd as UPDATE dml_heap_pt_r SET a = dml_heap_pt_s.a +1 FROM dml_heap_pt_s WHERE dml_heap_pt_r.a = dml_heap_pt_s.b ;
 EXECUTE plan_upd;
 rollback;
 
--- update_test16: Update and case
+--Update and case
 begin;
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE a = 20 ;
 UPDATE dml_heap_pt_r SET a = (SELECT case when c = 'r' then MAX(b) else 100 end FROM dml_heap_pt_r GROUP BY c) ;
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE a = 20 ;
 rollback;
 
--- update_test17: Negative test - Update with sub-query returning more than one row
+--Negative test - Update with sub-query returning more than one row
 SELECT SUM(a) FROM dml_heap_pt_r;
 UPDATE dml_heap_pt_r SET a = ( SELECT DISTINCT(b) FROM dml_heap_pt_s ) FROM dml_heap_pt_s WHERE dml_heap_pt_r.b = dml_heap_pt_s.a;
 SELECT SUM(a) FROM dml_heap_pt_r;
 
--- update_test18: Negative test - Update with sub-query returning more than one row
+--Negative test - Update with sub-query returning more than one row
 SELECT SUM(b) FROM dml_heap_pt_r;
 UPDATE dml_heap_pt_r SET b = (SELECT dml_heap_pt_r.b FROM dml_heap_pt_r,dml_heap_pt_s WHERE dml_heap_pt_r.a = dml_heap_pt_s.a );
 SELECT SUM(b) FROM dml_heap_pt_r;
 
--- update_test20: Negative test - Update WHERE join returns more than one tuple with different values.
+--Negative test - Update WHERE join returns more than one tuple with different values.
 CREATE TABLE dml_heap_pt_u as SELECT i as a, i as b  FROM generate_series(1,10)i;
 CREATE TABLE dml_heap_pt_v as SELECT i as a, i as b FROM generate_series(1,10)i;
 SELECT SUM(a) FROM dml_heap_pt_v;
 UPDATE dml_heap_pt_v SET a = dml_heap_pt_u.a FROM dml_heap_pt_u WHERE dml_heap_pt_u.b = dml_heap_pt_v.b;
 SELECT SUM(a) FROM dml_heap_pt_v;
 
--- update_test21: Update with joins on multiple table
+--Update with joins on multiple table
 begin;
 SELECT SUM(a) FROM dml_heap_pt_r;
 UPDATE dml_heap_pt_r SET a = dml_heap_pt_r.b+1 FROM dml_heap_pt_p,dml_heap_pt_s WHERE dml_heap_pt_r.b = dml_heap_pt_s.b and dml_heap_pt_r.a = dml_heap_pt_p.b+1;
 SELECT SUM(a) FROM dml_heap_pt_r;
 rollback;
 
--- update_test22: Update on table with composite distribution key
+--Update on table with composite distribution key
 -- This currently falls back to planner, even if ORCA is enabled. And planner can't
 -- produce plans that update distribution key columns.
 SELECT SUM(a) FROM dml_heap_pt_r;
 UPDATE dml_heap_pt_p SET a = dml_heap_pt_p.b % 2 FROM dml_heap_pt_r WHERE dml_heap_pt_p.b::int = dml_heap_pt_r.b::int and dml_heap_pt_p.a = dml_heap_pt_r.a;
 SELECT SUM(a) FROM dml_heap_pt_r;
 
--- update_test23: Update on table with composite distribution key
+--Update on table with composite distribution key
 begin;
 SELECT SUM(b) FROM dml_heap_pt_p;
 UPDATE dml_heap_pt_p SET b = (dml_heap_pt_p.b * 1.1)::int FROM dml_heap_pt_r WHERE dml_heap_pt_p.b = dml_heap_pt_r.a and dml_heap_pt_p.b = dml_heap_pt_r.b;
 SELECT SUM(b) FROM dml_heap_pt_p;
 rollback;
 
--- test24: Update the partition key and move tuples across partitions( moving tuple to default partition)
+--Update the partition key and move tuples across partitions( moving tuple to default partition)
 begin;
 SELECT SUM(a) FROM dml_heap_pt_s;
 UPDATE dml_heap_pt_s SET a = dml_heap_pt_r.a + 30000 FROM dml_heap_pt_r WHERE dml_heap_pt_r.b = dml_heap_pt_s.b;
 SELECT SUM(a) FROM dml_heap_pt_s;
 rollback;
 
--- test25: Negative test update partition key (no default partition)
+--Negative test update partition key (no default partition)
 SELECT SUM(b) FROM dml_heap_pt_r;
 UPDATE dml_heap_pt_r SET b = dml_heap_pt_r.a + 3000000 FROM dml_heap_pt_s WHERE dml_heap_pt_r.a = dml_heap_pt_s.a;
 SELECT SUM(b) FROM dml_heap_pt_r;
 
--- test4: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
 INSERT INTO dml_heap_r values(generate_series(1,10), generate_series(1,100), 'text');
@@ -1524,7 +1518,7 @@ SELECT COUNT(*) FROM dml_heap_r WHERE c ='text';
 SELECT COUNT(*) FROM dml_heap_r;
 rollback;
 
--- test5: Insert with generate_series and NULL
+--Insert with generate_series and NULL
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
 INSERT INTO dml_heap_r values(generate_series(1,10),NULL,'text');
@@ -1532,7 +1526,7 @@ SELECT * FROM dml_heap_r WHERE c ='text' ORDER BY 1;
 SELECT COUNT(*) FROM dml_heap_r;
 rollback;
 
--- test6: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
 TRUNCATE TABLE dml_heap_r;
@@ -1542,7 +1536,7 @@ SELECT COUNT(*) FROM dml_heap_r;
 SELECT COUNT(*) FROM dml_heap_r;
 rollback;
 
--- test7: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
 INSERT INTO dml_heap_r SELECT generate_series(1,10), generate_series(1,10),'text';
@@ -1550,14 +1544,14 @@ SELECT COUNT(*) FROM dml_heap_r WHERE c ='text';
 SELECT COUNT(*) FROM dml_heap_r;
 rollback;
 
--- test8: Insert with generate_series
+--Insert with generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
 INSERT INTO dml_heap_r SELECT * from generate_series(1,10);
 SELECT COUNT(*) FROM dml_heap_r;
 rollback;
 
--- test9: Join on the non-distribution key of target table
+--Join on the non-distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
 SELECT COUNT(*) FROM (SELECT dml_heap_r.* FROM dml_heap_r,dml_heap_s  WHERE dml_heap_r.b = dml_heap_s.b)foo;
@@ -1565,7 +1559,7 @@ INSERT INTO dml_heap_r SELECT dml_heap_r.* FROM dml_heap_r,dml_heap_s  WHERE dml
 SELECT COUNT(*) FROM dml_heap_r;
 rollback;
 
--- test10: Join on the distribution key of target table
+--Join on the distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_heap_s;
 SELECT COUNT(*) FROM (SELECT dml_heap_s.* FROM dml_heap_r,dml_heap_s WHERE dml_heap_s.a = dml_heap_r.a)foo;
@@ -1573,7 +1567,7 @@ INSERT INTO dml_heap_s SELECT dml_heap_s.* FROM dml_heap_r,dml_heap_s WHERE dml_
 SELECT COUNT(*) FROM dml_heap_s;
 rollback;
 
--- test11: Join on distribution key of target table
+--Join on distribution key of target table
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
 SELECT COUNT(*) FROM (SELECT dml_heap_r.a,dml_heap_r.b,dml_heap_s.c FROM dml_heap_s INNER JOIN dml_heap_r on dml_heap_r.a = dml_heap_s.a)foo;
@@ -1581,7 +1575,7 @@ INSERT INTO dml_heap_r SELECT dml_heap_r.a,dml_heap_r.b,dml_heap_s.c FROM dml_he
 SELECT COUNT(*) FROM dml_heap_r;
 rollback;
 
--- test12: Join on the distribution key of target table. Insert Large number of rows
+--Join on the distribution key of target table. Insert Large number of rows
 begin;
 SELECT COUNT(*) FROM dml_heap_s;
 SELECT COUNT(*) FROM (SELECT dml_heap_r.a,dml_heap_r.b,dml_heap_s.c FROM dml_heap_s INNER JOIN dml_heap_r on dml_heap_r.b <> dml_heap_s.b )foo;
@@ -1589,7 +1583,7 @@ INSERT INTO dml_heap_s SELECT dml_heap_r.a,dml_heap_r.b,dml_heap_s.c FROM dml_he
 SELECT COUNT(*) FROM dml_heap_s;
 rollback;
 
--- test13: Join with different column order
+--Join with different column order
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
 SELECT COUNT(*) FROM (SELECT dml_heap_s.a,dml_heap_r.b,'text' FROM dml_heap_r,dml_heap_s  WHERE dml_heap_r.b = dml_heap_s.b)foo;
@@ -1597,7 +1591,7 @@ INSERT INTO dml_heap_r(b,a,c) SELECT dml_heap_s.a,dml_heap_r.b,'text' FROM dml_h
 SELECT COUNT(*) FROM dml_heap_r;
 rollback;
 
--- test14: Join with Aggregate
+--Join with Aggregate
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
 SELECT COUNT(*) FROM (SELECT COUNT(*) + dml_heap_s.a, dml_heap_r.b + dml_heap_r.a ,'text' FROM dml_heap_r, dml_heap_s WHERE dml_heap_r.b = dml_heap_s.b GROUP BY dml_heap_s.a,dml_heap_r.b,dml_heap_r.a)foo;
@@ -1605,7 +1599,7 @@ INSERT INTO dml_heap_r SELECT COUNT(*) + dml_heap_s.a, dml_heap_r.b + dml_heap_r
 SELECT COUNT(*) FROM dml_heap_r;
 rollback;
 
--- test15: Join with DISTINCT
+--Join with DISTINCT
 begin;
 SELECT COUNT(*) FROM dml_heap_s;
 SELECT COUNT(*) FROM (SELECT DISTINCT dml_heap_r.a,dml_heap_r.b,dml_heap_s.c FROM dml_heap_s INNER JOIN dml_heap_r on dml_heap_s.a = dml_heap_r.a)foo;
@@ -1613,7 +1607,7 @@ INSERT INTO dml_heap_s SELECT DISTINCT dml_heap_r.a,dml_heap_r.b,dml_heap_s.c FR
 SELECT COUNT(*) FROM dml_heap_s;
 rollback;
 
--- test16: Insert NULL with Joins
+--Insert NULL with Joins
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
 SELECT COUNT(*) FROM (SELECT NULL,dml_heap_r.b,'text' FROM dml_heap_r,dml_heap_s WHERE dml_heap_r.b = dml_heap_s.b)foo;
@@ -1621,7 +1615,7 @@ INSERT INTO dml_heap_r SELECT NULL,dml_heap_r.b,'text' FROM dml_heap_r,dml_heap_
 SELECT COUNT(*) FROM dml_heap_r;
 rollback;
 
--- test17: Insert and CASE
+--Insert and CASE
 begin;
 SELECT COUNT(*) FROM dml_heap_r;
 SELECT COUNT(*) FROM (SELECT A,B, case when c ='s' then C  else NULL end as C FROM (SELECT sum(dml_heap_p.a) as A, dml_heap_p.a as B, dml_heap_s.c as C FROM dml_heap_p, dml_heap_s WHERE dml_heap_p.a = dml_heap_s.a GROUP BY dml_heap_p.a,dml_heap_s.c)as x GROUP BY A,B,C)foo;
@@ -1629,29 +1623,29 @@ INSERT INTO dml_heap_r SELECT A,B, case when c ='s' then C  else NULL end as C F
 SELECT COUNT(*) FROM dml_heap_r;
 rollback;
 
--- test18: Insert 0 rows
+--Insert 0 rows
 SELECT COUNT(*) FROM dml_heap_r;
 INSERT INTO dml_heap_r SELECT dml_heap_r.* FROM dml_heap_r,dml_heap_s WHERE dml_heap_r.b = dml_heap_s.a LIMIT 0;
 SELECT COUNT(*) FROM dml_heap_r;
 
--- test19: Insert 0 rows
+--Insert 0 rows
 SELECT COUNT(*) FROM dml_heap_r;
 INSERT INTO dml_heap_r SELECT dml_heap_r.* FROM dml_heap_r,dml_heap_s WHERE dml_heap_r.b = dml_heap_s.a and false;
 SELECT COUNT(*) FROM dml_heap_r;
 
--- test20: Negative tests Insert column of different data type
+--Negative tests Insert column of different data type
 SELECT COUNT(*) FROM dml_heap_r;
 SELECT COUNT(*) FROM ( SELECT ('a')::int, dml_heap_r.b,10 FROM dml_heap_s WHERE dml_heap_r.b = dml_heap_s.b)foo;
 INSERT INTO dml_heap_r SELECT ('a')::int, dml_heap_r.b,10 FROM dml_heap_s WHERE dml_heap_r.b = dml_heap_s.b;
 SELECT COUNT(*) FROM dml_heap_r;
 
--- test21: Negative test case. INSERT has more expressions than target columns
+--Negative test case. INSERT has more expressions than target columns
 SELECT COUNT(*) FROM dml_heap_s;
 SELECT COUNT(*) FROM (SELECT COUNT(*) as a, dml_heap_r.* FROM dml_heap_r, dml_heap_s WHERE dml_heap_s.a = dml_heap_r.a GROUP BY dml_heap_r.a, dml_heap_r.b, dml_heap_r.c)foo;
 INSERT INTO dml_heap_s SELECT COUNT(*) as a, dml_heap_r.* FROM dml_heap_r, dml_heap_s WHERE dml_heap_s.a = dml_heap_r.a GROUP BY dml_heap_r.a, dml_heap_r.b, dml_heap_r.c;
 SELECT COUNT(*) FROM dml_heap_s;
 
--- update_test6: Update and generate_series
+--Update and generate_series
 begin;
 SELECT SUM(a) FROM dml_heap_r WHERE a = 1;
 SELECT COUNT(*) FROM dml_heap_r WHERE c ='n';
@@ -1660,47 +1654,47 @@ SELECT COUNT(*) FROM dml_heap_r WHERE c ='n';
 SELECT SUM(a) FROM dml_heap_r WHERE a = 1;
 rollback;
 
--- update_test7: Update distcol where join on target table non dist key
+--Update distcol where join on target table non dist key
 begin;
 SELECT SUM(a) FROM dml_heap_r WHERE a = 1;
 UPDATE dml_heap_r SET a = dml_heap_r.a + 1 FROM dml_heap_s WHERE dml_heap_r.a = dml_heap_s.a;
 SELECT SUM(a) FROM dml_heap_r WHERE a = 1;
 rollback;
 
--- update_test8: Update and from values
+--Update and from values
 begin;
 SELECT SUM(b) FROM dml_heap_r WHERE b = 20;
 UPDATE dml_heap_r SET a = v.i + 1 FROM (VALUES(100, 20)) as v(i, j) WHERE dml_heap_r.b = v.j;
 SELECT SUM(b) FROM dml_heap_r WHERE b = 20;
 rollback;
 
--- update_test9: Update with Joins and set to constant value
+--Update with Joins and set to constant value
 begin;
 SELECT COUNT(*) FROM dml_heap_s WHERE b = 10;
 UPDATE dml_heap_s SET b = 10 FROM dml_heap_r WHERE dml_heap_r.b = dml_heap_s.a;
 SELECT COUNT(*) FROM dml_heap_s WHERE b = 10;
 rollback;
 
--- update_test10: Update distcol with predicate in subquery
+--Update distcol with predicate in subquery
 begin;
 UPDATE dml_heap_r SET a = dml_heap_r.a + 1 FROM dml_heap_s WHERE dml_heap_r.b = dml_heap_s.a and dml_heap_s.b in (SELECT dml_heap_s.b + dml_heap_r.a FROM dml_heap_s,dml_heap_r WHERE dml_heap_r.a > 10);
 rollback;
 
--- update_test11: Update with aggregate in subquery
+--Update with aggregate in subquery
 begin;
 SELECT COUNT(*) FROM dml_heap_s WHERE b = (SELECT COUNT(*) FROM dml_heap_s);
 UPDATE dml_heap_s SET b = (SELECT COUNT(*) FROM dml_heap_s) FROM dml_heap_r WHERE dml_heap_r.a = dml_heap_s.b;
 SELECT COUNT(*) FROM dml_heap_s WHERE b = (SELECT COUNT(*) FROM dml_heap_s);
 rollback;
 
--- update_test12: Update and limit in subquery
+--Update and limit in subquery
 begin;
 SELECT COUNT(*) FROM dml_heap_r WHERE a = 1;
 UPDATE dml_heap_r SET a = (SELECT DISTINCT(b) FROM dml_heap_s ORDER BY 1 LIMIT 1) FROM dml_heap_s WHERE dml_heap_r.b = dml_heap_s.a;
 SELECT COUNT(*) FROM dml_heap_r WHERE a = 1;
 rollback;
 
--- update_test13: Update multiple columns
+--Update multiple columns
 begin;
 SELECT COUNT(*) FROM dml_heap_r WHERE b is NULL;
 SELECT dml_heap_s.a + 10 FROM dml_heap_r,dml_heap_s WHERE dml_heap_r.a = dml_heap_s.a ORDER BY 1 LIMIT 1;
@@ -1710,7 +1704,7 @@ SELECT SUM(a) FROM dml_heap_r WHERE a = 1;
 SELECT COUNT(*) FROM dml_heap_r WHERE b is NULL;
 rollback;
 
--- update_test14: Update multiple columns
+--Update multiple columns
 begin;
 SELECT COUNT(*) FROM dml_heap_r WHERE c='z';
 SELECT dml_heap_s.a ,dml_heap_s.b,'z' FROM dml_heap_r,dml_heap_s WHERE dml_heap_r.a = dml_heap_s.b ORDER BY 1,2 LIMIT 1;
@@ -1719,46 +1713,46 @@ SELECT * FROM dml_heap_r WHERE c='z' ORDER BY 1 LIMIT 1;
 SELECT COUNT(*) FROM dml_heap_r WHERE c='z';
 rollback;
 
--- update_test15: Update with prepare plans
+--Update with prepare plans
 begin;
 PREPARE plan_upd_2 as UPDATE dml_heap_r SET a = dml_heap_s.a +1 FROM dml_heap_s WHERE dml_heap_r.a = dml_heap_s.b ;
 EXECUTE plan_upd_2;
 rollback;
 
--- update_test16: Update and case
+--Update and case
 begin;
 SELECT COUNT(*) FROM dml_heap_r WHERE a = 100 ;
 UPDATE dml_heap_r SET a = (SELECT case when c = 'r' then MAX(b) else 100 end FROM dml_heap_r GROUP BY c ORDER BY 1 LIMIT 1) ;
 SELECT COUNT(*) FROM dml_heap_r WHERE a = 100 ;
 rollback;
 
--- update_test17: Negative test - Update with sub-query returning more than one row
+--Negative test - Update with sub-query returning more than one row
 SELECT SUM(a) FROM dml_heap_r;
 UPDATE dml_heap_r SET a = ( SELECT DISTINCT(b) FROM dml_heap_s ) FROM dml_heap_s WHERE dml_heap_r.b = dml_heap_s.a;
 SELECT SUM(a) FROM dml_heap_r;
 
--- update_test18: Negative test - Update with sub-query returning more than one row
+--Negative test - Update with sub-query returning more than one row
 SELECT SUM(b) FROM dml_heap_r;
 UPDATE dml_heap_r SET b = (SELECT dml_heap_r.b FROM dml_heap_r,dml_heap_s WHERE dml_heap_r.a = dml_heap_s.a );
 SELECT SUM(b) FROM dml_heap_r;
 
--- update_test19: Negative test - Update with aggregates
+--Negative test - Update with aggregates
 SELECT SUM(b) FROM dml_heap_r;
 UPDATE dml_heap_r SET b = MAX(dml_heap_s.b) FROM dml_heap_s WHERE dml_heap_r.b = dml_heap_s.a;
 SELECT SUM(b) FROM dml_heap_r;
 
--- update_test20: Negative test - Update WHERE join returns more than one tuple with different values.
+--Negative test - Update WHERE join returns more than one tuple with different values.
 CREATE TABLE dml_heap_u as SELECT i as a, 1 as b  FROM generate_series(1,10)i;
 CREATE TABLE dml_heap_v as SELECT i as a ,i as b FROM generate_series(1,10)i;
 SELECT SUM(a) FROM dml_heap_v;
 UPDATE dml_heap_v SET a = dml_heap_u.a FROM dml_heap_u WHERE dml_heap_u.b = dml_heap_v.b;
 SELECT SUM(a) FROM dml_heap_v;
 
--- update_test21: Update with joins on multiple table
+--Update with joins on multiple table
 UPDATE dml_heap_r SET a = dml_heap_r.b+1 FROM dml_heap_p,dml_heap_s WHERE dml_heap_r.b = dml_heap_s.b and dml_heap_r.a = dml_heap_p.b+1;
 
--- update_test22: Update on table with composite distribution key
+--Update on table with composite distribution key
 UPDATE dml_heap_p SET a = dml_heap_p.b % 2 FROM dml_heap_r WHERE dml_heap_p.b::int = dml_heap_r.b::int and dml_heap_p.a = dml_heap_r.a;
 
--- update_test23: Update on table with composite distribution key
+--Update on table with composite distribution key
 UPDATE dml_heap_p SET b = (dml_heap_p.b * 1.1)::int FROM dml_heap_r WHERE dml_heap_p.b = dml_heap_r.a and dml_heap_p.b = dml_heap_r.b;


### PR DESCRIPTION
Similar to https://github.com/greenplum-db/gpdb/pull/3610.
This test may produce inconsistent result based on the partition which
it pick to validate the constraint. We have other places where we test
the similar intentions, so removing this flaky test.

Also removed the numbering of tests as it becomes cumbersome to maintain
the numbering.