### PR TITLE
Support gptransfer for 4.3 to master and update pipeline

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -49,7 +49,7 @@ groups:
 ################################
   - gate_cluster_start
   - mpp_interconnect
-  - DPM_gptransfer-5x-to-5x
+  - DPM_gptransfer
   - cs_crash_recovery_schema_topology
   - cs_crash_recovery_04_10
   - cs_crash_recovery_11_20
@@ -71,10 +71,9 @@ groups:
   - gate_mm_misc_end
 ################################
   - gate_nightly_start
-  - DPM_backup_43_restore_5
   - MM_gpexpand_1
   - MM_gpexpand_2
-  - DPM_gptransfer-43x-to-5x
+  - DPM_gptransfer_43x_to_master
   - cs_aoco_compression_large_01
   - cs_aoco_compression_large_02
   - cs_aoco_compression_large_03
@@ -142,14 +141,13 @@ groups:
   - cs_aoco_compression_small
   - cs_aoco_compression_small_serial
   - DPM_backup-restore
-  - DPM_gptransfer-43x-to-5x
-  - DPM_gptransfer-5x-to-5x
+  - DPM_gptransfer_43x_to_master
+  - DPM_gptransfer
   - MM_gpcheckcat
   - MM_gpexpand_1
   - MM_gpexpand_2
   - MM_gppkg
   - MM_gprecoverseg
-  - DPM_backup_43_restore_5
 
 - name: Experimental Tests
   jobs:
@@ -205,7 +203,7 @@ groups:
   jobs:
   - gate_cluster_start
   - mpp_interconnect
-  - DPM_gptransfer-5x-to-5x
+  - DPM_gptransfer
   - DPM_backup-restore
   - cs_crash_recovery_schema_topology
   - cs_crash_recovery_04_10
@@ -233,10 +231,9 @@ groups:
 - name: G:Nightly
   jobs:
   - gate_nightly_start
-  - DPM_backup_43_restore_5
   - MM_gpexpand_1
   - MM_gpexpand_2
-  - DPM_gptransfer-43x-to-5x
+  - DPM_gptransfer_43x_to_master
   - cs_aoco_compression_large_01
   - cs_aoco_compression_large_02
   - cs_aoco_compression_large_03
@@ -2110,7 +2107,7 @@ jobs:
     params:
       <<: *pulse_properties
       PULSE_PROJECT_NAME: "mpp-interconnect"
-- name: DPM_gptransfer-5x-to-5x
+- name: DPM_gptransfer
   plan:
   - aggregate:
     - get: gpdb_src
@@ -2309,7 +2306,7 @@ jobs:
   - aggregate:
     - get: gpdb_src
       passed:
-      - DPM_gptransfer-5x-to-5x
+      - DPM_gptransfer
       - DPM_backup-restore
       - mpp_interconnect
       - cs_crash_recovery_schema_topology
@@ -2596,70 +2593,6 @@ jobs:
     - get: gpdb_src_behave_tarball
       passed:
       - gate_icw_end
-- name: DPM_backup_43_restore_5
-  plan:
-  - get: nightly-trigger
-    tags: ["gpdb5_ccp_external_worker"]
-    trigger: ((nightly-trigger-flag))
-  - aggregate:
-    - get: gpdb_src
-      tags: ["gpdb5_ccp_external_worker"]
-      params:
-        submodules:
-        - gpMgmt/bin/pythonSrc/ext
-      passed: [gate_nightly_start]
-    - get: gpdb_binary
-      tags: ["gpdb5_ccp_external_worker"]
-      resource: bin_gpdb_centos6
-      passed: [gate_nightly_start]
-      trigger: ((reduced-frequency-trigger-flag))
-    - get: gpdb4_binary
-      tags: ["gpdb5_ccp_external_worker"]
-      resource: bin_gpdb4_centos6
-    - get: ccp_src
-      tags: ["gpdb5_ccp_external_worker"]
-    - get: centos-gpdb-dev-6
-      tags: ["gpdb5_ccp_external_worker"]
-  - put: terraform
-    tags: ["gpdb5_ccp_external_worker"]
-    params:
-      <<: *ccp_default_params
-      vars:
-        <<: *ccp_default_vars
-  - task: setup_gpdb4
-    tags: ["gpdb5_ccp_external_worker"]
-    file: ccp_src/ci/tasks/gen_cluster.yml
-    params:
-      <<: *ccp_gen_cluster_default_params
-    input_mapping:
-      gpdb_binary: gpdb4_binary
-    on_failure:
-      <<: *ccp_destroy
-  - task: run_backup_tests
-    tags: ["gpdb5_ccp_external_worker"]
-    file: gpdb_src/concourse/tasks/run_behave.yml
-    image: centos-gpdb-dev-6
-    params:
-      BEHAVE_FLAGS: --tags=backup_and_restore_backups --tags=-nbuonly --tags=-ddonly --tags=-skip_for_gpdb_43
-    on_failure:
-      <<: *debug_sleep
-  - task: setup_gpdb5
-    tags: ["gpdb5_ccp_external_worker"]
-    file: gpdb_src/concourse/tasks/setup_new_gpdb_for_backup_restore.yml
-    params:
-      <<: *ccp_gen_cluster_default_params
-    image: centos-gpdb-dev-6
-    on_failure:
-      <<: *debug_sleep
-  - task: run_restore_tests
-    tags: ["gpdb5_ccp_external_worker"]
-    file: gpdb_src/concourse/tasks/run_behave.yml
-    image: centos-gpdb-dev-6
-    params:
-      BEHAVE_FLAGS: --tags=backup_and_restore_restores --tags=-nbuonly --tags=-ddonly --tags=-skip_for_gpdb_43
-    on_failure:
-      <<: *debug_sleep
-  - *ccp_destroy
 - name: MM_gpexpand_1
   plan:
   - aggregate:
@@ -2746,7 +2679,7 @@ jobs:
     on_failure:
       <<: *debug_sleep
   - *ccp_destroy
-- name: DPM_gptransfer-43x-to-5x
+- name: DPM_gptransfer_43x_to_master
   plan:
   - get: nightly-trigger
     tags: ["gpdb5_ccp_external_worker"]
@@ -2985,7 +2918,6 @@ jobs:
     - get: gpdb_src
       trigger: true
       passed:
-      - DPM_backup_43_restore_5
       - MM_gpexpand_1
       - MM_gpexpand_2
       - cs_aoco_compression_large_01
@@ -2994,7 +2926,7 @@ jobs:
       - cs_aoco_compression_large_04
       - cs_aoco_compression_small
       - cs_aoco_compression_small_serial
-      - DPM_gptransfer-43x-to-5x
+      - DPM_gptransfer_43x_to_master
 ############### Nightly End
 
 ################ General Misc Start
@@ -3531,14 +3463,13 @@ jobs:
     - regression_tests_pxf_hdp
     - regression_tests_pxf_cdh
     - gpdb_rc_packaging_centos
-    - DPM_backup_43_restore_5
     - MM_gpcheckcat
     - MM_gprecoverseg
     - MM_gpexpand_1
     - MM_gpexpand_2
     - MM_gpinitstandby
-    - DPM_gptransfer-43x-to-5x
-    - DPM_gptransfer-5x-to-5x
+    - DPM_gptransfer_43x_to_master
+    - DPM_gptransfer
     - mpp_interconnect
     - QP_optimizer-functional
     - validate_pipeline

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gptransfer.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gptransfer.py
@@ -885,7 +885,7 @@ class GpTransfer(GpTestCase):
         self.assertEqual(escaped_query, validator._src_sql)
         self.assertEqual(escaped_query, validator._dest_sql)
 
-    def test__validate_good_range_partition_from_43x_to_5x(self):
+    def test__validate_good_range_partition_from_4_to_X(self):
         options = self.setup_partition_validation()
 
         singleton_side_effect = SingletonSideEffect()
@@ -914,7 +914,7 @@ class GpTransfer(GpTestCase):
         self.assertIn("Validating partition table transfer set...", self.get_info_messages())
 
 
-    def test__validate_good_list_partition_from_43x_to_5x(self):
+    def test__validate_good_list_partition_from_4_to_X(self):
         options = self.setup_partition_validation()
 
         singleton_side_effect = SingletonSideEffect()
@@ -939,7 +939,7 @@ class GpTransfer(GpTestCase):
 
         self.assertIn("Validating partition table transfer set...", self.get_info_messages())
 
-    def test__validate_good_multi_column_list_partition_from_43x_to_5x(self):
+    def test__validate_good_multi_column_list_partition_from_4_to_X(self):
         options = self.setup_partition_validation()
 
         singleton_side_effect = SingletonSideEffect()
@@ -965,7 +965,7 @@ class GpTransfer(GpTestCase):
 
         self.assertIn("Validating partition table transfer set...", self.get_info_messages())
 
-    def test__validate_good_multi_column_swapped_column_ordering_list_partition_from_5x_to_5x(self):
+    def test__validate_good_multi_column_swapped_column_ordering_list_partition_with_same_version(self):
         options = self.setup_partition_validation()
 
         singleton_side_effect = SingletonSideEffect()
@@ -991,7 +991,7 @@ class GpTransfer(GpTestCase):
 
         self.subject.GpTransfer(Mock(**options), [])
 
-    def test__validate_good_multi_column_swapped_column_ordering_list_partition_from_43x_to_5x(self):
+    def test__validate_good_multi_column_swapped_column_ordering_list_partition_from_4_to_X(self):
         options = self.setup_partition_validation()
 
         singleton_side_effect = SingletonSideEffect()

--- a/gpMgmt/bin/gptransfer_modules/partition_comparators.py
+++ b/gpMgmt/bin/gptransfer_modules/partition_comparators.py
@@ -1,8 +1,8 @@
 import re
 
 PARTITION_METADATA_PATTERN = re.compile('.*CONST (:.*) \[')
-KEY_WITH_METADATA_43X_TO_5X = ["parrangestart", "parrangeend", "parrangeevery", "parlistvalues"]
-KEY_WITH_METADATA_5X_TO_5X = ["version", "parrangestartincl"] + KEY_WITH_METADATA_43X_TO_5X
+KEY_WITH_METADATA_43_TO_5 = ["parrangestart", "parrangeend", "parrangeevery", "parlistvalues"]
+KEY_WITH_METADATA = ["version", "parrangestartincl"] + KEY_WITH_METADATA_43_TO_5
 
 
 class PartitionComparator(object):
@@ -28,11 +28,11 @@ class PartitionComparator(object):
         return result
 
 
-class Version4to5PartitionComparator(PartitionComparator):
+class Version4toXPartitionComparator(PartitionComparator):
 
     def _parse_value(self, partition_info_dict):
-        return super(Version4to5PartitionComparator, self)._parse_value(partition_info_dict,
-                                                                        KEY_WITH_METADATA_43X_TO_5X)
+        return super(Version4toXPartitionComparator, self)._parse_value(partition_info_dict,
+                                                                        KEY_WITH_METADATA_43_TO_5)
 
     def _remove_key_and_value(self, list_info, key_to_remove):
         while key_to_remove in list_info:
@@ -47,11 +47,11 @@ class Version4to5PartitionComparator(PartitionComparator):
         src_dict = self._parse_value(source_partition_info)
         dest_dict = self._parse_value(dest_partition_info)
 
-        for key in KEY_WITH_METADATA_43X_TO_5X:
-            version5_info = dest_dict[key]
+        for key in KEY_WITH_METADATA_43_TO_5:
+            version_info = dest_dict[key]
             # greenplum 5 added a 'consttypmod' attribute.
             # remove it so as to compare all other attributes
-            self._remove_key_and_value(version5_info, ':consttypmod')
+            self._remove_key_and_value(version_info, ':consttypmod')
             if src_dict[key] != dest_dict[key]:
                 return False
         return True
@@ -69,7 +69,7 @@ class SameVersionPartitionComparator(PartitionComparator):
         src_dict = self._parse_value(source_partition_info)
         dest_dict = self._parse_value(dest_partition_info)
 
-        for key in KEY_WITH_METADATA_5X_TO_5X:
+        for key in KEY_WITH_METADATA:
             if src_dict[key] != dest_dict[key]:
                 return False
         return True
@@ -81,8 +81,8 @@ class PartitionComparatorFactory:
         dest_ver = dest['version']
         if source_ver == dest_ver:
             return SameVersionPartitionComparator()
-        elif source_ver == '4.3' and dest_ver[0] == '5':
-            return Version4to5PartitionComparator()
+        elif source_ver == '4.3' and dest_ver != '4.3':
+            return Version4toXPartitionComparator()
 
         raise Exception("No comparator defined for source "
                         "and dest versions\n: %s \n\n %s" % (source, dest))


### PR DESCRIPTION
Previously, gptransfer only checked for the destination system to be on
GPDB5. Instead, check that the destination system is not GPDB4.

Remove backup 4.3 to 5 test and rename gptransfer tests. These were left over from the 5X branch. The gptransfer 4.3 to master test is still needed since this will be supported.