### PR TITLE
ci - Update timeouts for pr-pipeline

### DIFF
--- a/concourse/pipelines/pr_pipeline.yml
+++ b/concourse/pipelines/pr_pipeline.yml
@@ -125,7 +125,7 @@ jobs:
           BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
           TEST_OS: centos
           CONFIGURE_FLAGS: {{configure_flags}}
-        timeout: 1h
+        timeout: 2h
         on_failure: *pr_failure
 
       - task: icw_gporca_orca_centos6
@@ -139,7 +139,7 @@ jobs:
           BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
           TEST_OS: centos
           CONFIGURE_FLAGS: {{configure_flags}}
-        timeout: 2h30m
+        timeout: 5h
         on_failure: *pr_failure
 
       - task: icw_gporca_conan_ubuntu16
@@ -162,7 +162,7 @@ jobs:
           bin_gpdb: gpdb_artifacts
         params:
           TEST_OS: centos
-        timeout: 10m
+        timeout: 20m
         on_failure: *pr_failure
 
     - task: separate_qautils_files_for_rc


### PR DESCRIPTION
By looking at the Concourse database, we were able to find 3 jobs in the
pr pipeline that have failed due to timing out.  We are doubling the
timeouts for those 3 jobs only.

Signed-off-by: Alexandra Wang <lewang@pivotal.io>