### PR TITLE
Don't modify original query object during preprocessing

### DIFF
--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -2088,6 +2088,7 @@ rowtype_field_matches(Oid rowtypeid, int fieldnum,
 Query *
 fold_constants(PlannerGlobal *glob, Query *q, ParamListInfo boundParams, Size max_size)
 {
+	Query *query;
 	eval_const_expressions_context context;
 
 	context.glob = glob;
@@ -2100,9 +2101,10 @@ fold_constants(PlannerGlobal *glob, Query *q, ParamListInfo boundParams, Size ma
 
 	context.max_size = max_size;
 	
+	query = (Query *) copyObject(q);
 	return (Query *) query_or_expression_tree_mutator
 						(
-						(Node *) q,
+						(Node *) query,
 						eval_const_expressions_mutator,
 						&context,
 						0

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -2107,7 +2107,7 @@ fold_constants(PlannerGlobal *glob, Query *q, ParamListInfo boundParams, Size ma
 						(Node *) query,
 						eval_const_expressions_mutator,
 						&context,
-						0
+						QTW_DONT_COPY_QUERY
 						);
 }
 


### PR DESCRIPTION
For the following madlib query `select madlib.svec_plus('{1}:{4}', '{1}:{5}');`, we first do const folding before passing query to Orca. But during function evaluation, the 2 arguments are modified by madlib function. Before this patch, even the query object is copied in query_tree_mutator(), but it is flat copy. It just copy Datum of constvalue, not the actual data pointing by the constvalue. So to avoid assertion failure when folding constants, we have to do deep copy the whole query object.