### PR TITLE
Test for database up in tli_mismatch

### DIFF
--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/regress/test_basic.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/regress/test_basic.py
@@ -114,7 +114,7 @@ class regress(mpp.gpdb.tests.storage.walrepl.run.StandbyRunMixin, MPPTestCase):
         self.standby.promote()
 
         logger.info('Wait for the standby to be ready to accept connections ...')
-        time.sleep(3)
+        PSQL.wait_for_database_up(port=self.standby.port)
 
         # Verify the result replicated to the standby.
         logger.info('Verify if table foo exists...')
@@ -122,8 +122,9 @@ class regress(mpp.gpdb.tests.storage.walrepl.run.StandbyRunMixin, MPPTestCase):
                             str(self.standby.port))
 
         # The table should exist
-        stdout = proc.communicate()[0]
-        logger.info(stdout)
+        (stdout, stderr) = proc.communicate()
+        logger.info("stdout: %s" % stdout)
+        logger.info("stderr: %s" % stderr)
         search = "1000"
         self.assertTrue(stdout.find(search) >= 0)
 

--- a/src/test/tinc/tincrepo/mpp/lib/PSQL.py
+++ b/src/test/tinc/tincrepo/mpp/lib/PSQL.py
@@ -549,7 +549,7 @@ class PSQL(Command):
         return False
 
     @staticmethod
-    def wait_for_database_up():
+    def wait_for_database_up(dbname = None, host = None, port = None, username = None, password = None):
         '''
         Wait till the system is up, as master may take some time
         to come back after FI crash.
@@ -571,7 +571,9 @@ class PSQL(Command):
         time.sleep(30)
         for i in range(60):
             time.sleep(1)
-            res = PSQL.run_sql_command('select count(*) from gp_dist_random(\'gp_id\');', results=results)
+            res = PSQL.run_sql_command('select count(*) from gp_dist_random(\'gp_id\');',
+                                dbname=dbname, host=host, port=port, username = username,
+                                password=password, results=results)
             if results['rc'] == 0:
                 down = False
                 break


### PR DESCRIPTION
This fixes a flaky tinc test in which we fail over to a standby master, but
do not test to confirm the database is ready before querying it.

Signed-off-by: Xin Zhang <xzhang@pivotal.io>