### PR TITLE
Fix CTAS in UTILITY MODE after QueryDispatchDesc change

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -4705,6 +4705,7 @@ OpenIntoRel(QueryDesc *queryDesc)
 	char	   *intoTableSpaceName;
     GpPolicy   *targetPolicy;
 	bool		bufferPoolBulkLoad;
+	bool		validate_reloptions;
 
 	RelFileNode relFileNode;
 	
@@ -4807,7 +4808,12 @@ OpenIntoRel(QueryDesc *queryDesc)
 									 false);
 
 	/* get the relstorage (heap or AO tables) */
-	stdRdOptions = (StdRdOptions*) heap_reloptions(relkind, reloptions, queryDesc->ddesc->validate_reloptions);
+	if (queryDesc->ddesc)
+		validate_reloptions = queryDesc->ddesc->validate_reloptions;
+	else
+		validate_reloptions = true;
+
+	stdRdOptions = (StdRdOptions*) heap_reloptions(relkind, reloptions, validate_reloptions);
 	if(stdRdOptions->appendonly)
 		relstorage = stdRdOptions->columnstore ? RELSTORAGE_AOCOLS : RELSTORAGE_AOROWS;
 	else
@@ -4844,7 +4850,7 @@ OpenIntoRel(QueryDesc *queryDesc)
 											  targetPolicy,  	/* MPP */
 											  reloptions,
 											  allowSystemTableModsDDL,
-											  /* valid_opts */ !queryDesc->ddesc->validate_reloptions,
+											  /* valid_opts */ !validate_reloptions,
 						 					  &persistentTid,
 						 					  &persistentSerialNum);
 


### PR DESCRIPTION
In the below referenced commit, we added a new boolean
validate_reloptions to the QueryDispatchDesc. In UTILITY MODE, the
query descriptor does not have its QueryDispatchDesc initialized so
the segment would PANIC. To fix this, we default validate_reloptions
to true if the QueryDispatchDesc is not initialized as expected before
the change.

Reference:
https://github.com/greenplum-db/gpdb/commit/a3c07830258d62ae86ce9418b84ff0ca2e73e514

Authors: Jimmy Yih and Abhijit Subramanya