### PR TITLE
Make fsync default off to improve test stability.

### DIFF
--- a/concourse/scripts/run_tinc_test.sh
+++ b/concourse/scripts/run_tinc_test.sh
@@ -14,6 +14,10 @@ cat > ~/gpdb-env.sh << EOF
 EOF
 source ~/gpdb-env.sh
 
+# make fsync by default off to improve test stability
+gpconfig --skipvalidation -c fsync -v off
+gpstop -u
+
 createdb gptest
 createdb gpadmin
 cd ${TINC_DIR}


### PR DESCRIPTION
Signed-off-by: Taylor Vesely <tvesely@pivotal.io>
(cherry picked from commit 92311bfdd83472dceeea73571602ded867e74064)