### PR TITLE
fix bug gpload error count

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -1135,9 +1135,8 @@ class gpload:
         self.ERROR = 1
         self.options.qv = self.INFO
         self.options.l = None
-        self.lastcmdtime = ''
-        self.cmdtime = ''
         self.formatOpts = ""
+        self.startTimestamp = time.time()
         seenv = False
         seenq = False
 
@@ -2384,18 +2383,11 @@ class gpload:
                 results = self.db.query(queryStr.encode('utf-8')).getresult()
                 return (results[0])[0]
             else: # reuse_tables
-                queryStr = "select cmdtime, count(*) from gp_read_error_log('%s') group by cmdtime order by cmdtime desc limit 1" % pg.escape_string(self.extTableName)
+                queryStr = "select count(*) from gp_read_error_log('%s') where cmdtime > to_timestamp(%s)" % (pg.escape_string(self.extTableName), self.startTimestamp)
                 results = self.db.query(queryStr.encode('utf-8')).getresult()
                 global NUM_WARN_ROWS
-
-                if len(results) == 0:
-			NUM_WARN_ROWS = 0
-			return 0
-
-                if (results[0])[0] != self.cmdtime:
-                    self.lastcmdtime = (results[0])[0]
-                    NUM_WARN_ROWS = (results[0])[1]
-                    return (results[0])[1];
+                NUM_WARN_ROWS = (results[0])[0]
+                return (results[0])[0];
         return 0
 
     def report_errors(self):
@@ -2409,7 +2401,7 @@ class gpload:
         # if reuse_table is set, error message is not deleted.
         if errors and self.log_errors and self.reuse_tables:
             self.log(self.WARN, "Please use following query to access the detailed error")
-            self.log(self.WARN, "select * from gp_read_error_log('{0}') where cmdtime = '{1}'".format(pg.escape_string(self.extTableName), self.lastcmdtime))
+            self.log(self.WARN, "select * from gp_read_error_log('{0}') where cmdtime > to_timestamp('{1}')".format(pg.escape_string(self.extTableName), self.startTimestamp))
         self.exitValue = 1 if errors else 0
 
 
@@ -2417,12 +2409,6 @@ class gpload:
         """
         Handle the INSERT case
         """
-        if self.reuse_tables:
-            queryStr = "select cmdtime from gp_read_error_log('%s') group by cmdtime order by cmdtime desc limit 1" % pg.escape_string(self.extTableName)
-            results = self.db.query(queryStr.encode('utf-8')).getresult()
-            if len(results) > 0:
-                self.cmdtime = (results[0])[0]
-
         self.log(self.DEBUG, "into columns " + str(self.into_columns))
         cols = filter(lambda a:a[2]!=None, self.into_columns)
 

--- a/gpMgmt/bin/gpload_test/gpload2/init_file
+++ b/gpMgmt/bin/gpload_test/gpload2/init_file
@@ -17,4 +17,6 @@
 -- s/started gpfdist -p \d* -P \d* -f .*/ports/
 -- m/data_file.tbl/
 -- s/(").*data_file.tbl(")/data/
+-- m/cmdtime/
+-- s/cmdtime.*$/CONDITION/
 -- end_matchsubs

--- a/gpMgmt/bin/gpload_test/gpload2/query22.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query22.ans
@@ -1,0 +1,29 @@
+2017-10-27 02:32:34|INFO|gpload session started 2017-10-27 02:32:34
+2017-10-27 02:32:34|INFO|setting schema 'public' for table 'csvtable'
+2017-10-27 02:32:35|INFO|started gpfdist -p 8081 -P 8082 -f "/usr/local/greenplum-db-4.3.17.1/bin/gpload_test/gpload_formatopts_test/data_file.csv" -t 30
+2017-10-27 02:32:35|INFO|did not find an external table to reuse. creating ext_gpload_reusable_173dd57c_babf_11e7_8ae3_0242ac110003
+2017-10-27 02:32:35|WARN|5000 bad rows
+2017-10-27 02:32:35|WARN|Please use following query to access the detailed error
+2017-10-27 02:32:35|WARN|select * from gp_read_error_log('ext_gpload_reusable_173dd57c_babf_11e7_8ae3_0242ac110003') where cmdtime > to_timestamp('1509071554.95')
+2017-10-27 02:32:35|INFO|running time: 0.45 seconds
+2017-10-27 02:32:35|INFO|rows Inserted          = 5000
+2017-10-27 02:32:35|INFO|rows Updated           = 0
+2017-10-27 02:32:35|INFO|data formatting errors = 5000
+2017-10-27 02:32:35|INFO|gpload succeeded with warnings
+2017-10-27 02:32:35|INFO|gpload session started 2017-10-27 02:32:35
+2017-10-27 02:32:35|INFO|setting schema 'public' for table 'csvtable'
+2017-10-27 02:32:35|INFO|started gpfdist -p 8081 -P 8082 -f "/usr/local/greenplum-db-4.3.17.1/bin/gpload_test/gpload_formatopts_test/data_file.csv" -t 30
+2017-10-27 02:32:35|INFO|reusing external table ext_gpload_reusable_173dd57c_babf_11e7_8ae3_0242ac110003
+2017-10-27 02:32:35|WARN|5000 bad rows
+2017-10-27 02:32:35|WARN|Please use following query to access the detailed error
+2017-10-27 02:32:35|WARN|select * from gp_read_error_log('ext_gpload_reusable_173dd57c_babf_11e7_8ae3_0242ac110003') where cmdtime > to_timestamp('1509071555.52')
+2017-10-27 02:32:35|INFO|running time: 0.27 seconds
+2017-10-27 02:32:35|INFO|rows Inserted          = 5000
+2017-10-27 02:32:35|INFO|rows Updated           = 0
+2017-10-27 02:32:35|INFO|data formatting errors = 5000
+2017-10-27 02:32:35|INFO|gpload succeeded with warnings
+ count 
+-------
+ 10000
+(1 row)
+


### PR DESCRIPTION
gpload error count is incorrect when more than one segment has format
error, for the cmdtime is different, and only errors with the newest
cmdtime is counted.

So we add startTime which will be used for counting all the errors
occured during the same gpload operation.