### PR TITLE
Pass through bin_gpdb_centos7 for mpp_resource_group_centos7

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -2546,6 +2546,9 @@ jobs:
       - MM_gppkg
       - MM_gprecoverseg
     # Not used by icw group, but is passed through
+    - get: bin_gpdb_centos7
+      passed:
+      - gate_mm_misc_start
     - get: gpdb_src_tinc_tarball
       passed:
       - gate_mm_misc_start
@@ -2940,6 +2943,9 @@ jobs:
     - get: bin_gpdb_centos6
       passed:
       - gate_mm_misc_end
+    - get: bin_gpdb_centos7
+      passed:
+      - gate_mm_misc_end
 - name: MM_gpcheckcat
   plan:
   - aggregate:
@@ -3156,6 +3162,7 @@ jobs:
     - get: bin_gpdb
       tags: ["gpdb5_ccp_external_worker"]
       resource: bin_gpdb_centos7
+      passed: [gate_general_misc_start]
       trigger: true
     - get: ccp_src
       tags: ["gpdb5_ccp_external_worker"]


### PR DESCRIPTION
Previously, mpp_resource_group_centos7 use bin_gpdb_centos7 directly
which may cause the inconsistence of bin_gpdb_centos7 and gpdb_src.
This commit pass through bin_gpdb_centos7 from gate_mm_misc_start to
avoid this even though it's not used by mm_misc jobs.