### PR TITLE
Coverity fixes for FTS.

### DIFF
--- a/src/backend/fts/ftsprobefilerep.c
+++ b/src/backend/fts/ftsprobefilerep.c
@@ -49,7 +49,7 @@ static char probeSegment(CdbComponentDatabaseInfo *dbInfo)
 
 	probeInfo.segmentStatus = PROBE_DEAD;
 
-	return probeSegmentHelper(dbInfo, probeInfo);
+	return probeSegmentHelper(dbInfo, &probeInfo);
 }
 
 /*

--- a/src/include/postmaster/ftsprobe.h
+++ b/src/include/postmaster/ftsprobe.h
@@ -41,6 +41,6 @@ void
 #else
 char
 #endif
-probeSegmentHelper(CdbComponentDatabaseInfo *dbInfo, ProbeConnectionInfo probeInfo);
+probeSegmentHelper(CdbComponentDatabaseInfo *dbInfo, ProbeConnectionInfo *probeInfo);
 
 #endif


### PR DESCRIPTION
CID 178114: Performance inefficiencies  (PASS_BY_VALUE)
The `ProbeConnectionInfo` parameter was being passed to the
`probeSegmentHelper()` function by value. This is very inefficient. Fixed it by
passing the parameter as a reference using a pointer.

CID 178115: Calling "pqGetInt" without checking return value (as is done
elsewhere 52 out of 57 times).
The return value of `pqGetInt()` function was not being checked in the
`processProbeResponse()` function. Fixed it by checking for the return value.
If EOF is returned, a message is logged and false is returned to the caller.

Signed-off-by: Taylor Vesely <tvesely@pivotal.io>