### PR TITLE
resgroup: set proper cpu.shares for better performance.

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -323,6 +323,7 @@ char	   *gp_resqueue_priority_default_value;
 bool		gp_debug_resqueue_priority = false;
 
 /* Resource group GUCs */
+int			gp_resource_group_cpu_priority;
 double		gp_resource_group_cpu_limit;
 double		gp_resource_group_memory_limit;
 
@@ -3541,6 +3542,15 @@ struct config_int ConfigureNamesInt_gp[] =
 		},
 		&memory_spill_ratio,
 		20, 0, 100, NULL, NULL
+	},
+
+	{
+		{"gp_resource_group_cpu_priority", PGC_POSTMASTER, RESOURCES,
+			gettext_noop("Sets the cpu priority for postgres processes when resource group is enabled."),
+			NULL
+		},
+		&gp_resource_group_cpu_priority,
+		10, 1, 256, NULL, NULL
 	},
 
 	{

--- a/src/backend/utils/resgroup/resgroup-ops-linux.c
+++ b/src/backend/utils/resgroup/resgroup-ops-linux.c
@@ -620,12 +620,21 @@ ResGroupOps_Name(void)
 void
 ResGroupOps_Bless(void)
 {
+	/*
+	 * We only have to do these checks and initialization once on each host,
+	 * so only let postmaster do the job.
+	 */
 	if (IsUnderPostmaster)
 		return;
 
 	detectCgroupMountPoint();
 	checkPermission(0, true);
 
+	/*
+	 * Put postmaster and all the children processes into the gpdb cgroup,
+	 * otherwise auxiliary processes might get too low priority when
+	 * gp_resource_group_cpu_priority is set to a large value
+	 */
 	ResGroupOps_AssignGroup(InvalidOid, PostmasterPid);
 }
 

--- a/src/backend/utils/resgroup/resgroup-ops-linux.c
+++ b/src/backend/utils/resgroup/resgroup-ops-linux.c
@@ -23,6 +23,7 @@
 #error  cgroup is only available on linux
 #endif
 
+#include <fcntl.h>
 #include <unistd.h>
 #include <sched.h>
 #include <sys/file.h>
@@ -226,7 +227,7 @@ lockDir(const char *path, bool block)
 {
 	int fddir;
 
-	fddir = open(path, O_RDONLY | O_DIRECTORY);
+	fddir = open(path, O_RDONLY);
 	if (fddir < 0)
 	{
 		if (errno == ENOENT)

--- a/src/backend/utils/resgroup/resgroup-ops-linux.c
+++ b/src/backend/utils/resgroup/resgroup-ops-linux.c
@@ -49,7 +49,6 @@
 
 #define PROC_MOUNTS "/proc/self/mounts"
 #define MAX_INT_STRING_LEN 20
-#define MAX_PATH_LEN 256
 
 static char * buildPath(Oid group, const char *base, const char *comp, const char *prop, char *path, size_t pathsize);
 static int lockDir(const char *path, bool block);
@@ -69,7 +68,7 @@ static void detectCgroupMountPoint(void);
 
 static Oid currentGroupIdInCGroup = InvalidOid;
 static int cpucores = 0;
-static char cgdir[MAX_PATH_LEN];
+static char cgdir[MAXPGPATH];
 
 /*
  * Build path string with parameters.
@@ -110,7 +109,7 @@ buildPath(Oid group,
 static void
 unassignGroup(Oid group, const char *comp, int fddir)
 {
-	char path[128];
+	char path[MAXPGPATH];
 	size_t pathsize = sizeof(path);
 	char *buf;
 	size_t bufsize;
@@ -321,7 +320,7 @@ createDir(Oid group, const char *comp)
 static bool
 removeDir(Oid group, const char *comp, bool unassign)
 {
-	char path[128];
+	char path[MAXPGPATH];
 	size_t pathsize = sizeof(path);
 	int fddir;
 
@@ -453,7 +452,7 @@ readInt64(Oid group, const char *base, const char *comp, const char *prop)
 	int64 x;
 	char data[MAX_INT_STRING_LEN];
 	size_t datasize = sizeof(data);
-	char path[128];
+	char path[MAXPGPATH];
 	size_t pathsize = sizeof(path);
 
 	buildPath(group, base, comp, prop, path, pathsize);
@@ -474,7 +473,7 @@ writeInt64(Oid group, const char *base, const char *comp, const char *prop, int6
 {
 	char data[MAX_INT_STRING_LEN];
 	size_t datasize = sizeof(data);
-	char path[128];
+	char path[MAXPGPATH];
 	size_t pathsize = sizeof(path);
 
 	buildPath(group, base, comp, prop, path, pathsize);
@@ -492,7 +491,7 @@ writeInt64(Oid group, const char *base, const char *comp, const char *prop, int6
 static bool
 checkPermission(Oid group, bool report)
 {
-	char path[128];
+	char path[MAXPGPATH];
 	size_t pathsize = sizeof(path);
 	const char *comp;
 

--- a/src/backend/utils/resgroup/resgroup-ops-linux.c
+++ b/src/backend/utils/resgroup/resgroup-ops-linux.c
@@ -628,8 +628,19 @@ ResGroupOps_Bless(void)
 void
 ResGroupOps_Init(void)
 {
-	/* cfs_quota_us := cfs_period_us * ncores * gp_resource_group_cpu_limit */
-	/* shares := 1024 * 256 (max possible value) */
+	/*
+	 * cfs_quota_us := cfs_period_us * ncores * gp_resource_group_cpu_limit
+	 * shares := 1024 * 1 (default value)
+	 *
+	 * We used to set a larger shares (like 1024 * 256, the maximum possible
+	 * value), it has very bad effect on overall system performance,
+	 * especially on 1-core or 2-core low-end systems.
+	 * Processes in a cold cgroup get launched and scheduled with large
+	 * latency (a simple `cat a.txt` may executes for more than 100s).
+	 * Here a cold cgroup is a cgroup that doesn't have active running
+	 * processes, this includes not only the toplevel system cgroup,
+	 * but also the inactive gpdb resgroups.
+	 */
 
 	int64 cfs_period_us;
 	int ncores = getCpuCores();
@@ -638,7 +649,7 @@ ResGroupOps_Init(void)
 	cfs_period_us = readInt64(0, NULL, comp, "cpu.cfs_period_us");
 	writeInt64(0, NULL, comp, "cpu.cfs_quota_us",
 			   cfs_period_us * ncores * gp_resource_group_cpu_limit);
-	writeInt64(0, NULL, comp, "cpu.shares", 1024 * 256);
+	writeInt64(0, NULL, comp, "cpu.shares", 1024 * 1);
 }
 
 /* Adjust GUCs for this OS group implementation */

--- a/src/backend/utils/resgroup/resgroup-ops-linux.c
+++ b/src/backend/utils/resgroup/resgroup-ops-linux.c
@@ -620,8 +620,13 @@ ResGroupOps_Name(void)
 void
 ResGroupOps_Bless(void)
 {
+	if (IsUnderPostmaster)
+		return;
+
 	detectCgroupMountPoint();
 	checkPermission(0, true);
+
+	ResGroupOps_AssignGroup(InvalidOid, PostmasterPid);
 }
 
 /* Initialize the OS group */
@@ -728,7 +733,7 @@ ResGroupOps_DestroyGroup(Oid group)
 void
 ResGroupOps_AssignGroup(Oid group, int pid)
 {
-	if (group == currentGroupIdInCGroup)
+	if (IsUnderPostmaster && group == currentGroupIdInCGroup)
 		return;
 
 	writeInt64(group, NULL, "cpu", "cgroup.procs", pid);

--- a/src/backend/utils/resgroup/resgroup-ops-linux.c
+++ b/src/backend/utils/resgroup/resgroup-ops-linux.c
@@ -654,7 +654,8 @@ ResGroupOps_Init(void)
 	cfs_period_us = readInt64(0, NULL, comp, "cpu.cfs_period_us");
 	writeInt64(0, NULL, comp, "cpu.cfs_quota_us",
 			   cfs_period_us * ncores * gp_resource_group_cpu_limit);
-	writeInt64(0, NULL, comp, "cpu.shares", 1024 * 1);
+	writeInt64(0, NULL, comp, "cpu.shares",
+			   1024 * gp_resource_group_cpu_priority);
 }
 
 /* Adjust GUCs for this OS group implementation */

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -580,8 +580,15 @@ ResGroupDropFinish(Oid groupId, bool isCommit)
 	PG_CATCH();
 	{
 		InterruptHoldoffCount = savedInterruptHoldoffCount;
-		EmitErrorReport();
-		FlushErrorState();
+		if (elog_demote(WARNING))
+		{
+			EmitErrorReport();
+			FlushErrorState();
+		}
+		else
+		{
+			elog(LOG, "unable to demote error");
+		}
 	}
 	PG_END_TRY();
 
@@ -610,8 +617,15 @@ ResGroupCreateOnAbort(Oid groupId)
 	PG_CATCH();
 	{
 		InterruptHoldoffCount = savedInterruptHoldoffCount;
-		EmitErrorReport();
-		FlushErrorState();
+		if (elog_demote(WARNING))
+		{
+			EmitErrorReport();
+			FlushErrorState();
+		}
+		else
+		{
+			elog(LOG, "unable to demote error");
+		}
 	}
 	PG_END_TRY();
 	LWLockRelease(ResGroupLock);
@@ -656,8 +670,15 @@ ResGroupAlterOnCommit(Oid groupId,
 	PG_CATCH();
 	{
 		InterruptHoldoffCount = savedInterruptHoldoffCount;
-		EmitErrorReport();
-		FlushErrorState();
+		if (elog_demote(WARNING))
+		{
+			EmitErrorReport();
+			FlushErrorState();
+		}
+		else
+		{
+			elog(LOG, "unable to demote error");
+		}
 	}
 	PG_END_TRY();
 

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -96,6 +96,7 @@ extern int						gp_resgroup_memory_policy_auto_fixed_mem;
 extern bool						gp_resgroup_print_operator_memory_limits;
 extern int						memory_spill_ratio;
 
+extern int gp_resource_group_cpu_priority;
 extern double gp_resource_group_cpu_limit;
 extern double gp_resource_group_memory_limit;
 

--- a/src/test/isolation2/input/resgroup/resgroup_cpu_rate_limit.source
+++ b/src/test/isolation2/input/resgroup/resgroup_cpu_rate_limit.source
@@ -71,7 +71,7 @@ CREATE VIEW cancel_all AS
 
 ! python -c "print $(cat @cgroup_mnt_point@/cpu/gpdb/cpu.cfs_quota_us) == int($(cat @cgroup_mnt_point@/cpu/gpdb/cpu.cfs_period_us) * $(nproc) * $(psql -d isolation2resgrouptest -Aqtc "SHOW gp_resource_group_cpu_limit"))";
 
-! python -c "print $(cat @cgroup_mnt_point@/cpu/gpdb/cpu.shares) == 1024 * 256";
+! python -c "print $(cat @cgroup_mnt_point@/cpu/gpdb/cpu.shares) == 1024 * 1";
 
 --
 -- check default groups configuration

--- a/src/test/isolation2/input/resgroup/resgroup_cpu_rate_limit.source
+++ b/src/test/isolation2/input/resgroup/resgroup_cpu_rate_limit.source
@@ -66,12 +66,12 @@ CREATE VIEW cancel_all AS
 -- check gpdb cgroup configuration
 --
 -- cfs_quota_us := cfs_period_us * ncores * gp_resource_group_cpu_limit
--- shares := 1024 * ncores
+-- shares := 1024 * gp_resource_group_cpu_priority
 --
 
 ! python -c "print $(cat @cgroup_mnt_point@/cpu/gpdb/cpu.cfs_quota_us) == int($(cat @cgroup_mnt_point@/cpu/gpdb/cpu.cfs_period_us) * $(nproc) * $(psql -d isolation2resgrouptest -Aqtc "SHOW gp_resource_group_cpu_limit"))";
 
-! python -c "print $(cat @cgroup_mnt_point@/cpu/gpdb/cpu.shares) == 1024 * 1";
+! python -c "print $(cat @cgroup_mnt_point@/cpu/gpdb/cpu.shares) == 1024 * $(psql -d isolation2resgrouptest -Aqtc "SHOW gp_resource_group_cpu_priority")";
 
 --
 -- check default groups configuration

--- a/src/test/isolation2/output/resgroup/resgroup_cpu_rate_limit.source
+++ b/src/test/isolation2/output/resgroup/resgroup_cpu_rate_limit.source
@@ -52,7 +52,7 @@ CREATE
 True
 
 
-! python -c "print $(cat @cgroup_mnt_point@/cpu/gpdb/cpu.shares) == 1024 * 256";
+! python -c "print $(cat @cgroup_mnt_point@/cpu/gpdb/cpu.shares) == 1024 * 1";
 True
 
 

--- a/src/test/isolation2/output/resgroup/resgroup_cpu_rate_limit.source
+++ b/src/test/isolation2/output/resgroup/resgroup_cpu_rate_limit.source
@@ -45,14 +45,14 @@ CREATE
 -- check gpdb cgroup configuration
 --
 -- cfs_quota_us := cfs_period_us * ncores * gp_resource_group_cpu_limit
--- shares := 1024 * ncores
+-- shares := 1024 * gp_resource_group_cpu_priority
 --
 
 ! python -c "print $(cat @cgroup_mnt_point@/cpu/gpdb/cpu.cfs_quota_us) == int($(cat @cgroup_mnt_point@/cpu/gpdb/cpu.cfs_period_us) * $(nproc) * $(psql -d isolation2resgrouptest -Aqtc "SHOW gp_resource_group_cpu_limit"))";
 True
 
 
-! python -c "print $(cat @cgroup_mnt_point@/cpu/gpdb/cpu.shares) == 1024 * 1";
+! python -c "print $(cat @cgroup_mnt_point@/cpu/gpdb/cpu.shares) == 1024 * $(psql -d isolation2resgrouptest -Aqtc "SHOW gp_resource_group_cpu_priority")";
 True
 
 


### PR DESCRIPTION
We used to set a very large cgroup cpu.shares for gpdb but this might
cause bad performance on low end system with 1~2 cpu cores, processes in
cold cgroups can suffer form large latency.

Enhanced by setting cpu.shares to a proper value.

Also comes with some other minor changes.