### PR TITLE
Fix initializing SPIMemReserved when resource group is enabled.

### DIFF
--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -21,6 +21,7 @@
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
 #include "utils/typcache.h"
+#include "utils/resource_manager.h"
 #include "utils/resscheduler.h"
 
 #include "cdb/cdbvars.h"
@@ -2542,7 +2543,15 @@ static uint64 SPIMemReserved = 0;
 void SPI_InitMemoryReservation(void)
 {
 	Assert(!IsResManagerMemoryPolicyNone());
-	SPIMemReserved = (uint64) statement_mem * 1024L;;
+
+	if (IsResGroupEnabled())
+	{
+		SPIMemReserved = 0;
+	}
+	else
+	{
+		SPIMemReserved = (uint64) statement_mem * 1024L;;
+	}
 }
 
 /**


### PR DESCRIPTION
When resource group is enabled, initialization of
SPIMemReserved should not depend on statement_mem.