### PR TITLE
Fix for query with CUBE and HAVING clause (#3525)

### DIFF
--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -1405,6 +1405,10 @@ agg_retrieve_direct(AggState *aggstate)
 			if (!node->lastAgg && is_middle_rollup_agg)
 				return outerslot;
 
+			/* At this point we are done scanning the agg state because a null outerslot was produced above */
+			if(aggstate->agg_done)
+				return NULL;
+
 			/*
 			 * For the top-level of a rollup, we need to finalize
 			 * the aggregate value. First, we reset the context,

--- a/src/test/regress/expected/qp_olap_group.out
+++ b/src/test/regress/expected/qp_olap_group.out
@@ -6039,3 +6039,12 @@ EXECUTE p(2);
     4 |    |  
 (11 rows)
 
+-- ###### Queries involving CUBE with HAVING CLAUSE ###### --
+WITH src AS (SELECT 1 AS a, 1 AS b)
+SELECT 1 FROM src GROUP BY CUBE(a, b) HAVING a IS NOT NULL;
+ ?column? 
+----------
+        1
+        1
+(2 rows)
+

--- a/src/test/regress/expected/qp_olap_group_optimizer.out
+++ b/src/test/regress/expected/qp_olap_group_optimizer.out
@@ -6038,3 +6038,12 @@ EXECUTE p(2);
     2 | 52 | 2
 (5 rows)
 
+-- ###### Queries involving CUBE with HAVING CLAUSE ###### --
+WITH src AS (SELECT 1 AS a, 1 AS b)
+SELECT 1 FROM src GROUP BY CUBE(a, b) HAVING a IS NOT NULL;
+ ?column? 
+----------
+        1
+        1
+(2 rows)
+

--- a/src/test/regress/sql/qp_olap_group.sql
+++ b/src/test/regress/sql/qp_olap_group.sql
@@ -162,3 +162,8 @@ SELECT COUNT(DISTINCT cn) as cn_r, f, g FROM (SELECT cn, CASE WHEN (vn = 0) THEN
 SELECT COUNT(DISTINCT cn) as cn_r, f, g FROM (SELECT cn, vn + 1 AS f, 1 AS g FROM sale) sale_view GROUP BY ROLLUP(f,g) HAVING (f > 1);
 PREPARE p AS SELECT COUNT(DISTINCT cn) as cn_r, f, g FROM (SELECT cn, vn + $1 AS f, $1 AS g FROM sale) sale_view GROUP BY ROLLUP(f,g) HAVING (g > 1);
 EXECUTE p(2);
+
+-- ###### Queries involving CUBE with HAVING CLAUSE ###### --
+
+WITH src AS (SELECT 1 AS a, 1 AS b)
+SELECT 1 FROM src GROUP BY CUBE(a, b) HAVING a IS NOT NULL;


### PR DESCRIPTION
cherry-pick cube fix to 5X

* Fix crash for query with cube and having clause

We were not handling the case when a NULL outerslot was produced in agg_retrieve_direct.

* Adding test case for testing CUBE with HAVING clause

Signed-off-by: Ekta Khanna <ekhanna@pivotal.io>