### PR TITLE
Remove unnecessary serial tag from icw jobs

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -1355,7 +1355,6 @@ jobs:
       TEST_OS: centos
       CONFIGURE_FLAGS: {{configure_flags}}
 - name: icw_gporca_centos7
-  serial: true
   plan:
   - aggregate:
     - get: gpdb_src
@@ -1374,7 +1373,6 @@ jobs:
       TEST_OS: centos
       CONFIGURE_FLAGS: {{configure_flags}}
 - name: icw_gporca_sles11
-  serial: true
   plan:
   - aggregate:
     - get: gpdb_src


### PR DESCRIPTION
This causes max-in-flight to be 1 so subsequent commits will queue up. There doesn't seem to be any reason we need this.