### PR TITLE
cherry-pick Ban split of list-partitioned sub-partitions (#3453)

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -215,6 +215,7 @@ static void validateForeignKeyConstraint(FkConstraint *fkconstraint,
 static void createForeignKeyTriggers(Relation rel, FkConstraint *fkconstraint,
 						 Oid constraintOid);
 static void ATController(Relation rel, List *cmds, bool recurse);
+static void prepSplitCmd(Relation rel, PgPartRule *prule, bool is_at);
 static void ATPrepCmd(List **wqueue, Relation rel, AlterTableCmd *cmd,
 		  bool recurse, bool recursing);
 static void ATRewriteCatalogs(List **wqueue);
@@ -2836,6 +2837,66 @@ ATController(Relation rel, List *cmds, bool recurse)
 
 }
 
+
+/*
+ * prepSplitCmd
+ *
+ * Do initial sanity checking for an ALTER TABLE ... SPLIT PARTITION cmd.
+ * - Shouldn't have children
+ * - The usual permissions checks
+ * - Not called on HASH
+ */
+static void
+prepSplitCmd(Relation rel, PgPartRule *prule, bool is_at)
+{
+	PartitionNode		*pNode = NULL;
+	pNode = RelationBuildPartitionDesc(rel, false);
+
+	if (prule->topRule->children)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						errmsg("cannot split partition with child "
+									   "partitions"),
+						errhint("Try splitting the child partitions.")));
+
+	}
+
+	if (prule->topRule->parisdefault &&
+		prule->pNode->part->parkind == 'r' &&
+		is_at)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_SYNTAX_ERROR),
+					errmsg("AT clause cannot be used when splitting "
+						"a default RANGE partition")));
+	}
+	else if ((prule->pNode->part->parkind == 'l') && (pNode !=NULL && pNode->default_part)
+			 && (pNode->default_part->children))
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_GP_FEATURE_NOT_SUPPORTED),
+						errmsg("SPLIT PARTITION is not "
+								"currently supported when leaf partition is "
+								"list partitioned in multi level partition table")));
+		}
+	else if ((prule->pNode->part->parkind == 'l') && !is_at)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_SYNTAX_ERROR),
+					errmsg("cannot SPLIT DEFAULT PARTITION "
+						"with LIST"),
+				errhint("Use SPLIT with the AT clause instead.")));
+
+	}
+
+	if (prule->pNode->part->parkind == 'h')
+		ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+					errmsg("SPLIT is not supported for "
+						"HASH partitions")));
+}
+
 /*
  * ATPrepCmd
  *
@@ -3391,8 +3452,8 @@ ATPrepCmd(List **wqueue, Relation rel, AlterTableCmd *cmd,
 				/*
 				 * Need to do a bunch of validation:
 				 * 0) Target exists
-				 * 0.5) Shouldn't have children
-				 * 1) The usual permissions checks
+				 * 0.5) Shouldn't have children (Done in prepSplitCmd)
+				 * 1) The usual permissions checks (Done in prepSplitCmd)
 				 * 2) Not called on HASH
 				 * 3) AT () parameter falls into constraint specified
 				 * 4) INTO partitions don't exist except for the one being split
@@ -3401,46 +3462,13 @@ ATPrepCmd(List **wqueue, Relation rel, AlterTableCmd *cmd,
 				/* We'll error out if it doesn't exist */
 				prule1 = get_part_rule(rel, pid, true, true, NULL, false);
 
-				if (prule1->topRule->children)
-					ereport(ERROR,
-							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-							 errmsg("cannot split partition with child "
-									"partitions"),
-							 errhint("Try splitting the child partitions.")));
-
 				target = heap_open(prule1->topRule->parchildrelid,
 								   AccessExclusiveLock);
 
 				if (linitial((List *)pc->arg1))
 					is_at = false;
 
-				if (prule1->topRule->parisdefault &&
-					prule1->pNode->part->parkind == 'r' &&
-					is_at)
-				{
-					ereport(ERROR,
-							(errcode(ERRCODE_SYNTAX_ERROR),
-							 errmsg("AT clause cannot be used when splitting "
-									"a default RANGE partition")));
-				}
-				else if (prule1->pNode->part->parkind == 'l' && !is_at)
-				{
-					ereport(ERROR,
-							(errcode(ERRCODE_SYNTAX_ERROR),
-							 errmsg("cannot SPLIT DEFAULT PARTITION "
-									"with LIST"),
-							errhint("Use SPLIT with the AT clause instead.")));
-
-				}
-
-				if (prule1->pNode->part->parkind == 'h')
-					ereport(ERROR,
-							(errcode(ERRCODE_WRONG_OBJECT_TYPE),
-							 errmsg("SPLIT is not supported for "
-									"HASH partitions")));
-
-				if (linitial((List *)pc->arg1))
-					is_at = false;
+				prepSplitCmd(rel, prule1, is_at);
 
 				todo = (List *)pc->arg1;
 
@@ -3825,7 +3853,7 @@ ATPrepCmd(List **wqueue, Relation rel, AlterTableCmd *cmd,
 				 * By the way, at this point
 				 *   prule1 refers to the part to split
 				 *   prule2 refers to the first INTO part
-				 *   prule3 refers to the seconde INTO part
+				 *   prule3 refers to the second INTO part
 				 */
 				Insist( prule2 == NULL || prule3 == NULL );
 				
@@ -12607,6 +12635,7 @@ ATPExecPartAlter(List **wqueue, AlteredTableInfo *tab, Relation rel,
 	AlterPartitionCmd 	*pc2		   = NULL;
 	bool				 bPartitionCmd = true;	/* true if a "partition" cmd */
 	Relation			 rel2		   = rel;
+	bool				prepCmd		= false;	/* true if the sub command of ALTER PARTITION is a SPLIT PARTITION */
 
 	while (1)
 	{
@@ -12628,11 +12657,14 @@ ATPExecPartAlter(List **wqueue, AlteredTableInfo *tab, Relation rel,
 
 	switch (atc->subtype)
 	{
+		case AT_PartSplit:				/* Split */
+		{
+			prepCmd = true; /* if sub-command is split partition then it will require some preprocessing */
+		}
 		case AT_PartAdd:				/* Add */
 		case AT_PartAddForSplit:		/* Add, as part of a split */
 		case AT_PartCoalesce:			/* Coalesce */
 		case AT_PartDrop:				/* Drop */
-		case AT_PartSplit:				/* Split */
 		case AT_PartMerge:				/* Merge */
 		case AT_PartModify:				/* Modify */
 		case AT_PartSetTemplate:		/* Set Subpartition Template */
@@ -12692,6 +12724,18 @@ ATPExecPartAlter(List **wqueue, AlteredTableInfo *tab, Relation rel,
 			pid2->location  = -1;
 
 			pc2->partid = (Node *)pid2;
+
+			if (prepCmd) /* Prep the split partition sub-command */
+			{
+				PgPartRule			*prule1	= NULL;
+				bool is_at = true;
+				prule1 = get_part_rule(rel, pid2, true, true, NULL, false);
+
+				if (linitial((List *)pc2->arg1)) /* Check if the SPLIT PARTITION command has an AT clause */
+					is_at = false;
+
+				prepSplitCmd(rel, prule1, is_at);
+			}
 		}
 		else /* treat as a table */
 		{
@@ -12754,6 +12798,7 @@ ATPExecPartAlter(List **wqueue, AlteredTableInfo *tab, Relation rel,
 						 AccessExclusiveLock);
 		bPartitionCmd = false;
 	}
+
 	/* execute the command */
 	ATExecCmd(wqueue, tab, &rel2, atc);
 

--- a/src/test/regress/expected/partition1.out
+++ b/src/test/regress/expected/partition1.out
@@ -3438,14 +3438,56 @@ select tablename,partitiontablename, partitionname from pg_partitions where tabl
 
 -- SPLIT partition
 alter table mpp14613_list alter partition others split partition subothers at (10) into (partition b1, partition b2);
-NOTICE:  exchanged partition "subothers" of partition "others" of relation "mpp14613_list" with relation "pg_temp_291985"
-NOTICE:  dropped partition "subothers" for partition "others" of relation "mpp14613_list"
-NOTICE:  CREATE TABLE will create partition "mpp14613_list_1_prt_others_2_prt_b1" for table "mpp14613_list_1_prt_others"
-NOTICE:  CREATE TABLE will create partition "mpp14613_list_1_prt_others_2_prt_b2" for table "mpp14613_list_1_prt_others"
+ERROR:  SPLIT PARTITION is not currently supported when leaf partition is list partitioned in multi level partition table
 alter table mpp14613_range alter partition others split partition subothers at (10) into (partition b1, partition b2);
-NOTICE:  exchanged partition "subothers" of partition "others" of relation "mpp14613_range" with relation "pg_temp_292320"
-NOTICE:  dropped partition "subothers" for partition "others" of relation "mpp14613_range"
-ERROR:  invalid partition range specification.
+ERROR:  AT clause cannot be used when splitting a default RANGE partition
+-- ALTER TABLE ... ALTER PARTITION ... SPLIT DEFAULT PARTITION
+create table foo(
+  a int,
+  b int,
+  c int,
+  d int)
+  partition by range(b)
+  subpartition by list(c)
+  subpartition template
+ (
+    default subpartition subothers,
+    subpartition s1 values(1,2,3),
+    subpartition s2 values(4,5,6)
+ )
+ (
+    default partition others,
+    start(1) end(5) every(1)
+ );
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_others" for table "foo"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_others_2_prt_subothers" for table "foo_1_prt_others"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_others_2_prt_s1" for table "foo_1_prt_others"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_others_2_prt_s2" for table "foo_1_prt_others"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_2" for table "foo"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_2_2_prt_subothers" for table "foo_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_2_2_prt_s1" for table "foo_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_2_2_prt_s2" for table "foo_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_3" for table "foo"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_3_2_prt_subothers" for table "foo_1_prt_3"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_3_2_prt_s1" for table "foo_1_prt_3"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_3_2_prt_s2" for table "foo_1_prt_3"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_4" for table "foo"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_4_2_prt_subothers" for table "foo_1_prt_4"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_4_2_prt_s1" for table "foo_1_prt_4"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_4_2_prt_s2" for table "foo_1_prt_4"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_5" for table "foo"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_5_2_prt_subothers" for table "foo_1_prt_5"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_5_2_prt_s1" for table "foo_1_prt_5"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_5_2_prt_s2" for table "foo_1_prt_5"
+alter table foo alter partition others split partition subothers at (10) into (partition b1, default partition);
+ERROR:  SPLIT PARTITION is not currently supported when leaf partition is list partitioned in multi level partition table
+alter table foo alter partition others split partition subothers at (10) into (partition b1, partition subothers);
+ERROR:  SPLIT PARTITION is not currently supported when leaf partition is list partitioned in multi level partition table
+alter table foo alter partition others split default partition at (10) into (partition b1, default partition);
+ERROR:  SPLIT PARTITION is not currently supported when leaf partition is list partitioned in multi level partition table
+drop table foo;
 -- Drop table as gpcheckcat will complaint of not having constraint for newly
 -- created tables due to split.
 drop table mpp14613_list;

--- a/src/test/regress/sql/partition1.sql
+++ b/src/test/regress/sql/partition1.sql
@@ -1756,6 +1756,30 @@ select tablename,partitiontablename, partitionname from pg_partitions where tabl
 alter table mpp14613_list alter partition others split partition subothers at (10) into (partition b1, partition b2);
 alter table mpp14613_range alter partition others split partition subothers at (10) into (partition b1, partition b2);
 
+-- ALTER TABLE ... ALTER PARTITION ... SPLIT DEFAULT PARTITION
+create table foo(
+  a int,
+  b int,
+  c int,
+  d int)
+  partition by range(b)
+  subpartition by list(c)
+  subpartition template
+ (
+    default subpartition subothers,
+    subpartition s1 values(1,2,3),
+    subpartition s2 values(4,5,6)
+ )
+ (
+    default partition others,
+    start(1) end(5) every(1)
+ );
+
+alter table foo alter partition others split partition subothers at (10) into (partition b1, default partition);
+alter table foo alter partition others split partition subothers at (10) into (partition b1, partition subothers);
+alter table foo alter partition others split default partition at (10) into (partition b1, default partition);
+drop table foo;
+
 -- Drop table as gpcheckcat will complaint of not having constraint for newly
 -- created tables due to split.
 drop table mpp14613_list;


### PR DESCRIPTION
* Ban split of list-partitioned sub-partitions

Currently, GPDB does not support splitting a multi-level partition when
the leaf partition is partitioned by list. However, in many cases, we
did not correctly error out and instead crashed. This commit detects a
query attempting to split a list partitioned sub-partition and correctly
errors out.

Signed-off-by: Sam Dash <sdash@pivotal.io>

* Ban split of list-partitioned sub-partitions

Currently, GPDB does not support splitting a multi-level partition when
the leaf partition is partitioned by list. However, in many cases, we
did not correctly error out and instead crashed. This commit detects a
query attempting to split a list partitioned sub-partition and correctly
errors out.

Signed-off-by: Sam Dash <sdash@pivotal.io>

* Ban split of list-partitioned sub-partitions

Currently, GPDB does not support splitting a multi-level partition when
the leaf partition is partitioned by list. However, in many cases, we
did not correctly error out and instead crashed. This commit detects a
query attempting to split a list partitioned sub-partition and correctly
errors out.

Signed-off-by: Sam Dash <sdash@pivotal.io>