### PR TITLE
Fixes python path for macOS

### DIFF
--- a/README.macOS.bash
+++ b/README.macOS.bash
@@ -28,10 +28,10 @@ brew install go # Or get the latest from https://golang.org/dl/
 
 # Installing python libraries
 brew install python
-export PATH="/usr/local/opt/python/libexec/bin:$PATH"
 cat >> ~/.bash_profile << EOF
-export PATH="/usr/local/opt/python/libexec/bin:$PATH"
+export PATH=/usr/local/opt/python/libexec/bin:$PATH
 EOF
+source ~/.bash_profile
 pip install lockfile psi paramiko pysql psutil setuptools
 pip install unittest2 parse pexpect mock pyyaml
 pip install git+https://github.com/behave/behave@v1.2.4

--- a/README.macOS.md
+++ b/README.macOS.md
@@ -13,6 +13,7 @@ their environments.
 ## Step: install needed dependencies. This will install homebrew if missing
 ```
 ./README.macOS.bash
+source ~/.bash_profile
 ```
 
 ## Step: Workaround for libreadline / libxml2 on OSX 10.11 (El Capitan)


### PR DESCRIPTION
Prior to this change, make create-demo-cluster would fail since the
command line could not find pip.