### PR TITLE
Resource group improvement

### DIFF
--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -1479,7 +1479,7 @@ decideResGroup(void)
 	/* always find out the up-to-date resgroup id */
 	groupId = decideResGroupId();
 
-	LWLockAcquire(ResGroupLock, LW_EXCLUSIVE);
+	LWLockAcquire(ResGroupLock, LW_SHARED);
 	group = ResGroupHashFind(groupId, false);
 
 	if (!group)

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -2338,8 +2338,6 @@ SwitchResGroupOnSegment(const char *buf, int len)
 	selfAttachToSlot(group, slot);
 	Assert(selfHasSlot());
 
-	ResGroupSetMemorySpillRatio(&caps);
-
 	mempoolAutoReserve(group, &caps);
 	LWLockRelease(ResGroupLock);
 

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -1866,6 +1866,8 @@ slotGetMemSpill(const ResGroupCaps *caps)
 static void
 wakeupSlots(ResGroupData *group, bool grant)
 {
+	Assert(LWLockHeldExclusiveByMe(ResGroupLock));
+
 	while (!groupWaitQueueIsEmpty(group))
 	{
 		PGPROC		*waitProc;
@@ -2226,6 +2228,7 @@ UnassignResGroup(void)
 	}
 
 	Assert(selfIsAssignedValidGroup());
+	Assert(selfHasSlot());
 
 	/* Stop memory limit checking */
 	self->doMemCheck = false;

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -1426,7 +1426,6 @@ groupReserveMemQuota(ResGroupData *group)
 	}
 
 	group->memQuotaUsed += slotMemQuota;
-	Assert(group->memQuotaUsed <= group->memQuotaGranted);
 
 	return true;
 }
@@ -2171,7 +2170,6 @@ AssignResGroupOnMaster(void)
 	{
 retry:
 		group = decideResGroup();
-		Assert(selfIsAssignedValidGroup());
 
 		/* Acquire slot */
 		slot = groupAcquireSlot(group);
@@ -2930,7 +2928,6 @@ slotValidate(const ResGroupSlotData *slot)
 	if (slot->groupId == InvalidOid)
 	{
 		Assert(slot->sessionId == InvalidSessionId);
-		Assert(slot->groupId == InvalidOid);
 		Assert(slot->nProcs == 0);
 		Assert(slot->memQuota < 0);
 		Assert(slot->memUsage == 0);

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -1529,8 +1529,8 @@ groupAcquireSlot(ResGroupData *group)
 			/* got one, lucky */
 			initSlot(slot, &group->caps, group->groupId, gp_session_id);
 			group->totalExecuted++;
-			pgstat_report_resgroup(0, group->groupId);
 			LWLockRelease(ResGroupLock);
+			pgstat_report_resgroup(0, group->groupId);
 			return slot;
 		}
 	}
@@ -2268,6 +2268,8 @@ UnassignResGroup(void)
 	/* Cleanup group */
 	selfUnsetGroup();
 	LWLockRelease(ResGroupLock);
+
+	pgstat_report_resgroup(0, InvalidOid);
 
 	Assert(selfIsUnassigned());
 }

--- a/src/test/isolation2/expected/resgroup/resgroup_cancel_terminate_concurrency.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_cancel_terminate_concurrency.out
@@ -47,8 +47,7 @@ waiting|waiting_reason|current_query|rsgname
 -------+--------------+-------------+-------------------
 f      |              |<IDLE>       |rg_concurrency_test
 f      |              |<IDLE>       |rg_concurrency_test
-f      |              |<IDLE>       |rg_concurrency_test
-(3 rows)
+(2 rows)
 1q: ... <quitting>
 2q: ... <quitting>
 3q: ... <quitting>
@@ -105,10 +104,9 @@ server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
 SELECT * FROM rg_concurrency_view;
-waiting|waiting_reason|current_query|rsgname            
--------+--------------+-------------+-------------------
-f      |              |<IDLE>       |rg_concurrency_test
-(1 row)
+waiting|waiting_reason|current_query|rsgname
+-------+--------------+-------------+-------
+(0 rows)
 1q: ... <quitting>
 2q: ... <quitting>
 3q: ... <quitting>
@@ -166,11 +164,9 @@ BEGIN
 SELECT * FROM rg_concurrency_view;
 waiting|waiting_reason|current_query        |rsgname            
 -------+--------------+---------------------+-------------------
-f      |              |<IDLE>               |rg_concurrency_test
-f      |              |<IDLE>               |rg_concurrency_test
 f      |              |<IDLE> in transaction|rg_concurrency_test
 f      |              |<IDLE> in transaction|rg_concurrency_test
-(4 rows)
+(2 rows)
 1q: ... <quitting>
 2q: ... <quitting>
 6q: ... <quitting>


### PR DESCRIPTION
Improve resource group codes according to
action items from team code review.

* Change variable 'overused' to 'overuseMem'.
* Change variable 'memStocks*' to 'memChunks*'.
* Add comments for items in structure ResGroupData.
* Add comments for ShouldAssignResGroupOnMaster()
   explaining why resource group will not be assigned
   if we are in SIGUSR1 handler.
* Add comments for shouldBypassQuery().
* Add comments for localResWaiting.
* Change the mode of ResGroupLock to LW_SHARED in decideResGroup().
* Add necessary assertions for resource group.
* Remove unnecessary assertions in resource group.
* Refactor function ResGroupWaitCancel.
* Remove setting memory spill ratio for resource group on QEs.
* Make the name of static functions in resgroup.c start with lower character.
* Set resource group id to be InvalidOid in pg_stat_activity when transaction ends.

