### PR TITLE
Fix assert caused by UPDATE query with `with oids` target table

### DIFF
--- a/src/backend/executor/nodeSplitUpdate.c
+++ b/src/backend/executor/nodeSplitUpdate.c
@@ -153,6 +153,8 @@ ExecInitSplitUpdate(SplitUpdate *node, EState *estate, int eflags)
 	/* Check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK | EXEC_FLAG_REWIND)));
 
+	bool    has_oids = false;
+
 	SplitUpdateState *splitupdatestate;
 
 	splitupdatestate = makeNode(SplitUpdateState);
@@ -172,7 +174,15 @@ ExecInitSplitUpdate(SplitUpdate *node, EState *estate, int eflags)
 	splitupdatestate->deleteTuple = ExecInitExtraTupleSlot(estate);
 
 	/* New TupleDescriptor for output TupleTableSlots (old_values + new_values, ctid, gp_segment, action).*/
-	TupleDesc tupDesc = ExecTypeFromTL(node->plan.targetlist, false);
+	if (estate->es_result_relation_info != NULL &&
+		estate->es_result_relation_info->ri_RelationDesc != NULL &&
+		estate->es_result_relation_info->ri_RelationDesc->rd_rel != NULL &&
+		estate->es_result_relation_info->ri_RelationDesc->rd_rel->relhasoids)
+	{
+		has_oids = true;
+	}
+
+	TupleDesc tupDesc = ExecTypeFromTL(node->plan.targetlist, has_oids);
 	ExecSetSlotDescriptor(splitupdatestate->insertTuple, tupDesc);
 	ExecSetSlotDescriptor(splitupdatestate->deleteTuple, tupDesc);
 

--- a/src/test/regress/expected/qp_dml_oids.out
+++ b/src/test/regress/expected/qp_dml_oids.out
@@ -271,10 +271,7 @@ SELECT SUM(dml_heap_r.a) FROM dml_heap_p, dml_heap_r WHERE dml_heap_r.b = dml_he
    3
 (1 row)
 
--- FIXME: This currently trips an assertion, see
--- https://github.com/greenplum-db/gpdb/issues/3611
--- Re-enable once that's fixed!
---UPDATE dml_heap_r SET a = dml_heap_r.a FROM dml_heap_p WHERE dml_heap_r.b = dml_heap_p.a;
+UPDATE dml_heap_r SET a = dml_heap_r.a FROM dml_heap_p WHERE dml_heap_r.b = dml_heap_p.a;
 -- The query checks that the tuple oids remain the remain pre and post update .
 -- SELECT COUNT(*) FROM tempoid, dml_heap_r WHERE tempoid.oid = dml_heap_r.oid AND tempoid.col1 = dml_heap_r.col1 is a join on the tuple oids before update and after update. If the oids remain the same the below query should return 1 row which is equivalent to the number of rows in the table
 SELECT * FROM ( (SELECT COUNT(*) FROM dml_heap_r) UNION (SELECT COUNT(*) FROM tempoid, dml_heap_r WHERE tempoid.oid = dml_heap_r.oid AND tempoid.col1 = dml_heap_r.col1))foo;

--- a/src/test/regress/expected/qp_dml_oids_optimizer.out
+++ b/src/test/regress/expected/qp_dml_oids_optimizer.out
@@ -269,10 +269,7 @@ SELECT SUM(dml_heap_r.a) FROM dml_heap_p, dml_heap_r WHERE dml_heap_r.b = dml_he
    3
 (1 row)
 
--- FIXME: This currently trips an assertion, see
--- https://github.com/greenplum-db/gpdb/issues/3611
--- Re-enable once that's fixed!
---UPDATE dml_heap_r SET a = dml_heap_r.a FROM dml_heap_p WHERE dml_heap_r.b = dml_heap_p.a;
+UPDATE dml_heap_r SET a = dml_heap_r.a FROM dml_heap_p WHERE dml_heap_r.b = dml_heap_p.a;
 -- The query checks that the tuple oids remain the remain pre and post update .
 -- SELECT COUNT(*) FROM tempoid, dml_heap_r WHERE tempoid.oid = dml_heap_r.oid AND tempoid.col1 = dml_heap_r.col1 is a join on the tuple oids before update and after update. If the oids remain the same the below query should return 1 row which is equivalent to the number of rows in the table
 SELECT * FROM ( (SELECT COUNT(*) FROM dml_heap_r) UNION (SELECT COUNT(*) FROM tempoid, dml_heap_r WHERE tempoid.oid = dml_heap_r.oid AND tempoid.col1 = dml_heap_r.col1))foo;

--- a/src/test/regress/sql/qp_dml_oids.sql
+++ b/src/test/regress/sql/qp_dml_oids.sql
@@ -145,11 +145,7 @@ CREATE TABLE tempoid as SELECT oid,col1,a FROM dml_heap_r ORDER BY 1;
 
 SELECT SUM(dml_heap_r.a) FROM dml_heap_p, dml_heap_r WHERE dml_heap_r.b = dml_heap_p.a;
 
--- FIXME: This currently trips an assertion, see
--- https://github.com/greenplum-db/gpdb/issues/3611
--- Re-enable once that's fixed!
-
---UPDATE dml_heap_r SET a = dml_heap_r.a FROM dml_heap_p WHERE dml_heap_r.b = dml_heap_p.a;
+UPDATE dml_heap_r SET a = dml_heap_r.a FROM dml_heap_p WHERE dml_heap_r.b = dml_heap_p.a;
 
 -- The query checks that the tuple oids remain the remain pre and post update .
 -- SELECT COUNT(*) FROM tempoid, dml_heap_r WHERE tempoid.oid = dml_heap_r.oid AND tempoid.col1 = dml_heap_r.col1 is a join on the tuple oids before update and after update. If the oids remain the same the below query should return 1 row which is equivalent to the number of rows in the table


### PR DESCRIPTION
Fix failure by non-proper has_oids value when executing nodeSplitUpdate
when optimizer=on.  has_oids is different between nodes across Motion,
so that receiver motion cannot retrieve correct value from sender
motion.

This is cherry-picked from https://github.com/greenplum-db/gpdb-postgres-merge/pull/5 since the issue applies on master, 5X_STABLE and gpdb 4 as well.

Signed-off-by: Yu Yang <macroyuyang@pivotal.io>