### PR TITLE
Speed up gpstop by fifteen seconds or so

### DIFF
--- a/gpMgmt/bin/gppylib/commands/base.py
+++ b/gpMgmt/bin/gppylib/commands/base.py
@@ -111,7 +111,30 @@ class WorkerPool(object):
             logger.info('%0.2f%% of jobs completed' % (num_completed_percentage * 100))
             if num_completed >= command_count:
                 return
-            time.sleep(10)
+            self._join_work_queue_with_timeout(10)
+
+    def _join_work_queue_with_timeout(self, timeout):
+        """
+        Queue.join() unfortunately doesn't take a timeout (see
+        https://bugs.python.org/issue9634). Fake it here, with a solution
+        inspired by notes on that bug report.
+
+        XXX This solution uses undocumented Queue internals (though they are not
+        underscore-prefixed...).
+        """
+        done_condition = self.work_queue.all_tasks_done
+        done_condition.acquire()
+        try:
+            while self.work_queue.unfinished_tasks:
+                if (timeout <= 0):
+                    # Timed out.
+                    return
+
+                start_time = time.time()
+                done_condition.wait(timeout)
+                timeout -= (time.time() - start_time)
+        finally:
+            done_condition.release()
 
     def join(self):
         self.work_queue.join()


### PR DESCRIPTION
A cProfile of gpstop pointed to two calls to `time.sleep(10)`, which take up a fairly big chunk of time. Instead of just sleeping for ten seconds, wait on the `work_queue` with a timeout of ten seconds. This speeds up gpstop by about fifteen seconds per run on my machine.

This solution uses a workaround to Queue.join()'s lack of timeout; see https://bugs.python.org/issue9634 .

A less invasive approach would be to just reduce the sleep time to a second or so, but then we print a bunch of `[INFO]:-0.00% of jobs completed` lines. With this approach, we still only print status every ten seconds while waiting, but return immediately once we're done working.