### PR TITLE
Remove python installation directory when destroying cluster

### DIFF
--- a/concourse/scripts/backup_utils.sh
+++ b/concourse/scripts/backup_utils.sh
@@ -24,6 +24,7 @@ destroy_gpdb() {
 
     yes|gpdeletesystem -f -d $MASTER_DATA_DIRECTORY
     rm -rf $GPHOME/*
+    rm -rf /home/gpadmin/gpdb_src/gpMgmt/bin/pythonSrc/ext/install
 }
 
 setup_ddboost() {


### PR DESCRIPTION
In the backup_43_restore_5 test, which uses different python versions,
we were not properly removing the previous python packages. When running
behave on the restore side, packages for python 2.7 were not installed
since the directory was already present.

Signed-off-by: Chris Hajas <chajas@pivotal.io>