### PR TITLE
Remove stale FIXME from test answer file

### DIFF
--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -1297,9 +1297,6 @@ select C.j from C where not exists (select rank() over (order by B.i) from B  wh
  62
 (4 rows)
 
--- start_ignore
--- FIXME: ORCA produces the wrong plan and results for subselects with a grouping clause
--- end_ignore
 explain select * from A where not exists (select sum(C.i) from C where C.i = A.i group by a.i);
                    QUERY PLAN                   
 ------------------------------------------------


### PR DESCRIPTION
The original issue for which the FIXME was added is fixed in ORCA v2.46.2 and commit 8978e73 updated the test answer files with correct plan and results.

Hence the FIXME is no longer valid.