### PR TITLE
Fix tests, for changes in snapshot behavior of serializable transacti…

### DIFF
--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/reindex/concurrency/expected/serializable_reindex_with_drop_column_ao_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/reindex/concurrency/expected/serializable_reindex_with_drop_column_ao_part.ans
@@ -5,6 +5,11 @@ BEGIN
 BEGIN
 2: SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 SET
+2: select 'dummy select to establish snapshot';
+?column?                          
+----------------------------------
+dummy select to establish snapshot
+(1 row)
 1: alter table reindex_serialize_tab_ao_part drop column f;
 ALTER
 1: COMMIT;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/reindex/concurrency/expected/serializable_reindex_with_drop_column_heap.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/reindex/concurrency/expected/serializable_reindex_with_drop_column_heap.ans
@@ -8,6 +8,11 @@ BEGIN
 BEGIN
 2: SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 SET
+2: select 'dummy select to establish snapshot';
+?column?                          
+----------------------------------
+dummy select to establish snapshot
+(1 row)
 1: alter table reindex_serialize_tab_heap drop column c;
 ALTER
 1: COMMIT;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/reindex/concurrency/expected/serializable_reindex_with_drop_column_part_heap.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/reindex/concurrency/expected/serializable_reindex_with_drop_column_part_heap.ans
@@ -5,6 +5,11 @@ BEGIN
 BEGIN
 2: SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 SET
+2: select 'dummy select to establish snapshot';
+?column?                          
+----------------------------------
+dummy select to establish snapshot
+(1 row)
 1: alter table reindex_serialize_tab_heap_part drop column f;
 ALTER
 1: COMMIT;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/reindex/concurrency/expected/serializable_reindex_with_drop_index_ao.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/reindex/concurrency/expected/serializable_reindex_with_drop_index_ao.ans
@@ -8,6 +8,11 @@ BEGIN
 BEGIN
 2: SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 SET
+2: select 'dummy select to establish snapshot';
+?column?                          
+----------------------------------
+dummy select to establish snapshot
+(1 row)
 1: drop index idxg_reindex_serialize_tab_ao;
 DROP
 1: COMMIT;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/reindex/concurrency/expected/serializable_reindex_with_drop_index_heap.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/reindex/concurrency/expected/serializable_reindex_with_drop_index_heap.ans
@@ -8,6 +8,11 @@ BEGIN
 BEGIN
 2: SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 SET
+2: select 'dummy select to establish snapshot';
+?column?                          
+----------------------------------
+dummy select to establish snapshot
+(1 row)
 1: drop index idxg_reindex_dropindex_serialize_tab_heap;
 DROP
 1: COMMIT;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/reindex/concurrency/expected/serializable_reindex_with_insert_heap.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/reindex/concurrency/expected/serializable_reindex_with_insert_heap.ans
@@ -2,6 +2,11 @@
 BEGIN
 1: SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 SET
+1: select 'dummy select to establish snapshot';
+?column?                          
+----------------------------------
+dummy select to establish snapshot
+(1 row)
 2: BEGIN;
 BEGIN
 2: insert into reindex_serialize_tab_heap values(99,'green',now(),10,15.10);

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/reindex/concurrency/expected/serializable_reindex_with_insert_part_heap.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/reindex/concurrency/expected/serializable_reindex_with_insert_part_heap.ans
@@ -3,6 +3,11 @@
 BEGIN
 1: SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 SET
+1: select 'dummy select to establish snapshot';
+?column?                          
+----------------------------------
+dummy select to establish snapshot
+(1 row)
 2: BEGIN;
 BEGIN
 2:insert into reindex_serialize_ins_tab_heap_part(id, owner, description, property, poli, target) select i, 'user' || i, 'Testing GiST Index', '((3, 1300), (33, 1330))','( (22,660), (57,650), (68, 660) )', '( (76, 76), 76)' from generate_series(1111,1112) i ;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/reindex/concurrency/sql/serializable_reindex_with_drop_column_ao_part.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/reindex/concurrency/sql/serializable_reindex_with_drop_column_ao_part.sql
@@ -2,6 +2,7 @@
 1: BEGIN;
 2: BEGIN;
 2: SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+2: select 'dummy select to establish snapshot';
 1: alter table reindex_serialize_tab_ao_part drop column f;
 1: COMMIT;
 -- Remember index relfilenodes from master and segments before

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/reindex/concurrency/sql/serializable_reindex_with_drop_column_heap.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/reindex/concurrency/sql/serializable_reindex_with_drop_column_heap.sql
@@ -4,6 +4,7 @@ SET gp_create_table_random_default_distribution=off;
 1: BEGIN;
 2: BEGIN;
 2: SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+2: select 'dummy select to establish snapshot';
 1: alter table reindex_serialize_tab_heap drop column c;
 1: COMMIT;
 -- Remember index relfilenodes from master and segments before

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/reindex/concurrency/sql/serializable_reindex_with_drop_column_part_heap.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/reindex/concurrency/sql/serializable_reindex_with_drop_column_part_heap.sql
@@ -2,6 +2,7 @@
 1: BEGIN;
 2: BEGIN;
 2: SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+2: select 'dummy select to establish snapshot';
 1: alter table reindex_serialize_tab_heap_part drop column f;
 1: COMMIT;
 -- Remember index relfilenodes from master and segments before

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/reindex/concurrency/sql/serializable_reindex_with_drop_index_ao.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/reindex/concurrency/sql/serializable_reindex_with_drop_index_ao.sql
@@ -4,6 +4,7 @@ SET gp_create_table_random_default_distribution=off;
 1: BEGIN;
 2: BEGIN;
 2: SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+2: select 'dummy select to establish snapshot';
 1: drop index idxg_reindex_serialize_tab_ao;
 1: COMMIT;
 -- Remember index relfilenodes from master and segments before

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/reindex/concurrency/sql/serializable_reindex_with_drop_index_heap.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/reindex/concurrency/sql/serializable_reindex_with_drop_index_heap.sql
@@ -4,6 +4,7 @@ SET gp_create_table_random_default_distribution=off;
 1: BEGIN;
 2: BEGIN;
 2: SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+2: select 'dummy select to establish snapshot';
 1: drop index idxg_reindex_dropindex_serialize_tab_heap;
 1: COMMIT;
 -- Remember index relfilenodes from master and segments before

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/reindex/concurrency/sql/serializable_reindex_with_insert_heap.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/reindex/concurrency/sql/serializable_reindex_with_insert_heap.sql
@@ -3,6 +3,7 @@ SET gp_create_table_random_default_distribution=off;
 -- end_ignore
 1: BEGIN;
 1: SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+1: select 'dummy select to establish snapshot';
 2: BEGIN;
 2: insert into reindex_serialize_tab_heap values(99,'green',now(),10,15.10);
 2: COMMIT;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/reindex/concurrency/sql/serializable_reindex_with_insert_part_heap.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/reindex/concurrency/sql/serializable_reindex_with_insert_part_heap.sql
@@ -1,6 +1,7 @@
 -- @product_version gpdb: [4.3.4.0 -],4.3.4.0O2
 1: BEGIN;
 1: SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+1: select 'dummy select to establish snapshot';
 2: BEGIN;
 2:insert into reindex_serialize_ins_tab_heap_part(id, owner, description, property, poli, target) select i, 'user' || i, 'Testing GiST Index', '((3, 1300), (33, 1330))','( (22,660), (57,650), (68, 660) )', '( (76, 76), 76)' from generate_series(1111,1112) i ;
 2: COMMIT;


### PR DESCRIPTION
…ons.

Since commit 4a95afc1d3, a serializable transaction no longer establishes
the snapshot at the SET TRANSACTION ISOLATION LEVEL SERIALIZABLE command.
Now it establishes a snapshot at the first "real" query that requires a
snapshot. The new behavior matches PostgreSQL, and is a good thing. So
silence the test failures, by adding dummy queries to establish snapshots
at the same spots as before.

I can't make all of these tests pass on my laptop, even before that commit,
so I'm not sure if this fixes them all correctly. But I think so, and a few
of these I could even verify locally.