### PR TITLE
resgroup: move UnassignResGroup into AtEOXact_ResGroup

### DIFF
--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -135,7 +135,7 @@ registerResourceGroupCallback(ResourceGroupCallback callback, void *arg)
  * Note the callback functions would be removed as being processed.
  */
 void
-AtEOXact_ResGroup(bool isCommit)
+HandleResGroupDDLCallbacks(bool isCommit)
 {
 	ResourceGroupCallbackItem *current =
 		isCommit ? ResourceGroup_callbacks->next : ResourceGroup_callbacks->prev;

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -410,6 +410,16 @@ AllocResGroupEntry(Oid groupId, const ResGroupOpts *opts)
 	LWLockRelease(ResGroupLock);
 }
 
+void
+AtEOXact_ResGroup(bool isCommit)
+{
+	HandleResGroupDDLCallbacks(isCommit);
+
+	/* Release resource group slot at the end of a transaction */
+	if (ShouldUnassignResGroup())
+		UnassignResGroup();
+}
+
 /*
  * Load the resource groups in shared memory. Note this
  * can only be done after enough setup has been done. This uses

--- a/src/include/commands/resgroupcmds.h
+++ b/src/include/commands/resgroupcmds.h
@@ -28,6 +28,6 @@ extern Oid GetResGroupIdForName(char *name, LOCKMODE lockmode);
 extern char *GetResGroupNameForId(Oid oid, LOCKMODE lockmode);
 extern Oid GetResGroupIdForRole(Oid roleid);
 extern void GetResGroupCapabilities(Oid groupId, ResGroupCaps *resgroupCaps);
-extern void AtEOXact_ResGroup(bool isCommit);
+extern void HandleResGroupDDLCallbacks(bool isCommit);
 
 #endif   /* RESGROUPCMDS_H */

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -116,6 +116,7 @@ typedef enum
 /*
  * Functions in resgroup.c
  */
+extern void AtEOXact_ResGroup(bool isCommit);
 
 /* Shared memory and semaphores */
 extern Size ResGroupShmemSize(void);


### PR DESCRIPTION
* Do UnassignResGroup within prepareTransaction too, prepareTransaction()
will put QE out of any transactions temporarily until the second commit
command arrives, so any failures in this gap will cause leaks of resource
group including slots etc.
* Clean code, move UnassignResGroup() into AtEOXact_ResGroup() so resource
group related codes will not spread across prepare/commit/abort functions.