### PR TITLE
Change gp_resource_group_memory_limit default value to 0.7

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4903,7 +4903,7 @@ struct config_real ConfigureNamesReal_gp[] =
 			NULL
 		},
 		&gp_resource_group_memory_limit,
-		0.9, 0.0001, 1.0, NULL, NULL
+		0.7, 0.0001, 1.0, NULL, NULL
 	},
 
 	{


### PR DESCRIPTION
The default value is actually a recommendation. To be safe to cluster and make the segment memory usage is close to old experienced value, we will set this GUC default
to 0.7. 