### PR TITLE
Add permission checks for UDF pg_resgroup_get_status_kv.

### DIFF
--- a/src/backend/utils/resgroup/resgroup_helper.c
+++ b/src/backend/utils/resgroup/resgroup_helper.c
@@ -356,6 +356,14 @@ pg_resgroup_get_status_kv(PG_FUNCTION_ARGS)
 	
 	if (do_dump)
 	{
+		/* Only super user can call this function with para=dump. */
+		if (!superuser())
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+					 errmsg("Only superusers can call this function.")));
+		}
+		
 		initStringInfo(&str);
 		/* dump info in QD and collect info from QEs to form str.*/
 		dumpResGroupInfo(&str);

--- a/src/test/isolation2/expected/resgroup/resgroup_dumpinfo.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_dumpinfo.out
@@ -1,8 +1,10 @@
 DROP ROLE IF EXISTS role_dumpinfo_test;
 DROP
+DROP ROLE IF EXISTS role_permission;
+DROP
 -- start_ignore
 DROP RESOURCE GROUP rg_dumpinfo_test;
-DROP
+ERROR:  resource group "rg_dumpinfo_test" does not exist
 -- end_ignore
 
 CREATE LANGUAGE plpythonu;
@@ -51,7 +53,19 @@ END
 3q: ... <quitting>
 4q: ... <quitting>
 
+CREATE ROLE role_permission;
+CREATE
+SET ROLE role_permission;
+SET
+select value from pg_resgroup_get_status_kv('dump');
+ERROR:  Only superusers can call this function.
+
+SET ROLE gpadmin;
+SET
+
 DROP ROLE role_dumpinfo_test;
+DROP
+DROP ROLE role_permission;
 DROP
 DROP RESOURCE GROUP rg_dumpinfo_test;
 DROP

--- a/src/test/isolation2/input/resgroup/resgroup_dumpinfo.source
+++ b/src/test/isolation2/input/resgroup/resgroup_dumpinfo.source
@@ -1,4 +1,5 @@
 DROP ROLE IF EXISTS role_dumpinfo_test;
+DROP ROLE IF EXISTS role_permission;
 -- start_ignore
 DROP RESOURCE GROUP rg_dumpinfo_test;
 -- end_ignore
@@ -63,5 +64,12 @@ SELECT dump_test_check();
 3q:
 4q:
 
+CREATE ROLE role_permission;
+SET ROLE role_permission;
+select value from pg_resgroup_get_status_kv('dump');
+
+SET ROLE gpadmin;
+
 DROP ROLE role_dumpinfo_test;
+DROP ROLE role_permission;
 DROP RESOURCE GROUP rg_dumpinfo_test;


### PR DESCRIPTION
Non-superuser should not be able to execute pg_resgroup_get_status_kv.