### PR TITLE
Fix compilation of backend on getpeereid() enabled platforms

### DIFF
--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -71,7 +71,7 @@ LIBS := $(LIBS) -lpthread
 OBJS += $(addprefix $(top_builddir)/src/interfaces/libpq/,fe-protocol3_for_backend.o fe-connect_for_backend.o fe-exec.o pqexpbuffer.o fe-auth.o fe-misc.o fe-protocol2.o fe-secure.o)
 
 ifneq ($(filter getpeereid.o,$(LIBOBJS)),)
-OBJS += $(addprefix $(top_builddir)/src/interfaces/libpq,getpeereid.o)
+OBJS += $(addprefix $(top_builddir)/src/interfaces/libpq/,getpeereid.o)
 endif
 
 ##########################################################################

--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -68,7 +68,8 @@ endif
 LIBS := $(LIBS) -lpthread
 
 # Greenplum uses libpq to communicate between QD and QEs
-OBJS := $(OBJS) $(addprefix $(top_builddir)/src/interfaces/libpq/,fe-protocol3_for_backend.o fe-connect_for_backend.o fe-exec.o pqexpbuffer.o fe-auth.o fe-misc.o fe-protocol2.o fe-secure.o getpeereid.o)
+OBJS += $(addprefix $(top_builddir)/src/interfaces/libpq/,fe-protocol3_for_backend.o fe-connect_for_backend.o fe-exec.o pqexpbuffer.o fe-auth.o fe-misc.o fe-protocol2.o fe-secure.o)
+OBJS += $(addprefix $(top_builddir)/src/interfaces/libpq/,$(LIBOBJS))
 
 ##########################################################################
 

--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -70,7 +70,7 @@ LIBS := $(LIBS) -lpthread
 # Greenplum uses libpq to communicate between QD and QEs
 OBJS += $(addprefix $(top_builddir)/src/interfaces/libpq/,fe-protocol3_for_backend.o fe-connect_for_backend.o fe-exec.o pqexpbuffer.o fe-auth.o fe-misc.o fe-protocol2.o fe-secure.o)
 
-ifneq ($(filter getpeereid.o,$(LIBOBJS))
+ifneq ($(filter getpeereid.o,$(LIBOBJS)),)
 OBJS += $(addprefix $(top_builddir)/src/interfaces/libpq,getpeereid.o)
 endif
 

--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -69,7 +69,10 @@ LIBS := $(LIBS) -lpthread
 
 # Greenplum uses libpq to communicate between QD and QEs
 OBJS += $(addprefix $(top_builddir)/src/interfaces/libpq/,fe-protocol3_for_backend.o fe-connect_for_backend.o fe-exec.o pqexpbuffer.o fe-auth.o fe-misc.o fe-protocol2.o fe-secure.o)
-OBJS += $(addprefix $(top_builddir)/src/interfaces/libpq/,$(LIBOBJS))
+
+ifneq ($(filter getpeereid.o,$(LIBOBJS))
+OBJS += $(addprefix $(top_builddir)/src/interfaces/libpq,getpeereid.o)
+endif
 
 ##########################################################################
 


### PR DESCRIPTION
When getpeereid() is available in the platform we don't need it
from ports, always invoking it cause a compilation failure since
the object file will be missing. Fix by using the proper lookup
list from autoconf which will contain the list of required objs.