### PR TITLE
Fix conflicting parallel tests

### DIFF
--- a/src/test/regress/expected/qp_query_execution.out
+++ b/src/test/regress/expected/qp_query_execution.out
@@ -304,9 +304,9 @@ insert into foo_p select 6, i % 10, i , 1 || 'SOME NUMBER SOME NUMBER', i % 10 f
 insert into foo_p select 6, i % 10, i , 1 || 'SOME NUMBER SOME NUMBER', i % 10 from generate_series(1, 1000) i;
 insert into foo_p select 6, i % 10, i , 1 || 'SOME NUMBER SOME NUMBER', i % 10 from generate_series(1, 1000) i;
 set allow_system_table_mods=dml;
-update pg_class set reltuples = 100000000, relpages = 10000000 where relname like 'bar';
-update pg_class set reltuples = 1, relpages = 1 where relname like 'foo_p_1_prt_other';
-update pg_class set reltuples = 1, relpages = 1 where relname like 'foo_p_1_prt_2';
+update pg_class set reltuples = 100000000, relpages = 10000000 where relname = 'bar' and relnamespace = (select oid from pg_namespace where nspname = 'qp_query_execution');
+update pg_class set reltuples = 1, relpages = 1 where relname = 'foo_p_1_prt_other' and relnamespace = (select oid from pg_namespace where nspname = 'qp_query_execution');
+update pg_class set reltuples = 1, relpages = 1 where relname = 'foo_p_1_prt_2' and relnamespace = (select oid from pg_namespace where nspname = 'qp_query_execution');
 select foo_p.b, foo_p.t from foo_p left outer join bar on foo_p.a = bar.a  where foo_p.p =3 and foo_p.a = 6 order by 1, 2 desc limit 10;
  b |            t             
 ---+--------------------------
@@ -393,8 +393,8 @@ insert into foo_p select 6, i % 10, i , 1 || 'SOME NUMBER SOME NUMBER', i % 10 f
 insert into foo_p select 6, i % 10, i , 1 || 'SOME NUMBER SOME NUMBER', i % 10 from generate_series(1, 1000) i;
 insert into foo_p select 6, i % 10, i , 1 || 'SOME NUMBER SOME NUMBER', i % 10 from generate_series(1, 1000) i;
 set allow_system_table_mods=dml;
-update pg_class set reltuples = 100000000, relpages = 10000000 where relname like 'b';
-update pg_class set reltuples = 1, relpages = 1 where relname like 'abbp%';
+update pg_class set reltuples = 100000000, relpages = 10000000 where relname = 'b' and relnamespace = (select oid from pg_namespace where nspname = 'qp_query_execution');
+update pg_class set reltuples = 1, relpages = 1 where relname like 'abbp%' and relnamespace = (select oid from pg_namespace where nspname = 'qp_query_execution');
 select abbp.b, abbp.t from abbp join (select abbp.* from b, abbp where abbp.a = b.k and abbp.a = '6SOME NUMBER') FOO on abbp.a = FOO.a  where abbp.t is not null order by 1, 2 desc limit 10;
   b  | t 
 -----+---

--- a/src/test/regress/sql/qp_query_execution.sql
+++ b/src/test/regress/sql/qp_query_execution.sql
@@ -184,9 +184,9 @@ insert into foo_p select 6, i % 10, i , 1 || 'SOME NUMBER SOME NUMBER', i % 10 f
 insert into foo_p select 6, i % 10, i , 1 || 'SOME NUMBER SOME NUMBER', i % 10 from generate_series(1, 1000) i;
 
 set allow_system_table_mods=dml;
-update pg_class set reltuples = 100000000, relpages = 10000000 where relname like 'bar';
-update pg_class set reltuples = 1, relpages = 1 where relname like 'foo_p_1_prt_other';
-update pg_class set reltuples = 1, relpages = 1 where relname like 'foo_p_1_prt_2';
+update pg_class set reltuples = 100000000, relpages = 10000000 where relname = 'bar' and relnamespace = (select oid from pg_namespace where nspname = 'qp_query_execution');
+update pg_class set reltuples = 1, relpages = 1 where relname = 'foo_p_1_prt_other' and relnamespace = (select oid from pg_namespace where nspname = 'qp_query_execution');
+update pg_class set reltuples = 1, relpages = 1 where relname = 'foo_p_1_prt_2' and relnamespace = (select oid from pg_namespace where nspname = 'qp_query_execution');
 
 select foo_p.b, foo_p.t from foo_p left outer join bar on foo_p.a = bar.a  where foo_p.p =3 and foo_p.a = 6 order by 1, 2 desc limit 10;
 
@@ -223,8 +223,8 @@ insert into foo_p select 6, i % 10, i , 1 || 'SOME NUMBER SOME NUMBER', i % 10 f
 insert into foo_p select 6, i % 10, i , 1 || 'SOME NUMBER SOME NUMBER', i % 10 from generate_series(1, 1000) i;
 
 set allow_system_table_mods=dml;
-update pg_class set reltuples = 100000000, relpages = 10000000 where relname like 'b';
-update pg_class set reltuples = 1, relpages = 1 where relname like 'abbp%';
+update pg_class set reltuples = 100000000, relpages = 10000000 where relname = 'b' and relnamespace = (select oid from pg_namespace where nspname = 'qp_query_execution');
+update pg_class set reltuples = 1, relpages = 1 where relname like 'abbp%' and relnamespace = (select oid from pg_namespace where nspname = 'qp_query_execution');
 
 select abbp.b, abbp.t from abbp join (select abbp.* from b, abbp where abbp.a = b.k and abbp.a = '6SOME NUMBER') FOO on abbp.a = FOO.a  where abbp.t is not null order by 1, 2 desc limit 10;
 


### PR DESCRIPTION
Tests `qp_query_execution` and `qp_correlated_query` are run in parallel
in ICG. Excerpt from `greenplum_schedule` file:
```
test: qp_functions qp_misc_rio_join_small qp_misc_rio
qp_correlated_query qp_targeted_dispatch qp_gist_indexes2
qp_gist_indexes3 qp_gist_indexes4 qp_query_execution
```

If the timing is wrong, they conflict with each other and causes plan
differences in `qp_correlated_query`.

Both these tests create a relation named `B` in their own namespaces;
however `qp_query_execution` later updates the reltuples in pg_class for
`B`. This update command only uses `relname` to locate entry for `B` in
`pg_class` and updates its tuple count to a large value.

This update results in updating the `reltuples` for both relations `B` (in
namespace `qp_query_execution` and `qp_correlated_query`). This causes
intermittent EXPLAIN test failures in `qp_correlated_query` making it
flaky.

This commit fixes the problem by using `relnamespace` as well while
updating the `pg_class` to uniquely identify `B`.

Signed-off-by: Sambitesh Dash <sdash@pivotal.io>