### PR TITLE
Adding Conduct, Contribution and Issues template to fit community practices

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,50 @@
+# Code of Conduct
+
+## Intro
+
+Standing on the shoulders of the giants means not only leveraging the code base of the most successful open source relational database (PostgreSQL) but also taking a page out of one of the most successful open source governance bodies: Apache Software Foundation (ASF). Greenplum Database developer community has adopted not only the Apache License but also the following code of conduct heavily borrowing from an ASF’s:
+
+This code of conduct applies to all spaces that are associated with the participation in the Greenplum Database open source project, including chat, all public and private mailing lists, issue trackers, wikis, blogs, Twitter, and any other communication channel used by our community. A code of conduct which is specific to in-person events (ie., conferences, meetups, etc.) is expected to be a superset of this document covering additional principles put forward by the organizers of the event(s) and landlords of the space where the event is held.
+
+We expect this code of conduct to be honored by everyone who participates in the Greenplum Database community formally or informally, or claims any affiliation with the project, in any activities and especially when representing the Greenplum Database project, in any role.
+
+This code is not exhaustive or complete. It serves to distil our common understanding of a collaborative, shared environment and goals. We expect it to be followed in spirit as much as in the letter so that it can enrich all of us and the technical communities in which we participate.
+
+## Specific guidelines
+
+We strive to:
+1. **Be open** We invite anyone to participate in our community. We preferably use public methods of communication for project-related messages, unless discussing something sensitive. This applies to messages for help or project-related support, too; not only is a public support request much more likely to result in an answer to a question, it also makes sure that any inadvertent mistakes made by people answering will be more easily detected and corrected.
+2. **Be empathetic**, welcoming, friendly, and patient. We work together to resolve conflict, assume good intentions, and do our best to act in an empathetic fashion. We may all experience some frustration from time to time, but we do not allow frustration to turn into a personal attack. A community where people feel uncomfortable or threatened is not a productive one. We should be respectful when dealing with other community members as well as with people outside our community.
+3. **Be collaborative**. Our work will be used by other people, and in turn will depend on the work of others. When we make something for the benefit of the project, we are willing to explain to others how it works, so that they can build on the work to make it even better. Any decision we make will affect users and colleagues, and we take those consequences seriously when making decisions.
+4. **Be inquisitive**. Nobody knows everything! Asking questions early avoids many problems later, so questions are encouraged, though they may be directed to the appropriate forum. Those who are asked should be responsive and helpful, within the context of our shared goal of improving Greenplum Database project code.
+5. **Be careful in the words that we choose**. Whether we are participating as professionals or volunteers, we value professionalism in all interactions, and take responsibility for our own speech. Be kind to others. Do not insult or put down other participants. Harassment and other exclusionary behaviour are not acceptable. This includes, but is not limited to:
+    * Violent threats or language directed against another person.
+    * Sexist, racist, or otherwise discriminatory jokes and language.
+    * Posting sexually explicit or violent material.
+    * Posting (or threatening to post) other people's personally identifying information ("doxing").
+    * Sharing private content, such as emails sent privately or non-publicly, or unlogged forums such as IRC channel history.
+    * Personal insults, especially those using racist or sexist terms.
+    * Unwelcome sexual attention.
+    * Excessive or unnecessary profanity.
+    * Repeated harassment of others. In general, if someone asks you to stop, then stop.
+    * Advocating for, or encouraging, any of the above behaviour.
+6. **Be concise**. Keep in mind that what you write once will be read by hundreds of persons. Writing a short email means people can understand the conversation as efficiently as possible. Short emails should always strive to be empathetic, welcoming, friendly and patient. When a long explanation is necessary, consider adding a summary.
+    Try to bring new ideas to a conversation so that each mail adds something unique to the thread, keeping in mind that the rest of the thread still contains the other messages with arguments that have already been made.
+     Try to stay on topic, especially in discussions that are already fairly large.
+7. **Step down considerately**. Members of every project come and go. When somebody leaves or disengages from the project they should tell people they are leaving and take the proper steps to ensure that others can pick up where they left off. In doing so, they should remain respectful of those who continue to participate in the project and should not misrepresent the project's goals or achievements. Likewise, community members should respect any individual's choice to leave the project.
+
+## Diversity statement
+
+Greenplum Database project welcomes and encourages participation by everyone. We are committed to being a community that everyone feels good about joining. Although we may not be able to satisfy everyone, we will always work to treat everyone well.
+
+No matter how you identify yourself or how others perceive you: we welcome you. Though no list can hope to be comprehensive, we explicitly honour diversity in: age, culture, ethnicity, genotype, gender identity or expression, language, national origin, neurotype, phenotype, political beliefs, profession, race, religion, sexual orientation, socioeconomic status, subculture and technical ability.
+
+Though we welcome people fluent in all languages, Greenplum Database project development is conducted in English.
+
+Standards for behaviour in this community are detailed in the Code of Conduct above. We expect participants in our community to meet these standards in all their interactions and to help others to do so as well.
+
+## Reporting guidelines
+
+While this code of conduct should be adhered to by participants, we recognize that sometimes people may have a bad day, or be unaware of some of the guidelines in this code of conduct. When that happens, you may reply to them and point out this code of conduct. Such messages may be in public or in private, whatever is most appropriate. However, regardless of whether the message is public or not, it should still adhere to the relevant parts of this code of conduct; in particular, it should not be abusive or disrespectful.
+
+If you believe someone is violating this code of conduct, you may reply to them and point out this code of conduct. Assume good faith; it is more likely that participants are unaware of their bad behaviour than that they intentionally try to degrade the quality of the discussion. Should there be difficulties in dealing with the situation, you may report your compliance issues in confidence to coc@greenplum.org. This will go to an individual who is entrusted with your report.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Contributing
+
+Greenplum is maintained by a core team of developers with commit rights to the main gpdb repository on GitHub. At the same time, we are very eager to receive contributions from anybody in the wider Greenplum community. This section covers all you need to know if you want to see your code or documentation changes be added to Greenplum and appear in the future releases.
+
+## Getting started
+
+Greenplum is developed on GitHub, and anybody wishing to contribute to it will have to have a GitHub account and be familiar with Git tools and workflow. It is also recommend that you follow the developer's mailing list since some of the contributions may generate more detailed discussions there.
+
+Once you have your GitHub account, fork this repository so that you can have your private copy to start hacking on and to use as source of pull requests.
+
+Anybody contributing to Greenplum has to be covered by either the Corporate or the Individual Contributor License Agreement. If you have not previously done so, please fill out and submit the Contributor License Agreement. Note that we do allow for really trivial changes to be contributed without a CLA if they fall under the rubric of obvious fixes. However, since our GitHub workflow checks for CLA by default you may find it easier to submit one instead of claiming an "obvious fix" exception.
+
+## Licensing of Greenplum contributions
+
+If the contribution you're submitting is original work, you can assume that Pivotal will release it as part of an overall Greenplum release available to the downstream consumers under the Apache License, Version 2.0. However, in addition to that, Pivotal may also decide to release it under a different license (such as PostgreSQL License to the upstream consumers that require it. A typical example here would be Pivotal upstreaming your contribution back to PostgreSQL community (which can be done either verbatim or your contribution being upstreamed as part of the larger changeset).
+
+If the contribution you're submitting is NOT original work you have to indicate the name of the license and also make sure that it is similar in terms to the Apache License 2.0. Apache Software Foundation maintains a list of these licenses under Category A. In addition to that, you may be required to make proper attribution in the NOTICE file file similar to these examples.
+
+Finally, keep in mind that it is NEVER a good idea to remove licensing headers from the work that is not your original one. Even if you are using parts of the file that originally had a licensing header at the top you should err on the side of preserving it. As always, if you are not quite sure about the licensing implications of your contributions, feel free to reach out to us on the developer mailing list.
+
+## Coding guidelines
+
+Your chances of getting feedback and seeing your code merged into the project greatly depend on how granular your changes are. If you happen to have a bigger change in mind, we highly recommend engaging on the developer's mailing list first and sharing your proposal with us before you spend a lot of time writing code. Even when your proposal gets validated by the community, we still recommend doing the actual work as a series of small, self-contained commits. This makes the reviewer's job much easier and increases the timeliness of feedback.
+
+When it comes to C and C++ parts of Greenplum, we try to follow PostgreSQL Coding Conventions. In addition to that we require that:
+
+All Python code passes Pylint
+All Go code is formatted according to gofmt
+We recommend using git diff --color when reviewing your changes so that you don't have any spurious whitespace issues in the code that you submit.
+
+All new functionality that is contributed to Greenplum should be covered by regression tests that are contributed alongside it. If you are uncertain on how to test or document your work, please raise the question on the gpdb-dev mailing list and the developer community will do its best to help you.
+
+At the very minimum you should always be running make installcheck-world to make sure that you're not breaking anything.
+
+## Changes applicable to upstream PostgreSQL
+
+If the change you're working on touches functionality that is common between PostgreSQL and Greenplum, you may be asked to forward-port it to PostgreSQL. This is not only so that we keep reducing the delta between the two projects, but also so that any change that is relevant to PostgreSQL can benefit from a much broader review of the upstream PostgreSQL community. In general, it is a good idea to keep both code bases handy so you can be sure whether your changes may need to be forward-ported.
+
+## Submission timing
+
+To improve the odds of the right discussion of your patch or idea happening, pay attention to what the community work cycle is. For example, if you send in a brand new idea in the beta phase of a release, we may defer review or target its inclusion for a later version. Feel free to ask on the mailing list to learn more about the Greenplum release policy and timing.
+
+## Patch submission
+
+Once you are ready to share your work with the Greenplum core team and the rest of the Greenplum community, you should push all the commits to a branch in your own repository forked from the official Greenplum and send us a pull request.
+
+For now, we require all pull requests to be submitted against the main master branch, but over time, once there are many supported open source releases of Greenplum in the wild, you may decide to submit your pull requests against an active release branch if the change is only applicable to a given release.
+
+## Validation checks and CI
+
+Once you submit your pull request, you will immediately see a number of validation checks performed by our automated CI pipelines. There also will be a CLA check telling you whether your CLA was recognized. If any of these checks fails, you will need to update your pull request to take care of the issue. Pull requests with failed validation checks are very unlikely to receive any further peer review from the community members.
+
+Keep in mind that the most common reason for a failed CLA check is a mismatch between an email on file and an email recorded in the commits submitted as part of the pull request.
+
+If you cannot figure out why a certain validation check failed, feel free to ask on the developer's mailing list, but make sure to include a direct link to a pull request in your email.
+
+## Patch review
+
+A submitted pull request with passing validation checks is assumed to be available for peer review. Peer review is the process that ensures that contributions to Greenplum are of high quality and align well with the road map and community expectations. Every member of the Greenplum community is encouraged to review pull requests and provide feedback. Since you don't have to be a core team member to be able to do that, we recommend following a stream of pull reviews to anybody who's interested in becoming a long-term contributor to Greenplum. As Linus would say "given enough eyeballs, all bugs are shallow".
+
+One outcome of the peer review could be a consensus that you need to modify your pull request in certain ways. GitHub allows you to push additional commits into a branch from which a pull request was sent. Those additional commits will be then visible to all of the reviewers.
+
+A peer review converges when it receives at least one +1 and no -1s votes from the participants. At that point you should expect one of the core team members to pull your changes into the project.
+
+Greenplum prides itself on being a collaborative, consensus-driven environment. We do not believe in vetoes and any -1 vote casted as part of the peer review has to have a detailed technical explanation of what's wrong with the change. Should a strong disagreement arise it may be advisable to take the matter onto the mailing list since it allows for a more natural flow of the conversation.
+
+At any time during the patch review, you may experience delays based on the availability of reviewers and core team members. Please be patient. That being said, don't get discouraged either. If you're not getting expected feedback for a few days add a comment asking for updates on the pull request itself or send an email to the mailing list.
+
+## Direct commits to the repository
+
+On occasion you will see core team members committing directly to the repository without going through the pull request workflow. This is reserved for small changes only and the rule of thumb we use is this: if the change touches any functionality that may result in a test failure, then it has to go through a pull request workflow. If, on the other hand, the change is in the non-functional part of the code base (such as fixing a typo inside of a comment block) core team members can decide to just commit to the repository directly.

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,17 @@
+### Greenplum version or build
+
+
+
+### Expected behavior
+
+
+
+### Actual behavior
+
+
+
+
+### Step to reproduce the behavior
+
+
+

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,17 +1,14 @@
 ### Greenplum version or build
 
+### OS version and uname -a
 
+### autoconf options used ( config.status --config )
+
+### Installation information ( pg_config )
 
 ### Expected behavior
 
-
-
 ### Actual behavior
 
-
-
-
 ### Step to reproduce the behavior
-
-
 


### PR DESCRIPTION
Reviewing best practices for Conduct, Contribution docs for the community and adding copies of those.

Also adding Issues template to try to help make issue reporting be more fluid 