### PR TITLE
Change the way QE alloc/free resource group slot.

### DIFF
--- a/src/backend/utils/session_state.c
+++ b/src/backend/utils/session_state.c
@@ -107,6 +107,7 @@ SessionState_Acquire(int sessionId)
 		acquired->cleanupCountdown = CLEANUP_COUNTDOWN_BEFORE_RUNAWAY;
 		acquired->activeProcessCount = 0;
 		acquired->idle_start = 0;
+		acquired->resGroupSlot = NULL;
 
 #ifdef USE_ASSERT_CHECKING
 		acquired->isModifiedSessionId = false;
@@ -179,6 +180,7 @@ SessionState_Release(SessionState *acquired)
 		acquired->cleanupCountdown = CLEANUP_COUNTDOWN_BEFORE_RUNAWAY;
 		acquired->activeProcessCount = 0;
 		acquired->idle_start = 0;
+		acquired->resGroupSlot = NULL;
 
 #ifdef USE_ASSERT_CHECKING
 		acquired->isModifiedSessionId = false;

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -130,7 +130,6 @@ extern void AllocResGroupEntry(Oid groupId, const ResGroupOpts *opts);
 extern void SerializeResGroupInfo(StringInfo str);
 extern void DeserializeResGroupInfo(struct ResGroupCaps *capsOut,
 									Oid *groupId,
-									int *slotId,
 									const char *buf,
 									int len);
 

--- a/src/include/utils/session_state.h
+++ b/src/include/utils/session_state.h
@@ -88,6 +88,11 @@ typedef struct SessionState
 	 * next entry would point to the next used entry */
 	struct SessionState *next;
 
+	/*
+	 * Resource group per-session slot information.
+	 */
+	struct ResGroupSlotData *resGroupSlot;
+
 #ifdef USE_ASSERT_CHECKING
 	/* If we modify the sessionId in ProcMppSessionId, this field is turned on */
 	bool isModifiedSessionId;

--- a/src/include/utils/session_state.h
+++ b/src/include/utils/session_state.h
@@ -91,7 +91,7 @@ typedef struct SessionState
 	/*
 	 * Resource group per-session slot information.
 	 */
-	struct ResGroupSlotData *resGroupSlot;
+	void *resGroupSlot;
 
 #ifdef USE_ASSERT_CHECKING
 	/* If we modify the sessionId in ProcMppSessionId, this field is turned on */


### PR DESCRIPTION
Previously QD dispatches resource group slot id to QEs
and each QE gets a slot according to the slot id.

The problem with this way is if QD exits before QE and
then dispatches the same slot id in a new session, two
different sessions on QE may share the same slot.

In this commit, QD no longer dispatches slot id, each QE
alloc/free resource group slot from its own slot pool.

Signed-off-by: xiong-gang <gxiong@pivotal.io>