### PR TITLE
Update ICW files for changes in commit 356511dab9

### DIFF
--- a/src/test/regress/expected/qp_misc_jiras.out
+++ b/src/test/regress/expected/qp_misc_jiras.out
@@ -3144,7 +3144,7 @@ explain analyze select reltablespace  from pg_class where oid = (select reltoast
  Index Scan using pg_class_oid_index on pg_class  (cost=200.27..400.54 rows=1 width=4)
    Index Cond: oid = $0
    Rows out:  1 rows with 0.025 ms to first row, 0.026 ms to end, start offset by 0.042 ms.
-   InitPlan
+   InitPlan 1 (returns $0)
      ->  Index Scan using pg_class_relname_nsp_index on pg_class  (cost=0.00..200.27 rows=1 width=4)
            Index Cond: relname = 'tbl_8205'::name
            Rows out:  1 rows with 0.010 ms to first row, 0.012 ms to end of 2 scans, start offset by 0.044 ms.

--- a/src/test/regress/expected/qp_misc_jiras_optimizer.out
+++ b/src/test/regress/expected/qp_misc_jiras_optimizer.out
@@ -3165,7 +3165,7 @@ explain analyze select reltablespace  from pg_class where oid = (select reltoast
  Index Scan using pg_class_oid_index on pg_class  (cost=200.27..400.54 rows=1 width=4)
    Index Cond: oid = $0
    Rows out:  1 rows with 0.037 ms to first row, 0.038 ms to end, start offset by 0.047 ms.
-   InitPlan
+   InitPlan 1 (returns $0)
      ->  Index Scan using pg_class_relname_nsp_index on pg_class  (cost=0.00..200.27 rows=1 width=4)
            Index Cond: relname = 'tbl_8205'::name
            Rows out:  1 rows with 0.021 ms to first row, 0.023 ms to end of 2 scans, start offset by 0.049 ms.

--- a/src/test/regress/expected/subselect_gp2.out
+++ b/src/test/regress/expected/subselect_gp2.out
@@ -36,7 +36,7 @@ explain select sess_id from pg_stat_activity where current_query = (select curre
 -----------------------------------------------------------------------------------------
  Hash Join  (cost=2.10..17.18 rows=4 width=4)
    Hash Cond: s.usesysid = u.oid
-   InitPlan
+   InitPlan 1 (returns $0)
      ->  Result  (cost=0.00..0.01 rows=1 width=0)
    ->  Hash Join  (cost=1.07..16.11 rows=4 width=8)
          Hash Cond: s.datid = d.oid


### PR DESCRIPTION
The original commit updates explain.pm which is used to compare EXPLAIN outputs in ICW. It used to ignore InitPlans that are not in their own slice.

```
*** ./expected/subselect_gp2.out	Tue Oct 31 16:37:57 2017
--- ./results/subselect_gp2.out	Tue Oct 31 16:37:57 2017
***************
*** 45,51 ****
        ],
        'id' => 2,
        'parent' => 1,
!       'short' => 'InitPlan'
      },
      {
        'child' => [
--- 45,51 ----
        ],
        'id' => 2,
        'parent' => 1,
!       'short' => 'InitPlan 1 (returns $0)'
      },
      {
        'child' => [

```

```
*** ./expected/qp_misc_jiras.out	Tue Oct 31 16:41:44 2017
--- ./results/qp_misc_jiras.out	Tue Oct 31 16:41:44 2017
***************
*** 3325,3331 ****
        ],
        'id' => 2,
        'parent' => 1,
!       'short' => 'InitPlan'
      }
    ],
    'id' => 1,
--- 3324,3330 ----
        ],
        'id' => 2,
        'parent' => 1,
!       'short' => 'InitPlan 1 (returns $0)'
      }
    ],
    'id' => 1,
```

test qp_misc_jiras        ... ok
test subselect_gp2        ... ok

=====================
 All 2 tests passed.
=====================