### PR TITLE
Create separate static libpq for linking into backend

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -14,7 +14,6 @@ include Makefile.global
 
 
 all install installdirs uninstall distprep:
-	$(MAKE) -C interfaces/libpq $@
 	$(MAKE) -C port $@
 	$(MAKE) -C timezone $@
 	$(MAKE) -C backend $@

--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -49,6 +49,11 @@ endif
 
 OBJS = $(SUBDIROBJS) $(LOCALOBJS) $(top_builddir)/src/port/libpgport_srv.a
 
+# Greenplum uses libpq to communicate between QD and QEs
+LIBS += $(libpq_builddir)/libpq_srv.a
+
+postgres: | submake-libpq
+
 ifeq ($(PORTNAME), darwin)
 LDOPTS = -Z
 endif
@@ -66,9 +71,6 @@ endif
 
 # Greenplum uses threads in the backend
 LIBS := $(LIBS) -lpthread
-
-# Greenplum uses libpq to communicate between QD and QEs
-OBJS := $(OBJS) $(addprefix $(top_builddir)/src/interfaces/libpq/,fe-protocol3_for_backend.o fe-connect_for_backend.o fe-exec.o pqexpbuffer.o fe-auth.o fe-misc.o fe-protocol2.o fe-secure.o getpeereid.o)
 
 ##########################################################################
 

--- a/src/interfaces/libpq/Makefile
+++ b/src/interfaces/libpq/Makefile
@@ -70,10 +70,16 @@ endif
 
 SHLIB_EXPORTS = exports.txt
 
-all: all-lib fe-protocol3_for_backend.o fe-connect_for_backend.o
+all: all-lib libpq_srv.a
 
-%_for_backend.o: %.c
-	$(CC) -c $(filter-out -DFRONTEND, $(CPPFLAGS)) $< -o $@
+# foo_srv.o and foo.o are both built from foo.c, but only foo.o has -DFRONTEND
+OBJS_SRV = $(OBJS:%.o=%_srv.o)
+
+libpq_srv.a: $(OBJS_SRV)
+	$(AR) $(AROPT) $@ $^
+
+%_srv.o: %.c
+	$(CC) $(CFLAGS) $(subst -DFRONTEND,, $(CPPFLAGS)) -c $< -o $@
 
 # Shared library stuff
 include $(top_srcdir)/src/Makefile.shlib
@@ -133,6 +139,7 @@ clean distclean: clean-lib
 	rm -f *.o pg_config_paths.h crypt.c getaddrinfo.c getpeereid.c inet_aton.c inet_net_ntop.c noblock.c open.c pgstrcasecmp.c snprintf.c strerror.c strlcpy.c thread.c md5.c ip.c encnames.c wchar.c win32error.c pgsleep.c pthread.h libpq.rc exports.list
 # Might be left over from a Win32 client-only build
 	rm -f pg_config_paths.h
+	rm -f libpq_srv.a $(OBJS_SRV)
 
 maintainer-clean: distclean maintainer-clean-lib
 	rm -f libpq-dist.rc


### PR DESCRIPTION
Commit 510a20b6c2 removed gp_libpq_fe -- good riddance -- but broke the
build system in two ways:

  1. It hardcodes objects generated by AC_REPLACE_FUNCS, AC_LIBOBJ, and
  friends
  2. It hardcodes the compilation order in src/Makefile, instead of
  declaring dependency for backend: to be fair, this is a (bad)
  precedent set in upstream until 9.1 (see postgres/postgres@19e231bb
  and postgres/postgres@cfad144f).

As a result of 1 above, builds were broken on platforms where
`getpeereid` were provided, e.g. a Linux system with `libbsd` linked, or
a macOS system.
Point number 2 above mostly manifests itself when you're incrementally
rebuilding, e.g. `make -C src/backend` may result in

```
No rule to make target `../../src/interfaces/libpq/fe-protocol3_for_backend.o', needed by `postgres'.
```

This commit creates a non-frontend version of libpq, statically links it
to the backend, and explicit declare libpq as a dependency of the
backend.