### PR TITLE
Symlink libpq files for backend and optimize the makefiles

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -14,7 +14,6 @@ include Makefile.global
 
 
 all install installdirs uninstall distprep:
-	$(MAKE) -C interfaces/libpq $@
 	$(MAKE) -C port $@
 	$(MAKE) -C timezone $@
 	$(MAKE) -C backend $@

--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -67,13 +67,6 @@ endif
 # Greenplum uses threads in the backend
 LIBS := $(LIBS) -lpthread
 
-# Greenplum uses libpq to communicate between QD and QEs
-OBJS += $(addprefix $(top_builddir)/src/interfaces/libpq/,fe-protocol3_for_backend.o fe-connect_for_backend.o fe-exec.o pqexpbuffer.o fe-auth.o fe-misc.o fe-protocol2.o fe-secure.o)
-
-ifneq ($(filter getpeereid.o,$(LIBOBJS)),)
-OBJS += $(addprefix $(top_builddir)/src/interfaces/libpq/,getpeereid.o)
-endif
-
 ##########################################################################
 
 all: submake-libpgport postgres $(POSTGRES_IMP)

--- a/src/backend/cdb/dispatcher/test/Makefile
+++ b/src/backend/cdb/dispatcher/test/Makefile
@@ -8,7 +8,7 @@ TARGETS=cdbdispatchresult \
 include $(top_builddir)/src/backend/mock.mk
 
 cdbdispatchresult.t: \
-	$(MOCK_DIR)/interfaces/libpq/pqexpbuffer_mock.o \
+	$(MOCK_DIR)/backend/libpq/pqexpbuffer_mock.o \
 	$(MOCK_DIR)/backend/cdb/cdbrelsize_mock.o \
 	$(MOCK_DIR)/backend/cdb/cdbsrlz_mock.o \
 
@@ -19,7 +19,7 @@ cdbgang.t: \
 	$(MOCK_DIR)/backend/cdb/cdbutil_mock.o \
 	$(MOCK_DIR)/backend/cdb/cdbfts_mock.o \
 	$(MOCK_DIR)/backend/utils/misc/superuser_mock.o \
-	$(MOCK_DIR)/interfaces/libpq/fe-connect_mock.o \
+	$(MOCK_DIR)/backend/libpq/fe-connect_mock.o \
 	$(MOCK_DIR)/backend/utils/mmgr/redzone_handler_mock.o \
 	$(MOCK_DIR)/backend/utils/misc/faultinjector_mock.o
 

--- a/src/backend/common.mk
+++ b/src/backend/common.mk
@@ -28,7 +28,7 @@ SUBSYS.o: $(SUBDIROBJS) $(OBJS)
 
 objfiles.txt: Makefile $(SUBDIROBJS) $(OBJS)
 # Don't rebuild the list if only the OBJS have changed.
-	$(if $(filter-out $(OBJS),$?),( $(if $(SUBDIROBJS),cat $(SUBDIROBJS); )echo $(subst src/backend/../../,,$(addprefix $(subdir)/,$(OBJS))) ) >$@,touch $@)
+	$(if $(filter-out $(OBJS),$?),( $(if $(SUBDIROBJS),cat $(SUBDIROBJS); )echo $(addprefix $(subdir)/,$(OBJS)) ) >$@,touch $@)
 
 # make function to expand objfiles.txt contents
 expand_subsys = $(foreach file,$(1),$(if $(filter %/objfiles.txt,$(file)),$(patsubst ../../src/backend/%,%,$(addprefix $(top_builddir)/,$(shell cat $(file)))),$(file)))

--- a/src/backend/libpq/.gitignore
+++ b/src/backend/libpq/.gitignore
@@ -1,0 +1,9 @@
+fe-auth.c
+fe-connect.c
+fe-exec.c
+fe-misc.c
+fe-protocol2.c
+fe-protocol3.c
+fe-secure.c
+getpeereid.c
+pqexpbuffer.c

--- a/src/backend/libpq/Makefile
+++ b/src/backend/libpq/Makefile
@@ -11,10 +11,29 @@
 subdir = src/backend/libpq
 top_builddir = ../../..
 include $(top_builddir)/src/Makefile.global
+override CPPFLAGS += -I$(libpq_srcdir) -I$(top_srcdir)/src/port
 
 # be-fsstubs is here for historical reasons, probably belongs elsewhere
 
 OBJS = be-fsstubs.o be-secure.o auth.o crypt.o hba.o ip.o md5.o pqcomm.o \
-       pqformat.o pqsignal.o sha2.o pg_sha2.o
+       pqformat.o pqsignal.o sha2.o pg_sha2.o fe-protocol3.o fe-connect.o \
+       fe-exec.o pqexpbuffer.o fe-auth.o fe-misc.o fe-protocol2.o fe-secure.o \
+       $(filter getpeereid.o, $(LIBOBJS))
+
+fe-protocol3.c fe-connect.c fe-exec.c pqexpbuffer.c fe-auth.c fe-misc.c fe-protocol2.c fe-secure.c: % : $(top_srcdir)/src/interfaces/libpq/%
+	rm -f $@ && $(LN_S) $< .
+
+getpeereid.c: % : $(top_srcdir)/src/port/%
+	rm -f $@ && $(LN_S) $< .
+
+fe-connect.o: fe-connect.c $(top_builddir)/src/port/pg_config_paths.h
+
+$(top_builddir)/src/port/pg_config_paths.h:
+	$(MAKE) -C $(top_builddir)/src/port pg_config_paths.h
+
+clean distclean: clean-symlinks
+
+clean-symlinks:
+	rm -f fe-protocol3.c fe-connect.c fe-exec.c pqexpbuffer.c fe-auth.c fe-misc.c fe-protocol2.c fe-secure.c getpeereid.c
 
 include $(top_srcdir)/src/backend/common.mk

--- a/src/backend/mock.mk
+++ b/src/backend/mock.mk
@@ -125,7 +125,7 @@ ALL_OBJS=$(addprefix $(top_srcdir)/, \
 # in a test program.
 #
 # The argument is a list of backend object files that should *not* be included
-BACKEND_OBJS=$(filter-out $(1), $(subst _for_backend,,$(ALL_OBJS)))
+BACKEND_OBJS=$(filter-out $(1), $(ALL_OBJS))
 
 # If we are using linker's wrap feature in unit test, add wrap flags for
 # those mocked functions

--- a/src/interfaces/libpq/Makefile
+++ b/src/interfaces/libpq/Makefile
@@ -70,10 +70,7 @@ endif
 
 SHLIB_EXPORTS = exports.txt
 
-all: all-lib fe-protocol3_for_backend.o fe-connect_for_backend.o
-
-%_for_backend.o: %.c
-	$(CC) -c $(filter-out -DFRONTEND, $(CPPFLAGS)) $< -o $@
+all: all-lib
 
 # Shared library stuff
 include $(top_srcdir)/src/Makefile.shlib

--- a/src/interfaces/libpq/README
+++ b/src/interfaces/libpq/README
@@ -6,6 +6,4 @@ This directory contains the C version of Libpq, the POSTGRES frontend library.
 
 libpq is also used by QD to QEs communications, backend, check the macro FRONTEND.
 
-For now, only fe-protocol3.c and fe-connect.c are also compiled to a backend
-version, and only them two are specially noted in src/interfaces/libpq/Makefile
-and src/backend/Makefile.
+Check out Makefile in src/backend/libpq, which symlinks some files here.

--- a/src/test/unit/mock/.gitignore
+++ b/src/test/unit/mock/.gitignore
@@ -1,2 +1,1 @@
 backend
-interfaces


### PR DESCRIPTION
src/backend's makefiles have its own rules, this commit symlinks libpq
files for backend to leverage them, canonical and much simpler.

What are the rules?

1, src/backend compile SUBDIR, list OBJS in sub-directories'
objfiles.txt, then link them all into postgres.

2, mock.mk links all OBJS, but filters out the objects which mocked by
cases.