### PR TITLE
docs - gp_resource_group_memory_limit default is .7

### DIFF
--- a/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
@@ -128,7 +128,7 @@
             type="section"/></codeph> server configuration parameter identifies the maximum
         percentage of system memory resources to allocate to resource groups on each Greenplum
         Database segment node. The default <codeph>gp_resource_group_memory_limit</codeph> value is
-        .9 (90%).</p>
+        .7 (70%).</p>
       <p>The memory resource available on a Greenplum Database node is further divided equally among
         each segment on the node. Each resource group reserves a percentage of the segment memory
         for resource management. You identify this percentage via the <codeph>MEMORY_LIMIT</codeph>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -4970,7 +4970,7 @@
           <tbody>
             <row>
               <entry colname="col1">0.1 - 1.0</entry>
-              <entry colname="col2">0.9</entry>
+              <entry colname="col2">0.7</entry>
               <entry colname="col3">local<p>system</p><p>restart</p></entry>
             </row>
           </tbody>


### PR DESCRIPTION
small updates to guc ref page and using resource groups page.