### PR TITLE
Fix confusion between MemTuples and HeapTuples, for 5X_STABLE

### DIFF
--- a/src/backend/access/appendonly/appendonly_compaction.c
+++ b/src/backend/access/appendonly/appendonly_compaction.c
@@ -297,11 +297,10 @@ AppendOnlyMoveTuple(MemTuple tuple,
 }
 
 void
-AppendOnlyThrowAwayTuple(
-					Relation rel,
-					MemTuple tuple,
-					TupleTableSlot	*slot,
-					MemTupleBinding *mt_bind)
+AppendOnlyThrowAwayTuple(Relation rel,
+						 MemTuple tuple,
+						 TupleTableSlot	*slot,
+						 MemTupleBinding *mt_bind)
 {
 	AOTupleId *oldAoTupleId;
 
@@ -314,7 +313,7 @@ AppendOnlyThrowAwayTuple(
 
 	if (MemTupleHasExternal(tuple, mt_bind))
 	{
-		toast_delete(rel, (HeapTuple) tuple, mt_bind);
+		toast_delete(rel, (GenericTuple) tuple, mt_bind);
 	}
 
 	elogif(Debug_appendonly_print_compaction, DEBUG5, 

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -2956,11 +2956,11 @@ appendonly_insert(AppendOnlyInsertDesc aoInsertDesc,
 	 * into the relation; instup is the caller's original untoasted data.
 	 */
 	if (need_toast)
-		tup = (MemTuple) toast_insert_or_update(relation, (HeapTuple) instup,
-												NULL, aoInsertDesc->mt_bind,
-												aoInsertDesc->toast_tuple_target,
-												false,	/* errtbl is never AO */
-												true, true);
+		tup = toast_insert_or_update_memtup(relation, instup,
+											NULL, aoInsertDesc->mt_bind,
+											aoInsertDesc->toast_tuple_target,
+											false,	/* errtbl is never AO */
+											true, true);
 	else
 		tup = instup;
 

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -2651,12 +2651,6 @@ appendonly_update(AppendOnlyUpdateDesc aoUpdateDesc,
 	/* tableName */
 #endif
 
-	/*
-	 * We cannot deal with an update tuples with external tuples that may be
-	 * the same as the updated tuple. Compaction would go wild.
-	 */
-	Assert(!MemTupleHasExternal(memTuple, aoUpdateDesc->aoInsertDesc->mt_bind));
-
 	result = AppendOnlyVisimapDelete_Hide(&aoUpdateDesc->visiMapDelete, aoTupleId);
 	if (result != HeapTupleMayBeUpdated)
 		return result;

--- a/src/backend/access/common/heaptuple.c
+++ b/src/backend/access/common/heaptuple.c
@@ -285,7 +285,7 @@ heap_fill_tuple(TupleDesc tupleDesc,
 bool
 heap_attisnull(HeapTuple tup, int attnum)
 {
-	Assert(!is_heaptuple_memtuple(tup));
+	Assert(!is_memtuple((GenericTuple) tup));
 
 	if (attnum > (int) HeapTupleHeaderGetNatts(tup->t_data))
 		return true;
@@ -360,7 +360,7 @@ nocachegetattr(HeapTuple tuple,
 	bool		slow = false;	/* do we have to walk attrs? */
 	int			off;			/* current offset within data */
 
-	Assert(!is_heaptuple_memtuple(tuple));
+	Assert(!is_memtuple((GenericTuple) tuple));
 
 	/* ----------------
 	 *	 Three cases:
@@ -595,7 +595,7 @@ heap_getsysattr(HeapTuple tup, int attnum, bool *isnull)
 	Datum		result;
 
 	Assert(tup);
-	Assert(!is_heaptuple_memtuple(tup));
+	Assert(!is_memtuple((GenericTuple) tup));
 
 	/* Currently, no sys attribute ever reads as NULL. */
 	if (isnull)
@@ -661,7 +661,7 @@ heaptuple_copy_to(HeapTuple tuple, HeapTuple dest, uint32 *destlen)
 	if (!HeapTupleIsValid(tuple) || tuple->t_data == NULL)
 		return NULL;
 
-	Assert(!is_heaptuple_memtuple(tuple));
+	Assert(!is_memtuple((GenericTuple) tuple));
 
 	len = HEAPTUPLESIZE + tuple->t_len;
 	if(destlen && *destlen < len)
@@ -703,7 +703,7 @@ heap_copytuple_with_tuple(HeapTuple src, HeapTuple dest)
 		return;
 	}
 
-	Assert(!is_heaptuple_memtuple(src));
+	Assert(!is_memtuple((GenericTuple) src));
 
 	dest->t_len = src->t_len;
 	dest->t_self = src->t_self;
@@ -828,7 +828,7 @@ heaptuple_form_to(TupleDesc tupleDescriptor, Datum *values, bool *isnull, HeapTu
 								 (hasnull ? td->t_bits : NULL));
 
 	Assert(data_len == actual_len);
-	Assert(!is_heaptuple_memtuple(tuple));
+	Assert(!is_memtuple((GenericTuple) tuple));
 
 	return tuple;
 }
@@ -890,7 +890,7 @@ heap_modify_tuple(HeapTuple tuple,
 	bool	   *isnull;
 	HeapTuple	newTuple;
 
-	Assert(!is_heaptuple_memtuple(tuple));
+	Assert(!is_memtuple((GenericTuple) tuple));
 
 	/*
 	 * allocate and fill values and isnull arrays from either the tuple or the
@@ -1004,7 +1004,7 @@ heap_deform_tuple(HeapTuple tuple, TupleDesc tupleDesc,
 	bits8	   *bp = tup->t_bits;		/* ptr to null bitmap in tuple */
 	bool		slow = false;	/* can we use/set attcacheoff? */
 
-	Assert(!is_heaptuple_memtuple(tuple));
+	Assert(!is_memtuple((GenericTuple) tuple));
 	natts = HeapTupleHeaderGetNatts(tup);
 
 	/*

--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -2348,7 +2348,7 @@ heap_insert(Relation relation, HeapTuple tup, CommandId cid,
 		heaptup = tup;
 	}
 	else if (HeapTupleHasExternal(tup) || tup->t_len > TOAST_TUPLE_THRESHOLD)
-		heaptup = toast_insert_or_update(relation, tup, NULL, NULL,
+		heaptup = toast_insert_or_update(relation, tup, NULL,
 										 TOAST_TUPLE_TARGET, isFrozen,
 										 use_wal, use_fsm);
 	else
@@ -2858,7 +2858,7 @@ l1:
 		Assert(!HeapTupleHasExternal(&tp));
 	}
 	else if (HeapTupleHasExternal(&tp))
-		toast_delete(relation, &tp, NULL);
+		toast_delete(relation, (GenericTuple) &tp, NULL);
 
 	/*
 	 * Mark tuple for invalidation from system caches at next command
@@ -3308,7 +3308,7 @@ l2:
 		if (need_toast)
 		{
 			/* Note we always use WAL and FSM during updates */
-			heaptup = toast_insert_or_update(relation, newtup, &oldtup, NULL,
+			heaptup = toast_insert_or_update(relation, newtup, &oldtup,
 											 TOAST_TUPLE_TARGET, false, true, true);
 			newtupsize = MAXALIGN(heaptup->t_len);
 		}

--- a/src/backend/access/heap/rewriteheap.c
+++ b/src/backend/access/heap/rewriteheap.c
@@ -573,7 +573,7 @@ raw_heap_insert(RewriteState state, HeapTuple tup)
 		heaptup = tup;
 	}
 	else if (HeapTupleHasExternal(tup) || tup->t_len > TOAST_TUPLE_THRESHOLD)
-		heaptup = toast_insert_or_update(state->rs_new_rel, tup, NULL, NULL,
+		heaptup = toast_insert_or_update(state->rs_new_rel, tup, NULL,
 										 TOAST_TUPLE_TARGET, false,
 										 state->rs_use_wal, false);
 	else

--- a/src/backend/access/heap/tuptoaster.c
+++ b/src/backend/access/heap/tuptoaster.c
@@ -453,7 +453,7 @@ toast_datum_size(Datum value)
  * ----------
  */
 void
-toast_delete(Relation rel, HeapTuple oldtup, MemTupleBinding *pbind)
+toast_delete(Relation rel, GenericTuple oldtup, MemTupleBinding *pbind)
 {
 	TupleDesc	tupleDesc;
 	Form_pg_attribute *att;
@@ -461,7 +461,7 @@ toast_delete(Relation rel, HeapTuple oldtup, MemTupleBinding *pbind)
 	int			i;
 	Datum		toast_values[MaxHeapAttributeNumber];
 	bool		toast_isnull[MaxHeapAttributeNumber];
-	bool 		ismemtuple = is_heaptuple_memtuple(oldtup);
+	bool 		ismemtuple = is_memtuple(oldtup);
 	
 	AssertImply(ismemtuple, pbind);
 	AssertImply(!ismemtuple, !pbind);
@@ -495,10 +495,10 @@ toast_delete(Relation rel, HeapTuple oldtup, MemTupleBinding *pbind)
 
 	Assert(numAttrs <= MaxHeapAttributeNumber);
 
-	if(ismemtuple)
+	if (ismemtuple)
 		memtuple_deform((MemTuple) oldtup, pbind, toast_values, toast_isnull);
 	else
-		heap_deform_tuple(oldtup, tupleDesc, toast_values, toast_isnull);
+		heap_deform_tuple((HeapTuple) oldtup, tupleDesc, toast_values, toast_isnull);
 
 	/*
 	 * Check for external stored attributes and delete them from the secondary
@@ -548,12 +548,12 @@ static int compute_dest_tuplen(TupleDesc tupdesc, MemTupleBinding *pbind, bool h
 }
 
 
-HeapTuple
-toast_insert_or_update(Relation rel, HeapTuple newtup, HeapTuple oldtup, 
+static GenericTuple
+toast_insert_or_update_generic(Relation rel, GenericTuple newtup, GenericTuple oldtup,
 					   MemTupleBinding *pbind, int toast_tuple_target,
 					   bool isFrozen, bool use_wal, bool use_fsm)
 {
-	HeapTuple	result_tuple;
+	GenericTuple result_gtuple;
 	TupleDesc	tupleDesc;
 	Form_pg_attribute *att;
 	int			numAttrs;
@@ -576,11 +576,11 @@ toast_insert_or_update(Relation rel, HeapTuple newtup, HeapTuple oldtup,
 	bool		toast_free[MaxHeapAttributeNumber];
 	bool		toast_delold[MaxHeapAttributeNumber];
 
-	bool 		ismemtuple = is_heaptuple_memtuple(newtup);
+	bool 		ismemtuple = is_memtuple(newtup);
 
 	AssertImply(ismemtuple, pbind);
 	AssertImply(!ismemtuple, !pbind);
-	AssertImply(ismemtuple && oldtup, is_heaptuple_memtuple(oldtup));
+	AssertImply(ismemtuple && oldtup, is_memtuple(oldtup));
 	Assert(toast_tuple_target > 0);
 
 	/*
@@ -601,14 +601,14 @@ toast_insert_or_update(Relation rel, HeapTuple newtup, HeapTuple oldtup,
 	if(ismemtuple)
 		memtuple_deform((MemTuple) newtup, pbind, toast_values, toast_isnull);
 	else
-		heap_deform_tuple(newtup, tupleDesc, toast_values, toast_isnull);
+		heap_deform_tuple((HeapTuple) newtup, tupleDesc, toast_values, toast_isnull);
 
 	if (oldtup != NULL)
 	{
 		if(ismemtuple)
 			memtuple_deform((MemTuple) oldtup, pbind, toast_oldvalues, toast_oldisnull);
 		else
-			heap_deform_tuple(oldtup, tupleDesc, toast_oldvalues, toast_oldisnull);
+			heap_deform_tuple((HeapTuple) oldtup, tupleDesc, toast_oldvalues, toast_oldisnull);
 	}
 	/* ----------
 	 * Then collect information about the values given
@@ -748,7 +748,7 @@ toast_insert_or_update(Relation rel, HeapTuple newtup, HeapTuple oldtup,
 		hoff = offsetof(HeapTupleHeaderData, t_bits);
 		if (has_nulls)
 			hoff += BITMAPLEN(numAttrs);
-		if (newtup->t_data->t_infomask & HEAP_HASOID)
+		if (((HeapTuple) newtup)->t_data->t_infomask & HEAP_HASOID)
 			hoff += sizeof(Oid);
 		hoff = MAXALIGN(hoff);
 		/* now convert to a limit on the tuple data size */
@@ -993,14 +993,15 @@ toast_insert_or_update(Relation rel, HeapTuple newtup, HeapTuple oldtup,
 	if (need_change)
 	{
 		if(ismemtuple)
-			result_tuple = (HeapTuple) memtuple_form_to(pbind, toast_values, toast_isnull, NULL, NULL, false);
+			result_gtuple = (GenericTuple) memtuple_form_to(pbind, toast_values, toast_isnull, NULL, NULL, false);
 		else
 		{
-			HeapTupleHeader olddata = newtup->t_data;
+			HeapTupleHeader olddata = ((HeapTuple) newtup)->t_data;
 			HeapTupleHeader new_data;
 			int32		new_header_len;
 			int32		new_data_len;
 			int32		new_tuple_len;
+			HeapTuple	result_tuple;
 
 			/*
 			 * Calculate the new size of the tuple.
@@ -1027,7 +1028,7 @@ toast_insert_or_update(Relation rel, HeapTuple newtup, HeapTuple oldtup,
 			 */
 			result_tuple = (HeapTuple) palloc0(HEAPTUPLESIZE + new_tuple_len);
 			result_tuple->t_len = new_tuple_len;
-			result_tuple->t_self = newtup->t_self;
+			result_tuple->t_self = ((HeapTuple) newtup)->t_self;
 			new_data = (HeapTupleHeader) ((char *) result_tuple + HEAPTUPLESIZE);
 			result_tuple->t_data = new_data;
 
@@ -1048,10 +1049,11 @@ toast_insert_or_update(Relation rel, HeapTuple newtup, HeapTuple oldtup,
 							new_data_len,
 							&(new_data->t_infomask),
 							has_nulls ? new_data->t_bits : NULL);
+			result_gtuple = (GenericTuple) result_tuple;
 		}
 	}
 	else
-		result_tuple = newtup;
+		result_gtuple = newtup;
 
 	/*
 	 * Free allocated temp values
@@ -1069,9 +1071,38 @@ toast_insert_or_update(Relation rel, HeapTuple newtup, HeapTuple oldtup,
 			if (toast_delold[i])
 				toast_delete_datum(rel, toast_oldvalues[i]);
 
-	return result_tuple;
+	return result_gtuple;
 }
 
+HeapTuple
+toast_insert_or_update(Relation rel, HeapTuple newtup, HeapTuple oldtup,
+					   int toast_tuple_target,
+					   bool isFrozen, bool use_wal, bool use_fsm)
+{
+	return (HeapTuple) toast_insert_or_update_generic(rel,
+													  (GenericTuple) newtup,
+													  (GenericTuple) oldtup,
+													  NULL,
+													  toast_tuple_target,
+													  isFrozen,
+													  use_wal,
+													  use_fsm);
+}
+
+MemTuple
+toast_insert_or_update_memtup(Relation rel, MemTuple newtup, MemTuple oldtup,
+					   MemTupleBinding *pbind, int toast_tuple_target,
+					   bool isFrozen, bool use_wal, bool use_fsm)
+{
+	return (MemTuple) toast_insert_or_update_generic(rel,
+													 (GenericTuple) newtup,
+													 (GenericTuple) oldtup,
+													 pbind,
+													 toast_tuple_target,
+													 isFrozen,
+													 use_wal,
+													 use_fsm);
+}
 
 /* ----------
  * toast_flatten_tuple -

--- a/src/backend/access/heap/tuptoaster.c
+++ b/src/backend/access/heap/tuptoaster.c
@@ -993,7 +993,16 @@ toast_insert_or_update_generic(Relation rel, GenericTuple newtup, GenericTuple o
 	if (need_change)
 	{
 		if(ismemtuple)
+		{
 			result_gtuple = (GenericTuple) memtuple_form_to(pbind, toast_values, toast_isnull, NULL, NULL, false);
+			if (mtbind_has_oid(pbind))
+			{
+				Oid			oid;
+
+				oid = MemTupleGetOid((MemTuple) newtup, pbind);
+				MemTupleSetOid((MemTuple) result_gtuple, pbind, oid);
+			}
+		}
 		else
 		{
 			HeapTupleHeader olddata = ((HeapTuple) newtup)->t_data;

--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -2131,7 +2131,7 @@ IndexBuildHeapScan(Relation heapRelation,
 		MemoryContextReset(econtext->ecxt_per_tuple_memory);
 
 		/* Set up for predicate or expression evaluation */
-		ExecStoreGenericTuple(heapTuple, slot, false);
+		ExecStoreHeapTuple(heapTuple, slot, InvalidBuffer, false);
 
 		/*
 		 * In a partial index, discard tuples that don't satisfy the
@@ -2781,7 +2781,7 @@ validate_index_heapscan(Relation heapRelation,
 			MemoryContextReset(econtext->ecxt_per_tuple_memory);
 
 			/* Set up for predicate or expression evaluation */
-			ExecStoreGenericTuple(heapTuple, slot, false);
+			ExecStoreHeapTuple(heapTuple, slot, InvalidBuffer, false);
 
 			/*
 			 * In a partial index, discard tuples that don't satisfy the

--- a/src/backend/catalog/indexing.c
+++ b/src/backend/catalog/indexing.c
@@ -94,7 +94,7 @@ CatalogIndexInsert(CatalogIndexState indstate, HeapTuple heapTuple)
 
 	/* Need a slot to hold the tuple being examined */
 	slot = MakeSingleTupleTableSlot(RelationGetDescr(heapRelation));
-	ExecStoreGenericTuple(heapTuple, slot, false);
+	ExecStoreHeapTuple(heapTuple, slot, InvalidBuffer, false);
 
 	/*
 	 * for each index, form and insert the index tuple

--- a/src/backend/cdb/motion/cdbmotion.c
+++ b/src/backend/cdb/motion/cdbmotion.c
@@ -87,21 +87,21 @@ static void UpdateSentRecordCache(MotionConn *conn);
 static inline void
 reconstructTuple(MotionNodeEntry * pMNEntry, ChunkSorterEntry * pCSEntry, TupleRemapper *remapper)
 {
-	HeapTuple	htup;
+	GenericTuple tup;
 	SerTupInfo *pSerInfo = &pMNEntry->ser_tup_info;
 
 	/*
 	 * Convert the list of chunks into a tuple, then stow it away. This frees
 	 * our TCList as a side-effect
 	 */
-	htup = CvtChunksToHeapTup(&pCSEntry->chunk_list, pSerInfo, remapper);
+	tup = CvtChunksToTup(&pCSEntry->chunk_list, pSerInfo, remapper);
 
-	if (!htup)
+	if (!tup)
 		return;
 
-	htup = TRCheckAndRemap(remapper, pSerInfo->tupdesc, htup);
+	tup = TRCheckAndRemap(remapper, pSerInfo->tupdesc, tup);
 
-	htfifo_addtuple(pCSEntry->ready_tuples, htup);
+	htfifo_addtuple(pCSEntry->ready_tuples, tup);
 
 	/* Stats */
 	statNewTupleArrived(pMNEntry, pCSEntry);
@@ -482,7 +482,7 @@ SendReturnCode
 SendTuple(MotionLayerState *mlStates,
 		  ChunkTransportState *transportStates,
 		  int16 motNodeID,
-		  HeapTuple tuple,
+		  GenericTuple tuple,
 		  int16 targetRoute)
 {
 	MotionNodeEntry *pMNEntry;
@@ -615,7 +615,7 @@ ReceiveReturnCode
 RecvTupleFrom(MotionLayerState *mlStates,
 			  ChunkTransportState *transportStates,
 			  int16 motNodeID,
-			  HeapTuple *tup_i,
+			  GenericTuple *tup_i,
 			  int16 srcRoute)
 {
 	MotionNodeEntry *pMNEntry;

--- a/src/backend/cdb/motion/htupfifo.c
+++ b/src/backend/cdb/motion/htupfifo.c
@@ -91,13 +91,13 @@ htfifo_init(htup_fifo htf, int max_mem_kb)
 static void
 htfifo_cleanup(htup_fifo htf)
 {
-	HeapTuple	htup;
+	GenericTuple tup;
 
 	AssertArg(htf != NULL);
 
 	/* TODO:  This can be faster if we didn't reuse code, but this will work. */
-	while ((htup = htfifo_gettuple(htf)) != NULL)
-		heap_freetuple(htup);
+	while ((tup = htfifo_gettuple(htf)) != NULL)
+		pfree(tup);
 
 	while (htf->freelist)
 	{
@@ -144,12 +144,12 @@ htfifo_destroy(htup_fifo htf)
  * init-time, then an error is flagged.
  */
 void
-htfifo_addtuple(htup_fifo htf, HeapTuple htup)
+htfifo_addtuple(htup_fifo htf, GenericTuple tup)
 {
 	htf_entry	p_ent;
 
 	AssertArg(htf != NULL);
-	AssertArg(htup != NULL);
+	AssertArg(tup != NULL);
 
 	/* Populate the new entry. */
 	if (htf->freelist != NULL)
@@ -161,7 +161,7 @@ htfifo_addtuple(htup_fifo htf, HeapTuple htup)
 	{
 		p_ent = (htf_entry) palloc(sizeof(htf_entry_data));
 	}
-	p_ent->htup = htup;
+	p_ent->tup = tup;
 	p_ent->p_next = NULL;
 
 	/* Put the new entry at the end of the FIFO. */
@@ -181,7 +181,7 @@ htfifo_addtuple(htup_fifo htf, HeapTuple htup)
 	/* Update the FIFO state. */
 
 	htf->tup_count++;
-	htf->curr_mem_size += GetMemoryChunkSpace(p_ent) + GetMemoryChunkSpace(htup);
+	htf->curr_mem_size += GetMemoryChunkSpace(p_ent) + GetMemoryChunkSpace(tup);
 }
 
 
@@ -189,11 +189,11 @@ htfifo_addtuple(htup_fifo htf, HeapTuple htup)
  * Retrieve the next HeapTuple from the start of the FIFO. If the FIFO
  * is empty then NULL is returned.
  */
-HeapTuple
+GenericTuple
 htfifo_gettuple(htup_fifo htf)
 {
 	htf_entry	p_ent;
-	HeapTuple	htup;
+	GenericTuple tup;
 
 	AssertArg(htf != NULL);
 
@@ -210,8 +210,8 @@ htfifo_gettuple(htup_fifo htf)
 
 		p_ent->p_next = NULL;	/* Just for the sake of completeness... */
 
-		htup = p_ent->htup;
-		AssertState(htup != NULL);
+		tup = p_ent->tup;
+		AssertState(tup != NULL);
 
 		/* Update the FIFO state. */
 
@@ -220,7 +220,7 @@ htfifo_gettuple(htup_fifo htf)
 
 		htf->tup_count--;
 		htf->curr_mem_size -=
-			(GetMemoryChunkSpace(p_ent) + GetMemoryChunkSpace(htup));
+			(GetMemoryChunkSpace(p_ent) + GetMemoryChunkSpace(tup));
 
 		AssertState(htf->tup_count >= 0);
 		AssertState(htf->curr_mem_size >= 0);
@@ -245,8 +245,8 @@ htfifo_gettuple(htup_fifo htf)
 		 */
 		AssertState(htf->tup_count == 0);
 		AssertState(htf->curr_mem_size == 0);
-		htup = NULL;
+		tup = NULL;
 	}
 
-	return htup;
+	return tup;
 }

--- a/src/backend/cdb/motion/tupleremap.c
+++ b/src/backend/cdb/motion/tupleremap.c
@@ -129,10 +129,10 @@ struct TupleRemapper
 	bool		remap_needed;	/* is remap needed */
 };
 
-static HeapTuple TRRemapTuple(TupleRemapper *remapper,
+static GenericTuple TRRemapTuple(TupleRemapper *remapper,
 			 TupleDesc tupledesc,
 			 TupleRemapInfo **field_remapinfo,
-			 HeapTuple tuple);
+			 GenericTuple tuple);
 static Datum TRRemap(TupleRemapper *remapper, TupleRemapInfo *remapinfo,
 		Datum value, bool *changed);
 static Datum TRRemapArray(TupleRemapper *remapper, ArrayRemapInfo *remapinfo,
@@ -192,8 +192,8 @@ DestroyTupleRemapper(TupleRemapper *remapper)
  *
  * Form a new tuple with all the remote typmods remapped to local typmods.
  */
-HeapTuple
-TRCheckAndRemap(TupleRemapper *remapper, TupleDesc tupledesc, HeapTuple tuple)
+GenericTuple
+TRCheckAndRemap(TupleRemapper *remapper, TupleDesc tupledesc, GenericTuple tuple)
 {
 	if (!remapper->remap_needed)
 		return tuple;
@@ -256,11 +256,11 @@ TRHandleTypeLists(TupleRemapper *remapper, List *typelist)
 /*
  * Copy the given tuple, remapping any transient typmods contained in it.
  */
-static HeapTuple
+static GenericTuple
 TRRemapTuple(TupleRemapper *remapper,
 			 TupleDesc tupledesc,
 			 TupleRemapInfo **field_remapinfo,
-			 HeapTuple tuple)
+			 GenericTuple tuple)
 {
 	Datum	   *values;
 	bool	   *isnull;
@@ -279,14 +279,14 @@ TRRemapTuple(TupleRemapper *remapper,
 	isnull = (bool *) palloc(tupledesc->natts * sizeof(bool));
 
 	/* CDB */
-	if (is_heaptuple_memtuple(tuple))
+	if (is_memtuple(tuple))
 	{
 		MemTupleBinding *pbind = create_memtuple_binding(tupledesc);
 		memtuple_deform((MemTuple) tuple, pbind, values, isnull);
 	}
 	else
 	{
-		heap_deform_tuple(tuple, tupledesc, values, isnull);
+		heap_deform_tuple((HeapTuple) tuple, tupledesc, values, isnull);
 	}
 
 	/* Recursively process each interesting non-NULL attribute. */
@@ -299,7 +299,7 @@ TRRemapTuple(TupleRemapper *remapper,
 
 	/* Reconstruct the modified tuple, if anything was modified. */
 	if (changed)
-		return heap_form_tuple(tupledesc, values, isnull);
+		return (GenericTuple) heap_form_tuple(tupledesc, values, isnull);
 	else
 		return tuple;
 }
@@ -530,10 +530,10 @@ TRRemapRecord(TupleRemapper *remapper, RecordRemapInfo *remapinfo,
 		ItemPointerSetInvalid(&htup.t_self);
 		htup.t_len = HeapTupleHeaderGetDatumLength(tup);
 		htup.t_data = tup;
-		atup = TRRemapTuple(remapper,
-							remapinfo->tupledesc,
-							remapinfo->field_remap,
-							&htup);
+		atup = (HeapTuple) TRRemapTuple(remapper,
+										remapinfo->tupledesc,
+										remapinfo->field_remap,
+										(GenericTuple) &htup);
 
 		/* Apply the correct labeling for a local Datum. */
 		HeapTupleHeaderSetTypeId(atup->t_data, typid);

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -743,7 +743,7 @@ compute_index_stats(Relation onerel, double totalrows,
 			ResetExprContext(econtext);
 
 			/* Set up for predicate or expression evaluation */
-			ExecStoreGenericTuple(heapTuple, slot, false);
+			ExecStoreHeapTuple(heapTuple, slot, InvalidBuffer, false);
 
 			/* If index is partial, check predicate */
 			if (predicate != NIL)

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -4227,7 +4227,6 @@ CopyFromDispatch(CopyState cstate)
 static void
 CopyFrom(CopyState cstate)
 {
-	void		*tuple;
 	TupleDesc	tupDesc;
 	Form_pg_attribute *attr;
 	AttrNumber	num_phys_attrs,
@@ -4240,12 +4239,8 @@ CopyFrom(CopyState cstate)
 	int			attnum;
 	int			i;
 	Oid			in_func_oid;
-	Datum		*values = NULL;
-	bool		*nulls = NULL;
 	Datum		*partValues = NULL;
 	bool		*partNulls = NULL;
-	Datum		*baseValues = NULL;
-	bool		*baseNulls = NULL;
 	bool		isnull;
 	ResultRelInfo *resultRelInfo;
 	EState	   *estate = CreateExecutorState(); /* for ExecConstraints() */
@@ -4407,8 +4402,6 @@ CopyFrom(CopyState cstate)
 		CopyFromProcessDataFileHeader(cstate, cdbCopy, &file_has_oids);
 	}
 
-	baseValues = (Datum *) palloc(num_phys_attrs * sizeof(Datum));
-	baseNulls = (bool *) palloc(num_phys_attrs * sizeof(bool));
 	attr_offsets = (int *) palloc(num_phys_attrs * sizeof(int));
 
 	partValues = (Datum *) palloc(attr_count * sizeof(Datum));
@@ -4503,6 +4496,9 @@ PROCESS_SEGMENT_DATA:
 				bool		skip_tuple;
 				Oid			loaded_oid = InvalidOid;
 				char		relstorage;
+				Datum	   *baseValues;
+				bool	   *baseNulls;
+
 				CHECK_FOR_INTERRUPTS();
 
 				/* Reset the per-tuple exprcontext */
@@ -4512,6 +4508,10 @@ PROCESS_SEGMENT_DATA:
 				MemoryContextSwitchTo(GetPerTupleMemoryContext(estate));
 
 				/* Initialize all values for row to NULL */
+				ExecClearTuple(baseSlot);
+				baseValues = slot_get_values(baseSlot);
+				baseNulls = slot_get_isnull(baseSlot);
+
 				MemSet(baseValues, 0, num_phys_attrs * sizeof(Datum));
 				MemSet(baseNulls, true, num_phys_attrs * sizeof(bool));
 				/* reset attribute pointers */
@@ -4821,33 +4821,37 @@ PROCESS_SEGMENT_DATA:
 
 				MemoryContextSwitchTo(GetPerTupleMemoryContext(estate));
 
+				ExecStoreVirtualTuple(baseSlot);
+
 				/*
 				 * And now we can form the input tuple.
+				 *
+				 * The resulting tuple is stored in 'slot'
 				 */
 				if (resultRelInfo->ri_partSlot != NULL)
 				{
 					AttrMap *map = resultRelInfo->ri_partInsertMap;
 					Assert(map != NULL);
 
-
+					slot = resultRelInfo->ri_partSlot;
+					ExecClearTuple(slot);
+					partValues = slot_get_values(resultRelInfo->ri_partSlot);
+					partNulls = slot_get_isnull(resultRelInfo->ri_partSlot);
 					MemSet(partValues, 0, attr_count * sizeof(Datum));
 					MemSet(partNulls, true, attr_count * sizeof(bool));
 
 					reconstructTupleValues(map, baseValues, baseNulls, (int) num_phys_attrs,
 										   partValues, partNulls, (int) attr_count);
-
-					values = partValues;
-					nulls = partNulls;
+					ExecStoreVirtualTuple(slot);
 				}
 				else
 				{
-					values = baseValues;
-					nulls = baseNulls;
+					slot = baseSlot;
 				}
 
 				if (is_check_distkey && distData->p_nattrs > 0)
 				{
-					target_seg = GetTargetSeg(distData, values, nulls);
+					target_seg = GetTargetSeg(distData, slot_get_values(slot), slot_get_isnull(slot));
 					/*check distribution key if COPY FROM ON SEGMENT*/
 					if (GpIdentity.segindex != target_seg)
 						ereport(ERROR,
@@ -4855,31 +4859,6 @@ PROCESS_SEGMENT_DATA:
 								 errmsg("value of distribution key doesn't belong to segment with ID %d, it belongs to segment with ID %d",
 										GpIdentity.segindex, target_seg)));
 				}
-
-				if (relstorage == RELSTORAGE_AOROWS)
-				{
-					/* form a mem tuple */
-					tuple = (MemTuple)
-						memtuple_form_to(resultRelInfo->ri_aoInsertDesc->mt_bind,
-														values, nulls,
-														NULL, NULL, false);
-
-					if (cstate->oids && file_has_oids)
-						MemTupleSetOid(tuple, resultRelInfo->ri_aoInsertDesc->mt_bind, loaded_oid);
-				}
-				else if (relstorage == RELSTORAGE_AOCOLS)
-				{
-                    tuple = NULL;
-				}
-				else
-				{
-					/* form a regular heap tuple */
-					tuple = (HeapTuple) heap_form_tuple(resultRelInfo->ri_RelationDesc->rd_att, values, nulls);
-
-					if (cstate->oids && file_has_oids)
-						HeapTupleSetOid((HeapTuple)tuple, loaded_oid);
-				}
-
 
 				/*
 				 * Triggers and stuff need to be invoked in query context.
@@ -4897,12 +4876,9 @@ PROCESS_SEGMENT_DATA:
 					resultRelInfo->ri_TrigDesc->n_before_row[TRIGGER_EVENT_INSERT] > 0)
 				{
 					HeapTuple	newtuple;
+					HeapTuple	tuple;
 
-					if(relstorage == RELSTORAGE_AOCOLS)
-					{
-						Assert(!tuple);
-						elog(ERROR, "triggers are not supported on tables that use column-oriented storage");
-					}
+					tuple = ExecFetchSlotHeapTuple(slot);
 
 					Assert(resultRelInfo->ri_TrigFunctions != NULL);
 					newtuple = ExecBRInsertTriggers(estate, resultRelInfo, tuple);
@@ -4911,44 +4887,20 @@ PROCESS_SEGMENT_DATA:
 						skip_tuple = true;
 					else if (newtuple != tuple) /* modified by Trigger(s) */
 					{
-						heap_freetuple(tuple);
-						tuple = newtuple;
+						ExecStoreHeapTuple(newtuple, slot, InvalidBuffer, true);
 					}
 				}
 
 				if (!skip_tuple)
 				{
 					char relstorage = RelinfoGetStorage(resultRelInfo);
-					
-					if (resultRelInfo->ri_partSlot != NULL)
-					{
-						Assert(resultRelInfo->ri_partInsertMap != NULL);
-						slot = resultRelInfo->ri_partSlot;
-					}
-					else
-					{
-						slot = baseSlot;
-					}
-
-					if (relstorage != RELSTORAGE_AOCOLS)
-					{
-						/* Place tuple in tuple slot */
-						ExecStoreGenericTuple(tuple, slot, false);
-					}
-
-					else
-					{
-						ExecClearTuple(slot);
-						slot->PRIVATE_tts_values = values;
-						slot->PRIVATE_tts_isnull = nulls;
-						ExecStoreVirtualTuple(slot);
-					}
+					ItemPointerData insertedTid;
 
 					/*
 					 * Check the constraints of the tuple
 					 */
 					if (resultRelInfo->ri_RelationDesc->rd_att->constr)
-							ExecConstraints(resultRelInfo, slot, estate);
+						ExecConstraints(resultRelInfo, slot, estate);
 
 					/*
 					 * OK, store the tuple and create index entries for it
@@ -4956,37 +4908,47 @@ PROCESS_SEGMENT_DATA:
 					if (relstorage == RELSTORAGE_AOROWS)
 					{
 						Oid			tupleOid;
-						AOTupleId	aoTupleId;
-						
+						MemTuple	mtuple;
+
+						mtuple = ExecFetchSlotMemTuple(slot, false);
+
 						/* inserting into an append only relation */
-						appendonly_insert(resultRelInfo->ri_aoInsertDesc, tuple, &tupleOid, &aoTupleId);
-						
-						if (resultRelInfo->ri_NumIndices > 0)
-							ExecInsertIndexTuples(slot, (ItemPointer)&aoTupleId, estate, false);
+						appendonly_insert(resultRelInfo->ri_aoInsertDesc, mtuple, &tupleOid, (AOTupleId *) &insertedTid);
 					}
 					else if (relstorage == RELSTORAGE_AOCOLS)
 					{
-						AOTupleId aoTupleId;
-						
-                        aocs_insert_values(resultRelInfo->ri_aocsInsertDesc, values, nulls, &aoTupleId);
-						if (resultRelInfo->ri_NumIndices > 0)
-							ExecInsertIndexTuples(slot, (ItemPointer)&aoTupleId, estate, false);
+                        aocs_insert(resultRelInfo->ri_aocsInsertDesc, slot);
+						insertedTid = *slot_get_ctid(slot);
 					}
 					else if (relstorage == RELSTORAGE_EXTERNAL)
 					{
+						HeapTuple tuple;
+
+						tuple = ExecFetchSlotHeapTuple(slot);
 						external_insert(resultRelInfo->ri_extInsertDesc, tuple);
+						ItemPointerSetInvalid(&insertedTid);
 					}
 					else
 					{
-						heap_insert(resultRelInfo->ri_RelationDesc, tuple, mycid, use_wal, use_fsm, GetCurrentTransactionId());
+						HeapTuple tuple;
 
-						if (resultRelInfo->ri_NumIndices > 0)
-							ExecInsertIndexTuples(slot, &(((HeapTuple)tuple)->t_self), estate, false);
+						tuple = ExecFetchSlotHeapTuple(slot);
+						heap_insert(resultRelInfo->ri_RelationDesc, tuple, mycid, use_wal, use_fsm, GetCurrentTransactionId());
+						insertedTid = tuple->t_self;
 					}
 
+					if (resultRelInfo->ri_NumIndices > 0)
+						ExecInsertIndexTuples(slot, &insertedTid, estate, false);
 
 					/* AFTER ROW INSERT Triggers */
-					ExecARInsertTriggers(estate, resultRelInfo, tuple);
+					if (resultRelInfo->ri_TrigDesc &&
+						resultRelInfo->ri_TrigDesc->n_after_row[TRIGGER_EVENT_INSERT] > 0)
+					{
+						HeapTuple tuple;
+
+						tuple = ExecFetchSlotHeapTuple(slot);
+						ExecARInsertTriggers(estate, resultRelInfo, tuple);
+					}
 
 					/*
 					 * We count only tuples not suppressed by a BEFORE INSERT trigger;

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -215,6 +215,21 @@ CreateTrigger(CreateTrigStmt *stmt, Oid constraintOid)
 							NameListToString(stmt->funcname))));
 	}
 
+	/* Check GPDB limitations */
+	if ((RelationIsAoRows(rel) || RelationIsAoCols(rel)) &&
+		TRIGGER_FOR_ROW(tgtype) &&
+		!stmt->isconstraint)
+	{
+		if (TRIGGER_FOR_UPDATE(tgtype))
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("ON UPDATE triggers are not supported on append-only tables")));
+		if (TRIGGER_FOR_DELETE(tgtype))
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("ON DELETE triggers are not supported on append-only tables")));
+	}
+
 	/*
 	 * If the command is a user-entered CREATE CONSTRAINT TRIGGER command that
 	 * references one of the built-in RI_FKey trigger functions, assume it is
@@ -2159,6 +2174,14 @@ GetTupleForTrigger(EState *estate, ResultRelInfo *relinfo,
 	HeapTupleData tuple;
 	HeapTuple	result;
 	Buffer		buffer;
+
+	/* these should be rejected when you try to create such triggers, but let's check */
+	if (RelationIsAoRows(relation) || RelationIsAoCols(relation))
+		elog(ERROR, "UPDATE and DELETE triggers are not supported on append-only tables");
+	if (RelationIsExternal(relation))
+		elog(ERROR, "UPDATE and DELETE triggers are not supported on external tables");
+
+	Assert(RelationIsHeap(relation));
 
 	if (newSlot != NULL)
 	{

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -4482,7 +4482,7 @@ move_chain_tuple(Relation rel,
 	/* Create index entries for the moved tuple */
 	if (ec->resultRelInfo->ri_NumIndices > 0)
 	{
-		ExecStoreGenericTuple(&newtup, ec->slot, false);
+		ExecStoreHeapTuple(&newtup, ec->slot, InvalidBuffer, false);
 		ExecInsertIndexTuples(ec->slot, &(newtup.t_self), ec->estate, true);
 		ResetPerTupleExprContext(ec->estate);
 	}
@@ -4589,7 +4589,7 @@ move_plain_tuple(Relation rel,
 	/* insert index' tuples if needed */
 	if (ec->resultRelInfo->ri_NumIndices > 0)
 	{
-		ExecStoreGenericTuple(&newtup, ec->slot, false);
+		ExecStoreHeapTuple(&newtup, ec->slot, InvalidBuffer, false);
 		ExecInsertIndexTuples(ec->slot, &(newtup.t_self), ec->estate, true);
 		ResetPerTupleExprContext(ec->estate);
 	}

--- a/src/backend/executor/execBitmapTableScan.c
+++ b/src/backend/executor/execBitmapTableScan.c
@@ -119,7 +119,7 @@ BitmapTableScanPlanQualTuple(BitmapTableScanState *node)
 			return ExecClearTuple(slot);
 		}
 
-		ExecStoreGenericTuple(estate->es_evTuple[scanrelid - 1], slot, false);
+		ExecStoreHeapTuple(estate->es_evTuple[scanrelid - 1], slot, InvalidBuffer, false);
 
 		/* Does the tuple meet the original qual conditions? */
 		econtext->ecxt_scantuple = slot;

--- a/src/backend/executor/execHeapScan.c
+++ b/src/backend/executor/execHeapScan.c
@@ -75,7 +75,7 @@ HeapScanNext(ScanState *scanState)
 			return ExecClearTuple(slot);
 		}
 
-		ExecStoreGenericTuple(estate->es_evTuple[scanrelid - 1], slot, false);
+		ExecStoreHeapTuple(estate->es_evTuple[scanrelid - 1], slot, InvalidBuffer, false);
 
 		/*
 		 * Note that unlike IndexScan, SeqScan never uses keys in

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -3073,18 +3073,15 @@ ExecInsert(TupleTableSlot *slot,
 		   PlanGenerator planGen,
 		   bool isUpdate)
 {
-	void	   *tuple;
 	ResultRelInfo *resultRelInfo;
 	Relation	resultRelationDesc;
 	Oid			newId;
-	TupleTableSlot *partslot = NULL;
-
-	AOTupleId	aoTupleId = AOTUPLEID_INIT;
 
 	bool		rel_is_heap = false;
 	bool 		rel_is_aorows = false;
 	bool		rel_is_aocols = false;
 	bool		rel_is_external = false;
+	ItemPointerData lastTid;
 
 	/*
 	 * get information on the (current) result relation
@@ -3149,53 +3146,33 @@ ExecInsert(TupleTableSlot *slot,
 	rel_is_aorows = RelationIsAoRows(resultRelationDesc);
 	rel_is_external = RelationIsExternal(resultRelationDesc);
 
-	partslot = reconstructMatchingTupleSlot(slot, resultRelInfo);
-	if (rel_is_heap)
+	slot = reconstructMatchingTupleSlot(slot, resultRelInfo);
+
+	if (rel_is_external &&
+		estate->es_result_partitions &&
+		estate->es_result_partitions->part->parrelid != 0)
 	{
-		tuple = ExecFetchSlotHeapTuple(partslot);
-	}
-	else if (rel_is_aorows)
-	{
-		tuple = ExecFetchSlotMemTuple(partslot, false);
-	}
-	else if (rel_is_external) 
-	{
-		if (estate->es_result_partitions && 
-			estate->es_result_partitions->part->parrelid != 0)
-		{
-			ereport(ERROR,
+		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				errmsg("Insert into external partitions not supported.")));			
-			return;
-		}
-		else
-		{
-			tuple = ExecFetchSlotHeapTuple(partslot);
-		}
-	}
-	else
-	{
-		Assert(rel_is_aocols);
-		tuple = ExecFetchSlotMemTuple(partslot, true);
+				 errmsg("Insert into external partitions not supported.")));
 	}
 
-	Assert(partslot != NULL && tuple != NULL);
+	Assert(slot != NULL);
 
 	/* BEFORE ROW INSERT Triggers */
 	if (resultRelInfo->ri_TrigDesc &&
 		resultRelInfo->ri_TrigDesc->n_before_row[TRIGGER_EVENT_INSERT] > 0)
 	{
 		HeapTuple	newtuple;
+		HeapTuple	tuple;
+
+		tuple = ExecFetchSlotHeapTuple(slot);
 
 		/*
 		 * Not implemented for ORCA yet. It should fall back to the Postgres planner
 		 * if there are any before-row triggers.
 		 */
 		Assert(planGen == PLANGEN_PLANNER);
-
-		/* NYI */
-		if (rel_is_aocols)
-			elog(ERROR, "triggers are not supported on tables that use column-oriented storage");
 
 		newtuple = ExecBRInsertTriggers(estate, resultRelInfo, tuple);
 
@@ -3212,22 +3189,21 @@ ExecInsert(TupleTableSlot *slot,
 			 */
 			TupleTableSlot *newslot = estate->es_trig_tuple_slot;
 
-			if (newslot->tts_tupleDescriptor != partslot->tts_tupleDescriptor)
-				ExecSetSlotDescriptor(newslot, partslot->tts_tupleDescriptor);
+			if (newslot->tts_tupleDescriptor != slot->tts_tupleDescriptor)
+				ExecSetSlotDescriptor(newslot, slot->tts_tupleDescriptor);
 			ExecStoreHeapTuple(newtuple, newslot, InvalidBuffer, false);
-			newslot->tts_tableOid = partslot->tts_tableOid; /* for constraints */
+			newslot->tts_tableOid = slot->tts_tableOid; /* for constraints */
+			slot = newslot;
 			tuple = newtuple;
-			partslot = newslot;
 		}
 	}
+
 	/*
 	 * Check the constraints of the tuple
 	 */
-	if (resultRelationDesc->rd_att->constr &&
-			planGen == PLANGEN_PLANNER)
-	{
-		ExecConstraints(resultRelInfo, partslot, estate);
-	}
+	if (resultRelationDesc->rd_att->constr)
+		ExecConstraints(resultRelInfo, slot, estate);
+
 	/*
 	 * insert the tuple
 	 *
@@ -3238,6 +3214,8 @@ ExecInsert(TupleTableSlot *slot,
 	 */
 	if (rel_is_aorows)
 	{
+		MemTuple	mtuple;
+
 		if (resultRelInfo->ri_aoInsertDesc == NULL)
 		{
 			/* Set the pre-assigned fileseg number to insert into */
@@ -3250,7 +3228,8 @@ ExecInsert(TupleTableSlot *slot,
 
 		}
 
-		appendonly_insert(resultRelInfo->ri_aoInsertDesc, tuple, &newId, &aoTupleId);
+		mtuple = ExecFetchSlotMemTuple(slot, false);
+		appendonly_insert(resultRelInfo->ri_aoInsertDesc, mtuple, &newId, (AOTupleId *) &lastTid);
 	}
 	else if (rel_is_aocols)
 	{
@@ -3261,60 +3240,59 @@ ExecInsert(TupleTableSlot *slot,
 																resultRelInfo->ri_aosegno, false);
 		}
 
-		newId = aocs_insert(resultRelInfo->ri_aocsInsertDesc, partslot);
-		aoTupleId = *((AOTupleId*)slot_get_ctid(partslot));
+		newId = aocs_insert(resultRelInfo->ri_aocsInsertDesc, slot);
+		lastTid = *slot_get_ctid(slot);
 	}
 	else if (rel_is_external)
 	{
 		/* Writable external table */
+		HeapTuple tuple;
+
 		if (resultRelInfo->ri_extInsertDesc == NULL)
 			resultRelInfo->ri_extInsertDesc = external_insert_init(resultRelationDesc);
 
+		tuple = ExecFetchSlotHeapTuple(slot);
+
 		newId = external_insert(resultRelInfo->ri_extInsertDesc, tuple);
+		ItemPointerSetInvalid(&lastTid);
 	}
 	else
 	{
+		HeapTuple tuple;
+
 		Insist(rel_is_heap);
+
+		tuple = ExecFetchSlotHeapTuple(slot);
 
 		newId = heap_insert(resultRelationDesc,
 							tuple,
 							estate->es_output_cid,
 							true, true, GetCurrentTransactionId());
+		lastTid = tuple->t_self;
 	}
 
 	(estate->es_processed)++;
 	(resultRelInfo->ri_aoprocessed)++;
 	estate->es_lastoid = newId;
+	setLastTid(&lastTid);
 
-	partslot->tts_tableOid = RelationGetRelid(resultRelationDesc);
+	slot->tts_tableOid = RelationGetRelid(resultRelationDesc);
 
-	if (rel_is_aorows || rel_is_aocols)
+	/*
+	 * insert index entries for tuple
+	 */
+	if (resultRelInfo->ri_NumIndices > 0)
+		ExecInsertIndexTuples(slot, &lastTid, estate, false);
+
+	/* AFTER ROW INSERT Triggers */
+	if (resultRelInfo->ri_TrigDesc &&
+		resultRelInfo->ri_TrigDesc->n_after_row[TRIGGER_EVENT_INSERT] > 0)
 	{
-		/*
-		 * insert index entries for AO Row-Store tuple
-		 */
-		if (resultRelInfo->ri_NumIndices > 0)
-			ExecInsertIndexTuples(partslot, (ItemPointer)&aoTupleId, estate, false);
-	}
-	else
-	{
-		/* Use parttuple for index update in case this is an indexed heap table. */
-		TupleTableSlot *xslot = partslot;
-		void *xtuple = tuple;
+		HeapTuple tuple = ExecFetchSlotHeapTuple(slot);
 
-		setLastTid(&(((HeapTuple) xtuple)->t_self));
+		Assert(planGen == PLANGEN_PLANNER);
 
-		/*
-		 * insert index entries for tuple
-		 */
-		if (resultRelInfo->ri_NumIndices > 0)
-			ExecInsertIndexTuples(xslot, &(((HeapTuple) xtuple)->t_self), estate, false);
-
-		if (planGen == PLANGEN_PLANNER)
-		{
-			/* AFTER ROW INSERT Triggers */
-			ExecARInsertTriggers(estate, resultRelInfo, tuple);
-		}
+		ExecARInsertTriggers(estate, resultRelInfo, tuple);
 	}
 }
 
@@ -3470,7 +3448,7 @@ ldelete:;
 	{
 		case HeapTupleSelfUpdated:
 			/* already deleted by self; nothing to do */
-		
+
 			/*
 			 * In an scenario in which R(a,b) and S(a,b) have 
 			 *        R               S
@@ -3547,7 +3525,6 @@ ldelete:;
 	 * take care of it later.  We can't delete index tuples immediately
 	 * anyway, since the tuple is still visible to other transactions.
 	 */
-
 
 	if (!(isAORowsTable || isAOColsTable) && planGen == PLANGEN_PLANNER)
 	{
@@ -3752,14 +3729,13 @@ ExecUpdate(TupleTableSlot *slot,
 		   DestReceiver *dest,
 		   EState *estate)
 {
-	void*	tuple;
 	ResultRelInfo *resultRelInfo;
 	Relation	resultRelationDesc;
 	HTSU_Result result;
 	ItemPointerData update_ctid;
 	TransactionId update_xmax = InvalidTransactionId;
-	AOTupleId	aoTupleId = AOTUPLEID_INIT;
-	TupleTableSlot *partslot = NULL;
+	ItemPointerData lastTid;
+	bool		wasHotUpdate;
 
 	/*
 	 * abort the operation if not running transactions
@@ -3778,16 +3754,22 @@ ExecUpdate(TupleTableSlot *slot,
 	bool		rel_is_aocols = RelationIsAoCols(resultRelationDesc);
 	bool		rel_is_external = RelationIsExternal(resultRelationDesc);
 
+	if (rel_is_external &&
+		estate->es_result_partitions &&
+		estate->es_result_partitions->part->parrelid != 0)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("Update external partitions not supported.")));
+	}
+
 	/*
 	 * get the heap tuple out of the tuple table slot, making sure we have a
 	 * writable copy
 	 */
-	if (rel_is_heap)
-	{
-		partslot = slot;
-		tuple = ExecFetchSlotHeapTuple(partslot);
-	}
-	else if (rel_is_aorows || rel_is_aocols)
+
+
+	if (rel_is_aorows || rel_is_aocols)
 	{
 		/*
 		 * It is necessary to reconstruct a logically compatible tuple to
@@ -3796,38 +3778,12 @@ ExecUpdate(TupleTableSlot *slot,
 		 * columns, and MemTuple cannot deal with cases without converting
 		 * the target list back into the original relation's tuple desc.
 		 */
-		partslot = reconstructMatchingTupleSlot(slot, resultRelInfo);
-
-		/*
-		 * We directly inline toasted columns here as update with toasted columns
-		 * would create two references to the same toasted value.
-		 */
-		tuple = ExecFetchSlotMemTuple(partslot, true);
-	}
-	else if (rel_is_external) 
-	{
-		if (estate->es_result_partitions && 
-			estate->es_result_partitions->part->parrelid != 0)
-		{
-			ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				errmsg("Update external partitions not supported.")));			
-			return;
-		}
-		else
-		{
-			partslot = slot;
-			tuple = ExecFetchSlotHeapTuple(partslot);
-		}
-	}
-	else 
-	{
-		Insist(false);
+		slot = reconstructMatchingTupleSlot(slot, resultRelInfo);
 	}
 
 	/* see if this update would move the tuple to a different partition */
 	if (estate->es_result_partitions)
-		checkPartitionUpdate(estate, partslot, resultRelInfo);
+		checkPartitionUpdate(estate, slot, resultRelInfo);
 
 	/* BEFORE ROW UPDATE Triggers */
 	if (resultRelInfo->ri_TrigDesc &&
@@ -3838,9 +3794,6 @@ ExecUpdate(TupleTableSlot *slot,
 
 		if (slot == NULL)		/* "do nothing" */
 			return;
-
-		/* trigger might have changed tuple */
-		tuple = ExecFetchSlotHeapTuple(slot);
 	}
 
 	/*
@@ -3854,7 +3807,7 @@ ExecUpdate(TupleTableSlot *slot,
 	 */
 lreplace:;
 	if (resultRelationDesc->rd_att->constr)
-		ExecConstraints(resultRelInfo, partslot, estate);
+		ExecConstraints(resultRelInfo, slot, estate);
 
 	if (!GpPersistent_IsPersistentRelation(resultRelationDesc->rd_id))
 	{
@@ -3872,19 +3825,27 @@ lreplace:;
 		 */
 		if (rel_is_heap)
 		{
+			HeapTuple tuple;
+
+			tuple = ExecFetchSlotHeapTuple(slot);
+
 			result = heap_update(resultRelationDesc, tupleid, tuple,
 							 &update_ctid, &update_xmax,
 							 estate->es_output_cid,
 							 estate->es_crosscheck_snapshot,
 							 true /* wait for commit */ );
-		} 
+			lastTid = tuple->t_self;
+			wasHotUpdate = HeapTupleIsHeapOnly(tuple) != 0;
+		}
 		else if (rel_is_aorows)
 		{
+			MemTuple mtuple;
+
 			if (IsXactIsoLevelSerializable)
 			{
 				ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					errmsg("Updates on append-only tables are not supported in serializable transactions.")));			
+					errmsg("Updates on append-only tables are not supported in serializable transactions.")));
 			}
 
 			if (resultRelInfo->ri_updateDesc == NULL)
@@ -3893,8 +3854,13 @@ lreplace:;
 				resultRelInfo->ri_updateDesc = (AppendOnlyUpdateDesc)
 					appendonly_update_init(resultRelationDesc, ActiveSnapshot, resultRelInfo->ri_aosegno);
 			}
+
+			/* appendonly_update() requires that there are no toasted values */
+			mtuple = ExecFetchSlotMemTuple(slot, true);
+
 			result = appendonly_update(resultRelInfo->ri_updateDesc,
-								 tuple, (AOTupleId *) tupleid, &aoTupleId);
+									   mtuple, (AOTupleId *) tupleid, (AOTupleId *) &lastTid);
+			wasHotUpdate = false;
 		}
 		else if (rel_is_aocols)
 		{
@@ -3902,7 +3868,7 @@ lreplace:;
 			{
 				ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					errmsg("Updates on append-only tables are not supported in serializable transactions.")));			
+					errmsg("Updates on append-only tables are not supported in serializable transactions.")));
 			}
 
 			if (resultRelInfo->ri_updateDesc == NULL)
@@ -3912,12 +3878,14 @@ lreplace:;
 					aocs_update_init(resultRelationDesc, resultRelInfo->ri_aosegno);
 			}
 			result = aocs_update(resultRelInfo->ri_updateDesc,
-								 partslot, (AOTupleId *) tupleid, &aoTupleId);
+								 slot, (AOTupleId *) tupleid, (AOTupleId *) &lastTid);
+			wasHotUpdate = false;
 		}
 		else
 		{
-			Assert(!"We should not be here");
+			elog(ERROR, "invalid relation type");
 		}
+
 		switch (result)
 		{
 			case HeapTupleSelfUpdated:
@@ -3945,8 +3913,7 @@ lreplace:;
 					if (!TupIsNull(epqslot))
 					{
 						*tupleid = update_ctid;
-						partslot = ExecFilterJunk(estate->es_junkFilter, epqslot);
-						tuple = ExecFetchSlotHeapTuple(partslot);
+						slot = ExecFilterJunk(estate->es_junkFilter, epqslot);
 						goto lreplace;
 					}
 				}
@@ -3965,10 +3932,11 @@ lreplace:;
 		/*
 		 * Persistent metadata path.
 		 */
-		persistentTuple = heap_copytuple(tuple);
+		persistentTuple = ExecCopySlotHeapTuple(slot);
 		persistentTuple->t_self = *tupleid;
 
 		frozen_heap_inplace_update(resultRelationDesc, persistentTuple);
+		wasHotUpdate = false;
 
 		heap_freetuple(persistentTuple);
 	}
@@ -3992,17 +3960,16 @@ lreplace:;
 	 *
 	 * If it's a HOT update, we mustn't insert new index entries.
 	 */
-	if (rel_is_aorows || rel_is_aocols)
-	{
-		if (resultRelInfo->ri_NumIndices > 0)
-			ExecInsertIndexTuples(partslot, (ItemPointer)&aoTupleId, estate, false);
-	}
-	else
-	{
-		if (resultRelInfo->ri_NumIndices > 0 && !HeapTupleIsHeapOnly((HeapTuple) tuple))
-			ExecInsertIndexTuples(partslot, &(((HeapTuple) tuple)->t_self), estate, false);
+	if (resultRelInfo->ri_NumIndices > 0 && !wasHotUpdate)
+		ExecInsertIndexTuples(slot, &lastTid, estate, false);
 
-		/* AFTER ROW UPDATE Triggers */
+	/* AFTER ROW UPDATE Triggers */
+	if (resultRelInfo->ri_TrigDesc &&
+		resultRelInfo->ri_TrigDesc->n_after_row[TRIGGER_EVENT_UPDATE] > 0 &&
+		rel_is_heap)
+	{
+		HeapTuple tuple = ExecFetchSlotHeapTuple(slot);
+
 		ExecARUpdateTriggers(estate, resultRelInfo, tupleid, tuple);
 	}
 }

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -3855,8 +3855,7 @@ lreplace:;
 					appendonly_update_init(resultRelationDesc, ActiveSnapshot, resultRelInfo->ri_aosegno);
 			}
 
-			/* appendonly_update() requires that there are no toasted values */
-			mtuple = ExecFetchSlotMemTuple(slot, true);
+			mtuple = ExecFetchSlotMemTuple(slot, false);
 
 			result = appendonly_update(resultRelInfo->ri_updateDesc,
 									   mtuple, (AOTupleId *) tupleid, (AOTupleId *) &lastTid);

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -3213,7 +3213,7 @@ ExecInsert(TupleTableSlot *slot,
 
 				if (newslot->tts_tupleDescriptor != partslot->tts_tupleDescriptor)
 					ExecSetSlotDescriptor(newslot, partslot->tts_tupleDescriptor);
-				ExecStoreGenericTuple(newtuple, newslot, false);
+				ExecStoreHeapTuple(newtuple, newslot, InvalidBuffer, false);
 				newslot->tts_tableOid = partslot->tts_tableOid; /* for constraints */
 				tuple = newtuple;
 				partslot = newslot;

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -3181,43 +3181,43 @@ ExecInsert(TupleTableSlot *slot,
 
 	Assert(partslot != NULL && tuple != NULL);
 
-	/* Execute triggers in Planner-generated plans */
-	if (planGen == PLANGEN_PLANNER)
+	/* BEFORE ROW INSERT Triggers */
+	if (resultRelInfo->ri_TrigDesc &&
+		resultRelInfo->ri_TrigDesc->n_before_row[TRIGGER_EVENT_INSERT] > 0)
 	{
-		/* BEFORE ROW INSERT Triggers */
-		if (resultRelInfo->ri_TrigDesc &&
-			resultRelInfo->ri_TrigDesc->n_before_row[TRIGGER_EVENT_INSERT] > 0)
+		HeapTuple	newtuple;
+
+		/*
+		 * Not implemented for ORCA yet. It should fall back to the Postgres planner
+		 * if there are any before-row triggers.
+		 */
+		Assert(planGen == PLANGEN_PLANNER);
+
+		/* NYI */
+		if (rel_is_aocols)
+			elog(ERROR, "triggers are not supported on tables that use column-oriented storage");
+
+		newtuple = ExecBRInsertTriggers(estate, resultRelInfo, tuple);
+
+		if (newtuple == NULL)	/* "do nothing" */
+			return;
+
+		if (newtuple != tuple)	/* modified by Trigger(s) */
 		{
-			HeapTuple	newtuple;
+			/*
+			 * Put the modified tuple into a slot for convenience of routines
+			 * below.  We assume the tuple was allocated in per-tuple memory
+			 * context, and therefore will go away by itself. The tuple table
+			 * slot should not try to clear it.
+			 */
+			TupleTableSlot *newslot = estate->es_trig_tuple_slot;
 
-			/* NYI */
-			if(rel_is_aocols)
-				elog(ERROR, "triggers are not supported on tables that use column-oriented storage");
-
-			newtuple = ExecBRInsertTriggers(estate, resultRelInfo, tuple);
-
-			if (newtuple == NULL)	/* "do nothing" */
-			{
-				return;
-			}
-
-			if (newtuple != tuple)	/* modified by Trigger(s) */
-			{
-				/*
-				 * Put the modified tuple into a slot for convenience of routines
-				 * below.  We assume the tuple was allocated in per-tuple memory
-				 * context, and therefore will go away by itself. The tuple table
-				 * slot should not try to clear it.
-				 */
-				TupleTableSlot *newslot = estate->es_trig_tuple_slot;
-
-				if (newslot->tts_tupleDescriptor != partslot->tts_tupleDescriptor)
-					ExecSetSlotDescriptor(newslot, partslot->tts_tupleDescriptor);
-				ExecStoreHeapTuple(newtuple, newslot, InvalidBuffer, false);
-				newslot->tts_tableOid = partslot->tts_tableOid; /* for constraints */
-				tuple = newtuple;
-				partslot = newslot;
-			}
+			if (newslot->tts_tupleDescriptor != partslot->tts_tupleDescriptor)
+				ExecSetSlotDescriptor(newslot, partslot->tts_tupleDescriptor);
+			ExecStoreHeapTuple(newtuple, newslot, InvalidBuffer, false);
+			newslot->tts_tableOid = partslot->tts_tableOid; /* for constraints */
+			tuple = newtuple;
+			partslot = newslot;
 		}
 	}
 	/*

--- a/src/backend/executor/nodeBitmapAppendOnlyscan.c
+++ b/src/backend/executor/nodeBitmapAppendOnlyscan.c
@@ -266,8 +266,8 @@ BitmapAppendOnlyScanNext(BitmapAppendOnlyScanState *node)
 			return ExecClearTuple(slot);
 		}
 
-		ExecStoreGenericTuple(estate->es_evTuple[scanrelid - 1],
-					   slot, false);
+		ExecStoreHeapTuple(estate->es_evTuple[scanrelid - 1],
+						   slot, InvalidBuffer, false);
 
 		/* Does the tuple meet the original qual conditions? */
 		econtext->ecxt_scantuple = slot;

--- a/src/backend/executor/nodeBitmapHeapscan.c
+++ b/src/backend/executor/nodeBitmapHeapscan.c
@@ -165,8 +165,8 @@ BitmapHeapNext(BitmapHeapScanState *node)
 		}
 		
 
-		ExecStoreGenericTuple(estate->es_evTuple[scanrelid - 1],
-					   slot, false);
+		ExecStoreHeapTuple(estate->es_evTuple[scanrelid - 1],
+						   slot, InvalidBuffer, false);
 
 		/* Does the tuple meet the original qual conditions? */
 		econtext->ecxt_scantuple = slot;

--- a/src/backend/executor/nodeExternalscan.c
+++ b/src/backend/executor/nodeExternalscan.c
@@ -141,7 +141,7 @@ ExternalNext(ExternalScanState *node)
 		 */
 		if (tuple)
 		{
-			ExecStoreGenericTuple(tuple, slot, true);
+			ExecStoreHeapTuple(tuple, slot, InvalidBuffer, true);
 			if (node->ess_ScanDesc->fs_hasConstraints && !ExternalConstraintCheck(slot, node))
 			{
 				ExecClearTuple(slot);

--- a/src/backend/executor/nodeIndexscan.c
+++ b/src/backend/executor/nodeIndexscan.c
@@ -131,7 +131,7 @@ IndexNext(IndexScanState *node)
 			return ExecClearTuple(slot);
 		}
 
-		ExecStoreGenericTuple(estate->es_evTuple[scanrelid - 1], slot, false);
+		ExecStoreHeapTuple(estate->es_evTuple[scanrelid - 1], slot, InvalidBuffer, false);
 
 		/* Does the tuple meet the indexqual condition? */
 		econtext->ecxt_scantuple = slot;

--- a/src/backend/executor/nodeRowTrigger.c
+++ b/src/backend/executor/nodeRowTrigger.c
@@ -356,7 +356,7 @@ StoreTupleForTrigger(TupleTableSlot *slot, Datum *values, bool *nulls, ListCell 
 void
 ConstructNewTupleTableSlot(HeapTuple newtuple, TupleTableSlot *triggerTuple, ListCell *attr, Datum *values, bool *nulls)
 {
-	ExecStoreGenericTuple(newtuple , triggerTuple, true);
+	ExecStoreHeapTuple(newtuple , triggerTuple, InvalidBuffer, true);
 	slot_getallattrs(triggerTuple);
 
 	Datum *new_values = slot_get_values(triggerTuple);

--- a/src/backend/executor/nodeTidscan.c
+++ b/src/backend/executor/nodeTidscan.c
@@ -293,7 +293,7 @@ TidNext(TidScanState *node)
 		 * CURRENT OF case it might not match anyway ...
 		 */
 
-		ExecStoreGenericTuple(estate->es_evTuple[scanrelid - 1], slot, false);
+		ExecStoreHeapTuple(estate->es_evTuple[scanrelid - 1], slot, InvalidBuffer, false);
 
 		/* Flag for the next call that no more tuples */
 		estate->es_evTupleNull[scanrelid - 1] = true;

--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -796,7 +796,7 @@ tuplestore_puttuple_common(Tuplestorestate *state, void *tuple)
  * Backward scan is only allowed if randomAccess was set true or
  * EXEC_FLAG_BACKWARD was specified to tuplestore_set_eflags().
  */
-static GenericTuple *
+static GenericTuple
 tuplestore_gettuple(Tuplestorestate *state, bool forward,
 					bool *should_free)
 {
@@ -968,7 +968,7 @@ tuplestore_gettuple(Tuplestorestate *state, bool forward,
 }
 
 /*
- * tuplestore_gettupleslot - exported function to fetch a MemTuple
+ * tuplestore_gettupleslot - exported function to fetch a tuple into a slot
  *
  * If successful, put tuple in slot and return TRUE; else, clear the slot
  * and return FALSE.
@@ -987,7 +987,7 @@ tuplestore_gettupleslot(Tuplestorestate *state, bool forward,
 	GenericTuple tuple;
 	bool		should_free;
 
-	tuple = (GenericTuple) tuplestore_gettuple(state, forward, &should_free);
+	tuple = tuplestore_gettuple(state, forward, &should_free);
 
 	if (tuple)
 	{

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -56,7 +56,9 @@
 int			optreset;
 #endif
 
-#include "access/htup.h"
+#include "access/attnum.h"
+#include "access/sysattr.h"
+#include "catalog/pg_magic_oid.h"
 #include "catalog/pg_class.h"
 #include "catalog/pg_proc.h"
 #include "catalog/pg_trigger.h"

--- a/src/include/access/htup.h
+++ b/src/include/access/htup.h
@@ -22,6 +22,8 @@
 #include "storage/relfilenode.h"
 #include "access/sysattr.h"
 
+#include "access/memtup.h"
+
 /*
  * MaxTupleAttributeNumber limits the number of (user) columns in a tuple.
  * The key limit on this value is that the size of the fixed overhead for
@@ -511,14 +513,24 @@ typedef HeapTupleData *HeapTuple;
 
 #define HEAPTUPLESIZE	MAXALIGN(sizeof(HeapTupleData))
 
+/*
+ * GenericTuple is a pointer that can point to either a HeapTuple or a
+ * MemTuple. Use is_memtuple() to check which one it is.
+ *
+ * GenericTupleData has no definition; this is a fake "supertype".
+ */
+struct GenericTupleData;
+typedef struct GenericTupleData *GenericTuple;
+
 /* XXX Hack Hack Hack 
  * heaptuple, or memtuple, cannot be more than 2G, so, if
  * the first bit is ever set, it is really a memtuple
  */
-static inline bool is_heaptuple_memtuple(HeapTuple htup)
+static inline bool is_memtuple(GenericTuple tup)
 {
-	return ((htup->t_len & 0x80000000) != 0);
+	return ((((HeapTuple) tup)->t_len & 0x80000000) != 0);
 }
+
 static inline bool is_heaptuple_splitter(HeapTuple htup)
 {
 	return ((char *) htup->t_data) != ((char *) htup + HEAPTUPLESIZE);

--- a/src/include/access/tuptoaster.h
+++ b/src/include/access/tuptoaster.h
@@ -106,8 +106,13 @@
  */
 extern HeapTuple toast_insert_or_update(Relation rel,
 					   HeapTuple newtup, HeapTuple oldtup, 
-					   MemTupleBinding *pbind, int toast_tuple_target,
+					   int toast_tuple_target,
 					   bool isFrozen, bool use_wal, bool use_fsm);
+
+extern MemTuple toast_insert_or_update_memtup(Relation rel,
+							  MemTuple newtup, MemTuple oldtup, 
+							  MemTupleBinding *pbind, int toast_tuple_target,
+							  bool isFrozen, bool use_wal, bool use_fsm);
 
 /* ----------
  * toast_delete -
@@ -115,7 +120,7 @@ extern HeapTuple toast_insert_or_update(Relation rel,
  *	Called by heap_delete().
  * ----------
  */
-extern void toast_delete(Relation rel, HeapTuple oldtup, MemTupleBinding *pbind);
+extern void toast_delete(Relation rel, GenericTuple oldtup, MemTupleBinding *pbind);
 
 /* ----------
  * heap_tuple_fetch_attr() -

--- a/src/include/cdb/cdbmotion.h
+++ b/src/include/cdb/cdbmotion.h
@@ -105,7 +105,7 @@ extern void CheckAndSendRecordCache(MotionLayerState *mlStates,
 extern SendReturnCode SendTuple(MotionLayerState *mlStates,
 								ChunkTransportState *transportStates,
 								int16 motNodeID,
-								HeapTuple tuple,
+								GenericTuple tuple,
 								int16 targetRoute);
 
 
@@ -134,7 +134,7 @@ SendEndOfStream(MotionLayerState       *mlStates,
 extern ReceiveReturnCode RecvTupleFrom(MotionLayerState *mlStates,
 									   ChunkTransportState *transportStates,
 									   int16 motNodeID,
-									   HeapTuple *tup_i,
+									   GenericTuple *tup_i,
 									   int16 srcRoute);
 
 extern void SendStopMessage(MotionLayerState *mlStates,

--- a/src/include/cdb/htupfifo.h
+++ b/src/include/cdb/htupfifo.h
@@ -26,8 +26,8 @@
 /* An entry in the HeapTuple FIFO.	Entries are formed into queues. */
 typedef struct htf_entry_data
 {
-	/* The HeapTuple itself. */
-	HeapTuple	htup;
+	/* The tuple itself. */
+	GenericTuple tup;
 
 	/* The next entry in the FIFO. */
 	struct htf_entry_data *p_next;
@@ -71,7 +71,7 @@ extern htup_fifo htfifo_create(int max_mem_kb);
 extern void htfifo_init(htup_fifo htf, int max_mem_kb);
 extern void htfifo_destroy(htup_fifo htf);
 
-extern void htfifo_addtuple(htup_fifo htf, HeapTuple htup);
-extern HeapTuple htfifo_gettuple(htup_fifo htf);
+extern void htfifo_addtuple(htup_fifo htf, GenericTuple htup);
+extern GenericTuple htfifo_gettuple(htup_fifo htf);
 
 #endif   /* HTUPFIFO_H */

--- a/src/include/cdb/tupleremap.h
+++ b/src/include/cdb/tupleremap.h
@@ -20,7 +20,7 @@ typedef struct TupleRemapper TupleRemapper;
 
 extern TupleRemapper *CreateTupleRemapper(void);
 extern void DestroyTupleRemapper(TupleRemapper *remapper);
-extern HeapTuple TRCheckAndRemap(TupleRemapper *remapper, TupleDesc tupledesc, HeapTuple tuple);
+extern GenericTuple TRCheckAndRemap(TupleRemapper *remapper, TupleDesc tupledesc, GenericTuple tuple);
 extern void TRHandleTypeLists(TupleRemapper *remapper, List *typelist);
 
 #endif   /* TUPLEREMAP_H */

--- a/src/include/cdb/tupser.h
+++ b/src/include/cdb/tupser.h
@@ -83,10 +83,10 @@ extern void SerializeRecordCacheIntoChunks(SerTupInfo *pSerInfo,
 										   MotionConn *conn);
 
 /* Convert a HeapTuple into chunks ready to send out, in one pass */
-extern void SerializeTupleIntoChunks(HeapTuple tuple, SerTupInfo *pSerInfo, TupleChunkList tcList);
+extern void SerializeTupleIntoChunks(GenericTuple tuple, SerTupInfo *pSerInfo, TupleChunkList tcList);
 
 /* Convert a HeapTuple into chunks directly in a set of transport buffers */
-extern int SerializeTupleDirect(HeapTuple tuple, SerTupInfo *pSerInfo, struct directTransportBuffer *b);
+extern int SerializeTupleDirect(GenericTuple tuple, SerTupInfo *pSerInfo, struct directTransportBuffer *b);
 
 /* Deserialize a HeapTuple's data from a byte-array. */
 extern HeapTuple DeserializeTuple(SerTupInfo * pSerInfo, StringInfo serialTup);
@@ -94,6 +94,6 @@ extern HeapTuple DeserializeTuple(SerTupInfo * pSerInfo, StringInfo serialTup);
 /* Convert a sequence of chunks containing serialized tuple data into a
  * HeapTuple.
  */
-extern HeapTuple CvtChunksToHeapTup(TupleChunkList tclist, SerTupInfo * pSerInfo, TupleRemapper *remapper);
+extern GenericTuple CvtChunksToTup(TupleChunkList tclist, SerTupInfo * pSerInfo, TupleRemapper *remapper);
 
 #endif   /* TUPSER_H */

--- a/src/test/regress/expected/qp_dml_oids.out
+++ b/src/test/regress/expected/qp_dml_oids.out
@@ -1,0 +1,20 @@
+create schema qp_dml_oids;
+set search_path='qp_dml_oids';
+DROP TABLE IF EXISTS dml_ao;
+NOTICE:  table "dml_ao" does not exist, skipping
+CREATE TABLE dml_ao (a int , b int default -1, c text) WITH (appendonly = true, oids = true) DISTRIBUTED BY (a);
+NOTICE:  OIDS=TRUE is not recommended for user-created tables. Use OIDS=FALSE to prevent wrap-around of the OID counter
+INSERT INTO dml_ao VALUES(generate_series(1,2),generate_series(1,2),'r');
+INSERT INTO dml_ao VALUES(NULL,NULL,NULL);
+--
+-- Check that a tuple gets an OID, even if it's toasted (there used to
+-- be a bug, where toasting a tuple cleared its just-assigned OID)
+--
+INSERT INTO dml_ao (a, b, c) VALUES (10, 1, repeat('x', 50000));
+INSERT INTO dml_ao (a, b, c) VALUES (10, 2, repeat('x', 50000));
+SELECT COUNT(distinct oid) FROM dml_ao where a = 10;
+ count 
+-------
+     2
+(1 row)
+

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -113,7 +113,7 @@ test: tuple_serialization
 # temp tables
 test: bfv_cte bfv_joins bfv_subquery bfv_planner bfv_legacy bfv_temp bfv_dml
 
-test: qp_olap_mdqa qp_misc
+test: qp_olap_mdqa qp_misc qp_dml_oids
 
 test: qp_misc_jiras qp_with_clause qp_executor qp_olap_windowerr qp_olap_window qp_derived_table qp_bitmapscan session_level_memory_consumption
 test: qp_with_functional_inlining qp_with_functional_noinlining

--- a/src/test/regress/input/appendonly.source
+++ b/src/test/regress/input/appendonly.source
@@ -626,6 +626,48 @@ RESET enable_bitmapscan;
 DROP OWNED BY appendony_test_user2 CASCADE;
 DROP ROLE IF EXISTS appendony_test_user2;
 
+---------------------------------------------------------------
+-- Triggers
+---------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION ao_trigger_func() RETURNS trigger LANGUAGE plpgsql AS $$
+begin
+  raise notice 'new: %', NEW;
+  return new;
+end;
+$$;
+create table trigger_ao_test (id int4, t text) with (appendonly=true, orientation=row);
+create table trigger_aocs_test (id int4, t text) with (appendonly=true, orientation=column);
+
+CREATE TRIGGER show_trigger_data_trig_on_insert BEFORE INSERT ON trigger_ao_test
+FOR EACH ROW EXECUTE PROCEDURE ao_trigger_func();
+CREATE TRIGGER show_trigger_data_trig_on_insert BEFORE INSERT ON trigger_aocs_test
+FOR EACH ROW EXECUTE PROCEDURE ao_trigger_func();
+
+-- UPDATE or DELETE triggers are not supporeted on AO tables
+CREATE TRIGGER show_trigger_data_trig_on_update BEFORE UPDATE ON trigger_ao_test
+FOR EACH ROW EXECUTE PROCEDURE ao_trigger_func();
+CREATE TRIGGER show_trigger_data_trig_on_update BEFORE UPDATE ON trigger_aocs_test
+FOR EACH ROW EXECUTE PROCEDURE ao_trigger_func();
+CREATE TRIGGER show_trigger_data_trig_on_delete BEFORE DELETE ON trigger_ao_test
+FOR EACH ROW EXECUTE PROCEDURE ao_trigger_func();
+CREATE TRIGGER show_trigger_data_trig_on_delete BEFORE DELETE ON trigger_aocs_test
+FOR EACH ROW EXECUTE PROCEDURE ao_trigger_func();
+
+INSERT INTO trigger_ao_test VALUES (1, 'foo');
+INSERT INTO trigger_aocs_test VALUES (1, 'bar');
+
+COPY trigger_ao_test FROM STDIN;
+2	foocopy
+\.
+
+COPY trigger_aocs_test FROM STDIN;
+2	barcopy
+\.
+
+SELECT * FROM trigger_ao_test;
+SELECT * FROM trigger_aocs_test;
+
 --------------------------------------------------------------------------------
 -- Finally check to detect if any dangling gp_fastsequence entries are left
 -- behind by this SQL file

--- a/src/test/regress/output/appendonly.source
+++ b/src/test/regress/output/appendonly.source
@@ -1300,6 +1300,62 @@ RESET enable_indexscan;
 RESET enable_bitmapscan;
 DROP OWNED BY appendony_test_user2 CASCADE;
 DROP ROLE IF EXISTS appendony_test_user2;
+---------------------------------------------------------------
+-- Triggers
+---------------------------------------------------------------
+CREATE OR REPLACE FUNCTION ao_trigger_func() RETURNS trigger LANGUAGE plpgsql AS $$
+begin
+  raise notice 'new: %', NEW;
+  return new;
+end;
+$$;
+create table trigger_ao_test (id int4, t text) with (appendonly=true, orientation=row);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table trigger_aocs_test (id int4, t text) with (appendonly=true, orientation=column);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TRIGGER show_trigger_data_trig_on_insert BEFORE INSERT ON trigger_ao_test
+FOR EACH ROW EXECUTE PROCEDURE ao_trigger_func();
+CREATE TRIGGER show_trigger_data_trig_on_insert BEFORE INSERT ON trigger_aocs_test
+FOR EACH ROW EXECUTE PROCEDURE ao_trigger_func();
+-- UPDATE or DELETE triggers are not supporeted on AO tables
+CREATE TRIGGER show_trigger_data_trig_on_update BEFORE UPDATE ON trigger_ao_test
+FOR EACH ROW EXECUTE PROCEDURE ao_trigger_func();
+ERROR:  ON UPDATE triggers are not supported on append-only tables
+CREATE TRIGGER show_trigger_data_trig_on_update BEFORE UPDATE ON trigger_aocs_test
+FOR EACH ROW EXECUTE PROCEDURE ao_trigger_func();
+ERROR:  ON UPDATE triggers are not supported on append-only tables
+CREATE TRIGGER show_trigger_data_trig_on_delete BEFORE DELETE ON trigger_ao_test
+FOR EACH ROW EXECUTE PROCEDURE ao_trigger_func();
+ERROR:  ON DELETE triggers are not supported on append-only tables
+CREATE TRIGGER show_trigger_data_trig_on_delete BEFORE DELETE ON trigger_aocs_test
+FOR EACH ROW EXECUTE PROCEDURE ao_trigger_func();
+ERROR:  ON DELETE triggers are not supported on append-only tables
+INSERT INTO trigger_ao_test VALUES (1, 'foo');
+NOTICE:  new: (1,foo)  (seg0 127.0.0.1:40000 pid=24242)
+INSERT INTO trigger_aocs_test VALUES (1, 'bar');
+NOTICE:  new: (1,bar)  (seg0 127.0.0.1:40000 pid=24242)
+COPY trigger_ao_test FROM STDIN;
+NOTICE:  new: (2,foocopy)  (seg0 127.0.0.1:40000 pid=24242)
+CONTEXT:  COPY trigger_ao_test, line 1: "2	foocopy"
+COPY trigger_aocs_test FROM STDIN;
+NOTICE:  new: (2,barcopy)  (seg0 127.0.0.1:40000 pid=24242)
+CONTEXT:  COPY trigger_aocs_test, line 1: "2	barcopy"
+SELECT * FROM trigger_ao_test;
+ id |    t    
+----+---------
+  1 | foo
+  2 | foocopy
+(2 rows)
+
+SELECT * FROM trigger_aocs_test;
+ id |    t    
+----+---------
+  1 | bar
+  2 | barcopy
+(2 rows)
+
 --------------------------------------------------------------------------------
 -- Finally check to detect if any dangling gp_fastsequence entries are left
 -- behind by this SQL file

--- a/src/test/regress/sql/qp_dml_oids.sql
+++ b/src/test/regress/sql/qp_dml_oids.sql
@@ -1,0 +1,17 @@
+create schema qp_dml_oids;
+set search_path='qp_dml_oids';
+
+DROP TABLE IF EXISTS dml_ao;
+CREATE TABLE dml_ao (a int , b int default -1, c text) WITH (appendonly = true, oids = true) DISTRIBUTED BY (a);
+INSERT INTO dml_ao VALUES(generate_series(1,2),generate_series(1,2),'r');
+
+INSERT INTO dml_ao VALUES(NULL,NULL,NULL);
+
+--
+-- Check that a tuple gets an OID, even if it's toasted (there used to
+-- be a bug, where toasting a tuple cleared its just-assigned OID)
+--
+INSERT INTO dml_ao (a, b, c) VALUES (10, 1, repeat('x', 50000));
+INSERT INTO dml_ao (a, b, c) VALUES (10, 2, repeat('x', 50000));
+
+SELECT COUNT(distinct oid) FROM dml_ao where a = 10;


### PR DESCRIPTION
This is a back-port of PR #3701 for 5X_STABLE. It applied quite easily, just a few conflicts because of whitespace changes on master, and I had to add the `qp_dml_oids` test case, as that didn't exist on 5X_STABLE before.