### PR TITLE
Add XLogIsNeeded() macro.

### DIFF
--- a/src/backend/access/bitmap/bitmapattutil.c
+++ b/src/backend/access/bitmap/bitmapattutil.c
@@ -117,7 +117,8 @@ _bitmap_create_lov_heapandindex(Relation rel,
 		_bt_initmetapage(btree_metapage, P_NONE, 0);
 
 		/* XLOG the metapage */
-		if (!XLog_UnconvertedCanBypassWal() && !lovIndex->rd_istemp)
+
+		if (!lovIndex->rd_istemp)
 		{
 			// Fetch gp_persistent_relation_node information that will be added to XLOG record.
 			RelationFetchGpRelationNodeForXLog(lovIndex);

--- a/src/backend/access/bitmap/bitmappages.c
+++ b/src/backend/access/bitmap/bitmappages.c
@@ -306,7 +306,7 @@ _bitmap_init_buildstate(Relation index, BMBuildState *bmstate)
 	 * writes page to the shared buffer, we can't disable WAL archiving.
 	 * We will add this shortly.
 	 */	
-	bmstate->use_wal = !XLog_UnconvertedCanBypassWal() && !index->rd_istemp;
+	bmstate->use_wal = !index->rd_istemp;
 }
 
 /*

--- a/src/backend/access/nbtree/nbtsort.c
+++ b/src/backend/access/nbtree/nbtsort.c
@@ -209,10 +209,10 @@ _bt_leafbuild(BTSpool *btspool, BTSpool *btspool2)
 	wstate.index = btspool->index;
 
 	/*
-	 * We need to log index creation in WAL iff WAL archiving is enabled AND
-	 * it's not a temp index.
+	 * We need to log index creation in WAL iff WAL archiving/streaming is
+	 * enabled AND it's not a temp index.
 	 */
-	wstate.btws_use_wal = !XLog_UnconvertedCanBypassWal() && !wstate.index->rd_istemp;
+	wstate.btws_use_wal = XLogIsNeeded() && !wstate.index->rd_istemp;
 
 	/* reserve the metapage */
 	wstate.btws_pages_alloced = BTREE_METAPAGE + 1;

--- a/src/backend/commands/cluster.c
+++ b/src/backend/commands/cluster.c
@@ -849,10 +849,10 @@ copy_heap_data(Oid OIDNewHeap, Oid OIDOldHeap, Oid OIDOldIndex)
 		LockRelationOid(OldHeap->rd_rel->reltoastrelid, AccessExclusiveLock);
 
 	/*
-	 * We need to log the copied data in WAL iff WAL archiving is enabled AND
-	 * it's not a temp rel.
+	 * We need to log the copied data in WAL iff WAL archiving/streaming is
+	 * enabled AND it's not a temp rel.
 	 */
-	use_wal = XLogArchivingActive() && !NewHeap->rd_istemp;
+	use_wal = XLogIsNeeded() && !NewHeap->rd_istemp;
 
 	/* use_wal off requires rd_targblock be initially invalid */
 	Assert(NewHeap->rd_targblock == InvalidBlockNumber);

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -4275,7 +4275,7 @@ CopyFrom(CopyState cstate)
 	/*----------
 	 * Check to see if we can avoid writing WAL
 	 *
-	 * If archive logging is not enabled *and* either
+	 * If archive logging/streaming is not enabled *and* either
 	 *	- table was created in same transaction as this COPY
 	 *	- data is being written to relfilenode created in this transaction
 	 * then we can skip writing WAL.  It's safe because if the transaction
@@ -4303,8 +4303,7 @@ CopyFrom(CopyState cstate)
 		cstate->rel->rd_newRelfilenodeSubid != InvalidSubTransactionId)
 	{
 		use_fsm = false;
-		if (!XLogArchivingActive())
-			use_wal = false;
+		use_wal = XLogIsNeeded();
 	}
 
 	oldcontext = MemoryContextSwitchTo(estate->es_query_cxt);

--- a/src/backend/commands/dbcommands.c
+++ b/src/backend/commands/dbcommands.c
@@ -1170,7 +1170,7 @@ createdb(CreatedbStmt *stmt)
 				PersistentFileSysRelStorageMgr localRelStorageMgr;
 				PersistentFileSysRelBufpoolKind relBufpoolKind;
 				
-				useWal = !XLog_CanBypassWal();
+				useWal = XLogIsNeeded();
 				
 				GpPersistentRelationNode_GetRelationInfo(
 													dbInfoRel->relkind,

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -10059,7 +10059,7 @@ ATExecSetTableSpace_BufferPool(
 	 * We need to log the copied data in WAL enabled AND
 	 * it's not a temp rel.
 	 */
-	useWal = !XLog_CanBypassWal() && !rel->rd_istemp;
+	useWal = XLogIsNeeded() && !rel->rd_istemp;
 
 	if (Debug_persistent_print)
 		elog(Persistent_DebugPrintLevel(), 

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -4789,7 +4789,7 @@ OpenIntoRel(QueryDesc *queryDesc)
 	 */
 	bufferPoolBulkLoad = 
 		(relstorage_is_buffer_pool(relstorage) ?
-									XLog_CanBypassWal() : false);
+									!XLogIsNeeded() : false);
 
 	/* Now we can actually create the new relation */
 	intoRelationId = heap_create_with_catalog(intoName,

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -1186,6 +1186,19 @@ PostmasterMain(int argc, char *argv[])
              )));
 	}
 
+/*
+ * This value of max_wal_senders will be inherited by all the child processes
+ * through fork(). This value is used by XLogIsNeeded().
+ */
+#ifdef USE_SEGWALREP
+		max_wal_senders = 1;
+#else
+	if ( GpIdentity.segindex == MASTER_CONTENT_ID)
+		max_wal_senders = 1;
+	else
+		max_wal_senders = 0;
+#endif
+
 	if ( GpIdentity.numsegments < 0 )
 	{
 	    ereport(FATAL,

--- a/src/backend/replication/walsender.c
+++ b/src/backend/replication/walsender.c
@@ -78,7 +78,7 @@ WalSnd	   *MyWalSnd = NULL;
 
 /* Global state */
 bool		am_walsender = false;		/* Am I a walsender process ? */
-int			max_wal_senders = 1;	/* the maximum number of concurrent walsenders */
+int			max_wal_senders = 0;	/* the maximum number of concurrent walsenders */
 
 /* User-settable parameters for walsender */
 int			replication_timeout = 60 * 1000;	/* maximum time to send one

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -21,6 +21,7 @@
 #include "utils/relcache.h"
 #include "utils/timestamp.h"
 #include "cdb/cdbpublic.h"
+#include "replication/walsender.h"
 
 /*
  * REDO Tracking DEFINEs.
@@ -187,18 +188,12 @@ extern bool log_checkpoints;
 #define XLogArchivingActive()	(XLogArchiveMode)
 #define XLogArchiveCommandSet() (XLogArchiveCommand[0] != '\0')
 
-/* 
- * Whether we need to always generate transaction log (XLOG), or if we can
- * bypass it and get better performance.
- *
- * For GPDB, we do not support XLogArchivingActive(), so we don't use it as a condition.
- */
-extern bool XLog_CanBypassWal(void);
-
 /*
- * For FileRep code that doesn't have the Bypass WAL logic yet.
+ * Is WAL-logging necessary? We need to log an XLOG record iff either
+ * WAL archiving is enabled or XLOG streaming is allowed.
  */
-extern bool XLog_UnconvertedCanBypassWal(void);
+
+#define XLogIsNeeded() (XLogArchivingActive() || (max_wal_senders > 0))
 
 extern bool am_startup;
 

--- a/src/test/regress/input/gpcopy.source
+++ b/src/test/regress/input/gpcopy.source
@@ -1099,3 +1099,15 @@ SET gp_enable_segment_copy_checking=off;
 COPY COPY_FROM_PROGRAM_ERROR FROM PROGRAM $quote$bash -c "echo -e '$GP_SEGMENT_ID\n<SEGID>'"$quote$ on segment;
 COPY COPY_FROM_PROGRAM_ERROR FROM PROGRAM $quote$bash -c "echo -e '$GP_SEGMENT_I\n<SEGID>'"$quote$ on segment;
 SET gp_enable_segment_copy_checking=on;
+
+-- Test that xlog records are generated for COPY in the same transaction as
+-- created table. The actual validation for this test will be performed once the
+-- gp_replica_check tool is enabled.
+BEGIN;
+CREATE TABLE copy_from_same_txn(a int, b int);
+COPY copy_from_same_txn FROM stdin;
+1	1
+2	2
+3	3
+\.
+COMMIT;

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -1298,3 +1298,12 @@ COPY COPY_FROM_PROGRAM_ERROR FROM PROGRAM $quote$bash -c "echo -e '$GP_SEGMENT_I
 ERROR:  invalid input syntax for integer: ""  (seg0 172.17.0.2:40000 pid=27935)
 CONTEXT:  COPY copy_from_program_error, line 1, column 
 SET gp_enable_segment_copy_checking=on;
+-- Test that xlog records are generated for COPY in the same transaction as
+-- created table. The actual validation for this test will be performed once the
+-- gp_replica_check tool is enabled.
+BEGIN;
+CREATE TABLE copy_from_same_txn(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+COPY copy_from_same_txn FROM stdin;
+COMMIT;


### PR DESCRIPTION
    The macro is taken from the upstream commit
    40f908bdcdc726fc11912cd95dfd2f89603d1f37.
    
    This commit fixes issues for CLUSTER and COPY command where the commands would
    not generate necessary XLOG records when streaming replication is enabled. With
    the correct use of XLogIsNeeded() this is now fixed.
    
    This also cleans up the XLog_CanBypassWal() and XLog_UnconvertedCanBypassWal()
    functions by replacing their usage with XLogIsNeeded().
    
    Signed-off-by: Taylor Vesely <tvesely@pivotal.io>
    Signed-off-by: Asim R P <apraveen@pivotal.io>
