### PR TITLE
docs: update split limitation for multi-level partition.

### DIFF
--- a/gpdb-doc/dita/admin_guide/ddl/ddl-partition.xml
+++ b/gpdb-doc/dita/admin_guide/ddl/ddl-partition.xml
@@ -724,9 +724,9 @@ WITH TABLE jan12;
       <body>
         <p>Splitting a partition divides a partition into two partitions. You can split a partition
           using the <codeph>ALTER TABLE</codeph> command. You can split partitions only at the
-          lowest level of your partition hierarchy (partitions that contain data) and only range
-          partitions can be split, not list partitions. The split value you specify goes into the
-            <i>latter</i> partition. </p>
+          lowest level of your partition hierarchy (partitions that contain data). For a multi-level
+          partition design, only range partitions can be split, not list partitions. The split value
+          you specify goes into the <i>latter</i> partition. </p>
         <p>For example, to split a monthly partition into two with the first partition containing
           dates January 1-15 and the second partition containing dates January 16-31:</p>
         <p>

--- a/gpdb-doc/dita/admin_guide/ddl/ddl-partition.xml
+++ b/gpdb-doc/dita/admin_guide/ddl/ddl-partition.xml
@@ -725,8 +725,8 @@ WITH TABLE jan12;
         <p>Splitting a partition divides a partition into two partitions. You can split a partition
           using the <codeph>ALTER TABLE</codeph> command. You can split partitions only at the
           lowest level of your partition hierarchy (partitions that contain data). For a multi-level
-          partition design, only range partitions can be split, not list partitions. The split value
-          you specify goes into the <i>latter</i> partition. </p>
+          partition, only range partitions can be split, not list partitions. The split value you
+          specify goes into the <i>latter</i> partition. </p>
         <p>For example, to split a monthly partition into two with the first partition containing
           dates January 1-15 and the second partition containing dates January 16-31:</p>
         <p>

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_TABLE.xml
@@ -625,10 +625,10 @@ ALTER TABLE <varname>name</varname>
                                 </plentry>
                                 <plentry>
                                         <pt>SPLIT DEFAULT PARTITION</pt>
-                                        <pd>Splits a default partition. In a multi-level partition
-                                                design, only a range partition can be split, not a
-                                                list partition and you can only split the lowest
-                                                level default partitions (those that contain data).
+                                        <pd>Splits a default partition. In a multi-level partition,
+                                                only a range partition can be split, not a list
+                                                partition, and you can only split the lowest level
+                                                default partitions (those that contain data).
                                                 Splitting a default partition creates a new
                                                 partition containing the values specified and leaves
                                                 the default partition containing any values that do
@@ -652,10 +652,10 @@ ALTER TABLE <varname>name</varname>
                                 <plentry>
                                         <pt>SPLIT PARTITION</pt>
                                         <pd>Splits an existing partition into two partitions. In a
-                                                multi-level partition design, only a range partition
-                                                can be split, not a list partition and you can only
-                                                split the lowest level partitions (those that
-                                                contain data). </pd>
+                                                multi-level partition, only a range partition can be
+                                                split, not a list partition, and you can only split
+                                                the lowest level partitions (those that contain
+                                                data). </pd>
                                         <pd><b>AT</b> - Specifies a single value that should be used
                                                 as the criteria for the split. The partition will be
                                                 divided into two new partitions with the split value

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_TABLE.xml
@@ -625,9 +625,9 @@ ALTER TABLE <varname>name</varname>
                                 </plentry>
                                 <plentry>
                                         <pt>SPLIT DEFAULT PARTITION</pt>
-                                        <pd>Splits a default partition. Only a range partition can
-                                                be split, not a list partition. In a multi-level
-                                                partition design, you can only split the lowest
+                                        <pd>Splits a default partition. In a multi-level partition
+                                                design, only a range partition can be split, not a
+                                                list partition and you can only split the lowest
                                                 level default partitions (those that contain data).
                                                 Splitting a default partition creates a new
                                                 partition containing the values specified and leaves
@@ -651,9 +651,9 @@ ALTER TABLE <varname>name</varname>
                                 </plentry>
                                 <plentry>
                                         <pt>SPLIT PARTITION</pt>
-                                        <pd>Splits an existing partition into two partitions. Only a
-                                                range partition can be split, not a list partition.
-                                                In a multi-level partition design, you can only
+                                        <pd>Splits an existing partition into two partitions. In a
+                                                multi-level partition design, only a range partition
+                                                can be split, not a list partition and you can only
                                                 split the lowest level partitions (those that
                                                 contain data). </pd>
                                         <pd><b>AT</b> - Specifies a single value that should be used


### PR DESCRIPTION
For a multi-level partition table, only range partition can be split, not list partition.
For single level partition table, either range or list partition can be split.

PR for 5X_STABLE
Will be ported to MAIN