### PR TITLE
docs - PXF supports RPM install of clients

### DIFF
--- a/gpdb-doc/book/master_middleman/source/subnavs/pxf-subnav.erb
+++ b/gpdb-doc/book/master_middleman/source/subnavs/pxf-subnav.erb
@@ -15,10 +15,7 @@
             <a href="/docs/600/pxf/instcfg_pxf.html" format="markdown">Installing and Configuring PXF</a>
             <ul>
               <li>
-                <a href="/docs/600/pxf/hdfsclient_instcfg.html" format="markdown">Installing and Configuring the Hadoop Client for PXF</a>
-              </li>
-              <li>
-                <a href="/docs/600/pxf/hiveclient_instcfg.html" format="markdown">Installing and Configuring the Hive Client for PXF</a>
+                <a href="/docs/600/pxf/client_instcfg.html" format="markdown">Installing and Configuring Clients for PXF</a>
               </li>
               <li>
                 <a href="/docs/600/pxf/cfginitstart_pxf.html" format="markdown">Configuring, Initializing, and Starting PXF</a>

--- a/gpdb-doc/markdown/pxf/cfginitstart_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/cfginitstart_pxf.html.md.erb
@@ -38,7 +38,7 @@ The following PXF files and directories are installed in your Greenplum Database
 | `pxf`                 | The PXF installation directory.  |
 | `pxf/apache-tomcat`      | The PXF tomcat directory.  |
 | `pxf/bin`                 | The PXF script and executable directory.                                                                                                                                                                                                                       |
-| `pxf/conf`                | The PXF configuration directory. This directory contains the `pxf-private.classpath` and `pxf-profiles.xml` configuration files. |
+| `pxf/conf`                | The PXF configuration directory. This directory contains the `pxf-env.sh`, `pxf-private.classpath` and `pxf-profiles.xml` configuration files. |
 | `pxf/conf-templates`                | Configuration templates for PXF. |
 | `pxf/lib`                 | The PXF library directory.                                                                                                                                                                                                                       |
 | `pxf/logs`, | The PXF log file directory. Includes `pxf-service.log` and Tomcat-related logs including `catalina.out`. The log directory and log files are readable only by the `gpadmin` user.
@@ -55,10 +55,8 @@ You must explicitly initialize the PXF service instance. This one-time initializ
 
 Before initializing PXF in your Greenplum Database cluster, ensure that you have:
 
-- Installed and configured the required Hadoop client on each Greenplum Database segment host. Refer to [Installing and Configuring the Hadoop Client for PXF](hdfsclient_instcfg.html) for instructions.
+- Installed and configured the required Hadoop clients on each Greenplum Database segment host. Refer to [Installing and Configuring Clients for PXF](client_instcfg.html) for instructions.
 - Granted the `gpadmin` operating system user read permission on the relevant portions of your HDFS file system.
-- Installed and configured the required Hive client on each Greenplum Database segment host if you plan to use the PXF Hive connector. Refer to [Installing and Configuring the Hive Client for PXF](hiveclient_instcfg.html) for instructions.
-- Located and noted the full file system path to the base install directory of the Hadoop and Hive clients, `$PXF_HADOOP_HOME` and `$PXF_HIVE_HOME`.
  
 ### <a id="init-pxf-steps"></a>Procedure
 
@@ -85,10 +83,10 @@ Perform the following procedure to initialize PXF on each segment host in your G
     gpadmin@gpmaster$ gpssh -e -v -f seghostfile "sudo yum -y install unzip"
     ```
 
-4. Run the `pxf init` command to initialize the PXF service on each segment host. Provide your Hadoop base install directory in the `--hadoop-home` option value. If you plan to use the PXF Hive connector, also provide a `--hive-home` option and value. For example:
+4. Run the `pxf init` command to initialize the PXF service on each segment host. For example:
 
     ``` shell
-    gpadmin@gpmaster$ gpssh -e -v -f seghostfile "/usr/local/greenplum-db/pxf/bin/pxf init --hadoop-home \$PXF_HADOOP_HOME --hive-home \$PXF_HIVE_HOME"
+    gpadmin@gpmaster$ gpssh -e -v -f seghostfile "/usr/local/greenplum-db/pxf/bin/pxf init"
     ```
     
     The `init` command creates and initializes the PXF web application. It also updates the `pxf-private.classpath` file to include entries for your Hadoop distribution JAR files.
@@ -118,4 +116,4 @@ Perform the following procedure to start PXF on each segment host in your Greenp
 
 The `pxf` command supports `stop`, `restart`, and `status` operations in addition to `init` and `start`. These operations run locally. That is, if you want to start or stop the PXF agent on a specific segment host, you can log in to the host and run the command. If you want to start or stop the PXF agent on multiple segment hosts, use the `gpssh` utility as shown above, or individually log in to each segment host and run the command.
 
-**Note**: If you update your Hadoop or Hive configuration while the PXF service is running, you must copy any updated configuration files to each Greenplum Database segment host and restart PXF on each host.
+**Note**: If you update your Hadoop configuration while the PXF service is running, you must copy any updated configuration files to each Greenplum Database segment host and restart PXF on each host.

--- a/gpdb-doc/markdown/pxf/cfginitstart_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/cfginitstart_pxf.html.md.erb
@@ -38,7 +38,7 @@ The following PXF files and directories are installed in your Greenplum Database
 | `pxf`                 | The PXF installation directory.  |
 | `pxf/apache-tomcat`      | The PXF tomcat directory.  |
 | `pxf/bin`                 | The PXF script and executable directory.                                                                                                                                                                                                                       |
-| `pxf/conf`                | The PXF configuration directory. This directory contains the `pxf-env.sh`, `pxf-private.classpath` and `pxf-profiles.xml` configuration files. |
+| `pxf/conf`                | The PXF configuration directory. This directory contains the `pxf-env.sh`, `pxf-public.classpath`, `pxf-private.classpath` and `pxf-profiles.xml` configuration files. |
 | `pxf/conf-templates`                | Configuration templates for PXF. |
 | `pxf/lib`                 | The PXF library directory.                                                                                                                                                                                                                       |
 | `pxf/logs`, | The PXF log file directory. Includes `pxf-service.log` and Tomcat-related logs including `catalina.out`. The log directory and log files are readable only by the `gpadmin` user.
@@ -55,7 +55,7 @@ You must explicitly initialize the PXF service instance. This one-time initializ
 
 Before initializing PXF in your Greenplum Database cluster, ensure that you have:
 
-- Installed and configured the required Hadoop clients on each Greenplum Database segment host. Refer to [Installing and Configuring Clients for PXF](client_instcfg.html) for instructions.
+- Installed and configured the required Hadoop clients on each Greenplum Database segment host. Refer to [Installing and Configuring Hadoop Clients for PXF](client_instcfg.html) for instructions.
 - Granted the `gpadmin` operating system user read permission on the relevant portions of your HDFS file system.
  
 ### <a id="init-pxf-steps"></a>Procedure

--- a/gpdb-doc/markdown/pxf/client_instcfg.html.md.erb
+++ b/gpdb-doc/markdown/pxf/client_instcfg.html.md.erb
@@ -1,0 +1,197 @@
+---
+title: Installing and Configuring Clients for PXF
+---
+
+You use PXF connectors to access external data sources. PXF requires a client installation on each Greenplum Database segment host when reading external data from the following sources:
+
+- Hadoop
+- Hive
+- HBase
+
+Compatible Hadoop, Hive, and HBase clients for PXF include Cloudera, Hortonworks Data Platform, and generic Apache distributions.
+
+This topic describes how to install and configure Hadoop, Hive, and HBase client RPM distributions for PXF. When you install these clients via RPMs, PXF auto-detects your Hadoop distribution and optional Hive and HBase installations and sets certain configuration and class paths accordingly.
+
+If your Hadoop, Hive, and HBase installation is a custom or tarball distribution, refer to [Installing Tarball and Custom Clients](#client-install-custom) for instructions.
+
+## <a id="client-pxf-prereq"></a>Prerequisites
+
+Before setting up the Hadoop, Hive, and HBase clients for PXF, ensure that you have:
+
+- `scp` access to hosts running the HDFS, Hive, and HBase services in your Hadoop cluster.
+- Superuser permissions to add `yum` repository files and install RPM packages on each Greenplum Database segment host.
+- Access to, or superuser permissions to install, Java version 1.7 or 1.8 on each Greenplum Database segment host.
+
+
+## <a id="client-pxf-config-steps"></a>Procedure
+Perform the following procedure to install and configure the appropriate clients for PXF on each segment host in your Greenplum Database cluster. You will use the `gpssh` utility where possible to run a command on multiple hosts.
+
+1. Log in to your Greenplum Database master node and set up the environment:
+
+    ``` shell
+    $ ssh gpadmin@<gpmaster>
+    gpadmin@gpmaster$ . /usr/local/greenplum-db/greenplum_path.sh
+    ```
+
+2. Create a text file that lists your Greenplum Database segment hosts, one host name per line. Ensure that there are no blank lines or extra spaces in the file. For example, a file named `seghostfile` may include:
+
+    ``` pre
+    seghost1
+    seghost2
+    seghost3
+    ```
+    
+3. If not already present, install Java on each Greenplum Database segment host. For example:
+
+    ``` shell
+    gpadmin@gpmaster$ gpssh -e -v -f seghostfile sudo yum -y install java-1.8.0-openjdk-1.8.0*
+    ```
+
+4. Identify the Java base install directory. Update the `gpadmin` user's `.bash_profile` file on each segment host to include this `$JAVA_HOME` setting if it is not already present. For example:
+
+    ``` shell
+    gpadmin@gpmaster$ gpssh -e -v -f seghostfile "echo 'export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.144-0.b01.el7_4.x86_64/jre' >> /home/gpadmin/.bash_profile"
+    ```
+
+5. Set up a `yum` repository for your desired Hadoop distribution on each segment host.
+
+    1. Download the `.repo` file for your Hadoop distribution. For example:
+
+        For Cloudera distributions:
+
+        ``` shell
+        gpadmin@gpmaster$ wget https://archive.cloudera.com/cdh5/redhat/6/x86_64/cdh/cloudera-cdh5.repo
+        ```
+
+        For Hortonworks Data Platform distributions:
+
+        ``` shell
+        gpadmin@gpmaster$ wget http://public-repo-1.hortonworks.com/HDP/centos6/2.x/updates/2.6.2.0/hdp.repo
+        ```
+        
+    2. Copy the `.repo` file to each Greenplum Database segment host. For example:
+
+        ``` shell
+        gpadmin@gpmaster$ gpscp -v -f seghostfile <hadoop-dist>.repo =:/etc/yum.repos.d
+        ```
+
+    With the `.repo` file is in place, you can use the `yum` utility to install client RPM packages.
+
+6. Install the Hadoop client on each Greenplum Database segment host. For example:
+
+    ``` shell
+    gpadmin@gpmaster$ gpssh -e -v -f seghostfile sudo yum -y install hadoop-client
+    ```
+    
+7. If you plan to use the PXF Hive connector to access Hive table data, install the Hive client on each Greenplum Database segment host. For example:
+
+    ``` shell
+    gpadmin@gpmaster$ gpssh -e -v -f seghostfile sudo yum -y install hive
+    ```
+    
+8. If you plan to use the PXF HBase connector to access HBase table data, install the HBase client on each Greenplum Database segment host. For example:
+
+    ``` shell
+    gpadmin@gpmaster$ gpssh -e -v -f seghostfile sudo yum -y install hbase
+    ```
+
+You have installed the desired client packages on each segment host in your Greenplum Database cluster. Copy relevant HDFS, Hive, and HBase configuration from your Hadoop cluster to each Greenplum Database segment host. You will use the `gpscp` utility to copy files to multiple hosts.
+
+1. The Hadoop `core-site.xml` configuration file `fs.defaultFS` property value identifies the HDFS NameNode URI. PXF requires this information to access your Hadoop cluster. A sample `fs.defaultFS` setting follows:
+
+    ``` xml
+    <property>
+        <name>fs.defaultFS</name>
+        <value>hdfs://namenode.domain:8020</value>
+    </property>
+    ```
+    
+    PXF requires information from `core-site.xml` and other Hadoop configuration files. Copy these files from your Hadoop cluster to each Greenplum Database segment host.
+
+    1. Copy the `core-site.xml`, `hdfs-site.xml`, and `mapred-site.xml` Hadoop configuration files from your Hadoop cluster NameNode host to the current host. For example:
+
+        ``` shell
+        gpadmin@gpmaster$ scp hdfsuser@namenode:/etc/hadoop/conf/core-site.xml .
+        gpadmin@gpmaster$ scp hdfsuser@namenode:/etc/hadoop/conf/hdfs-site.xml .
+        gpadmin@gpmaster$ scp hdfsuser@namenode:/etc/hadoop/conf/mapred-site.xml .
+        ```
+        
+    2. Next, copy these Hadoop configuration files to each Greenplum Database segment host. For example:
+
+        ``` shell
+        gpadmin@gpmaster$ gpscp -v -f seghostfile core-site.xml =:/etc/hadoop/conf/core-site.xml
+        gpadmin@gpmaster$ gpscp -v -f seghostfile hdfs-site.xml =:/etc/hadoop/conf/hdfs-site.xml
+        gpadmin@gpmaster$ gpscp -v -f seghostfile mapred-site.xml =:/etc/hadoop/conf/mapred-site.xml
+        ```
+
+2. The Hive `hive-site.xml` configuration file `hive.metastore.uris` property value identifies the Hive Metastore URI. PXF requires this information to access the Hive service. A sample `hive.metastore.uris` setting follows:
+
+    ``` xml
+    <property>
+        <name>hive.metastore.uris</name>
+        <value>thrift://metastorehost.domain:9083</value>
+    </property>
+    ```
+    
+    If you plan to use the PXF Hive connector to access Hive table data, copy Hive configuration to each Greenplum Database segment host.
+    
+    1. Copy the `hive-site.xml` Hive configuration file from one of the hosts on which your Hive service is running to the current host. For example:
+
+        ``` shell
+        gpadmin@gpmaster$ scp hiveuser@hivehost:/etc/hive/conf/hive-site.xml .
+        ```
+
+    2. Next, copy the `hive-site.xml` configuration file to each Greenplum Database segment host. For example:
+
+        ``` shell
+        gpadmin@gpmaster$ gpscp -v -f seghostfile hive-site.xml =:/etc/hive/conf/hive-site.xml
+
+3. The HBase `hbase-site.xml` configuration file `hbase.rootdir` property value identifies the location of the HBase data directory. PXF requires this information to access the HBase service. A sample `hbase.rootdir` setting follows:
+
+    ``` xml
+    <property>
+        <name>hbase.rootdir</name>
+        <value>hdfs://hbasehost.domain:8020/apps/hbase/data</value>
+    </property>
+    ```
+    
+    If you plan to use the PXF HBase connector to access HBase table data, copy HBase configuration to each Greenplum Database segment host.
+    
+    1. Copy the `hbase-site.xml` HBase configuration file from one of the hosts on which your HBase service is running to the current host. For example:
+
+        ``` shell
+        gpadmin@gpmaster$ scp hbaseuser@hbasehost:/etc/hive/conf/hbase-site.xml .
+        ```
+
+    2. Next, copy the `hbase-site.xml` configuration file to each Greenplum Database segment host. For example:
+
+        ``` shell
+        gpadmin@gpmaster$ gpscp -v -f seghostfile hive-site.xml =:/etc/hbase/conf/hbase-site.xml
+
+
+## <a id="client-cfg-update"></a>Updating Hadoop Configuration
+
+If you update your Hadoop, Hive, or HBase configuration while the PXF service is running, you must copy the updated `.xml` file(s) to each Greenplum Database segment host and restart PXF.
+
+
+## <a id="client-install-custom"></a>Installing Tarball and Custom Clients
+
+If you did/can not install your Hadoop, Hive, and HBase clients via RPMs, you have a custom installation.
+
+Use the `HADOOP_ROOT` and `HADOOP_DISTRO` environment variables to provide additional configuration information to PXF for tarball and custom client Hadoop distributions. As specified below, you must set the relevant environment variable on the command line or in the PXF `$GPHOME/pxf/conf/pxf-env.sh` configuration file prior to initializing PXF.
+
+If you must install your Hadoop and optional Hive and HBase client distributions from a *tarball*:
+
+- You must install the Hadoop and optional Hive and HBase clients in peer directories that are all children of a Hadoop root directory. These client directories must simply-named as `hadoop`, `hive`, and `hbase`.
+
+- You must identify the full file system path to the Hadoop root directory in the `HADOOP_ROOT` environment variable setting.
+
+- The directory `$HADOOP_ROOT/hadoop/share/hadoop/common/lib` must exist.
+
+If the requirements above are not applicable to your Hadoop distribution, you are installing a *custom* tarball distribution:
+
+- You must set the `HADOOP_DISTRO` environment variable to the value `CUSTOM`.
+
+- After you initialize PXF, you must manually edit the `$GPHOME/pxf/conf/pxf-private.classpath` file to identify full file system paths to the Hadoop, Hive, and HBase JAR and configuration files. You must edit this file *before* you start PXF.
+
+**Note**: After you install a tarball or custom client distribution, you must copy Hadoop, Hive, and HBase configuration as described in the procedure above.

--- a/gpdb-doc/markdown/pxf/client_instcfg.html.md.erb
+++ b/gpdb-doc/markdown/pxf/client_instcfg.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Installing and Configuring Clients for PXF
+title: Installing and Configuring Hadoop Clients for PXF
 ---
 
 You use PXF connectors to access external data sources. PXF requires a client installation on each Greenplum Database segment host when reading external data from the following sources:
@@ -8,11 +8,13 @@ You use PXF connectors to access external data sources. PXF requires a client in
 - Hive
 - HBase
 
+PXF requires you install a Hadoop client. Hive and HBase client installation is required only if you plan to access those external data stores.
+
 Compatible Hadoop, Hive, and HBase clients for PXF include Cloudera, Hortonworks Data Platform, and generic Apache distributions.
 
 This topic describes how to install and configure Hadoop, Hive, and HBase client RPM distributions for PXF. When you install these clients via RPMs, PXF auto-detects your Hadoop distribution and optional Hive and HBase installations and sets certain configuration and class paths accordingly.
 
-If your Hadoop, Hive, and HBase installation is a custom or tarball distribution, refer to [Installing Tarball and Custom Clients](#client-install-custom) for instructions.
+If your Hadoop, Hive, and HBase installation is a custom or tarball distribution, refer to [Using a Custom Client Installation](#client-install-custom) for instructions.
 
 ## <a id="client-pxf-prereq"></a>Prerequisites
 
@@ -55,7 +57,7 @@ Perform the following procedure to install and configure the appropriate clients
 
 5. Set up a `yum` repository for your desired Hadoop distribution on each segment host.
 
-    1. Download the `.repo` file for your Hadoop distribution. For example:
+    1. Download the `.repo` file for your Hadoop distribution. For example, to download the file for RHEL 6:
 
         For Cloudera distributions:
 
@@ -174,24 +176,24 @@ You have installed the desired client packages on each segment host in your Gree
 If you update your Hadoop, Hive, or HBase configuration while the PXF service is running, you must copy the updated `.xml` file(s) to each Greenplum Database segment host and restart PXF.
 
 
-## <a id="client-install-custom"></a>Installing Tarball and Custom Clients
+## <a id="client-install-custom"></a>Using a Custom Client Installation
 
-If you did/can not install your Hadoop, Hive, and HBase clients via RPMs, you have a custom installation.
+If you can not install your Hadoop, Hive, and HBase clients via RPMs from supported distributions, you have a custom installation.
 
-Use the `HADOOP_ROOT` and `HADOOP_DISTRO` environment variables to provide additional configuration information to PXF for tarball and custom client Hadoop distributions. As specified below, you must set the relevant environment variable on the command line or in the PXF `$GPHOME/pxf/conf/pxf-env.sh` configuration file prior to initializing PXF.
+Use the `HADOOP_ROOT` and `HADOOP_DISTRO` environment variables to provide additional configuration information to PXF for custom client Hadoop distributions. As specified below, you must set the relevant environment variable on the command line or in the PXF `$GPHOME/pxf/conf/pxf-env.sh` configuration file prior to initializing PXF.
 
 If you must install your Hadoop and optional Hive and HBase client distributions from a *tarball*:
 
-- You must install the Hadoop and optional Hive and HBase clients in peer directories that are all children of a Hadoop root directory. These client directories must simply-named as `hadoop`, `hive`, and `hbase`.
+- You must install the Hadoop and optional Hive and HBase clients in peer directories that are all children of a Hadoop root directory. These client directories must be simply-named as `hadoop`, `hive`, and `hbase`.
 
-- You must identify the full file system path to the Hadoop root directory in the `HADOOP_ROOT` environment variable setting.
+- You must identify the absolute path to the Hadoop root directory in the `HADOOP_ROOT` environment variable setting.
 
 - The directory `$HADOOP_ROOT/hadoop/share/hadoop/common/lib` must exist.
 
-If the requirements above are not applicable to your Hadoop distribution, you are installing a *custom* tarball distribution:
+If the requirements above are not applicable to your Hadoop distribution:
 
 - You must set the `HADOOP_DISTRO` environment variable to the value `CUSTOM`.
 
-- After you initialize PXF, you must manually edit the `$GPHOME/pxf/conf/pxf-private.classpath` file to identify full file system paths to the Hadoop, Hive, and HBase JAR and configuration files. You must edit this file *before* you start PXF.
+- After you initialize PXF, you must manually edit the `$GPHOME/pxf/conf/pxf-private.classpath` file to identify absolute paths to the Hadoop, Hive, and HBase JAR and configuration files. You must edit this file *before* you start PXF.
 
-**Note**: After you install a tarball or custom client distribution, you must copy Hadoop, Hive, and HBase configuration as described in the procedure above.
+**Note**: After you install a custom client distribution, you must copy Hadoop, Hive, and HBase configuration as described in the procedure above.

--- a/gpdb-doc/markdown/pxf/hdfs_read_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_read_pxf.html.md.erb
@@ -29,11 +29,9 @@ This section describes how to use PXF to access HDFS data, including how to crea
 
 Before working with HDFS file data using PXF, ensure that:
 
--  You have installed and configured a Hadoop client on each Greenplum Database segment host. Refer to [Installing and Configuring the Hadoop Client for PXF](hdfsclient_instcfg.html) for instructions.
+-  You have installed and configured a Hadoop client on each Greenplum Database segment host. Refer to [Installing and Configuring Clients for PXF](client_instcfg.html) for instructions.
 - You have initialized PXF on your Greenplum Database segment hosts, and PXF is running on each host. See [Configuring, Initializing, and Starting PXF](cfginitstart_pxf.html) for PXF initialization, configuration, and startup information.
 - You have granted the `gpadmin` user read permission on the relevant portions of your HDFS file system.
-
-If you plan to access Avro format files, make sure that you have downloaded the required JAR file as described in [Installing and Configuring the Hadoop Client for PXF](hdfsclient_instcfg.html). You must restart PXF if you download and install this file while PXF is running.
 
 ## <a id="hdfs_fileformats"></a>HDFS File Formats
 

--- a/gpdb-doc/markdown/pxf/hdfs_read_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_read_pxf.html.md.erb
@@ -29,7 +29,7 @@ This section describes how to use PXF to access HDFS data, including how to crea
 
 Before working with HDFS file data using PXF, ensure that:
 
--  You have installed and configured a Hadoop client on each Greenplum Database segment host. Refer to [Installing and Configuring Clients for PXF](client_instcfg.html) for instructions.
+-  You have installed and configured a Hadoop client on each Greenplum Database segment host. Refer to [Installing and Configuring Hadoop Clients for PXF](client_instcfg.html) for instructions.
 - You have initialized PXF on your Greenplum Database segment hosts, and PXF is running on each host. See [Configuring, Initializing, and Starting PXF](cfginitstart_pxf.html) for PXF initialization, configuration, and startup information.
 - You have granted the `gpadmin` user read permission on the relevant portions of your HDFS file system.
 
@@ -102,7 +102,7 @@ The specific keywords and values used by the `pxf` protocol in the [CREATE EXTER
 
 | Keyword  | Value |
 |-------|-------------------------------------|
-| \<path-to-hdfs-file\>    | The the full file system path to the file in the HDFS data store. |
+| \<path-to-hdfs-file\>    | The absolute path to the file in the HDFS data store. |
 | PROFILE    | The `PROFILE` keyword must specify one of the values `HdfsTextSimple`, `HdfsTextMulti`, or `Avro`. |
 | \<custom-option\>  | \<custom-option\> is profile-specific. Profile-specific options are discussed in the relevant sections later in this topic.|
 | FORMAT | Use `FORMAT` `'TEXT'` with the `HdfsTextSimple` profile when \<path-to-hdfs-file\> references a plain text delimited file.<br> Use `FORMAT` `'CSV'`  with the `HdfsTextSimple` or `HdfsTextMulti` profile when \<path-to-hdfs-file\> references a comma-separated value file.  |

--- a/gpdb-doc/markdown/pxf/hdfs_write_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_write_pxf.html.md.erb
@@ -33,7 +33,7 @@ Note: Tables that you create with writable profiles can only be used for `INSERT
 
 Before working with HDFS file data using PXF, ensure that:
 
--  You have installed and configured a Hadoop client on each Greenplum Database segment host. Refer to [Installing and Configuring the Hadoop Client for PXF](hdfsclient_instcfg.html) for instructions.
+-  You have installed and configured a Hadoop client on each Greenplum Database segment host. Refer to [Installing and Configuring Clients for PXF](client_instcfg.html) for instructions.
 - You have initialized and started PXF on your Greenplum Database segment hosts. See [Configuring, Initializing, and Starting PXF](cfginitstart_pxf.html) for PXF initialization, configuration, and startup information.
 - You have granted the `gpadmin` user read and write permission to the appropriate directories in your HDFS file system.
 

--- a/gpdb-doc/markdown/pxf/hive_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hive_pxf.html.md.erb
@@ -29,7 +29,7 @@ The PXF Hive connector reads data stored in a Hive table. This section describes
 
 Before working with Hive table data using PXF, ensure that:
 
-- You have installed and configured a Hive client on each Greenplum Database segment host. Refer to [Installing and Configuring the Hive Client for PXF](hiveclient_instcfg.html) for instructions.
+- You have installed and configured a Hive client on each Greenplum Database segment host. Refer to [Installing and Configuring Clients for PXF](client_instcfg.html) for instructions.
 - You have initialized PXF on your Greenplum Database segment hosts, and PXF is running on each host. See [Configuring, Initializing, and Starting PXF](cfginitstart_pxf.html) for PXF initialization, configuration, and startup information.
 
 

--- a/gpdb-doc/markdown/pxf/hive_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hive_pxf.html.md.erb
@@ -29,7 +29,7 @@ The PXF Hive connector reads data stored in a Hive table. This section describes
 
 Before working with Hive table data using PXF, ensure that:
 
-- You have installed and configured a Hive client on each Greenplum Database segment host. Refer to [Installing and Configuring Clients for PXF](client_instcfg.html) for instructions.
+- You have installed and configured a Hive client on each Greenplum Database segment host. Refer to [Installing and Configuring Hadoop Clients for PXF](client_instcfg.html) for instructions.
 - You have initialized PXF on your Greenplum Database segment hosts, and PXF is running on each host. See [Configuring, Initializing, and Starting PXF](cfginitstart_pxf.html) for PXF initialization, configuration, and startup information.
 
 

--- a/gpdb-doc/markdown/pxf/instcfg_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/instcfg_pxf.html.md.erb
@@ -4,7 +4,7 @@ title: Installing and Configuring PXF
 
 The PXF Extension Framework provides connectors to Hadoop, Hive, and HBase data stores. To use these PXF connectors, you must install Hadoop, Hive, and HBase clients on each Greenplum Database segment host as described in this one-time installation and configuration procedure:
 
-- **[Installing and Configuring Clients for PXF](client_instcfg.html)**
+- **[Installing and Configuring Hadoop Clients for PXF](client_instcfg.html)**
 
 
 You must also configure and initialize PXF itself, and start the PXF service on each segment host:

--- a/gpdb-doc/markdown/pxf/instcfg_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/instcfg_pxf.html.md.erb
@@ -2,14 +2,12 @@
 title: Installing and Configuring PXF
 ---
 
-The PXF Extension Framework provides connectors to Hadoop and Hive data stores. To use these PXF connectors, you must install Hadoop and Hive clients on each Greenplum Database segment host as described in these one-time installation and configuration procedures:
+The PXF Extension Framework provides connectors to Hadoop, Hive, and HBase data stores. To use these PXF connectors, you must install Hadoop, Hive, and HBase clients on each Greenplum Database segment host as described in this one-time installation and configuration procedure:
 
-- **[Installing and Configuring the Hadoop Client for PXF](hdfsclient_instcfg.html)**
-
-- **[Installing and Configuring the Hive Client for PXF](hiveclient_instcfg.html)**
+- **[Installing and Configuring Clients for PXF](client_instcfg.html)**
 
 
-You must also configure and initialize PXF itself, in addition to starting the service:
+You must also configure and initialize PXF itself, and start the PXF service on each segment host:
 
 - **[Configuring, Initializing, and Starting PXF](cfginitstart_pxf.html)**
 

--- a/gpdb-doc/markdown/pxf/overview_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/overview_pxf.html.md.erb
@@ -29,7 +29,7 @@ The PXF Extension Framework (PXF) provides parallel, high throughput data access
 
 -   **[Installing and Configuring PXF](instcfg_pxf.html)**
 
-    This topic details the PXF installation, configuration, and startup procedures.
+    This topic details the installation, configuration, and startup procedures for PXF and supporting clients.
 
 -   **[Using PXF](using_pxf.html)**
 
@@ -41,7 +41,7 @@ The PXF Extension Framework (PXF) provides parallel, high throughput data access
 
 -   **[Accessing Hive Table Data](hive_pxf.html)**
 
-    This topic describes how to use the PXF Hive connector and related profiles to read Hive tables stored in Text, RCFile, Parquet, and ORC storage formats.
+    This topic describes how to use the PXF Hive connector and related profiles to read Hive tables stored in TextFile, RCFile, Parquet, and ORC storage formats.
 
 -   **[Troubleshooting PXF](troubleshooting_pxf.html)**
 

--- a/gpdb-doc/markdown/pxf/using_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/using_pxf.html.md.erb
@@ -118,14 +118,14 @@ A PXF profile definition includes the name of the profile, a description, and th
 </profile>
 ```
 
-**Note**: Profile `plugins` identify the Java classes that PXF uses to parse and access the external data. The typical PXF user need not concern themselves with the profile `plugins`.
+**Note**: Profile `<plugins>` identify the Java classes that PXF uses to parse and access the external data. The typical PXF user need not concern themselves with the profile `plugins`.
 
 
 ## <a id="profile-dependencies"></a>PXF JAR Dependencies
 
 You use the PXF Extension Framework to access data stored on external systems. Depending upon the external data source, this access may require that you install and/or configure additional components or services for the external data source. For example, to use PXF to access a file stored in HDFS, you must install a Hadoop client on each Greenplum Database segment host.
 
-PXF depends on JAR files and other configuration information provided by these additional components. The `$GPHOME/pxf/conf/pxf-private.classpath` and `$GPHOME/pxf/conf/pxf-public.classpath` configuration files identify PXF JAR dependencies. PXF manages the `pxf-private.classpath` file, adding entries as necessary based on options that you provide to the `pxf init` command. 
+PXF depends on JAR files and other configuration information provided by these additional components. The `$GPHOME/pxf/conf/pxf-private.classpath` and `$GPHOME/pxf/conf/pxf-public.classpath` configuration files identify PXF JAR dependencies. In most cases, PXF manages the `pxf-private.classpath` file, adding entries as necessary based on your Hadoop distribution and optional Hive and HBase client installations. 
 
 Should you need to add additional JAR dependencies for PXF, you must add them to the `pxf-public.classpath` file on each segment host, and then restart PXF on each host.
 

--- a/gpdb-doc/markdown/pxf/using_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/using_pxf.html.md.erb
@@ -142,7 +142,7 @@ FORMAT '[TEXT|CSV|CUSTOM]' (<formatting-properties>);
 ```
 **Note**: PXF does not currently support writable external tables.
 
-The `LOCATION` clause in a `CREATE EXTERNAL TABLE` statement specifying the `pxf` protocol is a URI that identifies the path to, or other information describing, the location of the external data. For example, if the external data source is HDFS, the \<path-to-data\> would identify the full file system path to a specific HDFS file. If the external data source is Hive, \<path-to-data\> would identify a schema-qualified Hive table name.
+The `LOCATION` clause in a `CREATE EXTERNAL TABLE` statement specifying the `pxf` protocol is a URI that identifies the path to, or other information describing, the location of the external data. For example, if the external data source is HDFS, the \<path-to-data\> would identify the absolute path to a specific HDFS file. If the external data source is Hive, \<path-to-data\> would identify a schema-qualified Hive table name.
 
 Use the query portion of the URI, introduced by the question mark (?), to identify the PXF profile name. 
 


### PR DESCRIPTION
docs now targeting RPM install of hadoop/hive/hbase clients. updates include:
- new page for hdfs/hive/hbase client install and config -  http://docs-gpdb-review-staging.cfapps.io/510/pxf/client_instcfg.html
    - replaces separate pages for hdfs and hive client config
    - focus the procedure on client installs via RPMs
    - address tarball and custom (i.e. advanced) install in a separate section
- removed avro jar download instructions
- references to hdfs- or hive- specific install pages are now xref'ing new page above