### PR TITLE
Fix memory tuple binding leak when calling tuplestore_putvalues for tuplestore.

### DIFF
--- a/src/backend/catalog/pg_exttable.c
+++ b/src/backend/catalog/pg_exttable.c
@@ -41,14 +41,14 @@ extern Datum pg_options_to_table(PG_FUNCTION_ARGS);
 
 /*
  * InsertExtTableEntry
- * 
+ *
  * Adds an entry into the pg_exttable catalog table. The entry
  * includes the reloid of the external relation that was created
  * in pg_class and a text array of external location URIs among
  * other external table properties.
  */
 void
-InsertExtTableEntry(Oid 	tbloid, 
+InsertExtTableEntry(Oid 	tbloid,
 					bool 	iswritable,
 					bool 	isweb,
 					bool	issreh,
@@ -290,14 +290,14 @@ GetExtTableEntryIfExists(Oid relid)
 	ExtTableEntry *extentry;
 	Datum		urilocations,
 				execlocations,
-				fmtcode, 
-				fmtopts, 
+				fmtcode,
+				fmtopts,
 				options,
-				command, 
-				rejectlimit, 
-				rejectlimittype, 
-				fmterrtbl, 
-				encoding, 
+				command,
+				rejectlimit,
+				rejectlimittype,
+				fmterrtbl,
+				encoding,
 				iswritable;
 	bool		isNull;
 	bool		locationNull = false;
@@ -348,7 +348,7 @@ GetExtTableEntryIfExists(Oid relid)
 		int			nelems;
 		int			i;
 		char*		loc_str = NULL;
-		
+
 		deconstruct_array(DatumGetArrayTypeP(urilocations),
 						  TEXTOID, -1, false, 'i',
 						  &elems, NULL, &nelems);
@@ -360,7 +360,7 @@ GetExtTableEntryIfExists(Oid relid)
 			/* append to a list of Value nodes, size nelems */
 			extentry->urilocations = lappend(extentry->urilocations, makeString(pstrdup(loc_str)));
 		}
-		
+
 		if(loc_str && (IS_FILE_URI(loc_str) || IS_GPFDIST_URI(loc_str) || IS_GPFDISTS_URI(loc_str)))
 			extentry->isweb = false;
 		else
@@ -379,20 +379,20 @@ GetExtTableEntryIfExists(Oid relid)
 		}
 
 	}
-		
+
 	/* get the execute command */
-	command = heap_getattr(tuple, 
-						   Anum_pg_exttable_command, 
-						   RelationGetDescr(pg_exttable_rel), 
+	command = heap_getattr(tuple,
+						   Anum_pg_exttable_command,
+						   RelationGetDescr(pg_exttable_rel),
 						   &isNull);
-	
+
 	if(isNull)
 	{
 		if(locationNull)
 			ereport(ERROR,
 					(errcode(ERRCODE_UNDEFINED_OBJECT),
-					 errmsg("got invalid pg_exttable tuple. location and command are both NULL")));	
-		
+					 errmsg("got invalid pg_exttable tuple. location and command are both NULL")));
+
 		extentry->command = NULL;
 	}
 	else
@@ -401,26 +401,26 @@ GetExtTableEntryIfExists(Oid relid)
 	}
 
 	/* get the format code */
-	fmtcode = heap_getattr(tuple, 
-						   Anum_pg_exttable_fmttype, 
-						   RelationGetDescr(pg_exttable_rel), 
+	fmtcode = heap_getattr(tuple,
+						   Anum_pg_exttable_fmttype,
+						   RelationGetDescr(pg_exttable_rel),
 						   &isNull);
-	
+
 	Insist(!isNull);
 	extentry->fmtcode = DatumGetChar(fmtcode);
-	Insist(extentry->fmtcode == 'c' || extentry->fmtcode == 't' 
+	Insist(extentry->fmtcode == 'c' || extentry->fmtcode == 't'
 		 || extentry->fmtcode == 'b' || extentry->fmtcode == 'a'
 		 || extentry->fmtcode == 'p');
 
 	/* get the format options string */
-	fmtopts = heap_getattr(tuple, 
-						   Anum_pg_exttable_fmtopts, 
-						   RelationGetDescr(pg_exttable_rel), 
+	fmtopts = heap_getattr(tuple,
+						   Anum_pg_exttable_fmtopts,
+						   RelationGetDescr(pg_exttable_rel),
 						   &isNull);
-	
+
 	Insist(!isNull);
 	extentry->fmtopts = TextDatumGetCString(fmtopts);
-	
+
     /* get the external table options string */
     options = heap_getattr(tuple,
                            Anum_pg_exttable_options,
@@ -453,58 +453,58 @@ GetExtTableEntryIfExists(Oid relid)
 	}
 
 	/* get the reject limit */
-	rejectlimit = heap_getattr(tuple, 
-							   Anum_pg_exttable_rejectlimit, 
-							   RelationGetDescr(pg_exttable_rel), 
+	rejectlimit = heap_getattr(tuple,
+							   Anum_pg_exttable_rejectlimit,
+							   RelationGetDescr(pg_exttable_rel),
 							   &isNull);
-	
+
 	if(!isNull)
 		extentry->rejectlimit = DatumGetInt32(rejectlimit);
 	else
 		extentry->rejectlimit = -1; /* mark that no SREH requested */
 
 	/* get the reject limit type */
-	rejectlimittype = heap_getattr(tuple, 
-								   Anum_pg_exttable_rejectlimittype, 
-								   RelationGetDescr(pg_exttable_rel), 
+	rejectlimittype = heap_getattr(tuple,
+								   Anum_pg_exttable_rejectlimittype,
+								   RelationGetDescr(pg_exttable_rel),
 								   &isNull);
-	
+
 	extentry->rejectlimittype = DatumGetChar(rejectlimittype);
 	if(!isNull)
 		Insist(extentry->rejectlimittype == 'r' || extentry->rejectlimittype == 'p');
 	else
 		extentry->rejectlimittype = -1;
-	
+
 	/* get the error table oid */
-	fmterrtbl = heap_getattr(tuple, 
-							 Anum_pg_exttable_fmterrtbl, 
-							 RelationGetDescr(pg_exttable_rel), 
+	fmterrtbl = heap_getattr(tuple,
+							 Anum_pg_exttable_fmterrtbl,
+							 RelationGetDescr(pg_exttable_rel),
 							 &isNull);
-    
+
 	if(isNull)
 		extentry->fmterrtbl = InvalidOid;
 	else
 		extentry->fmterrtbl = DatumGetObjectId(fmterrtbl);
 
 	/* get the table encoding */
-	encoding = heap_getattr(tuple, 
-							Anum_pg_exttable_encoding, 
-							RelationGetDescr(pg_exttable_rel), 
+	encoding = heap_getattr(tuple,
+							Anum_pg_exttable_encoding,
+							RelationGetDescr(pg_exttable_rel),
 							&isNull);
-	
+
 	Insist(!isNull);
 	extentry->encoding = DatumGetInt32(encoding);
 	Insist(PG_VALID_ENCODING(extentry->encoding));
 
 	/* get the table encoding */
-	iswritable = heap_getattr(tuple, 
-							  Anum_pg_exttable_writable, 
-							  RelationGetDescr(pg_exttable_rel), 
+	iswritable = heap_getattr(tuple,
+							  Anum_pg_exttable_writable,
+							  RelationGetDescr(pg_exttable_rel),
 							  &isNull);
 	Insist(!isNull);
 	extentry->iswritable = DatumGetBool(iswritable);
 
-	
+
 	/* Finish up scan and close pg_exttable catalog. */
 	systable_endscan(scan);
 	heap_close(pg_exttable_rel, RowExclusiveLock);
@@ -514,8 +514,8 @@ GetExtTableEntryIfExists(Oid relid)
 
 /*
  * RemoveExtTableEntry
- * 
- * Remove an external table entry from pg_exttable. Caller's 
+ *
+ * Remove an external table entry from pg_exttable. Caller's
  * responsibility to ensure that the relation has such an entry.
  */
 void

--- a/src/backend/commands/prepare.c
+++ b/src/backend/commands/prepare.c
@@ -456,7 +456,7 @@ InitQueryHashTable(void)
  * Exception: commandTag is presumed to be a pointer to a constant string,
  * or possibly NULL, so it need not be copied.	Note that commandTag should
  * be NULL only if the original query (before rewriting) was empty.
- * The original query nodetag is saved as well, only used if resource 
+ * The original query nodetag is saved as well, only used if resource
  * scheduling is enabled.
  */
 void

--- a/src/backend/executor/execQual.c
+++ b/src/backend/executor/execQual.c
@@ -579,7 +579,7 @@ ExecEvalAggref(AggrefExprState *aggref, ExprContext *econtext,
  *		Returns a Datum whose value is the value of a GROUPING_ID
  *		with respect to the given context.
  */
-static Datum 
+static Datum
 ExecEvalGroupingFunc(GroupingFuncExprState *gstate,
 					 ExprContext *econtext,
 					 bool *isNull, ExprDoneCond *isDone)
@@ -2020,7 +2020,7 @@ Tuplestorestate *
 ExecMakeTableFunctionResult(ExprState *funcexpr,
 							ExprContext *econtext,
 							TupleDesc expectedDesc,
-							uint64 operatorMemKB) 
+							uint64 operatorMemKB)
 {
 	Tuplestorestate *tupstore = NULL;
 	TupleDesc	tupdesc = NULL;
@@ -2229,7 +2229,7 @@ ExecMakeTableFunctionResult(ExprState *funcexpr,
 
 				mt_bind = create_memtuple_binding(tupdesc);
 
-				tupstore = tuplestore_begin_heap(true, false, operatorMemKB); 
+				tupstore = tuplestore_begin_heap(true, false, operatorMemKB);
 				MemoryContextSwitchTo(oldcontext);
 				rsinfo.setResult = tupstore;
 				rsinfo.setDesc = tupdesc;
@@ -2327,7 +2327,7 @@ no_function_result:
 	if (rsinfo.setResult == NULL)
 	{
 		MemoryContextSwitchTo(econtext->ecxt_per_query_memory);
-		tupstore = tuplestore_begin_heap(true, false, operatorMemKB); 
+		tupstore = tuplestore_begin_heap(true, false, operatorMemKB);
 		rsinfo.setResult = tupstore;
 		if (!returnsSet)
 		{
@@ -2501,13 +2501,13 @@ ExecEvalDistinct(FuncExprState *fcache,
 }
 
 static inline void ExecEvalFPStrict2Arg(FuncExprState *expr, ExprContext *econtext, bool *isNull, ExprDoneCond *isDone)
-{ 
+{
 	ExprDoneCond argDone[2];
 
 	Assert(expr->fp_arg[0] && expr->fp_arg[1]);
 	if(isDone)
 		*isDone = ExprSingleResult;
-	
+
 	expr->fp_datum[0] = ExecEvalExpr(expr->fp_arg[0], econtext, &expr->fp_null[0], &argDone[0]);
 	expr->fp_datum[1] = ExecEvalExpr(expr->fp_arg[1], econtext, &expr->fp_null[1], &argDone[1]);
 
@@ -2546,10 +2546,10 @@ static Datum ExecEvalFPStrict2_Int8Eq(FuncExprState *fstate, ExprContext *ctxt, 
 #define DATE_EQ_OID 1086
 
 /* Optimize x op y if op has no side effect.  Almost all our functions are
- * strict, 2 args.  
- * 
- * NOTE: You need to implement the ExecEvalFPStrict2_FUNC FAITHFULLY.  
- * For example, before you fast path int4add, make sure your implementation 
+ * strict, 2 args.
+ *
+ * NOTE: You need to implement the ExecEvalFPStrict2_FUNC FAITHFULLY.
+ * For example, before you fast path int4add, make sure your implementation
  * is the same as the old int4add, that is, you need to handle under/over flow etc.
  */
 static void FastPathStrict2Func(Oid funcoid, FuncExprState *fstate)
@@ -2603,7 +2603,7 @@ ExecEvalFPScalarArrayInt(ScalarArrayOpExprState *sstate,
 
 	if (isDone)
 		*isDone = ExprSingleResult;
-		
+
 	if (isnull)
 	{
 		*isNull = true;
@@ -2651,7 +2651,7 @@ ExecEvalFPScalarArrayStr(ScalarArrayOpExprState *sstate,
 
 	if (isDone)
 		*isDone = ExprSingleResult;
-		
+
 	if (isnull)
 	{
 		*isNull = true;
@@ -2715,7 +2715,7 @@ static void FastPathScalarArrayOp(ScalarArrayOpExpr *opexpr, ScalarArrayOpExprSt
 	};
 
 	int i;
-		
+
 	/* IN will be evaluated as OR */
 	if (!opexpr->useOr)
 		return;
@@ -2735,7 +2735,7 @@ static void FastPathScalarArrayOp(ScalarArrayOpExpr *opexpr, ScalarArrayOpExprSt
 
 	/* Better to have just two args */
 	Assert(list_length(sstate->fxprstate.args) == 2);
-	
+
 	/* only if the second args are const */
 	argstate = (ExprState *) lsecond(sstate->fxprstate.args);
 	if (argstate->evalfunc != ExecEvalConst)
@@ -2778,11 +2778,11 @@ static void FastPathScalarArrayOp(ScalarArrayOpExpr *opexpr, ScalarArrayOpExprSt
 	for (i = 0; i < sstate->fp_n; i++)
 	{
 		Datum elt;
-		
+
 		/* Do not deal with null yet */
 		if (bitmap && (*bitmap & bitmask) == 0)
 			return;
-		
+
 		elt = fetch_att(s, typbyval, typlen);
 		s = att_addlength_pointer(s, typlen, PointerGetDatum(s));
 		s = (char *) att_align_nominal(s, typalign);
@@ -2835,12 +2835,12 @@ static void FastPathScalarArrayOp(ScalarArrayOpExpr *opexpr, ScalarArrayOpExprSt
 	/* Now we are sure we can fast path this */
 	if (fnoid == INT2EQ_OID || fnoid == INT4EQ_OID || fnoid == INT8EQ_OID || fnoid == DATE_EQ_OID)
 		sstate->fxprstate.xprstate.evalfunc = (ExprStateEvalFunc) ExecEvalFPScalarArrayInt;
-	else if (fnoid == TEXTEQ_OID || fnoid == BPCHAREQ_OID) 
-		sstate->fxprstate.xprstate.evalfunc = (ExprStateEvalFunc) ExecEvalFPScalarArrayStr; 
+	else if (fnoid == TEXTEQ_OID || fnoid == BPCHAREQ_OID)
+		sstate->fxprstate.xprstate.evalfunc = (ExprStateEvalFunc) ExecEvalFPScalarArrayStr;
 	else
 		Assert(!"Wrong optimize_funcoid");
 }
-	
+
 /*
  * ExecEvalScalarArrayOp
  *
@@ -3759,10 +3759,10 @@ ExecEvalRowCompare(RowCompareExprState *rstate,
  *		ExecEvalTableValue
  * ----------------------------------------------------------------
  */
-static Datum 
+static Datum
 ExecEvalTableValue(ExprState	*estate,
 				   ExprContext	*econtext,
-				   bool			*isNull, 
+				   bool			*isNull,
 				   ExprDoneCond	*isDone)
 {
 	/* Guard against stack overflow due to overly complex expressions */
@@ -4964,7 +4964,7 @@ static Datum ExecEvalPartListNullTestExpr(PartListNullTestExprState *exprstate,
  *
  *    Evaluate CURRENT OF
  *
- *    Constant folding must have bound observed values of 
+ *    Constant folding must have bound observed values of
  * 	gp_segment_id, ctid, and tableoid into the CurrentOfExpr for
  *	this function's consumption.
  * ----------------------------------------------------------------
@@ -4987,12 +4987,12 @@ ExecEvalCurrentOfExpr(ExprState *exprstate, ExprContext *econtext,
 	slot = econtext->ecxt_scantuple;
 	Assert(!TupIsNull(slot));
 
-	/* 
+	/*
 	 * The currently scanned tuple must use heap storage for it to possibly
 	 * satisfy the CURRENT OF qualification. Despite our grand attempts during
-	 * parsing and constant folding to demand heap storage, the scanning of an 
-	 * AO part is still possible, when the current row uses heap storage, but the 
-	 * CURRENT OF invocation uses an unpruned scan of the partition table, yielding 
+	 * parsing and constant folding to demand heap storage, the scanning of an
+	 * AO part is still possible, when the current row uses heap storage, but the
+	 * CURRENT OF invocation uses an unpruned scan of the partition table, yielding
 	 * tuples from the AO parts before the desired heap tuple.
 	 */
 	if (TupHasHeapTuple(slot))
@@ -5302,7 +5302,7 @@ ExecInitExpr(Expr *node, PlanState *parent)
 				WindowFuncExprState *wfstate = makeNode(WindowFuncExprState);
 				int			numrefs;
 				WindowState *winstate = (WindowState *) parent;
-				
+
 				wfstate->xprstate.evalfunc = (ExprStateEvalFunc) ExecEvalWindowFunc;
 				if (parent && IsA(parent, WindowState))
 				{
@@ -5455,12 +5455,12 @@ ExecInitExpr(Expr *node, PlanState *parent)
 			{
 				AlternativeSubPlan *asplan = (AlternativeSubPlan *) node;
 				AlternativeSubPlanState *asstate;
-				
+
 				if (!parent)
 					elog(ERROR, "AlternativeSubPlan found with no parent plan");
-				
+
 				asstate = ExecInitAlternativeSubPlan(asplan, parent);
-				
+
 				state = (ExprState *) asstate;
 			}
 			break;
@@ -6361,7 +6361,7 @@ ExecVariableList(ProjectionInfo *projInfo,
 		TupleTableSlot *varSlot = *((TupleTableSlot **) slotptr);
 		int			varNumber = varNumbers[i] - 1;
 
-		values[i] = slot_getattr(varSlot, varNumber+1, &(isnull[i])); 
+		values[i] = slot_getattr(varSlot, varNumber+1, &(isnull[i]));
 	}
 }
 
@@ -6542,7 +6542,7 @@ neededColumnContextWalker(Node *node, neededColumnContext *c)
 	{
 		Var *var = (Var *)node;
 
-		if (var->varattno > 0) 
+		if (var->varattno > 0)
 		{
 			Assert(var->varattno <= c->n);
 			c->mask[var->varattno - 1] = true;

--- a/src/pl/plpgsql/src/plpgsql.h
+++ b/src/pl/plpgsql/src/plpgsql.h
@@ -763,7 +763,7 @@ extern PLpgSQL_plugin **plugin_ptr;
  */
 extern PLpgSQL_function *plpgsql_compile(FunctionCallInfo fcinfo,
 				bool forValidator);
-extern PLpgSQL_function *plpgsql_compile_inline(FunctionCallInfo fcinfo, 
+extern PLpgSQL_function *plpgsql_compile_inline(FunctionCallInfo fcinfo,
 				char *proc_source);
 extern int	plpgsql_parse_word(const char *word);
 extern int	plpgsql_parse_dblword(const char *word);


### PR DESCRIPTION
For instance, the simple query:
create table spilltest2 (a integer);
insert into spilltest2 select a from generate_series(1,40000000) a;
Current optimizer would generate FunctionTableScan for generate_series, which stores
result of generate_series in tuple store. Memory leak would happen because memory tuple
binding will be constructed every time in tuplestore_putvalues. It is not only memory leak
problem, also performance problem, because we don't need to construct memory tuple binding
for every row, but just once. This fix just change the interface of tuplestore_putvalues. It
will receive memory tuple binding as input, which is constructed once outside.

resource group case already catches this OOM failure. There is no test case for this fix.