### PR TITLE
Don't fire INSERT or DELETE triggers on UPDATE.

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -3159,18 +3159,13 @@ ExecInsert(TupleTableSlot *slot,
 
 	/* BEFORE ROW INSERT Triggers */
 	if (resultRelInfo->ri_TrigDesc &&
-		resultRelInfo->ri_TrigDesc->n_before_row[TRIGGER_EVENT_INSERT] > 0)
+		resultRelInfo->ri_TrigDesc->n_before_row[TRIGGER_EVENT_INSERT] > 0 &&
+		!isUpdate)
 	{
 		HeapTuple	newtuple;
 		HeapTuple	tuple;
 
 		tuple = ExecFetchSlotHeapTuple(slot);
-
-		/*
-		 * Not implemented for ORCA yet. It should fall back to the Postgres planner
-		 * if there are any before-row triggers.
-		 */
-		Assert(planGen == PLANGEN_PLANNER);
 
 		newtuple = ExecBRInsertTriggers(estate, resultRelInfo, tuple);
 
@@ -3284,7 +3279,8 @@ ExecInsert(TupleTableSlot *slot,
 
 	/* AFTER ROW INSERT Triggers */
 	if (resultRelInfo->ri_TrigDesc &&
-		resultRelInfo->ri_TrigDesc->n_after_row[TRIGGER_EVENT_INSERT] > 0)
+		resultRelInfo->ri_TrigDesc->n_after_row[TRIGGER_EVENT_INSERT] > 0 &&
+		!isUpdate)
 	{
 		HeapTuple tuple = ExecFetchSlotHeapTuple(slot);
 

--- a/src/test/regress/expected/bfv_dml.out
+++ b/src/test/regress/expected/bfv_dml.out
@@ -225,3 +225,28 @@ set optimizer_trace_fallback = on;
 -- in ORCA currently, so we can use that to trigger fallback.
 update update_pk_test set a=1 where row(1,2) = (SELECT 1, 2);
 ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+reset optimizer_trace_fallback;
+--
+-- Check that INSERT and DELETE triggers don't fire on UPDATE.
+--
+-- It may seem weird how that could happen, but with ORCA, UPDATEs are
+-- implemented as a "split update", which is really a DELETE and an INSERT.
+--
+CREATE TABLE bfv_dml_trigger_test (id int4, t text);
+INSERT INTO bfv_dml_trigger_test VALUES (1, 'foo');
+CREATE OR REPLACE FUNCTION bfv_dml_error_func() RETURNS trigger AS
+$$
+BEGIN
+   RAISE EXCEPTION 'trigger was called!';
+   RETURN NEW;
+END
+$$ LANGUAGE 'plpgsql';
+CREATE TRIGGER before_trigger BEFORE INSERT or DELETE ON bfv_dml_trigger_test
+FOR EACH ROW
+EXECUTE PROCEDURE bfv_dml_error_func();
+CREATE TRIGGER after_trigger AFTER INSERT or DELETE ON bfv_dml_trigger_test
+FOR EACH ROW
+EXECUTE PROCEDURE bfv_dml_error_func();
+UPDATE bfv_dml_trigger_test SET t = 'bar';
+UPDATE bfv_dml_trigger_test SET id = id + 1;
+ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns

--- a/src/test/regress/expected/bfv_dml_optimizer.out
+++ b/src/test/regress/expected/bfv_dml_optimizer.out
@@ -243,3 +243,27 @@ set optimizer_trace_fallback = on;
 update update_pk_test set a=1 where row(1,2) = (SELECT 1, 2);
 INFO:  GPORCA failed to produce a plan, falling back to planner
 ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+reset optimizer_trace_fallback;
+--
+-- Check that INSERT and DELETE triggers don't fire on UPDATE.
+--
+-- It may seem weird how that could happen, but with ORCA, UPDATEs are
+-- implemented as a "split update", which is really a DELETE and an INSERT.
+--
+CREATE TABLE bfv_dml_trigger_test (id int4, t text);
+INSERT INTO bfv_dml_trigger_test VALUES (1, 'foo');
+CREATE OR REPLACE FUNCTION bfv_dml_error_func() RETURNS trigger AS
+$$
+BEGIN
+   RAISE EXCEPTION 'trigger was called!';
+   RETURN NEW;
+END
+$$ LANGUAGE 'plpgsql';
+CREATE TRIGGER before_trigger BEFORE INSERT or DELETE ON bfv_dml_trigger_test
+FOR EACH ROW
+EXECUTE PROCEDURE bfv_dml_error_func();
+CREATE TRIGGER after_trigger AFTER INSERT or DELETE ON bfv_dml_trigger_test
+FOR EACH ROW
+EXECUTE PROCEDURE bfv_dml_error_func();
+UPDATE bfv_dml_trigger_test SET t = 'bar';
+UPDATE bfv_dml_trigger_test SET id = id + 1;

--- a/src/test/regress/sql/bfv_dml.sql
+++ b/src/test/regress/sql/bfv_dml.sql
@@ -132,3 +132,35 @@ set optimizer_trace_fallback = on;
 -- Subquery that returns a row rather than a single scalar isn't supported
 -- in ORCA currently, so we can use that to trigger fallback.
 update update_pk_test set a=1 where row(1,2) = (SELECT 1, 2);
+
+reset optimizer_trace_fallback;
+
+
+--
+-- Check that INSERT and DELETE triggers don't fire on UPDATE.
+--
+-- It may seem weird how that could happen, but with ORCA, UPDATEs are
+-- implemented as a "split update", which is really a DELETE and an INSERT.
+--
+CREATE TABLE bfv_dml_trigger_test (id int4, t text);
+
+INSERT INTO bfv_dml_trigger_test VALUES (1, 'foo');
+
+CREATE OR REPLACE FUNCTION bfv_dml_error_func() RETURNS trigger AS
+$$
+BEGIN
+   RAISE EXCEPTION 'trigger was called!';
+   RETURN NEW;
+END
+$$ LANGUAGE 'plpgsql';
+
+CREATE TRIGGER before_trigger BEFORE INSERT or DELETE ON bfv_dml_trigger_test
+FOR EACH ROW
+EXECUTE PROCEDURE bfv_dml_error_func();
+
+CREATE TRIGGER after_trigger AFTER INSERT or DELETE ON bfv_dml_trigger_test
+FOR EACH ROW
+EXECUTE PROCEDURE bfv_dml_error_func();
+
+UPDATE bfv_dml_trigger_test SET t = 'bar';
+UPDATE bfv_dml_trigger_test SET id = id + 1;


### PR DESCRIPTION
With ORCA, an UPDATE is actually implemented as an DELETE + INSERT. Don't
fire INSERT or DELETE triggers in that case.

This was broken by commit 740f304eea. I wonder if we should somehow fire
UPDATE triggers in that case, but I don't see any existing code to do that
either.