### PR TITLE
Fix memory leak in PL/python.

### DIFF
--- a/src/pl/plpython/plpython.c
+++ b/src/pl/plpython/plpython.c
@@ -2904,6 +2904,7 @@ static Datum
 PLyObject_ToDatum(PLyObToDatum *arg, int32 typmod, PyObject *plrv, bool inarray)
 {
 	char	   *str;
+	Datum		rv;
 
 	Assert(plrv != Py_None);
 
@@ -2949,10 +2950,12 @@ PLyObject_ToDatum(PLyObToDatum *arg, int32 typmod, PyObject *plrv, bool inarray)
 					 errhint("To return a composite type in an array, return the composite type as a Python tuple, e.g. \"[('foo')]\"")));
 	}
 
-	return InputFunctionCall(&arg->typfunc,
-							 str,
-							 arg->typioparam,
-							 typmod);
+	rv = InputFunctionCall(&arg->typfunc,
+						   str,
+						   arg->typioparam,
+						   typmod);
+	pfree(str);
+	return rv;
 }
 
 static Datum


### PR DESCRIPTION
Commit eb1740c6a5 backported a bunch of code from upstream, but the
backported code was structured slightly differently. That added a pstrdup()
call, with no corresponding pfree(). That lead to a memory leak in the
executor memory context, which adds up if e.g. the conversion of the
PL/Python function's return value to a Postgres type is very complicated.

This was revealed by a test case that returns a huge array. Converting the
Python array to a PostgreSQL array leaked the string representation of
every element.

create or replace function gen_array(x int)
returns float8[]
as
$$
    from random import random
    return [random() for _ in range(x)]
$$language plpythonu;

EXPLAIN ANALYZE select gen_array(120000000);

I did not add that test case to the regression suite, as there is no
convenient place to add it to. A memory leak just means that it consumes
a lot of memory, which would be difficult to test reliably.

Fixes github issue #3654.