### PR TITLE
Make qp_dml_oids test case more robust.

### DIFF
--- a/src/test/regress/expected/qp_dml_oids.out
+++ b/src/test/regress/expected/qp_dml_oids.out
@@ -2,12 +2,18 @@ create schema qp_dml_oids;
 set search_path='qp_dml_oids';
 DROP TABLE IF EXISTS dml_ao;
 NOTICE:  table "dml_ao" does not exist, skipping
+-- Create a table with OIDS, with a few rows
+--
+-- GPDB doesn't guarantee that OIDs on a user table are unique across nodes. So to
+-- make sure that the OIDs are unique in this test, all the rows have the same
+-- distribution key.
 CREATE TABLE dml_ao (a int , b int default -1, c text) WITH (appendonly = true, oids = true) DISTRIBUTED BY (a);
 NOTICE:  OIDS=TRUE is not recommended for user-created tables. Use OIDS=FALSE to prevent wrap-around of the OID counter
-INSERT INTO dml_ao VALUES(generate_series(1,2),generate_series(1,2),'r');
-INSERT INTO dml_ao VALUES(NULL,NULL,NULL);
+INSERT INTO dml_ao VALUES(1, 1, 'r');
+INSERT INTO dml_ao VALUES(1, 2, 'r');
+INSERT INTO dml_ao VALUES(1,NULL,NULL);
 --
--- DDL on AO/CO tables with OIDS(Negative Test)
+-- Check that UPDATE doesn't change the OIDs of existing rows.
 --
 DROP TABLE IF EXISTS tempoid;
 NOTICE:  table "tempoid" does not exist, skipping
@@ -16,7 +22,26 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a'
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 UPDATE dml_ao SET a = 100;
 ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
-SELECT * FROM ( (SELECT COUNT(*) FROM dml_ao) UNION (SELECT COUNT(*) FROM tempoid, dml_ao WHERE tempoid.oid = dml_ao.oid AND tempoid.gp_segment_id = dml_ao.gp_segment_id))foo;
+select count(distinct oid) from (select oid from tempoid UNION ALL select oid from dml_ao) as x;
+ count 
+-------
+     3
+(1 row)
+
+-- Repeat the test a few times, just to make sure that at least one of these
+-- UPDATEs moved the tuples across segments. To make sure that that doesn't
+-- change the OIDs either.
+UPDATE dml_ao SET a = 101;
+ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+select count(distinct oid) from (select oid from tempoid UNION ALL select oid from dml_ao) as x;
+ count 
+-------
+     3
+(1 row)
+
+UPDATE dml_ao SET a = 102;
+ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+select count(distinct oid) from (select oid from tempoid UNION ALL select oid from dml_ao) as x;
  count 
 -------
      3

--- a/src/test/regress/expected/qp_dml_oids_optimizer.out
+++ b/src/test/regress/expected/qp_dml_oids_optimizer.out
@@ -1,26 +1,50 @@
 create schema qp_dml_oids;
 set search_path='qp_dml_oids';
 DROP TABLE IF EXISTS dml_ao;
+NOTICE:  table "dml_ao" does not exist, skipping
+-- Create a table with OIDS, with a few rows
+--
+-- GPDB doesn't guarantee that OIDs on a user table are unique across nodes. So to
+-- make sure that the OIDs are unique in this test, all the rows have the same
+-- distribution key.
 CREATE TABLE dml_ao (a int , b int default -1, c text) WITH (appendonly = true, oids = true) DISTRIBUTED BY (a);
 NOTICE:  OIDS=TRUE is not recommended for user-created tables. Use OIDS=FALSE to prevent wrap-around of the OID counter
-INSERT INTO dml_ao VALUES(generate_series(1,2),generate_series(1,2),'r');
-INSERT INTO dml_ao VALUES(NULL,NULL,NULL);
+INSERT INTO dml_ao VALUES(1, 1, 'r');
+INSERT INTO dml_ao VALUES(1, 2, 'r');
+INSERT INTO dml_ao VALUES(1,NULL,NULL);
 --
--- DDL on AO/CO tables with OIDS(Negative Test)
+-- Check that UPDATE doesn't change the OIDs of existing rows.
 --
 DROP TABLE IF EXISTS tempoid;
+NOTICE:  table "tempoid" does not exist, skipping
 CREATE TABLE tempoid as SELECT oid,a FROM dml_ao ORDER BY 1;
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 UPDATE dml_ao SET a = 100;
-SELECT * FROM ( (SELECT COUNT(*) FROM dml_ao) UNION (SELECT COUNT(*) FROM tempoid, dml_ao WHERE tempoid.oid = dml_ao.oid AND tempoid.gp_segment_id = dml_ao.gp_segment_id))foo;
+select count(distinct oid) from (select oid from tempoid UNION ALL select oid from dml_ao) as x;
  count 
 -------
-     0
      3
-(2 rows)
+(1 row)
+
+-- Repeat the test a few times, just to make sure that at least one of these
+-- UPDATEs moved the tuples across segments. To make sure that that doesn't
+-- change the OIDs either.
+UPDATE dml_ao SET a = 101;
+select count(distinct oid) from (select oid from tempoid UNION ALL select oid from dml_ao) as x;
+ count 
+-------
+     3
+(1 row)
+
+UPDATE dml_ao SET a = 102;
+select count(distinct oid) from (select oid from tempoid UNION ALL select oid from dml_ao) as x;
+ count 
+-------
+     3
+(1 row)
 
 DROP TABLE IF EXISTS dml_heap_check_r;
+NOTICE:  table "dml_heap_check_r" does not exist, skipping
 CREATE TABLE dml_heap_check_r (
 	a int default 100 CHECK( a between 1 and 105), 
 	b float8 CONSTRAINT rcheck_b CHECK( b <> 0.00 and b IS NOT NULL),


### PR DESCRIPTION
I frequently saw failures when running the test on my laptop with ORCA.
The reason is that the OIDs on a user table are not guaranteed to be
unique across segments in GPDB. Depending on concurrent activity and
timing, the OID counters on different segments are not always in sync,
and can produce duplicates when looked at across all nodes. In fact, I
think the only reason this is currently passing on the pipeline so
reliably as it is, is because the test is run in parallel with other
tests that also create objects, which creates enough noise in the OID
allocations.

To fix, modify the test data in the test so that all the initial test rows
reside on the same segment. Within a segment, the OIDs are unique.