### PR TITLE
resgroup: remove the experimental warning.

### DIFF
--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -142,9 +142,6 @@ class Guc:
 
         elif self.name == "gp_resource_manager":
             if newval == "'group'":
-                LOGGER.warn("Managing queries with resource groups is an "
-                            "experimental feature. A work-in-progress version is "
-                            "enabled.")
                 msg = GpResGroup().validate()
                 if msg is not None:
                     return msg

--- a/src/test/isolation2/expected/resgroup/restore_default_resgroup.out
+++ b/src/test/isolation2/expected/resgroup/restore_default_resgroup.out
@@ -7,7 +7,6 @@
 20170830:00:35:09:440440 gpconfig:sdw6:gpadmin-[INFO]:-completed successfully with parameters '-c gp_resource_group_memory_limit -v 0.9'
 
 ! gpconfig -c gp_resource_manager -v group;
-20170830:00:35:09:440522 gpconfig:sdw6:gpadmin-[WARNING]:-Managing queries with resource groups is an experimental feature. A work-in-progress version is enabled.
 20170830:00:35:10:440522 gpconfig:sdw6:gpadmin-[INFO]:-completed successfully with parameters '-c gp_resource_manager -v group'
 
 ! gpconfig -c max_connections -v 100 -m 40;

--- a/src/test/isolation2/output/resgroup/enable_resgroup.source
+++ b/src/test/isolation2/output/resgroup/enable_resgroup.source
@@ -39,7 +39,6 @@
 ! rm -f /tmp/.resgroup_mem_helper.sh;
 
 ! gpconfig -c gp_resource_manager -v group;
-20170502:01:28:12:000367 gpconfig:sdw6:gpadmin-[WARNING]:-Managing queries with resource groups is an experimental feature. A work-in-progress version is enabled.
 20170502:01:28:13:000367 gpconfig:sdw6:gpadmin-[INFO]:-completed successfully
 
 ! gpconfig -c gp_resource_group_cpu_limit -v 0.9;

--- a/src/test/isolation2/output/resgroup/enable_resgroup_validate.source
+++ b/src/test/isolation2/output/resgroup/enable_resgroup_validate.source
@@ -15,7 +15,6 @@
 
 -- gpdb top group is not created
 ! gpconfig -c gp_resource_manager -v group;
-20170517:11:54:17:011348 gpconfig:nyu-vm-centos:gpadmin-[WARNING]:-Managing queries with resource groups is an experimental feature. A work-in-progress version is enabled.
 20170517:11:54:18:011348 gpconfig:nyu-vm-centos:gpadmin-[CRITICAL]:-new GUC value failed validation: [nyu-vm-centos:cgroup is not properly configured: directory '@cgroup_mnt_point@/cpu/gpdb/' does not exist]
 new GUC value failed validation: [nyu-vm-centos:cgroup is not properly configured: directory '@cgroup_mnt_point@/cpu/gpdb/' does not exist]
 
@@ -31,7 +30,6 @@ new GUC value failed validation: [nyu-vm-centos:cgroup is not properly configure
 
 -- gpdb directory should have rwx permission
 ! gpconfig -c gp_resource_manager -v group;
-20170517:11:54:18:011409 gpconfig:nyu-vm-centos:gpadmin-[WARNING]:-Managing queries with resource groups is an experimental feature. A work-in-progress version is enabled.
 20170517:11:54:18:011409 gpconfig:nyu-vm-centos:gpadmin-[CRITICAL]:-new GUC value failed validation: [nyu-vm-centos:cgroup is not properly configured: directory '@cgroup_mnt_point@/cpu/gpdb/' permission denied: require permission 'rwx']
 new GUC value failed validation: [nyu-vm-centos:cgroup is not properly configured: directory '@cgroup_mnt_point@/cpu/gpdb/' permission denied: require permission 'rwx']
 
@@ -54,7 +52,6 @@ new GUC value failed validation: [nyu-vm-centos:cgroup is not properly configure
 -- cpu.cfs_period_us should have read permission
 -- cpuacct.usage should have read permission
 ! gpconfig -c gp_resource_manager -v group;
-20170517:11:54:18:011466 gpconfig:nyu-vm-centos:gpadmin-[WARNING]:-Managing queries with resource groups is an experimental feature. A work-in-progress version is enabled.
 20170517:11:54:18:011466 gpconfig:nyu-vm-centos:gpadmin-[CRITICAL]:-new GUC value failed validation: [nyu-vm-centos:cgroup is not properly configured: file '@cgroup_mnt_point@/cpu/gpdb/cgroup.procs' permission denied: require permission 'rw']
 new GUC value failed validation: [nyu-vm-centos:cgroup is not properly configured: file '@cgroup_mnt_point@/cpu/gpdb/cgroup.procs' permission denied: require permission 'rw']
 


### PR DESCRIPTION
Currently we show the following experimental warning message, we can
remove it since we will GA on redhat/centos and SuSE official support is
also coming soon. Customers can refer to document for experimental
message for SuSE 11.

```
 gpconfig -c 'gp_resource_manager' -v 'group'
20171101:21:48:19:000469
gpconfig:0de5ce56403a:gpadmin-[WARNING]:-Managing queries with resource
groups is an experimental feature. A work-in-progress version is
enabled.
```