### PR TITLE
misc cleanup on resource group DDL function

### DIFF
--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -394,7 +394,6 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 {
 	Relation	pg_resgroupcapability_rel;
 	Oid			groupid;
-	ResourceGroupAlterCallbackContext *callbackCtx;
 	DefElem		*defel;
 	ResGroupLimitType	limitType;
 	ResGroupCaps		caps;
@@ -441,12 +440,6 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 				 errmsg("admin_group must have at least one concurrency")));
 	}
 
-	/* Argument of callback function should be allocated in heap region */
-	callbackCtx = (ResourceGroupAlterCallbackContext *)
-		MemoryContextAlloc(TopMemoryContext, sizeof(*callbackCtx));
-	callbackCtx->groupid = groupid;
-	callbackCtx->limittype = limitType;
-
 	/*
 	 * In validateCapabilities() we scan all the resource groups
 	 * to check whether the total cpu_rate_limit exceed 100 or not.
@@ -490,6 +483,13 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 
 	if (IsResGroupActivated())
 	{
+		ResourceGroupAlterCallbackContext *callbackCtx;
+
+		/* Argument of callback function should be allocated in heap region */
+		callbackCtx = (ResourceGroupAlterCallbackContext *)
+			MemoryContextAlloc(TopMemoryContext, sizeof(*callbackCtx));
+		callbackCtx->groupid = groupid;
+		callbackCtx->limittype = limitType;
 		callbackCtx->caps = caps;
 		registerResourceGroupCallback(alterResGroupCallback, (void *)callbackCtx);
 	}

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -364,11 +364,11 @@ DropResourceGroup(DropResourceGroupStmt *stmt)
 	 */
 	DeleteSharedComments(groupid, ResGroupRelationId);
 
-	/* metadata tracking */
-	MetaTrackDropObject(ResGroupRelationId, groupid);
-
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
+		/* metadata tracking */
+		MetaTrackDropObject(ResGroupRelationId, groupid);
+
 		CdbDispatchUtilityStatement((Node *) stmt,
 									DF_CANCEL_ON_ERROR|
 									DF_WITH_SNAPSHOT|
@@ -493,6 +493,11 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
+		MetaTrackUpdObject(ResGroupCapabilityRelationId,
+						   groupid,
+						   GetUserId(),
+						   "ALTER", defel->defname);
+
 		CdbDispatchUtilityStatement((Node *) stmt,
 									DF_CANCEL_ON_ERROR|
 									DF_WITH_SNAPSHOT|

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -501,12 +501,6 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 									NULL);
 	}
 
-	/*
-	 * Bump command counter to make this change visible in the callback
-	 * function alterResGroupCommitCallback()
-	 */
-	CommandCounterIncrement();
-
 	if (IsResGroupActivated())
 	{
 		callbackCtx->caps = caps;

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -420,14 +420,11 @@ InitResGroups(void)
 	Relation			relResGroup;
 	Relation			relResGroupCapability;
 
-	/*
-	 * On master, the postmaster does the initialization
-	 * On segments, the first QE does the initialization
-	 */
-	if (Gp_role == GP_ROLE_DISPATCH && GpIdentity.segindex != MASTER_CONTENT_ID)
-		return;
-
 	on_shmem_exit(AtProcExit_ResGroup, 0);
+
+	/*
+	 * On master and segments, the first backend does the initialization.
+	 */
 	if (pResGroupControl->loaded)
 		return;
 	/*

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -998,7 +998,6 @@ ResGroupDecideConcurrencyCaps(Oid groupId,
 	/* If resource group is not in use we can always pick the new settings. */
 	if (!IsResGroupActivated())
 	{
-		caps->concurrency.value = opts->concurrency;
 		caps->concurrency.proposed = opts->concurrency;
 		return;
 	}

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -397,7 +397,7 @@ AllocResGroupEntry(Oid groupId, const ResGroupCaps *caps)
 
 	LWLockAcquire(ResGroupLock, LW_EXCLUSIVE);
 
-	group = ResGroupCreate(groupId, caps);
+	group = createGroup(groupId, caps);
 	Assert(group != NULL);
 
 	LWLockRelease(ResGroupLock);
@@ -478,7 +478,7 @@ InitResGroups(void)
 		int cpuRateLimit;
 		Oid groupId = HeapTupleGetOid(tuple);
 
-		GetResGroupCapabilities(groupId, &caps);
+		GetResGroupCapabilities(relResGroupCapability, groupId, &caps);
 		cpuRateLimit = caps.cpuRateLimit;
 
 		group = createGroup(groupId, &caps);
@@ -497,6 +497,11 @@ InitResGroups(void)
 
 exit:
 	LWLockRelease(ResGroupLock);
+
+	/*
+	 * release lock here to guarantee we have no lock held when acquiring
+	 * resource group slot
+	 */
 	heap_close(relResGroup, AccessShareLock);
 	heap_close(relResGroupCapability, AccessShareLock);
 	CurrentResourceOwner = NULL;

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -654,7 +654,7 @@ ResGroupAlterOnCommit(Oid groupId,
 		{
 			ResGroupOps_SetCpuRateLimit(groupId, caps->cpuRateLimit);
 		}
-		else
+		else if (limittype != RESGROUP_LIMIT_TYPE_MEMORY_SPILL_RATIO)
 		{
 			shouldWakeUp = groupApplyMemCaps(group, caps);
 

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -895,9 +895,9 @@ ResGroupReserveMemory(int32 memoryChunks, int32 overuseChunks, bool *waiverUsed)
 		selfUnassignDroppedGroup();
 		self->doMemCheck = false;
 
-		LOG_RESGROUP_DEBUG(LOG, "resource group is concurrently dropped while reserving memory: "
-						   "dropped group=%d, my group=%d",
-						   groupGroupId, selfGroupId);
+		LOG_RESGROUP_DEBUG(LOG, "resource group is concurrently dropped while "
+							"reserving memory: dropped group=%d, my group=%d",
+							groupGroupId, selfGroupId);
 
 		return true;
 	}
@@ -967,9 +967,9 @@ ResGroupReleaseMemory(int32 memoryChunks)
 		selfUnassignDroppedGroup();
 		self->doMemCheck = false;
 
-		LOG_RESGROUP_DEBUG(LOG, "resource group is concurrently dropped while releasing memory: "
-						   "dropped group=%d, my group=%d",
-						   groupGroupId, selfGroupId);
+		LOG_RESGROUP_DEBUG(LOG, "resource group is concurrently dropped while "
+							"releasing memory: dropped group=%d, my group=%d",
+							groupGroupId, selfGroupId);
 
 		return;
 	}
@@ -2014,8 +2014,10 @@ addTotalQueueDuration(ResGroupData *group)
 
 	TimestampTz start = pgstat_fetch_resgroup_queue_timestamp();
 	TimestampTz now = GetCurrentTimestamp();
-	Datum durationDatum = DirectFunctionCall2(timestamptz_age, TimestampTzGetDatum(now), TimestampTzGetDatum(start));
-	Datum sumDatum = DirectFunctionCall2(interval_pl, IntervalPGetDatum(&group->totalQueuedTime), durationDatum);
+	Datum durationDatum = DirectFunctionCall2(timestamptz_age,
+						TimestampTzGetDatum(now), TimestampTzGetDatum(start));
+	Datum sumDatum = DirectFunctionCall2(interval_pl,
+						IntervalPGetDatum(&group->totalQueuedTime), durationDatum);
 	memcpy(&group->totalQueuedTime, DatumGetIntervalP(sumDatum), sizeof(Interval));
 }
 
@@ -2488,7 +2490,10 @@ groupHashRemove(Oid groupId)
 
 	Assert(LWLockHeldExclusiveByMe(ResGroupLock));
 
-	entry = (ResGroupHashEntry*)hash_search(pResGroupControl->htbl, (void *) &groupId, HASH_FIND, &found);
+	entry = (ResGroupHashEntry*)hash_search(pResGroupControl->htbl,
+											(void *) &groupId,
+											HASH_REMOVE,
+											&found);
 	if (!found)
 		ereport(ERROR,
 				(errcode(ERRCODE_DATA_CORRUPTED),
@@ -2500,8 +2505,6 @@ groupHashRemove(Oid groupId)
 	group->memQuotaGranted = 0;
 	group->memSharedGranted = 0;
 	group->groupId = InvalidOid;
-
-	hash_search(pResGroupControl->htbl, (void *) &groupId, HASH_REMOVE, &found);
 
 	wakeupGroups(groupId);
 }
@@ -2595,7 +2598,8 @@ groupSetMemorySpillRatio(const ResGroupCaps *caps)
 	char value[64];
 
 	snprintf(value, sizeof(value), "%d", caps->memSpillRatio.proposed);
-	set_config_option("memory_spill_ratio", value, PGC_USERSET, PGC_S_RESGROUP, GUC_ACTION_SET, true);
+	set_config_option("memory_spill_ratio", value, PGC_USERSET, PGC_S_RESGROUP,
+			GUC_ACTION_SET, true);
 }
 
 void
@@ -3287,7 +3291,8 @@ resgroupDumpCaps(StringInfo str, ResGroupCap *caps)
 	appendStringInfo(str, "\"caps\":[");
 	for (i = 1; i < RESGROUP_LIMIT_TYPE_COUNT; i++)
 	{
-		appendStringInfo(str, "{\"value\":%d,\"proposed\":%d}", caps[i].value, caps[i].proposed);
+		appendStringInfo(str, "{\"value\":%d,\"proposed\":%d}",
+						caps[i].value, caps[i].proposed);
 		if (i < RESGROUP_LIMIT_TYPE_COUNT - 1)
 			appendStringInfo(str, ",");
 	}

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -896,8 +896,8 @@ ResGroupReserveMemory(int32 memoryChunks, int32 overuseChunks, bool *waiverUsed)
 		self->doMemCheck = false;
 
 		LOG_RESGROUP_DEBUG(LOG, "resource group is concurrently dropped while "
-							"reserving memory: dropped group=%d, my group=%d",
-							groupGroupId, selfGroupId);
+						   "reserving memory: dropped group=%d, my group=%d",
+						   groupGroupId, selfGroupId);
 
 		return true;
 	}
@@ -968,8 +968,8 @@ ResGroupReleaseMemory(int32 memoryChunks)
 		self->doMemCheck = false;
 
 		LOG_RESGROUP_DEBUG(LOG, "resource group is concurrently dropped while "
-							"releasing memory: dropped group=%d, my group=%d",
-							groupGroupId, selfGroupId);
+						   "releasing memory: dropped group=%d, my group=%d",
+						   groupGroupId, selfGroupId);
 
 		return;
 	}
@@ -1921,9 +1921,11 @@ addTotalQueueDuration(ResGroupData *group)
 	TimestampTz start = pgstat_fetch_resgroup_queue_timestamp();
 	TimestampTz now = GetCurrentTimestamp();
 	Datum durationDatum = DirectFunctionCall2(timestamptz_age,
-						TimestampTzGetDatum(now), TimestampTzGetDatum(start));
+											  TimestampTzGetDatum(now),
+											  TimestampTzGetDatum(start));
 	Datum sumDatum = DirectFunctionCall2(interval_pl,
-						IntervalPGetDatum(&group->totalQueuedTime), durationDatum);
+										 IntervalPGetDatum(&group->totalQueuedTime),
+										 durationDatum);
 	memcpy(&group->totalQueuedTime, DatumGetIntervalP(sumDatum), sizeof(Interval));
 }
 

--- a/src/bin/pg_dump/pg_dumpall.c
+++ b/src/bin/pg_dump/pg_dumpall.c
@@ -636,11 +636,11 @@ dumpResGroups(PGconn *conn)
 			i_memory_spill_ratio;
 
 	printfPQExpBuffer(buf, "SELECT g.rsgname AS groupname, "
-					  "t1.proposed AS concurrency, "
-					  "t2.proposed AS cpu_rate_limit, "
-					  "t3.proposed AS memory_limit, "
-					  "t4.proposed AS memory_shared_quota, "
-					  "t5.proposed AS memory_spill_ratio "
+					  "t1.value AS concurrency, "
+					  "t2.value AS cpu_rate_limit, "
+					  "t3.value AS memory_limit, "
+					  "t4.value AS memory_shared_quota, "
+					  "t5.value AS memory_spill_ratio "
 					  "FROM pg_resgroup g, "
 					  "pg_resgroupcapability t1, "
 					  "pg_resgroupcapability t2, "

--- a/src/include/catalog/pg_resgroup.h
+++ b/src/include/catalog/pg_resgroup.h
@@ -77,6 +77,13 @@ typedef enum ResGroupLimitType
 	RESGROUP_LIMIT_TYPE_COUNT,
 } ResGroupLimitType;
 
+/*
+ * TODO:
+ * Alter resource like memory and concurrency cannot take effect immediately,
+ * so we introduce `proposed` for each capability to implement progressively 
+ * change. Turns out we don't really need it and we should remove it in 6.0.
+ * For now, `value` always equals to `proposed`.
+ */
 CATALOG(pg_resgroupcapability,6439) BKI_SHARED_RELATION
 {
 	Oid		resgroupid;	/* OID of the group with this capability  */

--- a/src/include/catalog/pg_resgroup.h
+++ b/src/include/catalog/pg_resgroup.h
@@ -77,13 +77,6 @@ typedef enum ResGroupLimitType
 	RESGROUP_LIMIT_TYPE_COUNT,
 } ResGroupLimitType;
 
-/*
- * TODO:
- * Alter resource like memory and concurrency cannot take effect immediately,
- * so we introduce `proposed` for each capability to implement progressively 
- * change. Turns out we don't really need it and we should remove it in 6.0.
- * For now, `value` always equals to `proposed`.
- */
 CATALOG(pg_resgroupcapability,6439) BKI_SHARED_RELATION
 {
 	Oid		resgroupid;	/* OID of the group with this capability  */

--- a/src/include/commands/resgroupcmds.h
+++ b/src/include/commands/resgroupcmds.h
@@ -17,8 +17,6 @@
 #include "nodes/parsenodes.h"
 #include "utils/resgroup.h"
 
-#define RESGROUP_MAX_MEMORY_LIMIT	(100)
-
 extern void CreateResourceGroup(CreateResourceGroupStmt *stmt);
 extern void DropResourceGroup(DropResourceGroupStmt *stmt);
 extern void AlterResourceGroup(AlterResourceGroupStmt *stmt);

--- a/src/include/commands/resgroupcmds.h
+++ b/src/include/commands/resgroupcmds.h
@@ -16,6 +16,7 @@
 
 #include "nodes/parsenodes.h"
 #include "utils/resgroup.h"
+#include "utils/relcache.h"
 
 extern void CreateResourceGroup(CreateResourceGroupStmt *stmt);
 extern void DropResourceGroup(DropResourceGroupStmt *stmt);
@@ -25,7 +26,9 @@ extern void AlterResourceGroup(AlterResourceGroupStmt *stmt);
 extern Oid GetResGroupIdForName(char *name, LOCKMODE lockmode);
 extern char *GetResGroupNameForId(Oid oid, LOCKMODE lockmode);
 extern Oid GetResGroupIdForRole(Oid roleid);
-extern void GetResGroupCapabilities(Oid groupId, ResGroupCaps *resgroupCaps);
+extern void GetResGroupCapabilities(Relation rel,
+									Oid groupId,
+									ResGroupCaps *resgroupCaps);
 extern void AtEOXact_ResGroup(bool isCommit);
 
 #endif   /* RESGROUPCMDS_H */

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -27,11 +27,7 @@
 /*
  * Resource group capability.
  */
-typedef struct ResGroupCap
-{
-	int		value;
-	int		proposed;
-} ResGroupCap;
+typedef int32 ResGroupCap;
 
 /*
  * Resource group capabilities.
@@ -59,33 +55,6 @@ typedef struct ResGroupCaps
 	ResGroupCap		memSharedQuota;
 	ResGroupCap		memSpillRatio;
 } ResGroupCaps;
-
-/*
- * Resource group setting options.
- *
- * These can represent the effective settings of a resource group,
- * or the new settings from ALTER RESOURCE GROUP syntax.
- *
- * The properties must be in the same order as ResGroupLimitType.
- *
- * This struct can also be converted to an array of int32 so the fields
- * can be accessed via index and iterated with loop.
- *
- *     ResGroupOpts opts;
- *     int32 *array = (int32 *) &opts;
- *     opts.concurrency = 1;
- *     array[RESGROUP_LIMIT_TYPE_CONCURRENCY] = 2;
- *     Assert(opts.concurrency == 2);
- */
-typedef struct ResGroupOpts
-{
-	int32			__unknown;			/* placeholder, do not use it */
-	int32			concurrency;
-	int32			cpuRateLimit;
-	int32			memLimit;
-	int32			memSharedQuota;
-	int32			memSpillRatio;
-} ResGroupOpts;
 
 /*
  * GUC variables.
@@ -134,7 +103,7 @@ extern void ResGroupControlInit(void);
 /* Load resource group information from catalog */
 extern void	InitResGroups(void);
 
-extern void AllocResGroupEntry(Oid groupId, const ResGroupOpts *opts);
+extern void AllocResGroupEntry(Oid groupId, const ResGroupCaps *caps);
 
 extern void SerializeResGroupInfo(StringInfo str);
 extern void DeserializeResGroupInfo(struct ResGroupCaps *capsOut,
@@ -151,8 +120,6 @@ extern void SwitchResGroupOnSegment(const char *buf, int len);
 /* Retrieve statistic information of type from resource group */
 extern Datum ResGroupGetStat(Oid groupId, ResGroupStatType type);
 
-extern void ResGroupOptsToCaps(const ResGroupOpts *optsIn, ResGroupCaps *capsOut);
-extern void ResGroupCapsToOpts(const ResGroupCaps *capsIn, ResGroupOpts *optsOut);
 extern void ResGroupDumpMemoryInfo(void);
 
 /* Check the memory limit of resource group */
@@ -166,12 +133,6 @@ extern void ResGroupAlterOnCommit(Oid groupId,
 								  ResGroupLimitType limittype,
 								  const ResGroupCaps *caps);
 extern void ResGroupCheckForDrop(Oid groupId, char *name);
-extern void ResGroupDecideMemoryCaps(int groupId,
-									 ResGroupCaps *caps,
-									 const ResGroupOpts *opts);
-extern void ResGroupDecideConcurrencyCaps(Oid groupId,
-										  ResGroupCaps *caps,
-										  const ResGroupOpts *opts);
 
 extern int32 ResGroupGetVmemLimitChunks(void);
 extern int32 ResGroupGetVmemChunkSizeInBits(void);

--- a/src/test/isolation2/expected/resgroup/resgroup_alter_memory_spill_ratio.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_alter_memory_spill_ratio.out
@@ -60,7 +60,7 @@ rg_spill_test|20                 |20                          |81               
 
 -- negative: memory_spill_ratio is larger than RESGROUP_MAX_MEMORY_SPILL_RATIO
 ALTER RESOURCE GROUP rg_spill_test SET MEMORY_SPILL_RATIO 101;
-ERROR:  memory spill ratio cannot be greater than 100
+ERROR:  memory_spill_ratio range is [0, 100]
 SELECT * FROM rg_spill_status;
 groupname    |memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
 -------------+-------------------+----------------------------+------------------+---------------------------

--- a/src/test/isolation2/expected/resgroup/resgroup_concurrency.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_concurrency.out
@@ -167,7 +167,7 @@ ALTER
 SELECT concurrency,proposed_concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
 concurrency|proposed_concurrency
 -----------+--------------------
-3          |2                   
+2          |2                   
 (1 row)
 -- When one transaction is finished, queueing transaction won't be woken up. There're 2 running transactions and 1 queueing transaction.
 24:END;

--- a/src/test/isolation2/expected/resgroup/resgroup_syntax.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_syntax.out
@@ -270,9 +270,9 @@ CREATE
 ALTER RESOURCE GROUP admin_group SET CONCURRENCY 0;
 ERROR:  admin_group must have at least one concurrency
 ALTER RESOURCE GROUP rg_test_group SET CONCURRENCY -1;
-ERROR:  concurrency limit cannot be less than 0
+ERROR:  concurrency range is [0, 'max_connections']
 ALTER RESOURCE GROUP rg_test_group SET CONCURRENCY 26;
-ERROR:  concurrency limit cannot be greater than 'max_connections'
+ERROR:  concurrency range is [0, 'max_connections']
 ALTER RESOURCE GROUP rg_test_group SET CONCURRENCY -0.5;
 ERROR:  syntax error at or near "0.5"
 LINE 1: ALTER RESOURCE GROUP rg_test_group SET CONCURRENCY -0.5;
@@ -310,9 +310,9 @@ ERROR:  syntax error at or near "0.1"
 LINE 1: ALTER RESOURCE GROUP rg_test_group SET CPU_RATE_LIMIT -0.1;
                                                                ^
 ALTER RESOURCE GROUP rg_test_group SET CPU_RATE_LIMIT -1;
-ERROR:  cpu rate limit cannot be less than 1
+ERROR:  cpu_rate_limit range is [1, 100]
 ALTER RESOURCE GROUP rg_test_group SET CPU_RATE_LIMIT 0;
-ERROR:  cpu rate limit cannot be less than 1
+ERROR:  cpu_rate_limit range is [1, 100]
 ALTER RESOURCE GROUP rg_test_group SET CPU_RATE_LIMIT 0.7;
 ERROR:  syntax error at or near "0.7"
 LINE 1: ALTER RESOURCE GROUP rg_test_group SET CPU_RATE_LIMIT 0.7;

--- a/src/test/isolation2/expected/resgroup/resgroup_unlimit_memory_spill_ratio.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_unlimit_memory_spill_ratio.out
@@ -40,9 +40,9 @@ ALTER
 ALTER RESOURCE GROUP rg_spill_test SET MEMORY_SPILL_RATIO 100;
 ALTER
 ALTER RESOURCE GROUP rg_spill_test SET MEMORY_SPILL_RATIO -1;
-ERROR:  memory spill ratio cannot be less than 0
+ERROR:  memory_spill_ratio range is [0, 100]
 ALTER RESOURCE GROUP rg_spill_test SET MEMORY_SPILL_RATIO 101;
-ERROR:  memory spill ratio cannot be greater than 100
+ERROR:  memory_spill_ratio range is [0, 100]
 
 DROP RESOURCE GROUP rg_spill_test;
 DROP

--- a/src/test/isolation2/output/resgroup/resgroup_alter_memory.source
+++ b/src/test/isolation2/output/resgroup/resgroup_alter_memory.source
@@ -94,7 +94,7 @@ ALTER
 SELECT * FROM rg_mem_status;
 groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
 ---------------+------------+---------------------+-------------------+----------------------------
-rg1_memory_test|60          |60                   |70                 |80                          
+rg1_memory_test|60          |60                   |80                 |80                          
 (1 row)
 
 1q: ... <quitting>
@@ -227,7 +227,7 @@ ALTER
 SELECT * FROM rg_mem_status;
 groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
 ---------------+------------+---------------------+-------------------+----------------------------
-rg1_memory_test|50          |60                   |60                 |60                          
+rg1_memory_test|60          |60                   |60                 |60                          
 (1 row)
 
 ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 40;
@@ -253,7 +253,7 @@ ALTER
 SELECT * FROM rg_mem_status;
 groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
 ---------------+------------+---------------------+-------------------+----------------------------
-rg1_memory_test|40          |10                   |60                 |60                          
+rg1_memory_test|10          |10                   |60                 |60                          
 (1 row)
 
 --
@@ -291,7 +291,7 @@ ALTER
 SELECT * FROM rg_mem_status;
 groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
 ---------------+------------+---------------------+-------------------+----------------------------
-rg1_memory_test|40          |40                   |60                 |20                          
+rg1_memory_test|40          |40                   |20                 |20                          
 (1 row)
 
 ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 30;
@@ -302,7 +302,7 @@ ALTER
 SELECT * FROM rg_mem_status;
 groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
 ---------------+------------+---------------------+-------------------+----------------------------
-rg1_memory_test|40          |30                   |60                 |20                          
+rg1_memory_test|30          |30                   |20                 |20                          
 (1 row)
 
 1q: ... <quitting>
@@ -345,7 +345,7 @@ ALTER
 SELECT * FROM rg_mem_status;
 groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
 ---------------+------------+---------------------+-------------------+----------------------------
-rg1_memory_test|30          |40                   |0                  |0                           
+rg1_memory_test|40          |40                   |0                  |0                           
 rg2_memory_test|20          |20                   |0                  |0                           
 (2 rows)
 
@@ -410,8 +410,8 @@ BEGIN
 SELECT * FROM rg_mem_status;
 groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
 ---------------+------------+---------------------+-------------------+----------------------------
-rg1_memory_test|30          |15                   |0                  |0                           
-rg2_memory_test|30          |40                   |0                  |0                           
+rg1_memory_test|15          |15                   |0                  |0                           
+rg2_memory_test|40          |40                   |0                  |0                           
 (2 rows)
 SELECT * FROM rg_activity_status;
 rsgname        |waiting_reason|current_query        
@@ -431,8 +431,8 @@ rg2_memory_test|              |<IDLE> in transaction
 SELECT * FROM rg_mem_status;
 groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
 ---------------+------------+---------------------+-------------------+----------------------------
-rg1_memory_test|30          |15                   |0                  |0                           
-rg2_memory_test|30          |40                   |0                  |0                           
+rg1_memory_test|15          |15                   |0                  |0                           
+rg2_memory_test|40          |40                   |0                  |0                           
 (2 rows)
 SELECT * FROM rg_activity_status;
 rsgname        |waiting_reason|current_query        
@@ -451,8 +451,8 @@ BEGIN
 SELECT * FROM rg_mem_status;
 groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
 ---------------+------------+---------------------+-------------------+----------------------------
-rg1_memory_test|30          |15                   |0                  |0                           
-rg2_memory_test|30          |40                   |0                  |0                           
+rg1_memory_test|15          |15                   |0                  |0                           
+rg2_memory_test|40          |40                   |0                  |0                           
 (2 rows)
 SELECT * FROM rg_activity_status;
 rsgname        |waiting_reason|current_query        
@@ -536,8 +536,8 @@ SET
 SELECT * FROM rg_mem_status;
 groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
 ---------------+------------+---------------------+-------------------+----------------------------
-rg1_memory_test|30          |15                   |0                  |0                           
-rg2_memory_test|30          |40                   |0                  |0                           
+rg1_memory_test|15          |15                   |0                  |0                           
+rg2_memory_test|40          |40                   |0                  |0                           
 (2 rows)
 SELECT * FROM rg_activity_status;
 rsgname        |waiting_reason|current_query        
@@ -557,8 +557,8 @@ END
 SELECT * FROM rg_mem_status;
 groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
 ---------------+------------+---------------------+-------------------+----------------------------
-rg1_memory_test|30          |15                   |0                  |0                           
-rg2_memory_test|30          |40                   |0                  |0                           
+rg1_memory_test|15          |15                   |0                  |0                           
+rg2_memory_test|40          |40                   |0                  |0                           
 (2 rows)
 SELECT * FROM rg_activity_status;
 rsgname        |waiting_reason|current_query        
@@ -581,8 +581,8 @@ BEGIN
 SELECT * FROM rg_mem_status;
 groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
 ---------------+------------+---------------------+-------------------+----------------------------
-rg1_memory_test|30          |15                   |0                  |0                           
-rg2_memory_test|30          |40                   |0                  |0                           
+rg1_memory_test|15          |15                   |0                  |0                           
+rg2_memory_test|40          |40                   |0                  |0                           
 (2 rows)
 SELECT * FROM rg_activity_status;
 rsgname        |waiting_reason|current_query        
@@ -666,8 +666,8 @@ SET
 SELECT * FROM rg_mem_status;
 groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
 ---------------+------------+---------------------+-------------------+----------------------------
-rg1_memory_test|30          |20                   |60                 |60                          
-rg2_memory_test|30          |40                   |0                  |0                           
+rg1_memory_test|20          |20                   |60                 |60                          
+rg2_memory_test|40          |40                   |0                  |0                           
 (2 rows)
 SELECT * FROM rg_activity_status;
 rsgname        |waiting_reason|current_query        
@@ -693,7 +693,7 @@ SELECT * FROM rg_mem_status;
 groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
 ---------------+------------+---------------------+-------------------+----------------------------
 rg1_memory_test|20          |20                   |30                 |30                          
-rg2_memory_test|30          |40                   |0                  |0                           
+rg2_memory_test|40          |40                   |0                  |0                           
 (2 rows)
 SELECT * FROM rg_activity_status;
 rsgname        |waiting_reason|current_query        
@@ -790,8 +790,8 @@ SET
 SELECT * FROM rg_mem_status;
 groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
 ---------------+------------+---------------------+-------------------+----------------------------
-rg1_memory_test|30          |20                   |90                 |90                          
-rg2_memory_test|30          |40                   |0                  |0                           
+rg1_memory_test|20          |20                   |90                 |90                          
+rg2_memory_test|40          |40                   |0                  |0                           
 (2 rows)
 SELECT * FROM rg_activity_status;
 rsgname        |waiting_reason|current_query        
@@ -810,8 +810,8 @@ ALTER
 SELECT * FROM rg_mem_status;
 groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
 ---------------+------------+---------------------+-------------------+----------------------------
-rg1_memory_test|30          |20                   |90                 |30                          
-rg2_memory_test|30          |40                   |0                  |0                           
+rg1_memory_test|20          |20                   |30                 |30                          
+rg2_memory_test|40          |40                   |0                  |0                           
 (2 rows)
 SELECT * FROM rg_activity_status;
 rsgname        |waiting_reason|current_query        
@@ -834,8 +834,8 @@ BEGIN
 SELECT * FROM rg_mem_status;
 groupname      |memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota
 ---------------+------------+---------------------+-------------------+----------------------------
-rg1_memory_test|30          |20                   |90                 |30                          
-rg2_memory_test|30          |40                   |0                  |0                           
+rg1_memory_test|20          |20                   |30                 |30                          
+rg2_memory_test|40          |40                   |0                  |0                           
 (2 rows)
 SELECT * FROM rg_activity_status;
 rsgname        |waiting_reason|current_query        


### PR DESCRIPTION
We introduced 'proposed' in pg_resgroupcapability, to deal with the problem that ALTER on memory and concurrency cannot take effect immediately. In the later implementation, we find it's not necessary. Currently, we make `value` always equal to `proposed`, and will remove it in the future.

Signed-off-by: Ning Yu <nyu@pivotal.io>