### PR TITLE
Switch to unified diff format for regression.diffs

### DIFF
--- a/src/test/regress/pg_regress.c
+++ b/src/test/regress/pg_regress.c
@@ -75,7 +75,7 @@ static char gpstringsubsprog[MAXPGPATH];
 /* currently we can use the same diff switches on all platforms */
 /* MPP:  Add stuff to ignore all the extra NOTICE messages we give */
 const char *basic_diff_opts = "-w -I HINT: -I CONTEXT: -I GP_IGNORE:";
-const char *pretty_diff_opts = "-w -I HINT: -I CONTEXT: -I GP_IGNORE: -C3";
+const char *pretty_diff_opts = "-w -I HINT: -I CONTEXT: -I GP_IGNORE: -U3";
 
 /* options settable from command line */
 _stringlist *dblist = NULL;


### PR DESCRIPTION
This is more of an RFC than anything else, since this is an opinion-based change and I expect there will be a few more opinions.

A big part of Postgres merge work is staring at failing tests that you have never seen in your life and trying to decipher why they've failed. IMHO the context diff format that we're currently using in our regression suite makes this more difficult than it needs to be, when paired with the output of `gpdiff.pl`.

As an example, take a look at this [recent failure from the merge pipeline](https://gpdb.data.pivotal.ci/teams/main/pipelines/postgres_merge/jobs/icw_planner_centos6/builds/67). I can see that diffs _exist_ -- look at all the exclamation points! -- but I have to scroll all over the place before I know what those diffs _are_. And I constantly match up the wrong lines in my head.

Compare with a [unified diff output](https://gist.github.com/jchampio/80e0301e00e0b7b7be362beb0f6e237a) of the same test failure, run locally on my machine. The lines that have changed are right next to each other, instead of separated by a screen. (It's even better with local syntax highlighting, but we can't take advantage of that in the Concourse output).

Other thoughts? opinions? Are there any automated pieces of our stack that require the context diff output? Are there any platforms we support that can't handle the `-U` option to `diff`? Would this be a major headache for anyone?