### PR TITLE
Add unit tests for append-optimized usage of invalid_page_tab hash table

### DIFF
--- a/src/backend/access/transam/test/Makefile
+++ b/src/backend/access/transam/test/Makefile
@@ -4,6 +4,10 @@ include $(top_builddir)/src/Makefile.global
 
 TARGETS=xact distributedlog xlog
 
+ifeq ($(enable_segwalrep), yes)
+TARGETS += xlogutils xlog_mm
+endif
+
 include $(top_builddir)/src/backend/mock.mk
 
 distributedlog.t: \
@@ -17,3 +21,7 @@ xact.t: \
 
 xlog.t: \
     $(MOCK_DIR)/backend/replication/walsender_mock.o
+
+xlog_mm.t: \
+	$(MOCK_DIR)/backend/access/transam/xlogutils_mock.o \
+	$(MOCK_DIR)/backend/cdb/cdbmirroredappendonly_mock.o

--- a/src/backend/access/transam/test/xlog_mm_test.c
+++ b/src/backend/access/transam/test/xlog_mm_test.c
@@ -1,0 +1,87 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include "cmockery.h"
+
+#include "../xlog_mm.c"
+
+static const XLogRecPtr InvalidXLogRecPtr = {0, 0};
+
+static int
+check_relfilenode_function(const RelFileNode *value, const RelFileNode *check_value)
+{
+	return RelFileNodeEquals(*value, *check_value);
+}
+
+/*
+ * Test that an MMXLOG_REMOVE_FILE AO transaction log record will call
+ * XLogAODropSegmentFile.
+ */
+void
+test_mmxlog_redo_mmxlog_remove_file_ao(void **state)
+{
+	RelFileNode relfilenode;
+	XLogRecord record;
+	XLogRecord *mockrecord;
+	xl_mm_fs_obj xlmmfsobj;
+	char *buffer;
+
+	/* Set our dbid */
+	GpIdentity.dbid = 4;
+
+	/* create mock relfilenode */
+	relfilenode.spcNode = DEFAULTTABLESPACE_OID;
+	relfilenode.dbNode = 12087 /* postgres database */;
+	relfilenode.relNode = FirstNormalObjectId;
+
+	/* create mock transaction log */
+	xlmmfsobj.objtype = MM_OBJ_RELFILENODE;
+	xlmmfsobj.filespace = SYSTEMFILESPACE_OID;
+	xlmmfsobj.tablespace = relfilenode.spcNode;
+	xlmmfsobj.database = relfilenode.dbNode;
+	xlmmfsobj.relfilenode = relfilenode.relNode;
+	xlmmfsobj.segnum = 2;
+
+	xlmmfsobj.u.dbid.master = 1;
+	xlmmfsobj.u.dbid.mirror = GpIdentity.dbid;
+
+	sprintf(xlmmfsobj.master_path, "./base/%d/%d", xlmmfsobj.database, xlmmfsobj.relfilenode);
+	sprintf(xlmmfsobj.mirror_path, "./base/%d/%d", xlmmfsobj.database, xlmmfsobj.relfilenode);
+
+	record.xl_info = MMXLOG_REMOVE_FILE;
+	record.xl_rmid = RM_MMXLOG_ID;
+	record.xl_len = 0;
+
+	buffer = (char *) malloc(SizeOfXLogRecord + sizeof(xl_mm_fs_obj));
+	memcpy(buffer, &record, SizeOfXLogRecord);
+	memcpy(&buffer[SizeOfXLogRecord], &xlmmfsobj, sizeof(xl_mm_fs_obj));
+	mockrecord = (XLogRecord *) buffer;
+
+	/* XLogAODropSegmentFile should be called with our mock relfilenode and segment file number */
+	expect_check(XLogAODropSegmentFile, &rnode, check_relfilenode_function, &relfilenode);
+	expect_value(XLogAODropSegmentFile, segmentFileNum, xlmmfsobj.segnum);
+	will_be_called(XLogAODropSegmentFile);
+
+	/* mock MirroredAppendOnly_Drop to skip */
+	expect_check(MirroredAppendOnly_Drop, relFileNode, check_relfilenode_function, &relfilenode);
+	expect_value(MirroredAppendOnly_Drop, segmentFileNum, xlmmfsobj.segnum);
+	expect_value(MirroredAppendOnly_Drop, relationName, NULL);
+	expect_value(MirroredAppendOnly_Drop, primaryOnly, true);
+	expect_not_value(MirroredAppendOnly_Drop, primaryError, NULL);
+	expect_not_value(MirroredAppendOnly_Drop, mirrorDataLossOccurred, NULL);
+	will_be_called(MirroredAppendOnly_Drop);
+
+	/* test that mmxlog_redo properly calls XLogAODropSegmentFile */
+	mmxlog_redo(InvalidXLogRecPtr, InvalidXLogRecPtr, mockrecord);
+}
+
+int
+main(int argc, char* argv[])
+{
+	cmockery_parse_arguments(argc, argv);
+
+	const UnitTest tests[] = {
+		unit_test(test_mmxlog_redo_mmxlog_remove_file_ao)
+	};
+	return run_tests(tests);
+}

--- a/src/backend/access/transam/test/xlogutils_test.c
+++ b/src/backend/access/transam/test/xlogutils_test.c
@@ -1,0 +1,51 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include "cmockery.h"
+
+#include "../xlogutils.c"
+
+/*
+ * Test that the invalid_page_tab hash table is properly used when invalid AO
+ * segment files are encountered.
+ */
+void
+test_ao_invalid_segment_file(void **state)
+{
+	RelFileNode relfilenode;
+	int32 segmentFileNum;
+
+	/* create mock relfilenode */
+	relfilenode.spcNode = DEFAULTTABLESPACE_OID;
+	relfilenode.dbNode = 12087 /* postgres database */;
+	relfilenode.relNode = FirstNormalObjectId;
+
+	segmentFileNum = 2;
+
+	/* invalid_page_tab should not be initialized */
+	assert_true(invalid_page_tab == NULL);
+
+	/* initialize invalid_page_tab and log an invalid AO segment file */
+	XLogAOSegmentFile(relfilenode, segmentFileNum);
+	assert_false(invalid_page_tab == NULL);
+	assert_int_equal(hash_get_num_entries(invalid_page_tab), 1);
+
+	/* try again but should not put in same entry */
+	XLogAOSegmentFile(relfilenode, segmentFileNum);
+	assert_int_equal(hash_get_num_entries(invalid_page_tab), 1);
+
+	/* forget the invalid AO segment file */
+	XLogAODropSegmentFile(relfilenode, segmentFileNum);
+	assert_int_equal(hash_get_num_entries(invalid_page_tab), 0);
+}
+
+int
+main(int argc, char* argv[])
+{
+	cmockery_parse_arguments(argc, argv);
+
+	const UnitTest tests[] = {
+		unit_test(test_ao_invalid_segment_file)
+	};
+	return run_tests(tests);
+}

--- a/src/backend/cdb/test/Makefile
+++ b/src/backend/cdb/test/Makefile
@@ -9,6 +9,10 @@ TARGETS=cdbtm \
 	cdbsrlz \
 	cdbdistributedsnapshot
 
+ifeq ($(enable_segwalrep), yes)
+TARGETS += cdbappendonlystorage cdbmirroredappendonly
+endif
+
 include $(top_builddir)/src/backend/mock.mk
 cdbtm.t: $(MOCK_DIR)/backend/storage/lmgr/lwlock_mock.o
 
@@ -17,3 +21,11 @@ cdbfilerep.t: \
 	$(MOCK_DIR)/backend/utils/mmgr/redzone_handler_mock.o
 
 cdbdistributedsnapshot.t: $(MOCK_DIR)/backend/access/transam/distributedlog_mock.o
+
+cdbappendonlystorage.t: \
+	$(MOCK_DIR)/backend/access/transam/xlog_mock.o \
+	$(MOCK_DIR)/backend/cdb/cdbmirroredappendonly_mock.o
+
+cdbmirroredappendonly.t: \
+	$(MOCK_DIR)/backend/storage/file/fd_mock.o \
+	$(MOCK_DIR)/backend/access/transam/xlogutils_mock.o

--- a/src/backend/cdb/test/cdbappendonlystorage_test.c
+++ b/src/backend/cdb/test/cdbappendonlystorage_test.c
@@ -1,0 +1,104 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include "cmockery.h"
+
+#include "../cdbappendonlystorage.c"
+
+static const XLogRecPtr InvalidXLogRecPtr = {0, 0};
+
+/*
+ * Test that calling appendonly_redo with XLOG_APPENDONLY_INSERT record will
+ * call ao_insert_replay.
+ */
+void
+test_appendonly_redo_insert_replay(void **state)
+{
+	RelFileNode relfilenode;
+	XLogRecord record;
+	XLogRecord *mockrecord;
+	xl_ao_insert xlaoinsert;
+	char *buffer;
+
+	/* create mock transaction log */
+	relfilenode.spcNode = DEFAULTTABLESPACE_OID;
+	relfilenode.dbNode = 12087 /* postgres database */;
+	relfilenode.relNode = FirstNormalObjectId;
+
+	xlaoinsert.target.node = relfilenode;
+	xlaoinsert.target.segment_filenum = 2;
+	xlaoinsert.target.offset = 12345;
+
+	record.xl_info = XLOG_APPENDONLY_INSERT;
+	record.xl_rmid = RM_APPEND_ONLY_ID;
+	record.xl_len = 0;
+
+	buffer = (char *) malloc(SizeOfXLogRecord + SizeOfAOInsert);
+	memcpy(buffer, &record, SizeOfXLogRecord);
+	memcpy(&buffer[SizeOfXLogRecord], &xlaoinsert, SizeOfAOInsert);
+	mockrecord = (XLogRecord *) buffer;
+
+	/* pretend we are a standby */
+	will_return(IsStandbyMode, true);
+
+	/* we expect ao_insert_replay to be called with XLOG_APPENDONLY_INSERT record type */
+	expect_any(ao_insert_replay, record);
+	will_be_called(ao_insert_replay);
+
+	/* run test */
+	appendonly_redo(InvalidXLogRecPtr, InvalidXLogRecPtr, mockrecord);
+}
+
+/*
+ * Test that calling appendonly_redo with XLOG_APPENDONLY_TRUNCATE record will
+ * call ao_truncate_replay.
+ */
+void
+test_appendonly_redo_truncate_replay(void **state)
+{
+	RelFileNode relfilenode;
+	XLogRecord record;
+	XLogRecord *mockrecord;
+	xl_ao_truncate xlaotruncate;
+	char *buffer;
+
+	/* create mock transaction log */
+	relfilenode.spcNode = DEFAULTTABLESPACE_OID;
+	relfilenode.dbNode = 12087 /* postgres database */;
+	relfilenode.relNode = FirstNormalObjectId;
+
+	xlaotruncate.target.node = relfilenode;
+	xlaotruncate.target.segment_filenum = 2;
+	xlaotruncate.target.offset = 12345;
+
+	record.xl_info = XLOG_APPENDONLY_TRUNCATE;
+	record.xl_rmid = RM_APPEND_ONLY_ID;
+	record.xl_len = 0;
+
+	buffer = (char *) malloc(SizeOfXLogRecord + sizeof(xl_ao_truncate));
+	memcpy(buffer, &record, SizeOfXLogRecord);
+	memcpy(&buffer[SizeOfXLogRecord], &xlaotruncate, sizeof(xl_ao_truncate));
+	mockrecord = (XLogRecord *) buffer;
+
+	/* pretend we are a standby */
+	will_return(IsStandbyMode, true);
+
+	/* we expect ao_truncate_replay to be called with XLOG_APPENDONLY_TRUNCATE record type */
+	expect_any(ao_truncate_replay, record);
+	will_be_called(ao_truncate_replay);
+
+	/* run test */
+	appendonly_redo(InvalidXLogRecPtr, InvalidXLogRecPtr, mockrecord);
+}
+
+int
+main(int argc, char* argv[])
+{
+	cmockery_parse_arguments(argc, argv);
+
+	const UnitTest tests[] = {
+		unit_test(test_appendonly_redo_insert_replay),
+		unit_test(test_appendonly_redo_truncate_replay)
+	};
+	return run_tests(tests);
+}

--- a/src/backend/cdb/test/cdbmirroredappendonly_test.c
+++ b/src/backend/cdb/test/cdbmirroredappendonly_test.c
@@ -1,0 +1,108 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include "cmockery.h"
+
+#include "../cdbmirroredappendonly.c"
+
+static int
+check_relfilenode_function(const RelFileNode *value, const RelFileNode *check_value)
+{
+	return RelFileNodeEquals(*value, *check_value);
+}
+
+/*
+ * Test that XLogAOSegmentFile will be called when we cannot find the AO
+ * segment file.
+ */
+static void
+ao_invalid_segment_file_test(uint8 xl_info)
+{
+	RelFileNode relfilenode;
+	XLogRecord record;
+	XLogRecord *mockrecord;
+	xl_ao_target xlaotarget;
+	char *buffer;
+
+	/* create mock transaction log */
+	relfilenode.spcNode = DEFAULTTABLESPACE_OID;
+	relfilenode.dbNode = 12087 /* postgres database */;
+	relfilenode.relNode = FirstNormalObjectId;
+
+	xlaotarget.node = relfilenode;
+	xlaotarget.segment_filenum = 2;
+	xlaotarget.offset = 12345;
+
+	record.xl_info = xl_info;
+	record.xl_rmid = RM_APPEND_ONLY_ID;
+	record.xl_len = 0;
+
+	if (xl_info == XLOG_APPENDONLY_INSERT)
+	{
+		xl_ao_insert xlaoinsert;
+
+		xlaoinsert.target = xlaotarget;
+		buffer = (char *) malloc(SizeOfXLogRecord + SizeOfAOInsert);
+		memcpy(&buffer[SizeOfXLogRecord], &xlaoinsert, SizeOfAOInsert);
+	}
+	else if (xl_info == XLOG_APPENDONLY_TRUNCATE)
+	{
+		xl_ao_truncate xlaotruncate;
+
+		xlaotruncate.target = xlaotarget;
+		buffer = (char *) malloc(SizeOfXLogRecord + sizeof(xl_ao_truncate));
+		memcpy(&buffer[SizeOfXLogRecord], &xlaotruncate, sizeof(xl_ao_truncate));
+	}
+	memcpy(buffer, &record, SizeOfXLogRecord);
+	mockrecord = (XLogRecord *) buffer;
+
+	/* mock to not find AO segment file */
+	expect_any(PathNameOpenFile, fileName);
+	expect_any(PathNameOpenFile, fileFlags);
+	expect_any(PathNameOpenFile, fileMode);
+	will_return(PathNameOpenFile, -1);
+
+	/* XLogAOSegmentFile should be called with our mock relfilenode and segment file number */
+	expect_check(XLogAOSegmentFile, &rnode, check_relfilenode_function, &relfilenode);
+	expect_value(XLogAOSegmentFile, segmentFileNum, xlaotarget.segment_filenum);
+	will_be_called(XLogAOSegmentFile);
+
+	/* run test */
+	if (xl_info == XLOG_APPENDONLY_INSERT)
+		ao_insert_replay(mockrecord);
+	else if (xl_info == XLOG_APPENDONLY_TRUNCATE)
+		ao_truncate_replay(mockrecord);
+}
+
+/*
+ * Test that ao_insert_replay will call XLogAOSegmentFile when we cannot find
+ * the AO segment file.
+ */
+void
+test_ao_insert_replay_invalid_segment_file(void **state)
+{
+	ao_invalid_segment_file_test(XLOG_APPENDONLY_INSERT);
+}
+
+/*
+ * Test that ao_truncate_replay will call XLogAOSegmentFile when we cannot find
+ * the AO segment file.
+ */
+void
+test_ao_truncate_replay_invalid_segment_file(void **state)
+{
+	ao_invalid_segment_file_test(XLOG_APPENDONLY_TRUNCATE);
+}
+
+int
+main(int argc, char* argv[])
+{
+	cmockery_parse_arguments(argc, argv);
+
+	const UnitTest tests[] = {
+		unit_test(test_ao_insert_replay_invalid_segment_file),
+		unit_test(test_ao_truncate_replay_invalid_segment_file)
+	};
+
+	return run_tests(tests);
+}


### PR DESCRIPTION
The unit tests are split into three separate code path pieces:
1. appendonly_redo -> ao_insert_replay -> XLogAOSegmentFile -> log_invalid_page
2. XLogAOSegmentFile followed by XLogAODropSegmentFile
3. mmxlog_redo -> XLogAODropSegmentFile -> forget_invalid_segment_file

These three pieces combined tests the case when AO XLOG records are
replayed but the corresponding segment files are missing from
filesystem. The replay is entered into the invalid_page_tab hash table
until a corresponding MMXLOG_REMOVE_FILE XLOG record type comes along
to remove the entry.

Currently these unit tests are under --enable-segwalrep configure flag
in the Makefile but can be moved to the actual TARGET if non-segwalrep
tests are added and need to be tested. Either way, the #ifdef's will
be removed some time during 6.0 development when ready.

Reference:
https://github.com/greenplum-db/gpdb/commit/b659d0479fa57c383e7dbe15043cd2ca9d46f77f