### PR TITLE
Allow pg_config --configure.

### DIFF
--- a/src/bin/pg_config/pg_config.c
+++ b/src/bin/pg_config/pg_config.c
@@ -233,15 +233,6 @@ show_pgxs(bool all)
 static void
 show_configure(bool all)
 {
-    /*
-     * we don't show our configure line -- it refers to many paths that are from the build machines, and doesn't make
-	 * _that_ much sense for the customers  to view as they take the builds that we produce
-	 */
-    if ( all )
-        return;
-    fprintf( stderr, _("CONFIGURE value not available\n"));
-    exit(1);
-
 #ifdef VAL_CONFIGURE
 	if (all)
 		printf("CONFIGURE = ");


### PR DESCRIPTION
Despite the comment, I see no reason to hide it.

Fixes github issue #2685.