### PR TITLE
Fix internal_bpchar_pattern_compare compare logic to keep it

### DIFF
--- a/src/backend/utils/adt/varchar.c
+++ b/src/backend/utils/adt/varchar.c
@@ -895,15 +895,6 @@ internal_bpchar_pattern_compare(BpChar *arg1, BpChar *arg2)
 	int			len1,
 				len2;
 
-	/*
-	 * Before we use VARDATA_SIZE, but we change it to use bcTruelen to
-	 * keep same bahavior with upstream. This bug doesn't exist before in
-	 * GPDB since IndexScan is not used for following query:
-	 * create table tbl(id int4, v char(10));
-	 * create index tbl_v_idx_bpchar on tbl using btree(v bpchar_pattern_ops);
-	 * insert into tbl values (1, 'abc');
-	 * select * from tbl where v = 'abc '::char(20);
-	 */
 	len1 = bcTruelen(arg1);
 	len2 = bcTruelen(arg2);
 


### PR DESCRIPTION
as same as upstream.

In upstream, internal_bpchar_pattern_compare compare inputs by ignoring
ending space. But GPDB it just use whole string compare. The bug didn't
appear because the before merging PG_MERGE_84 GPDB just use TableScan when executing
following query, but after PG_MERGE_84, IndexScan is used, and internal_bpchar_pattern_compare
will be used for index:
create table tbl(id int4, v char(10));
create index tbl_v_idx_bpchar on tbl using btree(v bpchar_pattern_ops);
insert into tbl values (1, 'abc');
explain select * from tbl where v = 'abc '::char(20);
select * from tbl where v = 'abc '::char(20);

Signed-off-by: Xiaoran Wang <xiwang@pivotal.io>