### PR TITLE
5x pipeline restructuring

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -2707,12 +2707,6 @@ jobs:
       <<: *ccp_gpdb4_gen_cluster_default_params
     on_failure:
       <<: *dpm_ccp_destroy
-  - task: netbackup_pre_test_setup
-    tags: ["netbackup"]
-    file: gpdb_src/concourse/tasks/setup_netbackup.yml
-    image: centos-gpdb-dev-6
-    params:
-      CUSTOM_ENV: export NETBACKUP_SERVER={{netbackup_host}}; export NETBACKUP_KEY={{netbackup_key}};
   - task: run_tests
     tags: ["ddboost"]
     file: gpdb_src/concourse/tasks/run_behave.yml
@@ -2758,12 +2752,6 @@ jobs:
       <<: *ccp_gpdb4_gen_cluster_default_params
     on_failure:
       <<: *dpm_ccp_destroy
-  - task: netbackup_pre_test_setup
-    tags: ["netbackup"]
-    file: gpdb_src/concourse/tasks/setup_netbackup.yml
-    image: centos-gpdb-dev-6
-    params:
-      CUSTOM_ENV: export NETBACKUP_SERVER={{netbackup_host}}; export NETBACKUP_KEY={{netbackup_key}};
   - task: run_tests
     tags: ["ddboost"]
     file: gpdb_src/concourse/tasks/run_behave.yml
@@ -2858,7 +2846,7 @@ jobs:
       <<: *ccp_gpdb4_gen_cluster_default_params
     on_failure:
       <<: *dpm_ccp_destroy
-  - task: setup_netbackup
+  - task: netbackup_pre_test_setup
     tags: ["netbackup"]
     file: gpdb_src/concourse/tasks/setup_netbackup.yml
     image: centos-gpdb-dev-6
@@ -2912,7 +2900,7 @@ jobs:
       <<: *ccp_gpdb4_gen_cluster_default_params
     on_failure:
       <<: *dpm_ccp_destroy
-  - task: setup_netbackup
+  - task: netbackup_pre_test_setup
     tags: ["netbackup"]
     file: gpdb_src/concourse/tasks/setup_netbackup.yml
     image: centos-gpdb-dev-6

--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -9,15 +9,14 @@ groups:
 ################################
   - gate_compile_start
   - compile_gpdb_centos6
-  - compile_gpdb_open_source_centos6
-  - compile_gpdb_binary_swap_centos6
   - compile_gpdb_centos7
   - compile_gpdb_sles11
   - compile_gpdb_ubuntu16
+  - compile_gpdb_open_source_centos6
+  - compile_gpdb_binary_swap_centos6
   - compile_gpdb_and_orca_conan_ubuntu16
   - compile_gpdb_windows_cl
   - compile_gpdb_aix7_remote
-  - gpdb_rc_packaging_centos
   - client_loader_remote_test_aix
   - gate_compile_end
 ################################
@@ -29,11 +28,13 @@ groups:
   - icw_planner_ubuntu16
   - icw_gporca_conan_ubuntu16
   - icw_planner_ictcp_centos6
+  - gate_icw_end
+  - QP_memory-accounting
+  - QP_optimizer-functional
+################################
+  - gate_cs_start
   - fts
   - storage
-  - gate_icw_end
-################################
-  - gate_cs_misc_start
   - cs_walrep_1
   - cs_walrep_2
   - cs_pg_twophase_01_10
@@ -44,20 +45,21 @@ groups:
   - cs_pg_twophase_switch_01_12
   - cs_pg_twophase_switch_13_24
   - cs_pg_twophase_switch_25_33
-  - gate_cs_misc_end
-################################
-  - gate_cluster_start
-  - mpp_interconnect
-  - DPM_gptransfer-5x-to-5x
   - cs_crash_recovery_schema_topology
   - cs_crash_recovery_04_10
   - cs_crash_recovery_11_20
   - cs_crash_recovery_21_30
   - cs_crash_recovery_31_42
-  - DPM_backup-restore
-  - gate_cluster_end
+  - gate_cs_end
 ################################
-  - gate_mm_misc_start
+  - gate_mpp_start
+  - mpp_interconnect
+  - mpp_resource_group_centos6
+  - mpp_resource_group_centos7
+  - gate_mpp_end
+################################
+  - gate_mm_start
+  - MM_gpcheckcat
   - MM_gppkg
   - MM_gprecoverseg
   - MM_gpcheck
@@ -67,20 +69,31 @@ groups:
   - MM_gpinitsystem
   - MU_check_centos
   - MM_gpinitstandby
-  - gate_mm_misc_end
-################################
-  - gate_nightly_start
-  - DPM_backup_43_restore_5
   - MM_gpexpand_1
   - MM_gpexpand_2
-  - DPM_gptransfer-43x-to-5x
+  - gate_mm_end
+################################
+  - gate_dpm_start
+  - DPM_backup-restore
   - DPM_backup-restore_ddboost_part1
   - DPM_backup-restore_ddboost_part2
   - DPM_backup-restore_ddboost_part3
   - DPM_backup-restore_netbackup_part1
   - DPM_backup-restore_netbackup_part2
   - DPM_backup-restore_netbackup_part3
-  - gate_nightly_end
+  - DPM_backup_43_restore_5
+  - DPM_gptransfer-43x-to-5x
+  - DPM_gptransfer-5x-to-5x
+  - gate_dpm_end
+################################
+  - gate_ud_start
+  - regression_tests_pxf_hdp_rpm
+  - regression_tests_pxf_hdp_tar
+  - regression_tests_pxf_cdh_rpm
+  - regression_tests_pxf_cdh_tar
+  - regression_tests_gphdfs_centos
+  - regression_tests_gpcloud_centos
+  - gate_ud_end
 ################################
   - gate_advanced_analytics_start
   - MADlib_Test_gppkg_Orca_centos6
@@ -92,20 +105,6 @@ groups:
   - postgis_centos7_ORCA_test
   - postgis_centos7_planner_test
   - gate_advanced_analytics_end
-################################
-  - gate_general_misc_start
-  - MM_gpcheckcat
-  - QP_memory-accounting
-  - QP_optimizer-functional
-  - regression_tests_pxf_hdp_rpm
-  - regression_tests_pxf_hdp_tar
-  - regression_tests_pxf_cdh_rpm
-  - regression_tests_pxf_cdh_tar
-  - regression_tests_gphdfs_centos
-  - regression_tests_gpcloud_centos
-  - mpp_resource_group_centos6
-  - mpp_resource_group_centos7
-  - gate_general_misc_end
 ################################
   - gate_filerep_start
   - cs_filerep_e2e_full_mirror
@@ -119,82 +118,40 @@ groups:
   jobs:
   - Release_Candidate
 
-- name: Remaining Pulse
-  jobs:
-  - mpp_interconnect
-
-- name: Adopted CCP
-  jobs:
-  - cs_walrep_1
-  - cs_walrep_2
-  - mpp_resource_group_centos6
-  - mpp_resource_group_centos7
-  - cs_filerep_e2e_full_primary
-  - cs_filerep_e2e_incr_primary
-  - cs_filerep_e2e_full_mirror
-  - cs_filerep_e2e_incr_mirror
-  - cs_pg_twophase_01_10
-  - cs_pg_twophase_11_20
-  - cs_pg_twophase_21_30
-  - cs_pg_twophase_31_40
-  - cs_pg_twophase_41_49
-  - cs_pg_twophase_switch_01_12
-  - cs_pg_twophase_switch_13_24
-  - cs_pg_twophase_switch_25_33
-  - cs_crash_recovery_schema_topology
-  - cs_crash_recovery_04_10
-  - cs_crash_recovery_11_20
-  - cs_crash_recovery_21_30
-  - cs_crash_recovery_31_42
-  - DPM_backup-restore
-  - DPM_gptransfer-43x-to-5x
-  - DPM_gptransfer-5x-to-5x
-  - MM_gpcheckcat
-  - MM_gpexpand_1
-  - MM_gpexpand_2
-  - MM_gppkg
-  - MM_gprecoverseg
-  - DPM_backup_43_restore_5
-  - DPM_backup-restore_ddboost_part1
-  - DPM_backup-restore_ddboost_part2
-  - DPM_backup-restore_ddboost_part3
-  - DPM_backup-restore_netbackup_part1
-  - DPM_backup-restore_netbackup_part2
-  - DPM_backup-restore_netbackup_part3
-
 - name: G:Compile
   jobs:
   - gate_compile_start
   - compile_gpdb_centos6
-  - compile_gpdb_open_source_centos6
   - compile_gpdb_centos7
   - compile_gpdb_sles11
   - compile_gpdb_ubuntu16
+  - compile_gpdb_open_source_centos6
+  - compile_gpdb_binary_swap_centos6
   - compile_gpdb_and_orca_conan_ubuntu16
   - compile_gpdb_windows_cl
   - compile_gpdb_aix7_remote
   - client_loader_remote_test_aix
-  - validate_pipeline
-  - gpdb_rc_packaging_centos
   - gate_compile_end
 
 - name: G:ICW
   jobs:
   - gate_icw_start
   - icw_planner_centos6
-  - icw_planner_ubuntu16
-  - icw_gporca_conan_ubuntu16
   - icw_gporca_centos6
   - icw_gporca_centos7
   - icw_gporca_sles11
+  - icw_planner_ubuntu16
+  - icw_gporca_conan_ubuntu16
   - icw_planner_ictcp_centos6
-  - fts
-  - storage
+  - QP_memory-accounting
+  - QP_optimizer-functional
   - gate_icw_end
 
-- name: G:CS_Misc
+- name: G:CS
   jobs:
-  - gate_cs_misc_start
+  - fts
+  - storage
+  - gate_cs_start
   - cs_walrep_1
   - cs_walrep_2
   - cs_pg_twophase_01_10
@@ -205,28 +162,27 @@ groups:
   - cs_pg_twophase_switch_01_12
   - cs_pg_twophase_switch_13_24
   - cs_pg_twophase_switch_25_33
-  - gate_cs_misc_end
-
-- name: G:Cluster
-  jobs:
-  - gate_cluster_start
-  - mpp_interconnect
-  - DPM_gptransfer-5x-to-5x
-  - DPM_backup-restore
   - cs_crash_recovery_schema_topology
   - cs_crash_recovery_04_10
   - cs_crash_recovery_11_20
   - cs_crash_recovery_21_30
   - cs_crash_recovery_31_42
-  - gate_cluster_end
+  - gate_cs_end
 
-- name: G:MM_Misc
+- name: G:MPP
   jobs:
-  - gate_mm_misc_start
+  - gate_mpp_start
+  - mpp_interconnect
+  - mpp_resource_group_centos6
+  - mpp_resource_group_centos7
+  - gate_mpp_end
+
+- name: G:MM
+  jobs:
+  - gate_mm_start
+  - MM_gpcheckcat
   - MM_gppkg
   - MM_gprecoverseg
-  - MM_gpexpand_1
-  - MM_gpexpand_2
   - MM_gpcheck
   - MM_analyzedb
   - MM_gpperfmon
@@ -234,22 +190,24 @@ groups:
   - MM_gpinitsystem
   - MU_check_centos
   - MM_gpinitstandby
-  - gate_mm_misc_end
-
-- name: G:Nightly
-  jobs:
-  - gate_nightly_start
-  - DPM_backup_43_restore_5
   - MM_gpexpand_1
   - MM_gpexpand_2
-  - DPM_gptransfer-43x-to-5x
+  - gate_mm_end
+
+- name: G:DPM
+  jobs:
+  - gate_dpm_start
+  - DPM_backup-restore
   - DPM_backup-restore_ddboost_part1
   - DPM_backup-restore_ddboost_part2
   - DPM_backup-restore_ddboost_part3
   - DPM_backup-restore_netbackup_part1
   - DPM_backup-restore_netbackup_part2
   - DPM_backup-restore_netbackup_part3
-  - gate_nightly_end
+  - DPM_backup_43_restore_5
+  - DPM_gptransfer-43x-to-5x
+  - DPM_gptransfer-5x-to-5x
+  - gate_dpm_end
 
 - name: G:AdvancedAnalytics
   jobs:
@@ -264,21 +222,16 @@ groups:
   - postgis_centos7_planner_test
   - gate_advanced_analytics_end
 
-- name: G:General
+- name: G:UD
   jobs:
-  - gate_general_misc_start
-  - MM_gpcheckcat
-  - QP_memory-accounting
-  - QP_optimizer-functional
+  - gate_ud_start
   - regression_tests_pxf_hdp_rpm
   - regression_tests_pxf_hdp_tar
   - regression_tests_pxf_cdh_rpm
   - regression_tests_pxf_cdh_tar
   - regression_tests_gphdfs_centos
   - regression_tests_gpcloud_centos
-  - mpp_resource_group_centos6
-  - mpp_resource_group_centos7
-  - gate_general_misc_end
+  - gate_ud_end
 
 - name: G:FileRep
   jobs:
@@ -311,7 +264,6 @@ resources:
     private_key: {{ccp-git-key}}
     uri: {{ccp-git-remote}}
     tag_filter: 1.0.4.1
-
 - name: terraform
   type: terraform
   source:
@@ -535,15 +487,6 @@ resources:
     secret_access_key: {{gpdb4-bucket-secret-access-key}}
     versioned_file: bin_gpdb_centos/bin_gpdb.tar.gz
 
-- name: installer_rhel6_gpdb_rc
-  type: s3
-  source:
-    access_key_id: {{bucket-access-key-id}}
-    bucket: {{bucket-name}}
-    region_name: {{aws-region}}
-    secret_access_key: {{bucket-secret-access-key}}
-    regexp: deliverables/software_only_installer/greenplum-db-(.*)-rhel6-x86_64.zip
-
 - name: installer_rhel6_gpdb_clients
   type: s3
   source:
@@ -598,15 +541,6 @@ resources:
     secret_access_key: {{bucket-secret-access-key}}
     regexp: deliverables/greenplum-loaders-5.(.*)-aix7_ppc_64.zip
 
-- name: qautils_rhel6_tarball
-  type: s3
-  source:
-    access_key_id: {{bucket-access-key-id}}
-    bucket: {{bucket-name}}
-    region_name: {{aws-region}}
-    secret_access_key: {{bucket-secret-access-key}}
-    versioned_file: deliverables/QAUtils-rhel6-x86_64.tar.gz
-
 - name: installer_sles11_gpdb_clients
   type: s3
   source:
@@ -624,24 +558,6 @@ resources:
     region_name: {{aws-region}}
     secret_access_key: {{bucket-secret-access-key}}
     regexp: deliverables/greenplum-loaders-5.(.*)-sles11-x86_64.zip
-
-- name: gpdb_src_tinc_tarball
-  type: s3
-  source:
-    access_key_id: {{bucket-access-key-id}}
-    bucket: {{bucket-name}}
-    region_name: {{aws-region}}
-    secret_access_key: {{bucket-secret-access-key}}
-    regexp: deliverables/greenplum-db-(.*)-src.tar.gz
-
-- name: gpdb_src_behave_tarball
-  type: s3
-  source:
-    access_key_id: {{bucket-access-key-id}}
-    bucket: {{bucket-name}}
-    region_name: {{aws-region}}
-    secret_access_key: {{bucket-secret-access-key}}
-    regexp: deliverables/greenplum-db-(.*)-behave.tar.gz
 
 - name: singlecluster-HDP
   type: s3
@@ -740,13 +656,27 @@ resources:
   type: time
   source:
     location: America/Los_Angeles
-    days: [Sunday, Monday, Tuesday, Wednesday, Thursday, Friday]
+    days: [Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday]
     start: {{reduced-frequency-trigger-start}}
     stop: {{reduced-frequency-trigger-stop}}
 
 ## ======================================================================
 ## reusable anchors
 ## ======================================================================
+
+ccp_jitter_delay_anchor: &ccp_jitter_delay
+  do:
+  - task: ccp jitter delay
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: alpine
+      run:
+        path: 'sh'
+        args: ['-c', 'sleep `expr $RANDOM % {{ccp_delay_jitter}} + 1`']
+
 
 ccp_default_params_anchor: &ccp_default_params
   action: create
@@ -824,7 +754,7 @@ debug_sleep_anchor: &debug_sleep
           tag: latest
       run:
         path: 'sh'
-        args: ['-c', 'sleep 6h']
+        args: ['-c', 'sleep {{ccp_debug_sleep}}']
     ensure:
       <<: *ccp_destroy
 
@@ -840,7 +770,7 @@ dpm_debug_sleep_anchor: &dpm_debug_sleep
           tag: latest
       run:
         path: 'sh'
-        args: ['-c', 'sleep 6h']
+        args: ['-c', 'sleep {{ccp_debug_sleep}}']
     ensure:
       <<: *dpm_ccp_destroy
 
@@ -849,27 +779,27 @@ pulse_properties_anchor: &pulse_properties
   PULSE_USERNAME: {{pulse_username}}
   PULSE_PASSWORD: {{pulse_password}}
 
-cs_ccp_aggregate_nightly_start_anchor: &cs_ccp_aggregate_nightly_start
+cs_ccp_aggregate_dpm_start_anchor: &cs_ccp_aggregate_dpm_start
   - get: gpdb_src
     tags: ["ccp"]
-    passed: [gate_nightly_start]
+    passed: [gate_dpm_start]
   - get: gpdb_binary
     tags: ["ccp"]
     resource: bin_gpdb_centos6
-    passed: [gate_nightly_start]
+    passed: [gate_dpm_start]
   - get: ccp_src
     tags: ["ccp"]
   - get: centos-gpdb-dev-6
     tags: ["ccp"]
 
-cs_ccp_aggregate_cluster_start_anchor: &cs_ccp_aggregate_cluster_start
+cs_ccp_aggregate_mpp_start_anchor: &cs_ccp_aggregate_mpp_start
   - get: gpdb_src
     tags: ["ccp"]
-    passed: [gate_cluster_start]
+    passed: [gate_cs_start]
   - get: gpdb_binary
     tags: ["ccp"]
     resource: bin_gpdb_centos6
-    passed: [gate_cluster_start]
+    passed: [gate_cs_start]
     trigger: true
   - get: ccp_src
     tags: ["ccp"]
@@ -936,26 +866,6 @@ jobs:
     - get: centos-mingw
     - get: ubuntu-gpdb-dev-16
 
-- name: compile_gpdb_and_orca_conan_ubuntu16
-  plan:
-  - aggregate:
-    - get: reduced-frequency-trigger
-      trigger: ((reduced-frequency-trigger-flag))
-    - get: gpdb_src
-      trigger: ((gpdb_src-trigger-flag))
-    - get: ubuntu-gpdb-dev-16
-      passed: [gate_compile_start]
-  - task: compile_gpdb_and_orca
-    file: gpdb_src/concourse/tasks/compile_gpdb_and_orca_with_conan.yml
-    params:
-      BINTRAY_REMOTE: {{bintray_remote}}
-      BINTRAY_REMOTE_URL: {{bintray_remote_url}}
-  - put: compiled_bits_gpdb_with_orca_conan_ubuntu16
-    params:
-      file: {{compiled_bits_gpdb_with_orca_conan_ubuntu16_versioned_file}}
-  - put: compiled_bits_orca_with_conan_ubuntu16
-    params:
-      file: {{compiled_bits_orca_with_conan_ubuntu16_versioned_file}}
 - name: compile_gpdb_centos6
   plan:
   - aggregate:
@@ -992,21 +902,7 @@ jobs:
     - put: installer_rhel6_gpdb_loaders
       params:
         file: gpdb_artifacts/greenplum-loaders-*-rhel6-x86_64.zip
-- name: compile_gpdb_open_source_centos6
-  public: true
-  plan:
-  - aggregate:
-    - get: reduced-frequency-trigger
-      trigger: ((reduced-frequency-trigger-flag))
-    - get: gpdb_src
-      trigger: ((gpdb_src-trigger-flag))
-    - get: centos-gpdb-dev-6
-      passed: [gate_compile_start]
-  - task: compile_gpdb
-    image: centos-gpdb-dev-6
-    file: gpdb_src/concourse/tasks/compile_gpdb_open_source_centos.yml
-    params:
-        CONFIGURE_FLAGS: {{configure_flags}}
+
 - name: compile_gpdb_centos7
   plan:
   - aggregate:
@@ -1044,24 +940,6 @@ jobs:
       params:
         file: gpdb_artifacts/greenplum-loaders-*-rhel7-x86_64.zip
 
-- name: compile_gpdb_ubuntu16
-  plan:
-  - aggregate:
-    - get: reduced-frequency-trigger
-      trigger: ((reduced-frequency-trigger-flag))
-    - get: gpdb_src
-      trigger: ((gpdb_src-trigger-flag))
-    - get: ubuntu-gpdb-dev-16
-      passed: [gate_compile_start]
-  - task: compile_gpdb
-    image: ubuntu-gpdb-dev-16
-    file: gpdb_src/concourse/tasks/compile_gpdb_open_source_ubuntu.yml
-    params:
-      CONFIGURE_FLAGS: {{configure_flags}}
-  - put: compiled_bits_ubuntu16
-    params:
-      file: compiled_bits_ubuntu16/compiled_bits_ubuntu16.tar.gz
-
 - name: compile_gpdb_sles11
   plan:
   - aggregate:
@@ -1093,6 +971,94 @@ jobs:
   - put: installer_sles11_gpdb_loaders
     params:
       file: gpdb_artifacts/greenplum-loaders-*-sles11-x86_64.zip
+
+- name: compile_gpdb_ubuntu16
+  plan:
+  - aggregate:
+    - get: reduced-frequency-trigger
+      trigger: ((reduced-frequency-trigger-flag))
+    - get: gpdb_src
+      trigger: ((gpdb_src-trigger-flag))
+    - get: ubuntu-gpdb-dev-16
+      passed: [gate_compile_start]
+  - task: compile_gpdb
+    image: ubuntu-gpdb-dev-16
+    file: gpdb_src/concourse/tasks/compile_gpdb_open_source_ubuntu.yml
+    params:
+      CONFIGURE_FLAGS: {{configure_flags}}
+  - put: compiled_bits_ubuntu16
+    params:
+      file: compiled_bits_ubuntu16/compiled_bits_ubuntu16.tar.gz
+
+- name: compile_gpdb_open_source_centos6
+  public: true
+  plan:
+  - aggregate:
+    - get: reduced-frequency-trigger
+      trigger: ((reduced-frequency-trigger-flag))
+    - get: gpdb_src
+      trigger: ((gpdb_src-trigger-flag))
+    - get: centos-gpdb-dev-6
+      passed: [gate_compile_start]
+  - task: compile_gpdb
+    image: centos-gpdb-dev-6
+    file: gpdb_src/concourse/tasks/compile_gpdb_open_source_centos.yml
+    params:
+        CONFIGURE_FLAGS: {{configure_flags}}
+
+- name: compile_gpdb_binary_swap_centos6
+  plan:
+  # This acts like a cache as this job will only be run once to get a
+  # binary to use for our binary swap compatibility tests. Setting a new
+  # tag or branch for the gpdb_src_binary_swap resource via set-pipeline
+  # will replace the cached binary.
+  - aggregate:
+    - get: gpdb_src
+      resource: gpdb_src_binary_swap
+      trigger: true
+      passed: [gate_compile_start]
+    - get: gpaddon_src
+      passed: [gate_compile_start]
+    - get: pxf_src
+      passed: [gate_compile_start]
+    - get: centos-gpdb-dev-6
+      passed: [gate_compile_start]
+  - task: compile_gpdb
+    file: gpdb_src/concourse/tasks/compile_gpdb.yml
+    image: centos-gpdb-dev-6
+    params:
+      IVYREPO_HOST: {{ivyrepo_host}}
+      IVYREPO_REALM: {{ivyrepo_realm}}
+      IVYREPO_USER: {{ivyrepo_user}}
+      IVYREPO_PASSWD: {{ivyrepo_passwd}}
+      TARGET_OS: centos
+      TARGET_OS_VERSION: 6
+  - aggregate:
+    - put: binary_swap_gpdb_centos6
+      params:
+        file: gpdb_artifacts/bin_gpdb.tar.gz
+
+- name: compile_gpdb_and_orca_conan_ubuntu16
+  plan:
+  - aggregate:
+    - get: reduced-frequency-trigger
+      trigger: ((reduced-frequency-trigger-flag))
+    - get: gpdb_src
+      trigger: ((gpdb_src-trigger-flag))
+    - get: ubuntu-gpdb-dev-16
+      passed: [gate_compile_start]
+  - task: compile_gpdb_and_orca
+    file: gpdb_src/concourse/tasks/compile_gpdb_and_orca_with_conan.yml
+    params:
+      BINTRAY_REMOTE: {{bintray_remote}}
+      BINTRAY_REMOTE_URL: {{bintray_remote_url}}
+  - put: compiled_bits_gpdb_with_orca_conan_ubuntu16
+    params:
+      file: {{compiled_bits_gpdb_with_orca_conan_ubuntu16_versioned_file}}
+  - put: compiled_bits_orca_with_conan_ubuntu16
+    params:
+      file: {{compiled_bits_orca_with_conan_ubuntu16_versioned_file}}
+
 - name: compile_gpdb_windows_cl
   plan:
   - aggregate:
@@ -1132,6 +1098,7 @@ jobs:
       tags: ["wix"]
       params:
         file: gpdb_artifacts/greenplum-loaders-*-WinXP-x86_32.msi
+
 - name: compile_gpdb_aix7_remote
   serial: true
   plan:
@@ -1155,12 +1122,10 @@ jobs:
       REMOTE_PORT: {{remote_port}}
       REMOTE_USER: {{remote_user}}
       REMOTE_KEY: {{remote_key}}
-
       IVYREPO_HOST: {{ivyrepo_host}}
       IVYREPO_REALM: {{ivyrepo_realm}}
       IVYREPO_USER: {{ivyrepo_user}}
       IVYREPO_PASSWD: {{ivyrepo_passwd}}
-
       BLD_TARGETS: "clients loaders"
   - aggregate:
     - put: installer_aix7_gpdb_clients
@@ -1169,127 +1134,6 @@ jobs:
     - put: installer_aix7_gpdb_loaders
       params:
         file: gpdb_artifacts/greenplum-loaders-*-aix7_ppc_64.zip
-- name: gpdb_rc_packaging_centos
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      passed:
-      - gate_compile_start
-      - compile_gpdb_centos6
-      - compile_gpdb_centos7
-    - get: gpaddon_src
-      passed:
-      - gate_compile_start
-      - compile_gpdb_centos6
-    - get: bin_gpdb_centos6
-      passed:
-      - compile_gpdb_centos6
-      trigger: true
-    - get: bin_gpdb_centos7
-      passed:
-      - compile_gpdb_centos7
-      trigger: true
-    - get: centos-gpdb-dev-6
-      passed: [gate_compile_start]
-    - get: centos-gpdb-dev-7
-      passed: [gate_compile_start]
-  - task: separate_qautils_files_for_rc_centos6
-    file: gpdb_src/concourse/tasks/separate_qautils_files_for_rc.yml
-    image: centos-gpdb-dev-6
-    input_mapping:
-      bin_gpdb: bin_gpdb_centos6
-    output_mapping:
-      rc_bin_gpdb: rc_bin_gpdb_rhel6
-    params:
-      QAUTILS_TARBALL: rc_bin_gpdb/QAUtils-rhel6-x86_64.tar.gz
-
-  - task: separate_qautils_files_for_rc_centos7
-    file: gpdb_src/concourse/tasks/separate_qautils_files_for_rc.yml
-    image: centos-gpdb-dev-7
-    input_mapping:
-      bin_gpdb: bin_gpdb_centos7
-    output_mapping:
-      rc_bin_gpdb: rc_bin_gpdb_rhel7
-    params:
-      QAUTILS_TARBALL: rc_bin_gpdb/QAUtils-rhel7-x86_64.tar.gz
-
-  - task: gpdb_src_tinc_packaging
-    file: gpdb_src/concourse/tasks/gpdb_src_tinc_packaging.yml
-    image: centos-gpdb-dev-6
-    input_mapping:
-      bin_gpdb: bin_gpdb_centos6
-    output_mapping:
-      rc_bin_gpdb: packaged_gpdb_src_tinc
-    params:
-      GPDB_SRC_TAR_GZ: rc_bin_gpdb/greenplum-db-@GP_VERSION@-src.tar.gz
-
-  - task: gpdb_src_behave_packaging
-    file: gpdb_src/concourse/tasks/gpdb_src_behave_packaging.yml
-    image: centos-gpdb-dev-6
-    input_mapping:
-      bin_gpdb: bin_gpdb_centos6
-    output_mapping:
-      rc_bin_gpdb: packaged_gpdb_src_behave
-    params:
-      GPDB_SRC_TAR_GZ: rc_bin_gpdb/greenplum-db-@GP_VERSION@-behave.tar.gz
-
-  - aggregate:
-    - task: gpdb_rc_packaging_centos6
-      file: gpdb_src/concourse/tasks/gpdb_packaging.yml
-      image: centos-gpdb-dev-6
-      input_mapping:
-        bin_gpdb: rc_bin_gpdb_rhel6
-      output_mapping:
-        packaged_gpdb: packaged_gpdb_rc_centos6
-      params:
-        INSTALL_SCRIPT_SRC: gpdb_src/gpAux/addon/license/installer-header-rhel-gpdb.sh
-        INSTALLER_ZIP: packaged_gpdb/greenplum-db-@GP_VERSION@-rhel6-x86_64.zip
-        ADD_README_INSTALL: true
-    - task: gpdb_appliance_rhel6_rc_packaging
-      file: gpdb_src/concourse/tasks/gpdb_packaging.yml
-      image: centos-gpdb-dev-6
-      input_mapping:
-        bin_gpdb: rc_bin_gpdb_rhel6
-      output_mapping:
-        packaged_gpdb: packaged_gpdb_appliance_rc_centos6
-      params:
-        INSTALL_SCRIPT_SRC: gpdb_src/gpAux/addon/license/installer-appliance-header-rhel-gpdb.sh
-        INSTALLER_ZIP: packaged_gpdb/greenplum-db-appliance-@GP_VERSION@-rhel6-x86_64.zip
-
-    - task: gpdb_rc_packaging_centos7
-      file: gpdb_src/concourse/tasks/gpdb_packaging.yml
-      image: centos-gpdb-dev-7
-      input_mapping:
-        bin_gpdb: rc_bin_gpdb_rhel7
-      output_mapping:
-        packaged_gpdb: packaged_gpdb_rc_centos7
-      params:
-        INSTALL_SCRIPT_SRC: gpdb_src/gpAux/addon/license/installer-header-rhel-gpdb.sh
-        INSTALLER_ZIP: packaged_gpdb/greenplum-db-@GP_VERSION@-rhel7-x86_64.zip
-        ADD_README_INSTALL: true
-    - task: gpdb_appliance_rhel7_rc_packaging
-      file: gpdb_src/concourse/tasks/gpdb_packaging.yml
-      image: centos-gpdb-dev-7
-      input_mapping:
-        bin_gpdb: rc_bin_gpdb_rhel7
-      output_mapping:
-        packaged_gpdb: packaged_gpdb_appliance_rc_centos7
-      params:
-        INSTALL_SCRIPT_SRC: gpdb_src/gpAux/addon/license/installer-appliance-header-rhel-gpdb.sh
-        INSTALLER_ZIP: packaged_gpdb/greenplum-db-appliance-@GP_VERSION@-rhel7-x86_64.zip
-  - aggregate:
-    - put: installer_rhel6_gpdb_rc
-      params:
-        file: packaged_gpdb_rc_centos6/greenplum-db-*-rhel6-x86_64.zip
-    - put: qautils_rhel6_tarball
-      params:
-        file: rc_bin_gpdb_rhel6/QAUtils-rhel6-x86_64.tar.gz
-    - put: gpdb_src_tinc_tarball
-      params:
-        file: packaged_gpdb_src_tinc/greenplum-db-*-src.tar.gz
-    - put: gpdb_src_behave_tarball
-      params:
-        file: packaged_gpdb_src_behave/greenplum-db-*-behave.tar.gz
 - name: client_loader_remote_test_aix
   serial: true
   plan:
@@ -1336,51 +1180,20 @@ jobs:
           REMOTE_KEY: {{remote_key}}
       - put: aix_environments
         params: {release: aix_environments}
-- name: compile_gpdb_binary_swap_centos6
-  plan:
-  # This acts like a cache as this job will only be run once to get a
-  # binary to use for our binary swap compatibility tests. Setting a new
-  # tag or branch for the gpdb_src_binary_swap resource via set-pipeline
-  # will replace the cached binary.
-  - aggregate:
-    - get: gpdb_src
-      resource: gpdb_src_binary_swap
-      trigger: true
-      passed: [gate_compile_start]
-    - get: gpaddon_src
-      passed: [gate_compile_start]
-    - get: pxf_src
-      passed: [gate_compile_start]
-    - get: centos-gpdb-dev-6
-      passed: [gate_compile_start]
-  - task: compile_gpdb
-    file: gpdb_src/concourse/tasks/compile_gpdb.yml
-    image: centos-gpdb-dev-6
-    params:
-      IVYREPO_HOST: {{ivyrepo_host}}
-      IVYREPO_REALM: {{ivyrepo_realm}}
-      IVYREPO_USER: {{ivyrepo_user}}
-      IVYREPO_PASSWD: {{ivyrepo_passwd}}
-      TARGET_OS: centos
-      TARGET_OS_VERSION: 6
-  - aggregate:
-    - put: binary_swap_gpdb_centos6
-      params:
-        file: gpdb_artifacts/bin_gpdb.tar.gz
+
+
 - name: gate_compile_end
   plan:
   - aggregate:
     - get: gpdb_src
       passed:
-      - gate_compile_start
-      - compile_gpdb_centos6
-      - compile_gpdb_open_source_centos6
-      - compile_gpdb_centos7
-      - compile_gpdb_sles11
-      - compile_gpdb_ubuntu16
-      - compile_gpdb_and_orca_conan_ubuntu16
-      - compile_gpdb_windows_cl
-      - gpdb_rc_packaging_centos
+        - compile_gpdb_centos6
+        - compile_gpdb_centos7
+        - compile_gpdb_sles11
+        - compile_gpdb_ubuntu16
+        - compile_gpdb_open_source_centos6
+        - compile_gpdb_and_orca_conan_ubuntu16
+        - compile_gpdb_windows_cl
       trigger: true
     - get: bin_gpdb_sles11
       passed:
@@ -1394,18 +1207,6 @@ jobs:
     - get: bin_gpdb_centos6
       passed:
       - compile_gpdb_centos6
-    - get: gpdb_src_tinc_tarball
-      passed:
-      - gpdb_rc_packaging_centos
-    - get: installer_rhel6_gpdb_rc
-      passed:
-      - gpdb_rc_packaging_centos
-    - get: qautils_rhel6_tarball
-      passed:
-      - gpdb_rc_packaging_centos
-    - get: gpdb_src_behave_tarball
-      passed:
-      - gpdb_rc_packaging_centos
     - get: compiled_bits_ubuntu16
       passed:
       - compile_gpdb_ubuntu16
@@ -1437,18 +1238,6 @@ jobs:
       - get: bin_gpdb_centos6
         passed:
         - gate_compile_end
-      - get: gpdb_src_tinc_tarball
-        passed:
-        - gate_compile_end
-      - get: installer_rhel6_gpdb_rc
-        passed:
-        - gate_compile_end
-      - get: qautils_rhel6_tarball
-        passed:
-        - gate_compile_end
-      - get: gpdb_src_behave_tarball
-        passed:
-        - gate_compile_end
       - get: compiled_bits_ubuntu16
         passed:
         - gate_compile_end
@@ -1458,6 +1247,7 @@ jobs:
       - get: compiled_bits_orca_with_conan_ubuntu16
         passed:
         - gate_compile_end
+
 - name: icw_planner_centos6
   plan:
   - aggregate:
@@ -1480,6 +1270,7 @@ jobs:
       BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
       TEST_OS: centos
       CONFIGURE_FLAGS: {{configure_flags}}
+
 - name: icw_gporca_centos6
   plan:
   - aggregate:
@@ -1498,6 +1289,7 @@ jobs:
       BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
       TEST_OS: centos
       CONFIGURE_FLAGS: {{configure_flags}}
+
 - name: icw_gporca_centos7
   plan:
   - aggregate:
@@ -1516,6 +1308,7 @@ jobs:
       BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
       TEST_OS: centos
       CONFIGURE_FLAGS: {{configure_flags}}
+
 - name: icw_gporca_sles11
   plan:
   - aggregate:
@@ -1534,6 +1327,7 @@ jobs:
       BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
       TEST_OS: sles
       CONFIGURE_FLAGS: {{configure_flags}}
+
 - name: icw_planner_ubuntu16
   plan:
   - aggregate:
@@ -1549,6 +1343,7 @@ jobs:
     params:
       MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off' installcheck-world
       CONFIGURE_FLAGS: {{configure_flags}}
+
 - name: icw_gporca_conan_ubuntu16
   plan:
   - aggregate:
@@ -1570,6 +1365,7 @@ jobs:
     file: gpdb_src/concourse/tasks/test_with_orca_conan.yml
     params:
       TEST_SUITE: "icw"
+
 - name: icw_planner_ictcp_centos6
   plan:
   - aggregate:
@@ -1587,7 +1383,28 @@ jobs:
       MAKE_TEST_COMMAND: PGOPTIONS='-c gp_interconnect_type=tcp -c optimizer=off' installcheck-world
       BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
       TEST_OS: centos
-- name: fts
+
+
+- name: QP_memory-accounting
+  plan:
+  - aggregate:
+    - get: gpdb_src
+      passed: [gate_icw_start]
+      trigger: true
+    - get: bin_gpdb
+      passed: [gate_icw_start]
+      resource: bin_gpdb_centos6
+    - get: centos-gpdb-dev-6
+  - task: memory-accounting
+    timeout: 3h
+    file: gpdb_src/concourse/tasks/tinc_gpdb.yml
+    image: centos-gpdb-dev-6
+    params:
+      MAKE_TEST_COMMAND: memory_accounting
+      TEST_OS: "centos"
+      CONFIGURE_FLAGS: {{configure_flags}}
+
+- name: QP_optimizer-functional
   plan:
   - aggregate:
     - get: gpdb_src
@@ -1596,6 +1413,96 @@ jobs:
     - get: bin_gpdb
       resource: bin_gpdb_centos6
       passed: [gate_icw_start]
+      trigger: true
+    - get: centos-gpdb-dev-6
+  - aggregate:
+    - task: optimizer_functional_part1
+      timeout: 3h
+      file: gpdb_src/concourse/tasks/tinc_gpdb.yml
+      image: centos-gpdb-dev-6
+      params:
+        MAKE_TEST_COMMAND: optimizer_functional_part1
+        BLDWRAP_POSTGRES_CONF_ADDONS: fsync=off optimizer_print_missing_stats=off
+        TEST_OS: centos
+        CONFIGURE_FLAGS: {{configure_flags}}
+    - task: optimizer_functional_part2
+      timeout: 3h
+      file: gpdb_src/concourse/tasks/tinc_gpdb.yml
+      image: centos-gpdb-dev-6
+      params:
+        MAKE_TEST_COMMAND: optimizer_functional_part2
+        BLDWRAP_POSTGRES_CONF_ADDONS: fsync=off optimizer_print_missing_stats=off
+        TEST_OS: centos
+        CONFIGURE_FLAGS: {{configure_flags}}
+
+- name: gate_icw_end
+  plan:
+  - aggregate:
+    - get: gpdb_src
+      passed:
+      - icw_planner_centos6
+      - icw_gporca_centos6
+      - icw_gporca_centos7
+      - icw_gporca_sles11
+      - icw_planner_ubuntu16
+      - icw_gporca_conan_ubuntu16
+      - icw_planner_ictcp_centos6
+      - QP_memory-accounting
+      - QP_optimizer-functional
+      trigger: true
+    - get: bin_gpdb_centos6
+      passed:
+      - icw_planner_centos6
+      - icw_gporca_centos6
+      - icw_planner_ictcp_centos6
+    - get: bin_gpdb_centos7
+      passed:
+      - icw_gporca_centos7
+    - get: bin_gpdb_sles11
+      passed:
+      - icw_gporca_sles11
+################# ICW Group End
+
+############## CS  Start
+- name: gate_cs_start
+  plan:
+  - task: sleep_before_starting
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: alpine
+      run:
+        path: 'sh'
+        args: ['-c', 'sleep `expr {{group_start_delay}} + 1 + $RANDOM % {{group_delay_jitter}}`']
+  - aggregate:
+    - get: gpdb_src
+      passed:
+      - gate_compile_end
+      trigger: true
+    - get: bin_gpdb_sles11
+      passed:
+      - gate_compile_end
+    - get: binary_swap_gpdb_centos6
+      passed:
+      - gate_compile_end
+    - get: bin_gpdb_centos7
+      passed:
+      - gate_compile_end
+    - get: bin_gpdb_centos6
+      passed:
+      - gate_compile_end
+
+- name: fts
+  plan:
+  - aggregate:
+    - get: gpdb_src
+      params: {submodules: none}
+      passed: [gate_cs_start]
+    - get: bin_gpdb
+      resource: bin_gpdb_centos6
+      passed: [gate_cs_start]
       trigger: true
     - get: centos-gpdb-dev-6
   - aggregate:
@@ -1623,15 +1530,16 @@ jobs:
         BLDWRAP_POSTGRES_CONF_ADDONS: gp_segment_connect_timeout=35 gp_fts_probe_interval=20
         TEST_OS: centos
         CONFIGURE_FLAGS: {{configure_flags}}
+
 - name: storage
   plan:
   - aggregate:
     - get: gpdb_src
       params: {submodules: none}
-      passed: [gate_icw_start]
+      passed: [gate_cs_start]
     - get: bin_gpdb
       resource: bin_gpdb_centos6
-      passed: [gate_icw_start]
+      passed: [gate_cs_start]
       trigger: true
     - get: centos-gpdb-dev-6
   - aggregate:
@@ -1679,85 +1587,18 @@ jobs:
         CONFIGURE_FLAGS: {{configure_flags}}
       image: centos-gpdb-dev-6
       timeout: 3h
-- name: gate_icw_end
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      passed:
-      - icw_planner_centos6
-      - icw_gporca_centos6
-      - icw_gporca_centos7
-      - icw_gporca_sles11
-      - icw_planner_ictcp_centos6
-      - fts
-      - storage
-      trigger: true
-    - get: bin_gpdb_centos6
-      passed:
-      - icw_planner_centos6
-      - icw_gporca_centos6
-      - icw_planner_ictcp_centos6
-    - get: bin_gpdb_centos7
-      passed:
-      - icw_gporca_centos7
-    - get: bin_gpdb_sles11
-      passed:
-      - icw_gporca_sles11
-    # Not used by icw group, but is passed through
-    - get: gpdb_src_tinc_tarball
-      passed:
-      - gate_icw_start
-    - get: installer_rhel6_gpdb_rc
-      passed:
-      - gate_icw_start
-    - get: qautils_rhel6_tarball
-      passed:
-      - gate_icw_start
-    - get: gpdb_src_behave_tarball
-      passed:
-      - gate_icw_start
-################# ICW Group End
 
-############## CS Misc Start
-- name: gate_cs_misc_start
-  plan:
-  - task: sleep_before_starting
-    config:
-      platform: linux
-      image_resource:
-        type: docker-image
-        source:
-          repository: alpine
-      run:
-        path: 'sh'
-        args: ['-c', 'sleep 300']
-  - aggregate:
-    - get: gpdb_src
-      passed:
-      - gate_compile_end
-      trigger: true
-    - get: bin_gpdb_sles11
-      passed:
-      - gate_compile_end
-    - get: binary_swap_gpdb_centos6
-      passed:
-      - gate_compile_end
-    - get: bin_gpdb_centos7
-      passed:
-      - gate_compile_end
-    - get: bin_gpdb_centos6
-      passed:
-      - gate_compile_end
 - name: cs_walrep_1
   plan:
+  - *ccp_jitter_delay
   - aggregate:
     - get: gpdb_src
       tags: ["ccp"]
-      passed: [gate_cs_misc_start]
+      passed: [gate_cs_start]
     - get: gpdb_binary
       tags: ["ccp"]
       resource: bin_gpdb_centos6
-      passed: [gate_cs_misc_start]
+      passed: [gate_cs_start]
       trigger: true
     - get: ccp_src
       tags: ["ccp"]
@@ -1785,16 +1626,18 @@ jobs:
     on_failure:
       <<: *debug_sleep
   - *ccp_destroy
+
 - name: cs_walrep_2
   plan:
+  - *ccp_jitter_delay
   - aggregate:
     - get: gpdb_src
       tags: ["ccp"]
-      passed: [gate_cs_misc_start]
+      passed: [gate_cs_start]
     - get: gpdb_binary
       tags: ["ccp"]
       resource: bin_gpdb_centos6
-      passed: [gate_cs_misc_start]
+      passed: [gate_cs_start]
       trigger: true
     - get: ccp_src
       tags: ["ccp"]
@@ -1822,16 +1665,18 @@ jobs:
     on_failure:
       <<: *debug_sleep
   - *ccp_destroy
+
 - name: cs_pg_twophase_01_10
   plan:
+  - *ccp_jitter_delay
   - aggregate:
     - get: gpdb_src
       tags: ["ccp"]
-      passed: [gate_cs_misc_start]
+      passed: [gate_cs_start]
     - get: gpdb_binary
       tags: ["ccp"]
       resource: bin_gpdb_centos6
-      passed: [gate_cs_misc_start]
+      passed: [gate_cs_start]
       trigger: true
     - get: ccp_src
       tags: ["ccp"]
@@ -1862,16 +1707,18 @@ jobs:
     on_failure:
       <<: *debug_sleep
   - *ccp_destroy
+
 - name: cs_pg_twophase_11_20
   plan:
+  - *ccp_jitter_delay
   - aggregate:
     - get: gpdb_src
       tags: ["ccp"]
-      passed: [gate_cs_misc_start]
+      passed: [gate_cs_start]
     - get: gpdb_binary
       tags: ["ccp"]
       resource: bin_gpdb_centos6
-      passed: [gate_cs_misc_start]
+      passed: [gate_cs_start]
       trigger: true
     - get: ccp_src
       tags: ["ccp"]
@@ -1902,16 +1749,18 @@ jobs:
     on_failure:
       <<: *debug_sleep
   - *ccp_destroy
+
 - name: cs_pg_twophase_21_30
   plan:
+  - *ccp_jitter_delay
   - aggregate:
     - get: gpdb_src
       tags: ["ccp"]
-      passed: [gate_cs_misc_start]
+      passed: [gate_cs_start]
     - get: gpdb_binary
       tags: ["ccp"]
       resource: bin_gpdb_centos6
-      passed: [gate_cs_misc_start]
+      passed: [gate_cs_start]
       trigger: true
     - get: ccp_src
       tags: ["ccp"]
@@ -1942,16 +1791,18 @@ jobs:
     on_failure:
       <<: *debug_sleep
   - *ccp_destroy
+
 - name: cs_pg_twophase_31_40
   plan:
+  - *ccp_jitter_delay
   - aggregate:
     - get: gpdb_src
       tags: ["ccp"]
-      passed: [gate_cs_misc_start]
+      passed: [gate_cs_start]
     - get: gpdb_binary
       tags: ["ccp"]
       resource: bin_gpdb_centos6
-      passed: [gate_cs_misc_start]
+      passed: [gate_cs_start]
       trigger: true
     - get: ccp_src
       tags: ["ccp"]
@@ -1982,16 +1833,18 @@ jobs:
     on_failure:
       <<: *debug_sleep
   - *ccp_destroy
+
 - name: cs_pg_twophase_41_49
   plan:
+  - *ccp_jitter_delay
   - aggregate:
     - get: gpdb_src
       tags: ["ccp"]
-      passed: [gate_cs_misc_start]
+      passed: [gate_cs_start]
     - get: gpdb_binary
       tags: ["ccp"]
       resource: bin_gpdb_centos6
-      passed: [gate_cs_misc_start]
+      passed: [gate_cs_start]
       trigger: true
     - get: ccp_src
       tags: ["ccp"]
@@ -2022,16 +1875,18 @@ jobs:
     on_failure:
       <<: *debug_sleep
   - *ccp_destroy
+
 - name: cs_pg_twophase_switch_01_12
   plan:
+  - *ccp_jitter_delay
   - aggregate:
     - get: gpdb_src
       tags: ["ccp"]
-      passed: [gate_cs_misc_start]
+      passed: [gate_cs_start]
     - get: gpdb_binary
       tags: ["ccp"]
       resource: bin_gpdb_centos6
-      passed: [gate_cs_misc_start]
+      passed: [gate_cs_start]
       trigger: true
     - get: ccp_src
       tags: ["ccp"]
@@ -2062,16 +1917,18 @@ jobs:
     on_failure:
       <<: *debug_sleep
   - *ccp_destroy
+
 - name: cs_pg_twophase_switch_13_24
   plan:
+  - *ccp_jitter_delay
   - aggregate:
     - get: gpdb_src
       tags: ["ccp"]
-      passed: [gate_cs_misc_start]
+      passed: [gate_cs_start]
     - get: gpdb_binary
       tags: ["ccp"]
       resource: bin_gpdb_centos6
-      passed: [gate_cs_misc_start]
+      passed: [gate_cs_start]
       trigger: true
     - get: ccp_src
       tags: ["ccp"]
@@ -2102,16 +1959,18 @@ jobs:
     on_failure:
       <<: *debug_sleep
   - *ccp_destroy
+
 - name: cs_pg_twophase_switch_25_33
   plan:
+  - *ccp_jitter_delay
   - aggregate:
     - get: gpdb_src
       tags: ["ccp"]
-      passed: [gate_cs_misc_start]
+      passed: [gate_cs_start]
     - get: gpdb_binary
       tags: ["ccp"]
       resource: bin_gpdb_centos6
-      passed: [gate_cs_misc_start]
+      passed: [gate_cs_start]
       trigger: true
     - get: ccp_src
       tags: ["ccp"]
@@ -2142,11 +2001,84 @@ jobs:
     on_failure:
       <<: *debug_sleep
   - *ccp_destroy
-- name: gate_cs_misc_end
+
+- name: cs_crash_recovery_schema_topology
+  plan:
+  - *ccp_jitter_delay
+  - aggregate: *cs_ccp_aggregate_mpp_start
+  - put: terraform
+    <<: *cs_ccp_terraform_params
+  - task: gen_cluster
+    <<: *cs_ccp_gen_cluster_params
+  - task: run_tests
+    <<: *cs_ccp_run_tests_params
+    params:
+      TINC_TARGET: crash_recovery_schema_topology
+  - *ccp_destroy
+
+- name: cs_crash_recovery_04_10
+  plan:
+  - *ccp_jitter_delay
+  - aggregate: *cs_ccp_aggregate_mpp_start
+  - put: terraform
+    <<: *cs_ccp_terraform_params
+  - task: gen_cluster
+    <<: *cs_ccp_gen_cluster_params
+  - task: run_tests
+    <<: *cs_ccp_run_tests_params
+    params:
+      TINC_TARGET: crash_recovery_04_10
+  - *ccp_destroy
+
+- name: cs_crash_recovery_11_20
+  plan:
+  - *ccp_jitter_delay
+  - aggregate: *cs_ccp_aggregate_mpp_start
+  - put: terraform
+    <<: *cs_ccp_terraform_params
+  - task: gen_cluster
+    <<: *cs_ccp_gen_cluster_params
+  - task: run_tests
+    <<: *cs_ccp_run_tests_params
+    params:
+      TINC_TARGET: crash_recovery_11_20
+  - *ccp_destroy
+
+- name: cs_crash_recovery_21_30
+  plan:
+  - *ccp_jitter_delay
+  - aggregate: *cs_ccp_aggregate_mpp_start
+  - put: terraform
+    <<: *cs_ccp_terraform_params
+  - task: gen_cluster
+    <<: *cs_ccp_gen_cluster_params
+  - task: run_tests
+    <<: *cs_ccp_run_tests_params
+    params:
+      TINC_TARGET: crash_recovery_21_30
+  - *ccp_destroy
+
+- name: cs_crash_recovery_31_42
+  plan:
+  - *ccp_jitter_delay
+  - aggregate: *cs_ccp_aggregate_mpp_start
+  - put: terraform
+    <<: *cs_ccp_terraform_params
+  - task: gen_cluster
+    <<: *cs_ccp_gen_cluster_params
+  - task: run_tests
+    <<: *cs_ccp_run_tests_params
+    params:
+      TINC_TARGET: crash_recovery_31_42
+  - *ccp_destroy
+
+- name: gate_cs_end
   plan:
   - aggregate:
     - get: gpdb_src
-      passed: &gate_cs_misc_passed
+      passed: &gate_cs_passed
+      - fts
+      - storage
       - cs_walrep_1
       - cs_walrep_2
       - cs_pg_twophase_01_10
@@ -2157,13 +2089,18 @@ jobs:
       - cs_pg_twophase_switch_01_12
       - cs_pg_twophase_switch_13_24
       - cs_pg_twophase_switch_25_33
+      - cs_crash_recovery_schema_topology
+      - cs_crash_recovery_04_10
+      - cs_crash_recovery_11_20
+      - cs_crash_recovery_21_30
+      - cs_crash_recovery_31_42
       trigger: true
     - get: bin_gpdb_centos6
-      passed: *gate_cs_misc_passed
-############## CS Misc End
+      passed: *gate_cs_passed
+############## CS End
 
-############### Cluster Start
-- name: gate_cluster_start
+############### MPP Start
+- name: gate_mpp_start
   plan:
   - task: sleep_before_starting
     config:
@@ -2174,30 +2111,35 @@ jobs:
           repository: alpine
       run:
         path: 'sh'
-        args: ['-c', 'sleep 300']
+        args: ['-c', 'sleep `expr 2 \* {{group_start_delay}} + 1 + $RANDOM % {{group_delay_jitter}}`']
   - aggregate:
     - get: gpdb_src
       passed:
-      - gate_mm_misc_end
+      - gate_compile_end
       trigger: true
     - get: bin_gpdb_centos6
       passed:
-      - gate_mm_misc_end
-    - get: gpdb_src_tinc_tarball
+      - gate_compile_end
+    - get: bin_gpdb_centos7
       passed:
-      - gate_mm_misc_end
-    - get: qautils_rhel6_tarball
-      passed:
-      - gate_mm_misc_end
-    - get: gpdb_src_behave_tarball
-      passed:
-      - gate_mm_misc_end
-    - get: installer_rhel6_gpdb_rc
-      passed:
-      - gate_mm_misc_end
+      - gate_compile_end
+
 - name: mpp_interconnect
   plan:
-  - aggregate: *cs_ccp_aggregate_cluster_start
+  - *ccp_jitter_delay
+  - aggregate:
+    - get: gpdb_src
+      tags: ["ccp"]
+      passed: [gate_mpp_start]
+    - get: gpdb_binary
+      tags: ["ccp"]
+      resource: bin_gpdb_centos6
+      passed: [gate_mpp_start]
+      trigger: true
+    - get: ccp_src
+      tags: ["ccp"]
+    - get: centos-gpdb-dev-6
+      tags: ["ccp"]
   - put: terraform
     <<: *cs_ccp_terraform_params
   - task: gen_cluster
@@ -2209,129 +2151,144 @@ jobs:
       PRE_TEST_SCRIPT_USER: centos
       PRE_TEST_SCRIPT: sudo bash -c 'yum -y install "kernel-devel-uname-r == $(uname -r)"'
   - *ccp_destroy
-- name: DPM_gptransfer-5x-to-5x
+
+- name: mpp_resource_group_centos6
   plan:
+  - *ccp_jitter_delay
   - aggregate:
     - get: gpdb_src
       tags: ["ccp"]
-      passed: [gate_cluster_start]
-    - get: gpdb_binary
+      passed: [gate_mpp_start]
+    - get: bin_gpdb
       tags: ["ccp"]
       resource: bin_gpdb_centos6
-      passed: [gate_cluster_start]
+      passed: [gate_mpp_start]
       trigger: true
     - get: ccp_src
       tags: ["ccp"]
     - get: centos-gpdb-dev-6
       tags: ["ccp"]
-  # The separate clusters can be created in parallel with the aggregate and do blocks
-  #  The terraform put and gen cluster that correspond must still happen serially
-  - aggregate:
-    - do:
-      - put: terraform
-        tags: ["ccp"]
-        params:
-          <<: *ccp_default_params
-          vars:
-            <<: *ccp_default_vars
-            aws_instance-node-instance_type: m4.large
-      - task: gen_cluster1
-        tags: ["ccp"]
-        file: ccp_src/ci/tasks/gen_cluster.yml
-        params:
-          <<: *ccp_gen_cluster_default_params
-        on_failure:
-          <<: *ccp_destroy
-    - do:
-      - put: terraform2
-        tags: ["ccp"]
-        params:
-          <<: *ccp_default_params
-          vars:
-            <<: *ccp_default_vars
-            aws_instance-node-instance_type: m4.large
-            cluster_suffix: "-2"
-      - task: gen_cluster2
-        tags: ["ccp"]
-        file: ccp_src/ci/tasks/gen_cluster.yml
-        params:
-          <<: *ccp_gen_cluster_default_params
-        input_mapping:
-          terraform: terraform2
-        output_mapping:
-          cluster_env_files: cluster_env_files2
-        on_failure:
-          put: terraform2
-          tags: ["ccp"]
-          params:
-            action: destroy
-            env_name_file: terraform2/name
-            terraform_source: ccp_src/aws/
-            vars:
-              <<: *ccp_default_vars
-              cluster_suffix: "-2"
-          get_params:
-            action: destroy
-  - task: gptransfer_pre_test_setup
+  - put: terraform
     tags: ["ccp"]
+    params:
+      <<: *ccp_default_params
+      vars:
+        <<: *ccp_default_vars
+  - task: gen_cluster
+    tags: ["ccp"]
+    file: ccp_src/ci/tasks/gen_cluster.yml
+    params:
+      <<: *ccp_gen_cluster_default_params
+    input_mapping:
+      gpdb_binary: bin_gpdb
+    on_failure:
+      <<: *ccp_destroy
+  - task: run_tests
+    tags: ["ccp"]
+    file: gpdb_src/concourse/tasks/ic_gpdb_resgroup.yml
+    image: centos-gpdb-dev-6
+    params:
+      TEST_OS: centos6
+    on_failure:
+      <<: *debug_sleep
+  - *ccp_destroy
+
+- name: mpp_resource_group_centos7
+  plan:
+  - *ccp_jitter_delay
+  - aggregate:
+    - get: gpdb_src
+      tags: ["gpdb5_ccp_external_worker"]
+      passed: [gate_mpp_start]
+    - get: bin_gpdb
+      tags: ["gpdb5_ccp_external_worker"]
+      resource: bin_gpdb_centos7
+      passed: [gate_mpp_start]
+      trigger: true
+    - get: ccp_src
+      tags: ["gpdb5_ccp_external_worker"]
+    - get: centos-gpdb-dev-7
+      tags: ["gpdb5_ccp_external_worker"]
+  - put: terraform
+    tags: ["gpdb5_ccp_external_worker"]
+    params:
+      <<: *ccp_default_params
+      vars:
+        <<: *ccp_default_vars
+        platform: centos7
+  - task: gen_cluster
+    tags: ["gpdb5_ccp_external_worker"]
+    file: ccp_src/ci/tasks/gen_cluster.yml
+    params:
+      <<: *ccp_gen_cluster_default_params
+    input_mapping:
+      gpdb_binary: bin_gpdb
+    on_failure:
+      <<: *ccp_destroy
+  - task: run_tests
+    tags: ["gpdb5_ccp_external_worker"]
+    file: gpdb_src/concourse/tasks/ic_gpdb_resgroup.yml
+    image: centos-gpdb-dev-7
+    params:
+      TEST_OS: centos7
+    on_failure:
+      <<: *debug_sleep
+  - *ccp_destroy
+
+- name: gate_mpp_end
+  plan:
+  - aggregate:
+    - get: gpdb_src
+      passed:
+        - mpp_interconnect
+        - mpp_resource_group_centos6
+        - mpp_resource_group_centos7
+      trigger: true
+
+############### MPP End
+
+################# MM Start
+- name: gate_mm_start
+  plan:
+  - task: sleep_before_starting
     config:
       platform: linux
-      inputs:
-        - name: cluster_env_files
-        - name: cluster_env_files2
-        - name: ccp_src
-        - name: gpdb_src
       image_resource:
         type: docker-image
         source:
-          repository: centos
-          tag: '6'
+          repository: alpine
       run:
-        path: sh
-        args:
-        - -exc
-        - |
-          source gpdb_src/concourse/scripts/transfer_utils.sh; setup_gptransfer
-    on_failure:
-      <<: *ccp_destroy_2_cluster
-  - task: run_gptransfer_tests
-    tags: ["ccp"]
-    file: gpdb_src/concourse/tasks/run_behave.yml
-    image: centos-gpdb-dev-6
-    params:
-      BEHAVE_FLAGS: --tags=gptransfer --tags=-skip_source_5
-      CUSTOM_ENV: export GPTRANSFER_DEST_HOST=mdw; export GPTRANSFER_DEST_PORT=5432; export GPTRANSFER_DEST_USER=gpadmin; export GPTRANSFER_MAP_FILE=/tmp/source_map_file; export GPTRANSFER_SOURCE_HOST=mdw-2; export GPTRANSFER_SOURCE_PORT=5432; export GPTRANSFER_SOURCE_USER=gpadmin;
-    on_failure:
-      do:
-      - task: debug_sleep_2_cluster
-        tags: ["ccp"]
-        config:
-          platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: alpine
-              tag: latest
-          run:
-            path: 'sh'
-            args: ['-c', 'sleep 6h']
-        ensure:
-          <<: *ccp_destroy_2_cluster
-  # Similar to the on_failure blocks, the final cleanup needs to be both clusters as well
-  - *ccp_destroy_2_cluster
-- name: DPM_backup-restore
+        path: 'sh'
+        args: ['-c', 'sleep `expr 3 \* {{group_start_delay}} + 1 + $RANDOM % {{group_delay_jitter}}`']
+  - aggregate:
+    - get: gpdb_src
+      passed:
+      - gate_compile_end
+      trigger: true
+    - get: bin_gpdb_centos6
+      passed:
+      - gate_compile_end
+    - get: bin_gpdb_centos7
+      passed:
+      - gate_compile_end
+    - get: bin_gpdb_sles11
+      passed:
+      - gate_compile_end
+
+- name: MM_gpcheckcat
   plan:
+  - *ccp_jitter_delay
   - aggregate:
     - get: gpdb_src
       tags: ["ccp"]
       params:
         submodules:
         - gpMgmt/bin/pythonSrc/ext
-      passed: [gate_cluster_start]
+      passed: [gate_mm_start]
     - get: gpdb_binary
       tags: ["ccp"]
       resource: bin_gpdb_centos6
-      passed: [gate_cluster_start]
+      passed: [gate_mm_start]
       trigger: true
     - get: ccp_src
       tags: ["ccp"]
@@ -2355,132 +2312,25 @@ jobs:
     file: gpdb_src/concourse/tasks/run_behave.yml
     image: centos-gpdb-dev-6
     params:
-      BEHAVE_FLAGS: --tags=backups,backup_and_restore_backups,backup_and_restore_restores,restores --tags=-nbuonly --tags=-ddonly
+      BEHAVE_FLAGS: --tags=gpcheckcat
     on_failure:
       <<: *debug_sleep
   - *ccp_destroy
-- name: cs_crash_recovery_schema_topology
-  plan:
-  - aggregate: *cs_ccp_aggregate_cluster_start
-  - put: terraform
-    <<: *cs_ccp_terraform_params
-  - task: gen_cluster
-    <<: *cs_ccp_gen_cluster_params
-  - task: run_tests
-    <<: *cs_ccp_run_tests_params
-    params:
-      TINC_TARGET: crash_recovery_schema_topology
-  - *ccp_destroy
-- name: cs_crash_recovery_04_10
-  plan:
-  - aggregate: *cs_ccp_aggregate_cluster_start
-  - put: terraform
-    <<: *cs_ccp_terraform_params
-  - task: gen_cluster
-    <<: *cs_ccp_gen_cluster_params
-  - task: run_tests
-    <<: *cs_ccp_run_tests_params
-    params:
-      TINC_TARGET: crash_recovery_04_10
-  - *ccp_destroy
-- name: cs_crash_recovery_11_20
-  plan:
-  - aggregate: *cs_ccp_aggregate_cluster_start
-  - put: terraform
-    <<: *cs_ccp_terraform_params
-  - task: gen_cluster
-    <<: *cs_ccp_gen_cluster_params
-  - task: run_tests
-    <<: *cs_ccp_run_tests_params
-    params:
-      TINC_TARGET: crash_recovery_11_20
-  - *ccp_destroy
-- name: cs_crash_recovery_21_30
-  plan:
-  - aggregate: *cs_ccp_aggregate_cluster_start
-  - put: terraform
-    <<: *cs_ccp_terraform_params
-  - task: gen_cluster
-    <<: *cs_ccp_gen_cluster_params
-  - task: run_tests
-    <<: *cs_ccp_run_tests_params
-    params:
-      TINC_TARGET: crash_recovery_21_30
-  - *ccp_destroy
-- name: cs_crash_recovery_31_42
-  plan:
-  - aggregate: *cs_ccp_aggregate_cluster_start
-  - put: terraform
-    <<: *cs_ccp_terraform_params
-  - task: gen_cluster
-    <<: *cs_ccp_gen_cluster_params
-  - task: run_tests
-    <<: *cs_ccp_run_tests_params
-    params:
-      TINC_TARGET: crash_recovery_31_42
-  - *ccp_destroy
-- name: gate_cluster_end
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      passed:
-      - DPM_gptransfer-5x-to-5x
-      - DPM_backup-restore
-      - mpp_interconnect
-      - cs_crash_recovery_schema_topology
-      - cs_crash_recovery_04_10
-      - cs_crash_recovery_11_20
-      - cs_crash_recovery_21_30
-      - cs_crash_recovery_31_42
-      trigger: true
-    - get: bin_gpdb_centos6
-      passed:
-      - DPM_backup-restore
-############### Cluster End
 
-################# MM Misc Start
-- name: gate_mm_misc_start
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      passed:
-      - gate_icw_end
-      trigger: true
-    - get: bin_gpdb_centos6
-      passed:
-      - gate_icw_end
-    - get: bin_gpdb_centos7
-      passed:
-      - gate_icw_end
-    - get: bin_gpdb_sles11
-      passed:
-      - gate_icw_end
-    # Not used by icw group, but is passed through
-    - get: gpdb_src_tinc_tarball
-      passed:
-      - gate_icw_end
-    - get: installer_rhel6_gpdb_rc
-      passed:
-      - gate_icw_end
-    - get: qautils_rhel6_tarball
-      passed:
-      - gate_icw_end
-    - get: gpdb_src_behave_tarball
-      passed:
-      - gate_icw_end
 - name: MM_gppkg
   plan:
+  - *ccp_jitter_delay
   - aggregate:
     - get: gpdb_src
       tags: ["ccp"]
       params:
         submodules:
         - gpMgmt/bin/pythonSrc/ext
-      passed: [gate_mm_misc_start]
+      passed: [gate_mm_start]
     - get: gpdb_binary
       tags: ["ccp"]
       resource: bin_gpdb_centos6
-      passed: [gate_mm_misc_start]
+      passed: [gate_mm_start]
       trigger: true
     - get: ccp_src
       tags: ["ccp"]
@@ -2515,19 +2365,21 @@ jobs:
     on_failure:
       <<: *debug_sleep
   - *ccp_destroy
+
 - name: MM_gprecoverseg
   plan:
+  - *ccp_jitter_delay
   - aggregate:
     - get: gpdb_src
       tags: ["ccp"]
       params:
         submodules:
         - gpMgmt/bin/pythonSrc/ext
-      passed: [gate_mm_misc_start]
+      passed: [gate_mm_start]
     - get: gpdb_binary
       tags: ["ccp"]
       resource: bin_gpdb_centos6
-      passed: [gate_mm_misc_start]
+      passed: [gate_mm_start]
       trigger: true
     - get: ccp_src
       tags: ["ccp"]
@@ -2555,6 +2407,7 @@ jobs:
     on_failure:
       <<: *debug_sleep
   - *ccp_destroy
+
 - name: MM_gpcheck
   plan:
   - aggregate: &gets_for_behave
@@ -2562,10 +2415,10 @@ jobs:
       params:
         submodules:
         - gpMgmt/bin/pythonSrc/ext
-      passed: [gate_mm_misc_start]
+      passed: [gate_mm_start]
     - get: bin_gpdb
       resource: bin_gpdb_centos6
-      passed: [gate_mm_misc_start]
+      passed: [gate_mm_start]
       trigger: true
     - get: centos-gpdb-dev-6
   - task: gpcheck_as_gpadmin
@@ -2574,6 +2427,7 @@ jobs:
     params:
       BEHAVE_TAGS: gpcheck_as_gpadmin
       GPCHECK_SETUP: true
+
 - name: MM_analyzedb
   plan:
   - aggregate: *gets_for_behave
@@ -2582,6 +2436,7 @@ jobs:
     image: centos-gpdb-dev-6
     params:
       BEHAVE_TAGS: analyzedb
+
 - name: MM_gpperfmon
   plan:
   - aggregate: *gets_for_behave
@@ -2590,6 +2445,7 @@ jobs:
     image: centos-gpdb-dev-6
     params:
       BEHAVE_TAGS: gpperfmon
+
 - name: MM_pt-rebuild
   plan:
   - aggregate: *gets_for_behave
@@ -2606,6 +2462,7 @@ jobs:
         MAKE_TEST_COMMAND: persistent_table_rebuild
         TEST_OS: centos
         CONFIGURE_FLAGS: {{configure_flags}}
+
 - name: MM_gpinitsystem
   plan:
   - aggregate: *gets_for_behave
@@ -2614,14 +2471,15 @@ jobs:
     image: centos-gpdb-dev-6
     params:
       BEHAVE_TAGS: gpinitsystem
+
 - name: MU_check_centos
   plan:
   - aggregate:
     - get: gpdb_src
-      passed: [gate_mm_misc_start]
+      passed: [gate_mm_start]
     - get: bin_gpdb
       resource: bin_gpdb_centos6
-      passed: [gate_mm_misc_start]
+      passed: [gate_mm_start]
       trigger: true
     - get: centos-gpdb-dev-6
   - task: MU_check_centos
@@ -2629,6 +2487,7 @@ jobs:
     image: centos-gpdb-dev-6
     params:
       TEST_OS: centos
+
 - name: MM_gpinitstandby
   plan:
   - aggregate: *gets_for_behave
@@ -2637,43 +2496,122 @@ jobs:
     image: centos-gpdb-dev-6
     params:
       BEHAVE_TAGS: gpinitstandby
-- name: gate_mm_misc_end
+
+- name: MM_gpexpand_1
+  plan:
+  - *ccp_jitter_delay
+  - aggregate:
+    - get: gpdb_src
+      tags: ["ccp"]
+      params:
+        submodules:
+        - gpMgmt/bin/pythonSrc/ext
+      passed: [gate_mm_start]
+    - get: gpdb_binary
+      tags: ["ccp"]
+      resource: bin_gpdb_centos6
+      passed: [gate_mm_start]
+      trigger: true
+    - get: ccp_src
+      tags: ["ccp"]
+    - get: centos-gpdb-dev-6
+      tags: ["ccp"]
+  - put: terraform
+    tags: ["ccp"]
+    params:
+      <<: *ccp_default_params
+      vars:
+        <<: *ccp_default_vars
+        number_of_nodes: 5
+  - task: gen_cluster
+    tags: ["ccp"]
+    file: ccp_src/ci/tasks/gen_cluster.yml
+    params:
+      <<: *ccp_gen_cluster_default_params
+    on_failure:
+      <<: *ccp_destroy
+  - task: run_tests
+    tags: ["ccp"]
+    file: gpdb_src/concourse/tasks/run_tinc.yml
+    image: centos-gpdb-dev-6
+    params:
+      TINC_TARGET: gpexpand_1
+      CUSTOM_ENV: HOST1=mdw HOST2=sdw1 HOST3=sdw2 HOST4=sdw3 HOST5=sdw4
+      PRE_TEST_SCRIPT: bash -c 'ssh-keygen -f ~/.ssh/id_rsa -y > ~/.ssh/id_rsa.pub; for i in mdw sdw{1..4}; do ssh centos@$i "sudo chmod 777 /usr/local"; done'
+    on_failure:
+      <<: *debug_sleep
+  - *ccp_destroy
+
+- name: MM_gpexpand_2
+  plan:
+  - *ccp_jitter_delay
+  - aggregate:
+    - get: gpdb_src
+      tags: ["ccp"]
+      params:
+        submodules:
+        - gpMgmt/bin/pythonSrc/ext
+      passed: [gate_mm_start]
+    - get: gpdb_binary
+      tags: ["ccp"]
+      resource: bin_gpdb_centos6
+      passed: [gate_mm_start]
+      trigger: true
+    - get: ccp_src
+      tags: ["ccp"]
+    - get: centos-gpdb-dev-6
+      tags: ["ccp"]
+  - put: terraform
+    tags: ["ccp"]
+    params:
+      <<: *ccp_default_params
+      vars:
+        <<: *ccp_default_vars
+        number_of_nodes: 5
+  - task: gen_cluster
+    tags: ["ccp"]
+    file: ccp_src/ci/tasks/gen_cluster.yml
+    params:
+      <<: *ccp_gen_cluster_default_params
+    on_failure:
+      <<: *ccp_destroy
+  - task: run_tests
+    tags: ["ccp"]
+    file: gpdb_src/concourse/tasks/run_tinc.yml
+    image: centos-gpdb-dev-6
+    params:
+      TINC_TARGET: gpexpand_2
+      CUSTOM_ENV: HOST1=mdw HOST2=sdw1 HOST3=sdw2 HOST4=sdw3 HOST5=sdw4
+      PRE_TEST_SCRIPT: bash -c 'ssh-keygen -f ~/.ssh/id_rsa -y > ~/.ssh/id_rsa.pub; for i in mdw sdw{1..4}; do ssh centos@$i "sudo chmod 777 /usr/local"; done'
+    on_failure:
+      <<: *debug_sleep
+  - *ccp_destroy
+
+
+- name: gate_mm_end
   plan:
   - aggregate:
     - get: gpdb_src
-      passed: &gate_mm_misc_end_passed
-      - MU_check_centos
-      - MM_analyzedb
-      - MM_gpinitsystem
-      - MM_gpperfmon
-      - MM_gpcheck
-      - MM_pt-rebuild
-      - MM_gpinitstandby
+      passed: &gate_mm_end_passed
+      - MM_gpcheckcat
       - MM_gppkg
       - MM_gprecoverseg
+      - MM_gpcheck
+      - MM_analyzedb
+      - MM_gpperfmon
+      - MM_pt-rebuild
+      - MM_gpinitsystem
+      - MU_check_centos
+      - MM_gpinitstandby
+      - MM_gpexpand_1
+      - MM_gpexpand_2
       trigger: true
     - get: bin_gpdb_centos6
-      passed: *gate_mm_misc_end_passed
-    # Not used by icw group, but is passed through
-    - get: bin_gpdb_centos7
-      passed:
-      - gate_mm_misc_start
-    - get: gpdb_src_tinc_tarball
-      passed:
-      - gate_mm_misc_start
-    - get: installer_rhel6_gpdb_rc
-      passed:
-      - gate_mm_misc_start
-    - get: qautils_rhel6_tarball
-      passed:
-      - gate_mm_misc_start
-    - get: gpdb_src_behave_tarball
-      passed:
-      - gate_mm_misc_start
-################# MM Misc End
+      passed: *gate_mm_end_passed
+################# MM End
 
-############### Nightly Start
-- name: gate_nightly_start
+############### DPM Start
+- name: gate_dpm_start
   plan:
   - task: sleep_before_starting
     config:
@@ -2684,43 +2622,384 @@ jobs:
           repository: alpine
       run:
         path: 'sh'
-        args: ['-c', 'sleep 300']
+        args: ['-c', 'sleep `expr 4 \* {{group_start_delay}} + 1 + $RANDOM % {{group_delay_jitter}}`']
   - aggregate:
     - get: gpdb_src
       passed:
-      - gate_icw_end
+      - gate_compile_end
       trigger: true
     - get: bin_gpdb_centos6
       passed:
-      - gate_icw_end
-    - get: gpdb_src_tinc_tarball
-      passed:
-      - gate_icw_end
-    - get: installer_rhel6_gpdb_rc
-      passed:
-      - gate_icw_end
-    - get: qautils_rhel6_tarball
-      passed:
-      - gate_icw_end
-    - get: gpdb_src_behave_tarball
-      passed:
-      - gate_icw_end
-- name: DPM_backup_43_restore_5
+      - gate_compile_end
+
+- name: DPM_backup-restore
   plan:
-  - get: nightly-trigger
-    tags: ["ccp"]
-    trigger: true
+  - *ccp_jitter_delay
   - aggregate:
     - get: gpdb_src
       tags: ["ccp"]
       params:
         submodules:
         - gpMgmt/bin/pythonSrc/ext
-      passed: [gate_nightly_start]
+      passed: [gate_dpm_start]
     - get: gpdb_binary
       tags: ["ccp"]
       resource: bin_gpdb_centos6
-      passed: [gate_nightly_start]
+      passed: [gate_dpm_start]
+      trigger: true
+    - get: ccp_src
+      tags: ["ccp"]
+    - get: centos-gpdb-dev-6
+      tags: ["ccp"]
+  - put: terraform
+    tags: ["ccp"]
+    params:
+      <<: *ccp_default_params
+      vars:
+        <<: *ccp_default_vars
+  - task: gen_cluster
+    tags: ["ccp"]
+    file: ccp_src/ci/tasks/gen_cluster.yml
+    params:
+      <<: *ccp_gen_cluster_default_params
+    on_failure:
+      <<: *ccp_destroy
+  - task: run_tests
+    tags: ["ccp"]
+    file: gpdb_src/concourse/tasks/run_behave.yml
+    image: centos-gpdb-dev-6
+    params:
+      BEHAVE_FLAGS: --tags=backups,backup_and_restore_backups,backup_and_restore_restores,restores --tags=-nbuonly --tags=-ddonly
+    on_failure:
+      <<: *debug_sleep
+  - *ccp_destroy
+
+- name: DPM_backup-restore_ddboost_part1
+  plan:
+  - get: nightly-trigger
+    trigger: true
+  - *ccp_jitter_delay
+  - aggregate:
+    - get: ccp_src
+      tags: ["ddboost"]
+    - get: gpdb_src
+      tags: ["ddboost"]
+      passed: [gate_dpm_start]
+    - get: gpdb_binary
+      tags: ["ddboost"]
+      resource: bin_gpdb_centos6
+      passed: [gate_dpm_start]
+    - get: centos-gpdb-dev-6
+      tags: ["ddboost"]
+  - put: terraform_for_dpm
+    params:
+      <<: *ccp_default_params
+      terraform_source: ccp_src/aws-pivotal-pa-toolsmiths/
+      vars:
+        <<: *ccp_default_vars
+    tags: ["ddboost"]
+  - task: gen_cluster
+    input_mapping:
+      terraform: terraform_for_dpm
+    tags: ["ddboost"]
+    file: ccp_src/ci/tasks/gen_cluster.yml
+    params:
+      <<: *ccp_gpdb4_gen_cluster_default_params
+    on_failure:
+      <<: *dpm_ccp_destroy
+  - task: netbackup_pre_test_setup
+    tags: ["netbackup"]
+    file: gpdb_src/concourse/tasks/setup_netbackup.yml
+    image: centos-gpdb-dev-6
+    params:
+      CUSTOM_ENV: export NETBACKUP_SERVER={{netbackup_host}}; export NETBACKUP_KEY={{netbackup_key}};
+  - task: run_tests
+    tags: ["ddboost"]
+    file: gpdb_src/concourse/tasks/run_behave.yml
+    image: centos-gpdb-dev-6
+    params:
+      BEHAVE_FLAGS: --tags=ddboostsetup,ddpartI
+      CUSTOM_ENV: export DD_SOURCE_HOST={{datadomain_source_host}}; export DD_DEST_HOST={{datadomain_dest_host}}; export DD_USER={{datadomain_user}}; export DD_PASSWORD={{datadomain_password}};
+      PRE_TEST_SCRIPT: "source /home/gpadmin/gpdb_src/concourse/scripts/backup_utils.sh; setup_ddboost"
+    on_failure:
+      <<: *dpm_debug_sleep
+  - *dpm_ccp_destroy
+
+- name: DPM_backup-restore_ddboost_part2
+  plan:
+  - get: nightly-trigger
+    trigger: true
+  - *ccp_jitter_delay
+  - aggregate:
+    - get: ccp_src
+      tags: ["ddboost"]
+    - get: gpdb_src
+      tags: ["ddboost"]
+      passed: [gate_dpm_start]
+    - get: gpdb_binary
+      tags: ["ddboost"]
+      resource: bin_gpdb_centos6
+      passed: [gate_dpm_start]
+    - get: centos-gpdb-dev-6
+      tags: ["ddboost"]
+  - put: terraform_for_dpm
+    params:
+      <<: *ccp_default_params
+      terraform_source: ccp_src/aws-pivotal-pa-toolsmiths/
+      vars:
+        <<: *ccp_default_vars
+    tags: ["ddboost"]
+  - task: gen_cluster
+    input_mapping:
+      terraform: terraform_for_dpm
+    tags: ["ddboost"]
+    file: ccp_src/ci/tasks/gen_cluster.yml
+    params:
+      <<: *ccp_gpdb4_gen_cluster_default_params
+    on_failure:
+      <<: *dpm_ccp_destroy
+  - task: netbackup_pre_test_setup
+    tags: ["netbackup"]
+    file: gpdb_src/concourse/tasks/setup_netbackup.yml
+    image: centos-gpdb-dev-6
+    params:
+      CUSTOM_ENV: export NETBACKUP_SERVER={{netbackup_host}}; export NETBACKUP_KEY={{netbackup_key}};
+  - task: run_tests
+    tags: ["ddboost"]
+    file: gpdb_src/concourse/tasks/run_behave.yml
+    image: centos-gpdb-dev-6
+    params:
+      BEHAVE_FLAGS: --tags=ddboostsetup,ddpartII
+      CUSTOM_ENV: export DD_SOURCE_HOST={{datadomain_source_host}}; export DD_DEST_HOST={{datadomain_dest_host}}; export DD_USER={{datadomain_user}}; export DD_PASSWORD={{datadomain_password}};
+      PRE_TEST_SCRIPT: "source /home/gpadmin/gpdb_src/concourse/scripts/backup_utils.sh; setup_ddboost"
+    on_failure:
+      <<: *dpm_debug_sleep
+  - *dpm_ccp_destroy
+
+- name: DPM_backup-restore_ddboost_part3
+  plan:
+  - get: nightly-trigger
+    trigger: true
+  - *ccp_jitter_delay
+  - aggregate:
+    - get: ccp_src
+      tags: ["ddboost"]
+    - get: gpdb_src
+      tags: ["ddboost"]
+      passed: [gate_dpm_start]
+    - get: gpdb_binary
+      tags: ["ddboost"]
+      resource: bin_gpdb_centos6
+      passed: [gate_dpm_start]
+    - get: centos-gpdb-dev-6
+      tags: ["ddboost"]
+  - put: terraform_for_dpm
+    params:
+      <<: *ccp_default_params
+      terraform_source: ccp_src/aws-pivotal-pa-toolsmiths/
+      vars:
+        <<: *ccp_default_vars
+    tags: ["ddboost"]
+  - task: gen_cluster
+    input_mapping:
+      terraform: terraform_for_dpm
+    tags: ["ddboost"]
+    file: ccp_src/ci/tasks/gen_cluster.yml
+    params:
+      <<: *ccp_gpdb4_gen_cluster_default_params
+    on_failure:
+      <<: *dpm_ccp_destroy
+  - task: run_tests
+    tags: ["ddboost"]
+    file: gpdb_src/concourse/tasks/run_behave.yml
+    image: centos-gpdb-dev-6
+    params:
+      BEHAVE_FLAGS: --tags=ddboostsetup,ddpartIII
+      CUSTOM_ENV: export DD_SOURCE_HOST={{datadomain_source_host}}; export DD_DEST_HOST={{datadomain_dest_host}}; export DD_USER={{datadomain_user}}; export DD_PASSWORD={{datadomain_password}};
+      PRE_TEST_SCRIPT: "source /home/gpadmin/gpdb_src/concourse/scripts/backup_utils.sh; setup_ddboost"
+    on_failure:
+      <<: *dpm_debug_sleep
+  - *dpm_ccp_destroy
+
+- name: DPM_backup-restore_netbackup_part1
+  plan:
+  - get: nightly-trigger
+    tags: ["netbackup"]
+    trigger: true
+  - *ccp_jitter_delay
+  - aggregate:
+    - get: ccp_src
+      tags: ["netbackup"]
+    - get: gpdb_src
+      tags: ["netbackup"]
+      passed: [gate_dpm_start]
+    - get: gpdb_binary
+      tags: ["netbackup"]
+      resource: bin_gpdb_centos6
+      passed: [gate_dpm_start]
+    - get: centos-gpdb-dev-6
+      tags: ["netbackup"]
+    - get: netbackup_installer
+      tags: ["netbackup"]
+      resource: netbackup-client-installer
+  - put: terraform_for_dpm
+    params:
+      <<: *ccp_default_params
+      terraform_source: ccp_src/aws-pivotal-pa-toolsmiths/
+      vars:
+        <<: *ccp_default_vars
+    tags: ["netbackup"]
+  - task: gen_cluster
+    input_mapping:
+      terraform: terraform_for_dpm
+    tags: ["netbackup"]
+    file: ccp_src/ci/tasks/gen_cluster.yml
+    params:
+      <<: *ccp_gpdb4_gen_cluster_default_params
+    on_failure:
+      <<: *dpm_ccp_destroy
+  - task: setup_netbackup
+    tags: ["netbackup"]
+    file: gpdb_src/concourse/tasks/setup_netbackup.yml
+    image: centos-gpdb-dev-6
+    params:
+      CUSTOM_ENV: export NETBACKUP_SERVER={{netbackup_host}}; export NETBACKUP_KEY={{netbackup_key}};
+  - task: run_tests
+    tags: ["netbackup"]
+    file: gpdb_src/concourse/tasks/run_behave.yml
+    image: centos-gpdb-dev-6
+    params:
+      BEHAVE_FLAGS: --tags=nbusetup77,nbupartI
+      CUSTOM_ENV: export NETBACKUP_SERVER={{netbackup_host}};
+    on_failure:
+      <<: *dpm_debug_sleep
+  - *dpm_ccp_destroy
+
+- name: DPM_backup-restore_netbackup_part2
+  plan:
+  - get: nightly-trigger
+    tags: ["netbackup"]
+    trigger: true
+  - *ccp_jitter_delay
+  - aggregate:
+    - get: ccp_src
+      tags: ["netbackup"]
+    - get: gpdb_src
+      tags: ["netbackup"]
+      passed: [gate_dpm_start]
+    - get: gpdb_binary
+      tags: ["netbackup"]
+      resource: bin_gpdb_centos6
+      passed: [gate_dpm_start]
+    - get: centos-gpdb-dev-6
+      tags: ["netbackup"]
+    - get: netbackup_installer
+      tags: ["netbackup"]
+      resource: netbackup-client-installer
+  - put: terraform_for_dpm
+    params:
+      <<: *ccp_default_params
+      terraform_source: ccp_src/aws-pivotal-pa-toolsmiths/
+      vars:
+        <<: *ccp_default_vars
+    tags: ["netbackup"]
+  - task: gen_cluster
+    input_mapping:
+      terraform: terraform_for_dpm
+    tags: ["netbackup"]
+    file: ccp_src/ci/tasks/gen_cluster.yml
+    params:
+      <<: *ccp_gpdb4_gen_cluster_default_params
+    on_failure:
+      <<: *dpm_ccp_destroy
+  - task: setup_netbackup
+    tags: ["netbackup"]
+    file: gpdb_src/concourse/tasks/setup_netbackup.yml
+    image: centos-gpdb-dev-6
+    params:
+      CUSTOM_ENV: export NETBACKUP_SERVER={{netbackup_host}}; export NETBACKUP_KEY={{netbackup_key}};
+  - task: run_tests
+    tags: ["netbackup"]
+    file: gpdb_src/concourse/tasks/run_behave.yml
+    image: centos-gpdb-dev-6
+    params:
+      BEHAVE_FLAGS: --tags=nbusetup77,nbupartII
+      CUSTOM_ENV: export NETBACKUP_SERVER={{netbackup_host}};
+    on_failure:
+      <<: *dpm_debug_sleep
+  - *dpm_ccp_destroy
+
+- name: DPM_backup-restore_netbackup_part3
+  plan:
+  - get: nightly-trigger
+    tags: ["netbackup"]
+    trigger: true
+  - *ccp_jitter_delay
+  - aggregate:
+    - get: ccp_src
+      tags: ["netbackup"]
+    - get: gpdb_src
+      tags: ["netbackup"]
+      passed: [gate_dpm_start]
+    - get: gpdb_binary
+      tags: ["netbackup"]
+      resource: bin_gpdb_centos6
+      passed: [gate_dpm_start]
+    - get: centos-gpdb-dev-6
+      tags: ["netbackup"]
+    - get: netbackup_installer
+      tags: ["netbackup"]
+      resource: netbackup-client-installer
+  - put: terraform_for_dpm
+    params:
+      <<: *ccp_default_params
+      terraform_source: ccp_src/aws-pivotal-pa-toolsmiths/
+      vars:
+        <<: *ccp_default_vars
+    tags: ["netbackup"]
+  - task: gen_cluster
+    input_mapping:
+      terraform: terraform_for_dpm
+    tags: ["netbackup"]
+    file: ccp_src/ci/tasks/gen_cluster.yml
+    params:
+      <<: *ccp_gpdb4_gen_cluster_default_params
+    on_failure:
+      <<: *dpm_ccp_destroy
+  - task: netbackup_pre_test_setup
+    tags: ["netbackup"]
+    file: gpdb_src/concourse/tasks/setup_netbackup.yml
+    image: centos-gpdb-dev-6
+    params:
+      CUSTOM_ENV: export NETBACKUP_SERVER={{netbackup_host}}; export NETBACKUP_KEY={{netbackup_key}};
+  - task: run_tests
+    tags: ["netbackup"]
+    file: gpdb_src/concourse/tasks/run_behave.yml
+    image: centos-gpdb-dev-6
+    params:
+      BEHAVE_FLAGS: --tags=nbusetup77,nbupartIII
+      CUSTOM_ENV: export NETBACKUP_SERVER={{netbackup_host}};
+    on_failure:
+      <<: *dpm_debug_sleep
+  - *dpm_ccp_destroy
+
+- name: DPM_backup_43_restore_5
+  plan:
+  - get: nightly-trigger
+    tags: ["ccp"]
+    trigger: true
+  - *ccp_jitter_delay
+  - aggregate:
+    - get: gpdb_src
+      tags: ["ccp"]
+      params:
+        submodules:
+        - gpMgmt/bin/pythonSrc/ext
+      passed: [gate_dpm_start]
+    - get: gpdb_binary
+      tags: ["ccp"]
+      resource: bin_gpdb_centos6
+      passed: [gate_dpm_start]
     - get: gpdb4_binary
       tags: ["ccp"]
       resource: bin_gpdb4_centos6
@@ -2768,261 +3047,21 @@ jobs:
     on_failure:
       <<: *debug_sleep
   - *ccp_destroy
-- name: MM_gpexpand_1
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      tags: ["ccp"]
-      params:
-        submodules:
-        - gpMgmt/bin/pythonSrc/ext
-      passed: [gate_mm_misc_start]
-    - get: gpdb_binary
-      tags: ["ccp"]
-      resource: bin_gpdb_centos6
-      passed: [gate_mm_misc_start]
-      trigger: true
-    - get: ccp_src
-      tags: ["ccp"]
-    - get: centos-gpdb-dev-6
-      tags: ["ccp"]
-  - put: terraform
-    tags: ["ccp"]
-    params:
-      <<: *ccp_default_params
-      vars:
-        <<: *ccp_default_vars
-        number_of_nodes: 5
-  - task: gen_cluster
-    tags: ["ccp"]
-    file: ccp_src/ci/tasks/gen_cluster.yml
-    params:
-      <<: *ccp_gen_cluster_default_params
-    on_failure:
-      <<: *ccp_destroy
-  - task: run_tests
-    tags: ["ccp"]
-    file: gpdb_src/concourse/tasks/run_tinc.yml
-    image: centos-gpdb-dev-6
-    params:
-      TINC_TARGET: gpexpand_1
-      CUSTOM_ENV: HOST1=mdw HOST2=sdw1 HOST3=sdw2 HOST4=sdw3 HOST5=sdw4
-      PRE_TEST_SCRIPT: bash -c 'ssh-keygen -f ~/.ssh/id_rsa -y > ~/.ssh/id_rsa.pub; for i in mdw sdw{1..4}; do ssh centos@$i "sudo chmod 777 /usr/local"; done'
-    on_failure:
-      <<: *debug_sleep
-  - *ccp_destroy
-- name: MM_gpexpand_2
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      tags: ["ccp"]
-      params:
-        submodules:
-        - gpMgmt/bin/pythonSrc/ext
-      passed: [gate_mm_misc_start]
-    - get: gpdb_binary
-      tags: ["ccp"]
-      resource: bin_gpdb_centos6
-      passed: [gate_mm_misc_start]
-      trigger: true
-    - get: ccp_src
-      tags: ["ccp"]
-    - get: centos-gpdb-dev-6
-      tags: ["ccp"]
-  - put: terraform
-    tags: ["ccp"]
-    params:
-      <<: *ccp_default_params
-      vars:
-        <<: *ccp_default_vars
-        number_of_nodes: 5
-  - task: gen_cluster
-    tags: ["ccp"]
-    file: ccp_src/ci/tasks/gen_cluster.yml
-    params:
-      <<: *ccp_gen_cluster_default_params
-    on_failure:
-      <<: *ccp_destroy
-  - task: run_tests
-    tags: ["ccp"]
-    file: gpdb_src/concourse/tasks/run_tinc.yml
-    image: centos-gpdb-dev-6
-    params:
-      TINC_TARGET: gpexpand_2
-      CUSTOM_ENV: HOST1=mdw HOST2=sdw1 HOST3=sdw2 HOST4=sdw3 HOST5=sdw4
-      PRE_TEST_SCRIPT: bash -c 'ssh-keygen -f ~/.ssh/id_rsa -y > ~/.ssh/id_rsa.pub; for i in mdw sdw{1..4}; do ssh centos@$i "sudo chmod 777 /usr/local"; done'
-    on_failure:
-      <<: *debug_sleep
-  - *ccp_destroy
-- name: DPM_backup-restore_netbackup_part1
-  plan:
-  - get: nightly-trigger
-    tags: ["netbackup"]
-    trigger: true
-  - aggregate:
-    - get: ccp_src
-      tags: ["netbackup"]
-    - get: gpdb_src
-      tags: ["netbackup"]
-      passed: [gate_nightly_start]
-    - get: gpdb_binary
-      tags: ["netbackup"]
-      resource: bin_gpdb_centos6
-      passed: [gate_nightly_start]
-    - get: centos-gpdb-dev-6
-      tags: ["netbackup"]
-    - get: netbackup_installer
-      tags: ["netbackup"]
-      resource: netbackup-client-installer
-  - put: terraform_for_dpm
-    params:
-      <<: *ccp_default_params
-      terraform_source: ccp_src/aws-pivotal-pa-toolsmiths/
-      vars:
-        <<: *ccp_default_vars
-    tags: ["netbackup"]
-  - task: gen_cluster
-    input_mapping:
-      terraform: terraform_for_dpm
-    tags: ["netbackup"]
-    file: ccp_src/ci/tasks/gen_cluster.yml
-    params:
-      <<: *ccp_gpdb4_gen_cluster_default_params
-    on_failure:
-      <<: *dpm_ccp_destroy
-  - task: netbackup_pre_test_setup
-    tags: ["netbackup"]
-    file: gpdb_src/concourse/tasks/setup_netbackup.yml
-    image: centos-gpdb-dev-6
-    params:
-      CUSTOM_ENV: export NETBACKUP_SERVER={{netbackup_host}}; export NETBACKUP_KEY={{netbackup_key}};
-  - task: run_tests
-    tags: ["netbackup"]
-    file: gpdb_src/concourse/tasks/run_behave.yml
-    image: centos-gpdb-dev-6
-    params:
-      BEHAVE_FLAGS: --tags=nbusetup77,nbupartI
-      CUSTOM_ENV: export NETBACKUP_SERVER={{netbackup_host}};
-    on_failure:
-      <<: *dpm_debug_sleep
-  - *dpm_ccp_destroy
-- name: DPM_backup-restore_netbackup_part2
-  plan:
-  - get: nightly-trigger
-    tags: ["netbackup"]
-    trigger: true
-  - aggregate:
-    - get: ccp_src
-      tags: ["netbackup"]
-    - get: gpdb_src
-      tags: ["netbackup"]
-      passed: [gate_nightly_start]
-    - get: gpdb_binary
-      tags: ["netbackup"]
-      resource: bin_gpdb_centos6
-      passed: [gate_nightly_start]
-    - get: centos-gpdb-dev-6
-      tags: ["netbackup"]
-    - get: netbackup_installer
-      tags: ["netbackup"]
-      resource: netbackup-client-installer
-  - put: terraform_for_dpm
-    params:
-      <<: *ccp_default_params
-      terraform_source: ccp_src/aws-pivotal-pa-toolsmiths/
-      vars:
-        <<: *ccp_default_vars
-    tags: ["netbackup"]
-  - task: gen_cluster
-    input_mapping:
-      terraform: terraform_for_dpm
-    tags: ["netbackup"]
-    file: ccp_src/ci/tasks/gen_cluster.yml
-    params:
-      <<: *ccp_gpdb4_gen_cluster_default_params
-    on_failure:
-      <<: *dpm_ccp_destroy
-  - task: netbackup_pre_test_setup
-    tags: ["netbackup"]
-    file: gpdb_src/concourse/tasks/setup_netbackup.yml
-    image: centos-gpdb-dev-6
-    params:
-      CUSTOM_ENV: export NETBACKUP_SERVER={{netbackup_host}}; export NETBACKUP_KEY={{netbackup_key}};
-  - task: run_tests
-    tags: ["netbackup"]
-    file: gpdb_src/concourse/tasks/run_behave.yml
-    image: centos-gpdb-dev-6
-    params:
-      BEHAVE_FLAGS: --tags=nbusetup77,nbupartII
-      CUSTOM_ENV: export NETBACKUP_SERVER={{netbackup_host}};
-    on_failure:
-      <<: *dpm_debug_sleep
-  - *dpm_ccp_destroy
-- name: DPM_backup-restore_netbackup_part3
-  plan:
-  - get: nightly-trigger
-    tags: ["netbackup"]
-    trigger: true
-  - aggregate:
-    - get: ccp_src
-      tags: ["netbackup"]
-    - get: gpdb_src
-      tags: ["netbackup"]
-      passed: [gate_nightly_start]
-    - get: gpdb_binary
-      tags: ["netbackup"]
-      resource: bin_gpdb_centos6
-      passed: [gate_nightly_start]
-    - get: centos-gpdb-dev-6
-      tags: ["netbackup"]
-    - get: netbackup_installer
-      tags: ["netbackup"]
-      resource: netbackup-client-installer
-  - put: terraform_for_dpm
-    params:
-      <<: *ccp_default_params
-      terraform_source: ccp_src/aws-pivotal-pa-toolsmiths/
-      vars:
-        <<: *ccp_default_vars
-    tags: ["netbackup"]
-  - task: gen_cluster
-    input_mapping:
-      terraform: terraform_for_dpm
-    tags: ["netbackup"]
-    file: ccp_src/ci/tasks/gen_cluster.yml
-    params:
-      <<: *ccp_gpdb4_gen_cluster_default_params
-    on_failure:
-      <<: *dpm_ccp_destroy
-  - task: netbackup_pre_test_setup
-    tags: ["netbackup"]
-    file: gpdb_src/concourse/tasks/setup_netbackup.yml
-    image: centos-gpdb-dev-6
-    params:
-      CUSTOM_ENV: export NETBACKUP_SERVER={{netbackup_host}}; export NETBACKUP_KEY={{netbackup_key}};
-  - task: run_tests
-    tags: ["netbackup"]
-    file: gpdb_src/concourse/tasks/run_behave.yml
-    image: centos-gpdb-dev-6
-    params:
-      BEHAVE_FLAGS: --tags=nbusetup77,nbupartIII
-      CUSTOM_ENV: export NETBACKUP_SERVER={{netbackup_host}};
-    on_failure:
-      <<: *dpm_debug_sleep
-  - *dpm_ccp_destroy
+
 - name: DPM_gptransfer-43x-to-5x
   plan:
   - get: nightly-trigger
     tags: ["ccp"]
     trigger: true
+  - *ccp_jitter_delay
   - aggregate:
     - get: gpdb_src
       tags: ["ccp"]
-      passed: [gate_nightly_start]
+      passed: [gate_dpm_start]
     - get: gpdb_binary
       tags: ["ccp"]
       resource: bin_gpdb_centos6
-      passed: [gate_nightly_start]
+      passed: [gate_dpm_start]
     - get: gpdb4_binary
       tags: ["ccp"]
       resource: bin_gpdb4_centos6
@@ -3121,229 +3160,317 @@ jobs:
               tag: latest
           run:
             path: 'sh'
-            args: ['-c', 'sleep 6h']
+            args: ['-c', 'sleep {{ccp_debug_sleep}}']
         ensure:
           <<: *ccp_destroy_2_cluster
   # Similar to the on_failure blocks, the final cleanup needs to be both clusters as well
   - *ccp_destroy_2_cluster
-- name: DPM_backup-restore_ddboost_part1
+
+- name: DPM_gptransfer-5x-to-5x
   plan:
-  - get: nightly-trigger
-    trigger: true
+  - *ccp_jitter_delay
   - aggregate:
-    - get: ccp_src
-      tags: ["ddboost"]
     - get: gpdb_src
-      tags: ["ddboost"]
-      passed: [gate_nightly_start]
+      tags: ["ccp"]
+      passed: [gate_dpm_start]
     - get: gpdb_binary
-      tags: ["ddboost"]
+      tags: ["ccp"]
       resource: bin_gpdb_centos6
-      passed: [gate_nightly_start]
+      passed: [gate_dpm_start]
+      trigger: true
+    - get: ccp_src
+      tags: ["ccp"]
     - get: centos-gpdb-dev-6
-      tags: ["ddboost"]
-  - put: terraform_for_dpm
-    params:
-      <<: *ccp_default_params
-      terraform_source: ccp_src/aws-pivotal-pa-toolsmiths/
-      vars:
-        <<: *ccp_default_vars
-    tags: ["ddboost"]
-  - task: gen_cluster
-    input_mapping:
-      terraform: terraform_for_dpm
-    tags: ["ddboost"]
-    file: ccp_src/ci/tasks/gen_cluster.yml
-    params:
-      <<: *ccp_gpdb4_gen_cluster_default_params
-    on_failure:
-      <<: *dpm_ccp_destroy
-  - task: ddboost_pre_test_setup
-    tags: ["ddboost"]
+      tags: ["ccp"]
+  # The separate clusters can be created in parallel with the aggregate and do blocks
+  #  The terraform put and gen cluster that correspond must still happen serially
+  - aggregate:
+    - do:
+      - put: terraform
+        tags: ["ccp"]
+        params:
+          <<: *ccp_default_params
+          vars:
+            <<: *ccp_default_vars
+            aws_instance-node-instance_type: m4.large
+      - task: gen_cluster1
+        tags: ["ccp"]
+        file: ccp_src/ci/tasks/gen_cluster.yml
+        params:
+          <<: *ccp_gen_cluster_default_params
+        on_failure:
+          <<: *ccp_destroy
+    - do:
+      - put: terraform2
+        tags: ["ccp"]
+        params:
+          <<: *ccp_default_params
+          vars:
+            <<: *ccp_default_vars
+            aws_instance-node-instance_type: m4.large
+            cluster_suffix: "-2"
+      - task: gen_cluster2
+        tags: ["ccp"]
+        file: ccp_src/ci/tasks/gen_cluster.yml
+        params:
+          <<: *ccp_gen_cluster_default_params
+        input_mapping:
+          terraform: terraform2
+        output_mapping:
+          cluster_env_files: cluster_env_files2
+        on_failure:
+          put: terraform2
+          tags: ["ccp"]
+          params:
+            action: destroy
+            env_name_file: terraform2/name
+            terraform_source: ccp_src/aws/
+            vars:
+              <<: *ccp_default_vars
+              cluster_suffix: "-2"
+          get_params:
+            action: destroy
+  - task: gptransfer_pre_test_setup
+    tags: ["ccp"]
     config:
       platform: linux
       inputs:
-       - name: ccp_src
-       - name: gpdb_src
-       - name: cluster_env_files
+        - name: cluster_env_files
+        - name: cluster_env_files2
+        - name: ccp_src
+        - name: gpdb_src
       image_resource:
         type: docker-image
         source:
           repository: centos
           tag: '6'
       run:
-        path: bash
+        path: sh
         args:
-        - -c
+        - -exc
         - |
-          set -ex
-          ccp_src/aws/setup_ssh_to_cluster.sh
-          scp cluster_env_files/terraform/name mdw:/tmp/terraform_name
-          export DD_SOURCE_HOST={{datadomain_source_host}}; export DD_DEST_HOST={{datadomain_dest_host}};
-          source gpdb_src/concourse/scripts/backup_utils.sh; setup_ddboost
+          source gpdb_src/concourse/scripts/transfer_utils.sh; setup_gptransfer
     on_failure:
-      <<: *dpm_ccp_destroy
-  - task: run_tests
-    tags: ["ddboost"]
+      <<: *ccp_destroy_2_cluster
+  - task: run_gptransfer_tests
+    tags: ["ccp"]
     file: gpdb_src/concourse/tasks/run_behave.yml
     image: centos-gpdb-dev-6
     params:
-      BEHAVE_FLAGS: --tags=ddboostsetup,ddpartI
-      CUSTOM_ENV: export DD_SOURCE_HOST={{datadomain_source_host}}; export DD_DEST_HOST={{datadomain_dest_host}}; export DD_USER={{datadomain_user}}; export DD_PASSWORD={{datadomain_password}};
+      BEHAVE_FLAGS: --tags=gptransfer --tags=-skip_source_5
+      CUSTOM_ENV: export GPTRANSFER_DEST_HOST=mdw; export GPTRANSFER_DEST_PORT=5432; export GPTRANSFER_DEST_USER=gpadmin; export GPTRANSFER_MAP_FILE=/tmp/source_map_file; export GPTRANSFER_SOURCE_HOST=mdw-2; export GPTRANSFER_SOURCE_PORT=5432; export GPTRANSFER_SOURCE_USER=gpadmin;
     on_failure:
-      <<: *dpm_debug_sleep
-  - *dpm_ccp_destroy
-- name: DPM_backup-restore_ddboost_part2
-  plan:
-  - get: nightly-trigger
-    trigger: true
-  - aggregate:
-    - get: ccp_src
-      tags: ["ddboost"]
-    - get: gpdb_src
-      tags: ["ddboost"]
-      passed: [gate_nightly_start]
-    - get: gpdb_binary
-      tags: ["ddboost"]
-      resource: bin_gpdb_centos6
-      passed: [gate_nightly_start]
-    - get: centos-gpdb-dev-6
-      tags: ["ddboost"]
-  - put: terraform_for_dpm
-    params:
-      <<: *ccp_default_params
-      terraform_source: ccp_src/aws-pivotal-pa-toolsmiths/
-      vars:
-        <<: *ccp_default_vars
-    tags: ["ddboost"]
-  - task: gen_cluster
-    input_mapping:
-      terraform: terraform_for_dpm
-    tags: ["ddboost"]
-    file: ccp_src/ci/tasks/gen_cluster.yml
-    params:
-      <<: *ccp_gpdb4_gen_cluster_default_params
-    on_failure:
-      <<: *dpm_ccp_destroy
-  - task: ddboost_pre_test_setup
-    tags: ["ddboost"]
-    config:
-      platform: linux
-      inputs:
-       - name: ccp_src
-       - name: gpdb_src
-       - name: cluster_env_files
-      image_resource:
-        type: docker-image
-        source:
-          repository: centos
-          tag: '6'
-      run:
-        path: bash
-        args:
-        - -c
-        - |
-          set -ex
-          ccp_src/aws/setup_ssh_to_cluster.sh
-          scp cluster_env_files/terraform/name mdw:/tmp/terraform_name
-          export DD_SOURCE_HOST={{datadomain_source_host}}; export DD_DEST_HOST={{datadomain_dest_host}};
-          source gpdb_src/concourse/scripts/backup_utils.sh; setup_ddboost
-    on_failure:
-      <<: *dpm_ccp_destroy
-  - task: run_tests
-    tags: ["ddboost"]
-    file: gpdb_src/concourse/tasks/run_behave.yml
-    image: centos-gpdb-dev-6
-    params:
-      BEHAVE_FLAGS: --tags=ddboostsetup,ddpartII
-      CUSTOM_ENV: export DD_SOURCE_HOST={{datadomain_source_host}}; export DD_DEST_HOST={{datadomain_dest_host}}; export DD_USER={{datadomain_user}}; export DD_PASSWORD={{datadomain_password}};
-    on_failure:
-      <<: *dpm_debug_sleep
-  - *dpm_ccp_destroy
-- name: DPM_backup-restore_ddboost_part3
-  plan:
-  - get: nightly-trigger
-    trigger: true
-  - aggregate:
-    - get: ccp_src
-      tags: ["ddboost"]
-    - get: gpdb_src
-      tags: ["ddboost"]
-      passed: [gate_nightly_start]
-    - get: gpdb_binary
-      tags: ["ddboost"]
-      resource: bin_gpdb_centos6
-      passed: [gate_nightly_start]
-    - get: centos-gpdb-dev-6
-      tags: ["ddboost"]
-  - put: terraform_for_dpm
-    params:
-      <<: *ccp_default_params
-      terraform_source: ccp_src/aws-pivotal-pa-toolsmiths/
-      vars:
-        <<: *ccp_default_vars
-    tags: ["ddboost"]
-  - task: gen_cluster
-    input_mapping:
-      terraform: terraform_for_dpm
-    tags: ["ddboost"]
-    file: ccp_src/ci/tasks/gen_cluster.yml
-    params:
-      <<: *ccp_gpdb4_gen_cluster_default_params
-    on_failure:
-      <<: *dpm_ccp_destroy
-  - task: ddboost_pre_test_setup
-    tags: ["ddboost"]
-    config:
-      platform: linux
-      inputs:
-       - name: ccp_src
-       - name: gpdb_src
-       - name: cluster_env_files
-      image_resource:
-        type: docker-image
-        source:
-          repository: centos
-          tag: '6'
-      run:
-        path: bash
-        args:
-        - -c
-        - |
-          set -ex
-          ccp_src/aws/setup_ssh_to_cluster.sh
-          scp cluster_env_files/terraform/name mdw:/tmp/terraform_name
-          export DD_SOURCE_HOST={{datadomain_source_host}}; export DD_DEST_HOST={{datadomain_dest_host}};
-          source gpdb_src/concourse/scripts/backup_utils.sh; setup_ddboost
-    on_failure:
-      <<: *dpm_ccp_destroy
-  - task: run_tests
-    tags: ["ddboost"]
-    file: gpdb_src/concourse/tasks/run_behave.yml
-    image: centos-gpdb-dev-6
-    params:
-      BEHAVE_FLAGS: --tags=ddboostsetup,ddpartIII
-      CUSTOM_ENV: export DD_SOURCE_HOST={{datadomain_source_host}}; export DD_DEST_HOST={{datadomain_dest_host}}; export DD_USER={{datadomain_user}}; export DD_PASSWORD={{datadomain_password}};
-    on_failure:
-      <<: *dpm_debug_sleep
-  - *dpm_ccp_destroy
-- name: gate_nightly_end
+      do:
+      - task: debug_sleep_2_cluster
+        tags: ["ccp"]
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: alpine
+              tag: latest
+          run:
+            path: 'sh'
+            args: ['-c', 'sleep {{ccp_debug_sleep}}']
+        ensure:
+          <<: *ccp_destroy_2_cluster
+  # Similar to the on_failure blocks, the final cleanup needs to be both clusters as well
+  - *ccp_destroy_2_cluster
+
+- name: gate_dpm_end
   plan:
   - aggregate:
     - get: gpdb_src
       trigger: true
       passed:
-      - DPM_backup_43_restore_5
-      - DPM_gptransfer-43x-to-5x
+      - DPM_backup-restore
       - DPM_backup-restore_ddboost_part1
       - DPM_backup-restore_ddboost_part2
       - DPM_backup-restore_ddboost_part3
       - DPM_backup-restore_netbackup_part1
       - DPM_backup-restore_netbackup_part2
       - DPM_backup-restore_netbackup_part3
-      - MM_gpexpand_1
-      - MM_gpexpand_2
-############### Nightly End
+      - DPM_backup_43_restore_5
+      - DPM_gptransfer-43x-to-5x
+      - DPM_gptransfer-5x-to-5x
+############### DPM End
+
+################ UD Start
+- name: gate_ud_start
+  plan:
+  - task: sleep_before_starting
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: alpine
+      run:
+        path: 'sh'
+        args: ['-c', 'sleep `expr 5 \* {{group_start_delay}} + 1 + $RANDOM % {{group_delay_jitter}}`']
+  - aggregate:
+    - get: gpdb_src
+      passed:
+      - gate_compile_end
+      trigger: true
+    - get: bin_gpdb_centos6
+      passed:
+      - gate_compile_end
+    - get: bin_gpdb_centos7
+      passed:
+      - gate_compile_end
+
+- name: regression_tests_pxf_hdp_rpm
+  plan:
+  - aggregate:
+    - get: gpdb_src
+      passed: [gate_ud_start]
+    - get: bin_gpdb
+      resource: bin_gpdb_centos6
+      passed: [gate_ud_start]
+      trigger: true
+    - get: singlecluster
+      resource: singlecluster-HDP
+      trigger: true
+    - get: pxf_automation_src
+      trigger: true
+    - get: centos-gpdb-dev-6
+  - aggregate:
+    - task: regression_tests_pxf
+      file: gpdb_src/concourse/tasks/regression_tests_pxf.yml
+      image: centos-gpdb-dev-6
+      params:
+        GROUP: gpdb
+        HADOOP_CLIENT: HDP
+        TARGET_OS: centos
+        TARGET_OS_VERSION: 6
+
+- name: regression_tests_pxf_hdp_tar
+  plan:
+  - aggregate:
+    - get: gpdb_src
+      passed: [gate_ud_start]
+    - get: bin_gpdb
+      resource: bin_gpdb_centos6
+      passed: [gate_ud_start]
+      trigger: true
+    - get: singlecluster
+      resource: singlecluster-HDP
+      trigger: true
+    - get: pxf_automation_src
+      trigger: true
+    - get: centos-gpdb-dev-6
+  - aggregate:
+    - task: regression_tests_pxf
+      file: gpdb_src/concourse/tasks/regression_tests_pxf.yml
+      image: centos-gpdb-dev-6
+      params:
+        GROUP: gpdb
+        HADOOP_CLIENT: TAR
+        TARGET_OS: centos
+        TARGET_OS_VERSION: 6
+
+- name: regression_tests_pxf_cdh_rpm
+  plan:
+  - aggregate:
+    - get: gpdb_src
+      passed: [gate_ud_start]
+    - get: bin_gpdb
+      resource: bin_gpdb_centos6
+      passed: [gate_ud_start]
+      trigger: true
+    - get: singlecluster
+      resource: singlecluster-CDH
+      trigger: true
+    - get: pxf_automation_src
+      trigger: true
+    - get: centos-gpdb-dev-6
+  - task: regression_tests_pxf
+    file: gpdb_src/concourse/tasks/regression_tests_pxf.yml
+    image: centos-gpdb-dev-6
+    params:
+      GROUP: gpdb
+      HADOOP_CLIENT: CDH
+      TARGET_OS: centos
+      TARGET_OS_VERSION: 6
+
+- name: regression_tests_pxf_cdh_tar
+  plan:
+  - aggregate:
+    - get: gpdb_src
+      passed: [gate_ud_start]
+    - get: bin_gpdb
+      resource: bin_gpdb_centos6
+      passed: [gate_ud_start]
+      trigger: true
+    - get: singlecluster
+      resource: singlecluster-CDH
+      trigger: true
+    - get: pxf_automation_src
+      trigger: true
+    - get: centos-gpdb-dev-6
+  - task: regression_tests_pxf
+    file: gpdb_src/concourse/tasks/regression_tests_pxf.yml
+    image: centos-gpdb-dev-6
+    params:
+      GROUP: gpdb
+      HADOOP_CLIENT: TAR
+      TARGET_OS: centos
+      TARGET_OS_VERSION: 6
+
+- name: regression_tests_gphdfs_centos
+  plan:
+  - aggregate:
+    - get: gpdb_src
+      passed: [gate_ud_start]
+    - get: bin_gpdb
+      passed: [gate_ud_start]
+      trigger: true
+      resource: bin_gpdb_centos6
+    - get: centos-gpdb-dev-6
+  - task: regression_tests_gphdfs
+    file: gpdb_src/concourse/tasks/regression_tests_gphdfs.yml
+    image: centos-gpdb-dev-6
+    params:
+      TARGET_OS: centos
+      TARGET_OS_VERSION: 6
+
+- name: regression_tests_gpcloud_centos
+  plan:
+  - aggregate:
+    - get: gpdb_src
+      passed: [gate_ud_start]
+    - get: bin_gpdb
+      resource: bin_gpdb_centos6
+      passed: [gate_ud_start]
+      trigger: true
+    - get: centos-gpdb-dev-6
+  - task: regression_tests_gpcloud
+    file: gpdb_src/concourse/tasks/regression_tests_gpcloud.yml
+    image: centos-gpdb-dev-6
+    params:
+      gpcloud_access_key_id: {{gpcloud-access-key-id}}
+      gpcloud_secret_access_key: {{gpcloud-secret-access-key}}
+      overwrite_gpcloud: false
+      TARGET_OS: centos
+      TARGET_OS_VERSION: 6
+
+- name: gate_ud_end
+  plan:
+  - aggregate:
+    - get: gpdb_src
+      passed: &gate_ud_end
+      - regression_tests_pxf_hdp_rpm
+      - regression_tests_pxf_hdp_tar
+      - regression_tests_pxf_cdh_rpm
+      - regression_tests_pxf_cdh_tar
+      - regression_tests_gphdfs_centos
+      - regression_tests_gpcloud_centos
+      trigger: true
+    - get: bin_gpdb_centos6
+      passed: *gate_ud_end
+################ UD End
 
 ############### Advanced Analytics Start
 - name: gate_advanced_analytics_start
@@ -3357,18 +3484,19 @@ jobs:
           repository: alpine
       run:
         path: 'sh'
-        args: ['-c', 'sleep 300']
+        args: ['-c', 'sleep `expr 6 \* {{group_start_delay}} + 1 + $RANDOM % {{group_delay_jitter}}`']
   - aggregate:
     - get: gpdb_src
       passed:
-      - gate_icw_end
+      - gate_compile_end
       trigger: true
     - get: bin_gpdb_centos6
       passed:
-      - gate_icw_end
+      - gate_compile_end
     - get: bin_gpdb_centos7
       passed:
-      - gate_icw_end
+      - gate_compile_end
+
 - name: MADlib_Test_gppkg_Orca_centos6
   plan:
   - aggregate:
@@ -3390,6 +3518,7 @@ jobs:
     params:
       TEST_OS: centos
       ORCA: "on"
+
 - name: MADlib_Test_gppkg_Planner_centos6
   plan:
   - aggregate:
@@ -3411,6 +3540,7 @@ jobs:
     params:
       TEST_OS: centos
       ORCA: "off"
+
 - name: MADlib_Test_gppkg_Orca_centos7
   plan:
   - aggregate:
@@ -3432,6 +3562,7 @@ jobs:
     params:
       TEST_OS: centos
       ORCA: "on"
+
 - name: MADlib_Test_gppkg7_Planner_centos7
   plan:
   - aggregate:
@@ -3453,6 +3584,7 @@ jobs:
     params:
       TEST_OS: centos
       ORCA: "off"
+
 - name: postgis_centos6_ORCA_test
   plan:
   - aggregate:
@@ -3481,6 +3613,7 @@ jobs:
       IVYREPO_REALM: {{ivyrepo_realm}}
       IVYREPO_USER: {{ivyrepo_user}}
       IVYREPO_PASSWD: {{ivyrepo_passwd}}
+
 - name: postgis_centos6_planner_test
   plan:
   - aggregate:
@@ -3509,6 +3642,7 @@ jobs:
       IVYREPO_REALM: {{ivyrepo_realm}}
       IVYREPO_USER: {{ivyrepo_user}}
       IVYREPO_PASSWD: {{ivyrepo_passwd}}
+
 - name: postgis_centos7_ORCA_test
   plan:
   - aggregate:
@@ -3537,6 +3671,7 @@ jobs:
       IVYREPO_REALM: {{ivyrepo_realm}}
       IVYREPO_USER: {{ivyrepo_user}}
       IVYREPO_PASSWD: {{ivyrepo_passwd}}
+
 - name: postgis_centos7_planner_test
   plan:
   - aggregate:
@@ -3565,6 +3700,7 @@ jobs:
       IVYREPO_REALM: {{ivyrepo_realm}}
       IVYREPO_USER: {{ivyrepo_user}}
       IVYREPO_PASSWD: {{ivyrepo_passwd}}
+
 - name: gate_advanced_analytics_end
   plan:
   - aggregate:
@@ -3581,348 +3717,31 @@ jobs:
       - postgis_centos7_planner_test
 ############### Advanced Analytics End
 
-################ General Misc Start
-- name: gate_general_misc_start
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      passed:
-      - gate_mm_misc_end
-      trigger: true
-    - get: bin_gpdb_centos6
-      passed:
-      - gate_mm_misc_end
-    - get: bin_gpdb_centos7
-      passed:
-      - gate_mm_misc_end
-- name: MM_gpcheckcat
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      tags: ["ccp"]
-      params:
-        submodules:
-        - gpMgmt/bin/pythonSrc/ext
-      passed: [gate_general_misc_start]
-    - get: gpdb_binary
-      tags: ["ccp"]
-      resource: bin_gpdb_centos6
-      passed: [gate_general_misc_start]
-      trigger: true
-    - get: ccp_src
-      tags: ["ccp"]
-    - get: centos-gpdb-dev-6
-      tags: ["ccp"]
-  - put: terraform
-    tags: ["ccp"]
-    params:
-      <<: *ccp_default_params
-      vars:
-        <<: *ccp_default_vars
-  - task: gen_cluster
-    tags: ["ccp"]
-    file: ccp_src/ci/tasks/gen_cluster.yml
-    params:
-      <<: *ccp_gen_cluster_default_params
-    on_failure:
-      <<: *ccp_destroy
-  - task: run_tests
-    tags: ["ccp"]
-    file: gpdb_src/concourse/tasks/run_behave.yml
-    image: centos-gpdb-dev-6
-    params:
-      BEHAVE_FLAGS: --tags=gpcheckcat
-    on_failure:
-      <<: *debug_sleep
-  - *ccp_destroy
-- name: QP_memory-accounting
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      passed: [gate_general_misc_start]
-      trigger: true
-    - get: bin_gpdb
-      passed: [gate_general_misc_start]
-      resource: bin_gpdb_centos6
-    - get: centos-gpdb-dev-6
-  - task: memory-accounting
-    timeout: 3h
-    file: gpdb_src/concourse/tasks/tinc_gpdb.yml
-    image: centos-gpdb-dev-6
-    params:
-      MAKE_TEST_COMMAND: memory_accounting
-      TEST_OS: "centos"
-      CONFIGURE_FLAGS: {{configure_flags}}
-- name: QP_optimizer-functional
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      params: {submodules: none}
-      passed: [gate_general_misc_start]
-    - get: bin_gpdb
-      resource: bin_gpdb_centos6
-      passed: [gate_general_misc_start]
-      trigger: true
-    - get: centos-gpdb-dev-6
-  - aggregate:
-    - task: optimizer_functional_part1
-      timeout: 3h
-      file: gpdb_src/concourse/tasks/tinc_gpdb.yml
-      image: centos-gpdb-dev-6
-      params:
-        MAKE_TEST_COMMAND: optimizer_functional_part1
-        BLDWRAP_POSTGRES_CONF_ADDONS: fsync=off optimizer_print_missing_stats=off
-        TEST_OS: centos
-        CONFIGURE_FLAGS: {{configure_flags}}
-    - task: optimizer_functional_part2
-      timeout: 3h
-      file: gpdb_src/concourse/tasks/tinc_gpdb.yml
-      image: centos-gpdb-dev-6
-      params:
-        MAKE_TEST_COMMAND: optimizer_functional_part2
-        BLDWRAP_POSTGRES_CONF_ADDONS: fsync=off optimizer_print_missing_stats=off
-        TEST_OS: centos
-        CONFIGURE_FLAGS: {{configure_flags}}
-- name: regression_tests_pxf_hdp_rpm
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      passed: [gate_general_misc_start]
-    - get: bin_gpdb
-      resource: bin_gpdb_centos6
-      passed: [gate_general_misc_start]
-      trigger: true
-    - get: singlecluster
-      resource: singlecluster-HDP
-      trigger: true
-    - get: pxf_automation_src
-      trigger: true
-    - get: centos-gpdb-dev-6
-  - aggregate:
-    - task: regression_tests_pxf
-      file: gpdb_src/concourse/tasks/regression_tests_pxf.yml
-      image: centos-gpdb-dev-6
-      params:
-        GROUP: gpdb
-        HADOOP_CLIENT: HDP
-        TARGET_OS: centos
-        TARGET_OS_VERSION: 6
-- name: regression_tests_pxf_hdp_tar
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      passed: [gate_general_misc_start]
-    - get: bin_gpdb
-      resource: bin_gpdb_centos6
-      passed: [gate_general_misc_start]
-      trigger: true
-    - get: singlecluster
-      resource: singlecluster-HDP
-      trigger: true
-    - get: pxf_automation_src
-      trigger: true
-    - get: centos-gpdb-dev-6
-  - aggregate:
-    - task: regression_tests_pxf
-      file: gpdb_src/concourse/tasks/regression_tests_pxf.yml
-      image: centos-gpdb-dev-6
-      params:
-        GROUP: gpdb
-        HADOOP_CLIENT: TAR
-        TARGET_OS: centos
-        TARGET_OS_VERSION: 6
-- name: regression_tests_pxf_cdh_rpm
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      passed: [gate_general_misc_start]
-    - get: bin_gpdb
-      resource: bin_gpdb_centos6
-      passed: [gate_general_misc_start]
-      trigger: true
-    - get: singlecluster
-      resource: singlecluster-CDH
-      trigger: true
-    - get: pxf_automation_src
-      trigger: true
-    - get: centos-gpdb-dev-6
-  - task: regression_tests_pxf
-    file: gpdb_src/concourse/tasks/regression_tests_pxf.yml
-    image: centos-gpdb-dev-6
-    params:
-      GROUP: gpdb
-      HADOOP_CLIENT: CDH
-      TARGET_OS: centos
-      TARGET_OS_VERSION: 6
-- name: regression_tests_pxf_cdh_tar
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      passed: [gate_general_misc_start]
-    - get: bin_gpdb
-      resource: bin_gpdb_centos6
-      passed: [gate_general_misc_start]
-      trigger: true
-    - get: singlecluster
-      resource: singlecluster-CDH
-      trigger: true
-    - get: pxf_automation_src
-      trigger: true
-    - get: centos-gpdb-dev-6
-  - task: regression_tests_pxf
-    file: gpdb_src/concourse/tasks/regression_tests_pxf.yml
-    image: centos-gpdb-dev-6
-    params:
-      GROUP: gpdb
-      HADOOP_CLIENT: TAR
-      TARGET_OS: centos
-      TARGET_OS_VERSION: 6
-- name: regression_tests_gphdfs_centos
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      passed: [gate_general_misc_start]
-    - get: bin_gpdb
-      passed: [gate_general_misc_start]
-      trigger: true
-      resource: bin_gpdb_centos6
-    - get: centos-gpdb-dev-6
-  - task: regression_tests_gphdfs
-    file: gpdb_src/concourse/tasks/regression_tests_gphdfs.yml
-    image: centos-gpdb-dev-6
-    params:
-      TARGET_OS: centos
-      TARGET_OS_VERSION: 6
-- name: regression_tests_gpcloud_centos
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      passed: [gate_general_misc_start]
-    - get: bin_gpdb
-      resource: bin_gpdb_centos6
-      passed: [gate_general_misc_start]
-      trigger: true
-    - get: centos-gpdb-dev-6
-  - task: regression_tests_gpcloud
-    file: gpdb_src/concourse/tasks/regression_tests_gpcloud.yml
-    image: centos-gpdb-dev-6
-    params:
-      gpcloud_access_key_id: {{gpcloud-access-key-id}}
-      gpcloud_secret_access_key: {{gpcloud-secret-access-key}}
-      overwrite_gpcloud: false
-      TARGET_OS: centos
-      TARGET_OS_VERSION: 6
-- name: mpp_resource_group_centos6
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      tags: ["ccp"]
-      passed: [gate_general_misc_start]
-    - get: bin_gpdb
-      tags: ["ccp"]
-      resource: bin_gpdb_centos6
-      passed: [gate_general_misc_start]
-      trigger: true
-    - get: ccp_src
-      tags: ["ccp"]
-    - get: centos-gpdb-dev-6
-      tags: ["ccp"]
-  - put: terraform
-    tags: ["ccp"]
-    params:
-      <<: *ccp_default_params
-      vars:
-        <<: *ccp_default_vars
-  - task: gen_cluster
-    tags: ["ccp"]
-    file: ccp_src/ci/tasks/gen_cluster.yml
-    params:
-      <<: *ccp_gen_cluster_default_params
-    input_mapping:
-      gpdb_binary: bin_gpdb
-    on_failure:
-      <<: *ccp_destroy
-  - task: run_tests
-    tags: ["ccp"]
-    file: gpdb_src/concourse/tasks/ic_gpdb_resgroup.yml
-    image: centos-gpdb-dev-6
-    params:
-      TEST_OS: centos6
-    on_failure:
-      <<: *debug_sleep
-  - *ccp_destroy
-- name: mpp_resource_group_centos7
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      tags: ["ccp"]
-      passed: [gate_general_misc_start]
-    - get: bin_gpdb
-      tags: ["ccp"]
-      resource: bin_gpdb_centos7
-      passed: [gate_general_misc_start]
-      trigger: true
-    - get: ccp_src
-      tags: ["ccp"]
-    - get: centos-gpdb-dev-7
-      tags: ["ccp"]
-  - put: terraform
-    tags: ["ccp"]
-    params:
-      <<: *ccp_default_params
-      vars:
-        <<: *ccp_default_vars
-        platform: centos7
-  - task: gen_cluster
-    tags: ["ccp"]
-    file: ccp_src/ci/tasks/gen_cluster.yml
-    params:
-      <<: *ccp_gen_cluster_default_params
-    input_mapping:
-      gpdb_binary: bin_gpdb
-    on_failure:
-      <<: *ccp_destroy
-  - task: run_tests
-    tags: ["ccp"]
-    file: gpdb_src/concourse/tasks/ic_gpdb_resgroup.yml
-    image: centos-gpdb-dev-7
-    params:
-      TEST_OS: centos7
-    on_failure:
-      <<: *debug_sleep
-  - *ccp_destroy
-- name: gate_general_misc_end
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      passed: &gate_general_misc_end
-      - QP_memory-accounting
-      - regression_tests_gpcloud_centos
-      - regression_tests_gphdfs_centos
-      - regression_tests_pxf_hdp_rpm
-      - regression_tests_pxf_hdp_tar
-      - regression_tests_pxf_cdh_rpm
-      - regression_tests_pxf_cdh_tar
-      - QP_optimizer-functional
-      - MM_gpcheckcat
-      trigger: true
-    - get: bin_gpdb_centos6
-      passed: *gate_general_misc_end
-################ General Misc End
-
 ################ FileRep Start
 - name: gate_filerep_start
   plan:
+  - task: sleep_before_starting
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: alpine
+      run:
+        path: 'sh'
+        args: ['-c', 'sleep `expr 7 \* {{group_start_delay}} + 1 + $RANDOM % {{group_delay_jitter}}`']
   - aggregate:
     - get: gpdb_src
       passed:
-      - gate_general_misc_end
+      - gate_compile_end
       trigger: true
     - get: bin_gpdb_centos6
       passed:
-      - gate_general_misc_end
+      - gate_compile_end
+
 - name: cs_filerep_e2e_full_mirror
   plan:
+  - *ccp_jitter_delay
   - aggregate:
     - get: gpdb_src
       tags: ["ccp"]
@@ -3961,8 +3780,10 @@ jobs:
     on_failure:
       <<: *debug_sleep
   - *ccp_destroy
+
 - name: cs_filerep_e2e_incr_mirror
   plan:
+  - *ccp_jitter_delay
   - aggregate:
     - get: gpdb_src
       tags: ["ccp"]
@@ -4001,8 +3822,10 @@ jobs:
     on_failure:
       <<: *debug_sleep
   - *ccp_destroy
+
 - name: cs_filerep_e2e_full_primary
   plan:
+  - *ccp_jitter_delay
   - aggregate:
     - get: gpdb_src
       tags: ["ccp"]
@@ -4040,8 +3863,10 @@ jobs:
     on_failure:
       <<: *debug_sleep
   - *ccp_destroy
+
 - name: cs_filerep_e2e_incr_primary
   plan:
+  - *ccp_jitter_delay
   - aggregate:
     - get: gpdb_src
       tags: ["ccp"]
@@ -4080,6 +3905,7 @@ jobs:
     on_failure:
       <<: *debug_sleep
   - *ccp_destroy
+
 - name: gate_filerep_end
   plan:
   - aggregate:
@@ -4157,7 +3983,6 @@ jobs:
     - regression_tests_pxf_hdp_tar
     - regression_tests_pxf_cdh_rpm
     - regression_tests_pxf_cdh_tar
-    - gpdb_rc_packaging_centos
     - DPM_backup-restore_ddboost_part1
     - DPM_backup-restore_ddboost_part2
     - DPM_backup-restore_ddboost_part3

--- a/concourse/scripts/validate_pipeline_release_jobs.py
+++ b/concourse/scripts/validate_pipeline_release_jobs.py
@@ -5,11 +5,11 @@ import re
 import yaml
 
 RELEASE_VALIDATOR_JOB = ['Release_Candidate']
-JOBS_THAT_ARE_GATES = ['gate_compile_start', 'gate_compile_end', 'gate_icw_start', 'gate_icw_end',
-        'gate_mm_misc_start', 'gate_mm_misc_end', 'gate_general_misc_start', 'gate_general_misc_end',
-        'gate_filerep_start', 'gate_filerep_end', 'gate_cluster_start', 'gate_cluster_end',
-        'gate_nightly_start', 'gate_nightly_end', 'gate_advanced_analytics_start',
-        'gate_advanced_analytics_end', 'gate_cs_misc_start', 'gate_cs_misc_end']
+JOBS_THAT_ARE_GATES = ['gate_compile_start', 'gate_compile_end', 'gate_icw_start',
+                       'gate_icw_end', 'gate_cs_start', 'gate_cs_end', 'gate_mpp_start',
+                       'gate_mpp_end', 'gate_mm_start', 'gate_mm_end', 'gate_dpm_start',
+                       'gate_dpm_end', 'gate_ud_start', 'gate_ud_end', 'gate_advanced_analytics_start',
+                       'gate_advanced_analytics_end', 'gate_filerep_start', 'gate_filerep_end']
 JOBS_THAT_SHOULD_NOT_BLOCK_RELEASE = ['compile_gpdb_binary_swap_centos6'] + RELEASE_VALIDATOR_JOB + JOBS_THAT_ARE_GATES
 
 pipeline_raw = open(os.environ['PIPELINE_FILE'],'r').read()


### PR DESCRIPTION
Multiple changes to master pipeline:

- All groups fire now after compile
- groups have a configurable delays
    - delays are configured via variable
    - there's also a configurable "jitter" to spread out multiple runs to avoid Concourse limits
- jobs and groups re-organized by topic
- kept gates to allow for disabling/enabling certain tests for development
- Added jitter for CCP concourse and also to CCP jobs to avoid hitting. the AWS API rate limit.

Testing over the weekend had total pipeline runtime to approximately 1h50m not including nightly job triggers.  The vast majority of tests are done in under 1h30m.

Pipeline is running in parallel here: https://gpdb-dev.data.pivotal.ci/teams/main/pipelines/mike:5X_STABLE

**Note** downside is that the full display is unwieldy as all jobs are stacked in a single column