### PR TITLE
Docs: Add gpbackup/gprestore docs

### DIFF
--- a/gpdb-doc/dita/admin_guide/managing/backup-gpbackup.xml
+++ b/gpdb-doc/dita/admin_guide/managing/backup-gpbackup.xml
@@ -138,12 +138,12 @@ Tables backed up:  2 / 2 [======================================================
 20171103:15:26:00 gpbackup:gpadmin:0ee2f5fb02c9:017527-[INFO]:-Backup completed successfully</codeblock></p>
       <p>The above command creates global and database-specific metadata files on the Greenplum
         Database master host in the default directory,
-          <codeph>$MASTER_DATA_DIRECTORY/backups/&lt;YYYYMMDD>/&lt;YYYYMMDDhhmmss>/</codeph>. For
+          <codeph>$MASTER_DATA_DIRECTORY/backups/&lt;YYYYMMDD>/&lt;YYYYMMDDHHMMSS>/</codeph>. For
         example:<codeblock>$ <b>ls /gpmaster/gpsne-1/backups/20171103/20171103152558/</b>
 gpbackup_20171103152558_config.yaml  gpbackup_20171103152558_postdata.sql  gpbackup_20171103152558_report
 gpbackup_20171103152558_global.sql   gpbackup_20171103152558_predata.sql   gpbackup_20171103152558_toc.yaml</codeblock></p>
       <p>By default, each segment stores table data for the backup in compressed CSV files in
-          <codeph>&lt;seg_dir>/backups/&lt;YYYYMMDD>/&lt;YYYYMMDDhhmmss>/</codeph>:<codeblock>$ <b>ls /gpdata1/gpsne0/backups/20171103/20171103152558/
+          <codeph>&lt;seg_dir>/backups/&lt;YYYYMMDD>/&lt;YYYYMMDDHHMMSS>/</codeph>:<codeblock>$ <b>ls /gpdata1/gpsne0/backups/20171103/20171103152558/
 </b>gpbackup_0_20171103152558_16524.gz  gpbackup_0_20171103152558_16543.gz</codeblock></p>
       <p>To consolidate all backup files into a single directory, include the
           <codeph>-backupdir</codeph>
@@ -167,7 +167,7 @@ $ <b>find /home/gpadmin/backups/ -type f</b>
       </section>
       <p>To use <codeph>gprestore</codeph> to restore from a backup set, you must use the
           <codeph>-timestamp</codeph> option to specify the exact timestamp value
-          (<codeph>YYYYMMDDhhmmss</codeph>) to restore. Include the <codeph>-createdb</codeph>
+          (<codeph>YYYYMMDDHHMMSS</codeph>) to restore. Include the <codeph>-createdb</codeph>
         option if the database does not exist in the cluster. For
         example:<codeblock>$ <b>dropdb demo</b>
 $ <b>gprestore -timestamp 20171103152558 -createdb</b>
@@ -251,7 +251,7 @@ water.tonic</codeblock></p>
         was created.</p>
       <p>By default, metadata and supporting files are stored on the Greenplum Database master host
         in the directory
-          <filepath>$MASTER_DATA_DIRECTORY/backups/YYYYMMDD/YYYYMMDDhhmmss/</filepath>. If you
+          <filepath>$MASTER_DATA_DIRECTORY/backups/YYYYMMDD/YYYYMMDDHHMMSS/</filepath>. If you
         specify a custom backup directory, this same file path is created as a subdirectory of the
         backup directory.  The following table describes the names and contents of the metadata and
         supporting files.<table frame="all" rowsep="1" colsep="1" id="table_nrz_4gj_tbb">
@@ -267,7 +267,7 @@ water.tonic</codeblock></p>
             </thead>
             <tbody>
               <row>
-                <entry><filepath>gpbackup_&lt;YYYYMMDDhhmmss>_global.sql</filepath></entry>
+                <entry><filepath>gpbackup_&lt;YYYYMMDDHHMMSS>_global.sql</filepath></entry>
                 <entry>This file is created only if you include the -globals option to
                     <codeph>gpbackup</codeph>. It contains DDL for objects that are global to the
                   Greenplum Cluster, and not owned by a specific database within the cluster. These
@@ -282,7 +282,7 @@ water.tonic</codeblock></p>
                   </ul></entry>
               </row>
               <row>
-                <entry><filepath>gpbackup_&lt;YYYYMMDDhhmmss>_predata.sql</filepath></entry>
+                <entry><filepath>gpbackup_&lt;YYYYMMDDHHMMSS>_predata.sql</filepath></entry>
                 <entry>Contains DDL for objects in the backed-up database (specified with
                     <codeph>-dbname)</codeph> that must be created <i>prior</i> to restoring the
                   actual data. These objects include:<ul id="ul_s35_nhj_tbb">
@@ -303,7 +303,7 @@ water.tonic</codeblock></p>
                   </ul></entry>
               </row>
               <row>
-                <entry><filepath>gpbackup_&lt;YYYYMMDDhhmmss>_postdata.sql</filepath></entry>
+                <entry><filepath>gpbackup_&lt;YYYYMMDDHHMMSS>_postdata.sql</filepath></entry>
                 <entry>Contains DDL for objects in the backed-up database (specified with
                     <codeph>-dbname)</codeph> that must be created <i>after</i> restoring the data.
                   These objects include:<ul id="ul_zyg_tgj_tbb">
@@ -314,7 +314,7 @@ water.tonic</codeblock></p>
                   </ul></entry>
               </row>
               <row>
-                <entry><filepath>gpbackup_&lt;YYYYMMDDhhmmss>_toc.yaml</filepath></entry>
+                <entry><filepath>gpbackup_&lt;YYYYMMDDHHMMSS>_toc.yaml</filepath></entry>
                 <entry>Contains metadata for locating object DDL in the
                     <filepath>_predata.sql</filepath> and <filepath>_postdata.sql</filepath> files.
                   This file also contains the table names and OIDs used for locating the
@@ -322,7 +322,7 @@ water.tonic</codeblock></p>
                     <xref href="#topic_xnj_b4c_tbb/section_oys_cpj_tbb" format="dita"/>.</entry>
               </row>
               <row>
-                <entry><filepath>gpbackup_&lt;YYYYMMDDhhmmss>_report</filepath></entry>
+                <entry><filepath>gpbackup_&lt;YYYYMMDDHHMMSS>_report</filepath></entry>
                 <entry>Contains information about the backup operation that is used to populate the
                   email notice (if configured) that is sent after the backup completes. This file
                   contains information such as:<ul id="ul_bjr_2kj_tbb">
@@ -333,7 +333,7 @@ water.tonic</codeblock></p>
                   </ul>See <xref href="#topic_qwd_d5d_tbb" format="dita"/>.</entry>
               </row>
               <row>
-                <entry><filepath>gpbackup_&lt;YYYYMMDDhhmmss>_config.yaml</filepath></entry>
+                <entry><filepath>gpbackup_&lt;YYYYMMDDHHMMSS>_config.yaml</filepath></entry>
                 <entry>Contains metadata about the execution of the particular backup task,
                   including: <ul id="ul_ids_vgj_tbb">
                     <li dir="ltr"><codeph>gpbackup</codeph> version</li>
@@ -351,17 +351,17 @@ water.tonic</codeblock></p>
         <title>Segment Data Files</title>
         <p>By default, each segment creates one compressed CSV file for each table that is backed up
           on the segment. The files are stored in
-            <filepath>&lt;seg_dir>/backups/YYYYMMDD/YYYYMMDDhhmmss/</filepath>. If you specify a
+            <filepath>&lt;seg_dir>/backups/YYYYMMDD/YYYYMMDDHHMMSS/</filepath>. If you specify a
           custom backup directory, segment data files are copied to this same file path as a
           subdirectory of the backup directory. </p>
         <p>Each data file uses the file name format
-            <filepath>gpbackup_&lt;content_id>_&lt;YYYYMMDDhhmmss>_&lt;oid>.gz</filepath> where:<ul
+            <filepath>gpbackup_&lt;content_id>_&lt;YYYYMMDDHHMMSS>_&lt;oid>.gz</filepath> where:<ul
             id="ul_cdb_jpj_tbb">
             <li><filepath>&lt;content_id></filepath> is the content ID of the segment.</li>
-            <li><filepath>&lt;YYYYMMDDhhmmss></filepath> is the timestamp of the
+            <li><filepath>&lt;YYYYMMDDHHMMSS></filepath> is the timestamp of the
                 <codeph>gpbackup</codeph> operation.</li>
             <li><filepath>&lt;oid></filepath> is the object ID of the table. The metadata file
-                <filepath>gpbackup_&lt;YYYYMMDDhhmmss>_toc.yaml</filepath> references this
+                <filepath>gpbackup_&lt;YYYYMMDDHHMMSS>_toc.yaml</filepath> references this
                 <filepath>&lt;oid></filepath> to locate the data for a specific table in a
               schema.</li>
           </ul></p>

--- a/gpdb-doc/dita/admin_guide/managing/backup-gpbackup.xml
+++ b/gpdb-doc/dita/admin_guide/managing/backup-gpbackup.xml
@@ -7,77 +7,365 @@
       are not intended for use in a production environment. Experimental features are subject to
       change without notice in future releases.</note>
     <p><codeph>gpbackup</codeph> and <codeph>gprestore</codeph> are new utilities that provide an
-      improved way to creating backup sets for Greenplum Database and for restoring objects from the
-      backup sets. <codeph>gpbackup</codeph> stores object metadata files and DDL files for a backup
-      in the Greenplum Database master data directory by default. Greenplum Database segments use
-      the <codeph>COPY .. ON SEGMENT</codeph> command to store their data for for backed-up tables
-      in CSV data files, located in each segment's data directory by default.</p>
-    <p>The backup metadata contains all of the information <codeph>gprestore</codeph> needs to
-      restore a full backup set in parallel, or to locate the specific DDL commands and CSV data
-      required to restore only a subset of the backed-up database objects. (See <xref
-        href="#topic_xnj_b4c_tbb" format="dita"/>for more information.) Storing the table data in
-      CSV files provides opportunities for using other restore utilities, such as
-        <codeph>gpload</codeph> to restore data either in the same cluster or another cluster. It
-      also provides the framework for restoring only individual objects in the data set, along with
-      any dependent objects, in future versions of <codeph>gprestore</codeph>.</p>
+      improved way of creating and restoring backup sets for Greenplum Database. By default,
+        <codeph>gpbackup</codeph> stores only the object metadata files and DDL files for a backup
+      in the Greenplum Database master data directory. Greenplum Database segments use the
+        <codeph>COPY .. ON SEGMENT</codeph> command to store their data for  backed-up tables in
+      compressed CSV data files, located in each segment's data directory.</p>
+    <p>The backup metadata files contain all of the information that <codeph>gprestore</codeph>
+      needs to restore a full backup set in parallel. Backup metadata also provides the framework
+      for restoring only individual objects in the data set, along with any dependent objects, in
+      future versions of <codeph>gprestore</codeph>. (See <xref href="#topic_xnj_b4c_tbb"
+        format="dita"/>for more information.) Storing the table data in CSV files also provides
+      opportunities for using other restore utilities, such as <codeph>gpload</codeph>, to restore
+      data either in the same cluster or another cluster. It </p>
     <p>Each <codeph>gpbackup</codeph> task uses a single transaction on the Greenplum database
-      master host. Utility-mode connections are initiated for each segment host, which perform the
-      associated <codeph>COPY .. ON SEGMENT</codeph> operations in parallel.</p>
+      master host. Utility-mode connections are created for each segment host, which perform the
+      associated <codeph>COPY .. ON SEGMENT</codeph> operations in parallel. The backup process
+      acquires an <codeph>ACCESS SHARE</codeph> lock on each table that is backed up.</p>
   </body>
   <topic id="topic_vh5_1hd_tbb">
     <title>Requirements and Limitations</title>
     <body>
       <p>You can use <codeph>gpbackup</codeph> and <codeph>gprestore</codeph> on Greenplum Database
         systems that support the <codeph>COPY .. ON SEGMENT</codeph> command (Greenplum Database
-        5.1.0 and later).</p>
+        5.1.0 and later<ph otherprops="pivotal">, or 4.3.17.0 and later</ph>).</p>
       <p><codeph>gpbackup</codeph> and <codeph>gprestore</codeph> are experimental features in this
         release, and have the following limitations:<ul id="ul_uqh_hhd_tbb">
           <li>Database object filtering is currently limited to schemas and tables.</li>
-          <li>Filtering objects with <codeph>gprestore</codeph> is not supported.</li>
+          <li>Filtering objects with <codeph>gprestore</codeph> is not yet supported.</li>
           <li>Incremental backups are not supported.</li>
         </ul></p>
+    </body>
+  </topic>
+  <topic id="topic_x3s_lqj_tbb">
+    <title>Objects Included in a Backup or Restore</title>
+    <body>
+      <p>The following table lists the objects that are backed up and restored with
+          <codeph>gpbackup</codeph> and <codeph>gprestore</codeph>. Database objects are backed up
+        for the database you specify with the <codeph>-dbname</codeph> option. Global objects
+        (Greenplum Database system objects) are backed up/restored only if you include the
+          <codeph>-globals</codeph> option.<table frame="all" rowsep="1" colsep="1"
+          id="table_vqq_3rj_tbb">
+          <title>Objects that are backed up and restored</title>
+          <tgroup cols="2">
+            <colspec colname="c1" colnum="1" colwidth="1.0*"/>
+            <colspec colname="c2" colnum="2" colwidth="1.0*"/>
+            <thead>
+              <row>
+                <entry>Database (for database specified with <codeph>-dbname</codeph>)</entry>
+                <entry>Global (requires the <codeph>-globals</codeph> option)</entry>
+              </row>
+            </thead>
+            <tbody>
+              <row>
+                <entry>
+                  <ul id="ul_kpk_yrj_tbb">
+                    <li>Session-level configuration parameter settings (GUCs)</li>
+                    <li>Schemas</li>
+                    <li>Procedural language extensions</li>
+                    <li>Sequences</li>
+                    <li dir="ltr">Comments</li>
+                    <li dir="ltr">Tables</li>
+                    <li dir="ltr">Owners</li>
+                    <li dir="ltr">Writable External Tables (DDL only) </li>
+                    <li dir="ltr">Readable External Tables (DDL only) </li>
+                    <li dir="ltr">Functions</li>
+                    <li dir="ltr">Aggregates</li>
+                    <li dir="ltr">Casts</li>
+                    <li dir="ltr">Types</li>
+                    <li dir="ltr">Views</li>
+                    <li dir="ltr">Protocols</li>
+                    <li dir="ltr">Triggers. (While Greenplum Database does not support triggers, any
+                      trigger definitions that are present are backed up and restored.)</li>
+                    <li dir="ltr">Rules</li>
+                    <li dir="ltr">Domains</li>
+                    <li dir="ltr">Operators, operator families, and operator classes</li>
+                    <li dir="ltr">Conversions</li>
+                    <li dir="ltr">Text search parsers, dictionaries, templates, and
+                      configurations</li>
+                  </ul>
+                </entry>
+                <entry>
+                  <ul id="ul_d2t_wrj_tbb">
+                    <li>Tablespaces</li>
+                    <li>Databases</li>
+                    <li>Database-wide configuration parameter settings (GUCs)</li>
+                    <li>Resource group definitions</li>
+                    <li>Resource queue definitions</li>
+                    <li>Roles</li>
+                    <li><codeph>GRANT</codeph> assignments of roles to databases</li>
+                  </ul>
+                </entry>
+              </row>
+            </tbody>
+          </tgroup>
+        </table></p>
+      <p>See also <xref href="#topic_xnj_b4c_tbb" format="dita"/>.</p>
     </body>
   </topic>
   <topic id="topic_qgj_b3d_tbb">
     <title>Performing Basic Backup and Restore Operations</title>
     <body>
-      <p>To perform a complete backup of a database including global metadata, use the command:
-        <codeblock>$ gpbackup -dbname database_name</codeblock></p>
+      <p>To perform a complete backup of a database, use the command:
+        <codeblock>$ gpbackup -dbname &lt;database_name></codeblock></p>
       <p>For a more complete backup, include the <codeph>-globals</codeph> option to back up
-        metadata for the entire Greenplum Database system, such as resource queue and resource group
-        configuration values, database roles, and ownership information for all configured
-        databases.  For example:<codeblock/></p>
-      <p>The above command creates global and database-specific metadata files in the default
-          directory,<codeph>$MASTER_DATA_DIRECTORY/backups/&lt;YYYYMMDD>/&lt;YYYYMMDDhhmmss>/</codeph>.
-        By default, each segment stores table data for the backup in compressed CSV files in
-          &lt;seg_dir><codeph>/backups/&lt;YYYYMMDD>/&lt;YYYYMMDDhhmmss>/</codeph>.  To consolidate
-        all backup files into a single directory, include the <codeph>-backupdir</codeph>
-        option:<codeblock/></p>
-      <p>When using <codeph>gprestore</codeph> to restore from a backup set, you must specify a
-        timestamp value (<codeph>YYYYMMDDhhmmss</codeph>) to apply. If you specified a custom
-          <codeph>-backupdir</codeph> to consolidate the backup files, you must include the same
-          <codeph>-backupdir</codeph> option when using <codeph>gprestore</codeph>.  For
-        example:<codeblock/></p>
+        metadata for the entire Greenplum Database system, such as:<ul id="ul_vpj_5p3_tbb">
+          <li>resource queue and resource group configuration values</li>
+          <li>database roles</li>
+          <li>ownership configuration for all databases</li>
+        </ul></p>
+      <p>For
+        example:<codeblock>$ <b>gpbackup -dbname demo --globals</b>
+20171103:15:25:58 gpbackup:gpadmin:0ee2f5fb02c9:017527-[INFO]:-Starting backup of database demo
+20171103:15:25:58 gpbackup:gpadmin:0ee2f5fb02c9:017527-[INFO]:-Backup Timestamp = 20171103152558
+20171103:15:25:58 gpbackup:gpadmin:0ee2f5fb02c9:017527-[INFO]:-Backup Database = demo
+20171103:15:25:58 gpbackup:gpadmin:0ee2f5fb02c9:017527-[INFO]:-Backup Type = Unfiltered Compressed Full Backup
+20171103:15:25:58 gpbackup:gpadmin:0ee2f5fb02c9:017527-[INFO]:-Acquiring ACCESS SHARE locks on tables
+20171103:15:25:58 gpbackup:gpadmin:0ee2f5fb02c9:017527-[INFO]:-Locks acquired
+20171103:15:25:58 gpbackup:gpadmin:0ee2f5fb02c9:017527-[INFO]:-Gathering table metadata
+20171103:15:25:58 gpbackup:gpadmin:0ee2f5fb02c9:017527-[INFO]:-Writing global database metadata to /gpmaster/gpsne-1/backups/20171103/20171103152558/gpbackup_20171103152558_global.sql
+20171103:15:25:59 gpbackup:gpadmin:0ee2f5fb02c9:017527-[INFO]:-Global database metadata backup complete
+20171103:15:25:59 gpbackup:gpadmin:0ee2f5fb02c9:017527-[INFO]:-Writing pre-data metadata to /gpmaster/gpsne-1/backups/20171103/20171103152558/gpbackup_20171103152558_predata.sql
+20171103:15:25:59 gpbackup:gpadmin:0ee2f5fb02c9:017527-[INFO]:-Pre-data metadata backup complete
+20171103:15:25:59 gpbackup:gpadmin:0ee2f5fb02c9:017527-[INFO]:-Writing post-data metadata to /gpmaster/gpsne-1/backups/20171103/20171103152558/gpbackup_20171103152558_postdata.sql
+20171103:15:25:59 gpbackup:gpadmin:0ee2f5fb02c9:017527-[INFO]:-Post-data metadata backup complete
+20171103:15:25:59 gpbackup:gpadmin:0ee2f5fb02c9:017527-[INFO]:-Writing data to file
+Tables backed up:  2 / 2 [==============================================================] 100.00% 0s
+20171103:15:25:59 gpbackup:gpadmin:0ee2f5fb02c9:017527-[INFO]:-Data backup complete
+20171103:15:25:59 gpbackup:gpadmin:0ee2f5fb02c9:017527-[WARNING]:-Found neither /usr/local/greenplum-db/./bin/mail_contacts nor /home/gpadmin/mail_contacts
+20171103:15:25:59 gpbackup:gpadmin:0ee2f5fb02c9:017527-[WARNING]:-Unable to send backup email notification
+20171103:15:26:00 gpbackup:gpadmin:0ee2f5fb02c9:017527-[INFO]:-Backup completed successfully</codeblock></p>
+      <p>The above command creates global and database-specific metadata files on the Greenplum
+        Database master host in the default directory,
+          <codeph>$MASTER_DATA_DIRECTORY/backups/&lt;YYYYMMDD>/&lt;YYYYMMDDhhmmss>/</codeph>. For
+        example:<codeblock>$ <b>ls /gpmaster/gpsne-1/backups/20171103/20171103152558/</b>
+gpbackup_20171103152558_config.yaml  gpbackup_20171103152558_postdata.sql  gpbackup_20171103152558_report
+gpbackup_20171103152558_global.sql   gpbackup_20171103152558_predata.sql   gpbackup_20171103152558_toc.yaml</codeblock></p>
+      <p>By default, each segment stores table data for the backup in compressed CSV files in
+          <codeph>&lt;seg_dir>/backups/&lt;YYYYMMDD>/&lt;YYYYMMDDhhmmss>/</codeph>:<codeblock>$ <b>ls /gpdata1/gpsne0/backups/20171103/20171103152558/
+</b>gpbackup_0_20171103152558_16524.gz  gpbackup_0_20171103152558_16543.gz</codeblock></p>
+      <p>To consolidate all backup files into a single directory, include the
+          <codeph>-backupdir</codeph>
+        option:<codeblock>$ <b>gpbackup -dbname demo --globals -backupdir /home/gpadmin/backups</b>
+20171103:15:31:56 gpbackup:gpadmin:0ee2f5fb02c9:017586-[INFO]:-Starting backup of database demo
+...
+20171103:15:31:58 gpbackup:gpadmin:0ee2f5fb02c9:017586-[INFO]:-Backup completed successfully
+$ <b>find /home/gpadmin/backups/ -type f</b>
+/home/gpadmin/backups/gpseg0/backups/20171103/20171103153156/gpbackup_0_20171103153156_16543.gz
+/home/gpadmin/backups/gpseg0/backups/20171103/20171103153156/gpbackup_0_20171103153156_16524.gz
+/home/gpadmin/backups/gpseg1/backups/20171103/20171103153156/gpbackup_1_20171103153156_16543.gz
+/home/gpadmin/backups/gpseg1/backups/20171103/20171103153156/gpbackup_1_20171103153156_16524.gz
+/home/gpadmin/backups/gpseg-1/backups/20171103/20171103153156/gpbackup_20171103153156_config.yaml
+/home/gpadmin/backups/gpseg-1/backups/20171103/20171103153156/gpbackup_20171103153156_predata.sql
+/home/gpadmin/backups/gpseg-1/backups/20171103/20171103153156/gpbackup_20171103153156_global.sql
+/home/gpadmin/backups/gpseg-1/backups/20171103/20171103153156/gpbackup_20171103153156_postdata.sql
+/home/gpadmin/backups/gpseg-1/backups/20171103/20171103153156/gpbackup_20171103153156_report
+/home/gpadmin/backups/gpseg-1/backups/20171103/20171103153156/gpbackup_20171103153156_toc.yaml</codeblock></p>
+      <section>
+        <title>Restoring from Backup</title>
+      </section>
+      <p>To use <codeph>gprestore</codeph> to restore from a backup set, you must use the
+          <codeph>-timestamp</codeph> option to specify the exact timestamp value
+          (<codeph>YYYYMMDDhhmmss</codeph>) to restore. Include the <codeph>-createdb</codeph>
+        option if the database does not exist in the cluster. For
+        example:<codeblock>$ <b>dropdb demo</b>
+$ <b>gprestore -timestamp 20171103152558 -createdb</b>
+20171103:15:45:30 gprestore:gpadmin:0ee2f5fb02c9:017714-[INFO]:-Restore Key = 20171103152558
+20171103:15:45:31 gprestore:gpadmin:0ee2f5fb02c9:017714-[INFO]:-Creating database
+20171103:15:45:44 gprestore:gpadmin:0ee2f5fb02c9:017714-[INFO]:-Database creation complete
+20171103:15:45:44 gprestore:gpadmin:0ee2f5fb02c9:017714-[INFO]:-Restoring pre-data metadata from /gpmaster/gpsne-1/backups/20171103/20171103152558/gpbackup_20171103152558_predata.sql
+20171103:15:45:45 gprestore:gpadmin:0ee2f5fb02c9:017714-[INFO]:-Pre-data metadata restore complete
+20171103:15:45:45 gprestore:gpadmin:0ee2f5fb02c9:017714-[INFO]:-Restoring data
+20171103:15:45:45 gprestore:gpadmin:0ee2f5fb02c9:017714-[INFO]:-Data restore complete
+20171103:15:45:45 gprestore:gpadmin:0ee2f5fb02c9:017714-[INFO]:-Restoring post-data metadata from /gpmaster/gpsne-1/backups/20171103/20171103152558/gpbackup_20171103152558_postdata.sql
+20171103:15:45:45 gprestore:gpadmin:0ee2f5fb02c9:017714-[INFO]:-Post-data metadata restore complete</codeblock></p>
+      <p>If you specified a custom <codeph>-backupdir</codeph> to consolidate the backup files,
+        include the same <codeph>-backupdir</codeph> option when using <codeph>gprestore</codeph> to
+        locate the backup
+        files:<codeblock>$ <b>dropdb demo</b>
+$ <b>gprestore -backupdir /home/gpadmin/backups/ -timestamp 20171103153156 -createdb</b>
+20171103:15:51:02 gprestore:gpadmin:0ee2f5fb02c9:017819-[INFO]:-Restore Key = 20171103153156
+...
+20171103:15:51:17 gprestore:gpadmin:0ee2f5fb02c9:017819-[INFO]:-Post-data metadata restore complete</codeblock></p>
       <p>By default, <codeph>gprestore</codeph> does not attempt to restore global metadata for the
-        Greenplum System. If this is necessary, include the <codeph>-globals</codeph>
-        argument:<codeblock/></p>
+        Greenplum System. If this is required, include the <codeph>-globals</codeph> argument.</p>
     </body>
   </topic>
   <topic id="topic_et4_b5d_tbb">
     <title>Filtering the Contents of a Backup</title>
     <body>
-      <p><codeph>gpbackup</codeph> backups up all schemas and tables in the specified database,
-        unless you specifically exclude or include individual table or schema objects. This can be
-        accomplished either using command-line options to define the inclusions or exclusions, or by
-        defining the objects to include/exclude in a text file. For example, the following command
-        backs up all tables in the ???? schema except for the ???? table:<codeblock/></p>
-      <p>You can specify -</p>
+      <p><codeph>gpbackup</codeph> backs up all schemas and tables in the specified database, unless
+        you exclude or include individual schema or table objects. You can filter the database
+        schemas that are backed up by using either the <codeph>-include-schema</codeph> or
+          <codeph>-exclude-schema</codeph> command-line options to <codeph>gpbackup</codeph>. For
+        example, if the "demo" database includes only two schemas, "wikipedia" and "twitter," both
+        of the following commands back up only the "wikipedia"
+        schema:<codeblock>$ <b>gpbackup -dbname demo -include-schema wikipedia</b>
+$ <b>gpbackup -dbname demo -exclude-schema twitter</b></codeblock></p>
+      <p>You can include multiple <codeph>-include-schema</codeph> options in a
+          <codeph>gpbackup</codeph>
+        <i>or</i> multiple <codeph>-exclude-schema</codeph> options. For
+        example:<codeblock>$ <b>gpbackup -dbname demo -include-schema wikipedia -include-schema twitter</b></codeblock></p>
+      <p>To filter the individual tables that are included in a backup set, create a list of
+        qualified table names in a text file to use for including or excluding the tables from a
+        backup. Each line in the text file must define a single table using the format
+          <codeph>&lt;schema-name>.&lt;table-name></codeph>. The file must not include trailing
+        lines. For example:<codeblock>wikipedia.articles
+twitter.message</codeblock></p>
+      <p>If a table or schema name uses any character other than a lowercase letter, number, or an
+        underscore character, then you must include that name in double quotes. For
+        example:<codeblock>beer."IPA"
+"Wine".riesling
+"Wine"."sauvignon blanc"
+water.tonic</codeblock></p>
+      <p>After creating the file, you can use it either to include or exclude tables with the
+          <codeph>gpbackup</codeph> options <codeph>-include-table-file</codeph> and
+          <codeph>-exclude-table-file</codeph>. For
+        example:<codeblock>$ <b>gpbackup -dbname demo -include-table-file /home/gpadmin/table-list.txt</b></codeblock></p>
     </body>
   </topic>
   <topic id="topic_qwd_d5d_tbb">
     <title>Configuring Email Notifications</title>
+    <body>
+      <p><codeph>gpbackup</codeph> will send out status email notifications after a back up
+        operation completes, if you place a file named <filepath>mail_contacts</filepath> in the
+        home directory of the Greenplum database superuser (gpadmin) or in the same directory as the
+          <codeph>gpbackup</codeph> utility (<filepath>$GPHOME/bin</filepath>). </p>
+      <p>This file must contain one email address per line. <codeph>gpbackup</codeph> issues a
+        warning if it cannot locate a <filepath>mail_contacts</filepath> file in either location. If
+        both locations have a <filepath>mail_contacts</filepath> file, then the one in
+          <filepath>$HOME</filepath> takes precedence.</p>
+      <note>The UNIX mail utility must be running on the Greenplum Database host and must be
+        configured to allow the Greenplum superuser (gpadmin) to send email.</note>
+    </body>
   </topic>
   <topic id="topic_xnj_b4c_tbb">
     <title>Understanding Backup Files</title>
+    <body>
+      <note type="warning">All <codeph>gpbackup</codeph> metadata files are created with read-only
+        permissions. Never delete or modify the metadata files for a <codeph>gpbackup</codeph>
+        backup set. Doing so will render the backup files non-functional.</note>
+      <p>A complete backup set for <codeph>gpbackup</codeph> includes multiple metadata files,
+        supporting files, and CSV data files, each designated with the timestamp at which the backup
+        was created.</p>
+      <p>By default, metadata and supporting files are stored on the Greenplum Database master host
+        in the directory
+          <filepath>$MASTER_DATA_DIRECTORY/backups/YYYYMMDD/YYYYMMDDhhmmss/</filepath>. If you
+        specify a custom backup directory, this same file path is created as a subdirectory of the
+        backup directory.  The following table describes the names and contents of the metadata and
+        supporting files.<table frame="all" rowsep="1" colsep="1" id="table_nrz_4gj_tbb">
+          <title>gpbackup Metadata Files (master)</title>
+          <tgroup cols="2">
+            <colspec colname="c1" colnum="1" colwidth="1.0*"/>
+            <colspec colname="c2" colnum="2" colwidth="1.0*"/>
+            <thead>
+              <row>
+                <entry>File name</entry>
+                <entry>Description</entry>
+              </row>
+            </thead>
+            <tbody>
+              <row>
+                <entry><filepath>gpbackup_&lt;YYYYMMDDhhmmss>_global.sql</filepath></entry>
+                <entry>This file is created only if you include the -globals option to
+                    <codeph>gpbackup</codeph>. It contains DDL for objects that are global to the
+                  Greenplum Cluster, and not owned by a specific database within the cluster. These
+                  objects include:<ul id="ul_f1b_dhj_tbb">
+                    <li>Tablespaces</li>
+                    <li>Databases</li>
+                    <li>Database-wide configuration parameter settings (GUCs)</li>
+                    <li>Resource group definitions</li>
+                    <li>Resource queue definitions</li>
+                    <li>Roles</li>
+                    <li><codeph>GRANT</codeph> assignments of roles to databases</li>
+                  </ul></entry>
+              </row>
+              <row>
+                <entry><filepath>gpbackup_&lt;YYYYMMDDhhmmss>_predata.sql</filepath></entry>
+                <entry>Contains DDL for objects in the backed-up database (specified with
+                    <codeph>-dbname)</codeph> that must be created <i>prior</i> to restoring the
+                  actual data. These objects include:<ul id="ul_s35_nhj_tbb">
+                    <li>Session-level configuration parameter settings (GUCs)</li>
+                    <li>Schemas</li>
+                    <li>Procedural language extensions</li>
+                    <li>Types</li>
+                    <li>Sequences</li>
+                    <li>Functions</li>
+                    <li>Tables</li>
+                    <li>Protocols</li>
+                    <li>Operators and operator classes</li>
+                    <li>Conversions</li>
+                    <li>Aggregates</li>
+                    <li>Casts</li>
+                    <li>Views</li>
+                    <li>Constraints</li>
+                  </ul></entry>
+              </row>
+              <row>
+                <entry><filepath>gpbackup_&lt;YYYYMMDDhhmmss>_postdata.sql</filepath></entry>
+                <entry>Contains DDL for objects in the backed-up database (specified with
+                    <codeph>-dbname)</codeph> that must be created <i>after</i> restoring the data.
+                  These objects include:<ul id="ul_zyg_tgj_tbb">
+                    <li dir="ltr">Indexes</li>
+                    <li dir="ltr">Rules</li>
+                    <li dir="ltr">Triggers. (While Greenplum Database does not support triggers, any
+                      trigger definitions that are present are backed up and restored.)</li>
+                  </ul></entry>
+              </row>
+              <row>
+                <entry><filepath>gpbackup_&lt;YYYYMMDDhhmmss>_toc.yaml</filepath></entry>
+                <entry>Contains metadata for locating object DDL in the
+                    <filepath>_predata.sql</filepath> and <filepath>_postdata.sql</filepath> files.
+                  This file also contains the table names and OIDs used for locating the
+                  corresponding table data in CSV data files that are created on each segment. See
+                    <xref href="#topic_xnj_b4c_tbb/section_oys_cpj_tbb" format="dita"/>.</entry>
+              </row>
+              <row>
+                <entry><filepath>gpbackup_&lt;YYYYMMDDhhmmss>_report</filepath></entry>
+                <entry>Contains information about the backup operation that is used to populate the
+                  email notice (if configured) that is sent after the backup completes. This file
+                  contains information such as:<ul id="ul_bjr_2kj_tbb">
+                    <li>Command-line options that were provided</li>
+                    <li>Database that was backed up</li>
+                    <li>Database version</li>
+                    <li>Backup type</li>
+                  </ul>See <xref href="#topic_qwd_d5d_tbb" format="dita"/>.</entry>
+              </row>
+              <row>
+                <entry><filepath>gpbackup_&lt;YYYYMMDDhhmmss>_config.yaml</filepath></entry>
+                <entry>Contains metadata about the execution of the particular backup task,
+                  including: <ul id="ul_ids_vgj_tbb">
+                    <li dir="ltr"><codeph>gpbackup</codeph> version</li>
+                    <li dir="ltr">Database name</li>
+                    <li dir="ltr">Greenplum Database version</li>
+                    <li dir="ltr">Additional option settings such as
+                        <codeph>-no-compression</codeph>, <codeph>-metadata-only</codeph>,
+                        <codeph>-data-only</codeph>, and <codeph>-with-stats</codeph>.</li>
+                  </ul></entry>
+              </row>
+            </tbody>
+          </tgroup>
+        </table></p>
+      <section id="section_oys_cpj_tbb">
+        <title>Segment Data Files</title>
+        <p>By default, each segment creates one compressed CSV file for each table that is backed up
+          on the segment. The files are stored in
+            <filepath>&lt;seg_dir>/backups/YYYYMMDD/YYYYMMDDhhmmss/</filepath>. If you specify a
+          custom backup directory, segment data files are copied to this same file path as a
+          subdirectory of the backup directory. </p>
+        <p>Each data file uses the file name format
+            <filepath>gpbackup_&lt;content_id>_&lt;YYYYMMDDhhmmss>_&lt;oid>.gz</filepath> where:<ul
+            id="ul_cdb_jpj_tbb">
+            <li><filepath>&lt;content_id></filepath> is the content ID of the segment.</li>
+            <li><filepath>&lt;YYYYMMDDhhmmss></filepath> is the timestamp of the
+                <codeph>gpbackup</codeph> operation.</li>
+            <li><filepath>&lt;oid></filepath> is the object ID of the table. The metadata file
+                <filepath>gpbackup_&lt;YYYYMMDDhhmmss>_toc.yaml</filepath> references this
+                <filepath>&lt;oid></filepath> to locate the data for a specific table in a
+              schema.</li>
+          </ul></p>
+      </section>
+    </body>
   </topic>
 </topic>

--- a/gpdb-doc/dita/admin_guide/managing/backup-gpbackup.xml
+++ b/gpdb-doc/dita/admin_guide/managing/backup-gpbackup.xml
@@ -3,9 +3,81 @@
 <topic id="topic_yrr_hqw_sbb">
   <title>Parallel Backup with gpbackup and gprestore</title>
   <body>
-    <p><codeph>gpbackup</codeph> uses a more flexible locking model that enables you to run multiple
-      backup operations simultaneously, and does not prevent <codeph>CREATE TABLE</codeph> or
-        <codeph>ALTER TABLE</codeph> operations during the backup. <codeph>gpbackup</codeph> also
-      separates database object DDL operations from </p>
+    <note><codeph>gpbackup</codeph> and <codeph>gprestore</codeph> are experimental utilities and
+      are not intended for use in a production environment. Experimental features are subject to
+      change without notice in future releases.</note>
+    <p><codeph>gpbackup</codeph> and <codeph>gprestore</codeph> are new utilities that provide an
+      improved way to creating backup sets for Greenplum Database and for restoring objects from the
+      backup sets. <codeph>gpbackup</codeph> stores object metadata files and DDL files for a backup
+      in the Greenplum Database master data directory by default. Greenplum Database segments use
+      the <codeph>COPY .. ON SEGMENT</codeph> command to store their data for for backed-up tables
+      in CSV data files, located in each segment's data directory by default.</p>
+    <p>The backup metadata contains all of the information <codeph>gprestore</codeph> needs to
+      restore a full backup set in parallel, or to locate the specific DDL commands and CSV data
+      required to restore only a subset of the backed-up database objects. (See <xref
+        href="#topic_xnj_b4c_tbb" format="dita"/>for more information.) Storing the table data in
+      CSV files provides opportunities for using other restore utilities, such as
+        <codeph>gpload</codeph> to restore data either in the same cluster or another cluster. It
+      also provides the framework for restoring only individual objects in the data set, along with
+      any dependent objects, in future versions of <codeph>gprestore</codeph>.</p>
+    <p>Each <codeph>gpbackup</codeph> task uses a single transaction on the Greenplum database
+      master host. Utility-mode connections are initiated for each segment host, which perform the
+      associated <codeph>COPY .. ON SEGMENT</codeph> operations in parallel.</p>
   </body>
+  <topic id="topic_vh5_1hd_tbb">
+    <title>Requirements and Limitations</title>
+    <body>
+      <p>You can use <codeph>gpbackup</codeph> and <codeph>gprestore</codeph> on Greenplum Database
+        systems that support the <codeph>COPY .. ON SEGMENT</codeph> command (Greenplum Database
+        5.1.0 and later).</p>
+      <p><codeph>gpbackup</codeph> and <codeph>gprestore</codeph> are experimental features in this
+        release, and have the following limitations:<ul id="ul_uqh_hhd_tbb">
+          <li>Database object filtering is currently limited to schemas and tables.</li>
+          <li>Filtering objects with <codeph>gprestore</codeph> is not supported.</li>
+          <li>Incremental backups are not supported.</li>
+        </ul></p>
+    </body>
+  </topic>
+  <topic id="topic_qgj_b3d_tbb">
+    <title>Performing Basic Backup and Restore Operations</title>
+    <body>
+      <p>To perform a complete backup of a database including global metadata, use the command:
+        <codeblock>$ gpbackup -dbname database_name</codeblock></p>
+      <p>For a more complete backup, include the <codeph>-globals</codeph> option to back up
+        metadata for the entire Greenplum Database system, such as resource queue and resource group
+        configuration values, database roles, and ownership information for all configured
+        databases.  For example:<codeblock/></p>
+      <p>The above command creates global and database-specific metadata files in the default
+          directory,<codeph>$MASTER_DATA_DIRECTORY/backups/&lt;YYYYMMDD>/&lt;YYYYMMDDhhmmss>/</codeph>.
+        By default, each segment stores table data for the backup in compressed CSV files in
+          &lt;seg_dir><codeph>/backups/&lt;YYYYMMDD>/&lt;YYYYMMDDhhmmss>/</codeph>.  To consolidate
+        all backup files into a single directory, include the <codeph>-backupdir</codeph>
+        option:<codeblock/></p>
+      <p>When using <codeph>gprestore</codeph> to restore from a backup set, you must specify a
+        timestamp value (<codeph>YYYYMMDDhhmmss</codeph>) to apply. If you specified a custom
+          <codeph>-backupdir</codeph> to consolidate the backup files, you must include the same
+          <codeph>-backupdir</codeph> option when using <codeph>gprestore</codeph>.  For
+        example:<codeblock/></p>
+      <p>By default, <codeph>gprestore</codeph> does not attempt to restore global metadata for the
+        Greenplum System. If this is necessary, include the <codeph>-globals</codeph>
+        argument:<codeblock/></p>
+    </body>
+  </topic>
+  <topic id="topic_et4_b5d_tbb">
+    <title>Filtering the Contents of a Backup</title>
+    <body>
+      <p><codeph>gpbackup</codeph> backups up all schemas and tables in the specified database,
+        unless you specifically exclude or include individual table or schema objects. This can be
+        accomplished either using command-line options to define the inclusions or exclusions, or by
+        defining the objects to include/exclude in a text file. For example, the following command
+        backs up all tables in the ???? schema except for the ???? table:<codeblock/></p>
+      <p>You can specify -</p>
+    </body>
+  </topic>
+  <topic id="topic_qwd_d5d_tbb">
+    <title>Configuring Email Notifications</title>
+  </topic>
+  <topic id="topic_xnj_b4c_tbb">
+    <title>Understanding Backup Files</title>
+  </topic>
 </topic>

--- a/gpdb-doc/dita/admin_guide/managing/backup-gpbackup.xml
+++ b/gpdb-doc/dita/admin_guide/managing/backup-gpbackup.xml
@@ -10,19 +10,24 @@
       improved way of creating and restoring backup sets for Greenplum Database. By default,
         <codeph>gpbackup</codeph> stores only the object metadata files and DDL files for a backup
       in the Greenplum Database master data directory. Greenplum Database segments use the
-        <codeph>COPY .. ON SEGMENT</codeph> command to store their data for  backed-up tables in
-      compressed CSV data files, located in each segment's data directory.</p>
+        <codeph>COPY .. ON SEGMENT</codeph> command to store their data for backed-up tables in
+      compressed CSV data files, located in each segment's <filepath>backups</filepath>
+      directory.</p>
     <p>The backup metadata files contain all of the information that <codeph>gprestore</codeph>
       needs to restore a full backup set in parallel. Backup metadata also provides the framework
       for restoring only individual objects in the data set, along with any dependent objects, in
       future versions of <codeph>gprestore</codeph>. (See <xref href="#topic_xnj_b4c_tbb"
-        format="dita"/>for more information.) Storing the table data in CSV files also provides
-      opportunities for using other restore utilities, such as <codeph>gpload</codeph>, to restore
-      data either in the same cluster or another cluster. It </p>
-    <p>Each <codeph>gpbackup</codeph> task uses a single transaction on the Greenplum database
-      master host. Utility-mode connections are created for each segment host, which perform the
-      associated <codeph>COPY .. ON SEGMENT</codeph> operations in parallel. The backup process
-      acquires an <codeph>ACCESS SHARE</codeph> lock on each table that is backed up.</p>
+        format="dita"/> for more information.) Storing the table data in CSV files also provides
+      opportunities for using other restore utilities, such as <codeph>gpload</codeph>, to load the
+      data either in the same cluster or another cluster. By default, one file is created for each
+      table on the segment. You can specify the <codeph> -leaf-partition-data</codeph> option with
+        <codeph>gpbackup</codeph> to create one data file per leaf partition of a partitioned table,
+      instead of a single file.</p>
+    <p>Each <codeph>gpbackup</codeph> task uses a single transaction in Greenplum Database. During
+      this transaction, metadata is backed up on the master host, and data for each table on each
+      segment host is written to CSV backup files using <codeph>COPY .. ON SEGMENT</codeph> commands
+      in parallel. The backup process acquires an <codeph>ACCESS SHARE</codeph> lock on each table
+      that is backed up.</p>
   </body>
   <topic id="topic_vh5_1hd_tbb">
     <title>Requirements and Limitations</title>
@@ -32,6 +37,8 @@
         5.1.0 and later<ph otherprops="pivotal">, or 4.3.17.0 and later</ph>).</p>
       <p><codeph>gpbackup</codeph> and <codeph>gprestore</codeph> are experimental features in this
         release, and have the following limitations:<ul id="ul_uqh_hhd_tbb">
+          <li>You can execute multiple instances of <codeph>gpbackup</codeph>, but each execution
+            requires a distinct timestamp.</li>
           <li>Database object filtering is currently limited to schemas and tables.</li>
           <li>Filtering objects with <codeph>gprestore</codeph> is not yet supported.</li>
           <li>Incremental backups are not supported.</li>
@@ -44,9 +51,9 @@
       <p>The following table lists the objects that are backed up and restored with
           <codeph>gpbackup</codeph> and <codeph>gprestore</codeph>. Database objects are backed up
         for the database you specify with the <codeph>-dbname</codeph> option. Global objects
-        (Greenplum Database system objects) are backed up/restored only if you include the
-          <codeph>-globals</codeph> option.<table frame="all" rowsep="1" colsep="1"
-          id="table_vqq_3rj_tbb">
+        (Greenplum Database system objects) are also backed up by default, but they are restored
+        only if you include the <codeph>-globals</codeph> option to
+          <codeph>gprestore</codeph>.<table frame="all" rowsep="1" colsep="1" id="table_vqq_3rj_tbb">
           <title>Objects that are backed up and restored</title>
           <tgroup cols="2">
             <colspec colname="c1" colnum="1" colwidth="1.0*"/>
@@ -54,7 +61,7 @@
             <thead>
               <row>
                 <entry>Database (for database specified with <codeph>-dbname</codeph>)</entry>
-                <entry>Global (requires the <codeph>-globals</codeph> option)</entry>
+                <entry>Global (requires the <codeph>-globals</codeph> option to restore)</entry>
               </row>
             </thead>
             <tbody>
@@ -107,16 +114,10 @@
   <topic id="topic_qgj_b3d_tbb">
     <title>Performing Basic Backup and Restore Operations</title>
     <body>
-      <p>To perform a complete backup of a database, use the command:
-        <codeblock>$ gpbackup -dbname &lt;database_name></codeblock></p>
-      <p>For a more complete backup, include the <codeph>-globals</codeph> option to back up
-        metadata for the entire Greenplum Database system, such as:<ul id="ul_vpj_5p3_tbb">
-          <li>resource queue and resource group configuration values</li>
-          <li>database roles</li>
-          <li>ownership configuration for all databases</li>
-        </ul></p>
+      <p>To perform a complete backup of a database, as well as Greenplum Database system metadata,
+        use the command: <codeblock>$ gpbackup -dbname &lt;database_name></codeblock></p>
       <p>For
-        example:<codeblock>$ <b>gpbackup -dbname demo --globals</b>
+        example:<codeblock>$ <b>gpbackup -dbname demo</b>
 20171103:15:25:58 gpbackup:gpadmin:0ee2f5fb02c9:017527-[INFO]:-Starting backup of database demo
 20171103:15:25:58 gpbackup:gpadmin:0ee2f5fb02c9:017527-[INFO]:-Backup Timestamp = 20171103152558
 20171103:15:25:58 gpbackup:gpadmin:0ee2f5fb02c9:017527-[INFO]:-Backup Database = demo
@@ -146,8 +147,8 @@ gpbackup_20171103152558_global.sql   gpbackup_20171103152558_predata.sql   gpbac
           <codeph>&lt;seg_dir>/backups/&lt;YYYYMMDD>/&lt;YYYYMMDDHHMMSS>/</codeph>:<codeblock>$ <b>ls /gpdata1/gpsne0/backups/20171103/20171103152558/
 </b>gpbackup_0_20171103152558_16524.gz  gpbackup_0_20171103152558_16543.gz</codeblock></p>
       <p>To consolidate all backup files into a single directory, include the
-          <codeph>-backupdir</codeph>
-        option:<codeblock>$ <b>gpbackup -dbname demo --globals -backupdir /home/gpadmin/backups</b>
+          <codeph>-backupdir</codeph> option. Note that you must specify an absolute path with this
+        option:<codeblock>$ <b>gpbackup -dbname demo -backupdir /home/gpadmin/backups</b>
 20171103:15:31:56 gpbackup:gpadmin:0ee2f5fb02c9:017586-[INFO]:-Starting backup of database demo
 ...
 20171103:15:31:58 gpbackup:gpadmin:0ee2f5fb02c9:017586-[INFO]:-Backup completed successfully
@@ -188,8 +189,15 @@ $ <b>gprestore -backupdir /home/gpadmin/backups/ -timestamp 20171103153156 -crea
 20171103:15:51:02 gprestore:gpadmin:0ee2f5fb02c9:017819-[INFO]:-Restore Key = 20171103153156
 ...
 20171103:15:51:17 gprestore:gpadmin:0ee2f5fb02c9:017819-[INFO]:-Post-data metadata restore complete</codeblock></p>
-      <p>By default, <codeph>gprestore</codeph> does not attempt to restore global metadata for the
-        Greenplum System. If this is required, include the <codeph>-globals</codeph> argument.</p>
+      <p><codeph>gprestore</codeph> does not attempt to restore global metadata for the Greenplum
+        System by default. If this is required, include the <codeph>-globals</codeph> argument.</p>
+      <p>By default, <codeph>gprestore</codeph> uses 2 parallel connections to restore table data
+        and metadata. If you have a large backup set, especially a large backup that contains
+        numerous indexes, then you can improve performance of the restore option by increasing the
+        number of parallel connections with the <codeph>-jobs</codeph> option. For
+        example:<codeblock>$ <b>gprestore -backupdir /home/gpadmin/backups/ -timestamp 20171103153156 -createdb -jobs 8</b></codeblock></p>
+      <p>Test the number of parallel connections with your backup set to determine the ideal number
+        for fast data recovery.</p>
     </body>
   </topic>
   <topic id="topic_et4_b5d_tbb">
@@ -268,10 +276,9 @@ water.tonic</codeblock></p>
             <tbody>
               <row>
                 <entry><filepath>gpbackup_&lt;YYYYMMDDHHMMSS>_global.sql</filepath></entry>
-                <entry>This file is created only if you include the -globals option to
-                    <codeph>gpbackup</codeph>. It contains DDL for objects that are global to the
-                  Greenplum Cluster, and not owned by a specific database within the cluster. These
-                  objects include:<ul id="ul_f1b_dhj_tbb">
+                <entry>Contains DDL for objects that are global to the Greenplum Cluster, and not
+                  owned by a specific database within the cluster. These objects include:<ul
+                    id="ul_f1b_dhj_tbb">
                     <li>Tablespaces</li>
                     <li>Databases</li>
                     <li>Database-wide configuration parameter settings (GUCs)</li>
@@ -279,7 +286,9 @@ water.tonic</codeblock></p>
                     <li>Resource queue definitions</li>
                     <li>Roles</li>
                     <li><codeph>GRANT</codeph> assignments of roles to databases</li>
-                  </ul></entry>
+                  </ul><p>Note that global metadata is not restored by default. You must include the
+                      <codeph>-globals</codeph> options to <codeph>gprestore</codeph> to restore
+                    global metadata.</p></entry>
               </row>
               <row>
                 <entry><filepath>gpbackup_&lt;YYYYMMDDHHMMSS>_predata.sql</filepath></entry>
@@ -353,7 +362,10 @@ water.tonic</codeblock></p>
           on the segment. The files are stored in
             <filepath>&lt;seg_dir>/backups/YYYYMMDD/YYYYMMDDHHMMSS/</filepath>. If you specify a
           custom backup directory, segment data files are copied to this same file path as a
-          subdirectory of the backup directory. </p>
+          subdirectory of the backup directory. If you include the
+            <codeph>-leaf-partition-data</codeph> option, <codeph>gpbackup</codeph> creates one data
+          file for each leaf partition of a partitioned table, instead of just one table for
+          file.</p>
         <p>Each data file uses the file name format
             <filepath>gpbackup_&lt;content_id>_&lt;YYYYMMDDHHMMSS>_&lt;oid>.gz</filepath> where:<ul
             id="ul_cdb_jpj_tbb">

--- a/gpdb-doc/dita/admin_guide/managing/backup-gpbackup.xml
+++ b/gpdb-doc/dita/admin_guide/managing/backup-gpbackup.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="topic_yrr_hqw_sbb">
+  <title>Parallel Backup with gpbackup and gprestore</title>
+  <body>
+    <p><codeph>gpbackup</codeph> uses a more flexible locking model that enables you to run multiple
+      backup operations simultaneously, and does not prevent <codeph>CREATE TABLE</codeph> or
+        <codeph>ALTER TABLE</codeph> operations during the backup. <codeph>gpbackup</codeph> also
+      separates database object DDL operations from </p>
+  </body>
+</topic>

--- a/gpdb-doc/dita/admin_guide/managing/backup-overview.xml
+++ b/gpdb-doc/dita/admin_guide/managing/backup-overview.xml
@@ -50,7 +50,14 @@
         change without notice in future releases.</note>
       <p><codeph>gpbackup</codeph> and <codeph>gprestore</codeph> are new utilities that are
         designed to improve the performance, functionality, and reliability of backups as compared
-        to <codeph>gpcrondump</codeph> and <codeph>gpdbrestore</codeph>. </p>
+        to <codeph>gpcrondump</codeph> and <codeph>gpdbrestore</codeph>. <codeph>gpbackup</codeph>
+        uses a more flexible locking scheme than <codeph>gpcrondump</codeph>, which enables you to
+        run multiple backup tasks simultaneously and does not prohibit <codeph>CREATE</codeph> or
+          <codeph>ALTER TABLE</codeph> operations during the backup. Backup artificats created with
+          <codeph>gpbackup</codeph> are designed to provide future capabilities for restoring
+        individual database objects along with their dependencies, such as functions and required
+        user-defined datatypes. See <xref href="backup-gpbackup.xml#topic_yrr_hqw_sbb"/> for more
+        information.</p>
     </section>
     <section>
       <title id="kk155276">Non-Parallel Backup with pg_dump</title>

--- a/gpdb-doc/dita/admin_guide/managing/backup-overview.xml
+++ b/gpdb-doc/dita/admin_guide/managing/backup-overview.xml
@@ -51,13 +51,15 @@
       <p><codeph>gpbackup</codeph> and <codeph>gprestore</codeph> are new utilities that are
         designed to improve the performance, functionality, and reliability of backups as compared
         to <codeph>gpcrondump</codeph> and <codeph>gpdbrestore</codeph>. <codeph>gpbackup</codeph>
-        uses a more flexible locking scheme than <codeph>gpcrondump</codeph>, which enables you to
-        run multiple backup tasks simultaneously and does not prohibit <codeph>CREATE</codeph> or
-          <codeph>ALTER TABLE</codeph> operations during the backup. Backup files created with
-          <codeph>gpbackup</codeph> are designed to provide future capabilities for restoring
-        individual database objects along with their dependencies, such as functions and required
-        user-defined datatypes. See <xref href="backup-gpbackup.xml#topic_yrr_hqw_sbb"/> for more
-        information.</p>
+        utilizes <codeph>ACCESS SHARE</codeph> locks at the individual table level, instead of
+          <codeph>EXCLUSIVE</codeph> locks on the <codeph>pg_class</codeph> catalog table. This
+        enables you to execute DML statements during the backup, such as <codeph>CREATE</codeph>,
+          <codeph>ALTER</codeph>,  <codeph>DROP</codeph>, and <codeph>TRUNCATE</codeph> operations,
+        as long as those operations do not target the current backup set. </p>
+      <p>Backup files created with <codeph>gpbackup</codeph> are designed to provide future
+        capabilities for restoring individual database objects along with their dependencies, such
+        as functions and required user-defined datatypes. See <xref
+          href="backup-gpbackup.xml#topic_yrr_hqw_sbb"/> for more information.</p>
     </section>
     <section>
       <title id="kk155276">Non-Parallel Backup with pg_dump</title>

--- a/gpdb-doc/dita/admin_guide/managing/backup-overview.xml
+++ b/gpdb-doc/dita/admin_guide/managing/backup-overview.xml
@@ -53,7 +53,7 @@
         to <codeph>gpcrondump</codeph> and <codeph>gpdbrestore</codeph>. <codeph>gpbackup</codeph>
         uses a more flexible locking scheme than <codeph>gpcrondump</codeph>, which enables you to
         run multiple backup tasks simultaneously and does not prohibit <codeph>CREATE</codeph> or
-          <codeph>ALTER TABLE</codeph> operations during the backup. Backup artificats created with
+          <codeph>ALTER TABLE</codeph> operations during the backup. Backup files created with
           <codeph>gpbackup</codeph> are designed to provide future capabilities for restoring
         individual database objects along with their dependencies, such as functions and required
         user-defined datatypes. See <xref href="backup-gpbackup.xml#topic_yrr_hqw_sbb"/> for more

--- a/gpdb-doc/dita/admin_guide/managing/backup-overview.xml
+++ b/gpdb-doc/dita/admin_guide/managing/backup-overview.xml
@@ -44,6 +44,15 @@
           <codeph>gpdbrestore</codeph> can also be used to copy files to the alternate location.</p>
     </section>
     <section>
+      <title>Parallel Backup with gpbackup and gprestore</title>
+      <note><codeph>gpbackup</codeph> and <codeph>gprestore</codeph> are experimental utilities and
+        are not intended for use in a production environment. Experimental features are subject to
+        change without notice in future releases.</note>
+      <p><codeph>gpbackup</codeph> and <codeph>gprestore</codeph> are new utilities that are
+        designed to improve the performance, functionality, and reliability of backups as compared
+        to <codeph>gpcrondump</codeph> and <codeph>gpdbrestore</codeph>. </p>
+    </section>
+    <section>
       <title id="kk155276">Non-Parallel Backup with pg_dump</title>
       <p>The PostgreSQL <codeph>pg_dump</codeph> and <codeph>pg_dumpall</codeph> non-parallel backup
         utilities can be used to create a single dump file on the master host that contains all data

--- a/gpdb-doc/dita/admin_guide/managing/backup.ditamap
+++ b/gpdb-doc/dita/admin_guide/managing/backup.ditamap
@@ -18,5 +18,6 @@
       <topicref href="gpdbrestore.xml"/>
       <topicref href="restore-diff-system.xml"/>
     </topicref>
+    <topicref href="backup-gpbackup.xml"/>
   </topicref>
 </map>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpbackup.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpbackup.xml
@@ -15,9 +15,9 @@
    [<b>-debug</b>]
    [<b>-exclude-schema</b> <varname>schema_name</varname>]
    [<b>-exclude-table-file</b> <varname>file_name</varname>]
-   [<b>-globals</b>]
    [<b>-include-schema</b> <varname>schema_name</varname>]
    [<b>-include-table-file</b> <varname>file_name</varname>]
+   [<b>-leaf-partition-data</b>]
    [<b>-metadata-only</b>]
    [<b>-no-compression</b>]
    [<b>-quiet</b>]
@@ -27,9 +27,10 @@
     </section>
     <section><title>Description</title><p>The <codeph>gpbackup</codeph> utility backs up the
         contents of a database into a collection of metadata files and data files that can be used
-        to restore the database at a later time using <codeph>gprestore</codeph>. By default, only
-        objects in the specified database are backed up. You can optionally supply the
-          <codeph>-globals</codeph> option to backup Greenplum Database system object. See <xref
+        to restore the database at a later time using <codeph>gprestore</codeph>. By default,
+          <codeph>gpbackup</codeph> backs up objects in the specified database as well as global
+        Greenplum Database system objects. You can optionally supply the <codeph>-globals</codeph>
+        option with <codeph>gprestore</codeph> to restore global objects. See <xref
           href="../../admin_guide/managing/backup-gpbackup.xml#topic_x3s_lqj_tbb"/> for additional
         information.</p><p><codeph>gpbackup</codeph> stores the object metadata files and DDL files
         for a backup in the Greenplum Database master data directory by default. Greenplum Database
@@ -37,8 +38,8 @@
         backed-up tables in compressed CSV data files, located in each segment's data directory. See
           <xref href="../../admin_guide/managing/backup-gpbackup.xml#topic_xnj_b4c_tbb"/> for
         additional information.</p><p>You can add the <codeph>-backupdir</codeph> option to copy all
-        backup files from the Greenplum Database master and segment hosts to a single location for
-        later use.  Additional options are provided to filter the backup set in order to include or
+        backup files from the Greenplum Database master and segment hosts to an absolute path for
+        later use. Additional options are provided to filter the backup set in order to include or
         exclude specific tables.</p><p>Each <codeph>gpbackup</codeph> task uses a single transaction
         on the Greenplum database master host. Utility-mode connections are created for each segment
         host, which perform the associated <codeph>COPY .. ON SEGMENT</codeph> operations in
@@ -63,7 +64,8 @@
           <pt><b>-backupdir</b>
             <varname>directory</varname></pt>
           <pd>Optional. Copies all required backup files (metadata files and data files) to the
-            specified directory. If you do not supply this option, metadata files are created on the
+            specified directory. You must specify <varname>directory</varname> as an absolute path
+            (not relative). If you do not supply this option, metadata files are created on the
             Greenplum Database master host in the
               <filepath>$MASTER_DATA_DIRECTORY/backups/YYYYMMDD/YYYYMMDDhhmmss/</filepath>
             directory. Segment hosts create CSV data files in the
@@ -111,14 +113,6 @@
       </parml>
       <parml>
         <plentry>
-          <pt><b>-globals</b></pt>
-          <pd>Optional. Backs up Greenplum Database system objects in addition to database objects.
-            See <xref href="../../admin_guide/managing/backup-gpbackup.xml#topic_x3s_lqj_tbb"
-            />.</pd>
-        </plentry>
-      </parml>
-      <parml>
-        <plentry>
           <pt><b>-include-schema</b>
             <varname>schema_name</varname></pt>
           <pd>Optional. Specifies a database schema to include in the backup. You can specify this
@@ -142,6 +136,13 @@
             Any tables not listed in this file are omitted from the backup set. See <xref
               href="../../admin_guide/managing/backup-gpbackup.xml#topic_et4_b5d_tbb"/> for more
             information.</pd>
+        </plentry>
+      </parml>
+      <parml>
+        <plentry>
+          <pt><b>-leaf-partition-data</b></pt>
+          <pd>Optional. For partitioned tables, creates one data file per leaf partition instead of
+            one data file for the entire table (the default).</pd>
         </plentry>
       </parml>
       <parml>
@@ -184,16 +185,16 @@
     </section>
     <section>
       <title>Examples</title>
-      <p>Backup all schemas and tables in the "demo"
-        database:<codeblock>$ gpbackup -dbname demo</codeblock></p>
+      <p>Backup all schemas and tables in the "demo" database, including global Greenplum Database
+        system objects statistics:<codeblock>$ gpbackup -dbname demo</codeblock></p>
       <p>Backup all schemas and tables in the "demo" database except for the "twitter"
         schema:<codeblock>$ gpbackup -dbname demo -exclude-schema twitter</codeblock></p>
       <p>Backup only the "twitter" schema in the "demo"
         database:<codeblock>$ gpbackup -dbname demo -include-schema twitter</codeblock></p>
-      <p>Backup all schemas and tables in the "demo" database, including as global Greenplum
-        Database system objects and query statistics, and copy all backup files to the
+      <p>Backup all schemas and tables in the "demo" database, including global Greenplum Database
+        system objects and query statistics, and copy all backup files to the
           <filepath>/home/gpadmin/backup</filepath>
-        directory:<codeblock>$ gpbackup -dbname demo -globals -with-stats -backupdir /home/gpadmin/backup</codeblock></p>
+        directory:<codeblock>$ gpbackup -dbname demo -with-stats -backupdir /home/gpadmin/backup</codeblock></p>
     </section>
     <section id="section9">
       <title>See Also</title>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpbackup.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpbackup.xml
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="topic_dyz_d5j_tbb">
+  <title>gpbackup</title>
+  <body>
+    <p>Create a Greenplum Database backup for use with the <codeph>gprestore</codeph> utility. </p>
+    <note><codeph>gpbackup</codeph> and <codeph>gprestore</codeph> are experimental utilities and
+      are not intended for use in a production environment. Experimental features are subject to
+      change without notice in future releases.</note>
+    <section>
+      <title>Synopsis</title>
+      <codeblock><b>gpbackup -dbname</b> <varname>database_name</varname>
+   [<b>-backupdir</b> <varname>directory</varname>]
+   [<b>-data-only</b>]
+   [<b>-debug</b>]
+   [<b>-exclude-schema</b> <varname>schema_name</varname>]
+   [<b>-exclude-table-file</b> <varname>file_name</varname>]
+   [<b>-globals</b>]
+   [<b>-include-schema</b> <varname>schema_name</varname>]
+   [<b>-include-table-file</b> <varname>file_name</varname>]
+   [<b>-metadata-only</b>]
+   [<b>-no-compression</b>]
+   [<b>-quiet</b>]
+   [<b>-verbose</b>]
+   [<b>-version</b>]
+   [<b>-with-stats</b>]</codeblock>
+    </section>
+    <section><title>Description</title><p>The <codeph>gpbackup</codeph> utility backs up the
+        contents of a database into a collection of metadata files and data files that can be used
+        to restore the database at a later time using <codeph>gprestore</codeph>. By default, only
+        objects in the specified database are backed up. You can optionally supply the
+          <codeph>-globals</codeph> option to backup Greenplum Database system object. See <xref
+          href="../../admin_guide/managing/backup-gpbackup.xml#topic_x3s_lqj_tbb"/> for additional
+        information.</p><p><codeph>gpbackup</codeph> stores the object metadata files and DDL files
+        for a backup in the Greenplum Database master data directory by default. Greenplum Database
+        segments use the <codeph>COPY .. ON SEGMENT</codeph> command to store their data for
+        backed-up tables in compressed CSV data files, located in each segment's data directory. See
+          <xref href="../../admin_guide/managing/backup-gpbackup.xml#topic_xnj_b4c_tbb"/> for
+        additional information.</p><p>You can add the <codeph>-backupdir</codeph> option to copy all
+        backup files from the Greenplum Database master and segment hosts to a single location for
+        later use.  Additional options are provided to filter the backup set in order to include or
+        exclude specific tables.</p><p>Each <codeph>gpbackup</codeph> task uses a single transaction
+        on the Greenplum database master host. Utility-mode connections are created for each segment
+        host, which perform the associated <codeph>COPY .. ON SEGMENT</codeph> operations in
+        parallel. The backup process acquires an <codeph>ACCESS SHARE</codeph> lock on each table
+        that is backed up.</p><codeph>gpbackup</codeph> will send out status email notifications
+      after a back up operation completes, if you place a file named
+        <filepath>mail_contacts</filepath> in the home directory of the Greenplum database superuser
+      (gpadmin) or in the same directory as the <codeph>gpbackup</codeph> utility
+        (<filepath>$GPHOME/bin</filepath>). See <xref
+        href="../../admin_guide/managing/backup-gpbackup.xml#topic_qwd_d5d_tbb"/>.</section>
+    <section>
+      <title>Options</title>
+      <parml>
+        <plentry>
+          <pt><b>-dbname</b>
+            <varname>database_name</varname></pt>
+          <pd>Required. Specifies the database to back up.</pd>
+        </plentry>
+      </parml>
+      <parml>
+        <plentry>
+          <pt><b>-backupdir</b>
+            <varname>directory</varname></pt>
+          <pd>Optional. Copies all required backup files (metadata files and data files) to the
+            specified directory. If you do not supply this option, metadata files are created on the
+            Greenplum Database master host in the
+              <filepath>$MASTER_DATA_DIRECTORY/backups/YYYYMMDD/YYYYMMDDhhmmss/</filepath>
+            directory. Segment hosts create CSV data files in the
+              <filepath>&lt;seg_dir>/backups/YYYYMMDD/YYYYMMDDhhmmss/</filepath> directory. When you
+            specify a custom backup directory, files are copied to these paths in subdirectories of
+            the backup directory.</pd>
+        </plentry>
+      </parml>
+      <parml>
+        <plentry>
+          <pt><b>-data-only</b></pt>
+          <pd>Optional. Backs up only the table data into CSV files, but does not backup metadata
+            files needed to recreate the tables and other database objects.</pd>
+        </plentry>
+      </parml>
+      <parml>
+        <plentry>
+          <pt><b>-debug</b></pt>
+          <pd>Optional. Displays verbose debug messages during operation.</pd>
+        </plentry>
+      </parml>
+      <parml>
+        <plentry>
+          <pt><b>-exclude-schema</b>
+            <varname>schema_name</varname></pt>
+          <pd>Optional. Specifies a database schema to exclude from the backup. You can specify this
+            option multiple times to exclude multiple schemas. You cannot combine this option with
+            the <codeph>-include-schema</codeph> option. See <xref
+              href="../../admin_guide/managing/backup-gpbackup.xml#topic_et4_b5d_tbb"/> for more
+            information.</pd>
+        </plentry>
+      </parml>
+      <parml>
+        <plentry>
+          <pt><b>-exclude-table-file</b>
+            <varname>file_name</varname></pt>
+          <pd>Optional. Specifies a text file containing a list of tables to exclude from the
+            backup. Each line in the text file must define a single table using the format
+              <codeph>&lt;schema-name>.&lt;table-name></codeph>. The file must not include trailing
+            lines. If a table or schema name uses any character other than a lowercase letter,
+            number, or an underscore character, then you must include that name in double quotes.
+            See <xref href="../../admin_guide/managing/backup-gpbackup.xml#topic_et4_b5d_tbb"/> for
+            more information.</pd>
+        </plentry>
+      </parml>
+      <parml>
+        <plentry>
+          <pt><b>-globals</b></pt>
+          <pd>Optional. Backs up Greenplum Database system objects in addition to database objects.
+            See <xref href="../../admin_guide/managing/backup-gpbackup.xml#topic_x3s_lqj_tbb"
+            />.</pd>
+        </plentry>
+      </parml>
+      <parml>
+        <plentry>
+          <pt><b>-include-schema</b>
+            <varname>schema_name</varname></pt>
+          <pd>Optional. Specifies a database schema to include in the backup. You can specify this
+            option multiple times to include multiple schemas. If you specify this option, any
+            schemas that are not included in subsequent <codeph>-include-schema</codeph> options are
+            omitted from the backup set. You cannot combine this option with the
+              <codeph>-exclude-schema</codeph> option. See <xref
+              href="../../admin_guide/managing/backup-gpbackup.xml#topic_et4_b5d_tbb"/> for more
+            information.</pd>
+        </plentry>
+      </parml>
+      <parml>
+        <plentry>
+          <pt><b>-include-table-file</b>
+            <varname>file_name</varname></pt>
+          <pd>Optional. Specifies a text file containing a list of tables to include in the backup.
+            Each line in the text file must define a single table using the format
+              <codeph>&lt;schema-name>.&lt;table-name></codeph>. The file must not include trailing
+            lines. If a table or schema name uses any character other than a lowercase letter,
+            number, or an underscore character, then you must include that name in double quotes.
+            Any tables not listed in this file are omitted from the backup set. See <xref
+              href="../../admin_guide/managing/backup-gpbackup.xml#topic_et4_b5d_tbb"/> for more
+            information.</pd>
+        </plentry>
+      </parml>
+      <parml>
+        <plentry>
+          <pt><b>-metadata-only</b></pt>
+          <pd>Optional. Creates only the metadata files (DDL) needed to recreate the database
+            objects, but does not back up the actual table data.</pd>
+        </plentry>
+      </parml>
+      <parml>
+        <plentry>
+          <pt><b>-no-compression</b></pt>
+          <pd>Optional. Do not compress the table data CSV files.</pd>
+        </plentry>
+      </parml>
+      <parml>
+        <plentry>
+          <pt><b>-quiet</b></pt>
+          <pd>Optional. Suppress all non-warning, non-error log messages.</pd>
+        </plentry>
+      </parml>
+      <parml>
+        <plentry>
+          <pt><b>-verbose</b></pt>
+          <pd>Optional. Print verbose log messages.</pd>
+        </plentry>
+      </parml>
+      <parml>
+        <plentry>
+          <pt><b>-version</b></pt>
+          <pd>Optional. Print the version number and exit.</pd>
+        </plentry>
+      </parml>
+      <parml>
+        <plentry>
+          <pt><b>-with-stats</b></pt>
+          <pd>Optional. Include query plan statistics in the backup set.</pd>
+        </plentry>
+      </parml>
+    </section>
+    <section>
+      <title>Examples</title>
+      <p>Backup all schemas and tables in the "demo"
+        database:<codeblock>$ gpbackup -dbname demo</codeblock></p>
+      <p>Backup all schemas and tables in the "demo" database except for the "twitter"
+        schema:<codeblock>$ gpbackup -dbname demo -exclude-schema twitter</codeblock></p>
+      <p>Backup only the "twitter" schema in the "demo"
+        database:<codeblock>$ gpbackup -dbname demo -include-schema twitter</codeblock></p>
+      <p>Backup all schemas and tables in the "demo" database, including as global Greenplum
+        Database system objects and query statistics, and copy all backup files to the
+          <filepath>/home/gpadmin/backup</filepath>
+        directory:<codeblock>$ gpbackup -dbname demo -globals -with-stats -backupdir /home/gpadmin/backup</codeblock></p>
+    </section>
+    <section id="section9">
+      <title>See Also</title>
+      <p>
+        <codeph>
+          <xref href="./gprestore.xml" type="topic" format="dita"/>
+        </codeph>
+      </p>
+    </section>
+  </body>
+</topic>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gprestore.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gprestore.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="topic_phj_g5j_tbb">
+  <title>gprestore</title>
+  <body>
+    <p>Restore a Greenplum Database backup that was created using <codeph>gpbackup</codeph> utility.
+      By default <codeph>gprestore</codeph> uses backed up metadata files and DDL files located in
+      the Greenplum Database master data directory, with table data stored locally on segment hosts
+      in CSV data files.</p>
+    <note><codeph>gpbackup</codeph> and <codeph>gprestore</codeph> are experimental utilities and
+      are not intended for use in a production environment. Experimental features are subject to
+      change without notice in future releases.</note>
+    <section>
+      <title>Synopsis</title>
+      <codeblock><b>gprestore -timestamp</b> <varname>YYYYMMDDHHMMSS</varname>
+   [<b>-backupdir</b> <varname>directory</varname>]
+   [<b>-createdb</b>]
+   [<b>-debug</b>]
+   [<b>-globals</b>]
+   [<b>-quiet</b>]
+   [<b>-redirect</b> <varname>database_name</varname>]
+   [<b>-verbose</b>]
+   [<b>-version</b>]
+   [<b>-with-stats</b>]</codeblock>
+    </section>
+    <section>
+      <title>Description</title>
+      <p>To use <codeph>gprestore</codeph> to restore from a backup set, you must include the
+          <codeph>-timestamp</codeph> option to specify the exact timestamp value
+          (<codeph>YYYYMMDDHHMMSS</codeph>) of the backup set to restore. If you specified a custom
+          <codeph>-backupdir</codeph> to consolidate the backup files, include the same
+          <codeph>-backupdir</codeph> option with <codeph>gprestore</codeph>.</p>
+      <p>Include the <codeph>-createdb</codeph> option if the database does not exist in the
+        cluster. You can optionally restore a backup set to a different database by using the
+          <codeph>-redirect</codeph> option.</p>
+      <p>If global Greenplum Database system objects or query plan statistics are available in the
+        backup set, you can restore those objects with the <codeph>-globals</codeph> and
+          <codeph>-with-stats</codeph> options, respectively. By default, only the database objects
+        in the backup set are restored.</p>
+      <p><codeph>gprestore</codeph> does not currently support filtering the database objects that
+        are restored from a backup set. </p>
+    </section>
+    <section>
+      <title>Options</title>
+      <parml>
+        <plentry>
+          <pt><b>-timestamp</b>
+            <varname>YYYYMMDDHHMMSS</varname></pt>
+          <pd>Required. Specifies the timestamp of the <codeph>gpbackup</codeph> backup set to
+            restore. By default, <codeph>gprestore</codeph> looks for files </pd>
+        </plentry>
+      </parml>
+    </section>
+  </body>
+</topic>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gprestore.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gprestore.xml
@@ -3,10 +3,10 @@
 <topic id="topic_phj_g5j_tbb">
   <title>gprestore</title>
   <body>
-    <p>Restore a Greenplum Database backup that was created using <codeph>gpbackup</codeph> utility.
-      By default <codeph>gprestore</codeph> uses backed up metadata files and DDL files located in
-      the Greenplum Database master data directory, with table data stored locally on segment hosts
-      in CSV data files.</p>
+    <p>Restore a Greenplum Database backup that was created using the <codeph>gpbackup</codeph>
+      utility. By default <codeph>gprestore</codeph> uses backed up metadata files and DDL files
+      located in the Greenplum Database master host data directory, with table data stored locally
+      on segment hosts in CSV data files.</p>
     <note><codeph>gpbackup</codeph> and <codeph>gprestore</codeph> are experimental utilities and
       are not intended for use in a production environment. Experimental features are subject to
       change without notice in future releases.</note>
@@ -29,10 +29,14 @@
           <codeph>-timestamp</codeph> option to specify the exact timestamp value
           (<codeph>YYYYMMDDHHMMSS</codeph>) of the backup set to restore. If you specified a custom
           <codeph>-backupdir</codeph> to consolidate the backup files, include the same
-          <codeph>-backupdir</codeph> option with <codeph>gprestore</codeph>.</p>
+          <codeph>-backupdir</codeph> option with <codeph>gprestore</codeph> to locate the backup
+        files.</p>
       <p>Include the <codeph>-createdb</codeph> option if the database does not exist in the
         cluster. You can optionally restore a backup set to a different database by using the
           <codeph>-redirect</codeph> option.</p>
+      <p>Database objects to be restored must not exist in the target database. If the database
+        itself is not available in Greenplum Database, include the <codeph>-createdb</codeph> option
+        to create it with <codeph>gprestore</codeph>.</p>
       <p>If global Greenplum Database system objects or query plan statistics are available in the
         backup set, you can restore those objects with the <codeph>-globals</codeph> and
           <codeph>-with-stats</codeph> options, respectively. By default, only the database objects
@@ -50,6 +54,97 @@
             restore. By default, <codeph>gprestore</codeph> looks for files </pd>
         </plentry>
       </parml>
+      <parml>
+        <plentry>
+          <pt><b>-backupdir</b>
+            <varname>directory</varname></pt>
+          <pd>Optional. Sources all backup files (metadata files and data files) from the specified
+            directory. If you do not supply this option, <codeph>gprestore</codeph> tries to locate
+            metadata files for the timestamp on the Greenplum Database master host in the
+              <filepath>$MASTER_DATA_DIRECTORY/backups/YYYYMMDD/YYYYMMDDhhmmss/</filepath>
+            directory. CSV data files must be available on each segment in the
+              <filepath>&lt;seg_dir>/backups/YYYYMMDD/YYYYMMDDhhmmss/</filepath> directory. Include
+            this option when you specify a custom backup directory with
+            <codeph>gpbackup</codeph>.</pd>
+        </plentry>
+      </parml>
+      <parml>
+        <plentry>
+          <pt><b>-createdb</b></pt>
+          <pd>Optional. Creates the database before restoring the database object metadata.</pd>
+        </plentry>
+      </parml>
+      <parml>
+        <plentry>
+          <pt><b>-debug</b></pt>
+          <pd>Optional. Displays verbose debug messages during operation.</pd>
+        </plentry>
+      </parml>
+      <parml>
+        <plentry>
+          <pt><b>-globals</b></pt>
+          <pd>Optional. Restores Greenplum Database system objects in the backup set, in addition to
+            database objects. See <xref
+              href="../../admin_guide/managing/backup-gpbackup.xml#topic_x3s_lqj_tbb"/>.</pd>
+        </plentry>
+      </parml>
+      <parml>
+        <plentry>
+          <pt><b>-quiet</b></pt>
+          <pd>Optional. Suppress all non-warning, non-error log messages.</pd>
+        </plentry>
+      </parml>
+      <parml>
+        <plentry>
+          <pt><b>-redirect</b>
+            <varname>database_name</varname></pt>
+          <pd>Optional. Restore to the specified <varname>database_name</varname> instead of to the
+            database that was backed up.</pd>
+        </plentry>
+      </parml>
+      <parml>
+        <plentry>
+          <pt><b>-verbose</b></pt>
+          <pd>Optional. Print verbose log messages.</pd>
+        </plentry>
+      </parml>
+      <parml>
+        <plentry>
+          <pt><b>-version</b></pt>
+          <pd>Optional. Print the version number and exit.</pd>
+        </plentry>
+      </parml>
+      <parml>
+        <plentry>
+          <pt><b>-with-stats</b></pt>
+          <pd>Optional. Restore query plan statistics from the backup set.</pd>
+        </plentry>
+      </parml>
+    </section>
+    <section>
+      <title>Examples</title>
+      <p>Create the demo database and restore all schemas and tables in the backup set for the
+        indicated
+        timestamp:<codeblock>$ dropdb demo;
+$ gprestore -timestamp 20171103152558 -createdb</codeblock></p>
+      <p>Restore the backup set to the "demos" database instead of the "demo" database that was
+        backed
+        up:<codeblock>$ createdb demo2;
+$ gprestore -timestamp 20171103152558 -redirect demo2</codeblock></p>
+      <p>Restore global Greenplum Database metadata and query plan statistics in addition to the
+        database
+        objects:<codeblock>$ gprestore -timestamp 20171103152558 -createdb -globals -with-stats</codeblock></p>
+      <p>Restore, using backup files that were created in the
+          <filepath>/home/gpadmin/backup</filepath>
+        directory:<codeblock>$ gprestore -backupdir /home/gpadmin/backups/ -timestamp 20171103153156 -createdb</codeblock></p>
+    </section>
+    <section id="section9">
+      <title>See Also</title>
+      <p>
+        <codeph>
+          <xref href="./gpbackup.xml" type="topic" format="dita"/>
+        </codeph>
+      </p>
     </section>
   </body>
 </topic>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gprestore.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gprestore.xml
@@ -17,6 +17,7 @@
    [<b>-createdb</b>]
    [<b>-debug</b>]
    [<b>-globals</b>]
+   [<b>-jobs</b> <varname>int</varname>]
    [<b>-quiet</b>]
    [<b>-redirect</b> <varname>database_name</varname>]
    [<b>-verbose</b>]
@@ -37,10 +38,16 @@
       <p>Database objects to be restored must not exist in the target database. If the database
         itself is not available in Greenplum Database, include the <codeph>-createdb</codeph> option
         to create it with <codeph>gprestore</codeph>.</p>
-      <p>If global Greenplum Database system objects or query plan statistics are available in the
-        backup set, you can restore those objects with the <codeph>-globals</codeph> and
-          <codeph>-with-stats</codeph> options, respectively. By default, only the database objects
-        in the backup set are restored.</p>
+      <p>Greenplum Database system objects are automatically included in a <codeph>gpbackup</codeph>
+        backup set, but these objects are only restored if you include the <codeph>-globals</codeph>
+        option to <codeph>gprestore</codeph>. Similarly, if you backed up query plan statistics
+        using the <codeph>-with-stats</codeph> option, you can restore those statistics by providing
+          <codeph>-with-stats</codeph> to <codeph>gprestore</codeph>. By default, only database
+        objects in the backup set are restored.</p>
+      <p>Performance of restore operations can be improved by creating multiple parallel connections
+        to restore table data and metadata. By default <codeph>gprestore</codeph> uses 2 parallel
+        connections, but you can increase this number with the the <codeph>-jobs</codeph> option for
+        large restore operations.</p>
       <p><codeph>gprestore</codeph> does not currently support filtering the database objects that
         are restored from a backup set. </p>
     </section>
@@ -51,7 +58,12 @@
           <pt><b>-timestamp</b>
             <varname>YYYYMMDDHHMMSS</varname></pt>
           <pd>Required. Specifies the timestamp of the <codeph>gpbackup</codeph> backup set to
-            restore. By default, <codeph>gprestore</codeph> looks for files </pd>
+            restore. By default <codeph>gprestore</codeph> tries to locate metadata files for the
+            timestamp on the Greenplum Database master host in the
+              <filepath>$MASTER_DATA_DIRECTORY/backups/YYYYMMDD/YYYYMMDDhhmmss/</filepath>
+            directory, and CSV data files in the
+              <filepath>&lt;seg_dir>/backups/YYYYMMDD/YYYYMMDDhhmmss/</filepath> directory of each
+            segment host.</pd>
         </plentry>
       </parml>
       <parml>
@@ -59,7 +71,8 @@
           <pt><b>-backupdir</b>
             <varname>directory</varname></pt>
           <pd>Optional. Sources all backup files (metadata files and data files) from the specified
-            directory. If you do not supply this option, <codeph>gprestore</codeph> tries to locate
+            directory. You must specify <varname>directory</varname> as an absolute path (not
+            relative). If you do not supply this option, <codeph>gprestore</codeph> tries to locate
             metadata files for the timestamp on the Greenplum Database master host in the
               <filepath>$MASTER_DATA_DIRECTORY/backups/YYYYMMDD/YYYYMMDDhhmmss/</filepath>
             directory. CSV data files must be available on each segment in the
@@ -86,6 +99,16 @@
           <pd>Optional. Restores Greenplum Database system objects in the backup set, in addition to
             database objects. See <xref
               href="../../admin_guide/managing/backup-gpbackup.xml#topic_x3s_lqj_tbb"/>.</pd>
+        </plentry>
+      </parml>
+      <parml>
+        <plentry>
+          <pt><b>-jobs</b>
+            <varname>int</varname></pt>
+          <pd>Optional. Specifies the number of parallel connections to use when restoring table
+            data and post-data metadata. By default, <codeph>gprestore</codeph> uses 2 parallel
+            connections. Increasing this number can improve the speed of restoring data, especially
+            data data uses numerous indexes.</pd>
         </plentry>
       </parml>
       <parml>
@@ -135,8 +158,8 @@ $ gprestore -timestamp 20171103152558 -redirect demo2</codeblock></p>
         database
         objects:<codeblock>$ gprestore -timestamp 20171103152558 -createdb -globals -with-stats</codeblock></p>
       <p>Restore, using backup files that were created in the
-          <filepath>/home/gpadmin/backup</filepath>
-        directory:<codeblock>$ gprestore -backupdir /home/gpadmin/backups/ -timestamp 20171103153156 -createdb</codeblock></p>
+          <filepath>/home/gpadmin/backup</filepath> directory, creating 8 parallel
+        connections:<codeblock>$ gprestore -backupdir /home/gpadmin/backups/ -timestamp 20171103153156 -createdb -jobs 8</codeblock></p>
     </section>
     <section id="section9">
       <title>See Also</title>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/util_ref.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/util_ref.xml
@@ -29,6 +29,8 @@
             <xref href="gpaddmirrors.xml#topic1" type="topic" format="dita"/>
           </p>
           <p>
+            <xref href="gpbackup.xml" type="topic" format="dita"/></p>
+          <p>
             <xref href="gpcheck.xml#topic1" type="topic" format="dita"/></p>
           <p>
             <xref href="gpcheckcat.xml#topic1"/>
@@ -98,6 +100,8 @@
           <p>
             <xref href="gpreload.xml#topic1"/>
           </p>
+          <p>
+            <xref href="gprestore.xml" type="topic" format="dita"/></p>
           <p> gp_restore (deprecated)</p>
           <p>gpsizecalc (deprecated)</p>
           <p>

--- a/gpdb-doc/dita/utility_guide/utility_guide.ditamap
+++ b/gpdb-doc/dita/utility_guide/utility_guide.ditamap
@@ -8,6 +8,7 @@
             <topicref href="admin_utilities/analyzedb.xml"/>
             <topicref href="admin_utilities/gpactivatestandby.xml"/>
             <topicref href="admin_utilities/gpaddmirrors.xml"/>
+            <topicref href="admin_utilities/gpbackup.xml"/>
             <topicref href="admin_utilities/gpcheck.xml"/>
             <topicref href="admin_utilities/gpcheckcat.xml"/>
             <topicref href="admin_utilities/gpcheckperf.xml"/>
@@ -31,6 +32,7 @@
             <topicref href="admin_utilities/gppkg.xml"/>
             <topicref href="admin_utilities/gprecoverseg.xml"/>
             <topicref href="admin_utilities/gpreload.xml"/>
+            <topicref href="admin_utilities/gprestore.xml"/>
             <topicref href="admin_utilities/gpscp.xml"/>
             <topicref href="admin_utilities/gpseginstall.xml"/>
             <topicref href="admin_utilities/gpssh.xml"/>


### PR DESCRIPTION
These changes are being staged in HTML at:

- [Backup and Restore Overview](http://docs-gpdb-review-staging.cfapps.io/510/admin_guide/managing/backup-overview.html) - Small overview about gpbackup/gprestore, comparing to gpcrondump/gpdbrestore.
- [Parallel Backup with gpbackup and gprestore](http://docs-gpdb-review-staging.cfapps.io/510/admin_guide/managing/backup-gpbackup.html) - Main "using" section.
- [gpbackup](http://docs-gpdb-review-staging.cfapps.io/510/utility_guide/admin_utilities/gpbackup.html) - reference page.
- [gprestore](http://docs-gpdb-review-staging.cfapps.io/510/utility_guide/admin_utilities/gprestore.html) - reference page.