### PR TITLE
formatter_fixedwidth: fix tests on Mac OS

### DIFF
--- a/contrib/formatter_fixedwidth/input/readable_query11.source
+++ b/contrib/formatter_fixedwidth/input/readable_query11.source
@@ -8,7 +8,7 @@
      s1='10',s2='10', s3='10', col_empty='5', col_null='5');
 
  -- query ext table can return correct results
- select * from tbl_ext_fixedwidth order by s1;
+ select * from tbl_ext_fixedwidth;
 
  -- When field length of s1 is 10, which is greater than its defined column length char(5)
  DROP EXTERNAL TABLE IF EXISTS tbl_ext_fixedwidth;

--- a/contrib/formatter_fixedwidth/input/readable_query27.source
+++ b/contrib/formatter_fixedwidth/input/readable_query27.source
@@ -9,7 +9,7 @@ FORMAT 'CUSTOM' (formatter='fixedwidth_in',
 
 -- Confirm only the trailing while spaces will be trimmed.
 -- The leading white spaces will be always reserved.
-select * from tbl_ext_fixedwidth order by s1;
+select * from tbl_ext_fixedwidth;
 
 select * from tbl_ext_fixedwidth where s1='cha' and s2='vara' and s3='texta';
 

--- a/contrib/formatter_fixedwidth/input/readable_query28.source
+++ b/contrib/formatter_fixedwidth/input/readable_query28.source
@@ -8,7 +8,7 @@
 
  -- Confirm only the trailing while spaces will be trimmed.
  -- The leading white spaces will be always reserved.
- select * from tbl_ext_fixedwidth order by s1;
+ select * from tbl_ext_fixedwidth;
 
  select * from tbl_ext_fixedwidth where s1='cha' and s2='vara' and s3='texta';
 

--- a/contrib/formatter_fixedwidth/input/readable_query30.source
+++ b/contrib/formatter_fixedwidth/input/readable_query30.source
@@ -11,7 +11,7 @@
  -- Confirm the trailing while spaces will be reserved for vary-length data types: varchar(n) and text
  -- Trailing space is NOT reserved for char(n) data type. This is correct.
  -- The leading white spaces will be always reserved.
- select * from tbl_ext_fixedwidth order by s1;
+ select * from tbl_ext_fixedwidth;
 
  select * from tbl_ext_fixedwidth where s1='cha' and s2='vara      ' and s3='texta     ';
 

--- a/contrib/formatter_fixedwidth/input/readable_query31.source
+++ b/contrib/formatter_fixedwidth/input/readable_query31.source
@@ -12,7 +12,7 @@
  -- and field "col_empty" only contains blanks, 
  -- then a NULL will be loaded into the table,
  -- even with preseve_blanks = on
- select * from tbl_ext_fixedwidth where col_empty is null order by s1;
+ select * from tbl_ext_fixedwidth where col_empty is null;
 
  -- 2. Define null = 'vara'
  DROP EXTERNAL TABLE IF EXISTS tbl_ext_fixedwidth;
@@ -27,7 +27,7 @@
  -- and field "col_empty" only contains blanks, 
  -- then an empty string will be loaded into the table
  -- only word 'vara' will be replaced as null
- select * from tbl_ext_fixedwidth where col_empty is not null order by s1;
+ select * from tbl_ext_fixedwidth where col_empty is not null;
 
  select * from tbl_ext_fixedwidth where s2 is null and col_empty is not null;
 
@@ -44,6 +44,6 @@
  -- and field "col_empty" only contains blanks, 
  -- then an empty string will be loaded into the table
  -- only word 'NULL' will be replaced as null
- select * from tbl_ext_fixedwidth where col_empty is not null order by s1;
+ select * from tbl_ext_fixedwidth where col_empty is not null;
 
  select * from tbl_ext_fixedwidth where col_null is null and col_empty is not null;

--- a/contrib/formatter_fixedwidth/output/readable_query11.source
+++ b/contrib/formatter_fixedwidth/output/readable_query11.source
@@ -7,17 +7,17 @@ CREATE READABLE EXTERNAL TABLE tbl_ext_fixedwidth (
  FORMAT 'CUSTOM' (formatter='fixedwidth_in', 
      s1='10',s2='10', s3='10', col_empty='5', col_null='5');
 -- query ext table can return correct results
-select * from tbl_ext_fixedwidth order by s1;
+select * from tbl_ext_fixedwidth;
           s1          |    s2     |     s3     | col_empty | col_null 
 ----------------------+-----------+------------+-----------+----------
  cha              | vara      | texta      |           | null
   chb             |  varb     |  textb     |           | NULL
    chc            |   varc    |   textc    |           | Null
-chd               |    vard   |    textd   |           | NULLL
- che              |     vare  |     texte  |           | 
-  chf             |      varf |      textf |           | null
- chg              |     varg  |     textg  |           | NULLa
-chh               |    varh   |    texth   |           | NULL_
+    chd           |    vard   |    textd   |           | NULLL
+     che          |     vare  |     texte  |           | 
+      chf         |      varf |      textf |           | null
+     chg          |     varg  |     textg  |           | NULLa
+    chh           |    varh   |    texth   |           | NULL_
    chi            |   vari    |   texti    |           | null
   chj             |  varj     |  textj     |           | aNULL
 (10 rows)

--- a/contrib/formatter_fixedwidth/output/readable_query27.source
+++ b/contrib/formatter_fixedwidth/output/readable_query27.source
@@ -8,17 +8,17 @@ FORMAT 'CUSTOM' (formatter='fixedwidth_in',
   s1='10',s2='10', s3='10');
 -- Confirm only the trailing while spaces will be trimmed.
 -- The leading white spaces will be always reserved.
-select * from tbl_ext_fixedwidth order by s1;
+select * from tbl_ext_fixedwidth;
      s1     |    s2     |     s3     
 ------------+-----------+------------
  cha        | vara      | texta
   chb       |  varb     |  textb
    chc      |   varc    |   textc
-chd         |    vard   |    textd
- che        |     vare  |     texte
-  chf       |      varf |      textf
- chg        |     varg  |     textg
-chh         |    varh   |    texth
+    chd     |    vard   |    textd
+     che    |     vare  |     texte
+      chf   |      varf |      textf
+     chg    |     varg  |     textg
+    chh     |    varh   |    texth
    chi      |   vari    |   texti
   chj       |  varj     |  textj
 (10 rows)

--- a/contrib/formatter_fixedwidth/output/readable_query28.source
+++ b/contrib/formatter_fixedwidth/output/readable_query28.source
@@ -7,19 +7,19 @@ CREATE READABLE EXTERNAL TABLE tbl_ext_fixedwidth (
      s1='10',s2='10', s3='10', preserve_blanks='OFF');
 -- Confirm only the trailing while spaces will be trimmed.
 -- The leading white spaces will be always reserved.
-select * from tbl_ext_fixedwidth order by s1;
- s1     |    s2     |     s3     
+select * from tbl_ext_fixedwidth;
+ s1       |    s2     |     s3     
 ------------+-----------+------------
- cha    | vara      | texta
-  chb   |  varb     |  textb
-   chc  |   varc    |   textc
-chd     |    vard   |    textd
- che    |     vare  |     texte
-  chf   |      varf |      textf
- chg    |     varg  |     textg
-chh     |    varh   |    texth
-   chi  |   vari    |   texti
-  chj   |  varj     |  textj
+ cha      | vara      | texta
+  chb     |  varb     |  textb
+   chc    |   varc    |   textc
+    chd   |    vard   |    textd
+     che  |     vare  |     texte
+      chf |      varf |      textf
+     chg  |     varg  |     textg
+    chh   |    varh   |    texth
+   chi    |   vari    |   texti
+  chj     |  varj     |  textj
 (10 rows)
 
 select * from tbl_ext_fixedwidth where s1='cha' and s2='vara' and s3='texta';

--- a/contrib/formatter_fixedwidth/output/readable_query30.source
+++ b/contrib/formatter_fixedwidth/output/readable_query30.source
@@ -10,19 +10,19 @@ CREATE READABLE EXTERNAL TABLE tbl_ext_fixedwidth (
 -- Confirm the trailing while spaces will be reserved for vary-length data types: varchar(n) and text
 -- Trailing space is NOT reserved for char(n) data type. This is correct.
 -- The leading white spaces will be always reserved.
-select * from tbl_ext_fixedwidth order by s1;
- s1     |     s2     |     s3     
+select * from tbl_ext_fixedwidth;
+ s1       |     s2     |     s3     
 ------------+------------+------------
- cha    | vara       | texta     
-  chb   |  varb      |  textb    
-   chc  |   varc     |   textc   
-chd     |    vard    |    textd  
- che    |     vare   |     texte 
-  chf   |      varf  |      textf
- chg    |     varg   |     textg 
-chh     |    varh    |    texth  
-   chi  |   vari     |   texti   
-  chj   |  varj      |  textj    
+ cha      | vara       | texta     
+  chb     |  varb      |  textb    
+   chc    |   varc     |   textc   
+    chd   |    vard    |    textd  
+     che  |     vare   |     texte 
+      chf |      varf  |      textf
+     chg  |     varg   |     textg 
+    chh   |    varh    |    texth  
+   chi    |   vari     |   texti   
+  chj     |  varj      |  textj    
 (10 rows)
 
 select * from tbl_ext_fixedwidth where s1='cha' and s2='vara  ' and s3='texta     ';

--- a/contrib/formatter_fixedwidth/output/readable_query31.source
+++ b/contrib/formatter_fixedwidth/output/readable_query31.source
@@ -11,19 +11,19 @@ CREATE READABLE EXTERNAL TABLE tbl_ext_fixedwidth (
 -- and field "col_empty" only contains blanks, 
 -- then a NULL will be loaded into the table,
 -- even with preseve_blanks = on
-select * from tbl_ext_fixedwidth where col_empty is null order by s1;
- s1     |     s2     |     s3     | col_empty | col_null 
+select * from tbl_ext_fixedwidth where col_empty is null;
+ s1       |     s2     |     s3     | col_empty | col_null 
 ------------+------------+------------+-----------+----------
- cha    | vara       | texta      |           | null 
-  chb   |  varb      |  textb     |           | NULL 
-   chc  |   varc     |   textc    |           | Null 
-chd     |    vard    |    textd   |           | NULLL
- che    |     vare   |     texte  |           | 
-  chf   |      varf  |      textf |           | null 
- chg    |     varg   |     textg  |           | NULLa
-chh     |    varh    |    texth   |           | NULL_
-   chi  |   vari     |   texti    |           | null 
-  chj       |  varj      |  textj     |           | aNULL
+ cha      | vara       | texta      |           | null 
+  chb     |  varb      |  textb     |           | NULL 
+   chc    |   varc     |   textc    |           | Null 
+    chd   |    vard    |    textd   |           | NULLL
+     che  |     vare   |     texte  |           | 
+      chf |      varf  |      textf |           | null 
+     chg  |     varg   |     textg  |           | NULLa
+    chh   |    varh    |    texth   |           | NULL_
+   chi    |   vari     |   texti    |           | null 
+  chj     |  varj      |  textj     |           | aNULL
 (10 rows)
 
  -- 2. Define null = 'vara'
@@ -38,19 +38,19 @@ chh     |    varh    |    texth   |           | NULL_
 -- and field "col_empty" only contains blanks, 
 -- then an empty string will be loaded into the table
 -- only word 'vara' will be replaced as null
-select * from tbl_ext_fixedwidth where col_empty is not null order by s1;
- s1     |     s2     |     s3     | col_empty | col_null 
+select * from tbl_ext_fixedwidth where col_empty is not null;
+ s1       |     s2     |     s3     | col_empty | col_null 
 ------------+------------+------------+-----------+----------
- cha    |            | texta      |           | null 
-  chb   |  varb      |  textb     |           | NULL 
-   chc  |   varc     |   textc    |           | Null 
-chd     |    vard    |    textd   |           | NULLL
- che    |     vare   |     texte  |           |      
-  chf   |      varf  |      textf |           | null 
- chg    |     varg   |     textg  |           | NULLa
-chh     |    varh    |    texth   |           | NULL_
-   chi  |   vari     |   texti    |           | null 
-  chj   |  varj      |  textj     |           | aNULL
+ cha      |            | texta      |           | null 
+  chb     |  varb      |  textb     |           | NULL 
+   chc    |   varc     |   textc    |           | Null 
+    chd   |    vard    |    textd   |           | NULLL
+     che  |     vare   |     texte  |           |      
+      chf |      varf  |      textf |           | null 
+     chg  |     varg   |     textg  |           | NULLa
+    chh   |    varh    |    texth   |           | NULL_
+   chi    |   vari     |   texti    |           | null 
+  chj     |  varj      |  textj     |           | aNULL
 (10 rows)
 
 select * from tbl_ext_fixedwidth where s2 is null and col_empty is not null;
@@ -71,17 +71,17 @@ select * from tbl_ext_fixedwidth where s2 is null and col_empty is not null;
 -- and field "col_empty" only contains blanks, 
 -- then an empty string will be loaded into the table
 -- only word 'NULL' will be replaced as null
-select * from tbl_ext_fixedwidth where col_empty is not null order by s1;
+select * from tbl_ext_fixedwidth where col_empty is not null;
      s1     |    s2     |     s3     | col_empty | col_null 
 ------------+-----------+------------+-----------+----------
  cha        | vara      | texta      |           | null
   chb       |  varb     |  textb     |           | 
    chc      |   varc    |   textc    |           | Null
-chd         |    vard   |    textd   |           | NULLL
- che        |     vare  |     texte  |           | 
-  chf       |      varf |      textf |           | null
- chg        |     varg  |     textg  |           | NULLa
-chh         |    varh   |    texth   |           | NULL_
+    chd     |    vard   |    textd   |           | NULLL
+     che    |     vare  |     texte  |           | 
+      chf   |      varf |      textf |           | null
+     chg    |     varg  |     textg  |           | NULLa
+    chh     |    varh   |    texth   |           | NULL_
    chi      |   vari    |   texti    |           | null
   chj       |  varj     |  textj     |           | aNULL
 (10 rows)


### PR DESCRIPTION
The default collation order on Mac doesn't appear to use Unicode collation (which ignores spaces on its first pass). For example:
```
Unicode Collation Order:
a
 a
  a
b
 b
  b

C Collation Order:
  a
  b
 a
 b
a
b
```
This causes failures for these tests; it's strange but not something we want to debug right now. Since we're not testing collation in these tests, remove the ORDER BY from these tests to let atmsort sort the contents of the SELECTs. Note that this requires us to fix the expected leading whitespace as well, since it affects atmsort order.