### PR TITLE
Print diffs generated in CCP TINC tests

### DIFF
--- a/concourse/scripts/run_tinc_test.sh
+++ b/concourse/scripts/run_tinc_test.sh
@@ -3,6 +3,16 @@
 TINC_TARGET="$@"
 TINC_DIR=/home/gpadmin/gpdb_src/src/test/tinc
 
+trap look4diffs ERR
+function look4diffs() {
+	find "\${TINC_DIR}" -name *.diff -exec cat {} \; >> "\${TINC_DIR}/regression.diffs"
+	echo "=================================================================="
+	echo "The differences that caused some tests to fail can also be viewed in the file saved at \${TINC_DIR}/regression.diffs."
+	echo "=================================================================="
+	cat "\${TINC_DIR}/regression.diffs"
+	exit 1
+}
+
 cat > ~/gpdb-env.sh << EOF
   source /usr/local/greenplum-db-devel/greenplum_path.sh
   export PGPORT=5432


### PR DESCRIPTION
If the test fails, we will search for diff files in the TINC directory
and print them all out. This will allow us to see the diff file
contents from the Concourse job UI. The trap function is copied from
the run_tinc_test.sh native Concourse TINC test script.