### PR TITLE
Fixes order when splitting nested partitions

### DIFF
--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -5712,6 +5712,16 @@ NOTICE:  exchanged partition "sp2" of partition "p1" of relation "mpp10223b" wit
 NOTICE:  dropped partition "sp2" for partition "p1" of relation "mpp10223b"
 NOTICE:  CREATE TABLE will create partition "mpp10223b_1_prt_p1_2_prt_sp2" for table "mpp10223b_1_prt_p1"
 NOTICE:  CREATE TABLE will create partition "mpp10223b_1_prt_p1_2_prt_sp3" for table "mpp10223b_1_prt_p1"
+ select partitiontablename,partitionposition,partitionrangestart,
+        partitionrangeend from pg_partitions where tablename = 'mpp10223b'
+            order by partitionposition;
+       partitiontablename      | partitionposition | partitionrangestart | partitionrangeend 
+ ------------------------------+-------------------+---------------------+-------------------
+  mpp10223b_1_prt_p1           |                 1 | 1                   | 10
+  mpp10223b_1_prt_p1_2_prt_sp2 |                 1 | 20                  | 25
+  mpp10223b_1_prt_p1_2_prt_sp3 |                 2 | 25                  | 30
+ (3 rows)
+ 
 select pg_get_partition_def('mpp10223b'::regclass,true);
                    pg_get_partition_def                   
 ----------------------------------------------------------
@@ -5720,8 +5730,8 @@ select pg_get_partition_def('mpp10223b'::regclass,true);
            (                                              
            PARTITION p1 START (1) END (10)                
                    (                                      
-                   SUBPARTITION sp3 START (25) END (30),  
-                   SUBPARTITION sp2 START (20) END (25)   
+                   SUBPARTITION sp2 START (20) END (25),   
+                   SUBPARTITION sp3 START (25) END (30)  
                    )                                      
            )
 (1 row)

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -5711,6 +5711,16 @@ NOTICE:  exchanged partition "sp2" of partition "p1" of relation "mpp10223b" wit
 NOTICE:  dropped partition "sp2" for partition "p1" of relation "mpp10223b"
 NOTICE:  CREATE TABLE will create partition "mpp10223b_1_prt_p1_2_prt_sp2" for table "mpp10223b_1_prt_p1"
 NOTICE:  CREATE TABLE will create partition "mpp10223b_1_prt_p1_2_prt_sp3" for table "mpp10223b_1_prt_p1"
+ select partitiontablename,partitionposition,partitionrangestart,
+        partitionrangeend from pg_partitions where tablename = 'mpp10223b'
+            order by partitionposition;
+       partitiontablename      | partitionposition | partitionrangestart | partitionrangeend 
+ ------------------------------+-------------------+---------------------+-------------------
+  mpp10223b_1_prt_p1           |                 1 | 1                   | 10
+  mpp10223b_1_prt_p1_2_prt_sp2 |                 1 | 20                  | 25
+  mpp10223b_1_prt_p1_2_prt_sp3 |                 2 | 25                  | 30
+ (3 rows)
+
 select pg_get_partition_def('mpp10223b'::regclass,true);
                    pg_get_partition_def                   
 ----------------------------------------------------------
@@ -5719,8 +5729,8 @@ select pg_get_partition_def('mpp10223b'::regclass,true);
            (                                              
            PARTITION p1 START (1) END (10)                
                    (                                      
-                   SUBPARTITION sp3 START (25) END (30),  
-                   SUBPARTITION sp2 START (20) END (25)   
+                   SUBPARTITION sp2 START (20) END (25),   
+                   SUBPARTITION sp3 START (25) END (30)  
                    )                                      
            )
 (1 row)

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -2583,6 +2583,10 @@ alter table mpp10223b alter partition p1
 split partition for (rank(1) ) at (25)
 into (partition sp2, partition sp3);
 
+select partitiontablename,partitionposition,partitionrangestart,
+       partitionrangeend from pg_partitions where tablename = 'mpp10223b'
+           order by partitionposition;
+
 select pg_get_partition_def('mpp10223b'::regclass,true);
 
 drop table mpp10223b;


### PR DESCRIPTION
Running ALTER TABLE PARTITION SPLIT on range subpartitions results in both new
partitions to incorrectly have the same partition order value (parruleord in
pg_partition_rule). ALTER TABLE PARTITION SPLIT is accomplished by running
multiple DDLs in sequence:

  1. CREATE TEMP TABLE to match the data type/orientation of the partition we are
     splitting

  2. ALTER TABLE PARTITION EXCHANGE the partition with the new temporary table.
     The temporary table now contains the partition data, and the partition
     table is now empty.

  3. ALTER TABLE DROP PARTITION on the exchanged partition (the new empty table)

  3a. Drop the partitioning rule on the empty partition

  3b. DROP TABLE on the empty partition

At this point (in the old behavior) we remove the partition rule from the in
memory copy of the partition metadata. We need to remove it from the context
here or ADD PARTITION will believe that a partition for the split range already
exists, and will fail to create a new partition.

Now, create two new partitions in the place of the old one. For each partition:

  4a. CREATE TABLE for the new range

  4b. ADD PARTITION - Search for a hole in the partition order to place the
      partition. Open up a hole in the parruleord if needed.

When adding a subpartition, ADD PARTITION relies on the partition scheme passed
to it in order to find any holes in the partition range. Previously, the
metadata was not refreshed when adding the second partition, and this resulted
in the ADD PARTITION command creating both tables with the same partition rule
order (parruleord). This commit resolves the issue by refreshing the partition
metadata (PgPartRule) passed to the CREATE TABLE/ADD PARTITION commands upon
each iteration.