### PR TITLE
resgroup: adjust cgroup mount list for centos6 pipeline.

### DIFF
--- a/concourse/scripts/ic_gpdb_resgroup.bash
+++ b/concourse/scripts/ic_gpdb_resgroup.bash
@@ -21,7 +21,7 @@ mount_cgroups() {
     local gpdb_host_alias=$1
     local basedir=/cgroup
     local options=rw,nosuid,nodev,noexec,relatime
-    local groups="hugetlb freezer pids devices cpuset blkio net_prio net_cls cpuacct cpu memory perf_event"
+    local groups="freezer devices cpuset blkio net_prio net_cls cpuacct cpu memory perf_event"
 
     if [ "$TEST_OS" = "centos7" ]; then return; fi
 


### PR DESCRIPTION
The cgroup controllers `hugetlb` and `pids` are not supported on centos6
pipeline, do not mount them.