### PR TITLE
 Fix cases which are unpredictable

### DIFF
--- a/contrib/formatter_fixedwidth/input/readable_query26.source
+++ b/contrib/formatter_fixedwidth/input/readable_query26.source
@@ -17,4 +17,4 @@ LOG ERRORS
 SEGMENT REJECT LIMIT 10 PERCENT;
 
 select count(*) from tbl_ext_fixedwidth;
-select count(*) from gp_read_error_log('tbl_ext_fixedwidth');
+select count(*) > 44 from gp_read_error_log('tbl_ext_fixedwidth');

--- a/contrib/formatter_fixedwidth/output/readable_query26.source
+++ b/contrib/formatter_fixedwidth/output/readable_query26.source
@@ -22,9 +22,9 @@ SEGMENT REJECT LIMIT 10 PERCENT;
 select count(*) from tbl_ext_fixedwidth;
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: invalid input syntax for integer: "s32"  (seg1 slice1 rh55-qavm55:7533 pid=29678)
 DETAIL:  External table tbl_ext_fixedwidth
-select count(*) from gp_read_error_log('tbl_ext_fixedwidth');
- count 
--------
-90
+select count(*) > 44 from gp_read_error_log('tbl_ext_fixedwidth');
+ ?column? 
+----------
+ t
 (1 row)
 

--- a/src/test/regress/expected/.gitignore
+++ b/src/test/regress/expected/.gitignore
@@ -31,3 +31,4 @@ table_functions_optimizer.out
 tablespace.out
 transient_types.out
 workfile_mgr_test.out
+trigger_sets_oid.out

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -98,4 +98,8 @@ s/Table "pg_temp_\d+.temp/Table "pg_temp_#####/
 # Mask out oid in error concurrent drop message
 m/\d+ was concurrently dropped/
 s/\d+ was concurrently dropped/##### was concurrently dropped/
+
+# Segment number is not predictable
+m/ERROR:  There are more external files \(URLs\) than primary segments that can read them.*/
+s/ERROR:  There are more external files \(URLs\) than primary segments that can read them.*/ERROR:  There are more external files (URLs) than primary segments that can read them./
 -- end_matchsubs

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -466,9 +466,7 @@ WHERE e1.i = e2.i ORDER BY e1.i
 )
 SELECT * FROM cte1 ORDER BY cte1.i;
 select count(*) from gp_read_error_log('exttab_cte_2');
-select count(*) from gp_read_error_log('exttab_cte_1');
 -- start_ignore
-select gp_read_error_log('exttab_cte_1');
 select gp_read_error_log('exttab_cte_2');
 -- end_ignore
 

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -53,6 +53,45 @@ DROP EXTERNAL TABLE EXT_REGION;
 -- --------------------------------------
 -- check platform
 -- --------------------------------------
+DROP TABLE IF EXISTS REG_REGION;
+DROP TABLE IF EXISTS tableless_heap;
+DROP TABLE IF EXISTS errlog_save;
+DROP TABLE IF EXISTS exttab_insert_1;
+DROP TABLE IF EXISTS exttab_ctas_1;
+DROP TABLE IF EXISTS exttab_constraints_insert_1;
+
+DROP EXTERNAL TABLE IF EXISTS tableless_ext;
+DROP EXTERNAL TABLE IF EXISTS ret_too_many_uris;
+DROP EXTERNAL TABLE IF EXISTS wet_too_many_uris;
+DROP EXTERNAL TABLE IF EXISTS exttab_basic_1;
+DROP EXTERNAL TABLE IF EXISTS exttab_basic_2;
+DROP EXTERNAL TABLE IF EXISTS exttab_basic_3;
+DROP EXTERNAL TABLE IF EXISTS exttab_basic_4;
+DROP EXTERNAL TABLE IF EXISTS exttab_basic_5;
+DROP EXTERNAL TABLE IF EXISTS exttab_basic_6;
+DROP EXTERNAL TABLE IF EXISTS exttab_basic_7;
+DROP EXTERNAL TABLE IF EXISTS exttab_constraints_1;
+DROP EXTERNAL TABLE IF EXISTS exttab_cte_1;
+DROP EXTERNAL TABLE IF EXISTS exttab_cte_2;
+DROP EXTERNAL TABLE IF EXISTS exttab_cursor_1;
+DROP EXTERNAL TABLE IF EXISTS exttab_cursor_2;
+DROP EXTERNAL TABLE IF EXISTS exttab_permissions_1;
+DROP EXTERNAL TABLE IF EXISTS exttab_permissions_2;
+DROP EXTERNAL TABLE IF EXISTS exttab_permissions_3;
+DROP EXTERNAL TABLE IF EXISTS exttab_subq_1;
+DROP EXTERNAL TABLE IF EXISTS exttab_subq_2;
+DROP EXTERNAL TABLE IF EXISTS exttab_subtxs_1;
+DROP EXTERNAL TABLE IF EXISTS exttab_subtxs_2;
+DROP EXTERNAL TABLE IF EXISTS exttab_txs_1;
+DROP EXTERNAL TABLE IF EXISTS exttab_txs_2;
+DROP EXTERNAL TABLE IF EXISTS exttab_udfs_1;
+DROP EXTERNAL TABLE IF EXISTS exttab_udfs_2;
+DROP EXTERNAL TABLE IF EXISTS exttab_views_3;
+
+DROP VIEW IF EXISTS exttab_views_3;
+
+DROP PROTOCOL IF EXISTS demoprot_untrusted;
+
 drop external web table if exists check_ps;
 CREATE EXTERNAL WEB TABLE check_ps (x text)
 execute E'( (ps -ef || ps -aux) | grep gpfdist | grep -v grep)'

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -522,7 +522,7 @@ create external table ret_too_many_uris(a text, b text) location(
   'gpfdist://foo.invalid:7070/ret.tbl19', 'gpfdist://foo.invalid:7070/ret.tbl20'
 ) format 'text';
 select * from ret_too_many_uris;
-ERROR:  There are more external files (URLs) than primary segments that can read them. Found 20 URLs and 3 primary segments.
+ERROR:  There are more external files (URLs) than primary segments that can read them.
 create writable external table wet_too_many_uris(a text, b text) location(
   'gpfdist://foo.invalid:7070/wet.out1',  'gpfdist://foo.invalid:7070/wet.out2',
   'gpfdist://foo.invalid:7070/wet.out3',  'gpfdist://foo.invalid:7070/wet.out4',

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -802,12 +802,6 @@ select count(*) from gp_read_error_log('exttab_cte_2');
      1
 (1 row)
 
-select count(*) from gp_read_error_log('exttab_cte_1');
- count 
--------
-     2
-(1 row)
-
 -- CTE without segment reject limit exceeded
 select gp_truncate_error_log('exttab_cte_1');
  gp_truncate_error_log 

--- a/src/test/regress/sql/.gitignore
+++ b/src/test/regress/sql/.gitignore
@@ -35,3 +35,4 @@ session_level_memory_consumption.sql
 transient_types.sql
 hooktest.sql
 gpcopy.sql
+trigger_sets_oid.sql


### PR DESCRIPTION
> commit 3bbedbe
> Author: Heikki Linnakangas <hlinnakangas@pivotal.io>
> Date:   Thu Nov 2 10:04:58 2017 +0200
>
>     Wake up faster, if a segment returns an error.
>     Previously, if a segment reported an error after starting up the
>     interconnect, it would take up to 250 ms for the main thread in the QD
>     process to wake up and poll the dispatcher connections, and to see that
>     there was an error. Shorten that time, by waking up immediately if the
>     QD->QE libpq socket becomes readable while we're waiting for data to
>     arrive in a Motion node.
>     This isn't a complete solution, because this will only wake up if one
>     arbitrarily chosen connection becomes readable, and we still rely on
>     polling for the others. But this greatly speeds up many common scenarios.
>     In particular, the "qp_functions_in_select" test now runs in under 5 s
>     on my laptop, when it took about 60 seconds before.

> Before this commit, the master would only check every 250 ms if one of the
> segments had reported an error. Now it wakes up and cancels the whole query as
> soon as it receives an error from the first segment. That makes it more likely
> that the other segments have not yet reached the same number of errors as what
> is memorized in the expected output.

These two cases check:

1, when selecting from a cte fails, one of the external table of the cte
reached the error limit, how many errors happened in the other external
table of the cte, which would not reached the limit.

2, when selecting from an external table with two locations mapped to
two segments each, one segment reached the reject limit, the other also
reached the same.

We could not predict these two results without special test files, even
without that commit actually. This commit removes the cte case and
checks at least one segment failed in case readable_query26.