### PR TITLE
Make `copy_output()` compatible with older python versions

### DIFF
--- a/concourse/scripts/test_gpdb.py
+++ b/concourse/scripts/test_gpdb.py
@@ -8,7 +8,6 @@ import subprocess
 import sys
 
 from builds.GpBuild import GpBuild
-from subprocess import check_output
 
 def install_gpdb(dependency_name):
     status = subprocess.call("mkdir -p /usr/local/gpdb", shell=True)
@@ -27,13 +26,16 @@ def create_gpadmin_user():
 
 
 def copy_output():
-    diff_files = check_output("find gpdb_src/ -name regression.diffs", shell=True).splitlines()
-    for diff_file in diff_files:
-        print(  "======================================================================\n" +
-                "DIFF FILE: " + diff_file+"\n" +
-                "----------------------------------------------------------------------")
-        with open(diff_file, 'r') as fin:
-            print fin.read()
+    for dirpath, dirs, diff_files in os.walk('gpdb_src/'):
+        if 'regression.diffs' in diff_files:
+            diff_file = dirpath + '/' + 'regression.diffs'
+            print(  "======================================================================\n" +
+                    "DIFF FILE: " + diff_file+"\n" +
+                    "----------------------------------------------------------------------")
+            with open(diff_file, 'r') as fin:
+                print fin.read()
+    shutil.copyfile("gpdb_src/src/test/regress/regression.diffs", "icg_output/regression.diffs")
+    shutil.copyfile("gpdb_src/src/test/regress/regression.out", "icg_output/regression.out")
 
 def main():
     parser = optparse.OptionParser()


### PR DESCRIPTION
The commit 640fd9d added `check_output()` to find the files with name regression.diffs inorder to print them on the console in case of any failing tests. `check_output` is supported on python version 2.7 and onwards. But currently, in ORCA ci(https://ci.orca.pivotalci.info) the docker image used to build gpdb with ORCA is still on older python (version 2.6) and hence causing the ORCA ci job to fail with check_output import error.
This commit updates `copy_output()` to ensure backward compatibility for python. Also, we have a chore filed in our backlog to update the docker image used in ORCA ci to use python version same as that in gpdb.

Signed-off-by: Dhanashree Kashid <dkashid@pivotal.io>