### PR TITLE
Backport of gpfdist fix: gpload hang due to non-reentrant function invoked in single handler

### DIFF
--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -11,7 +11,6 @@
 #include <apr_file_info.h>
 #include <apr_hash.h>
 #include <apr_pools.h>
-#include <apr_signal.h>
 #include <apr_strings.h>
 #include <apr_time.h>
 #include <event.h>
@@ -191,6 +190,7 @@ static struct
 	int				listen_sock_count;
 	SOCKET 			listen_socks[6];
 	struct event 	listen_events[6];
+	struct event 	signal_event;
 	struct
 	{
 		int 		gen;
@@ -364,7 +364,7 @@ static int get_unsent_bytes(request_t* r);
 static void * palloc_safe(request_t *r, apr_pool_t *pool, apr_size_t size, const char *fmt, ...);
 static void * pcalloc_safe(request_t *r, apr_pool_t *pool, apr_size_t size, const char *fmt, ...);
 
-void process_signal(int sig);
+static void process_term_signal(int sig, short event, void* arg);
 int gpfdist_init(int argc, const char* const argv[]);
 int gpfdist_run(void);
 
@@ -2310,6 +2310,22 @@ print_addrinfo_list(struct addrinfo *head)
 	}
 }
 
+static void
+signal_register()
+{
+	/* when SIGTERM raised invoke process_term_signal */
+	signal_set(&gcb.signal_event, SIGTERM, process_term_signal, 0);
+
+	/* high priority so we accept as fast as possible */
+	if(event_priority_set(&gcb.signal_event, 0))
+		gwarning(NULL, "signal event priority set failed");
+
+	/* start watching this event */
+	if (signal_add(&gcb.signal_event, 0))
+		gfatal(NULL, "cannot set up event on signal register");
+
+}
+
 /* Create HTTP port and start to receive request */
 static void
 http_setup(void)
@@ -2517,8 +2533,8 @@ http_setup(void)
 		event_set(&gcb.listen_events[i], gcb.listen_socks[i], EV_READ | EV_PERSIST,
 				  do_accept, 0);
 
-		/* high priority so we accept as fast as possible */
-		if (event_priority_set(&gcb.listen_events[i], 0))
+		/* only signal process function priority higher than socket handler */
+		if (event_priority_set(&gcb.listen_events[i], 1))
 			gwarning(NULL, "event_priority_set failed");
 
 		/* start watching this event */
@@ -2529,22 +2545,19 @@ http_setup(void)
 }
 
 void
-process_signal(int sig)
+process_term_signal(int sig, short event, void* arg)
 {
-	if (sig == SIGINT || sig == SIGTERM)
-	{
-		gwarning(NULL, "signal %d received. gpfdist exits", sig);
-		log_gpfdist_status();
-		fflush(stdout);
+	gwarning(NULL, "signal %d received. gpfdist exits", sig);
+	log_gpfdist_status();
+	fflush(stdout);
 
-		int i;
-		for (i = 0; i < gcb.listen_sock_count; i++)
-			if (gcb.listen_socks[i] > 0)
-			{
-				closesocket(gcb.listen_socks[i]);
-			}
-		exit(1);
-	}
+	int i;
+	for (i = 0; i < gcb.listen_sock_count; i++)
+		if (gcb.listen_socks[i] > 0)
+		{
+			closesocket(gcb.listen_socks[i]);
+		}
+	exit(1);
 }
 
 
@@ -3493,7 +3506,7 @@ int gpfdist_init(int argc, const char* const argv[])
 	if (0 != apr_pool_create(&gcb.pool, 0))
 		gfatal(NULL, "apr_app_initialize failed");
 
-	apr_signal_init(gcb.pool);
+	// apr_signal_init(gcb.pool);
 
 	gcb.session.tab = apr_hash_make(gcb.pool);
 
@@ -3506,13 +3519,15 @@ int gpfdist_init(int argc, const char* const argv[])
 #endif
 	/*
 	 * apr_signal(SIGINT, process_signal);
+	 * apr_signal(SIGTERM, process_signal);
 	 */
-	apr_signal(SIGTERM, process_signal);
 	if (opt.V)
 		putenv("EVENT_SHOW_METHOD=1");
 	putenv("EVENT_NOKQUEUE=1");
 
 	event_init();
+
+	signal_register();
 	http_setup();
 
 #ifdef USE_SSL

--- a/src/bin/gpfdist/stress/README
+++ b/src/bin/gpfdist/stress/README
@@ -1,0 +1,10 @@
+This stress test contain two bash files which are "query.bash" and "stress.bash".
+The scripts depend on mockd process(https://github.com/pivotal/mock-data) to generate some fake data.
+After mockd compilation and please fill the path into "stress.bash" MOCKD_PATH variable.
+
+"query.bash" is an infinity loop to query data from external table in the test database.
+Running this script after "stress.bash" start. It sleeps 2-7 seconds then send SIGTERM
+signal to gpfdist. If gpfdist exit successfully, it will restart gpfdist again and do this previous
+task again until gpfdist hang.
+
+gpfdist does not hang through three hours test.

--- a/src/bin/gpfdist/stress/query.bash
+++ b/src/bin/gpfdist/stress/query.bash
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+DBNAME="stressdb"
+EX_RT1="r1"
+EX_RT2="r2"
+EX_RT3="r3"
+function run_query() {
+  while :
+  do
+      psql -c "select * from $EX_RT1;" $DBNAME &> /dev/null
+      psql -c "select * from $EX_RT2;" $DBNAME &> /dev/null
+      psql -c "select * from $EX_RT3;" $DBNAME &> /dev/null
+      echo "------- query once -------"
+  done
+}
+
+run_query

--- a/src/bin/gpfdist/stress/stress.bash
+++ b/src/bin/gpfdist/stress/stress.bash
@@ -1,0 +1,110 @@
+#!/bin/bash
+DBNAME="stressdb"
+MOCKD_PATH="/mount/mockd-linux"
+
+TABLE_1="l1"
+EX_RT1="r1"
+EX_WT1="w1"
+STRUCTURE_1="(ID_INT int,NAME varchar(255),City varchar(255))"
+PRI_KEY1="DISTRIBUTED BY (ID_INT)"
+FILE_1="1.txt"
+ROW1=100
+
+TABLE_2="l2"
+EX_RT2="r2"
+EX_WT2="w2"
+STRUCTURE_2="(ID_INT int,NAME varchar(255),City varchar(255))"
+PRI_KEY2="DISTRIBUTED BY (ID_INT)"
+FILE_2="2.txt"
+ROW2=100000
+
+TABLE_3="l3"
+EX_RT3="r3"
+EX_WT3="w3"
+STRUCTURE_3="(ID_INT int,NAME varchar(255),City varchar(255))"
+PRI_KEY3="DISTRIBUTED BY (ID_INT)"
+FILE_3="3.txt"
+ROW3=1000000
+
+function create_database() {
+    if psql -lqt | cut -d\| -f 1 | grep -qw $DBNAME; then
+        echo "Has database named as stressdb, drop db first"
+        dropdb $DBNAME
+    fi
+
+    createdb $DBNAME
+
+    psql -c "create table $TABLE_1 $STRUCTURE_1 $PRI_KEY1;" $DBNAME
+    psql -c "create table $TABLE_2 $STRUCTURE_2 $PRI_KEY2;" $DBNAME
+    psql -c "create table $TABLE_3 $STRUCTURE_3 $PRI_KEY3;" $DBNAME
+
+    $MOCKD_PATH greenplum -u gpadmin -d $DBNAME -n $ROW1 -t $TABLE_1 -p $PGPORT
+    $MOCKD_PATH greenplum -u gpadmin -d $DBNAME -n $ROW2 -t $TABLE_2 -p $PGPORT
+    $MOCKD_PATH greenplum -u gpadmin -d $DBNAME -n $ROW3 -t $TABLE_3 -p $PGPORT
+
+    touch ./$FILE_1
+    psql -c "create external table $EX_RT1 $STRUCTURE_1 location ('gpfdist://127.0.0.1:8080/$FILE_1') format 'text';" $DBNAME
+    psql -c "create writable external table $EX_WT1 $STRUCTURE_1 location ('gpfdist://127.0.0.1:8080/$FILE_1') format 'text';" $DBNAME
+
+    touch ./$FILE_2
+    psql -c "create external table $EX_RT2 $STRUCTURE_2 location ('gpfdist://127.0.0.1:8080/$FILE_2') format 'text';" $DBNAME
+    psql -c "create writable external table $EX_WT2 $STRUCTURE_2 location ('gpfdist://127.0.0.1:8080/$FILE_2') format 'text';" $DBNAME
+
+    touch ./$FILE_3
+    psql -c "create external table $EX_RT3 $STRUCTURE_3 location ('gpfdist://127.0.0.1:8080/$FILE_3') format 'text';" $DBNAME
+    psql -c "create writable external table $EX_WT3 $STRUCTURE_3 location ('gpfdist://127.0.0.1:8080/$FILE_3') format 'text';" $DBNAME
+}
+
+fdist_Pid=
+function data_translation() {
+  run_gpfdist
+
+  psql -c "insert into $EX_WT1 select * from $TABLE_1;" $DBNAME
+  psql -c "insert into $EX_WT2 select * from $TABLE_2;" $DBNAME
+  psql -c "insert into $EX_WT3 select * from $TABLE_3;" $DBNAME
+
+  kill -15 $fdist_Pid
+}
+
+ret_value=0
+function kill_and_check_gpfdist() {
+  local sleep_sec=$(((RANDOM % 6) + 2))
+  echo "$fdist_Pid will be killed after $sleep_sec sec"
+  sleep $sleep_sec
+  kill -15 $fdist_Pid
+  sleep 1
+  wait > /dev/null
+
+  local result=`ps -a | sed -n /${fdist_Pid}/p`
+
+  if [ "${result:-null}" == null ]; then
+      ret_value=0
+  else
+      echo "ERROR: gpfdist seem to be hang"
+      ret_value=1
+  fi
+
+}
+
+function run_gpfdist() {
+  gpfdist >> /dev/null &
+  fdist_Pid=$!
+}
+
+
+function _main() {
+  pkill gpfdist
+  create_database
+  data_translation
+
+  while [ $ret_value -ne 1 ]
+  do
+      run_gpfdist
+      kill_and_check_gpfdist
+  done
+
+  echo "gpfdist does not exit after kill -15 send"
+  dropdb $DBNAME
+}
+
+_main


### PR DESCRIPTION
This is a backport of https://github.com/greenplum-db/gpdb/pull/3247, which includes the following commits by @weinan003:
* https://github.com/greenplum-db/gpdb/commit/bdc93fdaba873b759746ea5bd88e56c4c7954204
* https://github.com/greenplum-db/gpdb/commit/4ffbf5582d8c91192fbca6a96131c3e4ec6e5aa8
* https://github.com/greenplum-db/gpdb/commit/0f1da53e746c61186beb65a0ca625efc39016f1c

The issue is https://github.com/greenplum-db/gpdb/issues/3768.

Instead of using `libapr`, we register term signal in `libevent`, so that the signal handler
in the asynchronous model to avoid function non-reentrant problem.