### PR TITLE
Support interruption of optimization in ORCA

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("2.50.", GPORCA_VERSION_STRING, 5);
+return strncmp("2.51.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 2.50.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 2.51.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -12882,7 +12882,7 @@ int
 main ()
 {
 
-return strncmp("2.50.", GPORCA_VERSION_STRING, 5);
+return strncmp("2.51.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -12892,7 +12892,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 2.50.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 2.51.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v2.50.4@gpdb/stable
+orca/v2.51.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -121,7 +121,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	@echo "Resolve finished";
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget -O - https://github.com/greenplum-db/gporca/releases/download/v2.50.4/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget -O - https://github.com/greenplum-db/gporca/releases/download/v2.51.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/backend/gpopt/CGPOptimizer.cpp
+++ b/src/backend/gpopt/CGPOptimizer.cpp
@@ -157,6 +157,29 @@ CGPOptimizer::TerminateGPOPT ()
   gpos_terminate();
 }
 
+// Signal handler for ORCA
+void
+CGPOptimizer::SignalInterruptGPOPT
+	(
+	int iSignal
+	)
+{
+	if (SIGINT == iSignal || SIGTERM == iSignal)
+	{
+		CWorker::abort_requested = true;
+	}
+	// Other signal handlers shouldn't call this method since some other action
+	// than optimization interruption is required in those cases.
+}
+
+// Reset optimizer state to before SignalInterruptGPOPT() was called.
+// To be called after interrupts have been handled by ORCA.
+void
+CGPOptimizer::ResetInterruptsGPOPT (void)
+{
+	CWorker::abort_requested = false;
+}
+
 //---------------------------------------------------------------------------
 //	@function:
 //		PplstmtOptimize
@@ -226,6 +249,25 @@ void TerminateGPOPT ()
 {
 	return CGPOptimizer::TerminateGPOPT();
 }
+}
+
+// Signal handler for ORCA
+extern "C"
+{
+void SignalInterruptGPOPT (int signal)
+{
+	CGPOptimizer::SignalInterruptGPOPT(signal);
+}
+}
+
+// Reset optimizer state to before SignalInterruptGPOPT() was called.
+// To be called after interrupts have been handled by ORCA.
+extern "C"
+{
+	void ResetInterruptsGPOPT ()
+	{
+		CGPOptimizer::ResetInterruptsGPOPT();
+	}
 }
 
 // EOF

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -105,6 +105,10 @@ CTranslatorRelcacheToDXL::Pimdobj
 	IMDCacheObject *pmdcacheobj = NULL;
 	GPOS_ASSERT(NULL != pmda);
 
+#ifdef FAULT_INJECTOR
+	gpdb::OptTasksFaultInjector(OptRelcacheTranslatorCatalogAccess);
+#endif // FAULT_INJECTOR
+
 	switch(pmdid->Emdidt())
 	{
 		case IMDId::EmdidGPDB:
@@ -1101,9 +1105,6 @@ CTranslatorRelcacheToDXL::Pmdindex
 		{
 			oidRel = gpdb::OidRootPartition(oidRel);
 		}
-#ifdef FAULT_INJECTOR
-		gpdb::OptTasksFaultInjector(OptRelcacheTranslatorCatalogAccess);
-#endif // FAULT_INJECTOR
 
 		CMDIdGPDB *pmdidRel = GPOS_NEW(pmp) CMDIdGPDB(oidRel);
 

--- a/src/backend/optimizer/plan/orca.c
+++ b/src/backend/optimizer/plan/orca.c
@@ -136,6 +136,8 @@ optimize_query(Query *parse, ParamListInfo boundParams)
 
 	log_optimizer(result, fUnexpectedFailure);
 
+	CHECK_FOR_INTERRUPTS();
+
 	/*
 	 * If ORCA didn't produce a plan, bail out and fall back to the Postgres
 	 * planner.

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -106,6 +106,11 @@
 #include "utils/session_state.h"
 #include "utils/vmem_tracker.h"
 
+#ifdef USE_ORCA
+extern void SignalInterruptGPOPT(int signal);
+extern void ResetInterruptsGPOPT(void);
+#endif
+
 extern int	optind;
 extern char *optarg;
 
@@ -3512,6 +3517,13 @@ StatementCancelHandler(SIGNAL_ARGS)
 		QueryCancelPending = true;
 		QueryCancelCleanup = true;
 
+#ifdef USE_ORCA
+		if (Gp_role == GP_ROLE_DISPATCH)
+		{
+			SignalInterruptGPOPT(postgres_signal_arg);
+		}
+#endif
+
 		/*
 		 * If it's safe to interrupt, and we're waiting for a lock, service
 		 * the interrupt immediately.  No point in interrupting if we're
@@ -3643,6 +3655,13 @@ ProcessInterrupts(const char* filename, int lineno)
 		gp_simex_run = 0;
 	}
 #endif   /* USE_TEST_UTILS */
+
+#ifdef USE_ORCA
+	if (Gp_role == GP_ROLE_DISPATCH)
+	{
+		ResetInterruptsGPOPT();
+	}
+#endif
 
 	InterruptPending = false;
 	if (ProcDiePending)

--- a/src/include/gpopt/CGPOptimizer.h
+++ b/src/include/gpopt/CGPOptimizer.h
@@ -42,6 +42,16 @@ class CGPOptimizer
 
     static
     void TerminateGPOPT();
+
+    // Signal handler for ORCA
+    static
+    void SignalInterruptGPOPT(int iSignal);
+
+    // Reset optimizer state to before SignalInterruptGPOPT() was called.
+    // To be called after interrupts have been handled by ORCA.
+    static
+    void ResetInterruptsGPOPT();
+
 };
 
 #endif // CGPOptimizer_H

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -1944,6 +1944,28 @@ select sum(a) from orca.r group by b having count(*) > 2 order by b+1;
   57
 (6 rows)
 
+-- test interruption requests to optimization
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+select gp_inject_fault('opt_relcache_translator_catalog_access', 'reset', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+select gp_inject_fault('opt_relcache_translator_catalog_access', 'interrupt', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+select count(*) from orca.s;
+ count 
+-------
+    30
+(1 row)
+
 -- constants
 select 0.001::numeric from orca.r;
  numeric 

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -1945,6 +1945,26 @@ select sum(a) from orca.r group by b having count(*) > 2 order by b+1;
   57
 (6 rows)
 
+-- test interruption requests to optimization
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+select gp_inject_fault('opt_relcache_translator_catalog_access', 'reset', 1);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+select gp_inject_fault('opt_relcache_translator_catalog_access', 'interrupt', 1);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+select count(*) from orca.s;
+ERROR:  canceling statement due to user request
 -- constants
 select 0.001::numeric from orca.r;
  numeric 

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -64,6 +64,12 @@ select b from orca.r group by b having  count(*) <= avg(a) + (select count(*) fr
 select sum(a) from orca.r group by b having count(*) > 2 order by b+1;
 select sum(a) from orca.r group by b having count(*) > 2 order by b+1;
 
+-- test interruption requests to optimization
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+select gp_inject_fault('opt_relcache_translator_catalog_access', 'reset', 1);
+select gp_inject_fault('opt_relcache_translator_catalog_access', 'interrupt', 1);
+select count(*) from orca.s;
+
 -- constants
 
 select 0.001::numeric from orca.r;

--- a/src/test/unit/mock/gpopt_mock.c
+++ b/src/test/unit/mock/gpopt_mock.c
@@ -57,3 +57,15 @@ TerminateGPOPT ()
 {
 	elog(ERROR, "mock implementation of TerminateGPOPT called");
 }
+
+void
+SignalInterruptGPOPT(int iSignal)
+{
+	elog(ERROR, "mock implementation of SignalInterruptGPOPT called");
+}
+
+void
+ResetInterruptsGPOPT()
+{
+	elog(ERROR, "mock implementation of ResetInterruptsGPOPT called");
+}


### PR DESCRIPTION
To support it, this commit adds 2 new APIs to ORCA:
- SignalInterruptGPOPT(), which notifies the optimizer that abort is
  requested (it must be called from the signal handler)
- ResetInterruptsGPOPT(), which resets ORCA's state on the QD to before
  interruption, so that the next query is run normally.

Also check for interrupts right after ORCA returns.

```
create table f1(a int, b int, c int, d int, e int, f int, g int, h int);
create table f2(a int, b int, c int, d int, e int, f int, g int, h int);
create table f3(a int, b int, c int, d int, e int, f int, g int, h int);
create table f4(a int, b int, c int, d int, e int, f int, g int, h int);
create table f5(a int, b int, c int, d int, e int, f int, g int, h int);
create table f6(a int, b int, c int, d int, e int, f int, g int, h int);

shardikar=# explain select * from f1, f2, f3, f4, f5, f6 where f1.b = f2.b AND f2.b = f3.b AND f3.b = f4.b AND f4.b = f5.b AND f5.b = f6.b AND f1.c = f2.c;
^CCancel request sent
ERROR:  canceling statement due to user request
```

See corresponding changes in GPORCA : https://github.com/greenplum-db/gporca/pull/258

DONE: Update ORCA major version. 
DONE: Add test.