### PR TITLE
docs - memory implications when RGs active and failover occurs

### DIFF
--- a/gpdb-doc/dita/admin_guide/wlmgmt_intro.xml
+++ b/gpdb-doc/dita/admin_guide/wlmgmt_intro.xml
@@ -112,7 +112,7 @@
           fail. Use the following formula to calculate a safe value for
           <varname>gp_vmem_protect_limit</varname>; provide the <codeph>gp_vmem_rq</codeph>
           value you calculated earlier.</p><p><codeblock>
-gp_vmem_protect_limit = gp_vmem / max_acting_primary_segments</codeblock></p>
+gp_vmem_protect_limit = gp_vmem_rq / max_acting_primary_segments</codeblock></p>
           <p>where <codeph>max_acting_primary_segments</codeph> is the maximum number of
           primary segments that could be running on a host when mirror segments are activated
           due to a host or segment failure.</p>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -4967,6 +4967,25 @@
           </tbody>
         </tgroup>
       </table>
+      <note>When resource group-based resource management is active, the memory allotted to
+        a segment host is equally shared by active primary segments. Greenplum Database assigns
+        memory to primary segments when the segment takes the primary role. The initial memory
+        allotment to a primary segment does not change, even in a failover situation. This may
+        result in a segment host utilizing more memory than the
+        <codeph>gp_resource_group_memory_limit</codeph> setting permits.
+        <p>For example, suppose your Greenplum Database cluster is utilizing the default
+          <codeph>gp_resource_group_memory_limit</codeph> of <codeph>0.7</codeph> and a
+          segment host named <codeph>seghost1</codeph> has 4 primary segments and 4 mirror
+          segments. Greenplum Database assigns each primary segment on <codeph>seghost1</codeph>
+          <codeph>(0.7 / 4 = 0.175%)</codeph> of overall system memory. If failover occurs and
+          two mirrors on <codeph>seghost1</codeph> fail over to become primary segments,
+          each of the original 4 primaries retain their memory allotment of <codeph>0.175</codeph>,
+          and the two new primary segments are each allotted <codeph>(0.7 / 6 = 0.116%)</codeph>
+          of system memory. <codeph>seghost1</codeph>'s overall memory allocation
+          in this scenario is</p><p><codeblock>
+0.7 + (0.116 * 2) = 0.932%</codeblock></p>
+        <p>which is above the percentage configured
+          in the <codeph>gp_resource_group_memory_limit</codeph> setting.</p></note>
     </body>
   </topic>
   <topic id="gp_resource_manager">


### PR DESCRIPTION
- add note to gp_resource_group_memory_limit identifying the memory implications of failover.
- fix formula (unrelated)

@gaos1 @dyozie - this note is on the GUC reference page.  is this the appropriate location?  should i include the note elsewhere in the docs also or instead?   (i.e. add a "Failover considerations" section on the using page)

thanks.