### PR TITLE
resgroup: move UnassignResGroup into AtEOXact_ResGroup

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -2740,7 +2740,10 @@ CommitTransaction(void)
 	/* All relations that are in the vacuum process are being commited now. */
 	ResetVacuumRels();
 
-	/* Process resource group related callbacks */
+	/*
+	 * Process resource group commit processing,
+	 * It must be called after prepareDtxTransaction()
+	 */
 	AtEOXact_ResGroup(true);
 
 	/* Check we've released all buffer pins */
@@ -2837,10 +2840,6 @@ CommitTransaction(void)
 	RESUME_INTERRUPTS();
 
 	freeGangsForPortal(NULL);
-
-	/* Release resource group slot at the end of a transaction */
-	if (ShouldUnassignResGroup())
-		UnassignResGroup();
 }
 
 
@@ -2890,6 +2889,9 @@ PrepareTransaction(void)
 		if (!PrepareHoldablePortals())
 			break;
 	}
+
+	/* detach from current resouce group */
+	AtPrepare_ResGroup();
 
 	/* Now we can shut down the deferred-trigger manager */
 	AfterTriggerEndXact(true);
@@ -3045,9 +3047,6 @@ PrepareTransaction(void)
 	ResourceOwnerRelease(TopTransactionResourceOwner,
 						 RESOURCE_RELEASE_BEFORE_LOCKS,
 						 true, true);
-
-	/* Process resource group related callbacks */
-	AtEOXact_ResGroup(true);
 
 	/* Check we've released all buffer pins */
 	AtEOXact_Buffers(true);
@@ -3214,6 +3213,9 @@ AbortTransaction(void)
 	if (Gp_role == GP_ROLE_DISPATCH && IsResQueueEnabled())
 		AtAbort_ResScheduler();
 		
+	/* Perform any Resource Group abort processing. */
+	AtEOXact_ResGroup(false);
+
 	/* Perform any AO table abort processing */
 	AtAbort_AppendOnly();
 
@@ -3273,7 +3275,6 @@ AbortTransaction(void)
 		ResourceOwnerRelease(TopTransactionResourceOwner,
 							 RESOURCE_RELEASE_BEFORE_LOCKS,
 							 false, true);
-		AtEOXact_ResGroup(false);
 		AtEOXact_Buffers(false);
 		AtEOXact_RelationCache(false);
 		AtEOXact_Inval(false);
@@ -3393,10 +3394,6 @@ CleanupTransaction(void)
 	s->state = TRANS_DEFAULT;
 
 	finishDistributedTransactionContext("CleanupTransaction", true);
-
-	/* Release resource group slot at the end of a transaction */
-	if (ShouldUnassignResGroup())
-		UnassignResGroup();
 }
 
 /*

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -109,7 +109,7 @@ static void registerResourceGroupCallback(ResourceGroupCallback callback, void *
  * Note the callback functions would be removed as being processed.
  */
 void
-AtEOXact_ResGroup(bool isCommit)
+HandleResGroupDDLCallbacks(bool isCommit)
 {
 	if (ResourceGroup_callback.callback == NULL)
 		return;

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -403,6 +403,24 @@ AllocResGroupEntry(Oid groupId, const ResGroupCaps *caps)
 	LWLockRelease(ResGroupLock);
 }
 
+void
+AtEOXact_ResGroup(bool isCommit)
+{
+	HandleResGroupDDLCallbacks(isCommit);
+
+	/* Release resource group slot at the end of a transaction */
+	if (ShouldUnassignResGroup())
+		UnassignResGroup();
+}
+
+void
+AtPrepare_ResGroup(void)
+{
+	/* Release resource group slot */
+	if (ShouldUnassignResGroup())
+		UnassignResGroup();
+}
+
 /*
  * Load the resource groups in shared memory. Note this
  * can only be done after enough setup has been done. This uses

--- a/src/include/commands/resgroupcmds.h
+++ b/src/include/commands/resgroupcmds.h
@@ -30,5 +30,6 @@ extern void GetResGroupCapabilities(Relation rel,
 									Oid groupId,
 									ResGroupCaps *resgroupCaps);
 extern void AtEOXact_ResGroup(bool isCommit);
+extern void HandleResGroupDDLCallbacks(bool isCommit);
 
 #endif   /* RESGROUPCMDS_H */

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -95,6 +95,8 @@ typedef enum
 /*
  * Functions in resgroup.c
  */
+extern void AtEOXact_ResGroup(bool isCommit);
+extern void AtPrepare_ResGroup(void);
 
 /* Shared memory and semaphores */
 extern Size ResGroupShmemSize(void);

--- a/src/test/isolation2/input/resgroup/resgroup_alter_memory.source
+++ b/src/test/isolation2/input/resgroup/resgroup_alter_memory.source
@@ -495,3 +495,48 @@ DROP ROLE role1_memory_test;
 DROP ROLE role2_memory_test;
 DROP RESOURCE GROUP rg1_memory_test;
 DROP RESOURCE GROUP rg2_memory_test;
+
+--
+-- Test PrepareTransaction report an error
+--
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=5, memory_limit=5);
+CREATE ROLE rg_test_role RESOURCE GROUP rg_test_group;
+
+SET debug_dtm_action = "fail_begin_command";
+SET debug_dtm_action_target = "protocol";
+SET debug_dtm_action_protocol = "prepare";
+SET debug_dtm_action_segment = 0;
+
+-- ALTER should fail and the memory_limit in both catalog and share memory are
+-- still 5%
+ALTER RESOURCE GROUP rg_test_group set memory_limit 1;
+
+RESET debug_dtm_action;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action_segment;
+
+-- should still be 5% on both QD and QE
+select memory_limit from gp_toolkit.gp_resgroup_config where groupname = 'rg_test_group';
+
+--
+-- Test error happen on commit_prepare, DDL success after retry
+--
+SET debug_dtm_action = "fail_begin_command";
+SET debug_dtm_action_target = "protocol";
+SET debug_dtm_action_protocol = "commit_prepared";
+SET debug_dtm_action_segment = 0;
+
+-- ALTER should success
+ALTER RESOURCE GROUP rg_test_group set memory_limit 4;
+
+RESET debug_dtm_action;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action_segment;
+
+-- should still be 4% on both QD and QE
+select memory_limit from gp_toolkit.gp_resgroup_config where groupname = 'rg_test_group';
+
+DROP ROLE rg_test_role;
+DROP RESOURCE GROUP rg_test_group;

--- a/src/test/isolation2/output/resgroup/resgroup_alter_memory.source
+++ b/src/test/isolation2/output/resgroup/resgroup_alter_memory.source
@@ -862,3 +862,78 @@ DROP RESOURCE GROUP rg1_memory_test;
 DROP
 DROP RESOURCE GROUP rg2_memory_test;
 DROP
+
+--
+-- Test PrepareTransaction report an error
+--
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=5, memory_limit=5);
+CREATE
+CREATE ROLE rg_test_role RESOURCE GROUP rg_test_group;
+CREATE
+
+SET debug_dtm_action = "fail_begin_command";
+SET
+SET debug_dtm_action_target = "protocol";
+SET
+SET debug_dtm_action_protocol = "prepare";
+SET
+SET debug_dtm_action_segment = 0;
+SET
+
+-- ALTER should fail and the memory_limit in both catalog and share memory are
+-- still 5%
+ALTER RESOURCE GROUP rg_test_group set memory_limit 1;
+ERROR:  The distributed transaction 'Prepare' broadcast failed to one or more segments for gid = 1509599543-0000000983. (cdbtm.c:698)
+
+RESET debug_dtm_action;
+RESET
+RESET debug_dtm_action_target;
+RESET
+RESET debug_dtm_action_protocol;
+RESET
+RESET debug_dtm_action_segment;
+RESET
+
+-- should still be 5% on both QD and QE
+select memory_limit from gp_toolkit.gp_resgroup_config where groupname = 'rg_test_group';
+memory_limit
+------------
+5           
+(1 row)
+
+--
+-- Test error happen on commit_prepare, DDL success after retry
+--
+SET debug_dtm_action = "fail_begin_command";
+SET
+SET debug_dtm_action_target = "protocol";
+SET
+SET debug_dtm_action_protocol = "commit_prepared";
+SET
+SET debug_dtm_action_segment = 0;
+SET
+
+-- ALTER should success
+ALTER RESOURCE GROUP rg_test_group set memory_limit 4;
+ALTER
+
+RESET debug_dtm_action;
+RESET
+RESET debug_dtm_action_target;
+RESET
+RESET debug_dtm_action_protocol;
+RESET
+RESET debug_dtm_action_segment;
+RESET
+
+-- should still be 4% on both QD and QE
+select memory_limit from gp_toolkit.gp_resgroup_config where groupname = 'rg_test_group';
+memory_limit
+------------
+4           
+(1 row)
+
+DROP ROLE rg_test_role;
+DROP
+DROP RESOURCE GROUP rg_test_group;
+DROP


### PR DESCRIPTION
Reopen this PR because the last one blocked the pipeline.

* Do UnassignResGroup within prepareTransaction too, prepareTransaction()
will put QE out of any transactions temporarily until the second commit
command arrives, so any failures in this gap will cause leaks of resource
group including slots etc.
* Clean code, move UnassignResGroup() into AtEOXact_ResGroup() so resource
group related codes will not spread across prepare/commit/abort functions.
* Do not call callback functions in PrepareTransaction because the transaction
is not truly committed.