### PR TITLE
docs - add gp_toolkit discussion of resgroup views

### DIFF
--- a/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
@@ -530,7 +530,7 @@ gpstart
     <topic id="topic23" xml:lang="en">
       <title id="iz152239">Viewing Resource Group Query Status and CPU/Memory Usage</title>
       <body>
-        <p>The <codeph><xref href="../ref_guide/system_catalogs/gp_resgroup_status.xml" type="topic"
+        <p>The <codeph><xref href="../ref_guide/gp_toolkit.xml#topic31x" type="topic"
               format="dita"/></codeph>
           <codeph>gp_toolkit</codeph> system view enables you to view the status and activity of a
           resource group. The view displays the number of running and queued transactions. It also

--- a/gpdb-doc/dita/ref_guide/gp_toolkit.ditamap
+++ b/gpdb-doc/dita/ref_guide/gp_toolkit.ditamap
@@ -11,6 +11,8 @@
                 <topicref href="gp_toolkit.xml#topic21"
                         navtitle="Checking Server Configuration Files"/>
                 <topicref href="gp_toolkit.xml#topic24" navtitle="Checking for Failed Segments"/>
+                <topicref href="gp_toolkit.xml#topic26x"
+                        navtitle="Checking Resource Group Activity and Status"/>
                 <topicref href="gp_toolkit.xml#topic26"
                         navtitle="Checking Resource Queue Activity and Status"/>
                 <topicref href="gp_toolkit.xml#topic32"

--- a/gpdb-doc/dita/ref_guide/gp_toolkit.xml
+++ b/gpdb-doc/dita/ref_guide/gp_toolkit.xml
@@ -1533,6 +1533,190 @@
       </body>
     </topic>
   </topic>
+  <topic id="topic26x">
+    <title class="- topic/title ">Checking Resource Group Activity and Status</title>
+    <body class="- topic/body ">
+      <note>The resource group activity and status views described in this section are valid only when resource group-based resource management is active.</note>
+      <p>Resource groups manage transactions to avoid exhausting system CPU and
+        memory resources. Every database user is assigned a resource group.
+        Greenplum Database evaluates every transaction submitted by a user
+        against the limits configured for the user's resource group before
+        running the transaction.</p>
+      <p>You can use the <codeph>gp_resgroup_config</codeph> view to check the
+        configuration of each resource group. You can use the
+        <codeph>gp_resgroup_status</codeph> view to display the current 
+        transaction status and resource usage of each resource group.</p>
+      <ul class="- topic/ul ">
+        <li id="ie193806" class="- topic/li ">
+          <xref href="#topic27x" type="topic" format="dita"/>
+        </li>
+        <li id="ie193833" class="- topic/li ">
+          <xref href="#topic31x" type="topic" format="dita"/>
+        </li>
+      </ul>
+    </body>
+    <topic id="topic27x" xml:lang="en" ditaarch:DITAArchVersion="1.1"
+      domains="(topic ui-d) (topic hi-d) (topic pr-d) (topic sw-d)                          (topic ut-d) (topic indexing-d)"
+      class="- topic/topic ">
+      <title id="ie193152x" class="- topic/title ">gp_resgroup_config</title>
+      <body class="- topic/body ">
+        <p>The <codeph>gp_resgroup_config</codeph> view allows administrators to
+         see the current CPU, memory, and concurrency limits for a resource group.
+         The view also displays proposed limit settings. A proposed limit will
+         differ from the current limit when the limit has been altered, but the
+         new value could not be immediately applied.</p>
+        <p>This view is accessible to all users.</p>
+        <table id="ie177971x" class="- topic/table ">
+          <title class="- topic/title ">gp_resgroup_config</title>
+          <tgroup cols="2" class="- topic/tgroup ">
+            <colspec colnum="1" colname="col1" colwidth="85pt" class="- topic/colspec "/>
+            <colspec colnum="2" colname="col2" colwidth="291pt" class="- topic/colspec "/>
+            <thead class="- topic/thead ">
+              <row class="- topic/row ">
+                <entry colname="col1" class="- topic/entry ">Column</entry>
+                <entry colname="col2" class="- topic/entry ">Description</entry>
+              </row>
+            </thead>
+            <tbody class="- topic/tbody ">
+              <row class="- topic/row ">
+                <entry colname="col1" class="- topic/entry ">groupid</entry>
+                <entry colname="col2" class="- topic/entry ">The ID of the resource group.</entry>
+              </row>
+              <row class="- topic/row ">
+                <entry colname="col1" class="- topic/entry ">groupname</entry>
+                <entry colname="col2" class="- topic/entry ">The name of the resource group.</entry>
+              </row>
+              <row class="- topic/row ">
+                <entry colname="col1" class="- topic/entry ">concurrency</entry>
+                <entry colname="col2" class="- topic/entry ">The concurrency (<codeph>CONCURRENCY</codeph>) value specified for the resource group.</entry>
+              </row>
+              <row class="- topic/row ">
+                <entry colname="col1" class="- topic/entry ">proposed_concurrency</entry>
+                <entry colname="col2" class="- topic/entry ">The pending concurrency value for the resource group.</entry>
+              </row>
+
+              <row class="- topic/row ">
+                <entry colname="col1" class="- topic/entry ">cpu_rate_limit</entry>
+                <entry colname="col2" class="- topic/entry ">The CPU limit (<codeph>CPU_RATE_LIMIT</codeph>) value specified for the resource group.</entry>
+              </row>
+              <row class="- topic/row ">
+                <entry colname="col1" class="- topic/entry ">proposed_cpu_rate_limit</entry>
+                <entry colname="col2" class="- topic/entry ">The pending CPU limit value for the resource group.</entry>
+              </row>
+              <row class="- topic/row ">
+                <entry colname="col1" class="- topic/entry ">memory_limit</entry>
+                <entry colname="col2" class="- topic/entry ">The memory limit (<codeph>MEMORY_LIMIT</codeph>) value specified for the resource group.</entry>
+              </row>
+              <row class="- topic/row ">
+                <entry colname="col1" class="- topic/entry ">proposed_memory_limit</entry>
+                <entry colname="col2" class="- topic/entry ">The pending memory limit value for the resource group.</entry>
+              </row>
+              <row class="- topic/row ">
+                <entry colname="col1" class="- topic/entry ">memory_shared_quota</entry>
+                <entry colname="col2" class="- topic/entry ">The shared memory quota (<codeph>MEMORY_SHARED_QUOTA</codeph>) value specified for the resource group.</entry>
+              </row>
+              <row class="- topic/row ">
+                <entry colname="col1" class="- topic/entry ">proposed_memory_shared_quota</entry>
+                <entry colname="col2" class="- topic/entry ">The pending shared memory quota value for the resource group.</entry>
+              </row>
+              <row class="- topic/row ">
+                <entry colname="col1" class="- topic/entry ">memory_spill_ratio</entry>
+                <entry colname="col2" class="- topic/entry ">The memory spill ratio (<codeph>MEMORY_SPILL_RATIO</codeph>) value specified for the resource group.</entry>
+              </row>
+              <row class="- topic/row ">
+                <entry colname="col1" class="- topic/entry ">proposed_memory_spill_ratio</entry>
+                <entry colname="col2" class="- topic/entry ">The pending memory spill ratio value for the resource group.</entry>
+              </row>
+            </tbody>
+          </tgroup>
+        </table>
+      </body>
+    </topic>
+    <topic id="topic31x" xml:lang="en" ditaarch:DITAArchVersion="1.1"
+      domains="(topic ui-d) (topic hi-d) (topic pr-d) (topic sw-d)                          (topic ut-d) (topic indexing-d)"
+      class="- topic/topic ">
+      <title id="ie196285" class="- topic/title ">gp_resgroup_status</title>
+      <body class="- topic/body ">
+        <p>The <codeph>gp_resgroup_status</codeph> view allows administrators to
+          see status and activity for a resource group. It shows how many queries
+          are waiting to run and how many queries are currently active in the
+          system for each resource group. The view also displays current memory
+          and CPU usage for the resource group.</p>
+        <p>This view is accessible to all users.</p>
+        <table id="ie196287x" class="- topic/table ">
+          <title class="- topic/title ">gp_resgroup_status view</title>
+          <tgroup cols="2" class="- topic/tgroup ">
+            <colspec colnum="1" colname="col1" colwidth="178pt" class="- topic/colspec "/>
+            <colspec colnum="2" colname="col2" colwidth="198pt" class="- topic/colspec "/>
+            <thead class="- topic/thead ">
+              <row class="- topic/row ">
+                <entry colname="col1" class="- topic/entry ">Column</entry>
+                <entry colname="col2" class="- topic/entry ">Description</entry>
+              </row>
+            </thead>
+            <tbody class="- topic/tbody ">
+              <row class="- topic/row ">
+                <entry colname="col1" class="- topic/entry ">rsgname</entry>
+                <entry colname="col2" class="- topic/entry ">The name of the resource group.</entry>
+              </row>
+              <row class="- topic/row ">
+                <entry colname="col1" class="- topic/entry ">groupid</entry>
+                <entry colname="col2" class="- topic/entry ">The ID of the resource group.</entry>
+              </row>
+              <row class="- topic/row ">
+                <entry colname="col1" class="- topic/entry ">num_running</entry>
+                <entry colname="col2" class="- topic/entry ">The number of transactions currently executing in the resource group.</entry>
+              </row>
+              <row class="- topic/row ">
+                <entry colname="col1" class="- topic/entry ">num_queueing</entry>
+                <entry colname="col2" class="- topic/entry ">The number of currently queued transactions for the resource group.</entry>
+              </row>
+              <row class="- topic/row ">
+                <entry colname="col1" class="- topic/entry ">num_queued</entry>
+                <entry colname="col2" class="- topic/entry ">The total number of queued transactions for the resource group since the Greenplum Database cluster was last started, excluding the num_queueing.</entry>
+              </row>
+              <row class="- topic/row ">
+                <entry colname="col1" class="- topic/entry ">num_executed</entry>
+                <entry colname="col2" class="- topic/entry ">The total number of executed transactions in the resource group since the Greenplum Database cluster was last started, excluding the num_running.</entry>
+              </row>
+              <row class="- topic/row ">
+                <entry colname="col1" class="- topic/entry ">total_queue_duration</entry>
+                <entry colname="col2" class="- topic/entry ">The total time any transaction was queued since the Greenplum Database cluster was last started.</entry>
+              </row>
+              <row class="- topic/row ">
+                <entry colname="col1" class="- topic/entry ">cpu_usage</entry>
+                <entry colname="col2" class="- topic/entry ">The real-time CPU usage of the resource group on each Greenplum Database segment's host.</entry>
+              </row>
+              <row class="- topic/row ">
+                <entry colname="col1" class="- topic/entry ">memory_usage</entry>
+                <entry colname="col2" class="- topic/entry ">The real-time memory usage of the resource group on each Greenplum Database segment's host.</entry>
+              </row>
+            </tbody>
+          </tgroup>
+        </table>
+        <p> </p>
+        <p>The <codeph>cpu_usage</codeph> field is a JSON-formatted, key:value
+          string that identifies, for each resource group, the per-segment CPU
+          usage percentage. The key is segment id, the value is the percentage
+          of CPU usage by the resource group on the segment host. The total
+          CPU usage of all segments running on a segment host should not exceed
+          the <codeph>gp_resource_group_cpu_limit</codeph>. Example
+          <codeph>cpu_usage</codeph> column output:<codeblock>
+{"-1":0.01, "0":0.31, "1":0.31}</codeblock></p>
+        <p>In this example, segment <codeph>0</codeph> and segment 
+          <codeph>1</codeph> are running on the same host; their CPU usage
+          is the same.</p> 
+        <p>The <codeph>memory_usage</codeph> field is also a JSON-formatted,
+          key:value string. This string identifies, for each resource group, the
+          used, available, granted, and proposed fixed and shared memory quota 
+          allocations on each segment. The key is segment id. The values are 
+          memory values displayed in MB units. Example
+          <codeph>memory_usage</codeph> column output for a
+          single segment:<codeblock>
+"0":{"used":0, "available":76, "quota_used":-1, "quota_available":60, "quota_granted":60, "quota_proposed":60, "shared_used":0, "shared_available":16, "shared_granted":16, "shared_proposed":16}</codeblock></p>
+      </body>
+    </topic>
+  </topic>
   <topic id="topic26" xml:lang="en" ditaarch:DITAArchVersion="1.1"
     domains="(topic ui-d) (topic hi-d) (topic pr-d) (topic sw-d)                          (topic ut-d) (topic indexing-d)"
     class="- topic/topic ">

--- a/gpdb-doc/dita/ref_guide/gp_toolkit.xml
+++ b/gpdb-doc/dita/ref_guide/gp_toolkit.xml
@@ -1600,10 +1600,6 @@
                 <entry colname="col2" class="- topic/entry ">The CPU limit (<codeph>CPU_RATE_LIMIT</codeph>) value specified for the resource group.</entry>
               </row>
               <row class="- topic/row ">
-                <entry colname="col1" class="- topic/entry ">proposed_cpu_rate_limit</entry>
-                <entry colname="col2" class="- topic/entry ">The pending CPU limit value for the resource group.</entry>
-              </row>
-              <row class="- topic/row ">
                 <entry colname="col1" class="- topic/entry ">memory_limit</entry>
                 <entry colname="col2" class="- topic/entry ">The memory limit (<codeph>MEMORY_LIMIT</codeph>) value specified for the resource group.</entry>
               </row>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/gp_resgroup_config.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/gp_resgroup_config.xml
@@ -67,14 +67,6 @@
           </row>
           <row>
             <entry colname="col1">
-              <codeph>proposed_cpu_rate_limit</codeph>
-            </entry>
-            <entry colname="col2">text</entry>
-            <entry colname="col3">pg_resgroupcapability.proposed for pg_resgroupcapability.reslimittype = 2</entry>
-            <entry colname="col4">The pending CPU limit value for the resource group.</entry>
-          </row>
-          <row>
-            <entry colname="col1">
               <codeph>memory_limit</codeph>
             </entry>
             <entry colname="col2">text</entry>


### PR DESCRIPTION
add resource group-related content to gp_toolkit views page.  
- gp_resgroup_config
- gp_resgroup_status - discuss cpu_usage and memory_usage fields

i used sample cpu_usage and memory_usage output from a build that is now about a week old.

did i miss any important info in the cpu_usage/memory_usage discussion?

docs review site CI is very slow; hopefully the new resource groups section will appear at this link:
- http://docs-gpdb-review-staging.cfapps.io/510/ref_guide/gp_toolkit.html#topic26x