### PR TITLE
Bring back c3d8a92e which was reverted by accident

### DIFF
--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -308,3 +308,13 @@ select 1 from gp_dist_random('gp_id') limit 1;
 -- if previous gang is not destroyed, snapshot collision would happen
 select 1 from gp_dist_random('gp_id') limit 1;
 select gp_inject_fault('gang_created', 'reset', 1);
+
+--
+-- Test that an error happens after a big command is dispatched.
+--
+select gp_inject_fault('after_one_slice_dispatched', 'error', 1);
+select * from gp_dist_random('gp_id')
+	where gpname > (select * from repeat('sssss', 10000000));
+select gp_inject_fault('after_one_slice_dispatched', 'reset', 1);
+select * from gp_dist_random('gp_id')
+	where gpname > (select * from repeat('sssss', 10000000));

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -554,3 +554,29 @@ NOTICE:  Success:
  t
 (1 row)
 
+--
+-- Test that an error happens after a big command is dispatched.
+--
+select gp_inject_fault('after_one_slice_dispatched', 'error', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+select * from gp_dist_random('gp_id')
+	where gpname > (select * from repeat('sssss', 10000000));
+ERROR:  fault triggered, fault name:'after_one_slice_dispatched' fault type:'error'
+select gp_inject_fault('after_one_slice_dispatched', 'reset', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+select * from gp_dist_random('gp_id')
+	where gpname > (select * from repeat('sssss', 10000000));
+ gpname | numsegments | dbid | content 
+--------+-------------+------+---------
+(0 rows)
+


### PR DESCRIPTION
    Do a force flush before checking the result of a connection

    Previously, to speed up dispatching, cdbdisp_dispatchToGang_async
    and cdbdisp_waitDispatchFinish_async are designed to use nonblock
    flush to dispatch commands in bulk, however, risks exist that some
    commands are not fully dispatched in corner error cases, so QD must
    do a force flush before handling such connections, otherwise QD will
    get stuck.