### PR TITLE
concourse: gate compile jobs to start at same time

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -660,6 +660,7 @@ jobs:
   plan:
   - aggregate:
     - get: gpdb_src
+      passed: [gate_compile_start]
       trigger: ((gpdb_src-trigger-flag))
     - get: reduced-frequency-trigger
       trigger: ((reduced-frequency-trigger-flag))
@@ -693,6 +694,7 @@ jobs:
     - get: reduced-frequency-trigger
       trigger: ((reduced-frequency-trigger-flag))
     - get: gpdb_src
+      passed: [gate_compile_start]
       trigger: ((gpdb_src-trigger-flag))
       passed: [gate_compile_start]
     - get: gpaddon_src
@@ -725,6 +727,7 @@ jobs:
     - get: reduced-frequency-trigger
       trigger: ((reduced-frequency-trigger-flag))
     - get: gpdb_src
+      passed: [gate_compile_start]
       trigger: ((gpdb_src-trigger-flag))
     - get: gpaddon_src
       passed: [gate_compile_start]
@@ -751,6 +754,7 @@ jobs:
     - get: reduced-frequency-trigger
       trigger: ((reduced-frequency-trigger-flag))
     - get: gpdb_src
+      passed: [gate_compile_start]
       trigger: ((gpdb_src-trigger-flag))
     - get: ubuntu-gpdb-dev-16
       passed: [gate_compile_start]
@@ -770,6 +774,7 @@ jobs:
     - get: reduced-frequency-trigger
       trigger: ((reduced-frequency-trigger-flag))
     - get: gpdb_src
+      passed: [gate_compile_start]
       trigger: ((gpdb_src-trigger-flag))
     - get: centos-gpdb-dev-6
       passed: [gate_compile_start]
@@ -817,6 +822,7 @@ jobs:
     - get: reduced-frequency-trigger
       trigger: ((reduced-frequency-trigger-flag))
     - get: gpdb_src
+      passed: [gate_compile_start]
       trigger: ((gpdb_src-trigger-flag))
     - get: ubuntu-gpdb-dev-16
       passed: [gate_compile_start]
@@ -840,6 +846,7 @@ jobs:
       tags: ["wix"]
     - get: gpdb_src
       trigger: ((gpdb_src-trigger-flag))
+      passed: [gate_compile_start]
       tags: ["wix"]
     - get: gpaddon_src
       passed: [gate_compile_start]


### PR DESCRIPTION
Looks like the following. Needs to be backported to 5X_STABLE pipeline too.

I think it actually gave me a free pass on a dependency download flake by triggering a second time...? https://gpdb.data.pivotal.ci/teams/main/pipelines/5X_STABLE/jobs/compile_gpdb_and_orca_conan_ubuntu16/builds/80

![image](https://user-images.githubusercontent.com/6885889/32627720-48ffff98-c548-11e7-9296-766b656f60ec.png)
