### PR TITLE
Use actual page item in sequence xlog record

### DIFF
--- a/src/include/access/htup.h
+++ b/src/include/access/htup.h
@@ -224,6 +224,12 @@ typedef HeapTupleHeaderData *HeapTupleHeader;
 	(tup)->t_choice.t_heap.t_xmin = (xid) \
 )
 
+#define HeapTupleHeaderXminInvalid(tup) \
+( \
+    ((tup)->t_infomask & (HEAP_XMIN_COMMITTED|HEAP_XMIN_INVALID)) == \
+        HEAP_XMIN_INVALID \
+)
+
 #define HeapTupleHeaderGetXmax(tup) \
 ( \
 	(tup)->t_choice.t_heap.t_xmax \
@@ -232,6 +238,12 @@ typedef HeapTupleHeaderData *HeapTupleHeader;
 #define HeapTupleHeaderSetXmax(tup, xid) \
 ( \
 	(tup)->t_choice.t_heap.t_xmax = (xid) \
+)
+
+#define HeapTupleHeaderSetXminFrozen(tup) \
+( \
+    AssertMacro(!HeapTupleHeaderXminInvalid(tup)), \
+    ((tup)->t_infomask |= HEAP_XMIN_FROZEN) \
 )
 
 /*


### PR DESCRIPTION
First commit:
```
Use actual page item in sequence xlog record

The sequence xlog record generated at the end of DefineSequence
records the local tuple->t_data when the actual page item is
available. Not using the actual page item caused gp_replica_check
extension to fail for sequences because the tuple->t_data ctid would
be replicated as (0,0) instead of the actual page item ctid (0,1).

To fix this, we put the actual page item into the sequence xlog record
and get rid of the FrozenTransactionId hack that was going on in favor
of using frozen_heap_insert.
```

Second commit:
```
gp_replica_check extension should mask sequence blocks with seq_mask

We were using heap_mask which kinda worked but ideally we should be
using the intended mask for sequences which is seq_mask.
```