### PR TITLE
fix error_table

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -1137,6 +1137,7 @@ class gpload:
         self.options.l = None
         self.formatOpts = ""
         self.startTimestamp = time.time()
+        self.error_table = False
         seenv = False
         seenq = False
 
@@ -1468,7 +1469,10 @@ class gpload:
             self.options.d = self.options.U
 
         if self.getconfig('gpload:input:error_table', unicode, None):
-            self.control_file_error("ERROR_TABLE is not supported. Please use LOG_ERRORS instead.")
+            self.error_table = True
+            self.log(self.WARN,
+                        "ERROR_TABLE is not supported. " +
+                        "We will set LOG_ERRORS and REUSE_TABLES to True for compatibility.")
 
     def gpfdist_port_options(self, name, availablePorts, popenList):
         """
@@ -2642,6 +2646,9 @@ class gpload:
         if preload:
             truncate = self.getconfig('gpload:preload:truncate',bool,False)
             self.reuse_tables = self.getconfig('gpload:preload:reuse_tables',bool,False)
+        if self.error_table:
+            self.log_errors = True
+            self.reuse_tables = True
         if truncate == True:
             if method=='insert':
                 self.do_truncate(self.schemaTable)

--- a/gpMgmt/bin/gpload_test/gpload2/TEST.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST.py
@@ -95,7 +95,7 @@ d = mkpath('config')
 if not os.path.exists(d):
     os.mkdir(d)
 
-def write_config_file(mode='insert', reuse_flag='',columns_flag='0',mapping='0',portNum='8081',database='reuse_gptest',host='localhost',formatOpts='text',file='data/external_file_01.txt',table='texttable',format='text',delimiter="'|'",escape='',quote='',truncate='False',log_errors=None, error_limit='0'):
+def write_config_file(mode='insert', reuse_flag='',columns_flag='0',mapping='0',portNum='8081',database='reuse_gptest',host='localhost',formatOpts='text',file='data/external_file_01.txt',table='texttable',format='text',delimiter="'|'",escape='',quote='',truncate='False',log_errors=None, error_limit='0',error_table=None):
 
     f = open(mkpath('config/config_file'),'w')
     f.write("VERSION: 1.0.0.1")
@@ -132,6 +132,9 @@ def write_config_file(mode='insert', reuse_flag='',columns_flag='0',mapping='0',
         f.write("\n    - FORMAT: "+format)
     if log_errors:
         f.write("\n    - LOG_ERRORS: true")
+        f.write("\n    - ERROR_LIMIT: " + error_limit)
+    if error_table:
+        f.write("\n    - ERROR_TABLE: " + error_table)
         f.write("\n    - ERROR_LIMIT: " + error_limit)
     if delimiter:
         f.write("\n    - DELIMITER: "+delimiter)
@@ -417,7 +420,7 @@ class GPLoad_FormatOpts_TestCase(unittest.TestCase):
 
     def test_00_gpload_formatOpts_setup(self):
         "0  gpload setup"
-        for num in range(1,23):
+        for num in range(1,24):
            f = open(mkpath('query%d.sql' % num),'w')
            f.write("\! gpload -f "+mkpath('config/config_file')+ " -d reuse_gptest\n"+"\! gpload -f "+mkpath('config/config_file')+ " -d reuse_gptest\n")
            f.close()
@@ -577,6 +580,23 @@ class GPLoad_FormatOpts_TestCase(unittest.TestCase):
         copy_data('large_file.csv','data_file.csv')
         write_config_file(reuse_flag='true',formatOpts='csv',file='data_file.csv',table='csvtable',format='csv',delimiter="','",log_errors=True,error_limit='90000000')
         self.doTest(22)
+    def test_23_gpload_error_count(self):
+        "23  gpload error_table"
+        file = mkpath('setup.sql')
+        runfile(file)
+        f = open(mkpath('query23.sql'),'a')
+        f.write("\! psql -d reuse_gptest -c 'select count(*) from csvtable;'")
+        f.close()
+        f = open(mkpath('data/large_file.csv'),'w')
+        for i in range(0, 10000):
+            if i % 2 == 0:
+                f.write('1997,Ford,E350,"ac, abs, moon",3000.00,a\n')
+            else:
+                f.write('1997,Ford,E350,"ac, abs, moon",3000.00\n')
+        f.close()
+        copy_data('large_file.csv','data_file.csv')
+        write_config_file(reuse_flag='true',formatOpts='csv',file='data_file.csv',table='csvtable',format='csv',delimiter="','",error_table="err_table",error_limit='90000000')
+        self.doTest(23)
 
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(GPLoad_FormatOpts_TestCase)

--- a/gpMgmt/bin/gpload_test/gpload2/query23.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query23.ans
@@ -1,0 +1,31 @@
+2017-11-10 02:46:20|INFO|gpload session started 2017-11-10 02:46:20
+2017-11-10 02:46:20|WARN|ERROR_TABLE is not supported. We will set LOG_ERRORS and REUSE_TABLES to True for compatibility.
+2017-11-10 02:46:20|INFO|setting schema 'public' for table 'csvtable'
+2017-11-10 02:46:20|INFO|started gpfdist -p 8081 -P 8082 -f "/usr/local/greenplum-db-devel/bin/gpload_test/gpload2/data_file.csv" -t 30
+2017-11-10 02:46:20|INFO|did not find an external table to reuse. creating ext_gpload_reusable_54fd9764_c5c1_11e7_b31f_0242ac110003
+2017-11-10 02:46:20|WARN|5000 bad rows
+2017-11-10 02:46:20|WARN|Please use following query to access the detailed error
+2017-11-10 02:46:20|WARN|select * from gp_read_error_log('ext_gpload_reusable_54fd9764_c5c1_11e7_b31f_0242ac110003') where cmdtime > to_timestamp('1510281980.34')
+2017-11-10 02:46:20|INFO|running time: 0.34 seconds
+2017-11-10 02:46:20|INFO|rows Inserted          = 5000
+2017-11-10 02:46:20|INFO|rows Updated           = 0
+2017-11-10 02:46:20|INFO|data formatting errors = 5000
+2017-11-10 02:46:20|INFO|gpload succeeded with warnings
+2017-11-10 02:46:20|INFO|gpload session started 2017-11-10 02:46:20
+2017-11-10 02:46:20|WARN|ERROR_TABLE is not supported. We will set LOG_ERRORS and REUSE_TABLES to True for compatibility.
+2017-11-10 02:46:20|INFO|setting schema 'public' for table 'csvtable'
+2017-11-10 02:46:20|INFO|started gpfdist -p 8081 -P 8082 -f "/usr/local/greenplum-db-devel/bin/gpload_test/gpload2/data_file.csv" -t 30
+2017-11-10 02:46:20|INFO|reusing external table ext_gpload_reusable_54fd9764_c5c1_11e7_b31f_0242ac110003
+2017-11-10 02:46:21|WARN|5000 bad rows
+2017-11-10 02:46:21|WARN|Please use following query to access the detailed error
+2017-11-10 02:46:21|WARN|select * from gp_read_error_log('ext_gpload_reusable_54fd9764_c5c1_11e7_b31f_0242ac110003') where cmdtime > to_timestamp('1510281980.77')
+2017-11-10 02:46:21|INFO|running time: 0.31 seconds
+2017-11-10 02:46:21|INFO|rows Inserted          = 5000
+2017-11-10 02:46:21|INFO|rows Updated           = 0
+2017-11-10 02:46:21|INFO|data formatting errors = 5000
+2017-11-10 02:46:21|INFO|gpload succeeded with warnings
+ count 
+-------
+ 10000
+(1 row)
+


### PR DESCRIPTION
gpload ERROR_TABLE configuration is forbidden in GPDB5 and use
LOG_ERRORS instead. That's why Informatica 9.x connector can't
load data into GPDB5.

So we accept ERROR_TABLE, if ERROR_TABLE is set, we will not
create it as before, but set LOG_ERRORS and REUSE_TABLE to true
instead.