### PR TITLE
misc cleanup on resource group cpu/memory codes

### DIFF
--- a/src/include/utils/resgroup-ops.h
+++ b/src/include/utils/resgroup-ops.h
@@ -14,6 +14,7 @@
 #ifndef RES_GROUP_OPS_H
 #define RES_GROUP_OPS_H
 
+#define RESGROUP_ROOT_ID (InvalidOid)
 /*
  * Interfaces for OS dependent operations
  */


### PR DESCRIPTION
* Set/Unset doMemCheck in Attach/Detach slot.
* Use IsResGroupEnabled() in ResGroupReleaseMemory().
* Remove AssertImply in Attach/Detach slot.
* Replace magic number 0 with macro to represent cgroup top dir.
* Remove static global variable cpucores.
* Dump more info in ResGroupDumpMemoryInfo.