### PR TITLE
Supporting Join Optimization Levels in GPORCA

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("2.49.", GPORCA_VERSION_STRING, 5);
+return strncmp("2.50.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 2.49.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 2.50.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -12736,7 +12736,7 @@ int
 main ()
 {
 
-return strncmp("2.49.", GPORCA_VERSION_STRING, 5);
+return strncmp("2.50.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -12746,7 +12746,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 2.49.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 2.50.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v2.49.1@gpdb/stable
+orca/v2.50.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -121,7 +121,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	@echo "Resolve finished";
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget -O - https://github.com/greenplum-db/gporca/releases/download/v2.49.1/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget -O - https://github.com/greenplum-db/gporca/releases/download/v2.50.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -473,6 +473,26 @@ CConfigParamMapping::PbsPack
 		pbs->FExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfIndexGet2IndexScan));
 	}
 
+	CBitSet *pbsJoinHeuristic = NULL;
+	switch (optimizer_join_order)
+	{
+		case JOIN_ORDER_IN_QUERY:
+			pbsJoinHeuristic = CXform::PbsJoinOrderInQueryXforms(pmp);
+			break;
+		case JOIN_ORDER_GREEDY_SEARCH:
+			pbsJoinHeuristic = CXform::PbsJoinOrderOnGreedyXforms(pmp);
+			break;
+		case JOIN_ORDER_EXHAUSTIVE_SEARCH:
+			pbsJoinHeuristic = GPOS_NEW(pmp) CBitSet(pmp, EopttraceSentinel);
+			break;
+		default:
+			elog(ERROR, "Invalid value for optimizer_join_order, must \
+				 not come here");
+			break;
+	}
+	pbs->Union(pbsJoinHeuristic);
+	pbsJoinHeuristic->Release();
+
 	return pbs;
 }
 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -507,6 +507,7 @@ double		optimizer_sort_factor;
 int			optimizer_join_arity_for_associativity_commutativity;
 int         optimizer_array_expansion_threshold;
 int         optimizer_join_order_threshold;
+int			optimizer_join_order;
 int			optimizer_cte_inlining_bound;
 bool		optimizer_force_multistage_agg;
 bool		optimizer_force_three_stage_scalar_dqa;
@@ -652,6 +653,13 @@ static const struct config_enum_entry password_hash_algorithm_options[] = {
 	/* {"none", PASSWORD_HASH_NONE}, * this option is not exposed */
 	{"MD5", PASSWORD_HASH_MD5},
 	{"SHA-256", PASSWORD_HASH_SHA_256},
+	{NULL, 0}
+};
+
+static const struct config_enum_entry optimizer_join_order_options[] = {
+	{"query", JOIN_ORDER_IN_QUERY},
+	{"greedy", JOIN_ORDER_GREEDY_SEARCH},
+	{"exhaustive", JOIN_ORDER_EXHAUSTIVE_SEARCH},
 	{NULL, 0}
 };
 
@@ -5591,6 +5599,16 @@ struct config_enum ConfigureNamesEnum_gp[] =
 		},
 		&gp_workfile_type_hashjoin,
 		BFZ, gp_workfile_type_hashjoin_options, NULL, NULL
+	},
+
+	{
+		{"optimizer_join_order", PGC_USERSET, QUERY_TUNING_OTHER,
+			gettext_noop("Set optimizer join heuristic model."),
+			gettext_noop("Valid values are query, greedy and exhaustive"),
+			GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_join_order,
+		JOIN_ORDER_EXHAUSTIVE_SEARCH, optimizer_join_order_options, NULL, NULL
 	},
 
 	/* End-of-list marker */

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -486,6 +486,7 @@ extern double optimizer_sort_factor;
 /* Optimizer hints */
 extern int optimizer_array_expansion_threshold;
 extern int optimizer_join_order_threshold;
+extern int optimizer_join_order;
 extern int optimizer_join_arity_for_associativity_commutativity;
 extern int optimizer_cte_inlining_bound;
 extern bool optimizer_force_multistage_agg;
@@ -528,6 +529,11 @@ extern int codegen_optimization_level;
  * Enable logging of DPE match in optimizer.
  */
 extern bool	optimizer_partition_selection_log;
+
+/* optimizer join heuristic models */
+#define JOIN_ORDER_IN_QUERY                 0
+#define JOIN_ORDER_GREEDY_SEARCH            1
+#define JOIN_ORDER_EXHAUSTIVE_SEARCH        2
 
 extern char  *gp_email_smtp_server;
 extern char  *gp_email_smtp_userid;


### PR DESCRIPTION
The concept of optimization levels is known in many enterprise optimizers. It enables user to handle the degree of optimization that is being employed. The optimization levels allow the grouping of transformations into bags of rules (where each is assigned a particular level). By default all rules are applied, but if a user wants to apply fewer rules they are able to. This decision is made by them based on domain knowledge, and they know even with fewer rules being applied the plan generated satisfies their needs.

The Cascade optimizer, on which GPORCA is based on, allows grouping of transformation rules into optimization levels. This concept of optimization levels has also been extended to join ordering allowing user to pick the join order via the query or, use greedy approach or use exhaustive approach.

Postgres based planners use join_limit and from_limit to reduce the search space. While the objective of Optimization/Join is also to reduce search space, but the way it does it is different. It is requesting the optimizer to apply or not apply a subset of rules and providing more flexibility to the customer. This is one of the most frequently requested feature from our enterprise clients who have high degree of domain knowledge.

This PR introduces this concept. In the immediate future we are planning to add different polynomial join ordering techniques with guaranteed bound as part of the "Greedy" search.