### PR TITLE
Fix error message on DECLARE CURSOR ... SELECT INTO.

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -2918,10 +2918,10 @@ transformDeclareCursorStmt(ParseState *pstate, DeclareCursorStmt *stmt)
 	/* But we must explicitly disallow DECLARE CURSOR ... SELECT INTO */
 	if (result->intoClause)
 		ereport(ERROR,
-				(errcode(ERRCODE_SYNTAX_ERROR),
-				 errmsg("INSERT ... SELECT cannot specify INTO"),
+				(errcode(ERRCODE_INVALID_CURSOR_DEFINITION),
+				 errmsg("DECLARE CURSOR cannot specify INTO"),
 				 parser_errposition(pstate,
-						   exprLocation((Node *) result->intoClause))));
+								exprLocation((Node *) result->intoClause))));
 
 	/* FOR UPDATE and WITH HOLD are not compatible */
 	if (result->rowMarks != NIL && (stmt->options & CURSOR_OPT_HOLD))


### PR DESCRIPTION
The error message was changed accidentally in commit 78b0a42ec1. Probably
a copy-paste mistake. Change it back.