### PR TITLE
Add gp_replica_check for heap tables in ICW.

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -173,6 +173,9 @@ ifeq ($(enable_segwalrep), yes)
 	do \
 		gpcheckcat -R $$test -A;\
 	done;
+
+	# Verify the filesystem objects are consistent between primary and mirror
+	$(MAKE) -C contrib/gp_replica_check installcheck
 else
 	gpcheckcat -A
 	$(MAKE) -C contrib/pg_upgrade check

--- a/contrib/gp_replica_check/Makefile
+++ b/contrib/gp_replica_check/Makefile
@@ -6,3 +6,8 @@ SCRIPTS = gp_replica_check.py
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
+
+# For now run only for HEAP as for other object types like Sequence, AO, btree
+# there are still known differences to be fixed.
+installcheck: install
+	gp_replica_check.py -r="heap"

--- a/contrib/gp_replica_check/gp_replica_check.c
+++ b/contrib/gp_replica_check/gp_replica_check.c
@@ -172,11 +172,15 @@ compare_files(char* primaryfilepath, char* mirrorfilepath, RelfilenodeEntry *ren
 
 	primaryFile = PathNameOpenFile(primaryfilepath, O_RDONLY | PG_BINARY, S_IRUSR);
 	if (primaryFile < 0)
+	{
+		elog(WARNING, "Unable to open file %s", primaryfilepath);
 		return false;
+	}
 
 	mirrorFile = PathNameOpenFile(mirrorfilepath, O_RDONLY | PG_BINARY, S_IRUSR);
 	if (mirrorFile < 0)
 	{
+		elog(WARNING, "Unable to open file %s", mirrorfilepath);
 		FileClose(primaryFile);
 		return false;
 	}

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -4896,7 +4896,7 @@ OpenIntoRel(QueryDesc *queryDesc)
 	 */
 	bufferPoolBulkLoad = 
 		(relstorage_is_buffer_pool(relstorage) ?
-									!XLogIsNeeded() : false);
+									XLogIsNeeded() : false);
 
 	/* Now we can actually create the new relation */
 	intoRelationId = heap_create_with_catalog(intoName,
@@ -4969,7 +4969,7 @@ OpenIntoRel(QueryDesc *queryDesc)
 	/*
 	 * We can skip WAL-logging the insertions, unless PITR is in use.
 	 */
-	myState->use_wal = XLogArchivingActive();
+	myState->use_wal = XLogIsNeeded();
 	myState->rel = intoRelationDesc;
 
 	/* use_wal off requires rd_targblock be initially invalid */


### PR DESCRIPTION

Author: Abhijit Subramanya <asubramanya@pivotal.io>

    Add gp_replica_check for heap tables in ICW.

    When configured with --enable-segwalrep, the tool will be enabled only for heap
    relations. It has flagged some inconsistencies for other objects such as
    sequences and appendonly tables. Once the issues are fixed, the tool will be
    enabled to check for all objects created by ICW. This helps to consistently
    check primary and mirrors.

    Also add warning messages to gp_replica_check if files could not be opened.


Author: Abhijit Subramanya <asubramanya@pivotal.io>

    Fix use of XLogIsNeeded() in OpenIntoRel().

    We should use XLogIsNeeded() instead of XLogArchivingActive() to decide whether
    to generate XLog records or not. Otherwise the XLog records might not get
    streamed to the standby.

    Also fix the usage of XLogIsNeeded() in case of bulk loading using buffer pool
    with ctas statements.