### PR TITLE
Make 'gporca' test pass regardless of log_statement setting.

### DIFF
--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -10085,11 +10085,13 @@ explain select * from foo where b in ('1', '2');
 (5 rows)
 
 set optimizer_enable_ctas = off;
+set log_statement='none';
+set log_min_duration_statement=-1;
 set client_min_messages='log';
 create table foo_ctas(a) as (select generate_series(1,10)) distributed by (a);
-LOG:  statement: create table foo_ctas(a) as (select generate_series(1,10)) distributed by (a);
 reset client_min_messages;
-LOG:  statement: reset client_min_messages;
+reset log_min_duration_statement;
+reset log_statement;
 reset optimizer_enable_ctas;
 -- TVF with a subplan that generates an RTABLE entry
 create table bar(name text);

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -10141,14 +10141,16 @@ explain select * from foo where b in ('1', '2');
 (5 rows)
 
 set optimizer_enable_ctas = off;
+set log_statement='none';
+set log_min_duration_statement=-1;
 set client_min_messages='log';
 create table foo_ctas(a) as (select generate_series(1,10)) distributed by (a);
-LOG:  statement: create table foo_ctas(a) as (select generate_series(1,10)) distributed by (a);
 LOG:  2017-05-31 14:43:22:338568 PDT,THD000,NOTICE,"Feature not supported by the Pivotal Query Optimizer: CTAS. Set optimizer_enable_ctas to on to enable CTAS with GPORCA",
 INFO:  GPORCA failed to produce a plan, falling back to planner
 LOG:  Planner produced plan :0
 reset client_min_messages;
-LOG:  statement: reset client_min_messages;
+reset log_min_duration_statement;
+reset log_statement;
 reset optimizer_enable_ctas;
 -- start_ignore
 drop table bar;

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -1399,9 +1399,13 @@ create table foo (a int, b character varying(10));
 explain select * from foo where b in ('1', '2');
 
 set optimizer_enable_ctas = off;
+set log_statement='none';
+set log_min_duration_statement=-1;
 set client_min_messages='log';
 create table foo_ctas(a) as (select generate_series(1,10)) distributed by (a);
 reset client_min_messages;
+reset log_min_duration_statement;
+reset log_statement;
 reset optimizer_enable_ctas;
 
 -- start_ignore


### PR DESCRIPTION
This test would only produce the LOG lines memorized in the expected output
if log_statement='all' was set. Remove the assumption, by temporarily
setting log_statement (and log_min_duration_statement), like in some
earlier tests in the same file.