### PR TITLE
Don't bother to update distributed clog on sub-commit.

### DIFF
--- a/src/backend/access/transam/distributedlog.c
+++ b/src/backend/access/transam/distributedlog.c
@@ -70,17 +70,50 @@ typedef struct DistributedLogShmem
 
 static DistributedLogShmem *DistributedLogShared = NULL;
 
+static void DistributedLog_SetCommitted(TransactionId localXid,
+							DistributedTransactionTimeStamp dtxStartTime,
+							DistributedTransactionId distribXid,
+							bool isRedo);
 static int	DistributedLog_ZeroPage(int page, bool writeXlog);
 static bool DistributedLog_PagePrecedes(int page1, int page2);
 static void DistributedLog_WriteZeroPageXlogRec(int page);
 static void DistributedLog_WriteTruncateXlogRec(int page);
 
+/*
+ * Record that a distributed transaction and its possible sub-transactions
+ * committed, in the distributed log.
+ */
+void
+DistributedLog_SetCommittedTree(TransactionId xid, int nxids, TransactionId *xids,
+								DistributedTransactionTimeStamp	distribTimeStamp,
+								DistributedTransactionId distribXid,
+								bool isRedo)
+{
+	int			i;
+
+	/*
+	 * GPDB_84_MERGE_FIXME: This is a naive implementation, not very efficient.
+	 * Should update the list of transaction one distributed clog page at a time.
+	 * Similar to how we do for the clog now, since commit 06da3c570.
+	 */
+	DistributedLog_SetCommitted(xid,
+								distribTimeStamp,
+								distribXid,
+								isRedo);
+	for (i = 0; i < nxids; i++)
+	{
+		DistributedLog_SetCommitted(xids[i],
+									distribTimeStamp,
+									distribXid,
+									isRedo);
+	}
+}
+
 
 /*
  * Record that a distributed transaction committed in the distributed log.
- *
  */
-void
+static void
 DistributedLog_SetCommitted(
 	TransactionId 						localXid,
 	DistributedTransactionTimeStamp		distribTimeStamp,

--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -2136,11 +2136,10 @@ RecordTransactionCommitPrepared(TransactionId xid,
 	/*
 	 * Mark the distributed transaction committed.
 	 */
-	DistributedLog_SetCommitted(
-		xid,
-		distribTimeStamp,
-		distribXid,
-		/* isRedo */ false);
+	DistributedLog_SetCommittedTree(xid, nchildren, children,
+									distribTimeStamp,
+									distribXid
+									/* isRedo */ false);
 
 	/* Mark the transaction committed in pg_clog */
 	TransactionIdCommit(xid);

--- a/src/include/access/distributedlog.h
+++ b/src/include/access/distributedlog.h
@@ -45,11 +45,10 @@ typedef struct DistributedLogEntry
 /* Number of SLRU buffers to use for the distributed log */
 #define NUM_DISTRIBUTEDLOG_BUFFERS	8
 
-extern void DistributedLog_SetCommitted(
-							TransactionId localXid,
-							DistributedTransactionTimeStamp dtxStartTime,
-							DistributedTransactionId distribXid,
-							bool isRedo);
+extern void DistributedLog_SetCommittedTree(TransactionId xid, int nxids, TransactionId *xids,
+								DistributedTransactionTimeStamp	distribTimeStamp,
+								DistributedTransactionId distribXid,
+								bool isRedo);
 extern bool DistributedLog_CommittedCheck(
 							  TransactionId localXid,
 							  DistributedTransactionTimeStamp *dtxStartTime,


### PR DESCRIPTION
The distributed clog, like normal clog, will not be consulted for
subtransactions that are part of a still-in-progress transaction, so there
is no need to update it until we're ready to commit the top transaction.
This is basically the same changes that was done in the upstream for clog
in commit 06da3c570. We're about to merge that change from the upstream as
part of the PostgreSQL 8.4 merge, but we can make that change for the
distributed log separately, to keep the actual merge commit smaller.