### PR TITLE
resgroup: fix the memory quota check on memory_shared_quota=100

### DIFF
--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -1280,7 +1280,7 @@ groupGetSlot(ResGroupData *group)
 		return NULL;
 
 	slotMemQuota = groupReserveMemQuota(group);
-	if (slotMemQuota == 0)
+	if (slotMemQuota < 0)
 		return NULL;
 
 	/* Now actually get a free slot */
@@ -1331,7 +1331,7 @@ groupPutSlot(ResGroupData *group, ResGroupSlotData *slot)
 /*
  * Reserve memory quota for a slot in group.
  *
- * If there is not enough free memory quota then return 0 and nothing
+ * If there is not enough free memory quota then return -1 and nothing
  * is changed; otherwise return the reserved quota size.
  */
 static int32
@@ -1357,7 +1357,7 @@ groupReserveMemQuota(ResGroupData *group)
 	if (group->memQuotaUsed + slotMemQuota > group->memQuotaGranted)
 	{
 		/* No enough memory quota available, give up */
-		return 0;
+		return -1;
 	}
 
 	group->memQuotaUsed += slotMemQuota;

--- a/src/test/isolation2/input/resgroup/resgroup_memory_limit.source
+++ b/src/test/isolation2/input/resgroup/resgroup_memory_limit.source
@@ -139,6 +139,41 @@ CREATE ROLE role1_memory_test RESOURCE GROUP rg1_memory_test;
 2q:
 1q:
 
+-- 7) QD: concurrent transactions in same group with memory_shared_quota = 100
+
+ALTER RESOURCE GROUP rg1_memory_test SET memory_shared_quota 100;
+
+1: SET ROLE TO role1_memory_test;
+1: BEGIN;
+1: SELECT hold_memory_by_percent(1,0.6);
+2: SET ROLE TO role1_memory_test;
+2: BEGIN;
+2: SELECT hold_memory_by_percent(1,0.3);
+2q:
+2: SET ROLE TO role1_memory_test;
+2: BEGIN;
+2: SELECT hold_memory_by_percent(1,0.2);
+2: SELECT hold_memory_by_percent(1,0.2);
+2q:
+1q:
+
+-- 8) QE: concurrent transactions in same group with memory_shared_quota = 100
+
+ALTER RESOURCE GROUP rg1_memory_test SET memory_shared_quota 100;
+
+1: SET ROLE TO role1_memory_test;
+1: BEGIN;
+1: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(t1.dbid,0.6)=0;
+2: SET ROLE TO role1_memory_test;
+2: BEGIN;
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(t1.dbid,0.3)=0;
+2q:
+2: SET ROLE TO role1_memory_test;
+2: BEGIN;
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(t1.dbid,0.2)=0;
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(t1.dbid,0.2)=0;
+2q:
+1q:
 
 -- cleanup
 DROP ROLE role1_memory_test;

--- a/src/test/isolation2/output/resgroup/resgroup_memory_limit.source
+++ b/src/test/isolation2/output/resgroup/resgroup_memory_limit.source
@@ -295,6 +295,86 @@ SQL function "hold_memory_by_percent" statement 1
 2q: ... <quitting>
 1q: ... <quitting>
 
+-- 7) QD: concurrent transactions in same group with memory_shared_quota = 100
+
+ALTER RESOURCE GROUP rg1_memory_test SET memory_shared_quota 100;
+ALTER
+
+1: SET ROLE TO role1_memory_test;
+SET
+1: BEGIN;
+BEGIN
+1: SELECT hold_memory_by_percent(1,0.6);
+hold_memory_by_percent
+----------------------
+0                     
+(1 row)
+2: SET ROLE TO role1_memory_test;
+SET
+2: BEGIN;
+BEGIN
+2: SELECT hold_memory_by_percent(1,0.3);
+hold_memory_by_percent
+----------------------
+0                     
+(1 row)
+2q: ... <quitting>
+2: SET ROLE TO role1_memory_test;
+SET
+2: BEGIN;
+BEGIN
+2: SELECT hold_memory_by_percent(1,0.2);
+hold_memory_by_percent
+----------------------
+0                     
+(1 row)
+2: SELECT hold_memory_by_percent(1,0.2);
+ERROR:  Out of memory
+DETAIL:  Resource group memory limit reached
+CONTEXT:  SQL function "hold_memory_by_percent" statement 1
+2q: ... <quitting>
+1q: ... <quitting>
+
+-- 8) QE: concurrent transactions in same group with memory_shared_quota = 100
+
+ALTER RESOURCE GROUP rg1_memory_test SET memory_shared_quota 100;
+ALTER
+
+1: SET ROLE TO role1_memory_test;
+SET
+1: BEGIN;
+BEGIN
+1: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(t1.dbid,0.6)=0;
+count
+-----
+0    
+(1 row)
+2: SET ROLE TO role1_memory_test;
+SET
+2: BEGIN;
+BEGIN
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(t1.dbid,0.3)=0;
+count
+-----
+0    
+(1 row)
+2q: ... <quitting>
+2: SET ROLE TO role1_memory_test;
+SET
+2: BEGIN;
+BEGIN
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(t1.dbid,0.2)=0;
+count
+-----
+0    
+(1 row)
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(t1.dbid,0.2)=0;
+ERROR:  Out of memory  (seg0 slice1 192.168.99.102:25432 pid=18476)
+DETAIL:  
+Resource group memory limit reached
+SQL function "hold_memory_by_percent" statement 1
+2q: ... <quitting>
+1q: ... <quitting>
 
 -- cleanup
 DROP ROLE role1_memory_test;


### PR DESCRIPTION
A query will be put in the waiting queue if it cannot get some per slot
memory quota. However per slot memory slot is just expected to be 0 when
memory_shared_quota is 100, so a query hangs infinitely in such a case.

To fix this we now distinguish the "no enough quota" and "zero quota"
cases.