### PR TITLE
docs: gpload - YAML ERROR_TABLE element backward compatibility

### DIFF
--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpload.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpload.xml
@@ -803,9 +803,9 @@ OUTPUT:
    - TABLE: public.'"MyTable"'</codeblock>
             <p>If the YAML control file contains the <codeph>ERROR_TABLE</codeph> element that was
                 available in Greenplum Database 4.3.x, <codeph>gpload</codeph> logs a warning
-                stating that <codeph>ERROR_TABLE</codeph> is not supported the and handles load
-                errors as if the <codeph>LOG_ERRORS</codeph> and <codeph>REUSE_TABLE</codeph>
-                elements are set to <codeph>true</codeph>. Rows with formatting errors are logged
+                stating that <codeph>ERROR_TABLE</codeph> is not supported, and load errors are
+                handled as if the <codeph>LOG_ERRORS</codeph> and <codeph>REUSE_TABLE</codeph>
+                elements were set to <codeph>true</codeph>. Rows with formatting errors are logged
                 internally when running in single row error isolation mode.</p>
         </section>
         <section id="section10">

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpload.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpload.xml
@@ -801,6 +801,12 @@ INFO|<varname>#</varname> bad rows</codeblock>
    - '"MyColumn"': text
 OUTPUT:
    - TABLE: public.'"MyTable"'</codeblock>
+            <p>If the YAML control file contains the <codeph>ERROR_TABLE</codeph> element that was
+                available in Greenplum Database 4.3.x, <codeph>gpload</codeph> logs a warning
+                stating that <codeph>ERROR_TABLE</codeph> is not supported the and handles load
+                errors as if the <codeph>LOG_ERRORS</codeph> and <codeph>REUSE_TABLE</codeph>
+                elements are set to <codeph>true</codeph>. Rows with formatting errors are logged
+                internally when running in single row error isolation mode.</p>
         </section>
         <section id="section10">
             <title>Examples</title>


### PR DESCRIPTION
In 5.x, ERROR_TABLE in the YAML file was removed and returns an error.

Now, for backward compatibility, gpload issues a warning and 
uses LOG_ERRORS and REUSE_TABLE set to true.

see PR https://github.com/greenplum-db/gpdb/pull/3848

PR for 5X_STABLE
Will be ported to MAIN