### PR TITLE
Don't pushdown qual if subquery contains window functions

### DIFF
--- a/src/test/regress/expected/olap_window.out
+++ b/src/test/regress/expected/olap_window.out
@@ -8309,6 +8309,8 @@ i | sum
 6 |   6
 (4 rows)
 
+-- Should not push-down predicates referring to window functions in the subquery which is the source for the insertion
+insert into window_preds select k from ( select row_number() over() as k from window_preds union all select row_number() over() as k from window_preds) as t where k = 1;
 -- MPP-19964
 drop table if exists customers_test;
 NOTICE:  table "customers_test" does not exist, skipping

--- a/src/test/regress/expected/olap_window_optimizer.out
+++ b/src/test/regress/expected/olap_window_optimizer.out
@@ -8312,6 +8312,8 @@ select * from (select i, sum(i) over(partition by j) from (select i,j, row_numbe
  6 |   6
 (4 rows)
 
+-- Should not push-down predicates referring to window functions in the subquery which is the source for the insertion
+insert into window_preds select k from ( select row_number() over() as k from window_preds union all select row_number() over() as k from window_preds) as t where k = 1;
 -- MPP-19964
 drop table if exists customers_test;
 NOTICE:  table "customers_test" does not exist, skipping

--- a/src/test/regress/sql/olap_window.sql
+++ b/src/test/regress/sql/olap_window.sql
@@ -1605,6 +1605,9 @@ select * from (select i,j,k, sum(i) over(partition by i,j), row_number() over(pa
 select * from (select i,j,k, sum(i) over(partition by i,j), row_number() over(partition by i,j), rank() over(partition by i,j order by i) from window_preds) as foo where i+j>2 order by sum;
 select * from (select i, sum(i) over(partition by j) from (select i,j, row_number() over(partition by i) from window_preds) as bar) as foo where i>2 order by sum;
 
+-- Should not push-down predicates referring to window functions in the subquery which is the source for the insertion
+insert into window_preds select k from ( select row_number() over() as k from window_preds union all select row_number() over() as k from window_preds) as t where k = 1;
+
 -- MPP-19964
 drop table if exists customers_test;
 create table customers_test(name text, device_model text, device_id integer, ppp numeric) distributed by (device_id);


### PR DESCRIPTION
In the case of a query like the following:

INSERT INTO foo SELECT k FROM (SELECT ROW_NUMBER() OVER() AS k FROM foo
UNION ALL SELECT ROW_NUMBER() OVER() AS k FROM foo) AS t WHERE k = 1;

planner incorrectly pushed down the qual, k=1 causing an error in
execQual. While evaluating whether the qual is pushdown safe, we check
for window references in qual_contains_winref(), however, the function
incorrectly uses var numbers to check for pushdown safety. In the case
of INSERT queries, the root rtable and the subquery rtable are not
comparable, hence, we fail this check and consider the qual pushdown
safe.
We can do this check cleanly and elegantly in
subquery_is_pushdown_safe() similar to the way upstream does it. Hence
subquery_is_pushdown_safe() is modified to bail out from qual pushdown
if the subquery has any window references.

Signed-off-by: Melanie Plageman <melanieplageman@pivotal.io>