### PR TITLE
Make orafce build without PGXS

### DIFF
--- a/gpAux/extensions/orafce/Makefile
+++ b/gpAux/extensions/orafce/Makefile
@@ -16,7 +16,7 @@ PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 else
 subdir = contrib/orafce
-top_builddir = ../..
+top_builddir = ../../..
 include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk
 endif


### PR DESCRIPTION
While there is a target in gpAux/extensions for building orafuncs, we might as well allow it to be built without PGXS as well which is handy for quick compile tests. Set the correct path to the builddir such that Makefile dependencies can be picked up.