### PR TITLE
gpdeletesystem show too many blank lines

### DIFF
--- a/gpMgmt/bin/gpdeletesystem
+++ b/gpMgmt/bin/gpdeletesystem
@@ -165,14 +165,14 @@ def display_params(options, dburl, standby, segments, dumpDirsExist):
         port = segdb.getSegmentPort()
         logger.info('%s:%s:%s' % (host, datadir, port))
 
-    yn = ask_yesno('', 'Continue with Greenplum instance deletion?', 'N')
+    yn = ask_yesno(None, '\nContinue with Greenplum instance deletion?', 'N')
     if yn:
         logger.info('FINAL WARNING, you are about to delete the Greenplum instance')
         logger.info('on master host %s.' % dburl.pghost)
         if dumpDirsExist and options.force:
             logger.warn('There are database dump files, these will be DELETED if you continue!')
             g_warnings_generated = True
-        yn = ask_yesno('', 'Continue with Greenplum instance deletion?', 'N')
+        yn = ask_yesno(None, '\nContinue with Greenplum instance deletion?', 'N')
         if not yn:
             raise GpDeleteSystemException('User canceled')
     else:


### PR DESCRIPTION
When I use the command gpdeletesystem to delete the cluster, I found a lot of blank lines.

$ gpdeletesystem
...
0171113:17:20:31:003115 gpdeletesystem:node:gp5.0-[INFO]:-node:/data1/gp5.0/primary/gpseg0:40015


Continue with Greenplum instance deletion? Yy|Nn (default=N):
 > y
20171113:17:20:33:003115 gpdeletesystem:node:gp5.0-[INFO]:-FINAL WARNING, you are about to delete the Greenplum instance
20171113:17:20:33:003115 gpdeletesystem:node:gp5.0-[INFO]:-on master host 127.0.0.1.


Continue with Greenplum instance deletion? Yy|Nn (default=N):
 > n
20171113:17:20:40:003115 gpdeletesystem:node:gp5.0-[INFO]:-User canceled
20171113:17:20:40:003115 gpdeletesystem:node:gp5.0-[ERROR]:-Delete system failed

**The result of the modification:**
$ gpdeletesystem
...
20171113:17:21:32:003130 gpdeletesystem:node:gp5.0-[INFO]:-node:/data1/gp5.0/master/gpseg-1:9432
20171113:17:21:32:003130 gpdeletesystem:node:gp5.0-[INFO]:-node:/data1/gp5.0/primary/gpseg0:40015

Continue with Greenplum instance deletion? Yy|Nn (default=N):
 > y
20171113:17:21:33:003130 gpdeletesystem:node:gp5.0-[INFO]:-FINAL WARNING, you are about to delete the Greenplum instance
20171113:17:21:33:003130 gpdeletesystem:node:gp5.0-[INFO]:-on master host 127.0.0.1.

Continue with Greenplum instance deletion? Yy|Nn (default=N):
 > n
20171113:17:21:34:003130 gpdeletesystem:node:gp5.0-[INFO]:-User canceled
20171113:17:21:34:003130 gpdeletesystem:node:gp5.0-[ERROR]:-Delete system failed

**gpstart example**
$ gpstart
...
20171113:17:21:55:003306 gpstart:node:gp5.0-[INFO]:-   node   /data1/gp5.0/primary/gpseg0   40015

Continue with Greenplum instance startup Yy|Nn (default=N):
 > y
20171113:17:21:56:003306 gpstart:node:gp5.0-[INFO]:-Commencing parallel segment instance startup, 
...

**related code**
def ask_input(bg_info,msg,help,default,validator, *validator_opts):
    if bg_info is not None:    
        print "%s\n" % bg_info
