### PR TITLE
docs - pxf with oss greenplum

### DIFF
--- a/gpdb-doc/markdown/common/gpdb-features.html.md.erb
+++ b/gpdb-doc/markdown/common/gpdb-features.html.md.erb
@@ -54,4 +54,6 @@ the Greenplum hosts.
 
 - The deprecated <codeph>gpcheck</codeph> management utility and its replacement <codeph>gpsupport</codeph> are only supported with Pivotal Greenplum Database. 
 
+- To use the Greenplum Platform Extension Framework (PXF) with open source Greenplum Database, you must separately build and install the PXF server software. Refer to the build instructions in the PXF README files in the Greenplum Database and Apache HAWQ (incubating) repositories.
+
 - Suggestions to contact Pivotal Technical Support in this documentation are intended only for Pivotal Greenplum Database customers. 


### PR DESCRIPTION
PXF edits to the open source greenplum docs landing page:
- requires that the pxf server bits be built and installed separately
- refers to pxf readmes in greenplum database and apache hawq repos