### PR TITLE
Fix regression in intorel_receive for wal logging.

### DIFF
--- a/contrib/gp_replica_check/Makefile
+++ b/contrib/gp_replica_check/Makefile
@@ -10,4 +10,4 @@ include $(PGXS)
 # For now run only for HEAP as for other object types like Sequence, AO, btree
 # there are still known differences to be fixed.
 installcheck: install
-	gp_replica_check.py -r="heap"
+	gp_replica_check.py -r="heap, sequence"

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -5208,7 +5208,7 @@ intorel_receive(TupleTableSlot *slot, DestReceiver *self)
 		heap_insert(into_rel,
 					tuple,
 					myState->estate->es_output_cid,
-					myState->is_bulkload,
+					!myState->is_bulkload,
 					false, /* never any point in using FSM */
 					GetCurrentTransactionId());
 


### PR DESCRIPTION

    Refactor to use use_wal instead of is_bulkload.

    `DR_intorel` had redundant fields `use_wal` and `is_bulkload`, serving the same
    purpose. So, cleanup code to leverage `use_wal` throughout and remove
    `is_bulkload`.


    Fix regression in intorel_receive.

    Commit fa287d01b8b8f989b85d1ad69a2f42da6d762b4a missed retaining the original
    negation for `is_bulkload` argument to `heap_insert()`. So, in case bulkload
    being false, the use_wal also became false and no xlog records were getting
    generated. Commit b8f8fccc2d56d7a960a50d4ed5653b4b6ffdef78 attempted to fix it
    but just didn't fix the nagation at right place.