### PR TITLE
Remove unused external declaration

### DIFF
--- a/src/include/commands/tablecmds.h
+++ b/src/include/commands/tablecmds.h
@@ -47,8 +47,6 @@ extern Oid	DefineRelation(CreateStmt *stmt, char relkind, char relstorage, bool 
 
 extern void	DefineExternalRelation(CreateExternalStmt *stmt);
 
-extern void DefineForeignRelation(CreateForeignStmt *createForeignStmt);
-
 extern void	DefinePartitionedRelation(CreateStmt *stmt, Oid reloid);
 
 extern void EvaluateDeferredStatements(List *deferredStmts);


### PR DESCRIPTION
The function DefineForeignRelation referenced in utility.c was removed
in 601c58c33aa.