### PR TITLE
Fix typo in gprecoverseg

### DIFF
--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -355,7 +355,7 @@ class GpMirrorListToBuild:
                 raise
         else:
             try:
-                print 'updating flat files'
+                self.__logger.info("Updating flat files")
                 UpdateFlatFiles(gpArray, primaries=False).run()
             except MoveFilespaceError, e:
                 self.__logger.error(str(e))


### PR DESCRIPTION
$ gprecoverseg 
...
20171113:23:01:33:053614 gprecoverseg:node:gp5.0-[INFO]:-Ensuring that shared memory is cleaned up for stopped segments
**updating flat files**
20171113:23:01:33:053614 gprecoverseg:node:gp5.0-[INFO]:-Updating configuration with new mirrors
...

**The result of the modification:**
$ gprecoverseg
...
20171114:00:05:53:055658 gprecoverseg:node:gp5.0-[INFO]:-Ensuring that shared memory is cleaned up for stopped segments
**20171114:00:05:54:055658 gprecoverseg:node:gp5.0-[INFO]:-Updating flat files**
20171114:00:05:54:055658 gprecoverseg:node:gp5.0-[INFO]:-Updating configuration with new mirrors
...