### PR TITLE
Silence warnings about deprecated bison flags.

### DIFF
--- a/gpAux/extensions/gpmapreduce/Makefile
+++ b/gpAux/extensions/gpmapreduce/Makefile
@@ -36,7 +36,6 @@ MAPREDOBJS= $(addprefix $(BUILDDIR)/, $(FILES))
 GENOBJS   = $(addprefix $(SRCDIR)/, $(GENFILES))
 
 FLEXFLAGS = -i
-BISONFLAGS = -d
 
 all: submake-libpq gpmapreduce all-lib
 
@@ -59,7 +58,7 @@ $(SRCDIR)/yaml_parse.h: $(SRCDIR)/yaml_parse.c
 $(SRCDIR)/yaml_parse.c: $(SRCDIR)/yaml_parse.y
 ifdef BISON
 	@cd $(SRCDIR) ; \
-	$(BISON) $(BISONFLAGS) yaml_parse.y
+	$(BISON) -d $(BISONFLAGS) yaml_parse.y
 else
 	@$(missing) bison $< $@
 endif


### PR DESCRIPTION
In Makefile.global, we set BISONFLAGS to "-Wno-deprecated". Don't override
that in the gpmapreduce's Makefile. Put the -d flag directly to the bison
invocation's command-line, like it's done e.g. in src/backend/parser.