### PR TITLE
Use the new 8.3 style when printing Access Privileges in psql.

### DIFF
--- a/src/bin/psql/describe.c
+++ b/src/bin/psql/describe.c
@@ -871,17 +871,7 @@ permissionsList(const char *pattern)
 	   gettext_noop("table"), gettext_noop("view"), gettext_noop("sequence"),
 					  gettext_noop("Type"));
 
-	if (strcmp(get_line_style(&pset.popt.topt)->name,"old-ascii") != 0)
-	{
-	/*
-	 * This new code, which produces a more correct and more useful answer, is disabled
-	 * for the moment if the print format is old-ascii, because we'd need to upgrade the regression tests (cdbfast and make installcheck-good).
-	 */
 	printACLColumn(&buf, "c.relacl");
-	}
-	else
-	appendPQExpBuffer(&buf, "c.relacl as \"Access privileges\"");  /* Old style, pre-8.3 */
-
 
 	// GPDB_84_MERGE_FIXME: We haven't merged the patch that added attacl yet.
 #if 0
@@ -919,15 +909,7 @@ permissionsList(const char *pattern)
 
 	myopt.nullPrint = NULL;
 
-    if (strcmp(get_line_style(&pset.popt.topt)->name,"old-ascii") == 0)
-	{
-	    printfPQExpBuffer(&buf, _("Access privileges for database \"%s\""), PQdb(pset.db));
-	}
-	else
-	{
-		/* Current pgsql does it this way, but I've disabled this and am doing it the old way above to avoid breaking regression tests */
-	    printfPQExpBuffer(&buf, _("Access privileges"));
-	}
+	printfPQExpBuffer(&buf, _("Access privileges"));
 
 	myopt.title = buf.data;
 	myopt.translate_header = true;
@@ -1609,8 +1591,7 @@ describeOneTableDetails(const char *schemaname,
 		printTableAddHeader(&cont, headers[i], true, 'l');
 
 	/* Check if table is a view */
-	/* GPDB_84_MERGE_FIXME: look into the below comment.. can we take "&& verbose" ? */
-	if (tableinfo.relkind == 'v' /* && verbose  ***  GPDB change:  Do this even if not verbose, for 8.2 compatibility */)
+	if (tableinfo.relkind == 'v' && verbose)
 	{
 		PGresult   *result;
 
@@ -3231,11 +3212,7 @@ listTables(const char *tabtypes, const char *pattern, bool verbose, bool showSys
 						  ",\n c2.relname as \"%s\"",
 						  gettext_noop("Table"));
 
-	/*
-	 * GPDB:  Stupid check to see if we are using old-ascii, and therefore are possibly running regression tests, which haven't
-	 * been updated to expect the Size column in the result
-	 */
-	if (verbose && pset.sversion >= 80100 && strcmp(get_line_style(&pset.popt.topt)->name,"old-ascii") != 0)
+	if (verbose && pset.sversion >= 80100)
 		appendPQExpBuffer(&buf,
 						  ",\n  pg_catalog.pg_size_pretty(pg_catalog.pg_relation_size(c.oid)) as \"%s\"",
 						  gettext_noop("Size"));

--- a/src/test/regress/expected/dependency.out
+++ b/src/test/regress/expected/dependency.out
@@ -68,19 +68,21 @@ NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "deptest_pkey" fo
 GRANT ALL ON deptest1 TO regression_user2;
 RESET SESSION AUTHORIZATION;
 \z deptest1
-                                                          Access privileges for database "regression"
- Schema |   Name   | Type  |                                                         Access privileges                                                          
---------+----------+-------+----------------------------------------------------------------------------------------------------------------------------------------
- public | deptest1 | table | {regression_user0=arwdDxt/regression_user0,regression_user1=a*r*w*d*D*x*t*/regression_user0,regression_user2=arwdDxt/regression_user1}
+                              Access privileges
+ Schema |   Name   | Type  |                Access privileges                 
+--------+----------+-------+--------------------------------------------------
+ public | deptest1 | table | regression_user0=arwdDxt/regression_user0
+                           : regression_user1=a*r*w*d*D*x*t*/regression_user0
+                           : regression_user2=arwdDxt/regression_user1
 (1 row)
 
 DROP OWNED BY regression_user1;
 -- all grants revoked
 \z deptest1
-              Access privileges for database "regression"
- Schema |   Name   | Type  |             Access privileges              
---------+----------+-------+---------------------------------------------
- public | deptest1 | table | {regression_user0=arwdDxt/regression_user0}
+                           Access privileges
+ Schema |   Name   | Type  |             Access privileges             
+--------+----------+-------+-------------------------------------------
+ public | deptest1 | table | regression_user0=arwdDxt/regression_user0
 (1 row)
 
 -- table was dropped

--- a/src/test/regress/expected/olap_group.out
+++ b/src/test/regress/expected/olap_group.out
@@ -2857,40 +2857,40 @@ select grouping(cn,vn,pn) from sale group by rollup(cn); --error
 ERROR:  column "sale"."vn" is not in GROUP BY
 -- Using in View --
 create view cube_view as select cn,vn,grouping(vn,cn) from sale group by cube(cn,vn);
-\d cube_view;
-    View "public.cube_view"
-  Column  |  Type   | Modifiers 
-----------+---------+-----------
- cn       | integer | 
- vn       | integer | 
- grouping | bigint  | 
+\d+ cube_view;
+                View "public.cube_view"
+  Column  |  Type   | Modifiers | Storage | Description 
+----------+---------+-----------+---------+-------------
+ cn       | integer |           | plain   | 
+ vn       | integer |           | plain   | 
+ grouping | bigint  |           | plain   | 
 View definition:
  SELECT sale.cn, sale.vn, grouping(sale.vn, sale.cn) AS "grouping"
    FROM sale
   GROUP BY CUBE (sale.cn, sale.vn);
 
 create view rollup_view as select cn,vn,pn,grouping(cn,vn,pn) from sale group by rollup(cn),vn,pn;
-\d rollup_view;
-   View "public.rollup_view"
-  Column  |  Type   | Modifiers 
-----------+---------+-----------
- cn       | integer | 
- vn       | integer | 
- pn       | integer | 
- grouping | bigint  | 
+\d+ rollup_view;
+               View "public.rollup_view"
+  Column  |  Type   | Modifiers | Storage | Description 
+----------+---------+-----------+---------+-------------
+ cn       | integer |           | plain   | 
+ vn       | integer |           | plain   | 
+ pn       | integer |           | plain   | 
+ grouping | bigint  |           | plain   | 
 View definition:
  SELECT sale.cn, sale.vn, sale.pn, grouping(sale.cn, sale.vn, sale.pn) AS "grouping"
    FROM sale
   GROUP BY sale.vn, sale.pn, ROLLUP (sale.cn);
 
 create view gs_view as select cn,vn,grouping(vn,cn) from sale group by grouping sets ((vn), (cn), (), (cn,vn));
-\d gs_view;
-     View "public.gs_view"
-  Column  |  Type   | Modifiers 
-----------+---------+-----------
- cn       | integer | 
- vn       | integer | 
- grouping | bigint  | 
+\d+ gs_view;
+                 View "public.gs_view"
+  Column  |  Type   | Modifiers | Storage | Description 
+----------+---------+-----------+---------+-------------
+ cn       | integer |           | plain   | 
+ vn       | integer |           | plain   | 
+ grouping | bigint  |           | plain   | 
 View definition:
  SELECT sale.cn, sale.vn, grouping(sale.vn, sale.cn) AS "grouping"
    FROM sale
@@ -5670,31 +5670,31 @@ select count(*) from sale group by grouping sets((), ());
 create view grp_v1 as select count(*) from sale group by ();
 create view grp_v2 as select count(*) from sale group by grouping sets(());
 create view grp_v3 as select count(*) from sale group by grouping sets((), ());
-\d grp_v1;
-    View "public.grp_v1"
- Column |  Type  | Modifiers 
---------+--------+-----------
- count  | bigint | 
+\d+ grp_v1;
+                View "public.grp_v1"
+ Column |  Type  | Modifiers | Storage | Description 
+--------+--------+-----------+---------+-------------
+ count  | bigint |           | plain   | 
 View definition:
  SELECT count(*) AS count
    FROM sale
   GROUP BY ();
 
-\d grp_v2;
-    View "public.grp_v2"
- Column |  Type  | Modifiers 
---------+--------+-----------
- count  | bigint | 
+\d+ grp_v2;
+                View "public.grp_v2"
+ Column |  Type  | Modifiers | Storage | Description 
+--------+--------+-----------+---------+-------------
+ count  | bigint |           | plain   | 
 View definition:
  SELECT count(*) AS count
    FROM sale
   GROUP BY GROUPING SETS (());
 
-\d grp_v3;
-    View "public.grp_v3"
- Column |  Type  | Modifiers 
---------+--------+-----------
- count  | bigint | 
+\d+ grp_v3;
+                View "public.grp_v3"
+ Column |  Type  | Modifiers | Storage | Description 
+--------+--------+-----------+---------+-------------
+ count  | bigint |           | plain   | 
 View definition:
  SELECT count(*) AS count
    FROM sale

--- a/src/test/regress/expected/olap_window_seq.out
+++ b/src/test/regress/expected/olap_window_seq.out
@@ -7502,12 +7502,12 @@ FROM (SELECT * FROM sale) sale; --mvd 3,4,5->6; 3,4->7
 create view v1 as
 select dt, sum(cn) over(order by grouping(cn) range grouping(cn) preceding) 
 from sale group by rollup(cn,dt);
-\d v1
-      View "public.v1"
- Column |  Type  | Modifiers 
---------+--------+-----------
- dt     | date   | 
- sum    | bigint | 
+\d+ v1
+                  View "public.v1"
+ Column |  Type  | Modifiers | Storage | Description 
+--------+--------+-----------+---------+-------------
+ dt     | date   |           | plain   | 
+ sum    | bigint |           | plain   | 
 View definition:
  SELECT "Window".dt, sum("Window".cn) OVER (
  ORDER BY "Window".att_3 RANGE "Window".att_3 PRECEDING) AS sum

--- a/src/test/regress/expected/olap_window_seq_optimizer.out
+++ b/src/test/regress/expected/olap_window_seq_optimizer.out
@@ -7503,12 +7503,12 @@ FROM (SELECT * FROM sale) sale; --mvd 3,4,5->6; 3,4->7
 create view v1 as
 select dt, sum(cn) over(order by grouping(cn) range grouping(cn) preceding) 
 from sale group by rollup(cn,dt);
-\d v1
-      View "public.v1"
- Column |  Type  | Modifiers 
---------+--------+-----------
- dt     | date   | 
- sum    | bigint | 
+\d+ v1
+                  View "public.v1"
+ Column |  Type  | Modifiers | Storage | Description 
+--------+--------+-----------+---------+-------------
+ dt     | date   |           | plain   | 
+ sum    | bigint |           | plain   | 
 View definition:
  SELECT "Window".dt, sum("Window".cn) OVER (
  ORDER BY "Window".att_3 RANGE "Window".att_3 PRECEDING) AS sum

--- a/src/test/regress/expected/privileges.out
+++ b/src/test/regress/expected/privileges.out
@@ -678,28 +678,39 @@ grant select on dep_priv_test to regressuser4 with grant option;
 set session role regressuser4;
 grant select on dep_priv_test to regressuser5;
 \dp dep_priv_test
-                                                                                     Access privileges for database "regression"
- Schema |     Name      | Type  |                                                                                  Access privileges                                                                                  
---------+---------------+-------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- public | dep_priv_test | table | {regressuser1=arwdDxt/regressuser1,regressuser2=r*/regressuser1,regressuser3=r*/regressuser1,regressuser4=r*/regressuser2,regressuser4=r*/regressuser3,regressuser5=r/regressuser4}
+                         Access privileges
+ Schema |     Name      | Type  |         Access privileges         
+--------+---------------+-------+-----------------------------------
+ public | dep_priv_test | table | regressuser1=arwdDxt/regressuser1 
+                                : regressuser2=r*/regressuser1      
+                                : regressuser3=r*/regressuser1      
+                                : regressuser4=r*/regressuser2      
+                                : regressuser4=r*/regressuser3      
+                                : regressuser5=r/regressuser4
 (1 row)
 
 set session role regressuser2;
 revoke select on dep_priv_test from regressuser4 cascade;
 \dp dep_priv_test
-                                                         Access privileges for database "regression"
- Schema |     Name      | Type  |                                                     Access privileges                                                      
---------+---------------+-------+--------------------------------------------------------------------------------------------------------------------------------------------------------
- public | dep_priv_test | table | {regressuser1=arwdDxt/regressuser1,regressuser2=r*/regressuser1,regressuser3=r*/regressuser1,regressuser4=r*/regressuser3,regressuser5=r/regressuser4}
+                         Access privileges
+ Schema |     Name      | Type  |         Access privileges         
+--------+---------------+-------+-----------------------------------
+ public | dep_priv_test | table | regressuser1=arwdDxt/regressuser1 
+                                : regressuser2=r*/regressuser1      
+                                : regressuser3=r*/regressuser1      
+                                : regressuser4=r*/regressuser3      
+                                : regressuser5=r/regressuser4
 (1 row)
 
 set session role regressuser3;
 revoke select on dep_priv_test from regressuser4 cascade;
 \dp dep_priv_test
-                                          Access privileges for database "regression"
- Schema |     Name      | Type  |                                       Access privileges                                       
---------+---------------+-------+-----------------------------------------------------------------------------------------------
- public | dep_priv_test | table | {regressuser1=arwdDxt/regressuser1,regressuser2=r*/regressuser1,regressuser3=r*/regressuser1}
+                         Access privileges
+ Schema |     Name      | Type  |         Access privileges         
+--------+---------------+-------+-----------------------------------
+ public | dep_priv_test | table | regressuser1=arwdDxt/regressuser1 
+                                : regressuser2=r*/regressuser1      
+                                : regressuser3=r*/regressuser1
 (1 row)
 
 set session role regressuser1;

--- a/src/test/regress/expected/qp_with_clause.out
+++ b/src/test/regress/expected/qp_with_clause.out
@@ -9191,19 +9191,19 @@ from longlivingregions,denseregions,allcountrystats,country
 where longlivingregions.region = denseregions.region and allcountrystats.code = country.code and country.region = longlivingregions.region
 and country.indepyear > 1900
 );
-\d view_with_shared_scans;
-    View "qp_with_clause.view_with_shared_scans"
-       Column        |       Type       | Modifiers 
----------------------+------------------+-----------
- city_cnt            | bigint           | 
- lang_cnt            | bigint           | 
- name                | text             | 
- REGION_SURFACE_AREA | numeric          | 
- REGION_LIFETIME     | double precision | 
- REGION_POP          | bigint           | 
- lang_count          | bigint           | 
- REGION_GNP          | numeric          | 
- region              | text             | 
+\d+ view_with_shared_scans;
+                View "qp_with_clause.view_with_shared_scans"
+       Column        |       Type       | Modifiers | Storage  | Description 
+---------------------+------------------+-----------+----------+-------------
+ city_cnt            | bigint           |           | plain    | 
+ lang_cnt            | bigint           |           | plain    | 
+ name                | text             |           | extended | 
+ REGION_SURFACE_AREA | numeric          |           | main     | 
+ REGION_LIFETIME     | double precision |           | plain    | 
+ REGION_POP          | bigint           |           | plain    | 
+ lang_count          | bigint           |           | plain    | 
+ REGION_GNP          | numeric          |           | main     | 
+ region              | text             |           | extended | 
 View definition:
  WITH longlivingregions AS (
          SELECT foo."REGION_POP", foo."REGION_GNP", foo."REGION_LIFETIME", foo.region, count(DISTINCT countrylanguage.language) AS lang_count

--- a/src/test/regress/expected/qp_with_functional_inlining.out
+++ b/src/test/regress/expected/qp_with_functional_inlining.out
@@ -529,11 +529,11 @@ CREATE VIEW cte_view as
     INTERSECT 
     SELECT a FROM foo limit 10
 )SELECT * FROM CTE);
-\d cte_view
-    View "qp_with_functional.cte_view"
- Column |  Type   | Modifiers 
---------+---------+-----------
- e      | integer | 
+\d+ cte_view
+     View "qp_with_functional_inlining.cte_view"
+ Column |  Type   | Modifiers | Storage | Description 
+--------+---------+-----------+---------+-------------
+ e      | integer |           | plain   | 
 View definition:
  WITH cte(e) AS (
                  SELECT bar.d
@@ -569,12 +569,12 @@ CREATE VIEW cte_view as
       cte2(e,f) AS (SELECT e,d FROM bar, cte WHERE cte.e = bar.c )
 SELECT cte2.e,cte.f FROM cte,cte2 where cte.e = cte2.e
 );
-\d cte_view
-    View "qp_with_functional.cte_view"
- Column |  Type   | Modifiers 
---------+---------+-----------
- e      | integer | 
- f      | integer | 
+\d+ cte_view
+     View "qp_with_functional_inlining.cte_view"
+ Column |  Type   | Modifiers | Storage | Description 
+--------+---------+-----------+---------+-------------
+ e      | integer |           | plain   | 
+ f      | integer |           | plain   | 
 View definition:
  WITH cte(e, f) AS (
          SELECT foo.a, bar.d

--- a/src/test/regress/expected/qp_with_functional_noinlining.out
+++ b/src/test/regress/expected/qp_with_functional_noinlining.out
@@ -528,11 +528,11 @@ CREATE VIEW cte_view as
     INTERSECT 
     SELECT a FROM foo limit 10
 )SELECT * FROM CTE);
-\d cte_view
-    View "qp_with_functional.cte_view"
- Column |  Type   | Modifiers 
---------+---------+-----------
- e      | integer | 
+\d+ cte_view
+     View "qp_with_functional_inlining.cte_view"
+ Column |  Type   | Modifiers | Storage | Description 
+--------+---------+-----------+---------+-------------
+ e      | integer |           | plain   | 
 View definition:
  WITH cte(e) AS (
                  SELECT bar.d
@@ -568,12 +568,12 @@ CREATE VIEW cte_view as
       cte2(e,f) AS (SELECT e,d FROM bar, cte WHERE cte.e = bar.c )
 SELECT cte2.e,cte.f FROM cte,cte2 where cte.e = cte2.e
 );
-\d cte_view
-    View "qp_with_functional.cte_view"
- Column |  Type   | Modifiers 
---------+---------+-----------
- e      | integer | 
- f      | integer | 
+\d+ cte_view
+     View "qp_with_functional_inlining.cte_view"
+ Column |  Type   | Modifiers | Storage | Description 
+--------+---------+-----------+---------+-------------
+ e      | integer |           | plain   | 
+ f      | integer |           | plain   | 
 View definition:
  WITH cte(e, f) AS (
          SELECT foo.a, bar.d

--- a/src/test/regress/input/table_functions.source
+++ b/src/test/regress/input/table_functions.source
@@ -512,7 +512,7 @@ CREATE VIEW v1 AS
 
 SELECT * FROM v1 order by a, b;
 
-\d v1
+\d+ v1
 
 SELECT pg_get_viewdef('v1'::regclass);
 
@@ -522,7 +522,7 @@ CREATE VIEW v2 AS
 
 SELECT * FROM v2 order by a, b;
 
-\d v2
+\d+ v2
 
 SELECT pg_get_viewdef('v2'::regclass);
 
@@ -531,7 +531,7 @@ CREATE VIEW v3 AS
 
 SELECT * FROM v3 order by a, b;
 
-\d v3
+\d+ v3
 
 SELECT pg_get_viewdef('v3'::regclass);
 

--- a/src/test/regress/output/table_functions.source
+++ b/src/test/regress/output/table_functions.source
@@ -2134,12 +2134,12 @@ SELECT * FROM v1 order by a, b;
  4 |  value4.1/1
 (10 rows)
 
-\d v1
+\d+ v1
    View "table_function.v1"
- Column |  Type   | Modifiers 
---------+---------+-----------
- a      | integer | 
- b      | text    | 
+ Column |  Type   | Modifiers | Storage  | Description 
+--------+---------+-----------+----------+-------------
+ a      | integer |           | plain    | 
+ b      | text    |           | extended | 
 View definition:
  SELECT tf.a, tf.b
    FROM multiset_2(TABLE( SELECT example.a, example.b
@@ -2168,12 +2168,12 @@ SELECT * FROM v2 order by a, b;
  4 |  value4.1/1
 (10 rows)
 
-\d v2
+\d+ v2
    View "table_function.v2"
- Column |  Type   | Modifiers 
---------+---------+-----------
- a      | integer | 
- b      | text    | 
+ Column |  Type   | Modifiers | Storage  | Description 
+--------+---------+-----------+----------+-------------
+ a      | integer |           | plain    | 
+ b      | text    |           | extended | 
 View definition:
  SELECT tf.a, tf.b
    FROM multiset_2(TABLE( SELECT example.a, example.b
@@ -2203,12 +2203,12 @@ SELECT * FROM v3 order by a, b;
  4 |  value4.1/1
 (10 rows)
 
-\d v3
+\d+ v3
    View "table_function.v3"
- Column |  Type   | Modifiers 
---------+---------+-----------
- a      | integer | 
- b      | text    | 
+ Column |  Type   | Modifiers | Storage  | Description 
+--------+---------+-----------+----------+-------------
+ a      | integer |           | plain    | 
+ b      | text    |           | extended | 
 View definition:
  SELECT tf.a, tf.b
    FROM multiset_2(TABLE( SELECT example.a, example.b

--- a/src/test/regress/output/table_functions_optimizer.source
+++ b/src/test/regress/output/table_functions_optimizer.source
@@ -2134,12 +2134,12 @@ SELECT * FROM v1 order by a, b;
  4 |  value4.1/1
 (10 rows)
 
-\d v1
+\d+ v1
    View "table_function.v1"
- Column |  Type   | Modifiers 
---------+---------+-----------
- a      | integer | 
- b      | text    | 
+ Column |  Type   | Modifiers | Storage  | Description 
+--------+---------+-----------+----------+-------------
+ a      | integer |           | plain    | 
+ b      | text    |           | extended | 
 View definition:
  SELECT tf.a, tf.b
    FROM multiset_2(TABLE( SELECT example.a, example.b
@@ -2168,12 +2168,12 @@ SELECT * FROM v2 order by a, b;
  4 |  value4.1/1
 (10 rows)
 
-\d v2
+\d+ v2
    View "table_function.v2"
- Column |  Type   | Modifiers 
---------+---------+-----------
- a      | integer | 
- b      | text    | 
+ Column |  Type   | Modifiers | Storage  | Description 
+--------+---------+-----------+----------+-------------
+ a      | integer |           | plain    | 
+ b      | text    |           | extended | 
 View definition:
  SELECT tf.a, tf.b
    FROM multiset_2(TABLE( SELECT example.a, example.b
@@ -2203,12 +2203,12 @@ SELECT * FROM v3 order by a, b;
  4 |  value4.1/1
 (10 rows)
 
-\d v3
+\d+ v3
    View "table_function.v3"
- Column |  Type   | Modifiers 
---------+---------+-----------
- a      | integer | 
- b      | text    | 
+ Column |  Type   | Modifiers | Storage  | Description 
+--------+---------+-----------+----------+-------------
+ a      | integer |           | plain    | 
+ b      | text    |           | extended | 
 View definition:
  SELECT tf.a, tf.b
    FROM multiset_2(TABLE( SELECT example.a, example.b

--- a/src/test/regress/sql/olap_group.sql
+++ b/src/test/regress/sql/olap_group.sql
@@ -332,11 +332,11 @@ select grouping(cn,vn,pn) from sale group by rollup(cn); --error
 -- Using in View --
 
 create view cube_view as select cn,vn,grouping(vn,cn) from sale group by cube(cn,vn);
-\d cube_view;
+\d+ cube_view;
 create view rollup_view as select cn,vn,pn,grouping(cn,vn,pn) from sale group by rollup(cn),vn,pn;
-\d rollup_view;
+\d+ rollup_view;
 create view gs_view as select cn,vn,grouping(vn,cn) from sale group by grouping sets ((vn), (cn), (), (cn,vn));
-\d gs_view;
+\d+ gs_view;
 
 -- GROUP_ID function --
 
@@ -494,9 +494,9 @@ select count(*) from sale group by grouping sets((), ());
 create view grp_v1 as select count(*) from sale group by ();
 create view grp_v2 as select count(*) from sale group by grouping sets(());
 create view grp_v3 as select count(*) from sale group by grouping sets((), ());
-\d grp_v1;
-\d grp_v2;
-\d grp_v3;
+\d+ grp_v1;
+\d+ grp_v2;
+\d+ grp_v3;
 drop view grp_v1;
 drop view grp_v2;
 drop view grp_v3;

--- a/src/test/regress/sql/olap_window_seq.sql
+++ b/src/test/regress/sql/olap_window_seq.sql
@@ -1294,7 +1294,7 @@ FROM (SELECT * FROM sale) sale; --mvd 3,4,5->6; 3,4->7
 create view v1 as
 select dt, sum(cn) over(order by grouping(cn) range grouping(cn) preceding) 
 from sale group by rollup(cn,dt);
-\d v1
+\d+ v1
 drop view v1;
 
 -- MPP-2194, MPP-2236

--- a/src/test/regress/sql/qp_with_clause.sql
+++ b/src/test/regress/sql/qp_with_clause.sql
@@ -9780,7 +9780,7 @@ where longlivingregions.region = denseregions.region and allcountrystats.code = 
 and country.indepyear > 1900
 );
 
-\d view_with_shared_scans;
+\d+ view_with_shared_scans;
 
 select city_cnt,lang_cnt,name,region from view_with_shared_scans order by name LIMIT 50;
 

--- a/src/test/regress/sql/qp_with_functional.sql
+++ b/src/test/regress/sql/qp_with_functional.sql
@@ -380,7 +380,7 @@ CREATE VIEW cte_view as
     SELECT a FROM foo limit 10
 )SELECT * FROM CTE);
 
-\d cte_view
+\d+ cte_view
 
 SELECT * FROM cte_view ORDER BY 1;
 
@@ -392,7 +392,7 @@ CREATE VIEW cte_view as
       cte2(e,f) AS (SELECT e,d FROM bar, cte WHERE cte.e = bar.c )
 SELECT cte2.e,cte.f FROM cte,cte2 where cte.e = cte2.e
 );
-\d cte_view
+\d+ cte_view
 
 SELECT * FROM cte_view ORDER BY 1;
 


### PR DESCRIPTION
Long time ago, when updating our psql version to 8.3 (or something higher),
we had decided to keep the old single-line style when displaying access
privileges, to avoid having to update regression tests. It's time to move
forward, update the tests, and use the nicer 8.3 style for displaying
access privileges.

Also, \d on a view no longer prints the View Definition. You need to use
the verbose \d+ option for that. (I'm not a big fan of that change myself,
when I want to look at a view I'm almost always interested in the View
Definition. But let's not second-guess decisions made almost 10 years ago
in the upstream.)

Note: psql still defaults to the "old-ascii" style when printing multi-line
fields. The new style was introduced only later, in 9.0, so to avoid
changing all the expected output files, we should stick to the old style
until we reach that point in the merge. This commit only changes the style
for Access privileges, which is different from the multi-line style.