### PR TITLE
gpstop: add ability to stop all segments on a host

### DIFF
--- a/gpMgmt/bin/gppylib/commands/base.py
+++ b/gpMgmt/bin/gppylib/commands/base.py
@@ -51,7 +51,7 @@ class WorkerPool(object):
 
     halt_command = 'halt command'
 
-    def __init__(self, numWorkers=16, items=None, daemonize=False):
+    def __init__(self, numWorkers=16, items=None, daemonize=False, logger=gplog.get_default_logger()):
         if numWorkers <= 0:
             raise Exception("WorkerPool(): numWorkers should be greater than 0.")
         self.workers = []
@@ -108,7 +108,7 @@ class WorkerPool(object):
             num_completed_percentage = 0
             if command_count:
                 num_completed_percentage = float(num_completed) / command_count
-            logger.info('%0.2f%% of jobs completed' % (num_completed_percentage * 100))
+            self.logger.info('%0.2f%% of jobs completed' % (num_completed_percentage * 100))
             if num_completed >= command_count:
                 return
             self._join_work_queue_with_timeout(10)

--- a/gpMgmt/bin/gppylib/gparray.py
+++ b/gpMgmt/bin/gppylib/gparray.py
@@ -1151,6 +1151,8 @@ class GpArray:
 
             # Handle regular segments
             elif segdb.isSegmentQE():
+                if segdb.isSegmentMirror():
+                    self.hasMirrors = True
                 self.addSegmentDb(segdb)
 
             else:

--- a/gpMgmt/bin/gppylib/gparray.py
+++ b/gpMgmt/bin/gppylib/gparray.py
@@ -1616,6 +1616,13 @@ class GpArray:
         return hosts
 
     # --------------------------------------------------------------------
+    def get_master_host_names(self):
+        if self.hasStandbyMaster():
+            return [self.master.hostname, self.standbyMaster.hostname]
+        else:
+            return [self.master.hostname]
+
+    # --------------------------------------------------------------------
     def get_max_dbid(self,includeExpansionSegs=False):
         """Returns the maximum dbid in the array.  If includeExpansionSegs
         is True, this includes the expansion segment array in the search"""

--- a/gpMgmt/bin/gppylib/gphostcache.py
+++ b/gpMgmt/bin/gppylib/gphostcache.py
@@ -156,9 +156,10 @@ class GpInterfaceToHostNameCache:
 
 class GpHostCache:
 
-    def __init__(self, gparray, pool, skiplist=[], withMasters=False):
+    def __init__(self, gparray, pool, skiplist=[], withMasters=False, segs=None):
         self.gparray=gparray
         self.gphost_map={}        # hostname -> GpHost
+        self.segs = segs
 
         # these are any db's that should be skipped.
         skipmap={}
@@ -184,6 +185,9 @@ class GpHostCache:
             dblist = self.gparray.getDbList()
         else:
             dblist = self.gparray.getSegDbList()
+
+        if segs:
+            dblist = segs
 
         # build the interface->host mapping
         for db in dblist:

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpaddmirrors.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpaddmirrors.py
@@ -35,10 +35,10 @@ class GpAddMirrorsTest(GpTestCase):
         self.gpMasterEnvironmentMock = self.get_mock_from_apply_patch("GpMasterEnvironment")
         self.gpMasterEnvironmentMock.return_value.getMasterPort.return_value = 123456
         self.getConfigProviderFunctionMock = self.get_mock_from_apply_patch('getConfigurationProvider')
-        config_provider_mock = Mock(spec=GpConfigurationProvider)
-        self.getConfigProviderFunctionMock.return_value = config_provider_mock
-        config_provider_mock.initializeProvider.return_value = config_provider_mock
-        config_provider_mock.loadSystemConfig.return_value = self.gparrayMock
+        self.config_provider_mock = Mock(spec=GpConfigurationProvider)
+        self.getConfigProviderFunctionMock.return_value = self.config_provider_mock
+        self.config_provider_mock.initializeProvider.return_value = self.config_provider_mock
+        self.config_provider_mock.loadSystemConfig.return_value = self.gparrayMock
         self.mock_heap_checksum = self.get_mock_from_apply_patch('HeapChecksum')
         self.mock_heap_checksum.return_value.get_master_value.return_value = 1
         self.mock_heap_checksum.return_value.get_segments_checksum_settings.return_value = ([1], [0])
@@ -95,6 +95,7 @@ class GpAddMirrorsTest(GpTestCase):
         datadir_config = _write_datadir_config(self.mdd)
         mirror_config_output_file = "/tmp/test_gpaddmirrors.config"
         sys.argv = ['gpaddmirrors', '-o', mirror_config_output_file, '-m', datadir_config]
+        self.config_provider_mock.loadSystemConfig.return_value = GpArray([self.master, self.primary0, self.primary1])
         options, _ = self.parser.parse_args()
         subject = GpAddMirrorsProgram(options)
         subject.run()
@@ -111,6 +112,7 @@ class GpAddMirrorsTest(GpTestCase):
         mirror_config_output_file = "/tmp/test_gpaddmirrors.config"
         sys.argv = ['gpaddmirrors', '-p', '5000', '-o', mirror_config_output_file, '-m', datadir_config]
         options, _ = self.parser.parse_args()
+        self.config_provider_mock.loadSystemConfig.return_value = GpArray([self.master, self.primary0, self.primary1])
         subject = GpAddMirrorsProgram(options)
         subject.run()
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpstop.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpstop.py
@@ -303,6 +303,27 @@ class GpStop(GpTestCase):
             gpstop.run()
         self.assertEquals(0, self.mock_GpSegStopCmdInit.call_count)
 
+    def test_host_option_if_no_mirrors_fails(self):
+        sys.argv = ["gpstop", "-a", "--host", "sdw2"]
+        parser = self.subject.GpStop.createParser()
+        options, args = parser.parse_args()
+
+        self.master = GpDB.initFromString(
+            "1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
+        self.standby = GpDB.initFromString(
+            "2|-1|m|m|s|u|sdw1|sdw1|25432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
+        self.primary0 = GpDB.initFromString(
+            "3|0|p|p|s|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
+        self.primary1 = GpDB.initFromString(
+            "4|0|p|p|s|u|sdw2|sdw2|40001|41001|/data/primary1||/data/primary1/base/10899,/data/primary1/base/1,/data/primary1/base/10898,/data/primary1/base/25780,/data/primary1/base/34782")
+        self.mock_gparray.return_value = GpArray([self.master, self.standby, self.primary0, self.primary1])
+
+        gpstop = self.subject.GpStop.createProgram(options, args)
+
+        with self.assertRaisesRegexp(Exception,"Cannot perform host-specific gpstop on a cluster without segment mirroring."):
+            gpstop.run()
+        self.assertEquals(0, self.mock_GpSegStopCmdInit.call_count)
+
     def test_host_option_with_master_option_fails(self):
         sys.argv = ["gpstop", "--host", "sdw1", "-m"]
         parser = self.subject.GpStop.createParser()

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpstop.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpstop.py
@@ -5,6 +5,7 @@ import sys
 from gparray import GpDB, GpArray, Segment
 from mock import Mock, patch
 from gppylib.test.unit.gp_unittest import GpTestCase, run_tests
+from gppylib.commands.gp import GpSegStopCmd
 
 
 class GpStop(GpTestCase):
@@ -26,35 +27,63 @@ class GpStop(GpTestCase):
         self.mock_catalog = Mock()
         self.mock_gperafile = Mock()
         self.mock_unix = Mock()
-        self.gparray = self.createGpArrayWith2Primary2Mirrors()
+        self.gparray = self.createGpArrayWith4Primary4Mirrors()
 
         self.apply_patches([
             patch('gpstop.gp', return_value=self.mock_gp),
+            patch.object(GpSegStopCmd, "__init__", return_value=None),
             patch('gpstop.pgconf', return_value=self.mock_pgconf),
             patch('gpstop.os', return_value=self.mock_os),
             patch('gpstop.dbconn.connect', return_value=self.mock_conn),
             patch('gpstop.catalog', return_value=self.mock_catalog),
             patch('gpstop.unix', return_value=self.mock_unix),
             patch('gpstop.GpEraFile', return_value=self.mock_gperafile),
-            patch('gpstop.GpArray.initFromCatalog', return_value=self.gparray),
+            patch('gpstop.GpArray.initFromCatalog'),
+            patch('gpstop.gphostcache.unix.Ping'),
+            patch('gpstop.RemoteOperation'),
+            patch('gpstop.base.WorkerPool'),
         ])
+
         sys.argv = ["gpstop"]  # reset to relatively empty args list
+
+        # TODO: We are not unit testing how we report the segment stops. We've currently mocked it out
+        self.mock_workerpool = self.get_mock_from_apply_patch('WorkerPool')
+        self.mock_GpSegStopCmdInit = self.get_mock_from_apply_patch('__init__')
+        self.mock_gparray = self.get_mock_from_apply_patch('initFromCatalog')
+        self.mock_gparray.return_value = self.gparray
 
     def tearDown(self):
         super(GpStop, self).tearDown()
 
-    def createGpArrayWith2Primary2Mirrors(self):
-        master = GpDB.initFromString(
+    def createGpArrayWith4Primary4Mirrors(self):
+        self.master = GpDB.initFromString(
             "1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
-        primary0 = GpDB.initFromString(
+
+        self.primary0 = GpDB.initFromString(
             "2|0|p|p|s|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
-        primary1 = GpDB.initFromString(
-            "3|1|p|p|s|u|sdw2|sdw2|40001|41001|/data/primary1||/data/primary1/base/10899,/data/primary1/base/1,/data/primary1/base/10898,/data/primary1/base/25780,/data/primary1/base/34782")
-        mirror0 = GpDB.initFromString(
-            "4|0|m|m|s|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
-        mirror1 = GpDB.initFromString(
-            "5|1|m|m|s|u|sdw1|sdw1|50001|51001|/data/mirror1||/data/mirror1/base/10899,/data/mirror1/base/1,/data/mirror1/base/10898,/data/mirror1/base/25780,/data/mirror1/base/34782")
-        return GpArray([master, primary0, primary1, mirror0, mirror1])
+        self.primary1 = GpDB.initFromString(
+            "3|1|p|p|s|u|sdw1|sdw1|40001|41001|/data/primary1||/data/primary1/base/10899,/data/primary1/base/1,/data/primary1/base/10898,/data/primary1/base/25780,/data/primary1/base/34782")
+        self.primary2 = GpDB.initFromString(
+            "4|2|p|p|s|u|sdw2|sdw2|40002|41002|/data/primary2||/data/primary2/base/10899,/data/primary2/base/1,/data/primary2/base/10898,/data/primary2/base/25780,/data/primary2/base/34782")
+        self.primary3 = GpDB.initFromString(
+            "5|3|p|p|s|u|sdw2|sdw2|40003|41003|/data/primary3||/data/primary3/base/10899,/data/primary3/base/1,/data/primary3/base/10898,/data/primary3/base/25780,/data/primary3/base/34782")
+
+        self.mirror0 = GpDB.initFromString(
+            "6|0|m|m|s|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
+        self.mirror1 = GpDB.initFromString(
+            "7|1|m|m|s|u|sdw2|sdw2|50001|51001|/data/mirror1||/data/mirror1/base/10899,/data/mirror1/base/1,/data/mirror1/base/10898,/data/mirror1/base/25780,/data/mirror1/base/34782")
+        self.mirror2 = GpDB.initFromString(
+            "8|2|m|m|s|u|sdw1|sdw1|50002|51002|/data/mirror2||/data/mirror2/base/10899,/data/mirror2/base/1,/data/mirror2/base/10898,/data/mirror2/base/25780,/data/mirror2/base/34782")
+        self.mirror3 = GpDB.initFromString(
+            "9|3|m|m|s|u|sdw1|sdw1|50003|51003|/data/mirror3||/data/mirror3/base/10899,/data/mirror3/base/1,/data/mirror3/base/10898,/data/mirror3/base/25780,/data/mirror3/base/34782")
+        return GpArray([self.master, self.primary0, self.primary1, self.primary2, self.primary3, self.mirror0, self.mirror1, self.mirror2, self.mirror3])
+
+    def get_info_messages(self):
+        return [args[0][0] for args in self.subject.logger.info.call_args_list]
+
+    def get_error_messages(self):
+        return [args[0][0] for args in self.subject.logger.error.call_args_list]
+
 
     @patch('gpstop.userinput', return_value=Mock(spec=['ask_yesno']))
     def test_option_master_success_without_auto_accept(self, mock_userinput):
@@ -78,6 +107,140 @@ class GpStop(GpTestCase):
         gpstop = self.subject.GpStop.createProgram(options, args)
         gpstop.run()
         self.assertEqual(mock_userinput.ask_yesno.call_count, 0)
+
+    def test_option_hostonly_succeeds(self):
+        sys.argv = ["gpstop", "-a", "--host", "sdw1"]
+        parser = self.subject.GpStop.createParser()
+        options, args = parser.parse_args()
+
+        gpstop = self.subject.GpStop.createProgram(options, args)
+        gpstop.run()
+        log_messages = self.get_info_messages()
+        self.assertNotIn("sdw1   /data/mirror1    50001   u", log_messages)
+
+        self.assertIn("Targeting dbid %s for shutdown" % [self.primary0.getSegmentDbId(),
+                                                                   self.primary1.getSegmentDbId(),
+                                                                   self.mirror2.getSegmentDbId(),
+                                                                   self.mirror3.getSegmentDbId()], log_messages)
+        self.assertIn("Successfully shutdown 4 of 8 segment instances ", log_messages)
+
+    def test_host_missing_from_config(self):
+        sys.argv = ["gpstop", "-a", "--host", "nothere"]
+        host_names = self.gparray.getSegmentsByHostName(self.gparray.getDbList()).keys()
+
+        parser = self.subject.GpStop.createParser()
+        options, args = parser.parse_args()
+        gpstop = self.subject.GpStop.createProgram(options, args)
+        with self.assertRaises(SystemExit) as cm:
+            gpstop.run()
+        self.assertEquals(cm.exception.code, 1)
+        error_msgs = self.get_error_messages()
+        self.assertIn("host 'nothere' is not found in gp_segment_configuration", error_msgs)
+        self.assertIn("hosts in cluster config: %s" % host_names, error_msgs)
+
+    @patch('gpstop.userinput', return_value=Mock(spec=['ask_yesno']))
+    def test_happypath_in_interactive_mode(self, mock_userinput):
+        sys.argv = ["gpstop", "--host", "sdw1"]
+        parser = self.subject.GpStop.createParser()
+        options, args = parser.parse_args()
+
+        mock_userinput.ask_yesno.return_value = True
+        gpstop = self.subject.GpStop.createProgram(options, args)
+        gpstop.run()
+        log_messages = self.get_info_messages()
+
+        # two calls per host, first for primaries then for mirrors
+        self.assertEquals(2, self.mock_GpSegStopCmdInit.call_count)
+        self.assertIn("Targeting dbid %s for shutdown" % [self.primary0.getSegmentDbId(),
+                                                                   self.primary1.getSegmentDbId(),
+                                                                   self.mirror2.getSegmentDbId(),
+                                                                   self.mirror3.getSegmentDbId()], log_messages)
+
+        # call_obj[0] returns all unnamed arguments -> ['arg1', 'arg2']
+        # In this case, we have an object as an argument to poo.addCommand
+        # call_obj[1] returns a dict for all named arguments -> {key='arg3', key2='arg4'}
+        self.assertEquals(self.mock_GpSegStopCmdInit.call_args_list[0][1]['dbs'][0], self.primary0)
+        self.assertEquals(self.mock_GpSegStopCmdInit.call_args_list[0][1]['dbs'][1], self.primary1)
+        self.assertEquals(self.mock_GpSegStopCmdInit.call_args_list[1][1]['dbs'][0], self.mirror2)
+        self.assertEquals(self.mock_GpSegStopCmdInit.call_args_list[1][1]['dbs'][1], self.mirror3)
+        self.assertIn("   sdw1   /data/primary0   40000   u", log_messages)
+        self.assertIn("   sdw1   /data/primary1   40001   u", log_messages)
+        self.assertIn("   sdw1   /data/mirror2    50002   u", log_messages)
+        self.assertIn("   sdw1   /data/mirror3    50003   u", log_messages)
+
+        for line in log_messages:
+            self.assertNotRegexpMatches(line, "sdw2")
+
+        self.assertIn("Successfully shutdown 4 of 8 segment instances ", log_messages)
+
+    def test_host_option_segment_in_change_tracking_mode_fails(self):
+        sys.argv = ["gpstop", "-a", "--host", "sdw1"]
+        parser = self.subject.GpStop.createParser()
+        options, args = parser.parse_args()
+
+        self.primary0 = GpDB.initFromString(
+            "2|0|p|p|c|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
+        self.mirror0 = GpDB.initFromString(
+            "6|0|m|m|s|d|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
+        self.mock_gparray.return_value = GpArray([self.master, self.primary0,
+                                                  self.primary1, self.primary2,
+                                                  self.primary3, self.mirror0,
+                                                  self.mirror1, self.mirror2,
+                                                  self.mirror3])
+
+        gpstop = self.subject.GpStop.createProgram(options, args)
+
+        with self.assertRaisesRegexp(Exception,"Segment '%s' not synchronized. Aborting." % self.primary0):
+            gpstop.run()
+        self.assertEquals(0, self.mock_GpSegStopCmdInit.call_count)
+
+    def test_host_option_segment_in_resynchronizing_mode_fails(self):
+        sys.argv = ["gpstop", "-a", "--host", "sdw1"]
+        parser = self.subject.GpStop.createParser()
+        options, args = parser.parse_args()
+
+        self.primary0 = GpDB.initFromString(
+            "2|0|p|p|r|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
+        self.mirror0 = GpDB.initFromString(
+            "6|0|m|m|r|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
+        self.mock_gparray.return_value = GpArray([self.master, self.primary0,
+                                                  self.primary1, self.primary2,
+                                                  self.primary3, self.mirror0,
+                                                  self.mirror1, self.mirror2,
+                                                  self.mirror3])
+
+        gpstop = self.subject.GpStop.createProgram(options, args)
+
+        with self.assertRaisesRegexp(Exception,"Segment '%s' not synchronized. Aborting." % self.primary0):
+            gpstop.run()
+        self.assertEquals(0, self.mock_GpSegStopCmdInit.call_count)
+
+    def test_host_option_segment_down_is_skipped_succeeds(self):
+        sys.argv = ["gpstop", "-a", "--host", "sdw1"]
+        parser = self.subject.GpStop.createParser()
+        options, args = parser.parse_args()
+
+        self.primary0 = GpDB.initFromString(
+            "2|0|m|p|s|d|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
+        self.mirror0 = GpDB.initFromString(
+            "6|0|p|m|c|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
+        self.mock_gparray.return_value = GpArray([self.master, self.primary0,
+                                                  self.primary1, self.primary2,
+                                                  self.primary3, self.mirror0,
+                                                  self.mirror1, self.mirror2,
+                                                  self.mirror3])
+
+        gpstop = self.subject.GpStop.createProgram(options, args)
+        gpstop.run()
+        log_messages = self.get_info_messages()
+
+        self.assertEquals(2, self.mock_GpSegStopCmdInit.call_count)
+        self.assertIn("Targeting dbid %s for shutdown" % [self.primary1.getSegmentDbId(),
+                                                                   self.mirror2.getSegmentDbId(),
+                                                                   self.mirror3.getSegmentDbId()], log_messages)
+        self.assertIn("Successfully shutdown 3 of 8 segment instances ", log_messages)
+
+
 
 if __name__ == '__main__':
     run_tests()

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpstop.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpstop.py
@@ -261,6 +261,48 @@ class GpStop(GpTestCase):
             gpstop.run()
         self.assertEquals(0, self.mock_GpSegStopCmdInit.call_count)
 
+    def test_host_option_if_master_running_on_the_host_fails(self):
+        sys.argv = ["gpstop", "-a", "--host", "mdw"]
+        parser = self.subject.GpStop.createParser()
+        options, args = parser.parse_args()
+
+        self.master = GpDB.initFromString(
+            "1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
+        self.primary0 = GpDB.initFromString(
+            "2|0|p|p|s|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
+        self.mirror0 = GpDB.initFromString(
+            "3|0|m|m|s|u|sdw1|sdw1|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
+        self.mock_gparray.return_value = GpArray([self.master, self.primary0, self.mirror0])
+
+        gpstop = self.subject.GpStop.createProgram(options, args)
+
+        with self.assertRaisesRegexp(Exception,"Specified host '%s' has the master or standby master on it. This node can only be stopped as part of a full-cluster gpstop, without '--host'." %
+                                     self.master.getSegmentHostName()):
+            gpstop.run()
+        self.assertEquals(0, self.mock_GpSegStopCmdInit.call_count)
+
+    def test_host_option_if_standby_running_on_the_host_fails(self):
+        sys.argv = ["gpstop", "-a", "--host", "sdw1"]
+        parser = self.subject.GpStop.createParser()
+        options, args = parser.parse_args()
+
+        self.master = GpDB.initFromString(
+            "1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
+        self.standby = GpDB.initFromString(
+            "2|-1|m|m|s|u|sdw1|sdw1|25432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
+        self.primary0 = GpDB.initFromString(
+            "3|0|p|p|s|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
+        self.mirror0 = GpDB.initFromString(
+            "4|0|m|m|s|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
+        self.mock_gparray.return_value = GpArray([self.master, self.standby, self.primary0, self.mirror0])
+
+        gpstop = self.subject.GpStop.createProgram(options, args)
+
+        with self.assertRaisesRegexp(Exception,"Specified host '%s' has the master or standby master on it. This node can only be stopped as part of a full-cluster gpstop, without '--host'." %
+                                     self.standby.getSegmentHostName()):
+            gpstop.run()
+        self.assertEquals(0, self.mock_GpSegStopCmdInit.call_count)
+
     def test_host_option_with_master_option_fails(self):
         sys.argv = ["gpstop", "--host", "sdw1", "-m"]
         parser = self.subject.GpStop.createParser()

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpstop.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpstop.py
@@ -6,6 +6,7 @@ from gparray import GpDB, GpArray, Segment
 from mock import Mock, patch
 from gppylib.test.unit.gp_unittest import GpTestCase, run_tests
 from gppylib.commands.gp import GpSegStopCmd
+from gppylib.mainUtils import ProgramArgumentValidationException
 
 
 class GpStop(GpTestCase):
@@ -260,6 +261,41 @@ class GpStop(GpTestCase):
             gpstop.run()
         self.assertEquals(0, self.mock_GpSegStopCmdInit.call_count)
 
+    def test_host_option_with_master_option_fails(self):
+        sys.argv = ["gpstop", "--host", "sdw1", "-m"]
+        parser = self.subject.GpStop.createParser()
+        options, args = parser.parse_args()
+
+        with self.assertRaisesRegexp(ProgramArgumentValidationException, "Incompatible flags. Cannot mix '--host' "
+                                                                         "option with '-m' for master-only."):
+            self.subject.GpStop.createProgram(options, args)
+
+    def test_host_option_with_restart_option_fails(self):
+        sys.argv = ["gpstop", "--host", "sdw1", "-r"]
+        parser = self.subject.GpStop.createParser()
+        options, args = parser.parse_args()
+
+        with self.assertRaisesRegexp(ProgramArgumentValidationException, "Incompatible flags. Cannot mix '--host' "
+                                                                         "option with '-r' for restart."):
+            self.subject.GpStop.createProgram(options, args)
+
+    def test_host_option_with_request_sighup_option_fails(self):
+        sys.argv = ["gpstop", "--host", "sdw1", "-u"]
+        parser = self.subject.GpStop.createParser()
+        options, args = parser.parse_args()
+
+        with self.assertRaisesRegexp(ProgramArgumentValidationException, "Incompatible flags. Cannot mix '--host' "
+                                                                         "option with '-u' for config reload."):
+            self.subject.GpStop.createProgram(options, args)
+
+    def test_host_option_with_stop_standby_option_fails(self):
+        sys.argv = ["gpstop", "--host", "sdw1", "-y"]
+        parser = self.subject.GpStop.createParser()
+        options, args = parser.parse_args()
+
+        with self.assertRaisesRegexp(ProgramArgumentValidationException, "Incompatible flags. Cannot mix '--host' "
+                                                                         "option with '-y' for skipping standby."):
+            self.subject.GpStop.createProgram(options, args)
 
 if __name__ == '__main__':
     run_tests()

--- a/gpMgmt/bin/gppylib/utils.py
+++ b/gpMgmt/bin/gppylib/utils.py
@@ -398,9 +398,10 @@ class TableLogger:
     Use this by constructing it, then calling warn, info, and infoOrWarn with arrays of columns, then outputTable
     """
 
-    def __init__(self):
+    def __init__(self, logger=get_default_logger()):
         self.__lines = []
         self.__warningLines = {}
+        self.logger = logger
 
         #
         # If True, then warn calls will produce arrows as well at the end of the lines
@@ -473,7 +474,7 @@ class TableLogger:
                 #
                 # separator
                 #
-                logger.info("----------------------------------------------------")
+                self.logger.info("----------------------------------------------------")
             else:
                 outLine = []
                 for i, field in enumerate(line):
@@ -486,9 +487,9 @@ class TableLogger:
                 msg = "".join(outLine)
 
                 if doWarn:
-                    logger.warn(msg)
+                    self.logger.warn(msg)
                 else:
-                    logger.info("   " + msg) # add 3 so that lines will line up even with the INFO and WARNING stuff on front
+                    self.logger.info("   " + msg) # add 3 so that lines will line up even with the INFO and WARNING stuff on front
 
         return self
 

--- a/gpMgmt/bin/gpstop
+++ b/gpMgmt/bin/gpstop
@@ -95,10 +95,29 @@ class GpStop:
 
 
     #####
+    def _find_any_primary_and_mirror_on_same_host(self, segs):
+        map_content_id_to_segment = {}
+        for seg in segs:
+            seg_content_id = seg.getSegmentContentId()
+            if seg_content_id in map_content_id_to_segment:
+                if seg.isSegmentPrimary(True):
+                    return seg, map_content_id_to_segment[seg_content_id]
+                else:
+                    return map_content_id_to_segment[seg_content_id], seg
+            else:
+                map_content_id_to_segment[seg_content_id] = seg
+
+        return None, None
+
     def _filter_segments_for_single_host_stop(self):
         host_to_segments_mapping = self.gparray.getSegmentsByHostName(self.gparray.getSegDbList())
         segments_on_host = host_to_segments_mapping[self.onlyThisHost]
         up_segments_on_host = [seg for seg in segments_on_host if seg.isSegmentUp()]
+        matching_primary, matching_mirror = self._find_any_primary_and_mirror_on_same_host(up_segments_on_host)
+        if matching_primary or matching_mirror:
+            raise Exception("Segment host '%s' has both of corresponding primary "
+                            "'%s' and mirror '%s'. Aborting." % (matching_primary.getSegmentHostName(),
+                                                                 matching_primary, matching_mirror))
 
         for seg in up_segments_on_host:
             if seg.isSegmentModeSynchronized():

--- a/gpMgmt/bin/gpstop
+++ b/gpMgmt/bin/gpstop
@@ -32,6 +32,7 @@ try:
     from gppylib.gp_era import GpEraFile
     from gppylib.operations.unix import CleanSharedMem
     from gppylib.operations.utils import ParallelOperation, RemoteOperation
+    from gppylib.operations.rebalanceSegments import ReconfigDetectionSQLQueryCommand
 except ImportError, e:
     sys.exit('ERROR: Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
 
@@ -182,6 +183,22 @@ class GpStop:
                     # Reenable Ctrl-C
                     self.cleanup()
                     signal.signal(signal.SIGINT, signal.default_int_handler)
+
+                if self.onlyThisHost:
+                    logger.info("Recognizing new cluster state...")
+                    try:
+                        # currently responsible for triggering an update to gp_segment_configuration
+                        # because dbconn.connect() internally calls commit()
+                        self.conn = dbconn.connect(self.dburl)
+
+                        # backup in case connect() does not do a commit
+                        ReconfigDetectionSQLQueryCommand(self.conn).run()
+                    except Exception as e:
+                        logger.debug('query trying to start a transaction failed: %s' % str(e))
+                        logger.debug('expected: the purpose was that by attempting a transaction, gp_segment_configuration would be updated')
+                    finally:
+                        if self.conn:
+                            self.conn.close()
 
                 if self.restart:
                     logger.info("Restarting System...")

--- a/gpMgmt/bin/gpstop
+++ b/gpMgmt/bin/gpstop
@@ -156,6 +156,8 @@ class GpStop:
                     if self.onlyThisHost in self.gparray.get_master_host_names():
                         raise Exception("Specified host '%s' has the master or standby master on it. This node can only be stopped as part of a full-cluster gpstop, without '--host'." %
                                         self.onlyThisHost)
+                    if not self.gparray.hasMirrors:
+                        raise Exception("Cannot perform host-specific gpstop on a cluster without segment mirroring.")
                     segs = self._filter_segments_for_single_host_stop()
                 else:
                     segs = self.gparray.getSegDbList()

--- a/gpMgmt/bin/gpstop
+++ b/gpMgmt/bin/gpstop
@@ -818,17 +818,17 @@ class GpStop:
         addTo.add_option('-m', '--master_only', action='store_true',
                          help='stop master instance started in maintenance mode')
         addTo.add_option('-y', dest="stop_standby", action='store_false', default=True,
-                         help='stop master instance started in maintenance mode')
+                         help='Do not stop the standby master process.')
         addTo.add_option('-u', dest="request_sighup", action='store_true',
                          help="upload new master postgresql.conf settings, does not stop Greenplum array," \
-                              "issues a signal to the master segment potmaster process to reload")
+                              "issues a signal to the master segment postmaster process to reload")
 
         addTo.add_option('-B', '--parallel', type="int", default=DEFAULT_NUM_WORKERS, metavar="<parallel_processes>",
                          help='number of segment hosts to run in parallel. Default is %d' % DEFAULT_NUM_WORKERS)
         addTo.add_option('-t', '--timeout', dest='timeout', default=SEGMENT_STOP_TIMEOUT_DEFAULT, type='int',
                          help='time to wait for segment stop (in seconds)')
         addTo.add_option('--host', dest='only_this_host', type='string',
-                         help='stop all segments on this host if failover segments are available. '
+                         help='stop all segments on this host (this will only complete if failover segments are available). '
                               'hostname as displayed in gp_segment_configuration')
 
         parser.set_defaults(verbose=False, filters=[], slice=(None, None))
@@ -840,6 +840,22 @@ class GpStop:
         if options.mode != 'smart':
             if options.fast or options.immediate:
                 raise ProgramArgumentValidationException("Can not mix --mode options with older deprecated '-f,-i,-s'")
+
+        if options.master_only and options.only_this_host:
+            raise ProgramArgumentValidationException("Incompatible flags. Cannot mix '--host' option with '-m' for "
+                                                     "master-only.")
+
+        if options.restart and options.only_this_host:
+            raise ProgramArgumentValidationException("Incompatible flags. Cannot mix '--host' option with '-r' for "
+                                                     "restart.")
+
+        if options.request_sighup and options.only_this_host:
+            raise ProgramArgumentValidationException("Incompatible flags. Cannot mix '--host' option with '-u' for "
+                                                     "config reload.")
+
+        if (not options.stop_standby) and options.only_this_host:
+            raise ProgramArgumentValidationException("Incompatible flags. Cannot mix '--host' option with '-y' for "
+                                                     "skipping standby.")
 
         if options.fast:
             options.mode = "fast"

--- a/gpMgmt/bin/gpstop
+++ b/gpMgmt/bin/gpstop
@@ -24,7 +24,7 @@ try:
     from gppylib import pgconf
     from gppylib.commands import unix
     from gppylib.commands import gp
-    from gppylib.commands.gp import SEGMENT_STOP_TIMEOUT_DEFAULT
+    from gppylib.commands.gp import SEGMENT_STOP_TIMEOUT_DEFAULT, SegmentStop, GpSegStopCmd
     from gppylib.commands import base
     from gppylib.commands import pg
     from gppylib.commands import dca
@@ -64,7 +64,7 @@ class GpStop:
     def __init__(self, mode, master_datadir=None,
                  parallel=DEFAULT_NUM_WORKERS, quiet=False, masteronly=False, sighup=False,
                  interactive=False, stopstandby=False, restart=False,
-                 timeout=SEGMENT_STOP_TIMEOUT_DEFAULT, logfileDirectory=False):
+                 timeout=SEGMENT_STOP_TIMEOUT_DEFAULT, logfileDirectory=False, onlyThisHost=None):
         self.mode = mode
         self.master_datadir = master_datadir
         self.pool = None
@@ -79,6 +79,7 @@ class GpStop:
         self.hadFailures = False
         self.timeout = timeout
         self.logfileDirectory = logfileDirectory
+        self.onlyThisHost = onlyThisHost
 
         # some variables that will be assigned during run()
         self.gphome = None
@@ -93,7 +94,19 @@ class GpStop:
         pass
 
 
-        #####
+    #####
+    def _filter_segments_for_single_host_stop(self):
+        host_to_segments_mapping = self.gparray.getSegmentsByHostName(self.gparray.getSegDbList())
+        segments_on_host = host_to_segments_mapping[self.onlyThisHost]
+        up_segments_on_host = [seg for seg in segments_on_host if seg.isSegmentUp()]
+
+        for seg in up_segments_on_host:
+            if seg.isSegmentModeSynchronized():
+                continue
+            raise Exception("Segment '%s' not synchronized. Aborting." % seg)
+
+        return up_segments_on_host
+
 
     def run(self):
         """
@@ -118,8 +131,15 @@ class GpStop:
             if self.sighup:
                 return self._sighup_cluster()
             else:
+
+                segs = []
+                if self.onlyThisHost:
+                    segs = self._filter_segments_for_single_host_stop()
+                else:
+                    segs = self.gparray.getSegDbList()
+
                 if self.interactive:
-                    self._summarize_actions()
+                    self._summarize_actions(segs)
                     if not userinput.ask_yesno(None, "\nContinue with Greenplum instance shutdown", 'N'):
                         raise UserAbortedException()
 
@@ -127,9 +147,10 @@ class GpStop:
                     # Disable Ctrl-C
                     signal.signal(signal.SIGINT, signal.SIG_IGN)
 
-                    self._stop_master()
-                    self._stop_standby()
-                    self._stop_segments()
+                    if self.onlyThisHost is None:
+                        self._stop_master()
+                        self._stop_standby()
+                    self._stop_segments(segs)
                     self._stop_gpmmon()
                     self._stop_gpsmon()
                     self._remove_shared_memory()  # this creates a new logfile - why?
@@ -269,7 +290,18 @@ class GpStop:
         self._read_postgresqlconf()
         self._check_db_running()
         self._build_gparray()
+        if self.onlyThisHost:
+            self._is_hostname_valid()
         self._check_version()
+
+    ######
+    def _is_hostname_valid(self):
+        segments = self.gparray.getSegmentsByHostName( self.gparray.getDbList())
+        host_names = segments.keys()
+        if self.onlyThisHost not in host_names:
+            logger.error("host '%s' is not found in gp_segment_configuration" % self.onlyThisHost)
+            logger.error("hosts in cluster config: %s" % host_names)
+            raise SystemExit(1)
 
     ######
     def _check_version(self):
@@ -315,6 +347,7 @@ class GpStop:
         logger.info("Obtaining Segment details from master...")
         self.dburl = dbconn.DbURL(port=self.port, dbname='template1')
         self.gparray = GpArray.initFromCatalog(self.dburl, utility=True)
+
 
     ######
     def _stop_master(self, masterOnly=False):
@@ -404,7 +437,7 @@ class GpStop:
 
             logger.info("Stopping master standby host %s mode=fast" % standby.hostname)
             try:
-                cmd = gp.SegmentStop("stopping master standby",
+                cmd = SegmentStop("stopping master standby",
                                      standby.datadir, mode='fast',
                                      timeout=self.timeout,
                                      ctxt=base.REMOTE,
@@ -419,7 +452,7 @@ class GpStop:
             else:
                 logger.warning("Process master standby still running, will issue fast shutdown with immediate")
                 try:
-                    cmd = gp.SegmentStop("stopping master standby", standby.datadir, mode='immediate',
+                    cmd = SegmentStop("stopping master standby", standby.datadir, mode='immediate',
                                          timeout=self.timeout,
                                          ctxt=base.REMOTE, remoteHost=standby.hostname)
                     cmd.run(validateAfter=True)
@@ -446,15 +479,15 @@ class GpStop:
             return True
 
     ######
-    def _stop_segments(self):
+    def _stop_segments(self, segs):
         failed_seg_status = []
         workers = min(len(self.gparray.get_hostlist()), self.parallel)
-        self.pool = base.WorkerPool(numWorkers=workers)
+        self.pool = base.WorkerPool(numWorkers=workers, logger=logger)
 
-        segs = self.gparray.getSegDbList()
+        logger.info("Targeting dbid %s for shutdown" % [seg.getSegmentDbId() for seg in segs])
 
-        # read in the hostcache file and make sure we can ping everybody
-        self.hostcache = gphostcache.GpHostCache(self.gparray, self.pool)
+        self.hostcache = gphostcache.GpHostCache(self.gparray, self.pool, segs=segs)
+
         failed_pings = self.hostcache.ping_hosts(self.pool)
         for db in failed_pings:
             logger.warning(
@@ -467,7 +500,7 @@ class GpStop:
             # stop primaries
             logger.info("Commencing parallel primary segment instance shutdown, please wait...")
             try:
-                self._stopseg_cmds(True, False)
+                self._stopseg_cmds(True, False, segs=segs)
             finally:
                 self.pool.join()
             primary_success_seg_status = self._process_segment_stop(failed_seg_status)
@@ -475,7 +508,7 @@ class GpStop:
             # stop mirrors
             logger.info("Commencing parallel mirror segment instance shutdown, please wait...")
             try:
-                self._stopseg_cmds(False, True)
+                self._stopseg_cmds(False, True, segs=segs)
             finally:
                 self.pool.join()
             mirror_success_seg_status = self._process_segment_stop(failed_seg_status)
@@ -487,7 +520,7 @@ class GpStop:
             logger.info("Commencing parallel segment instance shutdown, please wait...")
             # There are no active-mirrors
             try:
-                self._stopseg_cmds(True, False)
+                self._stopseg_cmds(True, False, segs=segs)
             finally:
                 self.pool.join()
             success_seg_status = self._process_segment_stop(failed_seg_status)
@@ -496,19 +529,24 @@ class GpStop:
         pass
 
     ######
-    def _stopseg_cmds(self, includePrimaries, includeMirrors):
+    def _stopseg_cmds(self, includePrimaries, includeMirrors, segs):
         dispatch_count = 0
 
-        for gphost in self.hostcache.get_hosts():
+        host_segs_map = {}
+        for seg in segs:
+            if seg.getSegmentHostName() in host_segs_map.keys():
+                host_segs_map[seg.getSegmentHostName()].append(seg)
+            else:
+                host_segs_map[seg.getSegmentHostName()] = [seg]
+
+        for hostname, gpdb_objs in host_segs_map.iteritems():
             dbs = []
-            for db in gphost.dbs:
+            for db in gpdb_objs:
                 role = db.getSegmentRole()
                 if role == 'p' and includePrimaries:
                     dbs.append(db)
                 elif role != 'p' and includeMirrors:
                     dbs.append(db)
-
-            hostname = gphost.dbs[0].hostname
 
             # If we have no dbs then we have no segments of the type primary
             # or mirror.  This will occur when you have an entire host fail
@@ -518,7 +556,7 @@ class GpStop:
                 continue
 
             logger.debug("Dispatching command to shutdown %d segments on host: %s" % (len(dbs), hostname))
-            cmd = gp.GpSegStopCmd("remote segment starts on host '%s'" % hostname, self.gphome, self.gpversion,
+            cmd = GpSegStopCmd("remote segment starts on host '%s'" % hostname, self.gphome, self.gpversion,
                                   mode=self.mode, dbs=dbs, timeout=self.timeout,
                                   verbose=logging_is_verbose(), ctxt=base.REMOTE, remoteHost=hostname,
                                   logfileDirectory=self.logfileDirectory)
@@ -604,7 +642,7 @@ class GpStop:
                 for stat in success_seg_status:
                     logger.debug(stat)
 
-        tabLog = TableLogger().setWarnWithArrows(True)
+        tabLog = TableLogger(logger=logger).setWarnWithArrows(True)
         tabLog.addSeparator()
         tabLog.info(["Segments stopped successfully", "= %d" % stopped])
         tabLog.infoOrWarn(failed > 0, ["Segments with errors during stop", "= %d" % failed])
@@ -697,12 +735,12 @@ class GpStop:
         return 1
 
     ######
-    def _summarize_actions(self):
+    def _summarize_actions(self, segs):
         logger.info("--------------------------------------------")
         logger.info("Master instance parameters")
         logger.info("--------------------------------------------")
 
-        tabLog = TableLogger().setWarnWithArrows(True)
+        tabLog = TableLogger(logger=logger).setWarnWithArrows(True)
         tabLog.info(["Master Greenplum instance process active PID", "= %s" % self.pid])
         tabLog.info(["Database", "= %s" % self.dburl.pgdb])
         tabLog.info(["Master port", "= %s" % self.port])
@@ -719,9 +757,10 @@ class GpStop:
         logger.info("Segment instances that will be shutdown:")
         logger.info("--------------------------------------------")
 
-        tabLog = TableLogger().setWarnWithArrows(True)
+        tabLog = TableLogger(logger=logger).setWarnWithArrows(True)
         tabLog.info(["Host", "Datadir", "Port", "Status"])
-        for db in self.gparray.getSegDbList():
+
+        for db in segs:
             tabLog.info([db.getSegmentHostName(), db.getSegmentDataDirectory(),
                          str(db.getSegmentPort()), db.getSegmentStatus()])
         tabLog.outputTable()
@@ -769,6 +808,9 @@ class GpStop:
                          help='number of segment hosts to run in parallel. Default is %d' % DEFAULT_NUM_WORKERS)
         addTo.add_option('-t', '--timeout', dest='timeout', default=SEGMENT_STOP_TIMEOUT_DEFAULT, type='int',
                          help='time to wait for segment stop (in seconds)')
+        addTo.add_option('--host', dest='only_this_host', type='string',
+                         help='stop all segments on this host if failover segments are available. '
+                              'hostname as displayed in gp_segment_configuration')
 
         parser.set_defaults(verbose=False, filters=[], slice=(None, None))
         return parser
@@ -819,7 +861,8 @@ class GpStop:
                       stopstandby=options.stop_standby,
                       restart=options.restart,
                       timeout=options.timeout,
-                      logfileDirectory=logfileDirectory)
+                      logfileDirectory=logfileDirectory,
+                      onlyThisHost=options.only_this_host)
 
 
 if __name__ == '__main__':

--- a/gpMgmt/bin/gpstop
+++ b/gpMgmt/bin/gpstop
@@ -153,6 +153,9 @@ class GpStop:
 
                 segs = []
                 if self.onlyThisHost:
+                    if self.onlyThisHost in self.gparray.get_master_host_names():
+                        raise Exception("Specified host '%s' has the master or standby master on it. This node can only be stopped as part of a full-cluster gpstop, without '--host'." %
+                                        self.onlyThisHost)
                     segs = self._filter_segments_for_single_host_stop()
                 else:
                     segs = self.gparray.getSegDbList()

--- a/gpMgmt/doc/gpstop_help
+++ b/gpMgmt/doc/gpstop_help
@@ -11,11 +11,15 @@ gpstop [-d <master_data_directory>] [-B <parallel_processes>]
        [-M smart | fast | immediate] [-t <timeout_seconds>]
        [-r] [-y] [-a] [-l <logfile_directory>] [-v | -q]
 
-gpstop -m [-d <master_data_directory>] [-y] [-l <logfile_directory>] 
+gpstop -m [-d <master_data_directory>] [-y] [-l <logfile_directory>]
        [-v | -q]
 
 gpstop -u [-d <master_data_directory>] [-l <logfile_directory>] 
-          [-v | -q] 
+       [-v | -q]
+
+gpstop --host <segment_host_name> [-d <master_data_directory>]
+       [-l <logfile_directory>] [-t <timeout_seconds>] [-a]
+       [-v | -q]
 
 gpstop --version
 
@@ -67,6 +71,21 @@ OPTIONS
 
  Optional. The master host data directory. If not specified, 
  the value set for $MASTER_DATA_DIRECTORY will be used.
+
+
+--host <segment_host_name>
+
+ Stop all segments on this host. Specify segment_host_name as
+ it is displayed in gp_segment_configuration.
+
+ This cannot be used together with `-m`, `-r`, `-u`, or
+ `-y` options.
+
+ This will only complete if failover segments are available.
+ This will fail if the system doesn't have mirrors. It will also
+ fail if the specified host has a master or standby master on
+ it. It will also fail if the specified host has both a primary
+ and its corresponding mirror on it, the same host.
 
 
 -l <logfile_directory>
@@ -167,6 +186,7 @@ Stop a Greenplum Database system in smart mode:
 
   gpstop
 
+
 Stop a Greenplum Database system in fast mode:
 
   gpstop -M fast
@@ -180,6 +200,12 @@ Stop all segment instances and then restart the system:
 Stop a master instance that was started in maintenance mode:
 
   gpstop -m
+
+
+Stop all segments on a particular host, while keeping
+other hosts up:
+
+  gpstop --host sdw1
 
 
 Reload the postgresql.conf and pg_hba.conf files after 


### PR DESCRIPTION
gpstop: add ability to stop all active ~~primaries~~ segments on a host

Add a flag `--host` which stops all segments ~~in primary
role~~ on the specified host. An easy way to take down a set of segments
without having to ssh and kill processes.

Signed-off-by: Nadeem Ghani <nghani@pivotal.io>
Signed-off-by: C.J. Jameson <cjameson@pivotal.io>

Edit:
This will be back-ported to 5X_STABLE
Mirrors and primaries both
