### PR TITLE
resgroup: Fix memory quota calculation

### DIFF
--- a/src/backend/utils/mmgr/vmem_tracker.c
+++ b/src/backend/utils/mmgr/vmem_tracker.c
@@ -435,14 +435,12 @@ int32
 VmemTracker_GetChunkSizeInBits(void)
 {
 	/*
+	 * TODO:
 	 * For backend who has vmem tracker initialized and resource
 	 * group enabled, the chunk size is not expected to be used
 	 * until resource group is activated, otherwise, there might
 	 * be an inconsistency about the chunk size.
 	 */
-	AssertImply(vmemTrackerInited && IsResGroupEnabled(),
-				IsResGroupActivated());
-
 	return IsResGroupEnabled() ?
 		ResGroupGetVmemChunkSizeInBits() : chunkSizeInBits;
 }

--- a/src/include/commands/resgroupcmds.h
+++ b/src/include/commands/resgroupcmds.h
@@ -29,7 +29,4 @@ extern Oid GetResGroupIdForRole(Oid roleid);
 extern void GetResGroupCapabilities(Relation rel,
 									Oid groupId,
 									ResGroupCaps *resgroupCaps);
-extern void AtEOXact_ResGroup(bool isCommit);
-extern void HandleResGroupDDLCallbacks(bool isCommit);
-
 #endif   /* RESGROUPCMDS_H */

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -92,12 +92,6 @@ typedef enum
 	RES_GROUP_STAT_MEM_USAGE,
 } ResGroupStatType;
 
-/*
- * Functions in resgroup.c
- */
-extern void AtEOXact_ResGroup(bool isCommit);
-extern void AtPrepare_ResGroup(void);
-
 /* Shared memory and semaphores */
 extern Size ResGroupShmemSize(void);
 extern void ResGroupControlInit(void);

--- a/src/test/isolation2/expected/resgroup/resgroup_concurrency.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_concurrency.out
@@ -258,10 +258,7 @@ DROP
 DROP RESOURCE GROUP rg_concurrency_test;
 DROP
 
--- test5: concurrently alter resource group cpu rate limit
--- NONE
-
--- test6: cancel a query that is waiting for a slot
+-- test5: QD exit before QE
 DROP ROLE IF EXISTS role_concurrency_test;
 DROP
 -- start_ignore
@@ -301,6 +298,35 @@ DROP ROLE role_concurrency_test;
 DROP
 DROP RESOURCE GROUP rg_concurrency_test;
 DROP
+
+-- test6: cancel a query that is waiting for a slot
+DROP ROLE IF EXISTS role_concurrency_test;
+DROP
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+ERROR:  resource group "rg_concurrency_test" does not exist
+-- end_ignore
+
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=1, cpu_rate_limit=20, memory_limit=20);
+CREATE
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+CREATE
+51:SET ROLE role_concurrency_test;
+SET
+51:BEGIN;
+BEGIN
+52:SET ROLE role_concurrency_test;
+SET
+52&:BEGIN;  <waiting ...>
+51q: ... <quitting>
+52<:  <... completed>
+BEGIN
+52q: ... <quitting>
+DROP ROLE role_concurrency_test;
+DROP
+DROP RESOURCE GROUP rg_concurrency_test;
+DROP
+
 
 -- test7: terminate a query that is waiting for a slot
 DROP ROLE IF EXISTS role_concurrency_test;

--- a/src/test/isolation2/sql/resgroup/resgroup_concurrency.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_concurrency.sql
@@ -127,10 +127,7 @@ DROP RESOURCE GROUP rg_concurrency_test;
 DROP ROLE IF EXISTS role_concurrency_test;
 DROP RESOURCE GROUP rg_concurrency_test;
 
--- test5: concurrently alter resource group cpu rate limit
--- NONE
-
--- test6: cancel a query that is waiting for a slot
+-- test5: QD exit before QE 
 DROP ROLE IF EXISTS role_concurrency_test;
 -- start_ignore
 DROP RESOURCE GROUP rg_concurrency_test;
@@ -151,6 +148,25 @@ SELECT pg_cancel_backend(procpid) FROM pg_stat_activity WHERE waiting_reason='re
 52q:
 DROP ROLE role_concurrency_test;
 DROP RESOURCE GROUP rg_concurrency_test;
+
+-- test6: cancel a query that is waiting for a slot
+DROP ROLE IF EXISTS role_concurrency_test;
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+-- end_ignore
+
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=1, cpu_rate_limit=20, memory_limit=20);
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+51:SET ROLE role_concurrency_test;
+51:BEGIN;
+52:SET ROLE role_concurrency_test;
+52&:BEGIN;
+51q:
+52<:
+52q:
+DROP ROLE role_concurrency_test;
+DROP RESOURCE GROUP rg_concurrency_test;
+
 
 -- test7: terminate a query that is waiting for a slot
 DROP ROLE IF EXISTS role_concurrency_test;


### PR DESCRIPTION
    If a QD exits when the transaction is still active, QD will abort
    the transaction and destroy all gangs, without waiting for QEs
    finish the transaction. In this case, a new transaction (the resource
    group slot waken up by this QD) may execute before the QEs exit,
    so we cannot use the number of currently running QEs to calculate
    the memory quota.
