### PR TITLE
Fix clash on two test tables named "foo".

### DIFF
--- a/src/test/regress/expected/partition_pruning.out
+++ b/src/test/regress/expected/partition_pruning.out
@@ -3153,8 +3153,6 @@ select get_selected_parts('explain analyze select * from DATE_PARTS where month 
 (1 row)
 
 -- More Equality and General Predicates ---
-drop table if exists foo;
-NOTICE:  table "foo" does not exist, skipping
 create table foo(a int, b int)
 partition by list (b)
 (partition p1 values(1,3), partition p2 values(4,2), default partition other);

--- a/src/test/regress/expected/partition_pruning_optimizer.out
+++ b/src/test/regress/expected/partition_pruning_optimizer.out
@@ -2658,8 +2658,6 @@ select get_selected_parts('explain analyze select * from DATE_PARTS where month 
 (1 row)
 
 -- More Equality and General Predicates ---
-drop table if exists foo;
-NOTICE:  table "foo" does not exist, skipping
 create table foo(a int, b int)
 partition by list (b)
 (partition p1 values(1,3), partition p2 values(4,2), default partition other);

--- a/src/test/regress/expected/portals_updatable.out
+++ b/src/test/regress/expected/portals_updatable.out
@@ -775,19 +775,19 @@ ROLLBACK;
 UPDATE uctest SET f1 = f1 + 10 WHERE CURRENT OF a;
 ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 -- Negative, cursor-agnostic: cannot update external tables
-CREATE EXTERNAL WEB TABLE foo (x text) EXECUTE 'echo "foo";' FORMAT 'TEXT';
+CREATE EXTERNAL WEB TABLE ucexttest (x text) EXECUTE 'echo "foo";' FORMAT 'TEXT';
 BEGIN;
-DECLARE c CURSOR FOR SELECT * FROM foo;
+DECLARE c CURSOR FOR SELECT * FROM ucexttest;
 FETCH 1 from c;
   x  
 -----
  foo
 (1 row)
 
-UPDATE foo SET x = 'bar' WHERE CURRENT OF c;
-ERROR:  cannot update or delete from external relation "foo"
+UPDATE ucexttest SET x = 'bar' WHERE CURRENT OF c;
+ERROR:  cannot update or delete from external relation "ucexttest"
 ROLLBACK;
-DROP EXTERNAL TABLE foo;
+DROP EXTERNAL TABLE ucexttest;
 -- Negative, cursor-agnostic: cannot update AO
 CREATE TEMP TABLE aotest (a int, b text)
 	WITH (appendonly=true);

--- a/src/test/regress/expected/portals_updatable_optimizer.out
+++ b/src/test/regress/expected/portals_updatable_optimizer.out
@@ -775,19 +775,19 @@ ROLLBACK;
 UPDATE uctest SET f1 = f1 + 10 WHERE CURRENT OF a;
 ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 -- Negative, cursor-agnostic: cannot update external tables
-CREATE EXTERNAL WEB TABLE foo (x text) EXECUTE 'echo "foo";' FORMAT 'TEXT';
+CREATE EXTERNAL WEB TABLE ucexttest (x text) EXECUTE 'echo "foo";' FORMAT 'TEXT';
 BEGIN;
-DECLARE c CURSOR FOR SELECT * FROM foo;
+DECLARE c CURSOR FOR SELECT * FROM ucexttest;
 FETCH 1 from c;
   x  
 -----
  foo
 (1 row)
 
-UPDATE foo SET x = 'bar' WHERE CURRENT OF c;
-ERROR:  cannot update or delete from external relation "foo"
+UPDATE ucexttest SET x = 'bar' WHERE CURRENT OF c;
+ERROR:  cannot update or delete from external relation "ucexttest"
 ROLLBACK;
-DROP EXTERNAL TABLE foo;
+DROP EXTERNAL TABLE ucexttest;
 -- Negative, cursor-agnostic: cannot update AO
 CREATE TEMP TABLE aotest (a int, b text)
 	WITH (appendonly=true);

--- a/src/test/regress/sql/partition_pruning.sql
+++ b/src/test/regress/sql/partition_pruning.sql
@@ -772,7 +772,6 @@ select get_selected_parts('explain analyze select * from DATE_PARTS where month 
 select get_selected_parts('explain analyze select * from DATE_PARTS where month = 3;');  -- Not working (it only produces general)
 
 -- More Equality and General Predicates ---
-drop table if exists foo;
 create table foo(a int, b int)
 partition by list (b)
 (partition p1 values(1,3), partition p2 values(4,2), default partition other);

--- a/src/test/regress/sql/portals_updatable.sql
+++ b/src/test/regress/sql/portals_updatable.sql
@@ -418,14 +418,14 @@ ROLLBACK;
 UPDATE uctest SET f1 = f1 + 10 WHERE CURRENT OF a;
 
 -- Negative, cursor-agnostic: cannot update external tables
-CREATE EXTERNAL WEB TABLE foo (x text) EXECUTE 'echo "foo";' FORMAT 'TEXT';
+CREATE EXTERNAL WEB TABLE ucexttest (x text) EXECUTE 'echo "foo";' FORMAT 'TEXT';
 BEGIN;
-DECLARE c CURSOR FOR SELECT * FROM foo;
+DECLARE c CURSOR FOR SELECT * FROM ucexttest;
 FETCH 1 from c;
-UPDATE foo SET x = 'bar' WHERE CURRENT OF c;
+UPDATE ucexttest SET x = 'bar' WHERE CURRENT OF c;
 ROLLBACK;
 
-DROP EXTERNAL TABLE foo;
+DROP EXTERNAL TABLE ucexttest;
 
 -- Negative, cursor-agnostic: cannot update AO
 CREATE TEMP TABLE aotest (a int, b text)


### PR DESCRIPTION
A Concourse job just failed with a diff like this:

```
*** ./expected/partition_pruning.out	2017-11-16 08:38:51.463996042 +0000
--- ./results/partition_pruning.out	2017-11-16 08:38:51.691996042 +0000
***************
*** 5785,5790 ****
--- 5786,5793 ----

  -- More Equality and General Predicates ---
  drop table if exists foo;
+ ERROR:  "foo" is not a base table
+ HINT:  Use DROP EXTERNAL TABLE to remove an external table.
  create table foo(a int, b int)
  partition by list (b)
  (partition p1 values(1,3), partition p2 values(4,2), default partition other);
```

That's because both 'partition_pruning' and 'portals_updatable' use a test
table called 'foo', and they are run concurrently in the test scheudle. If
the above 'drop table' happens to run at just the right time, when the table
is created but not yet dropped in 'portals_updatable', you get that error.
The test table in 'partitions_pruning' is created in a different schema,
so creating two tables with the same name would actually be a problem, but
the 'drop table' sees the table created in the public schema, too.

To fix, rename the table in 'portals_updatable', and also remove the above
unnecessary 'drop table. Either one would be enough to fix the race
condition, but might as well do both.