### PR TITLE
concourse: hide gpexpand cluster setup in a task yml

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -2164,20 +2164,7 @@ jobs:
   - task: pre_run_test_setup
     tags: ["ccp"]
     image: centos-gpdb-dev-6
-    config:
-      platform: linux
-      inputs:
-       - name: ccp_src
-       - name: cluster_env_files
-      run:
-        path: bash
-        args:
-        - -c
-        - |
-          set -ex
-          ccp_src/aws/setup_ssh_to_cluster.sh
-          ssh -t mdw "HOST1=mdw HOST2=sdw1 HOST3=sdw2 HOST4=sdw3 HOST5=sdw4 \
-                      bash -c 'ssh-keygen -f ~/.ssh/id_rsa -y > ~/.ssh/id_rsa.pub; for i in mdw sdw{1..4}; do ssh centos@\$i \"sudo chmod 777 /usr/local\"; done'"
+    file: gpdb_src/concourse/tasks/setup_for_gpexpand_to_make_new_gpdb.yml
     on_failure:
       <<: *debug_sleep
   - task: run_tests
@@ -2227,20 +2214,7 @@ jobs:
   - task: pre_run_test_setup
     tags: ["ccp"]
     image: centos-gpdb-dev-6
-    config:
-      platform: linux
-      inputs:
-       - name: ccp_src
-       - name: cluster_env_files
-      run:
-        path: bash
-        args:
-        - -c
-        - |
-          set -ex
-          ccp_src/aws/setup_ssh_to_cluster.sh
-          ssh -t mdw "HOST1=mdw HOST2=sdw1 HOST3=sdw2 HOST4=sdw3 HOST5=sdw4 \
-                      bash -c 'ssh-keygen -f ~/.ssh/id_rsa -y > ~/.ssh/id_rsa.pub; for i in mdw sdw{1..4}; do ssh centos@\$i \"sudo chmod 777 /usr/local\"; done'"
+    file: gpdb_src/concourse/tasks/setup_for_gpexpand_to_make_new_gpdb.yml
     on_failure:
       <<: *debug_sleep
   - task: run_tests

--- a/concourse/tasks/setup_for_gpexpand_to_make_new_gpdb.yml
+++ b/concourse/tasks/setup_for_gpexpand_to_make_new_gpdb.yml
@@ -1,0 +1,13 @@
+platform: linux
+inputs:
+ - name: ccp_src
+ - name: cluster_env_files
+run:
+  path: bash
+  args:
+  - -c
+  - |
+    set -ex
+    ccp_src/aws/setup_ssh_to_cluster.sh
+    ssh -t mdw "HOST1=mdw HOST2=sdw1 HOST3=sdw2 HOST4=sdw3 HOST5=sdw4 \
+      bash -c 'ssh-keygen -f ~/.ssh/id_rsa -y > ~/.ssh/id_rsa.pub; for i in mdw sdw{1..4}; do ssh centos@\$i \"sudo chmod 777 /usr/local\"; done'"


### PR DESCRIPTION
Follow-up to https://github.com/greenplum-db/gpdb/pull/3722

These steps are necessary for:

gpssh assumes that there's a public key already in-place if there's a
private key. When we create the cluster CCP, we don't propagate the
public keys. So, this is a work around for that.

When we run gpseginstall, it creates a tarball of the binary ($GPHOME)
on the same parent directory. Since we have GPDB installed at
/usr/local/greenplum-db, it tries to create the tarball at /usr/local.
Which means we need user permissions for that directory.

Signed-off-by: Marbin Tan <mtan@pivotal.io>

Will plan to backport to 5X_STABLE after https://github.com/greenplum-db/gpdb/pull/3837 gets merged