### PR TITLE
gpcloud: fix autocompress and improve test coverage

### DIFF
--- a/gpAux/extensions/gpcloud/include/s3params.h
+++ b/gpAux/extensions/gpcloud/include/s3params.h
@@ -17,10 +17,12 @@ class S3Params {
           numOfChunks(0),
           lowSpeedLimit(0),
           lowSpeedTime(0),
+          proxy(""),
           debugCurl(false),
           autoCompress(false),
           verifyCert(false),
-          sseType(SSE_NONE) {
+          sseType(SSE_NONE),
+          gpcheckcloud_newline("") {
     }
 
     virtual ~S3Params() {

--- a/gpAux/extensions/gpcloud/src/s3conf.cpp
+++ b/gpAux/extensions/gpcloud/src/s3conf.cpp
@@ -64,18 +64,10 @@ S3Params InitConfig(const string& urlWithOptions) {
                     configSection);
 
     bool useHttps = s3Cfg.GetBool(configSection, "encryption", "true");
-    bool verifyCert = s3Cfg.GetBool(configSection, "verifycert", "true");
 
     string version = s3Cfg.Get(configSection, "version", "");
 
     S3Params params(sourceUrl, useHttps, version, urlRegion);
-
-    string sse_type = s3Cfg.Get(configSection, "server_side_encryption", "");
-    if (sse_type == "sse-s3") {
-        params.setSSEType(SSE_S3);
-    } else {
-        params.setSSEType(SSE_NONE);
-    }
 
     string content = s3Cfg.Get(configSection, "loglevel", "WARNING");
     s3ext_loglevel = getLogLevel(content.c_str());
@@ -107,9 +99,18 @@ S3Params InitConfig(const string& urlWithOptions) {
 
     params.setProxy(s3Cfg.Get(configSection, "proxy", ""));
 
-    params.setGpcheckcloud_newline(s3Cfg.Get(configSection, "gpcheckcloud_newline", "\n"));
+    params.setAutoCompress(s3Cfg.GetBool(configSection, "autocompress", "true"));
 
-    params.setVerifyCert(verifyCert);
+    params.setVerifyCert(s3Cfg.GetBool(configSection, "verifycert", "true"));
+
+    string sse_type = s3Cfg.Get(configSection, "server_side_encryption", "");
+    if (sse_type == "sse-s3") {
+        params.setSSEType(SSE_S3);
+    } else {
+        params.setSSEType(SSE_NONE);
+    }
+
+    params.setGpcheckcloud_newline(s3Cfg.Get(configSection, "gpcheckcloud_newline", "\n"));
 
     CheckEssentialConfig(params);
 

--- a/gpAux/extensions/gpcloud/test/data/s3test.conf
+++ b/gpAux/extensions/gpcloud/test/data/s3test.conf
@@ -49,6 +49,7 @@ secret = "secret_test"
 accessid = "accessid_test"
 encryption = false
 debug_curl = true
+autocompress = false
 
 [smallchunk]
 secret = "secret_test"

--- a/gpAux/extensions/gpcloud/test/s3conf_test.cpp
+++ b/gpAux/extensions/gpcloud/test/s3conf_test.cpp
@@ -31,7 +31,14 @@ TEST(Config, Basic) {
 
     EXPECT_FALSE(params.isDebugCurl());
 
+    EXPECT_EQ("", params.getProxy());
+
+    EXPECT_TRUE(params.isAutoCompress());
+    EXPECT_TRUE(params.isVerifyCert());
+
     EXPECT_EQ(SSE_S3, params.getSSEType());
+
+    EXPECT_EQ("\n", params.getGpcheckcloud_newline());
 }
 
 TEST(Config, SpecialSectionValues) {
@@ -65,6 +72,7 @@ TEST(Config, SpecialSwitches) {
     S3Params params = InitConfig("s3://abc/a config=data/s3test.conf section=special_switches");
 
     EXPECT_TRUE(params.isDebugCurl());
+    EXPECT_FALSE(params.isAutoCompress());
 }
 
 TEST(Config, SectionExist) {


### PR DESCRIPTION
autocompress feature was dropped by mistake, this commit fixes it and
add tests to cover all configuration options.