### PR TITLE
gpMgmt: Update `make` cleanup for gpMgmt directory

### DIFF
--- a/gpMgmt/Makefile
+++ b/gpMgmt/Makefile
@@ -135,6 +135,6 @@ install: generate_greenplum_path_file
 	rm -rf $(DESTDIR)$(prefix)/bin/gpload_test
 	find $(DESTDIR)$(prefix)/lib/python/gppylib -name test -type d | xargs rm -rf
 
-clean:
-	@$(MAKE) -C bin $@
-	@$(MAKE) -C sbin $@
+clean distclean:
+	$(MAKE) -C bin $@
+	$(MAKE) -C sbin $@

--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -259,19 +259,18 @@ solarisTest:
 installcheck:
 	$(MAKE) -C gpload_test $@
 
-.PHONY: clean
-clean :
-	@rm -rf $(PYLIB_SRC_EXT)/$(LOCKFILE_DIR)
-	@rm -rf $(PYLIB_SRC_EXT)/$(PARAMIKO_DIR)
-	@rm -rf $(PYLIB_SRC_EXT)/$(PYCRYPTO_DIR)
-	@rm -rf $(PYLIB_SRC_EXT)/$(PYLINT_DIR)
-	@rm -rf $(PYLIB_SRC_EXT)/$(LOGILAB_COMMON_DIR)
-	@rm -rf $(PYLIB_SRC_EXT)/$(LOGILAB_ASTNG_DIR)
-	@rm -rf $(STREAM_DIR)/stream lib/stream  
-	@rm -rf *.pyc lib/*.pyc
-	@rm -f gpcheckcatc gpcrondumpc gpexpandc gptransferc
-	@rm -f gpconfig_modules/gucs_disallowed_in_file.txt
-	@rm -f gppylib/data/$(GP_MAJORVERSION).json
-
-.PHONY: disclean
-distclean: clean
+clean distclean:
+	rm -rf $(PYLIB_SRC_EXT)/$(LOCKFILE_DIR)
+	rm -rf $(PYLIB_SRC_EXT)/$(PARAMIKO_DIR)
+	rm -rf $(PYLIB_SRC_EXT)/$(PYCRYPTO_DIR)
+	rm -rf $(PYLIB_SRC_EXT)/$(PYLINT_DIR)
+	rm -rf $(PYLIB_SRC_EXT)/$(LOGILAB_COMMON_DIR)
+	rm -rf $(PYLIB_SRC_EXT)/$(LOGILAB_ASTNG_DIR)
+	rm -rf $(PYLIB_SRC_EXT)/$(PYGRESQL_DIR)/build
+	rm -rf $(PYLIB_SRC)/$(PYGRESQL_DIR)/build
+	rm -rf $(PYLIB_SRC)/subprocess32/build
+	rm -rf $(STREAM_DIR)/stream lib/stream
+	rm -rf *.pyc lib/*.pyc
+	rm -f gpcheckcatc gpcrondumpc gpexpandc gptransferc
+	rm -f gpconfig_modules/gucs_disallowed_in_file.txt
+	rm -f gppylib/data/$(GP_MAJORVERSION).json

--- a/gpMgmt/sbin/Makefile
+++ b/gpMgmt/sbin/Makefile
@@ -8,5 +8,5 @@ install:
 	find . -not -path '*Makefile' -type f -exec cp -- {} $(prefix)/sbin/{} \;
 
 
-clean:
+clean distclean:
 	@rm -f *.pyc


### PR DESCRIPTION
When a user runs a `make distclean`, we actually don't cleanup the gpMgmt
directory. This change fixes this issue.

Make the clean more verbose. It's hard to tell what happened without any
feedback from the commands.

Update the clean/distclean to remove pythonSrc/*/build directories as well.