### PR TITLE
 FTS should record transition of primary to SYNC

### DIFF
--- a/contrib/gp_replica_check/Makefile
+++ b/contrib/gp_replica_check/Makefile
@@ -3,9 +3,16 @@ DATA = gp_replica_check--0.0.1.sql
 MODULES = gp_replica_check
 SCRIPTS = gp_replica_check.py
 
+ifdef USE_PGXS
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
+else
+subdir = contrib/gp_replica_check
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif
 
 # For now run only for HEAP as for other object types like Sequence, AO, btree
 # there are still known differences to be fixed.

--- a/gpAux/gpdemo/Makefile
+++ b/gpAux/gpdemo/Makefile
@@ -38,11 +38,11 @@ all:
 cluster create-demo-cluster:
 ifeq ($(enable_segwalrep), yes)
 	@WITH_MIRRORS=false ./demo_cluster.sh # will generate gpdemo-env.sh
-	@if [[ $(WITH_MIRRORS) == true ]]; then \
-	 	. ./gpdemo-env.sh; \
-	 	./gpsegwalrep.py init --host `hostname`; \
-	 	./gpsegwalrep.py start; \
-	 fi
+ifeq ($(WITH_MIRRORS), true)
+	@. ./gpdemo-env.sh; \
+	./gpsegwalrep.py init --host `hostname`; \
+	./gpsegwalrep.py start;
+endif
 	@echo ""
 else
 	@./demo_cluster.sh

--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -271,7 +271,7 @@ getCdbComponentInfo(bool DNSLookupAsError)
 		pRow->hostip = pstrdup(pRow->hostaddrs[0]);
 		Assert(strlen(pRow->hostip) <= INET6_ADDRSTRLEN);
 
-		if (pRow->role != SEGMENT_ROLE_PRIMARY)
+		if (pRow->role != GP_SEGMENT_CONFIGURATION_ROLE_PRIMARY)
 			continue;
 
 		hsEntry = (HostSegsEntry *) hash_search(hostSegsHash, pRow->hostip, HASH_ENTER, &found);
@@ -398,7 +398,7 @@ getCdbComponentInfo(bool DNSLookupAsError)
 	{
 		cdbInfo = &component_databases->segment_db_info[i];
 
-		if (cdbInfo->role != SEGMENT_ROLE_PRIMARY)
+		if (cdbInfo->role != GP_SEGMENT_CONFIGURATION_ROLE_PRIMARY)
 			continue;
 
 		hsEntry = (HostSegsEntry *) hash_search(hostSegsHash, cdbInfo->hostip, HASH_FIND, &found);
@@ -410,7 +410,7 @@ getCdbComponentInfo(bool DNSLookupAsError)
 	{
 		cdbInfo = &component_databases->entry_db_info[i];
 
-		if (cdbInfo->role != SEGMENT_ROLE_PRIMARY)
+		if (cdbInfo->role != GP_SEGMENT_CONFIGURATION_ROLE_PRIMARY)
 			continue;
 
 		hsEntry = (HostSegsEntry *) hash_search(hostSegsHash, cdbInfo->hostip, HASH_FIND, &found);

--- a/src/backend/fts/ftsprobe.c
+++ b/src/backend/fts/ftsprobe.c
@@ -94,13 +94,21 @@ static void
 probeRecordResponse(ProbeConnectionInfo *probeInfo, PGresult *result)
 {
 	probeInfo->result->isPrimaryAlive = true;
+
 	int *isMirrorAlive = (int *) PQgetvalue(result, 0,
 											Anum_fts_probe_response_is_mirror_up);
 	Assert (isMirrorAlive);
 	probeInfo->result->isMirrorAlive = *isMirrorAlive;
 
-	write_log("FTS: segment (content=%d, dbid=%d, role=%c) reported IsMirrorUp %d to the prober.",
-			  probeInfo->segmentId, probeInfo->dbId, probeInfo->role, probeInfo->result->isMirrorAlive);
+	int *isInSync = (int *) PQgetvalue(result, 0,
+									   Anum_fts_probe_response_is_in_sync);
+	Assert (isInSync);
+	probeInfo->result->isInSync = *isInSync;
+
+	write_log("FTS: segment (content=%d, dbid=%d, role=%c) reported isMirrorUp %d and isInSync %d to the prober.",
+			  probeInfo->segmentId, probeInfo->dbId, probeInfo->role,
+			  probeInfo->result->isMirrorAlive,
+			  probeInfo->result->isInSync);
 }
 
 /*

--- a/src/backend/fts/test/Makefile
+++ b/src/backend/fts/test/Makefile
@@ -23,7 +23,6 @@ ftsprobe.t: \
     $(MOCK_DIR)/backend/libpq/fe-connect_mock.o \
     $(MOCK_DIR)/backend/cdb/cdbthreadlog_mock.o
 
-
 fts.t: \
     $(MOCK_DIR)/backend/access/transam/xact_mock.o \
     $(MOCK_DIR)/backend/utils/time/snapmgr_mock.o \

--- a/src/backend/fts/test/fts_test.c
+++ b/src/backend/fts/test/fts_test.c
@@ -26,13 +26,13 @@ static CdbComponentDatabases *
 InitTestCdb(int segCnt, bool has_mirrors, char default_mode)
 {
 	int			i = 0;
-	int 		mirror_multiplier = 1;
+	int			mirror_multiplier = 1;
 
 	if (has_mirrors)
 		mirror_multiplier = 2;
 
 	CdbComponentDatabases *cdb =
-			(CdbComponentDatabases *) palloc(sizeof(CdbComponentDatabases));
+	(CdbComponentDatabases *) palloc(sizeof(CdbComponentDatabases));
 
 	cdb->total_entry_dbs = 1;
 	cdb->total_segment_dbs = segCnt * mirror_multiplier;	/* with mirror? */
@@ -41,9 +41,9 @@ InitTestCdb(int segCnt, bool has_mirrors, char default_mode)
 	cdb->my_segindex = -1;
 	cdb->my_isprimary = true;
 	cdb->entry_db_info = palloc(
-			sizeof(CdbComponentDatabaseInfo) * cdb->total_entry_dbs);
+								sizeof(CdbComponentDatabaseInfo) * cdb->total_entry_dbs);
 	cdb->segment_db_info = palloc(
-			sizeof(CdbComponentDatabaseInfo) * cdb->total_segment_dbs);
+								  sizeof(CdbComponentDatabaseInfo) * cdb->total_segment_dbs);
 
 
 	/* create the master entry_db_info */
@@ -68,12 +68,12 @@ InitTestCdb(int segCnt, bool has_mirrors, char default_mode)
 		if (has_mirrors)
 		{
 			cdbinfo->role = i % 2 ?
-							GP_SEGMENT_CONFIGURATION_ROLE_MIRROR :
-							GP_SEGMENT_CONFIGURATION_ROLE_PRIMARY;
+				GP_SEGMENT_CONFIGURATION_ROLE_MIRROR :
+				GP_SEGMENT_CONFIGURATION_ROLE_PRIMARY;
 
 			cdbinfo->preferred_role = i % 2 ?
-									  GP_SEGMENT_CONFIGURATION_ROLE_MIRROR :
-									  GP_SEGMENT_CONFIGURATION_ROLE_PRIMARY;
+				GP_SEGMENT_CONFIGURATION_ROLE_MIRROR :
+				GP_SEGMENT_CONFIGURATION_ROLE_PRIMARY;
 		}
 		else
 		{
@@ -87,16 +87,17 @@ InitTestCdb(int segCnt, bool has_mirrors, char default_mode)
 	return cdb;
 }
 
-static CdbComponentDatabaseInfo*
+static CdbComponentDatabaseInfo *
 GetSegmentFromCdbComponentDatabases(CdbComponentDatabases *dbs,
 									int16 segindex, char role)
 {
-	int i;
+	int			i;
 
-	for(i = 0; i < dbs->total_segment_dbs; i++)
+	for (i = 0; i < dbs->total_segment_dbs; i++)
 	{
 		CdbComponentDatabaseInfo *cdb = &dbs->segment_db_info[i];
-		if(cdb->segindex == segindex && cdb->role == role)
+
+		if (cdb->segindex == segindex && cdb->role == role)
 			return cdb;
 	}
 	return NULL;
@@ -123,64 +124,64 @@ MockFtsIsActive(bool expected_return_value)
 
 static int
 CheckConfigVals(const Datum *value, /* from the function under test */
-				const Datum *check_value) /* from the test case */
+				const Datum *check_value)	/* from the test case */
 {
-	return datumIsEqual(value[Anum_gp_segment_configuration_status-1],
-						check_value[Anum_gp_segment_configuration_status-1],
+	return datumIsEqual(value[Anum_gp_segment_configuration_status - 1],
+						check_value[Anum_gp_segment_configuration_status - 1],
 						true, false) &&
-		datumIsEqual(value[Anum_gp_segment_configuration_mode-1],
-					 check_value[Anum_gp_segment_configuration_mode-1],
+		datumIsEqual(value[Anum_gp_segment_configuration_mode - 1],
+					 check_value[Anum_gp_segment_configuration_mode - 1],
 					 true, false);
 }
 
 static int
-CheckHistrelVals(const Datum *value, /* from the function under test */
-				 const Datum *check_value) /* from the test case */
+CheckHistrelVals(const Datum *value,	/* from the function under test */
+				 const Datum *check_value)	/* from the test case */
 {
-	return datumIsEqual(value[Anum_gp_configuration_history_dbid-1],
-						check_value[Anum_gp_configuration_history_dbid-1],
+	return datumIsEqual(value[Anum_gp_configuration_history_dbid - 1],
+						check_value[Anum_gp_configuration_history_dbid - 1],
 						true, false) &&
-		   datumIsEqual(value[Anum_gp_configuration_history_desc-1],
-						check_value[Anum_gp_configuration_history_desc-1],
-						false, -1);
+		datumIsEqual(value[Anum_gp_configuration_history_desc - 1],
+					 check_value[Anum_gp_configuration_history_desc - 1],
+					 false, -1);
 }
 
 static void
 probeWalRepUpdateConfig_will_be_called_with(
-		int16 dbid,
-		int16 segindex,
-		bool IsSegmentAlive,
-		bool IsInSync)
+											int16 dbid,
+											int16 segindex,
+											char status,
+											char mode)
 {
 	/* Mock heap_open gp_configuration_history_relation */
 	static RelationData gp_configuration_history_relation;
+
 	expect_value(heap_open, relationId, GpConfigHistoryRelationId);
 	expect_any(heap_open, lockmode);
 	will_return(heap_open, &gp_configuration_history_relation);
 
 	/* Mock heap_open gp_segment_configuration_relation */
 	static RelationData gp_segment_configuration_relation;
+
 	expect_value(heap_open, relationId, GpSegmentConfigRelationId);
 	expect_any(heap_open, lockmode);
 	will_return(heap_open, &gp_segment_configuration_relation);
 
-	char desc[SQL_CMD_BUF_SIZE];
-	Datum *histvals = palloc(sizeof(Datum) * Natts_gp_configuration_history);
+	char		desc[SQL_CMD_BUF_SIZE];
+	Datum	   *histvals = palloc(sizeof(Datum) * Natts_gp_configuration_history);
 
-	histvals[Anum_gp_configuration_history_dbid-1] =
-			Int16GetDatum(dbid);
+	histvals[Anum_gp_configuration_history_dbid - 1] =
+		Int16GetDatum(dbid);
 
 	snprintf(desc, sizeof(desc),
 			 "FTS: update status and mode for dbid %d with contentid %d to %c and %c",
 			 dbid, segindex,
-			 IsSegmentAlive ? GP_SEGMENT_CONFIGURATION_STATUS_UP :
-			 GP_SEGMENT_CONFIGURATION_STATUS_DOWN,
-			 IsInSync ? GP_SEGMENT_CONFIGURATION_MODE_INSYNC :
-			 GP_SEGMENT_CONFIGURATION_MODE_NOTINSYNC
+			 status,
+			 mode
 		);
 
-	histvals[Anum_gp_configuration_history_desc-1] =
-			CStringGetTextDatum(desc);
+	histvals[Anum_gp_configuration_history_desc - 1] =
+		CStringGetTextDatum(desc);
 
 
 	/* Mock heap_form_tuple inline function */
@@ -224,18 +225,19 @@ probeWalRepUpdateConfig_will_be_called_with(
 	will_be_called_count(systable_beginscan, 1);
 
 	static HeapTupleData config_tuple;
+
 	expect_any(systable_getnext, sysscan);
 	will_return(systable_getnext, &config_tuple);
 
-	Datum *configvals = palloc(sizeof(Datum) * Natts_gp_segment_configuration);
-	configvals[Anum_gp_segment_configuration_status-1] =
-			CharGetDatum(IsSegmentAlive ? GP_SEGMENT_CONFIGURATION_STATUS_UP :
-						 GP_SEGMENT_CONFIGURATION_STATUS_DOWN);
-	configvals[Anum_gp_segment_configuration_mode-1] =
-			CharGetDatum(IsInSync ? GP_SEGMENT_CONFIGURATION_MODE_INSYNC :
-						 GP_SEGMENT_CONFIGURATION_MODE_NOTINSYNC);
+	Datum	   *configvals = palloc(sizeof(Datum) * Natts_gp_segment_configuration);
 
-	HeapTuple new_tuple = palloc(sizeof(HeapTupleData));
+	configvals[Anum_gp_segment_configuration_status - 1] =
+		CharGetDatum(status);
+	configvals[Anum_gp_segment_configuration_mode - 1] =
+		CharGetDatum(mode);
+
+	HeapTuple	new_tuple = palloc(sizeof(HeapTupleData));
+
 	expect_any(heap_modify_tuple, tuple);
 	expect_any(heap_modify_tuple, tupleDesc);
 	expect_check(heap_modify_tuple, replValues, CheckConfigVals, configvals);
@@ -253,34 +255,37 @@ probeWalRepUpdateConfig_will_be_called_with(
 }
 
 static void
-MockPrimaryAndMirrorProbeResponse(CdbComponentDatabases *cdbs,
-								  probe_response_per_segment *response,
-								  bool UpdatePrimary, bool UpdateMirror)
+ExpectedPrimaryAndMirrorConfiguration(CdbComponentDatabases *cdbs,
+									  CdbComponentDatabaseInfo *primary,
+									  char primaryStatus,
+									  char mirrorStatus,
+									  char mode,
+									  bool willUpdatePrimary,
+									  bool willUpdateMirror)
 {
-	CdbComponentDatabaseInfo *primary = response->segment_db_info;
-
-	CdbComponentDatabaseInfo *mirror =
-		FtsGetPeerSegment(cdbs, primary->segindex, primary->dbid);
-
 	/* mock FtsIsActive true */
 	MockFtsIsActive(true);
 
 	/* mock probeWalRepUpdateConfig */
-	if (UpdatePrimary) {
-		probeWalRepUpdateConfig_will_be_called_with(
-				primary->dbid,
-				primary->segindex,
-				response->result.isPrimaryAlive,
-				response->result.isInSync);
-	}
-
-	if (UpdateMirror)
+	if (willUpdatePrimary)
 	{
 		probeWalRepUpdateConfig_will_be_called_with(
-				mirror->dbid,
-				mirror->segindex,
-				response->result.isMirrorAlive,
-				response->result.isInSync);
+													primary->dbid,
+													primary->segindex,
+													primaryStatus,
+													mode);
+	}
+
+	if (willUpdateMirror)
+	{
+		CdbComponentDatabaseInfo *mirror =
+		FtsGetPeerSegment(cdbs, primary->segindex, primary->dbid);
+
+		probeWalRepUpdateConfig_will_be_called_with(
+													mirror->dbid,
+													mirror->segindex,
+													mirrorStatus,
+													mode);
 	}
 }
 
@@ -300,7 +305,7 @@ test_probeWalRepPublishUpdate_for_zero_segment(void **state)
 
 	context.count = 0;
 
-	bool is_updated = probeWalRepPublishUpdate(NULL, &context);
+	bool		is_updated = probeWalRepPublishUpdate(NULL, &context);
 
 	assert_false(is_updated);
 }
@@ -312,17 +317,20 @@ void
 test_probeWalRepPublishUpdate_for_FtsIsActive_false(void **state)
 {
 	probe_context context;
+
 	context.count = 1;
 	probe_response_per_segment response;
+
 	context.responses = &response;
 	CdbComponentDatabaseInfo info;
+
 	response.segment_db_info = &info;
 	info.role = GP_SEGMENT_CONFIGURATION_ROLE_PRIMARY;
 
 	/* mock FtsIsActive false */
 	MockFtsIsActive(false);
 
-	bool is_updated = probeWalRepPublishUpdate(NULL, &context);
+	bool		is_updated = probeWalRepPublishUpdate(NULL, &context);
 
 	assert_false(is_updated);
 }
@@ -334,10 +342,13 @@ void
 test_probeWalRepPublishUpdate_for_shutdown_requested(void **state)
 {
 	probe_context context;
+
 	context.count = 1;
 	probe_response_per_segment response;
+
 	context.responses = &response;
 	CdbComponentDatabaseInfo info;
+
 	response.segment_db_info = &info;
 	info.role = GP_SEGMENT_CONFIGURATION_ROLE_PRIMARY;
 
@@ -345,7 +356,7 @@ test_probeWalRepPublishUpdate_for_shutdown_requested(void **state)
 	shutdown_requested = true;
 	MockFtsIsActive(true);
 
-	bool is_updated = probeWalRepPublishUpdate(NULL, &context);
+	bool		is_updated = probeWalRepPublishUpdate(NULL, &context);
 
 	/* restore the original value to let the rest of the test pass */
 	shutdown_requested = false;
@@ -372,7 +383,7 @@ test_PrimayUpMirrorUpNotInSync_to_PrimayUpMirrorUpNotInSync(void **state)
 	context.responses[1].result.isPrimaryAlive = true;
 
 	/* probeWalRepPublishUpdate should not update a probe state */
-	bool is_updated = probeWalRepPublishUpdate(cdb_component_dbs, &context);
+	bool		is_updated = probeWalRepPublishUpdate(cdb_component_dbs, &context);
 
 	assert_false(is_updated);
 	pfree(cdb_component_dbs);
@@ -400,7 +411,7 @@ test_PrimayUpMirrorUpNotInSync_to_PrimaryDown(void **state)
 	context.responses[1].result.isPrimaryAlive = true;
 
 	/* No update must happen */
-	bool is_updated = probeWalRepPublishUpdate(cdb_component_dbs, &context);
+	bool		is_updated = probeWalRepPublishUpdate(cdb_component_dbs, &context);
 
 	assert_false(is_updated);
 	pfree(cdb_component_dbs);
@@ -433,9 +444,15 @@ test_PrimayUpMirrorUpNotInSync_to_PrimaryUpMirrorDownNotInSync(void **state)
 
 	/* the mirror will be updated */
 	PrimaryOrMirrorWillBeUpdated(1);
-	MockPrimaryAndMirrorProbeResponse(cdb_component_dbs, &context.responses[0], false, true);
+	ExpectedPrimaryAndMirrorConfiguration(cdb_component_dbs,
+										   /* primary */ context.responses[0].segment_db_info,
+										   /* primary status */ GP_SEGMENT_CONFIGURATION_STATUS_UP,
+										   /* mirror status */ GP_SEGMENT_CONFIGURATION_STATUS_DOWN,
+										   /* mode */ GP_SEGMENT_CONFIGURATION_MODE_NOTINSYNC,
+										   /* willUpdatePrimary */ false,
+										   /* willUpdateMirror */ true);
 
-	bool is_updated = probeWalRepPublishUpdate(cdb_component_dbs, &context);
+	bool		is_updated = probeWalRepPublishUpdate(cdb_component_dbs, &context);
 
 	assert_true(is_updated);
 	pfree(cdb_component_dbs);
@@ -457,8 +474,9 @@ test_PrimaryUpMirrorDownNotInSync_to_PrimayUpMirrorUpNotInSync(void **state)
 
 	/* set the mirror down in config */
 	CdbComponentDatabaseInfo *cdbinfo =
-			GetSegmentFromCdbComponentDatabases(
-				cdb_component_dbs, 0, GP_SEGMENT_CONFIGURATION_ROLE_MIRROR);
+	GetSegmentFromCdbComponentDatabases(
+										cdb_component_dbs, 0, GP_SEGMENT_CONFIGURATION_ROLE_MIRROR);
+
 	cdbinfo->status = GP_SEGMENT_CONFIGURATION_STATUS_DOWN;
 
 	FtsWalRepInitProbeContext(cdb_component_dbs, &context);
@@ -476,9 +494,15 @@ test_PrimaryUpMirrorDownNotInSync_to_PrimayUpMirrorUpNotInSync(void **state)
 
 	/* the mirror will be updated */
 	PrimaryOrMirrorWillBeUpdated(1);
-	MockPrimaryAndMirrorProbeResponse(cdb_component_dbs, &context.responses[0], false, true);
+	ExpectedPrimaryAndMirrorConfiguration(cdb_component_dbs,
+										   /* primary */ context.responses[0].segment_db_info,
+										   /* primary status */ GP_SEGMENT_CONFIGURATION_STATUS_UP,
+										   /* mirror status */ GP_SEGMENT_CONFIGURATION_STATUS_UP,
+										   /* mode */ GP_SEGMENT_CONFIGURATION_MODE_NOTINSYNC,
+										   /* willUpdatePrimary */ false,
+										   /* willUpdateMirror */ true);
 
-	bool is_updated = probeWalRepPublishUpdate(cdb_component_dbs, &context);
+	bool		is_updated = probeWalRepPublishUpdate(cdb_component_dbs, &context);
 
 	assert_true(is_updated);
 	pfree(cdb_component_dbs);
@@ -503,8 +527,9 @@ test_probeWalRepPublishUpdate_multiple_segments(void **state)
 	 * indicates it's up.
 	 */
 	CdbComponentDatabaseInfo *cdbinfo =
-			GetSegmentFromCdbComponentDatabases(
-				cdb_component_dbs, 0, GP_SEGMENT_CONFIGURATION_ROLE_MIRROR);
+	GetSegmentFromCdbComponentDatabases(
+										cdb_component_dbs, 0, GP_SEGMENT_CONFIGURATION_ROLE_MIRROR);
+
 	cdbinfo->status = GP_SEGMENT_CONFIGURATION_STATUS_DOWN;
 
 	FtsWalRepInitProbeContext(cdb_component_dbs, &context);
@@ -525,14 +550,30 @@ test_probeWalRepPublishUpdate_multiple_segments(void **state)
 	/* we are updating two of the four segments */
 	PrimaryOrMirrorWillBeUpdated(2);
 
-	/* the mirror will be updated */
-	MockPrimaryAndMirrorProbeResponse(cdb_component_dbs, &context.responses[0], false, true);
-	/* Second segment acts as double fault as not in sync and primary probe failed */
-	/* Third segment the mirror will be updated */
-	MockPrimaryAndMirrorProbeResponse(cdb_component_dbs, &context.responses[2], false, true);
-	/* the fourth segment will not change status */
+	/* First segment */
+	ExpectedPrimaryAndMirrorConfiguration(cdb_component_dbs,
+										   /* primary */ context.responses[0].segment_db_info,
+										   /* primary status */ GP_SEGMENT_CONFIGURATION_STATUS_UP,
+										   /* mirror status */ GP_SEGMENT_CONFIGURATION_STATUS_UP,
+										   /* mode */ GP_SEGMENT_CONFIGURATION_MODE_NOTINSYNC,
+										   /* willUpdatePrimary */ false,
+										   /* willUpdateMirror */ true);
 
-	bool is_updated = probeWalRepPublishUpdate(cdb_component_dbs, &context);
+	/*
+	 * Second segment acts as double fault as not in sync and primary probe
+	 * failed
+	 */
+	/* Third segment */
+	ExpectedPrimaryAndMirrorConfiguration(cdb_component_dbs,
+										   /* primary */ context.responses[2].segment_db_info,
+										   /* primary status */ GP_SEGMENT_CONFIGURATION_STATUS_UP,
+										   /* mirror status */ GP_SEGMENT_CONFIGURATION_STATUS_DOWN,
+										   /* mode */ GP_SEGMENT_CONFIGURATION_MODE_NOTINSYNC,
+										   /* willUpdatePrimary */ false,
+										   /* willUpdateMirror */ true);
+	/* Fourth segment will not change status */
+
+	bool		is_updated = probeWalRepPublishUpdate(cdb_component_dbs, &context);
 
 	assert_true(is_updated);
 	pfree(cdb_component_dbs);
@@ -542,7 +583,8 @@ test_probeWalRepPublishUpdate_multiple_segments(void **state)
  * 1 segment, is_updated is true, because primary and mirror will be
  * marked not in sync
  */
-void test_PrimayUpMirrorUpSync_to_PrimaryUpMirrorUpNotInSync(void **state)
+void
+test_PrimayUpMirrorUpSync_to_PrimaryUpMirrorUpNotInSync(void **state)
 {
 	probe_context context;
 	CdbComponentDatabases *cdb_component_dbs;
@@ -561,10 +603,15 @@ void test_PrimayUpMirrorUpSync_to_PrimaryUpMirrorUpNotInSync(void **state)
 	/* we are updating one segment pair */
 	PrimaryOrMirrorWillBeUpdated(1);
 
-	/* primary and mirror both will be updated */
-	MockPrimaryAndMirrorProbeResponse(cdb_component_dbs, &context.responses[0], true, true);
+	ExpectedPrimaryAndMirrorConfiguration(cdb_component_dbs,
+										   /* primary */ context.responses[0].segment_db_info,
+										   /* primary status */ GP_SEGMENT_CONFIGURATION_STATUS_UP,
+										   /* mirror status */ GP_SEGMENT_CONFIGURATION_STATUS_UP,
+										   /* mode */ GP_SEGMENT_CONFIGURATION_MODE_NOTINSYNC,
+										   /* willUpdatePrimary */ true,
+										   /* willUpdateMirror */ true);
 
-	bool is_updated = probeWalRepPublishUpdate(cdb_component_dbs, &context);
+	bool		is_updated = probeWalRepPublishUpdate(cdb_component_dbs, &context);
 
 	assert_true(is_updated);
 	pfree(cdb_component_dbs);
@@ -574,7 +621,8 @@ void test_PrimayUpMirrorUpSync_to_PrimaryUpMirrorUpNotInSync(void **state)
  * 1 segment, is_updated is true, because mirror will be marked down and
  * both will be marked not in sync
  */
-void test_PrimayUpMirrorUpSync_to_PrimaryUpMirrorDownNotInSync(void **state)
+void
+test_PrimayUpMirrorUpSync_to_PrimaryUpMirrorDownNotInSync(void **state)
 {
 	probe_context context;
 	CdbComponentDatabases *cdb_component_dbs;
@@ -594,10 +642,15 @@ void test_PrimayUpMirrorUpSync_to_PrimaryUpMirrorDownNotInSync(void **state)
 	/* we are updating one segment pair */
 	PrimaryOrMirrorWillBeUpdated(1);
 
-	/* primary and mirror both will be updated */
-	MockPrimaryAndMirrorProbeResponse(cdb_component_dbs, &context.responses[0], true, true);
+	ExpectedPrimaryAndMirrorConfiguration(cdb_component_dbs,
+										   /* primary */ context.responses[0].segment_db_info,
+										   /* primary status */ GP_SEGMENT_CONFIGURATION_STATUS_UP,
+										   /* mirror status */ GP_SEGMENT_CONFIGURATION_STATUS_DOWN,
+										   /* mode */ GP_SEGMENT_CONFIGURATION_MODE_NOTINSYNC,
+										   /* willUpdatePrimary */ true,
+										   /* willUpdateMirror */ true);
 
-	bool is_updated = probeWalRepPublishUpdate(cdb_component_dbs, &context);
+	bool		is_updated = probeWalRepPublishUpdate(cdb_component_dbs, &context);
 
 	assert_true(is_updated);
 	pfree(cdb_component_dbs);
@@ -607,7 +660,8 @@ void test_PrimayUpMirrorUpSync_to_PrimaryUpMirrorDownNotInSync(void **state)
  * 1 segment, is_updated is true, because primary will be marked down and
  * both will be marked not in sync
  */
-void test_PrimayUpMirrorUpSync_to_PrimaryDown(void **state)
+void
+test_PrimayUpMirrorUpSync_to_PrimaryDown(void **state)
 {
 	probe_context context;
 	CdbComponentDatabases *cdb_component_dbs;
@@ -625,10 +679,15 @@ void test_PrimayUpMirrorUpSync_to_PrimaryDown(void **state)
 	/* we are updating one segment pair */
 	PrimaryOrMirrorWillBeUpdated(1);
 
-	/* primary and mirror both will be updated */
-	MockPrimaryAndMirrorProbeResponse(cdb_component_dbs, &context.responses[0], true, true);
+	ExpectedPrimaryAndMirrorConfiguration(cdb_component_dbs,
+										   /* primary */ context.responses[0].segment_db_info,
+										   /* primary status */ GP_SEGMENT_CONFIGURATION_STATUS_DOWN,
+										   /* mirror status */ GP_SEGMENT_CONFIGURATION_STATUS_UP,
+										   /* mode */ GP_SEGMENT_CONFIGURATION_MODE_NOTINSYNC,
+										   /* willUpdatePrimary */ true,
+										   /* willUpdateMirror */ true);
 
-	bool is_updated = probeWalRepPublishUpdate(cdb_component_dbs, &context);
+	bool		is_updated = probeWalRepPublishUpdate(cdb_component_dbs, &context);
 
 	assert_true(is_updated);
 	pfree(cdb_component_dbs);
@@ -657,10 +716,15 @@ test_PrimayUpMirrorUpNotInSync_to_PrimayUpMirrorUpSync(void **state)
 	/* we are updating one segment pair */
 	PrimaryOrMirrorWillBeUpdated(1);
 
-	/* primary and mirror both will be updated */
-	MockPrimaryAndMirrorProbeResponse(cdb_component_dbs, &context.responses[0], true, true);
+	ExpectedPrimaryAndMirrorConfiguration(cdb_component_dbs,
+										   /* primary */ context.responses[0].segment_db_info,
+										   /* primary status */ GP_SEGMENT_CONFIGURATION_STATUS_UP,
+										   /* mirror status */ GP_SEGMENT_CONFIGURATION_STATUS_UP,
+										   /* mode */ GP_SEGMENT_CONFIGURATION_MODE_INSYNC,
+										   /* willUpdatePrimary */ true,
+										   /* willUpdateMirror */ true);
 
-	bool is_updated = probeWalRepPublishUpdate(cdb_component_dbs, &context);
+	bool		is_updated = probeWalRepPublishUpdate(cdb_component_dbs, &context);
 
 	assert_true(is_updated);
 	pfree(cdb_component_dbs);
@@ -682,8 +746,9 @@ test_PrimaryUpMirrorDownNotInSync_to_PrimayUpMirrorUpSync(void **state)
 
 	/* set the mirror down in config */
 	CdbComponentDatabaseInfo *cdbinfo =
-			GetSegmentFromCdbComponentDatabases(
-				cdb_component_dbs, 0, GP_SEGMENT_CONFIGURATION_ROLE_MIRROR);
+	GetSegmentFromCdbComponentDatabases(
+										cdb_component_dbs, 0, GP_SEGMENT_CONFIGURATION_ROLE_MIRROR);
+
 	cdbinfo->status = GP_SEGMENT_CONFIGURATION_STATUS_DOWN;
 
 	FtsWalRepInitProbeContext(cdb_component_dbs, &context);
@@ -696,10 +761,15 @@ test_PrimaryUpMirrorDownNotInSync_to_PrimayUpMirrorUpSync(void **state)
 	/* we are updating one segment pair */
 	PrimaryOrMirrorWillBeUpdated(1);
 
-	/* primary and mirror both will be updated */
-	MockPrimaryAndMirrorProbeResponse(cdb_component_dbs, &context.responses[0], true, true);
+	ExpectedPrimaryAndMirrorConfiguration(cdb_component_dbs,
+										   /* primary */ context.responses[0].segment_db_info,
+										   /* primary status */ GP_SEGMENT_CONFIGURATION_STATUS_UP,
+										   /* mirror status */ GP_SEGMENT_CONFIGURATION_STATUS_UP,
+										   /* mode */ GP_SEGMENT_CONFIGURATION_MODE_INSYNC,
+										   /* willUpdatePrimary */ true,
+										   /* willUpdateMirror */ true);
 
-	bool is_updated = probeWalRepPublishUpdate(cdb_component_dbs, &context);
+	bool		is_updated = probeWalRepPublishUpdate(cdb_component_dbs, &context);
 
 	assert_true(is_updated);
 	pfree(cdb_component_dbs);
@@ -711,30 +781,31 @@ test_PrimaryUpMirrorDownNotInSync_to_PrimayUpMirrorUpSync(void **state)
 void
 test_PrimaryUpMirrorDownNotInSync_to_PrimayUpMirrorDownNotInSync(void **state)
 {
-    probe_context context;
-    CdbComponentDatabases *cdb_component_dbs;
+	probe_context context;
+	CdbComponentDatabases *cdb_component_dbs;
 
-    cdb_component_dbs = InitTestCdb(1,
-                                    true,
-                                    GP_SEGMENT_CONFIGURATION_MODE_NOTINSYNC);
+	cdb_component_dbs = InitTestCdb(1,
+									true,
+									GP_SEGMENT_CONFIGURATION_MODE_NOTINSYNC);
 
-    /* set the mirror down in config */
-    CdbComponentDatabaseInfo *cdbinfo =
-            GetSegmentFromCdbComponentDatabases(
-                    cdb_component_dbs, 0, GP_SEGMENT_CONFIGURATION_ROLE_MIRROR);
-    cdbinfo->status = GP_SEGMENT_CONFIGURATION_STATUS_DOWN;
+	/* set the mirror down in config */
+	CdbComponentDatabaseInfo *cdbinfo =
+	GetSegmentFromCdbComponentDatabases(
+										cdb_component_dbs, 0, GP_SEGMENT_CONFIGURATION_ROLE_MIRROR);
 
-    FtsWalRepInitProbeContext(cdb_component_dbs, &context);
+	cdbinfo->status = GP_SEGMENT_CONFIGURATION_STATUS_DOWN;
 
-    /* Probe responded with Mirror Up and SYNC */
-    context.responses[0].result.isPrimaryAlive = true;
-    context.responses[0].result.isMirrorAlive = false;
-    context.responses[0].result.isInSync = false;
+	FtsWalRepInitProbeContext(cdb_component_dbs, &context);
 
-    bool is_updated = probeWalRepPublishUpdate(cdb_component_dbs, &context);
+	/* Probe responded with Mirror Up and SYNC */
+	context.responses[0].result.isPrimaryAlive = true;
+	context.responses[0].result.isMirrorAlive = false;
+	context.responses[0].result.isInSync = false;
 
-    assert_false(is_updated);
-    pfree(cdb_component_dbs);
+	bool		is_updated = probeWalRepPublishUpdate(cdb_component_dbs, &context);
+
+	assert_false(is_updated);
+	pfree(cdb_component_dbs);
 }
 
 /*
@@ -753,8 +824,9 @@ test_PrimaryUpMirrorDownNotInSync_to_PrimaryDown(void **state)
 
 	/* set the mirror down in config */
 	CdbComponentDatabaseInfo *cdbinfo =
-			GetSegmentFromCdbComponentDatabases(
-				cdb_component_dbs, 0, GP_SEGMENT_CONFIGURATION_ROLE_MIRROR);
+	GetSegmentFromCdbComponentDatabases(
+										cdb_component_dbs, 0, GP_SEGMENT_CONFIGURATION_ROLE_MIRROR);
+
 	cdbinfo->status = GP_SEGMENT_CONFIGURATION_STATUS_DOWN;
 
 	FtsWalRepInitProbeContext(cdb_component_dbs, &context);
@@ -764,18 +836,18 @@ test_PrimaryUpMirrorDownNotInSync_to_PrimaryDown(void **state)
 	/* no change for segment 2, probe returned */
 	context.responses[1].result.isPrimaryAlive = true;
 
-	bool is_updated = probeWalRepPublishUpdate(cdb_component_dbs, &context);
+	bool		is_updated = probeWalRepPublishUpdate(cdb_component_dbs, &context);
 
 	assert_false(is_updated);
 	pfree(cdb_component_dbs);
 }
 
 int
-main(int argc, char* argv[])
+main(int argc, char *argv[])
 {
 	cmockery_parse_arguments(argc, argv);
 
-	const UnitTest tests[] = {
+	const		UnitTest tests[] = {
 		/* -----------------------------------------------------------------------
 		 * Group of tests for probeWalRepPublishUpdate()
 		 * -----------------------------------------------------------------------
@@ -796,7 +868,7 @@ main(int argc, char* argv[])
 
 		unit_test(test_PrimaryUpMirrorDownNotInSync_to_PrimayUpMirrorUpSync),
 		unit_test(test_PrimaryUpMirrorDownNotInSync_to_PrimayUpMirrorUpNotInSync),
-        unit_test(test_PrimaryUpMirrorDownNotInSync_to_PrimayUpMirrorDownNotInSync),
+		unit_test(test_PrimaryUpMirrorDownNotInSync_to_PrimayUpMirrorDownNotInSync),
 		unit_test(test_PrimaryUpMirrorDownNotInSync_to_PrimaryDown)
 		/*-----------------------------------------------------------------------*/
 	};

--- a/src/backend/fts/test/ftsprobehandler_test.c
+++ b/src/backend/fts/test/ftsprobehandler_test.c
@@ -20,9 +20,9 @@ void AssertFailed()
 void
 test_HandleFtsWalRepProbe(void **state)
 {
-	bool expected_mirror_state = true;
-
-	will_return(IsMirrorUp, expected_mirror_state);
+	expect_any(GetMirrorStatus, IsMirrorUp);
+	expect_any(GetMirrorStatus, IsInSync);
+	will_be_called(GetMirrorStatus);
 
 	expect_value(BeginCommand, commandTag, FTS_MSG_TYPE_PROBE);
 	expect_value(BeginCommand, dest, DestRemote);

--- a/src/backend/replication/gp_replication.c
+++ b/src/backend/replication/gp_replication.c
@@ -22,9 +22,10 @@
  * True: if any mirror is up.
  * False: if none of the mirrors is up.
  */
-bool IsMirrorUp(void)
+void GetMirrorStatus(bool *IsMirrorUp, bool *IsInSync)
 {
-	bool IsMirrorUp = false;
+	*IsMirrorUp = false;
+	*IsInSync = false;
 
 	/*
 	 * Greenplum currently supports only ONE mirror per primary.
@@ -42,15 +43,17 @@ bool IsMirrorUp(void)
 		if (walsnd->pid != 0)
 		{
 			if(walsnd->state == WALSNDSTATE_CATCHUP
-				|| walsnd->state == WALSNDSTATE_STREAMING)
+			   || walsnd->state == WALSNDSTATE_STREAMING)
 			{
-				IsMirrorUp = true;
+				*IsMirrorUp = true;
+
+				if (walsnd->state == WALSNDSTATE_STREAMING)
+					*IsInSync = true;
+
 				break;
 			}
 		}
 	}
 
 	LWLockRelease(SyncRepLock);
-
-	return IsMirrorUp;
 }

--- a/src/backend/replication/test/gp_replication_test.c
+++ b/src/backend/replication/test/gp_replication_test.c
@@ -40,47 +40,77 @@ test_setup(WalSndCtlData *data, WalSndState state)
 }
 
 void
-test_IsMirrorUp_Pid_Zero(void **state)
+test_GetMirrorStatus_Pid_Zero(void **state)
 {
-	max_wal_senders = 1;
+	bool isMirrorUp;
+	bool isInSync;
 	WalSndCtlData data;
+
+	max_wal_senders = 1;
 	WalSndCtl = &data;
 	data.walsnds[0].pid = 0;
 
 	expect_lwlock();
-	assert_false(IsMirrorUp());
+	GetMirrorStatus(&isMirrorUp, &isInSync);
+
+	assert_false(isMirrorUp);
+	assert_false(isInSync);
 }
 
 void
-test_IsMirrorUp_WALSNDSTATE_STARTUP(void **state)
+test_GetMirrorStatus_WALSNDSTATE_STARTUP(void **state)
 {
+	bool isMirrorUp;
+	bool isInSync;
 	WalSndCtlData data;
+
 	test_setup(&data, WALSNDSTATE_STARTUP);
-	assert_false(IsMirrorUp());
+	GetMirrorStatus(&isMirrorUp, &isInSync);
+
+	assert_false(isMirrorUp);
+	assert_false(isInSync);
 }
 
 void
-test_IsMirrorUp_WALSNDSTATE_BACKUP(void **state)
+test_GetMirrorStatus_WALSNDSTATE_BACKUP(void **state)
 {
+	bool isMirrorUp;
+	bool isInSync;
 	WalSndCtlData data;
+
 	test_setup(&data, WALSNDSTATE_BACKUP);
-	assert_false(IsMirrorUp());
+	GetMirrorStatus(&isMirrorUp, &isInSync);
+
+	assert_false(isMirrorUp);
+	assert_false(isInSync);
 }
 
 void
-test_IsMirrorUp_WALSNDSTATE_CATCHUP(void **state)
+test_GetMirrorStatus_WALSNDSTATE_CATCHUP(void **state)
 {
+	bool isMirrorUp;
+	bool isInSync;
 	WalSndCtlData data;
+
 	test_setup(&data, WALSNDSTATE_CATCHUP);
-	assert_true(IsMirrorUp());
+	GetMirrorStatus(&isMirrorUp, &isInSync);
+
+	assert_true(isMirrorUp);
+	assert_false(isInSync);
 }
 
 void
-test_IsMirrorUp_WALSNDSTATE_STREAMING(void **state)
+test_GetMirrorStatus_WALSNDSTATE_STREAMING(void **state)
 {
+	bool isMirrorUp;
+	bool isInSync;
 	WalSndCtlData data;
+
 	test_setup(&data, WALSNDSTATE_STREAMING);
-	assert_true(IsMirrorUp());
+	GetMirrorStatus(&isMirrorUp, &isInSync);
+
+	assert_true(isMirrorUp);
+	assert_true(isInSync);
 }
 
 int
@@ -89,11 +119,11 @@ main(int argc, char* argv[])
 	cmockery_parse_arguments(argc, argv);
 
 	const UnitTest tests[] = {
-		unit_test(test_IsMirrorUp_Pid_Zero),
-		unit_test(test_IsMirrorUp_WALSNDSTATE_STARTUP),
-		unit_test(test_IsMirrorUp_WALSNDSTATE_BACKUP),
-		unit_test(test_IsMirrorUp_WALSNDSTATE_CATCHUP),
-		unit_test(test_IsMirrorUp_WALSNDSTATE_STREAMING)
+		unit_test(test_GetMirrorStatus_Pid_Zero),
+		unit_test(test_GetMirrorStatus_WALSNDSTATE_STARTUP),
+		unit_test(test_GetMirrorStatus_WALSNDSTATE_BACKUP),
+		unit_test(test_GetMirrorStatus_WALSNDSTATE_CATCHUP),
+		unit_test(test_GetMirrorStatus_WALSNDSTATE_STREAMING)
 	};
 	return run_tests(tests);
 }

--- a/src/include/cdb/cdbutil.h
+++ b/src/include/cdb/cdbutil.h
@@ -22,6 +22,7 @@
  */
 
 #include <math.h>
+#include "catalog/gp_segment_config.h"
 
 /* cdb_rand returns a random float value between 0 and 1 inclusive */
 #define cdb_rand() ((double) random() / (double) MAX_RANDOM_VALUE)
@@ -64,16 +65,18 @@ typedef struct CdbComponentDatabaseInfo
 	int16		hostSegs;		/* number of primary segments on the same hosts */
 } CdbComponentDatabaseInfo;
 
-#define SEGMENT_ROLE_PRIMARY 'p'
-#define SEGMENT_ROLE_MIRROR 'm'
-
 #define SEGMENT_IS_ACTIVE_MIRROR(p) \
-	((p)->role == SEGMENT_ROLE_MIRROR ? true : false)
+	((p)->role == GP_SEGMENT_CONFIGURATION_ROLE_MIRROR ? true : false)
 #define SEGMENT_IS_ACTIVE_PRIMARY(p) \
-	((p)->role == SEGMENT_ROLE_PRIMARY ? true : false)
+	((p)->role == GP_SEGMENT_CONFIGURATION_ROLE_PRIMARY ? true : false)
 
-#define SEGMENT_IS_ALIVE(p) ((p)->status == 'u' ? true : false)
+#define SEGMENT_IS_ALIVE(p) \
+	((p)->status == GP_SEGMENT_CONFIGURATION_STATUS_UP ? true : false)
 
+#define SEGMENT_IS_IN_SYNC(p) \
+	((p)->mode == GP_SEGMENT_CONFIGURATION_MODE_INSYNC ? true : false)
+#define SEGMENT_IS_NOT_INSYNC(p) \
+	((p)->mode == GP_SEGMENT_CONFIGURATION_MODE_NOTINSYNC ? true : false)
 
 /* --------------------------------------------------------------------------------------------------
  * Structure for return value from getCdbSegmentDatabases()

--- a/src/include/postmaster/fts.h
+++ b/src/include/postmaster/fts.h
@@ -23,8 +23,10 @@
 /* Queries for FTS messages */
 #define	FTS_MSG_TYPE_PROBE "PROBE"
 
-#define Natts_fts_probe_response 1
+#define Natts_fts_probe_response 2
 #define Anum_fts_probe_response_is_mirror_up 0
+#define Anum_fts_probe_response_is_in_sync 1
+
 #define FTS_PROBE_RESPONSE_NTUPLES 1
 
 typedef struct
@@ -32,6 +34,7 @@ typedef struct
 	int16 dbid;
 	bool isPrimaryAlive;
 	bool isMirrorAlive;
+	bool isInSync;
 } probe_result;
 
 typedef struct
@@ -50,6 +53,7 @@ typedef struct
 typedef struct ProbeResponse
 {
 	bool IsMirrorUp;
+	bool IsInSync;
 } ProbeResponse;
 
 #endif

--- a/src/include/replication/gp_replication.h
+++ b/src/include/replication/gp_replication.h
@@ -16,6 +16,6 @@
 
 #include "postgres.h"
 
-extern bool IsMirrorUp(void);
+extern void GetMirrorStatus(bool *IsMirrorUp, bool *IsInSync);
 
-#endif //GPDB_GP_REPLICATION_H
+#endif

--- a/src/test/walrep/expected/replication_views_mirrored.out
+++ b/src/test/walrep/expected/replication_views_mirrored.out
@@ -5,9 +5,8 @@ SELECT count(*) FROM gp_segment_configuration where preferred_role='m' and statu
      3
 (1 row)
 
--- Check how many WAL replication mirrors are up and not-in-sync
--- FIXME: mode should be 's', pending FTS changes
-SELECT count(*) FROM gp_segment_configuration where preferred_role='m' and mode='n';
+-- Check how many WAL replication mirrors are up and in-sync
+SELECT count(*) FROM gp_segment_configuration where preferred_role='m' and mode='s';
  count 
 -------
      3

--- a/src/test/walrep/sql/replication_views_mirrored.sql
+++ b/src/test/walrep/sql/replication_views_mirrored.sql
@@ -1,9 +1,8 @@
 -- Check how many WAL replication mirrors are up
 SELECT count(*) FROM gp_segment_configuration where preferred_role='m' and status='u';
 
--- Check how many WAL replication mirrors are up and not-in-sync
--- FIXME: mode should be 's', pending FTS changes
-SELECT count(*) FROM gp_segment_configuration where preferred_role='m' and mode='n';
+-- Check how many WAL replication mirrors are up and in-sync
+SELECT count(*) FROM gp_segment_configuration where preferred_role='m' and mode='s';
 
 -- Check pg_stat_replication view (this assumes standby master has not been created)
 SELECT * FROM pg_stat_replication;


### PR DESCRIPTION
Short snippets of commit messages for ease

commit b6f802aa60bdc80735d7e870f9b47e1cc5813f9e

    Do not fast exit SyncRepWaitForLSN() based on SyncStandbysDefined()

    By setting up synchronized replication between primary and standby, commits on
    primary should be blocked by function `SyncRepWaitForLSN()` until its effects
    replicated to the standby. `SyncRepWaitForLSN()` was fast exiting if the
    `SyncStandbysDefined()` is false, which means GUC `synchronous_standby_names` is
    empty.

    There was a race condition where the GUC is set but not reflected by some
    backends. However, the `pg_stat_replication` `sync_state` is `sync`, and the
    `state` is `streaming`, which means the commit should block and get replicated
    to the mirror before it returns.

    The change is to NOT do the fast exit based on the GUC, but only rely on
    `WalSndCtl->sync_standbys_defined`.

    Issue was spotted by Asim Praveen during whiteboard discussion.
    Discussion: https://www.postgresql.org/message-id/flat/CABrsG8j3kPD+kbbsx_isEpFvAgaOBNGyGpsqSjQ6L8vwVUaZAQ@mail.gmail.com

commit baf2d0b49f634fb81db8953261c7ba269d6e2358

    Unit tests for FTS state transitions.

commit 875c8d7a3b53423ad9a2b38529d3af244930765a

    FTS correctly handle double fault scenario.

    When primary and mirror are not in sync, cluster is running with no HA for that
    segment. If FTS fails to probe primary as well, currently nothing much can be
    done except retrying. So, in such case FTS should not mark both the segment as
    down as it would be cure is worse than the disease.

commit 57a5387af7e8a2d5e585a6620a124ff1fc17bc22

    FTS should record transition of primary to SYNC.

    If walsender state transitions to streaming, FTS must record transition of same
    on master in catalog. Recording the state to SYNC will enable failing over to
    mirror incase of need.

commit 92a1665922bdc90649490fc1bac0a20ce2eac05a

    Use macros from gp_segment_config.h and delete redundant definition
