### PR TITLE
Capture and echo stdout and stderr when behave test fails on return code

### DIFF
--- a/gpMgmt/test/behave_utils/utils.py
+++ b/gpMgmt/test/behave_utils/utils.py
@@ -183,9 +183,10 @@ def check_return_code(context, ret_code):
     if context.ret_code != int(ret_code):
         emsg = ""
         if context.error_message:
-            emsg += context.error_message
-        raise Exception(
-            "expected return code '%s' does not equal actual return code '%s' %s" % (ret_code, context.ret_code, emsg))
+            emsg += "STDERR:\n%s\n" % context.error_message
+        if context.stdout_message:
+            emsg += "STDOUT:\n%s\n" % context.stdout_message
+        raise Exception("expected return code '%s' does not equal actual return code '%s' \n%s" % (ret_code, context.ret_code, emsg))
 
 
 def check_not_return_code(context, ret_code):


### PR DESCRIPTION
Addresses issue #3914

This will only show stdout when tests fail on a step that checks the return code. However, this is one of the most frustrating errors to debug and also shows up all over the tests.