### PR TITLE
Fix race condition between DROP IF EXISTS and RENAME again.

### DIFF
--- a/src/test/isolation2/expected/drop_rename.out
+++ b/src/test/isolation2/expected/drop_rename.out
@@ -54,6 +54,40 @@ count
 10   
 (1 row)
 
+-- The same, but with DROP IF EXISTS. (We used to have a bug, where the DROP
+-- command found and drop the relation in the segments, but not in master.)
+1:drop table if exists t3;
+DROP
+1:create table t3 (a int, b text) distributed by (a);
+CREATE
+1:insert into t3 select i, '123 '||i from generate_series(1,10)i;
+INSERT 10
+1:begin;
+BEGIN
+1:alter table t3 rename to t3_new;
+ALTER
+2&:drop table if exists t3;  <waiting ...>
+1:commit;
+COMMIT
+2<:  <... completed>
+DROP
+2:select count(*) from t3;
+ERROR:  relation "t3" does not exist
+LINE 1: select count(*) from t3;
+                             ^
+2:select relname from pg_class where relname like 't3%';
+relname
+-------
+t3_new 
+(1 row)
+2:select relname from gp_dist_random('pg_class') where relname like 't3%';
+relname
+-------
+t3_new 
+t3_new 
+t3_new 
+(3 rows)
+
 1:drop table if exists t3;
 DROP
 1:create table t3 (a int, b text) distributed by (a);
@@ -76,4 +110,3 @@ DROP
 ERROR:  relation "t3" does not exist
 LINE 1: select count(*) from t3;
                              ^
-

--- a/src/test/isolation2/sql/drop_rename.sql
+++ b/src/test/isolation2/sql/drop_rename.sql
@@ -29,6 +29,20 @@
 2<:
 2:select count(*) from newt2;
 
+-- The same, but with DROP IF EXISTS. (We used to have a bug, where the DROP
+-- command found and drop the relation in the segments, but not in master.)
+1:drop table if exists t3;
+1:create table t3 (a int, b text) distributed by (a);
+1:insert into t3 select i, '123 '||i from generate_series(1,10)i;
+1:begin;
+1:alter table t3 rename to t3_new;
+2&:drop table if exists t3;
+1:commit;
+2<:
+2:select count(*) from t3;
+2:select relname from pg_class where relname like 't3%';
+2:select relname from gp_dist_random('pg_class') where relname like 't3%';
+
 1:drop table if exists t3;
 1:create table t3 (a int, b text) distributed by (a);
 1:insert into t3 select i, '123 '||i from generate_series(1,10)i;
@@ -40,4 +54,3 @@
 3<:
 2<:
 2:select count(*) from t3;
-


### PR DESCRIPTION
If a DROP IF EXISTS is run concurrently with ALTER TABLE RENAME TO, it's
possible that the table gets dropped on master, but not on the segments.
This was fixed earlier already, by commit 4739cd229b, but the fix got lost
during the 8.4 merge. Fix it again, in the same fashion, and also add
a test case so that it won't get lost again, at least not in exactly the
same manner.

Spotted by @kuien, github issue #3874. Thanks to @tvesely for the test
case.