### PR TITLE
add required commas

### DIFF
--- a/concourse/scripts/test_gpdb.py
+++ b/concourse/scripts/test_gpdb.py
@@ -52,8 +52,8 @@ def configure():
                             "--with-perl",
                             "--with-libxml",
                             "--with-python",
-                            "--with-libs=/usr/local/gpdb/lib"
-                            "--with-includes=/usr/local/gpdb/include"
+                            "--with-libs=/usr/local/gpdb/lib",
+                            "--with-includes=/usr/local/gpdb/include",
                             "--prefix=/usr/local/gpdb"], env=p_env, shell=True, cwd="gpdb_src")
 
 


### PR DESCRIPTION
-- apparently the python shelling-out utility is ok without the commas?  the script seems to be working despite this.