### PR TITLE
Enable synchronous WAL replication when primary first detects mirror up

### DIFF
--- a/src/backend/access/transam/test/Makefile
+++ b/src/backend/access/transam/test/Makefile
@@ -23,5 +23,6 @@ xlog.t: \
     $(MOCK_DIR)/backend/replication/walsender_mock.o
 
 xlog_mm.t: \
+	$(MOCK_DIR)/backend/access/transam/xlog_mock.o \
 	$(MOCK_DIR)/backend/access/transam/xlogutils_mock.o \
 	$(MOCK_DIR)/backend/cdb/cdbmirroredappendonly_mock.o

--- a/src/backend/access/transam/test/xlog_mm_test.c
+++ b/src/backend/access/transam/test/xlog_mm_test.c
@@ -14,7 +14,7 @@ check_relfilenode_function(const RelFileNode *value, const RelFileNode *check_va
 }
 
 /*
- * Test that an MMXLOG_REMOVE_FILE AO transaction log record will call
+ * Test that an MMXLOG_REMOVE_APPENDONLY_FILE xlog record will call
  * XLogAODropSegmentFile.
  */
 void
@@ -56,6 +56,9 @@ test_mmxlog_redo_mmxlog_remove_file_ao(void **state)
 	memcpy(buffer, &record, SizeOfXLogRecord);
 	memcpy(&buffer[SizeOfXLogRecord], &xlmmfsobj, sizeof(xl_mm_fs_obj));
 	mockrecord = (XLogRecord *) buffer;
+
+	/* Make sure we are in standby mode for any AO xlog replays */
+	will_return(IsStandbyMode, true);
 
 	/* XLogAODropSegmentFile should be called with our mock relfilenode and segment file number */
 	expect_check(XLogAODropSegmentFile, &rnode, check_relfilenode_function, &relfilenode);

--- a/src/backend/catalog/storage.c
+++ b/src/backend/catalog/storage.c
@@ -1508,6 +1508,11 @@ smgr_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record)
 
 	if (info == XLOG_SMGR_CREATE)
 	{
+/*
+ * Disable replay of XLOG_SMGR_CREATE until persistent tables and MMXLOG
+ * records are removed from Greenplum.
+ */
+#if 0
 		MirrorDataLossTrackingState mirrorDataLossTrackingState;
 		int64		mirrorDataLossTrackingSessionNum;
 
@@ -1525,6 +1530,14 @@ smgr_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record)
 						   mirrorDataLossTrackingSessionNum,
 						   /* ignoreAlreadyExists */ true,
 						   &mirrorDataLossOccurred);
+#endif
+		/*
+		 * Multipass crash recovery using persistent tables will handle
+		 * relation file creation on primary or master. On Standby,
+		 * MMXLOG_CREATE_FILE xlog record replayed in mmxlog_redo will take
+		 * care of things.
+		 */
+		return;
 	}
 	else if (info == XLOG_SMGR_TRUNCATE)
 	{

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -1180,45 +1180,6 @@ gpvars_show_gp_gpperfmon_log_alert_level(void)
 }
 
 /*
- * Request the fault-prober to suspend probes -- no fault actions will
- * be taken based on in-flight probes until the prober is unpaused.
- */
-bool
-gpvars_assign_gp_fts_probe_pause(bool newval, bool doit, GucSource source)
-{
-	if (doit)
-	{
-		/*
-		 * We only want to do fancy stuff on the master (where we have a
-		 * prober).
-		 */
-		if (ftsProbeInfo && Gp_segment == -1)
-		{
-			/*
-			 * fts_pauseProbes is externally set/cleared; fts_cancelProbes is
-			 * externally set and cleared by FTS
-			 */
-			ftsLock();
-			ftsProbeInfo->fts_pauseProbes = newval;
-			ftsProbeInfo->fts_discardResults = ftsProbeInfo->fts_discardResults || newval;
-			ftsUnlock();
-
-			/*
-			 * If we're unpausing, we want to force the prober to re-read
-			 * everything. (we want FtsNotifyProber()).
-			 */
-			if (!newval)
-			{
-				FtsNotifyProber();
-			}
-		}
-		gp_fts_probe_pause = newval;
-	}
-
-	return true;
-}
-
-/*
  * gpvars_assign_gp_resource_manager_policy
  * gpvars_show_gp_resource_manager_policy
  */

--- a/src/backend/fts/ftsprobehandler.c
+++ b/src/backend/fts/ftsprobehandler.c
@@ -69,5 +69,9 @@ HandleFtsWalRepProbe()
 	ProbeResponse response;
 
 	GetMirrorStatus(&response.IsMirrorUp, &response.IsInSync);
+
+	if (response.IsMirrorUp)
+		SetSyncStandbysDefined();
+
 	SendProbeResponse(&response);
 }

--- a/src/backend/fts/test/ftsprobehandler_test.c
+++ b/src/backend/fts/test/ftsprobehandler_test.c
@@ -22,6 +22,7 @@ test_HandleFtsWalRepProbe(void **state)
 {
 	expect_any(GetMirrorStatus, IsMirrorUp);
 	expect_any(GetMirrorStatus, IsInSync);
+	will_assign_value(GetMirrorStatus, IsMirrorUp, true);
 	will_be_called(GetMirrorStatus);
 
 	expect_value(BeginCommand, commandTag, FTS_MSG_TYPE_PROBE);
@@ -61,6 +62,8 @@ test_HandleFtsWalRepProbe(void **state)
 	expect_value(EndCommand, commandTag, FTS_MSG_TYPE_PROBE);
 	expect_value(EndCommand, dest, DestRemote);
 	will_be_called(EndCommand);
+
+	will_be_called(SetSyncStandbysDefined);
 
 	HandleFtsWalRepProbe();
 }

--- a/src/backend/postmaster/checkpointer.c
+++ b/src/backend/postmaster/checkpointer.c
@@ -346,7 +346,9 @@ CheckpointerMain(void)
 	PG_SETMASK(&UnBlockSig);
 
 	/* update global shmem state for sync rep */
+	LWLockAcquire(SyncRepLock, LW_EXCLUSIVE);
 	SyncRepUpdateSyncStandbysDefined();
+	LWLockRelease(SyncRepLock);
 
 	/*
 	 * Loop forever
@@ -376,7 +378,9 @@ CheckpointerMain(void)
 			ProcessConfigFile(PGC_SIGHUP);
 
 			/* update global shmem state for sync rep */
+			LWLockAcquire(SyncRepLock, LW_EXCLUSIVE);
 			SyncRepUpdateSyncStandbysDefined();
+			LWLockRelease(SyncRepLock);
 		}
 		if (checkpoint_requested)
 		{

--- a/src/backend/replication/syncrep.c
+++ b/src/backend/replication/syncrep.c
@@ -645,16 +645,23 @@ SyncRepWakeQueue(bool all, int mode)
  * if synchronous_standby_names is unset.  It's safe to check the current value
  * without the lock, because it's only ever updated by one process.  But we
  * must take the lock to change it.
+ *
+ * In Postgres, the SyncRepLock is taken inside this function since only the
+ * Checkpointer process calls this function.
+ *
+ * In GPDB, the SyncRepLock is taken outside this function because FTS probe
+ * handler will also call this function to bypass sending a SIGHUP to
+ * Checkpointer process for configuration reload.
  */
 void
 SyncRepUpdateSyncStandbysDefined(void)
 {
 	bool		sync_standbys_defined = SyncStandbysDefined();
 
+	Assert(LWLockHeldByMe(SyncRepLock));
+
 	if (sync_standbys_defined != WalSndCtl->sync_standbys_defined)
 	{
-		LWLockAcquire(SyncRepLock, LW_EXCLUSIVE);
-
 		/*
 		 * If synchronous_standby_names has been reset to empty, it's futile
 		 * for backends to continue to waiting.  Since the user no longer
@@ -676,8 +683,6 @@ SyncRepUpdateSyncStandbysDefined(void)
 		 * the queue (and never wake up).  This prevents that.
 		 */
 		WalSndCtl->sync_standbys_defined = sync_standbys_defined;
-
-		LWLockRelease(SyncRepLock);
 	}
 }
 

--- a/src/backend/replication/test/Makefile
+++ b/src/backend/replication/test/Makefile
@@ -10,5 +10,6 @@ include $(top_builddir)/src/backend/mock.mk
 gp_replication.t: \
     $(MOCK_DIR)/backend/utils/error/assert_mock.o \
     $(MOCK_DIR)/backend/utils/error/elog_mock.o \
+	$(MOCK_DIR)/backend/utils/misc/guc_gp_mock.o \
     $(MOCK_DIR)/backend/storage/lmgr/lwlock_mock.o
 endif

--- a/src/backend/replication/test/gp_replication_test.c
+++ b/src/backend/replication/test/gp_replication_test.c
@@ -18,10 +18,10 @@ void AssertFailed()
 #include "../gp_replication.c"
 
 static void
-expect_lwlock(void)
+expect_lwlock(LWLockMode lockmode)
 {
 	expect_value(LWLockAcquire, lockid, SyncRepLock);
-	expect_value(LWLockAcquire, mode, LW_SHARED);
+	expect_value(LWLockAcquire, mode, lockmode);
 	will_be_called(LWLockAcquire);
 
 	expect_value(LWLockRelease, lockid, SyncRepLock);
@@ -36,7 +36,7 @@ test_setup(WalSndCtlData *data, WalSndState state)
 	data->walsnds[0].pid = 1;
 	data->walsnds[0].state = state;
 
-	expect_lwlock();
+	expect_lwlock(LW_SHARED);
 }
 
 void
@@ -50,7 +50,7 @@ test_GetMirrorStatus_Pid_Zero(void **state)
 	WalSndCtl = &data;
 	data.walsnds[0].pid = 0;
 
-	expect_lwlock();
+	expect_lwlock(LW_SHARED);
 	GetMirrorStatus(&isMirrorUp, &isInSync);
 
 	assert_false(isMirrorUp);
@@ -113,6 +113,42 @@ test_GetMirrorStatus_WALSNDSTATE_STREAMING(void **state)
 	assert_true(isInSync);
 }
 
+void
+test_SetSyncStandbysDefined(void **state)
+{
+	WalSndCtlData data;
+	WalSndCtl = &data;
+	data.sync_standbys_defined = false;
+
+	expect_lwlock(LW_EXCLUSIVE);
+#ifdef USE_ASSERT_CHECKING
+	expect_value(LWLockHeldByMe, lockid, SyncRepLock);
+	will_return(LWLockHeldByMe, true);
+#endif
+
+	/*
+	 * set_gp_replication_config() should only be called once when mirror first
+	 * comes up to set synchronous wal rep state
+	 */
+	expect_string_count(set_gp_replication_config, name, "synchronous_standby_names", 1);
+	expect_string_count(set_gp_replication_config, value, "*", 1);
+	will_be_called(set_gp_replication_config);
+
+	/* simulate first call when mirror first comes up */
+	assert_false(WalSndCtl->sync_standbys_defined);
+	assert_true(SyncRepStandbyNames == NULL);
+	SetSyncStandbysDefined();
+
+	/* relative variables should have updated */
+	assert_true(WalSndCtl->sync_standbys_defined);
+	assert_true(strcmp(SyncRepStandbyNames, "*") == 0);
+
+	expect_lwlock(LW_EXCLUSIVE);
+
+	/* simulate second call after sync state is set which should do nothing */
+	SetSyncStandbysDefined();
+}
+
 int
 main(int argc, char* argv[])
 {
@@ -123,7 +159,8 @@ main(int argc, char* argv[])
 		unit_test(test_GetMirrorStatus_WALSNDSTATE_STARTUP),
 		unit_test(test_GetMirrorStatus_WALSNDSTATE_BACKUP),
 		unit_test(test_GetMirrorStatus_WALSNDSTATE_CATCHUP),
-		unit_test(test_GetMirrorStatus_WALSNDSTATE_STREAMING)
+		unit_test(test_GetMirrorStatus_WALSNDSTATE_STREAMING),
+		unit_test(test_SetSyncStandbysDefined)
 	};
 	return run_tests(tests);
 }

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -36,6 +36,7 @@
 #include "pgstat.h"
 #include "parser/scansup.h"
 #include "postmaster/syslogger.h"
+#include "postmaster/fts.h"
 #include "replication/walsender.h"
 #include "storage/bfz.h"
 #include "storage/proc.h"

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -319,9 +319,6 @@ extern bool gp_fts_probe_pause;
 extern int gp_fts_transition_retries;
 extern int gp_fts_transition_timeout;
 
-extern bool gpvars_assign_gp_fts_probe_pause(bool newval, bool doit, GucSource source);
-
-
 /*
  * Parameter gp_connections_per_thread
  *

--- a/src/include/postmaster/fts.h
+++ b/src/include/postmaster/fts.h
@@ -16,6 +16,7 @@
 #ifndef FTS_H
 #define FTS_H
 
+#include "utils/guc.h"
 #include "cdb/cdbutil.h"
 
 #ifdef USE_SEGWALREP
@@ -184,6 +185,9 @@ extern void FtsFailoverFilerep(FtsSegmentStatusChange *changes, int changeCount)
 extern void FtsRequestPostmasterShutdown(CdbComponentDatabaseInfo *primary, CdbComponentDatabaseInfo *mirror);
 extern bool FtsMasterShutdownRequested(void);
 extern void FtsRequestMasterShutdown(void);
+
+/* Interface for setting FTS GUCs */
+extern bool gpvars_assign_gp_fts_probe_pause(bool newval, bool doit, GucSource source);
 
 /*
  * If master has requested FTS to shutdown.

--- a/src/include/replication/gp_replication.h
+++ b/src/include/replication/gp_replication.h
@@ -17,5 +17,6 @@
 #include "postgres.h"
 
 extern void GetMirrorStatus(bool *IsMirrorUp, bool *IsInSync);
+extern void SetSyncStandbysDefined(void);
 
 #endif

--- a/src/test/isolation2/Makefile
+++ b/src/test/isolation2/Makefile
@@ -20,6 +20,10 @@ endif
 override CPPFLAGS := -I$(srcdir) -I$(libpq_srcdir) -I$(srcdir)/../regress $(CPPFLAGS)
 override LDLIBS := $(libpq_pgport) $(LDLIBS)
 
+ifeq ($(enable_segwalrep), yes)
+EXTRA_TESTS=segwalrep/commit_blocking
+endif
+
 all: pg_isolation2_regress$(X) all-lib
 
 pg_regress.o:
@@ -51,7 +55,7 @@ clean distclean:
 	rm -rf $(pg_regress_clean_files)
 
 installcheck: all gpdiff.pl gpstringsubs.pl
-	./pg_isolation2_regress --init-file=$(top_builddir)/src/test/regress/init_file --init-file=./init_file_isolation2 --psqldir='$(PSQLDIR)' --inputdir=$(srcdir) --ao-dir=uao --schedule=$(srcdir)/isolation2_schedule
+	./pg_isolation2_regress --init-file=$(top_builddir)/src/test/regress/init_file --init-file=./init_file_isolation2 --psqldir='$(PSQLDIR)' --inputdir=$(srcdir) --ao-dir=uao --schedule=$(srcdir)/isolation2_schedule $(EXTRA_TESTS)
 
 installcheck-resgroup: all gpdiff.pl gpstringsubs.pl prepare_dblink_sql
 	./pg_isolation2_regress --init-file=$(top_builddir)/src/test/regress/init_file --init-file=./init_file_resgroup --psqldir='$(PSQLDIR)' --inputdir=$(srcdir) --resgroup-dir=resgroup --dbname=isolation2resgrouptest --schedule=$(srcdir)/isolation2_resgroup_schedule

--- a/src/test/isolation2/expected/segwalrep/commit_blocking.out
+++ b/src/test/isolation2/expected/segwalrep/commit_blocking.out
@@ -1,0 +1,119 @@
+-- This test assumes 3 primaries and 3 mirrors from a gpdemo segwalrep cluster
+
+-- start_ignore
+create language plpythonu;
+CREATE
+-- end_ignore
+
+create or replace function pg_ctl(datadir text, command text, port int, contentid int) returns text as $$ import subprocess 
+cmd = 'pg_ctl -D %s ' % datadir if command in ('stop', 'restart'): cmd = cmd + '-w -m immediate %s' % command elif command == 'start': opts = '-p %d -\-gp_dbid=0 -\-silent-mode=true -i -M mirrorless -\-gp_contentid=%d -\-gp_num_contents_in_cluster=3' % (port, contentid) cmd = cmd + '-o "%s" start' % opts elif command == 'reload': cmd = cmd + 'reload' else: return 'Invalid command input' 
+return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '') $$ language plpythonu;
+CREATE
+
+-- create table and show commits are not blocked
+create table segwalrep_commit_blocking (a int) distributed by (a);
+CREATE
+insert into segwalrep_commit_blocking values (1);
+INSERT 1
+
+-- turn off fts
+! gpconfig -c gp_fts_probe_pause -v true --masteronly --skipvalidation;
+completed successfully with parameters '-c gp_fts_probe_pause -v true --masteronly --skipvalidation'
+
+1U: select pg_ctl((select fselocation from gp_segment_configuration c, pg_filespace_entry f where c.role='p' and c.content=-1 and c.dbid = f.fsedbid), 'reload', NULL, NULL);
+pg_ctl          
+----------------
+server signaled
+
+(1 row)
+
+-- stop a mirror and show commit on dbid 2 will block
+1U: select pg_ctl((select fselocation from gp_segment_configuration c, pg_filespace_entry f where c.role='m' and c.content=0 and c.dbid = f.fsedbid), 'stop', NULL, NULL);
+pg_ctl                                              
+----------------------------------------------------
+waiting for server to shut down done
+server stopped
+
+(1 row)
+2U&: insert into segwalrep_commit_blocking values (1);  <waiting ...>
+
+-- restart primary dbid 2
+1U: select pg_ctl((select fselocation from gp_segment_configuration c, pg_filespace_entry f where c.role='p' and c.content=0 and c.dbid = f.fsedbid), 'restart', NULL, NULL);
+pg_ctl                                                                                              
+----------------------------------------------------------------------------------------------------
+waiting for server to shut down done
+server stopped
+waiting for server to start done
+server started
+
+(1 row)
+
+-- should show dbid 2 utility mode connection closed because of primary restart
+2U<:  <... completed>
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+2Uq: ... <quitting>
+
+-- synchronous_standby_names should be set to '*' after primary restart
+2U: show synchronous_standby_names;
+synchronous_standby_names
+-------------------------
+*                        
+(1 row)
+
+-- this should block since mirror is not up and sync replication is on
+3: begin;
+BEGIN
+3: insert into segwalrep_commit_blocking values (1);
+INSERT 1
+3&: commit;  <waiting ...>
+
+-- this should not block due to direct dispatch to primary with active synced mirror
+4: insert into segwalrep_commit_blocking values (3);
+INSERT 1
+
+-- bring the mirror back up
+1U: select pg_ctl((select fselocation from gp_segment_configuration c, pg_filespace_entry f where c.role='m' and c.content=0 and c.dbid = f.fsedbid), 'start', (select port from gp_segment_configuration where content = 0 and preferred_role = 'm'), 0);
+pg_ctl          
+----------------
+server starting
+
+(1 row)
+
+-- turn on fts
+! gpconfig -c gp_fts_probe_pause -v false --masteronly --skipvalidation;
+completed successfully with parameters '-c gp_fts_probe_pause -v false --masteronly --skipvalidation'
+
+1U: select pg_ctl((select fselocation from gp_segment_configuration c, pg_filespace_entry f where c.role='p' and c.content=-1 and c.dbid = f.fsedbid), 'reload', NULL, NULL);
+pg_ctl          
+----------------
+server signaled
+
+(1 row)
+
+-- should unblock and commit now that mirror is back up
+3<:  <... completed>
+COMMIT
+
+-- everything should be back to normal
+4: insert into segwalrep_commit_blocking select i from generate_series(1,10)i;
+INSERT 10
+4: select * from segwalrep_commit_blocking order by a;
+a 
+--
+1 
+1 
+1 
+1 
+2 
+3 
+3 
+4 
+5 
+6 
+7 
+8 
+9 
+10
+(14 rows)

--- a/src/test/isolation2/init_file_isolation2
+++ b/src/test/isolation2/init_file_isolation2
@@ -8,4 +8,8 @@ s/^\d+.*gpfaultinjector.*-\[INFO\]:-//
 # entry db matches
 m/\s+\(entry db(.*)+\spid=\d+\)/
 s/\s+\(entry db(.*)+\spid=\d+\)//
+
+# remove beginning output of gpconfig
+m/^\d+.*gpconfig.*-\[INFO\]:-/
+s/^\d+.*gpconfig.*-\[INFO\]:-//
 -- end_matchsubs

--- a/src/test/isolation2/isolation2_segwalrep_schedule
+++ b/src/test/isolation2/isolation2_segwalrep_schedule
@@ -1,0 +1,1 @@
+test: segwalrep/commit_blocking

--- a/src/test/isolation2/sql/segwalrep/commit_blocking.sql
+++ b/src/test/isolation2/sql/segwalrep/commit_blocking.sql
@@ -1,0 +1,67 @@
+-- This test assumes 3 primaries and 3 mirrors from a gpdemo segwalrep cluster
+
+-- start_ignore
+create language plpythonu;
+-- end_ignore
+
+create or replace function pg_ctl(datadir text, command text, port int, contentid int)
+returns text as $$
+    import subprocess
+
+    cmd = 'pg_ctl -D %s ' % datadir
+    if command in ('stop', 'restart'):
+        cmd = cmd + '-w -m immediate %s' % command
+    elif command == 'start':
+        opts = '-p %d -\-gp_dbid=0 -\-silent-mode=true -i -M mirrorless -\-gp_contentid=%d -\-gp_num_contents_in_cluster=3' % (port, contentid)
+        cmd = cmd + '-o "%s" start' % opts
+    elif command == 'reload':
+        cmd = cmd + 'reload'
+    else:
+        return 'Invalid command input'
+
+    return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '')
+$$ language plpythonu;
+
+-- create table and show commits are not blocked
+create table segwalrep_commit_blocking (a int) distributed by (a);
+insert into segwalrep_commit_blocking values (1);
+
+-- turn off fts
+! gpconfig -c gp_fts_probe_pause -v true --masteronly --skipvalidation;
+1U: select pg_ctl((select fselocation from gp_segment_configuration c, pg_filespace_entry f where c.role='p' and c.content=-1 and c.dbid = f.fsedbid), 'reload', NULL, NULL);
+
+-- stop a mirror and show commit on dbid 2 will block
+1U: select pg_ctl((select fselocation from gp_segment_configuration c, pg_filespace_entry f where c.role='m' and c.content=0 and c.dbid = f.fsedbid), 'stop', NULL, NULL);
+2U&: insert into segwalrep_commit_blocking values (1);
+
+-- restart primary dbid 2
+1U: select pg_ctl((select fselocation from gp_segment_configuration c, pg_filespace_entry f where c.role='p' and c.content=0 and c.dbid = f.fsedbid), 'restart', NULL, NULL);
+
+-- should show dbid 2 utility mode connection closed because of primary restart
+2U<:
+2Uq:
+
+-- synchronous_standby_names should be set to '*' after primary restart
+2U: show synchronous_standby_names;
+
+-- this should block since mirror is not up and sync replication is on
+3: begin;
+3: insert into segwalrep_commit_blocking values (1);
+3&: commit;
+
+-- this should not block due to direct dispatch to primary with active synced mirror
+4: insert into segwalrep_commit_blocking values (3);
+
+-- bring the mirror back up
+1U: select pg_ctl((select fselocation from gp_segment_configuration c, pg_filespace_entry f where c.role='m' and c.content=0 and c.dbid = f.fsedbid), 'start', (select port from gp_segment_configuration where content = 0 and preferred_role = 'm'), 0);
+
+-- turn on fts
+! gpconfig -c gp_fts_probe_pause -v false --masteronly --skipvalidation;
+1U: select pg_ctl((select fselocation from gp_segment_configuration c, pg_filespace_entry f where c.role='p' and c.content=-1 and c.dbid = f.fsedbid), 'reload', NULL, NULL);
+
+-- should unblock and commit now that mirror is back up
+3<:
+
+-- everything should be back to normal
+4: insert into segwalrep_commit_blocking select i from generate_series(1,10)i;
+4: select * from segwalrep_commit_blocking order by a;

--- a/src/test/unit/mock/mocker.py
+++ b/src/test/unit/mock/mocker.py
@@ -58,7 +58,8 @@ class CFile(object):
         """
         content = CFile.m_comment_pat.sub('', content)
         # backend/libpq/be-secure.c contains private key with '//'
-        if 'be-secure' not in self.path and 'guc.c' not in self.path:
+        # backend/utils/misc/guc_gp.c gp_hadoop_connector_jardir has value with '//'
+        if 'be-secure' not in self.path and 'guc_gp.c' not in self.path:
             content = CFile.s_comment_pat.sub('', content)
         content = CFile.attribute_pat.sub('', content)
         return content


### PR DESCRIPTION
When a primary segment first detects mirror is up, primary will
automatically turn on synchronous WAL replication by directly setting
WalSndCtl->sync_standbys_defined to true during FTS probe handling
(bypassing the need to have postmaster reload and Checkpointer process
doing the update). The state will be persisted by inserting
synchronous_standby_names="*" into gp_replication.conf in case of
segment crash.