### PR TITLE
Fix regression in RelationTruncate() and Enable PageClearAllVisible() in mask_page_hint_bits()

### DIFF
--- a/src/backend/access/common/bufmask.c
+++ b/src/backend/access/common/bufmask.c
@@ -53,15 +53,12 @@ mask_page_hint_bits(Page page)
 	PageClearFull(page);
 	PageClearHasFreeLinePointers(page);
 
-/* GPDB_84_MERGE_FIXME */
-#if 0
 	/*
 	 * During replay, if the page LSN has advanced past our XLOG record's LSN,
 	 * we don't mark the page all-visible. See heap_xlog_visible() for
 	 * details.
 	 */
 	PageClearAllVisible(page);
-#endif
 }
 
 /*

--- a/src/backend/catalog/storage.c
+++ b/src/backend/catalog/storage.c
@@ -505,7 +505,7 @@ RelationTruncate(Relation rel, BlockNumber nblocks, bool markPersistentAsPhysica
 	 * harmless failure to truncate, that could spell trouble at WAL replay,
 	 * into a certain PANIC.
 	 */
-	if (rel->rd_istemp)
+	if (!rel->rd_istemp)
 	{
 		/*
 		 * Make an XLOG entry showing the file truncation.


### PR DESCRIPTION
Commit 3396000 seems to have introduced
regression, need to add negation. For non-temp relations xloggging is needed,
this was caught by new replic_check facility built for wal replication, as it
flagged differenece between primary and mirror files, since primary was getting
truncated to 0 but missing xlog record didn't truncate the file on mirror.

After these two commits gp_replia_check again gets back to green after ICW with wal replication for segments.