### PR TITLE
Fix DISTINCT with window functions.

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -1380,10 +1380,30 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 		 * Recover sort pathkeys for use later.  These may or may not match
 		 * the current_pathkeys resulting from the window plan.
 		 */
-		root->sort_pathkeys = make_pathkeys_for_sortclauses(root,
-															parse->sortClause,
-															result_plan->targetlist,
-															true);
+		if (parse->groupClause &&
+			grouping_is_sortable(parse->groupClause))
+			root->group_pathkeys =
+			make_pathkeys_for_groupclause(root,
+										  parse->groupClause,
+										  result_plan->targetlist);
+		else
+			root->group_pathkeys = NIL;
+
+		if (parse->distinctClause &&
+			grouping_is_sortable(parse->distinctClause))
+			root->distinct_pathkeys =
+				make_pathkeys_for_sortclauses(root,
+											  parse->distinctClause,
+											  result_plan->targetlist,
+											  false);
+		else
+			root->distinct_pathkeys = NIL;
+
+		root->sort_pathkeys =
+			make_pathkeys_for_sortclauses(root,
+										  parse->sortClause,
+										  result_plan->targetlist,
+										  false);
 	}
 	else
 	{

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -15,7 +15,7 @@
 #   hitting max_connections limit on segments.
 #
 
-test: gp_metadata variadic_parameters default_parameters function_extensions spi gp_xml pgoptions shared_scan null
+test: gp_aggregates gp_metadata variadic_parameters default_parameters function_extensions spi gp_xml pgoptions shared_scan null
 
 test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp gpcopy gp_create_table gp_create_view window_views
 test: filter gpctas gpdist matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var guc_gp gp_explain


### PR DESCRIPTION
The last 8.4 merge commit introduced support for DISTINCT with hashing,
and refactored the way grouping_planner() works with the path keys. That
broke DISTINCT with window functions, because the new distinct_pathkeys
field was not set correctly.

In commit 474f1db0b1, I moved some GPDB-added tests from the 'aggregates'
test, to a new 'gp_aggregates' test. But I forgot to add the new test file
to the test schedule, so it was not run. Oops. Add it to the schedule now.
The tests in 'gp_aggregates' cover this bug.