### PR TITLE
Make 'must_gather' logic when planning DISTINCT and ORDER BY more robust.

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -2034,7 +2034,6 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 	 * behavior, so in that case that's definitely what we want.
 	 */
 	if ((parse->distinctClause || parse->sortClause) &&
-		result_plan->flow->flotype != FLOW_SINGLETON &&
 		(root->config->honor_order_by || !root->parent_root) &&
 		!parse->intoClause &&
 		/*
@@ -2284,7 +2283,7 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 				mark_sort_locus(result_plan);
 			}
 
-			if (must_gather)
+			if (must_gather && result_plan->flow->flotype != FLOW_SINGLETON)
 			{
 				/*
 				 * As an optimization, eliminate any duplicates within the segment,
@@ -2297,7 +2296,6 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 
 				result_plan = (Plan *) make_motion_gather(root, result_plan, -1,
 														  current_pathkeys);
-				must_gather = false;
 			}
 
 			result_plan = (Plan *) make_unique(result_plan,
@@ -2326,7 +2324,7 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 			result_plan->flow = pull_up_Flow(result_plan, result_plan->lefttree);
 		}
 
-		if (must_gather)
+		if (must_gather && result_plan->flow->flotype != FLOW_SINGLETON)
 		{
 			/*
 			 * current_pathkeys might contain unneeded columns that have been
@@ -2338,7 +2336,6 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 			current_pathkeys = root->sort_pathkeys;
 			result_plan = (Plan *) make_motion_gather(root, result_plan, -1,
 													  current_pathkeys);
-			must_gather = false;
 		}
 	}
 

--- a/src/test/regress/expected/gp_aggregates.out
+++ b/src/test/regress/expected/gp_aggregates.out
@@ -159,6 +159,26 @@ select distinct t1.two, t2.two, t1.four, t2.four from tenk1 t1, tenk1 t2 where t
    1 |   1 |    3 |    3
 (4 rows)
 
+-- A variant with more result rows. We had a bug at one point where the
+-- Motion Gather node on top of this was missing the Merge Key, and hence
+-- the output came out unsorted. But it was not visible if all the rows
+-- were processed on the same segment, as is the case with the above variant
+-- with only two distinct 'two' values.
+select distinct ten, sum(ten) over() from tenk1 order by ten;
+ ten |  sum  
+-----+-------
+   0 | 45000
+   1 | 45000
+   2 | 45000
+   3 | 45000
+   4 | 45000
+   5 | 45000
+   6 | 45000
+   7 | 45000
+   8 | 45000
+   9 | 45000
+(10 rows)
+
 -- Test for a planner bug we used to have, when this query gets planned
 -- as a merge join. This should perform a merge join between 'l' and 'ps',
 -- using both pk and sk as the merge keys. Due to the bug, the planner

--- a/src/test/regress/sql/gp_aggregates.sql
+++ b/src/test/regress/sql/gp_aggregates.sql
@@ -44,6 +44,12 @@ select distinct two, sum(four) from tenk1 group by two order by two;
 select distinct two, sum(four) from tenk1 group by two having sum(four) > 5000;
 select distinct t1.two, t2.two, t1.four, t2.four from tenk1 t1, tenk1 t2 where t1.hundred=t2.hundred order by t1.two, t1.four;
 
+-- A variant with more result rows. We had a bug at one point where the
+-- Motion Gather node on top of this was missing the Merge Key, and hence
+-- the output came out unsorted. But it was not visible if all the rows
+-- were processed on the same segment, as is the case with the above variant
+-- with only two distinct 'two' values.
+select distinct ten, sum(ten) over() from tenk1 order by ten;
 
 -- Test for a planner bug we used to have, when this query gets planned
 -- as a merge join. This should perform a merge join between 'l' and 'ps',


### PR DESCRIPTION
The old logic was:

1. Decide if we need to put a Gather motion on top of the plan
2. Add nodes to handle DISTINCT
3. Add nodes to handle ORDER BY.
4. Add Gather node, if we decided so in step 1.

If in step 1, if the result was already focused on a single segment, we
would make note that no Gather is needed, and not add one in step 4.
However, the DISTINCT processing might add a Redistribute Motion node, so
that the final result is not focused on a single node.

I couldn't come up with a query where that would happen, as the code stands,
but we saw such a case on the "window functions rewrite" branch we've been
working on. There, the sort order/distribution of the input can be changed
to process window functions. But even if this isn't actively broken right
now, it seems more robust to change the logic so that 'must_gather' means
'at the end, the result must end up on a single node', instead of 'we must
add a Gather node'. The test that this adds exercises this issue after the
the window functions rewrite, but right now it passes with or without these
code changes. But might as well add it now.
