### PR TITLE
Make test case predictable, by not using random() to produce test data.

### DIFF
--- a/src/test/regress/expected/bfv_olap.out
+++ b/src/test/regress/expected/bfv_olap.out
@@ -126,7 +126,7 @@ create aggregate ema(float, float) (
     finalfunc = ema_fin,
     initcond = '(,)');
 create table ema_test (k int, v float ) distributed by (k);
-insert into ema_test select i, 4*random() + 10.0*(1+cos(radians(i*5))) from generate_series(0,19) i(i);
+insert into ema_test select i, 4*(i::float/20) + 10.0*(1+cos(radians(i*5))) from generate_series(0,19) i(i);
 -- TEST
 select k, v, ema(v, 0.9) over (order by k) from ema_test order by k;
 ERROR:  aggregate functions with no prelimfn or invprelimfn are not yet supported as window functions

--- a/src/test/regress/sql/bfv_olap.sql
+++ b/src/test/regress/sql/bfv_olap.sql
@@ -136,7 +136,7 @@ create aggregate ema(float, float) (
     initcond = '(,)');
 
 create table ema_test (k int, v float ) distributed by (k);
-insert into ema_test select i, 4*random() + 10.0*(1+cos(radians(i*5))) from generate_series(0,19) i(i);
+insert into ema_test select i, 4*(i::float/20) + 10.0*(1+cos(radians(i*5))) from generate_series(0,19) i(i);
 
 -- TEST
 select k, v, ema(v, 0.9) over (order by k) from ema_test order by k;


### PR DESCRIPTION
Currently, all the test queries on this data error out, which is why it
hasn't mattered. But we're about to make the queries work, in the window
functions rewrite.