### PR TITLE
Fix WAL-logging in RelationCreateStorage.

### DIFF
--- a/src/backend/catalog/storage.c
+++ b/src/backend/catalog/storage.c
@@ -250,7 +250,13 @@ RelationCreateStorage(RelFileNode rnode, bool istemp,
 					   mirrorDataLossTrackingSessionNum,
 					   false, /* ignoreAlreadyExists */
 					   mirrorDataLossOccurred);
-	if (istemp)
+
+	/*
+	 * With file replication, the caller is expected to create an MMXLOG WAL
+	 * record for this instead.
+	 */
+#ifdef USE_SEGWALREP
+	if (!istemp)
 	{
 		/*
 		 * Make an XLOG entry showing the file creation.  If we abort, the file
@@ -265,6 +271,7 @@ RelationCreateStorage(RelFileNode rnode, bool istemp,
 
 		lsn = XLogInsert(RM_SMGR_ID, XLOG_SMGR_CREATE, &rdata);
 	}
+#endif
 }
 
 void


### PR DESCRIPTION
The condition was reversed - we should WAL-log the creation, if it's *not*
a temporary relation. This was fixed in the upstream in commit 74ef810ca6,
which we would merge soon anyway, but there are some complications in GPDB:

In GPDB, this code in smgrcreate() to WAL-log the creation of a new
relation had been removed. Instead, the caller of smgrcreate() calls other
GPDB-specific functions to WAL-log the creation, as an MMXLOG_* record.
But when we merged the relation forks stuff, which moved this code from
smgr.c to storage.c, this code to WAL-log the creation of a new relation
as an SMGR_CREATE record was resurrected. But it didn't actually do
anything because the condition was reversed. Now that we're fixing the
condition, we have to expxlicitly disable it.

With the upcoming WAL replication work, we should WAL log it like in the
upstream. (I haven't tested this with WAL replication enabled, though, so
I'm not sure if we need to do something else, too, to make it actually
work correctly.)