### PR TITLE
Fixed make distclean not clean gpMgmt

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -133,6 +133,7 @@ distclean maintainer-clean:
 	$(MAKE) -C gpAux/platform $@
 	$(MAKE) -C contrib $@
 	$(MAKE) -C config $@
+	$(MAKE) -C gpMgmt $@
 	$(MAKE) -C src $@
 	rm -f config.cache config.log config.status GNUmakefile
 # Garbage from autoconf:


### PR DESCRIPTION
After python version updated, gpdb report build problem even after 'make distclean'.
The root cause is shell command broken because multiple python versions directories in below:
    gpMgmt/bin/pythonSrc/subprocess32
    gpMgmt/bin/pythonSrc/PyGreSQL-4.0/build/lib.linux