### PR TITLE
Resolve a few FIXMEs in JSON code, now that we have merged the features.

### DIFF
--- a/src/backend/utils/adt/json.c
+++ b/src/backend/utils/adt/json.c
@@ -1329,16 +1329,7 @@ json_categorize_type(Oid typoid,
 					{
 						Form_pg_cast castForm = (Form_pg_cast) GETSTRUCT(tuple);
 
-						/*
-						 * GPDB_84_MERGE_FIXME: handle when merging upstream
-						 * patch 092bc4965378840479e0250ae679e1d8e86577ee
-						 * "Add support for user-defined I/O conversion casts"
-						 */
-#if 0
 						if (castForm->castmethod == COERCION_METHOD_FUNCTION)
-#else
-						if (castForm->castfunc != InvalidOid)
-#endif
 						{
 							*tcategory = JSONTYPE_CAST;
 							*outfuncoid = castForm->castfunc;

--- a/src/backend/utils/adt/jsonfuncs.c
+++ b/src/backend/utils/adt/jsonfuncs.c
@@ -933,9 +933,8 @@ each_worker(PG_FUNCTION_ARGS, bool as_text)
 
 	state->ret_tdesc = CreateTupleDescCopy(tupdesc);
 	BlessTupleDesc(state->ret_tdesc);
-	/* GPDB_84_MERGE_FIXME: Use SFRM_Materialize_Random here */
 	state->tuple_store =
-		tuplestore_begin_heap(rsi->allowedModes & SFRM_Materialize,
+		tuplestore_begin_heap(rsi->allowedModes & SFRM_Materialize_Random,
 							  false, work_mem);
 
 	MemoryContextSwitchTo(old_cxt);
@@ -1106,9 +1105,8 @@ json_array_elements(PG_FUNCTION_ARGS)
 
 	state->ret_tdesc = CreateTupleDescCopy(tupdesc);
 	BlessTupleDesc(state->ret_tdesc);
-	/* GPDB_84_MERGE_FIXME: Use SFRM_Materialize_Random here */
 	state->tuple_store =
-		tuplestore_begin_heap(rsi->allowedModes & SFRM_Materialize,
+		tuplestore_begin_heap(rsi->allowedModes & SFRM_Materialize_Random,
 							  false, work_mem);
 
 	MemoryContextSwitchTo(old_cxt);
@@ -1619,9 +1617,8 @@ json_populate_recordset(PG_FUNCTION_ARGS)
 
 	state->ret_tdesc = CreateTupleDescCopy(tupdesc);
 	BlessTupleDesc(state->ret_tdesc);
-	/* GPDB_84_MERGE_FIXME: Use SFRM_Materialize_Random here */
 	state->tuple_store =
-		tuplestore_begin_heap(rsi->allowedModes & SFRM_Materialize,
+		tuplestore_begin_heap(rsi->allowedModes & SFRM_Materialize_Random,
 							  false, work_mem);
 
 	MemoryContextSwitchTo(old_cxt);


### PR DESCRIPTION
We have now merged user-defined I/O conversion casts, and
SFRM_Materialize_Random, from PostgreSQL 8.4. We can change the JSON code
that depended on those features to be identical to the upstream code now.

