### PR TITLE
Another attempt at silencing ORCA fallback notices in 'aggregates' test.

### DIFF
--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -735,16 +735,12 @@ create view agg_view1 as
   select aggfns(a,b,c)
     from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c);
 select * from agg_view1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-CONTEXT:  SQL function "aggfns_trans" during startup
                     aggfns                     
 -----------------------------------------------
  {"(1,3,foo)","(0,,)","(2,2,bar)","(3,1,baz)"}
 (1 row)
 
 select pg_get_viewdef('agg_view1'::regclass);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-CONTEXT:  SQL statement "SELECT * FROM pg_catalog.pg_rewrite WHERE ev_class = $1 AND rulename = $2"
                                                                      pg_get_viewdef                                                                     
 --------------------------------------------------------------------------------------------------------------------------------------------------------
  SELECT aggfns(v.a, v.b, v.c) AS aggfns FROM (VALUES (1,3,'foo'::text), (0,NULL::integer,NULL::text), (2,2,'bar'::text), (3,1,'baz'::text)) v(a, b, c);
@@ -755,9 +751,6 @@ create or replace view agg_view1 as
     from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
          generate_series(1,3) i;
 select * from agg_view1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-INFO:  GPORCA failed to produce a plan, falling back to planner
-CONTEXT:  SQL function "aggfns_trans" during startup
                     aggfns                     
 -----------------------------------------------
  {"(0,,)","(1,3,foo)","(2,2,bar)","(3,1,baz)"}
@@ -774,9 +767,6 @@ create or replace view agg_view1 as
     from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
          generate_series(1,3) i;
 select * from agg_view1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-INFO:  GPORCA failed to produce a plan, falling back to planner
-CONTEXT:  SQL function "aggfns_trans" during startup
                     aggfns                     
 -----------------------------------------------
  {"(3,1,baz)","(2,2,bar)","(1,3,foo)","(0,,)"}
@@ -792,9 +782,6 @@ create or replace view agg_view1 as
   select aggfns(a,b,c order by b+1)
     from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c);
 select * from agg_view1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-INFO:  GPORCA failed to produce a plan, falling back to planner
-CONTEXT:  SQL function "aggfns_trans" during startup
                     aggfns                     
 -----------------------------------------------
  {"(3,1,baz)","(2,2,bar)","(1,3,foo)","(0,,)"}
@@ -810,9 +797,6 @@ create or replace view agg_view1 as
   select aggfns(a,a,c order by b)
     from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c);
 select * from agg_view1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-INFO:  GPORCA failed to produce a plan, falling back to planner
-CONTEXT:  SQL function "aggfns_trans" during startup
                      aggfns                     
 ------------------------------------------------
  {"(3,3,baz)","(2,2,bar)","(1,1,foo)","(0,0,)"}
@@ -828,9 +812,6 @@ create or replace view agg_view1 as
   select aggfns(a,b,c order by c using ~<~)
     from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c);
 select * from agg_view1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-INFO:  GPORCA failed to produce a plan, falling back to planner
-CONTEXT:  SQL function "aggfns_trans" during startup
                     aggfns                     
 -----------------------------------------------
  {"(2,2,bar)","(3,1,baz)","(1,3,foo)","(0,,)"}
@@ -847,9 +828,6 @@ create or replace view agg_view1 as
     from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
          generate_series(1,2) i;
 select * from agg_view1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-INFO:  GPORCA failed to produce a plan, falling back to planner
-CONTEXT:  SQL function "aggfns_trans" during startup
                     aggfns                     
 -----------------------------------------------
  {"(0,,)","(1,3,foo)","(2,2,bar)","(3,1,baz)"}


### PR DESCRIPTION
The previous attempt, by priming the internal prepared plan by a dummy
pg_get_viewdef() call, turned out to not be very robust. I think that's
because activity in concurrent tests would sometimes cause the plan to be
invalidated and re-planned.

Disable optimizer_trace_fallback around the pg_get-viewdef() calls instead.