### PR TITLE
Increase sleep between launching gpfdist and running test queries.

### DIFF
--- a/src/test/regress/input/sreh.source
+++ b/src/test/regress/input/sreh.source
@@ -124,7 +124,7 @@ DROP TABLE sreh_constr;
 -- ###########################################################
 
 CREATE EXTERNAL WEB TABLE gpfdist_sreh_start (x text)
-execute E'((@bindir@/gpfdist -p 8080 -d @abs_srcdir@/data  </dev/null >/dev/null 2>&1 &); sleep 1; echo "starting...") '
+execute E'((@bindir@/gpfdist -p 8080 -d @abs_srcdir@/data  </dev/null >/dev/null 2>&1 &); sleep 3; echo "starting...") '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 

--- a/src/test/regress/output/sreh.source
+++ b/src/test/regress/output/sreh.source
@@ -234,7 +234,7 @@ DROP TABLE sreh_constr;
 -- External Tables 
 -- ###########################################################
 CREATE EXTERNAL WEB TABLE gpfdist_sreh_start (x text)
-execute E'((@bindir@/gpfdist -p 8080 -d @abs_srcdir@/data  </dev/null >/dev/null 2>&1 &); sleep 1; echo "starting...") '
+execute E'((@bindir@/gpfdist -p 8080 -d @abs_srcdir@/data  </dev/null >/dev/null 2>&1 &); sleep 3; echo "starting...") '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 CREATE EXTERNAL WEB TABLE gpfdist_sreh_stop (x text)


### PR DESCRIPTION
We've seen a lot of failures in the 'sreh' test in the pipeline, like this:

--- 263,269 ----
  FORMAT 'text' (delimiter '|')
  SEGMENT REJECT LIMIT 10000;
  SELECT * FROM sreh_ext;
! ERROR:  connection failed dummy_protocol://DUMMY_LOCATION
  INSERT INTO sreh_target SELECT * FROM sreh_ext;
  NOTICE:  Found 10 data formatting errors (10 or more input rows). Rejected related input data.
  SELECT count(*) FROM sreh_target;

I don't really know, but I'm guessing it could be because it sometimes
takes more than one second for gpfdist to fully start up, if there's a lot
of disk or other activity. Increase the sleep time from 1 to 3 seconds;
we'll see if that helps.