### PR TITLE
localtime_r() doesn't exist on MinGW, use localtime() instead.

### DIFF
--- a/src/bin/pg_dump/common.c
+++ b/src/bin/pg_dump/common.c
@@ -1243,12 +1243,12 @@ status_log_msg(const char *loglevel, const char *prog, const char *fmt,...)
 {
     va_list     ap;  
     char        szTimeNow[18];
-    struct tm   pNow;
+    struct tm  *pNow;
     time_t      tNow = time(NULL);
     char       *format = "%Y%m%d:%H:%M:%S";
 
-    localtime_r(&tNow, &pNow);
-    strftime(szTimeNow, 18, format, &pNow);
+    pNow = localtime(&tNow);
+    strftime(szTimeNow, 18, format, pNow);
 
     va_start(ap, fmt);
     fprintf(stderr, "%s|%s-[%s]:-", szTimeNow, prog, loglevel);


### PR DESCRIPTION
AFAICS, there is no need to be re-entrant or thread-safe here, so the normal
localtime() variant is fine.

I'm not sure why, but the MinGW build pipeline job started failing, after I
removed the extraneous headers from this file. The straightforward fix would
be to just add them back, but a little googling suggests that MinGW indeed
doesn't have localtime_r(). How did this ever work, I have no clue.

If we wanted to continue using localtime_r(), the proper fix would be to
add an autoconf test for it. But since we don't really need the re-entrant
version here, let's keep it simple.