### PR TITLE
Remove extra pg dump status logging

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/backup_and_restore_backups.feature
+++ b/gpMgmt/test/behave/mgmt_utils/backup_and_restore_backups.feature
@@ -122,26 +122,6 @@ Feature: Validate command line arguments
         Then gpcrondump should return a return code of 0
         And the timestamp from gpcrondump is stored
         And verify that the "report" file in " " dir contains "Backup Type: Full"
-        And verify that the "status" file in " " dir contains "reading schemas"
-        And verify that the "status" file in " " dir contains "reading user-defined functions"
-        And verify that the "status" file in " " dir contains "reading user-defined types"
-        And verify that the "status" file in " " dir contains "reading type storage options"
-        And verify that the "status" file in " " dir contains "reading procedural languages"
-        And verify that the "status" file in " " dir contains "reading user-defined aggregate functions"
-        And verify that the "status" file in " " dir contains "reading user-defined operators"
-        And verify that the "status" file in " " dir contains "reading user-defined external protocols"
-        And verify that the "status" file in " " dir contains "reading user-defined operator classes"
-        And verify that the "status" file in " " dir contains "reading user-defined conversions"
-        And verify that the "status" file in " " dir contains "reading user-defined tables"
-        And verify that the "status" file in " " dir contains "reading table inheritance information"
-        And verify that the "status" file in " " dir contains "reading rewrite rules"
-        And verify that the "status" file in " " dir contains "reading type casts"
-        And verify that the "status" file in " " dir contains "finding inheritance relationships"
-        And verify that the "status" file in " " dir contains "reading column info for interesting tables"
-        And verify that the "status" file in " " dir contains "flagging inherited columns in subtables"
-        And verify that the "status" file in " " dir contains "reading indexes"
-        And verify that the "status" file in " " dir contains "reading constraints"
-        And verify that the "status" file in " " dir contains "reading triggers"
 
     @nbupartI
     @ddpartI
@@ -1042,8 +1022,6 @@ Feature: Validate command line arguments
         Then gpcrondump should return a return code of 0
         And the full backup timestamp from gpcrondump is stored
         And all the data from the remote segments in "bkdb67" are stored in path "/tmp/custom_timestamps" for "full"
-        And verify that the file "/tmp/custom_timestamps/db_dumps/20140101/gp_dump_status_0_2_20140101010101" does not contain "reading indexes"
-        And verify that the file "/tmp/custom_timestamps/db_dumps/20140101/gp_dump_status_*_1_20140101010101" contains "reading indexes"
 
     Scenario: 68 Restore -T for incremental dump should restore metadata/postdata objects for tablenames with English and multibyte (chinese) characters
         Given the backup test is initialized with database "bkdb68"

--- a/src/bin/pg_dump/cdb/cdb_dump_agent.c
+++ b/src/bin/pg_dump/cdb/cdb_dump_agent.c
@@ -1409,8 +1409,6 @@ skipalldata:
 		for (i = 0; i < numObjs; i++)
 			dumpDumpableObject(g_fout, dobjs[i]);
 
-		reset();
-
 		CloseArchive(g_fout);
 		free(postDumpFileName);
 
@@ -1418,7 +1416,6 @@ skipalldata:
 	}
 	else
 	{
-		reset();
 		CloseArchive(g_fout);
 	}
 }

--- a/src/bin/pg_dump/common.c
+++ b/src/bin/pg_dump/common.c
@@ -80,7 +80,7 @@ bool is_gpdump = false; /* determines whether to print extra logging messages in
 static void flagInhTables(TableInfo *tbinfo, int numTables,
 			  InhInfo *inhinfo, int numInherits);
 static void flagInhAttrs(TableInfo *tblinfo, int numTables);
-DumpableObject **buildIndexArray(void *objArray, int numObjs,
+static DumpableObject **buildIndexArray(void *objArray, int numObjs,
 				Size objSize);
 static int	DOCatalogIdCompare(const void *p1, const void *p2);
 static int	ExtensionMemberIdCompare(const void *p1, const void *p2);
@@ -90,7 +90,6 @@ static int	strInArray(const char *pattern, char **arr, int arr_size);
 
 void status_log_msg(const char *loglevel, const char *prog, const char *fmt,...);
 
-void		reset(void);
 /*
  * getSchemaData
  *	  Collect information about all potentially dumpable objects
@@ -682,7 +681,7 @@ findObjectByOid(Oid oid, DumpableObject **indexArray, int numObjs)
 /*
  * Build an index array of DumpableObject pointers, sorted by OID
  */
-DumpableObject **
+static DumpableObject **
 buildIndexArray(void *objArray, int numObjs, Size objSize)
 {
 	DumpableObject **ptrs;
@@ -1056,32 +1055,6 @@ strInArray(const char *pattern, char **arr, int arr_size)
 	}
 	return -1;
 }
-
-
-/* cdb addition */
-void
-reset(void)
-{
-	free(dumpIdMap);
-	dumpIdMap = NULL;
-	allocedDumpIds = 0;
-	lastDumpId = 0;
-
-/*
- * Variables for mapping CatalogId to DumpableObject
- */
-	catalogIdMapValid = false;
-	free(catalogIdMap);
-	catalogIdMap = NULL;
-	numCatalogIds = 0;
-
-	numTables = 0;
-	numTypes = 0;
-	numFuncs = 0;
-	numOperators = 0;
-}
-
-/* end cdb_addition */
 
 
 /*

--- a/src/bin/pg_dump/pg_dump.h
+++ b/src/bin/pg_dump/pg_dump.h
@@ -542,7 +542,6 @@ extern void getDumpableObjects(DumpableObject ***objs, int *numObjs);
 extern void addObjectDependency(DumpableObject *dobj, DumpId refId);
 extern void removeObjectDependency(DumpableObject *dobj, DumpId refId);
 
-extern DumpableObject **buildIndexArray(void *objArray, int numObjs, Size objSize);
 extern DumpableObject *findObjectByOid(Oid oid, DumpableObject **indexArray, int numObjs);
 
 extern TableInfo *findTableByOid(Oid oid);


### PR DESCRIPTION
While investigating the `localtime_r` compilation failure on MinGW, I realized that we probably don't really need the extra logging that was calling localtime_r in the first place. AFAICS, it had been added just for the sake of cdb_dump_agent, although it also affected pg_dump in verbose mode. Revert the logging the way it is in the upstream; you can use --verbose if you want the status messages.