### PR TITLE
Re-enable code that was commented out by mistake.

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -339,7 +339,6 @@ _copyRecursiveUnion(RecursiveUnion *from)
 	 * copy remainder of node
 	 */
 	COPY_SCALAR_FIELD(wtParam);
-#if 0 /* GPDB_84_MERGE_FIXME: see FIXME in the typedef */
 	COPY_SCALAR_FIELD(numCols);
 	if (from->numCols > 0)
 	{
@@ -347,7 +346,6 @@ _copyRecursiveUnion(RecursiveUnion *from)
 		COPY_POINTER_FIELD(dupOperators, from->numCols * sizeof(Oid));
 	}
 	COPY_SCALAR_FIELD(numGroups);
-#endif
 
 	return newnode;
 }


### PR DESCRIPTION
While were working on merging the batch that introduced recursive UNION
without ALL, it was at first not clear if we can support recursive UNION
without ALL in the current GPDB optimizer/executor code. Turns out we can,
no problem there. But this code related to it was mistakenly left
commented-out. Apparently it's not exercised by any existing test, but
clearly it should not be commented out, so re-enable it.