### PR TITLE
Fix typo in gpexpand and gpmovemirrors

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -64,7 +64,7 @@ Adds additional segments to a pre-existing GPDB Array.
 """)
 
 _help = ["""
-The input file should be be a plain text file with a line for each segment
+The input file should be a plain text file with a line for each segment
 to add with the format:
 
   <hostname>:<port>:<data_directory>:<dbid>:<content>:<definedprimary>

--- a/gpMgmt/bin/gpmovemirrors
+++ b/gpMgmt/bin/gpmovemirrors
@@ -46,7 +46,7 @@ Moves mirror segments in a pre-existing GPDB Array.
 EXECNAME = os.path.split(__file__)[-1]
 
 _help = ["""
-The input file should be be a plain text file with the format:
+The input file should be a plain text file with the format:
 
   filespaceOrder=[<filespace1_fsname>[:<filespace2_fsname>:...]
   <old_address>:<port>:<system_filespace_location> <new_address:port>:<replication_port>:<system_filespace_location>[:<fselocation>:...]


### PR DESCRIPTION
$ gpmovemirrors 
...
The input file **should be be** a plain text file with the format:
...
