### PR TITLE
Merge with PostgreSQL 8.4devel, upto commit ba748f7a (reloptions refactor).

### DIFF
--- a/src/backend/access/bitmap/bitmaputil.c
+++ b/src/backend/access/bitmap/bitmaputil.c
@@ -1170,17 +1170,8 @@ bmoptions(PG_FUNCTION_ARGS)
 	bool		validate = PG_GETARG_BOOL(1);
 	bytea	   *result;
 
-	/*
-	 * It's not clear that fillfactor is useful for on-disk bitmap index,
-	 * but for the moment we'll accept it anyway.  (It won't do anything...)
-	 */
-#define BM_MIN_FILLFACTOR			10
-#define BM_DEFAULT_FILLFACTOR		100
-
 	result = default_reloptions(reloptions, validate,
-								RELKIND_INDEX,
-								BM_MIN_FILLFACTOR,
-								BM_DEFAULT_FILLFACTOR);
+								RELOPT_KIND_BITMAP);
 	if (result)
 		PG_RETURN_BYTEA_P(result);
 	PG_RETURN_NULL();

--- a/src/backend/access/common/Makefile
+++ b/src/backend/access/common/Makefile
@@ -12,6 +12,6 @@ subdir = src/backend/access/common
 top_builddir = ../../../..
 include $(top_builddir)/src/Makefile.global
 
-OBJS = bufmask.o memtuple.o heaptuple.o indextuple.o printtup.o reloptions.o scankey.o tupdesc.o  
+OBJS = bufmask.o memtuple.o heaptuple.o indextuple.o printtup.o reloptions.o reloptions_gp.o scankey.o tupdesc.o
 
 include $(top_srcdir)/src/backend/common.mk

--- a/src/backend/access/common/reloptions.c
+++ b/src/backend/access/common/reloptions.c
@@ -8,13 +8,16 @@
  *
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/access/common/reloptions.c,v 1.12 2009/01/01 17:23:34 momjian Exp $
+ *	  $PostgreSQL: pgsql/src/backend/access/common/reloptions.c,v 1.13 2009/01/05 17:14:28 alvherre Exp $
  *
  *-------------------------------------------------------------------------
  */
 
 #include "postgres.h"
 
+#include "access/gist_private.h"
+#include "access/hash.h"
+#include "access/nbtree.h"
 #include "access/reloptions.h"
 #include "catalog/pg_type.h"
 #include "cdb/cdbappendonlyam.h"
@@ -26,189 +29,362 @@
 #include "utils/formatting.h"
 #include "utils/guc.h"
 #include "utils/guc_tables.h"
+#include "utils/memutils.h"
 #include "utils/rel.h"
 #include "miscadmin.h"
 
-
 /*
- * This is set whenever the GUC gp_default_storage_options is set.
+ * Contents of pg_class.reloptions
+ *
+ * To add an option:
+ *
+ * (i) decide on a class (integer, real, bool, string), name, default value,
+ * upper and lower bounds (if applicable).
+ * (ii) add a record below.
+ * (iii) add it to StdRdOptions if appropriate
+ * (iv) add a block to the appropriate handling routine (probably
+ * default_reloptions)
+ * (v) don't forget to document the option
+ *
+ * Note that we don't handle "oids" in relOpts because it is handled by
+ * interpretOidsOption().
+ *
+ * To add an GPDB option, please touch reloptions_gp.c rather than this file.
  */
-static StdRdOptions ao_storage_opts;
 
-inline bool
-isDefaultAOCS(void)
+static relopt_bool boolRelOpts[] =
 {
-	return ao_storage_opts.columnstore;
-}
+	/* list terminator */
+	{ { NULL } }
+};
 
-inline bool
-isDefaultAO(void)
+static relopt_int intRelOpts[] =
 {
-	return ao_storage_opts.appendonly;
-}
+	{
+		{
+			"fillfactor",
+			"Packs table pages only to this percentage",
+			RELOPT_KIND_HEAP
+		},
+		HEAP_DEFAULT_FILLFACTOR, HEAP_MIN_FILLFACTOR, 100
+	},
+	{
+		{
+			"fillfactor",
+			"Packs btree index pages only to this percentage",
+			RELOPT_KIND_BTREE
+		},
+		BTREE_DEFAULT_FILLFACTOR, BTREE_MIN_FILLFACTOR, 100
+	},
+	{
+		{
+			"fillfactor",
+			"Packs hash index pages only to this percentage",
+			RELOPT_KIND_HASH
+		},
+		HASH_DEFAULT_FILLFACTOR, HASH_MIN_FILLFACTOR, 100
+	},
+	{
+		{
+			"fillfactor",
+			"Packs gist index pages only to this percentage",
+			RELOPT_KIND_GIST
+		},
+		GIST_DEFAULT_FILLFACTOR, GIST_MIN_FILLFACTOR, 100
+	},
+	/* list terminator */
+	{ { NULL } }
+};
+
+static relopt_real realRelOpts[] =
+{
+	/* list terminator */
+	{ { NULL } }
+};
+
+static relopt_string stringRelOpts[] = 
+{
+	/* list terminator */
+	{ { NULL } }
+};
+
+static relopt_gen **relOpts = NULL;
+static int last_assigned_kind = RELOPT_KIND_LAST_DEFAULT + 1;
+
+static int		num_custom_options = 0;
+static relopt_gen **custom_options = NULL;
+static bool		need_initialization = true;
+
+static void initialize_reloptions(void);
+static void parse_one_reloption(relopt_value *option, char *text_str,
+					int text_len, bool validate);
 
 /*
- * Accumulate a new datum for one AO storage option.
+ * initialize_reloptions
+ * 		initialization routine, must be called before parsing
+ *
+ * Initialize the relOpts array and fill each variable's type and name length.
  */
 static void
-accumAOStorageOpt(char *name, char *value,
-				  ArrayBuildState *astate, bool *foundAO, bool *aovalue)
+initialize_reloptions(void)
 {
-	text	   *t;
-	bool		boolval;
-	int			intval;
-	StringInfoData buf;
+	int		i;
+	int		j = 0;
 
-	Assert(astate);
+	initialize_reloptions_gp();
 
-	initStringInfo(&buf);
+	for (i = 0; boolRelOpts[i].gen.name; i++)
+		j++;
+	for (i = 0; intRelOpts[i].gen.name; i++)
+		j++;
+	for (i = 0; realRelOpts[i].gen.name; i++)
+		j++;
+	for (i = 0; stringRelOpts[i].gen.name; i++)
+		j++;
+	j += num_custom_options;
 
-	if (pg_strcasecmp(SOPT_APPENDONLY, name) == 0)
-	{
-		if (!parse_bool(value, &boolval))
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("invalid bool value \"%s\" for storage option \"%s\"",
-							value, name)));
-		/* "appendonly" option is explicitly specified. */
-		if (foundAO != NULL)
-			*foundAO = true;
-		if (aovalue != NULL)
-			*aovalue = boolval;
+	if (relOpts)
+		pfree(relOpts);
+	relOpts = MemoryContextAlloc(TopMemoryContext,
+								 (j + 1) * sizeof(relopt_gen *));
 
-		/*
-		 * Record value of "appendonly" option as true always.  Return
-		 * the value specified by user in aovalue.  Setting
-		 * appendonly=true always in the array of datums enables us to
-		 * reuse default_reloptions() and
-		 * validateAppendOnlyRelOptions().  If validations are
-		 * successful, we keep the user specified value for
-		 * appendonly.
-		 */
-		appendStringInfo(&buf, "%s=%s", SOPT_APPENDONLY, "true");
-	}
-	else if (pg_strcasecmp(SOPT_BLOCKSIZE, name) == 0)
+	j = 0;
+	for (i = 0; boolRelOpts[i].gen.name; i++)
 	{
-		if (!parse_int(value, &intval, 0 /* unit flags */,
-					   NULL /* hint message */))
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("invalid integer value \"%s\" for storage option \"%s\"",
-							value, name)));
-		appendStringInfo(&buf, "%s=%d", SOPT_BLOCKSIZE, intval);
+		relOpts[j] = &boolRelOpts[i].gen;
+		relOpts[j]->type = RELOPT_TYPE_BOOL;
+		relOpts[j]->namelen = strlen(relOpts[j]->name);
+		j++;
 	}
-	else if (pg_strcasecmp(SOPT_COMPTYPE, name) == 0)
+
+	for (i = 0; intRelOpts[i].gen.name; i++)
 	{
-		appendStringInfo(&buf, "%s=%s", SOPT_COMPTYPE, value);
+		relOpts[j] = &intRelOpts[i].gen;
+		relOpts[j]->type = RELOPT_TYPE_INT;
+		relOpts[j]->namelen = strlen(relOpts[j]->name);
+		j++;
 	}
-	else if (pg_strcasecmp(SOPT_COMPLEVEL, name) == 0)
+
+	for (i = 0; realRelOpts[i].gen.name; i++)
 	{
-		if (!parse_int(value, &intval, 0 /* unit flags */,
-					   NULL /* hint message */))
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("invalid integer value \"%s\" for storage option \"%s\"",
-							value, name)));
-		appendStringInfo(&buf, "%s=%d", SOPT_COMPLEVEL, intval);
+		relOpts[j] = &realRelOpts[i].gen;
+		relOpts[j]->type = RELOPT_TYPE_REAL;
+		relOpts[j]->namelen = strlen(relOpts[j]->name);
+		j++;
 	}
-	else if (pg_strcasecmp(SOPT_CHECKSUM, name) == 0)
+
+	for (i = 0; stringRelOpts[i].gen.name; i++)
 	{
-		if (!parse_bool(value, &boolval))
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("invalid bool value \"%s\" for storage option \"%s\"",
-							value, name)));
-		appendStringInfo(&buf, "%s=%s", SOPT_CHECKSUM, boolval ? "true" : "false");
+		relOpts[j] = &stringRelOpts[i].gen;
+		relOpts[j]->type = RELOPT_TYPE_STRING;
+		relOpts[j]->namelen = strlen(relOpts[j]->name);
+		j++;
 	}
-	else if (pg_strcasecmp(SOPT_ORIENTATION, name) == 0)
+
+	for (i = 0; i < num_custom_options; i++)
 	{
-		if ((pg_strcasecmp(value, "row") != 0) &&
-			(pg_strcasecmp(value, "column") != 0))
-		{
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("invalid value \"%s\" for storage option \"%s\"",
-							value, name)));
-		}
-		appendStringInfo(&buf, "%s=%s", SOPT_ORIENTATION, value);
+		relOpts[j] = custom_options[i];
+		j++;
 	}
-	else
-	{
+
+	/* add a list terminator */
+	relOpts[j] = NULL;
+}
+
+/*
+ * add_reloption_kind
+ * 		Create a new relopt_kind value, to be used in custom reloptions by
+ * 		user-defined AMs.
+ */
+int
+add_reloption_kind(void)
+{
+	if (last_assigned_kind >= RELOPT_KIND_MAX)
 		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("invalid storage option \"%s\"", name)));
-	}
+				(errmsg("user-defined relation parameter types limit exceeded")));
 
-	t = cstring_to_text(buf.data);
-
-	accumArrayResult(astate, PointerGetDatum(t), /* disnull */ false,
-					 TEXTOID, CurrentMemoryContext);
-	pfree(t);
-	pfree(buf.data);
+	return last_assigned_kind++;
 }
 
 /*
- * Reset appendonly storage options to factory defaults.  Callers must
- * free ao_opts->compresstype before calling this method.
+ * add_reloption
+ * 		Add an already-created custom reloption to the list, and recompute the
+ * 		main parser table.
  */
-inline void
-resetAOStorageOpts(StdRdOptions *ao_opts)
+static void
+add_reloption(relopt_gen *newoption)
 {
-	ao_opts->appendonly = AO_DEFAULT_APPENDONLY;
-	ao_opts->blocksize = AO_DEFAULT_BLOCKSIZE;
-	ao_opts->checksum = AO_DEFAULT_CHECKSUM;
-	ao_opts->columnstore = AO_DEFAULT_COLUMNSTORE;
-	ao_opts->compresslevel = AO_DEFAULT_COMPRESSLEVEL;
-	ao_opts->compresstype = NULL;
-}
+	static int		max_custom_options = 0;
 
-/*
- * This needs to happen whenever gp_default_storage_options GUC is
- * reset.
- */
-void
-resetDefaultAOStorageOpts(void)
-{
-	if (ao_storage_opts.compresstype)
-		free(ao_storage_opts.compresstype);
-	resetAOStorageOpts(&ao_storage_opts);
-}
-
-const StdRdOptions *
-currentAOStorageOptions(void)
-{
-	return (const StdRdOptions *) &ao_storage_opts;
-}
-
-/*
- * Set global appendonly storage options.
- */
-void
-setDefaultAOStorageOpts(StdRdOptions *copy)
-{
-	if (ao_storage_opts.compresstype)
+	if (num_custom_options >= max_custom_options)
 	{
-		free(ao_storage_opts.compresstype);
-		ao_storage_opts.compresstype = NULL;
-	}
-	memcpy(&ao_storage_opts, copy, sizeof(ao_storage_opts));
-	if (copy->compresstype != NULL)
-	{
-		if (pg_strcasecmp(copy->compresstype, "none") == 0)
+		MemoryContext	oldcxt;
+
+		oldcxt = MemoryContextSwitchTo(TopMemoryContext);
+
+		if (max_custom_options == 0)
 		{
-			/* Represent compresstype=none as NULL (MPP-25073). */
-			ao_storage_opts.compresstype = NULL;
+			max_custom_options = 8;
+			custom_options = palloc(max_custom_options * sizeof(relopt_gen *));
 		}
 		else
 		{
-			ao_storage_opts.compresstype = strdup(copy->compresstype);
-			if (ao_storage_opts.compresstype == NULL)
-				elog(ERROR, "out of memory");
+			max_custom_options *= 2;
+			custom_options = repalloc(custom_options,
+									  max_custom_options * sizeof(relopt_gen *));
 		}
+		MemoryContextSwitchTo(oldcxt);
 	}
+	custom_options[num_custom_options++] = newoption;
+
+	need_initialization = true;
 }
 
-static int setDefaultCompressionLevel(char* compresstype);
+/*
+ * allocate_reloption
+ * 		Allocate a new reloption and initialize the type-agnostic fields
+ * 		(for types other than string)
+ */
+static relopt_gen *
+allocate_reloption(int kind, int type, char *name, char *desc)
+{
+	MemoryContext	oldcxt;
+	size_t			size;
+	relopt_gen	   *newoption;
+
+	Assert(type != RELOPT_TYPE_STRING);
+
+	oldcxt = MemoryContextSwitchTo(TopMemoryContext);
+
+	switch (type)
+	{
+		case RELOPT_TYPE_BOOL:
+			size = sizeof(relopt_bool);
+			break;
+		case RELOPT_TYPE_INT:
+			size = sizeof(relopt_int);
+			break;
+		case RELOPT_TYPE_REAL:
+			size = sizeof(relopt_real);
+			break;
+		default:
+			elog(ERROR, "unsupported option type");
+			return NULL;	/* keep compiler quiet */
+	}
+
+	newoption = palloc(size);
+
+	newoption->name = pstrdup(name);
+	if (desc)
+		newoption->desc = pstrdup(desc);
+	else
+		newoption->desc = NULL;
+	newoption->kind = kind;
+	newoption->namelen = strlen(name);
+	newoption->type = type;
+
+	MemoryContextSwitchTo(oldcxt);
+
+	return newoption;
+}
+
+/*
+ * add_bool_reloption
+ * 		Add a new boolean reloption
+ */
+void
+add_bool_reloption(int kind, char *name, char *desc, bool default_val)
+{
+	relopt_bool	   *newoption;
+
+	newoption = (relopt_bool *) allocate_reloption(kind, RELOPT_TYPE_BOOL,
+												   name, desc);
+	newoption->default_val = default_val;
+
+	add_reloption((relopt_gen *) newoption);
+}
+
+/*
+ * add_int_reloption
+ * 		Add a new integer reloption
+ */
+void
+add_int_reloption(int kind, char *name, char *desc, int default_val,
+				  int min_val, int max_val)
+{
+	relopt_int	   *newoption;
+
+	newoption = (relopt_int *) allocate_reloption(kind, RELOPT_TYPE_INT,
+												  name, desc);
+	newoption->default_val = default_val;
+	newoption->min = min_val;
+	newoption->max = max_val;
+
+	add_reloption((relopt_gen *) newoption);
+}
+
+/*
+ * add_real_reloption
+ * 		Add a new float reloption
+ */
+void
+add_real_reloption(int kind, char *name, char *desc, double default_val,
+				  double min_val, double max_val)
+{
+	relopt_real	   *newoption;
+
+	newoption = (relopt_real *) allocate_reloption(kind, RELOPT_TYPE_REAL,
+												   name, desc);
+	newoption->default_val = default_val;
+	newoption->min = min_val;
+	newoption->max = max_val;
+
+	add_reloption((relopt_gen *) newoption);
+}
+
+/*
+ * add_string_reloption
+ *		Add a new string reloption
+ */
+void
+add_string_reloption(int kind, char *name, char *desc, char *default_val)
+{
+	MemoryContext	oldcxt;
+	relopt_string  *newoption;
+	int				default_len = 0;
+
+	oldcxt = MemoryContextSwitchTo(TopMemoryContext);
+
+	if (default_val)
+		default_len = strlen(default_val);
+
+	newoption = palloc0(sizeof(relopt_string) + default_len);
+
+	newoption->gen.name = pstrdup(name);
+	if (desc)
+		newoption->gen.desc = pstrdup(desc);
+	else
+		newoption->gen.desc = NULL;
+	newoption->gen.kind = kind;
+	newoption->gen.namelen = strlen(name);
+	newoption->gen.type = RELOPT_TYPE_STRING;
+	if (default_val)
+	{
+		strcpy(newoption->default_val, default_val);
+		newoption->default_len = default_len;
+		newoption->default_isnull = false;
+	}
+	else
+	{
+		newoption->default_val[0] = '\0';
+		newoption->default_len = 0;
+		newoption->default_isnull = true;
+	}
+
+	MemoryContextSwitchTo(oldcxt);
+
+	add_reloption((relopt_gen *) newoption);
+}
 
 /*
  * Transform a relation options list (list of DefElem) into the text array
@@ -335,470 +511,6 @@ transformRelOptions(Datum oldOptions, List *defList,
 	return result;
 }
 
-/*
- * Accept a string of the form "name=value,name=value,...".  Space
- * around ',' and '=' is allowed.  Parsed values are stored in
- * corresponding fields of StdRdOptions object.  The parser is a
- * finite state machine that changes states for each input character
- * scanned.
- */
-Datum
-parseAOStorageOpts(const char *opts_str, bool *aovalue)
-{
-	int dims[1];
-	int lbs[1];
-	Datum result;
-	ArrayBuildState *astate;
-
-	bool foundAO = false;
-	const char *cp;
-	const char *name_st=NULL;
-	const char *value_st=NULL;
-	char *name=NULL, *value=NULL;
-	enum state {
-		/*
-		 * Consume whitespace at the beginning of a name token.
-		 */
-		LEADING_NAME,
-
-		/*
-		 * Name token is being scanned.  Allowed characters are
-		 * alphabets, whitespace and '='.
-		 */
-		NAME_TOKEN,
-
-		/*
-		 * Name token was terminated by whitespace.  This state scans
-		 * the trailing whitespace after name token.
-		 */
-		TRAILING_NAME,
-
-		/*
-		 * Whitespace after '=' and before value token.
-		 */
-		LEADING_VALUE,
-
-		/*
-		 * Value token is being scanned.  Allowed characters are
-		 * alphabets, digits, '_'.  Value should be delimited by a
-		 * ',', whitespace or end of string '\0'.
-		 */
-		VALUE_TOKEN,
-
-		/*
-		 * Whitespace after value token.
-		 */
-		TRAILING_VALUE,
-
-		/*
-		 * End of string.  This state can only be entered from
-		 * VALUE_TOKEN or TRAILING_VALUE.
-		 */
-		EOS
-	};
-	enum state st = LEADING_NAME;
-
-	/*
-	 * Initialize ArrayBuildState ourselves rather than leaving it to
-	 * accumArrayResult().  This aviods the catalog lookup (pg_type)
-	 * performed by accumArrayResult().
-	 */
-	astate = (ArrayBuildState *) palloc(sizeof(ArrayBuildState));
-	astate->mcontext = CurrentMemoryContext;
-	astate->alen = 10; /* Initial number of name=value pairs. */
-	astate->dvalues = (Datum *) palloc(astate->alen * sizeof(Datum));
-	astate->dnulls = (bool *) palloc(astate->alen * sizeof(bool));
-	astate->nelems = 0;
-	astate->element_type = TEXTOID;
-	astate->typlen = -1;
-	astate->typbyval = false;
-	astate->typalign = 'i';
-
-	cp = opts_str-1;
-	do
-	{
-		++cp;
-		switch(st)
-		{
-			case LEADING_NAME:
-				if (isalpha(*cp))
-				{
-					st = NAME_TOKEN;
-					name_st = cp;
-				}
-				else if (!isspace(*cp))
-				{
-					ereport(ERROR,
-							(errcode(ERRCODE_SYNTAX_ERROR),
-							 errmsg("invalid storage option name in \"%s\"",
-									opts_str)));
-				}
-				break;
-			case NAME_TOKEN:
-				if (isspace(*cp))
-					st = TRAILING_NAME;
-				else if (*cp == '=')
-					st = LEADING_VALUE;
-				else if (!isalpha(*cp))
-					ereport(ERROR,
-							(errcode(ERRCODE_SYNTAX_ERROR),
-							 errmsg("invalid storage option name in \"%s\"",
-									opts_str)));
-				if (st != NAME_TOKEN)
-				{
-					name = palloc(cp - name_st + 1);
-					strncpy(name, name_st, cp-name_st);
-					name[cp-name_st] = '\0';
-					for (name_st = name; *name_st != '\0'; ++name_st)
-						*(char *)name_st = pg_tolower(*name_st);
-				}
-				break;
-			case TRAILING_NAME:
-				if (*cp == '=')
-					st = LEADING_VALUE;
-				else if (!isspace(*cp))
-					ereport(ERROR,
-							(errcode(ERRCODE_SYNTAX_ERROR),
-							 errmsg("invalid value for option \"%s\", expected \"=\"", name)));
-				break;
-			case LEADING_VALUE:
-				if (isalnum(*cp))
-				{
-					st = VALUE_TOKEN;
-					value_st = cp;
-				}
-				else if (!isspace(*cp))
-					ereport(ERROR,
-							(errcode(ERRCODE_SYNTAX_ERROR),
-							 errmsg("invalid value for option \"%s\"", name)));
-				break;
-			case VALUE_TOKEN:
-				if (isspace(*cp))
-					st = TRAILING_VALUE;
-				else if (*cp == '\0')
-					st = EOS;
-				else if (*cp == ',')
-					st = LEADING_NAME;
-				/* Need to check '_' for rle_type */
-				else if (!(isalnum(*cp) || *cp == '_'))
-					ereport(ERROR,
-							(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-							 errmsg("invalid value for option \"%s\"", name)));
-				if (st != VALUE_TOKEN)
-				{
-					value = palloc(cp - value_st + 1);
-					strncpy(value, value_st, cp-value_st);
-					value[cp-value_st] = '\0';
-					for (value_st = value; *value_st != '\0'; ++value_st)
-						*(char *)value_st = pg_tolower(*value_st);
-					Assert(name);
-					accumAOStorageOpt(name, value, astate,
-									  &foundAO, aovalue);
-					pfree(name);
-					name = NULL;
-					pfree(value);
-					value = NULL;
-				}
-				break;
-			case TRAILING_VALUE:
-				if (*cp == ',')
-					st = LEADING_NAME;
-				else if (*cp == '\0')
-					st = EOS;
-				else if (!isspace(*cp))
-					ereport(ERROR,
-							(errcode(ERRCODE_SYNTAX_ERROR),
-							 errmsg("syntax error after \"%s\"", value)));
-				break;
-			case EOS:
-				/*
-				 * We better get out of the loop right after entering
-				 * this state.  Therefore, we should never get here.
-				 */
-				elog(ERROR, "invalid value \"%s\" for GUC", opts_str);
-				break;
-		};
-	} while(*cp != '\0');
-	if (st != EOS)
-		elog(ERROR, "invalid value \"%s\" for GUC", opts_str);
-	if (!foundAO)
-	{
-		/*
-		 * Add "appendonly=true" datum if it was not explicitly
-		 * specified by user.  This is needed to validate the array of
-		 * datums constructed from user specified options.
-		 */
-		accumAOStorageOpt(SOPT_APPENDONLY, "true", astate, NULL, NULL);
-	}
-
-	lbs[0] = 1;
-	dims[0] = astate->nelems;
-	result = makeMdArrayResult(astate, 1, dims, lbs, CurrentMemoryContext, false);
-	pfree(astate->dvalues);
-	pfree(astate->dnulls);
-	pfree(astate);
-	return result;
-}
-
-/*
- * Return a datum that is array of "name=value" strings for each
- * appendonly storage option in opts.  This datum is used to populate
- * pg_class.reloptions during relation creation.
- *
- * To avoid catalog bloat, we only create "name=value" item for those
- * values in opts that are not specified in WITH clause and are
- * different from their initial defaults.
- */
-Datum
-transformAOStdRdOptions(StdRdOptions *opts, Datum withOpts)
-{
-	char *strval;
-	char intval[MAX_SOPT_VALUE_LEN];
-	Datum *withDatums = NULL;
-	text *t;
-	int len, i, withLen, soptLen, nWithOpts = 0;
-	ArrayType *withArr;
-	ArrayBuildState *astate = NULL;
-	bool foundAO = false, foundBlksz = false, foundComptype = false,
-			foundComplevel = false, foundChecksum = false,
-			foundOrientation = false;
-	/*
-	 * withOpts must be parsed to see if an option was spcified in
-	 * WITH() clause.
-	 */
-	if (DatumGetPointer(withOpts) != NULL)
-	{
-		withArr = DatumGetArrayTypeP(withOpts);
-		Assert(ARR_ELEMTYPE(withArr) == TEXTOID);
-		deconstruct_array(withArr, TEXTOID, -1, false, 'i', &withDatums,
-						  NULL, &nWithOpts);
-		/*
-		 * Include options specified in WITH() clause in the same
-		 * order as they are specified.  Otherwise we will end up with
-		 * regression failures due to diff with respect to answer
-		 * file.
-		 */
-		for (i = 0; i < nWithOpts; ++i)
-		{
-			t = DatumGetTextP(withDatums[i]);
-			strval = VARDATA(t);
-			/*
-			 * Text datums are usually not null terminated.  We must
-			 * never access beyond their length.
-			 */
-			withLen = VARSIZE(t) - VARHDRSZ;
-
-			/*
-			 * withDatums[i] may not be used directly.  It may be
-			 * e.g. "aPPendOnly=tRue".  Therefore we don't set it as
-			 * reloptions as is.
-			 */
-			soptLen = strlen(SOPT_APPENDONLY);
-			if (withLen > soptLen &&
-				pg_strncasecmp(strval, SOPT_APPENDONLY, soptLen) == 0)
-			{
-				foundAO = true;
-				strval = opts->appendonly ? "true" : "false";
-				len = VARHDRSZ + strlen(SOPT_APPENDONLY) + 1 + strlen(strval);
-				/* +1 leaves room for sprintf's trailing null */
-				t = (text *) palloc(len + 1);
-				SET_VARSIZE(t, len);
-				sprintf(VARDATA(t), "%s=%s", SOPT_APPENDONLY, strval);
-				astate = accumArrayResult(astate, PointerGetDatum(t), false,
-										  TEXTOID, CurrentMemoryContext);
-			}
-			soptLen = strlen(SOPT_BLOCKSIZE);
-			if (withLen > soptLen &&
-				pg_strncasecmp(strval, SOPT_BLOCKSIZE, soptLen) == 0)
-			{
-				foundBlksz = true;
-				snprintf(intval, MAX_SOPT_VALUE_LEN, "%d", opts->blocksize);
-				len = VARHDRSZ + strlen(SOPT_BLOCKSIZE) + 1 + strlen(intval);
-				/* +1 leaves room for sprintf's trailing null */
-				t = (text *) palloc(len + 1);
-				SET_VARSIZE(t, len);
-				sprintf(VARDATA(t), "%s=%s", SOPT_BLOCKSIZE, intval);
-				astate = accumArrayResult(astate, PointerGetDatum(t), false,
-										  TEXTOID, CurrentMemoryContext);
-			}
-			soptLen = strlen(SOPT_COMPTYPE);
-			if (withLen > soptLen &&
-				pg_strncasecmp(strval, SOPT_COMPTYPE, soptLen) == 0)
-			{
-				foundComptype = true;
-				/*
-				 * Record "none" as compresstype in reloptions if it
-				 * was explicitly specified in WITH clause.
-				 */
-				strval = (opts->compresstype != NULL) ?
-						opts->compresstype : "none";
-				len = VARHDRSZ + strlen(SOPT_COMPTYPE) + 1 + strlen(strval);
-				/* +1 leaves room for sprintf's trailing null */
-				t = (text *) palloc(len + 1);
-				SET_VARSIZE(t, len);
-				sprintf(VARDATA(t), "%s=%s", SOPT_COMPTYPE, strval);
-				astate = accumArrayResult(astate, PointerGetDatum(t), false,
-										  TEXTOID, CurrentMemoryContext);
-			}
-			soptLen = strlen(SOPT_COMPLEVEL);
-			if (withLen > soptLen &&
-				pg_strncasecmp(strval, SOPT_COMPLEVEL, soptLen) == 0)
-			{
-				foundComplevel = true;
-				snprintf(intval, MAX_SOPT_VALUE_LEN, "%d", opts->compresslevel);
-				len = VARHDRSZ + strlen(SOPT_COMPLEVEL) + 1 + strlen(intval);
-				/* +1 leaves room for sprintf's trailing null */
-				t = (text *) palloc(len + 1);
-				SET_VARSIZE(t, len);
-				sprintf(VARDATA(t), "%s=%s", SOPT_COMPLEVEL, intval);
-				astate = accumArrayResult(astate, PointerGetDatum(t), false,
-										  TEXTOID, CurrentMemoryContext);
-			}
-			soptLen = strlen(SOPT_CHECKSUM);
-			if (withLen > soptLen &&
-				pg_strncasecmp(strval, SOPT_CHECKSUM, soptLen) == 0)
-			{
-				foundChecksum = true;
-				strval = opts->checksum ? "true" : "false";
-				len = VARHDRSZ + strlen(SOPT_CHECKSUM) + 1 + strlen(strval);
-				/* +1 leaves room for sprintf's trailing null */
-				t = (text *) palloc(len + 1);
-				SET_VARSIZE(t, len);
-				sprintf(VARDATA(t), "%s=%s", SOPT_CHECKSUM, strval);
-				astate = accumArrayResult(astate, PointerGetDatum(t), false,
-										  TEXTOID, CurrentMemoryContext);
-			}
-			soptLen = strlen(SOPT_ORIENTATION);
-			if (withLen > soptLen &&
-				pg_strncasecmp(strval, SOPT_ORIENTATION, soptLen) == 0)
-			{
-				foundOrientation = true;
-				strval = opts->columnstore ? "column" : "row";
-				len = VARHDRSZ + strlen(SOPT_ORIENTATION) + 1 + strlen(strval);
-				/* +1 leaves room for sprintf's trailing null */
-				t = (text *) palloc(len + 1);
-				SET_VARSIZE(t, len);
-				sprintf(VARDATA(t), "%s=%s", SOPT_ORIENTATION, strval);
-				astate = accumArrayResult(astate, PointerGetDatum(t), false,
-										  TEXTOID, CurrentMemoryContext);
-			}
-			/*
-			 * Record fillfactor only if it's specified in WITH
-			 * clause.  Default fillfactor is assumed otherwise.
-			 */
-			soptLen = strlen(SOPT_FILLFACTOR);
-			if (withLen > soptLen &&
-				pg_strncasecmp(strval, SOPT_FILLFACTOR, soptLen) == 0)
-			{
-				snprintf(intval, MAX_SOPT_VALUE_LEN, "%d", opts->fillfactor);
-				len = VARHDRSZ + strlen(SOPT_FILLFACTOR) + 1 + strlen(intval);
-				/* +1 leaves room for sprintf's trailing null */
-				t = (text *) palloc(len + 1);
-				SET_VARSIZE(t, len);
-				sprintf(VARDATA(t), "%s=%s", SOPT_FILLFACTOR, intval);
-				astate = accumArrayResult(astate, PointerGetDatum(t), false,
-										  TEXTOID, CurrentMemoryContext);
-			}
-		}
-	}
-	/* Include options that are not defaults and not already included. */
-	if ((opts->appendonly != AO_DEFAULT_APPENDONLY) && !foundAO)
-	{
-		/* appendonly */
-		strval = opts->appendonly ? "true" : "false";
-		len = VARHDRSZ + strlen(SOPT_APPENDONLY) + 1 + strlen(strval);
-		/* +1 leaves room for sprintf's trailing null */
-		t = (text *) palloc(len + 1);
-		SET_VARSIZE(t, len);
-		sprintf(VARDATA(t), "%s=%s", SOPT_APPENDONLY, strval);
-		astate = accumArrayResult(astate, PointerGetDatum(t),
-								  false, TEXTOID,
-								  CurrentMemoryContext);
-	}
-	if ((opts->blocksize != AO_DEFAULT_BLOCKSIZE) && !foundBlksz)
-	{
-		/* blocksize */
-		snprintf(intval, MAX_SOPT_VALUE_LEN, "%d", opts->blocksize);
-		len = VARHDRSZ + strlen(SOPT_BLOCKSIZE) + 1 + strlen(intval);
-		/* +1 leaves room for sprintf's trailing null */
-		t = (text *) palloc(len + 1);
-		SET_VARSIZE(t, len);
-		sprintf(VARDATA(t), "%s=%s", SOPT_BLOCKSIZE, intval);
-		astate = accumArrayResult(astate, PointerGetDatum(t),
-								  false, TEXTOID,
-								  CurrentMemoryContext);
-	}
-	/*
-	 * Record compression options only if compression is enabled.  No
-	 * need to check compresstype here as by the time we get here,
-	 * "opts" should have been set by default_reloptions() correctly.
-	 */
-	if (opts->compresslevel > AO_DEFAULT_COMPRESSLEVEL &&
-		opts->compresstype != NULL)
-	{
-		if (!foundComptype && (
-				(pg_strcasecmp(opts->compresstype, AO_DEFAULT_COMPRESSTYPE) == 0
-				 && opts->compresslevel == 1 && !foundComplevel) ||
-				pg_strcasecmp(opts->compresstype,
-							  AO_DEFAULT_COMPRESSTYPE) != 0))
-		{
-			/* compress type */
-			strval = opts->compresstype;
-			len = VARHDRSZ + strlen(SOPT_COMPTYPE) + 1 + strlen(strval);
-			/* +1 leaves room for sprintf's trailing null */
-			t = (text *) palloc(len + 1);
-			SET_VARSIZE(t, len);
-			sprintf(VARDATA(t), "%s=%s", SOPT_COMPTYPE, strval);
-			astate = accumArrayResult(astate, PointerGetDatum(t),
-									  false, TEXTOID,
-									  CurrentMemoryContext);
-		}
-		/* When compression is enabled, default compresslevel is 1. */
-		if ((opts->compresslevel != 1) &&
-			!foundComplevel)
-		{
-			/* compress level */
-			snprintf(intval, MAX_SOPT_VALUE_LEN, "%d", opts->compresslevel);
-			len = VARHDRSZ + strlen(SOPT_COMPLEVEL) + 1 + strlen(intval);
-			/* +1 leaves room for sprintf's trailing null */
-			t = (text *) palloc(len + 1);
-			SET_VARSIZE(t, len);
-			sprintf(VARDATA(t), "%s=%s", SOPT_COMPLEVEL, intval);
-			astate = accumArrayResult(astate, PointerGetDatum(t),
-									  false, TEXTOID,
-									  CurrentMemoryContext);
-		}
-	}
-	if ((opts->checksum != AO_DEFAULT_CHECKSUM) && !foundChecksum)
-	{
-		/* checksum */
-		strval = opts->checksum ? "true" : "false";
-		len = VARHDRSZ + strlen(SOPT_CHECKSUM) + 1 + strlen(strval);
-		/* +1 leaves room for sprintf's trailing null */
-		t = (text *) palloc(len + 1);
-		SET_VARSIZE(t, len);
-		sprintf(VARDATA(t), "%s=%s", SOPT_CHECKSUM, strval);
-		astate = accumArrayResult(astate, PointerGetDatum(t),
-								  false, TEXTOID,
-								  CurrentMemoryContext);
-	}
-	if ((opts->columnstore != AO_DEFAULT_COLUMNSTORE) && !foundOrientation)
-	{
-		/* orientation */
-		strval = opts->columnstore ? "column" : "row";
-		len = VARHDRSZ + strlen(SOPT_ORIENTATION) + 1 + strlen(strval);
-		/* +1 leaves room for sprintf's trailing null */
-		t = (text *) palloc(len + 1);
-		SET_VARSIZE(t, len);
-		sprintf(VARDATA(t), "%s=%s", SOPT_ORIENTATION, strval);
-		astate = accumArrayResult(astate, PointerGetDatum(t),
-								  false, TEXTOID,
-								  CurrentMemoryContext);
-	}
-	return astate ?
-			makeArrayResult(astate, CurrentMemoryContext) :
-			PointerGetDatum(NULL);
-}
 
 /*
  * Convert the text-array format of reloptions into a List of DefElem.
@@ -847,407 +559,346 @@ untransformRelOptions(Datum options)
 /*
  * Interpret reloptions that are given in text-array format.
  *
- *	options: array of "keyword=value" strings, as built by transformRelOptions
- *	numkeywords: number of legal keywords
- *	keywords: the allowed keywords
- *	values: output area
- *	validate: if true, throw error for unrecognized keywords.
+ * options is a reloption text array as constructed by transformRelOptions.
+ * kind specifies the family of options to be processed.
  *
- * The keywords and values arrays must both be of length numkeywords.
- * The values entry corresponding to a keyword is set to a palloc'd string
- * containing the corresponding value, or NULL if the keyword does not appear.
+ * The return value is a relopt_value * array on which the options actually
+ * set in the options array are marked with isset=true.  The length of this
+ * array is returned in *numrelopts.  Options not set are also present in the
+ * array; this is so that the caller can easily locate the default values.
+ *
+ * If there are no options of the given kind, numrelopts is set to 0 and NULL
+ * is returned.
+ *
+ * Note: values of type int, bool and real are allocated as part of the
+ * returned array.  Values of type string are allocated separately and must
+ * be freed by the caller.
  */
-void
-parseRelOptions(Datum options, int numkeywords, const char *const * keywords,
-				char **values, bool validate)
+relopt_value *
+parseRelOptions(Datum options, bool validate, relopt_kind kind,
+				int *numrelopts)
 {
-	ArrayType  *array;
-	Datum	   *optiondatums;
-	int			noptions;
+	relopt_value *reloptions;
+	int			numoptions = 0;
 	int			i;
-	bool	isArrayToBeFreed = false;
+	int			j;
 
-	/* Initialize to "all defaulted" */
-	MemSet(values, 0, numkeywords * sizeof(char *));
+	if (need_initialization)
+		initialize_reloptions();
+
+	/* Build a list of expected options, based on kind */
+
+	for (i = 0; relOpts[i]; i++)
+		if (relOpts[i]->kind == kind)
+			numoptions++;
+
+	if (numoptions == 0)
+	{
+		*numrelopts = 0;
+		return NULL;
+	}
+
+	reloptions = palloc(numoptions * sizeof(relopt_value));
+
+	for (i = 0, j = 0; relOpts[i]; i++)
+	{
+		if (relOpts[i]->kind == kind)
+		{
+			reloptions[j].gen = relOpts[i];
+			reloptions[j].isset = false;
+			j++;
+		}
+	}
 
 	/* Done if no options */
-	if (!PointerIsValid(DatumGetPointer(options)))
-		return;
-
-	array = DatumGetArrayTypeP(options);
-	isArrayToBeFreed = (array != (ArrayType *)DatumGetPointer(options));
-
-	Assert(ARR_ELEMTYPE(array) == TEXTOID);
-
-	deconstruct_array(array, TEXTOID, -1, false, 'i',
-					  &optiondatums, NULL, &noptions);
-
-	for (i = 0; i < noptions; i++)
+	if (PointerIsValid(DatumGetPointer(options)))
 	{
-		text	   *optiontext = DatumGetTextP(optiondatums[i]);
-		char	   *text_str = VARDATA(optiontext);
-		int			text_len = VARSIZE(optiontext) - VARHDRSZ;
-		int			j;
+		ArrayType  *array;
+		Datum	   *optiondatums;
+		int			noptions;
 
-		/* Search for a match in keywords */
-		for (j = 0; j < numkeywords; j++)
+		array = DatumGetArrayTypeP(options);
+
+		Assert(ARR_ELEMTYPE(array) == TEXTOID);
+
+		deconstruct_array(array, TEXTOID, -1, false, 'i',
+						  &optiondatums, NULL, &noptions);
+
+		for (i = 0; i < noptions; i++)
 		{
-			int			kw_len = strlen(keywords[j]);
+			text	   *optiontext = DatumGetTextP(optiondatums[i]);
+			char	   *text_str = VARDATA(optiontext);
+			int			text_len = VARSIZE(optiontext) - VARHDRSZ;
+			int			j;
 
-			if (text_len > kw_len && text_str[kw_len] == '=' &&
-				pg_strncasecmp(text_str, keywords[j], kw_len) == 0)
+			/* Search for a match in reloptions */
+			for (j = 0; j < numoptions; j++)
 			{
-				char	   *value;
-				int			value_len;
+				int			kw_len = reloptions[j].gen->namelen;
 
-				if (values[j] && validate)
-					ereport(ERROR,
-							(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-						  errmsg("parameter \"%s\" specified more than once",
-								 keywords[j])));
-				value_len = text_len - kw_len - 1;
-				value = (char *) palloc(value_len + 1);
-				memcpy(value, text_str + kw_len + 1, value_len);
-				value[value_len] = '\0';
-				values[j] = value;
-				break;
+				if (text_len > kw_len && text_str[kw_len] == '=' &&
+					pg_strncasecmp(text_str, reloptions[j].gen->name,
+								   kw_len) == 0)
+				{
+					parse_one_reloption(&reloptions[j], text_str, text_len,
+										validate);
+					break;
+				}
+			}
+
+			if (j >= numoptions && validate)
+			{
+				char	   *s;
+				char	   *p;
+
+				s = TextDatumGetCString(optiondatums[i]);
+				p = strchr(s, '=');
+				if (p)
+					*p = '\0';
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+						 errmsg("unrecognized parameter \"%s\"", s)));
 			}
 		}
-		if (j >= numkeywords && validate)
-		{
-			char	   *s;
-			char	   *p;
-
-			s = TextDatumGetCString(optiondatums[i]);
-			p = strchr(s, '=');
-			if (p)
-				*p = '\0';
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("unrecognized parameter \"%s\"", s)));
-		}
 	}
-	pfree(optiondatums);
 
-	if (isArrayToBeFreed)
-	{
-		pfree(array);
-	}
+	*numrelopts = numoptions;
+	return reloptions;
 }
 
 /*
- * Merge user-specified reloptions with pre-configured default storage
- * options and return a StdRdOptions object.
+ * Subroutine for parseRelOptions, to parse and validate a single option's
+ * value
  */
-bytea *
-default_reloptions(Datum reloptions, bool validate, char relkind,
-				   int minFillfactor, int defaultFillfactor)
+static void
+parse_one_reloption(relopt_value *option, char *text_str, int text_len,
+					bool validate)
 {
-	StdRdOptions *result = (StdRdOptions *) palloc0(sizeof(StdRdOptions));
-	SET_VARSIZE(result, sizeof(StdRdOptions));
-	if (validate && (relkind == RELKIND_RELATION))
-	{
-		/*
-		 * Relation creation is in progress.  reloptions are specified
-		 * by user.  We should merge currently configured default
-		 * storage options along with user-specified ones.  It is
-		 * assumed that auxiliary relations (relkind != 'r') such as
-		 * toast, aoseg, etc are heap relations.
-		 */
-		result->appendonly = ao_storage_opts.appendonly;
-		result->blocksize = ao_storage_opts.blocksize;
-		result->checksum = ao_storage_opts.checksum;
-		result->columnstore = ao_storage_opts.columnstore;
-		result->compresslevel = ao_storage_opts.compresslevel;
-		if (ao_storage_opts.compresstype)
-		{
-			result->compresstype = pstrdup(ao_storage_opts.compresstype);
-		}
-	}
-	else
-	{
-		/*
-		 * We are called for either creating an auxiliary relation or
-		 * through heap_open().  If we are doing heap_open(),
-		 * reloptions argument contains pg_class.reloptions for the
-		 * relation being opened.
-		 */
-		resetAOStorageOpts(result);
-	}
-	result->fillfactor = defaultFillfactor;
+	char	   *value;
+	int			value_len;
+	bool		parsed;
+	bool		nofree = false;
 
-	parse_validate_reloptions(result, reloptions, validate, relkind);
-	if (result->appendonly == false &&
-		(result->fillfactor < minFillfactor || result->fillfactor > 100))
-	{
-		if (validate)
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("fillfactor=%d is out of range (should "
-							"be between %d and 100)",
-							result->fillfactor, minFillfactor)));
+	if (option->isset && validate)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("parameter \"%s\" specified more than once",
+						option->gen->name)));
 
-		result->fillfactor = defaultFillfactor;
+	value_len = text_len - option->gen->namelen - 1;
+	value = (char *) palloc(value_len + 1);
+	memcpy(value, text_str + option->gen->namelen + 1, value_len);
+	value[value_len] = '\0';
+
+	switch (option->gen->type)
+	{
+		case RELOPT_TYPE_BOOL:
+			{
+				parsed = parse_bool(value, &option->values.bool_val);
+				if (validate && !parsed)
+					ereport(ERROR,
+							(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+							 errmsg("invalid value for boolean option \"%s\": %s",
+									option->gen->name, value)));
+			}
+			break;
+		case RELOPT_TYPE_INT:
+			{
+				relopt_int	*optint = (relopt_int *) option->gen;
+
+				parsed = parse_int(value, &option->values.int_val, 0, NULL);
+				if (validate && !parsed)
+					ereport(ERROR,
+							(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+							 errmsg("invalid value for integer option \"%s\": %s",
+									option->gen->name, value)));
+				if (validate && (option->values.int_val < optint->min ||
+								 option->values.int_val > optint->max))
+					ereport(ERROR,
+							(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+							 errmsg("value %s out of bounds for option \"%s\"",
+									value, option->gen->name),
+							 errdetail("Valid values are between \"%d\" and \"%d\".",
+									   optint->min, optint->max)));
+			}
+			break;
+		case RELOPT_TYPE_REAL:
+			{
+				relopt_real	*optreal = (relopt_real *) option->gen;
+
+				parsed = parse_real(value, &option->values.real_val);
+				if (validate && !parsed)
+					ereport(ERROR,
+							(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+							 errmsg("invalid value for floating point option \"%s\": %s",
+									option->gen->name, value)));
+				if (validate && (option->values.real_val < optreal->min ||
+								 option->values.real_val > optreal->max))
+					ereport(ERROR,
+							(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+							 errmsg("value %s out of bounds for option \"%s\"",
+									value, option->gen->name),
+							 errdetail("Valid values are between \"%f\" and \"%f\".",
+									   optreal->min, optreal->max)));
+			}
+			break;
+		case RELOPT_TYPE_STRING:
+			option->values.string_val = value;
+			nofree = true;
+			parsed = true;
+			/* no validation possible */
+			break;
+		default:
+			elog(ERROR, "unsupported reloption type %d", option->gen->type);
+			break;
 	}
-	return (bytea *) result;
+
+	if (parsed)
+		option->isset = true;
+	if (!nofree)
+		pfree(value);
 }
 
-void
-parse_validate_reloptions(StdRdOptions *result, Datum reloptions,
-						  bool validate, char relkind)
+/*
+ * Given the result from parseRelOptions, allocate a struct that's of the
+ * specified base size plus any extra space that's needed for string variables.
+ *
+ * "base" should be sizeof(struct) of the reloptions struct (StdRdOptions or
+ * equivalent).
+ */
+void *
+allocateReloptStruct(Size base, relopt_value *options, int numoptions)
 {
-	static const char *const default_keywords[] = {
-			SOPT_FILLFACTOR,
-			SOPT_APPENDONLY,
-			SOPT_BLOCKSIZE,
-			SOPT_COMPTYPE,
-			SOPT_COMPLEVEL,
-			SOPT_CHECKSUM,
-			SOPT_ORIENTATION
+	Size		size = base;
+	int			i;
+
+	for (i = 0; i < numoptions; i++)
+		if (options[i].gen->type == RELOPT_TYPE_STRING)
+			size += GET_STRING_RELOPTION_LEN(options[i]) + 1;
+
+	return palloc0(size);
+}
+
+/*
+ * Given the result of parseRelOptions and a parsing table, fill in the
+ * struct (previously allocated with allocateReloptStruct) with the parsed
+ * values.
+ *
+ * rdopts is the pointer to the allocated struct to be filled.
+ * basesize is the sizeof(struct) that was passed to allocateReloptStruct.
+ * options, of length numoptions, is parseRelOptions' output.
+ * elems, of length numelems, is the table describing the allowed options.
+ * When validate is true, it is expected that all options appear in elems.
+ */
+void
+fillRelOptions(void *rdopts, Size basesize,
+			   relopt_value *options, int numoptions,
+			   bool validate,
+			   const relopt_parse_elt *elems, int numelems)
+{
+	int			i;
+	int			offset = basesize;
+
+	for (i = 0; i < numoptions; i++)
+	{
+		int			j;
+		bool		found = false;
+
+		for (j = 0; j < numelems; j++)
+		{
+			if (pg_strcasecmp(options[i].gen->name, elems[j].optname) == 0)
+			{
+				relopt_string *optstring;
+				char	   *itempos = ((char *) rdopts) + elems[j].offset;
+				char	   *string_val;
+
+				switch (options[i].gen->type)
+				{
+					case RELOPT_TYPE_BOOL:
+						*(bool *) itempos = options[i].isset ?
+							options[i].values.bool_val :
+							((relopt_bool *) options[i].gen)->default_val;
+						break;
+					case RELOPT_TYPE_INT:
+						*(int *) itempos = options[i].isset ?
+							options[i].values.int_val :
+							((relopt_int *) options[i].gen)->default_val;
+						break;
+					case RELOPT_TYPE_REAL:
+						*(double *) itempos = options[i].isset ?
+							options[i].values.real_val :
+							((relopt_real *) options[i].gen)->default_val;
+						break;
+					case RELOPT_TYPE_STRING:
+						optstring = (relopt_string *) options[i].gen;
+						if (options[i].isset)
+							string_val = options[i].values.string_val;
+						else if (!optstring->default_isnull)
+							string_val = optstring->default_val;
+						else
+							string_val = NULL;
+
+						if (string_val == NULL)
+							*(int *) itempos = 0;
+						else
+						{
+							strcpy((char *) rdopts + offset, string_val);
+							*(int *) itempos = offset;
+							offset += strlen(string_val) + 1;
+						}
+						break;
+					default:
+						elog(ERROR, "unrecognized reloption type %c",
+							 options[i].gen->type);
+						break;
+				}
+				found = true;
+				break;
+			}
+		}
+		if (validate && !found)
+			elog(ERROR, "reloption \"%s\" not found in parse table",
+				 options[i].gen->name);
+	}
+	SET_VARSIZE(rdopts, offset);
+}
+
+/*
+ * Option parser for anything that uses StdRdOptions (i.e. fillfactor only)
+ */
+bytea *
+default_reloptions(Datum reloptions, bool validate, relopt_kind kind)
+{
+	relopt_value   *options;
+	StdRdOptions   *rdopts;
+	int				numoptions;
+	/* The type of columnstores are different in StdRdOptions and options */
+	static const relopt_parse_elt tab[] = {
+		{"fillfactor", RELOPT_TYPE_INT, offsetof(StdRdOptions, fillfactor)},
+		{SOPT_APPENDONLY, RELOPT_TYPE_BOOL, offsetof(StdRdOptions, appendonly)},
+		{SOPT_BLOCKSIZE, RELOPT_TYPE_INT, offsetof(StdRdOptions, blocksize)},
+		{SOPT_COMPLEVEL, RELOPT_TYPE_INT, offsetof(StdRdOptions, compresslevel)},
+		{SOPT_COMPTYPE, RELOPT_TYPE_STRING, offsetof(StdRdOptions, compresstype)},
+		{SOPT_CHECKSUM, RELOPT_TYPE_BOOL, offsetof(StdRdOptions, checksum)},
+		{SOPT_ORIENTATION, RELOPT_TYPE_STRING, offsetof(StdRdOptions, orientation)}
 	};
-	char	   *values[ARRAY_SIZE(default_keywords)];
-	int			j = 0;
 
-	parseRelOptions(reloptions, ARRAY_SIZE(default_keywords),
-					default_keywords, values, validate);
+	options = parseRelOptions(reloptions, validate, kind, &numoptions);
 
-	/* fillfactor */
-	if (values[0] != NULL)
-	{
-		if (!parse_int(values[0], &result->fillfactor, 0, NULL))
-		{
-			if (validate)
-				ereport(ERROR,
-						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-						 errmsg("fillfactor must be an integer: \"%s\"",
-								values[0])));
-		}
-	}
+	/* if none set, we're done */
+	if (numoptions == 0)
+		return NULL;
 
-	/* appendonly */
-	if (values[1] != NULL)
-	{
-		if (relkind != RELKIND_RELATION)
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("usage of parameter \"appendonly\" in a non relation object is not supported")));
+	rdopts = allocateReloptStruct(sizeof(StdRdOptions), options, numoptions);
 
-		if (!parse_bool(values[1], &result->appendonly))
-		{
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("invalid parameter value for \"appendonly\": "
-							"\"%s\"", values[1])));
-		}
-	}
+	fillRelOptions((void *) rdopts, sizeof(StdRdOptions), options, numoptions,
+				   validate, tab, lengthof(tab));
 
-	/* blocksize */
-	if (values[2] != NULL)
-	{
-		if (relkind != RELKIND_RELATION && validate)
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("usage of parameter \"blocksize\" in a non relation object is not supported")));
+	validate_and_refill_options(rdopts, options, numoptions, kind, validate);
 
-		if (!result->appendonly && validate)
-			ereport(ERROR,
-					(errcode(ERRCODE_GP_FEATURE_NOT_SUPPORTED),
-					 errmsg("invalid option 'blocksize' for base relation. "
-							"Only valid for Append Only relations")));
+	pfree(options);
 
-		result->blocksize = pg_atoi(values[2], sizeof(int32), 0);
-
-		if (result->blocksize < MIN_APPENDONLY_BLOCK_SIZE ||
-			result->blocksize > MAX_APPENDONLY_BLOCK_SIZE ||
-			result->blocksize % MIN_APPENDONLY_BLOCK_SIZE != 0)
-		{
-			if (validate)
-				ereport(ERROR,
-						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-						 errmsg("block size must be between 8KB and 2MB and be"
-								" an 8KB multiple. Got %d", result->blocksize)));
-
-			result->blocksize = DEFAULT_APPENDONLY_BLOCK_SIZE;
-		}
-
-	}
-
-	/* compression type */
-	if (values[3] != NULL)
-	{
-		if (relkind != RELKIND_RELATION && validate)
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("usage of parameter \"compresstype\" in a non relation object is not supported")));
-
-		if (!result->appendonly && validate)
-			ereport(ERROR,
-					(errcode(ERRCODE_GP_FEATURE_NOT_SUPPORTED),
-					 errmsg("invalid option \"compresstype\" for base relation."
-							" Only valid for Append Only relations")));
-
-		result->compresstype = pstrdup(values[3]);
-		if (!compresstype_is_valid(result->compresstype))
-			ereport(ERROR,
-					(errcode(ERRCODE_UNDEFINED_OBJECT),
-					 errmsg("unknown compresstype \"%s\"",
-							result->compresstype)));
-		for (j = 0; j < strlen(result->compresstype); j++)
-			result->compresstype[j] = pg_tolower(result->compresstype[j]);
-	}
-
-	/* compression level */
-	if (values[4] != NULL)
-	{
-		if (relkind != RELKIND_RELATION && validate)
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("usage of parameter \"compresslevel\" in a non relation object is not supported")));
-
-		if (!result->appendonly && validate)
-			ereport(ERROR,
-					(errcode(ERRCODE_GP_FEATURE_NOT_SUPPORTED),
-					 errmsg("invalid option 'compresslevel' for base "
-							"relation. Only valid for Append Only relations")));
-
-		result->compresslevel = pg_atoi(values[4], sizeof(int32), 0);
-
-		if (result->compresstype &&
-			pg_strcasecmp(result->compresstype, "none") != 0 &&
-			result->compresslevel == 0 && validate)
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("compresstype can\'t be used with compresslevel 0")));
-		if (result->compresslevel < 0 || result->compresslevel > 9)
-		{
-			if (validate)
-				ereport(ERROR,
-						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-						 errmsg("compresslevel=%d is out of range (should be "
-								"between 0 and 9)",
-								result->compresslevel)));
-
-			result->compresslevel = setDefaultCompressionLevel(
-					result->compresstype);
-		}
-
-		/*
-		 * use the default compressor if compresslevel was indicated but not
-		 * compresstype. must make a copy otherwise str_tolower below will
-		 * crash.
-		 */
-		if (result->compresslevel > 0 && !result->compresstype)
-			result->compresstype = pstrdup(AO_DEFAULT_COMPRESSTYPE);
-
-		if (result->compresstype &&
-			(pg_strcasecmp(result->compresstype, "quicklz") == 0) &&
-			(result->compresslevel != 1))
-		{
-			if (validate)
-				ereport(ERROR,
-						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-						 errmsg("compresslevel=%d is out of range for "
-								"quicklz (should be 1)",
-								result->compresslevel)));
-
-			result->compresslevel = setDefaultCompressionLevel(
-					result->compresstype);
-		}
-
-		if (result->compresstype &&
-			(pg_strcasecmp(result->compresstype, "rle_type") == 0) &&
-			(result->compresslevel > 4))
-		{
-			if (validate)
-				ereport(ERROR,
-						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-						 errmsg("compresslevel=%d is out of range for rle_type"
-								" (should be in the range 1 to 4)",
-								result->compresslevel)));
-
-			result->compresslevel = setDefaultCompressionLevel(
-					result->compresstype);
-		}
-	}
-
-	/* checksum */
-	if (values[5] != NULL)
-	{
-		if (relkind != RELKIND_RELATION && validate)
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("usage of parameter \"checksum\" in a non relation "
-							"object is not supported")));
-
-		if (!result->appendonly && validate)
-			ereport(ERROR,
-					(errcode(ERRCODE_GP_FEATURE_NOT_SUPPORTED),
-					 errmsg("invalid option \"checksum\" for base relation. "
-							"Only valid for Append Only relations")));
-
-		if (!parse_bool(values[5], &result->checksum) && validate)
-		{
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("invalid parameter value for \"checksum\": \"%s\"",
-							values[5])));
-		}
-	}
-	/* Disable checksum for heap relations. */
-	else if (result->appendonly == false)
-		result->checksum = false;
-
-	/* columnstore */
-	if (values[6] != NULL)
-	{
-		if (relkind != RELKIND_RELATION && validate)
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("usage of parameter \"orientation\" in a non "
-							"relation object is not supported")));
-
-		if (!result->appendonly && validate)
-			ereport(ERROR,
-					(errcode(ERRCODE_GP_FEATURE_NOT_SUPPORTED),
-					 errmsg("invalid option \"orientation\" for base relation. "
-							"Only valid for Append Only relations")));
-
-		if (!(pg_strcasecmp(values[6], "column") == 0 ||
-			  pg_strcasecmp(values[6], "row") == 0) &&
-			validate)
-		{
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("invalid parameter value for \"orientation\": "
-							"\"%s\"", values[6])));
-		}
-
-		result->columnstore = (pg_strcasecmp(values[6], "column") == 0 ?
-							   true : false);
-
-		if (result->compresstype &&
-			(pg_strcasecmp(result->compresstype, "rle_type") == 0) &&
-			! result->columnstore)
-		{
-			if (validate)
-				ereport(ERROR,
-						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-						 errmsg("%s cannot be used with Append Only relations "
-								"row orientation", result->compresstype)));
-		}
-	}
-
-	if (result->appendonly && result->compresstype != NULL)
-		if (result->compresslevel == AO_DEFAULT_COMPRESSLEVEL)
-			result->compresslevel = setDefaultCompressionLevel(
-					result->compresstype);
-	for (int i = 0; i < ARRAY_SIZE(default_keywords); i++)
-	{
-		if (values[i])
-		{
-			pfree(values[i]);
-		}
-	}
+	return (bytea *) rdopts;
 }
 
 /*
@@ -1256,10 +907,22 @@ parse_validate_reloptions(StdRdOptions *result, Datum reloptions,
 bytea *
 heap_reloptions(char relkind, Datum reloptions, bool validate)
 {
-	return default_reloptions(reloptions, validate,
-							  relkind,
-							  HEAP_MIN_FILLFACTOR,
-							  HEAP_DEFAULT_FILLFACTOR);
+	switch (relkind)
+	{
+		case RELKIND_RELATION:
+			return default_reloptions(reloptions, validate, RELOPT_KIND_HEAP);
+		case RELKIND_TOASTVALUE:
+		case RELKIND_AOSEGMENTS:
+		case RELKIND_AOBLOCKDIR:
+		case RELKIND_AOVISIMAP:
+		case RELKIND_VIEW:
+		case RELKIND_COMPOSITE_TYPE:
+		case RELKIND_SEQUENCE:
+			return default_reloptions(reloptions, validate, RELOPT_KIND_INTERNAL);
+		default:
+			 /* sequences, composite types and views are not supported */
+			return NULL;
+	}
 }
 
 
@@ -1299,121 +962,4 @@ index_reloptions(RegProcedure amoptions, Datum reloptions, bool validate)
 		return NULL;
 
 	return DatumGetByteaP(result);
-}
-
-/*
- * validateAppendOnlyRelOptions
- *
- *		Various checks for validity of appendonly relation rules.
- */
-void validateAppendOnlyRelOptions(bool ao,
-								  int blocksize,
-								  int safewrite,
-								  int complevel,
-								  char* comptype,
-								  bool checksum,
-								  char relkind,
-								  bool co)
-{
-	if (relkind != RELKIND_RELATION)
-	{
-		if(ao)
-			ereport(ERROR,
-					(errcode(ERRCODE_GP_FEATURE_NOT_SUPPORTED),
-					 errmsg("appendonly may only be specified for base relations")));
-
-		if(checksum)
-			ereport(ERROR,
-					(errcode(ERRCODE_GP_FEATURE_NOT_SUPPORTED),
-					 errmsg("checksum may only be specified for base relations")));
-
-		if(comptype)
-			ereport(ERROR,
-					(errcode(ERRCODE_GP_FEATURE_NOT_SUPPORTED),
-					 errmsg("compresstype may only be specified for base relations")));
-	}
-
-	/*
-	 * If this is not an appendonly relation, no point in going
-	 * further.
-	 */
-	if (!ao)
-		return;
-
-	if (comptype &&
-		(pg_strcasecmp(comptype, "quicklz") == 0 ||
-		 pg_strcasecmp(comptype, "zlib") == 0 ||
-		 pg_strcasecmp(comptype, "rle_type") == 0))
-	{
-
-		if (! co &&
-			pg_strcasecmp(comptype, "rle_type") == 0)
-		{
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("%s cannot be used with Append Only relations row orientation",
-							comptype)));
-		}
-
-		if (comptype && complevel == 0)
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("compresstype cannot be used with compresslevel 0")));
-
-		if (complevel < 0 || complevel > 9)
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("compresslevel=%d is out of range (should be between 0 and 9)",
-							complevel)));
-
-		if (comptype && (pg_strcasecmp(comptype, "quicklz") == 0) &&
-			(complevel != 1))
-		{
-				ereport(ERROR,
-						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-						 errmsg("compresslevel=%d is out of range for quicklz "
-								 "(should be 1)", complevel)));
-		}
-		if (comptype && (pg_strcasecmp(comptype, "rle_type") == 0) &&
-			(complevel > 4))
-		{
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("compresslevel=%d is out of range for rle_type "
-							"(should be in the range 1 to 4)", complevel)));
-		}
-	}
-
-	if (blocksize < MIN_APPENDONLY_BLOCK_SIZE || blocksize > MAX_APPENDONLY_BLOCK_SIZE ||
-	    blocksize % MIN_APPENDONLY_BLOCK_SIZE != 0)
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("block size must be between 8KB and 2MB and "
-						"be an 8KB multiple, Got %d", blocksize)));
-
-	if (safewrite > MAX_APPENDONLY_BLOCK_SIZE || safewrite % 8 != 0)
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("safefswrite size must be less than 8MB and "
-						"be a multiple of 8")));
-
-	if (gp_safefswritesize > blocksize)
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("block size (%d) is smaller gp_safefswritesize (%d). "
-						"increase blocksize or decrease gp_safefswritesize if it "
-						"is safe to do so on this file system",
-						blocksize, gp_safefswritesize)));
-}
-
-/*
- * if no compressor type was specified, we set to no compression (level 0)
- * otherwise default for both zlib, quicklz and RLE to level 1.
- */
-static int setDefaultCompressionLevel(char* compresstype)
-{
-	if(!compresstype || pg_strcasecmp(compresstype, "none") == 0)
-		return 0;
-	else
-		return 1;
 }

--- a/src/backend/access/common/reloptions_gp.c
+++ b/src/backend/access/common/reloptions_gp.c
@@ -1,0 +1,1294 @@
+/*-------------------------------------------------------------------------
+ *
+ * reloptions_gp.c
+ *	  GPDB-specific relation options.
+ *
+ * These are in a separate file from reloptions.c, in order to reduce
+ * conflicts when merging with upstream code.
+ *
+ *
+ * Portions Copyright (c) 2017-Present Pivotal Software, Inc.
+ * Portions Copyright (c) 1996-2009, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ *
+ * IDENTIFICATION
+ *	  src/backend/access/common/reloptions_gp.c
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "access/bitmap.h"
+#include "access/reloptions.h"
+#include "cdb/cdbappendonlyam.h"
+#include "cdb/cdbvars.h"
+#include "utils/array.h"
+#include "utils/builtins.h"
+#include "utils/formatting.h"
+#include "utils/guc.h"
+#include "utils/memutils.h"
+#include "miscadmin.h"
+
+/*
+ * Confusingly, RELOPT_KIND_HEAP is also used for AO/CO tables. To reduce
+ * the confusion in this file, use this macro to check for "heap or AO/CO
+ * table".
+ */
+#define KIND_IS_RELATION(kind) ((kind) == RELOPT_KIND_HEAP)
+
+/*
+ * GPDB reloptions specification.
+ */
+
+static relopt_bool boolRelOpts_gp[] =
+{
+	{
+		{
+			SOPT_APPENDONLY,
+			"Append only storage parameter",
+			RELOPT_KIND_HEAP
+		},
+		AO_DEFAULT_APPENDONLY,
+	},
+	{
+		{
+			SOPT_CHECKSUM,
+			"Append table checksum",
+			RELOPT_KIND_HEAP
+		},
+		AO_DEFAULT_CHECKSUM
+	},
+	/* list terminator */
+	{{NULL}}
+};
+
+static relopt_int intRelOpts_gp[] =
+{
+	{
+		{
+			SOPT_FILLFACTOR,
+			"Packs bitmap index pages only to this percentage",
+			RELOPT_KIND_BITMAP
+		},
+		BITMAP_DEFAULT_FILLFACTOR, BITMAP_MIN_FILLFACTOR, 100
+	},
+	{
+		{
+			SOPT_BLOCKSIZE,
+			"AO tables block size in bytes",
+			RELOPT_KIND_HEAP
+		},
+		AO_DEFAULT_BLOCKSIZE, MIN_APPENDONLY_BLOCK_SIZE, MAX_APPENDONLY_BLOCK_SIZE
+	},
+	{
+		{
+			SOPT_COMPLEVEL,
+			"AO table compression level",
+			RELOPT_KIND_HEAP
+		},
+		AO_DEFAULT_COMPRESSLEVEL, AO_MIN_COMPRESSLEVEL, AO_MAX_COMPRESSLEVEL
+	},
+	{
+		{
+			SOPT_FILLFACTOR,
+			"Packs bitmap index pages only to this percentage",
+			RELOPT_KIND_INTERNAL
+		},
+		HEAP_DEFAULT_FILLFACTOR, HEAP_MIN_FILLFACTOR, 100
+	},
+	/* list terminator */
+	{{NULL}}
+};
+
+static relopt_real realRelOpts_gp[] =
+{
+	/* list terminator */
+	{{NULL}}
+};
+
+static relopt_string stringRelOpts_gp[] =
+{
+	{
+		{
+			SOPT_COMPTYPE,
+			"AO tables compression type",
+			RELOPT_KIND_HEAP
+		},
+		0, true, ""
+	},
+	{
+		{
+			SOPT_ORIENTATION,
+				"AO tables orientation",
+				RELOPT_KIND_HEAP
+		},
+			0, false, ""
+	},
+	/* list terminator */
+	{{NULL}}
+};
+
+static void free_options_deep(relopt_value *options, int num_options);
+static relopt_value *get_option_set(relopt_value *options, int num_options, const char *opt_name);
+
+/*
+ * initialize_reloptions_gp
+ * 		initialization routine for GPDB reloptions
+ *
+ * We use the add_*_option interface in reloptions.h to add GPDB-specific options.
+ */
+void
+initialize_reloptions_gp(void)
+{
+	int			i;
+
+	/* Set GPDB specific options */
+	for (i = 0; boolRelOpts_gp[i].gen.name; i++)
+	{
+		add_bool_reloption(boolRelOpts_gp[i].gen.kind,
+						   (char *) boolRelOpts_gp[i].gen.name,
+						   (char *) boolRelOpts_gp[i].gen.desc,
+						   boolRelOpts_gp[i].default_val);
+	}
+
+	for (i = 0; intRelOpts_gp[i].gen.name; i++)
+	{
+		add_int_reloption(intRelOpts_gp[i].gen.kind,
+						  (char *) intRelOpts_gp[i].gen.name,
+						  (char *) intRelOpts_gp[i].gen.desc,
+						  intRelOpts_gp[i].default_val,
+						  intRelOpts_gp[i].min,
+						  intRelOpts_gp[i].max);
+	}
+
+	for (i = 0; realRelOpts_gp[i].gen.name; i++)
+	{
+		add_real_reloption(realRelOpts_gp[i].gen.kind,
+						   (char *) realRelOpts_gp[i].gen.name,
+						   (char *) realRelOpts_gp[i].gen.desc,
+						   realRelOpts_gp[i].default_val,
+						   realRelOpts_gp[i].min, realRelOpts_gp[i].max);
+	}
+
+	for (i = 0; stringRelOpts_gp[i].gen.name; i++)
+	{
+		add_string_reloption(stringRelOpts_gp[i].gen.kind,
+							 (char *) stringRelOpts_gp[i].gen.name,
+							 (char *) stringRelOpts_gp[i].gen.desc,
+							 NULL);
+	}
+}
+
+/*
+ * This is set whenever the GUC gp_default_storage_options is set.
+ */
+static StdRdOptions ao_storage_opts;
+static bool ao_storage_opts_changed = false;
+
+bool
+isDefaultAOCS(void)
+{
+	return ao_storage_opts.columnstore;
+}
+
+bool
+isDefaultAO(void)
+{
+	return ao_storage_opts.appendonly;
+}
+
+/*
+ * Accumulate a new datum for one AO storage option.
+ */
+static void
+accumAOStorageOpt(char *name, char *value,
+				  ArrayBuildState *astate, bool *foundAO, bool *aovalue)
+{
+	text	   *t;
+	bool		boolval;
+	int			intval;
+	StringInfoData buf;
+
+	Assert(astate);
+
+	initStringInfo(&buf);
+
+	if (pg_strcasecmp(SOPT_APPENDONLY, name) == 0)
+	{
+		if (!parse_bool(value, &boolval))
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("invalid bool value \"%s\" for storage option \"%s\"",
+							value, name)));
+		/* "appendonly" option is explicitly specified. */
+		if (foundAO != NULL)
+			*foundAO = true;
+		if (aovalue != NULL)
+			*aovalue = boolval;
+
+		/*
+		 * Record value of "appendonly" option as true always.  Return the
+		 * value specified by user in aovalue.  Setting appendonly=true always
+		 * in the array of datums enables us to reuse default_reloptions() and
+		 * validateAppendOnlyRelOptions().  If validations are successful, we
+		 * keep the user specified value for appendonly.
+		 */
+		appendStringInfo(&buf, "%s=%s", SOPT_APPENDONLY, "true");
+	}
+	else if (pg_strcasecmp(SOPT_BLOCKSIZE, name) == 0)
+	{
+		if (!parse_int(value, &intval, 0 /* unit flags */ ,
+					   NULL /* hint message */ ))
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("invalid integer value \"%s\" for storage option \"%s\"",
+							value, name)));
+		appendStringInfo(&buf, "%s=%d", SOPT_BLOCKSIZE, intval);
+	}
+	else if (pg_strcasecmp(SOPT_COMPTYPE, name) == 0)
+	{
+		appendStringInfo(&buf, "%s=%s", SOPT_COMPTYPE, value);
+	}
+	else if (pg_strcasecmp(SOPT_COMPLEVEL, name) == 0)
+	{
+		if (!parse_int(value, &intval, 0 /* unit flags */ ,
+					   NULL /* hint message */ ))
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("invalid integer value \"%s\" for storage option \"%s\"",
+							value, name)));
+		appendStringInfo(&buf, "%s=%d", SOPT_COMPLEVEL, intval);
+	}
+	else if (pg_strcasecmp(SOPT_CHECKSUM, name) == 0)
+	{
+		if (!parse_bool(value, &boolval))
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("invalid bool value \"%s\" for storage option \"%s\"",
+							value, name)));
+		appendStringInfo(&buf, "%s=%s", SOPT_CHECKSUM, boolval ? "true" : "false");
+	}
+	else if (pg_strcasecmp(SOPT_ORIENTATION, name) == 0)
+	{
+		if ((pg_strcasecmp(value, "row") != 0) &&
+			(pg_strcasecmp(value, "column") != 0))
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("invalid value \"%s\" for storage option \"%s\"",
+							value, name)));
+		}
+		appendStringInfo(&buf, "%s=%s", SOPT_ORIENTATION, value);
+	}
+	else
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("invalid storage option \"%s\"", name)));
+	}
+
+	t = cstring_to_text(buf.data);
+
+	accumArrayResult(astate, PointerGetDatum(t), /* disnull */ false,
+					 TEXTOID, CurrentMemoryContext);
+	pfree(t);
+	pfree(buf.data);
+}
+
+/*
+ * Reset appendonly storage options to factory defaults.  Callers must
+ * free ao_opts->compresstype before calling this method.
+ */
+inline void
+resetAOStorageOpts(StdRdOptions *ao_opts)
+{
+	ao_opts->appendonly = AO_DEFAULT_APPENDONLY;
+	ao_opts->blocksize = AO_DEFAULT_BLOCKSIZE;
+	ao_opts->checksum = AO_DEFAULT_CHECKSUM;
+	ao_opts->columnstore = AO_DEFAULT_COLUMNSTORE;
+	ao_opts->compresslevel = AO_DEFAULT_COMPRESSLEVEL;
+	ao_opts->compresstype = NULL;
+	ao_opts->orientation = NULL;
+}
+
+/*
+ * This needs to happen whenever gp_default_storage_options GUC is
+ * reset.
+ */
+void
+resetDefaultAOStorageOpts(void)
+{
+	if (ao_storage_opts.compresstype)
+		free(ao_storage_opts.compresstype);
+
+	if (ao_storage_opts.orientation)
+		free(ao_storage_opts.orientation);
+
+	resetAOStorageOpts(&ao_storage_opts);
+	ao_storage_opts_changed = false;
+}
+
+const StdRdOptions *
+currentAOStorageOptions(void)
+{
+	return (const StdRdOptions *) &ao_storage_opts;
+}
+
+/*
+ * Set global appendonly storage options.
+ */
+void
+setDefaultAOStorageOpts(StdRdOptions *copy)
+{
+	if (ao_storage_opts.compresstype)
+	{
+		free(ao_storage_opts.compresstype);
+		ao_storage_opts.compresstype = NULL;
+	}
+
+	if (ao_storage_opts.orientation)
+	{
+		free(ao_storage_opts.orientation);
+		ao_storage_opts.orientation = NULL;
+	}
+
+	memcpy(&ao_storage_opts, copy, sizeof(ao_storage_opts));
+	if (copy->compresstype != NULL)
+	{
+		if (pg_strcasecmp(copy->compresstype, "none") == 0)
+		{
+			/* Represent compresstype=none as NULL (MPP-25073). */
+			ao_storage_opts.compresstype = NULL;
+		}
+		else
+		{
+			ao_storage_opts.compresstype = strdup(copy->compresstype);
+			if (ao_storage_opts.compresstype == NULL)
+				elog(ERROR, "out of memory");
+		}
+	}
+
+	if (copy->orientation != NULL)
+	{
+		ao_storage_opts.orientation = strdup(copy->orientation);
+		if (ao_storage_opts.orientation == NULL)
+			elog(ERROR, "out of memory");
+	}
+
+	ao_storage_opts_changed = true;
+}
+
+static int	setDefaultCompressionLevel(char *compresstype);
+
+/*
+ * Accept a string of the form "name=value,name=value,...".  Space
+ * around ',' and '=' is allowed.  Parsed values are stored in
+ * corresponding fields of StdRdOptions object.  The parser is a
+ * finite state machine that changes states for each input character
+ * scanned.
+ */
+Datum
+parseAOStorageOpts(const char *opts_str, bool *aovalue)
+{
+	int			dims[1];
+	int			lbs[1];
+	Datum		result;
+	ArrayBuildState *astate;
+
+	bool		foundAO = false;
+	const char *cp;
+	const char *name_st = NULL;
+	const char *value_st = NULL;
+	char	   *name = NULL,
+			   *value = NULL;
+	enum state
+	{
+		/*
+		 * Consume whitespace at the beginning of a name token.
+		 */
+		LEADING_NAME,
+
+		/*
+		 * Name token is being scanned.  Allowed characters are alphabets,
+		 * whitespace and '='.
+		 */
+		NAME_TOKEN,
+
+		/*
+		 * Name token was terminated by whitespace.  This state scans the
+		 * trailing whitespace after name token.
+		 */
+		TRAILING_NAME,
+
+		/*
+		 * Whitespace after '=' and before value token.
+		 */
+		LEADING_VALUE,
+
+		/*
+		 * Value token is being scanned.  Allowed characters are alphabets,
+		 * digits, '_'.  Value should be delimited by a ',', whitespace or end
+		 * of string '\0'.
+		 */
+		VALUE_TOKEN,
+
+		/*
+		 * Whitespace after value token.
+		 */
+		TRAILING_VALUE,
+
+		/*
+		 * End of string.  This state can only be entered from VALUE_TOKEN or
+		 * TRAILING_VALUE.
+		 */
+		EOS
+	};
+	enum state	st = LEADING_NAME;
+
+	/*
+	 * Initialize ArrayBuildState ourselves rather than leaving it to
+	 * accumArrayResult().  This aviods the catalog lookup (pg_type) performed
+	 * by accumArrayResult().
+	 */
+	astate = (ArrayBuildState *) palloc(sizeof(ArrayBuildState));
+	astate->mcontext = CurrentMemoryContext;
+	astate->alen = 10;			/* Initial number of name=value pairs. */
+	astate->dvalues = (Datum *) palloc(astate->alen * sizeof(Datum));
+	astate->dnulls = (bool *) palloc(astate->alen * sizeof(bool));
+	astate->nelems = 0;
+	astate->element_type = TEXTOID;
+	astate->typlen = -1;
+	astate->typbyval = false;
+	astate->typalign = 'i';
+
+	cp = opts_str - 1;
+	do
+	{
+		++cp;
+		switch (st)
+		{
+			case LEADING_NAME:
+				if (isalpha(*cp))
+				{
+					st = NAME_TOKEN;
+					name_st = cp;
+				}
+				else if (!isspace(*cp))
+				{
+					ereport(ERROR,
+							(errcode(ERRCODE_SYNTAX_ERROR),
+							 errmsg("invalid storage option name in \"%s\"",
+									opts_str)));
+				}
+				break;
+			case NAME_TOKEN:
+				if (isspace(*cp))
+					st = TRAILING_NAME;
+				else if (*cp == '=')
+					st = LEADING_VALUE;
+				else if (!isalpha(*cp))
+					ereport(ERROR,
+							(errcode(ERRCODE_SYNTAX_ERROR),
+							 errmsg("invalid storage option name in \"%s\"",
+									opts_str)));
+				if (st != NAME_TOKEN)
+				{
+					name = palloc(cp - name_st + 1);
+					strncpy(name, name_st, cp - name_st);
+					name[cp - name_st] = '\0';
+					for (name_st = name; *name_st != '\0'; ++name_st)
+						*(char *) name_st = pg_tolower(*name_st);
+				}
+				break;
+			case TRAILING_NAME:
+				if (*cp == '=')
+					st = LEADING_VALUE;
+				else if (!isspace(*cp))
+					ereport(ERROR,
+							(errcode(ERRCODE_SYNTAX_ERROR),
+							 errmsg("invalid value for option \"%s\", expected \"=\"", name)));
+				break;
+			case LEADING_VALUE:
+				if (isalnum(*cp))
+				{
+					st = VALUE_TOKEN;
+					value_st = cp;
+				}
+				else if (!isspace(*cp))
+					ereport(ERROR,
+							(errcode(ERRCODE_SYNTAX_ERROR),
+							 errmsg("invalid value for option \"%s\"", name)));
+				break;
+			case VALUE_TOKEN:
+				if (isspace(*cp))
+					st = TRAILING_VALUE;
+				else if (*cp == '\0')
+					st = EOS;
+				else if (*cp == ',')
+					st = LEADING_NAME;
+				/* Need to check '_' for rle_type */
+				else if (!(isalnum(*cp) || *cp == '_'))
+					ereport(ERROR,
+							(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+							 errmsg("invalid value for option \"%s\"", name)));
+				if (st != VALUE_TOKEN)
+				{
+					value = palloc(cp - value_st + 1);
+					strncpy(value, value_st, cp - value_st);
+					value[cp - value_st] = '\0';
+					for (value_st = value; *value_st != '\0'; ++value_st)
+						*(char *) value_st = pg_tolower(*value_st);
+					Assert(name);
+					accumAOStorageOpt(name, value, astate,
+									  &foundAO, aovalue);
+					pfree(name);
+					name = NULL;
+					pfree(value);
+					value = NULL;
+				}
+				break;
+			case TRAILING_VALUE:
+				if (*cp == ',')
+					st = LEADING_NAME;
+				else if (*cp == '\0')
+					st = EOS;
+				else if (!isspace(*cp))
+					ereport(ERROR,
+							(errcode(ERRCODE_SYNTAX_ERROR),
+							 errmsg("syntax error after \"%s\"", value)));
+				break;
+			case EOS:
+
+				/*
+				 * We better get out of the loop right after entering this
+				 * state.  Therefore, we should never get here.
+				 */
+				elog(ERROR, "invalid value \"%s\" for GUC", opts_str);
+				break;
+		};
+	} while (*cp != '\0');
+	if (st != EOS)
+		elog(ERROR, "invalid value \"%s\" for GUC", opts_str);
+	if (!foundAO)
+	{
+		/*
+		 * Add "appendonly=true" datum if it was not explicitly specified by
+		 * user.  This is needed to validate the array of datums constructed
+		 * from user specified options.
+		 */
+		accumAOStorageOpt(SOPT_APPENDONLY, "true", astate, NULL, NULL);
+	}
+
+	lbs[0] = 1;
+	dims[0] = astate->nelems;
+	result = makeMdArrayResult(astate, 1, dims, lbs, CurrentMemoryContext, false);
+	pfree(astate->dvalues);
+	pfree(astate->dnulls);
+	pfree(astate);
+	return result;
+}
+
+/*
+ * Return a datum that is array of "name=value" strings for each
+ * appendonly storage option in opts.  This datum is used to populate
+ * pg_class.reloptions during relation creation.
+ *
+ * To avoid catalog bloat, we only create "name=value" item for those
+ * values in opts that are not specified in WITH clause and are
+ * different from their initial defaults.
+ */
+Datum
+transformAOStdRdOptions(StdRdOptions *opts, Datum withOpts)
+{
+	char	   *strval;
+	char		intval[MAX_SOPT_VALUE_LEN];
+	Datum	   *withDatums = NULL;
+	text	   *t;
+	int			len,
+				i,
+				withLen,
+				soptLen,
+				nWithOpts = 0;
+	ArrayType  *withArr;
+	ArrayBuildState *astate = NULL;
+	bool		foundAO = false,
+				foundBlksz = false,
+				foundComptype = false,
+				foundComplevel = false,
+				foundChecksum = false,
+				foundOrientation = false;
+
+	/*
+	 * withOpts must be parsed to see if an option was spcified in WITH()
+	 * clause.
+	 */
+	if (DatumGetPointer(withOpts) != NULL)
+	{
+		withArr = DatumGetArrayTypeP(withOpts);
+		Assert(ARR_ELEMTYPE(withArr) == TEXTOID);
+		deconstruct_array(withArr, TEXTOID, -1, false, 'i', &withDatums,
+						  NULL, &nWithOpts);
+
+		/*
+		 * Include options specified in WITH() clause in the same order as
+		 * they are specified.  Otherwise we will end up with regression
+		 * failures due to diff with respect to answer file.
+		 */
+		for (i = 0; i < nWithOpts; ++i)
+		{
+			t = DatumGetTextP(withDatums[i]);
+			strval = VARDATA(t);
+
+			/*
+			 * Text datums are usually not null terminated.  We must never
+			 * access beyond their length.
+			 */
+			withLen = VARSIZE(t) - VARHDRSZ;
+
+			/*
+			 * withDatums[i] may not be used directly.  It may be e.g.
+			 * "aPPendOnly=tRue".  Therefore we don't set it as reloptions as
+			 * is.
+			 */
+			soptLen = strlen(SOPT_APPENDONLY);
+			if (withLen > soptLen &&
+				pg_strncasecmp(strval, SOPT_APPENDONLY, soptLen) == 0)
+			{
+				foundAO = true;
+				strval = opts->appendonly ? "true" : "false";
+				len = VARHDRSZ + strlen(SOPT_APPENDONLY) + 1 + strlen(strval);
+				/* +1 leaves room for sprintf's trailing null */
+				t = (text *) palloc(len + 1);
+				SET_VARSIZE(t, len);
+				sprintf(VARDATA(t), "%s=%s", SOPT_APPENDONLY, strval);
+				astate = accumArrayResult(astate, PointerGetDatum(t), false,
+										  TEXTOID, CurrentMemoryContext);
+			}
+			soptLen = strlen(SOPT_BLOCKSIZE);
+			if (withLen > soptLen &&
+				pg_strncasecmp(strval, SOPT_BLOCKSIZE, soptLen) == 0)
+			{
+				foundBlksz = true;
+				snprintf(intval, MAX_SOPT_VALUE_LEN, "%d", opts->blocksize);
+				len = VARHDRSZ + strlen(SOPT_BLOCKSIZE) + 1 + strlen(intval);
+				/* +1 leaves room for sprintf's trailing null */
+				t = (text *) palloc(len + 1);
+				SET_VARSIZE(t, len);
+				sprintf(VARDATA(t), "%s=%s", SOPT_BLOCKSIZE, intval);
+				astate = accumArrayResult(astate, PointerGetDatum(t), false,
+										  TEXTOID, CurrentMemoryContext);
+			}
+			soptLen = strlen(SOPT_COMPTYPE);
+			if (withLen > soptLen &&
+				pg_strncasecmp(strval, SOPT_COMPTYPE, soptLen) == 0)
+			{
+				foundComptype = true;
+
+				/*
+				 * Record "none" as compresstype in reloptions if it was
+				 * explicitly specified in WITH clause.
+				 */
+				strval = (opts->compresstype != NULL) ?
+					opts->compresstype : "none";
+				len = VARHDRSZ + strlen(SOPT_COMPTYPE) + 1 + strlen(strval);
+				/* +1 leaves room for sprintf's trailing null */
+				t = (text *) palloc(len + 1);
+				SET_VARSIZE(t, len);
+				sprintf(VARDATA(t), "%s=%s", SOPT_COMPTYPE, strval);
+				astate = accumArrayResult(astate, PointerGetDatum(t), false,
+										  TEXTOID, CurrentMemoryContext);
+			}
+			soptLen = strlen(SOPT_COMPLEVEL);
+			if (withLen > soptLen &&
+				pg_strncasecmp(strval, SOPT_COMPLEVEL, soptLen) == 0)
+			{
+				foundComplevel = true;
+				snprintf(intval, MAX_SOPT_VALUE_LEN, "%d", opts->compresslevel);
+				len = VARHDRSZ + strlen(SOPT_COMPLEVEL) + 1 + strlen(intval);
+				/* +1 leaves room for sprintf's trailing null */
+				t = (text *) palloc(len + 1);
+				SET_VARSIZE(t, len);
+				sprintf(VARDATA(t), "%s=%s", SOPT_COMPLEVEL, intval);
+				astate = accumArrayResult(astate, PointerGetDatum(t), false,
+										  TEXTOID, CurrentMemoryContext);
+			}
+			soptLen = strlen(SOPT_CHECKSUM);
+			if (withLen > soptLen &&
+				pg_strncasecmp(strval, SOPT_CHECKSUM, soptLen) == 0)
+			{
+				foundChecksum = true;
+				strval = opts->checksum ? "true" : "false";
+				len = VARHDRSZ + strlen(SOPT_CHECKSUM) + 1 + strlen(strval);
+				/* +1 leaves room for sprintf's trailing null */
+				t = (text *) palloc(len + 1);
+				SET_VARSIZE(t, len);
+				sprintf(VARDATA(t), "%s=%s", SOPT_CHECKSUM, strval);
+				astate = accumArrayResult(astate, PointerGetDatum(t), false,
+										  TEXTOID, CurrentMemoryContext);
+			}
+			soptLen = strlen(SOPT_ORIENTATION);
+			if (withLen > soptLen &&
+				pg_strncasecmp(strval, SOPT_ORIENTATION, soptLen) == 0)
+			{
+				foundOrientation = true;
+				strval = opts->columnstore ? "column" : "row";
+				len = VARHDRSZ + strlen(SOPT_ORIENTATION) + 1 + strlen(strval);
+				/* +1 leaves room for sprintf's trailing null */
+				t = (text *) palloc(len + 1);
+				SET_VARSIZE(t, len);
+				sprintf(VARDATA(t), "%s=%s", SOPT_ORIENTATION, strval);
+				astate = accumArrayResult(astate, PointerGetDatum(t), false,
+										  TEXTOID, CurrentMemoryContext);
+			}
+
+			/*
+			 * Record fillfactor only if it's specified in WITH clause.
+			 * Default fillfactor is assumed otherwise.
+			 */
+			soptLen = strlen(SOPT_FILLFACTOR);
+			if (withLen > soptLen &&
+				pg_strncasecmp(strval, SOPT_FILLFACTOR, soptLen) == 0)
+			{
+				snprintf(intval, MAX_SOPT_VALUE_LEN, "%d", opts->fillfactor);
+				len = VARHDRSZ + strlen(SOPT_FILLFACTOR) + 1 + strlen(intval);
+				/* +1 leaves room for sprintf's trailing null */
+				t = (text *) palloc(len + 1);
+				SET_VARSIZE(t, len);
+				sprintf(VARDATA(t), "%s=%s", SOPT_FILLFACTOR, intval);
+				astate = accumArrayResult(astate, PointerGetDatum(t), false,
+										  TEXTOID, CurrentMemoryContext);
+			}
+		}
+	}
+	/* Include options that are not defaults and not already included. */
+	if ((opts->appendonly != AO_DEFAULT_APPENDONLY) && !foundAO)
+	{
+		/* appendonly */
+		strval = opts->appendonly ? "true" : "false";
+		len = VARHDRSZ + strlen(SOPT_APPENDONLY) + 1 + strlen(strval);
+		/* +1 leaves room for sprintf's trailing null */
+		t = (text *) palloc(len + 1);
+		SET_VARSIZE(t, len);
+		sprintf(VARDATA(t), "%s=%s", SOPT_APPENDONLY, strval);
+		astate = accumArrayResult(astate, PointerGetDatum(t),
+								  false, TEXTOID,
+								  CurrentMemoryContext);
+	}
+	if ((opts->blocksize != AO_DEFAULT_BLOCKSIZE) && !foundBlksz)
+	{
+		/* blocksize */
+		snprintf(intval, MAX_SOPT_VALUE_LEN, "%d", opts->blocksize);
+		len = VARHDRSZ + strlen(SOPT_BLOCKSIZE) + 1 + strlen(intval);
+		/* +1 leaves room for sprintf's trailing null */
+		t = (text *) palloc(len + 1);
+		SET_VARSIZE(t, len);
+		sprintf(VARDATA(t), "%s=%s", SOPT_BLOCKSIZE, intval);
+		astate = accumArrayResult(astate, PointerGetDatum(t),
+								  false, TEXTOID,
+								  CurrentMemoryContext);
+	}
+
+	/*
+	 * Record compression options only if compression is enabled.  No need to
+	 * check compresstype here as by the time we get here, "opts" should have
+	 * been set by default_reloptions() correctly.
+	 */
+	if (opts->compresslevel > AO_DEFAULT_COMPRESSLEVEL &&
+		opts->compresstype != NULL)
+	{
+		if (!foundComptype && (
+							   (pg_strcasecmp(opts->compresstype, AO_DEFAULT_COMPRESSTYPE) == 0
+								&& opts->compresslevel == 1 && !foundComplevel) ||
+							   pg_strcasecmp(opts->compresstype,
+											 AO_DEFAULT_COMPRESSTYPE) != 0))
+		{
+			/* compress type */
+			strval = opts->compresstype;
+			len = VARHDRSZ + strlen(SOPT_COMPTYPE) + 1 + strlen(strval);
+			/* +1 leaves room for sprintf's trailing null */
+			t = (text *) palloc(len + 1);
+			SET_VARSIZE(t, len);
+			sprintf(VARDATA(t), "%s=%s", SOPT_COMPTYPE, strval);
+			astate = accumArrayResult(astate, PointerGetDatum(t),
+									  false, TEXTOID,
+									  CurrentMemoryContext);
+		}
+		/* When compression is enabled, default compresslevel is 1. */
+		if ((opts->compresslevel != 1) &&
+			!foundComplevel)
+		{
+			/* compress level */
+			snprintf(intval, MAX_SOPT_VALUE_LEN, "%d", opts->compresslevel);
+			len = VARHDRSZ + strlen(SOPT_COMPLEVEL) + 1 + strlen(intval);
+			/* +1 leaves room for sprintf's trailing null */
+			t = (text *) palloc(len + 1);
+			SET_VARSIZE(t, len);
+			sprintf(VARDATA(t), "%s=%s", SOPT_COMPLEVEL, intval);
+			astate = accumArrayResult(astate, PointerGetDatum(t),
+									  false, TEXTOID,
+									  CurrentMemoryContext);
+		}
+	}
+	if ((opts->checksum != AO_DEFAULT_CHECKSUM) && !foundChecksum)
+	{
+		/* checksum */
+		strval = opts->checksum ? "true" : "false";
+		len = VARHDRSZ + strlen(SOPT_CHECKSUM) + 1 + strlen(strval);
+		/* +1 leaves room for sprintf's trailing null */
+		t = (text *) palloc(len + 1);
+		SET_VARSIZE(t, len);
+		sprintf(VARDATA(t), "%s=%s", SOPT_CHECKSUM, strval);
+		astate = accumArrayResult(astate, PointerGetDatum(t),
+								  false, TEXTOID,
+								  CurrentMemoryContext);
+	}
+	if ((opts->columnstore != AO_DEFAULT_COLUMNSTORE) && !foundOrientation)
+	{
+		/* orientation */
+		strval = opts->columnstore ? "column" : "row";
+		len = VARHDRSZ + strlen(SOPT_ORIENTATION) + 1 + strlen(strval);
+		/* +1 leaves room for sprintf's trailing null */
+		t = (text *) palloc(len + 1);
+		SET_VARSIZE(t, len);
+		sprintf(VARDATA(t), "%s=%s", SOPT_ORIENTATION, strval);
+		astate = accumArrayResult(astate, PointerGetDatum(t),
+								  false, TEXTOID,
+								  CurrentMemoryContext);
+	}
+	return astate ?
+		makeArrayResult(astate, CurrentMemoryContext) :
+		PointerGetDatum(NULL);
+}
+
+void
+validate_and_adjust_options(StdRdOptions *result,
+							relopt_value *options,
+							int num_options, relopt_kind kind, bool validate)
+{
+	int			i;
+	relopt_value *fillfactor_opt;
+	relopt_value *appendonly_opt;
+	relopt_value *blocksize_opt;
+	relopt_value *comptype_opt;
+	relopt_value *complevel_opt;
+	relopt_value *checksum_opt;
+	relopt_value *orientation_opt;
+
+	/* fillfactor */
+	fillfactor_opt = get_option_set(options, num_options, SOPT_FILLFACTOR);
+	if (fillfactor_opt != NULL)
+	{
+		result->fillfactor = fillfactor_opt->values.int_val;
+	}
+	/* appendonly */
+	appendonly_opt = get_option_set(options, num_options, SOPT_APPENDONLY);
+	if (appendonly_opt != NULL)
+	{
+		if (!KIND_IS_RELATION(kind))
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("usage of parameter \"appendonly\" in a non relation object is not supported")));
+		result->appendonly = appendonly_opt->values.bool_val;
+	}
+
+	/* blocksize */
+	blocksize_opt = get_option_set(options, num_options, SOPT_BLOCKSIZE);
+	if (blocksize_opt != NULL)
+	{
+		if (!KIND_IS_RELATION(kind) && validate)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("usage of parameter \"blocksize\" in a non relation object is not supported")));
+
+		if (!result->appendonly && validate)
+			ereport(ERROR,
+					(errcode(ERRCODE_GP_FEATURE_NOT_SUPPORTED),
+					 errmsg("invalid option 'blocksize' for base relation. "
+							"Only valid for Append Only relations")));
+
+		result->blocksize = blocksize_opt->values.int_val;
+
+		if (result->blocksize < MIN_APPENDONLY_BLOCK_SIZE ||
+			result->blocksize > MAX_APPENDONLY_BLOCK_SIZE ||
+			result->blocksize % MIN_APPENDONLY_BLOCK_SIZE != 0)
+		{
+			if (validate)
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+						 errmsg("block size must be between 8KB and 2MB and be"
+								" an 8KB multiple. Got %d", result->blocksize)));
+
+			result->blocksize = DEFAULT_APPENDONLY_BLOCK_SIZE;
+		}
+
+	}
+
+	/* compression type */
+	comptype_opt = get_option_set(options, num_options, SOPT_COMPTYPE);
+	if (comptype_opt != NULL)
+	{
+		if (!KIND_IS_RELATION(kind) && validate)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("usage of parameter \"compresstype\" in a non relation object is not supported")));
+
+		if (!result->appendonly && validate)
+			ereport(ERROR,
+					(errcode(ERRCODE_GP_FEATURE_NOT_SUPPORTED),
+					 errmsg("invalid option \"compresstype\" for base relation."
+							" Only valid for Append Only relations")));
+
+		result->compresstype = pstrdup(comptype_opt->values.string_val);
+		if (!compresstype_is_valid(result->compresstype))
+			ereport(ERROR,
+					(errcode(ERRCODE_UNDEFINED_OBJECT),
+					 errmsg("unknown compresstype \"%s\"",
+							result->compresstype)));
+		for (i = 0; i < strlen(result->compresstype); i++)
+			result->compresstype[i] = pg_tolower(result->compresstype[i]);
+	}
+
+	/* compression level */
+	complevel_opt = get_option_set(options, num_options, SOPT_COMPLEVEL);
+	if (complevel_opt != NULL)
+	{
+		if (!KIND_IS_RELATION(kind) && validate)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("usage of parameter \"compresslevel\" in a non relation object is not supported")));
+
+		if (!result->appendonly && validate)
+			ereport(ERROR,
+					(errcode(ERRCODE_GP_FEATURE_NOT_SUPPORTED),
+					 errmsg("invalid option 'compresslevel' for base "
+							"relation. Only valid for Append Only relations")));
+
+		result->compresslevel = complevel_opt->values.int_val;
+
+		if (result->compresstype &&
+			pg_strcasecmp(result->compresstype, "none") != 0 &&
+			result->compresslevel == 0 && validate)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("compresstype can\'t be used with compresslevel 0")));
+		if (result->compresslevel < 0 || result->compresslevel > 9)
+		{
+			if (validate)
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+						 errmsg("compresslevel=%d is out of range (should be "
+								"between 0 and 9)",
+								result->compresslevel)));
+
+			result->compresslevel = setDefaultCompressionLevel(
+															   result->compresstype);
+		}
+
+		/*
+		 * use the default compressor if compresslevel was indicated but not
+		 * compresstype. must make a copy otherwise str_tolower below will
+		 * crash.
+		 */
+		if (result->compresslevel > 0 && !result->compresstype)
+			result->compresstype = pstrdup(AO_DEFAULT_COMPRESSTYPE);
+
+		if (result->compresstype &&
+			(pg_strcasecmp(result->compresstype, "quicklz") == 0) &&
+			(result->compresslevel != 1))
+		{
+			if (validate)
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+						 errmsg("compresslevel=%d is out of range for "
+								"quicklz (should be 1)",
+								result->compresslevel)));
+
+			result->compresslevel = setDefaultCompressionLevel(
+															   result->compresstype);
+		}
+
+		if (result->compresstype &&
+			(pg_strcasecmp(result->compresstype, "rle_type") == 0) &&
+			(result->compresslevel > 4))
+		{
+			if (validate)
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+						 errmsg("compresslevel=%d is out of range for rle_type"
+								" (should be in the range 1 to 4)",
+								result->compresslevel)));
+
+			result->compresslevel = setDefaultCompressionLevel(
+															   result->compresstype);
+		}
+	}
+
+	/* checksum */
+	checksum_opt = get_option_set(options, num_options, SOPT_CHECKSUM);
+	if (checksum_opt != NULL)
+	{
+		if (!KIND_IS_RELATION(kind) && validate)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("usage of parameter \"checksum\" in a non relation "
+							"object is not supported")));
+
+		if (!result->appendonly && validate)
+			ereport(ERROR,
+					(errcode(ERRCODE_GP_FEATURE_NOT_SUPPORTED),
+					 errmsg("invalid option \"checksum\" for base relation. "
+							"Only valid for Append Only relations")));
+		result->checksum = checksum_opt->values.bool_val;
+	}
+	/* Disable checksum for heap relations. */
+	else if (result->appendonly == false)
+		result->checksum = false;
+
+	/* columnstore */
+	orientation_opt = get_option_set(options, num_options, SOPT_ORIENTATION);
+	if (orientation_opt != NULL)
+	{
+		if (!KIND_IS_RELATION(kind) && validate)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("usage of parameter \"orientation\" in a non "
+							"relation object is not supported")));
+
+		if (!result->appendonly && validate)
+			ereport(ERROR,
+					(errcode(ERRCODE_GP_FEATURE_NOT_SUPPORTED),
+					 errmsg("invalid option \"orientation\" for base relation. "
+							"Only valid for Append Only relations")));
+
+		if (!(pg_strcasecmp(orientation_opt->values.string_val, "column") == 0 ||
+			  pg_strcasecmp(orientation_opt->values.string_val, "row") == 0) &&
+			validate)
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("invalid parameter value for \"orientation\": "
+							"\"%s\"", orientation_opt->values.string_val)));
+		}
+
+		result->columnstore = (pg_strcasecmp(orientation_opt->values.string_val, "column") == 0 ?
+							   true : false);
+
+		if (result->compresstype &&
+			(pg_strcasecmp(result->compresstype, "rle_type") == 0) &&
+			!result->columnstore)
+		{
+			if (validate)
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+						 errmsg("%s cannot be used with Append Only relations "
+								"row orientation", result->compresstype)));
+		}
+	}
+
+	if (result->appendonly && result->compresstype != NULL)
+		if (result->compresslevel == AO_DEFAULT_COMPRESSLEVEL)
+			result->compresslevel = setDefaultCompressionLevel(
+															   result->compresstype);
+}
+
+void
+validate_and_refill_options(StdRdOptions *result, relopt_value *options,
+							int numrelopts, relopt_kind kind, bool validate)
+{
+	if (validate &&
+		ao_storage_opts_changed &&
+		KIND_IS_RELATION(kind))
+	{
+		if (!(get_option_set(options, numrelopts, SOPT_APPENDONLY)))
+			result->appendonly = ao_storage_opts.appendonly;
+
+		if (!(get_option_set(options, numrelopts, SOPT_FILLFACTOR)))
+			result->fillfactor = ao_storage_opts.fillfactor;
+
+		if (!(get_option_set(options, numrelopts, SOPT_BLOCKSIZE)))
+			result->blocksize = ao_storage_opts.blocksize;
+
+		if (!(get_option_set(options, numrelopts, SOPT_COMPLEVEL)))
+			result->compresslevel = ao_storage_opts.compresslevel;
+
+		if (!(get_option_set(options, numrelopts, SOPT_COMPTYPE)))
+			result->compresstype = ao_storage_opts.compresstype;
+
+		if (!(get_option_set(options, numrelopts, SOPT_CHECKSUM)))
+			result->checksum = ao_storage_opts.checksum;
+
+		if (!(get_option_set(options, numrelopts, SOPT_ORIENTATION)))
+			result->columnstore = ao_storage_opts.columnstore;
+	}
+
+	validate_and_adjust_options(result, options, numrelopts, kind, validate);
+}
+
+void
+parse_validate_reloptions(StdRdOptions *result, Datum reloptions,
+						  bool validate, relopt_kind kind)
+{
+	relopt_value *options;
+	int			num_options;
+
+	options = parseRelOptions(reloptions, validate, RELOPT_KIND_HEAP,
+							  &num_options);
+
+	validate_and_adjust_options(result, options, num_options, kind, validate);
+	free_options_deep(options, num_options);
+}
+
+/*
+ * validateAppendOnlyRelOptions
+ *
+ *		Various checks for validity of appendonly relation rules.
+ */
+void
+validateAppendOnlyRelOptions(bool ao,
+							 int blocksize,
+							 int safewrite,
+							 int complevel,
+							 char *comptype,
+							 bool checksum,
+							 char relkind,
+							 bool co)
+{
+	if (relkind != RELKIND_RELATION)
+	{
+		if (ao)
+			ereport(ERROR,
+					(errcode(ERRCODE_GP_FEATURE_NOT_SUPPORTED),
+					 errmsg("appendonly may only be specified for base relations")));
+
+		if (checksum)
+			ereport(ERROR,
+					(errcode(ERRCODE_GP_FEATURE_NOT_SUPPORTED),
+					 errmsg("checksum may only be specified for base relations")));
+
+		if (comptype)
+			ereport(ERROR,
+					(errcode(ERRCODE_GP_FEATURE_NOT_SUPPORTED),
+					 errmsg("compresstype may only be specified for base relations")));
+	}
+
+	/*
+	 * If this is not an appendonly relation, no point in going further.
+	 */
+	if (!ao)
+		return;
+
+	if (comptype &&
+		(pg_strcasecmp(comptype, "quicklz") == 0 ||
+		 pg_strcasecmp(comptype, "zlib") == 0 ||
+		 pg_strcasecmp(comptype, "rle_type") == 0))
+	{
+
+		if (!co &&
+			pg_strcasecmp(comptype, "rle_type") == 0)
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("%s cannot be used with Append Only relations row orientation",
+							comptype)));
+		}
+
+		if (comptype && complevel == 0)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("compresstype cannot be used with compresslevel 0")));
+
+		if (complevel < 0 || complevel > 9)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("compresslevel=%d is out of range (should be between 0 and 9)",
+							complevel)));
+
+		if (comptype && (pg_strcasecmp(comptype, "quicklz") == 0) &&
+			(complevel != 1))
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("compresslevel=%d is out of range for quicklz "
+							"(should be 1)", complevel)));
+		}
+		if (comptype && (pg_strcasecmp(comptype, "rle_type") == 0) &&
+			(complevel > 4))
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("compresslevel=%d is out of range for rle_type "
+							"(should be in the range 1 to 4)", complevel)));
+		}
+	}
+
+	if (blocksize < MIN_APPENDONLY_BLOCK_SIZE ||
+		blocksize > MAX_APPENDONLY_BLOCK_SIZE ||
+		blocksize % MIN_APPENDONLY_BLOCK_SIZE != 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("block size must be between 8KB and 2MB and "
+						"be an 8KB multiple, Got %d", blocksize)));
+
+	if (safewrite > MAX_APPENDONLY_BLOCK_SIZE || safewrite % 8 != 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("safefswrite size must be less than 8MB and "
+						"be a multiple of 8")));
+
+	if (gp_safefswritesize > blocksize)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("block size (%d) is smaller gp_safefswritesize (%d). "
+						"increase blocksize or decrease gp_safefswritesize if it "
+						"is safe to do so on this file system",
+						blocksize, gp_safefswritesize)));
+}
+
+/*
+ * if no compressor type was specified, we set to no compression (level 0)
+ * otherwise default for both zlib, quicklz and RLE to level 1.
+ */
+static int
+setDefaultCompressionLevel(char *compresstype)
+{
+	if (!compresstype || pg_strcasecmp(compresstype, "none") == 0)
+		return 0;
+	else
+		return 1;
+}
+
+void
+free_options_deep(relopt_value *options, int num_options)
+{
+	int			i;
+
+	for (i = 0; i < num_options; ++i)
+	{
+		if (options[i].isset &&
+			options[i].gen->type == RELOPT_TYPE_STRING &&
+			options[i].values.string_val != NULL)
+		{
+			pfree(options[i].values.string_val);
+		}
+	}
+	pfree(options);
+}
+
+relopt_value *
+get_option_set(relopt_value *options, int num_options, const char *opt_name)
+{
+	int			i;
+	int			opt_name_len;
+	int			cmp_len;
+
+	opt_name_len = strlen(opt_name);
+	for (i = 0; i < num_options; ++i)
+	{
+		cmp_len = options[i].gen->namelen > opt_name_len ? opt_name_len : options[i].gen->namelen;
+		if (options[i].isset && pg_strncasecmp(options[i].gen->name, opt_name, cmp_len) == 0)
+			return &options[i];
+	}
+	return NULL;
+}

--- a/src/backend/access/gin/ginutil.c
+++ b/src/backend/access/gin/ginutil.c
@@ -8,7 +8,7 @@
  * Portions Copyright (c) 1994, Regents of the University of California
  *
  * IDENTIFICATION
- *			$PostgreSQL: pgsql/src/backend/access/gin/ginutil.c,v 1.19 2009/01/01 17:23:34 momjian Exp $
+ *			$PostgreSQL: pgsql/src/backend/access/gin/ginutil.c,v 1.20 2009/01/05 17:14:28 alvherre Exp $
  *-------------------------------------------------------------------------
  */
 
@@ -319,17 +319,7 @@ ginoptions(PG_FUNCTION_ARGS)
 	bool		validate = PG_GETARG_BOOL(1);
 	bytea	   *result;
 
-	/*
-	 * It's not clear that fillfactor is useful for GIN, but for the moment
-	 * we'll accept it anyway.  (It won't do anything...)
-	 */
-#define GIN_MIN_FILLFACTOR			10
-#define GIN_DEFAULT_FILLFACTOR		100
-
-	result = default_reloptions(reloptions, validate,
-								RELKIND_INDEX,
-								GIN_MIN_FILLFACTOR,
-								GIN_DEFAULT_FILLFACTOR);
+	result = default_reloptions(reloptions, validate, RELOPT_KIND_GIN);
 	if (result)
 		PG_RETURN_BYTEA_P(result);
 	PG_RETURN_NULL();

--- a/src/backend/access/gist/gistutil.c
+++ b/src/backend/access/gist/gistutil.c
@@ -8,7 +8,7 @@
  * Portions Copyright (c) 1994, Regents of the University of California
  *
  * IDENTIFICATION
- *			$PostgreSQL: pgsql/src/backend/access/gist/gistutil.c,v 1.32 2009/01/01 17:23:35 momjian Exp $
+ *			$PostgreSQL: pgsql/src/backend/access/gist/gistutil.c,v 1.33 2009/01/05 17:14:28 alvherre Exp $
  *-------------------------------------------------------------------------
  */
 #include "postgres.h"
@@ -730,10 +730,8 @@ gistoptions(PG_FUNCTION_ARGS)
 	bool		validate = PG_GETARG_BOOL(1);
 	bytea	   *result;
 
-	result = default_reloptions(reloptions, validate,
-								RELKIND_INDEX,
-								GIST_MIN_FILLFACTOR,
-								GIST_DEFAULT_FILLFACTOR);
+	result = default_reloptions(reloptions, validate, RELOPT_KIND_GIST);
+
 	if (result)
 		PG_RETURN_BYTEA_P(result);
 	PG_RETURN_NULL();

--- a/src/backend/access/hash/hashutil.c
+++ b/src/backend/access/hash/hashutil.c
@@ -8,7 +8,7 @@
  *
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/access/hash/hashutil.c,v 1.58 2009/01/01 17:23:35 momjian Exp $
+ *	  $PostgreSQL: pgsql/src/backend/access/hash/hashutil.c,v 1.59 2009/01/05 17:14:28 alvherre Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -224,10 +224,8 @@ hashoptions(PG_FUNCTION_ARGS)
 	bool		validate = PG_GETARG_BOOL(1);
 	bytea	   *result;
 
-	result = default_reloptions(reloptions, validate,
-								RELKIND_INDEX,
-								HASH_MIN_FILLFACTOR,
-								HASH_DEFAULT_FILLFACTOR);
+	result = default_reloptions(reloptions, validate, RELOPT_KIND_HASH);
+
 	if (result)
 		PG_RETURN_BYTEA_P(result);
 	PG_RETURN_NULL();

--- a/src/backend/access/nbtree/nbtutils.c
+++ b/src/backend/access/nbtree/nbtutils.c
@@ -8,7 +8,7 @@
  *
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/access/nbtree/nbtutils.c,v 1.92 2009/01/01 17:23:36 momjian Exp $
+ *	  $PostgreSQL: pgsql/src/backend/access/nbtree/nbtutils.c,v 1.93 2009/01/05 17:14:28 alvherre Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -1416,10 +1416,7 @@ btoptions(PG_FUNCTION_ARGS)
 	bool		validate = PG_GETARG_BOOL(1);
 	bytea	   *result;
 
-	result = default_reloptions(reloptions, validate,
-								RELKIND_INDEX,
-								BTREE_MIN_FILLFACTOR,
-								BTREE_DEFAULT_FILLFACTOR);
+	result = default_reloptions(reloptions, validate, RELOPT_KIND_BTREE);
 	if (result)
 		PG_RETURN_BYTEA_P(result);
 	PG_RETURN_NULL();

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -5834,7 +5834,7 @@ assign_gp_default_storage_options(const char *newval,
 			 */
 			resetAOStorageOpts(newopts);
 			parse_validate_reloptions(newopts, newopts_datum,
-									   /* validate */ true, RELKIND_RELATION);
+									   /* validate */ true, RELOPT_KIND_HEAP);
 			validateAppendOnlyRelOptions(
 										 newopts->appendonly,
 										 newopts->blocksize,

--- a/src/include/access/bitmap.h
+++ b/src/include/access/bitmap.h
@@ -866,4 +866,8 @@ extern void bitmap_xlog_startup(void);
 extern void bitmap_xlog_cleanup(void);
 extern bool bitmap_safe_restartpoint(void);
 
+/* reloptions.c */
+#define BITMAP_MIN_FILLFACTOR		10
+#define BITMAP_DEFAULT_FILLFACTOR	100
+
 #endif

--- a/src/include/access/reloptions.h
+++ b/src/include/access/reloptions.h
@@ -11,7 +11,7 @@
  * Portions Copyright (c) 1996-2009, PostgreSQL Global Development Group
  * Portions Copyright (c) 1994, Regents of the University of California
  *
- * $PostgreSQL: pgsql/src/include/access/reloptions.h,v 1.6 2009/01/01 17:23:56 momjian Exp $
+ * $PostgreSQL: pgsql/src/include/access/reloptions.h,v 1.7 2009/01/05 17:14:28 alvherre Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -26,6 +26,8 @@
 #define AO_DEFAULT_BLOCKSIZE      DEFAULT_APPENDONLY_BLOCK_SIZE
 /* Compression is turned off by default. */
 #define AO_DEFAULT_COMPRESSLEVEL  0
+#define AO_MIN_COMPRESSLEVEL  0
+#define AO_MAX_COMPRESSLEVEL  9
 /*
  * If compression is turned on without specifying compresstype, this
  * is the default.
@@ -34,22 +36,203 @@
 #define AO_DEFAULT_CHECKSUM       true
 #define AO_DEFAULT_COLUMNSTORE    false
 
+/* types supported by reloptions */
+typedef enum relopt_type
+{
+	RELOPT_TYPE_BOOL,
+	RELOPT_TYPE_INT,
+	RELOPT_TYPE_REAL,
+	RELOPT_TYPE_STRING
+} relopt_type;
+
+/* kinds supported by reloptions */
+typedef enum relopt_kind
+{
+	RELOPT_KIND_HEAP,
+	/* XXX do we need a separate kind for TOAST tables? */
+	RELOPT_KIND_BTREE,
+	RELOPT_KIND_HASH,
+	RELOPT_KIND_GIN,
+	RELOPT_KIND_GIST,
+	RELOPT_KIND_BITMAP,
+	RELOPT_KIND_INTERNAL,
+	/* if you add a new kind, make sure you update "last_default" too */
+	RELOPT_KIND_LAST_DEFAULT = RELOPT_KIND_INTERNAL,
+	RELOPT_KIND_MAX = 255
+} relopt_kind;
+
+/* generic struct to hold shared data */
+typedef struct relopt_gen
+{
+	const char *name;	/* must be first (used as list termination marker) */
+	const char *desc;
+	relopt_kind	kind;
+	int			namelen;
+	relopt_type	type;
+} relopt_gen;
+
+/* holds a parsed value */
+typedef struct relopt_value
+{
+	relopt_gen *gen;
+	bool		isset;
+	union
+	{
+		bool	bool_val;
+		int		int_val;
+		double	real_val;
+		char   *string_val;	/* allocated separately */
+	} values;
+} relopt_value;
+
+/* reloptions records for specific variable types */
+typedef struct relopt_bool
+{
+	relopt_gen	gen;
+	bool		default_val;
+} relopt_bool;
+	
+typedef struct relopt_int
+{
+	relopt_gen	gen;
+	int			default_val;
+	int			min;
+	int			max;
+} relopt_int;
+
+typedef struct relopt_real
+{
+	relopt_gen	gen;
+	double		default_val;
+	double		min;
+	double		max;
+} relopt_real;
+
+typedef struct relopt_string
+{
+	relopt_gen	gen;
+	int			default_len;
+	bool		default_isnull;
+	char		default_val[1];	/* variable length */
+} relopt_string;
+
+/* This is the table datatype for fillRelOptions */
+typedef struct
+{
+	const char *optname;		/* option's name */
+	relopt_type opttype;		/* option's datatype */
+	int			offset;			/* offset of field in result struct */
+} relopt_parse_elt;
+
+
+/*
+ * These macros exist for the convenience of amoptions writers.  See
+ * default_reloptions for an example of the intended usage.  Beware of
+ * multiple evaluation of arguments!
+ *
+ * Most of the time there's no need to call HAVE_RELOPTION manually, but it's
+ * possible that an amoptions routine needs to walk the array with a different
+ * purpose (say, to compute the size of a struct to allocate beforehand.)
+ */
+#define HAVE_RELOPTION(optname, option) \
+	(pg_strncasecmp(option.gen->name, optname, option.gen->namelen) == 0)
+
+#define HANDLE_INT_RELOPTION(optname, var, option) 					\
+	do {															\
+		if (HAVE_RELOPTION(optname, option))						\
+		{															\
+			if (option.isset)										\
+				var = option.values.int_val; 						\
+			else													\
+				var = ((relopt_int *) option.gen)->default_val; 	\
+			continue;												\
+		}															\
+	} while (0)
+
+#define HANDLE_BOOL_RELOPTION(optname, var, option) 				\
+	do {															\
+		if (HAVE_RELOPTION(optname, option))						\
+		{															\
+			if (option.isset)										\
+				var = option.values.bool_val; 						\
+			else													\
+				var = ((relopt_bool *) option.gen)->default_val;	\
+			continue;												\
+		}															\
+	} while (0)
+
+#define HANDLE_REAL_RELOPTION(optname, var, option) 				\
+	do {															\
+		if (HAVE_RELOPTION(optname, option))						\
+		{															\
+			if (option.isset)										\
+				var = option.values.real_val; 						\
+			else													\
+				var = ((relopt_real *) option.gen)->default_val;	\
+			continue;												\
+		}															\
+	} while (0)
+
+/* Note that this assumes that the variable is already allocated! */
+#define HANDLE_STRING_RELOPTION(optname, var, option) 				\
+	do {															\
+		if (HAVE_RELOPTION(optname, option))						\
+		{															\
+			relopt_string *optstring = (relopt_string *) option.gen;\
+			if (optstring->default_isnull)							\
+				var[0] = '\0';										\
+			else													\
+				strcpy(var,											\
+					   option.isset ? option.values.string_val : 	\
+					   optstring->default_val);						\
+			continue;												\
+		}															\
+	} while (0)
+
+/*
+ * For use during amoptions: get the strlen of a string option
+ * (either default or the user defined value)
+ */
+#define GET_STRING_RELOPTION_LEN(option) \
+	((option).isset ? strlen((option).values.string_val) : \
+	 ((relopt_string *) (option).gen)->default_len)
+
+/*
+ * For use by code reading options already parsed: get a pointer to the string
+ * value itself.  "optstruct" is the StdRdOption struct or equivalent, "member"
+ * is the struct member corresponding to the string option
+ */
+#define GET_STRING_RELOPTION(optstruct, member) \
+	((optstruct)->member == 0 ? NULL : \
+	 (char *)(optstruct) + (optstruct)->member)
+
+extern int add_reloption_kind(void);
+extern void add_bool_reloption(int kind, char *name, char *desc,
+				   bool default_val);
+extern void add_int_reloption(int kind, char *name, char *desc,
+				  int default_val, int min_val, int max_val);
+extern void add_real_reloption(int kind, char *name, char *desc,
+				   double default_val, double min_val, double max_val);
+extern void add_string_reloption(int kind, char *name, char *desc,
+					 char *default_val);
+			
 extern Datum transformRelOptions(Datum oldOptions, List *defList,
 					bool ignoreOids, bool isReset);
-
 extern List *untransformRelOptions(Datum options);
+extern relopt_value *parseRelOptions(Datum options, bool validate,
+				relopt_kind kind, int *numrelopts);
+extern void *allocateReloptStruct(Size base, relopt_value *options,
+					 int numoptions);
+extern void fillRelOptions(void *rdopts, Size basesize,
+			   relopt_value *options, int numoptions,
+			   bool validate,
+			   const relopt_parse_elt *elems, int nelems);
 
-extern void parseRelOptions(Datum options, int numkeywords,
-				const char *const * keywords,
-				char **values, bool validate);
-
-extern bytea *default_reloptions(Datum reloptions, bool validate, char relkind,
-				   int minFillfactor, int defaultFillfactor);
-
+extern bytea *default_reloptions(Datum reloptions, bool validate,
+				   relopt_kind kind);
 extern bytea *heap_reloptions(char relkind, Datum reloptions, bool validate);
-
 extern bytea *index_reloptions(RegProcedure amoptions, Datum reloptions,
-				 bool validate);
+				bool validate);
 
 extern void validateAppendOnlyRelOptions(bool ao, int blocksize, int writesize,
 										 int complevel, char* comptype, 
@@ -65,6 +248,13 @@ extern void setDefaultAOStorageOpts(StdRdOptions *copy);
 extern const StdRdOptions *currentAOStorageOptions(void);
 extern Datum parseAOStorageOpts(const char *opts_str, bool *aovalue);
 extern void parse_validate_reloptions(StdRdOptions *result, Datum reloptions,
-									  bool validate, char relkind);
+									  bool validate, relopt_kind relkind);
+
+/* in reloptions_gp.c */
+extern void initialize_reloptions_gp(void);
+extern void validate_and_refill_options(StdRdOptions *result, relopt_value *options,
+							int numoptions, relopt_kind kind, bool validate);
+extern void validate_and_adjust_options(StdRdOptions *result, relopt_value *options,
+										int num_options, relopt_kind kind, bool validate);
 
 #endif   /* RELOPTIONS_H */

--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -37,7 +37,7 @@
  * Portions Copyright (c) 1996-2009, PostgreSQL Global Development Group
  * Portions Copyright (c) 1994, Regents of the University of California
  *
- * $PostgreSQL: pgsql/src/include/catalog/catversion.h,v 1.516 2009/01/01 17:23:56 momjian Exp $
+ * $PostgreSQL: pgsql/src/include/catalog/catversion.h,v 1.517 2009/01/05 17:14:28 alvherre Exp $
  *
  *-------------------------------------------------------------------------
  */

--- a/src/include/utils/rel.h
+++ b/src/include/utils/rel.h
@@ -277,9 +277,10 @@ typedef struct StdRdOptions
 	bool		appendonly;		/* is this an appendonly relation? */
 	int			blocksize;		/* max varblock size (AO rels only) */
 	int			compresslevel;  /* compression level (AO rels only) */
-	char*		compresstype;   /* compression type (AO rels only) */
+	char	   *compresstype;	/* compression type (AO rels only) */
 	bool		checksum;		/* checksum (AO rels only) */
-	bool 		columnstore;		/* columnstore (AO only) */
+	bool 		columnstore;	/* columnstore (AO only) */
+	char	   *orientation;	/* orientation (AO only) */
 } StdRdOptions;
 
 #define HEAP_MIN_FILLFACTOR			10

--- a/src/test/regress/expected/alter_distribution_policy.out
+++ b/src/test/regress/expected/alter_distribution_policy.out
@@ -597,7 +597,7 @@ select * from atsdb;
 
 -- validate parameters
 alter table atsdb set with (appendonly = ff);
-ERROR:  invalid parameter value for "appendonly": "ff"
+ERROR:  invalid value for boolean option "appendonly": ff
 alter table atsdb set with (reorganize = true);
 alter table atsdb set with (fgdfgef = asds);
 ERROR:  unrecognized parameter "fgdfgef"

--- a/src/test/regress/expected/column_compression.out
+++ b/src/test/regress/expected/column_compression.out
@@ -447,7 +447,8 @@ alter table ccddl add column j int encoding(compresstype=yawn);
 ERROR:  unknown compresstype "yawn"
 alter table ccddl add column j int encoding(compresstype=zlib,
 compresslevel=100000);
-ERROR:  compresslevel=100000 is out of range (should be between 0 and 9)
+ERROR:  value 100000 out of bounds for option "compresslevel"
+DETAIL:  Valid values are between "0" and "9".
 alter table ccddl add column j int encoding(a=b);
 ERROR:  unrecognized parameter "a"
 drop table ccddl;
@@ -470,7 +471,8 @@ ERROR:  DEFAULT COLUMN ENCODING clause cannot override values set in WITH clause
 -- Invalid encoding clauses
 create table t1 (i int encoding (compresstype=zlib, compresslevel=19))
 with (appendonly=true, orientation=column);
-ERROR:  compresslevel=19 is out of range (should be between 0 and 9)
+ERROR:  value 19 out of bounds for option "compresslevel"
+DETAIL:  Valid values are between "0" and "9".
 create table t1 (i int encoding (compresstype=zlib, ahhhh=boooooo))
 with (appendonly=true, orientation=column);
 ERROR:  unrecognized parameter "ahhhh"
@@ -1840,7 +1842,8 @@ ERROR:  unrecognized parameter "a"
 alter type text set default encoding (compresstype=10);
 ERROR:  unknown compresstype "10"
 alter type text set default encoding (compresstype=zlib, compresslevel=100);
-ERROR:  compresslevel=100 is out of range (should be between 0 and 9)
+ERROR:  value 100 out of bounds for option "compresslevel"
+DETAIL:  Valid values are between "0" and "9".
 -- dependency check on drop type
 drop type int42 cascade;
 NOTICE:  drop cascades to 2 other objects

--- a/src/test/regress/expected/dsp.out
+++ b/src/test/regress/expected/dsp.out
@@ -508,7 +508,8 @@ create table co7(a int, b float,
 ERROR:  compresslevel=7 is out of range for rle_type (should be in the range 1 to 4)
 -- negative tests - session level set
 set gp_default_storage_options="compresstype=zlib,compresslevel=11";
-ERROR:  compresslevel=11 is out of range (should be between 0 and 9)
+ERROR:  value 11 out of bounds for option "compresslevel"
+DETAIL:  Valid values are between "0" and "9".
 set gp_default_storage_options="compresslevel=5,compresstype=RLE_TYPE";
 ERROR:  compresslevel=5 is out of range for rle_type (should be in the range 1 to 4)
 set gp_default_storage_options="compresslevel=1,compresstype=rle";

--- a/src/test/regress/output/aocs.source
+++ b/src/test/regress/output/aocs.source
@@ -61,7 +61,8 @@ CREATE TABLE tenk_aocs10 (like tenk_heap_for_aocs) with (appendonly=false, orien
 ERROR:  invalid option 'compresslevel' for base relation. Only valid for Append Only relations
 -- block size must be between 8KB and 2MB w/ 8KB multiple
 CREATE TABLE tenk_aocs11 (like tenk_heap_for_aocs) with (appendonly=true, orientation=column, blocksize=100) distributed by(unique1);
-ERROR:  block size must be between 8KB and 2MB and be an 8KB multiple. Got 100
+ERROR:  value 100 out of bounds for option "blocksize"
+DETAIL:  Valid values are between "8192" and "2097152".
 -- cannot have compresslevel 0
 CREATE TABLE tenk_aocs12 (like tenk_heap_for_aocs) with (appendonly=true, orientation=column, compresslevel=0, compresstype=zlib) distributed by(unique1);
 ERROR:  compresstype can't be used with compresslevel 0

--- a/src/test/regress/output/appendonly.source
+++ b/src/test/regress/output/appendonly.source
@@ -45,9 +45,11 @@ CREATE TABLE tenk_ao5 (like tenk_heap) with (appendonly=true, compresslevel=6, c
 CREATE TABLE tenk_ao6 (like tenk_heap) with (appendonly=false, compresslevel=6, checksum=true) distributed by(unique1);
 ERROR:  invalid option 'compresslevel' for base relation. Only valid for Append Only relations
 CREATE TABLE tenk_ao7 (like tenk_heap) with (appendonly=true, compresslevel=16, compresstype=zlib) distributed by(unique1);
-ERROR:  compresslevel=16 is out of range (should be between 0 and 9)
+ERROR:  value 16 out of bounds for option "compresslevel"
+DETAIL:  Valid values are between "0" and "9".
 CREATE TABLE tenk_ao8 (like tenk_heap) with (appendonly=true, blocksize=100) distributed by(unique1);
-ERROR:  block size must be between 8KB and 2MB and be an 8KB multiple. Got 100
+ERROR:  value 100 out of bounds for option "blocksize"
+DETAIL:  Valid values are between "8192" and "2097152".
 CREATE TABLE tenk_ao9 (like tenk_heap) with (appendonly=true, compresslevel=0, compresstype=zlib) distributed by(unique1);
 ERROR:  compresstype can't be used with compresslevel 0
 -- these should not work without appendonly=true


### PR DESCRIPTION
Merge the next commit from PostgreSQL 8.4, which refactors reloptions.c to
use a table-based parser. We are merging this as a separate commit, because
this needed also refactoring all the GPDB-added reloptions to the new
model.

This adds a new RELOPT_KIND_INTERNAL "relation kind", for TOAST tables and
auxiliary tables of append-only relations, like the AO visimap and block
dir. That will probably be refactored away later in the merge, when we
merge upstream commit 1c855f01ea, as that commit introduces a new
RELOPT_KIND_TOASTVALUE kind for TOAST tables, instead.

This also includes the new fillRelOptions(), from upstream commit
8ebe1e356c (also from 8.4), because that was very handy in the refactoring
of the GPDB code.

Author: Xiaoran Wang <xiwang@pivotal.io>
Author: Heikki Linnakangas <hlinnakangas@pivotal.io>
