### PR TITLE
Remove some code that was duplicated by a mis-merge.

### DIFF
--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -4438,8 +4438,6 @@ add_sort_column(AttrNumber colIdx, Oid sortOp, bool nulls_first,
 
 	Assert(OidIsValid(sortOp));
 
-	Assert(OidIsValid(sortOp));
-
 	for (i = 0; i < numCols; i++)
 	{
 		/*

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -3244,21 +3244,6 @@ eval_const_expressions_mutator(Node *node,
 					0);
 	}
 
-	if (IsA(node, PlaceHolderVar) && context->estimate)
-	{
-		/*
-		 * In estimation mode, just strip the PlaceHolderVar node altogether;
-		 * this amounts to estimating that the contained value won't be forced
-		 * to null by an outer join.  In regular mode we just use the default
-		 * behavior (ie, simplify the expression but leave the PlaceHolderVar
-		 * node intact).
-		 */
-		PlaceHolderVar *phv = (PlaceHolderVar *) node;
-		
-		return eval_const_expressions_mutator((Node *) phv->phexpr,
-											  context);
-	}
-
 	/*
 	 * For any node type not handled above, we recurse using
 	 * expression_tree_mutator, which will copy the node unchanged but try to


### PR DESCRIPTION
Harmless, but clearly useless and unintentional.