### PR TITLE
Fix initialization of GPDB-specific AO reloptions.

### DIFF
--- a/src/backend/access/common/reloptions.c
+++ b/src/backend/access/common/reloptions.c
@@ -128,11 +128,12 @@ static void parse_one_reloption(relopt_value *option, char *text_str,
 static void
 initialize_reloptions(void)
 {
-	int		i;
-	int		j = 0;
+	int			i;
+	int			j;
 
 	initialize_reloptions_gp();
 
+	j = 0;
 	for (i = 0; boolRelOpts[i].gen.name; i++)
 		j++;
 	for (i = 0; intRelOpts[i].gen.name; i++)
@@ -189,6 +190,9 @@ initialize_reloptions(void)
 
 	/* add a list terminator */
 	relOpts[j] = NULL;
+
+	/* flag the work is complete */
+	need_initialization = false;
 }
 
 /*

--- a/src/backend/access/common/reloptions_gp.c
+++ b/src/backend/access/common/reloptions_gp.c
@@ -143,6 +143,12 @@ void
 initialize_reloptions_gp(void)
 {
 	int			i;
+	static bool	initialized = false;
+
+	/* only add these on first call. */
+	if (initialized)
+		return;
+	initialized = true;
 
 	/* Set GPDB specific options */
 	for (i = 0; boolRelOpts_gp[i].gen.name; i++)


### PR DESCRIPTION
The options should only be registered once. Surprisingly, the duplicates
seem to be harmless, because everything worked, but the accumulation of
more and more reloptions was slowing down tests that created a lot of
tables.