### PR TITLE
Increase timeout on icw_planner_centos6 for PR

### DIFF
--- a/concourse/pipelines/pr_pipeline.yml
+++ b/concourse/pipelines/pr_pipeline.yml
@@ -125,7 +125,7 @@ jobs:
           BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
           TEST_OS: centos
           CONFIGURE_FLAGS: {{configure_flags}}
-        timeout: 2h
+        timeout: 3h
         on_failure: *pr_failure
 
       - task: icw_gporca_orca_centos6


### PR DESCRIPTION
icw_planner_centos6 was timing out occasionally at 2 hours, when pipeline is slow from other activity.  Bump it to 3.