### PR TITLE
Fix reversed flags to pull_up_clause().

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -2057,13 +2057,13 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 				List	   *extravars;
 
 				extravars = pull_var_clause(wc->startOffset,
-											PVC_INCLUDE_PLACEHOLDERS,
-											PVC_REJECT_AGGREGATES);
+											PVC_REJECT_AGGREGATES,
+											PVC_INCLUDE_PLACEHOLDERS);
 				window_tlist = add_to_flat_tlist(window_tlist, extravars);
 
 				extravars = pull_var_clause(wc->endOffset,
-											PVC_INCLUDE_PLACEHOLDERS,
-											PVC_REJECT_AGGREGATES);
+											PVC_REJECT_AGGREGATES,
+											PVC_INCLUDE_PLACEHOLDERS);
 				window_tlist = add_to_flat_tlist(window_tlist, extravars);
 			}
 


### PR DESCRIPTION
Looks like you can't actually get here with any aggregates or placeholders
in the start/end offsets, or we would've gotten errors.