### PR TITLE
Ensure ccp_destroy runs at the end of each ccp job

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -536,8 +536,6 @@ debug_sleep_anchor: &debug_sleep
       run:
         path: 'sh'
         args: ['-c', 'sleep {{ccp_debug_sleep}}']
-    ensure:
-      <<: *ccp_destroy
 
 pulse_properties_anchor: &pulse_properties
   PULSE_URL: {{pulse_url}}
@@ -590,8 +588,6 @@ cs_ccp_gen_cluster_params_anchor: &cs_ccp_gen_cluster_params
   file: ccp_src/ci/tasks/gen_cluster.yml
   params:
     <<: *ccp_gen_cluster_default_params
-  on_failure:
-    <<: *ccp_destroy
 
 cs_ccp_run_tests_params_anchor: &cs_ccp_run_tests_params
   tags: ["ccp"]
@@ -1266,8 +1262,6 @@ jobs:
     file: ccp_src/ci/tasks/gen_cluster.yml
     params:
       <<: *ccp_gen_cluster_default_params
-    on_failure:
-      <<: *ccp_destroy
   - task: run_tests
     tags: ["ccp"]
     file: gpdb_src/concourse/tasks/run_tinc.yml
@@ -1276,7 +1270,8 @@ jobs:
       TINC_TARGET: walrep_1
     on_failure:
       <<: *debug_sleep
-  - *ccp_destroy
+  ensure:
+    <<: *ccp_destroy
 
 - name: cs_walrep_2
   plan:
@@ -1305,8 +1300,6 @@ jobs:
     file: ccp_src/ci/tasks/gen_cluster.yml
     params:
       <<: *ccp_gen_cluster_default_params
-    on_failure:
-      <<: *ccp_destroy
   - task: run_tests
     tags: ["ccp"]
     file: gpdb_src/concourse/tasks/run_tinc.yml
@@ -1315,7 +1308,8 @@ jobs:
       TINC_TARGET: walrep_2
     on_failure:
       <<: *debug_sleep
-  - *ccp_destroy
+  ensure:
+    <<: *ccp_destroy
 
 - name: cs_pg_twophase_01_10
   plan:
@@ -1347,8 +1341,6 @@ jobs:
     file: ccp_src/ci/tasks/gen_cluster.yml
     params:
       <<: *ccp_gen_cluster_default_params
-    on_failure:
-      <<: *ccp_destroy
   - task: run_tests
     tags: ["ccp"]
     file: gpdb_src/concourse/tasks/run_tinc.yml
@@ -1357,7 +1349,8 @@ jobs:
       TINC_TARGET: test_pg_twophase_01_10
     on_failure:
       <<: *debug_sleep
-  - *ccp_destroy
+  ensure:
+    <<: *ccp_destroy
 
 - name: cs_pg_twophase_11_20
   plan:
@@ -1389,8 +1382,6 @@ jobs:
     file: ccp_src/ci/tasks/gen_cluster.yml
     params:
       <<: *ccp_gen_cluster_default_params
-    on_failure:
-      <<: *ccp_destroy
   - task: run_tests
     tags: ["ccp"]
     file: gpdb_src/concourse/tasks/run_tinc.yml
@@ -1399,7 +1390,8 @@ jobs:
       TINC_TARGET: test_pg_twophase_11_20
     on_failure:
       <<: *debug_sleep
-  - *ccp_destroy
+  ensure:
+    <<: *ccp_destroy
 
 - name: cs_pg_twophase_21_30
   plan:
@@ -1431,8 +1423,6 @@ jobs:
     file: ccp_src/ci/tasks/gen_cluster.yml
     params:
       <<: *ccp_gen_cluster_default_params
-    on_failure:
-      <<: *ccp_destroy
   - task: run_tests
     tags: ["ccp"]
     file: gpdb_src/concourse/tasks/run_tinc.yml
@@ -1441,7 +1431,8 @@ jobs:
       TINC_TARGET: test_pg_twophase_21_30
     on_failure:
       <<: *debug_sleep
-  - *ccp_destroy
+  ensure:
+    <<: *ccp_destroy
 
 - name: cs_pg_twophase_31_40
   plan:
@@ -1473,8 +1464,6 @@ jobs:
     file: ccp_src/ci/tasks/gen_cluster.yml
     params:
       <<: *ccp_gen_cluster_default_params
-    on_failure:
-      <<: *ccp_destroy
   - task: run_tests
     tags: ["ccp"]
     file: gpdb_src/concourse/tasks/run_tinc.yml
@@ -1483,7 +1472,8 @@ jobs:
       TINC_TARGET: test_pg_twophase_31_40
     on_failure:
       <<: *debug_sleep
-  - *ccp_destroy
+  ensure:
+    <<: *ccp_destroy
 
 - name: cs_pg_twophase_41_49
   plan:
@@ -1515,8 +1505,6 @@ jobs:
     file: ccp_src/ci/tasks/gen_cluster.yml
     params:
       <<: *ccp_gen_cluster_default_params
-    on_failure:
-      <<: *ccp_destroy
   - task: run_tests
     tags: ["ccp"]
     file: gpdb_src/concourse/tasks/run_tinc.yml
@@ -1525,7 +1513,8 @@ jobs:
       TINC_TARGET: test_pg_twophase_41_49
     on_failure:
       <<: *debug_sleep
-  - *ccp_destroy
+  ensure:
+    <<: *ccp_destroy
 
 - name: cs_pg_twophase_switch
   plan:
@@ -1557,8 +1546,6 @@ jobs:
     file: ccp_src/ci/tasks/gen_cluster.yml
     params:
       <<: *ccp_gen_cluster_default_params
-    on_failure:
-      <<: *ccp_destroy
   - task: run_tests
     tags: ["ccp"]
     file: gpdb_src/concourse/tasks/run_tinc.yml
@@ -1567,7 +1554,8 @@ jobs:
       TINC_TARGET: test_switch_01_12
     on_failure:
       <<: *debug_sleep
-  - *ccp_destroy
+  ensure:
+    <<: *ccp_destroy
 
 - name: cs_crash_recovery_schema_topology
   plan:
@@ -1581,7 +1569,8 @@ jobs:
     <<: *cs_ccp_run_tests_params
     params:
       TINC_TARGET: crash_recovery_schema_topology
-  - *ccp_destroy
+  ensure:
+    <<: *ccp_destroy
 
 - name: cs_crash_recovery_04_10
   plan:
@@ -1595,7 +1584,8 @@ jobs:
     <<: *cs_ccp_run_tests_params
     params:
       TINC_TARGET: crash_recovery_04_10
-  - *ccp_destroy
+  ensure:
+    <<: *ccp_destroy
 
 - name: cs_crash_recovery_11_20
   plan:
@@ -1609,7 +1599,8 @@ jobs:
     <<: *cs_ccp_run_tests_params
     params:
       TINC_TARGET: crash_recovery_11_20
-  - *ccp_destroy
+  ensure:
+    <<: *ccp_destroy
 
 - name: cs_crash_recovery_21_30
   plan:
@@ -1623,7 +1614,8 @@ jobs:
     <<: *cs_ccp_run_tests_params
     params:
       TINC_TARGET: crash_recovery_21_30
-  - *ccp_destroy
+  ensure:
+    <<: *ccp_destroy
 
 - name: cs_crash_recovery_31_42
   plan:
@@ -1637,7 +1629,8 @@ jobs:
     <<: *cs_ccp_run_tests_params
     params:
       TINC_TARGET: crash_recovery_31_42
-  - *ccp_destroy
+  ensure:
+    <<: *ccp_destroy
 
 - name: fts
   plan:
@@ -1824,7 +1817,8 @@ jobs:
     <<: *cs_ccp_run_tests_params
     params:
       TINC_TARGET: mpp_interconnect
-  - *ccp_destroy
+  ensure:
+    <<: *ccp_destroy
 
 - name: mpp_resource_group_centos6
   plan:
@@ -1855,8 +1849,6 @@ jobs:
       <<: *ccp_gen_cluster_default_params
     input_mapping:
       gpdb_binary: bin_gpdb
-    on_failure:
-      <<: *ccp_destroy
   - task: run_tests
     tags: ["ccp"]
     file: gpdb_src/concourse/tasks/ic_gpdb_resgroup.yml
@@ -1865,7 +1857,8 @@ jobs:
       TEST_OS: centos6
     on_failure:
       <<: *debug_sleep
-  - *ccp_destroy
+  ensure:
+    <<: *ccp_destroy
 
 - name: mpp_resource_group_centos7
   plan:
@@ -1897,8 +1890,6 @@ jobs:
       <<: *ccp_gen_cluster_default_params
     input_mapping:
       gpdb_binary: bin_gpdb
-    on_failure:
-      <<: *ccp_destroy
   - task: run_tests
     tags: ["ccp"]
     file: gpdb_src/concourse/tasks/ic_gpdb_resgroup.yml
@@ -1907,7 +1898,8 @@ jobs:
       TEST_OS: centos7
     on_failure:
       <<: *debug_sleep
-  - *ccp_destroy
+  ensure:
+    <<: *ccp_destroy
 
 - name: gate_mpp_end
   plan:
@@ -1978,15 +1970,11 @@ jobs:
     file: ccp_src/ci/tasks/gen_cluster.yml
     params:
       <<: *ccp_gen_cluster_default_params
-    on_failure:
-      <<: *ccp_destroy
   - task: setup_gppkg_second_install
     tags: ["ccp"]
     file: gpdb_src/concourse/tasks/gppkg_behave.yml
     params:
       SECOND_BINARY_INSTALL_LOCATION: /tmp/gppkg_migrate
-    on_failure:
-      <<: *ccp_destroy
   - task: run_tests
     tags: ["ccp"]
     file: gpdb_src/concourse/tasks/run_behave.yml
@@ -1995,7 +1983,8 @@ jobs:
       BEHAVE_FLAGS: --tags=gppkg
     on_failure:
       <<: *debug_sleep
-  - *ccp_destroy
+  ensure:
+    <<: *ccp_destroy
 
 - name: MM_gprecoverseg
   plan:
@@ -2027,8 +2016,6 @@ jobs:
     file: ccp_src/ci/tasks/gen_cluster.yml
     params:
       <<: *ccp_gen_cluster_default_params
-    on_failure:
-      <<: *ccp_destroy
   - task: run_tests
     tags: ["ccp"]
     file: gpdb_src/concourse/tasks/run_behave.yml
@@ -2037,7 +2024,8 @@ jobs:
       BEHAVE_FLAGS: --tags=gprecoverseg
     on_failure:
       <<: *debug_sleep
-  - *ccp_destroy
+  ensure:
+    <<: *ccp_destroy
 
 - name: MM_gpcheck
   plan:
@@ -2159,8 +2147,6 @@ jobs:
     file: ccp_src/ci/tasks/gen_cluster.yml
     params:
       <<: *ccp_gen_cluster_default_params
-    on_failure:
-      <<: *ccp_destroy
   - task: pre_run_test_setup
     tags: ["ccp"]
     image: centos-gpdb-dev-6
@@ -2176,7 +2162,8 @@ jobs:
       CUSTOM_ENV: HOST1=mdw HOST2=sdw1 HOST3=sdw2 HOST4=sdw3 HOST5=sdw4
     on_failure:
       <<: *debug_sleep
-  - *ccp_destroy
+  ensure:
+    <<: *ccp_destroy
 
 - name: MM_gpexpand_2
   plan:
@@ -2209,8 +2196,6 @@ jobs:
     file: ccp_src/ci/tasks/gen_cluster.yml
     params:
       <<: *ccp_gen_cluster_default_params
-    on_failure:
-      <<: *ccp_destroy
   - task: pre_run_test_setup
     tags: ["ccp"]
     image: centos-gpdb-dev-6
@@ -2226,7 +2211,8 @@ jobs:
       CUSTOM_ENV: HOST1=mdw HOST2=sdw1 HOST3=sdw2 HOST4=sdw3 HOST5=sdw4
     on_failure:
       <<: *debug_sleep
-  - *ccp_destroy
+  ensure:
+    <<: *ccp_destroy
 
 - name: MM_gpcheckcat
   plan:
@@ -2258,8 +2244,6 @@ jobs:
     file: ccp_src/ci/tasks/gen_cluster.yml
     params:
       <<: *ccp_gen_cluster_default_params
-    on_failure:
-      <<: *ccp_destroy
   - task: run_tests
     tags: ["ccp"]
     file: gpdb_src/concourse/tasks/run_behave.yml
@@ -2268,7 +2252,8 @@ jobs:
       BEHAVE_FLAGS: --tags=gpcheckcat
     on_failure:
       <<: *debug_sleep
-  - *ccp_destroy
+  ensure:
+    <<: *ccp_destroy
 
 - name: gate_mm_end
   plan:
@@ -2402,8 +2387,6 @@ jobs:
         - -exc
         - |
           source gpdb_src/concourse/scripts/transfer_utils.sh; setup_gptransfer
-    on_failure:
-      <<: *ccp_destroy_2_cluster
   - task: run_gptransfer_tests
     tags: ["ccp"]
     file: gpdb_src/concourse/tasks/run_behave.yml
@@ -2425,10 +2408,9 @@ jobs:
           run:
             path: 'sh'
             args: ['-c', 'sleep {{ccp_debug_sleep}}']
-        ensure:
-          <<: *ccp_destroy_2_cluster
   # Similar to the on_failure blocks, the final cleanup needs to be both clusters as well
-  - *ccp_destroy_2_cluster
+  ensure:
+    <<: *ccp_destroy_2_cluster
 
 - name: DPM_gptransfer
   plan:
@@ -2513,8 +2495,6 @@ jobs:
         - -exc
         - |
           source gpdb_src/concourse/scripts/transfer_utils.sh; setup_gptransfer
-    on_failure:
-      <<: *ccp_destroy_2_cluster
   - task: run_gptransfer_tests
     tags: ["ccp"]
     file: gpdb_src/concourse/tasks/run_behave.yml
@@ -2536,10 +2516,9 @@ jobs:
           run:
             path: 'sh'
             args: ['-c', 'sleep {{ccp_debug_sleep}}']
-        ensure:
-          <<: *ccp_destroy_2_cluster
   # Similar to the on_failure blocks, the final cleanup needs to be both clusters as well
-  - *ccp_destroy_2_cluster
+  ensure:
+    <<: *ccp_destroy_2_cluster
 
 - name: DPM_backup-restore
   plan:
@@ -2571,8 +2550,6 @@ jobs:
     file: ccp_src/ci/tasks/gen_cluster.yml
     params:
       <<: *ccp_gen_cluster_default_params
-    on_failure:
-      <<: *ccp_destroy
   - task: run_tests
     tags: ["ccp"]
     file: gpdb_src/concourse/tasks/run_behave.yml
@@ -2581,7 +2558,8 @@ jobs:
       BEHAVE_FLAGS: --tags=backups,backup_and_restore_backups,backup_and_restore_restores,restores --tags=-nbuonly --tags=-ddonly
     on_failure:
       <<: *debug_sleep
-  - *ccp_destroy
+  ensure:
+    <<: *ccp_destroy
 
 - name: gate_dpm_end
   plan:
@@ -2800,8 +2778,6 @@ jobs:
     file: ccp_src/ci/tasks/gen_cluster.yml
     params:
       <<: *ccp_gen_cluster_default_params
-    on_failure:
-      <<: *ccp_destroy
   - task: run_tests
     tags: ["ccp"]
     file: gpdb_src/concourse/tasks/run_tinc.yml
@@ -2810,7 +2786,8 @@ jobs:
       TINC_TARGET: filerep_end_to_end_full_mirror
     on_failure:
       <<: *debug_sleep
-  - *ccp_destroy
+  ensure:
+    <<: *ccp_destroy
 
 - name: cs_filerep_e2e_incr_mirror
   plan:
@@ -2842,8 +2819,6 @@ jobs:
     file: ccp_src/ci/tasks/gen_cluster.yml
     params:
       <<: *ccp_gen_cluster_default_params
-    on_failure:
-      <<: *ccp_destroy
   - task: run_tests
     tags: ["ccp"]
     file: gpdb_src/concourse/tasks/run_tinc.yml
@@ -2852,7 +2827,8 @@ jobs:
       TINC_TARGET: filerep_end_to_end_incr_mirror
     on_failure:
       <<: *debug_sleep
-  - *ccp_destroy
+  ensure:
+    <<: *ccp_destroy
 
 - name: cs_filerep_e2e_full_primary
   plan:
@@ -2883,8 +2859,6 @@ jobs:
     file: ccp_src/ci/tasks/gen_cluster.yml
     params:
       <<: *ccp_gen_cluster_default_params
-    on_failure:
-      <<: *ccp_destroy
   - task: run_tests
     tags: ["ccp"]
     file: gpdb_src/concourse/tasks/run_tinc.yml
@@ -2893,7 +2867,8 @@ jobs:
       TINC_TARGET: filerep_end_to_end_full_primary
     on_failure:
       <<: *debug_sleep
-  - *ccp_destroy
+  ensure:
+    <<: *ccp_destroy
 
 - name: cs_filerep_e2e_incr_primary
   plan:
@@ -2925,8 +2900,6 @@ jobs:
     file: ccp_src/ci/tasks/gen_cluster.yml
     params:
       <<: *ccp_gen_cluster_default_params
-    on_failure:
-      <<: *ccp_destroy
   - task: run_tests
     tags: ["ccp"]
     file: gpdb_src/concourse/tasks/run_tinc.yml
@@ -2935,7 +2908,8 @@ jobs:
       TINC_TARGET: filerep_end_to_end_incr_primary
     on_failure:
       <<: *debug_sleep
-  - *ccp_destroy
+  ensure:
+    <<: *ccp_destroy
 
 - name: gate_filerep_end
   plan:


### PR DESCRIPTION
Hopefully, this will help reduce the number of clusters leaked by ccp jobs. This places the ending `ccp_destroy` in an ensure block so that it will always run at the end of the job, and will run if any task before it errors out, fails, or is canceled by the user. I removed calls to `ccp_destroy` in the debug sleep anchors and gen_cluster steps because this should take care of destroying the cluster in both cases. 

Please take a look at your jobs and see if everything looks ok. The changes to each job are fairly minimal.