### PR TITLE
Greenplum specific background worker framework

### DIFF
--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -33,7 +33,8 @@ WANTED_DIRS += \
 		gp_inject_fault \
 		gp_cancel_query \
 		indexscan \
-    passwordcheck
+		passwordcheck \
+		bgworker_example
 
 ifeq ($(with_openssl),yes)
 WANTED_DIRS += sslinfo

--- a/contrib/bgworker_example/Makefile
+++ b/contrib/bgworker_example/Makefile
@@ -1,0 +1,14 @@
+# contrib/bgworker_example/Makefile
+
+MODULES = bgworker_example
+
+ifdef USE_PGXS
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
+else
+subdir = contrib/bgworker_example
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif

--- a/contrib/bgworker_example/bgworker_example.c
+++ b/contrib/bgworker_example/bgworker_example.c
@@ -1,0 +1,110 @@
+/* ------------------------------------------------------------------------
+ *
+ * bgworker_example.c
+ *		Sample implementation of workers for Greenplum Database specific
+ *		bgworker framework.
+ *
+ * Copyright (c) 2017-Present Pivotal Software, Inc.
+ *
+ * IDENTIFICATION
+ *		contrib/bgworker_example/bgworker_example.c
+ *
+ * ------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+/* These are always necessary for a bgworker */
+#include "miscadmin.h"
+#include "nodes/pg_list.h"
+#include "utils/timestamp.h"
+#include "postmaster/bgworker.h"
+#include "storage/ipc.h"
+#include "storage/latch.h"
+#include "storage/lwlock.h"
+#include "storage/proc.h"
+#include "storage/shmem.h"
+
+PG_MODULE_MAGIC;
+
+void	_PG_init(void);
+
+static bool	got_sigterm = false;
+
+static void
+bgworker_example_sigterm(SIGNAL_ARGS)
+{
+	int			save_errno = errno;
+
+	got_sigterm = true;
+	if (MyProc)
+		SetLatch(&MyProc->procLatch);
+
+	errno = save_errno;
+}
+
+static void
+bgworker_example_sighup(SIGNAL_ARGS)
+{
+	elog(LOG, "got sighup!");
+	if (MyProc)
+		SetLatch(&MyProc->procLatch);
+}
+
+static void
+bgworker_example_main(void *main_arg)
+{
+	BackgroundWorkerUnblockSignals();
+	
+	while (!got_sigterm)
+	{
+
+		int		rc;
+
+		/*
+		 * Background workers mustn't call usleep() or any direct equivalent:
+		 * instead, they may wait on their process latch, which sleeps as
+		 * necessary, but is awakened if postmaster dies.  That way the
+		 * background process goes away immediately in an emergency.
+		 */
+		elog(LOG, "In bgworker process %s %p", MyBgworkerEntry->bgw_name, MyProc);
+		rc = WaitLatch(&MyProc->procLatch,
+					   WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,
+					   1000L);
+		ResetLatch(&MyProc->procLatch);
+
+		/* emergency bailout if postmaster has died */
+		if (rc & WL_POSTMASTER_DEATH)
+			proc_exit(1);
+	}
+
+	proc_exit(1);
+}
+
+/*
+ * Entrypoint of this module.
+ *
+ * We register three worker processes here, to demonstrate how that can be done.
+ */
+void
+_PG_init(void)
+{
+	BackgroundWorker	worker;
+
+	elog(LOG, "_PG_init from bgworker_example");
+
+	/* register the worker processes.  These values are common for both */
+	worker.bgw_flags = BGWORKER_SHMEM_ACCESS;
+	worker.bgw_main = bgworker_example_main;
+	worker.bgw_sighup = bgworker_example_sighup;
+	worker.bgw_sigterm = bgworker_example_sigterm;
+	worker.bgw_restart_time = 5;
+
+	worker.bgw_name = "Example worker 1";
+	RegisterBackgroundWorker(&worker);
+
+	worker.bgw_name = "Example worker 2";
+	RegisterBackgroundWorker(&worker);
+
+	worker.bgw_name = "Example worker 3";
+	RegisterBackgroundWorker(&worker);
+}

--- a/src/backend/postmaster/Makefile
+++ b/src/backend/postmaster/Makefile
@@ -16,6 +16,6 @@ override CPPFLAGS := -I$(libpq_srcdir) $(CPPFLAGS)
 OBJS = autovacuum.o bgwriter.o checkpointer.o fork_process.o seqserver.o pgarch.o pgstat.o \
 	postmaster.o primary_mirror_mode.o primary_mirror_transition_client.o syslogger.o \
 	perfmon.o backoff.o perfmon_segmentinfo.o \
-	sendalert.o alertseverity.o autostats.o walwriter.o
+	sendalert.o alertseverity.o autostats.o walwriter.o bgworker.o
 
 include $(top_srcdir)/src/backend/common.mk

--- a/src/backend/postmaster/bgworker.c
+++ b/src/backend/postmaster/bgworker.c
@@ -1,0 +1,663 @@
+/*-------------------------------------------------------------------------
+ * bgworker.c
+ *		Greenplum Database specific pluggable background workers framework
+ *
+ * Copyright (c) 2017-Present Pivotal Software, Inc.
+ *
+ * IDENTIFICATION
+ *	  src/backend/postmaster/bgworker.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include <unistd.h>
+
+#include "libpq/pqsignal.h"
+#include "miscadmin.h"
+#include "cdb/cdbvars.h"
+#include "nodes/pg_list.h"
+#include "postmaster/postmaster.h"
+#include "postmaster/fork_process.h"
+#include "postmaster/bgworker.h"
+#include "storage/pmsignal.h"
+#include "storage/ipc.h"
+#include "storage/proc.h"
+#include "tcop/tcopprot.h"
+#include "utils/timestamp.h"
+#include "utils/ps_status.h"
+
+/*
+ * The postmaster's list of registered background workers, in private memory.
+ */
+List				*BackgroundWorkerList = NIL;
+BackgroundWorker	*MyBgworkerEntry = NULL;
+bool				StartWorkerNeeded = true;
+bool				HaveCrashedWorker = false;
+
+/*
+ * Determine how long should we let ServerLoop sleep.
+ *
+ * In normal conditions we wait at most one minute, to ensure that the other
+ * background tasks handled by ServerLoop get done even when no requests are
+ * arriving.  However, if there are background workers waiting to be started,
+ * we don't actually sleep so that they are quickly serviced.
+ */
+void
+DetermineSleepTime(struct timeval *timeout, int shutdown)
+{
+	TimestampTz next_wakeup = 0;
+
+	/*
+	 * Normal case: either there are no background workers at all, or we're in
+	 * a shutdown sequence (during which we ignore bgworkers altogether).
+	 */
+	if (shutdown > 0 ||
+		(!StartWorkerNeeded && !HaveCrashedWorker))
+	{
+		timeout->tv_sec = 60;
+		timeout->tv_usec = 0;
+		return;
+	}
+
+	if (StartWorkerNeeded)
+	{
+		timeout->tv_sec = 0;
+		timeout->tv_usec = 0;
+		return;
+	}
+
+	if (HaveCrashedWorker)
+	{
+		ListCell   *siter;
+
+		/*
+		 * When there are crashed bgworkers, we sleep just long enough that
+		 * they are restarted when they request to be.	Scan the list to
+		 * determine the minimum of all wakeup times according to most recent
+		 * crash time and requested restart interval.
+		 */
+		foreach(siter, BackgroundWorkerList)
+		{
+			RegisteredBgWorker *rw;
+			TimestampTz this_wakeup;
+
+			rw = lfirst(siter);
+
+			if (rw->rw_crashed_at == 0)
+				continue;
+
+			if (rw->rw_worker.bgw_restart_time == BGW_NEVER_RESTART)
+				continue;
+
+			this_wakeup = TimestampTzPlusMilliseconds(rw->rw_crashed_at,
+													  1000L * rw->rw_worker.bgw_restart_time);
+			if (next_wakeup == 0 || this_wakeup < next_wakeup)
+				next_wakeup = this_wakeup;
+		}
+	}
+
+	if (next_wakeup != 0)
+	{
+		int			microsecs;
+
+		TimestampDifference(GetCurrentTimestamp(), next_wakeup,
+							&timeout->tv_sec, &microsecs);
+		timeout->tv_usec = microsecs;
+
+		/* Ensure we don't exceed one minute */
+		if (timeout->tv_sec > 60)
+		{
+			timeout->tv_sec = 60;
+			timeout->tv_usec = 0;
+		}
+	}
+	else
+	{
+		timeout->tv_sec = 60;
+		timeout->tv_usec = 0;
+	}
+}
+
+static void
+bgworker_quickdie(SIGNAL_ARGS)
+{
+	sigaddset(&BlockSig, SIGQUIT);	/* prevent nested calls */
+	PG_SETMASK(&BlockSig);
+
+	/*
+	 * * We DO NOT want to run proc_exit() callbacks -- we're here because
+	 * shared memory may be corrupted, so we don't want to try to clean up our
+	 * transaction.  Just nail the windows shut and get out of town.  Now that
+	 * there's an atexit callback to prevent third-party code from breaking
+	 * things by calling exit() directly, we have to reset the callbacks
+	 * explicitly to make this work as intended.
+	 */
+	on_exit_reset();
+
+	/*
+	 * Note we do exit(0) here, not exit(2) like quickdie.	The reason is that
+	 * we don't want to be seen this worker as independently crashed, because
+	 * then postmaster would delay restarting it again afterwards. If some
+	 * idiot DBA manually sends SIGQUIT to a random bgworker, the "dead man
+	 * switch" will ensure that postmaster sees this as a crash.
+	 */
+	exit(0);
+}
+
+/*
+ * Standard SIGTERM handler for background workers
+ */
+static void
+bgworker_die(SIGNAL_ARGS)
+{
+	PG_SETMASK(&BlockSig);
+
+	ereport(FATAL,
+			(errcode(ERRCODE_ADMIN_SHUTDOWN),
+			 errmsg("terminating background worker \"%s\" due to administrator command",
+					MyBgworkerEntry->bgw_name)));
+}
+
+static void
+do_start_bgworker(void)
+{
+	sigjmp_buf	local_sigjmp_buf;
+	char		buf[MAXPGPATH];
+	BackgroundWorker *worker = MyBgworkerEntry;
+
+	if (worker == NULL)
+		elog(FATAL, "unable to find bgworker entry");
+
+	/* we are a postmaster subprocess now */
+	IsUnderPostmaster = true;
+	IsBackgroundWorker = true;
+
+	/* reset MyProcPid */
+	MyProcPid = getpid();
+
+	/* record Start Time for logging */
+	MyStartTime = time(NULL);
+
+	/* Identify myself via ps */
+	snprintf(buf, MAXPGPATH, "bgworker: %s", worker->bgw_name);
+	init_ps_display(buf, "", "", "");
+
+	SetProcessingMode(InitProcessing);
+
+	/* Apply PostAuthDelay */
+	if (PostAuthDelay > 0)
+		pg_usleep(PostAuthDelay * 1000000L);
+
+	/*
+	 * If possible, make this process a group leader, so that the postmaster
+	 * can signal any child processes too.
+	 */
+#ifdef HAVE_SETSID
+	if (setsid() < 0)
+		elog(FATAL, "setsid() failed: %m");
+#endif
+
+	/*
+	 * Set up signal handlers.
+	 *
+	 * Bgworker does not support connection now
+	 */
+	pqsignal(SIGINT, SIG_IGN);
+	pqsignal(SIGUSR1, SIG_IGN);
+	pqsignal(SIGFPE, SIG_IGN);
+
+	/* SIGTERM and SIGHUP are configurable */
+	if (worker->bgw_sigterm)
+		pqsignal(SIGTERM, worker->bgw_sigterm);
+	else
+		pqsignal(SIGTERM, bgworker_die);
+
+	if (worker->bgw_sighup)
+		pqsignal(SIGHUP, worker->bgw_sighup);
+	else
+		pqsignal(SIGHUP, SIG_IGN);
+
+	pqsignal(SIGQUIT, bgworker_quickdie);
+	pqsignal(SIGALRM, SIG_IGN);
+	pqsignal(SIGPIPE, SIG_IGN);
+	pqsignal(SIGUSR2, SIG_IGN);
+	pqsignal(SIGCHLD, SIG_DFL);
+
+	/*
+	 * If an exception is encountered, processing resumes here.
+	 *
+	 * See notes in postgres.c about the design of this coding.
+	 */
+	if (sigsetjmp(local_sigjmp_buf, 1) != 0)
+	{
+		/* Since not using PG_TRY, must reset error stack by hand */
+		error_context_stack = NULL;
+
+		/* Prevent interrupts while cleaning up */
+		HOLD_INTERRUPTS();
+
+		/* Report the error to the server log */
+		EmitErrorReport();
+
+		/*
+		 * Do we need more cleanup here?  For shmem-connected bgworkers, we
+		 * will call InitProcess below, which will install ProcKill as exit
+		 * callback.  That will take care of releasing locks, etc.
+		 */
+
+		/* and go away */
+		proc_exit(1);
+	}
+
+	/* We can now handle ereport(ERROR) */
+	PG_exception_stack = &local_sigjmp_buf;
+
+	/* Early initialization */
+	BaseInit();
+
+	/*		
+	 * If necessary, create a per-backend PGPROC struct in shared memory,		
+	 * except in the EXEC_BACKEND case where this was done in		
+	 * SubPostmasterMain. We must do this before we can use LWLocks (and in		
+	 * the EXEC_BACKEND case we already had to do some stuff with LWLocks).		
+	 */		
+#ifndef EXEC_BACKEND		
+	if (worker->bgw_flags & BGWORKER_SHMEM_ACCESS)		
+		InitProcess();		
+#endif
+
+	/*
+	 * Now invoke the user-defined worker code
+	 */
+	worker->bgw_main(worker->bgw_main_arg);
+
+	/* ... and if it returns, we're done */
+	proc_exit(0);
+}
+
+/*
+ * Start a new bgworker.
+ * Starting time conditions must have been checked already.
+ *
+ * This code is heavily based on autovacuum.c, q.v.
+ */
+static void
+start_bgworker(RegisteredBgWorker *rw)
+{
+	pid_t		worker_pid;
+
+	ereport(LOG,
+			(errmsg("starting background worker process \"%s\"",
+					rw->rw_worker.bgw_name)));
+
+#ifndef EXEC_BACKEND
+	switch ((worker_pid = fork_process()))
+	{
+		case -1:
+			ereport(LOG,
+					(errmsg("could not fork worker process: %m")));
+			return;
+		case 0:
+			/* in postmaster child ... */
+			/* Close the postmaster's sockets */
+			ClosePostmasterPorts(false);
+			/* Lose the postmaster's on-exit routines */
+			on_exit_reset();
+
+			/* Do NOT release postmaster's working memory context */
+			MyBgworkerEntry = &rw->rw_worker;
+
+			do_start_bgworker();
+			break;
+		default:
+			rw->rw_pid = worker_pid;
+	}
+#endif
+}
+
+
+/*
+ * If the time is right, start one background worker.
+ *
+ * As a side effect, the bgworker control variables are set or reset whenever
+ * there are more workers to start after this one, and whenever the overall
+ * system state requires it.
+ */
+void
+StartOneBackgroundWorker(bool fatalError, int pmState, int targetState)
+{
+	ListCell   *iter;
+	TimestampTz now = 0;
+
+	if (fatalError)
+	{
+		StartWorkerNeeded = false;
+		HaveCrashedWorker = false;
+		return;					/* not yet */
+	}
+
+	HaveCrashedWorker = false;
+
+	foreach(iter, BackgroundWorkerList)
+	{
+		RegisteredBgWorker *rw;
+
+		rw = lfirst(iter);
+
+		/* already running? */
+		if (rw->rw_pid != 0)
+			continue;
+
+		/*
+		 * I restarted (unless on registration it specified it doesn't want to
+		 * be restarted at all).  Check how long ago did a crash last happen.
+		 * If the last crash is too recent, don't start it right away; let it
+		 * be restarted once enough time has passed.
+		 */
+		if (rw->rw_crashed_at != 0)
+		{
+			if (rw->rw_worker.bgw_restart_time == BGW_NEVER_RESTART)
+				continue;
+			if (now == 0)
+				now = GetCurrentTimestamp();
+
+			if (!TimestampDifferenceExceeds(rw->rw_crashed_at, now,
+											rw->rw_worker.bgw_restart_time * 1000))
+			{
+				HaveCrashedWorker = true;
+				continue;
+			}
+		}
+		if (pmState == targetState)
+		{
+			/* reset crash time before calling assign_backendlist_entry */
+			rw->rw_crashed_at = 0;
+
+			/*
+			 * If necessary, allocate and assign the Backend element.  Note we
+			 * must do this before forking, so that we can handle out of
+			 * memory properly. If not connected, we don't need a Backend
+			 * element, but we still need a PMChildSlot.
+			 */
+			rw->rw_child_slot = MyPMChildSlot = AssignPostmasterChildSlot();
+			start_bgworker(rw); /* sets rw->rw_pid */
+
+			/*
+			 * Have ServerLoop call us again.  Note that there might not
+			 * actually *be* another runnable worker, but we don't care all
+			 * that much; we will find out the next time we run.
+			 */
+			StartWorkerNeeded = true;
+			return;
+		}
+	}
+	/* no runnable worker found */
+	StartWorkerNeeded = false;
+}
+
+/*
+ * Send a signal to bgworkers
+ */
+bool
+SignalUnconnectedWorkers(int signal, void (*signal_child) (pid_t, int))
+{
+	ListCell   *iter;
+	bool		signaled = false;
+
+	foreach(iter, BackgroundWorkerList)
+	{
+		RegisteredBgWorker *rw;
+
+		rw = lfirst(iter);
+
+		if (rw->rw_pid == 0)
+			continue;
+		ereport(DEBUG4,
+				(errmsg_internal("sending signal %d to process %d",
+								 signal, (int) rw->rw_pid)));
+		(*signal_child) (rw->rw_pid, signal);
+		signaled = true;
+	}
+	return signaled;
+}
+
+/*
+ * Scan the bgworkers list and see if the given PID (which has just stopped
+ * or crashed) is in it.  Handle its shutdown if so, and return true.  If not a
+ * bgworker, return false.
+ *
+ * This is heavily based on CleanupBackend.  One important difference is that
+ * we don't know yet that the dying process is a bgworker, so we must be silent
+ * until we're sure it is.
+ */
+bool
+CleanupBackgroundWorker(int pid, int exitstatus, void (*handleChildCrash) (int, int, const char *),
+						void(*logChildExit) (int, const char *, int, int))
+{
+	char		namebuf[MAXPGPATH];
+	ListCell   *iter;
+
+	foreach(iter, BackgroundWorkerList)
+	{
+		RegisteredBgWorker *rw;
+
+		rw = lfirst(iter);
+
+		if (rw->rw_pid != pid)
+			continue;
+
+		snprintf(namebuf, MAXPGPATH, "%s: %s", _("worker process"),
+				 rw->rw_worker.bgw_name);
+
+		/* Delay restarting any bgworker that exits with a nonzero status. */
+		if (!((exitstatus) == 0))
+			rw->rw_crashed_at = GetCurrentTimestamp();
+		else
+			rw->rw_crashed_at = 0;
+
+		/*
+		 * Additionally, for shared-memory-connected workers, just like a
+		 * backend, any exit status other than 0 or 1 is considered a crash
+		 * and causes a system-wide restart.
+		 */
+		if (rw->rw_worker.bgw_flags & BGWORKER_SHMEM_ACCESS)
+		{
+			if (!((exitstatus) == 0) && !(WIFEXITED(exitstatus) && WEXITSTATUS(exitstatus) == 1))
+			{
+				rw->rw_crashed_at = GetCurrentTimestamp();
+				(*handleChildCrash) (pid, exitstatus, namebuf);
+				return true;
+			}
+		}
+		if (!ReleasePostmasterChildSlot(rw->rw_child_slot))
+		{
+			/*
+			 * Uh-oh, the child failed to clean itself up.	Treat as a crash
+			 * after all.
+			 */
+			rw->rw_crashed_at = GetCurrentTimestamp();
+			(*handleChildCrash) (pid, exitstatus, namebuf);
+			return true;
+		}
+		rw->rw_pid = 0;
+		rw->rw_child_slot = 0;
+		(*logChildExit) (LOG, namebuf, pid, exitstatus);
+		return true;
+	}
+
+	return false;
+}
+
+/*
+ * Count up number of worker processes that did not request backend connections
+ */
+int
+CountUnconnectedWorkers(void)
+{
+	ListCell   *iter;
+	int			cnt = 0;
+
+	foreach(iter, BackgroundWorkerList)
+	{
+		RegisteredBgWorker *rw;
+
+		rw = lfirst(iter);
+
+		if (rw->rw_pid == 0)
+			continue;
+
+		cnt++;
+	}
+	return cnt;
+}
+
+/*
+ * Register a new background worker.
+ *
+ * This can only be called in the _PG_init function of a module library
+ * that's loaded by shared_preload_libraries; otherwise it has no effect.
+ */
+void
+RegisterBackgroundWorker(BackgroundWorker *worker)
+{
+	RegisteredBgWorker *rw;
+	int			namelen = strlen(worker->bgw_name);
+
+	if (!IsUnderPostmaster)
+		ereport(LOG,
+				(errmsg("registering background worker: %s", worker->bgw_name)));
+
+	if (Gp_role == GP_ROLE_UTILITY)
+		return;
+
+	if (!process_shared_preload_libraries_in_progress)
+	{
+		if (!IsUnderPostmaster)
+			ereport(LOG,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("background worker \"%s\": must be registered in shared_preload_libraries",
+							worker->bgw_name)));
+		return;
+	}
+
+	if ((worker->bgw_restart_time < 0 &&
+		 worker->bgw_restart_time != BGW_NEVER_RESTART) ||
+		(worker->bgw_restart_time > USECS_PER_DAY / 1000))
+	{
+		if (!IsUnderPostmaster)
+			ereport(LOG,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("background worker \"%s\": invalid restart interval",
+							worker->bgw_name)));
+		return;
+	}
+
+	/*
+	 * Copy the registration data into the registered workers list.
+	 */
+	rw = malloc(sizeof(RegisteredBgWorker) + namelen + 1);
+	if (rw == NULL)
+	{
+		ereport(LOG,
+				(errcode(ERRCODE_OUT_OF_MEMORY),
+				 errmsg("out of memory")));
+		return;
+	}
+	rw->rw_worker = *worker;
+	rw->rw_worker.bgw_name = ((char *) rw) + sizeof(RegisteredBgWorker);
+	strlcpy(rw->rw_worker.bgw_name, worker->bgw_name, namelen + 1);
+	rw->rw_pid = 0;
+	rw->rw_child_slot = 0;
+	rw->rw_crashed_at = 0;
+
+	BackgroundWorkerList = lappend(BackgroundWorkerList, rw);
+}
+
+/*
+ * Return the number of background workers registered that have at least
+ * one of the passed flag bits set.
+ */
+static int
+GetNumRegisteredBackgroundWorkers(int flags)
+{
+	ListCell   *iter;
+	int			count = 0;
+
+	foreach(iter, BackgroundWorkerList)
+	{
+		RegisteredBgWorker *rw;
+
+		rw = lfirst(iter);
+
+		if (flags != 0 &&
+			!(rw->rw_worker.bgw_flags & flags))
+			continue;
+
+		count++;
+	}
+
+	return count;
+}
+
+/*
+ * Return the number of bgworkers that need to have PGPROC entries.
+ */
+int
+GetNumShmemAttachedBgworkers(void)
+{
+	return GetNumRegisteredBackgroundWorkers(BGWORKER_SHMEM_ACCESS);
+}
+
+void
+BackgroundWorkerUnblockSignals(void)
+{
+	PG_SETMASK(&UnBlockSig);
+}
+
+void
+HandleBgworkerCrash(int pid, void (*signal_child) (pid_t, int), bool fatalError, int sendStop)
+{
+	ListCell   *cell;
+
+	/* Process background workers. */
+	foreach(cell, BackgroundWorkerList)
+	{
+		RegisteredBgWorker *rw;
+
+		rw = lfirst(cell);
+		if (rw->rw_pid == 0)
+			continue;		/* not running */
+		if (rw->rw_pid == pid)
+		{
+			/*
+			 * Found entry for freshly-dead worker, so remove it.
+			 */
+			(void) ReleasePostmasterChildSlot(rw->rw_child_slot);
+			rw->rw_pid = 0;
+			rw->rw_child_slot = 0;
+			/* don't reset crashed_at */
+			/* Keep looping so we can signal remaining workers */
+		}
+		else
+		{
+			/*
+			 * This worker is still alive.	Unless we did so already, tell it
+			 * to commit hara-kiri.
+			 *
+			 * SIGQUIT is the special signal that says exit without proc_exit
+			 * and let the user know what's going on. But if SendStop is set
+			 * (-s on command line), then we send SIGSTOP instead, so that we
+			 * can get core dumps from all backends by hand.
+			 */
+			if (!fatalError)
+			{
+				ereport(DEBUG2,
+							(errmsg_internal("sending %s to process %d",
+											 (sendStop ? "SIGSTOP" : "SIGQUIT"),
+											 (int) rw->rw_pid)));
+				(*signal_child)(rw->rw_pid, (sendStop ? SIGSTOP : SIGQUIT));
+			}
+		}
+	}
+}

--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -43,6 +43,7 @@
 #include "commands/async.h"
 #include "miscadmin.h"
 #include "postmaster/autovacuum.h"
+#include "postmaster/bgworker.h"
 #include "postmaster/fts.h"
 #include "replication/syncrep.h"
 #include "replication/walsender.h"
@@ -179,6 +180,7 @@ InitProcGlobal(int mppLocalProcessCounter)
 	PGPROC	   *procs;
 	int			i;
 	bool		found;
+	int			numBgworkers;
 
 	/* Create the ProcGlobal shared structure */
 	ProcGlobal = (PROC_HDR *)
@@ -199,6 +201,7 @@ InitProcGlobal(int mppLocalProcessCounter)
 	 */
 	ProcGlobal->freeProcs = NULL;
 	ProcGlobal->autovacFreeProcs = NULL;
+	ProcGlobal->bgworkerFreeProcs = NULL; /* Greenplum specific bgworker */
 
 	ProcGlobal->spins_per_delay = DEFAULT_SPINS_PER_DELAY;
 
@@ -236,6 +239,28 @@ InitProcGlobal(int mppLocalProcessCounter)
 		InitSharedLatch(&(procs[i].procLatch));
 		procs[i].links.next = (SHM_QUEUE *) ProcGlobal->autovacFreeProcs;
 		ProcGlobal->autovacFreeProcs = &procs[i];
+	}
+
+	/*
+	 * Greenplum specific bgworker
+	 */
+	numBgworkers = GetNumShmemAttachedBgworkers();
+	if (numBgworkers > 0)
+	{
+		procs = (PGPROC *) ShmemAlloc(numBgworkers * sizeof(PGPROC));
+		if (!procs)
+			ereport(FATAL,
+						(errcode(ERRCODE_OUT_OF_MEMORY),
+	 					 errmsg("out of shared memory")));
+		MemSet(procs, 0, numBgworkers * sizeof(PGPROC));
+		for (i = 0; i < numBgworkers; i++)
+		{
+			/* PGPROC for bgworker, add to bgworkerFreeProcs list */
+			PGSemaphoreCreate(&(procs[i].sem));
+			InitSharedLatch(&(procs[i].procLatch));
+			procs[i].links.next = (SHM_QUEUE *)ProcGlobal->bgworkerFreeProcs;
+			ProcGlobal->bgworkerFreeProcs = &procs[i];
+		}
 	}
 
 	MemSet(AuxiliaryProcs, 0, NUM_AUXILIARY_PROCS * sizeof(PGPROC));
@@ -299,6 +324,8 @@ InitProcess(void)
 
 	if (IsAutoVacuumWorkerProcess())
 		MyProc = procglobal->autovacFreeProcs;
+	else if (IsBackgroundWorker) /* Greenplum specific bgworker */
+		MyProc = procglobal->bgworkerFreeProcs;
 	else
 		MyProc = procglobal->freeProcs;
 
@@ -306,6 +333,8 @@ InitProcess(void)
 	{
 		if (IsAutoVacuumWorkerProcess())
 			procglobal->autovacFreeProcs = (PGPROC *) MyProc->links.next;
+		else if (IsBackgroundWorker)  /* Greenplum specific bgworker */
+			procglobal->bgworkerFreeProcs = (PGPROC *)MyProc->links.next;		
 		else
 			procglobal->freeProcs = (PGPROC *) MyProc->links.next;
 
@@ -804,6 +833,11 @@ ProcKill(int code, Datum arg)
 	{
 		proc->links.next = (SHM_QUEUE *) procglobal->autovacFreeProcs;
 		procglobal->autovacFreeProcs = proc;
+	}
+	else if (IsBackgroundWorker) /* Greenplum specific bgworker */
+	{
+		proc->links.next = (SHM_QUEUE *) procglobal->bgworkerFreeProcs;
+		procglobal->bgworkerFreeProcs = proc;
 	}
 	else
 	{

--- a/src/backend/utils/init/globals.c
+++ b/src/backend/utils/init/globals.c
@@ -93,6 +93,7 @@ pid_t		PostmasterPid = 0;
 bool		IsPostmasterEnvironment = false;
 bool		IsUnderPostmaster = false;
 bool		IsBinaryUpgrade = false;
+bool		IsBackgroundWorker = false; /* Greenplum specific bgworker */
 
 bool		ExitOnAnyError = false;
 

--- a/src/include/miscadmin.h
+++ b/src/include/miscadmin.h
@@ -201,6 +201,7 @@ do { \
 extern pid_t PostmasterPid;
 extern bool IsPostmasterEnvironment;
 extern PGDLLIMPORT bool IsUnderPostmaster;
+extern bool IsBackgroundWorker;  /* Greenplum specific bgworker */
 extern bool IsBinaryUpgrade;
 
 /* Are we binary-upgrading a QE node? */

--- a/src/include/postmaster/bgworker.h
+++ b/src/include/postmaster/bgworker.h
@@ -1,0 +1,93 @@
+/*-------------------------------------------------------------------------
+ * bgworker.h
+ *		Greenplum Database specific pluggable background workers interface.
+ * This is a GPDB specific implementation of background workers, with limited
+ * function. Can be replaced by postgres bgworker once merge work comes to PG9.3
+ *
+ * A background worker is a process able to run arbitrary, user-supplied code.
+ *
+ * Any external module loaded via shared_preload_libraries can register a
+ * worker. The worker process is forked from the postmaster and runs the
+ * user-supplied "main" function. Workers can remain active indefinitely,
+ * but will be terminated if a shutdown or crash occurs.
+ *
+ * If the fork() call fails in the postmaster, it will try again later.  Note
+ * that the failure can only be transient (fork failure due to high load,
+ * memory pressure, too many processes, etc). A worker which exits with
+ * a return code of 0 will be restarted immediately, A worker which exits with
+ * other return code will be restarted after the configured restart interval
+ * (unless that interval is BGW_NEVER_RESTART).
+ *
+ * Note that there might be more than one worker in a database concurrently,
+ * and the same module may request more than one worker running the same (or
+ * different) code.
+ *
+ * Copyright (c) 2017-Present Pivotal Software, Inc.
+ *
+ * IDENTIFICATION
+ *		src/include/postmaster/bgworker.h
+ *--------------------------------------------------------------------
+ */
+#ifndef BGWORKER_H
+#define BGWORKER_H
+
+/*
+ * Pass this flag to have your worker be able to connect to shared memory.
+ */
+#define BGWORKER_SHMEM_ACCESS		0x0001
+#define BGW_NEVER_RESTART			-1
+
+typedef void (*bgworker_main_type) (void *main_arg);
+typedef void (*bgworker_sighdlr_type) (SIGNAL_ARGS);
+
+
+typedef struct BackgroundWorker
+{
+	char	   *bgw_name;
+	int			bgw_flags;
+	int			bgw_restart_time;	/* in seconds, or BGW_NEVER_RESTART */
+	bgworker_main_type bgw_main;
+	void	   *bgw_main_arg;
+	bgworker_sighdlr_type bgw_sighup;
+	bgworker_sighdlr_type bgw_sigterm;
+} BackgroundWorker;
+
+/*
+ * List of background workers.
+ *
+ * GPDB bgworker specific: Database connection is not supported now
+ */
+typedef struct RegisteredBgWorker
+{
+	BackgroundWorker rw_worker; /* its registry entry */
+	pid_t		rw_pid;			/* 0 if not running */
+	int			rw_child_slot;
+	TimestampTz rw_crashed_at;	/* if not 0, time it last crashed */
+#ifdef EXEC_BACKEND
+	int			rw_cookie;
+#endif
+} RegisteredBgWorker;
+
+extern List *BackgroundWorkerList;
+extern BackgroundWorker *MyBgworkerEntry;
+
+extern bool HaveCrashedWorker;
+extern bool StartWorkerNeeded;
+
+extern void StartOneBackgroundWorker(bool fatalError, int, int);
+extern void DetermineSleepTime(struct timeval *timeout, int shutdown);
+extern bool SignalUnconnectedWorkers(int signal, void (*signal_child) (pid_t, int));
+extern bool CleanupBackgroundWorker(int pid, int exitstatus, void (*) (int, int, const char *), void (*) (int, const char *, int, int));
+extern void HandleBgworkerCrash(int pid, void (*signal_child) (pid_t, int), bool fatalError, int sendStop);
+extern int	CountUnconnectedWorkers(void);
+extern void RegisterBackgroundWorker(BackgroundWorker *worker);
+
+#ifdef EXEC_BACKEND
+BackgroundWorker *find_bgworker_entry(int cookie);
+#endif
+
+extern void RegisterBackgroundWorker(BackgroundWorker * worker);
+extern int	GetNumShmemAttachedBgworkers(void);
+/* Block/unblock signals in a background worker process */
+extern void BackgroundWorkerUnblockSignals(void);
+#endif							/* BGWORKER_H */

--- a/src/include/storage/proc.h
+++ b/src/include/storage/proc.h
@@ -193,6 +193,8 @@ typedef struct PROC_HDR
 	PGPROC	   *freeProcs;
 	/* Head of list of autovacuum's free PGPROC structures */
 	PGPROC	   *autovacFreeProcs;
+	/* Head of list of Greenplum specific bgworker free PGPROC structures */
+	PGPROC	   *bgworkerFreeProcs;
 	/* Current shared estimate of appropriate spins_per_delay value */
 	int			spins_per_delay;
 

--- a/src/test/regress/GNUmakefile
+++ b/src/test/regress/GNUmakefile
@@ -138,7 +138,7 @@ installdirs-tests: installdirs
 
 # Get some extra C modules from contrib/spi...
 
-all: refint$(DLSUFFIX) autoinc$(DLSUFFIX) tablespace-setup includecheck hooktest
+all: refint$(DLSUFFIX) autoinc$(DLSUFFIX) tablespace-setup includecheck hooktest bgworker_example$(DLSUFFIX)
 
 refint$(DLSUFFIX): $(top_builddir)/contrib/spi/refint$(DLSUFFIX)
 	cp $< $@
@@ -152,6 +152,11 @@ $(top_builddir)/contrib/spi/refint$(DLSUFFIX): $(top_srcdir)/contrib/spi/refint.
 $(top_builddir)/contrib/spi/autoinc$(DLSUFFIX): $(top_srcdir)/contrib/spi/autoinc.c
 	$(MAKE) -C $(top_builddir)/contrib/spi autoinc$(DLSUFFIX)
 
+bgworker_example$(DLSUFFIX): $(top_builddir)/contrib/bgworker_example/bgworker_example$(DLSUFFIX)
+	cp $< $@
+
+$(top_builddir)/contrib/bgworker_example/bgworker_example$(DLSUFFIX): $(top_srcdir)/contrib/bgworker_example/bgworker_example.c
+	$(MAKE) -C $(top_builddir)/contrib/bgworker_example bgworker_example$(DLSUFFIX)
 
 # Tablespace setup
 

--- a/src/test/regress/expected/bgworker.out
+++ b/src/test/regress/expected/bgworker.out
@@ -1,0 +1,67 @@
+--
+-- Tests the Greenplum specific bgworker framework can launch
+-- processes registed in contrib/bgworker_example
+--
+-- start_ignore
+SELECT * FROM pg_sleep(3);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+DROP EXTERNAL WEB TABLE IF EXISTS find_bgworker CASCADE;
+NOTICE:  table "find_bgworker" does not exist, skipping
+CREATE EXTERNAL WEB TABLE find_bgworker(line text) EXECUTE 'ps aux | grep bgworker 2>&1' ON MASTER FORMAT 'TEXT';
+CREATE OR REPLACE VIEW check_number_bgworkers AS
+SELECT CASE WHEN count(*) = (3 * (SELECT count(*) AS segnum FROM gp_segment_configuration WHERE role = 'p' AND hostname IN (SELECT hostname FROM gp_segment_configuration WHERE role = 'p' AND content = -1))) THEN true ELSE false END AS ok
+FROM find_bgworker WHERE line NOT LIKE '%grep%';
+CREATE OR REPLACE VIEW number_bgworkers_should_be_zero AS
+SELECT CASE WHEN count(*) = 0 THEN true ELSE false END AS ok
+FROM find_bgworker WHERE line NOT LIKE '%grep%';
+-- end_ignore
+-- This checks number of started bgworker processes equals
+-- (number of workers registed in contrib/bgworker_example) * (postmasters on this host)
+SELECT * FROM check_number_bgworkers;
+ ok 
+----
+ t
+(1 row)
+
+-- Should return 'true'
+-- start_ignore
+DROP EXTERNAL WEB TABLE IF EXISTS kill_bgworker;
+NOTICE:  table "kill_bgworker" does not exist, skipping
+CREATE EXTERNAL WEB TABLE kill_bgworker(line text) EXECUTE 'kill $(ps aux | grep bgworker | grep -v grep | grep -v kill | awk ''{print $2}'') > /dev/null 2>&1' ON MASTER FORMAT 'TEXT';
+-- end_ignore
+SELECT * FROM kill_bgworker;
+ line 
+------
+(0 rows)
+
+SELECT * FROM number_bgworkers_should_be_zero;
+ ok 
+----
+ t
+(1 row)
+
+-- Should be true
+-- Wait for postmaster restart bgworker processes
+SELECT * FROM pg_sleep(6);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT * FROM check_number_bgworkers;
+ ok 
+----
+ t
+(1 row)
+
+-- Should return 'true'
+-- start_ignore
+DROP VIEW check_number_bgworkers;
+DROP VIEW number_bgworkers_should_be_zero;
+DROP EXTERNAL WEB TABLE IF EXISTS find_bgworker CASCADE;
+DROP EXTERNAL WEB TABLE IF EXISTS kill_bgworker CASCADE;
+-- end_ignore

--- a/src/test/regress/expected/bgworker.out
+++ b/src/test/regress/expected/bgworker.out
@@ -13,7 +13,7 @@ DROP EXTERNAL WEB TABLE IF EXISTS find_bgworker CASCADE;
 NOTICE:  table "find_bgworker" does not exist, skipping
 CREATE EXTERNAL WEB TABLE find_bgworker(line text) EXECUTE 'ps aux | grep bgworker 2>&1' ON MASTER FORMAT 'TEXT';
 CREATE OR REPLACE VIEW check_number_bgworkers AS
-SELECT CASE WHEN count(*) = (3 * (SELECT count(*) AS segnum FROM gp_segment_configuration WHERE role = 'p' AND hostname IN (SELECT hostname FROM gp_segment_configuration WHERE role = 'p' AND content = -1))) THEN true ELSE false END AS ok
+SELECT CASE WHEN count(*) = 3 THEN true ELSE false END AS ok
 FROM find_bgworker WHERE line NOT LIKE '%grep%';
 CREATE OR REPLACE VIEW number_bgworkers_should_be_zero AS
 SELECT CASE WHEN count(*) = 0 THEN true ELSE false END AS ok

--- a/src/test/regress/expected/bgworker_cleanup.out
+++ b/src/test/regress/expected/bgworker_cleanup.out
@@ -2,37 +2,35 @@
 -- Clean up for bgworker.sql tests
 -- 
 -- start_ignore
-\! gpconfig -r shared_preload_libraries
-20171129:16:17:57:005067 gpconfig:sdw:gpadmin-[INFO]:-completed successfully with parameters '-r shared_preload_libraries'
 \! cp $MASTER_DATA_DIRECTORY/postgresql.conf.bgworkertest.bak $MASTER_DATA_DIRECTORY/postgresql.conf
 \! rm -f $MASTER_DATA_DIRECTORY/postgresql.conf.bgworkertest.bak
 \! PGDATESTYLE="" gpstop -rai
-20171129:16:17:57:006512 gpstop:sdw:gpadmin-[INFO]:-Starting gpstop with args: -rai
-20171129:16:17:57:006512 gpstop:sdw:gpadmin-[INFO]:-Gathering information and validating the environment...
-20171129:16:17:57:006512 gpstop:sdw:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
-20171129:16:17:57:006512 gpstop:sdw:gpadmin-[INFO]:-Obtaining Segment details from master...
-20171129:16:17:57:006512 gpstop:sdw:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 6.0.0-alpha.0+dev.1581.g3cb8ea8 build dev'
-20171129:16:17:57:006512 gpstop:sdw:gpadmin-[INFO]:-There are 1 connections to the database
-20171129:16:17:57:006512 gpstop:sdw:gpadmin-[INFO]:-Commencing Master instance shutdown with mode='immediate'
-20171129:16:17:57:006512 gpstop:sdw:gpadmin-[INFO]:-Master host=sdw
-20171129:16:17:57:006512 gpstop:sdw:gpadmin-[INFO]:-Commencing Master instance shutdown with mode=immediate
-20171129:16:17:57:006512 gpstop:sdw:gpadmin-[INFO]:-Master segment instance directory=/home/gpadmin/gpdb5.data/master/gpseg-1
-20171129:16:17:58:006512 gpstop:sdw:gpadmin-[INFO]:-Attempting forceful termination of any leftover master process
-20171129:16:17:58:006512 gpstop:sdw:gpadmin-[INFO]:-Terminating processes for segment /home/gpadmin/gpdb5.data/master/gpseg-1
-20171129:16:17:58:006512 gpstop:sdw:gpadmin-[INFO]:-No standby master host configured
-20171129:16:17:58:006512 gpstop:sdw:gpadmin-[INFO]:-Commencing parallel segment instance shutdown, please wait...
-20171129:16:17:58:006512 gpstop:sdw:gpadmin-[INFO]:-0.00% of jobs completed
-20171129:16:18:00:006512 gpstop:sdw:gpadmin-[INFO]:-100.00% of jobs completed
-20171129:16:18:00:006512 gpstop:sdw:gpadmin-[INFO]:-----------------------------------------------------
-20171129:16:18:00:006512 gpstop:sdw:gpadmin-[INFO]:-   Segments stopped successfully      = 2
-20171129:16:18:00:006512 gpstop:sdw:gpadmin-[INFO]:-   Segments with errors during stop   = 0
-20171129:16:18:00:006512 gpstop:sdw:gpadmin-[INFO]:-----------------------------------------------------
-20171129:16:18:00:006512 gpstop:sdw:gpadmin-[INFO]:-Successfully shutdown 2 of 2 segment instances 
-20171129:16:18:00:006512 gpstop:sdw:gpadmin-[INFO]:-Database successfully shutdown with no errors reported
-20171129:16:18:00:006512 gpstop:sdw:gpadmin-[INFO]:-Cleaning up leftover gpmmon process
-20171129:16:18:00:006512 gpstop:sdw:gpadmin-[INFO]:-No leftover gpmmon process found
-20171129:16:18:00:006512 gpstop:sdw:gpadmin-[INFO]:-Cleaning up leftover gpsmon processes
-20171129:16:18:00:006512 gpstop:sdw:gpadmin-[INFO]:-No leftover gpsmon processes on some hosts. not attempting forceful termination on these hosts
-20171129:16:18:00:006512 gpstop:sdw:gpadmin-[INFO]:-Cleaning up leftover shared memory
-20171129:16:18:01:006512 gpstop:sdw:gpadmin-[INFO]:-Restarting System...
+20171130:18:02:18:031952 gpstop:sdw:gpadmin-[INFO]:-Starting gpstop with args: -rai
+20171130:18:02:18:031952 gpstop:sdw:gpadmin-[INFO]:-Gathering information and validating the environment...
+20171130:18:02:18:031952 gpstop:sdw:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
+20171130:18:02:18:031952 gpstop:sdw:gpadmin-[INFO]:-Obtaining Segment details from master...
+20171130:18:02:18:031952 gpstop:sdw:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 6.0.0-alpha.0+dev.1581.g3cb8ea8 build dev'
+20171130:18:02:18:031952 gpstop:sdw:gpadmin-[INFO]:-There are 1 connections to the database
+20171130:18:02:18:031952 gpstop:sdw:gpadmin-[INFO]:-Commencing Master instance shutdown with mode='immediate'
+20171130:18:02:18:031952 gpstop:sdw:gpadmin-[INFO]:-Master host=sdw
+20171130:18:02:18:031952 gpstop:sdw:gpadmin-[INFO]:-Commencing Master instance shutdown with mode=immediate
+20171130:18:02:18:031952 gpstop:sdw:gpadmin-[INFO]:-Master segment instance directory=/home/gpadmin/gpdb5.data/master/gpseg-1
+20171130:18:02:19:031952 gpstop:sdw:gpadmin-[INFO]:-Attempting forceful termination of any leftover master process
+20171130:18:02:19:031952 gpstop:sdw:gpadmin-[INFO]:-Terminating processes for segment /home/gpadmin/gpdb5.data/master/gpseg-1
+20171130:18:02:19:031952 gpstop:sdw:gpadmin-[INFO]:-No standby master host configured
+20171130:18:02:19:031952 gpstop:sdw:gpadmin-[INFO]:-Commencing parallel segment instance shutdown, please wait...
+20171130:18:02:19:031952 gpstop:sdw:gpadmin-[INFO]:-0.00% of jobs completed
+20171130:18:02:21:031952 gpstop:sdw:gpadmin-[INFO]:-100.00% of jobs completed
+20171130:18:02:21:031952 gpstop:sdw:gpadmin-[INFO]:-----------------------------------------------------
+20171130:18:02:21:031952 gpstop:sdw:gpadmin-[INFO]:-   Segments stopped successfully      = 2
+20171130:18:02:21:031952 gpstop:sdw:gpadmin-[INFO]:-   Segments with errors during stop   = 0
+20171130:18:02:21:031952 gpstop:sdw:gpadmin-[INFO]:-----------------------------------------------------
+20171130:18:02:21:031952 gpstop:sdw:gpadmin-[INFO]:-Successfully shutdown 2 of 2 segment instances 
+20171130:18:02:21:031952 gpstop:sdw:gpadmin-[INFO]:-Database successfully shutdown with no errors reported
+20171130:18:02:21:031952 gpstop:sdw:gpadmin-[INFO]:-Cleaning up leftover gpmmon process
+20171130:18:02:21:031952 gpstop:sdw:gpadmin-[INFO]:-No leftover gpmmon process found
+20171130:18:02:21:031952 gpstop:sdw:gpadmin-[INFO]:-Cleaning up leftover gpsmon processes
+20171130:18:02:21:031952 gpstop:sdw:gpadmin-[INFO]:-No leftover gpsmon processes on some hosts. not attempting forceful termination on these hosts
+20171130:18:02:21:031952 gpstop:sdw:gpadmin-[INFO]:-Cleaning up leftover shared memory
+20171130:18:02:23:031952 gpstop:sdw:gpadmin-[INFO]:-Restarting System...
 -- end_ignore

--- a/src/test/regress/expected/bgworker_cleanup.out
+++ b/src/test/regress/expected/bgworker_cleanup.out
@@ -1,0 +1,38 @@
+--
+-- Clean up for bgworker.sql tests
+-- 
+-- start_ignore
+\! gpconfig -r shared_preload_libraries
+20171129:16:17:57:005067 gpconfig:sdw:gpadmin-[INFO]:-completed successfully with parameters '-r shared_preload_libraries'
+\! cp $MASTER_DATA_DIRECTORY/postgresql.conf.bgworkertest.bak $MASTER_DATA_DIRECTORY/postgresql.conf
+\! rm -f $MASTER_DATA_DIRECTORY/postgresql.conf.bgworkertest.bak
+\! PGDATESTYLE="" gpstop -rai
+20171129:16:17:57:006512 gpstop:sdw:gpadmin-[INFO]:-Starting gpstop with args: -rai
+20171129:16:17:57:006512 gpstop:sdw:gpadmin-[INFO]:-Gathering information and validating the environment...
+20171129:16:17:57:006512 gpstop:sdw:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
+20171129:16:17:57:006512 gpstop:sdw:gpadmin-[INFO]:-Obtaining Segment details from master...
+20171129:16:17:57:006512 gpstop:sdw:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 6.0.0-alpha.0+dev.1581.g3cb8ea8 build dev'
+20171129:16:17:57:006512 gpstop:sdw:gpadmin-[INFO]:-There are 1 connections to the database
+20171129:16:17:57:006512 gpstop:sdw:gpadmin-[INFO]:-Commencing Master instance shutdown with mode='immediate'
+20171129:16:17:57:006512 gpstop:sdw:gpadmin-[INFO]:-Master host=sdw
+20171129:16:17:57:006512 gpstop:sdw:gpadmin-[INFO]:-Commencing Master instance shutdown with mode=immediate
+20171129:16:17:57:006512 gpstop:sdw:gpadmin-[INFO]:-Master segment instance directory=/home/gpadmin/gpdb5.data/master/gpseg-1
+20171129:16:17:58:006512 gpstop:sdw:gpadmin-[INFO]:-Attempting forceful termination of any leftover master process
+20171129:16:17:58:006512 gpstop:sdw:gpadmin-[INFO]:-Terminating processes for segment /home/gpadmin/gpdb5.data/master/gpseg-1
+20171129:16:17:58:006512 gpstop:sdw:gpadmin-[INFO]:-No standby master host configured
+20171129:16:17:58:006512 gpstop:sdw:gpadmin-[INFO]:-Commencing parallel segment instance shutdown, please wait...
+20171129:16:17:58:006512 gpstop:sdw:gpadmin-[INFO]:-0.00% of jobs completed
+20171129:16:18:00:006512 gpstop:sdw:gpadmin-[INFO]:-100.00% of jobs completed
+20171129:16:18:00:006512 gpstop:sdw:gpadmin-[INFO]:-----------------------------------------------------
+20171129:16:18:00:006512 gpstop:sdw:gpadmin-[INFO]:-   Segments stopped successfully      = 2
+20171129:16:18:00:006512 gpstop:sdw:gpadmin-[INFO]:-   Segments with errors during stop   = 0
+20171129:16:18:00:006512 gpstop:sdw:gpadmin-[INFO]:-----------------------------------------------------
+20171129:16:18:00:006512 gpstop:sdw:gpadmin-[INFO]:-Successfully shutdown 2 of 2 segment instances 
+20171129:16:18:00:006512 gpstop:sdw:gpadmin-[INFO]:-Database successfully shutdown with no errors reported
+20171129:16:18:00:006512 gpstop:sdw:gpadmin-[INFO]:-Cleaning up leftover gpmmon process
+20171129:16:18:00:006512 gpstop:sdw:gpadmin-[INFO]:-No leftover gpmmon process found
+20171129:16:18:00:006512 gpstop:sdw:gpadmin-[INFO]:-Cleaning up leftover gpsmon processes
+20171129:16:18:00:006512 gpstop:sdw:gpadmin-[INFO]:-No leftover gpsmon processes on some hosts. not attempting forceful termination on these hosts
+20171129:16:18:00:006512 gpstop:sdw:gpadmin-[INFO]:-Cleaning up leftover shared memory
+20171129:16:18:01:006512 gpstop:sdw:gpadmin-[INFO]:-Restarting System...
+-- end_ignore

--- a/src/test/regress/expected/bgworker_setup.out
+++ b/src/test/regress/expected/bgworker_setup.out
@@ -1,0 +1,40 @@
+--
+-- Setup for bgworker.sql tests
+-- 
+-- We are setting shared_preload_libraries to "bgworker_example.so" and
+-- restart database, then use bgworker.sql to verify bgworker processes
+-- are correctly launched 
+-- start_ignore 
+\! cp $MASTER_DATA_DIRECTORY/postgresql.conf $MASTER_DATA_DIRECTORY/postgresql.conf.bgworkertest.bak
+\! gpconfig -c shared_preload_libraries -v "bgworker_example"
+20171129:16:17:34:030886 gpconfig:sdw:gpadmin-[INFO]:-completed successfully with parameters '-c shared_preload_libraries -v bgworker_example'
+\! PGDATESTYLE="" gpstop -rai
+20171129:16:17:34:032327 gpstop:sdw:gpadmin-[INFO]:-Starting gpstop with args: -rai
+20171129:16:17:34:032327 gpstop:sdw:gpadmin-[INFO]:-Gathering information and validating the environment...
+20171129:16:17:34:032327 gpstop:sdw:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
+20171129:16:17:34:032327 gpstop:sdw:gpadmin-[INFO]:-Obtaining Segment details from master...
+20171129:16:17:34:032327 gpstop:sdw:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 6.0.0-alpha.0+dev.1581.g3cb8ea8 build dev'
+20171129:16:17:34:032327 gpstop:sdw:gpadmin-[INFO]:-There are 1 connections to the database
+20171129:16:17:34:032327 gpstop:sdw:gpadmin-[INFO]:-Commencing Master instance shutdown with mode='immediate'
+20171129:16:17:34:032327 gpstop:sdw:gpadmin-[INFO]:-Master host=sdw
+20171129:16:17:34:032327 gpstop:sdw:gpadmin-[INFO]:-Commencing Master instance shutdown with mode=immediate
+20171129:16:17:34:032327 gpstop:sdw:gpadmin-[INFO]:-Master segment instance directory=/home/gpadmin/gpdb5.data/master/gpseg-1
+20171129:16:17:35:032327 gpstop:sdw:gpadmin-[INFO]:-Attempting forceful termination of any leftover master process
+20171129:16:17:35:032327 gpstop:sdw:gpadmin-[INFO]:-Terminating processes for segment /home/gpadmin/gpdb5.data/master/gpseg-1
+20171129:16:17:35:032327 gpstop:sdw:gpadmin-[INFO]:-No standby master host configured
+20171129:16:17:35:032327 gpstop:sdw:gpadmin-[INFO]:-Commencing parallel segment instance shutdown, please wait...
+20171129:16:17:35:032327 gpstop:sdw:gpadmin-[INFO]:-0.00% of jobs completed
+20171129:16:17:37:032327 gpstop:sdw:gpadmin-[INFO]:-100.00% of jobs completed
+20171129:16:17:37:032327 gpstop:sdw:gpadmin-[INFO]:-----------------------------------------------------
+20171129:16:17:37:032327 gpstop:sdw:gpadmin-[INFO]:-   Segments stopped successfully      = 2
+20171129:16:17:37:032327 gpstop:sdw:gpadmin-[INFO]:-   Segments with errors during stop   = 0
+20171129:16:17:37:032327 gpstop:sdw:gpadmin-[INFO]:-----------------------------------------------------
+20171129:16:17:37:032327 gpstop:sdw:gpadmin-[INFO]:-Successfully shutdown 2 of 2 segment instances 
+20171129:16:17:37:032327 gpstop:sdw:gpadmin-[INFO]:-Database successfully shutdown with no errors reported
+20171129:16:17:37:032327 gpstop:sdw:gpadmin-[INFO]:-Cleaning up leftover gpmmon process
+20171129:16:17:37:032327 gpstop:sdw:gpadmin-[INFO]:-No leftover gpmmon process found
+20171129:16:17:37:032327 gpstop:sdw:gpadmin-[INFO]:-Cleaning up leftover gpsmon processes
+20171129:16:17:38:032327 gpstop:sdw:gpadmin-[INFO]:-No leftover gpsmon processes on some hosts. not attempting forceful termination on these hosts
+20171129:16:17:38:032327 gpstop:sdw:gpadmin-[INFO]:-Cleaning up leftover shared memory
+20171129:16:17:39:032327 gpstop:sdw:gpadmin-[INFO]:-Restarting System...
+-- end_ignore

--- a/src/test/regress/expected/bgworker_setup.out
+++ b/src/test/regress/expected/bgworker_setup.out
@@ -6,35 +6,60 @@
 -- are correctly launched 
 -- start_ignore 
 \! cp $MASTER_DATA_DIRECTORY/postgresql.conf $MASTER_DATA_DIRECTORY/postgresql.conf.bgworkertest.bak
-\! gpconfig -c shared_preload_libraries -v "bgworker_example"
-20171129:16:17:34:030886 gpconfig:sdw:gpadmin-[INFO]:-completed successfully with parameters '-c shared_preload_libraries -v bgworker_example'
-\! PGDATESTYLE="" gpstop -rai
-20171129:16:17:34:032327 gpstop:sdw:gpadmin-[INFO]:-Starting gpstop with args: -rai
-20171129:16:17:34:032327 gpstop:sdw:gpadmin-[INFO]:-Gathering information and validating the environment...
-20171129:16:17:34:032327 gpstop:sdw:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
-20171129:16:17:34:032327 gpstop:sdw:gpadmin-[INFO]:-Obtaining Segment details from master...
-20171129:16:17:34:032327 gpstop:sdw:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 6.0.0-alpha.0+dev.1581.g3cb8ea8 build dev'
-20171129:16:17:34:032327 gpstop:sdw:gpadmin-[INFO]:-There are 1 connections to the database
-20171129:16:17:34:032327 gpstop:sdw:gpadmin-[INFO]:-Commencing Master instance shutdown with mode='immediate'
-20171129:16:17:34:032327 gpstop:sdw:gpadmin-[INFO]:-Master host=sdw
-20171129:16:17:34:032327 gpstop:sdw:gpadmin-[INFO]:-Commencing Master instance shutdown with mode=immediate
-20171129:16:17:34:032327 gpstop:sdw:gpadmin-[INFO]:-Master segment instance directory=/home/gpadmin/gpdb5.data/master/gpseg-1
-20171129:16:17:35:032327 gpstop:sdw:gpadmin-[INFO]:-Attempting forceful termination of any leftover master process
-20171129:16:17:35:032327 gpstop:sdw:gpadmin-[INFO]:-Terminating processes for segment /home/gpadmin/gpdb5.data/master/gpseg-1
-20171129:16:17:35:032327 gpstop:sdw:gpadmin-[INFO]:-No standby master host configured
-20171129:16:17:35:032327 gpstop:sdw:gpadmin-[INFO]:-Commencing parallel segment instance shutdown, please wait...
-20171129:16:17:35:032327 gpstop:sdw:gpadmin-[INFO]:-0.00% of jobs completed
-20171129:16:17:37:032327 gpstop:sdw:gpadmin-[INFO]:-100.00% of jobs completed
-20171129:16:17:37:032327 gpstop:sdw:gpadmin-[INFO]:-----------------------------------------------------
-20171129:16:17:37:032327 gpstop:sdw:gpadmin-[INFO]:-   Segments stopped successfully      = 2
-20171129:16:17:37:032327 gpstop:sdw:gpadmin-[INFO]:-   Segments with errors during stop   = 0
-20171129:16:17:37:032327 gpstop:sdw:gpadmin-[INFO]:-----------------------------------------------------
-20171129:16:17:37:032327 gpstop:sdw:gpadmin-[INFO]:-Successfully shutdown 2 of 2 segment instances 
-20171129:16:17:37:032327 gpstop:sdw:gpadmin-[INFO]:-Database successfully shutdown with no errors reported
-20171129:16:17:37:032327 gpstop:sdw:gpadmin-[INFO]:-Cleaning up leftover gpmmon process
-20171129:16:17:37:032327 gpstop:sdw:gpadmin-[INFO]:-No leftover gpmmon process found
-20171129:16:17:37:032327 gpstop:sdw:gpadmin-[INFO]:-Cleaning up leftover gpsmon processes
-20171129:16:17:38:032327 gpstop:sdw:gpadmin-[INFO]:-No leftover gpsmon processes on some hosts. not attempting forceful termination on these hosts
-20171129:16:17:38:032327 gpstop:sdw:gpadmin-[INFO]:-Cleaning up leftover shared memory
-20171129:16:17:39:032327 gpstop:sdw:gpadmin-[INFO]:-Restarting System...
+\! echo "shared_preload_libraries='bgworker_example'" >> $MASTER_DATA_DIRECTORY/postgresql.conf 
+\! PGDATESTYLE="" gpstop -ai
+20171130:18:01:57:026828 gpstop:sdw:gpadmin-[INFO]:-Starting gpstop with args: -ai
+20171130:18:01:57:026828 gpstop:sdw:gpadmin-[INFO]:-Gathering information and validating the environment...
+20171130:18:01:57:026828 gpstop:sdw:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
+20171130:18:01:57:026828 gpstop:sdw:gpadmin-[INFO]:-Obtaining Segment details from master...
+20171130:18:01:57:026828 gpstop:sdw:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 6.0.0-alpha.0+dev.1581.g3cb8ea8 build dev'
+20171130:18:01:57:026828 gpstop:sdw:gpadmin-[INFO]:-There are 1 connections to the database
+20171130:18:01:57:026828 gpstop:sdw:gpadmin-[INFO]:-Commencing Master instance shutdown with mode='immediate'
+20171130:18:01:57:026828 gpstop:sdw:gpadmin-[INFO]:-Master host=sdw
+20171130:18:01:57:026828 gpstop:sdw:gpadmin-[INFO]:-Commencing Master instance shutdown with mode=immediate
+20171130:18:01:57:026828 gpstop:sdw:gpadmin-[INFO]:-Master segment instance directory=/home/gpadmin/gpdb5.data/master/gpseg-1
+20171130:18:01:58:026828 gpstop:sdw:gpadmin-[INFO]:-Attempting forceful termination of any leftover master process
+20171130:18:01:58:026828 gpstop:sdw:gpadmin-[INFO]:-Terminating processes for segment /home/gpadmin/gpdb5.data/master/gpseg-1
+20171130:18:01:58:026828 gpstop:sdw:gpadmin-[INFO]:-No standby master host configured
+20171130:18:01:58:026828 gpstop:sdw:gpadmin-[INFO]:-Commencing parallel segment instance shutdown, please wait...
+20171130:18:01:58:026828 gpstop:sdw:gpadmin-[INFO]:-0.00% of jobs completed
+20171130:18:02:00:026828 gpstop:sdw:gpadmin-[INFO]:-100.00% of jobs completed
+20171130:18:02:00:026828 gpstop:sdw:gpadmin-[INFO]:-----------------------------------------------------
+20171130:18:02:00:026828 gpstop:sdw:gpadmin-[INFO]:-   Segments stopped successfully      = 2
+20171130:18:02:00:026828 gpstop:sdw:gpadmin-[INFO]:-   Segments with errors during stop   = 0
+20171130:18:02:00:026828 gpstop:sdw:gpadmin-[INFO]:-----------------------------------------------------
+20171130:18:02:00:026828 gpstop:sdw:gpadmin-[INFO]:-Successfully shutdown 2 of 2 segment instances 
+20171130:18:02:00:026828 gpstop:sdw:gpadmin-[INFO]:-Database successfully shutdown with no errors reported
+20171130:18:02:00:026828 gpstop:sdw:gpadmin-[INFO]:-Cleaning up leftover gpmmon process
+20171130:18:02:00:026828 gpstop:sdw:gpadmin-[INFO]:-No leftover gpmmon process found
+20171130:18:02:00:026828 gpstop:sdw:gpadmin-[INFO]:-Cleaning up leftover gpsmon processes
+20171130:18:02:00:026828 gpstop:sdw:gpadmin-[INFO]:-No leftover gpsmon processes on some hosts. not attempting forceful termination on these hosts
+20171130:18:02:00:026828 gpstop:sdw:gpadmin-[INFO]:-Cleaning up leftover shared memory
+\! cp /home/gpadmin/workspace_wh/gpdb_wh/src/test/regress/bgworker_example.so $GPHOME/lib/postgresql/
+\! PGDATESTYLE="" gpstart -a
+20171130:18:02:02:029710 gpstart:sdw:gpadmin-[INFO]:-Starting gpstart with args: -a
+20171130:18:02:02:029710 gpstart:sdw:gpadmin-[INFO]:-Gathering information and validating the environment...
+20171130:18:02:02:029710 gpstart:sdw:gpadmin-[INFO]:-Greenplum Binary Version: 'postgres (Greenplum Database) 6.0.0-alpha.0+dev.1581.g3cb8ea8 build dev'
+20171130:18:02:02:029710 gpstart:sdw:gpadmin-[INFO]:-Greenplum Catalog Version: '301711241'
+20171130:18:02:02:029710 gpstart:sdw:gpadmin-[INFO]:-Starting Master instance in admin mode
+20171130:18:02:03:029710 gpstart:sdw:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
+20171130:18:02:03:029710 gpstart:sdw:gpadmin-[INFO]:-Obtaining Segment details from master...
+20171130:18:02:03:029710 gpstart:sdw:gpadmin-[INFO]:-Setting new master era
+20171130:18:02:03:029710 gpstart:sdw:gpadmin-[INFO]:-Master Started...
+20171130:18:02:04:029710 gpstart:sdw:gpadmin-[INFO]:-Heap checksum setting is consistent across the cluster
+20171130:18:02:04:029710 gpstart:sdw:gpadmin-[INFO]:-Shutting down master
+20171130:18:02:05:029710 gpstart:sdw:gpadmin-[INFO]:-Commencing parallel segment instance startup, please wait...
+.. 
+20171130:18:02:07:029710 gpstart:sdw:gpadmin-[INFO]:-Process results...
+20171130:18:02:07:029710 gpstart:sdw:gpadmin-[INFO]:-----------------------------------------------------
+20171130:18:02:07:029710 gpstart:sdw:gpadmin-[INFO]:-   Successful segment starts                                            = 2
+20171130:18:02:07:029710 gpstart:sdw:gpadmin-[INFO]:-   Failed segment starts                                                = 0
+20171130:18:02:07:029710 gpstart:sdw:gpadmin-[INFO]:-   Skipped segment starts (segments are marked down in configuration)   = 0
+20171130:18:02:07:029710 gpstart:sdw:gpadmin-[INFO]:-----------------------------------------------------
+20171130:18:02:07:029710 gpstart:sdw:gpadmin-[INFO]:-Successfully started 2 of 2 segment instances 
+20171130:18:02:07:029710 gpstart:sdw:gpadmin-[INFO]:-----------------------------------------------------
+20171130:18:02:07:029710 gpstart:sdw:gpadmin-[INFO]:-Starting Master instance sdw directory /home/gpadmin/gpdb5.data/master/gpseg-1 
+20171130:18:02:08:029710 gpstart:sdw:gpadmin-[INFO]:-Command pg_ctl reports Master sdw instance active
+20171130:18:02:08:029710 gpstart:sdw:gpadmin-[INFO]:-No standby master configured.  skipping...
+20171130:18:02:08:029710 gpstart:sdw:gpadmin-[INFO]:-Database successfully started
 -- end_ignore

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -33,6 +33,12 @@ test: workfile/hashagg_spill workfile/hashjoin_spill workfile/materialize_spill 
 # 'zlib' utilizes fault injectors so it needs to be in a group by itself
 test: zlib
 
+# This test will change the shared_preload_libraries and need to restart the DB.
+# So it needs to be in a group by itself.
+test: bgworker_setup
+test: bgworker
+test: bgworker_cleanup
+
 # This test will change the gp_workfile_limit_per_segment and will need to restart the DB.
 # It will also use faultinjector - so it needs to be in a group by itself.
 test: segspace_setup

--- a/src/test/regress/input/bgworker_setup.source
+++ b/src/test/regress/input/bgworker_setup.source
@@ -8,6 +8,8 @@
 
 -- start_ignore 
 \! cp $MASTER_DATA_DIRECTORY/postgresql.conf $MASTER_DATA_DIRECTORY/postgresql.conf.bgworkertest.bak
-\! gpconfig -c shared_preload_libraries -v "bgworker_example"
-\! PGDATESTYLE="" gpstop -rai
+\! echo "shared_preload_libraries='bgworker_example'" >> $MASTER_DATA_DIRECTORY/postgresql.conf 
+\! PGDATESTYLE="" gpstop -ai
+\! cp @libdir@/bgworker_example@DLSUFFIX@ $GPHOME/lib/postgresql/
+\! PGDATESTYLE="" gpstart -a
 -- end_ignore

--- a/src/test/regress/sql/.gitignore
+++ b/src/test/regress/sql/.gitignore
@@ -36,3 +36,4 @@ transient_types.sql
 hooktest.sql
 gpcopy.sql
 trigger_sets_oid.sql
+bgworker_setup.sql

--- a/src/test/regress/sql/bgworker.sql
+++ b/src/test/regress/sql/bgworker.sql
@@ -9,7 +9,7 @@ DROP EXTERNAL WEB TABLE IF EXISTS find_bgworker CASCADE;
 CREATE EXTERNAL WEB TABLE find_bgworker(line text) EXECUTE 'ps aux | grep bgworker 2>&1' ON MASTER FORMAT 'TEXT';
 
 CREATE OR REPLACE VIEW check_number_bgworkers AS
-SELECT CASE WHEN count(*) = (3 * (SELECT count(*) AS segnum FROM gp_segment_configuration WHERE role = 'p' AND hostname IN (SELECT hostname FROM gp_segment_configuration WHERE role = 'p' AND content = -1))) THEN true ELSE false END AS ok
+SELECT CASE WHEN count(*) = 3 THEN true ELSE false END AS ok
 FROM find_bgworker WHERE line NOT LIKE '%grep%';
 
 CREATE OR REPLACE VIEW number_bgworkers_should_be_zero AS

--- a/src/test/regress/sql/bgworker.sql
+++ b/src/test/regress/sql/bgworker.sql
@@ -1,0 +1,45 @@
+--
+-- Tests the Greenplum specific bgworker framework can launch
+-- processes registed in contrib/bgworker_example
+--
+
+-- start_ignore
+SELECT * FROM pg_sleep(3);
+DROP EXTERNAL WEB TABLE IF EXISTS find_bgworker CASCADE;
+CREATE EXTERNAL WEB TABLE find_bgworker(line text) EXECUTE 'ps aux | grep bgworker 2>&1' ON MASTER FORMAT 'TEXT';
+
+CREATE OR REPLACE VIEW check_number_bgworkers AS
+SELECT CASE WHEN count(*) = (3 * (SELECT count(*) AS segnum FROM gp_segment_configuration WHERE role = 'p' AND hostname IN (SELECT hostname FROM gp_segment_configuration WHERE role = 'p' AND content = -1))) THEN true ELSE false END AS ok
+FROM find_bgworker WHERE line NOT LIKE '%grep%';
+
+CREATE OR REPLACE VIEW number_bgworkers_should_be_zero AS
+SELECT CASE WHEN count(*) = 0 THEN true ELSE false END AS ok
+FROM find_bgworker WHERE line NOT LIKE '%grep%';
+-- end_ignore
+
+-- This checks number of started bgworker processes equals
+-- (number of workers registed in contrib/bgworker_example) * (postmasters on this host)
+SELECT * FROM check_number_bgworkers;
+-- Should return 'true'
+
+-- start_ignore
+DROP EXTERNAL WEB TABLE IF EXISTS kill_bgworker;
+CREATE EXTERNAL WEB TABLE kill_bgworker(line text) EXECUTE 'kill $(ps aux | grep bgworker | grep -v grep | grep -v kill | awk ''{print $2}'') > /dev/null 2>&1' ON MASTER FORMAT 'TEXT';
+-- end_ignore
+
+SELECT * FROM kill_bgworker;
+SELECT * FROM number_bgworkers_should_be_zero;
+-- Should be true
+
+-- Wait for postmaster restart bgworker processes
+SELECT * FROM pg_sleep(6);
+
+SELECT * FROM check_number_bgworkers;
+-- Should return 'true'
+
+-- start_ignore
+DROP VIEW check_number_bgworkers;
+DROP VIEW number_bgworkers_should_be_zero;
+DROP EXTERNAL WEB TABLE IF EXISTS find_bgworker CASCADE;
+DROP EXTERNAL WEB TABLE IF EXISTS kill_bgworker CASCADE;
+-- end_ignore

--- a/src/test/regress/sql/bgworker_cleanup.sql
+++ b/src/test/regress/sql/bgworker_cleanup.sql
@@ -3,7 +3,6 @@
 -- 
 
 -- start_ignore
-\! gpconfig -r shared_preload_libraries
 \! cp $MASTER_DATA_DIRECTORY/postgresql.conf.bgworkertest.bak $MASTER_DATA_DIRECTORY/postgresql.conf
 \! rm -f $MASTER_DATA_DIRECTORY/postgresql.conf.bgworkertest.bak
 \! PGDATESTYLE="" gpstop -rai

--- a/src/test/regress/sql/bgworker_cleanup.sql
+++ b/src/test/regress/sql/bgworker_cleanup.sql
@@ -1,0 +1,10 @@
+--
+-- Clean up for bgworker.sql tests
+-- 
+
+-- start_ignore
+\! gpconfig -r shared_preload_libraries
+\! cp $MASTER_DATA_DIRECTORY/postgresql.conf.bgworkertest.bak $MASTER_DATA_DIRECTORY/postgresql.conf
+\! rm -f $MASTER_DATA_DIRECTORY/postgresql.conf.bgworkertest.bak
+\! PGDATESTYLE="" gpstop -rai
+-- end_ignore

--- a/src/test/regress/sql/bgworker_setup.sql
+++ b/src/test/regress/sql/bgworker_setup.sql
@@ -1,0 +1,13 @@
+--
+-- Setup for bgworker.sql tests
+-- 
+
+-- We are setting shared_preload_libraries to "bgworker_example.so" and
+-- restart database, then use bgworker.sql to verify bgworker processes
+-- are correctly launched 
+
+-- start_ignore 
+\! cp $MASTER_DATA_DIRECTORY/postgresql.conf $MASTER_DATA_DIRECTORY/postgresql.conf.bgworkertest.bak
+\! gpconfig -c shared_preload_libraries -v "bgworker_example"
+\! PGDATESTYLE="" gpstop -rai
+-- end_ignore


### PR DESCRIPTION
Borrowing bgworker concept from postgres 9.3, this commit implements
framework of background worker for Greenplum.
The original commit in postgres is https://github.com/postgres/postgres/commit/da07a1e856511dca59cbb1357616e26baa64428e

This framework enables modules listed in shared_preload_libraries can
register background workers, which be forked and monitored by postmaster.

Compared with the original commit in postgres 9.3, this commit only
provides limited function, to avoid difficulties for merge work.
 - No database connection support
 - Workers only start on pmState enters PM_RUN
 - Can optionally access shared memory
 - Can restart on crash
 - Added tests

Most of codes and functions are implemented in bgworker.c/h which
don't need to be considered in merge work before 9.3. Only necessary
changes are made in postmaster.c and proc.c with Greenplum specific
comments.

Author: Wang Hao <haowang@pivotal.io>
Author: Teng Zhang <tezhang@pivotal.io>