### PR TITLE
Refactor the way permissions are copied to new partition at ADD PARTITION.

### DIFF
--- a/src/backend/catalog/pg_shdepend.c
+++ b/src/backend/catalog/pg_shdepend.c
@@ -1189,7 +1189,6 @@ shdepDropOwned(List *roleids, DropBehavior behavior)
 					istmt.grantees = list_make1_oid(roleid);
 					istmt.grant_option = false;
 					istmt.behavior = DROP_CASCADE;
-					istmt.cooked_privs = NIL;
 
 					ExecGrantStmt_oids(&istmt);
 					break;

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -11216,6 +11216,16 @@ ATExecAddInherit(Relation child_rel, Node *node)
 	inherit_parent(parent_rel, child_rel, is_partition, inhAttrNameList);
 
 	/*
+	 * Also copy the ACL from the parent, if we're attaching a new partition
+	 * to a partitioned table.
+	 */
+	if (is_partition)
+	{
+		CopyRelationAcls(RelationGetRelid(parent_rel),
+						 RelationGetRelid(child_rel));
+	}
+
+	/*
 	 * Keep our lock on the parent relation until commit, unless we're
 	 * doing partitioning, in which case the parent is sufficiently locked.
 	 * We want to unlock here in case we're doing deep sub partitioning. We do

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -3075,7 +3075,6 @@ _copyGrantStmt(GrantStmt *from)
 	COPY_NODE_FIELD(grantees);
 	COPY_SCALAR_FIELD(grant_option);
 	COPY_SCALAR_FIELD(behavior);
-	COPY_NODE_FIELD(cooked_privs);
 
 	return newnode;
 }

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -1130,7 +1130,6 @@ _equalGrantStmt(GrantStmt *a, GrantStmt *b)
 	COMPARE_NODE_FIELD(grantees);
 	COMPARE_SCALAR_FIELD(grant_option);
 	COMPARE_SCALAR_FIELD(behavior);
-	COMPARE_NODE_FIELD(cooked_privs);
 
 	return true;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -3126,7 +3126,6 @@ _outGrantStmt(StringInfo str, GrantStmt *node)
 	WRITE_NODE_FIELD(grantees);
 	WRITE_BOOL_FIELD(grant_option);
 	WRITE_ENUM_FIELD(behavior, DropBehavior);
-	WRITE_NODE_FIELD(cooked_privs);
 }
 
 static void

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -1351,22 +1351,6 @@ _readCopyStmt(void)
 	READ_DONE();
 
 }
-static GrantStmt *
-_readGrantStmt(void)
-{
-	READ_LOCALS(GrantStmt);
-
-	READ_BOOL_FIELD(is_grant);
-	READ_ENUM_FIELD(objtype,GrantObjectType);
-	READ_NODE_FIELD(objects);
-	READ_NODE_FIELD(privileges);
-	READ_NODE_FIELD(grantees);
-	READ_BOOL_FIELD(grant_option);
-	READ_ENUM_FIELD(behavior, DropBehavior); Assert(local_node->behavior <= DROP_CASCADE);
-	READ_NODE_FIELD(cooked_privs);
-
-	READ_DONE();
-}
 
 static GrantRoleStmt *
 _readGrantRoleStmt(void)

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -2560,7 +2560,6 @@ _readCreateConversionStmt(void)
 	READ_DONE();
 }
 
-#ifndef COMPILING_BINARY_FUNCS
 static GrantStmt *
 _readGrantStmt(void)
 {
@@ -2573,11 +2572,9 @@ _readGrantStmt(void)
 	READ_NODE_FIELD(grantees);
 	READ_BOOL_FIELD(grant_option);
 	READ_ENUM_FIELD(behavior, DropBehavior);
-	READ_NODE_FIELD(cooked_privs);
 
 	READ_DONE();
 }
-#endif /* COMPILING_BINARY_FUNCS */
 
 static PrivGrantee *
 _readPrivGrantee(void)

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1465,7 +1465,6 @@ typedef struct GrantStmt
 	List	   *grantees;		/* list of PrivGrantee nodes */
 	bool		grant_option;	/* grant or revoke grant option */
 	DropBehavior behavior;		/* drop behavior (for REVOKE) */
-	List	   *cooked_privs;	/* precooked acls (from ADD PARTITION) */
 } GrantStmt;
 
 typedef struct PrivGrantee

--- a/src/include/utils/acl.h
+++ b/src/include/utils/acl.h
@@ -213,7 +213,6 @@ typedef struct
 	List	   *grantees;
 	bool		grant_option;
 	DropBehavior behavior;
-	List	   *cooked_privs; /* precooked AclItems from partitioning code */
 } InternalGrant;
 
 /*
@@ -261,6 +260,8 @@ extern Datum hash_aclitem(PG_FUNCTION_ARGS);
  */
 extern void ExecuteGrantStmt(GrantStmt *stmt);
 extern void ExecGrantStmt_oids(InternalGrant *istmt);
+
+extern void CopyRelationAcls(Oid src, Oid dest);
 
 extern AclMode pg_class_aclmask(Oid table_oid, Oid roleid,
 				 AclMode mask, AclMaskHow how);

--- a/src/test/regress/expected/bfv_partition.out
+++ b/src/test/regress/expected/bfv_partition.out
@@ -5674,6 +5674,47 @@ select 'pg_partition_templates', count(*) from pg_partition_templates where tabl
  pg_partition_templates |     0
 (1 row)
 
+--
+-- Check that dependencies to users are recorded correctly when operating on partitions.
+--
+CREATE ROLE part_acl_owner;
+CREATE ROLE part_acl_u1;
+GRANT ALL ON SCHEMA bfv_partition to part_acl_owner;
+SET ROLE part_acl_owner;
+CREATE TABLE part_acl_test (id int4) PARTITION BY LIST (id) (PARTITION p1 VALUES (1));
+GRANT SELECT ON part_acl_test TO part_acl_u1;
+ALTER TABLE part_acl_test ADD PARTITION p2 VALUES (2);
+-- View permissions
+\dp part_acl_*
+                                   Access privileges
+    Schema     |          Name          | Type  |           Access privileges           
+---------------+------------------------+-------+---------------------------------------
+ bfv_partition | part_acl_test          | table | part_acl_owner=arwdDxt/part_acl_owner 
+                                                : part_acl_u1=r/part_acl_owner
+ bfv_partition | part_acl_test_1_prt_p1 | table | part_acl_owner=arwdDxt/part_acl_owner 
+                                                : part_acl_u1=r/part_acl_owner
+ bfv_partition | part_acl_test_1_prt_p2 | table | part_acl_owner=arwdDxt/part_acl_owner 
+                                                : part_acl_u1=r/part_acl_owner
+(3 rows)
+
+-- View dependencies
+select classid::regclass, objid::regclass,
+       refclassid::regclass, rolname
+from pg_shdepend
+inner join pg_database on pg_database.oid = pg_shdepend.dbid
+left join pg_roles on pg_roles.oid = pg_shdepend.refobjid
+where classid = 'pg_class'::regclass and objid::regclass::text like 'part_acl_test%'
+and datname = current_database();
+ classid  |         objid          | refclassid |    rolname     
+----------+------------------------+------------+----------------
+ pg_class | part_acl_test          | pg_authid  | part_acl_owner
+ pg_class | part_acl_test_1_prt_p1 | pg_authid  | part_acl_owner
+ pg_class | part_acl_test_1_prt_p1 | pg_authid  | part_acl_u1
+ pg_class | part_acl_test          | pg_authid  | part_acl_u1
+ pg_class | part_acl_test_1_prt_p2 | pg_authid  | part_acl_owner
+ pg_class | part_acl_test_1_prt_p2 | pg_authid  | part_acl_u1
+(6 rows)
+
 -- CLEANUP
 -- start_ignore
 drop schema if exists bfv_partition cascade;
@@ -5681,4 +5722,6 @@ NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to function count_operator(text,text)
 drop cascades to function find_operator(text,text)
 DROP USER mpp3641_user;
+DROP ROLE part_acl_owner;
+DROP ROLE part_acl_u1;
 -- end_ignore


### PR DESCRIPTION
Instead of adding a special GrantStmt, with GPDB-specific "cooked_privs"
field, modify ATExecAddInherit() to copy the ACL from the parent to the
new child. This allows removing all the handling of "cooked_privs", which
was causing a rather large diff vs. upstream in aclchk.c, because of the
change in indentation. We could've just re-indented the code to match the
upstream, with a comment explaining why it's indented funnily, but this
seems more straightforward, anyway.

This also fixes a minor bug: The pg_shdepend entries for the roles
mentioned in the ACLs were not created in the old implementation. I'm not
sure if anything bad could happen because of that: the parent table would
have a dependency to them anyway, and I'm not sure if it's possible to
later revoke the ACL on the partitioned parent table, without also revoking
it from the partitions. But in any case, it was inconsistent with the
initial partitions created directly with CREATE TABLE; the dependencies for
those were recorded, but not with ADD PARTITION. Add a test case for that.