### PR TITLE
docs - removing gpbackup limitation for multi-level partitioned tables

### DIFF
--- a/gpdb-doc/dita/admin_guide/managing/backup-gpbackup.xml
+++ b/gpdb-doc/dita/admin_guide/managing/backup-gpbackup.xml
@@ -45,10 +45,6 @@
             inherited from the new parent table. In this case, <codeph>gpbackup</codeph> backs up
             conflicting <codeph>CREATE INDEX</codeph> statements, which causes an error when you
             restore the backup set.</li>
-          <li>You can back up and restore single level partitioned tables that have been altered by
-            exchanging a leaf child partition with a readable external table. You cannot back up and
-            restore multi-level partitioned tables when a leaf child partition is a readable
-            external table.</li>
           <li>You can execute multiple instances of <codeph>gpbackup</codeph>, but each execution
             requires a distinct timestamp.</li>
           <li>Database object filtering is currently limited to schemas and tables.</li>


### PR DESCRIPTION
Removing this limitation for 5.3.0.  (This will also go into master branch.)