### PR TITLE
Resent a cancel/finish signal if QE didn't respond for a long time.

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -750,7 +750,6 @@ signalQEs(CdbDispatchCmdAsync *pParms)
 
 		if (!dispatchResult->stillRunning ||
 			dispatchResult->wasCanceled ||
-			waitMode == dispatchResult->sentSignal ||
 			cdbconn_isBadConnection(segdbDesc))
 			continue;
 

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -589,6 +589,8 @@ ReadCommand(StringInfo inBuf)
 {
 	int			result;
 
+	SIMPLE_FAULT_INJECTOR(BeforeReadCommand);
+
 	if (whereToSendOutput == DestRemote)
 		result = SocketBackend(inBuf);
 	else

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -337,6 +337,8 @@ FaultInjectorIdentifierEnumToString[] = {
 		/* inject fault to report ERROR just after creating Gang */
 	_("resgroup_assigned_on_master"),
 		/* inject fault to report ERROR just after resource group is assigned on master */
+	_("before_read_command"),
+		/* inject fault before reading command */
 	_("not recognized"),
 };
 

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -225,6 +225,9 @@ typedef enum FaultInjectorIdentifier_e {
 	GangCreated,
 
 	ResGroupAssignedOnMaster,
+
+	BeforeReadCommand,
+
 	/* INSERT has to be done before that line */
 	FaultInjectorIdMax,
 	

--- a/src/test/regress/expected/query_finish_pending.out
+++ b/src/test/regress/expected/query_finish_pending.out
@@ -136,3 +136,31 @@ NOTICE:  Success:
  t
 (1 row)
 
+-- test if a query can be canceled when cancel signal arrives fast than the query dispatched.
+create table _tmp_table1 as select i as c1, i as c2 from generate_series(1, 10) i;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table _tmp_table2 as select i as c1, 0 as c2 from generate_series(0, 10) i;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- make one QE sleep before reading command
+select gp_inject_fault('before_read_command', 'sleep', '', '', '', 1, 50, 2::smallint);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+begin;
+select count(*) from _tmp_table1, _tmp_table2 where 100 / _tmp_table2.c2 > 1;
+ERROR:  division by zero  (seg0 slice1 172.17.0.2:25433 pid=31180)
+end;
+select gp_inject_fault('before_read_command', 'reset', 2);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+drop table _tmp_table1;
+drop table _tmp_table2;


### PR DESCRIPTION
Previously, dispatcher only send cancel/finish signal to QEs once, so if
the signal arrives faster than the query or is omitted by the secure_read(),
the QE may have no chance to quit if the QE is assigned to execute a MOTION
node and it's peer has been canceled.

This fixes issue #3950