### PR TITLE
Remove obsolete nb_classification composite type.

### DIFF
--- a/src/include/catalog/pg_attribute.h
+++ b/src/include/catalog/pg_attribute.h
@@ -509,15 +509,4 @@ DATA(insert ( 1259 gp_segment_id   23 0  4  -8 0 -1 -1 t p i t f f t 0));
 { 0, {"indexprs"},			25, -1, -1, 13, 0, -1, -1, false, 'x', 'i', false, false, false, true, 0 }, \
 { 0, {"indpred"},			25, -1, -1, 14, 0, -1, -1, false, 'x', 'i', false, false, false, true, 0 }
 
-
-/* -----------------------------------------------
- *      abstract types with no backing relations
- * -----------------------------------------------
- */
-
-/* nb_classification */
-DATA(insert ( 3250 classes  1009 -1 -1 1 1 -1 -1 f x i f f f t 0 ));
-DATA(insert ( 3250 accum    1022 -1 -1 2 1 -1 -1 f x d f f f t 0 ));
-DATA(insert ( 3250 apriori  1016 -1 -1 3 1 -1 -1 f x d f f f t 0 ));
-
 #endif   /* PG_ATTRIBUTE_H */

--- a/src/include/catalog/pg_class.h
+++ b/src/include/catalog/pg_class.h
@@ -142,9 +142,6 @@ DESCR("");
 DATA(insert OID = 1259 (  pg_class		PGNSP 83 PGUID 0 1259 0 0 0 0 0 f f r h 25 0 t f f f f 3 _null_ _null_ ));
 DESCR("");
 
-/* abstract tuple types */
-DATA(insert OID = 3250    ( nb_classification PGNSP 3251 PGUID 0 3250 0 0 0 0 0 f f c v 3 0 f f f f f 0 _null_ _null_ ));
-
 
 /*
  * pg_class table values for FormData_pg_class.

--- a/src/include/catalog/pg_type.h
+++ b/src/include/catalog/pg_type.h
@@ -623,8 +623,6 @@ DATA(insert OID = 2970 ( txid_snapshot	PGNSP PGUID -1 f b U f t \054 0 0 2949 tx
 DESCR("txid snapshot");
 DATA(insert OID = 2949 ( _txid_snapshot PGNSP PGUID -1 f b A f t \054 0 2970 0 array_in array_out array_recv array_send - - - d x f 0 -1 0 _null_ _null_ ));
 
-DATA(insert OID = 3251 (	nb_classification	   PGNSP PGUID -1 f c C f t \054 3250	0 0 record_in record_out record_recv record_send - - - d x f 0 -1 0 _null_ _null_ ));
-
 DATA(insert OID = 3300 (	gpaotid	   PGNSP PGUID 6 f b N f t \054 0	0 3301 gpaotidin gpaotidout gpaotidrecv gpaotidsend - - - s p f 0 -1 0 _null_ _null_ ));
 DESCR("(segment file num, row number), logical location of append-only tuple");
 #define AOTIDOID	3300


### PR DESCRIPTION
It was used by the old nb_classify() aggregate function. It was removed in
commit fae97ae742, but this type was left over.