### PR TITLE
Fix compilation of orca_debug module.

### DIFF
--- a/contrib/orca_debug/orca_debug.cpp
+++ b/contrib/orca_debug/orca_debug.cpp
@@ -805,9 +805,9 @@ static int extractFrozenQueryPlanAndExecute(char *pcQuery)
 
 	// The following steps are required to be able to execute the query.
 
-	DestReceiver *pdest = CreateDestReceiver(DestNone, NULL);
+	DestReceiver *pdest = CreateDestReceiver(DestNone);
 	QueryDesc    *pqueryDesc = CreateQueryDesc(pplstmt, PStrDup("Internal Query") /*plan->query */,
-			ActiveSnapshot,
+			GetActiveSnapshot(),
 			InvalidSnapshot,
 			pdest,
 			NULL /*paramLI*/,
@@ -854,9 +854,9 @@ static int extractFrozenPlanAndExecute(char *pcSerializedPS)
 
 	//The following steps are required to be able to execute the query.
 
-	DestReceiver *pdest = CreateDestReceiver(DestNone, NULL);
+	DestReceiver *pdest = CreateDestReceiver(DestNone);
 	QueryDesc    *pqueryDesc = CreateQueryDesc(pplstmt, PStrDup("Internal Query") /*plan->query */,
-			ActiveSnapshot,
+			GetActiveSnapshot(),
 			InvalidSnapshot,
 			pdest,
 			NULL /*paramLI*/,
@@ -886,9 +886,9 @@ static int executeXMLPlan(char *szXml)
 
 	// The following steps are required to be able to execute the query.
 
-	DestReceiver *pdest = CreateDestReceiver(DestNone, NULL);
+	DestReceiver *pdest = CreateDestReceiver(DestNone);
 	QueryDesc    *pqueryDesc = CreateQueryDesc(pplstmt, PStrDup("Internal Query") /*plan->query */,
-			ActiveSnapshot,
+			GetActiveSnapshot(),
 			InvalidSnapshot,
 			pdest,
 			NULL /*paramLI*/,


### PR DESCRIPTION
Was broken by commit 321c0529c9. This isn't compiled as part of a normal
build, which is why it went unnoticed.

I'm not sure if anyone cares about this module at all, but as long as it
sits in the repository, it'd be nice if it at least compiled. (The
regression tests have been broken since time immemorial.)