### PR TITLE
wrong err msg when file doesn't exists by restore

### DIFF
--- a/gpMgmt/bin/gppylib/operations/restore.py
+++ b/gpMgmt/bin/gppylib/operations/restore.py
@@ -903,10 +903,11 @@ class ValidateSegments(Operation):
                 raise ExceptionNoStackTraceNeeded("Host %s dir %s dbid %d marked as invalid" % (seg.getSegmentHostName(), seg.getSegmentDataDirectory(), seg.getSegmentDbId()))
 
             if self.context.netbackup_service_host is None:
+                user_or_default_dir = self.context.get_backup_dir(segment_dir=seg.getSegmentDataDirectory())
                 remote_file = get_filename_for_content(self.context, "dump", seg.getSegmentContentId(),
-                                                       self.context.get_backup_dir(segment_dir=seg.getSegmentDataDirectory()), seg.getSegmentHostName())
+                                                       user_or_default_dir, seg.getSegmentHostName())
                 if not remote_file:
-                    raise ExceptionNoStackTraceNeeded("No dump file on %s in %s" % (seg.getSegmentHostName(), seg.getSegmentDataDirectory()))
+                    raise ExceptionNoStackTraceNeeded("No dump file on %s in %s" % (seg.getSegmentHostName(), user_or_default_dir))
 
 def check_table_name_format_and_duplicate(table_list, restore_schemas=None):
     """


### PR DESCRIPTION
Currently, when a backup file doesn't exist, the gpdbrestore throws error 

```
raise ExceptionNoStackTraceNeeded("No dump file on %s in %s" % (seg.getSegmentHostName(), seg.getSegmentDataDirectory()))
```

There is an issue with the error message since when the user provides its own directory like using "-u" option and during the run when the dumpfile doesn't exist then the directory shown is also the default directory which is misleading, for eg.s

```
[gpadmin@gpdb 20171201]$ gpdbrestore -t 20171201142523 -e -u /home/gpadmin/testbackup/
[.....]
Continue with Greenplum restore Yy|Nn (default=N):
> y
20171201:19:35:43:020121 gpdbrestore:gpdb:gpadmin-[ERROR]:-gpdbrestore error: No dump file on gpdb in /data/primary/gp_4.3.18.0_201712011453470
```

This pull request fix provides the correct location where it couldn't find the dump for the backup key