### PR TITLE
Fixing planning for order sensitive window functions

### DIFF
--- a/src/test/regress/expected/window.out
+++ b/src/test/regress/expected/window.out
@@ -364,8 +364,8 @@ SELECT first_value(ten) OVER (PARTITION BY four ORDER BY ten), ten, four FROM te
 SELECT last_value(four) OVER (ORDER BY ten), ten, four FROM tenk1 WHERE unique2 < 10; 
  last_value | ten | four 
 ------------+-----+------
-          0 |   0 |    0
           0 |   0 |    2
+          0 |   0 |    0
           0 |   0 |    0
           1 |   1 |    1
           1 |   1 |    3
@@ -382,13 +382,13 @@ SELECT last_value(ten) OVER (PARTITION BY four), ten, four FROM
 	ORDER BY four, ten;
  last_value | ten | four 
 ------------+-----+------
-          0 |   0 |    0
-          0 |   0 |    0
-          0 |   4 |    0
-          1 |   1 |    1
-          1 |   1 |    1
-          1 |   7 |    1
-          1 |   9 |    1
+          4 |   0 |    0
+          4 |   0 |    0
+          4 |   4 |    0
+          9 |   1 |    1
+          9 |   1 |    1
+          9 |   7 |    1
+          9 |   9 |    1
           0 |   0 |    2
           3 |   1 |    3
           3 |   3 |    3
@@ -401,10 +401,10 @@ SELECT nth_value(ten, four + 1) OVER (PARTITION BY four), ten, four
          0 |   0 |    0
          0 |   0 |    0
          0 |   4 |    0
-         7 |   1 |    1
-         7 |   1 |    1
-         7 |   7 |    1
-         7 |   9 |    1
+         1 |   1 |    1
+         1 |   1 |    1
+         1 |   7 |    1
+         1 |   9 |    1
            |   0 |    2
            |   1 |    3
            |   3 |    3


### PR DESCRIPTION
Order sensitive windows functions such as `last_value` can produce wrong
results if the plan does not respect the given sort order and if there
is motion in between of resorting.

If the input plan specifies a specific order `s1` and the window sorting
needs to apply sort order of `s2` then:

If `s2` is a prefix of `s1`, window sorting has to made based on `s1` to
eleminate wrong resuls in order sensitive window functions.

Otherwise, window sorting can go with the normal flow and sort based on
`s2`.