### PR TITLE
Remove redundant TINC tests on invalid gp_default_storage_options setting.

### DIFF
--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/access_methods/storage_parameters/expected/database_compresslevel.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/access_methods/storage_parameters/expected/database_compresslevel.ans
@@ -320,13 +320,6 @@ select compresslevel, compresstype, blocksize, checksum, columnstore from pg_app
 
 Drop table ao_db_cl_t6;
 DROP TABLE
--- Create table with invalid value compresslevel=10
-Drop table if exists ao_db_cl_t4;
-psql:/path/sql_file:1: NOTICE:  table "ao_db_cl_t4" does not exist, skipping
-DROP TABLE
-Create table ao_db_cl_t4 ( i int, j int) with(compresslevel=10);
-psql:/path/sql_file:1: ERROR:  value 10 out of bounds for option "compresslevel"
-DETAIL:  Valid values are between "0" and "9".
 -- Create table with appendonly=false
 Drop table if exists ao_db_cl_t4;
 psql:/path/sql_file:1: NOTICE:  table "ao_db_cl_t4" does not exist, skipping
@@ -487,16 +480,6 @@ select attnum, attoptions from pg_attribute_encoding where attrelid='ao_db_cl_t7
 Drop table ao_db_cl_t7;
 DROP TABLE
 -- ========================
--- Set the database level guc to an invalid value
-Alter database dsp_db2 set gp_default_storage_options="appendonly=true, compresslevel=10";
-psql:/path/sql_file:1: ERROR:  value 10 out of bounds for option "compresslevel"
-DETAIL:  Valid values are between "0" and "9".
-Select datconfig from pg_database where datname='dsp_db2';
- datconfig 
------------
- 
-(1 row)
-
 -- Set database level Guc to 2, and create compresstype=quicklz
 Alter database dsp_db2 set gp_default_storage_options="appendonly=true, compresslevel=2";
 ALTER DATABASE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/access_methods/storage_parameters/expected/role_compresslevel.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/access_methods/storage_parameters/expected/role_compresslevel.ans
@@ -3,10 +3,6 @@
 -- Guc value to valid value compresslevel=1
 Alter role dsp_role1 set gp_default_storage_options="appendonly=true, compresslevel=1";
 ALTER ROLE
--- Set the role level guc to an invalid value
-Alter role dsp_role2 set gp_default_storage_options="appendonly=true, compresslevel=10";
-psql:/path/sql_file:1: ERROR:  value 10 out of bounds for option "compresslevel"
-DETAIL:  Valid values are between "0" and "9".
 -- Set role level Guc to 2, and create compresstype=quicklz
 Alter role dsp_role3 set gp_default_storage_options="appendonly=true, compresslevel=2";
 ALTER ROLE
@@ -335,13 +331,6 @@ select compresslevel, compresstype, blocksize, checksum, columnstore from pg_app
 
 Drop table ao_rl_cl_t6;
 DROP TABLE
--- Create table with invalid value compresslevel=10
-Drop table if exists ao_rl_cl_t4;
-psql:/path/sql_file:1: NOTICE:  table "ao_rl_cl_t4" does not exist, skipping
-DROP TABLE
-Create table ao_rl_cl_t4 ( i int, j int) with(compresslevel=10);
-psql:/path/sql_file:1: ERROR:  value 10 out of bounds for option "compresslevel"
-DETAIL:  Valid values are between "0" and "9".
 -- Create table with appendonly=false
 Drop table if exists ao_rl_cl_t4;
 psql:/path/sql_file:1: NOTICE:  table "ao_rl_cl_t4" does not exist, skipping

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/access_methods/storage_parameters/expected/session_compresslevel.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/access_methods/storage_parameters/expected/session_compresslevel.ans
@@ -228,13 +228,6 @@ select attnum, attoptions from pg_attribute_encoding where attrelid='ao_ss_cl_t6
 
 Drop table ao_ss_cl_t6;
 DROP TABLE
--- Create table with invalid value compresslevel=10
-Drop table if exists ao_ss_cl_t4;
-psql:/path/sql_file:1: NOTICE:  table "ao_ss_cl_t4" does not exist, skipping
-DROP TABLE
-Create table ao_ss_cl_t4 ( i int, j int) with(compresslevel=10);
-psql:/path/sql_file:1: ERROR:  value 10 out of bounds for option "compresslevel"
-DETAIL:  Valid values are between "0" and "9".
 -- Create table with appendonly=false
 Drop table if exists ao_ss_cl_t4;
 psql:/path/sql_file:1: NOTICE:  table "ao_ss_cl_t4" does not exist, skipping
@@ -415,10 +408,6 @@ select attnum, attoptions from pg_attribute_encoding where attrelid='ao_ss_cl_t7
 Drop table ao_ss_cl_t7;
 DROP TABLE
 -- ========================
--- Set the session level guc to an invalid value
-SET gp_default_storage_options="appendonly=true, compresslevel=10";
-psql:/path/sql_file:1: ERROR:  value 10 out of bounds for option "compresslevel"
-DETAIL:  Valid values are between "0" and "9".
 -- Set the sessionlevel guc to compresslevel=1 without appendonly=true
 SET gp_default_storage_options="compresslevel=1";
 SET

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/access_methods/storage_parameters/sql/database_compresslevel.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/access_methods/storage_parameters/sql/database_compresslevel.sql
@@ -117,12 +117,6 @@ select compresslevel, compresstype, blocksize, checksum, columnstore from pg_app
 Drop table ao_db_cl_t6;
 
 
--- Create table with invalid value compresslevel=10
-
-Drop table if exists ao_db_cl_t4;
-Create table ao_db_cl_t4 ( i int, j int) with(compresslevel=10);
-
-
 -- Create table with appendonly=false
 
 Drop table if exists ao_db_cl_t4;
@@ -185,11 +179,6 @@ Drop table ao_db_cl_t7;
 
 
 -- ========================
-
--- Set the database level guc to an invalid value
-
-Alter database dsp_db2 set gp_default_storage_options="appendonly=true, compresslevel=10";
-Select datconfig from pg_database where datname='dsp_db2';
 
 -- Set database level Guc to 2, and create compresstype=quicklz
 

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/access_methods/storage_parameters/sql/role_compresslevel.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/access_methods/storage_parameters/sql/role_compresslevel.sql
@@ -5,10 +5,6 @@
 -- Guc value to valid value compresslevel=1
 Alter role dsp_role1 set gp_default_storage_options="appendonly=true, compresslevel=1";
 
--- Set the role level guc to an invalid value
-
-Alter role dsp_role2 set gp_default_storage_options="appendonly=true, compresslevel=10";
-
 -- Set role level Guc to 2, and create compresstype=quicklz
 
 Alter role dsp_role3 set gp_default_storage_options="appendonly=true, compresslevel=2";
@@ -127,12 +123,6 @@ select relkind, relstorage, reloptions from pg_class where relname='ao_rl_cl_t6'
 select compresslevel, compresstype, blocksize, checksum, columnstore from pg_appendonly where relid = (select oid from pg_class where relname='ao_rl_cl_t6');
 
 Drop table ao_rl_cl_t6;
-
-
--- Create table with invalid value compresslevel=10
-
-Drop table if exists ao_rl_cl_t4;
-Create table ao_rl_cl_t4 ( i int, j int) with(compresslevel=10);
 
 
 -- Create table with appendonly=false

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/access_methods/storage_parameters/sql/session_compresslevel.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/access_methods/storage_parameters/sql/session_compresslevel.sql
@@ -91,12 +91,6 @@ select attnum, attoptions from pg_attribute_encoding where attrelid='ao_ss_cl_t6
 Drop table ao_ss_cl_t6;
 
 
--- Create table with invalid value compresslevel=10
-
-Drop table if exists ao_ss_cl_t4;
-Create table ao_ss_cl_t4 ( i int, j int) with(compresslevel=10);
-
-
 -- Create table with appendonly=false
 
 Drop table if exists ao_ss_cl_t4;
@@ -167,10 +161,6 @@ Drop table ao_ss_cl_t7;
 
 
 -- ========================
-
--- Set the session level guc to an invalid value
-
-SET gp_default_storage_options="appendonly=true, compresslevel=10";
 
 -- Set the sessionlevel guc to compresslevel=1 without appendonly=true
 SET gp_default_storage_options="compresslevel=1";


### PR DESCRIPTION
These tests were failing, because commit 724f9d27b1 changed the error
message. Instead of just memorizing the new expected output, let's remove
these tests altogether. We have similar tests in the main regression suite,
that ought to be enough.