### PR TITLE
Rewrite the way query cancel is delivered to ORCA.

### DIFF
--- a/src/backend/gpopt/CGPOptimizer.cpp
+++ b/src/backend/gpopt/CGPOptimizer.cpp
@@ -157,29 +157,6 @@ CGPOptimizer::TerminateGPOPT ()
   gpos_terminate();
 }
 
-// Signal handler for ORCA
-void
-CGPOptimizer::SignalInterruptGPOPT
-	(
-	int iSignal
-	)
-{
-	if (SIGINT == iSignal || SIGTERM == iSignal)
-	{
-		CWorker::abort_requested = true;
-	}
-	// Other signal handlers shouldn't call this method since some other action
-	// than optimization interruption is required in those cases.
-}
-
-// Reset optimizer state to before SignalInterruptGPOPT() was called.
-// To be called after interrupts have been handled by ORCA.
-void
-CGPOptimizer::ResetInterruptsGPOPT (void)
-{
-	CWorker::abort_requested = false;
-}
-
 //---------------------------------------------------------------------------
 //	@function:
 //		PplstmtOptimize
@@ -249,25 +226,6 @@ void TerminateGPOPT ()
 {
 	return CGPOptimizer::TerminateGPOPT();
 }
-}
-
-// Signal handler for ORCA
-extern "C"
-{
-void SignalInterruptGPOPT (int signal)
-{
-	CGPOptimizer::SignalInterruptGPOPT(signal);
-}
-}
-
-// Reset optimizer state to before SignalInterruptGPOPT() was called.
-// To be called after interrupts have been handled by ORCA.
-extern "C"
-{
-	void ResetInterruptsGPOPT ()
-	{
-		CGPOptimizer::ResetInterruptsGPOPT();
-	}
 }
 
 // EOF

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -502,8 +502,6 @@ COptTasks::Execute
 	// initialize DXL support
 	InitDXL();
 
-	bool abort_flag = false;
-
 	CAutoMemoryPool amp(CAutoMemoryPool::ElcNone, CMemoryPoolManager::EatTracker, false /* fThreadSafe */);
 
 	gpos_exec_params params;
@@ -512,7 +510,7 @@ COptTasks::Execute
 	params.stack_start = &params;
 	params.error_buffer = err_buf;
 	params.error_buffer_size = GPOPT_ERROR_BUFFER_SIZE;
-	params.abort_requested = &abort_flag;
+	params.abort_requested = &QueryCancelPending;
 
 	// execute task and send log message to server log
 	GPOS_TRY

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -106,11 +106,6 @@
 #include "utils/session_state.h"
 #include "utils/vmem_tracker.h"
 
-#ifdef USE_ORCA
-extern void SignalInterruptGPOPT(int signal);
-extern void ResetInterruptsGPOPT(void);
-#endif
-
 extern int	optind;
 extern char *optarg;
 
@@ -3517,13 +3512,6 @@ StatementCancelHandler(SIGNAL_ARGS)
 		QueryCancelPending = true;
 		QueryCancelCleanup = true;
 
-#ifdef USE_ORCA
-		if (Gp_role == GP_ROLE_DISPATCH)
-		{
-			SignalInterruptGPOPT(postgres_signal_arg);
-		}
-#endif
-
 		/*
 		 * If it's safe to interrupt, and we're waiting for a lock, service
 		 * the interrupt immediately.  No point in interrupting if we're
@@ -3655,13 +3643,6 @@ ProcessInterrupts(const char* filename, int lineno)
 		gp_simex_run = 0;
 	}
 #endif   /* USE_TEST_UTILS */
-
-#ifdef USE_ORCA
-	if (Gp_role == GP_ROLE_DISPATCH)
-	{
-		ResetInterruptsGPOPT();
-	}
-#endif
 
 	InterruptPending = false;
 	if (ProcDiePending)

--- a/src/include/gpopt/CGPOptimizer.h
+++ b/src/include/gpopt/CGPOptimizer.h
@@ -42,16 +42,6 @@ class CGPOptimizer
 
     static
     void TerminateGPOPT();
-
-    // Signal handler for ORCA
-    static
-    void SignalInterruptGPOPT(int iSignal);
-
-    // Reset optimizer state to before SignalInterruptGPOPT() was called.
-    // To be called after interrupts have been handled by ORCA.
-    static
-    void ResetInterruptsGPOPT();
-
 };
 
 #endif // CGPOptimizer_H

--- a/src/test/unit/mock/gpopt_mock.c
+++ b/src/test/unit/mock/gpopt_mock.c
@@ -57,15 +57,3 @@ TerminateGPOPT ()
 {
 	elog(ERROR, "mock implementation of TerminateGPOPT called");
 }
-
-void
-SignalInterruptGPOPT(int iSignal)
-{
-	elog(ERROR, "mock implementation of SignalInterruptGPOPT called");
-}
-
-void
-ResetInterruptsGPOPT()
-{
-	elog(ERROR, "mock implementation of ResetInterruptsGPOPT called");
-}


### PR DESCRIPTION
Commit 0dfd0ebcc8 added a new global flag to tell ORCA if query cancel has
occurred. However, it was not very careful on when the flag is set, and as
a result, the query cancel was sometimes delivered to wrong query. For
example, the flag was not cleared in the error handler in PostgresMain(),
so if a transaction was aborted, the flag was not cleared, and would cancel
the first query in the next transaction instead. (I think that's what we're
seeing in the CI pipeline.)

Maintaining a second flag, in addition to the QueryCancelPending flag
that's used by the rest of the backend, is going to be difficult to get
right. And even if we get it working now, it's likely to get broken as we
merge with PostgreSQL, if there are changes to where the flag is set or
cleared. Therefore, teach ORCA to check QueryCancelPending directly,
instead. Luckily, there seems to be an existing mechanism in ORCA, where we
can pass a pointer to a global 'bool' variable, which ORCA will then check
at the same points where it checked the new 'abort_requested' flag. It
seems to be tailor-made for exactly this. I'm not sure why it was not
connected to QueryCancelPending before, or why commit 0dfd0ebcc8 didn't
make use of it, but it seems to work.