### PR TITLE
Fix pipeline failures caused by 0dfd0eb.

### DIFF
--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -1966,6 +1966,13 @@ select count(*) from orca.s;
     30
 (1 row)
 
+select gp_inject_fault('opt_relcache_translator_catalog_access', 'reset', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
 -- constants
 select 0.001::numeric from orca.r;
  numeric 

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -1965,6 +1965,14 @@ NOTICE:  Success:
 
 select count(*) from orca.s;
 ERROR:  canceling statement due to user request
+select gp_inject_fault('opt_relcache_translator_catalog_access', 'reset', 1);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
 -- constants
 select 0.001::numeric from orca.r;
  numeric 

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -99,7 +99,9 @@ test: direct_dispatch bfv_dd bfv_dd_multicolumn bfv_dd_types
 # (https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=e5550d5fec66aa74caad1f79b79826ec64898688)
 test: catalog
 
-test: bfv_catalog bfv_index bfv_olap bfv_aggregate bfv_partition bfv_partition_plans DML_over_joins gporca bfv_statistic
+test: gporca
+
+test: bfv_catalog bfv_index bfv_olap bfv_aggregate bfv_partition bfv_partition_plans DML_over_joins bfv_statistic
  
 test: aggregate_with_groupingsets 
 

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -69,6 +69,7 @@ CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 select gp_inject_fault('opt_relcache_translator_catalog_access', 'reset', 1);
 select gp_inject_fault('opt_relcache_translator_catalog_access', 'interrupt', 1);
 select count(*) from orca.s;
+select gp_inject_fault('opt_relcache_translator_catalog_access', 'reset', 1);
 
 -- constants
 


### PR DESCRIPTION
Move gporca regression test out of the parallel group so that
gp_fault_injector functionality works correctly.
Also, as it turns out, ORCA is used to run pg/PLSQL queries sometimes
even when the GUC optimizer is set to off. So when gporca sets up the
gp_fault_injector, it gets activated later on in parallel group
qp_functions_in_from test is part of. So, reset the fault in gporca just
in case.


Running ICG now, but the tests individually pass on my Mac:
```
============== running regression test queries        ==============
test gporca               ... ok
test qp_functions_in_contexts_setup ... ok
test qp_functions_in_from ... ok

=====================
 All 3 tests passed.
=====================
```