### PR TITLE
Remove the extra blank lines in commands

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -64,7 +64,7 @@ Adds additional segments to a pre-existing GPDB Array.
 """)
 
 _help = ["""
-The input file should be be a plain text file with a line for each segment
+The input file should be a plain text file with a line for each segment
 to add with the format:
 
   <hostname>:<port>:<data_directory>:<dbid>:<content>:<definedprimary>

--- a/gpMgmt/bin/gpmovemirrors
+++ b/gpMgmt/bin/gpmovemirrors
@@ -46,7 +46,7 @@ Moves mirror segments in a pre-existing GPDB Array.
 EXECNAME = os.path.split(__file__)[-1]
 
 _help = ["""
-The input file should be be a plain text file with the format:
+The input file should be a plain text file with the format:
 
   filespaceOrder=[<filespace1_fsname>[:<filespace2_fsname>:...]
   <old_address>:<port>:<system_filespace_location> <new_address:port>:<replication_port>:<system_filespace_location>[:<fselocation>:...]

--- a/gpMgmt/bin/gppylib/programs/clsAddMirrors.py
+++ b/gpMgmt/bin/gppylib/programs/clsAddMirrors.py
@@ -667,7 +667,6 @@ class GpAddMirrorsProgram:
             logger.info("******************************************************************")
             logger.info("Mirror segments have been added; data synchronization is in progress.")
             logger.info("Data synchronization will continue in the background.")
-            logger.info("")
             logger.info("Use  gpstate -s  to check the resynchronization progress.")
             logger.info("******************************************************************")
 

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -1225,7 +1225,6 @@ class GpRecoverSegmentProgram:
                                      " Please review the output in the gprecoverseg log.")
                 self.logger.info("There is a resynchronization running in the background to bring all")
                 self.logger.info("segments in sync.")
-                self.logger.info("")
                 self.logger.info("Use gpstate -e to check the resynchronization progress.")
                 self.logger.info("******************************************************************")
 
@@ -1257,7 +1256,6 @@ class GpRecoverSegmentProgram:
             self.logger.info("******************************************************************")
             self.logger.info("Updating segments for resynchronization is completed.")
             self.logger.info("For segments updated successfully, resynchronization will continue in the background.")
-            self.logger.info("")
             self.logger.info("Use  gpstate -s  to check the resynchronization progress.")
             self.logger.info("******************************************************************")
 


### PR DESCRIPTION
When I used the command gprecoverseg, I found that there was an extra blank line to display, so I looked for other commands.

$ gprecoverseg 
...
20171129:18:04:27:004092 gprecoverseg:node:gp5.0-[INFO]:-For segments updated successfully, resynchronization will continue in the background.
20171129:18:04:27:004092 gprecoverseg:node:gp5.0-[INFO]:-
20171129:18:04:27:004092 gprecoverseg:node:gp5.0-[INFO]:-Use  gpstate -s  to check the resynchronization progress.
...

$ gprecoverseg -r
...
20171129:18:06:21:004435 gprecoverseg:node:gp5.0-[INFO]:-For segments updated successfully, resynchronization will continue in the background.
20171129:18:06:21:004435 gprecoverseg:node:gp5.0-[INFO]:-
20171129:18:06:21:004435 gprecoverseg:node:gp5.0-[INFO]:-Use  gpstate -s  to check the resynchronization progress.
...
20171129:18:06:21:004435 gprecoverseg:node:gp5.0-[INFO]:-segments in sync.
20171129:18:06:21:004435 gprecoverseg:node:gp5.0-[INFO]:-
20171129:18:06:21:004435 gprecoverseg:node:gp5.0-[INFO]:-Use gpstate -e to check the resynchronization progress.
...

$ gpaddmirrors -i add_mirror_config_file -B 1
...
20171129:23:48:06:035711 gpaddmirrors:node1:gp5.0-[INFO]:-Data synchronization will continue in the background.
20171129:23:48:06:035711 gpaddmirrors:node1:gp5.0-[INFO]:-
20171129:23:48:06:035711 gpaddmirrors:node1:gp5.0-[INFO]:-Use  gpstate -s  to check the resynchronization progress.
...