### PR TITLE
Implement the NOTICE when REVOKE is a no-op differently.

### DIFF
--- a/contrib/extprotocol/expected/exttableext.out
+++ b/contrib/extprotocol/expected/exttableext.out
@@ -2070,7 +2070,7 @@ drop cascades to external table exttabtest_w_new
     -- As superuser, REVOKE ALL privileges on protocol from non-privileged user demoprot_nopriv
     -- Both SELECT and INSERT permissions are revoked
     REVOKE ALL ON PROTOCOL demoprot FROM demoprot_nopriv;
-NOTICE:  no privileges could be revoked from role demoprot_nopriv on object demoprot
+NOTICE:  no privileges could be revoked
     -- login as non-privileged user "demoprot_nopriv"
     SET ROLE demoprot_nopriv;
     select user;
@@ -2166,7 +2166,7 @@ NOTICE:  drop cascades to external table exttabtest_r_new
     GRANT SELECT ON exttabtest TO demoprot_nopriv;
     -- As superuser, REVOKE SElECT privilege on protocol from non-privileged user demoprot_nopriv
     REVOKE SELECT ON PROTOCOL demoprot FROM demoprot_nopriv;
-NOTICE:  no privileges could be revoked from role demoprot_nopriv on object demoprot
+NOTICE:  no privileges could be revoked
     -- login as non-privileged user "demoprot_nopriv"
     SET ROLE demoprot_nopriv;
     select user;
@@ -2244,7 +2244,7 @@ NOTICE:  drop cascades to external table exttabtest_w_new
     GRANT SELECT ON exttabtest TO demoprot_nopriv;
     -- As superuser, REVOKE INSERT privilege on protocol from non-privileged user demoprot_nopriv
     REVOKE INSERT ON PROTOCOL demoprot FROM demoprot_nopriv;
-NOTICE:  no privileges could be revoked from role demoprot_nopriv on object demoprot
+NOTICE:  no privileges could be revoked
     -- login as non-privileged user "demoprot_nopriv"
     SET ROLE demoprot_nopriv;
     select user;

--- a/src/include/utils/acl.h
+++ b/src/include/utils/acl.h
@@ -221,7 +221,7 @@ typedef struct
  */
 extern Acl *acldefault(GrantObjectType objtype, Oid ownerId);
 extern Acl *aclupdate(const Acl *old_acl, const AclItem *mod_aip,
-		  int modechg, Oid ownerId, DropBehavior behavior, char *objName);
+		  int modechg, Oid ownerId, DropBehavior behavior);
 extern Acl *aclnewowner(const Acl *old_acl, Oid oldOwnerId, Oid newOwnerId);
 
 extern AclMode aclmask(const Acl *acl, Oid roleid, Oid ownerId,
@@ -240,6 +240,9 @@ extern void select_best_grantor(Oid roleId, AclMode privileges,
 					Oid *grantorId, AclMode *grantOptions);
 
 extern void initialize_acl(void);
+
+extern bool revoked_something;
+
 
 /*
  * SQL functions (from acl.c)

--- a/src/test/regress/expected/gp_owner_permission.out
+++ b/src/test/regress/expected/gp_owner_permission.out
@@ -16,19 +16,19 @@ CREATE INDEX idx_mytab1_heap ON mytab1_heap(b);
 INSERT INTO mytab1_heap SELECT a , a - 10 FROM generate_series(1,100) a;
 DELETE FROM mytab1_heap WHERE a % 4 = 0;
 REVOKE ALL PRIVILEGES ON mytab1_heap FROM test2;
-NOTICE:  no privileges could be revoked from role test2 on object mytab1_heap
+NOTICE:  no privileges could be revoked
 CREATE TABLE mytab1_ao(a int, b int) WITH (appendonly = TRUE);
 CREATE INDEX idx_mytab1_ao ON mytab1_ao(b);
 INSERT INTO mytab1_ao SELECT a , a - 10 FROM generate_series(1,100) a;
 DELETE FROM mytab1_ao WHERE a % 4 = 0;
 REVOKE ALL PRIVILEGES ON mytab1_ao FROM test2;
-NOTICE:  no privileges could be revoked from role test2 on object mytab1_ao
+NOTICE:  no privileges could be revoked
 CREATE TABLE mytab1_aoco(a int, b int) WITH (appendonly = TRUE, orientation = COLUMN);
 CREATE INDEX idx_mytab1_aoco ON mytab1_aoco(b);
 INSERT INTO mytab1_aoco SELECT a , a - 10 FROM generate_series(1,100) a;
 DELETE FROM mytab1_aoco WHERE a % 4 = 0;
 REVOKE ALL PRIVILEGES ON mytab1_aoco FROM test2;
-NOTICE:  no privileges could be revoked from role test2 on object mytab1_aoco
+NOTICE:  no privileges could be revoked
 COMMIT;
 SET role = test2;
 SET client_min_messages=WARNING;

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -459,7 +459,7 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 grant select on foo_p to part_role;
 revoke all on bar_p from part_role;
-NOTICE:  no privileges could be revoked from role part_role on object bar_p
+NOTICE:  no privileges could be revoked
 select has_table_privilege('part_role', 'foo_p_1_prt_6'::regclass, 'select');
  has_table_privilege 
 ---------------------
@@ -2739,10 +2739,7 @@ NOTICE:  CREATE TABLE will create partition "a_1_prt_g" for table "a"
 NOTICE:  CREATE TABLE will create partition "a_1_prt_g_2_prt_h" for table "a_1_prt_g"
 NOTICE:  CREATE TABLE will create partition "a_1_prt_g_2_prt_h_3_prt_i" for table "a_1_prt_g_2_prt_h"
 revoke all on a from public;
-NOTICE:  no privileges could be revoked from role PUBLIC on object a_1_prt_g
-NOTICE:  no privileges could be revoked from role PUBLIC on object a_1_prt_g_2_prt_h
-NOTICE:  no privileges could be revoked from role PUBLIC on object a_1_prt_g_2_prt_h_3_prt_i
-NOTICE:  no privileges could be revoked from role PUBLIC on object a
+NOTICE:  no privileges could be revoked
 grant insert on a to part_role;
 -- revoke it from one existing partition, to make sure we don't screw up
 -- existing permissions
@@ -2807,9 +2804,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 NOTICE:  CREATE TABLE will create partition "a_1_prt_f_1" for table "a"
 NOTICE:  CREATE TABLE will create partition "a_1_prt_f_2" for table "a"
 revoke all on a from public;
-NOTICE:  no privileges could be revoked from role PUBLIC on object a_1_prt_f_1
-NOTICE:  no privileges could be revoked from role PUBLIC on object a_1_prt_f_2
-NOTICE:  no privileges could be revoked from role PUBLIC on object a
+NOTICE:  no privileges could be revoked
 grant insert on a to part_role;
 alter table a split partition for(rank(1)) at (date '2006-01-01')
   into (partition f, partition g);

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -459,7 +459,7 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 grant select on foo_p to part_role;
 revoke all on bar_p from part_role;
-NOTICE:  no privileges could be revoked from role part_role on object bar_p
+NOTICE:  no privileges could be revoked
 select has_table_privilege('part_role', 'foo_p_1_prt_6'::regclass, 'select');
  has_table_privilege 
 ---------------------
@@ -2738,10 +2738,7 @@ NOTICE:  CREATE TABLE will create partition "a_1_prt_g" for table "a"
 NOTICE:  CREATE TABLE will create partition "a_1_prt_g_2_prt_h" for table "a_1_prt_g"
 NOTICE:  CREATE TABLE will create partition "a_1_prt_g_2_prt_h_3_prt_i" for table "a_1_prt_g_2_prt_h"
 revoke all on a from public;
-NOTICE:  no privileges could be revoked from role PUBLIC on object a_1_prt_g
-NOTICE:  no privileges could be revoked from role PUBLIC on object a_1_prt_g_2_prt_h
-NOTICE:  no privileges could be revoked from role PUBLIC on object a_1_prt_g_2_prt_h_3_prt_i
-NOTICE:  no privileges could be revoked from role PUBLIC on object a
+NOTICE:  no privileges could be revoked
 grant insert on a to part_role;
 -- revoke it from one existing partition, to make sure we don't screw up
 -- existing permissions
@@ -2806,9 +2803,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 NOTICE:  CREATE TABLE will create partition "a_1_prt_f_1" for table "a"
 NOTICE:  CREATE TABLE will create partition "a_1_prt_f_2" for table "a"
 revoke all on a from public;
-NOTICE:  no privileges could be revoked from role PUBLIC on object a_1_prt_f_1
-NOTICE:  no privileges could be revoked from role PUBLIC on object a_1_prt_f_2
-NOTICE:  no privileges could be revoked from role PUBLIC on object a
+NOTICE:  no privileges could be revoked
 grant insert on a to part_role;
 alter table a split partition for(rank(1)) at (date '2006-01-01')
   into (partition f, partition g);

--- a/src/test/regress/expected/privileges.out
+++ b/src/test/regress/expected/privileges.out
@@ -52,7 +52,7 @@ BEGIN;
 LOCK atest1 IN ACCESS EXCLUSIVE MODE;
 COMMIT;
 REVOKE ALL ON atest1 FROM PUBLIC;
-NOTICE:  no privileges could be revoked from role PUBLIC on object atest1
+NOTICE:  no privileges could be revoked
 SELECT * FROM atest1;
  a | b 
 ---+---
@@ -608,7 +608,7 @@ GRANT UPDATE ON atest4 TO regressuser3; -- fail
 WARNING:  no privileges were granted for "atest4"
 SET SESSION AUTHORIZATION regressuser1;
 REVOKE SELECT ON atest4 FROM regressuser3; -- does nothing
-NOTICE:  no privileges could be revoked from role regressuser3 on object atest4
+NOTICE:  no privileges could be revoked
 SELECT has_table_privilege('regressuser3', 'atest4', 'SELECT'); -- true
  has_table_privilege 
 ---------------------


### PR DESCRIPTION
See discussion at:

https://groups.google.com/a/greenplum.org/d/msg/gpdb-dev/Ttn_UJb4Otg/LS1cFrDiAwAJ

This gives a less verbose message that doesn't mention the object or role name. Also, if you list multiple roles or tables, you only get a NOTICE, if nothing was revoked from any of the objects. Currently you get a NOTICE for each object and role separately.