### PR TITLE
Fix issue that rows are inserted into wrong partitions

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14446,16 +14446,32 @@ split_rows(Relation intoa, Relation intob, Relation temprel)
 	/* constr might not be defined if this is a default partition */
 	if (intoa->rd_att->constr && intoa->rd_att->constr->num_check)
 	{
-		Node *bin = (Node *)make_ands_implicit(
-				(Expr *)stringToNode(intoa->rd_att->constr->check[0].ccbin));
-		achk = ExecPrepareExpr((Expr *)bin, estate);
+		uint16 idx;
+		List *bins = NIL;
+		
+		for (idx = 0; idx < intoa->rd_att->constr->num_check; idx++)
+		{
+			bins = list_concat(bins,
+					make_ands_implicit(
+						(Expr *)stringToNode(intoa->rd_att->constr->check[idx].ccbin)));
+		}
+
+		achk = ExecPrepareExpr((Expr *)bins, estate);
 	}
 
 	if (intob->rd_att->constr && intob->rd_att->constr->num_check)
 	{
-		Node *bin = (Node *)make_ands_implicit(
-				(Expr *)stringToNode(intob->rd_att->constr->check[0].ccbin));
-		bchk = ExecPrepareExpr((Expr *)bin, estate);
+		uint16 idx;
+		List *bins = NIL;
+		
+		for (idx = 0; idx < intob->rd_att->constr->num_check; idx++)
+		{
+			bins = list_concat(bins,
+					make_ands_implicit(
+						(Expr *)stringToNode(intob->rd_att->constr->check[idx].ccbin)));
+		}
+
+		bchk = ExecPrepareExpr((Expr *)bins, estate);
 	}
 
 	/* be careful about AO vs. normal heap tables */


### PR DESCRIPTION
Command "alter table xxxx alter partition xxx split default partition into xxx" splits an existing partition into two new partitions, previously split_rows() only checked the first constraint of
the new partitions to decide the target partition of the row which was proved to be incorrect and
rows may be split into unexpected partitions, this commit does a full check of all constraints of a
partition to make sure rows are inserted correctly. 

This fixes the flaky partition test cases #4051, ICW passed, @vraghavan78 @ashwinstar @asimrp 
please help to review, I 'm not expert in partition stuff, so just feel free to draft another PR if needed. 
