### PR TITLE
Add tests for the effect of --extra-version-suffix

### DIFF
--- a/concourse/scripts/deb_test_package.bash
+++ b/concourse/scripts/deb_test_package.bash
@@ -9,3 +9,6 @@ ${CURRENT_DIR}/gpdb_src/concourse/scripts/setup_gpadmin_user.bash
 su - gpadmin ${CURRENT_DIR}/gpdb_src/concourse/scripts/deb_init_cluster.bash
 su - gpadmin ${CURRENT_DIR}/gpdb_src/concourse/scripts/deb_test_cluster.bash
 
+su - gpadmin -c "source /opt/gpdb/greenplum_path.sh && psql -t -U gpadmin template1 -c 'select version()' | grep '\-oss'"
+# gpssh replaces "-" with " " in version string
+su - gpadmin -c "source /opt/gpdb/greenplum_path.sh && gpssh --version | grep ' oss'"


### PR DESCRIPTION
- should append to both psql 'select version()' and also to 'gpssh --version'
