### PR TITLE
Sleep after launching krb5kdc, to make sure it's up and running before use.

### DIFF
--- a/src/test/kerberos/installcheck.sh
+++ b/src/test/kerberos/installcheck.sh
@@ -50,7 +50,7 @@ bash setup-kdc.sh
 ###
 # Launch KDC daemon. (Note that -P requires an absolute path)
 #
-# We use the -n option to prevent it from detaching, but we put  it to
+# We use the -n option to prevent it from detaching, but we put it to
 # background with &. This way, it gets killed if the terminal session is
 # closed.
 LD_LIBRARY_PATH= krb5kdc -p 7500 -r GPDB.EXAMPLE -P "$(pwd)/krb5kdc.pid" -n &
@@ -63,6 +63,9 @@ wait %1
 }
 
 trap kill_kdc_pid EXIT
+
+# Sleep a little, to give krb5kdc time to start up.
+sleep 2
 
 ###
 # test KDC without exiting make, to ensure that server is stopped


### PR DESCRIPTION
Since commit 79b64dab99, the Kerberos test runs much faster. We've seen
sporadic failures in the pipeline since then. I suspect that's because
krb5kdc daemon has not fully started up, before the test tries to connect
to it. Add a 2-second delay after launching krb5kdc, to hopefully fix that.