### PR TITLE
gpexpand: test parallelism more loosely to reduce flakes

### DIFF
--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/utilities/gpexpand/scenarios/run_gpexpand.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/utilities/gpexpand/scenarios/run_gpexpand.py
@@ -457,7 +457,8 @@ class GpExpandTests(MPPTestCase):
         max_parallel = -1
         prev_count = int(number_of_parallel_table_redistributed)
 
-        while int(tables_in_progress) != int(number_of_parallel_table_redistributed) and int(tables_completed)<int(number_of_parallel_table_redistributed):
+        minimum_acceptable_evidence_of_parallelism = 2
+        while int(tables_in_progress) < minimum_acceptable_evidence_of_parallelism and int(tables_completed)<int(number_of_parallel_table_redistributed):
             tables_in_progress = self.get_value_from_query("select count(*) from gpexpand.status_detail where status='IN PROGRESS';")
             tables_completed = self.get_value_from_query("select count(*) from gpexpand.status_detail where status='COMPLETED';")
             tinctest.logger.info("waiting to reach desired number of parallel redistributions \ntables_completed : " + tables_completed)
@@ -466,7 +467,7 @@ class GpExpandTests(MPPTestCase):
             if int(tables_in_progress) > max_parallel:
                 max_parallel = int(tables_in_progress)
 
-        if max_parallel < int(number_of_parallel_table_redistributed):
+        if max_parallel < minimum_acceptable_evidence_of_parallelism:
             self.fail("The specified value was never reached.")
 
         while True :


### PR DESCRIPTION
The parallelism tests were too stringent, wanting to observe maximum parallelism
in order to go green. An example failure we saw was as follows, when 3 threads
had been "In Progress" together, but not all four (because one thread finished
really quickly):

`Worker GpExpandTests.check_number_of_parallel_tables_expanded_case_1 failed
execution: AssertionError: The specified value was never reached.`

Now, we simply assert that some parallelism is observed at some point (2 or more
"In Progress" at a time). If a test run "flakes" such that there never were two
"In Progress" at a time, that would be indistinguishable from serial execution,
so the test would still fail.

Author: C.J. Jameson <cjameson@pivotal.io>
Author: Shoaib Lari <slari@pivotal.io>