### PR TITLE
Slight revamp of the partition tests

### DIFF
--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -803,6 +803,18 @@ ERROR:  cannot EXCHANGE PARTITION for relation "sto_ao_ao" -- partition has chil
 drop table sto_ao_ao;
 drop table exh_ao_ao;
 -- XXX: not yet: VALIDATE parameter
+-- Exchange a partition with an external table; ensure that we require to use
+-- WITHOUT VALIDATION and that the new partition won't be included in TRUNCATE
+create table foo_p (i int, j int) distributed by (i) partition by range(j) (start(1) end(10) every(2));
+create readable external table bar_p(i int, j int) location ('gpfdist://host.invalid:8000/file') format 'text';
+alter table foo_p exchange partition for(rank(3)) with table bar_p;
+ERROR:  validation of external tables not supported
+HINT:  Use WITHOUT VALIDATION.
+alter table foo_p exchange partition for(rank(3)) with table bar_p without validation;
+truncate foo_p;
+ERROR:  "foo_p_1_prt_3" is an external relation and can't be truncated
+drop table foo_p;
+drop table bar_p;
 -- Check for overflow of circular data types like time
 -- Should fail
 CREATE TABLE TIME_TBL_HOUR_2 (f1 time(2)) distributed by (f1)

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -128,101 +128,43 @@ DETAIL: Key (r_regionkey)=(7) already exists.
 drop table region;
 -- exchange
 -- 1) test all sanity checking
+create table foo_p (i int, j int) distributed by (i)
+partition by range(j)
+(start(1) end(10) every(1));
+NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_1" for table "foo_p"
+NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_2" for table "foo_p"
+NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_3" for table "foo_p"
+NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_4" for table "foo_p"
+NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_5" for table "foo_p"
+NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_6" for table "foo_p"
+NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_7" for table "foo_p"
+NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_8" for table "foo_p"
+NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_9" for table "foo_p"
 -- policies are different
-create table foo_p (i int, j int) distributed by (i)
-partition by range(j)
-(start(1) end(10) every(1));
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_1" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_2" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_3" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_4" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_5" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_6" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_7" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_8" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_9" for table "foo_p"
-create table bar_p (i int, j int) distributed by (j);
+create table bar_p_diff_pol (i int, j int) distributed by (j);
 -- should fail
-alter table foo_p exchange partition for(rank(6)) with table bar_p;
-ERROR:  distribution policy for "bar_p" must be the same as that for "foo_p"
-drop table foo_p;
-drop table bar_p;
+alter table foo_p exchange partition for(rank(6)) with table bar_p_diff_pol;
+ERROR:  distribution policy for "bar_p_diff_pol" must be the same as that for "foo_p"
 -- random policy vs. hash policy
-create table foo_p (i int, j int) distributed by (i)
-partition by range(j)
-(start(1) end(10) every(1));
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_1" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_2" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_3" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_4" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_5" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_6" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_7" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_8" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_9" for table "foo_p"
-create table bar_p (i int, j int) distributed randomly;
+create table bar_p_rand_pol (i int, j int) distributed randomly;
 -- should fail
-alter table foo_p exchange partition for(rank(6)) with table bar_p;
-ERROR:  distribution policy for "bar_p" must be the same as that for "foo_p"
-drop table foo_p;
-drop table bar_p;
+alter table foo_p exchange partition for(rank(6)) with table bar_p_rand_pol;
+ERROR:  distribution policy for "bar_p_rand_pol" must be the same as that for "foo_p"
 -- different number of columns
-create table foo_p (i int, j int, k text) distributed by (i)
-partition by range(j)
-(start(1) end(10) every(1));
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_1" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_2" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_3" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_4" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_5" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_6" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_7" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_8" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_9" for table "foo_p"
-create table bar_p (i int, j int) distributed by (i);
+create table bar_p_diff_col (i int, j int, k int) distributed by (i);
 -- should fail
-alter table foo_p exchange partition for(rank(6)) with table bar_p;
-ERROR:  relation "bar_p" must have the same number columns as relation "foo_p"
-drop table foo_p;
-drop table bar_p;
+alter table foo_p exchange partition for(rank(6)) with table bar_p_diff_col;
+ERROR:  relation "bar_p_diff_col" must have the same number columns as relation "foo_p"
 -- different types
-create table foo_p (i int, j int) distributed by (i)
-partition by range(j)
-(start(1) end(10) every(1));
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_1" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_2" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_3" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_4" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_5" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_6" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_7" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_8" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_9" for table "foo_p"
-create table bar_p (i int, j int8) distributed by (i);
+create table bar_p_diff_typ (i int, j int8) distributed by (i);
 -- should fail
-alter table foo_p exchange partition for(rank(6)) with table bar_p;
+alter table foo_p exchange partition for(rank(6)) with table bar_p_diff_typ;
 ERROR:  type mismatch for attribute "j"
-drop table foo_p;
-drop table bar_p;
 -- different column names
-create table foo_p (i int, j int) distributed by (i)
-partition by range(j)
-(start(1) end(10) every(1));
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_1" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_2" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_3" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_4" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_5" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_6" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_7" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_8" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_9" for table "foo_p"
-create table bar_p (i int, m int) distributed by (i);
+create table bar_p_diff_colnam (i int, m int) distributed by (i);
 -- should fail
-alter table foo_p exchange partition for(rank(6)) with table bar_p;
-ERROR:  relation "bar_p" must have the same column names and column order as "foo_p"
-drop table foo_p;
-drop table bar_p;
+alter table foo_p exchange partition for(rank(6)) with table bar_p_diff_colnam;
+ERROR:  relation "bar_p_diff_colnam" must have the same column names and column order as "foo_p"
 -- still different schema, but more than one level partitioning
 CREATE TABLE two_level_pt(a int, b int, c int)
 DISTRIBUTED BY (a)
@@ -243,18 +185,6 @@ ERROR:  relation "candidate_for_leaf" must have the same column names and column
 -- different owner 
 create role part_role;
 NOTICE:  resource queue required -- using default resource queue "pg_default"
-create table foo_p (i int, j int) distributed by (i)
-partition by range(j)
-(start(1) end(10) every(1));
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_1" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_2" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_3" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_4" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_5" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_6" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_7" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_8" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_9" for table "foo_p"
 create table bar_p (i int, j int) distributed by (i);
 set session authorization part_role;
 -- should fail
@@ -347,44 +277,18 @@ NOTICE:  Table has parent, setting distribution columns to match parent table
 -- should fail
 alter table foo_p exchange partition for(rank(6)) with table bar_p;
 ERROR:  cannot exchange table "bar_p" as it inherits other table(s)
-drop table foo_p;
 drop table bar_p;
 drop table barparent;
 -- non-partition table involved in inheritance
-create table foo_p (i int, j int) distributed by (i)
-partition by range(j)
-(start(1) end(10) every(1));
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_1" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_2" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_3" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_4" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_5" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_6" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_7" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_8" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_9" for table "foo_p"
 create table bar_p(i int, j int) distributed by (i);
 create table barchild () inherits(bar_p);
 NOTICE:  Table has parent, setting distribution columns to match parent table
 -- should fail
 alter table foo_p exchange partition for(rank(6)) with table bar_p;
 ERROR:  cannot EXCHANGE table "bar_p" as it has child table(s)
-drop table foo_p;
 drop table barchild;
 drop table bar_p;
 -- rules on non-partition table
-create table foo_p (i int, j int) distributed by (i)
-partition by range(j)
-(start(1) end(10) every(1));
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_1" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_2" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_3" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_4" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_5" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_6" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_7" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_8" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_9" for table "foo_p"
 create table bar_p(i int, j int) distributed by (i);
 create table baz_p(i int, j int) distributed by (i);
 create rule bar_baz as on insert to bar_p do instead insert into baz_p

--- a/src/test/regress/expected/partition1.out
+++ b/src/test/regress/expected/partition1.out
@@ -295,8 +295,8 @@ create table ggg (a char(1), b date, d char(3))
 distributed by (a)
 partition by range (b)
 (
-partition aa start (date '2007-01-01') end (date '2008-01-01'),
-partition bb start (date '2008-01-01') end (date '2009-01-01') 
+partition aa start (date '2007-08-01') end (date '2008-01-01'),
+partition bb start (date '2008-01-01') end (date '2008-03-01') 
 every (interval '10 days'));
 NOTICE:  CREATE TABLE will create partition "ggg_1_prt_aa" for table "ggg"
 NOTICE:  CREATE TABLE will create partition "ggg_1_prt_bb_1" for table "ggg"
@@ -355,8 +355,8 @@ create table ggg (a char(1), b date, d char(3))
 distributed by (a)
 partition by range (b)
 (
-partition aa start (date '2007-01-01') end (date '2008-01-01') inclusive,
-partition bb start (date '2008-01-01') exclusive end (date '2009-01-01') 
+partition aa start (date '2007-08-01') end (date '2008-01-01') inclusive,
+partition bb start (date '2008-01-01') exclusive end (date '2008-03-01') 
 every (interval '10 days'));
 NOTICE:  CREATE TABLE will create partition "ggg_1_prt_aa" for table "ggg"
 NOTICE:  CREATE TABLE will create partition "ggg_1_prt_bb_1" for table "ggg"
@@ -801,22 +801,16 @@ partition by list (gender)
 subpartition by range (year)
 subpartition template (
 start (date '2001-01-01')
-end (date '2006-01-01') every (interval '1 year')) (
+end (date '2003-01-01') every (interval '1 year')) (
 partition boys values ('M'),
 partition girls values ('F')
 );
 NOTICE:  CREATE TABLE will create partition "rank2_1_prt_boys" for table "rank2"
 NOTICE:  CREATE TABLE will create partition "rank2_1_prt_boys_2_prt_1" for table "rank2_1_prt_boys"
 NOTICE:  CREATE TABLE will create partition "rank2_1_prt_boys_2_prt_2" for table "rank2_1_prt_boys"
-NOTICE:  CREATE TABLE will create partition "rank2_1_prt_boys_2_prt_3" for table "rank2_1_prt_boys"
-NOTICE:  CREATE TABLE will create partition "rank2_1_prt_boys_2_prt_4" for table "rank2_1_prt_boys"
-NOTICE:  CREATE TABLE will create partition "rank2_1_prt_boys_2_prt_5" for table "rank2_1_prt_boys"
 NOTICE:  CREATE TABLE will create partition "rank2_1_prt_girls" for table "rank2"
 NOTICE:  CREATE TABLE will create partition "rank2_1_prt_girls_2_prt_1" for table "rank2_1_prt_girls"
 NOTICE:  CREATE TABLE will create partition "rank2_1_prt_girls_2_prt_2" for table "rank2_1_prt_girls"
-NOTICE:  CREATE TABLE will create partition "rank2_1_prt_girls_2_prt_3" for table "rank2_1_prt_girls"
-NOTICE:  CREATE TABLE will create partition "rank2_1_prt_girls_2_prt_4" for table "rank2_1_prt_girls"
-NOTICE:  CREATE TABLE will create partition "rank2_1_prt_girls_2_prt_5" for table "rank2_1_prt_girls"
 drop table rank1 cascade;
 drop table rank2 cascade;
 -- alter table testing

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -803,6 +803,18 @@ ERROR:  cannot EXCHANGE PARTITION for relation "sto_ao_ao" -- partition has chil
 drop table sto_ao_ao;
 drop table exh_ao_ao;
 -- XXX: not yet: VALIDATE parameter
+-- Exchange a partition with an external table; ensure that we require to use
+-- WITHOUT VALIDATION and that the new partition won't be included in TRUNCATE
+create table foo_p (i int, j int) distributed by (i) partition by range(j) (start(1) end(10) every(2));
+create readable external table bar_p(i int, j int) location ('gpfdist://host.invalid:8000/file') format 'text';
+alter table foo_p exchange partition for(rank(3)) with table bar_p;
+ERROR:  validation of external tables not supported
+HINT:  Use WITHOUT VALIDATION.
+alter table foo_p exchange partition for(rank(3)) with table bar_p without validation;
+truncate foo_p;
+ERROR:  "foo_p_1_prt_3" is an external relation and can't be truncated
+drop table foo_p;
+drop table bar_p;
 -- Check for overflow of circular data types like time
 -- Should fail
 CREATE TABLE TIME_TBL_HOUR_2 (f1 time(2)) distributed by (f1)

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -128,101 +128,43 @@ DETAIL: Key (r_regionkey)=(7) already exists.
 drop table region;
 -- exchange
 -- 1) test all sanity checking
+create table foo_p (i int, j int) distributed by (i)
+partition by range(j)
+(start(1) end(10) every(1));
+NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_1" for table "foo_p"
+NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_2" for table "foo_p"
+NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_3" for table "foo_p"
+NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_4" for table "foo_p"
+NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_5" for table "foo_p"
+NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_6" for table "foo_p"
+NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_7" for table "foo_p"
+NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_8" for table "foo_p"
+NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_9" for table "foo_p"
 -- policies are different
-create table foo_p (i int, j int) distributed by (i)
-partition by range(j)
-(start(1) end(10) every(1));
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_1" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_2" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_3" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_4" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_5" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_6" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_7" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_8" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_9" for table "foo_p"
-create table bar_p (i int, j int) distributed by (j);
+create table bar_p_diff_pol (i int, j int) distributed by (j);
 -- should fail
-alter table foo_p exchange partition for(rank(6)) with table bar_p;
-ERROR:  distribution policy for "bar_p" must be the same as that for "foo_p"
-drop table foo_p;
-drop table bar_p;
+alter table foo_p exchange partition for(rank(6)) with table bar_p_diff_pol;
+ERROR:  distribution policy for "bar_p_diff_pol" must be the same as that for "foo_p"
 -- random policy vs. hash policy
-create table foo_p (i int, j int) distributed by (i)
-partition by range(j)
-(start(1) end(10) every(1));
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_1" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_2" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_3" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_4" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_5" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_6" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_7" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_8" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_9" for table "foo_p"
-create table bar_p (i int, j int) distributed randomly;
+create table bar_p_rand_pol (i int, j int) distributed randomly;
 -- should fail
-alter table foo_p exchange partition for(rank(6)) with table bar_p;
-ERROR:  distribution policy for "bar_p" must be the same as that for "foo_p"
-drop table foo_p;
-drop table bar_p;
+alter table foo_p exchange partition for(rank(6)) with table bar_p_rand_pol;
+ERROR:  distribution policy for "bar_p_rand_pol" must be the same as that for "foo_p"
 -- different number of columns
-create table foo_p (i int, j int, k text) distributed by (i)
-partition by range(j)
-(start(1) end(10) every(1));
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_1" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_2" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_3" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_4" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_5" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_6" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_7" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_8" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_9" for table "foo_p"
-create table bar_p (i int, j int) distributed by (i);
+create table bar_p_diff_col (i int, j int, k int) distributed by (i);
 -- should fail
-alter table foo_p exchange partition for(rank(6)) with table bar_p;
-ERROR:  relation "bar_p" must have the same number columns as relation "foo_p"
-drop table foo_p;
-drop table bar_p;
+alter table foo_p exchange partition for(rank(6)) with table bar_p_diff_col;
+ERROR:  relation "bar_p_diff_col" must have the same number columns as relation "foo_p"
 -- different types
-create table foo_p (i int, j int) distributed by (i)
-partition by range(j)
-(start(1) end(10) every(1));
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_1" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_2" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_3" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_4" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_5" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_6" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_7" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_8" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_9" for table "foo_p"
-create table bar_p (i int, j int8) distributed by (i);
+create table bar_p_diff_typ (i int, j int8) distributed by (i);
 -- should fail
-alter table foo_p exchange partition for(rank(6)) with table bar_p;
+alter table foo_p exchange partition for(rank(6)) with table bar_p_diff_typ;
 ERROR:  type mismatch for attribute "j"
-drop table foo_p;
-drop table bar_p;
 -- different column names
-create table foo_p (i int, j int) distributed by (i)
-partition by range(j)
-(start(1) end(10) every(1));
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_1" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_2" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_3" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_4" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_5" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_6" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_7" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_8" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_9" for table "foo_p"
-create table bar_p (i int, m int) distributed by (i);
+create table bar_p_diff_colnam (i int, m int) distributed by (i);
 -- should fail
-alter table foo_p exchange partition for(rank(6)) with table bar_p;
-ERROR:  relation "bar_p" must have the same column names and column order as "foo_p"
-drop table foo_p;
-drop table bar_p;
+alter table foo_p exchange partition for(rank(6)) with table bar_p_diff_colnam;
+ERROR:  relation "bar_p_diff_colnam" must have the same column names and column order as "foo_p"
 -- still different schema, but more than one level partitioning
 CREATE TABLE two_level_pt(a int, b int, c int)
 DISTRIBUTED BY (a)
@@ -243,18 +185,6 @@ ERROR:  relation "candidate_for_leaf" must have the same column names and column
 -- different owner 
 create role part_role;
 NOTICE:  resource queue required -- using default resource queue "pg_default"
-create table foo_p (i int, j int) distributed by (i)
-partition by range(j)
-(start(1) end(10) every(1));
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_1" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_2" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_3" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_4" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_5" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_6" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_7" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_8" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_9" for table "foo_p"
 create table bar_p (i int, j int) distributed by (i);
 set session authorization part_role;
 -- should fail
@@ -347,44 +277,18 @@ NOTICE:  Table has parent, setting distribution columns to match parent table
 -- should fail
 alter table foo_p exchange partition for(rank(6)) with table bar_p;
 ERROR:  cannot exchange table "bar_p" as it inherits other table(s)
-drop table foo_p;
 drop table bar_p;
 drop table barparent;
 -- non-partition table involved in inheritance
-create table foo_p (i int, j int) distributed by (i)
-partition by range(j)
-(start(1) end(10) every(1));
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_1" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_2" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_3" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_4" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_5" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_6" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_7" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_8" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_9" for table "foo_p"
 create table bar_p(i int, j int) distributed by (i);
 create table barchild () inherits(bar_p);
 NOTICE:  Table has parent, setting distribution columns to match parent table
 -- should fail
 alter table foo_p exchange partition for(rank(6)) with table bar_p;
 ERROR:  cannot EXCHANGE table "bar_p" as it has child table(s)
-drop table foo_p;
 drop table barchild;
 drop table bar_p;
 -- rules on non-partition table
-create table foo_p (i int, j int) distributed by (i)
-partition by range(j)
-(start(1) end(10) every(1));
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_1" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_2" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_3" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_4" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_5" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_6" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_7" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_8" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_9" for table "foo_p"
 create table bar_p(i int, j int) distributed by (i);
 create table baz_p(i int, j int) distributed by (i);
 create rule bar_baz as on insert to bar_p do instead insert into baz_p

--- a/src/test/regress/expected/partition_storage.out
+++ b/src/test/regress/expected/partition_storage.out
@@ -14,12 +14,6 @@ NOTICE:  CREATE TABLE will create partition "pt_heap_tab_1_prt_ghi" for table "p
 NOTICE:  CREATE TABLE will create partition "pt_heap_tab_1_prt_dft" for table "pt_heap_tab"
 --Create indexes on the table
  -- Partial index
---start_ignore
-drop index if exists heap_idx1 cascade;
-NOTICE:  index "heap_idx1" does not exist, skipping
-drop index if exists heap_idx2 cascade;
-NOTICE:  index "heap_idx2" does not exist, skipping
---end_ignore
  create index heap_idx1 on pt_heap_tab(a) where c > 10;
 NOTICE:  building index for child partition "pt_heap_tab_1_prt_abc"
 NOTICE:  building index for child partition "pt_heap_tab_1_prt_def"
@@ -87,11 +81,6 @@ NOTICE:  CREATE TABLE will create partition "pt_heap_tab_1_prt_xyz2" for table "
 
 --Exchange partition
  -- Create candidate table
---start_ignore
-drop table if exists heap_can cascade;
-drop table if exists ao_can cascade;
-drop table if exists co_can cascade;
---end_ignore
  create table heap_can(like pt_heap_tab);  
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
  create table ao_can(like pt_heap_tab) with (appendonly=true);   
@@ -174,12 +163,6 @@ Distributed by: (a)
  alter table pt_heap_tab drop partition jkl;
  truncate table pt_heap_tab;
 --Further create some more indexes
---start_ignore
-drop index if exists heap_idx3 cascade;
-NOTICE:  index "heap_idx3" does not exist, skipping
-drop index if exists heap_idx4 cascade;
-NOTICE:  index "heap_idx4" does not exist, skipping
---end_ignore
  create index heap_idx3 on pt_heap_tab(c,d) where a = 40 OR a = 50; -- multicol indx
 NOTICE:  building index for child partition "pt_heap_tab_1_prt_mno"
 NOTICE:  building index for child partition "pt_heap_tab_1_prt_abc2"
@@ -210,9 +193,6 @@ NOTICE:  dropped partition "dft" for relation "pt_heap_tab"
 NOTICE:  CREATE TABLE will create partition "pt_heap_tab_1_prt_uvw" for table "pt_heap_tab"
 NOTICE:  CREATE TABLE will create partition "pt_heap_tab_1_prt_dft" for table "pt_heap_tab"
 --Create an AO table with partitions ( having diff storage parameters)
---start_ignore
- drop table if exists pt_ao_tab cascade;
---end_ignore
  Create table  pt_ao_tab(a int, b text, c int , d int, e numeric,success bool) with ( appendonly=true )
  distributed by (a)
  partition by list(b)
@@ -228,12 +208,6 @@ NOTICE:  CREATE TABLE will create partition "pt_ao_tab_1_prt_ghi" for table "pt_
 NOTICE:  CREATE TABLE will create partition "pt_ao_tab_1_prt_dft" for table "pt_ao_tab"
 --Create indexes on the table
  -- Partial index
---start_ignore
-drop index if exists ao_idx1 cascade;
-NOTICE:  index "ao_idx1" does not exist, skipping
-drop index if exists ao_idx2 cascade;
-NOTICE:  index "ao_idx2" does not exist, skipping
---end_ignore
  create index ao_idx1 on pt_ao_tab(a) where c > 10;
 NOTICE:  building index for child partition "pt_ao_tab_1_prt_abc"
 NOTICE:  building index for child partition "pt_ao_tab_1_prt_def"
@@ -390,12 +364,6 @@ Distributed by: (a)
  alter table pt_ao_tab drop partition jkl;
  truncate table pt_ao_tab;
 --Further create some more indexes
---start_ignore
-drop index if exists ao_idx4 cascade;
-NOTICE:  index "ao_idx4" does not exist, skipping
-drop index if exists ao_idx3 cascade;
-NOTICE:  index "ao_idx3" does not exist, skipping
---end_ignore
  create index ao_idx3 on pt_ao_tab(c,d) where a = 40 OR a = 50; -- multicol indx
 NOTICE:  building index for child partition "pt_ao_tab_1_prt_mno"
 NOTICE:  building index for child partition "pt_ao_tab_1_prt_abc1"
@@ -656,12 +624,6 @@ NOTICE:  CREATE TABLE will create partition "pt_heap_tab_rng_1_prt_3" for table 
 NOTICE:  CREATE TABLE will create partition "pt_heap_tab_rng_1_prt_4" for table "pt_heap_tab_rng"
 NOTICE:  CREATE TABLE will create partition "pt_heap_tab_rng_1_prt_5" for table "pt_heap_tab_rng"
 -- Create indexes on the table
---start_ignore
-drop index if exists heap_rng_idx1 cascade;
-NOTICE:  index "heap_rng_idx1" does not exist, skipping
-drop index if exists heap_rng_idx2 cascade;
-NOTICE:  index "heap_rng_idx2" does not exist, skipping
---end_ignore
  -- partial index
  create index heap_rng_idx1 on pt_heap_tab_rng(a) where c > 10;
 NOTICE:  building index for child partition "pt_heap_tab_rng_1_prt_dft"
@@ -805,12 +767,6 @@ Options: appendonly=true, orientation=column
 Distributed by: (a)
 
 -- Create more index indexes
---start_ignore
-drop index if exists heap_rng_idx4 cascade;
-NOTICE:  index "heap_rng_idx4" does not exist, skipping
-drop index if exists heap_rng_idx3 cascade;
-NOTICE:  index "heap_rng_idx3" does not exist, skipping
---end_ignore
  create index heap_rng_idx3 on pt_heap_tab_rng(c,d) where a = 40 OR a = 50; -- multicol indx
 NOTICE:  building index for child partition "pt_heap_tab_rng_1_prt_2"
 NOTICE:  building index for child partition "pt_heap_tab_rng_1_prt_3"
@@ -863,12 +819,6 @@ NOTICE:  CREATE TABLE will create partition "pt_ao_tab_rng_1_prt_3" for table "p
 NOTICE:  CREATE TABLE will create partition "pt_ao_tab_rng_1_prt_4" for table "pt_ao_tab_rng"
 NOTICE:  CREATE TABLE will create partition "pt_ao_tab_rng_1_prt_5" for table "pt_ao_tab_rng"
 --Create indexes on the table
---start_ignore
-drop index if exists ao_rng_idx1 cascade;
-NOTICE:  index "ao_rng_idx1" does not exist, skipping
-drop index if exists ao_rng_idx2 cascade;
-NOTICE:  index "ao_rng_idx2" does not exist, skipping
---end_ignore
  -- partial index
  create index ao_rng_idx1 on pt_ao_tab_rng(a) where c > 10;
 NOTICE:  building index for child partition "pt_ao_tab_rng_1_prt_dft"
@@ -1012,12 +962,6 @@ Options: appendonly=true, orientation=column
 Distributed by: (a)
 
 -- Create more index indexes
---start_ignore
-drop index if exists ao_rng_idx4 cascade;
-NOTICE:  index "ao_rng_idx4" does not exist, skipping
-drop index if exists ao_rng_idx3 cascade;
-NOTICE:  index "ao_rng_idx3" does not exist, skipping
---end_ignore
  create index ao_rng_idx3 on pt_ao_tab_rng(c,d) where a = 40 OR a = 50; -- multicol indx
 NOTICE:  building index for child partition "pt_ao_tab_rng_1_prt_2"
 NOTICE:  building index for child partition "pt_ao_tab_rng_1_prt_3"
@@ -1070,12 +1014,6 @@ NOTICE:  CREATE TABLE will create partition "pt_co_tab_rng_1_prt_3" for table "p
 NOTICE:  CREATE TABLE will create partition "pt_co_tab_rng_1_prt_4" for table "pt_co_tab_rng"
 NOTICE:  CREATE TABLE will create partition "pt_co_tab_rng_1_prt_5" for table "pt_co_tab_rng"
 --Create indexes on the table
---start_ignore
-drop index if exists co_rng_idx1 cascade;
-NOTICE:  index "co_rng_idx1" does not exist, skipping
-drop index if exists co_rng_idx2 cascade;
-NOTICE:  index "co_rng_idx2" does not exist, skipping
---end_ignore
  -- partial index
  create index co_rng_idx1 on pt_co_tab_rng(a) where c > 10;
 NOTICE:  building index for child partition "pt_co_tab_rng_1_prt_dft"
@@ -1219,12 +1157,6 @@ Options: appendonly=true, orientation=column
 Distributed by: (a)
 
 -- Create more index indexes
---start_ignore
-drop index if exists co_rng_idx4 cascade;
-NOTICE:  index "co_rng_idx4" does not exist, skipping
-drop index if exists co_rng_idx3 cascade;
-NOTICE:  index "co_rng_idx3" does not exist, skipping
---end_ignore
  create index co_rng_idx3 on pt_co_tab_rng(c,d) where a = 40 OR a = 50; -- multicol indx
 NOTICE:  building index for child partition "pt_co_tab_rng_1_prt_2"
 NOTICE:  building index for child partition "pt_co_tab_rng_1_prt_3"

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -418,6 +418,15 @@ drop table sto_ao_ao;
 drop table exh_ao_ao;
 -- XXX: not yet: VALIDATE parameter
 
+-- Exchange a partition with an external table; ensure that we require to use
+-- WITHOUT VALIDATION and that the new partition won't be included in TRUNCATE
+create table foo_p (i int, j int) distributed by (i) partition by range(j) (start(1) end(10) every(2));
+create readable external table bar_p(i int, j int) location ('gpfdist://host.invalid:8000/file') format 'text';
+alter table foo_p exchange partition for(rank(3)) with table bar_p;
+alter table foo_p exchange partition for(rank(3)) with table bar_p without validation;
+truncate foo_p;
+drop table foo_p;
+drop table bar_p;
 
 -- Check for overflow of circular data types like time
 -- Should fail

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -60,55 +60,34 @@ drop table region;
 -- exchange
 -- 1) test all sanity checking
 
--- policies are different
 create table foo_p (i int, j int) distributed by (i)
 partition by range(j)
 (start(1) end(10) every(1));
-create table bar_p (i int, j int) distributed by (j);
+
+-- policies are different
+create table bar_p_diff_pol (i int, j int) distributed by (j);
 -- should fail
-alter table foo_p exchange partition for(rank(6)) with table bar_p;
-drop table foo_p;
-drop table bar_p;
+alter table foo_p exchange partition for(rank(6)) with table bar_p_diff_pol;
 
 -- random policy vs. hash policy
-create table foo_p (i int, j int) distributed by (i)
-partition by range(j)
-(start(1) end(10) every(1));
-create table bar_p (i int, j int) distributed randomly;
+create table bar_p_rand_pol (i int, j int) distributed randomly;
 -- should fail
-alter table foo_p exchange partition for(rank(6)) with table bar_p;
-drop table foo_p;
-drop table bar_p;
+alter table foo_p exchange partition for(rank(6)) with table bar_p_rand_pol;
 
 -- different number of columns
-create table foo_p (i int, j int, k text) distributed by (i)
-partition by range(j)
-(start(1) end(10) every(1));
-create table bar_p (i int, j int) distributed by (i);
+create table bar_p_diff_col (i int, j int, k int) distributed by (i);
 -- should fail
-alter table foo_p exchange partition for(rank(6)) with table bar_p;
-drop table foo_p;
-drop table bar_p;
+alter table foo_p exchange partition for(rank(6)) with table bar_p_diff_col;
 
 -- different types
-create table foo_p (i int, j int) distributed by (i)
-partition by range(j)
-(start(1) end(10) every(1));
-create table bar_p (i int, j int8) distributed by (i);
+create table bar_p_diff_typ (i int, j int8) distributed by (i);
 -- should fail
-alter table foo_p exchange partition for(rank(6)) with table bar_p;
-drop table foo_p;
-drop table bar_p;
+alter table foo_p exchange partition for(rank(6)) with table bar_p_diff_typ;
 
 -- different column names
-create table foo_p (i int, j int) distributed by (i)
-partition by range(j)
-(start(1) end(10) every(1));
-create table bar_p (i int, m int) distributed by (i);
+create table bar_p_diff_colnam (i int, m int) distributed by (i);
 -- should fail
-alter table foo_p exchange partition for(rank(6)) with table bar_p;
-drop table foo_p;
-drop table bar_p;
+alter table foo_p exchange partition for(rank(6)) with table bar_p_diff_colnam;
 
 -- still different schema, but more than one level partitioning
 CREATE TABLE two_level_pt(a int, b int, c int)
@@ -128,9 +107,6 @@ ALTER TABLE two_level_pt ALTER PARTITION FOR (1)
 
 -- different owner 
 create role part_role;
-create table foo_p (i int, j int) distributed by (i)
-partition by range(j)
-(start(1) end(10) every(1));
 create table bar_p (i int, j int) distributed by (i);
 set session authorization part_role;
 -- should fail
@@ -184,27 +160,18 @@ create table barparent(i int, j int) distributed by (i);
 create table bar_p () inherits(barparent);
 -- should fail
 alter table foo_p exchange partition for(rank(6)) with table bar_p;
-drop table foo_p;
 drop table bar_p;
 drop table barparent;
 
 -- non-partition table involved in inheritance
-create table foo_p (i int, j int) distributed by (i)
-partition by range(j)
-(start(1) end(10) every(1));
-
 create table bar_p(i int, j int) distributed by (i);
 create table barchild () inherits(bar_p);
 -- should fail
 alter table foo_p exchange partition for(rank(6)) with table bar_p;
-drop table foo_p;
 drop table barchild;
 drop table bar_p;
--- rules on non-partition table
-create table foo_p (i int, j int) distributed by (i)
-partition by range(j)
-(start(1) end(10) every(1));
 
+-- rules on non-partition table
 create table bar_p(i int, j int) distributed by (i);
 create table baz_p(i int, j int) distributed by (i);
 create rule bar_baz as on insert to bar_p do instead insert into baz_p

--- a/src/test/regress/sql/partition1.sql
+++ b/src/test/regress/sql/partition1.sql
@@ -203,8 +203,8 @@ create table ggg (a char(1), b date, d char(3))
 distributed by (a)
 partition by range (b)
 (
-partition aa start (date '2007-01-01') end (date '2008-01-01'),
-partition bb start (date '2008-01-01') end (date '2009-01-01') 
+partition aa start (date '2007-08-01') end (date '2008-01-01'),
+partition bb start (date '2008-01-01') end (date '2008-03-01') 
 every (interval '10 days'));
 
 drop table ggg cascade;
@@ -226,8 +226,8 @@ create table ggg (a char(1), b date, d char(3))
 distributed by (a)
 partition by range (b)
 (
-partition aa start (date '2007-01-01') end (date '2008-01-01') inclusive,
-partition bb start (date '2008-01-01') exclusive end (date '2009-01-01') 
+partition aa start (date '2007-08-01') end (date '2008-01-01') inclusive,
+partition bb start (date '2008-01-01') exclusive end (date '2008-03-01') 
 every (interval '10 days'));
 
 drop table ggg cascade;
@@ -477,7 +477,7 @@ partition by list (gender)
 subpartition by range (year)
 subpartition template (
 start (date '2001-01-01')
-end (date '2006-01-01') every (interval '1 year')) (
+end (date '2003-01-01') every (interval '1 year')) (
 partition boys values ('M'),
 partition girls values ('F')
 );

--- a/src/test/regress/sql/partition_storage.sql
+++ b/src/test/regress/sql/partition_storage.sql
@@ -1,7 +1,4 @@
 --Create a heap table with partitions ( having diff storage parameters)
---start_ignore
-drop table if exists pt_heap_tab cascade;
---end_ignore
  Create table  pt_heap_tab(a int, b text, c int , d int, e numeric,success bool) with ( appendonly=false )
  distributed by (a)
  partition by list(b)
@@ -14,10 +11,6 @@ drop table if exists pt_heap_tab cascade;
 
 --Create indexes on the table
  -- Partial index
---start_ignore
-drop index if exists heap_idx1 cascade;
-drop index if exists heap_idx2 cascade;
---end_ignore
  create index heap_idx1 on pt_heap_tab(a) where c > 10;
 
  -- Expression index
@@ -54,11 +47,6 @@ drop index if exists heap_idx2 cascade;
 
 --Exchange partition
  -- Create candidate table
---start_ignore
-drop table if exists heap_can cascade;
-drop table if exists ao_can cascade;
-drop table if exists co_can cascade;
---end_ignore
  create table heap_can(like pt_heap_tab);  
  create table ao_can(like pt_heap_tab) with (appendonly=true);   
  create table co_can(like pt_heap_tab)  with (appendonly=true,orientation=column);   
@@ -79,10 +67,6 @@ drop table if exists co_can cascade;
  truncate table pt_heap_tab;
 
 --Further create some more indexes
---start_ignore
-drop index if exists heap_idx3 cascade;
-drop index if exists heap_idx4 cascade;
---end_ignore
  create index heap_idx3 on pt_heap_tab(c,d) where a = 40 OR a = 50; -- multicol indx
  CREATE INDEX heap_idx4 ON pt_heap_tab ((b || ' ' || e)); --Expression
 
@@ -92,9 +76,6 @@ drop index if exists heap_idx4 cascade;
 --Split default partition
  alter table pt_heap_tab split default partition at ('uvw') into (partition dft, partition uvw);
 --Create an AO table with partitions ( having diff storage parameters)
---start_ignore
- drop table if exists pt_ao_tab cascade;
---end_ignore
  Create table  pt_ao_tab(a int, b text, c int , d int, e numeric,success bool) with ( appendonly=true )
  distributed by (a)
  partition by list(b)
@@ -107,10 +88,6 @@ drop index if exists heap_idx4 cascade;
 
 --Create indexes on the table
  -- Partial index
---start_ignore
-drop index if exists ao_idx1 cascade;
-drop index if exists ao_idx2 cascade;
---end_ignore
  create index ao_idx1 on pt_ao_tab(a) where c > 10;
 
  -- Expression index
@@ -174,10 +151,6 @@ drop table if exists co_can cascade;
  truncate table pt_ao_tab;
 
 --Further create some more indexes
---start_ignore
-drop index if exists ao_idx4 cascade;
-drop index if exists ao_idx3 cascade;
---end_ignore
  create index ao_idx3 on pt_ao_tab(c,d) where a = 40 OR a = 50; -- multicol indx
  CREATE INDEX ao_idx4 ON pt_ao_tab ((b || ' ' || e)); --Expression
 
@@ -290,10 +263,6 @@ drop table if exists co_can cascade;
  );
 
 -- Create indexes on the table
---start_ignore
-drop index if exists heap_rng_idx1 cascade;
-drop index if exists heap_rng_idx2 cascade;
---end_ignore
 
  -- partial index
  create index heap_rng_idx1 on pt_heap_tab_rng(a) where c > 10;
@@ -342,10 +311,6 @@ drop index if exists heap_rng_idx2 cascade;
  \d+ co_can
  \d+ heap_can
 -- Create more index indexes
---start_ignore
-drop index if exists heap_rng_idx4 cascade;
-drop index if exists heap_rng_idx3 cascade;
---end_ignore
  create index heap_rng_idx3 on pt_heap_tab_rng(c,d) where a = 40 OR a = 50; -- multicol indx
  CREATE INDEX heap_rng_idx4 ON pt_heap_tab_rng ((b || ' ' || e)); --Expression
 
@@ -368,10 +333,6 @@ drop index if exists heap_rng_idx3 cascade;
  );
 
 --Create indexes on the table
---start_ignore
-drop index if exists ao_rng_idx1 cascade;
-drop index if exists ao_rng_idx2 cascade;
---end_ignore
 
  -- partial index
  create index ao_rng_idx1 on pt_ao_tab_rng(a) where c > 10;
@@ -420,10 +381,6 @@ drop table if exists co_can cascade;
  \d+ heap_can
 
 -- Create more index indexes
---start_ignore
-drop index if exists ao_rng_idx4 cascade;
-drop index if exists ao_rng_idx3 cascade;
---end_ignore
 
  create index ao_rng_idx3 on pt_ao_tab_rng(c,d) where a = 40 OR a = 50; -- multicol indx
  CREATE INDEX ao_rng_idx4 ON pt_ao_tab_rng ((b || ' ' || e)); --Expression
@@ -446,10 +403,6 @@ drop index if exists ao_rng_idx3 cascade;
  );
 
 --Create indexes on the table
---start_ignore
-drop index if exists co_rng_idx1 cascade;
-drop index if exists co_rng_idx2 cascade;
---end_ignore
 
  -- partial index
  create index co_rng_idx1 on pt_co_tab_rng(a) where c > 10;
@@ -498,10 +451,6 @@ drop table if exists co_can cascade;
  \d+ heap_can
 
 -- Create more index indexes
---start_ignore
-drop index if exists co_rng_idx4 cascade;
-drop index if exists co_rng_idx3 cascade;
---end_ignore
 
  create index co_rng_idx3 on pt_co_tab_rng(c,d) where a = 40 OR a = 50; -- multicol indx
  CREATE INDEX co_rng_idx4 ON pt_co_tab_rng ((b || ' ' || e)); --Expression


### PR DESCRIPTION
Since ICW is a very longrunning process, attempt to reduce time consumption by reducing overhead during testing while keeping the test constant (coverage not reduced).

Avoid dropping/recreating underlying test tables when not required, reduce the number of partitions in some cases and skip pointless drops for objects we know doesn't exist. In total this shaves about 30-40 seconds off an ICW run on my local machine, mileage may vary.

Also adds a test for exchanging external partitions combined with `TRUNCATE` as that was missing from the coverage.