### PR TITLE
Add documentation for citext module

### DIFF
--- a/gpdb-doc/dita/ref_guide/data_types.xml
+++ b/gpdb-doc/dita/ref_guide/data_types.xml
@@ -12,7 +12,8 @@
     <p>Optional modules in the <filepath>contrib</filepath> directory may also install new data
       types.  The <codeph>hstore</codeph> module, for example, introduces a new data type and
       associated functions for working with key-value pairs. See <xref
-        href="../utility_guide/hstore.xml#topic_vcn_jkq_1bb"/>.</p>
+        href="../utility_guide/hstore.xml#topic_vcn_jkq_1bb"/>. The <codeph>citext</codeph> module 
+        adds a case-insensitive text data type. See <xref href="../utility_guide/citype.xml"/>.</p>
     <p>The following data types are specified by SQL: <i>bit</i>, <i>bit varying</i>,
       <i>boolean</i>, <i>character varying, varchar</i>, <i>character, char</i>, <i>date</i>,
         <i>double precision</i>, <i>integer</i>, <i>interval</i>, <i>numeric</i>, <i>decimal</i>,

--- a/gpdb-doc/dita/ref_guide/data_types.xml
+++ b/gpdb-doc/dita/ref_guide/data_types.xml
@@ -13,7 +13,7 @@
       types.  The <codeph>hstore</codeph> module, for example, introduces a new data type and
       associated functions for working with key-value pairs. See <xref
         href="../utility_guide/hstore.xml#topic_vcn_jkq_1bb"/>. The <codeph>citext</codeph> module 
-        adds a case-insensitive text data type. See <xref href="../utility_guide/citype.xml"/>.</p>
+        adds a case-insensitive text data type. See <xref href="../utility_guide/citext.xml"/>.</p>
     <p>The following data types are specified by SQL: <i>bit</i>, <i>bit varying</i>,
       <i>boolean</i>, <i>character varying, varchar</i>, <i>character, char</i>, <i>date</i>,
         <i>double precision</i>, <i>integer</i>, <i>interval</i>, <i>numeric</i>, <i>decimal</i>,

--- a/gpdb-doc/dita/utility_guide/citext.xml
+++ b/gpdb-doc/dita/utility_guide/citext.xml
@@ -4,7 +4,7 @@
 <topic id="topic1" xml:lang="en">
   <title id="ij138244">citext Data Type</title>
   <body>
-    <p>The citext module provides a case-insensitive character string type, citext. Essentially, it internally calls the <codeph>lower</codeph> function when comparing values. Otherwise, it behaves almost exactly like the text data type.</p>
+    <p>The citext module provides a case-insensitive character string type, <codeph>citext</codeph>. Essentially, it internally calls the <codeph>lower</codeph> function when comparing values. Otherwise, it behaves almost exactly like the <codeph>text</codeph> data type.</p>
     <p>The standard method to perform case-insensitive matches on text values is to use the <codeph>lower</codeph> function when comparing values, for example</p>
     <codeblock>SELECT * FROM tab WHERE lower(col) = LOWER(?);</codeblock>
     <p>This method works well, but has drawbacks:</p>
@@ -13,7 +13,7 @@
       <li>It does not work with an index, unless you create a functional index using <codeph>lower</codeph>.</li>
       <li>If you declare a column as UNIQUE or PRIMARY KEY, the implicitly generated index is case-sensitive. The index cannot be used for case-insensitive searches, and uniqueness is not enforced case-insensitively. </li>
     </ul>
-    <p>The citext data type allows you to eliminate calls to <codeph>lower</codeph> in SQL queries, and allows a primary key to be case-insensitive. citext is locale-aware, like the text type, which means comparing uppercase and lowercase characters depends on the rules of the LC_CTYPE locale setting. This behavior is as the same as using <codeph>lower</codeph> in queries, but it is done transparently by the data type, so you do not have to do anything special in your queries.</p>
+    <p>The <codeph>citext</codeph> data type allows you to eliminate calls to <codeph>lower</codeph> in SQL queries, and allows a primary key to be case-insensitive. <codeph>citext</codeph> is locale-aware, like the <codeph>text</codeph> type, which means comparing uppercase and lowercase characters depends on the rules of the LC_CTYPE locale setting. This behavior is the same as using <codeph>lower</codeph> in queries, but it is done transparently by the data type, so you do not have to do anything special in your queries.</p>
   </body>
   <topic id="topic_axc_qk4_ccb">
     <title>Installing citext</title>
@@ -25,7 +25,7 @@
   <topic id="topic_m4v_r5j_ccb">
     <title>Using the citext Type</title>
     <body>
-      <p>Here is a simple example defining a citext table column:</p>
+      <p>Here is a simple example defining a <codeph>citext</codeph> table column:</p>
       <codeblock>CREATE TABLE users (
     nick CITEXT PRIMARY KEY,
     pass TEXT   NOT NULL
@@ -46,7 +46,7 @@ SELECT * FROM users WHERE nick = 'Larry';
     <title>String Comparison Behavior</title>
     <body>
       <p><codeph>citext</codeph> performs comparisons by converting each string to lower case (as though the <codeph>lower</codeph> function were called) and then comparing the results normally. Two strings are considered equal if <codeph>lower</codeph> would produce identical results for them.</p>
-      <p>In order to emulate a case-insensitive collation as closely as possible, there are <codeph>citext</codeph>-specific versions of a number of string-processing operators and functions. So, for example, the regular expression operators <codeph>~</codeph> and <codeph>~*</codeph> exhibit the same behavior when applied to <codeph>citext</codeph>: they both match case-insensitively. The same is true for <codeph>!~</codeph> and <codeph>!~*</codeph>, as well as for the <codeph>LIKE</codeph> operators <codeph>~~</codeph> and <codeph>~~*</codeph>, and <codeph>!~~</codeph> and <codeph>!~~*</codeph>. If want to match case-sensitively, you can cast the operator's arguments to <codeph>text</codeph>.</p>
+      <p>In order to emulate a case-insensitive collation as closely as possible, there are <codeph>citext</codeph>-specific versions of a number of string-processing operators and functions. So, for example, the regular expression operators <codeph>~</codeph> and <codeph>~*</codeph> exhibit the same behavior when applied to <codeph>citext</codeph>: they both match case-insensitively. The same is true for <codeph>!~</codeph> and <codeph>!~*</codeph>, as well as for the <codeph>LIKE</codeph> operators <codeph>~~</codeph> and <codeph>~~*</codeph>, and <codeph>!~~</codeph> and <codeph>!~~*</codeph>. If you want to match case-sensitively, you can cast the operator's arguments to <codeph>text</codeph>.</p>
       <p>The following functions perform matching case-insensitively if their arguments are <codeph>citext</codeph>:</p>
       <ul id="ul_yjj_z5j_ccb">
         <li><codeph>regexp_match()</codeph></li>
@@ -67,7 +67,7 @@ SELECT * FROM users WHERE nick = 'Larry';
     <body>
       <ul id="ul_jmp_bvj_ccb">
         <li>
-          <p>The citext type's case-folding behavior depends on the <codeph>LC_CTYPE</codeph> setting of your database. How it compares values is therefore determined when the database is created. It is not truly case-insensitive in the terms defined by the Unicode standard. Effectively, what this means is that, as long as you're happy with your collation, you should be happy with <codeph>citext</codeph>'s comparisons. But if you have data in different languages stored in your database, users of one language may find their query results are not as expected if the collation is for another language.</p>
+          <p>The <codeph>citext</codeph> type's case-folding behavior depends on the <codeph>LC_CTYPE</codeph> setting of your database. How it compares values is therefore determined when the database is created. It is not truly case-insensitive in the terms defined by the Unicode standard. Effectively, what this means is that, as long as you're happy with your collation, you should be happy with <codeph>citext</codeph>'s comparisons. But if you have data in different languages stored in your database, users of one language may find their query results are not as expected if the collation is for another language.</p>
         </li>
         <!--<li><p>As of PostgreSQL 9.1, you can attach a <codeph>COLLATE</codeph> specification to <codeph>citext</codeph> columns or data values. Currently, <codeph>citext</codeph> operators will honor a non-default <codeph>COLLATE</codeph> specification while comparing case-folded strings, but the initial folding to lower case is always done according to the database's <codeph>LC_CTYPE</codeph> setting (that is, as though <codeph>COLLATE "default"</codeph> were given). This may be changed in a future release so that both steps follow the input <codeph>COLLATE</codeph> specification.</p></li>-->
         <li><codeph>citext</codeph> is not as efficient as <codeph>text</codeph> because the operator functions and the B-tree comparison functions must make copies of the data and convert them to lower case for comparisons. It is, however, slightly more efficient than using <codeph>lower</codeph> to perform case-insensitive matching.</li>

--- a/gpdb-doc/dita/utility_guide/citext.xml
+++ b/gpdb-doc/dita/utility_guide/citext.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic id="topic1" xml:lang="en">
+  <title id="ij138244">citext Data Type</title>
+  <body>
+    <p>The citext module provides a case-insensitive character string type, citext. Essentially, it internally calls the <codeph>lower</codeph> function when comparing values. Otherwise, it behaves almost exactly like the text data type.</p>
+    <p>The standard method to perform case-insensitive matches on text values is to use the <codeph>lower</codeph> function when comparing values, for example</p>
+    <codeblock>SELECT * FROM tab WHERE lower(col) = LOWER(?);</codeblock>
+    <p>This method works well, but has drawbacks:</p>
+    <ul id="ul_rbq_jk3_ccb">
+      <li>It makes your SQL statements verbose, and you must remember to use <codeph>lower</codeph> on both the column and the query value.</li>
+      <li>It does not work with an index, unless you create a functional index using <codeph>lower</codeph>.</li>
+      <li>If you declare a column as UNIQUE or PRIMARY KEY, the implicitly generated index is case-sensitive. The index cannot be used for case-insensitive searches, and uniqueness is not enforced case-insensitively. </li>
+    </ul>
+    <p>The citext data type allows you to eliminate calls to <codeph>lower</codeph> in SQL queries, and allows a primary key to be case-insensitive. citext is locale-aware, like the text type, which means comparing uppercase and lowercase characters depends on the rules of the LC_CTYPE locale setting. This behavior is as the same as using <codeph>lower</codeph> in queries, but it is done transparently by the data type, so you do not have to do anything special in your queries.</p>
+  </body>
+  <topic id="topic_axc_qk4_ccb">
+    <title>Installing citext</title>
+    <body>
+      <p>Before you can use the <codeph>citext</codeph> data type, run the installation script <codeph>$GPHOME/share/postgresql/contrib/citext.sql</codeph> in each database where you want to use the type:</p>
+      <codeblock>$ psql -d testdb -f $GPHOME/share/postgresql/contrib/citext.sql</codeblock>
+    </body>
+  </topic>
+  <topic id="topic_m4v_r5j_ccb">
+    <title>Using the citext Type</title>
+    <body>
+      <p>Here is a simple example defining a citext table column:</p>
+      <codeblock>CREATE TABLE users (
+    nick CITEXT PRIMARY KEY,
+    pass TEXT   NOT NULL
+);
+
+INSERT INTO users VALUES ( 'larry',  md5(random()::text) );
+INSERT INTO users VALUES ( 'Tom',    md5(random()::text) );
+INSERT INTO users VALUES ( 'Damian', md5(random()::text) );
+INSERT INTO users VALUES ( 'NEAL',   md5(random()::text) );
+INSERT INTO users VALUES ( 'Bjørn',  md5(random()::text) );
+
+SELECT * FROM users WHERE nick = 'Larry';
+</codeblock>
+      <p>The <codeph>SELECT</codeph> statement returns one tuple, even though the <codeph>nick</codeph> column is set to <codeph>larry</codeph> and the query specified <codeph>Larry</codeph>.</p>
+    </body>
+  </topic>
+  <topic id="topic_sz4_x5j_ccb">
+    <title>String Comparison Behavior</title>
+    <body>
+      <p><codeph>citext</codeph> performs comparisons by converting each string to lower case (as though the <codeph>lower</codeph> function were called) and then comparing the results normally. Two strings are considered equal if <codeph>lower</codeph> would produce identical results for them.</p>
+      <p>In order to emulate a case-insensitive collation as closely as possible, there are <codeph>citext</codeph>-specific versions of a number of string-processing operators and functions. So, for example, the regular expression operators <codeph>~</codeph> and <codeph>~*</codeph> exhibit the same behavior when applied to <codeph>citext</codeph>: they both match case-insensitively. The same is true for <codeph>!~</codeph> and <codeph>!~*</codeph>, as well as for the <codeph>LIKE</codeph> operators <codeph>~~</codeph> and <codeph>~~*</codeph>, and <codeph>!~~</codeph> and <codeph>!~~*</codeph>. If want to match case-sensitively, you can cast the operator's arguments to <codeph>text</codeph>.</p>
+      <p>The following functions perform matching case-insensitively if their arguments are <codeph>citext</codeph>:</p>
+      <ul id="ul_yjj_z5j_ccb">
+        <li><codeph>regexp_match()</codeph></li>
+        <li><codeph>regexp_matches()</codeph></li>
+        <li><codeph>regexp_replace()</codeph></li>
+        <li><codeph>regexp_split_to_array()</codeph></li>
+        <li><codeph>regexp_split_to_table()</codeph></li>
+        <li><codeph>replace()</codeph></li>
+        <li><codeph>split_part()</codeph></li>
+        <li><codeph>strpos()</codeph></li>
+        <li><codeph>translate()</codeph></li>
+      </ul>
+      <p>For the regexp functions, if you want to match case-sensitively, you can specify the “c” flag to force a case-sensitive match. If you want case-sensitive behavior, you must cast to <codeph>text</codeph> before using one of these functions.</p>
+    </body>
+  </topic>
+  <topic id="topic_j4w_z5j_ccb">
+    <title>Limitations</title>
+    <body>
+      <ul id="ul_jmp_bvj_ccb">
+        <li>
+          <p>The citext type's case-folding behavior depends on the <codeph>LC_CTYPE</codeph> setting of your database. How it compares values is therefore determined when the database is created. It is not truly case-insensitive in the terms defined by the Unicode standard. Effectively, what this means is that, as long as you're happy with your collation, you should be happy with <codeph>citext</codeph>'s comparisons. But if you have data in different languages stored in your database, users of one language may find their query results are not as expected if the collation is for another language.</p>
+        </li>
+        <!--<li><p>As of PostgreSQL 9.1, you can attach a <codeph>COLLATE</codeph> specification to <codeph>citext</codeph> columns or data values. Currently, <codeph>citext</codeph> operators will honor a non-default <codeph>COLLATE</codeph> specification while comparing case-folded strings, but the initial folding to lower case is always done according to the database's <codeph>LC_CTYPE</codeph> setting (that is, as though <codeph>COLLATE "default"</codeph> were given). This may be changed in a future release so that both steps follow the input <codeph>COLLATE</codeph> specification.</p></li>-->
+        <li><codeph>citext</codeph> is not as efficient as <codeph>text</codeph> because the operator functions and the B-tree comparison functions must make copies of the data and convert them to lower case for comparisons. It is, however, slightly more efficient than using <codeph>lower</codeph> to perform case-insensitive matching.</li>
+        <li><codeph>citext</codeph> may not be the best option if you need data to compare case-sensitively in some contexts and case-insensitively in other contexts. The standard answer is to use the <codeph>text</codeph> type and manually apply the <codeph>lower</codeph> function when you need to compare case-insensitively. This works if case-insensitive comparison is needed only infrequently. If you need case-insensitive behavior most of the time and case-sensitive infrequently, consider storing the data as <codeph>citext</codeph> and explicitly casting the column to <codeph>text</codeph> when you want case-sensitive comparison. In either situation, you will need two indexes if you want both types of searches to be fast.</li>
+        <li>The schema containing the <codeph>citext</codeph> operators must be in the current <codeph>search_path</codeph> (typically <codeph>public</codeph>); if it is not, the normal case-sensitive <codeph>text</codeph> operators will be invoked instead.</li>
+      </ul>
+    </body>
+  </topic>
+</topic>

--- a/gpdb-doc/dita/utility_guide/utility_guide.ditamap
+++ b/gpdb-doc/dita/utility_guide/utility_guide.ditamap
@@ -63,8 +63,8 @@
             </topicref>
         </topicref>
         <topicref href="contrib-modules.xml">
-            <topicref href="dblink.xml"/>
             <topicref href="citext.xml"/>
+            <topicref href="dblink.xml"/>
             <topicref href="hstore.xml"/>
             <topicref href="orafce_ref.xml"/>
             <topicref href="passwordcheck.xml"/>

--- a/gpdb-doc/dita/utility_guide/utility_guide.ditamap
+++ b/gpdb-doc/dita/utility_guide/utility_guide.ditamap
@@ -25,7 +25,7 @@
             <topicref href="admin_utilities/gplogfilter.xml"/>
             <topicref href="admin_utilities/gpmapreduce.xml"/>
             <topicref href="admin_utilities/gpmfr.xml"/>
-<!-- hidden until testing is complete -msk
+            <!-- hidden until testing is complete -msk
             <topicref href="admin_utilities/gpmovemirrors.xml"/>
 -->
             <topicref href="admin_utilities/gpperfmon_install.xml"/>
@@ -64,6 +64,7 @@
         </topicref>
         <topicref href="contrib-modules.xml">
             <topicref href="dblink.xml"/>
+            <topicref href="citext.xml"/>
             <topicref href="hstore.xml"/>
             <topicref href="orafce_ref.xml"/>
             <topicref href="passwordcheck.xml"/>


### PR DESCRIPTION
Adds the citext module to the "Additional Supplied Modules" section of the utility guide. 

Staged for review at http://docs-gpdb-review-staging.cfapps.io/530/utility_guide/citext.html

 