### PR TITLE
Ignore errors when closing external file if QueryFinishPending is true

### DIFF
--- a/src/backend/access/external/fileam.c
+++ b/src/backend/access/external/fileam.c
@@ -402,7 +402,12 @@ external_endscan(FileScanDesc scan)
 	 */
 	if (!scan->fs_noop && scan->fs_file)
 	{
-		url_fclose(scan->fs_file, true, relname);
+		/*
+		 * QueryFinishPending == true means QD have got
+		 * enough tuples and query can return correctly,
+		 * so slient errors when closing external file.
+		 */
+		url_fclose(scan->fs_file, !QueryFinishPending, relname);
 		scan->fs_file = NULL;
 	}
 


### PR DESCRIPTION
In GPDB, a web external scan is mainly divided to 3 steps:
1. url_execute_fopen () forks a child process and creates a pipe so that
child process can execute a command and sends the output back through
the pipe.
2. url_execute_fread () reads data from the pipe until child closed the
peer of the pipe.
3. url_execute_fclose () close the pipe firstly, then wait for the child
process to exit if failOnError is true.

However, for queries with LIMIT clause, QE may receive a query finish
signal after url_execute_fopen () and url_execute_fread() may be skipped
which means parent may close read peer of the pipe before child writing
some data and child will exit with SIGPIPE error. To fixed this, we set
failOnError to false if QueryFinishPending is true so that any errors
when closing external file will be ignored, QueryFinishPending means QD
have got enough tuples and query can return correctly, so it should be
fine to ignore the error in such case.

This fixes issue #4064