### PR TITLE
add test for PXF on ubuntu

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -764,9 +764,10 @@ jobs:
     - get: ubuntu-gpdb-dev-16
       passed: [gate_compile_start]
     - get: ubuntu-gpdb-debian-dev-16
-      passed:
-      - gate_compile_start
+      passed: [gate_compile_start]
     - get: debian_release
+    - get: pxf_src
+      passed: [gate_compile_start]
   - aggregate:
     - task: compile_gpdb
       image: ubuntu-gpdb-dev-16
@@ -2700,7 +2701,7 @@ jobs:
     - task: regression_tests_pxf_hdp_rpm
       input_mapping:
         bin_gpdb: bin_gpdb_centos6
-        singlecluster: singlecluster-HDP
+        singlecluster: singlecluster-hdp
       file: gpdb_src/concourse/tasks/regression_tests_pxf.yml
       image: centos-gpdb-dev-6
       params:
@@ -2711,7 +2712,7 @@ jobs:
     - task: regression_tests_pxf_hdp_tar
       input_mapping:
         bin_gpdb: bin_gpdb_centos6
-        singlecluster: singlecluster-HDP
+        singlecluster: singlecluster-hdp
       file: gpdb_src/concourse/tasks/regression_tests_pxf.yml
       image: centos-gpdb-dev-6
       params:
@@ -2722,7 +2723,7 @@ jobs:
     - task: regression_tests_pxf_cdh_rpm
       input_mapping:
         bin_gpdb: bin_gpdb_centos6
-        singlecluster: singlecluster-CDH
+        singlecluster: singlecluster-cdh
       file: gpdb_src/concourse/tasks/regression_tests_pxf.yml
       image: centos-gpdb-dev-6
       params:
@@ -2733,7 +2734,7 @@ jobs:
     - task: regression_tests_pxf_cdh_tar_centos
       input_mapping:
         bin_gpdb: bin_gpdb_centos6
-        singlecluster: singlecluster-CDH
+        singlecluster: singlecluster-cdh
       file: gpdb_src/concourse/tasks/regression_tests_pxf.yml
       image: centos-gpdb-dev-6
       params:
@@ -2744,7 +2745,7 @@ jobs:
     - task: regression_tests_pxf_cdh_tar_ubuntu
       input_mapping:
         bin_gpdb: compiled_bits_ubuntu16
-        singlecluster: singlecluster-CDH
+        singlecluster: singlecluster-cdh
       file: gpdb_src/concourse/tasks/regression_tests_pxf.yml
       image: ubuntu-gpdb-dev-16
       params:

--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -26,9 +26,10 @@ groups:
   - icw_gporca_sles11
   - icw_planner_ubuntu16
   - icw_gporca_conan_ubuntu16
-  - icw_extensions_gpcloud
   - test_gpdb_debian_package
   - icw_planner_ictcp_centos6
+  - icw_extensions_pxf
+  - icw_extensions_gpcloud
   - icw_gporca_centos6_gpos_memory
   - QP_memory-accounting
   - gate_icw_end
@@ -79,10 +80,7 @@ groups:
   - gate_dpm_end
 ################################
   - gate_ud_start
-  - regression_tests_pxf_hdp_rpm
-  - regression_tests_pxf_hdp_tar
-  - regression_tests_pxf_cdh_rpm
-  - regression_tests_pxf_cdh_tar
+  - icw_extensions_pxf
   - regression_tests_gphdfs_centos
   - gate_ud_end
 ################################
@@ -122,6 +120,7 @@ groups:
   - icw_gporca_centos7
   - icw_gporca_sles11
   - icw_planner_ictcp_centos6
+  - icw_extensions_pxf
   - icw_extensions_gpcloud
   - icw_gporca_centos6_gpos_memory
   - test_gpdb_debian_package
@@ -186,10 +185,7 @@ groups:
 - name: G:UD
   jobs:
   - gate_ud_start
-  - regression_tests_pxf_hdp_rpm
-  - regression_tests_pxf_hdp_tar
-  - regression_tests_pxf_cdh_rpm
-  - regression_tests_pxf_cdh_tar
+  - icw_extensions_pxf
   - regression_tests_gphdfs_centos
   - gate_ud_end
 
@@ -1268,6 +1264,7 @@ jobs:
       - icw_gporca_centos7
       - icw_gporca_sles11
       - icw_planner_ictcp_centos6
+      - icw_extensions_pxf
       - icw_extensions_gpcloud
       - icw_gporca_centos6_gpos_memory
       - QP_memory-accounting
@@ -2678,104 +2675,83 @@ jobs:
     - get: bin_gpdb_centos7
       passed:
       - gate_compile_end
+    - get: compiled_bits_ubuntu16
+      passed:
+      - gate_compile_end
 
-## PXF Regression Test Start
-- name: regression_tests_pxf_hdp_rpm
+- name: icw_extensions_pxf
   plan:
   - aggregate:
     - get: gpdb_src
       passed: [gate_ud_start]
-    - get: bin_gpdb
-      resource: bin_gpdb_centos6
-      passed: [gate_ud_start]
       trigger: true
-    - get: singlecluster
+    - get: bin_gpdb_centos6
+      passed: [gate_ud_start]
+    - get: compiled_bits_ubuntu16
+      passed: [gate_ud_start]
+    - get: singlecluster-hdp
       resource: singlecluster-HDP
-      trigger: true
-    - get: pxf_automation_src
-      trigger: true
-    - get: centos-gpdb-dev-6
-  - task: regression_tests_pxf
-    file: gpdb_src/concourse/tasks/regression_tests_pxf.yml
-    image: centos-gpdb-dev-6
-    params:
-      GROUP: {{pxf_automation_test_group}}
-      HADOOP_CLIENT: HDP
-      TARGET_OS: centos
-      TARGET_OS_VERSION: 6
-
-- name: regression_tests_pxf_hdp_tar
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      passed: [gate_ud_start]
-    - get: bin_gpdb
-      resource: bin_gpdb_centos6
-      passed: [gate_ud_start]
-      trigger: true
-    - get: singlecluster
-      resource: singlecluster-HDP
-      trigger: true
-    - get: pxf_automation_src
-      trigger: true
-    - get: centos-gpdb-dev-6
-  - task: regression_tests_pxf
-    file: gpdb_src/concourse/tasks/regression_tests_pxf.yml
-    image: centos-gpdb-dev-6
-    params:
-      GROUP: {{pxf_automation_test_group}}
-      HADOOP_CLIENT: TAR
-      TARGET_OS: centos
-      TARGET_OS_VERSION: 6
-
-- name: regression_tests_pxf_cdh_rpm
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      passed: [gate_ud_start]
-    - get: bin_gpdb
-      resource: bin_gpdb_centos6
-      passed: [gate_ud_start]
-      trigger: true
-    - get: singlecluster
+    - get: singlecluster-cdh
       resource: singlecluster-CDH
-      trigger: true
     - get: pxf_automation_src
-      trigger: true
     - get: centos-gpdb-dev-6
-  - task: regression_tests_pxf
-    file: gpdb_src/concourse/tasks/regression_tests_pxf.yml
-    image: centos-gpdb-dev-6
-    params:
-      GROUP: {{pxf_automation_test_group}}
-      HADOOP_CLIENT: CDH
-      TARGET_OS: centos
-      TARGET_OS_VERSION: 6
-
-- name: regression_tests_pxf_cdh_tar
-  plan:
+    - get: ubuntu-gpdb-dev-16
   - aggregate:
-    - get: gpdb_src
-      passed: [gate_ud_start]
-    - get: bin_gpdb
-      resource: bin_gpdb_centos6
-      passed: [gate_ud_start]
-      trigger: true
-    - get: singlecluster
-      resource: singlecluster-CDH
-      trigger: true
-    - get: pxf_automation_src
-      trigger: true
-    - get: centos-gpdb-dev-6
-  - task: regression_tests_pxf
-    file: gpdb_src/concourse/tasks/regression_tests_pxf.yml
-    image: centos-gpdb-dev-6
-    params:
-      GROUP: {{pxf_automation_test_group}}
-      HADOOP_CLIENT: TAR
-      TARGET_OS: centos
-      TARGET_OS_VERSION: 6
-## PXF Regression Tests End
+    - task: regression_tests_pxf_hdp_rpm
+      input_mapping:
+        bin_gpdb: bin_gpdb_centos6
+        singlecluster: singlecluster-HDP
+      file: gpdb_src/concourse/tasks/regression_tests_pxf.yml
+      image: centos-gpdb-dev-6
+      params:
+        GROUP: gpdb
+        HADOOP_CLIENT: HDP
+        TARGET_OS: centos
+        TARGET_OS_VERSION: 6
+    - task: regression_tests_pxf_hdp_tar
+      input_mapping:
+        bin_gpdb: bin_gpdb_centos6
+        singlecluster: singlecluster-HDP
+      file: gpdb_src/concourse/tasks/regression_tests_pxf.yml
+      image: centos-gpdb-dev-6
+      params:
+        GROUP: gpdb
+        HADOOP_CLIENT: TAR
+        TARGET_OS: centos
+        TARGET_OS_VERSION: 6
+    - task: regression_tests_pxf_cdh_rpm
+      input_mapping:
+        bin_gpdb: bin_gpdb_centos6
+        singlecluster: singlecluster-CDH
+      file: gpdb_src/concourse/tasks/regression_tests_pxf.yml
+      image: centos-gpdb-dev-6
+      params:
+        GROUP: gpdb
+        HADOOP_CLIENT: CDH
+        TARGET_OS: centos
+        TARGET_OS_VERSION: 6
+    - task: regression_tests_pxf_cdh_tar_centos
+      input_mapping:
+        bin_gpdb: bin_gpdb_centos6
+        singlecluster: singlecluster-CDH
+      file: gpdb_src/concourse/tasks/regression_tests_pxf.yml
+      image: centos-gpdb-dev-6
+      params:
+        GROUP: gpdb
+        HADOOP_CLIENT: TAR
+        TARGET_OS: centos
+        TARGET_OS_VERSION: 6
+    - task: regression_tests_pxf_cdh_tar_ubuntu
+      input_mapping:
+        bin_gpdb: compiled_bits_ubuntu16
+        singlecluster: singlecluster-CDH
+      file: gpdb_src/concourse/tasks/regression_tests_pxf.yml
+      image: ubuntu-gpdb-dev-16
+      params:
+        GROUP: gpdb
+        HADOOP_CLIENT: TAR
+        TARGET_OS: ubuntu
+        TARGET_OS_VERSION: 16
 
 - name: regression_tests_gphdfs_centos
   plan:
@@ -2800,10 +2776,7 @@ jobs:
   - aggregate:
     - get: gpdb_src
       passed:
-      - regression_tests_pxf_hdp_rpm
-      - regression_tests_pxf_hdp_tar
-      - regression_tests_pxf_cdh_rpm
-      - regression_tests_pxf_cdh_tar
+      - icw_extensions_pxf
       - regression_tests_gphdfs_centos
       trigger: true
 ################ General Misc End
@@ -3033,6 +3006,7 @@ jobs:
     - icw_gporca_conan_ubuntu16
     - test_gpdb_debian_package
     - icw_planner_ictcp_centos6
+    - icw_extensions_pxf
     - icw_extensions_gpcloud
     - client_loader_remote_test_aix
     - mpp_resource_group_centos6
@@ -3066,10 +3040,6 @@ jobs:
     - cs_crash_recovery_31_42
     - QP_memory-accounting
     - regression_tests_gphdfs_centos
-    - regression_tests_pxf_hdp_rpm
-    - regression_tests_pxf_hdp_tar
-    - regression_tests_pxf_cdh_rpm
-    - regression_tests_pxf_cdh_tar
     - MM_gpcheckcat
     - MM_gprecoverseg
     - MM_gpexpand_1

--- a/concourse/scripts/builds/GpBuild.py
+++ b/concourse/scripts/builds/GpBuild.py
@@ -1,21 +1,21 @@
 import subprocess
 from GpdbBuildBase import GpdbBuildBase
 
-INSTALL_DIR="/usr/local/gpdb"
+INSTALL_DIR = "/usr/local/gpdb"
 
 
 class GpBuild(GpdbBuildBase):
     def __init__(self, mode="orca"):
         GpdbBuildBase.__init__(self)
         self.mode = 'on' if mode == 'orca' else 'off'
-        self.configure_options =  [
-                                    "--enable-mapreduce",
-                                    "--with-gssapi",
-                                    "--with-perl",
-                                    "--with-libxml",
-                                    "--with-python",
-                                    "--prefix={0}".format(INSTALL_DIR)
-                                  ]
+        self.configure_options = [
+            "--enable-mapreduce",
+            "--with-gssapi",
+            "--with-perl",
+            "--with-libxml",
+            "--with-python",
+            "--prefix={0}".format(INSTALL_DIR)
+        ]
         self.source_gcc_env_cmd = ''
 
     def configure(self):
@@ -27,6 +27,11 @@ class GpBuild(GpdbBuildBase):
         return self.run_cmd(cmd, "gpdb_src")
 
     def create_demo_cluster(self):
+        """
+        create a demo cluster from script in gpdemo.
+        assumes current working dir is parent of gpdb_src
+        """
+
         return subprocess.call([
             "runuser gpadmin -c \"source {0}/greenplum_path.sh \
             && {1} make create-demo-cluster DEFAULT_QD_MAX_CONNECT=150\"".format(INSTALL_DIR, self.source_gcc_env_cmd)],
@@ -72,8 +77,8 @@ class GpBuild(GpdbBuildBase):
         return self.run_cmd(cmd, "gpdb_src")
 
     def run_cmd(self, cmd, working_dir):
-        cmd =  self.source_gcc_env_cmd + cmd
-        return  subprocess.call(cmd, shell=True, cwd=working_dir)
+        cmd = self.source_gcc_env_cmd + cmd
+        return subprocess.call(cmd, shell=True, cwd=working_dir)
 
     def make_install(self):
         cmd = "make install"

--- a/concourse/scripts/compile_gpdb_open_source_ubuntu.bash
+++ b/concourse/scripts/compile_gpdb_open_source_ubuntu.bash
@@ -7,48 +7,63 @@ COMPILED_BITS_FILENAME=${COMPILED_BITS_FILENAME:="compiled_bits_ubuntu16.tar.gz"
 
 function build_external_depends() {
     pushd gpdb_src/depends
-    ./configure
-    make
+        ./configure
+        make
     popd
 }
 
 function install_external_depends() {
     pushd gpdb_src/depends
-    make install
+        make install
     popd
 }
 
 function build_gpdb() {
     build_external_depends
     pushd gpdb_src
-    CWD=$(pwd)
-    LD_LIBRARY_PATH=${CWD}/depends/build/lib CC=$(which gcc) CXX=$(which g++) ./configure --enable-mapreduce --with-gssapi --with-perl --with-libxml \
-      --with-python \
-      --with-libraries=${CWD}/depends/build/lib \
-      --with-includes=${CWD}/depends/build/include \
-      --prefix=${GREENPLUM_INSTALL_DIR}
-    make -j4
-    LD_LIBRARY_PATH=${CWD}/depends/build/lib make install
+        CWD=$(pwd)
+        LD_LIBRARY_PATH=${CWD}/depends/build/lib CC=$(which gcc) CXX=$(which g++) ./configure \
+            --enable-mapreduce --with-gssapi --with-perl --with-libxml \
+            --enable-pxf \
+            --with-python \
+            --with-libraries=${CWD}/depends/build/lib \
+            --with-includes=${CWD}/depends/build/include \
+            --prefix=${GREENPLUM_INSTALL_DIR}
+        make -j4
+        LD_LIBRARY_PATH=${CWD}/depends/build/lib make install
     popd
     install_external_depends
 }
 
+function build_pxf() {
+  pushd pxf_src/pxf
+      export TERM=xterm
+      export BUILD_NUMBER="${TARGET_OS}"
+      export PXF_HOME="${GREENPLUM_INSTALL_DIR}/pxf"
+      export JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
+      export JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:/jre/bin/java::")
+      export SHELL=/bin/bash
+      make install DATABASE=gpdb
+  popd
+}
+
 function unittest_check_gpdb() {
-  make -C gpdb_src/src/backend -s unittest-check
+    make -C gpdb_src/src/backend -s unittest-check
 }
 
 function export_gpdb() {
-  TARBALL="$TRANSFER_DIR_ABSOLUTE_PATH"/$COMPILED_BITS_FILENAME
-  pushd $GREENPLUM_INSTALL_DIR
-    source greenplum_path.sh
-    python -m compileall -x test .
-    chmod -R 755 .
-    tar -czf ${TARBALL} ./*
-  popd
+    TARBALL="$TRANSFER_DIR_ABSOLUTE_PATH"/$COMPILED_BITS_FILENAME
+    pushd $GREENPLUM_INSTALL_DIR
+        source greenplum_path.sh
+        python -m compileall -x test .
+        chmod -R 755 .
+        tar -czf ${TARBALL} ./*
+    popd
 }
 
 function _main() {
     build_gpdb
+    build_pxf
     unittest_check_gpdb
     export_gpdb
 }

--- a/concourse/scripts/regression_tests_pxf.bash
+++ b/concourse/scripts/regression_tests_pxf.bash
@@ -2,8 +2,7 @@
 
 set -exo pipefail
 
-CWDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source "${CWDIR}/common.bash"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 GPHOME="/usr/local/greenplum-db-devel"
 PXF_HOME="${GPHOME}/pxf"
 

--- a/concourse/scripts/regression_tests_pxf.bash
+++ b/concourse/scripts/regression_tests_pxf.bash
@@ -3,175 +3,201 @@
 set -exo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-GPHOME="/usr/local/greenplum-db-devel"
-PXF_HOME="${GPHOME}/pxf"
+INSTALL_DIR="/usr/local/gpdb"
+
+PXF_HOME="${INSTALL_DIR}/pxf"
 
 function run_regression_test() {
-	cat > /home/gpadmin/run_regression_test.sh <<-EOF
-	set -exo pipefail
+    cat > /home/gpadmin/run_regression_test.sh <<-EOF
+#!/bin/bash
+    set -exo pipefail
+    if [ "$TARGET_OS" != "ubuntu" ]; then
+      source /opt/gcc_env.sh
+    fi
+    source ${INSTALL_DIR}/greenplum_path.sh
+    cd "\${1}/gpdb_src/gpAux"
+    source gpdemo/gpdemo-env.sh
+    cd "\${1}/gpdb_src/gpAux/extensions/pxf"
+    make installcheck USE_PGXS=1
+    [ -s regression.diffs ] && cat regression.diffs && exit 1
+    exit 0
+EOF
 
-	source /opt/gcc_env.sh
-	source ${GPHOME}/greenplum_path.sh
+    chown gpadmin:gpadmin /home/gpadmin/run_regression_test.sh
+    chmod a+x /home/gpadmin/run_regression_test.sh
 
-	cd "\${1}/gpdb_src/gpAux"
-	source gpdemo/gpdemo-env.sh
-
-	cd "\${1}/gpdb_src/gpAux/extensions/pxf"
-	make installcheck USE_PGXS=1
-
-	[ -s regression.diffs ] && cat regression.diffs && exit 1
-
-	exit 0
-	EOF
-
-	chown gpadmin:gpadmin /home/gpadmin/run_regression_test.sh
-	chmod a+x /home/gpadmin/run_regression_test.sh
-
-	su gpadmin -c "bash /home/gpadmin/run_regression_test.sh $(pwd)"
+    su gpadmin -c "bash /home/gpadmin/run_regression_test.sh $(pwd)"
 }
 
 function run_pxf_automation() {
-	cat > /home/gpadmin/run_pxf_automation_test.sh <<-EOF
-	set -exo pipefail
+    cat > /home/gpadmin/run_pxf_automation_test.sh <<-EOF
+#!/bin/bash
+    set -exo pipefail
+    source ${INSTALL_DIR}/greenplum_path.sh
+    source \${1}/gpdb_src/gpAux/gpdemo/gpdemo-env.sh
+    # set variables needed by PXF Automation and Parot to run in GPDB mode with SingleCluster and standalone PXF
+    export PG_MODE=GPDB
+    export GPHD_ROOT=$1
+    export PXF_HOME=${PXF_HOME}
+    psql -d template1 -c "CREATE EXTENSION PXF"
+    cd \${1}/pxf_automation_src
+    make GROUP=gpdb
+    exit 0
+EOF
 
-	source ${GPHOME}/greenplum_path.sh
-	source \${1}/gpdb_src/gpAux/gpdemo/gpdemo-env.sh
-
-	# set variables needed by PXF Automation and Parot to run in GPDB mode with SingleCluster and standalone PXF
-	export PG_MODE=GPDB
-	export GPHD_ROOT=$1
-	export PXF_HOME=${PXF_HOME}
-
-	# Copy PSI package from system python to GPDB as automation test requires it
-	psi_dir=\$(find /usr/lib64 -name psi | sort -r | head -1)
-	cp -r \${psi_dir} ${GPHOME}/lib/python
-	psql -d template1 -c "CREATE EXTENSION PXF"
-	cd \${1}/pxf_automation_src
-	make GROUP=gpdb
-
-	exit 0
-	EOF
-
-	chown gpadmin:gpadmin /home/gpadmin/run_pxf_automation_test.sh
-	chmod a+x /home/gpadmin/run_pxf_automation_test.sh
-	su gpadmin -c "bash /home/gpadmin/run_pxf_automation_test.sh $(pwd)"
+    chown gpadmin:gpadmin /home/gpadmin/run_pxf_automation_test.sh
+    chmod a+x /home/gpadmin/run_pxf_automation_test.sh
+    su gpadmin -c "bash /home/gpadmin/run_pxf_automation_test.sh $(pwd)"
 }
 
 function setup_gpadmin_user() {
-	./gpdb_src/concourse/scripts/setup_gpadmin_user.bash "$TARGET_OS"
+    ./gpdb_src/concourse/scripts/setup_gpadmin_user.bash
 }
 
 function unpack_tarball() {
-	local tarball=$1
-	echo "Unpacking tarball: $(ls ${tarball})"
-	tar xfp ${tarball} --strip-components=1
+    local tarball=$1
+    echo "Unpacking tarball: $(ls ${tarball})"
+    tar xfp ${tarball} --strip-components=1
 }
 
 function setup_singlecluster() {
-	pushd singlecluster && if [ -f ./*.tar.gz ]; then \
-		unpack_tarball ./*.tar.gz; \
-	fi && popd
+    pushd singlecluster
+        if [ -f ./*.tar.gz ]; then
+            unpack_tarball ./*.tar.gz
+        fi
+    popd
 
-	pushd singlecluster/bin
-	export SLAVES=1
-	./init-gphd.sh
-	# zookeeper required for HBase
-	./start-zookeeper.sh
-	./start-hdfs.sh
-	./start-yarn.sh
-	./start-hive.sh
-	./start-hbase.sh
-	popd
+    pushd singlecluster/bin
+        export SLAVES=1
+        ./init-gphd.sh
+        # zookeeper required for HBase
+        ./start-zookeeper.sh
+        ./start-hdfs.sh
+        ./start-yarn.sh
+        ./start-hive.sh
+        ./start-hbase.sh
+    popd
 }
 
 function install_hadoop_client_rpms() {
-	local hdfsrepo=$1
-	local yum_repofile_url=$2
+    local hdfsrepo=$1
+    local yum_repofile_url=$2
 
-	pushd /etc/yum.repos.d > /dev/null
-	# download yum repo definition file for the vendor stack
-	wget ${yum_repofile_url}
-	# install required RPMs
-	yum install -y hadoop-client
-	yum install -y hive
-	yum install -y hbase
-	# copy cluster configuration files from single cluster
-	mkdir -p /etc/hadoop/conf
-	cp ${hdfsrepo}/hadoop/etc/hadoop/core-site.xml /etc/hadoop/conf/
-	cp ${hdfsrepo}/hadoop/etc/hadoop/hdfs-site.xml /etc/hadoop/conf/
-	# mapred below is needed for test for mapreduce.input.fileinputformat.input.dir.recursive to be set to true
-	cp ${hdfsrepo}/hadoop/etc/hadoop/mapred-site.xml /etc/hadoop/conf/
-	mkdir -p /etc/hive/conf
-	cp ${hdfsrepo}/hive/conf/hive-site.xml /etc/hive/conf
-	mkdir -p /etc/hbase/conf
-	cp ${hdfsrepo}/hbase/conf/hbase-site.xml /etc/hbase/conf
-	popd
+    pushd /etc/yum.repos.d > /dev/null
+        # download yum repo definition file for the vendor stack
+        wget ${yum_repofile_url}
+        # install required RPMs
+        yum install -y hadoop-client
+        yum install -y hive
+        yum install -y hbase
+        # copy cluster configuration files from single cluster
+        mkdir -p /etc/hadoop/conf
+        cp ${hdfsrepo}/hadoop/etc/hadoop/core-site.xml /etc/hadoop/conf/
+        cp ${hdfsrepo}/hadoop/etc/hadoop/hdfs-site.xml /etc/hadoop/conf/
+        # mapred below is needed for test for mapreduce.input.fileinputformat.input.dir.recursive to be set to true
+        cp ${hdfsrepo}/hadoop/etc/hadoop/mapred-site.xml /etc/hadoop/conf/
+        mkdir -p /etc/hive/conf
+        cp ${hdfsrepo}/hive/conf/hive-site.xml /etc/hive/conf
+        mkdir -p /etc/hbase/conf
+        cp ${hdfsrepo}/hbase/conf/hbase-site.xml /etc/hbase/conf
+    popd
 }
 
 function setup_hadoop_client() {
-	local hdfsrepo=$1
+    local hdfsrepo=$1
 
-	case ${HADOOP_CLIENT} in
-		CDH)
-			install_hadoop_client_rpms ${hdfsrepo} "https://archive.cloudera.com/cdh5/redhat/6/x86_64/cdh/cloudera-cdh5.repo"
-			;;
-		HDP)
-			install_hadoop_client_rpms ${hdfsrepo} "http://public-repo-1.hortonworks.com/HDP/centos6/2.x/updates/2.6.2.0/hdp.repo"
-			;;
-		TAR)
-			# TAR-based setup, edit the properties in pxf-env.sh to specify HADOOP_ROOT value
-			sed -i -e "s|^[[:blank:]]*export HADOOP_ROOT=.*$|export HADOOP_ROOT=${hdfsrepo}|g" ${PXF_HOME}/conf/pxf-env.sh
-			;;
-		*)
-			echo "FATAL: Unknown HADOOP_CLIENT=${HADOOP_CLIENT} parameter value"
-			exit 1
-			;;
-	esac
+    case ${HADOOP_CLIENT} in
+         CDH)
+             install_hadoop_client_rpms ${hdfsrepo} "https://archive.cloudera.com/cdh5/redhat/6/x86_64/cdh/cloudera-cdh5.repo"
+             ;;
+         HDP)
+             install_hadoop_client_rpms ${hdfsrepo} "http://public-repo-1.hortonworks.com/HDP/centos6/2.x/updates/2.6.2.0/hdp.repo"
+             ;;
+         TAR)
+             # TAR-based setup, edit the properties in pxf-env.sh to specify HADOOP_ROOT value
+             sed -i -e "s|^[[:blank:]]*export HADOOP_ROOT=.*$|export HADOOP_ROOT=${hdfsrepo}|g" ${PXF_HOME}/conf/pxf-env.sh
+             ;;
+         *)
+             echo "FATAL: Unknown HADOOP_CLIENT=${HADOOP_CLIENT} parameter value"
+             exit 1
+             ;;
+    esac
 
-	echo "Contents of ${PXF_HOME}/conf/pxf-env.sh :"
-	cat ${PXF_HOME}/conf/pxf-env.sh
+    echo "Contents of ${PXF_HOME}/conf/pxf-env.sh :"
+    cat ${PXF_HOME}/conf/pxf-env.sh
 }
 
 function start_pxf() {
-	local hdfsrepo=$1
-	pushd ${PXF_HOME} > /dev/null
+    local hdfsrepo=$1
+    pushd ${PXF_HOME} > /dev/null
+        #Check if some other process is listening on 51200
+        netstat -tlpna | grep 51200 || true
+        su gpadmin -c "bash ./bin/pxf init"
+        su gpadmin -c "bash ./bin/pxf start"
+    popd > /dev/null
+}
 
-	#Check if some other process is listening on 51200
-	netstat -tlpna | grep 51200 || true
+function install_psi_python_tool() {
+    pip install --upgrade pip  # this was required on centos7
+    pip install psi -t ${INSTALL_DIR}/lib/python
+}
 
-	su gpadmin -c "bash ./bin/pxf init"
-	su gpadmin -c "bash ./bin/pxf start"
-	popd > /dev/null
+function configure_with_planner() {
+    PYTHONPATH=${SCRIPT_DIR}:${PYTHONPATH} python2 -c "from builds.GpBuild import GpBuild; \
+                                                       GpBuild(\"planner\").configure()"
+}
+
+function copy_gpdb_bits_to_gphome() {
+    mkdir -p ${INSTALL_DIR}
+    tar -xzf bin_gpdb/*.tar.gz -C ${INSTALL_DIR}
+    sed -i -e "s|GPHOME=.*|GPHOME=/usr/local/gpdb|g" ${INSTALL_DIR}/greenplum_path.sh
+}
+
+function install_java() {
+    # centos java has been installed by dockerfile; install via apt-get for ubuntu
+    if [ "$TARGET_OS" == "ubuntu" ]; then
+        apt-get update
+        apt-get install -y openjdk-8-jdk
+        export JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:/jre/bin/java::")
+        echo "export JAVA_HOME=${JAVA_HOME}" >> ~/.bash_profile
+        echo "export JAVA_HOME=${JAVA_HOME}" >> /home/gpadmin/.bash_profile
+        chown gpadmin:gpadmin /home/gpadmin/.bash_profile
+    fi
+}
+
+function make_cluster() {
+    PYTHONPATH=${SCRIPT_DIR}:${PYTHONPATH} python2 -c "from builds.GpBuild import GpBuild; \
+                                                       x = GpBuild(\"planner\").create_demo_cluster(); \
+                                                       exit(x)"
 }
 
 function _main() {
-	if [ -z "$TARGET_OS" ]; then
-		echo "FATAL: TARGET_OS is not set"
-		exit 1
-	fi
+    if [ -z "$TARGET_OS" ]; then
+        echo "FATAL: TARGET_OS is not set"
+        exit 1
+    fi
 
-	if [ "$TARGET_OS" != "centos" -a "$TARGET_OS" != "sles" ]; then
-		echo "FATAL: TARGET_OS is set to an unsupported value: $TARGET_OS"
-		echo "Configure TARGET_OS to be centos or sles"
-		exit 1
-	fi
+    time configure_with_planner
+    time copy_gpdb_bits_to_gphome
+    time install_psi_python_tool
+    time setup_gpadmin_user
+    time install_java
 
-	# Reserve port 51200 for PXF service
-	echo "pxf             51200/tcp               # PXF Service" >> /etc/services
+    # Reserve port 51200 for PXF service
+    echo "pxf             51200/tcp               # PXF Service" >> /etc/services
 
-	time configure
-	time install_gpdb
-	time setup_gpadmin_user
+    # setup hadoop before making GPDB cluster to use system python for yum install
+    time setup_singlecluster
+    time setup_hadoop_client $(pwd)/singlecluster
 
-	# setup hadoop before making GPDB cluster to use system python for yum install
-	time setup_singlecluster
-	time setup_hadoop_client $(pwd)/singlecluster
-
-	time make_cluster
-	time start_pxf $(pwd)/singlecluster
-	chown -R gpadmin:gpadmin $(pwd)
-	time run_regression_test
-	time run_pxf_automation $(pwd)/singlecluster
+    time make_cluster
+    time start_pxf $(pwd)/singlecluster
+    chown -R gpadmin:gpadmin singlecluster pxf_automation_src
+    time run_regression_test
+    if [ "$TARGET_OS" != "ubuntu" ]; then
+      # eventually include this after Ubuntu is supported better
+      time run_pxf_automation $(pwd)/singlecluster
+    fi
 }
 
 _main "$@"

--- a/concourse/tasks/compile_gpdb_open_source_ubuntu.yml
+++ b/concourse/tasks/compile_gpdb_open_source_ubuntu.yml
@@ -3,6 +3,7 @@ image_resource:
   type: docker-image
 inputs:
   - name: gpdb_src
+  - name: pxf_src
 outputs:
   - name: compiled_bits_ubuntu16
 run:


### PR DESCRIPTION
- group all PXF tests into a single job
- install java for ubuntu
- use python GpBuild tool
- test return value of create_demo_cluster
- export java_home in bash_profile
- format python -c into multiple lines
- Replace GPHOME in centos to /usr/local/gpdb
- export java_home in root
- enable pxf
- add pxf install step
- conditionalize platform setup & pxf_automation on ubuntu