### PR TITLE
docs - updates for gphdfs jar file changes

### DIFF
--- a/gpdb-doc/dita/admin_guide/external/g-hdfs-readable-and-writable-external-table-examples.xml
+++ b/gpdb-doc/dita/admin_guide/external/g-hdfs-readable-and-writable-external-table-examples.xml
@@ -17,8 +17,6 @@
    FORMAT 'TEXT' (DELIMITER ',');
 </codeblock>
       </p>
-      <note type="note">Omit the port number when using the <codeph>gpmr-1.0-gnet-1.0.0.1</codeph>
-         connector.</note>
       <p>The following code defines a set of readable external tables that have a custom format
          located in the same HDFS directory on port 8081.</p>
       <p>
@@ -27,8 +25,6 @@
    FORMAT 'custom' (formatter='gphdfs_import');
 </codeblock>
       </p>
-      <note type="note">Omit the port number when using the <codeph>gpmr-1.0-gnet-1.0.0.1</codeph>
-         connector.</note>
       <p>The following code defines an HDFS directory for a writable external table on port 8081
          with all compression options specified.</p>
       <p>
@@ -38,8 +34,6 @@
    FORMAT 'custom' (formatter='gphdfs_export');
 </codeblock>
       </p>
-      <note type="note">Omit the port number when using the <codeph>gpmr-1.0-gnet-1.0.0.1</codeph>
-         connector.</note>
       <p>Because the previous code uses the default compression options for
             <codeph>compression_type</codeph> and <codeph>codec</codeph>, the following command is
          equivalent.</p>
@@ -49,7 +43,5 @@
    FORMAT 'custom' (formatter='gphdfs_export');
 </codeblock>
       </p>
-      <note type="note">Omit the port number when using the <codeph>gpmr-1.0-gnet-1.0.0.1</codeph>
-         connector.</note>
    </body>
 </topic>

--- a/gpdb-doc/dita/admin_guide/external/g-one-time-hdfs-protocol-installation.xml
+++ b/gpdb-doc/dita/admin_guide/external/g-one-time-hdfs-protocol-installation.xml
@@ -63,7 +63,7 @@ export HADOOP_HOME=/usr/lib/gphd</codeblock><p>The
                                  <codeph>hadoop2</codeph>
                               </p></entry>
                            <entry colname="col3">
-                              <codeph>gphd-1.1</codeph>
+                              <codeph>gphd-1.1*</codeph>
                            </entry>
                            <entry colname="col4">master<p>session</p>reload </entry>
                         </row>
@@ -71,11 +71,8 @@ export HADOOP_HOME=/usr/lib/gphd</codeblock><p>The
                            <entry colname="col1">
                               <codeph>gp_hadoop_home</codeph>
                            </entry>
-                           <entry colname="col2">With Pivotal HD, this parameter specifies the
-                              installation directory for Hadoop. For example, the default
-                              installation directory is <filepath>/usr/lib/gphd</filepath>.<p>When
-                                 using Greenplum HD 1.2 or earlier, specify the same value as the
-                                 HADOOP_HOME environment variable.</p></entry>
+                           <entry colname="col2">This parameter specifies the
+                              installation directory for Hadoop.</entry>
                            <entry colname="col3">
                               <codeph>NULL</codeph>
                            </entry>
@@ -83,7 +80,8 @@ export HADOOP_HOME=/usr/lib/gphd</codeblock><p>The
                         </row>
                      </tbody>
                   </tgroup>
-               </table> For example, the following commands use the Greenplum Database utilities
+               </table> <note>*The default <codeph>gp_hadoop_target_version</codeph> value <codeph>gphd-1.1</codeph> is not supported; you must set this server configuration parameter to a supported value.</note>
+               For example, the following commands use the Greenplum Database utilities
                   <codeph>gpconfig</codeph> and <codeph>gpstop</codeph> to set the server
                configuration parameters and restart Greenplum
                Database:<codeblock>gpconfig -c gp_hadoop_target_version -v 'hdb2'

--- a/gpdb-doc/dita/admin_guide/external/g-reading-and-writing-custom-formatted-hdfs-data.xml
+++ b/gpdb-doc/dita/admin_guide/external/g-reading-and-writing-custom-formatted-hdfs-data.xml
@@ -23,7 +23,7 @@
         <p>See <xref href="#topic29"/>.</p>
         <p>MapReduce code is written in Java. Greenplum provides Java APIs for use in the MapReduce
             code. The Javadoc is available in the <codeph>$GPHOME/docs</codeph> directory. To view
-            the Javadoc, expand the file <codeph>gnet-1.1-javadoc.tar</codeph> and open
+            the Javadoc, expand the file <codeph>gnet-1.2-javadoc.tar</codeph> and open
                 <codeph>index.html</codeph>. The Javadoc documents the following packages:</p>
         <p>
             <codeblock>com.emc.greenplum.gpdb.hadoop.io
@@ -37,7 +37,7 @@ com.emc.greenplum.gpdb.hadoop.mapreduce.lib.output
                 <codeph>GPDBOutputFormat</codeph>. The Java packages are available in
                 <codeph>$GPHOME/lib/hadoop</codeph>. Compile and run the MapReduce job with the
             cross-connect package. For example, compile and run the MapReduce job with
-                <codeph>gphd-1.0-gnet-1.0.0.1.jar</codeph> if you use the Greenplum HD 1.0
+                <codeph>hdp2.0-gnet-1.2.0.0.jar</codeph> if you use the HDP
             distribution of Hadoop.</p>
         <p>To make the Java library available to all Hadoop users, the Hadoop cluster administrator
             should place the corresponding <codeph>gphdfs</codeph> connector jar in the
@@ -149,10 +149,6 @@ public class demoMR {
    FORMAT 'custom' (formatter='gphdfs_import');
 </codeblock>
                 </p>
-                <note type="note">
-                    <p>Omit the port number when using the <codeph>gpmr-1.0-gnet-1.0.0.1</codeph>
-                        connector.</p>
-                </note>
             </body>
         </topic>
     </topic>
@@ -178,8 +174,6 @@ public class demoMR {
                 <li id="du191051">Author and run code for a MapReduce job. Use the same import
                     statements shown in <xref href="#topic26"/>.</li>
             </ol>
-            <note type="note">Omit the port number when using the
-                    <codeph>gpmr-1.0-gnet-1.0.0.1</codeph> connector.</note>
         </body>
     </topic>
     <topic id="topic30">

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -4127,10 +4127,7 @@
   <topic id="gp_hadoop_home" otherprops="oss">
     <title>gp_hadoop_home</title>
     <body>
-      <p>When using Pivotal HD, specify the installation directory for Hadoop. For example, the
-        default installation directory is <codeph>/usr/lib/gphd</codeph>.</p>
-      <p>When using Greenplum HD 1.2 or earlier, specify the same value as the HADOOP_HOME
-        environment variable.</p>
+      <p>Specifies the installation directory for the Greenplum Database <codeph>gphdfs</codeph> Hadoop target.</p>
       <table id="gp_hadoop_home_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>
@@ -4157,7 +4154,7 @@
   <topic id="gp_hadoop_target_version">
     <title>gp_hadoop_target_version</title>
     <body>
-      <p>The installed version of Greenplum Hadoop target.</p>
+      <p>The installed version of the Greenplum Database <codeph>gphdfs</codeph> Hadoop target.</p>
       <table id="gp_hadoop_target_version_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>
@@ -4174,12 +4171,13 @@
             <row>
               <entry colname="col1"
                   >gpmr-1.2<p>hadoop2</p><p>hdp2</p><p>cdh5</p><p>cdh4.1</p></entry>
-              <entry colname="col2">gphd-1.1</entry>
+              <entry colname="col2">gphd-1.1*</entry>
               <entry colname="col3">local<p>session</p><p>reload</p></entry>
             </row>
           </tbody>
         </tgroup>
       </table>
+      <note>*The default <codeph>gp_hadoop_target_version</codeph> value <codeph>gphd-1.1</codeph> is not supported; you must set this server configuration parameter to a supported value.</note>
     </body>
   </topic>
   <topic id="gp_hashjoin_tuples_per_bucket">

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -4173,7 +4173,7 @@
           <tbody>
             <row>
               <entry colname="col1"
-                  >gphd-1.0<p>gphd-1.1</p><p>gphd-1.2</p><p>gphd-2.0</p><p>gphd-3.0</p><p>gpmr-1.0</p><p>gpmr-1.2</p><p>hadoop2</p><p>hdp2</p><p>cdh5</p><p>cdh3u2</p><p>cdh4.1</p></entry>
+                  >gpmr-1.2<p>hadoop2</p><p>hdp2</p><p>cdh5</p><p>cdh4.1</p></entry>
               <entry colname="col2">gphd-1.1</entry>
               <entry colname="col3">local<p>session</p><p>reload</p></entry>
             </row>


### PR DESCRIPTION
the recent changes to get gphdfs to build consolidated/removed some jar files.  doc updates related to this work include:
- needed to update a few references to jar file names
- removed notes related to gpmr-1.0 connector since this is not supported
- noticed that the list of supported gp_hadoop_target_version values on https://gpdb.docs.pivotal.io/520/admin_guide/external/g-one-time-hdfs-protocol-installation.html differed from the list on the guc reference page (https://gpdb.docs.pivotal.io/520/ref_guide/config_params/guc-list.html#gp_hadoop_target_version)
   - removed some values from the guc reference page
   - did not update the default gp_hadoop_target_version, since it is still gphd-1.1 in the code

this should be backported to 5X_STABLE.