### PR TITLE
behave: allow tests to run at midnight without flaking

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
@@ -1,6 +1,11 @@
 @gpcheckcat
 Feature: gpcheckcat tests
 
+    @logging
+    Scenario: gpcheckcat should log into gpAdminLogs
+        When the user runs "gpcheckcat -l"
+        Then verify that the utility gpcheckcat ever does logging into the user's "gpAdminLogs" directory
+
     @all
     Scenario: run all the checks in gpcheckcat
         Given database "all_good" is dropped and recreated
@@ -30,7 +35,6 @@ Feature: gpcheckcat tests
         And psql should print "(0 rows)" to stdout
         And verify that the schema "good_schema" exists in "leak_db"
         And the user runs "dropdb leak_db"
-        And verify that a log was created by gpcheckcat in the user's "gpAdminLogs" directory
 
     @unique_index
     Scenario: gpcheckcat should report unique index violations
@@ -42,7 +46,6 @@ Feature: gpcheckcat tests
         Then gpcheckcat should return a return code of 3
         And gpcheckcat should print "Table pg_compression has a violated unique index: pg_compression_compname_index" to stdout
         And the user runs "dropdb unique_index_db"
-        And verify that a log was created by gpcheckcat in the user's "gpAdminLogs" directory
 
     @miss_attr_table
     Scenario Outline: gpcheckcat should discover missing attributes for tables

--- a/gpMgmt/test/behave/mgmt_utils/gptransfer.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gptransfer.feature
@@ -11,6 +11,7 @@ Feature: gptransfer tests
         Given the gptransfer test is initialized
         And the user runs "gptransfer --full --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_SOURCE_USER --dest-port $GPTRANSFER_SOURCE_PORT --dest-host $GPTRANSFER_SOURCE_HOST --source-map-file $GPTRANSFER_MAP_FILE --batch-size=10"
         Then gptransfer should return a return code of 2
+        And verify that the utility gptransfer ever does logging into the user's "gpAdminLogs" directory
 
     Scenario: gptransfer full no validator
         Given the gptransfer test is initialized
@@ -626,12 +627,6 @@ Feature: gptransfer tests
         And the user runs "gptransfer --full --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user root --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --batch-size=10"
         Then gptransfer should return a return code of 2
 
-    Scenario: gptransfer with log in ~/gpAdminLogs
-        Given the gptransfer test is initialized
-        And the user runs "gptransfer --full --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --batch-size=10"
-        Then gptransfer should return a return code of 0
-        And verify that a log was created by gptransfer in the user's "gpAdminLogs" directory
-
     Scenario: gptransfer with log in /tmp
         Given the gptransfer test is initialized
         And the user runs "gptransfer --full --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE -l /tmp --batch-size=10"
@@ -640,8 +635,9 @@ Feature: gptransfer tests
 
     Scenario: gptransfer with log in nonexistent directory
         Given the gptransfer test is initialized
-        And the user runs "gptransfer --full --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE -l ~/gpAdminLogs/gpAdminLogs --batch-size=10"
+        And the user runs "gptransfer --full --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE -l /tmp/nonexistent-dir --batch-size=10"
         Then gptransfer should return a return code of 0
+        And verify that a log was created by gptransfer in the "/tmp/nonexistent-dir" directory
 
     Scenario: gptransfer --schema-only
         Given the gptransfer test is initialized
@@ -662,7 +658,6 @@ Feature: gptransfer tests
         And the user runs "gptransfer -t gptransfer_testdb1.public.t0 -q --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --batch-size=10"
         Then gptransfer should return a return code of 0
         And gptransfer should not print "Transfering" to stdout
-        And verify that a log was created by gptransfer in the user's "gpAdminLogs" directory
 
     Scenario: gptransfer --skip-existing conflicts with --full
         Given the gptransfer test is initialized

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -4125,20 +4125,21 @@ def impl(context, schema_name, dbname):
         raise Exception("Schema '%s' does not exist in the database '%s'" % (schema_name, dbname))
 
 
-def get_log_name(utilname, logdir):
-    today = datetime.now()
-    logname = "%s/%s_%s.log" % (logdir, utilname, today.strftime('%Y%m%d'))
-    return logname
-
-
-@then('verify that a log was created by {utilname} in the user\'s "{dirname}" directory')
+@then('verify that the utility {utilname} ever does logging into the user\'s "{dirname}" directory')
 def impl(context, utilname, dirname):
     absdirname = "%s/%s" % (os.path.expanduser("~"), dirname)
     if not os.path.exists(absdirname):
         raise Exception('No such directory: %s' % absdirname)
-    logname = get_log_name(utilname, absdirname)
-    if not os.path.exists(logname):
-        raise Exception('Log "%s" was not created' % logname)
+    pattern = "%s/%s_*.log" % (absdirname, utilname)
+    logs_for_a_util = glob.glob(pattern)
+    if not logs_for_a_util:
+        raise Exception('Logs matching "%s" were not created' % pattern)
+
+
+def get_log_name(utilname, logdir):
+    today = datetime.now()
+    logname = "%s/%s_%s.log" % (logdir, utilname, today.strftime('%Y%m%d'))
+    return logname
 
 
 @then('verify that a log was created by {utilname} in the "{dirname}" directory')


### PR DESCRIPTION
Pipeline demonstrating this change, especially the gptransfer tests (@khuddlefish) https://gpdb-dev.data.pivotal.ci/teams/main/pipelines/dev:slari-pivotal_gpcheckcat_midnight_test_fix_152355320

These two tests (gpcheckcat and gptransfer) used a step that looked for
a logfile with a date in the name. If that logfile existed at 11:59PM on
the day before, and the test looked for it at 12:00AM on the next day,
it "wouldn't be there"

`Exception: Log "/home/gpadmin/gpAdminLogs/gpcheckcat_20171122.log" was not created`

Refactor the tests so that assertions about using the typical
gpAdminLogs directory are as banal as possible; emphasize the gptransfer
tests of the user option to specify a log directory

Author: C.J. Jameson <cjameson@pivotal.io>
Author: Shoaib Lari <slari@pivotal.io>