### PR TITLE
Implement dynamic schema feature for external table

### DIFF
--- a/contrib/extprotocol/expected/exttableext.out
+++ b/contrib/extprotocol/expected/exttableext.out
@@ -10,7 +10,7 @@ NOTICE:  table "exttabtest_options_r" does not exist, skipping
     SELECT * FROM exttabtest_options_r
     EXCEPT ALL
     SELECT * FROM exttabtest;
-ERROR:  This is greenplum. (gpextprotocol.c:54)
+ERROR:  This is greenplum. (gpextprotocol.c:55)
 DETAIL:  External table exttabtest_options_r, file demoprot://exttabtest.txt
     DROP EXTERNAL TABLE IF EXISTS exttabtest_w;
 NOTICE:  table "exttabtest_w" does not exist, skipping
@@ -1635,7 +1635,7 @@ ERROR:  protocol "demoprot" does not exist  (seg0 slice1 rh55-qavm55:7532 pid=18
     -- However demoprot implementation prevents using any other protocol name than "demoprot"
     -- therefore the error is expected.
     select count(*) from exttabtest_r_new;
-ERROR:  internal error: demoprot called with a different protocol (demoprot_new) (gpextprotocol.c:106)  (seg0 slice1 rh55-qavm55:7532 pid=18394) (cdbdisp.c:1453)
+ERROR:  internal error: demoprot called with a different protocol (demoprot_new) (gpextprotocol.c:107)  (seg0 slice1 rh55-qavm55:7532 pid=18394) (cdbdisp.c:1453)
 DETAIL:  External table exttabtest_r_new, file demoprot_new://exttabtest.txt
     -- Rename protocol name back to demoprot
     ALTER PROTOCOL demoprot_new RENAME to demoprot;

--- a/contrib/extprotocol/gpextprotocol.c
+++ b/contrib/extprotocol/gpextprotocol.c
@@ -3,6 +3,7 @@
 #include "funcapi.h"
 
 #include "access/extprotocol.h"
+#include "commands/defrem.h"
 #include "catalog/pg_proc.h"
 #include "utils/array.h"
 #include "utils/builtins.h"
@@ -47,10 +48,10 @@ static void check_ext_options(const FunctionCallInfo fcinfo)
         List *options = exttbl->options;
 
         foreach(cell, options) {
-                Value *value = (Value *) lfirst(cell);
-                char *key = value->val.str;
-
-                if (key && strcasestr(key, "database") && !strcasestr(key, "greenplum")) {
+				DefElem *def = (DefElem *) lfirst(cell);
+				/* report error if the value of OPTION "database" is not "greenplum") */
+                if (def->defname != NULL && pg_strcasecmp(def->defname, "database") == 0
+	                && pg_strcasecmp(defGetString(def), "greenplum") != 0) {
                         ereport(ERROR, (0, errmsg("This is greenplum.")));
                 }
         }

--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -52,6 +52,7 @@
 #include "access/xact.h"
 #include "access/xlogutils.h"
 #include "catalog/catalog.h"
+#include "catalog/pg_exttable.h"
 #include "catalog/namespace.h"
 #include "miscadmin.h"
 #include "pgstat.h"
@@ -929,6 +930,24 @@ heapgettup_pagemode(HeapScanDesc scan,
 	}
 }
 
+Relation
+dynamic_external_relation_open(Oid relationId, Oid castRelid, LOCKMODE lockmode)
+{
+	Relation	r;
+
+
+	r = relation_open(relationId, lockmode);
+	Assert(RelationIsExternal(r));
+
+	if(castRelid!=InvalidOid)
+	{
+		Relation r2 = relation_open(castRelid, NoLock);
+		CopyDynExtTableAttListFromCastRel(r, r2->rd_att);
+		relation_close(r2, NoLock);
+	}
+
+	return r;
+}
 
 /* ----------------------------------------------------------------
  *					 heap access method interface

--- a/src/backend/catalog/pg_exttable.c
+++ b/src/backend/catalog/pg_exttable.c
@@ -506,7 +506,7 @@ CheckDynamicOptionForExtTab(Relation ext_rel)
 	{
 		DefElem *def = (DefElem *) lfirst(cell);
 
-		if (def->defname != NULL && pg_strcasecmp(def->defname, DYNAMIC_EXT_TAB_OPTION) == 0
+		if (def->defname != NULL && pg_strcasecmp(def->defname, DYNAMIC_EXT_TBL_OPTION) == 0
 				&& pg_strcasecmp(defGetString(def), "true") == 0)
 		{
 			return TRUE;
@@ -515,7 +515,7 @@ CheckDynamicOptionForExtTab(Relation ext_rel)
 }
 /**
  *  Dynamic External table can be used in the pseudo table function:
- *         GP_DYNAMIC_EXTTAB_AS_TAB('external_tab', 'cast_tab');
+ *         GP_DYNAMIC_EXTTBL_AS_TBL(('external_tbl', 'cast_tbl'));
  *  In this scenario, this function is called to auto replace external_tab's attribute list by the case_tab's.
  */
 void

--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -1964,6 +1964,7 @@ create_shareinput_producer_rte(ApplyShareInputContext *ctxt, int share_id,
 
 	rte = makeNode(RangeTblEntry);
 	rte->rtekind = RTE_CTE;
+	rte->castRelid = InvalidOid;
 	rte->ctename = pstrdup(buf);
 	rte->ctelevelsup = 0;
 	rte->self_reference = false;

--- a/src/backend/cdb/cdbplan.c
+++ b/src/backend/cdb/cdbplan.c
@@ -1002,6 +1002,7 @@ package_plan_as_rte(Query *query, Plan *plan, Alias *eref, List *pathkeys)
 	rte = makeNode(RangeTblEntry);
 	rte->rtekind = RTE_SUBQUERY;
 	rte->subquery = subquery;
+	rte->castRelid = InvalidOid;
 	rte->eref = eref;
 	rte->subquery_plan = plan;
 	rte->subquery_rtable = subquery->rtable;

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -947,7 +947,7 @@ ExecOpenScanExternalRelation(EState *estate, Index scanrelid)
 	rtentry = rt_fetch(scanrelid, estate->es_range_table);
 	reloid = rtentry->relid;
 
-	return relation_open(reloid, NoLock);
+	return dynamic_external_relation_open(reloid, rtentry->castRelid, NoLock);
 }
 
 /* ----------------------------------------------------------------

--- a/src/backend/gpopt/translate/CQueryMutators.cpp
+++ b/src/backend/gpopt/translate/CQueryMutators.cpp
@@ -1439,6 +1439,7 @@ CQueryMutators::PqueryConvertToDerivedTable
 	prte->subquery = pqueryDrvd;
 	prte->inFromCl = true;
 	prte->subquery->cteList = NIL;
+	prte->castRelid = InvalidOid;
 
 	if (NULL != pnodeHavingQual)
 	{

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -1292,7 +1292,7 @@ CTranslatorDXLToPlStmt::PrteFromDXLTVF
 
 	RangeTblEntry *prte = MakeNode(RangeTblEntry);
 	prte->rtekind = RTE_FUNCTION;
-
+	prte->castRelid = InvalidOid;
 	FuncExpr *pfuncexpr = MakeNode(FuncExpr);
 
 	pfuncexpr->funcid = CMDIdGPDB::PmdidConvert(pdxlop->PmdidFunc())->OidObjectId();
@@ -1367,6 +1367,7 @@ CTranslatorDXLToPlStmt::PrteFromDXLValueScan
 	RangeTblEntry *prte = MakeNode(RangeTblEntry);
 
 	prte->relid = InvalidOid;
+	prte->castRelid = InvalidOid;
 	prte->subquery = NULL;
 	prte->rtekind = RTE_VALUES;
 	prte->inh = false;			/* never true for values RTEs */
@@ -2579,6 +2580,7 @@ CTranslatorDXLToPlStmt::PsubqscanFromDXLSubqScan
 	// create an rtable entry for the subquery scan
 	RangeTblEntry *prte = MakeNode(RangeTblEntry);
 	prte->rtekind = RTE_SUBQUERY;
+	prte->castRelid = InvalidOid;
 
 	Alias *palias = MakeNode(Alias);
 	palias->colnames = NIL;
@@ -4215,6 +4217,7 @@ CTranslatorDXLToPlStmt::PrteFromTblDescr
 	GPOS_ASSERT(InvalidOid != oid);
 
 	prte->relid = oid;
+	prte->castRelid = InvalidOid;
 	prte->checkAsUser = pdxltabdesc->UlExecuteAsUser();
 	prte->requiredPerms |= ACL_NO_RIGHTS;
 

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -131,6 +131,12 @@ CTranslatorUtils::Pdxltabdesc
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("Query over external partitions"));
 	}
 
+	if (prte->castRelid != InvalidOid)
+	{
+		// fall back to the planner for queries over external table with dynamic schema
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("Query over external table with dynamic schema"));
+	}
+
 	CMDIdGPDB *pmdid = GPOS_NEW(pmp) CMDIdGPDB(oidRel);
 
 	const IMDRelation *pmdrel = pmda->Pmdrel(pmdid);

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -2268,6 +2268,7 @@ _copyRangeTblEntry(RangeTblEntry *from)
 
 	COPY_SCALAR_FIELD(rtekind);
 	COPY_SCALAR_FIELD(relid);
+	COPY_SCALAR_FIELD(castRelid);
 	COPY_NODE_FIELD(subquery);
 	COPY_SCALAR_FIELD(jointype);
 	COPY_NODE_FIELD(joinaliasvars);
@@ -2297,7 +2298,7 @@ _copyRangeTblEntry(RangeTblEntry *from)
 	COPY_NODE_FIELD(ctecoltypmods);
 
 	COPY_SCALAR_FIELD(forceDistRandom);
-    COPY_NODE_FIELD(pseudocols);                /*CDB*/
+	COPY_NODE_FIELD(pseudocols);                /*CDB*/
 
 	return newnode;
 }

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -2444,6 +2444,7 @@ _equalRangeTblEntry(RangeTblEntry *a, RangeTblEntry *b)
 {
 	COMPARE_SCALAR_FIELD(rtekind);
 	COMPARE_SCALAR_FIELD(relid);
+	COMPARE_SCALAR_FIELD(castRelid);
 	COMPARE_NODE_FIELD(subquery);
 	COMPARE_SCALAR_FIELD(jointype);
 	COMPARE_NODE_FIELD(joinaliasvars);

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -867,6 +867,7 @@ _outRangeTblEntry(StringInfo str, RangeTblEntry *node)
 		case RTE_RELATION:
 		case RTE_SPECIAL:
 			WRITE_OID_FIELD(relid);
+			WRITE_OID_FIELD(castRelid);
 			break;
 		case RTE_SUBQUERY:
 			WRITE_NODE_FIELD(subquery);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -3680,7 +3680,6 @@ _outRangeTblEntry(StringInfo str, RangeTblEntry *node)
 		case RTE_RELATION:
 		case RTE_SPECIAL:
 			WRITE_OID_FIELD(relid);
-			//WRITE_OID_FIELD(castRelid);
 			break;
 		case RTE_SUBQUERY:
 			WRITE_NODE_FIELD(subquery);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -3680,6 +3680,7 @@ _outRangeTblEntry(StringInfo str, RangeTblEntry *node)
 		case RTE_RELATION:
 		case RTE_SPECIAL:
 			WRITE_OID_FIELD(relid);
+			//WRITE_OID_FIELD(castRelid);
 			break;
 		case RTE_SUBQUERY:
 			WRITE_NODE_FIELD(subquery);

--- a/src/backend/nodes/print.c
+++ b/src/backend/nodes/print.c
@@ -269,8 +269,6 @@ print_rt(List *rtable)
 			case RTE_RELATION:
 				printf("%d\t%s\t%u",
 					   i, name, rte->relid);
-				//printf("%d\t%s\t%u",
-				//	   i, name, rte->castRelid);
 				break;
 			case RTE_SUBQUERY:
 				printf("%d\t%s\t[subquery]",

--- a/src/backend/nodes/print.c
+++ b/src/backend/nodes/print.c
@@ -269,6 +269,8 @@ print_rt(List *rtable)
 			case RTE_RELATION:
 				printf("%d\t%s\t%u",
 					   i, name, rte->relid);
+				//printf("%d\t%s\t%u",
+				//	   i, name, rte->castRelid);
 				break;
 			case RTE_SUBQUERY:
 				printf("%d\t%s\t[subquery]",

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -985,6 +985,7 @@ _readRangeTblEntry(void)
 		case RTE_RELATION:
 		case RTE_SPECIAL:
 			READ_OID_FIELD(relid);
+			READ_OID_FIELD(castRelid);
 			break;
 		case RTE_SUBQUERY:
 			READ_NODE_FIELD(subquery);

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -2032,6 +2032,7 @@ _readRangeTblEntry(void)
 		case RTE_RELATION:
 		case RTE_SPECIAL:
 			READ_OID_FIELD(relid);
+			//READ_OID_FIELD(castRelid);
 			break;
 		case RTE_SUBQUERY:
 			READ_NODE_FIELD(subquery);

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -2032,7 +2032,6 @@ _readRangeTblEntry(void)
 		case RTE_RELATION:
 		case RTE_SPECIAL:
 			READ_OID_FIELD(relid);
-			//READ_OID_FIELD(castRelid);
 			break;
 		case RTE_SUBQUERY:
 			READ_NODE_FIELD(subquery);

--- a/src/backend/optimizer/util/relnode.c
+++ b/src/backend/optimizer/util/relnode.c
@@ -109,7 +109,7 @@ build_simple_rel(PlannerInfo *root, int relid, RelOptKind reloptkind)
 		case RTE_RELATION:
 			/* Table --- retrieve statistics from the system catalogs */
 
-			get_relation_info(root, rte->relid, rte->inh, rel);
+			get_relation_info(root, rte, rte->inh, rel);
 
 			/* if we've been asked to, force the dist-policy to be partitioned-randomly. */
 			if (rte->forceDistRandom)

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -925,6 +925,7 @@ transformGroupedWindows(Query *qry)
 	rte = makeNode(RangeTblEntry);
 	rte->rtekind = RTE_SUBQUERY;
 	rte->subquery = subq;
+	rte->castRelid = InvalidOid;
 	rte->alias = NULL; /* fill in later */
 	rte->eref = NULL; /* fill in later */
 	rte->inFromCl = true;

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -54,7 +54,7 @@
 #include <limits.h>
 
 #include "catalog/index.h"
-#include "catalog/pg_exttable.h"  /*for macro DYNAMIC_EXT_TAB_OPTION*/
+#include "catalog/pg_exttable.h"  /*for macro DYNAMIC_EXT_TBL_OPTION*/
 #include "catalog/namespace.h"
 #include "catalog/pg_trigger.h"
 #include "commands/defrem.h"
@@ -4580,11 +4580,11 @@ CreateExternalStmt:	CREATE OptWritable EXTERNAL OptWeb OptTemp TABLE qualified_n
 
 								foreach(opt, n->extOptions)
 								{
-									if (pg_strcasecmp(((DefElem *) opt->data.ptr_value)->defname, DYNAMIC_EXT_TAB_OPTION) == 0
+									if (pg_strcasecmp(((DefElem *) opt->data.ptr_value)->defname, DYNAMIC_EXT_TBL_OPTION) == 0
 											&& pg_strcasecmp(((Value *)((DefElem *) opt->data.ptr_value)->arg)->val.str, "true")== 0)
 										ereport(ERROR,
 												(errcode(ERRCODE_SYNTAX_ERROR),
-												errmsg("External table with OPTIONS (%s 'true') can't include any column definition.", DYNAMIC_EXT_TAB_OPTION),
+												errmsg("External table with OPTIONS (%s 'true') can't include any column definition.", DYNAMIC_EXT_TBL_OPTION),
 												errhint("Please use empty column definition.")));
 								}
 							}

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -803,7 +803,7 @@ transformRangeFunction(ParseState *pstate, RangeFunction *r)
 
 	if (funcname)
 	{
-		if (pg_strncasecmp(funcname, GP_DYNAMIC_EXTTAB_AS_TAB, sizeof(GP_DYNAMIC_EXTTAB_AS_TAB)) == 0)
+		if (pg_strncasecmp(funcname, GP_DYNAMIC_EXTTBL_AS_TBL, sizeof(GP_DYNAMIC_EXTTBL_AS_TBL)) == 0)
 		{	/* OK, now we need to check the arguments and generate a RTE */
 			FuncCall *fc;
 			RangeVar *rel, *castRel;
@@ -815,12 +815,12 @@ transformRangeFunction(ParseState *pstate, RangeFunction *r)
 			fc = (FuncCall *)r->funccallnode;
 
 			if (list_length(fc->args) != 2)
-				elog(ERROR, "Invalid %s syntax.", GP_DYNAMIC_EXTTAB_AS_TAB);
+				elog(ERROR, "Invalid %s syntax.", GP_DYNAMIC_EXTTBL_AS_TBL);
 
 			/* Only 2 args:
 			 * arg1: external table name */
 			arg_val = arg = linitial(fc->args);
-			getTableNameFromArg(arg, &schemaname1, &tablename1, GP_DYNAMIC_EXTTAB_AS_TAB);
+			getTableNameFromArg(arg, &schemaname1, &tablename1, GP_DYNAMIC_EXTTBL_AS_TBL);
 
 			/* Got the name of the table, now we need to build the RTE for the table. */
 			rel = makeRangeVar(schemaname1, tablename1, arg_val->location);
@@ -828,7 +828,7 @@ transformRangeFunction(ParseState *pstate, RangeFunction *r)
 			/* arg2: The target table that dynamic external table will use it's attribute list */
 
 			arg = lsecond(fc->args);
-			getTableNameFromArg(arg, &schemaname2, &tablename2, GP_DYNAMIC_EXTTAB_AS_TAB);
+			getTableNameFromArg(arg, &schemaname2, &tablename2, GP_DYNAMIC_EXTTBL_AS_TBL);
 			castRel = makeRangeVar(schemaname2, tablename2, arg_val->location);
 
 			rte = addRangeTableEntryForDynamicExtTab(pstate, rel, r->alias, false, true, castRel);

--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -912,7 +912,7 @@ addRangeTableEntry_internal(ParseState *pstate,
 		Alias *alias,
 		bool inh,
 		bool inFromCl,
-		RangeVar *castRelv)
+		RangeVar *castRelRV)
 {
 	RangeTblEntry *rte = makeNode(RangeTblEntry);
 	char	   *refname = alias ? alias->aliasname : relation->relname;
@@ -952,15 +952,16 @@ addRangeTableEntry_internal(ParseState *pstate,
 	if (RelationIsExternal(rel))
 	{
 		inh = false;
-		if(castRelv)
+		if(castRelRV)
 		{
 			if(!CheckDynamicOptionForExtTab(rel))
 				elog(ERROR, "Only external table with OPTIONS (%s 'true') works for %s().", DYNAMIC_EXT_TAB_OPTION, GP_DYNAMIC_EXTTAB_AS_TAB);
 
-			castRel = parserOpenTable(pstate, castRelv, NoLock, nowait, NULL);
+			castRel = parserOpenTable(pstate, castRelRV, NoLock, nowait, NULL);
 			rte->castRelid = castRel->rd_id;
 		}
-	}else if(castRelv)
+	}
+	else if(castRelRV)
 	{
 		elog(ERROR, "The first arg for %s() should be external table.", GP_DYNAMIC_EXTTAB_AS_TAB);
 	}
@@ -970,7 +971,7 @@ addRangeTableEntry_internal(ParseState *pstate,
 	 * and/or actual column names.
 	 */
 	rte->eref = makeAlias(refname, NIL);
-	buildRelationAliases(castRelv?castRel->rd_att:rel->rd_att, alias, rte->eref);
+	buildRelationAliases(castRelRV?castRel->rd_att:rel->rd_att, alias, rte->eref);
 
 	/*
 	 * Drop the rel refcount, but keep the access lock till end of transaction

--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -347,7 +347,7 @@ checkNameSpaceConflicts(ParseState *pstate, List *namespace1,
 			if (rte1->rtekind == RTE_RELATION && rte1->alias == NULL &&
 					rte2->rtekind == RTE_RELATION && rte2->alias == NULL &&
 					rte1->castRelid != rte2->castRelid)
-				continue;        /* no conflict if use different param2 for GP_DYNAMIC_EXTTAB_AS_TAB('exttab', 'param2'); */
+				continue;        /* no conflict if use different param2 for GP_DYNAMIC_EXTTBL_AS_TBL('exttab', 'param2'); */
 			ereport(ERROR,
 					(errcode(ERRCODE_DUPLICATE_ALIAS),
 					 errmsg("table name \"%s\" specified more than once",
@@ -955,7 +955,7 @@ addRangeTableEntry_internal(ParseState *pstate,
 		if(castRelRV)
 		{
 			if(!CheckDynamicOptionForExtTab(rel))
-				elog(ERROR, "Only external table with OPTIONS (%s 'true') works for %s().", DYNAMIC_EXT_TAB_OPTION, GP_DYNAMIC_EXTTAB_AS_TAB);
+				elog(ERROR, "Only external table with OPTIONS (%s 'true') works for %s().", DYNAMIC_EXT_TBL_OPTION, GP_DYNAMIC_EXTTBL_AS_TBL);
 
 			castRel = parserOpenTable(pstate, castRelRV, NoLock, nowait, NULL);
 			rte->castRelid = castRel->rd_id;
@@ -963,7 +963,7 @@ addRangeTableEntry_internal(ParseState *pstate,
 	}
 	else if(castRelRV)
 	{
-		elog(ERROR, "The first arg for %s() should be external table.", GP_DYNAMIC_EXTTAB_AS_TAB);
+		elog(ERROR, "The first arg for %s() should be external table.", GP_DYNAMIC_EXTTBL_AS_TBL);
 	}
 
 	/*

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -41,6 +41,7 @@
 #endif
 
 #include <pthread.h>
+#include <utils/builtins.h>
 
 #include "access/distributedlog.h"
 #include "access/printtup.h"

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -2039,6 +2039,7 @@ deparse_context_for(const char *aliasname, Oid relid)
 	rte = makeNode(RangeTblEntry);
 	rte->rtekind = RTE_RELATION;
 	rte->relid = relid;
+	rte->castRelid = InvalidOid;
 	rte->eref = makeAlias(aliasname, NIL);
 	rte->inh = false;
 	rte->inFromCl = true;

--- a/src/include/access/heapam.h
+++ b/src/include/access/heapam.h
@@ -114,6 +114,7 @@ inline static void xl_heapnode_set(
 }
 
 /* in heap/heapam.c */
+extern Relation dynamic_external_relation_open(Oid relationId, Oid castRelid, LOCKMODE lockmode);
 extern Relation relation_open(Oid relationId, LOCKMODE lockmode);
 extern Relation try_relation_open(Oid relationId, LOCKMODE lockmode, 
 								  bool noWait);

--- a/src/include/catalog/pg_exttable.h
+++ b/src/include/catalog/pg_exttable.h
@@ -16,8 +16,10 @@
 #ifndef PG_EXTTABLE_H
 #define PG_EXTTABLE_H
 
+#include "access/tupdesc.h"
 #include "catalog/genbki.h"
 #include "nodes/pg_list.h"
+#include "utils/relcache.h"
 
 /*
  * pg_exttable definition.
@@ -118,11 +120,15 @@ extern ExtTableEntry *GetExtTableEntry(Oid relid);
 extern ExtTableEntry *GetExtTableEntryIfExists(Oid relid);
 
 extern void RemoveExtTableEntry(Oid relid);
+extern bool CheckDynamicOptionForExtTab(Relation ext_rel);
+extern void CopyDynExtTableAttListFromCastRel(Relation, TupleDesc);
 
 #define fmttype_is_custom(c) (c == 'b' || c == 'a' || c == 'p')
 #define fmttype_is_avro(c) (c == 'a')
 #define fmttype_is_parquet(c) (c == 'p')
 #define fmttype_is_text(c)   (c == 't')
 #define fmttype_is_csv(c)    (c == 'c')
+
+#define DYNAMIC_EXT_TAB_OPTION "dynamic_schema"
 
 #endif /* PG_EXTTABLE_H */

--- a/src/include/catalog/pg_exttable.h
+++ b/src/include/catalog/pg_exttable.h
@@ -129,6 +129,6 @@ extern void CopyDynExtTableAttListFromCastRel(Relation, TupleDesc);
 #define fmttype_is_text(c)   (c == 't')
 #define fmttype_is_csv(c)    (c == 'c')
 
-#define DYNAMIC_EXT_TAB_OPTION "dynamic_schema"
+#define DYNAMIC_EXT_TBL_OPTION "dynamic_schema"
 
 #endif /* PG_EXTTABLE_H */

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -550,6 +550,9 @@ extern bool gp_enable_direct_dispatch;
 /* Name of pseudo-function to access any table as if it was randomly distributed. */
 #define GP_DIST_RANDOM_NAME "GP_DIST_RANDOM"
 
+/* Name of psedo-funciton to cast dynamic schema external table to specific table's schema */
+#define GP_DYNAMIC_EXTTAB_AS_TAB "GP_DYNAMIC_EXTTAB_AS_TAB"
+
 /*
  * gp_log_gang (string)
  *

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -551,7 +551,7 @@ extern bool gp_enable_direct_dispatch;
 #define GP_DIST_RANDOM_NAME "GP_DIST_RANDOM"
 
 /* Name of psedo-funciton to cast dynamic schema external table to specific table's schema */
-#define GP_DYNAMIC_EXTTAB_AS_TAB "GP_DYNAMIC_EXTTAB_AS_TAB"
+#define GP_DYNAMIC_EXTTBL_AS_TBL "GP_DYNAMIC_EXTTBL_AS_TBL"
 
 /*
  * gp_log_gang (string)

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -22,6 +22,7 @@
 #ifndef PARSENODES_H
 #define PARSENODES_H
 
+#include "access/tupdesc.h"
 #include "nodes/bitmapset.h"
 #include "nodes/primnodes.h"
 #include "nodes/value.h"
@@ -722,6 +723,8 @@ typedef struct RangeTblEntry
 	 * Fields valid for a plain relation RTE (else zero):
 	 */
 	Oid			relid;			/* OID of the relation */
+
+	Oid         castRelid;				 /* For dynamic external table to cast it's attribute list to */
 
 	/*
 	 * Fields valid for a subquery RTE (else NULL):

--- a/src/include/optimizer/plancat.h
+++ b/src/include/optimizer/plancat.h
@@ -27,7 +27,7 @@ typedef void (*get_relation_info_hook_type) (PlannerInfo *root,
 extern PGDLLIMPORT get_relation_info_hook_type get_relation_info_hook;
 
 
-extern void get_relation_info(PlannerInfo *root, Oid relationObjectId,
+extern void get_relation_info(PlannerInfo *root, RangeTblEntry *rte,
 				  bool inhparent, RelOptInfo *rel);
 
 extern void estimate_rel_size(Relation rel, int32 *attr_widths,

--- a/src/include/parser/parse_relation.h
+++ b/src/include/parser/parse_relation.h
@@ -54,6 +54,13 @@ extern void markVarForSelectPriv(ParseState *pstate, Var *var,
 					 RangeTblEntry *rte);
 extern Relation parserOpenTable(ParseState *pstate, const RangeVar *relation,
 				int lockmode, bool nowait, bool *lockUpgraded);
+extern
+RangeTblEntry * addRangeTableEntryForDynamicExtTab(ParseState *pstate,
+								   RangeVar *relation,
+								   Alias *alias,
+								   bool inh,
+								   bool inFromCl,
+								   RangeVar *castRel);
 extern RangeTblEntry *addRangeTableEntry(ParseState *pstate,
 				   RangeVar *relation,
 				   Alias *alias,

--- a/src/test/regress/.gitignore
+++ b/src/test/regress/.gitignore
@@ -19,6 +19,7 @@ GPTest.pm
 /results/
 /log/
 
+data/dynamic_schema.csv
 data/wet_csv?.tbl
 data/wet_text?.tbl
 data/wet_syntax?.tbl

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -25,7 +25,7 @@
 -- s/cat\: cannot open (.*)$/cat\: $1\: NO SUCH FILE/
 --
 -- # remove code line number in Error message
--- m/.+GP_DYNAMIC_EXTTAB_AS_TAB\(\).+\(.*\.c:\d+\)/
+-- m/.+GP_DYNAMIC_EXTTBL_AS_TBL\(\).+\(.*\.c:\d+\)/
 -- s/\s+\(parse_relation.c:\d+\)//
 --
 -- end_matchsubs
@@ -351,40 +351,40 @@ format 'csv' OPTIONS (dynamic_schema 'true'); -- OK
 
 -- 2. test: select query
 SELECT count(*) FROM dyn_schema_ext1;
-SELECT count(*) FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext2', 'dyn_schema_t1'); -- ERROR:  Only external table with OPTIONS (dynamic_schema 'true') works for GP_DYNAMIC_EXTTAB_AS_TAB() 
-SELECT count(*) FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t1'); -- ok
-SELECT count(*) FROM GP_DYNAMIC_EXTTAB_AS_TAB('public.dyn_schema_ext3', 'public.dyn_schema_t1'); -- ok, check table name with schema
+SELECT count(*) FROM GP_DYNAMIC_EXTTBL_AS_TBL('dyn_schema_ext2', 'dyn_schema_t1'); -- ERROR:  Only external table with OPTIONS (dynamic_schema 'true') works for GP_DYNAMIC_EXTTBL_AS_TBL() 
+SELECT count(*) FROM GP_DYNAMIC_EXTTBL_AS_TBL('dyn_schema_ext3', 'dyn_schema_t1'); -- ok
+SELECT count(*) FROM GP_DYNAMIC_EXTTBL_AS_TBL('public.dyn_schema_ext3', 'public.dyn_schema_t1'); -- ok, check table name with schema
 
 -- 3. test: cast to different type
 create table dyn_schema_t2 (c1 char(8), c2 char(8));
-SELECT count(*) FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t2'); -- ok
--- test: multiple calling GP_DYNAMIC_EXTTAB_AS_TAB with differnt parameter.
-SELECT * FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t1') AS tab1, GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t2') AS tab2;
+SELECT count(*) FROM GP_DYNAMIC_EXTTBL_AS_TBL('dyn_schema_ext3', 'dyn_schema_t2'); -- ok
+-- test: multiple calling GP_DYNAMIC_EXTTBL_AS_TBL with differnt parameter.
+SELECT * FROM GP_DYNAMIC_EXTTBL_AS_TBL('dyn_schema_ext3', 'dyn_schema_t1') AS tab1, GP_DYNAMIC_EXTTBL_AS_TBL('dyn_schema_ext3', 'dyn_schema_t2') AS tab2;
 
 -- 4. test: add one more column
 create table dyn_schema_t3 (a int, b int, c int);
 insert into dyn_schema_t3 select a,a,a from generate_series(1,10) as a;
 COPY dyn_schema_t3 to '@abs_srcdir@/data/dynamic_schema.csv' CSV;
-SELECT * FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t3');
+SELECT * FROM GP_DYNAMIC_EXTTBL_AS_TBL('dyn_schema_ext3', 'dyn_schema_t3');
 COPY dyn_schema_t1 to '@abs_srcdir@/data/dynamic_schema.csv' CSV;
 
 -- 5. test: insert ... select ...
 INSERT INTO dyn_schema_t1 SELECT * FROM dyn_schema_ext1;
 SELECT count(*) FROM dyn_schema_t1;
-INSERT INTO dyn_schema_t1 SELECT * FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext2', 'dyn_schema_t1'); -- ERROR:  Only external table with OPTIONS (dynamic_schema 'true') works for GP_DYNAMIC_EXTTAB_AS_TAB() 
+INSERT INTO dyn_schema_t1 SELECT * FROM GP_DYNAMIC_EXTTBL_AS_TBL('dyn_schema_ext2', 'dyn_schema_t1'); -- ERROR:  Only external table with OPTIONS (dynamic_schema 'true') works for GP_DYNAMIC_EXTTBL_AS_TBL() 
 SELECT count(*) FROM dyn_schema_t1;
-INSERT INTO dyn_schema_t1 SELECT * FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t1'); -- work because dyn_schema_ext auto changed to use tableless_heap column list
+INSERT INTO dyn_schema_t1 SELECT * FROM GP_DYNAMIC_EXTTBL_AS_TBL('dyn_schema_ext3', 'dyn_schema_t1'); -- work because dyn_schema_ext auto changed to use tableless_heap column list
 SELECT count(*) FROM dyn_schema_t1;
-INSERT INTO dyn_schema_t2 SELECT * FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t2'); -- work because dyn_schema_ext auto changed to use tableless_heap column list
+INSERT INTO dyn_schema_t2 SELECT * FROM GP_DYNAMIC_EXTTBL_AS_TBL('dyn_schema_ext3', 'dyn_schema_t2'); -- work because dyn_schema_ext auto changed to use tableless_heap column list
 SELECT count(*) FROM dyn_schema_t2;
 
 -- 6. test: schema change in a transaction
 BEGIN;
 TRUNCATE dyn_schema_t1;
-INSERT INTO dyn_schema_t1 SELECT * FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t1'); 
+INSERT INTO dyn_schema_t1 SELECT * FROM GP_DYNAMIC_EXTTBL_AS_TBL('dyn_schema_ext3', 'dyn_schema_t1'); 
 SELECT * FROM dyn_schema_t1;
 ALTER TABLE dyn_schema_t1 ALTER COLUMN b TYPE char(8);
-INSERT INTO dyn_schema_t1 SELECT * FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t1'); 
+INSERT INTO dyn_schema_t1 SELECT * FROM GP_DYNAMIC_EXTTBL_AS_TBL('dyn_schema_ext3', 'dyn_schema_t1'); 
 SELECT * FROM dyn_schema_t1;
 COMMIT;
 

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -334,7 +334,7 @@ create external table dyn_schema_ext1(a int, b int)
 location ('file://@hostname@@abs_srcdir@/data/dynamic_schema.csv')
 format 'csv';
 
--- normal external table, not the same scheml with dyn_schema_t1 heap table 
+-- normal external table, not the same schema with dyn_schema_t1 heap table 
 create external table dyn_schema_ext2(a int)
 location ('file://@hostname@@abs_srcdir@/data/dynamic_schema.csv')
 format 'csv';
@@ -353,6 +353,7 @@ format 'csv' OPTIONS (dynamic_schema 'true'); -- OK
 SELECT count(*) FROM dyn_schema_ext1;
 SELECT count(*) FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext2', 'dyn_schema_t1'); -- ERROR:  Only external table with OPTIONS (dynamic_schema 'true') works for GP_DYNAMIC_EXTTAB_AS_TAB() 
 SELECT count(*) FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t1'); -- ok
+SELECT count(*) FROM GP_DYNAMIC_EXTTAB_AS_TAB('public.dyn_schema_ext3', 'public.dyn_schema_t1'); -- ok, check table name with schema
 
 -- 3. test: cast to different type
 create table dyn_schema_t2 (c1 char(8), c2 char(8));

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -24,6 +24,10 @@
 -- m/ERROR\:\s+external table .* command ended with .*cat\: cannot open.*/i
 -- s/cat\: cannot open (.*)$/cat\: $1\: NO SUCH FILE/
 --
+-- # remove code line number in Error message
+-- m/.+GP_DYNAMIC_EXTTAB_AS_TAB\(\).+\(.*\.c:\d+\)/
+-- s/\s+\(parse_relation.c:\d+\)//
+--
 -- end_matchsubs
 CREATE TABLE REG_REGION (R_REGIONKEY INT, R_NAME CHAR(25), R_COMMENT VARCHAR(152)) DISTRIBUTED BY (R_REGIONKEY);
 
@@ -55,12 +59,17 @@ DROP EXTERNAL TABLE EXT_REGION;
 -- --------------------------------------
 DROP TABLE IF EXISTS REG_REGION;
 DROP TABLE IF EXISTS tableless_heap;
+DROP TABLE IF EXISTS dyn_schema_t1;
+DROP TABLE IF EXISTS dyn_schema_t2;
 DROP TABLE IF EXISTS errlog_save;
 DROP TABLE IF EXISTS exttab_insert_1;
 DROP TABLE IF EXISTS exttab_ctas_1;
 DROP TABLE IF EXISTS exttab_constraints_insert_1;
 
 DROP EXTERNAL TABLE IF EXISTS tableless_ext;
+DROP EXTERNAL TABLE IF EXISTS dyn_schema_ext1;
+DROP EXTERNAL TABLE IF EXISTS dyn_schema_ext2;
+DROP EXTERNAL TABLE IF EXISTS dyn_schema_ext3;
 DROP EXTERNAL TABLE IF EXISTS ret_too_many_uris;
 DROP EXTERNAL TABLE IF EXISTS wet_too_many_uris;
 DROP EXTERNAL TABLE IF EXISTS exttab_basic_1;
@@ -313,8 +322,71 @@ select * from tableless_ext;
 SELECT gp_truncate_error_log('*.*');
 SELECT relname, linenum, errmsg FROM gp_read_error_log('tableless_ext');
 
+-- Test for dynamic schema external table
 
---
+-- 1. Prepare the testing data
+create table dyn_schema_t1 (a int, b int);
+insert into dyn_schema_t1 select a,a from generate_series(1,10) as a;
+COPY dyn_schema_t1 to '@abs_srcdir@/data/dynamic_schema.csv' CSV;
+
+-- normal external table, the same schema with dyn_schema_t1 heap table 
+create external table dyn_schema_ext1(a int, b int)
+location ('file://@hostname@@abs_srcdir@/data/dynamic_schema.csv')
+format 'csv';
+
+-- normal external table, not the same scheml with dyn_schema_t1 heap table 
+create external table dyn_schema_ext2(a int)
+location ('file://@hostname@@abs_srcdir@/data/dynamic_schema.csv')
+format 'csv';
+
+-- test: dynamic_schema conflict with column definition 
+create external table dyn_schema_ext3(a int)
+location ('file://@hostname@@abs_srcdir@/data/dynamic_schema.csv')
+format 'csv' OPTIONS (dynamic_schema 'true'); -- Error for dynamic_schema conflict with column definition
+
+-- test: dynamic schema
+create external table dyn_schema_ext3()
+location ('file://@hostname@@abs_srcdir@/data/dynamic_schema.csv')
+format 'csv' OPTIONS (dynamic_schema 'true'); -- OK
+
+-- 2. test: select query
+SELECT count(*) FROM dyn_schema_ext1;
+SELECT count(*) FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext2', 'dyn_schema_t1'); -- ERROR:  Only external table with OPTIONS (dynamic_schema 'true') works for GP_DYNAMIC_EXTTAB_AS_TAB() 
+SELECT count(*) FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t1'); -- ok
+
+-- 3. test: cast to different type
+create table dyn_schema_t2 (c1 char(8), c2 char(8));
+SELECT count(*) FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t2'); -- ok
+-- test: multiple calling GP_DYNAMIC_EXTTAB_AS_TAB with differnt parameter.
+SELECT * FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t1') AS tab1, GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t2') AS tab2;
+
+-- 4. test: add one more column
+create table dyn_schema_t3 (a int, b int, c int);
+insert into dyn_schema_t3 select a,a,a from generate_series(1,10) as a;
+COPY dyn_schema_t3 to '@abs_srcdir@/data/dynamic_schema.csv' CSV;
+SELECT * FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t3');
+COPY dyn_schema_t1 to '@abs_srcdir@/data/dynamic_schema.csv' CSV;
+
+-- 5. test: insert ... select ...
+INSERT INTO dyn_schema_t1 SELECT * FROM dyn_schema_ext1;
+SELECT count(*) FROM dyn_schema_t1;
+INSERT INTO dyn_schema_t1 SELECT * FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext2', 'dyn_schema_t1'); -- ERROR:  Only external table with OPTIONS (dynamic_schema 'true') works for GP_DYNAMIC_EXTTAB_AS_TAB() 
+SELECT count(*) FROM dyn_schema_t1;
+INSERT INTO dyn_schema_t1 SELECT * FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t1'); -- work because dyn_schema_ext auto changed to use tableless_heap column list
+SELECT count(*) FROM dyn_schema_t1;
+INSERT INTO dyn_schema_t2 SELECT * FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t2'); -- work because dyn_schema_ext auto changed to use tableless_heap column list
+SELECT count(*) FROM dyn_schema_t2;
+
+-- 6. test: schema change in a transaction
+BEGIN;
+TRUNCATE dyn_schema_t1;
+INSERT INTO dyn_schema_t1 SELECT * FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t1'); 
+SELECT * FROM dyn_schema_t1;
+ALTER TABLE dyn_schema_t1 ALTER COLUMN b TYPE char(8);
+INSERT INTO dyn_schema_t1 SELECT * FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t1'); 
+SELECT * FROM dyn_schema_t1;
+COMMIT;
+
 -- These fail because there are more locations than there are segments.
 --
 -- As written, if you have a large enough cluster, with more than 20

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -24,6 +24,10 @@
 -- m/ERROR\:\s+external table .* command ended with .*cat\: cannot open.*/i
 -- s/cat\: cannot open (.*)$/cat\: $1\: NO SUCH FILE/
 --
+-- # remove code line number in Error message
+-- m/.+GP_DYNAMIC_EXTTAB_AS_TAB\(\).+\(.*\.c:\d+\)/
+-- s/\s+\(parse_relation.c:\d+\)//
+--
 -- end_matchsubs
 CREATE TABLE REG_REGION (R_REGIONKEY INT, R_NAME CHAR(25), R_COMMENT VARCHAR(152)) DISTRIBUTED BY (R_REGIONKEY);
 -- --------------------------------------
@@ -501,7 +505,261 @@ SELECT relname, linenum, errmsg FROM gp_read_error_log('tableless_ext');
 ---------+---------+--------
 (0 rows)
 
---
+-- Test for dynamic schema external table
+-- 1. Prepare the testing data
+create table dyn_schema_t1 (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into dyn_schema_t1 select a,a from generate_series(1,10) as a;
+COPY dyn_schema_t1 to '@abs_srcdir@/data/dynamic_schema.csv' CSV;
+-- normal external table, the same schema with dyn_schema_t1 heap table 
+create external table dyn_schema_ext1(a int, b int)
+location ('file://@hostname@@abs_srcdir@/data/dynamic_schema.csv')
+format 'csv';
+-- normal external table, not the same scheml with dyn_schema_t1 heap table 
+create external table dyn_schema_ext2(a int)
+location ('file://@hostname@@abs_srcdir@/data/dynamic_schema.csv')
+format 'csv';
+-- test: dynamic_schema conflict with column definition 
+create external table dyn_schema_ext3(a int)
+location ('file://@hostname@@abs_srcdir@/data/dynamic_schema.csv')
+format 'csv' OPTIONS (dynamic_schema 'true'); -- Error for dynamic_schema conflict with column definition
+ERROR:  External table with OPTIONS (dynamic_schema 'true') can't include any column definition.
+HINT:  Please use empty column definition.
+-- test: dynamic schema
+create external table dyn_schema_ext3()
+location ('file://@hostname@@abs_srcdir@/data/dynamic_schema.csv')
+format 'csv' OPTIONS (dynamic_schema 'true'); -- OK
+-- 2. test: select query
+SELECT count(*) FROM dyn_schema_ext1;
+ count 
+-------
+    10
+(1 row)
+
+SELECT count(*) FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext2', 'dyn_schema_t1'); -- ERROR:  Only external table with OPTIONS (dynamic_schema 'true') works for GP_DYNAMIC_EXTTAB_AS_TAB() 
+ERROR:  Only external table with OPTIONS (dynamic_schema 'true') works for GP_DYNAMIC_EXTTAB_AS_TAB().
+SELECT count(*) FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t1'); -- ok
+ count 
+-------
+    10
+(1 row)
+
+-- 3. test: cast to different type
+create table dyn_schema_t2 (c1 char(8), c2 char(8));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SELECT count(*) FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t2'); -- ok
+ count 
+-------
+    10
+(1 row)
+
+-- test: multiple calling GP_DYNAMIC_EXTTAB_AS_TAB with differnt parameter.
+SELECT * FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t1') AS tab1, GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t2') AS tab2;
+ a  | b  |    c1    |    c2    
+----+----+----------+----------
+  1 |  1 | 1        | 1       
+  3 |  3 | 1        | 1       
+  8 |  8 | 1        | 1       
+  2 |  2 | 1        | 1       
+  4 |  4 | 1        | 1       
+  9 |  9 | 1        | 1       
+  5 |  5 | 1        | 1       
+ 10 | 10 | 1        | 1       
+  6 |  6 | 1        | 1       
+  7 |  7 | 1        | 1       
+  1 |  1 | 3        | 3       
+  3 |  3 | 3        | 3       
+  8 |  8 | 3        | 3       
+  2 |  2 | 3        | 3       
+  4 |  4 | 3        | 3       
+  9 |  9 | 3        | 3       
+  5 |  5 | 3        | 3       
+ 10 | 10 | 3        | 3       
+  6 |  6 | 3        | 3       
+  7 |  7 | 3        | 3       
+  1 |  1 | 8        | 8       
+  3 |  3 | 8        | 8       
+  8 |  8 | 8        | 8       
+  2 |  2 | 8        | 8       
+  4 |  4 | 8        | 8       
+  9 |  9 | 8        | 8       
+  5 |  5 | 8        | 8       
+ 10 | 10 | 8        | 8       
+  6 |  6 | 8        | 8       
+  7 |  7 | 8        | 8       
+  1 |  1 | 2        | 2       
+  3 |  3 | 2        | 2       
+  8 |  8 | 2        | 2       
+  2 |  2 | 2        | 2       
+  4 |  4 | 2        | 2       
+  9 |  9 | 2        | 2       
+  5 |  5 | 2        | 2       
+ 10 | 10 | 2        | 2       
+  6 |  6 | 2        | 2       
+  7 |  7 | 2        | 2       
+  1 |  1 | 4        | 4       
+  3 |  3 | 4        | 4       
+  8 |  8 | 4        | 4       
+  2 |  2 | 4        | 4       
+  4 |  4 | 4        | 4       
+  9 |  9 | 4        | 4       
+  5 |  5 | 4        | 4       
+ 10 | 10 | 4        | 4       
+  6 |  6 | 4        | 4       
+  7 |  7 | 4        | 4       
+  1 |  1 | 9        | 9       
+  3 |  3 | 9        | 9       
+  8 |  8 | 9        | 9       
+  2 |  2 | 9        | 9       
+  4 |  4 | 9        | 9       
+  9 |  9 | 9        | 9       
+  5 |  5 | 9        | 9       
+ 10 | 10 | 9        | 9       
+  6 |  6 | 9        | 9       
+  7 |  7 | 9        | 9       
+  1 |  1 | 5        | 5       
+  3 |  3 | 5        | 5       
+  8 |  8 | 5        | 5       
+  2 |  2 | 5        | 5       
+  4 |  4 | 5        | 5       
+  9 |  9 | 5        | 5       
+  5 |  5 | 5        | 5       
+ 10 | 10 | 5        | 5       
+  6 |  6 | 5        | 5       
+  7 |  7 | 5        | 5       
+  1 |  1 | 10       | 10      
+  3 |  3 | 10       | 10      
+  8 |  8 | 10       | 10      
+  2 |  2 | 10       | 10      
+  4 |  4 | 10       | 10      
+  9 |  9 | 10       | 10      
+  5 |  5 | 10       | 10      
+ 10 | 10 | 10       | 10      
+  6 |  6 | 10       | 10      
+  7 |  7 | 10       | 10      
+  1 |  1 | 6        | 6       
+  3 |  3 | 6        | 6       
+  8 |  8 | 6        | 6       
+  2 |  2 | 6        | 6       
+  4 |  4 | 6        | 6       
+  9 |  9 | 6        | 6       
+  5 |  5 | 6        | 6       
+ 10 | 10 | 6        | 6       
+  6 |  6 | 6        | 6       
+  7 |  7 | 6        | 6       
+  1 |  1 | 7        | 7       
+  3 |  3 | 7        | 7       
+  8 |  8 | 7        | 7       
+  2 |  2 | 7        | 7       
+  4 |  4 | 7        | 7       
+  9 |  9 | 7        | 7       
+  5 |  5 | 7        | 7       
+ 10 | 10 | 7        | 7       
+  6 |  6 | 7        | 7       
+  7 |  7 | 7        | 7       
+(100 rows)
+
+-- 4. test: add one more column
+create table dyn_schema_t3 (a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into dyn_schema_t3 select a,a,a from generate_series(1,10) as a;
+COPY dyn_schema_t3 to '@abs_srcdir@/data/dynamic_schema.csv' CSV;
+SELECT * FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t3');
+ a  | b  | c  
+----+----+----
+  1 |  1 |  1
+  3 |  3 |  3
+  8 |  8 |  8
+  2 |  2 |  2
+  4 |  4 |  4
+  9 |  9 |  9
+  5 |  5 |  5
+ 10 | 10 | 10
+  6 |  6 |  6
+  7 |  7 |  7
+(10 rows)
+
+COPY dyn_schema_t1 to '@abs_srcdir@/data/dynamic_schema.csv' CSV;
+-- 5. test: insert ... select ...
+INSERT INTO dyn_schema_t1 SELECT * FROM dyn_schema_ext1;
+SELECT count(*) FROM dyn_schema_t1;
+ count 
+-------
+    20
+(1 row)
+
+INSERT INTO dyn_schema_t1 SELECT * FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext2', 'dyn_schema_t1'); -- ERROR:  Only external table with OPTIONS (dynamic_schema 'true') works for GP_DYNAMIC_EXTTAB_AS_TAB() 
+ERROR:  Only external table with OPTIONS (dynamic_schema 'true') works for GP_DYNAMIC_EXTTAB_AS_TAB().
+SELECT count(*) FROM dyn_schema_t1;
+ count 
+-------
+    20
+(1 row)
+
+INSERT INTO dyn_schema_t1 SELECT * FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t1'); -- work because dyn_schema_ext auto changed to use tableless_heap column list
+SELECT count(*) FROM dyn_schema_t1;
+ count 
+-------
+    30
+(1 row)
+
+INSERT INTO dyn_schema_t2 SELECT * FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t2'); -- work because dyn_schema_ext auto changed to use tableless_heap column list
+SELECT count(*) FROM dyn_schema_t2;
+ count 
+-------
+    10
+(1 row)
+
+-- 6. test: schema change in a transaction
+BEGIN;
+TRUNCATE dyn_schema_t1;
+INSERT INTO dyn_schema_t1 SELECT * FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t1'); 
+SELECT * FROM dyn_schema_t1;
+ a  | b  
+----+----
+  1 |  1
+  2 |  2
+  3 |  3
+  4 |  4
+  5 |  5
+  6 |  6
+  7 |  7
+  8 |  8
+  9 |  9
+ 10 | 10
+(10 rows)
+
+ALTER TABLE dyn_schema_t1 ALTER COLUMN b TYPE char(8);
+INSERT INTO dyn_schema_t1 SELECT * FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t1'); 
+SELECT * FROM dyn_schema_t1;
+ a  |    b     
+----+----------
+  1 | 1       
+  2 | 2       
+  1 | 1       
+  2 | 2       
+  3 | 3       
+  4 | 4       
+  5 | 5       
+  6 | 6       
+  7 | 7       
+  3 | 3       
+  4 | 4       
+  5 | 5       
+  6 | 6       
+  7 | 7       
+  8 | 8       
+  9 | 9       
+ 10 | 10      
+  8 | 8       
+  9 | 9       
+ 10 | 10      
+(20 rows)
+
+COMMIT;
 -- These fail because there are more locations than there are segments.
 --
 -- As written, if you have a large enough cluster, with more than 20

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -516,7 +516,7 @@ COPY dyn_schema_t1 to '@abs_srcdir@/data/dynamic_schema.csv' CSV;
 create external table dyn_schema_ext1(a int, b int)
 location ('file://@hostname@@abs_srcdir@/data/dynamic_schema.csv')
 format 'csv';
--- normal external table, not the same scheml with dyn_schema_t1 heap table 
+-- normal external table, not the same schema with dyn_schema_t1 heap table 
 create external table dyn_schema_ext2(a int)
 location ('file://@hostname@@abs_srcdir@/data/dynamic_schema.csv')
 format 'csv';
@@ -540,6 +540,12 @@ SELECT count(*) FROM dyn_schema_ext1;
 SELECT count(*) FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext2', 'dyn_schema_t1'); -- ERROR:  Only external table with OPTIONS (dynamic_schema 'true') works for GP_DYNAMIC_EXTTAB_AS_TAB() 
 ERROR:  Only external table with OPTIONS (dynamic_schema 'true') works for GP_DYNAMIC_EXTTAB_AS_TAB().
 SELECT count(*) FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t1'); -- ok
+ count 
+-------
+    10
+(1 row)
+
+SELECT count(*) FROM GP_DYNAMIC_EXTTAB_AS_TAB('public.dyn_schema_ext3', 'public.dyn_schema_t1'); -- ok, check table name with schema
  count 
 -------
     10

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -25,7 +25,7 @@
 -- s/cat\: cannot open (.*)$/cat\: $1\: NO SUCH FILE/
 --
 -- # remove code line number in Error message
--- m/.+GP_DYNAMIC_EXTTAB_AS_TAB\(\).+\(.*\.c:\d+\)/
+-- m/.+GP_DYNAMIC_EXTTBL_AS_TBL\(\).+\(.*\.c:\d+\)/
 -- s/\s+\(parse_relation.c:\d+\)//
 --
 -- end_matchsubs
@@ -537,15 +537,15 @@ SELECT count(*) FROM dyn_schema_ext1;
     10
 (1 row)
 
-SELECT count(*) FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext2', 'dyn_schema_t1'); -- ERROR:  Only external table with OPTIONS (dynamic_schema 'true') works for GP_DYNAMIC_EXTTAB_AS_TAB() 
-ERROR:  Only external table with OPTIONS (dynamic_schema 'true') works for GP_DYNAMIC_EXTTAB_AS_TAB().
-SELECT count(*) FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t1'); -- ok
+SELECT count(*) FROM GP_DYNAMIC_EXTTBL_AS_TBL('dyn_schema_ext2', 'dyn_schema_t1'); -- ERROR:  Only external table with OPTIONS (dynamic_schema 'true') works for GP_DYNAMIC_EXTTBL_AS_TBL() 
+ERROR:  Only external table with OPTIONS (dynamic_schema 'true') works for GP_DYNAMIC_EXTTBL_AS_TBL().
+SELECT count(*) FROM GP_DYNAMIC_EXTTBL_AS_TBL('dyn_schema_ext3', 'dyn_schema_t1'); -- ok
  count 
 -------
     10
 (1 row)
 
-SELECT count(*) FROM GP_DYNAMIC_EXTTAB_AS_TAB('public.dyn_schema_ext3', 'public.dyn_schema_t1'); -- ok, check table name with schema
+SELECT count(*) FROM GP_DYNAMIC_EXTTBL_AS_TBL('public.dyn_schema_ext3', 'public.dyn_schema_t1'); -- ok, check table name with schema
  count 
 -------
     10
@@ -555,14 +555,14 @@ SELECT count(*) FROM GP_DYNAMIC_EXTTAB_AS_TAB('public.dyn_schema_ext3', 'public.
 create table dyn_schema_t2 (c1 char(8), c2 char(8));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-SELECT count(*) FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t2'); -- ok
+SELECT count(*) FROM GP_DYNAMIC_EXTTBL_AS_TBL('dyn_schema_ext3', 'dyn_schema_t2'); -- ok
  count 
 -------
     10
 (1 row)
 
--- test: multiple calling GP_DYNAMIC_EXTTAB_AS_TAB with differnt parameter.
-SELECT * FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t1') AS tab1, GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t2') AS tab2;
+-- test: multiple calling GP_DYNAMIC_EXTTBL_AS_TBL with differnt parameter.
+SELECT * FROM GP_DYNAMIC_EXTTBL_AS_TBL('dyn_schema_ext3', 'dyn_schema_t1') AS tab1, GP_DYNAMIC_EXTTBL_AS_TBL('dyn_schema_ext3', 'dyn_schema_t2') AS tab2;
  a  | b  |    c1    |    c2    
 ----+----+----------+----------
   1 |  1 | 1        | 1       
@@ -673,7 +673,7 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into dyn_schema_t3 select a,a,a from generate_series(1,10) as a;
 COPY dyn_schema_t3 to '@abs_srcdir@/data/dynamic_schema.csv' CSV;
-SELECT * FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t3');
+SELECT * FROM GP_DYNAMIC_EXTTBL_AS_TBL('dyn_schema_ext3', 'dyn_schema_t3');
  a  | b  | c  
 ----+----+----
   1 |  1 |  1
@@ -697,22 +697,22 @@ SELECT count(*) FROM dyn_schema_t1;
     20
 (1 row)
 
-INSERT INTO dyn_schema_t1 SELECT * FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext2', 'dyn_schema_t1'); -- ERROR:  Only external table with OPTIONS (dynamic_schema 'true') works for GP_DYNAMIC_EXTTAB_AS_TAB() 
-ERROR:  Only external table with OPTIONS (dynamic_schema 'true') works for GP_DYNAMIC_EXTTAB_AS_TAB().
+INSERT INTO dyn_schema_t1 SELECT * FROM GP_DYNAMIC_EXTTBL_AS_TBL('dyn_schema_ext2', 'dyn_schema_t1'); -- ERROR:  Only external table with OPTIONS (dynamic_schema 'true') works for GP_DYNAMIC_EXTTBL_AS_TBL() 
+ERROR:  Only external table with OPTIONS (dynamic_schema 'true') works for GP_DYNAMIC_EXTTBL_AS_TBL().
 SELECT count(*) FROM dyn_schema_t1;
  count 
 -------
     20
 (1 row)
 
-INSERT INTO dyn_schema_t1 SELECT * FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t1'); -- work because dyn_schema_ext auto changed to use tableless_heap column list
+INSERT INTO dyn_schema_t1 SELECT * FROM GP_DYNAMIC_EXTTBL_AS_TBL('dyn_schema_ext3', 'dyn_schema_t1'); -- work because dyn_schema_ext auto changed to use tableless_heap column list
 SELECT count(*) FROM dyn_schema_t1;
  count 
 -------
     30
 (1 row)
 
-INSERT INTO dyn_schema_t2 SELECT * FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t2'); -- work because dyn_schema_ext auto changed to use tableless_heap column list
+INSERT INTO dyn_schema_t2 SELECT * FROM GP_DYNAMIC_EXTTBL_AS_TBL('dyn_schema_ext3', 'dyn_schema_t2'); -- work because dyn_schema_ext auto changed to use tableless_heap column list
 SELECT count(*) FROM dyn_schema_t2;
  count 
 -------
@@ -722,7 +722,7 @@ SELECT count(*) FROM dyn_schema_t2;
 -- 6. test: schema change in a transaction
 BEGIN;
 TRUNCATE dyn_schema_t1;
-INSERT INTO dyn_schema_t1 SELECT * FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t1'); 
+INSERT INTO dyn_schema_t1 SELECT * FROM GP_DYNAMIC_EXTTBL_AS_TBL('dyn_schema_ext3', 'dyn_schema_t1'); 
 SELECT * FROM dyn_schema_t1;
  a  | b  
 ----+----
@@ -739,7 +739,7 @@ SELECT * FROM dyn_schema_t1;
 (10 rows)
 
 ALTER TABLE dyn_schema_t1 ALTER COLUMN b TYPE char(8);
-INSERT INTO dyn_schema_t1 SELECT * FROM GP_DYNAMIC_EXTTAB_AS_TAB('dyn_schema_ext3', 'dyn_schema_t1'); 
+INSERT INTO dyn_schema_t1 SELECT * FROM GP_DYNAMIC_EXTTBL_AS_TBL('dyn_schema_ext3', 'dyn_schema_t1'); 
 SELECT * FROM dyn_schema_t1;
  a  |    b     
 ----+----------


### PR DESCRIPTION
UPDATED:
----------
Implement dynamic schema feature for external table

Many customers complained that gptransfer will make pg_class catalog bloated. The reason
is: gptransfer will call "insert into dest_table select * from external_table", and for each dest_table, we need create one dedicated external_table because of schema difference. The dynamic schema external table can cast it's schema to any table's schema as needed.

To specify the external table be dynamic schema, add OPTIONS (dynamic_schema 'true') to 'CREATE EXTERNAL TABLE' statement. The column list definition in DDL should be empty.

A pseudo UDF GP_DYNAMIC_EXTTBL_AS_TBL('external_table', 'cast_table') is implemented to replace external table's schema by the cast_table's schema.

Signed-off-by: Tingfang Bao <bbao@pivotal.io>
---------------- Old commit message ----------------
Many customer complained that gptransfer will make pg_class catalog bloated. The reason
is: gptransfer will call "insert into dest_table select * from external_table", and for
each dest_table, we need create one dedicated external_table because of schema difference.

Here is a simple solution: each time reading the schema info of the external table, we just
read them from the dest_table in case of "insert into dest_table select * from external_table".

To specify the external table be schema-less, add OPTIONS (schemaless 'true') to 'CREATE
EXTERNAL TABLE' statement. The column list definition in DDL still kept because they will
be used in other cases.

Now only support "INSERT INTO target_table SELECT * FROM external_table", cannot support other
complex scenarios like 'INSERT INTO target_table(c1,c2) SELECT *,c1+c2 FROM external_table'.

Signed-off-by: Tingfang Bao <bbao@pivotal.io>