### PR TITLE
extprotocol: fix bad cast in check_ext_options

### DIFF
--- a/contrib/extprotocol/gpextprotocol.c
+++ b/contrib/extprotocol/gpextprotocol.c
@@ -47,8 +47,8 @@ static void check_ext_options(const FunctionCallInfo fcinfo)
         List *options = exttbl->options;
 
         foreach(cell, options) {
-                DefElem *def = (DefElem *) lfirst(cell);
-                char *key = def->defname;
+                Value *value = (Value *) lfirst(cell);
+                char *key = value->val.str;
 
                 if (key && strcasestr(key, "database") && !strcasestr(key, "greenplum")) {
                         ereport(ERROR, (0, errmsg("This is greenplum.")));


### PR DESCRIPTION
When this code was added (commit 210ab15e), it treated the `ExtTableEntry.options` member as a list of `DefElem`s. It's actually a list of `Value`s (specifically, `T_String` -- [see the current list creation](https://github.com/greenplum-db/gpdb/blob/master/src/backend/catalog/pg_exttable.c#L369-L370)). This code will break when the offset of `DefElem.defname` changes in the upcoming 8.4 merge iteration.