### PR TITLE
Adding scripts to check `Author:` prefix

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -301,5 +301,8 @@ distcheck: dist
 	rm -rf $(distdir) $(dummy)
 	@echo "Distribution integrity checks out."
 
+check-authorship:
+	src/tools/check_authorship
+
 .PHONY: dist distdir distcheck
 unexport split-dist

--- a/src/tools/check_authorship
+++ b/src/tools/check_authorship
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# check HEAD commit to ensure `Author:` exists
+git show --pretty=format:%b -s | grep "Author:"


### PR DESCRIPTION
This is to help people check whether their top commit message got
`Author:` prefix or not.

TODO: We need to figure out which high-level target to invoke
this commit message checking.