### PR TITLE
Fix the \h help for ALTER TYPE.

### DIFF
--- a/doc/src/sgml/ref/alter_type.sgml
+++ b/doc/src/sgml/ref/alter_type.sgml
@@ -23,14 +23,10 @@ PostgreSQL documentation
 
  <refsynopsisdiv>
   <synopsis>
-<!--
-     GPDB_84_MERGE_FIXME: Upstream has documentation on "RENAME TO"
-     that we didn't take. Should we add that?
--->
-ALTER TYPE <replaceable class="PARAMETER">name</replaceable> 
-   SET DEFAULT ENCODING ( storage_directive )
-     OWNER TO <replaceable class="PARAMETER">new_owner</replaceable> 
-   | SET SCHEMA <replaceable class="PARAMETER">new_schema</replaceable>
+ALTER TYPE <replaceable class="PARAMETER">name</replaceable> RENAME TO <replaceable class="PARAMETER">new_name</replaceable>
+ALTER TYPE <replaceable class="PARAMETER">name</replaceable> OWNER TO <replaceable class="PARAMETER">new_owner</replaceable> 
+ALTER TYPE <replaceable class="PARAMETER">name</replaceable> SET SCHEMA <replaceable class="PARAMETER">new_schema</replaceable>
+ALTER TYPE <replaceable class="PARAMETER">name</replaceable> SET DEFAULT ENCODING ( storage_directive )
   </synopsis>
  </refsynopsisdiv>
 
@@ -95,23 +91,6 @@ ALTER TYPE <replaceable class="PARAMETER">name</replaceable>
       </listitem>
      </varlistentry>
 
-     <varlistentry>
-      <term><replaceable class="PARAMETER">storage_directive</replaceable></term>
-      <listitem>
-       <para>
-        Sets any or all of the following: compression type, compression level, 
-        and blocksize, using the following format:
-        COMPRESSTYPE={ZLIB | QUICKLZ | RLE_TYPE | NONE} | 
-        COMPRESSLEVEL={0-9} | BLOCKSIZE={8192-2097152}
-       </para>
-       <para>
-       For more information on the compression and blocksize parameters, see the
-       "Storage Directives for Column-level Compression" in the Greenplum
-       Database Administrator Guide.
-       </para>
-      </listitem>
-     </varlistentry>
-
     </variablelist>
    </para>
   </refsect1>
@@ -139,13 +118,6 @@ ALTER TYPE email OWNER TO joe;
    to <literal>customers</literal>:
    <programlisting>
 ALTER TYPE email SET SCHEMA customers;
-   </programlisting>
-  </para>
-
-  <para>
-   To change the type int to have ZLIB column compression:
-   <programlisting>
-ALTER TYPE int SET DEFAULT ENCODING (COMPRESSTYPE=ZLIB);
    </programlisting>
   </para>
  </refsect1>

--- a/doc/src/sgml/ref/create_type.sgml
+++ b/doc/src/sgml/ref/create_type.sgml
@@ -613,60 +613,11 @@ CREATE TYPE <replaceable class="parameter">name</replaceable>
      </para>
     </listitem>
    </varlistentry>
-
-   <varlistentry>
-    <term><replaceable class="parameter">compression_type</replaceable></term>
-    <listitem>
-     <para>
-      One of the following: ZLIB, QUICKLZ , RLE_TYPE, or NONE.
-     </para>
-    </listitem>
-   </varlistentry>
-
-   <varlistentry>
-    <term><replaceable class="parameter">compression_level</replaceable></term>
-    <listitem>
-     <para>
-      Values between 0 and 9.
-     </para>
-    </listitem>
-   </varlistentry>
-
-   <varlistentry>
-    <term><replaceable class="parameter">blocksize</replaceable></term>
-    <listitem>
-     <para>
-      8192 – 2097152
-      The value must be a multiple of 8192. The default is 32768.
-     </para>
-     <para>
-       For more information on the compression and blocksize parameters, see the
-       "Storage Directives for Column-level Compression" in the Greenplum
-       Database Administrator Guide.
-     </para>
-    </listitem>
-   </varlistentry>
-  
-
-
-
   </variablelist>
  </refsect1>
 
  <refsect1 id="SQL-CREATETYPE-notes">
   <title>Notes</title>
-
-  <para>
-   It is best to avoid using type names that begin with the underscore
-   character (<literal>_</literal>).  <productname>PostgreSQL</productname>
-   forms the name of an array type by prepending one or more underscores
-   to the element type's name, and these names may collide with user-defined
-   type names that begin with underscore.  While the system will modify
-   generated array type names to avoid collisions, this does not help if the
-   conflicting array type already exists when you try to create your type.
-   Also, various old client software may assume that names beginning with
-   underscores always represent arrays.
-  </para>
 
   <para>
    Because there are no restrictions on use of a data type once it's been


### PR DESCRIPTION
It was missing ALTER TYPE RENAME TO, which we got as part of the 8.4 merge
earlier.

In the passing, remove some GPDB-added paragraphs from the SGML docs. The
SGML docs are currently not used for anything else than creating the \h
help text, so the extra explanations there will do nothing but create merge
conflicts.