### PR TITLE
Don't allow TRUNCATE on gp_relation_node.

### DIFF
--- a/src/backend/catalog/aclchk.c
+++ b/src/backend/catalog/aclchk.c
@@ -2370,9 +2370,7 @@ pg_class_aclmask(Oid table_oid, Oid roleid,
 #ifdef ACLDEBUG
 				elog(DEBUG2, "permission denied for persistent system catalog update");
 #endif
-				/* GPDB_84_MERGE_FIXME: wait, was this supposed to include
-				 * ACL_TRUNCATE? */
-				mask &= ~(ACL_INSERT | ACL_UPDATE | ACL_DELETE | ACL_USAGE);
+				mask &= ~(ACL_INSERT | ACL_UPDATE | ACL_DELETE | ACL_TRUNCATE | ACL_USAGE);
 			}
 		}
 
@@ -2390,9 +2388,7 @@ pg_class_aclmask(Oid table_oid, Oid roleid,
 #ifdef ACLDEBUG
 				elog(DEBUG2, "permission denied for gp_relation_node system catalog update");
 #endif
-				/* GPDB_84_MERGE_FIXME: wait, was this supposed to include
-				 * ACL_TRUNCATE? */
-				mask &= ~(ACL_INSERT | ACL_UPDATE | ACL_DELETE | ACL_USAGE);
+				mask &= ~(ACL_INSERT | ACL_UPDATE | ACL_DELETE | ACL_TRUNCATE | ACL_USAGE);
 			}
 		}
 	}


### PR DESCRIPTION
As noted in the FIXME comment, we should also disallow TRUNCATE here. It
doesn't make much sense to forbid DELETE, but allow TRUNCATE.

For persistent tables shared across all databases, this is just pro forma,
as TRUNCATE is not supported for shared tables in the first place. But for
gp_relation_node, the risk is real, although you have to jump through some
hoops: You need to log in in single-user mode, and set
allow_system_table_mods='all'.