### PR TITLE
Merge TIDBitmap API changes from upstream, and refactor

### DIFF
--- a/src/backend/access/bitmap/bitmap.c
+++ b/src/backend/access/bitmap/bitmap.c
@@ -37,9 +37,8 @@ static bool words_get_match(BMBatchWords *words, BMIterateResult *result,
                             BlockNumber blockno, PagetableEntry *entry,
 							bool newentry);
 static IndexScanDesc copy_scan_desc(IndexScanDesc scan);
-static void stream_free(StreamNode *self);
 static void indexstream_free(StreamNode *self);
-static bool pull_stream(StreamNode *self, PagetableEntry *e);
+static bool pull_stream(StreamBMIterator *iterator, PagetableEntry *e);
 static void cleanup_pos(BMScanPosition pos);
 
 /* type to hide BM specific stream state */
@@ -50,6 +49,8 @@ typedef struct BMStreamOpaque
 	/* Indicate that this stream contains no more bitmap words. */
 	bool is_done;
 } BMStreamOpaque;
+
+static void stream_free(BMStreamOpaque *so);
 
 /*
  * bmbuild() -- Build a new bitmap index.
@@ -163,6 +164,34 @@ bmgettuple(PG_FUNCTION_ARGS)
 	PG_RETURN_BOOL(res);
 }
 
+static void
+stream_end_iterate(StreamBMIterator *self)
+{
+	/* opaque may be NULL */
+	if (self->opaque) {
+		stream_free(self->opaque);
+		self->opaque = NULL;
+	}
+}
+
+static void
+stream_begin_iterate(StreamNode *self, StreamBMIterator *iterator)
+{
+	BMStreamOpaque *so;
+	IndexScanDesc scan = self->opaque;
+
+	iterator->pull = pull_stream;
+	iterator->end_iterate = stream_end_iterate;
+
+	/* create a memory context for the stream */
+	so = palloc(sizeof(BMStreamOpaque));
+	so->scan = copy_scan_desc(scan);
+	so->entry = NULL;
+	so->is_done = false;
+
+	iterator->opaque = so;
+}
+
 /*
  * bmgetbitmap() -- return a stream bitmap.
  */
@@ -187,28 +216,16 @@ bmgetbitmap(PG_FUNCTION_ARGS)
 
 	if (res)
 	{
-		BMScanPosition  sp;
-		IndexScanDesc copy = copy_scan_desc(scan);
-		BMStreamOpaque *so;
 		int vec;
 
 		/* perhaps this should be in a special context? */
 		is = (IndexStream *)palloc0(sizeof(IndexStream));
 		is->type = BMS_INDEX;
-		is->pull = pull_stream;
-		is->nextblock = 0;
+		is->begin_iterate = stream_begin_iterate;
 		is->free = indexstream_free;
 		is->set_instrument = NULL;
 		is->upd_instrument = NULL;
-
-		/* create a memory context for the stream */
-
-		so = palloc(sizeof(BMStreamOpaque));
-		sp = ((BMScanOpaque)copy->opaque)->bm_currPos;
-		so->scan = copy;
-		so->entry = NULL;
-		so->is_done = false;
-		is->opaque = (void *)so;
+		is->opaque = copy_scan_desc(scan);
 
 		if(!bm)
 		{
@@ -597,40 +614,67 @@ bmbuildCallback(Relation index, ItemPointer tupleId, Datum *attdata,
 }
 
 /*
+ * Free an IndexScanDesc created by copy_scan_desc(). If releaseBuffers is true,
+ * any Buffers pointed to by the BMScanPositions will be released as well.
+ */
+static void
+free_scan_desc(IndexScanDesc scan, bool releaseBuffers)
+{
+	BMScanOpaque s = scan->opaque;
+	int vec;
+
+	if (s->bm_currPos)
+	{
+		if (!releaseBuffers)
+		{
+			for (vec = 0; vec < s->bm_currPos->nvec; vec++)
+			{
+				BMVector bmvec = &(s->bm_currPos->posvecs[vec]);
+				bmvec->bm_lovBuffer = InvalidBuffer;
+			}
+		}
+
+		cleanup_pos(s->bm_currPos);
+		pfree(s->bm_currPos);
+		s->bm_currPos = NULL;
+	}
+	if (s->bm_markPos)
+	{
+		if (!releaseBuffers)
+		{
+			for (vec = 0; vec < s->bm_markPos->nvec; vec++)
+			{
+				BMVector bmvec = &(s->bm_markPos->posvecs[vec]);
+				bmvec->bm_lovBuffer = InvalidBuffer;
+			}
+		}
+
+		cleanup_pos(s->bm_markPos);
+		pfree(s->bm_markPos);
+		s->bm_markPos = NULL;
+	}
+
+	pfree(s);
+	pfree(scan);
+}
+
+/*
  * free the memory associated with the stream
  */
 
 static void
-stream_free(StreamNode *self)
+stream_free(BMStreamOpaque *so)
 {
-	IndexStream *is = self;
-	BMStreamOpaque *so = (BMStreamOpaque *)is->opaque;
-
 	/* opaque may be NULL */
 	if (so)
 	{
-		IndexScanDesc scan = so->scan;
-		BMScanOpaque s = (BMScanOpaque)scan->opaque;
-
-		is->opaque = NULL;
-		if(s->bm_currPos)
-		{
-			cleanup_pos(s->bm_currPos);
-			pfree(s->bm_currPos);
-			s->bm_currPos = NULL;
-		}
-		if(s->bm_markPos)
-		{
-			cleanup_pos(s->bm_markPos);
-			pfree(s->bm_markPos);
-			s->bm_markPos = NULL;
-		}
+		free_scan_desc(so->scan, false /* we can't release the underlying
+										  Buffers yet as there may be other
+										  iterators in operation */);
 
 		if (so->entry != NULL)
 			pfree(so->entry);
 
-		pfree(s);
-		pfree(scan);
 		pfree(so);
 	}
 }
@@ -640,8 +684,8 @@ stream_free(StreamNode *self)
  */
 static void
 indexstream_free(StreamNode *self) {
-	stream_free(self);
-
+	IndexScanDesc scan = self->opaque;
+	free_scan_desc(scan, true /* we can release the scanned Buffers now */);
 	pfree(self);
 }
 
@@ -667,41 +711,40 @@ cleanup_pos(BMScanPosition pos)
  */
 
 static bool 
-pull_stream(StreamNode *self, PagetableEntry *e)
+pull_stream(StreamBMIterator *iterator, PagetableEntry *e)
 {
-	StreamNode 	   *n = self;
 	bool			res = false;
 	bool 			newentry = true;
-	IndexStream    *is = (IndexStream *)n;
 	PagetableEntry *next;
 	BMScanPosition	scanPos;
 	IndexScanDesc	scan;
-	BMStreamOpaque *so;
+	BMStreamOpaque *so = iterator->opaque;
 
-	so = (BMStreamOpaque *)is->opaque;
 	/* empty bitmap vector */
 	if(so == NULL)
 		return false;
 	next = so->entry;
 
 	/* have we already got an entry? */
-	if(next && is->nextblock <= next->blockno)
+	if(next && iterator->nextblock <= next->blockno)
 	{
 		memcpy(e, next, sizeof(PagetableEntry));
 		return true;
 	}
 	else if (so->is_done)
 	{
-		stream_free(n);
-		is->opaque = NULL;
+		/* GPDB_84_MERGE_FIXME: this doesn't seem right; shouldn't we free at
+		 * end_iterate()? */
+		if (iterator->opaque) {
+			stream_free(iterator->opaque);
+			iterator->opaque = NULL;
+		}
 		return false;
 	}
-	
-	MemSet(e, 0, sizeof(PagetableEntry));
 
 	scan = so->scan;
 	scanPos = ((BMScanOpaque)scan->opaque)->bm_currPos;
-	e->blockno = is->nextblock;
+	e->blockno = iterator->nextblock;
 
 	so->is_done = false;
 
@@ -718,7 +761,7 @@ pull_stream(StreamNode *self, PagetableEntry *e)
 			elog(ERROR, "scan position uninitialized");
 
 		found = words_get_match(scanPos->bm_batchWords, &(scanPos->bm_result),
-							   is->nextblock, e, newentry);
+							   iterator->nextblock, e, newentry);
 
 		if(found)
 		{
@@ -741,7 +784,7 @@ pull_stream(StreamNode *self, PagetableEntry *e)
 				 * tell words_get_match() to continue looking at the page
 				 * it finished at
 				 */
-				is->nextblock = e->blockno;
+				iterator->nextblock = e->blockno;
 				newentry = false;
 			}
 		}
@@ -752,9 +795,9 @@ pull_stream(StreamNode *self, PagetableEntry *e)
 	 * contain possible query results, since in AO index cases, this range
 	 * can be very large.
 	 */
-	is->nextblock = e->blockno + 1;
+	iterator->nextblock = e->blockno + 1;
 	if (scanPos->bm_result.nextTid / BM_MAX_TUPLES_PER_PAGE > e->blockno + 1)
-		is->nextblock = scanPos->bm_result.nextTid / BM_MAX_TUPLES_PER_PAGE;
+		iterator->nextblock = scanPos->bm_result.nextTid / BM_MAX_TUPLES_PER_PAGE;
 	if (so->entry == NULL)
 		so->entry = (PagetableEntry *) palloc(sizeof(PagetableEntry));
 	memcpy(so->entry, e, sizeof(PagetableEntry));

--- a/src/backend/access/gin/ginget.c
+++ b/src/backend/access/gin/ginget.c
@@ -572,7 +572,7 @@ entryGetItem(Relation index, GinScanEntry entry)
 			if ( entry->partialMatchResult == NULL || entry->offset >= entry->partialMatchResult->ntuples )
 			{
 <<<<<<< HEAD
-				tbm_iterate( (Node *) entry->partialMatch, entry->partialMatchResult );
+				tbm_generic_iterate( entry->partialMatch, entry->partialMatchResult );
 =======
 				entry->partialMatchResult = tbm_iterate( entry->partialMatchIterator );
 >>>>>>> 43a57cf3657... Revise the TIDBitmap API to support multiple concurrent iterations over a

--- a/src/backend/access/gin/ginget.c
+++ b/src/backend/access/gin/ginget.c
@@ -107,7 +107,7 @@ scanForItems( Relation index, GinScanEntry scanEntry, BlockNumber rootPostingTre
 
 		if ((GinPageGetOpaque(page)->flags & GIN_DELETED) == 0 && GinPageGetOpaque(page)->maxoff >= FirstOffsetNumber )
 		{
-			tbm_add_tuples( (HashBitmap *) scanEntry->partialMatch,
+			tbm_add_tuples( (TIDBitmap *) scanEntry->partialMatch,
 							(ItemPointer)GinDataPageGetItem(page, FirstOffsetNumber),
 						 	GinPageGetOpaque(page)->maxoff, false);
 			scanEntry->predictNumberResult += GinPageGetOpaque(page)->maxoff;
@@ -244,7 +244,7 @@ computePartialMatchList( GinBtreeData *btree, GinBtreeStack *stack, GinScanEntry
 		}
 		else
 		{
-			tbm_add_tuples( (HashBitmap *) scanEntry->partialMatch, GinGetPosting(itup),  GinGetNPosting(itup), false);
+			tbm_add_tuples( (TIDBitmap *) scanEntry->partialMatch, GinGetPosting(itup),  GinGetNPosting(itup), false);
 			scanEntry->predictNumberResult +=  GinGetNPosting(itup);
 		}
 
@@ -319,7 +319,7 @@ startScanEntry(Relation index, GinState *ginstate, GinScanEntry entry)
 			if ( entry->partialMatch )
 			{
 <<<<<<< HEAD
-				tbm_free( (HashBitmap *) entry->partialMatch );
+				tbm_free( (TIDBitmap *) entry->partialMatch );
 =======
 				if (entry->partialMatchIterator)
 					tbm_end_iterate(entry->partialMatchIterator);
@@ -335,10 +335,10 @@ startScanEntry(Relation index, GinState *ginstate, GinScanEntry entry)
 			return;
 		}
 
-		if ( (HashBitmap *) entry->partialMatch && !tbm_is_empty((HashBitmap *) entry->partialMatch) )
+		if ( (TIDBitmap *) entry->partialMatch && !tbm_is_empty((TIDBitmap *) entry->partialMatch) )
 		{
 <<<<<<< HEAD
-			tbm_begin_iterate((HashBitmap *) entry->partialMatch);
+			tbm_begin_iterate((TIDBitmap *) entry->partialMatch);
 =======
 			entry->partialMatchIterator = tbm_begin_iterate(entry->partialMatch);
 >>>>>>> 43a57cf3657... Revise the TIDBitmap API to support multiple concurrent iterations over a
@@ -786,16 +786,16 @@ gingetbitmap(PG_FUNCTION_ARGS)
 {
 	IndexScanDesc scan = (IndexScanDesc) PG_GETARG_POINTER(0);
 	Node 		   *n = (Node *) PG_GETARG_POINTER(1);
-	HashBitmap	   *tbm;
+	TIDBitmap	   *tbm;
 	int64			ntids;
 
 	if (n == NULL)
 		/* XXX should we use less than work_mem for this? */
 		tbm = tbm_create(work_mem * 1024L);
-	else if (!IsA(n, HashBitmap))
+	else if (!IsA(n, TIDBitmap))
 		elog(ERROR, "non hash bitmap");
 	else
-		tbm = (HashBitmap *)n;
+		tbm = (TIDBitmap *)n;
  
 	if (GinIsNewKey(scan))
 		newScanKey(scan);

--- a/src/backend/access/gin/ginget.c
+++ b/src/backend/access/gin/ginget.c
@@ -8,7 +8,7 @@
  * Portions Copyright (c) 1994, Regents of the University of California
  *
  * IDENTIFICATION
- *			$PostgreSQL: pgsql/src/backend/access/gin/ginget.c,v 1.21 2009/01/01 17:23:34 momjian Exp $
+ *			$PostgreSQL: pgsql/src/backend/access/gin/ginget.c,v 1.22 2009/01/10 21:08:36 tgl Exp $
  *-------------------------------------------------------------------------
  */
 
@@ -296,6 +296,7 @@ startScanEntry(Relation index, GinState *ginstate, GinScanEntry entry)
 	entry->list = NULL;
 	entry->nlist = 0;
 	entry->partialMatch = NULL;
+	entry->partialMatchIterator = NULL;
 	entry->partialMatchResult = NULL;
 	entry->reduceResult = FALSE;
 	entry->predictNumberResult = 0;
@@ -317,7 +318,14 @@ startScanEntry(Relation index, GinState *ginstate, GinScanEntry entry)
 			 */
 			if ( entry->partialMatch )
 			{
+<<<<<<< HEAD
 				tbm_free( (HashBitmap *) entry->partialMatch );
+=======
+				if (entry->partialMatchIterator)
+					tbm_end_iterate(entry->partialMatchIterator);
+				entry->partialMatchIterator = NULL;
+				tbm_free( entry->partialMatch );
+>>>>>>> 43a57cf3657... Revise the TIDBitmap API to support multiple concurrent iterations over a
 				entry->partialMatch = NULL;
 			}
 			LockBuffer(stackEntry->buffer, GIN_UNLOCK);
@@ -329,7 +337,11 @@ startScanEntry(Relation index, GinState *ginstate, GinScanEntry entry)
 
 		if ( (HashBitmap *) entry->partialMatch && !tbm_is_empty((HashBitmap *) entry->partialMatch) )
 		{
+<<<<<<< HEAD
 			tbm_begin_iterate((HashBitmap *) entry->partialMatch);
+=======
+			entry->partialMatchIterator = tbm_begin_iterate(entry->partialMatch);
+>>>>>>> 43a57cf3657... Revise the TIDBitmap API to support multiple concurrent iterations over a
 			entry->isFinished = FALSE;
 		}
 	}
@@ -559,11 +571,17 @@ entryGetItem(Relation index, GinScanEntry entry)
 		{
 			if ( entry->partialMatchResult == NULL || entry->offset >= entry->partialMatchResult->ntuples )
 			{
+<<<<<<< HEAD
 				tbm_iterate( (Node *) entry->partialMatch, entry->partialMatchResult );
+=======
+				entry->partialMatchResult = tbm_iterate( entry->partialMatchIterator );
+>>>>>>> 43a57cf3657... Revise the TIDBitmap API to support multiple concurrent iterations over a
 
 				if ( entry->partialMatchResult == NULL )
 				{
 					ItemPointerSet(&entry->curItem, InvalidBlockNumber, InvalidOffsetNumber);
+					tbm_end_iterate(entry->partialMatchIterator);
+					entry->partialMatchIterator = NULL;
 					entry->isFinished = TRUE;
 					break;
 				}

--- a/src/backend/access/gin/ginget.c
+++ b/src/backend/access/gin/ginget.c
@@ -107,7 +107,7 @@ scanForItems( Relation index, GinScanEntry scanEntry, BlockNumber rootPostingTre
 
 		if ((GinPageGetOpaque(page)->flags & GIN_DELETED) == 0 && GinPageGetOpaque(page)->maxoff >= FirstOffsetNumber )
 		{
-			tbm_add_tuples( (TIDBitmap *) scanEntry->partialMatch,
+			tbm_add_tuples(scanEntry->partialMatch,
 							(ItemPointer)GinDataPageGetItem(page, FirstOffsetNumber),
 						 	GinPageGetOpaque(page)->maxoff, false);
 			scanEntry->predictNumberResult += GinPageGetOpaque(page)->maxoff;
@@ -140,7 +140,7 @@ computePartialMatchList( GinBtreeData *btree, GinBtreeStack *stack, GinScanEntry
 	Datum		idatum;
 	int32		cmp;
 
-	scanEntry->partialMatch = (Node *) tbm_create( work_mem * 1024L );
+	scanEntry->partialMatch = tbm_create(work_mem * 1024L);
 
 	for(;;)
 	{
@@ -244,7 +244,7 @@ computePartialMatchList( GinBtreeData *btree, GinBtreeStack *stack, GinScanEntry
 		}
 		else
 		{
-			tbm_add_tuples( (TIDBitmap *) scanEntry->partialMatch, GinGetPosting(itup),  GinGetNPosting(itup), false);
+			tbm_add_tuples(scanEntry->partialMatch, GinGetPosting(itup), GinGetNPosting(itup), false);
 			scanEntry->predictNumberResult +=  GinGetNPosting(itup);
 		}
 
@@ -318,14 +318,10 @@ startScanEntry(Relation index, GinState *ginstate, GinScanEntry entry)
 			 */
 			if ( entry->partialMatch )
 			{
-<<<<<<< HEAD
-				tbm_free( (TIDBitmap *) entry->partialMatch );
-=======
 				if (entry->partialMatchIterator)
 					tbm_end_iterate(entry->partialMatchIterator);
 				entry->partialMatchIterator = NULL;
 				tbm_free( entry->partialMatch );
->>>>>>> 43a57cf3657... Revise the TIDBitmap API to support multiple concurrent iterations over a
 				entry->partialMatch = NULL;
 			}
 			LockBuffer(stackEntry->buffer, GIN_UNLOCK);
@@ -335,13 +331,9 @@ startScanEntry(Relation index, GinState *ginstate, GinScanEntry entry)
 			return;
 		}
 
-		if ( (TIDBitmap *) entry->partialMatch && !tbm_is_empty((TIDBitmap *) entry->partialMatch) )
+		if ( entry->partialMatch && !tbm_is_empty(entry->partialMatch) )
 		{
-<<<<<<< HEAD
-			tbm_begin_iterate((TIDBitmap *) entry->partialMatch);
-=======
 			entry->partialMatchIterator = tbm_begin_iterate(entry->partialMatch);
->>>>>>> 43a57cf3657... Revise the TIDBitmap API to support multiple concurrent iterations over a
 			entry->isFinished = FALSE;
 		}
 	}
@@ -571,11 +563,7 @@ entryGetItem(Relation index, GinScanEntry entry)
 		{
 			if ( entry->partialMatchResult == NULL || entry->offset >= entry->partialMatchResult->ntuples )
 			{
-<<<<<<< HEAD
-				tbm_generic_iterate( entry->partialMatch, entry->partialMatchResult );
-=======
 				entry->partialMatchResult = tbm_iterate( entry->partialMatchIterator );
->>>>>>> 43a57cf3657... Revise the TIDBitmap API to support multiple concurrent iterations over a
 
 				if ( entry->partialMatchResult == NULL )
 				{

--- a/src/backend/access/gin/ginscan.c
+++ b/src/backend/access/gin/ginscan.c
@@ -8,7 +8,7 @@
  * Portions Copyright (c) 1994, Regents of the University of California
  *
  * IDENTIFICATION
- *			$PostgreSQL: pgsql/src/backend/access/gin/ginscan.c,v 1.20 2009/01/01 17:23:34 momjian Exp $
+ *			$PostgreSQL: pgsql/src/backend/access/gin/ginscan.c,v 1.21 2009/01/10 21:08:36 tgl Exp $
  *-------------------------------------------------------------------------
  */
 
@@ -61,6 +61,8 @@ fillScanKey(GinState *ginstate, GinScanKey key, OffsetNumber attnum, Datum query
 		key->scanEntry[i].offset = InvalidOffsetNumber;
 		key->scanEntry[i].buffer = InvalidBuffer;
 		key->scanEntry[i].partialMatch = NULL;
+		key->scanEntry[i].partialMatchIterator = NULL;
+		key->scanEntry[i].partialMatchResult = NULL;
 		key->scanEntry[i].strategy = strategy;
 		key->scanEntry[i].list = NULL;
 		key->scanEntry[i].nlist = 0;
@@ -107,6 +109,7 @@ resetScanKeys(GinScanKey keys, uint32 nkeys)
 			key->scanEntry[j].list = NULL;
 			key->scanEntry[j].nlist = 0;
 			key->scanEntry[j].partialMatch = NULL;
+			key->scanEntry[j].partialMatchIterator = NULL;
 			key->scanEntry[j].partialMatchResult = NULL;
 		}
 	}
@@ -132,6 +135,8 @@ freeScanKeys(GinScanKey keys, uint32 nkeys)
 				ReleaseBuffer(key->scanEntry[j].buffer);
 			if (key->scanEntry[j].list)
 				pfree(key->scanEntry[j].list);
+			if (key->scanEntry[j].partialMatchIterator)
+				tbm_end_iterate(key->scanEntry[j].partialMatchIterator);
 			if (key->scanEntry[j].partialMatch)
 				tbm_free((HashBitmap *) key->scanEntry[j].partialMatch);
 		}

--- a/src/backend/access/gin/ginscan.c
+++ b/src/backend/access/gin/ginscan.c
@@ -138,7 +138,7 @@ freeScanKeys(GinScanKey keys, uint32 nkeys)
 			if (key->scanEntry[j].partialMatchIterator)
 				tbm_end_iterate(key->scanEntry[j].partialMatchIterator);
 			if (key->scanEntry[j].partialMatch)
-				tbm_free((HashBitmap *) key->scanEntry[j].partialMatch);
+				tbm_free((TIDBitmap *) key->scanEntry[j].partialMatch);
 		}
 
 		pfree(key->entryRes);

--- a/src/backend/access/gin/ginscan.c
+++ b/src/backend/access/gin/ginscan.c
@@ -138,7 +138,7 @@ freeScanKeys(GinScanKey keys, uint32 nkeys)
 			if (key->scanEntry[j].partialMatchIterator)
 				tbm_end_iterate(key->scanEntry[j].partialMatchIterator);
 			if (key->scanEntry[j].partialMatch)
-				tbm_free((TIDBitmap *) key->scanEntry[j].partialMatch);
+				tbm_free(key->scanEntry[j].partialMatch);
 		}
 
 		pfree(key->entryRes);

--- a/src/backend/access/gist/gistget.c
+++ b/src/backend/access/gist/gistget.c
@@ -25,7 +25,7 @@
 
 
 static OffsetNumber gistfindnext(IndexScanDesc scan, OffsetNumber n);
-static int64 gistnext(IndexScanDesc scan, HashBitmap *tbm);
+static int64 gistnext(IndexScanDesc scan, TIDBitmap *tbm);
 static bool gistindex_keytest(IndexTuple tuple, IndexScanDesc scan,
 				  OffsetNumber offset);
 
@@ -112,15 +112,15 @@ gistgetbitmap(PG_FUNCTION_ARGS)
 {
 	IndexScanDesc scan = (IndexScanDesc) PG_GETARG_POINTER(0);
 	Node		   *n = (Node *) PG_GETARG_POINTER(1);
-	HashBitmap	   *tbm;
+	TIDBitmap	   *tbm;
 	int64			ntids;
 
 	if (n == NULL)
 		tbm = tbm_create(work_mem * 1024L);
-	else if (!IsA(n, HashBitmap))
+	else if (!IsA(n, TIDBitmap))
 		elog(ERROR, "non hash bitmap");
 	else
-		tbm = (HashBitmap *) n;
+		tbm = (TIDBitmap *) n;
 
 	ntids = gistnext(scan, tbm);
 
@@ -142,7 +142,7 @@ gistgetbitmap(PG_FUNCTION_ARGS)
  * non-killed tuple that matches the search key.
  */
 static int64
-gistnext(IndexScanDesc scan, HashBitmap *tbm)
+gistnext(IndexScanDesc scan, TIDBitmap *tbm)
 {
 	MIRROREDLOCK_BUFMGR_DECLARE;
 

--- a/src/backend/access/hash/hash.c
+++ b/src/backend/access/hash/hash.c
@@ -294,17 +294,17 @@ hashgetbitmap(PG_FUNCTION_ARGS)
 
 	IndexScanDesc 	scan = (IndexScanDesc) PG_GETARG_POINTER(0);
 	Node		   *n = (Node *) PG_GETARG_POINTER(1);
-	HashBitmap	   *tbm;
+	TIDBitmap	   *tbm;
 	HashScanOpaque	so = (HashScanOpaque) scan->opaque;
 	bool			res;
 	int64			ntids = 0;
 
 	if (n == NULL)
 		tbm = tbm_create(work_mem * 1024L);
-	else if (!IsA(n, HashBitmap))
+	else if (!IsA(n, TIDBitmap))
 		elog(ERROR, "non hash bitmap");
 	else
-		tbm = (HashBitmap *) n;
+		tbm = (TIDBitmap *) n;
 
 	// -------- MirroredLock ----------
 	MIRROREDLOCK_BUFMGR_LOCK;

--- a/src/backend/access/index/indexam.c
+++ b/src/backend/access/index/indexam.c
@@ -678,7 +678,7 @@ index_getnext(IndexScanDesc scan, ScanDirection direction)
  *
  *		it invokes am's getmulti function to get a bitmap. If am is an on-disk
  *		bitmap index access method (see bitmap.h), then a StreamBitmap is
- *		returned; a HashBitmap otherwise. Note that an index am's getmulti
+ *		returned; a TIDBitmap otherwise. Note that an index am's getmulti
  *		function can assume that the bitmap that it's given as argument is of
  *		the same type as what the function constructs itself.
  * ----------------

--- a/src/backend/access/nbtree/nbtree.c
+++ b/src/backend/access/nbtree/nbtree.c
@@ -567,7 +567,7 @@ btgettuple(PG_FUNCTION_ARGS)
 }
 
 /*
- * btgetbitmap() -- construct a HashBitmap.
+ * btgetbitmap() -- construct a TIDBitmap.
  */
 Datum
 btgetbitmap(PG_FUNCTION_ARGS)
@@ -576,7 +576,7 @@ btgetbitmap(PG_FUNCTION_ARGS)
 
 	IndexScanDesc scan = (IndexScanDesc) PG_GETARG_POINTER(0);
 	Node *n = (Node *)PG_GETARG_POINTER(1);
-	HashBitmap	*tbm;
+	TIDBitmap	*tbm;
 	BTScanOpaque so = (BTScanOpaque) scan->opaque;
 	int64		ntids = 0;
 	ItemPointer heapTid;
@@ -588,13 +588,13 @@ btgetbitmap(PG_FUNCTION_ARGS)
 		/* XXX should we use less than work_mem for this? */
 		tbm = tbm_create(work_mem * 1024L);
 	}
-	else if (!IsA(n, HashBitmap))
+	else if (!IsA(n, TIDBitmap))
 	{
 		elog(ERROR, "non hash bitmap");
 	}
 	else
 	{
-		tbm = (HashBitmap *)n;
+		tbm = (TIDBitmap *)n;
 	}
 
 	/* If we haven't started the scan yet, fetch the first page & tuple. */

--- a/src/backend/executor/execBitmapTableScan.c
+++ b/src/backend/executor/execBitmapTableScan.c
@@ -182,7 +182,7 @@ fetchNextBitmapPage(BitmapTableScanState *scanState)
 
 	while (gotBitmapPage && tbmres->ntuples == 0)
 	{
-		gotBitmapPage = tbm_iterate(scanState->tbm, (TBMIterateResult *)scanState->tbmres);
+		gotBitmapPage = tbm_generic_iterate(scanState->tbm, (TBMIterateResult *)scanState->tbmres);
 	}
 
 	if (gotBitmapPage)

--- a/src/backend/executor/execBitmapTableScan.c
+++ b/src/backend/executor/execBitmapTableScan.c
@@ -72,12 +72,7 @@ getBitmapTableScanMethod(TableType tableType)
 static inline void
 initBitmapState(BitmapTableScanState *scanstate)
 {
-	if (scanstate->tbmres == NULL)
-	{
-		scanstate->tbmres =
-			palloc0(sizeof(TBMIterateResult) +
-					MAX_TUPLES_PER_PAGE * sizeof(OffsetNumber));
-	}
+	/* GPDB_84_MERGE_FIXME: nothing to do? */
 }
 
 /*
@@ -89,10 +84,13 @@ freeBitmapState(BitmapTableScanState *scanstate)
 	/* BitmapIndexScan is the owner of the bitmap memory. Don't free it here */
 	scanstate->tbm = NULL;
 
-	/* BitmapTableScan created the iterator, so it is responsible to free its iterator */
-	if (scanstate->tbmres != NULL)
+	/* BitmapTableScan created the iterator, so it is responsible to free its
+	 * iterator. We free our GenericBMIterator here, though. It owns the tbmres
+	 * memory. */
+	if (scanstate->tbmiterator != NULL)
 	{
-		pfree(scanstate->tbmres);
+		tbm_generic_end_iterate(scanstate->tbmiterator);
+		scanstate->tbmiterator = NULL;
 		scanstate->tbmres = NULL;
 	}
 }
@@ -166,27 +164,28 @@ readBitmap(BitmapTableScanState *scanState)
 static bool
 fetchNextBitmapPage(BitmapTableScanState *scanState)
 {
+	TBMIterateResult *tbmres;
+
 	if (scanState->tbm == NULL)
 	{
 		return false;
 	}
 
-	TBMIterateResult *tbmres = (TBMIterateResult *)scanState->tbmres;
-
 	Assert(scanState->needNewBitmapPage);
 
-	bool gotBitmapPage = true;
-
-	/* Set to 0 so that we can enter the while loop */
-	tbmres->ntuples = 0;
-
-	while (gotBitmapPage && tbmres->ntuples == 0)
+	if (scanState->tbmiterator == NULL)
 	{
-		gotBitmapPage = tbm_generic_iterate(scanState->tbm, (TBMIterateResult *)scanState->tbmres);
+		scanState->tbmiterator = tbm_generic_begin_iterate(scanState->tbm);
 	}
 
-	if (gotBitmapPage)
+	do
 	{
+		tbmres = tbm_generic_iterate(scanState->tbmiterator);
+	} while (tbmres && (tbmres->ntuples == 0));
+
+	if (tbmres)
+	{
+		scanState->tbmres = tbmres;
 		scanState->iterator = NULL;
 		scanState->needNewBitmapPage = false;
 
@@ -200,7 +199,7 @@ fetchNextBitmapPage(BitmapTableScanState *scanState)
 		}
 	}
 
-	return gotBitmapPage;
+	return (tbmres != NULL);
 }
 
 /*
@@ -383,5 +382,8 @@ BitmapTableScanReScan(BitmapTableScanState *node, ExprContext *exprCtxt)
 {
 	ScanState *scanState = &node->ss;
 	DynamicScan_ReScan(scanState, exprCtxt);
+
+	freeBitmapState(node);
+
 	ExecReScan(outerPlanState(node), exprCtxt);
 }

--- a/src/backend/executor/execBitmapTableScan.c
+++ b/src/backend/executor/execBitmapTableScan.c
@@ -153,7 +153,7 @@ readBitmap(BitmapTableScanState *scanState)
 
 	Node *tbm = (Node *) MultiExecProcNode(outerPlanState(scanState));
 
-	if (!tbm || !(IsA(tbm, HashBitmap) || IsA(tbm, StreamBitmap)))
+	if (!tbm || !(IsA(tbm, TIDBitmap) || IsA(tbm, StreamBitmap)))
 		elog(ERROR, "unrecognized result from subplan");
 
 	scanState->tbm = tbm;

--- a/src/backend/executor/nodeBitmapAnd.c
+++ b/src/backend/executor/nodeBitmapAnd.c
@@ -124,7 +124,7 @@ MultiExecBitmapAnd(BitmapAndState *node)
 	int			nplans;
 	int			i;
 	bool		empty = false;
-	HashBitmap *hbm = NULL;
+	TIDBitmap  *hbm = NULL;
 
 	/* must provide our own instrumentation support */
 	if (node->ps.instrument)
@@ -146,7 +146,7 @@ MultiExecBitmapAnd(BitmapAndState *node)
 
 		subresult = MultiExecProcNode(subnode);
 
-		if (!subresult || !(IsA(subresult, HashBitmap) || IsA(subresult, StreamBitmap)))
+		if (!subresult || !(IsA(subresult, TIDBitmap) || IsA(subresult, StreamBitmap)))
 			elog(ERROR, "unrecognized result from subplan");
 
 		/*
@@ -154,14 +154,14 @@ MultiExecBitmapAnd(BitmapAndState *node)
 		 * If we encounter some streamed bitmaps we'll add this hash bitmap
 		 * as a stream to it.
 		 */
-		if (IsA(subresult, HashBitmap))
+		if (IsA(subresult, TIDBitmap))
 		{
 			/* first subplan that generates a hash bitmap */
 			if (hbm == NULL)
-				hbm = (HashBitmap *) subresult;
+				hbm = (TIDBitmap *) subresult;
 			else
 			{
-				tbm_intersect(hbm, (HashBitmap *)subresult);
+				tbm_intersect(hbm, (TIDBitmap *)subresult);
 			}
 
 			/*

--- a/src/backend/executor/nodeBitmapAppendOnlyscan.c
+++ b/src/backend/executor/nodeBitmapAppendOnlyscan.c
@@ -327,7 +327,7 @@ BitmapAppendOnlyScanNext(BitmapAppendOnlyScanState *node)
 			 * convert the (psuedo) heap block number and item number to an
 			 * Append-Only TID.
 			 */
-			if (!tbm_iterate(tbm, tbmres))
+			if (!tbm_generic_iterate(tbm, tbmres))
 			{
 				/* no more entries in the bitmap */
 				break;

--- a/src/backend/executor/nodeBitmapAppendOnlyscan.c
+++ b/src/backend/executor/nodeBitmapAppendOnlyscan.c
@@ -184,15 +184,7 @@ freeFetchDesc(BitmapAppendOnlyScanState *scanstate)
 static inline void
 initBitmapState(BitmapAppendOnlyScanState *scanstate)
 {
-	if (scanstate->baos_tbmres == NULL)
-	{
-		scanstate->baos_tbmres =
-			palloc(sizeof(TBMIterateResult) +
-					MAX_TUPLES_PER_PAGE * sizeof(OffsetNumber));
-
-		/* initialize result header */
-		MemSetAligned(scanstate->baos_tbmres, 0, sizeof(TBMIterateResult));
-	}
+	/* GPDB_84_MERGE_FIXME: nothing to do? */
 }
 
 /*
@@ -201,11 +193,11 @@ initBitmapState(BitmapAppendOnlyScanState *scanstate)
 static inline void
 freeBitmapState(BitmapAppendOnlyScanState *scanstate)
 {
-	/* BitmapIndexScan is the owner of the bitmap memory. Don't free it here */
-	scanstate->baos_tbm = NULL;
-	if (scanstate->baos_tbmres != NULL)
+	if (scanstate->baos_iterator)
 	{
-		pfree(scanstate->baos_tbmres);
+		tbm_generic_end_iterate(scanstate->baos_iterator);
+		scanstate->baos_iterator = NULL;
+		/* baos_tbmres is owned by the iterator and freed during end_iterate. */
 		scanstate->baos_tbmres = NULL;
 	}
 }
@@ -225,8 +217,7 @@ BitmapAppendOnlyScanNext(BitmapAppendOnlyScanState *node)
 	AOCSFetchDesc aocsFetchDesc;
 	AOCSFetchDesc aocsLossyFetchDesc;
 	Index		scanrelid;
-	Node  		*tbm;
-	TBMIterateResult *tbmres;
+	GenericBMIterator *iterator;
 	OffsetNumber psuedoHeapOffset;
 	ItemPointerData psudeoHeapTid;
 	AOTupleId aoTid;
@@ -246,9 +237,7 @@ BitmapAppendOnlyScanNext(BitmapAppendOnlyScanState *node)
 	aocsFetchDesc = node->baos_currentAOCSFetchDesc;
 	aocsLossyFetchDesc = node->baos_currentAOCSLossyFetchDesc;
 	scanrelid = ((BitmapAppendOnlyScan *) node->ss.ps.plan)->scan.scanrelid;
-	tbm = node->baos_tbm;
-	tbmres = (TBMIterateResult *) node->baos_tbmres;
-	Assert(tbmres != NULL);
+	iterator = node->baos_iterator;
 
 	/*
 	 * Check if we are evaluating PlanQual for tuple of this relation.
@@ -293,28 +282,36 @@ BitmapAppendOnlyScanNext(BitmapAppendOnlyScanState *node)
 	 * we have used up the bitmaps from the previous scan, do the next scan,
 	 * and prepare the bitmap to be iterated over.
  	 */
-	if (tbm == NULL)
+	if (iterator == NULL)
 	{
-		tbm = (Node *) MultiExecProcNode(outerPlanState(node));
+		Node *tbm = (Node *) MultiExecProcNode(outerPlanState(node));
 
 		if (!tbm || !(IsA(tbm, TIDBitmap) || IsA(tbm, StreamBitmap)))
 			elog(ERROR, "unrecognized result from subplan");
 
-		node->baos_tbm = tbm;
+		if (tbm == NULL)
+		{
+			ExecEagerFreeBitmapAppendOnlyScan(node);
+
+			return ExecClearTuple(slot);
+		}
+
+		/*
+		 * BitmapIndexScan is the owner of the bitmap memory. We don't take
+		 * ownership here; just begin iteration.
+		 */
+		node->baos_iterator = iterator = tbm_generic_begin_iterate(tbm);
 	}
 
-	if (tbm == NULL)
-	{
-		ExecEagerFreeBitmapAppendOnlyScan(node);
-
-		return ExecClearTuple(slot);
-	}
-
-	Assert(tbm != NULL);
-	Assert(tbmres != NULL);
+	Assert(iterator != NULL);
 
 	for (;;)
 	{
+		/* GPDB_84_MERGE_FIXME: can the baos_tbmres state be removed from
+		 * BitmapAppendOnlyScanState, or is it possible for it to be carried
+		 * through multiple calls to BitmapAppendOnlyScanNext()? */
+		TBMIterateResult *tbmres = node->baos_tbmres;
+
 		CHECK_FOR_INTERRUPTS();
 
 		if (QueryFinishPending)
@@ -327,11 +324,14 @@ BitmapAppendOnlyScanNext(BitmapAppendOnlyScanState *node)
 			 * convert the (psuedo) heap block number and item number to an
 			 * Append-Only TID.
 			 */
-			if (!tbm_generic_iterate(tbm, tbmres))
+			tbmres = tbm_generic_iterate(iterator);
+			if (!tbmres)
 			{
 				/* no more entries in the bitmap */
 				break;
 			}
+
+			node->baos_tbmres = tbmres;
 
 			/* If tbmres contains no tuples, continue. */
 			if (tbmres->ntuples == 0)
@@ -364,6 +364,7 @@ BitmapAppendOnlyScanNext(BitmapAppendOnlyScanState *node)
 			/*
 			 * Continuing in previously obtained page; advance cindex
 			 */
+			Assert(tbmres);
 			node->baos_cindex++;
 		}
 
@@ -596,7 +597,7 @@ ExecInitBitmapAppendOnlyScan(BitmapAppendOnlyScan *node, EState *estate, int efl
 	scanstate->ss.ps.plan = (Plan *) node;
 	scanstate->ss.ps.state = estate;
 
-	scanstate->baos_tbm = NULL;
+	scanstate->baos_iterator = NULL;
 	scanstate->baos_tbmres = NULL;
 	scanstate->baos_gotpage = false;
 	scanstate->baos_lossy = false;

--- a/src/backend/executor/nodeBitmapAppendOnlyscan.c
+++ b/src/backend/executor/nodeBitmapAppendOnlyscan.c
@@ -297,7 +297,7 @@ BitmapAppendOnlyScanNext(BitmapAppendOnlyScanState *node)
 	{
 		tbm = (Node *) MultiExecProcNode(outerPlanState(node));
 
-		if (!tbm || !(IsA(tbm, HashBitmap) || IsA(tbm, StreamBitmap)))
+		if (!tbm || !(IsA(tbm, TIDBitmap) || IsA(tbm, StreamBitmap)))
 			elog(ERROR, "unrecognized result from subplan");
 
 		node->baos_tbm = tbm;

--- a/src/backend/executor/nodeBitmapIndexscan.c
+++ b/src/backend/executor/nodeBitmapIndexscan.c
@@ -106,7 +106,7 @@ MultiExecBitmapIndexScan(BitmapIndexScanState *node)
 
 		/* CDB: If EXPLAIN ANALYZE, let bitmap share our Instrumentation. */
 		if (node->ss.ps.instrument)
-			tbm_bitmap_set_instrument(bitmap, node->ss.ps.instrument);
+			tbm_generic_set_instrument(bitmap, node->ss.ps.instrument);
 
 		if (node->biss_result == NULL)
 			node->biss_result = (Node *) bitmap;
@@ -191,7 +191,7 @@ ExecBitmapIndexReScan(BitmapIndexScanState *node, ExprContext *exprCtxt)
 
 	if (NULL != node->biss_result)
 	{
-		tbm_bitmap_free(node->biss_result);
+		tbm_generic_free(node->biss_result);
 		node->biss_result = NULL;
 	}
 }
@@ -228,7 +228,7 @@ ExecEndBitmapIndexScan(BitmapIndexScanState *node)
 	if (indexRelationDesc)
 		index_close(indexRelationDesc, NoLock);
 
-	tbm_bitmap_free(node->biss_result);
+	tbm_generic_free(node->biss_result);
 	node->biss_result = NULL;
 
 	EndPlanStateGpmonPkt(&node->ss.ps);

--- a/src/backend/executor/nodeBitmapIndexscan.c
+++ b/src/backend/executor/nodeBitmapIndexscan.c
@@ -94,7 +94,7 @@ MultiExecBitmapIndexScan(BitmapIndexScanState *node)
 		bitmap = index_getbitmap(scandesc, node->biss_result);
 
 		if ((NULL != bitmap) &&
-			!(IsA(bitmap, HashBitmap) || IsA(bitmap, StreamBitmap)))
+			!(IsA(bitmap, TIDBitmap) || IsA(bitmap, StreamBitmap)))
 		{
 			elog(ERROR, "unrecognized result from bitmap index scan");
 		}
@@ -182,7 +182,7 @@ ExecBitmapIndexReScan(BitmapIndexScanState *node, ExprContext *exprCtxt)
 
 	/* Sanity check */
 	if (node->biss_result &&
-		(!IsA(node->biss_result, HashBitmap) && !IsA(node->biss_result, StreamBitmap)))
+		(!IsA(node->biss_result, TIDBitmap) && !IsA(node->biss_result, StreamBitmap)))
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_GP_INTERNAL_ERROR),

--- a/src/backend/executor/nodeBitmapOr.c
+++ b/src/backend/executor/nodeBitmapOr.c
@@ -123,7 +123,7 @@ MultiExecBitmapOr(BitmapOrState *node)
 	PlanState **bitmapplans;
 	int			nplans;
 	int			i;
-	HashBitmap *hbm = NULL;
+	TIDBitmap  *hbm = NULL;
 
 	/* must provide our own instrumentation support */
 	if (node->ps.instrument)
@@ -148,17 +148,17 @@ MultiExecBitmapOr(BitmapOrState *node)
 		if(subresult == NULL)
 			continue;
 
-		if (!(IsA(subresult, HashBitmap) ||
+		if (!(IsA(subresult, TIDBitmap) ||
 			  IsA(subresult, StreamBitmap)))
 			elog(ERROR, "unrecognized result from subplan");
 
-		if (IsA(subresult, HashBitmap))
+		if (IsA(subresult, TIDBitmap))
 		{
 			if (hbm == NULL)
-				hbm = (HashBitmap *)subresult;
+				hbm = (TIDBitmap *)subresult;
 			else
 			{
-				tbm_union(hbm, (HashBitmap *)subresult);
+				tbm_union(hbm, (TIDBitmap *)subresult);
 			}
 		}
 		else

--- a/src/backend/nodes/tidbitmap.c
+++ b/src/backend/nodes/tidbitmap.c
@@ -23,7 +23,7 @@
  * Copyright (c) 2003-2009, PostgreSQL Global Development Group
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/nodes/tidbitmap.c,v 1.16 2009/01/01 17:23:43 momjian Exp $
+ *	  $PostgreSQL: pgsql/src/backend/nodes/tidbitmap.c,v 1.17 2009/01/10 21:08:36 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -79,10 +79,26 @@ struct HashBitmap
 	int			npages;			/* number of exact entries in pagetable */
 	int			nchunks;		/* number of lossy entries in pagetable */
 	bool		iterating;		/* tbm_begin_iterate called? */
+<<<<<<< HEAD
 	PagetableEntry entry1;		/* used when status == HASHBM_ONE_PAGE */
 	/* the remaining fields are used while producing sorted output: */
+=======
+	PagetableEntry entry1;		/* used when status == TBM_ONE_PAGE */
+	/* these are valid when iterating is true: */
+>>>>>>> 43a57cf3657... Revise the TIDBitmap API to support multiple concurrent iterations over a
 	PagetableEntry **spages;	/* sorted exact-page list, or NULL */
 	PagetableEntry **schunks;	/* sorted lossy-chunk list, or NULL */
+};
+
+/*
+ * When iterating over a bitmap in sorted order, a TBMIterator is used to
+ * track our progress.  There can be several iterators scanning the same
+ * bitmap concurrently.  Note that the bitmap becomes read-only as soon as
+ * any iterator is created.
+ */
+struct TBMIterator
+{
+	TIDBitmap  *tbm;			/* TIDBitmap we're iterating over */
 	int			spageptr;		/* next spages index */
 	int			schunkptr;		/* next schunks index */
 	int			schunkbit;		/* next bit to check in current schunk */
@@ -129,6 +145,7 @@ tbm_create(long maxbytes)
 	HashBitmap *tbm;
 	long		nbuckets;
 
+<<<<<<< HEAD
 	/*
 	 * Ensure that we don't have heap tuple offsets going beyond (INT16_MAX +
 	 * 1) or 32768. The executor iterates only over the first 32K tuples for
@@ -142,6 +159,11 @@ tbm_create(long maxbytes)
 	tbm = (HashBitmap *) palloc0(sizeof(HashBitmap));
 
 	tbm->type = T_HashBitmap;	/* Set NodeTag */
+=======
+	/* Create the TIDBitmap struct and zero all its fields */
+	tbm = makeNode(TIDBitmap);
+
+>>>>>>> 43a57cf3657... Revise the TIDBitmap API to support multiple concurrent iterations over a
 	tbm->mcxt = CurrentMemoryContext;
 	tbm->status = HASHBM_EMPTY;
 	tbm->instrument = NULL;
@@ -541,20 +563,85 @@ tbm_is_empty(const HashBitmap *tbm)
 /*
  * tbm_begin_iterate - prepare to iterate through a HashBitmap
  *
+ * The TBMIterator struct is created in the caller's memory context.
+ * For a clean shutdown of the iteration, call tbm_end_iterate; but it's
+ * okay to just allow the memory context to be released, too.  It is caller's
+ * responsibility not to touch the TBMIterator anymore once the TIDBitmap
+ * is freed.
+ *
  * NB: after this is called, it is no longer allowed to modify the contents
  * of the bitmap.  However, you can call this multiple times to scan the
- * contents repeatedly.
+ * contents repeatedly, including parallel scans.
  */
+<<<<<<< HEAD
 void
 tbm_begin_iterate(HashBitmap *tbm)
+=======
+TBMIterator *
+tbm_begin_iterate(TIDBitmap *tbm)
+>>>>>>> 43a57cf3657... Revise the TIDBitmap API to support multiple concurrent iterations over a
 {
-	HASH_SEQ_STATUS status;
-	PagetableEntry *page;
-	int			npages;
-	int			nchunks;
+	TBMIterator *iterator;
+
+	/*
+	 * Create the TBMIterator struct, with enough trailing space to serve the
+	 * needs of the TBMIterateResult sub-struct.
+	 */
+	iterator = (TBMIterator *) palloc(sizeof(TBMIterator) +
+									  MAX_TUPLES_PER_PAGE * sizeof(OffsetNumber));
+	iterator->tbm = tbm;
+
+	/*
+	 * Initialize iteration pointers.
+	 */
+	iterator->spageptr = 0;
+	iterator->schunkptr = 0;
+	iterator->schunkbit = 0;
+
+	/*
+	 * If we have a hashtable, create and fill the sorted page lists,
+	 * unless we already did that for a previous iterator.  Note that the
+	 * lists are attached to the bitmap not the iterator, so they can be
+	 * used by more than one iterator.
+	 */
+	if (tbm->status == TBM_HASH && !tbm->iterating)
+	{
+		HASH_SEQ_STATUS status;
+		PagetableEntry *page;
+		int			npages;
+		int			nchunks;
+
+		if (!tbm->spages && tbm->npages > 0)
+			tbm->spages = (PagetableEntry **)
+				MemoryContextAlloc(tbm->mcxt,
+								   tbm->npages * sizeof(PagetableEntry *));
+		if (!tbm->schunks && tbm->nchunks > 0)
+			tbm->schunks = (PagetableEntry **)
+				MemoryContextAlloc(tbm->mcxt,
+								   tbm->nchunks * sizeof(PagetableEntry *));
+
+		hash_seq_init(&status, tbm->pagetable);
+		npages = nchunks = 0;
+		while ((page = (PagetableEntry *) hash_seq_search(&status)) != NULL)
+		{
+			if (page->ischunk)
+				tbm->schunks[nchunks++] = page;
+			else
+				tbm->spages[npages++] = page;
+		}
+		Assert(npages == tbm->npages);
+		Assert(nchunks == tbm->nchunks);
+		if (npages > 1)
+			qsort(tbm->spages, npages, sizeof(PagetableEntry *),
+				  tbm_comparator);
+		if (nchunks > 1)
+			qsort(tbm->schunks, nchunks, sizeof(PagetableEntry *),
+				  tbm_comparator);
+	}
 
 	tbm->iterating = true;
 
+<<<<<<< HEAD
 	/*
 	 * Reset iteration pointers.
 	 */
@@ -595,6 +682,9 @@ tbm_begin_iterate(HashBitmap *tbm)
 		qsort(tbm->spages, npages, sizeof(PagetableEntry *), tbm_comparator);
 	if (nchunks > 1)
 		qsort(tbm->schunks, nchunks, sizeof(PagetableEntry *), tbm_comparator);
+=======
+	return iterator;
+>>>>>>> 43a57cf3657... Revise the TIDBitmap API to support multiple concurrent iterations over a
 }
 
 /*
@@ -691,11 +781,19 @@ tbm_iterate_page(PagetableEntry *page, TBMIterateResult *output)
  * examine all tuples on the page and check if they meet the intended
  * condition.
  */
+<<<<<<< HEAD
 static bool
 tbm_iterate_hash(HashBitmap *tbm, TBMIterateResult *output)
 {
 	PagetableEntry *e;
 	bool		more;
+=======
+TBMIterateResult *
+tbm_iterate(TBMIterator *iterator)
+{
+	TIDBitmap *tbm = iterator->tbm;
+	TBMIterateResult *output = &(iterator->output);
+>>>>>>> 43a57cf3657... Revise the TIDBitmap API to support multiple concurrent iterations over a
 
 	e = tbm_next_page(tbm, &more);
 	if (more && e)
@@ -723,10 +821,10 @@ tbm_next_page(HashBitmap *tbm, bool *more)
 	 * If lossy chunk pages remain, make sure we've advanced schunkptr/
 	 * schunkbit to the next set bit.
 	 */
-	while (tbm->schunkptr < tbm->nchunks)
+	while (iterator->schunkptr < tbm->nchunks)
 	{
-		PagetableEntry *chunk = tbm->schunks[tbm->schunkptr];
-		int			schunkbit = tbm->schunkbit;
+		PagetableEntry *chunk = tbm->schunks[iterator->schunkptr];
+		int			schunkbit = iterator->schunkbit;
 
 		while (schunkbit < PAGES_PER_CHUNK)
 		{
@@ -739,39 +837,51 @@ tbm_next_page(HashBitmap *tbm, bool *more)
 		}
 		if (schunkbit < PAGES_PER_CHUNK)
 		{
-			tbm->schunkbit = schunkbit;
+			iterator->schunkbit = schunkbit;
 			break;
 		}
 		/* advance to next chunk */
-		tbm->schunkptr++;
-		tbm->schunkbit = 0;
+		iterator->schunkptr++;
+		iterator->schunkbit = 0;
 	}
 
 	/*
 	 * If both chunk and per-page data remain, must output the numerically
 	 * earlier page.
 	 */
-	if (tbm->schunkptr < tbm->nchunks)
+	if (iterator->schunkptr < tbm->nchunks)
 	{
+<<<<<<< HEAD
 		PagetableEntry *chunk = tbm->schunks[tbm->schunkptr];
 		PagetableEntry *nextpage;
+=======
+		PagetableEntry *chunk = tbm->schunks[iterator->schunkptr];
+>>>>>>> 43a57cf3657... Revise the TIDBitmap API to support multiple concurrent iterations over a
 		BlockNumber chunk_blockno;
 
-		chunk_blockno = chunk->blockno + tbm->schunkbit;
-		if (tbm->spageptr >= tbm->npages ||
-			chunk_blockno < tbm->spages[tbm->spageptr]->blockno)
+		chunk_blockno = chunk->blockno + iterator->schunkbit;
+		if (iterator->spageptr >= tbm->npages ||
+			chunk_blockno < tbm->spages[iterator->spageptr]->blockno)
 		{
 			/* Return a lossy page indicator from the chunk */
+<<<<<<< HEAD
 			nextpage = (PagetableEntry *) palloc(sizeof(PagetableEntry));
 			nextpage->ischunk = true;
 			nextpage->blockno = chunk_blockno;
 			nextpage->recheck = true;
 			tbm->schunkbit++;
 			return nextpage;
+=======
+			output->blockno = chunk_blockno;
+			output->ntuples = -1;
+			output->recheck = true;
+			iterator->schunkbit++;
+			return output;
+>>>>>>> 43a57cf3657... Revise the TIDBitmap API to support multiple concurrent iterations over a
 		}
 	}
 
-	if (tbm->spageptr < tbm->npages)
+	if (iterator->spageptr < tbm->npages)
 	{
 		PagetableEntry *e;
 
@@ -779,15 +889,57 @@ tbm_next_page(HashBitmap *tbm, bool *more)
 		if (tbm->status == HASHBM_ONE_PAGE)
 			e = &tbm->entry1;
 		else
+<<<<<<< HEAD
 			e = tbm->spages[tbm->spageptr];
 
 		tbm->spageptr++;
 		return e;
+=======
+			page = tbm->spages[iterator->spageptr];
+
+		/* scan bitmap to extract individual offset numbers */
+		ntuples = 0;
+		for (wordnum = 0; wordnum < WORDS_PER_PAGE; wordnum++)
+		{
+			bitmapword	w = page->words[wordnum];
+
+			if (w != 0)
+			{
+				int			off = wordnum * BITS_PER_BITMAPWORD + 1;
+
+				while (w != 0)
+				{
+					if (w & 1)
+						output->offsets[ntuples++] = (OffsetNumber) off;
+					off++;
+					w >>= 1;
+				}
+			}
+		}
+		output->blockno = page->blockno;
+		output->ntuples = ntuples;
+		output->recheck = page->recheck;
+		iterator->spageptr++;
+		return output;
+>>>>>>> 43a57cf3657... Revise the TIDBitmap API to support multiple concurrent iterations over a
 	}
 
 	/* Nothing more in the bitmap */
 	*more = false;
 	return NULL;
+}
+
+/*
+ * tbm_end_iterate - finish an iteration over a TIDBitmap
+ *
+ * Currently this is just a pfree, but it might do more someday.  (For
+ * instance, it could be useful to count open iterators and allow the
+ * bitmap to return to read/write status when there are no more iterators.)
+ */
+void
+tbm_end_iterate(TBMIterator *iterator)
+{
+	pfree(iterator);
 }
 
 /*

--- a/src/backend/nodes/tidbitmap.c
+++ b/src/backend/nodes/tidbitmap.c
@@ -43,7 +43,7 @@
 #define BITNUM(x)	((x) % TBM_BITS_PER_BITMAPWORD)
 
 static bool tbm_iterate_page(PagetableEntry *page, TBMIterateResult *output);
-static PagetableEntry *tbm_next_page(TIDBitmap *tbm, bool *more);
+static PagetableEntry *tbm_next_page(TBMIterator *iterator, bool *more);
 static void tbm_upd_instrument(TIDBitmap *tbm);
 
 /*
@@ -83,6 +83,10 @@ struct TIDBitmap
 	/* these are valid when iterating is true: */
 	PagetableEntry **spages;	/* sorted exact-page list, or NULL */
 	PagetableEntry **schunks;	/* sorted lossy-chunk list, or NULL */
+
+	/* CDB: Statistics for EXPLAIN ANALYZE */
+	struct Instrumentation *instrument;
+	Size		bytesperentry;
 };
 
 /*
@@ -97,18 +101,17 @@ struct TBMIterator
 	int			spageptr;		/* next spages index */
 	int			schunkptr;		/* next schunks index */
 	int			schunkbit;		/* next bit to check in current schunk */
-
-	/* CDB: Statistics for EXPLAIN ANALYZE */
-	struct Instrumentation *instrument;
-	Size		bytesperentry;
 };
 
-/* A struct to hide away TIDBitmap state for a streaming bitmap */
-typedef struct HashStreamOpaque
+struct GenericBMIterator
 {
-	TIDBitmap *tbm;  /* HashStreamOpaque will not take the ownership of freeing TIDBitmap*/
-	PagetableEntry *entry;
-}	HashStreamOpaque;
+	const Node *bm;				/* [TID|Stream]Bitmap we're iterating over */
+	union
+	{
+		TBMIterator		 *hash;		/* iterator for TIDBitmap implementation */
+		StreamBMIterator *stream;	/* iterator for StreamBitmap implementation */
+	} impl;
+};
 
 /* Local function prototypes */
 static void tbm_union_page(TIDBitmap *a, const PagetableEntry *bpage);
@@ -121,7 +124,7 @@ static bool tbm_page_is_lossy(const TIDBitmap *tbm, BlockNumber pageno);
 static void tbm_mark_page_lossy(TIDBitmap *tbm, BlockNumber pageno);
 static void tbm_lossify(TIDBitmap *tbm);
 static int	tbm_comparator(const void *left, const void *right);
-static bool tbm_stream_block(StreamNode * self, PagetableEntry *e);
+static bool tbm_stream_block(StreamBMIterator *iterator, PagetableEntry *e);
 static void tbm_stream_free(StreamNode * self);
 static void tbm_stream_set_instrument(StreamNode * self, struct Instrumentation *instr);
 static void tbm_stream_upd_instrument(StreamNode * self);
@@ -625,37 +628,127 @@ tbm_begin_iterate(TIDBitmap *tbm)
 }
 
 /*
+ * tbm_stream_begin_iterate - prepare to iterate through a StreamBitmap
+ */
+static StreamBMIterator *
+tbm_stream_begin_iterate(StreamNode *node)
+{
+	StreamBMIterator *iterator = palloc0(sizeof(*iterator));
+
+	iterator->node = node;
+
+	switch (node->type)
+	{
+		case BMS_INDEX:
+		{
+			TIDBitmap *tbm = node->opaque;
+			iterator->input.hash = tbm_begin_iterate(tbm);
+			break;
+		}
+
+		case BMS_AND:
+		case BMS_OR:
+		{
+			ListCell *cell;
+			List	 *input = node->opaque;
+
+			/* Recursively initialize an iterator for each StreamNode. */
+			foreach(cell, input)
+			{
+				StreamNode 		 *inNode = lfirst(cell);
+				StreamBMIterator *inIter = tbm_stream_begin_iterate(inNode);
+
+				iterator->input.stream = lappend(iterator->input.stream, inIter);
+			}
+
+			break;
+		}
+
+		default:
+			Assert((node->type == BMS_INDEX)
+				   || (node->type == BMS_AND)
+				   || (node->type == BMS_OR));
+	}
+
+	return iterator;
+}
+
+/*
+ * tbm_generic_begin_iterate - prepare to iterate through either a TIDBitmap or
+ * a StreamBitmap
+ *
+ * The GenericBMIterator struct is created in the caller's memory context.
+ * For a clean shutdown of the iteration, call tbm_generic_end_iterate.
+ * It is caller's responsibility not to touch the iterator anymore once the
+ * Node passed to this function is freed.
+ *
+ * Similarly to tbm_begin_iterate, after this is called, it is no longer allowed
+ * to modify the contents of the bitmap.  However, you can call this multiple
+ * times to scan the contents repeatedly, including parallel scans.
+ */
+GenericBMIterator *
+tbm_generic_begin_iterate(Node *bm)
+{
+	GenericBMIterator *iterator;
+
+	Assert(IsA(bm, TIDBitmap) || IsA(bm, StreamBitmap));
+
+	/* Allocate space. */
+	iterator = palloc(sizeof(*iterator));
+	iterator->bm = bm;
+
+	switch (bm->type)
+	{
+		case T_TIDBitmap:
+			iterator->impl.hash = tbm_begin_iterate((TIDBitmap *) bm);
+			break;
+
+		case T_StreamBitmap:
+		{
+			StreamBitmap *sbm = (StreamBitmap *) bm;
+			iterator->impl.stream = tbm_stream_begin_iterate(sbm->streamNode);
+			break;
+		}
+
+		default:
+			elog(ERROR, "invalid node type");
+	}
+
+	return iterator;
+}
+
+/*
  * tbm_generic_iterate - scan through next page of a TIDBitmap or a
  * StreamBitmap.
  */
 bool
-tbm_generic_iterate(Node *tbm, TBMIterateResult *output)
+tbm_generic_iterate(GenericBMIterator *iterator, TBMIterateResult *output)
 {
+	const Node *tbm = iterator->bm;
+
 	Assert(IsA(tbm, TIDBitmap) || IsA(tbm, StreamBitmap));
 
 	switch (tbm->type)
 	{
 		case T_TIDBitmap:
 			{
-				TIDBitmap *hashBitmap = (TIDBitmap *) tbm;
+				const TIDBitmap *hashBitmap = (const TIDBitmap *) tbm;
+				TBMIterator *hashIterator = iterator->impl.hash;
 
-				if (!hashBitmap->iterating)
-					tbm_begin_iterate(hashBitmap);
+				Assert(hashIterator->tbm == hashBitmap);
+				Assert(hashBitmap->iterating);
 
-				return tbm_iterate(hashBitmap, output);
+				return tbm_iterate(hashIterator, output);
 			}
 		case T_StreamBitmap:
 			{
-				StreamBitmap *streamBitmap = (StreamBitmap *) tbm;
+				StreamBMIterator *streamIterator = iterator->impl.stream;
 				bool		status;
-				StreamNode *s;
 
-				s = streamBitmap->streamNode;
-
-				status = bitmap_stream_iterate((void *) s, &(streamBitmap->entry));
+				status = bitmap_stream_iterate(streamIterator, &streamIterator->entry);
 
 				/* XXX: perhaps we should only do this if status == true ? */
-				tbm_iterate_page(&(streamBitmap->entry), output);
+				tbm_iterate_page(&streamIterator->entry, output);
 
 				return status;
 			}
@@ -725,7 +818,7 @@ tbm_iterate(TBMIterator *iterator, TBMIterateResult *output)
 	PagetableEntry *e;
 	bool		more;
 
-	e = tbm_next_page(tbm, &more);
+	e = tbm_next_page(iterator, &more);
 	if (more && e)
 	{
 		tbm_iterate_page(e, output);
@@ -741,8 +834,9 @@ tbm_iterate(TBMIterator *iterator, TBMIterateResult *output)
  */
 
 static PagetableEntry *
-tbm_next_page(TIDBitmap *tbm, bool *more)
+tbm_next_page(TBMIterator *iterator, bool *more)
 {
+	TIDBitmap  *tbm = iterator->tbm;
 	Assert(tbm->iterating);
 
 	*more = true;
@@ -828,6 +922,74 @@ tbm_next_page(TIDBitmap *tbm, bool *more)
 void
 tbm_end_iterate(TBMIterator *iterator)
 {
+	pfree(iterator);
+}
+
+/*
+ * tbm_stream_end_iterate - finish an iteration over a StreamBitmap
+ */
+static void
+tbm_stream_end_iterate(StreamBMIterator *iterator)
+{
+	const StreamNode *node = iterator->node;
+
+	switch (node->type)
+	{
+		case BMS_INDEX:
+			tbm_end_iterate(iterator->input.hash);
+			break;
+
+		case BMS_AND:
+		case BMS_OR:
+		{
+			ListCell *cell;
+
+			/* Recursively free all iterators in the stream "tree". */
+			foreach(cell, iterator->input.stream)
+			{
+				StreamBMIterator *inIter = lfirst(cell);
+				tbm_stream_end_iterate(inIter);
+			}
+			list_free(iterator->input.stream);
+
+			break;
+		}
+
+		default:
+			Assert((node->type == BMS_INDEX)
+				   || (node->type == BMS_AND)
+				   || (node->type == BMS_OR));
+	}
+
+	pfree(iterator);
+}
+
+/*
+ * tbm_generic_end_iterate - finish an iteration over a TIDBitmap or
+ * StreamBitmap
+ */
+void
+tbm_generic_end_iterate(GenericBMIterator *iterator)
+{
+	const Node *bm = iterator->bm;
+
+	switch (bm->type)
+	{
+		case T_TIDBitmap:
+			tbm_end_iterate(iterator->impl.hash);
+			break;
+
+		case T_StreamBitmap:
+		{
+			tbm_stream_end_iterate(iterator->impl.stream);
+			break;
+		}
+
+		default:
+			Assert((bm->type == T_TIDBitmap)
+				   || (bm->type == T_StreamBitmap));
+	}
+
 	pfree(iterator);
 }
 
@@ -1108,15 +1270,16 @@ static void
 opstream_free(StreamNode *self)
 {
 	ListCell   *cell;
+	List	   *input = self->opaque;
 
-	foreach(cell, self->input)
+	foreach(cell, input)
 	{
 		StreamNode *inp = (StreamNode *) lfirst(cell);
 
 		if (inp->free)
 			inp->free(inp);
 	}
-	list_free(self->input);
+	list_free(input);
 	pfree(self);
 }
 
@@ -1124,8 +1287,9 @@ static void
 opstream_set_instrument(StreamNode *self, struct Instrumentation *instr)
 {
 	ListCell   *cell;
+	List	   *input = self->opaque;
 
-	foreach(cell, self->input)
+	foreach(cell, input)
 	{
 		StreamNode *inp = (StreamNode *) lfirst(cell);
 
@@ -1138,8 +1302,9 @@ static void
 opstream_upd_instrument(StreamNode *self)
 {
 	ListCell   *cell;
+	List	   *input = self->opaque;
 
-	foreach(cell, self->input)
+	foreach(cell, input)
 	{
 		StreamNode *inp = (StreamNode *) lfirst(cell);
 
@@ -1158,13 +1323,12 @@ make_opstream(StreamType kind, StreamNode *n1, StreamNode *n2)
 
 	op = (OpStream *) palloc0(sizeof(OpStream));
 	op->type = kind;
+	op->opaque = list_make2(n1, n2);
 	op->pull = bitmap_stream_iterate;
-	op->nextblock = 0;
-	op->input = list_make2(n1, n2);
 	op->free = opstream_free;
 	op->set_instrument = opstream_set_instrument;
 	op->upd_instrument = opstream_upd_instrument;
-	return (void *) op;
+	return op;
 }
 
 /*
@@ -1206,9 +1370,8 @@ stream_add_node(StreamBitmap *sbm, StreamNode *node, StreamType kind)
 		if ((n->type == BMS_AND && kind == BMS_AND) ||
 			(n->type == BMS_OR && kind == BMS_OR))
 		{
-			OpStream   *o = (OpStream *) n;
-
-			o->input = lappend(o->input, node);
+			/* n->opaque is our list of inputs; append to it */
+			n->opaque = lappend(n->opaque, node);
 		}
 		else if ((n->type == BMS_AND && kind != BMS_AND) ||
 				 (n->type == BMS_OR && kind != BMS_OR) ||
@@ -1236,22 +1399,15 @@ StreamNode *
 tbm_create_stream_node(TIDBitmap *tbm)
 {
 	IndexStream *is;
-	HashStreamOpaque *op;
 
 	is = (IndexStream *) palloc0(sizeof(IndexStream));
-	op = (HashStreamOpaque *) palloc(sizeof(HashStreamOpaque));
 
 	is->type = BMS_INDEX;
-	is->nextblock = 0;
+	is->opaque = tbm;
 	is->pull = tbm_stream_block;
 	is->free = tbm_stream_free;
 	is->set_instrument = tbm_stream_set_instrument;
 	is->upd_instrument = tbm_stream_upd_instrument;
-
-	op->tbm = tbm;
-	op->entry = NULL;
-
-	is->opaque = (void *) op;
 
 	return is;
 }
@@ -1261,62 +1417,61 @@ tbm_create_stream_node(TIDBitmap *tbm)
  *
  * Notice that the IndexStream passed in as opaque will tell us the
  * desired block to stream. If the block requrested is greater than or equal
- * to the block we've cached inside the HashStreamOpaque, return that.
+ * to the block we've cached inside the iterator, return that.
  */
 
 static bool
-tbm_stream_block(StreamNode *self, PagetableEntry *e)
+tbm_stream_block(StreamBMIterator *iterator, PagetableEntry *e)
 {
-	IndexStream *is = self;
-	HashStreamOpaque *op = (HashStreamOpaque *) is->opaque;
-	TIDBitmap *tbm = op->tbm;
-	PagetableEntry *next = op->entry;
+	TBMIterator *hashIterator = iterator->input.hash;
+	PagetableEntry *next = iterator->nextentry;
 	bool		more;
 
+	Assert(iterator->node->type == BMS_INDEX);
+
 	/* have we already got an entry? */
-	if (next && is->nextblock <= next->blockno)
+	if (next && iterator->nextblock <= next->blockno)
 	{
 		memcpy(e, next, sizeof(PagetableEntry));
 		return true;
 	}
 
-	if (!tbm->iterating)
-		tbm_begin_iterate(tbm);
-
 	/* we need a new entry */
-	op->entry = tbm_next_page(tbm, &more);
+	iterator->nextentry = tbm_next_page(hashIterator, &more);
 	if (more)
 	{
-		Assert(op->entry);
-		memcpy(e, op->entry, sizeof(PagetableEntry));
+		Assert(iterator->nextentry);
+		memcpy(e, iterator->nextentry, sizeof(PagetableEntry));
 	}
-	is->nextblock++;
+	iterator->nextblock++;
 	return more;
 }
 
 static void
 tbm_stream_free(StreamNode *self)
 {
-	HashStreamOpaque *op = (HashStreamOpaque *) self->opaque;
 	/*
-	 * op->tbm is actually a reference to node->bitmap from BitmapIndexScanState
-	 * BitmapIndexScanState would have freed the op->tbm already so we shouldn't
+	 * self->opaque is actually a reference to node->bitmap from BitmapIndexScanState
+	 * BitmapIndexScanState would have freed the self->opaque already so we shouldn't
 	 * access now.
 	 */
-	pfree(op);
 	pfree(self);
 }
 
 static void
 tbm_stream_set_instrument(StreamNode *self, struct Instrumentation *instr)
 {
-	tbm_set_instrument(((HashStreamOpaque *) self->opaque)->tbm, instr);
+	TIDBitmap *tbm = self->opaque;
+	Assert(self->type == BMS_INDEX);
+	tbm_set_instrument(tbm, instr);
 }
 
 static void
 tbm_stream_upd_instrument(StreamNode *self)
 {
-	tbm_upd_instrument(((HashStreamOpaque *) self->opaque)->tbm);
+	TIDBitmap *tbm = self->opaque;
+	Assert(self->type == BMS_INDEX);
+	tbm_upd_instrument(tbm);
 }
 
 
@@ -1330,17 +1485,16 @@ tbm_stream_upd_instrument(StreamNode *self)
  */
 
 bool
-bitmap_stream_iterate(StreamNode *n, PagetableEntry *e)
+bitmap_stream_iterate(StreamBMIterator *iterator, PagetableEntry *e)
 {
-	bool		res = false;
+	const StreamNode   *n = iterator->node;
+	bool				res = false;
 
 	MemSet(e, 0, sizeof(PagetableEntry));
 
 	if (n->type == BMS_INDEX)
 	{
-		IndexStream *is = (IndexStream *) n;
-
-		res = is->pull((void *) is, e);
+		res = n->pull(iterator, e);
 	}
 	else if (n->type == BMS_OR || n->type == BMS_AND)
 	{
@@ -1356,7 +1510,6 @@ bitmap_stream_iterate(StreamNode *n, PagetableEntry *e)
 		 * that for now.
 		 */
 		ListCell   *map;
-		OpStream   *op = (OpStream *) n;
 		BlockNumber minblockno;
 		ListCell   *cell;
 		int			wordnum;
@@ -1387,18 +1540,19 @@ restart:
 		empty = false;
 		matches = NIL;
 		minblockno = InvalidBlockNumber;
-		Assert(PointerIsValid(op->input));
-		foreach(map, op->input)
+		Assert(PointerIsValid(iterator->input.stream));
+		foreach(map, iterator->input.stream)
 		{
-			StreamNode *in = (StreamNode *) lfirst(map);
+			StreamBMIterator *inIter = lfirst(map);
+			const StreamNode *in = inIter->node;
 			PagetableEntry *new;
 			bool		r;
 
 			new = (PagetableEntry *) palloc(sizeof(PagetableEntry));
 
 			/* set the desired block */
-			in->nextblock = op->nextblock;
-			r = in->pull((void *) in, new);
+			inIter->nextblock = iterator->nextblock;
+			r = in->pull(inIter, new);
 
 			/*
 			 * Let to caller know we got a result from some input bitmap. This
@@ -1429,7 +1583,7 @@ restart:
 					 * an intersection we wont get any valid results from now
 					 * on, so tell our caller that
 					 */
-					op->nextblock = minblockno + 1;		/* seems safe */
+					iterator->nextblock = minblockno + 1;	/* seems safe */
 					return false;
 				}
 				else if (n->type == BMS_OR)
@@ -1461,7 +1615,7 @@ restart:
 					 */
 					e->ischunk = true;
 					/* XXX: we can just return now... I think :) */
-					op->nextblock = minblockno + 1;
+					iterator->nextblock = minblockno + 1;
 					list_free_deep(matches);
 					return res;
 				}
@@ -1485,7 +1639,7 @@ restart:
 				 * minblockno, so we cannot skip past it yet.
 				 */
 
-				op->nextblock = minblockno;
+				iterator->nextblock = minblockno;
 				empty = true;
 				break;
 			}
@@ -1501,7 +1655,7 @@ restart:
 		else
 			list_free_deep(matches);
 		if (res)
-			op->nextblock = minblockno + 1;
+			iterator->nextblock = minblockno + 1;
 	}
 	return res;
 }
@@ -1532,8 +1686,7 @@ tbm_generic_free(Node *bm)
 				StreamNode *sn = sbm->streamNode;
 
 				sbm->streamNode = NULL;
-				if (sn &&
-					sn->free)
+				if (sn && sn->free)
 					sn->free(sn);
 
 				pfree(sbm);

--- a/src/backend/nodes/tidbitmap.c
+++ b/src/backend/nodes/tidbitmap.c
@@ -124,10 +124,23 @@ static bool tbm_page_is_lossy(const TIDBitmap *tbm, BlockNumber pageno);
 static void tbm_mark_page_lossy(TIDBitmap *tbm, BlockNumber pageno);
 static void tbm_lossify(TIDBitmap *tbm);
 static int	tbm_comparator(const void *left, const void *right);
-static bool tbm_stream_block(StreamBMIterator *iterator, PagetableEntry *e);
-static void tbm_stream_free(StreamNode * self);
 static void tbm_stream_set_instrument(StreamNode * self, struct Instrumentation *instr);
 static void tbm_stream_upd_instrument(StreamNode * self);
+
+static StreamBMIterator *tbm_stream_begin_iterate(StreamNode *node);
+static void tbm_stream_end_iterate(StreamBMIterator *iterator);
+
+/* IndexStream callbacks */
+static void index_stream_begin_iterate(StreamNode *self, StreamBMIterator *iterator);
+static bool tbm_stream_block(StreamBMIterator *iterator, PagetableEntry *e);
+static void index_stream_end_iterate(StreamBMIterator *self);
+static void tbm_stream_free(StreamNode *self);
+
+/* OpStream callbacks */
+static void opstream_begin_iterate(StreamNode *self, StreamBMIterator *iterator);
+static bool opstream_iterate(StreamBMIterator *iterator, PagetableEntry *e);
+static void opstream_end_iterate(StreamBMIterator *self);
+static void opstream_free(StreamNode *self);
 
 /*
  * tbm_create - create an initially-empty bitmap
@@ -636,39 +649,7 @@ tbm_stream_begin_iterate(StreamNode *node)
 	StreamBMIterator *iterator = palloc0(sizeof(*iterator));
 
 	iterator->node = node;
-
-	switch (node->type)
-	{
-		case BMS_INDEX:
-		{
-			TIDBitmap *tbm = node->opaque;
-			iterator->input.hash = tbm_begin_iterate(tbm);
-			break;
-		}
-
-		case BMS_AND:
-		case BMS_OR:
-		{
-			ListCell *cell;
-			List	 *input = node->opaque;
-
-			/* Recursively initialize an iterator for each StreamNode. */
-			foreach(cell, input)
-			{
-				StreamNode 		 *inNode = lfirst(cell);
-				StreamBMIterator *inIter = tbm_stream_begin_iterate(inNode);
-
-				iterator->input.stream = lappend(iterator->input.stream, inIter);
-			}
-
-			break;
-		}
-
-		default:
-			Assert((node->type == BMS_INDEX)
-				   || (node->type == BMS_AND)
-				   || (node->type == BMS_OR));
-	}
+	node->begin_iterate(node, iterator);
 
 	return iterator;
 }
@@ -745,7 +726,8 @@ tbm_generic_iterate(GenericBMIterator *iterator, TBMIterateResult *output)
 				StreamBMIterator *streamIterator = iterator->impl.stream;
 				bool		status;
 
-				status = bitmap_stream_iterate(streamIterator, &streamIterator->entry);
+				MemSet(&streamIterator->entry, 0, sizeof(PagetableEntry));
+				status = streamIterator->pull(streamIterator, &streamIterator->entry);
 
 				/* XXX: perhaps we should only do this if status == true ? */
 				tbm_iterate_page(&streamIterator->entry, output);
@@ -931,36 +913,8 @@ tbm_end_iterate(TBMIterator *iterator)
 static void
 tbm_stream_end_iterate(StreamBMIterator *iterator)
 {
-	const StreamNode *node = iterator->node;
-
-	switch (node->type)
-	{
-		case BMS_INDEX:
-			tbm_end_iterate(iterator->input.hash);
-			break;
-
-		case BMS_AND:
-		case BMS_OR:
-		{
-			ListCell *cell;
-
-			/* Recursively free all iterators in the stream "tree". */
-			foreach(cell, iterator->input.stream)
-			{
-				StreamBMIterator *inIter = lfirst(cell);
-				tbm_stream_end_iterate(inIter);
-			}
-			list_free(iterator->input.stream);
-
-			break;
-		}
-
-		default:
-			Assert((node->type == BMS_INDEX)
-				   || (node->type == BMS_AND)
-				   || (node->type == BMS_OR));
-	}
-
+	/* end_iterate() will clean up whatever begin_iterate() set up. */
+	iterator->end_iterate(iterator);
 	pfree(iterator);
 }
 
@@ -1324,7 +1278,7 @@ make_opstream(StreamType kind, StreamNode *n1, StreamNode *n2)
 	op = (OpStream *) palloc0(sizeof(OpStream));
 	op->type = kind;
 	op->opaque = list_make2(n1, n2);
-	op->pull = bitmap_stream_iterate;
+	op->begin_iterate = opstream_begin_iterate;
 	op->free = opstream_free;
 	op->set_instrument = opstream_set_instrument;
 	op->upd_instrument = opstream_upd_instrument;
@@ -1404,12 +1358,34 @@ tbm_create_stream_node(TIDBitmap *tbm)
 
 	is->type = BMS_INDEX;
 	is->opaque = tbm;
-	is->pull = tbm_stream_block;
+	is->begin_iterate = index_stream_begin_iterate;
 	is->free = tbm_stream_free;
 	is->set_instrument = tbm_stream_set_instrument;
 	is->upd_instrument = tbm_stream_upd_instrument;
 
 	return is;
+}
+
+/*
+ * IndexStream iteration callbacks
+ */
+
+static void
+index_stream_begin_iterate(StreamNode *self, StreamBMIterator *iterator)
+{
+	TIDBitmap *tbm = self->opaque;
+
+	iterator->pull = tbm_stream_block;
+	iterator->end_iterate = index_stream_end_iterate;
+
+	/* Begin iterating on the underlying TIDBitmap. */
+	iterator->input.hash = tbm_begin_iterate(tbm);
+}
+
+static void
+index_stream_end_iterate(StreamBMIterator *self)
+{
+	tbm_end_iterate(self->input.hash);
 }
 
 /*
@@ -1474,189 +1450,215 @@ tbm_stream_upd_instrument(StreamNode *self)
 	tbm_upd_instrument(tbm);
 }
 
+/*
+ * OpStream iteration callbacks
+ */
+
+static void
+opstream_begin_iterate(StreamNode *self, StreamBMIterator *iterator)
+{
+	List	 *input = self->opaque;
+	ListCell *cell;
+
+	iterator->pull = opstream_iterate;
+	iterator->end_iterate = opstream_end_iterate;
+
+	/* Recursively initialize an iterator for each StreamNode. */
+	foreach(cell, input)
+	{
+		StreamNode 		 *inNode = lfirst(cell);
+		StreamBMIterator *inIter = tbm_stream_begin_iterate(inNode);
+
+		iterator->input.stream = lappend(iterator->input.stream, inIter);
+	}
+}
+
+static void
+opstream_end_iterate(StreamBMIterator *self)
+{
+	ListCell *cell;
+
+	/* Recursively free all iterators in the stream "tree". */
+	foreach(cell, self->input.stream)
+	{
+		StreamBMIterator *inIter = lfirst(cell);
+		tbm_stream_end_iterate(inIter);
+	}
+	list_free(self->input.stream);
+}
 
 /*
- * bitmap_stream_iterate()
+ * opstream_iterate()
  *
- * This is a generic iterator for bitmap streams. The function doesn't
+ * This is an iterator for OpStreams. The function doesn't
  * know anything about the streams it is actually iterating.
  *
  * Returns false when no more results can be obtained, otherwise true.
  */
-
-bool
-bitmap_stream_iterate(StreamBMIterator *iterator, PagetableEntry *e)
+static bool
+opstream_iterate(StreamBMIterator *iterator, PagetableEntry *e)
 {
 	const StreamNode   *n = iterator->node;
 	bool				res = false;
 
-	MemSet(e, 0, sizeof(PagetableEntry));
-
-	if (n->type == BMS_INDEX)
-	{
-		res = n->pull(iterator, e);
-	}
-	else if (n->type == BMS_OR || n->type == BMS_AND)
-	{
-		/*
-		 * There are two ways we can do this: either, we could maintain our
-		 * own top level BatchWords structure and pull blocks out of that OR
-		 * we could maintain batch words for each sub map and union/intersect
-		 * those together to get the resulting page entries.
-		 *
-		 * Now, BatchWords are specific to bitmap indexes so we'd have to
-		 * translate TIDBitmaps. All the infrastructure is available to
-		 * translate bitmap indexes into the TIDBitmap mechanism so we'll do
-		 * that for now.
-		 */
-		ListCell   *map;
-		BlockNumber minblockno;
-		ListCell   *cell;
-		int			wordnum;
-		List	   *matches;
-		bool		empty;
+	/*
+	 * There are two ways we can do this: either, we could maintain our
+	 * own top level BatchWords structure and pull blocks out of that OR
+	 * we could maintain batch words for each sub map and union/intersect
+	 * those together to get the resulting page entries.
+	 *
+	 * Now, BatchWords are specific to bitmap indexes so we'd have to
+	 * translate TIDBitmaps. All the infrastructure is available to
+	 * translate bitmap indexes into the TIDBitmap mechanism so we'll do
+	 * that for now.
+	 */
+	ListCell   *map;
+	BlockNumber minblockno;
+	ListCell   *cell;
+	int			wordnum;
+	List	   *matches;
+	bool		empty;
 
 
-		/*
-		 * First, iterate through each input bitmap stream and save the block
-		 * which is returned. TIDBitmaps are designed such that they do not
-		 * return blocks with no matches -- that is, say a TIDBitmap has
-		 * matches for block 1, 4 and 5 it store matches only for those
-		 * blocks. Therefore, we may have one stream return a match for block
-		 * 10, another for block 15 and another yet for block 10 again. In
-		 * this case, we cannot include block 15 in the union/intersection
-		 * because it represents matches on some page later in the scan. We'll
-		 * get around to it in good time.
-		 *
-		 * In this case, if we're doing a union, we perform the operation
-		 * without reference to block 15. If we're performing an intersection
-		 * we cannot perform it on block 10 because we didn't get any matches
-		 * for block 10 for one of the streams: the intersection with fail.
-		 * So, we set the desired block (op->nextblock) to block 15 and loop
-		 * around to the `restart' label.
-		 */
+	/*
+	 * First, iterate through each input bitmap stream and save the block
+	 * which is returned. TIDBitmaps are designed such that they do not
+	 * return blocks with no matches -- that is, say a TIDBitmap has
+	 * matches for block 1, 4 and 5 it store matches only for those
+	 * blocks. Therefore, we may have one stream return a match for block
+	 * 10, another for block 15 and another yet for block 10 again. In
+	 * this case, we cannot include block 15 in the union/intersection
+	 * because it represents matches on some page later in the scan. We'll
+	 * get around to it in good time.
+	 *
+	 * In this case, if we're doing a union, we perform the operation
+	 * without reference to block 15. If we're performing an intersection
+	 * we cannot perform it on block 10 because we didn't get any matches
+	 * for block 10 for one of the streams: the intersection with fail.
+	 * So, we set the desired block (op->nextblock) to block 15 and loop
+	 * around to the `restart' label.
+	 */
 restart:
-		e->blockno = InvalidBlockNumber;
-		empty = false;
-		matches = NIL;
-		minblockno = InvalidBlockNumber;
-		Assert(PointerIsValid(iterator->input.stream));
-		foreach(map, iterator->input.stream)
-		{
-			StreamBMIterator *inIter = lfirst(map);
-			const StreamNode *in = inIter->node;
-			PagetableEntry *new;
-			bool		r;
+	e->blockno = InvalidBlockNumber;
+	empty = false;
+	matches = NIL;
+	minblockno = InvalidBlockNumber;
+	Assert(PointerIsValid(iterator->input.stream));
+	foreach(map, iterator->input.stream)
+	{
+		StreamBMIterator *inIter = lfirst(map);
+		PagetableEntry *new;
+		bool		r;
 
-			new = (PagetableEntry *) palloc(sizeof(PagetableEntry));
+		new = (PagetableEntry *) palloc0(sizeof(PagetableEntry));
 
-			/* set the desired block */
-			inIter->nextblock = iterator->nextblock;
-			r = in->pull(inIter, new);
-
-			/*
-			 * Let to caller know we got a result from some input bitmap. This
-			 * doesn't hold true if we're doing an intersection, and that is
-			 * handled below
-			 */
-			res = res || r;
-
-			/* only include a match if the pull function tells us to */
-			if (r)
-			{
-				if (minblockno == InvalidBlockNumber)
-					minblockno = new->blockno;
-				else if (n->type == BMS_OR)
-					minblockno = Min(minblockno, new->blockno);
-				else
-					minblockno = Max(minblockno, new->blockno);
-				matches = lappend(matches, (void *) new);
-			}
-			else
-			{
-				pfree(new);
-
-				if (n->type == BMS_AND)
-				{
-					/*
-					 * No more results for this stream and since we're doing
-					 * an intersection we wont get any valid results from now
-					 * on, so tell our caller that
-					 */
-					iterator->nextblock = minblockno + 1;	/* seems safe */
-					return false;
-				}
-				else if (n->type == BMS_OR)
-					continue;
-			}
-		}
+		/* set the desired block */
+		inIter->nextblock = iterator->nextblock;
+		r = inIter->pull(inIter, new);
 
 		/*
-		 * Now we iterate through the actual matches and perform the desired
-		 * operation on those from the same minimum block
+		 * Let to caller know we got a result from some input bitmap. This
+		 * doesn't hold true if we're doing an intersection, and that is
+		 * handled below
 		 */
-		foreach(cell, matches)
+		res = res || r;
+
+		/* only include a match if the pull function tells us to */
+		if (r)
 		{
-			PagetableEntry *tmp = (PagetableEntry *) lfirst(cell);
-
-			if (tmp->blockno == minblockno)
-			{
-				if (e->blockno == InvalidBlockNumber)
-				{
-					memcpy(e, tmp, sizeof(PagetableEntry));
-					continue;
-				}
-
-				/* already initialised, so OR together */
-				if (tmp->ischunk == true)
-				{
-					/*
-					 * Okay, new entry is lossy so match our output as lossy
-					 */
-					e->ischunk = true;
-					/* XXX: we can just return now... I think :) */
-					iterator->nextblock = minblockno + 1;
-					list_free_deep(matches);
-					return res;
-				}
-				/* union/intersect existing output and new matches */
-				for (wordnum = 0; wordnum < WORDS_PER_PAGE; wordnum++)
-				{
-					if (n->type == BMS_OR)
-						e->words[wordnum] |= tmp->words[wordnum];
-					else
-						e->words[wordnum] &= tmp->words[wordnum];
-				}
-			}
-			else if (n->type == BMS_AND)
-			{
-				/*
-				 * One of our input maps didn't return a block for the desired
-				 * block number so, we loop around again.
-				 *
-				 * Notice that we don't set the next block as minblockno + 1.
-				 * We don't know if the other streams will find a match for
-				 * minblockno, so we cannot skip past it yet.
-				 */
-
-				iterator->nextblock = minblockno;
-				empty = true;
-				break;
-			}
-		}
-		if (empty)
-		{
-			/* start again */
-			empty = false;
-			MemSet(e->words, 0, sizeof(tbm_bitmapword) * WORDS_PER_PAGE);
-			list_free_deep(matches);
-			goto restart;
+			if (minblockno == InvalidBlockNumber)
+				minblockno = new->blockno;
+			else if (n->type == BMS_OR)
+				minblockno = Min(minblockno, new->blockno);
+			else
+				minblockno = Max(minblockno, new->blockno);
+			matches = lappend(matches, (void *) new);
 		}
 		else
-			list_free_deep(matches);
-		if (res)
-			iterator->nextblock = minblockno + 1;
+		{
+			pfree(new);
+
+			if (n->type == BMS_AND)
+			{
+				/*
+				 * No more results for this stream and since we're doing
+				 * an intersection we wont get any valid results from now
+				 * on, so tell our caller that
+				 */
+				iterator->nextblock = minblockno + 1;	/* seems safe */
+				return false;
+			}
+			else if (n->type == BMS_OR)
+				continue;
+		}
 	}
+
+	/*
+	 * Now we iterate through the actual matches and perform the desired
+	 * operation on those from the same minimum block
+	 */
+	foreach(cell, matches)
+	{
+		PagetableEntry *tmp = (PagetableEntry *) lfirst(cell);
+
+		if (tmp->blockno == minblockno)
+		{
+			if (e->blockno == InvalidBlockNumber)
+			{
+				memcpy(e, tmp, sizeof(PagetableEntry));
+				continue;
+			}
+
+			/* already initialised, so OR together */
+			if (tmp->ischunk == true)
+			{
+				/*
+				 * Okay, new entry is lossy so match our output as lossy
+				 */
+				e->ischunk = true;
+				/* XXX: we can just return now... I think :) */
+				iterator->nextblock = minblockno + 1;
+				list_free_deep(matches);
+				return res;
+			}
+			/* union/intersect existing output and new matches */
+			for (wordnum = 0; wordnum < WORDS_PER_PAGE; wordnum++)
+			{
+				if (n->type == BMS_OR)
+					e->words[wordnum] |= tmp->words[wordnum];
+				else
+					e->words[wordnum] &= tmp->words[wordnum];
+			}
+		}
+		else if (n->type == BMS_AND)
+		{
+			/*
+			 * One of our input maps didn't return a block for the desired
+			 * block number so, we loop around again.
+			 *
+			 * Notice that we don't set the next block as minblockno + 1.
+			 * We don't know if the other streams will find a match for
+			 * minblockno, so we cannot skip past it yet.
+			 */
+
+			iterator->nextblock = minblockno;
+			empty = true;
+			break;
+		}
+	}
+	if (empty)
+	{
+		/* start again */
+		empty = false;
+		MemSet(e->words, 0, sizeof(tbm_bitmapword) * WORDS_PER_PAGE);
+		list_free_deep(matches);
+		goto restart;
+	}
+	else
+		list_free_deep(matches);
+	if (res)
+		iterator->nextblock = minblockno + 1;
+
 	return res;
 }
 

--- a/src/backend/nodes/tidbitmap.c
+++ b/src/backend/nodes/tidbitmap.c
@@ -101,6 +101,7 @@ struct TBMIterator
 	int			spageptr;		/* next spages index */
 	int			schunkptr;		/* next schunks index */
 	int			schunkbit;		/* next bit to check in current schunk */
+	TBMIterateResult output;	/* MUST BE LAST (because variable-size) */
 };
 
 struct GenericBMIterator
@@ -646,7 +647,12 @@ tbm_begin_iterate(TIDBitmap *tbm)
 static StreamBMIterator *
 tbm_stream_begin_iterate(StreamNode *node)
 {
-	StreamBMIterator *iterator = palloc0(sizeof(*iterator));
+	/*
+	 * Create the StreamBMIterator struct, with enough trailing space to serve
+	 * the needs of the TBMIterateResult sub-struct.
+	 */
+	StreamBMIterator *iterator = palloc0(sizeof(StreamBMIterator) +
+								 MAX_TUPLES_PER_PAGE * sizeof(OffsetNumber));
 
 	iterator->node = node;
 	node->begin_iterate(node, iterator);
@@ -702,8 +708,8 @@ tbm_generic_begin_iterate(Node *bm)
  * tbm_generic_iterate - scan through next page of a TIDBitmap or a
  * StreamBitmap.
  */
-bool
-tbm_generic_iterate(GenericBMIterator *iterator, TBMIterateResult *output)
+TBMIterateResult *
+tbm_generic_iterate(GenericBMIterator *iterator)
 {
 	const Node *tbm = iterator->bm;
 
@@ -719,26 +725,27 @@ tbm_generic_iterate(GenericBMIterator *iterator, TBMIterateResult *output)
 				Assert(hashIterator->tbm == hashBitmap);
 				Assert(hashBitmap->iterating);
 
-				return tbm_iterate(hashIterator, output);
+				return tbm_iterate(hashIterator);
 			}
 		case T_StreamBitmap:
 			{
 				StreamBMIterator *streamIterator = iterator->impl.stream;
-				bool		status;
+				TBMIterateResult *output = NULL;
 
 				MemSet(&streamIterator->entry, 0, sizeof(PagetableEntry));
-				status = streamIterator->pull(streamIterator, &streamIterator->entry);
+				if (streamIterator->pull(streamIterator, &streamIterator->entry))
+				{
+					output = &streamIterator->output;
+					tbm_iterate_page(&streamIterator->entry, output);
+				}
 
-				/* XXX: perhaps we should only do this if status == true ? */
-				tbm_iterate_page(&streamIterator->entry, output);
-
-				return status;
+				return output;
 			}
 		default:
 			elog(ERROR, "unrecoganized node type");
 	}
 
-	return false;
+	return NULL;
 }
 
 /*
@@ -794,19 +801,20 @@ tbm_iterate_page(PagetableEntry *page, TBMIterateResult *output)
  * examine all tuples on the page and check if they meet the intended
  * condition.
  */
-bool
-tbm_iterate(TBMIterator *iterator, TBMIterateResult *output)
+TBMIterateResult *
+tbm_iterate(TBMIterator *iterator)
 {
 	PagetableEntry *e;
 	bool		more;
+	TBMIterateResult *output = &(iterator->output);
 
 	e = tbm_next_page(iterator, &more);
 	if (more && e)
 	{
 		tbm_iterate_page(e, output);
-		return true;
+		return output;
 	}
-	return false;
+	return NULL;
 }
 
 /*

--- a/src/backend/nodes/tidbitmap.c
+++ b/src/backend/nodes/tidbitmap.c
@@ -43,8 +43,8 @@
 #define BITNUM(x)	((x) % TBM_BITS_PER_BITMAPWORD)
 
 static bool tbm_iterate_page(PagetableEntry *page, TBMIterateResult *output);
-static bool tbm_iterate_hash(HashBitmap *tbm, TBMIterateResult *output);
-static PagetableEntry *tbm_next_page(HashBitmap *tbm, bool *more);
+static bool tbm_iterate_hash(TIDBitmap *tbm, TBMIterateResult *output);
+static PagetableEntry *tbm_next_page(TIDBitmap *tbm, bool *more);
 
 /*
  * dynahash.c is optimized for relatively large, long-lived hash tables.
@@ -59,15 +59,15 @@ static PagetableEntry *tbm_next_page(HashBitmap *tbm, bool *more);
  */
 typedef enum
 {
-	HASHBM_EMPTY,				/* no hashtable, nentries == 0 */
-	HASHBM_ONE_PAGE,			/* entry1 contains the single entry */
-	HASHBM_HASH					/* pagetable is valid, entry1 is not */
+	TBM_EMPTY,					/* no hashtable, nentries == 0 */
+	TBM_ONE_PAGE,				/* entry1 contains the single entry */
+	TBM_HASH					/* pagetable is valid, entry1 is not */
 } TBMStatus;
 
 /*
- * Here is the representation for a whole HashBitmap.
+ * Here is the representation for a whole TIDBitMap:
  */
-struct HashBitmap
+struct TIDBitmap
 {
 	NodeTag		type;			/* to make it a valid Node */
 	MemoryContext mcxt;			/* memory context containing me */
@@ -80,7 +80,7 @@ struct HashBitmap
 	int			nchunks;		/* number of lossy entries in pagetable */
 	bool		iterating;		/* tbm_begin_iterate called? */
 <<<<<<< HEAD
-	PagetableEntry entry1;		/* used when status == HASHBM_ONE_PAGE */
+	PagetableEntry entry1;		/* used when status == TBM_ONE_PAGE */
 	/* the remaining fields are used while producing sorted output: */
 =======
 	PagetableEntry entry1;		/* used when status == TBM_ONE_PAGE */
@@ -108,24 +108,23 @@ struct TBMIterator
 	Size		bytesperentry;
 };
 
-/* A struct to hide away HashBitmap state for a streaming bitmap */
+/* A struct to hide away TIDBitmap state for a streaming bitmap */
 typedef struct HashStreamOpaque
 {
-	HashBitmap *tbm;  /* HashStreamOpaque will not take the ownership of freeing HashBitmap */
+	TIDBitmap *tbm;  /* HashStreamOpaque will not take the ownership of freeing TIDBitmap*/
 	PagetableEntry *entry;
 }	HashStreamOpaque;
 
 /* Local function prototypes */
-static void tbm_union_page(HashBitmap *a, const PagetableEntry *bpage);
-static bool tbm_intersect_page(HashBitmap *a, PagetableEntry *apage,
-				   const HashBitmap *b);
-static const PagetableEntry *tbm_find_pageentry(const HashBitmap *tbm,
+static void tbm_union_page(TIDBitmap *a, const PagetableEntry *bpage);
+static bool tbm_intersect_page(TIDBitmap *a, PagetableEntry *apage,
+				   const TIDBitmap *b);
+static const PagetableEntry *tbm_find_pageentry(const TIDBitmap *tbm,
 				   BlockNumber pageno);
-
-static PagetableEntry *tbm_get_pageentry(HashBitmap *tbm, BlockNumber pageno);
-static bool tbm_page_is_lossy(const HashBitmap *tbm, BlockNumber pageno);
-static void tbm_mark_page_lossy(HashBitmap *tbm, BlockNumber pageno);
-static void tbm_lossify(HashBitmap *tbm);
+static PagetableEntry *tbm_get_pageentry(TIDBitmap *tbm, BlockNumber pageno);
+static bool tbm_page_is_lossy(const TIDBitmap *tbm, BlockNumber pageno);
+static void tbm_mark_page_lossy(TIDBitmap *tbm, BlockNumber pageno);
+static void tbm_lossify(TIDBitmap *tbm);
 static int	tbm_comparator(const void *left, const void *right);
 static bool tbm_stream_block(StreamNode * self, PagetableEntry *e);
 static void tbm_stream_free(StreamNode * self);
@@ -139,10 +138,10 @@ static void tbm_stream_upd_instrument(StreamNode * self);
  * at the time of this call.  It will be limited to (approximately) maxbytes
  * total memory consumption.
  */
-HashBitmap *
+TIDBitmap *
 tbm_create(long maxbytes)
 {
-	HashBitmap *tbm;
+	TIDBitmap  *tbm;
 	long		nbuckets;
 
 <<<<<<< HEAD
@@ -154,18 +153,18 @@ tbm_create(long maxbytes)
 	COMPILE_ASSERT(MaxHeapTuplesPerPage <= (INT16_MAX + 1));
 
 	/*
-	 * Create the HashBitmap struct.
+	 * Create the TIDBitmap struct.
 	 */
-	tbm = (HashBitmap *) palloc0(sizeof(HashBitmap));
+	tbm = (TIDBitmap *) palloc0(sizeof(TIDBitmap));
 
-	tbm->type = T_HashBitmap;	/* Set NodeTag */
+	tbm->type = T_TIDBitmap;	/* Set NodeTag */
 =======
 	/* Create the TIDBitmap struct and zero all its fields */
 	tbm = makeNode(TIDBitmap);
 
 >>>>>>> 43a57cf3657... Revise the TIDBitmap API to support multiple concurrent iterations over a
 	tbm->mcxt = CurrentMemoryContext;
-	tbm->status = HASHBM_EMPTY;
+	tbm->status = TBM_EMPTY;
 	tbm->instrument = NULL;
 
 	/*
@@ -191,11 +190,11 @@ tbm_create(long maxbytes)
  * proposition, we don't do it until we have to.
  */
 static void
-tbm_create_pagetable(HashBitmap *tbm)
+tbm_create_pagetable(TIDBitmap *tbm)
 {
 	HASHCTL		hash_ctl;
 
-	Assert(tbm->status != HASHBM_HASH);
+	Assert(tbm->status != TBM_HASH);
 	Assert(tbm->pagetable == NULL);
 
 	/* Create the hashtable proper */
@@ -204,13 +203,13 @@ tbm_create_pagetable(HashBitmap *tbm)
 	hash_ctl.entrysize = sizeof(PagetableEntry);
 	hash_ctl.hash = tag_hash;
 	hash_ctl.hcxt = tbm->mcxt;
-	tbm->pagetable = hash_create("HashBitmap",
+	tbm->pagetable = hash_create("TIDBitmap",
 								 128,	/* start small and extend */
 								 &hash_ctl,
 								 HASH_ELEM | HASH_FUNCTION | HASH_CONTEXT);
 
 	/* If entry1 is valid, push it into the hashtable */
-	if (tbm->status == HASHBM_ONE_PAGE)
+	if (tbm->status == TBM_ONE_PAGE)
 	{
 		PagetableEntry *page;
 		bool		found;
@@ -222,14 +221,14 @@ tbm_create_pagetable(HashBitmap *tbm)
 		memcpy(page, &tbm->entry1, sizeof(PagetableEntry));
 	}
 
-	tbm->status = HASHBM_HASH;
+	tbm->status = TBM_HASH;
 }
 
 /*
- * tbm_free - free a HashBitmap
+ * tbm_free - free a TIDBitmap
  */
 void
-tbm_free(HashBitmap *tbm)
+tbm_free(TIDBitmap *tbm)
 {
 	if (tbm->instrument)
 		tbm_bitmap_upd_instrument((Node *) tbm);
@@ -244,10 +243,10 @@ tbm_free(HashBitmap *tbm)
 
 
 /*
- * tbm_upd_instrument - Update the Instrumentation attached to a HashBitmap.
+ * tbm_upd_instrument - Update the Instrumentation attached to a TIDBitmap.
  */
 static void
-tbm_upd_instrument(HashBitmap *tbm)
+tbm_upd_instrument(TIDBitmap *tbm)
 {
 	Instrumentation *instr = tbm->instrument;
 	Size		workmemused;
@@ -266,13 +265,13 @@ tbm_upd_instrument(HashBitmap *tbm)
 
 /*
  * tbm_set_instrument
- *	Attach caller's Instrumentation object to a HashBitmap, unless the
- *	HashBitmap already has one.  We want the statistics to be associated
+ *	Attach caller's Instrumentation object to a TIDBitmap, unless the
+ *	TIDBitmap already has one.  We want the statistics to be associated
  *	with the plan node which originally created the bitmap, rather than a
  *	downstream consumer of the bitmap.
  */
 static void
-tbm_set_instrument(HashBitmap *tbm, struct Instrumentation *instr)
+tbm_set_instrument(TIDBitmap *tbm, struct Instrumentation *instr)
 {
 	if (instr == NULL ||
 		tbm->instrument == NULL)
@@ -284,10 +283,10 @@ tbm_set_instrument(HashBitmap *tbm, struct Instrumentation *instr)
 
 
 /*
- * tbm_add_tuples - add some tuple IDs to a HashBitmap
+ * tbm_add_tuples - add some tuple IDs to a TIDBitmap
  */
 void
-tbm_add_tuples(HashBitmap *tbm, const ItemPointer tids, int ntids,
+tbm_add_tuples(TIDBitmap *tbm, const ItemPointer tids, int ntids,
 			   bool recheck)
 {
 	int			i;
@@ -339,21 +338,21 @@ tbm_add_tuples(HashBitmap *tbm, const ItemPointer tids, int ntids,
  * a is modified in-place, b is not changed
  */
 void
-tbm_union(HashBitmap *a, const HashBitmap *b)
+tbm_union(TIDBitmap *a, const TIDBitmap *b)
 {
 	Assert(!a->iterating);
 	/* Nothing to do if b is empty */
 	if (b->nentries == 0)
 		return;
 	/* Scan through chunks and pages in b, merge into a */
-	if (b->status == HASHBM_ONE_PAGE)
+	if (b->status == TBM_ONE_PAGE)
 		tbm_union_page(a, &b->entry1);
 	else
 	{
 		HASH_SEQ_STATUS status;
 		PagetableEntry *bpage;
 
-		Assert(b->status == HASHBM_HASH);
+		Assert(b->status == TBM_HASH);
 		hash_seq_init(&status, b->pagetable);
 		while ((bpage = (PagetableEntry *) hash_seq_search(&status)) != NULL)
 			tbm_union_page(a, bpage);
@@ -362,7 +361,7 @@ tbm_union(HashBitmap *a, const HashBitmap *b)
 
 /* Process one page of b during a union op */
 static void
-tbm_union_page(HashBitmap *a, const PagetableEntry *bpage)
+tbm_union_page(TIDBitmap *a, const PagetableEntry *bpage)
 {
 	PagetableEntry *apage;
 	int			wordnum;
@@ -420,7 +419,7 @@ tbm_union_page(HashBitmap *a, const PagetableEntry *bpage)
  * a is modified in-place, b is not changed
  */
 void
-tbm_intersect(HashBitmap *a, const HashBitmap *b)
+tbm_intersect(TIDBitmap *a, const TIDBitmap *b)
 {
 	Assert(!a->iterating);
 	/* Nothing to do if a is empty */
@@ -430,7 +429,7 @@ tbm_intersect(HashBitmap *a, const HashBitmap *b)
 	a->nentries_hwm = Max(a->nentries_hwm, a->nentries);
 
 	/* Scan through chunks and pages in a, try to match to b */
-	if (a->status == HASHBM_ONE_PAGE)
+	if (a->status == TBM_ONE_PAGE)
 	{
 		if (tbm_intersect_page(a, &a->entry1, b))
 		{
@@ -439,7 +438,7 @@ tbm_intersect(HashBitmap *a, const HashBitmap *b)
 			a->npages--;
 			a->nentries--;
 			Assert(a->nentries == 0);
-			a->status = HASHBM_EMPTY;
+			a->status = TBM_EMPTY;
 		}
 	}
 	else
@@ -447,7 +446,7 @@ tbm_intersect(HashBitmap *a, const HashBitmap *b)
 		HASH_SEQ_STATUS status;
 		PagetableEntry *apage;
 
-		Assert(a->status == HASHBM_HASH);
+		Assert(a->status == TBM_HASH);
 		hash_seq_init(&status, a->pagetable);
 		while ((apage = (PagetableEntry *) hash_seq_search(&status)) != NULL)
 		{
@@ -474,7 +473,7 @@ tbm_intersect(HashBitmap *a, const HashBitmap *b)
  * Returns TRUE if apage is now empty and should be deleted from a
  */
 static bool
-tbm_intersect_page(HashBitmap *a, PagetableEntry *apage, const HashBitmap *b)
+tbm_intersect_page(TIDBitmap *a, PagetableEntry *apage, const TIDBitmap *b)
 {
 	const PagetableEntry *bpage;
 	int			wordnum;
@@ -552,16 +551,16 @@ tbm_intersect_page(HashBitmap *a, PagetableEntry *apage, const HashBitmap *b)
 }
 
 /*
- * tbm_is_empty - is a HashBitmap completely empty?
+ * tbm_is_empty - is a TIDBitmap completely empty?
  */
 bool
-tbm_is_empty(const HashBitmap *tbm)
+tbm_is_empty(const TIDBitmap *tbm)
 {
 	return (tbm->nentries == 0);
 }
 
 /*
- * tbm_begin_iterate - prepare to iterate through a HashBitmap
+ * tbm_begin_iterate - prepare to iterate through a TIDBitmap
  *
  * The TBMIterator struct is created in the caller's memory context.
  * For a clean shutdown of the iteration, call tbm_end_iterate; but it's
@@ -575,7 +574,7 @@ tbm_is_empty(const HashBitmap *tbm)
  */
 <<<<<<< HEAD
 void
-tbm_begin_iterate(HashBitmap *tbm)
+tbm_begin_iterate(TIDBitmap *tbm)
 =======
 TBMIterator *
 tbm_begin_iterate(TIDBitmap *tbm)
@@ -652,7 +651,7 @@ tbm_begin_iterate(TIDBitmap *tbm)
 	/*
 	 * Nothing else to do if no entries, nor if we don't have a hashtable.
 	 */
-	if (tbm->nentries == 0 || tbm->status != HASHBM_HASH)
+	if (tbm->nentries == 0 || tbm->status != TBM_HASH)
 		return;
 
 	/*
@@ -688,18 +687,18 @@ tbm_begin_iterate(TIDBitmap *tbm)
 }
 
 /*
- * tbm_iterate - scan through next page of a HashBitmap or a StreamBitmap.
+ * tbm_iterate - scan through next page of a TIDBitmap or a StreamBitmap.
  */
 bool
 tbm_iterate(Node *tbm, TBMIterateResult *output)
 {
-	Assert(IsA(tbm, HashBitmap) || IsA(tbm, StreamBitmap));
+	Assert(IsA(tbm, TIDBitmap) || IsA(tbm, StreamBitmap));
 
 	switch (tbm->type)
 	{
-		case T_HashBitmap:
+		case T_TIDBitmap:
 			{
-				HashBitmap *hashBitmap = (HashBitmap *) tbm;
+				TIDBitmap *hashBitmap = (TIDBitmap *) tbm;
 
 				if (!hashBitmap->iterating)
 					tbm_begin_iterate(hashBitmap);
@@ -772,7 +771,7 @@ tbm_iterate_page(PagetableEntry *page, TBMIterateResult *output)
 }
 
 /*
- * tbm_iterate_hash - scan through next page of a HashBitmap
+ * tbm_iterate_hash - scan through next page of a TIDBitmap
  *
  * Gets a TBMIterateResult representing one page, or NULL if there are
  * no more pages to scan.  Pages are guaranteed to be delivered in numerical
@@ -783,7 +782,7 @@ tbm_iterate_page(PagetableEntry *page, TBMIterateResult *output)
  */
 <<<<<<< HEAD
 static bool
-tbm_iterate_hash(HashBitmap *tbm, TBMIterateResult *output)
+tbm_iterate_hash(TIDBitmap *tbm, TBMIterateResult *output)
 {
 	PagetableEntry *e;
 	bool		more;
@@ -805,13 +804,13 @@ tbm_iterate(TBMIterator *iterator)
 }
 
 /*
- * tbm_next_page - actually traverse the HashBitmap
+ * tbm_next_page - actually traverse the TIDBitmap
  *
  * Store the next block of matches in nextpage.
  */
 
 static PagetableEntry *
-tbm_next_page(HashBitmap *tbm, bool *more)
+tbm_next_page(TIDBitmap *tbm, bool *more)
 {
 	Assert(tbm->iterating);
 
@@ -886,7 +885,7 @@ tbm_next_page(HashBitmap *tbm, bool *more)
 		PagetableEntry *e;
 
 		/* In ONE_PAGE state, we don't allocate an spages[] array */
-		if (tbm->status == HASHBM_ONE_PAGE)
+		if (tbm->status == TBM_ONE_PAGE)
 			e = &tbm->entry1;
 		else
 <<<<<<< HEAD
@@ -948,14 +947,14 @@ tbm_end_iterate(TBMIterator *iterator)
  * Returns NULL if there is no non-lossy entry for the pageno.
  */
 static const PagetableEntry *
-tbm_find_pageentry(const HashBitmap *tbm, BlockNumber pageno)
+tbm_find_pageentry(const TIDBitmap *tbm, BlockNumber pageno)
 {
 	const PagetableEntry *page;
 
 	if (tbm->nentries == 0)		/* in case pagetable doesn't exist */
 		return NULL;
 
-	if (tbm->status == HASHBM_ONE_PAGE)
+	if (tbm->status == TBM_ONE_PAGE)
 	{
 		page = &tbm->entry1;
 		if (page->blockno != pageno)
@@ -983,21 +982,21 @@ tbm_find_pageentry(const HashBitmap *tbm, BlockNumber pageno)
  * up to the caller to call tbm_lossify() at the next safe point if so.
  */
 static PagetableEntry *
-tbm_get_pageentry(HashBitmap *tbm, BlockNumber pageno)
+tbm_get_pageentry(TIDBitmap *tbm, BlockNumber pageno)
 {
 	PagetableEntry *page;
 	bool		found;
 
-	if (tbm->status == HASHBM_EMPTY)
+	if (tbm->status == TBM_EMPTY)
 	{
 		/* Use the fixed slot */
 		page = &tbm->entry1;
 		found = false;
-		tbm->status = HASHBM_ONE_PAGE;
+		tbm->status = TBM_ONE_PAGE;
 	}
 	else
 	{
-		if (tbm->status == HASHBM_ONE_PAGE)
+		if (tbm->status == TBM_ONE_PAGE)
 		{
 			page = &tbm->entry1;
 			if (page->blockno == pageno)
@@ -1029,7 +1028,7 @@ tbm_get_pageentry(HashBitmap *tbm, BlockNumber pageno)
  * tbm_page_is_lossy - is the page marked as lossily stored?
  */
 static bool
-tbm_page_is_lossy(const HashBitmap *tbm, BlockNumber pageno)
+tbm_page_is_lossy(const TIDBitmap *tbm, BlockNumber pageno)
 {
 	PagetableEntry *page;
 	BlockNumber chunk_pageno;
@@ -1038,7 +1037,7 @@ tbm_page_is_lossy(const HashBitmap *tbm, BlockNumber pageno)
 	/* we can skip the lookup if there are no lossy chunks */
 	if (tbm->nchunks == 0)
 		return false;
-	Assert(tbm->status == HASHBM_HASH);
+	Assert(tbm->status == TBM_HASH);
 
 	bitno = pageno % PAGES_PER_CHUNK;
 	chunk_pageno = pageno - bitno;
@@ -1063,7 +1062,7 @@ tbm_page_is_lossy(const HashBitmap *tbm, BlockNumber pageno)
  * up to the caller to call tbm_lossify() at the next safe point if so.
  */
 static void
-tbm_mark_page_lossy(HashBitmap *tbm, BlockNumber pageno)
+tbm_mark_page_lossy(TIDBitmap *tbm, BlockNumber pageno)
 {
 	PagetableEntry *page;
 	bool		found;
@@ -1073,7 +1072,7 @@ tbm_mark_page_lossy(HashBitmap *tbm, BlockNumber pageno)
 	int			bitnum;
 
 	/* We force the bitmap into hashtable mode whenever it's lossy */
-	if (tbm->status != HASHBM_HASH)
+	if (tbm->status != TBM_HASH)
 		tbm_create_pagetable(tbm);
 
 	bitno = pageno % PAGES_PER_CHUNK;
@@ -1134,7 +1133,7 @@ tbm_mark_page_lossy(HashBitmap *tbm, BlockNumber pageno)
  * tbm_lossify - lose some information to get back under the memory limit
  */
 static void
-tbm_lossify(HashBitmap *tbm)
+tbm_lossify(TIDBitmap *tbm)
 {
 	HASH_SEQ_STATUS status;
 	PagetableEntry *page;
@@ -1149,7 +1148,7 @@ tbm_lossify(HashBitmap *tbm)
 	 * just end up doing this again very soon.  We shoot for maxentries/2.
 	 */
 	Assert(!tbm->iterating);
-	Assert(tbm->status == HASHBM_HASH);
+	Assert(tbm->status == TBM_HASH);
 
 	hash_seq_init(&status, tbm->pagetable);
 	while ((page = (PagetableEntry *) hash_seq_search(&status)) != NULL)
@@ -1340,11 +1339,11 @@ stream_add_node(StreamBitmap *sbm, StreamNode *node, StreamType kind)
 }
 
 /*
- * tbm_create_stream_node() - turn a HashBitmap into a stream
+ * tbm_create_stream_node() - turn a TIDBitmap into a stream
  */
 
 StreamNode *
-tbm_create_stream_node(HashBitmap *tbm)
+tbm_create_stream_node(TIDBitmap *tbm)
 {
 	IndexStream *is;
 	HashStreamOpaque *op;
@@ -1368,7 +1367,7 @@ tbm_create_stream_node(HashBitmap *tbm)
 }
 
 /*
- * tbm_stream_block() - Fetch the next block from HashBitmap stream
+ * tbm_stream_block() - Fetch the next block from TIDBitmap stream
  *
  * Notice that the IndexStream passed in as opaque will tell us the
  * desired block to stream. If the block requrested is greater than or equal
@@ -1380,7 +1379,7 @@ tbm_stream_block(StreamNode *self, PagetableEntry *e)
 {
 	IndexStream *is = self;
 	HashStreamOpaque *op = (HashStreamOpaque *) is->opaque;
-	HashBitmap *tbm = op->tbm;
+	TIDBitmap *tbm = op->tbm;
 	PagetableEntry *next = op->entry;
 	bool		more;
 
@@ -1462,8 +1461,8 @@ bitmap_stream_iterate(StreamNode *n, PagetableEntry *e)
 		 * those together to get the resulting page entries.
 		 *
 		 * Now, BatchWords are specific to bitmap indexes so we'd have to
-		 * translate HashBitmaps. All the infrastructure is available to
-		 * translate bitmap indexes into the HashBitmap mechanism so we'll do
+		 * translate TIDBitmaps. All the infrastructure is available to
+		 * translate bitmap indexes into the TIDBitmap mechanism so we'll do
 		 * that for now.
 		 */
 		ListCell   *map;
@@ -1477,8 +1476,8 @@ bitmap_stream_iterate(StreamNode *n, PagetableEntry *e)
 
 		/*
 		 * First, iterate through each input bitmap stream and save the block
-		 * which is returned. HashBitmaps are designed such that they do not
-		 * return blocks with no matches -- that is, say a HashBitmap has
+		 * which is returned. TIDBitmaps are designed such that they do not
+		 * return blocks with no matches -- that is, say a TIDBitmap has
 		 * matches for block 1, 4 and 5 it store matches only for those
 		 * blocks. Therefore, we may have one stream return a match for block
 		 * 10, another for block 15 and another yet for block 10 again. In
@@ -1619,12 +1618,12 @@ restart:
 
 
 /*
- * --------- These functions accept either HashBitmap or StreamBitmap ---------
+ * --------- These functions accept either TIDBitmap or StreamBitmap ---------
  */
 
 
 /*
- * tbm_bitmap_free - free a HashBitmap or StreamBitmap
+ * tbm_bitmap_free - free a TIDBitmap or StreamBitmap
  */
 void
 tbm_bitmap_free(Node *bm)
@@ -1634,8 +1633,8 @@ tbm_bitmap_free(Node *bm)
 
 	switch (bm->type)
 	{
-		case T_HashBitmap:
-			tbm_free((HashBitmap *) bm);
+		case T_TIDBitmap:
+			tbm_free((TIDBitmap *) bm);
 			break;
 		case T_StreamBitmap:
 			{
@@ -1668,8 +1667,8 @@ tbm_bitmap_set_instrument(Node *bm, struct Instrumentation *instr)
 
 	switch (bm->type)
 	{
-		case T_HashBitmap:
-			tbm_set_instrument((HashBitmap *) bm, instr);
+		case T_TIDBitmap:
+			tbm_set_instrument((TIDBitmap *) bm, instr);
 			break;
 		case T_StreamBitmap:
 			{
@@ -1702,8 +1701,8 @@ tbm_bitmap_upd_instrument(Node *bm)
 
 	switch (bm->type)
 	{
-		case T_HashBitmap:
-			tbm_upd_instrument((HashBitmap *) bm);
+		case T_TIDBitmap:
+			tbm_upd_instrument((TIDBitmap *) bm);
 			break;
 		case T_StreamBitmap:
 			{

--- a/src/include/access/gin.h
+++ b/src/include/access/gin.h
@@ -4,7 +4,7 @@
  *
  *	Copyright (c) 2006-2009, PostgreSQL Global Development Group
  *
- *	$PostgreSQL: pgsql/src/include/access/gin.h,v 1.27 2009/01/01 17:23:55 momjian Exp $
+ *	$PostgreSQL: pgsql/src/include/access/gin.h,v 1.28 2009/01/10 21:08:36 tgl Exp $
  *--------------------------------------------------------------------------
  */
 
@@ -389,7 +389,12 @@ typedef struct GinScanEntryData
 
 	/* partial match support */
 	bool		isPartialMatch;
+<<<<<<< HEAD
 	Node 	   *partialMatch;
+=======
+	TIDBitmap  *partialMatch;
+	TBMIterator *partialMatchIterator;
+>>>>>>> 43a57cf3657... Revise the TIDBitmap API to support multiple concurrent iterations over a
 	TBMIterateResult *partialMatchResult;
 	StrategyNumber strategy;
 

--- a/src/include/access/gin.h
+++ b/src/include/access/gin.h
@@ -389,12 +389,8 @@ typedef struct GinScanEntryData
 
 	/* partial match support */
 	bool		isPartialMatch;
-<<<<<<< HEAD
-	Node 	   *partialMatch;
-=======
 	TIDBitmap  *partialMatch;
 	TBMIterator *partialMatchIterator;
->>>>>>> 43a57cf3657... Revise the TIDBitmap API to support multiple concurrent iterations over a
 	TBMIterateResult *partialMatchResult;
 	StrategyNumber strategy;
 

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -1805,12 +1805,8 @@ typedef struct BitmapHeapScanState
 	ScanState	ss;				/* its first field is NodeTag */
 	struct HeapScanDescData *ss_currentScanDesc;
 	List	   *bitmapqualorig;
-<<<<<<< HEAD
 	Node	   *tbm;
-=======
-	TIDBitmap  *tbm;
-	TBMIterator *tbmiterator;
->>>>>>> 43a57cf3657... Revise the TIDBitmap API to support multiple concurrent iterations over a
+	GenericBMIterator *tbmiterator;
 	TBMIterateResult *tbmres;
 } BitmapHeapScanState;
 
@@ -1830,7 +1826,7 @@ typedef struct BitmapAppendOnlyScanState
 	struct AOCSFetchDescData *baos_currentAOCSFetchDesc;
 	struct AOCSFetchDescData *baos_currentAOCSLossyFetchDesc;
 	List	   *baos_bitmapqualorig;
-	Node  		*baos_tbm;
+	GenericBMIterator *baos_iterator;
 	TBMIterateResult *baos_tbmres;
 	bool		baos_gotpage;
 	int			baos_cindex;
@@ -1859,6 +1855,7 @@ typedef struct BitmapTableScanState
 	void 						*scanDesc;
 	List           				*bitmapqualorig;
 	Node  						*tbm;
+	GenericBMIterator			*tbmiterator;
 	TBMIterateResult 	*tbmres;
 	bool						isLossyBitmapPage;
 	bool						recheckTuples;

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -9,7 +9,7 @@
  * Portions Copyright (c) 1996-2009, PostgreSQL Global Development Group
  * Portions Copyright (c) 1994, Regents of the University of California
  *
- * $PostgreSQL: pgsql/src/include/nodes/execnodes.h,v 1.199 2009/01/01 17:23:59 momjian Exp $
+ * $PostgreSQL: pgsql/src/include/nodes/execnodes.h,v 1.200 2009/01/10 21:08:36 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -1796,6 +1796,7 @@ typedef struct DynamicBitmapIndexScanState
  *
  *		bitmapqualorig	   execution state for bitmapqualorig expressions
  *		tbm				   bitmap obtained from child index scan(s)
+ *		tbmiterator		   iterator for scanning current pages
  *		tbmres			   current-page data
  * ----------------
  */
@@ -1804,7 +1805,12 @@ typedef struct BitmapHeapScanState
 	ScanState	ss;				/* its first field is NodeTag */
 	struct HeapScanDescData *ss_currentScanDesc;
 	List	   *bitmapqualorig;
+<<<<<<< HEAD
 	Node	   *tbm;
+=======
+	TIDBitmap  *tbm;
+	TBMIterator *tbmiterator;
+>>>>>>> 43a57cf3657... Revise the TIDBitmap API to support multiple concurrent iterations over a
 	TBMIterateResult *tbmres;
 } BitmapHeapScanState;
 

--- a/src/include/nodes/nodes.h
+++ b/src/include/nodes/nodes.h
@@ -526,7 +526,7 @@ typedef enum NodeTag
 	T_ReturnSetInfo,			/* in nodes/execnodes.h */
 	T_WindowObjectData,			/* private in nodeWindowAgg.c */
 	T_InlineCodeBlock,			/* in nodes/parsenodes.h */
-    T_HashBitmap,               /* in nodes/tidbitmap.h */
+	T_TIDBitmap,				/* in nodes/tidbitmap.h */
     T_StreamBitmap,             /* in nodes/tidbitmap.h */
 	T_FormatterData,            /* in access/formatter.h */
 	T_ExtProtocolData,          /* in access/extprotocol.h */

--- a/src/include/nodes/tidbitmap.h
+++ b/src/include/nodes/tidbitmap.h
@@ -136,6 +136,8 @@ typedef struct StreamBMIterator
 	PagetableEntry	   *nextentry;	/* for IndexStream, a pointer to the next cached entry */
 	BlockNumber			nextblock;	/* block number we're up to */
 	PagetableEntry		entry;		/* storage for a page of tids in this stream bitmap */
+	bool    	      (*pull)(struct StreamBMIterator *self, PagetableEntry *e);
+	void			  (*end_iterate)(struct StreamBMIterator *self);
 } StreamBMIterator;
 
 /* A version of TBMIterator that handles both TIDBitmap and StreamBitmap */
@@ -148,7 +150,7 @@ typedef struct StreamNode
 {
 	StreamType      type;       /* one of: BMS_INDEX, BMS_AND, BMS_OR */
 	void		   *opaque;		/* implementation-specific data */
-	bool          (*pull)(StreamBMIterator *iterator, PagetableEntry *e);
+	void 		  (*begin_iterate)(struct StreamNode *self, StreamBMIterator *iterator);
 	void          (*free)(struct StreamNode *self);
 	void          (*set_instrument)(struct StreamNode *self, struct Instrumentation *instr);
 	void          (*upd_instrument)(struct StreamNode *self);
@@ -194,7 +196,6 @@ extern void tbm_end_iterate(TBMIterator *iterator);
 extern void stream_move_node(StreamBitmap *strm, StreamBitmap *other, StreamType kind);
 extern void stream_add_node(StreamBitmap *strm, StreamNode *node, StreamType kind);
 extern StreamNode *tbm_create_stream_node(TIDBitmap *tbm);
-extern bool bitmap_stream_iterate(StreamBMIterator *iterator, PagetableEntry *e);
 
 /* These functions accept either a TIDBitmap or a StreamBitmap... */
 extern GenericBMIterator *tbm_generic_begin_iterate(Node *bm);

--- a/src/include/nodes/tidbitmap.h
+++ b/src/include/nodes/tidbitmap.h
@@ -174,6 +174,7 @@ struct StreamBMIterator
 		TBMIterator	   *hash;		/* for IndexStream */
 		List		   *stream;		/* for OpStream */
 	} input;						/* input iterator(s) */
+	void			   *opaque;		/* for the implementation in bitmap.c */
 
 	PagetableEntry	   *nextentry;	/* for IndexStream, a pointer to the next cached entry */
 	BlockNumber			nextblock;	/* block number we're up to */

--- a/src/include/nodes/tidbitmap.h
+++ b/src/include/nodes/tidbitmap.h
@@ -125,20 +125,7 @@ typedef struct StreamBitmap
 } StreamBitmap;
 
 /* A version of TBMIterator for StreamBitmap */
-typedef struct StreamBMIterator
-{
-	const struct StreamNode *node;	/* the root node to iterate out of */
-	union
-	{
-		TBMIterator	   *hash;		/* for IndexStream */
-		List		   *stream;		/* for OpStream */
-	} input;						/* input iterator(s) */
-	PagetableEntry	   *nextentry;	/* for IndexStream, a pointer to the next cached entry */
-	BlockNumber			nextblock;	/* block number we're up to */
-	PagetableEntry		entry;		/* storage for a page of tids in this stream bitmap */
-	bool    	      (*pull)(struct StreamBMIterator *self, PagetableEntry *e);
-	void			  (*end_iterate)(struct StreamBMIterator *self);
-} StreamBMIterator;
+typedef struct StreamBMIterator StreamBMIterator;
 
 /* A version of TBMIterator that handles both TIDBitmap and StreamBitmap */
 typedef struct GenericBMIterator GenericBMIterator;
@@ -178,6 +165,26 @@ typedef struct
 	OffsetNumber offsets[1];	/* VARIABLE LENGTH ARRAY */
 } TBMIterateResult;				/* VARIABLE LENGTH STRUCT */
 
+/* Make this visible for bitmap.c */
+struct StreamBMIterator
+{
+	const struct StreamNode *node;	/* the root node to iterate out of */
+	union
+	{
+		TBMIterator	   *hash;		/* for IndexStream */
+		List		   *stream;		/* for OpStream */
+	} input;						/* input iterator(s) */
+
+	PagetableEntry	   *nextentry;	/* for IndexStream, a pointer to the next cached entry */
+	BlockNumber			nextblock;	/* block number we're up to */
+	PagetableEntry		entry;		/* storage for a page of tids in this stream bitmap */
+
+	bool    	      (*pull)(struct StreamBMIterator *self, PagetableEntry *e);
+	void			  (*end_iterate)(struct StreamBMIterator *self);
+
+	TBMIterateResult	output;		/* MUST BE LAST (because variable-size) */
+};
+
 /* function prototypes in nodes/tidbitmap.c */
 extern TIDBitmap *tbm_create(long maxbytes);
 extern void tbm_free(TIDBitmap *tbm);
@@ -190,7 +197,7 @@ extern void tbm_intersect(TIDBitmap *a, const TIDBitmap *b);
 extern bool tbm_is_empty(const TIDBitmap *tbm);
 
 extern TBMIterator *tbm_begin_iterate(TIDBitmap *tbm);
-extern bool tbm_iterate(TBMIterator *iterator, TBMIterateResult *output);
+extern TBMIterateResult *tbm_iterate(TBMIterator *iterator);
 extern void tbm_end_iterate(TBMIterator *iterator);
 
 extern void stream_move_node(StreamBitmap *strm, StreamBitmap *other, StreamType kind);
@@ -199,7 +206,7 @@ extern StreamNode *tbm_create_stream_node(TIDBitmap *tbm);
 
 /* These functions accept either a TIDBitmap or a StreamBitmap... */
 extern GenericBMIterator *tbm_generic_begin_iterate(Node *bm);
-extern bool tbm_generic_iterate(GenericBMIterator *iterator, TBMIterateResult *output);
+extern TBMIterateResult *tbm_generic_iterate(GenericBMIterator *iterator);
 extern void tbm_generic_end_iterate(GenericBMIterator *iterator);
 extern void tbm_generic_free(Node *bm);
 extern void tbm_generic_set_instrument(Node *bm, struct Instrumentation *instr);

--- a/src/include/nodes/tidbitmap.h
+++ b/src/include/nodes/tidbitmap.h
@@ -107,9 +107,9 @@ typedef struct PagetableEntry
 
 /*
  * Actual bitmap representation is private to tidbitmap.c.	Callers can
- * do IsA(x, HashBitmap) on it, but nothing else.
+ * do IsA(x, TIDBitmap) on it, but nothing else.
  */
-typedef struct HashBitmap HashBitmap;
+typedef struct TIDBitmap TIDBitmap;
 
 /*
  * Stream bitmap representation.
@@ -163,26 +163,26 @@ typedef struct
 } TBMIterateResult;				/* VARIABLE LENGTH STRUCT */
 
 /* function prototypes in nodes/tidbitmap.c */
-extern HashBitmap *tbm_create(long maxbytes);
-extern void tbm_free(HashBitmap *tbm);
+extern TIDBitmap *tbm_create(long maxbytes);
+extern void tbm_free(TIDBitmap *tbm);
 
-extern void tbm_add_tuples(HashBitmap *tbm,
+extern void tbm_add_tuples(TIDBitmap *tbm,
 						   const ItemPointer tids, int ntids,
 						   bool recheck);
-extern void tbm_union(HashBitmap *a, const HashBitmap *b);
-extern void tbm_intersect(HashBitmap *a, const HashBitmap *b);
-extern bool tbm_is_empty(const HashBitmap *tbm);
+extern void tbm_union(TIDBitmap *a, const TIDBitmap *b);
+extern void tbm_intersect(TIDBitmap *a, const TIDBitmap *b);
+extern bool tbm_is_empty(const TIDBitmap *tbm);
 
-extern void tbm_begin_iterate(HashBitmap *tbm);
+extern void tbm_begin_iterate(TIDBitmap *tbm);
 extern bool tbm_iterate(Node *tbm, TBMIterateResult *output);
 
 extern void stream_move_node(StreamBitmap *strm, StreamBitmap *other, StreamType kind);
 extern void stream_add_node(StreamBitmap *strm, StreamNode *node, StreamType kind);
-extern StreamNode *tbm_create_stream_node(HashBitmap *tbm);
+extern StreamNode *tbm_create_stream_node(TIDBitmap *tbm);
 extern bool bitmap_stream_iterate(StreamNode *n, PagetableEntry *e);
 
 <<<<<<< HEAD
-/* These functions accept either a HashBitmap or a StreamBitmap... */
+/* These functions accept either a TIDBitmap or a StreamBitmap... */
 extern void tbm_bitmap_free(Node *bm);
 extern void tbm_bitmap_set_instrument(Node *bm, struct Instrumentation *instr);
 extern void tbm_bitmap_upd_instrument(Node *bm);

--- a/src/include/nodes/tidbitmap.h
+++ b/src/include/nodes/tidbitmap.h
@@ -111,16 +111,35 @@ typedef struct PagetableEntry
  */
 typedef struct TIDBitmap TIDBitmap;
 
+/* Likewise, TBMIterator is private */
+typedef struct TBMIterator TBMIterator;
+
 /*
  * Stream bitmap representation.
  */
 typedef struct StreamBitmap
 {
 	NodeTag			type;		/* to make it a valid Node */
-	PagetableEntry	entry;		/* a page of tids in this stream bitmap */
 	struct StreamNode      *streamNode; /* state internal to stream implementation */
     struct Instrumentation *instrument; /* CDB: stats for EXPLAIN ANALYZE */
 } StreamBitmap;
+
+/* A version of TBMIterator for StreamBitmap */
+typedef struct StreamBMIterator
+{
+	const struct StreamNode *node;	/* the root node to iterate out of */
+	union
+	{
+		TBMIterator	   *hash;		/* for IndexStream */
+		List		   *stream;		/* for OpStream */
+	} input;						/* input iterator(s) */
+	PagetableEntry	   *nextentry;	/* for IndexStream, a pointer to the next cached entry */
+	BlockNumber			nextblock;	/* block number we're up to */
+	PagetableEntry		entry;		/* storage for a page of tids in this stream bitmap */
+} StreamBMIterator;
+
+/* A version of TBMIterator that handles both TIDBitmap and StreamBitmap */
+typedef struct GenericBMIterator GenericBMIterator;
 
 /*
  * Stream object.
@@ -128,10 +147,8 @@ typedef struct StreamBitmap
 typedef struct StreamNode
 {
 	StreamType      type;       /* one of: BMS_INDEX, BMS_AND, BMS_OR */
-	bool          (*pull)(struct StreamNode *self, PagetableEntry *e);
-	BlockNumber		nextblock;	/* block number we're up to */
-	void		   *opaque;     /* for IndexStream only */
-	List		   *input;		/* input streams; for OpStream only */
+	void		   *opaque;		/* implementation-specific data */
+	bool          (*pull)(StreamBMIterator *iterator, PagetableEntry *e);
 	void          (*free)(struct StreamNode *self);
 	void          (*set_instrument)(struct StreamNode *self, struct Instrumentation *instr);
 	void          (*upd_instrument)(struct StreamNode *self);
@@ -148,9 +165,6 @@ typedef struct StreamNode   IndexStream;
  * AND or OR'd together
  */
 typedef struct StreamNode   OpStream;
-
-/* Likewise, TBMIterator is private */
-typedef struct TBMIterator TBMIterator;
 
 /* Result structure for tbm_iterate */
 typedef struct
@@ -173,26 +187,23 @@ extern void tbm_union(TIDBitmap *a, const TIDBitmap *b);
 extern void tbm_intersect(TIDBitmap *a, const TIDBitmap *b);
 extern bool tbm_is_empty(const TIDBitmap *tbm);
 
-extern void tbm_begin_iterate(TIDBitmap *tbm);
-extern bool tbm_iterate(Node *tbm, TBMIterateResult *output);
+extern TBMIterator *tbm_begin_iterate(TIDBitmap *tbm);
+extern bool tbm_iterate(TBMIterator *iterator, TBMIterateResult *output);
+extern void tbm_end_iterate(TBMIterator *iterator);
 
 extern void stream_move_node(StreamBitmap *strm, StreamBitmap *other, StreamType kind);
 extern void stream_add_node(StreamBitmap *strm, StreamNode *node, StreamType kind);
 extern StreamNode *tbm_create_stream_node(TIDBitmap *tbm);
-extern bool bitmap_stream_iterate(StreamNode *n, PagetableEntry *e);
+extern bool bitmap_stream_iterate(StreamBMIterator *iterator, PagetableEntry *e);
 
-<<<<<<< HEAD
 /* These functions accept either a TIDBitmap or a StreamBitmap... */
-extern bool tbm_generic_iterate(Node *tbm, TBMIterateResult *output);
+extern GenericBMIterator *tbm_generic_begin_iterate(Node *bm);
+extern bool tbm_generic_iterate(GenericBMIterator *iterator, TBMIterateResult *output);
+extern void tbm_generic_end_iterate(GenericBMIterator *iterator);
 extern void tbm_generic_free(Node *bm);
 extern void tbm_generic_set_instrument(Node *bm, struct Instrumentation *instr);
 extern void tbm_generic_upd_instrument(Node *bm);
 
 extern void tbm_convert_appendonly_tid_out(ItemPointer psudeoHeapTid, AOTupleId *aoTid);
-=======
-extern TBMIterator *tbm_begin_iterate(TIDBitmap *tbm);
-extern TBMIterateResult *tbm_iterate(TBMIterator *iterator);
-extern void tbm_end_iterate(TBMIterator *iterator);
->>>>>>> 43a57cf3657... Revise the TIDBitmap API to support multiple concurrent iterations over a
 
 #endif   /* TIDBITMAP_H */

--- a/src/include/nodes/tidbitmap.h
+++ b/src/include/nodes/tidbitmap.h
@@ -183,9 +183,10 @@ extern bool bitmap_stream_iterate(StreamNode *n, PagetableEntry *e);
 
 <<<<<<< HEAD
 /* These functions accept either a TIDBitmap or a StreamBitmap... */
-extern void tbm_bitmap_free(Node *bm);
-extern void tbm_bitmap_set_instrument(Node *bm, struct Instrumentation *instr);
-extern void tbm_bitmap_upd_instrument(Node *bm);
+extern bool tbm_generic_iterate(Node *tbm, TBMIterateResult *output);
+extern void tbm_generic_free(Node *bm);
+extern void tbm_generic_set_instrument(Node *bm, struct Instrumentation *instr);
+extern void tbm_generic_upd_instrument(Node *bm);
 
 extern void tbm_convert_appendonly_tid_out(ItemPointer psudeoHeapTid, AOTupleId *aoTid);
 =======

--- a/src/include/nodes/tidbitmap.h
+++ b/src/include/nodes/tidbitmap.h
@@ -17,7 +17,7 @@
  * Portions Copyright (c) 2012-Present Pivotal Software, Inc.
  * Copyright (c) 2003-2009, PostgreSQL Global Development Group
  *
- * $PostgreSQL: pgsql/src/include/nodes/tidbitmap.h,v 1.8 2009/01/01 17:24:00 momjian Exp $
+ * $PostgreSQL: pgsql/src/include/nodes/tidbitmap.h,v 1.9 2009/01/10 21:08:36 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -149,6 +149,9 @@ typedef struct StreamNode   IndexStream;
  */
 typedef struct StreamNode   OpStream;
 
+/* Likewise, TBMIterator is private */
+typedef struct TBMIterator TBMIterator;
+
 /* Result structure for tbm_iterate */
 typedef struct
 {
@@ -178,11 +181,17 @@ extern void stream_add_node(StreamBitmap *strm, StreamNode *node, StreamType kin
 extern StreamNode *tbm_create_stream_node(HashBitmap *tbm);
 extern bool bitmap_stream_iterate(StreamNode *n, PagetableEntry *e);
 
+<<<<<<< HEAD
 /* These functions accept either a HashBitmap or a StreamBitmap... */
 extern void tbm_bitmap_free(Node *bm);
 extern void tbm_bitmap_set_instrument(Node *bm, struct Instrumentation *instr);
 extern void tbm_bitmap_upd_instrument(Node *bm);
 
 extern void tbm_convert_appendonly_tid_out(ItemPointer psudeoHeapTid, AOTupleId *aoTid);
+=======
+extern TBMIterator *tbm_begin_iterate(TIDBitmap *tbm);
+extern TBMIterateResult *tbm_iterate(TBMIterator *iterator);
+extern void tbm_end_iterate(TBMIterator *iterator);
+>>>>>>> 43a57cf3657... Revise the TIDBitmap API to support multiple concurrent iterations over a
 
 #endif   /* TIDBITMAP_H */

--- a/src/test/regress/expected/bitmapscan.out
+++ b/src/test/regress/expected/bitmapscan.out
@@ -1041,7 +1041,7 @@ select * from bm_table_foo where d = 2 and (d = 1 or d = 2);
  2 | 2
 (1 row)
 
--- double free mixed bitmap indexes (StreamBitmap with HashBitmap)
+-- double free mixed bitmap indexes (StreamBitmap with TIDBitmap)
 CREATE TABLE bmheapcrash (
     btree_col2 date DEFAULT now(),
     bitmap_col text NOT NULL,

--- a/src/test/regress/expected/bitmapscan_ao.out
+++ b/src/test/regress/expected/bitmapscan_ao.out
@@ -149,7 +149,7 @@ WHERE foo.fid = bar.flex_value_set_id;
  54321
 (2 rows)
 
--- double free mixed bitmap indexes (StreamBitmap with HashBitmap)
+-- double free mixed bitmap indexes (StreamBitmap with TIDBitmap)
 CREATE TABLE bmcrash (
     btree_col2 date DEFAULT now(),
     bitmap_col text NOT NULL,

--- a/src/test/regress/sql/bitmapscan.sql
+++ b/src/test/regress/sql/bitmapscan.sql
@@ -300,7 +300,7 @@ select * from bm_table_foo where d = 3 and (d = 1 or d = 2);
 -- otherwise segments will eliminate nodes.
 select * from bm_table_foo where d = 2 and (d = 1 or d = 2);
 
--- double free mixed bitmap indexes (StreamBitmap with HashBitmap)
+-- double free mixed bitmap indexes (StreamBitmap with TIDBitmap)
 CREATE TABLE bmheapcrash (
     btree_col2 date DEFAULT now(),
     bitmap_col text NOT NULL,

--- a/src/test/regress/sql/bitmapscan_ao.sql
+++ b/src/test/regress/sql/bitmapscan_ao.sql
@@ -151,7 +151,7 @@ and c1.language = 'ZHS') bar,
 foo
 WHERE foo.fid = bar.flex_value_set_id;
 
--- double free mixed bitmap indexes (StreamBitmap with HashBitmap)
+-- double free mixed bitmap indexes (StreamBitmap with TIDBitmap)
 CREATE TABLE bmcrash (
     btree_col2 date DEFAULT now(),
     bitmap_col text NOT NULL,

--- a/src/tools/pgindent/typedefs.list
+++ b/src/tools/pgindent/typedefs.list
@@ -1232,7 +1232,6 @@ HashAggStatus
 HashAggTable
 HashAggTableSizes
 HashAllocFunc
-HashBitmap
 HASHBUCKET
 HashBuildState
 HashCompareFunc
@@ -2472,6 +2471,7 @@ TheLexeme
 TheSubstitute
 ThreadWaitingState
 threadWorkerInfo
+TIDBitmap
 TidHashKey
 TidPath
 TidScan


### PR DESCRIPTION
Upstream commit 43a57cf, which significantly changes the API for the `HashBitmap` (`TIDBitmap` in Postgres), is about to hit in an upcoming merge. This (unfortunately rather large) patchset is a joint effort by myself, Max Yang, Xiaoran Wang, Heikki Linnakangas, and Daniel Gustafsson to reduce our diff against upstream and support the incoming API changes with our GPDB-specific customizations.

The primary goal of this entire PR is to support concurrent iterations over a single `StreamBitmap` or `TIDBitmap`. GPDB has made significant changes to allow either one of those bitmap types to be iterated over without the caller necessarily needing to know which is which, and we've kept that property here.

You can take a look at the entire diff, but it's probably easier to go through patch by patch. I have done my best to clean up patch-on-patch changes and bugfixes -- there is still some backtracking, though.

General Roadmap
-----
- Cherry-pick the upstream `TIDBitmap` API change and commit it, *with merge conflicts*. They'll drop out in later commits, and it'll be easier to see whether the resolutions are in fact correct.
- Revert as much as possible of the `TIDBitmap` API to the upstream version, to avoid unnecessary merge hazards in the future. This is done in multiple commits at different points; it didn't seem like combining them all would be very readable.
- Add a `tbm_generic_` version of the API to differentiate upstream's `TIDBitmap`-only API from ours. Both `StreamBitmap` and `TIDBitmap` can be passed to this version of the API.
- Update each section of code to use the new generic API, and resolve the merge conflicts as we do.
- Fix up some memory management issues in `bitmap.c` that are now exacerbated by our changes.
- Finally, return an empty bitmap instead of `NULL` from `bmgetbitmap` if there are no results. This matches upstream behavior.