### PR TITLE
Remove hardcoded OID in GPORCA and add fallback inside GPDB translator

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
@@ -257,7 +257,7 @@ CTranslatorScalarToDXL::PdxlnScOpFromExpr
 	{
 		CHAR *sz = (CHAR*) gpdb::SzNodeToString(const_cast<Expr*>(pexpr));
 		CWStringDynamic *pstr = CDXLUtils::PstrFromSz(m_pmp, sz);
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiPlStmt2DXLConversion, pstr->Wsz());
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, pstr->Wsz());
 	}
 
 	CDXLNode *pdxlnReturn = (this->*pf)(pexpr, pmapvarcolid);
@@ -647,7 +647,7 @@ CTranslatorScalarToDXL::PdxlnScBoolExprFromExpr
 		GPOS_RAISE
 			(
 			gpdxl::ExmaDXL,
-			gpdxl::ExmiPlStmt2DXLConversion,
+			gpdxl::ExmiQuery2DXLUnsupportedFeature,
 			GPOS_WSZ_LIT("Boolean Expression (OR / AND): Incorrect Number of Children ")
 			);
 	}
@@ -656,7 +656,7 @@ CTranslatorScalarToDXL::PdxlnScBoolExprFromExpr
 		GPOS_RAISE
 			(
 			gpdxl::ExmaDXL,
-			gpdxl::ExmiPlStmt2DXLConversion,
+			gpdxl::ExmiQuery2DXLUnsupportedFeature,
 			GPOS_WSZ_LIT("Boolean Expression (NOT): Incorrect Number of Children ")
 			);
 	}
@@ -893,7 +893,7 @@ CTranslatorScalarToDXL::PdxlnScCaseStmtFromExpr
 			GPOS_RAISE
 				(
 				gpdxl::ExmaDXL,
-				gpdxl::ExmiPlStmt2DXLConversion,
+				gpdxl::ExmiQuery2DXLUnsupportedFeature,
 				GPOS_WSZ_LIT("Do not support SIMPLE CASE STATEMENT")
 				);
 			return NULL;
@@ -1312,7 +1312,7 @@ CTranslatorScalarToDXL::PdxlnScAggrefFromAggref
 		GPOS_RAISE
 		(
 				gpdxl::ExmaDXL,
-				gpdxl::ExmiPlStmt2DXLConversion,
+				gpdxl::ExmiQuery2DXLUnsupportedFeature,
 				GPOS_WSZ_LIT("Ordered aggregates")
 		);
 	}
@@ -1321,7 +1321,7 @@ CTranslatorScalarToDXL::PdxlnScAggrefFromAggref
 	if (paggref->aggdistinct)
 	{
 		GPOS_RAISE(gpdxl::ExmaDXL,
-				   gpdxl::ExmiPlStmt2DXLConversion,
+				   gpdxl::ExmiQuery2DXLUnsupportedFeature,
 				   GPOS_WSZ_LIT("Distinct aggregates"));
 	}
 
@@ -1418,7 +1418,7 @@ CTranslatorScalarToDXL::Pdxlwf
 	else if ((frameOptions & FRAMEOPTION_END_UNBOUNDED_FOLLOWING) != 0)
 		edxlfbLead = EdxlfbUnboundedFollowing;
 	else
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiPlStmt2DXLConversion,
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
 			   GPOS_WSZ_LIT("Unrecognized window frame option"));
 
 	EdxlFrameBoundary edxlfbTrail;
@@ -1433,7 +1433,7 @@ CTranslatorScalarToDXL::Pdxlwf
 	else if ((frameOptions & FRAMEOPTION_START_UNBOUNDED_FOLLOWING) != 0)
 		edxlfbTrail = EdxlfbUnboundedFollowing;
 	else
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiPlStmt2DXLConversion,
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
 			   GPOS_WSZ_LIT("Unrecognized window frame option"));
 
 	// We don't support non-default EXCLUDE [CURRENT ROW | GROUP | TIES |

--- a/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
@@ -1564,6 +1564,19 @@ CTranslatorScalarToDXL::PdxlnScWindowFunc
 
 	GPOS_ASSERT(EdxlwinstageSentinel != edxlwinstage && "Invalid window stage");
 
+	if (3103 == pwindowfunc->winfnoid)
+	{
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("PERCENT_RANK Window Functions"));
+	}
+	else if (3104 == pwindowfunc->winfnoid)
+	{
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("CUME_DIST Window Functions"));
+	}
+	else if (3105 == pwindowfunc->winfnoid)
+	{
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("NTILE(int4) Window Functions"));
+	}
+
 	/*
 	 * ORCA's ScalarWindowRef object doesn't have fields for the 'winstar'
 	 * and 'winagg', so we lose that information in the translation.

--- a/src/test/regress/expected/qp_olap_windowerr.out
+++ b/src/test/regress/expected/qp_olap_windowerr.out
@@ -461,33 +461,6 @@ win2 as (partition by cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale
 win3 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc),
 win4 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc);
 ERROR:  division by zero  (seg1 slice6 rahmaf2-mbp:25433 pid=48131)
--- MAX() function with partition by and order by having rows based framing clause in combination with other functions --
-SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.prc/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,
-TO_CHAR(COALESCE(PERCENT_RANK() OVER(win2),0),'99999999.9999999'),
-TO_CHAR(COALESCE(DENSE_RANK() OVER(win3),0),'99999999.9999999'),
-TO_CHAR(COALESCE(RANK() OVER(order by cf_olap_windowerr_sale.vn desc),0),'99999999.9999999'),
-TO_CHAR(COALESCE(ROW_NUMBER() OVER(win2),0),'99999999.9999999'),
-TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.vn)) OVER(order by cf_olap_windowerr_sale.cn asc),0),'99999999.9999999')
-FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
-WINDOW win1 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc,cf_olap_windowerr_sale.pn desc rows between unbounded preceding and 2 preceding ),
-win2 as (order by cf_olap_windowerr_sale.vn desc),
-win3 as (order by cf_olap_windowerr_sale.cn asc);
- qty  | pn  | vn |      to_char      | cn |      to_char      |      to_char      |      to_char      |      to_char      |      to_char      
-------+-----+----+-------------------+----+-------------------+-------------------+-------------------+-------------------+-------------------
-    1 | 400 | 50 |          .0000000 |  1 |          .0000000 |         1.0000000 |         1.0000000 |         1.0000000 |        50.0000000
-    1 | 200 | 10 |          .0000000 |  1 |         1.0000000 |         1.0000000 |        12.0000000 |        12.0000000 |        50.0000000
-    1 | 100 | 20 |          .0000000 |  1 |          .9090909 |         1.0000000 |        11.0000000 |        11.0000000 |        50.0000000
-    1 | 300 | 30 |          .0000000 |  1 |          .5454545 |         1.0000000 |         7.0000000 |         8.0000000 |        50.0000000
-   12 | 500 | 30 |          .0000000 |  1 |          .5454545 |         1.0000000 |         7.0000000 |         7.0000000 |        50.0000000
- 1100 | 100 | 40 |          .0000000 |  2 |          .1818182 |         2.0000000 |         3.0000000 |         4.0000000 |        50.0000000
-    1 | 400 | 50 |          .0000000 |  2 |          .0000000 |         2.0000000 |         1.0000000 |         2.0000000 |        50.0000000
-   12 | 500 | 30 |          .0000000 |  3 |          .5454545 |         3.0000000 |         7.0000000 |         9.0000000 |        50.0000000
-   12 | 600 | 30 |          .0000000 |  3 |          .5454545 |         3.0000000 |         7.0000000 |        10.0000000 |        50.0000000
-    1 | 200 | 40 |          .0000000 |  3 |          .1818182 |         3.0000000 |         3.0000000 |         3.0000000 |        50.0000000
-    1 | 700 | 40 |          .0000000 |  4 |          .1818182 |         4.0000000 |         3.0000000 |         5.0000000 |        50.0000000
-    1 | 800 | 40 |          .0000000 |  4 |          .1818182 |         4.0000000 |         3.0000000 |         6.0000000 |        50.0000000
-(12 rows)
-
 -- MAX() function with partition by and order by having rows based framing clause --
 SELECT cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.cn/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
@@ -3529,33 +3502,6 @@ SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sal
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn AND cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc rows unbounded preceding );
 ERROR:  division by zero
--- REGR_INTERCEPT() function with ONLY order by having rows based framing clause in combination with other functions --
-SELECT cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(REGR_INTERCEPT(floor(cf_olap_windowerr_sale.vn),floor(cf_olap_windowerr_sale.qty+cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),
-TO_CHAR(COALESCE(LAG(cast(floor(cf_olap_windowerr_sale.cn+cf_olap_windowerr_sale.cn) as int),cast (floor(cf_olap_windowerr_sale.pn-cf_olap_windowerr_sale.prc) as int),NULL) OVER(win2),0),'99999999.9999999'),cf_olap_windowerr_sale.vn,
-TO_CHAR(COALESCE(ROW_NUMBER() OVER(win2),0),'99999999.9999999'),
-TO_CHAR(COALESCE(ROW_NUMBER() OVER(win3),0),'99999999.9999999'),cf_olap_windowerr_sale.dt,
-TO_CHAR(COALESCE(RANK() OVER(win4),0),'99999999.9999999')
-FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
-WINDOW win1 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc rows floor(cf_olap_windowerr_sale.qty) preceding ),
-win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc),
-win3 as (partition by cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.pn desc),
-win4 as (partition by cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.vn desc);
- cn | qty  | pn  | qty  |      to_char      |      to_char      | vn |      to_char      |      to_char      |     dt     |      to_char      
-----+------+-----+------+-------------------+-------------------+----+-------------------+-------------------+------------+-------------------
-  1 |    1 | 100 |    1 |          .0000000 |          .0000000 | 20 |         4.0000000 |         1.0000000 | 05-01-1401 |         4.0000000
-  1 |    1 | 200 |    1 |         9.9454545 |          .0000000 | 10 |         2.0000000 |         1.0000000 | 03-01-1401 |         5.0000000
-  1 |    1 | 300 |    1 |          .0000000 |          .0000000 | 30 |         5.0000000 |         1.0000000 | 05-02-1401 |         2.0000000
-  1 |    1 | 400 |    1 |          .0000000 |          .0000000 | 50 |         6.0000000 |         7.0000000 | 06-01-1401 |         1.0000000
-  1 |   12 | 500 |   12 |        32.8312069 |          .0000000 | 30 |         8.0000000 |         5.0000000 | 06-01-1401 |         2.0000000
-  2 |    1 | 400 |    1 |        50.0000000 |          .0000000 | 50 |         7.0000000 |         6.0000000 | 06-01-1401 |         1.0000000
-  2 | 1100 | 100 | 1100 |          .0000000 |          .0000000 | 40 |         1.0000000 |         1.0000000 | 01-01-1401 |         2.0000000
-  3 |    1 | 200 |    1 |       -20.0000000 |          .0000000 | 40 |         3.0000000 |         1.0000000 | 04-01-1401 |         1.0000000
-  3 |   12 | 500 |   12 |        32.4666777 |          .0000000 | 30 |         9.0000000 |         4.0000000 | 06-01-1401 |         2.0000000
-  3 |   12 | 600 |   12 |        32.1819373 |          .0000000 | 30 |        10.0000000 |         3.0000000 | 06-01-1401 |         2.0000000
-  4 |    1 | 700 |    1 |        45.0000000 |          .0000000 | 40 |        11.0000000 |         2.0000000 | 06-01-1401 |         1.0000000
-  4 |    1 | 800 |    1 |          .0000000 |          .0000000 | 40 |        12.0000000 |         1.0000000 | 06-01-1401 |         1.0000000
-(12 rows)
-
 -- REGR_INTERCEPT() function with ONLY order by having rows based framing clause --
 SELECT cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(REGR_INTERCEPT(floor(cf_olap_windowerr_sale.pn*cf_olap_windowerr_sale.vn),floor(cf_olap_windowerr_sale.qty/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn ) cf_olap_windowerr_sale
@@ -4004,58 +3950,6 @@ TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.qty/cf_olap_windowerr_sale.prc
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn ) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc rows between 4 preceding and 4 following );
 ERROR:  division by zero  (seg0 slice2 rahmaf2-mbp:25432 pid=48130)
--- REGR_R2() function with partition by and order by having rows based framing clause in combination with other functions --
-SELECT cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(REGR_R2(floor(cf_olap_windowerr_sale.vn+cf_olap_windowerr_sale.qty),floor(cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn,
-TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.pn*cf_olap_windowerr_sale.qty)) OVER(win1),0),'99999999.9999999'),
-TO_CHAR(COALESCE(LAG(cast(floor(cf_olap_windowerr_sale.pn-cf_olap_windowerr_sale.pn) as int),cast (floor(cf_olap_windowerr_sale.vn-cf_olap_windowerr_sale.prc) as int),NULL) OVER(win2),0),'99999999.9999999'),
-TO_CHAR(COALESCE(LAG(cast(floor(cf_olap_windowerr_sale.pn) as int),cast (floor(cf_olap_windowerr_sale.qty-cf_olap_windowerr_sale.prc) as int),NULL) OVER(win3),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn,
-TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.qty+cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999'),
-TO_CHAR(COALESCE(COUNT(floor(cf_olap_windowerr_sale.qty*cf_olap_windowerr_sale.vn)) OVER(partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc rows between 3 preceding and unbounded following ),0),'99999999.9999999')
-FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
-WINDOW win1 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc rows between 3 preceding and unbounded following ),
-win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc),
-win3 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc);
- qty  |      to_char      | prc  | vn |      to_char      |      to_char      |      to_char      | cn |     dt     | pn  |      to_char      |      to_char      
-------+-------------------+------+----+-------------------+-------------------+-------------------+----+------------+-----+-------------------+-------------------
-    1 |          .0000000 |    0 | 10 |       200.0000000 |          .0000000 |          .0000000 |  1 | 03-01-1401 | 200 |       201.0000000 |         1.0000000
-    1 |          .0000000 |    0 | 20 |       100.0000000 |          .0000000 |          .0000000 |  1 | 05-01-1401 | 100 |       101.0000000 |         1.0000000
-    1 |          .0000000 |    0 | 30 |       300.0000000 |          .0000000 |          .0000000 |  1 | 05-02-1401 | 300 |       301.0000000 |         1.0000000
-    1 |          .0000000 |    0 | 40 |       200.0000000 |          .0000000 |          .0000000 |  3 | 04-01-1401 | 200 |       201.0000000 |         1.0000000
-    1 |          .0000000 |    0 | 50 |       400.0000000 |          .0000000 |          .0000000 |  1 | 06-01-1401 | 400 |       401.0000000 |         2.0000000
-    1 |          .0000000 |    0 | 50 |       400.0000000 |          .0000000 |          .0000000 |  2 | 06-01-1401 | 400 |       401.0000000 |         2.0000000
-    1 |          .0000000 |    1 | 40 |       800.0000000 |          .0000000 |       700.0000000 |  4 | 06-01-1401 | 700 |       801.0000000 |         2.0000000
-    1 |          .0000000 |    1 | 40 |       800.0000000 |          .0000000 |       800.0000000 |  4 | 06-01-1401 | 800 |       801.0000000 |         2.0000000
-   12 |          .0000000 |    5 | 30 |      7200.0000000 |          .0000000 |          .0000000 |  1 | 06-01-1401 | 500 |       612.0000000 |         3.0000000
-   12 |          .0000000 |    5 | 30 |      7200.0000000 |          .0000000 |          .0000000 |  3 | 06-01-1401 | 500 |       612.0000000 |         3.0000000
-   12 |          .0000000 |    5 | 30 |      7200.0000000 |          .0000000 |          .0000000 |  3 | 06-01-1401 | 600 |       612.0000000 |         3.0000000
- 1100 |          .0000000 | 2400 | 40 |    110000.0000000 |          .0000000 |          .0000000 |  2 | 01-01-1401 | 100 |      1200.0000000 |         1.0000000
-(12 rows)
-
--- REGR_SLOPE() function with ONLY order by having range based framing clause in combination with other functions --
-SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(REGR_SLOPE(floor(cf_olap_windowerr_sale.prc/cf_olap_windowerr_sale.cn),floor(cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.pn,
-TO_CHAR(COALESCE(ROW_NUMBER() OVER(win2),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.qty,
-TO_CHAR(COALESCE(LAG(cast(floor(cf_olap_windowerr_sale.qty) as int),cast (floor(cf_olap_windowerr_sale.cn-cf_olap_windowerr_sale.pn) as int),NULL) OVER(win3),0),'99999999.9999999'),cf_olap_windowerr_sale.dt,
-TO_CHAR(COALESCE(ROW_NUMBER() OVER(partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc),0),'99999999.9999999')
-FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn ) cf_olap_windowerr_sale
-WINDOW win1 as (order by cf_olap_windowerr_sale.pn desc range unbounded preceding ),
-win2 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.vn asc),
-win3 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc);
- vn | cn |      to_char      | pn  |      to_char      | prc  | qty  |      to_char      |     dt     |      to_char      
-----+----+-------------------+-----+-------------------+------+------+-------------------+------------+-------------------
- 10 |  1 |         -.3617021 | 200 |         1.0000000 |    0 |    1 |          .0000000 | 03-01-1401 |         1.0000000
- 20 |  1 |       -13.0319149 | 100 |         1.0000000 |    0 |    1 |          .0000000 | 05-01-1401 |         1.0000000
- 30 |  1 |         -.4736842 | 300 |         1.0000000 |    0 |    1 |          .0000000 | 05-02-1401 |         1.0000000
- 30 |  1 |        -1.6666667 | 500 |         1.0000000 |    5 |   12 |          .0000000 | 06-01-1401 |         1.0000000
- 30 |  3 |        -1.0000000 | 600 |         1.0000000 |    5 |   12 |          .0000000 | 06-01-1401 |         2.0000000
- 30 |  3 |        -1.6666667 | 500 |         2.0000000 |    5 |   12 |          .0000000 | 06-01-1401 |         1.0000000
- 40 |  2 |       -13.0319149 | 100 |         1.0000000 | 2400 | 1100 |          .0000000 | 01-01-1401 |         1.0000000
- 40 |  3 |         -.3617021 | 200 |         1.0000000 |    0 |    1 |          .0000000 | 04-01-1401 |         1.0000000
- 40 |  4 |          .0000000 | 700 |         1.0000000 |    1 |    1 |          .0000000 | 06-01-1401 |         1.0000000
- 40 |  4 |          .0000000 | 800 |         1.0000000 |    1 |    1 |          .0000000 | 06-01-1401 |         2.0000000
- 50 |  1 |         -.7205882 | 400 |         1.0000000 |    0 |    1 |          .0000000 | 06-01-1401 |         1.0000000
- 50 |  2 |         -.7205882 | 400 |         2.0000000 |    0 |    1 |          .0000000 | 06-01-1401 |         1.0000000
-(12 rows)
-
 -- REGR_SLOPE() function with ONLY order by having range based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(REGR_SLOPE(floor(cf_olap_windowerr_sale.qty*cf_olap_windowerr_sale.cn),floor(cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999'),
 TO_CHAR(COALESCE(DENSE_RANK() OVER(win2),0),'99999999.9999999'),cf_olap_windowerr_sale.pn,

--- a/src/test/regress/sql/qp_olap_windowerr.sql
+++ b/src/test/regress/sql/qp_olap_windowerr.sql
@@ -367,26 +367,6 @@ win2 as (partition by cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale
 win3 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc),
 win4 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc);
 
--- MAX() function with partition by and order by having rows based framing clause in combination with other functions --
-
--- start_ignore
--- GPDB_84_MERGE_FIXME:  GPORCA wrong results
-set optimizer = off;
--- end_ignore
-SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.prc/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,
-TO_CHAR(COALESCE(PERCENT_RANK() OVER(win2),0),'99999999.9999999'),
-TO_CHAR(COALESCE(DENSE_RANK() OVER(win3),0),'99999999.9999999'),
-TO_CHAR(COALESCE(RANK() OVER(order by cf_olap_windowerr_sale.vn desc),0),'99999999.9999999'),
-TO_CHAR(COALESCE(ROW_NUMBER() OVER(win2),0),'99999999.9999999'),
-TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.vn)) OVER(order by cf_olap_windowerr_sale.cn asc),0),'99999999.9999999')
-FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
-WINDOW win1 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc,cf_olap_windowerr_sale.pn desc rows between unbounded preceding and 2 preceding ),
-win2 as (order by cf_olap_windowerr_sale.vn desc),
-win3 as (order by cf_olap_windowerr_sale.cn asc);
--- start_ignore
-reset optimizer;
--- end_ignore
-
 -- MAX() function with partition by and order by having rows based framing clause --
 
 SELECT cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.cn/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999')
@@ -2580,27 +2560,6 @@ SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sal
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn AND cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc rows unbounded preceding );
 
--- REGR_INTERCEPT() function with ONLY order by having rows based framing clause in combination with other functions --
-
--- start_ignore
--- GPDB_84_MERGE_FIXME:  GPORCA wrong results
-set optimizer = off;
--- end_ignore
-SELECT cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(REGR_INTERCEPT(floor(cf_olap_windowerr_sale.vn),floor(cf_olap_windowerr_sale.qty+cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),
-TO_CHAR(COALESCE(LAG(cast(floor(cf_olap_windowerr_sale.cn+cf_olap_windowerr_sale.cn) as int),cast (floor(cf_olap_windowerr_sale.pn-cf_olap_windowerr_sale.prc) as int),NULL) OVER(win2),0),'99999999.9999999'),cf_olap_windowerr_sale.vn,
-TO_CHAR(COALESCE(ROW_NUMBER() OVER(win2),0),'99999999.9999999'),
-TO_CHAR(COALESCE(ROW_NUMBER() OVER(win3),0),'99999999.9999999'),cf_olap_windowerr_sale.dt,
-TO_CHAR(COALESCE(RANK() OVER(win4),0),'99999999.9999999')
-FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
-WINDOW win1 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc rows floor(cf_olap_windowerr_sale.qty) preceding ),
-win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc),
-win3 as (partition by cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.pn desc),
-win4 as (partition by cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.vn desc);
-
--- start_ignore
-reset optimizer;
--- end_ignore
-
 -- REGR_INTERCEPT() function with ONLY order by having rows based framing clause --
 
 SELECT cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(REGR_INTERCEPT(floor(cf_olap_windowerr_sale.pn*cf_olap_windowerr_sale.vn),floor(cf_olap_windowerr_sale.qty/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999')
@@ -2949,37 +2908,6 @@ SELECT cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.prc,cf_olap_windowerr_s
 TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.qty/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn ) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc rows between 4 preceding and 4 following );
-
--- REGR_R2() function with partition by and order by having rows based framing clause in combination with other functions --
-
-SELECT cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(REGR_R2(floor(cf_olap_windowerr_sale.vn+cf_olap_windowerr_sale.qty),floor(cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn,
-TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.pn*cf_olap_windowerr_sale.qty)) OVER(win1),0),'99999999.9999999'),
-TO_CHAR(COALESCE(LAG(cast(floor(cf_olap_windowerr_sale.pn-cf_olap_windowerr_sale.pn) as int),cast (floor(cf_olap_windowerr_sale.vn-cf_olap_windowerr_sale.prc) as int),NULL) OVER(win2),0),'99999999.9999999'),
-TO_CHAR(COALESCE(LAG(cast(floor(cf_olap_windowerr_sale.pn) as int),cast (floor(cf_olap_windowerr_sale.qty-cf_olap_windowerr_sale.prc) as int),NULL) OVER(win3),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn,
-TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.qty+cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999'),
-TO_CHAR(COALESCE(COUNT(floor(cf_olap_windowerr_sale.qty*cf_olap_windowerr_sale.vn)) OVER(partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc rows between 3 preceding and unbounded following ),0),'99999999.9999999')
-FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
-WINDOW win1 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc rows between 3 preceding and unbounded following ),
-win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc),
-win3 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc);
-
--- REGR_SLOPE() function with ONLY order by having range based framing clause in combination with other functions --
-
--- start_ignore
--- GPDB_84_MERGE_FIXME:  GPORCA wrong results
-set optimizer = off;
--- end_ignore
-SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(REGR_SLOPE(floor(cf_olap_windowerr_sale.prc/cf_olap_windowerr_sale.cn),floor(cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.pn,
-TO_CHAR(COALESCE(ROW_NUMBER() OVER(win2),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.qty,
-TO_CHAR(COALESCE(LAG(cast(floor(cf_olap_windowerr_sale.qty) as int),cast (floor(cf_olap_windowerr_sale.cn-cf_olap_windowerr_sale.pn) as int),NULL) OVER(win3),0),'99999999.9999999'),cf_olap_windowerr_sale.dt,
-TO_CHAR(COALESCE(ROW_NUMBER() OVER(partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc),0),'99999999.9999999')
-FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn ) cf_olap_windowerr_sale
-WINDOW win1 as (order by cf_olap_windowerr_sale.pn desc range unbounded preceding ),
-win2 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.vn asc),
-win3 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc);
--- start_ignore
-reset optimizer;
--- end_ignore
 
 -- REGR_SLOPE() function with ONLY order by having range based framing clause in combination with other functions --
 

--- a/src/test/regress/sql/qp_olap_windowerr.sql
+++ b/src/test/regress/sql/qp_olap_windowerr.sql
@@ -2,8 +2,6 @@
 -- STANDARD DATA FOR olap_* TESTS.
 --
 -- start_ignore
--- GPDB_84_MERGE_FIXME
-set optimizer to off;
 
 drop table cf_olap_windowerr_customer;
 drop table cf_olap_windowerr_vendor;
@@ -150,11 +148,6 @@ SELECT cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sal
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
 WINDOW win1 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc);
 
--- start_ignore
--- GPDB_84_MERGE_FIXME:  GPORCA produces incorrect plan causing executor error
--- Refer QP tracker story #153039698
--- Re-enable GPORCA once issue is fixed
--- end_ignore
 -- COUNT() function with ONLY order by having range based framing clause in combination with other functions --
 
 SELECT cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.prc, TO_CHAR(COALESCE(COUNT(floor(cf_olap_windowerr_sale.prc/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,
@@ -244,11 +237,6 @@ win3 as (partition by cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.
 win4 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc),
 win5 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc);
 
--- start_ignore
--- GPDB_84_MERGE_FIXME:  GPORCA produces incorrect plan causing executor error
--- Refer QP tracker story #153039698
--- Re-enable GPORCA once issue is fixed
--- end_ignore
 -- COUNT() function with partition by and order by having range based framing clause in combination with other functions--
 
 SELECT cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(COUNT(floor(cf_olap_windowerr_sale.vn/cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.cn,
@@ -299,11 +287,6 @@ win2 as (partition by cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.
 win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc),
 win4 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc);
 
--- start_ignore
--- GPDB_84_MERGE_FIXME:  GPORCA produces incorrect plan causing executor error
--- Refer QP tracker story #153039698
--- Re-enable GPORCA once issue is fixed
--- end_ignore
 -- MAX() function with ONLY order by having range based framing clause in combination with other functions --
 
 SELECT cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),
@@ -370,11 +353,6 @@ WINDOW win1 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn a
 win2 as (partition by cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc),
 win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc);
 
--- start_ignore
--- GPDB_84_MERGE_FIXME:  GPORCA produces incorrect plan causing executor error
--- Refer QP tracker story #153039698
--- Re-enable GPORCA once issue is fixed
--- end_ignore
 -- MAX() function with partition by and order by having range based framing clause in combination with other functions--
 
 SELECT cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,
@@ -389,14 +367,12 @@ win2 as (partition by cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale
 win3 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc),
 win4 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc);
 
--- start_ignore
--- GPDB_84_MERGE_FIXME: GPORCA does not support queries with percent_rank(). It
--- should fall back to planner.
--- Tracker Story: #153076325
--- Re-enable ORCA once the issue is fixed.
--- end_ignore
 -- MAX() function with partition by and order by having rows based framing clause in combination with other functions --
 
+-- start_ignore
+-- GPDB_84_MERGE_FIXME:  GPORCA wrong results
+set optimizer = off;
+-- end_ignore
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.prc/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,
 TO_CHAR(COALESCE(PERCENT_RANK() OVER(win2),0),'99999999.9999999'),
 TO_CHAR(COALESCE(DENSE_RANK() OVER(win3),0),'99999999.9999999'),
@@ -407,6 +383,9 @@ FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_ol
 WINDOW win1 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc,cf_olap_windowerr_sale.pn desc rows between unbounded preceding and 2 preceding ),
 win2 as (order by cf_olap_windowerr_sale.vn desc),
 win3 as (order by cf_olap_windowerr_sale.cn asc);
+-- start_ignore
+reset optimizer;
+-- end_ignore
 
 -- MAX() function with partition by and order by having rows based framing clause --
 
@@ -414,13 +393,6 @@ SELECT cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sal
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc rows between 7 preceding and unbounded following );
 
--- start_ignore
--- GPDB_84_MERGE_FIXME: GPORCA does not support queries with percent_rank(). It
--- should fall back to planner.
--- Tracker Story: #153076325
--- Re-enable ORCA once the issue is fixed.
-
--- end_ignore
 -- MAX() function with partition by and order by having rows based framing clause in combination with other functions --
 
 SELECT cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.qty+cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,
@@ -452,11 +424,6 @@ WINDOW win1 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.v
 win2 as (order by cf_olap_windowerr_sale.vn desc),
 win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc);
 
--- start_ignore
--- GPDB_84_MERGE_FIXME:  GPORCA produces incorrect plan causing wrong results
--- Refer QP tracker story #153077397
--- Re-enable GPORCA once issue is fixed
--- end_ignore
 -- MIN() function with NULL OVER() clause in combination with other window functions --
 
 SELECT cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.pn+cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999')
@@ -473,11 +440,6 @@ SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(MI
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.pn);
 
--- start_ignore
--- GPDB_84_MERGE_FIXME:  GPORCA produces incorrect plan causing executor error
--- Refer QP tracker story #153039698
--- Re-enable GPORCA once issue is fixed
--- end_ignore
 -- MIN() function with ONLY order by having range based framing clause in combination with other functions --
 
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.pn, TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,
@@ -523,11 +485,6 @@ SELECT cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sa
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn ) cf_olap_windowerr_sale
 WINDOW win1 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc rows current row );
 
--- start_ignore
--- GPDB_84_MERGE_FIXME:  GPORCA produces incorrect plan causing wrong results
--- Refer QP tracker story #153077397
--- Re-enable GPORCA once issue is fixed
--- end_ignore
 -- MIN() function with ONLY order by having rows based framing clause in combination with other functions --
 
 SELECT cf_olap_windowerr_sale.dt, TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,
@@ -564,10 +521,6 @@ win2 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_ola
 win3 as (order by cf_olap_windowerr_sale.vn asc),
 win4 as (order by cf_olap_windowerr_sale.cn asc);
 
--- start_ignore
--- GPDB_84_MERGE_FIXME:  GPORCA produces incorrect plan causing wrong results
--- Re-enable GPORCA once issue is fixed
--- end_ignore
 -- MIN() function with partition by and order by having range based framing clause in combination with other functions--
 
 SELECT cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.pn/cf_olap_windowerr_sale.qty)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty,
@@ -577,11 +530,6 @@ FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_ola
 WINDOW win1 as (partition by cf_olap_windowerr_sale.qty order by cf_olap_windowerr_sale.cn desc range unbounded preceding ),
 win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc);
 
--- start_ignore
--- GPDB_84_MERGE_FIXME:  GPORCA produces incorrect plan causing executor error
--- Refer QP tracker story #153039698
--- Re-enable GPORCA once issue is fixed
--- end_ignore
 -- MIN() function with partition by and order by having range based framing clause in combination with other functions--
 
 SELECT cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.pn+cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn,
@@ -590,10 +538,6 @@ FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_ola
 WINDOW win1 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.cn desc range between floor(cf_olap_windowerr_sale.prc-cf_olap_windowerr_sale.cn) preceding and floor(cf_olap_windowerr_sale.pn*cf_olap_windowerr_sale.prc) preceding );
 
 
--- start_ignore
--- GPDB_84_MERGE_FIXME:  GPORCA produces incorrect plan causing wrong results
--- Re-enable GPORCA once issue is fixed
--- end_ignore
 -- MIN() function with partition by and order by having rows based framing clause in combination with other functions --
 
 SELECT cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.vn+cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,
@@ -628,13 +572,6 @@ SELECT cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn, TO_CHAR(COALESCE(MIN
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc rows between current row and floor(cf_olap_windowerr_sale.cn/cf_olap_windowerr_sale.prc) following );
 
--- start_ignore
--- GPDB_84_MERGE_FIXME: GPORCA does not support queries with percent_rank(). It
--- should fall back to planner.
--- Tracker Story: #153076325
--- Re-enable ORCA once the issue is fixed.
-
--- end_ignore
 -- MIN() function with partition by and order by having rows based framing clause in combination with other functions --
 
 SELECT cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,
@@ -652,11 +589,6 @@ SELECT cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sa
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
 WINDOW win1 as (order by cf_olap_windowerr_sale.pn desc range unbounded preceding );
 
--- start_ignore
--- GPDB_84_MERGE_FIXME:  GPORCA produces incorrect plan causing executor error
--- Refer QP tracker story #153039698
--- Re-enable GPORCA once issue is fixed
--- end_ignore
 -- STDDEV() function with ONLY order by having range based framing clause --
 
 SELECT cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.prc, TO_CHAR(COALESCE(STDDEV(floor(cf_olap_windowerr_sale.qty)) OVER(win1),0),'99999999.9999999')
@@ -677,11 +609,6 @@ win2 as (order by cf_olap_windowerr_sale.pn asc),
 win3 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.pn asc),
 win4 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.cn desc);
 
--- start_ignore
--- GPDB_84_MERGE_FIXME:  GPORCA produces incorrect plan causing executor error
--- Refer QP tracker story #153039698
--- Re-enable GPORCA once issue is fixed
--- end_ignore
 -- STDDEV() function with ONLY order by having range based framing clause --
 
 SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(STDDEV(floor(cf_olap_windowerr_sale.prc-cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999')
@@ -735,11 +662,6 @@ WINDOW win1 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn
 win2 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc),
 win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc);
 
--- start_ignore
--- GPDB_84_MERGE_FIXME:  GPORCA produces incorrect plan causing executor error
--- Refer QP tracker story #153039698
--- Re-enable GPORCA once issue is fixed
--- end_ignore
 -- STDDEV() function with partition by and order by having range based framing clause --
 
 SELECT cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn, TO_CHAR(COALESCE(STDDEV(floor(cf_olap_windowerr_sale.qty/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn
@@ -799,11 +721,6 @@ WINDOW win1 as (order by cf_olap_windowerr_sale.pn desc range between unbounded 
 win2 as (partition by cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.vn asc),
 win3 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc);
 
--- start_ignore
--- GPDB_84_MERGE_FIXME:  GPORCA produces incorrect plan causing executor error
--- Refer QP tracker story #153039698
--- Re-enable GPORCA once issue is fixed
--- end_ignore
 -- STDDEV_POP() function with ONLY order by having range based framing clause --
 
 SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn, TO_CHAR(COALESCE(STDDEV_POP(floor(cf_olap_windowerr_sale.qty+cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999')
@@ -832,11 +749,6 @@ win2 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_ola
 win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc),
 win4 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.cn desc);
 
--- start_ignore
--- GPDB_84_MERGE_FIXME:  GPORCA produces incorrect plan causing executor error
--- Refer QP tracker story #153039698
--- Re-enable GPORCA once issue is fixed
--- end_ignore
 -- STDDEV_POP() function with partition by and order by having range based framing clause --
 
 SELECT cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(STDDEV_POP(floor(cf_olap_windowerr_sale.vn-cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn
@@ -888,11 +800,6 @@ win2 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_ola
 win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc),
 win4 as (order by cf_olap_windowerr_sale.pn desc);
 
--- start_ignore
--- GPDB_84_MERGE_FIXME:  GPORCA produces incorrect plan causing executor error
--- Refer QP tracker story #153039698
--- Re-enable GPORCA once issue is fixed
--- end_ignore
 -- STDDEV_SAMP() function with NULL OVER() clause in combination with other window functions --
 
 SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(STDDEV_SAMP(floor(cf_olap_windowerr_sale.prc*cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999')
@@ -930,11 +837,6 @@ TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.prc+cf_olap_windowerr_sale.vn)
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn ) cf_olap_windowerr_sale
 WINDOW win1 as (order by cf_olap_windowerr_sale.cn asc range between current row and current row );
 
--- start_ignore
--- GPDB_84_MERGE_FIXME:  GPORCA produces incorrect plan causing executor error
--- Refer QP tracker story #153039698
--- Re-enable GPORCA once issue is fixed
--- end_ignore
 -- STDDEV_SAMP() function with ONLY order by having range based framing clause in combination with other functions --
 
 SELECT cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.prc, TO_CHAR(COALESCE(STDDEV_SAMP(floor(cf_olap_windowerr_sale.prc-cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,
@@ -955,13 +857,6 @@ SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(STD
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
 WINDOW win1 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc rows floor(cf_olap_windowerr_sale.vn-cf_olap_windowerr_sale.vn) preceding );
 
--- start_ignore
--- GPDB_84_MERGE_FIXME: GPORCA does not support queries with percent_rank(). It
--- should fall back to planner.
--- Tracker Story: #153076325
--- Re-enable ORCA once the issue is fixed.
-
--- end_ignore
 -- STDDEV_SAMP() function with ONLY order by having rows based framing clause in combination with other functions --
 
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.dt, TO_CHAR(COALESCE(STDDEV_SAMP(floor(cf_olap_windowerr_sale.qty-cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),
@@ -985,11 +880,6 @@ SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.qty,cf_olap_windowerr_s
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
 WINDOW win1 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc rows between 7 following and floor(cf_olap_windowerr_sale.vn) following );
 
--- start_ignore
--- GPDB_84_MERGE_FIXME:  GPORCA produces incorrect plan causing wrong results
--- Refer QP tracker story #153077397
--- Re-enable GPORCA once issue is fixed
--- end_ignore
 -- STDDEV_SAMP() function with OVER() clause having PARTITION BY and ORDER BY (without framing) in combination with other window functions --
 
 SELECT cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(STDDEV_SAMP(floor(cf_olap_windowerr_sale.pn-cf_olap_windowerr_sale.qty)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn
@@ -1001,12 +891,6 @@ FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_ol
 WINDOW win1 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.cn asc,cf_olap_windowerr_sale.cn asc,cf_olap_windowerr_sale.vn asc),
 win2 as (partition by cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc);
 
--- start_ignore
--- GPDB_84_MERGE_FIXME: GPORCA does not support queries with percent_rank(),
--- cum_dist(). It should fall back to planner.
--- Tracker Story: #153076325
--- Re-enable ORCA once the issue is fixed.
--- end_ignore
 -- STDDEV_SAMP() function with partition by and order by having range based framing clause in combination with other functions--
 
 SELECT cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.prc, TO_CHAR(COALESCE(STDDEV_SAMP(floor(cf_olap_windowerr_sale.prc-cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),
@@ -2698,6 +2582,10 @@ WINDOW win1 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn d
 
 -- REGR_INTERCEPT() function with ONLY order by having rows based framing clause in combination with other functions --
 
+-- start_ignore
+-- GPDB_84_MERGE_FIXME:  GPORCA wrong results
+set optimizer = off;
+-- end_ignore
 SELECT cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(REGR_INTERCEPT(floor(cf_olap_windowerr_sale.vn),floor(cf_olap_windowerr_sale.qty+cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),
 TO_CHAR(COALESCE(LAG(cast(floor(cf_olap_windowerr_sale.cn+cf_olap_windowerr_sale.cn) as int),cast (floor(cf_olap_windowerr_sale.pn-cf_olap_windowerr_sale.prc) as int),NULL) OVER(win2),0),'99999999.9999999'),cf_olap_windowerr_sale.vn,
 TO_CHAR(COALESCE(ROW_NUMBER() OVER(win2),0),'99999999.9999999'),
@@ -2708,6 +2596,10 @@ WINDOW win1 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn a
 win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc),
 win3 as (partition by cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.pn desc),
 win4 as (partition by cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.vn desc);
+
+-- start_ignore
+reset optimizer;
+-- end_ignore
 
 -- REGR_INTERCEPT() function with ONLY order by having rows based framing clause --
 
@@ -3073,6 +2965,10 @@ win3 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.dt,cf_ola
 
 -- REGR_SLOPE() function with ONLY order by having range based framing clause in combination with other functions --
 
+-- start_ignore
+-- GPDB_84_MERGE_FIXME:  GPORCA wrong results
+set optimizer = off;
+-- end_ignore
 SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(REGR_SLOPE(floor(cf_olap_windowerr_sale.prc/cf_olap_windowerr_sale.cn),floor(cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.pn,
 TO_CHAR(COALESCE(ROW_NUMBER() OVER(win2),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.qty,
 TO_CHAR(COALESCE(LAG(cast(floor(cf_olap_windowerr_sale.qty) as int),cast (floor(cf_olap_windowerr_sale.cn-cf_olap_windowerr_sale.pn) as int),NULL) OVER(win3),0),'99999999.9999999'),cf_olap_windowerr_sale.dt,
@@ -3081,6 +2977,9 @@ FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_ola
 WINDOW win1 as (order by cf_olap_windowerr_sale.pn desc range unbounded preceding ),
 win2 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.vn asc),
 win3 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc);
+-- start_ignore
+reset optimizer;
+-- end_ignore
 
 -- REGR_SLOPE() function with ONLY order by having range based framing clause in combination with other functions --
 


### PR DESCRIPTION
The OID changed in GPDB 6. Opened a PR inside GPORCA to remove all hardcoded stuff.