### PR TITLE
Fix DQA translator due to changes brought in by Postgres 8.4 merge

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -1156,6 +1156,22 @@ gpdb::OidEqualityOpForOrderingOp
 	return InvalidOid;
 }
 
+Oid
+gpdb::OidOrderingOpForEqualityOp
+(
+	Oid opno,
+	bool *reverse
+	)
+{
+	GP_WRAP_START;
+	{
+		/* catalog tables: pg_amop */
+		return get_ordering_op_for_equality_op(opno, reverse);
+	}
+	GP_WRAP_END;
+	return InvalidOid;
+}
+
 char *
 gpdb::SzFuncName
 	(

--- a/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
@@ -1298,6 +1298,7 @@ CTranslatorScalarToDXL::PdxlnScAggrefFromAggref
 {
 	GPOS_ASSERT(IsA(pexpr, Aggref));
 	const Aggref *paggref = (Aggref *) pexpr;
+	BOOL aggDistinct = false;
 
 	static ULONG rgrgulMapping[][2] =
 		{
@@ -1317,12 +1318,9 @@ CTranslatorScalarToDXL::PdxlnScAggrefFromAggref
 		);
 	}
 
-	// FIXME: ORCA should keep the list of SortGroupClause objects for an Aggref
 	if (paggref->aggdistinct)
 	{
-		GPOS_RAISE(gpdxl::ExmaDXL,
-				   gpdxl::ExmiPlStmt2DXLConversion,
-				   GPOS_WSZ_LIT("Distinct aggregates"));
+		aggDistinct = true;
 	}
 
 	EdxlAggrefStage edxlaggstage = EdxlaggstageSentinel;
@@ -1363,7 +1361,7 @@ CTranslatorScalarToDXL::PdxlnScAggrefFromAggref
 		pmdidResolvedRetType = GPOS_NEW(m_pmp) CMDIdGPDB(paggref->aggtype);
 	}
 
-	CDXLScalarAggref *pdxlopAggref = GPOS_NEW(m_pmp) CDXLScalarAggref(m_pmp, pmdidAgg, pmdidResolvedRetType, paggref->aggdistinct, edxlaggstage);
+	CDXLScalarAggref *pdxlopAggref = GPOS_NEW(m_pmp) CDXLScalarAggref(m_pmp, pmdidAgg, pmdidResolvedRetType, aggDistinct, edxlaggstage);
 
 	// create the DXL node holding the scalar aggref
 	CDXLNode *pdxln = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlopAggref);

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -259,6 +259,9 @@ namespace gpdb {
 
 	// get equality operator for given ordering op (i.e. < or >)
 	Oid OidEqualityOpForOrderingOp(Oid opno, bool *reverse);
+	
+	// get ordering operator for given equality op (i.e. =)
+	Oid OidOrderingOpForEqualityOp(Oid opno, bool *reverse);
 
 	// function name
 	char *SzFuncName(Oid funcid);

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -205,7 +205,6 @@ SELECT count(four) AS cnt_1000 FROM onek;
 (1 row)
 
 SELECT count(DISTINCT four) AS cnt_4 FROM onek;
-INFO:  GPORCA failed to produce a plan, falling back to planner
  cnt_4 
 -------
      4
@@ -229,7 +228,6 @@ group by ten order by ten;
 
 select ten, count(four), sum(DISTINCT four) from onek
 group by ten order by ten;
-INFO:  GPORCA failed to produce a plan, falling back to planner
  ten | count | sum 
 -----+-------+-----
    0 |   100 |   2
@@ -288,7 +286,6 @@ CONTEXT:  SQL function "sum3" during startup
 select ten, sum(distinct four) from onek a
 group by ten
 having exists (select 1 from onek b where sum(distinct a.four) = b.four);
-INFO:  GPORCA failed to produce a plan, falling back to planner
  ten | sum 
 -----+-----
    2 |   2
@@ -592,7 +589,6 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 
 select array_agg(distinct a)
   from (values (1),(2),(1),(3),(null),(2)) v(a);
-INFO:  GPORCA failed to produce a plan, falling back to planner
   array_agg   
 --------------
  {1,2,3,NULL}
@@ -645,7 +641,6 @@ select aggfstr(distinct a,b,c)
   from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
        generate_series(1,3) i;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-INFO:  GPORCA failed to produce a plan, falling back to planner
 CONTEXT:  SQL function "aggf_trans" during startup
                 aggfstr                
 ---------------------------------------
@@ -655,7 +650,6 @@ CONTEXT:  SQL function "aggf_trans" during startup
 select aggfns(distinct a,b,c)
   from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
        generate_series(1,3) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
 INFO:  GPORCA failed to produce a plan, falling back to planner
 CONTEXT:  SQL function "aggfns_trans" during startup
                     aggfns                     

--- a/src/test/regress/expected/eagerfree_optimizer.out
+++ b/src/test/regress/expected/eagerfree_optimizer.out
@@ -123,16 +123,35 @@ select count(distinct d) from smallt;
 (1 row)
 
 explain analyze select count(distinct d) from smallt;
-                                                                   QUERY PLAN                                                                   
-------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=8.51..8.52 rows=1 width=8)
-   Rows out:  1 rows with 0.597 ms to end, start offset by 0.224 ms.
-   Executor memory:  33K bytes.
-   Work_mem used:  33K bytes.
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..8.00 rows=100 width=4)
-         Rows out:  100 rows at destination with 0.406 ms to first row, 0.502 ms to end, start offset by 0.224 ms.
-         ->  Seq Scan on smallt  (cost=0.00..4.00 rows=34 width=4)
-               Rows out:  Avg 33.3 rows x 3 workers.  Max 50 rows (seg1) with 0.013 ms to first row, 0.052 ms to end, start offset by 0.491 ms.
+                                                                                  QUERY PLAN                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..431.01 rows=1 width=8)
+   Rows out:  1 rows with 1.951 ms to end, start offset by 0.282 ms.
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.01 rows=20 width=4)
+         Rows out:  20 rows at destination with 1.917 ms to first row, 1.937 ms to end, start offset by 0.283 ms.
+         ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=4)
+               Group By: d
+               Rows out:  Avg 6.7 rows x 3 workers.  Max 9 rows (seg2) with 1.617 ms to first row, 1.626 ms to end, start offset by 0.503 ms.
+               ->  Sort  (cost=0.00..431.01 rows=7 width=4)
+                     Sort Key: d
+                     Sort Method:  quicksort  Max Memory: 33KB  Avg Memory: 33KB (3 segments)
+                     Rows out:  Avg 6.7 rows x 3 workers.  Max 9 rows (seg2) with 1.613 ms to end, start offset by 0.503 ms.
+                     Executor memory:  33K bytes avg, 33K bytes max (seg0).
+                     Work_mem used:  33K bytes avg, 33K bytes max (seg0). Workfile: (0 spilling)
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.01 rows=7 width=4)
+                           Hash Key: d
+                           Rows out:  Avg 6.7 rows x 3 workers at destination.  Max 9 rows (seg2) with 0.494 ms to first row, 1.584 ms to end, start offset by 0.518 ms.
+                           ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=4)
+                                 Group By: d
+                                 Rows out:  Avg 6.7 rows x 3 workers.  Max 10 rows (seg1) with 0.089 ms to first row, 0.108 ms to end, start offset by 1.907 ms.
+                                 ->  Sort  (cost=0.00..431.00 rows=34 width=4)
+                                       Sort Key: d
+                                       Sort Method:  quicksort  Max Memory: 33KB  Avg Memory: 33KB (3 segments)
+                                       Rows out:  Avg 33.3 rows x 3 workers.  Max 50 rows (seg1) with 0.085 ms to first row, 0.094 ms to end, start offset by 1.907 ms.
+                                       Executor memory:  33K bytes avg, 33K bytes max (seg0).
+                                       Work_mem used:  33K bytes avg, 33K bytes max (seg0). Workfile: (0 spilling)
+                                       ->  Table Scan on smallt  (cost=0.00..431.00 rows=34 width=4)
+                                             Rows out:  Avg 33.3 rows x 3 workers.  Max 50 rows (seg1) with 0.026 ms to first row, 0.039 ms to end, start offset by 1.927 ms.
  Slice statistics:
    (slice0)    Executor memory: 322K bytes.  Work_mem: 33K bytes max.
    (slice1)    Executor memory: 135K bytes avg x 3 workers, 135K bytes max (seg0).
@@ -151,17 +170,27 @@ select count(distinct d) from bigt;
 (1 row)
 
 explain analyze select count(distinct d) from bigt;
-                                                                      QUERY PLAN                                                                      
-------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=56631.65..56631.66 rows=1 width=8)
-   Rows out:  1 rows with 3654 ms to end, start offset by 0.314 ms.
-   Executor memory:  2649K bytes.
-   Work_mem used:  2649K bytes.
-   Work_mem wanted: 23514K bytes to lessen workfile I/O.
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..51627.95 rows=1000739 width=4)
-         Rows out:  1000000 rows at destination with 1.670 ms to first row, 942 ms to end, start offset by 0.315 ms.
-         ->  Seq Scan on bigt  (cost=0.00..11598.39 rows=333580 width=4)
-               Rows out:  Avg 333333.3 rows x 3 workers.  Max 333490 rows (seg0) with 0.034 ms to first row, 120 ms to end, start offset by 0.570 ms.
+                                                                               QUERY PLAN                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..485.83 rows=1 width=8)
+   Rows out:  1 rows with 374 ms to end, start offset by 0.268 ms.
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..485.81 rows=49200 width=4)
+         Rows out:  50000 rows at destination with 333 ms to first row, 365 ms to end, start offset by 0.269 ms.
+         ->  HashAggregate  (cost=0.00..485.08 rows=16400 width=4)
+               Group By: d
+               Rows out:  Avg 16666.7 rows x 3 workers.  Max 16693 rows (seg2) with 332 ms to first row, 335 ms to end, start offset by 0.482 ms.
+               Executor memory:  713K bytes avg, 713K bytes max (seg0).
+               (seg2)   Hash chain length 4.2 avg, 13 max, using 4016 of 4096 buckets; total 7 expansions.
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..483.07 rows=16400 width=4)
+                     Hash Key: d
+                     Rows out:  Avg 27809.3 rows x 3 workers at destination.  Max 27884 rows (seg2) with 291 ms to first row, 318 ms to end, start offset by 0.487 ms.
+                     ->  HashAggregate  (cost=0.00..482.86 rows=16400 width=4)
+                           Group By: d
+                           Rows out:  Avg 27809.3 rows x 3 workers.  Max 27828 rows (seg0) with 291 ms to first row, 300 ms to end, start offset by 0.632 ms.
+                           Executor memory:  1098K bytes avg, 1098K bytes max (seg0).
+                           (seg0)   Hash chain length 3.5 avg, 11 max, using 7903 of 8192 buckets; total 8 expansions.
+                           ->  Table Scan on bigt  (cost=0.00..439.81 rows=333580 width=4)
+                                 Rows out:  Avg 333333.3 rows x 3 workers.  Max 333490 rows (seg0) with 0.046 ms to first row, 211 ms to end, start offset by 0.637 ms.
  Slice statistics:
    (slice0)  * Executor memory: 3047K bytes.  Work_mem: 2649K bytes max, 23514K bytes wanted.
    (slice1)    Executor memory: 159K bytes avg x 3 workers, 159K bytes max (seg0).

--- a/src/test/regress/expected/qp_misc_jiras_optimizer.out
+++ b/src/test/regress/expected/qp_misc_jiras_optimizer.out
@@ -3035,97 +3035,115 @@ reset enable_seqscan;
 reset gp_enable_agg_distinct; 
 reset gp_enable_agg_distinct_pruning;
 set enable_groupagg=off;
--- start_ignore
--- GPDB_84_MERGE_FIXME: GPORCA is falling back during Query to DXL translation
--- due to following error: GPDB Expression type: Distinct aggregates not supported in DXL
--- Tracker Story: #153040298
--- Re-enable ORCA once the issue is fixed.
-set optimizer=off;
--- end_ignore
 -- both queries should use hashagg
 explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.j = t2.j) tmp group by j;
-                                                        QUERY PLAN                                                        
---------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=1468508.37..1542655.47 rows=1000 width=12)
-   ->  GroupAggregate  (cost=1468508.37..1542655.47 rows=334 width=12)
-         Group By: t1.j
-         ->  Sort  (cost=1468508.37..1487041.40 rows=2471070 width=4)
-               Sort Key: t1.j
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=7633.75..249739.33 rows=2471070 width=4)
-                     Hash Key: t1.j
-                     ->  Hash Join  (cost=7633.75..101475.12 rows=2471070 width=4)
-                           Hash Cond: t1.j = t2.j
-                           ->  Seq Scan on tbl5994_test t1  (cost=0.00..961.00 rows=28700 width=4)
-                           ->  Hash  (cost=4405.00..4405.00 rows=86100 width=4)
-                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..4405.00 rows=86100 width=4)
-                                       ->  Seq Scan on tbl5994_test t2  (cost=0.00..961.00 rows=28700 width=4)
- Settings:  enable_groupagg=off; optimizer=off; optimizer_force_three_stage_scalar_dqa=off; optimizer_segments=3
- Optimizer status: legacy query optimizer
-(15 rows)
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+   ->  Result  (cost=0.00..862.00 rows=1 width=8)
+         ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=8)
+               Group By: qp_misc_jiras.tbl5994_test.j
+               ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
+                     Group By: qp_misc_jiras.tbl5994_test.j
+                     ->  Sort  (cost=0.00..862.00 rows=1 width=4)
+                           Sort Key: qp_misc_jiras.tbl5994_test.j
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+                                 Hash Key: qp_misc_jiras.tbl5994_test.j
+                                 ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
+                                       Group By: qp_misc_jiras.tbl5994_test.j
+                                       ->  Sort  (cost=0.00..862.00 rows=1 width=4)
+                                             Sort Key: qp_misc_jiras.tbl5994_test.j
+                                             ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+                                                   Hash Cond: qp_misc_jiras.tbl5994_test.j = qp_misc_jiras.tbl5994_test.j
+                                                   ->  Table Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
+                                                   ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                                               ->  Table Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
+ Settings:  enable_groupagg=off; optimizer_force_three_stage_scalar_dqa=off; optimizer_segments=3
+ Optimizer status: PQO version 2.51.1
+(22 rows)
 
 explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.i = t2.i) tmp group by j;
-                                                    QUERY PLAN                                                    
-------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=1462911.87..1537058.97 rows=1000 width=12)
-   ->  GroupAggregate  (cost=1462911.87..1537058.97 rows=334 width=12)
-         Group By: t1.j
-         ->  Sort  (cost=1462911.87..1481444.90 rows=2471070 width=4)
-               Sort Key: t1.j
-               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=2037.25..244142.83 rows=2471070 width=4)
-                     Hash Key: t1.j
-                     ->  Hash Join  (cost=2037.25..95878.62 rows=2471070 width=4)
-                           Hash Cond: t1.i = t2.i
-                           ->  Seq Scan on tbl5994_test t1  (cost=0.00..961.00 rows=28700 width=8)
-                           ->  Hash  (cost=961.00..961.00 rows=28700 width=4)
-                                 ->  Seq Scan on tbl5994_test t2  (cost=0.00..961.00 rows=28700 width=4)
- Settings:  enable_groupagg=off; optimizer=off; optimizer_force_three_stage_scalar_dqa=off; optimizer_segments=3
- Optimizer status: legacy query optimizer
-(14 rows)
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+   ->  Result  (cost=0.00..862.00 rows=1 width=8)
+         ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=8)
+               Group By: qp_misc_jiras.tbl5994_test.j
+               ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
+                     Group By: qp_misc_jiras.tbl5994_test.j
+                     ->  Sort  (cost=0.00..862.00 rows=1 width=4)
+                           Sort Key: qp_misc_jiras.tbl5994_test.j
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+                                 Hash Key: qp_misc_jiras.tbl5994_test.j
+                                 ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
+                                       Group By: qp_misc_jiras.tbl5994_test.j
+                                       ->  Sort  (cost=0.00..862.00 rows=1 width=4)
+                                             Sort Key: qp_misc_jiras.tbl5994_test.j
+                                             ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+                                                   Hash Cond: qp_misc_jiras.tbl5994_test.i = qp_misc_jiras.tbl5994_test.i
+                                                   ->  Table Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=8)
+                                                   ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                                         ->  Table Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
+ Settings:  enable_groupagg=off; optimizer_force_three_stage_scalar_dqa=off; optimizer_segments=3
+ Optimizer status: PQO version 2.51.1
+(21 rows)
 
 set enable_groupagg=on;
 -- first query should use groupagg, and second one - hashagg
 explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.j = t2.j) tmp group by j;
-                                                        QUERY PLAN                                                        
---------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=1468508.37..1542655.47 rows=1000 width=12)
-   ->  GroupAggregate  (cost=1468508.37..1542655.47 rows=334 width=12)
-         Group By: t1.j
-         ->  Sort  (cost=1468508.37..1487041.40 rows=2471070 width=4)
-               Sort Key: t1.j
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=7633.75..249739.33 rows=2471070 width=4)
-                     Hash Key: t1.j
-                     ->  Hash Join  (cost=7633.75..101475.12 rows=2471070 width=4)
-                           Hash Cond: t1.j = t2.j
-                           ->  Seq Scan on tbl5994_test t1  (cost=0.00..961.00 rows=28700 width=4)
-                           ->  Hash  (cost=4405.00..4405.00 rows=86100 width=4)
-                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..4405.00 rows=86100 width=4)
-                                       ->  Seq Scan on tbl5994_test t2  (cost=0.00..961.00 rows=28700 width=4)
- Settings:  enable_groupagg=on; optimizer=off; optimizer_force_three_stage_scalar_dqa=off; optimizer_segments=3
- Optimizer status: legacy query optimizer
-(15 rows)
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+   ->  Result  (cost=0.00..862.00 rows=1 width=8)
+         ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=8)
+               Group By: qp_misc_jiras.tbl5994_test.j
+               ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
+                     Group By: qp_misc_jiras.tbl5994_test.j
+                     ->  Sort  (cost=0.00..862.00 rows=1 width=4)
+                           Sort Key: qp_misc_jiras.tbl5994_test.j
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+                                 Hash Key: qp_misc_jiras.tbl5994_test.j
+                                 ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
+                                       Group By: qp_misc_jiras.tbl5994_test.j
+                                       ->  Sort  (cost=0.00..862.00 rows=1 width=4)
+                                             Sort Key: qp_misc_jiras.tbl5994_test.j
+                                             ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+                                                   Hash Cond: qp_misc_jiras.tbl5994_test.j = qp_misc_jiras.tbl5994_test.j
+                                                   ->  Table Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
+                                                   ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                                               ->  Table Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
+ Settings:  enable_groupagg=on; optimizer_force_three_stage_scalar_dqa=off; optimizer_segments=3
+ Optimizer status: PQO version 2.51.1
+(22 rows)
 
 explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.i = t2.i) tmp group by j;
-                                                    QUERY PLAN                                                    
-------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=1462911.87..1537058.97 rows=1000 width=12)
-   ->  GroupAggregate  (cost=1462911.87..1537058.97 rows=334 width=12)
-         Group By: t1.j
-         ->  Sort  (cost=1462911.87..1481444.90 rows=2471070 width=4)
-               Sort Key: t1.j
-               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=2037.25..244142.83 rows=2471070 width=4)
-                     Hash Key: t1.j
-                     ->  Hash Join  (cost=2037.25..95878.62 rows=2471070 width=4)
-                           Hash Cond: t1.i = t2.i
-                           ->  Seq Scan on tbl5994_test t1  (cost=0.00..961.00 rows=28700 width=8)
-                           ->  Hash  (cost=961.00..961.00 rows=28700 width=4)
-                                 ->  Seq Scan on tbl5994_test t2  (cost=0.00..961.00 rows=28700 width=4)
- Settings:  enable_groupagg=on; optimizer=off; optimizer_force_three_stage_scalar_dqa=off; optimizer_segments=3
- Optimizer status: legacy query optimizer
-(14 rows)
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+   ->  Result  (cost=0.00..862.00 rows=1 width=8)
+         ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=8)
+               Group By: qp_misc_jiras.tbl5994_test.j
+               ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
+                     Group By: qp_misc_jiras.tbl5994_test.j
+                     ->  Sort  (cost=0.00..862.00 rows=1 width=4)
+                           Sort Key: qp_misc_jiras.tbl5994_test.j
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+                                 Hash Key: qp_misc_jiras.tbl5994_test.j
+                                 ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
+                                       Group By: qp_misc_jiras.tbl5994_test.j
+                                       ->  Sort  (cost=0.00..862.00 rows=1 width=4)
+                                             Sort Key: qp_misc_jiras.tbl5994_test.j
+                                             ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+                                                   Hash Cond: qp_misc_jiras.tbl5994_test.i = qp_misc_jiras.tbl5994_test.i
+                                                   ->  Table Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=8)
+                                                   ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                                         ->  Table Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
+ Settings:  enable_groupagg=on; optimizer_force_three_stage_scalar_dqa=off; optimizer_segments=3
+ Optimizer status: PQO version 2.51.1
+(21 rows)
 
--- start_ignore
-reset optimizer;
--- end_ignore
 drop table qp_misc_jiras.tbl5994_test;
 CREATE TABLE qp_misc_jiras.tbl_8205 (
 text_col text,

--- a/src/test/regress/expected/qp_olap_group_optimizer.out
+++ b/src/test/regress/expected/qp_olap_group_optimizer.out
@@ -6015,29 +6015,28 @@ SELECT COUNT(DISTINCT cn) as cn_r, f, g FROM (SELECT cn, CASE WHEN (vn = 0) THEN
 SELECT COUNT(DISTINCT cn) as cn_r, f, g FROM (SELECT cn, vn + 1 AS f, 1 AS g FROM sale) sale_view GROUP BY ROLLUP(f,g) HAVING (f > 1);
  cn_r | f  | g 
 ------+----+---
-    1 | 11 | 1
     1 | 21 | 1
     2 | 31 | 1
     3 | 41 | 1
+    1 | 11 |  
+    1 | 11 | 1
+    2 | 31 |  
+    2 | 51 |  
     2 | 51 | 1
-(5 rows)
+    1 | 21 |  
+    3 | 41 |  
+(10 rows)
 
 PREPARE p AS SELECT COUNT(DISTINCT cn) as cn_r, f, g FROM (SELECT cn, vn + $1 AS f, $1 AS g FROM sale) sale_view GROUP BY ROLLUP(f,g) HAVING (g > 1);
 EXECUTE p(2);
  cn_r | f  | g 
 ------+----+---
-    1 | 12 | 2
-    1 | 22 | 2
     2 | 32 | 2
+    1 | 12 | 2
     3 | 42 | 2
     2 | 52 | 2
-    1 | 12 |  
-    1 | 22 |  
-    2 | 32 |  
-    3 | 42 |  
-    2 | 52 |  
-    4 |    |  
-(11 rows)
+    1 | 22 | 2
+(5 rows)
 
 -- ###### Queries involving CUBE with HAVING CLAUSE ###### --
 WITH src AS (SELECT 1 AS a, 1 AS b)

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -1646,63 +1646,95 @@ EXPLAIN select count(*) from
 EXPLAIN select count(distinct ss.ten) from
   (select ten from tenk1 a
    where unique1 IN (select hundred from tenk1 b)) ss;
-                                                     QUERY PLAN                                                      
----------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=1176.00..1176.01 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=414.79..1126.22 rows=9955 width=4)
-         ->  Hash Join  (cost=414.79..728.02 rows=3319 width=4)
-               Hash Cond: a.unique1 = b.hundred
-               ->  Seq Scan on tenk1 a  (cost=0.00..188.55 rows=3319 width=8)
-               ->  Hash  (cost=413.54..413.54 rows=34 width=4)
-                     ->  HashAggregate  (cost=412.54..413.54 rows=34 width=4)
-                           Group By: b.hundred
-                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..387.65 rows=3319 width=4)
-                                 Hash Key: b.hundred
-                                 ->  Seq Scan on tenk1 b  (cost=0.00..188.55 rows=3319 width=4)
- Settings:  optimizer=off
- Optimizer status: legacy query optimizer
-(13 rows)
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..632.01 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..632.01 rows=10 width=4)
+         ->  GroupAggregate  (cost=0.00..632.01 rows=4 width=4)
+               Group By: public.tenk1.ten
+               ->  Sort  (cost=0.00..632.01 rows=4 width=4)
+                     Sort Key: public.tenk1.ten
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..632.01 rows=4 width=4)
+                           Hash Key: public.tenk1.ten
+                           ->  GroupAggregate  (cost=0.00..632.01 rows=4 width=4)
+                                 Group By: public.tenk1.ten
+                                 ->  Sort  (cost=0.00..632.01 rows=34 width=4)
+                                       Sort Key: public.tenk1.ten
+                                       ->  Nested Loop  (cost=0.00..632.00 rows=34 width=4)
+                                             Join Filter: true
+                                             ->  GroupAggregate  (cost=0.00..431.96 rows=34 width=4)
+                                                   Group By: public.tenk1.hundred
+                                                   ->  Sort  (cost=0.00..431.96 rows=34 width=4)
+                                                         Sort Key: public.tenk1.hundred
+                                                         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.96 rows=34 width=4)
+                                                               Hash Key: public.tenk1.hundred
+                                                               ->  HashAggregate  (cost=0.00..431.96 rows=34 width=4)
+                                                                     Group By: public.tenk1.hundred
+                                                                     ->  Table Scan on tenk1  (cost=0.00..431.52 rows=3404 width=4)
+                                             ->  Index Scan using tenk1_unique1 on tenk1  (cost=0.00..200.04 rows=1 width=4)
+                                                   Index Cond: public.tenk1.unique1 = public.tenk1.hundred
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.51.1
+(27 rows)
 
 EXPLAIN select count(*) from
   (select 1 from tenk1 a
    where unique1 IN (select distinct hundred from tenk1 b)) ss;
-                                                        QUERY PLAN                                                         
----------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=752.98..752.99 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=752.91..752.96 rows=1 width=8)
-         ->  Aggregate  (cost=752.91..752.92 rows=1 width=8)
-               ->  Hash Join  (cost=414.79..728.02 rows=3319 width=0)
-                     Hash Cond: a.unique1 = b.hundred
-                     ->  Seq Scan on tenk1 a  (cost=0.00..188.55 rows=3319 width=4)
-                     ->  Hash  (cost=413.54..413.54 rows=34 width=4)
-                           ->  HashAggregate  (cost=412.54..413.54 rows=34 width=4)
-                                 Group By: b.hundred
-                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..387.65 rows=3319 width=4)
-                                       Hash Key: b.hundred
-                                       ->  Seq Scan on tenk1 b  (cost=0.00..188.55 rows=3319 width=4)
- Settings:  optimizer=off
- Optimizer status: legacy query optimizer
-(14 rows)
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..632.00 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..632.00 rows=1 width=8)
+         ->  Aggregate  (cost=0.00..632.00 rows=1 width=8)
+               ->  Nested Loop  (cost=0.00..632.00 rows=34 width=1)
+                     Join Filter: true
+                     ->  GroupAggregate  (cost=0.00..431.96 rows=34 width=4)
+                           Group By: public.tenk1.hundred
+                           ->  Sort  (cost=0.00..431.96 rows=34 width=4)
+                                 Sort Key: public.tenk1.hundred
+                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.96 rows=34 width=4)
+                                       Hash Key: public.tenk1.hundred
+                                       ->  HashAggregate  (cost=0.00..431.96 rows=34 width=4)
+                                             Group By: public.tenk1.hundred
+                                             ->  Table Scan on tenk1  (cost=0.00..431.52 rows=3404 width=4)
+                     ->  Index Scan using tenk1_unique1 on tenk1  (cost=0.00..200.04 rows=1 width=1)
+                           Index Cond: public.tenk1.unique1 = public.tenk1.hundred
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.51.1
+(18 rows)
 
 EXPLAIN select count(distinct ss.ten) from
   (select ten from tenk1 a
    where unique1 IN (select distinct hundred from tenk1 b)) ss;
-                                                     QUERY PLAN                                                      
----------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=1176.00..1176.01 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=414.79..1126.22 rows=9955 width=4)
-         ->  Hash Join  (cost=414.79..728.02 rows=3319 width=4)
-               Hash Cond: a.unique1 = b.hundred
-               ->  Seq Scan on tenk1 a  (cost=0.00..188.55 rows=3319 width=8)
-               ->  Hash  (cost=413.54..413.54 rows=34 width=4)
-                     ->  HashAggregate  (cost=412.54..413.54 rows=34 width=4)
-                           Group By: b.hundred
-                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..387.65 rows=3319 width=4)
-                                 Hash Key: b.hundred
-                                 ->  Seq Scan on tenk1 b  (cost=0.00..188.55 rows=3319 width=4)
- Settings:  optimizer=off
- Optimizer status: legacy query optimizer
-(13 rows)
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..632.01 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..632.01 rows=10 width=4)
+         ->  GroupAggregate  (cost=0.00..632.01 rows=4 width=4)
+               Group By: public.tenk1.ten
+               ->  Sort  (cost=0.00..632.01 rows=4 width=4)
+                     Sort Key: public.tenk1.ten
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..632.01 rows=4 width=4)
+                           Hash Key: public.tenk1.ten
+                           ->  GroupAggregate  (cost=0.00..632.01 rows=4 width=4)
+                                 Group By: public.tenk1.ten
+                                 ->  Sort  (cost=0.00..632.01 rows=34 width=4)
+                                       Sort Key: public.tenk1.ten
+                                       ->  Nested Loop  (cost=0.00..632.00 rows=34 width=4)
+                                             Join Filter: true
+                                             ->  GroupAggregate  (cost=0.00..431.96 rows=34 width=4)
+                                                   Group By: public.tenk1.hundred
+                                                   ->  Sort  (cost=0.00..431.96 rows=34 width=4)
+                                                         Sort Key: public.tenk1.hundred
+                                                         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.96 rows=34 width=4)
+                                                               Hash Key: public.tenk1.hundred
+                                                               ->  HashAggregate  (cost=0.00..431.96 rows=34 width=4)
+                                                                     Group By: public.tenk1.hundred
+                                                                     ->  Table Scan on tenk1  (cost=0.00..431.52 rows=3404 width=4)
+                                             ->  Index Scan using tenk1_unique1 on tenk1  (cost=0.00..200.04 rows=1 width=4)
+                                                   Index Cond: public.tenk1.unique1 = public.tenk1.hundred
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.51.1
+(27 rows)
 
 --
 -- In case of simple exists query, planner can generate alternative

--- a/src/test/regress/sql/eagerfree.sql
+++ b/src/test/regress/sql/eagerfree.sql
@@ -30,16 +30,10 @@ set statement_mem=128000;
 set gp_enable_agg_distinct=off;
 set gp_eager_one_phase_agg=on;
 select count(distinct d) from smallt;
--- start_ignore
--- GPDB_84_MERGE_FIXME: GPORCA fallback: GPDB Expression type: Distinct aggregates not supported in DXL
--- end_ignore
 explain analyze select count(distinct d) from smallt;
 
 set statement_mem=2560;
 select count(distinct d) from bigt;
--- start_ignore
--- GPDB_84_MERGE_FIXME: GPORCA fallback: GPDB Expression type: Distinct aggregates not supported in DXL
--- end_ignore
 explain analyze select count(distinct d) from bigt;
 set statement_mem=128000;
 

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -347,17 +347,9 @@ insert into orca.onek values (439,5,1,3,9,19,9,39,39,439,439,18,19,'XQAAAA','FAA
 insert into orca.onek values (670,6,0,2,0,10,0,70,70,170,670,0,1,'UZAAAA','GAAAAA','OOOOxx');
 insert into orca.onek values (543,7,1,3,3,3,3,43,143,43,543,6,7,'XUAAAA','HAAAAA','VVVVxx');
 
--- start_ignore
--- GPDB_84_MERGE_FIXME: GPORCA fallback: GPDB Expression type: Distinct aggregates not supported in DXL
--- Re-enable GPORCA once issue is fixed
-set optimizer=off;
--- end_ignore
 select ten, sum(distinct four) from orca.onek a
 group by ten 
 having exists (select 1 from orca.onek b where sum(distinct a.four) = b.four);
--- start_ignore
-reset optimizer;
--- end_ignore
 
 -- indexes on partitioned tables
 create table orca.pp(a int) partition by range(a)(partition pp1 start(1) end(10));
@@ -632,25 +624,9 @@ create table orca.tab1(a int, b int, c int, d int, e int);
 insert into orca.tab1 values (1,2,3,4,5);
 insert into orca.tab1 values (1,2,3,4,5);
 insert into orca.tab1 values (1,2,3,4,5);
--- start_ignore
--- GPDB_84_MERGE_FIXME: GPORCA fallback: GPDB Expression type: Distinct aggregates not supported in DXL
--- Re-enable GPORCA once issue is fixed
-set optimizer=off;
--- end_ignore
 select b,d from orca.tab1 group by b,d having min(distinct d)>3;
--- start_ignore
-reset optimizer;
--- end_ignore
 select b,d from orca.tab1 group by b,d having d>3;
--- start_ignore
--- GPDB_84_MERGE_FIXME: GPORCA fallback: GPDB Expression type: Distinct aggregates not supported in DXL
--- Re-enable GPORCA once issue is fixed
-set optimizer=off;
--- end_ignore
 select b,d from orca.tab1 group by b,d having min(distinct d)>b;
--- start_ignore
-reset optimizer;
--- end_ignore
 
 create table orca.fooh1 (a int, b int, c int);
 create table orca.fooh2 (a int, b int, c int);
@@ -1326,17 +1302,9 @@ insert into canSetTag_input_data values(1, 1, 'A', 1);
 insert into canSetTag_input_data values(2, 1, 'A', 0);
 insert into canSetTag_input_data values(3, 0, 'B', 1);
 
--- start_ignore
--- GPDB_84_MERGE_FIXME: GPORCA fallback: GPDB Expression type: Distinct aggregates not supported in DXL
--- Re-enable GPORCA once issue is fixed
-set optimizer=off;
--- end_ignore
 create table canSetTag_bug_table as 
 SELECT attr, class, (select canSetTag_Func(count(distinct class)::int) from canSetTag_input_data)
    as dclass FROM canSetTag_input_data GROUP BY attr, class distributed by (attr);
--- start_ignore
-reset optimizer;
--- end_ignore
 
 drop function canSetTag_Func(x int);
 drop table canSetTag_bug_table;

--- a/src/test/regress/sql/olap_group.sql
+++ b/src/test/regress/sql/olap_group.sql
@@ -59,10 +59,6 @@ select cn, vn, pn, sum(qty*prc) from sale group by cube (cn, vn, pn);
 select cn, vn, pn, sum(qty*prc) from sale group by grouping sets ((), (cn), (vn), (pn), (cn,vn), (cn,pn), (vn,pn), (cn,vn,pn));
 --end_equiv
 
--- start_ignore
--- GPDB_84_MERGE_FIXME: Revert this after supporting DQA in ORCA after window merge
-set optimizer = off;
--- end_ignore
 -- start_equiv
 select cn, vn, pn, count(distinct dt) from sale group by cn, vn, pn
 union all
@@ -95,9 +91,6 @@ order by 1,2,3; -- order 1,2,3
 select cn, vn, pn, count(distinct dt) from sale group by cube (cn, vn, pn) order by 1,2,3; -- order 1,2,3
 select cn, vn, pn, count(distinct dt) from sale group by grouping sets ((), (cn), (vn), (pn), (cn,vn), (cn,pn), (vn,pn), (cn,vn,pn)) order by 1,2,3; -- order 1,2,3
 --end_equiv
--- start_ignore
-reset optimizer;
--- end_ignore
 --start_equiv order 1,2,3
 select cn, vn, pn, sum(qty*prc) from sale group by cn, vn, pn
 union all

--- a/src/test/regress/sql/qp_misc_jiras.sql
+++ b/src/test/regress/sql/qp_misc_jiras.sql
@@ -1864,11 +1864,6 @@ reset gp_enable_agg_distinct_pruning;
 
 
 set enable_groupagg=off;
--- start_ignore
--- GPDB_84_MERGE_FIXME: GPORCA fallback: GPDB Expression type: Distinct aggregates not supported in DXL
--- Re-enable ORCA once the issue is fixed.
-set optimizer=off;
--- end_ignore
 -- both queries should use hashagg
 explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.j = t2.j) tmp group by j;
 explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.i = t2.i) tmp group by j;
@@ -1877,9 +1872,6 @@ set enable_groupagg=on;
 -- first query should use groupagg, and second one - hashagg
 explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.j = t2.j) tmp group by j;
 explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.i = t2.i) tmp group by j;
--- start_ignore
-reset optimizer;
--- end_ignore
 
 drop table qp_misc_jiras.tbl5994_test;
 CREATE TABLE qp_misc_jiras.tbl_8205 (

--- a/src/test/regress/sql/qp_olap_group.sql
+++ b/src/test/regress/sql/qp_olap_group.sql
@@ -61,20 +61,10 @@ WHERE sale.pn=product.pn
 GROUP BY ROLLUP((sale.vn),(sale.vn),(sale.qty)),sale.pn,sale.cn;
 
 -- ###### Queries involving COVAR_POP() function ###### --
--- start_ignore
--- GPDB_84_MERGE_FIXME: GPORCA is falling back during Query to DXL translation
--- due to following error: GPDB Expression type: Distinct aggregates not supported in DXL
--- Tracker Story: #153040298
--- Re-enable ORCA once the issue is fixed.
-set optimizer=off;
--- end_ignore
 SELECT DISTINCT sale.qty,sale.pn,GROUPING(sale.pn,sale.pn), TO_CHAR(COALESCE(COVAR_POP(floor(sale.prc-sale.prc),floor(sale.vn-sale.prc)),0),'99999999.9999999'),TO_CHAR(COALESCE(VAR_POP(floor(sale.qty+sale.vn)),0),'99999999.9999999'),TO_CHAR(COALESCE(STDDEV_SAMP(floor(sale.pn)),0),'99999999.9999999'),TO_CHAR(COALESCE(AVG(DISTINCT floor(sale.pn)),0),'99999999.9999999') 
 FROM sale,product
 WHERE sale.pn=product.pn
 GROUP BY (),sale.qty,sale.pn;
--- start_ignore
-reset optimizer;
--- end_ignore
 
 -- ###### Queries involving COVAR_SAMP() function ###### --
 
@@ -168,25 +158,9 @@ GROUP BY ROLLUP((sale.prc),(sale.prc,sale.vn),(sale.qty,sale.qty),(sale.vn)),GRO
 
 -- ###### Rollup with DQA and constants in target list expressions and qualifications with same value as that of constant grouping column ###### --
 SELECT COUNT(DISTINCT cn) as cn_r, f, g FROM (SELECT cn, CASE WHEN (vn = 0) THEN 1 END AS f, 1 AS g FROM sale) sale_view GROUP BY ROLLUP(f,g);
--- start_ignore
--- GPDB_84_MERGE_FIXME: GPORCA is falling back during Query to DXL translation
--- due to following error: GPDB Expression type: Distinct aggregates not supported in DXL
--- Tracker Story: #153040298
--- Re-enable ORCA once the issue is fixed.
-set optimizer=off;
--- end_ignore
 SELECT COUNT(DISTINCT cn) as cn_r, f, g FROM (SELECT cn, vn + 1 AS f, 1 AS g FROM sale) sale_view GROUP BY ROLLUP(f,g) HAVING (f > 1);
--- start_ignore
--- GPDB_84_MERGE_FIXME: GPORCA is falling back during Query to DXL translation
--- due to following error: GPDB Expression type: Distinct aggregates not supported in DXL
--- Tracker Story: #153040298
--- Re-enable ORCA once the issue is fixed.
--- end_ignore
 PREPARE p AS SELECT COUNT(DISTINCT cn) as cn_r, f, g FROM (SELECT cn, vn + $1 AS f, $1 AS g FROM sale) sale_view GROUP BY ROLLUP(f,g) HAVING (g > 1);
 EXECUTE p(2);
--- start_ignore
-reset optimizer;
--- end_ignore
 
 -- ###### Queries involving CUBE with HAVING CLAUSE ###### --
 

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -708,10 +708,6 @@ EXPLAIN SELECT '' AS five, f1 AS "Correlated Field"
 EXPLAIN select count(*) from
   (select 1 from tenk1 a
    where unique1 IN (select hundred from tenk1 b)) ss;
--- start_ignore
--- GPDB_84_MERGE_FIXME: ORCA started supporting this feature, investigate why
-set optimizer = off;
--- end_ignore
 EXPLAIN select count(distinct ss.ten) from
   (select ten from tenk1 a
    where unique1 IN (select hundred from tenk1 b)) ss;
@@ -721,9 +717,6 @@ EXPLAIN select count(*) from
 EXPLAIN select count(distinct ss.ten) from
   (select ten from tenk1 a
    where unique1 IN (select distinct hundred from tenk1 b)) ss;
--- start_ignore
-reset optimizer;
--- end_ignore
 
 --
 -- In case of simple exists query, planner can generate alternative


### PR DESCRIPTION
Translate aggdistinct in AggRef
Prior to the postgres window merge, `aggdistinct` in `AggRef` was a bool and passed
as is to GPORCA. Now, this is a list of `SortGroupClause` objects for
`Aggref`. This commit, translates `aggdistinct` into a bool to pass to
ORCA and while translating from DXL to PLNSTMT, a list of
`SortGroupClause` is created from the corresponding args in `AggRef`.

Signed-off-by: Sambitesh Dash <sdash@pivotal.io>
