### PR TITLE
Clean up temp toast schema on backend exit.

### DIFF
--- a/src/backend/catalog/namespace.c
+++ b/src/backend/catalog/namespace.c
@@ -3167,7 +3167,7 @@ InitTempTableNamespace(void)
 	/*
 	 * GPDB: Delete old temp schema.
 	 *
-	 * Remove any vestigages of old temporary schema, if any.  This can
+	 * Remove any vestiges of old temporary schema, if any.  This can
 	 * happen when an old session crashes and doesn't run normal session
 	 * shutdown.
 	 *
@@ -3503,6 +3503,7 @@ RemoveTempRelationsCallback(int code, Datum arg)
 
 			/* MPP-3390: drop pg_temp_N schema entry from pg_namespace */
 			RemoveSchemaById(myTempNamespace);
+			RemoveSchemaById(myTempToastNamespace);
 			elog(DEBUG1, "Remove schema entry %u from pg_namespace", 
 				 myTempNamespace); 
 		}

--- a/src/test/regress/expected/bfv_temp.out
+++ b/src/test/regress/expected/bfv_temp.out
@@ -19,9 +19,17 @@ NOTICE:  Table created
  
 (1 row)
 
--- There should be one temp table, the one we created (we assume that there are no
--- other backends using temp tables running at the same time).
-select count(*) from pg_tables where schemaname like 'pg_temp%';
+-- Remember the name of the temp namespace and temp toast namespace
+CREATE TABLE temp_nspnames as
+select nsp.nspname as nspname, toastnsp.nspname as toastnspname from pg_class c
+inner join pg_namespace nsp on c.relnamespace = nsp.oid
+inner join pg_class toastc on toastc.oid = c.reltoastrelid
+inner join pg_namespace toastnsp on toastc.relnamespace = toastnsp.oid
+where c.oid = 'wmt_toast_issue_temp'::regclass;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'nspname' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- there should be exactly one temp table with that name.
+select count(*) from temp_nspnames;
  count 
 -------
      1
@@ -37,13 +45,22 @@ select pg_sleep(2);
  
 (1 row)
 
--- Check that the temporary table was dropped at disconnect.
-select * from pg_tables where schemaname like 'pg_temp%';
+-- Check that the temp namespaces were dropped altogether.
+select nsp.nspname, temp_nspnames.* FROM pg_namespace nsp, temp_nspnames
+where nsp.nspname = temp_nspnames.nspname OR nsp.nspname = temp_nspnames.toastnspname;
+ nspname | nspname | toastnspname 
+---------+---------+--------------
+(0 rows)
+
+-- Check that the temporary table was dropped at disconnect. (It really should be
+-- gone if the whole namespace is gone, but doesn't hurt to check.)
+select * from pg_tables where tablename = 'wmt_toast_issue_temp';
  schemaname | tablename | tableowner | tablespace | hasindexes | hasrules | hastriggers 
 ------------+-----------+------------+------------+------------+----------+-------------
 (0 rows)
 
 -- Clean up
 reset role;
+drop table temp_nspnames;
 drop function public.sec_definer_create_test();
 drop role sec_definer_role;


### PR DESCRIPTION
When a backend exits normally, the "pg_temp_<sessionid>" schema is dropped.
In GPDB 5, with the 8.3 merge, there is now a "pg_temp_toast_<sessionid>"
schema in addition to the temp schema, but it was not dropped. As a result,
you would end up with a lot of unused pg_temp_toast_* schemas. To fix,
also drop the temp toast schema at backend exit.

We will still leak temp schemas, and temp toast schemas, if a backend exits
abnormally, or if the server crashes. That's not a new issue, but we should
probably do something about that in the future, too.

Fixes github issue #4061. Backport to 5x_STABLE, where the toast temp
namespaces were introduced.