### PR TITLE
Reduce the contention on tmLock

### DIFF
--- a/src/backend/cdb/cdbtmutils.c
+++ b/src/backend/cdb/cdbtmutils.c
@@ -76,8 +76,6 @@ DtxStateToString(DtxState state)
 			return "Retry Commit Prepared";
 		case DTX_STATE_RETRY_ABORT_PREPARED:
 			return "Retry Abort Prepared";
-		case DTX_STATE_CRASH_COMMITTED:
-			return "Crash Committed";
 		default:
 			return "Unknown";
 	}

--- a/src/backend/cdb/test/Makefile
+++ b/src/backend/cdb/test/Makefile
@@ -2,15 +2,13 @@ subdir=src/backend/cdb
 top_builddir=../../../..
 include $(top_builddir)/src/Makefile.global
 
-TARGETS=cdbtm \
-	cdbbufferedread \
+TARGETS=cdbbufferedread \
 	cdbsrlz \
 	cdbdistributedsnapshot
 
 TARGETS += cdbappendonlystorage cdbappendonlyxlog
 
 include $(top_builddir)/src/backend/mock.mk
-cdbtm.t: $(MOCK_DIR)/backend/storage/lmgr/lwlock_mock.o
 
 cdbdistributedsnapshot.t: $(MOCK_DIR)/backend/access/transam/distributedlog_mock.o
 

--- a/src/backend/storage/ipc/test/Makefile
+++ b/src/backend/storage/ipc/test/Makefile
@@ -1,0 +1,10 @@
+subdir=src/backend/storage/ipc
+top_builddir=../../../../..
+include $(top_builddir)/src/Makefile.global
+
+TARGETS=procarray
+
+include $(top_builddir)/src/backend/mock.mk
+procarray.t: $(MOCK_DIR)/backend/storage/lmgr/lwlock_mock.o \
+			 $(MOCK_DIR)/backend/cdb/cdbtm_mock.o
+

--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -63,6 +63,7 @@
 
 #include "cdb/cdblocaldistribxact.h"
 #include "cdb/cdbgang.h"
+#include "cdb/cdbtm.h"
 #include "cdb/cdbvars.h"  /*Gp_is_writer*/
 #include "port/atomics.h"
 #include "utils/session_state.h"
@@ -437,6 +438,9 @@ InitProcess(void)
 	MyProc->waitPortalId = INVALID_PORTALID;
 
 	MyProc->queryCommandId = -1;
+
+	/* Init gxact */
+	initGxact(&MyProc->gxact);
 
 	/*
 	 * Arrange to clean up at backend exit.

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -386,7 +386,6 @@ errstart(int elevel, const char *filename, int lineno,
 				case DTX_STATE_INSERTING_FORGET_COMMITTED:
 				case DTX_STATE_INSERTED_FORGET_COMMITTED:
 				case DTX_STATE_NOTIFYING_ABORT_NO_PREPARED:
-				case DTX_STATE_CRASH_COMMITTED:
 					break;
 			}
 		}

--- a/src/backend/utils/init/postinit.c
+++ b/src/backend/utils/init/postinit.c
@@ -30,6 +30,7 @@
 #include "libpq/auth.h"
 #include "libpq/hba.h"
 #include "libpq/libpq-be.h"
+#include "cdb/cdbtm.h"
 #include "cdb/cdbvars.h"
 #include "cdb/cdbutil.h"
 #include "mb/pg_wchar.h"

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -926,6 +926,40 @@ FaultInjector_SetFaultInjection(
 			
 			break;
 		}
+
+		case FaultInjectorTypeWaitUntilTriggered:
+		{
+			FaultInjectorEntry_s	*entryLocal;
+
+			while ((entryLocal = FaultInjector_LookupHashEntry(entry->faultName)) != NULL &&
+				   entry->occurrence > entryLocal->numTimesTriggered)
+			{
+				pg_usleep(1000000L);  // 1 sec
+			}
+
+			if (entryLocal != NULL)
+			{
+				ereport(LOG,
+						(errcode(ERRCODE_FAULT_INJECT),
+						 errmsg("fault triggered %d times, fault name:'%s' fault type:'%s' ",
+							entry->occurrence,
+							entryLocal->faultName,
+							FaultInjectorTypeEnumToString[entry->faultInjectorType])));
+				status = STATUS_OK;
+			}
+			else
+			{
+				ereport(LOG,
+						(errcode(ERRCODE_FAULT_INJECT),
+						 errmsg("fault 'NULL', fault name:'%s'  ",
+								entryLocal->faultName)));
+
+				status = STATUS_ERROR;
+			}
+
+			break;
+		}
+
 		case FaultInjectorTypeStatus:
 		{	
 			HASH_SEQ_STATUS			hash_status;

--- a/src/include/storage/proc.h
+++ b/src/include/storage/proc.h
@@ -23,6 +23,7 @@
 #include "access/xlog.h"
 
 #include "cdb/cdblocaldistribxact.h"  /* LocalDistribXactData */
+#include "cdb/cdbtm.h"  /* TMGXACT */
 
 
 /*
@@ -172,6 +173,7 @@ struct PGPROC
 	void		*resSlot;	/* the resource group slot granted.
    							 * NULL indicates the resource group is
 							 * locked for drop. */
+	TMGXACT		gxact;
 };
 
 /* NOTE: "typedef struct PGPROC PGPROC" appears in storage/lock.h. */

--- a/src/include/storage/procarray.h
+++ b/src/include/storage/procarray.h
@@ -27,6 +27,7 @@ extern void CreateSharedProcArray(void);
 extern void ProcArrayAdd(PGPROC *proc);
 extern void ProcArrayRemove(PGPROC *proc, TransactionId latestXid);
 extern bool ProcArrayEndTransaction(PGPROC *proc, TransactionId latestXid, bool isCommit);
+extern void ProcArrayEndGxact(void);
 extern void ProcArrayClearTransaction(PGPROC *proc, bool commit);
 extern void ClearTransactionFromPgProc_UnderLock(PGPROC *proc, bool commit);
 
@@ -66,5 +67,7 @@ extern void updateSharedLocalSnapshot(struct DtxContextInfo *dtxContextInfo, str
 extern void GetSlotTableDebugInfo(void **snapshotArray, int *maxSlots);
 
 extern bool FindAndSignalProcess(int sessionId, int commandId);
+
+extern void getDtxCheckPointInfo(char **result, int *result_size);
 
 #endif   /* PROCARRAY_H */

--- a/src/include/utils/faultinjector_lists.h
+++ b/src/include/utils/faultinjector_lists.h
@@ -204,6 +204,8 @@ FI_IDENT(GangCreated, "gang_created")
 FI_IDENT(ResGroupAssignedOnMaster, "resgroup_assigned_on_master")
 /* inject fault before reading command */
 FI_IDENT(BeforeReadCommand, "before_read_command")
+/* inject fault before get checkpoint dtx information */
+FI_IDENT(CheckPointDtxInfo, "checkpoint_dtx_info")
 #endif
 
 /*

--- a/src/include/utils/faultinjector_lists.h
+++ b/src/include/utils/faultinjector_lists.h
@@ -229,6 +229,7 @@ FI_TYPE(FaultInjectorTypeSegv, "segv")
 FI_TYPE(FaultInjectorTypeInterrupt, "interrupt")
 FI_TYPE(FaultInjectorTypeFinishPending, "finish_pending")
 FI_TYPE(FaultInjectorTypeCheckpointAndPanic, "checkpoint_and_panic")
+FI_TYPE(FaultInjectorTypeWaitUntilTriggered, "wait_until_triggered")
 #endif
 
 /*

--- a/src/test/isolation2/expected/crash_recovery.out
+++ b/src/test/isolation2/expected/crash_recovery.out
@@ -1,0 +1,100 @@
+1:CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+CREATE
+1:CREATE TABLE crash_test_table(c1 int);
+CREATE
+
+-- transaction of session 2 and session 3 inserted 'COMMIT' record before checkpoint
+1:select gp_inject_fault('dtm_broadcast_commit_prepared', 'suspend', 1);
+gp_inject_fault
+---------------
+t              
+(1 row)
+2&:insert into crash_test_table values (1);  <waiting ...>
+3&:create table crash_test_ddl(c1 int);  <waiting ...>
+
+-- wait session 2 and session 3 hit inject point
+1:select gp_inject_fault('dtm_broadcast_commit_prepared', 'wait_until_triggered', '', '', '', 2, 0, 1);
+gp_inject_fault
+---------------
+t              
+(1 row)
+1:CHECKPOINT;
+CHECKPOINT
+
+-- transaction of session 4 inserted 'COMMIT' record after checkpoint
+4&:insert into crash_test_table values (2);  <waiting ...>
+
+-- wait session 4 hit inject point
+1:select gp_inject_fault('dtm_broadcast_commit_prepared', 'wait_until_triggered', '', '', '', 3, 0, 1);
+gp_inject_fault
+---------------
+t              
+(1 row)
+
+-- transaction of session 5 didn't insert 'COMMIT' record
+1:select gp_inject_fault('transaction_abort_after_distributed_prepared', 'suspend', 1);
+gp_inject_fault
+---------------
+t              
+(1 row)
+5&:INSERT INTO crash_test_table VALUES (3);  <waiting ...>
+
+-- wait session 5 hit inject point
+1:select gp_inject_fault('transaction_abort_after_distributed_prepared', 'wait_until_triggered', '', '', '', 1, 0, 1);
+gp_inject_fault
+---------------
+t              
+(1 row)
+
+-- check injector status
+1:select gp_inject_fault('dtm_broadcast_commit_prepared', 'status', 1);
+gp_inject_fault
+---------------
+t              
+(1 row)
+1:select gp_inject_fault('transaction_abort_after_distributed_prepared', 'status', 1);
+gp_inject_fault
+---------------
+t              
+(1 row)
+
+-- trigger crash
+1:select gp_inject_fault('before_read_command', 'panic', 1);
+gp_inject_fault
+---------------
+t              
+(1 row)
+1:select 1;
+PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+
+2<:  <... completed>
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+3<:  <... completed>
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+4<:  <... completed>
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+5<:  <... completed>
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+
+-- transaction of session 2, session 3 and session 4 will be committed during recovery.
+6:select * from crash_test_table;
+c1
+--
+1 
+2 
+(2 rows)
+6:select * from crash_test_ddl;
+c1
+--
+(0 rows)

--- a/src/test/isolation2/expected/crash_recovery_redundant_dtx.out
+++ b/src/test/isolation2/expected/crash_recovery_redundant_dtx.out
@@ -1,0 +1,54 @@
+1:CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+CREATE
+1:CREATE TABLE crash_test_redundant(c1 int);
+CREATE
+
+-- transaction of session 2 suspend after inserted 'COMMIT' record
+1:select gp_inject_fault('dtm_broadcast_commit_prepared', 'suspend', 1);
+gp_inject_fault
+---------------
+t              
+(1 row)
+-- checkpoint suspend before scanning proc array
+1:select gp_inject_fault('checkpoint_dtx_info', 'suspend', 1);
+gp_inject_fault
+---------------
+t              
+(1 row)
+1&:CHECKPOINT;  <waiting ...>
+
+-- the 'COMMIT' record is logically after REDO pointer
+2&:insert into crash_test_redundant values (1);  <waiting ...>
+
+-- resume checkpoint
+3:select gp_inject_fault('checkpoint_dtx_info', 'resume', 1);
+gp_inject_fault
+---------------
+t              
+(1 row)
+1<:  <... completed>
+CHECKPOINT
+
+-- trigger crash
+1:select gp_inject_fault('before_read_command', 'panic', 1);
+gp_inject_fault
+---------------
+t              
+(1 row)
+1:select 1;
+PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+
+2<:  <... completed>
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+
+-- transaction of session 2 should be recovered properly
+4:select * from crash_test_redundant;
+c1
+--
+1 
+(1 row)

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -108,3 +108,7 @@ test: vacuum_after_vacuum_skip_drop_column
 test: segwalrep/commit_blocking
 test: segwalrep/fts_unblock_primary
 test: segwalrep/mirror_promotion
+
+# Tests for crash recovery
+test: crash_recovery
+test: crash_recovery_redundant_dtx

--- a/src/test/isolation2/sql/crash_recovery.sql
+++ b/src/test/isolation2/sql/crash_recovery.sql
@@ -1,0 +1,41 @@
+1:CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+1:CREATE TABLE crash_test_table(c1 int);
+
+-- transaction of session 2 and session 3 inserted 'COMMIT' record before checkpoint
+1:select gp_inject_fault('dtm_broadcast_commit_prepared', 'suspend', 1);
+2&:insert into crash_test_table values (1);
+3&:create table crash_test_ddl(c1 int);
+
+-- wait session 2 and session 3 hit inject point
+1:select gp_inject_fault('dtm_broadcast_commit_prepared', 'wait_until_triggered', '', '', '', 2, 0, 1);
+1:CHECKPOINT;
+
+-- transaction of session 4 inserted 'COMMIT' record after checkpoint
+4&:insert into crash_test_table values (2);
+
+-- wait session 4 hit inject point
+1:select gp_inject_fault('dtm_broadcast_commit_prepared', 'wait_until_triggered', '', '', '', 3, 0, 1);
+
+-- transaction of session 5 didn't insert 'COMMIT' record
+1:select gp_inject_fault('transaction_abort_after_distributed_prepared', 'suspend', 1);
+5&:INSERT INTO crash_test_table VALUES (3);
+
+-- wait session 5 hit inject point
+1:select gp_inject_fault('transaction_abort_after_distributed_prepared', 'wait_until_triggered', '', '', '', 1, 0, 1);
+
+-- check injector status
+1:select gp_inject_fault('dtm_broadcast_commit_prepared', 'status', 1);
+1:select gp_inject_fault('transaction_abort_after_distributed_prepared', 'status', 1);
+
+-- trigger crash
+1:select gp_inject_fault('before_read_command', 'panic', 1);
+1:select 1;
+
+2<:
+3<:
+4<:
+5<:
+
+-- transaction of session 2, session 3 and session 4 will be committed during recovery.
+6:select * from crash_test_table;
+6:select * from crash_test_ddl;

--- a/src/test/isolation2/sql/crash_recovery_redundant_dtx.sql
+++ b/src/test/isolation2/sql/crash_recovery_redundant_dtx.sql
@@ -1,0 +1,24 @@
+1:CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+1:CREATE TABLE crash_test_redundant(c1 int);
+
+-- transaction of session 2 suspend after inserted 'COMMIT' record 
+1:select gp_inject_fault('dtm_broadcast_commit_prepared', 'suspend', 1);
+-- checkpoint suspend before scanning proc array
+1:select gp_inject_fault('checkpoint_dtx_info', 'suspend', 1);
+1&:CHECKPOINT;
+
+-- the 'COMMIT' record is logically after REDO pointer
+2&:insert into crash_test_redundant values (1);
+
+-- resume checkpoint
+3:select gp_inject_fault('checkpoint_dtx_info', 'resume', 1);
+1<:
+
+-- trigger crash
+1:select gp_inject_fault('before_read_command', 'panic', 1);
+1:select 1;
+
+2<:
+
+-- transaction of session 2 should be recovered properly
+4:select * from crash_test_redundant;

--- a/src/test/regress/atmsort.pm
+++ b/src/test/regress/atmsort.pm
@@ -267,7 +267,7 @@ m/\s+\(seg.*pid.*\)/
 s/\s+\(seg.*pid.*\)//
 
 # distributed transactions
-m/^(?:ERROR|WARNING|CONTEXT|NOTICE):.*gid\s+=\s+(?:\d+)/
+m/^(?:ERROR|WARNING|CONTEXT|NOTICE|PANIC):.*gid\s+=\s+(?:\d+)/
 s/gid.*/gid DUMMY/
 
 m/^(?:ERROR|WARNING|CONTEXT|NOTICE):.*connection.*failed.*(?:http|gpfdist)/


### PR DESCRIPTION
There are mainly 4 functions will traverse shmGxactArray concurrently:
createDtx, releaseGxact, CreateDistributedSnapshot and getDtxCheckPointInfo

For CreateDistributedSnapshot, we use the same idea as GetSnapshotData in
upstream: strict serialization of commits and rollbacks with snapshot-taking.
So we acquire tmLock in shared mode in CreateDistributedSnapshot, and acquire
tmLock in exclusive mode when a proc exits from a transaction(clearTransactionState()).

For getDtxCheckPointInfo, we introduce a new flag to represent a global transaction has
committed on master, but hasn't finished the second phase of 2PC. This kind of global
transactions should be recorded in the checkpoint record. A new lwlock(CheckpointTMLock)
is used to protect the flag.