### PR TITLE
Print window name in 'window "%s" does not exist' correctly.

### DIFF
--- a/src/backend/parser/parse_agg.c
+++ b/src/backend/parser/parse_agg.c
@@ -734,7 +734,7 @@ transformWindowFuncCall(ParseState *pstate, WindowFunc *wfunc,
 		if (lc == NULL)			/* didn't find it? */
 			ereport(ERROR,
 					(errcode(ERRCODE_UNDEFINED_OBJECT),
-					 errmsg("window \"%s\" does not exist", windef->name),
+					 errmsg("window \"%s\" does not exist", name),
 					 parser_errposition(pstate, windef->location)));
 	}
 	else

--- a/src/test/regress/expected/qp_olap_windowerr.out
+++ b/src/test/regress/expected/qp_olap_windowerr.out
@@ -5108,6 +5108,17 @@ LINE 1: delete from wintest_for_window_seq where count(*) over (orde...
                                                  ^
 drop table wintest_for_window_seq;
 --
+-- Test "window does not exist" error in window parsing code
+--
+select row_number() over (bogus) FROM generate_series(1,10) i;
+ERROR:  window "bogus" does not exist
+LINE 1: select row_number() over (bogus) FROM generate_series(1,10) ...
+                                 ^
+select row_number() over bogus FROM generate_series(1,10) i;
+ERROR:  window "bogus" does not exist
+LINE 1: select row_number() over bogus FROM generate_series(1,10) i;
+                                 ^
+--
 -- STANDARD DATA FOR olap_* TESTS.
 --
 -- start_ignore

--- a/src/test/regress/sql/qp_olap_windowerr.sql
+++ b/src/test/regress/sql/qp_olap_windowerr.sql
@@ -3889,6 +3889,11 @@ delete from wintest_for_window_seq where count(*) over (order by i) > 0;
 
 drop table wintest_for_window_seq;
 
+--
+-- Test "window does not exist" error in window parsing code
+--
+select row_number() over (bogus) FROM generate_series(1,10) i;
+select row_number() over bogus FROM generate_series(1,10) i;
 
 --
 -- STANDARD DATA FOR olap_* TESTS.


### PR DESCRIPTION
This code has been modified in GPDB, to turn "OVER (w)" into the same as
"OVER w". (Whether that's a good idea is another debate, but that's what we
have now, for compatibility with GPDB 5 and below). But the error printing
code was wrong, and printed 'window "(null)" does not exist", for the
OVER (w) syntax, if 'w' was not a valid window name.