### PR TITLE
Remove unused shmem copy of BgWriterPID.

### DIFF
--- a/src/include/postmaster/primary_mirror_mode.h
+++ b/src/include/postmaster/primary_mirror_mode.h
@@ -299,9 +299,6 @@ extern bool updateDataState(DataState_e dataState);
 
 extern int64 getChangeTrackingSessionId(void);
 
-extern void primaryMirrorSetBGWriterPID( pid_t pid );
-extern pid_t primaryMirrorGetBGWriterPID(void);
-
 extern void primaryMirrorSetIOSuspended( bool ioSuspended );
 extern bool primaryMirrorIsIOSuspended(void);
 


### PR DESCRIPTION
There was a mechanism to keep the PID of the background writer process in
shared memory, but it was unused. Remove.