### PR TITLE
Increase PR limit from 4 to 10

### DIFF
--- a/concourse/pipelines/pr_pipeline.yml
+++ b/concourse/pipelines/pr_pipeline.yml
@@ -48,7 +48,7 @@ resources:
 jobs:
   - name: compile_and_test_gpdb
     public: true
-    max_in_flight: 4
+    max_in_flight: 10
     plan:
     - aggregate:
       - get: gpdb_pr


### PR DESCRIPTION
This will allow more PR went through.

Originally, we bound at 4 to stablize the concourse. Now the concourse
is a lot more reliable, and we should be able to run more ICW in
parallel in the PR pipeline.

This will help us get faster feedback, so that we can innovate faster.

Author: Xin Zhang <xzhang@pivotal.io>
Author: Ashwin Agrawal <aagrawal@pivotal.io>