### PR TITLE
Disable the assert in StoreAttnoColIdMapping() and update answer files

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -3856,12 +3856,15 @@ CTranslatorQueryToDXL::StoreAttnoColIdMapping
 {
 	GPOS_ASSERT(NULL != phmiul);
 
-#ifdef GPOS_DEBUG
-	BOOL fResult =
-#endif // GPOS_DEBUG
-	phmiul->FInsert(GPOS_NEW(m_pmp) INT(iAttno), GPOS_NEW(m_pmp) ULONG(ulColId));
+	INT *piKey = GPOS_NEW(m_pmp) INT(iAttno);
+	ULONG *pulValue = GPOS_NEW(m_pmp) ULONG(ulColId);
+	BOOL fResult = phmiul->FInsert(piKey, pulValue);
 
-	GPOS_ASSERT(fResult);
+	if (!fResult)
+	{
+		GPOS_DELETE(piKey);
+		GPOS_DELETE(pulValue);
+	}
 }
 
 //---------------------------------------------------------------------------

--- a/src/test/regress/expected/qp_misc_jiras_optimizer.out
+++ b/src/test/regress/expected/qp_misc_jiras_optimizer.out
@@ -2383,33 +2383,28 @@ create table qp_misc_jiras.tbl7553_test (i int, j int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into qp_misc_jiras.tbl7553_test values(1,2);
--- start_ignore
--- GPDB_84_MERGE_FIXME: GPORCA is falling back during Query to DXL translation
--- with error: CTranslatorQueryToDXL.cpp:3864: Failed assertion: fResult.
--- Tracker Story: #153070478
--- Re-enable GPORCA once issue is fixed
-set optimizer=off;
--- end_ignore
 explain select i as a, i as b from qp_misc_jiras.tbl7553_test group by grouping sets( (a, b), (a));
-                                                                                             QUERY PLAN                                                                                             
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=8731.75..8759.25 rows=2750 width=20)
-   ->  HashAggregate  (cost=8731.75..8759.25 rows=917 width=20)
-         Group By: "rollup".a, "rollup".a, "rollup"."grouping", "rollup"."group_id"
-         ->  Subquery Scan "rollup"  (cost=8018.50..8724.25 rows=250 width=20)
-               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=8018.50..8716.75 rows=250 width=20)
-                     Hash Key: "rollup".a, "rollup".a, (Grouping), group_id()
-                     ->  GroupAggregate  (cost=8018.50..8701.75 rows=250 width=20)
-                           Group By: "rollup".a, "rollup"."grouping", "rollup"."group_id"
-                           ->  Subquery Scan "rollup"  (cost=8018.50..8684.25 rows=334 width=20)
-                                 ->  GroupAggregate  (cost=8018.50..8674.25 rows=334 width=20)
-                                       Group By: tbl7553_test.i, tbl7553_test.i
-                                       ->  Sort  (cost=8018.50..8233.75 rows=28700 width=4)
-                                             Sort Key: tbl7553_test.i
-                                             ->  Seq Scan on tbl7553_test  (cost=0.00..961.00 rows=28700 width=4)
- Settings:  enable_indexscan=off; enable_nestloop=on; enable_seqscan=off; gp_enable_agg_distinct=off; gp_enable_agg_distinct_pruning=off; optimizer=off; optimizer_force_three_stage_scalar_dqa=off
- Optimizer status: legacy query optimizer
-(16 rows)
+                                                                                            QUERY PLAN                                                                                             
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=1 width=4)
+   ->  Sequence  (cost=0.00..1293.00 rows=1 width=4)
+         ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=1 width=1)
+               ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+                     ->  Table Scan on tbl7553_test  (cost=0.00..431.00 rows=1 width=4)
+         ->  Append  (cost=0.00..862.00 rows=1 width=4)
+               ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
+                     Group By: share0_ref2.i
+                     ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+                           Sort Key: share0_ref2.i
+                           ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=1 width=4)
+               ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
+                     Group By: share0_ref3.i, share0_ref3.i
+                     ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+                           Sort Key: share0_ref3.i, share0_ref3.i
+                           ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=1 width=4)
+ Settings:  enable_indexscan=off; enable_nestloop=on; enable_seqscan=off; gp_enable_agg_distinct=off; gp_enable_agg_distinct_pruning=off; optimizer=on; optimizer_force_three_stage_scalar_dqa=off
+ Optimizer status: PQO version 2.51.0
+(18 rows)
 
 select i as a, i as b from qp_misc_jiras.tbl7553_test group by grouping sets( (a, b), (a)); 
  a | b 
@@ -2419,25 +2414,39 @@ select i as a, i as b from qp_misc_jiras.tbl7553_test group by grouping sets( (a
 (2 rows)
 
 explain select j as a, j as b from qp_misc_jiras.tbl7553_test group by grouping sets( (a, b), (a)); 
-                                                                                             QUERY PLAN                                                                                             
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=8731.75..8759.25 rows=2750 width=8)
-   ->  HashAggregate  (cost=8731.75..8759.25 rows=917 width=8)
-         Group By: partial_aggregation.a, partial_aggregation.a, partial_aggregation."grouping", partial_aggregation."group_id"
-         ->  Subquery Scan partial_aggregation  (cost=8018.50..8724.25 rows=250 width=20)
-               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=8018.50..8716.75 rows=250 width=20)
-                     Hash Key: "rollup".a, "rollup".a
-                     ->  GroupAggregate  (cost=8018.50..8701.75 rows=250 width=20)
-                           Group By: "rollup".a, "rollup"."grouping", "rollup"."group_id"
-                           ->  Subquery Scan "rollup"  (cost=8018.50..8684.25 rows=334 width=20)
-                                 ->  GroupAggregate  (cost=8018.50..8674.25 rows=334 width=20)
-                                       Group By: tbl7553_test.j, tbl7553_test.j
-                                       ->  Sort  (cost=8018.50..8233.75 rows=28700 width=4)
-                                             Sort Key: tbl7553_test.j
-                                             ->  Seq Scan on tbl7553_test  (cost=0.00..961.00 rows=28700 width=4)
- Settings:  enable_indexscan=off; enable_nestloop=on; enable_seqscan=off; gp_enable_agg_distinct=off; gp_enable_agg_distinct_pruning=off; optimizer=off; optimizer_force_three_stage_scalar_dqa=off
- Optimizer status: legacy query optimizer
-(16 rows)
+                                                                                            QUERY PLAN                                                                                             
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1293.00 rows=1 width=4)
+   ->  Sequence  (cost=0.00..1293.00 rows=1 width=4)
+         ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=1 width=1)
+               ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+                     ->  Table Scan on tbl7553_test  (cost=0.00..431.00 rows=1 width=4)
+         ->  Append  (cost=0.00..862.00 rows=1 width=4)
+               ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
+                     Group By: share0_ref2.j
+                     ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+                           Sort Key: share0_ref2.j
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                 Hash Key: share0_ref2.j
+                                 ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
+                                       Group By: share0_ref2.j
+                                       ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+                                             Sort Key: share0_ref2.j
+                                             ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=1 width=4)
+               ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
+                     Group By: share0_ref3.j, share0_ref3.j
+                     ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+                           Sort Key: share0_ref3.j, share0_ref3.j
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                 Hash Key: share0_ref3.j, share0_ref3.j
+                                 ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
+                                       Group By: share0_ref3.j, share0_ref3.j
+                                       ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+                                             Sort Key: share0_ref3.j, share0_ref3.j
+                                             ->  Shared Scan (share slice:id 2:0)  (cost=0.00..431.00 rows=1 width=4)
+ Settings:  enable_indexscan=off; enable_nestloop=on; enable_seqscan=off; gp_enable_agg_distinct=off; gp_enable_agg_distinct_pruning=off; optimizer=on; optimizer_force_three_stage_scalar_dqa=off
+ Optimizer status: PQO version 2.51.0
+(30 rows)
 
 select j as a, j as b from qp_misc_jiras.tbl7553_test group by grouping sets( (a, b), (a)); 
  a | b 
@@ -2446,9 +2455,6 @@ select j as a, j as b from qp_misc_jiras.tbl7553_test group by grouping sets( (a
  2 | 2
 (2 rows)
 
--- start_ignore
-reset optimizer;
--- end_ignore
 drop table qp_misc_jiras.tbl7553_test;
 -- Check that a table created with CTAS "inherits" the distribution key from
 -- the source table.

--- a/src/test/regress/sql/qp_misc_jiras.sql
+++ b/src/test/regress/sql/qp_misc_jiras.sql
@@ -1434,12 +1434,6 @@ DROP TABLE IF EXISTS qp_misc_jiras.one_of_every_data_type;
 
 create table qp_misc_jiras.tbl7553_test (i int, j int);
 insert into qp_misc_jiras.tbl7553_test values(1,2);
--- start_ignore
--- GPDB_84_MERGE_FIXME: GPORCA fallback: CTranslatorQueryToDXL.cpp:3864: Failed assertion: fResult
--- Tracker Story: #153070478
--- Re-enable GPORCA once issue is fixed
-set optimizer=off;
--- end_ignore
 explain select i as a, i as b from qp_misc_jiras.tbl7553_test group by grouping sets( (a, b), (a));
 
 select i as a, i as b from qp_misc_jiras.tbl7553_test group by grouping sets( (a, b), (a)); 
@@ -1448,9 +1442,6 @@ explain select j as a, j as b from qp_misc_jiras.tbl7553_test group by grouping 
 
 select j as a, j as b from qp_misc_jiras.tbl7553_test group by grouping sets( (a, b), (a)); 
 
--- start_ignore
-reset optimizer;
--- end_ignore
 drop table qp_misc_jiras.tbl7553_test;
 
 -- Check that a table created with CTAS "inherits" the distribution key from


### PR DESCRIPTION
When translating the query to DXL, Orca maps the attno to column id in a hash
map.  The hashmap failed to insert values for key that is already in the
hashmap.  Orca translator will fail the assertion when the key value pair is
not inserted successfully. When gpdb is build in non-debug mode, we don't see
this Orca falling back and it produces the correct plan. So it is OK to remove
assertion and release the memory allocated for the key and value when the
insertion is failed.

Author: Abhijit Subramanya <asubramanya@pivotal.io>