### PR TITLE
FTS turn off syncrep for primary when mirror is detected down

### DIFF
--- a/gpAux/gpdemo/gpsegwalrep.py
+++ b/gpAux/gpdemo/gpsegwalrep.py
@@ -236,18 +236,24 @@ class DestroyMirrors():
 
         commands.append("pg_ctl -D %s stop" % mirror_dir)
         commands.append("rm -rf %s" % mirror_dir)
+        thread_name = 'Mirror content %d' % mirror_contentid
+        command_finish = 'Destroyed mirror at %s' % mirror_dir
+        runcommands(commands, thread_name, command_finish, False)
 
+        # Let FTS recognize that mirrors are gone.  As a result,
+        # primaries will be marked not-in-sync.  If this step is
+        # omitted, FTS will stop probing as soon as mirrors are
+        # removed from catalog and primaries will be left "in-sync"
+        # without mirrors.
+        ForceFTSProbeScan(self.clusterconfig,
+                          GpSegmentConfiguration.STATUS_DOWN,
+                          GpSegmentConfiguration.NOT_IN_SYNC)
+
+        commands = []
         catalog_update_query = "select pg_catalog.gp_remove_segment_mirror(%d::int2)" % (mirror_contentid)
         commands.append("PGOPTIONS=\"-c gp_session_role=utility\" psql postgres -c \"%s\"" % catalog_update_query)
 
-        for sc in self.segconfigs:
-            if sc.content == mirror_contentid and sc.preferred_role == GpSegmentConfiguration.ROLE_PRIMARY:
-                commands.append("echo > %s/gp_replication.conf" % sc.fselocation)
-                commands.append("pg_ctl -D %s reload" % sc.fselocation)
-                break
-
-        thread_name = 'Mirror content %d' % mirror_contentid
-        command_finish = 'Destroyed mirror at %s' % mirror_dir
+        command_finish = 'Removed mirror %s from catalog' % mirror_dir
         runcommands(commands, thread_name, command_finish, False)
 
     def run(self):

--- a/gpAux/gpdemo/gpsegwalrep.py
+++ b/gpAux/gpdemo/gpsegwalrep.py
@@ -245,6 +245,10 @@ class DestroyMirrors():
         # omitted, FTS will stop probing as soon as mirrors are
         # removed from catalog and primaries will be left "in-sync"
         # without mirrors.
+        #
+        # FIXME: enhance gp_remove_segment_mirror() to do this, so
+        # that utility remains simplified.  Remove this stopgap
+        # thereafter.
         ForceFTSProbeScan(self.clusterconfig,
                           GpSegmentConfiguration.STATUS_DOWN,
                           GpSegmentConfiguration.NOT_IN_SYNC)

--- a/src/backend/fts/Makefile
+++ b/src/backend/fts/Makefile
@@ -13,7 +13,7 @@ override CPPFLAGS := -I$(libpq_srcdir) $(CPPFLAGS)
 
 OBJS = fts.o ftsprobe.o
 ifeq ($(enable_segwalrep), yes)
-OBJS += ftsprobehandler.o
+OBJS += ftsmessagehandler.o
 else
 OBJS += ftsfilerep.o ftsprobefilerep.o
 endif

--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -546,9 +546,13 @@ probeWalRepPublishUpdate(CdbComponentDatabases *cdbs, fts_context *context,
 		if (IsInSync != SEGMENT_IS_IN_SYNC(primary))
 			UpdatePrimary = UpdateMirror = true;
 
+		/* Primary must block commits as long as it and its mirror are alive. */
+		AssertImply(!UpdateMirror && IsMirrorAlive && IsPrimaryAlive,
+					response->result.isSyncRepEnabled);
+
 		if (!IsMirrorAlive && response->result.isSyncRepEnabled)
 		{
-			/* reschedule for the FTS to send a syncrep disable message */
+			/* Reschedule for the FTS to send a syncrep disable message */
 			response->isScheduled = false;
 			*need_syncrep_disabled = true;
 		}

--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -501,7 +501,7 @@ probeWalRepUpdateConfig(int16 dbid, int16 segindex, bool IsSegmentAlive, bool Is
 }
 
 static bool
-probeWalRepPublishUpdate(CdbComponentDatabases *cdbs, probe_context *context)
+probeWalRepPublishUpdate(CdbComponentDatabases *cdbs, fts_context *context)
 {
 	bool is_updated = false;
 
@@ -594,7 +594,7 @@ probeWalRepPublishUpdate(CdbComponentDatabases *cdbs, probe_context *context)
 }
 
 static void
-FtsWalRepInitProbeContext(CdbComponentDatabases *cdbs, probe_context *context)
+FtsWalRepInitProbeContext(CdbComponentDatabases *cdbs, fts_context *context)
 {
 	context->count = cdbs->total_segments;
 	context->responses = (probe_response_per_segment *)palloc(context->count * sizeof(probe_response_per_segment));
@@ -734,10 +734,10 @@ void FtsLoop()
 		oldContext = MemoryContextSwitchTo(probeContext);
 
 #ifdef USE_SEGWALREP
-		probe_context context;
+		fts_context context;
 
 		FtsWalRepInitProbeContext(cdbs, &context);
-		FtsWalRepProbeSegments(&context);
+		FtsWalRepMessageSegments(&context);
 
 		updated_probe_state = probeWalRepPublishUpdate(cdbs, &context);
 #else

--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -549,11 +549,8 @@ probeWalRepPublishUpdate(CdbComponentDatabases *cdbs, fts_context *context)
 		if (IsInSync != SEGMENT_IS_IN_SYNC(primary))
 			UpdatePrimary = UpdateMirror = true;
 
-		/*
-		 * Primary must block commits as long as it and its mirror are alive.
-		 * The only exception is when mirror transitions from down to up.
-		 */
-		AssertImply(!UpdateMirror && IsMirrorAlive && IsPrimaryAlive,
+		/* Primary must block commits as long as it and its mirror are alive. */
+		AssertImply(IsMirrorAlive && IsPrimaryAlive,
 					response->result.isSyncRepEnabled);
 
 		/*

--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -500,12 +500,15 @@ probeWalRepUpdateConfig(int16 dbid, int16 segindex, bool IsSegmentAlive, bool Is
 	}
 }
 
+/*
+ * Process probe resonses from primary segments:
+ * (a) Update gp_segment_configuration catalog table, if needed.
+ * (b) Indicate the segments that need to be messaged subsequently.
+ */
 static bool
-probeWalRepPublishUpdate(CdbComponentDatabases *cdbs, fts_context *context,
-						 bool *need_syncrep_disabled)
+probeWalRepPublishUpdate(CdbComponentDatabases *cdbs, fts_context *context)
 {
 	bool is_updated = false;
-	*need_syncrep_disabled = false;
 
 	for (int response_index = 0; response_index < context->num_primary_segments;
 		 response_index ++)
@@ -546,15 +549,25 @@ probeWalRepPublishUpdate(CdbComponentDatabases *cdbs, fts_context *context,
 		if (IsInSync != SEGMENT_IS_IN_SYNC(primary))
 			UpdatePrimary = UpdateMirror = true;
 
-		/* Primary must block commits as long as it and its mirror are alive. */
+		/*
+		 * Primary must block commits as long as it and its mirror are alive.
+		 * The only exception is when mirror transitions from down to up.
+		 */
 		AssertImply(!UpdateMirror && IsMirrorAlive && IsPrimaryAlive,
 					response->result.isSyncRepEnabled);
 
+		/*
+		 * Primaries that have syncrep enabled continue to block commits.  FTS
+		 * must notify them to unblock commits by sending syncrep off message.
+		 */
 		if (!IsMirrorAlive && response->result.isSyncRepEnabled)
 		{
-			/* Reschedule for the FTS to send a syncrep disable message */
-			response->isScheduled = false;
-			*need_syncrep_disabled = true;
+			response->message = FTS_MSG_SYNCREP_OFF;
+			/*
+			 * Mirror must be marked down in FTS configuration before primary
+			 * can be notified to unblock commits.
+			 */
+			Assert(UpdateMirror || !SEGMENT_IS_ALIVE(mirror));
 		}
 
 		/*
@@ -610,7 +623,6 @@ probeWalRepPublishUpdate(CdbComponentDatabases *cdbs, fts_context *context,
 static void
 FtsWalRepInitProbeContext(CdbComponentDatabases *cdbs, fts_context *context)
 {
-	context->messagetype = FTS_MSG_TYPE_PROBE;
 	context->num_primary_segments = cdbs->total_segments;
 	context->responses = (probe_response_per_segment *) palloc(
 		context->num_primary_segments * sizeof(probe_response_per_segment));
@@ -649,6 +661,7 @@ FtsWalRepInitProbeContext(CdbComponentDatabases *cdbs, fts_context *context)
 		response->result.isMirrorAlive = SEGMENT_IS_ALIVE(mirror);
 		response->result.isInSync = false;
 		response->result.isSyncRepEnabled = false;
+		response->message = FTS_MSG_PROBE;
 
 		response->segment_db_info = primary;
 		response->isScheduled = false;
@@ -656,6 +669,42 @@ FtsWalRepInitProbeContext(CdbComponentDatabases *cdbs, fts_context *context)
 		Assert(response_index < context->num_primary_segments);
 		response_index ++;
 	}
+}
+
+/*
+ * Setup context such that FTS threads can send a message other than PROBE to
+ * segments.  PROBE message must already be sent and response processed by the
+ * time this funtion is called.  Returns true if one or more segments need to
+ * be messaged.
+ */
+static bool
+FtsWalRepSetupMessageContext(fts_context *context)
+{
+	int i;
+	bool message_segments = false;
+
+	if (!FtsIsActive())
+		return false;
+
+	for (i = 0; i < context->num_primary_segments; i++)
+	{
+		probe_response_per_segment *response = &context->responses[i];
+		if (response->message == FTS_MSG_PROBE)
+		{
+			response->message = NULL;
+			response->isScheduled = true;
+		}
+		else
+		{
+			Assert(response->message == FTS_MSG_SYNCREP_OFF);
+			response->isScheduled = false;
+			response->result.isPrimaryAlive = false;
+			response->result.isInSync = false;
+			response->result.isSyncRepEnabled = false;
+			message_segments = true;
+		}
+	}
+	return message_segments;
 }
 #endif
 
@@ -752,20 +801,14 @@ void FtsLoop()
 
 #ifdef USE_SEGWALREP
 		fts_context context;
-		bool need_syncrep_disabled;
 
 		FtsWalRepInitProbeContext(cdbs, &context);
 		FtsWalRepMessageSegments(&context);
 
-		updated_probe_state =
-			probeWalRepPublishUpdate(cdbs, &context, &need_syncrep_disabled);
+		updated_probe_state = probeWalRepPublishUpdate(cdbs, &context);
 
-		/* some primaries may need to be unblocked */
-		if (need_syncrep_disabled)
-		{
-			context.messagetype = FTS_MSG_TYPE_SYNCREP_OFF;
+		if (FtsWalRepSetupMessageContext(&context))
 			FtsWalRepMessageSegments(&context);
-		}
 #else
 		/* probe segments */
 		FtsProbeSegments(cdbs, scan_status);

--- a/src/backend/fts/ftsmessagehandler.c
+++ b/src/backend/fts/ftsmessagehandler.c
@@ -97,11 +97,10 @@ HandleFtsWalRepSyncRepOff(void)
 {
 	FtsResponse response;
 
-	GetMirrorStatus(&response);
-
 	ereport(LOG,
 			(errmsg("turning off synchronous wal replication due to FTS request")));
 	UnsetSyncStandbysDefined();
+	GetMirrorStatus(&response);
 
 	SendFtsResponse(&response, FTS_MSG_TYPE_SYNCREP_OFF);
 }

--- a/src/backend/fts/ftsmessagehandler.c
+++ b/src/backend/fts/ftsmessagehandler.c
@@ -1,13 +1,13 @@
 /*-------------------------------------------------------------------------
  *
- * ftsprobehandler.c
- *	  Implementation of handling of FTS probe
+ * ftsmessagehandler.c
+ *	  Implementation of handling of FTS messages
  *
  * Portions Copyright (c) 2012-Present Pivotal Software, Inc.
  *
  *
  * IDENTIFICATION
- *	    src/backend/fts/ftsprobehandler.c
+ *	    src/backend/fts/ftsmessagehandler.c
  *
  *-------------------------------------------------------------------------
  */
@@ -20,7 +20,7 @@
 #include "replication/gp_replication.h"
 
 static void
-SendProbeResponse(ProbeResponse *response)
+SendFtsResponse(FtsResponse *response)
 {
 	StringInfoData buf;
 
@@ -29,11 +29,11 @@ SendProbeResponse(ProbeResponse *response)
 	BeginCommand(FTS_MSG_TYPE_PROBE, DestRemote);
 
 	pq_beginmessage(&buf, 'T');
-	pq_sendint(&buf, Natts_fts_probe_response, 2); /* 2 fields */
+	pq_sendint(&buf, Natts_fts_message_response, 2); /* 2 fields */
 
 	pq_sendstring(&buf, "is_mirror_up");
 	pq_sendint(&buf, 0, 4);		/* table oid */
-	pq_sendint(&buf, Anum_fts_probe_response_is_mirror_up, 2);		/* attnum */
+	pq_sendint(&buf, Anum_fts_message_response_is_mirror_up, 2);		/* attnum */
 	pq_sendint(&buf, BOOLOID, 4);		/* type oid */
 	pq_sendint(&buf, 1, 2);	/* typlen */
 	pq_sendint(&buf, -1, 4);		/* typmod */
@@ -41,7 +41,7 @@ SendProbeResponse(ProbeResponse *response)
 
 	pq_sendstring(&buf, "is_in_sync");
 	pq_sendint(&buf, 0, 4);		/* table oid */
-	pq_sendint(&buf, Anum_fts_probe_response_is_in_sync, 2);		/* attnum */
+	pq_sendint(&buf, Anum_fts_message_response_is_in_sync, 2);		/* attnum */
 	pq_sendint(&buf, BOOLOID, 4);		/* type oid */
 	pq_sendint(&buf, 1, 2);	/* typlen */
 	pq_sendint(&buf, -1, 4);		/* typmod */
@@ -50,7 +50,7 @@ SendProbeResponse(ProbeResponse *response)
 
 	/* Send a DataRow message */
 	pq_beginmessage(&buf, 'D');
-	pq_sendint(&buf, Natts_fts_probe_response, 2);		/* # of columns */
+	pq_sendint(&buf, Natts_fts_message_response, 2);		/* # of columns */
 
 	pq_sendint(&buf, 1, 4); /* col1 len */
 	pq_sendint(&buf, response->IsMirrorUp, 1);
@@ -66,12 +66,12 @@ SendProbeResponse(ProbeResponse *response)
 void
 HandleFtsWalRepProbe()
 {
-	ProbeResponse response;
+	FtsResponse response;
 
 	GetMirrorStatus(&response.IsMirrorUp, &response.IsInSync);
 
 	if (response.IsMirrorUp)
 		SetSyncStandbysDefined();
 
-	SendProbeResponse(&response);
+	SendFtsResponse(&response);
 }

--- a/src/backend/fts/ftsmessagehandler.c
+++ b/src/backend/fts/ftsmessagehandler.c
@@ -20,16 +20,16 @@
 #include "replication/gp_replication.h"
 
 static void
-SendFtsResponse(FtsResponse *response)
+SendFtsResponse(FtsResponse *response, const char *messagetype)
 {
 	StringInfoData buf;
 
 	initStringInfo(&buf);
 
-	BeginCommand(FTS_MSG_TYPE_PROBE, DestRemote);
+	BeginCommand(messagetype, DestRemote);
 
 	pq_beginmessage(&buf, 'T');
-	pq_sendint(&buf, Natts_fts_message_response, 2); /* 2 fields */
+	pq_sendint(&buf, Natts_fts_message_response, 2); /* 3 fields */
 
 	pq_sendstring(&buf, "is_mirror_up");
 	pq_sendint(&buf, 0, 4);		/* table oid */
@@ -46,6 +46,15 @@ SendFtsResponse(FtsResponse *response)
 	pq_sendint(&buf, 1, 2);	/* typlen */
 	pq_sendint(&buf, -1, 4);		/* typmod */
 	pq_sendint(&buf, 0, 2);		/* format code */
+
+	pq_sendstring(&buf, "is_syncrep_enabled");
+	pq_sendint(&buf, 0, 4);		/* table oid */
+	pq_sendint(&buf, Anum_fts_message_response_is_syncrep_enabled, 2);		/* attnum */
+	pq_sendint(&buf, BOOLOID, 4);		/* type oid */
+	pq_sendint(&buf, 1, 2);	/* typlen */
+	pq_sendint(&buf, -1, 4);		/* typmod */
+	pq_sendint(&buf, 0, 2);		/* format code */
+
 	pq_endmessage(&buf);
 
 	/* Send a DataRow message */
@@ -58,20 +67,55 @@ SendFtsResponse(FtsResponse *response)
 	pq_sendint(&buf, 1, 4); /* col2 len */
 	pq_sendint(&buf, response->IsInSync, 1);
 
+	pq_sendint(&buf, 1, 4); /* col3 len */
+	pq_sendint(&buf, response->IsSyncRepEnabled, 1);
+
 	pq_endmessage(&buf);
-	EndCommand(FTS_MSG_TYPE_PROBE, DestRemote);
+	EndCommand(messagetype, DestRemote);
 	pq_flush();
 }
 
-void
-HandleFtsWalRepProbe()
+static void
+HandleFtsWalRepProbe(void)
 {
 	FtsResponse response;
 
-	GetMirrorStatus(&response.IsMirrorUp, &response.IsInSync);
+	GetMirrorStatus(&response);
 
-	if (response.IsMirrorUp)
+	/*
+	 * We check response.IsSyncRepEnabled even though syncrep is again checked
+	 * later in the set function to avoid acquiring the SyncRepLock again.
+	 */
+	if (response.IsMirrorUp && !response.IsSyncRepEnabled)
 		SetSyncStandbysDefined();
 
-	SendFtsResponse(&response);
+	SendFtsResponse(&response, FTS_MSG_TYPE_PROBE);
+}
+
+static void
+HandleFtsWalRepSyncRepOff(void)
+{
+	FtsResponse response;
+
+	GetMirrorStatus(&response);
+
+	ereport(LOG,
+			(errmsg("turning off synchronous wal replication due to FTS request")));
+	UnsetSyncStandbysDefined();
+
+	SendFtsResponse(&response, FTS_MSG_TYPE_SYNCREP_OFF);
+}
+
+void
+HandleFtsMessage(const char* query_string)
+{
+	if (strncmp(query_string, FTS_MSG_TYPE_PROBE,
+				strlen(FTS_MSG_TYPE_PROBE)) == 0)
+		HandleFtsWalRepProbe();
+	else if (strncmp(query_string, FTS_MSG_TYPE_SYNCREP_OFF,
+					 strlen(FTS_MSG_TYPE_SYNCREP_OFF)) == 0)
+		HandleFtsWalRepSyncRepOff();
+	else
+		ereport(ERROR,
+				(errmsg("received unknown FTS query: %s", query_string)));
 }

--- a/src/backend/fts/ftsmessagehandler.c
+++ b/src/backend/fts/ftsmessagehandler.c
@@ -89,7 +89,7 @@ HandleFtsWalRepProbe(void)
 	if (response.IsMirrorUp && !response.IsSyncRepEnabled)
 		SetSyncStandbysDefined();
 
-	SendFtsResponse(&response, FTS_MSG_TYPE_PROBE);
+	SendFtsResponse(&response, FTS_MSG_PROBE);
 }
 
 static void
@@ -102,17 +102,17 @@ HandleFtsWalRepSyncRepOff(void)
 	UnsetSyncStandbysDefined();
 	GetMirrorStatus(&response);
 
-	SendFtsResponse(&response, FTS_MSG_TYPE_SYNCREP_OFF);
+	SendFtsResponse(&response, FTS_MSG_SYNCREP_OFF);
 }
 
 void
 HandleFtsMessage(const char* query_string)
 {
-	if (strncmp(query_string, FTS_MSG_TYPE_PROBE,
-				strlen(FTS_MSG_TYPE_PROBE)) == 0)
+	if (strncmp(query_string, FTS_MSG_PROBE,
+				strlen(FTS_MSG_PROBE)) == 0)
 		HandleFtsWalRepProbe();
-	else if (strncmp(query_string, FTS_MSG_TYPE_SYNCREP_OFF,
-					 strlen(FTS_MSG_TYPE_SYNCREP_OFF)) == 0)
+	else if (strncmp(query_string, FTS_MSG_SYNCREP_OFF,
+					 strlen(FTS_MSG_SYNCREP_OFF)) == 0)
 		HandleFtsWalRepSyncRepOff();
 	else
 		ereport(ERROR,

--- a/src/backend/fts/ftsmessagehandler.c
+++ b/src/backend/fts/ftsmessagehandler.c
@@ -87,7 +87,11 @@ HandleFtsWalRepProbe(void)
 	 * later in the set function to avoid acquiring the SyncRepLock again.
 	 */
 	if (response.IsMirrorUp && !response.IsSyncRepEnabled)
+	{
 		SetSyncStandbysDefined();
+		/* Syncrep is enabled now, so respond accordingly. */
+		response.IsSyncRepEnabled = true;
+	}
 
 	SendFtsResponse(&response, FTS_MSG_PROBE);
 }

--- a/src/backend/fts/ftsprobe.c
+++ b/src/backend/fts/ftsprobe.c
@@ -215,6 +215,10 @@ ftsReceive(FtsConnectionInfo *ftsInfo)
 	 */
 	if (ftsInfo->messagetype == FTS_MSG_TYPE_PROBE)
 		probeRecordResponse(ftsInfo, lastResult);
+	/* Primary must have syncrep disabled in response to SYNCREP_OFF message. */
+	AssertImply(ftsInfo->messagetype == FTS_MSG_TYPE_SYNCREP_OFF,
+				PQgetvalue(lastResult, 0, Anum_fts_message_response_is_syncrep_enabled) != NULL &&
+				*(PQgetvalue(lastResult, 0, Anum_fts_message_response_is_syncrep_enabled)) == false);
 
 	return true;
 }

--- a/src/backend/fts/ftsprobe.c
+++ b/src/backend/fts/ftsprobe.c
@@ -297,7 +297,7 @@ messageWalRepSegmentFromThread(void *arg)
 
 	int number_of_probed_segments = 0;
 
-	while(number_of_probed_segments < context->count)
+	while(number_of_probed_segments < context->num_primary_segments)
 	{
 		/*
 		 * Look for the unprocessed context
@@ -305,7 +305,7 @@ messageWalRepSegmentFromThread(void *arg)
 		int response_index = number_of_probed_segments;
 
 		pthread_mutex_lock(&worker_thread_mutex);
-		while(response_index < context->count)
+		while(response_index < context->num_primary_segments)
 		{
 			if (!context->responses[response_index].isScheduled)
 			{
@@ -320,7 +320,7 @@ messageWalRepSegmentFromThread(void *arg)
 		/*
 		 * If probed all the segments, we are done.
 		 */
-		if (response_index == context->count)
+		if (response_index == context->num_primary_segments)
 			break;
 
 		/*

--- a/src/backend/fts/test/Makefile
+++ b/src/backend/fts/test/Makefile
@@ -3,11 +3,11 @@ top_builddir=../../../..
 include $(top_builddir)/src/Makefile.global
 
 ifeq ($(enable_segwalrep), yes)
-TARGETS=ftsprobehandler ftsprobe fts
+TARGETS=ftsmessagehandler ftsprobe fts
 
 include $(top_builddir)/src/backend/mock.mk
 
-ftsprobehandler.t: \
+ftsmessagehandler.t: \
     $(MOCK_DIR)/backend/utils/error/assert_mock.o \
     $(MOCK_DIR)/backend/utils/error/elog_mock.o \
     $(MOCK_DIR)/backend/storage/lmgr/lwlock_mock.o \

--- a/src/backend/fts/test/Makefile
+++ b/src/backend/fts/test/Makefile
@@ -9,7 +9,6 @@ include $(top_builddir)/src/backend/mock.mk
 
 ftsmessagehandler.t: \
     $(MOCK_DIR)/backend/utils/error/assert_mock.o \
-    $(MOCK_DIR)/backend/utils/error/elog_mock.o \
     $(MOCK_DIR)/backend/storage/lmgr/lwlock_mock.o \
     $(MOCK_DIR)/backend/replication/gp_replication_mock.o \
     $(MOCK_DIR)/backend/lib/stringinfo_mock.o \

--- a/src/backend/fts/test/fts_test.c
+++ b/src/backend/fts/test/fts_test.c
@@ -389,8 +389,11 @@ test_PrimayUpMirrorUpNotInSync_to_PrimayUpMirrorUpNotInSync(void **state)
 									GP_SEGMENT_CONFIGURATION_MODE_NOTINSYNC);
 	FtsWalRepInitProbeContext(cdb_component_dbs, &context);
 
+	/* Primary must block commits as long as it and its mirror are alive. */
 	context.responses[0].result.isPrimaryAlive = true;
+	context.responses[0].result.isSyncRepEnabled = true;
 	context.responses[1].result.isPrimaryAlive = true;
+	context.responses[1].result.isSyncRepEnabled = true;
 
 	/* probeWalRepPublishUpdate should not update a probe state */
 	bool is_updated =
@@ -422,6 +425,7 @@ test_PrimayUpMirrorUpNotInSync_to_PrimaryDown(void **state)
 
 	/* Response received from second segment */
 	context.responses[1].result.isPrimaryAlive = true;
+	context.responses[1].result.isSyncRepEnabled = true;
 
 	/* No update must happen */
 	bool is_updated =
@@ -455,8 +459,9 @@ test_PrimayUpMirrorUpNotInSync_to_PrimaryUpMirrorDownNotInSync(void **state)
 	context.responses[0].result.isPrimaryAlive = true;
 	context.responses[0].result.isMirrorAlive = false;
 
+	/* Syncrep must be enabled because mirror is up. */
 	context.responses[1].result.isPrimaryAlive = true;
-
+	context.responses[1].result.isSyncRepEnabled = true;
 
 	/* the mirror will be updated */
 	PrimaryOrMirrorWillBeUpdated(1);
@@ -510,7 +515,9 @@ test_PrimaryUpMirrorDownNotInSync_to_PrimayUpMirrorUpNotInSync(void **state)
 
 	/* no change */
 	context.responses[1].result.isPrimaryAlive = true;
+	context.responses[1].result.isSyncRepEnabled = true;
 	context.responses[2].result.isPrimaryAlive = true;
+	context.responses[2].result.isSyncRepEnabled = true;
 
 	/* the mirror will be updated */
 	PrimaryOrMirrorWillBeUpdated(1);
@@ -572,6 +579,7 @@ test_probeWalRepPublishUpdate_multiple_segments(void **state)
 
 	/* Fourth segment, response received no change */
 	context.responses[3].result.isPrimaryAlive = true;
+	context.responses[3].result.isSyncRepEnabled = true;
 
 	/* we are updating two of the four segments */
 	PrimaryOrMirrorWillBeUpdated(2);
@@ -726,6 +734,7 @@ test_PrimayUpMirrorUpSync_to_PrimaryDown(void **state)
 
 	/* Probe responded with Mirror Up and Not In SYNC */
 	context.responses[0].result.isPrimaryAlive = false;
+	context.responses[0].result.isSyncRepEnabled = true;
 
 	/* we are updating one segment pair */
 	PrimaryOrMirrorWillBeUpdated(1);
@@ -766,6 +775,7 @@ test_PrimayUpMirrorUpNotInSync_to_PrimayUpMirrorUpSync(void **state)
 	/* Probe responded with Mirror Up and SYNC */
 	context.responses[0].result.isPrimaryAlive = true;
 	context.responses[0].result.isInSync = true;
+	context.responses[0].result.isSyncRepEnabled = true;
 
 	/* we are updating one segment pair */
 	PrimaryOrMirrorWillBeUpdated(1);
@@ -898,6 +908,7 @@ test_PrimaryUpMirrorDownNotInSync_to_PrimaryDown(void **state)
 
 	/* no change for segment 2, probe returned */
 	context.responses[1].result.isPrimaryAlive = true;
+	context.responses[1].result.isSyncRepEnabled = true;
 
 	bool is_updated =
 		probeWalRepPublishUpdate(cdb_component_dbs, &context, &need_syncrep_disabled);

--- a/src/backend/fts/test/fts_test.c
+++ b/src/backend/fts/test/fts_test.c
@@ -301,7 +301,7 @@ PrimaryOrMirrorWillBeUpdated(int count)
 void
 test_probeWalRepPublishUpdate_for_zero_segment(void **state)
 {
-	probe_context context;
+	fts_context context;
 
 	context.count = 0;
 
@@ -316,7 +316,7 @@ test_probeWalRepPublishUpdate_for_zero_segment(void **state)
 void
 test_probeWalRepPublishUpdate_for_FtsIsActive_false(void **state)
 {
-	probe_context context;
+	fts_context context;
 
 	context.count = 1;
 	probe_response_per_segment response;
@@ -341,7 +341,7 @@ test_probeWalRepPublishUpdate_for_FtsIsActive_false(void **state)
 void
 test_probeWalRepPublishUpdate_for_shutdown_requested(void **state)
 {
-	probe_context context;
+	fts_context context;
 
 	context.count = 1;
 	probe_response_per_segment response;
@@ -371,7 +371,7 @@ test_probeWalRepPublishUpdate_for_shutdown_requested(void **state)
 void
 test_PrimayUpMirrorUpNotInSync_to_PrimayUpMirrorUpNotInSync(void **state)
 {
-	probe_context context;
+	fts_context context;
 	CdbComponentDatabases *cdb_component_dbs;
 
 	cdb_component_dbs = InitTestCdb(2,
@@ -397,7 +397,7 @@ test_PrimayUpMirrorUpNotInSync_to_PrimayUpMirrorUpNotInSync(void **state)
 void
 test_PrimayUpMirrorUpNotInSync_to_PrimaryDown(void **state)
 {
-	probe_context context;
+	fts_context context;
 	CdbComponentDatabases *cdb_component_dbs;
 
 	cdb_component_dbs = InitTestCdb(2,
@@ -423,7 +423,7 @@ test_PrimayUpMirrorUpNotInSync_to_PrimaryDown(void **state)
 void
 test_PrimayUpMirrorUpNotInSync_to_PrimaryUpMirrorDownNotInSync(void **state)
 {
-	probe_context context;
+	fts_context context;
 	CdbComponentDatabases *cdb_component_dbs;
 
 	cdb_component_dbs = InitTestCdb(2,
@@ -465,7 +465,7 @@ test_PrimayUpMirrorUpNotInSync_to_PrimaryUpMirrorDownNotInSync(void **state)
 void
 test_PrimaryUpMirrorDownNotInSync_to_PrimayUpMirrorUpNotInSync(void **state)
 {
-	probe_context context;
+	fts_context context;
 	CdbComponentDatabases *cdb_component_dbs;
 
 	cdb_component_dbs = InitTestCdb(3,
@@ -515,7 +515,7 @@ test_PrimaryUpMirrorDownNotInSync_to_PrimayUpMirrorUpNotInSync(void **state)
 void
 test_probeWalRepPublishUpdate_multiple_segments(void **state)
 {
-	probe_context context;
+	fts_context context;
 	CdbComponentDatabases *cdb_component_dbs;
 
 	cdb_component_dbs = InitTestCdb(4,
@@ -586,7 +586,7 @@ test_probeWalRepPublishUpdate_multiple_segments(void **state)
 void
 test_PrimayUpMirrorUpSync_to_PrimaryUpMirrorUpNotInSync(void **state)
 {
-	probe_context context;
+	fts_context context;
 	CdbComponentDatabases *cdb_component_dbs;
 
 	/* Start in SYNC state */
@@ -624,7 +624,7 @@ test_PrimayUpMirrorUpSync_to_PrimaryUpMirrorUpNotInSync(void **state)
 void
 test_PrimayUpMirrorUpSync_to_PrimaryUpMirrorDownNotInSync(void **state)
 {
-	probe_context context;
+	fts_context context;
 	CdbComponentDatabases *cdb_component_dbs;
 
 	/* Start in SYNC mode */
@@ -663,7 +663,7 @@ test_PrimayUpMirrorUpSync_to_PrimaryUpMirrorDownNotInSync(void **state)
 void
 test_PrimayUpMirrorUpSync_to_PrimaryDown(void **state)
 {
-	probe_context context;
+	fts_context context;
 	CdbComponentDatabases *cdb_component_dbs;
 
 	/* set the mode to SYNC in config */
@@ -700,7 +700,7 @@ test_PrimayUpMirrorUpSync_to_PrimaryDown(void **state)
 void
 test_PrimayUpMirrorUpNotInSync_to_PrimayUpMirrorUpSync(void **state)
 {
-	probe_context context;
+	fts_context context;
 	CdbComponentDatabases *cdb_component_dbs;
 
 	cdb_component_dbs = InitTestCdb(1,
@@ -737,7 +737,7 @@ test_PrimayUpMirrorUpNotInSync_to_PrimayUpMirrorUpSync(void **state)
 void
 test_PrimaryUpMirrorDownNotInSync_to_PrimayUpMirrorUpSync(void **state)
 {
-	probe_context context;
+	fts_context context;
 	CdbComponentDatabases *cdb_component_dbs;
 
 	cdb_component_dbs = InitTestCdb(1,
@@ -781,7 +781,7 @@ test_PrimaryUpMirrorDownNotInSync_to_PrimayUpMirrorUpSync(void **state)
 void
 test_PrimaryUpMirrorDownNotInSync_to_PrimayUpMirrorDownNotInSync(void **state)
 {
-	probe_context context;
+	fts_context context;
 	CdbComponentDatabases *cdb_component_dbs;
 
 	cdb_component_dbs = InitTestCdb(1,
@@ -815,7 +815,7 @@ test_PrimaryUpMirrorDownNotInSync_to_PrimayUpMirrorDownNotInSync(void **state)
 void
 test_PrimaryUpMirrorDownNotInSync_to_PrimaryDown(void **state)
 {
-	probe_context context;
+	fts_context context;
 	CdbComponentDatabases *cdb_component_dbs;
 
 	cdb_component_dbs = InitTestCdb(2,

--- a/src/backend/fts/test/fts_test.c
+++ b/src/backend/fts/test/fts_test.c
@@ -499,6 +499,7 @@ test_PrimaryUpMirrorDownNotInSync_to_PrimayUpMirrorUpNotInSync(void **state)
 	context.responses[0].result.isPrimaryAlive = true;
 	context.responses[0].result.isMirrorAlive = true;
 	context.responses[0].isScheduled = true;
+	context.responses[0].result.isSyncRepEnabled = true;
 
 	/* no change */
 	context.responses[1].result.isPrimaryAlive = true;
@@ -555,6 +556,7 @@ test_probeWalRepPublishUpdate_multiple_segments(void **state)
 	/* First segment DOWN mirror, now reported UP */
 	context.responses[0].result.isPrimaryAlive = true;
 	context.responses[0].result.isMirrorAlive = true;
+	context.responses[0].result.isSyncRepEnabled = true;
 
 	/* Second segment no response received */
 
@@ -799,6 +801,7 @@ test_PrimaryUpMirrorDownNotInSync_to_PrimayUpMirrorUpSync(void **state)
 	context.responses[0].result.isPrimaryAlive = true;
 	context.responses[0].result.isMirrorAlive = true;
 	context.responses[0].result.isInSync = true;
+	context.responses[0].result.isSyncRepEnabled = true;
 
 	/* we are updating one segment pair */
 	PrimaryOrMirrorWillBeUpdated(1);

--- a/src/backend/fts/test/ftsmessagehandler_test.c
+++ b/src/backend/fts/test/ftsmessagehandler_test.c
@@ -17,15 +17,10 @@ void AssertFailed()
 /* Actual function body */
 #include "../ftsmessagehandler.c"
 
-void
-test_HandleFtsWalRepProbe(void **state)
+static void
+mockSendFtsResponse(const char *messagetype)
 {
-	expect_any(GetMirrorStatus, IsMirrorUp);
-	expect_any(GetMirrorStatus, IsInSync);
-	will_assign_value(GetMirrorStatus, IsMirrorUp, true);
-	will_be_called(GetMirrorStatus);
-
-	expect_value(BeginCommand, commandTag, FTS_MSG_TYPE_PROBE);
+	expect_value(BeginCommand, commandTag, messagetype);
 	expect_value(BeginCommand, dest, DestRemote);
 	will_be_called(BeginCommand);
 
@@ -57,15 +52,48 @@ test_HandleFtsWalRepProbe(void **state)
 	expect_any_count(pq_sendstring, str, -1);
 	will_be_called_count(pq_sendstring, -1);
 
-	will_be_called(pq_flush);
-
-	expect_value(EndCommand, commandTag, FTS_MSG_TYPE_PROBE);
+	expect_value(EndCommand, commandTag, messagetype);
 	expect_value(EndCommand, dest, DestRemote);
 	will_be_called(EndCommand);
 
+	will_be_called(pq_flush);
+}
+void
+test_HandleFtsWalRepProbe(void **state)
+{
+	FtsResponse mockresponse;
+	mockresponse.IsMirrorUp = true;
+	mockresponse.IsInSync = true;
+	mockresponse.IsSyncRepEnabled = false;
+
+	expect_any(GetMirrorStatus, response);
+	will_assign_memory(GetMirrorStatus, response, &mockresponse, sizeof(FtsResponse));
+	will_be_called(GetMirrorStatus);
+
 	will_be_called(SetSyncStandbysDefined);
 
+	mockSendFtsResponse(FTS_MSG_TYPE_PROBE);
+
 	HandleFtsWalRepProbe();
+}
+
+void
+test_HandleFtsWalRepSyncRepOff(void **state)
+{
+	FtsResponse mockresponse;
+	mockresponse.IsMirrorUp = false;
+	mockresponse.IsInSync = false;
+	mockresponse.IsSyncRepEnabled = true;
+
+	expect_any(GetMirrorStatus, response);
+	will_assign_memory(GetMirrorStatus, response, &mockresponse, sizeof(FtsResponse));
+	will_be_called(GetMirrorStatus);
+
+	will_be_called(UnsetSyncStandbysDefined);
+
+	mockSendFtsResponse(FTS_MSG_TYPE_SYNCREP_OFF);
+
+	HandleFtsWalRepSyncRepOff();
 }
 
 int
@@ -74,7 +102,8 @@ main(int argc, char* argv[])
 	cmockery_parse_arguments(argc, argv);
 
 	const UnitTest tests[] = {
-		unit_test(test_HandleFtsWalRepProbe)
+		unit_test(test_HandleFtsWalRepProbe),
+		unit_test(test_HandleFtsWalRepSyncRepOff)
 	};
 	return run_tests(tests);
 }

--- a/src/backend/fts/test/ftsmessagehandler_test.c
+++ b/src/backend/fts/test/ftsmessagehandler_test.c
@@ -72,7 +72,7 @@ test_HandleFtsWalRepProbe(void **state)
 
 	will_be_called(SetSyncStandbysDefined);
 
-	mockSendFtsResponse(FTS_MSG_TYPE_PROBE);
+	mockSendFtsResponse(FTS_MSG_PROBE);
 
 	HandleFtsWalRepProbe();
 }
@@ -91,7 +91,7 @@ test_HandleFtsWalRepSyncRepOff(void **state)
 
 	will_be_called(UnsetSyncStandbysDefined);
 
-	mockSendFtsResponse(FTS_MSG_TYPE_SYNCREP_OFF);
+	mockSendFtsResponse(FTS_MSG_SYNCREP_OFF);
 
 	HandleFtsWalRepSyncRepOff();
 }

--- a/src/backend/fts/test/ftsmessagehandler_test.c
+++ b/src/backend/fts/test/ftsmessagehandler_test.c
@@ -15,7 +15,7 @@ void AssertFailed()
 }
 
 /* Actual function body */
-#include "../ftsprobehandler.c"
+#include "../ftsmessagehandler.c"
 
 void
 test_HandleFtsWalRepProbe(void **state)

--- a/src/backend/fts/test/ftsprobe_test.c
+++ b/src/backend/fts/test/ftsprobe_test.c
@@ -30,7 +30,7 @@ static void write_log_will_be_called()
 	will_be_called(write_log);
 }
 
-static void probeTimeout_mock_timeout(ProbeConnectionInfo *info)
+static void probeTimeout_mock_timeout(FtsConnectionInfo *info)
 {
 	/*
 	 * set info->startTime to set proper elapse_ms
@@ -43,7 +43,7 @@ static void probeTimeout_mock_timeout(ProbeConnectionInfo *info)
 	write_log_will_be_called();
 }
 
-static void probePollIn_mock_success(ProbeConnectionInfo *info)
+static void probePollIn_mock_success(FtsConnectionInfo *info)
 {
 	expect_any(PQsocket, conn);
 	will_be_called(PQsocket);
@@ -52,7 +52,7 @@ static void probePollIn_mock_success(ProbeConnectionInfo *info)
 }
 
 
-static void probePollIn_mock_timeout(ProbeConnectionInfo *info)
+static void probePollIn_mock_timeout(FtsConnectionInfo *info)
 {
 	expect_any(PQsocket, conn);
 	will_be_called(PQsocket);
@@ -103,15 +103,15 @@ static void PQclear_will_be_called()
 }
 
 /*
- * Scenario: if primary didn't respond in time to FTS probe, probeReceive on
+ * Scenario: if primary didn't respond in time to FTS probe, ftsReceive on
  * master should fail.
  *
  * We are mocking the timeout behavior using probeTimeout().
  */
 void
-test_probeReceive_when_fts_handler_hung(void **state)
+test_ftsReceive_when_fts_handler_hung(void **state)
 {
-	ProbeConnectionInfo info;
+	FtsConnectionInfo info;
 	struct pg_conn conn;
 
 	info.conn = &conn;
@@ -126,19 +126,19 @@ test_probeReceive_when_fts_handler_hung(void **state)
 	/*
 	 * TEST
 	 */
-	bool actual_return_value = probeReceive(&info);
+	bool actual_return_value = ftsReceive(&info);
 
 	assert_false(actual_return_value);
 }
 
 /*
- * Scenario: if primary responds FATAL to FTS probe, probeReceive on master
+ * Scenario: if primary responds FATAL to FTS probe, ftsReceive on master
  * should fail due to PQconsumeInput() failed
  */
 void
-test_probeReceive_when_fts_handler_FATAL(void **state)
+test_ftsReceive_when_fts_handler_FATAL(void **state)
 {
-	ProbeConnectionInfo info;
+	FtsConnectionInfo info;
 	struct pg_conn conn;
 
 	info.conn = &conn;
@@ -154,19 +154,19 @@ test_probeReceive_when_fts_handler_FATAL(void **state)
 	/*
 	 * TEST
 	 */
-	bool actual_return_value = probeReceive(&info);
+	bool actual_return_value = ftsReceive(&info);
 
 	assert_false(actual_return_value);
 }
 
 /*
- * Scenario: if primary response ERROR to FTS probe, probeReceive on master
+ * Scenario: if primary response ERROR to FTS probe, ftsReceive on master
  * should fail due to PQresultStatus(lastResult) returned PGRES_FATAL_ERROR
  */
 void
-test_probeReceive_when_fts_handler_ERROR(void **state)
+test_ftsReceive_when_fts_handler_ERROR(void **state)
 {
-	ProbeConnectionInfo info;
+	FtsConnectionInfo info;
 	struct pg_conn conn;
 
 	info.conn = &conn;
@@ -187,7 +187,7 @@ test_probeReceive_when_fts_handler_ERROR(void **state)
 	/*
 	 * TEST
 	 */
-	bool actual_return_value = probeReceive(&info);
+	bool actual_return_value = ftsReceive(&info);
 
 	assert_false(actual_return_value);
 }
@@ -198,9 +198,9 @@ main(int argc, char* argv[])
 	cmockery_parse_arguments(argc, argv);
 
 	const UnitTest tests[] = {
-		unit_test(test_probeReceive_when_fts_handler_hung),
-		unit_test(test_probeReceive_when_fts_handler_FATAL),
-		unit_test(test_probeReceive_when_fts_handler_ERROR),
+		unit_test(test_ftsReceive_when_fts_handler_hung),
+		unit_test(test_ftsReceive_when_fts_handler_FATAL),
+		unit_test(test_ftsReceive_when_fts_handler_ERROR),
 	};
 	return run_tests(tests);
 }

--- a/src/backend/replication/gp_replication.c
+++ b/src/backend/replication/gp_replication.c
@@ -15,6 +15,7 @@
 #include "replication/walsender_private.h"
 #include "utils/builtins.h"
 
+#ifdef USE_SEGWALREP
 /*
  * Check the WalSndCtl to obtain if mirror is up or down, if the wal sender is
  * in streaming, and if synchronous replication is enabled or not.
@@ -54,7 +55,6 @@ void GetMirrorStatus(FtsResponse *response)
 	LWLockRelease(SyncRepLock);
 }
 
-#ifdef USE_SEGWALREP
 /*
  * Set WalSndCtl->sync_standbys_defined to true to enable synchronous segment
  * WAL replication and insert synchronous_standby_names="*" into the

--- a/src/backend/replication/test/Makefile
+++ b/src/backend/replication/test/Makefile
@@ -11,5 +11,6 @@ gp_replication.t: \
     $(MOCK_DIR)/backend/utils/error/assert_mock.o \
     $(MOCK_DIR)/backend/utils/error/elog_mock.o \
 	$(MOCK_DIR)/backend/utils/misc/guc_gp_mock.o \
-    $(MOCK_DIR)/backend/storage/lmgr/lwlock_mock.o
+    $(MOCK_DIR)/backend/storage/lmgr/lwlock_mock.o \
+	$(MOCK_DIR)/backend/storage/ipc/shmqueue_mock.o
 endif

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -5022,11 +5022,7 @@ PostgresMain(int argc, char *argv[],
 						exec_replication_command(query_string);
 #ifdef USE_SEGWALREP
 					else if (am_ftshandler)
-					{
-						Assert(strncmp(query_string, FTS_MSG_TYPE_PROBE,
-									   strlen(FTS_MSG_TYPE_PROBE)) == 0);
-						HandleFtsWalRepProbe();
-					}
+						HandleFtsMessage(query_string);
 #endif
 					else
 						exec_simple_query(query_string, NULL, -1);

--- a/src/include/postmaster/fts.h
+++ b/src/include/postmaster/fts.h
@@ -22,8 +22,8 @@
 #ifdef USE_SEGWALREP
 
 /* Queries for FTS messages */
-#define	FTS_MSG_TYPE_PROBE "PROBE"
-#define FTS_MSG_TYPE_SYNCREP_OFF "SYNCREP_OFF"
+#define	FTS_MSG_PROBE "PROBE"
+#define FTS_MSG_SYNCREP_OFF "SYNCREP_OFF"
 
 #define Natts_fts_message_response 3
 #define Anum_fts_message_response_is_mirror_up 0
@@ -46,11 +46,11 @@ typedef struct
 	CdbComponentDatabaseInfo *segment_db_info;
 	probe_result result;
 	bool isScheduled;
+	const char *message;
 } probe_response_per_segment;
 
 typedef struct
 {
-	const char *messagetype; /* probe or turn off syncrep */
 	int num_primary_segments; /* total number of primary segments */
 	probe_response_per_segment *responses;
 } fts_context;

--- a/src/include/postmaster/fts.h
+++ b/src/include/postmaster/fts.h
@@ -24,11 +24,11 @@
 /* Queries for FTS messages */
 #define	FTS_MSG_TYPE_PROBE "PROBE"
 
-#define Natts_fts_probe_response 2
-#define Anum_fts_probe_response_is_mirror_up 0
-#define Anum_fts_probe_response_is_in_sync 1
+#define Natts_fts_message_response 2
+#define Anum_fts_message_response_is_mirror_up 0
+#define Anum_fts_message_response_is_in_sync 1
 
-#define FTS_PROBE_RESPONSE_NTUPLES 1
+#define FTS_MESSAGE_RESPONSE_NTUPLES 1
 
 typedef struct
 {
@@ -49,13 +49,13 @@ typedef struct
 {
 	int count;
 	probe_response_per_segment *responses;
-} probe_context;
+} fts_context;
 
-typedef struct ProbeResponse
+typedef struct FtsResponse
 {
 	bool IsMirrorUp;
 	bool IsInSync;
-} ProbeResponse;
+} FtsResponse;
 
 #endif
 
@@ -164,7 +164,7 @@ extern bool FtsIsActive(void);
  * Interface for WALREP specific checking
  */
 extern void HandleFtsWalRepProbe(void);
-extern void FtsWalRepProbeSegments(probe_context *context);
+extern void FtsWalRepMessageSegments(fts_context *context);
 #else
 extern bool probePublishUpdate(CdbComponentDatabases *dbs, uint8 *probe_results);
 

--- a/src/include/postmaster/fts.h
+++ b/src/include/postmaster/fts.h
@@ -51,7 +51,7 @@ typedef struct
 typedef struct
 {
 	const char *messagetype; /* probe or turn off syncrep */
-	int count;
+	int num_primary_segments; /* total number of primary segments */
 	probe_response_per_segment *responses;
 } fts_context;
 

--- a/src/include/postmaster/fts.h
+++ b/src/include/postmaster/fts.h
@@ -23,10 +23,12 @@
 
 /* Queries for FTS messages */
 #define	FTS_MSG_TYPE_PROBE "PROBE"
+#define FTS_MSG_TYPE_SYNCREP_OFF "SYNCREP_OFF"
 
-#define Natts_fts_message_response 2
+#define Natts_fts_message_response 3
 #define Anum_fts_message_response_is_mirror_up 0
 #define Anum_fts_message_response_is_in_sync 1
+#define Anum_fts_message_response_is_syncrep_enabled 2
 
 #define FTS_MESSAGE_RESPONSE_NTUPLES 1
 
@@ -36,6 +38,7 @@ typedef struct
 	bool isPrimaryAlive;
 	bool isMirrorAlive;
 	bool isInSync;
+	bool isSyncRepEnabled;
 } probe_result;
 
 typedef struct
@@ -47,6 +50,7 @@ typedef struct
 
 typedef struct
 {
+	const char *messagetype; /* probe or turn off syncrep */
 	int count;
 	probe_response_per_segment *responses;
 } fts_context;
@@ -55,6 +59,7 @@ typedef struct FtsResponse
 {
 	bool IsMirrorUp;
 	bool IsInSync;
+	bool IsSyncRepEnabled;
 } FtsResponse;
 
 #endif
@@ -163,7 +168,7 @@ extern bool FtsIsActive(void);
 /*
  * Interface for WALREP specific checking
  */
-extern void HandleFtsWalRepProbe(void);
+extern void HandleFtsMessage(const char* query_string);
 extern void FtsWalRepMessageSegments(fts_context *context);
 #else
 extern bool probePublishUpdate(CdbComponentDatabases *dbs, uint8 *probe_results);

--- a/src/include/postmaster/ftsprobe.h
+++ b/src/include/postmaster/ftsprobe.h
@@ -34,7 +34,7 @@ typedef struct FtsConnectionInfo
 	int16 probe_errno;                   /* saved errno from the latest system call */
 	char errmsg[PROBE_ERR_MSG_LEN];      /* message returned by strerror() */
 	struct pg_conn *conn;                        /* libpq connection object */
-	const char *messagetype;
+	const char *message;
 } FtsConnectionInfo;
 
 #ifndef USE_SEGWALREP

--- a/src/include/postmaster/ftsprobe.h
+++ b/src/include/postmaster/ftsprobe.h
@@ -34,6 +34,7 @@ typedef struct FtsConnectionInfo
 	int16 probe_errno;                   /* saved errno from the latest system call */
 	char errmsg[PROBE_ERR_MSG_LEN];      /* message returned by strerror() */
 	struct pg_conn *conn;                        /* libpq connection object */
+	const char *messagetype;
 } FtsConnectionInfo;
 
 #ifndef USE_SEGWALREP

--- a/src/include/postmaster/ftsprobe.h
+++ b/src/include/postmaster/ftsprobe.h
@@ -19,7 +19,7 @@
 #define PROBE_ERR_MSG_LEN   (256)        /* length of error message for errno */
 
 struct pg_conn; /* PGconn ... #include "gp-libpq-fe.h" */
-typedef struct ProbeConnectionInfo
+typedef struct FtsConnectionInfo
 {
 	int16 dbId;                          /* the dbid of the segment */
 	int16 segmentId;                     /* content indicator: -1 for master, 0, ..., n-1 for segments */
@@ -34,10 +34,14 @@ typedef struct ProbeConnectionInfo
 	int16 probe_errno;                   /* saved errno from the latest system call */
 	char errmsg[PROBE_ERR_MSG_LEN];      /* message returned by strerror() */
 	struct pg_conn *conn;                        /* libpq connection object */
-} ProbeConnectionInfo;
+} FtsConnectionInfo;
 
-extern char *errmessage(ProbeConnectionInfo *probeInfo);
-extern bool probePollIn(ProbeConnectionInfo *probeInfo);
-extern bool probeTimeout(ProbeConnectionInfo *probeInfo, const char* calledFrom);
+#ifndef USE_SEGWALREP
+typedef FtsConnectionInfo ProbeConnectionInfo;
+#endif
+
+extern char *errmessage(FtsConnectionInfo *probeInfo);
+extern bool probePollIn(FtsConnectionInfo *probeInfo);
+extern bool probeTimeout(FtsConnectionInfo *probeInfo, const char* calledFrom);
 
 #endif

--- a/src/include/replication/gp_replication.h
+++ b/src/include/replication/gp_replication.h
@@ -19,9 +19,11 @@
 
 #include "postmaster/fts.h"
 
+#ifdef USE_SEGWALREP
 extern void GetMirrorStatus(FtsResponse *response);
 extern void SetSyncStandbysDefined(void);
 extern void UnsetSyncStandbysDefined(void);
+#endif
 
 extern Datum gp_replication_error(PG_FUNCTION_ARGS __attribute__((unused)) );
 

--- a/src/include/replication/gp_replication.h
+++ b/src/include/replication/gp_replication.h
@@ -17,8 +17,11 @@
 #include "postgres.h"
 #include "fmgr.h"
 
-extern void GetMirrorStatus(bool *IsMirrorUp, bool *IsInSync);
+#include "postmaster/fts.h"
+
+extern void GetMirrorStatus(FtsResponse *response);
 extern void SetSyncStandbysDefined(void);
+extern void UnsetSyncStandbysDefined(void);
 
 extern Datum gp_replication_error(PG_FUNCTION_ARGS __attribute__((unused)) );
 

--- a/src/test/isolation2/Makefile
+++ b/src/test/isolation2/Makefile
@@ -21,7 +21,7 @@ override CPPFLAGS := -I$(srcdir) -I$(libpq_srcdir) -I$(srcdir)/../regress $(CPPF
 override LDLIBS := $(libpq_pgport) $(LDLIBS)
 
 ifeq ($(enable_segwalrep), yes)
-EXTRA_TESTS=segwalrep/commit_blocking
+EXTRA_TESTS=segwalrep/commit_blocking segwalrep/fts_unblock_primary
 endif
 
 all: pg_isolation2_regress$(X) all-lib

--- a/src/test/isolation2/expected/segwalrep/commit_blocking.out
+++ b/src/test/isolation2/expected/segwalrep/commit_blocking.out
@@ -81,6 +81,10 @@ server starting
 
 (1 row)
 
+-- should unblock and commit now that mirror is back up and in-sync
+3<:  <... completed>
+COMMIT
+
 -- turn on fts
 ! gpconfig -c gp_fts_probe_pause -v false --masteronly --skipvalidation;
 completed successfully with parameters '-c gp_fts_probe_pause -v false --masteronly --skipvalidation'
@@ -91,10 +95,6 @@ pg_ctl
 server signaled
 
 (1 row)
-
--- should unblock and commit now that mirror is back up
-3<:  <... completed>
-COMMIT
 
 -- everything should be back to normal
 4: insert into segwalrep_commit_blocking select i from generate_series(1,10)i;

--- a/src/test/isolation2/expected/segwalrep/fts_unblock_primary.out
+++ b/src/test/isolation2/expected/segwalrep/fts_unblock_primary.out
@@ -1,7 +1,7 @@
 -- This test assumes 3 primaries and 3 mirrors from a gpdemo segwalrep cluster
 
 -- function to wait for mirror to come up in sync (1 minute timeout)
-create or replace function wait_for_streaming() returns void as $$ declare updated bool; /* in func */ begin /* in func */ for i in 1 .. 120 loop /* in func */ perform gp_request_fts_probe_scan(); /* in func */ select (mode = 's' and status = 'u') into updated /* in func */ from gp_segment_configuration /* in func */ where content = 0 and role = 'm'; /* in func */ exit when updated; /* in func */ perform pg_sleep(0.5); /* in func */ end loop; /* in func */ end; /* in func */ $$ language plpgsql;
+create or replace function wait_for_streaming(contentid smallint) returns void as $$ declare updated bool; /* in func */ begin /* in func */ for i in 1 .. 120 loop /* in func */ perform gp_request_fts_probe_scan(); /* in func */ select (mode = 's' and status = 'u') into updated /* in func */ from gp_segment_configuration /* in func */ where content = contentid and role = 'm'; /* in func */ exit when updated; /* in func */ perform pg_sleep(0.5); /* in func */ end loop; /* in func */ end; /* in func */ $$ language plpgsql;
 CREATE
 
 -- start_ignore
@@ -15,11 +15,11 @@ return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replac
 CREATE
 
 -- make sure we are in-sync for the primary we will be testing with
-select content, role, preferred_role, mode, status from gp_segment_configuration where content=0;
+select content, role, preferred_role, mode, status from gp_segment_configuration where content=2;
 content|role|preferred_role|mode|status
 -------+----+--------------+----+------
-0      |p   |p             |s   |u     
-0      |m   |m             |s   |u     
+2      |p   |p             |s   |u     
+2      |m   |m             |s   |u     
 (2 rows)
 
 -- create table and show commits are not blocked
@@ -40,7 +40,7 @@ server signaled
 (1 row)
 
 -- stop a mirror
-1U: select pg_ctl((select fselocation from gp_segment_configuration c, pg_filespace_entry f where c.role='m' and c.content=0 and c.dbid = f.fsedbid), 'stop', NULL, NULL);
+1U: select pg_ctl((select fselocation from gp_segment_configuration c, pg_filespace_entry f where c.role='m' and c.content=2 and c.dbid = f.fsedbid), 'stop', NULL, NULL);
 pg_ctl                                              
 ----------------------------------------------------
 waiting for server to shut down done
@@ -76,11 +76,11 @@ gp_request_fts_probe_scan
 -------------------------
 t                        
 (1 row)
-select content, role, preferred_role, mode, status from gp_segment_configuration where content=0;
+select content, role, preferred_role, mode, status from gp_segment_configuration where content=2;
 content|role|preferred_role|mode|status
 -------+----+--------------+----+------
-0      |p   |p             |n   |u     
-0      |m   |m             |n   |d     
+2      |p   |p             |n   |u     
+2      |m   |m             |n   |d     
 (2 rows)
 
 -- should unblock and commit after FTS sent primary a SyncRepOff libpq message
@@ -88,22 +88,22 @@ content|role|preferred_role|mode|status
 COMMIT
 
 -- bring the mirror back up and see primary s/u and mirror s/u
-1U: select pg_ctl((select fselocation from gp_segment_configuration c, pg_filespace_entry f where c.role='m' and c.content=0 and c.dbid = f.fsedbid), 'start', (select port from gp_segment_configuration where content = 0 and preferred_role = 'm'), 0);
+1U: select pg_ctl((select fselocation from gp_segment_configuration c, pg_filespace_entry f where c.role='m' and c.content=2 and c.dbid = f.fsedbid), 'start', (select port from gp_segment_configuration where content = 2 and preferred_role = 'm'), 2);
 pg_ctl          
 ----------------
 server starting
 
 (1 row)
-select wait_for_streaming();
+select wait_for_streaming(2::smallint);
 wait_for_streaming
 ------------------
                   
 (1 row)
-select content, role, preferred_role, mode, status from gp_segment_configuration where content=0;
+select content, role, preferred_role, mode, status from gp_segment_configuration where content=2;
 content|role|preferred_role|mode|status
 -------+----+--------------+----+------
-0      |p   |p             |s   |u     
-0      |m   |m             |s   |u     
+2      |p   |p             |s   |u     
+2      |m   |m             |s   |u     
 (2 rows)
 
 -- everything is back to normal

--- a/src/test/isolation2/expected/segwalrep/fts_unblock_primary.out
+++ b/src/test/isolation2/expected/segwalrep/fts_unblock_primary.out
@@ -1,0 +1,111 @@
+-- This test assumes 3 primaries and 3 mirrors from a gpdemo segwalrep cluster
+
+-- function to wait for mirror to come up in sync (1 minute timeout)
+create or replace function wait_for_streaming() returns void as $$ declare updated bool; /* in func */ begin /* in func */ for i in 1 .. 120 loop /* in func */ perform gp_request_fts_probe_scan(); /* in func */ select (mode = 's' and status = 'u') into updated /* in func */ from gp_segment_configuration /* in func */ where content = 0 and role = 'm'; /* in func */ exit when updated; /* in func */ perform pg_sleep(0.5); /* in func */ end loop; /* in func */ end; /* in func */ $$ language plpgsql;
+CREATE
+
+-- start_ignore
+create language plpythonu;
+CREATE
+-- end_ignore
+
+create or replace function pg_ctl(datadir text, command text, port int, contentid int) returns text as $$ import subprocess 
+cmd = 'pg_ctl -D %s ' % datadir if command in ('stop', 'restart'): cmd = cmd + '-w -m immediate %s' % command elif command == 'start': opts = '-p %d -\-gp_dbid=0 -\-silent-mode=true -i -M mirrorless -\-gp_contentid=%d -\-gp_num_contents_in_cluster=3' % (port, contentid) cmd = cmd + '-o "%s" start' % opts elif command == 'reload': cmd = cmd + 'reload' else: return 'Invalid command input' 
+return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '') $$ language plpythonu;
+CREATE
+
+-- make sure we are in-sync for the primary we will be testing with
+select content, role, preferred_role, mode, status from gp_segment_configuration where content=0;
+content|role|preferred_role|mode|status
+-------+----+--------------+----+------
+0      |p   |p             |s   |u     
+0      |m   |m             |s   |u     
+(2 rows)
+
+-- create table and show commits are not blocked
+create table fts_unblock_primary (a int) distributed by (a);
+CREATE
+insert into fts_unblock_primary values (1);
+INSERT 1
+
+-- turn off fts
+! gpconfig -c gp_fts_probe_pause -v true --masteronly --skipvalidation;
+completed successfully with parameters '-c gp_fts_probe_pause -v true --masteronly --skipvalidation'
+
+1U: select pg_ctl((select fselocation from gp_segment_configuration c, pg_filespace_entry f where c.role='p' and c.content=-1 and c.dbid = f.fsedbid), 'reload', NULL, NULL);
+pg_ctl          
+----------------
+server signaled
+
+(1 row)
+
+-- stop a mirror
+1U: select pg_ctl((select fselocation from gp_segment_configuration c, pg_filespace_entry f where c.role='m' and c.content=0 and c.dbid = f.fsedbid), 'stop', NULL, NULL);
+pg_ctl                                              
+----------------------------------------------------
+waiting for server to shut down done
+server stopped
+
+(1 row)
+
+-- this should block since mirror is not up and sync replication is on
+2: begin;
+BEGIN
+2: insert into fts_unblock_primary values (1);
+INSERT 1
+2&: commit;  <waiting ...>
+
+-- this should not block due to direct dispatch to primary with active synced mirror
+insert into fts_unblock_primary values (3);
+INSERT 1
+
+-- turn on fts
+! gpconfig -c gp_fts_probe_pause -v false --masteronly --skipvalidation;
+completed successfully with parameters '-c gp_fts_probe_pause -v false --masteronly --skipvalidation'
+
+1U: select pg_ctl((select fselocation from gp_segment_configuration c, pg_filespace_entry f where c.role='p' and c.content=-1 and c.dbid = f.fsedbid), 'reload', NULL, NULL);
+pg_ctl          
+----------------
+server signaled
+
+(1 row)
+
+--trigger fts probe and check to see primary marked n/u and mirror n/d
+select gp_request_fts_probe_scan();
+gp_request_fts_probe_scan
+-------------------------
+t                        
+(1 row)
+select content, role, preferred_role, mode, status from gp_segment_configuration where content=0;
+content|role|preferred_role|mode|status
+-------+----+--------------+----+------
+0      |p   |p             |n   |u     
+0      |m   |m             |n   |d     
+(2 rows)
+
+-- should unblock and commit after FTS sent primary a SyncRepOff libpq message
+2<:  <... completed>
+COMMIT
+
+-- bring the mirror back up and see primary s/u and mirror s/u
+1U: select pg_ctl((select fselocation from gp_segment_configuration c, pg_filespace_entry f where c.role='m' and c.content=0 and c.dbid = f.fsedbid), 'start', (select port from gp_segment_configuration where content = 0 and preferred_role = 'm'), 0);
+pg_ctl          
+----------------
+server starting
+
+(1 row)
+select wait_for_streaming();
+wait_for_streaming
+------------------
+                  
+(1 row)
+select content, role, preferred_role, mode, status from gp_segment_configuration where content=0;
+content|role|preferred_role|mode|status
+-------+----+--------------+----+------
+0      |p   |p             |s   |u     
+0      |m   |m             |s   |u     
+(2 rows)
+
+-- everything is back to normal
+insert into fts_unblock_primary select i from generate_series(1,10)i;
+INSERT 10

--- a/src/test/isolation2/sql/segwalrep/commit_blocking.sql
+++ b/src/test/isolation2/sql/segwalrep/commit_blocking.sql
@@ -55,12 +55,12 @@ insert into segwalrep_commit_blocking values (1);
 -- bring the mirror back up
 1U: select pg_ctl((select fselocation from gp_segment_configuration c, pg_filespace_entry f where c.role='m' and c.content=0 and c.dbid = f.fsedbid), 'start', (select port from gp_segment_configuration where content = 0 and preferred_role = 'm'), 0);
 
+-- should unblock and commit now that mirror is back up and in-sync
+3<:
+
 -- turn on fts
 ! gpconfig -c gp_fts_probe_pause -v false --masteronly --skipvalidation;
 1U: select pg_ctl((select fselocation from gp_segment_configuration c, pg_filespace_entry f where c.role='p' and c.content=-1 and c.dbid = f.fsedbid), 'reload', NULL, NULL);
-
--- should unblock and commit now that mirror is back up
-3<:
 
 -- everything should be back to normal
 4: insert into segwalrep_commit_blocking select i from generate_series(1,10)i;

--- a/src/test/isolation2/sql/segwalrep/fts_unblock_primary.sql
+++ b/src/test/isolation2/sql/segwalrep/fts_unblock_primary.sql
@@ -1,0 +1,81 @@
+-- This test assumes 3 primaries and 3 mirrors from a gpdemo segwalrep cluster
+
+-- function to wait for mirror to come up in sync (1 minute timeout)
+create or replace function wait_for_streaming()
+returns void as $$
+declare
+  updated bool; /* in func */
+begin /* in func */
+  for i in 1 .. 120 loop /* in func */
+    perform gp_request_fts_probe_scan(); /* in func */
+    select (mode = 's' and status = 'u') into updated /* in func */
+    from gp_segment_configuration /* in func */
+    where content = 0 and role = 'm'; /* in func */
+    exit when updated; /* in func */
+    perform pg_sleep(0.5); /* in func */
+  end loop; /* in func */
+end; /* in func */
+$$ language plpgsql;
+
+-- start_ignore
+create language plpythonu;
+-- end_ignore
+
+create or replace function pg_ctl(datadir text, command text, port int, contentid int)
+returns text as $$
+    import subprocess
+
+    cmd = 'pg_ctl -D %s ' % datadir
+    if command in ('stop', 'restart'):
+        cmd = cmd + '-w -m immediate %s' % command
+    elif command == 'start':
+        opts = '-p %d -\-gp_dbid=0 -\-silent-mode=true -i -M mirrorless -\-gp_contentid=%d -\-gp_num_contents_in_cluster=3' % (port, contentid)
+        cmd = cmd + '-o "%s" start' % opts
+    elif command == 'reload':
+        cmd = cmd + 'reload'
+    else:
+        return 'Invalid command input'
+
+    return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '')
+$$ language plpythonu;
+
+-- make sure we are in-sync for the primary we will be testing with
+select content, role, preferred_role, mode, status from gp_segment_configuration where content=0;
+
+-- create table and show commits are not blocked
+create table fts_unblock_primary (a int) distributed by (a);
+insert into fts_unblock_primary values (1);
+
+-- turn off fts
+! gpconfig -c gp_fts_probe_pause -v true --masteronly --skipvalidation;
+1U: select pg_ctl((select fselocation from gp_segment_configuration c, pg_filespace_entry f where c.role='p' and c.content=-1 and c.dbid = f.fsedbid), 'reload', NULL, NULL);
+
+-- stop a mirror
+1U: select pg_ctl((select fselocation from gp_segment_configuration c, pg_filespace_entry f where c.role='m' and c.content=0 and c.dbid = f.fsedbid), 'stop', NULL, NULL);
+
+-- this should block since mirror is not up and sync replication is on
+2: begin;
+2: insert into fts_unblock_primary values (1);
+2&: commit;
+
+-- this should not block due to direct dispatch to primary with active synced mirror
+insert into fts_unblock_primary values (3);
+
+-- turn on fts
+! gpconfig -c gp_fts_probe_pause -v false --masteronly --skipvalidation;
+1U: select pg_ctl((select fselocation from gp_segment_configuration c, pg_filespace_entry f where c.role='p' and c.content=-1 and c.dbid = f.fsedbid), 'reload', NULL, NULL);
+
+--trigger fts probe and check to see primary marked n/u and mirror n/d
+select gp_request_fts_probe_scan();
+select content, role, preferred_role, mode, status from gp_segment_configuration where content=0;
+
+-- should unblock and commit after FTS sent primary a SyncRepOff libpq message
+2<:
+
+-- bring the mirror back up and see primary s/u and mirror s/u
+1U: select pg_ctl((select fselocation from gp_segment_configuration c, pg_filespace_entry f where c.role='m' and c.content=0 and c.dbid = f.fsedbid), 'start', (select port from gp_segment_configuration where content = 0 and preferred_role = 'm'), 0);
+select wait_for_streaming();
+select content, role, preferred_role, mode, status from gp_segment_configuration where content=0;
+
+-- everything is back to normal
+insert into fts_unblock_primary select i from generate_series(1,10)i;

--- a/src/test/isolation2/sql/segwalrep/fts_unblock_primary.sql
+++ b/src/test/isolation2/sql/segwalrep/fts_unblock_primary.sql
@@ -1,7 +1,7 @@
 -- This test assumes 3 primaries and 3 mirrors from a gpdemo segwalrep cluster
 
 -- function to wait for mirror to come up in sync (1 minute timeout)
-create or replace function wait_for_streaming()
+create or replace function wait_for_streaming(contentid smallint)
 returns void as $$
 declare
   updated bool; /* in func */
@@ -10,7 +10,7 @@ begin /* in func */
     perform gp_request_fts_probe_scan(); /* in func */
     select (mode = 's' and status = 'u') into updated /* in func */
     from gp_segment_configuration /* in func */
-    where content = 0 and role = 'm'; /* in func */
+    where content = contentid and role = 'm'; /* in func */
     exit when updated; /* in func */
     perform pg_sleep(0.5); /* in func */
   end loop; /* in func */
@@ -40,7 +40,7 @@ returns text as $$
 $$ language plpythonu;
 
 -- make sure we are in-sync for the primary we will be testing with
-select content, role, preferred_role, mode, status from gp_segment_configuration where content=0;
+select content, role, preferred_role, mode, status from gp_segment_configuration where content=2;
 
 -- create table and show commits are not blocked
 create table fts_unblock_primary (a int) distributed by (a);
@@ -51,7 +51,7 @@ insert into fts_unblock_primary values (1);
 1U: select pg_ctl((select fselocation from gp_segment_configuration c, pg_filespace_entry f where c.role='p' and c.content=-1 and c.dbid = f.fsedbid), 'reload', NULL, NULL);
 
 -- stop a mirror
-1U: select pg_ctl((select fselocation from gp_segment_configuration c, pg_filespace_entry f where c.role='m' and c.content=0 and c.dbid = f.fsedbid), 'stop', NULL, NULL);
+1U: select pg_ctl((select fselocation from gp_segment_configuration c, pg_filespace_entry f where c.role='m' and c.content=2 and c.dbid = f.fsedbid), 'stop', NULL, NULL);
 
 -- this should block since mirror is not up and sync replication is on
 2: begin;
@@ -67,15 +67,15 @@ insert into fts_unblock_primary values (3);
 
 --trigger fts probe and check to see primary marked n/u and mirror n/d
 select gp_request_fts_probe_scan();
-select content, role, preferred_role, mode, status from gp_segment_configuration where content=0;
+select content, role, preferred_role, mode, status from gp_segment_configuration where content=2;
 
 -- should unblock and commit after FTS sent primary a SyncRepOff libpq message
 2<:
 
 -- bring the mirror back up and see primary s/u and mirror s/u
-1U: select pg_ctl((select fselocation from gp_segment_configuration c, pg_filespace_entry f where c.role='m' and c.content=0 and c.dbid = f.fsedbid), 'start', (select port from gp_segment_configuration where content = 0 and preferred_role = 'm'), 0);
-select wait_for_streaming();
-select content, role, preferred_role, mode, status from gp_segment_configuration where content=0;
+1U: select pg_ctl((select fselocation from gp_segment_configuration c, pg_filespace_entry f where c.role='m' and c.content=2 and c.dbid = f.fsedbid), 'start', (select port from gp_segment_configuration where content = 2 and preferred_role = 'm'), 2);
+select wait_for_streaming(2::smallint);
+select content, role, preferred_role, mode, status from gp_segment_configuration where content=2;
 
 -- everything is back to normal
 insert into fts_unblock_primary select i from generate_series(1,10)i;


### PR DESCRIPTION
Synchronized replication is on by default for Greenplum. When the
primary's mirror is detected down, the primary will continue to block
all commits until the mirror comes back up.

This commit introduces a new FTS message that will be sent to the
primary if an FTS probe detects a mirror is down and primary is stuck
in synchronous replication state. The new message will allow the
primary to turn off synchronous replication by setting the GUC
synchronous_standby_names to empty string (persisted in
gp_replication.conf) and setting the WalSndCtl shared-memory syncrep
state. As a result, backends that may be waiting for the mirror to
receive a commit will be unblocked.