### PR TITLE
Enable assert segwalrep pipeline

### DIFF
--- a/concourse/pipelines/pipeline_segwalrep.yml
+++ b/concourse/pipelines/pipeline_segwalrep.yml
@@ -91,7 +91,7 @@ jobs:
       MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=on' installcheck-world
       BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
       TEST_OS: centos
-      CONFIGURE_FLAGS: "--enable-segwalrep"
+      CONFIGURE_FLAGS: "((configure_flags)) --enable-segwalrep"
 
 - name: icw_planner_centos6
   plan:
@@ -110,7 +110,7 @@ jobs:
       MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off' installcheck-world
       BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
       TEST_OS: centos
-      CONFIGURE_FLAGS: "--enable-segwalrep"
+      CONFIGURE_FLAGS: "((configure_flags)) --enable-segwalrep"
 
 - name: segwalrep_mirrorless_centos6
   plan:
@@ -129,5 +129,5 @@ jobs:
       MAKE_TEST_COMMAND: "-C src/test/regress && make -C src/test/walrep install installcheck"
       BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
       TEST_OS: centos
-      CONFIGURE_FLAGS: "--enable-segwalrep"
+      CONFIGURE_FLAGS: "((configure_flags)) --enable-segwalrep"
       WITH_MIRRORS: false

--- a/src/backend/replication/syncrep.c
+++ b/src/backend/replication/syncrep.c
@@ -612,15 +612,15 @@ SyncRepWakeQueue(bool all, int mode)
 									   offsetof(PGPROC, syncRepLinks));
 
 		/*
+		 * Remove thisproc from queue.
+		 */
+		SHMQueueDelete(&(thisproc->syncRepLinks));
+
+		/*
 		 * Set state to complete; see SyncRepWaitForLSN() for discussion of
 		 * the various states.
 		 */
 		thisproc->syncRepState = SYNC_REP_WAIT_COMPLETE;
-
-		/*
-		 * Remove thisproc from queue.
-		 */
-		SHMQueueDelete(&(thisproc->syncRepLinks));
 
 		/*
 		 * Wake only when we have set state and removed from queue.


### PR DESCRIPTION
As a baby step to get the selwaprep tests into the master pipeline to avoid regression, we first need to enable the assert on the segwalrep pipeline.

This will help us find the assert related issues in the code, and clean them up before merge into the master pipeline.