### PR TITLE
Fix the gpinitsystem error log missing

### DIFF
--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -295,8 +295,8 @@ ERROR_EXIT () {
 	LOG_MSG "[INFO]:-Start Function $FUNCNAME"
 		TIME=`$DATE +%H":"%M":"%S`
 		CUR_DATE=`$DATE +%Y%m%d`
-		$ECHO "${CUR_DATE}:${TIME}:${PROG_NAME}:${CALL_HOST}:${USER_NAME}-$1 Script Exiting!" >> $LOG_FILE
-		$ECHO "${CUR_DATE}:${TIME}:${PROG_NAME}:${CALL_HOST}:${USER_NAME}-$1 Script Exiting!"
+		$ECHO "${CUR_DATE}:${TIME}:${PROG_PIDNAME}:${CALL_HOST}:${USER_NAME}-$1 Script Exiting!" >> $LOG_FILE
+		$ECHO "${CUR_DATE}:${TIME}:${PROG_PIDNAME}:${CALL_HOST}:${USER_NAME}-$1 Script Exiting!"
 		DEBUG_LEVEL=1
 		if [ $BACKOUT_FILE ]; then
 				if [ -s $BACKOUT_FILE ]; then


### PR DESCRIPTION
When I used the gpinitsystem command, I found a part of information missing in the error log(Between time and command). A series of experiments found that all error logs are like this, so I went to explore the reason, the result is a variable reference error.

20171207:06:53:00:**012321** gpinitsystem:node:gp-[INFO]:-Building primary segment instance array, please wait...
20171207:06:53:01:**012321** gpinitsystem:node:gp-[INFO]:-Building group mirror array type , please wait...
**20171207:06:53:01:gpinitsystem**:node:gp-[FATAL]:-MASTER_PORT overlaps with MIRROR_PORT_BASE. Script Exiting!

20171205:00:56:09:**012516** gpinitsystem:node:gp-[INFO]:-Commencing multi-home checks, Completed
20171205:00:56:09:**012516** gpinitsystem:node:gp-[INFO]:-Building primary segment instance array, please wait...
**20171205:00:56:10:gpinitsystem**:node:gp-[FATAL]:-Host node has an active database process on port = 40015 Script Exiting!