### PR TITLE
Remove the gpinitsystem extra symbol

### DIFF
--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -1100,7 +1100,7 @@ DISPLAY_CONFIG () {
         else
             LOG_MSG "[INFO]:-Standby Master             = Not Configured" 1
         fi
-        LOG_MSG "[INFO]:-Primary segment            = $QE_PRIMARY_COUNT" 1
+        LOG_MSG "[INFO]:-Number of primary segments = $QE_PRIMARY_COUNT" 1
         if [ x"" != x"$STANDBY_HOSTNAME" ];then
             for STANDBY_IP in "${STANDBY_IP_ADDRESS[@]}"
             do
@@ -1116,7 +1116,7 @@ DISPLAY_CONFIG () {
             LOG_MSG "[INFO]:-Replicaton port base       = $REPLICATION_PORT_BASE" 1
             LOG_MSG "[INFO]:-Mirror replicaton port base= $MIRROR_REPLICATION_PORT_BASE" 1
             ((NUM_MIRROR_DIRECTORY=${#MIRROR_DATA_DIRECTORY[@]}))
-            LOG_MSG "[INFO]:-Mirror segment             = $NUM_MIRROR_DIRECTORY" 1
+            LOG_MSG "[INFO]:-Number of mirror segments  = $NUM_MIRROR_DIRECTORY" 1
             LOG_MSG "[INFO]:-Mirroring config           = ON" 1
             if [ x"$INPUT_CONFIG" != x"" ];then
                 LOG_MSG "[INFO]:-Mirroring type             = Custom" 1

--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -1100,7 +1100,7 @@ DISPLAY_CONFIG () {
         else
             LOG_MSG "[INFO]:-Standby Master             = Not Configured" 1
         fi
-        LOG_MSG "[INFO]:-Primary segment #          = $QE_PRIMARY_COUNT" 1
+        LOG_MSG "[INFO]:-Primary segment            = $QE_PRIMARY_COUNT" 1
         if [ x"" != x"$STANDBY_HOSTNAME" ];then
             for STANDBY_IP in "${STANDBY_IP_ADDRESS[@]}"
             do
@@ -1116,7 +1116,7 @@ DISPLAY_CONFIG () {
             LOG_MSG "[INFO]:-Replicaton port base       = $REPLICATION_PORT_BASE" 1
             LOG_MSG "[INFO]:-Mirror replicaton port base= $MIRROR_REPLICATION_PORT_BASE" 1
             ((NUM_MIRROR_DIRECTORY=${#MIRROR_DATA_DIRECTORY[@]}))
-            LOG_MSG "[INFO]:-Mirror segment #           = $NUM_MIRROR_DIRECTORY" 1
+            LOG_MSG "[INFO]:-Mirror segment             = $NUM_MIRROR_DIRECTORY" 1
             LOG_MSG "[INFO]:-Mirroring config           = ON" 1
             if [ x"$INPUT_CONFIG" != x"" ];then
                 LOG_MSG "[INFO]:-Mirroring type             = Custom" 1


### PR DESCRIPTION
Remove extra symbol (#) that has no relation with others in the gpinitsystem.

$ gpinitsystem -c gpinitsystem_config
...
...gpinitsystem:node:gp-[INFO]:---------------------------------------
...gpinitsystem:node:gp-[INFO]:-Master Configuration
...gpinitsystem:node:gp-[INFO]:---------------------------------------
...gpinitsystem:node:gp-[INFO]:-Master instance name       = EMC Greenplum DW
...gpinitsystem:node:gp-[INFO]:-Master hostname               = node
...gpinitsystem:node:gp-[INFO]:-Master port                        = 9432
...gpinitsystem:node:gp-[INFO]:-Master instance dir            = /data1/gp/master/gpseg-1
...gpinitsystem:node:gp-[INFO]:-Master LOCALE                  = en_US.utf8
...gpinitsystem:node:gp-[INFO]:-Greenplum segment prefix= gpseg
...gpinitsystem:node:gp-[INFO]:-Master Database                = 
...gpinitsystem:node:gp-[INFO]:-Master connections            = 250
...gpinitsystem:node:gp-[INFO]:-Master buffers                    = 128000kB
...gpinitsystem:node:gp-[INFO]:-Segment connections         = 750
...gpinitsystem:node:gp-[INFO]:-Segment buffers                 = 128000kB
...gpinitsystem:node:gp-[INFO]:-Checkpoint segments         = 8
...gpinitsystem:node:gp-[INFO]:-Encoding                             = UNICODE
...gpinitsystem:node:gp-[INFO]:-Postgres param file             = Off
...gpinitsystem:node:gp-[INFO]:-Initdb to be used                = /usr/local/gp/bin/initdb
...gpinitsystem:node:gp-[INFO]:-GP_LIBRARY_PATH is          = /usr/local/gp/lib
...gpinitsystem:node:gp-[INFO]:-HEAP_CHECKSUM is           = on
...gpinitsystem:node:gp-[INFO]:-Ulimit check                        = Passed
...gpinitsystem:node:gp-[INFO]:-Array host connect type     = Single hostname per node
...gpinitsystem:node:gp-[INFO]:-Master IP address [1]          = ::1
...gpinitsystem:node:gp-[INFO]:-Master IP address [2]          = 192.168.59.106
...gpinitsystem:node:gp-[INFO]:-Master IP address [3]          = fe80::20c:29ff:feae:ff82
...gpinitsystem:node:gp-[INFO]:-Standby Master                  = Not Configured
...gpinitsystem:node:gp-[INFO]:-Primary segment **#**             = 1
...gpinitsystem:node:gp-[INFO]:-Total Database segments   = 1
...gpinitsystem:node:gp-[INFO]:-Trusted shell                       = ssh
...gpinitsystem:node:gp-[INFO]:-Number segment hosts      = 1
...gpinitsystem:node:gp-[INFO]:-Mirror port base                 = 50015
...gpinitsystem:node:gp-[INFO]:-Replicaton port base          = 41015
...gpinitsystem:node:gp-[INFO]:-Mirror replicaton port base= 51015
...gpinitsystem:node:gp-[INFO]:-Mirror segment **#**               = 1
...gpinitsystem:node:gp-[INFO]:-Mirroring config                 = ON
...gpinitsystem:node:gp-[INFO]:-Mirroring type                    = Group
...gpinitsystem:node:gp-[INFO]:----------------------------------------