### PR TITLE
Remove error symbol in gpinitsystem log

### DIFF
--- a/gpMgmt/bin/lib/gpcreateseg.sh
+++ b/gpMgmt/bin/lib/gpcreateseg.sh
@@ -217,7 +217,7 @@ PROCESS_QE () {
 	STOP_QE
     fi
 
-    LOG_MSG "[INFO]:-[$INST_COUNT]-End Function $FUNCNAME"
+    LOG_MSG "[INFO][$INST_COUNT]:-End Function $FUNCNAME"
 }
 
 STOP_QE() {


### PR DESCRIPTION
Remove error symbol (-) in gpinitsystem log. [0] indicates INST_COUNT of gpcreateseg.sh

$ gpinitsystem -c gpinitsystem_config
...
...gpcreateseg.sh:node:gp-[INFO]:-End Function RUN_COMMAND_REMOTE
...gpcreateseg.sh:node:gp-[INFO][0]:-Completed remote copy of segment data directory from node to node
...gpcreateseg.sh:node:gp-[INFO][0]:-Configuring segment postgresql.conf
...gpcreateseg.sh:node:gp-[INFO][0]:-Completed Update /data1/gp/mirror/gpseg0/postgresql.conf file
...gpcreateseg.sh:node:gp-[INFO][0]:-Completed Update /data1/gp/mirror/gpseg0/postgresql.conf file
...gpcreateseg.sh:node:gp-[INFO]:-Start Function SED_PG_CONF
...gpcreateseg.sh:node:gp-[INFO]:-Replaced line in /data1/gp/mirror/gpseg0/postgresql.conf on node
...gpcreateseg.sh:node:gp-[INFO]:-Replaced line in /data1/gp/mirror/gpseg0/postgresql.conf on node
...gpcreateseg.sh:node:gp-[INFO]:-End Function SED_PG_CONF
...gpcreateseg.sh:node:gp-[INFO][0]:-Completed Update port number to 9432
...gpcreateseg.sh:node:gp-[INFO]:-Start Function SED_PG_CONF
...gpcreateseg.sh:node:gp-[INFO]:-Replaced line in /data1/gp/mirror/gpseg0/postgresql.conf on node
...gpcreateseg.sh:node:gp-[INFO]:-Replaced line in /data1/gp/mirror/gpseg0/postgresql.conf on node
...gpcreateseg.sh:node:gp-[INFO]:-End Function SED_PG_CONF
...gpcreateseg.sh:node:gp-[INFO][0]:-Completed Update listen address
...gpcreateseg.sh:node:gp-[INFO]:-Start Function SED_PG_CONF
...gpcreateseg.sh:node:gp-[INFO]:-Appended line checkpoint_segments=8 to /data1/gp/mirror/gpseg0/postgresql.conf on node
...gpcreateseg.sh:node:gp-[INFO]:-End Function SED_PG_CONF
...gpcreateseg.sh:node:gp-[INFO][0]:-Completed Update checkpoint segments
...gpcreateseg.sh:node:**gp-[INFO][0]:-Configuring** segment pg_hba.conf
...gpcreateseg.sh:node:**gp-[INFO]:-[0]-End** Function PROCESS_QE
...gpcreateseg.sh:node:**gp-[INFO][0]:-End** Main
...