### PR TITLE
executor: resolve dead code FIXMEs for initBitmapState

### DIFF
--- a/src/backend/executor/execBitmapTableScan.c
+++ b/src/backend/executor/execBitmapTableScan.c
@@ -67,15 +67,6 @@ getBitmapTableScanMethod(TableType tableType)
 }
 
 /*
- * Initializes the state relevant to bitmaps.
- */
-static inline void
-initBitmapState(BitmapTableScanState *scanstate)
-{
-	/* GPDB_84_MERGE_FIXME: nothing to do? */
-}
-
-/*
  * Frees the state relevant to bitmaps.
  */
 static inline void
@@ -250,8 +241,6 @@ BitmapTableScanBeginPartition(ScanState *node, AttrNumber *attMap)
 	BitmapTableScanState *scanState = (BitmapTableScanState *)node;
 	BitmapTableScan *plan = (BitmapTableScan*)(node->ps.plan);
 
-	initBitmapState(scanState);
-
 	/* Remap the bitmapqualorig as we might have dropped column problem */
 	DynamicScan_RemapExpression(node, attMap, (Node *) plan->bitmapqualorig);
 
@@ -311,7 +300,6 @@ BitmapTableScanReScanPartition(ScanState *node)
 	freeBitmapState(scanState);
 	Assert(scanState->tbm == NULL);
 
-	initBitmapState(scanState);
 	scanState->needNewBitmapPage = true;
 	scanState->recheckTuples = true;
 

--- a/src/backend/executor/nodeBitmapAppendOnlyscan.c
+++ b/src/backend/executor/nodeBitmapAppendOnlyscan.c
@@ -179,15 +179,6 @@ freeFetchDesc(BitmapAppendOnlyScanState *scanstate)
 }
 
 /*
- * Initialize the state relevant to bitmaps.
- */
-static inline void
-initBitmapState(BitmapAppendOnlyScanState *scanstate)
-{
-	/* GPDB_84_MERGE_FIXME: nothing to do? */
-}
-
-/*
  * Free the state relevant to bitmaps
  */
 static inline void
@@ -230,7 +221,6 @@ BitmapAppendOnlyScanNext(BitmapAppendOnlyScanState *node)
 	econtext = node->ss.ps.ps_ExprContext;
 	slot = node->ss.ss_ScanTupleSlot;
 
-	initBitmapState(node);
 	initFetchDesc(node);
 
 	aoFetchDesc = node->baos_currentAOFetchDesc;

--- a/src/backend/executor/nodeBitmapHeapscan.c
+++ b/src/backend/executor/nodeBitmapHeapscan.c
@@ -90,15 +90,6 @@ freeScanDesc(BitmapHeapScanState *scanstate)
 }
 
 /*
- * Initialize the state relevant to bitmaps.
- */
-static inline void
-initBitmapState(BitmapHeapScanState *scanstate)
-{
-	/* GPDB_84_MERGE_FIXME: nothing to do? */
-}
-
-/*
  * Free the state relevant to bitmaps
  */
 static inline void
@@ -146,7 +137,6 @@ BitmapHeapNext(BitmapHeapScanState *node)
 	slot = node->ss.ss_ScanTupleSlot;
 
 	initScanDesc(node);
-	initBitmapState(node);
 
 	scan = node->ss_currentScanDesc;
 	scanrelid = ((BitmapHeapScan *) node->ss.ps.plan)->scan.scanrelid;


### PR DESCRIPTION
`initBitmapState` doesn't do anything anymore -- its logic has effectively been moved to other areas of the code. I had intended to get this in as part of commit 8ce6f34a, but I missed the boat.