### PR TITLE
Remove bloom filter from hash joins.

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4259,16 +4259,6 @@ struct config_int ConfigureNamesInt_gp[] =
 	},
 
 	{
-		{"gp_hashjoin_bloomfilter", PGC_USERSET, GP_ARRAY_TUNING,
-			gettext_noop("Use bloomfilter in hash join"),
-			gettext_noop("Use bloomfilter may speed up hashtable probing"),
-			GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL | GUC_GPDB_ADDOPT
-		},
-		&gp_hashjoin_bloomfilter,
-		1, 0, 1, NULL, NULL
-	},
-
-	{
 		{"gp_motion_slice_noop", PGC_USERSET, GP_ARRAY_TUNING,
 			gettext_noop("Make motion nodes in certain slices noop"),
 			gettext_noop("Make motion nodes noop, to help analyze performance"),

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -863,9 +863,6 @@ extern bool gp_hashagg_streambottom;
  */
 extern int gp_hashagg_default_nbatches;
 
-/* Hashjoin use bloom filter */
-extern int gp_hashjoin_bloomfilter;
-
 /* Get statistics for partitioned parent from a child */
 extern bool 	gp_statistics_pullup_from_child_partition;
 

--- a/src/include/executor/hashjoin.h
+++ b/src/include/executor/hashjoin.h
@@ -149,7 +149,6 @@ typedef struct HashJoinTableData
 
 	/* buckets[i] is head of list of tuples in i'th in-memory bucket */
 	struct HashJoinTupleData **buckets;
-	uint64     				  *bloom; /* bloom[i] is bloomfilter for buckets[i] */
 	/* buckets array is per-batch storage, as are all the tuples */
 
 	bool		skewEnabled;	/* are we using skew optimization? */


### PR DESCRIPTION
It was added as a performance optimization back in 2007, but it's not
doing much at the moment. Some quick testing on my laptop suggests that
it's a wash at best, and makes the join slightly slower in some scenarios.

This will reduce our diff vs upstream, reducing the chance of merge
conflicts in the future.