### PR TITLE
behave: make pid detection more robust

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -4519,8 +4519,18 @@ def impl(context, tabletype, table_name, dbname):
 @when('read pid from file "{filename}" and kill the process')
 @given('read pid from file "{filename}" and kill the process')
 def impl(context, filename):
-    with open(filename) as fr:
-        pid = fr.readline().strip()
+    retry = 0
+    pid = None
+
+    while retry < 5:
+        try:
+            with open(filename) as fr:
+                pid = fr.readline().strip()
+            if pid:
+                break
+        except:
+            retry += 1
+            time.sleep(retry * 0.1) # 100 millis, 200 millis, etc.
 
     if not pid:
         raise Exception("process id '%s' not found in the file '%s'" % (pid, filename))


### PR DESCRIPTION
This is simply a setup/cleanup step for the behave tests, so be
accomodating to try to get it to work.

Scope: affects gpcheckcat.feature and backups.feature; these tests
already have some timing affordances; this just adds a bit more backstop

Author: Marbin Tan <mtan@pivotal.io>
Author: C.J. Jameson <cjameson@pivotal.io>