### PR TITLE
Increase the timeout for wal receiver to start

### DIFF
--- a/src/test/walrep/expected/missing_xlog.out
+++ b/src/test/walrep/expected/missing_xlog.out
@@ -79,7 +79,7 @@ select pg_ctl((select fselocation from gp_segment_configuration c, pg_filespace_
 (1 row)
 
 -- check the view, we expect to see error
-select wait_for_replication_error('walread', 0, 100);
+select wait_for_replication_error('walread', 0, 200);
  wait_for_replication_error 
 ----------------------------
  t

--- a/src/test/walrep/sql/missing_xlog.sql
+++ b/src/test/walrep/sql/missing_xlog.sql
@@ -64,7 +64,7 @@ select move_xlog((select fselocation || '/pg_xlog' from gp_segment_configuration
 select pg_ctl((select fselocation from gp_segment_configuration c, pg_filespace_entry f where c.role='m' and c.content=0 and c.dbid = f.fsedbid), 'start', (select port from gp_segment_configuration where content = 0 and preferred_role = 'm'), 0);
 
 -- check the view, we expect to see error
-select wait_for_replication_error('walread', 0, 100);
+select wait_for_replication_error('walread', 0, 200);
 select sync_error from gp_stat_replication where gp_segment_id = 0;
 
 -- bring the missing xlog back on segment 0


### PR DESCRIPTION
There is a racing condition on the postmaster that the first request to
start the XLOG streaming (RequestXLogStreaming()) is ignored because
the WalReceiverPID wasn't yet reset to zero by do_reaper().

At worst case, it will take 10 seconds to restart a failed wal receiver.

To work around issue, we increase the timeout to 20 seconds to ensure
the wal receiver is properly restarted.

Author: Xin Zhang <xzhang@pivotal.io>
Author: Taylor Vesely <tvesely@pivotal.io>