### PR TITLE
docs - removing docs/references to gp_fault_strategy

### DIFF
--- a/gpdb-doc/dita/GPRefGuide.ditamap
+++ b/gpdb-doc/dita/GPRefGuide.ditamap
@@ -211,7 +211,6 @@
 			<topicref href="ref_guide/system_catalogs/gp_expansion_status.xml"/>
 			<topicref href="ref_guide/system_catalogs/gp_expansion_tables.xml"/>
 			<topicref href="ref_guide/system_catalogs/gp_fastsequence.xml"/>
-			<topicref href="ref_guide/system_catalogs/gp_fault_strategy.xml"/>
 			<topicref href="ref_guide/system_catalogs/gp_global_sequence.xml"/>
 			<topicref href="ref_guide/system_catalogs/gp_id.xml"/>
 			<topicref href="ref_guide/system_catalogs/gp_persistent_database_node.xml"/>

--- a/gpdb-doc/dita/ref_guide/ref_guide.ditamap
+++ b/gpdb-doc/dita/ref_guide/ref_guide.ditamap
@@ -148,7 +148,6 @@
 				<topicref href="system_catalogs/gp_expansion_status.xml"/>
 				<topicref href="system_catalogs/gp_expansion_tables.xml"/>
 				<topicref href="system_catalogs/gp_fastsequence.xml"/>
-				<topicref href="system_catalogs/gp_fault_strategy.xml"/>
 				<topicref href="system_catalogs/gp_global_sequence.xml"/>
 				<topicref href="system_catalogs/gp_id.xml"/>
 				<topicref href="system_catalogs/gp_persistent_database_node.xml"/>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/catalog_ref-tables.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/catalog_ref-tables.xml
@@ -17,9 +17,6 @@
       <li id="eu150308">
         <xref href="./gp_fastsequence.xml#topic1" type="topic" format="dita"/>
       </li>
-      <li id="eu150471">
-        <xref href="./gp_fault_strategy.xml#topic1" type="topic" format="dita"/>
-      </li>
       <li id="eu150472">
         <xref href="./gp_global_sequence.xml#topic1" type="topic" format="dita"/>
       </li>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/gp_fault_strategy.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/gp_fault_strategy.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE topic
-  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
-<topic id="topic1" xml:lang="en"><title id="fd163461">gp_fault_strategy</title><body><p>The <codeph>gp_fault_strategy</codeph> table specifies the fault action.</p><table id="fd163466"><title>pg_catalog.gp_fault_strategy</title><tgroup cols="4"><colspec colnum="1" colname="col1" colwidth="131pt"/><colspec colnum="2" colname="col2" colwidth="97pt"/><colspec colnum="3" colname="col3" colwidth="82pt"/><colspec colnum="4" colname="col4" colwidth="138pt"/><thead><row><entry colname="col1">column</entry><entry colname="col2">type</entry><entry colname="col3">references</entry><entry colname="col4">description</entry></row></thead><tbody><row><entry colname="col1"><codeph>fault_strategy</codeph></entry><entry colname="col2">char</entry><entry colname="col3"/><entry colname="col4">The mirror failover action to take when a segment failure occurs:<p>n =
-                nothing</p><p>f = file-based failover</p></entry></row></tbody></tgroup></table></body></topic>


### PR DESCRIPTION
Removing docs for gp_fault_strategy, as the catalog removed in https://github.com/greenplum-db/gpdb/pull/3265