### PR TITLE
behave: gprecoverseg - ensure that gpfaultinjector gets triggered

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -83,10 +83,12 @@ Feature: gprecoverseg tests
     @multinode
     Scenario: gprecoverseg with -i and -o option
         Given the database is running
+        And the database "gptest1" does not exist
         And all the segments are running
         And the segments are synchronized
         And the information of a "mirror" segment on a remote host is saved
         And user runs the command "gpfaultinjector  -f filerep_consumer  -m async -y fault" with the saved "mirror" segment option
+        Given database "gptest1" exists
         Then the saved mirror segment is marked down in config
         And the saved mirror segment process is still running on that host
         And user can start transactions
@@ -127,10 +129,12 @@ Feature: gprecoverseg tests
     @multinode
     Scenario: gprecoverseg should not throw exception for empty input file
         Given the database is running
+        And the database "gptest1" does not exist
         And all the segments are running
         And the segments are synchronized
         And the information of a "mirror" segment on a remote host is saved
         And user runs the command "gpfaultinjector  -f filerep_consumer  -m async -y fault" with the saved "mirror" segment option
+        Given database "gptest1" exists
         Then the saved mirror segment is marked down in config
         And the saved mirror segment process is still running on that host
         And user can start transactions
@@ -144,10 +148,12 @@ Feature: gprecoverseg tests
 
     Scenario: gprecoverseg does not recover segments with persistent rebuild inconsistencies
         Given the database is running
+        And the database "gptest1" does not exist
         And all the segments are running
         And the segments are synchronized
         And user runs the command "gpfaultinjector  -f filerep_consumer  -m async -y fault" on segment "0"
         And user runs the command "gpfaultinjector  -f filerep_consumer  -m async -y fault" on segment "1"
+        Given database "gptest1" exists
         Then the mirror with content id "0" is marked down in config
         Then the mirror with content id "1" is marked down in config
         And segment with content "0" has persistent tables that were rebuilt with mirrors disabled
@@ -167,6 +173,7 @@ Feature: gprecoverseg tests
         And the information of a "mirror" segment on any host is saved
         And user runs the command "gpfaultinjector  -f filerep_consumer  -m async -y reset" on segment "0"
         And user runs the command "gpfaultinjector  -f filerep_consumer  -m async -y fault" on segment "0"
+        Given database "gptest1" exists
         Then the mirror with content id "0" is marked down in config
         When the user runs "gprecoverseg -F -a"
         Then gprecoverseg should return a return code of 0
@@ -184,6 +191,7 @@ Feature: gprecoverseg tests
     @gprecoverseg_checksums
     Scenario: gprecoverseg should use the same setting for data_checksums for a full recovery
         Given the database is running
+        And the database "gptest1" does not exist
         And results of the sql "show data_checksums" db "template1" are stored in the context
         # cause a full recovery AFTER an injected failure on a remote primary
         And all the segments are running
@@ -192,6 +200,7 @@ Feature: gprecoverseg tests
         And the information of the corresponding primary segment on a remote host is saved
         And user runs the command "gpfaultinjector  -f filerep_consumer  -m async -y reset" with the saved "primary" segment option
         And user runs the command "gpfaultinjector  -f filerep_consumer  -m async -y fault" with the saved "primary" segment option
+        Given database "gptest1" exists
         Then the saved mirror segment is marked down in config
         And the saved mirror segment process is still running on that host
         And user can start transactions


### PR DESCRIPTION
    behave: gprecoverseg - ensure that gpfaultinjector gets triggered

    Ensure that we're triggering the `gpfaultinjector`.
    There are cases where even though we have the `gpfaultinjector` setup
    and the transaction still does not block properly.

    By creating a database, we ensure that all segments gets contacted,
    and FTS will detect the issue that we created with gpfaultinjector.