### PR TITLE
Fix internal_bpchar_pattern_compare compare logic to keep it

### DIFF
--- a/src/backend/utils/adt/varchar.c
+++ b/src/backend/utils/adt/varchar.c
@@ -895,9 +895,17 @@ internal_bpchar_pattern_compare(BpChar *arg1, BpChar *arg2)
 	int			len1,
 				len2;
 
-	/* GPDB_84_MERGE_FIXME: why have we changed these from bcTruelen()? */
-	len1 = VARSIZE_ANY_EXHDR(arg1);
-	len2 = VARSIZE_ANY_EXHDR(arg2);
+	/*
+	 * Before we use VARDATA_SIZE, but we change it to use bcTruelen to
+	 * keep same bahavior with upstream. This bug doesn't exist before in
+	 * GPDB since IndexScan is not used for following query:
+	 * create table tbl(id int4, v char(10));
+	 * create index tbl_v_idx_bpchar on tbl using btree(v bpchar_pattern_ops);
+	 * insert into tbl values (1, 'abc');
+	 * select * from tbl where v = 'abc '::char(20);
+	 */
+	len1 = bcTruelen(arg1);
+	len2 = bcTruelen(arg2);
 
 	result = strncmp(VARDATA_ANY(arg1), VARDATA_ANY(arg2), Min(len1, len2));
 	if (result != 0)

--- a/src/test/regress/expected/bfv_index.out
+++ b/src/test/regress/expected/bfv_index.out
@@ -547,3 +547,16 @@ select * from nestloop_x as x, nestloop_y as y where y.j > x.i + x.j + 2;
 (4 rows)
 
 drop table nestloop_x, nestloop_y;
+SET enable_seqscan = OFF;
+SET enable_indexscan = ON;
+DROP TABLE IF EXISTS bpchar_ops;
+CREATE TABLE bpchar_ops(id INT8, v char(10)) DISTRIBUTED BY(id);
+CREATE INDEX bpchar_ops_btree_idx ON bpchar_ops USING btree(v bpchar_pattern_ops);
+INSERT INTO bpchar_ops VALUES (0, 'row');
+SELECT * FROM bpchar_ops WHERE v = 'row '::char(20);
+ id |     v
+----+------------
+  0 | row
+(1 row)
+
+DROP TABLE bpchar_ops;

--- a/src/test/regress/expected/bfv_index_optimizer.out
+++ b/src/test/regress/expected/bfv_index_optimizer.out
@@ -537,3 +537,16 @@ select * from nestloop_x as x, nestloop_y as y where y.j > x.i + x.j + 2;
 (4 rows)
 
 drop table nestloop_x, nestloop_y;
+SET enable_seqscan = OFF;
+SET enable_indexscan = ON;
+DROP TABLE IF EXISTS bpchar_ops;
+CREATE TABLE bpchar_ops(id INT8, v char(10)) DISTRIBUTED BY(id);
+CREATE INDEX bpchar_ops_btree_idx ON bpchar_ops USING btree(v bpchar_pattern_ops);
+INSERT INTO bpchar_ops VALUES (0, 'row');
+SELECT * FROM bpchar_ops WHERE v = 'row '::char(20);
+ id |     v
+----+------------
+  0 | row
+(1 row)
+
+DROP TABLE bpchar_ops;

--- a/src/test/regress/sql/bfv_index.sql
+++ b/src/test/regress/sql/bfv_index.sql
@@ -246,3 +246,14 @@ explain select * from nestloop_x as x, nestloop_y as y where y.j > x.i + x.j + 2
 select * from nestloop_x as x, nestloop_y as y where y.j > x.i + x.j + 2;
 
 drop table nestloop_x, nestloop_y;
+
+SET enable_seqscan = OFF;
+SET enable_indexscan = ON;
+
+DROP TABLE IF EXISTS bpchar_ops;
+CREATE TABLE bpchar_ops(id INT8, v char(10)) DISTRIBUTED BY(id);
+CREATE INDEX bpchar_ops_btree_idx ON bpchar_ops USING btree(v bpchar_pattern_ops);
+INSERT INTO bpchar_ops VALUES (0, 'row');
+SELECT * FROM bpchar_ops WHERE v = 'row '::char(20);
+
+DROP TABLE bpchar_ops;


### PR DESCRIPTION
as same as upstream.

In upstream, internal_bpchar_pattern_compare compare inputs by ignoring
ending space. But GPDB it just use whole string compare. The bug didn't
appear because the before merging PG_MERGE_84 GPDB just use TableScan when executing
following query, but after PG_MERGE_84, IndexScan is used, and internal_bpchar_pattern_compare
will be used for index:
create table tbl(id int4, v char(10));
create index tbl_v_idx_bpchar on tbl using btree(v bpchar_pattern_ops);
insert into tbl values (1, 'abc');
explain select * from tbl where v = 'abc '::char(20);
select * from tbl where v = 'abc '::char(20);

Author: Xiaoran Wang <xiwang@pivotal.io>