### PR TITLE
Allow types coercible to text for hash distribution

### DIFF
--- a/contrib/citext/Makefile
+++ b/contrib/citext/Makefile
@@ -3,7 +3,7 @@
 MODULES = citext
 DATA_built = citext.sql
 DATA = uninstall_citext.sql
-REGRESS = citext
+REGRESS = citext citext_gp
 
 ifdef USE_PGXS
 PG_CONFIG = pg_config

--- a/contrib/citext/expected/citext.out
+++ b/contrib/citext/expected/citext.out
@@ -327,7 +327,8 @@ SELECT citext_larger( 'aardvark'::citext, 'Aaba'::citext ) = 'aardvark' AS t;
 CREATE TEMP TABLE srt (
    name CITEXT
 );
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'name' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO srt (name)
 VALUES ('aardvark'),
        ('AAA'),
@@ -1092,6 +1093,8 @@ CREATE TABLE caster (
     tsquery     tsquery,
     uuid        uuid
 );
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'citext' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO caster (text)          VALUES ('foo'::citext);
 INSERT INTO caster (citext)        VALUES ('foo'::text);
 INSERT INTO caster (varchar)       VALUES ('foo'::text);

--- a/contrib/citext/expected/citext_gp.out
+++ b/contrib/citext/expected/citext_gp.out
@@ -1,0 +1,11 @@
+--
+--  Test Greenplum extensions for citext datatype
+--
+create table citext_dist (a citext) distributed by (a);
+insert into citext_dist values ('XxX'), ('AaA'), ('JjJ');
+select count(distinct gp_segment_id) > 1 from citext_dist;
+ ?column? 
+----------
+ t
+(1 row)
+

--- a/contrib/citext/sql/citext_gp.sql
+++ b/contrib/citext/sql/citext_gp.sql
@@ -1,0 +1,7 @@
+--
+--  Test Greenplum extensions for citext datatype
+--
+
+create table citext_dist (a citext) distributed by (a);
+insert into citext_dist values ('XxX'), ('AaA'), ('JjJ');
+select count(distinct gp_segment_id) > 1 from citext_dist;

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -1764,8 +1764,7 @@ transformDistributedBy(ParseState *pstate, CreateStmtContext *cxt,
 							{
 								ereport(ERROR,
 										(errcode(ERRCODE_GP_FEATURE_NOT_SUPPORTED),
-										 errmsg("type \"%s\" can't be a part of a "
-												"distribution key",
+										 errmsg("type \"%s\" can't be a part of a distribution key",
 												format_type_be(typeOid))));
 							}
 
@@ -1856,8 +1855,7 @@ transformDistributedBy(ParseState *pstate, CreateStmtContext *cxt,
 						heap_close(rel, NoLock);
 
 						if (found)
-							elog(DEBUG1, "'DISTRIBUTED BY' clause refers to "
-								 "columns of inherited table");
+							elog(DEBUG1, "'DISTRIBUTED BY' clause refers to columns of inherited table");
 
 						if (found)
 							break;
@@ -1978,12 +1976,11 @@ transformDistributedBy(ParseState *pstate, CreateStmtContext *cxt,
 				{
 					ereport(ERROR,
 							(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-							 errmsg("UNIQUE constraint and DISTRIBUTED BY "
-									"definitions incompatible"),
+							 errmsg("UNIQUE constraint and DISTRIBUTED BY definitions incompatible"),
 							 errhint("When there is both a UNIQUE constraint, "
 									 "and a DISTRIBUTED BY clause, the "
 									 "DISTRIBUTED BY clause must be equal to "
-									 "or a left-subset of the UNIQUE columns")));
+									 "or a left-subset of the UNIQUE columns.")));
 				}
 				i++;
 			}


### PR DESCRIPTION
The hash distribution code relies on hardcoded support for all types which can be a distribution column. This works for built-in types but becomes problematic for external modules and extensions. The example at hand was citext, which isn't allowed as a distribution column. Using the type supplied `HASHPROC` for external types would give us a hash function, but risk redistribution if the function was altered in a backwards incompatible way in an upgrade.

The datatypes which can work with one of the built-in hash functions can however be supported as the built-in has is guaranteed to be stable across versions. Test for binary coercible types with TEXT and allow for distribution.

Includes a test for citext for this new capability. Also do some fixes on related error messages, keeping them on a single line to aid code grepping and ensuring to end hints with a period (and error messaeges without one).