### PR TITLE
Fix ORCA pipeline failure

### DIFF
--- a/concourse/scripts/build_gpdb.py
+++ b/concourse/scripts/build_gpdb.py
@@ -119,10 +119,10 @@ def main():
         status = gpBuild.make()
         fail_on_error(status)
 
-        status = gpBuild.unittest()
+        status = gpBuild.make_install()
         fail_on_error(status)
 
-        status = gpBuild.make_install()
+        status = gpBuild.unittest()
         fail_on_error(status)
 
         status = copy_installed(options.output_dir)


### PR DESCRIPTION
Unittests should be run after make install, as they require timezone
files under `<gpdb>/share/postgresql/timezone` directory which is placed
by `make install`. This reordering is required after `8ce6f34` commit.