### PR TITLE
tinc: gpexpand move port range lower than ephemeral ports

### DIFF
--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/utilities/gpexpand/test_gpexpand.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/utilities/gpexpand/test_gpexpand.py
@@ -169,12 +169,11 @@ class GPExpandTestCase(MPPTestCase, ScenarioTestCase):
 
         self.hosts = ['localhost']
 
-        # TODO: See if we can parameterize this
-        self.port_base = '40000'
+        self.port_base = '20500'
         self.master_port = os.environ.get('PGPORT', '10300')
-        self.mirror_port_base = '50000'
-        self.rep_port_base = '41000'
-        self.mirror_rep_port_base = '51000'
+        self.mirror_port_base = '21500'
+        self.rep_port_base = '22500'
+        self.mirror_rep_port_base = '23500'
 
         self.testcase_primary_dir = os.path.join(self.testcase_out_dir, 'data/primary')
         self.testcase_mirror_dir = os.path.join(self.testcase_out_dir, 'data/mirror')


### PR DESCRIPTION
Fix gpexpand the same way as this commit 4b439bc9cc813438b1143714e68365ef21b8d365

Port numbers used by GPDB should be below kernel's ephemeral port range

The ephemeral port range is given by net.ipv4.ip_local_port_range kernel
parameter. It is set to 32768 --> 60999. If GPDB uses port numbers in this
range, FTS probe request may not get a response, resulting in FTS incorrectly
marking a primary down.

We change the example configuration files to lower the port number to proper
range.

Author: Marbin Tan <mtan@pivotal.io>
Author: C.J. Jameson <cjameson@pivotal.io>

This will be back-ported to 5X_STABLE