### PR TITLE
Fix use-after-free in PyGreSQL

### DIFF
--- a/gpMgmt/bin/pythonSrc/PyGreSQL-4.0/pgmodule.c
+++ b/gpMgmt/bin/pythonSrc/PyGreSQL-4.0/pgmodule.c
@@ -2309,11 +2309,13 @@ pg_query(pgobject * self, PyObject * args)
 					{
 						char	*ret = PQcmdTuples(result);
 
-						PQclear(result);
 						if (ret[0])		/* return number of rows affected */
 						{
-							return PyString_FromString(ret);
+							PyObject* obj = PyString_FromString(ret);
+							PQclear(result);
+							return obj;
 						}
+						PQclear(result);
 						Py_INCREF(Py_None);
 						return Py_None;
 					}


### PR DESCRIPTION
pg_query function is the underlying workhorse for db.query in
python. For INSERT queries, it will return a string containing
the number of rows successfully inserted.

PQcmdTuples() parses a PGresult return by PQExec, if it's an insert
count result, return a pointer to the count. However this pointer
is the internal buffer of PGresult, it shouldn't be used after
PQClear(), although most time its content remain accessible and
unchanged. PyString_FromString will make a copy of the string, so
move PQClear() after PyString_FromString is safe.

This will fix the problem that gpload get an unprintable insert
count sometimes.