### PR TITLE
Support gptransfer only schema of databases or tables

### DIFF
--- a/gpMgmt/bin/gptransfer
+++ b/gpMgmt/bin/gptransfer
@@ -1726,7 +1726,8 @@ class GpTransferCommand(Command):
                     self._drop_target_table()
                     self._create_target_table()
                 if self._schema_only:
-                    return
+                    self._success = True
+                    return 0
                 if not self._table_pair.dest.external:
                     self._cleanup_named_pipes_needed = True
                     self._create_named_pipe()
@@ -2720,7 +2721,7 @@ class GpTransfer(object):
                 logger.warn('the data transfer.')
                 return 1
             else:
-                if self._validator_class:
+                if self._validator_class and not self._options.schema_only:
                     self._final_count_validation()
         else:
             # dry run

--- a/gpMgmt/test/behave/mgmt_utils/gptransfer.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gptransfer.feature
@@ -642,10 +642,16 @@ Feature: gptransfer tests
     Scenario: gptransfer --schema-only
         Given the gptransfer test is initialized
         And database "gptransfer_testdb1" exists
-        And schema "test_schema" exists in "gptransfer_testdb1"
         And the user runs "gptransfer --schema-only -t gptransfer_testdb1.public.t0 --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --batch-size=10"
         Then gptransfer should return a return code of 0
-        And verify that the schema "test_schema" exists in "gptransfer_testdb1"
+        And verify that there is a "heap" table "public.t0" in "gptransfer_testdb1"
+
+    Scenario: gptransfer --schema-only -d
+        Given the gptransfer test is initialized
+        And database "gptransfer_testdb1" exists
+        And the user runs "gptransfer --schema-only -d gptransfer_testdb1 --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --batch-size=10"
+        Then gptransfer should return a return code of 0
+        And verify that there is a "heap" table "public.t0" in "gptransfer_testdb1"
 
     Scenario: gptransfer --schema-only conflicts with --truncate
         Given the gptransfer test is initialized


### PR DESCRIPTION
This is to make gptransfer able to transfer only schema of databases or
tables, like "--schema-only -d foo" or "--schema-only -t bar.public.t1".
It could do that before actually but forgot to set the success flag.

Signed-off-by: Adam Lee <ali@pivotal.io>