### PR TITLE
fix FIXME in transformStorageEncodingClause

### DIFF
--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -3612,8 +3612,6 @@ transformStorageEncodingClause(List *options)
 	 */
 	d = transformRelOptions(PointerGetDatum(NULL),
 									  list_concat(extra, options),
-									  /* GPDB_84_MERGE_FIXME: do we need any
-									   * namespaces? */
 									  NULL, NULL,
 									  true, false);
 	(void)heap_reloptions(RELKIND_RELATION, d, true);


### PR DESCRIPTION
The parameter namespace passed to transformRelOptions routine
has only two values. One is 'toast',the other one is NULL.
'toast' value is to filter toast reloptions. NULL value is to
get no-toast reloptions.

In transformStorageEncodingClause routine just need to get
no-toast reloption.

Author: Max Yang <myang@pivotal.io>