### PR TITLE
Fix pg_total_relation_size() function for AO tables.

### DIFF
--- a/src/backend/utils/adt/dbsize.c
+++ b/src/backend/utils/adt/dbsize.c
@@ -426,10 +426,18 @@ if (RelationIsHeap(rel))
 		totalsize += fst.st_size;
 	}
 }
-else if (RelationIsAoRows(rel))
-	totalsize = GetAOTotalBytes(rel, SnapshotNow);
-else if (RelationIsAoCols(rel))
-	totalsize = GetAOCSTotalBytes(rel, SnapshotNow, true);
+/* AO tables don't have any extra forks. */
+else if (forknum == MAIN_FORKNUM)
+{
+	if (RelationIsAoRows(rel))
+	{
+		totalsize = GetAOTotalBytes(rel, SnapshotNow);
+	}
+	else if (RelationIsAoCols(rel))
+	{
+		totalsize = GetAOCSTotalBytes(rel, SnapshotNow, true);
+	}
+}
 
     /* RELSTORAGE_VIRTUAL has no space usage */
     return totalsize;
@@ -608,7 +616,8 @@ pg_total_relation_size(PG_FUNCTION_ARGS)
 
 		initStringInfo(&buffer);
 
-		appendStringInfo(&buffer, "select sum(pg_total_relation_size('%s.%s'))::int8 from gp_dist_random('gp_id');", quote_identifier(schemaName), quote_identifier(relName));
+		appendStringInfo(&buffer, "select pg_catalog.sum(pg_catalog.pg_total_relation_size('%s.%s'))::int8 from gp_dist_random('gp_id');",
+						 quote_identifier(schemaName), quote_identifier(relName));
 
 		size += get_size_from_segDBs(buffer.data);
 	}

--- a/src/test/regress/input/appendonly.source
+++ b/src/test/regress/input/appendonly.source
@@ -493,6 +493,15 @@ SELECT pg_total_relation_size('aosizetest_1') < pg_total_relation_size('aosizete
 DROP TABLE aosizetest_1;
 DROP TABLE aosizetest_2;
 
+
+-- Check that pg_total_relation_size() returns a sane value for an AO table.
+-- (As of this writing, 1468872 bytes, but leave some slack for minor changes
+-- to indexes etc.)
+CREATE TABLE aosizetest_3(a text) WITH (appendonly=true);
+insert into aosizetest_3 select repeat('x', 100) from generate_series(1, 10000);
+SELECT pg_total_relation_size('aosizetest_3') between 1400000 and 1500000;
+
+
 -- These tests validate current segfile selection algorithm
 DROP TABLE IF EXISTS ao_selection;
 CREATE TABLE ao_selection (a INT, b INT) WITH (appendonly=true);

--- a/src/test/regress/output/appendonly.source
+++ b/src/test/regress/output/appendonly.source
@@ -1082,6 +1082,17 @@ SELECT pg_total_relation_size('aosizetest_1') < pg_total_relation_size('aosizete
 
 DROP TABLE aosizetest_1;
 DROP TABLE aosizetest_2;
+-- Check that pg_total_relation_size() returns a sane value for an AO table.
+-- (As of this writing, 1468872 bytes, but leave some slack for minor changes
+-- to indexes etc.)
+CREATE TABLE aosizetest_3(a text) WITH (appendonly=true);
+insert into aosizetest_3 select repeat('x', 100) from generate_series(1, 10000);
+SELECT pg_total_relation_size('aosizetest_3') between 1400000 and 1500000;
+ ?column? 
+----------
+ t
+(1 row)
+
 -- These tests validate current segfile selection algorithm
 DROP TABLE IF EXISTS ao_selection;
 CREATE TABLE ao_selection (a INT, b INT) WITH (appendonly=true);


### PR DESCRIPTION
It didn't handle relation forks correctly, and counted the main fork's size
three times.