### PR TITLE
Reimplement ORCA interrupts using a callback function

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("2.51.", GPORCA_VERSION_STRING, 5);
+return strncmp("2.52.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 2.51.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 2.52.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -13498,7 +13498,7 @@ int
 main ()
 {
 
-return strncmp("2.51.", GPORCA_VERSION_STRING, 5);
+return strncmp("2.52.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -13508,7 +13508,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 2.51.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 2.52.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v2.51.4@gpdb/stable
+orca/v2.52.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -121,7 +121,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	@echo "Resolve finished";
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget -O - https://github.com/greenplum-db/gporca/releases/download/v2.51.4/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget -O - https://github.com/greenplum-db/gporca/releases/download/v2.52.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/backend/gpopt/CGPOptimizer.cpp
+++ b/src/backend/gpopt/CGPOptimizer.cpp
@@ -135,7 +135,8 @@ CGPOptimizer::InitGPOPT ()
 	gpos_alloc = gpdb::OptimizerAlloc;
 	gpos_free = gpdb::OptimizerFree;
   }
-  struct gpos_init_params params = {gpos_alloc, gpos_free};
+  struct gpos_init_params params =
+	{gpos_alloc, gpos_free, gpdb::FAbortRequested};
   gpos_init(&params);
   gpdxl_init();
   gpopt_init();
@@ -155,29 +156,6 @@ CGPOptimizer::TerminateGPOPT ()
   gpopt_terminate();
   gpdxl_terminate();
   gpos_terminate();
-}
-
-// Signal handler for ORCA
-void
-CGPOptimizer::SignalInterruptGPOPT
-	(
-	int iSignal
-	)
-{
-	if (SIGINT == iSignal || SIGTERM == iSignal)
-	{
-		CWorker::abort_requested = true;
-	}
-	// Other signal handlers shouldn't call this method since some other action
-	// than optimization interruption is required in those cases.
-}
-
-// Reset optimizer state to before SignalInterruptGPOPT() was called.
-// To be called after interrupts have been handled by ORCA.
-void
-CGPOptimizer::ResetInterruptsGPOPT (void)
-{
-	CWorker::abort_requested = false;
 }
 
 //---------------------------------------------------------------------------
@@ -249,25 +227,6 @@ void TerminateGPOPT ()
 {
 	return CGPOptimizer::TerminateGPOPT();
 }
-}
-
-// Signal handler for ORCA
-extern "C"
-{
-void SignalInterruptGPOPT (int signal)
-{
-	CGPOptimizer::SignalInterruptGPOPT(signal);
-}
-}
-
-// Reset optimizer state to before SignalInterruptGPOPT() was called.
-// To be called after interrupts have been handled by ORCA.
-extern "C"
-{
-	void ResetInterruptsGPOPT ()
-	{
-		CGPOptimizer::ResetInterruptsGPOPT();
-	}
 }
 
 // EOF

--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -3142,4 +3142,13 @@ gpdb::OptimizerFree
 	GP_WRAP_END;
 }
 
+// returns true if a query cancel is requested in GPDB
+bool
+gpdb::FAbortRequested
+	(
+	void
+	)
+{
+	return (QueryCancelPending || ProcDiePending);
+}
 // EOF

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -106,11 +106,6 @@
 #include "utils/session_state.h"
 #include "utils/vmem_tracker.h"
 
-#ifdef USE_ORCA
-extern void SignalInterruptGPOPT(int signal);
-extern void ResetInterruptsGPOPT(void);
-#endif
-
 extern int	optind;
 extern char *optarg;
 
@@ -3517,13 +3512,6 @@ StatementCancelHandler(SIGNAL_ARGS)
 		QueryCancelPending = true;
 		QueryCancelCleanup = true;
 
-#ifdef USE_ORCA
-		if (Gp_role == GP_ROLE_DISPATCH)
-		{
-			SignalInterruptGPOPT(postgres_signal_arg);
-		}
-#endif
-
 		/*
 		 * If it's safe to interrupt, and we're waiting for a lock, service
 		 * the interrupt immediately.  No point in interrupting if we're
@@ -3655,13 +3643,6 @@ ProcessInterrupts(const char* filename, int lineno)
 		gp_simex_run = 0;
 	}
 #endif   /* USE_TEST_UTILS */
-
-#ifdef USE_ORCA
-	if (Gp_role == GP_ROLE_DISPATCH)
-	{
-		ResetInterruptsGPOPT();
-	}
-#endif
 
 	InterruptPending = false;
 	if (ProcDiePending)

--- a/src/include/gpopt/CGPOptimizer.h
+++ b/src/include/gpopt/CGPOptimizer.h
@@ -42,16 +42,6 @@ class CGPOptimizer
 
     static
     void TerminateGPOPT();
-
-    // Signal handler for ORCA
-    static
-    void SignalInterruptGPOPT(int iSignal);
-
-    // Reset optimizer state to before SignalInterruptGPOPT() was called.
-    // To be called after interrupts have been handled by ORCA.
-    static
-    void ResetInterruptsGPOPT();
-
 };
 
 #endif // CGPOptimizer_H

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -643,6 +643,9 @@ namespace gpdb {
 
 	void OptimizerFree(void *ptr);
 
+	// returns true if a query cancel is requested in GPDB
+	bool FAbortRequested(void);
+
 } //namespace gpdb
 
 #define ForEach(cell, l)	\

--- a/src/test/unit/mock/gpopt_mock.c
+++ b/src/test/unit/mock/gpopt_mock.c
@@ -57,15 +57,3 @@ TerminateGPOPT ()
 {
 	elog(ERROR, "mock implementation of TerminateGPOPT called");
 }
-
-void
-SignalInterruptGPOPT(int iSignal)
-{
-	elog(ERROR, "mock implementation of SignalInterruptGPOPT called");
-}
-
-void
-ResetInterruptsGPOPT()
-{
-	elog(ERROR, "mock implementation of ResetInterruptsGPOPT called");
-}


### PR DESCRIPTION
As pointed out by Heikki, maintaining another variable to match one in
the database system will be error-prone and cumbersome, especially while
merging with upstream. This commit initializes ORCA with a pointer to a
GPDB function that returns true when QueryCancelPending or
ProcDiePending is set. This way we no longer have to micro-manage
setting and re-setting some internal ORCA variable, or touch signal
handlers.

Related ORCA changes : https://github.com/greenplum-db/gporca/pull/282