### PR TITLE
Ignore undetermined output within cursor.sql

### DIFF
--- a/src/test/regress/expected/cursor.out
+++ b/src/test/regress/expected/cursor.out
@@ -88,13 +88,14 @@ NOTICE:  Success:
 DECLARE cursor_c2 CURSOR FOR SELECT * FROM cursor_writer_reader WHERE b=666 ORDER BY 1;
 SAVEPOINT x;
 UPDATE cursor_writer_reader SET b=333 WHERE b=666;
+-- start_ignore
 select gp_inject_fault('qe_got_snapshot_and_interconnect', 'status', 2);
 NOTICE:  Success: fault name:'qe_got_snapshot_and_interconnect' fault type:'suspend' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'triggered'  num times hit:'1'
  gp_inject_fault 
 -----------------
  t
 (1 row)
-
+-- end_ignore
 select gp_inject_fault('qe_got_snapshot_and_interconnect', 'resume', 2);
 NOTICE:  Success:
  gp_inject_fault 

--- a/src/test/regress/sql/cursor.sql
+++ b/src/test/regress/sql/cursor.sql
@@ -57,7 +57,9 @@ select gp_inject_fault('qe_got_snapshot_and_interconnect', 'suspend', 2);
 DECLARE cursor_c2 CURSOR FOR SELECT * FROM cursor_writer_reader WHERE b=666 ORDER BY 1;
 SAVEPOINT x;
 UPDATE cursor_writer_reader SET b=333 WHERE b=666;
+-- start_ignore
 select gp_inject_fault('qe_got_snapshot_and_interconnect', 'status', 2);
+-- end_ignore
 select gp_inject_fault('qe_got_snapshot_and_interconnect', 'resume', 2);
 FETCH cursor_c2;
 SELECT * FROM cursor_writer_reader WHERE b=666 ORDER BY 1;


### PR DESCRIPTION
    When declaring a cursor, QD will not block until QE got a
    snapshot and set up a interconnect, so we can not guarantee
    that QD always see 'qe_got_snapshot_and_interconnect' was
    triggered. For the case itself, if the writer QE can get
    slower than the reader QE without the help of fault injector,
    it's even better.
This issue is exposed multiple times after we added a new ICW job on sles12 yesterday, but we can not
tell why it happens more often on sles12.
https://gpdb.data.pivotal.ci/teams/main/pipelines/gpdb_master/jobs/icw_planner_sles12/builds/8
https://gpdb.data.pivotal.ci/teams/main/pipelines/gpdb_master/jobs/icw_planner_sles12/builds/7 