### PR TITLE
Remove "chown gpdb_src" from CI scripts

### DIFF
--- a/concourse/scripts/gpcheckcloud_tests_gpcloud.bash
+++ b/concourse/scripts/gpcheckcloud_tests_gpcloud.bash
@@ -16,7 +16,6 @@ function gen_env(){
 	bash gpcheckcloud_regress.sh
 	EOF
 
-	chown -R gpadmin:gpadmin $(pwd)
 	chown gpadmin:gpadmin /home/gpadmin/run_regression_gpcheckcloud.sh
 	chmod a+x /home/gpadmin/run_regression_gpcheckcloud.sh
 }

--- a/concourse/scripts/regression_tests_gphdfs.bash
+++ b/concourse/scripts/regression_tests_gphdfs.bash
@@ -64,7 +64,6 @@ function gen_env(){
 	exit 0
 	EOF
 
-	chown -R gpadmin:gpadmin $(pwd)
 	chown gpadmin:gpadmin /home/gpadmin/run_regression_test.sh
 	chmod a+x /home/gpadmin/run_regression_test.sh
 }

--- a/concourse/scripts/regression_tests_pxf.bash
+++ b/concourse/scripts/regression_tests_pxf.bash
@@ -170,7 +170,17 @@ function _main() {
 
 	time make_cluster
 	time start_pxf $(pwd)/singlecluster
-	chown -R gpadmin:gpadmin $(pwd)
+        # Let's make sure that the pxf_automation_src directory is writeable
+        # Recusive chowning will hammer OverlayFS and introduce flakiness so we'll make
+        # the directory structure writable by all
+        local pxf_src_dir=pxf_automation_src
+        if [ -d "${pxf_src_dir}" ]
+        then
+            chmod a+w ${pxf_src_dir} 
+            find ${pxf_src_dir}  -type d -exec chmod a+w {} \;
+        fi
+        #chowning the singlecluster else test will fail
+        chown -R gpadmin:gpadmin singlecluster
 	time run_regression_test
 	time run_pxf_automation $(pwd)/singlecluster
 }

--- a/concourse/scripts/setup_gpadmin_user.bash
+++ b/concourse/scripts/setup_gpadmin_user.bash
@@ -34,7 +34,6 @@ ssh_keyscan_for_user() {
 }
 
 transfer_ownership() {
-    #  chown -R gpadmin:gpadmin gpdb_src
     chmod a+w gpdb_src
     find gpdb_src -type d -exec chmod a+w {} \;
     # Needed for the gpload test

--- a/concourse/scripts/setup_gpadmin_user.bash
+++ b/concourse/scripts/setup_gpadmin_user.bash
@@ -34,10 +34,14 @@ ssh_keyscan_for_user() {
 }
 
 transfer_ownership() {
-  chown -R gpadmin:gpadmin gpdb_src
-  [ -d /usr/local/gpdb ] && chown -R gpadmin:gpadmin /usr/local/gpdb
-  [ -d /usr/local/greenplum-db-devel ] && chown -R gpadmin:gpadmin /usr/local/greenplum-db-devel
-  chown -R gpadmin:gpadmin /home/gpadmin
+    #  chown -R gpadmin:gpadmin gpdb_src
+    chmod a+w gpdb_src
+    find gpdb_src -type d -exec chmod a+w {} \;
+    # Needed for the gpload test
+    [ -f gpdb_src/gpMgmt/bin/gpload_test/gpload2/data_file.csv ] && chown gpadmin:gpadmin gpdb_src/gpMgmt/bin/gpload_test/gpload2/data_file.csv
+    [ -d /usr/local/gpdb ] && chown -R gpadmin:gpadmin /usr/local/gpdb
+    [ -d /usr/local/greenplum-db-devel ] && chown -R gpadmin:gpadmin /usr/local/greenplum-db-devel
+    chown -R gpadmin:gpadmin /home/gpadmin
 }
 
 set_limits() {


### PR DESCRIPTION
This removes the recursive `chown` of `gpdb_src` in the CI scripts.  This played to overlayFS' weaknesses and caused some very heavy load and inconsistent performance in the CI.

In testing for ICW tests it reduce the 7-12 minute chown to < 10 seconds.