### PR TITLE
docs - costing diffs between gporca/planner and RQ limits

### DIFF
--- a/gpdb-doc/dita/admin_guide/workload_mgmt.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt.xml
@@ -76,11 +76,14 @@
           <pd>
             <note>GPORCA and the legacy Greenplum Database query optimizer utilize different
               query costing models and may compute different costs for the same query.
-              When resource queue-based resource management is active, use the
+              The Greenplum Database resource queue resource management scheme neither
+              differentiates nor aligns costs between GPORCA and the legacy optimizer; it
+              uses the literal cost value returned from the optimizer to throttle
+              queries.<p> When resource queue-based resource management is active, use the
               <codeph>MEMORY_LIMIT</codeph> and <codeph>ACTIVE_STATEMENTS</codeph> limits for
               resource queues rather than configuring cost-based limits. Even when using GPORCA,
               Greenplum Database may fall back to using the legacy query optimizer for certain
-              queries, so using cost-based limits can lead to unexpected results.</note>
+              queries, so using cost-based limits can lead to unexpected results.</p></note>
           </pd>
         </plentry>
       </parml></p>

--- a/gpdb-doc/dita/admin_guide/workload_mgmt.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt.xml
@@ -74,8 +74,13 @@
             exceeds the <codeph>MAX_COST</codeph> value set for the resource queue, the query is
             rejected as too expensive.</pd>
           <pd>
-            <note>Use <codeph>MEMORY_LIMIT</codeph> and <codeph>ACTIVE_STATEMENTS</codeph> to set
-              limits for resource queues rather than <codeph>MAX_COST</codeph>. </note>
+            <note>GPORCA and the legacy Greenplum Database query optimizer utilize different
+              query costing models and may compute differing costs for the same query.
+              When resource queue-based resource management is active, take into consideration
+              the query optimizer in use, and set resource queue limits appropriately. In
+               particular, use the <codeph>MEMORY_LIMIT</codeph> and 
+               <codeph>ACTIVE_STATEMENTS</codeph> limits for resource queues rather than
+               configuring cost-based limits.</note>
           </pd>
         </plentry>
       </parml></p>

--- a/gpdb-doc/dita/admin_guide/workload_mgmt.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt.xml
@@ -75,12 +75,12 @@
             rejected as too expensive.</pd>
           <pd>
             <note>GPORCA and the legacy Greenplum Database query optimizer utilize different
-              query costing models and may compute differing costs for the same query.
-              When resource queue-based resource management is active, take into consideration
-              the query optimizer in use, and set resource queue limits appropriately. In
-               particular, use the <codeph>MEMORY_LIMIT</codeph> and 
-               <codeph>ACTIVE_STATEMENTS</codeph> limits for resource queues rather than
-               configuring cost-based limits.</note>
+              query costing models and may compute different costs for the same query.
+              When resource queue-based resource management is active, use the
+              <codeph>MEMORY_LIMIT</codeph> and <codeph>ACTIVE_STATEMENTS</codeph> limits for
+              resource queues rather than configuring cost-based limits. Even when using GPORCA,
+              Greenplum Database may fall back to using the legacy query optimizer for certain
+              queries, so using cost-based limits can lead to unexpected results.</note>
           </pd>
         </plentry>
       </parml></p>

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_RESOURCE_QUEUE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_RESOURCE_QUEUE.xml
@@ -100,12 +100,12 @@
     <section id="section5">
       <title>Notes</title>
       <p>GPORCA and the legacy Greenplum Database query optimizer utilize different
-        query costing models and may compute differing costs for the same query.
-        When resource queue-based resource management is active, take into consideration
-        the query optimizer in use, and set resource queue limits appropriately. In
-        particular, use the <codeph>MEMORY_LIMIT</codeph> and
-        <codeph>ACTIVE_STATEMENTS</codeph> limits for resource queues rather than
-        configuring cost-based limits.
+        query costing models and may compute different costs for the same query.
+        When resource queue-based resource management is active, use the
+        <codeph>MEMORY_LIMIT</codeph> and <codeph>ACTIVE_STATEMENTS</codeph> limits for
+        resource queues rather than configuring cost-based limits. Even when using GPORCA,
+        Greenplum Database may fall back to using the legacy query optimizer for certain
+        queries, so using cost-based limits can lead to unexpected results.
       </p>
     </section>
     <section id="section6">

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_RESOURCE_QUEUE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_RESOURCE_QUEUE.xml
@@ -99,9 +99,14 @@
     </section>
     <section id="section5">
       <title>Notes</title>
-      <p>Use <codeph><xref href="./CREATE_ROLE.xml#topic1" type="topic" format="dita"/></codeph> or
-            <codeph><xref href="./ALTER_ROLE.xml#topic1" type="topic" format="dita"/></codeph> to
-        add a role (user) to a resource queue.</p>
+      <p>GPORCA and the legacy Greenplum Database query optimizer utilize different
+        query costing models and may compute differing costs for the same query.
+        When resource queue-based resource management is active, take into consideration
+        the query optimizer in use, and set resource queue limits appropriately. In
+        particular, use the <codeph>MEMORY_LIMIT</codeph> and
+        <codeph>ACTIVE_STATEMENTS</codeph> limits for resource queues rather than
+        configuring cost-based limits.
+      </p>
     </section>
     <section id="section6">
       <title>Examples</title>

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_RESOURCE_QUEUE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_RESOURCE_QUEUE.xml
@@ -99,14 +99,17 @@
     </section>
     <section id="section5">
       <title>Notes</title>
-      <p>GPORCA and the legacy Greenplum Database query optimizer utilize different
-        query costing models and may compute different costs for the same query.
-        When resource queue-based resource management is active, use the
-        <codeph>MEMORY_LIMIT</codeph> and <codeph>ACTIVE_STATEMENTS</codeph> limits for
-        resource queues rather than configuring cost-based limits. Even when using GPORCA,
-        Greenplum Database may fall back to using the legacy query optimizer for certain
-        queries, so using cost-based limits can lead to unexpected results.
-      </p>
+        <p>GPORCA and the legacy Greenplum Database query optimizer utilize different
+           query costing models and may compute different costs for the same query.
+           The Greenplum Database resource queue resource management scheme neither
+           differentiates nor aligns costs between GPORCA and the legacy optimizer; it
+           uses the literal cost value returned from the optimizer to throttle
+           queries.</p>
+        <p>When resource queue-based resource management is active, use the
+           <codeph>MEMORY_LIMIT</codeph> and <codeph>ACTIVE_STATEMENTS</codeph> limits for
+           resource queues rather than configuring cost-based limits. Even when using GPORCA,
+           Greenplum Database may fall back to using the legacy query optimizer for certain
+           queries, so using cost-based limits can lead to unexpected results.</p>
     </section>
     <section id="section6">
       <title>Examples</title>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_QUEUE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_QUEUE.xml
@@ -47,11 +47,14 @@
         that will be exempt from resource queueing.</p>
       <note>GPORCA and the legacy Greenplum Database query optimizer utilize different
               query costing models and may compute different costs for the same query.
-              When resource queue-based resource management is active, use the
+              The Greenplum Database resource queue resource management scheme neither
+              differentiates nor aligns costs between GPORCA and the legacy optimizer; it
+              uses the literal cost value returned from the optimizer to throttle
+              queries.<p> When resource queue-based resource management is active, use the
               <codeph>MEMORY_LIMIT</codeph> and <codeph>ACTIVE_STATEMENTS</codeph> limits for
               resource queues rather than configuring cost-based limits. Even when using GPORCA,
               Greenplum Database may fall back to using the legacy query optimizer for certain
-              queries, so using cost-based limits can lead to unexpected results.</note>
+              queries, so using cost-based limits can lead to unexpected results.</p></note>
       <p>If a value is not defined for <codeph>ACTIVE_STATEMENTS</codeph> or
           <codeph>MAX_COST</codeph>, it is set to <codeph>-1</codeph> by default (meaning no limit).
         After defining a resource queue, you must assign roles to the queue using the <codeph><xref

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_QUEUE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_QUEUE.xml
@@ -46,12 +46,12 @@
         for <codeph>MIN_COST</codeph> allows the administrator to define a cost for small queries
         that will be exempt from resource queueing.</p>
       <note>GPORCA and the legacy Greenplum Database query optimizer utilize different
-        query costing models and may compute differing costs for the same query.
-        When resource queue-based resource management is active, take into consideration
-        the query optimizer in use, and set resource queue limits appropriately. In
-        particular, use the <codeph>MEMORY_LIMIT</codeph> and
-        <codeph>ACTIVE_STATEMENTS</codeph> limits for resource queues rather than
-        configuring cost-based limits.</note>
+              query costing models and may compute different costs for the same query.
+              When resource queue-based resource management is active, use the
+              <codeph>MEMORY_LIMIT</codeph> and <codeph>ACTIVE_STATEMENTS</codeph> limits for
+              resource queues rather than configuring cost-based limits. Even when using GPORCA,
+              Greenplum Database may fall back to using the legacy query optimizer for certain
+              queries, so using cost-based limits can lead to unexpected results.</note>
       <p>If a value is not defined for <codeph>ACTIVE_STATEMENTS</codeph> or
           <codeph>MAX_COST</codeph>, it is set to <codeph>-1</codeph> by default (meaning no limit).
         After defining a resource queue, you must assign roles to the queue using the <codeph><xref

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_QUEUE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_QUEUE.xml
@@ -45,6 +45,13 @@
         exceed the cost limit will always be rejected and never allowed to run. Specifying a value
         for <codeph>MIN_COST</codeph> allows the administrator to define a cost for small queries
         that will be exempt from resource queueing.</p>
+      <note>GPORCA and the legacy Greenplum Database query optimizer utilize different
+        query costing models and may compute differing costs for the same query.
+        When resource queue-based resource management is active, take into consideration
+        the query optimizer in use, and set resource queue limits appropriately. In
+        particular, use the <codeph>MEMORY_LIMIT</codeph> and
+        <codeph>ACTIVE_STATEMENTS</codeph> limits for resource queues rather than
+        configuring cost-based limits.</note>
       <p>If a value is not defined for <codeph>ACTIVE_STATEMENTS</codeph> or
           <codeph>MAX_COST</codeph>, it is set to <codeph>-1</codeph> by default (meaning no limit).
         After defining a resource queue, you must assign roles to the queue using the <codeph><xref


### PR DESCRIPTION
costing model is different between gporca and planner
- add note to "using resource queues", CREATE RESOURCE QUEUES, and ALTER RESOURCE QUEUE pages

links on doc review site:
- http://docs-gpdb-review-staging.cfapps.io/530/admin_guide/workload_mgmt.html - see "MAX_COST" description
- http://docs-gpdb-review-staging.cfapps.io/530/ref_guide/sql_commands/ALTER_RESOURCE_QUEUE.html - see "Notes" section
- http://docs-gpdb-review-staging.cfapps.io/530/ref_guide/sql_commands/CREATE_RESOURCE_QUEUE.html#topic1 - see Description
