### PR TITLE
Able to cancel COPY PROGRAM ON SEGMENT if the program hangs

### DIFF
--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -32,6 +32,8 @@
 #include "utils/faultinjector.h"
 #include "utils/memutils.h"
 
+#include <poll.h>
+
 /*
  * Create a cdbCopy object that includes all the cdb
  * information and state needed by the backend COPY.
@@ -187,7 +189,7 @@ cdbCopyStart(CdbCopy *c, char *copyCmd, struct GpPolicy *policy)
 	MemoryContextSwitchTo(oldcontext);
 
 	CdbDispatchUtilityStatement((Node *) q->utilityStmt,
-								(c->copy_in ? DF_NEED_TWO_PHASE | DF_WITH_SNAPSHOT : DF_WITH_SNAPSHOT),
+								(c->copy_in ? DF_NEED_TWO_PHASE | DF_WITH_SNAPSHOT : DF_WITH_SNAPSHOT) | DF_CANCEL_ON_ERROR,
 								NIL,	/* FIXME */
 								NULL);
 
@@ -454,6 +456,7 @@ processCopyEndResults(CdbCopy *c,
 	SegmentDatabaseDescriptor *q;
 	int			seg;
 	PGresult   *res;
+	struct pollfd	*pollRead = (struct pollfd *) palloc(sizeof(struct pollfd));
 	int			segment_rows_rejected = 0;	/* num of rows rejected by this QE */
 	int			segment_rows_completed = 0; /* num of rows completed by this
 											 * QE */
@@ -485,6 +488,23 @@ processCopyEndResults(CdbCopy *c,
 			c->io_errors = true;
 		}
 
+		pollRead->fd = PQsocket(q->conn);
+		pollRead->events = POLLIN;
+		pollRead->revents = 0;
+
+		while (PQisBusy(q->conn))
+		{
+			if ((Gp_role == GP_ROLE_DISPATCH) && InterruptPending)
+			{
+				PQrequestCancel(q->conn);
+			}
+
+			if (poll(pollRead, 1, 200) > 0)
+			{
+				break;
+			}
+		}
+
 		/*
 		 * Fetch any error status existing on completion of the COPY command.
 		 * It is critical that for any connection that had an asynchronous
@@ -492,6 +512,7 @@ processCopyEndResults(CdbCopy *c,
 		 * Otherwise, the next time a command is sent to that connection, it
 		 * will return an error that there's a command pending.
 		 */
+		HOLD_INTERRUPTS();
 		while ((res = PQgetResult(q->conn)) != NULL && PQstatus(q->conn) != CONNECTION_BAD)
 		{
 			elog(DEBUG1, "PQgetResult got status %d seg %d    ",
@@ -617,6 +638,7 @@ processCopyEndResults(CdbCopy *c,
 			/* free the PGresult object */
 			PQclear(res);
 		}
+		RESUME_INTERRUPTS();
 
 		/* Finished with this segment db. */
 		c->segdb_state[seg][0] = SEGDB_DONE;
@@ -662,8 +684,6 @@ processCopyEndResults(CdbCopy *c,
 		}
 	}
 }
-
-
 
 /*
  * ends the copy command on all segment databases.


### PR DESCRIPTION
There are two places that QD keep trying to get data, ignore SIGINT, and
not send signal to QEs. If the program on segment has no input/output,
copy command hangs.

To fix it, this commit:

1, lets QD wait connections able to be read before PQgetResult(), and
cancels queries if gets interrupt signals while waiting
2, sets DF_CANCEL_ON_ERROR when dispatch in cdbcopy.c
3, completes copy error handling

-- prepare
create table test(t text);
copy test from program 'yes|head -n 655360';

-- could be canceled
copy test from program 'sleep 100 && yes test';
copy test from program 'sleep 100 && yes test<SEGID>' on segment;
copy test from program 'yes test';
copy test to '/dev/null';
copy test to program 'sleep 100 && yes test';
copy test to program 'sleep 100 && yes test<SEGID>' on segment;

-- should fail
copy test from program 'yes test<SEGID>' on segment;
copy test to program 'sleep 0.1 && cat > /dev/nulls';
copy test to program 'sleep 0.1<SEGID> && cat > /dev/nulls' on segment;