### PR TITLE
Enhance hardening docs on trust and ident

### DIFF
--- a/gpdb-doc/dita/admin_guide/client_auth.xml
+++ b/gpdb-doc/dita/admin_guide/client_auth.xml
@@ -7,35 +7,32 @@
     Greenplum Database.</shortdesc>
   <body>
     <p>When a Greenplum Database system is first initialized, the system contains one predefined
-       <i>superuser</i> role. This role will have the same name as the operating system user who
+        <i>superuser</i> role. This role will have the same name as the operating system user who
       initialized the Greenplum Database system. This role is referred to as
-      <codeph>gpadmin</codeph>. By default, the system is configured to only allow local 
+        <codeph>gpadmin</codeph>. By default, the system is configured to only allow local
       connections to the database from the <codeph>gpadmin</codeph> role. If you want to allow any
       other roles to connect, or if you want to allow connections from remote hosts, you have to
-      configure Greenplum Database to allow such connections. This section explains how to
-      configure client connections and authentication to Greenplum Database.</p>
+      configure Greenplum Database to allow such connections. This section explains how to configure
+      client connections and authentication to Greenplum Database.</p>
     <note>The PgBouncer connection pooler is bundled with Greenplum Database. PgBouncer can be
       configured to support LDAP or Active Directory authentication for users connecting to
-      Greenplum Database through the connection pooler client connections to Greenplum Database.
-      See
-      <xref
-        href="access_db/topics/pgbouncer.xml#topic_fstrm"/>. </note>
+      Greenplum Database through the connection pooler client connections to Greenplum Database. See
+        <xref href="access_db/topics/pgbouncer.xml#topic_fstrm"/>. </note>
   </body>
   <topic id="topic2" xml:lang="en">
     <title id="ip142171">Allowing Connections to Greenplum Database</title>
     <body>
       <p>Client access and authentication is controlled by the standard PostgreSQL host-based
-        authentication file, <filepath>pg_hba.conf</filepath>.  For detailed information about
-        this file, see <xref
-          href="http://www.postgresql.org/docs/9.0/interactive/auth-pg-hba-conf.html"
-          scope="external" format="html"
-        >The pg_hba.conf File</xref> in the PostgreSQL documentation. </p>
+        authentication file, <filepath>pg_hba.conf</filepath>. For detailed information about this
+        file, see <xref href="http://www.postgresql.org/docs/9.0/interactive/auth-pg-hba-conf.html"
+          scope="external" format="html">The pg_hba.conf File</xref> in the PostgreSQL
+        documentation. </p>
       <p>In Greenplum Database, the <filepath>pg_hba.conf</filepath> file of the master instance
         controls client access and authentication to your Greenplum Database system. The Greenplum
         Database segments also have <filepath>pg_hba.conf</filepath> files, but these are already
         correctly configured to allow only client connections from the master host. The segments
         never accept outside client connections, so there is no need to alter the
-        <codeph>pg_hba.conf</codeph> file on segments.</p>
+          <codeph>pg_hba.conf</codeph> file on segments.</p>
       <p>The general format of the <filepath>pg_hba.conf</filepath> file is a set of records, one
         per line. Greenplum Database ignores blank lines and any text after the <codeph>#</codeph>
         comment character. A record consists of a number of fields that are separated by spaces or
@@ -59,42 +56,37 @@
           <tbody>
             <row>
               <entry colname="col1">local</entry>
-              <entry colname="col2"
-                >Matches connection attempts using UNIX-domain sockets. Without a
+              <entry colname="col2">Matches connection attempts using UNIX-domain sockets. Without a
                 record of this type, UNIX-domain socket connections are disallowed.</entry>
             </row>
             <row>
               <entry colname="col1">host</entry>
-              <entry colname="col2"
-                  >Matches connection attempts made using TCP/IP. Remote TCP/IP connections will
-                not be possible unless the server is started with an appropriate value for the
-                <codeph>listen_addresses</codeph> server configuration parameter.</entry>
+              <entry colname="col2">Matches connection attempts made using TCP/IP. Remote TCP/IP
+                connections will not be possible unless the server is started with an appropriate
+                value for the <codeph>listen_addresses</codeph> server configuration
+                parameter.</entry>
             </row>
             <row>
               <entry colname="col1">hostssl</entry>
-              <entry colname="col2"
-                  >Matches connection attempts made using TCP/IP, but only when the connection is
-                made with SSL encryption. SSL must be enabled at server start time by setting the
-                <codeph>ssl</codeph> server configuration parameter. </entry>
+              <entry colname="col2">Matches connection attempts made using TCP/IP, but only when the
+                connection is made with SSL encryption. SSL must be enabled at server start time by
+                setting the <codeph>ssl</codeph> server configuration parameter. </entry>
             </row>
             <row>
               <entry colname="col1">hostnossl</entry>
-              <entry colname="col2"
-                >Matches connection attempts made over TCP/IP that do not use
+              <entry colname="col2">Matches connection attempts made over TCP/IP that do not use
                 SSL.</entry>
             </row>
             <row>
               <entry colname="col1">database</entry>
-              <entry colname="col2"
-                  >Specifies which database names this record matches. The value
+              <entry colname="col2">Specifies which database names this record matches. The value
                   <codeph>all</codeph> specifies that it matches all databases. Multiple database
                 names can be supplied by separating them with commas. A separate file containing
                 database names can be specified by preceding the file name with @.</entry>
             </row>
             <row>
               <entry colname="col1">role</entry>
-              <entry colname="col2"
-                  >Specifies which database role names this record matches. The
+              <entry colname="col2">Specifies which database role names this record matches. The
                 value <codeph>all</codeph> specifies that it matches all roles. If the specified
                 role is a group and you want all members of that group to be included, precede the
                 role name with a +. Multiple role names can be supplied by separating them with
@@ -103,45 +95,44 @@
             </row>
             <row>
               <entry colname="col1">CIDR-address</entry>
-              <entry colname="col2"
-                  >Specifies the client machine IP address range that this record matches. It
-                contains an IP address in standard dotted decimal notation and a CIDR mask length.
-                IP addresses can only be specified numerically, not as domain or host names. The
-                mask length indicates the number of high-order bits of the client IP address that
-                must match. Bits to the right of this must be zero in the given IP address. There
-                must not be any white space between the IP address, the /, and the CIDR mask length.
-                <p>Typical examples of a CIDR-address are 172.20.143.89/32 for a single host, or
-                  172.20.143.0/24 for a small network, or 10.6.0.0/16 for a larger one. To specify
-                  a single host, use a CIDR mask of 32 for IPv4 or 128 for IPv6. In a network
-                  address, do not omit trailing zeroes.</p></entry>
+              <entry colname="col2">Specifies the client machine IP address range that this record
+                matches. It contains an IP address in standard dotted decimal notation and a CIDR
+                mask length. IP addresses can only be specified numerically, not as domain or host
+                names. The mask length indicates the number of high-order bits of the client IP
+                address that must match. Bits to the right of this must be zero in the given IP
+                address. There must not be any white space between the IP address, the /, and the
+                CIDR mask length. <p>Typical examples of a CIDR-address are 172.20.143.89/32 for a
+                  single host, or 172.20.143.0/24 for a small network, or 10.6.0.0/16 for a larger
+                  one. To specify a single host, use a CIDR mask of 32 for IPv4 or 128 for IPv6. In
+                  a network address, do not omit trailing zeroes.</p></entry>
             </row>
             <row>
               <entry colname="col1">IP-address<p>IP-mask</p></entry>
-              <entry colname="col2"
-                >These fields can be used as an alternative to the CIDR-address notation. Instead
-                of specifying the mask length, the actual mask is specified in a separate column.
-                For example, 255.0.0.0 represents an IPv4 CIDR mask length of 8, and 255.255.255.255 represents a CIDR mask length of 32. These fields only apply to and 255.255.255.255 represents a CIDR mask length of 32. These fields only apply to host, hostssl, and hostnossl records. </entry>
+              <entry colname="col2">These fields can be used as an alternative to the CIDR-address
+                notation. Instead of specifying the mask length, the actual mask is specified in a
+                separate column. For example, 255.0.0.0 represents an IPv4 CIDR mask length of 8,
+                and 255.255.255.255 represents a CIDR mask length of 32. These fields only apply to
+                and 255.255.255.255 represents a CIDR mask length of 32. These fields only apply to
+                host, hostssl, and hostnossl records. </entry>
             </row>
             <row>
               <entry colname="col1">authentication-method</entry>
-              <entry colname="col2"
-                  >Specifies the authentication method to use when connecting. Greenplum supports
-                the <xref
+              <entry colname="col2">Specifies the authentication method to use when connecting.
+                Greenplum supports the <xref
                   href="http://www.postgresql.org/docs/9.0/static/auth-methods.html"
-                  scope="external" format="html"
-                >authentication methods</xref> supported by PostgreSQL 9.0.</entry>
+                  scope="external" format="html">authentication methods</xref> supported by
+                PostgreSQL 9.0.</entry>
             </row>
           </tbody>
         </tgroup>
       </table>
-      <note type="caution"
-          >For a more secure system, consider removing records for remote connections that use
-        trust authentication from the <codeph>pg_hba.conf</codeph> file. Trust authentication
-        grants any user who can connect to the server access to the database using any role they
-        specify. You can safely replace trust authentication with ident authentication for local
-        UNIX-socket connections. You can also use ident authentication for local and remote TCP
-        clients, but the client host must be running an ident service and you must trust the
-        integrity of that machine.</note>
+      <note type="caution">For a more secure system, consider removing records for remote
+        connections that use trust authentication from the <codeph>pg_hba.conf</codeph> file. Trust
+        authentication grants any user who can connect to the server access to the database using
+        any role they specify. You can safely replace trust authentication with ident authentication
+        for local UNIX-socket connections. You can also use ident authentication for local and
+        remote TCP clients, but the client host must be running an ident service and you must trust
+        the integrity of that machine.</note>
     </body>
     <topic id="topic3" xml:lang="en">
       <title id="ip141322">Editing the pg_hba.conf File</title>
@@ -158,17 +149,15 @@
           connections, for example 127.0.0.1/28. Using ident authentication for remote TCP
           connections is less secure because it requires you to trust the integrity of the ident
           service on the client's host.</p>
-        <p>This example shows how to edit the <filepath>pg_hba.conf</filepath> file of the master
-          to allow remote client access to all databases from all roles using encrypted password
+        <p>This example shows how to edit the <filepath>pg_hba.conf</filepath> file of the master to
+          allow remote client access to all databases from all roles using encrypted password
           authentication.</p>
         <section id="ip144328">
           <title>Editing pg_hba.conf</title>
           <ol id="ol_xz4_x15_jp">
-            <li id="ip142837"
-              >Open the file <filepath>$MASTER_DATA_DIRECTORY/pg_hba.conf</filepath>
+            <li id="ip142837">Open the file <filepath>$MASTER_DATA_DIRECTORY/pg_hba.conf</filepath>
               in a text editor.</li>
-            <li id="ip141930"
-              >Add a line to the file for each type of connection you want to allow.
+            <li id="ip141930">Add a line to the file for each type of connection you want to allow.
               Records are read sequentially, so the order of the records is significant. Typically,
               earlier records will have tight connection match parameters and weaker authentication
               methods, while later records will have looser match parameters and stronger
@@ -196,12 +185,10 @@ ldapsuffix=",ou=People,dc=company,dc=com"</codeblock></li>
                 <codeblock>$ gpstop -u</codeblock>
               </p></li>
           </ol>
-          <note type="note"
-              >Note that you can also control database access by
-            setting object privileges as described in <xref
-              href="roles_privs.xml#topic6" type="topic" format="dita"
-              />. The <filepath>pg_hba.conf</filepath> file just controls
-            who can initiate a database session and how those connections are authenticated.</note>
+          <note type="note">Note that you can also control database access by setting object
+            privileges as described in <xref href="roles_privs.xml#topic6" type="topic"
+              format="dita"/>. The <filepath>pg_hba.conf</filepath> file just controls who can
+            initiate a database session and how those connections are authenticated.</note>
         </section>
       </body>
     </topic>
@@ -215,8 +202,8 @@ ldapsuffix=",ou=People,dc=company,dc=com"</codeblock></li>
         can configure the <codeph>max_connections</codeph> server configuration parameter. This is a
           <i>local</i> parameter, meaning that you must set it in the
           <codeph>postgresql.conf</codeph> file of the master, the standby master, and each segment
-        instance (primary and mirror). The recommended value of
-          <codeph>max_connections</codeph> on segments is 5-10 times the value on the master.</p>
+        instance (primary and mirror). The recommended value of <codeph>max_connections</codeph> on
+        segments is 5-10 times the value on the master.</p>
       <p>When you set <codeph>max_connections</codeph>, you must also set the dependent parameter
           <codeph>max_prepared_transactions</codeph>. This value must be at least as large as the
         value of <codeph>max_connections</codeph> on the master, and segment instances should be set
@@ -244,25 +231,22 @@ max_prepared_transactions=100
       </ul>
       <p>The following steps set the parameter values with the Greenplum Database utility
           <codeph>gpconfig</codeph>. </p>
-      <p>For information about <codeph>gpconfig</codeph>, see the <i>Greenplum
-          Database Utility Guide</i>.</p>
+      <p>For information about <codeph>gpconfig</codeph>, see the <i>Greenplum Database Utility
+          Guide</i>.</p>
       <section id="ip142411">
         <title>To change the number of allowed connections</title>
         <ol id="ol_sty_r15_jp">
-          <li id="ip146498"
-              >Log into the Greenplum Database master host as the Greenplum Database
+          <li id="ip146498">Log into the Greenplum Database master host as the Greenplum Database
             administrator and source the file <codeph>$GPHOME/greenplum_path.sh</codeph>. </li>
-          <li id="ip146499"
-              >Set the value of the <codeph>max_connections</codeph> parameter. This
+          <li id="ip146499">Set the value of the <codeph>max_connections</codeph> parameter. This
               <codeph>gpconfig</codeph> command sets the value on the segments to 1000 and the value
             on the master to 200.<p>
               <codeblock>$ gpconfig -c max_connections -v 1000 -m 200
 </codeblock>
-            </p><p>The value on the segments must be greater than the value on the master. The 
-              recommended value of <codeph>max_connections</codeph> on segments is 5-10 times the 
+            </p><p>The value on the segments must be greater than the value on the master. The
+              recommended value of <codeph>max_connections</codeph> on segments is 5-10 times the
               value on the master. </p></li>
-          <li id="ip146502"
-              >Set the value of the <codeph>max_prepared_transactions</codeph>
+          <li id="ip146502">Set the value of the <codeph>max_prepared_transactions</codeph>
             parameter. This <codeph>gpconfig</codeph> command sets the value to 200 on the master
             and all segments.<p>
               <codeblock>$ gpconfig -c max_prepared_transactions -v 200
@@ -273,8 +257,7 @@ max_prepared_transactions=100
               <codeblock>$ gpstop -r
 </codeblock>
             </p></li>
-          <li id="ip146510"
-              >You can check the value of parameters on the master and segments with
+          <li id="ip146510">You can check the value of parameters on the master and segments with
             the <codeph>gpconfig</codeph>
             <codeph>-s</codeph> option. This <codeph>gpconfig</codeph> command displays the values
             of the <codeph>max_connections</codeph> parameter. <p>
@@ -306,8 +289,7 @@ max_prepared_transactions=100
         files <filepath>server.key</filepath> (server private key) and
           <filepath>server.crt</filepath> (server certificate) in the master data directory. These
         files must be set up correctly before an SSL-enabled Greenplum Database system can start. </p>
-      <note type="important"
-        > Do not protect the private key with a passphrase. The server does not
+      <note type="important"> Do not protect the private key with a passphrase. The server does not
         prompt for a passphrase for the private key, and the database startup fails with an error if
         one is required.</note>
       <p>A self-signed certificate can be used for testing, but a certificate signed by a
@@ -344,9 +326,7 @@ max_prepared_transactions=100
           <codeblock># chmod og-rwx server.key</codeblock>
         </p>
         <p>For more details on how to create your server private key and certificate, refer to the
-            <xref
-            href="https://www.openssl.org/docs/" format="html" scope="external"
-            >OpenSSL
+            <xref href="https://www.openssl.org/docs/" format="html" scope="external">OpenSSL
             documentation</xref>.</p>
       </body>
     </topic>

--- a/gpdb-doc/dita/admin_guide/client_auth.xml
+++ b/gpdb-doc/dita/admin_guide/client_auth.xml
@@ -7,40 +7,42 @@
     Greenplum Database.</shortdesc>
   <body>
     <p>When a Greenplum Database system is first initialized, the system contains one predefined
-        <i>superuser</i> role. This role will have the same name as the operating system user who
+       <i>superuser</i> role. This role will have the same name as the operating system user who
       initialized the Greenplum Database system. This role is referred to as
-        <codeph>gpadmin</codeph>. By default, the system is configured to only allow local
-      connections to the database from the <codeph>gpadmin</codeph> role. To allow any other roles
-      to connect, or to allow connections from remote hosts, you configure Greenplum Database to
-      allow such connections. </p>
+      <codeph>gpadmin</codeph>. By default, the system is configured to only allow local 
+      connections to the database from the <codeph>gpadmin</codeph> role. If you want to allow any
+      other roles to connect, or if you want to allow connections from remote hosts, you have to
+      configure Greenplum Database to allow such connections. This section explains how to
+      configure client connections and authentication to Greenplum Database.</p>
     <note>The PgBouncer connection pooler is bundled with Greenplum Database. PgBouncer can be
       configured to support LDAP or Active Directory authentication for users connecting to
-      Greenplum Database through the connection pooler client connections to Greenplum Database. See
-        <xref href="access_db/topics/pgbouncer.xml#topic_fstrm"/>. </note>
+      Greenplum Database through the connection pooler client connections to Greenplum Database.
+      See
+      <xref
+        href="access_db/topics/pgbouncer.xml#topic_fstrm"/>. </note>
   </body>
   <topic id="topic2" xml:lang="en">
     <title id="ip142171">Allowing Connections to Greenplum Database</title>
     <body>
       <p>Client access and authentication is controlled by the standard PostgreSQL host-based
-        authentication file, <filepath>pg_hba.conf</filepath>. In Greenplum Database, the
-          <filepath>pg_hba.conf</filepath> file of the master instance controls client access and
-        authentication to your Greenplum Database system. Greenplum Database segments have
-          <filepath>pg_hba.conf</filepath> files that are configured to allow only client
-        connections from the master host and never accept client connections. Do not alter the
-          <filepath>pg_hba.conf</filepath> file on your segments.</p>
-      <p>See <xref href="https://www.postgresql.org/docs/9.0/static/auth-pg-hba-conf.html"
-          scope="external" format="html"><ph>The pg_hba.conf File</ph></xref> in the PostgreSQL
-        documentation for more information. </p>
+        authentication file, <filepath>pg_hba.conf</filepath>.  For detailed information about
+        this file, see <xref
+          href="http://www.postgresql.org/docs/9.0/interactive/auth-pg-hba-conf.html"
+          scope="external" format="html"
+        >The pg_hba.conf File</xref> in the PostgreSQL documentation. </p>
+      <p>In Greenplum Database, the <filepath>pg_hba.conf</filepath> file of the master instance
+        controls client access and authentication to your Greenplum Database system. The Greenplum
+        Database segments also have <filepath>pg_hba.conf</filepath> files, but these are already
+        correctly configured to allow only client connections from the master host. The segments
+        never accept outside client connections, so there is no need to alter the
+        <codeph>pg_hba.conf</codeph> file on segments.</p>
       <p>The general format of the <filepath>pg_hba.conf</filepath> file is a set of records, one
-        per line. Blank lines and any text after the <codeph>#</codeph> comment character are ignored.
-        The first matching record is used for authentication. After the first match, the following
-        records are not evaluated. If the client cannot be authenticated using the method specified
-        in the first matching record, the connection is rejected. A record consists of a number of
-        fields that are separated by spaces and/or tabs. Fields can contain white space if the field
-        value is quoted. Records cannot be continued across multiple lines.
-        Each remote client access record has the following format:</p>
+        per line. Greenplum Database ignores blank lines and any text after the <codeph>#</codeph>
+        comment character. A record consists of a number of fields that are separated by spaces or
+        tabs. Fields can contain white space if the field value is quoted. Records cannot be
+        continued across lines. Each remote client access record has the following format:</p>
       <codeblock><i>host</i>   <i>database</i>   <i>role</i>   <i>CIDR-address</i>   <i>authentication-method</i></codeblock>
-      <p>Each UNIX-domain socket access record has the following format:</p>
+      <p>Each UNIX-domain socket access record is in this format:</p>
       <codeblock><i>local</i>   <i>database</i>   <i>role</i>   <i>authentication-method</i></codeblock>
       <p>The following table describes meaning of each field. </p>
       <table id="ip141709">
@@ -57,36 +59,42 @@
           <tbody>
             <row>
               <entry colname="col1">local</entry>
-              <entry colname="col2">Matches connection attempts using UNIX-domain sockets. Without a
+              <entry colname="col2"
+                >Matches connection attempts using UNIX-domain sockets. Without a
                 record of this type, UNIX-domain socket connections are disallowed.</entry>
             </row>
             <row>
               <entry colname="col1">host</entry>
-              <entry colname="col2">Matches connection attempts made using TCP/IP. Remote TCP/IP
-                connections will not be possible unless the server is started with an appropriate
-                value for the <ph>listen_addresses</ph> server configuration parameter.</entry>
+              <entry colname="col2"
+                  >Matches connection attempts made using TCP/IP. Remote TCP/IP connections will
+                not be possible unless the server is started with an appropriate value for the
+                <codeph>listen_addresses</codeph> server configuration parameter.</entry>
             </row>
             <row>
               <entry colname="col1">hostssl</entry>
-              <entry colname="col2">Matches connection attempts made using TCP/IP, but only when the
-                connection is made with SSL encryption. SSL must be enabled at server start time by
-                setting the <ph>ssl</ph> configuration parameter</entry>
+              <entry colname="col2"
+                  >Matches connection attempts made using TCP/IP, but only when the connection is
+                made with SSL encryption. SSL must be enabled at server start time by setting the
+                <codeph>ssl</codeph> server configuration parameter. </entry>
             </row>
             <row>
               <entry colname="col1">hostnossl</entry>
-              <entry colname="col2">Matches connection attempts made over TCP/IP that do not use
+              <entry colname="col2"
+                >Matches connection attempts made over TCP/IP that do not use
                 SSL.</entry>
             </row>
             <row>
               <entry colname="col1">database</entry>
-              <entry colname="col2">Specifies which database names this record matches. The value
+              <entry colname="col2"
+                  >Specifies which database names this record matches. The value
                   <codeph>all</codeph> specifies that it matches all databases. Multiple database
                 names can be supplied by separating them with commas. A separate file containing
                 database names can be specified by preceding the file name with @.</entry>
             </row>
             <row>
               <entry colname="col1">role</entry>
-              <entry colname="col2">Specifies which database role names this record matches. The
+              <entry colname="col2"
+                  >Specifies which database role names this record matches. The
                 value <codeph>all</codeph> specifies that it matches all roles. If the specified
                 role is a group and you want all members of that group to be included, precede the
                 role name with a +. Multiple role names can be supplied by separating them with
@@ -95,73 +103,92 @@
             </row>
             <row>
               <entry colname="col1">CIDR-address</entry>
-              <entry colname="col2">Specifies the client machine IP address range that this record
-                matches. It contains an IP address in standard dotted decimal notation and a CIDR
-                mask length. IP addresses can only be specified numerically, not as domain or host
-                names. The mask length indicates the number of high-order bits of the client IP
-                address that must match. Bits to the right of this must be zero in the given IP
-                address. There must not be any white space between the IP address, the /, and the
-                CIDR mask length. <p>Typical examples of a CIDR-address are 192.0.2.89/32 for a
-                  single host, or 192.0.2.0/24 for a small network, or 10.6.0.0/16 for a larger one.
-                  To specify a single host, use a CIDR mask of 32 for IPv4 or 128 for IPv6. In a
-                  network address, do not omit trailing zeroes.</p></entry>
+              <entry colname="col2"
+                  >Specifies the client machine IP address range that this record matches. It
+                contains an IP address in standard dotted decimal notation and a CIDR mask length.
+                IP addresses can only be specified numerically, not as domain or host names. The
+                mask length indicates the number of high-order bits of the client IP address that
+                must match. Bits to the right of this must be zero in the given IP address. There
+                must not be any white space between the IP address, the /, and the CIDR mask length.
+                <p>Typical examples of a CIDR-address are 172.20.143.89/32 for a single host, or
+                  172.20.143.0/24 for a small network, or 10.6.0.0/16 for a larger one. To specify
+                  a single host, use a CIDR mask of 32 for IPv4 or 128 for IPv6. In a network
+                  address, do not omit trailing zeroes.</p></entry>
             </row>
             <row>
               <entry colname="col1">IP-address<p>IP-mask</p></entry>
-              <entry colname="col2">These fields can be used as an alternative to the CIDR-address
-                notation. Instead of specifying the mask length, the actual mask is specified in a
-                separate column. For example, 255.255.255.255 represents a CIDR mask length of 32.
-                These fields only apply to host, hostssl, and hostnossl records. </entry>
+              <entry colname="col2"
+                >These fields can be used as an alternative to the CIDR-address notation. Instead
+                of specifying the mask length, the actual mask is specified in a separate column.
+                For example, 255.0.0.0 represents an IPv4 CIDR mask length of 8, and 255.255.255.255 represents a CIDR mask length of 32. These fields only apply to and 255.255.255.255 represents a CIDR mask length of 32. These fields only apply to host, hostssl, and hostnossl records. </entry>
             </row>
             <row>
               <entry colname="col1">authentication-method</entry>
-              <entry colname="col2">Specifies the authentication method to use when connecting.
-                Greenplum supports the <xref
-                  href="https://www.postgresql.org/docs/9.0/static/auth-methods.html"
-                  scope="external" format="html"><ph>authentication methods</ph></xref> supported by
-                PostgreSQL 9.0.</entry>
+              <entry colname="col2"
+                  >Specifies the authentication method to use when connecting. Greenplum supports
+                the <xref
+                  href="http://www.postgresql.org/docs/9.0/static/auth-methods.html"
+                  scope="external" format="html"
+                >authentication methods</xref> supported by PostgreSQL 9.0.</entry>
             </row>
           </tbody>
         </tgroup>
       </table>
+      <note type="caution"
+          >For a more secure system, consider removing records for remote connections that use
+        trust authentication from the <codeph>pg_hba.conf</codeph> file. Trust authentication
+        grants any user who can connect to the server access to the database using any role they
+        specify. You can safely replace trust authentication with ident authentication for local
+        UNIX-socket connections. You can also use ident authentication for local and remote TCP
+        clients, but the client host must be running an ident service and you must trust the
+        integrity of that machine.</note>
     </body>
     <topic id="topic3" xml:lang="en">
       <title id="ip141322">Editing the pg_hba.conf File</title>
       <body>
-        <p>This example shows how to edit the <filepath>pg_hba.conf</filepath> file of the master to
-          allow remote client access to all databases from all roles using encrypted password
+        <p>Initially, the <codeph>pg_hba.conf</codeph> file is set up with generous permissions for
+          the gpadmin user and no database access for other Greenplum Database roles. You will need
+          to edit the <codeph>pg_hba.conf</codeph> file to enable users' access to databases and to
+          secure the gpadmin user. Consider removing entries that have trust authentication, since
+          they allow anyone with access to the server to connect with any role they choose. For
+          local (UNIX socket) connections, use ident authentication, which requires the operating
+          system user to match the role specified. For local and remote TCP connections, ident
+          authentication requires the client's host to run an indent service. You can install an
+          ident service on the master host and then use ident authentication for local TCP
+          connections, for example 127.0.0.1/28. Using ident authentication for remote TCP
+          connections is less secure because it requires you to trust the integrity of the ident
+          service on the client's host.</p>
+        <p>This example shows how to edit the <filepath>pg_hba.conf</filepath> file of the master
+          to allow remote client access to all databases from all roles using encrypted password
           authentication.</p>
-        <note type="note">For a more secure system, consider removing all connections that use trust
-          authentication from your master <filepath>pg_hba.conf</filepath>. Trust authentication
-          means the role is granted access without any authentication, therefore bypassing all
-          security. Replace trust entries with ident authentication if your system has an ident
-          service available.</note>
         <section id="ip144328">
           <title>Editing pg_hba.conf</title>
           <ol id="ol_xz4_x15_jp">
-            <li id="ip142837">Open the file <filepath>$MASTER_DATA_DIRECTORY/pg_hba.conf</filepath>
+            <li id="ip142837"
+              >Open the file <filepath>$MASTER_DATA_DIRECTORY/pg_hba.conf</filepath>
               in a text editor.</li>
-            <li id="ip141930">Add a line to the file for each type of connection you want to allow.
+            <li id="ip141930"
+              >Add a line to the file for each type of connection you want to allow.
               Records are read sequentially, so the order of the records is significant. Typically,
               earlier records will have tight connection match parameters and weaker authentication
               methods, while later records will have looser match parameters and stronger
               authentication methods. For
-              example:<codeblock># allow the gpadmin user local access to all databases 
+              example:<codeblock># allow the gpadmin user local access to all databases
 # using ident authentication
 local   all   gpadmin   ident         sameuser
 host    all   gpadmin   127.0.0.1/32  ident
 host    all   gpadmin   ::1/128       ident
-# allow the 'dba' role access to any database from any 
-# host with IP address 192.168.x.x and use md5 encrypted 
+# allow the 'dba' role access to any database from any
+# host with IP address 192.168.x.x and use md5 encrypted
 # passwords to authenticate the user
-# Note that to use SHA-256 encryption, replace <i>md5</i> with 
+# Note that to use SHA-256 encryption, replace <i>md5</i> with
 # password in the line below
 host    all   dba   192.168.0.0/32  md5
-# allow all roles access to any database from any 
-# host and use ldap to authenticate the user. Greenplum role 
+# allow all roles access to any database from any
+# host and use ldap to authenticate the user. Greenplum role
 # names must match the LDAP common name.
-host    all   all   192.168.0.0/32  ldap ldapserver=usldap1 
-ldapport=1389 ldapprefix="cn=" 
+host    all   all   192.168.0.0/32  ldap ldapserver=usldap1
+ldapport=1389 ldapprefix="cn="
 ldapsuffix=",ou=People,dc=company,dc=com"</codeblock></li>
             <li id="ip141945">Save and close the file.</li>
             <li id="ip142080">Reload the <filepath>pg_hba.conf</filepath> configuration file for
@@ -169,10 +196,12 @@ ldapsuffix=",ou=People,dc=company,dc=com"</codeblock></li>
                 <codeblock>$ gpstop -u</codeblock>
               </p></li>
           </ol>
-          <note type="note">Note that you can also control database access by setting object
-            privileges as described in <xref href="roles_privs.xml#topic6" type="topic"
-              format="dita"/>. The <filepath>pg_hba.conf</filepath> file just controls who can
-            initiate a database session and how those connections are authenticated.</note>
+          <note type="note"
+              >Note that you can also control database access by
+            setting object privileges as described in <xref
+              href="roles_privs.xml#topic6" type="topic" format="dita"
+              />. The <filepath>pg_hba.conf</filepath> file just controls
+            who can initiate a database session and how those connections are authenticated.</note>
         </section>
       </body>
     </topic>
@@ -186,8 +215,8 @@ ldapsuffix=",ou=People,dc=company,dc=com"</codeblock></li>
         can configure the <codeph>max_connections</codeph> server configuration parameter. This is a
           <i>local</i> parameter, meaning that you must set it in the
           <codeph>postgresql.conf</codeph> file of the master, the standby master, and each segment
-        instance (primary and mirror). The value of <codeph>max_connections</codeph> on segments
-        should be 5-10 times the value on the master.</p>
+        instance (primary and mirror). The recommended value of
+          <codeph>max_connections</codeph> on segments is 5-10 times the value on the master.</p>
       <p>When you set <codeph>max_connections</codeph>, you must also set the dependent parameter
           <codeph>max_prepared_transactions</codeph>. This value must be at least as large as the
         value of <codeph>max_connections</codeph> on the master, and segment instances should be set
@@ -215,25 +244,28 @@ max_prepared_transactions=100
       </ul>
       <p>The following steps set the parameter values with the Greenplum Database utility
           <codeph>gpconfig</codeph>. </p>
-      <p>For information about <codeph>gpconfig</codeph>, see the <i>Greenplum Database Utility
-          Guide</i>.</p>
+      <p>For information about <codeph>gpconfig</codeph>, see the <i>Greenplum
+          Database Utility Guide</i>.</p>
       <section id="ip142411">
         <title>To change the number of allowed connections</title>
         <ol id="ol_sty_r15_jp">
-          <li id="ip146498">Log into the Greenplum Database master host as the Greenplum Database
+          <li id="ip146498"
+              >Log into the Greenplum Database master host as the Greenplum Database
             administrator and source the file <codeph>$GPHOME/greenplum_path.sh</codeph>. </li>
-          <li id="ip146499">Set the value of the <codeph>max_connections</codeph> parameter. This
+          <li id="ip146499"
+              >Set the value of the <codeph>max_connections</codeph> parameter. This
               <codeph>gpconfig</codeph> command sets the value on the segments to 1000 and the value
             on the master to 200.<p>
               <codeblock>$ gpconfig -c max_connections -v 1000 -m 200
 </codeblock>
-            </p><p>The value on the segments must be greater than the value on the master. The value
-              of <codeph>max_connections</codeph> on segments should be 5-10 times the value on the
-              master. </p></li>
-          <li id="ip146502">Set the value of the <codeph>max_prepared_transactions</codeph>
+            </p><p>The value on the segments must be greater than the value on the master. The 
+              recommended value of <codeph>max_connections</codeph> on segments is 5-10 times the 
+              value on the master. </p></li>
+          <li id="ip146502"
+              >Set the value of the <codeph>max_prepared_transactions</codeph>
             parameter. This <codeph>gpconfig</codeph> command sets the value to 200 on the master
             and all segments.<p>
-              <codeblock>$ gpconfig -c max_prepared_transactions -v 200 
+              <codeblock>$ gpconfig -c max_prepared_transactions -v 200
 </codeblock>
             </p><p>The value of <codeph>max_prepared_transactions</codeph> must be greater than or
               equal to <codeph>max_connections</codeph> on the master.</p></li>
@@ -241,11 +273,12 @@ max_prepared_transactions=100
               <codeblock>$ gpstop -r
 </codeblock>
             </p></li>
-          <li id="ip146510">You can check the value of parameters on the master and segments with
+          <li id="ip146510"
+              >You can check the value of parameters on the master and segments with
             the <codeph>gpconfig</codeph>
             <codeph>-s</codeph> option. This <codeph>gpconfig</codeph> command displays the values
             of the <codeph>max_connections</codeph> parameter. <p>
-              <codeblock>$ gpconfig -s max_connections 
+              <codeblock>$ gpconfig -s max_connections
 </codeblock>
             </p></li>
         </ol>
@@ -273,7 +306,8 @@ max_prepared_transactions=100
         files <filepath>server.key</filepath> (server private key) and
           <filepath>server.crt</filepath> (server certificate) in the master data directory. These
         files must be set up correctly before an SSL-enabled Greenplum Database system can start. </p>
-      <note type="important"> Do not protect the private key with a passphrase. The server does not
+      <note type="important"
+        > Do not protect the private key with a passphrase. The server does not
         prompt for a passphrase for the private key, and the database startup fails with an error if
         one is required.</note>
       <p>A self-signed certificate can be used for testing, but a certificate signed by a
@@ -310,7 +344,9 @@ max_prepared_transactions=100
           <codeblock># chmod og-rwx server.key</codeblock>
         </p>
         <p>For more details on how to create your server private key and certificate, refer to the
-            <xref href="https://www.openssl.org/docs/" format="html" scope="external">OpenSSL
+            <xref
+            href="https://www.openssl.org/docs/" format="html" scope="external"
+            >OpenSSL
             documentation</xref>.</p>
       </body>
     </topic>

--- a/gpdb-doc/dita/security-guide/topics/Authenticate.xml
+++ b/gpdb-doc/dita/security-guide/topics/Authenticate.xml
@@ -40,10 +40,10 @@
         client access record is in this format:
         <codeblock>host   database   role   CIDR-address   authentication-method
 </codeblock></p>
-      <p>Each UNIX-domain socket access record is in this format:
+      <p>A UNIX-domain socket access record is in this format:
         <codeblock>local   database   role   authentication-method
 </codeblock></p>
-      <p>The meaning of the <codeph>pg_hba_conf</codeph> fields is as follows: <parml>
+      <p>The meaning of the <codeph>pg_hba.conf</codeph> fields is as follows: <parml>
           <plentry>
             <pt>local</pt>
             <pd> Matches connection attempts using UNIX-domain sockets. Without a record of this
@@ -110,21 +110,36 @@
           <plentry>
             <pt> authentication-method </pt>
             <pd> Specifies the authentication method to use when connecting. See <xref
-                href="#topic_nyh_gwd_jr" format="dita"/> for more details. </pd>
+                href="#topic_nyh_gwd_jr" format="dita"/> for options. </pd>
           </plentry>
         </parml></p>
+      <note type="caution"
+        >For a more secure system, consider removing records for remote connections that use trust 
+        authentication from the <codeph>pg_hba.conf</codeph> file. Trust authentication grants any 
+        user who can connect to the server access to the database using any role they specify. You 
+        can safely replace trust authentication with ident authentication for local UNIX-socket 
+        connections. You can also use ident authentication for local and remote TCP clients, but 
+        the client host must be running an ident service and you must trust the integrity of that 
+        machine.</note>
     </body>
   </topic>
   <topic id="topic_xwr_rvd_jr">
     <title>Editing the pg_hba.conf File</title>
     <body>
+      <p>Initially, the <codeph>pg_hba.conf</codeph> file is set up  with generous permissions for
+        the gpadmin user and no database access for other Greenplum Database roles. You will need to
+        edit the <codeph>pg_hba.conf</codeph> file to enable users' access to databases and to
+        secure the gpadmin user. Consider removing entries that have trust authentication, since
+        they allow anyone with access to the server to connect with any role they choose. For local
+        (UNIX socket) connections, use ident authentication, which requires the operating system
+        user to match the role specified. For local and remote TCP connections, ident authentication
+        requires the client's host to run an indent service. You could install an ident service on
+        the master host and then use ident authentication for local TCP connections, for example
+        127.0.0.1/28. Using ident authentication for remote TCP connections is less secure because
+        it requires you to trust the integrity of the ident service on the client's host. </p>
       <p>This example shows how to edit the <codeph>pg_hba.conf</codeph> file of the master to allow
         remote client access to all databases from all roles using encrypted password
         authentication. </p>
-      <note>For a more secure system, consider removing all connections that use trust
-        authentication from your master <codeph>pg_hba.conf</codeph>. Trust authentication means the
-        role is granted access without any authentication, therefore bypassing all security. Replace
-        trust entries with ident authentication if your system has an ident service available. </note>
       <p>To edit <codeph>pg_hba.conf</codeph>:<ol id="ol_krz_zvd_jr">
           <li>Open the file <codeph>$MASTER_DATA_DIRECTORY/pg_hba.conf</codeph> in a text
             editor.</li>
@@ -190,8 +205,7 @@ host    all   dba   192.168.0.0/32  md5
             </plentry>
             <plentry>
               <pt>Ident</pt>
-              <pd>Authenticates based on the client's operating system user name. You should only
-                use this for local connections.</pd>
+              <pd>Authenticates based on the client's operating system user name. This is secure for local socket connections. Using ident for TCP connections from remote hosts requires that the client's host is running an ident service. The ident authentication method should only be used with remote hosts on a trusted, closed network. </pd>
             </plentry>
           </parml></p>
         <p>Following are some sample <codeph>pg_hba.conf</codeph> basic authentication

--- a/gpdb-doc/dita/security-guide/topics/Authenticate.xml
+++ b/gpdb-doc/dita/security-guide/topics/Authenticate.xml
@@ -113,20 +113,19 @@
                 href="#topic_nyh_gwd_jr" format="dita"/> for options. </pd>
           </plentry>
         </parml></p>
-      <note type="caution"
-        >For a more secure system, consider removing records for remote connections that use trust 
-        authentication from the <codeph>pg_hba.conf</codeph> file. Trust authentication grants any 
-        user who can connect to the server access to the database using any role they specify. You 
-        can safely replace trust authentication with ident authentication for local UNIX-socket 
-        connections. You can also use ident authentication for local and remote TCP clients, but 
-        the client host must be running an ident service and you must trust the integrity of that 
-        machine.</note>
+      <note type="caution">For a more secure system, consider removing records for remote
+        connections that use trust authentication from the <codeph>pg_hba.conf</codeph> file. Trust
+        authentication grants any user who can connect to the server access to the database using
+        any role they specify. You can safely replace trust authentication with ident authentication
+        for local UNIX-socket connections. You can also use ident authentication for local and
+        remote TCP clients, but the client host must be running an ident service and you must trust
+        the integrity of that machine.</note>
     </body>
   </topic>
   <topic id="topic_xwr_rvd_jr">
     <title>Editing the pg_hba.conf File</title>
     <body>
-      <p>Initially, the <codeph>pg_hba.conf</codeph> file is set up  with generous permissions for
+      <p>Initially, the <codeph>pg_hba.conf</codeph> file is set up with generous permissions for
         the gpadmin user and no database access for other Greenplum Database roles. You will need to
         edit the <codeph>pg_hba.conf</codeph> file to enable users' access to databases and to
         secure the gpadmin user. Consider removing entries that have trust authentication, since
@@ -205,7 +204,10 @@ host    all   dba   192.168.0.0/32  md5
             </plentry>
             <plentry>
               <pt>Ident</pt>
-              <pd>Authenticates based on the client's operating system user name. This is secure for local socket connections. Using ident for TCP connections from remote hosts requires that the client's host is running an ident service. The ident authentication method should only be used with remote hosts on a trusted, closed network. </pd>
+              <pd>Authenticates based on the client's operating system user name. This is secure for
+                local socket connections. Using ident for TCP connections from remote hosts requires
+                that the client's host is running an ident service. The ident authentication method
+                should only be used with remote hosts on a trusted, closed network. </pd>
             </plentry>
           </parml></p>
         <p>Following are some sample <codeph>pg_hba.conf</codeph> basic authentication

--- a/gpdb-doc/dita/utility_guide/client_utilities/psql.xml
+++ b/gpdb-doc/dita/utility_guide/client_utilities/psql.xml
@@ -177,7 +177,9 @@
             <pt>-h <varname>host</varname> | --host <varname>host</varname></pt>
             <pd>The host name of the machine on which the Greenplum master database server is
               running. If not specified, reads from the environment variable <codeph>PGHOST</codeph>
-              or defaults to localhost.</pd>
+              or defaults to localhost.</pd> 
+             <pd>When starting <codeph>psql</codeph> on the master host, if the <varname>host</varname> 
+              value begins with a slash, it is used as the directory for the UNIX-domain socket.</pd>
           </plentry>
           <plentry>
             <pt>-p <varname>port</varname> | --port <varname>port</varname></pt>


### PR DESCRIPTION
Reinforcing recommendation to tighten up trust auth entries. Clarification on local (socket) ident vs TPC ident. Add "psql -h /dir" to psql reference.  