### PR TITLE
Add data page checksum support to pg_upgrade

### DIFF
--- a/contrib/pg_upgrade/.gitignore
+++ b/contrib/pg_upgrade/.gitignore
@@ -1,2 +1,5 @@
 /pg_upgrade
-lalshell
+/lalshell
+/clusterConfigFile
+/clusterConfigPostgresAddonsFile
+/gpdemo-env.sh

--- a/contrib/pg_upgrade/test_gpdb.sh
+++ b/contrib/pg_upgrade/test_gpdb.sh
@@ -14,11 +14,19 @@ OLD_DATADIR=
 NEW_BINDIR=
 NEW_DATADIR=
 
+DEMOCLUSTER_OPTS=
+PGUPGRADE_OPTS=
+
 qddir=
 
 # The normal ICW run has a gpcheckcat call, so allow this testrunner to skip
 # running it in case it was just executed to save time.
 gpcheckcat=1
+
+# gpdemo can create a cluster without mirrors, and if such a cluster should be
+# upgraded then mirror upgrading must be turned off as it otherwise will report
+# a failure.
+mirrors=0
 
 # Smoketesting pg_upgrade is done by just upgrading the QD without diffing the
 # results. This is *NOT* a test of whether pg_upgrade can successfully upgrade
@@ -58,6 +66,14 @@ restore_cluster()
 	if ! git ls-files lalshell --error-unmatch >/dev/null 2>&1; then
 		rm -f lalshell
 	fi
+
+	# Remove configuration files created by setting up the new cluster
+	rm -f clusterConfigPostgresAddonsFile
+	rm -f clusterConfigFile
+	rm -f gpdemo-env.sh
+	
+	# Remove the temporary cluster
+	rm -rf "$temp_root"
 }
 
 upgrade_qd()
@@ -66,7 +82,7 @@ upgrade_qd()
 
 	# Run pg_upgrade
 	pushd $1
-	time ${NEW_BINDIR}/pg_upgrade --old-bindir=${OLD_BINDIR} --old-datadir=$2 --new-bindir=${NEW_BINDIR} --new-datadir=$3 --dispatcher-mode
+	time ${NEW_BINDIR}/pg_upgrade --old-bindir=${OLD_BINDIR} --old-datadir=$2 --new-bindir=${NEW_BINDIR} --new-datadir=$3 --dispatcher-mode ${PGUPGRADE_OPTS}
 	if (( $? )) ; then
 		echo "ERROR: Failure encountered in upgrading qd node"
 		exit 1
@@ -87,7 +103,7 @@ upgrade_segment()
 
 	# Run pg_upgrade
 	pushd $1
-	time ${NEW_BINDIR}/pg_upgrade --old-bindir=${OLD_BINDIR} --old-datadir=$2 --new-bindir=${NEW_BINDIR} --new-datadir=$3
+	time ${NEW_BINDIR}/pg_upgrade --old-bindir=${OLD_BINDIR} --old-datadir=$2 --new-bindir=${NEW_BINDIR} --new-datadir=$3 ${PGUPGRADE_OPTS}
 	if (( $? )) ; then
 		echo "ERROR: Failure encountered in upgrading node"
 		exit 1
@@ -103,13 +119,16 @@ usage()
 	echo " -b <dir>     Directory containing binaries"
 	echo " -s           Run smoketest only"
 	echo " -C           Skip gpcheckcat test"
+	echo " -k           Add checksums to new cluster"
+	echo " -K           Remove checksums during upgrade"
+	echo " -m           Upgrade mirrors"
 	exit 0
 }
 
 # Main
 temp_root=`pwd`/tmp_check
 
-while getopts ":o:b:sC" opt; do
+while getopts ":o:b:sCkKm" opt; do
 	case ${opt} in
 		o )
 			realpath OLD_DATADIR "${OPTARG}"
@@ -124,6 +143,18 @@ while getopts ":o:b:sC" opt; do
 		C )
 			gpcheckcat=0
 			;;
+		k )
+			add_checksums=1
+			PGUPGRADE_OPTS=' -J '
+			;;
+		K )
+			remove_checksums=1
+			DEMOCLUSTER_OPTS=' -K '
+			PGUPGRADE_OPTS=' -j '
+			;;
+		m )
+			mirrors=1
+			;;
 		* )
 			usage
 			;;
@@ -132,6 +163,11 @@ done
 
 if [ -z "${OLD_DATADIR}" ] || [ -z "${NEW_BINDIR}" ]; then
 	usage
+fi
+
+if [ ! -z "${add_checksums}"] && [ ! -z "${remove_checksums}" ]; then
+	echo "ERROR: adding and removing checksums are mutually exclusive"
+	exit 1
 fi
 
 rm -rf "$temp_root"
@@ -178,7 +214,7 @@ export DEMO_PORT_BASE=27432
 export NUM_PRIMARY_MIRROR_PAIRS=3
 export MASTER_DATADIR=${temp_root}
 cp ${OLD_DATADIR}/../lalshell .
-BLDWRAP_POSTGRES_CONF_ADDONS=fsync=off ${OLD_DATADIR}/../demo_cluster.sh
+BLDWRAP_POSTGRES_CONF_ADDONS=fsync=off ${OLD_DATADIR}/../demo_cluster.sh ${DEMOCLUSTER_OPTS}
 
 NEW_DATADIR="${temp_root}/datadirs"
 
@@ -208,7 +244,9 @@ for i in 1 2 3
 do
 	j=$(($i-1))
 	upgrade_segment "${temp_root}/upgrade/dbfast$i" "${OLD_DATADIR}/dbfast$i/demoDataDir$j/" "${NEW_DATADIR}/dbfast$i/demoDataDir$j/"
-	upgrade_segment "${temp_root}/upgrade/dbfast_mirror$i" "${OLD_DATADIR}/dbfast_mirror$i/demoDataDir$j/" "${NEW_DATADIR}/dbfast_mirror$i/demoDataDir$j/"
+	if (( $mirrors )) ; then
+		upgrade_segment "${temp_root}/upgrade/dbfast_mirror$i" "${OLD_DATADIR}/dbfast_mirror$i/demoDataDir$j/" "${NEW_DATADIR}/dbfast_mirror$i/demoDataDir$j/"
+	fi
 done
 
 . ${NEW_BINDIR}/../greenplum_path.sh

--- a/gpAux/gpdemo/demo_cluster.sh
+++ b/gpAux/gpdemo/demo_cluster.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
 # ======================================================================
+# Configuration Variables
+# ======================================================================
+
+# Set to zero to force cluster to be created without data checksums
+DATACHECKSUMS=1
+
+# ======================================================================
 # Data Directories
 # ======================================================================
 
@@ -68,9 +75,10 @@ checkDemoConfig(){
 
 USAGE(){
     echo ""
-    echo " `basename $0` -c -d -u"
-    echo " -c : check if demo is possible."
+    echo " `basename $0` {-c | -d | -u} <-K>"
+    echo " -c : Check if demo is possible."
     echo " -d : Delete the demo."
+    echo " -K : Create cluster without data checksums."
     echo " -u : Usage, prints this message."
     echo ""
 }
@@ -118,7 +126,7 @@ cleanDemo(){
 # Main Section
 #*****************************************************************************
 
-while getopts ":cd'?'" opt
+while getopts ":cdK'?'" opt
 do
 	case $opt in 
 		'?' ) USAGE ;;
@@ -132,6 +140,9 @@ do
            ;;
         d) cleanDemo
            exit 0
+           ;;
+        K) DATACHECKSUMS=0
+           shift
            ;;
         *) USAGE
            exit 0
@@ -277,6 +288,13 @@ cat >> $CLUSTER_CONFIG <<-EOF
 	
 	ENCODING=UNICODE
 EOF
+
+if [ "${DATACHECKSUMS}" == "0" ]; then
+    cat >> $CLUSTER_CONFIG <<-EOF
+	# Turn off data checksums
+	HEAP_CHECKSUM=off
+EOF
+fi
 
 if [ "${WITH_MIRRORS}" == "true" ]; then
     cat >> $CLUSTER_CONFIG <<-EOF


### PR DESCRIPTION
When upgrading the cluster, allow the addition or removal of data checksums on the data pages as they are copied across from the old cluster. This allows for adding checksums without requiring a
full dump/restore cycle.

The `test_gpdb.sh` script is extended to support adding/removal of checksums. In the process, also extend to remove gpdemo config files generated when setting up the new cluster, and put them in
`.gitignore` as well to keep git status happy during testing.

This also fixes a previously incorrect check for checksum version and aligns variable names better with upstream.