### PR TITLE
Fix FIXME in ExecMergeJoin routine.

### DIFF
--- a/src/backend/executor/nodeMergejoin.c
+++ b/src/backend/executor/nodeMergejoin.c
@@ -851,16 +851,9 @@ ExecMergeJoin(MergeJoinState *node)
 				innerTupleSlot = node->mj_InnerTupleSlot;
 				econtext->ecxt_innertuple = innerTupleSlot;
 
-				/* GPDB_84_MERGE_FIXME: why is this condition different from upstream? */
-				if (node->js.jointype == JOIN_SEMI &&
-					node->mj_MatchedOuter)
-					qualResult = false;
-				else
-				{
-					qualResult = (joinqual == NIL ||
-								  ExecQual(joinqual, econtext, false));
-					MJ_DEBUG_QUAL(joinqual, qualResult);
-				}
+				qualResult = (joinqual == NIL ||
+							  ExecQual(joinqual, econtext, false));
+				MJ_DEBUG_QUAL(joinqual, qualResult);
 
 				if (qualResult)
 				{


### PR DESCRIPTION
After finding a match in semijoin mode, arrange to advance to
the next outer tuple not next inner tuple after returning the
current match. The node->mj_MatchedOuter is always false here,
there is no need to check it.

Author: Max Yang <myang@pivotal.io>