### PR TITLE
behave: Allow gptransfer test to run at midnight without flaking.

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -4136,12 +4136,6 @@ def impl(context, utilname, dirname):
         raise Exception('Logs matching "%s" were not created' % pattern)
 
 
-def get_log_name(utilname, logdir):
-    today = datetime.now()
-    logname = "%s/%s_%s.log" % (logdir, utilname, today.strftime('%Y%m%d'))
-    return logname
-
-
 @then('verify that a log was created by {utilname} in the "{dirname}" directory')
 def impl(context, utilname, dirname):
     if not os.path.exists(dirname):
@@ -4172,36 +4166,6 @@ def impl(context, tablename, dbconn):
     run_gpcommand(context, command)
 
 
-# gptransfer must be run in verbose mode (-v) with default log location when using this step
-@then('verify that gptransfer has a sub batch size of "{num}"')
-def impl(context, num):
-    num = int(num)
-    log_dir = _get_gpAdminLogs_directory()
-    if not os.path.exists(log_dir):
-        raise Exception('No such directory: %s' % log_dir)
-    log_name = get_log_name('gptransfer', log_dir)
-
-    full_path = os.path.join(log_dir, log_name)
-
-    if not os.path.isfile(full_path):
-        raise Exception("Can not find file: %s" % full_path)
-
-    # todo why open file if we don't care about contents?
-    with open(full_path) as fd:
-        fd.read()
-
-    for i in range(num):
-        worker = "\[DEBUG\]:-\[worker%d\]" % i
-        try:
-            check_stdout_msg(context, worker)
-        except:
-            raise Exception("gptransfer sub batch size should be %d, is %d" % (num, i))
-
-    worker = "\[DEBUG\]:-\[worker%d\]" % num
-    try:
-        check_string_not_present_stdout(context, worker)
-    except:
-        raise Exception("gptransfer sub batch size should be %d, is at least %d" % (num, num + 1))
 
 
 def _get_gpAdminLogs_directory():

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -4146,9 +4146,10 @@ def get_log_name(utilname, logdir):
 def impl(context, utilname, dirname):
     if not os.path.exists(dirname):
         raise Exception('No such directory: %s' % dirname)
-    logname = get_log_name(utilname, dirname)
-    if not os.path.exists(logname):
-        raise Exception('Log "%s" was not created' % logname)
+    pattern = "%s/%s_*.log" % (dirname, utilname)
+    logs_for_a_util = glob.glob(pattern)
+    if not logs_for_a_util:
+        raise Exception('Logs matching "%s" were not created' % pattern)
 
 
 @given('a table is created containing rows of length "{length}" with connection "{dbconn}"')


### PR DESCRIPTION
The gptransfer test used a step that looked for a logfile with a date in the
name. If that logfile existed at 11:59PM on the day before, and the test looked
for it at 12:00AM on the next day, it "wouldn't be there"

Refactor the test so that assertions about using the typical
gpAdminLogs directory are as banal as possible.

Also see https://github.com/greenplum-db/gpdb/pull/4072/commits/84bf83d5013f891547dc21576d04a281cfd2faf7.

Author: Nadeem Ghani <nghani@pivotal.io>
Author: Shoaib Lari <slari@pivotal.io>