### PR TITLE
Update ORCA version - Cross Join

### DIFF
--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v2.53.0@gpdb/stable
+orca/v2.53.2@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -121,7 +121,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	@echo "Resolve finished";
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget -O - https://github.com/greenplum-db/gporca/releases/download/v2.53.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget -O - https://github.com/greenplum-db/gporca/releases/download/v2.53.2/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/test/regress/expected/gp_explain_optimizer.out
+++ b/src/test/regress/expected/gp_explain_optimizer.out
@@ -127,9 +127,9 @@ SELECT * from
 get_explain_output($$ 
 	select * from (values (1)) as f(a) join (values(2)) b(b) on a = b join foo on true join foo as foo2 on true $$) as et
 WHERE et like '%Hash Cond:%';
-                          et                          
-------------------------------------------------------
-         Hash Cond: "inner".column1 = "outer".column1
+                                et                                
+------------------------------------------------------------------
+                     Hash Cond: "outer".column1 = "outer".column1
 (1 row)
 
 SELECT * from

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -699,59 +699,58 @@ select * from A,B where exists (select * from C where C.j = A.j and B.i = all (s
 (0 rows)
 
 explain select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C where C.j = A.j and C.i = all (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
-                                                                                                                                                                                                                               QUERY PLAN                                                                                                                                                                                                                               
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Limit  (cost=0.00..2712506063.63 rows=4 width=12)
-   ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..2712506063.63 rows=10 width=12)
+                                                                                                                                                                                                                                  QUERY PLAN                                                                                                                                                                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=0.00..2712506237.29 rows=4 width=12)
+   ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..2712506237.29 rows=10 width=12)
          Merge Key: a.i, qp_correlated_query.b.i, qp_correlated_query.c.j
-         ->  Limit  (cost=0.00..2712506063.63 rows=4 width=12)
-               ->  Sort  (cost=0.00..2712506063.63 rows=90 width=12)
+         ->  Limit  (cost=0.00..2712506237.29 rows=4 width=12)
+               ->  Sort  (cost=0.00..2712506237.29 rows=90 width=12)
                      Sort Key: a.i, qp_correlated_query.b.i, qp_correlated_query.c.j
-                     ->  Nested Loop  (cost=0.00..2712506063.59 rows=90 width=12)
+                     ->  Nested Loop  (cost=0.00..2712506237.25 rows=90 width=12)
                            Join Filter: true
-                           ->  Hash Join  (cost=0.00..2648069.70 rows=10 width=8)
-                                 Hash Cond: a.j::bigint = (pg_catalog.sum((sum(qp_correlated_query.c.j)))) AND a.j = qp_correlated_query.c.j
-                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1324033.12 rows=10 width=12)
-                                       Hash Key: a.j
-                                       ->  Nested Loop  (cost=0.00..1324033.12 rows=10 width=12)
-                                             Join Filter: true
-                                             ->  Table Scan on a  (cost=0.00..431.00 rows=2 width=8)
-                                             ->  Materialize  (cost=0.00..431.00 rows=6 width=4)
-                                                   ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
-                                                         ->  Table Scan on b  (cost=0.00..431.00 rows=2 width=4)
-                                 ->  Hash  (cost=1324036.57..1324036.57 rows=3 width=12)
-                                       ->  GroupAggregate  (cost=0.00..1324036.57 rows=3 width=12)
-                                             Group By: qp_correlated_query.c.j
-                                             ->  Sort  (cost=0.00..1324036.57 rows=3 width=12)
-                                                   Sort Key: qp_correlated_query.c.j
-                                                   ->  Redistribute Motion 3:3  (slice5; segments: 3)  (cost=0.00..1324036.57 rows=3 width=12)
-                                                         Hash Key: qp_correlated_query.c.j
-                                                         ->  Result  (cost=0.00..1324036.57 rows=3 width=12)
-                                                               ->  GroupAggregate  (cost=0.00..1324036.57 rows=3 width=12)
-                                                                     Group By: qp_correlated_query.c.j
-                                                                     ->  Sort  (cost=0.00..1324036.57 rows=3 width=4)
-                                                                           Sort Key: qp_correlated_query.c.j
-                                                                           ->  Table Scan on c  (cost=0.00..1324036.57 rows=3 width=4)
-                                                                                 Filter: (subplan)
-                                                                                 SubPlan 1
-                                                                                   ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                           ->  Nested Loop  (cost=0.00..1324033.29 rows=18 width=8)
+                                 Join Filter: true
+                                 ->  Broadcast Motion 3:3  (slice5; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
+                                       ->  Table Scan on b  (cost=0.00..431.00 rows=2 width=4)
+                                 ->  Table Scan on c  (cost=0.00..431.00 rows=3 width=4)
+                           ->  Materialize  (cost=0.00..1324467.57 rows=5 width=4)
+                                 ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..1324467.57 rows=5 width=4)
+                                       ->  Hash Join  (cost=0.00..1324467.57 rows=2 width=4)
+                                             Hash Cond: (pg_catalog.sum((sum(qp_correlated_query.c.j)))) = a.j::bigint AND qp_correlated_query.c.j = a.j
+                                             ->  GroupAggregate  (cost=0.00..1324036.57 rows=3 width=12)
+                                                   Group By: qp_correlated_query.c.j
+                                                   ->  Sort  (cost=0.00..1324036.57 rows=3 width=12)
+                                                         Sort Key: qp_correlated_query.c.j
+                                                         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1324036.57 rows=3 width=12)
+                                                               Hash Key: qp_correlated_query.c.j
+                                                               ->  Result  (cost=0.00..1324036.57 rows=3 width=12)
+                                                                     ->  GroupAggregate  (cost=0.00..1324036.57 rows=3 width=12)
+                                                                           Group By: qp_correlated_query.c.j
+                                                                           ->  Sort  (cost=0.00..1324036.57 rows=3 width=4)
+                                                                                 Sort Key: qp_correlated_query.c.j
+                                                                                 ->  Table Scan on c  (cost=0.00..1324036.57 rows=3 width=4)
+                                                                                       Filter: (SubPlan 1)
+                                                                                       SubPlan 1
                                                                                          ->  Result  (cost=0.00..431.00 rows=1 width=1)
                                                                                                Filter: (CASE WHEN (sum((CASE WHEN $0 <> qp_correlated_query.b.i THEN 1 ELSE 0 END))) IS NULL THEN true WHEN (sum((CASE WHEN qp_correlated_query.b.i IS NULL THEN 1 ELSE 0 END))) > 0::bigint THEN NULL::boolean WHEN $0 IS NULL THEN NULL::boolean WHEN (sum((CASE WHEN $0 <> qp_correlated_query.b.i THEN 1 ELSE 0 END))) = 0::bigint THEN true ELSE false END) = true
                                                                                                ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                                                                                                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
-                                                                                                           ->  Result  (cost=0.00..431.00 rows=1 width=8)
-                                                                                                                 ->  Result  (cost=0.00..431.00 rows=1 width=4)
-                                                                                                                       Filter: $0 = qp_correlated_query.b.i
-                                                                                                                       ->  Materialize  (cost=0.00..431.00 rows=6 width=4)
-                                                                                                                             ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
-                                                                                                                                   ->  Table Scan on b  (cost=0.00..431.00 rows=2 width=4)
-                                                                                                                                         Filter: i <> 10
-                           ->  Materialize  (cost=0.00..431.00 rows=9 width=4)
-                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=9 width=4)
-                                       ->  Table Scan on c  (cost=0.00..431.00 rows=3 width=4)
- Settings:  optimizer=on
- Optimizer status: PQO version 2.34.0
-(50 rows)
+                                                                                                     Filter: (CASE WHEN (sum((CASE WHEN $0 <> qp_correlated_query.b.i THEN 1 ELSE 0 END))) IS NULL THEN true WHEN (sum((CASE WHEN qp_correlated_query.b.i IS NULL THEN 1 ELSE 0 END))) > 0::bigint THEN NULL::boolean WHEN $0 IS NULL THEN NULL::boolean WHEN (sum((CASE WHEN $0 <> qp_correlated_query.b.i THEN 1 ELSE 0 END))) = 0::bigint THEN true ELSE false END) = true
+                                                                                                     ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                                                                                                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+                                                                                                                 ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                                                                                       ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                                                                                                                             Filter: $0 = qp_correlated_query.b.i
+                                                                                                                             ->  Materialize  (cost=0.00..431.00 rows=6 width=4)
+                                                                                                                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
+                                                                                                                                         ->  Table Scan on b  (cost=0.00..431.00 rows=2 width=4)
+                                                                                                                                               Filter: i <> 10
+                                             ->  Hash  (cost=431.00..431.00 rows=2 width=8)
+                                                   ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=2 width=8)
+                                                         Hash Key: a.j
+                                                         ->  Table Scan on a  (cost=0.00..431.00 rows=2 width=8)
+ Optimizer status: PQO version 2.51.5
+(48 rows)
 
 select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C where C.j = A.j and C.i = all (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
  i | i  | j  


### PR DESCRIPTION
Test files are also updated in this commit as now we don't generate
cross join alternative if an input join was present.

cross join contains CScalarConst(1) as the join condition. if the
input expression is as below with cross join at top level between
CLogicalInnerJoin and CLogicalGet "t3"
```
+--CLogicalInnerJoin
   |--CLogicalInnerJoin
   |  |--CLogicalGet "t1"
   |  |--CLogicalGet "t2"
   |  +--CScalarCmp (=)
   |     |--CScalarIdent "a" (0)
   |     +--CScalarIdent "b" (9)
   |--CLogicalGet "t3"
   +--CScalarConst (1)
```
for the above expression (lower) predicate generated for the cross join
between t1 and t3 will be: CScalarConst (1) In only such cases, donot
generate such alternative with the lower join as cross join example:
```
+--CLogicalInnerJoin
   |--CLogicalInnerJoin
   |  |--CLogicalGet "t1"
   |  |--CLogicalGet "t3"
   |  +--CScalarConst (1)
   |--CLogicalGet "t2"
   +--CScalarCmp (=)
      |--CScalarIdent "a" (0)
      +--CScalarIdent "b" (9)
```

Signed-off-by: Shreedhar Hardikar <shardikar@pivotal.io>