### PR TITLE
docs: updates for CREATE FUNCTION attributes EXECUTE ON

### DIFF
--- a/gpdb-doc/dita/admin_guide/query/topics/defining-queries.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/defining-queries.xml
@@ -2,8 +2,7 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
 <topic id="defining-queries">
     <title id="in140509">Defining Queries</title>
-    <shortdesc>Greenplum Database is based on the PostgreSQL implementation of the SQL
-        standard. </shortdesc>
+    <shortdesc>Greenplum Database is based on the PostgreSQL implementation of the SQL standard. </shortdesc>
     <body>
         <p>This topic describes how to construct SQL queries in Greenplum Database.</p>
         <ul>
@@ -20,14 +19,15 @@
         <body>
             <p>SQL is a standard language for accessing databases. The language consists of elements
                 that enable data storage, retrieval, analysis, viewing, manipulation, and so on. You
-                use SQL commands to construct queries and commands that the Greenplum Database engine understands. SQL queries consist of a sequence of
-                commands. Commands consist of a sequence of valid tokens in correct syntax order,
-                terminated by a semicolon (<codeph>;</codeph>). </p>
-            <p>For more information about SQL commands, see the <cite>Greenplum
-                    Database Reference Guide</cite>.</p>
-            <p>Greenplum Database uses PostgreSQL's structure and syntax, with some
-                exceptions. For more information about SQL rules and concepts in PostgreSQL, see
-                "SQL Syntax" in the PostgreSQL documentation.</p>
+                use SQL commands to construct queries and commands that the Greenplum Database
+                engine understands. SQL queries consist of a sequence of commands. Commands consist
+                of a sequence of valid tokens in correct syntax order, terminated by a semicolon
+                    (<codeph>;</codeph>). </p>
+            <p>For more information about SQL commands, see the <cite>Greenplum Database Reference
+                    Guide</cite>.</p>
+            <p>Greenplum Database uses PostgreSQL's structure and syntax, with some exceptions. For
+                more information about SQL rules and concepts in PostgreSQL, see "SQL Syntax" in the
+                PostgreSQL documentation.</p>
         </body>
     </topic>
     <topic id="topic4" xml:lang="en">
@@ -46,8 +46,8 @@
                 <li id="in143969">A correlated subquery</li>
                 <li id="in199893">A field selection expression</li>
                 <li id="in199900">A function call</li>
-                <li id="in205284">A new column value in an <codeph>INSERT</codeph><ph
-                       > or <codeph>UPDATE</codeph></ph></li>
+                <li id="in205284">A new column value in an <codeph>INSERT</codeph><ph> or
+                            <codeph>UPDATE</codeph></ph></li>
                 <li id="in205286">An operator invocation column reference</li>
                 <li id="in144037">A positional parameter reference, in the body of a function
                     definition or prepared statement</li>
@@ -186,9 +186,8 @@
                 <p>
                     <codeblock>sqrt(2)</codeblock>
                 </p>
-                <p>See the <cite>Greenplum Database Reference Guide</cite> for
-                    lists of the built-in functions by category. You can add custom functions,
-                    too.</p>
+                <p>For information about using and creating functions, see <xref
+                        href="functions-operators.xml#topic26"/>.</p>
             </body>
         </topic>
         <topic id="topic11" xml:lang="en">
@@ -223,10 +222,10 @@
                 <p>For predefined aggregate functions, see <xref
                         href="../topics/functions-operators.xml#topic29"/>. You can also add custom
                     aggregate functions.</p>
-                <p>Greenplum Database provides the <codeph>MEDIAN</codeph> aggregate
-                    function, which returns the fiftieth percentile of the
-                        <codeph>PERCENTILE_CONT</codeph> result and special aggregate expressions
-                    for inverse distribution functions as follows:</p>
+                <p>Greenplum Database provides the <codeph>MEDIAN</codeph> aggregate function, which
+                    returns the fiftieth percentile of the <codeph>PERCENTILE_CONT</codeph> result
+                    and special aggregate expressions for inverse distribution functions as
+                    follows:</p>
                 <p>
                     <codeblock>PERCENTILE_CONT(_percentage_) WITHIN GROUP (ORDER BY _expression_)
 </codeblock>
@@ -241,8 +240,8 @@
                 <body>
                     <p>The following are current limitations of the aggregate expressions:</p>
                     <ul>
-                        <li id="in199103">Greenplum Database does not support the
-                            following keywords: ALL, DISTINCT, FILTER and OVER. See <xref
+                        <li id="in199103">Greenplum Database does not support the following
+                            keywords: ALL, DISTINCT, FILTER and OVER. See <xref
                                 href="../topics/functions-operators.xml#topic31/in2073121"/> for
                             more details. </li>
                         <li id="in199105">An aggregate expression can appear only in the result list
@@ -259,12 +258,12 @@
                             expression acts as a constant over any one evaluation of that subquery.
                             See <xref format="dita" href="#topic15" type="topic"/> and <xref
                                 href="../topics/functions-operators.xml#topic29/in204913"/>.</li>
-                        <li id="in200915">Greenplum Database does not support DISTINCT
-                            with multiple input expressions.</li>
+                        <li id="in200915">Greenplum Database does not support DISTINCT with multiple
+                            input expressions.</li>
                         <li id="in2009151">Greenplum Database does not support specifying an
                             aggregate function as an argument to another aggregate function.</li>
-                        <li id="in2009152">Greenplum Database does not support specifying a
-                            window function as an argument to an aggregate function.</li>
+                        <li id="in2009152">Greenplum Database does not support specifying a window
+                            function as an argument to an aggregate function.</li>
                     </ul>
                 </body>
             </topic>
@@ -356,7 +355,8 @@
         <topic id="topic14" xml:lang="en">
             <title>Type Casts</title>
             <body>
-                <p>A type cast specifies a conversion from one data type to another. Greenplum Database accepts two equivalent syntaxes for type casts:</p>
+                <p>A type cast specifies a conversion from one data type to another. Greenplum
+                    Database accepts two equivalent syntaxes for type casts:</p>
                 <p>
                     <codeblock>CAST ( expression AS type )
 expression::type
@@ -394,10 +394,11 @@ expression::type
                 <p>A correlated subquery (CSQ) is a <codeph>SELECT</codeph> query with a
                         <codeph>WHERE</codeph> clause or target list that contains references to the
                     parent outer clause. CSQs efficiently express results in terms of results of
-                    another query. Greenplum Database supports correlated subqueries
-                    that provide compatibility with many existing applications. A CSQ is a scalar or
-                    table subquery, depending on whether it returns one or multiple rows. Greenplum Database does not support correlated subqueries with
-                    skip-level correlations.</p>
+                    another query. Greenplum Database supports correlated subqueries that provide
+                    compatibility with many existing applications. A CSQ is a scalar or table
+                    subquery, depending on whether it returns one or multiple rows. Greenplum
+                    Database does not support correlated subqueries with skip-level
+                    correlations.</p>
             </body>
         </topic>
         <topic id="topic17" xml:lang="en">
@@ -416,16 +417,15 @@ expression::type
                     <codeblock>SELECT * FROM t1 WHERE 
 EXISTS (SELECT 1 FROM t2 WHERE t2.x = t1.x);
 </codeblock>
-                    <p>Greenplum Database uses one of the following methods to run
-                        CSQs:</p>
+                    <p>Greenplum Database uses one of the following methods to run CSQs:</p>
                     <ul>
                         <li id="in197793">Unnest the CSQ into join operations &#8211; This method is
-                            most efficient, and it is how Greenplum Database runs most
-                            CSQs, including queries from the TPC-H benchmark.</li>
+                            most efficient, and it is how Greenplum Database runs most CSQs,
+                            including queries from the TPC-H benchmark.</li>
                         <li id="in197800">Run the CSQ on every row of the outer query &#8211; This
-                            method is relatively inefficient, and it is how Greenplum Database runs queries that contain CSQs in the
-                                <codeph>SELECT</codeph> list or are connected by <codeph>OR</codeph>
-                            conditions.</li>
+                            method is relatively inefficient, and it is how Greenplum Database runs
+                            queries that contain CSQs in the <codeph>SELECT</codeph> list or are
+                            connected by <codeph>OR</codeph> conditions.</li>
                     </ul>
                     <p>The following examples illustrate how to rewrite some of these types of
                         queries to improve performance.</p>
@@ -488,14 +488,14 @@ WHERE x &lt; (SELECT count(*) FROM t3 WHERE t1.y = t3.y)
         <topic id="topic22" xml:lang="en">
             <title>Advanced Table Functions</title>
             <body>
-                <p>Greenplum Database supports table functions with
-                        <codeph>TABLE</codeph> value expressions. You can sort input rows for
-                    advanced table functions with an <codeph>ORDER BY</codeph> clause. You can
-                    redistribute them with a <codeph>SCATTER BY</codeph> clause to specify one or
-                    more columns or an expression for which rows with the specified characteristics
-                    are available to the same process. This usage is similar to using a
-                        <codeph>DISTRIBUTED BY</codeph> clause when creating a table, but the
-                    redistribution occurs when the query runs.</p>
+                <p>Greenplum Database supports table functions with <codeph>TABLE</codeph> value
+                    expressions. You can sort input rows for advanced table functions with an
+                        <codeph>ORDER BY</codeph> clause. You can redistribute them with a
+                        <codeph>SCATTER BY</codeph> clause to specify one or more columns or an
+                    expression for which rows with the specified characteristics are available to
+                    the same process. This usage is similar to using a <codeph>DISTRIBUTED
+                        BY</codeph> clause when creating a table, but the redistribution occurs when
+                    the query runs.</p>
                 <note type="note">Based on the distribution of data, Greenplum Database
                     automatically parallelizes table functions with <codeph>TABLE</codeph> value
                     parameters over the nodes of the cluster.</note>

--- a/gpdb-doc/dita/admin_guide/query/topics/functions-operators.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/functions-operators.xml
@@ -26,8 +26,24 @@
     <topic id="topic27" xml:lang="en">
         <title id="in201560">Using Functions in Greenplum Database</title>
         <body>
+            <p>When you invoke a function in Greenplum Database, function attributes control the
+                execution of the function. The volatility attributes (<codeph>IMMUTABLE</codeph>,
+                    <codeph>STABLE</codeph>, <codeph>VOLATILE</codeph>) and the <codeph>EXECUTE
+                    ON</codeph> attributes control two different aspects of function execution. In
+                general, volatility indicates when the function is executed, and <codeph>EXECUTE
+                    ON</codeph> indicates where it is executed. The volatility attributes are
+                PostgreSQL based attributes, the <codeph>EXECUTE ON</codeph> attributes are
+                Greenplum Database attributes.</p>
+            <p>For example, a function defined with the <codeph>IMMUTABLE</codeph> attribute can be
+                executed at query planning time, while a function with the <codeph>VOLATILE</codeph>
+                attribute must be executed for every row in the query. A function with the
+                    <codeph>EXECUTE ON MASTER</codeph> attribute is executed only on the master
+                segment, and a function with the <codeph>EXECUTE ON ALL SEGMENTS</codeph> attribute
+                is executed on all primary segment instances (not the master). </p>
+            <p>These tables summarize what Greenplum Database assumes about function execution based
+                on the attribute.</p>
             <table id="in201681">
-                <title>Functions in Greenplum Database</title>
+                <title>Function Volatility Attributes in Greenplum Database</title>
                 <tgroup cols="4">
                     <colspec colname="col1" colnum="1" colwidth="77*"/>
                     <colspec colname="col2" colnum="2" colwidth="86*"/>
@@ -35,7 +51,7 @@
                     <colspec colname="col4" colnum="4" colwidth="144*"/>
                     <thead>
                         <row>
-                            <entry colname="col1">Function Type</entry>
+                            <entry colname="col1">Function Attribute</entry>
                             <entry colname="col2">Greenplum Support</entry>
                             <entry colname="col3">Description</entry>
                             <entry colname="col4">Comments</entry>
@@ -66,7 +82,8 @@
                             <entry colname="col2">Restricted</entry>
                             <entry colname="col3">Function values can change within a single table
                                 scan. For example: <codeph>random()</codeph>,
-                                <codeph>timeofday()</codeph>.</entry>
+                                    <codeph>timeofday()</codeph>. This is the default
+                                attribute.</entry>
                             <entry colname="col4">Any function with side effects is volatile, even
                                 if its result is predictable. For example:
                                 <codeph>setval()</codeph>.</entry>
@@ -74,11 +91,57 @@
                     </tbody>
                 </tgroup>
             </table>
+            <table id="table_cnz_4ng_gcb">
+                <title>Function EXECUTE ON attributes in Greenplum Database </title>
+                <tgroup cols="3">
+                    <colspec colname="col1" colnum="1" colwidth="77*"/>
+                    <colspec colname="col3" colnum="2" colwidth="144*"/>
+                    <colspec colname="col4" colnum="3" colwidth="144*"/>
+                    <thead>
+                        <row>
+                            <entry colname="col1">Function Attribute</entry>
+                            <entry colname="col3">Description</entry>
+                            <entry colname="col4">Comments</entry>
+                        </row>
+                    </thead>
+                    <tbody>
+                        <row>
+                            <entry colname="col1">EXECUTE ON ANY</entry>
+                            <entry colname="col3">Indicates that the function can be executed on the
+                                master, or any segment instance, and it returns the same result
+                                regardless of where it is executed. This is the default
+                                attribute.</entry>
+                            <entry colname="col4">Greenplum Database determines where the function
+                                is executed.</entry>
+                        </row>
+                        <row>
+                            <entry colname="col1">EXECUTE ON MASTER</entry>
+                            <entry colname="col3">Indicates that the function must be executed on
+                                the master instance.</entry>
+                            <entry colname="col4">Specify this attribute if the user-defined
+                                function executes queries to access tables. </entry>
+                        </row>
+                        <row>
+                            <entry colname="col1">EXECUTE ON ALL SEGMENTS</entry>
+                            <entry colname="col3">Indicates that for each invocation, the function
+                                must be executed on all primary segment instances, but not the
+                                master.</entry>
+                            <entry colname="col4"/>
+                        </row>
+                    </tbody>
+                </tgroup>
+            </table>
+            <p>You can display the function volatility and <codeph>EXECUTE ON</codeph> attribute
+                information with the psql <codeph>\df+ <varname>function</varname></codeph>
+                command.</p>
             <p>Refer to the PostgreSQL <xref
                     href="https://www.postgresql.org/docs/8.3/static/xfunc-volatility.html"
                     scope="external" format="html">Function Volatility Categories</xref>
                 documentation for additional information about the Greenplum Database function
                 volatility classifications.</p>
+            <p>For more information about <codeph>EXECUTE ON</codeph> attributes, see <codeph><xref
+                        href="../../../ref_guide/sql_commands/CREATE_FUNCTION.xml#topic1"
+                        format="dita" scope="peer">CREATE FUNCTION</xref></codeph>.</p>
             <p>In Greenplum Database, data is divided up across segments — each segment is a
                 distinct PostgreSQL database. To prevent inconsistent or unexpected results, do not
                 execute functions classified as <codeph>VOLATILE</codeph> at the segment level if
@@ -92,19 +155,17 @@
                 without a <codeph>FROM</codeph> clause):</p>
             <p>
                 <codeblock>SELECT setval('myseq', 201);
-SELECT foo();
-</codeblock>
+SELECT foo();</codeblock>
             </p>
             <p>If a statement has a <codeph>FROM</codeph> clause containing a distributed table
                     <i>and</i> the function in the <codeph>FROM</codeph> clause returns a set of
                 rows, the statement can run on the segments:</p>
             <p>
-                <codeblock>SELECT * from foo();
-</codeblock>
+                <codeblock>SELECT * from foo();</codeblock>
             </p>
             <p>Greenplum Database does not support functions that return a table reference
                     (<codeph>rangeFuncs</codeph>) or functions that use the
-                    <codeph>refCursor</codeph> datatype.</p>
+                    <codeph>refCursor</codeph> data type.</p>
         </body>
         <topic id="topic281" xml:lang="en">
             <title id="in1414519">Function Volatility and Plan Caching</title>
@@ -113,7 +174,7 @@ SELECT foo();
                         <codeph>IMMUTABLE</codeph> function volatility categories for simple
                     interactive queries that are planned and immediately executed. It does not
                     matter much whether a function is executed once during planning or once during
-                    query execution startup. But there is a big difference when you save the plan
+                    query execution start up. But there is a big difference when you save the plan
                     and reuse it later. If you mislabel a function <codeph>IMMUTABLE</codeph>,
                     Greenplum Database may prematurely fold it to a constant during planning,
                     possibly reusing a stale value during subsequent execution of the plan. You may
@@ -133,6 +194,13 @@ SELECT foo();
                 default, user-defined functions are declared as <codeph>VOLATILE</codeph>, so if
                 your user-defined function is <codeph>IMMUTABLE</codeph> or <codeph>STABLE</codeph>,
                 you must specify the correct volatility level when you register your function.</p>
+            <p>By default, user-defined functions are declared as <codeph>EXEUCTE ON ANY</codeph>. A
+                function that executes queries to access tables is supported only when a function is
+                executed on the master instance. Such functions should be defined with the
+                    <codeph>EXECUTE ON MASTER</codeph> attribute. Otherwise, the function might
+                return incorrect results when the function is used in a complicated query. Without
+                the attribute, planner optimization might determine it would be beneficial to push
+                the function invocation to segment instances. </p>
             <p>When you create user-defined functions, avoid using fatal errors or destructive
                 calls. Greenplum Database may respond to such errors with a sudden shutdown or
                 restart.</p>

--- a/gpdb-doc/dita/admin_guide/query/topics/functions-operators.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/functions-operators.xml
@@ -37,9 +37,9 @@
             <p>For example, a function defined with the <codeph>IMMUTABLE</codeph> attribute can be
                 executed at query planning time, while a function with the <codeph>VOLATILE</codeph>
                 attribute must be executed for every row in the query. A function with the
-                    <codeph>EXECUTE ON MASTER</codeph> attribute is executed only on the master
+                    <codeph>EXECUTE ON MASTER</codeph> attribute executes only on the master
                 segment, and a function with the <codeph>EXECUTE ON ALL SEGMENTS</codeph> attribute
-                is executed on all primary segment instances (not the master). </p>
+                executes on all primary segment instances (not the master). </p>
             <p>These tables summarize what Greenplum Database assumes about function execution based
                 on the attribute.</p>
             <table id="in201681">
@@ -109,10 +109,10 @@
                             <entry colname="col1">EXECUTE ON ANY</entry>
                             <entry colname="col3">Indicates that the function can be executed on the
                                 master, or any segment instance, and it returns the same result
-                                regardless of where it is executed. This is the default
+                                regardless of where it executes. This is the default
                                 attribute.</entry>
                             <entry colname="col4">Greenplum Database determines where the function
-                                is executed.</entry>
+                                executes.</entry>
                         </row>
                         <row>
                             <entry colname="col1">EXECUTE ON MASTER</entry>
@@ -195,8 +195,8 @@ SELECT foo();</codeblock>
                 your user-defined function is <codeph>IMMUTABLE</codeph> or <codeph>STABLE</codeph>,
                 you must specify the correct volatility level when you register your function.</p>
             <p>By default, user-defined functions are declared as <codeph>EXEUCTE ON ANY</codeph>. A
-                function that executes queries to access tables is supported only when a function is
-                executed on the master instance. Such functions should be defined with the
+                function that executes queries to access tables is supported only when a function
+                executes on the master instance. Such functions must be defined with the
                     <codeph>EXECUTE ON MASTER</codeph> attribute. Otherwise, the function might
                 return incorrect results when the function is used in a complicated query. Without
                 the attribute, planner optimization might determine it would be beneficial to push

--- a/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-limitations.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-limitations.xml
@@ -40,15 +40,17 @@
             </ul></li>
           <li>Multiple <cmdname>DISTINCT</cmdname> qualified aggregate functions </li>
           <li>Inverse distribution functions</li>
+          <li>Queries that execute functions that are defined with the <codeph>ON MASTER</codeph> or
+              <codeph>ON ALL SEGMENTS</codeph> attribute</li>
         </ul></p>
     </body>
   </topic>
   <topic id="topic_u4t_vxl_vp">
     <title>Performance Regressions</title>
     <body>
-      <p>The following features are known performance regressions that occur with GPORCA
-          enabled:<ul id="ul_zp2_4yl_vp">
-           <li>Short running queries - For GPORCA, short running queries might encounter additional
+      <p>The following features are known performance regressions that occur with GPORCA enabled:<ul
+          id="ul_zp2_4yl_vp">
+          <li>Short running queries - For GPORCA, short running queries might encounter additional
             overhead due to GPORCA enhancements for determining an optimal query execution
             plan.</li>
           <li><cmdname>ANALYZE</cmdname> - For GPORCA, the <cmdname>ANALYZE</cmdname> command

--- a/gpdb-doc/dita/ref_guide/extensions/pl_perl.xml
+++ b/gpdb-doc/dita/ref_guide/extensions/pl_perl.xml
@@ -1,211 +1,179 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
-  <topic id="topic1" xml:lang="en">
+<topic id="topic1" xml:lang="en">
     <title id="px216155">Greenplum PL/Perl Language Extension</title>
     <body>
-      <p>This chapter includes the following information:</p>
-      <ul>
-<li id="px220017">
-<xref href="#topic2" type="topic" format="dita"/>
-</li>
-<li id="px220032">
-<xref href="#topic3" type="topic" format="dita"/>
-</li>
-<li id="px216091">
-<xref href="#topic31" type="topic" format="dita"/>
-</li>
-<li id="px214686">
-<xref href="#topic33" type="topic" format="dita"/>
-</li>
-</ul>
-</body>
+        <p>This chapter includes the following information:</p>
+        <ul>
+            <li id="px220017">
+                <xref href="#topic2" type="topic" format="dita"/>
+            </li>
+            <li id="px220032">
+                <xref href="#topic3" type="topic" format="dita"/>
+            </li>
+            <li id="px216091">
+                <xref href="#topic31" type="topic" format="dita"/>
+            </li>
+            <li id="px214686">
+                <xref href="#topic33" type="topic" format="dita"/>
+            </li>
+        </ul>
+    </body>
 
-<topic id="topic2" xml:lang="en">
-<title id="px216140">About Greenplum PL/Perl</title>
-<body>
-<p>
-With the Greenplum Database PL/Perl extension, you can write user-defined functions
-in Perl that take advantage of its advanced string manipulation operators and
-functions. PL/Perl provides both trusted and untrusted variants of the language.
-</p>
-<p>
-PL/Perl is embedded in your Greenplum Database distribution. Greenplum Database
-PL/Perl requires Perl to be installed on the system of each database host.
-</p>
-<p>
-Refer to the <xref href="https://www.postgresql.org/docs/9.1/static/plperl.html" scope="external" format="html">
-PostgreSQL PL/Perl documentation
-</xref>
- for additional information.
-</p>
-</body>
-</topic>
+    <topic id="topic2" xml:lang="en">
+        <title id="px216140">About Greenplum PL/Perl</title>
+        <body>
+            <p> With the Greenplum Database PL/Perl extension, you can write user-defined functions
+                in Perl that take advantage of its advanced string manipulation operators and
+                functions. PL/Perl provides both trusted and untrusted variants of the language. </p>
+            <p> PL/Perl is embedded in your Greenplum Database distribution. Greenplum Database
+                PL/Perl requires Perl to be installed on the system of each database host. </p>
+            <p> Refer to the <xref href="https://www.postgresql.org/docs/9.1/static/plperl.html"
+                    scope="external" format="html"> PostgreSQL PL/Perl documentation </xref> for
+                additional information. </p>
+        </body>
+    </topic>
 
-<topic id="topic3" xml:lang="en">
-<title>Greenplum Database PL/Perl Limitations</title>
-<body>
-<p>
-Limitations of the Greenplum Database PL/Perl language include:
-<ul>
-<li>Greenplum Database does not support PL/Perl triggers.</li>
-<li>PL/Perl functions cannot call each other directly.</li>
-<li>SPI is not yet fully implemented.</li>
-<li>If you fetch very large data sets using <codeph>spi_exec_query()</codeph>, you should be
-aware that these will all go into memory. You can avoid this problem by using
-<codeph>spi_query()/spi_fetchrow()</codeph>. A similar problem occurs if a
-set-returning function passes a large set of rows back to Greenplum Database
-via a <codeph>return</codeph> statement. Use <codeph>return_next</codeph> for
-each row returned to avoid this problem.</li>
-<li>When a session ends normally, not due to a fatal error, PL/Perl executes any
-<codeph>END</codeph> blocks that you have defined. No other actions are currently
-performed. (File handles are not automatically flushed and objects are not
-automatically destroyed.)</li>
-</ul> </p>
-</body>
-</topic>
+    <topic id="topic3" xml:lang="en">
+        <title>Greenplum Database PL/Perl Limitations</title>
+        <body>
+            <p> Limitations of the Greenplum Database PL/Perl language include: <ul>
+                    <li>Greenplum Database does not support PL/Perl triggers.</li>
+                    <li>PL/Perl functions cannot call each other directly.</li>
+                    <li>SPI is not yet fully implemented.</li>
+                    <li>If you fetch very large data sets using <codeph>spi_exec_query()</codeph>,
+                        you should be aware that these will all go into memory. You can avoid this
+                        problem by using <codeph>spi_query()/spi_fetchrow()</codeph>. A similar
+                        problem occurs if a set-returning function passes a large set of rows back
+                        to Greenplum Database via a <codeph>return</codeph> statement. Use
+                            <codeph>return_next</codeph> for each row returned to avoid this
+                        problem.</li>
+                    <li>When a session ends normally, not due to a fatal error, PL/Perl executes any
+                            <codeph>END</codeph> blocks that you have defined. No other actions are
+                        currently performed. (File handles are not automatically flushed and objects
+                        are not automatically destroyed.)</li>
+                </ul>
+            </p>
+        </body>
+    </topic>
 
 
-<topic id="topic31" xml:lang="en">
-<title>Trusted/Untrusted Language</title>
-<body>
-<p>
-PL/Perl includes trusted and untrusted language variants.
-</p>
-<p>
-The PL/Perl trusted language is named <codeph>plperl</codeph>. The trusted PL/Perl
-language restricts file system operations, as well as <codeph>require</codeph>,
-<codeph>use</codeph>, and other statements that could potentially interact with
-the operating system or database server process. With these restrictions in
-place, any Greenplum Database user can create and execute functions in the trusted
-<codeph>plperl</codeph> language.
-</p>
-<p>
-The PL/Perl untrusted language is named <codeph>plperlu</codeph>. You cannot
-restrict the operation of functions you create with the <codeph>plperlu</codeph>
-untrusted language. Only database superusers have privileges to create untrusted
-PL/Perl user-defined functions. And only database superusers and other database
-users that are explicitly granted the permissions can execute untrusted PL/Perl
-user-defined functions.
-</p>
-<p>
-PL/Perl has limitations with respect to communication between interpreters
-and the number of interpreters running in a single process. Refer to the
-PostgreSQL <xref href="https://www.postgresql.org/docs/9.1/static/plperl-trusted.html" scope="external" format="html">Trusted and Untrusted PL/Perl</xref>
-documentation for additional information.
-</p>
-</body>
-</topic>
+    <topic id="topic31" xml:lang="en">
+        <title>Trusted/Untrusted Language</title>
+        <body>
+            <p> PL/Perl includes trusted and untrusted language variants. </p>
+            <p> The PL/Perl trusted language is named <codeph>plperl</codeph>. The trusted PL/Perl
+                language restricts file system operations, as well as <codeph>require</codeph>,
+                    <codeph>use</codeph>, and other statements that could potentially interact with
+                the operating system or database server process. With these restrictions in place,
+                any Greenplum Database user can create and execute functions in the trusted
+                    <codeph>plperl</codeph> language. </p>
+            <p> The PL/Perl untrusted language is named <codeph>plperlu</codeph>. You cannot
+                restrict the operation of functions you create with the <codeph>plperlu</codeph>
+                untrusted language. Only database superusers have privileges to create untrusted
+                PL/Perl user-defined functions. And only database superusers and other database
+                users that are explicitly granted the permissions can execute untrusted PL/Perl
+                user-defined functions. </p>
+            <p> PL/Perl has limitations with respect to communication between interpreters and the
+                number of interpreters running in a single process. Refer to the PostgreSQL <xref
+                    href="https://www.postgresql.org/docs/9.1/static/plperl-trusted.html"
+                    scope="external" format="html">Trusted and Untrusted PL/Perl</xref>
+                documentation for additional information. </p>
+        </body>
+    </topic>
 
-<topic id="topic6" xml:lang="en">
-<title>Enabling and Removing PL/Perl Support</title>
-<body>
-<p>
-You must register the PL/Perl language with a database before you can create and
-execute a PL/Perl user-defined function within that database. To remove PL/Perl
-support, you must explicitly remove the extension from each database in which it
-was registered. You must be a database superuser or owner to register or remove
-trusted languages in Greenplum databases.
-</p>
-<note>Only database superusers may register or remove support for the
-<i>untrusted</i> PL/Perl language <codeph>plperlu</codeph>.</note>
-<p>
-Before you enable or remove PL/Perl support in a database, ensure that:
-<ul>
-<li>Your Greenplum Database is running.</li>
-<li>You have sourced <codeph>greenplum_path.sh</codeph>.</li>
-<li>You have set the <codeph>$MASTER_DATA_DIRECTORY</codeph> and
-<codeph>$GPHOME</codeph> environment variables.</li>
-</ul>
-</p>
-</body>
-<topic id="topic61" xml:lang="en">
-<title>Enabling PL/Perl Support</title>
-<body>
-<p>
-For each database in which you want to enable PL/Perl, register the language using the SQL
-<codeph><xref href="../sql_commands/CREATE_LANGUAGE.xml#topic1">CREATE LANGUAGE</xref></codeph>
-command or the Greenplum Database
-<codeph><xref href="../../utility_guide/client_utilities/createlang.xml#topic1">createlang</xref></codeph>
-utility. For example, run the following command as the <codeph>gpadmin</codeph>
-user to register the trusted PL/Perl language for the database named
-<codeph>testdb</codeph>:
-</p>
-<codeblock>$ createlang plperl -d testdb</codeblock>
-</body>
-</topic>
-<topic id="topic62" xml:lang="en">
-<title>Removing PL/Perl Support</title>
-<body>
-<p>
-To remove support for PL/Perl from a database, run the SQL 
-<codeph><xref href="../sql_commands/DROP_LANGUAGE.xml#topic1">DROP LANGUAGE</xref></codeph>
-command or the Greenplum Database
-<codeph><xref href="../../utility_guide/client_utilities/droplang.xml#topic1">droplang</xref></codeph>
-utility. For example, run the following command as the <codeph>gpadmin</codeph>
-user to remove support for the trusted PL/Perl language from the database named
-<codeph>testdb</codeph>:
-</p>
-<codeblock>
+    <topic id="topic6" xml:lang="en">
+        <title>Enabling and Removing PL/Perl Support</title>
+        <body>
+            <p> You must register the PL/Perl language with a database before you can create and
+                execute a PL/Perl user-defined function within that database. To remove PL/Perl
+                support, you must explicitly remove the extension from each database in which it was
+                registered. You must be a database superuser or owner to register or remove trusted
+                languages in Greenplum databases. </p>
+            <note>Only database superusers may register or remove support for the <i>untrusted</i>
+                PL/Perl language <codeph>plperlu</codeph>.</note>
+            <p> Before you enable or remove PL/Perl support in a database, ensure that: <ul>
+                    <li>Your Greenplum Database is running.</li>
+                    <li>You have sourced <codeph>greenplum_path.sh</codeph>.</li>
+                    <li>You have set the <codeph>$MASTER_DATA_DIRECTORY</codeph> and
+                            <codeph>$GPHOME</codeph> environment variables.</li>
+                </ul>
+            </p>
+        </body>
+        <topic id="topic61" xml:lang="en">
+            <title>Enabling PL/Perl Support</title>
+            <body>
+                <p> For each database in which you want to enable PL/Perl, register the language
+                    using the SQL <codeph><xref href="../sql_commands/CREATE_LANGUAGE.xml#topic1"
+                            >CREATE LANGUAGE</xref></codeph> command or the Greenplum Database
+                            <codeph><xref
+                            href="../../utility_guide/client_utilities/createlang.xml#topic1"
+                            >createlang</xref></codeph> utility. For example, run the following
+                    command as the <codeph>gpadmin</codeph> user to register the trusted PL/Perl
+                    language for the database named <codeph>testdb</codeph>: </p>
+                <codeblock>$ createlang plperl -d testdb</codeblock>
+            </body>
+        </topic>
+        <topic id="topic62" xml:lang="en">
+            <title>Removing PL/Perl Support</title>
+            <body>
+                <p> To remove support for PL/Perl from a database, run the SQL <codeph><xref
+                            href="../sql_commands/DROP_LANGUAGE.xml#topic1">DROP
+                        LANGUAGE</xref></codeph> command or the Greenplum Database <codeph><xref
+                            href="../../utility_guide/client_utilities/droplang.xml#topic1"
+                            >droplang</xref></codeph> utility. For example, run the following
+                    command as the <codeph>gpadmin</codeph> user to remove support for the trusted
+                    PL/Perl language from the database named <codeph>testdb</codeph>: </p>
+                <codeblock>
 $ psql -d testdb
 psql (8.3.23)
 Type "help" for help.
 
 testdb=# DROP LANGUAGE plperl;
 </codeblock>
-<p>
-The default <codeph>DROP LANGUAGE</codeph> behavior is <codeph>RESTRICT</codeph>;
-the command fails if any existing objects (such as functions) depend on the
-language. Specify the <codeph>CASCADE</codeph> clause to also drop all dependent
-objects, including functions that you created with PL/Perl.
-</p>
-</body>
-</topic>
-</topic>
+                <p> The default <codeph>DROP LANGUAGE</codeph> behavior is
+                    <codeph>RESTRICT</codeph>; the command fails if any existing objects (such as
+                    functions) depend on the language. Specify the <codeph>CASCADE</codeph> clause
+                    to also drop all dependent objects, including functions that you created with
+                    PL/Perl. </p>
+            </body>
+        </topic>
+    </topic>
 
-<topic id="topic33" xml:lang="en">
-<title>Developing Functions with PL/Perl</title>
-<body>
-<p>
-You define a PL/Perl function using the standard SQL <codeph><xref href="../sql_commands/CREATE_FUNCTION.xml#topic1">CREATE FUNCTION</xref></codeph> syntax.
-The body of a PL/Perl user-defined function is ordinary Perl code. The PL/Perl
-interpreter wraps this code inside a Perl subroutine.
-</p>
-<p>
-You can also create an anonymous code block with PL/Perl. An anonymous code block,
-called with the SQL <codeph><xref href="../sql_commands/DO.xml#topic1">DO</xref></codeph>
-command, receives no arguments, and whatever value it might return is discarded.
-Otherwise, a PL/Perl anonymous code block behaves just like a function.  Only
-database superusers create an anonymous code block with the untrusted
-<codeph>plperlu</codeph> language.
-</p>
-<p>
-The syntax of the <codeph>CREATE FUNCTION</codeph> command requires that you write
-the PL/Perl function body as a string constant. While it is more convenient to use
-dollar-quoting, you can choose to use escape string syntax (<codeph>E''</codeph>)
-provided that you double any single quote marks and backslashes used in the body
-of the function.
-</p>
-<p>
-PL/Perl arguments and results are handled as they are in Perl. Arguments you pass
-in to a PL/Perl function are accessed via the <codeph>@_</codeph> array. You
-return a result value with the <codeph>return</codeph> statement, or as the last
-expression evaluated in the function. A PL/Perl function cannot directly return a
-non-scalar type because you call it in a scalar context. You can return non-scalar
-types such as arrays, records, and sets in a PL/Perl function by returning a
-reference.
-</p>
-<p>
-PL/Perl treats null argument values as "undefined". Adding the
-<codeph>STRICT</codeph> keyword to the <codeph>LANGUAGE</codeph> subclause
-instructs Greenplum Database to immediately return null when any of the input
-arguments are null. When created as <codeph>STRICT</codeph>, the function itself
-need not perform null checks.
-</p>
-<p>The following PL/Perl function utilizes the <codeph>STRICT</codeph> keyword to
-return the greater of two integers, or null if any of the inputs are null:
-</p>
-<codeblock>
+    <topic id="topic33" xml:lang="en">
+        <title>Developing Functions with PL/Perl</title>
+        <body>
+            <p> You define a PL/Perl function using the standard SQL <codeph><xref
+                        href="../sql_commands/CREATE_FUNCTION.xml#topic1">CREATE
+                    FUNCTION</xref></codeph> syntax. The body of a PL/Perl user-defined function is
+                ordinary Perl code. The PL/Perl interpreter wraps this code inside a Perl
+                subroutine. </p>
+            <p> You can also create an anonymous code block with PL/Perl. An anonymous code block,
+                called with the SQL <codeph><xref href="../sql_commands/DO.xml#topic1"
+                    >DO</xref></codeph> command, receives no arguments, and whatever value it might
+                return is discarded. Otherwise, a PL/Perl anonymous code block behaves just like a
+                function. Only database superusers create an anonymous code block with the untrusted
+                    <codeph>plperlu</codeph> language. </p>
+            <p> The syntax of the <codeph>CREATE FUNCTION</codeph> command requires that you write
+                the PL/Perl function body as a string constant. While it is more convenient to use
+                dollar-quoting, you can choose to use escape string syntax (<codeph>E''</codeph>)
+                provided that you double any single quote marks and backslashes used in the body of
+                the function. </p>
+            <p> PL/Perl arguments and results are handled as they are in Perl. Arguments you pass in
+                to a PL/Perl function are accessed via the <codeph>@_</codeph> array. You return a
+                result value with the <codeph>return</codeph> statement, or as the last expression
+                evaluated in the function. A PL/Perl function cannot directly return a non-scalar
+                type because you call it in a scalar context. You can return non-scalar types such
+                as arrays, records, and sets in a PL/Perl function by returning a reference. </p>
+            <p> PL/Perl treats null argument values as "undefined". Adding the
+                    <codeph>STRICT</codeph> keyword to the <codeph>LANGUAGE</codeph> subclause
+                instructs Greenplum Database to immediately return null when any of the input
+                arguments are null. When created as <codeph>STRICT</codeph>, the function itself
+                need not perform null checks. </p>
+            <p>The following PL/Perl function utilizes the <codeph>STRICT</codeph> keyword to return
+                the greater of two integers, or null if any of the inputs are null: </p>
+            <codeblock>
 CREATE FUNCTION perl_max (integer, integer) RETURNS integer AS $$
     if ($_[0] > $_[1]) { return $_[0]; }
     return $_[1];
@@ -224,41 +192,35 @@ SELECT perl_max( 1, null );
 (1 row)
 </codeblock>
 
-<p>
-PL/Perl considers anything in a function argument that is not a reference to be a
-string, the standard Greenplum Database external text representation. The argument
-values supplied to a PL/Perl function are simply the input arguments converted to
-text form (just as if they had been displayed by a <codeph>SELECT</codeph>
-statement). In cases where the function argument is not an ordinary numeric or
-text type, you must convert the Greenplum Database type to a form that is more
-usable by Perl. Conversely, the <codeph>return</codeph> and
-<codeph>return_next</codeph> statements accept any string that is an acceptable
-input format for the function's declared return type.
-</p>
-<p>
-Refer to the PostgreSQL <xref href="https://www.postgresql.org/docs/9.1/static/plperl-funcs.html" scope="external" format="html">PL/Perl Functions and Arguments</xref>
-documentation for additional information, including composite type and result
-set manipulation.
-</p>
+            <p> PL/Perl considers anything in a function argument that is not a reference to be a
+                string, the standard Greenplum Database external text representation. The argument
+                values supplied to a PL/Perl function are simply the input arguments converted to
+                text form (just as if they had been displayed by a <codeph>SELECT</codeph>
+                statement). In cases where the function argument is not an ordinary numeric or text
+                type, you must convert the Greenplum Database type to a form that is more usable by
+                Perl. Conversely, the <codeph>return</codeph> and <codeph>return_next</codeph>
+                statements accept any string that is an acceptable input format for the function's
+                declared return type. </p>
+            <p> Refer to the PostgreSQL <xref
+                    href="https://www.postgresql.org/docs/9.1/static/plperl-funcs.html"
+                    scope="external" format="html">PL/Perl Functions and Arguments</xref>
+                documentation for additional information, including composite type and result set
+                manipulation. </p>
 
-</body>
+        </body>
 
-<topic id="topic3311" xml:lang="en">
-<title>Built-in PL/Perl Functions</title>
-<body>
-<p>
-PL/Perl includes built-in functions to access the database, including those to
-prepare and perform queries and manipulate query results. The language also
-includes utility functions for error logging and string manipulation.
-</p>
-<p>
-The following example creates a simple table with an integer and a text column. 
-It creates a PL/Perl user-defined function that takes an input string argument and
-invokes the <codeph>spi_exec_query()</codeph> built-in function to select all
-columns and rows of the table.  The function returns all rows in the query results
-where the <codeph>v</codeph> column includes the function input string.
-</p>
-<codeblock>
+        <topic id="topic3311" xml:lang="en">
+            <title>Built-in PL/Perl Functions</title>
+            <body>
+                <p>PL/Perl includes built-in functions to access the database, including those to
+                    prepare and perform queries and manipulate query results. The language also
+                    includes utility functions for error logging and string manipulation. </p>
+                <p> The following example creates a simple table with an integer and a text column.
+                    It creates a PL/Perl user-defined function that takes an input string argument
+                    and invokes the <codeph>spi_exec_query()</codeph> built-in function to select
+                    all columns and rows of the table. The function returns all rows in the query
+                    results where the <codeph>v</codeph> column includes the function input string. </p>
+                <codeblock>
 CREATE TABLE test (
     i int,
     v varchar
@@ -291,7 +253,7 @@ CREATE OR REPLACE FUNCTION return_match(varchar) RETURNS SETOF test AS $$
         }
     }
     return undef;
-$$ LANGUAGE plperl;
+$$ LANGUAGE plperl EXECUTE ON MASTER ;
 
 SELECT return_match( 'iff' );
  return_match
@@ -299,26 +261,22 @@ SELECT return_match( 'iff' );
  (4,different)
 (1 row)
 </codeblock>
-<p>
-Refer to the PostgreSQL PL/Perl <xref href="https://www.postgresql.org/docs/9.1/static/plperl-builtins.html" scope="external" format="html">Built-in Functions</xref>
-documentation for a detailed discussion of available functions.
-</p>
-</body>
-</topic>
-<topic id="topic331" xml:lang="en">
-<title>Global Values in PL/Perl</title>
-<body>
-<p>
-You can use the global hash map <codeph>%_SHARED</codeph> to share data, including
-code references, between PL/Perl function calls for the lifetime of the current
-session.
-</p>
-<p>
-The following example uses <codeph>%_SHARED</codeph> to share data between the
-user-defined <codeph>set_var()</codeph> and <codeph>get_var()</codeph> PL/Perl
-functions:
-</p>
-<codeblock>
+                <p> Refer to the PostgreSQL PL/Perl <xref
+                        href="https://www.postgresql.org/docs/9.1/static/plperl-builtins.html"
+                        scope="external" format="html">Built-in Functions</xref> documentation for a
+                    detailed discussion of available functions. </p>
+            </body>
+        </topic>
+        <topic id="topic331" xml:lang="en">
+            <title>Global Values in PL/Perl</title>
+            <body>
+                <p> You can use the global hash map <codeph>%_SHARED</codeph> to share data,
+                    including code references, between PL/Perl function calls for the lifetime of
+                    the current session. </p>
+                <p> The following example uses <codeph>%_SHARED</codeph> to share data between the
+                    user-defined <codeph>set_var()</codeph> and <codeph>get_var()</codeph> PL/Perl
+                    functions: </p>
+                <codeblock>
 CREATE OR REPLACE FUNCTION set_var(name text, val text) RETURNS text AS $$
     if ($_SHARED{$_[0]} = $_[1]) {
         return 'ok';
@@ -343,43 +301,38 @@ SELECT get_var('key1');
  value1
 (1 row)
 </codeblock>
-<p>
-For security reasons, PL/Perl creates a separate Perl interpreter for each role.
-This prevents accidental or malicious interference by one user with the behavior
-of another user's PL/Perl functions. Each such interpreter retains its own value
-of the <codeph>%_SHARED</codeph> variable and other global state. Two PL/Perl
-functions share the same value of <codeph>%_SHARED</codeph> if and only if they
-are executed by the same SQL role.
-</p>
-<p>
-There are situations where you must take explicit steps to ensure that PL/Perl
-functions can share data in <codeph>%_SHARED</codeph>. For example, if an
-application executes under multiple SQL roles
-(via <codeph>SECURITY DEFINER</codeph> functions, use of <codeph>SET ROLE</codeph>,
-etc.) in a single session, make sure that functions that need to communicate are
-owned by the same user, and mark these functions as
-<codeph>SECURITY DEFINER</codeph>.
-</p>
-</body>
-</topic>
+                <p> For security reasons, PL/Perl creates a separate Perl interpreter for each role.
+                    This prevents accidental or malicious interference by one user with the behavior
+                    of another user's PL/Perl functions. Each such interpreter retains its own value
+                    of the <codeph>%_SHARED</codeph> variable and other global state. Two PL/Perl
+                    functions share the same value of <codeph>%_SHARED</codeph> if and only if they
+                    are executed by the same SQL role. </p>
+                <p> There are situations where you must take explicit steps to ensure that PL/Perl
+                    functions can share data in <codeph>%_SHARED</codeph>. For example, if an
+                    application executes under multiple SQL roles (via <codeph>SECURITY
+                        DEFINER</codeph> functions, use of <codeph>SET ROLE</codeph>, etc.) in a
+                    single session, make sure that functions that need to communicate are owned by
+                    the same user, and mark these functions as <codeph>SECURITY DEFINER</codeph>.
+                </p>
+            </body>
+        </topic>
 
-<topic id="topic335" xml:lang="en">
-<title>Notes</title>
-<body>
-<p>
-Additional considerations when developing PL/Perl functions:
-<ul>
-<li>PL/Perl internally utilizes the UTF-8 encoding. It converts any arguments
-provided in other encodings to UTF-8, and converts return values from UTF-8 back
-to the original encoding.</li>
-<li>Nesting named PL/Perl subroutines retains the same dangers as in Perl.</li>
-<li>Only the untrusted PL/Perl language variant supports module import. Use
-<codeph>plperlu</codeph> with care.</li>
-<li>Any module that you use in a <codeph>plperlu</codeph> function must be available from the same location on all Greenplum Database hosts.</li>
-</ul>
-</p>
-</body>
+        <topic id="topic335" xml:lang="en">
+            <title>Notes</title>
+            <body>
+                <p> Additional considerations when developing PL/Perl functions: <ul>
+                        <li>PL/Perl internally utilizes the UTF-8 encoding. It converts any
+                            arguments provided in other encodings to UTF-8, and converts return
+                            values from UTF-8 back to the original encoding.</li>
+                        <li>Nesting named PL/Perl subroutines retains the same dangers as in
+                            Perl.</li>
+                        <li>Only the untrusted PL/Perl language variant supports module import. Use
+                                <codeph>plperlu</codeph> with care.</li>
+                        <li>Any module that you use in a <codeph>plperlu</codeph> function must be
+                            available from the same location on all Greenplum Database hosts.</li>
+                    </ul>
+                </p>
+            </body>
+        </topic>
+    </topic>
 </topic>
-</topic>
-</topic>
-

--- a/gpdb-doc/dita/ref_guide/extensions/pl_python.xml
+++ b/gpdb-doc/dita/ref_guide/extensions/pl_python.xml
@@ -655,12 +655,13 @@ INSERT INTO sales VALUES
         by the input value. In the Python function, the row numbering starts from 0. Valid input for
         the function is an integer between 0 and 4. </p>
       <codeblock>CREATE OR REPLACE FUNCTION mypytest(a integer) 
-  RETURNS text 
+  RETURNS setof text 
 AS $$ 
   rv = plpy.execute("SELECT * FROM sales ORDER BY id", 5)
-  region = rv[a]["region"]
+  region =[]
+  region.append(rv[a]["region"])
   return region
-$$ language plpythonu;</codeblock>
+$$ language plpythonu EXECUTE ON MASTER;</codeblock>
       <p>Running this <codeph>SELECT</codeph> statement returns the <codeph>REGION</codeph> column
         value from the third row of the result set.</p>
       <codeblock>SELECT mypytest(2) ;</codeblock>

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_FUNCTION.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_FUNCTION.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
-<topic id="topic1"><title id="an20941">ALTER FUNCTION</title><body><p id="sql_command_desc">Changes the definition of a function.</p><section id="section2"><title>Synopsis</title><codeblock id="sql_command_synopsis">ALTER FUNCTION <varname>name</varname> ( [ [<varname>argmode</varname>] [<varname>argname</varname>] <varname>argtype</varname> [, ...] ] ) 
+<topic id="topic1">
+  <title id="an20941">ALTER FUNCTION</title>
+  <body>
+    <p id="sql_command_desc">Changes the definition of a function.</p>
+    <section id="section2"
+        ><title>Synopsis</title><codeblock id="sql_command_synopsis">ALTER FUNCTION <varname>name</varname> ( [ [<varname>argmode</varname>] [<varname>argname</varname>] <varname>argtype</varname> [, ...] ] ) 
    <varname>action</varname> [, ... ] [RESTRICT]
 
 ALTER FUNCTION <varname>name</varname> ( [ [<varname>argmode</varname>] [<varname>argname</varname>] <varname>argtype</varname> [, ...] ] )
@@ -11,7 +16,9 @@ ALTER FUNCTION <varname>name</varname> ( [ [<varname>argmode</varname>] [<varnam
    OWNER TO <varname>new_owner</varname>
 
 ALTER FUNCTION <varname>name</varname> ( [ [<varname>argmode</varname>] [<varname>argname</varname>] <varname>argtype</varname> [, ...] ] ) 
-   SET SCHEMA <varname>new_schema</varname></codeblock><p>where <varname>action</varname> is one of:</p><codeblock>{CALLED ON NULL INPUT | RETURNS NULL ON NULL INPUT | STRICT}
+   SET SCHEMA <varname>new_schema</varname></codeblock><p>where
+          <varname>action</varname> is one
+      of:</p><codeblock>{CALLED ON NULL INPUT | RETURNS NULL ON NULL INPUT | STRICT}
 {IMMUTABLE | STABLE | VOLATILE}
 {[EXTERNAL] SECURITY INVOKER | [EXTERNAL] SECURITY DEFINER}
 EXECUTE ON { ANY | MASTER | ALL SEGMENTS }
@@ -19,72 +26,106 @@ COST <varname>execution_cost</varname>
 SET <varname>configuration_parameter</varname> { TO | = } { <varname>value</varname> | DEFAULT }
 SET <varname>configuration_parameter</varname> FROM CURRENT
 RESET <varname>configuration_parameter</varname>
-RESET ALL</codeblock></section><section id="section3"><title>Description</title><p><codeph>ALTER FUNCTION</codeph> changes the definition of a function.
-</p><p>You must own the function to use <codeph>ALTER FUNCTION</codeph>.
-To change a function's schema, you must also have <codeph>CREATE</codeph>
-privilege on the new schema. To alter the owner, you must also be a direct
-or indirect member of the new owning role, and that role must have <codeph>CREATE</codeph>
-privilege on the function's schema. (These restrictions enforce that
-altering the owner does not do anything you could not do by dropping
-and recreating the function. However, a superuser can alter ownership
-of any function anyway.) </p></section><section id="section4"><title>Parameters</title><parml><plentry><pt><varname>name</varname></pt><pd>The name (optionally schema-qualified) of an existing function. </pd></plentry><plentry><pt><varname>argmode</varname></pt><pd>The mode of an argument: either <codeph>IN</codeph>, <codeph>OUT</codeph>, <codeph>INOUT</codeph>, 
-or <codeph>VARIADIC</codeph>. If omitted, the default is <codeph>IN</codeph>.
-Note that <codeph>ALTER FUNCTION</codeph> does not actually pay any attention
-to <codeph>OUT</codeph> arguments, since only the input arguments are
-needed to determine the function's identity. So it is sufficient to
-list the <codeph>IN</codeph>, <codeph>INOUT</codeph>, and <codeph>VARIADIC</codeph> arguments.</pd></plentry><plentry><pt><varname>argname</varname></pt><pd>The name of an argument. Note that <codeph>ALTER FUNCTION</codeph>
-does not actually pay any attention to argument names, since only the
-argument data types are needed to determine the function's identity.
-</pd></plentry><plentry><pt><varname>argtype</varname></pt><pd>The data type(s) of the function's arguments (optionally schema-qualified),
-if any. </pd></plentry><plentry><pt><varname>new_name</varname></pt><pd>The new name of the function. </pd></plentry><plentry><pt><varname>new_owner</varname></pt><pd>The new owner of the function. Note that if the function is marked
-<codeph>SECURITY DEFINER</codeph>, it will subsequently execute as the
-new owner. </pd></plentry><plentry><pt><varname>new_schema</varname></pt><pd>The new schema for the function. </pd></plentry><plentry><pt>CALLED ON NULL INPUT</pt><pt>RETURNS NULL ON NULL INPUT</pt><pt>STRICT</pt><pd><codeph>CALLED ON NULL INPUT</codeph> changes the function so that
-it will be invoked when some or all of its arguments are null. <codeph>RETURNS
-NULL ON NULL INPUT</codeph> or <codeph>STRICT</codeph> changes the function
-so that it is not invoked if any of its arguments are null; instead,
-a null result is assumed automatically. See <codeph>CREATE FUNCTION</codeph>
-for more information.</pd></plentry><plentry><pt>IMMUTABLE</pt><pt>STABLE</pt><pt>VOLATILE</pt><pd>Change the volatility of the function to the specified setting. See
-<codeph>CREATE FUNCTION</codeph> for details. </pd></plentry><plentry><pt>[ EXTERNAL ] SECURITY INVOKER</pt><pt>[ EXTERNAL ] SECURITY DEFINER</pt><pd>Change whether the function is a security definer or not. The key
-word <codeph>EXTERNAL</codeph> is ignored for SQL conformance. See <codeph>CREATE
-FUNCTION</codeph> for more information about this capability.</pd></plentry>
+RESET ALL</codeblock></section>
+    <section id="section3"><title>Description</title><p><codeph>ALTER FUNCTION</codeph> changes the
+        definition of a function. </p><p>You must own the function to use <codeph>ALTER
+          FUNCTION</codeph>. To change a function's schema, you must also have
+          <codeph>CREATE</codeph> privilege on the new schema. To alter the owner, you must also be
+        a direct or indirect member of the new owning role, and that role must have
+          <codeph>CREATE</codeph> privilege on the function's schema. (These restrictions enforce
+        that altering the owner does not do anything you could not do by dropping and recreating the
+        function. However, a superuser can alter ownership of any function anyway.) </p></section>
+    <section id="section4"><title>Parameters</title><parml>
+        <plentry>
+          <pt><varname>name</varname></pt>
+          <pd>The name (optionally schema-qualified) of an existing function. </pd>
+        </plentry>
+        <plentry>
+          <pt><varname>argmode</varname></pt>
+          <pd>The mode of an argument: either <codeph>IN</codeph>, <codeph>OUT</codeph>,
+              <codeph>INOUT</codeph>, or <codeph>VARIADIC</codeph>. If omitted, the default is
+              <codeph>IN</codeph>. Note that <codeph>ALTER FUNCTION</codeph> does not actually pay
+            any attention to <codeph>OUT</codeph> arguments, since only the input arguments are
+            needed to determine the function's identity. So it is sufficient to list the
+              <codeph>IN</codeph>, <codeph>INOUT</codeph>, and <codeph>VARIADIC</codeph>
+            arguments.</pd>
+        </plentry>
+        <plentry>
+          <pt><varname>argname</varname></pt>
+          <pd>The name of an argument. Note that <codeph>ALTER FUNCTION</codeph> does not actually
+            pay any attention to argument names, since only the argument data types are needed to
+            determine the function's identity. </pd>
+        </plentry>
+        <plentry>
+          <pt><varname>argtype</varname></pt>
+          <pd>The data type(s) of the function's arguments (optionally schema-qualified), if any.
+          </pd>
+        </plentry>
+        <plentry>
+          <pt><varname>new_name</varname></pt>
+          <pd>The new name of the function. </pd>
+        </plentry>
+        <plentry>
+          <pt><varname>new_owner</varname></pt>
+          <pd>The new owner of the function. Note that if the function is marked <codeph>SECURITY
+              DEFINER</codeph>, it will subsequently execute as the new owner. </pd>
+        </plentry>
+        <plentry>
+          <pt><varname>new_schema</varname></pt>
+          <pd>The new schema for the function. </pd>
+        </plentry>
+        <plentry>
+          <pt>CALLED ON NULL INPUT</pt>
+          <pt>RETURNS NULL ON NULL INPUT</pt>
+          <pt>STRICT</pt>
+          <pd><codeph>CALLED ON NULL INPUT</codeph> changes the function so that it will be invoked
+            when some or all of its arguments are null. <codeph>RETURNS NULL ON NULL INPUT</codeph>
+            or <codeph>STRICT</codeph> changes the function so that it is not invoked if any of its
+            arguments are null; instead, a null result is assumed automatically. See <codeph><xref
+                href="CREATE_FUNCTION.xml#topic1">CREATE FUNCTION</xref></codeph> for more
+            information.</pd>
+        </plentry>
+        <plentry>
+          <pt>IMMUTABLE</pt>
+          <pt>STABLE</pt>
+          <pt>VOLATILE</pt>
+          <pd>Change the volatility of the function to the specified setting. See <codeph><xref
+                href="CREATE_FUNCTION.xml#topic1">CREATE FUNCTION</xref></codeph> for details. </pd>
+        </plentry>
+        <plentry>
+          <pt>[ EXTERNAL ] SECURITY INVOKER</pt>
+          <pt>[ EXTERNAL ] SECURITY DEFINER</pt>
+          <pd>Change whether the function is a security definer or not. The key word
+              <codeph>EXTERNAL</codeph> is ignored for SQL conformance. See <codeph>CREATE
+              FUNCTION</codeph> for more information about this capability.</pd>
+        </plentry>
+        <plentry>
+          <pt>EXECUTE ON ANY</pt>
+          <pt>EXECUTE ON MASTER</pt>
+          <pt>EXECUTE ON ALL SEGMENTS</pt>
+          <pd>The <codeph>EXECUTE ON</codeph> attributes specify where (master or segment instance)
+            a function is executed when it is invoked during the query execution process.</pd>
+          <pd><codeph>EXECUTE ON ANY</codeph> (the default) indicates that the function can be
+            executed on the master, or any segment instance, and it returns the same result
+            regardless of where it is executed. Greenplum Database determines where the function is
+            executed.</pd>
+          <pd><codeph>EXECUTE ON MASTER</codeph> indicates that the function must be executed on the
+            master instance. </pd>
+          <pd><codeph>EXECUTE ON ALL SEGMENTS</codeph> indicates that the function must be executed
+            on all primary segment instances, but not the master, for each invocation. The overall
+            result of the function is the <codeph>UNION ALL</codeph> of the results from all segment
+            instances. </pd>
+          <pd>For more information about the <codeph>EXECUTE ON</codeph> attributes, see
+                <codeph><xref href="CREATE_FUNCTION.xml#topic1">CREATE
+            FUNCTION</xref></codeph>.</pd>
+        </plentry>
 
-  <plentry>
-    <pt>EXECUTE ON ANY</pt>
-    <pt>EXECUTE ON MASTER</pt>
-    <pt>EXECUTE ON ALL SEGMENTS</pt>
-
-    <pd>
-      <codeph>EXECUTE ON ANY</codeph> (the default) indicates that
-      the function may be executed on the master, or any segment instance,
-      and it will return the same result regardless of where it is executed.
-    </pd>
-
-    <pd>
-      <codeph>EXECUTE ON MASTER</codeph> indicates that the function
-      must be executed on the master instance.
-    </pd>
-
-    <pd>
-      <codeph>EXECUTE ON ALL SEGMENTS</codeph> indicates that the
-      function must be executed on all segment instances. The overall
-      result of the function is the UNION ALL of the results from all
-      segment instances.
-    </pd>
-
-    <pd>
-      <codeph>ON MASTER</codeph> and <codeph>ALL SEGMENTS</codeph> are
-      only allowed on set-returning functions. Note that executing queries
-      that access any tables is only supported when a function is executed
-      on the master. Such functions should be marked as <codeph>EXECUTE
-      ON MASTER</codeph>. Otherwise, you might get an error if the function
-      is used in a complicated query, and the planner thinks it would be
-      beneficial to push the function invocation to the segment instances.
-    </pd>
-  </plentry>
-
-  <plentry><pt>COST <varname>execution_cost</varname></pt>
-        <pd>Change the estimated execution cost of the function. See <codeph>CREATE
-FUNCTION</codeph> for more information.</pd></plentry>
+        <plentry>
+          <pt>COST <varname>execution_cost</varname></pt>
+          <pd>Change the estimated execution cost of the function. See <codeph><xref
+                href="CREATE_FUNCTION.xml#topic1">CREATE FUNCTION</xref></codeph> for more
+            information.</pd>
+        </plentry>
         <plentry>
           <pt><varname>configuration_parameter</varname></pt>
           <pt><varname>value</varname></pt>
@@ -94,18 +135,33 @@ FUNCTION</codeph> for more information.</pd></plentry>
             function executes with the value present in its environment. Use <codeph>RESET
               ALL</codeph> to clear all function-local settings. <codeph>SET FROM CURRENT</codeph>
             applies the session's current value of the parameter when the function is entered.</pd>
-        </plentry><plentry><pt>RESTRICT</pt><pd>Ignored for conformance with the SQL standard. </pd></plentry></parml></section><section id="section5"><title>Notes</title><p>Greenplum Database has limitations on the use of functions defined as <codeph>STABLE</codeph> or
-          <codeph>VOLATILE</codeph>. See <codeph><xref href="./CREATE_FUNCTION.xml#topic1"
-            type="topic" format="dita"/></codeph> for more information.</p></section><section id="section6"><title>Examples</title><p>To rename the function <codeph>sqrt</codeph> for type <codeph>integer</codeph> to
-          <codeph>square_root</codeph>:</p><codeblock>ALTER FUNCTION sqrt(integer) RENAME TO square_root;</codeblock><p>To change the owner of the function <codeph>sqrt</codeph> for type <codeph>integer</codeph> to
-          <codeph>joe</codeph>:</p><codeblock>ALTER FUNCTION sqrt(integer) OWNER TO joe;</codeblock><p>To change the <varname>schema</varname> of the function <codeph>sqrt</codeph> for type
+        </plentry>
+        <plentry>
+          <pt>RESTRICT</pt>
+          <pd>Ignored for conformance with the SQL standard. </pd>
+        </plentry>
+      </parml></section>
+    <section id="section5"><title>Notes</title><p>Greenplum Database has limitations on the use of
+        functions defined as <codeph>STABLE</codeph> or <codeph>VOLATILE</codeph>. See <codeph><xref
+            href="./CREATE_FUNCTION.xml#topic1" type="topic" format="dita"/></codeph> for more
+        information.</p></section>
+    <section id="section6"><title>Examples</title><p>To rename the function <codeph>sqrt</codeph>
+        for type <codeph>integer</codeph> to
+        <codeph>square_root</codeph>:</p><codeblock>ALTER FUNCTION sqrt(integer) RENAME TO square_root;</codeblock><p>To
+        change the owner of the function <codeph>sqrt</codeph> for type <codeph>integer</codeph> to
+          <codeph>joe</codeph>:</p><codeblock>ALTER FUNCTION sqrt(integer) OWNER TO joe;</codeblock><p>To
+        change the <varname>schema</varname> of the function <codeph>sqrt</codeph> for type
           <codeph>integer</codeph> to <codeph>math</codeph>:</p><codeblock>ALTER FUNCTION sqrt(integer) SET SCHEMA math;</codeblock>
       <p>To adjust the search path that is automatically set for a function:</p>
-      <codeblock>ALTER FUNCTION check_password(text) RESET search_path;</codeblock></section><section id="section7"><title>Compatibility</title><p>This statement is partially compatible with the <codeph>ALTER FUNCTION</codeph>
-statement in the SQL standard. The standard allows more properties of
-a function to be modified, but does not provide the ability to rename
-a function, make a function a security definer, or change the owner,
-schema, or volatility of a function. The standard also requires the <codeph>RESTRICT</codeph>
-key word, which is optional in Greenplum Database. </p></section><section id="section8"><title>See Also</title><p><codeph><xref href="./CREATE_FUNCTION.xml#topic1" type="topic" format="dita"/></codeph>,
-            <codeph><xref href="./DROP_FUNCTION.xml#topic1" type="topic" format="dita"
-        /></codeph></p></section></body></topic>
+      <codeblock>ALTER FUNCTION check_password(text) RESET search_path;</codeblock></section>
+    <section id="section7"><title>Compatibility</title><p>This statement is partially compatible
+        with the <codeph>ALTER FUNCTION</codeph> statement in the SQL standard. The standard allows
+        more properties of a function to be modified, but does not provide the ability to rename a
+        function, make a function a security definer, or change the owner, schema, or volatility of
+        a function. The standard also requires the <codeph>RESTRICT</codeph> key word, which is
+        optional in Greenplum Database. </p></section>
+    <section id="section8"><title>See Also</title><p><codeph><xref
+            href="./CREATE_FUNCTION.xml#topic1" type="topic" format="dita"/></codeph>, <codeph><xref
+            href="./DROP_FUNCTION.xml#topic1" type="topic" format="dita"/></codeph></p></section>
+  </body>
+</topic>

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_FUNCTION.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_FUNCTION.xml
@@ -104,15 +104,15 @@ RESET ALL</codeblock></section>
           <pt>EXECUTE ON MASTER</pt>
           <pt>EXECUTE ON ALL SEGMENTS</pt>
           <pd>The <codeph>EXECUTE ON</codeph> attributes specify where (master or segment instance)
-            a function is executed when it is invoked during the query execution process.</pd>
+            a function executes when it is invoked during the query execution process.</pd>
           <pd><codeph>EXECUTE ON ANY</codeph> (the default) indicates that the function can be
             executed on the master, or any segment instance, and it returns the same result
-            regardless of where it is executed. Greenplum Database determines where the function is
-            executed.</pd>
-          <pd><codeph>EXECUTE ON MASTER</codeph> indicates that the function must be executed on the
-            master instance. </pd>
-          <pd><codeph>EXECUTE ON ALL SEGMENTS</codeph> indicates that the function must be executed
-            on all primary segment instances, but not the master, for each invocation. The overall
+            regardless of where it is executed. Greenplum Database determines where the function
+            executes.</pd>
+          <pd><codeph>EXECUTE ON MASTER</codeph> indicates that the function must execute only on
+            the master instance. </pd>
+          <pd><codeph>EXECUTE ON ALL SEGMENTS</codeph> indicates that the function must execute on
+            all primary segment instances, but not the master, for each invocation. The overall
             result of the function is the <codeph>UNION ALL</codeph> of the results from all segment
             instances. </pd>
           <pd>For more information about the <codeph>EXECUTE ON</codeph> attributes, see

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_FUNCTION.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_FUNCTION.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
-<topic id="topic1"><title id="bs20941">CREATE FUNCTION</title><body><p id="sql_command_desc">Defines a new function.</p><section id="section2"><title>Synopsis</title><codeblock id="sql_command_synopsis">CREATE [OR REPLACE] FUNCTION <varname>name</varname>    
+<topic id="topic1">
+    <title id="bs20941">CREATE FUNCTION</title>
+    <body>
+        <p id="sql_command_desc">Defines a new function.</p>
+        <section id="section2"
+            ><title>Synopsis</title><codeblock id="sql_command_synopsis">CREATE [OR REPLACE] FUNCTION <varname>name</varname>    
     ( [ [<varname>argmode</varname>] [<varname>argname</varname>] <varname>argtype</varname> [ { DEFAULT | = } <varname>defexpr</varname> ] [, ...] ] )
       [ RETURNS { [ SETOF ] rettype 
         | TABLE ([{ argname argtype | LIKE other table }
@@ -17,154 +22,225 @@
     | AS '<varname>definition</varname>'
     | AS '<varname>obj_file</varname>', '<varname>link_symbol</varname>' } ...
     [ WITH ({ DESCRIBE = describe_function
-           } [, ...] ) ]</codeblock></section><section id="section3"><title>Description</title><p><codeph>CREATE FUNCTION</codeph> defines a new function. <codeph>CREATE
-OR REPLACE FUNCTION</codeph> will either create a new function, or replace
-an existing definition. </p><p>The name of the new function must not match any existing function
-with the same argument types in the same schema. However, functions of
-different argument types may share a name (overloading). </p><p>To update the definition of an existing function, use <codeph>CREATE
-OR REPLACE FUNCTION</codeph>. It is not possible to change the name or
-argument types of a function this way (this would actually create a new,
-distinct function). Also, <codeph>CREATE OR REPLACE FUNCTION</codeph>
-will not let you change the return type of an existing function. To do
-that, you must drop and recreate the function. If you drop and then recreate
-a function, you will have to drop existing objects (rules, views, triggers,
-and so on) that refer to the old function. Use <codeph>CREATE OR REPLACE
-FUNCTION</codeph> to change a function definition without breaking objects
-that refer to the function.</p><p>For more information about creating functions, see the <xref href="https://www.postgresql.org/docs/8.3/static/xfunc.html" scope="external" format="html">User Defined Functions</xref> section of the PostgreSQL
-documentation.</p><sectiondiv id="section4"><b>Limited Use of VOLATILE and STABLE Functions</b><p>To prevent data from becoming out-of-sync across the segments in Greenplum
-Database, any function classified as <codeph>STABLE</codeph> or <codeph>VOLATILE</codeph>
-cannot be executed at the segment level if it contains SQL or modifies
-the database in any way. For example, functions such as <codeph>random()</codeph>
-or <codeph>timeofday()</codeph> are not allowed to execute on distributed
-data in Greenplum Database because they could potentially cause inconsistent
-data between the segment instances.</p><p>To ensure data consistency, <codeph>VOLATILE</codeph> and <codeph>STABLE</codeph>
-functions can safely be used in statements that are evaluated on and
-execute from the master. For example, the following statements are always
-executed on the master (statements without a <codeph>FROM</codeph> clause):</p><codeblock>SELECT setval('myseq', 201);
-SELECT foo();</codeblock><p>In cases where a statement has a <codeph>FROM</codeph> clause
-containing a distributed table and the function used
-in the <codeph>FROM</codeph> clause simply returns a set of
-rows, execution may be allowed on the segments:</p><codeblock>SELECT * FROM foo();</codeblock><p>One exception to this rule are functions that return a table reference
-(<codeph>rangeFuncs</codeph>) or functions that use the <codeph>refCursor</codeph>
-data type. Note that you cannot return a <codeph>refcursor</codeph> from
-any kind of function in Greenplum Database.</p></sectiondiv></section><section id="section5"><title>Parameters</title><parml><plentry><pt><varname>name</varname></pt><pd>The name (optionally schema-qualified) of the function to create.</pd></plentry><plentry><pt><varname>argmode</varname></pt><pd>The mode of an argument: either <codeph>IN</codeph>, <codeph>OUT</codeph>, <codeph>INOUT</codeph>, 
-or <codeph>VARIADIC</codeph>. Only <codeph>OUT</codeph> arguments can follow an argument declared as <codeph>VARIADIC</codeph>. If omitted, the default is <codeph>IN</codeph>.
-</pd></plentry><plentry><pt><varname>argname</varname></pt><pd>The name of an argument. Some languages (currently only PL/pgSQL)
-let you use the name in the function body. For other languages the name
-of an input argument is just extra documentation. But the name of an
-output argument is significant, since it defines the column name in the
-result row type. (If you omit the name for an output argument, the system
-will choose a default column name.) </pd></plentry><plentry><pt><varname>argtype</varname></pt><pd>The data type(s) of the function's arguments (optionally schema-qualified),
-if any. The argument types may be base, composite, or domain types, or
-may reference the type of a table column. </pd><pd>Depending on the implementation language it may also be allowed to
-specify pseudotypes such as <codeph>cstring</codeph>. Pseudotypes indicate
-that the actual argument type is either incompletely specified, or outside
-the set of ordinary SQL data types. </pd><pd>The type of a column is referenced by writing
-                            <codeph><varname>tablename</varname>.<varname>columnname</varname>%TYPE</codeph>. Using this
-                        feature can sometimes help make a function independent of changes to the
-                        definition of a table. </pd></plentry>
-<plentry><pt><varname>defexpr</varname></pt><pd>An expression to be used as the default value if
-  the parameter is not specified. The expression must be coercible to the argument type of the
-  parameter. Only <codeph>IN</codeph> and <codeph>INOUT</codeph> parameters can have a default
-  value. Each input parameter in the argument list that follows a parameter with a default value
-  must have a default value as well.</pd></plentry>
-<plentry><pt><varname>rettype</varname></pt><pd>The return data type (optionally schema-qualified). The return type
-can be a base, composite, or domain type, or may reference the type of
-a table column. Depending on the implementation language it may also
-be allowed to specify pseudotypes such as <codeph>cstring</codeph>. If
-the function is not supposed to return a value, specify <codeph>void</codeph>
-as the return type. </pd><pd>When there are <codeph>OUT</codeph> or <codeph>INOUT</codeph> parameters,
-the <codeph>RETURNS</codeph> clause may be omitted. If present, it must
-agree with the result type implied by the output parameters: <codeph>RECORD</codeph>
-if there are multiple output parameters, or the same type as the single
-output parameter. </pd><pd>The <codeph>SETOF</codeph> modifier indicates that the function will
-return a set of items, rather than a single item. </pd><pd>The type of a column is referenced by writing
-                            <codeph><varname>tablename</varname>.<varname>columnname</varname>%TYPE</codeph>. </pd></plentry><plentry><pt><varname>langname</varname></pt><pd>The name of the language that the function is implemented in. May be <codeph>SQL</codeph>,
-                            <codeph>C</codeph>, <codeph>internal</codeph>, or the name of a
-                        user-defined procedural language. See <codeph><xref
+           } [, ...] ) ]</codeblock></section>
+        <section id="section3"><title>Description</title><p><codeph>CREATE FUNCTION</codeph> defines
+                a new function. <codeph>CREATE OR REPLACE FUNCTION</codeph> will either create a new
+                function, or replace an existing definition. </p><p>The name of the new function
+                must not match any existing function with the same argument types in the same
+                schema. However, functions of different argument types may share a name
+                (overloading). </p><p>To update the definition of an existing function, use
+                    <codeph>CREATE OR REPLACE FUNCTION</codeph>. It is not possible to change the
+                name or argument types of a function this way (this would actually create a new,
+                distinct function). Also, <codeph>CREATE OR REPLACE FUNCTION</codeph> will not let
+                you change the return type of an existing function. To do that, you must drop and
+                recreate the function. If you drop and then recreate a function, you will have to
+                drop existing objects (rules, views, triggers, and so on) that refer to the old
+                function. Use <codeph>CREATE OR REPLACE FUNCTION</codeph> to change a function
+                definition without breaking objects that refer to the function.</p><p>For more
+                information about creating functions, see the <xref
+                    href="https://www.postgresql.org/docs/8.3/static/xfunc.html" scope="external"
+                    format="html">User Defined Functions</xref> section of the PostgreSQL
+                documentation.</p><sectiondiv id="section4"><b>Limited Use of VOLATILE and STABLE
+                    Functions</b><p>To prevent data from becoming out-of-sync across the segments in
+                    Greenplum Database, any function classified as <codeph>STABLE</codeph> or
+                        <codeph>VOLATILE</codeph> cannot be executed at the segment level if it
+                    contains SQL or modifies the database in any way. For example, functions such as
+                        <codeph>random()</codeph> or <codeph>timeofday()</codeph> are not allowed to
+                    execute on distributed data in Greenplum Database because they could potentially
+                    cause inconsistent data between the segment instances.</p><p>To ensure data
+                    consistency, <codeph>VOLATILE</codeph> and <codeph>STABLE</codeph> functions can
+                    safely be used in statements that are evaluated on and execute from the master.
+                    For example, the following statements are always executed on the master
+                    (statements without a <codeph>FROM</codeph>
+                    clause):</p><codeblock>SELECT setval('myseq', 201);
+SELECT foo();</codeblock><p>In
+                    cases where a statement has a <codeph>FROM</codeph> clause containing a
+                    distributed table and the function used in the <codeph>FROM</codeph> clause
+                    simply returns a set of rows, execution may be allowed on the
+                    segments:</p><codeblock>SELECT * FROM foo();</codeblock><p>One exception to this
+                    rule are functions that return a table reference (<codeph>rangeFuncs</codeph>)
+                    or functions that use the <codeph>refCursor</codeph> data type. Note that you
+                    cannot return a <codeph>refcursor</codeph> from any kind of function in
+                    Greenplum Database.</p></sectiondiv>
+            <sectiondiv><b>Function Volitionality and EXECUTE ON Attributes</b><p>Volatility
+                    attributes (<codeph>IMMUTABLE</codeph>, <codeph>STABLE</codeph>,
+                        <codeph>VOLITILE</codeph>) and <codeph>EXECUTE ON</codeph> attributes
+                    specify two different aspects of function execution. In general, volatility
+                    indicates when the function is executed, and <codeph>EXECUTE ON</codeph>
+                    indicates where it is executed. </p><p>For example, a function defined with the
+                        <codeph>IMMUTABLE</codeph> attribute can be executed at query planning time,
+                    while a function with the <codeph>VOLATILE</codeph> attribute must be executed
+                    for every row in the query. A function with the <codeph>EXECUTE ON
+                        MASTER</codeph> attribute is executed only on the master segment and a
+                    function with the <codeph>EXECUTE ON ALL SEGMENTS</codeph> attribute is executed
+                    on all primary segment instances (not the master).</p><p>See <xref
+                        href="../../admin_guide/query/topics/functions-operators.xml#topic26/in151167"
+                        >Using Functions and Operators</xref> in the <cite>Greenplum Database
+                        Administrator Guide</cite>.</p></sectiondiv></section>
+        <section id="section5"><title>Parameters</title><parml>
+                <plentry>
+                    <pt><varname>name</varname></pt>
+                    <pd>The name (optionally schema-qualified) of the function to create.</pd>
+                </plentry>
+                <plentry>
+                    <pt><varname>argmode</varname></pt>
+                    <pd>The mode of an argument: either <codeph>IN</codeph>, <codeph>OUT</codeph>,
+                            <codeph>INOUT</codeph>, or <codeph>VARIADIC</codeph>. Only
+                            <codeph>OUT</codeph> arguments can follow an argument declared as
+                            <codeph>VARIADIC</codeph>. If omitted, the default is
+                            <codeph>IN</codeph>. </pd>
+                </plentry>
+                <plentry>
+                    <pt><varname>argname</varname></pt>
+                    <pd>The name of an argument. Some languages (currently only PL/pgSQL) let you
+                        use the name in the function body. For other languages the name of an input
+                        argument is just extra documentation. But the name of an output argument is
+                        significant, since it defines the column name in the result row type. (If
+                        you omit the name for an output argument, the system will choose a default
+                        column name.) </pd>
+                </plentry>
+                <plentry>
+                    <pt><varname>argtype</varname></pt>
+                    <pd>The data type(s) of the function's arguments (optionally schema-qualified),
+                        if any. The argument types may be base, composite, or domain types, or may
+                        reference the type of a table column. </pd>
+                    <pd>Depending on the implementation language it may also be allowed to specify
+                        pseudotypes such as <codeph>cstring</codeph>. Pseudotypes indicate that the
+                        actual argument type is either incompletely specified, or outside the set of
+                        ordinary SQL data types. </pd>
+                    <pd>The type of a column is referenced by writing
+                                <codeph><varname>tablename</varname>.<varname>columnname</varname>%TYPE</codeph>.
+                        Using this feature can sometimes help make a function independent of changes
+                        to the definition of a table. </pd>
+                </plentry>
+                <plentry>
+                    <pt><varname>defexpr</varname></pt>
+                    <pd>An expression to be used as the default value if the parameter is not
+                        specified. The expression must be coercible to the argument type of the
+                        parameter. Only <codeph>IN</codeph> and <codeph>INOUT</codeph> parameters
+                        can have a default value. Each input parameter in the argument list that
+                        follows a parameter with a default value must have a default value as
+                        well.</pd>
+                </plentry>
+                <plentry>
+                    <pt><varname>rettype</varname></pt>
+                    <pd>The return data type (optionally schema-qualified). The return type can be a
+                        base, composite, or domain type, or may reference the type of a table
+                        column. Depending on the implementation language it may also be allowed to
+                        specify pseudotypes such as <codeph>cstring</codeph>. If the function is not
+                        supposed to return a value, specify <codeph>void</codeph> as the return
+                        type. </pd>
+                    <pd>When there are <codeph>OUT</codeph> or <codeph>INOUT</codeph> parameters,
+                        the <codeph>RETURNS</codeph> clause may be omitted. If present, it must
+                        agree with the result type implied by the output parameters:
+                            <codeph>RECORD</codeph> if there are multiple output parameters, or the
+                        same type as the single output parameter. </pd>
+                    <pd>The <codeph>SETOF</codeph> modifier indicates that the function will return
+                        a set of items, rather than a single item. </pd>
+                    <pd>The type of a column is referenced by writing
+                                <codeph><varname>tablename</varname>.<varname>columnname</varname>%TYPE</codeph>.
+                    </pd>
+                </plentry>
+                <plentry>
+                    <pt><varname>langname</varname></pt>
+                    <pd>The name of the language that the function is implemented in. May be
+                            <codeph>SQL</codeph>, <codeph>C</codeph>, <codeph>internal</codeph>, or
+                        the name of a user-defined procedural language. See <codeph><xref
                                 href="./CREATE_LANGUAGE.xml#topic1" type="topic" format="dita"
                             /></codeph> for the procedural languages supported in Greenplum
                         Database. For backward compatibility, the name may be enclosed by single
-                        quotes. </pd></plentry><plentry><pt>IMMUTABLE</pt><pt>STABLE</pt><pt>VOLATILE</pt><pd>These attributes inform the query optimizer about the behavior of
-the function. At most one choice may be specified. If none of these appear,
-<codeph>VOLATILE</codeph> is the default assumption. Since Greenplum
-Database currently has limited use of <codeph>VOLATILE</codeph> functions,
-if a function is truly <codeph>IMMUTABLE</codeph>, you must declare it
-as so to be able to use it without restrictions.</pd><pd><codeph>IMMUTABLE</codeph> indicates that the function cannot modify
-the database and always returns the same result when given the same argument
-values. It does not do database lookups or otherwise use information
-not directly present in its argument list. If this option is given, any
-call of the function with all-constant arguments can be immediately replaced
-with the function value.</pd><pd><codeph>STABLE</codeph> indicates that the function cannot modify
-the database, and that within a single table scan it will consistently
-return the same result for the same argument values, but that its result
-could change across SQL statements. This is the appropriate selection
-for functions whose results depend on database lookups, parameter values
-(such as the current time zone), and so on. Also note that the <varname>current_timestamp</varname>
-family of functions qualify as stable, since their values do not change
-within a transaction.</pd><pd><codeph>VOLATILE</codeph> indicates that the function value can change
-even within a single table scan, so no optimizations can be made. Relatively
-few database functions are volatile in this sense; some examples are
-<codeph>random()</codeph>, <codeph>timeofday()</codeph>.
-But note that any function that has side-effects must be classified volatile,
-even if its result is quite predictable, to prevent calls from being
-optimized away; an example is <codeph>setval()</codeph>.</pd></plentry><plentry><pt>CALLED ON NULL INPUT</pt><pt>RETURNS NULL ON NULL INPUT</pt><pt>STRICT</pt><pd><codeph>CALLED ON NULL INPUT</codeph> (the default) indicates that
-the function will be called normally when some of its arguments are null.
-It is then the function author's responsibility to check for null values
-if necessary and respond appropriately. <codeph>RETURNS NULL ON NULL
-INPUT</codeph> or <codeph>STRICT</codeph> indicates that the function
-always returns null whenever any of its arguments are null. If this parameter
-is specified, the function is not executed when there are null arguments;
-instead a null result is assumed automatically.</pd></plentry><plentry><pt>[EXTERNAL] SECURITY INVOKER</pt><pt>[EXTERNAL] SECURITY DEFINER</pt><pd><codeph>SECURITY INVOKER</codeph> (the default) indicates that the
-function is to be executed with the privileges of the user that calls
-it. <codeph>SECURITY DEFINER</codeph> specifies that the function is
-to be executed with the privileges of the user that created it. The key
-word <codeph>EXTERNAL</codeph> is allowed for SQL conformance, but it
-is optional since, unlike in SQL, this feature applies to all functions
-not just external ones.</pd></plentry>
+                        quotes. </pd>
+                </plentry>
+                <plentry>
+                    <pt>IMMUTABLE</pt>
+                    <pt>STABLE</pt>
+                    <pt>VOLATILE</pt>
+                    <pd>These attributes inform the query optimizer about the behavior of the
+                        function. At most one choice may be specified. If none of these appear,
+                            <codeph>VOLATILE</codeph> is the default assumption. Since Greenplum
+                        Database currently has limited use of <codeph>VOLATILE</codeph> functions,
+                        if a function is truly <codeph>IMMUTABLE</codeph>, you must declare it as so
+                        to be able to use it without restrictions.</pd>
+                    <pd><codeph>IMMUTABLE</codeph> indicates that the function cannot modify the
+                        database and always returns the same result when given the same argument
+                        values. It does not do database lookups or otherwise use information not
+                        directly present in its argument list. If this option is given, any call of
+                        the function with all-constant arguments can be immediately replaced with
+                        the function value.</pd>
+                    <pd><codeph>STABLE</codeph> indicates that the function cannot modify the
+                        database, and that within a single table scan it will consistently return
+                        the same result for the same argument values, but that its result could
+                        change across SQL statements. This is the appropriate selection for
+                        functions whose results depend on database lookups, parameter values (such
+                        as the current time zone), and so on. Also note that the
+                            <varname>current_timestamp</varname> family of functions qualify as
+                        stable, since their values do not change within a transaction.</pd>
+                    <pd><codeph>VOLATILE</codeph> indicates that the function value can change even
+                        within a single table scan, so no optimizations can be made. Relatively few
+                        database functions are volatile in this sense; some examples are
+                            <codeph>random()</codeph>, <codeph>timeofday()</codeph>. But note that
+                        any function that has side-effects must be classified volatile, even if its
+                        result is quite predictable, to prevent calls from being optimized away; an
+                        example is <codeph>setval()</codeph>.</pd>
+                </plentry>
+                <plentry>
+                    <pt>CALLED ON NULL INPUT</pt>
+                    <pt>RETURNS NULL ON NULL INPUT</pt>
+                    <pt>STRICT</pt>
+                    <pd><codeph>CALLED ON NULL INPUT</codeph> (the default) indicates that the
+                        function will be called normally when some of its arguments are null. It is
+                        then the function author's responsibility to check for null values if
+                        necessary and respond appropriately. <codeph>RETURNS NULL ON NULL
+                            INPUT</codeph> or <codeph>STRICT</codeph> indicates that the function
+                        always returns null whenever any of its arguments are null. If this
+                        parameter is specified, the function is not executed when there are null
+                        arguments; instead a null result is assumed automatically.</pd>
+                </plentry>
+                <plentry>
+                    <pt>[EXTERNAL] SECURITY INVOKER</pt>
+                    <pt>[EXTERNAL] SECURITY DEFINER</pt>
+                    <pd><codeph>SECURITY INVOKER</codeph> (the default) indicates that the function
+                        is to be executed with the privileges of the user that calls it.
+                            <codeph>SECURITY DEFINER</codeph> specifies that the function is to be
+                        executed with the privileges of the user that created it. The key word
+                            <codeph>EXTERNAL</codeph> is allowed for SQL conformance, but it is
+                        optional since, unlike in SQL, this feature applies to all functions not
+                        just external ones.</pd>
+                </plentry>
 
-  <plentry>
-    <pt>EXECUTE ON ANY</pt>
-    <pt>EXECUTE ON MASTER</pt>
-    <pt>EXECUTE ON ALL SEGMENTS</pt>
+                <plentry>
+                    <pt>EXECUTE ON ANY</pt>
+                    <pt>EXECUTE ON MASTER</pt>
+                    <pt>EXECUTE ON ALL SEGMENTS</pt>
+                    <pd>The <codeph>EXECUTE ON</codeph> attributes specify where (master or segment
+                        instance) a function is executed when it is invoked during the query
+                        execution process.</pd>
+                    <pd><codeph>EXECUTE ON ANY</codeph> (the default) indicates that the function
+                        can be executed on the master, or any segment instance, and it returns the
+                        same result regardless of where it is executed. Greenplum Database
+                        determines where the function is executed.</pd>
+                    <pd><codeph>EXECUTE ON MASTER</codeph> indicates that the function must be
+                        executed on the master instance. </pd>
+                    <pd><codeph>EXECUTE ON ALL SEGMENTS</codeph> indicates that the function must be
+                        executed on all primary segment instances, but not the master, for each
+                        invocation. The overall result of the function is the <codeph>UNION
+                            ALL</codeph> of the results from all segment instances. </pd>
+                    <pd>For information about using <codeph>EXECUTE ON</codeph> attributes, see
+                            <xref href="#topic1/section6" format="dita">Notes</xref>.</pd>
+                </plentry>
 
-    <pd>
-      <codeph>EXECUTE ON ANY</codeph> (the default) indicates that
-      the function may be executed on the master, or any segment instance,
-      and it will return the same result regardless of where it is executed.
-    </pd>
-
-    <pd>
-      <codeph>EXECUTE ON MASTER</codeph> indicates that the function
-      must be executed on the master instance.
-    </pd>
-
-    <pd>
-      <codeph>EXECUTE ON ALL SEGMENTS</codeph> indicates that the
-      function must be executed on all segment instances. The overall
-      result of the function is the UNION ALL of the results from all
-      segment instances.
-    </pd>
-
-    <pd>
-      <codeph>ON MASTER</codeph> and <codeph>ALL SEGMENTS</codeph> are
-      only allowed on set-returning functions. Note that executing queries
-      that access any tables is only supported when a function is executed
-      on the master. Such functions should be marked as <codeph>EXECUTE
-      ON MASTER</codeph>. Otherwise, you might get an error if the function
-      is used in a complicated query, and the planner thinks it would be
-      beneficial to push the function invocation to the segment instances.
-    </pd>
-  </plentry>
-
-  <plentry> <pt>COST <varname>execution_cost</varname></pt>
-<pd>A positive number identifying the estimated execution cost for the function,
-in <xref href="https://www.postgresql.org/docs/8.3/static/runtime-config-query.html#GUC-CPU-OPERATOR-COST" scope="external" format="html">cpu_operator_cost</xref> units.
-If the function returns a set, <varname>execution_cost</varname> identifies the
-cost per returned row. If the cost is not specified, C-language and internal
-functions default to 1 unit, while functions in other languages default to 100 
-units. The planner tries to evaluate the function less often when you specify
-larger <varname>execution_cost</varname> values.</pd></plentry>
+                <plentry>
+                    <pt>COST <varname>execution_cost</varname></pt>
+                    <pd>A positive number identifying the estimated execution cost for the function,
+                        in <xref
+                            href="https://www.postgresql.org/docs/8.3/static/runtime-config-query.html#GUC-CPU-OPERATOR-COST"
+                            scope="external" format="html">cpu_operator_cost</xref> units. If the
+                        function returns a set, <varname>execution_cost</varname> identifies the
+                        cost per returned row. If the cost is not specified, C-language and internal
+                        functions default to 1 unit, while functions in other languages default to
+                        100 units. The planner tries to evaluate the function less often when you
+                        specify larger <varname>execution_cost</varname> values.</pd>
+                </plentry>
                 <plentry>
                     <pt><varname>configuration_parameter</varname></pt>
                     <pt><varname>value</varname></pt>
@@ -173,60 +249,77 @@ larger <varname>execution_cost</varname> values.</pd></plentry>
                         restored to its prior value when the function exits. <codeph>SET FROM
                             CURRENT</codeph> applies the session's current value of the parameter
                         when the function is entered.</pd>
-                </plentry><plentry><pt><varname>definition</varname></pt><pd>A string constant defining the function; the meaning depends on the
-language. It may be an internal function name, the path to an object
-file, an SQL command, or text in a procedural language.</pd></plentry><plentry><pt><varname>obj_file, link_symbol</varname></pt><pd>This form of the <codeph>AS</codeph> clause is used for dynamically
-loadable C language functions when the function name in the C language
-source code is not the same as the name of the SQL function. The string
-<varname>obj_file</varname> is the name of the file containing the dynamically loadable
-object, and <varname>link_symbol</varname> is the name of the function in the C language
-source code. If the link symbol is omitted, it is assumed to be the same
-as the name of the SQL function being defined. It is recommended to locate
-shared libraries either relative to <codeph>$libdir</codeph> (which is
-located at <codeph>$GPHOME/lib</codeph>) or through the dynamic library
-path (set by the <codeph>dynamic_library_path</codeph> server configuration
-parameter). This simplifies version upgrades if the new installation
-is at a different location.</pd></plentry><plentry><pt><varname>describe_function</varname></pt><pd>The name of a callback function to execute when a query that calls
-this function is parsed. The callback function returns a tuple descriptor
-that indicates the result type.</pd></plentry></parml></section><section id="section6"><title>Notes</title><p>Any compiled code (shared library files) for custom functions must be
-placed in the same location on every host in your Greenplum Database
-array (master and all segments). This location must also be in the <codeph>LD_LIBRARY_PATH</codeph>
-so that the server can locate the files. It is recommended to locate
-shared libraries either relative to <codeph>$libdir</codeph> (which is
-located at <codeph>$GPHOME/lib</codeph>) or through the dynamic library
-path (set by the <codeph>dynamic_library_path</codeph> server configuration
-parameter) on all master segment instances in the Greenplum array.</p><p>The full SQL type syntax is allowed for input arguments and return
-value. However, some details of the type specification (such as the precision
-field for type <varname>numeric</varname>) are the responsibility of the underlying
-function implementation and are not recognized or enforced by the <codeph>CREATE
-FUNCTION</codeph> command. </p><p>Greenplum Database allows function overloading. The same name can
-be used for several different functions so long as they have distinct
-argument types. However, the C names of all functions must be different,
-so you must give overloaded C functions different C names (for example,
-use the argument types as part of the C names). </p><p>Two functions are considered the same if they have the same names
-and input argument types, ignoring any <codeph>OUT</codeph> parameters. Thus for example
-these declarations conflict:</p><codeblock>CREATE FUNCTION foo(int) ...
+                </plentry>
+                <plentry>
+                    <pt><varname>definition</varname></pt>
+                    <pd>A string constant defining the function; the meaning depends on the
+                        language. It may be an internal function name, the path to an object file,
+                        an SQL command, or text in a procedural language.</pd>
+                </plentry>
+                <plentry>
+                    <pt><varname>obj_file, link_symbol</varname></pt>
+                    <pd>This form of the <codeph>AS</codeph> clause is used for dynamically loadable
+                        C language functions when the function name in the C language source code is
+                        not the same as the name of the SQL function. The string
+                            <varname>obj_file</varname> is the name of the file containing the
+                        dynamically loadable object, and <varname>link_symbol</varname> is the name
+                        of the function in the C language source code. If the link symbol is
+                        omitted, it is assumed to be the same as the name of the SQL function being
+                        defined. It is recommended to locate shared libraries either relative to
+                            <codeph>$libdir</codeph> (which is located at
+                            <codeph>$GPHOME/lib</codeph>) or through the dynamic library path (set
+                        by the <codeph>dynamic_library_path</codeph> server configuration
+                        parameter). This simplifies version upgrades if the new installation is at a
+                        different location.</pd>
+                </plentry>
+                <plentry>
+                    <pt><varname>describe_function</varname></pt>
+                    <pd>The name of a callback function to execute when a query that calls this
+                        function is parsed. The callback function returns a tuple descriptor that
+                        indicates the result type.</pd>
+                </plentry>
+            </parml></section>
+        <section id="section6"><title>Notes</title><p>Any compiled code (shared library files) for
+                custom functions must be placed in the same location on every host in your Greenplum
+                Database array (master and all segments). This location must also be in the
+                    <codeph>LD_LIBRARY_PATH</codeph> so that the server can locate the files. It is
+                recommended to locate shared libraries either relative to <codeph>$libdir</codeph>
+                (which is located at <codeph>$GPHOME/lib</codeph>) or through the dynamic library
+                path (set by the <codeph>dynamic_library_path</codeph> server configuration
+                parameter) on all master segment instances in the Greenplum array.</p><p>The full
+                SQL type syntax is allowed for input arguments and return value. However, some
+                details of the type specification (such as the precision field for type
+                    <varname>numeric</varname>) are the responsibility of the underlying function
+                implementation and are not recognized or enforced by the <codeph>CREATE
+                    FUNCTION</codeph> command. </p><p>Greenplum Database allows function
+                overloading. The same name can be used for several different functions so long as
+                they have distinct argument types. However, the C names of all functions must be
+                different, so you must give overloaded C functions different C names (for example,
+                use the argument types as part of the C names). </p><p>Two functions are considered
+                the same if they have the same names and input argument types, ignoring any
+                    <codeph>OUT</codeph> parameters. Thus for example these declarations
+                conflict:</p><codeblock>CREATE FUNCTION foo(int) ...
 CREATE FUNCTION foo(int, out text) ...</codeblock>
-<p>Functions that have different argument type lists are not considered to conflict at
-creation time, but if argument defaults are provided, they might conflict in use.
-For example, consider:</p><codeblock>CREATE FUNCTION foo(int) ...
+            <p>Functions that have different argument type lists are not considered to conflict at
+                creation time, but if argument defaults are provided, they might conflict in use.
+                For example, consider:</p><codeblock>CREATE FUNCTION foo(int) ...
 CREATE FUNCTION foo(int, int default 42) ...</codeblock>
-<p>The call <codeph>foo(10)</codeph>, will fail due to the ambiguity about which function should
-be called.</p>
-<p>When repeated <codeph>CREATE FUNCTION</codeph> calls refer to the same
-object file, the file is only loaded once. To unload and reload the file,
-use the <codeph>LOAD</codeph> command. </p><p>You must have the <codeph>USAGE</codeph> privilege on a language to be able to define a function using that language.</p>
-<p>It is often helpful to use dollar quoting to write the function definition
-string, rather than the normal single quote syntax. Without dollar quoting,
-any single quotes or backslashes in the function definition must be escaped
-by doubling them. A dollar-quoted string constant consists of a dollar
-sign (<codeph>$</codeph>), an optional tag of zero or more characters,
-another dollar sign, an arbitrary sequence of characters that makes up
-the string content, a dollar sign, the same tag that began this dollar
-quote, and a dollar sign. Inside the dollar-quoted string, single quotes,
-backslashes, or any character can be used without escaping. The string
-content is always written literally. For example, here are two different
-ways to specify the string "Dianne's horse" using dollar quoting:</p><codeblock>$$Dianne's horse$$
+            <p>The call <codeph>foo(10)</codeph>, will fail due to the ambiguity about which
+                function should be called.</p>
+            <p>When repeated <codeph>CREATE FUNCTION</codeph> calls refer to the same object file,
+                the file is only loaded once. To unload and reload the file, use the
+                    <codeph>LOAD</codeph> command. </p><p>You must have the <codeph>USAGE</codeph>
+                privilege on a language to be able to define a function using that language.</p>
+            <p>It is often helpful to use dollar quoting to write the function definition string,
+                rather than the normal single quote syntax. Without dollar quoting, any single
+                quotes or backslashes in the function definition must be escaped by doubling them. A
+                dollar-quoted string constant consists of a dollar sign (<codeph>$</codeph>), an
+                optional tag of zero or more characters, another dollar sign, an arbitrary sequence
+                of characters that makes up the string content, a dollar sign, the same tag that
+                began this dollar quote, and a dollar sign. Inside the dollar-quoted string, single
+                quotes, backslashes, or any character can be used without escaping. The string
+                content is always written literally. For example, here are two different ways to
+                specify the string "Dianne's horse" using dollar quoting:</p><codeblock>$$Dianne's horse$$
 $SomeTag$Dianne's horse$SomeTag$</codeblock>
             <p>If a <codeph>SET</codeph> clause is attached to a function, the effects of a
                     <codeph>SET LOCAL</codeph> command executed inside the function for the same
@@ -238,26 +331,58 @@ $SomeTag$Dianne's horse$SomeTag$</codeblock>
                     LOCAL</codeph> command. The effects of such a command will persist after the
                 function exits, unless the current transaction is rolled back.</p>
             <p>If a function with a <codeph>VARIADIC</codeph> argument is declared as
-              <codeph>STRICT</codeph>, the strictness check tests that the variadic array as a
-               whole is non-null. PL/pgSQL will still call the function if the array has null
-               elements.</p>
-<sectiondiv id="section7"><b>Using Functions With Queries on Distributed Data</b><p>In some cases, Greenplum Database does not support using functions in
-a query where the data in a table specified in the <codeph>FROM</codeph>
-clause is distributed over Greenplum Database segments. As an example,
-this SQL query contains the function <codeph>func()</codeph>:</p><codeblock>SELECT func(a) FROM table1;</codeblock><p>The function is not supported for use in the query if all of the following
-conditions are met:</p><ul><li id="bs144942">The data of table <codeph>table1</codeph> is distributed over Greenplum
-Database segments.</li><li id="bs144694">The function <codeph>func()</codeph> reads or modifies data from distributed
-tables. </li><li id="bs145327">The function <codeph>func()</codeph> returns more than one row or takes
-an argument (<codeph>a</codeph>) that comes from <codeph>table1</codeph>.</li></ul><p>If any of the conditions are not met, the function is supported. Specifically,
-the function is supported if any of the following conditions apply:</p><ul><li id="bs144699">The function <codeph>func()</codeph> does not access data from distributed
-tables, or accesses data that is only on the Greenplum Database master.
-</li><li id="bs144700">The table <codeph>table1</codeph> is a master only table.</li><li id="bs144701">The function <codeph>func()</codeph> returns only one row and only takes
-input arguments that are constant values. The function is supported if
-it can be changed to require no input arguments.</li></ul></sectiondiv></section><section id="section8"><title>Examples</title><p>A very simple addition function:</p><codeblock>CREATE FUNCTION add(integer, integer) RETURNS integer
+                    <codeph>STRICT</codeph>, the strictness check tests that the variadic array as a
+                whole is non-null. PL/pgSQL will still call the function if the array has null
+                elements.</p>
+            <sectiondiv id="section7"><b>Using Functions with Queries on Distributed Data</b><p>In
+                    some cases, Greenplum Database does not support using functions in a query where
+                    the data in a table specified in the <codeph>FROM</codeph> clause is distributed
+                    over Greenplum Database segments. As an example, this SQL query contains the
+                    function
+                    <codeph>func()</codeph>:</p><codeblock>SELECT func(a) FROM table1;</codeblock><p>The
+                    function is not supported for use in the query if all of the following
+                    conditions are met:</p><ul>
+                    <li id="bs144942">The data of table <codeph>table1</codeph> is distributed over
+                        Greenplum Database segments.</li>
+                    <li id="bs144694">The function <codeph>func()</codeph> reads or modifies data
+                        from distributed tables. </li>
+                    <li id="bs145327">The function <codeph>func()</codeph> returns more than one row
+                        or takes an argument (<codeph>a</codeph>) that comes from
+                            <codeph>table1</codeph>.</li>
+                </ul><p>If any of the conditions are not met, the function is supported.
+                    Specifically, the function is supported if any of the following conditions
+                    apply:</p><ul>
+                    <li id="bs144699">The function <codeph>func()</codeph> does not access data from
+                        distributed tables, or accesses data that is only on the Greenplum Database
+                        master. </li>
+                    <li id="bs144700">The table <codeph>table1</codeph> is a master only table.</li>
+                    <li id="bs144701">The function <codeph>func()</codeph> returns only one row and
+                        only takes input arguments that are constant values. The function is
+                        supported if it can be changed to require no input arguments.</li>
+                </ul></sectiondiv>
+            <sectiondiv><b>Using EXECUTE ON attributes</b><p>A function that executes queries to
+                    access tables is only supported when a function is executed on the master. Such
+                    functions should be defined with the <codeph>EXECUTE ON MASTER</codeph>
+                    attribute. Otherwise, the function might return incorrect results when the
+                    function is used in a complicated query. Without the attribute, planner
+                    optimization might determine it would be beneficial to push the function
+                    invocation to segment instances.</p>These are limitations for functions defined
+                with the <codeph>EXECUTE ON MASTER</codeph> or <codeph>EXECUTE ON ALL
+                    SEGMENTS</codeph> attribute:<ul id="ul_nlg_jky_fcb">
+                    <li>The function must be a set-returning function.</li>
+                    <li>The function cannot be in the <codeph>FROM</codeph> clause of a query.</li>
+                    <li>The function cannot be in the <codeph>SELECT</codeph> list of a query with a
+                            <codeph>FROM</codeph> clause.</li>
+                    <li>A query that includes the function falls back from GPORCA to the legacy
+                        query planner.</li>
+                </ul></sectiondiv></section>
+        <section id="section8"><title>Examples</title><p>A very simple addition
+                function:</p><codeblock>CREATE FUNCTION add(integer, integer) RETURNS integer
     AS 'select $1 + $2;'
     LANGUAGE SQL
     IMMUTABLE
-    RETURNS NULL ON NULL INPUT;</codeblock><p>Increment an integer, making use of an argument name, in PL/pgSQL:</p><codeblock>CREATE OR REPLACE FUNCTION increment(i integer) RETURNS 
+    RETURNS NULL ON NULL INPUT;</codeblock><p>Increment
+                an integer, making use of an argument name, in PL/pgSQL:</p><codeblock>CREATE OR REPLACE FUNCTION increment(i integer) RETURNS 
 integer AS $$
         BEGIN
                 RETURN i + 1;
@@ -278,21 +403,42 @@ CREATE FUNCTION return_enum_as_array( anyenum, anyelement, anyelement )
     RETURNS TABLE (ae anyenum, aa anyarray) AS $$
     SELECT $1, array[$2, $3] 
 $$ LANGUAGE SQL STABLE;
-SELECT * FROM return_enum_as_array('red'::rainbow, 'green'::rainbow, 'blue'::rainbow);</codeblock><p>Return a record containing multiple output parameters:</p><codeblock>CREATE FUNCTION dup(in int, out f1 int, out f2 text)
+
+SELECT * FROM return_enum_as_array('red'::rainbow, 'green'::rainbow, 'blue'::rainbow);</codeblock><p>Return
+                a record containing multiple output
+                parameters:</p><codeblock>CREATE FUNCTION dup(in int, out f1 int, out f2 text)
     AS $$ SELECT $1, CAST($1 AS text) || ' is text' $$
     LANGUAGE SQL;
-SELECT * FROM dup(42);</codeblock><p>You can do the same thing more verbosely with an explicitly named composite
-type:</p><codeblock>CREATE TYPE dup_result AS (f1 int, f2 text);
+
+SELECT * FROM dup(42);</codeblock><p>You
+                can do the same thing more verbosely with an explicitly named composite type:</p><codeblock>CREATE TYPE dup_result AS (f1 int, f2 text);
 CREATE FUNCTION dup(int) RETURNS dup_result
     AS $$ SELECT $1, CAST($1 AS text) || ' is text' $$
     LANGUAGE SQL;
-SELECT * FROM dup(42);</codeblock></section><section id="section9"><title>Compatibility</title><p><codeph>CREATE FUNCTION</codeph> is defined in SQL:1999 and later. The
-Greenplum Database version is similar but not fully compatible. The attributes
-are not portable, neither are the different available languages. </p><p>For compatibility with some other database systems, <varname>argmode</varname>
-can be written either before or after <varname>argname</varname>. But only the first
-way is standard-compliant. </p>
-<p>The SQL standard does not specify parameter defaults.</p>
-</section><section id="section10"><title>See Also</title><p><codeph><xref href="ALTER_FUNCTION.xml#topic1" type="topic" format="dita"/></codeph>,
+
+SELECT * FROM dup(42);</codeblock>
+            <p>This function is defined with the <codeph>EXECUTE ON ALL SEGMENTS</codeph> to run on
+                all primary segment instances. The <codeph>SELECT</codeph> command executes the
+                function that returns the time it was run on each segment
+                instance.<codeblock>CREATE FUNCTION run_on_segs (text) returns setof text as $$
+  begin 
+    return next ($1 || ' - ' || now()::text ); 
+  end;
+ $$ language plpgsql VOLITILE EXECUTE ON ALL SEGMENTS;
+
+SELECT run_on_segs('my test');</codeblock></p></section>
+        <section id="section9"><title>Compatibility</title><p><codeph>CREATE FUNCTION</codeph> is
+                defined in SQL:1999 and later. The Greenplum Database version is similar but not
+                fully compatible. The attributes are not portable, neither are the different
+                available languages. </p><p>For compatibility with some other database systems,
+                    <varname>argmode</varname> can be written either before or after
+                    <varname>argname</varname>. But only the first way is standard-compliant. </p>
+            <p>The SQL standard does not specify parameter defaults.</p>
+        </section>
+        <section id="section10"><title>See Also</title><p><codeph><xref
+                        href="ALTER_FUNCTION.xml#topic1" type="topic" format="dita"/></codeph>,
                         <codeph><xref href="./DROP_FUNCTION.xml#topic1" type="topic" format="dita"
                     /></codeph>, <codeph><xref href="./LOAD.xml#topic1" type="topic" format="dita"
-                    /></codeph></p></section></body></topic>
+                    /></codeph></p></section>
+    </body>
+</topic>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_FUNCTION.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_FUNCTION.xml
@@ -64,7 +64,7 @@ SELECT foo();</codeblock><p>In
                     Greenplum Database.</p></sectiondiv>
             <sectiondiv><b>Function Volitionality and EXECUTE ON Attributes</b><p>Volatility
                     attributes (<codeph>IMMUTABLE</codeph>, <codeph>STABLE</codeph>,
-                        <codeph>VOLITILE</codeph>) and <codeph>EXECUTE ON</codeph> attributes
+                        <codeph>VOLATILE</codeph>) and <codeph>EXECUTE ON</codeph> attributes
                     specify two different aspects of function execution. In general, volatility
                     indicates when the function is executed, and <codeph>EXECUTE ON</codeph>
                     indicates where it is executed. </p><p>For example, a function defined with the
@@ -213,16 +213,16 @@ SELECT foo();</codeblock><p>In
                     <pt>EXECUTE ON MASTER</pt>
                     <pt>EXECUTE ON ALL SEGMENTS</pt>
                     <pd>The <codeph>EXECUTE ON</codeph> attributes specify where (master or segment
-                        instance) a function is executed when it is invoked during the query
-                        execution process.</pd>
+                        instance) a function executes when it is invoked during the query execution
+                        process.</pd>
                     <pd><codeph>EXECUTE ON ANY</codeph> (the default) indicates that the function
                         can be executed on the master, or any segment instance, and it returns the
                         same result regardless of where it is executed. Greenplum Database
-                        determines where the function is executed.</pd>
-                    <pd><codeph>EXECUTE ON MASTER</codeph> indicates that the function must be
-                        executed on the master instance. </pd>
-                    <pd><codeph>EXECUTE ON ALL SEGMENTS</codeph> indicates that the function must be
-                        executed on all primary segment instances, but not the master, for each
+                        determines where the function executes.</pd>
+                    <pd><codeph>EXECUTE ON MASTER</codeph> indicates that the function must execute
+                        only on the master instance. </pd>
+                    <pd><codeph>EXECUTE ON ALL SEGMENTS</codeph> indicates that the function must
+                        execute on all primary segment instances, but not the master, for each
                         invocation. The overall result of the function is the <codeph>UNION
                             ALL</codeph> of the results from all segment instances. </pd>
                     <pd>For information about using <codeph>EXECUTE ON</codeph> attributes, see
@@ -424,7 +424,7 @@ SELECT * FROM dup(42);</codeblock>
   begin 
     return next ($1 || ' - ' || now()::text ); 
   end;
- $$ language plpgsql VOLITILE EXECUTE ON ALL SEGMENTS;
+ $$ language plpgsql VOLATILE EXECUTE ON ALL SEGMENTS;
 
 SELECT run_on_segs('my test');</codeblock></p></section>
         <section id="section9"><title>Compatibility</title><p><codeph>CREATE FUNCTION</codeph> is

--- a/gpdb-doc/dita/ref_guide/sql_commands/DO.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/DO.xml
@@ -17,7 +17,7 @@
         returning void. It is parsed and executed a single time.</p>
       <p>The optional <codeph>LANGUAGE</codeph> clause can appear either before or after the code
         block.</p>
-      <p> Anonymous blocks are procedural language structures that provide the capability to create
+      <p>Anonymous blocks are procedural language structures that provide the capability to create
         and execute procedural code on the fly without persistently storing the code as database
         objects in the system catalogs. The concept of anonymous blocks is similar to UNIX shell
         scripts, which enable several manually entered commands to be grouped and executed as one
@@ -58,12 +58,15 @@
     <section id="section5">
       <title>Notes</title>
       <p>The PL/pgSQL language is installed on the Greenplum Database system and is registered in a
-        user created database. The PL/Python language is installed by default, but not registered. Other languages are
-        not installed or registered. The system catalog <codeph>pg_language</codeph> contains
-        information about the registered languages in a database.</p>
+        user created database. The PL/Python and PL/Perl languages are installed by default, but not
+        registered. Other languages are not installed or registered. The system catalog
+          <codeph>pg_language</codeph> contains information about the registered languages in a
+        database.</p>
       <p>The user must have <codeph>USAGE</codeph> privilege for the procedural language, or must be
         a superuser if the language is untrusted. This is the same privilege requirement as for
         creating a function in the language.</p>
+      <p>Anonymous blocks do not support function volatility or <codeph>EXECUTE ON</codeph>
+        attributes.</p>
     </section>
     <section>
       <title>Examples</title>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_proc.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_proc.xml
@@ -69,7 +69,7 @@
             </entry>
             <entry colname="col2">float4</entry>
             <entry colname="col3"/>
-            <entry colname="col4">Estimated execution cost (in cpu_operator_cost units); if 
+            <entry colname="col4">Estimated execution cost (in cpu_operator_cost units); if
               proretset is <codeph>true</codeph>, identifies the cost per row returned.</entry>
           </row>
           <row>
@@ -86,8 +86,8 @@
             </entry>
             <entry colname="col2">oid</entry>
             <entry colname="col3">pg_type.oid</entry>
-            <entry colname="col4">Data type of the variadic array parameter's elements, or zero
-              if the function does not have a variadic parameter.</entry>
+            <entry colname="col4">Data type of the variadic array parameter's elements, or zero if
+              the function does not have a variadic parameter.</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -177,9 +177,9 @@
             <entry colname="col2">oidvector</entry>
             <entry colname="col3">pg_type.oid</entry>
             <entry colname="col4">An array with the data types of the function arguments. This
-              includes only input arguments (including <codeph>INOUT</codeph> and 
-              <codeph>VARIADIC</codeph> arguments), and thus
-              represents the call signature of the function.</entry>
+              includes only input arguments (including <codeph>INOUT</codeph> and
+                <codeph>VARIADIC</codeph> arguments), and thus represents the call signature of the
+              function.</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -201,10 +201,10 @@
             <entry colname="col3"/>
             <entry colname="col4">An array with the modes of the function arguments:
                 <codeph>i</codeph> = <codeph>IN</codeph>, <codeph>o</codeph> = <codeph>OUT</codeph>
-              , <codeph>b</codeph> = <codeph>INOUT</codeph>, <codeph>v</codeph> = 
-              <codeph>VARIADIC</codeph>. If all the arguments are IN arguments,
-              this field will be null. Note that subscripts correspond to positions of
-              proallargtypes not proargtypes.</entry>
+              , <codeph>b</codeph> = <codeph>INOUT</codeph>, <codeph>v</codeph> =
+                <codeph>VARIADIC</codeph>. If all the arguments are IN arguments, this field will be
+              null. Note that subscripts correspond to positions of proallargtypes not
+              proargtypes.</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -223,11 +223,10 @@
             </entry>
             <entry colname="col2"> text </entry>
             <entry colname="col3"/>
-            <entry colname="col4">Expression trees for default argument values. This is a list with 
-              pronargdefaults elements, corresponding to the last
-              <varname>N</varname> input arguments (i.e., the last <varname>N</varname>
-              proargtypes positions). If none of the arguments have defaults,
-              this field is empty.</entry>
+            <entry colname="col4">Expression trees for default argument values. This is a list with
+              pronargdefaults elements, corresponding to the last <varname>N</varname> input
+              arguments (i.e., the last <varname>N</varname> proargtypes positions). If none of the
+              arguments have defaults, this field is empty.</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -250,6 +249,13 @@
               the interpretation is language-specific.</entry>
           </row>
           <row>
+            <entry colname="col1"><codeph>proconfig</codeph></entry>
+            <entry colname="col2">text[]</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">An array with runtime configuration variable settings that are
+              local to function execution.</entry>
+          </row>
+          <row>
             <entry colname="col1">
               <codeph>proacl</codeph>
             </entry>
@@ -257,6 +263,23 @@
             <entry colname="col3"/>
             <entry colname="col4">Access privileges for the function as given by
                 <codeph>GRANT</codeph>/<codeph>REVOKE</codeph>.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>prodataaccess</codeph></entry>
+            <entry colname="col2">char</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Provides a hint regarding the type SQL statements that are
+              included in the function: <codeph>n</codeph> - does not contain SQL,
+                <codeph>c</codeph> - contains SQL, <codeph>r</codeph> - contains SQL that reads
+              data, <codeph>m</codeph> - contains SQL that modifies data</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>proexeclocation</codeph></entry>
+            <entry colname="col2">char</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Where the function is executed when it is invoked:
+                <codeph>m</codeph> - master only, <codeph>a</codeph> - any segment instance,
+                <codeph>s</codeph> - all segment instances.</entry>
           </row>
         </tbody>
       </tgroup>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_proc.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_proc.xml
@@ -277,9 +277,9 @@
             <entry colname="col1"><codeph>proexeclocation</codeph></entry>
             <entry colname="col2">char</entry>
             <entry colname="col3"/>
-            <entry colname="col4">Where the function is executed when it is invoked:
-                <codeph>m</codeph> - master only, <codeph>a</codeph> - any segment instance,
-                <codeph>s</codeph> - all segment instances.</entry>
+            <entry colname="col4">Where the function executes when it is invoked: <codeph>m</codeph>
+              - master only, <codeph>a</codeph> - any segment instance, <codeph>s</codeph> - all
+              segment instances.</entry>
           </row>
         </tbody>
       </tgroup>


### PR DESCRIPTION
updated docs for EXECUTE ON attributes.
Changes with links to HTML on GPDB review site.

Updated EXECUTE ON attributes in:
[CREATE FUNCTION](http://docs-gpdb-review-staging.cfapps.io/540/ref_guide/sql_commands/CREATE_FUNCTION.html)
[ALTER FUNCTION](http://docs-gpdb-review-staging.cfapps.io/540/ref_guide/sql_commands/ALTER_FUNCTION.html)

Added statement that volatility and EXECUTE ON attributes not supported in DO command.
[DO command](http://docs-gpdb-review-staging.cfapps.io/540/ref_guide/sql_commands/DO.html)

Incorporated EXECUTE ON information to Functions and Operators. 
[Functions and Operators](http://docs-gpdb-review-staging.cfapps.io/540/admin_guide/query/topics/functions-operators.html)

Added EXECUTE ON limitation to GPORCA Limitations.

[GPORCA Limitations](http://docs-gpdb-review-staging.cfapps.io/540/admin_guide/query/topics/query-piv-opt-limitations.html)

Updated PL/Python, PL/Perl examples to use attributes.
[PL/Perl](http://docs-gpdb-review-staging.cfapps.io/540/ref_guide/extensions/pl_perl.html)
[PL/Python](http://docs-gpdb-review-staging.cfapps.io/540/ref_guide/extensions/pl_python.html)

Updated g_proc table - added columns: proconfig, prodataaccess, proexeclocation
[pg_proc table](http://docs-gpdb-review-staging.cfapps.io/540/ref_guide/system_catalogs/pg_proc.html)

see commit
https://github.com/greenplum-db/gpdb/commit/aa148d2a3cba9866a2c3a06364a26dee32d1c0a2

