### PR TITLE
Tune bitmap scan cost model by updating to nonlinear cost per page

### DIFF
--- a/src/backend/optimizer/path/costsize.c
+++ b/src/backend/optimizer/path/costsize.c
@@ -713,10 +713,17 @@ cost_bitmap_heap_scan(Path *path, PlannerInfo *root, RelOptInfo *baserel,
 	 * appropriate to charge seq_page_cost apiece.	The effect is nonlinear,
 	 * too. For lack of a better idea, interpolate like this to determine the
 	 * cost per page.
+	 *
+	 * GPDB:
+	 * The original formula from Postgres is still more like linear, in which
+	 * the cost per page will be dominated by random_page_cost, because the
+	 * default value of random_page_cost is 100x larger than seq_page_cost in
+	 * GPDB. Therefore, we update it to the following non-linear formula to
+	 * reflect the real cost per page when a majority of pages are fetched.
 	 */
 	if (pages_fetched >= 2.0)
-		cost_per_page = random_page_cost -
-			(random_page_cost - seq_page_cost) * sqrt(pages_fetched / T);
+		cost_per_page = seq_page_cost *
+			pow(random_page_cost / seq_page_cost, 1 - sqrt(pages_fetched / T));
 	else
 		cost_per_page = random_page_cost;
 
@@ -814,10 +821,17 @@ cost_bitmap_appendonly_scan(Path *path, PlannerInfo *root, RelOptInfo *baserel,
 	 * appropriate to charge seq_page_cost apiece.	The effect is nonlinear,
 	 * too. For lack of a better idea, interpolate like this to determine the
 	 * cost per page.
+	 *
+	 * GPDB:
+	 * The original formula from Postgres is still more like linear, in which
+	 * the cost per page will be dominated by random_page_cost, because the
+	 * default value of random_page_cost is 100x larger than seq_page_cost in
+	 * GPDB. Therefore, we update it to the following non-linear formula to
+	 * reflect the real cost per page when a majority of pages are fetched.
 	 */
 	if (pages_fetched >= 2.0)
-		cost_per_page = random_page_cost -
-			(random_page_cost - seq_page_cost) * sqrt(pages_fetched / T);
+		cost_per_page = seq_page_cost *
+			pow(random_page_cost / seq_page_cost, 1 - sqrt(pages_fetched / T));
 	else
 		cost_per_page = random_page_cost;
 

--- a/src/test/regress/sql/bfv_partition.sql
+++ b/src/test/regress/sql/bfv_partition.sql
@@ -809,6 +809,9 @@ INSERT INTO part_tbl VALUES (2015111000, 479534741, 99999999);
 INSERT INTO part_tbl VALUES (2015111000, 479534742, 99999999);
 CREATE INDEX part_tbl_idx 
 ON part_tbl(profile_key);
+-- start_ignore
+ANALYZE part_tbl;
+-- end_ignore
 EXPLAIN SELECT * FROM part_tbl WHERE profile_key = 99999999;
 SELECT * FROM part_tbl WHERE profile_key = 99999999;
 DROP TABLE part_tbl;

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -481,6 +481,9 @@ set optimizer_enable_space_pruning=off;
 set optimizer_enable_constant_expression_evaluation=on;
 set optimizer_enumerate_plans=on;
 set optimizer_plan_id = 2;
+-- start_ignore
+analyze orca.t_date;
+-- end_ignore
 explain select * from orca.t_date where user_id=9;
 select * from orca.t_date where user_id=9;
 
@@ -518,6 +521,9 @@ set optimizer_enable_constant_expression_evaluation=on;
 set optimizer_enumerate_plans=on;
 set optimizer_plan_id = 2;
 
+-- start_ignore
+analyze orca.t_text;
+-- end_ignore
 explain select * from orca.t_text where user_id=9;
 select * from orca.t_text where user_id=9;
 
@@ -563,6 +569,9 @@ insert into orca.t_employee values('01-08-2012'::date,2,'tag1','(2, ''foo'')'::o
 
 set optimizer_enable_constant_expression_evaluation=on;
 set optimizer_enable_dynamictablescan = off;
+-- start_ignore
+analyze orca.t_employee;
+-- end_ignore
 explain select * from orca.t_employee where user_id = 2;
 select * from orca.t_employee where user_id = 2;
 reset optimizer_enable_dynamictablescan;
@@ -592,6 +601,9 @@ set optimizer_use_external_constant_expression_evaluation_for_ints = on;
 set optimizer_enumerate_plans=on;
 set optimizer_plan_id = 2;
 
+-- start_ignore
+analyze orca.t_ceeval_ints;
+-- end_ignore
 explain select * from orca.t_ceeval_ints where user_id=4;
 select * from orca.t_ceeval_ints where user_id=4;
 
@@ -923,6 +935,9 @@ alter table orca.bm_dyn_test add partition part5 values(5);
 insert into orca.bm_dyn_test values(2, 5, '2');
 
 set optimizer_enable_bitmapscan=on;
+-- start_ignore
+analyze orca.bm_dyn_test;
+-- end_ignore
 -- gather on 1 segment because of direct dispatch
 explain select * from orca.bm_dyn_test where i=2 and t='2';
 select * from orca.bm_dyn_test where i=2 and t='2';
@@ -946,6 +961,9 @@ insert into orca.bm_dyn_test_onepart values(2, 5, '2');
 
 set optimizer_enable_bitmapscan=on;
 set optimizer_enable_dynamictablescan = off;
+-- start_ignore
+analyze orca.bm_dyn_test_onepart;
+-- end_ignore
 -- gather on 1 segment because of direct dispatch
 explain select * from orca.bm_dyn_test_onepart where i=2 and t='2';
 select * from orca.bm_dyn_test_onepart where i=2 and t='2';


### PR DESCRIPTION
We had some customers reporting that planner generates plan using seqscan
instead of bitmapscan, and the execution time of seqscan is 5x slower than
using bitmapscan, but the cost of bitmapscan is 2x the cost of seqscan. 
The statistics were updated and quite accurate.

Bitmap table scan uses a formula to interpolate between `random_page_cost` and
`seq_page_cost` to determine the cost per page. But it turns out that the default
value of `random_page_cost` is 100x of the value of `seq_page_cost`. With the
original cost formula, `random_page_cost` predominates in the final cost result,
even the formula is declared to be non-linear, but it is still more like linear,
which can't reflect the real cost per page when a majority of pages are fetched.

Therefore, the cost formula is updated to real non-linear function to reflect
both `random_page_cost` and `seq_page_cost` for different percentage of pages
fetched.

For example, for the default value `random_page_cost = 100`, `seq_page_cost = 1`,
if 80% pages are fetched, the cost per page in old formula is `11.45`, which is
10x more than seqscan, because the cost is dominated by random_page_cost in the
formula. With the new formula, the cost per page is `1.63`, which can reflect the
real cost better, in my opinion.

**Old cost formula:**
```
cost_per_page = random_page_cost - (random_page_cost - seq_page_cost) * sqrt(pages_fetched / T);
```
 
![image](https://user-images.githubusercontent.com/15352793/34134320-c74dfa82-e40e-11e7-8962-772208ed070b.png)

**New cost formula:**
```
cost_per_page = seq_page_cost * pow(random_page_cost / seq_page_cost, 1-sqrt(pages_fetched / T));
```

![image](https://user-images.githubusercontent.com/15352793/34134348-f7ac6fba-e40e-11e7-8972-5eebe651429d.png)



[#151934601]