### PR TITLE
Fix race between partition_pruning and portals_updatable tests

### DIFF
--- a/src/test/regress/expected/partition_pruning.out
+++ b/src/test/regress/expected/partition_pruning.out
@@ -13,7 +13,7 @@ set enable_seqscan=off;
 set enable_bitmapscan=on;
 set enable_indexscan=on;
 create schema partition_pruning;
-set search_path to partition_pruning, public;
+set search_path to partition_pruning;
 -- Set up common test tables.
 CREATE TABLE pt_lt_tab
 (
@@ -2502,7 +2502,7 @@ select * from ds_2 where month_id::int in (200808, 200801, 2008010) order by mon
 
 -- cleanup
 drop table ds_2;
-Create or replace function public.reverse(text) Returns text as $BODY$
+Create or replace function reverse(text) Returns text as $BODY$
 DECLARE
    Original alias for $1;
    Reverse_str text;
@@ -2552,8 +2552,8 @@ order by dnsname;
 
 -- cleanup
 drop table dnsdata cascade;
-drop function public.reverse(text) cascade;
-Create or replace function public.ZeroFunc(int) Returns int as $BODY$
+drop function reverse(text) cascade;
+Create or replace function ZeroFunc(int) Returns int as $BODY$
 BEGIN
   RETURN 0;
 END;
@@ -2565,7 +2565,7 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into mytable select x, x+1 from generate_series(1, 100000) as x;
 analyze mytable;
-CREATE INDEX mytable_idx1 ON mytable USING bitmap(zerofunc(i));
+CREATE INDEX mytable_idx1 ON mytable USING bitmap(ZeroFunc(i));
 select * from mytable where ZeroFunc(i)=0 and i=100 order by i;
   i  |  j  
 -----+-----

--- a/src/test/regress/expected/partition_pruning_optimizer.out
+++ b/src/test/regress/expected/partition_pruning_optimizer.out
@@ -13,7 +13,7 @@ set enable_seqscan=off;
 set enable_bitmapscan=on;
 set enable_indexscan=on;
 create schema partition_pruning;
-set search_path to partition_pruning, public;
+set search_path to partition_pruning;
 -- Set up common test tables.
 CREATE TABLE pt_lt_tab
 (
@@ -2023,7 +2023,7 @@ select * from ds_2 where month_id::int in (200808, 200801, 2008010) order by mon
 
 -- cleanup
 drop table ds_2;
-Create or replace function public.reverse(text) Returns text as $BODY$
+Create or replace function reverse(text) Returns text as $BODY$
 DECLARE
    Original alias for $1;
    Reverse_str text;
@@ -2073,8 +2073,8 @@ order by dnsname;
 
 -- cleanup
 drop table dnsdata cascade;
-drop function public.reverse(text) cascade;
-Create or replace function public.ZeroFunc(int) Returns int as $BODY$
+drop function reverse(text) cascade;
+Create or replace function ZeroFunc(int) Returns int as $BODY$
 BEGIN
   RETURN 0;
 END;
@@ -2086,7 +2086,7 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into mytable select x, x+1 from generate_series(1, 100000) as x;
 analyze mytable;
-CREATE INDEX mytable_idx1 ON mytable USING bitmap(zerofunc(i));
+CREATE INDEX mytable_idx1 ON mytable USING bitmap(ZeroFunc(i));
 select * from mytable where ZeroFunc(i)=0 and i=100 order by i;
   i  |  j  
 -----+-----

--- a/src/test/regress/sql/partition_pruning.sql
+++ b/src/test/regress/sql/partition_pruning.sql
@@ -15,7 +15,7 @@ set enable_bitmapscan=on;
 set enable_indexscan=on;
 
 create schema partition_pruning;
-set search_path to partition_pruning, public;
+set search_path to partition_pruning;
 
 -- Set up common test tables.
 CREATE TABLE pt_lt_tab
@@ -563,7 +563,7 @@ select * from ds_2 where month_id::int in (200808, 200801, 2008010) order by mon
 -- cleanup
 drop table ds_2;
 
-Create or replace function public.reverse(text) Returns text as $BODY$
+Create or replace function reverse(text) Returns text as $BODY$
 DECLARE
    Original alias for $1;
    Reverse_str text;
@@ -612,10 +612,10 @@ order by dnsname;
 
 -- cleanup
 drop table dnsdata cascade;
-drop function public.reverse(text) cascade;
+drop function reverse(text) cascade;
 
 
-Create or replace function public.ZeroFunc(int) Returns int as $BODY$
+Create or replace function ZeroFunc(int) Returns int as $BODY$
 BEGIN
   RETURN 0;
 END;
@@ -627,7 +627,7 @@ create table mytable(i int, j int);
 insert into mytable select x, x+1 from generate_series(1, 100000) as x;
 analyze mytable;
 
-CREATE INDEX mytable_idx1 ON mytable USING bitmap(zerofunc(i));
+CREATE INDEX mytable_idx1 ON mytable USING bitmap(ZeroFunc(i));
 
 
 select * from mytable where ZeroFunc(i)=0 and i=100 order by i;


### PR DESCRIPTION
The portals_updatable test makes use of the public.bar table, which the partition_pruning test was dropping if the stars aligned correctly. To fix, don't fall back to the public schema in the partition_pruning search path. Put the temporary functions in the partition_pruning schema as well for good measure.