### PR TITLE
Make btdexppages parameter to function gp_bloat_diag() numeric.

### DIFF
--- a/src/backend/catalog/gp_toolkit.sql
+++ b/src/backend/catalog/gp_toolkit.sql
@@ -981,7 +981,7 @@ GRANT SELECT ON TABLE gp_toolkit.gp_bloat_expected_pages TO public;
 --        gp_toolkit.gp_bloat_diag
 -- @in:
 --        int - actual number of pages according to statistics
---        int - expecte number of pages
+--        numeric - expected number of pages
 --        bool - is AO table?
 -- @out:
 --        int - bloat indicator
@@ -991,7 +991,7 @@ GRANT SELECT ON TABLE gp_toolkit.gp_bloat_expected_pages TO public;
 --        diagnose table bloat based on expected and actual number of pages
 --
 --------------------------------------------------------------------------------
-CREATE FUNCTION gp_toolkit.gp_bloat_diag(btdrelpages int, btdexppages int, aotable bool,
+CREATE FUNCTION gp_toolkit.gp_bloat_diag(btdrelpages int, btdexppages numeric, aotable bool,
     OUT bltidx int, OUT bltdiag text)
 AS
 $$
@@ -1024,7 +1024,7 @@ $$
 $$
 LANGUAGE SQL READS SQL DATA;
 
-GRANT EXECUTE ON FUNCTION gp_toolkit.gp_bloat_diag(int, int, bool, OUT int, OUT text) TO public;
+GRANT EXECUTE ON FUNCTION gp_toolkit.gp_bloat_diag(int, numeric, bool, OUT int, OUT text) TO public;
 
 
 --------------------------------------------------------------------------------
@@ -1048,7 +1048,7 @@ AS
     (
         SELECT
             fn.*, beg.*,
-            gp_toolkit.gp_bloat_diag(btdrelpages::int, btdexppages::int, iao.iaotype::bool) AS bd
+            gp_toolkit.gp_bloat_diag(btdrelpages::int, btdexppages::numeric, iao.iaotype::bool) AS bd
         FROM
             gp_toolkit.gp_bloat_expected_pages beg,
             pg_catalog.pg_class pgc,

--- a/src/test/regress/expected/gp_toolkit.out
+++ b/src/test/regress/expected/gp_toolkit.out
@@ -631,3 +631,20 @@ reset session authorization;
 drop database toolkit_testdb;
 drop role toolkit_user1;
 drop role toolkit_admin;
+create database gptoolkit;
+\c gptoolkit
+drop table if exists test;
+NOTICE:  table "test" does not exist, skipping
+create table test as select * from pg_attribute;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'attrelid' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+set allow_system_table_mods=dml ;
+update pg_statistic set stawidth=2034567890 where starelid = (select oid from pg_class where relname='test');
+select * from gp_toolkit.gp_bloat_diag;
+ bdirelid | bdinspname | bdirelname | bdirelpages | bdiexppages |              bdidiag               
+----------+------------+------------+-------------+-------------+------------------------------------
+     2618 | pg_catalog | pg_rewrite |          20 |           6 | moderate amount of bloat suspected
+(1 row)
+
+\c regression
+drop database gptoolkit

--- a/src/test/regress/sql/gp_toolkit.sql
+++ b/src/test/regress/sql/gp_toolkit.sql
@@ -368,3 +368,15 @@ reset session authorization;
 drop database toolkit_testdb;
 drop role toolkit_user1;
 drop role toolkit_admin;
+
+create database gptoolkit;
+\c gptoolkit
+drop table if exists test;
+create table test as select * from pg_attribute;
+set allow_system_table_mods=dml ;
+update pg_statistic set stawidth=2034567890 where starelid = (select oid from pg_class where relname='test');
+
+select * from gp_toolkit.gp_bloat_diag;
+
+\c regression
+drop database gptoolkit


### PR DESCRIPTION
The gp_bloat_expected_pages.btdexppages column is numeric, but it was passed to
the function gp_bloat_diag() as integer in the definition of the view of the
same name gp_bloat_diag. This caused integer overflow errors when the number of
expected pages exceeded max integer limit for columns with very large widths.

This changes the function signature and call to use numeric for the
btxexppages paramter.

Author: Nadeem Ghani <nghani@pivotal.io>
Author: Shoaib Lari <slari@pivotal.io>