### PR TITLE
Nonblocking open() FIFO files

### DIFF
--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -32,6 +32,8 @@
 #include "utils/faultinjector.h"
 #include "utils/memutils.h"
 
+#include <poll.h>
+
 /*
  * Create a cdbCopy object that includes all the cdb
  * information and state needed by the backend COPY.
@@ -187,7 +189,7 @@ cdbCopyStart(CdbCopy *c, char *copyCmd, struct GpPolicy *policy)
 	MemoryContextSwitchTo(oldcontext);
 
 	CdbDispatchUtilityStatement((Node *) q->utilityStmt,
-								(c->copy_in ? DF_NEED_TWO_PHASE | DF_WITH_SNAPSHOT : DF_WITH_SNAPSHOT),
+								(c->copy_in ? DF_NEED_TWO_PHASE | DF_WITH_SNAPSHOT : DF_WITH_SNAPSHOT) | DF_CANCEL_ON_ERROR,
 								NIL,	/* FIXME */
 								NULL);
 
@@ -454,6 +456,7 @@ processCopyEndResults(CdbCopy *c,
 	SegmentDatabaseDescriptor *q;
 	int			seg;
 	PGresult   *res;
+	struct pollfd	*pollRead = (struct pollfd *) palloc(sizeof(struct pollfd));
 	int			segment_rows_rejected = 0;	/* num of rows rejected by this QE */
 	int			segment_rows_completed = 0; /* num of rows completed by this
 											 * QE */
@@ -483,6 +486,23 @@ processCopyEndResults(CdbCopy *c,
 			appendStringInfo(&(c->err_msg), "primary segment %d, dbid %d, attempt blocked\n",
 							 seg, q->segment_database_info->dbid);
 			c->io_errors = true;
+		}
+
+		pollRead->fd = PQsocket(q->conn);
+		pollRead->events = POLLIN;
+		pollRead->revents = 0;
+
+		while (PQisBusy(q->conn))
+		{
+			if ((Gp_role == GP_ROLE_DISPATCH) && InterruptPending)
+			{
+				PQrequestCancel(q->conn);
+			}
+
+			if (poll(pollRead, 1, 200) > 0)
+			{
+				break;
+			}
 		}
 
 		/*
@@ -662,8 +682,6 @@ processCopyEndResults(CdbCopy *c,
 		}
 	}
 }
-
-
 
 /*
  * ends the copy command on all segment databases.

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -149,7 +149,7 @@ GetDistributionPolicyForPartition(CopyState cstate, EState *estate,
 static unsigned int
 GetTargetSeg(GpDistributionData *distData, Datum *baseValues, bool *baseNulls);
 static ProgramPipes *open_program_pipes(char *command, bool forwrite);
-static int close_program_pipes(CopyState cstate);
+static void close_program_pipes(CopyState cstate, bool ifThrow);
 
 /* ==========================================================================
  * The following macros aid in major refactoring of data processing code (in
@@ -489,7 +489,7 @@ CopySendEndOfRow(CopyState cstate)
 						 * error message from the subprocess' exit code than
 						 * just "Broken Pipe"
 						 */
-						close_program_pipes(cstate);
+						close_program_pipes(cstate, true);
 
 						/*
 						 * If close_program_pipes() didn't throw an error,
@@ -572,7 +572,7 @@ CopyToDispatchFlush(CopyState cstate)
 						 * error message from the subprocess' exit code than
 						 * just "Broken Pipe"
 						 */
-						close_program_pipes(cstate);
+						close_program_pipes(cstate, true);
 
 						/*
 						 * If close_program_pipes() didn't throw an error,
@@ -641,6 +641,30 @@ CopyGetData(CopyState cstate, void *databuf, int datasize)
 			bytesread = fread(databuf, 1, datasize, cstate->copy_file);
 			if (feof(cstate->copy_file))
 				cstate->fe_eof = true;
+			if (ferror(cstate->copy_file))
+			{
+				if (cstate->is_program)
+				{
+					int olderrno = errno;
+
+					close_program_pipes(cstate, true);
+
+					/*
+					 * If close_program_pipes() didn't throw an error,
+					 * the program terminated normally, but closed the
+					 * pipe first. Restore errno, and throw an error.
+					 */
+					errno = olderrno;
+
+					ereport(ERROR,
+							(errcode_for_file_access(),
+							 errmsg("could not read from COPY program: %m")));
+				}
+				else
+					ereport(ERROR,
+						(errcode_for_file_access(),
+						 errmsg("could not read from COPY file: %m")));
+			}
 			break;
 		case COPY_OLD_FE:
 			if (pq_getbytes((char *) databuf, datasize))
@@ -1884,7 +1908,7 @@ DoCopyInternal(const CopyStmt *stmt, const char *queryString, CopyState cstate)
 		{
 			if (cstate->is_program)
 			{
-				close_program_pipes(cstate);
+				close_program_pipes(cstate, true);
 			}
 			else if (FreeFile(cstate->copy_file))
 			{
@@ -1962,6 +1986,13 @@ DoCopy(const CopyStmt *stmt, const char *queryString)
 	}
 	PG_CATCH();
 	{
+		if (!(!cstate->on_segment && Gp_role == GP_ROLE_EXECUTE)) {
+			if (cstate->is_program)
+			{
+				close_program_pipes(cstate, false);
+			}
+		}
+
 		if (cstate->queryDesc)
 		{
 			/* should shutdown the mpp stuff such as interconnect and dispatch thread */
@@ -2098,7 +2129,7 @@ DoCopyTo(CopyState cstate)
 	{
 		if (cstate->is_program)
 		{
-			close_program_pipes(cstate);
+			close_program_pipes(cstate, true);
 		}
 		else if (FreeFile(cstate->copy_file))
 		{
@@ -3490,29 +3521,29 @@ CopyFromDispatch(CopyState cstate)
 
 		if (!cstate->binary)
 		{
-		/* read a chunk of data into the buffer */
-		PG_TRY();
-		{
-			bytesread = CopyGetData(cstate, cstate->raw_buf, RAW_BUF_SIZE);
-		}
-		PG_CATCH();
-		{
-			/*
-			 * If we are here, we got some kind of communication error
-			 * with the client or a bad protocol message. clean up and
-			 * re-throw error. Note that we don't handle this error in
-			 * any special way in SREH mode as it's not a data error.
-			 */
-			cdbCopyEnd(cdbCopy);
-			PG_RE_THROW();
-		}
-		PG_END_TRY();
+			/* read a chunk of data into the buffer */
+			PG_TRY();
+			{
+				bytesread = CopyGetData(cstate, cstate->raw_buf, RAW_BUF_SIZE);
+			}
+			PG_CATCH();
+			{
+				/*
+				 * If we are here, we got some kind of communication error
+				 * with the client or a bad protocol message. clean up and
+				 * re-throw error. Note that we don't handle this error in
+				 * any special way in SREH mode as it's not a data error.
+				 */
+				cdbCopyEnd(cdbCopy);
+				PG_RE_THROW();
+			}
+			PG_END_TRY();
 
-		cstate->raw_buf_done = false;
+			cstate->raw_buf_done = false;
 
-		/* set buffer pointers to beginning of the buffer */
-		cstate->begloc = cstate->raw_buf;
-		cstate->raw_buf_index = 0;
+			/* set buffer pointers to beginning of the buffer */
+			cstate->begloc = cstate->raw_buf;
+			cstate->raw_buf_index = 0;
 		}
 
 		/*
@@ -4234,10 +4265,6 @@ CopyFromDispatch(CopyState cstate)
 	FreeExecutorState(estate);
 }
 
-
-
-
-
 /*
  * Copy FROM file to relation.
  */
@@ -4449,13 +4476,28 @@ PROCESS_SEGMENT_DATA:
 
 		if (!cstate->binary)
 		{
-		/* read a chunk of data into the buffer */
-		bytesread = CopyGetData(cstate, cstate->raw_buf, RAW_BUF_SIZE);
-		cstate->raw_buf_done = false;
+			PG_TRY();
+			{
+				/* read a chunk of data into the buffer */
+				bytesread = CopyGetData(cstate, cstate->raw_buf, RAW_BUF_SIZE);
+			}
+			PG_CATCH();
+			{
+				/*
+				 * If we are here, we got some kind of communication error
+				 * with the client or a bad protocol message. clean up and
+				 * re-throw error. Note that we don't handle this error in
+				 * any special way in SREH mode as it's not a data error.
+				 */
+				COPY_HANDLE_ERROR;
+			}
+			PG_END_TRY();
 
-		/* set buffer pointers to beginning of the buffer */
-		cstate->begloc = cstate->raw_buf;
-		cstate->raw_buf_index = 0;
+			cstate->raw_buf_done = false;
+
+			/* set buffer pointers to beginning of the buffer */
+			cstate->begloc = cstate->raw_buf;
+			cstate->raw_buf_index = 0;
 		}
 
 		/*
@@ -4478,19 +4520,13 @@ PROCESS_SEGMENT_DATA:
 				PG_CATCH();
 				{
 					/*
-					 * TODO: use COPY_HANDLE_ERROR here, but make sure to
-					 * ignore this error per the "note:" below.
-					 */
-
-					/*
 					 * got here? encoding conversion error occured on the
 					 * header line (first row).
 					 */
 					if (cstate->errMode == ALL_OR_NOTHING)
 					{
 						/* re-throw error and abort */
-						cdbCopyEnd(cdbCopy);
-						PG_RE_THROW();
+						COPY_HANDLE_ERROR;
 					}
 					else
 					{
@@ -4596,9 +4632,6 @@ PROCESS_SEGMENT_DATA:
 
 						if(cstate->errMode == ALL_OR_NOTHING)
 						{
-							/* report error and abort */
-							cdbCopyEnd(cdbCopy);
-
 							ereport(ERROR,
 									(errcode(ERRCODE_BAD_COPY_FILE_FORMAT),
 									 errmsg("null OID in COPY data.")));
@@ -4687,18 +4720,18 @@ PROCESS_SEGMENT_DATA:
 						baseNulls[m] = isnull;
 						cstate->cur_attname = NULL;
 					}
-					}
-					PG_CATCH();
-					{
-						COPY_HANDLE_ERROR; /* SREH */
-					}
-					PG_END_TRY();
+				}
+				PG_CATCH();
+				{
+					COPY_HANDLE_ERROR; /* SREH */
+				}
+				PG_END_TRY();
 
-					if(cur_row_rejected)
-					{
-						ErrorIfRejectLimitReached(cstate->cdbsreh, cdbCopy);
-						QE_GOTO_NEXT_ROW;
-					}
+				if (cur_row_rejected)
+				{
+					ErrorIfRejectLimitReached(cstate->cdbsreh, cdbCopy);
+					QE_GOTO_NEXT_ROW;
+				}
 				}
 				else
 				{
@@ -4876,12 +4909,21 @@ PROCESS_SEGMENT_DATA:
 				if (is_check_distkey && distData->p_nattrs > 0)
 				{
 					target_seg = GetTargetSeg(distData, slot_get_values(slot), slot_get_isnull(slot));
-					/*check distribution key if COPY FROM ON SEGMENT*/
-					if (GpIdentity.segindex != target_seg)
-						ereport(ERROR,
-								(errcode(ERRCODE_INTEGRITY_CONSTRAINT_VIOLATION),
-								 errmsg("value of distribution key doesn't belong to segment with ID %d, it belongs to segment with ID %d",
-										GpIdentity.segindex, target_seg)));
+
+					PG_TRY();
+					{
+						/* check distribution key if COPY FROM ON SEGMENT */
+						if (GpIdentity.segindex != target_seg)
+							ereport(ERROR,
+									(errcode(ERRCODE_INTEGRITY_CONSTRAINT_VIOLATION),
+									 errmsg("value of distribution key doesn't belong to segment with ID %d, it belongs to segment with ID %d",
+											GpIdentity.segindex, target_seg)));
+					}
+					PG_CATCH();
+					{
+						COPY_HANDLE_ERROR;
+					}
+					PG_END_TRY();
 				}
 
 				/*
@@ -5053,7 +5095,7 @@ PROCESS_SEGMENT_DATA:
 	/* Done, clean up */
 	if (cstate->on_segment && cstate->is_program)
 	{
-		close_program_pipes(cstate);
+		close_program_pipes(cstate, true);
 	}
 	else if (cstate->on_segment && FreeFile(cstate->copy_file))
 	{
@@ -8102,8 +8144,8 @@ open_program_pipes(char *command, bool forwrite)
 	return program_pipes;
 }
 
-static int
-close_program_pipes(CopyState cstate)
+static void
+close_program_pipes(CopyState cstate, bool ifThrow)
 {
 	Assert(cstate->is_program);
 
@@ -8111,21 +8153,30 @@ close_program_pipes(CopyState cstate)
 	StringInfoData sinfo;
 	initStringInfo(&sinfo);
 
-	fclose(cstate->copy_file);
-	ret = pclose_with_stderr(cstate->program_pipes->pid, cstate->program_pipes->pipes, &sinfo);
+	if (cstate->copy_file)
+	{
+		fclose(cstate->copy_file);
+		cstate->copy_file = NULL;
+	}
+
+	if (kill(cstate->program_pipes->pid, 0) == 0) /* process exists */
+	{
+		ret = pclose_with_stderr(cstate->program_pipes->pid, cstate->program_pipes->pipes, &sinfo);
+	}
+
 	if (ret == 0)
 	{
 		/* pclose() ended successfully; no errors to reflect */
 		;
 	}
-	else if (ret == -1)
+	else if (ret == -1 && ifThrow)
 	{
 		/* pclose()/wait4() ended with an error; errno should be valid */
 		ereport(ERROR,
 				(errcode_for_file_access(),
 				 errmsg("can not close pipe: %m")));
 	}
-	else
+	else if (ifThrow)
 	{
 		/*
 		 * pclose() returned the process termination state.  The interpretExitCode() function
@@ -8135,6 +8186,4 @@ close_program_pipes(CopyState cstate)
 				(errcode(ERRCODE_SQL_ROUTINE_EXCEPTION),
 				 errmsg("command error message: %s", sinfo.data)));
 	}
-
-	return ret;
 }


### PR DESCRIPTION
If the writer end closed, blocking open() will hang and ignore
interrupts.

```
$ mkfifo /tmp/pipe0

gpadmin=# create external table fifo (t int) location('file://hostname/tmp/pipe0') format 'csv';
CREATE EXTERNAL TABLE
gpadmin=# select * from fifo;
^CCancel request sent
^CCancel request sent
^CCancel request sent
...

gpadmin=# copy fifo from '/tmp/pipe0';
^CCancel request sent
^CCancel request sent
^CCancel request sent
...
```

This commits nonblocking open() FIFO files, then set it back to blocking mode,
so we could keep the same behaviors while reading, and make it able to
be interrupted.

One thing changed:
Before this the read action could wait (actually blocks on open()) until
writers open. Now it just reads nothing and returns zero unless there is
already a writer.