### PR TITLE
docs - add info about greenplum database release versioning

### DIFF
--- a/gpdb-doc/dita/admin_guide/admin_guide.ditamap
+++ b/gpdb-doc/dita/admin_guide/admin_guide.ditamap
@@ -15,6 +15,7 @@
             <topicref href="intro/about_statistics.xml"/>
         </topicref>
         <topicref href="managing/partII.xml" id="partII">
+            <topicref href="managing/versioning.xml" navtitle="About Your Greenplum Database Release Version Number"/>
             <topicref href="managing/startstop.xml" navtitle="Starting and Stopping Greenplum"/>
             <topicref href="access_db/access_db.ditamap" format="ditamap"/>
             <topicref href="configure.ditamap" format="ditamap"/>

--- a/gpdb-doc/dita/admin_guide/admin_guide.ditamap
+++ b/gpdb-doc/dita/admin_guide/admin_guide.ditamap
@@ -15,7 +15,7 @@
             <topicref href="intro/about_statistics.xml"/>
         </topicref>
         <topicref href="managing/partII.xml" id="partII">
-            <topicref href="managing/versioning.xml" navtitle="About Your Greenplum Database Release Version Number"/>
+            <topicref href="managing/versioning.xml" navtitle="About the Greenplum Database Release Version Number"/>
             <topicref href="managing/startstop.xml" navtitle="Starting and Stopping Greenplum"/>
             <topicref href="access_db/access_db.ditamap" format="ditamap"/>
             <topicref href="configure.ditamap" format="ditamap"/>

--- a/gpdb-doc/dita/admin_guide/managing/managing.ditamap
+++ b/gpdb-doc/dita/admin_guide/managing/managing.ditamap
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
 <map>
+  <topicref href="versioning.xml" navtitle="About Your Greenplum Database Release Version Number"/>
   <topicref href="startstop.xml" navtitle="Starting and Stopping Greenplum"/>
   <topicref href="access_db.xml" navtitle="Accessing the Database"/>
   <topicref href="configure.xml" navtitle="Configuring Your Greenplum System"/>

--- a/gpdb-doc/dita/admin_guide/managing/managing.ditamap
+++ b/gpdb-doc/dita/admin_guide/managing/managing.ditamap
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
 <map>
-  <topicref href="versioning.xml" navtitle="About Your Greenplum Database Release Version Number"/>
+  <topicref href="versioning.xml" navtitle="About the Greenplum Database Release Version Number"/>
   <topicref href="startstop.xml" navtitle="Starting and Stopping Greenplum"/>
   <topicref href="access_db.xml" navtitle="Accessing the Database"/>
   <topicref href="configure.xml" navtitle="Configuring Your Greenplum System"/>

--- a/gpdb-doc/dita/admin_guide/managing/partII.xml
+++ b/gpdb-doc/dita/admin_guide/managing/partII.xml
@@ -8,6 +8,7 @@
   <body>
     <section otherprops="op-print">
       <p>This section contains the following topics:<ul id="ul_dgc_f4q_lp" otherprops="op-print">
+          <li><xref href="versioning.xml#topic1"/></li>
           <li><xref href="startstop.xml#topic1"/></li>
           <li><xref href="../access_db/topics/g-accessing-the-database.xml"/></li>
           <li><xref href="../topics/g-configuring-the-greenplum-system.xml#topic1"/></li>

--- a/gpdb-doc/dita/admin_guide/managing/versioning.xml
+++ b/gpdb-doc/dita/admin_guide/managing/versioning.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
 <topic id="topic1" xml:lang="en">
-  <title id="kg1382433">About your Greenplum Database Release Version Number</title>
+  <title id="kg1382433">About the Greenplum Database Release Version Number</title>
   <shortdesc>Greenplum Database version numbers and they way they change identify
     what has been modified from one Greenplum Database release to the next.</shortdesc>
   <body>
@@ -14,11 +14,11 @@
         <li><varname>z</varname> identifies the Patch version number</li>
       </ul>
     </p>
-    <p>Greenplum Database releases with the same Major release number are guaranteed 
-      to be backwards compatible.</p>
-    <p>Greenplum Database increments the Major release number when the catalog 
-      changes or when incompatible feature changes or new features are introduced.</p>
-    <p>The Minor release number for a given Major release is incremented when 
+    <p>Greenplum Database releases that have the same Major release number are 
+      guaranteed to be backwards compatible. Greenplum Database increments the
+      Major release number when the catalog changes or when incompatible feature
+      changes or new features are introduced.</p>
+    <p>The Minor release number for a given Major release increments when 
       backwards compatible new features are introduced or when a Greenplum Database
       feature is deprecated.</p>
     <p>Greenplum Database increments the Patch release number for a given Minor

--- a/gpdb-doc/dita/admin_guide/managing/versioning.xml
+++ b/gpdb-doc/dita/admin_guide/managing/versioning.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic id="topic1" xml:lang="en">
+  <title id="kg1382433">About your Greenplum Database Release Version Number</title>
+  <shortdesc>Greenplum Database version numbers and they way they change identify
+    what has been modified from one Greenplum Database release to the next.</shortdesc>
+  <body>
+    <p>A Greenplum Database release version number takes the format
+      <varname>x.y.z</varname>, where:
+      <ul>
+        <li><varname>x</varname> identifies the Major version number</li>
+        <li><varname>y</varname> identifies the Minor version number</li>
+        <li><varname>z</varname> identifies the Patch version number</li>
+      </ul>
+    </p>
+    <p>Greenplum Database releases with the same Major release number are guaranteed 
+      to be backwards compatible.</p>
+    <p>Greenplum Database increments the Major release number when the catalog 
+      changes or when incompatible feature changes or new features are introduced.</p>
+    <p>The Minor release number for a given Major release is incremented when 
+      backwards compatible new features are introduced or when a Greenplum Database
+      feature is deprecated.</p>
+    <p>Greenplum Database increments the Patch release number for a given Minor
+      release for backwards-compatible bug fixes.</p>
+  </body>
+</topic>

--- a/gpdb-doc/dita/admin_guide/managing/versioning.xml
+++ b/gpdb-doc/dita/admin_guide/managing/versioning.xml
@@ -17,10 +17,12 @@
     <p>Greenplum Database releases that have the same Major release number are 
       guaranteed to be backwards compatible. Greenplum Database increments the
       Major release number when the catalog changes or when incompatible feature
-      changes or new features are introduced.</p>
+      changes or new features are introduced. Previously deprecated functionality
+      may be removed in a major release.</p>
     <p>The Minor release number for a given Major release increments when 
       backwards compatible new features are introduced or when a Greenplum Database
-      feature is deprecated.</p>
+      feature is deprecated. (Previously deprecated functionality will never be
+      removed in a minor release.)</p>
     <p>Greenplum Database increments the Patch release number for a given Minor
       release for backwards-compatible bug fixes.</p>
   </body>


### PR DESCRIPTION
add new section to administrator guide describing components of greenplum database release version numbers.

doc review site link:
- http://docs-gpdb-review-staging.cfapps.io/540/admin_guide/managing/versioning.html
