### PR TITLE
Make gpinitsystem use walrep mirrors instead of filerep mirrors

### DIFF
--- a/gpAux/gpdemo/Makefile
+++ b/gpAux/gpdemo/Makefile
@@ -45,12 +45,7 @@ all:
 	$(MAKE) probe
 
 cluster create-demo-cluster:
-	@WITH_MIRRORS=false ./demo_cluster.sh # will generate gpdemo-env.sh
-ifeq ($(WITH_MIRRORS), true)
-	@. ./gpdemo-env.sh; \
-	./gpsegwalrep.py init --host `hostname`; \
-	./gpsegwalrep.py start;
-endif
+	@./demo_cluster.sh
 	@echo ""
 
 probe:

--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -1300,7 +1300,7 @@ CREATE_QD_DB () {
 		if [ $RETVAL -ne 0 ]; then
 			ERROR_EXIT "[FATAL]:-Could not establish connection to hostname $GP_HOSTNAME. Please check your configuration." 2
 		fi
-		UPDATE_GPCONFIG $GP_PORT $GP_DBID $GP_CONTENT $GP_HOSTNAME $GP_HOSTADDRESS $GP_PORT $GP_DIR p $GP_REPLICATION_PORT
+		UPDATE_GPCONFIG $GP_PORT $GP_DBID $GP_CONTENT $GP_HOSTNAME $GP_HOSTADDRESS $GP_PORT $GP_DIR p
 		LOAD_QE_SYSTEM_DATA $DEFAULTDB
 		SET_VAR $QD_PRIMARY_ARRAY
 		LOG_MSG "[INFO]:-End Function $FUNCNAME"
@@ -1327,15 +1327,7 @@ UPDATE_GPCONFIG () {
 		U_PORT=$6
 		U_DIR=$7
 		U_ROLE=$8
-		if [ $9 -eq 0 ]; then
-			U_REPLICATION_PORT=null
-		else 
-			U_REPLICATION_PORT=$9
-		fi
-
-        if [ $MIRRORING -ne 1 ]; then
-            U_REPLICATION_PORT=null
-        fi
+		U_REPLICATION_PORT=null
 
 		U_DB=$DEFAULTDB
 		CHK_COUNT=`env PGOPTIONS="-c gp_session_role=utility" $PSQL -p $MASTER_PORT -d "$U_DB" -A -t -c "SELECT count(*) FROM $GP_CONFIG_TBL WHERE content=${U_CONTENT} AND preferred_role='${U_ROLE}';" 2>/dev/null` >> $LOG_FILE 2>&1
@@ -1373,27 +1365,9 @@ LOAD_QE_SYSTEM_DATA () {
 				if [ $RETVAL -ne 0 ]; then
 					ERROR_EXIT "[FATAL]:-Could not establish connection to hostname $GP_HOSTNAME. Please check your configuration." 2
 				fi				
-				UPDATE_GPCONFIG $MASTER_PORT $GP_DBID $GP_CONTENT $GP_HOSTNAME $GP_HOSTADDRESS $GP_PORT $GP_DIR p $GP_REPLICATION_PORT
+				UPDATE_GPCONFIG $MASTER_PORT $GP_DBID $GP_CONTENT $GP_HOSTNAME $GP_HOSTADDRESS $GP_PORT $GP_DIR p
 				LOG_MSG "[INFO]:-Successfully added segment $GP_HOSTADDRESS to Master system tables"
 		done
-		if [ $MIRRORING -eq 1 ]; then
-				for I in "${QE_MIRROR_ARRAY[@]}"
-				do
-					SET_VAR $I
-					LOG_MSG "[INFO]:-Adding segment $GP_HOSTADDRESS, $GP_DBID, $GP_DIR to Master system tables as mirror"
-					GP_HOSTNAME=`HOST_LOOKUP $GP_HOSTADDRESS`
-					if [ x"$GP_HOSTNAME" = x"__lookup_of_hostname_failed__" ]; then
-						ERROR_EXIT "[FATAL]:-Hostname lookup for host $GP_HOSTADDRESS failed." 2
-					fi
-					PING_HOST $GP_HOSTNAME
-					RETVAL=$?
-					if [ $RETVAL -ne 0 ]; then
-						ERROR_EXIT "[FATAL]:-Could not establish connection to hostname $GP_HOSTNAME. Please check your configuration." 2
-					fi					
-					UPDATE_GPCONFIG $MASTER_PORT $GP_DBID $GP_CONTENT $GP_HOSTNAME $GP_HOSTADDRESS $GP_PORT $GP_DIR m $GP_REPLICATION_PORT
-					LOG_MSG "[INFO]:-Successfully added segment $GP_HOSTADDRESS to Master system tables as mirror"
-				done
-		fi
 		LOG_MSG "[INFO]:-End Function $FUNCNAME"
 }
 
@@ -1623,6 +1597,30 @@ CREATE_DATABASE () {
 		$PSQL -p $GP_PORT -d "$DEFAULTDB" -c"create database \"${DATABASE_NAME}\";" >> $LOG_FILE 2>&1
 		ERROR_CHK $? "create database $DATABASE_NAME" 2
 		LOG_MSG "[INFO]:-End Function $FUNCNAME"
+}
+
+FORCE_FTS_PROBE () {
+    LOG_MSG "[INFO]:-Start Function $FUNCNAME"
+    # loop on gp_segment_configuration to make sure primary/mirror pairs are up and in sync
+    for i in {1..60}; do
+        if [ $i == 60 ]; then
+            $PSQL -p $GP_PORT -d "$DEFAULTDB" -A -t -c "select * from gp_segment_configuration where (mode = 'n' or status = 'd') and content != -1;" >> $LOG_FILE 2>&1
+            $PSQL -p $GP_PORT -d "$DEFAULTDB" -A -t -c "select * from gp_stat_replication where sync_error != 'none' or sync_state != 'sync';" >> $LOG_FILE 2>&1
+            LOG_MSG "[WARN]:" 1
+            LOG_MSG "[WARN]:-Failed to start Greenplum instance; please review gpinitsystem log to determine failure." 1
+            ERROR_EXIT "[FATAL]:-Some primary/mirror segment pairs were found to be not in sync" 2
+            break;
+        fi
+
+        RESULT=$( $PSQL -p $GP_PORT -d "$DEFAULTDB" -A -t -c "select count(*) > 0 from gp_segment_configuration where (mode = 'n' or status = 'd') and content != -1;" )
+        if [ x"$RESULT" == x"f" ]; then
+            break
+        fi
+
+        $PSQL -p $GP_PORT -d "$DEFAULTDB" -c "select gp_request_fts_probe_scan()" >> /dev/null 2>&1
+        sleep 1;
+    done
+    LOG_MSG "[INFO]:-End Function $FUNCNAME"
 }
 
 SCAN_LOG () {
@@ -2031,9 +2029,6 @@ fi
 CREATE_QD_DB		
 
 CREATE_QES_PRIMARY
-if [ $MIRRORING -ne 0 ]; then
-	CREATE_QES_MIRROR
-fi
 if [ $REPORT_FAIL -ne 0 ];then
 	LOG_MSG "[FATAL]:-Errors generated from parallel processes" 1
 	LOG_MSG "[INFO]:-Dumped contents of status file to the log file" 1
@@ -2070,6 +2065,11 @@ if [ x"" != x"$DATABASE_NAME" ]; then
 fi
 
 SET_GP_USER_PW
+
+if [ $MIRRORING -ne 0 ]; then
+    CREATE_QES_MIRROR
+    FORCE_FTS_PROBE
+fi
 
 if [ x"" != x"$STANDBY_HOSTNAME" ];then
 	CREATE_STANDBY_QD

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -205,7 +205,7 @@ class PgCtlBackendOptions(CmdArgs):
         @param mode: mirroring mode
         @param content: content id
         """
-        self.extend(["-i", "-M", str(mode), "--gp_contentid="+str(content)])
+        self.extend(["-i", "-M", "mirrorless", "--gp_contentid="+str(content)])
         return self
 
     #

--- a/gpMgmt/bin/lib/gpcreateseg.sh
+++ b/gpMgmt/bin/lib/gpcreateseg.sh
@@ -137,86 +137,94 @@ PROCESS_QE () {
 
     # on mirror, copy data from primary
     if [ x"" != x"$COPY_FROM_PRIMARY_HOSTADDRESS" ]; then
-        LOG_MSG "[INFO]:-Copying data for mirror on ${GP_HOSTADDRESS} using remote copy from primary ${COPY_FROM_PRIMARY_HOSTADDRESS} ..." 1
-        RUN_COMMAND_REMOTE ${COPY_FROM_PRIMARY_HOSTADDRESS} "${EXPORT_GPHOME}; . ${GPHOME}/greenplum_path.sh; ${GPHOME}/bin/lib/pysync.py -x pg_log -x postgresql.conf -x postmaster.pid ${COPY_FROM_PRIMARY_DIR} \[${GP_HOSTADDRESS}\]:${GP_DIR}"
+        LOG_MSG "[INFO]:-Running pg_basebackup to init mirror on ${GP_HOSTADDRESS} using primary on ${COPY_FROM_PRIMARY_HOSTADDRESS} ..." 1
+        RUN_COMMAND_REMOTE ${COPY_FROM_PRIMARY_HOSTADDRESS} "${EXPORT_GPHOME}; . ${GPHOME}/greenplum_path.sh; echo 'host  replication ${GP_USER} samenet trust' >> ${COPY_FROM_PRIMARY_DIR}/pg_hba.conf; pg_ctl -D ${COPY_FROM_PRIMARY_DIR} reload"
+        RUN_COMMAND_REMOTE ${GP_HOSTADDRESS} "${EXPORT_GPHOME}; . ${GPHOME}/greenplum_path.sh; rm -rf ${GP_DIR}; ${GPHOME}/bin/pg_basebackup -x -R -c fast -E ./pg_log -E ./db_dumps -E ./gpperfmon/data -E ./gpperfmon/logs -D ${GP_DIR} -h ${COPY_FROM_PRIMARY_HOSTADDRESS} -p ${COPY_FROM_PRIMARY_PORT}; mkdir ${GP_DIR}/pg_log; mkdir ${GP_DIR}/pg_xlog/archive_status"
+        REGISTER_MIRROR
+        START_QE ""
         RETVAL=$?
-        PARA_EXIT $RETVAL "remote copy of segment data directory from ${COPY_FROM_PRIMARY_HOSTADDRESS} to ${GP_HOSTADDRESS}"
+        PARA_EXIT $RETVAL "pg_basebackup of segment data directory from ${COPY_FROM_PRIMARY_HOSTADDRESS} to ${GP_HOSTADDRESS}"
     fi
 
-    # Configure postgresql.conf
-    LOG_MSG "[INFO][$INST_COUNT]:-Configuring segment $PG_CONF"
-    $TRUSTED_SHELL ${GP_HOSTADDRESS} "$ECHO \"#MPP Specific parameters\" >> ${GP_DIR}/$PG_CONF"
-    RETVAL=$?
-    PARA_EXIT $RETVAL "Update ${GP_DIR}/$PG_CONF file"
-    $TRUSTED_SHELL ${GP_HOSTADDRESS} "$ECHO \"#----------------------\" >> ${GP_DIR}/$PG_CONF"
-    RETVAL=$?
-    PARA_EXIT $RETVAL "Update ${GP_DIR}/$PG_CONF file"
-    SED_PG_CONF ${GP_DIR}/$PG_CONF "$PORT_TXT" port=$GP_PORT 0 $GP_HOSTADDRESS
-    PARA_EXIT $RETVAL "Update port number to $GP_PORT"
-    SED_PG_CONF ${GP_DIR}/$PG_CONF "$LISTEN_ADR_TXT" listen_addresses=\'*\' 0 $GP_HOSTADDRESS
-    PARA_EXIT $RETVAL "Update listen address"
-    SED_PG_CONF ${GP_DIR}/$PG_CONF "$CHKPOINT_SEG_TXT" checkpoint_segments=$CHECK_POINT_SEGMENTS 0 $GP_HOSTADDRESS
-    PARA_EXIT $RETVAL "Update checkpoint segments"
-
-    if [ x"" != x"$PG_CONF_ADD_FILE" ]; then
-	LOG_MSG "[INFO][$INST_COUNT]:-Processing additional configuration parameters"
-	for NEW_PARAM in `$CAT $PG_CONF_ADD_FILE|$TR -s ' '|$TR -d ' '|$GREP -v "^#"`
-	do
-	    LOG_MSG "[INFO][$INST_COUNT]:-Adding config $NEW_PARAM to segment"
-	    SEARCH_TXT=`$ECHO $NEW_PARAM |$CUT -d"=" -f1`
-	    SED_PG_CONF ${GP_DIR}/$PG_CONF $SEARCH_TXT $NEW_PARAM 0 $GP_HOSTADDRESS
-	    PARA_EXIT $RETVAL "Update $PG_CONF $SEARCH_TXT $NEW_PARAM"
-	done
-    fi
-
-    # Configuring PG_HBA  -- on mirror, only need to add local addresses (skip the other addresses)
-    LOG_MSG "[INFO][$INST_COUNT]:-Configuring segment $PG_HBA"
+    # do primary stuff
     if [ x"" = x"$COPY_FROM_PRIMARY_HOSTADDRESS" ]; then
-	for MASTER_IP in "${MASTER_IP_ADDRESS[@]}"
-	do
-	    # MPP-15889
-	    CIDR_MASTER_IP=$(GET_CIDRADDR $MASTER_IP)
-	    $TRUSTED_SHELL ${GP_HOSTADDRESS} "$ECHO host	all	all	${CIDR_MASTER_IP}	trust >> ${GP_DIR}/$PG_HBA"
-	    PARA_EXIT $? "Update $PG_HBA for master IP address ${CIDR_MASTER_IP}"
-	done
-	if [ x"" != x"$STANDBY_HOSTNAME" ];then
-	    LOG_MSG "[INFO][$INST_COUNT]:-Processing Standby master IP address for segment instances"
-	    for STANDBY_IP in "${STANDBY_IP_ADDRESS[@]}"
-	    do
+        # Configure postgresql.conf
+        LOG_MSG "[INFO][$INST_COUNT]:-Configuring segment $PG_CONF"
+        $TRUSTED_SHELL ${GP_HOSTADDRESS} "$ECHO \"#MPP Specific parameters\" >> ${GP_DIR}/$PG_CONF"
+        RETVAL=$?
+        PARA_EXIT $RETVAL "Update ${GP_DIR}/$PG_CONF file"
+        $TRUSTED_SHELL ${GP_HOSTADDRESS} "$ECHO \"#----------------------\" >> ${GP_DIR}/$PG_CONF"
+        RETVAL=$?
+        PARA_EXIT $RETVAL "Update ${GP_DIR}/$PG_CONF file"
+        SED_PG_CONF ${GP_DIR}/$PG_CONF "$PORT_TXT" port=$GP_PORT 0 $GP_HOSTADDRESS
+        PARA_EXIT $RETVAL "Update port number to $GP_PORT"
+        SED_PG_CONF ${GP_DIR}/$PG_CONF "$LISTEN_ADR_TXT" listen_addresses=\'*\' 0 $GP_HOSTADDRESS
+        PARA_EXIT $RETVAL "Update listen address"
+        SED_PG_CONF ${GP_DIR}/$PG_CONF "$CHKPOINT_SEG_TXT" checkpoint_segments=$CHECK_POINT_SEGMENTS 0 $GP_HOSTADDRESS
+        PARA_EXIT $RETVAL "Update checkpoint segments"
+
+        if [ x"" != x"$PG_CONF_ADD_FILE" ]; then
+	        LOG_MSG "[INFO][$INST_COUNT]:-Processing additional configuration parameters"
+	        for NEW_PARAM in `$CAT $PG_CONF_ADD_FILE|$TR -s ' '|$TR -d ' '|$GREP -v "^#"`
+	        do
+	            LOG_MSG "[INFO][$INST_COUNT]:-Adding config $NEW_PARAM to segment"
+	            SEARCH_TXT=`$ECHO $NEW_PARAM |$CUT -d"=" -f1`
+	            SED_PG_CONF ${GP_DIR}/$PG_CONF $SEARCH_TXT $NEW_PARAM 0 $GP_HOSTADDRESS
+	            PARA_EXIT $RETVAL "Update $PG_CONF $SEARCH_TXT $NEW_PARAM"
+	        done
+        fi
+
+        # Configuring PG_HBA  -- on mirror, only need to add local addresses (skip the other addresses)
+        LOG_MSG "[INFO][$INST_COUNT]:-Configuring segment $PG_HBA"
+        if [ x"" = x"$COPY_FROM_PRIMARY_HOSTADDRESS" ]; then
+	        for MASTER_IP in "${MASTER_IP_ADDRESS[@]}"
+	        do
+	            # MPP-15889
+	            CIDR_MASTER_IP=$(GET_CIDRADDR $MASTER_IP)
+	            $TRUSTED_SHELL ${GP_HOSTADDRESS} "$ECHO host	all	all	${CIDR_MASTER_IP}	trust >> ${GP_DIR}/$PG_HBA"
+	            PARA_EXIT $? "Update $PG_HBA for master IP address ${CIDR_MASTER_IP}"
+	        done
+	        if [ x"" != x"$STANDBY_HOSTNAME" ];then
+	            LOG_MSG "[INFO][$INST_COUNT]:-Processing Standby master IP address for segment instances"
+	            for STANDBY_IP in "${STANDBY_IP_ADDRESS[@]}"
+	            do
+	                # MPP-15889
+	                CIDR_STANDBY_IP=$(GET_CIDRADDR $STANDBY_IP)
+		            $TRUSTED_SHELL ${GP_HOSTADDRESS} "$ECHO host	all	all	${CIDR_STANDBY_IP}	trust >> ${GP_DIR}/$PG_HBA"
+		            PARA_EXIT $? "Update $PG_HBA for master standby address ${CIDR_STANDBY_IP}"
+	            done
+	        fi
+        fi
+
+        # Add all local IPV4 addresses
+        SEGMENT_IPV4_LOCAL_ADDRESS_ALL=(`$TRUSTED_SHELL $GP_HOSTADDRESS "$IPV4_ADDR_LIST_CMD | $GREP inet | $GREP -v \"127.0.0\" | $AWK '{print \\$2}' | $CUT -d'/' -f1"`)
+        for ADDR in "${SEGMENT_IPV4_LOCAL_ADDRESS_ALL[@]}"
+        do
 	        # MPP-15889
-	        CIDR_STANDBY_IP=$(GET_CIDRADDR $STANDBY_IP)
-		$TRUSTED_SHELL ${GP_HOSTADDRESS} "$ECHO host	all	all	${CIDR_STANDBY_IP}	trust >> ${GP_DIR}/$PG_HBA"
-		PARA_EXIT $? "Update $PG_HBA for master standby address ${CIDR_STANDBY_IP}"
-	    done
-	fi
-    fi
+	        CIDR_ADDR=$(GET_CIDRADDR $ADDR)
+            $TRUSTED_SHELL ${GP_HOSTADDRESS} "$ECHO host     all          $USER_NAME         $CIDR_ADDR      trust >> ${GP_DIR}/$PG_HBA"
+        done
 
-    # Add all local IPV4 addresses
-    SEGMENT_IPV4_LOCAL_ADDRESS_ALL=(`$TRUSTED_SHELL $GP_HOSTADDRESS "$IPV4_ADDR_LIST_CMD | $GREP inet | $GREP -v \"127.0.0\" | $AWK '{print \\$2}' | $CUT -d'/' -f1"`)
-    for ADDR in "${SEGMENT_IPV4_LOCAL_ADDRESS_ALL[@]}"
-    do
-	# MPP-15889
-	CIDR_ADDR=$(GET_CIDRADDR $ADDR)
-        $TRUSTED_SHELL ${GP_HOSTADDRESS} "$ECHO host     all          $USER_NAME         $CIDR_ADDR      trust >> ${GP_DIR}/$PG_HBA"
-    done
+        # Add all local IPV6 addresses
+        SEGMENT_IPV6_LOCAL_ADDRESS_ALL=(`$TRUSTED_SHELL $GP_HOSTADDRESS "$IPV6_ADDR_LIST_CMD | $GREP inet6 | $AWK '{print \\$2}' | $CUT -d'/' -f1"`)
+        for ADDR in "${SEGMENT_IPV6_LOCAL_ADDRESS_ALL[@]}"
+        do
+	        # MPP-15889
+	        CIDR_ADDR=$(GET_CIDRADDR $ADDR)
+	        $TRUSTED_SHELL ${GP_HOSTADDRESS} "$ECHO host     all          $USER_NAME         $CIDR_ADDR      trust >> ${GP_DIR}/$PG_HBA"
+        done
 
-    # Add all local IPV6 addresses
-    SEGMENT_IPV6_LOCAL_ADDRESS_ALL=(`$TRUSTED_SHELL $GP_HOSTADDRESS "$IPV6_ADDR_LIST_CMD | $GREP inet6 | $AWK '{print \\$2}' | $CUT -d'/' -f1"`)
-    for ADDR in "${SEGMENT_IPV6_LOCAL_ADDRESS_ALL[@]}"
-    do
-	# MPP-15889
-	CIDR_ADDR=$(GET_CIDRADDR $ADDR)
-	$TRUSTED_SHELL ${GP_HOSTADDRESS} "$ECHO host     all          $USER_NAME         $CIDR_ADDR      trust >> ${GP_DIR}/$PG_HBA"
-    done
-    
-    if [ x"" = x"$COPY_FROM_PRIMARY_HOSTADDRESS" ]; then
-	# Primary: start the segment to fill in configuration
-	START_QE
-	UPDATE_MPP $GP_PORT "$ARRAY_NAME" $TOTAL_SEG $GP_DBID $GP_CONTENT 1 $GP_HOSTADDRESS $GP_DIR
-	STOP_QE
+        # start primary
+        START_QE "-w"
     fi
 
     LOG_MSG "[INFO]:-[$INST_COUNT]-End Function $FUNCNAME"
+}
+
+REGISTER_MIRROR() {
+    LOG_MSG "[INFO]:-Start Function $FUNCNAME"
+    env PGOPTIONS="-c gp_session_role=utility" $PSQL "${DEFAULTDB}" -c "select pg_catalog.gp_add_segment_mirror(${GP_CONTENT}::int2, '${GP_HOSTADDRESS}', '${GP_HOSTADDRESS}', ${GP_PORT}, -1, '{pg_system, ${GP_DIR}}')" >> $LOG_FILE 2>&1
+    LOG_MSG "[INFO]:-End Function $FUNCNAME"
 }
 
 STOP_QE() {
@@ -230,7 +238,8 @@ STOP_QE() {
 
 START_QE() {
 	LOG_MSG "[INFO][$INST_COUNT]:-Starting Functioning instance on segment ${GP_HOSTADDRESS}"
-	$TRUSTED_SHELL ${GP_HOSTADDRESS} "$EXPORT_LIB_PATH;export PGPORT=${GP_PORT}; $PG_CTL -w -l $GP_DIR/pg_log/startup.log -D $GP_DIR -o \"-i -p ${GP_PORT} -M mirrorless --gp_dbid=${GP_DBID} --gp_contentid=${GP_CONTENT} --gp_num_contents_in_cluster=0\" start" >> $LOG_FILE 2>&1
+	PG_CTL_WAIT=$1
+	$TRUSTED_SHELL ${GP_HOSTADDRESS} "$EXPORT_LIB_PATH;export PGPORT=${GP_PORT}; $PG_CTL $PG_CTL_WAIT -l $GP_DIR/pg_log/startup.log -D $GP_DIR -o \"-i -p ${GP_PORT} -M mirrorless --gp_dbid=${GP_DBID} --gp_contentid=${GP_CONTENT} --gp_num_contents_in_cluster=0\" start" >> $LOG_FILE 2>&1
 	RETVAL=$?
 	if [ $RETVAL -ne 0 ]; then
 		BACKOUT_COMMAND "$TRUSTED_SHELL $GP_HOSTADDRESS \"${EXPORT_LIB_PATH};export PGPORT=${GP_PORT}; $PG_CTL -w -D $GP_DIR -o \"-i -p ${GP_PORT}\" -m immediate  stop\""

--- a/gpMgmt/sbin/gpsegstart.py
+++ b/gpMgmt/sbin/gpsegstart.py
@@ -397,9 +397,6 @@ class GpSegStart:
         #
         self.checkPostmasters(must_be_running=True)
 
-        self.__convertSegments()
-        self.checkPostmasters(must_be_running=True)
-
         # At this point any segments remaining in the mapping are assumed to
         # have successfully started.
         #

--- a/gpMgmt/test/behave_utils/utils.py
+++ b/gpMgmt/test/behave_utils/utils.py
@@ -911,7 +911,7 @@ def are_segments_synchronized():
     gparray = GpArray.initFromCatalog(dbconn.DbURL())
     segments = gparray.getDbList()
     for seg in segments:
-        if seg.mode != MODE_SYNCHRONIZED:
+        if seg.mode != MODE_SYNCHRONIZED and not seg.isSegmentMaster(True):
             return False
     return True
 


### PR DESCRIPTION
gpinitsystem with walrep mirrors instead of filerep mirrors

With file replication gone, gpinitsystem should no longer try to
initialize the cluster through filerep sequence.

The sequence now goes as follows:
1. Create and start master in master-only mode
2. Create primaries and register to master
3. Stop master.
4. Run gpstart to start master and primaries.
5. Create mirrors w/ pg_basebackup and register to master.
6. Start the mirrors and wait until primaries and mirrors sync.