### PR TITLE
Fix parsing of port from postmaster.opts in pg_ctl

### DIFF
--- a/src/bin/pg_ctl/pg_ctl.c
+++ b/src/bin/pg_ctl/pg_ctl.c
@@ -510,8 +510,11 @@ test_postmaster_connection(bool do_checkpoint __attribute__((unused)))
 	 */
 	for (p = post_opts; *p;)
 	{
-		/* advance past whitespace */
-		while (isspace((unsigned char) *p))
+		/*
+		 * advance past whitespace/quoting
+		 * GPDB: We also advance upon seeing quotes and backslashes because our post_opts still has them.
+		 */
+		while (isspace((unsigned char) *p) || *p == '\'' || *p == '"')
 			p++;
 
 		if (strncmp(p, "-p", 2) == 0)


### PR DESCRIPTION
The string obtained from postmaster.opts will have port shown as
\"-p\". The parsing does not advance on the quotes and backslashes and
always skips the port. This is only working today because the next if
block parses postgresql.conf for the port.

Author: Jimmy Yih <jyih@pivotal.io>
Author: Marbin Tan <mtan@pivotal.io>