### PR TITLE
Updates for non-deterministic last_value tests

### DIFF
--- a/src/test/regress/expected/window.out
+++ b/src/test/regress/expected/window.out
@@ -377,34 +377,34 @@ SELECT last_value(four) OVER (ORDER BY ten), ten, four FROM tenk1 WHERE unique2 
 (10 rows)
 
 set search_path=singleseg, public;
-SELECT last_value(ten) OVER (PARTITION BY four), ten, four FROM
+SELECT last_value(ten) OVER (PARTITION BY four ORDER BY ten), ten, four FROM
 	(SELECT * FROM tenk1 WHERE unique2 < 10 ORDER BY four, ten)s
 	ORDER BY four, ten;
  last_value | ten | four 
 ------------+-----+------
           0 |   0 |    0
           0 |   0 |    0
-          0 |   4 |    0
+          4 |   4 |    0
           1 |   1 |    1
           1 |   1 |    1
-          1 |   7 |    1
-          1 |   9 |    1
+          7 |   7 |    1
+          9 |   9 |    1
           0 |   0 |    2
-          3 |   1 |    3
+          1 |   1 |    3
           3 |   3 |    3
 (10 rows)
 
-SELECT nth_value(ten, four + 1) OVER (PARTITION BY four), ten, four
+SELECT nth_value(ten, four + 1) OVER (PARTITION BY four ORDER BY ten), ten, four
 	FROM (SELECT * FROM tenk1 WHERE unique2 < 10 ORDER BY four, ten)s order by four,ten;
  nth_value | ten | four 
 -----------+-----+------
          0 |   0 |    0
          0 |   0 |    0
          0 |   4 |    0
-         7 |   1 |    1
-         7 |   1 |    1
-         7 |   7 |    1
-         7 |   9 |    1
+         1 |   1 |    1
+         1 |   1 |    1
+         1 |   7 |    1
+         1 |   9 |    1
            |   0 |    2
            |   1 |    3
            |   3 |    3

--- a/src/test/regress/sql/window.sql
+++ b/src/test/regress/sql/window.sql
@@ -1,7 +1,3 @@
--- start_ignore
--- GPDB_84_MERGE_FIXME
-set optimizer to off;
--- end_ignore
 --
 -- WINDOW FUNCTIONS
 --
@@ -80,11 +76,11 @@ SELECT first_value(ten) OVER (PARTITION BY four ORDER BY ten), ten, four FROM te
 SELECT last_value(four) OVER (ORDER BY ten), ten, four FROM tenk1 WHERE unique2 < 10; 
 
 set search_path=singleseg, public;
-SELECT last_value(ten) OVER (PARTITION BY four), ten, four FROM
+SELECT last_value(ten) OVER (PARTITION BY four ORDER BY ten), ten, four FROM
 	(SELECT * FROM tenk1 WHERE unique2 < 10 ORDER BY four, ten)s
 	ORDER BY four, ten;
 
-SELECT nth_value(ten, four + 1) OVER (PARTITION BY four), ten, four
+SELECT nth_value(ten, four + 1) OVER (PARTITION BY four ORDER BY ten), ten, four
 	FROM (SELECT * FROM tenk1 WHERE unique2 < 10 ORDER BY four, ten)s order by four,ten;
 
 reset search_path;


### PR DESCRIPTION
The new tests added as part of the postgres merge (in `window.sql`), contain tests of
window functions like: `last_value`, `nth_value` without specifying the
ORDER BY clause in the window function. Due to Redistribute Motion
getting added, the order is not deterministic without an explicit ORDER
BY clause within the window function.

This PR updates such tests for the relevant changes in ORCA (https://github.com/greenplum-db/gporca/commit/855ba856fdc59e88923523f1f8b2ead32ae32364).