### PR TITLE
Translate quantified subplan with cast on inner

### DIFF
--- a/src/include/gpopt/translate/CTranslatorDXLToScalar.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToScalar.h
@@ -27,6 +27,7 @@
 #include "naucrates/dxl/operators/CDXLNode.h"
 #include "naucrates/dxl/operators/CDXLDatum.h"
 #include "naucrates/dxl/operators/CDXLScalarArrayRefIndexList.h"
+#include "naucrates/dxl/operators/CDXLScalarCast.h"
 
 // fwd declarations
 namespace gpopt
@@ -228,11 +229,12 @@ namespace gpdxl
 
 			// translate subplan test expression
 			Expr *PexprSubplanTestExpr
-        			(
-        			CDXLNode *pdxlnTestExpr,
+				(
+				CDXLNode *pdxlnTestExpr,
 				SubLinkType slink,
-        			CMappingColIdVar *pmapcidvar
-        			);
+				CMappingColIdVar *pmapcidvar,
+				List **plparamIds
+				);
 			
 			// translate subplan parameters
 			void TranslateSubplanParams
@@ -319,6 +321,11 @@ namespace gpdxl
 			Const *PconstInt8(CDXLDatum *pdxldatum);
 			Const *PconstBool(CDXLDatum *pdxldatum);
 			Const *PconstGeneric(CDXLDatum *pdxldatum);
+			Expr *PrelabeltypeOrFuncexprFromDXLNodeScalarCast
+				(
+				const CDXLScalarCast *pdxlscalarcast,
+				Expr *pexprChild
+				);
 
 			// private copy ctor
 			CTranslatorDXLToScalar(const CTranslatorDXLToScalar&);

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -10098,3 +10098,75 @@ select * from unnest((select string_to_array(name, ',') from bar)) as a;
  person
 (1 row)
 
+-- Query should not fall back to planner and handle implicit cast properly
+CREATE TYPE myint;
+CREATE FUNCTION myintout(myint) RETURNS cstring AS 'int4out' LANGUAGE INTERNAL STRICT IMMUTABLE;
+NOTICE:  argument type myint is only a shell
+CREATE FUNCTION myintin(cstring) RETURNS myint AS 'int4in' LANGUAGE INTERNAL STRICT IMMUTABLE;
+NOTICE:  return type myint is only a shell
+CREATE TYPE myint
+(
+	INPUT=myintin,
+	OUTPUT=myintout,
+	INTERNALLENGTH=4,
+	PASSEDBYVALUE
+);
+CREATE FUNCTION myint_int8(myint) RETURNS int8 AS 'int48' LANGUAGE INTERNAL STRICT IMMUTABLE;
+CREATE CAST (myint AS int8) WITH FUNCTION myint_int8(myint) AS IMPLICIT;
+CREATE TABLE csq_cast_param_outer (a int, b myint);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO csq_cast_param_outer VALUES
+	(1, '42'),
+	(2, '12');
+CREATE TABLE csq_cast_param_inner (c int, d myint);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO csq_cast_param_inner VALUES
+	(11, '11'),
+	(101, '12');
+EXPLAIN SELECT a FROM csq_cast_param_outer WHERE b in (SELECT CASE WHEN a > 1 THEN d ELSE '42' END FROM csq_cast_param_inner);
+                                                   QUERY PLAN
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=1.11..2.49 rows=4 width=4)
+   ->  Nested Loop Semi Join  (cost=1.11..2.49 rows=2 width=4)
+         Join Filter: CASE WHEN csq_cast_param_outer.a > 1 THEN csq_cast_param_inner.d ELSE '42'::myint END::bigint = csq_cast_param_outer.b::bigint
+         ->  Seq Scan on csq_cast_param_outer  (cost=0.00..1.02 rows=1 width=8)
+         ->  Materialize  (cost=1.11..1.17 rows=2 width=4)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.10 rows=2 width=4)
+                     ->  Seq Scan on csq_cast_param_inner  (cost=0.00..1.02 rows=1 width=4)
+ Settings:  optimizer=off; optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
+ Optimizer status: legacy query optimizer
+(9 rows)
+
+SELECT a FROM csq_cast_param_outer WHERE b in (SELECT CASE WHEN a > 1 THEN d ELSE '42' END FROM csq_cast_param_inner);
+ a
+---
+ 1
+ 2
+(2 rows)
+
+DROP CAST (myint as int8);
+CREATE FUNCTION myint_numeric(myint) RETURNS numeric AS 'int4_numeric' LANGUAGE INTERNAL STRICT IMMUTABLE;
+CREATE CAST (myint AS numeric) WITH FUNCTION myint_numeric(myint) AS IMPLICIT;
+EXPLAIN SELECT a FROM csq_cast_param_outer WHERE b in (SELECT CASE WHEN a > 1 THEN d ELSE '42' END FROM csq_cast_param_inner);
+                                                    QUERY PLAN
+-------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=1.11..2.49 rows=4 width=4)
+   ->  Nested Loop Semi Join  (cost=1.11..2.49 rows=2 width=4)
+         Join Filter: CASE WHEN csq_cast_param_outer.a > 1 THEN csq_cast_param_inner.d ELSE '42'::myint END::numeric = csq_cast_param_outer.b::numeric
+         ->  Seq Scan on csq_cast_param_outer  (cost=0.00..1.02 rows=1 width=8)
+         ->  Materialize  (cost=1.11..1.17 rows=2 width=4)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.10 rows=2 width=4)
+                     ->  Seq Scan on csq_cast_param_inner  (cost=0.00..1.02 rows=1 width=4)
+ Settings:  optimizer=off; optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
+ Optimizer status: legacy query optimizer
+(9 rows)
+
+SELECT a FROM csq_cast_param_outer WHERE b in (SELECT CASE WHEN a > 1 THEN d ELSE '42' END FROM csq_cast_param_inner);
+ a
+---
+ 1
+ 2
+(2 rows)
+

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -10163,3 +10163,79 @@ select * from unnest((select string_to_array(name, ',') from bar)) as a;
  person
 (1 row)
 
+-- Query should not fall back to planner and handle implicit cast properly
+CREATE TYPE myint;
+CREATE FUNCTION myintout(myint) RETURNS cstring AS 'int4out' LANGUAGE INTERNAL STRICT IMMUTABLE;
+NOTICE:  argument type myint is only a shell
+CREATE FUNCTION myintin(cstring) RETURNS myint AS 'int4in' LANGUAGE INTERNAL STRICT IMMUTABLE;
+NOTICE:  return type myint is only a shell
+CREATE TYPE myint
+(
+	INPUT=myintin,
+	OUTPUT=myintout,
+	INTERNALLENGTH=4,
+	PASSEDBYVALUE
+);
+CREATE FUNCTION myint_int8(myint) RETURNS int8 AS 'int48' LANGUAGE INTERNAL STRICT IMMUTABLE;
+CREATE CAST (myint AS int8) WITH FUNCTION myint_int8(myint) AS IMPLICIT;
+CREATE TABLE csq_cast_param_outer (a int, b myint);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO csq_cast_param_outer VALUES
+	(1, '42'),
+	(2, '12');
+CREATE TABLE csq_cast_param_inner (c int, d myint);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO csq_cast_param_inner VALUES
+	(11, '11'),
+	(101, '12');
+EXPLAIN SELECT a FROM csq_cast_param_outer WHERE b in (SELECT CASE WHEN a > 1 THEN d ELSE '42' END FROM csq_cast_param_inner);
+                                                   QUERY PLAN
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324032.56 rows=2 width=4)
+   ->  Result  (cost=0.00..1324032.56 rows=1 width=4)
+         ->  Table Scan on csq_cast_param_outer  (cost=0.00..1324032.56 rows=1 width=4)
+               Filter: (SubPlan 1)
+               SubPlan 1
+                 ->  Result  (cost=0.00..431.00 rows=2 width=4)
+                       ->  Materialize  (cost=0.00..431.00 rows=2 width=4)
+                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
+                                   ->  Table Scan on csq_cast_param_inner  (cost=0.00..431.00 rows=1 width=4)
+ Settings:  optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
+ Optimizer status: PQO version 2.51.3
+(11 rows)
+
+SELECT a FROM csq_cast_param_outer WHERE b in (SELECT CASE WHEN a > 1 THEN d ELSE '42' END FROM csq_cast_param_inner);
+ a
+---
+ 1
+ 2
+(2 rows)
+
+DROP CAST (myint as int8);
+CREATE FUNCTION myint_numeric(myint) RETURNS numeric AS 'int4_numeric' LANGUAGE INTERNAL STRICT IMMUTABLE;
+CREATE CAST (myint AS numeric) WITH FUNCTION myint_numeric(myint) AS IMPLICIT;
+EXPLAIN SELECT a FROM csq_cast_param_outer WHERE b in (SELECT CASE WHEN a > 1 THEN d ELSE '42' END FROM csq_cast_param_inner);
+                                                   QUERY PLAN
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324032.56 rows=2 width=4)
+   ->  Result  (cost=0.00..1324032.56 rows=1 width=4)
+         ->  Table Scan on csq_cast_param_outer  (cost=0.00..1324032.56 rows=1 width=4)
+               Filter: (SubPlan 1)
+               SubPlan 1
+                 ->  Result  (cost=0.00..431.00 rows=2 width=4)
+                       ->  Materialize  (cost=0.00..431.00 rows=2 width=4)
+                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
+                                   ->  Table Scan on csq_cast_param_inner  (cost=0.00..431.00 rows=1 width=4)
+ Settings:  optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
+ Optimizer status: PQO version 2.51.3
+(11 rows)
+
+SELECT a FROM csq_cast_param_outer WHERE b in (SELECT CASE WHEN a > 1 THEN d ELSE '42' END FROM csq_cast_param_inner);
+ a
+---
+ 1
+ 2
+(2 rows)
+

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -1575,22 +1575,23 @@ EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f3 AS "Second Field"
   FROM SUBSELECT_TBL upper
   WHERE f3 IN (SELECT upper.f1 + f2 FROM SUBSELECT_TBL
                WHERE f2 = CAST(f3 AS integer)) ORDER BY 2,3;
-                                               QUERY PLAN                                               
---------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=2.18..2.19 rows=4 width=12)
-   Merge Key: upper.f1, upper.f3
-   ->  Sort  (cost=2.18..2.19 rows=2 width=12)
-         Sort Key: upper.f1, upper.f3
-         ->  Nested Loop Semi Join  (cost=3.16..6.90 rows=2 width=12)
-               Join Filter: (upper.f1 + subselect_tbl.f2)::double precision = upper.f3
-               ->  Seq Scan on subselect_tbl upper  (cost=0.00..3.08 rows=3 width=12)
-               ->  Materialize  (cost=3.16..3.19 rows=1 width=12)
-                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.16 rows=1 width=12)
-                           ->  Seq Scan on subselect_tbl  (cost=0.00..3.12 rows=1 width=12)
-                                 Filter: f2 = f3::integer
- Settings:  optimizer=on
- Optimizer status: legacy query optimizer
-(13 rows)
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1324033.89 rows=3 width=20)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324033.89 rows=8 width=12)
+         Merge Key: subselect_gp.subselect_tbl.f1, subselect_gp.subselect_tbl.f3
+         ->  Sort  (cost=0.00..1324033.89 rows=3 width=12)
+               Sort Key: subselect_gp.subselect_tbl.f1, subselect_gp.subselect_tbl.f3
+               ->  Table Scan on subselect_tbl  (cost=0.00..1324033.89 rows=3 width=12)
+                     Filter: (SubPlan 1)
+                     SubPlan 1
+                       ->  Result  (cost=0.00..431.00 rows=4 width=4)
+                             ->  Materialize  (cost=0.00..431.00 rows=4 width=4)
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=4 width=4)
+                                         ->  Table Scan on subselect_tbl  (cost=0.00..431.00 rows=2 width=4)
+                                               Filter: f2 = int4(f3)
+ Optimizer status: PQO version 2.53.1
+(14 rows)
 
 EXPLAIN SELECT '' AS five, f1 AS "Correlated Field"
   FROM SUBSELECT_TBL


### PR DESCRIPTION
In the case where there was a Scalar Cast on the inner,  ORCA failed to translate it. 

for example, given the following repro:
```
create table foo (a int, b varchar(10));
create table bar (c int, d varchar(10));
explain select a from foo where b in (select case when a > 1 then d else 'M' end from bar);
```

the translator would fall back, because it didn't expect the `testexpr` of the `SubPlan` expression to contain a cast (a `RelabelType` in this case).

This PR relaxes that assumption, and addresses both the case of a binary-coercible cast (translated as a `RelabelType`) and a regular cast (translated as a `FuncExpr`).

In passing, we also improved the `gporca` test so that it creates object solely in a schema by switching its `search_path`.

Jesse and Sam