### PR TITLE
Make gpstart work for walrep mirrors

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -372,12 +372,17 @@ class SegmentStart(Command):
         content = gpdb.getSegmentContentId()
         port    = gpdb.getSegmentPort()
         datadir = gpdb.getSegmentDataDirectory()
+        role    = gpdb.getSegmentRole()
 
         # build backend options
         b = PgCtlBackendOptions(port, dbid, numContentsInCluster)
         b.set_segment(mirrormode, content)
         b.set_utility(utilityMode)
         b.set_special(specialMode)
+
+        # mirror will be in recovery mode so pg_ctl -w flag won't work
+        if role == gparray.ROLE_MIRROR:
+            noWait = True
 
         # build pg_ctl command
         c = PgCtlStartArgs(datadir, b, era, wrapper, wrapper_args, not noWait, timeout)


### PR DESCRIPTION
All that was needed was to make sure mirrors are not started with
pg_ctl -w flag since the mirror is in recovery mode and will not
respond to PQPing messages.

Author: Jimmy Yih <jyih@pivotal.io>
Author: Marbin Tan <mtan@pivotal.io>