### PR TITLE
Pipeline generation production updates and fix for SLES jobs.

### DIFF
--- a/concourse/pipelines/gpdb_master-generated.yml
+++ b/concourse/pipelines/gpdb_master-generated.yml
@@ -30,7 +30,6 @@ groups:
 - name: all
   jobs:
   ## --------------------------------------------------------------------
-  - validate_pipeline
   - gate_compile_start
   - compile_gpdb_centos6
   - compile_gpdb_binary_swap_centos6
@@ -721,16 +720,6 @@ cs_ccp_run_tests_params_anchor: &cs_ccp_run_tests_params
 ## ======================================================================
 
 jobs:
-
-- name: validate_pipeline
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      trigger: true
-    - get: centos-gpdb-dev-6
-  - task: validate_pipeline
-    file: gpdb_src/concourse/tasks/validate_pipeline.yml
-    image: centos-gpdb-dev-6
 
 ## ======================================================================
 ##   ____                      _ _      
@@ -3426,4 +3415,3 @@ jobs:
     - DPM_gptransfer_43x_to_master
     - DPM_gptransfer
     - mpp_interconnect
-    - validate_pipeline

--- a/concourse/pipelines/pr_pipeline.yml
+++ b/concourse/pipelines/pr_pipeline.yml
@@ -106,13 +106,6 @@ jobs:
           BINTRAY_REMOTE: {{bintray_remote}}
           BINTRAY_REMOTE_URL: {{bintray_remote_url}}
 
-      - task: validate_pipeline
-        file: gpdb_pr/concourse/tasks/validate_pipeline.yml
-        image: centos-gpdb-dev-6
-        input_mapping:
-          gpdb_src: gpdb_pr
-        on_failure: *pr_failure
-
     - aggregate:
       - task: icw_planner_centos6
         file: gpdb_pr/concourse/tasks/ic_gpdb.yml

--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -38,9 +38,6 @@ groups:
 - name: all
   jobs:
   ## --------------------------------------------------------------------
-{% if pipeline_type == "prod" %}
-  - validate_pipeline
-{% endif %}
   - gate_compile_start
 {% if "centos6" in os_types %}
   - compile_gpdb_centos6
@@ -257,6 +254,7 @@ groups:
 
 ## ======================================================================
 
+{% if "centos6" in os_types %}
 - name: G:SegWALRep
   jobs:
   - compile_gpdb_segwalrep_centos6
@@ -264,6 +262,7 @@ groups:
   - icw_gporca_segwalrep_centos6
   - segwalrep_mirrorless_centos6
 
+{% endif %}
 {% endif %}
 {% if "MPP" in test_sections %}
 ## ======================================================================
@@ -361,11 +360,12 @@ resource_types:
 ## ======================================================================
 
 resources:
-{% if "CS" in test_sections or
-      "DPM" in test_sections or
+{% if ("ICW"    in test_sections and "sles" in os_types) or
+      "CS"      in test_sections or
+      "DPM"     in test_sections or
       "FileRep" in test_sections or
-      "MPP" in test_sections or
-      "MM" in test_sections %}
+      "MPP"     in test_sections or
+      "MM"      in test_sections %}
 - name: ccp_src
   type: git
   source:
@@ -374,7 +374,8 @@ resources:
     uri: {{ccp-git-remote}}
     tag_filter: {{ccp-tag-filter}}
 
-{% if "centos6" in os_types %}
+{% if "centos6" in os_types or
+      "ICW"     in test_sections %}
 - name: terraform
   type: terraform
   source:
@@ -471,7 +472,7 @@ resources:
     uri: ((debian-release-git-remote))
 
 {% endif %}
-{% if "centos6" in os_types or "aix7" in os_types %}
+{% if "centos6" in os_types or "sles" in os_types or "aix7" in os_types %}
 - name: centos-gpdb-dev-6
   type: docker-image
   source:
@@ -834,19 +835,7 @@ cs_ccp_run_tests_params_anchor: &cs_ccp_run_tests_params
 ## ======================================================================
 
 jobs:
-{% if pipeline_type == "prod" %}
 
-- name: validate_pipeline
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      trigger: true
-    - get: centos-gpdb-dev-6
-  - task: validate_pipeline
-    file: gpdb_src/concourse/tasks/validate_pipeline.yml
-    image: centos-gpdb-dev-6
-
-{% endif %}
 ## ======================================================================
 ##   ____                      _ _      
 ##  / ___|___  _ __ ___  _ __ (_) | ___ 
@@ -3039,5 +3028,4 @@ jobs:
     - DPM_gptransfer_43x_to_master
     - DPM_gptransfer
     - mpp_interconnect
-    - validate_pipeline
 {% endif %}

--- a/concourse/tasks/validate_pipeline.yml
+++ b/concourse/tasks/validate_pipeline.yml
@@ -1,9 +1,0 @@
-platform: linux
-image_resource:
-  type: docker-image
-inputs:
-  - name: gpdb_src
-run:
-  path: gpdb_src/concourse/scripts/validate_pipeline_release_jobs.py
-params:
-  PIPELINE_FILE: gpdb_src/concourse/pipelines/gpdb_master-generated.yml


### PR DESCRIPTION
o This moves the validation (subprocess call) of the pipelines release
  jobs into the tool which generates the production pipeline. The
  corresponding task validate_pipeline.yml is removed and
  corresponding job.

o Output production fly commands for both "gpdb_master" and
  "gpdb_master_without_asserts" pipelines. This will help engineers
  update both production pipelines.

o Fix the icw sles jobs in the development pipelines.

o Update README.md with clear usage examples.