### PR TITLE
Remove broken test queries.

### DIFF
--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -2563,111 +2563,25 @@ update v set j = 2;
 update v set j = 3;
 ERROR:  moving tuple from partition "v_1_prt_1" to partition "v_1_prt_2" not supported  (seg0 slarimac:40000 pid=97875)
 drop table v;
--- test AO seg totals
---
--- Note: ignore partition tablenames due to endianness issues
---
-create  or replace function ao_ptotal(relname text) returns float8 as $$
-declare
-  aosegname text;
-  tupcount float8 := 0;
-  rc int := 0;
-begin
-
-  execute 'select relname from pg_class where oid=(select segrelid from pg_class, pg_appendonly where relname=''' || relname || ''' and relid = pg_class.oid)' into aosegname;
-  if aosegname > 0 then
-	  execute 'select tupcount from pg_aoseg.' || aosegname into tupcount;
-  end if;
-  return tupcount;
-end; $$ language plpgsql volatile READS SQL DATA;
+-- try SREH on a partitioned table.
 create table ao_p (i int) with (appendonly = true)
  partition by range(i)
- (start(1) end(10) every(1));
+ (start(1) end(5) every(1));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 NOTICE:  CREATE TABLE will create partition "ao_p_1_prt_1" for table "ao_p"
 NOTICE:  CREATE TABLE will create partition "ao_p_1_prt_2" for table "ao_p"
 NOTICE:  CREATE TABLE will create partition "ao_p_1_prt_3" for table "ao_p"
 NOTICE:  CREATE TABLE will create partition "ao_p_1_prt_4" for table "ao_p"
-NOTICE:  CREATE TABLE will create partition "ao_p_1_prt_5" for table "ao_p"
-NOTICE:  CREATE TABLE will create partition "ao_p_1_prt_6" for table "ao_p"
-NOTICE:  CREATE TABLE will create partition "ao_p_1_prt_7" for table "ao_p"
-NOTICE:  CREATE TABLE will create partition "ao_p_1_prt_8" for table "ao_p"
-NOTICE:  CREATE TABLE will create partition "ao_p_1_prt_9" for table "ao_p"
-insert into ao_p values(1), (2), (3);
--- start_ignore
-select partitiontablename, ao_ptotal(partitiontablename)
-from pg_partitions where tablename = 'ao_p';
- partitiontablename | ao_ptotal 
---------------------+-----------
- ao_p_1_prt_1       |         1
- ao_p_1_prt_2       |         1
- ao_p_1_prt_3       |         1
- ao_p_1_prt_4       |          
- ao_p_1_prt_5       |          
- ao_p_1_prt_6       |          
- ao_p_1_prt_7       |          
- ao_p_1_prt_8       |          
- ao_p_1_prt_9       |          
-(9 rows)
-
--- end_ignore
-truncate ao_p;
--- start_ignore
-select partitiontablename, ao_ptotal(partitiontablename)
-from pg_partitions where tablename = 'ao_p';
- partitiontablename | ao_ptotal 
---------------------+-----------
- ao_p_1_prt_1       |          
- ao_p_1_prt_2       |          
- ao_p_1_prt_3       |          
- ao_p_1_prt_4       |          
- ao_p_1_prt_5       |          
- ao_p_1_prt_6       |          
- ao_p_1_prt_7       |          
- ao_p_1_prt_8       |          
- ao_p_1_prt_9       |          
-(9 rows)
-
--- end_ignore
-copy ao_p from stdin;
--- start_ignore
-select partitiontablename, ao_ptotal(partitiontablename)
-from pg_partitions where tablename = 'ao_p';
- partitiontablename | ao_ptotal 
---------------------+-----------
- ao_p_1_prt_1       |          
- ao_p_1_prt_2       |          
- ao_p_1_prt_3       |          
- ao_p_1_prt_4       |         1
- ao_p_1_prt_5       |         1
- ao_p_1_prt_6       |         1
- ao_p_1_prt_7       |          
- ao_p_1_prt_8       |          
- ao_p_1_prt_9       |          
-(9 rows)
-
--- end_ignore
--- try SREH
 copy ao_p from stdin log errors segment reject limit 100;
 NOTICE:  Found 2 data formatting errors (2 or more input rows). Rejected related input data.
--- start_ignore
-select partitiontablename, ao_ptotal(partitiontablename)
-from pg_partitions where tablename = 'ao_p';
- partitiontablename | ao_ptotal 
---------------------+-----------
- ao_p_1_prt_1       |          
- ao_p_1_prt_2       |          
- ao_p_1_prt_3       |          
- ao_p_1_prt_4       |         1
- ao_p_1_prt_5       |         1
- ao_p_1_prt_6       |         2
- ao_p_1_prt_7       |         1
- ao_p_1_prt_8       |          
- ao_p_1_prt_9       |          
-(9 rows)
+select * from ao_p;
+ i 
+---
+ 2
+ 3
+(2 rows)
 
--- end_ignore
 drop table ao_p;
 -- MPP-3591: make sure we get inclusive/exclusive right with every().
 create table k (i int) partition by range(i)

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -2562,111 +2562,25 @@ update v set j = 2;
 -- should fail
 update v set j = 3;
 drop table v;
--- test AO seg totals
---
--- Note: ignore partition tablenames due to endianness issues
---
-create  or replace function ao_ptotal(relname text) returns float8 as $$
-declare
-  aosegname text;
-  tupcount float8 := 0;
-  rc int := 0;
-begin
-
-  execute 'select relname from pg_class where oid=(select segrelid from pg_class, pg_appendonly where relname=''' || relname || ''' and relid = pg_class.oid)' into aosegname;
-  if aosegname > 0 then
-	  execute 'select tupcount from pg_aoseg.' || aosegname into tupcount;
-  end if;
-  return tupcount;
-end; $$ language plpgsql volatile READS SQL DATA;
+-- try SREH on a partitioned table.
 create table ao_p (i int) with (appendonly = true)
  partition by range(i)
- (start(1) end(10) every(1));
+ (start(1) end(5) every(1));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 NOTICE:  CREATE TABLE will create partition "ao_p_1_prt_1" for table "ao_p"
 NOTICE:  CREATE TABLE will create partition "ao_p_1_prt_2" for table "ao_p"
 NOTICE:  CREATE TABLE will create partition "ao_p_1_prt_3" for table "ao_p"
 NOTICE:  CREATE TABLE will create partition "ao_p_1_prt_4" for table "ao_p"
-NOTICE:  CREATE TABLE will create partition "ao_p_1_prt_5" for table "ao_p"
-NOTICE:  CREATE TABLE will create partition "ao_p_1_prt_6" for table "ao_p"
-NOTICE:  CREATE TABLE will create partition "ao_p_1_prt_7" for table "ao_p"
-NOTICE:  CREATE TABLE will create partition "ao_p_1_prt_8" for table "ao_p"
-NOTICE:  CREATE TABLE will create partition "ao_p_1_prt_9" for table "ao_p"
-insert into ao_p values(1), (2), (3);
--- start_ignore
-select partitiontablename, ao_ptotal(partitiontablename)
-from pg_partitions where tablename = 'ao_p';
- partitiontablename | ao_ptotal 
---------------------+-----------
- ao_p_1_prt_1       |         1
- ao_p_1_prt_2       |         1
- ao_p_1_prt_3       |         1
- ao_p_1_prt_4       |          
- ao_p_1_prt_5       |          
- ao_p_1_prt_6       |          
- ao_p_1_prt_7       |          
- ao_p_1_prt_8       |          
- ao_p_1_prt_9       |          
-(9 rows)
-
--- end_ignore
-truncate ao_p;
--- start_ignore
-select partitiontablename, ao_ptotal(partitiontablename)
-from pg_partitions where tablename = 'ao_p';
- partitiontablename | ao_ptotal 
---------------------+-----------
- ao_p_1_prt_1       |          
- ao_p_1_prt_2       |          
- ao_p_1_prt_3       |          
- ao_p_1_prt_4       |          
- ao_p_1_prt_5       |          
- ao_p_1_prt_6       |          
- ao_p_1_prt_7       |          
- ao_p_1_prt_8       |          
- ao_p_1_prt_9       |          
-(9 rows)
-
--- end_ignore
-copy ao_p from stdin;
--- start_ignore
-select partitiontablename, ao_ptotal(partitiontablename)
-from pg_partitions where tablename = 'ao_p';
- partitiontablename | ao_ptotal 
---------------------+-----------
- ao_p_1_prt_1       |          
- ao_p_1_prt_2       |          
- ao_p_1_prt_3       |          
- ao_p_1_prt_4       |         1
- ao_p_1_prt_5       |         1
- ao_p_1_prt_6       |         1
- ao_p_1_prt_7       |          
- ao_p_1_prt_8       |          
- ao_p_1_prt_9       |          
-(9 rows)
-
--- end_ignore
--- try SREH
 copy ao_p from stdin log errors segment reject limit 100;
 NOTICE:  Found 2 data formatting errors (2 or more input rows). Rejected related input data.
--- start_ignore
-select partitiontablename, ao_ptotal(partitiontablename)
-from pg_partitions where tablename = 'ao_p';
- partitiontablename | ao_ptotal 
---------------------+-----------
- ao_p_1_prt_1       |          
- ao_p_1_prt_2       |          
- ao_p_1_prt_3       |          
- ao_p_1_prt_4       |         1
- ao_p_1_prt_5       |         1
- ao_p_1_prt_6       |         2
- ao_p_1_prt_7       |         1
- ao_p_1_prt_8       |          
- ao_p_1_prt_9       |          
-(9 rows)
+select * from ao_p;
+ i 
+---
+ 2
+ 3
+(2 rows)
 
--- end_ignore
 drop table ao_p;
 -- MPP-3591: make sure we get inclusive/exclusive right with every().
 create table k (i int) partition by range(i)

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -1348,58 +1348,18 @@ update v set j = 2;
 update v set j = 3;
 drop table v;
 
--- test AO seg totals
---
--- Note: ignore partition tablenames due to endianness issues
---
-create  or replace function ao_ptotal(relname text) returns float8 as $$
-declare
-  aosegname text;
-  tupcount float8 := 0;
-  rc int := 0;
-begin
-
-  execute 'select relname from pg_class where oid=(select segrelid from pg_class, pg_appendonly where relname=''' || relname || ''' and relid = pg_class.oid)' into aosegname;
-  if aosegname > 0 then
-	  execute 'select tupcount from pg_aoseg.' || aosegname into tupcount;
-  end if;
-  return tupcount;
-end; $$ language plpgsql volatile READS SQL DATA;
-
+-- try SREH on a partitioned table.
 create table ao_p (i int) with (appendonly = true)
  partition by range(i)
- (start(1) end(10) every(1));
+ (start(1) end(5) every(1));
 
-insert into ao_p values(1), (2), (3);
--- start_ignore
-select partitiontablename, ao_ptotal(partitiontablename)
-from pg_partitions where tablename = 'ao_p';
--- end_ignore
-truncate ao_p;
--- start_ignore
-select partitiontablename, ao_ptotal(partitiontablename)
-from pg_partitions where tablename = 'ao_p';
--- end_ignore
-copy ao_p from stdin;
-4
-5
-6
-\.
--- start_ignore
-select partitiontablename, ao_ptotal(partitiontablename)
-from pg_partitions where tablename = 'ao_p';
--- end_ignore
--- try SREH
 copy ao_p from stdin log errors segment reject limit 100;
-6
-7
+2
+3
 10000
 f
 \.
--- start_ignore
-select partitiontablename, ao_ptotal(partitiontablename)
-from pg_partitions where tablename = 'ao_p';
--- end_ignore
+select * from ao_p;
 drop table ao_p;
 
 -- MPP-3591: make sure we get inclusive/exclusive right with every().


### PR DESCRIPTION
The ao_ptotal() test function was broken a long time ago, in the 8.3 merge,
by the removal of implicit cast from text to integer. You just got an
"operator does not exist: text > integer" error. However, the queries
using the function were inside start/end_ignore blocks, so that didn't

We have tests on tupcount elsewhere, in the uao_* tests, for example.
Whether the table is partitioned or not doesn't seem very interesting. So
just remove the test queries, rather than try to fix them. (I don't
understand what the endianess issue mentioned in the comment might've
been.)

I kept the test on COPY with REJECT LIMIT on partitioned table. I'm not
sure how interesting that is either, but it wasn't broken. While at it,
I reduced the number of partitions used, though, to shave off a few
milliseconds from the test.