### PR TITLE
WIP: try to find the end of \d tables correctly in atmsort

### DIFF
--- a/contrib/extprotocol/expected/exttableext.out
+++ b/contrib/extprotocol/expected/exttableext.out
@@ -689,9 +689,9 @@ Type: readable
 Encoding: UTF8
 Format type: text
 Format options: delimiter '	' null '\N' escape '\'
+External options: {}
 External location: demoprot://exttabtest.txt
 Execute on: all segments
-External options: {}
 
     select count(*) from pg_class where relname = 'exttabtest_r_newname';
  count 

--- a/src/test/regress/atmsort.pm
+++ b/src/test/regress/atmsort.pm
@@ -1102,6 +1102,7 @@ sub atmsort_bigloop
     my $getstatement = 0;
     my $has_order = 0;
     my $copy_to_stdout_result = 0;
+    my $describe_mode = 0;
     my $directive = {};
     my $big_ignore = 0;
     my %define_match_expression;
@@ -1218,12 +1219,41 @@ sub atmsort_bigloop
                 goto reprocess_row;
             }
 
+            my $end_of_table = 0;
+
+            if ($describe_mode)
+            {
+                # \d tables don't always end with a row count, and there may be
+                # more than one of them per command. So we allow any of the
+                # following to end the table:
+                # - a blank line
+                # - a row that doesn't have the same number of column separators
+                #   as the header line
+                # - a row count (checked below)
+                if ($ini =~ m/^$/)
+                {
+                    $end_of_table = 1;
+                }
+                elsif (exists($directive->{firstline}))
+                {
+                    # Count the number of column separators in the table header
+                    # and our current line.
+                    my @headerSeparators = $directive->{firstline} =~ m/\|/;
+                    my @lineSeparators = $ini =~ m/\|/;
+
+                    if (scalar @headerSeparators != scalar @lineSeparators)
+                    {
+                        $end_of_table = 1;
+                    }
+                }
+
+                # Don't reset describe_mode at the end of the table; there may
+                # be more tables still to go.
+            }
+
             # regex example: (5 rows)
             if ($ini =~ m/^\s*\(\d+\s+row(?:s)*\)\s*$/)
             {
-                format_query_output($glob_fqo,
-                                    $has_order, \@outarr, $directive);
-
                 # Always ignore the rowcount for explain plan out as the
                 # skeleton plans might be the same even if the row counts
                 # differ because of session level GUCs.
@@ -1231,6 +1261,14 @@ sub atmsort_bigloop
                 {
                     $ini = 'GP_IGNORE:' . $ini;
                 }
+
+                $end_of_table = 1;
+            }
+
+            if ($end_of_table)
+            {
+                format_query_output($glob_fqo,
+                                    $has_order, \@outarr, $directive);
 
                 $directive = {};
                 @outarr = ();
@@ -1282,6 +1320,10 @@ sub atmsort_bigloop
                 {
                     $directive->{explain} = 'normal';
                 }
+
+                # Should we apply more heuristics to try to find the end of \d
+                # output?
+                $describe_mode = ($ini =~ m/\\d/);
             }
 
 			# Catching multiple commands and capturing the parens matches

--- a/src/test/regress/atmsort.pm
+++ b/src/test/regress/atmsort.pm
@@ -1238,10 +1238,10 @@ sub atmsort_bigloop
                 {
                     # Count the number of column separators in the table header
                     # and our current line.
-                    my @headerSeparators = $directive->{firstline} =~ m/\|/;
-                    my @lineSeparators = $ini =~ m/\|/;
+                    my $headerSeparators = ($directive->{firstline} =~ tr/\|//);
+                    my $lineSeparators = ($ini =~ tr/\|//);
 
-                    if (scalar @headerSeparators != scalar @lineSeparators)
+                    if ($headerSeparators != $lineSeparators)
                     {
                         $end_of_table = 1;
                     }
@@ -1310,7 +1310,7 @@ sub atmsort_bigloop
             }
 
             # Note: \d is for the psql "describe"
-            if ($ini =~ m/(?:insert|update|delete|select|\\d|copy|execute)/i)
+            if ($ini =~ m/(?:insert|update|delete|select|^\s*\\d|copy|execute)/i)
             {
                 $copy_to_stdout_result = 0;
                 $has_order = 0;
@@ -1323,7 +1323,7 @@ sub atmsort_bigloop
 
                 # Should we apply more heuristics to try to find the end of \d
                 # output?
-                $describe_mode = ($ini =~ m/\\d/);
+                $describe_mode = ($ini =~ m/^\s*\\d/);
             }
 
 			# Catching multiple commands and capturing the parens matches


### PR DESCRIPTION
This is a work in progress; I certainly don't intend to push this right before the holidays. Please comment/review as you see fit.

Several `\d` variants don't put a row count at the end of their tables, which means that atmsort doesn't stop sorting output until it finds a row count somewhere later. Some tests are having their diff output horribly mangled because of this, which makes debugging difficult. Here's [a nonsense diff in Concourse](https://gpdb.data.pivotal.ci/teams/main/pipelines/gpdb_master/jobs/icw_gporca_centos6/builds/5) as an example. 

When we see a `\d` command, try to apply more heuristics for finding the end of a table. In addition to ending at a row count, end table sorting whenever we find a line that doesn't have the same number of column separators as the table header. If we don't have a table header, still attempt to end table sorting at a blank line.