### PR TITLE
Update qp_olap_windowerr tests

### DIFF
--- a/src/test/regress/expected/qp_olap_windowerr.out
+++ b/src/test/regress/expected/qp_olap_windowerr.out
@@ -1,7 +1,8 @@
 --
 -- STANDARD DATA FOR olap_* TESTS.
 --
--- start_ignore
+--- start_ignore
+set optimizer_trace_fallback = on;
 drop table cf_olap_windowerr_customer;
 ERROR:  table "cf_olap_windowerr_customer" does not exist
 drop table cf_olap_windowerr_vendor;
@@ -147,13 +148,13 @@ WINDOW win1 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn d
  04-01-1401 | 40 | 200 |          .0000000 |  3
  05-01-1401 | 20 | 100 |          .0000000 |  1
  05-02-1401 | 30 | 300 |          .0000000 |  1
+ 06-01-1401 | 50 | 400 |          .0000000 |  1
+ 06-01-1401 | 50 | 400 |          .0000000 |  2
  06-01-1401 | 30 | 500 |          .0000000 |  1
  06-01-1401 | 30 | 500 |          .0000000 |  3
  06-01-1401 | 30 | 600 |          .0000000 |  3
  06-01-1401 | 40 | 700 |          .0000000 |  4
  06-01-1401 | 40 | 800 |          .0000000 |  4
- 06-01-1401 | 50 | 400 |          .0000000 |  1
- 06-01-1401 | 50 | 400 |          .0000000 |  2
 (12 rows)
 
 -- COUNT() function with ONLY order by having range based framing clause in combination with other functions --
@@ -173,15 +174,15 @@ TO_CHAR(COALESCE(RANK() OVER(win3),0),'99999999.9999999'),
 TO_CHAR(COALESCE(LEAD(cast(floor(cf_olap_windowerr_sale.vn-cf_olap_windowerr_sale.cn) as int),cast (floor(cf_olap_windowerr_sale.prc-cf_olap_windowerr_sale.qty) as int),NULL) OVER(win4),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn ) cf_olap_windowerr_sale
 WINDOW win1 as (order by cf_olap_windowerr_sale.vn desc range between floor(cf_olap_windowerr_sale.cn+cf_olap_windowerr_sale.qty) preceding and 2 preceding ),
-win2 as (partition by cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.pn desc),
+win2 as (partition by cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc),
 win3 as (order by cf_olap_windowerr_sale.cn desc),
 win4 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc);
  pn  | vn | cn | prc  |      to_char      |      to_char      |      to_char      | qty  |      to_char      |      to_char      
 -----+----+----+------+-------------------+-------------------+-------------------+------+-------------------+-------------------
- 100 | 20 |  1 |    0 |          .0000000 |          .0000000 |         1.0000000 |    1 |         8.0000000 |        37.0000000
  100 | 40 |  2 | 2400 |         2.0000000 |         2.0000000 |         1.0000000 | 1100 |         6.0000000 |          .0000000
  200 | 10 |  1 |    0 |          .0000000 |          .0000000 |         1.0000000 |    1 |         8.0000000 |        38.0000000
  200 | 40 |  3 |    0 |          .0000000 |          .0000000 |         1.0000000 |    1 |         3.0000000 |         9.0000000
+ 100 | 20 |  1 |    0 |          .0000000 |          .0000000 |         1.0000000 |    1 |         8.0000000 |        37.0000000
  300 | 30 |  1 |    0 |          .0000000 |          .0000000 |         1.0000000 |    1 |         8.0000000 |        19.0000000
  400 | 50 |  1 |    0 |          .0000000 |          .0000000 |         1.0000000 |    1 |         8.0000000 |        29.0000000
  400 | 50 |  2 |    0 |          .0000000 |          .0000000 |         1.0000000 |    1 |         6.0000000 |        49.0000000
@@ -208,16 +209,16 @@ win4 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn,cf_ola
 ------+----+----+----+-------------------+----+-------------------+------+-----+-------------------+-------------------+-------------------+-------------------
     0 |  1 |  1 |  1 |         1.0000000 | 10 |          .0000000 |    1 | 200 |          .3333333 |          .3333333 |         1.0000000 |         1.0000000
     0 |  1 |  1 |  1 |         1.0000000 | 20 |          .0000000 |    1 | 100 |          .1666667 |          .1666667 |         1.0000000 |         1.0000000
-    0 |  1 |  1 |  1 |         2.0000000 | 50 |          .0000000 |    1 | 400 |          .5833333 |          .5833333 |         1.0000000 |         1.0000000
     0 |  1 |  1 |  1 |         4.0000000 | 30 |          .0000000 |    1 | 300 |          .4166667 |          .4166667 |         1.0000000 |         1.0000000
-    0 |  2 |  2 |  2 |         2.0000000 | 50 |          .0000000 |    1 | 400 |          .5833333 |          .5833333 |         1.0000000 |          .0000000
-    0 |  3 |  3 |  3 |         4.0000000 | 40 |          .0000000 |    1 | 200 |          .3333333 |          .3333333 |         1.0000000 |          .0000000
-    1 |  4 |  4 |  4 |         4.0000000 | 40 |          .0000000 |    1 | 700 |          .9166667 |          .9166667 |         1.0000000 |          .0000000
-    1 |  4 |  4 |  4 |         4.0000000 | 40 |          .0000000 |    1 | 800 |         1.0000000 |         1.0000000 |         1.0000000 |          .0000000
     5 |  1 |  1 |  1 |         4.0000000 | 30 |          .0000000 |   12 | 500 |          .7500000 |          .7500000 |         1.0000000 |          .0000000
     5 |  3 |  3 |  3 |         4.0000000 | 30 |          .0000000 |   12 | 500 |          .7500000 |          .7500000 |         1.0000000 |          .0000000
     5 |  3 |  3 |  3 |         4.0000000 | 30 |          .0000000 |   12 | 600 |          .8333333 |          .8333333 |         1.0000000 |          .0000000
+    0 |  3 |  3 |  3 |         4.0000000 | 40 |          .0000000 |    1 | 200 |          .3333333 |          .3333333 |         1.0000000 |          .0000000
+    1 |  4 |  4 |  4 |         4.0000000 | 40 |          .0000000 |    1 | 700 |          .9166667 |          .9166667 |         1.0000000 |          .0000000
+    1 |  4 |  4 |  4 |         4.0000000 | 40 |          .0000000 |    1 | 800 |         1.0000000 |         1.0000000 |         1.0000000 |          .0000000
  2400 |  2 |  2 |  2 |         6.0000000 | 40 |          .0000000 | 1100 | 100 |          .1666667 |          .1666667 |         1.0000000 |          .0000000
+    0 |  1 |  1 |  1 |         2.0000000 | 50 |          .0000000 |    1 | 400 |          .5833333 |          .5833333 |         1.0000000 |         1.0000000
+    0 |  2 |  2 |  2 |         2.0000000 | 50 |          .0000000 |    1 | 400 |          .5833333 |          .5833333 |         1.0000000 |          .0000000
 (12 rows)
 
 -- COUNT() function with ONLY order by having range based framing clause in combination with other functions --
@@ -226,7 +227,7 @@ TO_CHAR(COALESCE(ROW_NUMBER() OVER(win2),0),'99999999.9999999'),
 TO_CHAR(COALESCE(CUME_DIST() OVER(order by cf_olap_windowerr_sale.vn asc),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
 WINDOW win1 as (order by cf_olap_windowerr_sale.vn desc range between floor(cf_olap_windowerr_sale.cn-cf_olap_windowerr_sale.vn) preceding and floor(cf_olap_windowerr_sale.cn) following ),
-win2 as (order by cf_olap_windowerr_sale.vn asc);
+win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc);
 ERROR:  RANGE parameter cannot be negative
 -- COUNT() function with ONLY order by having range based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn, TO_CHAR(COALESCE(COUNT(floor(cf_olap_windowerr_sale.qty-cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,
@@ -240,7 +241,7 @@ SELECT cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sal
 TO_CHAR(COALESCE(ROW_NUMBER() OVER(win2),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
 WINDOW win1 as (order by cf_olap_windowerr_sale.cn asc range between current row and unbounded following ),
-win2 as (order by cf_olap_windowerr_sale.vn asc);
+win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc);
 ERROR:  division by zero
 -- COUNT() function with ONLY order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn, TO_CHAR(COALESCE(COUNT(floor(cf_olap_windowerr_sale.cn+cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),
@@ -252,7 +253,7 @@ FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_ola
 WINDOW win1 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc,cf_olap_windowerr_sale.vn desc,cf_olap_windowerr_sale.cn asc rows between floor(cf_olap_windowerr_sale.cn*cf_olap_windowerr_sale.qty) preceding and 4 following ),
 win2 as (order by cf_olap_windowerr_sale.pn asc),
 win3 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc);
-ERROR:  division by zero  (seg0 slice4 rahmaf2-mbp:25432 pid=48130)
+ERROR:  division by zero
 -- COUNT() function with ONLY order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(COUNT(floor(cf_olap_windowerr_sale.qty*cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,
 TO_CHAR(COALESCE(CUME_DIST() OVER(win2),0),'99999999.9999999'),cf_olap_windowerr_sale.dt,
@@ -282,25 +283,25 @@ win4 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn order 
 win5 as (order by cf_olap_windowerr_sale.vn asc);
  pn  | pn  | vn |      to_char      | prc  | cn |      to_char      |      to_char      |      to_char      |      to_char      |      to_char      
 -----+-----+----+-------------------+------+----+-------------------+-------------------+-------------------+-------------------+-------------------
- 100 | 100 | 20 |         1.0000000 |    0 |  1 |        11.0000000 |        11.0000000 |         1.0000000 |          .0000000 |         2.0000000
- 100 | 100 | 40 |         1.0000000 | 2400 |  2 |         3.0000000 |         6.0000000 |         1.0000000 |          .0000000 |         4.0000000
  200 | 200 | 10 |         1.0000000 |    0 |  1 |        12.0000000 |        12.0000000 |         3.0000000 |          .0000000 |         1.0000000
- 200 | 200 | 40 |         1.0000000 |    0 |  3 |         3.0000000 |         6.0000000 |         3.0000000 |          .0000000 |         4.0000000
+ 100 | 100 | 20 |         1.0000000 |    0 |  1 |        11.0000000 |        11.0000000 |         1.0000000 |          .0000000 |         2.0000000
+ 600 | 600 | 30 |         1.0000000 |    5 |  3 |         7.0000000 |        10.0000000 |        10.0000000 |          .0000000 |         3.0000000
+ 500 | 500 | 30 |         1.0000000 |    5 |  1 |         7.0000000 |        10.0000000 |         8.0000000 |          .0000000 |         3.0000000
  300 | 300 | 30 |         1.0000000 |    0 |  1 |         7.0000000 |        10.0000000 |         5.0000000 |          .0000000 |         3.0000000
+ 500 | 500 | 30 |         2.0000000 |    5 |  3 |         7.0000000 |        10.0000000 |         8.0000000 |          .0000000 |         3.0000000
+ 200 | 200 | 40 |         1.0000000 |    0 |  3 |         3.0000000 |         6.0000000 |         3.0000000 |          .0000000 |         4.0000000
+ 100 | 100 | 40 |         1.0000000 | 2400 |  2 |         3.0000000 |         6.0000000 |         1.0000000 |          .0000000 |         4.0000000
+ 800 | 800 | 40 |         1.0000000 |    1 |  4 |         3.0000000 |         6.0000000 |        12.0000000 |          .0000000 |         4.0000000
+ 700 | 700 | 40 |         1.0000000 |    1 |  4 |         3.0000000 |         6.0000000 |        11.0000000 |          .0000000 |         4.0000000
  400 | 400 | 50 |         2.0000000 |    0 |  1 |         1.0000000 |         2.0000000 |         6.0000000 |          .0000000 |         5.0000000
  400 | 400 | 50 |         2.0000000 |    0 |  2 |         1.0000000 |         2.0000000 |         6.0000000 |          .0000000 |         5.0000000
- 500 | 500 | 30 |         1.0000000 |    5 |  1 |         7.0000000 |        10.0000000 |         8.0000000 |          .0000000 |         3.0000000
- 500 | 500 | 30 |         2.0000000 |    5 |  3 |         7.0000000 |        10.0000000 |         8.0000000 |          .0000000 |         3.0000000
- 600 | 600 | 30 |         1.0000000 |    5 |  3 |         7.0000000 |        10.0000000 |        10.0000000 |          .0000000 |         3.0000000
- 700 | 700 | 40 |         1.0000000 |    1 |  4 |         3.0000000 |         6.0000000 |        11.0000000 |          .0000000 |         4.0000000
- 800 | 800 | 40 |         1.0000000 |    1 |  4 |         3.0000000 |         6.0000000 |        12.0000000 |          .0000000 |         4.0000000
 (12 rows)
 
 -- COUNT() function with partition by and order by having range based framing clause --
 SELECT cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(COUNT(floor(cf_olap_windowerr_sale.vn-cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.qty
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty order by cf_olap_windowerr_sale.cn desc range between floor(cf_olap_windowerr_sale.cn-cf_olap_windowerr_sale.prc) preceding and current row );
-ERROR:  RANGE parameter cannot be negative  (seg0 slice2 rahmaf2-mbp:25432 pid=48130)
+ERROR:  RANGE parameter cannot be negative  (seg0 slice2 127.0.0.1:25432 pid=55689)
 -- COUNT() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(COUNT(floor(cf_olap_windowerr_sale.pn/cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn,
 TO_CHAR(COALESCE(ROW_NUMBER() OVER(win2),0),'99999999.9999999'),cf_olap_windowerr_sale.vn,
@@ -310,24 +311,24 @@ TO_CHAR(COALESCE(LAG(cast(floor(cf_olap_windowerr_sale.pn/cf_olap_windowerr_sale
 TO_CHAR(COALESCE(RANK() OVER(win5),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc,cf_olap_windowerr_sale.pn desc,cf_olap_windowerr_sale.pn desc rows between 0 preceding and floor(cf_olap_windowerr_sale.pn+cf_olap_windowerr_sale.qty) following ),
-win2 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.cn desc),
+win2 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc),
 win3 as (order by cf_olap_windowerr_sale.vn desc),
 win4 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc),
 win5 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.cn desc);
  qty  | qty  | qty  |      to_char      | cn |     dt     | pn  |      to_char      | vn |      to_char      |      to_char      |      to_char      |      to_char      
 ------+------+------+-------------------+----+------------+-----+-------------------+----+-------------------+-------------------+-------------------+-------------------
-    1 |    1 |    1 |         1.0000000 |  1 | 03-01-1401 | 200 |         1.0000000 | 10 |         1.0000000 |         5.0000000 |          .0000000 |         1.0000000
     1 |    1 |    1 |         1.0000000 |  1 | 05-01-1401 | 100 |         1.0000000 | 20 |         1.0000000 |         4.0000000 |          .0000000 |         1.0000000
-    1 |    1 |    1 |         1.0000000 |  1 | 05-02-1401 | 300 |         1.0000000 | 30 |         1.0000000 |         3.0000000 |          .0000000 |         1.0000000
-    1 |    1 |    1 |         1.0000000 |  2 | 06-01-1401 | 400 |         1.0000000 | 50 |         1.0000000 |         1.0000000 |          .0000000 |         1.0000000
-    1 |    1 |    1 |         1.0000000 |  3 | 04-01-1401 | 200 |         1.0000000 | 40 |         1.0000000 |         2.0000000 |          .0000000 |         1.0000000
-    1 |    1 |    1 |         1.0000000 |  4 | 06-01-1401 | 800 |         1.0000000 | 40 |         1.0000000 |         2.0000000 |          .0000000 |         1.0000000
-    1 |    1 |    1 |         2.0000000 |  1 | 06-01-1401 | 400 |         1.0000000 | 50 |         1.0000000 |         1.0000000 |          .0000000 |         1.0000000
-    1 |    1 |    1 |         2.0000000 |  4 | 06-01-1401 | 700 |         1.0000000 | 40 |         1.0000000 |         2.0000000 |          .0000000 |         1.0000000
-   12 |   12 |   12 |         1.0000000 |  1 | 06-01-1401 | 500 |         1.0000000 | 30 |         1.0000000 |         3.0000000 |          .0000000 |         1.0000000
-   12 |   12 |   12 |         1.0000000 |  3 | 06-01-1401 | 600 |         1.0000000 | 30 |         1.0000000 |         3.0000000 |          .0000000 |         1.0000000
-   12 |   12 |   12 |         2.0000000 |  3 | 06-01-1401 | 500 |         1.0000000 | 30 |         1.0000000 |         3.0000000 |          .0000000 |         1.0000000
  1100 | 1100 | 1100 |         1.0000000 |  2 | 01-01-1401 | 100 |         1.0000000 | 40 |         1.0000000 |         2.0000000 |          .0000000 |         1.0000000
+    1 |    1 |    1 |         1.0000000 |  1 | 03-01-1401 | 200 |         1.0000000 | 10 |         1.0000000 |         5.0000000 |          .0000000 |         1.0000000
+    1 |    1 |    1 |         1.0000000 |  3 | 04-01-1401 | 200 |         1.0000000 | 40 |         1.0000000 |         2.0000000 |          .0000000 |         1.0000000
+    1 |    1 |    1 |         1.0000000 |  1 | 05-02-1401 | 300 |         1.0000000 | 30 |         1.0000000 |         3.0000000 |          .0000000 |         1.0000000
+    1 |    1 |    1 |         2.0000000 |  1 | 06-01-1401 | 400 |         1.0000000 | 50 |         1.0000000 |         1.0000000 |          .0000000 |         1.0000000
+    1 |    1 |    1 |         1.0000000 |  2 | 06-01-1401 | 400 |         1.0000000 | 50 |         1.0000000 |         1.0000000 |          .0000000 |         1.0000000
+   12 |   12 |   12 |         1.0000000 |  1 | 06-01-1401 | 500 |         1.0000000 | 30 |         1.0000000 |         3.0000000 |          .0000000 |         1.0000000
+   12 |   12 |   12 |         2.0000000 |  3 | 06-01-1401 | 500 |         1.0000000 | 30 |         1.0000000 |         3.0000000 |          .0000000 |         1.0000000
+   12 |   12 |   12 |         1.0000000 |  3 | 06-01-1401 | 600 |         1.0000000 | 30 |         1.0000000 |         3.0000000 |          .0000000 |         1.0000000
+    1 |    1 |    1 |         2.0000000 |  4 | 06-01-1401 | 700 |         1.0000000 | 40 |         1.0000000 |         2.0000000 |          .0000000 |         1.0000000
+    1 |    1 |    1 |         1.0000000 |  4 | 06-01-1401 | 800 |         1.0000000 | 40 |         1.0000000 |         2.0000000 |          .0000000 |         1.0000000
 (12 rows)
 
 -- MAX() function with ONLY order by having range based framing clause in combination with other functions --
@@ -351,7 +352,7 @@ TO_CHAR(COALESCE(ROW_NUMBER() OVER(win2),0),'99999999.9999999'),
 TO_CHAR(COALESCE(CUME_DIST() OVER(win3),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.cn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product,cf_olap_windowerr_vendor,cf_olap_windowerr_customer WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn AND cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn AND cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn) cf_olap_windowerr_sale
 WINDOW win1 as (order by cf_olap_windowerr_sale.vn asc range between 3 following and floor(cf_olap_windowerr_sale.pn-cf_olap_windowerr_sale.qty) following ),
-win2 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.pn asc),
+win2 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc),
 win3 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.cn desc);
 ERROR:  RANGE parameter cannot be negative
 -- MAX() function with ONLY order by having rows based framing clause in combination with other functions --
@@ -369,7 +370,7 @@ SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sal
 TO_CHAR(COALESCE(ROW_NUMBER() OVER(win2),0),'99999999.9999999'),cf_olap_windowerr_sale.prc
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
 WINDOW win1 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc,cf_olap_windowerr_sale.cn asc rows between floor(cf_olap_windowerr_sale.pn-cf_olap_windowerr_sale.prc) preceding and current row ),
-win2 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.vn asc);
+win2 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc);
 ERROR:  frame starting offset must not be negative
 -- MAX() function with ONLY order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.cn*cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999'),
@@ -385,18 +386,18 @@ win4 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc),
 win5 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc);
      dt     | prc  | cn | prc  | cn | cn |      to_char      |      to_char      | vn |      to_char      | pn  |      to_char      |      to_char      
 ------------+------+----+------+----+----+-------------------+-------------------+----+-------------------+-----+-------------------+-------------------
- 01-01-1401 | 2400 |  2 | 2400 |  2 |  2 |        80.0000000 |         2.0000000 | 40 |          .0000000 | 100 |          .0000000 |          .0000000
- 03-01-1401 |    0 |  1 |    0 |  1 |  1 |        10.0000000 |         5.0000000 | 10 |          .0000000 | 200 |      1100.0000000 |          .0000000
- 04-01-1401 |    0 |  3 |    0 |  3 |  3 |       120.0000000 |         2.0000000 | 40 |          .0000000 | 200 |          .0000000 |          .0000000
  05-01-1401 |    0 |  1 |    0 |  1 |  1 |        20.0000000 |         4.0000000 | 20 |          .0000000 | 100 |         1.0000000 |          .0000000
+ 03-01-1401 |    0 |  1 |    0 |  1 |  1 |        10.0000000 |         5.0000000 | 10 |          .0000000 | 200 |      1100.0000000 |          .0000000
  05-02-1401 |    0 |  1 |    0 |  1 |  1 |        30.0000000 |         3.0000000 | 30 |          .0000000 | 300 |         1.0000000 |          .0000000
  06-01-1401 |    0 |  1 |    0 |  1 |  1 |        50.0000000 |         1.0000000 | 50 |          .0000000 | 400 |         1.0000000 |          .0000000
- 06-01-1401 |    0 |  2 |    0 |  2 |  2 |       100.0000000 |         1.0000000 | 50 |          .0000000 | 400 |         1.0000000 |          .0000000
- 06-01-1401 |    1 |  4 |    1 |  4 |  4 |       160.0000000 |         2.0000000 | 40 |          .0000000 | 700 |         1.0000000 |          .0000000
- 06-01-1401 |    1 |  4 |    1 |  4 |  4 |       160.0000000 |         2.0000000 | 40 |          .0000000 | 800 |         1.0000000 |          .0000000
  06-01-1401 |    5 |  1 |    5 |  1 |  1 |        30.0000000 |         3.0000000 | 30 |          .0000000 | 500 |         1.0000000 |          .0000000
+ 01-01-1401 | 2400 |  2 | 2400 |  2 |  2 |        80.0000000 |         2.0000000 | 40 |          .0000000 | 100 |          .0000000 |          .0000000
+ 06-01-1401 |    0 |  2 |    0 |  2 |  2 |       100.0000000 |         1.0000000 | 50 |          .0000000 | 400 |         1.0000000 |          .0000000
+ 04-01-1401 |    0 |  3 |    0 |  3 |  3 |       120.0000000 |         2.0000000 | 40 |          .0000000 | 200 |          .0000000 |          .0000000
  06-01-1401 |    5 |  3 |    5 |  3 |  3 |        90.0000000 |         3.0000000 | 30 |          .0000000 | 500 |      1100.0000000 |          .0000000
  06-01-1401 |    5 |  3 |    5 |  3 |  3 |        90.0000000 |         3.0000000 | 30 |          .0000000 | 600 |         1.0000000 |          .0000000
+ 06-01-1401 |    1 |  4 |    1 |  4 |  4 |       160.0000000 |         2.0000000 | 40 |          .0000000 | 700 |         1.0000000 |          .0000000
+ 06-01-1401 |    1 |  4 |    1 |  4 |  4 |       160.0000000 |         2.0000000 | 40 |          .0000000 | 800 |         1.0000000 |          .0000000
 (12 rows)
 
 -- MAX() function with ONLY order by having rows based framing clause in combination with other functions --
@@ -410,16 +411,16 @@ WINDOW win1 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn d
 win2 as (partition by cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc);
  cn | vn | qty  | qty  |      to_char      | pn  |      to_char      |      to_char      |     dt     |      to_char      |      to_char      
 ----+----+------+------+-------------------+-----+-------------------+-------------------+------------+-------------------+-------------------
+  2 | 40 | 1100 | 1100 |        24.0000000 | 100 |         4.0000000 |          .0000000 | 01-01-1401 |         1.0000000 |         1.0000000
   1 | 10 |    1 |    1 |          .0000000 | 200 |         4.0000000 |          .0000000 | 03-01-1401 |         1.0000000 |         1.0000000
+  3 | 40 |    1 |    1 |          .0000000 | 200 |         4.0000000 |          .0000000 | 04-01-1401 |         1.0000000 |         1.0000000
   1 | 20 |    1 |    1 |          .0000000 | 100 |         4.0000000 |          .0000000 | 05-01-1401 |         1.0000000 |         1.0000000
   1 | 30 |    1 |    1 |          .0000000 | 300 |         4.0000000 |          .0000000 | 05-02-1401 |         1.0000000 |         1.0000000
-  1 | 30 |   12 |   12 |          .0000000 | 500 |         4.0000000 |          .0000000 | 06-01-1401 |         3.0000000 |         3.0000000
   1 | 50 |    1 |    1 |          .0000000 | 400 |         4.0000000 |        49.0000000 | 06-01-1401 |         1.0000000 |         1.0000000
-  2 | 40 | 1100 | 1100 |        24.0000000 | 100 |         4.0000000 |          .0000000 | 01-01-1401 |         1.0000000 |         1.0000000
   2 | 50 |    1 |    1 |          .0000000 | 400 |         4.0000000 |        18.0000000 | 06-01-1401 |         2.0000000 |         2.0000000
+  1 | 30 |   12 |   12 |          .0000000 | 500 |         4.0000000 |          .0000000 | 06-01-1401 |         3.0000000 |         3.0000000
   3 | 30 |   12 |   12 |          .0000000 | 500 |         4.0000000 |          .0000000 | 06-01-1401 |         4.0000000 |         4.0000000
   3 | 30 |   12 |   12 |          .0000000 | 600 |         4.0000000 |          .0000000 | 06-01-1401 |         5.0000000 |         5.0000000
-  3 | 40 |    1 |    1 |          .0000000 | 200 |         4.0000000 |          .0000000 | 04-01-1401 |         1.0000000 |         1.0000000
   4 | 40 |    1 |    1 |          .0000000 | 700 |         4.0000000 |        39.0000000 | 06-01-1401 |         6.0000000 |         6.0000000
   4 | 40 |    1 |    1 |          .0000000 | 800 |         4.0000000 |        39.0000000 | 06-01-1401 |         7.0000000 |         7.0000000
 (12 rows)
@@ -439,13 +440,13 @@ win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc);
  04-01-1401 |          .0000000 | 40 |          .0000000 |    1 |          .0000000 | 200
  05-01-1401 |          .0000000 | 20 |       -80.0000000 |    1 |          .0000000 | 100
  05-02-1401 |          .0000000 | 30 |      -270.0000000 |    1 |          .0000000 | 300
+ 06-01-1401 |          .0000000 | 50 |      -350.0000000 |    1 |          .0000000 | 400
+ 06-01-1401 |          .0000000 | 50 |          .0000000 |    1 |          .0000000 | 400
+ 06-01-1401 |         3.0000000 | 30 |          .0000000 |   12 |          .0000000 | 500
  06-01-1401 |          .0000000 | 30 |          .0000000 |   12 |          .0000000 | 500
  06-01-1401 |          .0000000 | 30 |          .0000000 |   12 |          .0000000 | 600
  06-01-1401 |          .0000000 | 40 |          .0000000 |    1 |          .0000000 | 700
  06-01-1401 |          .0000000 | 40 |          .0000000 |    1 |          .0000000 | 800
- 06-01-1401 |          .0000000 | 50 |          .0000000 |    1 |          .0000000 | 400
- 06-01-1401 |          .0000000 | 50 |      -350.0000000 |    1 |          .0000000 | 400
- 06-01-1401 |         3.0000000 | 30 |          .0000000 |   12 |          .0000000 | 500
 (12 rows)
 
 -- MAX() function with partition by and order by having range based framing clause in combination with other functions--
@@ -460,7 +461,7 @@ WINDOW win1 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qt
 win2 as (partition by cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.pn desc),
 win3 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc),
 win4 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc);
-ERROR:  division by zero  (seg1 slice6 rahmaf2-mbp:25433 pid=48131)
+ERROR:  division by zero  (seg1 slice3 127.0.0.1:25433 pid=55693)
 -- MAX() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.prc/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,
 TO_CHAR(COALESCE(PERCENT_RANK() OVER(win2),0),'99999999.9999999'),
@@ -470,29 +471,29 @@ TO_CHAR(COALESCE(ROW_NUMBER() OVER(win2),0),'99999999.9999999'),
 TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.vn)) OVER(order by cf_olap_windowerr_sale.cn asc),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc,cf_olap_windowerr_sale.pn desc rows between unbounded preceding and 2 preceding ),
-win2 as (order by cf_olap_windowerr_sale.vn desc),
+win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc),
 win3 as (order by cf_olap_windowerr_sale.cn asc);
  qty  | pn  | vn |      to_char      | cn |      to_char      |      to_char      |      to_char      |      to_char      |      to_char      
 ------+-----+----+-------------------+----+-------------------+-------------------+-------------------+-------------------+-------------------
-    1 | 400 | 50 |          .0000000 |  1 |          .0000000 |         1.0000000 |         1.0000000 |         1.0000000 |        50.0000000
-    1 | 200 | 10 |          .0000000 |  1 |         1.0000000 |         1.0000000 |        12.0000000 |        12.0000000 |        50.0000000
-    1 | 100 | 20 |          .0000000 |  1 |          .9090909 |         1.0000000 |        11.0000000 |        11.0000000 |        50.0000000
-    1 | 300 | 30 |          .0000000 |  1 |          .5454545 |         1.0000000 |         7.0000000 |         8.0000000 |        50.0000000
-   12 | 500 | 30 |          .0000000 |  1 |          .5454545 |         1.0000000 |         7.0000000 |         7.0000000 |        50.0000000
- 1100 | 100 | 40 |          .0000000 |  2 |          .1818182 |         2.0000000 |         3.0000000 |         4.0000000 |        50.0000000
-    1 | 400 | 50 |          .0000000 |  2 |          .0000000 |         2.0000000 |         1.0000000 |         2.0000000 |        50.0000000
-   12 | 500 | 30 |          .0000000 |  3 |          .5454545 |         3.0000000 |         7.0000000 |         9.0000000 |        50.0000000
-   12 | 600 | 30 |          .0000000 |  3 |          .5454545 |         3.0000000 |         7.0000000 |        10.0000000 |        50.0000000
+    1 | 400 | 50 |          .0000000 |  2 |          .5454545 |         2.0000000 |         1.0000000 |         7.0000000 |        50.0000000
+    1 | 400 | 50 |          .0000000 |  1 |          .4545455 |         1.0000000 |         1.0000000 |         6.0000000 |        50.0000000
+    1 | 800 | 40 |          .0000000 |  4 |         1.0000000 |         4.0000000 |         3.0000000 |        12.0000000 |        50.0000000
+    1 | 700 | 40 |          .0000000 |  4 |          .9090909 |         4.0000000 |         3.0000000 |        11.0000000 |        50.0000000
     1 | 200 | 40 |          .0000000 |  3 |          .1818182 |         3.0000000 |         3.0000000 |         3.0000000 |        50.0000000
-    1 | 700 | 40 |          .0000000 |  4 |          .1818182 |         4.0000000 |         3.0000000 |         5.0000000 |        50.0000000
-    1 | 800 | 40 |          .0000000 |  4 |          .1818182 |         4.0000000 |         3.0000000 |         6.0000000 |        50.0000000
+ 1100 | 100 | 40 |          .0000000 |  2 |          .0000000 |         2.0000000 |         3.0000000 |         1.0000000 |        50.0000000
+   12 | 500 | 30 |          .0000000 |  3 |          .7272727 |         3.0000000 |         7.0000000 |         9.0000000 |        50.0000000
+   12 | 600 | 30 |          .0000000 |  3 |          .8181818 |         3.0000000 |         7.0000000 |        10.0000000 |        50.0000000
+   12 | 500 | 30 |          .0000000 |  1 |          .6363636 |         1.0000000 |         7.0000000 |         8.0000000 |        50.0000000
+    1 | 300 | 30 |          .0000000 |  1 |          .3636364 |         1.0000000 |         7.0000000 |         5.0000000 |        50.0000000
+    1 | 100 | 20 |          .0000000 |  1 |          .2727273 |         1.0000000 |        11.0000000 |         4.0000000 |        50.0000000
+    1 | 200 | 10 |          .0000000 |  1 |          .0909091 |         1.0000000 |        12.0000000 |         2.0000000 |        50.0000000
 (12 rows)
 
 -- MAX() function with partition by and order by having rows based framing clause --
 SELECT cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.cn/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc rows between 7 preceding and unbounded following );
-ERROR:  division by zero  (seg0 slice2 rahmaf2-mbp:25432 pid=48130)
+ERROR:  division by zero  (seg0 slice2 127.0.0.1:25432 pid=55689)
 -- MAX() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.qty+cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,
 TO_CHAR(COALESCE(PERCENT_RANK() OVER(win2),0),'99999999.9999999'),
@@ -506,25 +507,25 @@ win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc),
 win4 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc);
  qty  |      to_char      | cn |     dt     | vn | pn  |      to_char      |      to_char      |      to_char      |      to_char      
 ------+-------------------+----+------------+----+-----+-------------------+-------------------+-------------------+-------------------
-    1 |       101.0000000 |  1 | 05-01-1401 | 20 | 100 |          .0000000 |          .0000000 |          .0000000 |         1.0000000
+ 1100 |      1200.0000000 |  2 | 01-01-1401 | 40 | 100 |          .0000000 |          .0000000 |          .0000000 |         1.0000000
     1 |       201.0000000 |  1 | 03-01-1401 | 10 | 200 |          .0000000 |       800.0000000 |          .0000000 |         1.0000000
     1 |       201.0000000 |  3 | 04-01-1401 | 40 | 200 |          .0000000 |          .0000000 |          .0000000 |         1.0000000
+    1 |       101.0000000 |  1 | 05-01-1401 | 20 | 100 |          .0000000 |          .0000000 |          .0000000 |         1.0000000
     1 |       301.0000000 |  1 | 05-02-1401 | 30 | 300 |          .0000000 |          .0000000 |          .0000000 |         1.0000000
     1 |       401.0000000 |  1 | 06-01-1401 | 50 | 400 |          .6666667 |          .0000000 |          .0000000 |         2.0000000
     1 |       401.0000000 |  2 | 06-01-1401 | 50 | 400 |          .6666667 |          .0000000 |          .0000000 |         1.0000000
-    1 |       701.0000000 |  4 | 06-01-1401 | 40 | 700 |          .3333333 |          .0000000 |          .0000000 |         1.0000000
-    1 |       801.0000000 |  4 | 06-01-1401 | 40 | 800 |          .0000000 |          .0000000 |          .0000000 |         1.0000000
    12 |       512.0000000 |  1 | 06-01-1401 | 30 | 500 |          .5000000 |          .0000000 |          .0000000 |         2.0000000
    12 |       512.0000000 |  3 | 06-01-1401 | 30 | 500 |          .5000000 |          .0000000 |          .0000000 |         1.0000000
    12 |       612.0000000 |  3 | 06-01-1401 | 30 | 600 |          .0000000 |          .0000000 |          .0000000 |         1.0000000
- 1100 |      1200.0000000 |  2 | 01-01-1401 | 40 | 100 |          .0000000 |          .0000000 |          .0000000 |         1.0000000
+    1 |       701.0000000 |  4 | 06-01-1401 | 40 | 700 |          .3333333 |          .0000000 |          .0000000 |         1.0000000
+    1 |       801.0000000 |  4 | 06-01-1401 | 40 | 800 |          .0000000 |          .0000000 |          .0000000 |         1.0000000
 (12 rows)
 
 -- MAX() function with partition by and order by having rows based framing clause --
 SELECT cf_olap_windowerr_sale.dt, TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.qty*cf_olap_windowerr_sale.qty)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc,cf_olap_windowerr_sale.cn desc rows between floor(cf_olap_windowerr_sale.vn-cf_olap_windowerr_sale.pn) following and unbounded following );
-ERROR:  frame starting offset must not be negative
+ERROR:  frame starting offset must not be negative  (seg0 slice1 127.0.0.1:25432 pid=55689)
 -- MAX() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn, TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.vn/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn,
 TO_CHAR(COALESCE(ROW_NUMBER() OVER(win2),0),'99999999.9999999'),
@@ -533,9 +534,9 @@ TO_CHAR(COALESCE(COUNT(floor(cf_olap_windowerr_sale.pn-cf_olap_windowerr_sale.cn
 TO_CHAR(COALESCE(LEAD(cast(floor(cf_olap_windowerr_sale.prc) as int),cast (floor(cf_olap_windowerr_sale.vn*cf_olap_windowerr_sale.pn) as int),NULL) OVER(win3),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn ) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc rows between floor(cf_olap_windowerr_sale.prc) following and unbounded following ),
-win2 as (order by cf_olap_windowerr_sale.vn desc),
+win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc),
 win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc);
-ERROR:  division by zero  (seg1 slice3 rahmaf2-mbp:25433 pid=48131)
+ERROR:  division by zero  (seg0 slice2 127.0.0.1:25432 pid=55689)
 -- MIN() function with NULL OVER() clause in combination with other window functions --
 SELECT cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.pn+cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999')
 ,
@@ -546,10 +547,10 @@ WINDOW win1 as (),
 win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc);
  pn  | prc  | vn | cn | prc  | qty  |      to_char      |      to_char      |      to_char      
 -----+------+----+----+------+------+-------------------+-------------------+-------------------
- 100 |    0 | 20 |  1 |    0 |    1 |       120.0000000 |          .0000000 |         4.0000000
  100 | 2400 | 40 |  2 | 2400 | 1100 |       120.0000000 |          .0000000 |         1.0000000
  200 |    0 | 10 |  1 |    0 |    1 |       120.0000000 |          .0000000 |         2.0000000
  200 |    0 | 40 |  3 |    0 |    1 |       120.0000000 |          .0000000 |         3.0000000
+ 100 |    0 | 20 |  1 |    0 |    1 |       120.0000000 |          .0000000 |         4.0000000
  300 |    0 | 30 |  1 |    0 |    1 |       120.0000000 |          .0000000 |         5.0000000
  400 |    0 | 50 |  1 |    0 |    1 |       120.0000000 |          .0000000 |         6.0000000
  400 |    0 | 50 |  2 |    0 |    1 |       120.0000000 |          .0000000 |         7.0000000
@@ -564,7 +565,7 @@ win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc);
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.vn/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.pn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.pn);
-ERROR:  division by zero  (seg0 slice2 rahmaf2-mbp:25432 pid=48130)
+ERROR:  division by zero  (seg0 slice2 127.0.0.1:25432 pid=55689)
 -- MIN() function with ONLY order by having range based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.pn, TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,
 TO_CHAR(COALESCE(LEAD(cast(floor(cf_olap_windowerr_sale.qty) as int),cast (floor(cf_olap_windowerr_sale.cn*cf_olap_windowerr_sale.cn) as int),NULL) OVER(win2),0),'99999999.9999999'),cf_olap_windowerr_sale.vn,
@@ -587,7 +588,7 @@ TO_CHAR(COALESCE(ROW_NUMBER() OVER(win3),0),'99999999.9999999'),cf_olap_windower
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn AND cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
 WINDOW win1 as (order by cf_olap_windowerr_sale.cn desc range between floor(cf_olap_windowerr_sale.pn) preceding and floor(cf_olap_windowerr_sale.qty) following ),
 win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc),
-win3 as (partition by cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.vn desc);
+win3 as (partition by cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc);
 ERROR:  division by zero
 -- MIN() function with ONLY order by having range based framing clause --
 SELECT cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999')
@@ -618,9 +619,9 @@ win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc);
  04-01-1401 |        10.0000000 |  3 | 40 |          .0000000 |         3.0000000
  05-01-1401 |        10.0000000 |  1 | 20 |          .0000000 |         4.0000000
  05-02-1401 |        10.0000000 |  1 | 30 |          .0000000 |         5.0000000
- 06-01-1401 |        10.0000000 |  1 | 30 |          .0000000 |         8.0000000
  06-01-1401 |        10.0000000 |  1 | 50 |          .0000000 |         6.0000000
  06-01-1401 |        10.0000000 |  2 | 50 |          .0000000 |         7.0000000
+ 06-01-1401 |        10.0000000 |  1 | 30 |          .0000000 |         8.0000000
  06-01-1401 |        10.0000000 |  3 | 30 |          .0000000 |         9.0000000
  06-01-1401 |        10.0000000 |  3 | 30 |          .0000000 |        10.0000000
  06-01-1401 |        10.0000000 |  4 | 40 |          .0000000 |        11.0000000
@@ -637,7 +638,7 @@ TO_CHAR(COALESCE(ROW_NUMBER() OVER(win3),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc rows between floor(cf_olap_windowerr_sale.qty-cf_olap_windowerr_sale.pn) preceding and current row ),
 win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc),
-win3 as (order by cf_olap_windowerr_sale.cn asc);
+win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc);
 ERROR:  frame starting offset must not be negative
 -- MIN() function with ONLY order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.vn,
@@ -680,7 +681,7 @@ SELECT cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_
 TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.vn*cf_olap_windowerr_sale.qty)) OVER(partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.cn desc range between floor(cf_olap_windowerr_sale.prc-cf_olap_windowerr_sale.cn) preceding and floor(cf_olap_windowerr_sale.pn*cf_olap_windowerr_sale.prc) preceding ),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product,cf_olap_windowerr_vendor,cf_olap_windowerr_customer WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn AND cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn AND cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.cn desc range between floor(cf_olap_windowerr_sale.prc-cf_olap_windowerr_sale.cn) preceding and floor(cf_olap_windowerr_sale.pn*cf_olap_windowerr_sale.prc) preceding );
-ERROR:  RANGE parameter cannot be negative  (seg0 slice5 rahmaf2-mbp:25432 pid=48130)
+ERROR:  RANGE parameter cannot be negative  (seg0 slice5 127.0.0.1:25432 pid=55689)
 -- MIN() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.vn+cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,
 TO_CHAR(COALESCE(CUME_DIST() OVER(win2),0),'99999999.9999999'),
@@ -695,10 +696,10 @@ win4 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc),
 win5 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc);
  pn  | qty  |     dt     | qty  |      to_char      | cn | vn |      to_char      |      to_char      |      to_char      |      to_char      
 -----+------+------------+------+-------------------+----+----+-------------------+-------------------+-------------------+-------------------
- 100 |    1 | 05-01-1401 |    1 |        21.0000000 |  1 | 20 |         1.0000000 |          .0000000 |       600.0000000 |          .0000000
  100 | 1100 | 01-01-1401 | 1100 |        42.0000000 |  2 | 40 |         1.0000000 |          .0000000 |          .0000000 |          .0000000
  200 |    1 | 03-01-1401 |    1 |        11.0000000 |  1 | 10 |          .8333333 |          .0000000 |       200.0000000 |       -39.0000000
  200 |    1 | 04-01-1401 |    1 |        43.0000000 |  3 | 40 |          .8333333 |          .0000000 |          .0000000 |          .0000000
+ 100 |    1 | 05-01-1401 |    1 |        21.0000000 |  1 | 20 |         1.0000000 |          .0000000 |       600.0000000 |          .0000000
  300 |    1 | 05-02-1401 |    1 |        31.0000000 |  1 | 30 |          .6666667 |          .0000000 |       100.0000000 |          .0000000
  400 |    1 | 06-01-1401 |    1 |        51.0000000 |  1 | 50 |          .5833333 |          .0000000 |       300.0000000 |          .0000000
  400 |    1 | 06-01-1401 |    1 |        51.0000000 |  2 | 50 |          .5833333 |          .0000000 |       300.0000000 |          .0000000
@@ -721,12 +722,12 @@ win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc),
 win3 as (order by cf_olap_windowerr_sale.vn desc),
 win4 as (order by cf_olap_windowerr_sale.cn desc),
 win5 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc);
-ERROR:  division by zero  (seg1 slice4 rahmaf2-mbp:25433 pid=48131)
+ERROR:  division by zero  (seg0 slice3 127.0.0.1:25432 pid=55689)
 -- MIN() function with partition by and order by having rows based framing clause --
 SELECT cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn, TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.pn/cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.vn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc rows between current row and floor(cf_olap_windowerr_sale.cn/cf_olap_windowerr_sale.prc) following );
-ERROR:  division by zero  (seg2 slice2 rahmaf2-mbp:25434 pid=48132)
+ERROR:  division by zero  (seg0 slice2 127.0.0.1:25432 pid=55689)
 -- MIN() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,
 TO_CHAR(COALESCE(PERCENT_RANK() OVER(win2),0),'99999999.9999999'),
@@ -738,10 +739,10 @@ win2 as (order by cf_olap_windowerr_sale.vn asc),
 win3 as (partition by cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc);
  pn  | qty  | vn |      to_char      | prc  | cn |     dt     |      to_char      |      to_char      |      to_char      
 -----+------+----+-------------------+------+----+------------+-------------------+-------------------+-------------------
- 100 |    1 | 20 |        20.0000000 |    0 |  1 | 05-01-1401 |          .0909091 |        40.0000000 |       101.0000000
  100 | 1100 | 40 |        40.0000000 | 2400 |  2 | 01-01-1401 |          .5454545 |        80.0000000 |          .0000000
  200 |    1 | 10 |        10.0000000 |    0 |  1 | 03-01-1401 |          .0000000 |        20.0000000 |       201.0000000
  200 |    1 | 40 |        40.0000000 |    0 |  3 | 04-01-1401 |          .5454545 |        80.0000000 |          .0000000
+ 100 |    1 | 20 |        20.0000000 |    0 |  1 | 05-01-1401 |          .0909091 |        40.0000000 |       101.0000000
  300 |    1 | 30 |        30.0000000 |    0 |  1 | 05-02-1401 |          .1818182 |        60.0000000 |       301.0000000
  400 |    1 | 50 |        50.0000000 |    0 |  1 | 06-01-1401 |          .9090909 |       100.0000000 |       401.0000000
  400 |    1 | 50 |        50.0000000 |    0 |  2 | 06-01-1401 |          .9090909 |       100.0000000 |       401.0000000
@@ -810,7 +811,7 @@ TO_CHAR(COALESCE(CUME_DIST() OVER(win2),0),'99999999.9999999'),
 TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.cn)) OVER(win2),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn AND cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
 WINDOW win1 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc,cf_olap_windowerr_sale.cn desc rows between floor(cf_olap_windowerr_sale.vn-cf_olap_windowerr_sale.pn) following and unbounded following ),
-win2 as (order by cf_olap_windowerr_sale.pn asc);
+win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc);
 ERROR:  frame starting offset must not be negative
 -- STDDEV() function with partition by and order by having range based framing clause in combination with other functions--
 SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(STDDEV(floor(cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999'),
@@ -823,25 +824,25 @@ win2 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn order 
 win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc);
  vn | pn  | cn | cn | qty  | cn |      to_char      |      to_char      |      to_char      |      to_char      
 ----+-----+----+----+------+----+-------------------+-------------------+-------------------+-------------------
+ 40 | 100 |  2 |  2 | 1100 |  2 |          .0000000 |          .0000000 |          .0000000 |         1.0000000
  10 | 200 |  1 |  1 |    1 |  1 |          .0000000 |          .0000000 |          .0000000 |         2.0000000
+ 40 | 200 |  3 |  3 |    1 |  3 |          .0000000 |          .0000000 |          .0000000 |         3.0000000
  20 | 100 |  1 |  1 |    1 |  1 |          .0000000 |          .0000000 |          .0000000 |         4.0000000
  30 | 300 |  1 |  1 |    1 |  1 |          .0000000 |          .0000000 |          .0000000 |         5.0000000
+ 50 | 400 |  1 |  1 |    1 |  1 |          .0000000 |         1.0000000 |          .0000000 |         6.0000000
+ 50 | 400 |  2 |  2 |    1 |  2 |          .0000000 |          .0000000 |          .0000000 |         7.0000000
  30 | 500 |  1 |  1 |   12 |  1 |          .0000000 |          .0000000 |          .0000000 |         8.0000000
  30 | 500 |  3 |  3 |   12 |  3 |          .0000000 |          .0000000 |          .0000000 |         9.0000000
  30 | 600 |  3 |  3 |   12 |  3 |          .0000000 |          .0000000 |          .0000000 |        10.0000000
- 40 | 100 |  2 |  2 | 1100 |  2 |          .0000000 |          .0000000 |          .0000000 |         1.0000000
- 40 | 200 |  3 |  3 |    1 |  3 |          .0000000 |          .0000000 |          .0000000 |         3.0000000
  40 | 700 |  4 |  4 |    1 |  4 |          .0000000 |          .0000000 |          .0000000 |        11.0000000
  40 | 800 |  4 |  4 |    1 |  4 |          .0000000 |          .0000000 |          .0000000 |        12.0000000
- 50 | 400 |  1 |  1 |    1 |  1 |          .0000000 |         1.0000000 |          .0000000 |         6.0000000
- 50 | 400 |  2 |  2 |    1 |  2 |          .0000000 |          .0000000 |          .0000000 |         7.0000000
 (12 rows)
 
 -- STDDEV() function with partition by and order by having range based framing clause --
 SELECT cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn, TO_CHAR(COALESCE(STDDEV(floor(cf_olap_windowerr_sale.qty/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn AND cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.cn asc range between unbounded preceding and 2 following );
-ERROR:  division by zero  (seg1 slice4 rahmaf2-mbp:25433 pid=48131)
+ERROR:  division by zero  (seg0 slice4 127.0.0.1:25432 pid=55689)
 -- STDDEV() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(STDDEV(floor(cf_olap_windowerr_sale.pn+cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn,
 TO_CHAR(COALESCE(COUNT(floor(cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999'),
@@ -850,15 +851,15 @@ TO_CHAR(COALESCE(ROW_NUMBER() OVER(win3),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn AND cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc,cf_olap_windowerr_sale.pn asc,cf_olap_windowerr_sale.cn asc rows between unbounded preceding and floor(cf_olap_windowerr_sale.qty-cf_olap_windowerr_sale.pn) preceding ),
 win2 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.vn asc),
-win3 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.cn asc);
-ERROR:  frame ending offset must not be negative  (seg0 slice3 rahmaf2-mbp:25432 pid=48149)
+win3 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc);
+ERROR:  frame ending offset must not be negative  (seg1 slice3 127.0.0.1:25433 pid=55690)
 -- STDDEV() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.dt, TO_CHAR(COALESCE(STDDEV(floor(cf_olap_windowerr_sale.cn/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.pn,
 TO_CHAR(COALESCE(LEAD(cast(floor(cf_olap_windowerr_sale.cn) as int),cast (floor(cf_olap_windowerr_sale.qty) as int),NULL) OVER(win2),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn AND cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc rows between 4 preceding and current row ),
 win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc);
-ERROR:  division by zero  (seg0 slice4 rahmaf2-mbp:25432 pid=48130)
+ERROR:  division by zero  (seg0 slice4 127.0.0.1:25432 pid=55689)
 -- STDDEV() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn, TO_CHAR(COALESCE(STDDEV(floor(cf_olap_windowerr_sale.prc-cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,
 TO_CHAR(COALESCE(DENSE_RANK() OVER(win2),0),'99999999.9999999'),
@@ -866,7 +867,7 @@ TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc rows between current row and floor(cf_olap_windowerr_sale.pn/cf_olap_windowerr_sale.prc) following ),
 win2 as (order by cf_olap_windowerr_sale.cn desc);
-ERROR:  division by zero  (seg0 slice2 rahmaf2-mbp:25432 pid=48130)
+ERROR:  division by zero  (seg0 slice2 127.0.0.1:25432 pid=55689)
 -- STDDEV_POP() function with NULL OVER() clause in combination with other window functions --
 SELECT cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(STDDEV_POP(floor(cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999')
 ,
@@ -880,12 +881,12 @@ win2 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.qty orde
 win3 as (partition by cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc);
  prc  | cn | prc  | pn  | qty  |      to_char      |      to_char      |      to_char      |      to_char      |      to_char      
 ------+----+------+-----+------+-------------------+-------------------+-------------------+-------------------+-------------------
-    0 |  1 |    0 | 100 |    1 |        11.1492401 |          .0000000 |         3.0000000 |         3.0000000 |          .0000000
     0 |  1 |    0 | 200 |    1 |        11.1492401 |          .0000000 |         1.0000000 |         1.0000000 |          .0000000
+    0 |  3 |    0 | 200 |    1 |        11.1492401 |          .0000000 |         3.0000000 |         2.0000000 |          .0000000
+    0 |  1 |    0 | 100 |    1 |        11.1492401 |          .0000000 |         3.0000000 |         3.0000000 |          .0000000
     0 |  1 |    0 | 300 |    1 |        11.1492401 |          .0000000 |         3.0000000 |         4.0000000 |          .0000000
     0 |  1 |    0 | 400 |    1 |        11.1492401 |          .0000000 |         3.0000000 |         5.0000000 |          .0000000
     0 |  2 |    0 | 400 |    1 |        11.1492401 |          .0000000 |         3.0000000 |         6.0000000 |          .0000000
-    0 |  3 |    0 | 200 |    1 |        11.1492401 |          .0000000 |         3.0000000 |         2.0000000 |          .0000000
     1 |  4 |    1 | 700 |    1 |        11.1492401 |          .0000000 |         4.0000000 |         1.0000000 |          .0000000
     1 |  4 |    1 | 800 |    1 |        11.1492401 |          .0000000 |         4.0000000 |         2.0000000 |          .0000000
     5 |  1 |    5 | 500 |   12 |        11.1492401 |          .0000000 |         1.0000000 |         1.0000000 |          .0000000
@@ -904,7 +905,7 @@ FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_ola
 WINDOW win1 as (order by cf_olap_windowerr_sale.pn desc range between unbounded preceding and current row ),
 win2 as (partition by cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.vn asc),
 win3 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc);
-ERROR:  division by zero  (seg0 slice5 rahmaf2-mbp:25432 pid=48146)
+ERROR:  division by zero
 -- STDDEV_POP() function with ONLY order by having range based framing clause --
 SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn, TO_CHAR(COALESCE(STDDEV_POP(floor(cf_olap_windowerr_sale.qty+cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn ) cf_olap_windowerr_sale
@@ -928,28 +929,28 @@ FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_ola
 WINDOW win1 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc rows between unbounded preceding and unbounded following ),
 win2 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.cn desc),
 win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc),
-win4 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.cn desc);
+win4 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc);
  qty  | qty  |      to_char      | vn |      to_char      | cn |     dt     | pn  |      to_char      |      to_char      
 ------+------+-------------------+----+-------------------+----+------------+-----+-------------------+-------------------
     1 |    1 |       440.8305293 | 10 |         1.0000000 |  1 | 03-01-1401 | 200 |          .0000000 |         1.0000000
     1 |    1 |       440.8305293 | 20 |         1.0000000 |  1 | 05-01-1401 | 100 |          .0000000 |         1.0000000
     1 |    1 |       440.8305293 | 30 |         1.0000000 |  1 | 05-02-1401 | 300 |          .0000000 |         1.0000000
-    1 |    1 |       440.8305293 | 40 |         1.0000000 |  3 | 04-01-1401 | 200 |          .0000000 |         1.0000000
-    1 |    1 |       440.8305293 | 40 |         1.0000000 |  4 | 06-01-1401 | 700 |          .0000000 |         1.0000000
-    1 |    1 |       440.8305293 | 40 |         1.0000000 |  4 | 06-01-1401 | 800 |          .0000000 |         1.0000000
     1 |    1 |       440.8305293 | 50 |         1.0000000 |  1 | 06-01-1401 | 400 |          .0000000 |         1.0000000
-    1 |    1 |       440.8305293 | 50 |         1.0000000 |  2 | 06-01-1401 | 400 |          .0000000 |         1.0000000
    12 |   12 |       440.8305293 | 30 |         1.0000000 |  1 | 06-01-1401 | 500 |          .0000000 |         1.0000000
+ 1100 | 1100 |       440.8305293 | 40 |         1.0000000 |  2 | 01-01-1401 | 100 |          .0000000 |         1.0000000
+    1 |    1 |       440.8305293 | 50 |         1.0000000 |  2 | 06-01-1401 | 400 |          .0000000 |         1.0000000
+    1 |    1 |       440.8305293 | 40 |         1.0000000 |  3 | 04-01-1401 | 200 |          .0000000 |         1.0000000
    12 |   12 |       440.8305293 | 30 |         1.0000000 |  3 | 06-01-1401 | 500 |          .0000000 |         1.0000000
    12 |   12 |       440.8305293 | 30 |         1.0000000 |  3 | 06-01-1401 | 600 |          .0000000 |         1.0000000
- 1100 | 1100 |       440.8305293 | 40 |         1.0000000 |  2 | 01-01-1401 | 100 |          .0000000 |         1.0000000
+    1 |    1 |       440.8305293 | 40 |         1.0000000 |  4 | 06-01-1401 | 700 |          .0000000 |         1.0000000
+    1 |    1 |       440.8305293 | 40 |         1.0000000 |  4 | 06-01-1401 | 800 |          .0000000 |         1.0000000
 (12 rows)
 
 -- STDDEV_POP() function with partition by and order by having range based framing clause --
 SELECT cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(STDDEV_POP(floor(cf_olap_windowerr_sale.vn-cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.vn desc range between unbounded preceding and floor(cf_olap_windowerr_sale.pn-cf_olap_windowerr_sale.qty) preceding );
-ERROR:  RANGE parameter cannot be negative  (seg2 slice2 rahmaf2-mbp:25434 pid=48132)
+ERROR:  RANGE parameter cannot be negative  (seg2 slice2 127.0.0.1:25434 pid=55691)
 -- STDDEV_POP() function with partition by and order by having range based framing clause in combination with other functions--
 SELECT cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(STDDEV_POP(floor(cf_olap_windowerr_sale.vn/cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty,
 TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.qty*cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),
@@ -962,22 +963,22 @@ WINDOW win1 as (partition by cf_olap_windowerr_sale.qty order by cf_olap_windowe
 win2 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.cn desc),
 win3 as (order by cf_olap_windowerr_sale.vn desc),
 win4 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc);
-ERROR:  RANGE parameter cannot be negative  (seg2 slice5 rahmaf2-mbp:25434 pid=48132)
+ERROR:  RANGE parameter cannot be negative  (seg0 slice3 127.0.0.1:25432 pid=55700)
 -- STDDEV_POP() function with partition by and order by having range based framing clause --
 SELECT cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.prc, TO_CHAR(COALESCE(STDDEV_POP(floor(cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.qty order by cf_olap_windowerr_sale.cn asc range between floor(cf_olap_windowerr_sale.vn+cf_olap_windowerr_sale.cn) preceding and floor(cf_olap_windowerr_sale.prc-cf_olap_windowerr_sale.vn) following );
-ERROR:  RANGE parameter cannot be negative  (seg0 slice3 rahmaf2-mbp:25432 pid=48130)
+ERROR:  RANGE parameter cannot be negative  (seg0 slice3 127.0.0.1:25432 pid=55689)
 -- STDDEV_POP() function with partition by and order by having rows based framing clause --
 SELECT cf_olap_windowerr_sale.prc, TO_CHAR(COALESCE(STDDEV_POP(floor(cf_olap_windowerr_sale.pn/cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn AND cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc rows between unbounded preceding and floor(cf_olap_windowerr_sale.cn-cf_olap_windowerr_sale.qty) preceding );
-ERROR:  frame ending offset must not be negative  (seg0 slice4 rahmaf2-mbp:25432 pid=48130)
+ERROR:  frame ending offset must not be negative  (seg0 slice4 127.0.0.1:25432 pid=55689)
 -- STDDEV_POP() function with partition by and order by having rows based framing clause --
 SELECT cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn, TO_CHAR(COALESCE(STDDEV_POP(floor(cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.dt
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc,cf_olap_windowerr_sale.cn desc rows between floor(cf_olap_windowerr_sale.vn/cf_olap_windowerr_sale.prc) preceding and unbounded following );
-ERROR:  division by zero  (seg1 slice2 rahmaf2-mbp:25433 pid=48131)
+ERROR:  division by zero  (seg0 slice2 127.0.0.1:25432 pid=55689)
 -- STDDEV_POP() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(STDDEV_POP(floor(cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),
 TO_CHAR(COALESCE(RANK() OVER(win2),0),'99999999.9999999'),
@@ -1005,18 +1006,18 @@ win3 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn order 
 win4 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.vn desc);
  vn | qty  |      to_char      |      to_char      |      to_char      |      to_char      | cn |     dt     |      to_char      | prc  |      to_char      
 ----+------+-------------------+-------------------+-------------------+-------------------+----+------------+-------------------+------+-------------------
- 10 |    1 |     27698.9781427 |      2440.0000000 |          .0000000 |          .0000000 |  1 | 03-01-1401 |         6.0000000 |    0 |         2.0000000
- 20 |    1 |     27698.9781427 |      2440.0000000 |          .0000000 |          .0000000 |  1 | 05-01-1401 |         5.0000000 |    0 |         4.0000000
- 30 |    1 |     27698.9781427 |      2440.0000000 |          .0000000 |          .0000000 |  1 | 05-02-1401 |         4.0000000 |    0 |         5.0000000
- 30 |   12 |     27698.9781427 |      2440.0000000 |          .0000000 |          .0000000 |  1 | 06-01-1401 |         1.0000000 |    5 |         8.0000000
- 30 |   12 |     27698.9781427 |      2440.0000000 |          .0000000 |          .0000000 |  3 | 06-01-1401 |         1.0000000 |    5 |         9.0000000
- 30 |   12 |     27698.9781427 |      2440.0000000 |          .0000000 |          .0000000 |  3 | 06-01-1401 |         1.0000000 |    5 |        10.0000000
- 40 |    1 |     27698.9781427 |      2440.0000000 |          .0000000 |          .0000000 |  3 | 04-01-1401 |         3.0000000 |    0 |         3.0000000
- 40 |    1 |     27698.9781427 |      2440.0000000 |          .0000000 |          .0000000 |  4 | 06-01-1401 |         1.0000000 |    1 |        11.0000000
- 40 |    1 |     27698.9781427 |      2440.0000000 |          .0000000 |          .0000000 |  4 | 06-01-1401 |         1.0000000 |    1 |        12.0000000
- 40 | 1100 |     27698.9781427 |      2440.0000000 |          .0000000 |          .0000000 |  2 | 01-01-1401 |         1.0000000 | 2400 |         1.0000000
  50 |    1 |     27698.9781427 |      2440.0000000 |          .0000000 |          .0000000 |  1 | 06-01-1401 |         1.0000000 |    0 |         6.0000000
  50 |    1 |     27698.9781427 |      2440.0000000 |          .0000000 |          .0000000 |  2 | 06-01-1401 |         1.0000000 |    0 |         7.0000000
+ 40 |    1 |     27698.9781427 |      2440.0000000 |          .0000000 |          .0000000 |  3 | 04-01-1401 |         3.0000000 |    0 |         3.0000000
+ 30 |    1 |     27698.9781427 |      2440.0000000 |          .0000000 |          .0000000 |  1 | 05-02-1401 |         4.0000000 |    0 |         5.0000000
+ 20 |    1 |     27698.9781427 |      2440.0000000 |          .0000000 |          .0000000 |  1 | 05-01-1401 |         5.0000000 |    0 |         4.0000000
+ 10 |    1 |     27698.9781427 |      2440.0000000 |          .0000000 |          .0000000 |  1 | 03-01-1401 |         6.0000000 |    0 |         2.0000000
+ 40 |    1 |     27698.9781427 |      2440.0000000 |          .0000000 |          .0000000 |  4 | 06-01-1401 |         1.0000000 |    1 |        11.0000000
+ 40 |    1 |     27698.9781427 |      2440.0000000 |          .0000000 |          .0000000 |  4 | 06-01-1401 |         1.0000000 |    1 |        12.0000000
+ 30 |   12 |     27698.9781427 |      2440.0000000 |          .0000000 |          .0000000 |  3 | 06-01-1401 |         1.0000000 |    5 |        10.0000000
+ 30 |   12 |     27698.9781427 |      2440.0000000 |          .0000000 |          .0000000 |  3 | 06-01-1401 |         1.0000000 |    5 |         9.0000000
+ 30 |   12 |     27698.9781427 |      2440.0000000 |          .0000000 |          .0000000 |  1 | 06-01-1401 |         1.0000000 |    5 |         8.0000000
+ 40 | 1100 |     27698.9781427 |      2440.0000000 |          .0000000 |          .0000000 |  2 | 01-01-1401 |         1.0000000 | 2400 |         1.0000000
 (12 rows)
 
 -- STDDEV_SAMP() function with ONLY order by having range based framing clause in combination with other functions --
@@ -1033,18 +1034,18 @@ win3 as (order by cf_olap_windowerr_sale.pn asc),
 win4 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc);
  vn |      to_char      | pn  |      to_char      |      to_char      |      to_char      |      to_char      |      to_char      
 ----+-------------------+-----+-------------------+-------------------+-------------------+-------------------+-------------------
+ 40 |       316.4791630 | 100 |         1.0000000 |          .0000000 |         1.0000000 |         1.0000000 |          .0000000
  10 |         5.4365021 | 200 |         1.0000000 |       200.0000000 |         2.0000000 |         2.0000000 |         4.0000000
+ 40 |         5.4365021 | 200 |         1.0000000 |       300.0000000 |         2.0000000 |         3.0000000 |          .0000000
  20 |       316.4791630 | 100 |         1.0000000 |       100.0000000 |         1.0000000 |         4.0000000 |          .0000000
  30 |         5.8736701 | 300 |         1.0000000 |       300.0000000 |         3.0000000 |         5.0000000 |          .0000000
- 30 |         6.9282032 | 600 |         5.0000000 |       100.0000000 |         6.0000000 |        10.0000000 |          .0000000
- 30 |         6.9856997 | 500 |         5.0000000 |          .0000000 |         5.0000000 |         8.0000000 |          .0000000
- 30 |         6.9856997 | 500 |         5.0000000 |          .0000000 |         5.0000000 |         9.0000000 |          .0000000
- 40 |          .0000000 | 700 |         5.0000000 |          .0000000 |         7.0000000 |        11.0000000 |          .0000000
- 40 |          .0000000 | 800 |         5.0000000 |          .0000000 |         8.0000000 |        12.0000000 |          .0000000
- 40 |         5.4365021 | 200 |         1.0000000 |       300.0000000 |         2.0000000 |         3.0000000 |          .0000000
- 40 |       316.4791630 | 100 |         1.0000000 |          .0000000 |         1.0000000 |         1.0000000 |          .0000000
  50 |         6.2297290 | 400 |         1.0000000 |       400.0000000 |         4.0000000 |         6.0000000 |          .0000000
  50 |         6.2297290 | 400 |         1.0000000 |       500.0000000 |         4.0000000 |         7.0000000 |          .0000000
+ 30 |         6.9856997 | 500 |         5.0000000 |          .0000000 |         5.0000000 |         8.0000000 |          .0000000
+ 30 |         6.9856997 | 500 |         5.0000000 |          .0000000 |         5.0000000 |         9.0000000 |          .0000000
+ 30 |         6.9282032 | 600 |         5.0000000 |       100.0000000 |         6.0000000 |        10.0000000 |          .0000000
+ 40 |          .0000000 | 700 |         5.0000000 |          .0000000 |         7.0000000 |        11.0000000 |          .0000000
+ 40 |          .0000000 | 800 |         5.0000000 |          .0000000 |         8.0000000 |        12.0000000 |          .0000000
 (12 rows)
 
 -- STDDEV_SAMP() function with ONLY order by having range based framing clause in combination with other functions --
@@ -1068,18 +1069,18 @@ win3 as (partition by cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.dt,cf_ol
 win4 as (partition by cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.pn asc);
  pn  | qty  | pn  | qty  | prc  |      to_char      | cn |      to_char      |      to_char      |      to_char      |     dt     |      to_char      | vn |      to_char      
 -----+------+-----+------+------+-------------------+----+-------------------+-------------------+-------------------+------------+-------------------+----+-------------------
- 100 |    1 | 100 |    1 |    0 |         2.7386128 |  1 |         4.0000000 |    240000.0000000 |          .0000000 | 05-01-1401 |         1.0000000 | 20 |       796.0000000
- 100 | 1100 | 100 | 1100 | 2400 |          .0000000 |  2 |         3.0000000 |    240000.0000000 |          .0000000 | 01-01-1401 |         1.0000000 | 40 |       796.0000000
- 200 |    1 | 200 |    1 |    0 |          .0000000 |  3 |         2.0000000 |      3000.0000000 |          .0000000 | 04-01-1401 |         1.0000000 | 40 |          .0000000
  200 |    1 | 200 |    1 |    0 |         2.7386128 |  1 |         4.0000000 |    240000.0000000 |          .0000000 | 03-01-1401 |         1.0000000 | 10 |       796.0000000
+ 200 |    1 | 200 |    1 |    0 |          .0000000 |  3 |         2.0000000 |      3000.0000000 |          .0000000 | 04-01-1401 |         1.0000000 | 40 |          .0000000
+ 100 |    1 | 100 |    1 |    0 |         2.7386128 |  1 |         4.0000000 |    240000.0000000 |          .0000000 | 05-01-1401 |         1.0000000 | 20 |       796.0000000
  300 |    1 | 300 |    1 |    0 |         2.7386128 |  1 |         4.0000000 |    240000.0000000 |          .0000000 | 05-02-1401 |         1.0000000 | 30 |       796.0000000
- 400 |    1 | 400 |    1 |    0 |          .0000000 |  2 |         3.0000000 |    240000.0000000 |          .0000000 | 06-01-1401 |         1.0000000 | 50 |       796.0000000
  400 |    1 | 400 |    1 |    0 |         2.7386128 |  1 |         4.0000000 |    240000.0000000 |          .0000000 | 06-01-1401 |         1.0000000 | 50 |       796.0000000
- 500 |   12 | 500 |   12 |    5 |          .0000000 |  3 |         2.0000000 |      3000.0000000 |          .0000000 | 06-01-1401 |         1.0000000 | 30 |          .0000000
- 500 |   12 | 500 |   12 |    5 |         2.7386128 |  1 |         4.0000000 |    240000.0000000 |          .0000000 | 06-01-1401 |         1.0000000 | 30 |       796.0000000
- 600 |   12 | 600 |   12 |    5 |          .0000000 |  3 |         2.0000000 |      3000.0000000 |          .0000000 | 06-01-1401 |         1.0000000 | 30 |          .0000000
+ 400 |    1 | 400 |    1 |    0 |          .0000000 |  2 |         3.0000000 |    240000.0000000 |          .0000000 | 06-01-1401 |         1.0000000 | 50 |       796.0000000
  700 |    1 | 700 |    1 |    1 |          .0000000 |  4 |         1.0000000 |       800.0000000 |          .0000000 | 06-01-1401 |         1.0000000 | 40 |          .0000000
  800 |    1 | 800 |    1 |    1 |          .0000000 |  4 |         1.0000000 |       800.0000000 |          .0000000 | 06-01-1401 |         1.0000000 | 40 |          .0000000
+ 500 |   12 | 500 |   12 |    5 |         2.7386128 |  1 |         4.0000000 |    240000.0000000 |          .0000000 | 06-01-1401 |         1.0000000 | 30 |       796.0000000
+ 500 |   12 | 500 |   12 |    5 |          .0000000 |  3 |         2.0000000 |      3000.0000000 |          .0000000 | 06-01-1401 |         1.0000000 | 30 |          .0000000
+ 600 |   12 | 600 |   12 |    5 |          .0000000 |  3 |         2.0000000 |      3000.0000000 |          .0000000 | 06-01-1401 |         1.0000000 | 30 |          .0000000
+ 100 | 1100 | 100 | 1100 | 2400 |          .0000000 |  2 |         3.0000000 |    240000.0000000 |          .0000000 | 01-01-1401 |         1.0000000 | 40 |       796.0000000
 (12 rows)
 
 -- STDDEV_SAMP() function with ONLY order by having rows based framing clause --
@@ -1098,18 +1099,18 @@ WINDOW win1 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn d
 win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc);
  qty  | cn | vn | qty  |     dt     |      to_char      |      to_char      |      to_char      |      to_char      |      to_char      
 ------+----+----+------+------------+-------------------+-------------------+-------------------+-------------------+-------------------
+ 1100 |  2 | 40 | 1100 | 01-01-1401 |          .0000000 |          .0000000 |    240000.0000000 |          .0000000 |          .0000000
     1 |  1 | 10 |    1 | 03-01-1401 |          .0000000 |          .0000000 |          .0000000 |          .0909091 |          .0909091
+    1 |  3 | 40 |    1 | 04-01-1401 |          .0000000 |          .0000000 |          .0000000 |          .1818182 |          .1818182
     1 |  1 | 20 |    1 | 05-01-1401 |          .0000000 |          .0000000 |          .0000000 |          .2727273 |          .2727273
     1 |  1 | 30 |    1 | 05-02-1401 |          .0000000 |          .0000000 |          .0000000 |          .3636364 |          .3636364
     1 |  1 | 50 |    1 | 06-01-1401 |          .0000000 |          .0000000 |          .0000000 |          .4545455 |          .4545455
     1 |  2 | 50 |    1 | 06-01-1401 |          .0000000 |          .0000000 |          .0000000 |          .5454545 |          .5454545
-    1 |  3 | 40 |    1 | 04-01-1401 |          .0000000 |          .0000000 |          .0000000 |          .1818182 |          .1818182
-    1 |  4 | 40 |    1 | 06-01-1401 |          .0000000 |          .0000000 |          .0000000 |          .9090909 |          .9090909
-    1 |  4 | 40 |    1 | 06-01-1401 |          .0000000 |          .0000000 |          .0000000 |         1.0000000 |         1.0000000
    12 |  1 | 30 |   12 | 06-01-1401 |          .0000000 |          .0000000 |          .0000000 |          .6363636 |          .6363636
    12 |  3 | 30 |   12 | 06-01-1401 |          .0000000 |          .0000000 |          .0000000 |          .7272727 |          .7272727
    12 |  3 | 30 |   12 | 06-01-1401 |          .0000000 |          .0000000 |          .0000000 |          .8181818 |          .8181818
- 1100 |  2 | 40 | 1100 | 01-01-1401 |          .0000000 |          .0000000 |    240000.0000000 |          .0000000 |          .0000000
+    1 |  4 | 40 |    1 | 06-01-1401 |          .0000000 |          .0000000 |          .0000000 |          .9090909 |          .9090909
+    1 |  4 | 40 |    1 | 06-01-1401 |          .0000000 |          .0000000 |          .0000000 |         1.0000000 |         1.0000000
 (12 rows)
 
 -- STDDEV_SAMP() function with ONLY order by having rows based framing clause --
@@ -1141,25 +1142,25 @@ WINDOW win1 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn a
 SELECT cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(STDDEV_SAMP(floor(cf_olap_windowerr_sale.pn-cf_olap_windowerr_sale.qty)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn
 ,
 TO_CHAR(COALESCE(LAG(cast(floor(cf_olap_windowerr_sale.qty-cf_olap_windowerr_sale.pn) as int),cast (floor(cf_olap_windowerr_sale.qty-cf_olap_windowerr_sale.vn) as int),NULL) OVER(win2),0),'99999999.9999999'),
-TO_CHAR(COALESCE(ROW_NUMBER() OVER(partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.cn asc,cf_olap_windowerr_sale.cn asc,cf_olap_windowerr_sale.vn asc),0),'99999999.9999999'),
+TO_CHAR(COALESCE(ROW_NUMBER() OVER(partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc,cf_olap_windowerr_sale.cn asc,cf_olap_windowerr_sale.vn asc),0),'99999999.9999999'),
 TO_CHAR(COALESCE(DENSE_RANK() OVER(win2),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.cn asc,cf_olap_windowerr_sale.cn asc,cf_olap_windowerr_sale.vn asc),
 win2 as (partition by cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc);
  cn | cn |      to_char      |     dt     | vn | pn  |      to_char      |      to_char      |      to_char      
 ----+----+-------------------+------------+----+-----+-------------------+-------------------+-------------------
-  1 |  1 |          .0000000 | 03-01-1401 | 10 | 200 |          .0000000 |         1.0000000 |         1.0000000
-  1 |  1 |          .0000000 | 05-01-1401 | 20 | 100 |          .0000000 |         1.0000000 |         1.0000000
+  3 |  3 |          .0000000 | 04-01-1401 | 40 | 200 |          .0000000 |         1.0000000 |         2.0000000
+  1 |  1 |          .0000000 | 06-01-1401 | 50 | 400 |          .0000000 |         1.0000000 |         1.0000000
+  3 |  3 |          .0000000 | 06-01-1401 | 30 | 500 |          .0000000 |         1.0000000 |         3.0000000
   1 |  1 |          .0000000 | 05-02-1401 | 30 | 300 |          .0000000 |         1.0000000 |         1.0000000
   1 |  1 |          .0000000 | 06-01-1401 | 30 | 500 |          .0000000 |         1.0000000 |         2.0000000
-  1 |  1 |          .0000000 | 06-01-1401 | 50 | 400 |          .0000000 |         1.0000000 |         1.0000000
+  4 |  4 |          .0000000 | 06-01-1401 | 40 | 800 |          .0000000 |         1.0000000 |         4.0000000
   2 |  2 |          .0000000 | 01-01-1401 | 40 | 100 |          .0000000 |         1.0000000 |         1.0000000
+  1 |  1 |          .0000000 | 03-01-1401 | 10 | 200 |          .0000000 |         1.0000000 |         1.0000000
+  1 |  1 |          .0000000 | 05-01-1401 | 20 | 100 |          .0000000 |         1.0000000 |         1.0000000
   2 |  2 |          .0000000 | 06-01-1401 | 50 | 400 |          .0000000 |         1.0000000 |         2.0000000
-  3 |  3 |          .0000000 | 04-01-1401 | 40 | 200 |          .0000000 |         1.0000000 |         2.0000000
-  3 |  3 |          .0000000 | 06-01-1401 | 30 | 500 |          .0000000 |         1.0000000 |         3.0000000
   3 |  3 |          .0000000 | 06-01-1401 | 30 | 600 |          .0000000 |         1.0000000 |         4.0000000
   4 |  4 |          .0000000 | 06-01-1401 | 40 | 700 |          .0000000 |         1.0000000 |         3.0000000
-  4 |  4 |          .0000000 | 06-01-1401 | 40 | 800 |          .0000000 |         1.0000000 |         4.0000000
 (12 rows)
 
 -- STDDEV_SAMP() function with partition by and order by having range based framing clause in combination with other functions--
@@ -1201,18 +1202,18 @@ win3 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.cn,cf_ol
 win4 as (partition by cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.vn desc);
  pn  | vn |      to_char      | prc  | cn |      to_char      |      to_char      |      to_char      |      to_char      |      to_char      |     dt     | qty  
 -----+----+-------------------+------+----+-------------------+-------------------+-------------------+-------------------+-------------------+------------+------
- 100 | 20 |          .0000000 |    0 |  1 |          .0000000 |         4.0000000 |         1.0000000 |         4.0000000 |          .0000000 | 05-01-1401 |    1
- 100 | 40 |          .0000000 | 2400 |  2 |          .0000000 |         1.0000000 |         1.0000000 |         1.0000000 |          .0000000 | 01-01-1401 | 1100
  200 | 10 |          .0000000 |    0 |  1 |          .0000000 |         2.0000000 |         1.0000000 |         2.0000000 |          .0000000 | 03-01-1401 |    1
- 200 | 40 |          .0000000 |    0 |  3 |          .0000000 |         3.0000000 |         1.0000000 |         3.0000000 |          .0000000 | 04-01-1401 |    1
+ 100 | 20 |          .0000000 |    0 |  1 |          .0000000 |         4.0000000 |         1.0000000 |         4.0000000 |          .0000000 | 05-01-1401 |    1
  300 | 30 |          .0000000 |    0 |  1 |          .0000000 |         5.0000000 |         1.0000000 |         5.0000000 |          .0000000 | 05-02-1401 |    1
  400 | 50 |          .0000000 |    0 |  1 |          .0000000 |         6.0000000 |         1.0000000 |         6.0000000 |          .0000000 | 06-01-1401 |    1
  400 | 50 |          .0000000 |    0 |  2 |          .0000000 |         7.0000000 |         1.0000000 |         7.0000000 |          .0000000 | 06-01-1401 |    1
- 500 | 30 |          .0000000 |    5 |  1 |          .0000000 |         8.0000000 |         1.0000000 |         8.0000000 |          .0000000 | 06-01-1401 |   12
- 500 | 30 |          .0000000 |    5 |  3 |          .0000000 |         9.0000000 |         1.0000000 |         9.0000000 |          .0000000 | 06-01-1401 |   12
- 600 | 30 |          .0000000 |    5 |  3 |          .0000000 |        10.0000000 |         1.0000000 |        10.0000000 |          .0000000 | 06-01-1401 |   12
- 700 | 40 |          .0000000 |    1 |  4 |          .0000000 |        11.0000000 |         1.0000000 |        11.0000000 |          .0000000 | 06-01-1401 |    1
+ 200 | 40 |          .0000000 |    0 |  3 |          .0000000 |         3.0000000 |         1.0000000 |         3.0000000 |          .0000000 | 04-01-1401 |    1
  800 | 40 |          .0000000 |    1 |  4 |          .0000000 |        12.0000000 |         1.0000000 |        12.0000000 |          .0000000 | 06-01-1401 |    1
+ 700 | 40 |          .0000000 |    1 |  4 |          .0000000 |        11.0000000 |         1.0000000 |        11.0000000 |          .0000000 | 06-01-1401 |    1
+ 500 | 30 |          .0000000 |    5 |  1 |          .0000000 |         8.0000000 |         1.0000000 |         8.0000000 |          .0000000 | 06-01-1401 |   12
+ 600 | 30 |          .0000000 |    5 |  3 |          .0000000 |        10.0000000 |         1.0000000 |        10.0000000 |          .0000000 | 06-01-1401 |   12
+ 500 | 30 |          .0000000 |    5 |  3 |          .0000000 |         9.0000000 |         1.0000000 |         9.0000000 |          .0000000 | 06-01-1401 |   12
+ 100 | 40 |          .0000000 | 2400 |  2 |          .0000000 |         1.0000000 |         1.0000000 |         1.0000000 |          .0000000 | 01-01-1401 | 1100
 (12 rows)
 
 -- STDDEV_SAMP() function with partition by and order by having range based framing clause in combination with other functions--
@@ -1224,7 +1225,7 @@ FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_ol
 WINDOW win1 as (partition by cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.vn desc range between floor(cf_olap_windowerr_sale.qty) following and floor(cf_olap_windowerr_sale.qty-cf_olap_windowerr_sale.vn) following ),
 win2 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.cn desc),
 win3 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc);
-ERROR:  RANGE parameter cannot be negative  (seg0 slice2 rahmaf2-mbp:25432 pid=48143)
+ERROR:  RANGE parameter cannot be negative  (seg0 slice2 127.0.0.1:25432 pid=55692)
 -- STDDEV_SAMP() function with partition by and order by having range based framing clause in combination with other functions--
 SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(STDDEV_SAMP(floor(cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn,
 TO_CHAR(COALESCE(LEAD(cast(floor(cf_olap_windowerr_sale.prc+cf_olap_windowerr_sale.qty) as int),cast (floor(cf_olap_windowerr_sale.cn-cf_olap_windowerr_sale.pn) as int),NULL) OVER(win2),0),'99999999.9999999')
@@ -1234,24 +1235,24 @@ win2 as (partition by cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn order
  vn | prc  | cn | qty  |      to_char      |     dt     | pn  |      to_char      
 ----+------+----+------+-------------------+------------+-----+-------------------
  10 |    0 |  1 |    1 |          .0000000 | 03-01-1401 | 200 |          .0000000
- 20 |    0 |  1 |    1 |          .0000000 | 05-01-1401 | 100 |          .0000000
  30 |    0 |  1 |    1 |          .0000000 | 05-02-1401 | 300 |          .0000000
- 30 |    5 |  1 |   12 |          .0000000 | 06-01-1401 | 500 |          .0000000
- 30 |    5 |  3 |   12 |          .0000000 | 06-01-1401 | 500 |          .0000000
- 30 |    5 |  3 |   12 |          .0000000 | 06-01-1401 | 600 |          .0000000
+ 50 |    0 |  1 |    1 |          .0000000 | 06-01-1401 | 400 |          .0000000
+ 50 |    0 |  2 |    1 |          .0000000 | 06-01-1401 | 400 |          .0000000
+ 20 |    0 |  1 |    1 |          .0000000 | 05-01-1401 | 100 |          .0000000
  40 |    0 |  3 |    1 |          .0000000 | 04-01-1401 | 200 |          .0000000
  40 |    1 |  4 |    1 |          .0000000 | 06-01-1401 | 700 |          .0000000
  40 |    1 |  4 |    1 |          .0000000 | 06-01-1401 | 800 |          .0000000
+ 30 |    5 |  1 |   12 |          .0000000 | 06-01-1401 | 500 |          .0000000
+ 30 |    5 |  3 |   12 |          .0000000 | 06-01-1401 | 500 |          .0000000
+ 30 |    5 |  3 |   12 |          .0000000 | 06-01-1401 | 600 |          .0000000
  40 | 2400 |  2 | 1100 |          .0000000 | 01-01-1401 | 100 |          .0000000
- 50 |    0 |  1 |    1 |          .0000000 | 06-01-1401 | 400 |          .0000000
- 50 |    0 |  2 |    1 |          .0000000 | 06-01-1401 | 400 |          .0000000
 (12 rows)
 
 -- STDDEV_SAMP() function with partition by and order by having rows based framing clause --
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(STDDEV_SAMP(floor(cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn AND cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc,cf_olap_windowerr_sale.cn desc,cf_olap_windowerr_sale.cn desc rows floor(cf_olap_windowerr_sale.cn-cf_olap_windowerr_sale.pn) preceding );
-ERROR:  frame starting offset must not be negative  (seg0 slice4 127.0.0.1:40000 pid=16456)
+ERROR:  frame starting offset must not be negative  (seg0 slice4 127.0.0.1:25432 pid=55689)
 -- STDDEV_SAMP() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(STDDEV_SAMP(floor(cf_olap_windowerr_sale.cn/cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn,
 TO_CHAR(COALESCE(LAG(cast(floor(cf_olap_windowerr_sale.cn*cf_olap_windowerr_sale.pn) as int),cast (floor(cf_olap_windowerr_sale.qty/cf_olap_windowerr_sale.prc) as int),NULL) OVER(win2),0),'99999999.9999999'),
@@ -1270,13 +1271,13 @@ TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.qty/cf_olap_windowerr_sale.prc
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn AND cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc rows between 3 preceding and current row ),
 win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc),
-win3 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.pn asc);
-ERROR:  division by zero  (seg0 slice4 rahmaf2-mbp:25432 pid=48130)
+win3 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc);
+ERROR:  division by zero  (seg0 slice4 127.0.0.1:25432 pid=55689)
 -- STDDEV_SAMP() function with partition by and order by having rows based framing clause --
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(STDDEV_SAMP(floor(cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn AND cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc,cf_olap_windowerr_sale.cn desc,cf_olap_windowerr_sale.vn asc rows between floor(cf_olap_windowerr_sale.prc-cf_olap_windowerr_sale.cn) following and floor(cf_olap_windowerr_sale.vn) following );
-ERROR:  frame starting offset must not be negative
+ERROR:  frame starting offset must not be negative  (seg0 slice4 127.0.0.1:25432 pid=55689)
 -- SUM() function with ONLY order by having range based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.dt, TO_CHAR(COALESCE(SUM(floor(cf_olap_windowerr_sale.qty/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),
 TO_CHAR(COALESCE(DENSE_RANK() OVER(win2),0),'99999999.9999999'),
@@ -1287,7 +1288,7 @@ TO_CHAR(COALESCE(RANK() OVER(win2),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (order by cf_olap_windowerr_sale.pn asc range current row ),
 win2 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.pn asc),
-win3 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.cn desc),
+win3 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc),
 win4 as (order by cf_olap_windowerr_sale.vn asc);
 ERROR:  division by zero
 -- SUM() function with ONLY order by having range based framing clause in combination with other functions --
@@ -1298,18 +1299,18 @@ WINDOW win1 as (order by cf_olap_windowerr_sale.cn asc range between unbounded p
 win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc);
  qty  |      to_char      | cn |      to_char      | vn 
 ------+-------------------+----+-------------------+----
+ 1100 |       230.0000000 |  2 |          .0000000 | 40
+    1 |       140.0000000 |  1 |        39.0000000 | 10
+    1 |       330.0000000 |  3 |          .0000000 | 40
     1 |       140.0000000 |  1 |          .0000000 | 20
     1 |       140.0000000 |  1 |          .0000000 | 30
     1 |       140.0000000 |  1 |          .0000000 | 50
-    1 |       140.0000000 |  1 |        39.0000000 | 10
     1 |       230.0000000 |  2 |          .0000000 | 50
-    1 |       330.0000000 |  3 |          .0000000 | 40
-    1 |       410.0000000 |  4 |          .0000000 | 40
-    1 |       410.0000000 |  4 |          .0000000 | 40
    12 |       140.0000000 |  1 |          .0000000 | 30
    12 |       330.0000000 |  3 |          .0000000 | 30
    12 |       330.0000000 |  3 |          .0000000 | 30
- 1100 |       230.0000000 |  2 |          .0000000 | 40
+    1 |       410.0000000 |  4 |          .0000000 | 40
+    1 |       410.0000000 |  4 |          .0000000 | 40
 (12 rows)
 
 -- SUM() function with ONLY order by having range based framing clause in combination with other functions --
@@ -1325,14 +1326,14 @@ win2 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty,cf_ol
 win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc);
  cn | prc  |      to_char      |      to_char      | vn | qty  | pn  |      to_char      |      to_char      |      to_char      |      to_char      
 ----+------+-------------------+-------------------+----+------+-----+-------------------+-------------------+-------------------+-------------------
+  2 | 2400 |      4800.0000000 |          .0000000 | 40 | 1100 | 100 |        40.0000000 |         1.0000000 |         1.0000000 |          .0000000
   1 |    0 |      3300.0000000 |          .0000000 | 10 |    1 | 200 |        10.0000000 |         1.0000000 |         1.0000000 |       -98.0000000
+  3 |    0 |      4800.0000000 |          .0000000 | 40 |    1 | 200 |        40.0000000 |         1.0000000 |         1.0000000 |      -199.0000000
   1 |    0 |      3300.0000000 |          .0000000 | 20 |    1 | 100 |        20.0000000 |         1.0000000 |         1.0000000 |      -197.0000000
   1 |    0 |      3300.0000000 |          .0000000 | 30 |    1 | 300 |        30.0000000 |         1.0000000 |         1.0000000 |       -99.0000000
   1 |    0 |      3300.0000000 |          .0000000 | 50 |    1 | 400 |        50.0000000 |         1.0000000 |         1.0000000 |      -299.0000000
-  1 |    5 |      3300.0000000 |          .0000000 | 30 |   12 | 500 |        30.0000000 |         1.0000000 |         1.0000000 |       -98.0000000
   2 |    0 |      4800.0000000 |          .0000000 | 50 |    1 | 400 |        50.0000000 |         1.0000000 |         1.0000000 |      -399.0000000
-  2 | 2400 |      4800.0000000 |          .0000000 | 40 | 1100 | 100 |        40.0000000 |         1.0000000 |         1.0000000 |          .0000000
-  3 |    0 |      4800.0000000 |          .0000000 | 40 |    1 | 200 |        40.0000000 |         1.0000000 |         1.0000000 |      -199.0000000
+  1 |    5 |      3300.0000000 |          .0000000 | 30 |   12 | 500 |        30.0000000 |         1.0000000 |         1.0000000 |       -98.0000000
   3 |    5 |      4800.0000000 |          .0000000 | 30 |   12 | 500 |        30.0000000 |         1.0000000 |         1.0000000 |      -199.0000000
   3 |    5 |      4800.0000000 |          .0000000 | 30 |   12 | 600 |        30.0000000 |         1.0000000 |         1.0000000 |      -197.0000000
   4 |    1 |      4800.0000000 |          .0000000 | 40 |    1 | 700 |        40.0000000 |         1.0000000 |         1.0000000 |      -696.0000000
@@ -1364,18 +1365,18 @@ win3 as (order by cf_olap_windowerr_sale.vn desc),
 win4 as (partition by cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc);
  qty  | qty  | prc  | cn | cn |      to_char      | pn  |      to_char      |     dt     |      to_char      |      to_char      | vn |      to_char      |      to_char      
 ------+------+------+----+----+-------------------+-----+-------------------+------------+-------------------+-------------------+----+-------------------+-------------------
-    1 |    1 |    0 |  1 |  1 |      3115.0000000 | 400 |          .0000000 | 06-01-1401 |         1.0000000 |         1.0000000 | 50 |          .0000000 |          .0000000
-    1 |    1 |    0 |  1 |  1 |      3918.0000000 | 300 |          .0000000 | 05-02-1401 |         1.0000000 |         7.0000000 | 30 |          .0000000 |          .0000000
-    1 |    1 |    0 |  1 |  1 |      4219.0000000 | 200 |          .0000000 | 03-01-1401 |         1.0000000 |        12.0000000 | 10 |          .0000000 |          .0000000
-    1 |    1 |    0 |  1 |  1 |      4623.0000000 | 100 |          .0000000 | 05-01-1401 |         1.0000000 |        11.0000000 | 20 |          .0000000 |          .0000000
-    1 |    1 |    0 |  2 |  2 |      3115.0000000 | 400 |          .0000000 | 06-01-1401 |         2.0000000 |         1.0000000 | 50 |          .0000000 |          .0000000
-    1 |    1 |    0 |  3 |  3 |      4219.0000000 | 200 |          .0000000 | 04-01-1401 |         1.0000000 |         3.0000000 | 40 |          .0000000 |          .0000000
-    1 |    1 |    1 |  4 |  4 |          .0000000 | 800 |          .0000000 | 06-01-1401 |         1.0000000 |         3.0000000 | 40 |          .0000000 |          .0000000
-    1 |    1 |    1 |  4 |  4 |       804.0000000 | 700 |          .0000000 | 06-01-1401 |         1.0000000 |         3.0000000 | 40 |          .0000000 |          .0000000
-   12 |   12 |    5 |  1 |  1 |      2111.0000000 | 500 |          .0000000 | 06-01-1401 |         1.0000000 |         7.0000000 | 30 |          .0000000 |          .0000000
-   12 |   12 |    5 |  3 |  3 |      1508.0000000 | 600 |          .0000000 | 06-01-1401 |         1.0000000 |         7.0000000 | 30 |          .0000000 |          .0000000
-   12 |   12 |    5 |  3 |  3 |      2111.0000000 | 500 |          .0000000 | 06-01-1401 |         2.0000000 |         7.0000000 | 30 |          .0000000 |          .0000000
  1100 | 1100 | 2400 |  2 |  2 |      4623.0000000 | 100 |          .0000000 | 01-01-1401 |         1.0000000 |         3.0000000 | 40 |          .0000000 |          .0000000
+    1 |    1 |    0 |  1 |  1 |      4623.0000000 | 100 |          .0000000 | 05-01-1401 |         1.0000000 |        11.0000000 | 20 |          .0000000 |          .0000000
+    1 |    1 |    0 |  1 |  1 |      4219.0000000 | 200 |          .0000000 | 03-01-1401 |         1.0000000 |        12.0000000 | 10 |          .0000000 |          .0000000
+    1 |    1 |    0 |  3 |  3 |      4219.0000000 | 200 |          .0000000 | 04-01-1401 |         1.0000000 |         3.0000000 | 40 |          .0000000 |          .0000000
+    1 |    1 |    0 |  1 |  1 |      3918.0000000 | 300 |          .0000000 | 05-02-1401 |         1.0000000 |         7.0000000 | 30 |          .0000000 |          .0000000
+    1 |    1 |    0 |  1 |  1 |      3115.0000000 | 400 |          .0000000 | 06-01-1401 |         1.0000000 |         1.0000000 | 50 |          .0000000 |          .0000000
+    1 |    1 |    0 |  2 |  2 |      3115.0000000 | 400 |          .0000000 | 06-01-1401 |         2.0000000 |         1.0000000 | 50 |          .0000000 |          .0000000
+   12 |   12 |    5 |  1 |  1 |      2111.0000000 | 500 |          .0000000 | 06-01-1401 |         1.0000000 |         7.0000000 | 30 |          .0000000 |          .0000000
+   12 |   12 |    5 |  3 |  3 |      2111.0000000 | 500 |          .0000000 | 06-01-1401 |         2.0000000 |         7.0000000 | 30 |          .0000000 |          .0000000
+   12 |   12 |    5 |  3 |  3 |      1508.0000000 | 600 |          .0000000 | 06-01-1401 |         1.0000000 |         7.0000000 | 30 |          .0000000 |          .0000000
+    1 |    1 |    1 |  4 |  4 |       804.0000000 | 700 |          .0000000 | 06-01-1401 |         1.0000000 |         3.0000000 | 40 |          .0000000 |          .0000000
+    1 |    1 |    1 |  4 |  4 |          .0000000 | 800 |          .0000000 | 06-01-1401 |         1.0000000 |         3.0000000 | 40 |          .0000000 |          .0000000
 (12 rows)
 
 -- SUM() function with ONLY order by having rows based framing clause --
@@ -1399,20 +1400,20 @@ FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_ol
 WINDOW win1 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc,cf_olap_windowerr_sale.cn asc,cf_olap_windowerr_sale.vn desc rows between floor(cf_olap_windowerr_sale.prc) preceding and floor(cf_olap_windowerr_sale.pn-cf_olap_windowerr_sale.pn) following ),
 win2 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc),
 win3 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc),
-win4 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.cn desc, cf_olap_windowerr_sale.pn),
+win4 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc, cf_olap_windowerr_sale.pn),
 win5 as (order by cf_olap_windowerr_sale.pn asc);
  pn  | vn | cn |      to_char      |      to_char      | prc  |     dt     | qty  |      to_char      |      to_char      |      to_char      |      to_char      
 -----+----+----+-------------------+-------------------+------+------------+------+-------------------+-------------------+-------------------+-------------------
- 100 | 20 |  1 |         1.0000000 |          .0000000 |    0 | 05-01-1401 |    1 |          .0000000 |         1.0000000 |          .0000000 |         1.0000000
  100 | 40 |  2 |         1.0000000 |          .0000000 | 2400 | 01-01-1401 | 1100 |          .0000000 |         1.0000000 |          .0000000 |         1.0000000
+ 100 | 20 |  1 |         1.0000000 |          .0000000 |    0 | 05-01-1401 |    1 |          .0000000 |         1.0000000 |          .0000000 |         1.0000000
  200 | 10 |  1 |         1.0000000 |          .0000000 |    0 | 03-01-1401 |    1 |          .0000000 |         1.0000000 |          .1818182 |         1.0000000
  200 | 40 |  3 |         1.0000000 |          .0000000 |    0 | 04-01-1401 |    1 |          .0000000 |         1.0000000 |          .1818182 |         1.0000000
  300 | 30 |  1 |         1.0000000 |          .0000000 |    0 | 05-02-1401 |    1 |          .0000000 |         1.0000000 |          .3636364 |         1.0000000
- 400 | 50 |  1 |         1.0000000 |          .0000000 |    0 | 06-01-1401 |    1 |          .0000000 |         2.0000000 |          .4545455 |         1.0000000
- 400 | 50 |  2 |         1.0000000 |          .0000000 |    0 | 06-01-1401 |    1 |          .0000000 |         1.0000000 |          .4545455 |         1.0000000
- 500 | 30 |  1 |         6.0000000 |          .0000000 |    5 | 06-01-1401 |   12 |          .0000000 |         3.0000000 |          .6363636 |         1.0000000
- 500 | 30 |  3 |         6.0000000 |          .0000000 |    5 | 06-01-1401 |   12 |          .0000000 |         1.0000000 |          .6363636 |         1.0000000
- 600 | 30 |  3 |         6.0000000 |          .0000000 |    5 | 06-01-1401 |   12 |          .0000000 |         2.0000000 |          .8181818 |         1.0000000
+ 400 | 50 |  1 |         1.0000000 |          .0000000 |    0 | 06-01-1401 |    1 |          .0000000 |         1.0000000 |          .4545455 |         1.0000000
+ 400 | 50 |  2 |         1.0000000 |          .0000000 |    0 | 06-01-1401 |    1 |          .0000000 |         2.0000000 |          .4545455 |         1.0000000
+ 500 | 30 |  3 |         6.0000000 |          .0000000 |    5 | 06-01-1401 |   12 |          .0000000 |         2.0000000 |          .6363636 |         1.0000000
+ 500 | 30 |  1 |         6.0000000 |          .0000000 |    5 | 06-01-1401 |   12 |          .0000000 |         1.0000000 |          .6363636 |         1.0000000
+ 600 | 30 |  3 |         6.0000000 |          .0000000 |    5 | 06-01-1401 |   12 |          .0000000 |         3.0000000 |          .8181818 |         1.0000000
  700 | 40 |  4 |         2.0000000 |        40.0000000 |    1 | 06-01-1401 |    1 |          .0000000 |         1.0000000 |          .9090909 |         1.0000000
  800 | 40 |  4 |         2.0000000 |        40.0000000 |    1 | 06-01-1401 |    1 |          .0000000 |         2.0000000 |         1.0000000 |         1.0000000
 (12 rows)
@@ -1426,16 +1427,16 @@ WINDOW win1 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.d
 win2 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc);
  qty  |      to_char      | prc  | cn |     dt     |      to_char      | pn  |      to_char      
 ------+-------------------+------+----+------------+-------------------+-----+-------------------
-    1 |        10.0000000 |    0 |  1 | 03-01-1401 |          .0000000 | 200 |         1.0000000
-    1 |        20.0000000 |    0 |  1 | 05-01-1401 |          .0000000 | 100 |         1.0000000
-    1 |        30.0000000 |    0 |  1 | 05-02-1401 |          .0000000 | 300 |         1.0000000
-    1 |        40.0000000 |    0 |  3 | 04-01-1401 |          .0000000 | 200 |         1.0000000
-    1 |        50.0000000 |    0 |  1 | 06-01-1401 |          .0000000 | 400 |         1.0000000
     1 |        80.0000000 |    1 |  4 | 06-01-1401 |          .0000000 | 700 |         2.0000000
     1 |        80.0000000 |    1 |  4 | 06-01-1401 |          .0000000 | 800 |         2.0000000
+    1 |        10.0000000 |    0 |  1 | 03-01-1401 |          .0000000 | 200 |         1.0000000
+    1 |        40.0000000 |    0 |  3 | 04-01-1401 |          .0000000 | 200 |         1.0000000
+    1 |        30.0000000 |    0 |  1 | 05-02-1401 |          .0000000 | 300 |         1.0000000
+    1 |        50.0000000 |    0 |  1 | 06-01-1401 |          .0000000 | 400 |         1.0000000
     1 |       100.0000000 |    0 |  2 | 06-01-1401 |          .0000000 | 400 |         2.0000000
    12 |        30.0000000 |    5 |  1 | 06-01-1401 |          .0000000 | 500 |         1.0000000
    12 |        90.0000000 |    5 |  3 | 06-01-1401 |          .0000000 | 500 |         3.0000000
+    1 |        20.0000000 |    0 |  1 | 05-01-1401 |          .0000000 | 100 |         1.0000000
    12 |        90.0000000 |    5 |  3 | 06-01-1401 |          .0000000 | 600 |         3.0000000
  1100 |        40.0000000 | 2400 |  2 | 01-01-1401 |          .0000000 | 100 |         1.0000000
 (12 rows)
@@ -1444,7 +1445,7 @@ win2 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.pn order
 SELECT cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(SUM(floor(cf_olap_windowerr_sale.cn/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.pn asc range between floor(cf_olap_windowerr_sale.qty) preceding and current row );
-ERROR:  division by zero  (seg1 slice3 rahmaf2-mbp:25433 pid=48131)
+ERROR:  division by zero  (seg1 slice3 127.0.0.1:25433 pid=55690)
 -- SUM() function with partition by and order by having range based framing clause in combination with other functions--
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(SUM(floor(cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.pn,
 TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.pn*cf_olap_windowerr_sale.qty)) OVER(partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.vn asc range between current row and current row ),0),'99999999.9999999'),
@@ -1454,25 +1455,25 @@ WINDOW win1 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn
 win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc);
  qty  | vn | qty  |      to_char      | pn  |      to_char      |      to_char      
 ------+----+------+-------------------+-----+-------------------+-------------------
+ 1100 | 40 | 1100 |      2400.0000000 | 100 |    110000.0000000 |          .0000000
     1 | 10 |    1 |          .0000000 | 200 |       200.0000000 |        10.0000000
+    1 | 40 |    1 |          .0000000 | 200 |       200.0000000 |        40.0000000
     1 | 20 |    1 |          .0000000 | 100 |       100.0000000 |        20.0000000
     1 | 30 |    1 |          .0000000 | 300 |       300.0000000 |        30.0000000
-    1 | 40 |    1 |          .0000000 | 200 |       200.0000000 |        40.0000000
+    1 | 50 |    1 |          .0000000 | 400 |       400.0000000 |        50.0000000
+    1 | 50 |    1 |          .0000000 | 400 |       400.0000000 |        50.0000000
+   12 | 30 |   12 |        10.0000000 | 500 |      6000.0000000 |          .0000000
+   12 | 30 |   12 |        10.0000000 | 500 |      6000.0000000 |          .0000000
+   12 | 30 |   12 |         5.0000000 | 600 |      7200.0000000 |          .0000000
     1 | 40 |    1 |         1.0000000 | 700 |       700.0000000 |        30.0000000
     1 | 40 |    1 |         1.0000000 | 800 |       800.0000000 |        30.0000000
-    1 | 50 |    1 |          .0000000 | 400 |       400.0000000 |        50.0000000
-    1 | 50 |    1 |          .0000000 | 400 |       400.0000000 |        50.0000000
-   12 | 30 |   12 |         5.0000000 | 600 |      7200.0000000 |          .0000000
-   12 | 30 |   12 |        10.0000000 | 500 |      6000.0000000 |          .0000000
-   12 | 30 |   12 |        10.0000000 | 500 |      6000.0000000 |          .0000000
- 1100 | 40 | 1100 |      2400.0000000 | 100 |    110000.0000000 |          .0000000
 (12 rows)
 
 -- SUM() function with partition by and order by having range based framing clause --
 SELECT cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.dt, TO_CHAR(COALESCE(SUM(floor(cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.pn asc range between floor(cf_olap_windowerr_sale.qty/cf_olap_windowerr_sale.prc) following and unbounded following );
-ERROR:  division by zero  (seg2 slice2 rahmaf2-mbp:25434 pid=48132)
+ERROR:  division by zero  (seg0 slice2 127.0.0.1:25432 pid=55689)
 -- SUM() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(SUM(floor(cf_olap_windowerr_sale.prc+cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn,
 TO_CHAR(COALESCE(CUME_DIST() OVER(win2),0),'99999999.9999999'),
@@ -1483,7 +1484,7 @@ FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_ol
 WINDOW win1 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc,cf_olap_windowerr_sale.pn asc rows floor(cf_olap_windowerr_sale.prc-cf_olap_windowerr_sale.cn) preceding ),
 win2 as (order by cf_olap_windowerr_sale.cn desc),
 win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc);
-ERROR:  frame starting offset must not be negative  (seg0 slice2 127.0.0.1:40000 pid=16456)
+ERROR:  frame starting offset must not be negative  (seg0 slice2 127.0.0.1:25432 pid=55689)
 -- SUM() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.prc, TO_CHAR(COALESCE(SUM(floor(cf_olap_windowerr_sale.prc-cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.vn,
 TO_CHAR(COALESCE(LAG(cast(floor(cf_olap_windowerr_sale.cn/cf_olap_windowerr_sale.qty) as int),cast (floor(cf_olap_windowerr_sale.vn) as int),NULL) OVER(win2),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,
@@ -1514,13 +1515,13 @@ win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc);
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn, TO_CHAR(COALESCE(SUM(floor(cf_olap_windowerr_sale.vn/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.cn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn AND cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc rows between floor(cf_olap_windowerr_sale.vn+cf_olap_windowerr_sale.cn) preceding and current row );
-ERROR:  division by zero  (seg0 slice4 rahmaf2-mbp:25432 pid=48130)
+ERROR:  division by zero  (seg0 slice4 127.0.0.1:25432 pid=55689)
 -- SUM() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(SUM(floor(cf_olap_windowerr_sale.vn/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn,
 TO_CHAR(COALESCE(COUNT(floor(cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn AND cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc rows between current row and current row );
-ERROR:  division by zero  (seg1 slice3 rahmaf2-mbp:25433 pid=48131)
+ERROR:  division by zero  (seg0 slice3 127.0.0.1:25432 pid=55689)
 -- VAR_POP() function with ONLY order by having range based framing clause --
 SELECT cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(VAR_POP(floor(cf_olap_windowerr_sale.cn/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn ) cf_olap_windowerr_sale
@@ -1539,7 +1540,7 @@ TO_CHAR(COALESCE(LAG(cast(floor(cf_olap_windowerr_sale.prc) as int),cast (floor(
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn AND cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
 WINDOW win1 as (order by cf_olap_windowerr_sale.cn desc range between floor(cf_olap_windowerr_sale.cn/cf_olap_windowerr_sale.prc) preceding and 4 preceding ),
 win2 as (order by cf_olap_windowerr_sale.vn asc),
-win3 as (order by cf_olap_windowerr_sale.pn asc),
+win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc),
 win4 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc);
 ERROR:  division by zero
 -- VAR_POP() function with ONLY order by having range based framing clause in combination with other functions --
@@ -1579,10 +1580,10 @@ win2 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn,cf_ola
 win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc);
  pn  | pn  | vn | cn | qty  |      to_char      |      to_char      |     dt     |      to_char      |      to_char      
 -----+-----+----+----+------+-------------------+-------------------+------------+-------------------+-------------------
- 100 | 100 | 20 |  1 |    1 |       168.7500000 |         1.0000000 | 05-01-1401 |        21.0000000 |         1.0000000
  100 | 100 | 40 |  2 | 1100 |          .0000000 |         1.0000000 | 01-01-1401 |      1140.0000000 |          .0000000
  200 | 200 | 10 |  1 |    1 |       225.0000000 |         1.0000000 | 03-01-1401 |        11.0000000 |      1100.0000000
  200 | 200 | 40 |  3 |    1 |       200.0000000 |         1.0000000 | 04-01-1401 |        41.0000000 |         1.0000000
+ 100 | 100 | 20 |  1 |    1 |       168.7500000 |         1.0000000 | 05-01-1401 |        21.0000000 |         1.0000000
  300 | 300 | 30 |  1 |    1 |       136.0000000 |         1.0000000 | 05-02-1401 |        31.0000000 |         1.0000000
  400 | 400 | 50 |  1 |    1 |       180.5555556 |         1.0000000 | 06-01-1401 |        51.0000000 |         1.0000000
  400 | 400 | 50 |  2 |    1 |       195.9183673 |         1.0000000 | 06-01-1401 |        51.0000000 |         1.0000000
@@ -1617,12 +1618,12 @@ TO_CHAR(COALESCE(RANK() OVER(partition by cf_olap_windowerr_sale.dt,cf_olap_wind
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.pn desc range between 0 preceding and floor(cf_olap_windowerr_sale.pn-cf_olap_windowerr_sale.qty) following ),
 win2 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc);
-ERROR:  RANGE parameter cannot be negative  (seg0 slice3 rahmaf2-mbp:25432 pid=48130)
+ERROR:  RANGE parameter cannot be negative  (seg0 slice2 127.0.0.1:25432 pid=55689)
 -- VAR_POP() function with partition by and order by having range based framing clause --
 SELECT cf_olap_windowerr_sale.dt, TO_CHAR(COALESCE(VAR_POP(floor(cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty order by cf_olap_windowerr_sale.vn desc range between current row and floor(cf_olap_windowerr_sale.vn-cf_olap_windowerr_sale.qty) following );
-ERROR:  RANGE parameter cannot be negative  (seg1 slice3 rahmaf2-mbp:25433 pid=48131)
+ERROR:  RANGE parameter cannot be negative  (seg1 slice3 127.0.0.1:25433 pid=55690)
 -- VAR_POP() function with partition by and order by having range based framing clause in combination with other functions--
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.pn, TO_CHAR(COALESCE(VAR_POP(floor(cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,
 TO_CHAR(COALESCE(COUNT(floor(cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999'),
@@ -1635,24 +1636,24 @@ win2 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn order 
  qty  | cn | prc  | pn  |      to_char      |     dt     | vn |      to_char      |      to_char      |      to_char      |      to_char      
 ------+----+------+-----+-------------------+------------+----+-------------------+-------------------+-------------------+-------------------
     1 |  1 |    0 | 100 |          .0000000 | 05-01-1401 | 20 |         1.0000000 |         1.0000000 |          .0000000 |         1.0000000
-    1 |  1 |    0 | 200 |          .0000000 | 03-01-1401 | 10 |         1.0000000 |         1.0000000 |          .0000000 |         1.0000000
-    1 |  1 |    0 | 300 |          .0000000 | 05-02-1401 | 30 |         1.0000000 |         1.0000000 |          .0000000 |         1.0000000
-    1 |  1 |    0 | 400 |          .0000000 | 06-01-1401 | 50 |         1.0000000 |         1.0000000 |          .0000000 |         1.0000000
-    1 |  2 |    0 | 400 |          .0000000 | 06-01-1401 | 50 |         1.0000000 |         1.0000000 |          .0000000 |         1.0000000
+ 1100 |  2 | 2400 | 100 |          .0000000 | 01-01-1401 | 40 |         1.0000000 |      1100.0000000 |          .0000000 |         1.0000000
     1 |  3 |    0 | 200 |          .0000000 | 04-01-1401 | 40 |         1.0000000 |         1.0000000 |          .0000000 |         1.0000000
+    1 |  1 |    0 | 300 |          .0000000 | 05-02-1401 | 30 |         1.0000000 |         1.0000000 |          .0000000 |         1.0000000
     1 |  4 |    1 | 700 |          .0000000 | 06-01-1401 | 40 |         1.0000000 |         1.0000000 |          .0000000 |         1.0000000
     1 |  4 |    1 | 800 |          .0000000 | 06-01-1401 | 40 |         1.0000000 |         1.0000000 |          .0000000 |         1.0000000
+    1 |  1 |    0 | 200 |          .0000000 | 03-01-1401 | 10 |         1.0000000 |         1.0000000 |          .0000000 |         1.0000000
+    1 |  1 |    0 | 400 |          .0000000 | 06-01-1401 | 50 |         1.0000000 |         1.0000000 |          .0000000 |         1.0000000
    12 |  1 |    5 | 500 |          .0000000 | 06-01-1401 | 30 |         1.0000000 |        12.0000000 |          .0000000 |         1.0000000
+    1 |  2 |    0 | 400 |          .0000000 | 06-01-1401 | 50 |         1.0000000 |         1.0000000 |          .0000000 |         1.0000000
    12 |  3 |    5 | 500 |          .0000000 | 06-01-1401 | 30 |         1.0000000 |        12.0000000 |          .0000000 |         1.0000000
    12 |  3 |    5 | 600 |          .0000000 | 06-01-1401 | 30 |         1.0000000 |        12.0000000 |          .0000000 |         1.0000000
- 1100 |  2 | 2400 | 100 |          .0000000 | 01-01-1401 | 40 |         1.0000000 |      1100.0000000 |          .0000000 |         1.0000000
 (12 rows)
 
 -- VAR_POP() function with partition by and order by having rows based framing clause --
 SELECT cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(VAR_POP(floor(cf_olap_windowerr_sale.qty)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.vn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc rows between unbounded preceding and floor(cf_olap_windowerr_sale.prc-cf_olap_windowerr_sale.cn) following );
-ERROR:  frame ending offset must not be negative
+ERROR:  frame ending offset must not be negative  (seg0 slice2 127.0.0.1:25432 pid=55689)
 -- VAR_POP() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.dt, TO_CHAR(COALESCE(VAR_POP(floor(cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,
 TO_CHAR(COALESCE(LEAD(cast(floor(cf_olap_windowerr_sale.qty) as int),cast (floor(cf_olap_windowerr_sale.cn-cf_olap_windowerr_sale.vn) as int),NULL) OVER(win2),0),'99999999.9999999'),
@@ -1663,18 +1664,18 @@ WINDOW win1 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn
 win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc);
  qty  |     dt     |      to_char      | prc  | cn | vn | pn  |      to_char      |      to_char      |      to_char      
 ------+------------+-------------------+------+----+----+-----+-------------------+-------------------+-------------------
+ 1100 | 01-01-1401 |          .0000000 | 2400 |  2 | 40 | 100 |          .0000000 |         1.0000000 |          .0833333
     1 | 03-01-1401 |          .0000000 |    0 |  1 | 10 | 200 |          .0000000 |         2.0000000 |          .1666667
     1 | 04-01-1401 |          .0000000 |    0 |  3 | 40 | 200 |          .0000000 |         3.0000000 |          .2500000
     1 | 05-01-1401 |          .0000000 |    0 |  1 | 20 | 100 |          .0000000 |         4.0000000 |          .3333333
     1 | 05-02-1401 |          .0000000 |    0 |  1 | 30 | 300 |          .0000000 |         5.0000000 |          .4166667
     1 | 06-01-1401 |          .0000000 |    0 |  1 | 50 | 400 |          .0000000 |         6.0000000 |          .5000000
     1 | 06-01-1401 |          .0000000 |    0 |  2 | 50 | 400 |          .0000000 |         7.0000000 |          .5833333
-    1 | 06-01-1401 |          .0000000 |    1 |  4 | 40 | 700 |          .0000000 |        11.0000000 |          .9166667
-    1 | 06-01-1401 |          .0000000 |    1 |  4 | 40 | 800 |          .0000000 |        12.0000000 |         1.0000000
    12 | 06-01-1401 |          .0000000 |    5 |  1 | 30 | 500 |          .0000000 |         8.0000000 |          .6666667
    12 | 06-01-1401 |          .0000000 |    5 |  3 | 30 | 500 |          .0000000 |         9.0000000 |          .7500000
    12 | 06-01-1401 |          .0000000 |    5 |  3 | 30 | 600 |          .0000000 |        10.0000000 |          .8333333
- 1100 | 01-01-1401 |          .0000000 | 2400 |  2 | 40 | 100 |          .0000000 |         1.0000000 |          .0833333
+    1 | 06-01-1401 |          .0000000 |    1 |  4 | 40 | 700 |          .0000000 |        11.0000000 |          .9166667
+    1 | 06-01-1401 |          .0000000 |    1 |  4 | 40 | 800 |          .0000000 |        12.0000000 |         1.0000000
 (12 rows)
 
 -- VAR_POP() function with partition by and order by having rows based framing clause in combination with other functions --
@@ -1688,7 +1689,7 @@ FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_ol
 WINDOW win1 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc rows between floor(cf_olap_windowerr_sale.pn) preceding and floor(cf_olap_windowerr_sale.cn) following ),
 win2 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.cn asc),
 win3 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.pn asc);
-ERROR:  division by zero  (seg0 slice2 rahmaf2-mbp:25432 pid=48136)
+ERROR:  division by zero  (seg0 slice2 127.0.0.1:25432 pid=55700)
 -- VAR_POP() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn, TO_CHAR(COALESCE(VAR_POP(floor(cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,
 TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.qty/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),
@@ -1700,7 +1701,7 @@ FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_ola
 WINDOW win1 as (partition by cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc,cf_olap_windowerr_sale.vn asc rows between current row and unbounded following ),
 win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc),
 win3 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc);
-ERROR:  division by zero  (seg0 slice5 rahmaf2-mbp:25432 pid=48130)
+ERROR:  division by zero  (seg0 slice5 127.0.0.1:25432 pid=55689)
 -- VAR_SAMP() function with ONLY order by having range based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(VAR_SAMP(floor(cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.pn,
 TO_CHAR(COALESCE(LEAD(cast(floor(cf_olap_windowerr_sale.prc) as int),cast (floor(cf_olap_windowerr_sale.qty*cf_olap_windowerr_sale.cn) as int),NULL) OVER(win2),0),'99999999.9999999'),cf_olap_windowerr_sale.cn
@@ -1716,18 +1717,18 @@ WINDOW win1 as (order by cf_olap_windowerr_sale.pn asc range between unbounded p
 win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc);
  qty  | pn  | pn  | vn |      to_char      |      to_char      
 ------+-----+-----+----+-------------------+-------------------
-    1 | 100 | 100 | 20 |         1.4242424 |        20.0000000
+ 1100 | 100 | 100 | 40 |         1.4242424 |          .0000000
     1 | 200 | 200 | 10 |         1.4242424 |        10.0000000
     1 | 200 | 200 | 40 |         1.4242424 |        30.0000000
+    1 | 100 | 100 | 20 |         1.4242424 |        20.0000000
     1 | 300 | 300 | 30 |         1.4242424 |        30.0000000
     1 | 400 | 400 | 50 |         1.4242424 |        50.0000000
     1 | 400 | 400 | 50 |         1.4242424 |       360.0000000
-    1 | 700 | 700 | 40 |         1.4242424 |          .0000000
-    1 | 800 | 800 | 40 |         1.4242424 |          .0000000
    12 | 500 | 500 | 30 |         1.4242424 |          .0000000
    12 | 500 | 500 | 30 |         1.4242424 |          .0000000
    12 | 600 | 600 | 30 |         1.4242424 |     44000.0000000
- 1100 | 100 | 100 | 40 |         1.4242424 |          .0000000
+    1 | 700 | 700 | 40 |         1.4242424 |          .0000000
+    1 | 800 | 800 | 40 |         1.4242424 |          .0000000
 (12 rows)
 
 -- VAR_SAMP() function with ONLY order by having range based framing clause in combination with other functions --
@@ -1741,16 +1742,16 @@ WINDOW win1 as (order by cf_olap_windowerr_sale.cn desc range between floor(cf_o
 win2 as (order by cf_olap_windowerr_sale.cn asc);
  cn | vn | cn |      to_char      |      to_char      |      to_char      |      to_char      |      to_char      
 ----+----+----+-------------------+-------------------+-------------------+-------------------+-------------------
-  1 | 20 |  1 |          .0000000 |          .0000000 |          .0000000 |          .0000000 |          .0000000
-  1 | 10 |  1 |          .0000000 |          .0000000 |          .0000000 |          .0000000 |          .0000000
   1 | 30 |  1 |          .0000000 |          .0000000 |          .0000000 |          .0000000 |          .0000000
   1 | 50 |  1 |          .0000000 |          .0000000 |          .0000000 |          .0000000 |          .0000000
   1 | 30 |  1 |          .0000000 |          .0000000 |          .0000000 |          .0000000 |          .0000000
-  2 | 40 |  2 |          .0000000 |          .0000000 |          .0000000 |          .4545455 |          .0000000
+  1 | 10 |  1 |          .0000000 |          .0000000 |          .0000000 |          .0000000 |          .0000000
+  1 | 20 |  1 |          .0000000 |          .0000000 |          .0000000 |          .0000000 |          .0000000
   2 | 50 |  2 |          .0000000 |          .0000000 |          .0000000 |          .4545455 |          .0000000
+  2 | 40 |  2 |          .0000000 |          .0000000 |          .0000000 |          .4545455 |          .0000000
+  3 | 30 |  3 |          .0000000 |          .0000000 |          .0000000 |          .6363636 |          .0000000
+  3 | 30 |  3 |          .0000000 |          .0000000 |          .0000000 |          .6363636 |          .0000000
   3 | 40 |  3 |          .0000000 |          .0000000 |          .0000000 |          .6363636 |          .0000000
-  3 | 30 |  3 |          .0000000 |          .0000000 |          .0000000 |          .6363636 |          .0000000
-  3 | 30 |  3 |          .0000000 |          .0000000 |          .0000000 |          .6363636 |          .0000000
   4 | 40 |  4 |          .0000000 |          .0000000 |          .0000000 |          .9090909 |          .0000000
   4 | 40 |  4 |          .0000000 |          .0000000 |          .0000000 |          .9090909 |          .0000000
 (12 rows)
@@ -1783,18 +1784,18 @@ FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_ola
 WINDOW win1 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc rows between 8 following and unbounded following );
  prc  | qty  | qty  | pn  | qty  |      to_char      | vn 
 ------+------+------+-----+------+-------------------+----
-    0 |    1 |    1 | 100 |    1 |          .0000000 | 20
+ 2400 | 1100 | 1100 | 100 | 1100 |          .0000000 | 40
     0 |    1 |    1 | 200 |    1 |          .0000000 | 10
     0 |    1 |    1 | 200 |    1 |          .0000000 | 40
+    0 |    1 |    1 | 100 |    1 |          .0000000 | 20
     0 |    1 |    1 | 300 |    1 |          .0000000 | 30
     0 |    1 |    1 | 400 |    1 |          .0000000 | 50
     0 |    1 |    1 | 400 |    1 |          .0000000 | 50
-    1 |    1 |    1 | 700 |    1 |          .0000000 | 40
-    1 |    1 |    1 | 800 |    1 |          .0000000 | 40
     5 |   12 |   12 | 500 |   12 |          .0000000 | 30
     5 |   12 |   12 | 500 |   12 |          .0000000 | 30
     5 |   12 |   12 | 600 |   12 |          .0000000 | 30
- 2400 | 1100 | 1100 | 100 | 1100 |          .0000000 | 40
+    1 |    1 |    1 | 700 |    1 |          .0000000 | 40
+    1 |    1 |    1 | 800 |    1 |          .0000000 | 40
 (12 rows)
 
 -- VAR_SAMP() function with ONLY order by having rows based framing clause in combination with other functions --
@@ -1815,8 +1816,8 @@ TO_CHAR(COALESCE(ROW_NUMBER() OVER(win2),0),'99999999.9999999'),
 TO_CHAR(COALESCE(DENSE_RANK() OVER(order by cf_olap_windowerr_sale.cn desc),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.cn asc range floor(cf_olap_windowerr_sale.qty-cf_olap_windowerr_sale.pn) preceding ),
-win2 as (order by cf_olap_windowerr_sale.cn desc);
-ERROR:  RANGE parameter cannot be negative  (seg0 slice3 rahmaf2-mbp:25432 pid=48130)
+win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc);
+ERROR:  RANGE parameter cannot be negative  (seg0 slice3 127.0.0.1:25432 pid=55689)
 -- VAR_SAMP() function with partition by and order by having range based framing clause in combination with other functions--
 SELECT cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.prc, TO_CHAR(COALESCE(VAR_SAMP(floor(cf_olap_windowerr_sale.vn*cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.vn,
 TO_CHAR(COALESCE(DENSE_RANK() OVER(win2),0),'99999999.9999999'),
@@ -1824,7 +1825,7 @@ TO_CHAR(COALESCE(PERCENT_RANK() OVER(order by cf_olap_windowerr_sale.pn asc),0),
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn ) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.vn desc range between floor(cf_olap_windowerr_sale.qty/cf_olap_windowerr_sale.prc) preceding and current row ),
 win2 as (order by cf_olap_windowerr_sale.pn asc);
-ERROR:  division by zero  (seg0 slice3 rahmaf2-mbp:25432 pid=48130)
+ERROR:  division by zero  (seg0 slice3 127.0.0.1:25432 pid=55689)
 -- VAR_SAMP() function with partition by and order by having range based framing clause in combination with other functions--
 SELECT cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(VAR_SAMP(floor(cf_olap_windowerr_sale.pn*cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn,
 TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.pn-cf_olap_windowerr_sale.qty)) OVER(partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.pn desc range between current row and unbounded following ),0),'99999999.9999999'),
@@ -1867,7 +1868,7 @@ win3 as (order by cf_olap_windowerr_sale.pn asc);
 SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(VAR_SAMP(floor(cf_olap_windowerr_sale.qty-cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn ) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc,cf_olap_windowerr_sale.pn desc rows floor(cf_olap_windowerr_sale.prc-cf_olap_windowerr_sale.vn) preceding );
-ERROR:  frame starting offset must not be negative  (seg0 slice3 127.0.0.1:40000 pid=16456)
+ERROR:  frame starting offset must not be negative  (seg1 slice2 127.0.0.1:25433 pid=55690)
 -- VAR_SAMP() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(VAR_SAMP(floor(cf_olap_windowerr_sale.prc/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.pn,
 TO_CHAR(COALESCE(LEAD(cast(floor(cf_olap_windowerr_sale.pn) as int),cast (floor(cf_olap_windowerr_sale.qty) as int),NULL) OVER(win2),0),'99999999.9999999'),
@@ -1878,17 +1879,17 @@ FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_ola
 WINDOW win1 as (partition by cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc,cf_olap_windowerr_sale.pn asc,cf_olap_windowerr_sale.pn desc rows between 0 preceding and current row ),
 win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc),
 win3 as (order by cf_olap_windowerr_sale.vn desc);
-ERROR:  division by zero  (seg0 slice4 rahmaf2-mbp:25432 pid=48130)
+ERROR:  division by zero  (seg0 slice3 127.0.0.1:25432 pid=55689)
 -- VAR_SAMP() function with partition by and order by having rows based framing clause --
 SELECT cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(VAR_SAMP(floor(cf_olap_windowerr_sale.vn/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn ) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc,cf_olap_windowerr_sale.pn desc rows between current row and 9 following );
-ERROR:  division by zero  (seg0 slice3 rahmaf2-mbp:25432 pid=48130)
+ERROR:  division by zero  (seg0 slice3 127.0.0.1:25432 pid=55689)
 -- VAR_SAMP() function with partition by and order by having rows based framing clause --
 SELECT cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(VAR_SAMP(floor(cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc rows between floor(cf_olap_windowerr_sale.vn-cf_olap_windowerr_sale.qty) following and unbounded following );
-ERROR:  frame starting offset must not be negative
+ERROR:  frame starting offset must not be negative  (seg2 slice2 127.0.0.1:25434 pid=55691)
 -- VARIANCE() function with NULL OVER() clause in combination with other window functions --
 SELECT cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn, TO_CHAR(COALESCE(VARIANCE(floor(cf_olap_windowerr_sale.prc-cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999')
 ,
@@ -1907,10 +1908,10 @@ win3 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn order 
  04-01-1401 | 200 |    479459.6590909 |    240000.0000000 |         2.0000000 |  3 |         5.0000000 |          .0000000
  05-01-1401 | 100 |    479459.6590909 |    240000.0000000 |         4.0000000 |  1 |        12.0000000 |          .0000000
  05-02-1401 | 300 |    479459.6590909 |    240000.0000000 |         4.0000000 |  1 |        12.0000000 |          .0000000
- 06-01-1401 | 400 |    479459.6590909 |    240000.0000000 |         3.0000000 |  2 |         7.0000000 |          .0000000
  06-01-1401 | 400 |    479459.6590909 |    240000.0000000 |         4.0000000 |  1 |        12.0000000 |          .0000000
- 06-01-1401 | 500 |    479459.6590909 |    240000.0000000 |         2.0000000 |  3 |         5.0000000 |          .0000000
  06-01-1401 | 500 |    479459.6590909 |    240000.0000000 |         4.0000000 |  1 |        12.0000000 |          .0000000
+ 06-01-1401 | 400 |    479459.6590909 |    240000.0000000 |         3.0000000 |  2 |         7.0000000 |          .0000000
+ 06-01-1401 | 500 |    479459.6590909 |    240000.0000000 |         2.0000000 |  3 |         5.0000000 |          .0000000
  06-01-1401 | 600 |    479459.6590909 |    240000.0000000 |         2.0000000 |  3 |         5.0000000 |          .0000000
  06-01-1401 | 700 |    479459.6590909 |    240000.0000000 |         1.0000000 |  4 |         2.0000000 |          .0000000
  06-01-1401 | 800 |    479459.6590909 |    240000.0000000 |         1.0000000 |  4 |         2.0000000 |          .0000000
@@ -1930,7 +1931,7 @@ win2 as (order by cf_olap_windowerr_sale.pn asc),
 win3 as (order by cf_olap_windowerr_sale.pn asc),
 win4 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc),
 win5 as (order by cf_olap_windowerr_sale.pn desc);
-ERROR:  division by zero  (seg0 slice4 rahmaf2-mbp:25432 pid=48143)
+ERROR:  division by zero
 -- VARIANCE() function with ONLY order by having range based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.pn, TO_CHAR(COALESCE(VARIANCE(floor(cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.vn,
 TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.qty-cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),
@@ -1978,18 +1979,18 @@ win3 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn,cf_ola
 win4 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.vn asc);
  cn |      to_char      | vn |      to_char      |     dt     | pn  |      to_char      |      to_char      | prc  | qty  
 ----+-------------------+----+-------------------+------------+-----+-------------------+-------------------+------+------
+  2 |          .0000000 | 40 |         1.0000000 | 01-01-1401 | 100 |          .0000000 |         1.0000000 | 2400 | 1100
   1 |          .0000000 | 10 |         1.0000000 | 03-01-1401 | 200 |          .0000000 |         1.0000000 |    0 |    1
+  3 |          .0000000 | 40 |         1.0000000 | 04-01-1401 | 200 |          .0000000 |         1.0000000 |    0 |    1
   1 |          .0000000 | 20 |         1.0000000 | 05-01-1401 | 100 |          .0000000 |         1.0000000 |    0 |    1
   1 |          .0000000 | 30 |         1.0000000 | 05-02-1401 | 300 |          .0000000 |         1.0000000 |    0 |    1
   1 |          .0000000 | 30 |         1.0000000 | 06-01-1401 | 500 |          .0000000 |         1.0000000 |    5 |   12
-  1 |          .0000000 | 50 |         1.0000000 | 06-01-1401 | 400 |          .0000000 |         1.0000000 |    0 |    1
-  2 |          .0000000 | 40 |         1.0000000 | 01-01-1401 | 100 |          .0000000 |         1.0000000 | 2400 | 1100
-  2 |          .0000000 | 50 |         1.0000000 | 06-01-1401 | 400 |          .0000000 |         1.0000000 |    0 |    1
   3 |          .0000000 | 30 |         1.0000000 | 06-01-1401 | 500 |          .0000000 |         1.0000000 |    5 |   12
   3 |          .0000000 | 30 |         1.0000000 | 06-01-1401 | 600 |          .0000000 |         1.0000000 |    5 |   12
-  3 |          .0000000 | 40 |         1.0000000 | 04-01-1401 | 200 |          .0000000 |         1.0000000 |    0 |    1
   4 |          .0000000 | 40 |         1.0000000 | 06-01-1401 | 700 |          .0000000 |         1.0000000 |    1 |    1
   4 |          .0000000 | 40 |         1.0000000 | 06-01-1401 | 800 |          .0000000 |         1.0000000 |    1 |    1
+  1 |          .0000000 | 50 |         1.0000000 | 06-01-1401 | 400 |          .0000000 |         1.0000000 |    0 |    1
+  2 |          .0000000 | 50 |         1.0000000 | 06-01-1401 | 400 |          .0000000 |         1.0000000 |    0 |    1
 (12 rows)
 
 -- VARIANCE() function with ONLY order by having rows based framing clause in combination with other functions --
@@ -2003,20 +2004,20 @@ FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_ola
 WINDOW win1 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc,cf_olap_windowerr_sale.cn asc,cf_olap_windowerr_sale.vn asc rows between unbounded preceding and unbounded following ),
 win2 as (partition by cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.qty order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc),
 win3 as (order by cf_olap_windowerr_sale.vn asc),
-win4 as (partition by cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.cn asc),
+win4 as (partition by cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc),
 win5 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc);
  cn | vn |      to_char      |      to_char      | qty  |      to_char      |      to_char      |      to_char      |      to_char      | pn  
 ----+----+-------------------+-------------------+------+-------------------+-------------------+-------------------+-------------------+-----
+  2 | 40 |        32.7272727 |          .0000000 | 1100 |        12.0000000 |          .8333333 |         1.0000000 |          .0000000 | 100
   1 | 10 |        32.7272727 |          .0000000 |    1 |        12.0000000 |          .0833333 |         1.0000000 |          .0000000 | 200
+  3 | 40 |        32.7272727 |          .0000000 |    1 |        12.0000000 |          .8333333 |         1.0000000 |          .0000000 | 200
   1 | 20 |        32.7272727 |          .0000000 |    1 |        12.0000000 |          .1666667 |         2.0000000 |          .0000000 | 100
   1 | 30 |        32.7272727 |          .0000000 |    1 |        12.0000000 |          .5000000 |         3.0000000 |          .0000000 | 300
-  1 | 30 |        32.7272727 |          .0000000 |   12 |        12.0000000 |          .5000000 |         1.0000000 |          .0000000 | 500
   1 | 50 |        32.7272727 |          .0000000 |    1 |        12.0000000 |         1.0000000 |         4.0000000 |          .0000000 | 400
-  2 | 40 |        32.7272727 |          .0000000 | 1100 |        12.0000000 |          .8333333 |         1.0000000 |          .0000000 | 100
   2 | 50 |        32.7272727 |          .0000000 |    1 |        12.0000000 |         1.0000000 |         1.0000000 |          .0000000 | 400
-  3 | 30 |        32.7272727 |          .0000000 |   12 |        12.0000000 |          .5000000 |         1.0000000 |          .0000000 | 600
-  3 | 30 |        32.7272727 |          .0000000 |   12 |        12.0000000 |          .5000000 |         2.0000000 |          .0000000 | 500
-  3 | 40 |        32.7272727 |          .0000000 |    1 |        12.0000000 |          .8333333 |         1.0000000 |          .0000000 | 200
+  1 | 30 |        32.7272727 |          .0000000 |   12 |        12.0000000 |          .5000000 |         1.0000000 |          .0000000 | 500
+  3 | 30 |        32.7272727 |          .0000000 |   12 |        12.0000000 |          .5000000 |         1.0000000 |          .0000000 | 500
+  3 | 30 |        32.7272727 |          .0000000 |   12 |        12.0000000 |          .5000000 |         2.0000000 |          .0000000 | 600
   4 | 40 |        32.7272727 |          .0000000 |    1 |        12.0000000 |          .8333333 |         1.0000000 |          .0000000 | 700
   4 | 40 |        32.7272727 |          .0000000 |    1 |        12.0000000 |          .8333333 |         2.0000000 |          .0000000 | 800
 (12 rows)
@@ -2059,18 +2060,18 @@ win2 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty,cf_ol
 win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc);
  vn |     dt     | pn  |      to_char      | cn | qty  |      to_char      |      to_char      |      to_char      |      to_char      |      to_char      
 ----+------------+-----+-------------------+----+------+-------------------+-------------------+-------------------+-------------------+-------------------
+ 40 | 01-01-1401 | 100 |          .0000000 |  2 | 1100 |          .0000000 |         1.0000000 |          .0000000 |      1200.0000000 |         1.0000000
  10 | 03-01-1401 | 200 |          .0000000 |  1 |    1 |          .0000000 |         1.0000000 |          .0000000 |          .0000000 |         1.0000000
+ 40 | 04-01-1401 | 200 |          .0000000 |  3 |    1 |          .0000000 |         1.0000000 |          .0000000 |          .0000000 |         1.0000000
  20 | 05-01-1401 | 100 |          .0000000 |  1 |    1 |          .0000000 |         1.0000000 |          .0000000 |          .0000000 |         1.0000000
  30 | 05-02-1401 | 300 |          .0000000 |  1 |    1 |          .0000000 |         1.0000000 |          .0000000 |          .0000000 |         1.0000000
+ 50 | 06-01-1401 | 400 |          .0000000 |  1 |    1 |          .0000000 |         1.0000000 |          .0000000 |          .0000000 |         1.0000000
+ 50 | 06-01-1401 | 400 |          .0000000 |  2 |    1 |          .0000000 |         2.0000000 |          .0000000 |          .0000000 |         2.0000000
  30 | 06-01-1401 | 500 |          .0000000 |  1 |   12 |          .0000000 |         1.0000000 |          .0000000 |          .0000000 |         1.0000000
  30 | 06-01-1401 | 500 |          .0000000 |  3 |   12 |          .0000000 |         2.0000000 |          .0000000 |          .0000000 |         2.0000000
  30 | 06-01-1401 | 600 |          .0000000 |  3 |   12 |          .0000000 |         1.0000000 |          .0000000 |          .0000000 |         1.0000000
- 40 | 01-01-1401 | 100 |          .0000000 |  2 | 1100 |          .0000000 |         1.0000000 |          .0000000 |      1200.0000000 |         1.0000000
- 40 | 04-01-1401 | 200 |          .0000000 |  3 |    1 |          .0000000 |         1.0000000 |          .0000000 |          .0000000 |         1.0000000
  40 | 06-01-1401 | 700 |          .0000000 |  4 |    1 |          .0000000 |         1.0000000 |          .0000000 |          .0000000 |         1.0000000
  40 | 06-01-1401 | 800 |          .0000000 |  4 |    1 |          .0000000 |         1.0000000 |          .0000000 |          .0000000 |         1.0000000
- 50 | 06-01-1401 | 400 |          .0000000 |  1 |    1 |          .0000000 |         1.0000000 |          .0000000 |          .0000000 |         1.0000000
- 50 | 06-01-1401 | 400 |          .0000000 |  2 |    1 |          .0000000 |         2.0000000 |          .0000000 |          .0000000 |         2.0000000
 (12 rows)
 
 -- VARIANCE() function with partition by and order by having range based framing clause in combination with other functions--
@@ -2081,25 +2082,25 @@ WINDOW win1 as (partition by cf_olap_windowerr_sale.pn order by cf_olap_windower
 win2 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc);
  prc  | cn |      to_char      | pn  |      to_char      |     dt     | vn 
 ------+----+-------------------+-----+-------------------+------------+----
-    0 |  1 |          .0000000 | 100 |        20.0000000 | 05-01-1401 | 20
-    0 |  1 |          .0000000 | 200 |        10.0000000 | 03-01-1401 | 10
-    0 |  1 |          .0000000 | 300 |        30.0000000 | 05-02-1401 | 30
+    5 |  3 |          .0000000 | 600 |          .0000000 | 06-01-1401 | 30
+    1 |  4 |          .0000000 | 800 |          .0000000 | 06-01-1401 | 40
     0 |  1 |          .0000000 | 400 |        50.0000000 | 06-01-1401 | 50
     0 |  2 |          .0000000 | 400 |        50.0000000 | 06-01-1401 | 50
+    0 |  1 |          .0000000 | 200 |        10.0000000 | 03-01-1401 | 10
+    0 |  1 |          .0000000 | 300 |        30.0000000 | 05-02-1401 | 30
     0 |  3 |       450.0000000 | 200 |          .0000000 | 04-01-1401 | 40
-    1 |  4 |          .0000000 | 700 |          .0000000 | 06-01-1401 | 40
-    1 |  4 |          .0000000 | 800 |          .0000000 | 06-01-1401 | 40
+    0 |  1 |          .0000000 | 100 |        20.0000000 | 05-01-1401 | 20
     5 |  1 |          .0000000 | 500 |          .0000000 | 06-01-1401 | 30
     5 |  3 |          .0000000 | 500 |          .0000000 | 06-01-1401 | 30
-    5 |  3 |          .0000000 | 600 |          .0000000 | 06-01-1401 | 30
  2400 |  2 |       200.0000000 | 100 |          .0000000 | 01-01-1401 | 40
+    1 |  4 |          .0000000 | 700 |          .0000000 | 06-01-1401 | 40
 (12 rows)
 
 -- VARIANCE() function with partition by and order by having range based framing clause --
 SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.dt, TO_CHAR(COALESCE(VARIANCE(floor(cf_olap_windowerr_sale.pn-cf_olap_windowerr_sale.qty)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.vn desc range floor(cf_olap_windowerr_sale.vn-cf_olap_windowerr_sale.pn) preceding );
-ERROR:  RANGE parameter cannot be negative  (seg0 slice1 rahmaf2-mbp:25432 pid=48130)
+ERROR:  RANGE parameter cannot be negative  (seg0 slice1 127.0.0.1:25432 pid=55689)
 -- VARIANCE() function with partition by and order by having range based framing clause in combination with other functions--
 SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(VARIANCE(floor(cf_olap_windowerr_sale.pn+cf_olap_windowerr_sale.qty)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,
 TO_CHAR(COALESCE(LEAD(cast(floor(cf_olap_windowerr_sale.pn) as int),cast (floor(cf_olap_windowerr_sale.cn) as int),NULL) OVER(win2),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,
@@ -2155,7 +2156,7 @@ win2 as (order by cf_olap_windowerr_sale.cn desc);
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.dt, TO_CHAR(COALESCE(VARIANCE(floor(cf_olap_windowerr_sale.pn/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.vn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product,cf_olap_windowerr_vendor,cf_olap_windowerr_customer WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn AND cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn AND cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc rows between 9 preceding and unbounded following );
-ERROR:  division by zero  (seg1 slice5 rahmaf2-mbp:25433 pid=48131)
+ERROR:  division by zero  (seg0 slice5 127.0.0.1:25432 pid=55689)
 -- VARIANCE() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(VARIANCE(floor(cf_olap_windowerr_sale.vn/cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,
 TO_CHAR(COALESCE(PERCENT_RANK() OVER(win2),0),'99999999.9999999'),
@@ -2165,7 +2166,7 @@ FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_ola
 WINDOW win1 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc rows between current row and floor(cf_olap_windowerr_sale.qty-cf_olap_windowerr_sale.pn) following ),
 win2 as (partition by cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.vn asc),
 win3 as (order by cf_olap_windowerr_sale.pn desc);
-ERROR:  frame ending offset must not be negative  (seg0 slice3 127.0.0.1:40000 pid=16554)
+ERROR:  frame ending offset must not be negative  (seg0 slice2 127.0.0.1:25432 pid=55715)
 -- VARIANCE() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.prc, TO_CHAR(COALESCE(VARIANCE(floor(cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty,
 TO_CHAR(COALESCE(LEAD(cast(floor(cf_olap_windowerr_sale.qty) as int),cast (floor(cf_olap_windowerr_sale.qty-cf_olap_windowerr_sale.prc) as int),NULL) OVER(win2),0),'99999999.9999999'),cf_olap_windowerr_sale.pn,
@@ -2177,21 +2178,21 @@ FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_ola
 WINDOW win1 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc rows between floor(cf_olap_windowerr_sale.cn*cf_olap_windowerr_sale.prc) following and 1 following ),
 win2 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc),
 win3 as (order by cf_olap_windowerr_sale.cn desc),
-win4 as (order by cf_olap_windowerr_sale.pn asc);
+win4 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc);
  prc  |      to_char      | cn | vn | qty  |      to_char      | pn  |      to_char      |      to_char      |      to_char      |      to_char      
 ------+-------------------+----+----+------+-------------------+-----+-------------------+-------------------+-------------------+-------------------
-    0 |          .0000000 |  1 | 10 |    1 |          .0000000 | 200 |         4.0000000 |          .1818182 |          .0000000 |         4.0000000
-    0 |          .0000000 |  1 | 20 |    1 |          .0000000 | 100 |         4.0000000 |          .0000000 |          .0000000 |         1.0000000
+ 2400 |          .0000000 |  2 | 40 | 1100 |          .0000000 | 100 |         3.0000000 |          .0000000 |          .0000000 |         1.0000000
+    0 |          .0000000 |  1 | 10 |    1 |          .0000000 | 200 |         4.0000000 |          .0909091 |          .0000000 |         2.0000000
+    0 |          .0000000 |  3 | 40 |    1 |          .0000000 | 200 |         2.0000000 |          .1818182 |          .0000000 |         3.0000000
+    0 |          .0000000 |  1 | 20 |    1 |          .0000000 | 100 |         4.0000000 |          .2727273 |          .0000000 |         4.0000000
     0 |          .0000000 |  1 | 30 |    1 |          .0000000 | 300 |         4.0000000 |          .3636364 |          .0000000 |         5.0000000
     0 |          .0000000 |  1 | 50 |    1 |          .0000000 | 400 |         4.0000000 |          .4545455 |          .0000000 |         6.0000000
-    0 |          .0000000 |  2 | 50 |    1 |          .0000000 | 400 |         3.0000000 |          .4545455 |          .0000000 |         7.0000000
-    0 |          .0000000 |  3 | 40 |    1 |          .0000000 | 200 |         2.0000000 |          .1818182 |          .0000000 |         3.0000000
+    0 |          .0000000 |  2 | 50 |    1 |          .0000000 | 400 |         3.0000000 |          .5454545 |          .0000000 |         7.0000000
+    5 |          .0000000 |  1 | 30 |   12 |          .0000000 | 500 |         4.0000000 |          .6363636 |          .0000000 |         8.0000000
+    5 |          .0000000 |  3 | 30 |   12 |          .0000000 | 500 |         2.0000000 |          .7272727 |          .0000000 |         9.0000000
+    5 |          .0000000 |  3 | 30 |   12 |          .0000000 | 600 |         2.0000000 |          .8181818 |          .0000000 |        10.0000000
     1 |          .0000000 |  4 | 40 |    1 |         1.0000000 | 700 |         1.0000000 |          .9090909 |          .0000000 |        11.0000000
     1 |          .0000000 |  4 | 40 |    1 |         1.0000000 | 800 |         1.0000000 |         1.0000000 |          .0000000 |        12.0000000
-    5 |          .0000000 |  1 | 30 |   12 |          .0000000 | 500 |         4.0000000 |          .6363636 |          .0000000 |         9.0000000
-    5 |          .0000000 |  3 | 30 |   12 |          .0000000 | 500 |         2.0000000 |          .6363636 |          .0000000 |         8.0000000
-    5 |          .0000000 |  3 | 30 |   12 |          .0000000 | 600 |         2.0000000 |          .8181818 |          .0000000 |        10.0000000
- 2400 |          .0000000 |  2 | 40 | 1100 |          .0000000 | 100 |         3.0000000 |          .0000000 |          .0000000 |         2.0000000
 (12 rows)
 
 -- CORR() function with ONLY order by having range based framing clause in combination with other functions --
@@ -2208,14 +2209,14 @@ win3 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty,cf_ol
 win4 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc);
  cn |     dt     | vn |      to_char      |      to_char      |      to_char      |      to_char      | qty  | pn  |      to_char      |      to_char      
 ----+------------+----+-------------------+-------------------+-------------------+-------------------+------+-----+-------------------+-------------------
+  2 | 01-01-1401 | 40 |          .5544789 |        50.0000000 |         6.0000000 |         1.0000000 | 1100 | 100 |    250000.0000000 |          .0000000
   1 | 03-01-1401 | 10 |          .0000000 |        50.0000000 |         1.0000000 |         1.0000000 |    1 | 200 |    250000.0000000 |         1.0000000
+  3 | 04-01-1401 | 40 |          .2511638 |        50.0000000 |         8.0000000 |         1.0000000 |    1 | 200 |    360000.0000000 |          .0000000
   1 | 05-01-1401 | 20 |          .0000000 |        50.0000000 |         1.0000000 |         1.0000000 |    1 | 100 |    250000.0000000 |          .0000000
   1 | 05-02-1401 | 30 |          .0000000 |        50.0000000 |         1.0000000 |         1.0000000 |    1 | 300 |    250000.0000000 |          .0000000
-  1 | 06-01-1401 | 30 |          .0000000 |        50.0000000 |         1.0000000 |         1.0000000 |   12 | 500 |    250000.0000000 |          .0000000
   1 | 06-01-1401 | 50 |          .0000000 |        50.0000000 |         1.0000000 |         1.0000000 |    1 | 400 |    250000.0000000 |          .0000000
-  2 | 01-01-1401 | 40 |          .5544789 |        50.0000000 |         6.0000000 |         1.0000000 | 1100 | 100 |    250000.0000000 |          .0000000
   2 | 06-01-1401 | 50 |          .5544789 |        50.0000000 |         6.0000000 |         1.0000000 |    1 | 400 |    250000.0000000 |          .0000000
-  3 | 04-01-1401 | 40 |          .2511638 |        50.0000000 |         8.0000000 |         1.0000000 |    1 | 200 |    360000.0000000 |          .0000000
+  1 | 06-01-1401 | 30 |          .0000000 |        50.0000000 |         1.0000000 |         1.0000000 |   12 | 500 |    250000.0000000 |          .0000000
   3 | 06-01-1401 | 30 |          .2511638 |        50.0000000 |         8.0000000 |         1.0000000 |   12 | 500 |    360000.0000000 |          .0000000
   3 | 06-01-1401 | 30 |          .2511638 |        50.0000000 |         8.0000000 |         1.0000000 |   12 | 600 |    360000.0000000 |          .0000000
   4 | 06-01-1401 | 40 |          .3379763 |        50.0000000 |        11.0000000 |         1.0000000 |    1 | 700 |    640000.0000000 |          .0000000
@@ -2236,16 +2237,16 @@ win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc),
 win4 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc);
      dt     | cn | qty  |      to_char      | vn |      to_char      |      to_char      |      to_char      |      to_char      |      to_char      | pn  
 ------------+----+------+-------------------+----+-------------------+-------------------+-------------------+-------------------+-------------------+-----
- 01-01-1401 |  2 | 1100 |          .9999999 | 40 |          .0000000 |          .0833333 |          .0000000 |         6.0000000 |          .0000000 | 100
  03-01-1401 |  1 |    1 |          .9999226 | 10 |        -3.0000000 |          .1666667 |          .0000000 |        12.0000000 |          .0000000 | 200
- 04-01-1401 |  3 |    1 |          .9999999 | 40 |          .0000000 |          .2500000 |          .0000000 |         6.0000000 |          .0000000 | 200
  05-01-1401 |  1 |    1 |          .9999246 | 20 |          .0000000 |          .3333333 |          .0000000 |        11.0000000 |          .0000000 | 100
  05-02-1401 |  1 |    1 |          .9999270 | 30 |          .0000000 |          .4166667 |          .0000000 |        10.0000000 |          .0000000 | 300
- 06-01-1401 |  1 |    1 |          .0000000 | 50 |          .0000000 |          .5000000 |          .0000000 |         2.0000000 |          .0000000 | 400
  06-01-1401 |  1 |   12 |          .9999270 | 30 |          .0000000 |          .6666667 |          .0000000 |        10.0000000 |          .0000000 | 500
+ 06-01-1401 |  1 |    1 |          .0000000 | 50 |          .0000000 |          .5000000 |          .0000000 |         2.0000000 |          .0000000 | 400
+ 01-01-1401 |  2 | 1100 |          .9999999 | 40 |          .0000000 |          .0833333 |          .0000000 |         6.0000000 |          .0000000 | 100
  06-01-1401 |  2 |    1 |          .0000000 | 50 |          .0000000 |          .5833333 |          .0000000 |         2.0000000 |          .0000000 | 400
  06-01-1401 |  3 |   12 |          .9999270 | 30 |          .0000000 |          .7500000 |          .0000000 |        10.0000000 |          .0000000 | 500
  06-01-1401 |  3 |   12 |          .9999270 | 30 |          .0000000 |          .8333333 |          .0000000 |        10.0000000 |          .0000000 | 600
+ 04-01-1401 |  3 |    1 |          .9999999 | 40 |          .0000000 |          .2500000 |          .0000000 |         6.0000000 |          .0000000 | 200
  06-01-1401 |  4 |    1 |          .9999999 | 40 |          .0000000 |          .9166667 |          .0000000 |         6.0000000 |          .0000000 | 700
  06-01-1401 |  4 |    1 |          .9999999 | 40 |          .0000000 |         1.0000000 |          .0000000 |         6.0000000 |          .0000000 | 800
 (12 rows)
@@ -2304,7 +2305,7 @@ WINDOW win1 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn d
 win2 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.pn asc),
 win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc),
 win4 as (order by cf_olap_windowerr_sale.pn desc);
-ERROR:  division by zero
+ERROR:  division by zero  (seg0 slice2 127.0.0.1:25432 pid=55689)
 -- CORR() function with ONLY order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(CORR(floor(cf_olap_windowerr_sale.cn),floor(cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),
 TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.prc*cf_olap_windowerr_sale.prc)) OVER(order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc rows between floor(cf_olap_windowerr_sale.cn-cf_olap_windowerr_sale.vn) preceding and unbounded following ),0),'99999999.9999999')
@@ -2323,38 +2324,38 @@ WINDOW win1 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pr
 win2 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc);
      dt     |     dt     | prc  |     dt     |      to_char      | cn |      to_char      |      to_char      |      to_char      | vn | pn  |      to_char      
 ------------+------------+------+------------+-------------------+----+-------------------+-------------------+-------------------+----+-----+-------------------
- 01-01-1401 | 01-01-1401 | 2400 | 01-01-1401 |          .0000000 |  2 |         1.0000000 |          .0000000 |          .0000000 | 40 | 100 |         1.0000000
- 03-01-1401 | 03-01-1401 |    0 | 03-01-1401 |          .0000000 |  1 |         1.0000000 |          .0000000 |          .0000000 | 10 | 200 |         1.0000000
  04-01-1401 | 04-01-1401 |    0 | 04-01-1401 |          .0000000 |  3 |         1.0000000 |          .0000000 |          .0000000 | 40 | 200 |         1.0000000
- 05-01-1401 | 05-01-1401 |    0 | 05-01-1401 |          .0000000 |  1 |         1.0000000 |          .0000000 |          .0000000 | 20 | 100 |         1.0000000
+ 06-01-1401 | 06-01-1401 |    1 | 06-01-1401 |          .0000000 |  4 |         2.0000000 |          .0000000 |          .0000000 | 40 | 700 |         1.0000000
+ 03-01-1401 | 03-01-1401 |    0 | 03-01-1401 |          .0000000 |  1 |         1.0000000 |          .0000000 |          .0000000 | 10 | 200 |         1.0000000
  05-02-1401 | 05-02-1401 |    0 | 05-02-1401 |          .0000000 |  1 |         1.0000000 |          .0000000 |          .0000000 | 30 | 300 |         1.0000000
  06-01-1401 | 06-01-1401 |    0 | 06-01-1401 |          .0000000 |  1 |         1.0000000 |          .0000000 |          .0000000 | 50 | 400 |         1.0000000
  06-01-1401 | 06-01-1401 |    0 | 06-01-1401 |          .0000000 |  2 |         2.0000000 |         1.0000000 |          .0000000 | 50 | 400 |         2.0000000
- 06-01-1401 | 06-01-1401 |    1 | 06-01-1401 |          .0000000 |  4 |         2.0000000 |          .0000000 |          .0000000 | 40 | 700 |         1.0000000
- 06-01-1401 | 06-01-1401 |    1 | 06-01-1401 |          .0000000 |  4 |         2.0000000 |          .0000000 |          .0000000 | 40 | 800 |         1.0000000
+ 05-01-1401 | 05-01-1401 |    0 | 05-01-1401 |          .0000000 |  1 |         1.0000000 |          .0000000 |          .0000000 | 20 | 100 |         1.0000000
  06-01-1401 | 06-01-1401 |    5 | 06-01-1401 |          .0000000 |  1 |         1.0000000 |          .0000000 |          .0000000 | 30 | 500 |         1.0000000
  06-01-1401 | 06-01-1401 |    5 | 06-01-1401 |          .0000000 |  3 |         3.0000000 |          .5000000 |          .0000000 | 30 | 500 |         2.0000000
  06-01-1401 | 06-01-1401 |    5 | 06-01-1401 |          .0000000 |  3 |         3.0000000 |          .5000000 |          .0000000 | 30 | 600 |         1.0000000
+ 01-01-1401 | 01-01-1401 | 2400 | 01-01-1401 |          .0000000 |  2 |         1.0000000 |          .0000000 |          .0000000 | 40 | 100 |         1.0000000
+ 06-01-1401 | 06-01-1401 |    1 | 06-01-1401 |          .0000000 |  4 |         2.0000000 |          .0000000 |          .0000000 | 40 | 800 |         1.0000000
 (12 rows)
 
 -- CORR() function with partition by and order by having range based framing clause --
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(CORR(floor(cf_olap_windowerr_sale.vn/cf_olap_windowerr_sale.prc),floor(cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.cn asc range between 1 preceding and floor(cf_olap_windowerr_sale.cn/cf_olap_windowerr_sale.prc) following );
-ERROR:  division by zero  (seg0 slice2 rahmaf2-mbp:25432 pid=48130)
+ERROR:  division by zero  (seg0 slice2 127.0.0.1:25432 pid=55689)
 -- CORR() function with partition by and order by having range based framing clause in combination with other functions--
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(CORR(floor(cf_olap_windowerr_sale.prc-cf_olap_windowerr_sale.prc),floor(cf_olap_windowerr_sale.pn-cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn,
 TO_CHAR(COALESCE(COUNT(floor(cf_olap_windowerr_sale.qty/cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),
 TO_CHAR(COALESCE(CUME_DIST() OVER(win2),0),'99999999.9999999'),
 TO_CHAR(COALESCE(LAG(cast(floor(cf_olap_windowerr_sale.qty+cf_olap_windowerr_sale.pn) as int),cast (floor(cf_olap_windowerr_sale.pn) as int),NULL) OVER(win3),0),'99999999.9999999'),
-TO_CHAR(COALESCE(ROW_NUMBER() OVER(partition by cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.pn asc),0),'99999999.9999999'),
+TO_CHAR(COALESCE(ROW_NUMBER() OVER(partition by cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc),0),'99999999.9999999'),
 TO_CHAR(COALESCE(LEAD(cast(floor(cf_olap_windowerr_sale.pn-cf_olap_windowerr_sale.prc) as int),cast (floor(cf_olap_windowerr_sale.qty*cf_olap_windowerr_sale.qty) as int),NULL) OVER(win4),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.dt
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.cn desc range between floor(cf_olap_windowerr_sale.qty-cf_olap_windowerr_sale.prc) preceding and unbounded following ),
 win2 as (partition by cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.pn asc),
 win3 as (partition by cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc),
 win4 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc);
-ERROR:  RANGE parameter cannot be negative  (seg2 slice4 rahmaf2-mbp:25434 pid=48151)
+ERROR:  RANGE parameter cannot be negative  (seg2 slice2 127.0.0.1:25434 pid=55702)
 -- CORR() function with partition by and order by having range based framing clause in combination with other functions--
 SELECT cf_olap_windowerr_sale.prc, TO_CHAR(COALESCE(CORR(floor(cf_olap_windowerr_sale.pn+cf_olap_windowerr_sale.pn),floor(cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,
 TO_CHAR(COALESCE(CUME_DIST() OVER(win2),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn,
@@ -2366,18 +2367,18 @@ win2 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.prc,cf_ol
 win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc);
  prc  |      to_char      |     dt     | vn |      to_char      | cn | qty  | pn  |      to_char      |      to_char      
 ------+-------------------+------------+----+-------------------+----+------+-----+-------------------+-------------------
+ 2400 |          .0000000 | 01-01-1401 | 40 |         1.0000000 |  2 | 1100 | 100 |      3500.0000000 |          .0000000
     0 |          .0000000 | 03-01-1401 | 10 |         1.0000000 |  1 |    1 | 200 |         1.0000000 |          .0000000
     0 |          .0000000 | 04-01-1401 | 40 |         1.0000000 |  3 |    1 | 200 |         1.0000000 |          .0000000
     0 |          .0000000 | 05-01-1401 | 20 |         1.0000000 |  1 |    1 | 100 |         1.0000000 |          .0000000
     0 |          .0000000 | 05-02-1401 | 30 |         1.0000000 |  1 |    1 | 300 |         1.0000000 |          .0000000
     0 |          .0000000 | 06-01-1401 | 50 |         1.0000000 |  1 |    1 | 400 |         1.0000000 |          .0000000
     0 |          .0000000 | 06-01-1401 | 50 |         1.0000000 |  2 |    1 | 400 |         1.0000000 |          .0000000
-    1 |         1.0000000 | 06-01-1401 | 40 |          .5000000 |  4 |    1 | 800 |         2.0000000 |          .0000000
-    1 |         1.0000000 | 06-01-1401 | 40 |         1.0000000 |  4 |    1 | 700 |         2.0000000 |          .0000000
-    5 |         1.0000000 | 06-01-1401 | 30 |          .5000000 |  3 |   12 | 600 |        17.0000000 |          .0000000
     5 |         1.0000000 | 06-01-1401 | 30 |         1.0000000 |  1 |   12 | 500 |        17.0000000 |          .0000000
     5 |         1.0000000 | 06-01-1401 | 30 |         1.0000000 |  3 |   12 | 500 |        17.0000000 |          .0000000
- 2400 |          .0000000 | 01-01-1401 | 40 |         1.0000000 |  2 | 1100 | 100 |      3500.0000000 |          .0000000
+    5 |         1.0000000 | 06-01-1401 | 30 |          .5000000 |  3 |   12 | 600 |        17.0000000 |          .0000000
+    1 |         1.0000000 | 06-01-1401 | 40 |         1.0000000 |  4 |    1 | 700 |         2.0000000 |          .0000000
+    1 |         1.0000000 | 06-01-1401 | 40 |          .5000000 |  4 |    1 | 800 |         2.0000000 |          .0000000
 (12 rows)
 
 -- CORR() function with partition by and order by having range based framing clause in combination with other functions--
@@ -2393,16 +2394,16 @@ win2 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.dt order
 ----+-----+-----+------+-------------------+------------+----+-------------------+------+-------------------+-------------------+-------------------
   3 | 200 | 200 |    1 |          .0000000 | 04-01-1401 | 40 |          .0000000 |    0 |         1.0000000 |         1.0000000 |         1.0000000
   2 | 100 | 100 | 1100 |          .0000000 | 01-01-1401 | 40 |          .0000000 | 2400 |         1.0000000 |         1.0000000 |         1.0000000
-  1 | 200 | 200 |    1 |          .0000000 | 03-01-1401 | 10 |          .0000000 |    0 |         1.0000000 |         1.0000000 |         1.0000000
-  1 | 500 | 500 |   12 |          .0000000 | 06-01-1401 | 30 |          .0000000 |    5 |         1.0000000 |         1.0000000 |         1.0000000
-  3 | 500 | 500 |   12 |          .0000000 | 06-01-1401 | 30 |          .0000000 |    5 |         2.0000000 |         2.0000000 |         2.0000000
-  3 | 600 | 600 |   12 |          .0000000 | 06-01-1401 | 30 |          .0000000 |    5 |         3.0000000 |         3.0000000 |         3.0000000
   1 | 100 | 100 |    1 |          .0000000 | 05-01-1401 | 20 |          .0000000 |    0 |         1.0000000 |         1.0000000 |         1.0000000
   1 | 300 | 300 |    1 |          .0000000 | 05-02-1401 | 30 |          .0000000 |    0 |         1.0000000 |         1.0000000 |         1.0000000
   1 | 400 | 400 |    1 |          .0000000 | 06-01-1401 | 50 |          .0000000 |    0 |         1.0000000 |         1.0000000 |         1.0000000
   2 | 400 | 400 |    1 |          .0000000 | 06-01-1401 | 50 |          .0000000 |    0 |         2.0000000 |         2.0000000 |         2.0000000
   4 | 700 | 700 |    1 |          .0000000 | 06-01-1401 | 40 |       800.0000000 |    1 |         1.0000000 |         1.0000000 |         1.0000000
   4 | 800 | 800 |    1 |          .0000000 | 06-01-1401 | 40 |          .0000000 |    1 |         2.0000000 |         2.0000000 |         2.0000000
+  1 | 200 | 200 |    1 |          .0000000 | 03-01-1401 | 10 |          .0000000 |    0 |         1.0000000 |         1.0000000 |         1.0000000
+  1 | 500 | 500 |   12 |          .0000000 | 06-01-1401 | 30 |          .0000000 |    5 |         1.0000000 |         1.0000000 |         1.0000000
+  3 | 500 | 500 |   12 |          .0000000 | 06-01-1401 | 30 |          .0000000 |    5 |         2.0000000 |         2.0000000 |         2.0000000
+  3 | 600 | 600 |   12 |          .0000000 | 06-01-1401 | 30 |          .0000000 |    5 |         3.0000000 |         3.0000000 |         3.0000000
 (12 rows)
 
 -- CORR() function with partition by and order by having range based framing clause in combination with other functions--
@@ -2417,24 +2418,24 @@ win3 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn,cf_ola
  cn | vn |      to_char      |     dt     |      to_char      | prc  | qty  |      to_char      | pn  |      to_char      
 ----+----+-------------------+------------+-------------------+------+------+-------------------+-----+-------------------
   1 | 10 |          .0000000 | 03-01-1401 |          .0000000 |    0 |    1 |          .0000000 | 200 |         1.0000000
+  3 | 40 |          .0000000 | 04-01-1401 |          .0000000 |    0 |    1 |          .0000000 | 200 |         1.0000000
   1 | 20 |          .0000000 | 05-01-1401 |          .0000000 |    0 |    1 |          .0000000 | 100 |         1.0000000
   1 | 30 |          .0000000 | 05-02-1401 |          .0000000 |    0 |    1 |          .0000000 | 300 |         1.0000000
-  1 | 30 |          .0000000 | 06-01-1401 |          .0000000 |    5 |   12 |          .0000000 | 500 |         1.0000000
-  1 | 50 |          .0000000 | 06-01-1401 |          .0000000 |    0 |    1 |          .0000000 | 400 |         1.0000000
   2 | 40 |          .0000000 | 01-01-1401 |          .0000000 | 2400 | 1100 |          .0000000 | 100 |         1.0000000
+  1 | 50 |          .0000000 | 06-01-1401 |          .0000000 |    0 |    1 |          .0000000 | 400 |         1.0000000
+  1 | 30 |          .0000000 | 06-01-1401 |          .0000000 |    5 |   12 |          .0000000 | 500 |         1.0000000
   2 | 50 |          .0000000 | 06-01-1401 |          .0000000 |    0 |    1 |          .0000000 | 400 |         2.0000000
   3 | 30 |          .0000000 | 06-01-1401 |          .0000000 |    5 |   12 |          .0000000 | 500 |         2.0000000
   3 | 30 |          .0000000 | 06-01-1401 |          .0000000 |    5 |   12 |          .0000000 | 600 |         3.0000000
-  3 | 40 |          .0000000 | 04-01-1401 |          .0000000 |    0 |    1 |          .0000000 | 200 |         1.0000000
-  4 | 40 |          .0000000 | 06-01-1401 |          .0000000 |    1 |    1 |          .0000000 | 800 |         2.0000000
   4 | 40 |          .0000000 | 06-01-1401 |       800.0000000 |    1 |    1 |          .0000000 | 700 |         1.0000000
+  4 | 40 |          .0000000 | 06-01-1401 |          .0000000 |    1 |    1 |          .0000000 | 800 |         2.0000000
 (12 rows)
 
 -- CORR() function with partition by and order by having rows based framing clause --
 SELECT cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(CORR(floor(cf_olap_windowerr_sale.qty),floor(cf_olap_windowerr_sale.qty)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc,cf_olap_windowerr_sale.cn asc,cf_olap_windowerr_sale.vn asc rows between unbounded preceding and floor(cf_olap_windowerr_sale.pn-cf_olap_windowerr_sale.qty) preceding );
-ERROR:  frame ending offset must not be negative  (seg2 slice2 127.0.0.1:40002 pid=16458)
+ERROR:  frame ending offset must not be negative  (seg2 slice2 127.0.0.1:25434 pid=55691)
 -- CORR() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(CORR(floor(cf_olap_windowerr_sale.qty+cf_olap_windowerr_sale.vn),floor(cf_olap_windowerr_sale.cn+cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.pn,
 TO_CHAR(COALESCE(DENSE_RANK() OVER(win2),0),'99999999.9999999'),
@@ -2448,7 +2449,7 @@ win2 as (order by cf_olap_windowerr_sale.vn desc),
 win3 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty order by cf_olap_windowerr_sale.vn desc),
 win4 as (partition by cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.pn desc),
 win5 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.cn desc);
-ERROR:  division by zero  (seg0 slice6 rahmaf2-mbp:25432 pid=48146)
+ERROR:  division by zero  (seg0 slice4 127.0.0.1:25432 pid=55689)
 -- COVAR_POP() function with ONLY order by having range based framing clause --
 SELECT cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(COVAR_POP(floor(cf_olap_windowerr_sale.pn-cf_olap_windowerr_sale.pn),floor(cf_olap_windowerr_sale.vn/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.pn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn AND cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
@@ -2484,25 +2485,25 @@ win2 as (partition by cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.
 win3 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc);
  qty  | qty  | vn |     dt     | cn | qty  |      to_char      | pn  |      to_char      |      to_char      |      to_char      |      to_char      
 ------+------+----+------------+----+------+-------------------+-----+-------------------+-------------------+-------------------+-------------------
+ 1100 | 1100 | 40 | 01-01-1401 |  2 | 1100 |          .0000000 | 100 |          .0000000 |          .0000000 |         1.0000000 |         1.0000000
     1 |    1 | 10 | 03-01-1401 |  1 |    1 |       203.3057851 | 200 |        10.0000000 |          .0000000 |         1.0000000 |         1.0000000
+    1 |    1 | 40 | 04-01-1401 |  3 |    1 |       185.0000000 | 200 |          .0000000 |          .0000000 |         1.0000000 |         1.0000000
     1 |    1 | 20 | 05-01-1401 |  1 |    1 |       153.0864198 | 100 |        20.0000000 |          .0000000 |         1.0000000 |         1.0000000
     1 |    1 | 30 | 05-02-1401 |  1 |    1 |        71.8750000 | 300 |        30.0000000 |          .0000000 |         1.0000000 |         1.0000000
-    1 |    1 | 40 | 04-01-1401 |  3 |    1 |       185.0000000 | 200 |          .0000000 |          .0000000 |         1.0000000 |         1.0000000
-    1 |    1 | 40 | 06-01-1401 |  4 |    1 |          .0000000 | 700 |          .0000000 |          .0000000 |         1.0000000 |         1.0000000
-    1 |    1 | 40 | 06-01-1401 |  4 |    1 |          .0000000 | 800 |          .0000000 |          .0000000 |         1.0000000 |         1.0000000
     1 |    1 | 50 | 06-01-1401 |  1 |    1 |         4.0816327 | 400 |        50.0000000 |          .0000000 |         1.0000000 |         1.0000000
     1 |    1 | 50 | 06-01-1401 |  2 |    1 |       -69.4444444 | 400 |        40.0000000 |          .0000000 |         1.0000000 |         1.0000000
    12 |   12 | 30 | 06-01-1401 |  1 |   12 |          .0000000 | 500 |          .0000000 |          .0000000 |         1.0000000 |         1.0000000
    12 |   12 | 30 | 06-01-1401 |  3 |   12 |          .0000000 | 500 |          .0000000 |          .0000000 |         1.0000000 |         1.0000000
    12 |   12 | 30 | 06-01-1401 |  3 |   12 |          .0000000 | 600 |          .0000000 |          .0000000 |         1.0000000 |         1.0000000
- 1100 | 1100 | 40 | 01-01-1401 |  2 | 1100 |          .0000000 | 100 |          .0000000 |          .0000000 |         1.0000000 |         1.0000000
+    1 |    1 | 40 | 06-01-1401 |  4 |    1 |          .0000000 | 700 |          .0000000 |          .0000000 |         1.0000000 |         1.0000000
+    1 |    1 | 40 | 06-01-1401 |  4 |    1 |          .0000000 | 800 |          .0000000 |          .0000000 |         1.0000000 |         1.0000000
 (12 rows)
 
 -- COVAR_POP() function with partition by and order by having range based framing clause --
 SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(COVAR_POP(floor(cf_olap_windowerr_sale.pn+cf_olap_windowerr_sale.qty),floor(cf_olap_windowerr_sale.pn*cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn AND cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.vn desc range between floor(cf_olap_windowerr_sale.cn-cf_olap_windowerr_sale.pn) preceding and floor(cf_olap_windowerr_sale.vn) preceding );
-ERROR:  RANGE parameter cannot be negative  (seg0 slice3 rahmaf2-mbp:25432 pid=48130)
+ERROR:  RANGE parameter cannot be negative  (seg0 slice3 127.0.0.1:25432 pid=55689)
 -- COVAR_POP() function with partition by and order by having range based framing clause in combination with other functions--
 SELECT cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(COVAR_POP(floor(cf_olap_windowerr_sale.vn),floor(cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999'),
 TO_CHAR(COALESCE(LAG(cast(floor(cf_olap_windowerr_sale.pn) as int),cast (floor(cf_olap_windowerr_sale.qty+cf_olap_windowerr_sale.prc) as int),NULL) OVER(win2),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,
@@ -2521,13 +2522,13 @@ win4 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc);
  04-01-1401 |    1 | 04-01-1401 | 40 | 200 | 40 |          .0000000 |       200.0000000 |  3 |          .0000000 |          .0000000 |         3.0000000
  05-01-1401 |    1 | 05-01-1401 | 20 | 100 | 20 |          .0000000 |       200.0000000 |  1 |          .0000000 |          .0000000 |         4.0000000
  05-02-1401 |    1 | 05-02-1401 | 30 | 300 | 30 |          .0000000 |       100.0000000 |  1 |          .0000000 |          .0000000 |         5.0000000
- 06-01-1401 |    1 | 06-01-1401 | 40 | 700 | 40 |          .0000000 |       500.0000000 |  4 |          .0000000 |          .0000000 |        11.0000000
- 06-01-1401 |    1 | 06-01-1401 | 40 | 800 | 40 |          .0000000 |       600.0000000 |  4 |          .0000000 |          .0000000 |        12.0000000
  06-01-1401 |    1 | 06-01-1401 | 50 | 400 | 50 |          .0000000 |       300.0000000 |  1 |          .0000000 |          .0000000 |         6.0000000
  06-01-1401 |    1 | 06-01-1401 | 50 | 400 | 50 |          .0000000 |       400.0000000 |  2 |          .0000000 |          .0000000 |         7.0000000
  06-01-1401 |   12 | 06-01-1401 | 30 | 500 | 30 |          .0000000 |          .0000000 |  1 |          .0000000 |          .0000000 |         8.0000000
  06-01-1401 |   12 | 06-01-1401 | 30 | 500 | 30 |          .0000000 |          .0000000 |  3 |          .0000000 |          .0000000 |         9.0000000
  06-01-1401 |   12 | 06-01-1401 | 30 | 600 | 30 |          .0000000 |          .0000000 |  3 |          .0000000 |          .0000000 |        10.0000000
+ 06-01-1401 |    1 | 06-01-1401 | 40 | 700 | 40 |          .0000000 |       500.0000000 |  4 |          .0000000 |          .0000000 |        11.0000000
+ 06-01-1401 |    1 | 06-01-1401 | 40 | 800 | 40 |          .0000000 |       600.0000000 |  4 |          .0000000 |          .0000000 |        12.0000000
 (12 rows)
 
 -- COVAR_POP() function with partition by and order by having range based framing clause in combination with other functions--
@@ -2540,7 +2541,7 @@ FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_ola
 WINDOW win1 as (partition by cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.cn desc range between floor(cf_olap_windowerr_sale.qty-cf_olap_windowerr_sale.cn) preceding and unbounded following ),
 win2 as (order by cf_olap_windowerr_sale.vn asc),
 win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc);
-ERROR:  RANGE parameter cannot be negative  (seg0 slice3 rahmaf2-mbp:25432 pid=48130)
+ERROR:  RANGE parameter cannot be negative  (seg0 slice3 127.0.0.1:25432 pid=55689)
 -- COVAR_POP() function with partition by and order by having range based framing clause in combination with other functions--
 SELECT cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(COVAR_POP(floor(cf_olap_windowerr_sale.vn),floor(cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,
 TO_CHAR(COALESCE(LAG(cast(floor(cf_olap_windowerr_sale.cn) as int),cast (floor(cf_olap_windowerr_sale.vn+cf_olap_windowerr_sale.cn) as int),NULL) OVER(win2),0),'99999999.9999999'),cf_olap_windowerr_sale.dt,
@@ -2549,19 +2550,19 @@ TO_CHAR(COALESCE(PERCENT_RANK() OVER(partition by cf_olap_windowerr_sale.dt,cf_o
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn ) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.pn asc range between floor(cf_olap_windowerr_sale.cn-cf_olap_windowerr_sale.prc) following and floor(cf_olap_windowerr_sale.cn+cf_olap_windowerr_sale.prc) following ),
 win2 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc);
-ERROR:  RANGE parameter cannot be negative  (seg0 slice4 rahmaf2-mbp:25432 pid=48130)
+ERROR:  RANGE parameter cannot be negative  (seg0 slice3 127.0.0.1:25432 pid=55715)
 -- COVAR_POP() function with partition by and order by having range based framing clause --
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(COVAR_POP(floor(cf_olap_windowerr_sale.pn),floor(cf_olap_windowerr_sale.qty)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.pn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn ) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.pn asc range between floor(cf_olap_windowerr_sale.vn-cf_olap_windowerr_sale.prc) following and unbounded following );
-ERROR:  RANGE parameter cannot be negative  (seg2 slice3 rahmaf2-mbp:25434 pid=48132)
+ERROR:  RANGE parameter cannot be negative  (seg2 slice3 127.0.0.1:25434 pid=55691)
 -- COVAR_POP() function with partition by and order by having range based framing clause in combination with other functions--
 SELECT cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(COVAR_POP(floor(cf_olap_windowerr_sale.cn),floor(cf_olap_windowerr_sale.vn/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,
 TO_CHAR(COALESCE(LAG(cast(floor(cf_olap_windowerr_sale.cn) as int),cast (floor(cf_olap_windowerr_sale.pn) as int),NULL) OVER(win2),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.pn desc range between floor(cf_olap_windowerr_sale.prc) following and unbounded following ),
 win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc);
-ERROR:  division by zero  (seg0 slice3 rahmaf2-mbp:25432 pid=48130)
+ERROR:  division by zero  (seg0 slice3 127.0.0.1:25432 pid=55689)
 -- COVAR_POP() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(COVAR_POP(floor(cf_olap_windowerr_sale.prc),floor(cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,
 TO_CHAR(COALESCE(LAG(cast(floor(cf_olap_windowerr_sale.vn*cf_olap_windowerr_sale.prc) as int),cast (floor(cf_olap_windowerr_sale.cn-cf_olap_windowerr_sale.prc) as int),NULL) OVER(win2),0),'99999999.9999999'),
@@ -2574,10 +2575,10 @@ win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc),
 win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc);
  pn  | cn |      to_char      |     dt     | vn |      to_char      |      to_char      |      to_char      |      to_char      
 -----+----+-------------------+------------+----+-------------------+-------------------+-------------------+-------------------
- 100 |  1 |          .0000000 | 05-01-1401 | 20 |          .0000000 |       300.0000000 |         4.0000000 |         4.0000000
  100 |  2 |          .0000000 | 01-01-1401 | 40 |          .0000000 |       200.0000000 |         1.0000000 |         1.0000000
  200 |  1 |          .0000000 | 03-01-1401 | 10 |     96000.0000000 |       200.0000000 |         2.0000000 |         2.0000000
  200 |  3 |          .0000000 | 04-01-1401 | 40 |          .0000000 |       400.0000000 |         3.0000000 |         3.0000000
+ 100 |  1 |          .0000000 | 05-01-1401 | 20 |          .0000000 |       300.0000000 |         4.0000000 |         4.0000000
  300 |  1 |          .0000000 | 05-02-1401 | 30 |          .0000000 |       400.0000000 |         5.0000000 |         5.0000000
  400 |  1 |          .0000000 | 06-01-1401 | 50 |          .0000000 |       400.0000000 |         6.0000000 |         6.0000000
  400 |  2 |          .0000000 | 06-01-1401 | 50 |          .0000000 |        41.0000000 |         7.0000000 |         7.0000000
@@ -2592,7 +2593,7 @@ win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc);
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(COVAR_POP(floor(cf_olap_windowerr_sale.cn-cf_olap_windowerr_sale.qty),floor(cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc,cf_olap_windowerr_sale.cn desc,cf_olap_windowerr_sale.cn asc rows between unbounded preceding and floor(cf_olap_windowerr_sale.vn-cf_olap_windowerr_sale.prc) following );
-ERROR:  frame ending offset must not be negative  (seg2 slice2 127.0.0.1:40002 pid=16458)
+ERROR:  frame ending offset must not be negative  (seg2 slice2 127.0.0.1:25434 pid=55691)
 -- COVAR_POP() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(COVAR_POP(floor(cf_olap_windowerr_sale.cn/cf_olap_windowerr_sale.vn),floor(cf_olap_windowerr_sale.qty)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.pn,
 TO_CHAR(COALESCE(CUME_DIST() OVER(win2),0),'99999999.9999999'),
@@ -2606,22 +2607,22 @@ win3 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.prc,cf_ol
  10 |  1 |  1 | 03-01-1401 |    0 |    1 |          .0000000 | 200 |          .8333333 |          .0000000
  20 |  1 |  1 | 05-01-1401 |    0 |    1 |          .0000000 | 100 |         1.0000000 |          .0000000
  30 |  1 |  1 | 05-02-1401 |    0 |    1 |          .0000000 | 300 |          .6666667 |          .0000000
+ 50 |  1 |  1 | 06-01-1401 |    0 |    1 |          .0000000 | 400 |          .5833333 |          .0000000
  30 |  1 |  1 | 06-01-1401 |    5 |   12 |          .0000000 | 500 |          .4166667 |          .0000000
- 30 |  3 |  3 | 06-01-1401 |    5 |   12 |          .0000000 | 500 |          .4166667 |          .0000000
- 30 |  3 |  3 | 06-01-1401 |    5 |   12 |          .0000000 | 600 |          .2500000 |          .0000000
+ 50 |  2 |  2 | 06-01-1401 |    0 |    1 |          .0000000 | 400 |          .5833333 |          .0000000
  40 |  2 |  2 | 01-01-1401 | 2400 | 1100 |          .0000000 | 100 |         1.0000000 |          .0000000
  40 |  3 |  3 | 04-01-1401 |    0 |    1 |          .0000000 | 200 |          .8333333 |          .0000000
+ 30 |  3 |  3 | 06-01-1401 |    5 |   12 |          .0000000 | 500 |          .4166667 |          .0000000
+ 30 |  3 |  3 | 06-01-1401 |    5 |   12 |          .0000000 | 600 |          .2500000 |          .0000000
  40 |  4 |  4 | 06-01-1401 |    1 |    1 |          .0000000 | 700 |          .1666667 |       700.0000000
  40 |  4 |  4 | 06-01-1401 |    1 |    1 |          .0000000 | 800 |          .0833333 |       800.0000000
- 50 |  1 |  1 | 06-01-1401 |    0 |    1 |          .0000000 | 400 |          .5833333 |          .0000000
- 50 |  2 |  2 | 06-01-1401 |    0 |    1 |          .0000000 | 400 |          .5833333 |          .0000000
 (12 rows)
 
 -- COVAR_POP() function with partition by and order by having rows based framing clause --
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn, TO_CHAR(COALESCE(COVAR_POP(floor(cf_olap_windowerr_sale.prc/cf_olap_windowerr_sale.prc),floor(cf_olap_windowerr_sale.pn+cf_olap_windowerr_sale.qty)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc,cf_olap_windowerr_sale.cn desc rows between floor(cf_olap_windowerr_sale.vn) preceding and floor(cf_olap_windowerr_sale.pn) following );
-ERROR:  division by zero  (seg2 slice2 rahmaf2-mbp:25434 pid=48132)
+ERROR:  division by zero  (seg0 slice2 127.0.0.1:25432 pid=55689)
 -- COVAR_POP() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.prc, TO_CHAR(COALESCE(COVAR_POP(floor(cf_olap_windowerr_sale.qty),floor(cf_olap_windowerr_sale.cn*cf_olap_windowerr_sale.qty)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn,
 TO_CHAR(COALESCE(LAG(cast(floor(cf_olap_windowerr_sale.pn) as int),cast (floor(cf_olap_windowerr_sale.prc-cf_olap_windowerr_sale.qty) as int),NULL) OVER(win2),0),'99999999.9999999'),
@@ -2632,16 +2633,16 @@ WINDOW win1 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.dt
 win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc);
  cn | prc  | qty  | prc  |      to_char      |     dt     | pn  |      to_char      |      to_char      |      to_char      
 ----+------+------+------+-------------------+------------+-----+-------------------+-------------------+-------------------
+  2 | 2400 | 1100 | 2400 |          .0000000 | 01-01-1401 | 100 |          .0000000 |          .0000000 |         1.0000000
   1 |    0 |    1 |    0 |          .0000000 | 03-01-1401 | 200 |       200.0000000 |          .0909091 |         2.0000000
+  3 |    0 |    1 |    0 |          .0000000 | 04-01-1401 | 200 |       100.0000000 |          .1818182 |         3.0000000
   1 |    0 |    1 |    0 |          .0000000 | 05-01-1401 | 100 |       300.0000000 |          .2727273 |         4.0000000
   1 |    0 |    1 |    0 |          .0000000 | 05-02-1401 | 300 |       400.0000000 |          .3636364 |         5.0000000
   1 |    0 |    1 |    0 |        68.0204082 | 06-01-1401 | 400 |       400.0000000 |          .4545455 |         6.0000000
-  1 |    5 |   12 |    5 |        63.3600000 | 06-01-1401 | 500 |          .0000000 |          .6363636 |         8.0000000
   2 |    0 |    1 |    0 |        67.8333333 | 06-01-1401 | 400 |       500.0000000 |          .5454545 |         7.0000000
-  2 | 2400 | 1100 | 2400 |          .0000000 | 01-01-1401 | 100 |          .0000000 |          .0000000 |         1.0000000
-  3 |    0 |    1 |    0 |          .0000000 | 04-01-1401 | 200 |       100.0000000 |          .1818182 |         3.0000000
-  3 |    5 |   12 |    5 |        78.2222222 | 06-01-1401 | 600 |          .0000000 |          .8181818 |        10.0000000
+  1 |    5 |   12 |    5 |        63.3600000 | 06-01-1401 | 500 |          .0000000 |          .6363636 |         8.0000000
   3 |    5 |   12 |    5 |        88.0000000 | 06-01-1401 | 500 |          .0000000 |          .7272727 |         9.0000000
+  3 |    5 |   12 |    5 |        78.2222222 | 06-01-1401 | 600 |          .0000000 |          .8181818 |        10.0000000
   4 |    1 |    1 |    1 |          .0000000 | 06-01-1401 | 700 |       700.0000000 |          .9090909 |        11.0000000
   4 |    1 |    1 |    1 |          .0000000 | 06-01-1401 | 800 |       800.0000000 |         1.0000000 |        12.0000000
 (12 rows)
@@ -2682,15 +2683,15 @@ win2 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn,cf_ola
 win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc);
  pn  | prc  |      to_char      | cn |      to_char      |      to_char      |     dt     |      to_char      |      to_char      
 -----+------+-------------------+----+-------------------+-------------------+------------+-------------------+-------------------
- 100 |    0 |       233.3333333 |  1 |          .0000000 |         1.0000000 | 05-01-1401 |         1.0000000 |          .0000000
  100 | 2400 |          .0000000 |  2 |      2400.0000000 |         1.0000000 | 01-01-1401 |         1.0000000 |          .0000000
- 200 |    0 |       300.0000000 |  3 |      2400.0000000 |         1.0000000 | 04-01-1401 |         1.0000000 |          .0000000
  200 |    0 |       450.0000000 |  1 |      2400.0000000 |         1.0000000 | 03-01-1401 |         1.0000000 |         1.0000000
+ 200 |    0 |       300.0000000 |  3 |      2400.0000000 |         1.0000000 | 04-01-1401 |         1.0000000 |          .0000000
+ 100 |    0 |       233.3333333 |  1 |          .0000000 |         1.0000000 | 05-01-1401 |         1.0000000 |          .0000000
  300 |    0 |       100.0000000 |  1 |          .0000000 |         1.0000000 | 05-02-1401 |         1.0000000 |          .0000000
- 400 |    0 |       133.3333333 |  2 |          .0000000 |         1.0000000 | 06-01-1401 |         1.0000000 |          .0000000
  400 |    0 |       233.3333333 |  1 |          .0000000 |         1.0000000 | 06-01-1401 |         1.0000000 |          .0000000
- 500 |    5 |       175.0000000 |  3 |      2400.0000000 |         1.0000000 | 06-01-1401 |         1.0000000 |          .0000000
+ 400 |    0 |       133.3333333 |  2 |          .0000000 |         1.0000000 | 06-01-1401 |         1.0000000 |          .0000000
  500 |    5 |       198.2142857 |  1 |      2400.0000000 |         1.0000000 | 06-01-1401 |         1.0000000 |          .0000000
+ 500 |    5 |       175.0000000 |  3 |      2400.0000000 |         1.0000000 | 06-01-1401 |         1.0000000 |          .0000000
  600 |    5 |       156.6666667 |  3 |      2400.0000000 |         1.0000000 | 06-01-1401 |         1.0000000 |          .0000000
  700 |    1 |        33.3333333 |  4 |         5.0000000 |         1.0000000 | 06-01-1401 |         1.0000000 |          .0000000
  800 |    1 |        33.3333333 |  4 |         5.0000000 |         1.0000000 | 06-01-1401 |         1.0000000 |          .0000000
@@ -2709,17 +2710,17 @@ TO_CHAR(COALESCE(RANK() OVER(win2),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product,cf_olap_windowerr_vendor,cf_olap_windowerr_customer WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn AND cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn AND cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.cn desc range between unbounded preceding and floor(cf_olap_windowerr_sale.prc-cf_olap_windowerr_sale.pn) preceding ),
 win2 as (order by cf_olap_windowerr_sale.cn asc);
-ERROR:  RANGE parameter cannot be negative  (seg0 slice4 rahmaf2-mbp:25432 pid=48130)
+ERROR:  RANGE parameter cannot be negative  (seg0 slice4 127.0.0.1:25432 pid=55689)
 -- COVAR_SAMP() function with partition by and order by having range based framing clause --
 SELECT cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(COVAR_SAMP(floor(cf_olap_windowerr_sale.qty+cf_olap_windowerr_sale.vn),floor(cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn AND cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.cn asc range between unbounded preceding and floor(cf_olap_windowerr_sale.vn-cf_olap_windowerr_sale.prc) following );
-ERROR:  RANGE parameter cannot be negative  (seg0 slice4 rahmaf2-mbp:25432 pid=48130)
+ERROR:  RANGE parameter cannot be negative  (seg0 slice4 127.0.0.1:25432 pid=55689)
 -- COVAR_SAMP() function with partition by and order by having range based framing clause --
 SELECT cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(COVAR_SAMP(floor(cf_olap_windowerr_sale.cn),floor(cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.pn asc range between floor(cf_olap_windowerr_sale.vn-cf_olap_windowerr_sale.pn) preceding and current row );
-ERROR:  RANGE parameter cannot be negative  (seg0 slice2 rahmaf2-mbp:25432 pid=48130)
+ERROR:  RANGE parameter cannot be negative  (seg0 slice2 127.0.0.1:25432 pid=55689)
 -- COVAR_SAMP() function with partition by and order by having range based framing clause in combination with other functions--
 SELECT cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(COVAR_SAMP(floor(cf_olap_windowerr_sale.qty/cf_olap_windowerr_sale.prc),floor(cf_olap_windowerr_sale.pn+cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,
 TO_CHAR(COALESCE(CUME_DIST() OVER(win2),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,
@@ -2732,22 +2733,22 @@ WINDOW win1 as (partition by cf_olap_windowerr_sale.pn order by cf_olap_windower
 win2 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.cn desc),
 win3 as (partition by cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc),
 win4 as (order by cf_olap_windowerr_sale.vn asc);
-ERROR:  division by zero
+ERROR:  division by zero  (seg0 slice3 127.0.0.1:25432 pid=55700)
 -- COVAR_SAMP() function with partition by and order by having range based framing clause --
 SELECT cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(COVAR_SAMP(floor(cf_olap_windowerr_sale.vn+cf_olap_windowerr_sale.vn),floor(cf_olap_windowerr_sale.pn/(cf_olap_windowerr_sale.prc+1))) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn ) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty order by cf_olap_windowerr_sale.vn asc range between floor(cf_olap_windowerr_sale.pn-cf_olap_windowerr_sale.prc) preceding and unbounded following );
-ERROR:  RANGE parameter cannot be negative  (seg2 slice3 rahmaf2-mbp:25434 pid=48132)
+ERROR:  RANGE parameter cannot be negative  (seg2 slice3 127.0.0.1:25434 pid=55691)
 -- COVAR_SAMP() function with partition by and order by having range based framing clause --
 SELECT cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.prc, TO_CHAR(COALESCE(COVAR_SAMP(floor(cf_olap_windowerr_sale.pn),floor(cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.pn desc range between current row and floor(cf_olap_windowerr_sale.prc-cf_olap_windowerr_sale.qty) following );
-ERROR:  RANGE parameter cannot be negative  (seg1 slice2 rahmaf2-mbp:25433 pid=48131)
+ERROR:  RANGE parameter cannot be negative  (seg0 slice2 127.0.0.1:25432 pid=55689)
 -- COVAR_SAMP() function with partition by and order by having range based framing clause --
 SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(COVAR_SAMP(floor(cf_olap_windowerr_sale.qty*cf_olap_windowerr_sale.pn),floor(cf_olap_windowerr_sale.cn-cf_olap_windowerr_sale.qty)) OVER(win1),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product,cf_olap_windowerr_vendor,cf_olap_windowerr_customer WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn AND cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn AND cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.vn asc range between floor(cf_olap_windowerr_sale.cn-cf_olap_windowerr_sale.qty) following and 0 following );
-ERROR:  RANGE parameter cannot be negative  (seg1 slice4 rahmaf2-mbp:25433 pid=48131)
+ERROR:  RANGE parameter cannot be negative  (seg0 slice4 127.0.0.1:25432 pid=55689)
 -- COVAR_SAMP() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.prc, TO_CHAR(COALESCE(COVAR_SAMP(floor(cf_olap_windowerr_sale.prc/cf_olap_windowerr_sale.cn),floor(cf_olap_windowerr_sale.pn-cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn,
 TO_CHAR(COALESCE(ROW_NUMBER() OVER(win2),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,
@@ -2756,8 +2757,8 @@ TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9
 TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.qty-cf_olap_windowerr_sale.vn)) OVER(partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc rows between unbounded preceding and floor(cf_olap_windowerr_sale.pn-cf_olap_windowerr_sale.qty) preceding ),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc rows between unbounded preceding and floor(cf_olap_windowerr_sale.pn-cf_olap_windowerr_sale.qty) preceding ),
-win2 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.vn desc);
-ERROR:  frame ending offset must not be negative  (seg1 slice3 127.0.0.1:40001 pid=16525)
+win2 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc);
+ERROR:  frame ending offset must not be negative  (seg1 slice3 127.0.0.1:25433 pid=55716)
 -- COVAR_SAMP() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.dt, TO_CHAR(COALESCE(COVAR_SAMP(floor(cf_olap_windowerr_sale.prc+cf_olap_windowerr_sale.cn),floor(cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn,
 TO_CHAR(COALESCE(CUME_DIST() OVER(win2),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn,
@@ -2778,18 +2779,18 @@ win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc);
  05-02-1401 | 05-02-1401 |          .0000000 |    1 | 30 |         1.0000000 |  1 | 300 |         1.0000000 |          .0000000 |          .0000000 |         1.0000000
  06-01-1401 | 06-01-1401 |          .0000000 |    1 | 50 |         1.0000000 |  1 | 400 |         1.0000000 |          .0000000 |          .0000000 |         1.0000000
  06-01-1401 | 06-01-1401 |          .0000000 |    1 | 50 |         1.0000000 |  2 | 400 |         1.0000000 |          .0000000 |          .0000000 |         1.0000000
- 06-01-1401 | 06-01-1401 |          .0000000 |   12 | 30 |          .5000000 |  3 | 500 |          .5000000 |         5.0000000 |          .0000000 |          .5000000
  06-01-1401 | 06-01-1401 |          .0000000 |   12 | 30 |         1.0000000 |  1 | 500 |         1.0000000 |         5.0000000 |          .0000000 |         1.0000000
+ 06-01-1401 | 06-01-1401 |          .0000000 |   12 | 30 |          .5000000 |  3 | 500 |          .5000000 |         5.0000000 |          .0000000 |          .5000000
  06-01-1401 | 06-01-1401 |          .0000000 |   12 | 30 |         1.0000000 |  3 | 600 |         1.0000000 |         5.0000000 |          .0000000 |         1.0000000
- 06-01-1401 | 06-01-1401 |          .6666667 |    1 | 40 |         1.0000000 |  4 | 800 |         1.0000000 |          .0000000 |          .0000000 |         1.0000000
  06-01-1401 | 06-01-1401 |         1.0000000 |    1 | 40 |          .5000000 |  4 | 700 |          .5000000 |          .0000000 |          .0000000 |          .5000000
+ 06-01-1401 | 06-01-1401 |          .6666667 |    1 | 40 |         1.0000000 |  4 | 800 |         1.0000000 |          .0000000 |          .0000000 |         1.0000000
 (12 rows)
 
 -- COVAR_SAMP() function with partition by and order by having rows based framing clause --
 SELECT cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(COVAR_SAMP(floor(cf_olap_windowerr_sale.vn/cf_olap_windowerr_sale.cn),floor(cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc,cf_olap_windowerr_sale.pn asc rows between floor(cf_olap_windowerr_sale.vn-cf_olap_windowerr_sale.pn) preceding and 2 preceding );
-ERROR:  frame starting offset must not be negative  (seg0 slice1 127.0.0.1:40000 pid=16456)
+ERROR:  frame starting offset must not be negative  (seg0 slice1 127.0.0.1:25432 pid=55689)
 -- COVAR_SAMP() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.prc, TO_CHAR(COALESCE(COVAR_SAMP(floor(cf_olap_windowerr_sale.vn),floor(cf_olap_windowerr_sale.prc*cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty,
 TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.prc)) OVER(partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.qty order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc rows between floor(cf_olap_windowerr_sale.vn-cf_olap_windowerr_sale.pn) preceding and current row ),0),'99999999.9999999'),
@@ -2800,7 +2801,7 @@ FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_ola
 WINDOW win1 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.qty order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc rows between floor(cf_olap_windowerr_sale.vn-cf_olap_windowerr_sale.pn) preceding and current row ),
 win2 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.qty order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc),
 win3 as (order by cf_olap_windowerr_sale.cn asc);
-ERROR:  frame starting offset must not be negative  (seg0 slice3 127.0.0.1:40000 pid=16524)
+ERROR:  frame starting offset must not be negative  (seg0 slice3 127.0.0.1:25432 pid=55692)
 -- REGR_AVGX() function with ONLY order by having range based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(REGR_AVGX(floor(cf_olap_windowerr_sale.pn/cf_olap_windowerr_sale.prc),floor(cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999'),
 TO_CHAR(COALESCE(RANK() OVER(win2),0),'99999999.9999999'),
@@ -2811,18 +2812,18 @@ WINDOW win1 as (order by cf_olap_windowerr_sale.vn asc range between 3 following
 win2 as (order by cf_olap_windowerr_sale.vn desc);
  vn | pn  | cn | vn |      to_char      |      to_char      |      to_char      |      to_char      
 ----+-----+----+----+-------------------+-------------------+-------------------+-------------------
- 10 | 200 |  1 | 10 |          .0000000 |        12.0000000 |     44000.0000000 |         1.0000000
- 20 | 100 |  1 | 20 |          .0000000 |        11.0000000 |     44000.0000000 |          .9166667
- 30 | 300 |  1 | 30 |          .0000000 |         7.0000000 |     44000.0000000 |          .8333333
- 30 | 500 |  1 | 30 |          .0000000 |         7.0000000 |     44000.0000000 |          .8333333
- 30 | 500 |  3 | 30 |          .0000000 |         7.0000000 |     44000.0000000 |          .8333333
- 30 | 600 |  3 | 30 |          .0000000 |         7.0000000 |     44000.0000000 |          .8333333
- 40 | 100 |  2 | 40 |          .0000000 |         3.0000000 |     44000.0000000 |          .5000000
- 40 | 200 |  3 | 40 |          .0000000 |         3.0000000 |     44000.0000000 |          .5000000
- 40 | 700 |  4 | 40 |          .0000000 |         3.0000000 |     44000.0000000 |          .5000000
- 40 | 800 |  4 | 40 |          .0000000 |         3.0000000 |     44000.0000000 |          .5000000
  50 | 400 |  1 | 50 |          .0000000 |         1.0000000 |        50.0000000 |          .1666667
  50 | 400 |  2 | 50 |          .0000000 |         1.0000000 |        50.0000000 |          .1666667
+ 40 | 800 |  4 | 40 |          .0000000 |         3.0000000 |     44000.0000000 |          .5000000
+ 40 | 200 |  3 | 40 |          .0000000 |         3.0000000 |     44000.0000000 |          .5000000
+ 40 | 700 |  4 | 40 |          .0000000 |         3.0000000 |     44000.0000000 |          .5000000
+ 40 | 100 |  2 | 40 |          .0000000 |         3.0000000 |     44000.0000000 |          .5000000
+ 30 | 500 |  3 | 30 |          .0000000 |         7.0000000 |     44000.0000000 |          .8333333
+ 30 | 300 |  1 | 30 |          .0000000 |         7.0000000 |     44000.0000000 |          .8333333
+ 30 | 500 |  1 | 30 |          .0000000 |         7.0000000 |     44000.0000000 |          .8333333
+ 30 | 600 |  3 | 30 |          .0000000 |         7.0000000 |     44000.0000000 |          .8333333
+ 20 | 100 |  1 | 20 |          .0000000 |        11.0000000 |     44000.0000000 |          .9166667
+ 10 | 200 |  1 | 10 |          .0000000 |        12.0000000 |     44000.0000000 |         1.0000000
 (12 rows)
 
 -- REGR_AVGX() function with ONLY order by having rows based framing clause --
@@ -2843,9 +2844,9 @@ win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc);
  04-01-1401 |  3 |        32.0000000 | 40 | 200 |          .0000000
  05-01-1401 |  1 |        32.0000000 | 20 | 100 |         4.0000000
  05-02-1401 |  1 |        32.0000000 | 30 | 300 |         2.0000000
- 06-01-1401 |  1 |        32.0000000 | 30 | 500 |         5.0000000
  06-01-1401 |  1 |        32.0000000 | 50 | 400 |         2.0000000
  06-01-1401 |  2 |        32.0000000 | 50 | 400 |         2.0000000
+ 06-01-1401 |  1 |        32.0000000 | 30 | 500 |         5.0000000
  06-01-1401 |  3 |        32.0000000 | 30 | 500 |         5.0000000
  06-01-1401 |  3 |        32.0000000 | 30 | 600 |         5.0000000
  06-01-1401 |  4 |        32.0000000 | 40 | 700 |        13.0000000
@@ -2864,17 +2865,17 @@ TO_CHAR(COALESCE(LAG(cast(floor(cf_olap_windowerr_sale.qty) as int),cast (floor(
 TO_CHAR(COALESCE(RANK() OVER(win4),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.pn asc range current row ),
-win2 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.cn desc),
+win2 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc),
 win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc),
 win4 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.cn asc);
-ERROR:  division by zero  (seg2 slice2 rahmaf2-mbp:25434 pid=48215)
+ERROR:  division by zero  (seg0 slice2 127.0.0.1:25432 pid=55700)
 -- REGR_AVGX() function with partition by and order by having range based framing clause in combination with other functions--
 SELECT cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt, TO_CHAR(COALESCE(REGR_AVGX(floor(cf_olap_windowerr_sale.pn/cf_olap_windowerr_sale.prc),floor(cf_olap_windowerr_sale.pn*cf_olap_windowerr_sale.qty)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn,
 TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.cn/cf_olap_windowerr_sale.qty)) OVER(partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty order by cf_olap_windowerr_sale.vn desc range between unbounded preceding and current row ),0),'99999999.9999999'),
 TO_CHAR(COALESCE(COUNT(floor(cf_olap_windowerr_sale.cn)) OVER(partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty order by cf_olap_windowerr_sale.vn desc range between unbounded preceding and current row ),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty order by cf_olap_windowerr_sale.vn desc range between unbounded preceding and current row );
-ERROR:  division by zero  (seg2 slice2 rahmaf2-mbp:25434 pid=48132)
+ERROR:  division by zero  (seg0 slice2 127.0.0.1:25432 pid=55689)
 -- REGR_AVGX() function with partition by and order by having range based framing clause in combination with other functions--
 SELECT cf_olap_windowerr_sale.prc, TO_CHAR(COALESCE(REGR_AVGX(floor(cf_olap_windowerr_sale.cn+cf_olap_windowerr_sale.pn),floor(cf_olap_windowerr_sale.pn/cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn,
 TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.vn/cf_olap_windowerr_sale.prc)) OVER(partition by cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.cn desc range between unbounded preceding and 3 following ),0),'99999999.9999999'),
@@ -2882,7 +2883,7 @@ TO_CHAR(COALESCE(RANK() OVER(win2),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn AND cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.cn desc range between unbounded preceding and 3 following ),
 win2 as (order by cf_olap_windowerr_sale.cn asc);
-ERROR:  division by zero  (seg0 slice3 rahmaf2-mbp:25432 pid=48130)
+ERROR:  division by zero  (seg0 slice3 127.0.0.1:25432 pid=55689)
 -- REGR_AVGX() function with partition by and order by having range based framing clause in combination with other functions--
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.prc, TO_CHAR(COALESCE(REGR_AVGX(floor(cf_olap_windowerr_sale.cn),floor(cf_olap_windowerr_sale.qty)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,
 TO_CHAR(COALESCE(RANK() OVER(win2),0),'99999999.9999999'),
@@ -2896,18 +2897,18 @@ win2 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_ola
 win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc);
  qty  | pn  | cn | prc  |      to_char      |     dt     | vn |      to_char      |      to_char      |      to_char      |      to_char      |      to_char      
 ------+-----+----+------+-------------------+------------+----+-------------------+-------------------+-------------------+-------------------+-------------------
-    1 | 100 |  1 |    0 |          .0000000 | 05-01-1401 | 20 |         1.0000000 |          .0000000 |          .0000000 |         1.0000000 |          .3333333
+ 1100 | 100 |  2 | 2400 |          .0000000 | 01-01-1401 | 40 |         1.0000000 |          .0000000 |          .0000000 |         1.0000000 |          .0833333
     1 | 200 |  1 |    0 |          .0000000 | 03-01-1401 | 10 |         1.0000000 |          .0000000 |          .0000000 |         1.0000000 |          .1666667
     1 | 200 |  3 |    0 |          .0000000 | 04-01-1401 | 40 |         1.0000000 |          .0000000 |          .0000000 |         1.0000000 |          .2500000
+    1 | 100 |  1 |    0 |          .0000000 | 05-01-1401 | 20 |         1.0000000 |          .0000000 |          .0000000 |         1.0000000 |          .3333333
     1 | 300 |  1 |    0 |          .0000000 | 05-02-1401 | 30 |         1.0000000 |          .0000000 |          .0000000 |         1.0000000 |          .4166667
     1 | 400 |  1 |    0 |          .0000000 | 06-01-1401 | 50 |         1.0000000 |          .0000000 |          .0000000 |         1.0000000 |          .5000000
     1 | 400 |  2 |    0 |          .0000000 | 06-01-1401 | 50 |         1.0000000 |          .0000000 |          .0000000 |         1.0000000 |          .5833333
-    1 | 700 |  4 |    1 |          .0000000 | 06-01-1401 | 40 |         1.0000000 |          .0000000 |          .0000000 |         1.0000000 |          .9166667
-    1 | 800 |  4 |    1 |          .0000000 | 06-01-1401 | 40 |         1.0000000 |          .0000000 |          .0000000 |         1.0000000 |         1.0000000
    12 | 500 |  1 |    5 |          .0000000 | 06-01-1401 | 30 |         1.0000000 |          .0000000 |          .0000000 |         1.0000000 |          .6666667
    12 | 500 |  3 |    5 |          .0000000 | 06-01-1401 | 30 |         1.0000000 |          .0000000 |          .0000000 |         1.0000000 |          .7500000
    12 | 600 |  3 |    5 |          .0000000 | 06-01-1401 | 30 |         1.0000000 |          .0000000 |          .0000000 |         1.0000000 |          .8333333
- 1100 | 100 |  2 | 2400 |          .0000000 | 01-01-1401 | 40 |         1.0000000 |          .0000000 |          .0000000 |         1.0000000 |          .0833333
+    1 | 700 |  4 |    1 |          .0000000 | 06-01-1401 | 40 |         1.0000000 |          .0000000 |          .0000000 |         1.0000000 |          .9166667
+    1 | 800 |  4 |    1 |          .0000000 | 06-01-1401 | 40 |         1.0000000 |          .0000000 |          .0000000 |         1.0000000 |         1.0000000
 (12 rows)
 
 -- REGR_AVGX() function with partition by and order by having range based framing clause in combination with other functions--
@@ -2917,7 +2918,7 @@ TO_CHAR(COALESCE(ROW_NUMBER() OVER(win2),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.vn asc range between floor(cf_olap_windowerr_sale.prc-cf_olap_windowerr_sale.pn) following and unbounded following ),
 win2 as (partition by cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc);
-ERROR:  RANGE parameter cannot be negative  (seg0 slice2 rahmaf2-mbp:25432 pid=48143)
+ERROR:  RANGE parameter cannot be negative  (seg0 slice2 127.0.0.1:25432 pid=55700)
 -- REGR_AVGX() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(REGR_AVGX(floor(cf_olap_windowerr_sale.prc+cf_olap_windowerr_sale.cn),floor(cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn,
 TO_CHAR(COALESCE(COUNT(floor(cf_olap_windowerr_sale.prc*cf_olap_windowerr_sale.cn)) OVER(partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc,cf_olap_windowerr_sale.pn asc,cf_olap_windowerr_sale.pn desc rows between unbounded preceding and 1 preceding ),0),'99999999.9999999'),
@@ -2929,18 +2930,18 @@ win2 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn,cf_ola
 win3 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc);
  qty  | vn | vn |      to_char      | cn | pn  |      to_char      |      to_char      |     dt     |      to_char      
 ------+----+----+-------------------+----+-----+-------------------+-------------------+------------+-------------------
+    1 | 40 | 40 |          .0000000 |  3 | 200 |          .0000000 |         1.0000000 | 04-01-1401 |          .0000000
+   12 | 30 | 30 |          .0000000 |  3 | 500 |          .0000000 |         1.0000000 | 06-01-1401 |          .0000000
+   12 | 30 | 30 |         3.0000000 |  3 | 600 |         1.0000000 |         1.0000000 | 06-01-1401 |          .0000000
+    1 | 40 | 40 |          .0000000 |  4 | 700 |          .0000000 |         1.0000000 | 06-01-1401 |       699.0000000
+    1 | 40 | 40 |         4.0000000 |  4 | 800 |         1.0000000 |         1.0000000 | 06-01-1401 |       799.0000000
+ 1100 | 40 | 40 |          .0000000 |  2 | 100 |          .0000000 |         1.0000000 | 01-01-1401 |          .0000000
     1 | 10 | 10 |          .0000000 |  1 | 200 |          .0000000 |         1.0000000 | 03-01-1401 |          .0000000
     1 | 20 | 20 |          .0000000 |  1 | 100 |          .0000000 |         1.0000000 | 05-01-1401 |          .0000000
     1 | 30 | 30 |          .0000000 |  1 | 300 |          .0000000 |         1.0000000 | 05-02-1401 |          .0000000
-    1 | 40 | 40 |          .0000000 |  3 | 200 |          .0000000 |         1.0000000 | 04-01-1401 |          .0000000
-    1 | 40 | 40 |          .0000000 |  4 | 700 |          .0000000 |         1.0000000 | 06-01-1401 |       699.0000000
-    1 | 40 | 40 |         4.0000000 |  4 | 800 |         1.0000000 |         1.0000000 | 06-01-1401 |       799.0000000
+   12 | 30 | 30 |         1.0000000 |  1 | 500 |         1.0000000 |         1.0000000 | 06-01-1401 |          .0000000
     1 | 50 | 50 |          .0000000 |  1 | 400 |          .0000000 |         1.0000000 | 06-01-1401 |          .0000000
     1 | 50 | 50 |          .0000000 |  2 | 400 |          .0000000 |         1.0000000 | 06-01-1401 |          .0000000
-   12 | 30 | 30 |          .0000000 |  3 | 500 |          .0000000 |         1.0000000 | 06-01-1401 |          .0000000
-   12 | 30 | 30 |         1.0000000 |  1 | 500 |         1.0000000 |         1.0000000 | 06-01-1401 |          .0000000
-   12 | 30 | 30 |         3.0000000 |  3 | 600 |         1.0000000 |         1.0000000 | 06-01-1401 |          .0000000
- 1100 | 40 | 40 |          .0000000 |  2 | 100 |          .0000000 |         1.0000000 | 01-01-1401 |          .0000000
 (12 rows)
 
 -- REGR_AVGX() function with partition by and order by having rows based framing clause in combination with other functions --
@@ -2952,7 +2953,7 @@ TO_CHAR(COALESCE(RANK() OVER(partition by cf_olap_windowerr_sale.vn order by cf_
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn AND cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc rows between floor(cf_olap_windowerr_sale.prc-cf_olap_windowerr_sale.vn) preceding and floor(cf_olap_windowerr_sale.pn+cf_olap_windowerr_sale.prc) preceding ),
 win2 as (partition by cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc);
-ERROR:  frame starting offset must not be negative  (seg0 slice3 127.0.0.1:40000 pid=16767)
+ERROR:  frame starting offset must not be negative  (seg0 slice3 127.0.0.1:25432 pid=55715)
 -- REGR_AVGX() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(REGR_AVGX(floor(cf_olap_windowerr_sale.pn-cf_olap_windowerr_sale.prc),floor(cf_olap_windowerr_sale.pn-cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,
 TO_CHAR(COALESCE(COUNT(floor(cf_olap_windowerr_sale.pn/cf_olap_windowerr_sale.pn)) OVER(partition by cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc,cf_olap_windowerr_sale.cn asc rows between floor(cf_olap_windowerr_sale.vn/cf_olap_windowerr_sale.cn) following and 1 following ),0),'99999999.9999999'),
@@ -2961,22 +2962,22 @@ TO_CHAR(COALESCE(DENSE_RANK() OVER(partition by cf_olap_windowerr_sale.dt,cf_ola
 TO_CHAR(COALESCE(LAG(cast(floor(cf_olap_windowerr_sale.vn-cf_olap_windowerr_sale.qty) as int),cast (floor(cf_olap_windowerr_sale.cn-cf_olap_windowerr_sale.qty) as int),NULL) OVER(win3),0),'99999999.9999999'),cf_olap_windowerr_sale.pn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn ) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc,cf_olap_windowerr_sale.cn asc rows between floor(cf_olap_windowerr_sale.vn/cf_olap_windowerr_sale.cn) following and 1 following ),
-win2 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.cn desc),
+win2 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc),
 win3 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc);
  qty  |      to_char      | cn | vn |      to_char      |      to_char      |     dt     |      to_char      |      to_char      | pn  
 ------+-------------------+----+----+-------------------+-------------------+------------+-------------------+-------------------+-----
-    1 |          .0000000 |  1 | 10 |          .0000000 |         1.0000000 | 03-01-1401 |         1.0000000 |         9.0000000 | 200
     1 |          .0000000 |  1 | 20 |          .0000000 |         1.0000000 | 05-01-1401 |         1.0000000 |        19.0000000 | 100
+ 1100 |          .0000000 |  2 | 40 |          .0000000 |         1.0000000 | 01-01-1401 |         1.0000000 |          .0000000 | 100
+    1 |          .0000000 |  1 | 10 |          .0000000 |         1.0000000 | 03-01-1401 |         1.0000000 |         9.0000000 | 200
     1 |          .0000000 |  1 | 30 |          .0000000 |         1.0000000 | 05-02-1401 |         1.0000000 |        29.0000000 | 300
     1 |          .0000000 |  1 | 50 |          .0000000 |         1.0000000 | 06-01-1401 |         1.0000000 |        49.0000000 | 400
     1 |          .0000000 |  2 | 50 |          .0000000 |         1.0000000 | 06-01-1401 |         1.0000000 |        49.0000000 | 400
-    1 |          .0000000 |  3 | 40 |          .0000000 |         1.0000000 | 04-01-1401 |         1.0000000 |          .0000000 | 200
-    1 |          .0000000 |  4 | 40 |          .0000000 |         1.0000000 | 06-01-1401 |         1.0000000 |          .0000000 | 800
-    1 |          .0000000 |  4 | 40 |          .0000000 |         2.0000000 | 06-01-1401 |         1.0000000 |          .0000000 | 700
    12 |          .0000000 |  1 | 30 |          .0000000 |         2.0000000 | 06-01-1401 |         1.0000000 |          .0000000 | 500
    12 |          .0000000 |  3 | 30 |          .0000000 |         1.0000000 | 06-01-1401 |         1.0000000 |          .0000000 | 500
+    1 |          .0000000 |  4 | 40 |          .0000000 |         1.0000000 | 06-01-1401 |         1.0000000 |          .0000000 | 700
+    1 |          .0000000 |  3 | 40 |          .0000000 |         1.0000000 | 04-01-1401 |         1.0000000 |          .0000000 | 200
    12 |          .0000000 |  3 | 30 |          .0000000 |         2.0000000 | 06-01-1401 |         1.0000000 |          .0000000 | 600
- 1100 |          .0000000 |  2 | 40 |          .0000000 |         1.0000000 | 01-01-1401 |         1.0000000 |          .0000000 | 100
+    1 |          .0000000 |  4 | 40 |          .0000000 |         2.0000000 | 06-01-1401 |         1.0000000 |          .0000000 | 800
 (12 rows)
 
 -- REGR_AVGX() function with partition by and order by having rows based framing clause in combination with other functions --
@@ -3016,23 +3017,23 @@ TO_CHAR(COALESCE(ROW_NUMBER() OVER(win2),0),'99999999.9999999'),
 TO_CHAR(COALESCE(RANK() OVER(win4),0),'99999999.9999999'),cf_olap_windowerr_sale.dt
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
 WINDOW win1 as (order by cf_olap_windowerr_sale.pn desc range 4 preceding ),
-win2 as (order by cf_olap_windowerr_sale.vn desc),
+win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc),
 win3 as (partition by cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc),
 win4 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.vn desc);
  vn | qty  | qty  | qty  |      to_char      | pn  |      to_char      |      to_char      | cn |      to_char      |      to_char      |     dt     
 ----+------+------+------+-------------------+-----+-------------------+-------------------+----+-------------------+-------------------+------------
- 10 |    1 |    1 |    1 |       200.0000000 | 200 |         1.0000000 |          .0000000 |  1 |        12.0000000 |         1.0000000 | 03-01-1401
- 20 |    1 |    1 |    1 |       100.0000000 | 100 |          .9090909 |          .0000000 |  1 |        11.0000000 |         1.0000000 | 05-01-1401
- 30 |    1 |    1 |    1 |       300.0000000 | 300 |          .5454545 |          .0000000 |  1 |         8.0000000 |         1.0000000 | 05-02-1401
- 30 |   12 |   12 |   12 |       500.0000000 | 500 |          .5454545 |          .0000000 |  1 |         9.0000000 |         1.0000000 | 06-01-1401
- 30 |   12 |   12 |   12 |       500.0000000 | 500 |          .5454545 |          .0000000 |  3 |         7.0000000 |         1.0000000 | 06-01-1401
- 30 |   12 |   12 |   12 |       600.0000000 | 600 |          .5454545 |          .0000000 |  3 |        10.0000000 |         1.0000000 | 06-01-1401
- 40 |    1 |    1 |    1 |       200.0000000 | 200 |          .1818182 |          .0000000 |  3 |         6.0000000 |         1.0000000 | 04-01-1401
- 40 |    1 |    1 |    1 |       700.0000000 | 700 |          .1818182 |          .0000000 |  4 |         3.0000000 |         1.0000000 | 06-01-1401
- 40 |    1 |    1 |    1 |       800.0000000 | 800 |          .1818182 |          .0000000 |  4 |         4.0000000 |         1.0000000 | 06-01-1401
- 40 | 1100 | 1100 | 1100 |       100.0000000 | 100 |          .1818182 |          .0000000 |  2 |         5.0000000 |         1.0000000 | 01-01-1401
- 50 |    1 |    1 |    1 |       400.0000000 | 400 |          .0000000 |          .0000000 |  1 |         1.0000000 |         1.0000000 | 06-01-1401
- 50 |    1 |    1 |    1 |       400.0000000 | 400 |          .0000000 |          .0000000 |  2 |         2.0000000 |         1.0000000 | 06-01-1401
+ 40 | 1100 | 1100 | 1100 |       100.0000000 | 100 |          .0000000 |          .0000000 |  2 |         1.0000000 |         1.0000000 | 01-01-1401
+ 10 |    1 |    1 |    1 |       200.0000000 | 200 |          .0909091 |          .0000000 |  1 |         2.0000000 |         1.0000000 | 03-01-1401
+ 40 |    1 |    1 |    1 |       200.0000000 | 200 |          .1818182 |          .0000000 |  3 |         3.0000000 |         1.0000000 | 04-01-1401
+ 20 |    1 |    1 |    1 |       100.0000000 | 100 |          .2727273 |          .0000000 |  1 |         4.0000000 |         1.0000000 | 05-01-1401
+ 30 |    1 |    1 |    1 |       300.0000000 | 300 |          .3636364 |          .0000000 |  1 |         5.0000000 |         1.0000000 | 05-02-1401
+ 50 |    1 |    1 |    1 |       400.0000000 | 400 |          .4545455 |          .0000000 |  1 |         6.0000000 |         1.0000000 | 06-01-1401
+ 30 |   12 |   12 |   12 |       500.0000000 | 500 |          .6363636 |          .0000000 |  1 |         8.0000000 |         1.0000000 | 06-01-1401
+ 50 |    1 |    1 |    1 |       400.0000000 | 400 |          .5454545 |          .0000000 |  2 |         7.0000000 |         1.0000000 | 06-01-1401
+ 30 |   12 |   12 |   12 |       500.0000000 | 500 |          .7272727 |          .0000000 |  3 |         9.0000000 |         1.0000000 | 06-01-1401
+ 30 |   12 |   12 |   12 |       600.0000000 | 600 |          .8181818 |          .0000000 |  3 |        10.0000000 |         1.0000000 | 06-01-1401
+ 40 |    1 |    1 |    1 |       700.0000000 | 700 |          .9090909 |          .0000000 |  4 |        11.0000000 |         1.0000000 | 06-01-1401
+ 40 |    1 |    1 |    1 |       800.0000000 | 800 |         1.0000000 |          .0000000 |  4 |        12.0000000 |         1.0000000 | 06-01-1401
 (12 rows)
 
 -- REGR_AVGY() function with ONLY order by having range based framing clause in combination with other functions --
@@ -3061,18 +3062,18 @@ FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_ola
 WINDOW win1 as (order by cf_olap_windowerr_sale.cn asc range between floor(cf_olap_windowerr_sale.prc+cf_olap_windowerr_sale.vn) following and unbounded following );
  prc  |     dt     |      to_char      | cn 
 ------+------------+-------------------+----
-    0 | 03-01-1401 |          .0000000 |  1
-    0 | 04-01-1401 |          .0000000 |  3
+    5 | 06-01-1401 |          .0000000 |  1
     0 | 05-01-1401 |          .0000000 |  1
     0 | 05-02-1401 |          .0000000 |  1
+    0 | 03-01-1401 |          .0000000 |  1
     0 | 06-01-1401 |          .0000000 |  1
     0 | 06-01-1401 |          .0000000 |  2
-    1 | 06-01-1401 |          .0000000 |  4
-    1 | 06-01-1401 |          .0000000 |  4
-    5 | 06-01-1401 |          .0000000 |  1
-    5 | 06-01-1401 |          .0000000 |  3
-    5 | 06-01-1401 |          .0000000 |  3
  2400 | 01-01-1401 |          .0000000 |  2
+    5 | 06-01-1401 |          .0000000 |  3
+    5 | 06-01-1401 |          .0000000 |  3
+    0 | 04-01-1401 |          .0000000 |  3
+    1 | 06-01-1401 |          .0000000 |  4
+    1 | 06-01-1401 |          .0000000 |  4
 (12 rows)
 
 -- REGR_AVGY() function with ONLY order by having rows based framing clause in combination with other functions --
@@ -3086,18 +3087,18 @@ win2 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty,cf_ol
 win3 as (partition by cf_olap_windowerr_sale.qty order by cf_olap_windowerr_sale.pn asc);
  vn |      to_char      | pn  |      to_char      | cn |     dt     | qty  |      to_char      |      to_char      
 ----+-------------------+-----+-------------------+----+------------+------+-------------------+-------------------
- 10 |       550.5000000 | 200 |       200.0000000 |  1 | 03-01-1401 |    1 |       210.0000000 |         2.0000000
  20 |       275.7500000 | 100 |       100.0000000 |  1 | 05-01-1401 |    1 |       240.0000000 |         1.0000000
- 30 |        95.3333333 | 500 |          .0000000 |  1 | 06-01-1401 |   12 |       840.0000000 |         1.0000000
- 30 |        95.3333333 | 500 |          .0000000 |  3 | 06-01-1401 |   12 |       840.0000000 |         1.0000000
- 30 |        95.3333333 | 600 |          .0000000 |  3 | 06-01-1401 |   12 |       840.0000000 |         3.0000000
+ 10 |       550.5000000 | 200 |       200.0000000 |  1 | 03-01-1401 |    1 |       210.0000000 |         2.0000000
+ 40 |       367.3333333 | 200 |          .0000000 |  3 | 04-01-1401 |    1 |       240.0000000 |         2.0000000
  30 |       220.8000000 | 300 |       300.0000000 |  1 | 05-02-1401 |    1 |       330.0000000 |         4.0000000
- 40 |        95.3333333 | 100 |          .0000000 |  2 | 01-01-1401 | 1100 |       840.0000000 |         1.0000000
+ 50 |       184.1666667 | 400 |       400.0000000 |  1 | 06-01-1401 |    1 |       450.0000000 |         5.0000000
+ 50 |       158.0000000 | 400 |          .0000000 |  2 | 06-01-1401 |    1 |       450.0000000 |         5.0000000
  40 |        95.3333333 | 700 |          .0000000 |  4 | 06-01-1401 |    1 |       840.0000000 |         7.0000000
  40 |        95.3333333 | 800 |          .0000000 |  4 | 06-01-1401 |    1 |       840.0000000 |         8.0000000
- 40 |       367.3333333 | 200 |          .0000000 |  3 | 04-01-1401 |    1 |       240.0000000 |         2.0000000
- 50 |       158.0000000 | 400 |          .0000000 |  2 | 06-01-1401 |    1 |       450.0000000 |         5.0000000
- 50 |       184.1666667 | 400 |       400.0000000 |  1 | 06-01-1401 |    1 |       450.0000000 |         5.0000000
+ 30 |        95.3333333 | 500 |          .0000000 |  3 | 06-01-1401 |   12 |       840.0000000 |         1.0000000
+ 30 |        95.3333333 | 500 |          .0000000 |  1 | 06-01-1401 |   12 |       840.0000000 |         1.0000000
+ 30 |        95.3333333 | 600 |          .0000000 |  3 | 06-01-1401 |   12 |       840.0000000 |         3.0000000
+ 40 |        95.3333333 | 100 |          .0000000 |  2 | 01-01-1401 | 1100 |       840.0000000 |         1.0000000
 (12 rows)
 
 -- REGR_AVGY() function with ONLY order by having rows based framing clause in combination with other functions --
@@ -3112,18 +3113,18 @@ win2 as (partition by cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn,cf_ol
 win3 as (partition by cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.pn desc);
  pn  |     dt     |     dt     |      to_char      | cn |      to_char      | vn | qty  |      to_char      |      to_char      |      to_char      
 -----+------------+------------+-------------------+----+-------------------+----+------+-------------------+-------------------+-------------------
- 100 | 01-01-1401 | 01-01-1401 |          .0000000 |  2 |          .0000000 | 40 | 1100 |          .0000000 |          .0000000 |          .0000000
- 100 | 05-01-1401 | 05-01-1401 |          .0000000 |  1 |          .0000000 | 20 |    1 |          .0000000 |          .0000000 |          .0000000
  200 | 03-01-1401 | 03-01-1401 |          .0000000 |  1 |          .0000000 | 10 |    1 |          .0000000 |          .0000000 |          .0000000
  200 | 04-01-1401 | 04-01-1401 |          .0000000 |  3 |          .0000000 | 40 |    1 |          .0000000 |          .0000000 |          .0000000
+ 100 | 05-01-1401 | 05-01-1401 |          .0000000 |  1 |          .0000000 | 20 |    1 |          .0000000 |          .0000000 |          .0000000
  300 | 05-02-1401 | 05-02-1401 |        24.0000000 |  1 |          .0000000 | 30 |    1 |          .0000000 |         1.0000000 |         2.0000000
- 400 | 06-01-1401 | 06-01-1401 |         8.0000000 |  2 |          .0000000 | 50 |    1 |          .0000000 |         3.0000000 |         1.0000000
  400 | 06-01-1401 | 06-01-1401 |        12.0000000 |  1 |          .0000000 | 50 |    1 |          .0000000 |         2.0000000 |         1.0000000
- 500 | 06-01-1401 | 06-01-1401 |         4.8000000 |  3 |          .0000000 | 30 |   12 |          .0000000 |         5.0000000 |         1.0000000
- 500 | 06-01-1401 | 06-01-1401 |         6.0000000 |  1 |          .0000000 | 30 |   12 |          .0000000 |         4.0000000 |         1.0000000
- 600 | 06-01-1401 | 06-01-1401 |         4.0000000 |  3 |          .0000000 | 30 |   12 |          .0000000 |         6.0000000 |         1.0000000
+ 400 | 06-01-1401 | 06-01-1401 |         8.0000000 |  2 |          .0000000 | 50 |    1 |          .0000000 |         3.0000000 |         1.0000000
  700 | 06-01-1401 | 06-01-1401 |         3.4285714 |  4 |          .0000000 | 40 |    1 |          .0000000 |         7.0000000 |         1.0000000
  800 | 06-01-1401 | 06-01-1401 |         3.0000000 |  4 |          .0000000 | 40 |    1 |          .0000000 |         8.0000000 |         1.0000000
+ 500 | 06-01-1401 | 06-01-1401 |         6.0000000 |  1 |          .0000000 | 30 |   12 |          .0000000 |         4.0000000 |         1.0000000
+ 500 | 06-01-1401 | 06-01-1401 |         4.8000000 |  3 |          .0000000 | 30 |   12 |          .0000000 |         5.0000000 |         1.0000000
+ 600 | 06-01-1401 | 06-01-1401 |         4.0000000 |  3 |          .0000000 | 30 |   12 |          .0000000 |         6.0000000 |         1.0000000
+ 100 | 01-01-1401 | 01-01-1401 |          .0000000 |  2 |          .0000000 | 40 | 1100 |          .0000000 |          .0000000 |          .0000000
 (12 rows)
 
 -- REGR_AVGY() function with ONLY order by having rows based framing clause in combination with other functions --
@@ -3152,32 +3153,32 @@ win2 as (partition by cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.
     0 | 10 | 200 | 200 |       601.4166667 |          .0000000
     0 | 20 | 100 | 100 |       601.4166667 |          .0000000
     0 | 30 | 300 | 300 |       601.4166667 |       501.0000000
-    0 | 40 | 200 | 200 |       601.4166667 |       704.0000000
-    0 | 50 | 400 | 400 |       601.4166667 |          .0000000
-    0 | 50 | 400 | 400 |       601.4166667 |       402.0000000
-    1 | 40 | 700 | 700 |       601.4166667 |       704.0000000
-    1 | 40 | 800 | 800 |       601.4166667 |       804.0000000
     5 | 30 | 500 | 500 |       601.4166667 |          .0000000
     5 | 30 | 500 | 500 |       601.4166667 |          .0000000
     5 | 30 | 600 | 600 |       601.4166667 |          .0000000
  2400 | 40 | 100 | 100 |       601.4166667 |          .0000000
+    0 | 40 | 200 | 200 |       601.4166667 |       704.0000000
+    1 | 40 | 700 | 700 |       601.4166667 |       704.0000000
+    1 | 40 | 800 | 800 |       601.4166667 |       804.0000000
+    0 | 50 | 400 | 400 |       601.4166667 |       402.0000000
+    0 | 50 | 400 | 400 |       601.4166667 |          .0000000
 (12 rows)
 
 -- REGR_AVGY() function with partition by and order by having range based framing clause --
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(REGR_AVGY(floor(cf_olap_windowerr_sale.prc),floor(cf_olap_windowerr_sale.vn+cf_olap_windowerr_sale.qty)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn AND cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.cn desc range between floor(cf_olap_windowerr_sale.pn) preceding and floor(cf_olap_windowerr_sale.cn-cf_olap_windowerr_sale.vn) preceding );
-ERROR:  RANGE parameter cannot be negative  (seg1 slice4 rahmaf2-mbp:25433 pid=48131)
+ERROR:  RANGE parameter cannot be negative  (seg0 slice4 127.0.0.1:25432 pid=55689)
 -- REGR_AVGY() function with partition by and order by having range based framing clause --
 SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.prc, TO_CHAR(COALESCE(REGR_AVGY(floor(cf_olap_windowerr_sale.cn/cf_olap_windowerr_sale.prc),floor(cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn ) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.cn asc range between current row and unbounded following );
-ERROR:  division by zero  (seg0 slice2 rahmaf2-mbp:25432 pid=48130)
+ERROR:  division by zero  (seg1 slice2 127.0.0.1:25433 pid=55690)
 -- REGR_AVGY() function with partition by and order by having range based framing clause --
 SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(REGR_AVGY(floor(cf_olap_windowerr_sale.pn),floor(cf_olap_windowerr_sale.prc+cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn AND cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.vn desc range between floor(cf_olap_windowerr_sale.vn) following and floor(cf_olap_windowerr_sale.cn/cf_olap_windowerr_sale.prc) following );
-ERROR:  division by zero  (seg2 slice3 rahmaf2-mbp:25434 pid=48132)
+ERROR:  division by zero  (seg0 slice3 127.0.0.1:25432 pid=55689)
 -- REGR_AVGY() function with partition by and order by having range based framing clause in combination with other functions--
 SELECT cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(REGR_AVGY(floor(cf_olap_windowerr_sale.cn*cf_olap_windowerr_sale.cn),floor(cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.qty,
 TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.vn/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),
@@ -3186,21 +3187,21 @@ TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.prc)) OVER(partition by cf_ola
 TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.pn/cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.cn asc range between 4 following and unbounded following ),
-win2 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.vn asc);
+win2 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc);
  vn |      to_char      | cn |     dt     | qty  |      to_char      |      to_char      | prc  |      to_char      |      to_char      
 ----+-------------------+----+------------+------+-------------------+-------------------+------+-------------------+-------------------
  10 |          .0000000 |  1 | 03-01-1401 |    1 |          .0000000 |         1.0000000 |    0 |          .0000000 |          .0000000
  20 |          .0000000 |  1 | 05-01-1401 |    1 |          .0000000 |         1.0000000 |    0 |          .0000000 |          .0000000
- 30 |          .0000000 |  1 | 05-02-1401 |    1 |          .0000000 |         1.0000000 |    0 |          .0000000 |          .0000000
- 30 |          .0000000 |  1 | 06-01-1401 |   12 |          .0000000 |         1.0000000 |    5 |         5.0000000 |          .0000000
- 30 |          .0000000 |  3 | 06-01-1401 |   12 |          .0000000 |         1.0000000 |    5 |         5.0000000 |          .0000000
- 30 |          .0000000 |  3 | 06-01-1401 |   12 |          .0000000 |         2.0000000 |    5 |         5.0000000 |          .0000000
  40 |          .0000000 |  2 | 01-01-1401 | 1100 |          .0000000 |         1.0000000 | 2400 |      2400.0000000 |          .0000000
  40 |          .0000000 |  3 | 04-01-1401 |    1 |          .0000000 |         1.0000000 |    0 |          .0000000 |          .0000000
  40 |          .0000000 |  4 | 06-01-1401 |    1 |          .0000000 |         1.0000000 |    1 |         1.0000000 |          .0000000
  40 |          .0000000 |  4 | 06-01-1401 |    1 |          .0000000 |         2.0000000 |    1 |         1.0000000 |          .0000000
+ 30 |          .0000000 |  1 | 05-02-1401 |    1 |          .0000000 |         1.0000000 |    0 |          .0000000 |          .0000000
+ 30 |          .0000000 |  1 | 06-01-1401 |   12 |          .0000000 |         1.0000000 |    5 |         5.0000000 |          .0000000
  50 |          .0000000 |  1 | 06-01-1401 |    1 |          .0000000 |         1.0000000 |    0 |          .0000000 |          .0000000
  50 |          .0000000 |  2 | 06-01-1401 |    1 |          .0000000 |         1.0000000 |    0 |          .0000000 |          .0000000
+ 30 |          .0000000 |  3 | 06-01-1401 |   12 |          .0000000 |         1.0000000 |    5 |         5.0000000 |          .0000000
+ 30 |          .0000000 |  3 | 06-01-1401 |   12 |          .0000000 |         2.0000000 |    5 |         5.0000000 |          .0000000
 (12 rows)
 
 -- REGR_AVGY() function with partition by and order by having rows based framing clause in combination with other functions --
@@ -3215,7 +3216,7 @@ WINDOW win1 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.dt
 win2 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc),
 win3 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc),
 win4 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.cn asc);
-ERROR:  division by zero  (seg2 slice7 rahmaf2-mbp:25434 pid=48132)
+ERROR:  division by zero  (seg0 slice3 127.0.0.1:25432 pid=55695)
 -- REGR_AVGY() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(REGR_AVGY(floor(cf_olap_windowerr_sale.pn-cf_olap_windowerr_sale.qty),floor(cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,
 TO_CHAR(COALESCE(LAG(cast(floor(cf_olap_windowerr_sale.cn*cf_olap_windowerr_sale.vn) as int),cast (floor(cf_olap_windowerr_sale.cn) as int),NULL) OVER(win2),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,
@@ -3227,10 +3228,10 @@ win2 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_ola
 win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc);
  pn  | vn |      to_char      | cn |     dt     |      to_char      | prc  |      to_char      |      to_char      
 -----+----+-------------------+----+------------+-------------------+------+-------------------+-------------------
- 100 | 20 |          .0000000 |  1 | 05-01-1401 |          .0000000 |    0 |         1.0000000 |          .0000000
  100 | 40 |          .0000000 |  2 | 01-01-1401 |          .0000000 | 2400 |         1.0000000 |          .0000000
  200 | 10 |          .0000000 |  1 | 03-01-1401 |          .0000000 |    0 |         1.0000000 |         4.0000000
  200 | 40 |          .0000000 |  3 | 04-01-1401 |          .0000000 |    0 |         1.0000000 |          .0000000
+ 100 | 20 |          .0000000 |  1 | 05-01-1401 |          .0000000 |    0 |         1.0000000 |          .0000000
  300 | 30 |          .0000000 |  1 | 05-02-1401 |          .0000000 |    0 |         1.0000000 |          .0000000
  400 | 50 |          .0000000 |  1 | 06-01-1401 |          .0000000 |    0 |         1.0000000 |          .0000000
  400 | 50 |          .0000000 |  2 | 06-01-1401 |          .0000000 |    0 |         1.0000000 |          .0000000
@@ -3245,7 +3246,7 @@ win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc);
 SELECT cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(REGR_AVGY(floor(cf_olap_windowerr_sale.prc),floor(cf_olap_windowerr_sale.vn/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc,cf_olap_windowerr_sale.cn desc rows between unbounded preceding and unbounded following );
-ERROR:  division by zero  (seg1 slice3 rahmaf2-mbp:25433 pid=48131)
+ERROR:  division by zero  (seg1 slice3 127.0.0.1:25433 pid=55690)
 -- REGR_AVGY() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(REGR_AVGY(floor(cf_olap_windowerr_sale.cn+cf_olap_windowerr_sale.qty),floor(cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,
 TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.prc*cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),
@@ -3255,12 +3256,12 @@ FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_ola
 WINDOW win1 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc rows between floor(cf_olap_windowerr_sale.vn-cf_olap_windowerr_sale.qty) preceding and unbounded following ),
 win2 as (order by cf_olap_windowerr_sale.pn desc),
 win3 as (partition by cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.cn desc);
-ERROR:  frame starting offset must not be negative  (seg2 slice2 127.0.0.1:40002 pid=16562)
+ERROR:  frame starting offset must not be negative  (seg2 slice2 127.0.0.1:25434 pid=55691)
 -- REGR_AVGY() function with partition by and order by having rows based framing clause --
 SELECT cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.dt, TO_CHAR(COALESCE(REGR_AVGY(floor(cf_olap_windowerr_sale.pn*cf_olap_windowerr_sale.prc),floor(cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc rows between current row and floor(cf_olap_windowerr_sale.prc-cf_olap_windowerr_sale.cn) following );
-ERROR:  frame ending offset must not be negative  (seg0 slice2 127.0.0.1:40000 pid=16456)
+ERROR:  frame ending offset must not be negative  (seg0 slice2 127.0.0.1:25432 pid=55689)
 -- REGR_COUNT() function with OVER() clause having ONLY PARTITION BY in combination with other window functions --
 SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn, TO_CHAR(COALESCE(REGR_COUNT(floor(cf_olap_windowerr_sale.qty),floor(cf_olap_windowerr_sale.pn+cf_olap_windowerr_sale.qty)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.cn
 ,
@@ -3272,21 +3273,21 @@ FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_ola
 WINDOW win1 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.prc),
 win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc),
 win3 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.cn asc),
-win4 as (order by cf_olap_windowerr_sale.vn asc);
+win4 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc);
  vn | pn  | pn  |      to_char      | prc  | cn |      to_char      |      to_char      |      to_char      |     dt     |      to_char      
 ----+-----+-----+-------------------+------+----+-------------------+-------------------+-------------------+------------+-------------------
- 10 | 200 | 200 |         1.0000000 |    0 |  1 |          .0000000 |          .0909091 |         1.0000000 | 03-01-1401 |         1.0000000
- 20 | 100 | 100 |         1.0000000 |    0 |  1 |          .0000000 |          .2727273 |         1.0000000 | 05-01-1401 |         2.0000000
- 30 | 300 | 300 |         1.0000000 |    0 |  1 |          .0000000 |          .3636364 |         1.0000000 | 05-02-1401 |         3.0000000
- 30 | 500 | 500 |         1.0000000 |    5 |  1 |          .0000000 |          .6363636 |         1.0000000 | 06-01-1401 |         4.0000000
- 30 | 500 | 500 |         2.0000000 |    5 |  3 |          .0000000 |          .7272727 |         1.0000000 | 06-01-1401 |         5.0000000
- 30 | 600 | 600 |         2.0000000 |    5 |  3 |          .0000000 |          .8181818 |         1.0000000 | 06-01-1401 |         6.0000000
- 40 | 100 | 100 |         1.0000000 | 2400 |  2 |          .0000000 |          .0000000 |         1.0000000 | 01-01-1401 |         7.0000000
- 40 | 200 | 200 |         1.0000000 |    0 |  3 |          .0000000 |          .1818182 |         1.0000000 | 04-01-1401 |         8.0000000
- 40 | 700 | 700 |         2.0000000 |    1 |  4 |          .0000000 |          .9090909 |         1.0000000 | 06-01-1401 |         9.0000000
- 40 | 800 | 800 |         2.0000000 |    1 |  4 |          .0000000 |         1.0000000 |         1.0000000 | 06-01-1401 |        10.0000000
- 50 | 400 | 400 |         1.0000000 |    0 |  1 |          .0000000 |          .4545455 |         1.0000000 | 06-01-1401 |        11.0000000
- 50 | 400 | 400 |         1.0000000 |    0 |  2 |          .0000000 |          .5454545 |         1.0000000 | 06-01-1401 |        12.0000000
+ 40 | 100 | 100 |         1.0000000 | 2400 |  2 |          .0000000 |          .0000000 |         1.0000000 | 01-01-1401 |         1.0000000
+ 10 | 200 | 200 |         1.0000000 |    0 |  1 |          .0000000 |          .0909091 |         1.0000000 | 03-01-1401 |         2.0000000
+ 40 | 200 | 200 |         1.0000000 |    0 |  3 |          .0000000 |          .1818182 |         1.0000000 | 04-01-1401 |         3.0000000
+ 20 | 100 | 100 |         1.0000000 |    0 |  1 |          .0000000 |          .2727273 |         1.0000000 | 05-01-1401 |         4.0000000
+ 30 | 300 | 300 |         1.0000000 |    0 |  1 |          .0000000 |          .3636364 |         1.0000000 | 05-02-1401 |         5.0000000
+ 50 | 400 | 400 |         1.0000000 |    0 |  1 |          .0000000 |          .4545455 |         1.0000000 | 06-01-1401 |         6.0000000
+ 50 | 400 | 400 |         1.0000000 |    0 |  2 |          .0000000 |          .5454545 |         1.0000000 | 06-01-1401 |         7.0000000
+ 30 | 500 | 500 |         1.0000000 |    5 |  1 |          .0000000 |          .6363636 |         1.0000000 | 06-01-1401 |         8.0000000
+ 30 | 500 | 500 |         2.0000000 |    5 |  3 |          .0000000 |          .7272727 |         1.0000000 | 06-01-1401 |         9.0000000
+ 30 | 600 | 600 |         2.0000000 |    5 |  3 |          .0000000 |          .8181818 |         1.0000000 | 06-01-1401 |        10.0000000
+ 40 | 700 | 700 |         2.0000000 |    1 |  4 |          .0000000 |          .9090909 |         1.0000000 | 06-01-1401 |        11.0000000
+ 40 | 800 | 800 |         2.0000000 |    1 |  4 |          .0000000 |         1.0000000 |         1.0000000 | 06-01-1401 |        12.0000000
 (12 rows)
 
 -- REGR_COUNT() function with ONLY order by having range based framing clause --
@@ -3304,7 +3305,7 @@ TO_CHAR(COALESCE(RANK() OVER(order by cf_olap_windowerr_sale.cn desc),0),'999999
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn AND cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (order by cf_olap_windowerr_sale.cn asc range current row ),
 win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc),
-win3 as (order by cf_olap_windowerr_sale.cn desc);
+win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc);
 ERROR:  division by zero
 -- REGR_COUNT() function with ONLY order by having range based framing clause --
 SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(REGR_COUNT(floor(cf_olap_windowerr_sale.qty),floor(cf_olap_windowerr_sale.pn/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999')
@@ -3326,14 +3327,14 @@ win2 as (order by cf_olap_windowerr_sale.vn desc),
 win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc);
  cn |     dt     |      to_char      |      to_char      | vn |      to_char      
 ----+------------+-------------------+-------------------+----+-------------------
+  2 | 01-01-1401 |         5.0000000 |         2.0000000 | 40 |          .0000000
   1 | 03-01-1401 |         7.0000000 |         5.0000000 | 10 |          .0000000
+  3 | 04-01-1401 |         2.0000000 |         2.0000000 | 40 |          .0000000
   1 | 05-01-1401 |         7.0000000 |         4.0000000 | 20 |          .0000000
   1 | 05-02-1401 |         7.0000000 |         3.0000000 | 30 |          .0000000
   1 | 06-01-1401 |         7.0000000 |         1.0000000 | 50 |          .0000000
-  1 | 06-01-1401 |         7.0000000 |         3.0000000 | 30 |          .0000000
-  2 | 01-01-1401 |         5.0000000 |         2.0000000 | 40 |          .0000000
   2 | 06-01-1401 |         5.0000000 |         1.0000000 | 50 |          .0000000
-  3 | 04-01-1401 |         2.0000000 |         2.0000000 | 40 |          .0000000
+  1 | 06-01-1401 |         7.0000000 |         3.0000000 | 30 |          .0000000
   3 | 06-01-1401 |         2.0000000 |         3.0000000 | 30 |          .0000000
   3 | 06-01-1401 |         2.0000000 |         3.0000000 | 30 |          .0000000
   4 | 06-01-1401 |          .0000000 |         2.0000000 | 40 |          .0000000
@@ -3373,7 +3374,7 @@ ERROR:  frame ending offset must not be negative
 SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn, TO_CHAR(COALESCE(REGR_COUNT(floor(cf_olap_windowerr_sale.cn/cf_olap_windowerr_sale.prc),floor(cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.vn asc range between unbounded preceding and unbounded following );
-ERROR:  division by zero  (seg0 slice3 rahmaf2-mbp:25432 pid=48130)
+ERROR:  division by zero  (seg0 slice3 127.0.0.1:25432 pid=55689)
 -- REGR_COUNT() function with partition by and order by having range based framing clause in combination with other functions--
 SELECT cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn, TO_CHAR(COALESCE(REGR_COUNT(floor(cf_olap_windowerr_sale.qty+cf_olap_windowerr_sale.cn),floor(cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn,
 TO_CHAR(COALESCE(CUME_DIST() OVER(win2),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,
@@ -3387,18 +3388,18 @@ win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc),
 win4 as (order by cf_olap_windowerr_sale.vn asc);
  pn  | pn  | pn  |      to_char      | prc  | vn |      to_char      | cn |      to_char      |      to_char      |      to_char      
 -----+-----+-----+-------------------+------+----+-------------------+----+-------------------+-------------------+-------------------
- 100 | 100 | 100 |         1.0000000 |    0 | 20 |         1.0000000 |  1 |          .0000000 |         2.0000000 |         2.0000000
- 100 | 100 | 100 |         1.0000000 | 2400 | 40 |         1.0000000 |  2 |          .0000000 |         7.0000000 |        10.0000000
  200 | 200 | 200 |         1.0000000 |    0 | 10 |         1.0000000 |  1 |          .0000000 |         1.0000000 |         1.0000000
- 200 | 200 | 200 |         1.0000000 |    0 | 40 |         1.0000000 |  3 |          .0000000 |         7.0000000 |        10.0000000
+ 100 | 100 | 100 |         1.0000000 |    0 | 20 |         1.0000000 |  1 |          .0000000 |         2.0000000 |         2.0000000
+ 500 | 500 | 500 |         2.0000000 |    5 | 30 |         1.0000000 |  1 |          .0000000 |         3.0000000 |         6.0000000
+ 600 | 600 | 600 |         1.0000000 |    5 | 30 |         1.0000000 |  3 |          .0000000 |         3.0000000 |         6.0000000
  300 | 300 | 300 |         1.0000000 |    0 | 30 |         1.0000000 |  1 |          .0000000 |         3.0000000 |         6.0000000
+ 500 | 500 | 500 |         2.0000000 |    5 | 30 |         1.0000000 |  3 |          .0000000 |         3.0000000 |         6.0000000
+ 200 | 200 | 200 |         1.0000000 |    0 | 40 |         1.0000000 |  3 |          .0000000 |         7.0000000 |        10.0000000
+ 100 | 100 | 100 |         1.0000000 | 2400 | 40 |         1.0000000 |  2 |          .0000000 |         7.0000000 |        10.0000000
+ 800 | 800 | 800 |         1.0000000 |    1 | 40 |         1.0000000 |  4 |          .0000000 |         7.0000000 |        10.0000000
+ 700 | 700 | 700 |         1.0000000 |    1 | 40 |         1.0000000 |  4 |          .0000000 |         7.0000000 |        10.0000000
  400 | 400 | 400 |         2.0000000 |    0 | 50 |         1.0000000 |  1 |          .0000000 |        11.0000000 |        12.0000000
  400 | 400 | 400 |         2.0000000 |    0 | 50 |         1.0000000 |  2 |          .0000000 |        11.0000000 |        12.0000000
- 500 | 500 | 500 |         2.0000000 |    5 | 30 |         1.0000000 |  1 |          .0000000 |         3.0000000 |         6.0000000
- 500 | 500 | 500 |         2.0000000 |    5 | 30 |         1.0000000 |  3 |          .0000000 |         3.0000000 |         6.0000000
- 600 | 600 | 600 |         1.0000000 |    5 | 30 |         1.0000000 |  3 |          .0000000 |         3.0000000 |         6.0000000
- 700 | 700 | 700 |         1.0000000 |    1 | 40 |         1.0000000 |  4 |          .0000000 |         7.0000000 |        10.0000000
- 800 | 800 | 800 |         1.0000000 |    1 | 40 |         1.0000000 |  4 |          .0000000 |         7.0000000 |        10.0000000
 (12 rows)
 
 -- REGR_COUNT() function with partition by and order by having range based framing clause --
@@ -3407,18 +3408,18 @@ FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_ola
 WINDOW win1 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.vn asc range between 3 following and unbounded following );
  pn  | cn |      to_char      | prc  |     dt     | vn 
 -----+----+-------------------+------+------------+----
- 100 |  1 |          .0000000 |    0 | 05-01-1401 | 20
- 100 |  2 |          .0000000 | 2400 | 01-01-1401 | 40
  200 |  1 |          .0000000 |    0 | 03-01-1401 | 10
- 200 |  3 |          .0000000 |    0 | 04-01-1401 | 40
  300 |  1 |          .0000000 |    0 | 05-02-1401 | 30
- 400 |  1 |          .0000000 |    0 | 06-01-1401 | 50
  400 |  2 |          .0000000 |    0 | 06-01-1401 | 50
- 500 |  1 |          .0000000 |    5 | 06-01-1401 | 30
- 500 |  3 |          .0000000 |    5 | 06-01-1401 | 30
+ 400 |  1 |          .0000000 |    0 | 06-01-1401 | 50
  600 |  3 |          .0000000 |    5 | 06-01-1401 | 30
- 700 |  4 |          .0000000 |    1 | 06-01-1401 | 40
+ 500 |  3 |          .0000000 |    5 | 06-01-1401 | 30
+ 500 |  1 |          .0000000 |    5 | 06-01-1401 | 30
+ 200 |  3 |          .0000000 |    0 | 04-01-1401 | 40
+ 100 |  1 |          .0000000 |    0 | 05-01-1401 | 20
  800 |  4 |          .0000000 |    1 | 06-01-1401 | 40
+ 700 |  4 |          .0000000 |    1 | 06-01-1401 | 40
+ 100 |  2 |          .0000000 | 2400 | 01-01-1401 | 40
 (12 rows)
 
 -- REGR_COUNT() function with partition by and order by having rows based framing clause in combination with other functions --
@@ -3438,22 +3439,22 @@ win5 as (partition by cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.
  10 |    0 | 10 |         1.0000000 |  1 |    1 | 200 |          .0000000 | 03-01-1401 |         1.0000000 |         1.0000000 |          .0000000
  20 |    0 | 20 |         1.0000000 |  1 |    1 | 100 |          .0000000 | 05-01-1401 |          .9166667 |         1.0000000 |          .0000000
  30 |    0 | 30 |         1.0000000 |  1 |    1 | 300 |          .0000000 | 05-02-1401 |          .8333333 |         1.0000000 |          .0000000
+ 50 |    0 | 50 |         1.0000000 |  1 |    1 | 400 |          .0000000 | 06-01-1401 |          .1666667 |         1.0000000 |          .0000000
  30 |    5 | 30 |         1.0000000 |  1 |   12 | 500 |          .0000000 | 06-01-1401 |          .8333333 |         1.0000000 |          .0000000
+ 40 | 2400 | 40 |         1.0000000 |  2 | 1100 | 100 |          .0000000 | 01-01-1401 |          .5000000 |          .5000000 |          .0000000
+ 50 |    0 | 50 |         1.0000000 |  2 |    1 | 400 |          .0000000 | 06-01-1401 |          .1666667 |          .5000000 |          .0000000
+ 40 |    0 | 40 |         1.0000000 |  3 |    1 | 200 |          .0000000 | 04-01-1401 |          .5000000 |          .5000000 |          .0000000
  30 |    5 | 30 |         1.0000000 |  3 |   12 | 500 |          .0000000 | 06-01-1401 |          .8333333 |          .5000000 |          .0000000
  30 |    5 | 30 |         1.0000000 |  3 |   12 | 600 |          .0000000 | 06-01-1401 |          .8333333 |         1.0000000 |          .0000000
- 40 |    0 | 40 |         1.0000000 |  3 |    1 | 200 |          .0000000 | 04-01-1401 |          .5000000 |          .5000000 |          .0000000
  40 |    1 | 40 |         1.0000000 |  4 |    1 | 700 |          .0000000 | 06-01-1401 |          .5000000 |         1.0000000 |          .0000000
  40 |    1 | 40 |         1.0000000 |  4 |    1 | 800 |          .0000000 | 06-01-1401 |          .5000000 |         1.0000000 |          .0000000
- 40 | 2400 | 40 |         1.0000000 |  2 | 1100 | 100 |          .0000000 | 01-01-1401 |          .5000000 |          .5000000 |          .0000000
- 50 |    0 | 50 |         1.0000000 |  1 |    1 | 400 |          .0000000 | 06-01-1401 |          .1666667 |         1.0000000 |          .0000000
- 50 |    0 | 50 |         1.0000000 |  2 |    1 | 400 |          .0000000 | 06-01-1401 |          .1666667 |          .5000000 |          .0000000
 (12 rows)
 
 -- REGR_COUNT() function with partition by and order by having rows based framing clause --
 SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.dt, TO_CHAR(COALESCE(REGR_COUNT(floor(cf_olap_windowerr_sale.pn-cf_olap_windowerr_sale.qty),floor(cf_olap_windowerr_sale.qty)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc rows between unbounded preceding and floor(cf_olap_windowerr_sale.qty/cf_olap_windowerr_sale.prc) following );
-ERROR:  division by zero  (seg0 slice3 rahmaf2-mbp:25432 pid=48130)
+ERROR:  division by zero  (seg0 slice3 127.0.0.1:25432 pid=55689)
 -- REGR_COUNT() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt, TO_CHAR(COALESCE(REGR_COUNT(floor(cf_olap_windowerr_sale.prc),floor(cf_olap_windowerr_sale.qty)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,
 TO_CHAR(COALESCE(LAG(cast(floor(cf_olap_windowerr_sale.qty/cf_olap_windowerr_sale.prc) as int),cast (floor(cf_olap_windowerr_sale.cn+cf_olap_windowerr_sale.qty) as int),NULL) OVER(win2),0),'99999999.9999999'),cf_olap_windowerr_sale.vn,
@@ -3471,7 +3472,7 @@ ERROR:  division by zero
 SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn, TO_CHAR(COALESCE(REGR_COUNT(floor(cf_olap_windowerr_sale.pn/cf_olap_windowerr_sale.cn),floor(cf_olap_windowerr_sale.vn/cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product,cf_olap_windowerr_vendor,cf_olap_windowerr_customer WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn AND cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn AND cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc rows between floor(cf_olap_windowerr_sale.qty-cf_olap_windowerr_sale.cn) preceding and floor(cf_olap_windowerr_sale.vn) preceding );
-ERROR:  frame starting offset must not be negative  (seg0 slice5 127.0.0.1:40000 pid=16456)
+ERROR:  frame starting offset must not be negative  (seg0 slice4 127.0.0.1:25432 pid=55689)
 -- REGR_COUNT() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(REGR_COUNT(floor(cf_olap_windowerr_sale.qty),floor(cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,
 TO_CHAR(COALESCE(LEAD(cast(floor(cf_olap_windowerr_sale.pn+cf_olap_windowerr_sale.prc) as int),cast (floor(cf_olap_windowerr_sale.cn-cf_olap_windowerr_sale.qty) as int),NULL) OVER(win2),0),'99999999.9999999'),
@@ -3538,22 +3539,22 @@ TO_CHAR(COALESCE(RANK() OVER(win4),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc rows floor(cf_olap_windowerr_sale.qty) preceding ),
 win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc),
-win3 as (partition by cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.pn desc),
+win3 as (partition by cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc),
 win4 as (partition by cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.vn desc);
  cn | qty  | pn  | qty  |      to_char      |      to_char      | vn |      to_char      |      to_char      |     dt     |      to_char      
 ----+------+-----+------+-------------------+-------------------+----+-------------------+-------------------+------------+-------------------
+  1 |    1 | 400 |    1 |          .0000000 |          .0000000 | 50 |         6.0000000 |         1.0000000 | 06-01-1401 |         1.0000000
+  1 |    1 | 300 |    1 |          .0000000 |          .0000000 | 30 |         5.0000000 |         1.0000000 | 05-02-1401 |         2.0000000
+  1 |   12 | 500 |   12 |        32.8312069 |          .0000000 | 30 |         8.0000000 |         3.0000000 | 06-01-1401 |         2.0000000
   1 |    1 | 100 |    1 |          .0000000 |          .0000000 | 20 |         4.0000000 |         1.0000000 | 05-01-1401 |         4.0000000
   1 |    1 | 200 |    1 |         9.9454545 |          .0000000 | 10 |         2.0000000 |         1.0000000 | 03-01-1401 |         5.0000000
-  1 |    1 | 300 |    1 |          .0000000 |          .0000000 | 30 |         5.0000000 |         1.0000000 | 05-02-1401 |         2.0000000
-  1 |    1 | 400 |    1 |          .0000000 |          .0000000 | 50 |         6.0000000 |         7.0000000 | 06-01-1401 |         1.0000000
-  1 |   12 | 500 |   12 |        32.8312069 |          .0000000 | 30 |         8.0000000 |         5.0000000 | 06-01-1401 |         2.0000000
-  2 |    1 | 400 |    1 |        50.0000000 |          .0000000 | 50 |         7.0000000 |         6.0000000 | 06-01-1401 |         1.0000000
+  2 |    1 | 400 |    1 |        50.0000000 |          .0000000 | 50 |         7.0000000 |         2.0000000 | 06-01-1401 |         1.0000000
   2 | 1100 | 100 | 1100 |          .0000000 |          .0000000 | 40 |         1.0000000 |         1.0000000 | 01-01-1401 |         2.0000000
   3 |    1 | 200 |    1 |       -20.0000000 |          .0000000 | 40 |         3.0000000 |         1.0000000 | 04-01-1401 |         1.0000000
+  3 |   12 | 600 |   12 |        32.1819373 |          .0000000 | 30 |        10.0000000 |         5.0000000 | 06-01-1401 |         2.0000000
   3 |   12 | 500 |   12 |        32.4666777 |          .0000000 | 30 |         9.0000000 |         4.0000000 | 06-01-1401 |         2.0000000
-  3 |   12 | 600 |   12 |        32.1819373 |          .0000000 | 30 |        10.0000000 |         3.0000000 | 06-01-1401 |         2.0000000
-  4 |    1 | 700 |    1 |        45.0000000 |          .0000000 | 40 |        11.0000000 |         2.0000000 | 06-01-1401 |         1.0000000
-  4 |    1 | 800 |    1 |          .0000000 |          .0000000 | 40 |        12.0000000 |         1.0000000 | 06-01-1401 |         1.0000000
+  4 |    1 | 700 |    1 |        45.0000000 |          .0000000 | 40 |        11.0000000 |         6.0000000 | 06-01-1401 |         1.0000000
+  4 |    1 | 800 |    1 |          .0000000 |          .0000000 | 40 |        12.0000000 |         7.0000000 | 06-01-1401 |         1.0000000
 (12 rows)
 
 -- REGR_INTERCEPT() function with ONLY order by having rows based framing clause --
@@ -3575,18 +3576,18 @@ win3 as (order by cf_olap_windowerr_sale.cn desc),
 win4 as (partition by cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc);
  prc  |      to_char      | cn |      to_char      | vn |      to_char      |      to_char      |      to_char      |      to_char      |     dt     
 ------+-------------------+----+-------------------+----+-------------------+-------------------+-------------------+-------------------+------------
+ 2400 |          .0000000 |  2 |          .0000000 | 40 |         1.0000000 |         1.0000000 |         6.0000000 |          .0000000 | 01-01-1401
     0 |          .0000000 |  1 |          .0000000 | 10 |         2.0000000 |         2.0000000 |         8.0000000 |          .0000000 | 03-01-1401
+    0 |          .0000000 |  3 |          .0000000 | 40 |         3.0000000 |         3.0000000 |         3.0000000 |          .0000000 | 04-01-1401
     0 |          .0000000 |  1 |          .0000000 | 20 |         4.0000000 |         4.0000000 |         8.0000000 |          .0000000 | 05-01-1401
     0 |          .0000000 |  1 |          .0000000 | 30 |         5.0000000 |         5.0000000 |         8.0000000 |          .0000000 | 05-02-1401
     0 |          .0000000 |  1 |          .0000000 | 50 |         6.0000000 |         6.0000000 |         8.0000000 |          .0000000 | 06-01-1401
     0 |          .0000000 |  2 |          .0000000 | 50 |         7.0000000 |         7.0000000 |         6.0000000 |          .0000000 | 06-01-1401
-    0 |          .0000000 |  3 |          .0000000 | 40 |         3.0000000 |         3.0000000 |         3.0000000 |          .0000000 | 04-01-1401
-    1 |          .0000000 |  4 |          .0000000 | 40 |        11.0000000 |        11.0000000 |         1.0000000 |       150.0000000 | 06-01-1401
-    1 |          .0000000 |  4 |          .0000000 | 40 |        12.0000000 |        12.0000000 |         1.0000000 |        40.0000000 | 06-01-1401
     5 |          .0000000 |  1 |          .0000000 | 30 |         8.0000000 |         8.0000000 |         8.0000000 |          .0000000 | 06-01-1401
     5 |          .0000000 |  3 |          .0000000 | 30 |         9.0000000 |         9.0000000 |         3.0000000 |          .0000000 | 06-01-1401
     5 |          .0000000 |  3 |          .0000000 | 30 |        10.0000000 |        10.0000000 |         3.0000000 |          .0000000 | 06-01-1401
- 2400 |          .0000000 |  2 |          .0000000 | 40 |         1.0000000 |         1.0000000 |         6.0000000 |          .0000000 | 01-01-1401
+    1 |          .0000000 |  4 |          .0000000 | 40 |        11.0000000 |        11.0000000 |         1.0000000 |       150.0000000 | 06-01-1401
+    1 |          .0000000 |  4 |          .0000000 | 40 |        12.0000000 |        12.0000000 |         1.0000000 |        40.0000000 | 06-01-1401
 (12 rows)
 
 -- REGR_INTERCEPT() function with ONLY order by having rows based framing clause in combination with other functions --
@@ -3610,7 +3611,7 @@ FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_ol
 WINDOW win1 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc rows between floor(cf_olap_windowerr_sale.prc) preceding and floor(cf_olap_windowerr_sale.vn-cf_olap_windowerr_sale.qty) preceding ),
 win2 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc),
 win3 as (order by cf_olap_windowerr_sale.vn desc);
-ERROR:  frame ending offset must not be negative  (seg1 slice2 127.0.0.1:40001 pid=16674)
+ERROR:  frame ending offset must not be negative
 -- REGR_INTERCEPT() function with ONLY order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(REGR_INTERCEPT(floor(cf_olap_windowerr_sale.vn+cf_olap_windowerr_sale.cn),floor(cf_olap_windowerr_sale.prc-cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999'),
 TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.pn+cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),
@@ -3623,18 +3624,18 @@ win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc),
 win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc);
  vn | vn | vn | cn |      to_char      |      to_char      |      to_char      |      to_char      |      to_char      
 ----+----+----+----+-------------------+-------------------+-------------------+-------------------+-------------------
+ 40 | 40 | 40 |  2 |          .0000000 |       102.0000000 |          .0000000 |          .0000000 |         2.0000000
  10 | 10 | 10 |  1 |        11.1308017 |       201.0000000 |      -799.0000000 |          .0000000 |         2.0000000
+ 40 | 40 | 40 |  3 |          .3333333 |       203.0000000 |          .0000000 |          .0000000 |         3.0000000
  20 | 20 | 20 |  1 |        -1.0000000 |       203.0000000 |          .0000000 |          .0000000 |         3.0000000
  30 | 30 | 30 |  1 |         1.0000000 |       301.0000000 |          .0000000 |          .0000000 |         3.0000000
+ 50 | 50 | 50 |  1 |         1.0000000 |       401.0000000 |          .0000000 |          .0000000 |         3.0000000
+ 50 | 50 | 50 |  2 |          .0000000 |       402.0000000 |          .0000000 |          .0000000 |         3.0000000
  30 | 30 | 30 |  1 |        10.0000000 |       501.0000000 |          .0000000 |          .0000000 |         3.0000000
  30 | 30 | 30 |  3 |          .0000000 |       503.0000000 |          .0000000 |          .0000000 |         3.0000000
  30 | 30 | 30 |  3 |          .0000000 |       603.0000000 |          .0000000 |          .0000000 |         3.0000000
- 40 | 40 | 40 |  2 |          .0000000 |       102.0000000 |          .0000000 |          .0000000 |         2.0000000
- 40 | 40 | 40 |  3 |          .3333333 |       203.0000000 |          .0000000 |          .0000000 |         3.0000000
- 40 | 40 | 40 |  4 |          .0000000 |       804.0000000 |          .0000000 |          .0000000 |         4.0000000
  40 | 40 | 40 |  4 |        13.3571429 |       704.0000000 |          .0000000 |          .0000000 |         4.0000000
- 50 | 50 | 50 |  1 |         1.0000000 |       401.0000000 |          .0000000 |          .0000000 |         3.0000000
- 50 | 50 | 50 |  2 |          .0000000 |       402.0000000 |          .0000000 |          .0000000 |         3.0000000
+ 40 | 40 | 40 |  4 |          .0000000 |       804.0000000 |          .0000000 |          .0000000 |         4.0000000
 (12 rows)
 
 -- REGR_INTERCEPT() function with ONLY order by having rows based framing clause in combination with other functions --
@@ -3643,7 +3644,7 @@ TO_CHAR(COALESCE(PERCENT_RANK() OVER(win2),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
 WINDOW win1 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc rows between floor(cf_olap_windowerr_sale.prc/cf_olap_windowerr_sale.prc) preceding and unbounded following ),
 win2 as (partition by cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.pn desc);
-ERROR:  division by zero
+ERROR:  division by zero  (seg0 slice2 127.0.0.1:25432 pid=55689)
 -- REGR_INTERCEPT() function with ONLY order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(REGR_INTERCEPT(floor(cf_olap_windowerr_sale.prc+cf_olap_windowerr_sale.pn),floor(cf_olap_windowerr_sale.pn/cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.vn,
 TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.vn*cf_olap_windowerr_sale.qty)) OVER(win1),0),'99999999.9999999'),
@@ -3664,7 +3665,7 @@ FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_ol
 WINDOW win1 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.cn desc range unbounded preceding ),
 win2 as (order by cf_olap_windowerr_sale.vn asc),
 win3 as (order by cf_olap_windowerr_sale.cn asc);
-ERROR:  division by zero  (seg2 slice2 rahmaf2-mbp:25434 pid=48132)
+ERROR:  division by zero  (seg0 slice2 127.0.0.1:25432 pid=55689)
 -- REGR_INTERCEPT() function with partition by and order by having range based framing clause in combination with other functions--
 SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(REGR_INTERCEPT(floor(cf_olap_windowerr_sale.pn/cf_olap_windowerr_sale.prc),floor(cf_olap_windowerr_sale.qty)) OVER(win1),0),'99999999.9999999'),
 TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.cn*cf_olap_windowerr_sale.qty)) OVER(partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.pn asc range between unbounded preceding and floor(cf_olap_windowerr_sale.vn) preceding ),0),'99999999.9999999'),
@@ -3676,30 +3677,30 @@ WINDOW win1 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn
 win2 as (partition by cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc);
  vn | cn | pn  |     dt     | vn |      to_char      |      to_char      |      to_char      |      to_char      |      to_char      
 ----+----+-----+------------+----+-------------------+-------------------+-------------------+-------------------+-------------------
- 10 |  1 | 200 | 03-01-1401 | 10 |          .0000000 |          .0000000 |          .0000000 |          .0000000 |          .0000000
- 20 |  1 | 100 | 05-01-1401 | 20 |          .0000000 |          .0000000 |          .0000000 |          .0000000 |         1.0000000
- 30 |  1 | 300 | 05-02-1401 | 30 |          .0000000 |          .0000000 |          .0000000 |          .0000000 |          .0000000
- 30 |  1 | 500 | 06-01-1401 | 30 |          .0000000 |          .0000000 |          .0000000 |          .0000000 |          .0000000
- 30 |  3 | 500 | 06-01-1401 | 30 |          .0000000 |          .0000000 |          .0000000 |          .0000000 |         1.0000000
- 30 |  3 | 600 | 06-01-1401 | 30 |          .0000000 |          .0000000 |          .0000000 |          .0000000 |          .0000000
- 40 |  2 | 100 | 01-01-1401 | 40 |          .0000000 |          .0000000 |          .0000000 |          .0000000 |          .0000000
- 40 |  3 | 200 | 04-01-1401 | 40 |          .0000000 |          .0000000 |          .0000000 |          .0000000 |         1.0000000
- 40 |  4 | 700 | 06-01-1401 | 40 |          .0000000 |          .0000000 |          .0000000 |          .0000000 |          .0000000
- 40 |  4 | 800 | 06-01-1401 | 40 |          .0000000 |          .0000000 |          .0000000 |          .0000000 |          .0000000
  50 |  1 | 400 | 06-01-1401 | 50 |          .0000000 |          .0000000 |          .0000000 |          .0000000 |          .0000000
  50 |  2 | 400 | 06-01-1401 | 50 |          .0000000 |          .0000000 |          .0000000 |          .0000000 |         1.0000000
+ 30 |  3 | 600 | 06-01-1401 | 30 |          .0000000 |          .0000000 |          .0000000 |          .0000000 |          .0000000
+ 40 |  4 | 800 | 06-01-1401 | 40 |          .0000000 |          .0000000 |          .0000000 |          .0000000 |          .0000000
+ 10 |  1 | 200 | 03-01-1401 | 10 |          .0000000 |          .0000000 |          .0000000 |          .0000000 |          .0000000
+ 40 |  3 | 200 | 04-01-1401 | 40 |          .0000000 |          .0000000 |          .0000000 |          .0000000 |         1.0000000
+ 30 |  1 | 300 | 05-02-1401 | 30 |          .0000000 |          .0000000 |          .0000000 |          .0000000 |          .0000000
+ 40 |  2 | 100 | 01-01-1401 | 40 |          .0000000 |          .0000000 |          .0000000 |          .0000000 |          .0000000
+ 20 |  1 | 100 | 05-01-1401 | 20 |          .0000000 |          .0000000 |          .0000000 |          .0000000 |         1.0000000
+ 30 |  1 | 500 | 06-01-1401 | 30 |          .0000000 |          .0000000 |          .0000000 |          .0000000 |          .0000000
+ 30 |  3 | 500 | 06-01-1401 | 30 |          .0000000 |          .0000000 |          .0000000 |          .0000000 |         1.0000000
+ 40 |  4 | 700 | 06-01-1401 | 40 |          .0000000 |          .0000000 |          .0000000 |          .0000000 |          .0000000
 (12 rows)
 
 -- REGR_INTERCEPT() function with partition by and order by having range based framing clause --
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(REGR_INTERCEPT(floor(cf_olap_windowerr_sale.cn+cf_olap_windowerr_sale.prc),floor(cf_olap_windowerr_sale.cn/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.vn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.vn asc range between floor(cf_olap_windowerr_sale.cn) preceding and current row );
-ERROR:  division by zero  (seg0 slice2 rahmaf2-mbp:25432 pid=48130)
+ERROR:  division by zero  (seg0 slice2 127.0.0.1:25432 pid=55689)
 -- REGR_INTERCEPT() function with partition by and order by having range based framing clause --
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(REGR_INTERCEPT(floor(cf_olap_windowerr_sale.vn+cf_olap_windowerr_sale.pn),floor(cf_olap_windowerr_sale.pn/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.vn desc range between current row and current row );
-ERROR:  division by zero  (seg2 slice2 rahmaf2-mbp:25434 pid=48132)
+ERROR:  division by zero  (seg0 slice2 127.0.0.1:25432 pid=55689)
 -- REGR_INTERCEPT() function with partition by and order by having range based framing clause in combination with other functions--
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn, TO_CHAR(COALESCE(REGR_INTERCEPT(floor(cf_olap_windowerr_sale.pn),floor(cf_olap_windowerr_sale.vn/cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,
 TO_CHAR(COALESCE(ROW_NUMBER() OVER(win2),0),'99999999.9999999'),
@@ -3709,7 +3710,7 @@ TO_CHAR(COALESCE(LAG(cast(floor(cf_olap_windowerr_sale.prc/cf_olap_windowerr_sal
 TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.pn/cf_olap_windowerr_sale.vn)) OVER(win3),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn ) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.cn desc range between current row and unbounded following ),
-win2 as (order by cf_olap_windowerr_sale.vn desc),
+win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc),
 win3 as (order by cf_olap_windowerr_sale.vn asc),
 win4 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc);
 ERROR:  division by zero
@@ -3725,7 +3726,7 @@ WINDOW win1 as (partition by cf_olap_windowerr_sale.cn order by cf_olap_windower
 win2 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.cn asc),
 win3 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.vn asc),
 win4 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc);
-ERROR:  division by zero  (seg1 slice5 rahmaf2-mbp:25433 pid=48131)
+ERROR:  division by zero  (seg0 slice3 127.0.0.1:25432 pid=55695)
 -- REGR_INTERCEPT() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(REGR_INTERCEPT(floor(cf_olap_windowerr_sale.qty),floor(cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),
 TO_CHAR(COALESCE(RANK() OVER(win2),0),'99999999.9999999'),
@@ -3740,18 +3741,18 @@ win3 as (partition by cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.
 win4 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.pn desc);
  pn  | pn  | qty  |     dt     | qty  | qty  |      to_char      |      to_char      |      to_char      |      to_char      | cn |      to_char      |      to_char      
 -----+-----+------+------------+------+------+-------------------+-------------------+-------------------+-------------------+----+-------------------+-------------------
- 100 | 100 |    1 | 05-01-1401 |    1 |    1 |          .0000000 |        11.0000000 |          .0000000 |          .0000000 |  1 |          .0000000 |          .2500000
  100 | 100 | 1100 | 01-01-1401 | 1100 | 1100 |          .0000000 |        11.0000000 |          .0000000 |          .0000000 |  2 |          .0000000 |          .0000000
  200 | 200 |    1 | 03-01-1401 |    1 |    1 |          .0000000 |         9.0000000 |          .0000000 |          .0000000 |  1 |          .0000000 |          .0000000
  200 | 200 |    1 | 04-01-1401 |    1 |    1 |          .0000000 |         9.0000000 |          .0000000 |          .0000000 |  3 |          .0000000 |          .0000000
+ 100 | 100 |    1 | 05-01-1401 |    1 |    1 |          .0000000 |        11.0000000 |          .0000000 |          .0000000 |  1 |          .0000000 |          .2500000
  300 | 300 |    1 | 05-02-1401 |    1 |    1 |          .0000000 |         8.0000000 |          .0000000 |          .0000000 |  1 |          .0000000 |          .5000000
+ 500 | 500 |   12 | 06-01-1401 |   12 |   12 |          .0000000 |         4.0000000 |          .0000000 |          .0000000 |  1 |          .0000000 |         1.0000000
  400 | 400 |    1 | 06-01-1401 |    1 |    1 |          .0000000 |         6.0000000 |          .0000000 |          .0000000 |  1 |         1.0000000 |          .7500000
  400 | 400 |    1 | 06-01-1401 |    1 |    1 |         1.0000000 |         6.0000000 |          .0000000 |          .0000000 |  2 |          .0000000 |         1.0000000
- 500 | 500 |   12 | 06-01-1401 |   12 |   12 |          .0000000 |         4.0000000 |          .0000000 |          .0000000 |  1 |          .0000000 |         1.0000000
- 500 | 500 |   12 | 06-01-1401 |   12 |   12 |          .0000000 |         4.0000000 |          .0000000 |          .0000000 |  3 |         1.0000000 |          .5000000
  600 | 600 |   12 | 06-01-1401 |   12 |   12 |          .0000000 |         3.0000000 |          .0000000 |          .0000000 |  3 |          .0000000 |         1.0000000
- 700 | 700 |    1 | 06-01-1401 |    1 |    1 |          .0000000 |         2.0000000 |          .0000000 |          .0000000 |  4 |         1.0000000 |          .0000000
+ 500 | 500 |   12 | 06-01-1401 |   12 |   12 |          .0000000 |         4.0000000 |          .0000000 |          .0000000 |  3 |         1.0000000 |          .5000000
  800 | 800 |    1 | 06-01-1401 |    1 |    1 |          .0000000 |         1.0000000 |          .0000000 |          .0000000 |  4 |          .0000000 |         1.0000000
+ 700 | 700 |    1 | 06-01-1401 |    1 |    1 |          .0000000 |         2.0000000 |          .0000000 |          .0000000 |  4 |         1.0000000 |          .0000000
 (12 rows)
 
 -- REGR_INTERCEPT() function with partition by and order by having rows based framing clause in combination with other functions --
@@ -3767,18 +3768,18 @@ win2 as (partition by cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale
 win3 as (order by cf_olap_windowerr_sale.pn desc);
  vn |     dt     | pn  |      to_char      | cn |      to_char      | prc  |      to_char      |      to_char      |      to_char      |      to_char      
 ----+------------+-----+-------------------+----+-------------------+------+-------------------+-------------------+-------------------+-------------------
- 10 | 03-01-1401 | 200 |          .0000000 |  1 |          .0000000 |    0 |          .7272727 |         1.0000000 |         1.0000000 |         1.0000000
- 20 | 05-01-1401 | 100 |          .0000000 |  1 |          .0000000 |    0 |          .9090909 |         3.0000000 |         1.0000000 |         1.0000000
- 30 | 05-02-1401 | 300 |          .0000000 |  1 |          .0000000 |    0 |          .6363636 |         4.0000000 |         1.0000000 |         1.0000000
- 30 | 06-01-1401 | 500 |         3.0000000 |  3 |          .0000000 |    5 |          .2727273 |         2.0000000 |         1.0000000 |        12.0000000
- 30 | 06-01-1401 | 500 |        12.0000000 |  1 |          .0000000 |    5 |          .2727273 |         1.0000000 |         1.0000000 |        12.0000000
- 30 | 06-01-1401 | 600 |         2.1000000 |  3 |          .0000000 |    5 |          .1818182 |         3.0000000 |         1.0000000 |        12.0000000
- 40 | 01-01-1401 | 100 |          .0000000 |  2 |          .0000000 | 2400 |          .9090909 |         1.0000000 |      2402.0000000 |      1100.0000000
- 40 | 04-01-1401 | 200 |          .0000000 |  3 |          .0000000 |    0 |          .7272727 |         2.0000000 |         3.0000000 |         1.0000000
- 40 | 06-01-1401 | 700 |         6.5000000 |  4 |          .0000000 |    1 |          .0909091 |         1.0000000 |         1.0000000 |        12.0000000
  40 | 06-01-1401 | 800 |         7.7941176 |  4 |          .0000000 |    1 |          .0000000 |         2.0000000 |         1.0000000 |        12.0000000
+ 40 | 06-01-1401 | 700 |         6.5000000 |  4 |          .0000000 |    1 |          .0909091 |         1.0000000 |         1.0000000 |        12.0000000
+ 30 | 06-01-1401 | 600 |         2.1000000 |  3 |          .0000000 |    5 |          .1818182 |         3.0000000 |         1.0000000 |        12.0000000
+ 30 | 06-01-1401 | 500 |        12.0000000 |  1 |          .0000000 |    5 |          .2727273 |         1.0000000 |         1.0000000 |        12.0000000
+ 30 | 06-01-1401 | 500 |         3.0000000 |  3 |          .0000000 |    5 |          .2727273 |         2.0000000 |         1.0000000 |        12.0000000
  50 | 06-01-1401 | 400 |          .0000000 |  1 |          .0000000 |    0 |          .4545455 |         5.0000000 |         1.0000000 |         1.0000000
  50 | 06-01-1401 | 400 |         1.0000000 |  2 |          .0000000 |    0 |          .4545455 |         6.0000000 |         1.0000000 |         1.0000000
+ 30 | 05-02-1401 | 300 |          .0000000 |  1 |          .0000000 |    0 |          .6363636 |         4.0000000 |         1.0000000 |         1.0000000
+ 40 | 04-01-1401 | 200 |          .0000000 |  3 |          .0000000 |    0 |          .7272727 |         2.0000000 |         3.0000000 |         1.0000000
+ 10 | 03-01-1401 | 200 |          .0000000 |  1 |          .0000000 |    0 |          .7272727 |         1.0000000 |         1.0000000 |         1.0000000
+ 40 | 01-01-1401 | 100 |          .0000000 |  2 |          .0000000 | 2400 |          .9090909 |         1.0000000 |      2402.0000000 |      1100.0000000
+ 20 | 05-01-1401 | 100 |          .0000000 |  1 |          .0000000 |    0 |          .9090909 |         3.0000000 |         1.0000000 |         1.0000000
 (12 rows)
 
 -- REGR_INTERCEPT() function with partition by and order by having rows based framing clause in combination with other functions --
@@ -3789,12 +3790,12 @@ TO_CHAR(COALESCE(RANK() OVER(win2),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn AND cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.qty order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc rows between floor(cf_olap_windowerr_sale.cn-cf_olap_windowerr_sale.vn) preceding and current row ),
 win2 as (order by cf_olap_windowerr_sale.pn asc);
-ERROR:  frame starting offset must not be negative  (seg0 slice4 127.0.0.1:40000 pid=16456)
+ERROR:  frame starting offset must not be negative  (seg0 slice4 127.0.0.1:25432 pid=55689)
 -- REGR_INTERCEPT() function with partition by and order by having rows based framing clause --
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(REGR_INTERCEPT(floor(cf_olap_windowerr_sale.qty),floor(cf_olap_windowerr_sale.cn+cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn AND cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc,cf_olap_windowerr_sale.pn asc,cf_olap_windowerr_sale.cn asc rows between floor(cf_olap_windowerr_sale.qty+cf_olap_windowerr_sale.qty) following and floor(cf_olap_windowerr_sale.prc-cf_olap_windowerr_sale.cn) following );
-ERROR:  frame ending offset must not be negative  (seg0 slice4 127.0.0.1:40000 pid=16456)
+ERROR:  frame ending offset must not be negative  (seg0 slice3 127.0.0.1:25432 pid=55689)
 -- REGR_R2() function with ONLY order by having range based framing clause --
 SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn, TO_CHAR(COALESCE(REGR_R2(floor(cf_olap_windowerr_sale.qty),floor(cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn AND cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
@@ -3811,8 +3812,8 @@ win2 as (order by cf_olap_windowerr_sale.cn desc),
 win3 as (partition by cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc);
  pn  | cn | qty  | cn | prc  |      to_char      |      to_char      |      to_char      |      to_char      
 -----+----+------+----+------+-------------------+-------------------+-------------------+-------------------
- 100 |  1 |    1 |  1 |    0 |         1.0000000 |         1.0000000 |         1.0000000 |          .0000000
  100 |  2 | 1100 |  2 | 2400 |         1.0000000 |          .5833333 |          .5833333 |          .0000000
+ 100 |  1 |    1 |  1 |    0 |         1.0000000 |         1.0000000 |         1.0000000 |          .0000000
  200 |  1 |    1 |  1 |    0 |         1.0000000 |         1.0000000 |         1.0000000 |          .0000000
  200 |  3 |    1 |  3 |    0 |         1.0000000 |          .4166667 |          .4166667 |          .0000000
  300 |  1 |    1 |  1 |    0 |         1.0000000 |         1.0000000 |         1.0000000 |          .0000000
@@ -3859,16 +3860,16 @@ win5 as (order by cf_olap_windowerr_sale.cn desc);
 ------+-------------------+----+-------------------+------------+----+-------------------+-----+-------------------+-------------------+-------------------
     1 |          .9999964 |  4 |         1.0000000 | 06-01-1401 | 40 |         1.0000000 | 800 |          .0000000 |         1.0000000 |          .0000000
     1 |          .9999965 |  4 |         1.0000000 | 06-01-1401 | 40 |         2.0000000 | 700 |          .0000000 |         1.0000000 |          .0000000
-    1 |         1.0000000 |  1 |         1.0000000 | 03-01-1401 | 10 |         7.0000000 | 200 |          .0000000 |         1.0000000 |          .6363636
-    1 |         1.0000000 |  1 |         1.0000000 | 05-01-1401 | 20 |         8.0000000 | 100 |          .0000000 |         1.0000000 |          .6363636
-    1 |         1.0000000 |  1 |         1.0000000 | 05-02-1401 | 30 |         6.0000000 | 300 |          .0000000 |         1.0000000 |          .6363636
-    1 |         1.0000000 |  1 |         1.0000000 | 06-01-1401 | 50 |         5.0000000 | 400 |          .0000000 |         1.0000000 |          .6363636
-    1 |         1.0000000 |  2 |         1.0000000 | 06-01-1401 | 50 |         5.0000000 | 400 |          .0000000 |         1.0000000 |          .4545455
-    1 |         1.0000000 |  3 |         1.0000000 | 04-01-1401 | 40 |         7.0000000 | 200 |          .0000000 |         1.0000000 |          .1818182
    12 |          .9999965 |  3 |         1.0000000 | 06-01-1401 | 30 |         3.0000000 | 600 |          .0000000 |         1.0000000 |          .1818182
+    1 |         1.0000000 |  3 |         1.0000000 | 04-01-1401 | 40 |         7.0000000 | 200 |          .0000000 |         1.0000000 |          .1818182
    12 |          .9999976 |  3 |         1.0000000 | 06-01-1401 | 30 |         4.0000000 | 500 |          .0000000 |         1.0000000 |          .1818182
-   12 |          .9999989 |  1 |         1.0000000 | 06-01-1401 | 30 |         4.0000000 | 500 |          .0000000 |         1.0000000 |          .6363636
+    1 |         1.0000000 |  2 |         1.0000000 | 06-01-1401 | 50 |         5.0000000 | 400 |          .0000000 |         1.0000000 |          .4545455
  1100 |          .0000000 |  2 |         1.0000000 | 01-01-1401 | 40 |         8.0000000 | 100 |          .0000000 |         1.0000000 |          .4545455
+   12 |          .9999989 |  1 |         1.0000000 | 06-01-1401 | 30 |         4.0000000 | 500 |          .0000000 |         1.0000000 |          .6363636
+    1 |         1.0000000 |  1 |         1.0000000 | 06-01-1401 | 50 |         5.0000000 | 400 |          .0000000 |         1.0000000 |          .6363636
+    1 |         1.0000000 |  1 |         1.0000000 | 05-02-1401 | 30 |         6.0000000 | 300 |          .0000000 |         1.0000000 |          .6363636
+    1 |         1.0000000 |  1 |         1.0000000 | 05-01-1401 | 20 |         8.0000000 | 100 |          .0000000 |         1.0000000 |          .6363636
+    1 |         1.0000000 |  1 |         1.0000000 | 03-01-1401 | 10 |         7.0000000 | 200 |          .0000000 |         1.0000000 |          .6363636
 (12 rows)
 
 -- REGR_R2() function with ONLY order by having rows based framing clause --
@@ -3898,7 +3899,7 @@ TO_CHAR(COALESCE(ROW_NUMBER() OVER(win2),0),'99999999.9999999'),cf_olap_windower
 TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.cn)) OVER(order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc,cf_olap_windowerr_sale.cn desc rows between 2 preceding and unbounded following ),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product,cf_olap_windowerr_vendor,cf_olap_windowerr_customer WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn AND cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn AND cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn) cf_olap_windowerr_sale
 WINDOW win1 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc,cf_olap_windowerr_sale.cn desc rows between 2 preceding and unbounded following ),
-win2 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.pn desc);
+win2 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc);
 ERROR:  division by zero
 -- REGR_R2() function with partition by and order by having range based framing clause in combination with other functions--
 SELECT cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(REGR_R2(floor(cf_olap_windowerr_sale.pn/cf_olap_windowerr_sale.cn),floor(cf_olap_windowerr_sale.pn+cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,
@@ -3912,39 +3913,39 @@ win2 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn,cf_ola
 win3 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc);
  cn | cn |      to_char      | prc  |     dt     | vn |      to_char      |      to_char      |      to_char      |      to_char      | pn  
 ----+----+-------------------+------+------------+----+-------------------+-------------------+-------------------+-------------------+-----
-  1 |  1 |          .0000000 |    0 | 03-01-1401 | 10 |         1.0000000 |         1.0000000 |         1.0000000 |          .0000000 | 200
-  1 |  1 |          .0000000 |    0 | 05-01-1401 | 20 |         1.0000000 |         1.0000000 |         1.0000000 |          .0000000 | 100
-  1 |  1 |          .0000000 |    0 | 05-02-1401 | 30 |         1.0000000 |         1.0000000 |         1.0000000 |          .0000000 | 300
-  1 |  1 |          .0000000 |    0 | 06-01-1401 | 50 |         1.0000000 |         1.0000000 |         1.0000000 |          .0000000 | 400
-  1 |  1 |          .0000000 |    5 | 06-01-1401 | 30 |         1.0000000 |         1.0000000 |         1.0000000 |          .0000000 | 500
-  2 |  2 |          .0000000 |    0 | 06-01-1401 | 50 |         1.0000000 |         1.0000000 |         1.0000000 |          .0000000 | 400
-  2 |  2 |          .0000000 | 2400 | 01-01-1401 | 40 |         1.0000000 |         1.0000000 |         1.0000000 |          .0000000 | 100
   3 |  3 |          .0000000 |    0 | 04-01-1401 | 40 |         1.0000000 |         1.0000000 |         1.0000000 |          .0000000 | 200
+  1 |  1 |          .0000000 |    0 | 05-01-1401 | 20 |         1.0000000 |         1.0000000 |         1.0000000 |          .0000000 | 100
+  1 |  1 |          .0000000 |    5 | 06-01-1401 | 30 |         1.0000000 |         1.0000000 |         1.0000000 |          .0000000 | 500
   3 |  3 |         1.0000000 |    5 | 06-01-1401 | 30 |         2.0000000 |         2.0000000 |         1.0000000 |          .0000000 | 500
-  3 |  3 |         1.0000000 |    5 | 06-01-1401 | 30 |         2.0000000 |         2.0000000 |         1.0000000 |          .0000000 | 600
-  4 |  4 |         1.0000000 |    1 | 06-01-1401 | 40 |         2.0000000 |         2.0000000 |         1.0000000 |          .0000000 | 700
   4 |  4 |         1.0000000 |    1 | 06-01-1401 | 40 |         2.0000000 |         2.0000000 |         1.0000000 |          .0000000 | 800
+  2 |  2 |          .0000000 | 2400 | 01-01-1401 | 40 |         1.0000000 |         1.0000000 |         1.0000000 |          .0000000 | 100
+  1 |  1 |          .0000000 |    0 | 03-01-1401 | 10 |         1.0000000 |         1.0000000 |         1.0000000 |          .0000000 | 200
+  1 |  1 |          .0000000 |    0 | 05-02-1401 | 30 |         1.0000000 |         1.0000000 |         1.0000000 |          .0000000 | 300
+  4 |  4 |         1.0000000 |    1 | 06-01-1401 | 40 |         2.0000000 |         2.0000000 |         1.0000000 |          .0000000 | 700
+  3 |  3 |         1.0000000 |    5 | 06-01-1401 | 30 |         2.0000000 |         2.0000000 |         1.0000000 |          .0000000 | 600
+  1 |  1 |          .0000000 |    0 | 06-01-1401 | 50 |         1.0000000 |         1.0000000 |         1.0000000 |          .0000000 | 400
+  2 |  2 |          .0000000 |    0 | 06-01-1401 | 50 |         1.0000000 |         1.0000000 |         1.0000000 |          .0000000 | 400
 (12 rows)
 
 -- REGR_R2() function with partition by and order by having range based framing clause --
 SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.prc, TO_CHAR(COALESCE(REGR_R2(floor(cf_olap_windowerr_sale.vn+cf_olap_windowerr_sale.vn),floor(cf_olap_windowerr_sale.qty/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn AND cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.qty order by cf_olap_windowerr_sale.cn asc range between unbounded preceding and unbounded following );
-ERROR:  division by zero  (seg2 slice4 rahmaf2-mbp:25434 pid=48132)
+ERROR:  division by zero  (seg0 slice4 127.0.0.1:25432 pid=55689)
 -- REGR_R2() function with partition by and order by having range based framing clause in combination with other functions--
 SELECT cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.prc, TO_CHAR(COALESCE(REGR_R2(floor(cf_olap_windowerr_sale.qty),floor(cf_olap_windowerr_sale.qty-cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.vn,
 TO_CHAR(COALESCE(LAG(cast(floor(cf_olap_windowerr_sale.vn) as int),cast (floor(cf_olap_windowerr_sale.prc) as int),NULL) OVER(win2),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.cn desc range between floor(cf_olap_windowerr_sale.pn) preceding and floor(cf_olap_windowerr_sale.pn-cf_olap_windowerr_sale.prc) preceding ),
 win2 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc);
-ERROR:  RANGE parameter cannot be negative  (seg2 slice3 127.0.0.1:40002 pid=16769)
+ERROR:  RANGE parameter cannot be negative  (seg2 slice3 127.0.0.1:25434 pid=55694)
 -- REGR_R2() function with partition by and order by having range based framing clause in combination with other functions--
 SELECT cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt, TO_CHAR(COALESCE(REGR_R2(floor(cf_olap_windowerr_sale.cn),floor(cf_olap_windowerr_sale.qty*cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999'),
 TO_CHAR(COALESCE(LAG(cast(floor(cf_olap_windowerr_sale.prc-cf_olap_windowerr_sale.vn) as int),cast (floor(cf_olap_windowerr_sale.vn/cf_olap_windowerr_sale.vn) as int),NULL) OVER(win2),0),'99999999.9999999'),cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.pn asc range between current row and floor(cf_olap_windowerr_sale.prc/cf_olap_windowerr_sale.prc) following ),
 win2 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc);
-ERROR:  division by zero  (seg0 slice3 rahmaf2-mbp:25432 pid=48149)
+ERROR:  division by zero  (seg0 slice3 127.0.0.1:25432 pid=55954)
 -- REGR_R2() function with partition by and order by having range based framing clause in combination with other functions--
 SELECT cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.prc, TO_CHAR(COALESCE(REGR_R2(floor(cf_olap_windowerr_sale.cn),floor(cf_olap_windowerr_sale.pn/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.pn,
 TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.cn+cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999'),
@@ -3955,14 +3956,14 @@ WINDOW win1 as (partition by cf_olap_windowerr_sale.pn order by cf_olap_windower
 win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc);
  cn | prc  | cn | cn | prc  |      to_char      | pn  |      to_char      |      to_char      |      to_char      
 ----+------+----+----+------+-------------------+-----+-------------------+-------------------+-------------------
-  1 |    0 |  1 |  1 |    0 |          .0000000 | 100 |          .0000000 |          .0000000 |         4.0000000
+  2 | 2400 |  2 |  2 | 2400 |          .0000000 | 100 |          .0000000 |          .0000000 |         1.0000000
   1 |    0 |  1 |  1 |    0 |          .0000000 | 200 |          .0000000 |          .0000000 |         2.0000000
+  3 |    0 |  3 |  3 |    0 |          .0000000 | 200 |          .0000000 |         2.0000000 |         3.0000000
+  1 |    0 |  1 |  1 |    0 |          .0000000 | 100 |          .0000000 |          .0000000 |         4.0000000
   1 |    0 |  1 |  1 |    0 |          .0000000 | 300 |          .0000000 |          .0000000 |         5.0000000
   1 |    0 |  1 |  1 |    0 |          .0000000 | 400 |          .0000000 |          .0000000 |         6.0000000
-  1 |    5 |  1 |  1 |    5 |          .0000000 | 500 |          .0000000 |         2.0000000 |         8.0000000
   2 |    0 |  2 |  2 |    0 |          .0000000 | 400 |          .0000000 |         1.0000000 |         7.0000000
-  2 | 2400 |  2 |  2 | 2400 |          .0000000 | 100 |          .0000000 |          .0000000 |         1.0000000
-  3 |    0 |  3 |  3 |    0 |          .0000000 | 200 |          .0000000 |         2.0000000 |         3.0000000
+  1 |    5 |  1 |  1 |    5 |          .0000000 | 500 |          .0000000 |         2.0000000 |         8.0000000
   3 |    5 |  3 |  3 |    5 |          .0000000 | 500 |          .0000000 |          .0000000 |         9.0000000
   3 |    5 |  3 |  3 |    5 |          .0000000 | 600 |          .0000000 |          .0000000 |        10.0000000
   4 |    1 |  4 |  4 |    1 |          .0000000 | 700 |          .0000000 |         1.0000000 |        11.0000000
@@ -3973,7 +3974,7 @@ win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc);
 SELECT cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(REGR_R2(floor(cf_olap_windowerr_sale.pn/cf_olap_windowerr_sale.prc),floor(cf_olap_windowerr_sale.pn*cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn AND cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.qty order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc,cf_olap_windowerr_sale.vn desc,cf_olap_windowerr_sale.vn asc rows floor(cf_olap_windowerr_sale.vn) preceding );
-ERROR:  division by zero  (seg0 slice4 rahmaf2-mbp:25432 pid=48130)
+ERROR:  division by zero  (seg0 slice4 127.0.0.1:25432 pid=55689)
 -- REGR_R2() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(REGR_R2(floor(cf_olap_windowerr_sale.vn/cf_olap_windowerr_sale.prc),floor(cf_olap_windowerr_sale.cn+cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.dt,
 TO_CHAR(COALESCE(COUNT(floor(cf_olap_windowerr_sale.prc+cf_olap_windowerr_sale.cn)) OVER(partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc,cf_olap_windowerr_sale.cn asc rows current row ),0),'99999999.9999999'),
@@ -3983,12 +3984,12 @@ FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_ol
 WINDOW win1 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc,cf_olap_windowerr_sale.cn asc rows current row ),
 win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc),
 win3 as (order by cf_olap_windowerr_sale.pn asc);
-ERROR:  division by zero  (seg0 slice2 rahmaf2-mbp:25432 pid=48130)
+ERROR:  division by zero  (seg0 slice2 127.0.0.1:25432 pid=55689)
 -- REGR_R2() function with partition by and order by having rows based framing clause --
 SELECT cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(REGR_R2(floor(cf_olap_windowerr_sale.pn+cf_olap_windowerr_sale.qty),floor(cf_olap_windowerr_sale.vn/cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc,cf_olap_windowerr_sale.vn desc,cf_olap_windowerr_sale.pn asc rows between unbounded preceding and floor(cf_olap_windowerr_sale.prc-cf_olap_windowerr_sale.pn) preceding );
-ERROR:  frame ending offset must not be negative  (seg0 slice3 127.0.0.1:40000 pid=16456)
+ERROR:  frame ending offset must not be negative  (seg0 slice3 127.0.0.1:25432 pid=55689)
 -- REGR_R2() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.prc, TO_CHAR(COALESCE(REGR_R2(floor(cf_olap_windowerr_sale.pn),floor(cf_olap_windowerr_sale.vn/cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,
 TO_CHAR(COALESCE(LEAD(cast(floor(cf_olap_windowerr_sale.prc) as int),cast (floor(cf_olap_windowerr_sale.qty) as int),NULL) OVER(win2),0),'99999999.9999999'),
@@ -3997,13 +3998,13 @@ TO_CHAR(COALESCE(DENSE_RANK() OVER(order by cf_olap_windowerr_sale.ord, cf_olap_
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc,cf_olap_windowerr_sale.pn desc,cf_olap_windowerr_sale.cn desc rows between floor(cf_olap_windowerr_sale.prc) preceding and floor(cf_olap_windowerr_sale.prc-cf_olap_windowerr_sale.vn) preceding ),
 win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc);
-ERROR:  frame ending offset must not be negative  (seg0 slice2 127.0.0.1:40000 pid=16456)
+ERROR:  frame ending offset must not be negative  (seg0 slice2 127.0.0.1:25432 pid=55689)
 -- REGR_R2() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(REGR_R2(floor(cf_olap_windowerr_sale.qty-cf_olap_windowerr_sale.prc),floor(cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),
 TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.qty/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn ) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc rows between 4 preceding and 4 following );
-ERROR:  division by zero  (seg0 slice2 rahmaf2-mbp:25432 pid=48130)
+ERROR:  division by zero  (seg0 slice2 127.0.0.1:25432 pid=55689)
 -- REGR_R2() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(REGR_R2(floor(cf_olap_windowerr_sale.vn+cf_olap_windowerr_sale.qty),floor(cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn,
 TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.pn*cf_olap_windowerr_sale.qty)) OVER(win1),0),'99999999.9999999'),
@@ -4017,18 +4018,18 @@ win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc),
 win3 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc);
  qty  |      to_char      | prc  | vn |      to_char      |      to_char      |      to_char      | cn |     dt     | pn  |      to_char      |      to_char      
 ------+-------------------+------+----+-------------------+-------------------+-------------------+----+------------+-----+-------------------+-------------------
+ 1100 |          .0000000 | 2400 | 40 |    110000.0000000 |          .0000000 |          .0000000 |  2 | 01-01-1401 | 100 |      1200.0000000 |         1.0000000
     1 |          .0000000 |    0 | 10 |       200.0000000 |          .0000000 |          .0000000 |  1 | 03-01-1401 | 200 |       201.0000000 |         1.0000000
+    1 |          .0000000 |    0 | 40 |       200.0000000 |          .0000000 |          .0000000 |  3 | 04-01-1401 | 200 |       201.0000000 |         1.0000000
     1 |          .0000000 |    0 | 20 |       100.0000000 |          .0000000 |          .0000000 |  1 | 05-01-1401 | 100 |       101.0000000 |         1.0000000
     1 |          .0000000 |    0 | 30 |       300.0000000 |          .0000000 |          .0000000 |  1 | 05-02-1401 | 300 |       301.0000000 |         1.0000000
-    1 |          .0000000 |    0 | 40 |       200.0000000 |          .0000000 |          .0000000 |  3 | 04-01-1401 | 200 |       201.0000000 |         1.0000000
     1 |          .0000000 |    0 | 50 |       400.0000000 |          .0000000 |          .0000000 |  1 | 06-01-1401 | 400 |       401.0000000 |         2.0000000
     1 |          .0000000 |    0 | 50 |       400.0000000 |          .0000000 |          .0000000 |  2 | 06-01-1401 | 400 |       401.0000000 |         2.0000000
-    1 |          .0000000 |    1 | 40 |       800.0000000 |          .0000000 |       700.0000000 |  4 | 06-01-1401 | 700 |       801.0000000 |         2.0000000
-    1 |          .0000000 |    1 | 40 |       800.0000000 |          .0000000 |       800.0000000 |  4 | 06-01-1401 | 800 |       801.0000000 |         2.0000000
    12 |          .0000000 |    5 | 30 |      7200.0000000 |          .0000000 |          .0000000 |  1 | 06-01-1401 | 500 |       612.0000000 |         3.0000000
    12 |          .0000000 |    5 | 30 |      7200.0000000 |          .0000000 |          .0000000 |  3 | 06-01-1401 | 500 |       612.0000000 |         3.0000000
    12 |          .0000000 |    5 | 30 |      7200.0000000 |          .0000000 |          .0000000 |  3 | 06-01-1401 | 600 |       612.0000000 |         3.0000000
- 1100 |          .0000000 | 2400 | 40 |    110000.0000000 |          .0000000 |          .0000000 |  2 | 01-01-1401 | 100 |      1200.0000000 |         1.0000000
+    1 |          .0000000 |    1 | 40 |       800.0000000 |          .0000000 |       700.0000000 |  4 | 06-01-1401 | 700 |       801.0000000 |         2.0000000
+    1 |          .0000000 |    1 | 40 |       800.0000000 |          .0000000 |       800.0000000 |  4 | 06-01-1401 | 800 |       801.0000000 |         2.0000000
 (12 rows)
 
 -- REGR_SLOPE() function with ONLY order by having range based framing clause in combination with other functions --
@@ -4038,7 +4039,7 @@ TO_CHAR(COALESCE(LAG(cast(floor(cf_olap_windowerr_sale.qty) as int),cast (floor(
 TO_CHAR(COALESCE(ROW_NUMBER() OVER(partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn ) cf_olap_windowerr_sale
 WINDOW win1 as (order by cf_olap_windowerr_sale.pn desc range unbounded preceding ),
-win2 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.vn asc),
+win2 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc),
 win3 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc);
  vn | cn |      to_char      | pn  |      to_char      | prc  | qty  |      to_char      |     dt     |      to_char      
 ----+----+-------------------+-----+-------------------+------+------+-------------------+------------+-------------------
@@ -4046,14 +4047,14 @@ win3 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_ola
  20 |  1 |       -13.0319149 | 100 |         1.0000000 |    0 |    1 |          .0000000 | 05-01-1401 |         1.0000000
  30 |  1 |         -.4736842 | 300 |         1.0000000 |    0 |    1 |          .0000000 | 05-02-1401 |         1.0000000
  30 |  1 |        -1.6666667 | 500 |         1.0000000 |    5 |   12 |          .0000000 | 06-01-1401 |         1.0000000
- 30 |  3 |        -1.0000000 | 600 |         1.0000000 |    5 |   12 |          .0000000 | 06-01-1401 |         2.0000000
- 30 |  3 |        -1.6666667 | 500 |         2.0000000 |    5 |   12 |          .0000000 | 06-01-1401 |         1.0000000
+ 50 |  1 |         -.7205882 | 400 |         1.0000000 |    0 |    1 |          .0000000 | 06-01-1401 |         1.0000000
  40 |  2 |       -13.0319149 | 100 |         1.0000000 | 2400 | 1100 |          .0000000 | 01-01-1401 |         1.0000000
+ 50 |  2 |         -.7205882 | 400 |         2.0000000 |    0 |    1 |          .0000000 | 06-01-1401 |         1.0000000
+ 30 |  3 |        -1.6666667 | 500 |         2.0000000 |    5 |   12 |          .0000000 | 06-01-1401 |         1.0000000
+ 30 |  3 |        -1.0000000 | 600 |         1.0000000 |    5 |   12 |          .0000000 | 06-01-1401 |         2.0000000
  40 |  3 |         -.3617021 | 200 |         1.0000000 |    0 |    1 |          .0000000 | 04-01-1401 |         1.0000000
  40 |  4 |          .0000000 | 700 |         1.0000000 |    1 |    1 |          .0000000 | 06-01-1401 |         1.0000000
  40 |  4 |          .0000000 | 800 |         1.0000000 |    1 |    1 |          .0000000 | 06-01-1401 |         2.0000000
- 50 |  1 |         -.7205882 | 400 |         1.0000000 |    0 |    1 |          .0000000 | 06-01-1401 |         1.0000000
- 50 |  2 |         -.7205882 | 400 |         2.0000000 |    0 |    1 |          .0000000 | 06-01-1401 |         1.0000000
 (12 rows)
 
 -- REGR_SLOPE() function with ONLY order by having range based framing clause in combination with other functions --
@@ -4064,7 +4065,7 @@ TO_CHAR(COALESCE(RANK() OVER(win3),0),'99999999.9999999'),
 TO_CHAR(COALESCE(ROW_NUMBER() OVER(win2),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
 WINDOW win1 as (order by cf_olap_windowerr_sale.cn desc range between unbounded preceding and 4 preceding ),
-win2 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.pn desc),
+win2 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc),
 win3 as (partition by cf_olap_windowerr_sale.qty order by cf_olap_windowerr_sale.vn asc);
 ERROR:  division by zero
 -- REGR_SLOPE() function with ONLY order by having range based framing clause in combination with other functions --
@@ -4103,7 +4104,7 @@ FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_ola
 WINDOW win1 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc rows between unbounded preceding and current row ),
 win2 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.qty order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc),
 win3 as (partition by cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.pn asc);
-ERROR:  division by zero  (seg1 slice4 rahmaf2-mbp:25433 pid=48131)
+ERROR:  division by zero
 -- REGR_SLOPE() function with ONLY order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(REGR_SLOPE(floor(cf_olap_windowerr_sale.prc*cf_olap_windowerr_sale.pn),floor(cf_olap_windowerr_sale.pn+cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.pn,
 TO_CHAR(COALESCE(RANK() OVER(win2),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,
@@ -4121,8 +4122,8 @@ TO_CHAR(COALESCE(ROW_NUMBER() OVER(win2),0),'99999999.9999999'),
 TO_CHAR(COALESCE(DENSE_RANK() OVER(partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.cn desc),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn ) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.cn desc range current row ),
-win2 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.cn desc);
-ERROR:  division by zero  (seg0 slice4 rahmaf2-mbp:25432 pid=48130)
+win2 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc);
+ERROR:  division by zero  (seg0 slice3 127.0.0.1:25432 pid=55700)
 -- REGR_SLOPE() function with partition by and order by having range based framing clause in combination with other functions--
 SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.prc, TO_CHAR(COALESCE(REGR_SLOPE(floor(cf_olap_windowerr_sale.prc),floor(cf_olap_windowerr_sale.qty)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.qty,
 TO_CHAR(COALESCE(DENSE_RANK() OVER(win2),0),'99999999.9999999'),
@@ -4134,12 +4135,12 @@ WINDOW win1 as (partition by cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.v
 win2 as (order by cf_olap_windowerr_sale.vn asc),
 win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc),
 win4 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc);
-ERROR:  RANGE parameter cannot be negative  (seg0 slice2 rahmaf2-mbp:25432 pid=48130)
+ERROR:  RANGE parameter cannot be negative  (seg0 slice2 127.0.0.1:25432 pid=55689)
 -- REGR_SLOPE() function with partition by and order by having range based framing clause --
 SELECT cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(REGR_SLOPE(floor(cf_olap_windowerr_sale.prc-cf_olap_windowerr_sale.cn),floor(cf_olap_windowerr_sale.qty)) OVER(win1),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.vn desc range between current row and floor(cf_olap_windowerr_sale.vn-cf_olap_windowerr_sale.pn) following );
-ERROR:  RANGE parameter cannot be negative  (seg0 slice2 rahmaf2-mbp:25432 pid=48130)
+ERROR:  RANGE parameter cannot be negative  (seg0 slice2 127.0.0.1:25432 pid=55689)
 -- REGR_SLOPE() function with partition by and order by having range based framing clause in combination with other functions--
 SELECT cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.pn, TO_CHAR(COALESCE(REGR_SLOPE(floor(cf_olap_windowerr_sale.vn-cf_olap_windowerr_sale.qty),floor(cf_olap_windowerr_sale.prc+cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,
 TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.vn/cf_olap_windowerr_sale.qty)) OVER(partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.cn desc range between current row and floor(cf_olap_windowerr_sale.qty-cf_olap_windowerr_sale.prc) following ),0),'99999999.9999999'),
@@ -4147,7 +4148,7 @@ TO_CHAR(COALESCE(PERCENT_RANK() OVER(win2),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn AND cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.cn desc range between current row and floor(cf_olap_windowerr_sale.qty-cf_olap_windowerr_sale.prc) following ),
 win2 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.vn desc);
-ERROR:  RANGE parameter cannot be negative  (seg0 slice4 rahmaf2-mbp:25432 pid=48130)
+ERROR:  RANGE parameter cannot be negative  (seg2 slice3 127.0.0.1:25434 pid=55691)
 -- REGR_SLOPE() function with partition by and order by having range based framing clause in combination with other functions--
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn, TO_CHAR(COALESCE(REGR_SLOPE(floor(cf_olap_windowerr_sale.pn),floor(cf_olap_windowerr_sale.pn/cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,
 TO_CHAR(COALESCE(LEAD(cast(floor(cf_olap_windowerr_sale.qty) as int),cast (floor(cf_olap_windowerr_sale.qty) as int),NULL) OVER(win2),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,
@@ -4158,18 +4159,18 @@ win2 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.prc,cf_ol
 win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc);
  qty  | pn  |      to_char      | cn |     dt     | vn |      to_char      | prc  |      to_char      
 ------+-----+-------------------+----+------------+----+-------------------+------+-------------------
-    1 | 100 |          .0000000 |  1 | 05-01-1401 | 20 |          .0000000 |    0 |          .0000000
+ 1100 | 100 |          .0000000 |  2 | 01-01-1401 | 40 |          .0000000 | 2400 |          .0000000
     1 | 200 |          .0000000 |  1 | 03-01-1401 | 10 |          .0000000 |    0 |          .0000000
     1 | 200 |          .0000000 |  3 | 04-01-1401 | 40 |          .0000000 |    0 |          .0000000
+    1 | 100 |          .0000000 |  1 | 05-01-1401 | 20 |          .0000000 |    0 |          .0000000
     1 | 300 |          .0000000 |  1 | 05-02-1401 | 30 |          .0000000 |    0 |          .0000000
     1 | 400 |          .0000000 |  1 | 06-01-1401 | 50 |         1.0000000 |    0 |          .0000000
     1 | 400 |          .0000000 |  2 | 06-01-1401 | 50 |          .0000000 |    0 |          .0000000
-    1 | 700 |         4.0000000 |  4 | 06-01-1401 | 40 |          .0000000 |    1 |          .0000000
-    1 | 800 |         4.0000000 |  4 | 06-01-1401 | 40 |          .0000000 |    1 |          .0000000
    12 | 500 |          .0000000 |  1 | 06-01-1401 | 30 |          .0000000 |    5 |          .0000000
    12 | 500 |         2.9411765 |  3 | 06-01-1401 | 30 |          .0000000 |    5 |          .0000000
    12 | 600 |         2.9411765 |  3 | 06-01-1401 | 30 |          .0000000 |    5 |          .0000000
- 1100 | 100 |          .0000000 |  2 | 01-01-1401 | 40 |          .0000000 | 2400 |          .0000000
+    1 | 700 |         4.0000000 |  4 | 06-01-1401 | 40 |          .0000000 |    1 |          .0000000
+    1 | 800 |         4.0000000 |  4 | 06-01-1401 | 40 |          .0000000 |    1 |          .0000000
 (12 rows)
 
 -- REGR_SLOPE() function with partition by and order by having range based framing clause in combination with other functions--
@@ -4189,15 +4190,15 @@ win5 as (partition by cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.cn order
  10 |    0 |  1 | 200 |          .0000000 |          .0000000 | 03-01-1401 |    1 |          .0000000 |         3.0000000 |         1.0000000
  20 |    0 |  1 | 100 |          .0000000 |          .0000000 | 05-01-1401 |    1 |          .0000000 |         1.0000000 |         1.0000000
  30 |    0 |  1 | 300 |          .0000000 |          .0000000 | 05-02-1401 |    1 |          .0000000 |         5.0000000 |         1.0000000
- 30 |    5 |  1 | 500 |          .2000000 |          .0000000 | 06-01-1401 |   12 |          .0000000 |         8.0000000 |          .0000000
- 30 |    5 |  3 | 500 |          .2000000 |          .0000000 | 06-01-1401 |   12 |          .6363636 |         8.0000000 |          .0000000
- 30 |    5 |  3 | 600 |          .2666667 |          .0000000 | 06-01-1401 |   12 |          .6363636 |        10.0000000 |          .0000000
+ 50 |    0 |  1 | 400 |          .0000000 |          .0000000 | 06-01-1401 |    1 |          .0000000 |         6.0000000 |         1.0000000
+ 50 |    0 |  2 | 400 |          .0000000 |          .0000000 | 06-01-1401 |    1 |          .4545455 |         6.0000000 |          .0000000
  40 |    0 |  3 | 200 |         -.0004167 |          .0000000 | 04-01-1401 |    1 |          .6363636 |         3.0000000 |          .0000000
  40 |    1 |  4 | 700 |         -.0006250 |          .0000000 | 06-01-1401 |    1 |          .9090909 |        11.0000000 |          .0000000
  40 |    1 |  4 | 800 |         -.0006945 |          .0000000 | 06-01-1401 |    1 |          .9090909 |        12.0000000 |          .0000000
+ 30 |    5 |  1 | 500 |          .2000000 |          .0000000 | 06-01-1401 |   12 |          .0000000 |         8.0000000 |          .0000000
+ 30 |    5 |  3 | 500 |          .2000000 |          .0000000 | 06-01-1401 |   12 |          .6363636 |         8.0000000 |          .0000000
+ 30 |    5 |  3 | 600 |          .2666667 |          .0000000 | 06-01-1401 |   12 |          .6363636 |        10.0000000 |          .0000000
  40 | 2400 |  2 | 100 |          .0000000 |          .0000000 | 01-01-1401 | 1100 |          .4545455 |         1.0000000 |          .0000000
- 50 |    0 |  1 | 400 |          .0000000 |          .0000000 | 06-01-1401 |    1 |          .0000000 |         6.0000000 |         1.0000000
- 50 |    0 |  2 | 400 |          .0000000 |          .0000000 | 06-01-1401 |    1 |          .4545455 |         6.0000000 |          .0000000
 (12 rows)
 
 -- REGR_SLOPE() function with partition by and order by having rows based framing clause in combination with other functions --
@@ -4221,13 +4222,13 @@ win2 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.dt,cf_ola
 win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc);
  pn  | vn |      to_char      |      to_char      |     dt     |      to_char      |      to_char      | cn 
 -----+----+-------------------+-------------------+------------+-------------------+-------------------+----
- 100 | 20 |          .0000000 |         1.0000000 | 05-01-1401 |          .0000000 |       100.0000000 |  1
  100 | 40 |          .0000000 |          .0000000 | 01-01-1401 |      2400.0000000 |          .0000000 |  2
  200 | 10 |          .0000000 |         1.0000000 | 03-01-1401 |          .0000000 |       200.0000000 |  1
  200 | 40 |          .0000000 |          .0000000 | 04-01-1401 |          .0000000 |       200.0000000 |  3
+ 100 | 20 |          .0000000 |         1.0000000 | 05-01-1401 |          .0000000 |       100.0000000 |  1
  300 | 30 |          .0000000 |         1.0000000 | 05-02-1401 |          .0000000 |       300.0000000 |  1
- 400 | 50 |          .0000000 |          .0000000 | 06-01-1401 |          .0000000 |       400.0000000 |  2
  400 | 50 |          .0000000 |         1.0000000 | 06-01-1401 |          .0000000 |       400.0000000 |  1
+ 400 | 50 |          .0000000 |          .0000000 | 06-01-1401 |          .0000000 |       400.0000000 |  2
  500 | 30 |          .0000000 |          .0000000 | 06-01-1401 |         5.0000000 |          .0000000 |  1
  500 | 30 |          .0000000 |          .0000000 | 06-01-1401 |         5.0000000 |          .0000000 |  3
  600 | 30 |          .0000000 |          .0000000 | 06-01-1401 |         5.0000000 |          .0000000 |  3
@@ -4241,8 +4242,8 @@ TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.pn/cf_olap_windowerr_sale.vn))
 TO_CHAR(COALESCE(ROW_NUMBER() OVER(win2),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc,cf_olap_windowerr_sale.cn asc,cf_olap_windowerr_sale.cn desc rows between current row and floor(cf_olap_windowerr_sale.qty-cf_olap_windowerr_sale.pn) following ),
-win2 as (order by cf_olap_windowerr_sale.cn desc);
-ERROR:  frame ending offset must not be negative  (seg0 slice3 127.0.0.1:40000 pid=16456)
+win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc);
+ERROR:  frame ending offset must not be negative  (seg0 slice2 127.0.0.1:25432 pid=55689)
 -- REGR_SLOPE() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(REGR_SLOPE(floor(cf_olap_windowerr_sale.pn),floor(cf_olap_windowerr_sale.cn/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn,
 TO_CHAR(COALESCE(LAG(cast(floor(cf_olap_windowerr_sale.pn+cf_olap_windowerr_sale.qty) as int),cast (floor(cf_olap_windowerr_sale.prc-cf_olap_windowerr_sale.cn) as int),NULL) OVER(win2),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,
@@ -4252,21 +4253,21 @@ TO_CHAR(COALESCE(DENSE_RANK() OVER(win3),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc,cf_olap_windowerr_sale.pn asc rows between 4 following and 2 following ),
 win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc),
-win3 as (order by cf_olap_windowerr_sale.pn asc);
+win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc);
  prc  | vn |      to_char      | qty  | pn  |      to_char      | cn |      to_char      |      to_char      |      to_char      
 ------+----+-------------------+------+-----+-------------------+----+-------------------+-------------------+-------------------
-    0 | 10 |          .0000000 |    1 | 200 |       201.0000000 |  1 |         4.0000000 |         3.0000000 |         2.0000000
-    0 | 20 |          .0000000 |    1 | 100 |       301.0000000 |  1 |         1.0000000 |         1.0000000 |         1.0000000
-    0 | 30 |          .0000000 |    1 | 300 |       401.0000000 |  1 |         5.0000000 |         5.0000000 |         3.0000000
-    0 | 40 |          .0000000 |    1 | 200 |       401.0000000 |  3 |         3.0000000 |         3.0000000 |         2.0000000
-    0 | 50 |          .0000000 |    1 | 400 |       401.0000000 |  1 |         7.0000000 |         6.0000000 |         4.0000000
-    0 | 50 |          .0000000 |    1 | 400 |       512.0000000 |  2 |         6.0000000 |         6.0000000 |         4.0000000
-    1 | 40 |          .0000000 |    1 | 700 |          .0000000 |  4 |        11.0000000 |        11.0000000 |         7.0000000
-    1 | 40 |          .0000000 |    1 | 800 |          .0000000 |  4 |        12.0000000 |        12.0000000 |         8.0000000
-    5 | 30 |          .0000000 |   12 | 500 |       101.0000000 |  1 |         8.0000000 |         8.0000000 |         5.0000000
-    5 | 30 |          .0000000 |   12 | 500 |       401.0000000 |  3 |         9.0000000 |         8.0000000 |         5.0000000
-    5 | 30 |          .0000000 |   12 | 600 |       512.0000000 |  3 |        10.0000000 |        10.0000000 |         6.0000000
- 2400 | 40 |          .0000000 | 1100 | 100 |          .0000000 |  2 |         2.0000000 |         1.0000000 |         1.0000000
+    0 | 20 |          .0000000 |    1 | 100 |       301.0000000 |  1 |         4.0000000 |         1.0000000 |         4.0000000
+ 2400 | 40 |          .0000000 | 1100 | 100 |          .0000000 |  2 |         1.0000000 |         1.0000000 |         1.0000000
+    0 | 40 |          .0000000 |    1 | 200 |       401.0000000 |  3 |         3.0000000 |         3.0000000 |         3.0000000
+    0 | 10 |          .0000000 |    1 | 200 |       201.0000000 |  1 |         2.0000000 |         3.0000000 |         2.0000000
+    0 | 30 |          .0000000 |    1 | 300 |       401.0000000 |  1 |         5.0000000 |         5.0000000 |         5.0000000
+    0 | 50 |          .0000000 |    1 | 400 |       512.0000000 |  2 |         7.0000000 |         6.0000000 |         7.0000000
+    0 | 50 |          .0000000 |    1 | 400 |       401.0000000 |  1 |         6.0000000 |         6.0000000 |         6.0000000
+    5 | 30 |          .0000000 |   12 | 500 |       101.0000000 |  1 |         8.0000000 |         8.0000000 |         8.0000000
+    5 | 30 |          .0000000 |   12 | 500 |       401.0000000 |  3 |         9.0000000 |         8.0000000 |         9.0000000
+    5 | 30 |          .0000000 |   12 | 600 |       512.0000000 |  3 |        10.0000000 |        10.0000000 |        10.0000000
+    1 | 40 |          .0000000 |    1 | 700 |          .0000000 |  4 |        11.0000000 |        11.0000000 |        11.0000000
+    1 | 40 |          .0000000 |    1 | 800 |          .0000000 |  4 |        12.0000000 |        12.0000000 |        12.0000000
 (12 rows)
 
 -- REGR_SXX() function with ONLY order by having range based framing clause --
@@ -4354,7 +4355,7 @@ TO_CHAR(COALESCE(COUNT(floor(cf_olap_windowerr_sale.prc+cf_olap_windowerr_sale.c
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn AND cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc,cf_olap_windowerr_sale.vn desc rows between current row and floor(cf_olap_windowerr_sale.cn-cf_olap_windowerr_sale.qty) following ),
 win2 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.vn asc);
-ERROR:  frame ending offset must not be negative  (seg1 slice4 127.0.0.1:40001 pid=16955)
+ERROR:  frame ending offset must not be negative
 -- REGR_SXX() function with ONLY order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn, TO_CHAR(COALESCE(REGR_SXX(floor(cf_olap_windowerr_sale.prc),floor(cf_olap_windowerr_sale.qty)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,
 TO_CHAR(COALESCE(CUME_DIST() OVER(win2),0),'99999999.9999999'),
@@ -4366,28 +4367,28 @@ FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_ol
 WINDOW win1 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc,cf_olap_windowerr_sale.vn desc,cf_olap_windowerr_sale.cn asc rows between floor(cf_olap_windowerr_sale.pn) following and unbounded following ),
 win2 as (order by cf_olap_windowerr_sale.vn desc),
 win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc),
-win4 as (partition by cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.vn desc);
+win4 as (partition by cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc);
  qty  | pn  |      to_char      | cn | vn |      to_char      |      to_char      |      to_char      |      to_char      |      to_char      |     dt     
 ------+-----+-------------------+----+----+-------------------+-------------------+-------------------+-------------------+-------------------+------------
-    1 | 100 |          .0000000 |  1 | 20 |          .9166667 |     96000.0000000 |        11.0000000 |          .0000000 |         1.0000000 | 05-01-1401
+ 1100 | 100 |          .0000000 |  2 | 40 |          .5000000 |     96000.0000000 |         6.0000000 |          .0000000 |         1.0000000 | 01-01-1401
     1 | 200 |          .0000000 |  1 | 10 |         1.0000000 |     96000.0000000 |        12.0000000 |          .0000000 |         1.0000000 | 03-01-1401
     1 | 200 |          .0000000 |  3 | 40 |          .5000000 |     96000.0000000 |         6.0000000 |          .0000000 |         1.0000000 | 04-01-1401
+    1 | 100 |          .0000000 |  1 | 20 |          .9166667 |     96000.0000000 |        11.0000000 |          .0000000 |         1.0000000 | 05-01-1401
     1 | 300 |          .0000000 |  1 | 30 |          .8333333 |     96000.0000000 |        10.0000000 |          .0000000 |         1.0000000 | 05-02-1401
-    1 | 400 |          .0000000 |  1 | 50 |          .1666667 |          .0000000 |         2.0000000 |          .0000000 |         2.0000000 | 06-01-1401
-    1 | 400 |          .0000000 |  2 | 50 |          .1666667 |          .0000000 |         2.0000000 |          .0000000 |         1.0000000 | 06-01-1401
-    1 | 700 |          .0000000 |  4 | 40 |          .5000000 |     96000.0000000 |         6.0000000 |          .0000000 |         3.0000000 | 06-01-1401
-    1 | 800 |          .0000000 |  4 | 40 |          .5000000 |     96000.0000000 |         6.0000000 |          .0000000 |         4.0000000 | 06-01-1401
-   12 | 500 |          .0000000 |  1 | 30 |          .8333333 |     96000.0000000 |        10.0000000 |          .0000000 |         7.0000000 | 06-01-1401
-   12 | 500 |          .0000000 |  3 | 30 |          .8333333 |     96000.0000000 |        10.0000000 |          .0000000 |         6.0000000 | 06-01-1401
+    1 | 400 |          .0000000 |  1 | 50 |          .1666667 |          .0000000 |         2.0000000 |          .0000000 |         1.0000000 | 06-01-1401
+    1 | 400 |          .0000000 |  2 | 50 |          .1666667 |          .0000000 |         2.0000000 |          .0000000 |         2.0000000 | 06-01-1401
+   12 | 500 |          .0000000 |  1 | 30 |          .8333333 |     96000.0000000 |        10.0000000 |          .0000000 |         3.0000000 | 06-01-1401
+   12 | 500 |          .0000000 |  3 | 30 |          .8333333 |     96000.0000000 |        10.0000000 |          .0000000 |         4.0000000 | 06-01-1401
    12 | 600 |          .0000000 |  3 | 30 |          .8333333 |     96000.0000000 |        10.0000000 |          .0000000 |         5.0000000 | 06-01-1401
- 1100 | 100 |          .0000000 |  2 | 40 |          .5000000 |     96000.0000000 |         6.0000000 |          .0000000 |         1.0000000 | 01-01-1401
+    1 | 700 |          .0000000 |  4 | 40 |          .5000000 |     96000.0000000 |         6.0000000 |          .0000000 |         6.0000000 | 06-01-1401
+    1 | 800 |          .0000000 |  4 | 40 |          .5000000 |     96000.0000000 |         6.0000000 |          .0000000 |         7.0000000 | 06-01-1401
 (12 rows)
 
 -- REGR_SXX() function with partition by and order by having range based framing clause --
 SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(REGR_SXX(floor(cf_olap_windowerr_sale.prc-cf_olap_windowerr_sale.pn),floor(cf_olap_windowerr_sale.vn+cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product,cf_olap_windowerr_vendor,cf_olap_windowerr_customer WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn AND cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn AND cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.cn asc range floor(cf_olap_windowerr_sale.cn-cf_olap_windowerr_sale.pn) preceding );
-ERROR:  RANGE parameter cannot be negative  (seg1 slice4 rahmaf2-mbp:25433 pid=48131)
+ERROR:  RANGE parameter cannot be negative  (seg0 slice4 127.0.0.1:25432 pid=55689)
 -- REGR_SXX() function with partition by and order by having range based framing clause --
 SELECT cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.dt, TO_CHAR(COALESCE(REGR_SXX(floor(cf_olap_windowerr_sale.qty),floor(cf_olap_windowerr_sale.pn/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product,cf_olap_windowerr_vendor,cf_olap_windowerr_customer WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn AND cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn AND cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn) cf_olap_windowerr_sale
@@ -4399,20 +4400,20 @@ WINDOW win1 as (partition by cf_olap_windowerr_sale.dt order by cf_olap_windower
     0 | 20 | 100 | 05-01-1401 |          .0000000 |  1
     0 | 30 | 300 | 05-02-1401 |          .0000000 |  1
  2400 | 40 | 100 | 01-01-1401 |          .0000000 |  2
-    0 | 50 | 400 | 06-01-1401 |          .0000000 |  1
     5 | 30 | 500 | 06-01-1401 |          .0000000 |  1
+    0 | 50 | 400 | 06-01-1401 |          .0000000 |  1
     0 | 50 | 400 | 06-01-1401 |          .0000000 |  2
     5 | 30 | 500 | 06-01-1401 |          .0000000 |  3
     5 | 30 | 600 | 06-01-1401 |          .0000000 |  3
-    1 | 40 | 800 | 06-01-1401 |          .0000000 |  4
     1 | 40 | 700 | 06-01-1401 |          .0000000 |  4
+    1 | 40 | 800 | 06-01-1401 |          .0000000 |  4
 (12 rows)
 
 -- REGR_SXX() function with partition by and order by having range based framing clause --
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.prc, TO_CHAR(COALESCE(REGR_SXX(floor(cf_olap_windowerr_sale.prc-cf_olap_windowerr_sale.pn),floor(cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.cn asc range between floor(cf_olap_windowerr_sale.qty) preceding and floor(cf_olap_windowerr_sale.qty/cf_olap_windowerr_sale.prc) preceding );
-ERROR:  division by zero  (seg0 slice3 rahmaf2-mbp:25432 pid=48130)
+ERROR:  division by zero  (seg0 slice3 127.0.0.1:25432 pid=55689)
 -- REGR_SXX() function with partition by and order by having range based framing clause in combination with other functions--
 SELECT cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(REGR_SXX(floor(cf_olap_windowerr_sale.qty/cf_olap_windowerr_sale.prc),floor(cf_olap_windowerr_sale.vn-cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.vn,
 TO_CHAR(COALESCE(PERCENT_RANK() OVER(win2),0),'99999999.9999999'),cf_olap_windowerr_sale.pn,
@@ -4420,9 +4421,9 @@ TO_CHAR(COALESCE(ROW_NUMBER() OVER(win2),0),'99999999.9999999'),
 TO_CHAR(COALESCE(LAG(cast(floor(cf_olap_windowerr_sale.prc) as int),cast (floor(cf_olap_windowerr_sale.prc) as int),NULL) OVER(win3),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn AND cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.vn desc range between 4 preceding and current row ),
-win2 as (partition by cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.vn asc),
+win2 as (partition by cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc),
 win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc);
-ERROR:  division by zero  (seg1 slice5 rahmaf2-mbp:25433 pid=48131)
+ERROR:  division by zero  (seg0 slice4 127.0.0.1:25432 pid=55695)
 -- REGR_SXX() function with partition by and order by having range based framing clause in combination with other functions--
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn, TO_CHAR(COALESCE(REGR_SXX(floor(cf_olap_windowerr_sale.vn),floor(cf_olap_windowerr_sale.cn*cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,
 TO_CHAR(COALESCE(LEAD(cast(floor(cf_olap_windowerr_sale.qty/(cf_olap_windowerr_sale.prc+1)) as int),cast (floor(cf_olap_windowerr_sale.qty) as int),NULL) OVER(win2),0),'99999999.9999999'),cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,
@@ -4437,36 +4438,36 @@ win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc),
 win4 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc);
  qty  | pn  | pn  |      to_char      | cn |      to_char      |     dt     | vn |      to_char      |      to_char      |      to_char      |      to_char      
 ------+-----+-----+-------------------+----+-------------------+------------+----+-------------------+-------------------+-------------------+-------------------
-    1 | 100 | 100 |          .0000000 |  1 |          .0000000 | 05-01-1401 | 20 |         1.0000000 |          .0000000 |         1.0000000 |          .0000000
+ 1100 | 100 | 100 |          .0000000 |  2 |          .0000000 | 01-01-1401 | 40 |         1.0000000 |          .0000000 |         1.0000000 |          .0000000
     1 | 200 | 200 |          .0000000 |  1 |          .0000000 | 03-01-1401 | 10 |         1.0000000 |          .0000000 |         1.0000000 |          .0000000
     1 | 200 | 200 |          .0000000 |  3 |          .0000000 | 04-01-1401 | 40 |         1.0000000 |          .0000000 |         1.0000000 |          .0000000
+    1 | 100 | 100 |          .0000000 |  1 |          .0000000 | 05-01-1401 | 20 |         1.0000000 |          .0000000 |         1.0000000 |          .0000000
     1 | 300 | 300 |          .0000000 |  1 |          .0000000 | 05-02-1401 | 30 |         1.0000000 |          .0000000 |         1.0000000 |          .0000000
     1 | 400 | 400 |          .0000000 |  1 |         1.0000000 | 06-01-1401 | 50 |         1.0000000 |          .0000000 |         1.0000000 |          .0000000
     1 | 400 | 400 |          .0000000 |  2 |          .0000000 | 06-01-1401 | 50 |         2.0000000 |          .0000000 |         2.0000000 |          .0000000
-    1 | 700 | 700 |          .0000000 |  4 |          .0000000 | 06-01-1401 | 40 |         1.0000000 |          .0000000 |         1.0000000 |          .0000000
-    1 | 800 | 800 |          .0000000 |  4 |          .0000000 | 06-01-1401 | 40 |         2.0000000 |          .0000000 |         2.0000000 |          .0000000
    12 | 500 | 500 |          .0000000 |  1 |          .0000000 | 06-01-1401 | 30 |         1.0000000 |          .0000000 |         1.0000000 |          .0000000
    12 | 500 | 500 |          .0000000 |  3 |          .0000000 | 06-01-1401 | 30 |         2.0000000 |          .0000000 |         2.0000000 |          .0000000
    12 | 600 | 600 |          .0000000 |  3 |          .0000000 | 06-01-1401 | 30 |         3.0000000 |          .0000000 |         3.0000000 |          .0000000
- 1100 | 100 | 100 |          .0000000 |  2 |          .0000000 | 01-01-1401 | 40 |         1.0000000 |          .0000000 |         1.0000000 |          .0000000
+    1 | 700 | 700 |          .0000000 |  4 |          .0000000 | 06-01-1401 | 40 |         1.0000000 |          .0000000 |         1.0000000 |          .0000000
+    1 | 800 | 800 |          .0000000 |  4 |          .0000000 | 06-01-1401 | 40 |         2.0000000 |          .0000000 |         2.0000000 |          .0000000
 (12 rows)
 
 -- REGR_SXX() function with partition by and order by having rows based framing clause --
 SELECT cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.prc, TO_CHAR(COALESCE(REGR_SXX(floor(cf_olap_windowerr_sale.qty/cf_olap_windowerr_sale.prc),floor(cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn ) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc rows floor(cf_olap_windowerr_sale.cn) preceding );
-ERROR:  division by zero  (seg1 slice3 rahmaf2-mbp:25433 pid=48131)
+ERROR:  division by zero  (seg0 slice3 127.0.0.1:25432 pid=55689)
 -- REGR_SXX() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(REGR_SXX(floor(cf_olap_windowerr_sale.qty+cf_olap_windowerr_sale.qty),floor(cf_olap_windowerr_sale.qty/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,
 TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc,cf_olap_windowerr_sale.pn desc rows current row );
-ERROR:  division by zero  (seg0 slice1 rahmaf2-mbp:25432 pid=48130)
+ERROR:  division by zero  (seg0 slice1 127.0.0.1:25432 pid=55689)
 -- REGR_SXX() function with partition by and order by having rows based framing clause --
 SELECT cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn, TO_CHAR(COALESCE(REGR_SXX(floor(cf_olap_windowerr_sale.vn),floor(cf_olap_windowerr_sale.prc/cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc rows between unbounded preceding and floor(cf_olap_windowerr_sale.prc-cf_olap_windowerr_sale.cn) following );
-ERROR:  frame ending offset must not be negative  (seg0 slice3 127.0.0.1:40000 pid=16456)
+ERROR:  frame ending offset must not be negative  (seg0 slice3 127.0.0.1:25432 pid=55689)
 -- REGR_SXX() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(REGR_SXX(floor(cf_olap_windowerr_sale.pn/cf_olap_windowerr_sale.pn),floor(cf_olap_windowerr_sale.cn+cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn,
 TO_CHAR(COALESCE(LEAD(cast(floor(cf_olap_windowerr_sale.prc-cf_olap_windowerr_sale.prc) as int),cast (floor(cf_olap_windowerr_sale.cn) as int),NULL) OVER(win2),0),'99999999.9999999'),cf_olap_windowerr_sale.qty,
@@ -4481,30 +4482,30 @@ win3 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn order 
 win4 as (partition by cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc);
  vn | cn |      to_char      | prc  |     dt     | pn  |      to_char      | qty  |      to_char      |      to_char      |      to_char      |      to_char      
 ----+----+-------------------+------+------------+-----+-------------------+------+-------------------+-------------------+-------------------+-------------------
- 10 |  1 |          .0000000 |    0 | 03-01-1401 | 200 |          .0000000 |    1 |      -190.0000000 |          .0000000 |       200.0000000 |         1.0000000
- 20 |  1 |          .0000000 |    0 | 05-01-1401 | 100 |          .0000000 |    1 |       -80.0000000 |          .0000000 |       100.0000000 |         1.0000000
- 30 |  1 |          .0000000 |    0 | 05-02-1401 | 300 |          .0000000 |    1 |      -270.0000000 |          .0000000 |       300.0000000 |         1.0000000
+ 40 |  4 |          .0000000 |    1 | 06-01-1401 | 700 |          .0000000 |    1 |      -660.0000000 |          .0000000 |          .0000000 |         1.0000000
+ 40 |  4 |          .0000000 |    1 | 06-01-1401 | 800 |          .0000000 |    1 |      -760.0000000 |          .0000000 |          .0000000 |         1.0000000
  30 |  1 |          .0000000 |    5 | 06-01-1401 | 500 |          .0000000 |   12 |      -470.0000000 |          .0000000 |          .0000000 |         1.0000000
  30 |  3 |          .0000000 |    5 | 06-01-1401 | 500 |          .0000000 |   12 |      -470.0000000 |          .0000000 |          .0000000 |         1.0000000
  30 |  3 |          .0000000 |    5 | 06-01-1401 | 600 |          .0000000 |   12 |      -570.0000000 |          .0000000 |          .0000000 |         1.0000000
- 40 |  2 |          .0000000 | 2400 | 01-01-1401 | 100 |          .0000000 | 1100 |       -60.0000000 |          .0000000 |          .0000000 |         1.0000000
+ 10 |  1 |          .0000000 |    0 | 03-01-1401 | 200 |          .0000000 |    1 |      -190.0000000 |          .0000000 |       200.0000000 |         1.0000000
  40 |  3 |          .0000000 |    0 | 04-01-1401 | 200 |          .0000000 |    1 |      -160.0000000 |          .0000000 |       200.0000000 |         1.0000000
- 40 |  4 |          .0000000 |    1 | 06-01-1401 | 700 |          .0000000 |    1 |      -660.0000000 |          .0000000 |          .0000000 |         1.0000000
- 40 |  4 |          .0000000 |    1 | 06-01-1401 | 800 |          .0000000 |    1 |      -760.0000000 |          .0000000 |          .0000000 |         1.0000000
+ 20 |  1 |          .0000000 |    0 | 05-01-1401 | 100 |          .0000000 |    1 |       -80.0000000 |          .0000000 |       100.0000000 |         1.0000000
+ 30 |  1 |          .0000000 |    0 | 05-02-1401 | 300 |          .0000000 |    1 |      -270.0000000 |          .0000000 |       300.0000000 |         1.0000000
  50 |  1 |          .0000000 |    0 | 06-01-1401 | 400 |          .0000000 |    1 |      -350.0000000 |          .0000000 |       400.0000000 |         1.0000000
  50 |  2 |          .0000000 |    0 | 06-01-1401 | 400 |          .0000000 |    1 |      -350.0000000 |          .0000000 |       400.0000000 |         1.0000000
+ 40 |  2 |          .0000000 | 2400 | 01-01-1401 | 100 |          .0000000 | 1100 |       -60.0000000 |          .0000000 |          .0000000 |         1.0000000
 (12 rows)
 
 -- REGR_SXX() function with partition by and order by having rows based framing clause --
 SELECT cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(REGR_SXX(floor(cf_olap_windowerr_sale.vn/cf_olap_windowerr_sale.prc),floor(cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc rows between current row and 0 following );
-ERROR:  division by zero  (seg2 slice3 rahmaf2-mbp:25434 pid=48132)
+ERROR:  division by zero  (seg2 slice3 127.0.0.1:25434 pid=55691)
 -- REGR_SXX() function with partition by and order by having rows based framing clause --
 SELECT cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.pn, TO_CHAR(COALESCE(REGR_SXX(floor(cf_olap_windowerr_sale.qty*cf_olap_windowerr_sale.prc),floor(cf_olap_windowerr_sale.pn/cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn AND cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc rows between floor(cf_olap_windowerr_sale.prc) following and floor(cf_olap_windowerr_sale.vn-cf_olap_windowerr_sale.pn) following );
-ERROR:  frame ending offset must not be negative  (seg1 slice4 127.0.0.1:40001 pid=16457)
+ERROR:  frame ending offset must not be negative  (seg0 slice3 127.0.0.1:25432 pid=55689)
 -- REGR_SXY() function with OVER() clause having ONLY PARTITION BY in combination with other window functions --
 SELECT cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(REGR_SXY(floor(cf_olap_windowerr_sale.pn),floor(cf_olap_windowerr_sale.qty)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn
 ,
@@ -4515,7 +4516,7 @@ FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_ola
 WINDOW win1 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn),
 win2 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.cn desc),
 win3 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc);
-ERROR:  division by zero  (seg1 slice4 rahmaf2-mbp:25433 pid=48275)
+ERROR:  division by zero  (seg0 slice6 127.0.0.1:25432 pid=55689)
 -- REGR_SXY() function with ONLY order by having range based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn, TO_CHAR(COALESCE(REGR_SXY(floor(cf_olap_windowerr_sale.qty),floor(cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,
 TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.pn+cf_olap_windowerr_sale.vn)) OVER(order by cf_olap_windowerr_sale.cn asc range floor(cf_olap_windowerr_sale.qty-cf_olap_windowerr_sale.pn) preceding ),0),'99999999.9999999'),
@@ -4538,14 +4539,14 @@ win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc),
 win3 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc);
      dt     | vn | vn |      to_char      | cn |      to_char      |      to_char      |      to_char      |      to_char      |      to_char      | pn  
 ------------+----+----+-------------------+----+-------------------+-------------------+-------------------+-------------------+-------------------+-----
- 01-01-1401 | 40 | 40 |   1318800.0000000 |  2 |         2.0000000 |         2.0000000 |         2.0000000 |          .0000000 |          .0000000 | 100
  03-01-1401 | 10 | 10 |        44.0000000 |  1 |         5.0000000 |         5.0000000 |         1.0000000 |      3500.0000000 |          .0000000 | 200
- 04-01-1401 | 40 | 40 |        36.6666667 |  3 |         3.0000000 |         3.0000000 |         3.0000000 |          .0000000 |          .0000000 | 200
  05-01-1401 | 20 | 20 |        44.0000000 |  1 |         5.0000000 |         5.0000000 |         1.0000000 |         1.0000000 |          .0000000 | 100
  05-02-1401 | 30 | 30 |        44.0000000 |  1 |         5.0000000 |         5.0000000 |         1.0000000 |         1.0000000 |          .0000000 | 300
- 06-01-1401 | 30 | 30 |        36.6666667 |  3 |         3.0000000 |         3.0000000 |         3.0000000 |         1.0000000 |          .0000000 | 600
- 06-01-1401 | 30 | 30 |        36.6666667 |  3 |         3.0000000 |         3.0000000 |         3.0000000 |      3500.0000000 |          .0000000 | 500
  06-01-1401 | 30 | 30 |        44.0000000 |  1 |         5.0000000 |         5.0000000 |         1.0000000 |         1.0000000 |          .0000000 | 500
+ 06-01-1401 | 30 | 30 |        36.6666667 |  3 |         3.0000000 |         3.0000000 |         3.0000000 |      3500.0000000 |          .0000000 | 500
+ 06-01-1401 | 30 | 30 |        36.6666667 |  3 |         3.0000000 |         3.0000000 |         3.0000000 |         1.0000000 |          .0000000 | 600
+ 01-01-1401 | 40 | 40 |   1318800.0000000 |  2 |         2.0000000 |         2.0000000 |         2.0000000 |          .0000000 |          .0000000 | 100
+ 04-01-1401 | 40 | 40 |        36.6666667 |  3 |         3.0000000 |         3.0000000 |         3.0000000 |          .0000000 |          .0000000 | 200
  06-01-1401 | 40 | 40 |          .0000000 |  4 |         2.0000000 |         2.0000000 |         4.0000000 |         1.0000000 |          .0000000 | 700
  06-01-1401 | 40 | 40 |          .0000000 |  4 |         2.0000000 |         2.0000000 |         4.0000000 |         1.0000000 |          .0000000 | 800
  06-01-1401 | 50 | 50 |        44.0000000 |  1 |         5.0000000 |         5.0000000 |         1.0000000 |         1.0000000 |          .0000000 | 400
@@ -4572,10 +4573,10 @@ win4 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc),
 win5 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc);
  pn  | prc  | pn  | pn  |      to_char      | cn |      to_char      |     dt     | vn |      to_char      |      to_char      |      to_char      |      to_char      
 -----+------+-----+-----+-------------------+----+-------------------+------------+----+-------------------+-------------------+-------------------+-------------------
- 100 |    0 | 100 | 100 |          .0000000 |  1 |         1.0000000 | 05-01-1401 | 20 |         1.0000000 |         1.0000000 |         1.0000000 |          .0000000
  100 | 2400 | 100 | 100 |      3741.4285714 |  2 |         1.0000000 | 01-01-1401 | 40 |         1.0000000 |         2.0000000 |          .0000000 |          .0000000
  200 |    0 | 200 | 200 |          .0000000 |  1 |         1.0000000 | 03-01-1401 | 10 |         1.0000000 |         1.0000000 |         1.0000000 |          .0000000
  200 |    0 | 200 | 200 |          .0000000 |  3 |         1.0000000 | 04-01-1401 | 40 |         1.0000000 |         3.0000000 |         1.0000000 |          .0000000
+ 100 |    0 | 100 | 100 |          .0000000 |  1 |         1.0000000 | 05-01-1401 | 20 |         1.0000000 |         1.0000000 |         1.0000000 |          .0000000
  300 |    0 | 300 | 300 |          .0000000 |  1 |         1.0000000 | 05-02-1401 | 30 |         1.0000000 |         1.0000000 |         1.0000000 |          .0000000
  400 |    0 | 400 | 400 |          .0000000 |  1 |          .5000000 | 06-01-1401 | 50 |         1.0000000 |         1.0000000 |         1.0000000 |          .0000000
  400 |    0 | 400 | 400 |      2100.0000000 |  2 |         1.0000000 | 06-01-1401 | 50 |         2.0000000 |         2.0000000 |         1.0000000 |          .0000000
@@ -4614,23 +4615,23 @@ TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.qty)) OVER(win1),0),'99999999.
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
 WINDOW win1 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc,cf_olap_windowerr_sale.cn asc rows 3 preceding ),
 win2 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc),
-win3 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.vn desc),
+win3 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc),
 win4 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.dt order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc),
 win5 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc);
  vn | qty  | pn  | cn |      to_char      |      to_char      |      to_char      |      to_char      |     dt     |      to_char      |      to_char      
 ----+------+-----+----+-------------------+-------------------+-------------------+-------------------+------------+-------------------+-------------------
- 10 |    1 | 200 |  1 |     29970.0000000 |          .0000000 |         1.0000000 |          .0000000 | 03-01-1401 |         2.0000000 |      1100.0000000
+ 40 | 1100 | 100 |  2 |          .0000000 |          .0000000 |         1.0000000 |          .0000000 | 01-01-1401 |          .0000000 |      1100.0000000
  20 |    1 | 100 |  1 |     26475.0000000 |          .0000000 |         1.0000000 |          .0000000 | 05-01-1401 |         2.0000000 |      1100.0000000
+ 10 |    1 | 200 |  1 |     29970.0000000 |          .0000000 |         1.0000000 |          .0000000 | 03-01-1401 |         2.0000000 |      1100.0000000
+ 40 |    1 | 200 |  3 |     19980.0000000 |          .0000000 |         1.0000000 |          .0000000 | 04-01-1401 |         2.0000000 |      1100.0000000
  30 |    1 | 300 |  1 |      2000.0000000 |          .0000000 |         1.0000000 |          .0000000 | 05-02-1401 |         2.0000000 |         1.0000000
+ 50 |    1 | 400 |  1 |      8000.0000000 |          .0000000 |         1.0000000 |          .0000000 | 06-01-1401 |         2.0000000 |         1.0000000
+ 50 |    1 | 400 |  2 |     12000.0000000 |          .0000000 |         1.0000000 |          .0000000 | 06-01-1401 |         2.0000000 |         1.0000000
  30 |   12 | 500 |  1 |      -220.0000000 |          .0000000 |         1.0000000 |          .0000000 | 06-01-1401 |          .0000000 |        12.0000000
  30 |   12 | 500 |  3 |     -4440.0000000 |          .0000000 |         1.0000000 |          .0000000 | 06-01-1401 |          .0000000 |        12.0000000
  30 |   12 | 600 |  3 |     -4330.0000000 |          .0000000 |         1.0000000 |          .0000000 | 06-01-1401 |          .0000000 |        12.0000000
- 40 |    1 | 200 |  3 |     19980.0000000 |          .0000000 |         1.0000000 |          .0000000 | 04-01-1401 |         2.0000000 |      1100.0000000
  40 |    1 | 700 |  4 |      2335.0000000 |          .0000000 |         1.0000000 |          .0000000 | 06-01-1401 |          .0000000 |        12.0000000
  40 |    1 | 800 |  4 |      3780.0000000 |          .0000000 |         1.0000000 |          .0000000 | 06-01-1401 |          .0000000 |        12.0000000
- 40 | 1100 | 100 |  2 |          .0000000 |          .0000000 |         1.0000000 |          .0000000 | 01-01-1401 |          .0000000 |      1100.0000000
- 50 |    1 | 400 |  1 |      8000.0000000 |          .0000000 |         1.0000000 |          .0000000 | 06-01-1401 |         2.0000000 |         1.0000000
- 50 |    1 | 400 |  2 |     12000.0000000 |          .0000000 |         1.0000000 |          .0000000 | 06-01-1401 |         2.0000000 |         1.0000000
 (12 rows)
 
 -- REGR_SXY() function with ONLY order by having rows based framing clause --
@@ -4647,7 +4648,7 @@ ERROR:  frame ending offset must not be negative
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(REGR_SXY(floor(cf_olap_windowerr_sale.qty+cf_olap_windowerr_sale.prc),floor(cf_olap_windowerr_sale.pn/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn AND cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.cn asc range unbounded preceding );
-ERROR:  division by zero  (seg0 slice3 rahmaf2-mbp:25432 pid=48130)
+ERROR:  division by zero  (seg0 slice3 127.0.0.1:25432 pid=55689)
 -- REGR_SXY() function with partition by and order by having range based framing clause in combination with other functions--
 SELECT cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.dt, TO_CHAR(COALESCE(REGR_SXY(floor(cf_olap_windowerr_sale.cn),floor(cf_olap_windowerr_sale.qty)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn,
 TO_CHAR(COALESCE(DENSE_RANK() OVER(win2),0),'99999999.9999999'),
@@ -4662,14 +4663,14 @@ win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc),
 win4 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc);
      dt     | vn |     dt     |      to_char      | cn | pn  |      to_char      |      to_char      |      to_char      |      to_char      |      to_char      
 ------------+----+------------+-------------------+----+-----+-------------------+-------------------+-------------------+-------------------+-------------------
- 01-01-1401 | 40 | 01-01-1401 |          .0000000 |  2 | 100 |         1.0000000 |         1.0000000 |          .0000000 |         1.0000000 |          .0000000
  03-01-1401 | 10 | 03-01-1401 |          .0000000 |  1 | 200 |         1.0000000 |         1.0000000 |        40.0000000 |         2.0000000 |          .0000000
- 04-01-1401 | 40 | 04-01-1401 |          .0000000 |  3 | 200 |         1.0000000 |         1.0000000 |          .0000000 |         3.0000000 |          .0000000
  05-01-1401 | 20 | 05-01-1401 |          .0000000 |  1 | 100 |         1.0000000 |         1.0000000 |          .0000000 |         4.0000000 |          .0000000
  05-02-1401 | 30 | 05-02-1401 |          .0000000 |  1 | 300 |         1.0000000 |         1.0000000 |          .0000000 |         5.0000000 |          .0000000
  06-01-1401 | 30 | 06-01-1401 |          .0000000 |  1 | 500 |         1.0000000 |         1.0000000 |          .0000000 |         8.0000000 |          .0000000
  06-01-1401 | 30 | 06-01-1401 |          .0000000 |  3 | 500 |         1.0000000 |         1.0000000 |          .0000000 |         9.0000000 |          .0000000
  06-01-1401 | 30 | 06-01-1401 |          .0000000 |  3 | 600 |         1.0000000 |         1.0000000 |          .0000000 |        10.0000000 |          .0000000
+ 01-01-1401 | 40 | 01-01-1401 |          .0000000 |  2 | 100 |         1.0000000 |         1.0000000 |          .0000000 |         1.0000000 |          .0000000
+ 04-01-1401 | 40 | 04-01-1401 |          .0000000 |  3 | 200 |         1.0000000 |         1.0000000 |          .0000000 |         3.0000000 |          .0000000
  06-01-1401 | 40 | 06-01-1401 |          .0000000 |  4 | 700 |         1.0000000 |         1.0000000 |          .0000000 |        11.0000000 |          .0000000
  06-01-1401 | 40 | 06-01-1401 |          .0000000 |  4 | 800 |         1.0000000 |         1.0000000 |          .0000000 |        12.0000000 |          .0000000
  06-01-1401 | 50 | 06-01-1401 |          .0000000 |  1 | 400 |         1.0000000 |         1.0000000 |          .0000000 |         6.0000000 |          .0000000
@@ -4687,18 +4688,18 @@ win2 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn,cf_ola
 win3 as (partition by cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.pn asc);
  cn | vn | vn |      to_char      | prc  |      to_char      |     dt     | pn  |      to_char      |      to_char      
 ----+----+----+-------------------+------+-------------------+------------+-----+-------------------+-------------------
-  1 | 10 | 10 |          .0000000 |    0 |          .0000000 | 03-01-1401 | 200 |         2.0000000 |         2.0000000
-  1 | 20 | 20 |          .0000000 |    0 |          .0000000 | 05-01-1401 | 100 |         1.0000000 |         1.0000000
-  1 | 30 | 30 |          .0000000 |    0 |          .0000000 | 05-02-1401 | 300 |         3.0000000 |         4.0000000
-  1 | 30 | 30 |          .0000000 |    5 |          .0000000 | 06-01-1401 | 500 |         1.0000000 |         1.0000000
-  1 | 50 | 50 |          .0000000 |    0 |          .0000000 | 06-01-1401 | 400 |         4.0000000 |         5.0000000
-  2 | 40 | 40 |          .0000000 | 2400 |          .0000000 | 01-01-1401 | 100 |         1.0000000 |         1.0000000
-  2 | 50 | 50 |          .0000000 |    0 |        51.0000000 | 06-01-1401 | 400 |         4.0000000 |         5.0000000
-  3 | 30 | 30 |          .0000000 |    5 |          .0000000 | 06-01-1401 | 500 |         1.0000000 |         1.0000000
-  3 | 30 | 30 |          .0000000 |    5 |          .0000000 | 06-01-1401 | 600 |         2.0000000 |         3.0000000
-  3 | 40 | 40 |          .0000000 |    0 |          .0000000 | 04-01-1401 | 200 |         2.0000000 |         2.0000000
   4 | 40 | 40 |          .0000000 |    1 |        41.0000000 | 06-01-1401 | 700 |         1.0000000 |         1.0000000
   4 | 40 | 40 |          .0000000 |    1 |        41.0000000 | 06-01-1401 | 800 |         2.0000000 |         2.0000000
+  3 | 30 | 30 |          .0000000 |    5 |          .0000000 | 06-01-1401 | 500 |         1.0000000 |         1.0000000
+  1 | 30 | 30 |          .0000000 |    5 |          .0000000 | 06-01-1401 | 500 |         1.0000000 |         1.0000000
+  3 | 30 | 30 |          .0000000 |    5 |          .0000000 | 06-01-1401 | 600 |         2.0000000 |         3.0000000
+  1 | 20 | 20 |          .0000000 |    0 |          .0000000 | 05-01-1401 | 100 |         1.0000000 |         1.0000000
+  3 | 40 | 40 |          .0000000 |    0 |          .0000000 | 04-01-1401 | 200 |         2.0000000 |         2.0000000
+  1 | 10 | 10 |          .0000000 |    0 |          .0000000 | 03-01-1401 | 200 |         2.0000000 |         2.0000000
+  1 | 30 | 30 |          .0000000 |    0 |          .0000000 | 05-02-1401 | 300 |         3.0000000 |         4.0000000
+  2 | 50 | 50 |          .0000000 |    0 |        51.0000000 | 06-01-1401 | 400 |         4.0000000 |         5.0000000
+  1 | 50 | 50 |          .0000000 |    0 |          .0000000 | 06-01-1401 | 400 |         4.0000000 |         5.0000000
+  2 | 40 | 40 |          .0000000 | 2400 |          .0000000 | 01-01-1401 | 100 |         1.0000000 |         1.0000000
 (12 rows)
 
 -- REGR_SXY() function with partition by and order by having range based framing clause in combination with other functions--
@@ -4711,9 +4712,9 @@ TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.qty)) OVER(order by cf_olap_wi
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn ) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.pn desc range between floor(cf_olap_windowerr_sale.cn) preceding and 1 following ),
 win2 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc),
-win3 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.vn asc),
+win3 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc),
 win4 as (order by cf_olap_windowerr_sale.pn asc);
-ERROR:  division by zero  (seg0 slice5 rahmaf2-mbp:25432 pid=48130)
+ERROR:  division by zero  (seg1 slice2 127.0.0.1:25433 pid=55690)
 -- REGR_SXY() function with partition by and order by having range based framing clause in combination with other functions--
 SELECT cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.dt, TO_CHAR(COALESCE(REGR_SXY(floor(cf_olap_windowerr_sale.qty/cf_olap_windowerr_sale.prc),floor(cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn,
 TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.vn/cf_olap_windowerr_sale.qty)) OVER(partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty order by cf_olap_windowerr_sale.pn desc range between current row and current row ),0),'99999999.9999999'),
@@ -4724,12 +4725,12 @@ FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_ola
 WINDOW win1 as (partition by cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty order by cf_olap_windowerr_sale.pn desc range between current row and current row ),
 win2 as (order by cf_olap_windowerr_sale.pn asc),
 win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc);
-ERROR:  division by zero  (seg0 slice5 rahmaf2-mbp:25432 pid=48130)
+ERROR:  division by zero  (seg0 slice5 127.0.0.1:25432 pid=55689)
 -- REGR_SXY() function with partition by and order by having range based framing clause --
 SELECT cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn, TO_CHAR(COALESCE(REGR_SXY(floor(cf_olap_windowerr_sale.qty/cf_olap_windowerr_sale.qty),floor(cf_olap_windowerr_sale.cn+cf_olap_windowerr_sale.qty)) OVER(win1),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn AND cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.pn desc range between floor(cf_olap_windowerr_sale.cn-cf_olap_windowerr_sale.qty) following and floor(cf_olap_windowerr_sale.vn*cf_olap_windowerr_sale.prc) following );
-ERROR:  RANGE parameter cannot be negative  (seg0 slice4 rahmaf2-mbp:25432 pid=48130)
+ERROR:  RANGE parameter cannot be negative  (seg0 slice4 127.0.0.1:25432 pid=55689)
 -- REGR_SXY() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.dt, TO_CHAR(COALESCE(REGR_SXY(floor(cf_olap_windowerr_sale.vn/cf_olap_windowerr_sale.vn),floor(cf_olap_windowerr_sale.pn/cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,
 TO_CHAR(COALESCE(MAX(floor(cf_olap_windowerr_sale.vn*cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),
@@ -4740,8 +4741,8 @@ TO_CHAR(COALESCE(COUNT(floor(cf_olap_windowerr_sale.cn*cf_olap_windowerr_sale.pr
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc,cf_olap_windowerr_sale.cn desc rows current row ),
 win2 as (partition by cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc),
-win3 as (order by cf_olap_windowerr_sale.cn desc);
-ERROR:  division by zero  (seg1 slice3 rahmaf2-mbp:25433 pid=48131)
+win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc);
+ERROR:  division by zero  (seg0 slice3 127.0.0.1:25432 pid=55689)
 -- REGR_SXY() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(REGR_SXY(floor(cf_olap_windowerr_sale.qty*cf_olap_windowerr_sale.prc),floor(cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,
 TO_CHAR(COALESCE(LEAD(cast(floor(cf_olap_windowerr_sale.pn) as int),cast (floor(cf_olap_windowerr_sale.cn*cf_olap_windowerr_sale.prc) as int),NULL) OVER(win2),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,
@@ -4752,9 +4753,9 @@ TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.pn*cf_olap_windowerr_sale.cn))
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn AND cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn desc,cf_olap_windowerr_sale.vn desc rows between unbounded preceding and floor(cf_olap_windowerr_sale.cn-cf_olap_windowerr_sale.pn) preceding ),
 win2 as (partition by cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn desc),
-win3 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.cn desc),
+win3 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.prc order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc),
 win4 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc);
-ERROR:  frame ending offset must not be negative  (seg0 slice4 127.0.0.1:40000 pid=16767)
+ERROR:  frame ending offset must not be negative  (seg0 slice3 127.0.0.1:25432 pid=55715)
 -- REGR_SXY() function with partition by and order by having rows based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(REGR_SXY(floor(cf_olap_windowerr_sale.prc),floor(cf_olap_windowerr_sale.prc/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.prc,
 TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.qty/cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999'),
@@ -4762,7 +4763,7 @@ TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.vn/cf_olap_windowerr_sale.cn))
 TO_CHAR(COALESCE(MIN(floor(cf_olap_windowerr_sale.cn*cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.cn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc rows between current row and current row );
-ERROR:  division by zero  (seg0 slice2 rahmaf2-mbp:25432 pid=48130)
+ERROR:  division by zero  (seg0 slice2 127.0.0.1:25432 pid=55689)
 -- REGR_SYY() function with ONLY order by having range based framing clause in combination with other functions --
 SELECT cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.qty, TO_CHAR(COALESCE(REGR_SYY(floor(cf_olap_windowerr_sale.cn*cf_olap_windowerr_sale.vn),floor(cf_olap_windowerr_sale.cn*cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.pn,
 TO_CHAR(COALESCE(LEAD(cast(floor(cf_olap_windowerr_sale.cn+cf_olap_windowerr_sale.qty) as int),cast (floor(cf_olap_windowerr_sale.vn-cf_olap_windowerr_sale.qty) as int),NULL) OVER(win2),0),'99999999.9999999'),
@@ -4777,16 +4778,16 @@ win3 as (order by cf_olap_windowerr_sale.vn asc);
 ----+------+------------+----+------+-------------------+-----+-------------------+-------------------+-------------------+-------------------
   1 |    0 | 03-01-1401 | 10 |    1 |      8075.0000000 | 200 |         5.0000000 |         2.0000000 |          .0909091 |          .0000000
   1 |    0 | 05-01-1401 | 20 |    1 |      1800.0000000 | 100 |          .0000000 |         4.0000000 |          .2727273 |          .0909091
-  1 |    0 | 05-02-1401 | 30 |    1 |      8680.0000000 | 300 |          .0000000 |         5.0000000 |          .3636364 |          .1818182
-  1 |    0 | 06-01-1401 | 50 |    1 |     10685.7142857 | 400 |          .0000000 |         6.0000000 |          .4545455 |          .9090909
   1 |    5 | 06-01-1401 | 30 |   12 |     12488.8888889 | 500 |          .0000000 |         8.0000000 |          .6363636 |          .1818182
-  2 |    0 | 06-01-1401 | 50 |    1 |     10685.7142857 | 400 |          .0000000 |         7.0000000 |          .5454545 |          .9090909
-  2 | 2400 | 01-01-1401 | 40 | 1100 |      1800.0000000 | 100 |          .0000000 |         1.0000000 |          .0000000 |          .5454545
-  3 |    0 | 04-01-1401 | 40 |    1 |      8075.0000000 | 200 |          .0000000 |         3.0000000 |          .1818182 |          .5454545
-  3 |    5 | 06-01-1401 | 30 |   12 |     12488.8888889 | 500 |          .0000000 |         9.0000000 |          .7272727 |          .1818182
   3 |    5 | 06-01-1401 | 30 |   12 |     13360.0000000 | 600 |          .0000000 |        10.0000000 |          .8181818 |          .1818182
-  4 |    1 | 06-01-1401 | 40 |    1 |     22090.9090909 | 700 |          .0000000 |        11.0000000 |          .9090909 |          .5454545
+  1 |    0 | 05-02-1401 | 30 |    1 |      8680.0000000 | 300 |          .0000000 |         5.0000000 |          .3636364 |          .1818182
+  3 |    5 | 06-01-1401 | 30 |   12 |     12488.8888889 | 500 |          .0000000 |         9.0000000 |          .7272727 |          .1818182
+  3 |    0 | 04-01-1401 | 40 |    1 |      8075.0000000 | 200 |          .0000000 |         3.0000000 |          .1818182 |          .5454545
+  2 | 2400 | 01-01-1401 | 40 | 1100 |      1800.0000000 | 100 |          .0000000 |         1.0000000 |          .0000000 |          .5454545
   4 |    1 | 06-01-1401 | 40 |    1 |     29366.6666667 | 800 |          .0000000 |        12.0000000 |         1.0000000 |          .5454545
+  4 |    1 | 06-01-1401 | 40 |    1 |     22090.9090909 | 700 |          .0000000 |        11.0000000 |          .9090909 |          .5454545
+  1 |    0 | 06-01-1401 | 50 |    1 |     10685.7142857 | 400 |          .0000000 |         6.0000000 |          .4545455 |          .9090909
+  2 |    0 | 06-01-1401 | 50 |    1 |     10685.7142857 | 400 |          .0000000 |         7.0000000 |          .5454545 |          .9090909
 (12 rows)
 
 -- REGR_SYY() function with ONLY order by having range based framing clause in combination with other functions --
@@ -4801,10 +4802,10 @@ win2 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_ola
 win3 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn desc);
  pn  | qty  | cn |      to_char      |      to_char      | vn |      to_char      |      to_char      |      to_char      
 -----+------+----+-------------------+-------------------+----+-------------------+-------------------+-------------------
- 100 |    1 |  1 |          .0000000 |          .0000000 | 20 |         1.0000000 |         1.0000000 |          .0000000
  100 | 1100 |  2 |    580000.0000000 |          .0000000 | 40 |         1.0000000 |      1100.0000000 |          .0000000
  200 |    1 |  1 |          .0000000 |          .0000000 | 10 |         1.0000000 |         1.0000000 |   2640000.0000000
  200 |    1 |  3 |          .0000000 |          .0000000 | 40 |         1.0000000 |         1.0000000 |          .0000000
+ 100 |    1 |  1 |          .0000000 |          .0000000 | 20 |         1.0000000 |         1.0000000 |          .0000000
  300 |    1 |  1 |          .0000000 |          .0000000 | 30 |         1.0000000 |         1.0000000 |          .0000000
  400 |    1 |  1 |          .0000000 |          .0000000 | 50 |          .5000000 |         1.0000000 |          .0000000
  400 |    1 |  2 |          .0000000 |          .0000000 | 50 |         1.0000000 |         1.0000000 |          .0000000
@@ -4857,7 +4858,7 @@ ERROR:  division by zero
 SELECT cf_olap_windowerr_sale.cn, TO_CHAR(COALESCE(REGR_SYY(floor(cf_olap_windowerr_sale.cn),floor(cf_olap_windowerr_sale.cn-cf_olap_windowerr_sale.qty)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.vn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn ) cf_olap_windowerr_sale
 WINDOW win1 as (order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc,cf_olap_windowerr_sale.cn asc,cf_olap_windowerr_sale.vn asc rows between floor(cf_olap_windowerr_sale.qty/cf_olap_windowerr_sale.prc) preceding and 8 following );
-ERROR:  division by zero  (seg0 slice2 rahmaf2-mbp:25432 pid=48130)
+ERROR:  division by zero  (seg0 slice2 127.0.0.1:25432 pid=55689)
 -- REGR_SYY() function with ONLY order by having rows based framing clause --
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn, TO_CHAR(COALESCE(REGR_SYY(floor(cf_olap_windowerr_sale.qty*cf_olap_windowerr_sale.prc),floor(cf_olap_windowerr_sale.vn+cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.pn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_customer,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.cn=cf_olap_windowerr_customer.cn AND cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
@@ -4893,14 +4894,14 @@ win3 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn order 
   1 | 20 |  1 |    1 |          .0000000 | 100 |          .0000000 |         4.0000000 |          .0000000 |         4.0000000 |         1.0000000
   1 | 30 |  1 |    1 |          .0000000 | 300 |          .0000000 |         5.0000000 |        12.0000000 |         5.0000000 |         1.0000000
   1 | 30 |  1 |   12 |          .0000000 | 500 |          .0000000 |         8.0000000 |        12.0000000 |         8.0000000 |         2.0000000
-  1 | 50 |  1 |    1 |          .0000000 | 400 |          .0000000 |         6.0000000 |         1.0000000 |         6.0000000 |         1.0000000
-  2 | 40 |  2 | 1100 |          .0000000 | 100 |          .0000000 |         1.0000000 |      1100.0000000 |         1.0000000 |         1.0000000
-  2 | 50 |  2 |    1 |          .0000000 | 400 |          .0000000 |         7.0000000 |          .0000000 |         7.0000000 |         2.0000000
   3 | 30 |  3 |   12 |          .0000000 | 500 |          .0000000 |         9.0000000 |        12.0000000 |         9.0000000 |         3.0000000
   3 | 30 |  3 |   12 |          .0000000 | 600 |          .0000000 |        10.0000000 |        12.0000000 |        10.0000000 |         4.0000000
+  2 | 40 |  2 | 1100 |          .0000000 | 100 |          .0000000 |         1.0000000 |      1100.0000000 |         1.0000000 |         1.0000000
   3 | 40 |  3 |    1 |          .0000000 | 200 |          .0000000 |         3.0000000 |          .0000000 |         3.0000000 |         2.0000000
   4 | 40 |  4 |    1 |          .0000000 | 700 |          .0000000 |        11.0000000 |          .0000000 |        11.0000000 |         3.0000000
   4 | 40 |  4 |    1 |          .0000000 | 800 |          .0000000 |        12.0000000 |          .0000000 |        12.0000000 |         4.0000000
+  1 | 50 |  1 |    1 |          .0000000 | 400 |          .0000000 |         6.0000000 |         1.0000000 |         6.0000000 |         1.0000000
+  2 | 50 |  2 |    1 |          .0000000 | 400 |          .0000000 |         7.0000000 |          .0000000 |         7.0000000 |         2.0000000
 (12 rows)
 
 -- REGR_SYY() function with partition by and order by having range based framing clause in combination with other functions--
@@ -4908,7 +4909,7 @@ SELECT cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sa
 TO_CHAR(COALESCE(COUNT(floor(cf_olap_windowerr_sale.pn)) OVER(partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.cn desc range between unbounded preceding and 3 following ),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_vendor WHERE cf_olap_windowerr_sale_ord.vn=cf_olap_windowerr_vendor.vn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.cn desc range between unbounded preceding and 3 following );
-ERROR:  division by zero  (seg0 slice2 rahmaf2-mbp:25432 pid=48130)
+ERROR:  division by zero  (seg0 slice2 127.0.0.1:25432 pid=55689)
 -- REGR_SYY() function with partition by and order by having range based framing clause in combination with other functions--
 SELECT cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn, TO_CHAR(COALESCE(REGR_SYY(floor(cf_olap_windowerr_sale.vn),floor(cf_olap_windowerr_sale.qty+cf_olap_windowerr_sale.vn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,
 TO_CHAR(COALESCE(LEAD(cast(floor(cf_olap_windowerr_sale.vn) as int),cast (floor(cf_olap_windowerr_sale.vn) as int),NULL) OVER(win2),0),'99999999.9999999'),cf_olap_windowerr_sale.qty,
@@ -4916,22 +4917,22 @@ TO_CHAR(COALESCE(CUME_DIST() OVER(win2),0),'99999999.9999999')
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.vn asc range between floor(cf_olap_windowerr_sale.qty-cf_olap_windowerr_sale.vn) preceding and 1 following ),
 win2 as (partition by cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc);
-ERROR:  RANGE parameter cannot be negative  (seg2 slice3 rahmaf2-mbp:25434 pid=48132)
+ERROR:  RANGE parameter cannot be negative  (seg0 slice2 127.0.0.1:25432 pid=55689)
 -- REGR_SYY() function with partition by and order by having rows based framing clause --
 SELECT cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.prc,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.prc, TO_CHAR(COALESCE(REGR_SYY(floor(cf_olap_windowerr_sale.vn/cf_olap_windowerr_sale.prc),floor(cf_olap_windowerr_sale.pn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.pn asc rows between unbounded preceding and unbounded following );
-ERROR:  division by zero  (seg0 slice2 rahmaf2-mbp:25432 pid=48130)
+ERROR:  division by zero  (seg0 slice2 127.0.0.1:25432 pid=55689)
 -- REGR_SYY() function with partition by and order by having rows based framing clause --
 SELECT cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.dt, TO_CHAR(COALESCE(REGR_SYY(floor(cf_olap_windowerr_sale.vn),floor(cf_olap_windowerr_sale.vn/cf_olap_windowerr_sale.prc)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.vn asc rows between 8 preceding and current row );
-ERROR:  division by zero  (seg0 slice1 rahmaf2-mbp:25432 pid=48130)
+ERROR:  division by zero  (seg0 slice1 127.0.0.1:25432 pid=55689)
 -- REGR_SYY() function with partition by and order by having rows based framing clause --
 SELECT cf_olap_windowerr_sale.pn, TO_CHAR(COALESCE(REGR_SYY(floor(cf_olap_windowerr_sale.cn+cf_olap_windowerr_sale.prc),floor(cf_olap_windowerr_sale.cn)) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn,cf_olap_windowerr_sale.qty
 FROM (SELECT cf_olap_windowerr_sale_ord.* FROM cf_olap_windowerr_sale_ord,cf_olap_windowerr_product WHERE cf_olap_windowerr_sale_ord.pn=cf_olap_windowerr_product.pn) cf_olap_windowerr_sale
 WINDOW win1 as (partition by cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn,cf_olap_windowerr_sale.qty,cf_olap_windowerr_sale.pn order by cf_olap_windowerr_sale.ord, cf_olap_windowerr_sale.cn asc rows between floor(cf_olap_windowerr_sale.prc-cf_olap_windowerr_sale.pn) preceding and unbounded following );
-ERROR:  frame starting offset must not be negative  (seg0 slice2 rahmaf2-mbp:25432 pid=48130)
+ERROR:  frame starting offset must not be negative  (seg0 slice2 127.0.0.1:25432 pid=55689)
 -- The PRECEDING/FOLLOWING clauses cannot be NULL.
 SELECT sum(g) OVER (ORDER BY g ROWS BETWEEN NULL::int4 PRECEDING AND UNBOUNDED FOLLOWING) from generate_series(1, 5) g;
 ERROR:  frame starting offset must not be null
@@ -5035,16 +5036,16 @@ INSERT INTO qp_filter_test VALUES (10, NULL);
 select j, i, ntile(j) over (partition by j order by i) FROM qp_filter_test;
  j | i  | ntile 
 ---+----+-------
-   |  8 |      
-   | 10 |      
  1 |  1 |     1
  1 |  2 |     1
  1 |  3 |     1
- 2 |    |     2
  2 |  4 |     1
  2 |  6 |     1
+ 2 |    |     2
  3 |  7 |     1
  3 |  9 |     2
+   |  8 |      
+   | 10 |      
 (10 rows)
 
 SELECT ntile(-1) over (order by i) FROM qp_filter_test;


### PR DESCRIPTION
There was a difference in the results between planner and optimizer due
to different value of row_number assigned.

row_number() is inherently non-deterministic in GPDB. For example, for
the following query:

  select row_number() over (partition by b) from foo;

Let's say that foo was not distributed by b. In this case, to compute
the WindowAgg, we would first have to redistribute the table on b (or
gather all the tuples on master). Thus, for rows having the same b
value, the row_number assigned depends on the order in which they are
received by the WindowAgg - which is non-deterministic.

In qp_olap_windowerr.sql tests, we mitigate this by forcing an order on
ord column, which is unique in this context, making it easier to compare
test results.