### PR TITLE
gpperfmon: Document installing a fork of sigar on CentOS 7

### DIFF
--- a/gpAux/gpperfmon/README.md
+++ b/gpAux/gpperfmon/README.md
@@ -8,7 +8,10 @@ Find more information about the architecture on [the wiki page](https://github.c
 
 ### libsigar:
 	https://github.com/hyperic/sigar
-	For macOS:
+	For CentOS 6:
+		yum install sigar-devel
+	For macOS and CentOS 7 (and others):
+	    Use this updated fork: https://github.com/boundary/sigar
 		to build:
 	    `mkdir build && cd build && cmake .. && make && make install`
 


### PR DESCRIPTION
https://github.com/hyperic/sigar is not under active development.

https://github.com/boundary/sigar is a fork that has been somewhat updated. In particular, it has a fix to allow it to compile with GCC 5 and 6.