### PR TITLE
Start running segspace test for wal replication.

### DIFF
--- a/src/test/regress/GNUmakefile
+++ b/src/test/regress/GNUmakefile
@@ -178,9 +178,8 @@ hooktest:
 pg_regress_call = ./pg_regress --inputdir=$(srcdir) --dlpath=. --multibyte=$(MULTIBYTE) $(MAXCONNOPT) $(NOLOCALE) --init-file=$(srcdir)/init_file
 
 # These are currently skipped because they don't work yet for segment wal replication
-# segspace: cannot restart database at the moment
 # filespace: segment wal replication does not handle filespaces yet
-pg_regress_call := $(pg_regress_call) --exclude-tests="segspace_setup segspace segspace_cleanup filespace"
+pg_regress_call := $(pg_regress_call) --exclude-tests="filespace"
 
 check: all
 	$(pg_regress_call) --temp-install=./tmp_check --top-builddir=$(top_builddir) --schedule=$(srcdir)/parallel_schedule 


### PR DESCRIPTION
Now that gpstop/gpstart works for wal replication, remove segspace from
--exclude-tests. filespace is only one remains in --exclude-tests list which
would go away soon as well.