### PR TITLE
Fix bug in ALTER TABLE ADD COLUMN for AOCS

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -1849,6 +1849,20 @@ aocs_addcol_closefiles(AOCSAddColumnDesc desc)
 						  desc->num_newcols, false /* non-empty VPEntry */ );
 }
 
+void
+aocs_addcol_setfirstrownum(AOCSAddColumnDesc desc, int64 firstRowNum)
+{
+       int                     i;
+       for (i = 0; i < desc->num_newcols; ++i)
+       {
+               /*
+                * Next block's first row number.
+                */
+               desc->dsw[i]->blockFirstRowNum = firstRowNum;
+       }
+}
+
+
 /*
  * Force writing new varblock in each segfile open for insert.
  */

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -4969,6 +4969,7 @@ ATAocsWriteNewColumns(
 				 * greater than 1.
 				 */
 				expectedFRN = sdesc->ao_read.current.firstRowNum;
+				aocs_addcol_setfirstrownum(idesc, expectedFRN);
 			}
 			else
 			{

--- a/src/include/cdb/cdbaocsam.h
+++ b/src/include/cdb/cdbaocsam.h
@@ -264,4 +264,6 @@ extern void aocs_addcol_finish(AOCSAddColumnDesc desc);
 extern void aocs_addcol_emptyvpe(
 		Relation rel, AOCSFileSegInfo **segInfos,
 		int32 nseg, int num_newcols);
+extern void aocs_addcol_setfirstrownum(AOCSAddColumnDesc desc,
+		int64 firstRowNum);
 #endif   /* AOCSAM_H */

--- a/src/test/regress/expected/alter_table_aocs.out
+++ b/src/test/regress/expected/alter_table_aocs.out
@@ -736,6 +736,38 @@ select count(*) from pg_attribute where attrelid='aocs_multi_level_part_table'::
 alter table aocs_multi_level_part_table split partition part3 at (date '2011-01-01') into (partition part3, partition part4);
 ERROR:  cannot split partition with child partitions
 HINT:  Try splitting the child partitions.
+-- Test case: alter table add column with FirstRowNumber > 1
+create table aocs_first_row_number (a int, b int) with (appendonly=true, orientation=column);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create index i_aocs_first_row_number on aocs_first_row_number using btree(b);
+-- abort an insert transaction to generate a first row number > 1
+begin;
+insert into aocs_first_row_number select i,i from generate_series(1,100)i;
+abort;
+insert into aocs_first_row_number select i,i from generate_series(101, 200)i;
+alter table aocs_first_row_number add column c int default -1;
+-- At this point, block directory entry for column c starts from first row number = 1, 
+-- which is not the same as first row number for columns a and b.  
+-- correct result using base table
+set enable_seqscan=on;
+set enable_indexscan=off;
+select c from aocs_first_row_number where b = 10;
+ c 
+---
+(0 rows)
+
+set enable_seqscan=off;
+set enable_indexscan=on;
+-- Used to have wrong result using index: this select returns 1 tuple when no tuples should be returned.
+-- expect: same result as scanning the base table
+select c from aocs_first_row_number where b = 10;
+ c 
+---
+(0 rows)
+
+reset enable_seqscan;
+reset enable_indexscan;
 -- cleanup so as not to affect other installcheck tests
 -- (e.g. column_compression).
 set client_min_messages='WARNING';


### PR DESCRIPTION
If the first insert into AOCS table aborted, the visible blocks in the block
directory should be greater than 1. By default, we initialize the
`DatumStreamWriter` with `blockFirstRowNumber=1` for newly added columns. Hence,
the first row numbers are not consistent between the visible blocks. This caused
inconsistency between the base table scan vs. the scan using indexes through
block directory.

This wrong result issue is only happened to the first invisible blocks. The
current code (`aocs_addcol_endblock()` called in `ATAocsWriteNewColumns()`) already
handles other gaps after the first visible blocks.

The fix updates the `blockFirstRowNumber` with `expectedFRN`, and hence fixed the
mis-alignment of visible blocks.

Author: Xin Zhang <xzhang@pivotal.io>
Author: Ashwin Agrawal <aagrawal@pivotal.io>