### PR TITLE
Add TAP tests for client from upstream

### DIFF
--- a/src/bin/initdb/Makefile
+++ b/src/bin/initdb/Makefile
@@ -53,3 +53,9 @@ clean distclean maintainer-clean:
 
 # ensure that changes in datadir propagate into object file
 initdb.o: initdb.c $(top_builddir)/src/Makefile.global
+
+check:
+	$(prove_check)
+
+installcheck:
+	$(prove_installcheck)

--- a/src/bin/initdb/t/001_initdb.pl
+++ b/src/bin/initdb/t/001_initdb.pl
@@ -1,0 +1,50 @@
+# To test successful data directory creation with a additional feature, first
+# try to elaborate the "successful creation" test instead of adding a test.
+# Successful initdb consumes much time and I/O.
+
+use strict;
+use warnings;
+use PostgresNode;
+use TestLib;
+use Test::More tests => 13;
+
+my $tempdir = TestLib::tempdir;
+my $xlogdir = "$tempdir/pgxlog";
+my $datadir = "$tempdir/data";
+
+program_help_ok('initdb');
+program_version_ok('initdb');
+program_options_handling_ok('initdb');
+
+command_fails([ 'initdb', '-S', "$tempdir/nonexistent" ],
+	'sync missing data directory');
+
+mkdir $xlogdir;
+mkdir "$xlogdir/lost+found";
+command_fails(
+	[ 'initdb', '-X', $xlogdir, $datadir ],
+	'existing nonempty xlog directory');
+rmdir "$xlogdir/lost+found";
+command_fails(
+	[ 'initdb', '-X', 'pgxlog', $datadir ],
+	'relative xlog directory not allowed');
+
+#command_fails(
+#	[ 'initdb', '-U', 'pg_test', $datadir ],
+#	'role names cannot begin with "pg_"');
+
+mkdir $datadir;
+
+# make sure we run one successful test without a TZ setting so we test
+# initdb's time zone setting code
+{
+
+	# delete local only works from perl 5.12, so use the older way to do this
+	local (%ENV) = %ENV;
+	delete $ENV{TZ};
+
+	command_ok([ 'initdb', '-T', 'german', '-X', $xlogdir, $datadir ],
+		'successful creation');
+}
+#command_ok([ 'initdb', '-S', $datadir ], 'sync only');
+command_fails([ 'initdb', $datadir ], 'existing data directory');

--- a/src/bin/initdb/t/001_initdb.pl
+++ b/src/bin/initdb/t/001_initdb.pl
@@ -29,6 +29,7 @@ command_fails(
 	[ 'initdb', '-X', 'pgxlog', $datadir ],
 	'relative xlog directory not allowed');
 
+# GPDB_84_MERGE_FIXME: reenable this after -U is ported.
 #command_fails(
 #	[ 'initdb', '-U', 'pg_test', $datadir ],
 #	'role names cannot begin with "pg_"');
@@ -46,5 +47,7 @@ mkdir $datadir;
 	command_ok([ 'initdb', '-T', 'german', '-X', $xlogdir, $datadir ],
 		'successful creation');
 }
+
+# GPDB_84_MERGE_FIXME: reenable this after -S is ported.
 #command_ok([ 'initdb', '-S', $datadir ], 'sync only');
 command_fails([ 'initdb', $datadir ], 'existing data directory');

--- a/src/bin/pg_config/Makefile
+++ b/src/bin/pg_config/Makefile
@@ -53,3 +53,9 @@ uninstall:
 
 clean distclean maintainer-clean:
 	rm -f pg_config$(X) $(OBJS)
+
+check:
+	$(prove_check)
+
+installcheck:
+	$(prove_installcheck)

--- a/src/bin/pg_config/t/001_pg_config.pl
+++ b/src/bin/pg_config/t/001_pg_config.pl
@@ -1,0 +1,16 @@
+use strict;
+use warnings;
+use TestLib;
+use Test::More tests => 20;
+
+program_help_ok('pg_config');
+program_version_ok('pg_config');
+program_options_handling_ok('pg_config');
+command_like([ 'pg_config', '--bindir' ], qr/bin/, 'pg_config single option')
+  ;    # XXX might be wrong
+command_like([ 'pg_config', '--bindir', '--libdir' ],
+	qr/bin.*\n.*lib/, 'pg_config two options');
+command_like([ 'pg_config', '--libdir', '--bindir' ],
+	qr/lib.*\n.*bin/, 'pg_config two options different order');
+command_like(['pg_config'], qr/.*\n.*\n.*/,
+	'pg_config without options prints many lines');

--- a/src/bin/pg_controldata/Makefile
+++ b/src/bin/pg_controldata/Makefile
@@ -36,3 +36,9 @@ uninstall:
 
 clean distclean maintainer-clean:
 	rm -f pg_controldata$(X) $(OBJS)
+
+check:
+	$(prove_check)
+
+installcheck:
+	$(prove_installcheck)

--- a/src/bin/pg_controldata/t/001_pg_controldata.pl
+++ b/src/bin/pg_controldata/t/001_pg_controldata.pl
@@ -1,0 +1,18 @@
+use strict;
+use warnings;
+use PostgresNode;
+use TestLib;
+use Test::More tests => 13;
+
+program_help_ok('pg_controldata');
+program_version_ok('pg_controldata');
+program_options_handling_ok('pg_controldata');
+command_fails(['pg_controldata'], 'pg_controldata without arguments fails');
+command_fails([ 'pg_controldata', 'nonexistent' ],
+	'pg_controldata with nonexistent directory fails');
+
+my $node = get_new_demo_node('main');
+#$node->init;
+
+command_like([ 'pg_controldata', $node->name ],
+	qr/checkpoint/, 'pg_controldata produces output');

--- a/src/bin/pg_controldata/t/001_pg_controldata.pl
+++ b/src/bin/pg_controldata/t/001_pg_controldata.pl
@@ -12,6 +12,9 @@ command_fails([ 'pg_controldata', 'nonexistent' ],
 	'pg_controldata with nonexistent directory fails');
 
 my $node = get_new_demo_node('main');
+
+# GPDB_84_MERGE_FIXME: Seems there already exist demo cluster in
+# GPDB, should we init cluster here or just use demo cluster?
 #$node->init;
 
 command_like([ 'pg_controldata', $node->name ],


### PR DESCRIPTION
The TAP tests added for this commit includes:
initdb, pg_config, pg_controldata. Just did some minor changes to make it
pass for GPDB environment. This is just initial porting, which doesn't require
init/start/stop of GPDB cluster. Will add more client related TAP test cases.
In GPDB environment, I am not sure whether it is a good idea to run init/start/stop
GPDB cluster in each TAP tests seems it requires more memory on single machine because
there exist already a demo cluster.
