### PR TITLE
Add retries using grace period for declaring mirror down.

### DIFF
--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -654,6 +654,7 @@ FtsWalRepInitProbeContext(CdbComponentDatabases *cdbs, fts_context *context)
 		response->result.isMirrorAlive = SEGMENT_IS_ALIVE(mirror);
 		response->result.isInSync = false;
 		response->result.isSyncRepEnabled = false;
+		response->result.retryRequested = false;
 		response->message = FTS_MSG_PROBE;
 
 		response->segment_db_info = primary;

--- a/src/backend/fts/ftsmessagehandler.c
+++ b/src/backend/fts/ftsmessagehandler.c
@@ -55,6 +55,14 @@ SendFtsResponse(FtsResponse *response, const char *messagetype)
 	pq_sendint(&buf, -1, 4);		/* typmod */
 	pq_sendint(&buf, 0, 2);		/* format code */
 
+	pq_sendstring(&buf, "request_retry");
+	pq_sendint(&buf, 0, 4);		/* table oid */
+	pq_sendint(&buf, Anum_fts_message_response_request_retry, 2);		/* attnum */
+	pq_sendint(&buf, BOOLOID, 4);		/* type oid */
+	pq_sendint(&buf, 1, 2);	/* typlen */
+	pq_sendint(&buf, -1, 4);		/* typmod */
+	pq_sendint(&buf, 0, 2);		/* format code */
+
 	pq_endmessage(&buf);
 
 	/* Send a DataRow message */
@@ -69,6 +77,9 @@ SendFtsResponse(FtsResponse *response, const char *messagetype)
 
 	pq_sendint(&buf, 1, 4); /* col3 len */
 	pq_sendint(&buf, response->IsSyncRepEnabled, 1);
+
+	pq_sendint(&buf, 1, 4); /* col4 len */
+	pq_sendint(&buf, response->RequestRetry, 1);
 
 	pq_endmessage(&buf);
 	EndCommand(messagetype, DestRemote);

--- a/src/backend/fts/ftsprobe.c
+++ b/src/backend/fts/ftsprobe.c
@@ -109,11 +109,17 @@ probeRecordResponse(FtsConnectionInfo *ftsInfo, PGresult *result)
 	Assert (isSyncRepEnabled);
 	ftsInfo->result->isSyncRepEnabled = *isSyncRepEnabled;
 
-	write_log("FTS: segment (content=%d, dbid=%d, role=%c) reported isMirrorUp %d, isInSync %d, and isSyncRepEnabled %d to the prober.",
+	int *retryRequested = (int *) PQgetvalue(result, 0,
+											 Anum_fts_message_response_request_retry);
+	Assert (retryRequested);
+	ftsInfo->result->retryRequested = *retryRequested;
+
+	write_log("FTS: segment (content=%d, dbid=%d, role=%c) reported isMirrorUp %d, isInSync %d, isSyncRepEnabled %d and retryRequested %d to the prober.",
 			  ftsInfo->segmentId, ftsInfo->dbId, ftsInfo->role,
 			  ftsInfo->result->isMirrorAlive,
 			  ftsInfo->result->isInSync,
-			  ftsInfo->result->isSyncRepEnabled);
+			  ftsInfo->result->isSyncRepEnabled,
+			  ftsInfo->result->retryRequested);
 }
 
 /*
@@ -213,7 +219,15 @@ ftsReceive(FtsConnectionInfo *ftsInfo)
 	 * the gp_segment_configuration to avoid waiting the fts probe interval.
 	 */
 	if (strcmp(ftsInfo->message, FTS_MSG_PROBE) == 0)
+	{
 		probeRecordResponse(ftsInfo, lastResult);
+		if (ftsInfo->result->retryRequested)
+		{
+			write_log("FTS: primary asked to retry the probe for (content=%d, dbid=%d)",
+					  ftsInfo->segmentId, ftsInfo->dbId);
+			return false;
+		}
+	}
 	/* Primary must have syncrep disabled in response to SYNCREP_OFF message. */
 	AssertImply(strcmp(ftsInfo->message, FTS_MSG_SYNCREP_OFF) == 0,
 				PQgetvalue(lastResult, 0, Anum_fts_message_response_is_syncrep_enabled) != NULL &&

--- a/src/backend/replication/gp_replication.c
+++ b/src/backend/replication/gp_replication.c
@@ -16,6 +16,13 @@
 #include "utils/builtins.h"
 
 /*
+ * If mirror disconnects and re-connects between this period, or just takes
+ * this much time during initial connection of cluster start, it will not get
+ * reported as down to FTS.
+ */
+#define FTS_MARKING_MIRROR_DOWN_GRACE_PERIOD 30 /* secs */
+
+/*
  * Check the WalSndCtl to obtain if mirror is up or down, if the wal sender is
  * in streaming, and if synchronous replication is enabled or not.
  */
@@ -23,6 +30,7 @@ void GetMirrorStatus(FtsResponse *response)
 {
 	response->IsMirrorUp = false;
 	response->IsInSync = false;
+	response->RequestRetry = false;
 
 	/*
 	 * Greenplum currently supports only ONE mirror per primary.
@@ -37,7 +45,24 @@ void GetMirrorStatus(FtsResponse *response)
 		/* use volatile pointer to prevent code rearrangement */
 		volatile WalSnd *walsnd = &WalSndCtl->walsnds[i];
 
-		if (walsnd->pid != 0)
+		if (walsnd->pid == 0)
+		{
+			Assert(walsnd->marked_pid_zero_at_time);
+			pg_time_t delta = ((pg_time_t) time(NULL)) - walsnd->marked_pid_zero_at_time;
+			/*
+			 * Report mirror as down, only if it didn't connect for below
+			 * grace period to primary. This helps to avoid marking mirror
+			 * down unnecessarily when restarting primary or due to small n/w
+			 * glitch. During this period, request FTS to probe again.
+			 */
+			if (delta < FTS_MARKING_MIRROR_DOWN_GRACE_PERIOD)
+			{
+				elog(LOG,
+					 "requesting fts retry as mirror didn't connect yet but in grace period " INT64_FORMAT, delta);
+				response->RequestRetry = true;
+			}
+		}
+		else
 		{
 			if(walsnd->state == WALSNDSTATE_CATCHUP
 			   || walsnd->state == WALSNDSTATE_STREAMING)

--- a/src/include/postmaster/fts.h
+++ b/src/include/postmaster/fts.h
@@ -24,10 +24,11 @@
 #define	FTS_MSG_PROBE "PROBE"
 #define FTS_MSG_SYNCREP_OFF "SYNCREP_OFF"
 
-#define Natts_fts_message_response 3
+#define Natts_fts_message_response 4
 #define Anum_fts_message_response_is_mirror_up 0
 #define Anum_fts_message_response_is_in_sync 1
 #define Anum_fts_message_response_is_syncrep_enabled 2
+#define Anum_fts_message_response_request_retry 3
 
 #define FTS_MESSAGE_RESPONSE_NTUPLES 1
 
@@ -38,6 +39,7 @@ typedef struct
 	bool isMirrorAlive;
 	bool isInSync;
 	bool isSyncRepEnabled;
+	bool retryRequested;
 } probe_result;
 
 typedef struct
@@ -59,6 +61,7 @@ typedef struct FtsResponse
 	bool IsMirrorUp;
 	bool IsInSync;
 	bool IsSyncRepEnabled;
+	bool RequestRetry;
 } FtsResponse;
 
 extern bool am_ftshandler;

--- a/src/include/replication/walsender_private.h
+++ b/src/include/replication/walsender_private.h
@@ -84,6 +84,13 @@ typedef struct WalSnd
 	int			sync_standby_priority;
 
 	bool		synchronous;
+
+	/*
+	 * Records time when PID was set to 0, either during initialization or due
+	 * to disconnection. This helps to detect time passed since mirror didn't
+	 * connect.
+	 */
+	pg_time_t   marked_pid_zero_at_time;
 } WalSnd;
 
 extern WalSnd *MyWalSnd;


### PR DESCRIPTION
If fts detects primary as down, it retries n times before marking it down. But
mirror gets marked as down if connection to primary has not been made or
lost. This surfaced as problem mostly during cluster start (gpstart), where
sequence is to start primary and mirror followed by master. In many instances
when master probed primary, mirror connection was yet to be made and hence up
mirror in configuration unnecessarily got marked down, if if just few secs latr
mirror established connection to primary.

So, to avoid such sitations plus make it little resilient against minor network
glitches, adding variable to record when initialization or disconnection
happened. Using the same on fts probe find now can find how long mirror didn't
showed-up. Only if mirror didn't show-up for allowed period (30 secs) for now
report it was down, else request fts to retry the probe. This logic doesn't
affect regular flow also avoids any waiting in utilties for specific states
after cluster restart.