### PR TITLE
Make newly-added gp_bloat_diag test less sensitive.

### DIFF
--- a/src/test/regress/expected/gp_toolkit.out
+++ b/src/test/regress/expected/gp_toolkit.out
@@ -273,6 +273,17 @@ select * from gp_toolkit.gp_bloat_diag where bdirelid = 'toolkit_skew'::regclass
 ----------+------------+------------+-------------+-------------+---------
 (0 rows)
 
+-- Check that gp_bloat_diag can deal with big numbers. (This used to provoke an
+-- integer overflow error, before the view was fixed to use numerics for all the
+-- calculations.)
+create table wide_width_test as select * from pg_attribute;
+set allow_system_table_mods=dml ;
+update pg_statistic set stawidth=2034567890 where starelid = (select oid from pg_class where relname='test');
+select * from gp_toolkit.gp_bloat_diag WHERE bdinspname <> 'pg_catalog';
+ bdirelid | bdinspname | bdirelname | bdirelpages | bdiexppages | bdidiag 
+----------+------------+------------+-------------+-------------+---------
+(0 rows)
+
 -- MPP-5871 : ERROR: GetSnapshotData timed out waiting for Writer to set the shared snapshot.
 set client_min_messages='warning';
 CREATE TABLE mpp5871_statistics (
@@ -631,20 +642,3 @@ reset session authorization;
 drop database toolkit_testdb;
 drop role toolkit_user1;
 drop role toolkit_admin;
-create database gptoolkit;
-\c gptoolkit
-drop table if exists test;
-NOTICE:  table "test" does not exist, skipping
-create table test as select * from pg_attribute;
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'attrelid' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-set allow_system_table_mods=dml ;
-update pg_statistic set stawidth=2034567890 where starelid = (select oid from pg_class where relname='test');
-select * from gp_toolkit.gp_bloat_diag;
- bdirelid | bdinspname | bdirelname | bdirelpages | bdiexppages |              bdidiag               
-----------+------------+------------+-------------+-------------+------------------------------------
-     2618 | pg_catalog | pg_rewrite |          20 |           6 | moderate amount of bloat suspected
-(1 row)
-
-\c regression
-drop database gptoolkit

--- a/src/test/regress/sql/gp_toolkit.sql
+++ b/src/test/regress/sql/gp_toolkit.sql
@@ -139,6 +139,16 @@ select btdrelpages > 0 as btdrelpages_over_0,
 from gp_toolkit.gp_bloat_expected_pages where btdrelid = 'toolkit_skew'::regclass;
 select * from gp_toolkit.gp_bloat_diag where bdirelid = 'toolkit_skew'::regclass;
 
+
+-- Check that gp_bloat_diag can deal with big numbers. (This used to provoke an
+-- integer overflow error, before the view was fixed to use numerics for all the
+-- calculations.)
+create table wide_width_test as select * from pg_attribute;
+set allow_system_table_mods=dml ;
+update pg_statistic set stawidth=2034567890 where starelid = (select oid from pg_class where relname='test');
+
+select * from gp_toolkit.gp_bloat_diag WHERE bdinspname <> 'pg_catalog';
+
 -- MPP-5871 : ERROR: GetSnapshotData timed out waiting for Writer to set the shared snapshot.
 set client_min_messages='warning';
 CREATE TABLE mpp5871_statistics (
@@ -368,15 +378,3 @@ reset session authorization;
 drop database toolkit_testdb;
 drop role toolkit_user1;
 drop role toolkit_admin;
-
-create database gptoolkit;
-\c gptoolkit
-drop table if exists test;
-create table test as select * from pg_attribute;
-set allow_system_table_mods=dml ;
-update pg_statistic set stawidth=2034567890 where starelid = (select oid from pg_class where relname='test');
-
-select * from gp_toolkit.gp_bloat_diag;
-
-\c regression
-drop database gptoolkit


### PR DESCRIPTION
The test was sensitive to the number of pages in the pg_rewrite system
table's index, for no good reason. Also, don't create a new database for
it, to speed it up, and add a brief comment to explain what the purpose of
the test is.