### PR TITLE
Remove ssh keyscan for github.com

### DIFF
--- a/concourse/scripts/setup_gpadmin_user.bash
+++ b/concourse/scripts/setup_gpadmin_user.bash
@@ -28,7 +28,6 @@ ssh_keyscan_for_user() {
   {
     ssh-keyscan localhost
     ssh-keyscan 0.0.0.0
-    ssh-keyscan github.com
     ssh-keyscan `hostname`
   } >> "${home_dir}/.ssh/known_hosts"
 }


### PR DESCRIPTION
It seems like an automatic keyscan for "github.com" is a developer convenience. Since a keyscan implies a security choice, the end user should choose what to trust, rather than this script.