### PR TITLE
Update default value of optimizer_join_arity_for_associativity_commutativity to 18 [#153423417]

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4601,7 +4601,7 @@ struct config_int ConfigureNamesInt_gp[] =
 			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_join_arity_for_associativity_commutativity,
-		7, 0, INT_MAX, NULL, NULL
+		18, 0, INT_MAX, NULL, NULL
 	},
 
 	{


### PR DESCRIPTION
For TPC-DS query 64, setting `optimizer_join_arity_for_associativity_commutativity` to 18 produces a plan that improves the performance as compared to the previous default value of 7. The remaining TPC-DS queries don't regress due to this change.
This PR updates the default value of `optimizer_join_arity_for_associativity_commutativity` to 18 instead of 7. 