### PR TITLE
Use FtsTestConnection() only if fts_status is initialized. Also some filerep related code cleanup.

### DIFF
--- a/src/backend/commands/vacuumlazy.c
+++ b/src/backend/commands/vacuumlazy.c
@@ -593,10 +593,6 @@ lazy_scan_heap(Relation onerel, LVRelStats *vacrelstats,
 				(errmsg("relation \"%s\" page %u is uninitialized --- fixing",
 						relname, blkno)));
 				PageInit(page, BufferGetPageSize(buf), 0);
-
-				/* must record in xlog so that changetracking will know about this change */
-				log_heap_newpage(onerel, page, blkno);
-
 				empty_pages++;
 			}
 			freespace = PageGetHeapFreeSpace(page);

--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -398,6 +398,7 @@ CdbComponentDatabases *readCdbComponentInfoAndUpdateStatus(MemoryContext probeCo
 		ftsProbeInfo->fts_status[segInfo->dbid] = segStatus;
 	}
 
+	ftsProbeInfo->fts_status_initialized = true;
 	return cdbs;
 }
 

--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -392,9 +392,6 @@ CdbComponentDatabases *readCdbComponentInfoAndUpdateStatus(MemoryContext probeCo
 		if (segInfo->mode == GP_SEGMENT_CONFIGURATION_MODE_INSYNC)
 			segStatus |= FTS_STATUS_SYNCHRONIZED;
 
-		if (segInfo->mode == GP_SEGMENT_CONFIGURATION_MODE_CHANGETRACKING)
-			segStatus |= FTS_STATUS_CHANGELOGGING;
-
 		ftsProbeInfo->fts_status[segInfo->dbid] = segStatus;
 	}
 

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -675,9 +675,6 @@ bool Gp_entry_postmaster = false;
 static int Save_MppLocalProcessCounter = 0;
 static DistributedTransactionTimeStamp Save_DtxStartTime = 0;
 
-/* changetracking size info from cdbresynchronizechangetracking.h */
-extern int64 ChangeTracking_GetTotalSpaceUsedOnDisk(void);
-
 #ifndef WIN32
 /*
  * File descriptors for pipe used to monitor if postmaster is alive.

--- a/src/backend/storage/buffer/bufmgr.c
+++ b/src/backend/storage/buffer/bufmgr.c
@@ -179,23 +179,6 @@ static inline bool ConditionalAcquireContentLock( volatile BufferDesc *buf, LWLo
 }
 
 /*
- * Read Buffer for pages to be Resynced
- */
-Buffer
-ReadBuffer_Resync(SMgrRelation reln, BlockNumber blockNum)
-{
-	bool		isHit;
-
-	return ReadBuffer_common(reln,
-							 false, /* isLocalBuf */
-							 MAIN_FORKNUM,
-							 blockNum,
-							 RBM_NORMAL, /* mode */
-							 NULL,	/* strategy */
-							 &isHit);
-}
-
-/*
  * PrefetchBuffer -- initiate asynchronous read of a block of a relation
  *
  * This is named by analogy to ReadBuffer but doesn't actually allocate a

--- a/src/backend/storage/lmgr/lmgr.c
+++ b/src/backend/storage/lmgr/lmgr.c
@@ -339,60 +339,6 @@ UnlockRelationForExtension(Relation relation, LOCKMODE lockmode)
 	LockRelease(&tag, lockmode, false);
 }
 
-/*
- * Separate routine for LockRelationForExtension() because resync workers do not have relation.  
- */
-void
-LockRelationForResyncExtension(RelFileNode *relFileNode, LOCKMODE lockmode)
-{
-	LOCKTAG		tag;
-	
-	SET_LOCKTAG_RELATION_EXTEND(tag,
-								relFileNode->dbNode,
-								relFileNode->relNode);
-	
-	(void) LockAcquire(&tag, lockmode, false, false);
-}
-
-/*
- * Separate routine for UnlockRelationForExtension() because resync workers do not have relation.
- */
-void
-UnlockRelationForResyncExtension(RelFileNode *relFileNode, LOCKMODE lockmode)
-{
-	LOCKTAG		tag;
-	
-	SET_LOCKTAG_RELATION_EXTEND(tag,
-								relFileNode->dbNode,
-								relFileNode->relNode);
-	
-	LockRelease(&tag, lockmode, false);
-}
-
-void
-LockRelationForResynchronize(RelFileNode *relFileNode, LOCKMODE lockmode)
-{
-	LOCKTAG		tag;
-
-	SET_LOCKTAG_RELATION_RESYNCHRONIZE(tag,
-						 relFileNode->dbNode,
-						 relFileNode->relNode);
-
-	(void) LockAcquire(&tag, lockmode, false, false);
-}
-
-void
-UnlockRelationForResynchronize(RelFileNode *relFileNode, LOCKMODE lockmode)
-{
-	LOCKTAG		tag;
-
-	SET_LOCKTAG_RELATION_RESYNCHRONIZE(tag,
-						 relFileNode->dbNode,
-						 relFileNode->relNode);
-
-	LockRelease(&tag, lockmode, false);
-}
-
 LockAcquireResult
 LockRelationAppendOnlySegmentFile(RelFileNode *relFileNode, int32 segno, LOCKMODE lockmode, bool dontWait)
 {
@@ -863,12 +809,6 @@ DescribeLockTag(StringInfo buf, const LOCKTAG *tag)
 							 tag->locktag_field2,
 							 tag->locktag_field1);
 			break;
-		case LOCKTAG_RELATION_RESYNCHRONIZE:
-			appendStringInfo(buf,
-							 _("resynchronize relation %u of database %u"),
-							 tag->locktag_field1,
-							 tag->locktag_field2);
-			break;
 		case LOCKTAG_RELATION_APPENDONLY_SEGMENT_FILE:
 			appendStringInfo(buf,
 							 _("segment file %u of appendonly relation %u of database %u"),
@@ -941,7 +881,6 @@ LockTagIsTemp(const LOCKTAG *tag)
 		case LOCKTAG_RELATION_EXTEND:
 		case LOCKTAG_PAGE:
 		case LOCKTAG_TUPLE:
-		case LOCKTAG_RELATION_RESYNCHRONIZE:
 		case LOCKTAG_RELATION_APPENDONLY_SEGMENT_FILE:
 			/* check for lock on a temp relation */
 			/* field1 is dboid, field2 is reloid for all of these */

--- a/src/backend/storage/smgr/md.c
+++ b/src/backend/storage/smgr/md.c
@@ -966,11 +966,6 @@ mdtruncate(SMgrRelation reln, ForkNumber forknum, BlockNumber nblocks,
 						nblocks, curnblk)));
 	}
 
-	/*
-	 * Resync issues truncate to mirror only. In that case on primary nblocks
-	 * will be always identical to curnblock since nblocks is allocated while
-	 * holding LockRelationForResyncExtension.
-	 */
 	if (nblocks == curnblk && (forknum != MAIN_FORKNUM))
 		return;					/* no work */
 

--- a/src/backend/utils/adt/lockfuncs.c
+++ b/src/backend/utils/adt/lockfuncs.c
@@ -31,7 +31,6 @@ static const char *const LockTagTypeNames[] = {
 	"tuple",
 	"transactionid",
 	"virtualxid",
-	"resynchronize",
 	"append-only segment file",
 	"object",
 	"resource queue",
@@ -345,7 +344,6 @@ pg_lock_status(PG_FUNCTION_ARGS)
 		{
 			case LOCKTAG_RELATION:
 			case LOCKTAG_RELATION_EXTEND:
-			case LOCKTAG_RELATION_RESYNCHRONIZE:
 				values[1] = ObjectIdGetDatum(lock->tag.locktag_field1);
 				values[2] = ObjectIdGetDatum(lock->tag.locktag_field2);
 				nulls[3] = true;

--- a/src/include/access/twophase.h
+++ b/src/include/access/twophase.h
@@ -83,10 +83,6 @@ extern void RemoveTwoPhaseFile(TransactionId xid, bool giveWarning);
 
 extern void CheckPointTwoPhase(XLogRecPtr redo_horizon);
 
-extern void PrepareIntentAppendOnlyCommitWork(char *gid);
-
-extern void PrepareDecrAppendOnlyCommitWork(char *gid);
-
 extern bool FinishPreparedTransaction(const char *gid, bool isCommit, bool raiseErrorIfNotFound);
 
 extern int TwoPhaseRecoverMirror(void);

--- a/src/include/catalog/gp_segment_config.h
+++ b/src/include/catalog/gp_segment_config.h
@@ -35,10 +35,6 @@
 #define GP_SEGMENT_CONFIGURATION_MODE_INSYNC 's'
 #define GP_SEGMENT_CONFIGURATION_MODE_NOTINSYNC 'n'
 
-#define GP_SEGMENT_CONFIGURATION_MODE_CHANGETRACKING 'c'
-#define GP_SEGMENT_CONFIGURATION_MODE_RESYNC 'r'
-
-
 /* ----------------
  *		gp_segment_configuration definition.  cpp turns this into
  *		typedef struct FormData_gp_segment_configuration

--- a/src/include/cdb/cdbfts.h
+++ b/src/include/cdb/cdbfts.h
@@ -12,27 +12,18 @@
 #include "utils/guc.h"
 #include "cdb/cdbgang.h"
 
-struct FtsSegDBState
-{
-	bool	valid;
-	bool	primary;
-	int16	id;
-};
-
 #define FTS_MAX_DBS (128 * 1024)
 
 #define FTS_STATUS_ALIVE				(1<<0)
 #define FTS_STATUS_PRIMARY				(1<<1)
 #define FTS_STATUS_DEFINEDPRIMARY		(1<<2)
 #define FTS_STATUS_SYNCHRONIZED			(1<<3)
-#define FTS_STATUS_CHANGELOGGING		(1<<4)
 
 #define FTS_STATUS_TEST(dbid, status, flag) (((status)[(dbid)] & (flag)) ? true : false)
 #define FTS_STATUS_ISALIVE(dbid, status) FTS_STATUS_TEST((dbid), (status), FTS_STATUS_ALIVE)
 #define FTS_STATUS_ISPRIMARY(dbid, status) FTS_STATUS_TEST((dbid), (status), FTS_STATUS_PRIMARY)
 #define FTS_STATUS_ISDEFINEDPRIMARY(dbid, status) FTS_STATUS_TEST((dbid), (status), FTS_STATUS_DEFINEDPRIMARY)
 #define FTS_STATUS_IS_SYNCED(dbid, status) FTS_STATUS_TEST((dbid), (status), FTS_STATUS_SYNCHRONIZED)
-#define FTS_STATUS_IS_CHANGELOGGING(dbid, status) FTS_STATUS_TEST((dbid), (status), FTS_STATUS_CHANGELOGGING)
 
 typedef struct FtsProbeInfo
 {

--- a/src/include/cdb/cdbfts.h
+++ b/src/include/cdb/cdbfts.h
@@ -41,6 +41,7 @@ typedef struct FtsProbeInfo
 	volatile uint64		fts_statusVersion;
 	volatile bool		fts_pauseProbes;
 	volatile bool		fts_discardResults;
+	volatile bool       fts_status_initialized;
 	volatile uint8		fts_status[FTS_MAX_DBS];
 } FtsProbeInfo;
 

--- a/src/include/postmaster/fts.h
+++ b/src/include/postmaster/fts.h
@@ -75,7 +75,6 @@ enum probe_result_e
 	PROBE_DEAD            = 0x00,
 	PROBE_ALIVE           = 0x01,
 	PROBE_SEGMENT         = 0x02,
-	PROBE_RESYNC_COMPLETE = 0x04,
 	PROBE_FAULT_CRASH     = 0x08,
 	PROBE_FAULT_MIRROR    = 0x10,
 	PROBE_FAULT_NET       = 0x20,
@@ -85,8 +84,6 @@ enum probe_result_e
 
 #define PROBE_IS_ALIVE(dbInfo) \
 	PROBE_CHECK_FLAG(probe_results[(dbInfo)->dbid], PROBE_ALIVE)
-#define PROBE_IS_RESYNC_COMPLETE(dbInfo) \
-	PROBE_CHECK_FLAG(probe_results[(dbInfo)->dbid], PROBE_RESYNC_COMPLETE)
 #define PROBE_HAS_FAULT_CRASH(dbInfo) \
 	PROBE_CHECK_FLAG(probe_results[(dbInfo)->dbid], PROBE_FAULT_CRASH)
 #define PROBE_HAS_FAULT_MIRROR(dbInfo) \

--- a/src/include/storage/bufmgr.h
+++ b/src/include/storage/bufmgr.h
@@ -170,7 +170,6 @@ extern Buffer ReadBuffer(Relation reln, BlockNumber blockNum);
 extern Buffer ReadBufferExtended(Relation reln, ForkNumber forkNum,
 				   BlockNumber blockNum, ReadBufferMode mode,
 				   BufferAccessStrategy strategy);
-extern Buffer ReadBuffer_Resync(SMgrRelation reln, BlockNumber blockNum);
 extern Buffer ReadBufferWithoutRelcache(RelFileNode rnode, bool isLocalBuf,
 						  ForkNumber forkNum, BlockNumber blockNum,
 						  ReadBufferMode mode, BufferAccessStrategy strategy);

--- a/src/include/storage/lmgr.h
+++ b/src/include/storage/lmgr.h
@@ -42,12 +42,6 @@ extern void UnlockRelationIdForSession(LockRelId *relid, LOCKMODE lockmode);
 /* Lock a relation for extension */
 extern void LockRelationForExtension(Relation relation, LOCKMODE lockmode);
 extern void UnlockRelationForExtension(Relation relation, LOCKMODE lockmode);
-extern void LockRelationForResyncExtension(RelFileNode *relFileNode, LOCKMODE lockmode);
-extern void UnlockRelationForResyncExtension(RelFileNode *relFileNode, LOCKMODE lockmode);
-
-/* Lock a relation for resynchronize */
-extern void LockRelationForResynchronize(RelFileNode *relFileNode, LOCKMODE lockmode);
-extern void UnlockRelationForResynchronize(RelFileNode *relFileNode, LOCKMODE lockmode);
 
 /* Lock a relation for Append-Only segment files. */
 extern LockAcquireResult LockRelationAppendOnlySegmentFile(RelFileNode *relFileNode, int32 segno, LOCKMODE lockmode, bool dontWait);

--- a/src/include/storage/lock.h
+++ b/src/include/storage/lock.h
@@ -192,8 +192,6 @@ typedef enum LockTagType
 	/* ID info for a transaction is its TransactionId */
 	LOCKTAG_VIRTUALTRANSACTION, /* virtual transaction (ditto) */
 	/* ID info for a virtual transaction is its VirtualTransactionId */
-	LOCKTAG_RELATION_RESYNCHRONIZE,			/* whole relation for resynchronize */
-	/* ID info for a relation is DB OID + REL OID; DB OID = 0 if shared */
 	LOCKTAG_RELATION_APPENDONLY_SEGMENT_FILE,	/* Segment file within an Append-Only relation */
 	/* ID info for a relation is DB OID + REL OID + (LOGICAL) SEGMENT FILE # */
 	LOCKTAG_OBJECT,				/* non-relation database object */
@@ -280,14 +278,6 @@ typedef struct LOCKTAG
 	 (locktag).locktag_field3 = 0, \
 	 (locktag).locktag_field4 = 0, \
 	 (locktag).locktag_type = LOCKTAG_VIRTUALTRANSACTION, \
-	 (locktag).locktag_lockmethodid = DEFAULT_LOCKMETHOD)
-
-#define SET_LOCKTAG_RELATION_RESYNCHRONIZE(locktag,dboid,reloid) \
-	((locktag).locktag_field1 = (dboid), \
-	 (locktag).locktag_field2 = (reloid), \
-	 (locktag).locktag_field3 = 0, \
-	 (locktag).locktag_field4 = 0, \
-	 (locktag).locktag_type = LOCKTAG_RELATION_RESYNCHRONIZE, \
 	 (locktag).locktag_lockmethodid = DEFAULT_LOCKMETHOD)
 
 #define SET_LOCKTAG_RELATION_APPENDONLY_SEGMENT_FILE(locktag,dboid,reloid,segno) \

--- a/src/include/storage/proc.h
+++ b/src/include/storage/proc.h
@@ -212,27 +212,6 @@ typedef struct PROC_HDR
  * during normal operation. Startup process also consumes one slot, but WAL
  * writer and autovacuum launcher are launched only after it has exited (4
  * slots).
- *
- * FileRep Process uses 
- *			a) 10 slots on Primary 
- *					1) Sender
- *					2) Receiver Ack
- *					3) Consumer Ack 
- *					4) Recovery 
- *					5) Resync Manager 
- *					6) Resync Worker 1
- *					7) Resync Worker 2
- *					8) Resync Worker 3
- *					9) Resync Worker 4
- *				   10) Verification
- * 
- *			b) 6 slots on Mirror 
- *					1) Receiver 
- *					2) Consumer 
- *					3) Consumer Writer
- *					4) Consumer Append Only
- *					5) Consumer Verification
- *					6) Sender Ack
  */
 #define NUM_AUXILIARY_PROCS	 14
 

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -7,7 +7,7 @@ test: resource_queue
 test: alter_blocks_for_update_and_viceversa
 test: reader_waits_for_lock
 test: drop_rename
-#test: master_panic_after_phase1_commit
+test: master_panic_after_phase1_commit
 
 test: setup
 # Tests on Append-Optimized tables (row-oriented).


### PR DESCRIPTION
commit 3f3faf1f701d8a274a00a71fa096eec07d9e0b29
Author: Ashwin Agrawal <aagrawal@pivotal.io>
Date:   Tue Jan 2 23:27:46 2018 -0800

    Remove prepareAppendOnlyIntentCount and related functions.

commit 70a5ef2a7cd5ee76bc6f8af6c67b76d766d5cc5d
Author: Ashwin Agrawal <aagrawal@pivotal.io>
Date:   Tue Jan 2 23:19:16 2018 -0800

    Remove persistentendxactrec.h

commit d7f0e23ed75cc6ab22aa12e88b5900e300f257bd
Author: Ashwin Agrawal <aagrawal@pivotal.io>
Date:   Tue Jan 2 22:31:28 2018 -0800

    Remove some more references for changetracking and resync

    - Special lock functions for RelationExtension
    - Special function ReadBuffer_Resync()
    - States related to CT and RESYNC
    - Xlog during PageInit() for vacuum lazy (upstream doesn't have it so removed it)

commit 9278e278ee7883c834fbcaea2d347b0af3134e94
Author: Ashwin Agrawal <aagrawal@pivotal.io>
Date:   Tue Jan 2 22:15:10 2018 -0800

    Revert "Disable new added 2PC test as failing in CI."

    This reverts commit 1a27788edfd2163cbfcb1dc30c5eb870eac77181. As should be
    passing now since FTS using uninitialized variable `fts_status` causing the
    failure has been fixed now.

commit f8ef785748430e5dec4c7cb97ff5494251942338
Author: Ashwin Agrawal <aagrawal@pivotal.io>
Date:   Tue Jan 2 17:56:08 2018 -0800

    Use FtsTestConnection() only if fts_status is initialized

    On QD start, FTS process can take sometime to start and initialize the
    `ftsProbeInfo->fts_status`. So, check against the same only if its
    initialized and avoid incorrectly reporting segment as down and
    failing queries.
  