### PR TITLE
(WIP) Don't let primary to act as standby if it was normally shut down.

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -6564,7 +6564,8 @@ StartupXLOG(void)
 		 * it means the standby crashed post promotion but before recovery.conf
 		 * cleanup. Hence, it is not considered a standby request this time.
 		 */
-		if (ControlFile->state == DB_IN_STANDBY_PROMOTED)
+		if (ControlFile->state == DB_IN_STANDBY_PROMOTED ||
+			ControlFile->state == DB_SHUTDOWNED)
 			StandbyModeRequested = false;
 	}
 


### PR DESCRIPTION
 If we add standby master and activate it as primary, there would be a recovery.conf exists. If we gpstop/gpstart, we cannot tell whether it is primary or standby. A convenient way is to use DB_SHUTDOWNED.
There is still working in progress.  Other things should be considered:
1. Seems we should remove recovery.conf or change standby_mod = 'off' after gpactivatestandby calls for promotion successfully.
2. If postmaster crash or by killed, it is not easy for postmaster to tell whether it is primary or standby