### PR TITLE
Revert max_wal_senders bump and move walreceiver test to mirrorless run

### DIFF
--- a/contrib/gp_replica_check/gp_replica_check.c
+++ b/contrib/gp_replica_check/gp_replica_check.c
@@ -217,11 +217,8 @@ sync_wait(void)
 		LWLockAcquire(SyncRepLock, LW_SHARED);
 		for (i = 0; i < max_wal_senders; i++)
 		{
-			/* Ignore standbys that are not connected at the moment */
-			if (WalSndCtl->walsnds[i].pid == 0)
-				continue;
-
-			if (WalSndCtl->walsnds[i].state != WALSNDSTATE_STREAMING
+			if (WalSndCtl->walsnds[i].pid == 0
+				|| WalSndCtl->walsnds[i].state != WALSNDSTATE_STREAMING
 				|| !XLByteLE(ckpt_lsn, WalSndCtl->walsnds[i].apply))
 				break;
 		}

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -1142,12 +1142,8 @@ PostmasterMain(int argc, char *argv[])
 	/*
 	 * This value of max_wal_senders will be inherited by all the child processes
 	 * through fork(). This value is used by XLogIsNeeded().
-	 *
-	 * In a normal setup, each node only has one replica. But have some headroom,
-	 * for other tools that want to use a replication connection, and for hung
-	 * connections, etc.
 	 */
-	max_wal_senders = 5;
+	max_wal_senders = 1;
 
 	if ( GpIdentity.numsegments < 0 )
 	{

--- a/src/test/walrep/Makefile
+++ b/src/test/walrep/Makefile
@@ -8,16 +8,11 @@ include $(top_builddir)/src/Makefile.global
 
 WITH_MIRRORS ?= true
 REGRESS = setup
-# WALREP_FIXME: 'walreceiver' test gets confused now that the QD node has a standby,
-# too, in the default demo cluster. I (= Heikki) think that we should remove the
-# 'walreceiver' test altogether. Tt doesn't seem very useful, now that we have
-# WAL replication working and exercising the walreceiver code anyway.
-#walreceiver
 
 # These two tests can only run without mirrors due to limit of 1
 # walsender-walreceiver connection only
 ifeq ($(WITH_MIRRORS), false)
-REGRESS += generate_ao_xlog generate_aoco_xlog replication_views_mirrorless
+REGRESS += walreceiver generate_ao_xlog generate_aoco_xlog replication_views_mirrorless
 else
 REGRESS += replication_views_mirrored missing_xlog
 endif


### PR DESCRIPTION
We can just skip running the walreceiver test on a mirrored cluster since it doesn't make sense to.

For max_wal_senders bump, @ashwinstar and I think it's unnecessary to bump max_wal_senders until it is actually needed (i.e. many mirrors for one primary).  It's more safe to keep it hardcoded as 1 and makes it simple for our first iteration of wal replication.