### PR TITLE
Set fts_status when updating gp_segment_configuration

### DIFF
--- a/src/backend/cdb/cdbfts.c
+++ b/src/backend/cdb/cdbfts.c
@@ -205,7 +205,7 @@ FtsTestConnection(CdbComponentDatabaseInfo *failedDBInfo, bool fullScan)
 		 * fts_status. We shouldn't be checking against uninitialzed variable.
 		 */
 		if (ftsProbeInfo->fts_status_initialized)
-			return FTS_STATUS_ISALIVE(failedDBInfo->dbid, ftsProbeInfo->fts_status);
+			return FTS_STATUS_IS_UP(ftsProbeInfo->fts_status[failedDBInfo->dbid]);
 
 		return true;
 	}
@@ -214,7 +214,7 @@ FtsTestConnection(CdbComponentDatabaseInfo *failedDBInfo, bool fullScan)
 
 	Assert(ftsProbeInfo->fts_status_initialized);
 
-	return FTS_STATUS_ISALIVE(failedDBInfo->dbid, ftsProbeInfo->fts_status);
+	return FTS_STATUS_IS_UP(ftsProbeInfo->fts_status[failedDBInfo->dbid]);
 }
 
 /*

--- a/src/include/cdb/cdbfts.h
+++ b/src/include/cdb/cdbfts.h
@@ -14,16 +14,21 @@
 
 #define FTS_MAX_DBS (128 * 1024)
 
-#define FTS_STATUS_ALIVE				(1<<0)
-#define FTS_STATUS_PRIMARY				(1<<1)
-#define FTS_STATUS_DEFINEDPRIMARY		(1<<2)
-#define FTS_STATUS_SYNCHRONIZED			(1<<3)
+/*
+ * There used to many more states here but currently dispatch is only checking
+ * if segment is UP or not. So just have that, when needed for other states
+ * this can be extended.
+ */
+#define FTS_STATUS_UP				(1<<0)
 
-#define FTS_STATUS_TEST(dbid, status, flag) (((status)[(dbid)] & (flag)) ? true : false)
-#define FTS_STATUS_ISALIVE(dbid, status) FTS_STATUS_TEST((dbid), (status), FTS_STATUS_ALIVE)
-#define FTS_STATUS_ISPRIMARY(dbid, status) FTS_STATUS_TEST((dbid), (status), FTS_STATUS_PRIMARY)
-#define FTS_STATUS_ISDEFINEDPRIMARY(dbid, status) FTS_STATUS_TEST((dbid), (status), FTS_STATUS_DEFINEDPRIMARY)
-#define FTS_STATUS_IS_SYNCED(dbid, status) FTS_STATUS_TEST((dbid), (status), FTS_STATUS_SYNCHRONIZED)
+#define FTS_STATUS_TEST(status, flag) (((status) & (flag)) ? true : false)
+#define FTS_STATUS_IS_UP(status) FTS_STATUS_TEST((status), FTS_STATUS_UP)
+
+#define FTS_STATUS_SET(status, flag) ((status) |= (flag))
+#define FTS_STATUS_SET_UP(status) FTS_STATUS_SET((status), FTS_STATUS_UP)
+
+#define FTS_STATUS_RESET(status, flag) ((status) &= ~(flag))
+#define FTS_STATUS_SET_DOWN(status) FTS_STATUS_RESET((status), FTS_STATUS_UP)
 
 typedef struct FtsProbeInfo
 {

--- a/src/include/postmaster/fts.h
+++ b/src/include/postmaster/fts.h
@@ -154,8 +154,6 @@ extern void FtsProbeSegments(CdbComponentDatabases *dbs, uint8 *scan_status);
 extern bool FtsIsSegmentAlive(CdbComponentDatabaseInfo *segInfo);
 extern CdbComponentDatabaseInfo *FtsGetPeerSegment(CdbComponentDatabases *cdbs,
 												   int content, int dbid);
-extern void FtsDumpChanges(FtsSegmentStatusChange *changes, int changeEntries);
-
 /*
  * Interface for checking if FTS is active
  */


### PR DESCRIPTION
This change help `FtsTestConnection()` to correctly report segment
state. `probeWalRepPublishUpdate()` updating fts_status if
primary/mirror gets marked as down.

Also, removed all other states and code setting the same as its not
used for anything.