### PR TITLE
Remove use of pg_filespace from gpperfmon

### DIFF
--- a/gpAux/gpperfmon/src/gpmon/gpmondb.c
+++ b/gpAux/gpperfmon/src/gpmon/gpmondb.c
@@ -523,8 +523,7 @@ void gpdb_get_hostlist(int* hostcnt, host_t** host_table, apr_pool_t* global_poo
 	int e;
 
 	// 0 -- hostname, 1 -- address, 2 -- datadir, 3 -- is_master,
-	const char *QUERY = "SELECT distinct hostname, address, case when content < 0 then 1 else 0 end as is_master, MAX(fselocation) as datadir FROM pg_filespace_entry "
-			    "JOIN gp_segment_configuration on (dbid = fsedbid) WHERE fsefsoid = (select oid from pg_filespace where fsname='pg_system') "
+	const char *QUERY = "SELECT distinct hostname, address, case when content < 0 then 1 else 0 end as is_master, MAX(datadir) as datadir FROM gp_segment_configuration "
 		  	    "GROUP BY (hostname, address, is_master) order by hostname";
 
 	if (0 != (e = apr_pool_create_alloc(&pool, NULL)))

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -868,7 +868,7 @@ quantum = 15
 min_query_time = 20
 
 # This should be a percentage between 0 and 100 and should be
-# less than the error_disk_space_percentage.  If a filesystem’s
+# less than the error_disk_space_percentage.  If a filesystem's
 # disk space used percentage equals or exceeds this value a
 # warning will be logged and a warning email/snmp trap may be
 # sent.  If this configuration is set to 0 or not specified, no
@@ -877,7 +877,7 @@ min_query_time = 20
 
 # This should be a percentage between 0 and 100 and should be
 # greater than the warning_disk_space_percentage. If a
-# filesystem’s disk space used percentage equals or exceeds
+# filesystem's disk space used percentage equals or exceeds
 # this value an error will be logged and a error email/snmp
 # trap may be sent.  If this configuration is set to 0 or not
 # specified, no errors are sent.

--- a/gpMgmt/test/behave/mgmt_utils/gpperfmon.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpperfmon.feature
@@ -87,9 +87,9 @@ Feature: gpperfmon
         Then wait until the results from boolean sql "SELECT count(*) > 0 FROM diskspace_history" is "true"
 
     """
-    The gpperfmon_skew_cpu_and_cpu_elapsed does not work on MacOS because of Sigar lib limitations.
+    The gpperfmon_queries_history_metrics does not work on MacOS because of Sigar lib limitations.
     To run all the other scenarios and omit this test on MacOS, use:
-    $ behave test/behave/mgmt_utils/gpperfmon.feature --tags @gpperfmon --tags ~@gpperfmon_skew_cpu_and_cpu_elapsed
+    $ behave test/behave/mgmt_utils/gpperfmon.feature --tags @gpperfmon --tags ~@gpperfmon_queries_history_metrics
     """
     @gpperfmon_queries_history_metrics
     Scenario: gpperfmon records cpu_elapsed, skew_cpu, skew_rows and rows_out

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -4929,10 +4929,12 @@ def impl(context):
 @when('the setting "{variable_name}" is NOT set in the configuration file "{path_to_file}"')
 def impl(context, variable_name, path_to_file):
     path = os.path.join(os.getenv("MASTER_DATA_DIRECTORY"), path_to_file)
-    output_file = "/tmp/gpperfmon_temp_config"
-    cmd = Command("sed to remove line", "sed '/^%s/,+1 d' < %s > %s" % (variable_name, path, output_file))
-    cmd.run(validateAfter=True)
-    shutil.move(output_file, path)
+    temp_file = "/tmp/gpperfmon_temp_config"
+    with open(path) as oldfile, open(temp_file, 'w') as newfile:
+        for line in oldfile:
+            if variable_name not in line:
+                newfile.write(line)
+    shutil.move(temp_file, path)
 
 
 @given('the setting "{setting_string}" is placed in the configuration file "{path_to_file}"')


### PR DESCRIPTION
- use the new fact that datadirs are in the gp_segment_configuration
- fix a few things with the gpperfmon behave tests (mostly for macOS)
   --> the change to mgmt_utils.py is to do the config file manipulation
   natively in python
   --> the change to the gp_bash_functions.sh is to use ASCII '
   characters so that python string comparison is happier

Author: C.J. Jameson <cjameson@pivotal.io>