### PR TITLE
[walreplication] Mask sequences and re-add sequence checks to gp_replica_check test

### DIFF
--- a/contrib/gp_replica_check/Makefile
+++ b/contrib/gp_replica_check/Makefile
@@ -17,4 +17,4 @@ endif
 # For now run don't run for object types like btree as
 # there are still known differences to be fixed.
 installcheck: install
-	gp_replica_check.py -r="heap, ao"
+	gp_replica_check.py -r="heap, sequence, ao"

--- a/contrib/gp_replica_check/Makefile
+++ b/contrib/gp_replica_check/Makefile
@@ -14,7 +14,7 @@ include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk
 endif
 
-# For now run only for HEAP as for other object types like Sequence, btree
+# For now run don't run for object types like btree as
 # there are still known differences to be fixed.
 installcheck: install
 	gp_replica_check.py -r="heap, ao"

--- a/contrib/gp_replica_check/gp_replica_check.c
+++ b/contrib/gp_replica_check/gp_replica_check.c
@@ -348,6 +348,7 @@ retry:
 		char		mirrorFileBuf[BLCKSZ];
 		int			primaryFileBytesRead;
 		int			mirrorFileBytesRead;
+		int			diff;
 
 		CHECK_FOR_INTERRUPTS();
 
@@ -419,13 +420,13 @@ retry:
 			}
 		}
 
-		if (memcmp(primaryFileBuf, mirrorFileBuf, primaryFileBytesRead) != 0)
+		if ((diff = memcmp(primaryFileBuf, mirrorFileBuf, primaryFileBytesRead)) != 0)
 		{
 			/* different contents */
 			ereport(NOTICE,
-					(errmsg("%s files \"%s\" and \"%s\" mismatch at blockno %u",
+					(errmsg("%s files \"%s\" and \"%s\" mismatch by %i at blockno %u",
 							get_relation_type_data(rentry->relam, rentry->relstorage, rentry->relkind).name,
-							primaryfilepath, mirrorfilepath, blockno)));
+							primaryfilepath, mirrorfilepath, diff, blockno)));
 			goto retry;
 		}
 

--- a/contrib/gp_replica_check/gp_replica_check.c
+++ b/contrib/gp_replica_check/gp_replica_check.c
@@ -261,6 +261,18 @@ compare_files(char *primaryfilepath, char *mirrorfilepath, RelfilenodeEntry *ren
 retry:
 	CHECK_FOR_INTERRUPTS();
 
+	/* If the files were still open from previous attempt, close them first. */
+	if (primaryFile != -1)
+	{
+		FileClose(primaryFile);
+		primaryFile = -1;
+	}
+	if (mirrorFile != -1)
+	{
+		FileClose(mirrorFile);
+		mirrorFile = -1;
+	}
+
 	if (attempts == NUM_RETRIES)
 	{
 		ereport(WARNING,
@@ -280,18 +292,6 @@ retry:
 		 */
 		if (!sync_wait())
 			return false;
-	}
-
-	/* If the files were still open from previous attempt, close them first. */
-	if (primaryFile != -1)
-	{
-		FileClose(primaryFile);
-		primaryFile = -1;
-	}
-	if (mirrorFile != -1)
-	{
-		FileClose(mirrorFile);
-		mirrorFile = -1;
 	}
 
 	/*

--- a/contrib/gp_replica_check/gp_replica_check.c
+++ b/contrib/gp_replica_check/gp_replica_check.c
@@ -276,7 +276,7 @@ retry:
 	if (attempts == NUM_RETRIES)
 	{
 		ereport(WARNING,
-				(errmsg("%s files %s and %s mismatch at blockno %d, gave up after %d retries",
+				(errmsg("%s files \"%s\" and \"%s\" mismatch at blockno %d, gave up after %d retries",
 						get_relation_type_data(rentry->relam, rentry->relstorage, rentry->relkind).name,
 						primaryfilepath, mirrorfilepath, blockno, attempts)));
 		return false;
@@ -379,9 +379,10 @@ retry:
 		{
 			/* length mismatch */
 			ereport(NOTICE,
-					(errmsg("%s files \"%s\" and \"%s\" mismatch at blockno %u",
+					(errmsg("%s files \"%s\" and \"%s\" mismatch at blockno %u, primary length: %i, mirror length: %i",
 							get_relation_type_data(rentry->relam, rentry->relstorage, rentry->relkind).name,
-							primaryfilepath, mirrorfilepath, blockno)));
+							primaryfilepath, mirrorfilepath, blockno,
+							primaryFileBytesRead, mirrorFileBytesRead)));
 			goto retry;
 		}
 

--- a/src/backend/commands/sequence.c
+++ b/src/backend/commands/sequence.c
@@ -111,6 +111,7 @@ static void init_params(List *options, bool isInit,
 			Form_pg_sequence new, List **owned_by);
 static void do_setval(Oid relid, int64 next, bool iscalled);
 static void process_owned_by(Relation seqrel, List *owned_by);
+static void mask_seq_values(Page page);
 
 static void
 cdb_sequence_nextval(SeqTable elm,
@@ -1732,12 +1733,50 @@ cdb_sequence_nextval_server(Oid    tablespaceid,
 }                               /* cdb_sequence_server_nextval */
 
 /*
+ * Mask last_value and log_cnt for consistency checking
+ *
+ * To avoid logging every fetch from a sequence, SEQ_LOG_VALS are pre-logged
+ * and thus we need to mask the last_value and log_cnt during consistency
+ * checks.
+ */
+static void
+mask_seq_values(Page page)
+{
+	OffsetNumber 		i;
+	OffsetNumber 		maxoff;
+	Form_pg_sequence	seqtup;
+
+	maxoff = PageGetMaxOffsetNumber(page);
+
+	for (i = FirstOffsetNumber; i <= maxoff; i = OffsetNumberNext(i))
+	{
+		HeapTupleData	htup;
+		ItemId			iid = PageGetItemId(page, i);
+
+		htup.t_data = (HeapTupleHeader) ((char *) page + ItemIdGetOffset(iid));
+		htup.t_len = ItemIdGetLength(iid);
+
+		seqtup = (Form_pg_sequence) GETSTRUCT(&htup);
+		MemSet(&seqtup->last_value, 0, sizeof(int64));
+		MemSet(&seqtup->log_cnt, 0, sizeof(int64));
+	}
+}
+
+/*
  * Mask a Sequence page before performing consistency checks on it.
  */
 void
-seq_mask(char *page, BlockNumber blkno)
+seq_mask(char *pagedata, BlockNumber blkno)
 {
+	Page		page = (Page) pagedata;
+
 	mask_page_lsn_and_checksum(page);
+
+	/*
+	 * last_value and log_cnt need to be masked to account for SEQ_LOG_VALS
+	 * skipped loggings of fetching
+	 */
+	mask_seq_values(page);
 
 	mask_unused_space(page);
 }


### PR DESCRIPTION
Fix masking of `last_value` and `log_cnt` in the sequences to account for the pre-logging, and re-add sequences to `gp_replica_check` tests.

This also includes a few small patches to `gp_replica_check` that I found helpful, see individual commit messages for info.

@hlinnaka 