### PR TITLE
Refactor gpArray to Clarify Usage

### DIFF
--- a/gpMgmt/bin/README
+++ b/gpMgmt/bin/README
@@ -84,18 +84,18 @@ dattimeutils.py  -  Several utility functions for dealing with date/time data
 
 gparray.py
    |
-   +-  GpDB      - Configuration information for a single dbid
+   +-  Segment      - Configuration information for a single dbid
    |
-   +-  GpSegment - Configuration information for a single content id
-   |     \-  Contains multiple GpDB objects
+   +-  SegmentPair - Configuration information for a single content id
+   |     \-  Contains multiple Segment objects
    |
    +-  GpArray   - Configuration information for a Greenplum Database
-         \-  Contains multiple GpSegment objects
+         \-  Contains multiple SegmentPair objects
 
 gphostcache.py   
   |
   +- GpHost      - Information about a single Host
-  |    \- Contains all the GpDB objects on the host
+  |    \- Contains all the Segment objects on the host
   |
   +- GpHostCache - Helps resolve interface->hostname lookups
        \- Contains all the GpHosts referenced in a Greenplum Database

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -742,13 +742,13 @@ class SegmentTemplate:
     def _select_src_segment(self):
         """Gets a segment to use as a source for pg_hba.conf
         and postgresql.conf files"""
-        seg = self.gparray.segmentPairs[0]
-        if seg.primaryDB.valid:
-            self.srcSegHostname = seg.primaryDB.getSegmentHostName()
-            self.srcSegDataDir = seg.primaryDB.getSegmentDataDirectory()
-        elif seg.mirrorDBs[0] is not None and seg.mirrorDBs[0].valid:
-            self.srcSegHostname = seg.mirrorDBs[0].getSegmentHostName()
-            self.srcSegDataDir = seg.mirrorDBs[0].getSegmentDataDirectory()
+        segPair = self.gparray.segmentPairs[0]
+        if segPair.primaryDB.valid:
+            self.srcSegHostname = segPair.primaryDB.getSegmentHostName()
+            self.srcSegDataDir = segPair.primaryDB.getSegmentDataDirectory()
+        elif segPair.mirrorDB and segPair.mirrorDB.valid:
+            self.srcSegHostname = segPair.mirrorDB.getSegmentHostName()
+            self.srcSegDataDir = segPair.mirrorDB.getSegmentDataDirectory()
         else:
             raise SegmentTemplateError("no valid segdb for content=0 to use as a template")
 

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -742,7 +742,7 @@ class SegmentTemplate:
     def _select_src_segment(self):
         """Gets a segment to use as a source for pg_hba.conf
         and postgresql.conf files"""
-        seg = self.gparray.segments[0]
+        seg = self.gparray.segmentPairs[0]
         if seg.primaryDB.valid:
             self.srcSegHostname = seg.primaryDB.getSegmentHostName()
             self.srcSegDataDir = seg.primaryDB.getSegmentDataDirectory()
@@ -2503,7 +2503,7 @@ UPDATE gp_distribution_policy
         if not heap_checksum_util.are_segments_consistent(consistent, inconsistent):
             self.logger.fatal("Cluster heap checksum setting differences reported")
             self.logger.fatal("Heap checksum settings on %d of %d segment instances do not match master <<<<<<<<"
-                              % (len(inconsistent_segment_msgs), len(self.gparray.segments)))
+                              % (len(inconsistent_segment_msgs), len(self.gparray.segmentPairs)))
             self.logger.fatal("Review %s for details" % get_logfile())
             log_to_file_only("Failed checksum consistency validation:", logging.WARN)
             self.logger.fatal("gpexpand error: Cluster will not be modified as checksum settings are not consistent "

--- a/gpMgmt/bin/gpfilespace
+++ b/gpMgmt/bin/gpfilespace
@@ -614,7 +614,7 @@ class GPFilespace:
         self.fspacename = None  # name for the filespace
         self.dir = options.output
         self.master = None  # [] list of master segments
-        self.segments = None  # {} dbid => GpDB resolution
+        self.segments = None  # {} dbid => Segment resolution
         self.hosts = None  # {} hostname => GPHost resolution
         self.nics = None  # {} nic => hostname resolution
         self.config = None  # {} host configuration groups
@@ -712,8 +712,8 @@ class GPFilespace:
         GPFilespace::get_configuration()
         
         Extracts gp_configuration from the database and uses it to populate:
-          self.segments = hash of segments {dbid: GpDB()}
-          self.master   = list of master segments [GpDB()]
+          self.segments = hash of segments {dbid: Segment()}
+          self.master   = list of master segments [Segment()]
 
         If any existing configuration groups or host lists are present they
         will be obliterated, but we will keep any existing nic->hostname
@@ -733,7 +733,7 @@ class GPFilespace:
         except Exception, e:
             raise GPDatabaseError(str(e))
 
-        # These have pointers to the old GpDB so they must be destroyed
+        # These have pointers to the old Segment so they must be destroyed
         # before we populate the new structures.
         self.master = []
         self.segments = {}

--- a/gpMgmt/bin/gppylib/README
+++ b/gpMgmt/bin/gppylib/README
@@ -35,7 +35,7 @@ Coding Principles
     Never set a default value for the fundamental aspects of a class.
 
     This is bad:
-        class GpDB():
+        class Segment():
             def __init__(self, dbid=-1, ...):
                 self.dbid = dbid  # ^^ Setting the core aspects of the class
 
@@ -47,11 +47,11 @@ Coding Principles
     function with parameters set by name for clarity.
 
     This is unclear:
-        db = GpDB(-1, 'p', 0, 'm', 's', 'u', 'localhost', 'localhost', 5432,
+        db = Segment(-1, 'p', 0, 'm', 's', 'u', 'localhost', 'localhost', 5432,
 		          datadir, None)
 
     This is better:
-        db = GpDB(content = -1, preferred_role = 'p', dbid = 0, role = 'p',
+        db = Segment(content = -1, preferred_role = 'p', dbid = 0, role = 'p',
 				  mode = 's', status = 'u', hostname = 'localhost',
 				  address = 'localhost', port = 5432, datadir = '/gpdata/gp-1',
 				  replicationPort = None)

--- a/gpMgmt/bin/gppylib/heapchecksum.py
+++ b/gpMgmt/bin/gppylib/heapchecksum.py
@@ -40,7 +40,7 @@ class HeapChecksum:
 
     def get_segments_checksum_settings(self, gpdb_list=None):
         """
-        :return: two lists of GpDB objects (as defined in gparray) for successes and failures,
+        :return: two lists of Segment objects (as defined in gparray) for successes and failures,
         where successes have successfully reported their checksum values
         """
         failures = []
@@ -74,7 +74,7 @@ class HeapChecksum:
 
     def check_segment_consistency(self, successes):
         """
-        :param successes: list of segments (GpDB objects) for which we successfully determined checksum setting
+        :param successes: list of segments (Segment objects) for which we successfully determined checksum setting
         :return: lists of segments that are consistent with master and inconsistent with master, respectively,
         along with master GpDb itself
         """

--- a/gpMgmt/bin/gppylib/operations/test/unit/__init__.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/__init__.py
@@ -2,12 +2,12 @@
 from os.path import abspath as _abspath
 __path__[0] = _abspath(__path__[0])
 
-from gppylib.gparray import GpArray, GpDB
+from gppylib.gparray import GpArray, Segment
 
 def setup_fake_gparray():
-    master = GpDB.initFromString("1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
-    primary0 = GpDB.initFromString("2|0|p|p|s|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
-    primary1 = GpDB.initFromString("3|1|p|p|s|u|sdw2|sdw2|40001|41001|/data/primary1||/data/primary1/base/10899,/data/primary1/base/1,/data/primary1/base/10898,/data/primary1/base/25780,/data/primary1/base/34782")
-    mirror0 = GpDB.initFromString("4|0|m|m|s|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
-    mirror1 = GpDB.initFromString("5|1|m|m|s|u|sdw1|sdw1|50001|51001|/data/mirror1||/data/mirror1/base/10899,/data/mirror1/base/1,/data/mirror1/base/10898,/data/mirror1/base/25780,/data/mirror1/base/34782")
+    master = Segment.initFromString("1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
+    primary0 = Segment.initFromString("2|0|p|p|s|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
+    primary1 = Segment.initFromString("3|1|p|p|s|u|sdw2|sdw2|40001|41001|/data/primary1||/data/primary1/base/10899,/data/primary1/base/1,/data/primary1/base/10898,/data/primary1/base/25780,/data/primary1/base/34782")
+    mirror0 = Segment.initFromString("4|0|m|m|s|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
+    mirror1 = Segment.initFromString("5|1|m|m|s|u|sdw1|sdw1|50001|51001|/data/mirror1||/data/mirror1/base/10899,/data/mirror1/base/1,/data/mirror1/base/10898,/data/mirror1/base/25780,/data/mirror1/base/34782")
     return GpArray([master,primary0,primary1,mirror0,mirror1])

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_backup_utils.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_backup_utils.py
@@ -7,7 +7,7 @@ import os
 import shutil
 import unittest
 from gppylib.commands.base import CommandResult
-from gppylib.gparray import GpArray, GpDB
+from gppylib.gparray import GpArray, Segment
 from gppylib.operations.backup_utils import *
 from . import setup_fake_gparray
 

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_buildMirrorSegments.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) Greenplum Inc 2008. All Rights Reserved. 
 #
-from gppylib.gparray import GpDB
+from gppylib.gparray import Segment
 from gppylib.test.unit.gp_unittest import *
 import tempfile, os, shutil
 from gppylib.commands.base import CommandResult
@@ -100,7 +100,7 @@ class buildMirrorSegmentsTestCase(GpTestCase):
         self.assertEquals(self.logger.call_count, 0)
 
     @patch('gppylib.operations.utils.ParallelOperation.run')
-    @patch('gppylib.gparray.GpDB.getSegmentHostName', side_effect=['foo1', 'foo2'])
+    @patch('gppylib.gparray.Segment.getSegmentHostName', side_effect=['foo1', 'foo2'])
     def test_ensureSharedMemCleaned(self, mock1, mock2):
         self.buildMirrorSegs._GpMirrorListToBuild__ensureSharedMemCleaned(Mock(), [Mock(), Mock()])
         self.logger.info.assert_any_call('Ensuring that shared memory is cleaned up for stopped segments')
@@ -119,7 +119,7 @@ class buildMirrorSegmentsTestCase(GpTestCase):
     @patch('gppylib.operations.startSegments.StartSegmentsOperation')
     def test_startAll_fails(self, mock1, mock2):
         result = StartSegmentsResult()
-        failed_segment = GpDB.initFromString(
+        failed_segment = Segment.initFromString(
             "2|0|p|p|s|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
         result.addFailure(failed_segment, 'reason', 'reasoncode')
         mock1.return_value.startSegments.return_value = result

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_dump.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_dump.py
@@ -5,7 +5,7 @@
 import unittest
 from datetime import datetime
 from gppylib.commands.base import Command, CommandResult
-from gppylib.gparray import GpArray, GpDB
+from gppylib.gparray import GpArray, Segment
 from gppylib.operations.backup_utils import *
 from gppylib.operations.dump import *
 from mock import patch, MagicMock, Mock, mock_open, call, ANY
@@ -891,7 +891,7 @@ class DumpTestCase(unittest.TestCase):
                 seg.get_primary_dbid.return_value = id + 2
             return self.mock_segs
 
-    @patch('gppylib.gparray.GpDB.getSegmentHostName', return_value='sdw')
+    @patch('gppylib.gparray.Segment.getSegmentHostName', return_value='sdw')
     def test_backup_config_files_with_nbu_default(self, mock1):
         with patch('gppylib.operations.dump.backup_file_with_nbu', side_effect=my_counter) as nbu_mock:
             global i

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_restore.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_restore.py
@@ -1115,7 +1115,7 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
             from gppylib.commands.base import REMOTE
             cmd.assert_called_with("restoring metadata files to segment", cmdStr, ctxt=REMOTE, remoteHost="sdw")
 
-    @patch('gppylib.gparray.GpDB.getSegmentHostName', return_value='sdw')
+    @patch('gppylib.gparray.Segment.getSegmentHostName', return_value='sdw')
     def test_restore_config_files_with_nbu_default(self, mock1):
         with patch('gppylib.operations.restore.restore_file_with_nbu', side_effect=my_counter) as nbu_mock:
             global i

--- a/gpMgmt/bin/gppylib/programs/clsAddMirrors.py
+++ b/gpMgmt/bin/gppylib/programs/clsAddMirrors.py
@@ -60,7 +60,7 @@ def validateFlexibleHeadersListAllFilespaces(configFileLabel, gpArray, fileData)
 
 class GpMirrorBuildCalculator:
     """
-    Create mirror segment (GpDB) objects for an existing array, using different strategies.
+    Create mirror segment (Segment) objects for an existing array, using different strategies.
 
     This class should be used by constructing and then calling either getSpreadMirrors, getGroupMirrors, or call
        addMirror multiple times
@@ -121,7 +121,7 @@ class GpMirrorBuildCalculator:
         mirrorIndexOnTargetHost = self.__mirrorsAddedByHost[targetHost]
         assert mirrorIndexOnTargetHost is not None
 
-        mirror = gparray.GpDB(
+        mirror = gparray.Segment(
             content=primary.getSegmentContentId(),
             preferred_role=gparray.ROLE_MIRROR,
             dbid=self.__nextDbId,
@@ -614,7 +614,7 @@ class GpAddMirrorsProgram:
         if not heap_checksum_util.are_segments_consistent(consistent, inconsistent):
             logger.fatal("Cluster heap checksum setting differences reported")
             logger.fatal("Heap checksum settings on %d of %d segment instances do not match master <<<<<<<<"
-                              % (len(inconsistent_segment_msgs), len(gpArray.segments)))
+                              % (len(inconsistent_segment_msgs), len(gpArray.segmentPairs)))
             logger.fatal("Review %s for details" % get_logfile())
             log_to_file_only("Failed checksum consistency validation:", logging.WARN)
             logger.fatal("gpaddmirrors error: Cluster will not be modified as checksum settings are not consistent "

--- a/gpMgmt/bin/gppylib/programs/clsSystemState.py
+++ b/gpMgmt/bin/gppylib/programs/clsSystemState.py
@@ -682,7 +682,7 @@ class GpSystemStateProgram:
 
         # segments that are down (excluding those that are part of changetracking)
         changeTrackingMirrors = [contentIdToMirror[s.getSegmentContentId()][0] for s in primariesInChangeTracking]
-        changeTrackingMirrorsByDbId = GpArray.getSegmentsGroupedByValue(changeTrackingMirrors, gparray.GpDB.getSegmentDbId)
+        changeTrackingMirrorsByDbId = GpArray.getSegmentsGroupedByValue(changeTrackingMirrors, gparray.Segment.getSegmentDbId)
         segmentsThatAreDown = [s for s in gpArray.getSegDbList() if \
                             not s.getSegmentDbId() in changeTrackingMirrorsByDbId and \
                             data.isSegmentProbablyDown(s)]

--- a/gpMgmt/bin/gppylib/programs/test/unit/test_cluster_clsrecoversegment.py
+++ b/gpMgmt/bin/gppylib/programs/test/unit/test_cluster_clsrecoversegment.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from gparray import GpDB, GpArray
+from gparray import Segment, GpArray
 from gppylib import gparray
 from gppylib.commands.base import CommandResult, WorkerPool, Command
 from gppylib.programs.clsRecoverSegment import GpRecoverSegmentProgram
@@ -113,13 +113,13 @@ class GpRecoverSegmentProgramTestCase(GpTestCase):
         self.subject._check_segment_state_for_connection(conf_provider)
 
     def test_check_segment_state__when_one_segment_not_ready__raises(self):
-        segment1 = Mock(spec=GpDB)
+        segment1 = Mock(spec=Segment)
         segment1.getSegmentHostName.return_value = 'foo1'
         segment1.isSegmentUp.return_value = True
         segment1.isSegmentMaster.return_value = False
         segment1.isSegmentStandby.return_value = False
 
-        segment2 = Mock(spec=GpDB)
+        segment2 = Mock(spec=Segment)
         segment2.getSegmentHostName.return_value = 'foo2'
         segment2.isSegmentUp.return_value = True
         segment2.isSegmentMaster.return_value = False
@@ -147,7 +147,7 @@ class GpRecoverSegmentProgramTestCase(GpTestCase):
                                                   'mode: PrimarySegment\nsegmentState: ChangeTrackingDisabled\n'
                                                   'dataState: InChangeTracking\n',
                                                   False, True)
-        segment_mock = Mock(spec=GpDB)
+        segment_mock = Mock(spec=Segment)
         segment_mock.isSegmentQD.return_value = False
         segment_mock.isSegmentModeInChangeLogging.return_value = True
         segment_mock.getSegmentHostName.return_value = 'foo1'
@@ -173,7 +173,7 @@ class GpRecoverSegmentProgramTestCase(GpTestCase):
                                                   'mode: PrimarySegment\nsegmentState: ChangeTrackingDisabled\n'
                                                   'dataState: InChangeTracking\n',
                                                   False, True)
-        segment = Mock(spec=GpDB)
+        segment = Mock(spec=Segment)
         segment.isSegmentQD.return_value = False
         segment.isSegmentModeInChangeLogging.return_value = True
         segment.getSegmentHostName.return_value = 'foo1'
@@ -220,7 +220,7 @@ class GpRecoverSegmentProgramTestCase(GpTestCase):
         gparray_mock = Mock(spec=GpArray)
         gparray_mock.hasMirrors = True
 
-        segment_mock = Mock(spec=GpDB)
+        segment_mock = Mock(spec=Segment)
         segment_mock.getSegmentContentId.return_value = 0
         mismatched = self.subject.is_segment_mirror_state_mismatched(gparray_mock, segment_mock)
         self.assertTrue(mismatched)
@@ -230,7 +230,7 @@ class GpRecoverSegmentProgramTestCase(GpTestCase):
         gparray_mock = Mock(spec=GpArray)
         gparray_mock.hasMirrors = True
 
-        segment_mock = Mock(spec=GpDB)
+        segment_mock = Mock(spec=Segment)
         segment_mock.getSegmentContentId.return_value = 0
         mismatched = self.subject.is_segment_mirror_state_mismatched(gparray_mock, segment_mock)
         self.assertFalse(mismatched)
@@ -239,7 +239,7 @@ class GpRecoverSegmentProgramTestCase(GpTestCase):
         gparray_mock = Mock(spec=GpArray)
         gparray_mock.hasMirrors = False
 
-        segment_mock = Mock(spec=GpDB)
+        segment_mock = Mock(spec=Segment)
         segment_mock.getSegmentDbId.return_value = 0
         mismatched = self.subject.is_segment_mirror_state_mismatched(gparray_mock, segment_mock)
         self.assertFalse(mismatched)
@@ -254,7 +254,7 @@ class GpRecoverSegmentProgramTestCase(GpTestCase):
     ############################################################
     # Private
     def _get_mock_segment(self, name, port, address, datadir):
-        segment = Mock(spec=GpDB)
+        segment = Mock(spec=Segment)
         segment.getSegmentHostName.return_value = name
         segment.getSegmentAddress.return_value = address
         segment.getSegmentPort.return_value = port
@@ -267,12 +267,12 @@ class GpRecoverSegmentProgramTestCase(GpTestCase):
         return conf_provider
 
     def _segments_mock(self):
-        segment1 = Mock(spec=GpDB)
+        segment1 = Mock(spec=Segment)
         segment1.getSegmentHostName.return_value = 'foo1'
         segment1.isSegmentUp.return_value = True
         segment1.isSegmentMaster.return_value = False
         segment1.isSegmentStandby.return_value = False
-        segment2 = Mock(spec=GpDB)
+        segment2 = Mock(spec=Segment)
         segment2.getSegmentHostName.return_value = 'foo2'
         segment2.isSegmentUp.return_value = True
         segment2.isSegmentMaster.return_value = False

--- a/gpMgmt/bin/gppylib/system/configurationImplGpdb.py
+++ b/gpMgmt/bin/gppylib/system/configurationImplGpdb.py
@@ -13,7 +13,7 @@ from gppylib.gplog import *
 from gppylib.utils import checkNotNone
 from gppylib.system.configurationInterface import *
 from gppylib.system.ComputeCatalogUpdate import ComputeCatalogUpdate
-from gppylib.gparray import GpArray, GpDB, InvalidSegmentConfiguration
+from gppylib.gparray import GpArray, Segment, InvalidSegmentConfiguration
 from gppylib import gparray
 from gppylib.db import dbconn
 from gppylib.commands.gp import get_local_db_mode

--- a/gpMgmt/bin/gppylib/test/unit/__init__.py
+++ b/gpMgmt/bin/gppylib/test/unit/__init__.py
@@ -2,12 +2,12 @@
 from os.path import abspath as _abspath
 __path__[0] = _abspath(__path__[0])
 
-from gppylib.gparray import GpArray, GpDB
+from gppylib.gparray import GpArray, Segment
 
 def setup_fake_gparray():
-    master = GpDB.initFromString("1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
-    primary0 = GpDB.initFromString("2|0|p|p|s|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
-    primary1 = GpDB.initFromString("3|1|p|p|s|u|sdw2|sdw2|40001|41001|/data/primary1||/data/primary1/base/10899,/data/primary1/base/1,/data/primary1/base/10898,/data/primary1/base/25780,/data/primary1/base/34782")
-    mirror0 = GpDB.initFromString("4|0|m|m|s|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
-    mirror1 = GpDB.initFromString("5|1|m|m|s|u|sdw1|sdw1|50001|51001|/data/mirror1||/data/mirror1/base/10899,/data/mirror1/base/1,/data/mirror1/base/10898,/data/mirror1/base/25780,/data/mirror1/base/34782")
+    master = Segment.initFromString("1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
+    primary0 = Segment.initFromString("2|0|p|p|s|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
+    primary1 = Segment.initFromString("3|1|p|p|s|u|sdw2|sdw2|40001|41001|/data/primary1||/data/primary1/base/10899,/data/primary1/base/1,/data/primary1/base/10898,/data/primary1/base/25780,/data/primary1/base/34782")
+    mirror0 = Segment.initFromString("4|0|m|m|s|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
+    mirror1 = Segment.initFromString("5|1|m|m|s|u|sdw1|sdw1|50001|51001|/data/mirror1||/data/mirror1/base/10899,/data/mirror1/base/1,/data/mirror1/base/10898,/data/mirror1/base/25780,/data/mirror1/base/34782")
     return GpArray([master,primary0,primary1,mirror0,mirror1])

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gp.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gp.py
@@ -6,7 +6,7 @@ from StringIO import StringIO
 
 from commands.base import CommandResult
 from commands.gp import GpReadConfig
-from gparray import GpDB, GpArray, Segment
+from gparray import Segment, GpArray, SegmentPair
 import shutil
 from mock import *
 from gp_unittest import *
@@ -20,15 +20,15 @@ class GpConfig(GpTestCase):
         self.host_cache = Mock()
 
     def createGpArrayWith2Primary2Mirrors(self):
-        master = GpDB.initFromString(
+        master = Segment.initFromString(
             "1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
-        primary0 = GpDB.initFromString(
+        primary0 = Segment.initFromString(
             "2|0|p|p|s|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
-        primary1 = GpDB.initFromString(
+        primary1 = Segment.initFromString(
             "3|1|p|p|s|u|sdw2|sdw2|40001|41001|/data/primary1||/data/primary1/base/10899,/data/primary1/base/1,/data/primary1/base/10898,/data/primary1/base/25780,/data/primary1/base/34782")
-        mirror0 = GpDB.initFromString(
+        mirror0 = Segment.initFromString(
             "4|0|m|m|s|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
-        mirror1 = GpDB.initFromString(
+        mirror1 = Segment.initFromString(
             "5|1|m|m|s|u|sdw1|sdw1|50001|51001|/data/mirror1||/data/mirror1/base/10899,/data/mirror1/base/1,/data/mirror1/base/10898,/data/mirror1/base/25780,/data/mirror1/base/34782")
         return GpArray([master, primary0, primary1, mirror0, mirror1])
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpaddmirrors.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpaddmirrors.py
@@ -5,7 +5,7 @@ import StringIO
 from mock import *
 from gp_unittest import *
 from gppylib.programs.clsAddMirrors import GpAddMirrorsProgram, ProgramArgumentValidationException
-from gparray import GpDB, GpArray
+from gparray import Segment, GpArray
 from gppylib.system.environment import GpMasterEnvironment
 from gppylib.system.configurationInterface import GpConfigurationProvider
 
@@ -124,15 +124,15 @@ class GpAddMirrorsTest(GpTestCase):
         self.assertIn("55000", result[1])
 
     def _createGpArrayWith2Primary2Mirrors(self):
-        self.master = GpDB.initFromString(
+        self.master = Segment.initFromString(
             "1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
-        self.primary0 = GpDB.initFromString(
+        self.primary0 = Segment.initFromString(
             "2|0|p|p|s|u|sdw1|sdw1|40000|41000|/Users/pivotal/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
-        self.primary1 = GpDB.initFromString(
+        self.primary1 = Segment.initFromString(
             "3|1|p|p|s|u|sdw2|sdw2|40001|41001|/data/primary1||/data/primary1/base/10899,/data/primary1/base/1,/data/primary1/base/10898,/data/primary1/base/25780,/data/primary1/base/34782")
-        mirror0 = GpDB.initFromString(
+        mirror0 = Segment.initFromString(
             "4|0|m|m|s|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
-        mirror1 = GpDB.initFromString(
+        mirror1 = Segment.initFromString(
             "5|1|m|m|s|u|sdw1|sdw1|50001|51001|/data/mirror1||/data/mirror1/base/10899,/data/mirror1/base/1,/data/mirror1/base/10898,/data/mirror1/base/25780,/data/mirror1/base/34782")
 
         return GpArray([self.master, self.primary0, self.primary1, mirror0, mirror1])

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gparray.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gparray.py
@@ -224,7 +224,7 @@ class GpArrayTestCase(GpTestCase):
         lastport = 0
         for seg in gparray.segmentPairs:
             prim = seg.primaryDB            
-            mir = seg.mirrorDBs[0]
+            mir = seg.mirrorDB
             self.assertNotEqual(prim.hostname, mir.hostname)
             if prim.port not in portdict:
                 portdict[prim.port] = 1

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gparray.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gparray.py
@@ -9,7 +9,7 @@
 """
 import os
 
-from gppylib.gparray import GpArray, GpDB, createSegmentRows, get_gparray_from_config
+from gppylib.gparray import GpArray, Segment, createSegmentRows, get_gparray_from_config
 from gppylib import gplog
 from gp_unittest import *
 from mock import patch, Mock
@@ -185,17 +185,17 @@ class GpArrayTestCase(GpTestCase):
 #------------------------------- non-test helpers --------------------------------
     def _setup_gparray(self, hostlist, interface_list, primary_list, primary_portbase, mirror_type,
                        mirror_list, mirror_portbase, dir_prefix, primary_replication_portbase, mirror_replication_portbase):
-        master = GpDB(content = -1,
-                    preferred_role = 'p',
-                    dbid = 0,
-                    role = 'p',
-                    mode = 's',
-                    status = 'u',
-                    hostname = 'masterhost',
-                    address = 'masterhost-1',
-                    port = 5432,
-                    datadir = '/masterdir',
-                    replicationPort = 5433)
+        master = Segment(content = -1,
+                         preferred_role = 'p',
+                         dbid = 0,
+                         role = 'p',
+                         mode = 's',
+                         status = 'u',
+                         hostname = 'masterhost',
+                         address = 'masterhost-1',
+                         port = 5432,
+                         datadir = '/masterdir',
+                         replicationPort = 5433)
         allrows = []
         allrows.append(master)                 
         rows =  createSegmentRows(hostlist, interface_list, primary_list, primary_portbase, mirror_type,
@@ -203,17 +203,17 @@ class GpArrayTestCase(GpTestCase):
         
         
         for row in rows:
-            newrow = GpDB(content = row.content, 
-                          preferred_role = 'p' if convert_bool(row.isprimary) else 'm', 
-                          dbid = row.dbid,
-                          role = 'p' if convert_bool(row.isprimary) else 'm',
-                          mode = 's', 
-                          status = 'u', 
-                          hostname = row.host, 
-                          address = row.address, 
-                          port = row.port, 
-                          datadir = row.fulldir, 
-                          replicationPort = row.prPort) 
+            newrow = Segment(content = row.content,
+                             preferred_role = 'p' if convert_bool(row.isprimary) else 'm',
+                             dbid = row.dbid,
+                             role = 'p' if convert_bool(row.isprimary) else 'm',
+                             mode = 's',
+                             status = 'u',
+                             hostname = row.host,
+                             address = row.address,
+                             port = row.port,
+                             datadir = row.fulldir,
+                             replicationPort = row.prPort)
             allrows.append(newrow)
         
         gparray = GpArray(allrows)
@@ -222,7 +222,7 @@ class GpArrayTestCase(GpTestCase):
     def _validate_array(self, gparray): 
         portdict = {}
         lastport = 0
-        for seg in gparray.segments:
+        for seg in gparray.segmentPairs:
             prim = seg.primaryDB            
             mir = seg.mirrorDBs[0]
             self.assertNotEqual(prim.hostname, mir.hostname)

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpconfig.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpconfig.py
@@ -10,7 +10,7 @@ from StringIO import StringIO
 import errno
 from pygresql.pg import DatabaseError
 
-from gparray import GpDB, GpArray, Segment
+from gparray import Segment, GpArray, SegmentPair
 import shutil
 from mock import *
 from gp_unittest import *
@@ -55,7 +55,7 @@ class GpConfig(GpTestCase):
         self.host_cache = Mock()
 
         self.host = GpHost('localhost')
-        seg = Segment()
+        seg = SegmentPair()
         db = self.gparray.master
         seg.addPrimary(db)
         seg.datadir = self.gparray.master.datadir
@@ -465,15 +465,15 @@ class GpConfig(GpTestCase):
 
     @staticmethod
     def _create_gparray_with_2_primary_2_mirrors():
-        master = GpDB.initFromString(
+        master = Segment.initFromString(
             "1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
-        primary0 = GpDB.initFromString(
+        primary0 = Segment.initFromString(
             "2|0|p|p|s|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
-        primary1 = GpDB.initFromString(
+        primary1 = Segment.initFromString(
             "3|1|p|p|s|u|sdw2|sdw2|40001|41001|/data/primary1||/data/primary1/base/10899,/data/primary1/base/1,/data/primary1/base/10898,/data/primary1/base/25780,/data/primary1/base/34782")
-        mirror0 = GpDB.initFromString(
+        mirror0 = Segment.initFromString(
             "4|0|m|m|s|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
-        mirror1 = GpDB.initFromString(
+        mirror1 = Segment.initFromString(
             "5|1|m|m|s|u|sdw1|sdw1|50001|51001|/data/mirror1||/data/mirror1/base/10899,/data/mirror1/base/1,/data/mirror1/base/10898,/data/mirror1/base/25780,/data/mirror1/base/34782")
         return GpArray([master, primary0, primary1, mirror0, mirror1])
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpexpand.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpexpand.py
@@ -3,7 +3,7 @@ import imp
 
 from gp_unittest import *
 from mock import *
-from gparray import GpDB, GpArray
+from gparray import Segment, GpArray
 from gppylib.db.dbconn import DbURL
 from gppylib.db import catalog
 from gppylib.gplog import *
@@ -115,15 +115,15 @@ class GpExpand(GpTestCase):
                                                                   "segments defined \n\nExiting...")
 
     def createGpArrayWith2Primary2Mirrors(self):
-        self.master = GpDB.initFromString(
+        self.master = Segment.initFromString(
             "1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
-        self.primary0 = GpDB.initFromString(
+        self.primary0 = Segment.initFromString(
             "2|0|p|p|s|u|aspen|sdw1|40000|41000|/Users/pivotal/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
-        self.primary1 = GpDB.initFromString(
+        self.primary1 = Segment.initFromString(
             "3|1|p|p|s|u|sdw2|sdw2|40001|41001|/data/primary1||/data/primary1/base/10899,/data/primary1/base/1,/data/primary1/base/10898,/data/primary1/base/25780,/data/primary1/base/34782")
-        self.mirror0 = GpDB.initFromString(
+        self.mirror0 = Segment.initFromString(
             "4|0|m|m|s|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
-        self.mirror1 = GpDB.initFromString(
+        self.mirror1 = Segment.initFromString(
             "5|1|m|m|s|u|sdw1|sdw1|50001|51001|/data/mirror1||/data/mirror1/base/10899,/data/mirror1/base/1,/data/mirror1/base/10898,/data/mirror1/base/25780,/data/mirror1/base/34782")
         return GpArray([self.master, self.primary0, self.primary1, self.mirror0, self.mirror1])
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
@@ -6,7 +6,7 @@ import tempfile
 from mock import *
 
 from gp_unittest import *
-from gppylib.gparray import GpArray, GpDB
+from gppylib.gparray import GpArray, Segment
 from gppylib.heapchecksum import HeapChecksum
 from gppylib.operations.buildMirrorSegments import GpMirrorToBuild, GpMirrorListToBuild
 from gppylib.pgconf import gucdict, setting
@@ -249,15 +249,15 @@ class GpRecoversegTestCase(GpTestCase):
         self.assertEqual(cm.exception.code, 0)
 
     def _create_gparray_with_2_primary_2_mirrors(self):
-        master = GpDB.initFromString(
+        master = Segment.initFromString(
             "1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
-        self.primary0 = GpDB.initFromString(
+        self.primary0 = Segment.initFromString(
             "2|0|p|p|s|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
-        primary1 = GpDB.initFromString(
+        primary1 = Segment.initFromString(
             "3|1|p|p|s|u|sdw2|sdw2|40001|41001|/data/primary1||/data/primary1/base/10899,/data/primary1/base/1,/data/primary1/base/10898,/data/primary1/base/25780,/data/primary1/base/34782")
-        self.mirror0 = GpDB.initFromString(
+        self.mirror0 = Segment.initFromString(
             "4|0|m|m|s|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
-        mirror1 = GpDB.initFromString(
+        mirror1 = Segment.initFromString(
             "5|1|m|m|s|u|sdw1|sdw1|50001|51001|/data/mirror1||/data/mirror1/base/10899,/data/mirror1/base/1,/data/mirror1/base/10898,/data/mirror1/base/25780,/data/mirror1/base/34782")
         return GpArray([master, self.primary0, primary1, self.mirror0, mirror1])
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpstart.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpstart.py
@@ -5,7 +5,7 @@ import sys
 
 from mock import Mock, patch
 
-from gparray import GpDB, GpArray
+from gparray import Segment, GpArray
 from gppylib.operations.startSegments import StartSegmentsResult
 from gppylib.test.unit.gp_unittest import GpTestCase, run_tests
 
@@ -232,17 +232,17 @@ class GpStart(GpTestCase):
         self.subject.logger.error.assert_any_call("gpstart error: Heap checksum settings are not consistent across the cluster.")
 
     def _createGpArrayWith2Primary2Mirrors(self):
-        self.master = GpDB.initFromString(
+        self.master = Segment.initFromString(
             "1|-1|p|p|s|u|mdw|mdw|5432|5532|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
-        self.primary0 = GpDB.initFromString(
+        self.primary0 = Segment.initFromString(
             "2|0|p|p|s|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
-        self.primary1 = GpDB.initFromString(
+        self.primary1 = Segment.initFromString(
             "3|1|p|p|s|u|sdw2|sdw2|40001|41001|/data/primary1||/data/primary1/base/10899,/data/primary1/base/1,/data/primary1/base/10898,/data/primary1/base/25780,/data/primary1/base/34782")
-        self.mirror0 = GpDB.initFromString(
+        self.mirror0 = Segment.initFromString(
             "4|0|m|m|s|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
-        self.mirror1 = GpDB.initFromString(
+        self.mirror1 = Segment.initFromString(
             "5|1|m|m|s|u|sdw1|sdw1|50001|51001|/data/mirror1||/data/mirror1/base/10899,/data/mirror1/base/1,/data/mirror1/base/10898,/data/mirror1/base/25780,/data/mirror1/base/34782")
-        self.standby = GpDB.initFromString(
+        self.standby = Segment.initFromString(
             "6|-1|m|m|s|u|sdw3|sdw3|5433|5533|/data/standby||/data/standby/base/10899,/data/standby/base/1,/data/standby/base/10898,/data/standby/base/25780,/data/standby/base/34782")
         return GpArray([self.master, self.primary0, self.primary1, self.mirror0, self.mirror1])
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpstop.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpstop.py
@@ -2,7 +2,7 @@ import imp
 import os
 import sys
 
-from gparray import GpDB, GpArray, Segment
+from gparray import Segment, GpArray, SegmentPair
 from mock import Mock, patch
 from gppylib.test.unit.gp_unittest import GpTestCase, run_tests
 from gppylib.commands.gp import GpSegStopCmd
@@ -57,25 +57,25 @@ class GpStop(GpTestCase):
         super(GpStop, self).tearDown()
 
     def createGpArrayWith4Primary4Mirrors(self):
-        self.master = GpDB.initFromString(
+        self.master = Segment.initFromString(
             "1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
 
-        self.primary0 = GpDB.initFromString(
+        self.primary0 = Segment.initFromString(
             "2|0|p|p|s|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
-        self.primary1 = GpDB.initFromString(
+        self.primary1 = Segment.initFromString(
             "3|1|p|p|s|u|sdw1|sdw1|40001|41001|/data/primary1||/data/primary1/base/10899,/data/primary1/base/1,/data/primary1/base/10898,/data/primary1/base/25780,/data/primary1/base/34782")
-        self.primary2 = GpDB.initFromString(
+        self.primary2 = Segment.initFromString(
             "4|2|p|p|s|u|sdw2|sdw2|40002|41002|/data/primary2||/data/primary2/base/10899,/data/primary2/base/1,/data/primary2/base/10898,/data/primary2/base/25780,/data/primary2/base/34782")
-        self.primary3 = GpDB.initFromString(
+        self.primary3 = Segment.initFromString(
             "5|3|p|p|s|u|sdw2|sdw2|40003|41003|/data/primary3||/data/primary3/base/10899,/data/primary3/base/1,/data/primary3/base/10898,/data/primary3/base/25780,/data/primary3/base/34782")
 
-        self.mirror0 = GpDB.initFromString(
+        self.mirror0 = Segment.initFromString(
             "6|0|m|m|s|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
-        self.mirror1 = GpDB.initFromString(
+        self.mirror1 = Segment.initFromString(
             "7|1|m|m|s|u|sdw2|sdw2|50001|51001|/data/mirror1||/data/mirror1/base/10899,/data/mirror1/base/1,/data/mirror1/base/10898,/data/mirror1/base/25780,/data/mirror1/base/34782")
-        self.mirror2 = GpDB.initFromString(
+        self.mirror2 = Segment.initFromString(
             "8|2|m|m|s|u|sdw1|sdw1|50002|51002|/data/mirror2||/data/mirror2/base/10899,/data/mirror2/base/1,/data/mirror2/base/10898,/data/mirror2/base/25780,/data/mirror2/base/34782")
-        self.mirror3 = GpDB.initFromString(
+        self.mirror3 = Segment.initFromString(
             "9|3|m|m|s|u|sdw1|sdw1|50003|51003|/data/mirror3||/data/mirror3/base/10899,/data/mirror3/base/1,/data/mirror3/base/10898,/data/mirror3/base/25780,/data/mirror3/base/34782")
         return GpArray([self.master, self.primary0, self.primary1, self.primary2, self.primary3, self.mirror0, self.mirror1, self.mirror2, self.mirror3])
 
@@ -179,9 +179,9 @@ class GpStop(GpTestCase):
         parser = self.subject.GpStop.createParser()
         options, args = parser.parse_args()
 
-        self.primary0 = GpDB.initFromString(
+        self.primary0 = Segment.initFromString(
             "2|0|p|p|c|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
-        self.mirror0 = GpDB.initFromString(
+        self.mirror0 = Segment.initFromString(
             "6|0|m|m|s|d|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
         self.mock_gparray.return_value = GpArray([self.master, self.primary0,
                                                   self.primary1, self.primary2,
@@ -200,9 +200,9 @@ class GpStop(GpTestCase):
         parser = self.subject.GpStop.createParser()
         options, args = parser.parse_args()
 
-        self.primary0 = GpDB.initFromString(
+        self.primary0 = Segment.initFromString(
             "2|0|p|p|r|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
-        self.mirror0 = GpDB.initFromString(
+        self.mirror0 = Segment.initFromString(
             "6|0|m|m|r|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
         self.mock_gparray.return_value = GpArray([self.master, self.primary0,
                                                   self.primary1, self.primary2,
@@ -221,9 +221,9 @@ class GpStop(GpTestCase):
         parser = self.subject.GpStop.createParser()
         options, args = parser.parse_args()
 
-        self.primary0 = GpDB.initFromString(
+        self.primary0 = Segment.initFromString(
             "2|0|m|p|s|d|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
-        self.mirror0 = GpDB.initFromString(
+        self.mirror0 = Segment.initFromString(
             "6|0|p|m|c|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
         self.mock_gparray.return_value = GpArray([self.master, self.primary0,
                                                   self.primary1, self.primary2,
@@ -246,12 +246,12 @@ class GpStop(GpTestCase):
         parser = self.subject.GpStop.createParser()
         options, args = parser.parse_args()
 
-        self.master = GpDB.initFromString(
+        self.master = Segment.initFromString(
             "1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
 
-        self.primary0 = GpDB.initFromString(
+        self.primary0 = Segment.initFromString(
             "2|0|p|p|s|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
-        self.mirror0 = GpDB.initFromString(
+        self.mirror0 = Segment.initFromString(
             "3|0|m|m|s|u|sdw1|sdw1|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
         self.mock_gparray.return_value = GpArray([self.master, self.primary0, self.mirror0])
 
@@ -266,11 +266,11 @@ class GpStop(GpTestCase):
         parser = self.subject.GpStop.createParser()
         options, args = parser.parse_args()
 
-        self.master = GpDB.initFromString(
+        self.master = Segment.initFromString(
             "1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
-        self.primary0 = GpDB.initFromString(
+        self.primary0 = Segment.initFromString(
             "2|0|p|p|s|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
-        self.mirror0 = GpDB.initFromString(
+        self.mirror0 = Segment.initFromString(
             "3|0|m|m|s|u|sdw1|sdw1|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
         self.mock_gparray.return_value = GpArray([self.master, self.primary0, self.mirror0])
 
@@ -286,13 +286,13 @@ class GpStop(GpTestCase):
         parser = self.subject.GpStop.createParser()
         options, args = parser.parse_args()
 
-        self.master = GpDB.initFromString(
+        self.master = Segment.initFromString(
             "1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
-        self.standby = GpDB.initFromString(
+        self.standby = Segment.initFromString(
             "2|-1|m|m|s|u|sdw1|sdw1|25432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
-        self.primary0 = GpDB.initFromString(
+        self.primary0 = Segment.initFromString(
             "3|0|p|p|s|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
-        self.mirror0 = GpDB.initFromString(
+        self.mirror0 = Segment.initFromString(
             "4|0|m|m|s|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
         self.mock_gparray.return_value = GpArray([self.master, self.standby, self.primary0, self.mirror0])
 
@@ -308,13 +308,13 @@ class GpStop(GpTestCase):
         parser = self.subject.GpStop.createParser()
         options, args = parser.parse_args()
 
-        self.master = GpDB.initFromString(
+        self.master = Segment.initFromString(
             "1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
-        self.standby = GpDB.initFromString(
+        self.standby = Segment.initFromString(
             "2|-1|m|m|s|u|sdw1|sdw1|25432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
-        self.primary0 = GpDB.initFromString(
+        self.primary0 = Segment.initFromString(
             "3|0|p|p|s|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
-        self.primary1 = GpDB.initFromString(
+        self.primary1 = Segment.initFromString(
             "4|0|p|p|s|u|sdw2|sdw2|40001|41001|/data/primary1||/data/primary1/base/10899,/data/primary1/base/1,/data/primary1/base/10898,/data/primary1/base/25780,/data/primary1/base/34782")
         self.mock_gparray.return_value = GpArray([self.master, self.standby, self.primary0, self.primary1])
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gptransfer.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gptransfer.py
@@ -7,7 +7,7 @@ import tempfile
 import shutil
 from mock import *
 from gp_unittest import *
-from gparray import GpDB, GpArray
+from gparray import Segment, GpArray
 from gppylib.db.dbconn import UnexpectedRowsError
 from pygresql import pgdb
 from gppylib.operations.backup_utils import escapeDoubleQuoteInSQLString
@@ -1080,15 +1080,15 @@ class GpTransfer(GpTestCase):
         self.assertIn("Partition value is different in the partition hierarchy between", log_messages[1])
 
     def createGpArrayWith2Primary2Mirrors(self):
-        master = GpDB.initFromString(
+        master = Segment.initFromString(
             "1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
-        primary0 = GpDB.initFromString(
+        primary0 = Segment.initFromString(
             "2|0|p|p|s|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
-        primary1 = GpDB.initFromString(
+        primary1 = Segment.initFromString(
             "3|1|p|p|s|u|sdw2|sdw2|40001|41001|/data/primary1||/data/primary1/base/10899,/data/primary1/base/1,/data/primary1/base/10898,/data/primary1/base/25780,/data/primary1/base/34782")
-        mirror0 = GpDB.initFromString(
+        mirror0 = Segment.initFromString(
             "4|0|m|m|s|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
-        mirror1 = GpDB.initFromString(
+        mirror1 = Segment.initFromString(
             "5|1|m|m|s|u|sdw1|sdw1|50001|51001|/data/mirror1||/data/mirror1/base/10899,/data/mirror1/base/1,/data/mirror1/base/10898,/data/mirror1/base/25780,/data/mirror1/base/34782")
         return GpArray([master, primary0, primary1, mirror0, mirror1])
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_heapchecksum.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_heapchecksum.py
@@ -1,6 +1,6 @@
 from mock import Mock, patch
 
-from gparray import GpDB, GpArray
+from gparray import Segment, GpArray
 from gppylib.commands.base import CommandResult
 from gppylib.heapchecksum import HeapChecksum, REMOTE
 from gppylib.test.unit.gp_unittest import GpTestCase
@@ -67,17 +67,17 @@ Data page checksum version:           1
         super(GpHeapChecksumTestCase, self).tearDown()
 
     def createGpArrayWith2Primary2Mirrors(self):
-        master = GpDB.initFromString(
+        master = Segment.initFromString(
             "1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
-        self.primary0 = GpDB.initFromString(
+        self.primary0 = Segment.initFromString(
             "2|0|p|p|s|u|aspen|sdw1|40000|41000|/Users/pivotal/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
-        primary1 = GpDB.initFromString(
+        primary1 = Segment.initFromString(
             "3|1|p|p|s|u|sdw2|sdw2|40001|41001|/data/primary1||/data/primary1/base/10899,/data/primary1/base/1,/data/primary1/base/10898,/data/primary1/base/25780,/data/primary1/base/34782")
-        mirror0 = GpDB.initFromString(
+        mirror0 = Segment.initFromString(
             "4|0|m|m|s|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
-        mirror1 = GpDB.initFromString(
+        mirror1 = Segment.initFromString(
             "5|1|m|m|s|u|sdw1|sdw1|50001|51001|/data/mirror1||/data/mirror1/base/10899,/data/mirror1/base/1,/data/mirror1/base/10898,/data/mirror1/base/25780,/data/mirror1/base/34782")
-        standby_master = GpDB.initFromString(
+        standby_master = Segment.initFromString(
             "6|-1|m|m|s|u|mdw_standby|mdw_standby|25432|None|/data/standby_master||/data/standby_master/base/10899,/data/standby_master/base/1,/data/standby_master/base/10898,/data/standby_master/base/25780,/data/standby_master/base/34782")
         return GpArray([master, self.primary0, primary1, mirror0, mirror1, standby_master])
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_rebalance_segment.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_rebalance_segment.py
@@ -1,7 +1,7 @@
 from mock import *
 
 from gp_unittest import *
-from gppylib.gparray import GpArray, GpDB
+from gppylib.gparray import GpArray, Segment
 from gppylib.commands.base import CommandResult
 from gppylib.operations.rebalanceSegments import GpSegmentRebalanceOperation
 
@@ -59,15 +59,15 @@ class RebalanceSegmentsTestCase(GpTestCase):
         self.assertFalse(result)
 
     def _create_gparray_with_2_primary_2_mirrors(self):
-        master = GpDB.initFromString(
+        master = Segment.initFromString(
             "1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
-        self.primary0 = GpDB.initFromString(
+        self.primary0 = Segment.initFromString(
             "2|0|p|p|s|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
-        primary1 = GpDB.initFromString(
+        primary1 = Segment.initFromString(
             "3|1|p|p|s|u|sdw2|sdw2|40001|41001|/data/primary1||/data/primary1/base/10899,/data/primary1/base/1,/data/primary1/base/10898,/data/primary1/base/25780,/data/primary1/base/34782")
-        self.mirror0 = GpDB.initFromString(
+        self.mirror0 = Segment.initFromString(
             "4|0|m|m|s|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
-        mirror1 = GpDB.initFromString(
+        mirror1 = Segment.initFromString(
             "5|1|m|m|s|u|sdw1|sdw1|50001|51001|/data/mirror1||/data/mirror1/base/10899,/data/mirror1/base/1,/data/mirror1/base/10898,/data/mirror1/base/25780,/data/mirror1/base/34782")
         return GpArray([master, self.primary0, primary1, self.mirror0, mirror1])
 

--- a/gpMgmt/bin/gppylib/testold/testDriver.py
+++ b/gpMgmt/bin/gppylib/testold/testDriver.py
@@ -4,7 +4,7 @@ from gppylib.gplog import *
 from gppylib.system.configurationInterface import *
 from gppylib.system import configurationImplTest, fileSystemImplTest, fileSystemInterface, osInterface, osImplTest, \
         faultProberInterface, faultProberImplTest
-from gppylib.gparray import GpDB
+from gppylib.gparray import Segment
 
 logger = get_default_logger()
 
@@ -51,17 +51,17 @@ class TestDriver:
             dataDirectory = row[9]
             replicationPort = None if row[10] == "" else int(row[10])
 
-            segment = GpDB(content=contentId,
-                           preferred_role=preferredRole,
-                           dbid=dbId,
-                           role=role,
-                           mode=mode,
-                           status=status,
-                           hostname=hostName,
-                           address=address,
-                           port=port,
-                           datadir=dataDirectory,
-                           replicationPort=replicationPort)
+            segment = Segment(content=contentId,
+                              preferred_role=preferredRole,
+                              dbid=dbId,
+                              role=role,
+                              mode=mode,
+                              status=status,
+                              hostname=hostName,
+                              address=address,
+                              port=port,
+                              datadir=dataDirectory,
+                              replicationPort=replicationPort)
 
             self.__configurationProvider.addTestSegment(segment)
 

--- a/gpMgmt/bin/gppylib/utils.py
+++ b/gpMgmt/bin/gppylib/utils.py
@@ -643,7 +643,7 @@ def createSegmentSpecificPath(path, gpPrefix, segment):
     Create a segment specific path for the given gpPrefix and segment
 
     @param gpPrefix a string used to prefix directory names
-    @param segment a GpDB value
+    @param segment a Segment value
     """
     return os.path.join(path, '%s%d' % (gpPrefix, segment.getSegmentContentId()))
 

--- a/gpMgmt/bin/gpstart
+++ b/gpMgmt/bin/gpstart
@@ -547,8 +547,8 @@ class GpStart:
                              if f.getReasonCode() == gp.SEGSTART_ERROR_MIRRORING_FAILURE]
 
         allSegmentsByContent = GpArray.getSegmentsByContentId(gparray.getSegDbList())
-        successfulSegmentsByDbId = GpArray.getSegmentsGroupedByValue(successfulSegments, GpDB.getSegmentDbId)
-        mirroringFailuresByDbId = GpArray.getSegmentsGroupedByValue(mirroringFailures, GpDB.getSegmentDbId)
+        successfulSegmentsByDbId = GpArray.getSegmentsGroupedByValue(successfulSegments, Segment.getSegmentDbId)
+        mirroringFailuresByDbId = GpArray.getSegmentsGroupedByValue(mirroringFailures, Segment.getSegmentDbId)
 
         #
         # look at each content, see if there is a segment available (or one which can be made

--- a/gpMgmt/bin/lib/gpconfigurenewsegment
+++ b/gpMgmt/bin/lib/gpconfigurenewsegment
@@ -11,7 +11,7 @@ from gppylib.commands import unix
 from gppylib.commands.pg import DbStatus
 from gppylib import gplog
 from gppylib.commands.base import *
-from gppylib.gparray import GpDB
+from gppylib.gparray import Segment
 from gppylib.utils import canStringBeParsedAsInt
 from gppylib.gp_dbid import writeGpDbidFile
 from time import sleep

--- a/gpMgmt/sbin/gpgetstatususingtransition.py
+++ b/gpMgmt/sbin/gpgetstatususingtransition.py
@@ -143,7 +143,7 @@ class GpSegStatusProgram:
             raise ProgramArgumentValidationException("-D argument not specified")
 
         toFetch = self.__options.statusQueryRequests.split(":")
-        segments = map(gparray.GpDB.initFromString, self.__options.dirList)
+        segments = map(gparray.Segment.initFromString, self.__options.dirList)
 
         output = {}
         for seg in segments:

--- a/gpMgmt/sbin/gpsegstart.py
+++ b/gpMgmt/sbin/gpsegstart.py
@@ -135,7 +135,7 @@ class GpSegStart:
 
         # validate/store arguments
         #
-        self.dblist                = map(gparray.GpDB.initFromString, dblist)
+        self.dblist                = map(gparray.Segment.initFromString, dblist)
 
         expected_gpversion         = gpversion
         actual_gpversion           = gp.GpVersion.local('local GP software version check', os.path.abspath(os.pardir))
@@ -297,7 +297,7 @@ class GpSegStart:
         # examine the results from the segments
         #
         segments     = self.overall_status.dirmap.values()
-        dataDirToSeg = gparray.GpArray.getSegmentsGroupedByValue(segments, gparray.GpDB.getSegmentDataDirectory)
+        dataDirToSeg = gparray.GpArray.getSegmentsGroupedByValue(segments, gparray.Segment.getSegmentDataDirectory)
         toStop       = []
         cmds         = self.pool.getCompletedItems()
 

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/xidlimits/test_xidlimits.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/xidlimits/test_xidlimits.py
@@ -201,7 +201,7 @@ class XidlimitsTests(MPPTestCase):
 
         @param limit: one of WARN_LIMIT, STOP_LIMIT and WRAP_LIMIT.
 
-        @param segdb: an instance of GpDB class representing the segment on
+        @param segdb: an instance of Segment class representing the segment on
         which the limit will be exceeded.
         """
         dburl = dbconn.DbURL(hostname=segdb.hostname, port=segdb.port)
@@ -274,7 +274,7 @@ class XidlimitsTests(MPPTestCase):
         that is created off template0.
 
         @param segdb: identifies the segment on which to operate.  It is an
-        instance of GpDB class.
+        instance of Segment class.
 
         Note that the database dbname must have all tuples frozen (xmin=2).
         This holds true of template0 and of a database created off template0,


### PR DESCRIPTION
The gpArray use of GpDB and Segment classes was confusing. This change renames GpDB to Segment and Segment to SegmentPair to clarify usage. Its a big diff, but a simple, repeating change.

We also refactored SegmentPair to conform to  our usage of only one mirror per primary.
