### PR TITLE
Fix Filter required properties for correlated subqueries in ORCA

### DIFF
--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v2.53.4@gpdb/stable
+orca/v2.53.8@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -121,7 +121,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget -q -O - https://github.com/greenplum-db/gporca/releases/download/v2.53.4/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget -q -O - https://github.com/greenplum-db/gporca/releases/download/v2.53.8/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -53,6 +53,23 @@ insert into C values(99,7);
 insert into C values(78,62);
 insert into C values(2,7);
 analyze C;
+create table D(i integer, j integer) distributed by (j);
+insert into D values(1,1);
+insert into D values(19,5);
+insert into D values(99,62);
+insert into D values(1,1);
+insert into D values(78,-1);
+analyze D;
+create table E(i integer, j integer) distributed by (i);
+insert into E values(1,889);
+insert into E values(288,1);
+insert into E values(-1,625);
+insert into E values(32,65);
+insert into E values(32,62);
+insert into E values(3,-1);
+insert into E values(99,7);
+insert into E values(78,62);
+analyze E;
 -- end_ignore
 -- -- -- --
 -- Basic queries with IN clause
@@ -186,6 +203,19 @@ select * from A where exists (select * from B,C where C.j = A.j and B.i not in (
  78 | -1
  99 | 62
 (4 rows)
+
+select * from A,B where exists (select * from E where E.j = A.j and B.i not in (select E.i from E where E.i != 10)) order by 1,2,3,4;
+ i  | j  | i  | j 
+----+----+----+---
+  1 |  1 |  2 | 7
+  1 |  1 |  2 | 7
+  1 |  1 | 88 | 1
+  1 |  1 | 88 | 1
+ 78 | -1 |  2 | 7
+ 78 | -1 | 88 | 1
+ 99 | 62 |  2 | 7
+ 99 | 62 | 88 | 1
+(8 rows)
 
 select * from B where not exists (select * from A,C where C.j = A.j and B.i in (select max(C.i) from C where C.i = A.i and C.i != 10)) order by 1, 2;
  i  | j  
@@ -1295,15 +1325,6 @@ insert into qp_csq_t4 values (3,4);
 insert into qp_csq_t4 values (5,6);
 insert into qp_csq_t4 values (7,8);
 analyze qp_csq_t4;
-drop table if exists D;
-NOTICE:  table "d" does not exist, skipping
-create table D(i integer, j integer) distributed by (j);
-insert into D values(1,1);
-insert into D values(19,5);
-insert into D values(99,62);
-insert into D values(1,1);
-insert into D values(78,-1);
-analyze D;
 -- end_ignore
 -- -- -- --
 -- Basic CSQ with UPDATE statements

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -53,6 +53,23 @@ insert into C values(99,7);
 insert into C values(78,62);
 insert into C values(2,7);
 analyze C;
+create table D(i integer, j integer) distributed by (j);
+insert into D values(1,1);
+insert into D values(19,5);
+insert into D values(99,62);
+insert into D values(1,1);
+insert into D values(78,-1);
+analyze D;
+create table E(i integer, j integer) distributed by (i);
+insert into E values(1,889);
+insert into E values(288,1);
+insert into E values(-1,625);
+insert into E values(32,65);
+insert into E values(32,62);
+insert into E values(3,-1);
+insert into E values(99,7);
+insert into E values(78,62);
+analyze E;
 -- end_ignore
 -- -- -- --
 -- Basic queries with IN clause
@@ -186,6 +203,19 @@ select * from A where exists (select * from B,C where C.j = A.j and B.i not in (
  78 | -1
  99 | 62
 (4 rows)
+
+select * from A,B where exists (select * from E where E.j = A.j and B.i not in (select E.i from E where E.i != 10)) order by 1,2,3,4;
+ i  | j  | i  | j 
+----+----+----+---
+  1 |  1 |  2 | 7
+  1 |  1 |  2 | 7
+  1 |  1 | 88 | 1
+  1 |  1 | 88 | 1
+ 78 | -1 |  2 | 7
+ 78 | -1 | 88 | 1
+ 99 | 62 |  2 | 7
+ 99 | 62 | 88 | 1
+(8 rows)
 
 select * from B where not exists (select * from A,C where C.j = A.j and B.i in (select max(C.i) from C where C.i = A.i and C.i != 10)) order by 1, 2;
  i  | j  
@@ -694,9 +724,13 @@ select * from A,B where exists (select * from C where C.j = A.j and B.i = all (s
 
 -- Planner should fail due to skip-level correlation not supported. ORCA should pass
 select * from A,B where exists (select * from C where C.j = A.j and B.i = all (select min(C.j) from C where C.j = B.j)) order by 1,2,3,4;
- i | j | i | j 
----+---+---+---
-(0 rows)
+ i  | j  | i | j
+----+----+---+---
+  1 |  1 | 1 | 1
+  1 |  1 | 1 | 1
+ 78 | -1 | 1 | 1
+ 99 | 62 | 1 | 1
+(4 rows)
 
 explain select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C where C.j = A.j and C.i = all (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
                                                                                                                                                                                                                                   QUERY PLAN                                                                                                                                                                                                                                  
@@ -1430,15 +1464,6 @@ insert into qp_csq_t4 values (3,4);
 insert into qp_csq_t4 values (5,6);
 insert into qp_csq_t4 values (7,8);
 analyze qp_csq_t4;
-drop table if exists D;
-NOTICE:  table "d" does not exist, skipping
-create table D(i integer, j integer) distributed by (j);
-insert into D values(1,1);
-insert into D values(19,5);
-insert into D values(99,62);
-insert into D values(1,1);
-insert into D values(78,-1);
-analyze D;
 -- end_ignore
 -- -- -- --
 -- Basic CSQ with UPDATE statements

--- a/src/test/regress/expected/rangefuncs_optimizer.out
+++ b/src/test/regress/expected/rangefuncs_optimizer.out
@@ -25,16 +25,18 @@ LINE 1: select * from foo2, foot(foo2.fooid) z where foo2.f2 = z.f2;
                                  ^
 -- function in subselect
 select * from foo2 where f2 in (select f2 from foot(foo2.fooid) z where z.fooid = foo2.fooid) ORDER BY 1,2;
-ERROR:  function cannot execute on a QE slice because it accesses relation "public.foo2" 
-DETAIL:  SQL function "foot" during startup
+ERROR:  query plan with multiple segworker groups is not supported
+HINT:  likely caused by a function that reads or modifies data in a distributed table
+CONTEXT:  SQL function "foot" statement 1
 -- function in subselect
 select * from foo2 where f2 in (select f2 from foot(1) z where z.fooid = foo2.fooid) ORDER BY 1,2;
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.foo2"  
 DETAIL:  SQL function "foot" during startup
 -- function in subselect
 select * from foo2 where f2 in (select f2 from foot(foo2.fooid) z where z.fooid = 1) ORDER BY 1,2;
-ERROR:  function cannot execute on a QE slice because it accesses relation "public.foo2" 
-DETAIL:  SQL function "foot" during startup
+ERROR:  query plan with multiple segworker groups is not supported
+HINT:  likely caused by a function that reads or modifies data in a distributed table
+CONTEXT:  SQL function "foot" statement 1
 -- nested functions
 select foot.fooid, foot.f2 from foot(sin(pi()/2)::int) ORDER BY 1,2;
  fooid | f2  

--- a/src/test/regress/sql/qp_correlated_query.sql
+++ b/src/test/regress/sql/qp_correlated_query.sql
@@ -68,6 +68,27 @@ insert into C values(78,62);
 insert into C values(2,7);
 
 analyze C;
+
+create table D(i integer, j integer) distributed by (j);
+insert into D values(1,1);
+insert into D values(19,5);
+insert into D values(99,62);
+insert into D values(1,1);
+insert into D values(78,-1);
+
+analyze D;
+
+create table E(i integer, j integer) distributed by (i);
+insert into E values(1,889);
+insert into E values(288,1);
+insert into E values(-1,625);
+insert into E values(32,65);
+insert into E values(32,62);
+insert into E values(3,-1);
+insert into E values(99,7);
+insert into E values(78,62);
+
+analyze E;
 -- end_ignore
 
 -- -- -- --
@@ -92,6 +113,7 @@ select A.i, B.i, C.j from A, B, C where A.j in (select C.j from C where C.j = A.
 select a, x from qp_csq_t1, qp_csq_t2 where qp_csq_t1.a not in (select x) order by a,x;
 select A.i from A where A.i not in (select B.i from B where A.i = B.i) order by A.i;
 select * from A where exists (select * from B,C where C.j = A.j and B.i not in (select sum(C.i) from C where C.i = B.i and C.i != 10)) order by 1,2;
+select * from A,B where exists (select * from E where E.j = A.j and B.i not in (select E.i from E where E.i != 10)) order by 1,2,3,4;
 
 select * from B where not exists (select * from A,C where C.j = A.j and B.i in (select max(C.i) from C where C.i = A.i and C.i != 10)) order by 1, 2;
 select * from B where not exists (select * from A,C where C.j = A.j and B.i not in (select max(C.i) from C where C.i = A.i and C.i != 10)) order by 1, 2;
@@ -247,16 +269,6 @@ insert into qp_csq_t4 values (7,8);
 
 analyze qp_csq_t4;
 
-drop table if exists D;
-
-create table D(i integer, j integer) distributed by (j);
-insert into D values(1,1);
-insert into D values(19,5);
-insert into D values(99,62);
-insert into D values(1,1);
-insert into D values(78,-1);
-
-analyze D;
 -- end_ignore
 
 -- -- -- --


### PR DESCRIPTION
This commit brings in ORCA changes that ensure that a Materialize node is not
added under a Filter when its child contains outer references.  Otherwise, the
subplan is not rescanned (because it is under a Material), producing wrong
results. A rescan is necessary for it evaluates the subplan for each of the
outer referenced values.

For example:

```
SELECT * FROM A,B WHERE EXISTS (
  SELECT * FROM E WHERE E.j = A.j and B.i NOT IN (
    SELECT E.i FROM E WHERE E.i != 10));
```

For the above query ORCA produces a plan with two nested subplans:

```
Result
  Filter: (SubPlan 2)
  ->  Gather Motion 3:1
        ->  Nested Loop
              Join Filter: true
              ->  Broadcast Motion 3:3
                    ->  Table Scan on a
              ->  Table Scan on b
  SubPlan 2
    ->  Result
          Filter: public.c.j = $0
          ->  Materialize
                ->  Result
                      Filter: (SubPlan 1)
                      ->  Materialize
                            ->  Gather Motion 3:1
                                  ->  Table Scan on c
                      SubPlan 1
                        ->  Materialize
                              ->  Gather Motion 3:1
                                    ->  Table Scan on c
                                          Filter: i <> 10
```

The Materialize node (on top of Filter with Subplan 1) has cdb_strict = true.
The cdb_strict semantics dictate that when the Materialize is rescanned,
instead of destroying its tuplestore, it resets the accessor pointer to the
beginning and the subtree is NOT rescanned.
So the entries from the first scan are returned for all future calls; i.e. the
results depend on the first row output by the cross join. This causes wrong and
non-deterministic results.

Also, this commit reinstates this test in qp_correlated_query.sql. It also
fixes another wrong result caused by the same issue. Note that the changes in
rangefuncs_optimizer.out are because ORCA now no longer falls back for those
queries. Instead it produces a plan which is executed on master (instead of the
segments as was done by planner) which changes the error messages.

Also bump ORCA version to 2.53.5.

Signed-off-by: Ekta Khanna <ekhanna@pivotal.io>

ORCA PR: https://github.com/greenplum-db/gporca/pull/296