### PR TITLE
Enabled index scan for append-only tables

### DIFF
--- a/src/backend/access/index/indexam.c
+++ b/src/backend/access/index/indexam.c
@@ -674,6 +674,40 @@ index_getnext(IndexScanDesc scan, ScanDirection direction)
 }
 
 /* ----------------
+ * 		index_getnext_indexitem - get the next index tuple from a scan
+ *
+ * Finds the next index tuple satisfying the scan keys. Note that the
+ * corresponding heap tuple is not accessed, and thus no time qual (snapshot)
+ * check is done, other than the index AM's internal check for killed tuples
+ * (which most callers of this routine will probably want to suppress by
+ * setting scan->ignore_killed_tuples = false).
+ *
+ * On success (TRUE return), the heap TID of the found index entry is in
+ * scan->xs_ctup.t_self, scan->xs_cbuf is untouched.
+ */
+bool
+index_getnext_indexitem(IndexScanDesc scan, ScanDirection direction)
+{
+	FmgrInfo *procedure;
+	bool found;
+
+	SCAN_CHECKS;
+	GET_SCAN_PROCEDURE(amgettuple);
+
+	/* just make sure this is false... */
+	scan->kill_prior_tuple = false;
+
+	/*
+	 * have the am's gettuple proc do all the work.
+	 */
+	found = DatumGetBool(FunctionCall2(procedure,
+									PointerGetDatum(scan),
+									Int32GetDatum(direction)));
+
+	return found;
+}
+
+/* ----------------
  *		index_getbitmap - get all tuples at once from an index scan
  *
  *		it invokes am's getmulti function to get a bitmap. If am is an on-disk

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -368,9 +368,16 @@ set_plain_rel_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 	 * The appendonlyam.c module will optimize fetches in TID order by keeping
 	 * the last decompressed block between fetch calls.
 	 */
-	if (rel->relstorage == RELSTORAGE_AOROWS ||
-		rel->relstorage == RELSTORAGE_AOCOLS)
-		indexpathlist = NIL;
+	/*
+	 * Through introducing one GUC, we can control whether to use index scan
+	 * for Append-Only tables.
+	 */
+	if (!root->config->gp_enable_appendonly_indexscan)
+	{
+		if (rel->relstorage == RELSTORAGE_AOROWS ||
+				rel->relstorage == RELSTORAGE_AOCOLS)
+			indexpathlist = NIL;
+	}
 
 	if (indexpathlist && root->config->enable_indexscan)
 		pathlist = list_concat(pathlist, indexpathlist);

--- a/src/backend/optimizer/path/indxpath.c
+++ b/src/backend/optimizer/path/indxpath.c
@@ -1917,9 +1917,12 @@ best_inner_indexscan(PlannerInfo *root, RelOptInfo *rel,
 		indexpaths = NIL;
 
 	/* Exclude plain index paths if the relation is an append-only relation. */
-	if (rel->relstorage == RELSTORAGE_AOROWS ||
-		rel->relstorage == RELSTORAGE_AOCOLS)
-		indexpaths = NIL;
+	if (!root->config->gp_enable_appendonly_indexscan)
+	{
+		if (rel->relstorage == RELSTORAGE_AOROWS ||
+				rel->relstorage == RELSTORAGE_AOCOLS)
+			indexpaths = NIL;
+	}
 
 	/*
 	 * If we found anything usable, generate a BitmapHeapPath for the most

--- a/src/backend/optimizer/plan/planmain.c
+++ b/src/backend/optimizer/plan/planmain.c
@@ -532,6 +532,7 @@ PlannerConfig *DefaultPlannerConfig(void)
 	c1->enable_mergejoin = enable_mergejoin;
 	c1->enable_hashjoin = enable_hashjoin;
 	c1->gp_enable_hashjoin_size_heuristic = gp_enable_hashjoin_size_heuristic;
+	c1->gp_enable_appendonly_indexscan = gp_enable_appendonly_indexscan;
 	c1->gp_enable_fallback_plan = gp_enable_fallback_plan;
 	c1->gp_enable_predicate_propagation = gp_enable_predicate_propagation;
 	c1->mpp_trying_fallback_plan = false;

--- a/src/backend/optimizer/plan/setrefs.c
+++ b/src/backend/optimizer/plan/setrefs.c
@@ -480,13 +480,6 @@ set_plan_refs(PlannerGlobal *glob, Plan *plan, int rtoffset)
 
 				splan->scan.scanrelid += rtoffset;
 
-#ifdef USE_ASSERT_CHECKING
-				RangeTblEntry *rte = rt_fetch(splan->scan.scanrelid, glob->finalrtable);
-				char relstorage = get_rel_relstorage(rte->relid);
-				Assert(relstorage != RELSTORAGE_AOROWS &&
-					   relstorage != RELSTORAGE_AOCOLS);
-#endif
-
 				splan->scan.plan.targetlist =
 					fix_scan_list(glob, splan->scan.plan.targetlist, rtoffset);
 				splan->scan.plan.qual =

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -392,6 +392,7 @@ int			gp_idf_deduplicate;
 bool		fts_diskio_check = false;
 
 /* Planner gucs */
+bool		gp_enable_appendonly_indexscan = false;
 bool		gp_enable_hashjoin_size_heuristic = false;
 bool		gp_enable_fallback_plan = true;
 bool		gp_enable_predicate_propagation = false;
@@ -706,6 +707,14 @@ struct config_bool ConfigureNamesBool_gp[] =
 		},
 		&enable_groupagg,
 		true, NULL, NULL
+	},
+	{
+		{"gp_enable_appendonly_indexscan", PGC_USERSET, QUERY_TUNING_METHOD,
+			gettext_noop("Enables the planner's use of index scan plans for append-only tables."),
+			NULL
+		},
+		&gp_enable_appendonly_indexscan,
+		false, NULL, NULL
 	},
 	{
 		{"gp_enable_hashjoin_size_heuristic", PGC_USERSET, QUERY_TUNING_METHOD,

--- a/src/include/access/genam.h
+++ b/src/include/access/genam.h
@@ -117,6 +117,7 @@ extern void index_endscan(IndexScanDesc scan);
 extern void index_markpos(IndexScanDesc scan);
 extern void index_restrpos(IndexScanDesc scan);
 extern HeapTuple index_getnext(IndexScanDesc scan, ScanDirection direction);
+extern bool index_getnext_indexitem(IndexScanDesc scan, ScanDirection direction);
 extern Node *index_getbitmap(IndexScanDesc scan, Node *bitmap);
 
 extern IndexBulkDeleteResult *index_bulk_delete(IndexVacuumInfo *info,

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -42,6 +42,8 @@ struct MemTupleBinding;
 struct MemTupleData;
 struct HeapScanDescData;
 struct FileScanDescData;
+struct AppendOnlyFetchDescData;
+struct AOCSFetchDescData;
 struct MirroredBufferPoolBulkLoadInfo;
 struct SliceTable;
 
@@ -1701,6 +1703,8 @@ typedef struct IndexScanState
 	ExprContext *iss_RuntimeContext;
 	Relation	iss_RelationDesc;
 	IndexScanDesc iss_ScanDesc;
+	struct AppendOnlyFetchDescData *iss_AOFetchDesc;
+	struct AOCSFetchDescData *iss_AOCSFetchDesc;
 
 	/*
 	 * tableOid is the oid of the partition or relation on which our current

--- a/src/include/nodes/plannerconfig.h
+++ b/src/include/nodes/plannerconfig.h
@@ -24,6 +24,7 @@ typedef struct PlannerConfig
 	bool		enable_mergejoin;
 	bool		enable_hashjoin;
 	bool        gp_enable_hashjoin_size_heuristic;
+	bool		gp_enable_appendonly_indexscan;
 	bool		gp_enable_fallback_plan;
 	bool        gp_enable_predicate_propagation;
 	bool		mpp_trying_fallback_plan;

--- a/src/include/optimizer/cost.h
+++ b/src/include/optimizer/cost.h
@@ -82,6 +82,7 @@ extern int	constraint_exclusion;
 
 extern Cost disable_cost;
 
+extern bool gp_enable_appendonly_indexscan;
 extern bool gp_enable_hashjoin_size_heuristic;          /*CDB*/
 extern bool gp_enable_fallback_plan;
 extern bool gp_enable_predicate_propagation;


### PR DESCRIPTION
As the title suggested, this commit enables the planner to generate index scan plans for append-only (including row-oriented and column-oriented) tables.

A little bit about the background of this commit. In our company, HashData Inc., we are using append-only tables (especially column-oriented) aggressively. This is because we are using object storage services, such as AWS S3, Aliyun OSS, QingCloud QingStor and etc., as the underlying storage layer, and the objects (files) provided by most of object storage systems are immutable. Using append-only tables as the default table format is a more natural choice. Even using append-only tables, we still want to provide full functionalities as those provided by heap tables. That's why we want to enable index scan for append-only tables. Actually, even for GPDB, in many usage cases of append-only tables, index scan plans are 100~1000 times faster than sequence scan plans, especially for those queries like "ORDER BY key LIMIT 10" with a btree index built on the "key" column.

There are some remaining issues: (1) this commit only enabled the legacy planner to generate index scan plans for append-only tables; we still need to update the code of ORCA to enable ORCA to generate index scan plans for append-only tables. Since I am not quite familiar with ORCA, that task is far beyond my capability. (2) Even for the legacy planner, the implementation of this commit just works. There is still much room for improvement.


