### PR TITLE
Fix bug that planner generates redundant motion for joins on distribution key

### DIFF
--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -339,6 +339,36 @@ select * from foo where a not in (select c from bar where c <= 5);
 set enable_nestloop to off;
 set enable_hashjoin to on;
 set enable_mergejoin to off;
+CREATE TABLE R(a varchar(20), b int) DISTRIBUTED BY (a);
+CREATE TABLE S(a varchar(20), b int) DISTRIBUTED BY (a);
+-- Make sure there is no motion to redistribute or broadcast any table,
+-- because the join keys are also the distribution key of the 2 tables.
+EXPLAIN SELECT * FROM R, S WHERE R.a = S.a;
+                                        QUERY PLAN
+-------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=898.75..171576.25 rows=1260250 width=124)
+   ->  Hash Join  (cost=898.75..171576.25 rows=420084 width=124)
+         Hash Cond: r.a::text = s.a::text
+         ->  Seq Scan on r  (cost=0.00..455.00 rows=11834 width=62)
+         ->  Hash  (cost=455.00..455.00 rows=11834 width=62)
+               ->  Seq Scan on s  (cost=0.00..455.00 rows=11834 width=62)
+ Settings:  enable_hashjoin=on; enable_mergejoin=off; enable_nestloop=off; optimizer=off
+ Optimizer status: legacy query optimizer
+(8 rows)
+
+EXPLAIN SELECT * FROM R LEFT OUTER JOIN S ON R.a = S.a;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=898.75..171576.25 rows=1260250 width=124)
+   ->  Hash Left Join  (cost=898.75..171576.25 rows=420084 width=124)
+         Hash Cond: r.a::text = s.a::text
+         ->  Seq Scan on r  (cost=0.00..455.00 rows=11834 width=62)
+         ->  Hash  (cost=455.00..455.00 rows=11834 width=62)
+               ->  Seq Scan on s  (cost=0.00..455.00 rows=11834 width=62)
+ Settings:  enable_hashjoin=on; enable_mergejoin=off; enable_nestloop=off; optimizer=off
+ Optimizer status: legacy query optimizer
+(8 rows)
+
 create table dept
 (
 	id int,

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -350,6 +350,35 @@ select * from foo where a not in (select c from bar where c <= 5);
 set enable_nestloop to off;
 set enable_hashjoin to on;
 set enable_mergejoin to off;
+CREATE TABLE R(a varchar(20), b int) DISTRIBUTED BY (a);
+CREATE TABLE S(a varchar(20), b int) DISTRIBUTED BY (a);
+-- Make sure there is no motion to redistribute or broadcast any table,
+-- because the join keys are also the distribution key of the 2 tables.
+EXPLAIN SELECT * FROM R, S WHERE R.a = S.a;
+                                       QUERY PLAN
+----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=24)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=24)
+         Hash Cond: r.a::text = s.a::text
+         ->  Table Scan on r  (cost=0.00..431.00 rows=1 width=12)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=12)
+               ->  Table Scan on s  (cost=0.00..431.00 rows=1 width=12)
+ Settings:  enable_hashjoin=on; enable_mergejoin=off; enable_nestloop=off; optimizer=on
+ Optimizer status: PQO version 2.53.4
+(8 rows)
+
+EXPLAIN SELECT * FROM R LEFT OUTER JOIN S ON R.a = S.a;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=2 width=24)
+   ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=24)
+         Hash Cond: r.a::text = s.a::text
+         ->  Table Scan on r  (cost=0.00..431.00 rows=1 width=12)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=12)
+               ->  Table Scan on s  (cost=0.00..431.00 rows=1 width=12)
+ Optimizer: PQO version 2.55.10
+(7 rows)
+
 create table dept
 (
 	id int,

--- a/src/test/regress/sql/join_gp.sql
+++ b/src/test/regress/sql/join_gp.sql
@@ -173,6 +173,13 @@ set enable_nestloop to off;
 set enable_hashjoin to on;
 set enable_mergejoin to off;
 
+CREATE TABLE R(a varchar(20), b int) DISTRIBUTED BY (a);
+CREATE TABLE S(a varchar(20), b int) DISTRIBUTED BY (a);
+-- Make sure there is no motion to redistribute or broadcast any table,
+-- because the join keys are also the distribution key of the 2 tables.
+EXPLAIN SELECT * FROM R, S WHERE R.a = S.a;
+EXPLAIN SELECT * FROM R LEFT OUTER JOIN S ON R.a = S.a;
+
 create table dept
 (
 	id int,


### PR DESCRIPTION
Commit 087bf2e8919d4403c345846245ed0682e134416c made big change on the
"equivalence classes" mechanism. Unfortunately, when it compares the expression
equality in function 'get_eclass_for_sort_expr', it doesn't strip out the
'relabel' node. GPDB may automatically add a relabel node(or cast it) for
binary-coercible type, like varchar to text, which causes planner to generate
bad plan to broadcast or redistribute the table that is already distributed by
the join key, due to the inablity to match the equivalence class in the
function. The issue has been fixed by stripping out the relabel node when
matching.

Fixes issue #4175.