### PR TITLE
Faithfully translate a cast over param for subplan testexpr

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -49,6 +49,7 @@ using namespace gpdxl;
 using namespace gpos;
 using namespace gpopt;
 
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CTranslatorDXLToScalar::CTranslatorDXLToScalar
@@ -590,35 +591,37 @@ CTranslatorDXLToScalar::PsubplanFromDXLNodeScSubPlan
 	)
 {
 	CDXLTranslateContext *pdxltrctxOut = (dynamic_cast<CMappingColIdVarPlStmt*>(pmapcidvar))->PpdxltrctxOut();
-	
+
 	CContextDXLToPlStmt *pctxdxltoplstmt = (dynamic_cast<CMappingColIdVarPlStmt*>(pmapcidvar))->Pctxdxltoplstmt();
 
 	CDXLScalarSubPlan *pdxlop = CDXLScalarSubPlan::PdxlopConvert(pdxlnSubPlan->Pdxlop());
-	
+
 	// translate subplan test expression
-        SubLinkType slink = CTranslatorUtils::Slink(pdxlop->Edxlsptype());
-        Expr *pexprTestExpr = PexprSubplanTestExpr(pdxlop->PdxlnTestExpr(), slink, pmapcidvar);
+	List *plparamIds = NIL;
+
+	SubLinkType slink = CTranslatorUtils::Slink(pdxlop->Edxlsptype());
+	Expr *pexprTestExpr = PexprSubplanTestExpr(pdxlop->PdxlnTestExpr(), slink, pmapcidvar, &plparamIds);
 
 	const DrgPdxlcr *pdrgdxlcrOuterRefs = pdxlop->DrgdxlcrOuterRefs();
 	const DrgPmdid *pdrgmdidOuterRefs = pdxlop->DrgmdidOuterRefs();
 
 	const ULONG ulLen = pdrgdxlcrOuterRefs->UlLength();
-	
+
 	// create a copy of the translate context: the param mappings from the outer scope get copied in the constructor
 	CDXLTranslateContext dxltrctxSubplan(m_pmp, pdxltrctxOut->FParentAggNode(), pdxltrctxOut->PhmColParam());
-	
+
 	// insert new outer ref mappings in the subplan translate context
 	for (ULONG ul = 0; ul < ulLen; ul++)
 	{
 		IMDId *pmdid = (*pdrgmdidOuterRefs)[ul];
 		CDXLColRef *pdxlcr = (*pdrgdxlcrOuterRefs)[ul];
 		ULONG ulColid = pdxlcr->UlID();
-		
+
 		if (NULL == dxltrctxSubplan.Pmecolidparamid(ulColid))
 		{
 			// keep outer reference mapping to the original column for subsequent subplans
 			CMappingElementColIdParamId *pmecolidparamid = GPOS_NEW(m_pmp) CMappingElementColIdParamId(ulColid, pctxdxltoplstmt->UlNextParamId(), pmdid);
-			
+
 #ifdef GPOS_DEBUG
 			BOOL fInserted =
 #endif
@@ -652,16 +655,7 @@ CTranslatorDXLToScalar::PsubplanFromDXLNodeScSubPlan
 	// translate subplan and set test expression
 	SubPlan *psubplan = PsubplanFromChildPlan(pplanChild, slink, pctxdxltoplstmt);
 	psubplan->testexpr = (Node *) pexprTestExpr;
-	if (NULL != psubplan->testexpr && nodeTag(psubplan->testexpr) != T_Const)
-        {
-		// test expression is used for non-scalar subplan,
-		// second arg of test expression must be an EXEC param referring to subplan output,
-		// we add this param to subplan param ids before translating other params 
-
-                Param *pparam = (Param *) gpdb::PvListNth(((OpExpr *)psubplan->testexpr)->args, 1);
-                psubplan->paramIds = NIL;
-                psubplan->paramIds = gpdb::PlAppendInt(psubplan->paramIds, pparam->paramid);
-        }
+	psubplan->paramIds = plparamIds;
 
 	// translate other subplan params
 	TranslateSubplanParams(psubplan, &dxltrctxSubplan, pdrgdxlcrOuterRefs, pmapcidvar);
@@ -669,6 +663,28 @@ CTranslatorDXLToScalar::PsubplanFromDXLNodeScSubPlan
 	return (Expr *)psubplan;
 }
 
+inline BOOL FDXLCastedId(CDXLNode *pdxln)
+{
+	return EdxlopScalarCast == pdxln->Pdxlop()->Edxlop() &&
+		   pdxln->UlArity() > 0 && EdxlopScalarIdent == (*pdxln)[0]->Pdxlop()->Edxlop();
+}
+
+inline Oid OidParamOidFromDXLIdentOrDXLCastIdent(CDXLNode *pdxlnIdentOrCastIdent)
+{
+	GPOS_ASSERT(EdxlopScalarIdent == pdxlnIdentOrCastIdent->Pdxlop()->Edxlop() || FDXLCastedId(pdxlnIdentOrCastIdent));
+
+	CDXLScalarIdent *pdxlopInnerIdent;
+	if (EdxlopScalarIdent == pdxlnIdentOrCastIdent->Pdxlop()->Edxlop())
+	{
+		pdxlopInnerIdent = CDXLScalarIdent::PdxlopConvert(pdxlnIdentOrCastIdent->Pdxlop());
+	}
+	else
+	{
+		pdxlopInnerIdent = CDXLScalarIdent::PdxlopConvert((*pdxlnIdentOrCastIdent)[0]->Pdxlop());
+	}
+	Oid oidInnerType = CMDIdGPDB::PmdidConvert(pdxlopInnerIdent->PmdidType())->OidObjectId();
+	return oidInnerType;
+}
 
 //---------------------------------------------------------------------------
 //      @function:
@@ -683,7 +699,8 @@ CTranslatorDXLToScalar::PexprSubplanTestExpr
 	(
 	CDXLNode *pdxlnTestExpr,
 	SubLinkType slink,
-	CMappingColIdVar *pmapcidvar
+	CMappingColIdVar *pmapcidvar,
+	List **plparamIds
 	)
 {
 	if (EXPR_SUBLINK == slink || EXISTS_SUBLINK == slink || NOT_EXISTS_SUBLINK == slink)
@@ -711,7 +728,7 @@ CTranslatorDXLToScalar::PexprSubplanTestExpr
 	CDXLNode *pdxlnOuterChild = (*pdxlnTestExpr)[0];
 	CDXLNode *pdxlnInnerChild = (*pdxlnTestExpr)[1];
 
-	if (EdxlopScalarIdent != pdxlnInnerChild->Pdxlop()->Edxlop())
+	if (EdxlopScalarIdent != pdxlnInnerChild->Pdxlop()->Edxlop() && !FDXLCastedId(pdxlnInnerChild))
 	{
 		// test expression is expected to be a comparison between an outer expression 
 		// and a scalar identifier from subplan child
@@ -720,10 +737,8 @@ CTranslatorDXLToScalar::PexprSubplanTestExpr
 
 	// extract type of inner column
         CDXLScalarComp *pdxlopCmp = CDXLScalarComp::PdxlopConvert(pdxlnTestExpr->Pdxlop());
-        CDXLScalarIdent *pdxlopInnerIdent = CDXLScalarIdent::PdxlopConvert(pdxlnInnerChild->Pdxlop());
-        Oid oidInnerType = CMDIdGPDB::PmdidConvert(pdxlopInnerIdent->PmdidType())->OidObjectId();
 
-	// create an OpExpr for subplan test expression
+		// create an OpExpr for subplan test expression
         OpExpr *popexpr = MakeNode(OpExpr);
         popexpr->opno = CMDIdGPDB::PmdidConvert(pdxlopCmp->Pmdid())->OidObjectId();
         const IMDScalarOp *pmdscop = m_pmda->Pmdscop(pdxlopCmp->Pmdid());
@@ -739,16 +754,31 @@ CTranslatorDXLToScalar::PexprSubplanTestExpr
         plistArgs = gpdb::PlAppendElement(plistArgs, pexprTestExprOuterArg);
 
 	// second arg must be an EXEC param which is replaced during query execution with subplan output
-        Param *pparam = MakeNode(Param);
-        pparam->paramkind = PARAM_EXEC;
-	CContextDXLToPlStmt *pctxdxltoplstmt = (dynamic_cast<CMappingColIdVarPlStmt*>(pmapcidvar))->Pctxdxltoplstmt();
+	Param *pparam = MakeNode(Param);
+	pparam->paramkind = PARAM_EXEC;
+	CContextDXLToPlStmt *pctxdxltoplstmt = (dynamic_cast<CMappingColIdVarPlStmt *>(pmapcidvar))->Pctxdxltoplstmt();
 	pparam->paramid = pctxdxltoplstmt->UlNextParamId();
-	pparam->paramtype = oidInnerType;
+	pparam->paramtype = OidParamOidFromDXLIdentOrDXLCastIdent(pdxlnInnerChild);
 
-        plistArgs = gpdb::PlAppendElement(plistArgs, pparam);
-        popexpr->args = plistArgs;
+	// test expression is used for non-scalar subplan,
+	// second arg of test expression must be an EXEC param referring to subplan output,
+	// we add this param to subplan param ids before translating other params
 
-        return (Expr *) popexpr;
+	*plparamIds = gpdb::PlAppendInt(*plparamIds, pparam->paramid);
+
+	if (EdxlopScalarIdent == pdxlnInnerChild->Pdxlop()->Edxlop())
+	{
+		plistArgs = gpdb::PlAppendElement(plistArgs, pparam);
+	}
+	else // we have a cast
+	{
+		CDXLScalarCast *pdxlScalaCast = CDXLScalarCast::PdxlopConvert(pdxlnInnerChild->Pdxlop());
+		Expr *pexprCastParam = PrelabeltypeOrFuncexprFromDXLNodeScalarCast(pdxlScalaCast, (Expr *) pparam);
+		plistArgs = gpdb::PlAppendElement(plistArgs, pexprCastParam);
+	}
+	popexpr->args = plistArgs;
+
+	return (Expr *) popexpr;
 }
 
 
@@ -1063,39 +1093,19 @@ CTranslatorDXLToScalar::PnullifFromDXLNodeScNullIf
 	return (Expr *) pnullifexpr;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CTranslatorDXLToScalar::PrelabeltypeFromDXLNodeScCast
-//
-//	@doc:
-//		Translates a DXL scalar cast into a GPDB RelabelType / FuncExpr node
-//
-//---------------------------------------------------------------------------
 Expr *
-CTranslatorDXLToScalar::PrelabeltypeFromDXLNodeScCast
-	(
-	const CDXLNode *pdxlnCast,
-	CMappingColIdVar *pmapcidvar
-	)
+CTranslatorDXLToScalar::PrelabeltypeOrFuncexprFromDXLNodeScalarCast(const CDXLScalarCast *pdxlscalarcast, Expr *pexprChild)
 {
-	GPOS_ASSERT(NULL != pdxlnCast);
-	CDXLScalarCast *pdxlop = CDXLScalarCast::PdxlopConvert(pdxlnCast->Pdxlop());
-
-	GPOS_ASSERT(1 == pdxlnCast->UlArity());
-	CDXLNode *pdxlnChild = (*pdxlnCast)[0];
-
-	Expr *pexprChild = PexprFromDXLNodeScalar(pdxlnChild, pmapcidvar);
-
-	if (IMDId::FValid(pdxlop->PmdidFunc()))
+	if (IMDId::FValid(pdxlscalarcast->PmdidFunc()))
 	{
 		FuncExpr *pfuncexpr = MakeNode(FuncExpr);
-		pfuncexpr->funcid = CMDIdGPDB::PmdidConvert(pdxlop->PmdidFunc())->OidObjectId();
+		pfuncexpr->funcid = CMDIdGPDB::PmdidConvert(pdxlscalarcast->PmdidFunc())->OidObjectId();
 
-		const IMDFunction *pmdfunc = m_pmda->Pmdfunc(pdxlop->PmdidFunc());
+		const IMDFunction *pmdfunc = m_pmda->Pmdfunc(pdxlscalarcast->PmdidFunc());
 		pfuncexpr->funcretset = pmdfunc->FReturnsSet();;
 
 		pfuncexpr->funcformat = COERCE_IMPLICIT_CAST;
-		pfuncexpr->funcresulttype = CMDIdGPDB::PmdidConvert(pdxlop->PmdidType())->OidObjectId();
+		pfuncexpr->funcresulttype = CMDIdGPDB::PmdidConvert(pdxlscalarcast->PmdidType())->OidObjectId();
 
 		pfuncexpr->args = NIL;
 		pfuncexpr->args = gpdb::PlAppendElement(pfuncexpr->args, pexprChild);
@@ -1105,13 +1115,32 @@ CTranslatorDXLToScalar::PrelabeltypeFromDXLNodeScCast
 
 	RelabelType *prelabeltype = MakeNode(RelabelType);
 
-	prelabeltype->resulttype = CMDIdGPDB::PmdidConvert(pdxlop->PmdidType())->OidObjectId();
+	prelabeltype->resulttype = CMDIdGPDB::PmdidConvert(pdxlscalarcast->PmdidType())->OidObjectId();
 	prelabeltype->arg = pexprChild;
 	prelabeltype->resulttypmod = -1;
 	prelabeltype->location = -1;
 	prelabeltype->relabelformat = COERCE_DONTCARE;
 
 	return (Expr *) prelabeltype;
+}
+
+// Translates a DXL scalar cast into a GPDB RelabelType / FuncExpr node
+Expr *
+CTranslatorDXLToScalar::PrelabeltypeFromDXLNodeScCast
+	(
+	const CDXLNode *pdxlnCast,
+	CMappingColIdVar *pmapcidvar
+	)
+{
+	GPOS_ASSERT(NULL != pdxlnCast);
+	const CDXLScalarCast *pdxlop = CDXLScalarCast::PdxlopConvert(pdxlnCast->Pdxlop());
+
+	GPOS_ASSERT(1 == pdxlnCast->UlArity());
+	CDXLNode *pdxlnChild = (*pdxlnCast)[0];
+
+	Expr *pexprChild = PexprFromDXLNodeScalar(pdxlnChild, pmapcidvar);
+
+	return PrelabeltypeOrFuncexprFromDXLNodeScalarCast(pdxlop, pexprChild);
 }
 
 

--- a/src/include/gpopt/translate/CTranslatorDXLToScalar.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToScalar.h
@@ -27,6 +27,7 @@
 #include "naucrates/dxl/operators/CDXLNode.h"
 #include "naucrates/dxl/operators/CDXLDatum.h"
 #include "naucrates/dxl/operators/CDXLScalarArrayRefIndexList.h"
+#include "naucrates/dxl/operators/CDXLScalarCast.h"
 
 // fwd declarations
 namespace gpopt
@@ -228,11 +229,12 @@ namespace gpdxl
 
 			// translate subplan test expression
 			Expr *PexprSubplanTestExpr
-        			(
-        			CDXLNode *pdxlnTestExpr,
+				(
+				CDXLNode *pdxlnTestExpr,
 				SubLinkType slink,
-        			CMappingColIdVar *pmapcidvar
-        			);
+				CMappingColIdVar *pmapcidvar,
+				List **plparamIds
+				);
 			
 			// translate subplan parameters
 			void TranslateSubplanParams
@@ -319,6 +321,11 @@ namespace gpdxl
 			Const *PconstInt8(CDXLDatum *pdxldatum);
 			Const *PconstBool(CDXLDatum *pdxldatum);
 			Const *PconstGeneric(CDXLDatum *pdxldatum);
+			Expr *PrelabeltypeOrFuncexprFromDXLNodeScalarCast
+				(
+				const CDXLScalarCast *pdxlscalarcast,
+				Expr *pexprChild
+				);
 
 			// private copy ctor
 			CTranslatorDXLToScalar(const CTranslatorDXLToScalar&);

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -10144,3 +10144,75 @@ select * from unnest((select string_to_array(name, ',') from bar)) as a;
  person
 (1 row)
 
+-- Query should not fall back to planner and handle implicit cast properly
+CREATE TYPE myint;
+CREATE FUNCTION myintout(myint) RETURNS cstring AS 'int4out' LANGUAGE INTERNAL STRICT IMMUTABLE;
+NOTICE:  argument type myint is only a shell
+CREATE FUNCTION myintin(cstring) RETURNS myint AS 'int4in' LANGUAGE INTERNAL STRICT IMMUTABLE;
+NOTICE:  return type myint is only a shell
+CREATE TYPE myint
+(
+	INPUT=myintin,
+	OUTPUT=myintout,
+	INTERNALLENGTH=4,
+	PASSEDBYVALUE
+);
+CREATE FUNCTION myint_int8(myint) RETURNS int8 AS 'int48' LANGUAGE INTERNAL STRICT IMMUTABLE;
+CREATE CAST (myint AS int8) WITH FUNCTION myint_int8(myint) AS IMPLICIT;
+CREATE TABLE csq_cast_param_outer (a int, b myint);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO csq_cast_param_outer VALUES
+	(1, '42'),
+	(2, '12');
+CREATE TABLE csq_cast_param_inner (c int, d myint);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO csq_cast_param_inner VALUES
+	(11, '11'),
+	(101, '12');
+EXPLAIN SELECT a FROM csq_cast_param_outer WHERE b in (SELECT CASE WHEN a > 1 THEN d ELSE '42' END FROM csq_cast_param_inner);
+                                                   QUERY PLAN
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=1.11..2.49 rows=4 width=4)
+   ->  Nested Loop Semi Join  (cost=1.11..2.49 rows=2 width=4)
+         Join Filter: CASE WHEN csq_cast_param_outer.a > 1 THEN csq_cast_param_inner.d ELSE '42'::myint END::bigint = csq_cast_param_outer.b::bigint
+         ->  Seq Scan on csq_cast_param_outer  (cost=0.00..1.02 rows=1 width=8)
+         ->  Materialize  (cost=1.11..1.17 rows=2 width=4)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.10 rows=2 width=4)
+                     ->  Seq Scan on csq_cast_param_inner  (cost=0.00..1.02 rows=1 width=4)
+ Settings:  optimizer=off; optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
+ Optimizer status: legacy query optimizer
+(9 rows)
+
+SELECT a FROM csq_cast_param_outer WHERE b in (SELECT CASE WHEN a > 1 THEN d ELSE '42' END FROM csq_cast_param_inner);
+ a
+---
+ 1
+ 2
+(2 rows)
+
+DROP CAST (myint as int8);
+CREATE FUNCTION myint_numeric(myint) RETURNS numeric AS 'int4_numeric' LANGUAGE INTERNAL STRICT IMMUTABLE;
+CREATE CAST (myint AS numeric) WITH FUNCTION myint_numeric(myint) AS IMPLICIT;
+EXPLAIN SELECT a FROM csq_cast_param_outer WHERE b in (SELECT CASE WHEN a > 1 THEN d ELSE '42' END FROM csq_cast_param_inner);
+                                                    QUERY PLAN
+-------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=1.11..2.49 rows=4 width=4)
+   ->  Nested Loop Semi Join  (cost=1.11..2.49 rows=2 width=4)
+         Join Filter: CASE WHEN csq_cast_param_outer.a > 1 THEN csq_cast_param_inner.d ELSE '42'::myint END::numeric = csq_cast_param_outer.b::numeric
+         ->  Seq Scan on csq_cast_param_outer  (cost=0.00..1.02 rows=1 width=8)
+         ->  Materialize  (cost=1.11..1.17 rows=2 width=4)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.10 rows=2 width=4)
+                     ->  Seq Scan on csq_cast_param_inner  (cost=0.00..1.02 rows=1 width=4)
+ Settings:  optimizer=off; optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
+ Optimizer status: legacy query optimizer
+(9 rows)
+
+SELECT a FROM csq_cast_param_outer WHERE b in (SELECT CASE WHEN a > 1 THEN d ELSE '42' END FROM csq_cast_param_inner);
+ a
+---
+ 1
+ 2
+(2 rows)
+

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -10209,3 +10209,79 @@ select * from unnest((select string_to_array(name, ',') from bar)) as a;
  person
 (1 row)
 
+-- Query should not fall back to planner and handle implicit cast properly
+CREATE TYPE myint;
+CREATE FUNCTION myintout(myint) RETURNS cstring AS 'int4out' LANGUAGE INTERNAL STRICT IMMUTABLE;
+NOTICE:  argument type myint is only a shell
+CREATE FUNCTION myintin(cstring) RETURNS myint AS 'int4in' LANGUAGE INTERNAL STRICT IMMUTABLE;
+NOTICE:  return type myint is only a shell
+CREATE TYPE myint
+(
+	INPUT=myintin,
+	OUTPUT=myintout,
+	INTERNALLENGTH=4,
+	PASSEDBYVALUE
+);
+CREATE FUNCTION myint_int8(myint) RETURNS int8 AS 'int48' LANGUAGE INTERNAL STRICT IMMUTABLE;
+CREATE CAST (myint AS int8) WITH FUNCTION myint_int8(myint) AS IMPLICIT;
+CREATE TABLE csq_cast_param_outer (a int, b myint);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO csq_cast_param_outer VALUES
+	(1, '42'),
+	(2, '12');
+CREATE TABLE csq_cast_param_inner (c int, d myint);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO csq_cast_param_inner VALUES
+	(11, '11'),
+	(101, '12');
+EXPLAIN SELECT a FROM csq_cast_param_outer WHERE b in (SELECT CASE WHEN a > 1 THEN d ELSE '42' END FROM csq_cast_param_inner);
+                                                   QUERY PLAN
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324032.56 rows=2 width=4)
+   ->  Result  (cost=0.00..1324032.56 rows=1 width=4)
+         ->  Table Scan on csq_cast_param_outer  (cost=0.00..1324032.56 rows=1 width=4)
+               Filter: (SubPlan 1)
+               SubPlan 1
+                 ->  Result  (cost=0.00..431.00 rows=2 width=4)
+                       ->  Materialize  (cost=0.00..431.00 rows=2 width=4)
+                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
+                                   ->  Table Scan on csq_cast_param_inner  (cost=0.00..431.00 rows=1 width=4)
+ Settings:  optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
+ Optimizer status: PQO version 2.51.3
+(11 rows)
+
+SELECT a FROM csq_cast_param_outer WHERE b in (SELECT CASE WHEN a > 1 THEN d ELSE '42' END FROM csq_cast_param_inner);
+ a
+---
+ 1
+ 2
+(2 rows)
+
+DROP CAST (myint as int8);
+CREATE FUNCTION myint_numeric(myint) RETURNS numeric AS 'int4_numeric' LANGUAGE INTERNAL STRICT IMMUTABLE;
+CREATE CAST (myint AS numeric) WITH FUNCTION myint_numeric(myint) AS IMPLICIT;
+EXPLAIN SELECT a FROM csq_cast_param_outer WHERE b in (SELECT CASE WHEN a > 1 THEN d ELSE '42' END FROM csq_cast_param_inner);
+                                                   QUERY PLAN
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324032.56 rows=2 width=4)
+   ->  Result  (cost=0.00..1324032.56 rows=1 width=4)
+         ->  Table Scan on csq_cast_param_outer  (cost=0.00..1324032.56 rows=1 width=4)
+               Filter: (SubPlan 1)
+               SubPlan 1
+                 ->  Result  (cost=0.00..431.00 rows=2 width=4)
+                       ->  Materialize  (cost=0.00..431.00 rows=2 width=4)
+                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
+                                   ->  Table Scan on csq_cast_param_inner  (cost=0.00..431.00 rows=1 width=4)
+ Settings:  optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
+ Optimizer status: PQO version 2.51.3
+(11 rows)
+
+SELECT a FROM csq_cast_param_outer WHERE b in (SELECT CASE WHEN a > 1 THEN d ELSE '42' END FROM csq_cast_param_inner);
+ a
+---
+ 1
+ 2
+(2 rows)
+

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -1554,22 +1554,23 @@ EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f3 AS "Second Field"
   FROM SUBSELECT_TBL upper
   WHERE f3 IN (SELECT upper.f1 + f2 FROM SUBSELECT_TBL
                WHERE f2 = CAST(f3 AS integer)) ORDER BY 2,3;
-                                               QUERY PLAN                                               
---------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=2.18..2.19 rows=4 width=12)
-   Merge Key: upper.f1, upper.f3
-   ->  Sort  (cost=2.18..2.19 rows=2 width=12)
-         Sort Key: upper.f1, upper.f3
-         ->  Nested Loop EXISTS Join  (cost=1.06..2.15 rows=2 width=12)
-               Join Filter: (upper.f1 + subselect_tbl.f2)::double precision = upper.f3
-               ->  Seq Scan on subselect_tbl upper  (cost=0.00..1.01 rows=1 width=12)
-               ->  Materialize  (cost=1.06..1.09 rows=1 width=12)
-                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.05 rows=1 width=12)
-                           ->  Seq Scan on subselect_tbl  (cost=0.00..1.01 rows=1 width=12)
-                                 Filter: f2 = f3::integer
- Settings:  optimizer=on
- Optimizer status: legacy query optimizer
-(13 rows)
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1324033.89 rows=3 width=20)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324033.89 rows=8 width=12)
+         Merge Key: subselect_gp.subselect_tbl.f1, subselect_gp.subselect_tbl.f3
+         ->  Sort  (cost=0.00..1324033.89 rows=3 width=12)
+               Sort Key: subselect_gp.subselect_tbl.f1, subselect_gp.subselect_tbl.f3
+               ->  Table Scan on subselect_tbl  (cost=0.00..1324033.89 rows=3 width=12)
+                     Filter: (SubPlan 1)
+                     SubPlan 1
+                       ->  Result  (cost=0.00..431.00 rows=4 width=4)
+                             ->  Materialize  (cost=0.00..431.00 rows=4 width=4)
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=4 width=4)
+                                         ->  Table Scan on subselect_tbl  (cost=0.00..431.00 rows=2 width=4)
+                                               Filter: f2 = int4(f3)
+ Optimizer status: PQO version 2.53.1
+(14 rows)
 
 EXPLAIN SELECT '' AS five, f1 AS "Correlated Field"
   FROM SUBSELECT_TBL

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -1434,6 +1434,46 @@ create table bar(name text);
 insert into bar values('person');
 select * from unnest((select string_to_array(name, ',') from bar)) as a;
 
+-- Query should not fall back to planner and handle implicit cast properly
+
+CREATE TYPE myint;
+
+CREATE FUNCTION myintout(myint) RETURNS cstring AS 'int4out' LANGUAGE INTERNAL STRICT IMMUTABLE;
+CREATE FUNCTION myintin(cstring) RETURNS myint AS 'int4in' LANGUAGE INTERNAL STRICT IMMUTABLE;
+
+CREATE TYPE myint
+(
+	INPUT=myintin,
+	OUTPUT=myintout,
+	INTERNALLENGTH=4,
+	PASSEDBYVALUE
+);
+
+CREATE FUNCTION myint_int8(myint) RETURNS int8 AS 'int48' LANGUAGE INTERNAL STRICT IMMUTABLE;
+
+CREATE CAST (myint AS int8) WITH FUNCTION myint_int8(myint) AS IMPLICIT;
+
+CREATE TABLE csq_cast_param_outer (a int, b myint);
+INSERT INTO csq_cast_param_outer VALUES
+	(1, '42'),
+	(2, '12');
+
+CREATE TABLE csq_cast_param_inner (c int, d myint);
+INSERT INTO csq_cast_param_inner VALUES
+	(11, '11'),
+	(101, '12');
+
+EXPLAIN SELECT a FROM csq_cast_param_outer WHERE b in (SELECT CASE WHEN a > 1 THEN d ELSE '42' END FROM csq_cast_param_inner);
+SELECT a FROM csq_cast_param_outer WHERE b in (SELECT CASE WHEN a > 1 THEN d ELSE '42' END FROM csq_cast_param_inner);
+
+DROP CAST (myint as int8);
+
+CREATE FUNCTION myint_numeric(myint) RETURNS numeric AS 'int4_numeric' LANGUAGE INTERNAL STRICT IMMUTABLE;
+CREATE CAST (myint AS numeric) WITH FUNCTION myint_numeric(myint) AS IMPLICIT;
+
+EXPLAIN SELECT a FROM csq_cast_param_outer WHERE b in (SELECT CASE WHEN a > 1 THEN d ELSE '42' END FROM csq_cast_param_inner);
+SELECT a FROM csq_cast_param_outer WHERE b in (SELECT CASE WHEN a > 1 THEN d ELSE '42' END FROM csq_cast_param_inner);
+
 -- start_ignore
 DROP SCHEMA orca CASCADE;
 -- end_ignore


### PR DESCRIPTION
Instead of assuming that casts are always binary coercible (and hence that we
could get away with just dropping them), translate casts in ORCA plans into
either a RelabelType or a FuncExpr.

Signed-off-by: Sambitesh Dash <sdash@pivotal.io>