### PR TITLE
Replace user group "supergroup" with "gpadmin"

### DIFF
--- a/concourse/scripts/setup_gpadmin_user.bash
+++ b/concourse/scripts/setup_gpadmin_user.bash
@@ -56,17 +56,17 @@ set_limits() {
 }
 
 setup_gpadmin_user() {
-  groupadd supergroup
+
   case "$TEST_OS" in
     sles)
       groupadd gpadmin
-      /usr/sbin/useradd -G gpadmin,supergroup,tty gpadmin
+      /usr/sbin/useradd -G gpadmin,tty gpadmin
       ;;
     centos)
-      /usr/sbin/useradd -G supergroup,tty gpadmin
+      /usr/sbin/useradd -G tty gpadmin
       ;;
     ubuntu)
-      /usr/sbin/useradd -G supergroup,tty gpadmin -s /bin/bash
+      /usr/sbin/useradd -G tty gpadmin -s /bin/bash
       ;;
     *) echo "Unknown OS: $TEST_OS"; exit 1 ;;
   esac


### PR DESCRIPTION
In the script used for creating user "gpadmin", instead of using a
nonstandard group named "supergroup" that doesn't seem to be used
anywhere, do the more standard practice of creating a group "gpadmin" that matches
the username.
