### PR TITLE
Fix parsing of recovery.conf to not fail due to PGOPTIONS.

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -5879,18 +5879,17 @@ str_time(pg_time_t tnow)
  * See if there is a recovery command file (recovery.conf), and if so
  * read in parameters for recovery in standby mode.
  *
- * XXX longer term intention is to expand this to
- * cater for additional parameters and controls
- * possibly use a flex lexer similar to the GUC one
+ * The file is parsed using the main configuration parser.
  */
 void
 XLogReadRecoveryCommandFile(int emode)
 {
 	FILE	   *fd;
-	char		cmdline[MAXPGPATH];
 	TimeLineID	rtli = 0;
 	bool		rtliGiven = false;
-	bool		syntaxError = false;
+	ConfigVariable *item,
+				   *head = NULL,
+				   *tail = NULL;
 
 	fd = AllocateFile(RECOVERY_COMMAND_FILE, "r");
 	if (fd == NULL)
@@ -5908,71 +5907,33 @@ XLogReadRecoveryCommandFile(int emode)
 					" for recovery in standby mode")));
 
 	/*
-	 * Parse the file...
-	 */
-	while (fgets(cmdline, sizeof(cmdline), fd) != NULL)
+	 * Since we're asking ParseConfigFp() to error out at FATAL, there's no
+	 * need to check the return value.
+	 */ 
+	ParseConfigFp(fd, RECOVERY_COMMAND_FILE, 0, FATAL, &head, &tail);
+
+	for (item = head; item; item = item->next)
 	{
-		/* skip leading whitespace and check for # comment */
-		char	   *ptr;
-		char	   *tok1;
-		char	   *tok2;
-
-		for (ptr = cmdline; *ptr; ptr++)
+		if (strcmp(item->name, "recovery_end_command") == 0)
 		{
-			if (!isspace((unsigned char) *ptr))
-				break;
-		}
-		if (*ptr == '\0' || *ptr == '#')
-			continue;
-
-		/* identify the quoted parameter value */
-		tok1 = strtok(ptr, "'");
-		if (!tok1)
-		{
-			syntaxError = true;
-			break;
-		}
-		tok2 = strtok(NULL, "'");
-		if (!tok2)
-		{
-			syntaxError = true;
-			break;
-		}
-		/* reparse to get just the parameter name */
-		tok1 = strtok(ptr, " \t=");
-		if (!tok1)
-		{
-			syntaxError = true;
-			break;
-		}
-
-		if (strcmp(tok1, "primary_conninfo") == 0)
-		{
-			PrimaryConnInfo = pstrdup(tok2);
-			ereport(emode,
-					(errmsg("primary_conninfo = \"%s\"",
-							PrimaryConnInfo)));
-		}
-		else if (strcmp(tok1, "recovery_end_command") == 0)
-		{
-			recoveryEndCommand = pstrdup(tok2);
-			ereport(LOG,
+			recoveryEndCommand = pstrdup(item->value);
+			ereport(DEBUG2,
 					(errmsg("recovery_end_command = '%s'",
 							recoveryEndCommand)));
 		}
-		else if (strcmp(tok1, "recovery_target_timeline") == 0)
+		else if (strcmp(item->name, "recovery_target_timeline") == 0)
 		{
 			rtliGiven = true;
-			if (strcmp(tok2, "latest") == 0)
+			if (strcmp(item->value, "latest") == 0)
 				rtli = 0;
 			else
 			{
 				errno = 0;
-				rtli = (TimeLineID) strtoul(tok2, NULL, 0);
+				rtli = (TimeLineID) strtoul(item->value, NULL, 0);
 				if (errno == EINVAL || errno == ERANGE)
 					ereport(FATAL,
 							(errmsg("recovery_target_timeline is not a valid number: \"%s\"",
-									tok2)));
+									item->value)));
 			}
 			if (rtli)
 				ereport(LOG,
@@ -5981,21 +5942,21 @@ XLogReadRecoveryCommandFile(int emode)
 				ereport(LOG,
 						(errmsg("recovery_target_timeline = latest")));
 		}
-		else if (strcmp(tok1, "recovery_target_xid") == 0)
+		else if (strcmp(item->name, "recovery_target_xid") == 0)
 		{
 			errno = 0;
-			recoveryTargetXid = (TransactionId) strtoul(tok2, NULL, 0);
+			recoveryTargetXid = (TransactionId) strtoul(item->value, NULL, 0);
 			if (errno == EINVAL || errno == ERANGE)
 				ereport(FATAL,
 				 (errmsg("recovery_target_xid is not a valid number: \"%s\"",
-						 tok2)));
-			ereport(LOG,
+						 item->value)));
+			ereport(DEBUG2,
 					(errmsg("recovery_target_xid = %u",
 							recoveryTargetXid)));
 			recoveryTarget = true;
 			recoveryTargetExact = true;
 		}
-		else if (strcmp(tok1, "recovery_target_time") == 0)
+		else if (strcmp(item->name, "recovery_target_time") == 0)
 		{
 			/*
 			 * if recovery_target_xid specified, then this overrides
@@ -6011,45 +5972,46 @@ XLogReadRecoveryCommandFile(int emode)
 			 */
 			recoveryTargetTime =
 				DatumGetTimestampTz(DirectFunctionCall3(timestamptz_in,
-														CStringGetDatum(tok2),
+														CStringGetDatum(item->value),
 												ObjectIdGetDatum(InvalidOid),
 														Int32GetDatum(-1)));
 			ereport(LOG,
 					(errmsg("recovery_target_time = '%s'",
 							timestamptz_to_str(recoveryTargetTime))));
 		}
-		else if (strcmp(tok1, "recovery_target_inclusive") == 0)
+		else if (strcmp(item->name, "recovery_target_inclusive") == 0)
 		{
 			/*
 			 * does nothing if a recovery_target is not also set
 			 */
-			if (!parse_bool(tok2, &recoveryTargetInclusive))
+			if (!parse_bool(item->value, &recoveryTargetInclusive))
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-						 errmsg("parameter \"recovery_target_inclusive\" requires a Boolean value")));
-			ereport(LOG,
-					(errmsg("standby_mode = %s", tok2)));
+						 errmsg("parameter \"%s\" requires a Boolean value", "recovery_target_inclusive")));
+			ereport(DEBUG2,
+					(errmsg("recovery_target_inclusive = %s", item->value)));
 		}
-		else if (strcmp(tok1, "standby_mode") == 0)
+		else if (strcmp(item->name, "standby_mode") == 0)
 		{
-			if (!parse_bool(tok2, &StandbyModeRequested))
-				  ereport(ERROR,
-							(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					  errmsg("parameter \"standby_mode\" requires a Boolean value")));
+			if (!parse_bool(item->value, &StandbyModeRequested))
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+						 errmsg("parameter \"%s\" requires a Boolean value", "standby_mode")));
+			ereport(DEBUG2,
+					(errmsg("standby_mode = '%s'", item->value)));
+		}
+		else if (strcmp(item->name, "primary_conninfo") == 0)
+		{
+			PrimaryConnInfo = pstrdup(item->value);
+			ereport(DEBUG2,
+					(errmsg("primary_conninfo = '%s'",
+							PrimaryConnInfo)));
 		}
 		else
 			ereport(FATAL,
 					(errmsg("unrecognized recovery parameter \"%s\"",
-							tok1)));
+							item->name)));
 	}
-
-	FreeFile(fd);
-
-	if (syntaxError)
-		ereport(FATAL,
-				(errmsg("syntax error in recovery command file: %s",
-						cmdline),
-			  errhint("Lines should have the format parameter = 'value'.")));
 
 	/*
 	 * Check for compulsory parameters
@@ -6069,6 +6031,9 @@ XLogReadRecoveryCommandFile(int emode)
 				(errmsg("recovery command file \"%s\" request for standby mode not specified",
 						RECOVERY_COMMAND_FILE)));
 	}
+
+	FreeConfigVariables(head);
+	FreeFile(fd);
 }
 
 /*

--- a/src/backend/commands/extension.c
+++ b/src/backend/commands/extension.c
@@ -449,7 +449,7 @@ parse_extension_control_file(ExtensionControlFile *control,
 {
 	char	   *filename;
 	FILE	   *file;
-	struct name_value_pair *item,
+	ConfigVariable *item,
 			   *head = NULL,
 			   *tail = NULL;
 
@@ -481,7 +481,7 @@ parse_extension_control_file(ExtensionControlFile *control,
 	 * Parse the file content, using GUC's file parsing code.  We need not
 	 * check the return value since any errors will be thrown at ERROR level.
 	 */
-	(void) ParseConfigFile(filename, NULL, 0, PGC_SIGHUP, ERROR, &head, &tail);
+	(void) ParseConfigFile(filename, 0, PGC_SIGHUP, ERROR, &head, &tail);
 
 
 	/*
@@ -568,7 +568,7 @@ parse_extension_control_file(ExtensionControlFile *control,
 							item->name, filename)));
 	}
 
-	free_name_value_list(head);
+	FreeConfigVariables(head);
 
 	if (control->relocatable && control->schema != NULL)
 		ereport(ERROR,

--- a/src/backend/utils/misc/guc-file.l
+++ b/src/backend/utils/misc/guc-file.l
@@ -46,7 +46,8 @@ int GUC_yylex_destroy  (void);
 #undef fprintf
 #define fprintf(file, fmt, msg) GUC_flex_fatal(msg)
 
-enum {
+enum
+{
 	GUC_ID = 1,
 	GUC_STRING = 2,
 	GUC_INTEGER = 3,
@@ -66,6 +67,7 @@ static sigjmp_buf *GUC_flex_fatal_jmp;
 int GUC_yylex(void);
 
 static int GUC_flex_fatal(const char *msg);
+
 static char *GUC_scanstr(const char *s);
 
 %}
@@ -130,7 +132,9 @@ void
 ProcessConfigFile(GucContext context)
 {
 	int			elevel;
-	struct name_value_pair *item, *head, *tail;
+	ConfigVariable *item,
+				   *head,
+				   *tail;
 	char	   *cvc = NULL;
 	struct config_string *cvc_struct;
 	const char *envvar;
@@ -153,14 +157,14 @@ ProcessConfigFile(GucContext context)
 	head = tail = NULL;
 
 	if (!ParseConfigFile(ConfigFileName, NULL,
-						 0, context, elevel,
+						 0, elevel,
 						 &head, &tail))
 		goto cleanup_list;
 
 	Assert(gp_replication_config_filename);
 
 	if (!ParseConfigFile(gp_replication_config_filename, NULL,
-						 0, context, elevel,
+						 0, elevel,
 						 &head, &tail))
 		goto cleanup_list;
 
@@ -340,7 +344,7 @@ ProcessConfigFile(GucContext context)
 	PgReloadTime = GetCurrentTimestamp();
 
  cleanup_list:
-	free_name_value_list(head);
+	FreeConfigVariables(head);
 	if (cvc)
 		free(cvc);
 }
@@ -362,47 +366,18 @@ GUC_flex_fatal(const char *msg)
 }
 
 /*
- * Read and parse a single configuration file.  This function recurses
- * to handle "include" directives.
- *
- * Input parameters:
- *	config_file: absolute or relative path of file to read
- *	calling_file: absolute path of file containing the "include" directive,
- *		or NULL at outer level (config_file must be absolute at outer level)
- *	depth: recursion depth (used only to prevent infinite recursion)
- *	context: GucContext passed to ProcessConfigFile()
- *	elevel: error logging level determined by ProcessConfigFile()
- * Output parameters:
- *	head_p, tail_p: head and tail of linked list of name/value pairs
- *
- * *head_p and *tail_p must be initialized to NULL for the first call to the top
- * recursion level.  On exit, they contain a list of name-value pairs read from
- * the input file(s).
- *
- * Returns TRUE if successful, FALSE if an error occurred.  The error has
- * already been ereport'd, it is only necessary for the caller to clean up
- * its own state and release the name/value pairs list.
- *
- * Note: if elevel >= ERROR then an error will not return control to the
- * caller, and internal state such as open files will not be cleaned up.
- * This case occurs only during postmaster or standalone-backend startup,
- * where an error will lead to immediate process exit anyway; so there is
- * no point in contorting the code so it can clean up nicely.
+ * See next function for details. This one will just work with a config_file
+ * name rather than an already opened File Descriptor
  */
 bool
 ParseConfigFile(const char *config_file, const char *calling_file,
-				int depth, GucContext context, int elevel,
-				struct name_value_pair **head_p,
-				struct name_value_pair **tail_p)
+				int depth, int elevel,
+				ConfigVariable **head_p,
+				ConfigVariable **tail_p)
 {
 	bool		OK = true;
-	unsigned int save_ConfigFileLineno = ConfigFileLineno;
-	sigjmp_buf *save_GUC_flex_fatal_jmp = GUC_flex_fatal_jmp;
-	sigjmp_buf	flex_fatal_jmp;
-	char		abs_path[MAXPGPATH];
 	FILE	   *fp;
-	volatile YY_BUFFER_STATE lex_buffer = NULL;
-	int			token;
+	char		abs_path[MAXPGPATH];
 
 	/*
 	 * Reject too-deep include nesting depth.  This is just a safety check
@@ -416,7 +391,6 @@ ParseConfigFile(const char *config_file, const char *calling_file,
 				 errmsg("could not open configuration file \"%s\": maximum nesting depth exceeded",
 						config_file)));
 
-		Assert(PGC_POSTMASTER != context || IsUnderPostmaster);
 		return false;
 	}
 
@@ -426,12 +400,23 @@ ParseConfigFile(const char *config_file, const char *calling_file,
 	 */
 	if (!is_absolute_path(config_file))
 	{
-		Assert(calling_file != NULL);
-		strlcpy(abs_path, calling_file, sizeof(abs_path));
-		get_parent_directory(abs_path);
-		join_path_components(abs_path, abs_path, config_file);
-		canonicalize_path(abs_path);
-		config_file = abs_path;
+		if (calling_file != NULL)
+		{
+			strlcpy(abs_path, calling_file, sizeof(abs_path));
+			get_parent_directory(abs_path);
+			join_path_components(abs_path, abs_path, config_file);
+			canonicalize_path(abs_path);
+			config_file = abs_path;
+		}
+		else
+		{
+			/*
+			 * calling_file is NULL, we make an absolute path from $PGDATA
+			 */
+			join_path_components(abs_path, data_directory, config_file);
+			canonicalize_path(abs_path);
+			config_file = abs_path;
+		}
 	}
 
 	fp = AllocateFile(config_file, "r");
@@ -442,9 +427,52 @@ ParseConfigFile(const char *config_file, const char *calling_file,
 				 errmsg("could not open configuration file \"%s\": %m",
 						config_file)));
 
-		Assert(PGC_POSTMASTER != context || IsUnderPostmaster);
 		return false;
 	}
+
+	OK = ParseConfigFp(fp, config_file, depth, elevel, head_p, tail_p);
+
+	FreeFile(fp);
+
+	return OK;
+}
+
+/*
+ * Read and parse a single configuration file.  This function recurses
+ * to handle "include" directives.
+ *
+ * Input parameters:
+ *	fp: file pointer from AllocateFile for the configuration file to parse
+ *	config_file: absolute or relative path of file to read
+ *	depth: recursion depth (used only to prevent infinite recursion)
+ *	elevel: error logging level determined by ProcessConfigFile()
+ * Output parameters:
+ *	head_p, tail_p: head and tail of linked list of name/value pairs
+ *
+ * *head_p and *tail_p must be initialized to NULL before calling the outer
+ * recursion level.  On exit, they contain a list of name-value pairs read
+ * from the input file(s).
+ *
+ * Returns TRUE if successful, FALSE if an error occurred.  The error has
+ * already been ereport'd, it is only necessary for the caller to clean up
+ * its own state and release the ConfigVariable list.
+ *
+ * Note: if elevel >= ERROR then an error will not return control to the
+ * caller, and internal state such as open files will not be cleaned up.
+ * This case occurs only during postmaster or standalone-backend startup,
+ * where an error will lead to immediate process exit anyway; so there is
+ * no point in contorting the code so it can clean up nicely.
+ */
+bool
+ParseConfigFp(FILE *fp, const char *config_file, int depth, int elevel,
+			  ConfigVariable **head_p, ConfigVariable **tail_p)
+{
+	volatile bool OK = true;
+	unsigned int save_ConfigFileLineno = ConfigFileLineno;
+	sigjmp_buf *save_GUC_flex_fatal_jmp = GUC_flex_fatal_jmp;
+	sigjmp_buf	flex_fatal_jmp;
+	volatile YY_BUFFER_STATE lex_buffer = NULL;
+	int			token;
 
 	if (sigsetjmp(flex_fatal_jmp, 1) == 0)
 		GUC_flex_fatal_jmp = &flex_fatal_jmp;
@@ -457,7 +485,6 @@ ParseConfigFile(const char *config_file, const char *calling_file,
 		 */
 		elog(elevel, "%s at file \"%s\" line %u",
 			 GUC_flex_fatal_errmsg, config_file, ConfigFileLineno);
-
 		OK = false;
 		goto cleanup_exit;
 	}
@@ -473,8 +500,9 @@ ParseConfigFile(const char *config_file, const char *calling_file,
 	/* This loop iterates once per logical line */
 	while ((token = yylex()))
 	{
-		char	   *opt_name, *opt_value;
-		struct name_value_pair *item;
+		char	   *opt_name = NULL;
+		char	   *opt_value = NULL;
+		ConfigVariable *item;
 
 		if (token == GUC_EOL)	/* empty or comment line */
 			continue;
@@ -491,9 +519,9 @@ ParseConfigFile(const char *config_file, const char *calling_file,
 
 		/* now we must have the option value */
 		if (token != GUC_ID &&
-			token != GUC_STRING && 
-			token != GUC_INTEGER && 
-			token != GUC_REAL && 
+			token != GUC_STRING &&
+			token != GUC_INTEGER &&
+			token != GUC_REAL &&
 			token != GUC_UNQUOTED_STRING)
 			goto parse_error;
 		if (token == GUC_STRING)	/* strip quotes and escapes */
@@ -519,10 +547,9 @@ ParseConfigFile(const char *config_file, const char *calling_file,
 			 * immediately.
 			 */
 			if (!ParseConfigFile(opt_value, config_file,
-								 depth + 1, context, elevel,
+								 depth + 1, elevel,
 								 head_p, tail_p))
 			{
-				Assert(PGC_POSTMASTER != context || IsUnderPostmaster);
 				pfree(opt_name);
 				pfree(opt_value);
 				OK = false;
@@ -605,29 +632,25 @@ ParseConfigFile(const char *config_file, const char *calling_file,
 
 cleanup_exit:
 	yy_delete_buffer(lex_buffer);
-	FreeFile(fp);
 	/* Each recursion level must save and restore these static variables. */
 	ConfigFileLineno = save_ConfigFileLineno;
 	GUC_flex_fatal_jmp = save_GUC_flex_fatal_jmp;
-	
-	Assert(OK || (context == PGC_POSTMASTER && IsUnderPostmaster) || context == PGC_SIGHUP);
-
 	return OK;
 }
 
 
 /*
- * Free a list of name/value pairs, including the names and the values
+ * Free a list of ConfigVariables, including the names and the values
  */
 void
-free_name_value_list(struct name_value_pair *list)
+FreeConfigVariables(ConfigVariable *list)
 {
-	struct name_value_pair *item;
+	ConfigVariable *item;
 
 	item = list;
 	while (item)
 	{
-		struct name_value_pair *next = item->next;
+		ConfigVariable *next = item->next;
 
 		pfree(item->name);
 		pfree(item->value);

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -396,6 +396,7 @@ int			log_temp_files = -1;
 
 int			num_temp_buffers = 1000;
 
+char	   *data_directory;
 char	   *ConfigFileName;
 char	   *HbaFileName;
 char	   *IdentFileName;

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -5304,10 +5304,10 @@ select_gp_replication_config_files(const char *configdir, const char *progname)
  * values before writing them.
  */
 static void
-write_gp_replication_conf_file(int fd, const char *filename, struct name_value_pair *head)
+write_gp_replication_conf_file(int fd, const char *filename, ConfigVariable *head)
 {
 	StringInfoData buf;
-	struct name_value_pair *item;
+	ConfigVariable *item;
 
 	initStringInfo(&buf);
 
@@ -5372,11 +5372,10 @@ write_gp_replication_conf_file(int fd, const char *filename, struct name_value_p
  * or deleting the entry for item "name" (delete if "value" == NULL).
  */
 static void
-replace_gp_replication_config_value(struct name_value_pair  **head_p, struct name_value_pair **tail_p,
+replace_gp_replication_config_value(ConfigVariable **head_p, ConfigVariable **tail_p,
                                     const char *name, const char *value)
 {
-	struct name_value_pair  *item,
-			*prev = NULL;
+	ConfigVariable *item, *prev = NULL;
 
 	/* Search the list for an existing match (we assume there's only one) */
 	for (item = *head_p; item != NULL; item = item->next)
@@ -5550,8 +5549,8 @@ validate_gp_replication_conf_option(struct config_generic *record,
 void
 set_gp_replication_config(const char *name, const char *value)
 {
-	struct name_value_pair *head = NULL;
-	struct name_value_pair *tail = NULL;
+	ConfigVariable *head = NULL;
+	ConfigVariable *tail = NULL;
 	volatile int Tmpfd;
 	char GpReplicationConfigTempFilename[MAXPGPATH];
 	char GpReplicationConfigFilename[MAXPGPATH];
@@ -5592,7 +5591,7 @@ set_gp_replication_config(const char *name, const char *value)
 					               GpReplicationConfigFilename)));
 
 		/* parse it */
-		if (!ParseConfigFile(GpReplicationConfigFilename, NULL, 0, PGC_SUSET, LOG, &head, &tail))
+		if (!ParseConfigFile(GpReplicationConfigFilename, 0, PGC_SUSET, LOG, &head, &tail))
 			ereport(ERROR,
 			        (errcode(ERRCODE_CONFIG_FILE_ERROR),
 					        errmsg("could not parse contents of file \"%s\"",

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -110,6 +110,26 @@ typedef enum
 } GucSource;
 
 /*
+ * Parsing the configuation file will return a list of name-value pairs
+ */
+typedef struct ConfigVariable
+{
+	char       *name;
+	char       *value;
+	char	   *filename;
+	int			sourceline;
+	struct ConfigVariable  *next;
+} ConfigVariable;
+
+extern bool ParseConfigFile(const char *config_file, const char *calling_file,
+				int depth, int elevel,
+				ConfigVariable **head_p, ConfigVariable **tail_p);
+extern bool ParseConfigFp(FILE *fp, const char *config_file,
+			  int depth, int elevel,
+			  ConfigVariable **head_p, ConfigVariable **tail_p);
+extern void FreeConfigVariables(ConfigVariable *list);
+
+/*
  * Enum values are made up of an array of name-value pairs
  */
 struct config_enum_entry
@@ -118,21 +138,6 @@ struct config_enum_entry
 	int			val;
 	bool		hidden;
 };
-
-typedef struct name_value_pair
-{
-	char       *name;
-	char       *value;
-	char	   *filename;
-	int			sourceline;
-	struct name_value_pair *next;
-} name_value_pair;
-
-extern bool ParseConfigFile(const char *config_file, const char *calling_file,
-							int depth, GucContext context, int elevel,
-							struct name_value_pair **head_p,
-							struct name_value_pair **tail_p);
-extern void free_name_value_list(struct name_value_pair * list);
 
 typedef const char *(*GucStringAssignHook) (const char *newval, bool doit, GucSource source);
 typedef bool (*GucBoolAssignHook) (bool newval, bool doit, GucSource source);
@@ -343,6 +348,7 @@ extern int Debug_dtm_action_protocol;
 extern int Debug_dtm_action_segment;
 extern int Debug_dtm_action_nestinglevel;
 
+extern char *data_directory;
 extern char *ConfigFileName;
 extern char *HbaFileName;
 extern char *IdentFileName;


### PR DESCRIPTION
This is mostly cherry-pick of upstream commit
commit 970a18687f9b3058e89d5994a8fbf70888e79548
Author: Robert Haas <rhaas@postgresql.org>
Date:   Fri Dec 3 08:44:15 2010 -0500

    Use GUC lexer for recovery.conf parsing.

    This eliminates some crufty, special-purpose code and, as a non-trivial
    side benefit, allows recovery.conf parameters to be unquoted.

    Dimitri Fontaine, with review and cleanup by Alvaro Herrera, Itagaki
    Takahiro, and me.