### PR TITLE
gpstart: fix OOM issue

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -359,7 +359,7 @@ class SegmentStart(Command):
     all of the segments on a specified GpHost.
     """
 
-    def __init__(self, name, gpdb, numContentsInCluster, era, mirrormode,
+    def __init__(self, name, gpdb, numContentsInCluster, era, mirrormode, master_heap_checksum_value,
                  utilityMode=False, ctxt=LOCAL, remoteHost=None,
                  noWait=False, timeout=SEGMENT_TIMEOUT_DEFAULT,
                  specialMode=None, wrapper=None, wrapper_args=None):
@@ -706,6 +706,8 @@ SEGSTART_ERROR_SERVER_DID_NOT_RESPOND = 7
 SEGSTART_ERROR_PG_CTL_FAILED = 8
 SEGSTART_ERROR_CHECKING_CONNECTION_AND_LOCALE_FAILED = 9
 SEGSTART_ERROR_PING_FAILED = 10 # not actually done inside GpSegStartCmd, done instead by caller
+SEGSTART_ERROR_PG_CONTROLDATA_FAILED = 11
+SEGSTART_ERROR_CHECKSUM_MISMATCH = 12
 SEGSTART_ERROR_OTHER = 1000
 
 
@@ -718,7 +720,7 @@ class GpSegStartArgs(CmdArgs):
     "$GPHOME/sbin/gpsegstart.py -M mirrorless -V 'gpversion' -n 1 --era 123 -t 600"
     """
 
-    def __init__(self, mirrormode, gpversion, num_cids, era, timeout):
+    def __init__(self, mirrormode, gpversion, num_cids, era, master_checksum_value, timeout):
         """
         @param mirrormode - mirror start mode (START_AS_PRIMARY_OR_MIRROR or START_AS_MIRRORLESS)
         @param gpversion - version (from postgres --gp-version)
@@ -726,14 +728,19 @@ class GpSegStartArgs(CmdArgs):
         @param era - master era
         @param timeout - seconds to wait before giving up
         """
-        CmdArgs.__init__(self, [
+        default_args = [
             "$GPHOME/sbin/gpsegstart.py",
             "-M", str(mirrormode),
             "-V '%s'" % gpversion,
             "-n", str(num_cids),
             "--era", str(era),
             "-t", str(timeout)
-        ])
+        ]
+        if master_checksum_value != None:
+            default_args.append("--master-checksum-version")
+            default_args.append(str(master_checksum_value))
+
+        CmdArgs.__init__(self, default_args)
 
     def set_special(self, special):
         """
@@ -758,7 +765,7 @@ class GpSegStartArgs(CmdArgs):
 
 class GpSegStartCmd(Command):
     def __init__(self, name, gphome, segments, gpversion,
-                 mirrormode, numContentsInCluster, era,
+                 mirrormode, numContentsInCluster, era, master_checksum_value,
                  timeout=SEGMENT_TIMEOUT_DEFAULT, verbose=False,
                  ctxt=LOCAL, remoteHost=None, pickledTransitionData=None,
                  specialMode=None, wrapper=None, wrapper_args=None,
@@ -768,7 +775,7 @@ class GpSegStartCmd(Command):
         self.dblist = [x for x in segments]
 
         # build gpsegstart command string
-        c = GpSegStartArgs(mirrormode, gpversion, numContentsInCluster, era, timeout)
+        c = GpSegStartArgs(mirrormode, gpversion, numContentsInCluster, era, master_checksum_value,timeout)
         c.set_verbose(verbose)
         c.set_special(specialMode)
         c.set_transition(pickledTransitionData)

--- a/gpMgmt/bin/gppylib/commands/pg.py
+++ b/gpMgmt/bin/gppylib/commands/pg.py
@@ -262,3 +262,6 @@ class PgControlData(Command):
                     (n,v) = l.split(':', 1)
                     self.data[n.strip()] = v.strip() 
         return self.data[name]
+
+    def get_datadir(self):
+        return self.datadir

--- a/gpMgmt/bin/gppylib/operations/startSegments.py
+++ b/gpMgmt/bin/gppylib/operations/startSegments.py
@@ -72,7 +72,7 @@ class StartSegmentsOperation:
     """
 
     def __init__(self, workerPool, quiet, gpVersion,
-                 gpHome, masterDataDirectory, timeout=SEGMENT_TIMEOUT_DEFAULT,
+                 gpHome, masterDataDirectory, master_checksum_value, timeout=SEGMENT_TIMEOUT_DEFAULT,
                  specialMode=None, wrapper=None, wrapper_args=None,
                  logfileDirectory=False):
         checkNotNone("workerPool", workerPool)
@@ -86,6 +86,7 @@ class StartSegmentsOperation:
         self.__specialMode = specialMode
         self.__wrapper = wrapper
         self.__wrapper_args = wrapper_args
+        self.master_checksum_value = master_checksum_value
         self.logfileDirectory = logfileDirectory
 
     def startSegments(self, gpArray, segments, startMethod, era):
@@ -204,6 +205,7 @@ class StartSegmentsOperation:
                                    mirroringModePreTransition,
                                    numContentsInCluster,
                                    era,
+                                   self.master_checksum_value,
                                    self.__timeout,
                                    verbose=logging_is_verbose(),
                                    ctxt=base.REMOTE,

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpsegstart.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpsegstart.py
@@ -1,0 +1,131 @@
+import sys, os
+import gpsegstart
+from mock import Mock, patch
+from gppylib.test.unit.gp_unittest import GpTestCase
+from gppylib.commands.base import CommandResult
+from gppylib.commands.pg import PgControlData
+from gppylib.commands import gp
+
+
+class GpSegStart(GpTestCase):
+    def setUp(self):
+        self.subject = gpsegstart
+        self.subject.logger = Mock(
+            spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal', 'warning_to_file_only'])
+        local_version = gp.GpVersion.local('local GP software version check', gp.get_gphome())
+        self.failing_data_dir = "/doesnt/exist/datadirs/dbfast_mirror1/demoDataDir0"
+        self.args_list = ["gpsegstart.py", "-V", local_version,
+                          "-n",  "3",  "--era", "5c105ee373d42194_180105120208", "-t", "600",  "-p", "pickled transition data",
+                          "-D", "2|0|p|p|s|u|aspen|aspen|25432|25438|/doesnt/exist/datadirs/dbfast1/demoDataDir0||",
+                          "-D", "5|0|m|m|s|u|aspen|aspen|25435|25441|" + self.failing_data_dir + "||",
+                          "-D", "3|1|p|p|s|u|aspen|aspen|25433|25439|/doesnt/exist/datadirs/dbfast2/demoDataDir1||",
+                          "-D", "6|1|m|m|s|u|aspen|aspen|25436|25442|/doesnt/exist/datadirs/dbfast_mirror2/demoDataDir1||",
+                          "-D", "4|2|p|p|s|u|aspen|aspen|25434|25440|/doesnt/exist/datadirs/dbfast3/demoDataDir2||",
+                          "-D", "7|2|m|m|s|u|aspen|aspen|25437|25443|/doesnt/exist/datadirs/dbfast_mirror3/demoDataDir2||",
+
+                          ]
+        self.apply_patches([
+            patch('os.path.isdir'),
+            patch('os.path.exists'),
+            patch('os.kill'),
+            patch('gpsegstart.gp.recovery_startup', return_value=None),
+            patch('gpsegstart.base64.urlsafe_b64decode'),
+            patch('gpsegstart.pickle.loads', return_value="random string"),
+            patch('gpsegstart.gp.SendFilerepTransitionMessage.buildTransitionMessageCommand'),
+            patch('gpsegstart.base.WorkerPool'),
+            patch('gpsegstart.gp.read_postmaster_pidfile', return_value=111),
+            patch('gpsegstart.PgControlData.run')
+            ])
+
+        self.mock_workerpool = self.get_mock_from_apply_patch('WorkerPool')
+
+    def tearDown(self):
+        super(GpSegStart, self).tearDown()
+
+    def test_startSegments(self):
+        sys.argv = self.args_list
+
+        parser = self.subject.GpSegStart.createParser()
+        options, args = parser.parse_args()
+
+        gpsegstart = self.subject.GpSegStart.createProgram(options, args)
+        exitCode = gpsegstart.run()
+
+        self.assertEqual(exitCode, 0)
+        for result in gpsegstart.overall_status.results:
+            self.assertTrue(result.reasoncode == gp.SEGSTART_SUCCESS)
+
+    @patch.object(PgControlData, "get_results", return_value=CommandResult(0, '/tmp/f1', '', True, False))
+    @patch.object(PgControlData, "get_value", return_value="1")
+    def test_startSegments_when_checksums_match(self, mock1, mock2):
+        self.args_list.append("--master-checksum-version")
+        self.args_list.append("1")
+        sys.argv = self.args_list
+
+        parser = self.subject.GpSegStart.createParser()
+        options, args = parser.parse_args()
+
+        gpsegstart = self.subject.GpSegStart.createProgram(options, args)
+        exitCode = gpsegstart.run()
+
+        self.assertEqual(exitCode, 0)
+        for result in gpsegstart.overall_status.results:
+            self.assertTrue(result.reasoncode == gp.SEGSTART_SUCCESS)
+
+    @patch.object(PgControlData, "get_results", return_value=CommandResult(0, '/tmp/f1', '', True, False))
+    @patch.object(PgControlData, "get_value", return_value="1")
+    def test_startSegments_when_checksums_mismatch(self, mock1, mock2):
+        self.args_list.append("--master-checksum-version")
+        self.args_list.append("0")
+        sys.argv = self.args_list
+
+        parser = self.subject.GpSegStart.createParser()
+        options, args = parser.parse_args()
+
+        gpsegstart = self.subject.GpSegStart.createProgram(options, args)
+        exitCode = gpsegstart.run()
+
+        self.assertEqual(exitCode, 1)
+        for result in gpsegstart.overall_status.results:
+            self.assertTrue(result.reasoncode == gp.SEGSTART_ERROR_CHECKSUM_MISMATCH)
+
+    @patch.object(PgControlData, "get_results", return_value=CommandResult(1, '/tmp/f1', '', True, False))
+    def test_startSegments_when_pg_controldata_failed(self, mock1):
+        self.args_list.append("--master-checksum-version")
+        self.args_list.append("1")
+        sys.argv = self.args_list
+
+        parser = self.subject.GpSegStart.createParser()
+        options, args = parser.parse_args()
+
+        gpsegstart = self.subject.GpSegStart.createProgram(options, args)
+        exitCode = gpsegstart.run()
+
+        self.assertEqual(exitCode, 1)
+        for result in gpsegstart.overall_status.results:
+            self.assertTrue(result.reasoncode == gp.SEGSTART_ERROR_PG_CONTROLDATA_FAILED)
+
+    @patch.object(PgControlData, "get_results", return_value=CommandResult(0, '/tmp/f1', '', True, False))
+    @patch.object(PgControlData, "get_value", return_value="1")
+    @patch.object(gp.SegmentStart, "get_results", return_value=CommandResult(1, '/tmp/f1', '', True, False))
+    def test_startSegments_when_pg_ctl_failed(self, mock1, mock2, mock_get_results):
+        self.args_list.append("--master-checksum-version")
+        self.args_list.append("1")
+        sys.argv = self.args_list
+
+        mock_get_results.segment = Mock()
+        mock_get_results.segment.getSegmentDataDirectory.return_value = self.failing_data_dir
+
+        parser = self.subject.GpSegStart.createParser()
+        options, args = parser.parse_args()
+
+        gpsegstart = self.subject.GpSegStart.createProgram(options, args)
+        with patch('gpsegstart.base.WorkerPool.return_value.getCompletedItems', return_value=[mock_get_results]):
+            exitCode = gpsegstart.run()
+
+        self.assertEqual(exitCode, 1)
+        for result in gpsegstart.overall_status.results:
+            if result.datadir == self.failing_data_dir:
+                self.assertTrue(result.reasoncode == gp.SEGSTART_ERROR_PG_CTL_FAILED)
+            else:
+                self.assertTrue(result.reasoncode == gp.SEGSTART_SUCCESS)

--- a/gpMgmt/bin/gpstart
+++ b/gpMgmt/bin/gpstart
@@ -121,48 +121,13 @@ class GpStart:
                 return 0
 
             if self.skip_heap_checksum_validation:
+                self.master_checksum_value = None
                 logger.warning("Because of --skip-heap-checksum-validation, the GUC for data_checksums "
-                               "will not be checked between master and segments")
+                                   "will not be checked between master and segments")
             else:
-                # check that checksum settings are consistent across the cluster
                 num_workers = min(len(self.gparray.get_hostlist()), self.parallel)
-                heap_checksum = HeapChecksum(gparray=self.gparray, num_workers=num_workers, logger=logger)
-                if self.gparray.hasStandbyMaster():
-                    if heap_checksum.get_master_value() != heap_checksum.get_standby_value():
-                        logger.warning("Heap checksum settings on standby master do not match master <<<<<<<<")
-                        logger.error("gpstart error: Heap checksum settings are not consistent across the cluster.")
-                        return 1
-
-                successes, failures = heap_checksum.get_segments_checksum_settings()
-                if len(successes) == 0:
-                    logger.fatal("No segments responded to ssh query for heap checksum. Not starting the array.")
-                    return 1
-
-                consistent, inconsistent, master_checksum_value = heap_checksum.check_segment_consistency(successes)
-
-                if not heap_checksum.are_segments_consistent(consistent, inconsistent):
-                    logger.fatal("Cluster heap checksum setting differences reported.")
-                    logger.fatal("Shutting down master")
-                    cmd = gp.GpStop("Shutting down master", masterOnly=True,
-                                    fast=True, quiet=logging_is_quiet(),
-                                    verbose=logging_is_verbose(),
-                                    datadir=self.master_datadir,
-                                    logfileDirectory=self.logfileDirectory)
-                    cmd.run()
-
-                    logger.fatal("Heap checksum settings on %d of %d segment instances do not match master <<<<<<<<"
-                                 % (len(inconsistent), len(inconsistent) + len(consistent)))
-                    logger.fatal("Review %s for details" % get_logfile())
-                    log_to_file_only("Failed checksum consistency validation:", logging.WARN)
-                    for gpdb in inconsistent:
-                        segment_id = gpdb.getSegmentDbId()
-                        checksum = gpdb.heap_checksum
-                        log_to_file_only("dbid: %s "
-                                         "checksum set to %s differs from master checksum set to %s" %
-                                         (segment_id, checksum, master_checksum_value), logging.WARN)
-
-                    return 1
-                logger.info("Heap checksum setting is consistent across the cluster")
+                self.master_checksum_value = HeapChecksum(gparray=self.gparray, num_workers=num_workers,
+                                                          logger=logger).get_master_value()
 
             # Do we have an even-number of recovered segments ?
             if len(self.gparray.recoveredSegmentDbids) > 0 and len(self.gparray.recoveredSegmentDbids) % 2 == 0:
@@ -478,8 +443,8 @@ class GpStart:
 
         # this will eventually start gpsegstart.py
         segmentStartOp = StartSegmentsOperation(self.pool, self.quiet, self.gpversion,
-                                                self.gphome, self.master_datadir, self.timeout,
-                                                self.specialMode, self.wrapper, self.wrapper_args,
+                                                self.gphome, self.master_datadir, self.master_checksum_value,
+                                                self.timeout, self.specialMode, self.wrapper, self.wrapper_args,
                                                 logfileDirectory=self.logfileDirectory)
         segmentStartResult = segmentStartOp.startSegments(self.gparray, segmentsToStart, startMode, self.era)
 

--- a/gpMgmt/sbin/gpsegstart.py
+++ b/gpMgmt/sbin/gpsegstart.py
@@ -18,6 +18,7 @@ from gppylib.gpparseopts import OptParser, OptChecker
 from gppylib import gparray, gplog
 from gppylib.commands import base, gp
 from gppylib.utils import parseKeyColonValueLines
+from gppylib.commands.pg import PgControlData
 
 logger = gplog.get_default_logger()
 
@@ -131,7 +132,7 @@ class GpSegStart:
 
     def __init__(self, dblist, gpversion, mirroringMode, num_cids, era,
                  timeout, pickledTransitionData, specialMode, wrapper, wrapper_args,
-                 logfileDirectory=False):
+                 master_checksum_version, logfileDirectory=False):
 
         # validate/store arguments
         #
@@ -164,6 +165,7 @@ class GpSegStart:
         self.overall_status        = None
 
         self.logfileDirectory      = logfileDirectory
+        self.master_checksum_version = master_checksum_version
 
     def getOverallStatusKeys(self):
         return self.overall_status.dirmap.keys()
@@ -238,11 +240,32 @@ class GpSegStart:
         self.logger.info("Starting segments... (mirroringMode %s)" % self.mirroringMode)
 
         for datadir, seg in self.overall_status.dirmap.items():
+
+            if self.master_checksum_version != None:
+                cmd = PgControlData(name='run pg_controldata', datadir=datadir)
+                cmd.run(validateAfter=True)
+                res = cmd.get_results()
+
+                if res.rc != 0:
+                    msg = "pg_controldata failed.\nstdout:%s\nstderr:%s\n" % (res.stdout, res.stderr)
+                    reasoncode = gp.SEGSTART_ERROR_PG_CONTROLDATA_FAILED
+                    self.overall_status.mark_failed(datadir, msg, reasoncode)
+                    continue
+
+                segment_heap_checksum_version = cmd.get_value('Data page checksum version')
+                if segment_heap_checksum_version != self.master_checksum_version:
+                    msg = "Segment checksum %s does not match master checksum %s.\n" % (segment_heap_checksum_version,
+                                                                                        self.master_checksum_version)
+                    reasoncode = gp.SEGSTART_ERROR_CHECKSUM_MISMATCH
+                    self.overall_status.mark_failed(datadir, msg, reasoncode)
+                    continue
+
             cmd = gp.SegmentStart("Starting seg at dir %s" % datadir, 
                                   seg,
                                   self.num_cids,
                                   self.era,
                                   self.mirroringMode,
+                                  self.master_checksum_version,
                                   timeout=self.timeout,
                                   specialMode=self.specialMode,
                                   wrapper=self.wrapper,
@@ -448,6 +471,7 @@ class GpSegStart:
                            help='start the instance in upgrade or maintenance mode')
         parser.add_option('', '--wrapper', dest="wrapper", default=None, type='string')
         parser.add_option('', '--wrapper-args', dest="wrapper_args", default=None, type='string')
+        parser.add_option('', '--master-checksum-version', dest="master_checksum_version", default=None, type='string', action="store")
         
         return parser
 
@@ -467,6 +491,7 @@ class GpSegStart:
                           options.specialMode,
                           options.wrapper,
                           options.wrapper_args,
+                          options.master_checksum_version,
                           logfileDirectory=logfileDirectory)
 
 #------------------------------------------------------------------------- 


### PR DESCRIPTION
gpstart did a cluster-wide check of heap_checksum settings and refused
to start the cluster if this setting was inconsistent. This meant a
round of ssh'ing across the cluster which was causing OOM errors with
large clusters.

This commit moves the heap_checksum validation to gpsegstart.py, and
changes the logic so that only those segments which have the same
heap_checksum setting as master are started.

Author: Nadeem Ghani <nghani@pivotal.io>
Author: Shoaib Lari <slari@pivotal.io>