### PR TITLE
Remove redundant macro `HASHJOIN_IS_OUTER`

### DIFF
--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -25,14 +25,11 @@
 #include "utils/faultinjector.h"
 #include "utils/memutils.h"
 
-/* Returns true for JOIN_LEFT, JOIN_ANTI and JOIN_LASJ_NOTIN jointypes */
-#define HASHJOIN_IS_OUTER(hjstate)  ((hjstate)->hj_NullInnerTupleSlot != NULL)
-
 #include "cdb/cdbvars.h"
 #include "miscadmin.h"			/* work_mem */
 
-/* Returns true for JOIN_LEFT and JOIN_ANTI jointypes */
-#define HASHJOIN_IS_OUTER(hjstate)	((hjstate)->hj_NullInnerTupleSlot != NULL)
+/* Returns true for JOIN_LEFT, JOIN_ANTI and JOIN_LASJ_NOTIN jointypes */
+#define HASHJOIN_IS_OUTER(hjstate)  ((hjstate)->hj_NullInnerTupleSlot != NULL)
 
 static TupleTableSlot *ExecHashJoinOuterGetTuple(PlanState *outerNode,
 						  HashJoinState *hjstate,


### PR DESCRIPTION
`HASHJOIN_IS_OUTER` already existed in `nodeHashJoin.c`; but was added again
by commit 321c052.
This commit removes the redundant copy of the same.