### PR TITLE
 Fix synchronous_standby_names inconsistencies

### DIFF
--- a/src/backend/fts/ftsprobe.c
+++ b/src/backend/fts/ftsprobe.c
@@ -215,10 +215,6 @@ ftsReceive(FtsConnectionInfo *ftsInfo)
 	 */
 	if (strcmp(ftsInfo->message, FTS_MSG_PROBE) == 0)
 		probeRecordResponse(ftsInfo, lastResult);
-	/* Primary must have syncrep disabled in response to SYNCREP_OFF message. */
-	AssertImply(strcmp(ftsInfo->message, FTS_MSG_SYNCREP_OFF) == 0,
-				PQgetvalue(lastResult, 0, Anum_fts_message_response_is_syncrep_enabled) != NULL &&
-				*(PQgetvalue(lastResult, 0, Anum_fts_message_response_is_syncrep_enabled)) == false);
 
 	return true;
 }

--- a/src/backend/mock.mk
+++ b/src/backend/mock.mk
@@ -58,7 +58,6 @@ EXCL_OBJS+=\
 	src/backend/utils/adt/lockfuncs.o \
 	src/backend/utils/adt/mac.o \
 	src/backend/utils/adt/matrix.o \
-	src/backend/utils/adt/misc.o \
 	src/backend/utils/adt/oracle_compat.o \
 	src/backend/utils/adt/pgstatfuncs.o \
 	src/backend/utils/adt/pivot.o \

--- a/src/backend/postmaster/checkpointer.c
+++ b/src/backend/postmaster/checkpointer.c
@@ -346,9 +346,7 @@ CheckpointerMain(void)
 	PG_SETMASK(&UnBlockSig);
 
 	/* update global shmem state for sync rep */
-	LWLockAcquire(SyncRepLock, LW_EXCLUSIVE);
 	SyncRepUpdateSyncStandbysDefined();
-	LWLockRelease(SyncRepLock);
 
 	/*
 	 * Loop forever
@@ -378,9 +376,7 @@ CheckpointerMain(void)
 			ProcessConfigFile(PGC_SIGHUP);
 
 			/* update global shmem state for sync rep */
-			LWLockAcquire(SyncRepLock, LW_EXCLUSIVE);
 			SyncRepUpdateSyncStandbysDefined();
-			LWLockRelease(SyncRepLock);
 		}
 		if (checkpoint_requested)
 		{

--- a/src/backend/replication/gp_replication.c
+++ b/src/backend/replication/gp_replication.c
@@ -63,31 +63,27 @@ void GetMirrorStatus(FtsResponse *response)
 void
 SetSyncStandbysDefined(void)
 {
-	LWLockAcquire(SyncRepLock, LW_EXCLUSIVE);
-
 	if (!WalSndCtl->sync_standbys_defined)
 	{
-		SyncRepStandbyNames = "*";
-		set_gp_replication_config("synchronous_standby_names", SyncRepStandbyNames);
-		SyncRepUpdateSyncStandbysDefined();
-	}
+		set_gp_replication_config("synchronous_standby_names", "*");
 
-	LWLockRelease(SyncRepLock);
+		/* Signal a reload to the postmaster. */
+		elog(LOG, "signaling configuration reload: setting synchronous_standby_names to '*'");
+		DirectFunctionCall1(pg_reload_conf, PointerGetDatum(NULL) /* unused */);
+	}
 }
 
 void
 UnsetSyncStandbysDefined(void)
 {
-	LWLockAcquire(SyncRepLock, LW_EXCLUSIVE);
-
 	if (WalSndCtl->sync_standbys_defined)
 	{
-		SyncRepStandbyNames = "";
-		set_gp_replication_config("synchronous_standby_names", SyncRepStandbyNames);
-		SyncRepUpdateSyncStandbysDefined();
-	}
+		set_gp_replication_config("synchronous_standby_names", "");
 
-	LWLockRelease(SyncRepLock);
+		/* Signal a reload to the postmaster. */
+		elog(LOG, "signaling configuration reload: setting synchronous_standby_names to ''");
+		DirectFunctionCall1(pg_reload_conf, PointerGetDatum(NULL) /* unused */);
+	}
 }
 #endif
 

--- a/src/backend/replication/test/gp_replication_test.c
+++ b/src/backend/replication/test/gp_replication_test.c
@@ -109,84 +109,6 @@ test_GetMirrorStatus_WALSNDSTATE_STREAMING(void **state)
 	assert_true(response.IsInSync);
 }
 
-void
-test_SetSyncStandbysDefined(void **state)
-{
-	WalSndCtlData data;
-	WalSndCtl = &data;
-	data.sync_standbys_defined = false;
-
-	expect_lwlock(LW_EXCLUSIVE);
-#ifdef USE_ASSERT_CHECKING
-	expect_value(LWLockHeldByMe, lockid, SyncRepLock);
-	will_return(LWLockHeldByMe, true);
-#endif
-
-	/*
-	 * set_gp_replication_config() should only be called once when mirror first
-	 * comes up to set synchronous wal rep state
-	 */
-	expect_string_count(set_gp_replication_config, name, "synchronous_standby_names", 1);
-	expect_string_count(set_gp_replication_config, value, "*", 1);
-	will_be_called(set_gp_replication_config);
-
-	/* simulate first call when mirror first comes up */
-	assert_false(WalSndCtl->sync_standbys_defined);
-	assert_true(SyncRepStandbyNames == NULL);
-	SetSyncStandbysDefined();
-
-	/* relative variables should have updated */
-	assert_true(WalSndCtl->sync_standbys_defined);
-	assert_true(strcmp(SyncRepStandbyNames, "*") == 0);
-
-	expect_lwlock(LW_EXCLUSIVE);
-
-	/* simulate second call after sync state is set which should do nothing */
-	SetSyncStandbysDefined();
-}
-
-void
-test_UnsetSyncStandbysDefined(void **state)
-{
-	int shmqueuenext_calls;
-	WalSndCtlData data;
-	WalSndCtl = &data;
-	data.sync_standbys_defined = true;
-
-	/* mock SHMQueueNext to skip the SyncRepWakeQueue */
-#ifdef USE_ASSERT_CHECKING
-	shmqueuenext_calls = 4;
-#else
-	shmqueuenext_calls = 2;
-#endif
-	expect_any_count(SHMQueueNext, queue, shmqueuenext_calls);
-	expect_any_count(SHMQueueNext, curElem, shmqueuenext_calls);
-	expect_any_count(SHMQueueNext, linkOffset, shmqueuenext_calls);
-	will_return_count(SHMQueueNext, NULL, shmqueuenext_calls);
-
-	expect_lwlock(LW_EXCLUSIVE);
-#ifdef USE_ASSERT_CHECKING
-	expect_value(LWLockHeldByMe, lockid, SyncRepLock);
-	will_return(LWLockHeldByMe, true);
-#endif
-
-	/* unset the GUC in-memory */
-	expect_string_count(set_gp_replication_config, name, "synchronous_standby_names", 1);
-	expect_string_count(set_gp_replication_config, value, "", 1);
-	will_be_called(set_gp_replication_config);
-
-	/* simulate call when primary is in synchronous replication */
-	assert_true(WalSndCtl->sync_standbys_defined);
-	assert_true(strcmp(SyncRepStandbyNames, "*") == 0);
-
-	/* call the function we are testing */
-	UnsetSyncStandbysDefined();
-
-	/* relative variables should have updated */
-	assert_false(WalSndCtl->sync_standbys_defined);
-	assert_true(strcmp(SyncRepStandbyNames, "") == 0);
-}
-
 int
 main(int argc, char* argv[])
 {
@@ -197,9 +119,7 @@ main(int argc, char* argv[])
 		unit_test(test_GetMirrorStatus_WALSNDSTATE_STARTUP),
 		unit_test(test_GetMirrorStatus_WALSNDSTATE_BACKUP),
 		unit_test(test_GetMirrorStatus_WALSNDSTATE_CATCHUP),
-		unit_test(test_GetMirrorStatus_WALSNDSTATE_STREAMING),
-		unit_test(test_SetSyncStandbysDefined),
-		unit_test(test_UnsetSyncStandbysDefined)
+		unit_test(test_GetMirrorStatus_WALSNDSTATE_STREAMING)
 	};
 	return run_tests(tests);
 }

--- a/src/test/isolation2/expected/segwalrep/commit_blocking.out
+++ b/src/test/isolation2/expected/segwalrep/commit_blocking.out
@@ -16,6 +16,17 @@ CREATE
 insert into segwalrep_commit_blocking values (1);
 INSERT 1
 
+-- WALREP_FIXME: we don't wait for the GUC to propagate to the ftsprobe process; it's
+-- possible that one final probe could get through after we shut down the mirror
+-- in the next line and throw off the test (since if the mirror is marked down,
+-- the primary won't block). As a temporary nasty hack, try to reduce possible
+-- flake by issuing a probe manually, which will delay the next one by a minute.
+select gp_request_fts_probe_scan();
+gp_request_fts_probe_scan
+-------------------------
+t                        
+(1 row)
+
 -- turn off fts
 ! gpconfig -c gp_fts_probe_pause -v true --masteronly --skipvalidation;
 completed successfully with parameters '-c gp_fts_probe_pause -v true --masteronly --skipvalidation'

--- a/src/test/isolation2/expected/segwalrep/fts_unblock_primary.out
+++ b/src/test/isolation2/expected/segwalrep/fts_unblock_primary.out
@@ -22,6 +22,15 @@ content|role|preferred_role|mode|status
 2      |m   |m             |s   |u     
 (2 rows)
 
+-- synchronous_standby_names should be set to '*' by default on primary 2, since
+-- we have a working/sync'd mirror
+-- XXX We assume primary 2 is DBID 4, which may not be the case.
+4U: show synchronous_standby_names;
+synchronous_standby_names
+-------------------------
+*                        
+(1 row)
+
 -- create table and show commits are not blocked
 create table fts_unblock_primary (a int) distributed by (a);
 CREATE
@@ -87,6 +96,13 @@ content|role|preferred_role|mode|status
 2<:  <... completed>
 COMMIT
 
+-- synchronous_standby_names should now be empty on the primary
+4U: show synchronous_standby_names;
+synchronous_standby_names
+-------------------------
+                         
+(1 row)
+
 -- bring the mirror back up and see primary s/u and mirror s/u
 1U: select pg_ctl((select fselocation from gp_segment_configuration c, pg_filespace_entry f where c.role='m' and c.content=2 and c.dbid = f.fsedbid), 'start', (select port from gp_segment_configuration where content = 2 and preferred_role = 'm'), 2);
 pg_ctl          
@@ -109,3 +125,10 @@ content|role|preferred_role|mode|status
 -- everything is back to normal
 insert into fts_unblock_primary select i from generate_series(1,10)i;
 INSERT 10
+
+-- synchronous_standby_names should be back to its original value on the primary
+4U: show synchronous_standby_names;
+synchronous_standby_names
+-------------------------
+*                        
+(1 row)

--- a/src/test/isolation2/sql/segwalrep/commit_blocking.sql
+++ b/src/test/isolation2/sql/segwalrep/commit_blocking.sql
@@ -26,6 +26,13 @@ $$ language plpythonu;
 create table segwalrep_commit_blocking (a int) distributed by (a);
 insert into segwalrep_commit_blocking values (1);
 
+-- WALREP_FIXME: we don't wait for the GUC to propagate to the ftsprobe process; it's
+-- possible that one final probe could get through after we shut down the mirror
+-- in the next line and throw off the test (since if the mirror is marked down,
+-- the primary won't block). As a temporary nasty hack, try to reduce possible
+-- flake by issuing a probe manually, which will delay the next one by a minute.
+select gp_request_fts_probe_scan();
+
 -- turn off fts
 ! gpconfig -c gp_fts_probe_pause -v true --masteronly --skipvalidation;
 1U: select pg_ctl((select fselocation from gp_segment_configuration c, pg_filespace_entry f where c.role='p' and c.content=-1 and c.dbid = f.fsedbid), 'reload', NULL, NULL);

--- a/src/test/isolation2/sql/segwalrep/fts_unblock_primary.sql
+++ b/src/test/isolation2/sql/segwalrep/fts_unblock_primary.sql
@@ -42,6 +42,11 @@ $$ language plpythonu;
 -- make sure we are in-sync for the primary we will be testing with
 select content, role, preferred_role, mode, status from gp_segment_configuration where content=2;
 
+-- synchronous_standby_names should be set to '*' by default on primary 2, since
+-- we have a working/sync'd mirror
+-- XXX We assume primary 2 is DBID 4, which may not be the case.
+4U: show synchronous_standby_names;
+
 -- create table and show commits are not blocked
 create table fts_unblock_primary (a int) distributed by (a);
 insert into fts_unblock_primary values (1);
@@ -72,6 +77,9 @@ select content, role, preferred_role, mode, status from gp_segment_configuration
 -- should unblock and commit after FTS sent primary a SyncRepOff libpq message
 2<:
 
+-- synchronous_standby_names should now be empty on the primary
+4U: show synchronous_standby_names;
+
 -- bring the mirror back up and see primary s/u and mirror s/u
 1U: select pg_ctl((select fselocation from gp_segment_configuration c, pg_filespace_entry f where c.role='m' and c.content=2 and c.dbid = f.fsedbid), 'start', (select port from gp_segment_configuration where content = 2 and preferred_role = 'm'), 2);
 select wait_for_streaming(2::smallint);
@@ -79,3 +87,6 @@ select content, role, preferred_role, mode, status from gp_segment_configuration
 
 -- everything is back to normal
 insert into fts_unblock_primary select i from generate_series(1,10)i;
+
+-- synchronous_standby_names should be back to its original value on the primary
+4U: show synchronous_standby_names;


### PR DESCRIPTION
`synchronous_standby_names` is set on the first FTS probe after starting the cluster, and it's written to disk, but it doesn't actually get persisted in memory on all cluster processes. The backend that "sets" the value exits without SIGHUP'ing the cluster, and it therefore "resets" to the empty string. If you're lucky enough to restart the cluster after this point, everything works as expected, but until then the cluster is in a strange state.

Revert `SyncRepUpdateSyncStandbysDefined` to its upstream contract: only checkpointer may call it, and it acquires the SyncRepLock on its own. Add a shared Latch that the FTS handler backend will wait on during syncrep changes. This ensures that at least one backend (the FTS handler) has received the configuration changes in their entirety before responding to the FTS master.
  
This exposes a bug in `SetSyncStandbysDefined` and friends: you can't set a GUC to an unmalloc'd string, since configuration reload expects to be able to free the previous value.