### PR TITLE
Fix minor issues with gpinitstandby

### DIFF
--- a/src/backend/replication/basebackup.c
+++ b/src/backend/replication/basebackup.c
@@ -877,7 +877,7 @@ sendDir(char *path, int basepathlen, bool sizeonly, List *tablespaces,
 				}
 			}
 			if (!skip_this_dir)
-				size += sendDir(pathbuf, basepathlen, sizeonly, tablespaces, NIL);
+				size += sendDir(pathbuf, basepathlen, sizeonly, tablespaces, exclude);
 		}
 		else if (S_ISREG(statbuf.st_mode))
 		{

--- a/src/bin/pg_basebackup/pg_basebackup.c
+++ b/src/bin/pg_basebackup/pg_basebackup.c
@@ -870,7 +870,7 @@ ReceiveAndUnpackTarFile(PGconn *conn, PGresult *res, int rownum)
 	if (basetablespace)
 		strlcpy(current_path, basedir, sizeof(current_path));
 	else
-		strlcpy(current_path, PQgetvalue(res, rownum, 2), sizeof(current_path));
+		strlcpy(current_path, PQgetvalue(res, rownum, 1), sizeof(current_path));
 
 	/*
 	 * Get the COPY data


### PR DESCRIPTION
*     Fix tablespace attribute number for pg_basebackup. In libpq, the attribute number is 0 zero based.
*     Fix pg_basebackup -E option.  Server side should exclude sub directory even parent directory
    wanted.

Will port `fb05f3ce83d` if required when primary and standby on the same machine with tablespace.

Another question is: for instance, if standby's dbid = 10, and primary's dbid = 1, how let standby recover from pg_basebackup results with dbid = 1?