### PR TITLE
Fix gpintstandby,gpactivatestandby tests under walrep_1

### DIFF
--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/gpinitstandby/__init__.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/gpinitstandby/__init__.py
@@ -117,19 +117,14 @@ class GpinitStandby(object):
     def initstand_by_with_default(self):
         master_host = self.get_masterhost()
         gp_cmd =  "/bin/bash -c 'gpinitstandby -s %s'" % (master_host)
-        logfile = open(local_path('install.log'),'w')
-
-        child = pexpect.spawn(gp_cmd, timeout=400)
-        child.logfile = logfile
+        cmd = Command(name='Running the command', cmdStr = gp_cmd)
+        tinctest.logger.info('%s' % cmd)
+        cmd.run(validateAfter=False)
         sleep(2)
-        check = child.expect(['.* Enter standby filespace location for filespace pg_system .*', ' '])
-        if check != 0:
-            child.close()
-
-        l_file = open(local_path('install.log'),'r')
-        lines = l_file.readlines()
+        result = cmd.get_results()
+        lines = result.stdout.splitlines()
         for line in lines:
-            if 'default: NA' in line:
+            if 'Data directory already exists' in line:
                 return True
         return False
 

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/run/test_gpactivatestandby.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/run/test_gpactivatestandby.py
@@ -85,7 +85,7 @@ class gpactivatestandby(StandbyRunMixin, MPPTestCase):
                 ' '.join(['gpinitstandby', '-a',
                     '-s', self.standby_host,
                     '-P', self.standby_port,
-                    '-F', 'pg_system:' + self.standby_datadir]))
+                    '-F', self.standby_datadir]))
         cmd.run(validateAfter=True)
 
         nsender = self.wait_for_walsender()

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/run/test_gpinitstandby.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/run/test_gpinitstandby.py
@@ -59,7 +59,7 @@ class gpinitstandby(StandbyRunMixin, MPPTestCase):
                       ' '.join(['gpinitstandby', '-a',
                          '-s', array.master.getSegmentHostName(),
                          '-P', self.standby_port,
-                         '-F', 'pg_system:' + self.standby_datadir]))
+                         '-F', self.standby_datadir]))
         cmd.run(validateAfter=True)
 
         nsender = self.wait_for_walsender()
@@ -83,7 +83,7 @@ class gpinitstandby(StandbyRunMixin, MPPTestCase):
         cmd = Command('gpinitstandby',
                       'gpinitstandby -a -s {0} -F {1}'.format(
                             array.master.getSegmentHostName(),
-                            'pg_system:/tmp/dummydir'))
+                            '/tmp/dummydir'))
         cmd.run()
         self.assertIn('cannot create standby on the same host and port',
                         cmd.get_results().stdout)


### PR DESCRIPTION
* Fix tests associated filespace.
* Update expected result of gpinitstandby with no standby_master directory.

Author: Max Yang <myang@pivotal.io>
Author: Xiaoran Wang <xiwang@pivotal.io>