### PR TITLE
[walreplication] Fully revert two duplicated commits

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -7570,7 +7570,14 @@ StartupXLOG(void)
 							   true);
 #endif
 
-	bool needToPromoteCatalog = (ControlFile->state == DB_IN_STANDBY_PROMOTED);
+	/*
+	 * If we are a standby with contentid -1 and undergoing promotion,
+	 * update ourselves as the new master in catalog.  This does not
+	 * apply to a mirror (standby of a GPDB segment) because it is
+	 * managed by FTS.
+	 */
+	bool needToPromoteCatalog = (GpIdentity.segindex == MASTER_CONTENT_ID &&
+								 ControlFile->state == DB_IN_STANDBY_PROMOTED);
 
 	LWLockAcquire(ControlFileLock, LW_EXCLUSIVE);
 	ControlFile->state = DB_IN_PRODUCTION;

--- a/src/backend/fts/ftsmessagehandler.c
+++ b/src/backend/fts/ftsmessagehandler.c
@@ -116,6 +116,7 @@ HandleFtsWalRepSyncRepOff(void)
 			(errmsg("turning off synchronous wal replication due to FTS request")));
 	UnsetSyncStandbysDefined();
 	GetMirrorStatus(&response);
+
 	SendFtsResponse(&response, FTS_MSG_SYNCREP_OFF);
 }
 


### PR DESCRIPTION
This reverts commit 0277b584 (which was already partially reverted in 0039844) and commit 4b4643f8. Commit 2b939748 already applied the logical intent of these commits, as well as some improvements which were accidentally reverted.