### PR TITLE
WIP: Add several fixes tablespace handling

### DIFF
--- a/gpMgmt/bin/gpinitstandby
+++ b/gpMgmt/bin/gpinitstandby
@@ -287,31 +287,59 @@ def delete_standby(options):
 
     # Reenable Ctrl-C
     signal.signal(signal.SIGINT,signal.default_int_handler)
-  
+
+
+#-------------------------------------------------------------------------
+def get_tablespace_paths(standby_dbid):
+    dburl = getDbUrlForInitStandby()
+    conn = dbconn.connect(dburl, utility=True)
+    sql = ("SELECT gp_tablespace_path(spclocation, %d) FROM pg_tablespace WHERE spcname "
+           "<> 'pg_default' AND spcname <> 'pg_global'") % standby_dbid
+    cur = dbconn.execSQL(conn, sql)
+
+    paths = []
+    for tblspc_path in cur.fetchall():
+        paths.append(tblspc_path[0])
+
+    conn.close()
+    return paths
+
+
+#-------------------------------------------------------------------------
+def do_remove_standby_datadir(standby_datadir, standby_host, standby_dbid):
+    pool = base.WorkerPool(numWorkers=DEFAULT_BATCH_SIZE)
+
+    cmd = unix.RemoveDirectory('delete standby datadir',
+                               standby_datadir, ctxt=base.REMOTE,
+                               remoteHost=standby_host)
+    pool.addCommand(cmd)
+
+    for tablespace_path in get_tablespace_paths(standby_dbid):
+        cmd = unix.RemoveDirectory('delete standby tablespace dir:%s' % (tablespace_path),
+                                   tablespace_path, ctxt=base.REMOTE,
+                                   remoteHost=standby_host)
+        pool.addCommand(cmd)
+
+    pool.join()
+    try:
+        pool.check_results()
+    except Exception, ex:
+        logger.error('Failed to remove data directory on standby master.')
+        raise GpInitStandbyException(ex)
+    finally:
+        pool.haltWork()
+
+
 #-------------------------------------------------------------------------
 def remove_standby_datadir(array):
     """Removes the data directory on the standby master."""
 
-    # WALREP_FIXME: We should also remove tablespace paths for the server here.
-
     if array.standbyMaster:
         logger.info('Removing data directory on standby master...')
-       
-        pool = base.WorkerPool(numWorkers=DEFAULT_BATCH_SIZE)
-        
-        cmd = unix.RemoveDirectory('delete standby datadir',
-                                   array.standbyMaster.getSegmentDataDirectory(), ctxt=base.REMOTE,
-                                   remoteHost=array.standbyMaster.getSegmentHostName())
-        pool.addCommand(cmd)
+        do_remove_standby_datadir(array.standbyMaster.getSegmentDataDirectory(),
+                                  array.standbyMaster.getSegmentHostName(),
+                                  array.standbyMaster.getSegmentDbId())
 
-        pool.join()
-        try:
-            pool.check_results()
-        except Exception, ex:
-            logger.error('Failed to remove data directory on standby master.')
-            raise GpInitStandbyException(ex)
-        finally:
-            pool.haltWork()
             
 def check_and_start_standby():
     """Checks if standby master is up and starts the standby master, if stopped."""
@@ -325,6 +353,7 @@ def check_and_start_standby():
     conn = dbconn.connect(dburl, utility=True)
     sql = "SELECT * FROM pg_stat_replication"
     cur = dbconn.execSQL(conn, sql)
+
     if cur.rowcount >= 1:
         logger.info("Standy master is already up and running.")
         return
@@ -457,6 +486,7 @@ def create_standby(options):
             logger.info('Restoring pg_hba.conf file...')
             restore_pg_hba_on_segment(array)
             undo_update_pg_hba_conf(array)
+            do_remove_standby_datadir(standby.datadir, standby.hostname, standby.dbid)
 
         raise GpInitStandbyException(ex)
 
@@ -700,7 +730,8 @@ def copy_master_datadir_to_standby(options, array, standby_datadir):
                         '-E', './gpperfmon/logs',
                         '-D', standby_datadir,
                         '-h', array.master.getSegmentHostName(),
-                        '-p', str(array.master.getSegmentPort())])
+                        '-p', str(array.master.getSegmentPort()),
+                        '--target-dbid', str(array.standbyMaster.getSegmentDbId())])
     cmd = base.Command('pg_basebackup',
                        cmd_str,
                        ctxt=base.REMOTE,

--- a/src/backend/catalog/catalog.c
+++ b/src/backend/catalog/catalog.c
@@ -105,7 +105,7 @@ tablespace_version_directory(void)
 {
 	static char path[MAXPGPATH];
 
-	snprintf(path, MAXPGPATH, "%s_db%d", GP_TABLESPACE_VERSION_DIRECTORY, GpIdentity.dbid);
+	snprintf(path, MAXPGPATH, "%s%d", GP_TABLESPACE_VERSION_PREFIX, GpIdentity.dbid);
 
 	return path;
 }

--- a/src/backend/utils/adt/misc.c
+++ b/src/backend/utils/adt/misc.c
@@ -25,6 +25,7 @@
 #include "catalog/pg_tablespace.h"
 #include "commands/dbcommands.h"
 #include "funcapi.h"
+#include "fmgr.h"
 #include "miscadmin.h"
 #include "parser/keywords.h"
 #include "postmaster/syslogger.h"
@@ -33,6 +34,7 @@
 #include "storage/procarray.h"
 #include "utils/backend_cancel.h"
 #include "utils/builtins.h"
+#include "utils/palloc.h"
 #include "tcop/tcopprot.h"
 
 #define atooid(x)  ((Oid) strtoul((x), NULL, 10))
@@ -486,4 +488,26 @@ Datum
 pg_typeof(PG_FUNCTION_ARGS)
 {
 	PG_RETURN_OID(get_fn_expr_argtype(fcinfo->flinfo, 0));
+}
+
+/*
+ * Get GPDB tablespace path.
+ * For example: /tmp/myspc/GPDB_8.4_301801031_db1, where /tmp/myspc is spclocation in
+ * pg_tablespace, and ending 1 is the dbid.
+ */
+Datum
+gp_tablespace_path(PG_FUNCTION_ARGS)
+{
+	char		tblspace_path[MAXPGPATH];
+	const char	*spclocation = text_to_cstring(PG_GETARG_CSTRING(0));
+	int32_t		dbid = PG_GETARG_INT32(1);
+	int			ret;
+	ret = snprintf(tblspace_path, sizeof(tblspace_path),
+				   "%s/%s%d", spclocation, GP_TABLESPACE_VERSION_PREFIX, dbid);
+
+	if (ret >= sizeof(tblspace_path))
+		elog(ERROR, "%s/%s%d is too long than path length limit: %d",
+			 spclocation, GP_TABLESPACE_VERSION_PREFIX, dbid, MAXPGPATH);
+
+	PG_RETURN_CSTRING(pstrdup(tblspace_path));
 }

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -31,6 +31,8 @@
 #define GP_TABLESPACE_VERSION_DIRECTORY	"GPDB_" PG_MAJORVERSION "_" \
 									CppAsString2(CATALOG_VERSION_NO)
 
+#define GP_TABLESPACE_VERSION_PREFIX GP_TABLESPACE_VERSION_DIRECTORY "_db"
+
 extern const char *forkNames[];
 extern ForkNumber forkname_to_number(char *forkName);
 

--- a/src/include/catalog/pg_proc.h
+++ b/src/include/catalog/pg_proc.h
@@ -49,7 +49,7 @@ CATALOG(pg_proc,1255) BKI_BOOTSTRAP
 	bool		proisstrict;	/* strict with respect to NULLs? */
 	bool		proretset;		/* returns a set? */
 	char		provolatile;	/* see PROVOLATILE_ categories below */
-	int2		pronargs;		/* number of arguments */
+	int2		pronargs;		/*  of arguments */
 	int2		pronargdefaults;	/* number of arguments with defaults */
 	Oid			prorettype;		/* OID of result type */
 
@@ -2366,6 +2366,9 @@ DATA(insert OID = 2289 (  pg_options_to_table		PGNSP PGUID 12 1 3 0 f f f t t s 
 DESCR("convert generic options array to name/value table");
 
 DATA(insert OID = 1619 (  pg_typeof				PGNSP PGUID 12 1 0 0 f f f f f s 1 0 2206 "2276" _null_ _null_ _null_ _null_  pg_typeof _null_ _null_ _null_ ));
+DESCR("returns the type of the argument");
+
+DATA(insert OID = 7305 (  gp_tablespace_path	PGNSP PGUID 12 1 0 0 f f f f f s 2 0 2275 "25 23" _null_ _null_ _null_ _null_  gp_tablespace_path _null_ _null_ _null_ ));
 DESCR("returns the type of the argument");
 
 /* Generic referential integrity constraint triggers */

--- a/src/include/utils/builtins.h
+++ b/src/include/utils/builtins.h
@@ -468,6 +468,7 @@ extern Datum pg_rotate_logfile(PG_FUNCTION_ARGS);
 extern Datum pg_sleep(PG_FUNCTION_ARGS);
 extern Datum pg_get_keywords(PG_FUNCTION_ARGS);
 extern Datum pg_typeof(PG_FUNCTION_ARGS);
+extern Datum gp_tablespace_path(PG_FUNCTION_ARGS);
 
 /* oid.c */
 extern Datum oidin(PG_FUNCTION_ARGS);


### PR DESCRIPTION
* Add two options in pg_basebackup: --target-dbid and --tablespace-version-prefix,
  both of which are used by gpinitstandby.
  target-dbid is passed in so that pg_basebackup know how to backup tablespace related
  data, and won't conflict with primary tablespace on the same machine and tablespace
  points to same location.
* Enhance gpinitstandby -r to cleanup tablespace related folders when standby is removed.

The issue not resolved is for gpactivatestandby. Currently, for some reason, we change gpdbid
of standby back to 1, which is the old primary gpdbid. This hehavior makes tablespace inconsitent.

Author: Xiaoran Wang <xiwang@pivotal.io>
Author: Max Yang <myang@pivotal.io>