### PR TITLE
Fix gpexpand for walrep

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -1685,13 +1685,6 @@ Set PGDATABASE or use the -D option to specify the correct database to use.""" %
                 if restore_conn != None:
                     restore_conn.close()
 
-    def sync_new_mirrors(self):
-        """ This method will execute gprecoverseg so that all new segments sync with their mirrors."""
-        if self.gparray.get_mirroring_enabled() == True:
-            self.logger.info('Starting new mirror segment synchronization')
-            cmd = GpRecoverSeg(name="gpexpand syncing mirrors", options="-a -F")
-            cmd.run(validateAfter=True)
-
     def start_prepare(self):
         """Inserts into gpexpand.status that expansion preparation has started."""
         if self.options.filename:
@@ -2792,7 +2785,7 @@ def main(options, args, parser):
             _gp_expand.prepare_schema()
             logger.info('Starting Greenplum Database')
             GpStart.local('gpexpand expansion prepare final start')
-            _gp_expand.sync_new_mirrors()
+            # When the mirrors come up, it should sync with the primary on its own.
             logger.info('************************************************')
             logger.info('Initialization of the system expansion complete.')
             logger.info('To begin table expansion onto the new segments')

--- a/gpMgmt/bin/gppylib/gparray.py
+++ b/gpMgmt/bin/gppylib/gparray.py
@@ -520,7 +520,9 @@ class SegmentPair:
         prim_mode = self.primaryDB.getSegmentMode()
 
         if not self.mirrorDB:
-            return (prim_status, prim_mode) in VALID_SEGMENT_STATES
+            # Since we don't have a mirror, we can assume that the status would
+            # be down and not in sync.
+            return (prim_status, prim_mode, STATUS_DOWN, MODE_NOT_SYNC) in VALID_SEGMENT_STATES
 
         mirror_status = self.mirrorDB.getSegmentStatus()
         mirror_role = self.mirrorDB.getSegmentMode()

--- a/gpMgmt/bin/gppylib/system/configurationImplGpdb.py
+++ b/gpMgmt/bin/gppylib/system/configurationImplGpdb.py
@@ -200,8 +200,7 @@ class GpConfigurationProviderUsingGpdbCatalog(GpConfigurationProvider) :
         # add the new segment
         dbId = self.__callSegmentAdd(conn, gpArray, seg)
 
-        # We should assume that gp_add_segment_primary() will update the
-        # mode and status
+        # gp_add_segment_primary() will update the mode and status.
 
         # get the newly added segment's content id
         # MPP-12393 et al WARNING: there is an unusual side effect going on here.

--- a/gpMgmt/bin/gppylib/system/configurationImplGpdb.py
+++ b/gpMgmt/bin/gppylib/system/configurationImplGpdb.py
@@ -200,8 +200,8 @@ class GpConfigurationProviderUsingGpdbCatalog(GpConfigurationProvider) :
         # add the new segment
         dbId = self.__callSegmentAdd(conn, gpArray, seg)
 
-        # update the segment mode and status
-        self.__updateSegmentModeStatus(conn, seg)
+        # We should assume that gp_add_segment_primary() will update the
+        # mode and status
 
         # get the newly added segment's content id
         # MPP-12393 et al WARNING: there is an unusual side effect going on here.
@@ -231,7 +231,6 @@ class GpConfigurationProviderUsingGpdbCatalog(GpConfigurationProvider) :
         and record our action in gp_configuration_history.
         """
         dbId = self.__callSegmentAddMirror(conn, gpArray, seg)
-        self.__updateSegmentModeStatus(conn, seg)
         self.__insertConfigHistory(conn, dbId, "%s: inserted mirror segment configuration" % textForConfigTable)
 
 
@@ -246,8 +245,6 @@ class GpConfigurationProviderUsingGpdbCatalog(GpConfigurationProvider) :
 
         dbId = self.__callSegmentAddMirror(conn, gpArray, seg)
 
-        # now update mode/status since this is not done by gp_add_segment_mirror
-        self.__updateSegmentModeStatus(conn, seg)
         self.__insertConfigHistory(conn, seg.getSegmentDbId(),
                                    "%s: inserted segment configuration for full recovery or original dbid %s" \
                                    % (textForConfigTable, origDbId))


### PR DESCRIPTION
gpexpand: remove sync_new_mirrors from gpexpand.
The syncing should be done automatically by the mirror, when the mirror
connects to the primary.

Author: Marbin Tan <mtan@pivotal.io>
Author: Shoaib Lari <slari@pivotal.io>

---

gp_segment_configuration should be updated through gp_add_segment_primary and gp_add_segment_mirror

- Add a fix for our status validation check.
We were checking an incorrect of elements in a tuple, it was always
return false if you only had primaries.
Make it such that the mirrors will always be assumed down when
validating when you only have primaries for the cluster.
