### PR TITLE
[walreplication] Reclaim space when an AO segment is dropped at AO compaction.

### DIFF
--- a/src/backend/access/aocs/aocs_compaction.c
+++ b/src/backend/access/aocs/aocs_compaction.c
@@ -36,29 +36,48 @@
 #include "utils/guc.h"
 #include "miscadmin.h"
 
-/**
+/*
  * Drops a segment file.
  *
+ * Actually, we just truncate the segfile to 0 bytes, to reclaim the space.
+ * Before GPDB 6, we used to remove the file, but with WAL replication, we
+ * no longer have a convenient function to remove a single segment of a
+ * relation. An empty file is as almost as good as a non-existent file. If
+ * the relation is dropped later, the code in mdunlink() will remove all
+ * segments, including any empty ones we've left behind.
  */
 static void
 AOCSCompaction_DropSegmentFile(Relation aorel,
 							   int segno)
 {
-	int			pseudoSegNo;
 	int			col;
 
 	Assert(RelationIsAoCols(aorel));
 
 	for (col = 0; col < RelationGetNumberOfAttributes(aorel); col++)
 	{
-		pseudoSegNo = (col * AOTupleId_MultiplierSegmentFileNum) + segno;
+		char		filenamepath[MAXPGPATH];
+		int			pseudoSegNo;
+		File		fd;
 
-		// WALREP_FIXME: Call smgrunlink() directly on the segfile.
+		/* Open and truncate the relation segfile beyond its eof */
+		MakeAOSegmentFileName(aorel, segno, col, &pseudoSegNo, filenamepath);
 
 		elogif(Debug_appendonly_print_compaction, LOG,
 			   "Drop segment file: "
 			   "segno %d",
 			   pseudoSegNo);
+
+		fd = OpenAOSegmentFile(aorel, filenamepath, pseudoSegNo, 0);
+		if (fd >= 0)
+		{
+			TruncateAOSegmentFile(fd, aorel, pseudoSegNo, 0);
+			CloseAOSegmentFile(fd);
+		}
+		else
+		{
+			elog(LOG, "could not truncate segfile %s, because it does not exist", filenamepath);
+		}
 	}
 }
 

--- a/src/backend/access/appendonly/appendonly_compaction.c
+++ b/src/backend/access/appendonly/appendonly_compaction.c
@@ -50,20 +50,38 @@
 /*
  * Drops a segment file.
  *
+ * Actually, we just truncate the segfile to 0 bytes, to reclaim the space.
+ * Before GPDB 6, we used to remove the file, but with WAL replication, we
+ * no longer have a convenient function to remove a single segment of a
+ * relation. An empty file is as almost as good as a non-existent file. If
+ * the relation is dropped later, the code in mdunlink() will remove all
+ * segments, including any empty ones we've left behind.
  */
 static void
-AppendOnlyCompaction_DropSegmentFile(Relation aorel,
-									 int segno)
+AppendOnlyCompaction_DropSegmentFile(Relation aorel, int segno)
 {
+	char		filenamepath[MAXPGPATH];
+	int32		fileSegNo;
+	File		fd;
+
+	Assert(RelationIsAoRows(aorel));
+
 	elogif(Debug_appendonly_print_compaction, LOG,
 		   "Drop segment file: segno %d", segno);
 
-	// WALREP_FIXME: smgrunlink() or something here.
-#if 0
-	MirroredFileSysObj_ScheduleDropAppendOnlyFile(&aorel->rd_node,
-												  segno,
-												  RelationGetRelationName(aorel));
-#endif
+	/* Open and truncate the relation segfile beyond its eof */
+	MakeAOSegmentFileName(aorel, segno, -1, &fileSegNo, filenamepath);
+
+	fd = OpenAOSegmentFile(aorel, filenamepath, fileSegNo, 0);
+	if (fd >= 0)
+	{
+		TruncateAOSegmentFile(fd, aorel, fileSegNo, 0);
+		CloseAOSegmentFile(fd);
+	}
+	else
+	{
+		elog(LOG, "could not truncate segfile %s, because it does not exist", filenamepath);
+	}
 }
 
 /*


### PR DESCRIPTION
In the first cut of the walreplication work, I left out the part that
drops a segfile during AO compaction, because there was no
straightforward native PostgreSQL function to drop just a single segfile.
However, that leads to a massive disk space leak, as the space freed by
VACUUM on an AO table is not reclaimed, until the same segment number is
used again for further insertions, so we clearly must do something about
that.

Instead of dropping the segfile altogether, like we used to, truncate the
file to 0 bytes. Mostly because that's more expedient to do, as we have
the functions to do that and to WAL-log that, whereas code to fully remove
just a single segfile doesn't exist. But if you squint a bit, you could
even call that an optimization: it saves the overhead of recreating the
file again, if you load more data to it later.