### PR TITLE
gen_pipeline.py: don't clobber envvars when calling other scripts

### DIFF
--- a/concourse/pipelines/gen_pipeline.py
+++ b/concourse/pipelines/gen_pipeline.py
@@ -132,9 +132,11 @@ if __name__ == "__main__":
         print "Validate Pipeline Release Jobs"
         print "----------------------------------------------------------------------"
         try:
+            env = os.environ.copy()
+            env['PIPELINE_FILE'] = ARGS.output_filename
             subprocess.check_call(["python",
                                    "../scripts/validate_pipeline_release_jobs.py"],
-                                  env={"PIPELINE_FILE":ARGS.output_filename})
+                                  env=env)
         except subprocess.CalledProcessError:
             exit(1)
 


### PR DESCRIPTION
I use `virtualenv` for most of my Python utilities, and `gen_pipeline.py` switches away from my venv stack to the standard system stack when it runs `validate_pipeline_release_jobs.py` (which causes some really confusing import failures). To avoid that, we can have the script inherit the current environment instead of resetting it.