### PR TITLE
Provide infrastructure for Greenplum cluster monitoring using hook

### DIFF
--- a/contrib/auto_explain/auto_explain.c
+++ b/contrib/auto_explain/auto_explain.c
@@ -127,7 +127,7 @@ explain_ExecutorStart(QueryDesc *queryDesc, int eflags)
 	{
 		/* Enable per-node instrumentation iff log_analyze is required. */
 		if (auto_explain_log_analyze && (eflags & EXEC_FLAG_EXPLAIN_ONLY) == 0)
-			queryDesc->doInstrument = true;
+			queryDesc->instrument_options = INSTRUMENT_ALL;
 	}
 
 	if (prev_ExecutorStart)
@@ -147,7 +147,7 @@ explain_ExecutorStart(QueryDesc *queryDesc, int eflags)
 			MemoryContext oldcxt;
 
 			oldcxt = MemoryContextSwitchTo(queryDesc->estate->es_query_cxt);
-			queryDesc->totaltime = InstrAlloc(1);
+			queryDesc->totaltime = InstrAlloc(1, queryDesc->instrument_options);
 			MemoryContextSwitchTo(oldcxt);
 		}
 	}
@@ -200,7 +200,7 @@ explain_ExecutorEnd(QueryDesc *queryDesc)
 
 			initStringInfo(&buf);
 			ExplainPrintPlan(&buf, queryDesc,
-						 queryDesc->doInstrument && auto_explain_log_analyze,
+						 queryDesc->instrument_options && auto_explain_log_analyze,
 							 auto_explain_log_verbose);
 
 			/* Remove last line break */

--- a/contrib/gp_internal_tools/Makefile
+++ b/contrib/gp_internal_tools/Makefile
@@ -1,4 +1,4 @@
-MODULES    = gp_ao_co_diagnostics gp_workfile_mgr gp_session_state_memory_stats
+MODULES    = gp_ao_co_diagnostics gp_workfile_mgr gp_session_state_memory_stats gp_instrument_shmem
 DATA       = gp_session_state.sql uninstall_gp_session_state.sql
 
 PG_CPPFLAGS = -I$(libpq_srcdir)

--- a/contrib/gp_internal_tools/gp_instrument_shmem.c
+++ b/contrib/gp_internal_tools/gp_instrument_shmem.c
@@ -1,0 +1,180 @@
+/*-------------------------------------------------------------------------
+ *
+ * gp_instrument_shmem.c
+ *    Functions for diagnos Instrumentation Shmem slots
+ *
+ * Copyright (c) 2017-Present Pivotal Software, Inc.
+ *
+ *-------------------------------------------------------------------------
+*/
+#include "postgres.h"
+#include "funcapi.h"
+#include "cdb/cdbvars.h"
+#include "utils/builtins.h"
+#include "executor/instrument.h"
+
+PG_MODULE_MAGIC;
+
+Datum		gp_instrument_shmem_summary(PG_FUNCTION_ARGS);
+Datum		gp_instrument_shmem_detail(PG_FUNCTION_ARGS);
+
+/* Helper functions */
+static InstrumentationSlot *next_used_slot(int32 *);
+
+PG_FUNCTION_INFO_V1(gp_instrument_shmem_summary);
+PG_FUNCTION_INFO_V1(gp_instrument_shmem_detail);
+
+#define GET_SLOT_BY_INDEX(index) ((InstrumentationSlot*)(InstrumentGlobal + 1) + (index))
+
+/*
+ * Get summary of shmem instrument slot usage
+ *
+ * ---------------------------------------------------------------------
+ * Interface to gp_instrument_shmem_summary function.
+ *
+ * The gp_instrument_shmem_summary function get the summary of shmem instrument slot usage.
+ * It can be invoked by creating a function via psql that references it.
+ * For example,
+ *
+ * CREATE FUNCTION gp_instrument_shmem_summary()
+ *   RETURNS TABLE ( segid int4
+ *   				,num_free int8
+ *   				,num_used int8
+ *                 )
+ *   AS '$libdir/gp_instrument_shmem', 'gp_instrument_shmem_summary' LANGUAGE C IMMUTABLE;
+ */
+Datum
+gp_instrument_shmem_summary(PG_FUNCTION_ARGS)
+{
+	TupleDesc	tupdesc;
+	int			nattr = 3;
+
+	tupdesc = CreateTemplateTupleDesc(nattr, false);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 1, "segid", INT4OID, -1, 0);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 2, "num_free", INT8OID, -1, 0);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 3, "num_used", INT8OID, -1, 0);
+	tupdesc = BlessTupleDesc(tupdesc);
+
+	Datum		values[nattr];
+	bool		nulls[nattr];
+
+	MemSet(nulls, 0, sizeof(nulls));
+
+	values[0] = Int32GetDatum(Gp_segment);
+	if (InstrumentGlobal)
+	{
+		values[1] = Int64GetDatum(InstrumentGlobal->free);
+		values[2] = Int64GetDatum(InstrShmemNumSlots() - InstrumentGlobal->free);
+	}
+	else
+	{
+		nulls[1] = true;
+		nulls[2] = true;
+	}
+	HeapTuple	tuple = heap_form_tuple(tupdesc, values, nulls);
+	Datum		result = HeapTupleGetDatum(tuple);
+
+	PG_RETURN_DATUM(result);
+}
+
+static InstrumentationSlot *
+next_used_slot(int32 *crtIndexPtr)
+{
+	if (InstrumentGlobal == NULL)
+		return NULL;
+
+	while (*crtIndexPtr < InstrShmemNumSlots() && SlotIsEmpty(GET_SLOT_BY_INDEX(*crtIndexPtr)))
+		(*crtIndexPtr)++;
+	return *crtIndexPtr >= InstrShmemNumSlots() ? NULL : GET_SLOT_BY_INDEX((*crtIndexPtr)++);
+}
+
+/*
+ * Get summary of shmem instrument slot usage
+ *
+ * ---------------------------------------------------------------------
+ * Interface to gp_instrument_shmem_detail function.
+ *
+ * The gp_instrument_shmem_detail function get the detail of shmem instrument slot usage.
+ * It can be invoked by creating a function via psql that references it.
+ * For example,
+ *
+ * CREATE FUNCTION gp_instrument_shmem_detail()
+ *   RETURNS TABLE ( tmid int4
+ *   				,ssid int4
+ *   				,ccnt int2
+ *   				,segid int2
+ *   				,pid int4
+ *   				,nid int2
+ *   				,tuplecount int8
+ *   				,nloops int8
+ *   				,ntuples int8
+ *                 )
+ *   AS '$libdir/gp_instrument_shmem', 'gp_instrument_shmem_detail' LANGUAGE C IMMUTABLE;
+ */
+Datum
+gp_instrument_shmem_detail(PG_FUNCTION_ARGS)
+{
+	FuncCallContext *funcctx;
+	int32	   *crtIndexPtr;
+	int			nattr = 9;
+
+	if (SRF_IS_FIRSTCALL())
+	{
+		/* create a function context for cross-call persistence */
+		funcctx = SRF_FIRSTCALL_INIT();
+
+		/* Switch to memory context appropriate for multiple function calls */
+		MemoryContext oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
+
+		TupleDesc	tupdesc = CreateTemplateTupleDesc(nattr, false);
+
+		TupleDescInitEntry(tupdesc, (AttrNumber) 1, "tmid", INT4OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 2, "ssid", INT4OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 3, "ccnt", INT2OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 4, "segid", INT2OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 5, "pid", INT4OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 6, "nid", INT2OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 7, "tuplecount", INT8OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 8, "nloops", INT8OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 9, "ntuples", INT8OID, -1, 0);
+
+		funcctx->tuple_desc = BlessTupleDesc(tupdesc);
+
+		crtIndexPtr = (int32 *) palloc(sizeof(*crtIndexPtr));
+		*crtIndexPtr = 0;
+		funcctx->user_fctx = crtIndexPtr;
+		MemoryContextSwitchTo(oldcontext);
+	}
+
+	funcctx = SRF_PERCALL_SETUP();
+	crtIndexPtr = (int32 *) funcctx->user_fctx;
+	while (true)
+	{
+		InstrumentationSlot *slot = next_used_slot(crtIndexPtr);
+
+		if (slot == NULL)
+		{
+			/* Reached the end of the entry array, we're done */
+			SRF_RETURN_DONE(funcctx);
+		}
+		Datum		values[nattr];
+		bool		nulls[nattr];
+
+		memset(nulls, 0, sizeof(nulls));
+
+		values[0] = Int32GetDatum((slot->tmid));
+		values[1] = Int32GetDatum(slot->ssid);
+		values[2] = Int16GetDatum(slot->ccnt);
+		values[3] = Int16GetDatum(slot->segid);
+		values[4] = Int32GetDatum(slot->pid);
+		values[5] = Int16GetDatum(slot->nid);
+		values[6] = Int64GetDatum((int64) ((slot->data).tuplecount));
+		values[7] = Int64GetDatum((int64) ((slot->data).ntuples));
+		values[8] = Int64GetDatum((int64) ((slot->data).nloops));
+
+		HeapTuple	tuple = heap_form_tuple(funcctx->tuple_desc, values, nulls);
+		Datum		result = HeapTupleGetDatum(tuple);
+
+		SRF_RETURN_NEXT(funcctx, result);
+	}
+}

--- a/contrib/pg_stat_statements/pg_stat_statements.c
+++ b/contrib/pg_stat_statements/pg_stat_statements.c
@@ -493,7 +493,7 @@ pgss_ExecutorStart(QueryDesc *queryDesc, int eflags)
 			MemoryContext oldcxt;
 
 			oldcxt = MemoryContextSwitchTo(queryDesc->estate->es_query_cxt);
-			queryDesc->totaltime = InstrAlloc(1);
+			queryDesc->totaltime = InstrAlloc(1, queryDesc->instrument_options);
 			MemoryContextSwitchTo(oldcxt);
 		}
 	}

--- a/src/backend/cdb/cdbexplain.c
+++ b/src/backend/cdb/cdbexplain.c
@@ -1648,7 +1648,7 @@ cdbexplain_showExecStats(struct PlanState *planstate,
 
 	/* Number of rescans */
 	if (instr->nloops > 1)
-		appendStringInfo(str, " of %.0f scans", instr->nloops);
+		appendStringInfo(str, " of %ld scans", instr->nloops);
 
 	/* Time from start of query on qDisp to this worker's first result row */
 	if (!(INSTR_TIME_IS_ZERO(instr->firststart)))
@@ -1839,7 +1839,7 @@ cdbexplain_showExecStats(struct PlanState *planstate,
 					double		totalPartTableScannedPerRescan = ns->totalPartTableScanned.vmax / instr->nloops;
 
 					appendStringInfo(str,
-									 "Partitions scanned:  %.0f (out of %d) %s of %.0f scans.\n",
+									 "Partitions scanned:  %.0f (out of %d) %s of %ld scans.\n",
 									 totalPartTableScannedPerRescan,
 									 numTotalLeafParts,
 									 segbuf,
@@ -1863,7 +1863,7 @@ cdbexplain_showExecStats(struct PlanState *planstate,
 					double		maxPartTableScannedPerRescan = ns->totalPartTableScanned.vmax / instr->nloops;
 
 					appendStringInfo(str,
-									 "Partitions scanned:  Avg %.1f (out of %d) x %d workers of %.0f scans."
+									 "Partitions scanned:  Avg %.1f (out of %d) x %d workers of %ld scans."
 									 "  Max %.0f parts%s.\n",
 									 totalPartTableScannedPerRescan,
 									 numTotalLeafParts,

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -53,6 +53,7 @@
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
 #include "utils/snapmgr.h"
+#include "utils/metrics_utils.h"
 
 #include "cdb/cdbvars.h"
 #include "cdb/cdbcopy.h"
@@ -1631,6 +1632,10 @@ DoCopyInternal(const CopyStmt *stmt, const char *queryString, CopyState cstate)
 					GetResqueueName(GetResQueueId()),
 					GetResqueuePriority(GetResQueueId()));
 		}
+
+		/* GPDB hook for collecting query info */
+		if (query_info_collect_hook)
+			(*query_info_collect_hook)(METRICS_QUERY_SUBMIT, cstate->queryDesc);
 
 		/*
 		 * Call ExecutorStart to prepare the plan for execution.

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -1618,7 +1618,8 @@ DoCopyInternal(const CopyStmt *stmt, const char *queryString, CopyState cstate)
 		cstate->queryDesc = CreateQueryDesc(plan, queryString,
 											GetActiveSnapshot(),
 											InvalidSnapshot,
-											dest, NULL, false);
+											dest, NULL,
+											GP_INSTRUMENT_OPTS);
 
 		if (gp_enable_gpperfmon && Gp_role == GP_ROLE_DISPATCH)
 		{

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -33,6 +33,7 @@
 #include "utils/builtins.h"
 #include "utils/guc.h"
 #include "utils/lsyscache.h"
+#include "utils/metrics_utils.h"
 #include "utils/tuplesort.h"
 #include "utils/snapmgr.h"
 
@@ -366,6 +367,10 @@ ExplainOnePlan(PlannedStmt *plannedstmt, ExplainStmt *stmt,
 				GetResqueueName(GetResQueueId()),
 				GetResqueuePriority(GetResQueueId()));
 	}
+
+	/* GPDB hook for collecting query info */
+	if (query_info_collect_hook)
+		(*query_info_collect_hook)(METRICS_QUERY_SUBMIT, queryDesc);
 
 	/*
 	 * Start timing.

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -339,6 +339,10 @@ ExplainOnePlan(PlannedStmt *plannedstmt, ExplainStmt *stmt,
 	double		totaltime = 0;
 	StringInfoData buf;
 	int			eflags;
+	int			instrument_option = INSTRUMENT_NONE;
+
+	if (stmt->analyze)
+		instrument_option = INSTRUMENT_ALL;
 
 	/*
 	 * Use a snapshot with an updated command ID to ensure this query sees
@@ -350,7 +354,7 @@ ExplainOnePlan(PlannedStmt *plannedstmt, ExplainStmt *stmt,
 	queryDesc = CreateQueryDesc(plannedstmt, queryString,
 								GetActiveSnapshot(), InvalidSnapshot,
 								None_Receiver, params,
-								stmt->analyze);
+								instrument_option);
 
 	if (gp_enable_gpperfmon && Gp_role == GP_ROLE_DISPATCH)
 	{
@@ -644,7 +648,7 @@ report_triggers(ResultRelInfo *rInfo, bool show_relname, StringInfo buf)
 			appendStringInfo(buf, " on %s",
 							 RelationGetRelationName(rInfo->ri_RelationDesc));
 
-		appendStringInfo(buf, ": time=%.3f calls=%.0f\n",
+		appendStringInfo(buf, ": time=%.3f calls=%ld\n",
 						 1000.0 * instr->total, instr->ntuples);
 	}
 }
@@ -1575,7 +1579,7 @@ explain_outNode(StringInfo str,
 	}
 
     /* CDB: Show actual row count, etc. */
-	if (planstate->instrument)
+	if (planstate->instrument && planstate->instrument->need_cdb)
 	{
         cdbexplain_showExecStats(planstate,
                                  str,

--- a/src/backend/commands/extension.c
+++ b/src/backend/commands/extension.c
@@ -43,6 +43,7 @@
 #include "commands/comment.h"
 #include "commands/extension.h"
 #include "commands/schemacmds.h"
+#include "executor/instrument.h"
 #include "funcapi.h"
 #include "mb/pg_wchar.h"
 #include "miscadmin.h"
@@ -735,7 +736,8 @@ execute_sql_string(const char *sql, const char *filename)
 				qdesc = CreateQueryDesc((PlannedStmt *) stmt,
 										sql,
 										GetActiveSnapshot(), NULL,
-										dest, NULL, false);
+										dest, NULL,
+										GP_INSTRUMENT_OPTS);
 
 				ExecutorStart(qdesc, 0);
 				ExecutorRun(qdesc, ForwardScanDirection, 0);

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -11536,7 +11536,7 @@ build_ctas_with_dist(Relation rel, List *dist_clause,
 	/* Create a QueryDesc requesting no output */
 	queryDesc = CreateQueryDesc(stmt, pstrdup("(internal SELECT INTO query)"),
 								GetActiveSnapshot(), InvalidSnapshot,
-								dest, NULL, false);
+								dest, NULL, INSTRUMENT_NONE);
 
 	PopActiveSnapshot();
 

--- a/src/backend/executor/execHHashagg.c
+++ b/src/backend/executor/execHHashagg.c
@@ -913,7 +913,7 @@ agg_hash_initial_pass(AggState *aggstate)
 				break;
 			}
 
-			if (!hashtable->is_spilling && aggstate->ss.ps.instrument)
+			if (!hashtable->is_spilling && aggstate->ss.ps.instrument && aggstate->ss.ps.instrument->need_cdb)
 			{
 				/* Update in-memory hash table statistics before spilling. */
 				agg_hash_table_stat_upd(hashtable);
@@ -980,7 +980,7 @@ agg_hash_initial_pass(AggState *aggstate)
 		}
 	}
 
-	if (!hashtable->is_spilling && aggstate->ss.ps.instrument)
+	if (!hashtable->is_spilling && aggstate->ss.ps.instrument && aggstate->ss.ps.instrument->need_cdb)
 	{
 		/* Update in-memory hash table statistics if not already done when spilling */
 		agg_hash_table_stat_upd(hashtable);
@@ -1767,7 +1767,7 @@ agg_hash_reload(AggState *aggstate)
 
 			elog(gp_workfile_caching_loglevel, "HashAgg: respill occurring in agg_hash_reload while loading batch data");
 
-			if (!hashtable->is_spilling && aggstate->ss.ps.instrument)
+			if (!hashtable->is_spilling && aggstate->ss.ps.instrument && aggstate->ss.ps.instrument->need_cdb)
 			{
 				/* Update in-memory hash table statistics before spilling. */
 				agg_hash_table_stat_upd(hashtable);
@@ -1856,7 +1856,7 @@ agg_hash_reload(AggState *aggstate)
 			 GET_BUFFER_SIZE(hashtable));
 	}
 
-	if (!hashtable->is_spilling && aggstate->ss.ps.instrument)
+	if (!hashtable->is_spilling && aggstate->ss.ps.instrument && aggstate->ss.ps.instrument->need_cdb)
 	{
 		/* Update in-memory hash table statistics if not already done when spilling */
 		agg_hash_table_stat_upd(hashtable);
@@ -2055,7 +2055,7 @@ agg_hash_next_pass(AggState *aggstate)
 	}
 	
 	/* Report statistics for EXPLAIN ANALYZE. */
-	if (!more && aggstate->ss.ps.instrument)
+	if (!more && aggstate->ss.ps.instrument && aggstate->ss.ps.instrument->need_cdb)
 	{
 		Instrumentation    *instr = aggstate->ss.ps.instrument;
 

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -393,7 +393,7 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 	 */
 	estate->es_snapshot = RegisterSnapshot(queryDesc->snapshot);
 	estate->es_crosscheck_snapshot = RegisterSnapshot(queryDesc->crosscheck_snapshot);
-	estate->es_instrument = queryDesc->doInstrument;
+	estate->es_instrument = queryDesc->instrument_options;
 	estate->showstatctx = queryDesc->showstatctx;
 
 	/*
@@ -457,7 +457,7 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 		}
 
 		/* Pass EXPLAIN ANALYZE flag to qExecs. */
-		estate->es_sliceTable->doInstrument = queryDesc->doInstrument;
+		estate->es_sliceTable->instrument_options = queryDesc->instrument_options;
 
 		/* set our global sliceid variable for elog. */
 		currentSliceId = LocallyExecutingSliceIndex(estate);
@@ -513,8 +513,8 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 			currentSliceId = LocallyExecutingSliceIndex(estate);
 
 			/* Should we collect statistics for EXPLAIN ANALYZE? */
-			estate->es_instrument = sliceTable->doInstrument;
-			queryDesc->doInstrument = sliceTable->doInstrument;
+			estate->es_instrument = sliceTable->instrument_options;
+			queryDesc->instrument_options = sliceTable->instrument_options;
 		}
 
 		/* InitPlan() will acquire locks by walking the entire plan
@@ -965,7 +965,8 @@ standard_ExecutorRun(QueryDesc *queryDesc,
 	{
         /* If EXPLAIN ANALYZE, let qExec try to return stats to qDisp. */
         if (estate->es_sliceTable &&
-            estate->es_sliceTable->doInstrument &&
+            estate->es_sliceTable->instrument_options &&
+            (estate->es_sliceTable->instrument_options & INSTRUMENT_CDB) &&
             Gp_role == GP_ROLE_EXECUTE)
         {
             PG_TRY();
@@ -1095,7 +1096,8 @@ standard_ExecutorEnd(QueryDesc *queryDesc)
      * If EXPLAIN ANALYZE, qExec returns stats to qDisp now.
      */
     if (estate->es_sliceTable &&
-        estate->es_sliceTable->doInstrument &&
+        estate->es_sliceTable->instrument_options &&
+        (estate->es_sliceTable->instrument_options & INSTRUMENT_CDB) &&
         Gp_role == GP_ROLE_EXECUTE)
         cdbexplain_sendExecStats(queryDesc);
 
@@ -2224,7 +2226,7 @@ InitResultRelInfo(ResultRelInfo *resultRelInfo,
 				  Relation resultRelationDesc,
 				  Index resultRelationIndex,
 				  CmdType operation,
-				  bool doInstrument)
+				  int instrument_options)
 {
 	/*
 	 * Check valid relkind ... parser and/or planner should have noticed this
@@ -2299,8 +2301,8 @@ InitResultRelInfo(ResultRelInfo *resultRelInfo,
 
 		resultRelInfo->ri_TrigFunctions = (FmgrInfo *)
 			palloc0(n * sizeof(FmgrInfo));
-		if (doInstrument)
-			resultRelInfo->ri_TrigInstrument = InstrAlloc(n);
+		if (instrument_options)
+			resultRelInfo->ri_TrigInstrument = InstrAlloc(n, instrument_options);
 		else
 			resultRelInfo->ri_TrigInstrument = NULL;
 	}

--- a/src/backend/executor/execProcnode.c
+++ b/src/backend/executor/execProcnode.c
@@ -777,7 +777,7 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 
 	/* Set up instrumentation for this node if requested */
 	if (estate->es_instrument && result != NULL)
-		result->instrument = InstrAlloc(1);
+		result->instrument = GpInstrAlloc(node, estate->es_instrument);
 
 	/* Also set up gpmon counters */
 	InitPlanNodeGpmonPkt(node, &result->gpmon_pkt, estate);
@@ -864,7 +864,7 @@ ExecProcNode(PlanState *node)
 		ExecReScan(node, NULL); /* let ReScan handle this */
 
 	if (node->instrument)
-		InstrStartNode(node->instrument);
+		INSTR_START_NODE(node->instrument);
 
 	if(!node->fHadSentGpmon)
 		CheckSendPlanStateGpmonPkt(node);
@@ -1054,7 +1054,7 @@ ExecProcNode(PlanState *node)
 	}
 
 	if (node->instrument)
-		InstrStopNode(node->instrument, TupIsNull(result) ? 0.0 : 1.0);
+		INSTR_STOP_NODE(node->instrument, TupIsNull(result) ? 0 : 1);
 
 	if (node->plan)
 		TRACE_POSTGRESQL_EXECPROCNODE_EXIT(Gp_segment, currentSliceId, nodeTag(node), node->plan->plan_node_id);

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -67,6 +67,7 @@
 #include "cdb/cdbmotion.h"
 #include "cdb/cdbsreh.h"
 #include "cdb/memquota.h"
+#include "executor/instrument.h"
 #include "executor/spi.h"
 #include "utils/elog.h"
 #include "miscadmin.h"
@@ -1409,7 +1410,7 @@ InitSliceTable(EState *estate, int nMotions, int nSubplans)
 	table->nMotions = nMotions;
 	table->nInitPlans = nSubplans;
 	table->slices = NIL;
-    table->doInstrument = false;
+	table->instrument_options = INSTRUMENT_NONE;
 
 	/* Each slice table has a unique-id. */
 	table->ic_instance_id = ++gp_interconnect_id;

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -75,6 +75,7 @@
 #include "storage/ipc.h"
 #include "cdb/cdbllize.h"
 #include "utils/workfile_mgr.h"
+#include "utils/metrics_utils.h"
 
 #include "cdb/memquota.h"
 
@@ -2097,6 +2098,10 @@ void mppExecutorCleanup(QueryDesc *queryDesc)
 	/* caller must have switched into per-query memory context already */
 	estate = queryDesc->estate;
 
+	/* GPDB hook for collecting query info */
+	if (query_info_collect_hook && QueryCancelCleanup)
+		(*query_info_collect_hook)(METRICS_QUERY_CANCELING, queryDesc);
+
 	/*
 	 * If this query is being canceled, record that when the gpperfmon
 	 * is enabled.
@@ -2151,6 +2156,10 @@ void mppExecutorCleanup(QueryDesc *queryDesc)
 		TeardownInterconnect(estate->interconnect_context, estate->motionlayer_context, true /* force EOS */, true);
 		estate->es_interconnect_is_setup = false;
 	}
+
+	/* GPDB hook for collecting query info */
+	if (query_info_collect_hook)
+		(*query_info_collect_hook)(QueryCancelCleanup ? METRICS_QUERY_CANCELED : METRICS_QUERY_ERROR, queryDesc);
 	
 	/**
 	 * Perfmon related stuff.

--- a/src/backend/executor/functions.c
+++ b/src/backend/executor/functions.c
@@ -548,7 +548,8 @@ postquel_start(execution_state *es, SQLFunctionCachePtr fcache)
 								 fcache->src,
 								 snapshot, InvalidSnapshot,
 								 dest,
-								 fcache->paramLI, false);
+								 fcache->paramLI,
+								 GP_INSTRUMENT_OPTS);
 
 		if (gp_enable_gpperfmon 
 			&& Gp_role == GP_ROLE_DISPATCH 

--- a/src/backend/executor/functions.c
+++ b/src/backend/executor/functions.c
@@ -34,6 +34,7 @@
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"
 #include "utils/typcache.h"
+#include "utils/metrics_utils.h"
 #include "catalog/namespace.h"
 #include "catalog/pg_namespace.h"
 #include "cdb/cdbvars.h"
@@ -550,6 +551,10 @@ postquel_start(execution_state *es, SQLFunctionCachePtr fcache)
 								 dest,
 								 fcache->paramLI,
 								 GP_INSTRUMENT_OPTS);
+
+		/* GPDB hook for collecting query info */
+		if (query_info_collect_hook)
+			(*query_info_collect_hook)(METRICS_QUERY_SUBMIT, es->qd);
 
 		if (gp_enable_gpperfmon 
 			&& Gp_role == GP_ROLE_DISPATCH 

--- a/src/backend/executor/instrument.c
+++ b/src/backend/executor/instrument.c
@@ -16,15 +16,42 @@
 #include "postgres.h"
 
 #include <unistd.h>
+#include <cdb/cdbvars.h>
 
+#include "storage/spin.h"
 #include "executor/instrument.h"
+#include "utils/memutils.h"
 
+static bool shouldPickInstrInShmem(NodeTag tag);
+static Instrumentation *pickInstrFromShmem(const Plan *plan, int instrument_options);
+static void instrShmemRecycleCallback(ResourceReleasePhase phase, bool isCommit,
+						  bool isTopLevel, void *arg);
+
+InstrumentationHeader *InstrumentGlobal = NULL;
+
+static int  scanNodeCounter = 0;
+static int  shmemNumSlots = -1;
+static bool instrumentResownerCallbackRegistered = false;
+static InstrumentationResownerSet *slotsOccupied = NULL;
 
 /* Allocate new instrumentation structure(s) */
 Instrumentation *
-InstrAlloc(int n)
+InstrAlloc(int n, int instrument_options)
 {
 	Instrumentation *instr = palloc0(n * sizeof(Instrumentation));
+
+	if (instrument_options & (INSTRUMENT_TIMER | INSTRUMENT_CDB))
+	{
+		bool		need_timer = (instrument_options & INSTRUMENT_TIMER) != 0;
+		bool		need_cdb = (instrument_options & INSTRUMENT_CDB) != 0;
+		int			i;
+
+		for (i = 0; i < n; i++)
+		{
+			instr[i].need_timer = need_timer;
+			instr[i].need_cdb = need_cdb;
+		}
+	}
 
 	/* we don't need to do any initialization except zero 'em */
 	instr->numPartScanned = 0;
@@ -33,6 +60,11 @@ InstrAlloc(int n)
 }
 
 /* Entry to a plan node */
+/*
+ * GPDB Note: Macro INSTR_START_NODE replaces InstrStartNode in ExecProcNode for
+ * performance benefits, other files keep using InstrStartNode. Pay attention
+ * to keep InstrStartNode/INSTR_START_NODE synchronized when modifying this function.
+ */
 void
 InstrStartNode(Instrumentation *instr)
 {
@@ -43,8 +75,13 @@ InstrStartNode(Instrumentation *instr)
 }
 
 /* Exit from a plan node */
+/*
+ * GPDB Note: Macro INSTR_STOP_NODE replaces InstrStopNode in ExecProcNode for
+ * performance benefits, other files keep using InstrStopNode. Pay attention
+ * to keep InstrStopNode/INSTR_STOP_NODE synchronized when modifying this function.
+ */
 void
-InstrStopNode(Instrumentation *instr, double nTuples)
+InstrStopNode(Instrumentation *instr, uint64 nTuples)
 {
 	instr_time	endtime;
 
@@ -102,4 +139,250 @@ InstrEndLoop(Instrumentation *instr)
 	INSTR_TIME_SET_ZERO(instr->counter);
 	instr->firsttuple = 0;
 	instr->tuplecount = 0;
+}
+
+/* Calculate number slots from gp_instrument_shmem_size */
+Size
+InstrShmemNumSlots(void)
+{
+	if (shmemNumSlots < 0) {
+		shmemNumSlots = (int)(gp_instrument_shmem_size * 1024 - sizeof(InstrumentationHeader)) / sizeof(InstrumentationSlot);
+		shmemNumSlots = (shmemNumSlots < 0) ? 0 : shmemNumSlots;
+	}
+	return shmemNumSlots;
+}
+
+/* Allocate a header and an array of Instrumentation slots */
+Size
+InstrShmemSize(void)
+{
+	Size		size = 0;
+	Size		number_slots;
+
+	/* If start in utility mode, disallow Instrumentation on Shmem */
+	if (Gp_session_role == GP_ROLE_UTILITY)
+		return size;
+
+	/* If GUCs not enabled, bypass Instrumentation on Shmem */
+	if (!gp_enable_query_metrics || gp_instrument_shmem_size <= 0)
+		return size;
+
+	number_slots = InstrShmemNumSlots();
+
+	if (number_slots <= 0)
+		return size;
+
+	size = add_size(size, sizeof(InstrumentationHeader));
+	size = add_size(size, mul_size(number_slots, sizeof(InstrumentationSlot)));
+
+	return size;
+}
+
+/* Initialize Shmem space to construct a free list of Instrumentation */
+void
+InstrShmemInit(void)
+{
+	Size		size, number_slots;
+	InstrumentationSlot *slot;
+	InstrumentationHeader *header;
+	int			i;
+
+	number_slots = InstrShmemNumSlots();
+	size = InstrShmemSize();
+	if (size <= 0)
+		return;
+
+	/* Allocate space from Shmem */
+	header = (InstrumentationHeader *) ShmemAlloc(size);
+	if (!header)
+		ereport(FATAL, (errcode(ERRCODE_OUT_OF_MEMORY), errmsg("out of shared memory")));
+
+	/* Initialize header and all slots to zeroes, then modify as needed */
+	memset(header, PATTERN, size);
+
+	/* pointer to the first Instrumentation slot */
+	slot = (InstrumentationSlot *) (header + 1);
+
+	/* header points to the first slot */
+	header->head = slot;
+	header->free = number_slots;
+	SpinLockInit(&header->lock);
+
+	/* Each slot points to next one to construct the free list */
+	for (i = 0; i < number_slots - 1; i++)
+		GetInstrumentNext(&slot[i]) = &slot[i + 1];
+	GetInstrumentNext(&slot[i]) = NULL;
+
+	/* Finished init the free list */
+	InstrumentGlobal = header;
+
+	if (NULL != InstrumentGlobal && !instrumentResownerCallbackRegistered)
+	{
+		/*
+		 * Register a callback function in ResourceOwner to recycle Instr in
+		 * shmem
+		 */
+		RegisterResourceReleaseCallback(instrShmemRecycleCallback, NULL);
+		instrumentResownerCallbackRegistered = true;
+	}
+}
+
+/*
+ * This is GPDB replacement of InstrAlloc for ExecInitNode to get an
+ * Instrumentation struct
+ *
+ * Use shmem if gp_enable_query_metrics is on and there is free slot.
+ * Otherwise use local memory.
+ */
+Instrumentation *
+GpInstrAlloc(const Plan *node, int instrument_options)
+{
+	Instrumentation *instr = NULL;
+
+	if (shouldPickInstrInShmem(nodeTag(node)))
+		instr = pickInstrFromShmem(node, instrument_options);
+
+	if (instr == NULL)
+		instr = InstrAlloc(1, instrument_options);
+
+	return instr;
+}
+
+static bool
+shouldPickInstrInShmem(NodeTag tag)
+{
+	/* For utility mode, don't alloc in shmem */
+	if (Gp_session_role == GP_ROLE_UTILITY)
+		return false;
+
+	if (!gp_enable_query_metrics || NULL == InstrumentGlobal)
+		return false;
+
+	switch (tag)
+	{
+		case T_SeqScan:
+		case T_AppendOnlyScan:
+		case T_AOCSScan:
+		case T_TableScan:
+
+			/*
+			 * If table has many partitions, legacy planner will generate a
+			 * plan with many SCAN nodes under a APPEND node. If the number of
+			 * partitions are too many, this plan will occupy too many slots.
+			 * Here is a limitation on number of shmem slots used by scan
+			 * nodes for each backend. Instruments exceeding the limitation
+			 * are allocated local memory.
+			 */
+			if (scanNodeCounter >= MAX_SCAN_ON_SHMEM)
+				return false;
+			scanNodeCounter++;
+			break;
+		default:
+			break;
+	}
+	return true;
+}
+
+/*
+ * Pick an Instrumentation from free slots in Shmem.
+ * Return NULL when no more free slots in Shmem.
+ *
+ * Instrumentation returned by this function requires to be
+ * recycled back to the free slots list when the query is done.
+ * See instrShmemRecycleCallback for recycling behavior
+ */
+static Instrumentation *
+pickInstrFromShmem(const Plan *plan, int instrument_options)
+{
+	Instrumentation *instr = NULL;
+	InstrumentationSlot *slot = NULL;
+	InstrumentationResownerSet *item;
+
+	/* Lock to protect write to header */
+	SpinLockAcquire(&InstrumentGlobal->lock);
+
+	/* Pick the first free slot */
+	slot = InstrumentGlobal->head;
+	if (NULL != slot && SlotIsEmpty(slot))
+	{
+		/* Header points to the next free slot */
+		InstrumentGlobal->head = GetInstrumentNext(slot);
+		InstrumentGlobal->free--;
+	}
+
+	SpinLockRelease(&InstrumentGlobal->lock);
+
+	if (NULL != slot && SlotIsEmpty(slot))
+	{
+		memset(slot, 0x00, sizeof(InstrumentationSlot));
+		/* initialize the picked slot */
+		instr = &(slot->data);
+		slot->segid = (int16) Gp_segment;
+		slot->pid = MyProcPid;
+		gpmon_gettmid(&(slot->tmid));
+		slot->ssid = gp_session_id;
+		slot->ccnt = gp_command_count;
+		slot->nid = (int16) plan->plan_node_id;
+
+		MemoryContext contextSave = MemoryContextSwitchTo(TopMemoryContext);
+
+		item = (InstrumentationResownerSet *) palloc0(sizeof(InstrumentationResownerSet));
+		item->owner = CurrentResourceOwner;
+		item->slot = slot;
+		item->next = slotsOccupied;
+		slotsOccupied = item;
+		MemoryContextSwitchTo(contextSave);
+	}
+
+	if (NULL != instr && instrument_options & (INSTRUMENT_TIMER | INSTRUMENT_CDB))
+	{
+		instr->need_timer = (instrument_options & INSTRUMENT_TIMER) != 0;
+		instr->need_cdb = (instrument_options & INSTRUMENT_CDB) != 0;
+	}
+
+	return instr;
+}
+
+/*
+ * Recycle instrumentation in shmem
+ */
+static void
+instrShmemRecycleCallback(ResourceReleasePhase phase, bool isCommit, bool isTopLevel, void *arg)
+{
+	InstrumentationResownerSet *next;
+	InstrumentationResownerSet *curr;
+	InstrumentationSlot *slot;
+
+	if (NULL == InstrumentGlobal || NULL == slotsOccupied || phase != RESOURCE_RELEASE_AFTER_LOCKS)
+		return;
+
+	/* Reset scanNodeCounter */
+	scanNodeCounter = 0;
+
+	next = slotsOccupied;
+	slotsOccupied = NULL;
+	SpinLockAcquire(&InstrumentGlobal->lock);
+	while (next)
+	{
+		curr = next;
+		next = curr->next;
+		if (curr->owner != CurrentResourceOwner)
+		{
+			curr->next = slotsOccupied;
+			slotsOccupied = curr;
+			continue;
+		}
+
+		slot = curr->slot;
+
+		/* Recycle Instrumentation slot back to the free list */
+		memset(slot, PATTERN, sizeof(InstrumentationSlot));
+
+		GetInstrumentNext(slot) = InstrumentGlobal->head;
+		InstrumentGlobal->head = slot;
+		InstrumentGlobal->free++;
+
+		pfree(curr);
+	}
+	SpinLockRelease(&InstrumentGlobal->lock);
 }

--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -275,7 +275,7 @@ initialize_aggregates(AggState *aggstate,
 			 * CDB: If EXPLAIN ANALYZE, let all of our tuplesort operations
 			 * share our Instrumentation object and message buffer.
 			 */
-			if (aggstate->ss.ps.instrument)
+			if (aggstate->ss.ps.instrument && aggstate->ss.ps.instrument->need_cdb)
 				tuplesort_set_instrument(peraggstate->sortstate,
 										 aggstate->ss.ps.instrument,
 										 aggstate->ss.ps.cdbexplainbuf);
@@ -1073,7 +1073,7 @@ ExecAgg(AggState *node)
 				case HASHAGG_END_OF_PASSES:
 					node->agg_done = true;
 					/* Append stats before destroying the htable for EXPLAIN ANALYZE */
-					if (node->ss.ps.instrument)
+					if (node->ss.ps.instrument && (node->ss.ps.instrument)->need_cdb)
 					{
 						agg_hash_explain(node);
 					}
@@ -1783,7 +1783,7 @@ ExecInitAgg(Agg *node, EState *estate, int eflags)
 	/*
 	 * CDB: Offer extra info for EXPLAIN ANALYZE.
 	 */
-	if (estate->es_instrument)
+	if (estate->es_instrument && (estate->es_instrument & INSTRUMENT_CDB))
 	{
 		/* Allocate string buffer. */
 		aggstate->ss.ps.cdbexplainbuf = makeStringInfo();

--- a/src/backend/executor/nodeAssertOp.c
+++ b/src/backend/executor/nodeAssertOp.c
@@ -157,7 +157,7 @@ ExecInitAssertOp(AssertOp *node, EState *estate, int eflags)
 
 	ExecAssignProjectionInfo(planState, tupDesc);
 
-	if (estate->es_instrument)
+	if (estate->es_instrument && (estate->es_instrument & INSTRUMENT_CDB))
 	{
 	        assertOpState->ps.cdbexplainbuf = makeStringInfo();
 

--- a/src/backend/executor/nodeBitmapIndexscan.c
+++ b/src/backend/executor/nodeBitmapIndexscan.c
@@ -105,7 +105,7 @@ MultiExecBitmapIndexScan(BitmapIndexScanState *node)
 			break;
 
 		/* CDB: If EXPLAIN ANALYZE, let bitmap share our Instrumentation. */
-		if (node->ss.ps.instrument)
+		if (node->ss.ps.instrument && (node->ss.ps.instrument)->need_cdb)
 			tbm_generic_set_instrument(bitmap, node->ss.ps.instrument);
 
 		if (node->biss_result == NULL)

--- a/src/backend/executor/nodeDML.c
+++ b/src/backend/executor/nodeDML.c
@@ -189,7 +189,7 @@ ExecInitDML(DML *node, EState *estate, int eflags)
 	ReleaseTupleDesc(dmlstate->junkfilter->jf_cleanTupType);
 	dmlstate->junkfilter->jf_cleanTupType = cleanTupType;
 
-	if (estate->es_instrument)
+	if (estate->es_instrument && (estate->es_instrument & INSTRUMENT_CDB))
 	{
 	        dmlstate->ps.cdbexplainbuf = makeStringInfo();
 

--- a/src/backend/executor/nodeFunctionscan.c
+++ b/src/backend/executor/nodeFunctionscan.c
@@ -33,6 +33,7 @@
 #include "utils/lsyscache.h"
 #include "cdb/memquota.h"
 #include "executor/spi.h"
+#include "executor/instrument.h"
 
 
 static TupleTableSlot *FunctionNext(FunctionScanState *node);
@@ -78,7 +79,7 @@ FunctionNext(FunctionScanState *node)
 										PlanStateOperatorMemKB( (PlanState *) node));
 
 		/* CDB: Offer extra info for EXPLAIN ANALYZE. */
-		if (node->ss.ps.instrument)
+		if (node->ss.ps.instrument && node->ss.ps.instrument->need_cdb)
 		{
 			/* Let the tuplestore share our Instrumentation object. */
 			tuplestore_set_instrument(tuplestorestate, node->ss.ps.instrument);

--- a/src/backend/executor/nodeHash.c
+++ b/src/backend/executor/nodeHash.c
@@ -1261,7 +1261,8 @@ ExecHashTableExplainEnd(PlanState *planstate, struct StringInfoData *buf)
     if (!hashtable ||
         !hashtable->stats ||
         hashtable->nbatch < 1 ||
-        !jinstrument)
+        !jinstrument ||
+        !jinstrument->need_cdb)
         return;
 
     stats = hashtable->stats;

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -175,7 +175,7 @@ ExecHashJoin(HashJoinState *node)
 		/*
 		 * CDB: Offer extra info for EXPLAIN ANALYZE.
 		 */
-		if (estate->es_instrument)
+		if (estate->es_instrument && (estate->es_instrument & INSTRUMENT_CDB))
 			ExecHashTableExplainInit(hashNode, node, hashtable);
 
 
@@ -1342,7 +1342,7 @@ ExecHashJoinReloadHashTable(HashJoinState *hjstate)
 		 * after we build the hash table, the inner batch file is no longer
 		 * needed
 		 */
-		if (hjstate->js.ps.instrument)
+		if (hjstate->js.ps.instrument && hjstate->js.ps.instrument->need_cdb)
 		{
 			Assert(hashtable->stats);
 			hashtable->stats->batchstats[curbatch].innerfilesize =

--- a/src/backend/executor/nodeMaterial.c
+++ b/src/backend/executor/nodeMaterial.c
@@ -112,7 +112,7 @@ ExecMaterial(MaterialState *node)
 		node->ts_pos = (void *) tsa;
 
         /* CDB: Offer extra info for EXPLAIN ANALYZE. */
-        if (node->ss.ps.instrument)
+        if (node->ss.ps.instrument && node->ss.ps.instrument->need_cdb)
         {
             /* Let the tuplestore share our Instrumentation object. */
 			ntuplestore_setinstrument(ts, node->ss.ps.instrument);

--- a/src/backend/executor/nodeRowTrigger.c
+++ b/src/backend/executor/nodeRowTrigger.c
@@ -570,7 +570,7 @@ ExecInitRowTrigger(RowTrigger *node, EState *estate, int eflags)
 	ExecSetSlotDescriptor(rowTriggerState->oldTuple, tupDesc);
 	ExecSetSlotDescriptor(rowTriggerState->triggerTuple, tupDesc);
 
-	if (estate->es_instrument)
+	if (estate->es_instrument && (estate->es_instrument & INSTRUMENT_CDB))
 	{
 	        rowTriggerState->ps.cdbexplainbuf = makeStringInfo();
 

--- a/src/backend/executor/nodeSort.c
+++ b/src/backend/executor/nodeSort.c
@@ -152,7 +152,7 @@ ExecSort(SortState *node)
 		}
 
 		/* If EXPLAIN ANALYZE, share our Instrumentation object with sort. */
-		if (node->ss.ps.instrument)
+		if (node->ss.ps.instrument && node->ss.ps.instrument->need_cdb)
 			tuplesort_set_instrument(tuplesortstate,
 									 node->ss.ps.instrument,
 									 node->ss.ps.cdbexplainbuf);
@@ -323,7 +323,7 @@ ExecInitSort(Sort *node, EState *estate, int eflags)
 	/* 
 	 * CDB: Offer extra info for EXPLAIN ANALYZE.
 	 */
-	if (estate->es_instrument)
+	if (estate->es_instrument && (estate->es_instrument & INSTRUMENT_CDB))
 	{
 		/* Allocate string buffer. */
 		sortstate->ss.ps.cdbexplainbuf = makeStringInfo();

--- a/src/backend/executor/nodeSplitUpdate.c
+++ b/src/backend/executor/nodeSplitUpdate.c
@@ -192,7 +192,7 @@ ExecInitSplitUpdate(SplitUpdate *node, EState *estate, int eflags)
 	ExecAssignResultTypeFromTL(&splitupdatestate->ps);
 	ExecAssignProjectionInfo(&splitupdatestate->ps, NULL);
 
-	if (estate->es_instrument)
+	if (estate->es_instrument && (estate->es_instrument & INSTRUMENT_CDB))
 	{
 			splitupdatestate->ps.cdbexplainbuf = makeStringInfo();
 

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -1157,7 +1157,7 @@ PG_TRY();
 		queryDesc->estate->dispatcherState->primaryResults)
 	{
 		/* If EXPLAIN ANALYZE, collect execution stats from qExecs. */
-		if (planstate->instrument)
+		if (planstate->instrument && planstate->instrument->need_cdb)
 		{
 			/* Wait for all gangs to finish. */
 			CdbCheckDispatchResult(queryDesc->estate->dispatcherState,
@@ -1196,7 +1196,7 @@ PG_TRY();
 PG_CATCH();
 {
 	/* If EXPLAIN ANALYZE, collect local and distributed execution stats. */
-	if (planstate->instrument)
+	if (planstate->instrument && planstate->instrument->need_cdb)
 	{
 		cdbexplain_localExecStats(planstate, econtext->ecxt_estate->showstatctx);
 		if (!explainRecvStats &&
@@ -1247,7 +1247,7 @@ PG_END_TRY();
 	planstate->state->currentSubplanLevel--;
 
 	/* If EXPLAIN ANALYZE, collect local execution stats. */
-	if (planstate->instrument)
+	if (planstate->instrument && planstate->instrument->need_cdb)
 		cdbexplain_localExecStats(planstate, econtext->ecxt_estate->showstatctx);
 
 	/* Restore memory high-water mark for root slice of main query. */

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -1902,7 +1902,7 @@ _SPI_execute_plan(SPIPlanPtr plan, ParamListInfo paramLI,
 										plansource->query_string,
 										snap, crosscheck_snapshot,
 										dest,
-										paramLI, false);
+										paramLI, INSTRUMENT_NONE);
 
 				if (gp_enable_gpperfmon 
 						&& Gp_role == GP_ROLE_DISPATCH 

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -34,6 +34,7 @@
 #include "utils/resource_manager.h"
 #include "utils/resscheduler.h"
 #include "utils/faultinjector.h"
+#include "utils/metrics_utils.h"
 
 #include "cdb/cdbvars.h"
 #include "miscadmin.h"
@@ -1904,6 +1905,10 @@ _SPI_execute_plan(SPIPlanPtr plan, ParamListInfo paramLI,
 										dest,
 										paramLI, INSTRUMENT_NONE);
 
+				/* GPDB hook for collecting query info */
+				if (query_info_collect_hook)
+					(*query_info_collect_hook)(METRICS_QUERY_SUBMIT, qdesc);
+			
 				if (gp_enable_gpperfmon 
 						&& Gp_role == GP_ROLE_DISPATCH 
 						&& log_min_messages < DEBUG4)

--- a/src/backend/executor/test/nodeSubplan_test.c
+++ b/src/backend/executor/test/nodeSubplan_test.c
@@ -28,6 +28,8 @@ test__ExecSetParamPlan__Check_Dispatch_Results(void **state)
 	plan->xprstate.expr = makeNode(SubPlanState);
 	plan->planstate = makeNode(SubPlanState);
 	plan->planstate->instrument = (Instrumentation *)palloc(sizeof(Instrumentation));
+	plan->planstate->instrument->need_timer = true;
+	plan->planstate->instrument->need_cdb = true;
 	plan->planstate->plan = makeNode(SubPlanState);
 	
 	EState *estate = CreateExecutorState();

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -4482,8 +4482,8 @@ _copySliceTable(SliceTable *from)
 	COPY_SCALAR_FIELD(nInitPlans);
 	COPY_SCALAR_FIELD(localSlice);
 	COPY_NODE_FIELD(slices);
-    COPY_SCALAR_FIELD(doInstrument);
-    COPY_SCALAR_FIELD(ic_instance_id);
+	COPY_SCALAR_FIELD(instrument_options);
+	COPY_SCALAR_FIELD(ic_instance_id);
 
 	return newnode;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -4125,7 +4125,7 @@ _outSliceTable(StringInfo str, SliceTable *node)
 	WRITE_INT_FIELD(nInitPlans);
 	WRITE_INT_FIELD(localSlice);
 	WRITE_NODE_FIELD(slices); /* List of int */
-    WRITE_BOOL_FIELD(doInstrument);
+	WRITE_INT_FIELD(instrument_options);
 	WRITE_INT_FIELD(ic_instance_id);
 }
 

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -2754,7 +2754,7 @@ _readSliceTable(void)
 	READ_INT_FIELD(nInitPlans);
 	READ_INT_FIELD(localSlice);
 	READ_NODE_FIELD(slices); /* List of Slice* */
-    READ_BOOL_FIELD(doInstrument);
+	READ_INT_FIELD(instrument_options);
 	READ_INT_FIELD(ic_instance_id);
 
 	READ_DONE();

--- a/src/backend/postmaster/perfmon_segmentinfo.c
+++ b/src/backend/postmaster/perfmon_segmentinfo.c
@@ -33,6 +33,7 @@
 #include "storage/backendid.h"
 #include "storage/pmsignal.h"			/* PostmasterIsAlive */
 
+#include "utils/metrics_utils.h"
 #include "utils/resowner.h"
 #include "utils/ps_status.h"
 
@@ -57,6 +58,12 @@ static gpmon_packet_t seginfopkt;
 /* GpmonPkt-related routines */
 static void InitSegmentInfoGpmonPkt(gpmon_packet_t *gpmon_pkt);
 static void UpdateSegmentInfoGpmonPkt(gpmon_packet_t *gpmon_pkt);
+
+/*
+ * query info collector hook
+ * Use this hook to collect real-time query information and status data.
+ */
+query_info_collect_hook_type query_info_collect_hook = NULL;
 
 /**
  * Main entry point for segment info process. This forks off a sender process

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -1853,8 +1853,9 @@ ServiceStartable(PMSubProc *subProc)
 	 * GUC gp_enable_gpperfmon controls the start
 	 * of both the 'perfmon' and 'stats sender' processes
 	 */
-	if ((subProc->procType == PerfmonProc || subProc->procType == PerfmonSegmentInfoProc)
-	    && !gp_enable_gpperfmon)
+	if (subProc->procType == PerfmonProc && !gp_enable_gpperfmon)
+		result = 0;
+	else if (subProc->procType == PerfmonSegmentInfoProc && !gp_enable_gpperfmon && !gp_enable_query_metrics)
 		result = 0;
 	else
 		result = ((subProc->flags & flagNeeded) != 0);

--- a/src/backend/storage/ipc/ipci.c
+++ b/src/backend/storage/ipc/ipci.c
@@ -55,6 +55,7 @@
 #include "utils/tqual.h"
 #include "postmaster/backoff.h"
 #include "cdb/memquota.h"
+#include "executor/instrument.h"
 #include "executor/spi.h"
 #include "utils/workfile_mgr.h"
 #include "utils/session_state.h"
@@ -190,6 +191,9 @@ CreateSharedMemoryAndSemaphores(bool makePrivate, int port)
 		/* Consider the size of the SessionState array */
 		size = add_size(size, SessionState_ShmemSize());
 
+		/* size of Instrumentation slots */
+		size = add_size(size, InstrShmemSize());
+
 		/*
 		 * Create the shmem segment
 		 */
@@ -321,6 +325,12 @@ CreateSharedMemoryAndSemaphores(bool makePrivate, int port)
 	SyncScanShmemInit();
 	workfile_mgr_cache_init();
 	BackendCancelShmemInit();
+
+	/*
+	 * Set up Instrumentation free list
+	 */
+	if (!IsUnderPostmaster)
+		InstrShmemInit();
 
 #ifdef EXEC_BACKEND
 

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -35,6 +35,7 @@
 #include "postmaster/autostats.h"
 #include "postmaster/backoff.h"
 #include "utils/resscheduler.h"
+#include "utils/metrics_utils.h"
 #include "utils/tqual.h"
 
 
@@ -249,6 +250,10 @@ ProcessQuery(Portal portal,
 				GetResqueueName(portal->queueId),
 				GetResqueuePriority(portal->queueId));
 	}
+
+	/* GPDB hook for collecting query info */
+	if (query_info_collect_hook)
+		(*query_info_collect_hook)(METRICS_QUERY_SUBMIT, queryDesc);
 
 	queryDesc->plannedstmt->query_mem = ResourceManagerGetQueryMemoryLimit(queryDesc->plannedstmt);
 
@@ -654,6 +659,10 @@ PortalStart(Portal portal, ParamListInfo params, Snapshot snapshot,
 							GetResqueueName(portal->queueId),
 							GetResqueuePriority(portal->queueId));
 				}
+
+				/* GPDB hook for collecting query info */
+				if (query_info_collect_hook)
+					(*query_info_collect_hook)(METRICS_QUERY_SUBMIT, queryDesc);
 
 				/* 
 				 * let queryDesc know that it is running a query in stages

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -452,6 +452,10 @@ bool		optimizer_analyze_midlevel_partition;
 static int	gp_server_version_num;
 static char *gp_server_version_string;
 
+/* Query Metrics */
+bool		gp_enable_query_metrics = false;
+int			gp_instrument_shmem_size = 5120;
+
 /* Security */
 bool		gp_reject_internal_tcp_conn = true;
 
@@ -1692,6 +1696,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 		},
 		&gp_enable_gpperfmon,
 		false, gpvars_assign_gp_enable_gpperfmon, NULL
+	},
+
+	{
+		{"gp_enable_query_metrics", PGC_USERSET, UNGROUPED,
+			gettext_noop("Enable query execution metrics collection."),
+			NULL,
+			GUC_GPDB_ADDOPT
+		},
+		&gp_enable_query_metrics,
+		false, NULL, NULL
 	},
 
 	{
@@ -3620,6 +3634,16 @@ struct config_int ConfigureNamesInt_gp[] =
 		},
 		&gpperfmon_port,
 		8888, 1024, 65535, NULL, NULL
+	},
+
+	{
+		{"gp_instrument_shmem_size", PGC_POSTMASTER, UNGROUPED,
+			gettext_noop("Sets the size of shmem allocated for instrumentation."),
+			NULL,
+			GUC_UNIT_KB
+		},
+		&gp_instrument_shmem_size,
+		5120, 0, 131072, NULL, NULL
 	},
 
 	{

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -1699,10 +1699,9 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"gp_enable_query_metrics", PGC_USERSET, UNGROUPED,
-			gettext_noop("Enable query execution metrics collection."),
-			NULL,
-			GUC_GPDB_ADDOPT
+		{"gp_enable_query_metrics", PGC_POSTMASTER, UNGROUPED,
+			gettext_noop("Enable all query metrics collection."),
+			NULL	
 		},
 		&gp_enable_query_metrics,
 		false, NULL, NULL

--- a/src/backend/utils/resscheduler/resscheduler.c
+++ b/src/backend/utils/resscheduler/resscheduler.c
@@ -44,6 +44,7 @@
 #include "utils/memutils.h"
 #include "utils/resscheduler.h"
 #include "utils/syscache.h"
+#include "utils/metrics_utils.h"
 #include "utils/tqual.h"
 
 /*
@@ -705,6 +706,10 @@ ResLockPortal(Portal portal, QueryDesc *qDesc)
 
 				/* If we had acquired the resource queue lock, release it and clean up */	
 				ResLockRelease(&tag, portal->portalId);
+			
+				/* GPDB hook for collecting query info */
+				if (query_info_collect_hook)
+					(*query_info_collect_hook)(METRICS_QUERY_ERROR, qDesc);
 
 				/*
 				 * Perfmon related stuff: clean up if we got cancelled

--- a/src/backend/utils/sort/tuplesort.c
+++ b/src/backend/utils/sort/tuplesort.c
@@ -1306,7 +1306,7 @@ tuplesort_performsort(Tuplesortstate *state)
 			dumptuples(state, true);
 
 			/* CDB: How much work_mem would be enough for in-memory sort? */
-			if (state->instrument)
+			if (state->instrument && state->instrument->need_cdb)
 			{
 				/*
 				 * The workmemwanted is summed up of the following:
@@ -3752,7 +3752,7 @@ tuplesort_sorted_insert(Tuplesortstate *state, SortTuple *tuple,
 void
 tuplesort_finalize_stats(Tuplesortstate *state)
 {
-    if (state->instrument && !state->statsFinalized)
+    if (state->instrument && state->instrument->need_cdb && !state->statsFinalized)
     {
         double  workmemused;
 

--- a/src/backend/utils/sort/tuplesort_mk.c
+++ b/src/backend/utils/sort/tuplesort_mk.c
@@ -1064,7 +1064,7 @@ tuplesort_end_mk(Tuplesortstate_mk *state)
 void
 tuplesort_finalize_stats_mk(Tuplesortstate_mk *state)
 {
-	if (state->instrument && !state->statsFinalized)
+	if (state->instrument && state->instrument->need_cdb && !state->statsFinalized)
 	{
 		Size		maxSpaceUsedOnSort = MemoryContextGetPeakSpace(state->sortcontext);
 

--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -476,7 +476,7 @@ tuplestore_end(Tuplestorestate *state)
 	/*
 	 * CDB: Report statistics to EXPLAIN ANALYZE.
 	 */
-	if (state->instrument)
+	if (state->instrument && state->instrument->need_cdb)
 	{
 		double  nbytes;
 

--- a/src/backend/utils/sort/tuplestorenew.c
+++ b/src/backend/utils/sort/tuplestorenew.c
@@ -467,7 +467,7 @@ static NTupleStorePage *nts_get_free_page(NTupleStore *nts)
 	init_page(page);
 	++nts->page_cnt;
 
-	if(nts->instrument)
+	if(nts->instrument && nts->instrument->need_cdb)
 	{
 		nts->instrument->workmemused = Max(nts->instrument->workmemused, nts->page_cnt * BLCKSZ); 
 		if(nts->last_page)

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -836,6 +836,8 @@ extern bool gpvars_assign_gp_enable_gpperfmon(bool newval, bool doit, GucSource 
 extern bool gpvars_assign_gp_gpperfmon_send_interval(int newval, bool doit, GucSource source);
 extern bool gp_enable_gpperfmon;
 extern int gp_gpperfmon_send_interval;
+extern bool gp_enable_query_metrics;
+extern int gp_instrument_shmem_size;
 extern bool force_bitmap_table_scan;
 
 extern bool dml_ignore_target_partition_check;

--- a/src/include/executor/execdesc.h
+++ b/src/include/executor/execdesc.h
@@ -132,7 +132,7 @@ typedef struct SliceTable
 	int			nInitPlans;		/* The number of initplan slices allocated */
 	int			localSlice;		/* Index of the slice to execute. */
 	List	   *slices;			/* List of slices */
-	bool		doInstrument;	/* true => collect stats for EXPLAIN ANALYZE */
+	int			instrument_options;	/* OR of InstrumentOption flags */
 	uint32		ic_instance_id;
 } SliceTable;
 
@@ -242,7 +242,7 @@ typedef struct QueryDesc
 	Snapshot	crosscheck_snapshot;	/* crosscheck for RI update/delete */
 	DestReceiver *dest;			/* the destination for tuple output */
 	ParamListInfo params;		/* param values being passed in */
-	bool		doInstrument;	/* TRUE requests runtime instrumentation */
+	int			instrument_options;		/* OR of InstrumentOption flags */
 
 	/* These fields are set by ExecutorStart */
 	TupleDesc	tupDesc;		/* descriptor for result tuples */
@@ -274,7 +274,7 @@ extern QueryDesc *CreateQueryDesc(PlannedStmt *plannedstmt,
 				Snapshot crosscheck_snapshot,
 				DestReceiver *dest,
 				ParamListInfo params,
-				bool doInstrument);
+				int instrument_options);
 
 extern QueryDesc *CreateUtilityQueryDesc(Node *utilitystmt,
 					   const char *sourceText,

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -247,7 +247,7 @@ extern void InitResultRelInfo(ResultRelInfo *resultRelInfo,
 				  Relation resultRelationDesc,
 				  Index resultRelationIndex,
 				  CmdType operation,
-				  bool doInstrument);
+				  int instrument_options);
 extern ResultRelInfo *ExecGetTriggerResultRel(EState *estate, Oid relid);
 extern bool ExecContextForcesOids(PlanState *planstate, bool *hasoids);
 extern void ExecConstraints(ResultRelInfo *resultRelInfo,

--- a/src/include/executor/hashjoin.h
+++ b/src/include/executor/hashjoin.h
@@ -165,7 +165,7 @@ typedef struct HashJoinTableData
 
 	bool		growEnabled;	/* flag to shut off nbatch increases */
 
-	double		totalTuples;	/* # tuples obtained from inner plan */
+	uint64		totalTuples;	/* # tuples obtained from inner plan */
 
 	/*
 	 * These arrays are allocated for the life of the hash join, but only if

--- a/src/include/executor/instrument.h
+++ b/src/include/executor/instrument.h
@@ -15,39 +15,159 @@
 #ifndef INSTRUMENT_H
 #define INSTRUMENT_H
 
+#include "executor/executor.h"
+#include "nodes/plannodes.h"
 #include "portability/instr_time.h"
+#include "utils/resowner.h"
 
 struct CdbExplain_NodeSummary;          /* private def in cdb/cdbexplain.c */
 
+/* Flag bits included in InstrAlloc's instrument_options bitmask */
+typedef enum InstrumentOption
+{
+	INSTRUMENT_NONE = 0,
+	INSTRUMENT_TIMER = 1 << 0,	/* needs timer (and row counts) */
+	INSTRUMENT_BUFFERS = 1 << 1,	/* needs buffer usage (not implemented yet) */
+	INSTRUMENT_ROWS = 1 << 2,	/* needs row count */
+	INSTRUMENT_CDB = 0x40000000,	/* needs cdb statistics */
+	INSTRUMENT_ALL = PG_INT32_MAX
+} InstrumentOption;
 
 typedef struct Instrumentation
 {
+	/* Parameters set at node creation: */
+	bool		need_timer;		/* TRUE if we need timer data */
+	bool		need_cdb;		/* TRUE if we need cdb statistics */
+
 	/* Info about current plan cycle: */
 	bool		running;		/* TRUE if we've completed first tuple */
 	instr_time	starttime;		/* Start time of current iteration of node */
 	instr_time	counter;		/* Accumulated runtime for this node */
 	double		firsttuple;		/* Time for first tuple of this cycle */
-	double		tuplecount;		/* Tuples emitted so far this cycle */
+	uint64		tuplecount;		/* Tuples emitted so far this cycle */
 	/* Accumulated statistics across all completed cycles: */
 	double		startup;		/* Total startup time (in seconds) */
 	double		total;			/* Total total time (in seconds) */
-	double		ntuples;		/* Total tuples produced */
-	double		nloops;			/* # of run cycles for this node */
-    double		execmemused;    /* CDB: executor memory used (bytes) */
-    double		workmemused;    /* CDB: work_mem actually used (bytes) */
-    double		workmemwanted;  /* CDB: work_mem to avoid scratch i/o (bytes) */
+	uint64		ntuples;		/* Total tuples produced */
+	uint64		nloops;			/* # of run cycles for this node */
+	double		execmemused;	/* CDB: executor memory used (bytes) */
+	double		workmemused;	/* CDB: work_mem actually used (bytes) */
+	double		workmemwanted;	/* CDB: work_mem to avoid scratch i/o (bytes) */
 	instr_time	firststart;		/* CDB: Start time of first iteration of node */
-	bool		workfileCreated;/* TRUE if workfiles are created in this node */
-	int		numPartScanned; /* Number of part tables scanned */
-	const char* sortMethod;	/* CDB: Type of sort */
-	const char* sortSpaceType; /*CDB: Sort space type (Memory / Disk) */
-	long			  sortSpaceUsed; /* CDB: Memory / Disk used by sort(KBytes) */
-    struct CdbExplain_NodeSummary  *cdbNodeSummary; /* stats from all qExecs */
+	bool		workfileCreated;	/* TRUE if workfiles are created in this
+									 * node */
+	int			numPartScanned; /* Number of part tables scanned */
+	const char *sortMethod;		/* CDB: Type of sort */
+	const char *sortSpaceType;	/* CDB: Sort space type (Memory / Disk) */
+	long		sortSpaceUsed;	/* CDB: Memory / Disk used by sort(KBytes) */
+	struct CdbExplain_NodeSummary *cdbNodeSummary;	/* stats from all qExecs */
 } Instrumentation;
 
-extern Instrumentation *InstrAlloc(int n);
+extern Instrumentation *InstrAlloc(int n, int instrument_options);
 extern void InstrStartNode(Instrumentation *instr);
-extern void InstrStopNode(Instrumentation *instr, double nTuples);
+extern void InstrStopNode(Instrumentation *instr, uint64 nTuples);
 extern void InstrEndLoop(Instrumentation *instr);
+
+/*
+ * GPDB Note: Macro INSTR_START_NODE replaces InstrStartNode in ExecProcNode for
+ * performance benefits, other files keep using InstrStartNode. Pay attention
+ * to keep InstrStartNode/INSTR_START_NODE synchronized when modifying this macro.
+ */
+#define INSTR_START_NODE(instr) do {											\
+	if ((instr)->need_timer) {													\
+		if (INSTR_TIME_IS_ZERO((instr)->starttime))								\
+			INSTR_TIME_SET_CURRENT((instr)->starttime);							\
+		else																	\
+			elog(DEBUG2, "INSTR_START_NODE called twice in a row");				\
+	}																			\
+} while(0)
+
+/*
+ * GPDB Note: Macro INSTR_STOP_NODE replaces InstrStopNode in ExecProcNode for
+ * performance benefits, other files keep using InstrStopNode. Pay attention
+ * to keep InstrStopNode/INSTR_STOP_NODE synchronized when modifying this macro.
+ */
+#define INSTR_STOP_NODE(instr, nTuples) do {									\
+	(instr)->tuplecount += (nTuples);											\
+	if ((instr)->need_timer)													\
+	{																			\
+		instr_time endtime;														\
+		if (INSTR_TIME_IS_ZERO((instr)->starttime))								\
+		{																		\
+			elog(DEBUG2, "INSTR_STOP_NODE called without start");				\
+			break;																\
+		}																		\
+		INSTR_TIME_SET_CURRENT(endtime);										\
+		INSTR_TIME_ACCUM_DIFF((instr)->counter, endtime, (instr)->starttime);	\
+		INSTR_TIME_SET_ZERO((instr)->starttime);								\
+	}																			\
+	if (!(instr)->running)														\
+	{																			\
+		(instr)->running = true;												\
+		(instr)->firsttuple = INSTR_TIME_GET_DOUBLE((instr)->counter);			\
+		(instr)->firststart = (instr)->starttime;								\
+	}																			\
+} while(0)
+
+#define GP_INSTRUMENT_OPTS (gp_enable_query_metrics ? INSTRUMENT_ROWS : INSTRUMENT_NONE)
+
+/* Greenplum query metrics */
+typedef struct InstrumentationHeader
+{
+	void	   *head;
+	int			free;
+	slock_t		lock;
+} InstrumentationHeader;
+
+typedef struct InstrumentationSlot
+{
+	Instrumentation data;
+	int32		pid;			/* process id */
+	int32		tmid;			/* transaction time */
+	int32		ssid;			/* session id */
+	int32		ccnt;			/* command count */
+	int16		segid;			/* segment id */
+	int16		nid;			/* node id */
+} InstrumentationSlot;
+
+/*
+ * To guarantee the slot recycled properly,
+ * record the slot with its resource owner when picked
+ */
+typedef struct InstrumentationResownerSet
+{
+	InstrumentationSlot *slot;
+	ResourceOwner owner;
+	struct InstrumentationResownerSet *next;
+} InstrumentationResownerSet;
+
+extern InstrumentationHeader *InstrumentGlobal;
+extern Size InstrShmemNumSlots(void);
+extern Size InstrShmemSize(void);
+extern void InstrShmemInit(void);
+extern Instrumentation *GpInstrAlloc(const Plan *node, int instrument_options);
+
+/*
+ * For each free slot in shmem, fill it with specific pattern
+ * Use this pattern to detect the slot has been recycled.
+ * Also protect writes outside the allocated shmem buffer.
+ */
+#define PATTERN 0xd5
+#define LONG_PATTERN 0xd5d5d5d5d5d5d5d5
+
+/*
+ * Empty if first 8 bytes of slot filled with pattern.
+ */
+#define SlotIsEmpty(slot) ((*((int64 *)(slot)) ^ LONG_PATTERN) == 0)
+
+/*
+ * The last 8 bytes of slot points to next free slot.
+ */
+#define GetInstrumentNext(slot) (*((InstrumentationSlot **)((slot) + 1) - 1))
+
+/*
+ * Limit the maximum scan node's instr per query in shmem
+ */
+#define MAX_SCAN_ON_SHMEM 300
 
 #endif   /* INSTRUMENT_H */

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -1389,6 +1389,8 @@ typedef struct PlanState
 	 */
 	int		gpmon_plan_tick;
 	gpmon_packet_t gpmon_pkt;
+
+	bool		fHadSentNodeStart;
 } PlanState;
 
 /* Gpperfmon helper functions defined in execGpmon.c */

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -558,7 +558,7 @@ typedef struct EState
 	Oid			es_lastoid;		/* last oid processed (by INSERT) */
 	List	   *es_rowMarks;	/* not good place, but there is no other */
 
-	bool		es_instrument;	/* true requests runtime instrumentation */
+	int			es_instrument;	/* OR of InstrumentOption flags */
 	bool		es_select_into; /* true if doing SELECT INTO */
 	bool		es_into_oids;	/* true to generate OIDs in SELECT INTO */
 

--- a/src/include/postmaster/perfmon_segmentinfo.h
+++ b/src/include/postmaster/perfmon_segmentinfo.h
@@ -26,4 +26,9 @@ extern int gp_perfmon_segment_interval;
 /* Interface */
 extern int perfmon_segmentinfo_start(void);
 
+typedef void (*cluster_state_collect_hook_type)(void);
+extern PGDLLIMPORT cluster_state_collect_hook_type cluster_state_collect_hook;
+
+#define SEGMENT_INFO_LOOP_SLEEP_MS (100)
+
 #endif /* PERFMON_SEGMENTINFO_H */

--- a/src/include/utils/builtins.h
+++ b/src/include/utils/builtins.h
@@ -1242,4 +1242,7 @@ extern Datum enable_xform(PG_FUNCTION_ARGS);
 /* Optimizer's version */
 extern Datum gp_opt_version(PG_FUNCTION_ARGS);
 
+/* query_metrics.c */
+extern Datum gp_instrument_shmem_summary(PG_FUNCTION_ARGS);
+
 #endif   /* BUILTINS_H */

--- a/src/include/utils/metrics_utils.h
+++ b/src/include/utils/metrics_utils.h
@@ -1,0 +1,35 @@
+/*-------------------------------------------------------------------------
+ *
+ * metrics_utils.h
+ *	  Definitions for query info collector enum and functions
+ *
+ * Portions Copyright (c) 2017-Present Pivotal Software, Inc.
+ *
+ *
+ * IDENTIFICATION
+ *	    src/include/utils/metrics_utils.h
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef METRICS_UTILS_H
+#define METRICS_UTILS_H 
+
+typedef enum
+{	
+	METRICS_PLAN_NODE_INITIALIZE = 100,
+	METRICS_PLAN_NODE_EXECUTING,
+	METRICS_PLAN_NODE_FINISHED,
+	
+	METRICS_QUERY_SUBMIT = 200,
+	METRICS_QUERY_START,
+	METRICS_QUERY_DONE,
+	METRICS_QUERY_ERROR,
+	METRICS_QUERY_CANCELING,
+	METRICS_QUERY_CANCELED
+} QueryMetricsStatus;
+
+typedef void (*query_info_collect_hook_type)(QueryMetricsStatus, void *);
+extern PGDLLIMPORT query_info_collect_hook_type query_info_collect_hook;
+
+#endif   /* METRICS_UTILS_H */

--- a/src/test/isolation2/expected/instr_in_shmem_setup.out
+++ b/src/test/isolation2/expected/instr_in_shmem_setup.out
@@ -1,0 +1,3 @@
+-- start_ignore
+! gpconfig -c gp_enable_query_metrics -v on; ! gpstop -rai;
+-- end_ignore

--- a/src/test/isolation2/expected/instr_in_shmem_terminate.out
+++ b/src/test/isolation2/expected/instr_in_shmem_terminate.out
@@ -1,0 +1,114 @@
+-- start_ignore
+-- Isolation test for instrumentation in shmem
+-- One session executing a query then another session
+-- try to cancel/terminate the query, instrumentation
+-- slots in shmem should be recycled correctly.
+
+DROP SCHEMA IF EXISTS QUERY_METRICS CASCADE;
+DROP
+CREATE SCHEMA QUERY_METRICS;
+CREATE
+SET SEARCH_PATH=QUERY_METRICS;
+SET
+
+CREATE EXTERNAL WEB TABLE __gp_localid ( localid    int ) EXECUTE E'echo $GP_SEGMENT_ID' FORMAT 'TEXT';
+CREATE
+GRANT SELECT ON TABLE __gp_localid TO public;
+GRANT
+
+CREATE EXTERNAL WEB TABLE __gp_masterid ( masterid    int ) EXECUTE E'echo $GP_SEGMENT_ID' ON MASTER FORMAT 'TEXT';
+CREATE
+GRANT SELECT ON TABLE __gp_masterid TO public;
+GRANT
+
+CREATE FUNCTION gp_instrument_shmem_detail_f() RETURNS SETOF RECORD AS '$libdir/gp_instrument_shmem', 'gp_instrument_shmem_detail' LANGUAGE C IMMUTABLE;
+CREATE
+GRANT EXECUTE ON FUNCTION gp_instrument_shmem_detail_f() TO public;
+GRANT
+
+CREATE VIEW gp_instrument_shmem_detail AS WITH all_entries AS ( SELECT C.* FROM __gp_localid, gp_instrument_shmem_detail_f() as C ( tmid int4,ssid int4,ccnt int2,segid int2,pid int4 ,nid int2,tuplecount int8,nloops int8,ntuples int8 ) UNION ALL SELECT C.* FROM __gp_masterid, gp_instrument_shmem_detail_f() as C ( tmid int4,ssid int4,ccnt int2,segid int2,pid int4 ,nid int2,tuplecount int8,nloops int8,ntuples int8 )) SELECT tmid, ssid, ccnt,segid, pid, nid, tuplecount, nloops, ntuples FROM all_entries ORDER BY segid;
+CREATE
+GRANT SELECT ON gp_instrument_shmem_details TO public;
+ERROR:  relation "gp_instrument_shmem_details" does not exist
+
+CREATE TABLE a (id int) DISTRIBUTED BY (id);
+CREATE
+INSERT INTO a SELECT * FROM generate_series(1, 50);
+INSERT 50
+SET OPTIMIZER=OFF;
+SET
+ANALYZE a;
+ANALYZE
+-- end_ignore
+
+-- only this query in instrument slots, expected 1
+SELECT count(*) FROM (SELECT 1 FROM gp_instrument_shmem_detail GROUP BY ssid, ccnt) t;
+count
+-----
+1    
+(1 row)
+
+CREATE TABLE foo AS SELECT i a, i b FROM generate_series(1, 10) i;
+CREATE 10
+
+-- expect this query terminated by 'test pg_terminate_backend'
+1&:EXPLAIN ANALYZE CREATE TEMP TABLE t1 AS SELECT count(*) FROM QUERY_METRICS.foo WHERE pg_sleep(20) IS NULL;  <waiting ...>
+-- extract the pid for the previous query
+SELECT pg_terminate_backend(procpid, 'test pg_terminate_backend') FROM pg_stat_activity WHERE current_query LIKE 'EXPLAIN ANALYZE CREATE TEMP TABLE t1 AS SELECT%' ORDER BY procpid LIMIT 1;
+pg_terminate_backend
+--------------------
+t                   
+(1 row)
+1<:  <... completed>
+FATAL:  terminating connection due to administrator command: "test pg_terminate_backend"
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+1q: ... <quitting>
+
+-- query backend to ensure no PANIC on postmaster
+SELECT count(*) FROM foo;
+count
+-----
+10   
+(1 row)
+
+-- Expected result is 1 row, means only current query in instrument slots,
+-- If more than one row returned, means previous test has leaked slots.
+SELECT count(*) FROM (SELECT 1 FROM gp_instrument_shmem_detail GROUP BY ssid, ccnt) t;
+count
+-----
+1    
+(1 row)
+
+-- expect this query cancelled by 'test pg_cancel_backend'
+2&:EXPLAIN ANALYZE CREATE TEMP TABLE t2 AS SELECT count(*) FROM QUERY_METRICS.foo WHERE pg_sleep(20) IS NULL;  <waiting ...>
+-- extract the pid for the previous query
+SELECT pg_cancel_backend(procpid, 'test pg_cancel_backend') FROM pg_stat_activity WHERE current_query LIKE 'EXPLAIN ANALYZE CREATE TEMP TABLE t2 AS SELECT%' ORDER BY procpid LIMIT 1;
+pg_cancel_backend
+-----------------
+t                
+(1 row)
+2<:  <... completed>
+ERROR:  canceling statement due to user request: "test pg_cancel_backend"
+2q: ... <quitting>
+
+-- query backend to ensure no PANIC on postmaster
+SELECT count(*) FROM foo;
+count
+-----
+10   
+(1 row)
+
+-- Expected result is 1 row, means only current query in instrument slots,
+-- If more than one row returned, means previous test has leaked slots.
+SELECT count(*) FROM (SELECT 1 FROM gp_instrument_shmem_detail GROUP BY ssid, ccnt) t;
+count
+-----
+1    
+(1 row)
+
+-- start_ignore
+DROP SCHEMA IF EXISTS QUERY_METRICS CASCADE;
+DROP
+-- end_ignore

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -8,6 +8,8 @@ test: alter_blocks_for_update_and_viceversa
 test: reader_waits_for_lock
 test: drop_rename
 test: master_panic_after_phase1_commit
+test: instr_in_shmem_setup
+test: instr_in_shmem_terminate
 
 test: setup
 # Tests on Append-Optimized tables (row-oriented).

--- a/src/test/isolation2/sql/instr_in_shmem_setup.sql
+++ b/src/test/isolation2/sql/instr_in_shmem_setup.sql
@@ -1,0 +1,4 @@
+-- start_ignore
+! gpconfig -c gp_enable_query_metrics -v on; 
+! gpstop -rai;
+-- end_ignore

--- a/src/test/isolation2/sql/instr_in_shmem_terminate.sql
+++ b/src/test/isolation2/sql/instr_in_shmem_terminate.sql
@@ -1,0 +1,92 @@
+-- start_ignore
+-- Isolation test for instrumentation in shmem
+-- One session executing a query then another session
+-- try to cancel/terminate the query, instrumentation
+-- slots in shmem should be recycled correctly.
+
+DROP SCHEMA IF EXISTS QUERY_METRICS CASCADE;
+CREATE SCHEMA QUERY_METRICS;
+SET SEARCH_PATH=QUERY_METRICS;
+
+CREATE EXTERNAL WEB TABLE __gp_localid
+(
+    localid    int
+)
+EXECUTE E'echo $GP_SEGMENT_ID' FORMAT 'TEXT';
+GRANT SELECT ON TABLE __gp_localid TO public;
+
+CREATE EXTERNAL WEB TABLE __gp_masterid
+(
+    masterid    int
+)
+EXECUTE E'echo $GP_SEGMENT_ID' ON MASTER FORMAT 'TEXT';
+GRANT SELECT ON TABLE __gp_masterid TO public;
+
+CREATE FUNCTION gp_instrument_shmem_detail_f()
+RETURNS SETOF RECORD
+AS '$libdir/gp_instrument_shmem', 'gp_instrument_shmem_detail'
+LANGUAGE C IMMUTABLE;
+GRANT EXECUTE ON FUNCTION gp_instrument_shmem_detail_f() TO public;
+
+CREATE VIEW gp_instrument_shmem_detail AS
+WITH all_entries AS (
+  SELECT C.*
+    FROM __gp_localid, gp_instrument_shmem_detail_f() as C (
+      tmid int4,ssid int4,ccnt int2,segid int2,pid int4
+      ,nid int2,tuplecount int8,nloops int8,ntuples int8
+    )
+  UNION ALL
+  SELECT C.*
+    FROM __gp_masterid, gp_instrument_shmem_detail_f() as C (
+      tmid int4,ssid int4,ccnt int2,segid int2,pid int4
+      ,nid int2,tuplecount int8,nloops int8,ntuples int8
+    ))
+SELECT tmid, ssid, ccnt,segid, pid, nid, tuplecount, nloops, ntuples
+FROM all_entries
+ORDER BY segid;
+GRANT SELECT ON gp_instrument_shmem_details TO public;
+
+CREATE TABLE a (id int) DISTRIBUTED BY (id);
+INSERT INTO a SELECT * FROM generate_series(1, 50);
+SET OPTIMIZER=OFF;
+ANALYZE a;
+-- end_ignore
+
+-- only this query in instrument slots, expected 1
+SELECT count(*) FROM (SELECT 1 FROM gp_instrument_shmem_detail GROUP BY ssid, ccnt) t;
+
+CREATE TABLE foo AS SELECT i a, i b FROM generate_series(1, 10) i;
+
+-- expect this query terminated by 'test pg_terminate_backend'
+1&:EXPLAIN ANALYZE CREATE TEMP TABLE t1 AS SELECT count(*) FROM QUERY_METRICS.foo WHERE pg_sleep(20) IS NULL;
+-- extract the pid for the previous query
+SELECT pg_terminate_backend(procpid, 'test pg_terminate_backend')
+FROM pg_stat_activity WHERE current_query LIKE 'EXPLAIN ANALYZE CREATE TEMP TABLE t1 AS SELECT%' ORDER BY procpid LIMIT 1;
+1<:
+1q:
+
+-- query backend to ensure no PANIC on postmaster
+SELECT count(*) FROM foo;
+
+-- Expected result is 1 row, means only current query in instrument slots,
+-- If more than one row returned, means previous test has leaked slots.
+SELECT count(*) FROM (SELECT 1 FROM gp_instrument_shmem_detail GROUP BY ssid, ccnt) t;
+
+-- expect this query cancelled by 'test pg_cancel_backend'
+2&:EXPLAIN ANALYZE CREATE TEMP TABLE t2 AS SELECT count(*) FROM QUERY_METRICS.foo WHERE pg_sleep(20) IS NULL;
+-- extract the pid for the previous query
+SELECT pg_cancel_backend(procpid, 'test pg_cancel_backend')
+FROM pg_stat_activity WHERE current_query LIKE 'EXPLAIN ANALYZE CREATE TEMP TABLE t2 AS SELECT%' ORDER BY procpid LIMIT 1;
+2<:
+2q:
+
+-- query backend to ensure no PANIC on postmaster
+SELECT count(*) FROM foo;
+
+-- Expected result is 1 row, means only current query in instrument slots,
+-- If more than one row returned, means previous test has leaked slots.
+SELECT count(*) FROM (SELECT 1 FROM gp_instrument_shmem_detail GROUP BY ssid, ccnt) t;
+
+-- start_ignore
+DROP SCHEMA IF EXISTS QUERY_METRICS CASCADE;
+-- end_ignore

--- a/src/test/regress/GNUmakefile
+++ b/src/test/regress/GNUmakefile
@@ -135,7 +135,7 @@ installdirs-tests: installdirs
 
 # Get some extra C modules from contrib/spi...
 
-all: refint$(DLSUFFIX) autoinc$(DLSUFFIX) tablespace-setup includecheck hooktest
+all: refint$(DLSUFFIX) autoinc$(DLSUFFIX) tablespace-setup includecheck hooktest query_info_hook_test
 
 refint$(DLSUFFIX): $(top_builddir)/contrib/spi/refint$(DLSUFFIX)
 	cp $< $@
@@ -168,6 +168,10 @@ includecheck:
 hooktest:
 	$(MAKE) -C $< $@
 
+.PHONY: query_info_hook_test
+query_info_hook_test:
+	$(MAKE) -C $< $@
+
 ##
 ## Run tests
 ##
@@ -180,7 +184,7 @@ check: all
 installcheck: all
 	$(pg_regress_call)  --psqldir=$(PSQLDIR) --schedule=$(srcdir)/serial_schedule 
 
-installcheck-good: all twophase_pqexecparams hooktest
+installcheck-good: all twophase_pqexecparams hooktest query_info_hook_test
 	if [ -z "$(INSTALLCHECK_GOOD_KERBEROS)" ]; then \
 	$(pg_regress_call)  --psqldir=$(PSQLDIR) --schedule=$(srcdir)/parallel_schedule --schedule=$(srcdir)/greenplum_schedule --ao-dir=uao; \
 	else \
@@ -216,6 +220,7 @@ clean distclean maintainer-clean: clean-lib
 # things built by `all' target
 	$(MAKE) -C $(top_builddir)/contrib/spi clean
 	$(MAKE) -C hooktest/ clean
+	$(MAKE) -C query_info_hook_test/ clean
 	rm -f twophase_pqexecparams
 # things created by dynamic configs
 	find sql -type l | xargs rm -f

--- a/src/test/regress/expected/.gitignore
+++ b/src/test/regress/expected/.gitignore
@@ -32,3 +32,4 @@ tablespace.out
 transient_types.out
 workfile_mgr_test.out
 trigger_sets_oid.out
+query_info_hook_test.out

--- a/src/test/regress/expected/instr_in_shmem.out
+++ b/src/test/regress/expected/instr_in_shmem.out
@@ -1,0 +1,208 @@
+-- start_ignore
+-- Test instrument in shmem does not break EXPLAIN
+-- and EXPLAIN ANALYZE. Also instrumentation slots
+-- are correctly recycled.
+-- This test can not run in parallel with other tests.
+-- end_ignore
+-- default value
+SHOW GP_ENABLE_QUERY_METRICS;
+ gp_enable_query_metrics 
+-------------------------
+ on
+(1 row)
+
+SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+SHOW GP_INSTRUMENT_SHMEM_SIZE;
+ gp_instrument_shmem_size 
+--------------------------
+ 5MB
+(1 row)
+
+SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+-- start_ignore
+DROP SCHEMA IF EXISTS QUERY_METRICS CASCADE; 
+NOTICE:  schema "query_metrics" does not exist, skipping
+CREATE SCHEMA QUERY_METRICS;
+SET SEARCH_PATH=QUERY_METRICS;
+CREATE EXTERNAL WEB TABLE __gp_localid
+(
+    localid    int
+)
+EXECUTE E'echo $GP_SEGMENT_ID' FORMAT 'TEXT';
+GRANT SELECT ON TABLE __gp_localid TO public;
+CREATE EXTERNAL WEB TABLE __gp_masterid
+(
+    masterid    int
+)
+EXECUTE E'echo $GP_SEGMENT_ID' ON MASTER FORMAT 'TEXT';
+GRANT SELECT ON TABLE __gp_masterid TO public;
+CREATE FUNCTION gp_instrument_shmem_summary_f()
+RETURNS SETOF RECORD
+AS '$libdir/gp_instrument_shmem', 'gp_instrument_shmem_summary'
+LANGUAGE C IMMUTABLE;
+GRANT EXECUTE ON FUNCTION gp_instrument_shmem_summary_f() TO public;
+CREATE VIEW gp_instrument_shmem_summary AS
+WITH all_entries AS (
+  SELECT C.*
+    FROM __gp_localid, gp_instrument_shmem_summary_f() as C (
+      segid int, num_free bigint, num_used bigint
+    )
+  UNION ALL
+  SELECT C.*
+    FROM __gp_masterid, gp_instrument_shmem_summary_f() as C (
+      segid int, num_free bigint, num_used bigint
+    ))
+SELECT segid, num_free, num_used
+FROM all_entries
+ORDER BY segid;
+GRANT SELECT ON gp_instrument_shmem_summary TO public;
+CREATE FUNCTION gp_instrument_shmem_detail_f()
+RETURNS SETOF RECORD
+AS '$libdir/gp_instrument_shmem', 'gp_instrument_shmem_detail'
+LANGUAGE C IMMUTABLE;
+GRANT EXECUTE ON FUNCTION gp_instrument_shmem_detail_f() TO public;
+CREATE VIEW gp_instrument_shmem_detail AS
+WITH all_entries AS (
+  SELECT C.*
+    FROM __gp_localid, gp_instrument_shmem_detail_f() as C (
+      tmid int4,ssid int4,ccnt int2,segid int2,pid int4
+      ,nid int2,tuplecount int8,nloops int8,ntuples int8
+    )
+  UNION ALL
+  SELECT C.*
+    FROM __gp_masterid, gp_instrument_shmem_detail_f() as C (
+      tmid int4,ssid int4,ccnt int2,segid int2,pid int4
+      ,nid int2,tuplecount int8,nloops int8,ntuples int8
+    ))
+SELECT tmid, ssid, ccnt,segid, pid, nid, tuplecount, nloops, ntuples
+FROM all_entries
+ORDER BY segid;
+GRANT SELECT ON gp_instrument_shmem_detail TO public;
+CREATE TABLE a (id int) DISTRIBUTED BY (id);
+INSERT INTO a SELECT * FROM generate_series(1, 50);
+SET OPTIMIZER=OFF;
+ANALYZE a;
+-- Expected result is 1 row, means only current query in instrument slots,
+-- If more than one row returned, means previous test has leaked slots.
+SELECT count(*) FROM (SELECT 1 FROM gp_instrument_shmem_detail GROUP BY ssid, ccnt) t;
+ count 
+-------
+     1
+(1 row)
+
+-- regression to EXPLAN ANALZE
+EXPLAIN ANALYZE SELECT 1/0;
+ERROR:  division by zero
+EXPLAIN ANALYZE SELECT count(*) FROM a where id < (1/(select count(*) where 1=0));
+ERROR:  division by zero  (seg0 slice1 10.152.10.43:20000 pid=25058)
+EXPLAIN ANALYZE SELECT count(*) FROM a a1, a a2, a a3;
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=23614.53..23614.54 rows=1 width=8)
+   Rows out:  1 rows with 16 ms to end.
+   ->  Gather Motion 9:1  (slice3; segments: 9)  (cost=23614.41..23614.51 rows=1 width=8)
+         Rows out:  9 rows at destination with 11 ms to first row, 16 ms to end.
+         ->  Aggregate  (cost=23614.41..23614.42 rows=1 width=8)
+               Rows out:  Avg 1.0 rows x 9 workers.  Max 1 rows (seg0) with 12 ms to end.
+               ->  Nested Loop  (cost=29.90..22989.40 rows=13889 width=0)
+                     Rows out:  Avg 13888.9 rows x 9 workers.  Max 17500 rows (seg6) with 3.320 ms to first row, 11 ms to end.
+                     ->  Nested Loop  (cost=14.95..474.45 rows=278 width=0)
+                           Rows out:  Avg 277.8 rows x 9 workers.  Max 350 rows (seg6) with 0.250 ms to first row, 0.618 ms to end.
+                           ->  Seq Scan on a a1  (cost=0.00..9.50 rows=6 width=0)
+                                 Rows out:  Avg 5.6 rows x 9 workers.  Max 7 rows (seg6) with 0.052 ms to first row, 0.064 ms to end.
+                           ->  Materialize  (cost=14.95..19.45 rows=50 width=0)
+                                 Rows out:  Avg 277.8 rows x 9 workers.  Max 350 rows (seg6) with 0.165 ms to first row, 0.351 ms to end of 7 scans.
+                                 ->  Broadcast Motion 9:9  (slice1; segments: 9)  (cost=0.00..14.50 rows=50 width=0)
+                                       Rows out:  Avg 50.0 rows x 9 workers at destination.  Max 50 rows (seg0) with 0.044 ms to first row, 0.117 ms to end.
+                                       ->  Seq Scan on a a3  (cost=0.00..9.50 rows=6 width=0)
+                                             Rows out:  Avg 5.6 rows x 9 workers.  Max 7 rows (seg6) with 0.238 ms to first row, 0.246 ms to end.
+                     ->  Materialize  (cost=14.95..19.45 rows=50 width=0)
+                           Rows out:  Avg 13889.9 rows x 9 workers.  Max 17501 rows (seg6) with 3.060 ms to first row, 5.964 ms to end of 351 scans.
+                           ->  Broadcast Motion 9:9  (slice2; segments: 9)  (cost=0.00..14.50 rows=50 width=0)
+                                 Rows out:  Avg 50.0 rows x 9 workers at destination.  Max 50 rows (seg0) with 0.129 ms to first row, 2.538 ms to end.
+                                 ->  Seq Scan on a a2  (cost=0.00..9.50 rows=6 width=0)
+                                       Rows out:  Avg 5.6 rows x 9 workers.  Max 7 rows (seg6) with 0.121 ms to first row, 0.127 ms to end.
+ Slice statistics:
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 248K bytes avg x 9 workers, 248K bytes max (seg0).
+   (slice2)    Executor memory: 248K bytes avg x 9 workers, 248K bytes max (seg0).
+   (slice3)    Executor memory: 311K bytes avg x 9 workers, 311K bytes max (seg0).
+ Statement statistics:
+   Memory used: 128000K bytes
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+ Total runtime: 129.936 ms
+(34 rows)
+
+EXPLAIN SELECT 1/0;
+                QUERY PLAN                
+------------------------------------------
+ Result  (cost=0.00..0.01 rows=1 width=0)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(3 rows)
+
+EXPLAIN SELECT count(*) FROM a where id < (1/(select count(*) where 1=0));
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Aggregate  (cost=10.00..10.01 rows=1 width=8)
+   InitPlan 1 (returns $0)  (slice2)
+     ->  Aggregate  (cost=0.02..0.03 rows=1 width=8)
+           ->  Result  (cost=0.00..0.01 rows=1 width=0)
+                 One-Time Filter: false
+   ->  Gather Motion 9:1  (slice1; segments: 9)  (cost=9.84..9.95 rows=1 width=8)
+         ->  Aggregate  (cost=9.84..9.85 rows=1 width=8)
+               ->  Seq Scan on a  (cost=0.00..9.75 rows=2 width=0)
+                     Filter: id < (1 / $0)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(11 rows)
+
+EXPLAIN SELECT count(*) FROM a a1, a a2, a a3;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=23614.53..23614.54 rows=1 width=8)
+   ->  Gather Motion 9:1  (slice3; segments: 9)  (cost=23614.41..23614.51 rows=1 width=8)
+         ->  Aggregate  (cost=23614.41..23614.42 rows=1 width=8)
+               ->  Nested Loop  (cost=29.90..22989.40 rows=13889 width=0)
+                     ->  Nested Loop  (cost=14.95..474.45 rows=278 width=0)
+                           ->  Seq Scan on a a1  (cost=0.00..9.50 rows=6 width=0)
+                           ->  Materialize  (cost=14.95..19.45 rows=50 width=0)
+                                 ->  Broadcast Motion 9:9  (slice1; segments: 9)  (cost=0.00..14.50 rows=50 width=0)
+                                       ->  Seq Scan on a a3  (cost=0.00..9.50 rows=6 width=0)
+                     ->  Materialize  (cost=14.95..19.45 rows=50 width=0)
+                           ->  Broadcast Motion 9:9  (slice2; segments: 9)  (cost=0.00..14.50 rows=50 width=0)
+                                 ->  Seq Scan on a a2  (cost=0.00..9.50 rows=6 width=0)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(14 rows)
+
+-- Expected result is 1 row, means only current query in instrument slots,
+-- If more than one row returned, means previous test has leaked slots.
+SELECT count(*) FROM (SELECT 1 FROM gp_instrument_shmem_detail GROUP BY ssid, ccnt) t;
+ count 
+-------
+     1
+(1 row)
+
+-- start_ignore
+DROP SCHEMA IF EXISTS QUERY_METRICS CASCADE; 
+NOTICE:  drop cascades to 7 other objects
+DETAIL:  drop cascades to external table __gp_localid
+drop cascades to external table __gp_masterid
+drop cascades to function gp_instrument_shmem_summary_f()
+drop cascades to view gp_instrument_shmem_summary
+drop cascades to function gp_instrument_shmem_detail_f()
+drop cascades to view gp_instrument_shmem_detail
+drop cascades to table a
+-- end_ignore

--- a/src/test/regress/expected/instr_in_shmem_setup.out
+++ b/src/test/regress/expected/instr_in_shmem_setup.out
@@ -1,0 +1,8 @@
+-- gp_enable_query_metrics GUC will enable instrumentation
+-- collection for every query in following tests.
+-- After all tests finished, the last test check_instr_in_shmem
+-- will check for leaks of instrumentation slots in shmem.
+-- start_ignore
+\! gpconfig -c gp_enable_query_metrics -v on 
+\! PGDATESTYLE="" gpstop -rai
+-- end_ignore

--- a/src/test/regress/expected/instr_in_shmem_verify.out
+++ b/src/test/regress/expected/instr_in_shmem_verify.out
@@ -1,0 +1,69 @@
+-- start_ignore
+-- This test checks for leaks of instrumentation slots in shmem.
+-- gp_instrument_shmem_detail is a function can retrieve
+-- instrumentation slots contents on every segment.
+-- This test should run after all other regression tests are done,
+-- then it calls the function to detect if any left over
+-- instrumentation slots exists.
+DROP SCHEMA IF EXISTS QUERY_METRICS CASCADE; 
+NOTICE:  schema "query_metrics" does not exist, skipping
+CREATE SCHEMA QUERY_METRICS;
+SET SEARCH_PATH=QUERY_METRICS;
+CREATE EXTERNAL WEB TABLE __gp_localid
+(
+    localid    int
+)
+EXECUTE E'echo $GP_SEGMENT_ID' FORMAT 'TEXT';
+GRANT SELECT ON TABLE __gp_localid TO public;
+CREATE EXTERNAL WEB TABLE __gp_masterid
+(
+    masterid    int
+)
+EXECUTE E'echo $GP_SEGMENT_ID' ON MASTER FORMAT 'TEXT';
+GRANT SELECT ON TABLE __gp_masterid TO public;
+CREATE FUNCTION gp_instrument_shmem_detail_f()
+RETURNS SETOF RECORD
+AS '$libdir/gp_instrument_shmem', 'gp_instrument_shmem_detail'
+LANGUAGE C IMMUTABLE;
+GRANT EXECUTE ON FUNCTION gp_instrument_shmem_detail_f() TO public;
+CREATE VIEW gp_instrument_shmem_detail AS
+WITH all_entries AS (
+  SELECT C.*
+    FROM __gp_localid, gp_instrument_shmem_detail_f() as C (
+      tmid int4,ssid int4,ccnt int2,segid int2,pid int4
+      ,nid int2,tuplecount int8,nloops int8,ntuples int8
+    )
+  UNION ALL
+  SELECT C.*
+    FROM __gp_masterid, gp_instrument_shmem_detail_f() as C (
+      tmid int4,ssid int4,ccnt int2,segid int2,pid int4
+      ,nid int2,tuplecount int8,nloops int8,ntuples int8
+    ))
+SELECT tmid, ssid, ccnt,segid, pid, nid, tuplecount, nloops, ntuples
+FROM all_entries
+ORDER BY segid;
+GRANT SELECT ON gp_instrument_shmem_detail TO public;
+SET OPTIMIZER=OFF;
+-- end_ignore
+SELECT count(*) FROM pg_stat_activity;
+ count 
+-------
+     1
+(1 row)
+
+-- Expected result is 1 row, means only current query in instrument slots,
+-- If more than one row returned, means previous test has leaked slots.
+SELECT count(*) FROM (SELECT 1 FROM gp_instrument_shmem_detail GROUP BY ssid, ccnt) t;
+ count 
+-------
+     1
+(1 row)
+
+-- start_ignore
+DROP SCHEMA IF EXISTS QUERY_METRICS CASCADE; 
+NOTICE:  drop cascades to 4 other objects
+DETAIL:  drop cascades to external table __gp_localid
+drop cascades to external table __gp_masterid
+drop cascades to function gp_instrument_shmem_detail_f()
+drop cascades to view gp_instrument_shmem_detail
+-- end_ignore

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -142,6 +142,9 @@ test: qp_olap_group qp_olap_group2
 
 test: hooktest partition_rank
 
+# Test query_info_collect_hook are called in expected sequence on normal query, query error/abort
+test: query_info_hook_test
+
 ignore: tpch500GB_orca
 
 # Tests for "compaction", i.e. VACUUM, of updatable append-only tables

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -14,11 +14,18 @@
 #   to the segments, and therefore has to run in smaller groups to avoid
 #   hitting max_connections limit on segments.
 #
+
+# enable query metrics cluster GUC
+test: instr_in_shmem_setup
+# run separately - because slot counter may influenced by other parallel queries
+test: instr_in_shmem
+
 test: gp_tablespace gp_aggregates gp_metadata variadic_parameters default_parameters function_extensions spi gp_xml pgoptions shared_scan
 test: spi_processed64bit
 
 test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp gpcopy gp_create_table gp_create_view window_views
 test: filter gpctas gpdist matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var guc_gp gp_explain
+
 test: bitmap_index gp_dump_query_oids analyze gp_owner_permission
 test: indexjoin as_alias regex_gp gpparams with_clause transient_types gp_rules
 # dispatch should always run seperately from other cases.
@@ -32,6 +39,9 @@ test: workfile/hashagg_spill workfile/hashjoin_spill workfile/materialize_spill 
 # test workfiles compressed using zlib
 # 'zlib' utilizes fault injectors so it needs to be in a group by itself
 test: zlib
+
+# Check for shmem leak for instrumentation slots before gpdb restart
+test: instr_in_shmem_verify
 
 # This test will change the gp_workfile_limit_per_segment and will need to restart the DB.
 # It will also use faultinjector - so it needs to be in a group by itself.
@@ -188,5 +198,8 @@ test: metadata_track
 test: workfile_mgr_test
 
 test: psql_gp_commands pg_resetxlog
+
+# Check for shmem leak for instrumentation slots
+test: instr_in_shmem_verify
 
 # end of tests

--- a/src/test/regress/input/query_info_hook_test.source
+++ b/src/test/regress/input/query_info_hook_test.source
@@ -1,0 +1,12 @@
+LOAD '@abs_builddir@/query_info_hook_test/query_info_hook_test@DLSUFFIX@';
+SET client_min_messages='warning';
+
+-- Test Normal case
+SELECT * FROM generate_series(1, 3);
+
+-- Test Error case
+SELECT * FROM generate_series(1, 3/0);
+
+-- Test query abort
+select pg_cancel_backend(pg_backend_pid());
+

--- a/src/test/regress/output/query_info_hook_test.source
+++ b/src/test/regress/output/query_info_hook_test.source
@@ -1,0 +1,38 @@
+LOAD '@abs_builddir@/query_info_hook_test/query_info_hook_test@DLSUFFIX@';
+SET client_min_messages='warning';
+-- Test Normal case
+SELECT * FROM generate_series(1, 3);
+WARNING:  Query submit
+WARNING:  Query start
+WARNING:  Plan node initializing
+WARNING:  Plan node executing
+WARNING:  Plan node finished
+WARNING:  Query Done
+ generate_series 
+-----------------
+               1
+               2
+               3
+(3 rows)
+
+-- Test Error case
+SELECT * FROM generate_series(1, 3/0);
+WARNING:  Query submit
+WARNING:  Query start
+WARNING:  Plan node initializing
+WARNING:  Plan node executing
+WARNING:  Query Error
+WARNING:  Query Error
+ERROR:  division by zero
+-- Test query abort
+select pg_cancel_backend(pg_backend_pid());
+WARNING:  Query submit
+WARNING:  Query start
+WARNING:  Plan node initializing
+WARNING:  Plan node executing
+WARNING:  Plan node executing
+WARNING:  Query Canceling
+WARNING:  Query Canceled
+WARNING:  Query Canceling
+WARNING:  Query Canceled
+ERROR:  canceling statement due to user request

--- a/src/test/regress/query_info_hook_test/Makefile
+++ b/src/test/regress/query_info_hook_test/Makefile
@@ -1,0 +1,15 @@
+MODULE_big = query_info_hook_test
+OBJS = query_info_hook_test.o
+
+REGRESS = query_info_hook_test
+
+ifdef USE_PGXS
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
+else
+subdir = src/test/regress/query_info_hook_test
+top_builddir = ../../../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif

--- a/src/test/regress/query_info_hook_test/query_info_hook_test.c
+++ b/src/test/regress/query_info_hook_test/query_info_hook_test.c
@@ -1,0 +1,63 @@
+#include "postgres.h"
+
+#include "fmgr.h"
+#include "utils/metrics_utils.h"
+
+PG_MODULE_MAGIC;
+
+void _PG_init(void);
+void _PG_fini(void);
+
+static query_info_collect_hook_type prev_query_info_collect_hook;
+
+static void
+test_hook(QueryMetricsStatus, void* args);
+
+void
+_PG_init(void)
+{
+	prev_query_info_collect_hook = query_info_collect_hook;
+	query_info_collect_hook = test_hook;
+}
+
+void
+_PG_fini(void)
+{
+	query_info_collect_hook = prev_query_info_collect_hook;
+}
+
+static void
+test_hook(QueryMetricsStatus status, void* args)
+{
+	switch (status)
+	{
+		case METRICS_PLAN_NODE_INITIALIZE:
+			ereport(WARNING, (errmsg("Plan node initializing")));
+			break;
+		case METRICS_PLAN_NODE_EXECUTING:
+			ereport(WARNING, (errmsg("Plan node executing")));
+			break;
+		case METRICS_PLAN_NODE_FINISHED:
+			ereport(WARNING, (errmsg("Plan node finished")));
+			break;
+		case METRICS_QUERY_SUBMIT:
+			ereport(WARNING, (errmsg("Query submit")));
+			break;
+		case METRICS_QUERY_START:
+			ereport(WARNING, (errmsg("Query start")));
+			break;
+		case METRICS_QUERY_DONE:
+			ereport(WARNING, (errmsg("Query Done")));
+			break;
+		case METRICS_QUERY_ERROR:
+			ereport(WARNING, (errmsg("Query Error")));
+			break;
+		case METRICS_QUERY_CANCELING:
+			ereport(WARNING, (errmsg("Query Canceling")));
+			break;
+		case METRICS_QUERY_CANCELED:
+			ereport(WARNING, (errmsg("Query Canceled")));
+			break;
+	}
+}
+

--- a/src/test/regress/sql/.gitignore
+++ b/src/test/regress/sql/.gitignore
@@ -36,3 +36,4 @@ transient_types.sql
 hooktest.sql
 gpcopy.sql
 trigger_sets_oid.sql
+query_info_hook_test.sql

--- a/src/test/regress/sql/instr_in_shmem.sql
+++ b/src/test/regress/sql/instr_in_shmem.sql
@@ -1,0 +1,103 @@
+-- start_ignore
+-- Test instrument in shmem does not break EXPLAIN
+-- and EXPLAIN ANALYZE. Also instrumentation slots
+-- are correctly recycled.
+-- This test can not run in parallel with other tests.
+-- end_ignore
+
+-- default value
+SHOW GP_ENABLE_QUERY_METRICS;
+SELECT 1;
+
+SHOW GP_INSTRUMENT_SHMEM_SIZE;
+SELECT 1;
+
+-- start_ignore
+DROP SCHEMA IF EXISTS QUERY_METRICS CASCADE; 
+CREATE SCHEMA QUERY_METRICS;
+SET SEARCH_PATH=QUERY_METRICS;
+
+CREATE EXTERNAL WEB TABLE __gp_localid
+(
+    localid    int
+)
+EXECUTE E'echo $GP_SEGMENT_ID' FORMAT 'TEXT';
+GRANT SELECT ON TABLE __gp_localid TO public;
+
+CREATE EXTERNAL WEB TABLE __gp_masterid
+(
+    masterid    int
+)
+EXECUTE E'echo $GP_SEGMENT_ID' ON MASTER FORMAT 'TEXT';
+GRANT SELECT ON TABLE __gp_masterid TO public;
+
+CREATE FUNCTION gp_instrument_shmem_summary_f()
+RETURNS SETOF RECORD
+AS '$libdir/gp_instrument_shmem', 'gp_instrument_shmem_summary'
+LANGUAGE C IMMUTABLE;
+GRANT EXECUTE ON FUNCTION gp_instrument_shmem_summary_f() TO public;
+
+CREATE VIEW gp_instrument_shmem_summary AS
+WITH all_entries AS (
+  SELECT C.*
+    FROM __gp_localid, gp_instrument_shmem_summary_f() as C (
+      segid int, num_free bigint, num_used bigint
+    )
+  UNION ALL
+  SELECT C.*
+    FROM __gp_masterid, gp_instrument_shmem_summary_f() as C (
+      segid int, num_free bigint, num_used bigint
+    ))
+SELECT segid, num_free, num_used
+FROM all_entries
+ORDER BY segid;
+GRANT SELECT ON gp_instrument_shmem_summary TO public;
+
+CREATE FUNCTION gp_instrument_shmem_detail_f()
+RETURNS SETOF RECORD
+AS '$libdir/gp_instrument_shmem', 'gp_instrument_shmem_detail'
+LANGUAGE C IMMUTABLE;
+GRANT EXECUTE ON FUNCTION gp_instrument_shmem_detail_f() TO public;
+
+CREATE VIEW gp_instrument_shmem_detail AS
+WITH all_entries AS (
+  SELECT C.*
+    FROM __gp_localid, gp_instrument_shmem_detail_f() as C (
+      tmid int4,ssid int4,ccnt int2,segid int2,pid int4
+      ,nid int2,tuplecount int8,nloops int8,ntuples int8
+    )
+  UNION ALL
+  SELECT C.*
+    FROM __gp_masterid, gp_instrument_shmem_detail_f() as C (
+      tmid int4,ssid int4,ccnt int2,segid int2,pid int4
+      ,nid int2,tuplecount int8,nloops int8,ntuples int8
+    ))
+SELECT tmid, ssid, ccnt,segid, pid, nid, tuplecount, nloops, ntuples
+FROM all_entries
+ORDER BY segid;
+GRANT SELECT ON gp_instrument_shmem_detail TO public;
+
+CREATE TABLE a (id int) DISTRIBUTED BY (id);
+INSERT INTO a SELECT * FROM generate_series(1, 50);
+SET OPTIMIZER=OFF;
+ANALYZE a;
+
+-- Expected result is 1 row, means only current query in instrument slots,
+-- If more than one row returned, means previous test has leaked slots.
+SELECT count(*) FROM (SELECT 1 FROM gp_instrument_shmem_detail GROUP BY ssid, ccnt) t;
+
+-- regression to EXPLAN ANALZE
+EXPLAIN ANALYZE SELECT 1/0;
+EXPLAIN ANALYZE SELECT count(*) FROM a where id < (1/(select count(*) where 1=0));
+EXPLAIN ANALYZE SELECT count(*) FROM a a1, a a2, a a3;
+EXPLAIN SELECT 1/0;
+EXPLAIN SELECT count(*) FROM a where id < (1/(select count(*) where 1=0));
+EXPLAIN SELECT count(*) FROM a a1, a a2, a a3;
+
+-- Expected result is 1 row, means only current query in instrument slots,
+-- If more than one row returned, means previous test has leaked slots.
+SELECT count(*) FROM (SELECT 1 FROM gp_instrument_shmem_detail GROUP BY ssid, ccnt) t;
+
+-- start_ignore
+DROP SCHEMA IF EXISTS QUERY_METRICS CASCADE; 
+-- end_ignore

--- a/src/test/regress/sql/instr_in_shmem_setup.sql
+++ b/src/test/regress/sql/instr_in_shmem_setup.sql
@@ -1,0 +1,9 @@
+-- gp_enable_query_metrics GUC will enable instrumentation
+-- collection for every query in following tests.
+-- After all tests finished, the last test check_instr_in_shmem
+-- will check for leaks of instrumentation slots in shmem.
+
+-- start_ignore
+\! gpconfig -c gp_enable_query_metrics -v on 
+\! PGDATESTYLE="" gpstop -rai
+-- end_ignore

--- a/src/test/regress/sql/instr_in_shmem_verify.sql
+++ b/src/test/regress/sql/instr_in_shmem_verify.sql
@@ -1,0 +1,60 @@
+-- start_ignore
+-- This test checks for leaks of instrumentation slots in shmem.
+-- gp_instrument_shmem_detail is a function can retrieve
+-- instrumentation slots contents on every segment.
+-- This test should run after all other regression tests are done,
+-- then it calls the function to detect if any left over
+-- instrumentation slots exists.
+
+DROP SCHEMA IF EXISTS QUERY_METRICS CASCADE; 
+CREATE SCHEMA QUERY_METRICS;
+SET SEARCH_PATH=QUERY_METRICS;
+CREATE EXTERNAL WEB TABLE __gp_localid
+(
+    localid    int
+)
+EXECUTE E'echo $GP_SEGMENT_ID' FORMAT 'TEXT';
+GRANT SELECT ON TABLE __gp_localid TO public;
+CREATE EXTERNAL WEB TABLE __gp_masterid
+(
+    masterid    int
+)
+EXECUTE E'echo $GP_SEGMENT_ID' ON MASTER FORMAT 'TEXT';
+GRANT SELECT ON TABLE __gp_masterid TO public;
+
+CREATE FUNCTION gp_instrument_shmem_detail_f()
+RETURNS SETOF RECORD
+AS '$libdir/gp_instrument_shmem', 'gp_instrument_shmem_detail'
+LANGUAGE C IMMUTABLE;
+GRANT EXECUTE ON FUNCTION gp_instrument_shmem_detail_f() TO public;
+
+CREATE VIEW gp_instrument_shmem_detail AS
+WITH all_entries AS (
+  SELECT C.*
+    FROM __gp_localid, gp_instrument_shmem_detail_f() as C (
+      tmid int4,ssid int4,ccnt int2,segid int2,pid int4
+      ,nid int2,tuplecount int8,nloops int8,ntuples int8
+    )
+  UNION ALL
+  SELECT C.*
+    FROM __gp_masterid, gp_instrument_shmem_detail_f() as C (
+      tmid int4,ssid int4,ccnt int2,segid int2,pid int4
+      ,nid int2,tuplecount int8,nloops int8,ntuples int8
+    ))
+SELECT tmid, ssid, ccnt,segid, pid, nid, tuplecount, nloops, ntuples
+FROM all_entries
+ORDER BY segid;
+GRANT SELECT ON gp_instrument_shmem_detail TO public;
+
+SET OPTIMIZER=OFF;
+-- end_ignore
+
+SELECT count(*) FROM pg_stat_activity;
+
+-- Expected result is 1 row, means only current query in instrument slots,
+-- If more than one row returned, means previous test has leaked slots.
+SELECT count(*) FROM (SELECT 1 FROM gp_instrument_shmem_detail GROUP BY ssid, ccnt) t;
+
+-- start_ignore
+DROP SCHEMA IF EXISTS QUERY_METRICS CASCADE; 
+-- end_ignore


### PR DESCRIPTION
This PR aims to provide a simple yet flexible framework to emit Greenplum various metrics. The main idea is to use hook, so that hook implementation will be able to collect and monitor needed cluster or query information.

In this PR, support to capture below information:
- Query status, like submit, start, finish, abort etc
- Query plan node and progress for each node, like tuple counts

So far, it has some overlap with gpmon, coming PRs will refactor gpmon to use hook.

Greenplum Command Center Team