### PR TITLE
Enable GIN indexes.

### DIFF
--- a/contrib/hstore/expected/hstore.out
+++ b/contrib/hstore/expected/hstore.out
@@ -612,7 +612,6 @@ select count(*) from testhstore where h ? 'public';
 
 drop index hidx;
 create index hidx on testhstore using gin (h);
-ERROR:  GIN indexes are not supported
 set enable_seqscan=off;
 select count(*) from testhstore where h @> 'wait=>NULL';
  count 

--- a/gpdb-doc/dita/admin_guide/ddl/ddl-index.xml
+++ b/gpdb-doc/dita/admin_guide/ddl/ddl-index.xml
@@ -90,7 +90,7 @@ VACUUM ANALYZE old_table;
   <topic id="topic92" xml:lang="en">
     <title>Index Types</title>
     <body>
-      <p>Greenplum Database supports the Postgres index types B-tree and GiST. Hash and GIN indexes
+      <p>Greenplum Database supports the Postgres index types B-tree, GiST, and GIN. Hash indexes
         are not supported. Each index type uses a different algorithm that is best suited to
         different types of queries. B-tree indexes fit the most common situations and are the
         default index type. See <xref

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_INDEX.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_INDEX.xml
@@ -8,7 +8,7 @@
                 <section id="section2">
                         <title>Synopsis</title>
                         <codeblock id="sql_command_synopsis">CREATE [UNIQUE] INDEX <varname>name</varname> ON <varname>table</varname>
-       [USING btree|bitmap|gist]
+       [USING btree|bitmap|gist|gin]
        ( {<varname>column</varname> | (<varname>expression</varname>)} [<varname>opclass</varname>] [, ...] )
        [ WITH ( FILLFACTOR = <varname>value</varname> ) ]
        [TABLESPACE <varname>tablespace</varname>]
@@ -29,7 +29,7 @@
                                 For example, an index computed on <codeph>upper(col)</codeph> would
                                 allow the clause <codeph>WHERE upper(col) = 'JIM'</codeph> to use an
                                 index. </p>
-                        <p>Greenplum Database provides the index methods B-tree, bitmap, and GiST.
+                        <p>Greenplum Database provides the index methods B-tree, bitmap, GiST, and GIN.
                                 Users can also define their own index methods, but that is fairly
                                 complicated. </p>
                         <p>When the <codeph>WHERE</codeph> clause is present, a partial index is
@@ -85,11 +85,11 @@
                                 </plentry>
                                 <plentry>
                                         <pt>
-                                                <varname>btree | bitmap | gist</varname>
+                                                <varname>btree | bitmap | gist | gin</varname>
                                         </pt>
                                         <pd>The name of the index method to be used. Choices are
                                                   <codeph>btree</codeph>, <codeph>bitmap</codeph>,
-                                                and <codeph>gist</codeph>. The default method is
+                                                <codeph>gist</codeph>, and <codeph>gin</codeph>. The default method is
                                                   <codeph>btree</codeph>. </pd>
                                 </plentry>
                                 <plentry>
@@ -97,7 +97,7 @@
                                                 <varname>column</varname>
                                         </pt>
                                         <pd>The name of a column of the table on which to create the
-                                                index. Only the B-tree, bitmap, and GiST index
+                                                index. Only the B-tree, bitmap, GiST, and GIN index
                                                 methods support multicolumn indexes.</pd>
                                 </plentry>
                                 <plentry>
@@ -206,7 +206,7 @@
                                         href="https://www.postgresql.org/docs/8.3/static/indexes-types.html"
                                         scope="external" format="html">PostgreSQL
                                         documentation</xref>.</p>
-                        <p>The use of hash and GIN indexes has been disabled in Greenplum
+                        <p>The use of hash indexes has been disabled in Greenplum
                                 Database.</p>
                 </section>
                 <section id="section6">

--- a/gpdb-doc/dita/utility_guide/hstore.xml
+++ b/gpdb-doc/dita/utility_guide/hstore.xml
@@ -199,8 +199,12 @@ b</codeblock>
   <section>
    <title>Indexes</title>
    <p><codeph>hstore</codeph> has index support for <codeph>@&gt;</codeph> and <codeph>?</codeph>
-    operators. You can use the GiST index type. For example:</p>
-   <codeblock>CREATE INDEX hidx ON testhstore USING GIST(h);</codeblock>
+    operators. You can use either GiST or GIN index types. For example:</p>
+   <codeblock>
+CREATE INDEX hidx ON testhstore USING GIST(h);
+
+CREATE INDEX hidx ON testhstore USING GIN(h);
+   </codeblock>
   </section>
   <section>
    <title>Examples</title>

--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -419,12 +419,6 @@ DefineIndex(RangeVar *heapRelation,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("hash indexes are not supported")));
 
-	/* MPP-9329: disable creation of GIN indexes */
-	if (accessMethodId == GIN_AM_OID)
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("GIN indexes are not supported")));
-
 	if (unique && !accessMethodForm->amcanunique)
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -2040,12 +2040,11 @@ static struct config_int ConfigureNamesInt[] =
 		0, 0, INT_MAX, assign_tcp_keepalives_count, show_tcp_keepalives_count
 	},
 
-	/* MPP-9413: gin indexes are disabled */
 	{
 		{"gin_fuzzy_search_limit", PGC_USERSET, CLIENT_CONN_OTHER,
 			gettext_noop("Sets the maximum allowed result for exact search by GIN."),
 			NULL,
-            GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_GPDB_ADDOPT
 		},
 		&GinFuzzySearchLimit,
 		0, 0, INT_MAX, NULL, NULL

--- a/src/backend/utils/misc/postgresql.conf.sample
+++ b/src/backend/utils/misc/postgresql.conf.sample
@@ -434,6 +434,7 @@ log_autostats=off	# print additional autostats information
 #vacuum_freeze_min_age = 50000000
 #vacuum_freeze_table_age = 150000000
 #bytea_output='escape'
+#gin_fuzzy_search_limit = 0
 
 # - Locale and Formatting -
 

--- a/src/test/regress/expected/create_index.out
+++ b/src/test/regress/expected/create_index.out
@@ -176,7 +176,6 @@ SET enable_seqscan = OFF;
 SET enable_indexscan = ON;
 SET enable_bitmapscan = OFF;
 CREATE INDEX intarrayidx ON array_index_op_test USING gin (i);
-ERROR:  GIN indexes are not supported
 SELECT * FROM array_index_op_test WHERE i @> '{32}' ORDER BY seqno;
  seqno |                i                |                                                                 t                                                                  
 -------+---------------------------------+------------------------------------------------------------------------------------------------------------------------------------
@@ -264,7 +263,6 @@ SELECT * FROM array_index_op_test WHERE i = '{47,77}' ORDER BY seqno;
 (1 row)
 
 CREATE INDEX textarrayidx ON array_index_op_test USING gin (t);
-ERROR:  GIN indexes are not supported
 SELECT * FROM array_index_op_test WHERE t @> '{AAAAAAAA72908}' ORDER BY seqno;
  seqno |           i           |                                                                     t                                                                      
 -------+-----------------------+--------------------------------------------------------------------------------------------------------------------------------------------
@@ -420,9 +418,7 @@ SELECT * FROM array_index_op_test WHERE i = '{47,77}' ORDER BY seqno;
 
 -- And try it with a multicolumn GIN index
 DROP INDEX intarrayidx, textarrayidx;
-ERROR:  index "intarrayidx" does not exist
 CREATE INDEX botharrayidx ON array_index_op_test USING gin (i, t);
-ERROR:  GIN indexes are not supported
 SET enable_seqscan = OFF;
 SET enable_indexscan = ON;
 SET enable_bitmapscan = OFF;


### PR DESCRIPTION
A long time ago, they were disabled, because the GIN code had not been
modified to work with file replication. Now with WAL replication, there's
no reason to not support them.