### PR TITLE
Add create-tinc-test-cluster make target

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -174,6 +174,10 @@ create-demo-cluster:
 destroy-demo-cluster:
 	$(MAKE) -C gpAux/gpdemo destroy-demo-cluster
 
+create-tinc-test-cluster: destroy-demo-cluster
+	$(MAKE) -C gpAux/gpdemo DEFAULT_QD_MAX_CONNECT=250 NUM_PRIMARY_MIRROR_PAIRS=2
+	. gpAux/gpdemo/gpdemo-env.sh && createdb gptest
+
 # Run mock tests, that don't require a running server. Arguably these should
 # be part of [install]check-world, but we treat them more like part of
 # compilation than regression testing, in the CI. But they are too heavy-weight

--- a/README.md
+++ b/README.md
@@ -133,6 +133,24 @@ make installcheck-world
   upstream. We try to keep the upstream tests identical to the upstream
   versions, to make merging with newer PostgreSQL releases easier.
 
+### Running TINC tests
+
+* create TINC test cluster
+
+It's different from the `create-demo-cluster` to pass the ICW tests. It has
+less number of primaries and also support more connections.
+
+```
+# assuming repo cloned under ~/workspace/gpdb
+cd ~/workspace/gpdb
+source /usr/local/gpdb/greenplum_path.sh
+make create-tinc-test-cluster
+source gpAux/gpdemo/gpdemo-env.sh
+make -C src/test/tinc walrep_2 # to run walrep_2 tinc tests
+```
+
+To understand more about TINC, please refer to `src/test/tinc/README`.
+
 ## Alternative Configurations
 
 ### Building GPDB without GPORCA

--- a/src/test/tinc/Makefile
+++ b/src/test/tinc/Makefile
@@ -24,7 +24,13 @@ tincmmgrregress:
 	@echo regression test tincmmgr
 	make -C tincmmgr regress
 
-TESTER=tinc.py
+TESTER= \
+	export PGDATABASE=gptest && \
+	export TINCHOME=$(PWD) && \
+	export TINCREPOHOME=$(TINCHOME)/tincrepo && \
+	export PYTHONPATH=$(TINCHOME):$(TINCHOME)/ext:$(PYTHONPATH):$(TINCREPOHOME) && \
+	export PATH=$(TINCHOME):$(TINCHOME)/ext:$(TINCHOME)/ext/unittest2:$(TINCHOME)/sbin/:$(PATH) && \
+	tinc.py
 
 DISCOVER=discover
 


### PR DESCRIPTION
Adding support to create cluster for tinc testing. This also create
gptest database. Here is an example script to run tinc tests:

```
cd ~/workspace/gpdb
source .../greenplum_path.sh
make create-tinc-test-cluster
source gpAux/gpdemo/gpdemo-env.sh
make -C src/test/tinc walrep_2 # to run walrep_2 tinc tests
```

Author: Xin Zhang <xzhang@pivotal.io>
Author: Ashwin Agrawal <aagrawal@pivotal.io>