### PR TITLE
docs - pxf to main subnav, refer to main topic name consistently

### DIFF
--- a/gpdb-doc/book/master_middleman/source/subnavs/gpdb-landing-subnav.erb
+++ b/gpdb-doc/book/master_middleman/source/subnavs/gpdb-landing-subnav.erb
@@ -20,6 +20,9 @@
       <li>
          <a href="/docs/600/ref_guide/ref_guide.html">Reference Guide</a>
       </li>
+      <li>
+         <a href="/docs/600/admin_guide/external/pxf-overview.html">Greenplum Platform Extension Framework (PXF)</a>
+      </li>
     </ul>
   </div>
 </div>

--- a/gpdb-doc/dita/admin_guide/external/pxf-overview.xml
+++ b/gpdb-doc/dita/admin_guide/external/pxf-overview.xml
@@ -7,6 +7,6 @@
     <p>PXF is installed with HDFS, Hive, and HBase connectors. These connectors enable you to read external HDFS file system and Hive and HBase table data stored in text, Avro, JSON, RCFile, Parquet, SequenceFile, and ORC formats.</p>
     <note>PXF does not currently support filter predicate pushdown in the HDFS, Hive, and HBase connectors.</note>
     <p>The Greenplum Platform Extension Framework includes a protocol C library and a Java service. After you configure and initialize PXF, you start a single PXF JVM process on each Greenplum Database segment host. This long-running process concurrently serves multiple query requests.</p>
-    <p>For detailed information about the architecture of and using PXF, refer to the <xref href="../../pxf/overview_pxf.html" type="topic" format="html">Using PXF with External Data</xref> documentation.</p>
+    <p>For detailed information about the architecture of and using PXF, refer to the <xref href="../../pxf/overview_pxf.html" type="topic" format="html">Greenplum Platform Extension Framework (PXF)</xref> documentation.</p>
   </body>
 </topic>

--- a/gpdb-doc/markdown/pxf/overview_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/overview_pxf.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Using PXF with External Data
+title: Greenplum Platform Extension Framework (PXF)
 ---
 
 <!--


### PR DESCRIPTION
currently takes 4 clicks or so to get to main pxf documentation.  lets make it easier for the customer to find these docs.

add pxf topic to main subnav (left panel).
make the main topic name consistent with other doc sections.