### PR TITLE
docs: unhide gpmovemirrors in utility guide

### DIFF
--- a/gpdb-doc/dita/utility_guide/admin_utilities/util_ref.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/util_ref.xml
@@ -83,10 +83,9 @@
           <p>
             <xref href="gpmfr.xml#topic1" type="topic" format="dita"/>
           </p>
-          <!-- hidden until testing is complete -msk
             <p>
             <xref href="gpmovemirrors.xml#topic1"/>
-          </p>-->
+          </p>
           <p>
             <xref href="gpperfmon_install.xml#topic1"/>
           </p>

--- a/gpdb-doc/dita/utility_guide/utility_guide.ditamap
+++ b/gpdb-doc/dita/utility_guide/utility_guide.ditamap
@@ -25,9 +25,7 @@
             <topicref href="admin_utilities/gplogfilter.xml"/>
             <topicref href="admin_utilities/gpmapreduce.xml"/>
             <topicref href="admin_utilities/gpmfr.xml"/>
-            <!-- hidden until testing is complete -msk
             <topicref href="admin_utilities/gpmovemirrors.xml"/>
--->
             <topicref href="admin_utilities/gpperfmon_install.xml"/>
             <topicref href="admin_utilities/gppkg.xml"/>
             <topicref href="admin_utilities/gprecoverseg.xml"/>


### PR DESCRIPTION
PR for 5X_STABLE only