### PR TITLE
Remove unnecessary ftsEnabled variable

### DIFF
--- a/src/backend/cdb/cdbfts.c
+++ b/src/backend/cdb/cdbfts.c
@@ -43,7 +43,6 @@
 #define MASTER_SEGMENT_ID -1
 
 FtsProbeInfo *ftsProbeInfo = NULL;	/* Probe process updates this structure */
-volatile bool *ftsEnabled;
 volatile bool *ftsShutdownMaster;
 static LWLockId ftsControlLock;
 
@@ -80,7 +79,6 @@ FtsShmemInit(void)
 
 	/* Initialize locks and shared memory area */
 
-	ftsEnabled = &shared->ftsEnabled;
 	ftsShutdownMaster = &shared->ftsShutdownMaster;
 	ftsControlLock = shared->ControlLock;
 
@@ -107,7 +105,6 @@ FtsShmemInit(void)
 		shared->fts_probe_info.fts_statusVersion = 0;
 		shared->fts_probe_info.fts_status_initialized = false;
 
-		shared->ftsEnabled = true;	/* ??? */
 		shared->ftsShutdownMaster = false;
 	}
 }
@@ -262,8 +259,6 @@ FtsTestSegmentDBIsDown(SegmentDatabaseDescriptor *segdbDesc, int size)
 	int			i = 0;
 	bool		forceRescan = true;
 
-	Assert(isFTSEnabled());
-
 	for (i = 0; i < size; i++)
 	{
 		CdbComponentDatabaseInfo *segInfo = segdbDesc[i].segment_database_info;
@@ -288,9 +283,6 @@ FtsTestSegmentDBIsDown(SegmentDatabaseDescriptor *segdbDesc, int size)
 void
 FtsCondSetTxnReadOnly(bool *XactFlag)
 {
-	if (!isFTSEnabled())
-		return;
-
 	if (*ftsReadOnlyFlag && Gp_role != GP_ROLE_UTILITY)
 		*XactFlag = true;
 }

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -473,13 +473,6 @@ buildGangDefinition(GangType type, int gang_id, int size, int content)
 		cdb_component_dbs->total_segment_dbs <= 0)
 		insist_log(false, "schema not populated while building segworker group");
 
-	/* if mirroring is not configured */
-	if (cdb_component_dbs->total_segment_dbs == cdb_component_dbs->total_segments)
-	{
-		ELOG_DISPATCHER_DEBUG("building Gang: mirroring not configured");
-		disableFTS();
-	}
-
 	perGangContext = AllocSetContextCreate(GangContext, "Per Gang Context",
 										   ALLOCSET_DEFAULT_MINSIZE,
 										   ALLOCSET_DEFAULT_INITSIZE,

--- a/src/backend/cdb/dispatcher/cdbgang_async.c
+++ b/src/backend/cdb/dispatcher/cdbgang_async.c
@@ -298,8 +298,7 @@ create_gang_retry:
 		MemoryContextSwitchTo(GangContext);
 
 		/* FTS shows some segment DBs are down */
-		if (isFTSEnabled() &&
-			FtsTestSegmentDBIsDown(newGangDefinition->db_descriptors, size))
+		if (FtsTestSegmentDBIsDown(newGangDefinition->db_descriptors, size))
 		{
 
 			DisconnectAndDestroyGang(newGangDefinition);

--- a/src/backend/cdb/dispatcher/cdbgang_thread.c
+++ b/src/backend/cdb/dispatcher/cdbgang_thread.c
@@ -224,8 +224,7 @@ create_gang_retry:
 	/* there'er failed connections */
 
 	/* FTS shows some segment DBs are down, destroy all gangs. */
-	if (isFTSEnabled() &&
-		FtsTestSegmentDBIsDown(newGangDefinition->db_descriptors, size))
+	if (FtsTestSegmentDBIsDown(newGangDefinition->db_descriptors, size))
 	{
 		appendPQExpBuffer(&create_gang_error, "FTS detected one or more segments are down\n");
 		goto exit;

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -2841,7 +2841,10 @@ retry1:
 			break;
 	}
 
-	SIMPLE_FAULT_INJECTOR(ProcessStartupPacketFault);
+	if (!am_ftshandler)
+	{
+		SIMPLE_FAULT_INJECTOR(ProcessStartupPacketFault);
+	}
 
 	return STATUS_OK;
 }

--- a/src/include/cdb/cdbfts.h
+++ b/src/include/cdb/cdbfts.h
@@ -45,7 +45,6 @@ typedef struct FtsProbeInfo
 
 typedef struct FtsControlBlock
 {
-	bool		ftsEnabled;
 	bool		ftsShutdownMaster;
 
 	LWLockId	ControlLock;
@@ -57,13 +56,7 @@ typedef struct FtsControlBlock
 
 }	FtsControlBlock;
 
-extern volatile bool *ftsEnabled;
-
 extern FtsProbeInfo *ftsProbeInfo;
-
-#define isFTSEnabled() (ftsEnabled != NULL && *ftsEnabled)
-
-#define disableFTS() (*ftsEnabled = false)
 
 extern int	FtsShmemSize(void);
 extern void FtsShmemInit(void);


### PR DESCRIPTION
commit 72dfe12abbf254204a55bbac225e00c0e559b1e1
    Remove unnecessary ftsEnabled variable

    This ftsEnabled variable is no longer necessary because FTS is always
    enabled now. Back in 4.3.x and 5.x, this variable was a representation
    of whether or not the cluster had filerep mirrors.

    Author: Xin Zhang <xzhang@pivotal.io>
    Author: Jimmy Yih <jyih@pivotal.io>

commit 2f14078d496fe1a1ccbe3769cd788da72e8e1302
    Disable ProcessStartupPacket fault injector for FTS handler process

    This was found in the dispatch ICG regress test where
    ProcessStartupPacket fault injector was being used. In this recent
    version of 6.0, FTS probe handler now uses ProcessStartupPacket. In
    addition to blocking the backend, this now blocks the FTS probe
    handler which caused failover to occur.

    Author: Xin Zhang <xzhang@pivotal.io>
    Author: Jimmy Yih <jyih@pivotal.io>

This should fix https://github.com/greenplum-db/gpdb/issues/4331.