### PR TITLE
Updating Memory accounting test query

### DIFF
--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v2.53.10@gpdb/stable
+orca/v2.53.11@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -121,7 +121,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget -q -O - https://github.com/greenplum-db/gporca/releases/download/v2.53.10/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget -q -O - https://github.com/greenplum-db/gporca/releases/download/v2.53.11/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/test/tinc/tincrepo/resource_management/memory_accounting/scenario/oom_test/answer/oom.ans
+++ b/src/test/tinc/tincrepo/resource_management/memory_accounting/scenario/oom_test/answer/oom.ans
@@ -17,23 +17,23 @@ select 2 as oom_test;
 (1 row)
 
 select count(*) from
-  (select l0.l_orderkey from
+  (select l0.l_partkey from
     (lineitem l0
-     left outer join lineitem l1 on l0.l_orderkey = l1.l_orderkey
-     left outer join lineitem l2 on l1.l_orderkey = l2.l_orderkey
-     left outer join lineitem l3 on l2.l_orderkey = l3.l_orderkey
-     left outer join lineitem l4 on l3.l_orderkey = l4.l_orderkey
-     left outer join lineitem l5 on l4.l_orderkey = l5.l_orderkey
-     left outer join lineitem l6 on l5.l_orderkey = l6.l_orderkey
-     left outer join lineitem l7 on l6.l_orderkey = l7.l_orderkey
-     left outer join lineitem l8 on l7.l_orderkey = l8.l_orderkey
-     left outer join lineitem l9 on l8.l_orderkey = l9.l_orderkey
-     left outer join lineitem l10 on l9.l_orderkey = l10.l_orderkey
-     left outer join lineitem l11 on l10.l_orderkey = l11.l_orderkey
-     left outer join lineitem l12 on l11.l_orderkey = l12.l_orderkey
-     left outer join lineitem l13 on l12.l_orderkey = l13.l_orderkey
-     left outer join lineitem l14 on l13.l_orderkey = l14.l_orderkey
-     left outer join lineitem l15 on l14.l_orderkey = l15.l_orderkey)
-    order by l0.l_orderkey) as foo;
+     left outer join lineitem l1 on l0.l_partkey = l1.l_partkey
+     left outer join lineitem l2 on l1.l_partkey = l2.l_partkey
+     left outer join lineitem l3 on l2.l_partkey = l3.l_partkey
+     left outer join lineitem l4 on l3.l_partkey = l4.l_partkey
+     left outer join lineitem l5 on l4.l_partkey = l5.l_partkey
+     left outer join lineitem l6 on l5.l_partkey = l6.l_partkey
+     left outer join lineitem l7 on l6.l_partkey = l7.l_partkey
+     left outer join lineitem l8 on l7.l_partkey = l8.l_partkey
+     left outer join lineitem l9 on l8.l_partkey = l9.l_partkey
+     left outer join lineitem l10 on l9.l_partkey = l10.l_partkey
+     left outer join lineitem l11 on l10.l_partkey = l11.l_partkey
+     left outer join lineitem l12 on l11.l_partkey = l12.l_partkey
+     left outer join lineitem l13 on l12.l_partkey = l13.l_partkey
+     left outer join lineitem l14 on l13.l_partkey = l14.l_partkey
+     left outer join lineitem l15 on l14.l_partkey = l15.l_partkey)
+    order by l0.l_partkey) as foo;
 psql:/data/suchitra/workspace/tincrepo/main/memory_accounting/scenario/oom_test/output/oom.sql:31: ERROR:  Out of memory  (seg0 slice12 rh55-qavm67:9655 pid=17870)
 DETAIL:  VM Protect failed to allocate 16384 bytes, 0 MB available

--- a/src/test/tinc/tincrepo/resource_management/memory_accounting/scenario/oom_test/answer/singlequery_oom.ans
+++ b/src/test/tinc/tincrepo/resource_management/memory_accounting/scenario/oom_test/answer/singlequery_oom.ans
@@ -17,23 +17,23 @@ select 1 as oom_test;
 (1 row)
 
 select count(*) from
-  (select l0.l_orderkey from
+  (select l0.l_partkey from
     (lineitem l0
-     left outer join lineitem l1 on l0.l_orderkey = l1.l_orderkey
-     left outer join lineitem l2 on l1.l_orderkey = l2.l_orderkey
-     left outer join lineitem l3 on l2.l_orderkey = l3.l_orderkey
-     left outer join lineitem l4 on l3.l_orderkey = l4.l_orderkey
-     left outer join lineitem l5 on l4.l_orderkey = l5.l_orderkey
-     left outer join lineitem l6 on l5.l_orderkey = l6.l_orderkey
-     left outer join lineitem l7 on l6.l_orderkey = l7.l_orderkey
-     left outer join lineitem l8 on l7.l_orderkey = l8.l_orderkey
-     left outer join lineitem l9 on l8.l_orderkey = l9.l_orderkey
-     left outer join lineitem l10 on l9.l_orderkey = l10.l_orderkey
-     left outer join lineitem l11 on l10.l_orderkey = l11.l_orderkey
-     left outer join lineitem l12 on l11.l_orderkey = l12.l_orderkey
-     left outer join lineitem l13 on l12.l_orderkey = l13.l_orderkey
-     left outer join lineitem l14 on l13.l_orderkey = l14.l_orderkey
-     left outer join lineitem l15 on l14.l_orderkey = l15.l_orderkey)
-    order by l0.l_orderkey) as foo;
+     left outer join lineitem l1 on l0.l_partkey = l1.l_partkey
+     left outer join lineitem l2 on l1.l_partkey = l2.l_partkey
+     left outer join lineitem l3 on l2.l_partkey = l3.l_partkey
+     left outer join lineitem l4 on l3.l_partkey = l4.l_partkey
+     left outer join lineitem l5 on l4.l_partkey = l5.l_partkey
+     left outer join lineitem l6 on l5.l_partkey = l6.l_partkey
+     left outer join lineitem l7 on l6.l_partkey = l7.l_partkey
+     left outer join lineitem l8 on l7.l_partkey = l8.l_partkey
+     left outer join lineitem l9 on l8.l_partkey = l9.l_partkey
+     left outer join lineitem l10 on l9.l_partkey = l10.l_partkey
+     left outer join lineitem l11 on l10.l_partkey = l11.l_partkey
+     left outer join lineitem l12 on l11.l_partkey = l12.l_partkey
+     left outer join lineitem l13 on l12.l_partkey = l13.l_partkey
+     left outer join lineitem l14 on l13.l_partkey = l14.l_partkey
+     left outer join lineitem l15 on l14.l_partkey = l15.l_partkey)
+    order by l0.l_partkey) as foo;
 psql:/data/suchitra/workspace/tincrepo/main/memory_accounting/scenario/oom_test/output/singlequery_oom.sql:31: ERROR:  Out of memory  (seg0 slice14 rh55-qavm67:9655 pid=30792)
 DETAIL:  VM Protect failed to allocate 524392 bytes, 0 MB available

--- a/src/test/tinc/tincrepo/resource_management/memory_accounting/scenario/oom_test/sql/oom.sql
+++ b/src/test/tinc/tincrepo/resource_management/memory_accounting/scenario/oom_test/sql/oom.sql
@@ -5,23 +5,27 @@
 
 show gp_vmem_protect_limit;
 
+--start_ignore
+set optimizer_enable_motion_redistribute=off;
+--end_ignore
+
 select 2 as oom_test;
 select count(*) from
-  (select l0.l_orderkey from
+  (select l0.l_partkey from
     (lineitem l0
-     left outer join lineitem l1 on l0.l_orderkey = l1.l_orderkey
-     left outer join lineitem l2 on l1.l_orderkey = l2.l_orderkey
-     left outer join lineitem l3 on l2.l_orderkey = l3.l_orderkey
-     left outer join lineitem l4 on l3.l_orderkey = l4.l_orderkey
-     left outer join lineitem l5 on l4.l_orderkey = l5.l_orderkey
-     left outer join lineitem l6 on l5.l_orderkey = l6.l_orderkey
-     left outer join lineitem l7 on l6.l_orderkey = l7.l_orderkey
-     left outer join lineitem l8 on l7.l_orderkey = l8.l_orderkey
-     left outer join lineitem l9 on l8.l_orderkey = l9.l_orderkey
-     left outer join lineitem l10 on l9.l_orderkey = l10.l_orderkey
-     left outer join lineitem l11 on l10.l_orderkey = l11.l_orderkey
-     left outer join lineitem l12 on l11.l_orderkey = l12.l_orderkey
-     left outer join lineitem l13 on l12.l_orderkey = l13.l_orderkey
-     left outer join lineitem l14 on l13.l_orderkey = l14.l_orderkey
-     left outer join lineitem l15 on l14.l_orderkey = l15.l_orderkey)
-    order by l0.l_orderkey) as foo;
+     left outer join lineitem l1 on l0.l_partkey = l1.l_partkey
+     left outer join lineitem l2 on l1.l_partkey = l2.l_partkey
+     left outer join lineitem l3 on l2.l_partkey = l3.l_partkey
+     left outer join lineitem l4 on l3.l_partkey = l4.l_partkey
+     left outer join lineitem l5 on l4.l_partkey = l5.l_partkey
+     left outer join lineitem l6 on l5.l_partkey = l6.l_partkey
+     left outer join lineitem l7 on l6.l_partkey = l7.l_partkey
+     left outer join lineitem l8 on l7.l_partkey = l8.l_partkey
+     left outer join lineitem l9 on l8.l_partkey = l9.l_partkey
+     left outer join lineitem l10 on l9.l_partkey = l10.l_partkey
+     left outer join lineitem l11 on l10.l_partkey = l11.l_partkey
+     left outer join lineitem l12 on l11.l_partkey = l12.l_partkey
+     left outer join lineitem l13 on l12.l_partkey = l13.l_partkey
+     left outer join lineitem l14 on l13.l_partkey = l14.l_partkey
+     left outer join lineitem l15 on l14.l_partkey = l15.l_partkey)
+    order by l0.l_partkey) as foo;

--- a/src/test/tinc/tincrepo/resource_management/memory_accounting/scenario/oom_test/sql/singlequery_oom.sql
+++ b/src/test/tinc/tincrepo/resource_management/memory_accounting/scenario/oom_test/sql/singlequery_oom.sql
@@ -4,24 +4,27 @@
 -- @description Single query that runs OOM
 
 show gp_vmem_protect_limit;
+-- start_ignore
+set optimizer_enable_motion_redistribute = off;
+-- end_ignore
 
 select 1 as oom_test;
 select count(*) from
-  (select l0.l_orderkey from
+  (select l0.l_partkey from
     (lineitem l0
-     left outer join lineitem l1 on l0.l_orderkey = l1.l_orderkey
-     left outer join lineitem l2 on l1.l_orderkey = l2.l_orderkey
-     left outer join lineitem l3 on l2.l_orderkey = l3.l_orderkey
-     left outer join lineitem l4 on l3.l_orderkey = l4.l_orderkey
-     left outer join lineitem l5 on l4.l_orderkey = l5.l_orderkey
-     left outer join lineitem l6 on l5.l_orderkey = l6.l_orderkey
-     left outer join lineitem l7 on l6.l_orderkey = l7.l_orderkey
-     left outer join lineitem l8 on l7.l_orderkey = l8.l_orderkey
-     left outer join lineitem l9 on l8.l_orderkey = l9.l_orderkey
-     left outer join lineitem l10 on l9.l_orderkey = l10.l_orderkey
-     left outer join lineitem l11 on l10.l_orderkey = l11.l_orderkey
-     left outer join lineitem l12 on l11.l_orderkey = l12.l_orderkey
-     left outer join lineitem l13 on l12.l_orderkey = l13.l_orderkey
-     left outer join lineitem l14 on l13.l_orderkey = l14.l_orderkey
-     left outer join lineitem l15 on l14.l_orderkey = l15.l_orderkey)
-    order by l0.l_orderkey) as foo;
+     left outer join lineitem l1 on l0.l_partkey = l1.l_partkey
+     left outer join lineitem l2 on l1.l_partkey = l2.l_partkey
+     left outer join lineitem l3 on l2.l_partkey = l3.l_partkey
+     left outer join lineitem l4 on l3.l_partkey = l4.l_partkey
+     left outer join lineitem l5 on l4.l_partkey = l5.l_partkey
+     left outer join lineitem l6 on l5.l_partkey = l6.l_partkey
+     left outer join lineitem l7 on l6.l_partkey = l7.l_partkey
+     left outer join lineitem l8 on l7.l_partkey = l8.l_partkey
+     left outer join lineitem l9 on l8.l_partkey = l9.l_partkey
+     left outer join lineitem l10 on l9.l_partkey = l10.l_partkey
+     left outer join lineitem l11 on l10.l_partkey = l11.l_partkey
+     left outer join lineitem l12 on l11.l_partkey = l12.l_partkey
+     left outer join lineitem l13 on l12.l_partkey = l13.l_partkey
+     left outer join lineitem l14 on l13.l_partkey = l14.l_partkey
+     left outer join lineitem l15 on l14.l_partkey = l15.l_partkey)
+    order by l0.l_partkey) as foo;


### PR DESCRIPTION
The existing memory accounting test for OOM was not able to exceed the
OOM bound due to the plan generated by ORCA v2.53.11. Prior to that the
it would hit the OOM limit.  This commit updates the
test query to exceed OOM with the latest version of ORCA and also bump
the version to 2.53.11.

Signed-off-by: Abhijit Subramanya <asubramanya@pivotal.io>