### PR TITLE
Set tupledesc in remapper only when remapping is required.

### DIFF
--- a/src/backend/cdb/motion/tupleremap.c
+++ b/src/backend/cdb/motion/tupleremap.c
@@ -201,9 +201,13 @@ TRCheckAndRemap(TupleRemapper *remapper, TupleDesc tupledesc, GenericTuple tuple
 	if (!remapper->field_remapinfo)
 	{
 		Assert(remapper->tupledesc == NULL);
-		remapper->tupledesc = tupledesc;
 		remapper->field_remapinfo = BuildFieldRemapInfo(tupledesc,
 														remapper->mycontext);
+		if (remapper->field_remapinfo != NULL)
+		{
+			/* Remapping is required. Save a copy of the tupledesc */
+			remapper->tupledesc = tupledesc;
+		}
 	}
 
 	return TRRemapTuple(remapper, tupledesc, remapper->field_remapinfo, tuple);

--- a/src/test/regress/input/transient_types.source
+++ b/src/test/regress/input/transient_types.source
@@ -176,5 +176,22 @@ INSERT INTO typemod_init VALUES ('A');
 SELECT C FROM ( SELECT B.varchar_col FROM ( SELECT A.varchar_col FROM typemod_init A) B GROUP BY B.varchar_col) C;
 DROP TABLE typemod_init ;
 
+-- Test the case that there is no fields require remapping, such as VOIDOID
+DROP TABLE IF EXISTS t_nomap;
+CREATE TABLE t_nomap AS SELECT f1 FROM generate_series(1,10) f1;
+CREATE OR REPLACE FUNCTION foo()
+RETURNS VOID
+AS $$
+BEGIN
+
+END
+$$
+LANGUAGE plpgsql
+IMMUTABLE;
+
+SELECT q FROM (SELECT max(f1) AS max FROM t_nomap GROUP BY f1 ORDER BY f1) q ORDER BY max;
+SELECT foo() FROM t_nomap;
+DROP TABLE t_nomap;
+DROP FUNCTION foo();
 
 drop schema transient_types;

--- a/src/test/regress/output/transient_types.source
+++ b/src/test/regress/output/transient_types.source
@@ -400,4 +400,51 @@ SELECT C FROM ( SELECT B.varchar_col FROM ( SELECT A.varchar_col FROM typemod_in
 (1 row)
 
 DROP TABLE typemod_init ;
+-- Test the case that there is no fields require remapping, such as VOIDOID
+DROP TABLE IF EXISTS t_nomap;
+NOTICE:  table "t_nomap" does not exist, skipping
+CREATE TABLE t_nomap AS SELECT f1 FROM generate_series(1,10) f1;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'f1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE OR REPLACE FUNCTION foo()
+RETURNS VOID
+AS $$
+BEGIN
+
+END
+$$
+LANGUAGE plpgsql
+IMMUTABLE;
+SELECT q FROM (SELECT max(f1) AS max FROM t_nomap GROUP BY f1 ORDER BY f1) q ORDER BY max;
+  q   
+------
+ (1)
+ (2)
+ (3)
+ (4)
+ (5)
+ (6)
+ (7)
+ (8)
+ (9)
+ (10)
+(10 rows)
+
+SELECT foo() FROM t_nomap;
+ foo 
+-----
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+(10 rows)
+
+DROP TABLE t_nomap;
+DROP FUNCTION foo();
 drop schema transient_types;


### PR DESCRIPTION
When build remap info for fields of type described by given
tupledesc, set tupledesc in remapper only when remapping
is required.