### PR TITLE
make_etags: avoid recursive symbolic creation.

### DIFF
--- a/src/tools/make_etags
+++ b/src/tools/make_etags
@@ -6,8 +6,3 @@ rm -f ./TAGS
 
 find `pwd`/ -type f -name '*.[chyl]' -print |
 	xargs etags --append -o TAGS
-
-find . \( -name CVS -prune \) -o \( -name .git -prune \) -o -type d -print |
-while read DIR
-do	[ "$DIR" != "." ] && ln -f -s `pwd`/TAGS "$DIR"
-done


### PR DESCRIPTION
It works fine without all those links in each and every directory in source code
so remove the extra work and annoyance.