### PR TITLE
gpload supports user to definite external staging table name

### DIFF
--- a/gpMgmt/bin/gpload_test/gpload2/TEST.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST.py
@@ -95,7 +95,7 @@ d = mkpath('config')
 if not os.path.exists(d):
     os.mkdir(d)
 
-def write_config_file(mode='insert', reuse_flag='',columns_flag='0',mapping='0',portNum='8081',database='reuse_gptest',host='localhost',formatOpts='text',file='data/external_file_01.txt',table='texttable',format='text',delimiter="'|'",escape='',quote='',truncate='False',log_errors=None, error_limit='0',error_table=None,externalSchema=None):
+def write_config_file(mode='insert', reuse_flag='',columns_flag='0',mapping='0',portNum='8081',database='reuse_gptest',host='localhost',formatOpts='text',file='data/external_file_01.txt',table='texttable',format='text',delimiter="'|'",escape='',quote='',truncate='False',log_errors=None, error_limit='0',error_table=None,externalSchema=None,staging_table=None):
 
     f = open(mkpath('config/config_file'),'w')
     f.write("VERSION: 1.0.0.1")
@@ -177,6 +177,8 @@ def write_config_file(mode='insert', reuse_flag='',columns_flag='0',mapping='0',
         f.write("\n    - SCHEMA: "+externalSchema)
     f.write("\n   PRELOAD:")
     f.write("\n    - REUSE_TABLES: "+reuse_flag)
+    if staging_table:
+        f.write("\n    - STAGING_TABLE: "+staging_table)
     f.write("\n")
     f.close()
 
@@ -423,7 +425,7 @@ class GPLoad_FormatOpts_TestCase(unittest.TestCase):
 
     def test_00_gpload_formatOpts_setup(self):
         "0  gpload setup"
-        for num in range(1,25):
+        for num in range(1,29):
            f = open(mkpath('query%d.sql' % num),'w')
            f.write("\! gpload -f "+mkpath('config/config_file')+ " -d reuse_gptest\n"+"\! gpload -f "+mkpath('config/config_file')+ " -d reuse_gptest\n")
            f.close()
@@ -617,6 +619,46 @@ class GPLoad_FormatOpts_TestCase(unittest.TestCase):
         copy_data('large_file.csv','data_file.csv')
         write_config_file(reuse_flag='true',formatOpts='csv',file='data_file.csv',table='csvtable',format='csv',delimiter="','",log_errors=True,error_limit='90000000',externalSchema='test')
         self.doTest(24)
+    def test_25_gpload_ext_staging_table(self):
+        "25  gpload reuse ext_staging_table if it is configured"
+        file = mkpath('setup.sql')
+        runfile(file)
+        f = open(mkpath('query25.sql'),'a')
+        f.write("\! psql -d reuse_gptest -c 'select count(*) from csvtable;'")
+        f.close()
+        copy_data('external_file_13.csv','data_file.csv')
+        write_config_file(reuse_flag='true',formatOpts='csv',file='data_file.csv',table='csvtable',format='csv',delimiter="','",log_errors=True,error_limit='10',staging_table='staging_table')
+        self.doTest(25)
+    def test_26_gpload_ext_staging_table_with_externalschema(self):
+        "26  gpload reuse ext_staging_table if it is configured with externalschema"
+        file = mkpath('setup.sql')
+        runfile(file)
+        f = open(mkpath('query26.sql'),'a')
+        f.write("\! psql -d reuse_gptest -c 'select count(*) from csvtable;'")
+        f.close()
+        copy_data('external_file_13.csv','data_file.csv')
+        write_config_file(reuse_flag='true',formatOpts='csv',file='data_file.csv',table='csvtable',format='csv',delimiter="','",log_errors=True,error_limit='10',staging_table='staging_table',externalSchema='test')
+        self.doTest(26)
+    def test_27_gpload_ext_staging_table_with_externalschema(self):
+        "27  gpload reuse ext_staging_table if it is configured with externalschema"
+        file = mkpath('setup.sql')
+        runfile(file)
+        f = open(mkpath('query27.sql'),'a')
+        f.write("\! psql -d reuse_gptest -c 'select count(*) from test.csvtable;'")
+        f.close()
+        copy_data('external_file_13.csv','data_file.csv')
+        write_config_file(reuse_flag='true',formatOpts='csv',file='data_file.csv',table='test.csvtable',format='csv',delimiter="','",log_errors=True,error_limit='10',staging_table='staging_table',externalSchema="'%'")
+        self.doTest(27)
+    def test_28_gpload_ext_staging_table_with_dot(self):
+        "28  gpload reuse ext_staging_table if it is configured with dot"
+        file = mkpath('setup.sql')
+        runfile(file)
+        f = open(mkpath('query28.sql'),'a')
+        f.write("\! psql -d reuse_gptest -c 'select count(*) from test.csvtable;'")
+        f.close()
+        copy_data('external_file_13.csv','data_file.csv')
+        write_config_file(reuse_flag='true',formatOpts='csv',file='data_file.csv',table='test.csvtable',format='csv',delimiter="','",log_errors=True,error_limit='10',staging_table='t.staging_table')
+        self.doTest(28)
 
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(GPLoad_FormatOpts_TestCase)

--- a/gpMgmt/bin/gpload_test/gpload2/data/external_file_13.csv
+++ b/gpMgmt/bin/gpload_test/gpload2/data/external_file_13.csv
@@ -1,0 +1,2 @@
+123,abc,abc,abc,1.23
+234,bcd,bcd,bcd,2.34

--- a/gpMgmt/bin/gpload_test/gpload2/query25.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query25.ans
@@ -1,0 +1,22 @@
+2018-01-17 21:31:13|INFO|gpload session started 2018-01-17 21:31:13
+2018-01-17 21:31:13|INFO|setting schema 'public' for table 'csvtable'
+2018-01-17 21:31:13|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/lhl/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.csv" -t 30
+2018-01-17 21:31:13|INFO|running time: 0.09 seconds
+2018-01-17 21:31:13|INFO|rows Inserted          = 2
+2018-01-17 21:31:13|INFO|rows Updated           = 0
+2018-01-17 21:31:13|INFO|data formatting errors = 0
+2018-01-17 21:31:13|INFO|gpload succeeded
+2018-01-17 21:31:13|INFO|gpload session started 2018-01-17 21:31:13
+2018-01-17 21:31:13|INFO|setting schema 'public' for table 'csvtable'
+2018-01-17 21:31:13|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/lhl/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.csv" -t 30
+2018-01-17 21:31:13|INFO|reusing external staging table staging_table
+2018-01-17 21:31:13|INFO|running time: 0.08 seconds
+2018-01-17 21:31:13|INFO|rows Inserted          = 2
+2018-01-17 21:31:13|INFO|rows Updated           = 0
+2018-01-17 21:31:13|INFO|data formatting errors = 0
+2018-01-17 21:31:13|INFO|gpload succeeded
+ count 
+-------
+     4
+(1 row)
+

--- a/gpMgmt/bin/gpload_test/gpload2/query26.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query26.ans
@@ -1,0 +1,22 @@
+2018-01-17 21:36:48|INFO|gpload session started 2018-01-17 21:36:48
+2018-01-17 21:36:48|INFO|setting schema 'public' for table 'csvtable'
+2018-01-17 21:36:48|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/lhl/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.csv" -t 30
+2018-01-17 21:36:48|INFO|running time: 0.09 seconds
+2018-01-17 21:36:48|INFO|rows Inserted          = 2
+2018-01-17 21:36:48|INFO|rows Updated           = 0
+2018-01-17 21:36:48|INFO|data formatting errors = 0
+2018-01-17 21:36:48|INFO|gpload succeeded
+2018-01-17 21:36:48|INFO|gpload session started 2018-01-17 21:36:48
+2018-01-17 21:36:48|INFO|setting schema 'public' for table 'csvtable'
+2018-01-17 21:36:48|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/lhl/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.csv" -t 30
+2018-01-17 21:36:48|INFO|reusing external staging table test.staging_table
+2018-01-17 21:36:48|INFO|running time: 0.08 seconds
+2018-01-17 21:36:48|INFO|rows Inserted          = 2
+2018-01-17 21:36:48|INFO|rows Updated           = 0
+2018-01-17 21:36:48|INFO|data formatting errors = 0
+2018-01-17 21:36:48|INFO|gpload succeeded
+ count 
+-------
+     4
+(1 row)
+

--- a/gpMgmt/bin/gpload_test/gpload2/query27.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query27.ans
@@ -1,0 +1,20 @@
+2018-01-17 21:43:21|INFO|gpload session started 2018-01-17 21:43:21
+2018-01-17 21:43:21|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/lhl/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.csv" -t 30
+2018-01-17 21:43:21|INFO|running time: 0.09 seconds
+2018-01-17 21:43:21|INFO|rows Inserted          = 2
+2018-01-17 21:43:21|INFO|rows Updated           = 0
+2018-01-17 21:43:21|INFO|data formatting errors = 0
+2018-01-17 21:43:21|INFO|gpload succeeded
+2018-01-17 21:43:21|INFO|gpload session started 2018-01-17 21:43:21
+2018-01-17 21:43:22|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/lhl/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.csv" -t 30
+2018-01-17 21:43:22|INFO|reusing external staging table test.staging_table
+2018-01-17 21:43:22|INFO|running time: 0.08 seconds
+2018-01-17 21:43:22|INFO|rows Inserted          = 2
+2018-01-17 21:43:22|INFO|rows Updated           = 0
+2018-01-17 21:43:22|INFO|data formatting errors = 0
+2018-01-17 21:43:22|INFO|gpload succeeded
+ count 
+-------
+     4
+(1 row)
+

--- a/gpMgmt/bin/gpload_test/gpload2/query28.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query28.ans
@@ -1,0 +1,19 @@
+2018-01-18 04:07:25|INFO|gpload session started 2018-01-18 04:07:25
+2018-01-18 04:07:25|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/lhl/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.csv" -t 30
+2018-01-18 04:07:25|ERROR|Character '.' is not allowed in staging_table parameter. Please use EXTERNAL->SCHEMA to set the schema of external table
+2018-01-18 04:07:25|INFO|rows Inserted          = 0
+2018-01-18 04:07:25|INFO|rows Updated           = 0
+2018-01-18 04:07:25|INFO|data formatting errors = 0
+2018-01-18 04:07:25|INFO|gpload failed
+2018-01-18 04:07:25|INFO|gpload session started 2018-01-18 04:07:25
+2018-01-18 04:07:25|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/lhl/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.csv" -t 30
+2018-01-18 04:07:25|ERROR|Character '.' is not allowed in staging_table parameter. Please use EXTERNAL->SCHEMA to set the schema of external table
+2018-01-18 04:07:25|INFO|rows Inserted          = 0
+2018-01-18 04:07:25|INFO|rows Updated           = 0
+2018-01-18 04:07:25|INFO|data formatting errors = 0
+2018-01-18 04:07:25|INFO|gpload failed
+ count 
+-------
+     0
+(1 row)
+

--- a/gpMgmt/bin/gpload_test/gpload2/setup.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/setup.ans
@@ -5,6 +5,8 @@ CREATE DATABASE
 You are now connected to database "reuse_gptest" as user "gpadmin".
 CREATE SCHEMA test;
 CREATE SCHEMA
+DROP EXTERNAL TABLE IF EXISTS temp_gpload_staging_table;
+DROP EXTERNAL TABLE
 DROP TABLE IF EXISTS texttable;
 NOTICE:  table "texttable" does not exist, skipping
 DROP TABLE
@@ -17,6 +19,10 @@ CREATE TABLE texttable (
             n5 numeric, n6 real, n7 double precision) DISTRIBUTED BY (n1);
 CREATE TABLE
 CREATE TABLE csvtable (
+	    year int, make text, model text, decription text, price decimal)
+            DISTRIBUTED BY (year);
+CREATE TABLE
+CREATE TABLE test.csvtable (
 	    year int, make text, model text, decription text, price decimal)
             DISTRIBUTED BY (year);
 CREATE TABLE

--- a/gpMgmt/bin/gpload_test/gpload2/setup.sql
+++ b/gpMgmt/bin/gpload_test/gpload2/setup.sql
@@ -6,6 +6,7 @@ CREATE DATABASE reuse_gptest;
 
 CREATE SCHEMA test;
 
+DROP EXTERNAL TABLE IF EXISTS temp_gpload_staging_table;
 DROP TABLE IF EXISTS texttable;
 DROP TABLE IF EXISTS csvtable;
 CREATE TABLE texttable (
@@ -13,5 +14,8 @@ CREATE TABLE texttable (
             n1 smallint, n2 integer, n3 bigint, n4 decimal,
             n5 numeric, n6 real, n7 double precision) DISTRIBUTED BY (n1);
 CREATE TABLE csvtable (
+	    year int, make text, model text, decription text, price decimal)
+            DISTRIBUTED BY (year);
+CREATE TABLE test.csvtable (
 	    year int, make text, model text, decription text, price decimal)
             DISTRIBUTED BY (year);


### PR DESCRIPTION
Support EXT_STAGING_TABLE option in configuration file for user
 to definite the reusing external table by themselves instead of
searching in gpload, which may have bad performance if there are
too many external tables.