### PR TITLE
Add tablespace test cases in gpinitstandby.

### DIFF
--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/gpinitstandby/__init__.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/gpinitstandby/__init__.py
@@ -22,6 +22,7 @@ import pexpect as pexpect
 
 import tinctest
 from tinctest.lib import local_path
+from gppylib.commands import base
 from gppylib.commands.base import Command
 from mpp.lib.config import GPDBConfig
 from mpp.lib.PSQL import PSQL
@@ -54,9 +55,10 @@ class GpinitStandby(object):
             return False
         return True
 
-    def verify_gpinitstandby(self, primary_pid):  
+    def verify_gpinitstandby(self, primary_pid, datadir):
         '''Verify the presence of standby in recovery mode '''
-        if (self.stdby.check_gp_segment_config()) and (self.stdby.check_pg_stat_replication()) and (self.stdby.check_standby_processes())and self.compare_primary_pid(primary_pid) :
+        tinctest.logger.info("verify standby...")
+        if (self.stdby.check_gp_segment_config(datadir)) and (self.stdby.check_pg_stat_replication()) and (self.stdby.check_standby_processes())and self.compare_primary_pid(primary_pid) :
             return True
         return False
 
@@ -146,3 +148,13 @@ class GpinitStandby(object):
             return False
         child.close()
         return True
+
+    def check_dir_exist_on_standby(self, standby, location):
+        cmd = Command(name='Make dierctory on standby before running the command', cmdStr = 'ls -l %s' % location, ctxt = base.REMOTE, remoteHost = standby)
+        tinctest.logger.info('%s' % cmd)
+        cmd.run(validateAfter=True)
+        result = cmd.get_results()
+        if result.rc != 0:
+            return False
+        else:
+            return True

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/gpinitstandby/drop_filespace.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/gpinitstandby/drop_filespace.sql
@@ -1,6 +1,0 @@
--- start_ignore
-SET gp_create_table_random_default_distribution=off;
--- end_ignore
-DROP TABLE  fs_walrepl_table;
-DROP TABLESPACE ts_walrepl_a;
-DROP FILESPACE fs_walrepl_a;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/gpinitstandby/tablespace.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/gpinitstandby/tablespace.sql
@@ -1,6 +1,4 @@
 -- start_ignore
 SET gp_create_table_random_default_distribution=off;
 -- end_ignore
-CREATE TABLESPACE ts_walrepl_a FILESPACE fs_walrepl_a; 
-
 CREATE TABLE fs_walrepl_table(a int, b int) TABLESPACE ts_walrepl_a;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/gpinitstandby/test_gpinitstandby.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/gpinitstandby/test_gpinitstandby.py
@@ -112,50 +112,45 @@ class GpinitStandsbyTestCase(MPPTestCase):
     def test_gpinitstanby_to_new_host(self):
         self.create_directory(self.mdd)
         self.assertTrue(self.gp.run(option = '-s %s' % self.standby))
-        self.assertTrue(self.gp.verify_gpinitstandby(self.primary_pid))
+        self.assertTrue(self.gp.verify_gpinitstandby(self.primary_pid, self.mdd))
 
 
     def test_gpinitstandby_to_same_host_new_port_and_new_mdd(self):
         pgutil.clean_dir(self.host,self.standby_loc)
         self.assertTrue(self.gp.run(option = '-P %s -s %s -F %s' % (self.standby_port, self.host, self.standby_loc)))
-        self.assertTrue(self.gp.verify_gpinitstandby(self.primary_pid))
+        self.assertTrue(self.gp.verify_gpinitstandby(self.primary_pid, self.standby_loc))
         
 
     @unittest.skipIf(not config.is_multinode(), "Test applies only to a multinode cluster")
     def test_gpinitstandby_new_host_new_port(self):
         self.create_directory(self.mdd)
         self.assertTrue(self.gp.run(option = '-P %s -s %s' % (self.standby_port, self.standby)))
-        self.assertTrue(self.gp.verify_gpinitstandby(self.primary_pid))
+        self.assertTrue(self.gp.verify_gpinitstandby(self.primary_pid, self.mdd))
 
     @unittest.skipIf(not config.is_multinode(), "Test applies only to a multinode cluster")
     def test_gpinitstandby_new_host_new_mdd(self):
         self.create_directory(self.standby_loc)
         self.assertTrue(self.gp.run(option = '-F %s -s %s' % (self.standby_loc, self.standby)))
-        self.assertTrue(self.gp.verify_gpinitstandby(self.primary_pid))
+        self.assertTrue(self.gp.verify_gpinitstandby(self.primary_pid, self.standby_loc))
     
-	# WALREP_FIXME: Enable this after tablespace with walrep works
-    #def test_gpinitstandby_to_same_with_filespaces(self):
-    #    from mpp.lib.gpfilespace import Gpfilespace
-    #    gpfile = Gpfilespace()
-    #    gpfile.create_filespace('fs_walrepl_a')
-    #    PSQL.run_sql_file(local_path('filespace.sql'), dbname = self.db_name)
-    #    filespace_loc = self.gp.get_filespace_location() 
-    #    filespace_loc = os.path.join(os.path.split(filespace_loc)[0], 'newstandby')
-    #    filespaces = "pg_system:%s,fs_walrepl_a:%s" %(self.standby_loc , filespace_loc)
-    #    self.assertTrue(self.gp.run(option = '-F %s -s %s -P %s' % (filespaces, self.host, self.standby_port)))
-    #    self.assertTrue(self.gp.verify_gpinitstandby(self.primary_pid))
-    #
-    #@unittest.skipIf(not config.is_multinode(), "Test applies only to a multinode cluster")
-    #def test_gpinitstandby_new_host_with_filespace(self):
-    #    from mpp.lib.gpfilespace import Gpfilespace
-    #    gpfile = Gpfilespace()
-    #    gpfile.create_filespace('fs_walrepl_a')
-    #    PSQL.run_sql_file(local_path('filespace.sql'), dbname = self.db_name)
-    #    filespace_loc = self.gp.get_filespace_location()
-    #    self.create_directory(filespace_loc)
-    #    filespaces = "pg_system:%s,fs_walrepl_a:%s" % (self.mdd, filespace_loc)
-    #    self.assertTrue(self.gp.run(option = '-F %s -s %s -P %s' % (filespaces, self.standby, self.standby_port)))
-    #    self.assertTrue(self.gp.verify_gpinitstandby(self.primary_pid))
+    def test_gpinitstandby_to_same_with_tablespace(self):
+        from mpp.lib.gptablespace import Gptablespace
+        gptablespace = Gptablespace()
+        gptablespace.create_tablespace('ts_walrepl_a','/tmp/tbl')
+        PSQL.run_sql_file(local_path('tablespace.sql'), dbname = self.db_name)
+        self.assertTrue(self.gp.run(option = '-F %s -s %s -P %s' % (self.standby_loc, self.host, self.standby_port)))
+        self.assertTrue(self.gp.verify_gpinitstandby(self.primary_pid, self.standby_loc))
+        #self.assertTrue(self.gp.check_dir_exist_on_standby(self.host, gptablespace.get_standby_tablespace_directory('ts_walrepl_a')))
+
+    @unittest.skipIf(not config.is_multinode(), "Test applies only to a multinode cluster")
+    def test_gpinitstandby_new_host_with_tablespace(self):
+        from mpp.lib.gptablespace import Gptablespace
+        gptablespace = Gptablespace()
+        gptablespace.create_tablespace('ts_walrepl_a', '/tmp/tbl')
+        PSQL.run_sql_file(local_path('tablespace.sql'), dbname = self.db_name)
+        self.assertTrue(self.gp.run(option = '-F %s -s %s -P %s' % (self.standby_loc, self.standby, self.standby_port)))
+        self.assertTrue(self.gp.verify_gpinitstandby(self.primary_pid, self.standby_loc))
+        #self.assertTrue(self.gp.check_dir_exist_on_standby(self.standby, gptablespace.get_standby_tablespace_directory('ts_walrepl_a')))
     
     def test_gpinitstandby_remove_from_same_host(self):
         #self.gp.create_dir_on_standby(self.host, self.standby_loc)
@@ -188,16 +183,6 @@ class GpinitStandsbyTestCase(MPPTestCase):
     def test_gpinitstandby_with_no_default_path(self):
         self.assertTrue(self.gp.initstand_by_with_default())
     
-	# WALREP_FIXME: Enable this after tablespace with walrep works
-    #@unittest.skipIf(not config.is_multinode(), "Test applies only to a multinode cluster")
-    #def test_gpinitstandby_prompt_for_filespace(self):
-    #    from mpp.lib.gpfilespace import Gpfilespace
-    #    gpfile = Gpfilespace()
-    #    gpfile.create_filespace('fs_walrepl_a')
-    #    PSQL.run_sql_file(local_path('filespace.sql'), dbname = self.db_name)
-    #    filespace_loc = self.gp.get_filespace_location()
-    #    self.create_directory(filespace_loc)
-    #    self.assertTrue(self.gp.init_with_prompt(filespace_loc))
 
     def test_gpinistandby_with_M(self):
         '''

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/lib/verify.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/lib/verify.py
@@ -69,12 +69,15 @@ class StandbyVerify(object):
                     pg_stat_replication
              """)
 
-    def check_gp_segment_config(self):
+    def check_gp_segment_config(self, datadir = None):
         ''' Check for the new entry in gp_segment_configuration'''
         sm_count = PSQL.run_sql_command("select count(*) from gp_segment_configuration where content='-1' and role='m';", flags='-q -t', dbname='postgres')
         if int(sm_count.strip()) != 1:
             return False
         tinctest.logger.info('A new entry is added for standby in gp_segment_configuration')
+        result = PSQL.run_sql_command("select datadir from gp_segment_configuration where content='-1' and role='m';", flags='-q -t', dbname='postgres')
+        if datadir is not None and datadir != result.strip():
+            return False
         return True
 
     def check_pg_stat_replication(self):
@@ -133,4 +136,7 @@ class StandbyVerify(object):
         if len(standby_processes) != len(process_list):
             return False
         tinctest.logger.info('All the standby processes are present at standby host''')
+        return True
+
+    def check_standby_tablespace(self):
         return True

--- a/src/test/tinc/tincrepo/mpp/lib/gptablespace.py
+++ b/src/test/tinc/tincrepo/mpp/lib/gptablespace.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+"""
+Copyright (c) 2004-Present Pivotal Software, Inc.
+
+This program and the accompanying materials are made available under
+the terms of the under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+############################################################################
+import os
+import re
+
+import tinctest
+from gppylib.commands.base import Command
+from mpp.lib.PSQL import PSQL
+from mpp.lib.config import GPDBConfig
+from tinctest.lib import local_path, run_shell_command
+from tinctest.main import TINCException
+
+class GPtablespaceException(TINCException): pass
+class Gptablespace(object):
+
+    def __init__(self, config=None):
+        if config is not None:
+            self.config = config
+        else:
+            self.config = GPDBConfig()
+
+    def get_standby_tablespace_directory(self, tablespace):
+        '''
+        Get the standby tablespace directory location
+        @param tablespace: tablespace name
+        @return dir: standby tablespace directory
+        '''
+        sql_cmd = "SELECT dbid from gp_segment_configuration where content = -1 and role = 'm'";
+        dbid = int(PSQL.run_sql_command(sql_cmd, flags = '-t -q -c', dbname='postgres'))
+        sql_cmd = ("SELECT gp_tablespace_path(spclocation, %d) FROM pg_tablespace WHERE spcname <> %s") % (dbid, tablespace)
+        dir = PSQL.run_sql_command(sql_cmd, flags = '-t -q', dbname='postgres')
+        return dir
+
+    def exists(self, tablespace):
+        '''
+        Check whether tablespace exist in catalog
+        @param tablespace:tablespace name
+        @return True or False
+        '''
+        fs_out = PSQL.run_sql_command("select count(*) from pg_tablespace where spcname='%s'" % tablespace, flags = '-t -q', dbname='postgres')
+        if int(fs_out.strip()) > 0:
+            return True
+        return False
+
+    def create_tablespace(self, tablespace, loc):
+        '''
+        @param tablespace: Tablespace Name
+        @param loc: Tablespace location
+        '''
+        if self.exists(tablespace) is True:
+            tinctest.logger.info('tablespace %s exists' % tablespace)
+            return
+
+        for record in self.config.record:
+            cmd = "gpssh -h %s -e 'rm -rf %s; mkdir -p %s'"  % (record.hostname, loc, loc)
+            run_shell_command(cmd)
+        tinctest.logger.info('create tablespace %s' % tablespace)
+        sql_cmd = 'create tablespace %s location \'%s\'' % (tablespace, loc)
+        PSQL.run_sql_command(sql_cmd, flags = '-t -q -c', dbname='postgres')
+


### PR DESCRIPTION
* Add two test cases, test_gpinitstandby_to_same_with_tablespace
  and test_gpinitstandby_new_host_with_tablespace. The first one
  creates a new tablespace and gpinitstandby on master host. The
  second one also creates a new tablespace firstly,but then
  gpinitstandby on another host instead.

* Remove test_gpinitstandby_prompt_for_filespace test case.

As the pr copying tablespace from primary to standby with standby
dbid is not merged, the codes checking the standby tablespace
directory is commented out curruntlly.

Author: Max Yang <myang@pivotal.io>
Author: Xiaoran Wang <xiwang@pivotal.io>