### PR TITLE
Misc cleanups to avoid silly merge conflicts

### DIFF
--- a/src/backend/access/hash/hash.c
+++ b/src/backend/access/hash/hash.c
@@ -271,9 +271,10 @@ hashgettuple(PG_FUNCTION_ARGS)
 	/* Release read lock on current buffer, but keep it pinned */
 	if (BufferIsValid(so->hashso_curbuf))
 		_hash_chgbufaccess(rel, so->hashso_curbuf, HASH_READ, HASH_NOLOCK);
-	
+
 	PG_RETURN_BOOL(res);
 }
+
 
 /*
  * hashgetbitmap() -- get all tuples at once
@@ -329,6 +330,7 @@ hashgetbitmap(PG_FUNCTION_ARGS)
 
 	PG_RETURN_POINTER(tbm);
 }
+
 
 /*
  *	hashbeginscan() -- start a scan on a hash index

--- a/src/backend/access/transam/varsup.c
+++ b/src/backend/access/transam/varsup.c
@@ -77,15 +77,15 @@ GetNewTransactionId(bool isSubXact, bool setProcXid)
 		 * To avoid swamping the postmaster with signals, we issue the
 		 * autovac request only once per 64K transaction starts.  This
 		 * still gives plenty of chances before we get into real trouble.
-		 *
-		 * if (IsUnderPostmaster && (xid % 65536) == 0)
-		 * {
-		 * 		elog(LOG, "GetNewTransactionId: requesting autovac (xid %u xidVacLimit %u)", xid, ShmemVariableCache->xidVacLimit);
-		 * 		SendPostmasterSignal(PMSIGNAL_START_AUTOVAC);
-		 * }
-		 *
-		 * MPP-19652: autovacuum disabled
 		 */
+		/* MPP-19652: autovacuum disabled */
+#if 0
+		if (IsUnderPostmaster && (xid % 65536) == 0)
+		{
+			elog(LOG, "GetNewTransactionId: requesting autovac (xid %u xidVacLimit %u)", xid, ShmemVariableCache->xidVacLimit);
+			SendPostmasterSignal(PMSIGNAL_START_AUTOVAC);
+		}
+#endif
 		if (IsUnderPostmaster &&
 		 TransactionIdFollowsOrEquals(xid, ShmemVariableCache->xidStopLimit))
 			ereport(ERROR,
@@ -274,14 +274,15 @@ SetTransactionIdLimit(TransactionId oldest_datfrozenxid,
 	 * assign hook (too many processes would try to execute the hook,
 	 * resulting in race conditions as well as crashes of those not connected
 	 * to shared memory).  Perhaps this can be improved someday.
-	 *
-	 * MPP-19652: autovacuum disabled
-	 * 
-	 *	xidVacLimit = oldest_datfrozenxid + autovacuum_freeze_max_age;
-	 *	if (xidVacLimit < FirstNormalTransactionId)
-	 *		xidVacLimit += FirstNormalTransactionId;
 	 */
+	/* MPP-19652: autovacuum disabled */
+#if 0
+	xidVacLimit = oldest_datfrozenxid + autovacuum_freeze_max_age;
+	if (xidVacLimit < FirstNormalTransactionId)
+		xidVacLimit += FirstNormalTransactionId;
+#else
 	xidVacLimit = xidWarnLimit;
+#endif
 
 	/* Grab lock for just long enough to set the new limit values */
 	LWLockAcquire(XidGenLock, LW_EXCLUSIVE);
@@ -305,9 +306,13 @@ SetTransactionIdLimit(TransactionId oldest_datfrozenxid,
 	 * database per invocation.  Once it's finished cleaning up the oldest
 	 * database, it'll call here, and we'll signal the postmaster to start
 	 * another iteration immediately if there are still any old databases.
-	 *
-	 * MPP-19652: autovacuum disabled
 	 */
+	/* MPP-19652: autovacuum disabled */
+#if 0
+	if (TransactionIdFollowsOrEquals(curXid, xidVacLimit) &&
+		IsUnderPostmaster)
+		SendPostmasterSignal(PMSIGNAL_START_AUTOVAC_LAUNCHER);
+#endif
 
 	/* Give an immediate warning if past the wrap warn point */
 	if (TransactionIdFollowsOrEquals(curXid, xidWarnLimit))

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -3407,7 +3407,7 @@ RemoveOldXlogFiles(uint32 log, uint32 seg, XLogRecPtr endptr)
 				else
 				{
 					/* No need for any more future segments... */
-					int rc = 0;
+					int			rc;
 
 					ereport(DEBUG2,
 							(errmsg("removing transaction log file \"%s\"",

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -6797,7 +6797,6 @@ StartupXLOG(void)
 	ereport(DEBUG1,
 			(errmsg("next MultiXactId: %u; next MultiXactOffset: %u",
 					checkPoint.nextMulti, checkPoint.nextMultiOffset)));
-
 	if (!TransactionIdIsNormal(checkPoint.nextXid))
 		ereport(PANIC,
 				(errmsg("invalid next transaction ID")));

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -3436,15 +3436,6 @@ RemoveOldXlogFiles(uint32 log, uint32 seg, XLogRecPtr endptr)
 										path)));
 						continue;
 					}
-					snprintf(newpath, MAXPGPATH, "%s.deleted", path);
-					if (rename(path, newpath) != 0)
-					{
-						ereport(LOG,
-								(errcode_for_file_access(),
-								 errmsg("could not rename old transaction log file \"%s\": %m",
-										path)));
-						continue;
-					}
 					rc = unlink(newpath);
 #else
 					rc = unlink(path);

--- a/src/backend/catalog/information_schema.sql
+++ b/src/backend/catalog/information_schema.sql
@@ -217,7 +217,6 @@ GRANT SELECT ON information_schema_catalog_name TO PUBLIC;
 CREATE DOMAIN time_stamp AS timestamp(2) with time zone
     DEFAULT current_timestamp(2);
 
-
 /*
  * 5.7
  * YES_OR_NO domain

--- a/src/backend/catalog/pg_largeobject.c
+++ b/src/backend/catalog/pg_largeobject.c
@@ -88,7 +88,7 @@ LargeObjectDrop(Oid loid)
 
 	pg_largeobject = heap_open(LargeObjectRelationId, RowExclusiveLock);
 
-	sd = systable_beginscan(pg_largeobject, LargeObjectLoidPagenoIndexId, true,
+	sd = systable_beginscan(pg_largeobject, LargeObjectLOidPNIndexId, true,
 							SnapshotNow, 1, skey);
 
 	while ((tuple = systable_getnext(sd)) != NULL)
@@ -125,7 +125,7 @@ LargeObjectExists(Oid loid)
 
 	pg_largeobject = heap_open(LargeObjectRelationId, AccessShareLock);
 
-	sd = systable_beginscan(pg_largeobject, LargeObjectLoidPagenoIndexId, true,
+	sd = systable_beginscan(pg_largeobject, LargeObjectLOidPNIndexId, true,
 							SnapshotNow, 1, skey);
 
 	if (systable_getnext(sd) != NULL)

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -33,7 +33,6 @@
  *-------------------------------------------------------------------------
  */
 #include "postgres.h"
-#include "gpmon/gpmon.h"
 
 #include "access/heapam.h"
 #include "access/aosegfiles.h"

--- a/src/backend/executor/nodeAppend.c
+++ b/src/backend/executor/nodeAppend.c
@@ -247,7 +247,7 @@ ExecInitAppend(Append *node, EState *estate, int eflags)
 		 */
 		appendstate->as_whichplan = i;
 		exec_append_initialize_next(appendstate);
-		
+
 		appendplanstates[i] = ExecInitNode(initNode, estate, eflags);
 	}
 
@@ -351,7 +351,6 @@ ExecAppend(AppendState *node)
 			return result;
 		}
 
-
 		/*
 		 * Go on to the "next" subplan in the appropriate direction. If no
 		 * more subplans, return the empty slot set up for us by
@@ -361,7 +360,6 @@ ExecAppend(AppendState *node)
 			node->as_whichplan++;
 		else
 			node->as_whichplan--;
-
 		if (!exec_append_initialize_next(node))
 			return ExecClearTuple(node->ps.ps_ResultTupleSlot);
 

--- a/src/backend/executor/nodeFunctionscan.c
+++ b/src/backend/executor/nodeFunctionscan.c
@@ -34,6 +34,7 @@
 #include "cdb/memquota.h"
 #include "executor/spi.h"
 
+
 static TupleTableSlot *FunctionNext(FunctionScanState *node);
 static void ExecFunctionScanExplainEnd(PlanState *planstate, struct StringInfoData *buf);
 

--- a/src/backend/storage/large_object/inv_api.c
+++ b/src/backend/storage/large_object/inv_api.c
@@ -79,7 +79,7 @@ open_lo_relation(void)
 		if (lo_heap_r == NULL)
 			lo_heap_r = heap_open(LargeObjectRelationId, RowExclusiveLock);
 		if (lo_index_r == NULL)
-			lo_index_r = index_open(LargeObjectLoidPagenoIndexId, RowExclusiveLock);
+			lo_index_r = index_open(LargeObjectLOidPNIndexId, RowExclusiveLock);
 	}
 	PG_CATCH();
 	{
@@ -154,7 +154,7 @@ myLargeObjectExists(Oid loid, Snapshot snapshot)
 
 	pg_largeobject = heap_open(LargeObjectRelationId, AccessShareLock);
 
-	sd = systable_beginscan(pg_largeobject, LargeObjectLoidPagenoIndexId, true,
+	sd = systable_beginscan(pg_largeobject, LargeObjectLOidPNIndexId, true,
 							snapshot, 1, skey);
 
 	if (systable_getnext(sd) != NULL)
@@ -202,7 +202,7 @@ inv_create(Oid lobjId)
 	{
 		open_lo_relation();
 
-		lobjId = GetNewOidWithIndex(lo_heap_r, LargeObjectLoidPagenoIndexId,
+		lobjId = GetNewOidWithIndex(lo_heap_r, LargeObjectLOidPNIndexId,
 									Anum_pg_largeobject_loid);
 	}
 

--- a/src/backend/utils/cache/syscache.c
+++ b/src/backend/utils/cache/syscache.c
@@ -106,7 +106,7 @@ struct cachedesc
 
 static const struct cachedesc cacheinfo[] = {
 	{AggregateRelationId,		/* AGGFNOID */
-		AggregateAggfnoidIndexId,
+		AggregateFnoidIndexId,
 		1,
 		{
 			Anum_pg_aggregate_aggfnoid,
@@ -425,7 +425,7 @@ static const struct cachedesc cacheinfo[] = {
 		4
 	},
 	{NamespaceRelationId,		/* NAMESPACENAME */
-		NamespaceNspnameIndexId,
+		NamespaceNameIndexId,
 		1,
 		{
 			Anum_pg_namespace_nspname,

--- a/src/include/catalog/indexing.h
+++ b/src/include/catalog/indexing.h
@@ -60,7 +60,7 @@ extern void CatalogUpdateIndexes(Relation heapRel, HeapTuple heapTuple);
  */
 
 DECLARE_UNIQUE_INDEX(pg_aggregate_fnoid_index, 2650, on pg_aggregate using btree(aggfnoid oid_ops));
-#define AggregateAggfnoidIndexId	2650
+#define AggregateFnoidIndexId  2650
 
 DECLARE_UNIQUE_INDEX(pg_am_name_index, 2651, on pg_am using btree(amname name_ops));
 #define AmNameIndexId  2651
@@ -169,10 +169,10 @@ DECLARE_UNIQUE_INDEX(pg_language_oid_index, 2682, on pg_language using btree(oid
 #define LanguageOidIndexId	2682
 
 DECLARE_UNIQUE_INDEX(pg_largeobject_loid_pn_index, 2683, on pg_largeobject using btree(loid oid_ops, pageno int4_ops));
-#define LargeObjectLoidPagenoIndexId	2683
+#define LargeObjectLOidPNIndexId  2683
 
 DECLARE_UNIQUE_INDEX(pg_namespace_nspname_index, 2684, on pg_namespace using btree(nspname name_ops));
-#define NamespaceNspnameIndexId	2684
+#define NamespaceNameIndexId  2684
 DECLARE_UNIQUE_INDEX(pg_namespace_oid_index, 2685, on pg_namespace using btree(oid oid_ops));
 #define NamespaceOidIndexId  2685
 

--- a/src/include/commands/prepare.h
+++ b/src/include/commands/prepare.h
@@ -13,12 +13,9 @@
 #ifndef PREPARE_H
 #define PREPARE_H
 
-#include "executor/execdesc.h"
 #include "executor/executor.h"
 #include "utils/plancache.h"
 #include "utils/timestamp.h"
-
-struct TupOutputState;                  /* #include "executor/executor.h" */
 
 /*
  * The data structure representing a prepared statement.  This is now just

--- a/src/include/commands/user.h
+++ b/src/include/commands/user.h
@@ -14,11 +14,11 @@
 #include "nodes/parsenodes.h"
 
 
-/* Hook to check passwords in CreateRole and AlterRole */
-#define PASSWORD_TYPE_PLAINTEXT     0
-#define PASSWORD_TYPE_MD5           1
+/* Hook to check passwords in CreateRole() and AlterRole() */
+#define PASSWORD_TYPE_PLAINTEXT		0
+#define PASSWORD_TYPE_MD5			1
 
-typedef void (*check_password_hook_type) (const char *username, const char *password, int password_type, Datum validunitl_time, bool validutil_null);
+typedef void (*check_password_hook_type) (const char *username, const char *password, int password_type, Datum validuntil_time, bool validuntil_null);
 
 extern PGDLLIMPORT check_password_hook_type check_password_hook;
 

--- a/src/include/executor/execdebug.h
+++ b/src/include/executor/execdebug.h
@@ -69,7 +69,6 @@
 #define T_OR_F(b)				((b) ? "true" : "false")
 #define NULL_OR_TUPLE(slot)		(TupIsNull(slot) ? "null" : "a tuple")
 
-
 /* ----------------
  *		nest loop debugging defines
  * ----------------

--- a/src/include/executor/nodeHashjoin.h
+++ b/src/include/executor/nodeHashjoin.h
@@ -17,9 +17,6 @@
 #include "nodes/execnodes.h"
 #include "storage/buffile.h"
 
-struct HashJoinBatchSide;               /* #include "executor/hashjoin.h" */
-struct Instrumentation;                 /* #include "executor/instrument.h" */
-
 extern int	ExecCountSlotsHashJoin(HashJoin *node);
 extern HashJoinState *ExecInitHashJoin(HashJoin *node, EState *estate, int eflags);
 extern TupleTableSlot *ExecHashJoin(HashJoinState *node);

--- a/src/include/utils/relcache.h
+++ b/src/include/utils/relcache.h
@@ -23,6 +23,7 @@
 #include "nodes/pg_list.h"
 #include "catalog/pg_class.h"
 
+
 typedef struct RelationData *Relation;
 
 /* ----------------
@@ -60,7 +61,7 @@ extern void RelationInitIndexAccessInfo(Relation relation);
 extern void RelationCacheInitialize(void);
 extern void RelationCacheInitializePhase2(void);
 extern void RelationCacheInitializePhase3(void);
-	
+
 /*
  * Routine to create a relcache entry for an about-to-be-created relation
  */

--- a/src/include/utils/relcache.h
+++ b/src/include/utils/relcache.h
@@ -106,6 +106,7 @@ extern void IndexSupportInitialize(oidvector *indclass,
 
 /* should be used only by relcache.c and catcache.c */
 extern bool criticalRelcachesBuilt;
+/* should be used only by relcache.c and postinit.c */
 extern bool criticalSharedRelcachesBuilt;
 
 #endif   /* RELCACHE_H */


### PR DESCRIPTION
I did a trial run of `git merge -Xpatience 78a09145e0f8322e625bbc7d69fcb865ce4f3034` on my laptop to see what we're going to be dealing with, when we start the 9.0 merge. These are a few little things that caught my eye, that caused merge conflicts. Might as well get these out of the way before the merge.