### PR TITLE
Fix updating rx_buffer_pool when tear down connection.

### DIFF
--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -3075,6 +3075,8 @@ SetupUDPIFCInterconnect_Internal(EState *estate)
 				conn->pkt_q_size = 0;
 				conn->pkt_q_head = 0;
 				conn->pkt_q_tail = 0;
+
+				SIMPLE_FAULT_INJECTOR(InterconnectSetupPalloc);
 				conn->pkt_q = (uint8 **) palloc0(conn->pkt_q_capacity * sizeof(uint8 *));
 
 				/* update the max buffer count of our rx buffer pool.  */
@@ -3456,11 +3458,11 @@ TeardownUDPIFCInterconnect_Internal(ChunkTransportState *transportStates,
 					if (conn->cdbProc == NULL)
 						continue;
 
-					rx_buffer_pool.maxCount -= conn->pkt_q_capacity;
-
 					/* out of memory has occurred, break out */
 					if (!conn->pkt_q)
 						break;
+
+					rx_buffer_pool.maxCount -= conn->pkt_q_capacity;
 
 					connDelHash(&ic_control_info.connHtab, conn);
 

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -327,6 +327,8 @@ FaultInjectorIdentifierEnumToString[] = {
 		/* inject fault in cdbdisp_dispatchX*/
 	_("interconnect_stop_ack_is_lost"),
 		/* inject fault in interconnect to skip sending the stop ack */
+	_("interconnect_setup_palloc"),
+		/* inject fault in interconnect to make palloc0 fail in setup */
 	_("qe_got_snapshot_and_interconnect"),
 		/* inject fault after qe got snapshot and interconnect*/
 	_("fsync_counter"),

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -216,6 +216,7 @@ typedef enum FaultInjectorIdentifier_e {
 	AfterOneSliceDispatched,
 
 	InterconnectStopAckIsLost,
+	InterconnectSetupPalloc,
 	QEGotSnapshotAndInterconnect,
 
 	FsyncCounter,

--- a/src/test/regress/expected/ic.out
+++ b/src/test/regress/expected/ic.out
@@ -478,3 +478,27 @@ NOTICE:  Success:
 
 commit;
 drop table ic_test_1;
+/*
+ * If message queue of connection is failed to be allocated in
+ * SetupUDPIFCInterconnect_Internal() , it should be handled properly
+ * in TeardownUDPIFCInterconnect_Internal().
+ */
+CREATE TABLE a (i INT, j INT) DISTRIBUTED BY (i);
+INSERT INTO a (SELECT i, i * i FROM generate_series(1, 10) as i);
+SELECT gp_inject_fault('interconnect_setup_palloc', 'error', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+SELECT * FROM a;
+ERROR:  fault triggered, fault name:'interconnect_setup_palloc' fault type:'error'
+DROP TABLE a;
+SELECT gp_inject_fault('interconnect_setup_palloc', 'reset', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+

--- a/src/test/regress/sql/ic.sql
+++ b/src/test/regress/sql/ic.sql
@@ -200,3 +200,15 @@ select gp_inject_fault('interconnect_stop_ack_is_lost', 'reset', 1);
 select gp_inject_fault('interconnect_stop_ack_is_lost', 'skip', 1);
 commit;
 drop table ic_test_1;
+
+/*
+ * If message queue of connection is failed to be allocated in
+ * SetupUDPIFCInterconnect_Internal(), it should be handled properly
+ * in TeardownUDPIFCInterconnect_Internal().
+ */
+CREATE TABLE a (i INT, j INT) DISTRIBUTED BY (i);
+INSERT INTO a (SELECT i, i * i FROM generate_series(1, 10) as i);
+SELECT gp_inject_fault('interconnect_setup_palloc', 'error', 1);
+SELECT * FROM a;
+DROP TABLE a;
+SELECT gp_inject_fault('interconnect_setup_palloc', 'reset', 1);


### PR DESCRIPTION
Do not update rx_buffer_pool.maxCount when tear down
connection if conn->pkt_q is failed to be assigned a
valid address in set up connection.