### PR TITLE
Add tablespace test cases in gpinitstandby.

### DIFF
--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/gpinitstandby/__init__.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/gpinitstandby/__init__.py
@@ -22,6 +22,7 @@ import pexpect as pexpect
 
 import tinctest
 from tinctest.lib import local_path
+from gppylib.commands import base
 from gppylib.commands.base import Command
 from mpp.lib.config import GPDBConfig
 from mpp.lib.PSQL import PSQL
@@ -54,9 +55,10 @@ class GpinitStandby(object):
             return False
         return True
 
-    def verify_gpinitstandby(self, primary_pid):  
+    def verify_gpinitstandby(self, primary_pid, datadir):
         '''Verify the presence of standby in recovery mode '''
-        if (self.stdby.check_gp_segment_config()) and (self.stdby.check_pg_stat_replication()) and (self.stdby.check_standby_processes())and self.compare_primary_pid(primary_pid) :
+        tinctest.logger.info("verify standby...")
+        if self.stdby.check_gp_segment_config(datadir) and self.stdby.check_pg_stat_replication() and self.stdby.check_standby_processes() and self.compare_primary_pid(primary_pid) :
             return True
         return False
 
@@ -146,3 +148,10 @@ class GpinitStandby(object):
             return False
         child.close()
         return True
+
+    def check_dir_exist_on_standby(self, standby, location):
+        cmd = Command(name='Make directory on standby before running the command', cmdStr='ls -l %s' % location, ctxt=base.REMOTE, remoteHost=standby)
+        tinctest.logger.info('%s' % cmd)
+        cmd.run(validateAfter=True)
+        result = cmd.get_results()
+        return result.rc !=0

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/gpinitstandby/drop_filespace.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/gpinitstandby/drop_filespace.sql
@@ -1,6 +1,0 @@
--- start_ignore
-SET gp_create_table_random_default_distribution=off;
--- end_ignore
-DROP TABLE  fs_walrepl_table;
-DROP TABLESPACE ts_walrepl_a;
-DROP FILESPACE fs_walrepl_a;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/gpinitstandby/tablespace.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/gpinitstandby/tablespace.sql
@@ -1,6 +1,4 @@
 -- start_ignore
 SET gp_create_table_random_default_distribution=off;
 -- end_ignore
-CREATE TABLESPACE ts_walrepl_a FILESPACE fs_walrepl_a; 
-
 CREATE TABLE fs_walrepl_table(a int, b int) TABLESPACE ts_walrepl_a;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/lib/verify.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/lib/verify.py
@@ -69,12 +69,16 @@ class StandbyVerify(object):
                     pg_stat_replication
              """)
 
-    def check_gp_segment_config(self):
+    def check_gp_segment_config(self, datadir = None):
         ''' Check for the new entry in gp_segment_configuration'''
         sm_count = PSQL.run_sql_command("select count(*) from gp_segment_configuration where content='-1' and role='m';", flags='-q -t', dbname='postgres')
         if int(sm_count.strip()) != 1:
             return False
         tinctest.logger.info('A new entry is added for standby in gp_segment_configuration')
+        result = PSQL.run_sql_command("select datadir from gp_segment_configuration " 
+                                       "where content='-1' and role='m';", flags='-q -t', dbname='postgres')
+        if datadir is not None and datadir != result.strip():
+            return False
         return True
 
     def check_pg_stat_replication(self):
@@ -133,4 +137,7 @@ class StandbyVerify(object):
         if len(standby_processes) != len(process_list):
             return False
         tinctest.logger.info('All the standby processes are present at standby host''')
+        return True
+
+    def check_standby_tablespace(self):
         return True

--- a/src/test/tinc/tincrepo/mpp/lib/gptablespace.py
+++ b/src/test/tinc/tincrepo/mpp/lib/gptablespace.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+"""
+Copyright (c) 2004-Present Pivotal Software, Inc.
+
+This program and the accompanying materials are made available under
+the terms of the under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+############################################################################
+import tinctest
+from gppylib.commands.base import Command
+from mpp.lib.PSQL import PSQL
+from mpp.lib.config import GPDBConfig
+from tinctest.lib import local_path, run_shell_command
+from tinctest.main import TINCException
+
+class Gptablespace(object):
+
+    def __init__(self, config=None):
+        if config is not None:
+            self.config = config
+        else:
+            self.config = GPDBConfig()
+
+    def get_standby_tablespace_directory(self, tablespace):
+        '''
+        Get the standby tablespace directory location
+        @param tablespace: tablespace name
+        @return dir: standby tablespace directory
+        '''
+        sql_cmd = "SELECT dbid from gp_segment_configuration where content = -1 and role = 'm'";
+        dbid = int(PSQL.run_sql_command(sql_cmd, flags = '-t -q -c', dbname='postgres'))
+        sql_cmd = ("SELECT gp_tablespace_path(spclocation, %d) FROM pg_tablespace WHERE spcname <> %s") % (dbid, tablespace)
+        dir = PSQL.run_sql_command(sql_cmd, flags = '-t -q', dbname='postgres')
+        return dir
+
+    def exists(self, tablespace):
+        '''
+        Check whether tablespace exist in catalog
+        @param tablespace:tablespace name
+        @return True or False
+        '''
+        fs_out = PSQL.run_sql_command("select count(*) from pg_tablespace where spcname='%s'" % tablespace, flags = '-t -q', dbname='postgres')
+        if int(fs_out.strip()) > 0:
+            return True
+        return False
+
+    def create_tablespace(self, tablespace, loc):
+        '''
+        @param tablespace: Tablespace Name
+        @param loc: Tablespace location
+        '''
+        if self.exists(tablespace):
+            tinctest.logger.info('tablespace %s exists' % tablespace)
+            return
+
+        for record in self.config.record:
+            cmd = "gpssh -h %s -e 'rm -rf %s; mkdir -p %s'"  % (record.hostname, loc, loc)
+            run_shell_command(cmd)
+        tinctest.logger.info('create tablespace %s' % tablespace)
+        sql_cmd = 'create tablespace %s location \'%s\'' % (tablespace, loc)
+        PSQL.run_sql_command(sql_cmd, flags = '-t -q -c', dbname='postgres')
+


### PR DESCRIPTION
* Add two test cases, test_gpinitstandby_to_same_with_tablespace
  and test_gpinitstandby_new_host_with_tablespace. The first one
  creates a new tablespace and gpinitstandby on master host. The
  second one also creates a new tablespace firstly,but then
  gpinitstandby on another host instead.

* Remove test_gpinitstandby_prompt_for_filespace test case.

As the pr copying tablespace from primary to standby with standby
dbid is not merged, the codes checking the standby tablespace
directory is commented out curruntlly.

Author: Max Yang <myang@pivotal.io>
Author: Xiaoran Wang <xiwang@pivotal.io>