### PR TITLE
concourse: Validate pipeline only after it is generated

### DIFF
--- a/concourse/pipelines/gen_pipeline.py
+++ b/concourse/pipelines/gen_pipeline.py
@@ -128,17 +128,6 @@ if __name__ == "__main__":
     if ARGS.pipeline_type == 'prod':
         ARGS.os_types = ['centos6', 'centos7', 'sles', 'aix7', 'win', 'ubuntu16']
         ARGS.test_sections = ['ICW', 'CS', 'MPP', 'MM', 'DPM', 'UD']
-        print "======================================================================"
-        print "Validate Pipeline Release Jobs"
-        print "----------------------------------------------------------------------"
-        try:
-            env = os.environ.copy()
-            env['PIPELINE_FILE'] = ARGS.output_filename
-            subprocess.check_call(["python",
-                                   "../scripts/validate_pipeline_release_jobs.py"],
-                                  env=env)
-        except subprocess.CalledProcessError:
-            exit(1)
 
     if ARGS.pipeline_type != 'prod' and ARGS.output_filename == 'gpdb_master-generated.yml':
         ARGS.output_filename = 'gpdb-' + ARGS.pipeline_type + '-' + ARGS.user + '.yml'
@@ -177,6 +166,20 @@ if __name__ == "__main__":
         MSG += '    -v tf-bucket-path=dev/' + ARGS.pipeline_type + '/ \\\n'
         MSG += '    -v bucket-name=gpdb5-concourse-builds-dev\n'
 
+    create_pipeline()
+
+    if ARGS.pipeline_type == 'prod':
+        print "======================================================================"
+        print "Validate Pipeline Release Jobs"
+        print "----------------------------------------------------------------------"
+        try:
+            env = os.environ.copy()
+            env['PIPELINE_FILE'] = ARGS.output_filename
+            subprocess.check_call(["python",
+                                   "../scripts/validate_pipeline_release_jobs.py"],
+                                  env=env)
+        except subprocess.CalledProcessError:
+            exit(1)
+
     print MSG
 
-    create_pipeline()


### PR DESCRIPTION
The common situation was doing a big rebase of a branch: a conflicting
diff shows up in the template file as well as the generated pipeline.

The right way to handle that situation is resolve the diff in the
template and then regenerate the pipeline (rather than resolving the
diff in the generated file)

However, before this change, the pipeline validation was happening
before the new pipeline was generated, and thus the yaml parsing choked
on the git merge conflict indicators `======`

Also, only print out the message if it passes validation.

Author: C.J. Jameson <cjameson@pivotal.io>
Author: Jim Doty <jdoty@pivotal.io>

- [ ] TODO: backport to 5X_STABLE as well.