### PR TITLE
Fix coverity defect CID 182261: Uninitialized variables (UNINIT)

### DIFF
--- a/src/backend/utils/adt/selfuncs.c
+++ b/src/backend/utils/adt/selfuncs.c
@@ -166,14 +166,6 @@ static Datum string_to_datum(const char *str, Oid datatype);
 static Const *string_to_const(const char *str, Oid datatype);
 static Const *string_to_bytea_const(const char *str, size_t str_len);
 
-static Selectivity
-mcv_selectivity_cdb(VariableStatData   *vardata,
-                    FmgrInfo           *opproc,
-				    Datum               constval,
-                    bool                varonleft,
-				    Selectivity        *sumcommonp,     /* OUT */
-                    double             *nvaluesp);      /* OUT */
-
 
 /*
  *		eqsel			- Selectivity of "=" for any data types.
@@ -551,24 +543,14 @@ scalarineqsel(PlannerInfo *root, Oid operator, bool isgt,
  * total population is returned into *sumcommonp.  Zeroes are returned
  * if there is no MCV list.
  *
- * CDB: The number of MCVs is returned into *nvaluesp.
  */
-double
-mcv_selectivity(VariableStatData *vardata, FmgrInfo *opproc,
-				Datum constval, bool varonleft,
-				double *sumcommonp)
-{
-    return mcv_selectivity_cdb(vardata, opproc, constval, varonleft,
-                               sumcommonp, NULL);
-}
 
-static Selectivity
-mcv_selectivity_cdb(VariableStatData   *vardata,
+double
+mcv_selectivity(VariableStatData   *vardata,
                     FmgrInfo           *opproc,
 				    Datum               constval,
                     bool                varonleft,
-				    Selectivity        *sumcommonp,     /* OUT */
-                    double             *nvaluesp)       /* OUT */
+				    double        *sumcommonp)     /* OUT */
 {
 	double		mcv_selec,
 				sumcommon;
@@ -600,8 +582,6 @@ mcv_selectivity_cdb(VariableStatData   *vardata,
 	}
 
 	*sumcommonp = sumcommon;
-	if (nvaluesp)
-		*nvaluesp = sslot.nvalues;
 	return mcv_selec;
 }
 

--- a/src/backend/utils/adt/selfuncs.c
+++ b/src/backend/utils/adt/selfuncs.c
@@ -2000,7 +2000,7 @@ eqjoinsel_inner(Oid operator,
 	{
 		HeapTuple tp = getStatsTuple(vardata1);
 		stats1 = (Form_pg_statistic) GETSTRUCT(tp);
-		have_mcvs1 = get_attstatsslot(&sslot1, vardata1->statsTuple,
+		have_mcvs1 = get_attstatsslot(&sslot1, tp,
 									  STATISTIC_KIND_MCV, InvalidOid,
 							 ATTSTATSSLOT_VALUES | ATTSTATSSLOT_NUMBERS);
 
@@ -2010,7 +2010,7 @@ eqjoinsel_inner(Oid operator,
 	{
 		HeapTuple tp = getStatsTuple(vardata2);
 		stats2 = (Form_pg_statistic) GETSTRUCT(tp);
-		have_mcvs2 = get_attstatsslot(&sslot2, vardata2->statsTuple,
+		have_mcvs2 = get_attstatsslot(&sslot2, tp,
 									  STATISTIC_KIND_MCV, InvalidOid,
 							 ATTSTATSSLOT_VALUES | ATTSTATSSLOT_NUMBERS);
 	}


### PR DESCRIPTION
The variable nvaluesp was being assigned the value of sslot.nvalues
after sslot was passed into free_attstatsslot. Since nvaluesp was not
being used in the function, just remove it to fix the issue.

Also get rid of the cdb version of mcv_selectivity() since the extra OUT
parameter `nvaluesp` is no longer there. 

Fix suggested by Daniel Gustafsson

Author: Abhijit Subramanya <asubramanya@pivotal.io>
Author: Dhanashree Kashid <dkashid@pivotal.io>