### PR TITLE
gpexpand: Make it work with segwalrep.

### DIFF
--- a/gpMgmt/bin/gpcheckmirrorseg.pl
+++ b/gpMgmt/bin/gpcheckmirrorseg.pl
@@ -2554,7 +2554,7 @@ if (1)
 	$psql_str .= $glob_connect
         if (defined($glob_connect));
 
-	# select from gp_segment_configuration and pg_filespace_entry,
+	# select from gp_segment_configuration
 	# to get file system location and port number
 
 	$psql_str .= " -c \' ".
@@ -2582,38 +2582,28 @@ if (1)
 	$psql_str .= $glob_connect
         if (defined($glob_connect));
 
-	# select from gp_segment_configuration and pg_filespace_entry,
+	# select from gp_segment_configuration,
 	# constructing a single row for each primary/mirror pair
 
 	$psql_str .= " -c \' ".
 		"select gscp.content, " .
 		"gscp.hostname as phostname, gscp.address as paddress, " .
-		"fep.fselocation as ploc, " .
+		"gscp.datadir as ploc, " .
 		"gscm.hostname as mhostname, gscm.address as maddress, " .
-		"fem.fselocation as mloc, " .
-		"pfs.oid fsoid, " .
-		"pfs.fsname, " .
+		"gscm.datadir as mloc, " .
 		"gscp.mode, " .
 		"gscp.status, " .
 		"gscm.mode as mmode, " .
 		"gscp.status as mstatus " .
 		"from " .
-		"gp_segment_configuration gscp, pg_filespace_entry fep, " .
-		"gp_segment_configuration gscm, pg_filespace_entry fem, " .
-		"pg_filespace pfs " .
+		"gp_segment_configuration gscp," .
+		"gp_segment_configuration gscm" .
 		"where " .
-		"fep.fsedbid=gscp.dbid " . # and gscp.content > -1 " .
-		"and " .
-		"fem.fsedbid=gscm.dbid " . # and gscm.content > -1 " .
-		"and " .
-		# match the filespace ids
-		"fem.fsefsoid = fep.fsefsoid " . 
-		"and gscp.content = gscm.content " .
+		"gscp.content = gscm.content " .
 		# use "dollar-quoting" to avoid dealing with nested single-quotes:
 		# $q$p$q$ is equivalent to 'p'
 		"and gscp.role =  " .  '$q$p$q$ ' .
-		"and gscm.role =  " .  '$q$m$q$ ' .
-		"and pfs.oid = fep.fsefsoid " ;
+		"and gscm.role =  " .  '$q$m$q$ ' ;
 
 	# MPP-9883, MPP-9891: run integrity check only for desired segments
 	$psql_str .= " and gscp.content in ( " . 

--- a/gpMgmt/bin/gpdeletesystem
+++ b/gpMgmt/bin/gpdeletesystem
@@ -186,6 +186,12 @@ def check_for_dump_files(options):
     logger.info('Checking for database dump files...')
     return gp.GpDumpDirsExist.local('check for dump dirs', options.master_data_dir)
 
+def getTablespaceDirs():
+    sqlcmd = "select spclocation FROM pg_tablespace where spcname != 'pg_default' and spcname != 'pg_global'"
+    with dbconn.connect(dbconn.DbURL()) as conn:
+        tablespaces = dbconn.execSQL(conn, sqlcmd).fetchall()
+
+    return [row[0] for row in tablespaces]
 
 # -------------------------------------------------------------------------
 # delete_system() - deletes a GPDB system
@@ -206,13 +212,12 @@ def delete_cluster(options):
     dburl = dbconn.DbURL(port=options.pgport)
     try:
         array = gparray.GpArray.initFromCatalog(dburl, True)
+        tablespaceDirs = getTablespaceDirs()
     except Exception, ex:
         raise GpDeleteSystemException('Failed to get database configuration: %s' % ex.__str__())
     # get all segdbs
     segments = array.getDbList()
 
-    # getSegmentsByHostName(segments)
-    segdbs_by_host = gparray.GpArray.getSegmentsByHostName(segments)
     standby = array.standbyMaster
 
     # Display the options
@@ -232,6 +237,25 @@ def delete_cluster(options):
 
     # From this point on we don't want ctrl-c to happen
     signal.signal(signal.SIGINT, signal.SIG_IGN)
+
+    # create pool
+    pool = base.WorkerPool(numWorkers=options.batch_size)
+
+    logger.info('Deleting tablespace directories...')
+    # getSegmentsByHostName(segments)
+    segmentHosts = gparray.GpArray.getSegmentsByHostName(segments).keys()
+    for segmentHost in segmentHosts:
+        for tablespaceDir in tablespaceDirs:
+            logger.debug('Queueing up command to remove %s:%s' % (segmentHost,
+                                                                  tablespaceDir))
+            cmd = unix.RemoveDirectory('remove tablespace dir', tablespaceDir,
+                                       ctxt=base.REMOTE, remoteHost=segmentHost)
+            pool.addCommand(cmd)
+
+    logger.info('Waiting for worker threads to delete tablespace dirs...')
+    pool.join()
+    pool.haltWork()
+    pool.joinWorkers()
 
     # create pool
     pool = base.WorkerPool(numWorkers=options.batch_size)

--- a/gpMgmt/bin/gpdeletesystem
+++ b/gpMgmt/bin/gpdeletesystem
@@ -238,13 +238,12 @@ def delete_cluster(options):
 
     logger.info('Deleting segments and removing data directories...')
     for segdb in segments:
-        filespaces = segdb.getSegmentFilespaces().items()
-        for (oid, filespace) in filespaces:
-            logger.debug('Queueing up command to remove %s:%s' % (segdb.getSegmentHostName(),
-                                                                  filespace))
-            cmd = unix.RemoveDirectory('remove fs dir', filespace, ctxt=base.REMOTE,
-                                       remoteHost=segdb.getSegmentHostName())
-            pool.addCommand(cmd)
+        segmentDataDirectory = segdb.getSegmentDataDirectory()
+        logger.debug('Queueing up command to remove %s:%s' % (segdb.getSegmentHostName(),
+                                                              segmentDataDirectory))
+        cmd = unix.RemoveDirectory('remove data dir', segmentDataDirectory, ctxt=base.REMOTE,
+                                   remoteHost=segdb.getSegmentHostName())
+        pool.addCommand(cmd)
 
     logger.info('Waiting for worker threads to complete...')
     pool.join()

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -756,6 +756,44 @@ class SegmentTemplate:
         self.pool.join()
         self.pool.check_results()
 
+    def _start_new_primary_segments(self):
+        newSegments = self.gparray.getExpansionSegDbList()
+        for seg in newSegments:
+            if seg.isSegmentMirror() == True:
+                continue
+            """ Start all the new segments in utilty mode. """
+            segStartCmd = SegmentStart(
+                name="Starting new segment dbid %s on host %s." % (str(seg.getSegmentDbId()), seg.getSegmentHostName())
+                , gpdb=seg
+                , numContentsInCluster=0  # Starting seg on it's own.
+                , era=None
+                , mirrormode=MIRROR_MODE_MIRRORLESS
+                , utilityMode=True
+                , ctxt=REMOTE
+                , remoteHost=seg.getSegmentHostName()
+                , noWait=False
+                , timeout=SEGMENT_TIMEOUT_DEFAULT)
+            self.pool.addCommand(segStartCmd)
+        self.pool.join()
+        self.pool.check_results()
+
+    def _stop_new_primary_segments(self):
+        newSegments = self.gparray.getExpansionSegDbList()
+        for seg in newSegments:
+            if seg.isSegmentMirror() == True:
+                continue
+            segStopCmd = SegmentStop(
+                name="Stopping new segment dbid %s on host %s." % (str(seg.getSegmentDbId), seg.getSegmentHostName())
+                , dataDir=seg.getSegmentDataDirectory()
+                , mode='smart'
+                , nowait=False
+                , ctxt=REMOTE
+                , remoteHost=seg.getSegmentHostName()
+            )
+            self.pool.addCommand(segStopCmd)
+        self.pool.join()
+        self.pool.check_results()
+
     def _configure_new_segments(self):
         """Configures new segments.  This includes modifying the postgresql.conf file
         and setting up the gp_id table"""
@@ -773,9 +811,19 @@ class SegmentTemplate:
         self.pool.join()
         self.pool.check_results()
 
+        self._start_new_primary_segments()
+
         self.logger.info('Configuring new segments (mirror)')
-        new_segment_info = ConfigureNewSegment.buildSegmentInfoForNewSegment(self.gparray.getExpansionSegDbList(),
-                                                                             primaryMirror='mirror')
+
+        mirrorsList = []
+        for segPair in self.gparray.getExpansionSegPairList():
+            mirror = segPair.mirrorDB
+            mirror.primaryHostname = segPair.primaryDB.getSegmentHostName()
+            mirror.primarySegmentPort = segPair.primaryDB.getSegmentPort()
+            mirrorsList.append(mirror)
+
+        new_segment_info = ConfigureNewSegment.buildSegmentInfoForNewSegment(mirrorsList, primaryMirror='mirror')
+
         for host in iter(new_segment_info):
             segCfgCmd = ConfigureNewSegment('gpexpand configure new segments', new_segment_info[host],
                                             tarFile=self.schema_tar_file, newSegments=True,
@@ -785,6 +833,8 @@ class SegmentTemplate:
 
         self.pool.join()
         self.pool.check_results()
+
+        self._stop_new_primary_segments()
 
     def _fixup_template(self):
         """Copies postgresql.conf and pg_hba.conf files from a valid segment on the system.

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -759,7 +759,7 @@ class SegmentTemplate:
     def _start_new_primary_segments(self):
         newSegments = self.gparray.getExpansionSegDbList()
         for seg in newSegments:
-            if seg.isSegmentMirror() == True:
+            if seg.isSegmentMirror():
                 continue
             """ Start all the new segments in utilty mode. """
             segStartCmd = SegmentStart(
@@ -771,7 +771,7 @@ class SegmentTemplate:
                 , utilityMode=True
                 , ctxt=REMOTE
                 , remoteHost=seg.getSegmentHostName()
-                , noWait=False
+                , pg_ctl_wait=True
                 , timeout=SEGMENT_TIMEOUT_DEFAULT)
             self.pool.addCommand(segStartCmd)
         self.pool.join()
@@ -815,8 +815,11 @@ class SegmentTemplate:
 
         self.logger.info('Configuring new segments (mirror)')
 
+        # This loop enriches segments which are mirrors with two fields, primaryHostname and primarySegmentPort.
         mirrorsList = []
         for segPair in self.gparray.getExpansionSegPairList():
+            if segPair.mirrorDB is None:
+                continue
             mirror = segPair.mirrorDB
             mirror.primaryHostname = segPair.primaryDB.getSegmentHostName()
             mirror.primarySegmentPort = segPair.primaryDB.getSegmentPort()
@@ -828,7 +831,7 @@ class SegmentTemplate:
             segCfgCmd = ConfigureNewSegment('gpexpand configure new segments', new_segment_info[host],
                                             tarFile=self.schema_tar_file, newSegments=True,
                                             verbose=gplog.logging_is_verbose(), batchSize=self.batch_size,
-                                            ctxt=REMOTE, remoteHost=host, validationOnly=True)
+                                            ctxt=REMOTE, remoteHost=host, validationOnly=False)
             self.pool.addCommand(segCfgCmd)
 
         self.pool.join()
@@ -1596,7 +1599,7 @@ Set PGDATABASE or use the -D option to specify the correct database to use.""" %
                 , utilityMode=True
                 , ctxt=REMOTE
                 , remoteHost=seg.getSegmentHostName()
-                , noWait=False
+                , pg_ctl_wait=True
                 , timeout=SEGMENT_TIMEOUT_DEFAULT)
             self.pool.addCommand(segStartCmd)
         self.pool.join()

--- a/gpMgmt/bin/gpinitstandby
+++ b/gpMgmt/bin/gpinitstandby
@@ -21,6 +21,7 @@ try:
     from gppylib.gp_dbid import GpDbidFile
     from gppylib.operations.initstandby import cleanup_pg_hba_backup_on_segment, update_pg_hba_conf_on_segments, restore_pg_hba_on_segment
     from gppylib.operations.package import SyncPackages
+    from gppylib.commands.pg import PgBaseBackup
 except ImportError, e:
     sys.exit('ERROR: Cannot import modules.  Please check that you '
              'have sourced greenplum_path.sh.  Detail: ' + str(e))
@@ -689,20 +690,9 @@ def copy_master_datadir_to_standby(options, array, standby_datadir):
     # here in the data directory here already, and teach pg_basebackup to
     # map the per-dbid directories to the new dbid.
     
-    # We exclude certain unnecessary directories from being copied as they will greatly
-    # slow down the speed of gpinitstandby if containing a lot of data
-    cmd_str = ' '.join(['pg_basebackup',
-                        '-x', '-R',
-                        '-c', 'fast',
-                        '-E', './pg_log',
-                        '-E', './db_dumps',
-                        '-E', './gpperfmon/data',
-                        '-E', './gpperfmon/logs',
-                        '-D', standby_datadir,
-                        '-h', array.master.getSegmentHostName(),
-                        '-p', str(array.master.getSegmentPort())])
-    cmd = base.Command('pg_basebackup',
-                       cmd_str,
+    cmd = PgBaseBackup(pgdata=standby_datadir,
+                       host=array.master.getSegmentHostName(),
+                       port=str(array.master.getSegmentPort()),
                        ctxt=base.REMOTE,
                        remoteHost=options.standby_host)
     try:

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -1101,9 +1101,9 @@ class ConfigureNewSegment(Command):
                         : if primary then 'true' else 'false'
                         : if target is reused location then 'true' else 'false'
                         : <segment dbid>
-
         """
         result = {}
+
         for segIndex, seg in enumerate(segments):
             if primaryMirror == 'primary' and seg.isSegmentPrimary() == False:
                continue
@@ -1115,16 +1115,37 @@ class ConfigureNewSegment(Command):
             else:
                 result[hostname] = ''
 
-            isTargetReusedLocation = isTargetReusedLocationArr and isTargetReusedLocationArr[segIndex]
+            # only a mirror segment has these two attributes
+            # added on the fly, by callers
+            primaryHostname = getattr(seg, 'primaryHostname', "")
+            primarySegmentPort = getattr(seg, 'primarySegmentPort', "-1")
 
-            result[hostname] += '%s:%d:%s:%s:%d' % (seg.getSegmentDataDirectory(), seg.getSegmentPort(),
-                        "true" if seg.isSegmentPrimary(current_role=True) else "false",
-                        "true" if isTargetReusedLocation else "false",
-                        seg.getSegmentDbId()
+            isTargetReusedLocation = isTargetReusedLocationArr and isTargetReusedLocationArr[segIndex]
+            result[hostname] += '%s:%d:%s:%s:%d:%s:%s' % (seg.getSegmentDataDirectory(), seg.getSegmentPort(),
+                                                          "true" if seg.isSegmentPrimary(current_role=True) else "false",
+                                                          "true" if isTargetReusedLocation else "false",
+                                                          seg.getSegmentDbId(),
+                                                          primaryHostname,
+                                                          primarySegmentPort
             )
         return result
 
+def buildSegInfo(seg, isTargetReusedLocation="false", primarySegment=None):
+    # if primaryMirror == 'primary' and seg.isSegmentPrimary() == False:
+    #    continue
+    # elif primaryMirror == 'mirror' and seg.isSegmentPrimary() == True:
+    #    continue
 
+    result = '%s:%d:%s:%s:%d:%s' % (seg.getSegmentDataDirectory(),
+                                            seg.getSegmentPort(),
+                                            "true" if seg.isSegmentPrimary(current_role=True) else "false",
+                                            isTargetReusedLocation,
+                                            seg.getSegmentDbId(),
+                                            "notapplicableonprimary",
+                                            "notapplicableonprimary",
+                                            #segPrimary.getSegmentHostName() if seg.isSegmentMirror() else "notapplicableonprimary"
+                                            )
+    return result
 
 #-----------------------------------------------
 class GpVersion(Command):

--- a/gpMgmt/bin/gppylib/gparray.py
+++ b/gpMgmt/bin/gppylib/gparray.py
@@ -1200,6 +1200,12 @@ class GpArray:
         return dbs
 
     # --------------------------------------------------------------------
+    def getExpansionSegPairList(self):
+        """Returns a list of all SegmentPair objects that make up the new segments
+        of an expansion"""
+        return self.expansionSegmentPairs
+
+    # --------------------------------------------------------------------
     def getSegmentContainingDb(self, db):
         for segPair in self.segmentPairs:
             for segDb in segPair.get_dbs():

--- a/gpMgmt/bin/gppylib/system/configurationImplGpdb.py
+++ b/gpMgmt/bin/gppylib/system/configurationImplGpdb.py
@@ -203,13 +203,6 @@ class GpConfigurationProviderUsingGpdbCatalog(GpConfigurationProvider) :
         # gp_add_segment_primary() will update the mode and status.
 
         # get the newly added segment's content id
-        # MPP-12393 et al WARNING: there is an unusual side effect going on here.
-        # Although gp_add_segment_primary() executed by __callSegmentAdd() above returns
-        # the dbId of the new row in gp_segment_configuration, the following
-        # select from gp_segment_configuration can return 0 rows if the updates
-        # done by __updateSegmentModeStatus()
-        # are not done first.  Don't change the order of these operations unless you
-        # understand why gp_add_segment_primary() behaves as it does.
         sql = "select content from pg_catalog.gp_segment_configuration where dbId = %s" % self.__toSqlIntValue(seg.getSegmentDbId())
         logger.debug(sql)
         sqlResult = self.__fetchSingleOutputRow(conn, sql)

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gp.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gp.py
@@ -5,7 +5,7 @@ import tempfile
 from StringIO import StringIO
 
 from commands.base import CommandResult
-from commands.gp import GpReadConfig
+from commands.gp import GpReadConfig, ConfigureNewSegment
 from gparray import Segment, GpArray, SegmentPair
 import shutil
 from mock import *

--- a/gpMgmt/bin/lib/gpconfigurenewsegment
+++ b/gpMgmt/bin/lib/gpconfigurenewsegment
@@ -6,6 +6,7 @@ from optparse import Option, OptionGroup, OptionParser, OptionValueError, SUPPRE
 
 from gppylib.gpparseopts import OptParser, OptChecker
 from gppylib.commands.gp import ModifyPostgresqlConfSetting, SegmentStart, SegmentStop
+from gppylib.commands.pg import PgBaseBackup
 from gppylib.db import dbconn
 from gppylib.commands import unix
 from gppylib.commands.pg import DbStatus
@@ -71,8 +72,7 @@ class ConfExpSegCmd(Command):
 
         if not os.path.exists(os.path.dirname(path)):
             logger.info("gpconfigurenewsegment:validatePath path %s does not exist" % path)
-            raise ValidationException("Parent directory for %s directory '%s' does not exist" %
-                    ("system data", path))
+            raise ValidationException("Parent directory for system data directory '%s' does not exist" % path)
 
         if not os.path.exists(path):
             return
@@ -125,19 +125,9 @@ class ConfExpSegCmd(Command):
 
                     if not self.isPrimary:
                         # Create a mirror based on the primary
-                        # We exclude certain unnecessary directories from being copied as they will greatly
-                        # slow down the speed of gpinitstandby if containing a lot of data
-                        cmd_str = ' '.join(['pg_basebackup',
-                                            '-x', '-R',
-                                            '-c', 'fast',
-                                            '-E', './pg_log',
-                                            '-E', './db_dumps',
-                                            '-E', './gpperfmon/data',
-                                            '-E', './gpperfmon/logs',
-                                            '-D', self.datadir,
-                                            '-h', self.syncWithSegmentHostname,
-                                            '-p', str(self.syncWithSegmentPort)])
-                        cmd = Command('pg_basebackup', cmd_str)
+                        cmd = PgBaseBackup(pgdata=self.datadir,
+                                           host=self.syncWithSegmentHostname,
+                                           port=str(self.syncWithSegmentPort))
                         try:
                             cmd.run(validateAfter=True)
                             self.set_results(CommandResult(0, '', '', True, False))

--- a/gpMgmt/bin/lib/gpconfigurenewsegment
+++ b/gpMgmt/bin/lib/gpconfigurenewsegment
@@ -17,7 +17,7 @@ from gppylib.gp_dbid import writeGpDbidFile
 from time import sleep
 from gppylib.operations.buildMirrorSegments import gDatabaseDirectories, gDatabaseFiles
 
-description = (""" 
+description = ("""
 
 Configure segment directories for installation into a pre-existing GPDB array.
 
@@ -41,7 +41,7 @@ class ValidationException(Exception):
 
 class ConfExpSegCmd(Command):
     def __init__(self, name, cmdstr, datadir, port, dbid, newseg, tarfile, useLighterDirectoryValidation, isPrimary,
-                    filespaceOids, filespaceDirs, verbose, validationOnly, writeGpDbidFileOnly):
+                     syncWithSegmentHostname, syncWithSegmentPort, verbose, validationOnly, writeGpDbidFileOnly):
         """
         @param useLighterDirectoryValidation if True then we don't require an empty directory; we just require that
                                              database stuff is not there.
@@ -53,9 +53,9 @@ class ConfExpSegCmd(Command):
         self.tarfile = tarfile
         self.verbose = verbose
         self.useLighterDirectoryValidation = useLighterDirectoryValidation
-        self.filespaceOids = filespaceOids
-        self.filespaceDirs = filespaceDirs
         self.isPrimary = isPrimary
+        self.syncWithSegmentHostname = syncWithSegmentHostname
+        self.syncWithSegmentPort = syncWithSegmentPort
 
         #
         # validationOnly if True then we validate directories and other simple things only; we don't
@@ -66,39 +66,31 @@ class ConfExpSegCmd(Command):
         self.writeGpDbidFileOnly = writeGpDbidFileOnly
         Command.__init__(self, name, cmdstr)
 
-    def validatePath(self, path, isSystemFilespaceDir):
+    def validatePath(self, path):
         """
         Raises ValidationException when a validation problem is detected
         """
 
         if not os.path.exists(os.path.dirname(path)):
+            logger.info("gpconfigurenewsegment:validatePath path %s does not exist" % path)
             raise ValidationException("Parent directory for %s directory '%s' does not exist" %
-                    ( "system data" if isSystemFilespaceDir else "filespace", path) )
+                    ("system data", path))
 
         if not os.path.exists(path):
-            #
-            # dir doesn't exist is okay -- other scripts, or filerep mirroring code, will create it
-            #
             return
 
         if self.useLighterDirectoryValidation:
 
-            if isSystemFilespaceDir:
-                # validate that we don't contain database directories or files
-                for toCheck in gDatabaseDirectories:
-                    if toCheck != "pg_log": # it's okay to have pg_log -- to save old logs around to look at
-                        if os.path.exists(os.path.join(path, toCheck)):
-                            raise ValidationException("Segment directory '%s' contains directory %s but should not!" %
-                                        (path, toCheck))
-                for toCheck in gDatabaseFiles:
+            # validate that we don't contain database directories or files
+            for toCheck in gDatabaseDirectories:
+                if toCheck != "pg_log": # it's okay to have pg_log -- to save old logs around to look at
                     if os.path.exists(os.path.join(path, toCheck)):
-                        raise ValidationException("Segment directory '%s' contains file %s but should not!" %
+                        raise ValidationException("Segment directory '%s' contains directory %s but should not!" %
                                     (path, toCheck))
-            else:
-
-                for name in os.listdir( path ):
-                    if name[0] in "0123456789": # the database files here will have  
-                        raise ValidationException("Filespace directory contains invalid file(s): '%s'" % path)
+            for toCheck in gDatabaseFiles:
+                if os.path.exists(os.path.join(path, toCheck)):
+                    raise ValidationException("Segment directory '%s' contains file %s but should not!" %
+                                              (path, toCheck))
         else:
             # it better be empty
             if len(os.listdir(path)) != 0:
@@ -109,27 +101,6 @@ class ConfExpSegCmd(Command):
             os.chmod(path, 0700)
         else:
             os.mkdir(path, 0700)
-            
-    def fixupFilespaces(self):
-        """
-        This method will take file spaces stored in the system data directory and put them in their proper locations.
-        """
-        if self.filespaceOids == None:
-            return
-        try:
-            logger.info("copy filespaces to their locations")
-           # only on primary do we create it -- otherwise, mirroring code creates it on replay
-            filespaceDataDir = self.datadir + "/" + DESTINATION_FILE_SPACES_DIRECTORY
-            i = 0
-            for i in range(len(self.filespaceOids)):
-                sourceDir = filespaceDataDir + "/" + str(self.filespaceOids[i])
-                targetDir = self.filespaceDirs[i]
-                cpCmd = unix.LocalDirCopy("copy filespace from %s to %s" % (sourceDir, targetDir), sourceDir, targetDir)
-                cpCmd.run(validateAfter=True)
-            unix.RemoveDirectory.local("remove filespace template after copy to proper location", filespaceDataDir)
-        except Exception, e:
-            self.set_results(CommandResult(1, '', e, True, False))
-            raise
 
     def run(self):
         try:
@@ -141,9 +112,7 @@ class ConfExpSegCmd(Command):
                     # make directories, extract template update postgresql.conf
                     logger.info("Validate data directories for new segment")
                     try:
-                        self.validatePath(self.datadir, True)
-                        for path in self.filespaceDirs:
-                            self.validatePath(path, False)
+                        self.validatePath(self.datadir)
                     except ValidationException, e:
                         msg = "for segment with port %s: %s" %  (self.port, e.getMessage())
                         self.set_results(CommandResult(1, '', msg, True, False))
@@ -153,16 +122,37 @@ class ConfExpSegCmd(Command):
                         raise
 
                     if self.validationOnly:
-                        self.set_results(CommandResult(0, '', '', True, False))
+                       self.set_results(CommandResult(0, '', '', True, False))
+                       return
+
+                    if not self.isPrimary:
+                        # Create a mirror based on the primary
+                        # We exclude certain unnecessary directories from being copied as they will greatly
+                        # slow down the speed of gpinitstandby if containing a lot of data
+                        cmd_str = ' '.join(['pg_basebackup',
+                                            '-x', '-R',
+                                            '-c', 'fast',
+                                            '-E', './pg_log',
+                                            '-E', './db_dumps',
+                                            '-E', './gpperfmon/data',
+                                            '-E', './gpperfmon/logs',
+                                            '-D', self.datadir,
+                                            '-h', self.syncWithSegmentHostname,
+                                            '-p', str(self.syncWithSegmentPort)])
+                        cmd = Command('pg_basebackup', cmd_str)
+                        try:
+                            cmd.run(validateAfter=True)
+                            self.set_results(CommandResult(0, '', '', True, False))
+                        except Exception, e:
+                            self.set_results(CommandResult(1,'',e,True,False))
+                            raise
+
+                        logger.info("ran pg_backbackup: %s" % cmd.cmdStr)
                         return
 
                     logger.info("Create or update data directories for new segment")
                     try:
                         self.makeOrUpdatePathAsNeeded(self.datadir)
-                        if self.isPrimary:
-                            # only on primary do we create it -- otherwise, mirroring code creates it on replay
-                            for path in self.filespaceDirs:
-                                self.makeOrUpdatePathAsNeeded(path)
                     except Exception, e:
                         self.set_results(CommandResult(1,'',e,True,False))
                         raise
@@ -176,10 +166,6 @@ class ConfExpSegCmd(Command):
                         self.set_results(extractTarCmd.get_results())
                         logger.error(extractTarCmd.get_results())
                         raise
-
-                    if self.isPrimary:
-                        # only on primary do we create it -- otherwise, mirroring code creates it on replay
-                        self.fixupFilespaces()
 
                     logger.info("create gp_dbid file for segment")
                     writeGpDbidFile(self.datadir, self.dbid, logger=gplog.get_logger_if_verbose())
@@ -209,7 +195,7 @@ class ConfExpSegCmd(Command):
                         stopCmd.run(validateAfter=True)
                     except:
                         pass
-                    
+
         except Exception, e:
             self.set_results(CommandResult(1, '', e, True, False))
             if self.verbose:
@@ -229,7 +215,7 @@ def getOidDirLists(oidDirs):
         dirList.append(oidDirs[i])
         i = i + 1
     return oidList, dirList
-        
+
 
 def parseargs():
     parser = OptParser(option_class=OptChecker,
@@ -237,9 +223,9 @@ def parseargs():
                 version='%prog version $Revision: $')
     parser.set_usage('%prog is a utility script used by gpexpand, gprecoverseg, and gpaddmirrors and is not intended to be run separately.')
     parser.remove_option('-h')
-    
+
     parser.add_option('-v','--verbose', action='store_true', help='debug output.')
-    parser.add_option('-c', '--confinfo', type='string')                        
+    parser.add_option('-c', '--confinfo', type='string')
     parser.add_option('-t', '--tarfile', type='string')
     parser.add_option('-n', '--newsegments', action='store_true')
     parser.add_option('-B', '--batch-size', type='int', default=DEFAULT_BATCH_SIZE, metavar='<batch_size>')
@@ -247,7 +233,7 @@ def parseargs():
     parser.add_option("-W", "--write-gpid-file-only", dest="writeGpidFileOnly", action='store_true', default=False)
 
     parser.set_defaults(verbose=False, filters=[], slice=(None, None))
-    
+
     # Parse the command line arguments
     (options, args) = parser.parse_args()
 
@@ -297,18 +283,22 @@ try:
     (options, args, seg_info) = parseargs()
     if options.verbose:
         gplog.enable_verbose_logging()
-        
+
     logger.info("Starting gpconfigurenewsegment with args: %s" % ' '.join(sys.argv[1:]))
-    
+
     pool = WorkerPool(numWorkers=options.batch_size)
-    
+
     for seg in seg_info:
         dataDir = seg[0]
         port = seg[1]
         isPrimary = seg[2] == "true"
         directoryValidationLevel = seg[3] == "true"
         dbid = int(seg[4])
-        filespaceOids, filespaceDirs = getOidDirLists(seg[5:])
+
+        # These variables should not be used if it's a primary
+        # they will be junk data passed through the config.
+        primaryHostName = seg[5]
+        primarySegmentPort = int(seg[6])
 
         cmd = ConfExpSegCmd( name = 'Configure segment directory'
                            , cmdstr = ' '.join(sys.argv)
@@ -319,8 +309,8 @@ try:
                            , tarfile = options.tarfile
                            , useLighterDirectoryValidation = directoryValidationLevel
                            , isPrimary = isPrimary
-                           , filespaceOids = filespaceOids
-                           , filespaceDirs = filespaceDirs
+                           , syncWithSegmentHostname = primaryHostName
+                           , syncWithSegmentPort = primarySegmentPort
                            , verbose = options.verbose
                            , validationOnly = options.validationOnly
                            , writeGpDbidFileOnly = options.writeGpidFileOnly

--- a/gpMgmt/bin/lib/gpconfigurenewsegment
+++ b/gpMgmt/bin/lib/gpconfigurenewsegment
@@ -28,8 +28,6 @@ Used by at least gpexpand, gprecoverseg, and gpaddmirrors
 DEFAULT_BATCH_SIZE=8
 EXECNAME = os.path.split(__file__)[-1]
 
-DESTINATION_FILE_SPACES_DIRECTORY = "fs_directory"
-
 class ValidationException(Exception):
 
     def __init__(self, msg):

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1349,7 +1349,7 @@ def impl(context, seg):
                                , utilityMode=False
                                , ctxt=REMOTE
                                , remoteHost=hostname
-                               , noWait=False
+                               , pg_ctl_wait=True
                                , timeout=300)
     segStartCmd.run(validateAfter=True)
 

--- a/src/backend/utils/gp/segadmin.c
+++ b/src/backend/utils/gp/segadmin.c
@@ -566,7 +566,7 @@ gp_add_segment_mirror(PG_FUNCTION_ARGS)
 
 	new.db.dbid = get_availableDbId();
 	new.db.mode = GP_SEGMENT_CONFIGURATION_MODE_NOTINSYNC;
-	new.db.status = GP_SEGMENT_CONFIGURATION_STATUS_DOWN;
+	new.db.status = GP_SEGMENT_CONFIGURATION_STATUS_UP;
 	new.db.role = GP_SEGMENT_CONFIGURATION_ROLE_MIRROR;
 	new.db.preferred_role = GP_SEGMENT_CONFIGURATION_ROLE_MIRROR;
 

--- a/src/backend/utils/gp/segadmin.c
+++ b/src/backend/utils/gp/segadmin.c
@@ -566,7 +566,7 @@ gp_add_segment_mirror(PG_FUNCTION_ARGS)
 
 	new.db.dbid = get_availableDbId();
 	new.db.mode = GP_SEGMENT_CONFIGURATION_MODE_NOTINSYNC;
-	new.db.status = GP_SEGMENT_CONFIGURATION_STATUS_UP;
+	new.db.status = GP_SEGMENT_CONFIGURATION_STATUS_DOWN;
 	new.db.role = GP_SEGMENT_CONFIGURATION_ROLE_MIRROR;
 	new.db.preferred_role = GP_SEGMENT_CONFIGURATION_ROLE_MIRROR;
 


### PR DESCRIPTION
The gpexpand utility and associated code are modified to work with the WALREP
code.  Previously, gpexpand only worked with the primaries and relied on Filerep
to populate the mirrors. We are changing gpexpand such that it initializes the
mirrors using pg_basebackup and set them up for WAL replication.

Also, since the WALREP branch removed Filespaces, so we have also done the same
and replaced references to Filespaces by the Data Directory of the segments.

This PR supersedes https://github.com/greenplum-db/gpdb/pull/4302.

Author: Marbin Tan <mtan@pivotal.io>
Author: Shoaib Lari <slari@pivotal.io>
Author: Nadeem Ghani <nghani@pivotal.io>