### PR TITLE
Fix assertion failure

### DIFF
--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -1597,7 +1597,7 @@ GetSnapshotData(Snapshot snapshot)
 						(errmsg("GetSnapshotData(): READER currentcommandid %d curcid %d segmatesync %d",
 								GetCurrentCommandId(false), snapshot->curcid, segmateSync)));
 
-				if (TransactionXmin > snapshot->xmin)
+				if (TransactionIdPrecedes(snapshot->xmin, TransactionXmin))
 					TransactionXmin = snapshot->xmin;
 
 				return snapshot;

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -1597,6 +1597,9 @@ GetSnapshotData(Snapshot snapshot)
 						(errmsg("GetSnapshotData(): READER currentcommandid %d curcid %d segmatesync %d",
 								GetCurrentCommandId(false), snapshot->curcid, segmateSync)));
 
+				if (TransactionXmin > snapshot->xmin)
+					TransactionXmin = snapshot->xmin;
+
 				return snapshot;
 			}
 			else


### PR DESCRIPTION
Entry DB process share snapshot with QD process, but it didn't update
the TransactionXmin. The assert in SubTransGetData() will fail in some
cases:
   Assert(TransactionIdFollowsOrEquals(xid, TransactionXmin));

1.QD takes a snapshot which contains a in-progress transaction A.
2.Transaction A commits.
3.QD creates a gang of entry DB. The entry DB process takes a snapshot
in InitPostgres and updates TransactionXmin.
4.The entry DB process scans the tuple inserted by the transaction A,
and find it's in the snapshot but its xid is larger than TransactionXmin.