### PR TITLE
Fix standby's tablespace directory issue of gpinitstandby

### DIFF
--- a/gpMgmt/bin/gpinitstandby
+++ b/gpMgmt/bin/gpinitstandby
@@ -287,31 +287,59 @@ def delete_standby(options):
 
     # Reenable Ctrl-C
     signal.signal(signal.SIGINT,signal.default_int_handler)
-  
+
+
+#-------------------------------------------------------------------------
+def get_tablespace_paths(standby_dbid):
+    dburl = getDbUrlForInitStandby()
+    conn = dbconn.connect(dburl, utility=True)
+    sql = ("SELECT gp_tablespace_path(spclocation, %d) FROM pg_tablespace WHERE spcname "
+           "<> 'pg_default' AND spcname <> 'pg_global'") % standby_dbid
+    cur = dbconn.execSQL(conn, sql)
+
+    paths = []
+    for tblspc_path in cur.fetchall():
+        paths.append(tblspc_path[0])
+
+    conn.close()
+    return paths
+
+
+#-------------------------------------------------------------------------
+def do_remove_standby_datadir(standby_datadir, standby_host, standby_dbid):
+    pool = base.WorkerPool(numWorkers=DEFAULT_BATCH_SIZE)
+
+    cmd = unix.RemoveDirectory('delete standby datadir',
+                               standby_datadir, ctxt=base.REMOTE,
+                               remoteHost=standby_host)
+    pool.addCommand(cmd)
+
+    for tablespace_path in get_tablespace_paths(standby_dbid):
+        cmd = unix.RemoveDirectory('delete standby tablespace dir:%s' % (tablespace_path),
+                                   tablespace_path, ctxt=base.REMOTE,
+                                   remoteHost=standby_host)
+        pool.addCommand(cmd)
+
+    pool.join()
+    try:
+        pool.check_results()
+    except Exception, ex:
+        logger.error('Failed to remove data directory on standby master.')
+        raise GpInitStandbyException(ex)
+    finally:
+        pool.haltWork()
+
+
 #-------------------------------------------------------------------------
 def remove_standby_datadir(array):
     """Removes the data directory on the standby master."""
 
-    # WALREP_FIXME: We should also remove tablespace paths for the server here.
-
     if array.standbyMaster:
         logger.info('Removing data directory on standby master...')
-       
-        pool = base.WorkerPool(numWorkers=DEFAULT_BATCH_SIZE)
-        
-        cmd = unix.RemoveDirectory('delete standby datadir',
-                                   array.standbyMaster.getSegmentDataDirectory(), ctxt=base.REMOTE,
-                                   remoteHost=array.standbyMaster.getSegmentHostName())
-        pool.addCommand(cmd)
+        do_remove_standby_datadir(array.standbyMaster.getSegmentDataDirectory(),
+                                  array.standbyMaster.getSegmentHostName(),
+                                  array.standbyMaster.getSegmentDbId())
 
-        pool.join()
-        try:
-            pool.check_results()
-        except Exception, ex:
-            logger.error('Failed to remove data directory on standby master.')
-            raise GpInitStandbyException(ex)
-        finally:
-            pool.haltWork()
             
 def check_and_start_standby():
     """Checks if standby master is up and starts the standby master, if stopped."""
@@ -325,6 +353,7 @@ def check_and_start_standby():
     conn = dbconn.connect(dburl, utility=True)
     sql = "SELECT * FROM pg_stat_replication"
     cur = dbconn.execSQL(conn, sql)
+
     if cur.rowcount >= 1:
         logger.info("Standy master is already up and running.")
         return
@@ -457,6 +486,7 @@ def create_standby(options):
             logger.info('Restoring pg_hba.conf file...')
             restore_pg_hba_on_segment(array)
             undo_update_pg_hba_conf(array)
+            do_remove_standby_datadir(standby.datadir, standby.hostname, standby.dbid)
 
         raise GpInitStandbyException(ex)
 
@@ -700,7 +730,8 @@ def copy_master_datadir_to_standby(options, array, standby_datadir):
                         '-E', './gpperfmon/logs',
                         '-D', standby_datadir,
                         '-h', array.master.getSegmentHostName(),
-                        '-p', str(array.master.getSegmentPort())])
+                        '-p', str(array.master.getSegmentPort()),
+                        '--target-dbid', str(array.standbyMaster.getSegmentDbId())])
     cmd = base.Command('pg_basebackup',
                        cmd_str,
                        ctxt=base.REMOTE,


### PR DESCRIPTION
* Add option in pg_basebackup: --target-dbid, which is used by gpinitstandby.
target-dbid is passed in so that pg_basebackup know how to backup tablespace related
data, and won't conflict with primary tablespace on the same machine and tablespace
points to same location.

* Enhance gpinitstandby -r to cleanup tablespace related folders when standby is removed.

The issue not resolved is for gpactivatestandby. Currently, for some reason, we change gpdbid
of standby back to 1, which is the old primary gpdbid. This hehavior makes tablespace inconsitent.

Author: Xiaoran Wang <xiwang@pivotal.io>
Author: Max Yang <myang@pivotal.io>