### PR TITLE
Fix get_attstatsslot()/free_attstatsslot() when statistics are broken.

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -577,16 +577,12 @@ gpdb::PlExtractNodesExpression
 void
 gpdb::FreeAttrStatsSlot
 	(
-	Oid atttype,
-	Datum *pValues,
-	int iValues,
-	float4 *pNumbers,
-	int iNumbers
+	AttStatsSlot *sslot
 	)
 {
 	GP_WRAP_START;
 	{
-		free_attstatsslot(atttype, pValues, iValues, pNumbers, iNumbers);
+		free_attstatsslot(sslot);
 		return;
 	}
 	GP_WRAP_END;
@@ -774,20 +770,16 @@ gpdb::OidArrayType
 bool
 gpdb::FGetAttrStatsSlot
 	(
+	AttStatsSlot *sslot,
 	HeapTuple statstuple,
-	Oid atttype,
-	int32 atttypmod,
 	int iReqKind,
 	Oid reqop,
-	Datum **ppValues,
-	int *iValues,
-	float4 **ppfNumbers,
-	int *piNumbers
+	int flags
 	)
 {
 	GP_WRAP_START;
 	{
-		return get_attstatsslot(statstuple, atttype, atttypmod, iReqKind, reqop, ppValues, iValues, ppfNumbers, piNumbers);
+		return get_attstatsslot(sslot, statstuple, iReqKind, reqop, flags);
 	}
 	GP_WRAP_END;
 	return false;

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -2385,33 +2385,32 @@ CTranslatorRelcacheToDXL::PimdobjColStats
 		return CDXLColStats::PdxlcolstatsDummy(pmp, pmdidColStats, pmdnameCol, dWidth);
 	}
 
+	// histogram values extracted from the pg_statistic tuple for a given column
+	AttStatsSlot histSlot;
 
-	Datum	   *pdrgdatumMCVValues = NULL;
-	int			iNumMCVValues = 0;
-	float4	   *pdrgfMCVFrequencies = NULL;
-	int			iNumMCVFrequencies = 0;
-	Datum		*pdrgdatumHistValues = NULL;
-	int			iNumHistValues = 0;
+	// most common values and their frequencies extracted from the pg_statistic
+	// tuple for a given column
+	AttStatsSlot mcvSlot;
 
 	(void)	gpdb::FGetAttrStatsSlot
 			(
+					&mcvSlot,
 					heaptupleStats,
-					oidAttType,
-					-1,
 					STATISTIC_KIND_MCV,
 					InvalidOid,
-					&pdrgdatumMCVValues, &iNumMCVValues,
-					&pdrgfMCVFrequencies, &iNumMCVFrequencies
+					ATTSTATSSLOT_VALUES | ATTSTATSSLOT_NUMBERS
 			);
 
-	if (iNumMCVValues != iNumMCVFrequencies)
+	if (mcvSlot.nvalues != mcvSlot.nnumbers)
 	{
-		// if the number of MCVs and number of MCFs do not match, we discard the MCVs and MCFs
-		gpdb::FreeAttrStatsSlot(oidAttType, pdrgdatumMCVValues, iNumMCVValues, pdrgfMCVFrequencies, iNumMCVFrequencies);
-		iNumMCVValues = 0;
-		iNumMCVFrequencies = 0;
-		pdrgdatumMCVValues = NULL;
-		pdrgfMCVFrequencies = NULL;
+		// if the number of MCVs(nvalues) and number of MCFs(nnumbers) do not match, we discard the MCVs and MCFs
+		gpdb::FreeAttrStatsSlot(&mcvSlot);
+		mcvSlot.numbers = NULL;
+		mcvSlot.values = NULL;
+		mcvSlot.values_arr = NULL;
+		mcvSlot.numbers_arr = NULL;
+		mcvSlot.nnumbers = 0;
+		mcvSlot.nvalues = 0;
 
 		char msgbuf[NAMEDATALEN * 2 + 100];
 		snprintf(msgbuf, sizeof(msgbuf), "The number of most common values and frequencies do not match on column %ls of table %ls.",
@@ -2434,7 +2433,7 @@ CTranslatorRelcacheToDXL::PimdobjColStats
 	}
 
 	// fix mcv and null frequencies (sometimes they can add up to more than 1.0)
-	NormalizeFrequencies(pdrgfMCVFrequencies, (ULONG) iNumMCVValues, &dNullFrequency);
+	NormalizeFrequencies(mcvSlot.numbers, (ULONG) mcvSlot.nvalues, &dNullFrequency);
 
 	// column width
 	CDouble dWidth = CDouble(fpsStats->stawidth);
@@ -2454,21 +2453,20 @@ CTranslatorRelcacheToDXL::PimdobjColStats
 
 	// total MCV frequency
 	CDouble dMCFSum = 0.0;
-	for (int i = 0; i < iNumMCVValues; i++)
+	for (int i = 0; i < mcvSlot.nvalues; i++)
 	{
-		dMCFSum = dMCFSum + CDouble(pdrgfMCVFrequencies[i]);
+		dMCFSum = dMCFSum + CDouble(mcvSlot.numbers[i]);
 	}
 
 	// get histogram datums from pg_statistic entry
 	(void) gpdb::FGetAttrStatsSlot
 			(
+					&histSlot,
 					heaptupleStats,
-					oidAttType,
-					-1,
 					STATISTIC_KIND_HISTOGRAM,
 					InvalidOid,
-					&pdrgdatumHistValues, &iNumHistValues,
-					NULL, NULL);
+					ATTSTATSSLOT_VALUES
+			);
 
 	CDouble dNDVBuckets(0.0);
 	CDouble dFreqBuckets(0.0);
@@ -2487,11 +2485,11 @@ CTranslatorRelcacheToDXL::PimdobjColStats
 		 oidAttType,
 		 dDistinct,
 		 dNullFrequency,
-		 pdrgdatumMCVValues,
-		 pdrgfMCVFrequencies,
-		 ULONG(iNumMCVValues),
-		 pdrgdatumHistValues,
-		 ULONG(iNumHistValues)
+		 mcvSlot.values,
+		 mcvSlot.numbers,
+		 ULONG(mcvSlot.nvalues),
+		 histSlot.values,
+		 ULONG(histSlot.nvalues)
 		 );
 
 		GPOS_ASSERT(NULL != pdrgpdxlbucketTransformed);
@@ -2521,8 +2519,8 @@ CTranslatorRelcacheToDXL::PimdobjColStats
 	}
 
 	// free up allocated datum and float4 arrays
-	gpdb::FreeAttrStatsSlot(oidAttType, pdrgdatumMCVValues, iNumMCVValues, pdrgfMCVFrequencies, iNumMCVFrequencies);
-	gpdb::FreeAttrStatsSlot(oidAttType, pdrgdatumHistValues, iNumHistValues, NULL, 0);
+	gpdb::FreeAttrStatsSlot(&mcvSlot);
+	gpdb::FreeAttrStatsSlot(&histSlot);
 
 	gpdb::FreeHeapTuple(heaptupleStats);
 

--- a/src/backend/utils/adt/selfuncs.c
+++ b/src/backend/utils/adt/selfuncs.c
@@ -138,11 +138,11 @@ static Const *string_to_bytea_const(const char *str, size_t str_len);
 
 static Selectivity
 mcv_selectivity_cdb(VariableStatData   *vardata,
-                    FmgrInfo           *opproc,
-				    Datum               constval,
-                    bool                varonleft,
-				    Selectivity        *sumcommonp,     /* OUT */
-                    double             *nvaluesp);      /* OUT */
+					FmgrInfo           *opproc,
+					Datum               constval,
+					bool                varonleft,
+					Selectivity        *sumcommonp,     /* OUT */
+					double             *nvaluesp);      /* OUT */
 
 
 /*
@@ -163,10 +163,6 @@ eqsel(PG_FUNCTION_ARGS)
 	VariableStatData vardata;
 	Node	   *other = NULL;
 	bool		varonleft = false;
-	Datum	   *values;
-	int			nvalues;
-	float4	   *numbers;
-	int			nnumbers;
 	double		selec;
 
 	/*
@@ -192,6 +188,7 @@ eqsel(PG_FUNCTION_ARGS)
 	{
 		Form_pg_statistic stats;
 		HeapTuple tp = getStatsTuple(&vardata);
+		AttStatsSlot sslot;
 
 		stats = (Form_pg_statistic) GETSTRUCT(tp);
 
@@ -209,27 +206,25 @@ eqsel(PG_FUNCTION_ARGS)
 			 * test.  If you don't like this, maybe you shouldn't be using
 			 * eqsel for your operator...)
 			 */
-			if (get_attstatsslot(tp,
-								 vardata.atttype, vardata.atttypmod,
-								 STATISTIC_KIND_MCV, InvalidOid,
-								 &values, &nvalues,
-								 &numbers, &nnumbers))
+			if (get_attstatsslot(&sslot,tp,
+							 STATISTIC_KIND_MCV, InvalidOid,
+							 ATTSTATSSLOT_VALUES | ATTSTATSSLOT_NUMBERS))
 			{
 				FmgrInfo	eqproc;
 
 				fmgr_info(get_opcode(operator), &eqproc);
 
-				for (i = 0; i < nvalues; i++)
+				for (i = 0; i < sslot.nvalues; i++)
 				{
 					/* be careful to apply operator right way 'round */
 					if (varonleft)
 						match = DatumGetBool(FunctionCall2(&eqproc,
-														   values[i],
+														   sslot.values[i],
 														   constval));
 					else
 						match = DatumGetBool(FunctionCall2(&eqproc,
 														   constval,
-														   values[i]));
+														   sslot.values[i]));
 					if (match)
 						break;
 				}
@@ -237,9 +232,7 @@ eqsel(PG_FUNCTION_ARGS)
 			else
 			{
 				/* no most-common-value info available */
-				values = NULL;
-				numbers = NULL;
-				i = nvalues = nnumbers = 0;
+				i = 0;	/* keep compiler quiet */
 			}
 
 			if (match)
@@ -249,7 +242,7 @@ eqsel(PG_FUNCTION_ARGS)
 				 * exactly (or as exactly as ANALYZE could calculate it,
 				 * anyway).
 				 */
-				selec = numbers[i];
+				selec = sslot.numbers[i];
 			}
 			else
 			{
@@ -261,8 +254,8 @@ eqsel(PG_FUNCTION_ARGS)
 				double		sumcommon = 0.0;
 				double		otherdistinct;
 
-				for (i = 0; i < nnumbers; i++)
-					sumcommon += numbers[i];
+				for (i = 0; i < sslot.nnumbers; i++)
+					sumcommon += sslot.numbers[i];
 				selec = 1.0 - sumcommon - stats->stanullfrac;
 				CLAMP_PROBABILITY(selec);
 
@@ -273,7 +266,7 @@ eqsel(PG_FUNCTION_ARGS)
 				 * distinct values.
 				 */
 				otherdistinct = get_variable_numdistinct(&vardata)
-					- nnumbers;
+					- sslot.nnumbers;
 				if (otherdistinct > 1)
 					selec /= otherdistinct;
 
@@ -281,12 +274,11 @@ eqsel(PG_FUNCTION_ARGS)
 				 * Another cross-check: selectivity shouldn't be estimated as
 				 * more than the least common "most common value".
 				 */
-				if (nnumbers > 0 && selec > numbers[nnumbers - 1])
-					selec = numbers[nnumbers - 1];
+				if (sslot.nnumbers > 0 && selec > sslot.numbers[sslot.nnumbers - 1])
+					selec = sslot.numbers[sslot.nnumbers - 1];
 			}
 
-			free_attstatsslot(vardata.atttype, values, nvalues,
-							  numbers, nnumbers);
+			free_attstatsslot(&sslot);
 		}
 		else
 		{
@@ -311,15 +303,13 @@ eqsel(PG_FUNCTION_ARGS)
 			 * Cross-check: selectivity should never be estimated as more than
 			 * the most common value's.
 			 */
-			if (get_attstatsslot(tp,
-								 vardata.atttype, vardata.atttypmod,
+			if (get_attstatsslot(&sslot, tp,
 								 STATISTIC_KIND_MCV, InvalidOid,
-								 NULL, NULL,
-								 &numbers, &nnumbers))
+								 ATTSTATSSLOT_NUMBERS))
 			{
-				if (nnumbers > 0 && selec > numbers[0])
-					selec = numbers[0];
-				free_attstatsslot(vardata.atttype, NULL, 0, numbers, nnumbers);
+				if (sslot.nnumbers > 0 && selec > sslot.numbers[0])
+					selec = sslot.numbers[0];
+				free_attstatsslot(&sslot);
 			}
 		}
 	}
@@ -472,8 +462,8 @@ scalarineqsel(PlannerInfo *root, Oid operator, bool isgt,
  */
 double
 mcv_selectivity(VariableStatData *vardata, FmgrInfo *opproc,
-				Datum constval, bool varonleft,
-				double *sumcommonp)
+                               Datum constval, bool varonleft,
+                               double *sumcommonp)
 {
     return mcv_selectivity_cdb(vardata, opproc, constval, varonleft,
                                sumcommonp, NULL);
@@ -481,50 +471,46 @@ mcv_selectivity(VariableStatData *vardata, FmgrInfo *opproc,
 
 static Selectivity
 mcv_selectivity_cdb(VariableStatData   *vardata,
-                    FmgrInfo           *opproc,
-				    Datum               constval,
-                    bool                varonleft,
-				    Selectivity        *sumcommonp,     /* OUT */
-                    double             *nvaluesp)       /* OUT */
+					FmgrInfo           *opproc,
+					Datum               constval,
+					bool                varonleft,
+					Selectivity        *sumcommonp,     /* OUT */
+					double        *nvaluesp)     /* OUT */
 {
 	double		mcv_selec,
 				sumcommon;
-	Datum	   *values;
-	int			nvalues = 0;
-	float4	   *numbers;
-	int			nnumbers;
+	AttStatsSlot sslot;
 	int			i;
 	HeapTuple	tp = getStatsTuple(vardata);
 
 	mcv_selec = 0.0;
 	sumcommon = 0.0;
 
+	memset(&sslot, 0, sizeof(AttStatsSlot));
+
 	if (HeapTupleIsValid(tp) &&
-		get_attstatsslot(tp,
-						 vardata->atttype, vardata->atttypmod,
+		get_attstatsslot(&sslot, tp,
 						 STATISTIC_KIND_MCV, InvalidOid,
-						 &values, &nvalues,
-						 &numbers, &nnumbers))
+						 ATTSTATSSLOT_VALUES | ATTSTATSSLOT_NUMBERS))
 	{
-		for (i = 0; i < nvalues; i++)
+		for (i = 0; i < sslot.nvalues; i++)
 		{
 			if (varonleft ?
 				DatumGetBool(FunctionCall2(opproc,
-										   values[i],
+										   sslot.values[i],
 										   constval)) :
 				DatumGetBool(FunctionCall2(opproc,
 										   constval,
-										   values[i])))
-				mcv_selec += numbers[i];
-			sumcommon += numbers[i];
+										   sslot.values[i])))
+				mcv_selec += sslot.numbers[i];
+			sumcommon += sslot.numbers[i];
 		}
-		free_attstatsslot(vardata->atttype, values, nvalues,
-						  numbers, nnumbers);
+		free_attstatsslot(&sslot);
 	}
 
 	*sumcommonp = sumcommon;
 	if (nvaluesp)
-		*nvaluesp = nvalues;
+		*nvaluesp = sslot.nvalues;
 	return mcv_selec;
 }
 
@@ -560,42 +546,39 @@ histogram_selectivity(VariableStatData *vardata, FmgrInfo *opproc,
 					  int min_hist_size, int n_skip)
 {
 	double		result;
-	Datum	   *values;
-	int			nvalues;
 	HeapTuple	tp = getStatsTuple(vardata);
+	AttStatsSlot sslot;
 
 	/* check sanity of parameters */
 	Assert(n_skip >= 0);
 	Assert(min_hist_size > 2 * n_skip);
 
 	if (HeapTupleIsValid(tp) &&
-		get_attstatsslot(tp,
-						 vardata->atttype, vardata->atttypmod,
+		get_attstatsslot(&sslot, tp,
 						 STATISTIC_KIND_HISTOGRAM, InvalidOid,
-						 &values, &nvalues,
-						 NULL, NULL))
+						 ATTSTATSSLOT_VALUES))
 	{
-		if (nvalues >= min_hist_size)
+		if (sslot.nvalues >= min_hist_size)
 		{
 			int			nmatch = 0;
 			int			i;
 
-			for (i = n_skip; i < nvalues - n_skip; i++)
+			for (i = n_skip; i < sslot.nvalues - n_skip; i++)
 			{
 				if (varonleft ?
 					DatumGetBool(FunctionCall2(opproc,
-											   values[i],
+											   sslot.values[i],
 											   constval)) :
 					DatumGetBool(FunctionCall2(opproc,
 											   constval,
-											   values[i])))
+											   sslot.values[i])))
 					nmatch++;
 			}
-			result = ((double) nmatch) / ((double) (nvalues - 2 * n_skip));
+			result = ((double) nmatch) / ((double) (sslot.nvalues - 2 * n_skip));
 		}
 		else
 			result = -1;
-		free_attstatsslot(vardata->atttype, values, nvalues, NULL, 0);
+		free_attstatsslot(&sslot);
 	}
 	else
 		result = -1;
@@ -622,9 +605,8 @@ ineq_histogram_selectivity(VariableStatData *vardata,
 						   Datum constval, Oid consttype)
 {
 	double		hist_selec;
-	Datum	   *values;
-	int			nvalues;
 	HeapTuple	tp = getStatsTuple(vardata);
+	AttStatsSlot sslot;
 
 	hist_selec = 0.0;
 
@@ -639,13 +621,11 @@ ineq_histogram_selectivity(VariableStatData *vardata,
 	 * the reverse way if isgt is TRUE.
 	 */
 	if (HeapTupleIsValid(tp) &&
-		get_attstatsslot(tp,
-						 vardata->atttype, vardata->atttypmod,
+		get_attstatsslot(&sslot, tp,
 						 STATISTIC_KIND_HISTOGRAM, InvalidOid,
-						 &values, &nvalues,
-						 NULL, NULL))
+						 ATTSTATSSLOT_VALUES))
 	{
-		if (nvalues > 1)
+		if (sslot.nvalues > 1)
 		{
 			/*
 			 * Use binary search to find proper location, ie, the first slot
@@ -656,7 +636,7 @@ ineq_histogram_selectivity(VariableStatData *vardata,
 			 */
 			double		histfrac;
 			int			lobound = 0;	/* first possible slot to search */
-			int			hibound = nvalues;		/* last+1 slot to search */
+			int			hibound = sslot.nvalues;		/* last+1 slot to search */
 
 			while (lobound < hibound)
 			{
@@ -664,7 +644,7 @@ ineq_histogram_selectivity(VariableStatData *vardata,
 				bool		ltcmp;
 
 				ltcmp = DatumGetBool(FunctionCall2(opproc,
-												   values[probe],
+												   sslot.values[probe],
 												   constval));
 				if (isgt)
 					ltcmp = !ltcmp;
@@ -679,7 +659,7 @@ ineq_histogram_selectivity(VariableStatData *vardata,
 				/* Constant is below lower histogram boundary. */
 				histfrac = 0.0;
 			}
-			else if (lobound >= nvalues)
+			else if (lobound >= sslot.nvalues)
 			{
 				/* Constant is above upper histogram boundary. */
 				histfrac = 1.0;
@@ -700,7 +680,7 @@ ineq_histogram_selectivity(VariableStatData *vardata,
 				 * interpolation within this bin.
 				 */
 				if (convert_to_scalar(constval, consttype, &val,
-									  values[i - 1], values[i],
+									  sslot.values[i - 1], sslot.values[i],
 									  vardata->vartype,
 									  &low, &high, isgt))
 				{
@@ -747,7 +727,7 @@ ineq_histogram_selectivity(VariableStatData *vardata,
 				 * binfrac partial bin below the constant.
 				 */
 				histfrac = (double) (i - 1) + binfrac;
-				histfrac /= (double) (nvalues - 1);
+				histfrac /= (double) (sslot.nvalues - 1);
 			}
 
 			/*
@@ -769,7 +749,7 @@ ineq_histogram_selectivity(VariableStatData *vardata,
 				hist_selec = 0.9999;
 		}
 
-		free_attstatsslot(vardata->atttype, values, nvalues, NULL, 0);
+		free_attstatsslot(&sslot);
 	}
 
 	return hist_selec;
@@ -1287,22 +1267,17 @@ booltestsel(PlannerInfo *root, BoolTestType booltesttype, Node *arg,
 	{
 		Form_pg_statistic stats;
 		double		freq_null;
-		Datum	   *values;
-		int			nvalues;
-		float4	   *numbers;
-		int			nnumbers;
-		HeapTuple	tp = getStatsTuple(&vardata);
+		AttStatsSlot sslot;
 
+		HeapTuple	tp = getStatsTuple(&vardata);
 
 		stats = (Form_pg_statistic) GETSTRUCT(tp);
 		freq_null = stats->stanullfrac;
 
-		if (get_attstatsslot(tp,
-							 vardata.atttype, vardata.atttypmod,
+		if (get_attstatsslot(&sslot, tp,
 							 STATISTIC_KIND_MCV, InvalidOid,
-							 &values, &nvalues,
-							 &numbers, &nnumbers)
-			&& nnumbers > 0)
+							 ATTSTATSSLOT_VALUES | ATTSTATSSLOT_NUMBERS)
+			&& sslot.nnumbers > 0)
 		{
 			double		freq_true;
 			double		freq_false;
@@ -1310,10 +1285,10 @@ booltestsel(PlannerInfo *root, BoolTestType booltesttype, Node *arg,
 			/*
 			 * Get first MCV frequency and derive frequency for true.
 			 */
-			if (DatumGetBool(values[0]))
-				freq_true = numbers[0];
+			if (DatumGetBool(sslot.values[0]))
+				freq_true = sslot.numbers[0];
 			else
-				freq_true = 1.0 - numbers[0] - freq_null;
+				freq_true = 1.0 - sslot.numbers[0] - freq_null;
 
 			/*
 			 * Next derive frequency for false. Then use these as appropriate
@@ -1354,8 +1329,7 @@ booltestsel(PlannerInfo *root, BoolTestType booltesttype, Node *arg,
 					break;
 			}
 
-			free_attstatsslot(vardata.atttype, values, nvalues,
-							  numbers, nnumbers);
+			free_attstatsslot(&sslot);
 		}
 		else
 		{
@@ -1848,45 +1822,35 @@ eqjoinsel(PG_FUNCTION_ARGS)
 	Form_pg_statistic stats1 = NULL;
 	Form_pg_statistic stats2 = NULL;
 	bool		have_mcvs1 = false;
-	Datum	   *values1 = NULL;
-	int			nvalues1 = 0;
-	float4	   *numbers1 = NULL;
-	int			nnumbers1 = 0;
 	bool		have_mcvs2 = false;
-	Datum	   *values2 = NULL;
-	int			nvalues2 = 0;
-	float4	   *numbers2 = NULL;
-	int			nnumbers2 = 0;
+	AttStatsSlot sslot1;
+	AttStatsSlot sslot2;
 
 	get_join_variables(root, args, &vardata1, &vardata2);
 
 	nd1 = get_variable_numdistinct(&vardata1);
 	nd2 = get_variable_numdistinct(&vardata2);
 
+	memset(&sslot1, 0, sizeof(sslot1));
+	memset(&sslot2, 0, sizeof(sslot2));
+
 	if (HeapTupleIsValid(getStatsTuple(&vardata1)))
 	{
 		HeapTuple tp = getStatsTuple(&vardata1);
 		stats1 = (Form_pg_statistic) GETSTRUCT(tp);
-		have_mcvs1 = get_attstatsslot(tp,
-									  vardata1.atttype,
-									  vardata1.atttypmod,
-									  STATISTIC_KIND_MCV,
-									  InvalidOid,
-									  &values1, &nvalues1,
-									  &numbers1, &nnumbers1);
+		have_mcvs1 = get_attstatsslot(&sslot1, tp,
+									  STATISTIC_KIND_MCV, InvalidOid,
+							 ATTSTATSSLOT_VALUES | ATTSTATSSLOT_NUMBERS);
+
 	}
 
 	if (HeapTupleIsValid(getStatsTuple(&vardata2)))
 	{
 		HeapTuple tp = getStatsTuple(&vardata2);
 		stats2 = (Form_pg_statistic) GETSTRUCT(tp);
-		have_mcvs2 = get_attstatsslot(tp,
-									  vardata2.atttype,
-									  vardata2.atttypmod,
-									  STATISTIC_KIND_MCV,
-									  InvalidOid,
-									  &values2, &nvalues2,
-									  &numbers2, &nnumbers2);
+		have_mcvs2 = get_attstatsslot(&sslot2, tp,
+									  STATISTIC_KIND_MCV, InvalidOid,
+							 ATTSTATSSLOT_VALUES | ATTSTATSSLOT_NUMBERS);
 	}
 
 	if (have_mcvs1 && have_mcvs2)
@@ -1921,8 +1885,8 @@ eqjoinsel(PG_FUNCTION_ARGS)
 					nmatches;
 
 		fmgr_info(get_opcode(operator), &eqproc);
-		hasmatch1 = (bool *) palloc0(nvalues1 * sizeof(bool));
-		hasmatch2 = (bool *) palloc0(nvalues2 * sizeof(bool));
+		hasmatch1 = (bool *) palloc0(sslot1.nvalues * sizeof(bool));
+		hasmatch2 = (bool *) palloc0(sslot2.nvalues * sizeof(bool));
 
 		/*
 		 * If we are doing any variant of JOIN_IN, pretend all the values of
@@ -1944,8 +1908,8 @@ eqjoinsel(PG_FUNCTION_ARGS)
 		{
 			float4		oneovern = 1.0 / nd2;
 
-			for (i = 0; i < nvalues2; i++)
-				numbers2[i] = oneovern;
+			for (i = 0; i < sslot2.nvalues; i++)
+				sslot2.numbers[i] = oneovern;
 			nullfrac2 = oneovern;
 		}
 
@@ -1957,20 +1921,20 @@ eqjoinsel(PG_FUNCTION_ARGS)
 		 */
 		matchprodfreq = 0.0;
 		nmatches = 0;
-		for (i = 0; i < nvalues1; i++)
+		for (i = 0; i < sslot1.nvalues; i++)
 		{
 			int			j;
 
-			for (j = 0; j < nvalues2; j++)
+			for (j = 0; j < sslot2.nvalues; j++)
 			{
 				if (hasmatch2[j])
 					continue;
 				if (DatumGetBool(FunctionCall2(&eqproc,
-											   values1[i],
-											   values2[j])))
+											   sslot1.values[i],
+											   sslot2.values[j])))
 				{
 					hasmatch1[i] = hasmatch2[j] = true;
-					matchprodfreq += numbers1[i] * numbers2[j];
+					matchprodfreq += sslot1.numbers[i] * sslot2.numbers[j];
 					nmatches++;
 					break;
 				}
@@ -1979,22 +1943,22 @@ eqjoinsel(PG_FUNCTION_ARGS)
 		CLAMP_PROBABILITY(matchprodfreq);
 		/* Sum up frequencies of matched and unmatched MCVs */
 		matchfreq1 = unmatchfreq1 = 0.0;
-		for (i = 0; i < nvalues1; i++)
+		for (i = 0; i < sslot1.nvalues; i++)
 		{
 			if (hasmatch1[i])
-				matchfreq1 += numbers1[i];
+				matchfreq1 += sslot1.numbers[i];
 			else
-				unmatchfreq1 += numbers1[i];
+				unmatchfreq1 += sslot1.numbers[i];
 		}
 		CLAMP_PROBABILITY(matchfreq1);
 		CLAMP_PROBABILITY(unmatchfreq1);
 		matchfreq2 = unmatchfreq2 = 0.0;
-		for (i = 0; i < nvalues2; i++)
+		for (i = 0; i < sslot2.nvalues; i++)
 		{
 			if (hasmatch2[i])
-				matchfreq2 += numbers2[i];
+				matchfreq2 += sslot2.numbers[i];
 			else
-				unmatchfreq2 += numbers2[i];
+				unmatchfreq2 += sslot2.numbers[i];
 		}
 		CLAMP_PROBABILITY(matchfreq2);
 		CLAMP_PROBABILITY(unmatchfreq2);
@@ -2019,15 +1983,15 @@ eqjoinsel(PG_FUNCTION_ARGS)
 		 * MCVs plus non-MCV values.
 		 */
 		totalsel1 = matchprodfreq;
-		if (nd2 > nvalues2)
-			totalsel1 += unmatchfreq1 * otherfreq2 / (nd2 - nvalues2);
+		if (nd2 > sslot2.nvalues)
+			totalsel1 += unmatchfreq1 * otherfreq2 / (nd2 - sslot2.nvalues);
 		if (nd2 > nmatches)
 			totalsel1 += otherfreq1 * (otherfreq2 + unmatchfreq2) /
 				(nd2 - nmatches);
 		/* Same estimate from the point of view of relation 2. */
 		totalsel2 = matchprodfreq;
-		if (nd1 > nvalues1)
-			totalsel2 += unmatchfreq2 * otherfreq1 / (nd1 - nvalues1);
+		if (nd1 > sslot1.nvalues)
+			totalsel2 += unmatchfreq2 * otherfreq1 / (nd1 - sslot1.nvalues);
 		if (nd1 > nmatches)
 			totalsel2 += otherfreq2 * (otherfreq1 + unmatchfreq1) /
 				(nd1 - nmatches);
@@ -2072,12 +2036,8 @@ eqjoinsel(PG_FUNCTION_ARGS)
 			selec /= nd2;
 	}
 
-	if (have_mcvs1)
-		free_attstatsslot(vardata1.atttype, values1, nvalues1,
-						  numbers1, nnumbers1);
-	if (have_mcvs2)
-		free_attstatsslot(vardata2.atttype, values2, nvalues2,
-						  numbers2, nnumbers2);
+	free_attstatsslot(&sslot1);
+	free_attstatsslot(&sslot2);
 
 	ReleaseVariableStats(vardata1);
 	ReleaseVariableStats(vardata2);
@@ -2903,8 +2863,7 @@ estimate_hash_bucketsize(PlannerInfo *root, Node *hashkey, double nbuckets)
 				stanullfrac,
 				mcvfreq,
 				avgfreq;
-	float4	   *numbers;
-	int			nnumbers;
+	AttStatsSlot sslot;
 
 	examine_variable(root, hashkey, 0, &vardata);
 
@@ -2966,19 +2925,16 @@ estimate_hash_bucketsize(PlannerInfo *root, Node *hashkey, double nbuckets)
 	if (HeapTupleIsValid(getStatsTuple(&vardata)))
 	{
 		HeapTuple tp = getStatsTuple(&vardata);
-
-		if (get_attstatsslot(tp,
-							 vardata.atttype, vardata.atttypmod,
+		if (get_attstatsslot(&sslot, tp,
 							 STATISTIC_KIND_MCV, InvalidOid,
-							 NULL, NULL, &numbers, &nnumbers))
+							 ATTSTATSSLOT_NUMBERS))
 		{
 			/*
 			 * The first MCV stat is for the most common value.
 			 */
-			if (nnumbers > 0)
-				mcvfreq = numbers[0];
-			free_attstatsslot(vardata.atttype, NULL, 0,
-							  numbers, nnumbers);
+			if (sslot.nnumbers > 0)
+				mcvfreq = sslot.numbers[0];
+			free_attstatsslot(&sslot);
 		}
 	}
 
@@ -3577,7 +3533,7 @@ static void inline adjust_partition_table_statistic_for_parent(HeapTuple statsTu
  *		otherwise NULL.
  *	vartype: exposed type of the expression; this should always match
  *		the declared input type of the operator we are estimating for.
- *	atttype, atttypmod: type data to pass to get_attstatsslot().  This is
+ *	atttype, atttypmod: actual type/typmod of the "var" expression.  This is
  *		commonly the same as the exposed type of the variable argument,
  *		but can be different in binary-compatible-type cases.
  *
@@ -3971,8 +3927,7 @@ get_variable_range(PlannerInfo *root, VariableStatData *vardata, Oid sortop,
 	Form_pg_statistic stats;
 	int16		typLen;
 	bool		typByVal;
-	Datum	   *values;
-	int			nvalues;
+	AttStatsSlot sslot;
 	int			i;
 	HeapTuple	tp = getStatsTuple(vardata);
 
@@ -3992,27 +3947,23 @@ get_variable_range(PlannerInfo *root, VariableStatData *vardata, Oid sortop,
 	 * the one we want, fail --- this suggests that there is data we can't
 	 * use.
 	 */
-	if (get_attstatsslot(tp,
-						 vardata->atttype, vardata->atttypmod,
+	if (get_attstatsslot(&sslot, tp,
 						 STATISTIC_KIND_HISTOGRAM, sortop,
-						 &values, &nvalues,
-						 NULL, NULL))
+						 ATTSTATSSLOT_VALUES))
 	{
-		if (nvalues > 0)
+		if (sslot.nvalues > 0)
 		{
-			tmin = datumCopy(values[0], typByVal, typLen);
-			tmax = datumCopy(values[nvalues - 1], typByVal, typLen);
+			tmin = datumCopy(sslot.values[0], typByVal, typLen);
+			tmax = datumCopy(sslot.values[sslot.nvalues - 1], typByVal, typLen);
 			have_data = true;
 		}
-		free_attstatsslot(vardata->atttype, values, nvalues, NULL, 0);
+		free_attstatsslot(&sslot);
 	}
-	else if (get_attstatsslot(tp,
-							  vardata->atttype, vardata->atttypmod,
+	else if (get_attstatsslot(&sslot, tp,
 							  STATISTIC_KIND_HISTOGRAM, InvalidOid,
-							  &values, &nvalues,
-							  NULL, NULL))
+							  0))
 	{
-		free_attstatsslot(vardata->atttype, values, nvalues, NULL, 0);
+		free_attstatsslot(&sslot);
 		return false;
 	}
 
@@ -4022,11 +3973,9 @@ get_variable_range(PlannerInfo *root, VariableStatData *vardata, Oid sortop,
 	 * the MCVs.  However, usually the MCVs will not be the extreme values, so
 	 * avoid unnecessary data copying.
 	 */
-	if (get_attstatsslot(tp,
-						 vardata->atttype, vardata->atttypmod,
+	if (get_attstatsslot(&sslot, tp,
 						 STATISTIC_KIND_MCV, InvalidOid,
-						 &values, &nvalues,
-						 NULL, NULL))
+						 ATTSTATSSLOT_VALUES))
 	{
 		bool		tmin_is_mcv = false;
 		bool		tmax_is_mcv = false;
@@ -4034,22 +3983,22 @@ get_variable_range(PlannerInfo *root, VariableStatData *vardata, Oid sortop,
 
 		fmgr_info(get_opcode(sortop), &opproc);
 
-		for (i = 0; i < nvalues; i++)
+		for (i = 0; i < sslot.nvalues; i++)
 		{
 			if (!have_data)
 			{
-				tmin = tmax = values[i];
+				tmin = tmax = sslot.values[i];
 				tmin_is_mcv = tmax_is_mcv = have_data = true;
 				continue;
 			}
-			if (DatumGetBool(FunctionCall2(&opproc, values[i], tmin)))
+			if (DatumGetBool(FunctionCall2(&opproc, sslot.values[i], tmin)))
 			{
-				tmin = values[i];
+				tmin = sslot.values[i];
 				tmin_is_mcv = true;
 			}
-			if (DatumGetBool(FunctionCall2(&opproc, tmax, values[i])))
+			if (DatumGetBool(FunctionCall2(&opproc, tmax, sslot.values[i])))
 			{
-				tmax = values[i];
+				tmax = sslot.values[i];
 				tmax_is_mcv = true;
 			}
 		}
@@ -4057,7 +4006,7 @@ get_variable_range(PlannerInfo *root, VariableStatData *vardata, Oid sortop,
 			tmin = datumCopy(tmin, typByVal, typLen);
 		if (tmax_is_mcv)
 			tmax = datumCopy(tmax, typByVal, typLen);
-		free_attstatsslot(vardata->atttype, values, nvalues, NULL, 0);
+		free_attstatsslot(&sslot);
 	}
 
 	*min = tmin;
@@ -5287,42 +5236,39 @@ btcostestimate(PG_FUNCTION_ARGS)
 
 	if (HeapTupleIsValid(tuple))
 	{
-		float4	   *numbers;
-		int			nnumbers;
+		AttStatsSlot sslot;
 
-		if (get_attstatsslot(tuple, InvalidOid, 0,
-							 STATISTIC_KIND_CORRELATION,
-							 index->fwdsortop[0],
-							 NULL, NULL, &numbers, &nnumbers))
+		if (get_attstatsslot(&sslot, tuple,
+							 STATISTIC_KIND_CORRELATION, index->fwdsortop[0],
+							 ATTSTATSSLOT_NUMBERS))
 		{
 			double		varCorrelation;
 
-			Assert(nnumbers == 1);
-			varCorrelation = numbers[0];
+			Assert(sslot.nnumbers == 1);
+			varCorrelation = sslot.numbers[0];
 
 			if (index->ncolumns > 1)
 				*indexCorrelation = varCorrelation * 0.75;
 			else
 				*indexCorrelation = varCorrelation;
 
-			free_attstatsslot(InvalidOid, NULL, 0, numbers, nnumbers);
+			free_attstatsslot(&sslot);
 		}
-		else if (get_attstatsslot(tuple, InvalidOid, 0,
-								  STATISTIC_KIND_CORRELATION,
-								  index->revsortop[0],
-								  NULL, NULL, &numbers, &nnumbers))
+		else if (get_attstatsslot(&sslot, tuple,
+							      STATISTIC_KIND_CORRELATION, index->revsortop[0],
+							      ATTSTATSSLOT_NUMBERS))
 		{
 			double		varCorrelation;
 
-			Assert(nnumbers == 1);
-			varCorrelation = numbers[0];
+			Assert(sslot.nnumbers == 1);
+			varCorrelation = sslot.numbers[0];
 
 			if (index->ncolumns > 1)
 				*indexCorrelation = -varCorrelation * 0.75;
 			else
 				*indexCorrelation = -varCorrelation;
 
-			free_attstatsslot(InvalidOid, NULL, 0, numbers, nnumbers);
+			free_attstatsslot(&sslot);
 		}
 		ReleaseSysCache(tuple);
 	}

--- a/src/backend/utils/cache/lsyscache.c
+++ b/src/backend/utils/cache/lsyscache.c
@@ -3039,33 +3039,39 @@ get_attavgwidth(Oid relid, AttrNumber attnum)
  * most callers will want to extract more than one value from the cache
  * entry, and we don't want to repeat the cache lookup unnecessarily.
  *
- * statstuple: pg_statistics tuple to be examined.
- * atttype: type OID of attribute (can be InvalidOid if values == NULL).
- * atttypmod: typmod of attribute (can be 0 if values == NULL).
+ * sslot: pointer to output area (typically, a local variable in the caller).
+ * statstuple: pg_statistic tuple to be examined.
  * reqkind: STAKIND code for desired statistics slot kind.
  * reqop: STAOP value wanted, or InvalidOid if don't care.
- * values, nvalues: if not NULL, the slot's stavalues are extracted.
- * numbers, nnumbers: if not NULL, the slot's stanumbers are extracted.
+ * flags: bitmask of ATTSTATSSLOT_VALUES and/or ATTSTATSSLOT_NUMBERS.
  *
- * If assigned, values and numbers are set to point to palloc'd arrays.
- * If the attribute type is pass-by-reference, the values referenced by
- * the values array are themselves palloc'd.  The palloc'd stuff can be
- * freed by calling free_attstatsslot.
+ * If a matching slot is found, TRUE is returned, and *sslot is filled thus:
+ * staop: receives the actual STAOP value.
+ * valuetype: receives actual datatype of the elements of stavalues.
+ * values: receives pointer to an array of the slot's stavalues.
+ * nvalues: receives number of stavalues.
+ * numbers: receives pointer to an array of the slot's stanumbers (as float4).
+ * nnumbers: receives number of stanumbers.
  *
- * Note: at present, atttype/atttypmod aren't actually used here at all.
- * But the caller must have the correct (or at least binary-compatible)
- * type ID to pass to free_attstatsslot later.
+ * valuetype/values/nvalues are InvalidOid/NULL/0 if ATTSTATSSLOT_VALUES
+ * wasn't specified.  Likewise, numbers/nnumbers are NULL/0 if
+ * ATTSTATSSLOT_NUMBERS wasn't specified.
+ *
+ * If no matching slot is found, FALSE is returned, and *sslot is zeroed.
+ *
+ * The data referred to by the fields of sslot is locally palloc'd and
+ * is independent of the original pg_statistic tuple.  When the caller
+ * is done with it, call free_attstatsslot to release the palloc'd data.
+ *
+ * If it's desirable to call free_attstatsslot when get_attstatsslot might
+ * not have been called, memset'ing sslot to zeroes will allow that.
  */
 bool
-get_attstatsslot(HeapTuple statstuple,
-				 Oid atttype, int32 atttypmod,
-				 int reqkind, Oid reqop,
-				 Datum **values, int *nvalues,
-				 float4 **numbers, int *nnumbers)
+get_attstatsslot(AttStatsSlot *sslot, HeapTuple statstuple,
+				 int reqkind, Oid reqop, int flags)
 {
 	Form_pg_statistic stats = (Form_pg_statistic) GETSTRUCT(statstuple);
-	int			i,
-				j;
+	int			i;
 	Datum		val;
 	bool		isnull;
 	ArrayType  *statarray;
@@ -3073,6 +3079,9 @@ get_attstatsslot(HeapTuple statstuple,
 	int			narrayelem;
 	HeapTuple	typeTuple;
 	Form_pg_type typeForm;
+
+	/* initialize *sslot properly */
+	memset(sslot, 0, sizeof(AttStatsSlot));
 
 	for (i = 0; i < STATISTIC_NUM_SLOTS; i++)
 	{
@@ -3083,17 +3092,21 @@ get_attstatsslot(HeapTuple statstuple,
 	if (i >= STATISTIC_NUM_SLOTS)
 		return false;			/* not there */
 
-	if (values)
-	{
-		*values = NULL;
-		*nvalues = 0;
+	sslot->staop = (&stats->staop1)[i];
 
+	if (flags & ATTSTATSSLOT_VALUES)
+	{
 		val = SysCacheGetAttr(STATRELATT, statstuple,
 							  Anum_pg_statistic_stavalues1 + i,
 							  &isnull);
 		if (isnull)
 			elog(ERROR, "stavalues is null");
-		statarray = DatumGetArrayTypeP(val);
+
+		/*
+		 * Detoast the array if needed, and in any case make a copy that's
+		 * under control of this AttStatsSlot.
+		 */
+		statarray = DatumGetArrayTypePCopy(val);
 
 		/**
 		 * Could be an empty array.
@@ -3101,64 +3114,56 @@ get_attstatsslot(HeapTuple statstuple,
 		if (ARR_NDIM(statarray) > 0)
 		{
 			/*
-			 * Need to get info about the array element type.  We look at the
-			 * actual element type embedded in the array, which might be only
-			 * binary-compatible with the passed-in atttype.  The info we
-			 * extract here should be the same either way, but deconstruct_array
-			 * is picky about having an exact type OID match.
+			 * Extract the actual array element type, and pass it back in case the
+			 * caller needs it.
 			 */
-			arrayelemtype = ARR_ELEMTYPE(statarray);
-			typeTuple = SearchSysCache(TYPEOID,
-									   ObjectIdGetDatum(arrayelemtype),
-									   0, 0, 0);
+			sslot->valuetype = arrayelemtype = ARR_ELEMTYPE(statarray);
+
+			/* Need info about element type */
+			typeTuple = SearchSysCache1(TYPEOID, ObjectIdGetDatum(arrayelemtype));
 			if (!HeapTupleIsValid(typeTuple))
 				elog(ERROR, "cache lookup failed for type %u", arrayelemtype);
 			typeForm = (Form_pg_type) GETSTRUCT(typeTuple);
 
 			/* Deconstruct array into Datum elements; NULLs not expected */
 			deconstruct_array(statarray,
-					arrayelemtype,
-					typeForm->typlen,
-					typeForm->typbyval,
-					typeForm->typalign,
-					values, NULL, nvalues);
+							  arrayelemtype,
+							  typeForm->typlen,
+							  typeForm->typbyval,
+							  typeForm->typalign,
+							  &sslot->values, NULL, &sslot->nvalues);
 
 			/*
 			 * If the element type is pass-by-reference, we now have a bunch of
-			 * Datums that are pointers into the syscache value.  Copy them to
-			 * avoid problems if syscache decides to drop the entry.
+			 * Datums that are pointers into the statarray, so we need to keep
+			 * that until free_attstatsslot.  Otherwise, all the useful info is in
+			 * sslot->values[], so we can free the array object immediately.
 			 */
 			if (!typeForm->typbyval)
-			{
-				for (j = 0; j < *nvalues; j++)
-				{
-					(*values)[j] = datumCopy((*values)[j],
-							typeForm->typbyval,
-							typeForm->typlen);
-				}
-			}
+				sslot->values_arr = statarray;
+			else
+				pfree(statarray);
 
 			ReleaseSysCache(typeTuple);
 		}
-
-		/*
-		 * Free statarray if it's a detoasted copy.
-		 */
-		if ((Pointer) statarray != DatumGetPointer(val))
+		else
 			pfree(statarray);
+
 	}
 
-	if (numbers)
+	if (flags & ATTSTATSSLOT_NUMBERS)
 	{
-		*numbers = NULL;
-		*nnumbers = 0;
-
 		val = SysCacheGetAttr(STATRELATT, statstuple,
 							  Anum_pg_statistic_stanumbers1 + i,
 							  &isnull);
 		if (isnull)
 			elog(ERROR, "stanumbers is null");
-		statarray = DatumGetArrayTypeP(val);
+
+		/*
+		 * Detoast the array if needed, and in any case make a copy that's
+		 * under control of this AttStatsSlot.
+		 */
+		statarray = DatumGetArrayTypePCopy(val);
 
 		/**
 		 * Could be an empty array.
@@ -3175,15 +3180,15 @@ get_attstatsslot(HeapTuple statstuple,
 					ARR_HASNULL(statarray) ||
 					ARR_ELEMTYPE(statarray) != FLOAT4OID)
 				elog(ERROR, "stanumbers is not a 1-D float4 array");
-			*numbers = (float4 *) palloc(narrayelem * sizeof(float4));
-			*nnumbers = narrayelem;
-			memcpy(*numbers, ARR_DATA_PTR(statarray), narrayelem * sizeof(float4));
-		}
 
-		/*
-		 * Free statarray if it's a detoasted copy.
-		 */
-		if ((Pointer) statarray != DatumGetPointer(val))
+			/* Give caller a pointer directly into the statarray */
+			sslot->numbers = (float4 *) ARR_DATA_PTR(statarray);
+			sslot->nnumbers = narrayelem;
+
+			/* We'll free the statarray in free_attstatsslot */
+			sslot->numbers_arr = statarray;
+		}
+		else
 			pfree(statarray);
 	}
 
@@ -3193,27 +3198,19 @@ get_attstatsslot(HeapTuple statstuple,
 /*
  * free_attstatsslot
  *		Free data allocated by get_attstatsslot
- *
- * atttype need be valid only if values != NULL.
  */
 void
-free_attstatsslot(Oid atttype,
-				  Datum *values, int nvalues,
-				  float4 *numbers, int nnumbers)
+free_attstatsslot(AttStatsSlot *sslot)
 {
-	if (values)
-	{
-		if (!get_typbyval(atttype))
-		{
-			int			i;
-
-			for (i = 0; i < nvalues; i++)
-				pfree(DatumGetPointer(values[i]));
-		}
-		pfree(values);
-	}
-	if (numbers)
-		pfree(numbers);
+	/* The values[] array was separately palloc'd by deconstruct_array */
+	if (sslot->values)
+		pfree(sslot->values);
+	/* The numbers[] array points into numbers_arr, do not pfree it */
+	/* Free the detoasted array objects, if any */
+	if (sslot->values_arr)
+		pfree(sslot->values_arr);
+	if (sslot->numbers_arr)
+		pfree(sslot->numbers_arr);
 }
 
 /*

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -19,6 +19,7 @@
 #include "access/attnum.h"
 #include "utils/faultinjector.h"
 #include "parser/parse_coerce.h"
+#include "utils/lsyscache.h"
 
 // fwd declarations
 typedef struct SysScanDescData *SysScanDesc;
@@ -182,11 +183,11 @@ namespace gpdb {
 			char elmalign, Datum **elemsp, bool **nullsp, int *nelemsp);
 
 	// attribute stats slot
-	bool FGetAttrStatsSlot(HeapTuple statstuple, Oid atttype, int32 atttypmod, int reqkind,
-			Oid reqop, Datum **values, int *nvalues, float4 **numbers, int *nnumbers);
+	bool FGetAttrStatsSlot(AttStatsSlot *sslot, HeapTuple statstuple, int reqkind,
+			Oid reqop, int flags);
 
 	// free attribute stats slot
-	void FreeAttrStatsSlot(Oid atttype, Datum *values, int nvalues, float4 *numbers, int nnumbers);
+	void FreeAttrStatsSlot(AttStatsSlot *sslot);
 
 	// attribute statistics
 	HeapTuple HtAttrStats(Oid relid, AttrNumber attnum);

--- a/src/include/utils/lsyscache.h
+++ b/src/include/utils/lsyscache.h
@@ -41,6 +41,28 @@ typedef enum CmpType
 	CmptOther	// other operator
 } CmpType;
 
+/* Flag bits for get_attstatsslot */
+#define ATTSTATSSLOT_VALUES		0x01
+#define ATTSTATSSLOT_NUMBERS	0x02
+
+/* Result struct for get_attstatsslot */
+typedef struct AttStatsSlot
+{
+	/* Always filled: */
+	Oid			staop;			/* Actual staop for the found slot */
+	/* Filled if ATTSTATSSLOT_VALUES is specified: */
+	Oid			valuetype;		/* Actual datatype of the values */
+	Datum	   *values;			/* slot's "values" array, or NULL if none */
+	int			nvalues;		/* length of values[], or 0 */
+	/* Filled if ATTSTATSSLOT_NUMBERS is specified: */
+	float4	   *numbers;		/* slot's "numbers" array, or NULL if none */
+	int			nnumbers;		/* length of numbers[], or 0 */
+
+	/* Remaining fields are private to get_attstatsslot/free_attstatsslot */
+	void	   *values_arr;		/* palloc'd values array, if any */
+	void	   *numbers_arr;	/* palloc'd numbers array, if any */
+} AttStatsSlot;
+
 extern bool op_in_opfamily(Oid opno, Oid opfamily);
 extern int	get_op_opfamily_strategy(Oid opno, Oid opfamily);
 extern void get_op_opfamily_properties(Oid opno, Oid opfamily,
@@ -152,14 +174,9 @@ extern Oid	getBaseTypeAndTypmod(Oid typid, int32 *typmod);
 extern int32 get_typavgwidth(Oid typid, int32 typmod);
 extern int32 get_attavgwidth(Oid relid, AttrNumber attnum);
 extern HeapTuple get_att_stats(Oid relid, AttrNumber attnum);
-extern bool get_attstatsslot(HeapTuple statstuple,
-				 Oid atttype, int32 atttypmod,
-				 int reqkind, Oid reqop,
-				 Datum **values, int *nvalues,
-				 float4 **numbers, int *nnumbers);
-extern void free_attstatsslot(Oid atttype,
-				  Datum *values, int nvalues,
-				  float4 *numbers, int nnumbers);
+extern bool get_attstatsslot(AttStatsSlot *sslot, HeapTuple statstuple,
+				 int reqkind, Oid reqop, int flags);
+extern void free_attstatsslot(AttStatsSlot *sslot);
 extern char *get_namespace_name(Oid nspid);
 extern Oid	get_roleid(const char *rolname);
 extern Oid	get_roleid_checked(const char *rolname);

--- a/src/include/utils/selfuncs.h
+++ b/src/include/utils/selfuncs.h
@@ -72,8 +72,8 @@ typedef struct VariableStatData
 	/* NB: if statsTuple!=NULL, it must be freed when caller is done */
 	double		numdistinctFromPrimaryKey; /* this is the numdistinct as estimated from the primary key relation. If this is < 0, then it is ignored. */
 	Oid			vartype;		/* exposed type of expression */
-	Oid			atttype;		/* type to pass to get_attstatsslot */
-	int32		atttypmod;		/* typmod to pass to get_attstatsslot */
+	Oid			atttype;		/* actual type (after stripping relabel) */
+	int32		atttypmod;		/* actual typmod (after stripping relabel) */
 	bool		isunique;		/* true if matched to a unique index */
 } VariableStatData;
 

--- a/src/test/regress/expected/bfv_statistic.out
+++ b/src/test/regress/expected/bfv_statistic.out
@@ -427,3 +427,23 @@ NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_97" for table "t252
 NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_98" for table "t25289_t4"
 NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_99" for table "t25289_t4"
 ANALYZE T25289_T4;
+--
+-- expect NO crash when the statistic slot for an attribute is broken
+--
+CREATE TABLE good_tab(a int, b text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE test_broken_stats(a int, b text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO test_broken_stats VALUES(1, 'abc'), (2, 'cde'), (3, 'efg'), (3, 'efg'), (3, 'efg'), (1, 'abc'), (2, 'cde'); 
+ANALYZE test_broken_stats;
+SET allow_system_table_mods='DML';
+-- Simulate broken stats by changing the data type of MCV slot to a different type than in pg_attribute 
+UPDATE pg_statistic SET stavalues1='{1,2,3}'::int[] WHERE starelid ='bfv_statistic.test_broken_stats'::regclass AND staattnum=2;
+SELECT * FROM test_broken_stats t1, good_tab t2 WHERE t1.b = t2.b;
+ a | b | a | b 
+---+---+---+---
+(0 rows)
+
+RESET allow_system_table_mods;

--- a/src/test/regress/expected/bfv_statistic_optimizer.out
+++ b/src/test/regress/expected/bfv_statistic_optimizer.out
@@ -427,3 +427,23 @@ NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_97" for table "t252
 NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_98" for table "t25289_t4"
 NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_99" for table "t25289_t4"
 ANALYZE T25289_T4;
+--
+-- expect NO crash when the statistic slot for an attribute is broken
+--
+CREATE TABLE good_tab(a int, b text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE test_broken_stats(a int, b text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO test_broken_stats VALUES(1, 'abc'), (2, 'cde'), (3, 'efg'), (3, 'efg'), (3, 'efg'), (1, 'abc'), (2, 'cde'); 
+ANALYZE test_broken_stats;
+SET allow_system_table_mods='DML';
+-- Simulate broken stats by changing the data type of MCV slot to a different type than in pg_attribute 
+UPDATE pg_statistic SET stavalues1='{1,2,3}'::int[] WHERE starelid ='bfv_statistic.test_broken_stats'::regclass AND staattnum=2;
+SELECT * FROM test_broken_stats t1, good_tab t2 WHERE t1.b = t2.b;
+ a | b | a | b 
+---+---+---+---
+(0 rows)
+
+RESET allow_system_table_mods;


### PR DESCRIPTION
In scenarios where pg_statistic contains wrong statistic entry for an
attribute, or when the statistics on a particular attribute are broken,
for e.g the type of elements stored in stavalues<1/2/3> is different
than the actual attribute type or when there are holes in the attribute
numbers due to adding/dropping columns; following two APIs fail because
they relied on the attribute type sent by the caller:

- get_attstatsslot() : Extracts the contents (numbers/frequency array and
values array) of the requested statistic slot (MCV, HISTOGRAM etc). If the
attribute is pass-by-reference or if the attribute is of toastable type
(varlena types)then it returns a copy allocated with palloc()
- free_attstatsslot() : Frees any palloc'd data by get_attstatsslot()

This problem was fixed in upstream 8.3
(8c21b4e9226df1f6f16091e557fb313f5d308cde) for get_attstatsslot(),
wherein the actual element type of the array will be used for
deconstructing it rather that using caller passed OID.
free_attstatsslot() still depends on the type oid sent by caller.

However the issue still exists for free_attstatsslot() where it crashes while
freeing the array. The crash happened because the caller sent type OID was of
type TEXT meaning this a varlena type and hence free_attstatsslot() attempted
to free the datum; however due to the broken slot the datums extracted from
values array were of fixed length type such as int. We considered the int value
as memory address and crashed while freeing it.

This commit brings in a following fix from upstream 10 which redesigns
get_attstatsslot()/free_attstatsslot() such than they robust to scenarios like
these.

commit 9aab83fc5039d83e84144b7bed3fb1d62a74ae78
Author: Tom Lane <tgl@sss.pgh.pa.us>
Date:   Sat May 13 15:14:39 2017 -0400

    Redesign get_attstatsslot()/free_attstatsslot() for more safety and speed.

    The mess cleaned up in commit da0759600 is clear evidence that it's a
    bug hazard to expect the caller of get_attstatsslot()/free_attstatsslot()
    to provide the correct type OID for the array elements in the slot.
    Moreover, we weren't even getting any performance benefit from that,
    since get_attstatsslot() was extracting the real type OID from the array
    anyway.  So we ought to get rid of that requirement; indeed, it would
    make more sense for get_attstatsslot() to pass back the type OID it found,
    in case the caller isn't sure what to expect, which is likely in binary-
    compatible-operator cases.

    Another problem with the current implementation is that if the stats array
    element type is pass-by-reference, we incur a palloc/memcpy/pfree cycle
    for each element.  That seemed acceptable when the code was written because
    we were targeting O(10) array sizes --- but these days, stats arrays are
    almost always bigger than that, sometimes much bigger.  We can save a
    significant number of cycles by doing one palloc/memcpy/pfree of the whole
    array.  Indeed, in the now-probably-common case where the array is toasted,
    that happens anyway so this method is basically free.  (Note: although the
    catcache code will inline any out-of-line toasted values, it doesn't
    decompress them.  At the other end of the size range, it doesn't expand
    short-header datums either.  In either case, DatumGetArrayTypeP would have
    to make a copy.  We do end up using an extra array copy step if the element
    type is pass-by-value and the array length is neither small enough for a
    short header nor large enough to have suffered compression.  But that
    seems like a very acceptable price for winning in pass-by-ref cases.)

    Hence, redesign to take these insights into account.  While at it,
    convert to an API in which we fill a struct rather than passing a bunch
    of pointers to individual output arguments.  That will make it less
    painful if we ever want further expansion of what get_attstatsslot can
    pass back.

    It's certainly arguable that this is new development and not something to
    push post-feature-freeze.  However, I view it as primarily bug-proofing
    and therefore something that's better to have sooner not later.  Since
    we aren't quite at beta phase yet, let's put it in.

    Discussion: https://postgr.es/m/16364.1494520862@sss.pgh.pa.us

Most of the changes are same as the upstream commit with following additional
changes:
- Relcache translator changes in ORCA.
- Added a test that simulates the crash due to broken stats
- get_attstatsslot() contains an extra check for empty slot array which existed
in master but is not there in upstream.

Signed-off-by: Abhijit Subramanya <asubramanya@pivotal.io>
(cherry picked from commit ae06d7b0e2612aa62c6e7fe3568ea7082e736408)