### PR TITLE
Propagate segment errcodes to dispatcher

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_dtx.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_dtx.c
@@ -143,7 +143,7 @@ CdbDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 		/*
 		 * Wait for all QEs to finish.	Don't cancel.
 		 */
-		pr = cdbdisp_getDispatchResults(&ds, errmsgbuf);
+		pr = cdbdisp_getDispatchResults(&ds, errmsgbuf, NULL);
 
 		if (!GangOK(primaryGang))
 		{

--- a/src/include/cdb/cdbdisp.h
+++ b/src/include/cdb/cdbdisp.h
@@ -129,10 +129,11 @@ CdbCheckDispatchResult(struct CdbDispatcherState *ds, DispatchWaitMode waitMode)
  *
  * Return Values:
  *   Return NULL If one or more QEs got Error in which case qeErrorMsg contain
- *   QE error messages.
+ *   QE error messages and qeErrorCode the thrown ERRCODE.
  */
 struct CdbDispatchResults *
-cdbdisp_getDispatchResults(struct CdbDispatcherState *ds, StringInfoData *qeErrorMsg);
+cdbdisp_getDispatchResults(struct CdbDispatcherState *ds,
+						   StringInfoData *qeErrorMsg, int *qeErrorCode);
 
 /*
  * Wait for all QEs to finish, then report any errors from the given

--- a/src/test/regress/expected/function_extensions.out
+++ b/src/test/regress/expected/function_extensions.out
@@ -386,3 +386,21 @@ alter function test_srf() EXECUTE ON ANY;
 
 DROP FUNCTION test_srf();
 DROP ROLE srftestuser;
+-- Test error propagation from segments
+CREATE TABLE uniq_test(id int primary key);
+NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "uniq_test_pkey" for table "uniq_test"
+CREATE OR REPLACE FUNCTION trigger_unique() RETURNS void AS $$
+BEGIN
+	INSERT INTO uniq_test VALUES (1);
+	INSERT INTO uniq_test VALUES (1);
+	EXCEPTION WHEN unique_violation THEN
+		raise notice 'unique_violation';
+END;
+$$ LANGUAGE plpgsql volatile;
+SELECT trigger_unique();
+NOTICE:  unique_violation
+ trigger_unique 
+----------------
+ 
+(1 row)
+

--- a/src/test/regress/expected/function_extensions_optimizer.out
+++ b/src/test/regress/expected/function_extensions_optimizer.out
@@ -387,3 +387,21 @@ alter function test_srf() EXECUTE ON ANY;
 
 DROP FUNCTION test_srf();
 DROP ROLE srftestuser;
+-- Test error propagation from segments
+CREATE TABLE uniq_test(id int primary key);
+NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "uniq_test_pkey" for table "uniq_test"
+CREATE OR REPLACE FUNCTION trigger_unique() RETURNS void AS $$
+BEGIN
+	INSERT INTO uniq_test VALUES (1);
+	INSERT INTO uniq_test VALUES (1);
+	EXCEPTION WHEN unique_violation THEN
+		raise notice 'unique_violation';
+END;
+$$ LANGUAGE plpgsql volatile;
+SELECT trigger_unique();
+NOTICE:  unique_violation
+ trigger_unique 
+----------------
+ 
+(1 row)
+

--- a/src/test/regress/sql/function_extensions.sql
+++ b/src/test/regress/sql/function_extensions.sql
@@ -220,3 +220,15 @@ alter function test_srf() EXECUTE ON ANY;
 
 DROP FUNCTION test_srf();
 DROP ROLE srftestuser;
+
+-- Test error propagation from segments
+CREATE TABLE uniq_test(id int primary key);
+CREATE OR REPLACE FUNCTION trigger_unique() RETURNS void AS $$
+BEGIN
+	INSERT INTO uniq_test VALUES (1);
+	INSERT INTO uniq_test VALUES (1);
+	EXCEPTION WHEN unique_violation THEN
+		raise notice 'unique_violation';
+END;
+$$ LANGUAGE plpgsql volatile;
+SELECT trigger_unique();


### PR DESCRIPTION
The errcode thrown in an `ereport()` on a segment was passed back to the dispatcher, but then dropped and replaced with a default errcode of `ERRCODE_DATA_EXCEPTION`. This works for most situations, but when trapping errors the exact errcode must be propagated. This extends the API to extract the errcode as well. The below case from #4398 illustrates the issue:
```SQL
  CREATE TABLE test1(id int primary key);
  CREATE TABLE test2(id int primary key);
  INSERT INTO test1 VALUES(1);
  INSERT INTO test2 VALUES(1);
  CREATE OR REPLACE FUNCTION merge_table() RETURNS void AS $$
  DECLARE
	v_insert_sql varchar;
  BEGIN
	v_insert_sql :='INSERT INTO test1 SELECT * FROM test2';
	EXECUTE v_insert_sql;
	EXCEPTION WHEN unique_violation THEN
		RAISE NOTICE 'unique_violation';
	END;
  $$ LANGUAGE plpgsql volatile;
  SELECT merge_table();
```