### PR TITLE
Remove flaky test in QP-memory-accounting

### DIFF
--- a/src/test/tinc/tincrepo/resource_management/memory_accounting/scenario/oom_test/answer/verify_multiple_random_oom.ans
+++ b/src/test/tinc/tincrepo/resource_management/memory_accounting/scenario/oom_test/answer/verify_multiple_random_oom.ans
@@ -4,12 +4,6 @@
 -- @created 2014-02-05 12:00:00
 -- @modified 2014-02-05 12:00:00
 -- @description Check segment log to verify memory usage logging in event of OOM
-select logseverity, logstate, logmessage from gp_toolkit.__gp_log_segment_ext where logmessage like '%Logging memory usage.' and  logtime >= (select logtime from gp_toolkit.__gp_log_master_ext where logmessage like 'statement: select 3 as oom_test;' order by logtime desc limit 1) order by logtime desc limit 1;
- logseverity | logstate |                                           logmessage                                           
--------------+----------+------------------------------------------------------------------------------------------------
- LOG         | 00000    | One or more query execution processes ran out of memory on this segment. Logging memory usage.
-(1 row)
-
 select logseverity, logstate, logmessage from gp_toolkit.__gp_log_segment_ext where logstate = 'XX000' and  logtime >= (select logtime from gp_toolkit.__gp_log_master_ext where logmessage like 'statement: select 3 as oom_test;' order by logtime desc limit 1) order by logtime desc limit 1;
  logseverity | logstate | logmessage 
 -------------+----------+------------

--- a/src/test/tinc/tincrepo/resource_management/memory_accounting/scenario/oom_test/sql/verify_multiple_random_oom.sql
+++ b/src/test/tinc/tincrepo/resource_management/memory_accounting/scenario/oom_test/sql/verify_multiple_random_oom.sql
@@ -3,6 +3,4 @@
 -- @modified 2014-02-05 12:00:00
 -- @description Check segment log to verify memory usage logging in event of OOM
 
-select logseverity, logstate, logmessage from gp_toolkit.__gp_log_segment_ext where logmessage like '%Logging memory usage.' and  logtime >= (select logtime from gp_toolkit.__gp_log_master_ext where logmessage like 'statement: select 3 as oom_test;' order by logtime desc limit 1) order by logtime desc limit 1;
-
 select logseverity, logstate, logmessage from gp_toolkit.__gp_log_segment_ext where logstate = 'XX000' and  logtime >= (select logtime from gp_toolkit.__gp_log_master_ext where logmessage like 'statement: select 3 as oom_test;' order by logtime desc limit 1) order by logtime desc limit 1;


### PR DESCRIPTION
The flakyness is caused by the Orca version bump to 2.53.11, in which Orca
improved the equivclasses for inner/outer join plan. Previously Orca generated
bad plan, causing OOM. But as of 2.53.11, Orca generated better plan, may not
cause OOM. Due to the flakyness of this test, remove it.