### PR TITLE
Revert encoding handling in pg_regress to upstream

### DIFF
--- a/src/test/regress/GNUmakefile
+++ b/src/test/regress/GNUmakefile
@@ -26,9 +26,6 @@ PGPORT?=15432
 # where to find psql for testing an existing installation
 PSQLDIR = $(bindir)
 
-# default encoding
-MULTIBYTE = SQL_ASCII
-
 # maximum simultaneous connections for parallel tests
 MAXCONNOPT =
 ifdef MAX_CONNECTIONS
@@ -175,7 +172,7 @@ hooktest:
 ## Run tests
 ##
 
-pg_regress_call = ./pg_regress --inputdir=$(srcdir) --dlpath=. --multibyte=$(MULTIBYTE) $(MAXCONNOPT) $(NOLOCALE) --init-file=$(srcdir)/init_file
+pg_regress_call = ./pg_regress --inputdir=$(srcdir) --dlpath=. $(if $(MULTIBYTE),--multibyte=$(MULTIBYTE)) $(MAXCONNOPT) $(NOLOCALE) --init-file=$(srcdir)/init_file
 
 check: all
 	$(pg_regress_call) --temp-install=./tmp_check --top-builddir=$(top_builddir) --schedule=$(srcdir)/parallel_schedule 

--- a/src/test/regress/GNUmakefile
+++ b/src/test/regress/GNUmakefile
@@ -27,7 +27,7 @@ PGPORT?=15432
 PSQLDIR = $(bindir)
 
 # default encoding
-##MULTIBYTE = LATIN1
+MULTIBYTE = SQL_ASCII
 
 # maximum simultaneous connections for parallel tests
 MAXCONNOPT =

--- a/src/test/regress/pg_regress.c
+++ b/src/test/regress/pg_regress.c
@@ -1011,7 +1011,7 @@ initialize_environment(void)
 	/*
 	 * Set multibyte as requested
 	 */
-	if (encoding && strlen(encoding) > 0)
+	if (encoding)
 		doputenv("PGCLIENTENCODING", encoding);
 	else
 		unsetenv("PGCLIENTENCODING");
@@ -2172,7 +2172,7 @@ create_database(const char *dbname)
 	 * not mess up the tests.
 	 */
 	header(_("creating database \"%s\""), dbname);
-	if (encoding && strlen(encoding) > 0)
+	if (encoding)
 		psql_command("postgres", "CREATE DATABASE \"%s\" TEMPLATE=template0 ENCODING='%s'", dbname, encoding);
 	else
 		psql_command("postgres", "CREATE DATABASE \"%s\" TEMPLATE=template0", dbname);


### PR DESCRIPTION
If we avoid calling `pg_regress` with an empty `--multibyte` we can skip GPDB specific handling of the encoding parameter in `pg_regress` and instead follow upstream. While the local diffs weren't wrong per se, avoiding merge conflicts is of more interest.

Also revert the commented out `MULTIBYTE` in the makefile to match the upstream value.