### PR TITLE
Tablespace path should have Greenplum major version.

### DIFF
--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -28,7 +28,7 @@
  * This constant has been renamed so that we catch and know to modify all
  * upstream uses of TABLESPACE_VERSION_DIRECTORY.
  */
-#define GP_TABLESPACE_VERSION_DIRECTORY	"GPDB_" PG_MAJORVERSION "_" \
+#define GP_TABLESPACE_VERSION_DIRECTORY	"GPDB_" GP_MAJORVERSION "_" \
 									CppAsString2(CATALOG_VERSION_NO)
 
 extern const char *forkNames[];


### PR DESCRIPTION
I am not sure why `CATALOG_VERSION_NO ` is needed in the tablespace path. Can it be loosed ?