### PR TITLE
fix windows fe-connect compilation error

### DIFF
--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -16,7 +16,11 @@
 
 #include "cdb/cdbutil.h"
 #include "executor/execdesc.h"
+#ifdef WIN32
+#include "pthread-win32.h"
+#else
 #include <pthread.h>
+#endif
 #include "utils/faultinjector.h"
 #include "utils/portal.h"
 
@@ -126,7 +130,11 @@ extern void cleanupPortalGangs(Portal portal);
 extern int largestGangsize(void);
 extern void setLargestGangsize(int size);
 
+#ifdef WIN32
+extern int gp_pthread_create(DWORD *thread, void *(*start_routine)(void *), void *arg, const char *caller);
+#else
 extern int gp_pthread_create(pthread_t *thread, void *(*start_routine)(void *), void *arg, const char *caller);
+#endif
 
 /*
  * cdbgang_parse_gpqeid_params

--- a/src/include/utils/elog.h
+++ b/src/include/utils/elog.h
@@ -90,8 +90,13 @@
 /* threaded thing. 
  * Caller beware: ereport and elog can only be called from main thread.
  */
+#ifdef WIN32
+#include "pthread-win32.h"
+extern DWORD main_tid;
+#else
 #include <pthread.h>
 extern pthread_t main_tid;
+#endif
 #ifndef _WIN32
 #define mythread() ((unsigned long) pthread_self())
 #define mainthread() ((unsigned long) main_tid)


### PR DESCRIPTION
The commit that broke win32 compilation:
https://github.com/greenplum-db/gpdb/commit/f9c7df6914b63487a10b319e998e611986b0d7ce

To fix this, we put some win32 ifdefs around Greenplum-specific code
around threading. We don't really compile windows server so this
should be fine for now to compile the windows CCL.