### PR TITLE
Docs adding reference for maintenance_work_mem

### DIFF
--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -579,6 +579,7 @@
             <li>
               <xref href="#log_truncate_on_rotation"/>
             </li>
+            <li><xref href="#maintenance_work_mem" format="dita"/></li>
             <li>
               <xref href="#max_appendonly_tables"/>
             </li>
@@ -6721,6 +6722,36 @@
             <row>
               <entry colname="col1">Boolean</entry>
               <entry colname="col2">off</entry>
+              <entry colname="col3">local<p>system</p><p>restart</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
+  <topic id="maintenance_work_mem">
+    <title>maintenance_work_mem</title>
+    <body>
+      <p>Specifies the maximum amount of memory to be used in maintenance operations, such as
+          <codeph>VACUUM</codeph> and <codeph>CREATE INDEX</codeph>. It defaults to 16 megabytes
+        (16MB). Larger settings might improve performance for vacuuming and for restoring database
+        dumps.</p>
+      <table id="table_wfs_tfp_qcb">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">Integer</entry>
+              <entry colname="col2">16</entry>
               <entry colname="col3">local<p>system</p><p>restart</p></entry>
             </row>
           </tbody>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -213,6 +213,7 @@
                 <xref href="guc-list.xml#gp_workfile_limit_per_segment" type="section"
                   >gp_workfile_limit_per_segment</xref>
               </p>
+              <p><xref href="guc-list.xml#maintenance_work_mem" format="dita"/></p>
               <p>
                 <xref href="guc-list.xml#max_stack_depth" type="section">max_stack_depth</xref>
               </p>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -191,6 +191,7 @@
             <topicref href="guc-list.xml#log_temp_files"/>
             <topicref href="guc-list.xml#log_timezone"/>
             <topicref href="guc-list.xml#log_truncate_on_rotation"/>
+            <topicref href="guc-list.xml#maintenance_work_mem"/>
             <topicref href="guc-list.xml#max_appendonly_tables"/>
             <topicref href="guc-list.xml#max_connections"/>
             <topicref href="guc-list.xml#max_files_per_process"/>


### PR DESCRIPTION
maintenance_work_mem is currently mentioned in our docs and in recent postgresql 8.4 PRs.  Adding missing reference page based on postgresql 8.4 docs.

Please validate and indicate if any changes are needed for GPDB.