### PR TITLE
Handle PQPING_MIRROR_READY in pg_ctl start do_wait switch

### DIFF
--- a/src/bin/pg_ctl/pg_ctl.c
+++ b/src/bin/pg_ctl/pg_ctl.c
@@ -799,6 +799,10 @@ do_start(void)
 				print_msg(_(" stopped waiting\n"));
 				print_msg(_("server is still starting up\n"));
 				break;
+			case PQPING_MIRROR_READY:
+				print_msg(_(" done\n"));
+				print_msg(_("server started in mirror mode\n"));
+				break;
 			case PQPING_MIRROR_OR_QUIESCENT:
 				print_msg(_(" done\n"));
 				print_msg(_("server started in mirror or quiescent mode\n"));


### PR DESCRIPTION
The pg_ctl response output for PQPING_MIRROR_READY was missing in
https://github.com/greenplum-db/gpdb/commit/b824fe8f269934987e30a4c177605b250703d20f. We
just need it to say the mirror has started.

Reported by Daniel Gustafsson in gpdb-dev mailing list:
https://groups.google.com/a/greenplum.org/forum/#!topic/gpdb-dev/oNrxvVEG-UY