### PR TITLE
isolation2: Initial attempt to parallel schedule.

### DIFF
--- a/src/test/isolation/isolation_schedule
+++ b/src/test/isolation/isolation_schedule
@@ -4,6 +4,5 @@ test: heap-serializable-vacuum-freeze
 test: heap-serializable-vacuum
 test: ao-serializable-read
 test: ao-serializable-vacuum
-test: ao-insert-eof
-test: create_index_hot
-test: udf-insert-deadlock
+
+test: ao-insert-eof create_index_hot udf-insert-deadlock

--- a/src/test/isolation2/input/uao/alter_while_vacuum.source
+++ b/src/test/isolation2/input/uao/alter_while_vacuum.source
@@ -1,12 +1,11 @@
 -- @Description Ensures that an alter table while a vacuum operation is ok
 -- 
-DROP TABLE IF EXISTS ao;
-CREATE TABLE ao (a INT, b INT) WITH (appendonly=true, orientation=@orientation@);
-INSERT INTO ao SELECT i as a, i as b FROM generate_series(1, 100000) AS i;
+CREATE TABLE alter_while_vacuum_@orientation@ (a INT, b INT) WITH (appendonly=true, orientation=@orientation@);
+INSERT INTO alter_while_vacuum_@orientation@ SELECT i as a, i as b FROM generate_series(1, 100000) AS i;
 
-DELETE FROM ao WHERE a < 12000;
-1: SELECT COUNT(*) FROM ao;
-1>: ALTER TABLE ao ADD COLUMN d bigint DEFAULT 10;
-2: VACUUM ao;
+DELETE FROM alter_while_vacuum_@orientation@ WHERE a < 12000;
+1: SELECT COUNT(*) FROM alter_while_vacuum_@orientation@;
+1>: ALTER TABLE alter_while_vacuum_@orientation@ ADD COLUMN d bigint DEFAULT 10;
+2: VACUUM alter_while_vacuum_@orientation@;
 1<:
-1: SELECT * FROM ao WHERE a < 12010;
+1: SELECT * FROM alter_while_vacuum_@orientation@ WHERE a < 12010;

--- a/src/test/isolation2/input/uao/alter_while_vacuum2.source
+++ b/src/test/isolation2/input/uao/alter_while_vacuum2.source
@@ -1,19 +1,17 @@
 -- @Description Ensures that an alter table while a vacuum operation is ok
 -- 
-DROP TABLE IF EXISTS ao;
+CREATE TABLE alter_while_vacuum2_@orientation@ (a INT, b INT) WITH (appendonly=true, orientation=@orientation@);
+INSERT INTO alter_while_vacuum2_@orientation@ SELECT i as a, i as b FROM generate_series(1, 100000) AS i;
+INSERT INTO alter_while_vacuum2_@orientation@ SELECT i as a, i as b FROM generate_series(1, 100000) AS i;
+INSERT INTO alter_while_vacuum2_@orientation@ SELECT i as a, i as b FROM generate_series(1, 100000) AS i;
+INSERT INTO alter_while_vacuum2_@orientation@ SELECT i as a, i as b FROM generate_series(1, 100000) AS i;
+INSERT INTO alter_while_vacuum2_@orientation@ SELECT i as a, i as b FROM generate_series(1, 100000) AS i;
+INSERT INTO alter_while_vacuum2_@orientation@ SELECT i as a, i as b FROM generate_series(1, 100000) AS i;
 
-CREATE TABLE ao (a INT, b INT) WITH (appendonly=true, orientation=@orientation@);
-INSERT INTO ao SELECT i as a, i as b FROM generate_series(1, 100000) AS i;
-INSERT INTO ao SELECT i as a, i as b FROM generate_series(1, 100000) AS i;
-INSERT INTO ao SELECT i as a, i as b FROM generate_series(1, 100000) AS i;
-INSERT INTO ao SELECT i as a, i as b FROM generate_series(1, 100000) AS i;
-INSERT INTO ao SELECT i as a, i as b FROM generate_series(1, 100000) AS i;
-INSERT INTO ao SELECT i as a, i as b FROM generate_series(1, 100000) AS i;
-
-DELETE FROM ao WHERE a < 12000;
-1: SELECT COUNT(*) FROM ao;
+DELETE FROM alter_while_vacuum2_@orientation@ WHERE a < 12000;
+1: SELECT COUNT(*) FROM alter_while_vacuum2_@orientation@;
 2: set debug_appendonly_print_compaction=true;
-2>: VACUUM ao;
-1: Alter table ao set with ( reorganize='true') distributed randomly;
+2>: VACUUM alter_while_vacuum2_@orientation@;
+1: Alter table alter_while_vacuum2_@orientation@ set with ( reorganize='true') distributed randomly;
 2<:
-1: SELECT COUNT(*) FROM ao WHERE a < 12010;
+1: SELECT COUNT(*) FROM alter_while_vacuum2_@orientation@ WHERE a < 12010;

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -1,12 +1,6 @@
-test: pg_terminate_backend
-test: deadlock_under_entry_db_singleton
-test: starve_case
+test: pg_terminate_backend deadlock_under_entry_db_singleton starve_case pg_views_concurrent_drop alter_blocks_for_update_and_viceversa drop_rename reader_waits_for_lock resource_queue
+
 test: commit_transaction_block_checkpoint
-test: pg_views_concurrent_drop
-test: resource_queue
-test: alter_blocks_for_update_and_viceversa
-test: reader_waits_for_lock
-test: drop_rename
 test: master_panic_after_phase1_commit
 
 test: setup

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -5,8 +5,7 @@ test: master_panic_after_phase1_commit
 
 test: setup
 # Tests on Append-Optimized tables (row-oriented).
-test: uao/alter_while_vacuum_row
-test: uao/alter_while_vacuum2_row
+test: uao/alter_while_vacuum_row uao/alter_while_vacuum2_row
 test: uao/compaction_full_stats_row
 test: uao/compaction_utility_row
 test: uao/compaction_utility_insert_row
@@ -51,8 +50,7 @@ test: uao/vacuum_while_vacuum_row
 test: uao/vacuum_cleanup_row
 
 # Tests on Append-Optimized tables (column-oriented).
-test: uao/alter_while_vacuum_column
-test: uao/alter_while_vacuum2_column
+test: uao/alter_while_vacuum_column uao/alter_while_vacuum2_column
 test: uao/compaction_full_stats_column
 test: uao/compaction_utility_column
 test: uao/compaction_utility_insert_column

--- a/src/test/isolation2/output/uao/alter_while_vacuum.source
+++ b/src/test/isolation2/output/uao/alter_while_vacuum.source
@@ -1,25 +1,23 @@
 -- @Description Ensures that an alter table while a vacuum operation is ok
 --
-DROP TABLE IF EXISTS ao;
-DROP
-CREATE TABLE ao (a INT, b INT) WITH (appendonly=true, orientation=@orientation@);
+CREATE TABLE alter_while_vacuum_@orientation@ (a INT, b INT) WITH (appendonly=true, orientation=@orientation@);
 CREATE
-INSERT INTO ao SELECT i as a, i as b FROM generate_series(1, 100000) AS i;
+INSERT INTO alter_while_vacuum_@orientation@ SELECT i as a, i as b FROM generate_series(1, 100000) AS i;
 INSERT 100000
 
-DELETE FROM ao WHERE a < 12000;
+DELETE FROM alter_while_vacuum_@orientation@ WHERE a < 12000;
 DELETE 11999
-1: SELECT COUNT(*) FROM ao;
+1: SELECT COUNT(*) FROM alter_while_vacuum_@orientation@;
 count
 -----
 88001
 (1 row)
-1>: ALTER TABLE ao ADD COLUMN d bigint DEFAULT 10;  <waiting ...>
-2: VACUUM ao;
+1>: ALTER TABLE alter_while_vacuum_@orientation@ ADD COLUMN d bigint DEFAULT 10;  <waiting ...>
+2: VACUUM alter_while_vacuum_@orientation@;
 VACUUM
 1<:  <... completed>
 ALTER
-1: SELECT * FROM ao WHERE a < 12010;
+1: SELECT * FROM alter_while_vacuum_@orientation@ WHERE a < 12010;
 a    |b    |d 
 -----+-----+--
 12000|12000|10

--- a/src/test/isolation2/output/uao/alter_while_vacuum2.source
+++ b/src/test/isolation2/output/uao/alter_while_vacuum2.source
@@ -1,38 +1,35 @@
 -- @Description Ensures that an alter table while a vacuum operation is ok
 --
-DROP TABLE IF EXISTS ao;
-DROP
-
-CREATE TABLE ao (a INT, b INT) WITH (appendonly=true, orientation=@orientation@);
+CREATE TABLE alter_while_vacuum2_@orientation@ (a INT, b INT) WITH (appendonly=true, orientation=@orientation@);
 CREATE
-INSERT INTO ao SELECT i as a, i as b FROM generate_series(1, 100000) AS i;
+INSERT INTO alter_while_vacuum2_@orientation@ SELECT i as a, i as b FROM generate_series(1, 100000) AS i;
 INSERT 100000
-INSERT INTO ao SELECT i as a, i as b FROM generate_series(1, 100000) AS i;
+INSERT INTO alter_while_vacuum2_@orientation@ SELECT i as a, i as b FROM generate_series(1, 100000) AS i;
 INSERT 100000
-INSERT INTO ao SELECT i as a, i as b FROM generate_series(1, 100000) AS i;
+INSERT INTO alter_while_vacuum2_@orientation@ SELECT i as a, i as b FROM generate_series(1, 100000) AS i;
 INSERT 100000
-INSERT INTO ao SELECT i as a, i as b FROM generate_series(1, 100000) AS i;
+INSERT INTO alter_while_vacuum2_@orientation@ SELECT i as a, i as b FROM generate_series(1, 100000) AS i;
 INSERT 100000
-INSERT INTO ao SELECT i as a, i as b FROM generate_series(1, 100000) AS i;
+INSERT INTO alter_while_vacuum2_@orientation@ SELECT i as a, i as b FROM generate_series(1, 100000) AS i;
 INSERT 100000
-INSERT INTO ao SELECT i as a, i as b FROM generate_series(1, 100000) AS i;
+INSERT INTO alter_while_vacuum2_@orientation@ SELECT i as a, i as b FROM generate_series(1, 100000) AS i;
 INSERT 100000
 
-DELETE FROM ao WHERE a < 12000;
+DELETE FROM alter_while_vacuum2_@orientation@ WHERE a < 12000;
 DELETE 71994
-1: SELECT COUNT(*) FROM ao;
+1: SELECT COUNT(*) FROM alter_while_vacuum2_@orientation@;
 count 
 ------
 528006
 (1 row)
 2: set debug_appendonly_print_compaction=true;
 SET
-2>: VACUUM ao;  <waiting ...>
-1: Alter table ao set with ( reorganize='true') distributed randomly;
+2>: VACUUM alter_while_vacuum2_@orientation@;  <waiting ...>
+1: Alter table alter_while_vacuum2_@orientation@ set with ( reorganize='true') distributed randomly;
 ALTER
 2<:  <... completed>
 VACUUM
-1: SELECT COUNT(*) FROM ao WHERE a < 12010;
+1: SELECT COUNT(*) FROM alter_while_vacuum2_@orientation@ WHERE a < 12010;
 count
 -----
 60   


### PR DESCRIPTION
Isolation2 schedule is completely serial currently. Seeking motivation from
upstream discussion to parallelize isolation schedule
(http://www.postgresql-archive.org/reducing-isolation-tests-runtime-td6002684.html)
tried for isolation2 and it works for these tests. Cuts down time to 4 secs from
11 secs (serially) on my laptop. (We currently have very few tests in isolation
which run under 1 sec so not very useful there.)

Need to carefull look at other tests and schedule can be rearranged to make more
tests run in parallel group. Just wish to open this up before moving further.