### PR TITLE
concourse: Allow gen_pipeline.py to be run from any directory

### DIFF
--- a/concourse/pipelines/README.md
+++ b/concourse/pipelines/README.md
@@ -136,7 +136,9 @@ fly -t gpdb-dev \
     -c gpdb-dpm-curry.yml \
     -l ~/workspace/continuous-integration/secrets/gpdb_common-ci-secrets.yml \
     -l ~/workspace/continuous-integration/secrets/gpdb_master-ci-secrets.yml \
-    -v bucket-name=gpdb5-concourse-builds-dev
+    -v bucket-name=gpdb5-concourse-builds-dev \
+    -v gpdb-git-remote=<https://github.com/<github-user>/gpdb> \
+    -v gpdb-git-branch=<branch-name>
 ```
 
 Use the following to generate a pipeline with `ICW` and `CS` test jobs
@@ -162,6 +164,7 @@ fly -t gpdb-dev \
     -c gpdb-cs-durant.yml \
     -l ~/workspace/continuous-integration/secrets/gpdb_common-ci-secrets.yml \
     -l ~/workspace/continuous-integration/secrets/gpdb_master-ci-secrets.yml \
-    -v bucket-name=gpdb5-concourse-builds-dev
-
+    -v bucket-name=gpdb5-concourse-builds-dev \
+    -v gpdb-git-remote=<https://github.com/<github-user>/gpdb> \
+    -v gpdb-git-branch=<branch-name>
 ```


### PR DESCRIPTION
The output argument `-O` is now a filepath, not a filename

The template argument is still a filename within `templates/` because that's
how Jinja likes it

Author: C.J. Jameson <cjameson@pivotal.io>
Author: Shoaib Lari <slari@pivotal.io>

 - [ ] Backport to 5X_STABLE