### PR TITLE
Allow multi-line SQL statements in isolation2 spec

### DIFF
--- a/src/test/isolation2/input/uao/vacuum_while_insert.source
+++ b/src/test/isolation2/input/uao/vacuum_while_insert.source
@@ -26,9 +26,29 @@ insert into ao select generate_series(1,1000);
 
 DELETE FROM ao WHERE a < 128;
 1: BEGIN;
-1>: insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);COMMIT;
+1>: insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;COMMIT;
 4: BEGIN;
-4>: insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);COMMIT;
+4>: insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;COMMIT;
 2: VACUUM ao;
 1<:
 4<:

--- a/src/test/isolation2/sql/starve_case.sql
+++ b/src/test/isolation2/sql/starve_case.sql
@@ -52,14 +52,16 @@ LANGUAGE plpgsql STABLE;
 1: begin;
 1: select * from starve;
 
-2: insert into starve_helper select 'session2', setting::int from pg_settings where name = 'gp_session_id';
+2: insert into starve_helper select 'session2', setting::int from pg_settings
+   where name = 'gp_session_id';
 -- Wait on access exclusive lock.
 2: begin;
 2>: alter table starve rename column c to d;
 
 select wait_until_locks_awaited('session2');
 
-3: insert into starve_helper select 'session3', setting::int from pg_settings where name = 'gp_session_id';
+3: insert into starve_helper select 'session3', setting::int
+   from pg_settings where name = 'gp_session_id';
 -- ENTRY_DB_SINGLETON reader requests access share lock on table
 -- starve.  The lockmode conflicts with already existing waiter's
 -- lockmode (access exclusive).  And the writer is not holding any
@@ -71,14 +73,16 @@ select wait_until_locks_awaited('session3');
 
 -- Check the lock table, expect both session2 and session3 to wait.
 -- expect: 2 rows with AccessExclusiveLock and AccessSharedLock
-select mode from pg_locks where granted=false and relation='starve'::regclass and gp_segment_id=-1;
+select mode from pg_locks where granted=false and relation='starve'::regclass
+and gp_segment_id=-1;
 
 -- Let everyone move forward.
 1: commit;
 
 -- session2 is granted the lock on starve table first.
 2<:
-2: select mode from pg_locks where granted=false and relation='starve'::regclass and gp_segment_id=-1;
+2: select mode from pg_locks where granted=false and
+   relation='starve'::regclass and gp_segment_id=-1;
 2: commit;
 
 -- session3 is granted the lock after session2 commits.  We should
@@ -97,14 +101,16 @@ truncate table starve_helper;
 1: begin;
 1: select * from starve;
 
-2: insert into starve_helper select 'session2', setting::int from pg_settings where name = 'gp_session_id';
+2: insert into starve_helper select 'session2', setting::int from
+   pg_settings where name = 'gp_session_id';
 -- Wait on access exclusive lock.
 2: begin;
 2>: alter table starve add column e int default 0;
 
 select wait_until_locks_awaited('session2');
 
-3: insert into starve_helper select 'session3', setting::int from pg_settings where name = 'gp_session_id';
+3: insert into starve_helper select 'session3', setting::int from pg_settings
+   where name = 'gp_session_id';
 3: begin;
 -- Wait on RowExclusiveLock on table starve because session2 is
 -- waiting on the same lock with a conflicting lockmode.
@@ -116,7 +122,8 @@ select wait_until_locks_awaited('session3');
 -- Session2 must go first.
 2<:
 -- Ensure that session3 is still waiting.
-2: select mode from pg_locks where granted=false and relation='starve'::regclass and gp_segment_id=-1;
+2: select mode from pg_locks where granted=false and relation='starve'::regclass
+   and gp_segment_id=-1;
 2: commit;
 
 -- Session3 gets the lock only after session2 commits.

--- a/src/test/isolation2/sql_isolation_testcase.py
+++ b/src/test/isolation2/sql_isolation_testcase.py
@@ -37,7 +37,10 @@ def is_digit(n):
 class SQLIsolationExecutor(object):
     def __init__(self, dbname=''):
         self.processes = {}
-        self.command_pattern = re.compile(r"^(-?\d+)([&\\<\\>Uq]*?)\:(.*)")
+        # The re.S flag makes the "." in the regex match newlines.
+        # When matched against a command in process_command(), all
+        # lines in the command are matched and sent as SQL query.
+        self.command_pattern = re.compile(r"^(-?\d+)([&\\<\\>Uq]*?)\:(.*)", re.S)
         if dbname:
             self.dbname = dbname
         else:


### PR DESCRIPTION
End of multi-line as well as single line SQL commands is marked by ';'.  One test is modified to demonstrate the usage.