### PR TITLE
gpdeletesystem: require force if backups exist

### DIFF
--- a/gpMgmt/bin/gpdeletesystem
+++ b/gpMgmt/bin/gpdeletesystem
@@ -184,7 +184,8 @@ def display_params(options, dburl, standby, segments, dumpDirsExist):
 # -------------------------------------------------------------------------
 def check_for_dump_files(options):
     logger.info('Checking for database dump files...')
-    return gp.GpDumpDirsExist.local('check for dump dirs', options.master_data_dir)
+    return gp.GpDirsExist.local('check for dump dirs', baseDir=options.master_data_dir, dirName="'*dump*'") \
+           or gp.GpDirsExist.local('check for dump dirs', baseDir=options.master_data_dir, dirName="'*backups*'")
 
 def getTablespaceDirs():
     sqlcmd = "select spclocation FROM pg_tablespace where spcname != 'pg_default' and spcname != 'pg_global'"
@@ -202,10 +203,10 @@ def delete_cluster(options):
     # check for dumps if needed
     dump_files_exist = check_for_dump_files(options)
     if not options.force and dump_files_exist:
-        logger.fatal('Located possible database dump file on Master instance host')
+        logger.fatal('Located possible database backup file on Master instance host')
         logger.fatal('in directory %s' % options.master_data_dir)
-        logger.fatal('To override database dump file checking use -f option')
-        raise GpDeleteSystemException('Dump files exist')
+        logger.fatal('To override database backup file checking use -f option')
+        raise GpDeleteSystemException('Backup files exist')
 
     # get gparray object
     logger.info('Getting segment information...')
@@ -277,62 +278,63 @@ def delete_cluster(options):
     # Re-enable ctrl-c
     signal.signal(signal.SIGINT, signal.default_int_handler)
 
-
+#############
+if __name__ == '__main__':
 # -------------------------------------------------------------------------
 # main
 # -------------------------------------------------------------------------
 
-g_warnings_generated = False
-g_errors_generated = False
+    g_warnings_generated = False
+    g_errors_generated = False
 
-# setup logging
-logger = get_default_logger()
-setup_tool_logging(EXECNAME, unix.getLocalHostname(), unix.getUserName())
+    # setup logging
+    logger = get_default_logger()
+    setup_tool_logging(EXECNAME, unix.getLocalHostname(), unix.getUserName())
 
-# parse args and options
-(options, args) = parseargs()
+    # parse args and options
+    (options, args) = parseargs()
 
-# if we got a new log dir, we can now set it up.
-if options.logfile:
-    setup_tool_logging(EXECNAME, unix.getLocalHostname(), unix.getUserName(), logdir=options.logfile)
+    # if we got a new log dir, we can now set it up.
+    if options.logfile:
+        setup_tool_logging(EXECNAME, unix.getLocalHostname(), unix.getUserName(), logdir=options.logfile)
 
-try:
-    # save off cwd
-    cwd = os.getcwd()
-    # chdir to home to prevent from trying to delete a dir while we are in it
-    home = os.getenv('USERPROFILE') or os.getenv('HOME')
-    os.chdir(home)
-
-    # do the delete
-    delete_cluster(options)
-
-    # now try to go back into the original cwd
     try:
-        os.chdir(cwd)
-    except:
-        # we can ignore this as cwd must no longer exist
-        pass
+        # save off cwd
+        cwd = os.getcwd()
+        # chdir to home to prevent from trying to delete a dir while we are in it
+        home = os.getenv('USERPROFILE') or os.getenv('HOME')
+        os.chdir(home)
 
-except GpDeleteSystemException, ex:
-    g_errors_generated = True
-    if ex.__str__() == 'User canceled':
-        logger.info(ex.__str__())
-    else:
-        logger.fatal(ex.__str__())
-    if options.verbose:
-        logger.exception(ex)
-except Exception, ex:
-    g_errors_generated = True
-    logger.fatal('Error deleting system: %s' % ex.__str__())
-    if options.verbose:
-        logger.exception(ex)
-finally:
-    if g_errors_generated:
-        logger.error('Delete system failed')
-        sys.exit(2)
-    elif g_warnings_generated:
-        logger.warn('Delete system completed but warnings were generated.')
-        sys.exit(1)
-    else:
-        logger.info('Delete system successful.')
-        sys.exit(0)
+        # do the delete
+        delete_cluster(options)
+
+        # now try to go back into the original cwd
+        try:
+            os.chdir(cwd)
+        except:
+            # we can ignore this as cwd must no longer exist
+            pass
+
+    except GpDeleteSystemException, ex:
+        g_errors_generated = True
+        if ex.__str__() == 'User canceled':
+            logger.info(ex.__str__())
+        else:
+            logger.fatal(ex.__str__())
+        if options.verbose:
+            logger.exception(ex)
+    except Exception, ex:
+        g_errors_generated = True
+        logger.fatal('Error deleting system: %s' % ex.__str__())
+        if options.verbose:
+            logger.exception(ex)
+    finally:
+        if g_errors_generated:
+            logger.error('Delete system failed')
+            sys.exit(2)
+        elif g_warnings_generated:
+            logger.warn('Delete system completed but warnings were generated.')
+            sys.exit(1)
+        else:
+            logger.info('Delete system successful.')
+            sys.exit(0)

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -1036,17 +1036,17 @@ class GpCleanSegmentDirectories(Command):
         Command.__init__(self, name, cmdStr, ctxt, remoteHost)
 
 #-----------------------------------------------
-class GpDumpDirsExist(Command):
+class GpDirsExist(Command):
     """
     Checks if gp_dump* directories exist in the given directory
     """
-    def __init__(self, name, baseDir, ctxt=LOCAL, remoteHost=None):
-        cmdStr = "find %s -name '*dump*' -print" % baseDir
+    def __init__(self, name, baseDir, dirName, ctxt=LOCAL, remoteHost=None):
+        cmdStr = "find %s -name %s -print" % (baseDir, dirName)
         Command.__init__(self, name, cmdStr, ctxt, remoteHost)
 
     @staticmethod
-    def local(name, baseDir):
-        cmd = GpDumpDirsExist(name, baseDir)
+    def local(name, baseDir, dirName):
+        cmd = GpDirsExist(name, baseDir=baseDir, dirName=dirName)
         cmd.run(validateAfter=True)
         dirCount = len(cmd.get_results().stdout.split('\n'))
         # This is > 1 because the command output will terminate with \n

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpdeletesystem.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpdeletesystem.py
@@ -1,0 +1,63 @@
+import imp, os
+from optparse import Values
+import tempfile
+import shutil
+from gp_unittest import *
+from mock import *
+
+class GpDeleteSystemTestCase(GpTestCase):
+    def setUp(self):
+        # because gpdeletesystem does not have a .py extension, we have to use imp to import it
+        # if we had a gpdeletesystem.py, this is equivalent to:
+        #   import gpdeletesystem
+        #   self.subject = gpdeletesystem
+        gpdeletesystem_file = os.path.abspath(os.path.dirname(__file__) + "/../../../gpdeletesystem")
+        self.subject = imp.load_source('gpdeletesystem', gpdeletesystem_file)
+        self.tmpDir = tempfile.mkdtemp()
+        os.chmod(self.tmpDir, 0777)
+        self.options = Values()
+        setattr(self.options, 'master_data_dir', self.tmpDir)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpDir)
+
+    def test_check_dump_files_exist(self):
+        os.mkdir(os.path.join(self.tmpDir, 'db_dumps'))
+        self.assertEquals(self.subject.check_for_dump_files(self.options), True)
+
+    def test_check_no_dump_files(self):
+        os.mkdir(os.path.join(self.tmpDir, 'doesntmatch'))
+        self.assertEquals(self.subject.check_for_dump_files(self.options), False)
+
+    def test_check_backup_files_exist(self):
+        os.mkdir(os.path.join(self.tmpDir, 'backups'))
+        self.assertEquals(self.subject.check_for_dump_files(self.options), True)
+
+    def test_delete_cluster_backups_exist_noforce_fails(self):
+        setattr(self.options, 'force', '')
+        os.mkdir(os.path.join(self.tmpDir, 'backups'))
+        with self.assertRaises(self.subject.GpDeleteSystemException) as context:
+            self.subject.delete_cluster(self.options)
+
+        self.assertTrue('Backup files exist' in context.exception)
+
+    def test_delete_cluster_dumps_exist_noforce_fails(self):
+        setattr(self.options, 'force', '')
+        os.mkdir(os.path.join(self.tmpDir, 'db_dumps'))
+        with self.assertRaises(self.subject.GpDeleteSystemException) as context:
+            self.subject.delete_cluster(self.options)
+
+        self.assertTrue('Backup files exist' in context.exception)
+
+
+    @patch('gpdeletesystem.dbconn.DbURL', return_value=Mock())
+    @patch('gpdeletesystem.gparray.GpArray.initFromCatalog', return_value=Mock())
+    def test_delete_cluster_force_succeeds(self, dbURL, initFromCatalog):
+        setattr(self.options, 'force', True)
+        setattr(self.options, 'pgport', 5432)
+        os.mkdir(os.path.join(self.tmpDir, 'backups'))
+        os.mkdir(os.path.join(self.tmpDir, 'db_dumps'))
+        with self.assertRaises(self.subject.GpDeleteSystemException) as context:
+            self.subject.delete_cluster(self.options)
+
+        self.assertTrue('Failed to get database configuration' in context.exception.message)


### PR DESCRIPTION
The current behavior is to check for the existence of dumps dirs and, unless
run with the -f flag, error out if they do. This commit extends this
check to backups.

Author: Nadeem Ghani <nghani@pivotal.io>