### PR TITLE
Fix commit_transaction_block_checkpoint isolation2 test flakiness

### DIFF
--- a/src/test/isolation2/expected/commit_transaction_block_checkpoint.out
+++ b/src/test/isolation2/expected/commit_transaction_block_checkpoint.out
@@ -19,6 +19,13 @@ BEGIN
 CREATE
 2&: commit;  <waiting ...>
 
+-- wait for the fault to trigger since following checkpoint could be faster
+select gp_inject_fault('twophase_transaction_commit_prepared', 'wait_until_triggered', '', '', '', 1, 0, 3);
+gp_inject_fault
+---------------
+t                     
+(1 row)
+
 -- do checkpoint on segment content 1 in utility mode, and it should block
 1U&: checkpoint;  <waiting ...>
 
@@ -51,6 +58,13 @@ BEGIN
 2: drop table t_commit_transaction_block_checkpoint;
 DROP
 2&: commit;  <waiting ...>
+
+-- wait for the fault to trigger since following checkpoint could be faster
+select gp_inject_fault('onephase_transaction_commit', 'wait_until_triggered', '', '', '', 1, 0, 1);
+gp_inject_fault
+---------------
+t                     
+(1 row)
 
 -- do checkpoint on master in utility mode, and it should block
 -1U&: checkpoint;  <waiting ...>

--- a/src/test/isolation2/sql/commit_transaction_block_checkpoint.sql
+++ b/src/test/isolation2/sql/commit_transaction_block_checkpoint.sql
@@ -11,6 +11,9 @@ select gp_inject_fault('twophase_transaction_commit_prepared', 'suspend', 3);
 2: create table t_commit_transaction_block_checkpoint (c int) distributed by (c);
 2&: commit;
 
+-- wait for the fault to trigger since following checkpoint could be faster
+select gp_inject_fault('twophase_transaction_commit_prepared', 'wait_until_triggered', '', '', '', 1, 0, 3);
+
 -- do checkpoint on segment content 1 in utility mode, and it should block
 1U&: checkpoint;
 
@@ -30,6 +33,9 @@ select gp_inject_fault('onephase_transaction_commit', 'suspend', 1);
 2: begin;
 2: drop table t_commit_transaction_block_checkpoint;
 2&: commit;
+
+-- wait for the fault to trigger since following checkpoint could be faster
+select gp_inject_fault('onephase_transaction_commit', 'wait_until_triggered', '', '', '', 1, 0, 1);
 
 -- do checkpoint on master in utility mode, and it should block
 -1U&: checkpoint;


### PR DESCRIPTION
There was a timing issue where a checkpoint called in a utility mode
session went through before the session could trigger the fault to
block commits. To prevent this timing issue, we wait for the fault to
trigger before calling the checkpoint.