### PR TITLE
Fix dispatching of queries with record-type parameters.

### DIFF
--- a/src/backend/cdb/motion/tupleremap.c
+++ b/src/backend/cdb/motion/tupleremap.c
@@ -260,6 +260,29 @@ TRHandleTypeLists(TupleRemapper *remapper, List *typelist)
 	}
 }
 
+
+/*
+ * Remap a single Datum, which can be a RECORD datum using the remote system's
+ * typmods.
+ */
+Datum
+TRRemapDatum(TupleRemapper *remapper, Oid typeid, Datum value)
+{
+	TupleRemapInfo *remapinfo;
+	bool		changed;
+
+	remapinfo = BuildTupleRemapInfo(typeid, remapper->mycontext);
+
+	if (!remapinfo)
+		return value;
+
+	value = TRRemap(remapper, remapinfo, value, &changed);
+
+	pfree(remapinfo);
+
+	return value;
+}
+
 /*
  * Copy the given tuple, remapping any transient typmods contained in it.
  */

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -2537,6 +2537,23 @@ _readTupleDescNode(void)
 	READ_DONE();
 }
 
+static SerializedParamExternData *
+_readSerializedParamExternData(void)
+{
+	READ_LOCALS(SerializedParamExternData);
+
+	READ_BOOL_FIELD(isnull);
+	READ_INT16_FIELD(pflags);
+	READ_OID_FIELD(ptype);
+	READ_INT16_FIELD(plen);
+	READ_BOOL_FIELD(pbyval);
+
+	if (!local_node->isnull)
+		local_node->value = readDatum(local_node->pbyval);
+
+	READ_DONE();
+}
+
 static AlterExtensionStmt *
 _readAlterExtensionStmt(void)
 {
@@ -3593,8 +3610,12 @@ readNodeBinary(void)
 			case T_AlterExtensionContentsStmt:
 				return_value = _readAlterExtensionContentsStmt();
 				break;
+
 			case T_TupleDescNode:
 				return_value = _readTupleDescNode();
+				break;
+			case T_SerializedParamExternData:
+				return_value = _readSerializedParamExternData();
 				break;
 
 			case T_AlterTSConfigurationStmt:

--- a/src/include/cdb/cdbdisp_query.h
+++ b/src/include/cdb/cdbdisp_query.h
@@ -106,4 +106,7 @@ CdbDispatchUtilityStatement(struct Node *stmt,
 							List *oid_assignments,
 							struct CdbPgResults* cdb_pgresults);
 
+
+extern ParamListInfo deserializeParamListInfo(const char *str, int slen);
+
 #endif   /* CDBDISP_QUERY_H */

--- a/src/include/cdb/tupleremap.h
+++ b/src/include/cdb/tupleremap.h
@@ -22,5 +22,6 @@ extern TupleRemapper *CreateTupleRemapper(void);
 extern void DestroyTupleRemapper(TupleRemapper *remapper);
 extern GenericTuple TRCheckAndRemap(TupleRemapper *remapper, TupleDesc tupledesc, GenericTuple tuple);
 extern void TRHandleTypeLists(TupleRemapper *remapper, List *typelist);
+extern Datum TRRemapDatum(TupleRemapper *remapper, Oid typeid, Datum value);
 
 #endif   /* TUPLEREMAP_H */

--- a/src/include/nodes/nodes.h
+++ b/src/include/nodes/nodes.h
@@ -166,7 +166,13 @@ typedef enum NodeTag
 	T_RowTriggerState,
 	T_AssertOpState,
 	T_PartitionSelectorState,
+
+	/*
+	 * TupleDesc and ParamListInfo are not Nodes as such, but you can wrap
+	 * them in TupleDescNode and SerializedParamExternData structs for serialization.
+	 */
 	T_TupleDescNode,
+	T_SerializedParamExternData,
 
 	/*
 	 * TAGS FOR PRIMITIVE NODES (primnodes.h)
@@ -611,9 +617,10 @@ extern char *nodeToString(void *obj);
  * nodes/outfast.c. This special version of nodeToString is only used by serializeNode.
  * It's a quick hack that allocates 8K buffer for StringInfo struct through initStringIinfoSizeOf
  */
-extern char *nodeToBinaryStringFast(void *obj, int * size);
+extern char *nodeToBinaryStringFast(void *obj, int *length);
 
 extern Node *readNodeFromBinaryString(const char *str, int len);
+
 /*
  * nodes/{readfuncs.c,read.c}
  */

--- a/src/include/nodes/params.h
+++ b/src/include/nodes/params.h
@@ -54,6 +54,26 @@ typedef struct ParamListInfoData
 typedef ParamListInfoData *ParamListInfo;
 
 
+/*
+ * Serialized form of ParamExternData. This is used when query parameters
+ * are serialized, when dispatching a query from QD to QEs.
+ */
+typedef struct SerializedParamExternData
+{
+	NodeTag		type;
+
+	/* Fields from ParamExternData */
+	Datum		value;			/* parameter value */
+	bool		isnull;			/* is it NULL? */
+	uint16		pflags;			/* flag bits, see above */
+	Oid			ptype;			/* parameter's datatype, or 0 */
+
+	/* Extra information about the type */
+	int16		plen;
+	bool		pbyval;
+
+} SerializedParamExternData;
+
 /* ----------------
  *	  ParamExecData
  *

--- a/src/test/regress/input/transient_types.source
+++ b/src/test/regress/input/transient_types.source
@@ -194,4 +194,43 @@ SELECT foo() FROM t_nomap;
 DROP TABLE t_nomap;
 DROP FUNCTION foo();
 
+--
+-- Use a transient record type in a parameter of a query that's dispatched to segments
+--
+-- For these tests, the QD needs to serialize a transient record type to the QE, while
+-- all the previous tests were for the other direction, in Motion nodes.
+--
+drop table if exists t;
+create table t as select i as id from generate_series(1,8) i;
+insert into t values (100000);
+
+do $$
+declare
+  r record;
+  nestedr record;
+
+  result record;
+begin
+  select 1 as i, 2 AS j into r;
+  select r as nestedrec, 'foo' AS foo into nestedr;
+
+  raise notice 'r: %', r;
+  raise notice 'nestedr: %', nestedr;
+
+  -- Reference one field of a 'record' variable.
+  select * into result from t where id=r.i;
+  raise notice 'result 1: %', result.id;
+
+  -- Same with a nested 'record' variable
+  select * into result from t where id > length(nestedr.nestedrec::text) + 1000;
+  raise notice 'result 2: %', result.id;
+
+  -- Reference the record variable itself.
+  select * into result from t where id > length(nestedr::text) + 1000;
+  raise notice 'result 3: %', result.id;
+end;
+$$;
+
+drop table if exists t;
+
 drop schema transient_types;

--- a/src/test/regress/output/transient_types.source
+++ b/src/test/regress/output/transient_types.source
@@ -447,4 +447,45 @@ SELECT foo() FROM t_nomap;
 
 DROP TABLE t_nomap;
 DROP FUNCTION foo();
+--
+-- Use a transient record type in a parameter of a query that's dispatched to segments
+--
+-- For these tests, the QD needs to serialize a transient record type to the QE, while
+-- all the previous tests were for the other direction, in Motion nodes.
+--
+drop table if exists t;
+create table t as select i as id from generate_series(1,8) i;
+insert into t values (100000);
+do $$
+declare
+  r record;
+  nestedr record;
+
+  result record;
+begin
+  select 1 as i, 2 AS j into r;
+  select r as nestedrec, 'foo' AS foo into nestedr;
+
+  raise notice 'r: %', r;
+  raise notice 'nestedr: %', nestedr;
+
+  -- Reference one field of a 'record' variable.
+  select * into result from t where id=r.i;
+  raise notice 'result 1: %', result.id;
+
+  -- Same with a nested 'record' variable
+  select * into result from t where id > length(nestedr.nestedrec::text) + 1000;
+  raise notice 'result 2: %', result.id;
+
+  -- Reference the record variable itself.
+  select * into result from t where id > length(nestedr::text) + 1000;
+  raise notice 'result 3: %', result.id;
+end;
+$$;
+NOTICE:  r: (1,2)
+NOTICE:  nestedr: ("(1,2)",foo)
+NOTICE:  result 1: 1
+NOTICE:  result 2: 100000
+NOTICE:  result 3: 100000
+drop table if exists t;
 drop schema transient_types;


### PR DESCRIPTION
This fixes the "ERROR:  record type has not been registered" error, when
a record-type variable is used in a query inside a PL/pgSQL function.
This is essentially the same problem we battled with in Motion nodes
in GPDB 5, and added the whole tuple remapper to deal with it. Only this
time, the problem is with record Datums being dispatched from QD to QE,
as Params, rather than with record Datums being transferred across a
Motion.

To fix, send the transient record type cache along with the query
parameters, if there are any of the parameters are transient record types.
This is a bit inefficient, as the transient record type cache can be quite
large. A more fine-grained approach would be to send only those record
types that are actually used in the parameters, but more code would be
required to figure that out. This will do for now.

Refactor the serialization and deserialization of the query parameters, to
leverage the outfast/readfast functions.

Backport to 5X_STABLE. This changes the wire format of query parameters, so
this requires the QD and QE to be on the same minor version. But this does
not change the on-disk format, or the numbering of existing Node tags.

Fixes github issue #4444.