### PR TITLE
Fix make_pathkey_from_sortinfo() call

### DIFF
--- a/src/backend/optimizer/path/pathkeys.c
+++ b/src/backend/optimizer/path/pathkeys.c
@@ -1330,10 +1330,16 @@ make_pathkeys_for_groupclause(PlannerInfo *root,
 
 		if (IsA(node, SortGroupClause))
 		{
-			SortGroupClause *gc = (SortGroupClause *) node;
+			SortGroupClause *sortcl = (SortGroupClause *) node;
 
-			sortkey = (Expr *) get_sortgroupclause_expr(gc, tlist);
-			pathkey = make_pathkey_from_sortinfo(root, sortkey, gc->sortop, gc->nulls_first, false, 0);
+			sortkey = (Expr *) get_sortgroupclause_expr(sortcl, tlist);
+			Assert(OidIsValid(sortcl->sortop));
+			pathkey = make_pathkey_from_sortinfo(root,
+												 sortkey,
+												 sortcl->sortop,
+												 sortcl->nulls_first,
+												 sortcl->tleSortGroupRef,
+												 false);
 
 			/*
 			 * The pathkey becomes a one-element sublist. canonicalize_pathkeys() might


### PR DESCRIPTION
The 'sortref' and 'canonicalize' arguments seem reversed. And why are
we not passing 'tleSortGroupRef' argument, when we have it?

This isn't causing any trouble on 'master', but on the iteration_6 branch
where we are merging with PostgreSQL 9.0, this was causing the following
failure in the 'uao_ddl/temp_on_commit_delete_rows_row' test:
+ERROR:  volatile EquivalenceClass has no sortref (equivclass.c:465)

I'm not sure why that doesn't occur on 'master', but this seems wrong
in any case.