### PR TITLE
Fix binary swap test failed by guc gp_enable_query_metrics.

### DIFF
--- a/src/test/isolation2/expected/instr_in_shmem_cleanup.out
+++ b/src/test/isolation2/expected/instr_in_shmem_cleanup.out
@@ -1,0 +1,3 @@
+-- start_ignore
+! gpconfig -r gp_enable_query_metrics; ! gpstop -rai;
+-- end_ignore

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -10,6 +10,7 @@ test: reader_waits_for_lock
 test: drop_rename
 test: instr_in_shmem_setup
 test: instr_in_shmem_terminate
+test: instr_in_shmem_cleanup
 
 test: setup
 # Tests on Append-Optimized tables (row-oriented).

--- a/src/test/isolation2/sql/instr_in_shmem_cleanup.sql
+++ b/src/test/isolation2/sql/instr_in_shmem_cleanup.sql
@@ -1,0 +1,4 @@
+-- start_ignore
+! gpconfig -r gp_enable_query_metrics; 
+! gpstop -rai;
+-- end_ignore

--- a/src/test/regress/expected/instr_in_shmem_cleanup.out
+++ b/src/test/regress/expected/instr_in_shmem_cleanup.out
@@ -1,0 +1,6 @@
+-- restore gp_enable_query_metrics to default
+-- to avoid conflict with binary swap test
+-- start_ignore
+\! gpconfig -r gp_enable_query_metrics
+\! PGDATESTYLE="" gpstop -rai
+-- end_ignore

--- a/src/test/regress/expected/instr_in_shmem_setup.out
+++ b/src/test/regress/expected/instr_in_shmem_setup.out
@@ -1,6 +1,6 @@
 -- gp_enable_query_metrics GUC will enable instrumentation
 -- collection for every query in following tests.
--- After all tests finished, the last test check_instr_in_shmem
+-- After all tests finished, the last test instr_in_shmem_verify
 -- will check for leaks of instrumentation slots in shmem.
 -- start_ignore
 \! gpconfig -c gp_enable_query_metrics -v on 

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -202,5 +202,6 @@ test: psql_gp_commands pg_resetxlog
 
 # Check for shmem leak for instrumentation slots
 test: instr_in_shmem_verify
+test: instr_in_shmem_cleanup
 
 # end of tests

--- a/src/test/regress/sql/instr_in_shmem_cleanup.sql
+++ b/src/test/regress/sql/instr_in_shmem_cleanup.sql
@@ -1,0 +1,7 @@
+-- restore gp_enable_query_metrics to default
+-- to avoid conflict with binary swap test
+
+-- start_ignore
+\! gpconfig -r gp_enable_query_metrics
+\! PGDATESTYLE="" gpstop -rai
+-- end_ignore

--- a/src/test/regress/sql/instr_in_shmem_setup.sql
+++ b/src/test/regress/sql/instr_in_shmem_setup.sql
@@ -1,6 +1,6 @@
 -- gp_enable_query_metrics GUC will enable instrumentation
 -- collection for every query in following tests.
--- After all tests finished, the last test check_instr_in_shmem
+-- After all tests finished, the last test instr_in_shmem_verify
 -- will check for leaks of instrumentation slots in shmem.
 
 -- start_ignore


### PR DESCRIPTION
In c3a9ed28aad53951d9eca162c0eae14414c7f036 there is a new guc in regression and isolation2 test. It is set to `ON` in postgresql.conf but not restored because we want it to be enabled with more tests. Then in binary swap test, after switched to 5.0.0 gpdb cannot recognize this guc leads to failure. This fix restore the guc in postgresql.conf.
In the long term, this guc should change to `ON` by default according to design. Then these tests will be refactored.