### PR TITLE
Make gprecoverseg full work

### DIFF
--- a/gpMgmt/bin/gppylib/commands/unix.py
+++ b/gpMgmt/bin/gppylib/commands/unix.py
@@ -575,7 +575,7 @@ class RemoveDirectoryContents(Command):
         unique_dir = "/tmp/emptyForRemove%s" % uuid.uuid4()
         cmd_str = "if [ -d {target_dir} ]; then " \
                   "mkdir -p {unique_dir}  &&  " \
-                  "{cmd} -a --delete {unique_dir}/ {target_dir}/  &&  " \
+                  "{cmd} -a --no-perms --delete {unique_dir}/ {target_dir}/  &&  " \
                   "rmdir {unique_dir} ; fi".format(
                     unique_dir=unique_dir,
                     cmd=findCmdInPath('rsync'),

--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -363,51 +363,6 @@ class GpMirrorListToBuild:
             unix.MakeDirectory("create blank directory for segment", subDir).run(validateAfter=True)
             unix.Chmod.local('set permissions on blank dir', subDir, '0700')
 
-    def __buildTarFileForTransfer(self, gpEnv, masterSegment, sampleSegment, newSegments):
-        """
-        Returns the file for the tarfile that should be transferred and used
-         for building the blank segment
-
-        """
-        masterDir = gpEnv.getMasterDataDir()
-
-        # note that this tempdir will be left around on the system (this is what other scripts do currently)
-        tempDir = gp.createTempDirectoryName(gpEnv.getMasterDataDir(), "gpbuildingsegment")
-        unix.MakeDirectory("create temp directory for segment", tempDir).run(validateAfter=True)
-
-        schemaDir = tempDir + "/schema"
-        unix.MakeDirectory("create temp schema directory for segment", schemaDir).run(validateAfter=True)
-        unix.Chmod.local('set permissions on schema dir', schemaDir, '0700')  # set perms so postgres can start
-
-        #
-        # Copy remote files from the sample segment to the master
-        #
-        for toCopyFromRemote in ["postgresql.conf", "pg_hba.conf"]:
-            cmd = gp.RemoteCopy('copying %s from a segment' % toCopyFromRemote,
-                                os.path.join(sampleSegment.getSegmentDataDirectory(), toCopyFromRemote),
-                                masterSegment.getSegmentHostName(), schemaDir, ctxt=base.REMOTE,
-                                remoteHost=sampleSegment.getSegmentAddress())
-            cmd.run(validateAfter=True)
-
-        appendNewEntriesToHbaFile(schemaDir + "/pg_hba.conf", newSegments)
-
-        #
-        # Use the master's version of other files, and build
-        #
-        self.__createEmptyDirectories(schemaDir, gDatabaseDirectories)
-        self.__createEmptyDirectories(schemaDir, gDatabaseSubDirectories)
-        self.__copyFiles(masterDir, schemaDir, ["PG_VERSION", "pg_ident.conf"])
-
-        #
-        # Build final tar
-        #
-        tarFileName = "gp_emptySegmentSchema.tar"
-        tarFile = tempDir + "/" + tarFileName
-        cmd = gp.CreateTar('gpbuildingmirrorsegment tar segment template', schemaDir, tarFile)
-        cmd.run(validateAfter=True)
-
-        return (tempDir, tarFile, tarFileName)
-
     def __copySegmentDirectories(self, gpEnv, gpArray, directives):
         """
         directives should be composed of GpCopySegmentDirectoryDirective values
@@ -415,22 +370,27 @@ class GpMirrorListToBuild:
         if len(directives) == 0:
             return
 
-        srcSegments = [d.getSrcSegment() for d in directives]
-        destSegments = [d.getDestSegment() for d in directives]
-        isTargetReusedLocation = [d.isTargetReusedLocation() for d in directives]
+        srcSegments = []
+        destSegments = []
+        isTargetReusedLocation = []
+        for directive in directives:
+            srcSegment = directive.getSrcSegment()
+            destSegment = directive.getDestSegment()
+            destSegment.primaryHostname = srcSegment.getSegmentHostName()
+            destSegment.primarySegmentPort = srcSegment.getSegmentPort()
+
+            srcSegments.append(srcSegment)
+            destSegments.append(destSegment)
+            isTargetReusedLocation.append(directive.isTargetReusedLocation())
+
         destSegmentByHost = GpArray.getSegmentsByHostName(destSegments)
         newSegmentInfo = gp.ConfigureNewSegment.buildSegmentInfoForNewSegment(destSegments, isTargetReusedLocation)
-
-        self.__logger.info('Building template directory')
-        (tempDir, blankTarFile, tarFileName) = self.__buildTarFileForTransfer(gpEnv, gpArray.master, srcSegments[0],
-                                                                              destSegments)
 
         def createConfigureNewSegmentCommand(hostName, cmdLabel, validationOnly):
             segmentInfo = newSegmentInfo[hostName]
             checkNotNone("segmentInfo for %s" % hostName, segmentInfo)
             return gp.ConfigureNewSegment(cmdLabel,
                                           segmentInfo,
-                                          tarFile=tarFileName,
                                           newSegments=True,
                                           verbose=gplog.logging_is_verbose(),
                                           batchSize=self.__parallelDegree,
@@ -465,16 +425,6 @@ class GpMirrorListToBuild:
             raise ExceptionNoStackTraceNeeded("\n" + ("\n".join(validationErrors)))
 
         #
-        # copy tar from master to target hosts
-        #
-        self.__logger.info('Copying template directory file')
-        cmds = []
-        for hostName in destSegmentByHost.keys():
-            cmds.append(gp.RemoteCopy("copy segment tar", blankTarFile, hostName, tarFileName))
-
-        self.__runWaitAndCheckWorkerPoolForErrorsAndClear(cmds, "building and transferring basic segment directory")
-
-        #
         # unpack and configure new segments
         #
         self.__logger.info('Configuring new segments')
@@ -502,20 +452,6 @@ class GpMirrorListToBuild:
                                   recursive=True)
                         cmd.run(validateAfter=True)
                         break
-
-        #
-        # Clean up copied tar from each remote host
-        #
-        self.__logger.info('Cleaning files')
-        cmds = []
-        for hostName, segments in destSegmentByHost.iteritems():
-            cmds.append(unix.RemoveFile('remove tar file', tarFileName, ctxt=gp.REMOTE, remoteHost=hostName))
-        self.__runWaitAndCheckWorkerPoolForErrorsAndClear(cmds, "cleaning up tar file on segment hosts")
-
-        #
-        # clean up the local temp directory
-        #
-        unix.RemoveDirectory.local('remove temp directory', tempDir)
 
     def _get_running_postgres_segments(self, segments):
         running_segments = []

--- a/gpMgmt/bin/lib/gpconfigurenewsegment
+++ b/gpMgmt/bin/lib/gpconfigurenewsegment
@@ -145,15 +145,16 @@ class ConfExpSegCmd(Command):
                         self.set_results(CommandResult(1,'',e,True,False))
                         raise
 
-                    logger.info("extract tar file to new segment")
-                    extractTarCmd = unix.ExtractTar('extract tar file to new segment', self.tarfile, self.datadir )
-                    try:
-                        logger.debug('Extracting tar file %s to %s' % (self.tarfile, self.datadir))
-                        extractTarCmd.run(validateAfter=True)
-                    except:
-                        self.set_results(extractTarCmd.get_results())
-                        logger.error(extractTarCmd.get_results())
-                        raise
+                    if self.tarfile:
+                        logger.info("extract tar file to new segment")
+                        extractTarCmd = unix.ExtractTar('extract tar file to new segment', self.tarfile, self.datadir )
+                        try:
+                            logger.debug('Extracting tar file %s to %s' % (self.tarfile, self.datadir))
+                            extractTarCmd.run(validateAfter=True)
+                        except:
+                            self.set_results(extractTarCmd.get_results())
+                            logger.error(extractTarCmd.get_results())
+                            raise
 
                     logger.info("create gp_dbid file for segment")
                     writeGpDbidFile(self.datadir, self.dbid, logger=gplog.get_logger_if_verbose())
@@ -231,9 +232,6 @@ def parseargs():
     if options.batch_size <= 0:
         logger.warn('batch_size was less than zero.  Setting to 1.')
         options.batch_size = 1
-
-    if options.newsegments and not options.tarfile:
-        raise Exception('-n option requires -t option to be specified')
 
     if options.validationOnly and options.writeGpidFileOnly:
         raise Exception('Only one of --validation-only and --write-gpid-file-only can be specified')

--- a/gpMgmt/sbin/gpcleansegmentdir.py
+++ b/gpMgmt/sbin/gpcleansegmentdir.py
@@ -35,22 +35,10 @@ class GpCleanSegmentDirectoryProgram:
 
         logger.info("Cleaning main data directories")
         for segment in segments:
-            dir = segment.getSegmentDataDirectory()
-            logger.info("Cleaning %s" % dir)
+            segmentdir = segment.getSegmentDataDirectory()
+            logger.info("Cleaning %s" % segmentdir)
 
-            for toClean in gDatabaseDirectories:
-                if toClean != "pg_log":
-                    unix.RemoveDirectory('clean segment', os.path.join(dir, toClean)).run(validateAfter=True)
-            for toClean in gDatabaseFiles:
-                unix.RemoveFile('clean segment', os.path.join(dir, toClean)).run(validateAfter=True)
-
-        for segment in segments:
-            for filespaceOid, dir in segment.getSegmentFilespaces().iteritems():
-                if filespaceOid != gparray.SYSTEM_FILESPACE:
-                    #
-                    # delete entire filespace directory -- filerep code on server will recreate it
-                    #
-                    unix.RemoveDirectory('clean segment filespace dir', dir).run(validateAfter=True)
+            unix.RemoveDirectoryContents('clean segment', segmentdir).run(validateAfter=True)
 
     def cleanup(self):
         pass

--- a/src/test/isolation2/expected/segwalrep/mirror_promotion.out
+++ b/src/test/isolation2/expected/segwalrep/mirror_promotion.out
@@ -43,57 +43,8 @@ content|preferred_role|role|status|mode
 0Uq: ... <quitting>
 
 -- fully recover the failed primary as new mirror
-!\retcode ../../../gpAux/gpdemo/gpsegwalrep.py recoverfull;
+!\retcode gprecoverseg -aF;
 -- start_ignore
-2018-01-10 23:42:04.312398: fetching cluster configuration
-2018-01-10 23:42:04.405057: fetched cluster configuration
-found 3 distinct content IDs
-Mirror content 0:  2018-01-10 23:42:04.423853: Running command... rm -rf /Users/aagrawal/workspace/gpdata/dbfast1/demoDataDir0
-Mirror content 0:  
-Mirror content 0:  2018-01-10 23:42:04.508628: Running command... pg_basebackup -x -R -c fast -E ./pg_log -E ./db_dumps -E ./gpperfmon/data -E ./gpperfmon/logs -D /Users/aagrawal/workspace/gpdata/dbfast1/demoDataDir0 -h 127.0.0.1 -p 25435
-Mirror content 0:  NOTICE:  WAL archiving is not enabled; you must ensure that all required WAL segments are copied through other means to complete the backup
-Mirror content 0:  
-Mirror content 0:  2018-01-10 23:42:05.009465: Running command... mkdir /Users/aagrawal/workspace/gpdata/dbfast1/demoDataDir0/pg_log; mkdir /Users/aagrawal/workspace/gpdata/dbfast1/demoDataDir0/pg_xlog/archive_status
-Mirror content 0:  
-Mirror content 0:  2018-01-10 23:42:05.020184: Initialized mirror at /Users/aagrawal/workspace/gpdata/dbfast1/demoDataDir0
-
-Segment primary content 0:  2018-01-10 23:42:05.020494: Running command... pg_ctl -D /Users/aagrawal/workspace/gpdata/dbfast1/demoDataDir0  -o '-p 25432 --gp_dbid=0 --silent-mode=true -i --gp_contentid=0 --gp_num_contents_in_cluster=3' start
-Segment primary content 0:  server starting
-Segment primary content 0:  
-Segment primary content 0:  2018-01-10 23:42:05.048563: Running command... pg_ctl -D /Users/aagrawal/workspace/gpdata/dbfast1/demoDataDir0 status
-Segment primary content 0:  pg_ctl: server is running (PID: 35912)
-Segment primary content 0:  
-Segment primary content 0:  2018-01-10 23:42:05.055839: Started primary segment with content 0 and port 25432 at /Users/aagrawal/workspace/gpdata/dbfast1/demoDataDir0
-
-Force FTS probe scan:  2018-01-10 23:42:05.056015: Running command... psql postgres -c "SELECT gp_request_fts_probe_scan()"
-Force FTS probe scan:   gp_request_fts_probe_scan 
-Force FTS probe scan:  ---------------------------
-Force FTS probe scan:   t
-Force FTS probe scan:  (1 row)
-Force FTS probe scan:  
-Force FTS probe scan:  
-Force FTS probe scan:  2018-01-10 23:42:06.088302: FTS probe refreshed catalog
-
-2018-01-10 23:42:06.088478: fetching cluster configuration
-2018-01-10 23:42:06.179366: fetched cluster configuration
-found 3 distinct content IDs
-:  2018-01-10 23:42:06.189714: Running command... psql postgres -c "select * from gp_segment_configuration order by content, dbid"
-:   dbid | content | role | preferred_role | mode | status | port  |     hostname      |      address      |                           datadir                            
-:  ------+---------+------+----------------+------+--------+-------+-------------------+-------------------+--------------------------------------------------------------
-:      1 |      -1 | p    | p              | n    | u      | 15432 | ashwins-mac.local | ashwins-mac.local | /Users/aagrawal/workspace/gpdata/qddir/demoDataDir-1
-:      8 |      -1 | m    | m              | s    | u      | 16432 | ashwins-mac.local | ashwins-mac.local | /Users/aagrawal/workspace/gpdata/standby
-:      2 |       0 | m    | p              | s    | u      | 25432 | ashwins-mac.local | ashwins-mac.local | /Users/aagrawal/workspace/gpdata/dbfast1/demoDataDir0
-:      5 |       0 | p    | m              | s    | u      | 25435 | ashwins-mac.local | ashwins-mac.local | /Users/aagrawal/workspace/gpdata/dbfast_mirror1/demoDataDir0
-:      3 |       1 | p    | p              | s    | u      | 25433 | ashwins-mac.local | ashwins-mac.local | /Users/aagrawal/workspace/gpdata/dbfast2/demoDataDir1
-:      7 |       1 | m    | m              | s    | u      | 25436 | ashwins-mac.local | ashwins-mac.local | /Users/aagrawal/workspace/gpdata/dbfast_mirror2/demoDataDir1
-:      4 |       2 | p    | p              | s    | u      | 25434 | ashwins-mac.local | ashwins-mac.local | /Users/aagrawal/workspace/gpdata/dbfast3/demoDataDir2
-:      6 |       2 | m    | m              | s    | u      | 25437 | ashwins-mac.local | ashwins-mac.local | /Users/aagrawal/workspace/gpdata/dbfast_mirror3/demoDataDir2
-:  (8 rows)
-:  
-:  
-:  2018-01-10 23:42:06.205890: 
-
-
 -- end_ignore
 (exited with code 0)
 
@@ -137,57 +88,8 @@ content|preferred_role|role|status|mode
 (1 row)
 
 -- now, let's fully recover the mirror
-!\retcode ../../../gpAux/gpdemo/gpsegwalrep.py recoverfull;
+!\retcode gprecoverseg -aF;
 -- start_ignore
-2018-01-10 23:42:12.624505: fetching cluster configuration
-2018-01-10 23:42:12.717571: fetched cluster configuration
-found 3 distinct content IDs
-Mirror content 0:  2018-01-10 23:42:12.733807: Running command... rm -rf /Users/aagrawal/workspace/gpdata/dbfast_mirror1/demoDataDir0
-Mirror content 0:  
-Mirror content 0:  2018-01-10 23:42:12.830415: Running command... pg_basebackup -x -R -c fast -E ./pg_log -E ./db_dumps -E ./gpperfmon/data -E ./gpperfmon/logs -D /Users/aagrawal/workspace/gpdata/dbfast_mirror1/demoDataDir0 -h 127.0.0.1 -p 25432
-Mirror content 0:  NOTICE:  WAL archiving is not enabled; you must ensure that all required WAL segments are copied through other means to complete the backup
-Mirror content 0:  
-Mirror content 0:  2018-01-10 23:42:14.326265: Running command... mkdir /Users/aagrawal/workspace/gpdata/dbfast_mirror1/demoDataDir0/pg_log; mkdir /Users/aagrawal/workspace/gpdata/dbfast_mirror1/demoDataDir0/pg_xlog/archive_status
-Mirror content 0:  
-Mirror content 0:  2018-01-10 23:42:14.335604: Initialized mirror at /Users/aagrawal/workspace/gpdata/dbfast_mirror1/demoDataDir0
-
-Segment mirror content 0:  2018-01-10 23:42:14.335990: Running command... pg_ctl -D /Users/aagrawal/workspace/gpdata/dbfast_mirror1/demoDataDir0  -o '-p 25435 --gp_dbid=0 --silent-mode=true -i --gp_contentid=0 --gp_num_contents_in_cluster=3' start
-Segment mirror content 0:  server starting
-Segment mirror content 0:  
-Segment mirror content 0:  2018-01-10 23:42:14.362829: Running command... pg_ctl -D /Users/aagrawal/workspace/gpdata/dbfast_mirror1/demoDataDir0 status
-Segment mirror content 0:  pg_ctl: server is running (PID: 35968)
-Segment mirror content 0:  
-Segment mirror content 0:  2018-01-10 23:42:14.370174: Started mirror segment with content 0 and port 25435 at /Users/aagrawal/workspace/gpdata/dbfast_mirror1/demoDataDir0
-
-Force FTS probe scan:  2018-01-10 23:42:14.370351: Running command... psql postgres -c "SELECT gp_request_fts_probe_scan()"
-Force FTS probe scan:   gp_request_fts_probe_scan 
-Force FTS probe scan:  ---------------------------
-Force FTS probe scan:   t
-Force FTS probe scan:  (1 row)
-Force FTS probe scan:  
-Force FTS probe scan:  
-Force FTS probe scan:  2018-01-10 23:42:15.399794: FTS probe refreshed catalog
-
-2018-01-10 23:42:15.399942: fetching cluster configuration
-2018-01-10 23:42:15.492766: fetched cluster configuration
-found 3 distinct content IDs
-:  2018-01-10 23:42:15.503241: Running command... psql postgres -c "select * from gp_segment_configuration order by content, dbid"
-:   dbid | content | role | preferred_role | mode | status | port  |     hostname      |      address      |                           datadir                            
-:  ------+---------+------+----------------+------+--------+-------+-------------------+-------------------+--------------------------------------------------------------
-:      1 |      -1 | p    | p              | n    | u      | 15432 | ashwins-mac.local | ashwins-mac.local | /Users/aagrawal/workspace/gpdata/qddir/demoDataDir-1
-:      8 |      -1 | m    | m              | s    | u      | 16432 | ashwins-mac.local | ashwins-mac.local | /Users/aagrawal/workspace/gpdata/standby
-:      2 |       0 | p    | p              | s    | u      | 25432 | ashwins-mac.local | ashwins-mac.local | /Users/aagrawal/workspace/gpdata/dbfast1/demoDataDir0
-:      5 |       0 | m    | m              | s    | u      | 25435 | ashwins-mac.local | ashwins-mac.local | /Users/aagrawal/workspace/gpdata/dbfast_mirror1/demoDataDir0
-:      3 |       1 | p    | p              | s    | u      | 25433 | ashwins-mac.local | ashwins-mac.local | /Users/aagrawal/workspace/gpdata/dbfast2/demoDataDir1
-:      7 |       1 | m    | m              | s    | u      | 25436 | ashwins-mac.local | ashwins-mac.local | /Users/aagrawal/workspace/gpdata/dbfast_mirror2/demoDataDir1
-:      4 |       2 | p    | p              | s    | u      | 25434 | ashwins-mac.local | ashwins-mac.local | /Users/aagrawal/workspace/gpdata/dbfast3/demoDataDir2
-:      6 |       2 | m    | m              | s    | u      | 25437 | ashwins-mac.local | ashwins-mac.local | /Users/aagrawal/workspace/gpdata/dbfast_mirror3/demoDataDir2
-:  (8 rows)
-:  
-:  
-:  2018-01-10 23:42:15.519589: 
-
-
 -- end_ignore
 (exited with code 0)
 

--- a/src/test/isolation2/sql/segwalrep/mirror_promotion.sql
+++ b/src/test/isolation2/sql/segwalrep/mirror_promotion.sql
@@ -37,7 +37,7 @@ where content = 0;
 0Uq:
 
 -- fully recover the failed primary as new mirror
-!\retcode ../../../gpAux/gpdemo/gpsegwalrep.py recoverfull;
+!\retcode gprecoverseg -aF;
 
 -- expect: to see the new rebuilt mirror up and in sync
 select content, preferred_role, role, status, mode
@@ -60,7 +60,7 @@ where content = 0;
 0U: select 1;
 
 -- now, let's fully recover the mirror
-!\retcode ../../../gpAux/gpdemo/gpsegwalrep.py recoverfull;
+!\retcode gprecoverseg -aF;
 
 -- now, the content 0 primary and mirror should be at their preferred role
 -- and up and in-sync


### PR DESCRIPTION
The gprecoverseg tool has been broken after filerep and persistent
tables were removed.  This commit cleans it up a little bit and makes
full mirror recovery work.