### PR TITLE
CI: Remove references to tf-bucket-path from README

### DIFF
--- a/concourse/pipelines/README.md
+++ b/concourse/pipelines/README.md
@@ -136,7 +136,6 @@ fly -t gpdb-dev \
     -c gpdb-dpm-curry.yml \
     -l ~/workspace/continuous-integration/secrets/gpdb_common-ci-secrets.yml \
     -l ~/workspace/continuous-integration/secrets/gpdb_master-ci-secrets.yml \
-    -v tf-bucket-path=dev/dpm/ \
     -v bucket-name=gpdb5-concourse-builds-dev
 ```
 
@@ -163,7 +162,6 @@ fly -t gpdb-dev \
     -c gpdb-cs-durant.yml \
     -l ~/workspace/continuous-integration/secrets/gpdb_common-ci-secrets.yml \
     -l ~/workspace/continuous-integration/secrets/gpdb_master-ci-secrets.yml \
-    -v tf-bucket-path=dev/cs/ \
     -v bucket-name=gpdb5-concourse-builds-dev
 
 ```


### PR DESCRIPTION
Commit 3520f6c8ae402d18cb60f79975cac334032e3e1c removed all references to
the parameter tf-bucket-path because it is now hardcoded to clusters.
