### PR TITLE
Refactor the way Semi-Joins plans are constructed.

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -2211,10 +2211,6 @@ _copySpecialJoinInfo(SpecialJoinInfo *from)
 	COPY_SCALAR_FIELD(lhs_strict);
 	COPY_SCALAR_FIELD(delay_upper_joins);
 	COPY_NODE_FIELD(join_quals);
-	COPY_SCALAR_FIELD(try_join_unique);	/* CDB */
-	COPY_SCALAR_FIELD(consider_dedup);	/* CDB */
-	COPY_NODE_FIELD(semi_operators);
-	COPY_NODE_FIELD(semi_rhs_exprs);
 
 	return newnode;
 }

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -854,10 +854,6 @@ _equalSpecialJoinInfo(SpecialJoinInfo *a, SpecialJoinInfo *b)
 	COMPARE_SCALAR_FIELD(lhs_strict);
 	COMPARE_SCALAR_FIELD(delay_upper_joins);
 	COMPARE_NODE_FIELD(join_quals);
-	COMPARE_SCALAR_FIELD(try_join_unique);	/* CDB */
-	COMPARE_SCALAR_FIELD(consider_dedup);		/* CDB */
-	COMPARE_NODE_FIELD(semi_operators);
-	COMPARE_NODE_FIELD(semi_rhs_exprs);
 
 	return true;
 }

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -1625,9 +1625,6 @@ _outNode(StringInfo str, void *obj)
 			case T_IndexOptInfo:
 				_outIndexOptInfo(str, obj);
 				break;
-			case T_CdbRelDedupInfo:
-				_outCdbRelDedupInfo(str, obj);
-				break;
 			case T_PathKey:
 				_outPathKey(str, obj);
 				break;

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -1944,7 +1944,6 @@ _outUniquePath(StringInfo str, UniquePath *node)
 	WRITE_FLOAT_FIELD(rows, "%.0f");
     WRITE_BOOL_FIELD(must_repartition);                 /*CDB*/
     WRITE_BITMAPSET_FIELD(distinct_on_rowid_relids);    /*CDB*/
-	WRITE_NODE_FIELD(distinct_on_exprs);                /*CDB*/
 
 	WRITE_NODE_FIELD(subpath);
 }
@@ -2064,7 +2063,6 @@ _outRelOptInfo(StringInfo str, RelOptInfo *node)
 	/* WRITE_NODE_FIELD(pathlist);              */
 	/* WRITE_NODE_FIELD(cheapest_startup_path); */
 	/* WRITE_NODE_FIELD(cheapest_total_path);   */
-	WRITE_NODE_FIELD(dedup_info);
 	WRITE_UINT_FIELD(relid);
 	WRITE_ENUM_FIELD(rtekind, RTEKind);
 	WRITE_INT_FIELD(min_attr);
@@ -2141,22 +2139,6 @@ _outCdbRelColumnInfo(StringInfo str, CdbRelColumnInfo *node)
 	WRITE_NODE_FIELD(defexpr);
 }
 #endif /* COMPILING_BINARY_FUNCS */
-
-static void
-_outCdbRelDedupInfo(StringInfo str, CdbRelDedupInfo *node)
-{
-	WRITE_NODE_TYPE("CdbRelDedupInfo");
-
-	WRITE_BITMAPSET_FIELD(prejoin_dedup_subqrelids);
-	WRITE_BITMAPSET_FIELD(spent_subqrelids);
-	WRITE_BOOL_FIELD(try_postjoin_dedup);
-	WRITE_BOOL_FIELD(no_more_subqueries);
-	WRITE_NODE_FIELD(join_unique_ininfo);
-	/* Skip writing Path ptrs to avoid endless recursion */
-	/* WRITE_NODE_FIELD(later_dedup_pathlist);  */
-	/* WRITE_NODE_FIELD(cheapest_startup_path); */
-	/* WRITE_NODE_FIELD(cheapest_total_path);   */
-}
 
 #ifndef COMPILING_BINARY_FUNCS
 static void
@@ -2273,10 +2255,6 @@ _outSpecialJoinInfo(StringInfo str, SpecialJoinInfo *node)
 	WRITE_BOOL_FIELD(lhs_strict);
 	WRITE_BOOL_FIELD(delay_upper_joins);
 	WRITE_NODE_FIELD(join_quals);
-	WRITE_BOOL_FIELD(try_join_unique);	/*CDB*/
-	WRITE_BOOL_FIELD(consider_dedup);	/*CDB*/
-	WRITE_NODE_FIELD(semi_operators);
-	WRITE_NODE_FIELD(semi_rhs_exprs);
 }
 
 static void
@@ -4715,9 +4693,6 @@ _outNode(StringInfo str, void *obj)
 				break;
 			case T_CdbRelColumnInfo:
 				_outCdbRelColumnInfo(str, obj);
-				break;
-			case T_CdbRelDedupInfo:
-				_outCdbRelDedupInfo(str, obj);
 				break;
 			case T_EquivalenceClass:
 				_outEquivalenceClass(str, obj);

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -301,10 +301,6 @@ set_plain_rel_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 		set_baserel_size_estimates(root, rel);
 	}
 
-	/* CDB: Attach subquery duplicate suppression info. */
-	if (root->join_info_list)
-		rel->dedup_info = cdb_make_rel_dedup_info(root, rel);
-
 	/*
 	 * Generate paths and add them to the rel's pathlist.
 	 *
@@ -782,10 +778,6 @@ set_subquery_pathlist(PlannerInfo *root, RelOptInfo *rel,
 	else
 		rel->tuples = rel->subplan->plan_rows;
 
-	/* CDB: Attach subquery duplicate suppression info. */
-	if (root->join_info_list)
-		rel->dedup_info = cdb_make_rel_dedup_info(root, rel);
-
 	/* Mark rel with estimated output rows, width, etc */
 	set_baserel_size_estimates(root, rel);
 
@@ -813,10 +805,6 @@ set_function_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 {
 	/* CDB: Could the function return more than one row? */
 	rel->onerow = !expression_returns_set(rte->funcexpr);
-
-	/* CDB: Attach subquery duplicate suppression info. */
-	if (root->join_info_list)
-		rel->dedup_info = cdb_make_rel_dedup_info(root, rel);
 
 	/* Mark rel with estimated output rows, width, etc */
 	set_function_size_estimates(root, rel);
@@ -873,10 +861,6 @@ set_tablefunction_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rt
 	/* Could the function return more than one row? */
 	rel->onerow = !expression_returns_set(rte->funcexpr);
 
-	/* Attach subquery duplicate suppression info. */
-	if (root->join_info_list)
-		rel->dedup_info = cdb_make_rel_dedup_info(root, rel);
-
 	/* Mark rel with estimated output rows, width, etc */
 	set_table_function_size_estimates(root, rel);
 
@@ -900,10 +884,6 @@ set_values_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 	/* CDB: Just one row? */
 	rel->onerow = (rel->tuples <= 1 &&
 				   !expression_returns_set((Node *) rte->values_lists));
-
-	/* CDB: Attach subquery duplicate suppression info. */
-	if (root->join_info_list)
-		rel->dedup_info = cdb_make_rel_dedup_info(root, rel);
 
 	/* Generate appropriate path */
 	add_path(root, rel, create_valuesscan_path(root, rel, rte));

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -873,8 +873,8 @@ create_unique_plan(PlannerInfo *root, UniquePath *best_path)
 	 * subplan's tlist; and we don't install it into the subplan unless we are
 	 * sorting or stuff has to be added.
 	 */
-	in_operators = best_path->distinct_on_eq_operators; /* CDB */
-	uniq_exprs = best_path->distinct_on_exprs;	/* CDB */
+	in_operators = best_path->in_operators;
+	uniq_exprs = best_path->uniq_exprs;
 
 	/* initialize modified subplan tlist as just the "required" vars */
 	newtlist = build_relation_tlist(best_path->path.parent);

--- a/src/backend/optimizer/plan/initsplan.c
+++ b/src/backend/optimizer/plan/initsplan.c
@@ -70,7 +70,6 @@ static bool check_outerjoin_delay(PlannerInfo *root, Relids *relids_p,
 static bool check_equivalence_delay(PlannerInfo *root,
 						RestrictInfo *restrictinfo);
 static bool check_redundant_nullability_qual(PlannerInfo *root, Node *clause);
-static void compute_semijoin_info(SpecialJoinInfo* sjinfo, PlannerInfo* root);
 
 
 /*****************************************************************************
@@ -696,12 +695,7 @@ make_outerjoininfo(PlannerInfo *root,
 	sjinfo->delay_upper_joins = false;
 	sjinfo->join_quals = clause;
 
-	/* If we chose to take inner join path for this semi join then we MAY
-	 * need to deduplicate the join result.
-	 */
-	sjinfo->consider_dedup = jointype == JOIN_SEMI ? true : false;
-	sjinfo->try_join_unique = false;
-
+	/* If it's a full join, no need to be very smart */
 	if (jointype == JOIN_FULL)
 	{
 		sjinfo->min_lefthand = bms_copy(left_rels);
@@ -852,143 +846,7 @@ make_outerjoininfo(PlannerInfo *root,
 	sjinfo->min_lefthand = min_lefthand;
 	sjinfo->min_righthand = min_righthand;
 
-	compute_semijoin_info(sjinfo, root);
-
 	return sjinfo;
-}
-
-/*
- * compute_semijoin_info
- *	  Fill semijoin-related fields of a new SpecialJoinInfo
- */
-static void
-compute_semijoin_info(SpecialJoinInfo* sjinfo, PlannerInfo* root)
-{
-	List	   *semi_operators;
-	List	   *semi_rhs_exprs;
-	List	   *in_vars;
-	Relids fixed_lefthand = NULL;
-	ListCell   *lc;
-
-	sjinfo->semi_operators = NIL;
-	sjinfo->semi_rhs_exprs = NIL;
-
-	/* Nothing more to do if it's not a semijoin */
-	if (sjinfo->jointype != JOIN_SEMI)
-		return;
-
-	/*
-	 * Uncorrelated "=ANY" or EXISTS subqueries can use JOIN_UNIQUE dedup technique
-	 * Prepare information for pre-join deduplication here which is later used
-	 * by cdb_make_rel_dedup_info()
-	 */
-	semi_operators = NIL;
-	semi_rhs_exprs = NIL;
-	foreach(lc, sjinfo->join_quals)
-	{
-		Node* qual = lfirst(lc);
-		OpExpr	*op;
-		Oid		opno;
-		List	*opfamilies;
-		List	*opstrats;
-		Node	   *left_expr;
-		Node	   *right_expr;
-		Relids		left_varnos;
-		Relids		right_varnos;
-		Relids		all_varnos;
-
-		/*
-		 * We should not come here when sublink contains volatile functions
-		 * All the sublink pull up functions bail out if there is a volatile
-		 * function in sublink's testexpr.
-		 */
-		Assert(!contain_volatile_functions((Node *) qual));
-
-		if (!IsA(qual, OpExpr) ||
-				list_length(((OpExpr *)qual)->args) != 2)
-		{
-			/* No, but does it reference both sides? */
-			all_varnos = pull_varnos(qual);
-			if (!bms_overlap(all_varnos, sjinfo->syn_righthand) ||
-					bms_is_subset(all_varnos, sjinfo->syn_righthand))
-			{
-				/* Clause refers to only one rel, so ignore it */
-				continue;
-			}
-			/* Non-operator clause referencing both sides, must punt */
-			return;
-		}
-
-		/* Otherwise it is an OpExpr */
-		op = (OpExpr *) qual;
-		opno = op->opno;
-		left_expr = linitial(op->args);
-		right_expr = lsecond(op->args);
-		left_varnos = pull_varnos(left_expr);
-		right_varnos = pull_varnos(right_expr);
-		all_varnos = bms_union(left_varnos, right_varnos);
-
-		/* Does it reference both sides? */
-		if (!bms_overlap(all_varnos, sjinfo->syn_righthand) ||
-				bms_is_subset(all_varnos, sjinfo->syn_righthand))
-		{
-
-			/* Clause refers to only one rel, so ignore it */
-			continue;
-		}
-
-		get_op_btree_interpretation(opno, &opfamilies, &opstrats);
-
-		/* check rel membership of arguments */
-		if (!bms_is_empty(right_varnos) &&
-				bms_is_subset(right_varnos, sjinfo->syn_righthand) &&
-				!bms_overlap(left_varnos, sjinfo->syn_righthand) &&
-				list_member_int(opstrats, ROWCOMPARE_EQ))
-		{
-			/* right_expr is RHS only & op is good -> OK to do dedup */
-			semi_operators = lappend_oid(semi_operators, opno);
-			semi_rhs_exprs = lappend(semi_rhs_exprs, copyObject(right_expr));
-			sjinfo->try_join_unique = true;
-		}
-	}
-
-	if (semi_rhs_exprs == NIL)
-		return;
-
-	sjinfo->semi_rhs_exprs = semi_rhs_exprs;
-	sjinfo->semi_operators = semi_operators;
-
-	/*
-	 * If the lefthand side of qual is an inherited relation, then
-	 * cdb_make_rel_dedup_info() expects relids of parent base rels and not
-	 * the child relids. Replace them appropriately here.
-	 */
-	foreach(lc, root->append_rel_list)
-	{
-		AppendRelInfo *appinfo = (AppendRelInfo *) lfirst(lc);
-
-		if (bms_is_member(appinfo->child_relid, sjinfo->min_lefthand))
-		{
-			fixed_lefthand = bms_add_member(fixed_lefthand, appinfo->parent_relid);
-		}
-	}
-
-	/*
-	 * We need the IN/EXISTS's righthand-side vars to be available at the join,
-	 * in case we try to unique-ify the subselect's outputs.
-	 * Add targetlist entries for each var needed sub_targetlist we computed above.
-	 */
-	// GPDB_84_MERGE_FIXME: Should we include placeholder vars as well in pull_var_clause?
-	in_vars = pull_var_clause((Node *) sjinfo->semi_rhs_exprs,
-							  PVC_RECURSE_AGGREGATES,
-							  PVC_REJECT_PLACEHOLDERS);
-
-	if (in_vars != NIL)
-	{
-		add_vars_to_targetlist(root, in_vars,
-				bms_union(fixed_lefthand, sjinfo->min_righthand));
-		list_free(in_vars);
-	}
 }
 
 

--- a/src/backend/optimizer/plan/planmain.c
+++ b/src/backend/optimizer/plan/planmain.c
@@ -285,17 +285,6 @@ query_planner(PlannerInfo *root, List *tlist,
 	Insist(final_rel->cheapest_startup_path);
 
 	/*
-	 * CDB: Subquery duplicate suppression should be all finished by now.
-	 *
-	 * CDB TODO: If query has DISTINCT, GROUP BY with just MIN/MAX aggs, or
-	 * LIMIT 1, consider paths in which subquery duplicate suppression has
-	 * not been completed.  (Would have to change set_cheapest_dedup() to not
-	 * discard them.)
-	 */
-	Insist(final_rel->cheapest_startup_path->subq_complete &&
-		   final_rel->cheapest_total_path->subq_complete);
-
-	/*
 	 * If there's grouping going on, estimate the number of result groups. We
 	 * couldn't do this any earlier because it depends on relation size
 	 * estimates that were set up above.

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -573,9 +573,6 @@ subquery_planner(PlannerGlobal *glob, Query *parse,
 	 */
 	AssertImply(parse->jointree->fromlist, list_length(parse->jointree->fromlist) == 1);
 
-	/* CDB: Stash current query level's relids before pulling up subqueries. */
-	root->currlevel_relids = get_relids_in_jointree((Node *) parse->jointree, false);
-
 	/*
 	 * Look for ANY and EXISTS SubLinks in WHERE and JOIN/ON clauses, and try
 	 * to transform them into joins.  Note that this step does not descend
@@ -632,16 +629,6 @@ subquery_planner(PlannerGlobal *glob, Query *parse,
 	 * subqueries.
 	 */
 	expand_inherited_tables(root);
-
-	/* CDB: If parent RTE belongs to current query level, children do too. */
-	foreach(l, root->append_rel_list)
-	{
-		AppendRelInfo *appinfo = (AppendRelInfo *) lfirst(l);
-
-		if (bms_is_member(appinfo->parent_relid, root->currlevel_relids))
-			root->currlevel_relids = bms_add_member(root->currlevel_relids,
-													appinfo->child_relid);
-	}
 
 	/*
 	 * Set hasHavingQual to remember if HAVING clause is present.  Needed

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -21,6 +21,7 @@
 #include "catalog/pg_operator.h"
 #include "catalog/pg_proc.h"
 #include "executor/executor.h"
+#include "executor/nodeHash.h"
 #include "miscadmin.h"
 #include "optimizer/clauses.h"
 #include "optimizer/cost.h"
@@ -37,21 +38,9 @@
 
 #include "cdb/cdbpath.h"        /* cdb_create_motion_path() etc */
 
-static void     cdb_set_cheapest_dedup(PlannerInfo *root, RelOptInfo *rel);
-static bool     cdb_is_path_deduped(Path *path);
-static bool     cdb_subpath_tried_postjoin_dedup(Path *path, Relids subqrelids);
-static UniquePath  *create_limit1_path(PlannerInfo *root, Path *subpath);
-static UniquePath *create_unique_exprlist_path(PlannerInfo *root,
-							Path *subpath, List *distinct_on_exprs,
-							List *distinct_on_operators);
-static UniquePath *create_unique_rowid_path(PlannerInfo *root,
-						 Path *subpath, Relids dedup_relids);
-static UniquePath  *make_limit1_path(Path *subpath);
-static UniquePath  *make_unique_path(Path *subpath);
 static List *translate_sub_tlist(List *tlist, int relid);
 static bool query_is_distinct_for(Query *query, List *colnos, List *opids);
 static Oid	distinct_col_search(int colno, List *colnos, List *opids);
-static bool hash_safe_operators(List *opids);
 
 static CdbVisitOpt pathnode_walk_list(List *pathlist,
 				   CdbVisitOpt (*walker)(Path *path, void *context),
@@ -401,42 +390,21 @@ compare_fractional_path_costs(Path *path1, Path *path2,
 void
 set_cheapest(PlannerInfo *root, RelOptInfo *parent_rel)
 {
+	List	   *pathlist = parent_rel->pathlist;
 	ListCell   *p;
 	Path	   *cheapest_startup_path;
 	Path	   *cheapest_total_path;
-    CdbRelDedupInfo    *dedup_info = parent_rel->dedup_info;
 
 	Assert(IsA(parent_rel, RelOptInfo));
 
-    /* CDB: Add paths incorporating subquery duplicate suppression. */
-    if (dedup_info &&
-        dedup_info->later_dedup_pathlist)
-    {
-        cdb_set_cheapest_dedup(root, parent_rel);
+	/* CDB: Empty pathlist is possible if user set some enable_xxx = off. */
+	if (pathlist == NIL)
+	{
+		parent_rel->cheapest_startup_path = parent_rel->cheapest_total_path = NULL;
+		return;
+	}
 
-        /* If main pathlist is empty, put the later_dedup paths there. */
-        if (!parent_rel->pathlist &&
-            dedup_info->later_dedup_pathlist)
-        {
-            parent_rel->pathlist = dedup_info->later_dedup_pathlist;
-            parent_rel->cheapest_startup_path = dedup_info->cheapest_startup_path;
-            parent_rel->cheapest_total_path = dedup_info->cheapest_total_path;
-            dedup_info->later_dedup_pathlist = NIL;
-            dedup_info->cheapest_startup_path = NULL;
-            dedup_info->cheapest_total_path = NULL;
-            Assert(parent_rel->cheapest_total_path);
-            return;
-        }
-    }
-
-    /* CDB: Empty pathlist is possible if user set some enable_xxx = off. */
-    if (!parent_rel->pathlist)
-    {
-        parent_rel->cheapest_startup_path = parent_rel->cheapest_total_path = NULL;
-        return;
-    }
-
-    cheapest_startup_path = cheapest_total_path = (Path *) linitial(parent_rel->pathlist);
+	cheapest_startup_path = cheapest_total_path = (Path *) linitial(parent_rel->pathlist);
 
 	for_each_cell(p, lnext(list_head(parent_rel->pathlist)))
 	{
@@ -460,387 +428,8 @@ set_cheapest(PlannerInfo *root, RelOptInfo *parent_rel)
 
 	parent_rel->cheapest_startup_path = cheapest_startup_path;
 	parent_rel->cheapest_total_path = cheapest_total_path;
-
-}                               /* set_cheapest */
-
-
-/*
- * cdb_set_cheapest_dedup
- *
- * Called by set_cheapest() to augment a RelOptInfo with paths that
- * provide for subquery duplicate suppression.
- */
-static void
-cdb_set_cheapest_dedup(PlannerInfo *root, RelOptInfo *rel)
-{
-    CdbRelDedupInfo    *dedup = rel->dedup_info;
-    ListCell           *cell;
-	List               *save_pathlist;
-	Path               *save_cheapest_startup;
-	Path               *save_cheapest_total;
-    Path               *subpath;
-    UniquePath         *upath = NULL;
-
-    /*
-     * If rel has only 1 row, joining with it cannot produce duplicates.
-     *
-     * Some paths could have been added to the later_dedup_pathlist before
-     * the discovery that at most one row can satisfy the predicates.
-     * Transfer any such to the main pathlist.
-     */
-    if (rel->onerow)
-    {
-        /* Seize the later_dedup_pathlist. */
-        save_pathlist = dedup->later_dedup_pathlist;
-        dedup->later_dedup_pathlist = NIL;
-
-        /* Add its paths to the main pathlist. */
-        foreach(cell, save_pathlist)
-            add_path(root, rel, (Path *)lfirst(cell));
-
-        /* Verify that the paths weren't added to the wrong list. */
-        Insist(!dedup->later_dedup_pathlist);
-        return;
-    }
-
-    /*
-     * Pick out the lowest-cost paths in later_dedup_pathlist.
-     *
-     * The choice is made by a recursive call to set_cheapest(), for which we
-     * momentarily hijack the main pathlist fields in RelOptInfo.
-     */
-    save_pathlist = rel->pathlist;
-    save_cheapest_startup = rel->cheapest_startup_path;
-    save_cheapest_total = rel->cheapest_total_path;
-    rel->pathlist = dedup->later_dedup_pathlist;
-    rel->cheapest_startup_path = NULL;
-    rel->cheapest_total_path = NULL;
-    dedup->later_dedup_pathlist = NIL;  /* to stop the recursion */
-
-    set_cheapest(root, rel);
-
-    dedup->later_dedup_pathlist = rel->pathlist;
-    dedup->cheapest_startup_path = rel->cheapest_startup_path;
-    dedup->cheapest_total_path = rel->cheapest_total_path;
-    rel->pathlist = save_pathlist;
-    rel->cheapest_startup_path = save_cheapest_startup;
-    rel->cheapest_total_path = save_cheapest_total;
-
-    /*
-     * If rel is the final result of a pulled-up uncorrelated "= ANY" subquery,
-     * consider a path that yields the distinct rows of the subquery.
-     *
-     * For an uncorrelated "= ANY" subquery, we'll consider plans in which
-     * we remove duplicates from the rel containing the subquery result,
-     * before that is joined with any other rels.  An "=" predicate (which
-     * was created by convert_IN_to_join()) ensures that at most one row of
-     * the duplicate-free subquery result can join with any one row of the
-     * subquery's parent query.
-     *
-     * (Formerly in PostgreSQL this pre-join duplicate suppression was invoked
-     * via special jointype codes: JOIN_UNIQUE_OUTER and JOIN_UNIQUE_INNER.)
-     *
-     * CDB TODO: We wouldn't have to do anything special if we knew the
-     * subquery result rows are distinct because of a UNIQUE constraint.
-     *
-     * CDB TODO: Correlated subquery could use JOIN_UNIQUE if all outer
-     * refs can be pulled up above the UniquePath operator, or if umethod
-     * is UNIQUE_PATH_NOOP.
-     *
-     * CDB TODO: Avoid sorting when the subpath is ordered on the
-     * sub_targetlist columns.
-     */
-    if (dedup->join_unique_ininfo)
-    {
-		Assert(dedup->join_unique_ininfo->semi_rhs_exprs);
-		/* Top off the subpath with DISTINCT ON the result columns. */
-		upath = create_unique_exprlist_path(root,
-											dedup->cheapest_total_path,
-											dedup->join_unique_ininfo->semi_rhs_exprs,
-											dedup->join_unique_ininfo->semi_operators);
-		/* Add to rel's main pathlist. */
-		add_path(root, rel, (Path *)upath);
-    }
-
-    /*
-     * Consider post-join duplicate removal.
-     *
-     * Post-join duplicate removal is done by inserting a Unique operator that
-     * is DISTINCT ON the unique row identifiers of those relids that do *not*
-     * derive from flattened subqueries.
-     *
-     * If there is at least one subquery whose required inputs are all present
-     * in this rel, and no subquery having some inputs present and some inputs
-     * absent, then cdb_make_rel_dedup_info() has set the try_postjoin_dedup
-     * flag and filled in the prejoin_dedup_subqrelids field giving the relids
-     * of those subqueries' own tables.  Those subqueries are candidates for
-     * late duplicate removal.
-     *
-     * NB: "Required inputs" means the sublink's lefthand relids, the
-     * subquery's own tables (the sublink's righthand relids), and the
-     * relids of outer references.
-     */
-    else if (dedup->try_postjoin_dedup)
-    {
-        Relids  distinct_relids = NULL;
-
-        Assert(dedup->prejoin_dedup_subqrelids);
-
-        /* hide later_dedup_pathlist while we walk it, so add_path can't upd. */
-        save_pathlist = dedup->later_dedup_pathlist;
-        dedup->later_dedup_pathlist = NIL;
-
-        foreach(cell, save_pathlist)
-        {
-            subpath = (Path *)lfirst(cell);
-            Assert(!subpath->subq_complete);
-
-            /*
-             * When one subplan of a join is the source of all of the relids in
-             * postjoin_dedup_allrelids, we can assume post-join duplicate
-             * removal has already been considered upstream.  We could keep on
-             * considering it after every subsequent join, to insert the Unique
-             * op at the point where it is cheapest.  But we do not attempt
-             * that, because at present the join result size estimates are
-             * untrustworthy.
-             *
-             * CDB TODO: Could remove this after fixing the join selectivity.
-             */
-            if (cdb_subpath_tried_postjoin_dedup(subpath,
-                                                 dedup->prejoin_dedup_subqrelids))
-                continue;
-
-            /*
-             * Build set of tables whose row ids will be the DISTINCT ON keys.
-             * The bitmapset object will be shared; don't free it!
-             */
-            if (!distinct_relids)
-                distinct_relids =
-                    bms_difference(rel->relids, dedup->prejoin_dedup_subqrelids);
-
-            /*
-             * Top off the subpath with DISTINCT ON the non-subquery row ids.
-             * Add to rel's main pathlist.
-             */
-            upath = create_unique_rowid_path(root, subpath, distinct_relids);
-            add_path(root, rel, (Path *)upath);
-        }
-
-        /* Verify that our new paths haven't gone into the wrong pathlist. */
-        Insist(!dedup->later_dedup_pathlist);
-        dedup->later_dedup_pathlist = save_pathlist;
-    }
-
-    /*
-     * Don't consider plans that further delay duplicate suppression
-     * after all subqueries have been fully evaluated.  (If a later join
-     * happens to reduce the amount of data, duplicate removal could be
-     * cheaper afterward and it would be better to wait.  However, we
-     * don't currently trust the join result size estimates that much.)
-     *
-     * CDB TODO: If current query level has GROUP BY with only MIN/MAX aggs,
-     * DISTINCT or LIMIT 1, retain these paths... but move them into the rel's
-     * main pathlist since no extra step will be needed downstream for dedup.
-     */
-    if (dedup->no_more_subqueries)
-        dedup->later_dedup_pathlist = NIL;
-
-}                             /* cdb_set_cheapest_dedup */
-
-
-/*
- * cdb_is_path_deduped
- *
- * Returns true if there is no flattened subquery whose tables are all present,
- * or if the given path takes care of all the duplicate suppression for such
- * subqueries, so that they require no further action downstream.
- *
- * Returns false if some flattened subquery has all tables present but still
- * needs duplicate suppression to be done downstream.
- *
- * Not affected by subqueries which have some but not all tables present.
- */
-typedef struct CdbIsPathDedupedCtx
-{
-    Relids          all_subqrelids;
-    Relids          deduped_relids;
-    bool            deduped_unshared;
-} CdbIsPathDedupedCtx;
-
-static CdbVisitOpt
-cdb_is_path_deduped_walker(Path *path, void* context)
-{
-    CdbIsPathDedupedCtx    *ctx = (CdbIsPathDedupedCtx *)context;
-    RelOptInfo             *rel = path->parent;
-    Relids                  deduped;
-
-    /* Skip path unless rel includes all relids of some flattened subquery. */
-    if (!rel->dedup_info ||
-        !rel->dedup_info->prejoin_dedup_subqrelids)
-        return CdbVisit_Skip;       /* no relids to add; don't visit children */
-
-    /* Dedup usually wraps up all subqueries whose tables are all present. */
-    deduped = rel->dedup_info->prejoin_dedup_subqrelids;
-
-    /* Already satisfied? */
-    if (path->subq_complete)
-        goto put_deduped_result;
-
-    /* If rel has only 1 row, joining with it cannot produce duplicates. */
-    if (rel->onerow)
-        goto put_deduped_result;
-
-    switch (path->pathtype)
-    {
-        /*
-         * Unique op is used only for subquery duplicate suppression, at present.
-         * Subqueries whose relids are covered by a Unique op don't require
-         * further duplicate suppression downstream.
-         */
-        case T_Unique:
-            goto put_deduped_result;
-
-        /*
-         * Join with jointype JOIN_SEMI will suppress duplicates for all
-         * subqueries whose relids are covered by the join's inner rel.
-         */
-        case T_HashJoin:
-	    case T_MergeJoin:
-	    case T_NestLoop:
-        {
-            JoinPath   *joinpath = (JoinPath *)path;
-            RelOptInfo *inner_rel = joinpath->innerjoinpath->parent;
-            CdbVisitOpt status;
-
-            /* Visit the outer subpath. */
-            status = pathnode_walk_node(joinpath->outerjoinpath,
-                                        cdb_is_path_deduped_walker,
-                                        ctx);
-            if (status != CdbVisit_Walk)
-                return status;
-
-            /* Subqueries on inner side of JOIN_SEMI can't cause duplicates. */
-            if (joinpath->jointype == JOIN_SEMI)
-            {
-                if (!inner_rel->dedup_info ||
-                    !inner_rel->dedup_info->prejoin_dedup_subqrelids)
-                    return CdbVisit_Walk;
-                deduped = inner_rel->dedup_info->prejoin_dedup_subqrelids;
-                goto put_deduped_result;
-            }
-
-            /* Visit the inner subpath. */
-            return pathnode_walk_node(joinpath->innerjoinpath,
-                                      cdb_is_path_deduped_walker,
-                                      ctx);
-        }
-
-        default:
-            break;
-    }
-    return CdbVisit_Walk;       /* onward to visit children */
-
-    /*
-     * Add this Path node's deduped relids to set.
-     * To reduce allocations, try to return an existing bitmapset.
-     */
-put_deduped_result:
-    if (!ctx->deduped_relids)
-    {
-        ctx->deduped_relids = deduped;
-        ctx->deduped_unshared = false;
-    }
-    else if (ctx->deduped_unshared)
-        ctx->deduped_relids = bms_add_members(ctx->deduped_relids, deduped);
-    else
-    {
-        ctx->deduped_relids = bms_union(ctx->deduped_relids, deduped);
-        ctx->deduped_unshared = true;
-    }
-
-    /*
-     * All found?  Then stop.
-     */
-    if (bms_equal(ctx->deduped_relids, ctx->all_subqrelids))
-        return CdbVisit_Success;
-
-    /* Done with this branch; don't visit children, but proceed to next. */
-    return CdbVisit_Skip;
-}                               /* cdb_is_path_deduped_walker */
-
-static bool
-cdb_is_path_deduped(Path *path)
-{
-    CdbIsPathDedupedCtx context;
-    CdbVisitOpt         status;
-
-    if (!path->parent->dedup_info ||
-        !path->parent->dedup_info->prejoin_dedup_subqrelids)
-        return true;
-
-    context.all_subqrelids = path->parent->dedup_info->prejoin_dedup_subqrelids;
-    context.deduped_relids = NULL;
-    context.deduped_unshared = false;
-
-    status = pathnode_walk_node(path, cdb_is_path_deduped_walker, &context);
-
-    if (context.deduped_unshared)
-        bms_free(context.deduped_relids);
-
-    return status == CdbVisit_Success;
-}                               /* cdb_is_path_deduped */
-
-
-/*
- * cdb_subpath_tried_postjoin_dedup
- *
- * Returns true if the given Path has a subpath in which post-join duplicate
- * suppression can be assumed to have been considered already for exactly the
- * given set of subquery relids.
- */
-typedef struct CdbSubpathTriedPostjoinDedupCtx
-{
-    RelOptInfo     *given_rel;
-    Relids          subqrelids;
-} CdbSubpathTriedPostjoinDedupCtx;
-
-static CdbVisitOpt
-cdb_subpath_tried_postjoin_dedup_walker(Path *path, void* context)
-{
-    CdbSubpathTriedPostjoinDedupCtx *ctx = (CdbSubpathTriedPostjoinDedupCtx *)context;
-    RelOptInfo *rel = path->parent;
-
-    /* Descend thru parent_rel's Path nodes to top Path node of an input rel. */
-    if (rel == ctx->given_rel)
-        return CdbVisit_Walk;
-
-    /* If none of the given relids come from this input rel, advance to next. */
-    if (!bms_overlap(ctx->subqrelids, rel->relids))
-        return CdbVisit_Skip;
-
-    /* Succeed if rel is marked for post-join dedup of given subqueries. */
-    if (rel->dedup_info &&
-        rel->dedup_info->try_postjoin_dedup &&
-        bms_equal(rel->dedup_info->prejoin_dedup_subqrelids, ctx->subqrelids))
-        return CdbVisit_Success;
-
-    return CdbVisit_Failure;
-}                               /* cdb_subpath_tried_postjoin_dedup_walker */
-
-static bool
-cdb_subpath_tried_postjoin_dedup(Path *path, Relids subqrelids)
-{
-    CdbSubpathTriedPostjoinDedupCtx context;
-    CdbVisitOpt             status;
-
-    context.given_rel = path->parent;
-    context.subqrelids = subqrelids;
-
-    status = pathnode_walk_kids(path, cdb_subpath_tried_postjoin_dedup_walker, &context);
-
-    return (status == CdbVisit_Success);
-}                               /* cdb_subpath_tried_postjoin_dedup */
-
+	parent_rel->cheapest_unique_path = NULL;	/* computed only if needed */
+}
 
 /*
  * add_path
@@ -886,8 +475,6 @@ add_path(PlannerInfo *root, RelOptInfo *parent_rel, Path *new_path)
 	ListCell   *insert_after = NULL;	/* where to insert new item */
 	ListCell   *p1_prev = NULL;
 	ListCell   *p1;
-    List      **which_pathlist;
-    List       *pathlist;
 
 	/*
 	 * This is a convenient place to check for query cancel --- no part of the
@@ -900,57 +487,12 @@ add_path(PlannerInfo *root, RelOptInfo *parent_rel, Path *new_path)
 
     Assert(cdbpathlocus_is_valid(new_path->locus));
 
-   /*
-     * CDB: Can we limit the rel to 1 row without affecting the query result?
-     *
-     * If rel's targetlist is empty, then only the rel's row count affects
-     * downstream processing.  And if the rel consists only of subquery tables
-     * which have not been joined with tables of the current query level, then
-     * all that matters is whether the number of result rows is zero or nonzero.
-     * We'll insert LIMIT 1 on top of every path.
-     *
-     * This situation won't come up often.  Flattened uncorrelated EXISTS
-     * subqueries would be a typical example, if not for the fact that they
-     * are pulled out for separate optimization as InitPlans.
-     */
-    if (!parent_rel->reltargetlist &&
-        !parent_rel->onerow &&
-        !bms_overlap(parent_rel->relids, root->currlevel_relids))
-        new_path = (Path *)create_limit1_path(root, new_path);
-
-    /*
-     * CDB: Note whether duplicate suppression has been completed for all
-     * flattened subqueries whose tables are all present.
-     *
-     * Paths that await later addition of duplicate suppression are kept in a
-     * separate pathlist.
-     *
-     * NB: We set subq_complete false if all tables of a not-deduped subquery
-     * are present, even if the not-deduped subquery is joined with a deduped
-     * one.  The earlier deduping can't help the later one, except perhaps by
-     * reducing the number of rows; so don't bother to keep flags about it.
-     */
-    Assert(!new_path->subq_complete);
-    if (!parent_rel->dedup_info ||
-        cdb_is_path_deduped(new_path))
-    {
-        new_path->subq_complete = true;
-        which_pathlist = &parent_rel->pathlist;
-        pathlist = *which_pathlist;
-    }
-    else
-    {
-        new_path->subq_complete = false;
-        which_pathlist = &parent_rel->dedup_info->later_dedup_pathlist;
-        pathlist = *which_pathlist;
-    }
-
 	/*
 	 * Loop to check proposed new path against old paths.  Note it is possible
 	 * for more than one old path to be tossed out because new_path dominates
 	 * it.
 	 */
-	p1 = list_head(pathlist);		    /* cannot use foreach here */
+	p1 = list_head(parent_rel->pathlist);		/* cannot use foreach here */
 	while (p1 != NULL)
 	{
 		Path	   *old_path = (Path *) lfirst(p1);
@@ -1018,7 +560,8 @@ add_path(PlannerInfo *root, RelOptInfo *parent_rel, Path *new_path)
 		 */
 		if (remove_old)
 		{
-			pathlist = list_delete_cell(pathlist, p1, p1_prev);
+			parent_rel->pathlist = list_delete_cell(parent_rel->pathlist,
+													p1, p1_prev);
 
 			/*
 			 * Delete the data pointed-to by the deleted cell, if possible
@@ -1030,7 +573,7 @@ add_path(PlannerInfo *root, RelOptInfo *parent_rel, Path *new_path)
 			if (p1_prev)
 				p1 = lnext(p1_prev);
 			else
-				p1 = list_head(pathlist);
+				p1 = list_head(parent_rel->pathlist);
 		}
 		else
 		{
@@ -1055,9 +598,9 @@ add_path(PlannerInfo *root, RelOptInfo *parent_rel, Path *new_path)
 	{
 		/* Accept the new path: insert it at proper place in pathlist */
 		if (insert_after)
-			lappend_cell(pathlist, insert_after, new_path);
+			lappend_cell(parent_rel->pathlist, insert_after, new_path);
 		else
-			pathlist = lcons(new_path, pathlist);
+			parent_rel->pathlist = lcons(new_path, parent_rel->pathlist);
 	}
 	else
 	{
@@ -1065,10 +608,44 @@ add_path(PlannerInfo *root, RelOptInfo *parent_rel, Path *new_path)
 		if (!IsA(new_path, IndexPath))
 			pfree(new_path);
 	}
-
-    /* Put back the updated pathlist ptr. */
-    *which_pathlist = pathlist;
 }                               /* add_path */
+
+
+/*
+ * Wrapper around add_path(), for join paths.
+ *
+ * If the join was originally a semi-join, that's been implemented as an
+ * inner-join, followed by removing duplicates, adds the UniquePath on
+ * top of the join. Otherwise, just passes through the Path to add_path().
+ */
+void
+cdb_add_join_path(PlannerInfo *root, RelOptInfo *parent_rel, JoinType orig_jointype,
+				  JoinPath *new_path)
+{
+	Path	   *path = (Path *) new_path;
+
+	if (!new_path)
+		return;
+
+	if (orig_jointype == JOIN_DEDUP_SEMI)
+	{
+		Assert(new_path->jointype == JOIN_INNER);
+		path = (Path *) create_unique_rowid_path(root,
+												 parent_rel,
+												 (Path *) new_path,
+												 new_path->outerjoinpath->parent->relids);
+	}
+	else if (orig_jointype == JOIN_DEDUP_SEMI_REVERSE)
+	{
+		Assert(new_path->jointype == JOIN_INNER);
+		path = (Path *) create_unique_rowid_path(root,
+												 parent_rel,
+												 (Path *) new_path,
+												 new_path->innerjoinpath->parent->relids);
+	}
+
+	add_path(root, parent_rel, path);
+}
 
 
 /*****************************************************************************
@@ -1703,11 +1280,6 @@ create_material_path(PlannerInfo *root, RelOptInfo *rel, Path *subpath)
 }
 
 
-/* GPDB_84_MERGE_NOTE: Before commit e006a24a, this function used in_info_list
- * to compute in_operators and uniq_exprs. After this commit, this function used sjinfo instead.
- * But in GPDB, this function receives distinct_on_operators (in_operators) and distinct_on_exprs (uniq_exprs)
- * hence we don't need to make any changes here. */
-
 /*
  * create_unique_path
  *	  Creates a path representing elimination of distinct rows from the
@@ -1720,29 +1292,201 @@ create_material_path(PlannerInfo *root, RelOptInfo *rel, Path *subpath)
  * for the rel).  So we cache the result.
  */
 UniquePath *
-create_unique_path(PlannerInfo *root,
-                   Path        *subpath,
-                   List        *distinct_on_exprs,
-				   List		   *distinct_on_operators,
-                   Relids       distinct_on_rowid_relids)
+create_unique_path(PlannerInfo *root, RelOptInfo *rel, Path *subpath,
+				   SpecialJoinInfo *sjinfo)
 {
 	UniquePath *pathnode;
 	Path		sort_path;		/* dummy for result of cost_sort */
 	Path		agg_path;		/* dummy for result of cost_agg */
-    RelOptInfo *rel = subpath->parent;
+	MemoryContext oldcontext;
+	List	   *in_operators;
+	List	   *uniq_exprs;
+	bool		all_btree;
+	bool		all_hash;
 	int			numCols;
-    double      subpath_rows;
-    bool        hashable = false;
+	ListCell   *lc;
+	CdbPathLocus locus;
 
-    subpath_rows = cdbpath_rows(root, subpath);
+	/* Caller made a mistake if subpath isn't cheapest_total ... */
+	Assert(subpath == rel->cheapest_total_path);
+	/* ... or if SpecialJoinInfo is the wrong one */
+	Assert(sjinfo->jointype == JOIN_SEMI);
+	Assert(bms_equal(rel->relids, sjinfo->syn_righthand));
 
-    /* Allocate and partially initialize a UniquePath node. */
-    pathnode = make_unique_path(subpath);
+	/* If result already cached, return it */
+	if (rel->cheapest_unique_path)
+		return (UniquePath *) rel->cheapest_unique_path;
 
-    /* Share caller's expr list and operators, and relids. */
-    pathnode->distinct_on_exprs = distinct_on_exprs;
-	pathnode->distinct_on_eq_operators = distinct_on_operators;
-    pathnode->distinct_on_rowid_relids = distinct_on_rowid_relids;
+	/* If we previously failed, return NULL quickly */
+	if (sjinfo->join_quals == NIL)
+		return NULL;
+
+	/*
+	 * We must ensure path struct and subsidiary data are allocated in main
+	 * planning context; otherwise GEQO memory management causes trouble.
+	 * (Compare best_inner_indexscan().)
+	 */
+	oldcontext = MemoryContextSwitchTo(root->planner_cxt);
+
+	/*----------
+	 * Look to see whether the semijoin's join quals consist of AND'ed
+	 * equality operators, with (only) RHS variables on only one side of
+	 * each one.  If so, we can figure out how to enforce uniqueness for
+	 * the RHS.
+	 *
+	 * Note that the input join_quals list is the list of quals that are
+	 * *syntactically* associated with the semijoin, which in practice means
+	 * the synthesized comparison list for an IN or the WHERE of an EXISTS.
+	 * Particularly in the latter case, it might contain clauses that aren't
+	 * *semantically* associated with the join, but refer to just one side or
+	 * the other.  We can ignore such clauses here, as they will just drop
+	 * down to be processed within one side or the other.  (It is okay to
+	 * consider only the syntactically-associated clauses here because for a
+	 * semijoin, no higher-level quals could refer to the RHS, and so there
+	 * can be no other quals that are semantically associated with this join.
+	 * We do things this way because it is useful to be able to run this test
+	 * before we have extracted the list of quals that are actually
+	 * semantically associated with the particular join.)
+	 *
+	 * Note that the in_operators list consists of the joinqual operators
+	 * themselves (but commuted if needed to put the RHS value on the right).
+	 * These could be cross-type operators, in which case the operator
+	 * actually needed for uniqueness is a related single-type operator.
+	 * We assume here that that operator will be available from the btree
+	 * or hash opclass when the time comes ... if not, create_unique_plan()
+	 * will fail.
+	 *----------
+	 */
+	in_operators = NIL;
+	uniq_exprs = NIL;
+	all_btree = true;
+	all_hash = enable_hashagg;	/* don't consider hash if not enabled */
+	foreach(lc, sjinfo->join_quals)
+	{
+		OpExpr	   *op = (OpExpr *) lfirst(lc);
+		Oid			opno;
+		Node	   *left_expr;
+		Node	   *right_expr;
+		Relids		left_varnos;
+		Relids		right_varnos;
+		Relids		all_varnos;
+
+		/* Is it a binary opclause? */
+		if (!IsA(op, OpExpr) ||
+			list_length(op->args) != 2)
+		{
+			/* No, but does it reference both sides? */
+			all_varnos = pull_varnos((Node *) op);
+			if (!bms_overlap(all_varnos, sjinfo->syn_righthand) ||
+				bms_is_subset(all_varnos, sjinfo->syn_righthand))
+			{
+				/*
+				 * Clause refers to only one rel, so ignore it --- unless it
+				 * contains volatile functions, in which case we'd better
+				 * punt.
+				 */
+				if (contain_volatile_functions((Node *) op))
+					goto no_unique_path;
+				continue;
+			}
+			/* Non-operator clause referencing both sides, must punt */
+			goto no_unique_path;
+		}
+
+		/* Extract data from binary opclause */
+		opno = op->opno;
+		left_expr = linitial(op->args);
+		right_expr = lsecond(op->args);
+		left_varnos = pull_varnos(left_expr);
+		right_varnos = pull_varnos(right_expr);
+		all_varnos = bms_union(left_varnos, right_varnos);
+
+		/* Does it reference both sides? */
+		if (!bms_overlap(all_varnos, sjinfo->syn_righthand) ||
+			bms_is_subset(all_varnos, sjinfo->syn_righthand))
+		{
+			/*
+			 * Clause refers to only one rel, so ignore it --- unless it
+			 * contains volatile functions, in which case we'd better punt.
+			 */
+			if (contain_volatile_functions((Node *) op))
+				goto no_unique_path;
+			continue;
+		}
+
+		/* check rel membership of arguments */
+		if (!bms_is_empty(right_varnos) &&
+			bms_is_subset(right_varnos, sjinfo->syn_righthand) &&
+			!bms_overlap(left_varnos, sjinfo->syn_righthand))
+		{
+			/* typical case, right_expr is RHS variable */
+		}
+		else if (!bms_is_empty(left_varnos) &&
+				 bms_is_subset(left_varnos, sjinfo->syn_righthand) &&
+				 !bms_overlap(right_varnos, sjinfo->syn_righthand))
+		{
+			/* flipped case, left_expr is RHS variable */
+			opno = get_commutator(opno);
+			if (!OidIsValid(opno))
+				goto no_unique_path;
+			right_expr = left_expr;
+		}
+		else
+			goto no_unique_path;
+
+		/* all operators must be btree equality or hash equality */
+		if (all_btree)
+		{
+			/* oprcanmerge is considered a hint... */
+			if (!op_mergejoinable(opno) ||
+				get_mergejoin_opfamilies(opno) == NIL)
+				all_btree = false;
+		}
+		if (all_hash)
+		{
+			/* ... but oprcanhash had better be correct */
+			if (!op_hashjoinable(opno))
+				all_hash = false;
+		}
+		if (!(all_btree || all_hash))
+			goto no_unique_path;
+
+		/* so far so good, keep building lists */
+		in_operators = lappend_oid(in_operators, opno);
+		uniq_exprs = lappend(uniq_exprs, copyObject(right_expr));
+	}
+
+	/* Punt if we didn't find at least one column to unique-ify */
+	if (uniq_exprs == NIL)
+		goto no_unique_path;
+
+	/*
+	 * The expressions we'd need to unique-ify mustn't be volatile.
+	 */
+	if (contain_volatile_functions((Node *) uniq_exprs))
+		goto no_unique_path;
+
+    /* Repartition first if duplicates might be on different QEs. */
+    if (!CdbPathLocus_IsBottleneck(subpath->locus) &&
+		!cdbpathlocus_is_hashed_on_exprs(subpath->locus, uniq_exprs))
+	{
+		goto no_unique_path;
+        locus = cdbpathlocus_from_exprs(root, uniq_exprs);
+        subpath = cdbpath_create_motion_path(root, subpath, NIL, false, locus);
+        Insist(subpath);
+	}
+	else
+		locus = subpath->locus;
+
+	/*
+	 * If we get here, we can unique-ify using at least one of sorting and
+	 * hashing.  Start building the result Path object.
+	 */
+	pathnode = makeNode(UniquePath);
+
+	pathnode->path.pathtype = T_Unique;
+	pathnode->path.parent = rel;
+	pathnode->path.locus = locus;
 
 	/*
 	 * Treat the output as always unsorted, since we don't necessarily have
@@ -1750,58 +1494,72 @@ create_unique_path(PlannerInfo *root,
 	 */
 	pathnode->path.pathkeys = NIL;
 
+	pathnode->subpath = subpath;
+	pathnode->in_operators = in_operators;
+	pathnode->uniq_exprs = uniq_exprs;
+
 	/*
-	 * If we know the targetlist, try to estimate number of result rows;
-	 * otherwise punt.
+	 * If the input is a subquery whose output must be unique already, then we
+	 * don't need to do anything.  The test for uniqueness has to consider
+	 * exactly which columns we are extracting; for example "SELECT DISTINCT
+	 * x,y" doesn't guarantee that x alone is distinct. So we cannot check for
+	 * this optimization unless uniq_exprs consists only of simple Vars
+	 * referencing subquery outputs.  (Possibly we could do something with
+	 * expressions in the subquery outputs, too, but for now keep it simple.)
 	 */
-	if (distinct_on_exprs)
+	if (rel->rtekind == RTE_SUBQUERY)
 	{
-		pathnode->rows = estimate_num_groups(root, distinct_on_exprs, subpath_rows);
-		numCols = list_length(distinct_on_exprs);
+		RangeTblEntry *rte = planner_rt_fetch(rel->relid, root);
+		List	   *sub_tlist_colnos;
+
+		sub_tlist_colnos = translate_sub_tlist(uniq_exprs, rel->relid);
+
+		if (sub_tlist_colnos &&
+			query_is_distinct_for(rte->subquery,
+								  sub_tlist_colnos, in_operators))
+		{
+			pathnode->umethod = UNIQUE_PATH_NOOP;
+			pathnode->rows = rel->rows;
+			pathnode->path.startup_cost = subpath->startup_cost;
+			pathnode->path.total_cost = subpath->total_cost;
+			pathnode->path.pathkeys = subpath->pathkeys;
+
+			rel->cheapest_unique_path = (Path *) pathnode;
+
+			MemoryContextSwitchTo(oldcontext);
+
+			return pathnode;
+		}
 	}
-	else
+
+	/* Estimate number of output rows */
+	pathnode->rows = estimate_num_groups(root, uniq_exprs, rel->rows);
+	numCols = list_length(uniq_exprs);
+
+	// FIXME?
+    //subpath_rows = cdbpath_rows(root, subpath);
+
+	if (all_btree)
 	{
-		pathnode->rows = subpath_rows;
-		numCols = 1;
+		/*
+		 * Estimate cost for sort+unique implementation
+		 */
+		cost_sort(&sort_path, root, NIL,
+				  subpath->total_cost,
+				  rel->rows,
+				  rel->width,
+				  -1.0);
+
+		/*
+		 * Charge one cpu_operator_cost per comparison per input tuple. We
+		 * assume all columns get compared at most of the tuples. (XXX
+		 * probably this is an overestimate.)  This should agree with
+		 * make_unique.
+		 */
+		sort_path.total_cost += cpu_operator_cost * rel->rows * numCols;
 	}
 
-	/*
-	 * Estimate cost for sort+unique implementation
-	 */
-	cost_sort(&sort_path, root, NIL,
-			  subpath->total_cost,
-			  subpath_rows,
-			  rel->width,
-			  -1.0);
-
-	/*
-	 * Charge one cpu_operator_cost per comparison per input tuple. We assume
-	 * all columns get compared at most of the tuples.	(XXX probably this is
-	 * an overestimate.)  This should agree with make_unique.
-	 */
-	sort_path.total_cost += cpu_operator_cost * subpath_rows * numCols;
-
-	/*
-	 * Is it safe to use a hashed implementation?  If so, estimate and compare
-	 * costs.  We only try this if we know the targetlist for sure (else we
-	 * can't be sure about the datatypes involved).
-     *
-     * CDB: For dedup, the distinct_on_exprs list isn't built until later,
-     * but we know the data types will be hashable.
-	 */
-	pathnode->umethod = UNIQUE_PATH_SORT;
-	pathnode->path.startup_cost = sort_path.startup_cost;
-	pathnode->path.total_cost = sort_path.total_cost;
-
-    if (distinct_on_exprs && hash_safe_operators(distinct_on_operators))
-        hashable = true;
-    if (distinct_on_rowid_relids)
-        hashable = true;
-    if (hashable
-    		&& (root->config->enable_hashagg
-    				|| root->config->mpp_trying_fallback_plan
-    		)
-    )
+	if (all_hash)
 	{
 		/*
 		 * Estimate the overhead per hashtable entry at 64 bytes (same as in
@@ -1809,26 +1567,50 @@ create_unique_path(PlannerInfo *root,
 		 */
 		int			hashentrysize = rel->width + 64;
 
-        /*
-         * CDB TODO: Hybrid hashed aggregation is not limited by work_mem.
-         */
-        if (hashentrysize * pathnode->rows <= global_work_mem(root))
-		{
+		if (hashentrysize * pathnode->rows > work_mem * 1024L)
+			all_hash = false;	/* don't try to hash */
+		else
 			cost_agg(&agg_path, root,
 					 AGG_HASHED, 0,
 					 numCols, pathnode->rows,
 					 subpath->startup_cost,
 					 subpath->total_cost,
-					 rel->rows, 0.0, 0.0, hashentrysize, false);
-			if (agg_path.total_cost < sort_path.total_cost || 
-                (!root->config->enable_sort && !root->config->mpp_trying_fallback_plan))
-            {
-                pathnode->umethod = UNIQUE_PATH_HASH;
-		        pathnode->path.startup_cost = agg_path.startup_cost;
-		        pathnode->path.total_cost = agg_path.total_cost;
-            }
-		}
+					 rel->rows,
+					 0, /* input_width */
+					 0, /* hash_batches */
+					 0, /* hashentry_width */
+					 false /* streaming */
+				);
 	}
+
+	if (all_btree && all_hash)
+	{
+		if (agg_path.total_cost < sort_path.total_cost)
+			pathnode->umethod = UNIQUE_PATH_HASH;
+		else
+			pathnode->umethod = UNIQUE_PATH_SORT;
+	}
+	else if (all_btree)
+		pathnode->umethod = UNIQUE_PATH_SORT;
+	else if (all_hash)
+		pathnode->umethod = UNIQUE_PATH_HASH;
+	else
+		goto no_unique_path;
+
+	if (pathnode->umethod == UNIQUE_PATH_HASH)
+	{
+		pathnode->path.startup_cost = agg_path.startup_cost;
+		pathnode->path.total_cost = agg_path.total_cost;
+	}
+	else
+	{
+		pathnode->path.startup_cost = sort_path.startup_cost;
+		pathnode->path.total_cost = sort_path.total_cost;
+	}
+
+	rel->cheapest_unique_path = (Path *) pathnode;
+
+	MemoryContextSwitchTo(oldcontext);
 
 	/* see MPP-1140 */
 	if (pathnode->umethod == UNIQUE_PATH_HASH)
@@ -1854,99 +1636,77 @@ create_unique_path(PlannerInfo *root,
 	}
 
 	return pathnode;
-}                               /* create_unique_path */
 
+no_unique_path:			/* failure exit */
 
-/*
- * create_unique_exprlist_path
- *	  Creates a path representing elimination of distinct rows from the
- *	  input data.
- *
- * Returns a UniquePath node representing a "DISTINCT ON e1,...,en" operator,
- * where e1,...,en are the expressions in the 'distinct_on_exprs' list.
- *
- * NB: The returned node shares the 'distinct_on_exprs' list given by the
- * caller; the list and its members must not be changed or freed during the
- * node's lifetime.
- *
- * If a row's duplicates might occur in more than one partition, a Motion
- * operator will be needed to bring them together.  Since this path might
- * not be chosen, we won't take the time to create a CdbMotionPath node here.
- * Just estimate what the cost would be, and assign a dummy locus; leave
- * the real work for create_plan().
- */
-static UniquePath *
-create_unique_exprlist_path(PlannerInfo *root, Path *subpath,
-                            List *distinct_on_exprs,
-							List *distinct_on_operators)
-{
-	UniquePath *uniquepath;
-    RelOptInfo *rel = subpath->parent;
+	/* Mark the SpecialJoinInfo as not unique-able */
+	sjinfo->join_quals = NIL;
 
-    Assert(distinct_on_exprs);
-    Assert(distinct_on_operators);
+	MemoryContextSwitchTo(oldcontext);
 
-	/*
-	 * If the input is a subquery whose output must be unique already, then we
-	 * don't need to do anything.  The test for uniqueness has to consider
-	 * exactly which columns we are extracting; for example "SELECT DISTINCT
-	 * x,y" doesn't guarantee that x alone is distinct. So we cannot check for
-	 * this optimization unless we found our own targetlist above, and it
-	 * consists only of simple Vars referencing subquery outputs.  (Possibly
-	 * we could do something with expressions in the subquery outputs, too,
-	 * but for now keep it simple.)
-	 */
-	if (rel->rtekind == RTE_SUBQUERY)
-	{
-		RangeTblEntry *rte = planner_rt_fetch(rel->relid, root);
-		List	   *sub_tlist_colnos;
-
-		sub_tlist_colnos = translate_sub_tlist(distinct_on_exprs, rel->relid);
-
-		if (sub_tlist_colnos &&
-			query_is_distinct_for(rte->subquery, sub_tlist_colnos, distinct_on_operators))
-		{
-            uniquepath = make_unique_path(subpath);
-			uniquepath->umethod = UNIQUE_PATH_NOOP;
-			uniquepath->rows = cdbpath_rows(root, subpath);
-            uniquepath->distinct_on_exprs = distinct_on_exprs;  /* share list */
-			uniquepath->distinct_on_eq_operators = distinct_on_operators;
-			return uniquepath;
-		}
-	}
-
-    /* Repartition first if duplicates might be on different QEs. */
-    if (!CdbPathLocus_IsBottleneck(subpath->locus) &&
-        !cdbpathlocus_is_hashed_on_exprs(subpath->locus, distinct_on_exprs))
-    {
-        CdbPathLocus    locus;
-
-        locus = cdbpathlocus_from_exprs(root, distinct_on_exprs);
-        subpath = cdbpath_create_motion_path(root, subpath, NIL, false, locus);
-        Insist(subpath);
-    }
-
-    /* Create the UniquePath node.  (Might return NULL if enable_sort = off.) */
-    uniquepath = create_unique_path(root, subpath,
-									distinct_on_exprs, distinct_on_operators,
-									NULL);
-
-	return uniquepath;
-}                               /* create_unique_exprlist_path */
-
+	return NULL;
+}
 
 /*
- * create_unique_rowid_path
+ * create_unique_rowid_path (GPDB)
  *
- * CDB: Used when a subquery predicate (such as "x IN (SELECT ...)") has
- * been flattened into a join with the tables of the current query.  A row
- * of the cross-product of the current query's tables might join with more
- * than one row from the subquery and thus be duplicated.  Removing such
- * duplicates after the join is called deduping.
+ * Create a UniquePath to deduplicate based on the ctid and gp_segment_id,
+ * or some other columns that uniquely identify a row. This is used as part
+ * of implementing semi-joins (such as "x IN (SELECT ...)").
  *
- * Returns a UniquePath node representing a "DISTINCT ON r1,...,rn" operator,
- * where (r1,...,rn) represents a unique identifier for each row of the cross
- * product of the tables specified by the 'distinct_relids' parameter.
+ * In PostgreSQL, semi-joins are implemented with JOIN_SEMI join types, or
+ * by first eliminating duplicates from the inner side, and then performing
+ * normal inner join (that's JOIN_UNIQUE_OUTER and JOIN_UNIQUE_INNER). GPDB
+ * has a third way to implement them: Perform an inner join first, and then
+ * eliminate duplicates from the result. The JOIN_DEDUP_SEMI and
+ * JOIN_DEDUP_SEMI_REVERSE join types indicate such plans.
+ *
+ * The JOIN_DEDUP_SEMI plan will look something like this:
+ *
+ * postgres=# explain select * from s where exists (select 1 from r where s.a = r.b);
+ *                                                       QUERY PLAN                                                      
+ * ----------------------------------------------------------------------------------------------------------------------
+ *  Gather Motion 3:1  (slice3; segments: 3)  (cost=189.75..190.75 rows=100 width=18)
+ *    ->  HashAggregate  (cost=189.75..190.75 rows=34 width=18)
+ *          Group By: s.ctid::bigint, s.gp_segment_id
+ *          ->  Result  (cost=11.75..189.25 rows=34 width=18)
+ *                ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=11.75..189.25 rows=34 width=18)
+ *                      Hash Key: s.ctid
+ *                      ->  Hash Join  (cost=11.75..187.25 rows=34 width=18)
+ *                            Hash Cond: r.b = s.a
+ *                            ->  Seq Scan on r  (cost=0.00..112.00 rows=3334 width=4)
+ *                            ->  Hash  (cost=8.00..8.00 rows=100 width=18)
+ *                                  ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..8.00 rows=100 width=18)
+ *                                        ->  Seq Scan on s  (cost=0.00..4.00 rows=34 width=18)
+ *  Settings:  optimizer=off
+ *  Optimizer status: legacy query optimizer
+ * (14 rows)
+ *
+ *
+ * In PostgreSQL, this is never better than doing a JOIN_SEMI directly.
+ * But it can be a win in GPDB, if the distribution of the outer and inner
+ * relations don't match, and the outer relation is much larger than the
+ * inner relation. In the above example, a normal semi-join would have to
+ * have 's' on the outer side, and 'r' on the inner side. A hash semi-join
+ * can't be performed the other way 'round, because the duplicate
+ * elimination in a semi-join is done when building the hash table.
+ * Furthermore, you can't have a Broadcast motion on the outer side of
+ * a semi-join, because that could also generate duplicates. That leaves
+ * the planner no choice, but to redistribute the larger 'r' relation,
+ * in a JOIN_SEMI plan.
+ *
+ * So in GPDB, we try to implement semi-joins as a inner joins, followed
+ * by an explicit UniquePath to eliminate the duplicates. That allows the
+ * above plan, where the smaller 's' relation is Broadcast to all the
+ * segments, and the duplicates that can arise from doing that are eliminated
+ * above the join. You get one more Motion than with a JOIN_SEMI plan, but
+ * each Motion has to move much fewer rows.
+ *
+ * The role of this function is to insert the UniquePath to represent
+ * the deduplication above the join. Returns a UniquePath node representing
+ * a "DISTINCT ON r1,...,rn" operator, where (r1,...,rn) represents a unique
+ * identifier for each row of the cross product of the tables specified by
+ * the 'distinct_relids' parameter.
  *
  * NB: The returned node shares the given 'distinct_relids' bitmapset object;
  * so the caller must not free or modify it during the node's lifetime.
@@ -1957,19 +1717,135 @@ create_unique_exprlist_path(PlannerInfo *root, Path *subpath,
  * Just estimate what the cost would be, and assign a dummy locus; leave
  * the real work for create_plan().
  */
-static UniquePath *
+UniquePath *
 create_unique_rowid_path(PlannerInfo *root,
+						 RelOptInfo *rel,
                          Path        *subpath,
                          Relids       distinct_relids)
 {
-	UniquePath *uniquepath;
+	UniquePath *pathnode;
+	CdbPathLocus locus;
+	Path		sort_path;		/* dummy for result of cost_sort */
+	Path		agg_path;		/* dummy for result of cost_agg */
+	int			numCols;
+	bool		all_btree;
+	bool		all_hash;
 
     Assert(!bms_is_empty(distinct_relids));
 
-    /* Create the UniquePath node.  (Might return NULL if enable_sort = off.) */
-    uniquepath = create_unique_path(root, subpath, NIL, NIL, distinct_relids);
-    if (!uniquepath)
-        return NULL;
+	/*
+	 * For easier merging (albeit it's going to manual), keep this function
+	 * similar to create_unique_path(). In this function, we deduplicate based
+	 * on ctid and gp_segment_id, or other unique identifiers that we generate
+	 * on the fly. Sorting and hashing are both possible, but we keep these
+	 * as variables to resemble create_unique_path().
+	 */
+	all_btree = true;
+	all_hash = true;
+
+	locus = subpath->locus;
+
+	/*
+	 * Start building the result Path object.
+	 */
+	pathnode = makeNode(UniquePath);
+
+	pathnode->path.pathtype = T_Unique;
+	pathnode->path.parent = rel;
+	pathnode->path.locus = locus;
+
+	/*
+	 * Treat the output as always unsorted, since we don't necessarily have
+	 * pathkeys to represent it.
+	 */
+	pathnode->path.pathkeys = NIL;
+
+	pathnode->subpath = subpath;
+	pathnode->in_operators = NIL;
+	pathnode->uniq_exprs = NIL;
+	pathnode->distinct_on_rowid_relids = distinct_relids;
+
+	/*
+	 * For cost estimation purposes, assume we'll deduplicate based on ctid and
+	 * gp_segment_id. If the outer side of the join is a join relation itself,
+	 * we'll need to deduplicate based on gp_segment_id and ctid of all the
+	 * involved base tables, or other identifiers. See cdbpath_dedup_fixup()
+	 * for the details, but here, for cost estimation purposes, just assume
+	 * it's going to be two columns.
+	 */
+	numCols	= 2;
+	pathnode->rows = rel->rows;
+
+	if (all_btree)
+	{
+		/*
+		 * Estimate cost for sort+unique implementation
+		 */
+		cost_sort(&sort_path, root, NIL,
+				  subpath->total_cost,
+				  rel->rows,
+				  rel->width,
+				  -1.0);
+
+		/*
+		 * Charge one cpu_operator_cost per comparison per input tuple. We
+		 * assume all columns get compared at most of the tuples. (XXX
+		 * probably this is an overestimate.)  This should agree with
+		 * make_unique.
+		 */
+		sort_path.total_cost += cpu_operator_cost * rel->rows * numCols;
+	}
+
+	if (all_hash)
+	{
+		/*
+		 * Estimate the overhead per hashtable entry at 64 bytes (same as in
+		 * planner.c).
+		 */
+		int			hashentrysize = rel->width + 64;
+
+		if (hashentrysize * pathnode->rows > work_mem * 1024L)
+			all_hash = false;	/* don't try to hash */
+		else
+			cost_agg(&agg_path, root,
+					 AGG_HASHED, 0,
+					 numCols, pathnode->rows,
+					 subpath->startup_cost,
+					 subpath->total_cost,
+					 rel->rows,
+					 0, /* input_width */
+					 0, /* hash_batches */
+					 0, /* hashentry_width */
+					 false /* streaming */
+				);
+	}
+
+	if (all_btree && all_hash)
+	{
+		if (agg_path.total_cost < sort_path.total_cost)
+			pathnode->umethod = UNIQUE_PATH_HASH;
+		else
+			pathnode->umethod = UNIQUE_PATH_SORT;
+	}
+	else if (all_btree)
+		pathnode->umethod = UNIQUE_PATH_SORT;
+	else if (all_hash)
+		pathnode->umethod = UNIQUE_PATH_HASH;
+	else
+	{
+		Assert(false);
+	}
+
+	if (pathnode->umethod == UNIQUE_PATH_HASH)
+	{
+		pathnode->path.startup_cost = agg_path.startup_cost;
+		pathnode->path.total_cost = agg_path.total_cost;
+	}
+	else
+	{
+		pathnode->path.startup_cost = sort_path.startup_cost;
+		pathnode->path.total_cost = sort_path.total_cost;
+	}
 
     /* Add repartitioning cost if duplicates might be on different QEs. */
     if (!CdbPathLocus_IsBottleneck(subpath->locus) &&
@@ -1979,121 +1855,50 @@ create_unique_rowid_path(PlannerInfo *root,
         Cost            repartition_cost;
 
         /* Tell create_unique_plan() to insert Motion operator atop subpath. */
-        uniquepath->must_repartition = true;
+        pathnode->must_repartition = true;
 
         /* Set a fake locus.  Repartitioning key won't be built until later. */
-        CdbPathLocus_MakeStrewn(&uniquepath->path.locus);
-		uniquepath->path.sameslice_relids = NULL;
+        CdbPathLocus_MakeStrewn(&pathnode->path.locus);
+		pathnode->path.sameslice_relids = NULL;
 
         /* Estimate repartitioning cost. */
         memset(&motionpath, 0, sizeof(motionpath));
         motionpath.path.type = T_CdbMotionPath;
         motionpath.path.parent = subpath->parent;
-        motionpath.path.locus = uniquepath->path.locus;
+        motionpath.path.locus = pathnode->path.locus;
         motionpath.subpath = subpath;
         cdbpath_cost_motion(root, &motionpath);
 
         /* Add MotionPath cost to UniquePath cost. */
         repartition_cost = motionpath.path.total_cost - subpath->total_cost;
-        uniquepath->path.total_cost += repartition_cost;
+        pathnode->path.total_cost += repartition_cost;
     }
 
-	return uniquepath;
+	/* see MPP-1140 */
+	if (pathnode->umethod == UNIQUE_PATH_HASH)
+	{
+		/* hybrid hash agg is not rescannable, and may present a motion hazard */
+		pathnode->path.motionHazard = subpath->motionHazard;
+		pathnode->path.rescannable = false;
+	}
+	else
+	{
+		/* sort or plain implies materialization and breaks deadlock cycle.
+		 *  (NB: Must not reset motionHazard when sort is eliminated due to
+		 *  existing ordering; but Unique sort is never optimized away at present.)
+		 */
+		pathnode->path.motionHazard = subpath->motionHazard;
+
+		/* Same reasoning applies to rescanablilty.  If no actual sort is placed
+		 * in the plan, then rescannable is set correctly to the subpath value.
+		 * If sort intervenes, it should be set to true.  We depend
+		 * on the above claim that sort will always intervene.
+		 */
+		pathnode->path.rescannable = true;
+	}
+
+	return pathnode;
 }                               /* create_unique_rowid_path */
-
-
-/*
- * create_limit1_path
- *
- * CDB: Add operators on top of the path to ensure uniqueness by
- * discarding all but the first row of the given subpath's result.
- *
- * If a row's duplicates might occur in more than one partition, a Motion
- * operator will be inserted to bring them together.
- */
-UniquePath *
-create_limit1_path(PlannerInfo *root, Path *subpath)
-{
-    UniquePath     *uniquepath;
-    CdbPathLocus    singleQE;
-
-    /* Add LIMIT 1 operator. */
-    uniquepath = make_limit1_path(subpath);
-
-    /* Add Motion operator to gather to a single qExec, then LIMIT 1 again. */
-    if (CdbPathLocus_IsPartitioned(subpath->locus))
-    {
-        CdbPathLocus_MakeSingleQE(&singleQE);
-        subpath = cdbpath_create_motion_path(root, (Path *)uniquepath, NIL,
-                                             false, singleQE);
-
-        /* Add another LIMIT 1 on top. */
-        uniquepath = make_limit1_path(subpath);
-
-		uniquepath->path.motionHazard = subpath->motionHazard;
-    }
-	return uniquepath;
-}                               /* create_limit1_path */
-
-
-/*
- * make_limit1_path
- *
- * CDB: Returns a UniquePath which ensures uniqueness by producing at most
- * one row of the given subpath's result.
- */
-UniquePath *
-make_limit1_path(Path *subpath)
-{
-    UniquePath *uniquepath = make_unique_path(subpath);
-
-    uniquepath->umethod = UNIQUE_PATH_LIMIT1;
-    uniquepath->rows = 1;
-
-    /* Cost to get a single row is same as startup cost (from subpath). */
-    uniquepath->path.total_cost = uniquepath->path.startup_cost;
-
-    return uniquepath;
-}                               /* make_limit1_path */
-
-
-/*
- * make_unique_path
- *    Allocates and partially initializes a UniquePath node to be completed
- *    by the caller.
- */
-UniquePath *
-make_unique_path(Path *subpath)
-{
-	UniquePath     *pathnode;
-    MemoryContext   oldcontext;
-
-	/* Allocate in same context as parent rel in case GEQO is ever used. */
-	oldcontext = MemoryContextSwitchTo(GetMemoryChunkContext(subpath->parent));
-
-    /* Allocate the UniquePath node. */
-	pathnode = makeNode(UniquePath);
-
-    /* Copy Path header from subpath. */
-    pathnode->path = *subpath;
-
-    /* Fix up the Path header. */
-    pathnode->path.type = T_UniquePath;
-    pathnode->path.pathtype = T_Unique;
-
-    /* Initialize added UniquePath fields. */
-    pathnode->subpath = subpath;
-    pathnode->distinct_on_exprs = NIL;
-    pathnode->distinct_on_eq_operators = NIL;
-    pathnode->distinct_on_rowid_relids = NULL;
-    pathnode->must_repartition = false;
-
-	/* Restore caller's allocation context. */
-	MemoryContextSwitchTo(oldcontext);
-
-    return pathnode;
-}                               /* make_unique_path */
-
 
 /*
  * translate_sub_tlist - get subquery column numbers represented by tlist
@@ -2284,31 +2089,6 @@ distinct_col_search(int colno, List *colnos, List *opids)
 			return lfirst_oid(lc2);
 	}
 	return InvalidOid;
-}
-
-/*
- * hash_safe_operators - can all the specified IN operators be hashed?
- *
- * We assume hashed aggregation will work if each IN operator is marked
- * hashjoinable.  If the IN operators are cross-type, this could conceivably
- * fail: the aggregation will need a hashable equality operator for the RHS
- * datatype --- but it's pretty hard to conceive of a hash opfamily that has
- * cross-type hashing without support for hashing the individual types, so
- * we don't expend cycles here to support the case.  We could check
- * get_compatible_hash_operator() instead of just op_hashjoinable(), but the
- * former is a significantly more expensive test.
- */
-static bool
-hash_safe_operators(List *opids)
-{
-	ListCell   *lc;
-
-	foreach(lc, opids)
-	{
-		if (!op_hashjoinable(lfirst_oid(lc)))
-			return false;
-	}
-	return true;
 }
 
 /*
@@ -2549,31 +2329,6 @@ create_worktablescan_path(PlannerInfo *root, RelOptInfo *rel, CdbLocusType ctelo
 	return pathnode;
 }
 
-/*
- * cdb_jointype_to_join_in
- *    Returns JOIN_SEMI if the jointype should be changed from JOIN_INNER to
- *    JOIN_SEMI so as to produce at most one matching inner row per outer row.
- *    Else returns the given jointype.
- *
- * CDB TODO: Allow outer joins to use the JOIN_SEMI technique.
- * CDB TODO: Occasionally, symmetric JOIN_SEMI might be useful (aka 'match join').
- */
-static inline JoinType
-cdb_jointype_to_join_semi(RelOptInfo *joinrel, JoinType jointype, Path *inner_path)
-{
-    CdbRelDedupInfo    *dedup = joinrel->dedup_info;
-
-    if (dedup &&
-        dedup->spent_subqrelids &&
-        bms_is_subset(inner_path->parent->relids, dedup->spent_subqrelids) &&
-        !IsA(inner_path, UniquePath) &&
-        jointype == JOIN_INNER)
-    {
-        jointype = JOIN_SEMI;
-    }
-    return jointype;
-}                               /* cdb_jointype_to_join_semi */
-
 bool
 path_contains_inner_index(Path *path)
 {
@@ -2635,13 +2390,6 @@ create_nestloop_path(PlannerInfo *root,
 	NestPath       *pathnode;
     CdbPathLocus    join_locus;
     bool            inner_must_be_local = false;
-
-    /* CDB: Change jointype to JOIN_SEMI from JOIN_INNER (if eligible). */
-    if (joinrel->dedup_info)
-    {
-        jointype = cdb_jointype_to_join_semi(joinrel, jointype, inner_path);
-        sjinfo->jointype = jointype;
-    }
 
     /* CDB: Inner indexpath must execute in the same backend as the
      * nested join to receive input values from the outer rel.
@@ -2755,13 +2503,6 @@ create_mergejoin_path(PlannerInfo *root,
     CdbPathLocus    join_locus;
     List           *outermotionkeys;
     List           *innermotionkeys;
-
-    /* CDB: Change jointype to JOIN_SEMI from JOIN_INNER (if eligible). */
-    if (joinrel->dedup_info)
-    {
-        jointype = cdb_jointype_to_join_semi(joinrel, jointype, inner_path);
-        sjinfo->jointype = jointype;
-    }
 
     /*
      * Do subpaths have useful ordering?
@@ -2923,13 +2664,6 @@ create_hashjoin_path(PlannerInfo *root,
 	HashPath       *pathnode;
 	CdbPathLocus    join_locus;
 
-	/* CDB: Change jointype to JOIN_SEMI from JOIN_INNER (if eligible). */
-	if (joinrel->dedup_info)
-	{
-		jointype = cdb_jointype_to_join_semi(joinrel, jointype, inner_path);
-		sjinfo->jointype = jointype;
-	}
-
 	/* Add motion nodes above subpaths and decide where to join. */
 	join_locus = cdbpath_motion_for_join(root,
 										 jointype,
@@ -2942,6 +2676,30 @@ create_hashjoin_path(PlannerInfo *root,
 										 false);
 	if (CdbPathLocus_IsNull(join_locus))
 		return NULL;
+
+	/*
+	 * CDB: If gp_enable_hashjoin_size_heuristic is set, disallow inner
+	 * joins where the inner rel is the larger of the two inputs.
+	 *
+	 * Note cdbpath_motion_for_join() has to precede this so we can get
+	 * the right row count, in case Broadcast Motion is inserted above an
+	 * input path.
+	 */
+	if (jointype == JOIN_INNER &&
+		root->config->gp_enable_hashjoin_size_heuristic &&
+		!root->config->mpp_trying_fallback_plan)
+	{
+		double		outersize;
+		double		innersize;
+
+		outersize = ExecHashRowSize(outer_path->parent->width) *
+			cdbpath_rows(root, outer_path);
+		innersize = ExecHashRowSize(inner_path->parent->width) *
+			cdbpath_rows(root, inner_path);
+
+		if (innersize > outersize)
+			return NULL;
+	}
 
 	pathnode = makeNode(HashPath);
 

--- a/src/include/nodes/nodes.h
+++ b/src/include/nodes/nodes.h
@@ -320,7 +320,6 @@ typedef enum NodeTag
 
     /* Tags for MPP planner nodes (relation.h) */
     T_CdbMotionPath = 580,
-    T_CdbRelDedupInfo,
     T_CdbRelColumnInfo,
 
 	/*
@@ -698,25 +697,31 @@ typedef enum JoinType
 	 * support these codes.  NOTE: in JOIN_SEMI output, it is unspecified
 	 * which matching RHS row is joined to.  In JOIN_ANTI output, the row is
 	 * guaranteed to be null-extended.
-     *
-     * CDB: We no longer use JOIN_REVERSE_IN, JOIN_UNIQUE_OUTER or
-     * JOIN_UNIQUE_INNER.  The definitions are retained in case they
-     * might be referenced in the source code of user-defined
-     * selectivity functions brought over from PostgreSQL.
 	 */
 	JOIN_SEMI,					/* 1 copy of each LHS row that has match(es) */
 	JOIN_ANTI,					/* 1 copy of each LHS row that has no match */
 	JOIN_LASJ_NOTIN,			/* Left Anti Semi Join with Not-In semantics:
 									If any NULL values are produced by inner side,
 									return no join results. Otherwise, same as LASJ */
-	JOIN_REVERSE_IN,			/* at most one result per inner row */
 
 	/*
 	 * These codes are used internally in the planner, but are not supported
 	 * by the executor (nor, indeed, by most of the planner).
 	 */
 	JOIN_UNIQUE_OUTER,			/* LHS path must be made unique */
-	JOIN_UNIQUE_INNER			/* RHS path must be made unique */
+	JOIN_UNIQUE_INNER,			/* RHS path must be made unique */
+
+	/*
+	 * GDPB: Like JOIN_UNIQUE_OUTER/INNER, these codes are used internally
+	 * in the planner, but are not supported by the executor or by most of the
+	 * planner. A JOIN_DEDUP_SEMI join indicates a semi-join, but to be
+	 * implemented by performing a normal inner join, and eliminating the
+	 * duplicates with a UniquePath above the join. That can be useful in
+	 * an MPP enviroment, if performing the join as an inner join avoids
+	 * moving the larger of the two relations.
+	 */
+	JOIN_DEDUP_SEMI,			/* inner join, LHS path must be made unique afterwards */
+	JOIN_DEDUP_SEMI_REVERSE		/* inner join, RHS path must be made unique afterwards */
 
 	/*
 	 * We might need additional join types someday.

--- a/src/include/optimizer/pathnode.h
+++ b/src/include/optimizer/pathnode.h
@@ -34,6 +34,7 @@ extern int compare_fractional_path_costs(Path *path1, Path *path2,
 							  double fraction);
 extern void set_cheapest(PlannerInfo *root, RelOptInfo *parent_rel);    /*CDB*/
 extern void add_path(PlannerInfo *root, RelOptInfo *parent_rel, Path *new_path);
+extern void cdb_add_join_path(PlannerInfo *root, RelOptInfo *parent_rel, JoinType orig_jointype, JoinPath *new_path);
 
 extern Path *create_seqscan_path(PlannerInfo *root, RelOptInfo *rel);
 extern ExternalPath *create_external_path(PlannerInfo *root, RelOptInfo *rel);
@@ -69,11 +70,12 @@ extern TidPath *create_tidscan_path(PlannerInfo *root, RelOptInfo *rel,
 extern AppendPath *create_append_path(PlannerInfo *root, RelOptInfo *rel, List *subpaths);
 extern ResultPath *create_result_path(List *quals);
 extern MaterialPath *create_material_path(PlannerInfo *root, RelOptInfo *rel, Path *subpath);
-extern UniquePath *create_unique_path(PlannerInfo *root,
-		Path        *subpath,
-		List        *distinct_on_exprs,
-		List		   *distinct_on_operators,
-		Relids       distinct_on_rowid_relids);
+extern UniquePath *create_unique_path(PlannerInfo *root, RelOptInfo *rel,
+				   Path *subpath, SpecialJoinInfo *sjinfo);
+extern UniquePath *create_unique_rowid_path(PlannerInfo *root,
+						 RelOptInfo *rel,
+                         Path        *subpath,
+                         Relids       distinct_relids);
 extern Path *create_subqueryscan_path(PlannerInfo *root, RelOptInfo *rel, List *pathkeys);
 extern Path *create_functionscan_path(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte);
 extern Path *create_tablefunction_path(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte);
@@ -141,7 +143,5 @@ extern Var *cdb_define_pseudo_column(PlannerInfo   *root,
 extern CdbRelColumnInfo *cdb_find_pseudo_column(PlannerInfo *root, Var *var);
 
 extern CdbRelColumnInfo *cdb_rte_find_pseudo_column(RangeTblEntry *rte, AttrNumber attno);
-
-extern CdbRelDedupInfo *cdb_make_rel_dedup_info(PlannerInfo *root, RelOptInfo *rel);
 
 #endif   /* PATHNODE_H */

--- a/src/test/regress/expected/dpe.out
+++ b/src/test/regress/expected/dpe.out
@@ -286,15 +286,11 @@ select * from t, pt where t1 = pt1 and ptid = tid;
 --
 -- in and exists clauses
 --
--- start_ignore
--- GPDB_84_MERGE_FIXME: merging upstream commit 8dcf18414 made this plan more
--- complicated; make sure it's an okay change.
--- end_ignore
 explain select * from pt where ptid in (select tid from t where t1 = 'hello' || tid);
-                                                      QUERY PLAN                                                       
------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=1.10..20.39 rows=54 width=31)
-   ->  Hash Join  (cost=1.10..20.39 rows=18 width=31)
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=1.09..20.45 rows=54 width=31)
+   ->  Hash Semi Join  (cost=1.09..20.45 rows=18 width=31)
          Hash Cond: dpe_single.pt.ptid = t.tid
          ->  Append  (cost=0.00..18.54 rows=18 width=31)
                ->  Result  (cost=0.00..3.09 rows=3 width=31)
@@ -315,19 +311,15 @@ explain select * from pt where ptid in (select tid from t where t1 = 'hello' || 
                ->  Result  (cost=0.00..3.09 rows=3 width=31)
                      One-Time Filter: PartSelected
                      ->  Seq Scan on pt_1_prt_6 pt  (cost=0.00..3.09 rows=3 width=31)
-         ->  Hash  (cost=1.09..1.09 rows=1 width=11)
-               ->  Partition Selector for pt (dynamic scan id: 1)  (cost=1.06..1.09 rows=1 width=11)
+         ->  Hash  (cost=1.07..1.07 rows=1 width=11)
+               ->  Partition Selector for pt (dynamic scan id: 1)  (cost=0.00..1.07 rows=1 width=11)
                      Filter: t.tid
-                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=1.06..1.09 rows=1 width=11)
-                           ->  HashAggregate  (cost=1.06..1.07 rows=1 width=36)
-                                 Group By: t.tid
-                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.06 rows=1 width=11)
-                                       Hash Key: t.tid
-                                       ->  Seq Scan on t  (cost=0.00..1.04 rows=1 width=11)
-                                             Filter: t1 = ('hello'::text || tid::text)
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.07 rows=1 width=11)
+                           ->  Seq Scan on t  (cost=0.00..1.04 rows=1 width=11)
+                                 Filter: t1 = ('hello'::text || tid::text)
  Settings:  gp_segments_for_planner=2; optimizer=off; optimizer_segments=2
  Optimizer status: legacy query optimizer
-(34 rows)
+(30 rows)
 
 select * from pt where ptid in (select tid from t where t1 = 'hello' || tid);
  dist |   pt1   |  pt2  |    pt3    | ptid 

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -559,47 +559,44 @@ select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j
 (10 rows)
 
 explain select A.i, B.i, C.j from A, B, C where A.j = any ( select C.j from C where not exists(select C.i from C,A where C.i = A.i and C.i =10)) order by A.i, B.i, C.j limit 10;
-                                                                     QUERY PLAN                                                                     
-----------------------------------------------------------------------------------------------------------------------------------------------------
- Limit  (cost=43.24..43.47 rows=10 width=12)
-   InitPlan 1 (returns $0)  (slice7)
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=37.98..38.21 rows=10 width=12)
+   InitPlan 1 (returns $0)  (slice6)
      ->  Limit  (cost=0.00..1.88 rows=1 width=0)
-           ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1.88 rows=1 width=0)
+           ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1.88 rows=1 width=0)
                  ->  Limit  (cost=0.00..1.86 rows=1 width=0)
                        ->  Nested Loop  (cost=0.00..6.18 rows=2 width=0)
                              ->  Seq Scan on c  (cost=0.00..3.11 rows=1 width=4)
                                    Filter: i = 10
                              ->  Seq Scan on a  (cost=0.00..3.06 rows=1 width=4)
                                    Filter: qp_correlated_query.a.i = 10
-   ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=41.38..41.61 rows=10 width=12)
+   ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=36.10..36.33 rows=10 width=12)
          Merge Key: qp_correlated_query.a.i, b.i, qp_correlated_query.c.j
-         ->  Limit  (cost=41.38..41.41 rows=4 width=12)
-               ->  Sort  (cost=41.38..42.17 rows=106 width=12)
+         ->  Limit  (cost=36.10..36.13 rows=4 width=12)
+               ->  Sort  (cost=36.10..36.78 rows=90 width=12)
                      Sort Key: qp_correlated_query.a.i, b.i, qp_correlated_query.c.j
-                     ->  Result  (cost=9.99..34.55 rows=106 width=12)
+                     ->  Result  (cost=10.62..30.27 rows=90 width=12)
                            One-Time Filter: NOT $0
-                           ->  Nested Loop  (cost=9.99..34.55 rows=106 width=12)
-                                 ->  Nested Loop  (cost=6.52..12.09 rows=12 width=8)
-                                       ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=3.45..6.92 rows=6 width=4)
-                                             ->  Hash Join  (cost=3.45..6.68 rows=2 width=4)
-                                                   Hash Cond: qp_correlated_query.a.j = qp_correlated_query.c.j
-                                                   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.15 rows=2 width=8)
-                                                         Hash Key: qp_correlated_query.a.j
-                                                         ->  Seq Scan on a  (cost=0.00..3.05 rows=2 width=8)
-                                                   ->  Hash  (cost=3.36..3.36 rows=3 width=4)
-                                                         ->  HashAggregate  (cost=3.29..3.36 rows=3 width=4)
-                                                               Group By: qp_correlated_query.c.j
-                                                               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..3.27 rows=3 width=4)
-                                                                     Hash Key: qp_correlated_query.c.j
+                           ->  Nested Loop  (cost=10.62..30.27 rows=90 width=12)
+                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.45 rows=9 width=4)
+                                       ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
+                                 ->  Materialize  (cost=10.62..10.92 rows=10 width=8)
+                                       ->  Nested Loop  (cost=9.84..10.59 rows=10 width=8)
+                                             ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=6.77..6.92 rows=2 width=10)
+                                                   ->  HashAggregate  (cost=6.76..6.81 rows=2 width=10)
+                                                         Group By: qp_correlated_query.a.ctid::bigint
+                                                         ->  Hash Join  (cost=3.11..6.75 rows=2 width=10)
+                                                               Hash Cond: qp_correlated_query.c.j = qp_correlated_query.a.j
+                                                               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..3.45 rows=9 width=4)
                                                                      ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
-                                       ->  Materialize  (cost=3.07..3.13 rows=2 width=4)
-                                             ->  Seq Scan on b  (cost=0.00..3.06 rows=2 width=4)
-                                 ->  Materialize  (cost=3.48..3.75 rows=9 width=4)
-                                       ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..3.45 rows=9 width=4)
-                                             ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
+                                                               ->  Hash  (cost=3.05..3.05 rows=2 width=14)
+                                                                     ->  Seq Scan on a  (cost=0.00..3.05 rows=2 width=14)
+                                             ->  Materialize  (cost=3.07..3.13 rows=2 width=4)
+                                                   ->  Seq Scan on b  (cost=0.00..3.06 rows=2 width=4)
  Settings:  optimizer=off
  Optimizer status: legacy query optimizer
-(36 rows)
+(35 rows)
 
 select A.i, B.i, C.j from A, B, C where A.j = any ( select C.j from C where not exists(select C.i from C,A where C.i = A.i and C.i =10)) order by A.i, B.i, C.j limit 10;
  i | i  | j  
@@ -1247,25 +1244,25 @@ select A.i from A where not exists (select B.i from B where B.i in (select C.i f
 (3 rows)
 
 explain select * from B where not exists (select * from C,A where C.i in (select C.i from C where C.i = A.i and C.i != 10) AND B.i = C.i);
-                                        QUERY PLAN                                         
--------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=9.58..12.69 rows=4 width=8)
-   ->  Hash Anti Join  (cost=9.58..12.69 rows=2 width=8)
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=9.62..12.74 rows=4 width=8)
+   ->  Hash Anti Join  (cost=9.62..12.74 rows=2 width=8)
          Hash Cond: b.i = qp_correlated_query.c.i
          ->  Seq Scan on b  (cost=0.00..3.06 rows=2 width=8)
-         ->  Hash  (cost=9.52..9.52 rows=2 width=4)
-               ->  Hash Semi Join  (cost=6.34..9.52 rows=2 width=4)
-                     Hash Cond: qp_correlated_query.c.i = qp_correlated_query.c.i
-                     ->  Seq Scan on c  (cost=0.00..3.11 rows=3 width=4)
-                           Filter: i <> 10
-                     ->  Hash  (cost=6.29..6.29 rows=2 width=8)
-                           ->  Hash Join  (cost=3.11..6.29 rows=2 width=8)
-                                 Hash Cond: qp_correlated_query.c.i = a.i
-                                 ->  Seq Scan on c  (cost=0.00..3.11 rows=3 width=4)
+         ->  Hash  (cost=9.57..9.57 rows=2 width=4)
+               ->  Hash Semi Join  (cost=6.33..9.57 rows=2 width=4)
+                     Hash Cond: a.i = qp_correlated_query.c.i
+                     ->  Hash Join  (cost=3.11..6.30 rows=2 width=8)
+                           Hash Cond: qp_correlated_query.c.i = a.i
+                           ->  Seq Scan on c  (cost=0.00..3.11 rows=3 width=4)
+                                 Filter: i <> 10
+                           ->  Hash  (cost=3.06..3.06 rows=2 width=4)
+                                 ->  Seq Scan on a  (cost=0.00..3.06 rows=2 width=4)
                                        Filter: i <> 10
-                                 ->  Hash  (cost=3.06..3.06 rows=2 width=4)
-                                       ->  Seq Scan on a  (cost=0.00..3.06 rows=2 width=4)
-                                             Filter: i <> 10
+                     ->  Hash  (cost=3.11..3.11 rows=3 width=4)
+                           ->  Seq Scan on c  (cost=0.00..3.11 rows=3 width=4)
+                                 Filter: i <> 10
  Settings:  optimizer=off
  Optimizer status: legacy query optimizer
 (19 rows)
@@ -1280,28 +1277,28 @@ select * from B where not exists (select * from C,A where C.i in (select C.i fro
 (4 rows)
 
 explain select * from A where A.i in (select C.j from C,B where B.i in (select i from C));
-                                                         QUERY PLAN                                                         
-----------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice4; segments: 3)  (cost=7.81..11.26 rows=39 width=8)
-   ->  Hash Join  (cost=7.81..11.26 rows=13 width=8)
-         Hash Cond: a.i = qp_correlated_query.c.j
-         ->  Seq Scan on a  (cost=0.00..3.05 rows=2 width=8)
-         ->  Hash  (cost=7.72..7.72 rows=3 width=4)
-               ->  HashAggregate  (cost=7.65..7.72 rows=3 width=4)
-                     Group By: qp_correlated_query.c.j
-                     ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=3.14..7.50 rows=20 width=4)
-                           Hash Key: qp_correlated_query.c.j
-                           ->  Nested Loop  (cost=3.14..6.33 rows=20 width=4)
-                                 ->  Broadcast Motion 1:3  (slice2; segments: 1)  (cost=3.14..3.16 rows=1 width=0)
-                                       ->  Limit  (cost=3.14..3.14 rows=1 width=0)
-                                             ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=3.14..3.16 rows=1 width=0)
-                                                   ->  Limit  (cost=3.14..3.14 rows=1 width=0)
-                                                         ->  Hash Semi Join  (cost=3.14..6.33 rows=3 width=0)
-                                                               Hash Cond: qp_correlated_query.c.i = b.i
-                                                               ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
-                                                               ->  Hash  (cost=3.06..3.06 rows=2 width=4)
-                                                                     ->  Seq Scan on b  (cost=0.00..3.06 rows=2 width=4)
-                                 ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)  (cost=17.11..17.16 rows=6 width=18)
+   ->  HashAggregate  (cost=17.11..17.16 rows=2 width=18)
+         Group By: a.ctid::bigint, a.gp_segment_id
+         ->  Result  (cost=9.74..17.08 rows=2 width=18)
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=9.74..17.08 rows=2 width=18)
+                     Hash Key: a.ctid
+                     ->  Hash Join  (cost=9.74..16.97 rows=2 width=18)
+                           Hash Cond: qp_correlated_query.c.j = a.i
+                           ->  Nested Loop  (cost=6.30..12.93 rows=18 width=4)
+                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=3.20..6.59 rows=6 width=0)
+                                       ->  Hash Semi Join  (cost=3.20..6.35 rows=2 width=0)
+                                             Hash Cond: b.i = qp_correlated_query.c.i
+                                             ->  Seq Scan on b  (cost=0.00..3.06 rows=2 width=4)
+                                             ->  Hash  (cost=3.09..3.09 rows=3 width=4)
+                                                   ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
+                                 ->  Materialize  (cost=3.10..3.19 rows=3 width=4)
+                                       ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
+                           ->  Hash  (cost=3.25..3.25 rows=5 width=18)
+                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..3.25 rows=5 width=18)
+                                       ->  Seq Scan on a  (cost=0.00..3.05 rows=2 width=18)
  Settings:  optimizer=off
  Optimizer status: legacy query optimizer
 (22 rows)

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -1453,15 +1453,15 @@ EXPLAIN SELECT '' AS six, f1 AS "Uncorrelated Field" FROM SUBSELECT_TBL
     f2 IN (SELECT f1 FROM SUBSELECT_TBL)) ORDER BY 2;
                                                    QUERY PLAN                                                   
 ----------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=10.51..10.57 rows=21 width=4)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=9.93..9.95 rows=8 width=4)
    Merge Key: subselect_gp.subselect_tbl.f1
-   ->  Sort  (cost=10.51..10.57 rows=7 width=4)
+   ->  Sort  (cost=9.93..9.95 rows=3 width=4)
          Sort Key: subselect_gp.subselect_tbl.f1
-         ->  Hash Semi Join  (cost=6.74..10.05 rows=7 width=4)
+         ->  Hash Semi Join  (cost=6.61..9.81 rows=3 width=4)
                Hash Cond: subselect_gp.subselect_tbl.f1 = subselect_gp.subselect_tbl.f2
                ->  Seq Scan on subselect_tbl  (cost=0.00..3.08 rows=3 width=4)
-               ->  Hash  (cost=6.59..6.59 rows=4 width=8)
-                     ->  Hash Join  (cost=3.18..6.59 rows=4 width=8)
+               ->  Hash  (cost=6.52..6.52 rows=3 width=8)
+                     ->  Hash Semi Join  (cost=3.18..6.52 rows=3 width=8)
                            Hash Cond: subselect_gp.subselect_tbl.f2 = subselect_gp.subselect_tbl.f1
                            ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.24 rows=3 width=4)
                                  Hash Key: subselect_gp.subselect_tbl.f2
@@ -1606,84 +1606,76 @@ EXPLAIN SELECT '' AS five, f1 AS "Correlated Field"
 EXPLAIN select count(*) from
   (select 1 from tenk1 a
    where unique1 IN (select hundred from tenk1 b)) ss;
-                                                        QUERY PLAN                                                         
----------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=752.98..752.99 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=752.91..752.96 rows=1 width=8)
-         ->  Aggregate  (cost=752.91..752.92 rows=1 width=8)
-               ->  Hash Join  (cost=414.79..728.02 rows=3319 width=4)
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=728.58..728.59 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=728.51..728.56 rows=1 width=8)
+         ->  Aggregate  (cost=728.51..728.52 rows=1 width=8)
+               ->  Hash Semi Join  (cost=512.09..728.00 rows=34 width=0)
                      Hash Cond: a.unique1 = b.hundred
                      ->  Seq Scan on tenk1 a  (cost=0.00..188.55 rows=3319 width=4)
-                     ->  Hash  (cost=413.54..413.54 rows=34 width=4)
-                           ->  HashAggregate  (cost=412.54..413.54 rows=34 width=4)
-                                 Group By: b.hundred
-                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..387.65 rows=3319 width=4)
-                                       Hash Key: b.hundred
-                                       ->  Seq Scan on tenk1 b  (cost=0.00..188.55 rows=3319 width=4)
+                     ->  Hash  (cost=387.65..387.65 rows=3319 width=4)
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..387.65 rows=3319 width=4)
+                                 Hash Key: b.hundred
+                                 ->  Seq Scan on tenk1 b  (cost=0.00..188.55 rows=3319 width=4)
  Settings:  optimizer=off
  Optimizer status: legacy query optimizer
-(14 rows)
+(12 rows)
 
 EXPLAIN select count(distinct ss.ten) from
   (select ten from tenk1 a
    where unique1 IN (select hundred from tenk1 b)) ss;
-                                                     QUERY PLAN                                                      
----------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=1176.00..1176.01 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=414.79..1126.22 rows=9955 width=4)
-         ->  Hash Join  (cost=414.79..728.02 rows=3319 width=4)
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=733.78..733.79 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=513.07..733.27 rows=100 width=4)
+         ->  Hash Semi Join  (cost=513.07..729.27 rows=34 width=4)
                Hash Cond: a.unique1 = b.hundred
-               ->  Seq Scan on tenk1 a  (cost=0.00..188.55 rows=3319 width=8)
-               ->  Hash  (cost=413.54..413.54 rows=34 width=4)
-                     ->  HashAggregate  (cost=412.54..413.54 rows=34 width=4)
-                           Group By: b.hundred
-                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..387.65 rows=3319 width=4)
-                                 Hash Key: b.hundred
-                                 ->  Seq Scan on tenk1 b  (cost=0.00..188.55 rows=3319 width=4)
+               ->  Seq Scan on tenk1 a  (cost=0.00..188.78 rows=3326 width=8)
+               ->  Hash  (cost=388.34..388.34 rows=3326 width=4)
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..388.34 rows=3326 width=4)
+                           Hash Key: b.hundred
+                           ->  Seq Scan on tenk1 b  (cost=0.00..188.78 rows=3326 width=4)
  Settings:  optimizer=off
  Optimizer status: legacy query optimizer
-(13 rows)
+(11 rows)
 
 EXPLAIN select count(*) from
   (select 1 from tenk1 a
    where unique1 IN (select distinct hundred from tenk1 b)) ss;
-                                                        QUERY PLAN                                                         
----------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=752.98..752.99 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=752.91..752.96 rows=1 width=8)
-         ->  Aggregate  (cost=752.91..752.92 rows=1 width=8)
-               ->  Hash Join  (cost=414.79..728.02 rows=3319 width=0)
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=729.85..729.86 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=729.78..729.83 rows=1 width=8)
+         ->  Aggregate  (cost=729.78..729.79 rows=1 width=8)
+               ->  Hash Semi Join  (cost=513.07..729.27 rows=34 width=0)
                      Hash Cond: a.unique1 = b.hundred
-                     ->  Seq Scan on tenk1 a  (cost=0.00..188.55 rows=3319 width=4)
-                     ->  Hash  (cost=413.54..413.54 rows=34 width=4)
-                           ->  HashAggregate  (cost=412.54..413.54 rows=34 width=4)
-                                 Group By: b.hundred
-                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..387.65 rows=3319 width=4)
-                                       Hash Key: b.hundred
-                                       ->  Seq Scan on tenk1 b  (cost=0.00..188.55 rows=3319 width=4)
+                     ->  Seq Scan on tenk1 a  (cost=0.00..188.78 rows=3326 width=4)
+                     ->  Hash  (cost=388.34..388.34 rows=3326 width=4)
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..388.34 rows=3326 width=4)
+                                 Hash Key: b.hundred
+                                 ->  Seq Scan on tenk1 b  (cost=0.00..188.78 rows=3326 width=4)
  Settings:  optimizer=off
  Optimizer status: legacy query optimizer
-(14 rows)
+(12 rows)
 
 EXPLAIN select count(distinct ss.ten) from
   (select ten from tenk1 a
    where unique1 IN (select distinct hundred from tenk1 b)) ss;
-                                                     QUERY PLAN                                                      
----------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=1176.00..1176.01 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=414.79..1126.22 rows=9955 width=4)
-         ->  Hash Join  (cost=414.79..728.02 rows=3319 width=4)
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=733.78..733.79 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=513.07..733.27 rows=100 width=4)
+         ->  Hash Semi Join  (cost=513.07..729.27 rows=34 width=4)
                Hash Cond: a.unique1 = b.hundred
-               ->  Seq Scan on tenk1 a  (cost=0.00..188.55 rows=3319 width=8)
-               ->  Hash  (cost=413.54..413.54 rows=34 width=4)
-                     ->  HashAggregate  (cost=412.54..413.54 rows=34 width=4)
-                           Group By: b.hundred
-                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..387.65 rows=3319 width=4)
-                                 Hash Key: b.hundred
-                                 ->  Seq Scan on tenk1 b  (cost=0.00..188.55 rows=3319 width=4)
+               ->  Seq Scan on tenk1 a  (cost=0.00..188.78 rows=3326 width=8)
+               ->  Hash  (cost=388.34..388.34 rows=3326 width=4)
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..388.34 rows=3326 width=4)
+                           Hash Key: b.hundred
+                           ->  Seq Scan on tenk1 b  (cost=0.00..188.78 rows=3326 width=4)
  Settings:  optimizer=off
  Optimizer status: legacy query optimizer
-(13 rows)
+(11 rows)
 
 --
 -- In case of simple exists query, planner can generate alternative


### PR DESCRIPTION
This removes much of the GPDB machinery to handle "deduplication paths"
within the planner. We will now use the upstream code to build JOIN_SEMI
paths, as well as paths where the outer side of the join is first
deduplicated (JOIN_UNIQUE_OUTER/INNER).

The old style "join first and deduplicate later" plans can be better in
some cases, however. To still be able to generate such plan, add new
JOIN_DEDUP_SEMI join type, which is transformed into JOIN_INNER followed
by the deduplication step after the join, during planning.

This new way of constructing these plans is simpler, and allows removing
a bunch of code, and reverting some more code to the way it is in the
upstream.

I'm not sure if this can generate the same plans that the old code could,
in all cases. In particular, I think the old "late deduplication"
mechanism could delay the deduplication further, all the way to the top of
the join tree. I'm not sure when that woud be useful, though, and the
regression suite doesn't seem to contain any such cases (with EXPLAIN). Or
maybe I misunderstood the old code. In any case, I think this is good
enough.