### PR TITLE
CI: Remove references to tf-bucket-path from README

### DIFF
--- a/concourse/pipelines/README.md
+++ b/concourse/pipelines/README.md
@@ -129,7 +129,6 @@ fly -t gpdb-dev \
     -c gpdb-dpm-curry.yml \
     -l ~/workspace/continuous-integration/secrets/gpdb_common-ci-secrets.yml \
     -l ~/workspace/continuous-integration/secrets/gpdb_5X_STABLE-ci-secrets.yml \
-    -v tf-bucket-path=dev/dpm/ \
     -v bucket-name=gpdb5-concourse-builds-dev
 ```
 
@@ -156,7 +155,6 @@ fly -t gpdb-dev \
     -c gpdb-cs-durant.yml \
     -l ~/workspace/continuous-integration/secrets/gpdb_common-ci-secrets.yml \
     -l ~/workspace/continuous-integration/secrets/gpdb_5X_STABLE-ci-secrets.yml \
-    -v tf-bucket-path=dev/cs/ \
     -v bucket-name=gpdb5-concourse-builds-dev
 
 ```


### PR DESCRIPTION
Commit e924b46e87fee9e300f8baf93ee6c8bd390e4ec5 removed all references
to the parameter tf-bucket-path because it is now hardcoded to clusters.