### PR TITLE
Fixes GOPATH

### DIFF
--- a/README.macOS.bash
+++ b/README.macOS.bash
@@ -87,7 +87,7 @@ EOF
 # Step: GOPATH for Golang
 cat >> ~/.bash_profile << EOF
 export GOPATH=\$HOME/go:\$HOME/workspace/gpdb/gpMgmt/go-utils
-export PATH=\$GOPATH/bin:\$PATH
+export PATH=\$HOME/go/bin:\$HOME/workspace/gpdb/gpMgmt/go-utils/bin:\$PATH
 EOF
 
 # Step: speed up compile time (optional)


### PR DESCRIPTION
Sometime last year, we discussed setting the GOPATH and PATH as follows

export GOPATH=/Users/pivotal/go:/Users/pivotal/workspace/gpdb/gpMgmt/go-utils
export PATH=/Users/pivotal/go:/Users/pivotal/workspace/gpdb/gpMgmt/go-utils/bin:
/Users/pivotal/.rbenv/shims:/Users/pivotal/go:/Users/pivotal/workspace/gpdb/gpMgmt/go-utils/bin:/usr/local/opt/python/libexec/bin:/usr/local/opt/python/libexec/bin:/Users/pivotal/.rbenv/shims:/Users/pivotal/.rbenv/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin

But I'm now realizing that this is tricky since PATH does not see all
the binaries in the GOPATH. Only the last directory will have its bin:

/Users/pivotal/go:/Users/pivotal/workspace/gpdb/gpMgmt/go-utils/bin:
/usr/local/opt/python/libexec/bin:....

Shell parameter expression could help solve this problem,
PATH=${GOPATH//:/bin:}:$PATH but this adds /bin to all
directories except for the last one.

Instead, we will just hardcode both directories onto PATH