### PR TITLE
docs: update shared mem. info in GUCS max_fsm_pages and max_connections

### DIFF
--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -6994,13 +6994,12 @@
         parameter, <xref href="#max_prepared_transactions" format="dita"/> must be increased as
         well. For more information about limiting concurrent connections, see "Configuring Client
         Authentication" in the <i>Greenplum Database Administrator Guide</i>.</p>
-      <p>Increasing this parameter may cause Greenplum Database to request more shared memory.
-        Increasing this parameter might cause Greenplum Database to request more shared memory. See
+      <p>Increasing this parameter might cause Greenplum Database to request more shared memory. See
           <xref href="#shared_buffers" format="dita"/> for information about Greenplum server
         instance shared memory buffers. If this value is increased, <xref href="#shared_buffers"
           format="dita"/> and the kernel parameter <codeph>SHMMAX</codeph> might also need to be
-        increased. Also, parameters that depend shared memory such as <xref href="#max_fsm_pages"/>
-        might need to be changed.</p>
+        increased. Also, parameters that depend on shared memory such as <xref href="#max_fsm_pages"
+        /> might need to be changed.</p>
       <table id="max_connections_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>
@@ -7060,7 +7059,7 @@
       <p>Sets the maximum number of disk pages for which free space will be tracked in the shared
         free-space map. Six bytes of shared memory are consumed for each page slot. If this value is
         increased, <xref href="#shared_buffers" format="dita"/> and the kernel parameter
-          <codeph>SHMMAX</codeph> might also need to be increased. Also, parameters that depend
+          <codeph>SHMMAX</codeph> might also need to be increased. Also, parameters that depend on
         shared memory such as <xref href="#max_connections"/> might need to be changed.</p>
       <table id="max_fsm_pages_table">
         <tgroup cols="3">

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -6994,10 +6994,13 @@
         parameter, <xref href="#max_prepared_transactions" format="dita"/> must be increased as
         well. For more information about limiting concurrent connections, see "Configuring Client
         Authentication" in the <i>Greenplum Database Administrator Guide</i>.</p>
-      <p>Increasing this parameter may cause Greenplum Database to request more shared
-        memory.Increasing this parameter might cause Greenplum Database to request more shared
-        memory. See <xref href="#shared_buffers" format="dita"/> for information about Greenplum
-        server instance shared memory buffers.</p>
+      <p>Increasing this parameter may cause Greenplum Database to request more shared memory.
+        Increasing this parameter might cause Greenplum Database to request more shared memory. See
+          <xref href="#shared_buffers" format="dita"/> for information about Greenplum server
+        instance shared memory buffers. If this value is increased, <xref href="#shared_buffers"
+          format="dita"/> and the kernel parameter <codeph>SHMMAX</codeph> might also need to be
+        increased. Also, parameters that depend shared memory such as <xref href="#max_fsm_pages"/>
+        might need to be changed.</p>
       <table id="max_connections_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>
@@ -7055,7 +7058,10 @@
     <title>max_fsm_pages</title>
     <body>
       <p>Sets the maximum number of disk pages for which free space will be tracked in the shared
-        free-space map. Six bytes of shared memory are consumed for each page slot. </p>
+        free-space map. Six bytes of shared memory are consumed for each page slot. If this value is
+        increased, <xref href="#shared_buffers" format="dita"/> and the kernel parameter
+          <codeph>SHMMAX</codeph> might also need to be increased. Also, parameters that depend
+        shared memory such as <xref href="#max_connections"/> might need to be changed.</p>
       <table id="max_fsm_pages_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>
@@ -7084,7 +7090,7 @@
     <body>
       <p>Sets the maximum number of relations for which free space will be tracked in the shared
         memory free-space map. Should be set to a value larger than the total number of:</p>
-      <p>tables + indexes + system tables.</p>
+      <codeblock>tables + indexes + system tables</codeblock>
       <p>It costs about 60 bytes of memory for each relation per segment instance. It is better to
         allow some room for overhead and set too high rather than too low.</p>
       <table id="max_fsm_relations_table">


### PR DESCRIPTION
Add info from support about shared memory conflicts.

PR for 5X_STABLE
Will be ported to MAIN - NOTE: max_fsm* GUCs removed in main.