### PR TITLE
FTS handle uninitialized role and mode in probe response

### DIFF
--- a/src/backend/fts/ftsprobe.c
+++ b/src/backend/fts/ftsprobe.c
@@ -782,6 +782,18 @@ probeProcessResponse(ProbeConnectionInfo *probeInfo)
 					  probeRole,
 					  probeMode);
 		}
+
+		/*
+		 * The segment responded to the probe in the middle of postmaster
+		 * reset so mark the probe dead, wait a couple seconds for the primary
+		 * to finish, and attempt to retry the probe.
+		 */
+		if (role == PMModeUninitialized && mode == DataStateNotInitialized)
+		{
+			probeInfo->segmentStatus = PROBE_DEAD;
+			pg_usleep(2 * USECS_PER_SEC);
+			return false;
+		}
 	}
 
 	/* check if segment reported a fault */

--- a/src/backend/fts/test/Makefile
+++ b/src/backend/fts/test/Makefile
@@ -1,0 +1,11 @@
+subdir=src/backend/fts
+top_builddir=../../../..
+include $(top_builddir)/src/Makefile.global
+
+TARGETS=ftsprobe
+
+include $(top_builddir)/src/backend/mock.mk
+
+ftsprobe.t: \
+	$(MOCK_DIR)/backend/utils/error/elog_mock.o \
+	$(MOCK_DIR)/backend/cdb/cdbthreadlog_mock.o

--- a/src/backend/fts/test/ftsprobe_test.c
+++ b/src/backend/fts/test/ftsprobe_test.c
@@ -1,0 +1,83 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include "cmockery.h"
+
+#include "postgres.h"
+#include "utils/timestamp.h"
+
+/* redefine pg_usleep to mock */
+#undef pg_usleep
+#define pg_usleep pg_usleep_mock
+
+int pg_usleep_called = 0;
+static void pg_usleep_mock(long microsec)
+{
+	/*
+	 * An uninitialized role and mode will result in extra 2 second sleep to
+	 * give primary segment more time to finish startup. Make sure 2 seconds
+	 * is given to pg_usleep mock.
+	 */
+	assert_int_equal(microsec, 2 * USECS_PER_SEC);
+
+	pg_usleep_called++;
+}
+
+/* Actual function body */
+#include "../ftsprobe.c"
+
+static void write_log_will_be_called()
+{
+	expect_any(write_log, fmt);
+	will_be_called(write_log);
+}
+
+void
+test_probeProcessResponse_uninitialized_role_and_mode(void **state)
+{
+	ProbeConnectionInfo probeInfo;
+	uint32 n32;
+	bool result;
+
+	memset(&probeInfo, 0, sizeof(ProbeConnectionInfo));
+
+	/* mock a primary probe response with uninitialized role and mode */
+	n32 = htonl((uint32) PROBE_RESPONSE_LEN);
+	memcpy(probeInfo.response, &n32, 4);
+	n32 = htonl((uint32) PMModeUninitialized);
+	memcpy(probeInfo.response+4, &n32, 4);
+	n32 = htonl((uint32) SegmentStateNotInitialized);
+	memcpy(probeInfo.response+8, &n32, 4);
+	n32 = htonl((uint32) DataStateNotInitialized);
+	memcpy(probeInfo.response+12, &n32, 4);
+	n32 = htonl((uint32) FaultTypeNotInitialized);
+	memcpy(probeInfo.response+16, &n32, 4);
+
+	probeInfo.segmentStatus = PROBE_DEAD;
+	probeInfo.role = 'p';
+	probeInfo.mode = 's';
+
+	/* reset pg_usleep counter */
+	pg_usleep_called = 0;
+
+	write_log_will_be_called();
+
+	/* run the test */
+	result = probeProcessResponse(&probeInfo);
+
+	/* should have returned false and marked probe dead for probe retry */
+	assert_false(result);
+	assert_true(probeInfo.segmentStatus == PROBE_DEAD);
+	assert_int_equal(pg_usleep_called, 1);
+}
+
+int
+main(int argc, char* argv[])
+{
+	cmockery_parse_arguments(argc, argv);
+
+	const UnitTest tests[] = {
+		unit_test(test_probeProcessResponse_uninitialized_role_and_mode)
+	};
+	return run_tests(tests);
+}


### PR DESCRIPTION
Primary segments can be probed under PMModeUninitialized in scenarios
such as database startup during gpstart or more importantly during
postmaster reset. Current 5X_STABLE/4.3_STABLE FTS design does not
handle uninitialized role and mode in the primary probe response so
the FTS would continue to probe the primary assuming the primary would
finish its transition to PMModePrimarySegment in a future
probe. However, it was observed in a SIGBUS edge case (hardware issue)
where a primary segment went into a continuous postmaster reset loop
and would never get out of PMModeUninitialized. In this scenario, FTS
would continue to probe the bad primary segment and not attempt a
failover to the mirror segment. The database would then be unusable
until manual intervention is done to fix or stop the primary segment.

We now handle the case by retrying the probe if uninitialized role and
mode is seen in the primary probe response. After the maximum retry
counts have been attempted, FTS will go forward with failover to
mirror.