### PR TITLE
Fix assertion failure in cost estimation of merge joins.

### DIFF
--- a/src/backend/optimizer/path/costsize.c
+++ b/src/backend/optimizer/path/costsize.c
@@ -2001,9 +2001,13 @@ cost_mergejoin(MergePath *path, PlannerInfo *root, SpecialJoinInfo *sjinfo)
 	/*
 	 * Convert selectivities to row counts.  We force outer_rows and
 	 * inner_rows to be at least 1, but the skip_rows estimates can be zero.
+	 *
+	 * CDB: Don't round the skip-estimates, like camp_row_est() doesn't
+	 * round the normal estimates in GPDB. Otherwise the assertions might
+	 * fail.
 	 */
-	outer_skip_rows = rint(outer_path_rows * outerstartsel);
-	inner_skip_rows = rint(inner_path_rows * innerstartsel);
+	outer_skip_rows = outer_path_rows * outerstartsel;
+	inner_skip_rows = inner_path_rows * innerstartsel;
 	outer_rows = clamp_row_est(outer_path_rows * outerendsel);
 	inner_rows = clamp_row_est(inner_path_rows * innerendsel);
 


### PR DESCRIPTION
When I run the regression tests with enable_mergejoin=on, I got:

+FATAL:  Unexpected internal error (costsize.c:2010)
+DETAIL:  FailedAssertion("!(outer_skip_rows <= outer_rows)", File: "costsize.c", Line: 2010)
+HINT:  Process 26232 will wait for gp_debug_linger=120 seconds before termination.
+Note that its locks and other resources will not be released until then.
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+connection to server was lost

That happened in the 'gp_recursive_cte' test, with this query:

select recursive_table_1.id from recursive_table_1, recursive_table_2 where recursive_table_1.id = recursive_table_2.id and EXISTS (select * from r where r.i = recursive_table_2.id);

I tried to reduce that to a simpler test case, but gave up. I'm sure it
could be done, but I wasn't able to, with quick testing. This bug seems
unlikely to reappear in the same form, and it's covered by the existing
test, even if it's a bit accidental, so that's good enough for me.