### PR TITLE
Enable listen_addresses

### DIFF
--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -1249,6 +1249,10 @@ CREATE_QD_DB () {
 		SED_PG_CONF ${GP_DIR}/$PG_CONF "$PORT_TXT" port=$GP_PORT 0
 		ERROR_CHK $? "set Master port=$GP_PORT in $PG_CONF" 2
 		LOG_MSG "[INFO]:-Completed setting the Master port to $MASTER_PORT"
+		LOG_MSG "[INFO]:-Setting the Master listen addresses to '*'"
+		SED_PG_CONF ${GP_DIR}/$PG_CONF "$LISTEN_ADR_TXT" listen_addresses=\'*\' 0
+		ERROR_CHK $? "set Master listen addresses to '*' in $PG_CONF" 2
+		LOG_MSG "[INFO]:-Completed setting the listen addresses to '*'"
 		LOG_MSG "[INFO]:-Setting Master logging option"
 		SED_PG_CONF ${GP_DIR}/$PG_CONF "$LOG_STATEMENT_TXT" log_statement=all 0
 		ERROR_CHK $? "set log_statement=all in ${GP_DIR}/$PG_CONF" 1

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -188,7 +188,7 @@ class PgCtlBackendOptions(CmdArgs):
         """
         @param seqserver: start with seqserver?
         """
-        self.extend(["-i", "--gp_contentid=-1"])
+        self.append("--gp_contentid=-1")
         if seqserver: self.append("-E")
         return self
 
@@ -196,7 +196,7 @@ class PgCtlBackendOptions(CmdArgs):
         """
         @param content: content id
         """
-        self.extend(["-i", "--gp_contentid="+str(content)])
+        self.append("--gp_contentid="+str(content))
         return self
 
     #

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -41,6 +41,7 @@
 #include "port/pg_crc32c.h"
 #include "storage/latch.h"
 #include "storage/pmsignal.h"
+#include "postmaster/postmaster.h"
 
 #include "cdb/tupchunklist.h"
 #include "cdb/ml_ipc.h"
@@ -1162,6 +1163,7 @@ setupUDPListeningSocket(int *listenerSocketFd, uint16 *listenerPort, int *txFami
 	int			fd = -1;
 	const char *fun;
 
+
 	/*
 	 * At the moment, we don't know which of IPv6 or IPv4 is wanted, or even
 	 * supported, so just ask getaddrinfo...
@@ -1198,7 +1200,7 @@ setupUDPListeningSocket(int *listenerSocketFd, uint16 *listenerPort, int *txFami
 #endif
 
 	fun = "getaddrinfo";
-	s = getaddrinfo(NULL, service, &hints, &addrs);
+	s = getaddrinfo(BackendListenAddress, service, &hints, &addrs);
 	if (s != 0)
 		elog(ERROR, "getaddrinfo says %s", gai_strerror(s));
 

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -196,6 +196,7 @@ static Backend *ShmemBackendArray;
 int			PostPortNumber;
 char	   *UnixSocketDir;
 char	   *ListenAddresses;
+char	   *BackendListenAddress;
 
 /*
  * ReservedBackends is the number of backends reserved for superuser use.
@@ -1073,6 +1074,12 @@ PostmasterMain(int argc, char *argv[])
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 					 errmsg("invalid list syntax for \"listen_addresses\"")));
 		}
+
+		/* If there are more than one listen address, backend bind on all addresses*/
+		if (list_length(elemlist) > 1)
+			BackendListenAddress = NULL;
+		else
+			BackendListenAddress = ListenAddresses;
 
 		foreach(l, elemlist)
 		{

--- a/src/include/postmaster/postmaster.h
+++ b/src/include/postmaster/postmaster.h
@@ -22,6 +22,7 @@ extern int	Unix_socket_permissions;
 extern char *Unix_socket_group;
 extern char *UnixSocketDir;
 extern char *ListenAddresses;
+extern char *BackendListenAddress;
 extern bool ClientAuthInProgress;
 extern int	PreAuthDelay;
 extern int	AuthenticationTimeout;


### PR DESCRIPTION
listen_addresses in postgresql.conf doesn't taken effect now, backend and
postmaster are listening on all addresses. From the point of security, we
should be able to let user specify the listen address.