### PR TITLE
Remove assertions that will never be triggered

### DIFF
--- a/src/backend/utils/resource_manager/memquota.c
+++ b/src/backend/utils/resource_manager/memquota.c
@@ -292,7 +292,6 @@ static bool PolicyAutoPrelimWalker(Node *node, PolicyAutoContext *context)
 		return false;
 	}
 
-	Assert(node);
 	Assert(context);
 	if (is_plan_node(node))
 	{
@@ -322,7 +321,6 @@ static bool PolicyAutoAssignWalker(Node *node, PolicyAutoContext *context)
 		return false;
 	}
 
-	Assert(node);
 	Assert(context);
 
 	if (is_plan_node(node))
@@ -770,7 +768,6 @@ PolicyEagerFreePrelimWalker(Node *node, PolicyEagerFreeContext *context)
 		return false;
 	}
 
-	Assert(node);
 	Assert(context);
 
 	OperatorGroupNode *parentGroupNode = NULL;
@@ -849,7 +846,6 @@ PolicyEagerFreeAssignWalker(Node *node, PolicyEagerFreeContext *context)
 		return false;
 	}
 
-	Assert(node);
 	Assert(context);
 
 	const uint64 nonMemIntenseOpMemKB = (uint64)(*gp_resmanager_memory_policy_auto_fixed_mem);

--- a/src/backend/utils/resource_manager/memquota.c
+++ b/src/backend/utils/resource_manager/memquota.c
@@ -800,7 +800,7 @@ PolicyEagerFreePrelimWalker(Node *node, PolicyEagerFreeContext *context)
 	Assert(!result);
 
 	/*
-	 * If this node is the top nodoe in a group, at this point, we should have all info about
+	 * If this node is the top node in a group, at this point, we should have all info about
 	 * its child groups. We then calculate the maximum number of potential concurrently
 	 * active memory-intensive operators and non-memory-intensive operators in all
 	 * child groups.


### PR DESCRIPTION
Since `node` has already been checked in the preceding `if` statement, the assertion is will never hit and will only cost processing so remove all instances of this pattern.

There are a few more assertions in this file that from reading should probably be made into `ereport(ERROR..` instead, but that's for another PR.