### PR TITLE
Fix a case with a Hash Agg and ORDER BY.

### DIFF
--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -4286,9 +4286,11 @@ add_second_stage_agg(PlannerInfo *root,
 								 result_plan);
 
 	/*
-	 * Agg will not change the sort order unless it is hashed.
+	 * A sorted Agg will not change the sort order.
 	 */
 	agg_node->flow = pull_up_Flow(agg_node, agg_node->lefttree);
+	if (aggstrategy != AGG_SORTED)
+		*p_current_pathkeys = NIL;
 
 	/*
 	 * Since the rtable has changed, we had better recreate a RelOptInfo entry

--- a/src/test/regress/expected/bfv_olap.out
+++ b/src/test/regress/expected/bfv_olap.out
@@ -540,6 +540,22 @@ WHERE c = 87 ;
 ----------
 (0 rows)
 
+--
+-- This used to crash, and/or produce incorrect results. The culprit was that a Hash Agg
+-- was used, but the planner put a Gather Merge at the top, without a Sort, even though
+-- a Hash Agg doesn't preserve the sort order.
+--
+SELECT sale.qty
+FROM sale
+GROUP BY ROLLUP((qty)) order by 1;
+ qty  
+------
+    1
+   12
+ 1100
+     
+(4 rows)
+
 -- CLEANUP
 -- start_ignore
 drop schema bfv_olap cascade;

--- a/src/test/regress/sql/bfv_olap.sql
+++ b/src/test/regress/sql/bfv_olap.sql
@@ -361,6 +361,15 @@ FROM (
 ) AS sup(c, d)
 WHERE c = 87 ;
 
+--
+-- This used to crash, and/or produce incorrect results. The culprit was that a Hash Agg
+-- was used, but the planner put a Gather Merge at the top, without a Sort, even though
+-- a Hash Agg doesn't preserve the sort order.
+--
+SELECT sale.qty
+FROM sale
+GROUP BY ROLLUP((qty)) order by 1;
+
 
 -- CLEANUP
 -- start_ignore


### PR DESCRIPTION
A Hash Agg doesn't preserve sort order. The grouping extensions planner
didn't get the memo. That caused an assertion failure, when a Gather Motion
with a Merge Key was put on top of a Hash Agg, without a Sort, and the rows
didn't come out in the expected order.

This fixes the assertion fault mentioned in github issue #4488, but not
the main issue of incorrect results.