### PR TITLE
A few small fixes to memquota.c

### DIFF
--- a/src/backend/executor/nodeResult.c
+++ b/src/backend/executor/nodeResult.c
@@ -421,7 +421,7 @@ ExecInitResult(Result *node, EState *estate, int eflags)
 	ExecAssignProjectionInfo(&resstate->ps, NULL);
 
 	if (!IsResManagerMemoryPolicyNone()
-			&& IsResultMemoryIntesive(node))
+			&& IsResultMemoryIntensive(node))
 	{
 		SPI_ReserveMemory(((Plan *)node)->operatorMemKB * 1024L);
 	}

--- a/src/backend/utils/resource_manager/memquota.c
+++ b/src/backend/utils/resource_manager/memquota.c
@@ -56,6 +56,7 @@ typedef struct PolicyAutoContext
 static bool PolicyAutoPrelimWalker(Node *node, PolicyAutoContext *context);
 static bool	PolicyAutoAssignWalker(Node *node, PolicyAutoContext *context);
 static bool IsAggMemoryIntensive(Agg *agg);
+static bool IsMemoryIntensiveOperator(Node *node, PlannedStmt *stmt);
 
 struct OperatorGroupNode;
 
@@ -234,7 +235,7 @@ IsResultMemoryIntensive(Result *res)
 /**
  * Is an operator memory intensive?
  */
-bool
+static bool
 IsMemoryIntensiveOperator(Node *node, PlannedStmt *stmt)
 {
 	Assert(is_plan_node(node));

--- a/src/backend/utils/resource_manager/memquota.c
+++ b/src/backend/utils/resource_manager/memquota.c
@@ -210,7 +210,7 @@ IsBlockingOperator(Node *node)
  * Is a result node memory intensive? It is if it contains function calls.
  */
 bool
-IsResultMemoryIntesive(Result *res)
+IsResultMemoryIntensive(Result *res)
 {
 
 	List *funcNodes = extract_nodes(NULL /* glob */,
@@ -257,7 +257,7 @@ IsMemoryIntensiveOperator(Node *node, PlannedStmt *stmt)
 		case T_Result:
 			{
 				Result *res = (Result *) node;
-				return IsResultMemoryIntesive(res);
+				return IsResultMemoryIntensive(res);
 			}
 		default:
 			return false;

--- a/src/include/cdb/memquota.h
+++ b/src/include/cdb/memquota.h
@@ -57,11 +57,6 @@ extern uint64 PolicyAutoStatementMemForNoSpillKB(PlannedStmt *stmt, uint64 minOp
  */
 extern bool IsResultMemoryIntensive(Result *res);
 
-/**
- * Is operator memory intensive
- */
-extern bool IsMemoryIntensiveOperator(Node *node, PlannedStmt *stmt);
-
 /*
  * Calculate the amount of memory reserved for the query
  */

--- a/src/include/cdb/memquota.h
+++ b/src/include/cdb/memquota.h
@@ -55,7 +55,7 @@ extern uint64 PolicyAutoStatementMemForNoSpillKB(PlannedStmt *stmt, uint64 minOp
 /**
  * Is result node memory intensive?
  */
-extern bool IsResultMemoryIntesive(Result *res);
+extern bool IsResultMemoryIntensive(Result *res);
 
 /**
  * Is operator memory intensive


### PR DESCRIPTION
Rename IsResultMemoryIntensive() to fix typo in name. The function was lacking an 'n', making it intesive rather than intensive. Since this is an API change, this is done for the next major version. All callers updated.

Make `IsMemoryIntensiveOperator()` static. This function is only used in `memquota.c`, and based on the API it seems reasonable to keep it there, so declaring it static.