### PR TITLE
Fix missing_xlog with longer timeout

### DIFF
--- a/src/test/walrep/expected/missing_xlog.out
+++ b/src/test/walrep/expected/missing_xlog.out
@@ -165,7 +165,7 @@ select move_xlog('/tmp/missing_xlog', (select datadir || '/pg_xlog' from gp_segm
 (1 row)
 
 -- the error should go away
-select wait_for_replication_error('none', 0, 100);
+select wait_for_replication_error('none', 0, 200);
  wait_for_replication_error 
 ----------------------------
  t

--- a/src/test/walrep/sql/missing_xlog.sql
+++ b/src/test/walrep/sql/missing_xlog.sql
@@ -134,5 +134,5 @@ select sync_error from gp_stat_replication where gp_segment_id = 0;
 select move_xlog('/tmp/missing_xlog', (select datadir || '/pg_xlog' from gp_segment_configuration c where c.role='p' and c.content=0));
 
 -- the error should go away
-select wait_for_replication_error('none', 0, 100);
+select wait_for_replication_error('none', 0, 200);
 select sync_error from gp_stat_replication where gp_segment_id = 0;


### PR DESCRIPTION
There is 5 sec delay between mirror retry to connect to primary. The original
timeout to detect for the streaming state change was 10 seconds, which caused
stability issue of the test if the probe happen to fall between two mirror
retries.

The fix increase the timeout to 20 seconds (200), which is also consistent with
rest of the timeout used in the test.

Author: Xin Zhang <xzhang@pivotal.io>