### PR TITLE
Fix flaky dispatch test

### DIFF
--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -233,10 +233,10 @@ select gp_inject_fault('send_qe_details_init_backend', 'reset', 2);
 -- Test createGang timeout.
 -- gp_segment_connect_timeout = 0 : wait forever
 -- gp_segment_connect_timeout = 1 : wait 1 second
-set gp_segment_connect_timeout to 1;
 select cleanupAllGangs();
 
 select gp_inject_fault('process_startup_packet', 'sleep', '', '', '', 1, 5, 2::smallint);
+set gp_segment_connect_timeout to 1;
 
 -- expect timeout failure
 select * from dispatch_test_t1, dispatch_test_t2, dispatch_test_t3

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -432,7 +432,6 @@ NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11284)
 -- Test createGang timeout.
 -- gp_segment_connect_timeout = 0 : wait forever
 -- gp_segment_connect_timeout = 1 : wait 1 second
-set gp_segment_connect_timeout to 1;
 select cleanupAllGangs();
  cleanupallgangs 
 -----------------
@@ -446,6 +445,7 @@ NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11314)
  t
 (1 row)
 
+set gp_segment_connect_timeout to 1;
 -- expect timeout failure
 select * from dispatch_test_t1, dispatch_test_t2, dispatch_test_t3
 where dispatch_test_t1.c2 = dispatch_test_t2.c2 and dispatch_test_t2.c3 = dispatch_test_t3.c3;


### PR DESCRIPTION
set gp_segment_connect_timeout to 1s would make the following
gp_inject_fault statement fail sometimes when the system is busy.