### PR TITLE
Align settings for Ubuntu ICW in Concourse

### DIFF
--- a/concourse/scripts/ic_gpdb_ubuntu.bash
+++ b/concourse/scripts/ic_gpdb_ubuntu.bash
@@ -22,7 +22,11 @@ function setup_gpadmin_user() {
 
 function make_cluster() {
   source "${GREENPLUM_INSTALL_DIR}/greenplum_path.sh"
+  export BLDWRAP_POSTGRES_CONF_ADDONS=${BLDWRAP_POSTGRES_CONF_ADDONS}
+  # Currently, the max_concurrency tests in src/test/isolation2
+  # require max_connections of at least 129.
   export DEFAULT_QD_MAX_CONNECT=150
+  export STATEMENT_MEM=250MB
   pushd gpdb_src/gpAux/gpdemo
     su gpadmin -c "source ${GREENPLUM_INSTALL_DIR}/greenplum_path.sh && make create-demo-cluster"
   popd


### PR DESCRIPTION
There were differences in the cluster configuration for Ubuntu compared to the other operating systems in the CI.  CentOS and SLES were both running ICW with statement_mem set to 250MB but
this was not done for Ubuntu.  Also, the configuration addons were not set.  This worked fine since no ICW statement actually needed more than the default setting, but with the new nodes coming we will cross over that threshold which breaks Ubuntu builds.

Bump the setting to match CentOS and SLES, and also include the conf addons in case we start using them again.

That being said, the ideal situation would be to not have a special path for Ubuntu and instead be able to source the common script (or make the common script take a PATH parameter), but thats left as an exercise for the reader.