### PR TITLE
Separate PXF system parameters from user parameters

### DIFF
--- a/gpAux/extensions/pxf/src/pxfuriparser.c
+++ b/gpAux/extensions/pxf/src/pxfuriparser.c
@@ -240,7 +240,7 @@ GPHDUri_parse_option(char *pair, GPHDUri *uri)
 
 	char	   *x_gp_key = normalize_key_name(option_data->key);
 
-	if (strcmp(x_gp_key, "X-GP-PROFILE") == 0)
+	if (strcmp(x_gp_key, "X-GP-OPTIONS-PROFILE") == 0)
 		uri->profile = pstrdup(option_data->value);
 	pfree(x_gp_key);
 

--- a/gpAux/extensions/pxf/src/pxfutils.c
+++ b/gpAux/extensions/pxf/src/pxfutils.c
@@ -4,7 +4,8 @@
 
 /*
  * Full name of the HEADER KEY expected by the PXF service
- * Converts input string to upper case and prepends "X-GP-" string
+ * Converts input string to upper case and prepends "X-GP-OPTIONS-" string
+ * This will be used for all user defined parameters to be isolate from internal parameters
  */
 char *
 normalize_key_name(const char *key)
@@ -16,7 +17,7 @@ normalize_key_name(const char *key)
 				 errmsg("internal error in pxfutils.c:normalize_key_name. Parameter key is null or empty.")));
 	}
 
-	return psprintf("X-GP-%s", str_toupper(pstrdup(key), strlen(key)));
+	return psprintf("X-GP-OPTIONS-%s", str_toupper(pstrdup(key), strlen(key)));
 }
 
 /*

--- a/gpAux/extensions/pxf/src/pxfutils.h
+++ b/gpAux/extensions/pxf/src/pxfutils.h
@@ -3,7 +3,7 @@
 
 #include "postgres.h"
 
-/* convert input string to upper case and prepend "X-GP-" prefix */
+/* convert input string to upper case and prepend "X-GP-OPTIONS-" prefix */
 char	   *normalize_key_name(const char *key);
 
 /* get the name of the type, given the OID */

--- a/gpAux/extensions/pxf/test/pxfheaders_test.c
+++ b/gpAux/extensions/pxf/test/pxfheaders_test.c
@@ -59,12 +59,12 @@ test_build_http_headers(void **state)
 
 	OptionData *option_data1 = (OptionData *) palloc0(sizeof(OptionData));
 
-	option_data1->key = "option1-key";
-	option_data1->value = "option1-value";
+	option_data1->key = "key1";
+	option_data1->value = "value1";
 	OptionData *option_data2 = (OptionData *) palloc0(sizeof(OptionData));
 
-	option_data2->key = "option2-key";
-	option_data2->value = "option2-value";
+	option_data2->key = "key2";
+	option_data2->value = "value2";
 	gphd_uri->options = list_make2(option_data1, option_data2);
 
 	tuple.natts = 0;
@@ -109,11 +109,11 @@ test_build_http_headers(void **state)
 
 	expect_string(normalize_key_name, key, "key1");
 	will_return(normalize_key_name, pstrdup("X-GP-OPTIONS-KEY1"));
-	expect_headers_append(headers, "X-GP-OPTIONS-KEY1", "option1-value");
+	expect_headers_append(headers, "X-GP-OPTIONS-KEY1", "value1");
 
 	expect_string(normalize_key_name, key, "key2");
 	will_return(normalize_key_name, pstrdup("X-GP-OPTIONS-KEY2"));
-	expect_headers_append(headers, "X-GP-OPTION-KEY2", "option2-value");
+	expect_headers_append(headers, "X-GP-OPTIONS-KEY2", "value2");
 
 	expect_headers_append(headers, "X-GP-URI", gphd_uri->uri);
 	expect_headers_append(headers, "X-GP-HAS-FILTER", "0");

--- a/gpAux/extensions/pxf/test/pxfheaders_test.c
+++ b/gpAux/extensions/pxf/test/pxfheaders_test.c
@@ -107,13 +107,13 @@ test_build_http_headers(void **state)
 	expect_headers_append(headers, "X-GP-DATA-DIR", gphd_uri->data);
 
 
-	expect_string(normalize_key_name, key, "option1-key");
-	will_return(normalize_key_name, pstrdup("X-GP-OPTION1-KEY"));
-	expect_headers_append(headers, "X-GP-OPTION1-KEY", "option1-value");
+	expect_string(normalize_key_name, key, "key1");
+	will_return(normalize_key_name, pstrdup("X-GP-OPTIONS-KEY1"));
+	expect_headers_append(headers, "X-GP-OPTIONS-KEY1", "option1-value");
 
-	expect_string(normalize_key_name, key, "option2-key");
-	will_return(normalize_key_name, pstrdup("X-GP-OPTION2-KEY"));
-	expect_headers_append(headers, "X-GP-OPTION2-KEY", "option2-value");
+	expect_string(normalize_key_name, key, "key2");
+	will_return(normalize_key_name, pstrdup("X-GP-OPTIONS-KEY2"));
+	expect_headers_append(headers, "X-GP-OPTION-KEY2", "option2-value");
 
 	expect_headers_append(headers, "X-GP-URI", gphd_uri->uri);
 	expect_headers_append(headers, "X-GP-HAS-FILTER", "0");

--- a/gpAux/extensions/pxf/test/pxfutils_test.c
+++ b/gpAux/extensions/pxf/test/pxfutils_test.c
@@ -14,11 +14,11 @@ test_normalize_key_name(void **state)
 {
 	char	   *replaced = normalize_key_name("bar");
 
-	assert_string_equal(replaced, "X-GP-BAR");
+	assert_string_equal(replaced, "X-GP-OPTIONS-BAR");
 	pfree(replaced);
 
 	replaced = normalize_key_name("FOO");
-	assert_string_equal(replaced, "X-GP-FOO");
+	assert_string_equal(replaced, "X-GP-OPTIONS-FOO");
 	pfree(replaced);
 
 	/* test null string */


### PR DESCRIPTION
PXF system parameters will continue using X-GP- prefix.
PXF user parameters will use X-GP-OPTIONS- prefix.
The purpose is to isolate these groups from each other from possible collisions.
The corresponding PXF Server side PR is here apache/incubator-hawq#1332