### PR TITLE
Add type modifiers (typmod) support to ORCA

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("2.54.", GPORCA_VERSION_STRING, 5);
+return strncmp("2.55.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 2.54.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 2.55.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -13050,7 +13050,7 @@ int
 main ()
 {
 
-return strncmp("2.54.", GPORCA_VERSION_STRING, 5);
+return strncmp("2.55.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -13060,7 +13060,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 2.54.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 2.55.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v2.54.5@gpdb/stable
+orca/v2.55.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -121,7 +121,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget -q -O - https://github.com/greenplum-db/gporca/releases/download/v2.54.5/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget -q -O - https://github.com/greenplum-db/gporca/releases/download/v2.55.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/backend/gpopt/translate/CMappingColIdVarPlStmt.cpp
+++ b/src/backend/gpopt/translate/CMappingColIdVarPlStmt.cpp
@@ -113,6 +113,7 @@ CMappingColIdVarPlStmt::PparamFromDXLNodeScId
 		pparam->paramkind = PARAM_EXEC;
 		pparam->paramid = pmecolidparamid->UlParamId();
 		pparam->paramtype = CMDIdGPDB::PmdidConvert(pmecolidparamid->PmdidType())->OidObjectId();
+		pparam->paramtypmod = pmecolidparamid->ITypeModifier();
 	}
 
 	return pparam;
@@ -231,7 +232,7 @@ CMappingColIdVarPlStmt::PvarFromDXLNodeScId
 						idxVarno,
 						attno,
 						CMDIdGPDB::PmdidConvert(pdxlop->PmdidType())->OidObjectId(),
-						-1,	// vartypmod
+						pdxlop->ITypeModifier(),
 						0	// varlevelsup
 						);
 

--- a/src/backend/gpopt/translate/CMappingElementColIdParamId.cpp
+++ b/src/backend/gpopt/translate/CMappingElementColIdParamId.cpp
@@ -35,12 +35,14 @@ CMappingElementColIdParamId::CMappingElementColIdParamId
 	(
 	ULONG ulColId,
 	ULONG ulParamId,
-	IMDId *pmdid
+	IMDId *pmdid,
+	INT iTypeModifier
 	)
 	:
 	m_ulColId(ulColId),
 	m_ulParamId(ulParamId),
-	m_pmdid(pmdid)
+	m_pmdid(pmdid),
+	m_iTypeModifier(iTypeModifier)
 {
 }
 

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -2983,7 +2983,7 @@ CTranslatorDXLToPlStmt::PappendFromDXLAppend
 							idxVarno,
 							attno,
 							CMDIdGPDB::PmdidConvert(pdxlopScIdent->PmdidType())->OidObjectId(),
-							-1,	// vartypmod
+							pdxlopScIdent->ITypeModifier(),
 							0	// varlevelsup
 							);
 
@@ -3189,7 +3189,7 @@ CTranslatorDXLToPlStmt::PshscanFromDXLCTEProducer
 			GPOS_ASSERT(IsA(pexpr, Var));
 
 			Var *pvar = (Var *) pexpr;
-			Var *pvarNew = gpdb::PvarMakeVar(OUTER, pvar->varattno, pvar->vartype, -1 /* vartypmod */,	0 /* varlevelsup */);
+			Var *pvarNew = gpdb::PvarMakeVar(OUTER, pvar->varattno, pvar->vartype, pvar->vartypmod,	0 /* varlevelsup */);
 			pvarNew->varnoold = pvar->varnoold;
 			pvarNew->varoattno = pvar->varoattno;
 
@@ -3380,7 +3380,7 @@ CTranslatorDXLToPlStmt::PshscanFromDXLCTEConsumer
 		CDXLScalarIdent *pdxlopScIdent = CDXLScalarIdent::PdxlopConvert(pdxlnScIdent->Pdxlop());
 		OID oidType = CMDIdGPDB::PmdidConvert(pdxlopScIdent->PmdidType())->OidObjectId();
 
-		Var *pvar = gpdb::PvarMakeVar(OUTER, (AttrNumber) (ul + 1), oidType, -1 /* vartypmod */,  0	/* varlevelsup */);
+		Var *pvar = gpdb::PvarMakeVar(OUTER, (AttrNumber) (ul + 1), oidType, pdxlopScIdent->ITypeModifier(),  0	/* varlevelsup */);
 
 		CHAR *szResname = CTranslatorUtils::SzFromWsz(pdxlopPrE->PmdnameAlias()->Pstr()->Wsz());
 		TargetEntry *pte = gpdb::PteMakeTargetEntry((Expr *) pvar, (AttrNumber) (ul + 1), szResname, false /* resjunk */);
@@ -4482,6 +4482,7 @@ CTranslatorDXLToPlStmt::PlTargetListForHashNode
 
 		// find column type
 		OID oidType = gpdb::OidExprType((Node*) pteChild->expr);
+		INT iTypeModifier = gpdb::IExprTypeMod((Node *) pteChild->expr);
 
 		// find the original varno and attno for this column
 		Index idxVarnoold = 0;
@@ -4505,7 +4506,7 @@ CTranslatorDXLToPlStmt::PlTargetListForHashNode
 					OUTER,
 					pteChild->resno,
 					oidType,
-					-1,	// vartypmod
+					iTypeModifier,
 					0	// varlevelsup
 					);
 
@@ -4851,12 +4852,13 @@ CTranslatorDXLToPlStmt::UlAddTargetEntryForColId
 	// TODO: Oct 29, 2012; see if entry already exists in the target list
 	
 	OID oidExpr = gpdb::OidExprType((Node*) pte->expr);
+	INT iTypeModifier = gpdb::IExprTypeMod((Node *) pte->expr);
 	Var *pvar = gpdb::PvarMakeVar
 						(
 						OUTER,
 						pte->resno,
 						oidExpr,
-						-1,	// vartypmod
+						iTypeModifier,
 						0	// varlevelsup
 						);
 	ULONG ulResNo = gpdb::UlListLength(*pplTargetList) + 1;

--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -665,11 +665,12 @@ CTranslatorDXLToScalar::PsubplanFromDXLNodeScSubPlan
 		CDXLColRef *pdxlcr = (*pdrgdxlcrOuterRefs)[ul];
 		IMDId *pmdid = pdxlcr->PmdidType();
 		ULONG ulColid = pdxlcr->UlID();
+		INT iTypeModifier = pdxlcr->ITypeModifier();
 
 		if (NULL == dxltrctxSubplan.Pmecolidparamid(ulColid))
 		{
 			// keep outer reference mapping to the original column for subsequent subplans
-			CMappingElementColIdParamId *pmecolidparamid = GPOS_NEW(m_pmp) CMappingElementColIdParamId(ulColid, pctxdxltoplstmt->UlNextParamId(), pmdid);
+			CMappingElementColIdParamId *pmecolidparamid = GPOS_NEW(m_pmp) CMappingElementColIdParamId(ulColid, pctxdxltoplstmt->UlNextParamId(), pmdid, iTypeModifier);
 
 #ifdef GPOS_DEBUG
 			BOOL fInserted =
@@ -718,7 +719,7 @@ inline BOOL FDXLCastedId(CDXLNode *pdxln)
 		   pdxln->UlArity() > 0 && EdxlopScalarIdent == (*pdxln)[0]->Pdxlop()->Edxlop();
 }
 
-inline Oid OidParamOidFromDXLIdentOrDXLCastIdent(CDXLNode *pdxlnIdentOrCastIdent)
+inline CTranslatorDXLToScalar::STypeOidAndTypeModifier OidParamOidFromDXLIdentOrDXLCastIdent(CDXLNode *pdxlnIdentOrCastIdent)
 {
 	GPOS_ASSERT(EdxlopScalarIdent == pdxlnIdentOrCastIdent->Pdxlop()->Edxlop() || FDXLCastedId(pdxlnIdentOrCastIdent));
 
@@ -732,7 +733,8 @@ inline Oid OidParamOidFromDXLIdentOrDXLCastIdent(CDXLNode *pdxlnIdentOrCastIdent
 		pdxlopInnerIdent = CDXLScalarIdent::PdxlopConvert((*pdxlnIdentOrCastIdent)[0]->Pdxlop());
 	}
 	Oid oidInnerType = CMDIdGPDB::PmdidConvert(pdxlopInnerIdent->PmdidType())->OidObjectId();
-	return oidInnerType;
+	INT iTypeModifier = pdxlopInnerIdent->ITypeModifier();
+	return {oidInnerType, iTypeModifier};
 }
 
 //---------------------------------------------------------------------------
@@ -807,7 +809,9 @@ CTranslatorDXLToScalar::PexprSubplanTestExpr
 	pparam->paramkind = PARAM_EXEC;
 	CContextDXLToPlStmt *pctxdxltoplstmt = (dynamic_cast<CMappingColIdVarPlStmt *>(pmapcidvar))->Pctxdxltoplstmt();
 	pparam->paramid = pctxdxltoplstmt->UlNextParamId();
-	pparam->paramtype = OidParamOidFromDXLIdentOrDXLCastIdent(pdxlnInnerChild);
+	CTranslatorDXLToScalar::STypeOidAndTypeModifier oidAndTypeModifier = OidParamOidFromDXLIdentOrDXLCastIdent(pdxlnInnerChild);
+	pparam->paramtype = oidAndTypeModifier.OidType;
+	pparam->paramtypmod = oidAndTypeModifier.ITypeModifier;
 
 	// test expression is used for non-scalar subplan,
 	// second arg of test expression must be an EXEC param referring to subplan output,
@@ -861,6 +865,7 @@ CTranslatorDXLToScalar::TranslateSubplanParams
 		pdxlcr->AddRef();
 		const CMappingElementColIdParamId *pmecolidparamid = pdxltrctx->Pmecolidparamid(pdxlcr->UlID());
 
+		// TODO: eliminate pparam, it's not *really* used, and it's (short-term) leaked
 		Param *pparam = PparamFromMapping(pmecolidparamid);
 		psubplan->parParam = gpdb::PlAppendInt(psubplan->parParam, pparam->paramid);
 
@@ -958,6 +963,7 @@ CTranslatorDXLToScalar::PparamFromMapping
 	pparam->paramid = pmecolidparamid->UlParamId();
 	pparam->paramkind = PARAM_EXEC;
 	pparam->paramtype = CMDIdGPDB::PmdidConvert(pmecolidparamid->PmdidType())->OidObjectId();
+	pparam->paramtypmod = pmecolidparamid->ITypeModifier();
 
 	return pparam;
 }
@@ -1220,7 +1226,7 @@ CTranslatorDXLToScalar::PcoerceFromDXLNodeScCoerceToDomain
 
         pcoerce->resulttype = CMDIdGPDB::PmdidConvert(pdxlop->PmdidResultType())->OidObjectId();
         pcoerce->arg = pexprChild;
-        pcoerce->resulttypmod = pdxlop->IMod();
+        pcoerce->resulttypmod = pdxlop->ITypeModifier();
         pcoerce->location = pdxlop->ILoc();
         pcoerce->coercionformat = (CoercionForm)  pdxlop->Edxlcf();
 
@@ -1288,7 +1294,7 @@ CTranslatorDXLToScalar::PcoerceFromDXLNodeScArrayCoerceExpr
         pcoerce->arg = pexprChild;
         pcoerce->elemfuncid = CMDIdGPDB::PmdidConvert(pdxlop->PmdidElementFunc())->OidObjectId();
         pcoerce->resulttype = CMDIdGPDB::PmdidConvert(pdxlop->PmdidResultType())->OidObjectId();
-        pcoerce->resulttypmod = pdxlop->IMod();
+        pcoerce->resulttypmod = pdxlop->ITypeModifier();
         pcoerce->isExplicit = pdxlop->FIsExplicit();
         pcoerce->coerceformat = (CoercionForm)  pdxlop->Edxlcf();
         pcoerce->location = pdxlop->ILoc();
@@ -1657,7 +1663,7 @@ CTranslatorDXLToScalar::PconstGeneric
 
 	Const *pconst = MakeNode(Const);
 	pconst->consttype = CMDIdGPDB::PmdidConvert(pdxldatumgeneric->Pmdid())->OidObjectId();
-	pconst->consttypmod = -1;
+	pconst->consttypmod = pdxldatumgeneric->ITypeModifier();
 	pconst->constbyval = pdxldatumgeneric->FByValue();
 	pconst->constisnull = pdxldatumgeneric->FNull();
 	pconst->constlen = pdxldatumgeneric->UlLength();
@@ -1967,6 +1973,7 @@ CTranslatorDXLToScalar::PexprArrayRef
 	ArrayRef *parrayref = MakeNode(ArrayRef);
 	parrayref->refarraytype = CMDIdGPDB::PmdidConvert(pdxlop->PmdidArray())->OidObjectId();
 	parrayref->refelemtype = CMDIdGPDB::PmdidConvert(pdxlop->PmdidElem())->OidObjectId();
+	parrayref->reftypmod = pdxlop->ITypeModifier();
 
 	const ULONG ulArity = pdxlnArrayref->UlArity();
 	GPOS_ASSERT(3 == ulArity || 4 == ulArity);

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -810,6 +810,7 @@ CTranslatorQueryToDXL::PdxlnCTAS()
 											m_pidgtorCol->UlNextId(),
 											iResno /* iAttno */,
 											pmdid,
+											pdxlopIdent->ITypeModifier(),
 											false /* fDropped */
 											);
 		pdrgpdxlcd->Append(pdxlcd);
@@ -1599,7 +1600,8 @@ CTranslatorQueryToDXL::PdxlnWindow
 																					m_pmp,
 																					GPOS_NEW(m_pmp) CMDName(m_pmp, pmdnameAlias->Pstr()),
 																					ulColId,
-																					GPOS_NEW(m_pmp) CMDIdGPDB(gpdb::OidExprType((Node*) pte->expr))
+																					GPOS_NEW(m_pmp) CMDIdGPDB(gpdb::OidExprType((Node*) pte->expr)),
+																					gpdb::IExprTypeMod((Node*) pte->expr)
 																					)
 																		)
 															);
@@ -2374,6 +2376,7 @@ CTranslatorQueryToDXL::PdxlnConstTableGet() const
 										m_pidgtorCol->UlNextId(),
 										1 /* iAttno */,
 										GPOS_NEW(m_pmp) CMDIdGPDB(pmdid->OidObjectId()),
+										IDefaultTypeModifier,
 										false /* fDropped */
 										);
 	pdrgpdxlcd->Append(pdxlcd);
@@ -3090,6 +3093,7 @@ CTranslatorQueryToDXL::PdxlnFromValues
 													ulColId,
 													ulColPos + 1 /* iAttno */,
 													GPOS_NEW(m_pmp) CMDIdGPDB(pconst->consttype),
+													pconst->consttypmod,
 													false /* fDropped */
 													);
 
@@ -3121,6 +3125,7 @@ CTranslatorQueryToDXL::PdxlnFromValues
 														ulColId,
 														ulColPos + 1 /* iAttno */,
 														GPOS_NEW(m_pmp) CMDIdGPDB(gpdb::OidExprType((Node*) pexpr)),
+														gpdb::IExprTypeMod((Node*) pexpr),
 														false /* fDropped */
 														);
 					pdrgpdxlcd->Append(pdxlcd);
@@ -3920,7 +3925,8 @@ CTranslatorQueryToDXL::PdrgpdxlnConstructOutputCols
 
 		// create a column reference
 		IMDId *pmdidType = GPOS_NEW(m_pmp) CMDIdGPDB(gpdb::OidExprType( (Node*) pte->expr));
-		CDXLColRef *pdxlcr = GPOS_NEW(m_pmp) CDXLColRef(m_pmp, pmdname, ulColId, pmdidType);
+		INT iTypeModifier = gpdb::IExprTypeMod((Node*) pte->expr);
+		CDXLColRef *pdxlcr = GPOS_NEW(m_pmp) CDXLColRef(m_pmp, pmdname, ulColId, pmdidType, iTypeModifier);
 		CDXLScalarIdent *pdxlopIdent = GPOS_NEW(m_pmp) CDXLScalarIdent
 												(
 												m_pmp,

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -811,6 +811,7 @@ CTranslatorRelcacheToDXL::Pdrgpmdcol
 										pmdnameCol,
 										att->attnum,
 										pmdidCol,
+										att->atttypmod,
 										!att->attnotnull,
 										att->attisdropped,
 										pdxlnDefault /* default value */,
@@ -1028,7 +1029,8 @@ CTranslatorRelcacheToDXL::AddSystemColumns
 										(
 										pmdnameCol, 
 										attno, 
-										CTranslatorUtils::PmdidSystemColType(pmp, attno), 
+										CTranslatorUtils::PmdidSystemColType(pmp, attno),
+										IDefaultTypeModifier,
 										false,	// fNullable
 										false,	// fDropped
 										NULL,	// default value
@@ -2117,6 +2119,7 @@ CTranslatorRelcacheToDXL::Pmdcheckconstraint
 										ul + 1 /*ulColId*/,
 										pmdcol->IAttno(),
 										pmdidColType,
+										pmdcol->ITypeModifier(),
 										false /* fColDropped */
 										);
 		pdrgpdxlcd->Append(pdxlcd);
@@ -2767,7 +2770,7 @@ CTranslatorRelcacheToDXL::PimdobjCast
 		case COERCION_PATH_ARRAYCOERCE:
 		{
 			coercePathType = IMDCast::EmdtArrayCoerce;
-			return GPOS_NEW(pmp) CMDArrayCoerceCastGPDB(pmp, pmdid, pmdname, pmdidSrc, pmdidDest, fBinaryCoercible, GPOS_NEW(pmp) CMDIdGPDB(oidCastFunc), IMDCast::EmdtArrayCoerce, -1, false, EdxlcfImplicitCast, -1);
+			return GPOS_NEW(pmp) CMDArrayCoerceCastGPDB(pmp, pmdid, pmdname, pmdidSrc, pmdidDest, fBinaryCoercible, GPOS_NEW(pmp) CMDIdGPDB(oidCastFunc), IMDCast::EmdtArrayCoerce, IDefaultTypeModifier, false, EdxlcfImplicitCast, -1);
 		}
 			break;
 		case COERCION_PATH_FUNC:
@@ -3440,6 +3443,7 @@ CTranslatorRelcacheToDXL::PmdpartcnstrIndex
 										ul + 1, // ulColId
 										pmdcol->IAttno(),
 										pmdidColType,
+										pmdcol->ITypeModifier(),
 										false // fColDropped
 										);
 		pdrgpdxlcd->Append(pdxlcd);
@@ -3528,6 +3532,7 @@ CTranslatorRelcacheToDXL::PmdpartcnstrRelation
 											ul + 1, // ulColId
 											pmdcol->IAttno(),
 											pmdidColType,
+											pmdcol->ITypeModifier(),
 											false // fColDropped
 											);
 			pdrgpdxlcd->Append(pdxlcd);

--- a/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
@@ -172,7 +172,8 @@ CTranslatorScalarToDXL::PdxlnScIdFromVar
 												m_pmp,
 												pmdname,
 												ulId,
-												GPOS_NEW(m_pmp) CMDIdGPDB(pvar->vartype)
+												GPOS_NEW(m_pmp) CMDIdGPDB(pvar->vartype),
+												pvar->vartypmod
 												);
 
 	// create the scalar ident operator
@@ -593,7 +594,9 @@ CTranslatorScalarToDXL::Pdxldatum
 	pmdid->Release();
 
  	// translate gpdb datum into a DXL datum
-	CDXLDatum *pdxldatum = CTranslatorScalarToDXL::Pdxldatum(pmp, pmdtype, pconst->constisnull, pconst->constlen, pconst->constvalue);
+	CDXLDatum *pdxldatum = CTranslatorScalarToDXL::Pdxldatum(pmp, pmdtype, pconst->consttypmod, pconst->constisnull,
+															 pconst->constlen,
+															 pconst->constvalue);
 
 	return pdxldatum;
 }
@@ -1251,6 +1254,7 @@ CTranslatorScalarToDXL::PdxlnScFuncExprFromFuncExpr
 {
 	GPOS_ASSERT(IsA(pexpr, FuncExpr));
 	const FuncExpr *pfuncexpr = (FuncExpr *) pexpr;
+	int32 iTypeModifier = gpdb::IExprTypeMod((Node *) pexpr);
 
 	CMDIdGPDB *pmdidFunc = GPOS_NEW(m_pmp) CMDIdGPDB(pfuncexpr->funcid);
 
@@ -1263,6 +1267,7 @@ CTranslatorScalarToDXL::PdxlnScFuncExprFromFuncExpr
 												m_pmp,
 												pmdidFunc,
 												GPOS_NEW(m_pmp) CMDIdGPDB(pfuncexpr->funcresulttype),
+												iTypeModifier,
 												pfuncexpr->funcretset
 												)
 									);
@@ -1504,7 +1509,8 @@ CTranslatorScalarToDXL::PdxlnWindowFrameEdgeVal
 																m_pmp,
 																GPOS_NEW(m_pmp) CMDName(m_pmp, &strUnnamedCol),
 																ulPrElId,
-																GPOS_NEW(m_pmp) CMDIdGPDB(gpdb::OidExprType(const_cast<Node*>(pnode)))
+																GPOS_NEW(m_pmp) CMDIdGPDB(gpdb::OidExprType(const_cast<Node*>(pnode))),
+																gpdb::IExprTypeMod(const_cast<Node*>(pnode))
 																)
 													);
 
@@ -1935,6 +1941,7 @@ CTranslatorScalarToDXL::PdxlnArrayRef
 	const ArrayRef *parrayref = (ArrayRef *) pexpr;
 	Oid restype;
 
+	INT iTypeModifier = parrayref->reftypmod;
 	/* slice and/or store operations yield the array type */
 	if (parrayref->reflowerindexpr || parrayref->refassgnexpr)
 		restype = parrayref->refarraytype;
@@ -1946,6 +1953,7 @@ CTranslatorScalarToDXL::PdxlnArrayRef
 						(
 						m_pmp,
 						GPOS_NEW(m_pmp) CMDIdGPDB(parrayref->refelemtype),
+						iTypeModifier,
 						GPOS_NEW(m_pmp) CMDIdGPDB(parrayref->refarraytype),
 						GPOS_NEW(m_pmp) CMDIdGPDB(restype)
 						);
@@ -2075,6 +2083,7 @@ CTranslatorScalarToDXL::Pdxldatum
 	(
 	IMemoryPool *pmp,
 	const IMDType *pmdtype,
+	INT iTypeModifier,
 	BOOL fNull,
 	ULONG ulLen,
 	Datum datum
@@ -2105,7 +2114,7 @@ CTranslatorScalarToDXL::Pdxldatum
 	if (NULL == pf)
 	{
 		// generate a datum of generic type
-		return PdxldatumGeneric(pmp, pmdtype, fNull, ulLen, datum);
+		return PdxldatumGeneric(pmp, pmdtype, iTypeModifier, fNull, ulLen, datum);
 	}
 	else
 	{
@@ -2125,6 +2134,7 @@ CTranslatorScalarToDXL::PdxldatumGeneric
 	(
 	IMemoryPool *pmp,
 	const IMDType *pmdtype,
+	INT iTypeModifier,
 	BOOL fNull,
 	ULONG ulLen,
 	Datum datum
@@ -2153,7 +2163,7 @@ CTranslatorScalarToDXL::PdxldatumGeneric
 		lValue = LValue(pmdid, fNull, pba, ulLength);
 	}
 
-	return CMDTypeGenericGPDB::Pdxldatum(pmp, pmdid, fConstByVal, fNull, pba, ulLength, lValue, dValue);
+	return CMDTypeGenericGPDB::Pdxldatum(pmp, pmdid, iTypeModifier, fConstByVal, fNull, pba, ulLength, lValue, dValue);
 }
 
 
@@ -2478,7 +2488,7 @@ CTranslatorScalarToDXL::Pdatum
 	}
 	GPOS_ASSERT(fNull || ulLength > 0);
 
-	CDXLDatum *pdxldatum = CTranslatorScalarToDXL::Pdxldatum(pmp, pmdtype, fNull, ulLength, datum);
+	CDXLDatum *pdxldatum = CTranslatorScalarToDXL::Pdxldatum(pmp, pmdtype, 0, fNull, ulLength, datum);
 	IDatum *pdatum = pmdtype->Pdatum(pmp, pdxldatum);
 	pdxldatum->Release();
 	return pdatum;

--- a/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
@@ -2488,7 +2488,7 @@ CTranslatorScalarToDXL::Pdatum
 	}
 	GPOS_ASSERT(fNull || ulLength > 0);
 
-	CDXLDatum *pdxldatum = CTranslatorScalarToDXL::Pdxldatum(pmp, pmdtype, 0, fNull, ulLength, datum);
+	CDXLDatum *pdxldatum = CTranslatorScalarToDXL::Pdxldatum(pmp, pmdtype, gpmd::IDefaultTypeModifier, fNull, ulLength, datum);
 	IDatum *pdatum = pmdtype->Pdatum(pmp, pdxldatum);
 	pdxldatum->Release();
 	return pdatum;

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -183,6 +183,7 @@ CTranslatorUtils::Pdxltabdesc
 											pidgtor->UlNextId(),
 											pmdcol->IAttno(),
 											pmdidColType,
+											pmdcol->ITypeModifier(), /* iTypeModifier */
 											false, /* fColDropped */
 											pmdcol->UlLength()
 											);
@@ -292,7 +293,7 @@ CTranslatorUtils::Pdxltvf
 	if (NULL != prte->funccoltypes)
 	{
 		// function returns record - use col names and types from query
-		pdrgdxlcd = PdrgdxlcdRecord(pmp, pidgtor, prte->eref->colnames, prte->funccoltypes);
+		pdrgdxlcd = PdrgdxlcdRecord(pmp, pidgtor, prte->eref->colnames, prte->funccoltypes, prte->funccoltypmods);
 	}
 	else if (pmdType->FComposite() && IMDId::FValid(pmdType->PmdidBaseRelation()))
 	{
@@ -326,7 +327,8 @@ CTranslatorUtils::Pdxltvf
 	{
 		// function returns base type
 		CMDName mdnameFunc = pmdfunc->Mdname();
-		pdrgdxlcd = PdrgdxlcdBase(pmp, pidgtor, pmdidRetType, &mdnameFunc);
+		// table valued functions don't describe the returned column type modifiers, hence the -1
+		pdrgdxlcd = PdrgdxlcdBase(pmp, pidgtor, pmdidRetType, IDefaultTypeModifier, &mdnameFunc);
 	}
 
 	CMDName *pmdfuncname = GPOS_NEW(pmp) CMDName(pmp, pmdfunc->Mdname().Pstr());
@@ -449,20 +451,24 @@ CTranslatorUtils::PdrgdxlcdRecord
 	IMemoryPool *pmp,
 	CIdGenerator *pidgtor,
 	List *plColNames,
-	List *plColTypes
+	List *plColTypes,
+	List *plColTypeModifiers
 	)
 {
 	ListCell *plcColName = NULL;
 	ListCell *plcColType = NULL;
+	ListCell *plcColTypeModifier = NULL;
 
 	ULONG ul = 0;
 	DrgPdxlcd *pdrgdxlcd = GPOS_NEW(pmp) DrgPdxlcd(pmp);
 
-	ForBoth (plcColName, plColNames,
-			plcColType, plColTypes)
+	ForThree (plcColName, plColNames,
+			plcColType, plColTypes,
+			plcColTypeModifier, plColTypeModifiers)
 	{
 		Value *pvalue = (Value *) lfirst(plcColName);
 		Oid coltype = lfirst_oid(plcColType);
+		INT iTypeModifier = lfirst_int(plcColTypeModifier);
 
 		CHAR *szColName = strVal(pvalue);
 		CWStringDynamic *pstrColName = CDXLUtils::PstrFromSz(pmp, szColName);
@@ -478,6 +484,7 @@ CTranslatorUtils::PdrgdxlcdRecord
 										pidgtor->UlNextId(),
 										INT(ul + 1) /* iAttno */,
 										pmdidColType,
+										iTypeModifier,
 										false /* fColDropped */
 										);
 		pdrgdxlcd->Append(pdxlcd);
@@ -522,6 +529,8 @@ CTranslatorUtils::PdrgdxlcdRecord
 		IMDId *pmdidColType = (*pdrgpmdidOutArgTypes)[ul];
 		pmdidColType->AddRef();
 
+		// This function is only called to construct column descriptors for table-valued functions
+		// which won't have type modifiers for columns of the returned table
 		CDXLColDescr *pdxlcd = GPOS_NEW(pmp) CDXLColDescr
 										(
 										pmp,
@@ -529,6 +538,7 @@ CTranslatorUtils::PdrgdxlcdRecord
 										pidgtor->UlNextId(),
 										INT(ul + 1) /* iAttno */,
 										pmdidColType,
+										IDefaultTypeModifier,
 										false /* fColDropped */
 										);
 		pdrgdxlcd->Append(pdxlcd);
@@ -552,6 +562,7 @@ CTranslatorUtils::PdrgdxlcdBase
 	IMemoryPool *pmp,
 	CIdGenerator *pidgtor,
 	IMDId *pmdidRetType,
+	INT iTypeModifier,
 	CMDName *pmdName
 	)
 {
@@ -567,6 +578,7 @@ CTranslatorUtils::PdrgdxlcdBase
 									pidgtor->UlNextId(),
 									INT(1) /* iAttno */,
 									pmdidRetType,
+									iTypeModifier, /* iTypeModifier */
 									false /* fColDropped */
 									);
 
@@ -611,6 +623,7 @@ CTranslatorUtils::PdrgdxlcdComposite
 										pidgtor->UlNextId(),
 										INT(ul + 1) /* iAttno */,
 										pmdidColType,
+										pmdcol->ITypeModifier(), /* iTypeModifier */
 										false /* fColDropped */
 										);
 		pdrgdxlcd->Append(pdxlcd);
@@ -1611,6 +1624,7 @@ CTranslatorUtils::Pdxlcd
 
 	// create a column descriptor
 	OID oidType = gpdb::OidExprType((Node *) pte->expr);
+	INT iTypeModifier = gpdb::IExprTypeMod((Node *) pte->expr);
 	CMDIdGPDB *pmdidColType = GPOS_NEW(pmp) CMDIdGPDB(oidType);
 	CDXLColDescr *pdxlcd = GPOS_NEW(pmp) CDXLColDescr
 									(
@@ -1619,6 +1633,7 @@ CTranslatorUtils::Pdxlcd
 									ulColId,
 									ulPos, /* attno */
 									pmdidColType,
+									iTypeModifier, /* iTypeModifier */
 									false /* fColDropped */
 									);
 
@@ -1646,7 +1661,7 @@ CTranslatorUtils::PdxlnDummyPrElem
 
 	// create a column reference for the scalar identifier to be casted
 	CMDName *pmdname = GPOS_NEW(pmp) CMDName(pmp, pdxlcdOutput->Pmdname()->Pstr());
-	CDXLColRef *pdxlcr = GPOS_NEW(pmp) CDXLColRef(pmp, pmdname, ulColIdInput, pmdidCopy);
+	CDXLColRef *pdxlcr = GPOS_NEW(pmp) CDXLColRef(pmp, pmdname, ulColIdInput, pmdidCopy, pdxlcdOutput->ITypeModifier());
 	CDXLScalarIdent *pdxlopIdent = GPOS_NEW(pmp) CDXLScalarIdent(pmp, pdxlcr);
 
 	CDXLNode *pdxlnPrEl = GPOS_NEW(pmp) CDXLNode
@@ -2388,6 +2403,7 @@ CTranslatorUtils::PdxlnPrElNull
 										(
 										pmp,
 										pmdid,
+										IDefaultTypeModifier,
 										fByValue /*fConstByVal*/,
 										true /*fConstNull*/,
 										NULL, /*pba */

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -657,6 +657,11 @@ namespace gpdb {
 		 (cell1) != NULL && (cell2) != NULL;						\
 		 (cell1) = lnext(cell1), (cell2) = lnext(cell2))
 
+#define ForThree(cell1, list1, cell2, list2, cell3, list3)							\
+	for ((cell1) = gpdb::PlcListHead(list1), (cell2) = gpdb::PlcListHead(list2), (cell3) = gpdb::PlcListHead(list3);	\
+		 (cell1) != NULL && (cell2) != NULL && (cell3) != NULL;						\
+		 (cell1) = lnext(cell1), (cell2) = lnext(cell2), (cell3) = lnext(cell3))
+
 #define ForEachWithCount(cell, list, counter) \
 	for ((cell) = gpdb::PlcListHead(list), (counter)=0; \
 	     (cell) != NULL; \

--- a/src/include/gpopt/translate/CMappingElementColIdParamId.h
+++ b/src/include/gpopt/translate/CMappingElementColIdParamId.h
@@ -46,10 +46,12 @@ namespace gpdxl
 			// param type
 			IMDId *m_pmdid;
 
+			INT m_iTypeModifier;
+
 		public:
 
 			// ctors and dtor
-			CMappingElementColIdParamId(ULONG ulColId, ULONG ulParamId, IMDId *pmdid);
+			CMappingElementColIdParamId(ULONG ulColId, ULONG ulParamId, IMDId *pmdid, INT iTypeModifier);
 
 			virtual
 			~CMappingElementColIdParamId()
@@ -71,6 +73,11 @@ namespace gpdxl
 			IMDId *PmdidType() const
 			{
 				return m_pmdid;
+			}
+
+			INT ITypeModifier() const
+			{
+				return m_iTypeModifier;
 			}
 	};
 }

--- a/src/include/gpopt/translate/CTranslatorDXLToScalar.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToScalar.h
@@ -331,6 +331,12 @@ namespace gpdxl
 			CTranslatorDXLToScalar(const CTranslatorDXLToScalar&);
 
 		public:
+			struct STypeOidAndTypeModifier
+			{
+				OID OidType;
+				INT ITypeModifier;
+			};
+
 			// ctor
 			CTranslatorDXLToScalar(IMemoryPool *pmp, CMDAccessor *pmda, ULONG ulSegments);
 

--- a/src/include/gpopt/translate/CTranslatorScalarToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorScalarToDXL.h
@@ -434,6 +434,7 @@ namespace gpdxl
 				(
 				IMemoryPool *pmp,
 				const IMDType *pmdtype,
+				INT iTypeModifier,
 				BOOL fNull,
 				ULONG ulLen,
 				Datum datum
@@ -547,6 +548,7 @@ namespace gpdxl
 				(
 				IMemoryPool *pmp,
 				const IMDType *pmdtype,
+				INT iTypeModifier,
 				BOOL fNull,
 				ULONG ulLen,
 				Datum datum

--- a/src/include/gpopt/translate/CTranslatorUtils.h
+++ b/src/include/gpopt/translate/CTranslatorUtils.h
@@ -170,7 +170,8 @@ namespace gpdxl
 						IMemoryPool *pmp,
 						CIdGenerator *pidgtor,
 						List *plColNames,
-						List *plColTypes
+						List *plColTypes,
+						List *plColTypeModifiers
 						);
 
 			// get column descriptors from a record type
@@ -190,6 +191,7 @@ namespace gpdxl
 						IMemoryPool *pmp,
 						CIdGenerator *pidgtor,
 						IMDId *pmdidRetType,
+						INT iTypeModifier,
 						CMDName *pmdName
 						);
 


### PR DESCRIPTION
ORCA has historically ignored type modifiers from databases that support them, noticeably Postgres and Greenplum. This has led to surprises in a few cases:

1. The output description over the wire (for Postgres protocol) will lose the type modifier information, which often meant length. This surprises code that expects a non-default type modifier, e.g. a JDBC driver.

2. The executor in some cases -- notably DML -- expects a precise type modifier. Because ORCA always erases the type modifiers and presents a default, the executor is forced to find that information elsewhere.

After this commit, ORCA will be aware of type modifiers in table columns, scalar identifiers, constants, and length-coercion casts.


Signed-off-by: Jesse Zhang <sbjesse@gmail.com>

Need to be reviewed with https://github.com/greenplum-db/gporca/pull/329