### PR TITLE
Keep assertion specific declarations to assertion builds

### DIFF
--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -552,9 +552,11 @@ apply_motion_mutator(Node *node, ApplyMotionState *context)
 	int			saveNextMotionID;
 	int			saveNumInitPlans;
 	int			saveSliceDepth;
-	PlannerInfo *root = (PlannerInfo *) context->base.node;
 
+#ifdef USE_ASSERT_CHECKING
+	PlannerInfo *root = (PlannerInfo *) context->base.node;
 	Assert(root && IsA(root, PlannerInfo));
+#endif
 
 	if (node == NULL)
 		return NULL;

--- a/src/backend/cdb/cdbsubselect.c
+++ b/src/backend/cdb/cdbsubselect.c
@@ -600,11 +600,9 @@ convert_EXPR_to_join(PlannerInfo *root, OpExpr *opexp)
 		 * Construct the join expression involving the new pulled up subselect.
 		 */
 		Assert(list_length(root->parse->jointree->fromlist) == 1);
-		Node	   *larg = lfirst(list_head(root->parse->jointree->fromlist));	/* represents the
-																				 * top-level join tree
-																				 * entry */
 
-		Assert(larg != NULL);
+		/* represents the top-level join tree entry */
+		Assert(linitial(root->parse->jointree->fromlist) != NULL);
 
 		JoinExpr   *join_expr = make_join_expr(NULL, rteIndex, JOIN_INNER);
 

--- a/src/backend/nodes/tidbitmap.c
+++ b/src/backend/nodes/tidbitmap.c
@@ -735,7 +735,9 @@ tbm_generic_iterate(GenericBMIterator *iterator)
 	{
 		case T_TIDBitmap:
 			{
+#ifdef USE_ASSERT_CHECKING
 				const TIDBitmap *hashBitmap = (const TIDBitmap *) tbm;
+#endif
 				TBMIterator *hashIterator = iterator->impl.hash;
 
 				Assert(hashIterator->tbm == hashBitmap);

--- a/src/backend/utils/sort/tuplestorenew.c
+++ b/src/backend/utils/sort/tuplestorenew.c
@@ -172,10 +172,12 @@ nts_page_set_first_valid_slotn(NTupleStorePage *page, int fs)
 {
 	page->header.first_slot = fs;
 }
+#if USE_ASSERT_CHECKING
 static inline int nts_page_valid_slot_cnt(NTupleStorePage *page)
 {
 	return nts_page_slot_cnt(page) - nts_page_first_valid_slotn(page);
 }
+#endif
 static inline NTupleStorePageSlotEntry *nts_page_slot_entry(NTupleStorePage *page, int slotn)
 {
 	return &(page->slot[-slotn]);


### PR DESCRIPTION
When building without assertions, any storage allocated for an assertion will generate a compiler warning for unused variable or function. Wrap all such locations in the `USE_ASSERT_CHECKING`
macro to remove warnings.