### PR TITLE
Remove workarounds for bug in ancient macOS version

### DIFF
--- a/src/backend/commands/tablespace.c
+++ b/src/backend/commands/tablespace.c
@@ -735,10 +735,6 @@ destroy_tablespace_directories(Oid tablespaceoid, bool redo)
 			strcmp(de->d_name, "..") == 0)
 			continue;
 
-		/* Odd... On snow leopard, we get back "/" as a subdir, which is wrong. Ingore it */
-		if (de->d_name[0] == '/' && de->d_name[1] == '\0')
-			continue;
-
 		subfile = palloc(strlen(linkloc_with_version_dir) + 1 + strlen(de->d_name) + 1);
 		sprintf(subfile, "%s/%s", linkloc_with_version_dir, de->d_name);
 
@@ -819,9 +815,6 @@ directory_is_empty(const char *path)
 	{
 		if (strcmp(de->d_name, ".") == 0 ||
 			strcmp(de->d_name, "..") == 0)
-			continue;
-		/* Odd... On snow leopard, we get back "/" as a subdir, which is wrong. Ingore it */
-		if (de->d_name[0] == '/' && de->d_name[1] == '\0')
 			continue;
 		FreeDir(dirdesc);
 		return false;


### PR DESCRIPTION
The referenced bug does not affect modern versions of macOS (tested back to El Capitan), and Snow Leopard is EOL since long. Remove the workarounds which aligns the code with upstream.

This workaround is not present/needed in PostgreSQL, with the code running on [Leopard](https://buildfarm.postgresql.org/cgi-bin/show_history.pl?nm=locust&br=HEAD) as well as [Snow Leopard (at latest patchlevel)](https://buildfarm.postgresql.org/cgi-bin/show_history.pl?nm=dromedary&br=HEAD) in the buildfarm without issues, so it seems questionable that this is a problem even in Snow Leopard anymore.