### PR TITLE
gprecoverseg incremental should fail if sync error is found

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -621,6 +621,8 @@ class GpRecoverSegmentProgram:
                 self.syncPackages(new_hosts)
 
             if not mirrorBuilder.buildMirrors("recover", gpEnv, gpArray):
+                self.trigger_fts_probe(gpArray)
+                self.logger.fatal("Full segment recovery may be required.")
                 sys.exit(1)
 
             confProvider.sendPgElogFromMaster("Recovery of %d segment(s) has been started." % \


### PR DESCRIPTION
During gprecoverseg incremental recovery, the mirrors are started and
begins syncing with their respective primaries. If a primary does not
have the XLOG requested by the mirror, the mirror is pretty much
unrecoverable and needs to be reinitialized by using gprecoverseg full
recovery.

We now detect this by starting the mirrors and checking the
sync_errors column in gp_stat_replication. If a sync_error is found,
the mirror is stopped and full recovery is suggested to the user for
any mirrors unable to undergo incremental recovery.