### PR TITLE
Remove the custom_variable_classes parameter.

### DIFF
--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -54,9 +54,6 @@
             <li>
               <xref href="#cursor_tuple_fraction"/>
             </li>
-            <li>
-              <xref href="#custom_variable_classes"/>
-            </li>
             <li><xref href="#data_checksums" format="dita"/></li>
             <li>
               <xref href="#DateStyle"/>
@@ -1273,35 +1270,6 @@
               <entry colname="col1">integer</entry>
               <entry colname="col2">1</entry>
               <entry colname="col3">master<p>session</p><p>reload</p></entry>
-            </row>
-          </tbody>
-        </tgroup>
-      </table>
-    </body>
-  </topic>
-  <topic id="custom_variable_classes">
-    <title>custom_variable_classes</title>
-    <body>
-      <p>Specifies one or several class names to be used for custom variables. A custom variable is
-        a variable not normally known to the server but used by some add-on modules. Such variables
-        must have names consisting of a class name, a dot, and a variable name.</p>
-      <table id="custom_variable_classes_table">
-        <tgroup cols="3">
-          <colspec colnum="1" colname="col1" colwidth="1*"/>
-          <colspec colnum="2" colname="col2" colwidth="1*"/>
-          <colspec colnum="3" colname="col3" colwidth="1*"/>
-          <thead>
-            <row>
-              <entry colname="col1">Value Range</entry>
-              <entry colname="col2">Default</entry>
-              <entry colname="col3">Set Classifications</entry>
-            </row>
-          </thead>
-          <tbody>
-            <row>
-              <entry colname="col1">comma-separated list of class names</entry>
-              <entry colname="col2">unset</entry>
-              <entry colname="col3">local<p>system</p><p>restart</p></entry>
             </row>
           </tbody>
         </tgroup>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -21,7 +21,6 @@
             <topicref href="guc-list.xml#cpu_operator_cost"/>
             <topicref href="guc-list.xml#cpu_tuple_cost"/>
             <topicref href="guc-list.xml#cursor_tuple_fraction"/>
-            <topicref href="guc-list.xml#custom_variable_classes"/>
             <topicref href="guc-list.xml#data_checksums"/>
             <topicref href="guc-list.xml#DateStyle"/>
             <topicref href="guc-list.xml#db_user_namespace"/>

--- a/src/backend/utils/misc/guc-file.l
+++ b/src/backend/utils/misc/guc-file.l
@@ -136,7 +136,6 @@ ProcessConfigFile(GucContext context)
 				   *head,
 				   *tail;
 	char	   *cvc = NULL;
-	struct config_string *cvc_struct;
 	const char *envvar;
 	int			i;
 
@@ -169,41 +168,6 @@ ProcessConfigFile(GucContext context)
 		goto cleanup_list;
 
 	/*
-	 * We need the proposed new value of custom_variable_classes to check
-	 * custom variables with.  ParseConfigFile ensured that if it's in
-	 * the file, it's first in the list.  But first check to see if we
-	 * have an active value from the command line, which should override
-	 * the file in any case.  (Since there's no relevant env var, the
-	 * only possible nondefault sources are the file and ARGV.)
-	 */
-	cvc_struct = (struct config_string *)
-		find_option("custom_variable_classes", false, elevel);
-	if (cvc_struct && cvc_struct->gen.reset_source > PGC_S_FILE)
-	{
-		cvc = guc_strdup(elevel, cvc_struct->reset_val);
-		if (cvc == NULL)
-			goto cleanup_list;
-	}
-	else if (head != NULL &&
-			 guc_name_compare(head->name, "custom_variable_classes") == 0)
-	{
-		/*
-		 * Need to canonicalize the value via the assign hook.  Casting away
-		 * const is a bit ugly, but we know the result is malloc'd.
-		 */
-		cvc = (char *) assign_custom_variable_classes(head->value,
-													  false, PGC_S_FILE);
-		if (cvc == NULL)
-		{
-			ereport(elevel,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("invalid value for parameter \"%s\": \"%s\"",
-							head->name, head->value)));
-			goto cleanup_list;
-		}
-	}
-
-	/*
 	 * Mark all extant GUC variables as not present in the config file.
 	 * We need this so that we can tell below which ones have been removed
 	 * from the file since we last processed it.
@@ -232,6 +196,7 @@ ProcessConfigFile(GucContext context)
 			 * of custom_variable_classes.  If so, reject.  We don't care
 			 * which side is at fault.
 			 */
+#if 0
 			if (!is_custom_class(item->name, sep - item->name, cvc))
 			{
 				ereport(elevel,
@@ -240,6 +205,7 @@ ProcessConfigFile(GucContext context)
 								item->name)));
 				goto cleanup_list;
 			}
+#endif
 			/*
 			 * 2. There is no GUC entry.  If we called set_config_option then
 			 * it would make a placeholder, which we don't want to do yet,
@@ -558,40 +524,6 @@ ParseConfigFp(FILE *fp, const char *config_file, int depth, int elevel,
 			yy_switch_to_buffer(lex_buffer);
 			pfree(opt_name);
 			pfree(opt_value);
-		}
-		else if (guc_name_compare(opt_name, "custom_variable_classes") == 0)
-		{
-			/*
-			 * This variable must be processed first as it controls
-			 * the validity of other variables; so it goes at the head
-			 * of the result list.  If we already found a value for it,
-			 * replace with this one.
-			 */
-			item = *head_p;
-			if (item != NULL &&
-				guc_name_compare(item->name, "custom_variable_classes") == 0)
-			{
-				/* replace existing head item */
-				pfree(item->name);
-				pfree(item->value);
-				item->name = opt_name;
-				item->value = opt_value;
-				item->filename = pstrdup(config_file);
-				item->sourceline = ConfigFileLineno-1;
-			}
-			else
-			{
-				/* prepend to list */
-				item = palloc(sizeof *item);
-				item->name = opt_name;
-				item->value = opt_value;
-				item->filename = pstrdup(config_file);
-				item->sourceline = ConfigFileLineno-1;
-				item->next = *head_p;
-				*head_p = item;
-				if (*tail_p == NULL)
-					*tail_p = item;
-			}
 		}
 		else
 		{

--- a/src/backend/utils/misc/postgresql.conf.sample
+++ b/src/backend/utils/misc/postgresql.conf.sample
@@ -550,4 +550,4 @@ gp_vmem_protect_limit = 8192  #Virtual memory limit (in MB).
 # CUSTOMIZED OPTIONS
 #------------------------------------------------------------------------------
 
-#custom_variable_classes = ''			# list of custom variable class names
+# Add settings for extensions here

--- a/src/pl/plperl/expected/plperl_init.out
+++ b/src/pl/plperl/expected/plperl_init.out
@@ -1,5 +1,5 @@
 -- test plperl.on_plperl_init errors are fatal
--- Avoid need for custom_variable_classes = 'plperl'
+-- Must load plperl before we can set on_plperl_init
 LOAD 'plperl';
 SET SESSION plperl.on_plperl_init = ' system("/nonesuch"); ';
 SHOW plperl.on_plperl_init;

--- a/src/pl/plperl/expected/plperl_shared.out
+++ b/src/pl/plperl/expected/plperl_shared.out
@@ -1,6 +1,6 @@
 -- test plperl.on_plperl_init via the shared hash
 -- (must be done before plperl is first used)
--- Avoid need for custom_variable_classes = 'plperl'
+-- Must load plperl before we can set on_plperl_init
 LOAD 'plperl';
 -- testing on_plperl_init gets run, and that it can alter %_SHARED
 SET plperl.on_plperl_init = '$_SHARED{on_init} = 42';

--- a/src/pl/plperl/expected/plperlu.out
+++ b/src/pl/plperl/expected/plperlu.out
@@ -1,6 +1,6 @@
 -- Use ONLY plperlu tests here. For plperl/plerlu combined tests
 -- see plperl_plperlu.sql
--- Avoid need for custom_variable_classes = 'plperl'
+-- Must load plperl before we can set on_plperlu_init
 LOAD 'plperl';
 -- Test plperl.on_plperlu_init gets run
 SET plperl.on_plperlu_init = '$_SHARED{init} = 42';

--- a/src/pl/plperl/sql/plperl_init.sql
+++ b/src/pl/plperl/sql/plperl_init.sql
@@ -1,6 +1,6 @@
 -- test plperl.on_plperl_init errors are fatal
 
--- Avoid need for custom_variable_classes = 'plperl'
+-- Must load plperl before we can set on_plperl_init
 LOAD 'plperl';
 
 SET SESSION plperl.on_plperl_init = ' system("/nonesuch"); ';

--- a/src/pl/plperl/sql/plperl_shared.sql
+++ b/src/pl/plperl/sql/plperl_shared.sql
@@ -1,7 +1,7 @@
 -- test plperl.on_plperl_init via the shared hash
 -- (must be done before plperl is first used)
 
--- Avoid need for custom_variable_classes = 'plperl'
+-- Must load plperl before we can set on_plperl_init
 LOAD 'plperl';
 
 -- testing on_plperl_init gets run, and that it can alter %_SHARED

--- a/src/pl/plperl/sql/plperlu.sql
+++ b/src/pl/plperl/sql/plperlu.sql
@@ -1,7 +1,7 @@
 -- Use ONLY plperlu tests here. For plperl/plerlu combined tests
 -- see plperl_plperlu.sql
 
--- Avoid need for custom_variable_classes = 'plperl'
+-- Must load plperl before we can set on_plperlu_init
 LOAD 'plperl';
 
 -- Test plperl.on_plperlu_init gets run


### PR DESCRIPTION
In the upcoming PostgreSQL 9.0 merge, validating the custom variable
classes was causing grief in with the new plpgsql.variable_conflict GUC.
If you set that GUC after loading plpgsql in the QD, plpgsql migh still not
be loaded in QE processes. If the GUC was changed in the QD, the QD would
dispatch the new value to QE processes, which threw an error because the
'plpgsql' custom variable class was not defined.

In principle, we would have the same problem with any other GUC added by
a loadable module.

To fix,  cherry-pick upstream commit from 9.2, to remove the GUC and the
validation of custom variable classes altogether. Might as well do that
now, rather than make some temporary work-arounds, since it's a sensible
change that we'll get eventually from upstream anyway.

Upstream commit:

commit 1a00c0ef5368bb7b8ddcb3cf279df36577918ac4
Author: Tom Lane <tgl@sss.pgh.pa.us>
Date:   Tue Oct 4 12:36:18 2011 -0400

    Remove the custom_variable_classes parameter.

    This variable provides only marginal error-prevention capability (since
    it can only check the prefix of a qualified GUC name), and the consensus
    is that that isn't worth the amount of hassle that maintaining the setting
    creates for DBAs.  So, let's just remove it.

    With this commit, the system will silently accept a value for any qualified
    GUC name at all, whether it has anything to do with any known extension or
    not.  (Unqualified names still have to match known built-in settings,
    though; and you will get a WARNING at extension load time if there's an
    unrecognized setting with that extension's prefix.)

    There's still some discussion ongoing about whether to tighten that up and
    if so how; but if we do come up with a solution, it's not likely to look
    anything like custom_variable_classes.