### PR TITLE
Fix bug using for hashing unhashable fields

### DIFF
--- a/src/backend/cdb/cdbsetop.c
+++ b/src/backend/cdb/cdbsetop.c
@@ -26,6 +26,8 @@
 #include "cdb/cdbsetop.h"
 #include "cdb/cdbvars.h"
 #include "cdb/cdbpullup.h"
+#include "cdb/cdbhash.h"
+#include "parser/parse_expr.h"
 
 static Flow *copyFlow(Flow *model_flow, bool withExprs, bool withSort);
 static List *makeHashExprsFromNonjunkTargets(List *targetList);
@@ -400,7 +402,7 @@ makeHashExprsFromNonjunkTargets(List *targetlist)
 	{
 		TargetEntry *tle = (TargetEntry *) lfirst(cell);
 
-		if (!tle->resjunk)
+		if (!tle->resjunk && isGreenplumDbHashable(exprType((Node *) tle->expr)))
 		{
 			hashlist = lappend(hashlist, copyObject(tle->expr));
 		}


### PR DESCRIPTION
got assert in planner when plan contains motion and hash by all fields in select.
when select contains something unhashable like hyperloglog structure.

Maybe using parser/parse_expr.h is invalid, please correct me.