### PR TITLE
Add error code to error, to avoid printing source file name and lineno.

### DIFF
--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -232,7 +232,9 @@ AllocateWriterGang()
 	{
 		if (!GangOK(primaryWriterGang))
 		{
-			elog(ERROR, "could not connect to segment: initialization of segworker group failed");
+			ereport(ERROR,
+					(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
+					 errmsg("could not connect to segment: initialization of segworker group failed")));
 		}
 		else
 		{

--- a/src/test/isolation2/expected/uao_crash_compaction_column.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_column.out
@@ -86,19 +86,19 @@ t
 (1 row)
 3:VACUUM crash_vacuum_in_appendonly_insert;
 ERROR:  fault triggered, fault name:'appendonly_insert' fault type:'panic'  (seg0 127.0.1.1:25432 pid=11542)
-ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:235)
+ERROR:  could not connect to segment: initialization of segworker group failed
 1<:  <... completed>
 ERROR:  Error on receive from seg0 127.0.1.1:25432 pid=11554: server closed the connection unexpectedly
 DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
-ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:235)
+ERROR:  could not connect to segment: initialization of segworker group failed
 2<:  <... completed>
 ERROR:  Error on receive from seg0 127.0.1.1:25432 pid=11564: server closed the connection unexpectedly
 DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
-ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:235)
+ERROR:  could not connect to segment: initialization of segworker group failed
 
 -- wait for segment to complete recovering
 0U: SELECT 1;

--- a/src/test/isolation2/expected/uao_crash_compaction_row.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_row.out
@@ -86,19 +86,19 @@ t
 (1 row)
 3:VACUUM crash_vacuum_in_appendonly_insert;
 ERROR:  fault triggered, fault name:'appendonly_insert' fault type:'panic'  (seg0 127.0.1.1:25432 pid=9756)
-ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:235)
+ERROR:  could not connect to segment: initialization of segworker group failed
 1<:  <... completed>
 ERROR:  Error on receive from seg0 127.0.1.1:25432 pid=9768: server closed the connection unexpectedly
 DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
-ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:235)
+ERROR:  could not connect to segment: initialization of segworker group failed
 2<:  <... completed>
 ERROR:  Error on receive from seg0 127.0.1.1:25432 pid=9779: server closed the connection unexpectedly
 DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
-ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:235)
+ERROR:  could not connect to segment: initialization of segworker group failed
 
 -- wait for segment to complete recovering
 0U: SELECT 1;

--- a/src/test/regress/expected/udf_exception_blocks_panic_scenarios.out
+++ b/src/test/regress/expected/udf_exception_blocks_panic_scenarios.out
@@ -97,7 +97,7 @@ NOTICE:  Releasing segworker groups to finish aborting the transaction.
 ERROR:  DTM error (gathered results from cmd ' Begin Internal Subtransaction') (cdbtm.c:2040)
 DETAIL:  PANIC for debug_dtm_action = 4, debug_dtm_action_protocol =  Begin Internal Subtransaction (postgres.c:1440)  (seg1 127.0.1.1:25433 pid=24563)
 CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 8 during statement block entry
-ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:235)
+ERROR:  could not connect to segment: initialization of segworker group failed
 select * from employees;
 ERROR:  relation "employees" does not exist
 LINE 1: select * from employees;
@@ -113,9 +113,9 @@ DROP TABLE IF EXISTS employees;
 NOTICE:  table "employees" does not exist, skipping
 select test_protocol_allseg(1, 2,'f');
 NOTICE:  Releasing segworker groups to finish aborting the transaction.
-ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:235)
+ERROR:  could not connect to segment: initialization of segworker group failed
 CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 18 during exception cleanup
-ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:235)
+ERROR:  could not connect to segment: initialization of segworker group failed
 select * from employees;
 ERROR:  relation "employees" does not exist
 LINE 1: select * from employees;
@@ -131,9 +131,9 @@ DROP TABLE IF EXISTS employees;
 NOTICE:  table "employees" does not exist, skipping
 select test_protocol_allseg(1, 2,'f');
 NOTICE:  Releasing segworker groups to finish aborting the transaction.
-ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:235)
+ERROR:  could not connect to segment: initialization of segworker group failed
 CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 18 during exception cleanup
-ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:235)
+ERROR:  could not connect to segment: initialization of segworker group failed
 select * from employees;
 ERROR:  relation "employees" does not exist
 LINE 1: select * from employees;
@@ -149,9 +149,9 @@ DROP TABLE IF EXISTS employees;
 NOTICE:  table "employees" does not exist, skipping
 select test_protocol_allseg(1, 2,'f');
 NOTICE:  Releasing segworker groups to finish aborting the transaction.
-ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:235)
+ERROR:  could not connect to segment: initialization of segworker group failed
 CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 17 during exception cleanup
-ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:235)
+ERROR:  could not connect to segment: initialization of segworker group failed
 select * from employees;
 ERROR:  relation "employees" does not exist
 LINE 1: select * from employees;
@@ -167,9 +167,9 @@ DROP TABLE IF EXISTS employees;
 NOTICE:  table "employees" does not exist, skipping
 select test_protocol_allseg(1, 2,'f');
 NOTICE:  Releasing segworker groups to finish aborting the transaction.
-ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:235)
+ERROR:  could not connect to segment: initialization of segworker group failed
 CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 17 during exception cleanup
-ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:235)
+ERROR:  could not connect to segment: initialization of segworker group failed
 select * from employees;
 ERROR:  relation "employees" does not exist
 LINE 1: select * from employees;
@@ -185,9 +185,9 @@ DROP TABLE IF EXISTS employees;
 NOTICE:  table "employees" does not exist, skipping
 select test_protocol_allseg(1, 2,'f');
 NOTICE:  Releasing segworker groups to finish aborting the transaction.
-ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:235)
+ERROR:  could not connect to segment: initialization of segworker group failed
 CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 17 during exception cleanup
-ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:235)
+ERROR:  could not connect to segment: initialization of segworker group failed
 select * from employees;
 ERROR:  relation "employees" does not exist
 LINE 1: select * from employees;


### PR DESCRIPTION
Internal errors, i.e. errors without an error code, have the source file
name and line number appended to the error message. That's troublesome for
regression tests, as the line number needs to be memorized in the expected
output. Use a proper error code, to avoid that, and because it's nice to
have proper error codes anyway.