### PR TITLE
Improve filerep logging

### DIFF
--- a/src/backend/cdb/cdbfilerep.c
+++ b/src/backend/cdb/cdbfilerep.c
@@ -1787,7 +1787,8 @@ void
 FileRep_InsertConfigLogEntryInternal(char		*description,
 									 const char *fileName,
 									 int		lineNumber,
-									 const char *funcName)
+									 const char *funcName,
+									 bool printStack)
 {
 	char		temp[128];
 	char		buftime[128];
@@ -1819,7 +1820,8 @@ FileRep_InsertConfigLogEntryInternal(char		*description,
 						getpid(),
 						fileName,
 						lineNumber,
-						funcName)));
+						funcName),
+				errprintstack(printStack)));
 		return;
 	}
 
@@ -2437,7 +2439,14 @@ FileRep_SetSegmentState(SegmentState_e segmentState, FaultType_e faultType)
 		SendPostmasterSignal(PMSIGNAL_FILEREP_STATE_CHANGE);
 	}
 
-	FileRep_InsertConfigLogEntry("set segment state");
+	if (segmentState == SegmentStateFault)
+	{
+		FileRep_InsertConfigLogEntry_PrintStack("set segment state");
+	}
+	else
+	{
+		FileRep_InsertConfigLogEntry("set segment state");	
+	}
 }
 
 void

--- a/src/backend/postmaster/primary_mirror_mode.c
+++ b/src/backend/postmaster/primary_mirror_mode.c
@@ -1185,7 +1185,7 @@ requestTransitionToPrimaryMirrorMode(PrimaryMirrorModeTransitionArguments *args,
 	assertModuleInitialized();
 	targetMode = args->mode;
 
-	elog(getPrimaryMirrorModeDebugLogLevel(true),
+	elog(LOG,
 		 "PrimaryMirrorTransitionRequest: to primary/mirror mode %s, "
 		 "data state %s, host %s, port %d, peer %s, peerPort %d%s%s",
 		 getMirrorModeLabel(targetMode), getDataStateLabel(args->dataState),

--- a/src/include/cdb/cdbfilerep.h
+++ b/src/include/cdb/cdbfilerep.h
@@ -1214,12 +1214,17 @@ extern	void FileRep_InsertLogEntry(
 									uint32					fileRepMessageCount);
 
 #define FileRep_InsertConfigLogEntry(description)	\
-			FileRep_InsertConfigLogEntryInternal(description, __FILE__, __LINE__, PG_FUNCNAME_MACRO)
+			FileRep_InsertConfigLogEntryInternal(description, __FILE__, __LINE__, PG_FUNCNAME_MACRO, false)
+
+#define FileRep_InsertConfigLogEntry_PrintStack(description)	\
+			FileRep_InsertConfigLogEntryInternal(description, __FILE__, __LINE__, PG_FUNCNAME_MACRO, true)
+
 
 extern void	FileRep_InsertConfigLogEntryInternal(char		*description,
 												 const char *fileName,
 												 int		lineNumber,
-												 const char *funcName);
+												 const char *funcName,
+												 bool printStack);
 
 extern void FileRep_Sleep1ms(int retry);
 extern void FileRep_Sleep10ms(int retry);


### PR DESCRIPTION
In many cases, when a segment sets a fault, or receives a transition message from another source, no breadcrumbs are left behind to suggest how or why this happened. Now, when a client connection is created to transition a segment from one state to another, we will log that connection had taken place. In addition, any time that a segment sets a filerep fault, we will print a stack trace to help us understand why it has done so.