### PR TITLE
Correct log message for inProgressXid in createDtxSnapshot().

### DIFF
--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -2474,7 +2474,7 @@ createDtxSnapshot(
 
 		elog(DTM_DEBUG5,
 			 "createDtxSnapshot added inProgressDistributedXid = %u to snapshot",
-			 ds->inProgressXidArray[count]);
+			 inProgressXid);
 	}
 
 	distribSnapshotId = (*shmNextSnapshotId)++;


### PR DESCRIPTION
The `count++` above log message invalidates `inProgressXid` printed in log
message.