### PR TITLE
Make resgroup work on Ubuntu

### DIFF
--- a/concourse/scripts/ic_gpdb_ubuntu.bash
+++ b/concourse/scripts/ic_gpdb_ubuntu.bash
@@ -94,12 +94,15 @@ function _main() {
     time configure
     time setup_gpadmin_user
     time make_cluster
-	if [ "$RESOURCE_MANAGER" != group ]; then
+	if [ "$RESOURCE_MANAGER" = group ]; then
+		time gen_icw_test_script
+		time run_icw_test
+	else
 		time gen_unit_test_script
 		time gen_icw_test_script
 		time run_unit_test
+		time run_icw_test
 	fi
-	time run_icw_test
 }
 
 _main "$@"

--- a/concourse/scripts/ic_gpdb_ubuntu.bash
+++ b/concourse/scripts/ic_gpdb_ubuntu.bash
@@ -11,9 +11,6 @@ mount_cgroups() {
     local options=rw,nosuid,nodev,noexec,relatime
     local groups="cpuset blkio cpuacct cpu memory"
 
-	# TODO: verify cgroup dirs are already properly mounted
-	return
-
 	mkdir -p $basedir
 	mount -t tmpfs tmpfs $basedir
 	for group in $groups; do

--- a/concourse/scripts/ic_gpdb_ubuntu.bash
+++ b/concourse/scripts/ic_gpdb_ubuntu.bash
@@ -11,23 +11,23 @@ mount_cgroups() {
     local options=rw,nosuid,nodev,noexec,relatime
     local groups="cpuset blkio cpuacct cpu memory"
 
-	mkdir -p $basedir
-	mount -t tmpfs tmpfs $basedir
-	for group in $groups; do
-			mkdir -p $basedir/$group
-			mount -t cgroup -o $options,$group cgroup $basedir/$group
-	done
+    mkdir -p $basedir
+    mount -t tmpfs tmpfs $basedir
+    for group in $groups; do
+        mkdir -p $basedir/$group
+        mount -t cgroup -o $options,$group cgroup $basedir/$group
+    done
 }
 
 make_cgroups_dir() {
     local basedir=$CGROUP_BASEDIR
 
-	for comp in cpu cpuacct; do
-		chmod -R 777 $basedir/$comp
-		mkdir -p $basedir/$comp/gpdb
-		chown -R gpadmin:gpadmin $basedir/$comp/gpdb
-		chmod -R 777 $basedir/$comp/gpdb
-	done
+    for comp in cpu cpuacct; do
+        chmod -R 777 $basedir/$comp
+        mkdir -p $basedir/$comp/gpdb
+        chown -R gpadmin:gpadmin $basedir/$comp/gpdb
+        chmod -R 777 $basedir/$comp/gpdb
+    done
 }
 
 function load_transfered_bits_into_install_dir() {
@@ -119,17 +119,17 @@ function _main() {
     time configure
     time setup_gpadmin_user
     time make_cluster
-	if [ "$RESOURCE_MANAGER" = group ]; then
-		time mount_cgroups
-		time make_cgroups_dir
-		time gen_icw_test_script
-		time run_icw_test
-	else
-		time gen_unit_test_script
-		time gen_icw_test_script
-		time run_unit_test
-		time run_icw_test
-	fi
+    if [ "$RESOURCE_MANAGER" = group ]; then
+        time mount_cgroups
+        time make_cgroups_dir
+        time gen_icw_test_script
+        time run_icw_test
+    else
+        time gen_unit_test_script
+        time gen_icw_test_script
+        time run_unit_test
+        time run_icw_test
+    fi
 }
 
 _main "$@"

--- a/concourse/scripts/ic_gpdb_ubuntu.bash
+++ b/concourse/scripts/ic_gpdb_ubuntu.bash
@@ -74,6 +74,7 @@ FEOF
   source ${GREENPLUM_INSTALL_DIR}/greenplum_path.sh
   source \${SRC_DIR}/gpAux/gpdemo/gpdemo-env.sh
   cd \${SRC_DIR}
+  make -C src/test/regress
   make -s ${MAKE_TEST_COMMAND}
 
 EOF

--- a/concourse/scripts/ic_gpdb_ubuntu.bash
+++ b/concourse/scripts/ic_gpdb_ubuntu.bash
@@ -94,10 +94,12 @@ function _main() {
     time configure
     time setup_gpadmin_user
     time make_cluster
-    time gen_unit_test_script
-    time gen_icw_test_script
-    time run_unit_test
-    time run_icw_test
+	if [ "$RESOURCE_MANAGER" != group ]; then
+		time gen_unit_test_script
+		time gen_icw_test_script
+		time run_unit_test
+	fi
+	time run_icw_test
 }
 
 _main "$@"

--- a/concourse/tasks/ic_gpdb_ubuntu.yml
+++ b/concourse/tasks/ic_gpdb_ubuntu.yml
@@ -11,5 +11,6 @@ params:
   WITH_MIRRORS:
   TRANSFER_DIR: compiled_bits_ubuntu16
   COMPILED_BITS_FILENAME: compiled_bits_ubuntu16.tar.gz
+  RESOURCE_MANAGER: queue
 run:
   path: gpdb_src/concourse/scripts/ic_gpdb_ubuntu.bash

--- a/gpMgmt/bin/gpcheckresgroupimpl
+++ b/gpMgmt/bin/gpcheckresgroupimpl
@@ -54,7 +54,6 @@ class cgroup(object):
         self.validate_permission("cpuacct/gpdb/cpuacct.stat", "r")
 
         self.validate_permission("memory/memory.limit_in_bytes", "r")
-        self.validate_permission("memory/memory.memsw.limit_in_bytes", "r")
 
     def die(self, msg):
         exit(self.impl + self.error_prefix + msg)

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckresgroupimpl.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckresgroupimpl.py
@@ -160,11 +160,6 @@ class GpCheckResGroupImplCGroup(unittest.TestCase):
         with self.assertRaisesRegexp(AssertionError, "file '.*/memory/memory.limit_in_bytes' does not exist"):
             self.cgroup.validate_all()
 
-    def test_when_memsw_limit_in_bytes_bad_permission(self):
-        os.chmod(os.path.join(self.cgroup_mntpnt, "memory", "memory.memsw.limit_in_bytes"), 0100)
-        with self.assertRaisesRegexp(AssertionError, "file '.*/memory/memory.memsw.limit_in_bytes' permission denied: require permission 'r'"):
-            self.cgroup.validate_all()
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/test/isolation2/sql/resgroup/resgroup_alter_concurrency.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_alter_concurrency.sql
@@ -276,6 +276,11 @@ ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 1;
 13q:
 14q:
 15q:
+-- start_ignore
+-- The 'q' command returns before the underlying segments all actually quit,
+-- so a following DROP command might fail.  Add a delay here as a workaround.
+SELECT pg_sleep(1);
+-- end_ignore
 
 --
 -- 8. increase concurrency from 0


### PR DESCRIPTION
Some minor fixes/enhancements to make resgroup work on Ubuntu:

- resgroup: add delay in a testcase
- resgroup: retry proc migration for rmdir to succeed
- resgroup: make cgroup memsw.limit_in_bytes optional