### PR TITLE
Make resgroup work on Ubuntu

### DIFF
--- a/gpMgmt/bin/gpcheckresgroupimpl
+++ b/gpMgmt/bin/gpcheckresgroupimpl
@@ -54,7 +54,6 @@ class cgroup(object):
         self.validate_permission("cpuacct/gpdb/cpuacct.stat", "r")
 
         self.validate_permission("memory/memory.limit_in_bytes", "r")
-        self.validate_permission("memory/memory.memsw.limit_in_bytes", "r")
 
     def die(self, msg):
         exit(self.impl + self.error_prefix + msg)

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckresgroupimpl.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckresgroupimpl.py
@@ -160,11 +160,6 @@ class GpCheckResGroupImplCGroup(unittest.TestCase):
         with self.assertRaisesRegexp(AssertionError, "file '.*/memory/memory.limit_in_bytes' does not exist"):
             self.cgroup.validate_all()
 
-    def test_when_memsw_limit_in_bytes_bad_permission(self):
-        os.chmod(os.path.join(self.cgroup_mntpnt, "memory", "memory.memsw.limit_in_bytes"), 0100)
-        with self.assertRaisesRegexp(AssertionError, "file '.*/memory/memory.memsw.limit_in_bytes' permission denied: require permission 'r'"):
-            self.cgroup.validate_all()
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/backend/utils/resgroup/resgroup-ops-linux.c
+++ b/src/backend/utils/resgroup/resgroup-ops-linux.c
@@ -735,13 +735,13 @@ ResGroupOps_CreateGroup(Oid group)
 	 * although the group dir is created the interface files may not be
 	 * created yet, so we check them repeatedly until everything is ready.
 	 */
-	while (++retry <= 10 && !checkPermission(group, false))
+	while (++retry <= MAX_RETRY && !checkPermission(group, false))
 		pg_usleep(1000);
 
-	if (retry > 10)
+	if (retry > MAX_RETRY)
 	{
 		/*
-		 * still not ready after 10 retries, might be a real error,
+		 * still not ready after MAX_RETRY retries, might be a real error,
 		 * raise the error.
 		 */
 		checkPermission(group, true);

--- a/src/backend/utils/resgroup/resgroup-ops-linux.c
+++ b/src/backend/utils/resgroup/resgroup-ops-linux.c
@@ -579,7 +579,7 @@ getCgMemoryInfo(uint64 *cgram, uint64 *cgmemsw)
 	}
 	else
 	{
-		elog(LOG, "swap memory is unlimited");
+		elog(DEBUG1, "swap memory is unlimited");
 		*cgmemsw = (uint64) -1LL;
 	}
 }

--- a/src/test/isolation2/sql/resgroup/resgroup_alter_concurrency.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_alter_concurrency.sql
@@ -276,6 +276,11 @@ ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 1;
 13q:
 14q:
 15q:
+-- start_ignore
+-- The 'q' command returns before the underlying segments all actually quit,
+-- so a following DROP command might fail.  Add a delay here as a workaround.
+SELECT pg_sleep(1);
+-- end_ignore
 
 --
 -- 8. increase concurrency from 0


### PR DESCRIPTION
Some minor fixes/enhancements to make resgroup work on Ubuntu:

- resgroup: add delay in a testcase
- resgroup: retry proc migration for rmdir to succeed
- resgroup: make cgroup memsw.limit_in_bytes optional