### PR TITLE
Make gprecoverseg rebalance work

### DIFF
--- a/gpMgmt/bin/gppylib/operations/rebalanceSegments.py
+++ b/gpMgmt/bin/gppylib/operations/rebalanceSegments.py
@@ -94,7 +94,7 @@ class GpSegmentRebalanceOperation:
                 self.logger.info("=============================START ANOTHER RECOVER=========================================")
                 # import here because GpRecoverSegmentProgram and GpSegmentRebalanceOperation have a circular dependency
                 from gppylib.programs.clsRecoverSegment import GpRecoverSegmentProgram
-                sys.argv = ['gprecoverseg', '-a']
+                sys.argv = ['gprecoverseg', '-aF']
                 local_parser = GpRecoverSegmentProgram.createParser()
                 local_options, args = local_parser.parse_args()
                 cmd = GpRecoverSegmentProgram.createProgram(local_options, args)
@@ -104,7 +104,7 @@ class GpSegmentRebalanceOperation:
                 if e.code != 0:
                     self.logger.error("Failed to start the synchronization step of the segment rebalance.")
                     self.logger.error("Check the gprecoverseg log file, correct any problems, and re-run")
-                    self.logger.error("'gprecoverseg -a'.")
+                    self.logger.error("'gprecoverseg -aF'.")
                     raise Exception("Error synchronizing.\nError: %s" % str(e))
             finally:
                 if cmd:


### PR DESCRIPTION
The gprecoverseg tool has been broken after filerep and persistent
tables were removed. This commit makes rebalance work again by using
full recovery instead of incremental. This commit should maybe be
reverted once pg_rewind is implemented since incremental would then be
usable.

Co-authored-by: Jimmy Yih <jyih@pivotal.io>
Co-authored-by: David Kimura <dkimura@pivotal.io>