### PR TITLE
Update answer files in vacuumFaults TINC tests.

### DIFF
--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/scenario/test_faults.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/scenario/test_faults.py
@@ -51,11 +51,8 @@ class scenario_sql(SQLTestCase):
 @tinctest.skipLoading('scenario')
 class scenario_fault(MPPTestCase):
 
-    def setUp(self):
-        self.filereputil = Filerepe2e_Util()
-
     def inject(self, faultname, faulttype, segid):
-        self.filereputil.inject_fault(f=faultname, y=faulttype, seg_id=segid)
+        Filerepe2e_Util().inject_fault(f=faultname, y=faulttype, seg_id=segid)
 
     def check_connection(self):
         '''

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/scenario/xml/heap_crash_after_truncate.xml
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/scenario/xml/heap_crash_after_truncate.xml
@@ -54,7 +54,7 @@ select pg_relation_size('ivfheap') from gp_dist_random('gp_id') where gp_segment
         <trigger><![CDATA[
 vacuum full vfheap;
 ERROR:  fault triggered, fault name:'vacuum_full_after_truncate' fault type:'checkpoint_and_panic'
-ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:xxx)
+ERROR:  could not connect to segment: initialization of segworker group failed
         ]]></trigger>
         <post><![CDATA[
 select pg_relation_size('vfheap') from gp_dist_random('gp_id') where gp_segment_id = 0;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/scenario/xml/heap_crash_before_truncate.xml
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/scenario/xml/heap_crash_before_truncate.xml
@@ -50,7 +50,7 @@ select pg_relation_size('ivfheap') from gp_dist_random('gp_id') where gp_segment
         <trigger><![CDATA[
 vacuum full vfheap;
 ERROR:  fault triggered, fault name:'vacuum_full_before_truncate' fault type:'panic' (seg0 haradh1-mac.local:40000 pid=15655) (cdbdisp.c:1526)
-ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:xxx)
+ERROR:  could not connect to segment: initialization of segworker group failed
         ]]></trigger>
         <post><![CDATA[
 select pg_relation_size('vfheap') from gp_dist_random('gp_id') where gp_segment_id = 0;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/scenario/xml/heap_update_crash_before_truncate.xml
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/scenario/xml/heap_update_crash_before_truncate.xml
@@ -51,7 +51,7 @@ select pg_relation_size('ivfheap') from gp_dist_random('gp_id') where gp_segment
         <trigger><![CDATA[
 vacuum full vfheap;
 ERROR:  fault triggered, fault name:'vacuum_full_before_truncate' fault type:'panic' (seg0 haradh1-mac.local:40000 pid=15655) (cdbdisp.c:1526)
-ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:xxx)
+ERROR:  could not connect to segment: initialization of segworker group failed
         ]]></trigger>
         <post><![CDATA[
 select pg_relation_size('vfheap') from gp_dist_random('gp_id') where gp_segment_id = 0;


### PR DESCRIPTION
The source file and line number is removed from the answer files because
of a code change that replaced elog(ERROR) with ereport(ERROR) in commit
89b4365e0ab.

Also removed the step to create extension for fault injector from
setUp() method.  That was causing the check_connection() method to
report assert failure if master was recovering from PANIC.

This is a quick fix to make the CI green.  The tests need to be moved
from TINC to isolation2 but that's a separate commit.