### PR TITLE
Fix gprecoverseg Behave tests

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -165,7 +165,7 @@ class GpRecoverSegmentProgram:
             for lineno, line in line_reader(f):
                 fixed, flexible = parse_gprecoverseg_line(filename, lineno, line)
                 rows.append(ParsedConfigFileRow(fixed, flexible, line))
-        fileData = ParsedConfigFile(rows)
+        fileData = ParsedConfigFile([], rows)
 
         allAddresses = [row.getFixedValuesMap()["newAddress"] for row in fileData.getRows()
                         if "newAddress" in row.getFixedValuesMap()]

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -12,7 +12,8 @@ Feature: gprecoverseg tests
         Given the database is running
         And user kills a primary postmaster process
         And user can start transactions
-        When the user runs "gprecoverseg -a"
+        # WALREP_FIXME: Change to incremental once pg_rewind is introduced into gprecoverseg
+        When the user runs "gprecoverseg -F -a"
         Then gprecoverseg should return a return code of 0
         And gprecoverseg should not print "Unhandled exception in thread started by <bound method Worker.__bootstrap" to stdout
         And the segments are synchronized
@@ -31,7 +32,8 @@ Feature: gprecoverseg tests
         And the background pid is killed on "primary" segment
         And we run a sample background script to generate a pid on "primary" segment
         And we generate the postmaster.pid file with the background pid on "primary" segment
-        And the user runs "gprecoverseg -a"
+        # WALREP_FIXME: Change to incremental once pg_rewind is introduced into gprecoverseg
+        And the user runs "gprecoverseg -F -a"
         Then gprecoverseg should return a return code of 0
         And gprecoverseg should not print "Unhandled exception in thread started by <bound method Worker.__bootstrap" to stdout
         And gprecoverseg should print "Skipping to stop segment.* on host.* since it is not a postgres process" to stdout
@@ -53,7 +55,8 @@ Feature: gprecoverseg tests
         And user kills a primary postmaster process
         When user can start transactions
         And we generate the postmaster.pid file with a non running pid on the same "primary" segment
-        And the user runs "gprecoverseg -a"
+        # WALREP_FIXME: Change to incremental once pg_rewind is introduced into gprecoverseg
+        And the user runs "gprecoverseg -F -a"
         Then gprecoverseg should return a return code of 0
         And gprecoverseg should not print "Unhandled exception in thread started by <bound method Worker.__bootstrap" to stdout
         And all the segments are running
@@ -65,82 +68,46 @@ Feature: gprecoverseg tests
         And the backup pid file is deleted on "primary" segment
 
     @multinode
-    Scenario: gprecoverseg full recovery testing, with gpfaultinjector putting cluster into change tracking
+    Scenario: gprecoverseg full recovery testing
         Given the database is running
-        And the database "gptest1" does not exist
         And all the segments are running
         And the segments are synchronized
         And the information of a "mirror" segment on a remote host is saved
-        And user runs the command "gpfaultinjector  -f filerep_consumer  -m async -y fault" with the saved "mirror" segment option
-        Given database "gptest1" exists
-        Then the saved mirror segment is marked down in config
-        And the saved mirror segment process is still running on that host
+        When user kills a "mirror" process with the saved information
         And user can start transactions
+        Then the saved "mirror" segment is marked down in config
         When the user runs "gprecoverseg -F -a"
         Then gprecoverseg should return a return code of 0
         And all the segments are running
-        And user runs the command "gpfaultinjector  -f filerep_consumer  -m async -y reset" with the saved "mirror" segment option
+        And the segments are synchronized
 
     @multinode
     Scenario: gprecoverseg with -i and -o option
         Given the database is running
-        And the database "gptest1" does not exist
         And all the segments are running
         And the segments are synchronized
         And the information of a "mirror" segment on a remote host is saved
-        And user runs the command "gpfaultinjector  -f filerep_consumer  -m async -y fault" with the saved "mirror" segment option
-        Given database "gptest1" exists
-        Then the saved mirror segment is marked down in config
-        And the saved mirror segment process is still running on that host
+        When user kills a "mirror" process with the saved information
         And user can start transactions
+        Then the saved "mirror" segment is marked down in config
         When the user runs "gprecoverseg -o failedSegmentFile"
         Then gprecoverseg should return a return code of 0
         Then gprecoverseg should print "Configuration file output to failedSegmentFile successfully" to stdout
         When the user runs "gprecoverseg -i failedSegmentFile -a"
         Then gprecoverseg should return a return code of 0
         Then gprecoverseg should print "1 segment\(s\) to recover" to stdout
-        And user runs the command "gpfaultinjector  -f filerep_consumer  -m async -y reset" with the saved "mirror" segment option
-
-    @multinode
-    @fail_on_corrupted_change_tracking
-    Scenario: gprecoverseg fails on corrupted change tracking logs, must run full recovery
-        Given the database is running
-        And the database "gptest1" does not exist
         And all the segments are running
         And the segments are synchronized
-        And the information of a "mirror" segment on a remote host is saved
-        And the information of the corresponding primary segment on a remote host is saved
-
-        When user runs the command "gpfaultinjector -f filerep_consumer  -m async -y fault" with the saved "mirror" segment option
-        Given database "gptest1" exists
-        Then the saved mirror segment is marked down in config
-
-        When user runs the command "gpfaultinjector -y skip -f change_tracking_disable" with the saved "primary" segment option
-        Given the database "gptest1" does not exist
-        Then wait until the segment state of the corresponding primary goes in ChangeTrackingDisabled
-
-        When the user runs "gprecoverseg -a"
-        Then gprecoverseg should print "in change tracking disabled state, need to run recoverseg with -F option" to stdout
-        And the saved mirror segment is marked down in config
-
-        When the user runs "gprecoverseg -a -F"
-        Then all the segments are running
-        And the segments are synchronized
-        And user runs the command "gpfaultinjector -y reset -f change_tracking_disable" with the saved "primary" segment option
-        When user runs the command "gpfaultinjector -f filerep_consumer  -m async -y reset" with the saved "mirror" segment option
 
     @multinode
     Scenario: gprecoverseg should not throw exception for empty input file
         Given the database is running
-        And the database "gptest1" does not exist
         And all the segments are running
         And the segments are synchronized
         And the information of a "mirror" segment on a remote host is saved
-        And user runs the command "gpfaultinjector  -f filerep_consumer  -m async -y fault" with the saved "mirror" segment option
-        Given database "gptest1" exists
-        Then the saved mirror segment is marked down in config
-        And the saved mirror segment process is still running on that host
+        When user kills a "mirror" process with the saved information
         And user can start transactions
+        Then the saved "mirror" segment is marked down in config
         When the user runs command "touch /tmp/empty_file"
         When the user runs "gprecoverseg -i /tmp/empty_file -a"
         Then gprecoverseg should return a return code of 0
@@ -148,71 +115,27 @@ Feature: gprecoverseg tests
         When the user runs "gprecoverseg -a -F"
         Then all the segments are running
         And the segments are synchronized
-        And user runs the command "gpfaultinjector  -f filerep_consumer  -m async -y reset" with the saved "mirror" segment option
-
-    Scenario: gprecoverseg does not recover segments with persistent rebuild inconsistencies
-        Given the database is running
-        And the database "gptest1" does not exist
-        And all the segments are running
-        And the segments are synchronized
-        And user runs the command "gpfaultinjector  -f filerep_consumer  -m async -y fault" on segment "0"
-        And user runs the command "gpfaultinjector  -f filerep_consumer  -m async -y fault" on segment "1"
-        Given database "gptest1" exists
-        Then the mirror with content id "0" is marked down in config
-        Then the mirror with content id "1" is marked down in config
-        And segment with content "0" has persistent tables that were rebuilt with mirrors disabled
-        When the user runs "gprecoverseg -a"
-        Then gprecoverseg should return a return code of 0
-        Then verify that segment with content "0" is not recovered
-        Then verify that segment with content "1" is recovered
-        Then delete extra tid persistent table entries on cid "0"
-        When the user runs "gprecoverseg -a -F"
-        Then all the segments are running
-        And the segments are synchronized
-        And user runs the command "gpfaultinjector  -f filerep_consumer  -m async -y reset" on segment "0"
-        And user runs the command "gpfaultinjector  -f filerep_consumer  -m async -y reset" on segment "1"
-
-    Scenario: gprecoverseg -r should not hang when some segments are not yet synchronized
-        Given the database is running
-        And all the segments are running
-        And the segments are synchronized
-        And the information of a "mirror" segment on any host is saved
-        And user runs the command "gpfaultinjector  -f filerep_consumer  -m async -y fault" on segment "0"
-        Given database "gptest1" exists
-        Then the mirror with content id "0" is marked down in config
-        When the user runs "gprecoverseg -F -a"
-        Then gprecoverseg should return a return code of 0
-        Given at least one segment is resynchronized
-        When the user runs "gprecoverseg -r -a"
-        Then gprecoverseg should print "Some segments are not yet synchronized" to stdout
-        Then gprecoverseg should return a return code of 2
-        And the segments are synchronized
-        When the user runs "gprecoverseg -r -a"
-        Then gprecoverseg should return a return code of 0
-        Then all the segments are running
-        And the segments are synchronized
-        And user runs the command "gpfaultinjector  -f filerep_consumer  -m async -y reset" on segment "0"
 
     @multinode
     @gprecoverseg_checksums
     Scenario: gprecoverseg should use the same setting for data_checksums for a full recovery
         Given the database is running
-        And the database "gptest1" does not exist
         And results of the sql "show data_checksums" db "template1" are stored in the context
-        # cause a full recovery AFTER an injected failure on a remote primary
+        # cause a full recovery AFTER a failure on a remote primary
         And all the segments are running
         And the segments are synchronized
         And the information of a "mirror" segment on a remote host is saved
         And the information of the corresponding primary segment on a remote host is saved
-        And user runs the command "gpfaultinjector  -f filerep_consumer  -m async -y fault" with the saved "primary" segment option
-        Given database "gptest1" exists
-        Then the saved mirror segment is marked down in config
-        And the saved mirror segment process is still running on that host
+        When user kills a "primary" process with the saved information
         And user can start transactions
+        Then the saved "primary" segment is marked down in config
         When the user runs "gprecoverseg -F -a"
         Then gprecoverseg should return a return code of 0
         And gprecoverseg should print "Heap checksum setting is consistent between master and the segments that are candidates for recoverseg" to stdout
+        When the user runs "gprecoverseg -ra"
+        Then gprecoverseg should return a return code of 0
+        And gprecoverseg should print "Heap checksum setting is consistent between master and the segments that are candidates for recoverseg" to stdout
         And all the segments are running
+        And the segments are synchronized
         # validate the the new segment has the correct setting by getting admin connection to that segment
         Then the saved primary segment reports the same value for sql "show data_checksums" db "template1" as was saved
-        And user runs the command "gpfaultinjector  -f filerep_consumer  -m async -y reset" with the saved "primary" segment option

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1843,16 +1843,6 @@ def impl(_):
         if not timestamp in file:
             raise Exception("file found containing inconsistent timestamp")
 
-
-@when('user kills a mirror process with the saved information')
-def impl(context):
-    cmdStr = "ps ux | grep '[m]irror process' | grep %s  | awk '{print $2}'" % context.mirror_port
-    cmd = Command(name='get mirror pid: %s' % cmdStr, cmdStr=cmdStr)
-    cmd.run()
-    pid = cmd.get_stdout_lines()[0]
-    kill_process(int(pid), context.mirror_segdbname, sig=signal.SIGABRT)
-
-
 @when('user temporarily moves the data directory of the killed mirror')
 @then('user temporarily moves the data directory of the killed mirror')
 def impl(context):


### PR DESCRIPTION
After filerep, filespaces, and persistent tables were removed, we
disabled the gprecoverseg Behave tests which needed gprecoverseg to be
refactored before the tests could run. Currently, gprecoverseg is in a
usable state so it's time to fix these Behave tests and have them
running again. Some refactoring, workarounds, and test removal was
needed which is detailed here.

Refactoring:
1. The tests used gpfaultinjector to cause a mirror or primary down
situation. This is not really needed and just killing the segments is
good enough. Also, injecting a fault on a mirror doesn't really do
anything anymore because it would not trigger due to the mirror being
in recovery mode.
2. The checksum test did not look correct so we refactored it to what
we think it was suppose to look like.

Workaround:
Running incremental recovery after killing a primary to trigger
failover will not work without pg_rewind.  These calls have been
changed to use full recovery similar to how gprecoverseg rebalancing
works right now. Once pg_rewind is introduced, they should be changed
back to use incremental recovery.

Test Removal:
1. A scenario checked for failure when there were corrupted
changetracking logs. If corrupted, a full recovery must be run. We
delete this test since changetracking logs are no longer a
thing. However, this scenario is very similar to our src/test/walrep
missing_xlogs test. That might be good enough as a low-level
replacement but we may want to add a full end-to-end scenario back in
these Behave tests.
2. A scenario checked that gprecoverseg would not recover segments
with persistent rebuild inconsistencies. Persistent tables no longer
exist so the scenario is okay to remove.