### PR TITLE
More flexible docker container based on Ubuntu 16

### DIFF
--- a/src/tools/docker/ubuntu-16.04-persistent/Dockerfile
+++ b/src/tools/docker/ubuntu-16.04-persistent/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:16.04
+EXPOSE 5432
+
+ADD container_init.sh /container_init.sh
+ADD gpdb_start.sh /gpdb_start.sh
+
+CMD bash /container_init.sh && tail -f /dev/null
+

--- a/src/tools/docker/ubuntu-16.04-persistent/README.md
+++ b/src/tools/docker/ubuntu-16.04-persistent/README.md
@@ -1,0 +1,40 @@
+# Docker container of Greenplum DB based on Ubuntu 16
+
+This container raises the Greenplum database in "Single Instance" mode (master and two segments in one docker container). Use docker `-v` to mount host data directory to the container `/data` directory (as in example below).
+
+This dockerfile is using PPA for Ubuntu 16 — https://launchpad.net/~greenplum/+archive/ubuntu/db
+
+## Build and run
+```
+$ docker build -t local/gpdb .
+$ docker run -d -p 5432:5432 -h dwgpdb -v /srv/data/:/data local/gpdb
+```
+The host name `dwgpdb` is strongly required to initializing the database properly with the same data from `/data` directory after restarting or rebuilding the container.
+
+## The first connect to GPDB from the host
+```
+# apt-get install postgresql-client-9.5
+$ psql -h 127.0.0.1 -p 5432 -U gpadmin
+Password: gppassword
+gpadmin=# select version();
+```
+Check the docker logs if the connection is failed:
+```
+$ docker ps -a
+$ docker logs --follow <GPDB_CONTAINDER_ID>
+```
+
+## Using gp-utils in container
+File `greenplum_path.sh` added to `.bashrc` of `gpmaster` user so you can use gp-utils immediately in container:
+```
+$ docker ps
+$ docker exec -it <GPDB_CONTAINER_ID> bash
+# su gpadmin
+$ gpstate
+```
+
+## Stop database
+```
+$ docker ps
+$ docker stop <GPDB_CONTAINER_ID>
+```

--- a/src/tools/docker/ubuntu-16.04-persistent/README.md
+++ b/src/tools/docker/ubuntu-16.04-persistent/README.md
@@ -13,16 +13,18 @@ $ docker run -d -p 5432:5432 -h dwgpdb -v /tmp/gpdata:/data local/gpdb
 The host name `dwgpdb` is strongly required to initializing the database properly with the same data from `/data` directory after restarting or rebuilding the container.
 
 ## The first connect to GPDB from the host
+Review the docker logs to check that GPDB is installed and started up successfully:
+```
+$ docker ps -a
+$ docker logs --follow <GPDB_CONTAINDER_ID>
+```
+
+Connect:
 ```
 # apt-get install postgresql-client-9.5
 $ psql -h 127.0.0.1 -p 5432 -U gpadmin
 Password: gppassword
 gpadmin=# select version();
-```
-Check the docker logs if the connection is failed:
-```
-$ docker ps -a
-$ docker logs --follow <GPDB_CONTAINDER_ID>
 ```
 
 ## Using gp-utils in container

--- a/src/tools/docker/ubuntu-16.04-persistent/README.md
+++ b/src/tools/docker/ubuntu-16.04-persistent/README.md
@@ -7,7 +7,8 @@ This dockerfile is using PPA for Ubuntu 16 — https://launchpad.net/~greenplum/
 ## Build and run
 ```
 $ docker build -t local/gpdb .
-$ docker run -d -p 5432:5432 -h dwgpdb -v /srv/data/:/data local/gpdb
+$ mkdir -p /tmp/gpdata/
+$ docker run -d -p 5432:5432 -h dwgpdb -v /tmp/gpdata:/data local/gpdb
 ```
 The host name `dwgpdb` is strongly required to initializing the database properly with the same data from `/data` directory after restarting or rebuilding the container.
 

--- a/src/tools/docker/ubuntu-16.04-persistent/container_init.sh
+++ b/src/tools/docker/ubuntu-16.04-persistent/container_init.sh
@@ -64,7 +64,10 @@ fi
 echo '========================> GPDB start'
 /etc/init.d/ssh start
 sleep 2
+chown gpadmin:gpadmin /gpdb_start.sh
+chmod +x /gpdb_start.sh
 su - gpadmin bash -c '/gpdb_start.sh'
+echo '========================> GPDB ready'
 
 
 

--- a/src/tools/docker/ubuntu-16.04-persistent/container_init.sh
+++ b/src/tools/docker/ubuntu-16.04-persistent/container_init.sh
@@ -1,0 +1,70 @@
+export DATA_DIR="/data"
+
+if [ ! -f "/opt/gpdb/greenplum_path.sh" ]; then
+	echo '========================> Install GPDB'
+	apt update
+	apt install -y \
+		software-properties-common \
+		python-software-properties \
+		less \
+		ssh
+	add-apt-repository -y ppa:greenplum/db
+	apt update
+
+	apt install -y greenplum-db-oss
+	source /opt/gpdb/greenplum_path.sh
+	locale-gen en_US.utf8
+fi
+
+if [ ! -d "$DATA_DIR/gpdata" ]; then
+	echo '========================> Make $DATA_DIR/gpdata/'
+	mkdir -p $DATA_DIR/gpdata/gpdata1
+	mkdir -p $DATA_DIR/gpdata/gpdata2
+	mkdir -p $DATA_DIR/gpdata/gpmaster
+fi
+
+if [ ! -f "$DATA_DIR/gpdata/gpinitsystem_singlenode" ]; then
+	echo '========================> Make gpinitsystem_singlenode and hostlist_singlenode'
+	echo 'ARRAY_NAME="GPDB SINGLENODE"' > $DATA_DIR/gpdata/gpinitsystem_singlenode
+	echo 'MACHINE_LIST_FILE='$DATA_DIR'/gpdata/hostlist_singlenode' >> $DATA_DIR/gpdata/gpinitsystem_singlenode
+	echo 'SEG_PREFIX=gpsne' >> $DATA_DIR/gpdata/gpinitsystem_singlenode
+	echo 'PORT_BASE=40000' >> $DATA_DIR/gpdata/gpinitsystem_singlenode
+	echo 'declare -a DATA_DIRECTORY=('$DATA_DIR'/gpdata/gpdata1 '$DATA_DIR'/gpdata/gpdata2)' >> $DATA_DIR/gpdata/gpinitsystem_singlenode
+	echo 'MASTER_HOSTNAME=dwgpdb' >> $DATA_DIR/gpdata/gpinitsystem_singlenode
+	echo 'MASTER_DIRECTORY='$DATA_DIR'/gpdata/gpmaster' >> $DATA_DIR/gpdata/gpinitsystem_singlenode
+	echo 'MASTER_PORT=5432' >> $DATA_DIR/gpdata/gpinitsystem_singlenode
+	echo 'TRUSTED_SHELL=ssh' >> $DATA_DIR/gpdata/gpinitsystem_singlenode
+	echo 'CHECK_POINT_SEGMENTS=8' >> $DATA_DIR/gpdata/gpinitsystem_singlenode
+	echo 'ENCODING=UNICODE' >> $DATA_DIR/gpdata/gpinitsystem_singlenode
+	echo 'DATABASE_NAME=gpadmin' >> $DATA_DIR/gpdata/gpinitsystem_singlenode
+
+	echo dwgpdb > $DATA_DIR/gpdata/hostlist_singlenode
+fi
+
+if [ ! -d "/home/gpadmin" ]; then
+	echo '========================> Add gpadmin'
+	useradd -md /home/gpadmin/ gpadmin
+	chown gpadmin -R $DATA_DIR/gpdata
+	echo  "export DATA_DIR=$DATA_DIR" >> /home/gpadmin/.profile
+	echo  "export MASTER_DATA_DIRECTORY=$DATA_DIR/gpdata/gpmaster/gpsne-1" >> /home/gpadmin/.profile
+	echo  "export GPHOME=/opt/gpdb" >> /home/gpadmin/.profile
+	echo  "source $GPHOME/greenplum_path.sh" >> /home/gpadmin/.profile
+
+	echo  "export DATA_DIR=$DATA_DIR" >> /home/gpadmin/.bashrc
+	echo  "export MASTER_DATA_DIRECTORY=$DATA_DIR/gpdata/gpmaster/gpsne-1" >> /home/gpadmin/.bashrc
+	echo  "export GPHOME=/opt/gpdb" >> /home/gpadmin/.bashrc
+	echo  "source $GPHOME/greenplum_path.sh" >> /home/gpadmin/.bashrc
+
+	chown gpadmin:gpadmin /home/gpadmin/.profile
+	su - gpadmin bash -c 'mkdir /home/gpadmin/.ssh'
+	ssh-keygen -f /home/gpadmin/.ssh/id_rsa -t rsa -N ""
+	chown -R gpadmin:gpadmin /home/gpadmin/.ssh/*
+fi
+
+echo '========================> GPDB start'
+/etc/init.d/ssh start
+sleep 2
+su - gpadmin bash -c '/gpdb_start.sh'
+
+
+

--- a/src/tools/docker/ubuntu-16.04-persistent/container_init.sh
+++ b/src/tools/docker/ubuntu-16.04-persistent/container_init.sh
@@ -61,13 +61,12 @@ if [ ! -d "/home/gpadmin" ]; then
 	chown -R gpadmin:gpadmin /home/gpadmin/.ssh/*
 fi
 
-echo '========================> GPDB start'
+echo '========================> GPDB is starting...'
 /etc/init.d/ssh start
 sleep 2
 chown gpadmin:gpadmin /gpdb_start.sh
 chmod +x /gpdb_start.sh
 su - gpadmin bash -c '/gpdb_start.sh'
-echo '========================> GPDB ready'
 
 
 

--- a/src/tools/docker/ubuntu-16.04-persistent/gpdb_start.sh
+++ b/src/tools/docker/ubuntu-16.04-persistent/gpdb_start.sh
@@ -1,0 +1,20 @@
+export DATA_DIR="/data"
+export GPHOME=/opt/gpdb
+SHELL=/bin/bash
+source $GPHOME/greenplum_path.sh
+MASTER_DATA_DIRECTORY=$DATA_DIR/gpdata/gpmaster/gpsne-1/
+
+
+gpssh-exkeys -f $DATA_DIR/gpdata/hostlist_singlenode
+
+if [ -f "$DATA_DIR/gpdata/gpmaster/gpsne-1/pg_hba.conf" ]; then
+	echo '========================> Simple start GPDB'
+	gpstart -a
+else
+	echo '========================> Init and start GPDB'
+	gpinitsystem -ac $DATA_DIR/gpdata/gpinitsystem_singlenode
+	sleep 2
+	echo "ALTER USER gpadmin WITH PASSWORD 'gppassword';" | psql
+	echo "host all  all 0.0.0.0/0 password" >> $DATA_DIR/gpdata/gpmaster/gpsne-1/pg_hba.conf
+	gpstop -ra
+fi

--- a/src/tools/docker/ubuntu-16.04-persistent/gpdb_start.sh
+++ b/src/tools/docker/ubuntu-16.04-persistent/gpdb_start.sh
@@ -8,13 +8,15 @@ MASTER_DATA_DIRECTORY=$DATA_DIR/gpdata/gpmaster/gpsne-1/
 gpssh-exkeys -f $DATA_DIR/gpdata/hostlist_singlenode
 
 if [ -f "$DATA_DIR/gpdata/gpmaster/gpsne-1/pg_hba.conf" ]; then
-	echo '========================> Simple start GPDB'
+	echo '========================> Simple start GPDB in progress...'
 	gpstart -a
 else
-	echo '========================> Init and start GPDB'
+	echo '========================> Init and start GPDB in progress...'
 	gpinitsystem -ac $DATA_DIR/gpdata/gpinitsystem_singlenode
 	sleep 2
 	echo "ALTER USER gpadmin WITH PASSWORD 'gppassword';" | psql
 	echo "host all  all 0.0.0.0/0 password" >> $DATA_DIR/gpdata/gpmaster/gpsne-1/pg_hba.conf
 	gpstop -ra
 fi
+
+echo '========================> GPDB starting process has completed, check the result above or try to connect'


### PR DESCRIPTION
Hi there!

Here is the more flexible version of [the container on Ubuntu 16](https://github.com/greenplum-db/gpdb/tree/master/src/tools/docker/ubuntu-16.04).

What upgraded:

* This version of the container could be restarted or container could be rebuild (run, stop, delete, run again) and Greenplum will restart automatically with data you're using before restart or rebuild.

* Added the option `DATABASE_NAME` to fix the error `psql: FATAL:  database "gpadmin" does not exist` in previous container. So you don't need to initialize the database in container manually to connect.

* Added password to external connections. So you can use the database right now after container is up

As result this container allow users to run and testing the database immediately. Hopefully it also helps Ubuntu administrators.

Also I want to tell many thanks to Greenplum Team!

PS: it will be great to add a manual to tune the system for GP on Ubuntu like it's described in [the manual](http://gpdb.docs.pivotal.io/540/install_guide/prep_os_install_gpdb.html) for RHEL, CentOS and SUSE