### PR TITLE
Remove residual FIXME from window merge work

### DIFF
--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v2.55.0@gpdb/stable
+orca/v2.55.1@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v2.55.1@gpdb/stable
+orca/v2.55.2@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -121,7 +121,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget -q -O - https://github.com/greenplum-db/gporca/releases/download/v2.55.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget -q -O - https://github.com/greenplum-db/gporca/releases/download/v2.55.1/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -121,7 +121,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget -q -O - https://github.com/greenplum-db/gporca/releases/download/v2.55.1/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget -q -O - https://github.com/greenplum-db/gporca/releases/download/v2.55.2/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/gpdb-doc/markdown/pxf/hdfs_write_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_write_pxf.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Writing Data to HDFS with PXF (Experimental)
+title: Writing Data to HDFS with PXF
 ---
 
 <!--
@@ -20,8 +20,6 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-
-<div class="note warning">Warning: Writing text and binary data to HDFS an experimental PXF feature and is not intended for use in a production environment. Experimental features are subject to change without notice in future releases.</div>
 
 You can use the PXF HDFS connector to write text and SequenceFile format binary data to files stored on HDFS. When you create a writable external table with the PXF HDFS connector, you specify the name of a directory on HDFS. When you insert records into the external table, the block(s) of data you insert are written to one or more files in the directory you specified.
 

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -612,13 +612,6 @@ set_append_rel_pathlist(PlannerInfo *root, RelOptInfo *rel,
 	}
 
 	/*
-	 * GPDB_84_MERGE_FIXME: review the estimation math here; 8.4 changed the
-	 * logic around. In particular, we capped the minimum parent_rows at 1,
-	 * whereas upstream will divide by any positive number. We also set
-	 * rel->width to width_avg if the parent_rows are zero, whereas upstream
-	 * sets it to zero.
-	 */
-	/*
 	 * Save the finished size estimates.
 	 */
 	rel->rows = parent_rows;
@@ -639,9 +632,6 @@ set_append_rel_pathlist(PlannerInfo *root, RelOptInfo *rel,
 	else if (list_length(subpaths) == 1)
 		rel->onerow = ((Path *) linitial(subpaths))->parent->onerow;
 
-	/*
-	 * GPDB_84_MERGE_FIXME: ensure that this rel->tuples count works for us.
-	 */
 	/*
 	 * Set "raw tuples" count equal to "rows" for the appendrel; needed
 	 * because some places assume rel->tuples is valid for any baserel.

--- a/src/test/regress/expected/bfv_aggregate.out
+++ b/src/test/regress/expected/bfv_aggregate.out
@@ -1570,6 +1570,24 @@ select array_agg(a order by b desc nulls last) from aggordertest;
  {NULL,3,1,2,1,2}
 (1 row)
 
+-- begin MPP-14125: if prelim function is missing, do not choose hash agg.
+create temp table mpp14125 as select repeat('a', a) a, a % 10 b from generate_series(1, 100)a;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+explain select string_agg(a) from mpp14125 group by b;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice2; segments: 2)  (cost=8.32..9.20 rows=5 width=36)
+   ->  GroupAggregate  (cost=8.32..9.20 rows=5 width=36)
+         Group By: b
+         ->  Sort  (cost=8.32..8.57 rows=50 width=55)
+               Sort Key: b
+               ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..5.00 rows=50 width=55)
+                     Hash Key: b
+                     ->  Seq Scan on mpp14125  (cost=0.00..3.00 rows=50 width=55)
+(8 rows)
+
+-- end MPP-14125
 -- CLEANUP
 set client_min_messages='warning';
 drop schema bfv_aggregate cascade;

--- a/src/test/regress/expected/bfv_aggregate_optimizer.out
+++ b/src/test/regress/expected/bfv_aggregate_optimizer.out
@@ -1569,6 +1569,25 @@ select array_agg(a order by b desc nulls last) from aggordertest;
  {NULL,3,1,2,1,2}
 (1 row)
 
+-- begin MPP-14125: if prelim function is missing, do not choose hash agg.
+create temp table mpp14125 as select repeat('a', a) a, a % 10 b from generate_series(1, 100)a;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+explain select string_agg(a) from mpp14125 group by b;
+                                                  QUERY PLAN
+--------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.07 rows=10 width=8)
+   ->  Result  (cost=0.00..431.07 rows=4 width=8)
+         ->  GroupAggregate  (cost=0.00..431.07 rows=4 width=8)
+               Group Key: b
+               ->  Sort  (cost=0.00..431.06 rows=34 width=55)
+                     Sort Key: b
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.01 rows=34 width=55)
+                           Hash Key: b
+                           ->  Table Scan on mpp14125  (cost=0.00..431.00 rows=34 width=55)
+ Optimizer: PQO version 2.55.0
+(10 rows)
+
+-- end MPP-14125
 -- CLEANUP
 set client_min_messages='warning';
 drop schema bfv_aggregate cascade;

--- a/src/test/regress/expected/olap_group.out
+++ b/src/test/regress/expected/olap_group.out
@@ -6021,22 +6021,6 @@ select sum((select prc from sale where cn = s.cn and vn = s.vn and pn = s.pn)) f
 (1 row)
 
 -- end MPP-14021
--- begin MPP-14125: if prelim function is missing, do not choose hash agg.
-create temp table mpp14125 as select repeat('a', a) a, a % 10 b from generate_series(1, 100)a;
-explain select string_agg(a) from mpp14125 group by b;
-                                              QUERY PLAN                                              
-------------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice2; segments: 2)  (cost=8.32..9.20 rows=5 width=36)
-   ->  GroupAggregate  (cost=8.32..9.20 rows=5 width=36)
-         Group By: b
-         ->  Sort  (cost=8.32..8.57 rows=50 width=55)
-               Sort Key: b
-               ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..5.00 rows=50 width=55)
-                     Hash Key: b
-                     ->  Seq Scan on mpp14125  (cost=0.00..3.00 rows=50 width=55)
-(8 rows)
-
--- end MPP-14125
 -- Test COUNT in a subquery
 create table prod_agg (sale integer, prod varchar);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'sale' as the Greenplum Database data distribution key for this table.

--- a/src/test/regress/sql/bfv_aggregate.sql
+++ b/src/test/regress/sql/bfv_aggregate.sql
@@ -1386,7 +1386,10 @@ select array_agg(a order by b nulls last) from aggordertest;
 select array_agg(a order by b desc nulls first) from aggordertest;
 select array_agg(a order by b desc nulls last) from aggordertest;
 
-
+-- begin MPP-14125: if prelim function is missing, do not choose hash agg.
+create temp table mpp14125 as select repeat('a', a) a, a % 10 b from generate_series(1, 100)a;
+explain select string_agg(a) from mpp14125 group by b;
+-- end MPP-14125
 -- CLEANUP
 set client_min_messages='warning';
 drop schema bfv_aggregate cascade;

--- a/src/test/regress/sql/olap_group.sql
+++ b/src/test/regress/sql/olap_group.sql
@@ -138,11 +138,6 @@ select cn, vn, pn, sum(qty*prc) from sale group by cube (cn, vn, pn) order by 1,
 select cn, vn, pn, sum(qty*prc) from sale group by grouping sets ((), (cn), (vn), (pn), (cn,vn), (cn,pn), (vn,pn), (cn,vn,pn)) order by 1,2,3; -- order 1,2,3
 --end_equiv
 
--- start_ignore
--- GPDB_84_MERGE_FIXME: ORCA started supporting this feature, investigate why
-set optimizer = off;
--- end_ignore
-
 -- ***BUG*** The extended groupings aren't correctly ordered! Maybe they wrongly parallel sorted!
 --start_equiv order 1,2,3
 select cn, vn, pn, count(distinct dt) from sale group by cn, vn, pn
@@ -177,9 +172,6 @@ order by 1,2,3; -- order 1,2,3
 select cn, vn, pn, count(distinct dt) from sale group by cube (cn, vn, pn) order by 1,2,3; -- order 1,2,3
 select cn, vn, pn, count(distinct dt) from sale group by grouping sets ((), (cn), (vn), (pn), (cn,vn), (cn,pn), (vn,pn), (cn,vn,pn)) order by 1,2,3; -- order 1,2,3
 --end_equiv
--- start_ignore
-reset optimizer;
--- end_ignore
 
 -- Ordinary Grouping Set Specifications --
 
@@ -602,18 +594,6 @@ drop table s6756 cascade; --ignore
 -- begin MPP-14021
 select sum((select prc from sale where cn = s.cn and vn = s.vn and pn = s.pn)) from sale s;
 -- end MPP-14021
-
--- begin MPP-14125: if prelim function is missing, do not choose hash agg.
-create temp table mpp14125 as select repeat('a', a) a, a % 10 b from generate_series(1, 100)a;
--- start_ignore
--- GPDB_84_MERGE_FIXME: ORCA started supporting this feature, investigate why
-set optimizer = off;
--- end_ignore
-explain select string_agg(a) from mpp14125 group by b;
--- start_ignore
-reset optimizer;
--- end_ignore
--- end MPP-14125
 
 -- Test COUNT in a subquery
 create table prod_agg (sale integer, prod varchar);


### PR DESCRIPTION
During window merge, DQA was temporarily disabled with GPORCA.
After the following PR, this was resolved. In this PR, I am cleaning a
residual outdated fixme

https://github.com/greenplum-db/gpdb/pull/4086

The string_agg function was categorized as ordered window aggregate in
GPDB 5. So GPORCA did not support that and fallbacks to planner. In GPDB
6 string_agg is a straightforward window aggregate, so GPORCA supports
it.

I moved the string_agg function to bfv_aggregate to avoid creating another _optimizer answer file, and the test can belong in bfv_aggregate.