### PR TITLE
Fix bug in RESET/RESET ALL command

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -6032,7 +6032,7 @@ ExecSetVariableStmt(VariableSetStmt *stmt)
 			else
 				appendStringInfo(&buffer, "RESET %s", stmt->name);
 
-			CdbDispatchCommand(buffer.data, 0, NULL);
+			CdbDispatchSetCommand(buffer.data, false);
 		}
 	}
 }

--- a/src/test/regress/expected/guc_gp.out
+++ b/src/test/regress/expected/guc_gp.out
@@ -78,3 +78,45 @@ set work_mem='1MB';
 WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 reset work_mem;
 WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
+--
+-- Test if RESET timezone is dispatched to all slices
+--
+CREATE TABLE timezone_table AS SELECT * FROM (VALUES (123,1513123564),(123,1512140765),(123,1512173164),(123,1512396441)) foo(a, b) DISTRIBUTED RANDOMLY;
+SELECT DISTINCT to_timestamp(b)::date FROM timezone_table;
+ to_timestamp 
+--------------
+ 12-01-2017
+ 12-04-2017
+ 12-12-2017
+(3 rows)
+
+SET timezone= 'America/New_York';
+SHOW timezone;
+     TimeZone     
+------------------
+ America/New_York
+(1 row)
+
+SELECT DISTINCT to_timestamp(b)::date FROM timezone_table;
+ to_timestamp 
+--------------
+ 12-01-2017
+ 12-04-2017
+ 12-12-2017
+(3 rows)
+
+RESET timezone;
+SHOW timezone;
+ TimeZone 
+----------
+ PST8PDT
+(1 row)
+
+SELECT DISTINCT to_timestamp(b)::date FROM timezone_table;
+ to_timestamp 
+--------------
+ 12-01-2017
+ 12-04-2017
+ 12-12-2017
+(3 rows)
+

--- a/src/test/regress/sql/guc_gp.sql
+++ b/src/test/regress/sql/guc_gp.sql
@@ -73,3 +73,16 @@ DROP FUNCTION if exists test_call_set_command();
 -- another way to detect that the GUC's assign-hook is called only once.
 set work_mem='1MB';
 reset work_mem;
+
+--
+-- Test if RESET timezone is dispatched to all slices
+--
+CREATE TABLE timezone_table AS SELECT * FROM (VALUES (123,1513123564),(123,1512140765),(123,1512173164),(123,1512396441)) foo(a, b) DISTRIBUTED RANDOMLY;
+
+SELECT DISTINCT to_timestamp(b)::date FROM timezone_table;
+SET timezone= 'America/New_York';
+SHOW timezone;
+SELECT DISTINCT to_timestamp(b)::date FROM timezone_table;
+RESET timezone;
+SHOW timezone;
+SELECT DISTINCT to_timestamp(b)::date FROM timezone_table;


### PR DESCRIPTION
Prior to this commit, on calling `RESET`/`RESET ALL` command, the value of guc was not getting updated on all the slices(already spun up reader slices). This caused wrong results.
This PR fixes the issue.
