### PR TITLE
Avoid format-overflow warning on setting headers

### DIFF
--- a/src/backend/access/external/fileam.c
+++ b/src/backend/access/external/fileam.c
@@ -2437,7 +2437,7 @@ external_set_env_vars_ext(extvar_t *extvar, char *uri, bool csv, char *escape, c
 	char	   *encoded_delim;
 	int			line_delim_len;
 
-	sprintf(extvar->GP_CSVOPT,
+	snprintf(extvar->GP_CSVOPT, sizeof(extvar->GP_CSVOPT),
 			"m%dx%dq%dn%dh%d",
 			csv ? 1 : 0,
 			escape ? 255 & *escape : 0,

--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -754,7 +754,7 @@ set_httpheader(URL_CURL_FILE *fcurl, const char *name, const char *value)
 		elog(ERROR, "set_httpheader name/value is too long. name = %s, value=%s",
 			 name, value);
 
-	sprintf(tmp, "%s: %s", name, value);
+	snprintf(tmp, sizeof(tmp), "%s: %s", name, value);
 
 	new_httpheader = curl_slist_append(fcurl->curl->x_httpheader, tmp);
 	if (new_httpheader == NULL)

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -371,8 +371,8 @@ vacuum(VacuumStmt *vacstmt, Oid relid, bool do_toast,
 	volatile bool all_rels,
 				in_outer_xact,
 				use_own_xacts;
-	List	   *vacuum_relations;
-	List	   *analyze_relations;
+	List	   *vacuum_relations = NIL;
+	List	   *analyze_relations = NIL;
 
 	if ((vacstmt->options & VACOPT_VACUUM) &&
 		(vacstmt->options & VACOPT_ROOTONLY))
@@ -976,6 +976,8 @@ vacuumStatement_Relation(VacuumStmt *vacstmt, Oid relid,
 	vacstmt->options |= VACOPT_VACUUM;
 	vacstmt->va_cols = NIL;		/* A plain VACUUM cannot list columns */
 
+	stats_context.updated_stats = NIL;
+
 	/*
 	 * We compact segment file by segment file.
 	 * Therefore in some cases, we have multiple vacuum dispatches
@@ -1268,8 +1270,6 @@ vacuumStatement_Relation(VacuumStmt *vacstmt, Oid relid,
 			int 		i, nindexes;
 			bool 		has_bitmap = false;
 			Relation   *i_rel = NULL;
-
-			stats_context.updated_stats = NIL;
 
 			vac_open_indexes(onerel, AccessShareLock, &nindexes, &i_rel);
 			if (i_rel != NULL)

--- a/src/backend/executor/execQual.c
+++ b/src/backend/executor/execQual.c
@@ -2351,7 +2351,6 @@ ExecMakeTableFunctionResult(ExprState *funcexpr,
 			{
 				tuplestore_putvalues(tupstore, tupdesc, &result, &fcinfo.isnull);
 			}
-			MemoryContextSwitchTo(oldcontext);
 
 			/*
 			 * Are we done?


### PR DESCRIPTION
The new -Wformat-overflow warning in GCC7 fails to understand that
the buffer is in fact large enough, likely because it counds on the
integers possibly being negative. Move to using snprintf() instead
since that accounts for buffer size, and is really what we should
have done in the first place.  Also touch up the consumer of the
GP_CSVOPT buffer even though it's using a buffer oversized enough
to probably not cause that same warning.