### PR TITLE
docs - note OOM query failure when resource groups active

### DIFF
--- a/gpdb-doc/dita/admin_guide/wlmgmt.xml
+++ b/gpdb-doc/dita/admin_guide/wlmgmt.xml
@@ -80,7 +80,7 @@
           <row>
             <entry colname="col1">Query Failure</entry>
             <entry colname="col2">Query may fail immediately if not enough memory</entry>
-            <entry colname="col3">Query may fail after reaching transaction memory limit</entry>
+            <entry colname="col3">Query may fail after reaching transaction fixed memory limit, no shared resource group memory exits, and the transaction requests more memory</entry>
           </row>
           <row>
             <entry colname="col1">Limit Bypass</entry>

--- a/gpdb-doc/dita/admin_guide/wlmgmt.xml
+++ b/gpdb-doc/dita/admin_guide/wlmgmt.xml
@@ -80,7 +80,7 @@
           <row>
             <entry colname="col1">Query Failure</entry>
             <entry colname="col2">Query may fail immediately if not enough memory</entry>
-            <entry colname="col3">Query may fail after reaching transaction fixed memory limit, no shared resource group memory exits, and the transaction requests more memory</entry>
+            <entry colname="col3">Query may fail after reaching transaction fixed memory limit when no shared resource group memory exists and the transaction requests more memory</entry>
           </row>
           <row>
             <entry colname="col1">Limit Bypass</entry>

--- a/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
@@ -189,11 +189,14 @@
           <title>Resource Group Memory Allotments</title>
           <image href="graphics/resgroupmem.png" id="image_iqn_dsl_wlrg"/>
         </fig></p>
-
       <p>When a query's memory usage exceeds the fixed per-transaction memory usage amount,
         Greenplum Database allocates available resource group shared memory to the query. The
         maximum amount of resource group memory available to a specific transaction slot is the sum
         of the transaction's fixed memory and the full resource group shared memory allotment.</p>
+      <note>Greenplum Database does not actively monitor transaction memory usage in resource
+        groups. A transaction submitted in a resource group will fail and exit if the memory
+        requested by the transaction exceeds the available fixed and shared memory in the
+        group.</note>
 
       <section id="topic833sp" xml:lang="en">
         <title>Query Operator Memory</title>

--- a/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
@@ -193,10 +193,10 @@
         Greenplum Database allocates available resource group shared memory to the query. The
         maximum amount of resource group memory available to a specific transaction slot is the sum
         of the transaction's fixed memory and the full resource group shared memory allotment.</p>
-      <note>Greenplum Database does not actively monitor transaction memory usage in resource
-        groups. A transaction submitted in a resource group will fail and exit if the memory
-        requested by the transaction exceeds the available fixed and shared memory in the
-        group.</note>
+      <note>Greenplum Database tracks, but does not actively monitor, transaction memory usage
+        in resource groups. A transaction submitted in a resource group will fail and exit
+        when memory usage exceeds its fixed memory allotment, no available resource group
+        shared memory exists, and the transaction requests more memory.</note>
 
       <section id="topic833sp" xml:lang="en">
         <title>Query Operator Memory</title>


### PR DESCRIPTION
add a note that transaction will fail if no memory available in resource group.

doc review site link:  http://docs-gpdb-review-staging.cfapps.io/550/admin_guide/workload_mgmt_resgroups.html#topic8339717 (note at end of section)