### PR TITLE
Remove fix me in primenode.h

### DIFF
--- a/src/backend/optimizer/README.orca
+++ b/src/backend/optimizer/README.orca
@@ -1,0 +1,42 @@
+NOT_EXIST_SUBLINK Subplan used inside GPORCA
+============================================
+
+GPORCA uses NOT_EXIST_SUBLINK to implement co-related left anti semijoin.
+Therefore we still need this in the executor for GPORCA plans.
+
+Example:
+
+```sql
+CREATE TABLE csq_r(a int) distributed by (a);
+INSERT INTO csq_r VALUES (1);
+CREATE OR REPLACE FUNCTION csq_f(a int) RETURNS int AS $$ select $1 $$ LANGUAGE SQL CONTAINS SQL;
+explain SELECT * FROM csq_r WHERE not exists (SELECT * FROM csq_f(csq_r.a));
+Physical plan:
++--CPhysicalMotionGather(master)   rows:1   width:34  rebinds:1   cost:882688.037301   origin: [Grp:7, GrpExpr:14]
+   +--CPhysicalCorrelatedLeftAntiSemiNLJoin("" (8))   rows:1   width:34  rebinds:1   cost:882688.037287   origin: [Grp:7, GrpExpr:13]
+      |--CPhysicalTableScan "csq_r" ("csq_r")   rows:1   width:34  rebinds:1   cost:431.000019   origin: [Grp:0, GrpExpr:1]
+      |--CPhysicalComputeScalar   rows:1   width:1  rebinds:1   cost:0.000002   origin: [Grp:5, GrpExpr:1]
+      |  |--CPhysicalConstTableGet Columns: ["" (8)] Values: [(1)]   rows:1   width:1  rebinds:1   cost:0.000001   origin: [Grp:1, GrpExpr:1]
+      |  +--CScalarProjectList   origin: [Grp:4, GrpExpr:0]
+      |     +--CScalarProjectElement "csq_f" (9)   origin: [Grp:3, GrpExpr:0]
+      |        +--CScalarIdent "a" (0)   origin: [Grp:2, GrpExpr:0]
+      +--CScalarConst (1)   origin: [Grp:8, GrpExpr:0]
+",
+                                   QUERY PLAN
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..882688.04 rows=1 width=4)
+   Output: a
+   ->  Table Scan on public.csq_r  (cost=0.00..882688.04 rows=1 width=4)
+         Output: a
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice1; segments: 3)
+           ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                 Output:
+                 ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                       Output: $0,
+                       ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                             Output: true
+ Optimizer: PQO version 2.55.2
+(13 rows)
+```
+

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -604,7 +604,7 @@ typedef enum SubLinkType
 	EXPR_SUBLINK,
 	ARRAY_SUBLINK,
 	CTE_SUBLINK,				/* for SubPlans only */
-	NOT_EXISTS_SUBLINK
+	NOT_EXISTS_SUBLINK /* GPORCA use NOT_EXIST_SUBLINK to implement correlated left anti semijoin. */
 } SubLinkType;
 
 

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -604,7 +604,7 @@ typedef enum SubLinkType
 	EXPR_SUBLINK,
 	ARRAY_SUBLINK,
 	CTE_SUBLINK,				/* for SubPlans only */
-	NOT_EXISTS_SUBLINK /* GPORCA use NOT_EXIST_SUBLINK to implement correlated left anti semijoin. */
+	NOT_EXISTS_SUBLINK /* GPORCA uses NOT_EXIST_SUBLINK to implement correlated left anti semijoin. */
 } SubLinkType;
 
 

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -604,7 +604,7 @@ typedef enum SubLinkType
 	EXPR_SUBLINK,
 	ARRAY_SUBLINK,
 	CTE_SUBLINK,				/* for SubPlans only */
-	NOT_EXISTS_SUBLINK   /* GPDB_84_MERGE_FIXME: Does ORCA really need this? */
+	NOT_EXISTS_SUBLINK
 } SubLinkType;
 
 


### PR DESCRIPTION
GPORCA uses NOT_EXIST_SUBLINK to implement co-related left anti semijoin.
Therefore we still need this in the executor for GPORCA plans.

Example:

```sql
CREATE TABLE csq_r(a int) distributed by (a);
INSERT INTO csq_r VALUES (1);
CREATE OR REPLACE FUNCTION csq_f(a int) RETURNS int AS $$ select $1 $$ LANGUAGE SQL CONTAINS SQL;
explain SELECT * FROM csq_r WHERE not exists (SELECT * FROM csq_f(csq_r.a));
Physical plan:
+--CPhysicalMotionGather(master)   rows:1   width:34  rebinds:1   cost:882688.037301   origin: [Grp:7, GrpExpr:14]
   +--CPhysicalCorrelatedLeftAntiSemiNLJoin("" (8))   rows:1   width:34  rebinds:1   cost:882688.037287   origin: [Grp:7, GrpExpr:13]
      |--CPhysicalTableScan "csq_r" ("csq_r")   rows:1   width:34  rebinds:1   cost:431.000019   origin: [Grp:0, GrpExpr:1]
      |--CPhysicalComputeScalar   rows:1   width:1  rebinds:1   cost:0.000002   origin: [Grp:5, GrpExpr:1]
      |  |--CPhysicalConstTableGet Columns: ["" (8)] Values: [(1)]   rows:1   width:1  rebinds:1   cost:0.000001   origin: [Grp:1, GrpExpr:1]
      |  +--CScalarProjectList   origin: [Grp:4, GrpExpr:0]
      |     +--CScalarProjectElement "csq_f" (9)   origin: [Grp:3, GrpExpr:0]
      |        +--CScalarIdent "a" (0)   origin: [Grp:2, GrpExpr:0]
      +--CScalarConst (1)   origin: [Grp:8, GrpExpr:0]
",
                                   QUERY PLAN
---------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..882688.04 rows=1 width=4)
   Output: a
   ->  Table Scan on public.csq_r  (cost=0.00..882688.04 rows=1 width=4)
         Output: a
         Filter: (SubPlan 1)
         SubPlan 1  (slice1; segments: 3)
           ->  Result  (cost=0.00..0.00 rows=1 width=1)
                 Output:
                 ->  Result  (cost=0.00..0.00 rows=1 width=1)
                       Output: $0,
                       ->  Result  (cost=0.00..0.00 rows=1 width=1)
                             Output: true
 Optimizer: PQO version 2.55.2
(13 rows)
```