### PR TITLE
docs - misc pxf updates related to parquet, user impersonation

### DIFF
--- a/gpdb-doc/book/master_middleman/source/subnavs/pxf-subnav.erb
+++ b/gpdb-doc/book/master_middleman/source/subnavs/pxf-subnav.erb
@@ -15,10 +15,10 @@
             <a href="/docs/550/pxf/instcfg_pxf.html" format="markdown">Installing and Configuring PXF</a>
             <ul>
               <li>
-                <a href="/docs/550/pxf/pxfuserimpers.html">Configuring User Impersonation and Proxying</a>
+                <a href="/docs/550/pxf/client_instcfg.html" format="markdown">Installing and Configuring Hadoop Clients for PXF</a>
               </li>
               <li>
-                <a href="/docs/550/pxf/client_instcfg.html" format="markdown">Installing and Configuring Hadoop Clients for PXF</a>
+                <a href="/docs/550/pxf/pxfuserimpers.html">Configuring User Impersonation and Proxying</a>
               </li>
               <li>
                 <a href="/docs/550/pxf/cfginitstart_pxf.html" format="markdown">Configuring, Initializing, and Managing PXF</a>

--- a/gpdb-doc/markdown/pxf/hdfs_read_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_read_pxf.html.md.erb
@@ -53,7 +53,7 @@ The PXF HDFS connector provides the following profiles to read the data formats 
 | JSON | Json | Read JSON format data (\<filename\>.json). |
 | Parquet | Parquet | Read Parquet format data (\<filename\>.parq). |
 
-**Note:** You can also use PXF to read and write Parquet files using Hive connector, which supports both primitive and complex data types. See [Accessing Hive Table Data with PXF](hive_pxf.html). 
+**Note:** You can also use the PXF Hive connector to read Hive tables stored in Parquet format. The Hive connector `Hive` profile supports both primitive and complex data types. See [Accessing Hive Table Data with PXF](hive_pxf.html). 
 
 ## <a id="hdfs_cmdline"></a>HDFS Shell Command Primer
 Hadoop includes command-line tools that interact directly with your HDFS file system. These tools support typical file system operations including copying and listing files, changing file permissions, and so forth.

--- a/gpdb-doc/markdown/pxf/instcfg_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/instcfg_pxf.html.md.erb
@@ -2,14 +2,15 @@
 title: Installing and Configuring PXF
 ---
 
-PXF accesses Hadoop services on behalf of Greenplum Database end users. By default, PXF tries to access data source services (HDFS, Hive, HBase) using the identity of the Greenplum Database user account that logs into Greenplum Database. In order to support this functionality, you must configure proxy settings for Hadoop, as well as for Hive and HDFS if you intend to use those PXF connectors. Follow the procedures in:
-
-- **[Configuring User Impersonation and Proxying](pxfuserimpers.html)**
-
 The Greenplum Platform Extension Framework (PXF) provides connectors to Hadoop, Hive, and HBase data stores. To use these PXF connectors, you must install Hadoop, Hive, and HBase clients on each Greenplum Database segment host as described in this one-time installation and configuration procedure:
 
 - **[Installing and Configuring Hadoop Clients for PXF](client_instcfg.html)**
 
+PXF accesses Hadoop services on behalf of Greenplum Database end users. By default, PXF tries to access data source services (HDFS, Hive, HBase) using the identity of the Greenplum Database user account that logs into Greenplum Database. In order to support this functionality, you must configure proxy settings for Hadoop, as well as for Hive and HDFS if you intend to use those PXF connectors. Follow procedures in:
+
+- **[Configuring User Impersonation and Proxying](pxfuserimpers.html)**
+
+to configure user impersonation and proxying for Hadoop services, or to turn off PXF user impersonation.
 
 You must also configure and initialize PXF itself, and start the PXF service on each segment host:
 

--- a/gpdb-doc/markdown/pxf/pxfuserimpers.html.md.erb
+++ b/gpdb-doc/markdown/pxf/pxfuserimpers.html.md.erb
@@ -6,7 +6,7 @@ PXF accesses Hadoop services on behalf of Greenplum Database end users. By defau
 
 With the default PXF configuration, you must explicitly configure each Hadoop data source (HDFS, Hive, HBase) to allow the PXF process owner (usually `gpadmin`) to act as a proxy for impersonating users or groups. See [Configuring Hadoop Proxying](#hadoop), [Hive User Impersonation](#hive), and [HBase User Impersonation](#hbase).  
 
-As an alternative, you can disable PXF user impersonation. With user impersonation disabled, PXF executes all Hadoop service requests as the PXF process owner (usually `gpadmin`). This behavior matches earlier releases of PXF, but it provides no means to control access to Hadoop services for different Greenplum Database users in Hadoop. It requires that the `gpadmin` user have access to all files and directories in HDFS, and all tables in Hive and HBase that need to be accessed as PXF external tables. See [Configuring PXF User Impersonation](#pxf_cfg_proc) for information about disabling user impersonation.
+As an alternative, you can disable PXF user impersonation. With user impersonation disabled, PXF executes all Hadoop service requests as the PXF process owner (usually `gpadmin`). This behavior matches earlier releases of PXF, but it provides no means to control access to Hadoop services for different Greenplum Database users in Hadoop. It requires that the `gpadmin` user have access to all files and directories in HDFS, and all tables in Hive and HBase that are referenced in PXF external table definitions. See [Configuring PXF User Impersonation](#pxf_cfg_proc) for information about disabling user impersonation.
 
 ## <a id="pxf_cfg_proc"></a>Configure PXF User Impersonation
 
@@ -45,11 +45,11 @@ Perform the following procedure to turn PXF user impersonation on or off in your
 
 ## <a id="hadoop"></a>Configure Hadoop Proxying
 
-When PXF user personation is enabled (the default), you must configure the Hadoop `core-site.xml` configuration file permit user impersonation for PXF. Follow these steps:
+When PXF user personation is enabled (the default), you must configure the Hadoop `core-site.xml` configuration file to permit user impersonation for PXF. Follow these steps:
 
-1. Open the `core-site.xml` configuration file using a text editor, or use Ambari to add or edit the property values described in this procedure.
+1. Open the `core-site.xml` configuration file using a text editor, or use Ambari to add or edit the Hadoop property values described in this procedure.
 
-2. Set the property `hadoop.proxyuser.<name>.hosts` to specify the list of PXF host names where proxy requests are permitted. Substitute `<name>` for the PXF user (generally `gpadmin`) and provide multiple hostnames in a comma-separated list.  For example:
+2. Set the property `hadoop.proxyuser.<name>.hosts` to specify the list of PXF host names from which proxy requests are permitted. Substitute the PXF proxy user (generally `gpadmin`) for `<name>`, and provide multiple PXF host names in a comma-separated list.  For example:
 
     ``` xml
     <property>
@@ -65,13 +65,14 @@ When PXF user personation is enabled (the default), you must configure the Hadoo
         <value>group1,group2</value>
     </property>
     ```
-4. After changing `core-site.xml`, restart Hadoop for your changes to take effect.
+4. After changing `core-site.xml`, you must restart Hadoop for your changes to take effect.
 
 ## <a id="hive"></a>Hive User Impersonation
 
-The PXF Hive connector uses the Hive MetaStore to determine the HDFS locations of Hive tables, and then accesses the underlying HDFS files directly. No specific impersonation configuration is required for Hive, because the Hadoop proxy configuration in `core-site.xml` also applies to Hive access.
+The PXF Hive connector uses the Hive MetaStore to determine the HDFS locations of Hive tables, and then accesses the underlying HDFS files directly. No specific impersonation configuration is required for Hive, because the Hadoop proxy configuration in `core-site.xml` also applies to Hive tables accessed in this manner.
 
 
 ## <a id="hbase"></a>HBase User Impersonation
 
 In order for user impersonation to work with HBase, you must enable the `AccessController` coprocessor in the HBase configuration and restart the cluster. See [61.3 Server-side Configuration for Simple User Access Operation](http://hbase.apache.org/book.html#hbase.secure.configuration) in the Apache HBase Reference Guide for the required `hbase-site.xml` configuration settings.
+

--- a/gpdb-doc/markdown/pxf/upgrade_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/upgrade_pxf.html.md.erb
@@ -60,6 +60,8 @@ After you upgrade to the new version of Greenplum Database, perform the followin
     gpadmin@gpmaster$ . /usr/local/greenplum-db/greenplum_path.sh
     ```
 
+2. PXF user impersonation is on by default in Greenplum Database version 5.5.0 and later. If you are upgrading from an older *PXF.from* version, you must configure user impersonation for the underlying Hadoop services. Refer to [Configuring User Impersonation and Proxying](pxfuserimpers.html) for instructions, including the configuration procedure to turn off PXF user impersonation.
+
 2. If you updated the `pxf-env.sh` configuration file in your *PXF.from* installation, re-apply those changes to the file, and copy the updated `pxf-env.sh` to all segment hosts. For example, if `seghostfile` contains a list, one-host-per-line, of the segment hosts in your Greenplum Database cluster:
 
     ``` shell

--- a/gpdb-doc/markdown/pxf/using_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/using_pxf.html.md.erb
@@ -107,7 +107,7 @@ PXF provides the following built-in profiles. Those profiles that support write 
 | Hive | RCFile | Hive, HiveRC | Record columnar data consisting of binary key/value pairs. |
 | Hive | SequenceFile | Hive | Data consisting of binary key/value pairs. |
 | Hive | ORC | Hive, HiveORC, HiveVectorizedORC | Optimized row columnar data with stripe, footer, and postscript sections. |
-| Hive | Parquet | Hive | Compressed columnar data representation. *Supports read and write.*|
+| Hive | Parquet | Hive | Compressed columnar data representation.|
 
 A PXF profile definition includes the name of the profile, a description, and the Java classes that implement parsing and reading external data for the profile. Built-in PXF profiles are defined in the `$GPHOME/pxf/conf/pxf-profiles-default.xml` configuration file. The built-in `HdfsTextSimple` profile definition is reproduced below:
 


### PR DESCRIPTION
a few misc updates
- parquet via hive does not support write
- add  user impersonation config step to upgrade
- reorder install/cfg steps - move user impers cfg to after installing hadoop client section