### PR TITLE
docs - add json field info to gp_resgroup_status page

### DIFF
--- a/gpdb-doc/dita/ref_guide/gp_toolkit.xml
+++ b/gpdb-doc/dita/ref_guide/gp_toolkit.xml
@@ -1691,7 +1691,7 @@
           </tgroup>
         </table>
         <p> </p>
-        <p>The <codeph>cpu_usage</codeph> field is a JSON-formatted, key:value
+        <p id="json_field_info1">The <codeph>cpu_usage</codeph> field is a JSON-formatted, key:value
           string that identifies, for each resource group, the per-segment CPU
           usage percentage. The key is segment id, the value is the percentage
           of CPU usage by the resource group on the segment host. The total
@@ -1702,7 +1702,7 @@
         <p>In this example, segment <codeph>0</codeph> and segment 
           <codeph>1</codeph> are running on the same host; their CPU usage
           is the same.</p> 
-        <p>The <codeph>memory_usage</codeph> field is also a JSON-formatted,
+        <p id="json_field_info2">The <codeph>memory_usage</codeph> field is also a JSON-formatted,
           key:value string. This string identifies, for each resource group, the
           used, available, granted, and proposed fixed and shared memory quota 
           allocations on each segment. The key is segment id. The values are 

--- a/gpdb-doc/dita/ref_guide/system_catalogs/gp_resgroup_status.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/gp_resgroup_status.xml
@@ -100,5 +100,8 @@
         </tbody>
       </tgroup>
     </table>
+    <p> </p>
+    <p conref="../gp_toolkit.xml#topic31x/json_field_info1"/>
+    <p conref="../gp_toolkit.xml#topic31x/json_field_info2"/>
   </body>
 </topic>


### PR DESCRIPTION
short term fix - added a conref to pull json field info from gp_toolkit page to gp_resgroup_status system view ref page.  (longer term fix is to refactor the content on the system view ref pages and gp_toolkit page to make consistent across views.)