### PR TITLE
Need to close pipe files even if COPY PROGRAME already exit

### DIFF
--- a/src/backend/access/external/url_execute.c
+++ b/src/backend/access/external/url_execute.c
@@ -777,7 +777,7 @@ read_err_msg(int fid, StringInfo sinfo)
 int
 pclose_with_stderr(int pid, int *pipes, StringInfo sinfo)
 {
-	int status;
+	int status = 0;
 
 	/* close the data pipe. we can now read from error pipe without being blocked */
 	close(pipes[EXEC_DATA_P]);
@@ -786,11 +786,14 @@ pclose_with_stderr(int pid, int *pipes, StringInfo sinfo)
 
 	close(pipes[EXEC_ERR_P]);
 
-#ifndef WIN32
-	waitpid(pid, &status, 0);
-#else
-    status = -1;
-#endif
+	if (kill(pid, 0) == 0) /* process exists */
+	{
+	#ifndef WIN32
+		waitpid(pid, &status, 0);
+	#else
+		status = -1;
+	#endif
+	}
 
 	return status;
 }

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -8203,11 +8203,8 @@ close_program_pipes(CopyState cstate, bool ifThrow)
 	{
 		return;
 	}
-
-	if (kill(cstate->program_pipes->pid, 0) == 0) /* process exists */
-	{
-		ret = pclose_with_stderr(cstate->program_pipes->pid, cstate->program_pipes->pipes, &sinfo);
-	}
+	
+	ret = pclose_with_stderr(cstate->program_pipes->pid, cstate->program_pipes->pipes, &sinfo);
 
 	if (ret == 0 || !ifThrow)
 	{


### PR DESCRIPTION
Need to close pipe files even if COPY PROGRAME already exit before parent process ask child process to exit, otherwise it will lead file description leak in a long time running.