### PR TITLE
Abort transaction before exiting FTS process in case of an error

### DIFF
--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -264,6 +264,8 @@ ftsMain(int argc, char *argv[])
 		/* Report the error to the server log */
 		EmitErrorReport();
 
+		AbortCurrentTransaction();
+
 		/*
 		 * We can now go away.	Note that because we'll call InitProcess, a
 		 * callback will be registered to do ProcKill, which will clean up
@@ -420,6 +422,8 @@ probeWalRepUpdateConfig(int16 dbid, int16 segindex, char role,
 		histtuple = heap_form_tuple(RelationGetDescr(histrel), histvals, histnulls);
 		simple_heap_insert(histrel, histtuple);
 		CatalogUpdateIndexes(histrel, histtuple);
+
+		SIMPLE_FAULT_INJECTOR(FtsUpdateConfig);
 
 		heap_close(histrel, RowExclusiveLock);
 	}

--- a/src/backend/fts/ftsmessagehandler.c
+++ b/src/backend/fts/ftsmessagehandler.c
@@ -335,6 +335,8 @@ HandleFtsWalRepPromote(void)
 void
 HandleFtsMessage(const char* query_string)
 {
+	SIMPLE_FAULT_INJECTOR(FtsHandleMessage);
+
 	if (strncmp(query_string, FTS_MSG_PROBE,
 				strlen(FTS_MSG_PROBE)) == 0)
 		HandleFtsWalRepProbe();

--- a/src/backend/fts/test/Makefile
+++ b/src/backend/fts/test/Makefile
@@ -25,6 +25,7 @@ ftsprobe.t: \
 
 fts.t: \
     $(MOCK_DIR)/backend/access/transam/xact_mock.o \
+    $(MOCK_DIR)/backend/utils/misc/faultinjector_mock.o \
     $(MOCK_DIR)/backend/utils/time/snapmgr_mock.o \
     $(MOCK_DIR)/backend/access/heap/heapam_mock.o \
     $(MOCK_DIR)/backend/access/common/heaptuple_mock.o \

--- a/src/backend/fts/test/fts_test.c
+++ b/src/backend/fts/test/fts_test.c
@@ -156,6 +156,11 @@ probeWalRepUpdateConfig_will_be_called_with(
 	expect_any(heap_open, lockmode);
 	will_return(heap_open, &gp_configuration_history_relation);
 
+	expect_value(FaultInjector_InjectFaultIfSet, identifier, FtsUpdateConfig);
+	expect_value(FaultInjector_InjectFaultIfSet, ddlStatement, DDLNotSpecified);
+	expect_value(FaultInjector_InjectFaultIfSet, databaseName, "");
+	expect_value(FaultInjector_InjectFaultIfSet, tableName, "");
+	will_return(FaultInjector_InjectFaultIfSet, FaultInjectorTypeNotSpecified);
 	/* Mock heap_open gp_segment_configuration_relation */
 	static RelationData gp_segment_configuration_relation;
 

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -2048,7 +2048,6 @@ retry1:
 						ereport(FATAL,
 								(errcode(ERRCODE_PROTOCOL_VIOLATION),
 								 errmsg("cannot handle FTS connection on master")));
-					SIMPLE_FAULT_INJECTOR(FtsHandleMessage);
 					am_ftshandler = true;
 					am_mirror = IsRoleMirror();
 				}

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -2048,6 +2048,7 @@ retry1:
 						ereport(FATAL,
 								(errcode(ERRCODE_PROTOCOL_VIOLATION),
 								 errmsg("cannot handle FTS connection on master")));
+					SIMPLE_FAULT_INJECTOR(FtsHandleMessage);
 					am_ftshandler = true;
 					am_mirror = IsRoleMirror();
 				}

--- a/src/include/utils/faultinjector_lists.h
+++ b/src/include/utils/faultinjector_lists.h
@@ -176,6 +176,10 @@ FI_IDENT(FaultExecHashJoinNewBatch, "exec_hashjoin_new_batch")
 FI_IDENT(FtsWaitForShutdown, "fts_wait_for_shutdown")
 /* inject fault in FTS loop */
 FI_IDENT(FtsProbe, "fts_probe")
+/* inject fault in FTS where it updates configuration */
+FI_IDENT(FtsUpdateConfig, "fts_update_config")
+/* inject fault in FTS message handler */
+FI_IDENT(FtsHandleMessage, "fts_handle_message")
 /* inject fault before cleaning up a runaway query */
 FI_IDENT(RunawayCleanup, "runaway_cleanup")
 /* inject fault while translating relcache entries */

--- a/src/test/regress/expected/fts_error.out
+++ b/src/test/regress/expected/fts_error.out
@@ -1,0 +1,83 @@
+create extension if not exists gp_inject_fault;
+select count(*) = 2 as in_sync from gp_segment_configuration
+where content = 0 and mode = 's';
+ in_sync 
+---------
+ t
+(1 row)
+
+-- Once this fault is hit, FTS process should abort current
+-- transaction and exit.
+select gp_inject_fault('fts_update_config', 'error', '', '', '', -1, 0, 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+-- FTS probe connection should encounter an error due to this fault,
+-- injected on content 0 primary.
+select gp_inject_fault('fts_handle_message', 'error', '', '', '', -1, 0, dbid)
+from gp_segment_configuration where content = 0 and role = 'p';
+NOTICE:  Success:  (seg0 10.64.6.27:25432 pid=42073)
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+-- Upon failure to probe content 0 primary, FTS will try to update the
+-- configuration.  The update to configuration will hit error due to
+-- the "fts_update_config" fault.
+select gp_inject_fault('fts_update_config', 'wait_until_triggered', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+select gp_inject_fault('fts_handle_message', 'reset', dbid)
+from gp_segment_configuration where content = 0 and role = 'p';
+NOTICE:  Success:  (seg0 10.64.6.27:25432 pid=42073)
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+select gp_inject_fault('fts_update_config', 'reset', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+-- Verify that FTS didn't leak any locks due to the error during
+-- config update.
+select locktype, mode, relation, pid, granted from pg_locks where
+relation = 'gp_segment_configuration'::regclass or
+relation = 'gp_configuration_history'::regclass;
+ locktype | mode | relation | pid | granted 
+----------+------+----------+-----+---------
+(0 rows)
+
+select gp_inject_fault('fts_update_config', 'reset', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+-- Postmaster should have restarted FTS by now.  Trigger a scan and
+-- validate that configuration is sane.
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t
+(1 row)
+
+select count(*) = 2 as in_sync from gp_segment_configuration
+where content = 0 and mode = 's';
+ in_sync 
+---------
+ t
+(1 row)
+

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -197,7 +197,7 @@ test: vacuum_full_freeze_heap
 test: vacuum_full_heap
 test: vacuum_full_heap_bitmapindex
 
-test: ao_checksum_corruption AOCO_Compression2 table_statistics
+test: ao_checksum_corruption AOCO_Compression2 table_statistics fts_error
 test: metadata_track
 test: workfile_mgr_test
 

--- a/src/test/regress/sql/fts_error.sql
+++ b/src/test/regress/sql/fts_error.sql
@@ -1,0 +1,31 @@
+create extension if not exists gp_inject_fault;
+select count(*) = 2 as in_sync from gp_segment_configuration
+where content = 0 and mode = 's';
+-- Once this fault is hit, FTS process should abort current
+-- transaction and exit.
+select gp_inject_fault('fts_update_config', 'error', '', '', '', -1, 0, 1);
+-- FTS probe connection should encounter an error due to this fault,
+-- injected on content 0 primary.
+select gp_inject_fault('fts_handle_message', 'error', '', '', '', -1, 0, dbid)
+from gp_segment_configuration where content = 0 and role = 'p';
+-- Upon failure to probe content 0 primary, FTS will try to update the
+-- configuration.  The update to configuration will hit error due to
+-- the "fts_update_config" fault.
+select gp_inject_fault('fts_update_config', 'wait_until_triggered', 1);
+
+select gp_inject_fault('fts_handle_message', 'reset', dbid)
+from gp_segment_configuration where content = 0 and role = 'p';
+
+select gp_inject_fault('fts_update_config', 'reset', 1);
+
+-- Verify that FTS didn't leak any locks due to the error during
+-- config update.
+select locktype, mode, relation, pid, granted from pg_locks where
+relation = 'gp_segment_configuration'::regclass or
+relation = 'gp_configuration_history'::regclass;
+select gp_inject_fault('fts_update_config', 'reset', 1);
+-- Postmaster should have restarted FTS by now.  Trigger a scan and
+-- validate that configuration is sane.
+select gp_request_fts_probe_scan();
+select count(*) = 2 as in_sync from gp_segment_configuration
+where content = 0 and mode = 's';


### PR DESCRIPTION
FTS makes updates to cluster configuration metadata tables.  These
updates are made within a transaction.  If an error is encountered,
the transaction must be aborted and all locks must be released before
FTS process exits.

A new ICW test is added to simulate error during configuration update.

Co-authored-by: David Kimura <dkimura@pivotal.io>