### PR TITLE
Extend pg_upgrade to cover (more) unhandled cases

### DIFF
--- a/contrib/pg_upgrade/Makefile
+++ b/contrib/pg_upgrade/Makefile
@@ -18,6 +18,11 @@ OBJS += aotable.o gpdb4_heap_convert.o version_old_gpdb4.o oid_dump.o
 PG_CPPFLAGS  = -DFRONTEND -DDLSUFFIX=\"$(DLSUFFIX)\" -I$(srcdir) -I$(libpq_srcdir)
 PG_LIBS = $(libpq_pgport)
 
+# We don't need to add tmp_check to the EXTRA_CLEAN since it's a default name
+# and thus already handled by PGXS "make clean"
+EXTRA_CLEAN = clusterConfigPostgresAddonsFile clusterConfigFile gpdemo-env.sh \
+              hostfile
+
 ifdef USE_PGXS
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/contrib/pg_upgrade/test_gpdb.sh
+++ b/contrib/pg_upgrade/test_gpdb.sh
@@ -59,6 +59,7 @@ realpath()
 
 restore_cluster()
 {
+	pushd $base_dir
 	# Reset the pg_control files from the old cluster which were renamed
 	# .old by pg_upgrade to avoid booting up an upgraded cluster.
 	find ${OLD_DATADIR} -type f -name 'pg_control.old' |
@@ -72,13 +73,14 @@ restore_cluster()
 		rm -f lalshell
 	fi
 
-	# Remove configuration files created by setting up the new cluster
-	rm -f clusterConfigPostgresAddonsFile
-	rm -f clusterConfigFile
-	rm -f gpdemo-env.sh
-	
-	# Remove the temporary cluster if requested
+	# Remove the temporary cluster, and associated files, if requested
 	if (( !$retain_tempdir )) ; then
+		# Remove configuration files created by setting up the new cluster
+		rm -f "clusterConfigPostgresAddonsFile"
+		rm -f "clusterConfigFile"
+		rm -f "gpdemo-env.sh"
+		rm -f "hostfile"
+		# Remove temporary cluster
 		rm -rf "$temp_root"
 	fi
 }
@@ -129,12 +131,13 @@ usage()
 	echo " -k           Add checksums to new cluster"
 	echo " -K           Remove checksums during upgrade"
 	echo " -m           Upgrade mirrors"
-	echo " -r           Retain temporary directory after test"
+	echo " -r           Retain temporary installation after test"
 	exit 0
 }
 
 # Main
 temp_root=`pwd`/tmp_check
+base_dir=`pwd`
 
 while getopts ":o:b:sCkKmr" opt; do
 	case ${opt} in

--- a/contrib/pg_upgrade/test_gpdb.sh
+++ b/contrib/pg_upgrade/test_gpdb.sh
@@ -75,6 +75,12 @@ restore_cluster()
 
 	# Remove the temporary cluster, and associated files, if requested
 	if (( !$retain_tempdir )) ; then
+		# If we are asked to blow away the temp root, echo any potential error
+		# files to the output channel to aid debugging
+		find ${temp_root} -type f -name "*.txt" | grep -v share |
+		while read error_file; do
+			cat ${error_file}
+		done
 		# Remove configuration files created by setting up the new cluster
 		rm -f "clusterConfigPostgresAddonsFile"
 		rm -f "clusterConfigFile"

--- a/contrib/pg_upgrade/test_gpdb.sh
+++ b/contrib/pg_upgrade/test_gpdb.sh
@@ -213,7 +213,7 @@ fi
 # upgrading a faulty catalog won't work.
 if (( $gpcheckcat )) ; then
 	gpcheckcat
-		if (( $? )) ; then
+	if (( $? )) ; then
 		echo "ERROR: gpcheckcat reported catalog issues, fix before upgrading"
 		exit 1
 	fi

--- a/contrib/pg_upgrade/test_gpdb.sh
+++ b/contrib/pg_upgrade/test_gpdb.sh
@@ -209,6 +209,7 @@ fi
 # Run any pre-upgrade tasks to prep the cluster
 if [ -f "test_gpdb_pre.sql" ]; then
 	psql -f test_gpdb_pre.sql regression
+	psql -f test_gpdb_pre.sql isolation2test
 fi
 
 # Ensure that the catalog is sane before attempting an upgrade. While there is

--- a/contrib/pg_upgrade/test_gpdb.sh
+++ b/contrib/pg_upgrade/test_gpdb.sh
@@ -191,9 +191,17 @@ fi
 trap restore_cluster EXIT
 
 # The cluster should be running by now, but in case it isn't, issue a restart.
-# Worst case we powercycle once for no reason, but it's better than failing
-# due to not having a cluster to work with.
-gpstart -a
+# Since we expect the testcluster to be a stock standard gpdemo, we test for
+# the presence of it. Worst case we powercycle once for no reason, but it's
+# better than failing due to not having a cluster to work with.
+if [ -f "/tmp/.s.PGSQL.15432.lock" ]; then
+	ps aux | grep  `head -1 /tmp/.s.PGSQL.15432.lock` | grep -q postgres
+	if (( $? )) ; then
+		gpstart -a
+	fi
+else
+	gpstart -a
+fi
 
 # Run any pre-upgrade tasks to prep the cluster
 if [ -f "test_gpdb_pre.sql" ]; then

--- a/contrib/pg_upgrade/test_gpdb_pre.sql
+++ b/contrib/pg_upgrade/test_gpdb_pre.sql
@@ -31,12 +31,3 @@ DROP TABLE IF EXISTS partition_pruning.pt_lt_tab CASCADE;
 DROP TABLE IF EXISTS dcl_messaging_test CASCADE;
 DROP TABLE IF EXISTS my_tq_agg_opt_part CASCADE;
 DROP TABLE IF EXISTS pt_indx_tab CASCADE;
-
--- These partitioned tables have a SERIAL column. That's also not
--- not reconstructed by pg_dump + restore correctly.
-DROP TABLE IF EXISTS ao_wt_sub_partzlib8192_5_2_uncompr CASCADE;
-DROP TABLE IF EXISTS ao_wt_sub_partzlib8192_5_uncompr CASCADE;
-DROP TABLE IF EXISTS co_cr_sub_partzlib8192_1_2_uncompr CASCADE;
-DROP TABLE IF EXISTS co_cr_sub_partzlib8192_1_uncompr CASCADE;
-DROP TABLE IF EXISTS co_wt_sub_partrle_type8192_1_2_uncompr CASCADE;
-DROP TABLE IF EXISTS co_wt_sub_partrle_type8192_1_uncompr CASCADE;

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -3805,6 +3805,7 @@ getTables(int *numTables)
 	int			i_reloptions;
 	int			i_toastreloptions;
 	int			i_parrelid;
+	int			i_parlevel;
 
 	/* Make sure we are in proper schema */
 	selectSourceSchema("pg_catalog");
@@ -3847,7 +3848,8 @@ getTables(int *numTables)
 						  "(SELECT spcname FROM pg_tablespace t WHERE t.oid = c.reltablespace) AS reltablespace, "
 						"array_to_string(c.reloptions, ', ') AS reloptions, "
 						  "array_to_string(array(SELECT 'toast.' || x FROM unnest(tc.reloptions) x), ', ') AS toast_reloptions "
-						  ", p.parrelid as parrelid "
+						  ", p.parrelid as parrelid, "
+						  " pl.parlevel as parlevel "
 						  "FROM pg_class c "
 						  "LEFT JOIN pg_depend d ON "
 						  "(c.relkind = '%c' AND "
@@ -3857,6 +3859,7 @@ getTables(int *numTables)
 					   "LEFT JOIN pg_class tc ON (c.reltoastrelid = tc.oid) "
 						  "LEFT JOIN pg_partition_rule pr ON c.oid = pr.parchildrelid "
 						  "LEFT JOIN pg_partition p ON pr.paroid = p.oid "
+						  "LEFT JOIN pg_partition pl ON (c.oid = pl.parrelid AND pl.parlevel = 0)"
 						  "WHERE c.relkind in ('%c', '%c', '%c', '%c') "
 						  "AND c.oid NOT IN (SELECT p.parchildrelid FROM pg_partition_rule p LEFT "
 						  "JOIN pg_exttable e ON p.parchildrelid=e.reloid WHERE e.reloid IS NULL)"
@@ -3884,6 +3887,7 @@ getTables(int *numTables)
 						  "(SELECT spcname FROM pg_tablespace t WHERE t.oid = c.reltablespace) AS reltablespace, "
 						"array_to_string(c.reloptions, ', ') AS reloptions, "
 						  "p.parrelid as parrelid, "
+						  "p.parlevel as parlevel "
 						  "NULL AS toast_reloptions "
 						  "FROM pg_class c "
 						  "LEFT JOIN pg_depend d ON "
@@ -3893,6 +3897,7 @@ getTables(int *numTables)
 						  "d.refclassid = c.tableoid AND d.deptype = 'a') "
 						  "LEFT JOIN pg_partition_rule pr ON c.oid = pr.parchildrelid "
 						  "LEFT JOIN pg_partition p ON pr.paroid = p.oid "
+						  "LEFT JOIN pg_partition pl ON (c.oid = pl.parrelid AND pl.parlevel = 0)"
 						  "WHERE relkind in ('%c', '%c', '%c', '%c') %s"
 						  "ORDER BY c.oid",
 						  username_subquery,
@@ -3946,6 +3951,7 @@ getTables(int *numTables)
 	i_reloptions = PQfnumber(res, "reloptions");
 	i_toastreloptions = PQfnumber(res, "toast_reloptions");
 	i_parrelid = PQfnumber(res, "parrelid");
+	i_parlevel = PQfnumber(res, "parlevel");
 
 	if (lockWaitTimeout && g_fout->remoteVersion >= 70300)
 	{
@@ -4005,6 +4011,11 @@ getTables(int *numTables)
 			snprintf(tmpStr, sizeof(tmpStr), "%s%s", tblinfo[i].dobj.name, EXT_PARTITION_NAME_POSTFIX);
 			tblinfo[i].dobj.name = strdup(tmpStr);
 		}
+		if (PQgetisnull(res, i, i_parlevel) ||
+			atoi(PQgetvalue(res, i, i_parlevel)) > 0)
+			tblinfo[i].parparent = false;
+		else
+			tblinfo[i].parparent = true;
 
 		/* other fields were zeroed above */
 
@@ -12173,7 +12184,12 @@ dumpAttrDef(Archive *fout, AttrDefInfo *adinfo)
 	q = createPQExpBuffer();
 	delq = createPQExpBuffer();
 
-	appendPQExpBuffer(q, "ALTER TABLE ONLY %s ",
+	/*
+	 * If the table is the parent of a partitioning hierarchy, the default
+	 * constraint must be applied to all children as well.
+	 */
+	appendPQExpBuffer(q, "ALTER TABLE %s %s ",
+					  tbinfo->parparent ? "" : "ONLY",
 					  fmtId(tbinfo->dobj.name));
 	appendPQExpBuffer(q, "ALTER COLUMN %s SET DEFAULT %s;\n",
 					  fmtId(tbinfo->attnames[adnum - 1]),

--- a/src/bin/pg_dump/pg_dump.h
+++ b/src/bin/pg_dump/pg_dump.h
@@ -322,6 +322,7 @@ typedef struct _tableInfo
 	struct _tableInfo **parents;	/* TableInfos of immediate parents */
 	struct _tableDataInfo *dataObj;		/* TableDataInfo, if dumping its data */
 	Oid			parrelid;			/* external partition's parent oid */
+	bool		parparent;		/* true if the table is partition parent */
 } TableInfo;
 
 typedef struct _attrDefInfo


### PR DESCRIPTION
`pg_upgrade` is currently not handling every possible state that a Greenplum database can be in, this is an attempt at reducing the gap. See the individual commits for more details.