### PR TITLE
This is PR 4515 (Fix AO header kind bug for bulk dense content) with an ICW test

### DIFF
--- a/src/backend/cdb/cdbappendonlystoragewrite.c
+++ b/src/backend/cdb/cdbappendonlystoragewrite.c
@@ -1263,7 +1263,6 @@ AppendOnlyStorageWrite_CompressAppend(AppendOnlyStorageWrite *storageWrite,
 {
 	uint8	   *header;
 	uint8	   *dataBuffer;
-	int32		dataRoundedUpLen = 0;	/* Shutup compiler. */
 	int32		dataBufferWithOverrrunLen;
 	PGFunction *cfns = storageWrite->compression_functions;
 	PGFunction	compressor;
@@ -1295,12 +1294,11 @@ AppendOnlyStorageWrite_CompressAppend(AppendOnlyStorageWrite *storageWrite,
 	 * Compress into the BufferedAppend buffer after the large header (and
 	 * optional checksum, etc.
 	 */
-	(void) gp_trycompress_new(
-							  sourceData,
+	(void) gp_trycompress_new(sourceData,
 							  sourceLen,
 							  dataBuffer,
 							  dataBufferWithOverrrunLen,
-			sourceLen, //Limit compression to be no more than the input size.
+							  sourceLen, //Limit compression to be no more than the input size.
 							  compressedLen,
 							  storageWrite->storageAttributes.compressLevel,
 							  compressor,
@@ -1317,127 +1315,76 @@ AppendOnlyStorageWrite_CompressAppend(AppendOnlyStorageWrite *storageWrite,
 	 * The best solution to this seems to be to make the threshold at which we
 	 * compress data user configurable.
 	 */
-	if (*compressedLen < sourceLen)
-	{
-		/*
-		 * Compression successful.
-		 */
-		dataRoundedUpLen = AOStorage_RoundUp(*compressedLen, storageWrite->formatVersion);
-
-		AOStorage_ZeroPad(
-						  dataBuffer,
-						  *compressedLen,
-						  dataRoundedUpLen);
-
-		switch (storageWrite->getBufferAoHeaderKind)
-		{
-			case AoHeaderKind_SmallContent:
-
-				/*
-				 * Make the header and compute the checksum if necessary.
-				 */
-				AppendOnlyStorageFormat_MakeSmallContentHeader
-					(header,
-					 storageWrite->storageAttributes.checksum,
-					 storageWrite->isFirstRowNumSet,
-					 storageWrite->formatVersion,
-					 storageWrite->firstRowNum,
-					 executorBlockKind,
-					 itemCount,
-					 sourceLen,
-					 *compressedLen);
-				break;
-
-			case AoHeaderKind_BulkDenseContent:
-
-				/*
-				 * Make the header and compute the checksum if necessary.
-				 */
-				AppendOnlyStorageFormat_MakeBulkDenseContentHeader
-					(header,
-					 storageWrite->storageAttributes.checksum,
-					 storageWrite->isFirstRowNumSet,
-					 storageWrite->formatVersion,
-					 storageWrite->firstRowNum,
-					 executorBlockKind,
-					 itemCount,
-					 sourceLen,
-					 *compressedLen);
-				break;
-
-			default:
-				elog(ERROR, "Unexpected Append-Only header kind %d",
-					 storageWrite->getBufferAoHeaderKind);
-				break;
-		}
-
-		if (Debug_appendonly_print_storage_headers)
-		{
-			AppendOnlyStorageWrite_LogBlockHeader(storageWrite,
-												  BufferedAppendCurrentBufferPosition(&storageWrite->bufferedAppend),
-												  header);
-		}
-
-		elogif(Debug_appendonly_print_insert, LOG,
-			   "Append-only insert finished compressed block for table '%s' "
-			   "(segment file '%s', header offset in file " INT64_FORMAT ", "
-			   "length = %d, compressed length %d, item count %d, block count " INT64_FORMAT ")",
-			   storageWrite->relationName,
-			   storageWrite->segmentFileName,
-		  BufferedAppendCurrentBufferPosition(&storageWrite->bufferedAppend),
-			   sourceLen,
-			   *compressedLen,
-			   itemCount,
-			   storageWrite->bufferCount);
-	}
-	else
-	{
-		/*
-		 * Unable to compress the data to smaller the input size. Solution:
-		 * Indicate in the header we are storing an non-compressed block.
-		 */
-		*compressedLen = 0;
-
-		dataRoundedUpLen = AOStorage_RoundUp(sourceLen, storageWrite->formatVersion);
-
-		/*
-		 * Copy non-compressed data in after the header information.
-		 */
+	int32 dataLen = *compressedLen;
+	if (*compressedLen >= sourceLen) {
+		dataLen = sourceLen;
 		memcpy(dataBuffer, sourceData, sourceLen);
+		*compressedLen = 0;
+	}
+	int32 dataRoundedUpLen = AOStorage_RoundUp(dataLen, storageWrite->formatVersion);
+	AOStorage_ZeroPad(dataBuffer, dataLen, dataRoundedUpLen);
+	switch (storageWrite->getBufferAoHeaderKind)
+	{
+		case AoHeaderKind_SmallContent:
 
-		AOStorage_ZeroPad(dataBuffer, sourceLen, dataRoundedUpLen);
+			/*
+			 * Make the header and compute the checksum if necessary.
+			 */
+			AppendOnlyStorageFormat_MakeSmallContentHeader
+				(header,
+				 storageWrite->storageAttributes.checksum,
+				 storageWrite->isFirstRowNumSet,
+				 storageWrite->formatVersion,
+				 storageWrite->firstRowNum,
+				 executorBlockKind,
+				 itemCount,
+				 sourceLen,
+				 *compressedLen);
+			break;
 
-		/*
-		 * Make the header and compute the checksum if necessary.
-		 */
-		AppendOnlyStorageFormat_MakeSmallContentHeader
-			(header,
-			 storageWrite->storageAttributes.checksum,
-			 storageWrite->isFirstRowNumSet,
-			 storageWrite->formatVersion,
-			 storageWrite->firstRowNum,
-			 executorBlockKind,
-			 itemCount,
+		case AoHeaderKind_BulkDenseContent:
+
+			/*
+			 * Make the header and compute the checksum if necessary.
+			 */
+			AppendOnlyStorageFormat_MakeBulkDenseContentHeader
+				(header,
+				 storageWrite->storageAttributes.checksum,
+				 storageWrite->isFirstRowNumSet,
+				 storageWrite->formatVersion,
+				 storageWrite->firstRowNum,
+				 executorBlockKind,
+				 itemCount,
+				 sourceLen,
+				 *compressedLen);
+			break;
+
+		default:
+			elog(ERROR, "Unexpected Append-Only header kind %d",
+				 storageWrite->getBufferAoHeaderKind);
+			break;
+	}
+
+	if (Debug_appendonly_print_storage_headers)
+	{
+		AppendOnlyStorageWrite_LogBlockHeader(storageWrite,
+											  BufferedAppendCurrentBufferPosition(&storageWrite->bufferedAppend),
+											  header);
+	}
+
+	if (Debug_appendonly_print_insert) {
+		elog(LOG,
+			 "Append-only insert block for table '%s' stored %s "
+				"(segment file '%s', header offset in file " INT64_FORMAT ", "
+				"source length = %d, result length %d item count %d, block count " INT64_FORMAT ")",
+			 storageWrite->relationName,
+			 (*compressedLen > 0) ? "compressed" : "uncompressed (couldn't compress)",
+			 storageWrite->segmentFileName,
+			 BufferedAppendCurrentBufferPosition(&storageWrite->bufferedAppend),
 			 sourceLen,
-			  /* compressedLen */ 0);
-
-		if (Debug_appendonly_print_storage_headers)
-		{
-			AppendOnlyStorageWrite_LogBlockHeader(storageWrite,
-												  BufferedAppendCurrentBufferPosition(&storageWrite->bufferedAppend),
-												  header);
-		}
-
-		elogif(Debug_appendonly_print_insert, LOG,
-			   "Append-only insert could not compress block for table '%s' smaller -- non-compressed block stored "
-			   "(segment file '%s', header offset in file " INT64_FORMAT ", "
-			   "length = %d, item count %d, block count " INT64_FORMAT ")",
-			   storageWrite->relationName,
-			   storageWrite->segmentFileName,
-		  BufferedAppendCurrentBufferPosition(&storageWrite->bufferedAppend),
-			   sourceLen,
-			   itemCount,
-			   storageWrite->bufferCount);
+			 dataLen,
+			 itemCount,
+			 storageWrite->bufferCount);
 	}
 
 	*bufferLen = storageWrite->currentCompleteHeaderLen + dataRoundedUpLen;

--- a/src/backend/cdb/cdbappendonlystoragewrite.c
+++ b/src/backend/cdb/cdbappendonlystoragewrite.c
@@ -1276,8 +1276,8 @@ AppendOnlyStorageWrite_CompressAppend(AppendOnlyStorageWrite *storageWrite,
 	/* UNDONE: This can be a duplicate call... */
 	storageWrite->currentCompleteHeaderLen =
 		AppendOnlyStorageWrite_CompleteHeaderLen(
-												 storageWrite,
-										storageWrite->getBufferAoHeaderKind);
+			storageWrite,
+			storageWrite->getBufferAoHeaderKind);
 
 	header = BufferedAppendGetMaxBuffer(&storageWrite->bufferedAppend);
 	if (header == NULL)
@@ -1299,7 +1299,7 @@ AppendOnlyStorageWrite_CompressAppend(AppendOnlyStorageWrite *storageWrite,
 							  sourceLen,
 							  dataBuffer,
 							  dataBufferWithOverrrunLen,
-							  sourceLen, //Limit compression to be no more than the input size.
+							  sourceLen, /* maxCompressedLen */
 							  compressedLen,
 							  storageWrite->storageAttributes.compressLevel,
 							  compressor,
@@ -1329,20 +1329,19 @@ AppendOnlyStorageWrite_CompressAppend(AppendOnlyStorageWrite *storageWrite,
 	 * compress data user configurable.
 	 */
 	int32 dataLen = *compressedLen;
-	if (*compressedLen >= sourceLen) {
+	if (*compressedLen >= sourceLen)
+	{
 		dataLen = sourceLen;
 		memcpy(dataBuffer, sourceData, sourceLen);
 		*compressedLen = 0;
 	}
 	int32 dataRoundedUpLen = AOStorage_RoundUp(dataLen, storageWrite->formatVersion);
 	AOStorage_ZeroPad(dataBuffer, dataLen, dataRoundedUpLen);
+
+	/* Make the header and compute the checksum if necessary. */
 	switch (storageWrite->getBufferAoHeaderKind)
 	{
 		case AoHeaderKind_SmallContent:
-
-			/*
-			 * Make the header and compute the checksum if necessary.
-			 */
 			AppendOnlyStorageFormat_MakeSmallContentHeader
 				(header,
 				 storageWrite->storageAttributes.checksum,
@@ -1356,9 +1355,12 @@ AppendOnlyStorageWrite_CompressAppend(AppendOnlyStorageWrite *storageWrite,
 			break;
 
 		case AoHeaderKind_BulkDenseContent:
-
 			/*
-			 * Make the header and compute the checksum if necessary.
+			 * This header is used when compresslevel > 1 is specified with
+			 * rle_type compression.  The sourceData is already encoded with
+			 * RLE.  It is further compressed with bulk compression.
+			 * Corresponding datumstream version is
+			 * DatumStreamVersion_Dense_Enhanced.
 			 */
 			AppendOnlyStorageFormat_MakeBulkDenseContentHeader
 				(header,
@@ -1373,32 +1375,32 @@ AppendOnlyStorageWrite_CompressAppend(AppendOnlyStorageWrite *storageWrite,
 			break;
 
 		default:
-			elog(ERROR, "Unexpected Append-Only header kind %d",
+			elog(ERROR, "unexpected Append-Only header kind %d",
 				 storageWrite->getBufferAoHeaderKind);
 			break;
 	}
 
 	if (Debug_appendonly_print_storage_headers)
 	{
-		AppendOnlyStorageWrite_LogBlockHeader(storageWrite,
-											  BufferedAppendCurrentBufferPosition(&storageWrite->bufferedAppend),
-											  header);
+		AppendOnlyStorageWrite_LogBlockHeader(
+			storageWrite,
+			BufferedAppendCurrentBufferPosition(&storageWrite->bufferedAppend),
+			header);
 	}
 
-	if (Debug_appendonly_print_insert) {
-		elog(LOG,
-			 "Append-only insert block for table '%s' stored %s "
-				"(segment file '%s', header offset in file " INT64_FORMAT ", "
-				"source length = %d, result length %d item count %d, block count " INT64_FORMAT ")",
-			 storageWrite->relationName,
-			 (*compressedLen > 0) ? "compressed" : "uncompressed (couldn't compress)",
-			 storageWrite->segmentFileName,
-			 BufferedAppendCurrentBufferPosition(&storageWrite->bufferedAppend),
-			 sourceLen,
-			 dataLen,
-			 itemCount,
-			 storageWrite->bufferCount);
-	}
+	elogif(Debug_appendonly_print_insert, LOG,
+		   "Append-only insert block for table '%s' stored %s "
+		   "(segment file '%s', header offset in file " INT64_FORMAT ", "
+		   "source length = %d, result length %d item count %d, block count "
+		   INT64_FORMAT ")",
+		   storageWrite->relationName,
+		   (*compressedLen > 0) ? "compressed" : "uncompressed",
+		   storageWrite->segmentFileName,
+		   BufferedAppendCurrentBufferPosition(&storageWrite->bufferedAppend),
+		   sourceLen,
+		   dataLen,
+		   itemCount,
+		   storageWrite->bufferCount);
 
 	*bufferLen = storageWrite->currentCompleteHeaderLen + dataRoundedUpLen;
 }

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -105,6 +105,7 @@ FaultInjectorTypeEnumToString[] = {
 	_("interrupt"),
 	_("finish_pending"),
 	_("checkpoint_and_panic"),
+	_("wait_until_triggered"),
 	_("not recognized"),
 };
 
@@ -1400,6 +1401,40 @@ FaultInjector_SetFaultInjection(
 			
 			break;
 		}
+
+		case FaultInjectorTypeWaitUntilTriggered:
+		{
+			FaultInjectorEntry_s	*entryLocal;
+
+			while ((entryLocal = FaultInjector_LookupHashEntry(entry->faultName)) != NULL &&
+				   entry->occurrence > entryLocal->numTimesTriggered)
+			{
+				pg_usleep(1000000L);  // 1 sec
+			}
+
+			if (entryLocal != NULL)
+			{
+				ereport(LOG,
+						(errcode(ERRCODE_FAULT_INJECT),
+						 errmsg("fault triggered %d times, fault name:'%s' fault type:'%s' ",
+							entry->occurrence,
+							entryLocal->faultName,
+							FaultInjectorTypeEnumToString[entry->faultInjectorType])));
+				status = STATUS_OK;
+			}
+			else
+			{
+				ereport(LOG,
+						(errcode(ERRCODE_FAULT_INJECT),
+						 errmsg("fault 'NULL', fault name:'%s'  ",
+								entryLocal->faultName)));
+
+				status = STATUS_ERROR;
+			}
+
+			break;
+		}
+
 		case FaultInjectorTypeStatus:
 		{	
 			HASH_SEQ_STATUS			hash_status;

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -284,6 +284,8 @@ FaultInjectorIdentifierEnumToString[] = {
 		/* inject fault before an append-only delete */
 	_("appendonly_update"),
 		/* inject fault before an append-only update */
+	_("appendonly_skip_compression"),
+		/* inject fault in append-only compression function */
 	_("reindex_db"),
 		/* inject fault while reindex db is in progress */
 	_("reindex_relation"),
@@ -1064,6 +1066,7 @@ FaultInjector_NewHashEntry(
 
 			case InterconnectStopAckIsLost:
 			case SendQEDetailsInitBackend:
+			case AppendOnlySkipCompression:
 
 				break;
 			default:

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -181,6 +181,7 @@ typedef enum FaultInjectorIdentifier_e {
 	AppendOnlyInsert,
 	AppendOnlyDelete,
 	AppendOnlyUpdate,
+	AppendOnlySkipCompression,
 
 	ReindexDB,
 	ReindexRelation,

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -277,6 +277,7 @@ typedef enum FaultInjectorType_e {
 
 	FaultInjectorTypeCheckpointAndPanic,
 
+	FaultInjectorTypeWaitUntilTriggered,
 	/* INSERT has to be done before that line */
 	FaultInjectorTypeMax,
 	

--- a/src/test/regress/input/aocs.source
+++ b/src/test/regress/input/aocs.source
@@ -533,3 +533,33 @@ a.c1
 ;
 
 drop table bms_ao_bug;
+-- Small content as well as bulk dense content headers need to be used
+-- appropriately if compression is found to be not useful.  This test
+-- cover a bug where only small content headers were generated in such
+-- a case.
+create table aocs_small_and_dense_content (a int, b int) with
+(appendonly =true, orientation=column, blocksize=409600,
+ compresstype=rle_type, compresslevel=4);
+
+insert into aocs_small_and_dense_content select i,i from
+generate_series(1,800000)i;
+
+create extension if not exists gp_inject_fault;
+-- Inject fault on one primary segment that will cause compression to
+-- be considered not useful.
+select gp_inject_fault('appendonly_skip_compression', 'skip', '', '',
+'aocs_small_and_dense_content', -1, 0, dbid)
+from gp_segment_configuration where role = 'p' and content = 0;
+
+insert into aocs_small_and_dense_content select i,i from
+generate_series(1,800000)i;
+
+select gp_inject_fault('appendonly_skip_compression', 'wait_until_triggered', dbid)
+from gp_segment_configuration where role = 'p' and content = 0;
+
+-- This should not fail if small content or bulk dense content headers
+-- are used correctly in spite of compression not possible.
+select count(*) from aocs_small_and_dense_content;
+
+select gp_inject_fault('appendonly_skip_compression', 'reset', dbid)
+from gp_segment_configuration where role = 'p' and content = 0;

--- a/src/test/regress/output/aocs.source
+++ b/src/test/regress/output/aocs.source
@@ -1045,3 +1045,49 @@ a.c1
 (1 row)
 
 drop table bms_ao_bug;
+-- Small content as well as bulk dense content headers need to be used
+-- appropriately if compression is found to be not useful.  This test
+-- cover a bug where only small content headers were generated in such
+-- a case.
+create table aocs_small_and_dense_content (a int, b int) with
+(appendonly =true, orientation=column, blocksize=409600,
+ compresstype=rle_type, compresslevel=4);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into aocs_small_and_dense_content select i,i from
+generate_series(1,800000)i;
+create extension if not exists gp_inject_fault;
+-- Inject fault on one primary segment that will cause compression to
+-- be considered not useful.
+select gp_inject_fault('appendonly_skip_compression', 'skip', '', '',
+'aocs_small_and_dense_content', -1, 0, dbid)
+from gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+insert into aocs_small_and_dense_content select i,i from
+generate_series(1,800000)i;
+select gp_inject_fault('appendonly_skip_compression', 'wait_until_triggered', dbid)
+from gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+-- This should not fail if small content or bulk dense content headers
+-- are used correctly in spite of compression not possible.
+select count(*) from aocs_small_and_dense_content;
+  count  
+---------
+ 1600000
+(1 row)
+
+select gp_inject_fault('appendonly_skip_compression', 'reset', dbid)
+from gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+


### PR DESCRIPTION
The two commits to PR #4515 have been squashed into one.  A commit to introduce `wait_for_triggered` fault type is backported from master.

@tvar can you please take a look at the test case?