### PR TITLE
Give a better error message, if preparing an xact fails.

### DIFF
--- a/contrib/extprotocol/expected/exttableext.out
+++ b/contrib/extprotocol/expected/exttableext.out
@@ -11,7 +11,7 @@ NOTICE:  table "exttabtest_options_r" does not exist, skipping
     EXCEPT ALL
     SELECT * FROM exttabtest;
 ERROR:  This is greenplum. (gpextprotocol.c:54)
-DETAIL:  External table exttabtest_options_r, file demoprot://exttabtest.txt
+CONTEXT:  External table exttabtest_options_r, file demoprot://exttabtest.txt
     DROP EXTERNAL TABLE IF EXISTS exttabtest_w;
 NOTICE:  table "exttabtest_w" does not exist, skipping
     CREATE WRITABLE EXTERNAL TABLE exttabtest_w(like exttabtest)
@@ -435,7 +435,7 @@ NOTICE:  table "exttabtest_r_1record" does not exist, skipping
     -- and will cause following SElECT query to fail
     SELECT * FROM exttabtest_r_1record order by id;
 ERROR:  demoprot_import: could not open file "exttabtest_1record.txt" for reading: No such file or directory  (seg0 slice1 rh55-qavm55:7532 pid=23845)
-DETAIL:  External table exttabtest_r_1record, file demoprot://exttabtest_1record.txt
+CONTEXT:  External table exttabtest_r_1record, file demoprot://exttabtest_1record.txt
     -- Drop External Tables
     DROP EXTERNAL TABLE IF EXISTS exttabtest_r_1record;
     DROP EXTERNAL TABLE IF EXISTS exttabtest_w_1record;
@@ -1305,7 +1305,7 @@ ERROR:  formatter_export error: unsupported data type (gpformatter.c:100)  (seg1
     -- select should fail since INT type is not supported
     select count(*) from format_long_r;
 ERROR:  demoprot_import: could not open file "format_long_test13" for reading: No such file or directory  (seg1 slice1 rh55-qavm55:7533 pid=27134)
-DETAIL:  External table format_long_r
+CONTEXT:  External table format_long_r
     -- ERROR:  formatter_import error: unsupported data type (gpformatter.c:256)  (seg1 slice1 rh55-qavm57:5533 pid=20204) (cdbdisp.c:1458)
 -- Test 75: External table contains dropped columns
 -- SAS example formatter does NOT support dropping column from external table (both RET and WET).
@@ -1347,7 +1347,7 @@ ERROR:  formatter_export: dropped columns (gpformatter.c:80)  (seg0 rh55-qavm55:
     -- Read from RET using data file format_long_test13 create by previous test
     select count(*) from format_r;
 ERROR:  demoprot_import: could not open file "format_long_test13" for reading: No such file or directory  (seg0 slice1 rh55-qavm55:7532 pid=27212)
-DETAIL:  External table format_r
+CONTEXT:  External table format_r
     -- ERROR:  formatter_import: dropped columns (gpformatter.c:244)  (seg2 slice1 rh55-qavm58:5532 pid=20911) (cdbdisp.c:1458)
 -- Test 76: External table contains added column
 -- Add column to external table is fine.
@@ -1636,7 +1636,7 @@ ERROR:  protocol "demoprot" does not exist  (seg0 slice1 rh55-qavm55:7532 pid=18
     -- therefore the error is expected.
     select count(*) from exttabtest_r_new;
 ERROR:  internal error: demoprot called with a different protocol (demoprot_new) (gpextprotocol.c:106)  (seg0 slice1 rh55-qavm55:7532 pid=18394) (cdbdisp.c:1453)
-DETAIL:  External table exttabtest_r_new, file demoprot_new://exttabtest.txt
+CONTEXT:  External table exttabtest_r_new, file demoprot_new://exttabtest.txt
     -- Rename protocol name back to demoprot
     ALTER PROTOCOL demoprot_new RENAME to demoprot;
     -- Verify access old ext table that referencing old protocol name would succeed

--- a/contrib/formatter_fixedwidth/output/readable_query10.source
+++ b/contrib/formatter_fixedwidth/output/readable_query10.source
@@ -11,7 +11,7 @@ FORMAT 'CUSTOM' (formatter='fixedwidth_in',
 -- regardless null string and preserve_blanks settings.
 select * from tbl_ext_fixedwidth where col_null is null order by s1;
 ERROR:  the fixed width formatter requires a length specification for each one of the external table columns being used (currently <5>, however format string has <4>  (seg0 slice1 killnz1:64100 pid=5914)
-DETAIL:  External table tbl_ext_fixedwidth
+CONTEXT:  External table tbl_ext_fixedwidth
 -- This is true even using "LIKE other table" syntax when creating ext table
 -- Create heap table "missing_col_null", which has default value 'NULL' for column "col_null"
 DROP TABLE IF EXISTS heap_col_null;
@@ -60,4 +60,4 @@ Execute on: all segments
 -- Note field "col_null" is loaded with null value
 select * from tbl_ext_fixedwidth where col_null is null order by s1;
 ERROR:  the fixed width formatter requires a length specification for each one of the external table columns being used (currently <5>, however format string has <4>  (seg1 slice1 killnz1:64101 pid=5916)
-DETAIL:  External table tbl_ext_fixedwidth
+CONTEXT:  External table tbl_ext_fixedwidth

--- a/contrib/formatter_fixedwidth/output/readable_query11.source
+++ b/contrib/formatter_fixedwidth/output/readable_query11.source
@@ -33,4 +33,4 @@ FORMAT 'CUSTOM' (formatter='fixedwidth_in',
 -- query ext table correctly show the error message
 select * from tbl_ext_fixedwidth order by s1;
 ERROR:  value too long for type character varying(5)  (seg0 slice1 rh55-qavm55:7532 pid=23646)
-DETAIL:  External table tbl_ext_fixedwidth
+CONTEXT:  External table tbl_ext_fixedwidth

--- a/contrib/formatter_fixedwidth/output/readable_query12.source
+++ b/contrib/formatter_fixedwidth/output/readable_query12.source
@@ -10,4 +10,4 @@ FORMAT 'CUSTOM' (formatter='fixedwidth_in', s1='10',
     n3='10', n4='10', n5='10', n6='10', n7='15');
 SELECT * FROM tbl_ext_fixedwidth ORDER BY s1;
 ERROR:  Expected line size from the formatting string: 120, but the actual size is: 119  (seg0 slice1 rh55-qavm55:7532 pid=23898)
-DETAIL:  External table tbl_ext_fixedwidth
+CONTEXT:  External table tbl_ext_fixedwidth

--- a/contrib/formatter_fixedwidth/output/readable_query13.source
+++ b/contrib/formatter_fixedwidth/output/readable_query13.source
@@ -11,4 +11,4 @@ FORMAT 'CUSTOM' (formatter='fixedwidth_in', s1='10',
     n3='10', n4='10', n5='10', n6='10', n7='15');
 SELECT * FROM tbl_ext_fixedwidth ORDER BY s1;
 ERROR:  Expected line size from the formatting string: 120, but the actual size is: 105  (seg0 slice1 rh55-qavm55:7532 pid=23951)
-DETAIL:  External table tbl_ext_fixedwidth
+CONTEXT:  External table tbl_ext_fixedwidth

--- a/contrib/formatter_fixedwidth/output/readable_query18.source
+++ b/contrib/formatter_fixedwidth/output/readable_query18.source
@@ -9,4 +9,4 @@ FORMAT 'CUSTOM' (formatter='fixedwidth_in', s1='10',
     n5='10', n6='10', n7='15');
 select * from tbl_ext_fixedwidth order by s1;
 ERROR:  the fixed width formatter requires a length specification for each one of the external table columns being used (missing field <s_2>  (seg0 slice1 killnz1:64100 pid=7503)
-DETAIL:  External table tbl_ext_fixedwidth
+CONTEXT:  External table tbl_ext_fixedwidth

--- a/contrib/formatter_fixedwidth/output/readable_query19.source
+++ b/contrib/formatter_fixedwidth/output/readable_query19.source
@@ -10,4 +10,4 @@ FORMAT 'CUSTOM' (formatter='fixedwidth_in', s1='10',
     n3='10', n4='10', n5='10', n6='10', n7='15');
 SELECT * FROM tbl_ext_fixedwidth ORDER BY s1;
 ERROR:  invalid input syntax for integer: "bbb"  (seg0 slice1 rh55-qavm55:7532 pid=26366)
-DETAIL:  External table tbl_ext_fixedwidth
+CONTEXT:  External table tbl_ext_fixedwidth

--- a/contrib/formatter_fixedwidth/output/readable_query23.source
+++ b/contrib/formatter_fixedwidth/output/readable_query23.source
@@ -11,4 +11,4 @@ FORMAT 'CUSTOM' (formatter='fixedwidth_in', s1='10',
 SEGMENT REJECT LIMIT 3 ROWS;
 SELECT * FROM tbl_ext_fixedwidth ORDER BY s1;
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: invalid input syntax for integer: "u32"  (seg0 slice1 rh55-qavm55:7532 pid=27454)
-DETAIL:  External table tbl_ext_fixedwidth
+CONTEXT:  External table tbl_ext_fixedwidth

--- a/contrib/formatter_fixedwidth/output/readable_query26.source
+++ b/contrib/formatter_fixedwidth/output/readable_query26.source
@@ -21,7 +21,7 @@ LOG ERRORS
 SEGMENT REJECT LIMIT 10 PERCENT;
 select count(*) from tbl_ext_fixedwidth;
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: invalid input syntax for integer: "s32"  (seg1 slice1 rh55-qavm55:7533 pid=29678)
-DETAIL:  External table tbl_ext_fixedwidth
+CONTEXT:  External table tbl_ext_fixedwidth
 select count(*) > 44 from gp_read_error_log('tbl_ext_fixedwidth');
  ?column? 
 ----------

--- a/contrib/formatter_fixedwidth/output/readable_query29.source
+++ b/contrib/formatter_fixedwidth/output/readable_query29.source
@@ -8,4 +8,4 @@ FORMAT 'CUSTOM' (formatter='fixedwidth_in', preserve_blanks='on',
     s1='10',s2='10', s3='10');
 select * from tbl_ext_fixedwidth order by s1;
 ERROR:  A null_value was not defined. When preserve_blanks is on, a null_value 								 must be defined in the formatter arguments string  (seg1 slice1 rh55-qavm55:7533 pid=30448)
-DETAIL:  External table tbl_ext_fixedwidth
+CONTEXT:  External table tbl_ext_fixedwidth

--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -1170,8 +1170,9 @@ EndPrepare(GlobalTransaction gxact)
 	/* If we crash now, we have prepared: WAL replay will fix things */
 	if (Debug_abort_after_segment_prepared)
 	{
-		elog(PANIC,
-			 "Raise an error as directed by Debug_abort_after_segment_prepared");
+		ereport(PANIC,
+				(errcode(ERRCODE_FAULT_INJECT),
+				 errmsg("Raise an error as directed by Debug_abort_after_segment_prepared")));
 	}
 
 	/*

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -4245,14 +4245,14 @@ AfterTriggerSetState(ConstraintsSetStmt *stmt)
 	else
 	{
 		/* no snapshot needed */
-		if (Gp_role == GP_ROLE_DISPATCH)
-		{
-			CdbDispatchUtilityStatement((Node *) stmt,
-										DF_CANCEL_ON_ERROR|
-										DF_NEED_TWO_PHASE,
-										NIL,
-										NULL);
-		}
+	}
+	if (Gp_role == GP_ROLE_DISPATCH)
+	{
+		CdbDispatchUtilityStatement((Node *) stmt,
+									DF_CANCEL_ON_ERROR|
+									DF_NEED_TWO_PHASE,
+									NIL,
+									NULL);
 	}
 }
 

--- a/src/bin/gpfdist/regress/output/exttab1.source
+++ b/src/bin/gpfdist/regress/output/exttab1.source
@@ -495,7 +495,7 @@ select * from ext_fill1 order by a,b,c; -- should pad missing attrs with nulls
 
 select * from ext_fill2 order by a,b,c; -- should fail due to empty data line
 ERROR:  missing data for column "b", found empty data line  (seg0 slice1 @hostname@:50000 pid=64819)
-DETAIL:  External table ext_fill2, line 3 of gpfdist://@hostname@:7070/exttab1/missing_fields2.data: ""
+CONTEXT:  External table ext_fill2, line 3 of gpfdist://@hostname@:7070/exttab1/missing_fields2.data: ""
 select * from ext_fill3_fnn where c is null; -- should be empty
  a | b | c 
 ---+---+---
@@ -560,8 +560,7 @@ select * from ext_newline1; -- should pass. using the correct linefeed. file has
 
 select * from ext_newline2; -- should fail. using an incorrect linefeed. file has 'lf'.
 ERROR:  extra data after last expected column  (seg0 slice1 @hostname@:50000 pid=64819)
-DETAIL:  
-External table ext_newline2, line 1 of gpfdist://@hostname@:7070/exttab1/nation.tbl: "0|ALGERIA|0| haggle. carefully final deposits detect slyly agai
+CONTEXT:  External table ext_newline2, line 1 of gpfdist://@hostname@:7070/exttab1/nation.tbl: "0|ALGERIA|0| haggle. carefully final deposits detect slyly agai
 1|ARGENTINA|1|al foxes promise slyly..."
 drop external table ext_newline1;
 drop external table ext_newline2;

--- a/src/include/cdb/cdbdisp.h
+++ b/src/include/cdb/cdbdisp.h
@@ -132,8 +132,7 @@ CdbCheckDispatchResult(struct CdbDispatcherState *ds, DispatchWaitMode waitMode)
  *   QE error messages and qeErrorCode the thrown ERRCODE.
  */
 struct CdbDispatchResults *
-cdbdisp_getDispatchResults(struct CdbDispatcherState *ds,
-						   StringInfoData *qeErrorMsg, int *qeErrorCode);
+cdbdisp_getDispatchResults(struct CdbDispatcherState *ds, ErrorData **qeError);
 
 /*
  * Wait for all QEs to finish, then report any errors from the given

--- a/src/include/cdb/cdbdisp_dtx.h
+++ b/src/include/cdb/cdbdisp_dtx.h
@@ -34,15 +34,15 @@ struct CdbPgResults;
  */
 struct pg_result **
 CdbDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
-								   int flags,
-								   char	*dtxProtocolCommandLoggingStr,
-								   char	*gid,
-								   DistributedTransactionId	gxid,
-								   StringInfo errmsgbuf,
-								   int *resultCount,
-								   bool* badGangs,
-								   CdbDispatchDirectDesc *direct,
-								   char *argument, int argumentLength );
+							  int flags,
+							  char	*dtxProtocolCommandLoggingStr,
+							  char	*gid,
+							  DistributedTransactionId	gxid,
+							  ErrorData **qeError,
+							  int *resultCount,
+							  bool* badGangs,
+							  CdbDispatchDirectDesc *direct,
+							  char *argument, int argumentLength );
 
 
 /*

--- a/src/include/cdb/cdbdispatchresult.h
+++ b/src/include/cdb/cdbdispatchresult.h
@@ -265,12 +265,10 @@ void
 cdbdisp_debugDispatchResult(CdbDispatchResult  *dispatchResult);
 
 /*
- * Format a CdbDispatchResult into a StringInfo buffer provided by caller.
- * It reports at most one error.
+ * Construct an ErrorData from the dispatch results.
  */
-void
-cdbdisp_dumpDispatchResult(CdbDispatchResult *dispatchResult,
-                           struct StringInfoData *buf);
+ErrorData *
+cdbdisp_dumpDispatchResult(CdbDispatchResult *dispatchResult);
 
 /*
  * Format a CdbDispatchResults object.
@@ -278,9 +276,9 @@ cdbdisp_dumpDispatchResult(CdbDispatchResult *dispatchResult,
  * Returns ERRCODE_xxx if some error was found, or 0 if no errors.
  * Before calling this function, you must call CdbCheckDispatchResult().
  */
-int
+void
 cdbdisp_dumpDispatchResults(struct CdbDispatchResults *gangResults,
-                            struct StringInfoData *buffer);
+							ErrorData **qeError);
 
 /*
  * Return sum of the cmdTuples values from CdbDispatchResult

--- a/src/include/utils/elog.h
+++ b/src/include/utils/elog.h
@@ -204,6 +204,10 @@ void elog_internalerror(const char *filename, int lineno, const char *funcname)
 #define ereport(elevel, rest)	\
 	ereport_domain(elevel, TEXTDOMAIN, rest)
 
+#define ereport_and_return(elevel, rest)	\
+	(errstart((elevel), __FILE__, __LINE__, PG_FUNCNAME_MACRO, TEXTDOMAIN), \
+		errfinish_and_return rest )
+
 #define TEXTDOMAIN NULL
 
 /*
@@ -474,6 +478,8 @@ extern void FreeErrorData(ErrorData *edata);
 extern void FlushErrorState(void);
 extern void ReThrowError(ErrorData *edata)  __attribute__((__noreturn__));
 extern void pg_re_throw(void) __attribute__((noreturn));
+
+extern ErrorData *errfinish_and_return(int dummy,...);
 
 /*
  * CDB: elog_demote

--- a/src/pl/plperl/expected/plperl_trigger.out
+++ b/src/pl/plperl/expected/plperl_trigger.out
@@ -198,7 +198,7 @@ CREATE TRIGGER "test_trigger_recurse" BEFORE INSERT ON trigger_test
 FOR EACH ROW EXECUTE PROCEDURE "trigger_recurse"();
 INSERT INTO trigger_test (i, v) values (10000, 'top');
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement at line 6.
-DETAIL:  PL/Perl function "trigger_recurse"
+CONTEXT:  PL/Perl function "trigger_recurse"
 SELECT * FROM trigger_test;
  i |                v                 |   foo   
 ---+----------------------------------+---------

--- a/src/pl/plpython/expected/plpython_trigger.out
+++ b/src/pl/plpython/expected/plpython_trigger.out
@@ -252,15 +252,9 @@ CREATE TRIGGER stupid_trigger1
 BEFORE INSERT ON trigger_test
 FOR EACH ROW EXECUTE PROCEDURE stupid1();
 INSERT INTO trigger_test VALUES (1, 'one');
--- start_ignore
--- GPDB_90_MERGE_FIXME: The context information is printed differently than in
--- upstream. Why? Looks like some kind of a bug or deficiency in the error handling
--- code. In GPDB, these errors come from segments, probably related to that.
--- end_ignore
 ERROR:  unexpected return value from trigger procedure
-DETAIL:  
-Expected None or a string.
-PL/Python function "stupid1"
+DETAIL:  Expected None or a string.
+CONTEXT:  PL/Python function "stupid1"
 DROP TRIGGER stupid_trigger1 ON trigger_test;
 -- returning MODIFY from DELETE trigger
 CREATE FUNCTION stupid2() RETURNS trigger
@@ -285,9 +279,8 @@ BEFORE UPDATE ON trigger_test
 FOR EACH ROW EXECUTE PROCEDURE stupid3();
 UPDATE trigger_test SET v = 'null' WHERE i = 0;
 ERROR:  unexpected return value from trigger procedure
-DETAIL:  
-Expected None, "OK", "SKIP", or "MODIFY".
-PL/Python function "stupid3"
+DETAIL:  Expected None, "OK", "SKIP", or "MODIFY".
+CONTEXT:  PL/Python function "stupid3"
 DROP TRIGGER stupid_trigger3 ON trigger_test;
 -- Unicode variant
 CREATE FUNCTION stupid3u() RETURNS trigger
@@ -299,9 +292,8 @@ BEFORE UPDATE ON trigger_test
 FOR EACH ROW EXECUTE PROCEDURE stupid3u();
 UPDATE trigger_test SET v = 'null' WHERE i = 0;
 ERROR:  unexpected return value from trigger procedure
-DETAIL:  
-Expected None, "OK", "SKIP", or "MODIFY".
-PL/Python function "stupid3u"
+DETAIL:  Expected None, "OK", "SKIP", or "MODIFY".
+CONTEXT:  PL/Python function "stupid3u"
 DROP TRIGGER stupid_trigger3 ON trigger_test;
 -- deleting the TD dictionary
 CREATE FUNCTION stupid4() RETURNS trigger
@@ -314,8 +306,7 @@ BEFORE UPDATE ON trigger_test
 FOR EACH ROW EXECUTE PROCEDURE stupid4();
 UPDATE trigger_test SET v = 'null' WHERE i = 0;
 ERROR:  TD["new"] deleted, cannot modify row
-DETAIL:  
-while modifying trigger row
+CONTEXT:  while modifying trigger row
 PL/Python function "stupid4"
 DROP TRIGGER stupid_trigger4 ON trigger_test;
 -- TD not a dictionary
@@ -329,8 +320,7 @@ BEFORE UPDATE ON trigger_test
 FOR EACH ROW EXECUTE PROCEDURE stupid5();
 UPDATE trigger_test SET v = 'null' WHERE i = 0;
 ERROR:  TD["new"] is not a dictionary
-DETAIL:  
-while modifying trigger row
+CONTEXT:  while modifying trigger row
 PL/Python function "stupid5"
 DROP TRIGGER stupid_trigger5 ON trigger_test;
 -- TD not having string keys
@@ -344,8 +334,7 @@ BEFORE UPDATE ON trigger_test
 FOR EACH ROW EXECUTE PROCEDURE stupid6();
 UPDATE trigger_test SET v = 'null' WHERE i = 0;
 ERROR:  TD["new"] dictionary key at ordinal position 0 is not a string
-DETAIL:  
-while modifying trigger row
+CONTEXT:  while modifying trigger row
 PL/Python function "stupid6"
 DROP TRIGGER stupid_trigger6 ON trigger_test;
 -- TD keys not corresponding to row columns
@@ -359,8 +348,7 @@ BEFORE UPDATE ON trigger_test
 FOR EACH ROW EXECUTE PROCEDURE stupid7();
 UPDATE trigger_test SET v = 'null' WHERE i = 0;
 ERROR:  key "a" found in TD["new"] does not exist as a column in the triggering row
-DETAIL:  
-while modifying trigger row
+CONTEXT:  while modifying trigger row
 PL/Python function "stupid7"
 DROP TRIGGER stupid_trigger7 ON trigger_test;
 -- Unicode variant
@@ -374,8 +362,7 @@ BEFORE UPDATE ON trigger_test
 FOR EACH ROW EXECUTE PROCEDURE stupid7u();
 UPDATE trigger_test SET v = 'null' WHERE i = 0;
 ERROR:  key "a" found in TD["new"] does not exist as a column in the triggering row
-DETAIL:  
-while modifying trigger row
+CONTEXT:  while modifying trigger row
 PL/Python function "stupid7u"
 DROP TRIGGER stupid_trigger7 ON trigger_test;
 -- calling a trigger function directly

--- a/src/test/isolation2/expected/crash_recovery_dtm.out
+++ b/src/test/isolation2/expected/crash_recovery_dtm.out
@@ -185,7 +185,7 @@ t
 11: SET debug_abort_after_segment_prepared = true;
 SET
 11: DELETE FROM QE_panic_test_table;
-ERROR:  The distributed transaction 'Prepare' broadcast failed to one or more segments for gid = 1519017804-0000000012. (cdbtm.c:692)
+ERROR:  Raise an error as directed by Debug_abort_after_segment_prepared  (seg0 127.0.0.1:40000 pid=547)
 11: SELECT count(*) from QE_panic_test_table;
 count
 -----

--- a/src/test/isolation2/expected/deadlock_under_entry_db_singleton.out
+++ b/src/test/isolation2/expected/deadlock_under_entry_db_singleton.out
@@ -91,8 +91,7 @@ founddeadlockprocess
 -- tried to update table from ENTRY_DB_SINGLETON (which is read-only) in session1
 1<:  <... completed>
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db 127.0.0.1:15432 pid=94879)
-DETAIL:  
-SQL statement "UPDATE deadlock_entry_db_singleton_table SET d = d + 1  WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE deadlock_entry_db_singleton_table SET d = d + 1  WHERE c = $1"
 PL/pgSQL function "function_volatile" line 3 at SQL statement
 2<:  <... completed>
 UPDATE 10

--- a/src/test/isolation2/expected/starve_case.out
+++ b/src/test/isolation2/expected/starve_case.out
@@ -92,7 +92,7 @@ COMMIT
 -- see error column 'c' doesn't exist because session2 renamed it.
 3<:  <... completed>
 ERROR:  column "c" does not exist  (entry db 127.0.0.1:15432 pid=94829)
-DETAIL:  PL/pgSQL function "function_starve_volatile" line 5 at SQL statement
+CONTEXT:  PL/pgSQL function "function_starve_volatile" line 5 at SQL statement
 3: commit;
 COMMIT
 

--- a/src/test/isolation2/expected/udf_exception_blocks_panic_scenarios.out
+++ b/src/test/isolation2/expected/udf_exception_blocks_panic_scenarios.out
@@ -58,8 +58,7 @@ SET
 DROP TABLE IF EXISTS employees;
 DROP
 select test_protocol_allseg(1, 2,'f');
-ERROR:  DTM error (gathered results from cmd ' Begin Internal Subtransaction') (cdbtm.c:2040)
-DETAIL:  PANIC for debug_dtm_action = 4, debug_dtm_action_protocol =  Begin Internal Subtransaction (postgres.c:1490)  (seg1 127.0.1.1:25433 pid=27784)
+ERROR:  PANIC for debug_dtm_action = 4, debug_dtm_action_protocol =  Begin Internal Subtransaction (postgres.c:1490)  (seg1 127.0.1.1:25433 pid=27784)
 CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 8 during statement block entry
 ERROR:  could not connect to segment: initialization of segworker group failed
 -- make sure segment recovery is complete after panic.

--- a/src/test/regress/expected/distributed_transactions.out
+++ b/src/test/regress/expected/distributed_transactions.out
@@ -47,7 +47,6 @@ INSERT INTO distxact1_1 VALUES (7);
 INSERT INTO distxact1_1 VALUES (8);
 SET debug_abort_after_distributed_prepared = true;
 COMMIT;
-NOTICE:  Releasing segworker groups to retry broadcast.
 ERROR:  Raise an error as directed by Debug_abort_after_distributed_prepared
 RESET debug_abort_after_distributed_prepared;
 SELECT * FROM distxact1_1;
@@ -72,8 +71,7 @@ SET debug_dtm_action = "fail_begin_command";
 SET debug_dtm_action_target = "protocol";
 SET debug_dtm_action_protocol = "prepare";
 COMMIT;
-NOTICE:  Releasing segworker groups to retry broadcast.
-ERROR:  The distributed transaction 'Prepare' broadcast failed to one or more segments for gid = 1259106572-0000015083. (cdbtm.c:633)
+ERROR:  Raise ERROR for debug_dtm_action = 2, debug_dtm_action_protocol = Distributed Prepare  (seg1 127.0.0.1:40001 pid=25677)
 RESET debug_dtm_action;
 RESET debug_dtm_action_target;
 RESET debug_dtm_action_protocol;
@@ -136,7 +134,6 @@ SET debug_dtm_action_target = "protocol";
 SET debug_dtm_action_protocol = "abort_prepared";
 COMMIT;
 WARNING:  the distributed transaction 'Abort Prepared' broadcast failed to one or more segments for gid = 1477546849-0000000078.  Retrying ... try 1
-NOTICE:  Releasing segworker groups to retry broadcast.
 ERROR:  Raise an error as directed by Debug_abort_after_distributed_prepared
 SELECT * FROM distxact1_4;
  a 
@@ -211,9 +208,7 @@ CREATE TABLE distxact3_1 (a int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 SAVEPOINT s;
-ERROR:  could not execute command on QE
-DETAIL:  Raise ERROR for debug_dtm_action = 2, commandTag = SAVEPOINT  (seg1 cmcdevitt-mac-pro.local:50002 pid=66019)
-HINT:  command: 'RELEASE SAVEPOINT s'
+ERROR:  Raise ERROR for debug_dtm_action = 2, commandTag = SAVEPOINT  (seg1 127.0.0.1:40001 pid=19151)
 ROLLBACK;
 RESET debug_dtm_action_sql_command_tag;
 RESET debug_dtm_action;
@@ -248,9 +243,7 @@ INSERT INTO distxact3_2 VALUES (26);
 INSERT INTO distxact3_2 VALUES (27);
 INSERT INTO distxact3_2 VALUES (28);
 RELEASE SAVEPOINT s;
-ERROR:  could not execute command on QE
-DETAIL:  Raise ERROR for debug_dtm_action = 2, commandTag = RELEASE  (seg1 cmcdevitt-mac-pro.local:50002 pid=66019)
-HINT:  command: 'RELEASE SAVEPOINT s'
+ERROR:  Raise ERROR for debug_dtm_action = 2, commandTag = RELEASE  (seg1 127.0.0.1:40001 pid=19151)
 ROLLBACK;
 RESET debug_dtm_action_sql_command_tag;
 RESET debug_dtm_action;
@@ -285,9 +278,7 @@ INSERT INTO distxact3_3 VALUES (36);
 INSERT INTO distxact3_3 VALUES (37);
 INSERT INTO distxact3_3 VALUES (38);
 ROLLBACK TO SAVEPOINT s;
-ERROR:  could not execute command on QE
-DETAIL:  Raise ERROR for debug_dtm_action = 2, commandTag = ROLLBACK  (seg1 cmcdevitt-mac-pro.local:50002 pid=66019)
-HINT:  command: 'ROLLBACK TO SAVEPOINT s'
+ERROR:  Raise ERROR for debug_dtm_action = 2, commandTag = ROLLBACK  (seg1 127.0.0.1:40001 pid=19151)
 ROLLBACK;
 RESET debug_dtm_action_sql_command_tag;
 RESET debug_dtm_action;
@@ -800,7 +791,6 @@ select count(*) = 5 as passed from subt_reindex_co;
 \c postgres
 SET debug_abort_after_distributed_prepared = true;
 reindex table pg_class;
-NOTICE:  Releasing segworker groups to retry broadcast.
 ERROR:  Raise an error as directed by Debug_abort_after_distributed_prepared
 RESET debug_abort_after_distributed_prepared;
 \c regression

--- a/src/test/regress/expected/dml_in_udf.out
+++ b/src/test/regress/expected/dml_in_udf.out
@@ -298,8 +298,7 @@ END
 $$ LANGUAGE plpgsql VOLATILE MODIFIES SQL DATA;
 INSERT INTO volatilefn_dml_int8(col1,col3) SELECT col2,dml_in_udf_func(14) FROM volatilefn_dml_int8_candidate;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 rh55-qavm52:34533 pid=31563)
-DETAIL:  
-SQL statement "DROP TABLE IF EXISTS udftest_foo"
+CONTEXT:  SQL statement "DROP TABLE IF EXISTS udftest_foo"
 PL/pgSQL function "dml_in_udf_func" line 2 at SQL statement
 SELECT * FROM volatilefn_dml_int8 ORDER BY 1,2,3;
  col1 | col2 | col3 | col4 

--- a/src/test/regress/expected/plpgsql.out
+++ b/src/test/regress/expected/plpgsql.out
@@ -1026,213 +1026,171 @@ insert into Room values ('106', 'Office');
 --
 insert into WSlot values ('WS.001.1a', '001', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.001.1b', '001', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.001.2a', '001', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.001.2b', '001', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.001.3a', '001', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.001.3b', '001', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.002.1a', '002', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.002.1b', '002', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.002.2a', '002', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.002.2b', '002', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.002.3a', '002', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.002.3b', '002', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.003.1a', '003', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.003.1b', '003', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.003.2a', '003', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.003.2b', '003', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.003.3a', '003', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.003.3b', '003', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.101.1a', '101', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.101.1b', '101', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.101.2a', '101', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.101.2b', '101', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.101.3a', '101', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.101.3b', '101', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.102.1a', '102', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.102.1b', '102', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.102.2a', '102', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.102.2b', '102', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.102.3a', '102', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.102.3b', '102', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.105.1a', '105', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.105.1b', '105', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.105.2a', '105', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.105.2b', '105', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.105.3a', '105', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.105.3b', '105', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.106.1a', '106', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.106.1b', '106', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.106.2a', '106', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.106.2b', '106', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.106.3a', '106', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.106.3b', '106', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 --
 -- Now create the patch fields and their slots
@@ -1243,96 +1201,78 @@ insert into PField values ('PF0_1', 'Wallslots basement');
 --
 insert into PSlot values ('PS.base.a1', 'PF0_1', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.a2', 'PF0_1', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.a3', 'PF0_1', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.a4', 'PF0_1', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.a5', 'PF0_1', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.a6', 'PF0_1', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 --
 -- These are already wired to the wall connectors
 --
 insert into PSlot values ('PS.base.b1', 'PF0_1', '', 'WS.002.1a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.b2', 'PF0_1', '', 'WS.002.1b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.b3', 'PF0_1', '', 'WS.002.2a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.b4', 'PF0_1', '', 'WS.002.2b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.b5', 'PF0_1', '', 'WS.002.3a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.b6', 'PF0_1', '', 'WS.002.3b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.c1', 'PF0_1', '', 'WS.003.1a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.c2', 'PF0_1', '', 'WS.003.1b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.c3', 'PF0_1', '', 'WS.003.2a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.c4', 'PF0_1', '', 'WS.003.2b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.c5', 'PF0_1', '', 'WS.003.3a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.c6', 'PF0_1', '', 'WS.003.3b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 --
 -- This patchfield will be renamed later into PF0_2 - so its
@@ -1341,184 +1281,148 @@ PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PField values ('PF0_X', 'Phonelines basement');
 insert into PSlot values ('PS.base.ta1', 'PF0_X', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.ta2', 'PF0_X', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.ta3', 'PF0_X', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.ta4', 'PF0_X', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.ta5', 'PF0_X', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.ta6', 'PF0_X', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.tb1', 'PF0_X', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.tb2', 'PF0_X', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.tb3', 'PF0_X', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.tb4', 'PF0_X', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.tb5', 'PF0_X', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.tb6', 'PF0_X', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PField values ('PF1_1', 'Wallslots first floor');
 insert into PSlot values ('PS.first.a1', 'PF1_1', '', 'WS.101.1a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.a2', 'PF1_1', '', 'WS.101.1b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.a3', 'PF1_1', '', 'WS.101.2a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.a4', 'PF1_1', '', 'WS.101.2b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.a5', 'PF1_1', '', 'WS.101.3a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.a6', 'PF1_1', '', 'WS.101.3b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.b1', 'PF1_1', '', 'WS.102.1a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.b2', 'PF1_1', '', 'WS.102.1b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.b3', 'PF1_1', '', 'WS.102.2a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.b4', 'PF1_1', '', 'WS.102.2b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.b5', 'PF1_1', '', 'WS.102.3a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.b6', 'PF1_1', '', 'WS.102.3b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.c1', 'PF1_1', '', 'WS.105.1a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.c2', 'PF1_1', '', 'WS.105.1b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.c3', 'PF1_1', '', 'WS.105.2a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.c4', 'PF1_1', '', 'WS.105.2b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.c5', 'PF1_1', '', 'WS.105.3a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.c6', 'PF1_1', '', 'WS.105.3b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.d1', 'PF1_1', '', 'WS.106.1a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.d2', 'PF1_1', '', 'WS.106.1b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.d3', 'PF1_1', '', 'WS.106.2a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.d4', 'PF1_1', '', 'WS.106.2b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.d5', 'PF1_1', '', 'WS.106.3a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.d6', 'PF1_1', '', 'WS.106.3b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 --
 -- Now we wire the wall connectors 1a-2a in room 001 to the
@@ -1601,63 +1505,51 @@ select * from PSlot where slotname ~ 'PS.base.a' order by slotname;
 insert into PField values ('PF1_2', 'Phonelines first floor');
 insert into PSlot values ('PS.first.ta1', 'PF1_2', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.ta2', 'PF1_2', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.ta3', 'PF1_2', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.ta4', 'PF1_2', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.ta5', 'PF1_2', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.ta6', 'PF1_2', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.tb1', 'PF1_2', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.tb2', 'PF1_2', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.tb3', 'PF1_2', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.tb4', 'PF1_2', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.tb5', 'PF1_2', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.tb6', 'PF1_2', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 --
 -- Fix the wrong name for patchfield PF0_2
@@ -1682,141 +1574,121 @@ select * from WSlot order by slotname;
 --
 insert into PLine values ('PL.001', '-0', 'Central call', 'PS.base.ta1');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.002', '-101', '', 'PS.base.ta2');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.003', '-102', '', 'PS.base.ta3');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.004', '-103', '', 'PS.base.ta5');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.005', '-104', '', 'PS.base.ta6');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.006', '-106', '', 'PS.base.tb2');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.007', '-108', '', 'PS.base.tb3');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.008', '-109', '', 'PS.base.tb4');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.009', '-121', '', 'PS.base.tb5');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.010', '-122', '', 'PS.base.tb6');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.015', '-134', '', 'PS.first.ta1');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.016', '-137', '', 'PS.first.ta3');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.017', '-139', '', 'PS.first.ta4');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.018', '-362', '', 'PS.first.tb1');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.019', '-363', '', 'PS.first.tb2');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.020', '-364', '', 'PS.first.tb3');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.021', '-365', '', 'PS.first.tb5');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.022', '-367', '', 'PS.first.tb6');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.028', '-501', 'Fax entrance', 'PS.base.ta2');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.029', '-502', 'Fax first floor', 'PS.first.ta1');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
@@ -1826,32 +1698,28 @@ PL/pgSQL function "tg_backlink_a" line 6 at assignment
 --
 insert into PHone values ('PH.hc001', 'Hicom standard', 'WS.001.1a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.wslot"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select          * from WSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from WSlot where slotname = myname"
 PL/pgSQL function "tg_slotlink_set" line 37 at SQL statement
 SQL statement "SELECT tg_slotlink_set(new.slotlink, new.slotname)"
 PL/pgSQL function "tg_slotlink_a" line 6 at assignment
 update PSlot set slotlink = 'PS.base.ta1' where slotname = 'PS.base.a1';
 insert into PHone values ('PH.hc002', 'Hicom standard', 'WS.002.1a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.wslot"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select          * from WSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from WSlot where slotname = myname"
 PL/pgSQL function "tg_slotlink_set" line 37 at SQL statement
 SQL statement "SELECT tg_slotlink_set(new.slotlink, new.slotname)"
 PL/pgSQL function "tg_slotlink_a" line 6 at assignment
 update PSlot set slotlink = 'PS.base.ta5' where slotname = 'PS.base.b1';
 insert into PHone values ('PH.hc003', 'Hicom standard', 'WS.002.2a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.wslot"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select          * from WSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from WSlot where slotname = myname"
 PL/pgSQL function "tg_slotlink_set" line 37 at SQL statement
 SQL statement "SELECT tg_slotlink_set(new.slotlink, new.slotname)"
 PL/pgSQL function "tg_slotlink_a" line 6 at assignment
 update PSlot set slotlink = 'PS.base.tb2' where slotname = 'PS.base.b3';
 insert into PHone values ('PH.fax001', 'Canon fax', 'WS.001.2a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.wslot"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select          * from WSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from WSlot where slotname = myname"
 PL/pgSQL function "tg_slotlink_set" line 37 at SQL statement
 SQL statement "SELECT tg_slotlink_set(new.slotlink, new.slotname)"
 PL/pgSQL function "tg_slotlink_a" line 6 at assignment
@@ -1862,8 +1730,7 @@ update PSlot set slotlink = 'PS.base.ta2' where slotname = 'PS.base.a3';
 --
 insert into Hub values ('base.hub1', 'Patchfield PF0_1 hub', 16);
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "insert into HSlot (slotname, hubname, slotno, slotlink)
+CONTEXT:  SQL statement "insert into HSlot (slotname, hubname, slotno, slotlink)
 		values ('HS.dummy', hname, i, '')"
 PL/pgSQL function "tg_hub_adjustslots" line 10 at SQL statement
 SQL statement "SELECT tg_hub_adjustslots(new.name, 0, new.nslots)"
@@ -1871,8 +1738,7 @@ PL/pgSQL function "tg_hub_a" line 6 at assignment
 insert into System values ('orion', 'PC');
 insert into IFace values ('IF', 'orion', 'eth0', 'WS.002.1b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.system"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select             * from system where name = new.sysname"
+CONTEXT:  SQL statement "select             * from system where name = new.sysname"
 PL/pgSQL function "tg_iface_biu" line 5 at SQL statement
 update PSlot set slotlink = 'HS.base.hub1.1' where slotname = 'PS.base.b2';
 --
@@ -1900,24 +1766,20 @@ update PSlot set slotlink = 'PS.not.there' where slotname = 'PS.base.a1';
 update PSlot set slotlink = 'XX.illegal' where slotname = 'PS.base.a1';
 insert into HSlot values ('HS', 'base.hub1', 1, '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.hub"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select             * from Hub where name = new.hubname"
+CONTEXT:  SQL statement "select             * from Hub where name = new.hubname"
 PL/pgSQL function "tg_hslot_biu" line 6 at SQL statement
 insert into HSlot values ('HS', 'base.hub1', 20, '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.hub"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select             * from Hub where name = new.hubname"
+CONTEXT:  SQL statement "select             * from Hub where name = new.hubname"
 PL/pgSQL function "tg_hslot_biu" line 6 at SQL statement
 delete from HSlot;
 insert into IFace values ('IF', 'notthere', 'eth0', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.system"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select             * from system where name = new.sysname"
+CONTEXT:  SQL statement "select             * from system where name = new.sysname"
 PL/pgSQL function "tg_iface_biu" line 5 at SQL statement
 insert into IFace values ('IF', 'orion', 'ethernet_interface_name_too_long', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.system"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select             * from system where name = new.sysname"
+CONTEXT:  SQL statement "select             * from system where name = new.sysname"
 PL/pgSQL function "tg_iface_biu" line 5 at SQL statement
 --
 -- The following tests are unrelated to the scenario outlined above;

--- a/src/test/regress/expected/plpgsql_optimizer.out
+++ b/src/test/regress/expected/plpgsql_optimizer.out
@@ -1026,213 +1026,171 @@ insert into Room values ('106', 'Office');
 --
 insert into WSlot values ('WS.001.1a', '001', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.001.1b', '001', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.001.2a', '001', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.001.2b', '001', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.001.3a', '001', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.001.3b', '001', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.002.1a', '002', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.002.1b', '002', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.002.2a', '002', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.002.2b', '002', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.002.3a', '002', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.002.3b', '002', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.003.1a', '003', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.003.1b', '003', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.003.2a', '003', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.003.2b', '003', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.003.3a', '003', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.003.3b', '003', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.101.1a', '101', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.101.1b', '101', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.101.2a', '101', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.101.2b', '101', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.101.3a', '101', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.101.3b', '101', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.102.1a', '102', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.102.1b', '102', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.102.2a', '102', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.102.2b', '102', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.102.3a', '102', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.102.3b', '102', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.105.1a', '105', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.105.1b', '105', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.105.2a', '105', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.105.2b', '105', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.105.3a', '105', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.105.3b', '105', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.106.1a', '106', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.106.1b', '106', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.106.2a', '106', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.106.2b', '106', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.106.3a', '106', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.106.3b', '106', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
+CONTEXT:  SQL statement "SELECT count(*) = 0 from Room where roomno = new.roomno"
 PL/pgSQL function "tg_wslot_biu" line 2 at IF
 --
 -- Now create the patch fields and their slots
@@ -1243,96 +1201,78 @@ insert into PField values ('PF0_1', 'Wallslots basement');
 --
 insert into PSlot values ('PS.base.a1', 'PF0_1', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.a2', 'PF0_1', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.a3', 'PF0_1', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.a4', 'PF0_1', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.a5', 'PF0_1', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.a6', 'PF0_1', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 --
 -- These are already wired to the wall connectors
 --
 insert into PSlot values ('PS.base.b1', 'PF0_1', '', 'WS.002.1a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.b2', 'PF0_1', '', 'WS.002.1b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.b3', 'PF0_1', '', 'WS.002.2a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.b4', 'PF0_1', '', 'WS.002.2b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.b5', 'PF0_1', '', 'WS.002.3a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.b6', 'PF0_1', '', 'WS.002.3b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.c1', 'PF0_1', '', 'WS.003.1a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.c2', 'PF0_1', '', 'WS.003.1b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.c3', 'PF0_1', '', 'WS.003.2a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.c4', 'PF0_1', '', 'WS.003.2b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.c5', 'PF0_1', '', 'WS.003.3a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.c6', 'PF0_1', '', 'WS.003.3b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 --
 -- This patchfield will be renamed later into PF0_2 - so its
@@ -1341,184 +1281,148 @@ PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PField values ('PF0_X', 'Phonelines basement');
 insert into PSlot values ('PS.base.ta1', 'PF0_X', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.ta2', 'PF0_X', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.ta3', 'PF0_X', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.ta4', 'PF0_X', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.ta5', 'PF0_X', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.ta6', 'PF0_X', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.tb1', 'PF0_X', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.tb2', 'PF0_X', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.tb3', 'PF0_X', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.tb4', 'PF0_X', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.tb5', 'PF0_X', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.tb6', 'PF0_X', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PField values ('PF1_1', 'Wallslots first floor');
 insert into PSlot values ('PS.first.a1', 'PF1_1', '', 'WS.101.1a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.a2', 'PF1_1', '', 'WS.101.1b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.a3', 'PF1_1', '', 'WS.101.2a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.a4', 'PF1_1', '', 'WS.101.2b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.a5', 'PF1_1', '', 'WS.101.3a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.a6', 'PF1_1', '', 'WS.101.3b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.b1', 'PF1_1', '', 'WS.102.1a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.b2', 'PF1_1', '', 'WS.102.1b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.b3', 'PF1_1', '', 'WS.102.2a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.b4', 'PF1_1', '', 'WS.102.2b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.b5', 'PF1_1', '', 'WS.102.3a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.b6', 'PF1_1', '', 'WS.102.3b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.c1', 'PF1_1', '', 'WS.105.1a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.c2', 'PF1_1', '', 'WS.105.1b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.c3', 'PF1_1', '', 'WS.105.2a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.c4', 'PF1_1', '', 'WS.105.2b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.c5', 'PF1_1', '', 'WS.105.3a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.c6', 'PF1_1', '', 'WS.105.3b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.d1', 'PF1_1', '', 'WS.106.1a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.d2', 'PF1_1', '', 'WS.106.1b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.d3', 'PF1_1', '', 'WS.106.2a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.d4', 'PF1_1', '', 'WS.106.2b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.d5', 'PF1_1', '', 'WS.106.3a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.d6', 'PF1_1', '', 'WS.106.3b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 --
 -- Now we wire the wall connectors 1a-2a in room 001 to the
@@ -1601,63 +1505,51 @@ select * from PSlot where slotname ~ 'PS.base.a' order by slotname;
 insert into PField values ('PF1_2', 'Phonelines first floor');
 insert into PSlot values ('PS.first.ta1', 'PF1_2', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.ta2', 'PF1_2', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.ta3', 'PF1_2', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.ta4', 'PF1_2', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.ta5', 'PF1_2', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.ta6', 'PF1_2', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.tb1', 'PF1_2', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.tb2', 'PF1_2', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.tb3', 'PF1_2', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.tb4', 'PF1_2', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.tb5', 'PF1_2', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.first.tb6', 'PF1_2', '', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select            * from PField where name = ps.pfname"
+CONTEXT:  SQL statement "select            * from PField where name = ps.pfname"
 PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 --
 -- Fix the wrong name for patchfield PF0_2
@@ -1682,141 +1574,121 @@ select * from WSlot order by slotname;
 --
 insert into PLine values ('PL.001', '-0', 'Central call', 'PS.base.ta1');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.002', '-101', '', 'PS.base.ta2');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.003', '-102', '', 'PS.base.ta3');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.004', '-103', '', 'PS.base.ta5');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.005', '-104', '', 'PS.base.ta6');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.006', '-106', '', 'PS.base.tb2');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.007', '-108', '', 'PS.base.tb3');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.008', '-109', '', 'PS.base.tb4');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.009', '-121', '', 'PS.base.tb5');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.010', '-122', '', 'PS.base.tb6');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.015', '-134', '', 'PS.first.ta1');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.016', '-137', '', 'PS.first.ta3');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.017', '-139', '', 'PS.first.ta4');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.018', '-362', '', 'PS.first.tb1');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.019', '-363', '', 'PS.first.tb2');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.020', '-364', '', 'PS.first.tb3');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.021', '-365', '', 'PS.first.tb5');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.022', '-367', '', 'PS.first.tb6');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.028', '-501', 'Fax entrance', 'PS.base.ta2');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.029', '-502', 'Fax first floor', 'PS.first.ta1');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select          * from PSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
 SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function "tg_backlink_a" line 6 at assignment
@@ -1826,32 +1698,28 @@ PL/pgSQL function "tg_backlink_a" line 6 at assignment
 --
 insert into PHone values ('PH.hc001', 'Hicom standard', 'WS.001.1a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.wslot"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select          * from WSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from WSlot where slotname = myname"
 PL/pgSQL function "tg_slotlink_set" line 37 at SQL statement
 SQL statement "SELECT tg_slotlink_set(new.slotlink, new.slotname)"
 PL/pgSQL function "tg_slotlink_a" line 6 at assignment
 update PSlot set slotlink = 'PS.base.ta1' where slotname = 'PS.base.a1';
 insert into PHone values ('PH.hc002', 'Hicom standard', 'WS.002.1a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.wslot"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select          * from WSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from WSlot where slotname = myname"
 PL/pgSQL function "tg_slotlink_set" line 37 at SQL statement
 SQL statement "SELECT tg_slotlink_set(new.slotlink, new.slotname)"
 PL/pgSQL function "tg_slotlink_a" line 6 at assignment
 update PSlot set slotlink = 'PS.base.ta5' where slotname = 'PS.base.b1';
 insert into PHone values ('PH.hc003', 'Hicom standard', 'WS.002.2a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.wslot"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select          * from WSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from WSlot where slotname = myname"
 PL/pgSQL function "tg_slotlink_set" line 37 at SQL statement
 SQL statement "SELECT tg_slotlink_set(new.slotlink, new.slotname)"
 PL/pgSQL function "tg_slotlink_a" line 6 at assignment
 update PSlot set slotlink = 'PS.base.tb2' where slotname = 'PS.base.b3';
 insert into PHone values ('PH.fax001', 'Canon fax', 'WS.001.2a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.wslot"  (seg0 127.0.0.1:40000 pid=1760)
-DETAIL:  
-SQL statement "select          * from WSlot where slotname = myname"
+CONTEXT:  SQL statement "select          * from WSlot where slotname = myname"
 PL/pgSQL function "tg_slotlink_set" line 37 at SQL statement
 SQL statement "SELECT tg_slotlink_set(new.slotlink, new.slotname)"
 PL/pgSQL function "tg_slotlink_a" line 6 at assignment
@@ -1862,8 +1730,7 @@ update PSlot set slotlink = 'PS.base.ta2' where slotname = 'PS.base.a3';
 --
 insert into Hub values ('base.hub1', 'Patchfield PF0_1 hub', 16);
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg1 127.0.0.1:40001 pid=1761)
-DETAIL:  
-SQL statement "insert into HSlot (slotname, hubname, slotno, slotlink)
+CONTEXT:  SQL statement "insert into HSlot (slotname, hubname, slotno, slotlink)
 		values ('HS.dummy', hname, i, '')"
 PL/pgSQL function "tg_hub_adjustslots" line 10 at SQL statement
 SQL statement "SELECT tg_hub_adjustslots(new.name, 0, new.nslots)"
@@ -1871,8 +1738,7 @@ PL/pgSQL function "tg_hub_a" line 6 at assignment
 insert into System values ('orion', 'PC');
 insert into IFace values ('IF', 'orion', 'eth0', 'WS.002.1b');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.system"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select             * from system where name = new.sysname"
+CONTEXT:  SQL statement "select             * from system where name = new.sysname"
 PL/pgSQL function "tg_iface_biu" line 5 at SQL statement
 update PSlot set slotlink = 'HS.base.hub1.1' where slotname = 'PS.base.b2';
 --
@@ -1900,24 +1766,20 @@ update PSlot set slotlink = 'PS.not.there' where slotname = 'PS.base.a1';
 update PSlot set slotlink = 'XX.illegal' where slotname = 'PS.base.a1';
 insert into HSlot values ('HS', 'base.hub1', 1, '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.hub"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select             * from Hub where name = new.hubname"
+CONTEXT:  SQL statement "select             * from Hub where name = new.hubname"
 PL/pgSQL function "tg_hslot_biu" line 6 at SQL statement
 insert into HSlot values ('HS', 'base.hub1', 20, '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.hub"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select             * from Hub where name = new.hubname"
+CONTEXT:  SQL statement "select             * from Hub where name = new.hubname"
 PL/pgSQL function "tg_hslot_biu" line 6 at SQL statement
 delete from HSlot;
 insert into IFace values ('IF', 'notthere', 'eth0', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.system"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select             * from system where name = new.sysname"
+CONTEXT:  SQL statement "select             * from system where name = new.sysname"
 PL/pgSQL function "tg_iface_biu" line 5 at SQL statement
 insert into IFace values ('IF', 'orion', 'ethernet_interface_name_too_long', '');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.system"  (seg2 127.0.0.1:40002 pid=1762)
-DETAIL:  
-SQL statement "select             * from system where name = new.sysname"
+CONTEXT:  SQL statement "select             * from system where name = new.sysname"
 PL/pgSQL function "tg_iface_biu" line 5 at SQL statement
 --
 -- The following tests are unrelated to the scenario outlined above;

--- a/src/test/regress/expected/qp_functions.out
+++ b/src/test/regress/expected/qp_functions.out
@@ -549,7 +549,7 @@ select child_list('grand_parent');
 
 select name, child_list(name) from fun_tree;
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.fun_tree"  (seg0 slice1 krajaraman:25432 pid=57476)
-DETAIL:  SQL function "child_list" during startup
+CONTEXT:  SQL function "child_list" during startup
 -- start_ignore
 create or replace function fun_array(anyelement,anyelement) returns anyarray AS $$ select array[$1,$2]; $$ language sql;
 -- end_ignore

--- a/src/test/regress/expected/qp_functions_in_from.out
+++ b/src/test/regress/expected/qp_functions_in_from.out
@@ -454,8 +454,7 @@ SELECT * FROM func1_sql_setint_imm(5), foo order by 1,2,3;
 -- @description function_in_from_join_9.sql
 SELECT * FROM func1_read_int_sql_vol(5), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_vol" line 4 at SQL statement
 -- @description function_in_from_join_10.sql
 SELECT * FROM func1_read_int_sql_stb(5), foo order by 1,2,3; 
@@ -477,8 +476,7 @@ SELECT * FROM func1_read_int_sql_stb(5), foo order by 1,2,3;
 begin;
 SELECT * FROM func1_mod_int_vol(5), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_from_join_14.sql
@@ -587,8 +585,7 @@ SELECT * FROM func1_nosql_vol(func2_sql_int_imm(5)), foo order by 1,2,3;
 -- @description function_in_from_join_withfunc2_6.sql
 SELECT * FROM func1_nosql_vol(func2_read_int_vol(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_from_join_withfunc2_7.sql
 SELECT * FROM func1_nosql_vol(func2_read_int_stb(5)), foo order by 1,2,3; 
@@ -610,8 +607,7 @@ SELECT * FROM func1_nosql_vol(func2_read_int_stb(5)), foo order by 1,2,3;
 begin;
 SELECT * FROM func1_nosql_vol(func2_mod_int_vol(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_from_join_withfunc2_9.sql
@@ -720,8 +716,7 @@ SELECT * FROM func1_nosql_stb(func2_sql_int_imm(5)), foo order by 1,2,3;
 -- @description function_in_from_join_withfunc2_16.sql
 SELECT * FROM func1_nosql_stb(func2_read_int_vol(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_from_join_withfunc2_17.sql
 SELECT * FROM func1_nosql_stb(func2_read_int_stb(5)), foo order by 1,2,3; 
@@ -743,8 +738,7 @@ SELECT * FROM func1_nosql_stb(func2_read_int_stb(5)), foo order by 1,2,3;
 begin;
 SELECT * FROM func1_nosql_stb(func2_mod_int_vol(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_from_join_withfunc2_19.sql
@@ -853,8 +847,7 @@ SELECT * FROM func1_nosql_imm(func2_sql_int_imm(5)), foo order by 1,2,3;
 -- @description function_in_from_join_withfunc2_26.sql
 SELECT * FROM func1_nosql_imm(func2_read_int_vol(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_from_join_withfunc2_27.sql
 SELECT * FROM func1_nosql_imm(func2_read_int_stb(5)), foo order by 1,2,3; 
@@ -876,8 +869,7 @@ SELECT * FROM func1_nosql_imm(func2_read_int_stb(5)), foo order by 1,2,3;
 begin;
 SELECT * FROM func1_nosql_imm(func2_mod_int_vol(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_from_join_withfunc2_29.sql
@@ -986,8 +978,7 @@ SELECT * FROM func1_sql_int_vol(func2_sql_int_imm(5)), foo order by 1,2,3;
 -- @description function_in_from_join_withfunc2_36.sql
 SELECT * FROM func1_sql_int_vol(func2_read_int_vol(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_from_join_withfunc2_37.sql
 SELECT * FROM func1_sql_int_vol(func2_read_int_stb(5)), foo order by 1,2,3; 
@@ -1009,8 +1000,7 @@ SELECT * FROM func1_sql_int_vol(func2_read_int_stb(5)), foo order by 1,2,3;
 begin;
 SELECT * FROM func1_sql_int_vol(func2_mod_int_vol(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_from_join_withfunc2_39.sql
@@ -1119,8 +1109,7 @@ SELECT * FROM func1_sql_int_stb(func2_sql_int_imm(5)), foo order by 1,2,3;
 -- @description function_in_from_join_withfunc2_46.sql
 SELECT * FROM func1_sql_int_stb(func2_read_int_vol(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_from_join_withfunc2_47.sql
 SELECT * FROM func1_sql_int_stb(func2_read_int_stb(5)), foo order by 1,2,3; 
@@ -1142,8 +1131,7 @@ SELECT * FROM func1_sql_int_stb(func2_read_int_stb(5)), foo order by 1,2,3;
 begin;
 SELECT * FROM func1_sql_int_stb(func2_mod_int_vol(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_from_join_withfunc2_49.sql
@@ -1252,8 +1240,7 @@ SELECT * FROM func1_sql_int_imm(func2_sql_int_imm(5)), foo order by 1,2,3;
 -- @description function_in_from_join_withfunc2_56.sql
 SELECT * FROM func1_sql_int_imm(func2_read_int_vol(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_from_join_withfunc2_57.sql
 SELECT * FROM func1_sql_int_imm(func2_read_int_stb(5)), foo order by 1,2,3; 
@@ -1275,8 +1262,7 @@ SELECT * FROM func1_sql_int_imm(func2_read_int_stb(5)), foo order by 1,2,3;
 begin;
 SELECT * FROM func1_sql_int_imm(func2_mod_int_vol(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_from_join_withfunc2_59.sql
@@ -2738,57 +2724,48 @@ rollback;
 -- @description function_in_from_join_withfunc2_90.sql
 SELECT * FROM func1_read_int_sql_vol(func2_nosql_vol(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_vol" line 4 at SQL statement
 -- @description function_in_from_join_withfunc2_91.sql
 SELECT * FROM func1_read_int_sql_vol(func2_nosql_stb(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_vol" line 4 at SQL statement
 -- @description function_in_from_join_withfunc2_92.sql
 SELECT * FROM func1_read_int_sql_vol(func2_nosql_imm(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_vol" line 4 at SQL statement
 -- @description function_in_from_join_withfunc2_93.sql
 SELECT * FROM func1_read_int_sql_vol(func2_sql_int_vol(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_vol" line 4 at SQL statement
 -- @description function_in_from_join_withfunc2_94.sql
 SELECT * FROM func1_read_int_sql_vol(func2_sql_int_stb(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_vol" line 4 at SQL statement
 -- @description function_in_from_join_withfunc2_95.sql
 SELECT * FROM func1_read_int_sql_vol(func2_sql_int_imm(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_vol" line 4 at SQL statement
 -- @description function_in_from_join_withfunc2_96.sql
 SELECT * FROM func1_read_int_sql_vol(func2_read_int_vol(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_from_join_withfunc2_97.sql
 SELECT * FROM func1_read_int_sql_vol(func2_read_int_stb(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_vol" line 4 at SQL statement
 -- @description function_in_from_join_withfunc2_98.sql
 begin;
 SELECT * FROM func1_read_int_sql_vol(func2_mod_int_vol(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_from_join_withfunc2_99.sql
@@ -2801,8 +2778,7 @@ rollback;
 -- @description function_in_from_join_withfunc2_100.sql
 SELECT * FROM func1_read_int_sql_stb(func2_nosql_vol(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_stb" line 4 at SQL statement
 -- @description function_in_from_join_withfunc2_101.sql
 SELECT * FROM func1_read_int_sql_stb(func2_nosql_stb(5)), foo order by 1,2,3; 
@@ -2839,8 +2815,7 @@ SELECT * FROM func1_read_int_sql_stb(func2_nosql_imm(5)), foo order by 1,2,3;
 -- @description function_in_from_join_withfunc2_103.sql
 SELECT * FROM func1_read_int_sql_stb(func2_sql_int_vol(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_stb" line 4 at SQL statement
 -- @description function_in_from_join_withfunc2_104.sql
 SELECT * FROM func1_read_int_sql_stb(func2_sql_int_stb(5)), foo order by 1,2,3; 
@@ -2877,8 +2852,7 @@ SELECT * FROM func1_read_int_sql_stb(func2_sql_int_imm(5)), foo order by 1,2,3;
 -- @description function_in_from_join_withfunc2_106.sql
 SELECT * FROM func1_read_int_sql_stb(func2_read_int_vol(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_from_join_withfunc2_107.sql
 SELECT * FROM func1_read_int_sql_stb(func2_read_int_stb(5)), foo order by 1,2,3; 
@@ -2900,8 +2874,7 @@ SELECT * FROM func1_read_int_sql_stb(func2_read_int_stb(5)), foo order by 1,2,3;
 begin;
 SELECT * FROM func1_read_int_sql_stb(func2_mod_int_vol(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_from_join_withfunc2_109.sql
@@ -2977,72 +2950,63 @@ rollback;
 begin;
 SELECT * FROM func1_mod_int_vol(func2_nosql_vol(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_from_join_withfunc2_131.sql
 begin;
 SELECT * FROM func1_mod_int_vol(func2_nosql_stb(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_from_join_withfunc2_132.sql
 begin;
 SELECT * FROM func1_mod_int_vol(func2_nosql_imm(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_from_join_withfunc2_133.sql
 begin;
 SELECT * FROM func1_mod_int_vol(func2_sql_int_vol(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_from_join_withfunc2_134.sql
 begin;
 SELECT * FROM func1_mod_int_vol(func2_sql_int_stb(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_from_join_withfunc2_135.sql
 begin;
 SELECT * FROM func1_mod_int_vol(func2_sql_int_imm(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_from_join_withfunc2_136.sql
 begin;
 SELECT * FROM func1_mod_int_vol(func2_read_int_vol(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_from_join_withfunc2_137.sql
 begin;
 SELECT * FROM func1_mod_int_vol(func2_read_int_stb(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_from_join_withfunc2_138.sql
 begin;
 SELECT * FROM func1_mod_int_vol(func2_mod_int_vol(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_from_join_withfunc2_139.sql
@@ -3056,8 +3020,7 @@ rollback;
 begin;
 SELECT * FROM func1_mod_int_stb(func2_nosql_vol(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_from_join_withfunc2_141.sql
@@ -3078,8 +3041,7 @@ rollback;
 begin;
 SELECT * FROM func1_mod_int_stb(func2_sql_int_vol(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_from_join_withfunc2_144.sql
@@ -3100,8 +3062,7 @@ rollback;
 begin;
 SELECT * FROM func1_mod_int_stb(func2_read_int_vol(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_from_join_withfunc2_147.sql
@@ -3115,8 +3076,7 @@ rollback;
 begin;
 SELECT * FROM func1_mod_int_stb(func2_mod_int_vol(5)), foo order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db 127.0.0.1:5432 pid=30809)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_from_join_withfunc2_149.sql
@@ -5923,8 +5883,7 @@ rollback;
 -- @description function_in_from_subqry_withfunc2_90.sql
 SELECT * FROM foo, (SELECT * FROM func1_read_int_sql_vol(func2_nosql_vol(5))) r order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db 127.0.0.1:5432 pid=31269)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_vol" line 4 at SQL statement
 -- @description function_in_from_subqry_withfunc2_91.sql
 SELECT * FROM foo, (SELECT * FROM func1_read_int_sql_vol(func2_nosql_stb(5))) r order by 1,2,3; 
@@ -5961,8 +5920,7 @@ SELECT * FROM foo, (SELECT * FROM func1_read_int_sql_vol(func2_nosql_imm(5))) r 
 -- @description function_in_from_subqry_withfunc2_93.sql
 SELECT * FROM foo, (SELECT * FROM func1_read_int_sql_vol(func2_sql_int_vol(5))) r order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db 127.0.0.1:5432 pid=31282)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_vol" line 4 at SQL statement
 -- @description function_in_from_subqry_withfunc2_94.sql
 SELECT * FROM foo, (SELECT * FROM func1_read_int_sql_vol(func2_sql_int_stb(5))) r order by 1,2,3; 
@@ -5999,8 +5957,7 @@ SELECT * FROM foo, (SELECT * FROM func1_read_int_sql_vol(func2_sql_int_imm(5))) 
 -- @description function_in_from_subqry_withfunc2_96.sql
 SELECT * FROM foo, (SELECT * FROM func1_read_int_sql_vol(func2_read_int_vol(5))) r order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db 127.0.0.1:5432 pid=31292)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_vol" line 4 at SQL statement
 -- @description function_in_from_subqry_withfunc2_97.sql
 SELECT * FROM foo, (SELECT * FROM func1_read_int_sql_vol(func2_read_int_stb(5))) r order by 1,2,3; 
@@ -6022,8 +5979,7 @@ SELECT * FROM foo, (SELECT * FROM func1_read_int_sql_vol(func2_read_int_stb(5)))
 begin;
 SELECT * FROM foo, (SELECT * FROM func1_read_int_sql_vol(func2_mod_int_vol(5))) r order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db 127.0.0.1:5432 pid=31302)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_from_subqry_withfunc2_99.sql
@@ -6036,8 +5992,7 @@ rollback;
 -- @description function_in_from_subqry_withfunc2_100.sql
 SELECT * FROM foo, (SELECT * FROM func1_read_int_sql_stb(func2_nosql_vol(5))) r order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db 127.0.0.1:5432 pid=31302)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_stb" line 4 at SQL statement
 -- @description function_in_from_subqry_withfunc2_101.sql
 SELECT * FROM foo, (SELECT * FROM func1_read_int_sql_stb(func2_nosql_stb(5))) r order by 1,2,3; 
@@ -6074,8 +6029,7 @@ SELECT * FROM foo, (SELECT * FROM func1_read_int_sql_stb(func2_nosql_imm(5))) r 
 -- @description function_in_from_subqry_withfunc2_103.sql
 SELECT * FROM foo, (SELECT * FROM func1_read_int_sql_stb(func2_sql_int_vol(5))) r order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db 127.0.0.1:5432 pid=31302)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_stb" line 4 at SQL statement
 -- @description function_in_from_subqry_withfunc2_104.sql
 SELECT * FROM foo, (SELECT * FROM func1_read_int_sql_stb(func2_sql_int_stb(5))) r order by 1,2,3; 
@@ -6112,8 +6066,7 @@ SELECT * FROM foo, (SELECT * FROM func1_read_int_sql_stb(func2_sql_int_imm(5))) 
 -- @description function_in_from_subqry_withfunc2_106.sql
 SELECT * FROM foo, (SELECT * FROM func1_read_int_sql_stb(func2_read_int_vol(5))) r order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db 127.0.0.1:5432 pid=31302)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_stb" line 4 at SQL statement
 -- @description function_in_from_subqry_withfunc2_107.sql
 SELECT * FROM foo, (SELECT * FROM func1_read_int_sql_stb(func2_read_int_stb(5))) r order by 1,2,3; 
@@ -6135,8 +6088,7 @@ SELECT * FROM foo, (SELECT * FROM func1_read_int_sql_stb(func2_read_int_stb(5)))
 begin;
 SELECT * FROM foo, (SELECT * FROM func1_read_int_sql_stb(func2_mod_int_vol(5))) r order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db 127.0.0.1:5432 pid=31302)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_from_subqry_withfunc2_109.sql
@@ -6212,8 +6164,7 @@ rollback;
 begin;
 SELECT * FROM foo, (SELECT * FROM func1_mod_int_vol(func2_nosql_vol(5))) r order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db 127.0.0.1:5432 pid=31302)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_from_subqry_withfunc2_131.sql
@@ -6256,8 +6207,7 @@ rollback;
 begin;
 SELECT * FROM foo, (SELECT * FROM func1_mod_int_vol(func2_sql_int_vol(5))) r order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db 127.0.0.1:5432 pid=31381)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_from_subqry_withfunc2_134.sql
@@ -6300,8 +6250,7 @@ rollback;
 begin;
 SELECT * FROM foo, (SELECT * FROM func1_mod_int_vol(func2_read_int_vol(5))) r order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db 127.0.0.1:5432 pid=31391)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_from_subqry_withfunc2_137.sql
@@ -6326,8 +6275,7 @@ rollback;
 begin;
 SELECT * FROM foo, (SELECT * FROM func1_mod_int_vol(func2_mod_int_vol(5))) r order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db 127.0.0.1:5432 pid=31401)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_from_subqry_withfunc2_139.sql
@@ -6341,8 +6289,7 @@ rollback;
 begin;
 SELECT * FROM foo, (SELECT * FROM func1_mod_int_stb(func2_nosql_vol(5))) r order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db 127.0.0.1:5432 pid=31401)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_from_subqry_withfunc2_141.sql
@@ -6363,8 +6310,7 @@ rollback;
 begin;
 SELECT * FROM foo, (SELECT * FROM func1_mod_int_stb(func2_sql_int_vol(5))) r order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db 127.0.0.1:5432 pid=31401)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_from_subqry_withfunc2_144.sql
@@ -6385,8 +6331,7 @@ rollback;
 begin;
 SELECT * FROM foo, (SELECT * FROM func1_mod_int_stb(func2_read_int_vol(5))) r order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db 127.0.0.1:5432 pid=31401)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_from_subqry_withfunc2_147.sql
@@ -6400,8 +6345,7 @@ rollback;
 begin;
 SELECT * FROM foo, (SELECT * FROM func1_mod_int_stb(func2_mod_int_vol(5))) r order by 1,2,3; 
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db 127.0.0.1:5432 pid=31401)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_from_subqry_withfunc2_149.sql

--- a/src/test/regress/expected/qp_functions_in_select.out
+++ b/src/test/regress/expected/qp_functions_in_select.out
@@ -296,57 +296,49 @@ SELECT func1_sql_setint_imm(a) FROM foo order by 1;
 -- @description function_in_select_column_9.sql
 SELECT func1_read_int_sql_vol(a) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_vol" line 4 at SQL statement
 -- @description function_in_select_column_10.sql
 SELECT func1_read_int_sql_stb(a) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_stb" line 4 at SQL statement
 -- @description function_in_select_column_11.sql
 SELECT func1_read_setint_sql_vol(a) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_vol" line 4 at FOR over SELECT rows
 -- @description function_in_select_column_12.sql
 SELECT func1_read_setint_sql_stb(a) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_select_column_13.sql
 begin;
 SELECT func1_mod_int_vol(a) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_14.sql
 begin;
 SELECT func1_mod_int_stb(a) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_15.sql
 begin;
 SELECT func1_mod_setint_vol(a) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_select_column_16.sql
 begin;
 SELECT func1_mod_setint_stb(a) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_0.sql
@@ -448,29 +440,25 @@ SELECT func1_nosql_vol(func2_sql_int_imm(a)) FROM foo order by 1;
 -- @description function_in_select_column_withfunc2_6.sql
 SELECT func1_nosql_vol(func2_read_int_vol(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_7.sql
 SELECT func1_nosql_vol(func2_read_int_stb(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_stb" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_8.sql
 begin;
 SELECT func1_nosql_vol(func2_mod_int_vol(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_9.sql
 begin;
 SELECT func1_nosql_vol(func2_mod_int_stb(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_10.sql
@@ -572,29 +560,25 @@ SELECT func1_nosql_stb(func2_sql_int_imm(a)) FROM foo order by 1;
 -- @description function_in_select_column_withfunc2_16.sql
 SELECT func1_nosql_stb(func2_read_int_vol(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_17.sql
 SELECT func1_nosql_stb(func2_read_int_stb(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_stb" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_18.sql
 begin;
 SELECT func1_nosql_stb(func2_mod_int_vol(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_19.sql
 begin;
 SELECT func1_nosql_stb(func2_mod_int_stb(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_20.sql
@@ -696,29 +680,25 @@ SELECT func1_nosql_imm(func2_sql_int_imm(a)) FROM foo order by 1;
 -- @description function_in_select_column_withfunc2_26.sql
 SELECT func1_nosql_imm(func2_read_int_vol(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_27.sql
 SELECT func1_nosql_imm(func2_read_int_stb(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_stb" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_28.sql
 begin;
 SELECT func1_nosql_imm(func2_mod_int_vol(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_29.sql
 begin;
 SELECT func1_nosql_imm(func2_mod_int_stb(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_30.sql
@@ -820,29 +800,25 @@ SELECT func1_sql_int_vol(func2_sql_int_imm(a)) FROM foo order by 1;
 -- @description function_in_select_column_withfunc2_36.sql
 SELECT func1_sql_int_vol(func2_read_int_vol(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_37.sql
 SELECT func1_sql_int_vol(func2_read_int_stb(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_stb" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_38.sql
 begin;
 SELECT func1_sql_int_vol(func2_mod_int_vol(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_39.sql
 begin;
 SELECT func1_sql_int_vol(func2_mod_int_stb(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_40.sql
@@ -944,29 +920,25 @@ SELECT func1_sql_int_stb(func2_sql_int_imm(a)) FROM foo order by 1;
 -- @description function_in_select_column_withfunc2_46.sql
 SELECT func1_sql_int_stb(func2_read_int_vol(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_47.sql
 SELECT func1_sql_int_stb(func2_read_int_stb(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_stb" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_48.sql
 begin;
 SELECT func1_sql_int_stb(func2_mod_int_vol(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_49.sql
 begin;
 SELECT func1_sql_int_stb(func2_mod_int_stb(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_50.sql
@@ -1068,29 +1040,25 @@ SELECT func1_sql_int_imm(func2_sql_int_imm(a)) FROM foo order by 1;
 -- @description function_in_select_column_withfunc2_56.sql
 SELECT func1_sql_int_imm(func2_read_int_vol(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_57.sql
 SELECT func1_sql_int_imm(func2_read_int_stb(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_stb" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_58.sql
 begin;
 SELECT func1_sql_int_imm(func2_mod_int_vol(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_59.sql
 begin;
 SELECT func1_sql_int_imm(func2_mod_int_stb(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_60.sql
@@ -1492,29 +1460,25 @@ SELECT func1_sql_setint_vol(func2_sql_int_imm(a)) FROM foo order by 1;
 -- @description function_in_select_column_withfunc2_66.sql
 SELECT func1_sql_setint_vol(func2_read_int_vol(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_67.sql
 SELECT func1_sql_setint_vol(func2_read_int_stb(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_stb" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_68.sql
 begin;
 SELECT func1_sql_setint_vol(func2_mod_int_vol(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_69.sql
 begin;
 SELECT func1_sql_setint_vol(func2_mod_int_stb(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_70.sql
@@ -1916,29 +1880,25 @@ SELECT func1_sql_setint_stb(func2_sql_int_imm(a)) FROM foo order by 1;
 -- @description function_in_select_column_withfunc2_76.sql
 SELECT func1_sql_setint_stb(func2_read_int_vol(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_77.sql
 SELECT func1_sql_setint_stb(func2_read_int_stb(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_stb" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_78.sql
 begin;
 SELECT func1_sql_setint_stb(func2_mod_int_vol(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_79.sql
 begin;
 SELECT func1_sql_setint_stb(func2_mod_int_stb(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_80.sql
@@ -2340,605 +2300,521 @@ SELECT func1_sql_setint_imm(func2_sql_int_imm(a)) FROM foo order by 1;
 -- @description function_in_select_column_withfunc2_86.sql
 SELECT func1_sql_setint_imm(func2_read_int_vol(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_87.sql
 SELECT func1_sql_setint_imm(func2_read_int_stb(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_stb" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_88.sql
 begin;
 SELECT func1_sql_setint_imm(func2_mod_int_vol(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_89.sql
 begin;
 SELECT func1_sql_setint_imm(func2_mod_int_stb(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_90.sql
 SELECT func1_read_int_sql_vol(func2_nosql_vol(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_vol" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_91.sql
 SELECT func1_read_int_sql_vol(func2_nosql_stb(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_vol" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_92.sql
 SELECT func1_read_int_sql_vol(func2_nosql_imm(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_vol" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_93.sql
 SELECT func1_read_int_sql_vol(func2_sql_int_vol(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_vol" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_94.sql
 SELECT func1_read_int_sql_vol(func2_sql_int_stb(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_vol" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_95.sql
 SELECT func1_read_int_sql_vol(func2_sql_int_imm(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_vol" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_96.sql
 SELECT func1_read_int_sql_vol(func2_read_int_vol(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_97.sql
 SELECT func1_read_int_sql_vol(func2_read_int_stb(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_stb" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_98.sql
 begin;
 SELECT func1_read_int_sql_vol(func2_mod_int_vol(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_99.sql
 begin;
 SELECT func1_read_int_sql_vol(func2_mod_int_stb(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_100.sql
 SELECT func1_read_int_sql_stb(func2_nosql_vol(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_stb" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_101.sql
 SELECT func1_read_int_sql_stb(func2_nosql_stb(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_stb" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_102.sql
 SELECT func1_read_int_sql_stb(func2_nosql_imm(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_stb" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_103.sql
 SELECT func1_read_int_sql_stb(func2_sql_int_vol(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_stb" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_104.sql
 SELECT func1_read_int_sql_stb(func2_sql_int_stb(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_stb" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_105.sql
 SELECT func1_read_int_sql_stb(func2_sql_int_imm(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_stb" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_106.sql
 SELECT func1_read_int_sql_stb(func2_read_int_vol(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_107.sql
 SELECT func1_read_int_sql_stb(func2_read_int_stb(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_stb" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_108.sql
 begin;
 SELECT func1_read_int_sql_stb(func2_mod_int_vol(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_109.sql
 begin;
 SELECT func1_read_int_sql_stb(func2_mod_int_stb(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_110.sql
 SELECT func1_read_setint_sql_vol(func2_nosql_vol(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_vol" line 4 at FOR over SELECT rows
 -- @description function_in_select_column_withfunc2_111.sql
 SELECT func1_read_setint_sql_vol(func2_nosql_stb(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_vol" line 4 at FOR over SELECT rows
 -- @description function_in_select_column_withfunc2_112.sql
 SELECT func1_read_setint_sql_vol(func2_nosql_imm(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_vol" line 4 at FOR over SELECT rows
 -- @description function_in_select_column_withfunc2_113.sql
 SELECT func1_read_setint_sql_vol(func2_sql_int_vol(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_vol" line 4 at FOR over SELECT rows
 -- @description function_in_select_column_withfunc2_114.sql
 SELECT func1_read_setint_sql_vol(func2_sql_int_stb(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_vol" line 4 at FOR over SELECT rows
 -- @description function_in_select_column_withfunc2_115.sql
 SELECT func1_read_setint_sql_vol(func2_sql_int_imm(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_vol" line 4 at FOR over SELECT rows
 -- @description function_in_select_column_withfunc2_116.sql
 SELECT func1_read_setint_sql_vol(func2_read_int_vol(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_117.sql
 SELECT func1_read_setint_sql_vol(func2_read_int_stb(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_stb" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_118.sql
 begin;
 SELECT func1_read_setint_sql_vol(func2_mod_int_vol(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_119.sql
 begin;
 SELECT func1_read_setint_sql_vol(func2_mod_int_stb(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_120.sql
 SELECT func1_read_setint_sql_stb(func2_nosql_vol(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_select_column_withfunc2_121.sql
 SELECT func1_read_setint_sql_stb(func2_nosql_stb(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_select_column_withfunc2_122.sql
 SELECT func1_read_setint_sql_stb(func2_nosql_imm(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_select_column_withfunc2_123.sql
 SELECT func1_read_setint_sql_stb(func2_sql_int_vol(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_select_column_withfunc2_124.sql
 SELECT func1_read_setint_sql_stb(func2_sql_int_stb(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_select_column_withfunc2_125.sql
 SELECT func1_read_setint_sql_stb(func2_sql_int_imm(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_select_column_withfunc2_126.sql
 SELECT func1_read_setint_sql_stb(func2_read_int_vol(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_127.sql
 SELECT func1_read_setint_sql_stb(func2_read_int_stb(a)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_stb" line 4 at SQL statement
 -- @description function_in_select_column_withfunc2_128.sql
 begin;
 SELECT func1_read_setint_sql_stb(func2_mod_int_vol(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_129.sql
 begin;
 SELECT func1_read_setint_sql_stb(func2_mod_int_stb(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_130.sql
 begin;
 SELECT func1_mod_int_vol(func2_nosql_vol(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_131.sql
 begin;
 SELECT func1_mod_int_vol(func2_nosql_stb(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_132.sql
 begin;
 SELECT func1_mod_int_vol(func2_nosql_imm(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_133.sql
 begin;
 SELECT func1_mod_int_vol(func2_sql_int_vol(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_134.sql
 begin;
 SELECT func1_mod_int_vol(func2_sql_int_stb(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_135.sql
 begin;
 SELECT func1_mod_int_vol(func2_sql_int_imm(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_136.sql
 begin;
 SELECT func1_mod_int_vol(func2_read_int_vol(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_137.sql
 begin;
 SELECT func1_mod_int_vol(func2_read_int_stb(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_138.sql
 begin;
 SELECT func1_mod_int_vol(func2_mod_int_vol(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_139.sql
 begin;
 SELECT func1_mod_int_vol(func2_mod_int_stb(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_140.sql
 begin;
 SELECT func1_mod_int_stb(func2_nosql_vol(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_141.sql
 begin;
 SELECT func1_mod_int_stb(func2_nosql_stb(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_142.sql
 begin;
 SELECT func1_mod_int_stb(func2_nosql_imm(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_143.sql
 begin;
 SELECT func1_mod_int_stb(func2_sql_int_vol(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_144.sql
 begin;
 SELECT func1_mod_int_stb(func2_sql_int_stb(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_145.sql
 begin;
 SELECT func1_mod_int_stb(func2_sql_int_imm(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_146.sql
 begin;
 SELECT func1_mod_int_stb(func2_read_int_vol(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_147.sql
 begin;
 SELECT func1_mod_int_stb(func2_read_int_stb(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_148.sql
 begin;
 SELECT func1_mod_int_stb(func2_mod_int_vol(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_149.sql
 begin;
 SELECT func1_mod_int_stb(func2_mod_int_stb(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_150.sql
 begin;
 SELECT func1_mod_setint_vol(func2_nosql_vol(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_151.sql
 begin;
 SELECT func1_mod_setint_vol(func2_nosql_stb(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_152.sql
 begin;
 SELECT func1_mod_setint_vol(func2_nosql_imm(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_153.sql
 begin;
 SELECT func1_mod_setint_vol(func2_sql_int_vol(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_154.sql
 begin;
 SELECT func1_mod_setint_vol(func2_sql_int_stb(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_155.sql
 begin;
 SELECT func1_mod_setint_vol(func2_sql_int_imm(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_156.sql
 begin;
 SELECT func1_mod_setint_vol(func2_read_int_vol(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_157.sql
 begin;
 SELECT func1_mod_setint_vol(func2_read_int_stb(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_158.sql
 begin;
 SELECT func1_mod_setint_vol(func2_mod_int_vol(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_159.sql
 begin;
 SELECT func1_mod_setint_vol(func2_mod_int_stb(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_160.sql
 begin;
 SELECT func1_mod_setint_stb(func2_nosql_vol(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_161.sql
 begin;
 SELECT func1_mod_setint_stb(func2_nosql_stb(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_162.sql
 begin;
 SELECT func1_mod_setint_stb(func2_nosql_imm(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_163.sql
 begin;
 SELECT func1_mod_setint_stb(func2_sql_int_vol(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_164.sql
 begin;
 SELECT func1_mod_setint_stb(func2_sql_int_stb(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_165.sql
 begin;
 SELECT func1_mod_setint_stb(func2_sql_int_imm(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_166.sql
 begin;
 SELECT func1_mod_setint_stb(func2_read_int_vol(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_167.sql
 begin;
 SELECT func1_mod_setint_stb(func2_read_int_stb(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_168.sql
 begin;
 SELECT func1_mod_setint_stb(func2_mod_int_vol(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_column_withfunc2_169.sql
 begin;
 SELECT func1_mod_setint_stb(func2_mod_int_stb(a)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_select_constant_0.sql
@@ -3238,8 +3114,7 @@ SELECT func1_sql_setint_imm(5) FROM foo order by 1;
 -- @description function_in_select_constant_9.sql
 SELECT func1_read_int_sql_vol(5) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_vol" line 4 at SQL statement
 -- @description function_in_select_constant_10.sql
 SELECT func1_read_int_sql_stb(5) FROM foo order by 1; 
@@ -3260,21 +3135,18 @@ SELECT func1_read_int_sql_stb(5) FROM foo order by 1;
 -- @description function_in_select_constant_11.sql
 SELECT func1_read_setint_sql_vol(5) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_vol" line 4 at FOR over SELECT rows
 -- @description function_in_select_constant_12.sql
 SELECT func1_read_setint_sql_stb(5) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_select_constant_13.sql
 begin;
 SELECT func1_mod_int_vol(5) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_constant_14.sql
@@ -3288,16 +3160,14 @@ rollback;
 begin;
 SELECT func1_mod_setint_vol(5) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_select_constant_16.sql
 begin;
 SELECT func1_mod_setint_stb(5) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_0.sql
@@ -3399,8 +3269,7 @@ SELECT func1_nosql_vol(func2_sql_int_imm(5)) FROM foo order by 1;
 -- @description function_in_select_constant_withfunc2_6.sql
 SELECT func1_nosql_vol(func2_read_int_vol(5)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_select_constant_withfunc2_7.sql
 SELECT func1_nosql_vol(func2_read_int_stb(5)) FROM foo order by 1; 
@@ -3422,8 +3291,7 @@ SELECT func1_nosql_vol(func2_read_int_stb(5)) FROM foo order by 1;
 begin;
 SELECT func1_nosql_vol(func2_mod_int_vol(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_9.sql
@@ -3532,8 +3400,7 @@ SELECT func1_nosql_stb(func2_sql_int_imm(5)) FROM foo order by 1;
 -- @description function_in_select_constant_withfunc2_16.sql
 SELECT func1_nosql_stb(func2_read_int_vol(5)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_select_constant_withfunc2_17.sql
 SELECT func1_nosql_stb(func2_read_int_stb(5)) FROM foo order by 1; 
@@ -3555,8 +3422,7 @@ SELECT func1_nosql_stb(func2_read_int_stb(5)) FROM foo order by 1;
 begin;
 SELECT func1_nosql_stb(func2_mod_int_vol(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_19.sql
@@ -3665,8 +3531,7 @@ SELECT func1_nosql_imm(func2_sql_int_imm(5)) FROM foo order by 1;
 -- @description function_in_select_constant_withfunc2_26.sql
 SELECT func1_nosql_imm(func2_read_int_vol(5)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_select_constant_withfunc2_27.sql
 SELECT func1_nosql_imm(func2_read_int_stb(5)) FROM foo order by 1; 
@@ -3688,8 +3553,7 @@ SELECT func1_nosql_imm(func2_read_int_stb(5)) FROM foo order by 1;
 begin;
 SELECT func1_nosql_imm(func2_mod_int_vol(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_29.sql
@@ -3798,8 +3662,7 @@ SELECT func1_sql_int_vol(func2_sql_int_imm(5)) FROM foo order by 1;
 -- @description function_in_select_constant_withfunc2_36.sql
 SELECT func1_sql_int_vol(func2_read_int_vol(5)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_select_constant_withfunc2_37.sql
 SELECT func1_sql_int_vol(func2_read_int_stb(5)) FROM foo order by 1; 
@@ -3821,8 +3684,7 @@ SELECT func1_sql_int_vol(func2_read_int_stb(5)) FROM foo order by 1;
 begin;
 SELECT func1_sql_int_vol(func2_mod_int_vol(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_39.sql
@@ -3931,8 +3793,7 @@ SELECT func1_sql_int_stb(func2_sql_int_imm(5)) FROM foo order by 1;
 -- @description function_in_select_constant_withfunc2_46.sql
 SELECT func1_sql_int_stb(func2_read_int_vol(5)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_select_constant_withfunc2_47.sql
 SELECT func1_sql_int_stb(func2_read_int_stb(5)) FROM foo order by 1; 
@@ -3954,8 +3815,7 @@ SELECT func1_sql_int_stb(func2_read_int_stb(5)) FROM foo order by 1;
 begin;
 SELECT func1_sql_int_stb(func2_mod_int_vol(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_49.sql
@@ -4064,8 +3924,7 @@ SELECT func1_sql_int_imm(func2_sql_int_imm(5)) FROM foo order by 1;
 -- @description function_in_select_constant_withfunc2_56.sql
 SELECT func1_sql_int_imm(func2_read_int_vol(5)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_select_constant_withfunc2_57.sql
 SELECT func1_sql_int_imm(func2_read_int_stb(5)) FROM foo order by 1; 
@@ -4087,8 +3946,7 @@ SELECT func1_sql_int_imm(func2_read_int_stb(5)) FROM foo order by 1;
 begin;
 SELECT func1_sql_int_imm(func2_mod_int_vol(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_59.sql
@@ -4497,8 +4355,7 @@ SELECT func1_sql_setint_vol(func2_sql_int_imm(5)) FROM foo order by 1;
 -- @description function_in_select_constant_withfunc2_66.sql
 SELECT func1_sql_setint_vol(func2_read_int_vol(5)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_select_constant_withfunc2_67.sql
 SELECT func1_sql_setint_vol(func2_read_int_stb(5)) FROM foo order by 1; 
@@ -4570,8 +4427,7 @@ SELECT func1_sql_setint_vol(func2_read_int_stb(5)) FROM foo order by 1;
 begin;
 SELECT func1_sql_setint_vol(func2_mod_int_vol(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_69.sql
@@ -4980,8 +4836,7 @@ SELECT func1_sql_setint_stb(func2_sql_int_imm(5)) FROM foo order by 1;
 -- @description function_in_select_constant_withfunc2_76.sql
 SELECT func1_sql_setint_stb(func2_read_int_vol(5)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_select_constant_withfunc2_77.sql
 SELECT func1_sql_setint_stb(func2_read_int_stb(5)) FROM foo order by 1; 
@@ -5053,8 +4908,7 @@ SELECT func1_sql_setint_stb(func2_read_int_stb(5)) FROM foo order by 1;
 begin;
 SELECT func1_sql_setint_stb(func2_mod_int_vol(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_79.sql
@@ -5463,8 +5317,7 @@ SELECT func1_sql_setint_imm(func2_sql_int_imm(5)) FROM foo order by 1;
 -- @description function_in_select_constant_withfunc2_86.sql
 SELECT func1_sql_setint_imm(func2_read_int_vol(5)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_select_constant_withfunc2_87.sql
 SELECT func1_sql_setint_imm(func2_read_int_stb(5)) FROM foo order by 1; 
@@ -5536,8 +5389,7 @@ SELECT func1_sql_setint_imm(func2_read_int_stb(5)) FROM foo order by 1;
 begin;
 SELECT func1_sql_setint_imm(func2_mod_int_vol(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_89.sql
@@ -5550,57 +5402,48 @@ rollback;
 -- @description function_in_select_constant_withfunc2_90.sql
 SELECT func1_read_int_sql_vol(func2_nosql_vol(5)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_vol" line 4 at SQL statement
 -- @description function_in_select_constant_withfunc2_91.sql
 SELECT func1_read_int_sql_vol(func2_nosql_stb(5)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_vol" line 4 at SQL statement
 -- @description function_in_select_constant_withfunc2_92.sql
 SELECT func1_read_int_sql_vol(func2_nosql_imm(5)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_vol" line 4 at SQL statement
 -- @description function_in_select_constant_withfunc2_93.sql
 SELECT func1_read_int_sql_vol(func2_sql_int_vol(5)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_vol" line 4 at SQL statement
 -- @description function_in_select_constant_withfunc2_94.sql
 SELECT func1_read_int_sql_vol(func2_sql_int_stb(5)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_vol" line 4 at SQL statement
 -- @description function_in_select_constant_withfunc2_95.sql
 SELECT func1_read_int_sql_vol(func2_sql_int_imm(5)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_vol" line 4 at SQL statement
 -- @description function_in_select_constant_withfunc2_96.sql
 SELECT func1_read_int_sql_vol(func2_read_int_vol(5)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_select_constant_withfunc2_97.sql
 SELECT func1_read_int_sql_vol(func2_read_int_stb(5)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_vol" line 4 at SQL statement
 -- @description function_in_select_constant_withfunc2_98.sql
 begin;
 SELECT func1_read_int_sql_vol(func2_mod_int_vol(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_99.sql
@@ -5613,8 +5456,7 @@ rollback;
 -- @description function_in_select_constant_withfunc2_100.sql
 SELECT func1_read_int_sql_stb(func2_nosql_vol(5)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_stb" line 4 at SQL statement
 -- @description function_in_select_constant_withfunc2_101.sql
 SELECT func1_read_int_sql_stb(func2_nosql_stb(5)) FROM foo order by 1; 
@@ -5651,8 +5493,7 @@ SELECT func1_read_int_sql_stb(func2_nosql_imm(5)) FROM foo order by 1;
 -- @description function_in_select_constant_withfunc2_103.sql
 SELECT func1_read_int_sql_stb(func2_sql_int_vol(5)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_stb" line 4 at SQL statement
 -- @description function_in_select_constant_withfunc2_104.sql
 SELECT func1_read_int_sql_stb(func2_sql_int_stb(5)) FROM foo order by 1; 
@@ -5689,8 +5530,7 @@ SELECT func1_read_int_sql_stb(func2_sql_int_imm(5)) FROM foo order by 1;
 -- @description function_in_select_constant_withfunc2_106.sql
 SELECT func1_read_int_sql_stb(func2_read_int_vol(5)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_select_constant_withfunc2_107.sql
 SELECT func1_read_int_sql_stb(func2_read_int_stb(5)) FROM foo order by 1; 
@@ -5712,8 +5552,7 @@ SELECT func1_read_int_sql_stb(func2_read_int_stb(5)) FROM foo order by 1;
 begin;
 SELECT func1_read_int_sql_stb(func2_mod_int_vol(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_109.sql
@@ -5726,57 +5565,48 @@ rollback;
 -- @description function_in_select_constant_withfunc2_110.sql
 SELECT func1_read_setint_sql_vol(func2_nosql_vol(5)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_vol" line 4 at FOR over SELECT rows
 -- @description function_in_select_constant_withfunc2_111.sql
 SELECT func1_read_setint_sql_vol(func2_nosql_stb(5)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_vol" line 4 at FOR over SELECT rows
 -- @description function_in_select_constant_withfunc2_112.sql
 SELECT func1_read_setint_sql_vol(func2_nosql_imm(5)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_vol" line 4 at FOR over SELECT rows
 -- @description function_in_select_constant_withfunc2_113.sql
 SELECT func1_read_setint_sql_vol(func2_sql_int_vol(5)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_vol" line 4 at FOR over SELECT rows
 -- @description function_in_select_constant_withfunc2_114.sql
 SELECT func1_read_setint_sql_vol(func2_sql_int_stb(5)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_vol" line 4 at FOR over SELECT rows
 -- @description function_in_select_constant_withfunc2_115.sql
 SELECT func1_read_setint_sql_vol(func2_sql_int_imm(5)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_vol" line 4 at FOR over SELECT rows
 -- @description function_in_select_constant_withfunc2_116.sql
 SELECT func1_read_setint_sql_vol(func2_read_int_vol(5)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_select_constant_withfunc2_117.sql
 SELECT func1_read_setint_sql_vol(func2_read_int_stb(5)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_vol" line 4 at FOR over SELECT rows
 -- @description function_in_select_constant_withfunc2_118.sql
 begin;
 SELECT func1_read_setint_sql_vol(func2_mod_int_vol(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_119.sql
@@ -5789,57 +5619,48 @@ rollback;
 -- @description function_in_select_constant_withfunc2_120.sql
 SELECT func1_read_setint_sql_stb(func2_nosql_vol(5)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_select_constant_withfunc2_121.sql
 SELECT func1_read_setint_sql_stb(func2_nosql_stb(5)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_select_constant_withfunc2_122.sql
 SELECT func1_read_setint_sql_stb(func2_nosql_imm(5)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_select_constant_withfunc2_123.sql
 SELECT func1_read_setint_sql_stb(func2_sql_int_vol(5)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_select_constant_withfunc2_124.sql
 SELECT func1_read_setint_sql_stb(func2_sql_int_stb(5)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_select_constant_withfunc2_125.sql
 SELECT func1_read_setint_sql_stb(func2_sql_int_imm(5)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_select_constant_withfunc2_126.sql
 SELECT func1_read_setint_sql_stb(func2_read_int_vol(5)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_select_constant_withfunc2_127.sql
 SELECT func1_read_setint_sql_stb(func2_read_int_stb(5)) FROM foo order by 1; 
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_select_constant_withfunc2_128.sql
 begin;
 SELECT func1_read_setint_sql_stb(func2_mod_int_vol(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_129.sql
@@ -5853,72 +5674,63 @@ rollback;
 begin;
 SELECT func1_mod_int_vol(func2_nosql_vol(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_131.sql
 begin;
 SELECT func1_mod_int_vol(func2_nosql_stb(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_132.sql
 begin;
 SELECT func1_mod_int_vol(func2_nosql_imm(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_133.sql
 begin;
 SELECT func1_mod_int_vol(func2_sql_int_vol(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_134.sql
 begin;
 SELECT func1_mod_int_vol(func2_sql_int_stb(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_135.sql
 begin;
 SELECT func1_mod_int_vol(func2_sql_int_imm(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_136.sql
 begin;
 SELECT func1_mod_int_vol(func2_read_int_vol(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_137.sql
 begin;
 SELECT func1_mod_int_vol(func2_read_int_stb(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_138.sql
 begin;
 SELECT func1_mod_int_vol(func2_mod_int_vol(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_139.sql
@@ -5932,8 +5744,7 @@ rollback;
 begin;
 SELECT func1_mod_int_stb(func2_nosql_vol(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_141.sql
@@ -5954,8 +5765,7 @@ rollback;
 begin;
 SELECT func1_mod_int_stb(func2_sql_int_vol(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_144.sql
@@ -5976,8 +5786,7 @@ rollback;
 begin;
 SELECT func1_mod_int_stb(func2_read_int_vol(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_147.sql
@@ -5991,8 +5800,7 @@ rollback;
 begin;
 SELECT func1_mod_int_stb(func2_mod_int_vol(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_149.sql
@@ -6006,72 +5814,63 @@ rollback;
 begin;
 SELECT func1_mod_setint_vol(func2_nosql_vol(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_151.sql
 begin;
 SELECT func1_mod_setint_vol(func2_nosql_stb(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_152.sql
 begin;
 SELECT func1_mod_setint_vol(func2_nosql_imm(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_153.sql
 begin;
 SELECT func1_mod_setint_vol(func2_sql_int_vol(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_154.sql
 begin;
 SELECT func1_mod_setint_vol(func2_sql_int_stb(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_155.sql
 begin;
 SELECT func1_mod_setint_vol(func2_sql_int_imm(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_156.sql
 begin;
 SELECT func1_mod_setint_vol(func2_read_int_vol(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_157.sql
 begin;
 SELECT func1_mod_setint_vol(func2_read_int_stb(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_158.sql
 begin;
 SELECT func1_mod_setint_vol(func2_mod_int_vol(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_159.sql
@@ -6085,72 +5884,63 @@ rollback;
 begin;
 SELECT func1_mod_setint_stb(func2_nosql_vol(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_161.sql
 begin;
 SELECT func1_mod_setint_stb(func2_nosql_stb(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_162.sql
 begin;
 SELECT func1_mod_setint_stb(func2_nosql_imm(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_163.sql
 begin;
 SELECT func1_mod_setint_stb(func2_sql_int_vol(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_164.sql
 begin;
 SELECT func1_mod_setint_stb(func2_sql_int_stb(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_165.sql
 begin;
 SELECT func1_mod_setint_stb(func2_sql_int_imm(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_166.sql
 begin;
 SELECT func1_mod_setint_stb(func2_read_int_vol(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_167.sql
 begin;
 SELECT func1_mod_setint_stb(func2_read_int_stb(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_168.sql
 begin;
 SELECT func1_mod_setint_stb(func2_mod_int_vol(5)) FROM foo order by 1;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.0.1:40000 pid=3228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_select_constant_withfunc2_169.sql

--- a/src/test/regress/expected/qp_functions_in_subquery.out
+++ b/src/test/regress/expected/qp_functions_in_subquery.out
@@ -328,8 +328,7 @@ SELECT * FROM foo, (SELECT func1_read_int_sql_stb(5)) r order by 1,2,3;
 -- @description function_in_subqry_12.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(5)) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 rh55-qavm20:40500 pid=7821)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_subqry_13.sql
 begin;
@@ -360,8 +359,7 @@ rollback;
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(5)) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 rh55-qavm20:40500 pid=8138)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_0.sql
@@ -3247,8 +3245,7 @@ rollback;
 -- @description function_in_subqry_withfunc2_100.sql
 SELECT * FROM foo, (SELECT func1_read_int_sql_stb(func2_nosql_vol(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 rh55-qavm20:40500 pid=18624)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_stb" line 4 at SQL statement
 -- @description function_in_subqry_withfunc2_101.sql
 SELECT * FROM foo, (SELECT func1_read_int_sql_stb(func2_nosql_stb(5))) r order by 1,2,3;
@@ -3285,8 +3282,7 @@ SELECT * FROM foo, (SELECT func1_read_int_sql_stb(func2_nosql_imm(5))) r order b
 -- @description function_in_subqry_withfunc2_103.sql
 SELECT * FROM foo, (SELECT func1_read_int_sql_stb(func2_sql_int_vol(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 rh55-qavm20:40500 pid=18867)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_stb" line 4 at SQL statement
 -- @description function_in_subqry_withfunc2_104.sql
 SELECT * FROM foo, (SELECT func1_read_int_sql_stb(func2_sql_int_stb(5))) r order by 1,2,3;
@@ -3323,8 +3319,7 @@ SELECT * FROM foo, (SELECT func1_read_int_sql_stb(func2_sql_int_imm(5))) r order
 -- @description function_in_subqry_withfunc2_106.sql
 SELECT * FROM foo, (SELECT func1_read_int_sql_stb(func2_read_int_vol(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 rh55-qavm20:40500 pid=19110)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_stb" line 4 at SQL statement
 -- @description function_in_subqry_withfunc2_107.sql
 SELECT * FROM foo, (SELECT func1_read_int_sql_stb(func2_read_int_stb(5))) r order by 1,2,3;
@@ -3346,8 +3341,7 @@ SELECT * FROM foo, (SELECT func1_read_int_sql_stb(func2_read_int_stb(5))) r orde
 begin;
 SELECT * FROM foo, (SELECT func1_read_int_sql_stb(func2_mod_int_vol(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 rh55-qavm20:40500 pid=19275)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_109.sql
@@ -3360,27 +3354,23 @@ rollback;
 -- @description function_in_subqry_withfunc2_110.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_vol(func2_nosql_vol(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db rh55-qavm20:5432 pid=4599)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_vol" line 4 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_113.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_vol(func2_sql_int_vol(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db rh55-qavm20:5432 pid=5285)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_vol" line 4 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_116.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_vol(func2_read_int_vol(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 rh55-qavm20:40500 pid=19929)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_vol" line 4 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_118.sql
 begin;
 SELECT * FROM foo, (SELECT func1_read_setint_sql_vol(func2_mod_int_vol(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 rh55-qavm20:40500 pid=20097)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_vol" line 4 at FOR over SELECT rows
 rollback;
 -- @description function_in_subqry_withfunc2_119.sql
@@ -3393,57 +3383,48 @@ rollback;
 -- @description function_in_subqry_withfunc2_120.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_nosql_vol(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db rh55-qavm20:5432 pid=6463)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_121.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_nosql_stb(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 rh55-qavm20:40500 pid=20334)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_122.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_nosql_imm(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 rh55-qavm20:40500 pid=20417)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_123.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_sql_int_vol(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db rh55-qavm20:5432 pid=6842)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_124.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_sql_int_stb(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 rh55-qavm20:40500 pid=20583)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_125.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_sql_int_imm(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 rh55-qavm20:40500 pid=20666)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_126.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_read_int_vol(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 rh55-qavm20:40500 pid=20749)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_127.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_read_int_stb(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 rh55-qavm20:40500 pid=20834)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_128.sql
 begin;
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_mod_int_vol(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 rh55-qavm20:40500 pid=20935)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 rollback;
 -- @description function_in_subqry_withfunc2_129.sql
@@ -3626,8 +3607,7 @@ rollback;
 begin;
 SELECT * FROM foo, (SELECT func1_mod_int_stb(func2_nosql_vol(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 rh55-qavm20:40500 pid=21899)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_141.sql
@@ -3648,8 +3628,7 @@ rollback;
 begin;
 SELECT * FROM foo, (SELECT func1_mod_int_stb(func2_sql_int_vol(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 rh55-qavm20:40500 pid=22120)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_144.sql
@@ -3670,8 +3649,7 @@ rollback;
 begin;
 SELECT * FROM foo, (SELECT func1_mod_int_stb(func2_read_int_vol(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 rh55-qavm20:40500 pid=22341)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_147.sql
@@ -3685,8 +3663,7 @@ rollback;
 begin;
 SELECT * FROM foo, (SELECT func1_mod_int_stb(func2_mod_int_vol(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 rh55-qavm20:40500 pid=22501)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_149.sql
@@ -3700,32 +3677,28 @@ rollback;
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_vol(func2_nosql_vol(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db rh55-qavm20:5432 pid=9731)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_153.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_vol(func2_sql_int_vol(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db rh55-qavm20:5432 pid=10341)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_156.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_vol(func2_read_int_vol(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 rh55-qavm20:40500 pid=23154)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_158.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_vol(func2_mod_int_vol(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 rh55-qavm20:40500 pid=23322)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_159.sql
@@ -3739,72 +3712,63 @@ rollback;
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_nosql_vol(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db rh55-qavm20:5432 pid=11507)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_161.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_nosql_stb(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 rh55-qavm20:40500 pid=23566)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_162.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_nosql_imm(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 rh55-qavm20:40500 pid=23649)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_163.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_sql_int_vol(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db rh55-qavm20:5432 pid=11886)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_164.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_sql_int_stb(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 rh55-qavm20:40500 pid=23815)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_165.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_sql_int_imm(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 rh55-qavm20:40500 pid=23898)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_166.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_read_int_vol(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 rh55-qavm20:40500 pid=23981)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_167.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_read_int_stb(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 rh55-qavm20:40500 pid=24066)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_168.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_mod_int_vol(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 rh55-qavm20:40500 pid=24149)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_169.sql

--- a/src/test/regress/expected/qp_functions_in_subquery_constant.out
+++ b/src/test/regress/expected/qp_functions_in_subquery_constant.out
@@ -2456,8 +2456,7 @@ SELECT * FROM foo, (SELECT func1_sql_setint_imm(5) from foo) r order by 1,2,3;
 -- @description function_in_subqry_constant_9.sql
 SELECT * FROM foo, (SELECT func1_read_int_sql_vol(5) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 rh55-qavm20:40500 pid=6180)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_vol" line 4 at SQL statement
 -- @description function_in_subqry_constant_10.sql
 SELECT * FROM foo, (SELECT func1_read_int_sql_stb(5) from foo) r order by 1,2,3;
@@ -2568,21 +2567,18 @@ SELECT * FROM foo, (SELECT func1_read_int_sql_stb(5) from foo) r order by 1,2,3;
 -- @description function_in_subqry_constant_11.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_vol(5) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db rh55-qavm20:5432 pid=14304)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_vol" line 4 at FOR over SELECT rows
 -- @description function_in_subqry_constant_12.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(5) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db rh55-qavm20:5432 pid=14507)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_subqry_constant_13.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_int_vol(5) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg1 slice1 rh55-qavm20:40501 pid=6540)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_14.sql
@@ -2596,16 +2592,14 @@ rollback;
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_vol(5) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db rh55-qavm20:5432 pid=14930)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_16.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(5) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db rh55-qavm20:5432 pid=15133)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_0.sql
@@ -3247,8 +3241,7 @@ SELECT * FROM foo, (SELECT func1_nosql_vol(func2_sql_int_imm(5)) from foo) r ord
 -- @description function_in_subqry_constant_withfunc2_6.sql
 SELECT * FROM foo, (SELECT func1_nosql_vol(func2_read_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 rh55-qavm20:40500 pid=13865)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_subqry_constant_withfunc2_7.sql
 SELECT * FROM foo, (SELECT func1_nosql_vol(func2_read_int_stb(5)) from foo) r order by 1,2,3;
@@ -3360,8 +3353,7 @@ SELECT * FROM foo, (SELECT func1_nosql_vol(func2_read_int_stb(5)) from foo) r or
 begin;
 SELECT * FROM foo, (SELECT func1_nosql_vol(func2_mod_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg1 slice1 rh55-qavm20:40501 pid=14035)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_9.sql
@@ -4010,8 +4002,7 @@ SELECT * FROM foo, (SELECT func1_nosql_stb(func2_sql_int_imm(5)) from foo) r ord
 -- @description function_in_subqry_constant_withfunc2_16.sql
 SELECT * FROM foo, (SELECT func1_nosql_stb(func2_read_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 rh55-qavm20:40500 pid=14674)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_subqry_constant_withfunc2_17.sql
 SELECT * FROM foo, (SELECT func1_nosql_stb(func2_read_int_stb(5)) from foo) r order by 1,2,3;
@@ -4123,8 +4114,7 @@ SELECT * FROM foo, (SELECT func1_nosql_stb(func2_read_int_stb(5)) from foo) r or
 begin;
 SELECT * FROM foo, (SELECT func1_nosql_stb(func2_mod_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 rh55-qavm20:40500 pid=14842)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_19.sql
@@ -4773,8 +4763,7 @@ SELECT * FROM foo, (SELECT func1_nosql_imm(func2_sql_int_imm(5)) from foo) r ord
 -- @description function_in_subqry_constant_withfunc2_26.sql
 SELECT * FROM foo, (SELECT func1_nosql_imm(func2_read_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg1 slice1 rh55-qavm20:40501 pid=15485)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_subqry_constant_withfunc2_27.sql
 SELECT * FROM foo, (SELECT func1_nosql_imm(func2_read_int_stb(5)) from foo) r order by 1,2,3;
@@ -4886,8 +4875,7 @@ SELECT * FROM foo, (SELECT func1_nosql_imm(func2_read_int_stb(5)) from foo) r or
 begin;
 SELECT * FROM foo, (SELECT func1_nosql_imm(func2_mod_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 rh55-qavm20:40500 pid=15651)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_29.sql
@@ -5536,8 +5524,7 @@ SELECT * FROM foo, (SELECT func1_sql_int_vol(func2_sql_int_imm(5)) from foo) r o
 -- @description function_in_subqry_constant_withfunc2_36.sql
 SELECT * FROM foo, (SELECT func1_sql_int_vol(func2_read_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg1 slice1 rh55-qavm20:40501 pid=16294)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_subqry_constant_withfunc2_37.sql
 SELECT * FROM foo, (SELECT func1_sql_int_vol(func2_read_int_stb(5)) from foo) r order by 1,2,3;
@@ -5649,8 +5636,7 @@ SELECT * FROM foo, (SELECT func1_sql_int_vol(func2_read_int_stb(5)) from foo) r 
 begin;
 SELECT * FROM foo, (SELECT func1_sql_int_vol(func2_mod_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg1 slice1 rh55-qavm20:40501 pid=16463)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_39.sql
@@ -6299,8 +6285,7 @@ SELECT * FROM foo, (SELECT func1_sql_int_stb(func2_sql_int_imm(5)) from foo) r o
 -- @description function_in_subqry_constant_withfunc2_46.sql
 SELECT * FROM foo, (SELECT func1_sql_int_stb(func2_read_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 rh55-qavm20:40500 pid=17102)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_subqry_constant_withfunc2_47.sql
 SELECT * FROM foo, (SELECT func1_sql_int_stb(func2_read_int_stb(5)) from foo) r order by 1,2,3;
@@ -6412,8 +6397,7 @@ SELECT * FROM foo, (SELECT func1_sql_int_stb(func2_read_int_stb(5)) from foo) r 
 begin;
 SELECT * FROM foo, (SELECT func1_sql_int_stb(func2_mod_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg1 slice1 rh55-qavm20:40501 pid=17272)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_49.sql
@@ -7062,8 +7046,7 @@ SELECT * FROM foo, (SELECT func1_sql_int_imm(func2_sql_int_imm(5)) from foo) r o
 -- @description function_in_subqry_constant_withfunc2_56.sql
 SELECT * FROM foo, (SELECT func1_sql_int_imm(func2_read_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 rh55-qavm20:40500 pid=17911)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_subqry_constant_withfunc2_57.sql
 SELECT * FROM foo, (SELECT func1_sql_int_imm(func2_read_int_stb(5)) from foo) r order by 1,2,3;
@@ -7175,8 +7158,7 @@ SELECT * FROM foo, (SELECT func1_sql_int_imm(func2_read_int_stb(5)) from foo) r 
 begin;
 SELECT * FROM foo, (SELECT func1_sql_int_imm(func2_mod_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 rh55-qavm20:40500 pid=18079)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_59.sql
@@ -10825,8 +10807,7 @@ SELECT * FROM foo, (SELECT func1_sql_setint_vol(func2_sql_int_imm(5)) from foo) 
 -- @description function_in_subqry_constant_withfunc2_66.sql
 SELECT * FROM foo, (SELECT func1_sql_setint_vol(func2_read_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg1 slice1 rh55-qavm20:40501 pid=18740)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_subqry_constant_withfunc2_67.sql
 SELECT * FROM foo, (SELECT func1_sql_setint_vol(func2_read_int_stb(5)) from foo) r order by 1,2,3;
@@ -11438,8 +11419,7 @@ SELECT * FROM foo, (SELECT func1_sql_setint_vol(func2_read_int_stb(5)) from foo)
 begin;
 SELECT * FROM foo, (SELECT func1_sql_setint_vol(func2_mod_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg1 slice1 rh55-qavm20:40501 pid=18908)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_69.sql
@@ -15088,8 +15068,7 @@ SELECT * FROM foo, (SELECT func1_sql_setint_stb(func2_sql_int_imm(5)) from foo) 
 -- @description function_in_subqry_constant_withfunc2_76.sql
 SELECT * FROM foo, (SELECT func1_sql_setint_stb(func2_read_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 rh55-qavm20:40500 pid=19547)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_subqry_constant_withfunc2_77.sql
 SELECT * FROM foo, (SELECT func1_sql_setint_stb(func2_read_int_stb(5)) from foo) r order by 1,2,3;
@@ -15701,8 +15680,7 @@ SELECT * FROM foo, (SELECT func1_sql_setint_stb(func2_read_int_stb(5)) from foo)
 begin;
 SELECT * FROM foo, (SELECT func1_sql_setint_stb(func2_mod_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg1 slice1 rh55-qavm20:40501 pid=19717)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_79.sql
@@ -19351,8 +19329,7 @@ SELECT * FROM foo, (SELECT func1_sql_setint_imm(func2_sql_int_imm(5)) from foo) 
 -- @description function_in_subqry_constant_withfunc2_86.sql
 SELECT * FROM foo, (SELECT func1_sql_setint_imm(func2_read_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg1 slice1 rh55-qavm20:40501 pid=20358)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_subqry_constant_withfunc2_87.sql
 SELECT * FROM foo, (SELECT func1_sql_setint_imm(func2_read_int_stb(5)) from foo) r order by 1,2,3;
@@ -19964,8 +19941,7 @@ SELECT * FROM foo, (SELECT func1_sql_setint_imm(func2_read_int_stb(5)) from foo)
 begin;
 SELECT * FROM foo, (SELECT func1_sql_setint_imm(func2_mod_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 rh55-qavm20:40500 pid=20524)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_89.sql
@@ -19978,57 +19954,48 @@ rollback;
 -- @description function_in_subqry_constant_withfunc2_90.sql
 SELECT * FROM foo, (SELECT func1_read_int_sql_vol(func2_nosql_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 rh55-qavm20:40500 pid=20679)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_vol" line 4 at SQL statement
 -- @description function_in_subqry_constant_withfunc2_91.sql
 SELECT * FROM foo, (SELECT func1_read_int_sql_vol(func2_nosql_stb(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg1 slice1 rh55-qavm20:40501 pid=20767)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_vol" line 4 at SQL statement
 -- @description function_in_subqry_constant_withfunc2_92.sql
 SELECT * FROM foo, (SELECT func1_read_int_sql_vol(func2_nosql_imm(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg1 slice1 rh55-qavm20:40501 pid=20853)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_vol" line 4 at SQL statement
 -- @description function_in_subqry_constant_withfunc2_93.sql
 SELECT * FROM foo, (SELECT func1_read_int_sql_vol(func2_sql_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 rh55-qavm20:40500 pid=20937)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_vol" line 4 at SQL statement
 -- @description function_in_subqry_constant_withfunc2_94.sql
 SELECT * FROM foo, (SELECT func1_read_int_sql_vol(func2_sql_int_stb(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg1 slice1 rh55-qavm20:40501 pid=21025)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_vol" line 4 at SQL statement
 -- @description function_in_subqry_constant_withfunc2_95.sql
 SELECT * FROM foo, (SELECT func1_read_int_sql_vol(func2_sql_int_imm(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg1 slice1 rh55-qavm20:40501 pid=21111)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_vol" line 4 at SQL statement
 -- @description function_in_subqry_constant_withfunc2_96.sql
 SELECT * FROM foo, (SELECT func1_read_int_sql_vol(func2_read_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 rh55-qavm20:40500 pid=21195)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_subqry_constant_withfunc2_97.sql
 SELECT * FROM foo, (SELECT func1_read_int_sql_vol(func2_read_int_stb(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg1 slice1 rh55-qavm20:40501 pid=21284)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_vol" line 4 at SQL statement
 -- @description function_in_subqry_constant_withfunc2_98.sql
 begin;
 SELECT * FROM foo, (SELECT func1_read_int_sql_vol(func2_mod_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 rh55-qavm20:40500 pid=21368)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_99.sql
@@ -20041,8 +20008,7 @@ rollback;
 -- @description function_in_subqry_constant_withfunc2_100.sql
 SELECT * FROM foo, (SELECT func1_read_int_sql_stb(func2_nosql_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 rh55-qavm20:40500 pid=21523)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_stb" line 4 at SQL statement
 -- @description function_in_subqry_constant_withfunc2_101.sql
 SELECT * FROM foo, (SELECT func1_read_int_sql_stb(func2_nosql_stb(5)) from foo) r order by 1,2,3;
@@ -20259,8 +20225,7 @@ SELECT * FROM foo, (SELECT func1_read_int_sql_stb(func2_nosql_imm(5)) from foo) 
 -- @description function_in_subqry_constant_withfunc2_103.sql
 SELECT * FROM foo, (SELECT func1_read_int_sql_stb(func2_sql_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 rh55-qavm20:40500 pid=21773)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func1_read_int_sql_stb" line 4 at SQL statement
 -- @description function_in_subqry_constant_withfunc2_104.sql
 SELECT * FROM foo, (SELECT func1_read_int_sql_stb(func2_sql_int_stb(5)) from foo) r order by 1,2,3;
@@ -20477,8 +20442,7 @@ SELECT * FROM foo, (SELECT func1_read_int_sql_stb(func2_sql_int_imm(5)) from foo
 -- @description function_in_subqry_constant_withfunc2_106.sql
 SELECT * FROM foo, (SELECT func1_read_int_sql_stb(func2_read_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 rh55-qavm20:40500 pid=22023)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_subqry_constant_withfunc2_107.sql
 SELECT * FROM foo, (SELECT func1_read_int_sql_stb(func2_read_int_stb(5)) from foo) r order by 1,2,3;
@@ -20590,8 +20554,7 @@ SELECT * FROM foo, (SELECT func1_read_int_sql_stb(func2_read_int_stb(5)) from fo
 begin;
 SELECT * FROM foo, (SELECT func1_read_int_sql_stb(func2_mod_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg1 slice1 rh55-qavm20:40501 pid=22194)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_109.sql
@@ -20604,57 +20567,48 @@ rollback;
 -- @description function_in_subqry_constant_withfunc2_110.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_vol(func2_nosql_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db rh55-qavm20:5432 pid=17448)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_vol" line 4 at FOR over SELECT rows
 -- @description function_in_subqry_constant_withfunc2_111.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_vol(func2_nosql_stb(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db rh55-qavm20:5432 pid=17651)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_vol" line 4 at FOR over SELECT rows
 -- @description function_in_subqry_constant_withfunc2_112.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_vol(func2_nosql_imm(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db rh55-qavm20:5432 pid=17854)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_vol" line 4 at FOR over SELECT rows
 -- @description function_in_subqry_constant_withfunc2_113.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_vol(func2_sql_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db rh55-qavm20:5432 pid=18057)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_vol" line 4 at FOR over SELECT rows
 -- @description function_in_subqry_constant_withfunc2_114.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_vol(func2_sql_int_stb(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db rh55-qavm20:5432 pid=18260)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_vol" line 4 at FOR over SELECT rows
 -- @description function_in_subqry_constant_withfunc2_115.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_vol(func2_sql_int_imm(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db rh55-qavm20:5432 pid=18463)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_vol" line 4 at FOR over SELECT rows
 -- @description function_in_subqry_constant_withfunc2_116.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_vol(func2_read_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg1 slice1 rh55-qavm20:40501 pid=22898)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_subqry_constant_withfunc2_117.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_vol(func2_read_int_stb(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db rh55-qavm20:5432 pid=18766)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_vol" line 4 at FOR over SELECT rows
 -- @description function_in_subqry_constant_withfunc2_118.sql
 begin;
 SELECT * FROM foo, (SELECT func1_read_setint_sql_vol(func2_mod_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 rh55-qavm20:40500 pid=23071)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_119.sql
@@ -20667,57 +20621,48 @@ rollback;
 -- @description function_in_subqry_constant_withfunc2_120.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_nosql_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db rh55-qavm20:5432 pid=19250)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_subqry_constant_withfunc2_121.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_nosql_stb(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db rh55-qavm20:5432 pid=19472)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_subqry_constant_withfunc2_122.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_nosql_imm(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db rh55-qavm20:5432 pid=19675)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_subqry_constant_withfunc2_123.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_sql_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db rh55-qavm20:5432 pid=19878)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_subqry_constant_withfunc2_124.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_sql_int_stb(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db rh55-qavm20:5432 pid=20081)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_subqry_constant_withfunc2_125.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_sql_int_imm(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db rh55-qavm20:5432 pid=20284)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_subqry_constant_withfunc2_126.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_read_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 rh55-qavm20:40500 pid=23742)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 -- @description function_in_subqry_constant_withfunc2_127.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_read_int_stb(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (entry db rh55-qavm20:5432 pid=20587)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_subqry_constant_withfunc2_128.sql
 begin;
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_mod_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 rh55-qavm20:40500 pid=23915)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_129.sql
@@ -20731,72 +20676,63 @@ rollback;
 begin;
 SELECT * FROM foo, (SELECT func1_mod_int_vol(func2_nosql_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 rh55-qavm20:40500 pid=24070)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_131.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_int_vol(func2_nosql_stb(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg1 slice1 rh55-qavm20:40501 pid=24158)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_132.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_int_vol(func2_nosql_imm(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg1 slice1 rh55-qavm20:40501 pid=24244)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_133.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_int_vol(func2_sql_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg1 slice1 rh55-qavm20:40501 pid=24330)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_134.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_int_vol(func2_sql_int_stb(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 rh55-qavm20:40500 pid=24414)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_135.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_int_vol(func2_sql_int_imm(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 rh55-qavm20:40500 pid=24500)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_136.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_int_vol(func2_read_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 rh55-qavm20:40500 pid=24586)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_137.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_int_vol(func2_read_int_stb(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg1 slice1 rh55-qavm20:40501 pid=24675)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_138.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_int_vol(func2_mod_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 rh55-qavm20:40500 pid=24759)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_139.sql
@@ -20810,8 +20746,7 @@ rollback;
 begin;
 SELECT * FROM foo, (SELECT func1_mod_int_stb(func2_nosql_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg1 slice1 rh55-qavm20:40501 pid=24916)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_141.sql
@@ -20832,8 +20767,7 @@ rollback;
 begin;
 SELECT * FROM foo, (SELECT func1_mod_int_stb(func2_sql_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg1 slice1 rh55-qavm20:40501 pid=25158)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func1_mod_int_stb" line 2 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_144.sql
@@ -20854,8 +20788,7 @@ rollback;
 begin;
 SELECT * FROM foo, (SELECT func1_mod_int_stb(func2_read_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 rh55-qavm20:40500 pid=25382)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_147.sql
@@ -20869,8 +20802,7 @@ rollback;
 begin;
 SELECT * FROM foo, (SELECT func1_mod_int_stb(func2_mod_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg1 slice1 rh55-qavm20:40501 pid=25545)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_149.sql
@@ -20884,72 +20816,63 @@ rollback;
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_vol(func2_nosql_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db rh55-qavm20:5432 pid=23179)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_151.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_vol(func2_nosql_stb(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db rh55-qavm20:5432 pid=23382)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_152.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_vol(func2_nosql_imm(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db rh55-qavm20:5432 pid=23585)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_153.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_vol(func2_sql_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db rh55-qavm20:5432 pid=23788)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_154.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_vol(func2_sql_int_stb(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db rh55-qavm20:5432 pid=23991)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_155.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_vol(func2_sql_int_imm(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db rh55-qavm20:5432 pid=24212)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_156.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_vol(func2_read_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg1 slice1 rh55-qavm20:40501 pid=26217)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_157.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_vol(func2_read_int_stb(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db rh55-qavm20:5432 pid=24515)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_158.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_vol(func2_mod_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg1 slice1 rh55-qavm20:40501 pid=26390)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_159.sql
@@ -20963,72 +20886,63 @@ rollback;
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_nosql_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db rh55-qavm20:5432 pid=25228)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_161.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_nosql_stb(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db rh55-qavm20:5432 pid=25486)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_162.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_nosql_imm(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db rh55-qavm20:5432 pid=25690)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_163.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_sql_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db rh55-qavm20:5432 pid=25893)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_164.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_sql_int_stb(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db rh55-qavm20:5432 pid=26104)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_165.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_sql_int_imm(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db rh55-qavm20:5432 pid=26309)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_166.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_read_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice1 rh55-qavm20:40500 pid=27078)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "func2_read_int_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_167.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_read_int_stb(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db rh55-qavm20:5432 pid=26630)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_168.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_mod_int_vol(5)) from foo) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg1 slice1 rh55-qavm20:40501 pid=27253)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "func2_mod_int_vol" line 2 at SQL statement
 rollback;
 -- @description function_in_subqry_constant_withfunc2_169.sql

--- a/src/test/regress/expected/qp_functions_in_with.out
+++ b/src/test/regress/expected/qp_functions_in_with.out
@@ -491,29 +491,25 @@ WITH v(a, b) AS (SELECT func1_sql_setint_imm(a), b FROM foo WHERE b < 5) SELECT 
 -- @description function_in_with_11.sql
 WITH v(a, b) AS (SELECT func1_read_setint_sql_vol(a), b FROM foo WHERE b < 5) SELECT v1.a, v2.b FROM v AS v1, v AS v2 WHERE v1.a < v2.a order by v1.a, v2.b;  
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice2 127.0.0.1:40000 pid=3234)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_vol" line 4 at FOR over SELECT rows
 -- @description function_in_with_12.sql
 WITH v(a, b) AS (SELECT func1_read_setint_sql_stb(a), b FROM foo WHERE b < 5) SELECT v1.a, v2.b FROM v AS v1, v AS v2 WHERE v1.a < v2.a order by v1.a, v2.b;  
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice2 127.0.0.1:40000 pid=3234)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_with_15.sql
 begin;
 WITH v(a, b) AS (SELECT func1_mod_setint_vol(a), b FROM foo WHERE b < 5) SELECT v1.a, v2.b FROM v AS v1, v AS v2 WHERE v1.a < v2.a order by v1.a, v2.b;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice2 127.0.0.1:40000 pid=3234)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_with_16.sql
 begin;
 WITH v(a, b) AS (SELECT func1_mod_setint_stb(a), b FROM foo WHERE b < 5) SELECT v1.a, v2.b FROM v AS v1, v AS v2 WHERE v1.a < v2.a order by v1.a, v2.b;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice2 127.0.0.1:40000 pid=3234)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_with_withfunc2_0.sql
@@ -3453,168 +3449,144 @@ WITH v(a, b) AS (SELECT func1_sql_setint_imm(func2_sql_int_imm(a)), b FROM foo W
 -- @description function_in_with_withfunc2_110.sql
 WITH v(a, b) AS (SELECT func1_read_setint_sql_vol(func2_nosql_vol(a)), b FROM foo WHERE b < 5) SELECT v1.a, v2.b FROM v AS v1, v AS v2 WHERE v1.a < v2.a order by v1.a, v2.b;  
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice2 127.0.0.1:40000 pid=3234)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_vol" line 4 at FOR over SELECT rows
 -- @description function_in_with_withfunc2_111.sql
 WITH v(a, b) AS (SELECT func1_read_setint_sql_vol(func2_nosql_stb(a)), b FROM foo WHERE b < 5) SELECT v1.a, v2.b FROM v AS v1, v AS v2 WHERE v1.a < v2.a order by v1.a, v2.b;  
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice2 127.0.0.1:40000 pid=3234)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_vol" line 4 at FOR over SELECT rows
 -- @description function_in_with_withfunc2_112.sql
 WITH v(a, b) AS (SELECT func1_read_setint_sql_vol(func2_nosql_imm(a)), b FROM foo WHERE b < 5) SELECT v1.a, v2.b FROM v AS v1, v AS v2 WHERE v1.a < v2.a order by v1.a, v2.b;  
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice2 127.0.0.1:40000 pid=3234)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_vol" line 4 at FOR over SELECT rows
 -- @description function_in_with_withfunc2_113.sql
 WITH v(a, b) AS (SELECT func1_read_setint_sql_vol(func2_sql_int_vol(a)), b FROM foo WHERE b < 5) SELECT v1.a, v2.b FROM v AS v1, v AS v2 WHERE v1.a < v2.a order by v1.a, v2.b;  
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice2 127.0.0.1:40000 pid=3234)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_vol" line 4 at FOR over SELECT rows
 -- @description function_in_with_withfunc2_114.sql
 WITH v(a, b) AS (SELECT func1_read_setint_sql_vol(func2_sql_int_stb(a)), b FROM foo WHERE b < 5) SELECT v1.a, v2.b FROM v AS v1, v AS v2 WHERE v1.a < v2.a order by v1.a, v2.b;  
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice2 127.0.0.1:40000 pid=3234)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_vol" line 4 at FOR over SELECT rows
 -- @description function_in_with_withfunc2_115.sql
 WITH v(a, b) AS (SELECT func1_read_setint_sql_vol(func2_sql_int_imm(a)), b FROM foo WHERE b < 5) SELECT v1.a, v2.b FROM v AS v1, v AS v2 WHERE v1.a < v2.a order by v1.a, v2.b;  
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice2 127.0.0.1:40000 pid=3234)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_vol" line 4 at FOR over SELECT rows
 -- @description function_in_with_withfunc2_120.sql
 WITH v(a, b) AS (SELECT func1_read_setint_sql_stb(func2_nosql_vol(a)), b FROM foo WHERE b < 5) SELECT v1.a, v2.b FROM v AS v1, v AS v2 WHERE v1.a < v2.a order by v1.a, v2.b;  
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice2 127.0.0.1:40000 pid=3234)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_with_withfunc2_121.sql
 WITH v(a, b) AS (SELECT func1_read_setint_sql_stb(func2_nosql_stb(a)), b FROM foo WHERE b < 5) SELECT v1.a, v2.b FROM v AS v1, v AS v2 WHERE v1.a < v2.a order by v1.a, v2.b;  
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice2 127.0.0.1:40000 pid=3234)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_with_withfunc2_122.sql
 WITH v(a, b) AS (SELECT func1_read_setint_sql_stb(func2_nosql_imm(a)), b FROM foo WHERE b < 5) SELECT v1.a, v2.b FROM v AS v1, v AS v2 WHERE v1.a < v2.a order by v1.a, v2.b;  
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice2 127.0.0.1:40000 pid=3234)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_with_withfunc2_123.sql
 WITH v(a, b) AS (SELECT func1_read_setint_sql_stb(func2_sql_int_vol(a)), b FROM foo WHERE b < 5) SELECT v1.a, v2.b FROM v AS v1, v AS v2 WHERE v1.a < v2.a order by v1.a, v2.b;  
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice2 127.0.0.1:40000 pid=3234)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_with_withfunc2_124.sql
 WITH v(a, b) AS (SELECT func1_read_setint_sql_stb(func2_sql_int_stb(a)), b FROM foo WHERE b < 5) SELECT v1.a, v2.b FROM v AS v1, v AS v2 WHERE v1.a < v2.a order by v1.a, v2.b;  
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice2 127.0.0.1:40000 pid=3234)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_with_withfunc2_125.sql
 WITH v(a, b) AS (SELECT func1_read_setint_sql_stb(func2_sql_int_imm(a)), b FROM foo WHERE b < 5) SELECT v1.a, v2.b FROM v AS v1, v AS v2 WHERE v1.a < v2.a order by v1.a, v2.b;  
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_contexts.bar"  (seg0 slice2 127.0.0.1:40000 pid=3234)
-DETAIL:  
-SQL statement "SELECT d FROM bar WHERE c <> $1"
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function "func1_read_setint_sql_stb" line 4 at FOR over SELECT rows
 -- @description function_in_with_withfunc2_150.sql
 begin;
 WITH v(a, b) AS (SELECT func1_mod_setint_vol(func2_nosql_vol(a)), b FROM foo WHERE b < 5) SELECT v1.a, v2.b FROM v AS v1, v AS v2 WHERE v1.a < v2.a order by v1.a, v2.b;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice2 127.0.0.1:40000 pid=3234)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_with_withfunc2_151.sql
 begin;
 WITH v(a, b) AS (SELECT func1_mod_setint_vol(func2_nosql_stb(a)), b FROM foo WHERE b < 5) SELECT v1.a, v2.b FROM v AS v1, v AS v2 WHERE v1.a < v2.a order by v1.a, v2.b;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice2 127.0.0.1:40000 pid=3234)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_with_withfunc2_152.sql
 begin;
 WITH v(a, b) AS (SELECT func1_mod_setint_vol(func2_nosql_imm(a)), b FROM foo WHERE b < 5) SELECT v1.a, v2.b FROM v AS v1, v AS v2 WHERE v1.a < v2.a order by v1.a, v2.b;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice2 127.0.0.1:40000 pid=3234)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_with_withfunc2_153.sql
 begin;
 WITH v(a, b) AS (SELECT func1_mod_setint_vol(func2_sql_int_vol(a)), b FROM foo WHERE b < 5) SELECT v1.a, v2.b FROM v AS v1, v AS v2 WHERE v1.a < v2.a order by v1.a, v2.b;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice2 127.0.0.1:40000 pid=3234)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_with_withfunc2_154.sql
 begin;
 WITH v(a, b) AS (SELECT func1_mod_setint_vol(func2_sql_int_stb(a)), b FROM foo WHERE b < 5) SELECT v1.a, v2.b FROM v AS v1, v AS v2 WHERE v1.a < v2.a order by v1.a, v2.b;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice2 127.0.0.1:40000 pid=3234)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_with_withfunc2_155.sql
 begin;
 WITH v(a, b) AS (SELECT func1_mod_setint_vol(func2_sql_int_imm(a)), b FROM foo WHERE b < 5) SELECT v1.a, v2.b FROM v AS v1, v AS v2 WHERE v1.a < v2.a order by v1.a, v2.b;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice2 127.0.0.1:40000 pid=3234)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_vol" line 4 at SQL statement
 rollback;
 -- @description function_in_with_withfunc2_160.sql
 begin;
 WITH v(a, b) AS (SELECT func1_mod_setint_stb(func2_nosql_vol(a)), b FROM foo WHERE b < 5) SELECT v1.a, v2.b FROM v AS v1, v AS v2 WHERE v1.a < v2.a order by v1.a, v2.b;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice2 127.0.0.1:40000 pid=3234)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_with_withfunc2_161.sql
 begin;
 WITH v(a, b) AS (SELECT func1_mod_setint_stb(func2_nosql_stb(a)), b FROM foo WHERE b < 5) SELECT v1.a, v2.b FROM v AS v1, v AS v2 WHERE v1.a < v2.a order by v1.a, v2.b;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice2 127.0.0.1:40000 pid=3234)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_with_withfunc2_162.sql
 begin;
 WITH v(a, b) AS (SELECT func1_mod_setint_stb(func2_nosql_imm(a)), b FROM foo WHERE b < 5) SELECT v1.a, v2.b FROM v AS v1, v AS v2 WHERE v1.a < v2.a order by v1.a, v2.b;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice2 127.0.0.1:40000 pid=3234)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_with_withfunc2_163.sql
 begin;
 WITH v(a, b) AS (SELECT func1_mod_setint_stb(func2_sql_int_vol(a)), b FROM foo WHERE b < 5) SELECT v1.a, v2.b FROM v AS v1, v AS v2 WHERE v1.a < v2.a order by v1.a, v2.b;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice2 127.0.0.1:40000 pid=3234)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_with_withfunc2_164.sql
 begin;
 WITH v(a, b) AS (SELECT func1_mod_setint_stb(func2_sql_int_stb(a)), b FROM foo WHERE b < 5) SELECT v1.a, v2.b FROM v AS v1, v AS v2 WHERE v1.a < v2.a order by v1.a, v2.b;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice2 127.0.0.1:40000 pid=3234)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;
 -- @description function_in_with_withfunc2_165.sql
 begin;
 WITH v(a, b) AS (SELECT func1_mod_setint_stb(func2_sql_int_imm(a)), b FROM foo WHERE b < 5) SELECT v1.a, v2.b FROM v AS v1, v AS v2 WHERE v1.a < v2.a order by v1.a, v2.b;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice2 127.0.0.1:40000 pid=3234)
-DETAIL:  
-SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function "func1_mod_setint_stb" line 4 at SQL statement
 rollback;

--- a/src/test/regress/expected/qp_misc_jiras.out
+++ b/src/test/regress/expected/qp_misc_jiras.out
@@ -2591,8 +2591,7 @@ $$
 language plpgsql;
 select gp_segment_id, a, func2(a) from qp_misc_jiras.fim1; -- we should disallow this
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_misc_jiras.pg_foo"  (seg2 slice1 nikos-mac:25434 pid=94008)
-DETAIL:  
-SQL statement "select count(*) from qp_misc_jiras.pg_foo"
+CONTEXT:  SQL statement "select count(*) from qp_misc_jiras.pg_foo"
 PL/pgSQL function "func2" line 4 at EXECUTE statement
 create or replace function func3(int) returns int as $$
 declare
@@ -3480,7 +3479,7 @@ explain select x, median2(y) from qp_misc_jiras.tbl9613 group by x; -- this shou
 
 select x, median2(y) from qp_misc_jiras.tbl9613 group by x; -- this should be disallowed
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_misc_jiras.tbl9613"  (seg0 slice1 nikos-mac:25432 pid=94006)
-DETAIL:  SQL function "_final_median2" during startup
+CONTEXT:  SQL function "_final_median2" during startup
 -- start_ignore
 drop table qp_misc_jiras.tbl9613;
 DROP AGGREGATE "median"(numeric);

--- a/src/test/regress/expected/qp_misc_jiras_optimizer.out
+++ b/src/test/regress/expected/qp_misc_jiras_optimizer.out
@@ -2597,8 +2597,7 @@ $$
 language plpgsql;
 select gp_segment_id, a, func2(a) from qp_misc_jiras.fim1; -- we should disallow this
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_misc_jiras.pg_foo"  (seg1 slice1 nikos-mac:25433 pid=95127)
-DETAIL:  
-SQL statement "select count(*) from qp_misc_jiras.pg_foo"
+CONTEXT:  SQL statement "select count(*) from qp_misc_jiras.pg_foo"
 PL/pgSQL function "func2" line 4 at EXECUTE statement
 create or replace function func3(int) returns int as $$
 declare
@@ -3512,7 +3511,7 @@ explain select x, median2(y) from qp_misc_jiras.tbl9613 group by x; -- this shou
 
 select x, median2(y) from qp_misc_jiras.tbl9613 group by x; -- this should be disallowed
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_misc_jiras.tbl9613"  (seg0 slice1 nikos-mac:25432 pid=95126)
-DETAIL:  SQL function "_final_median2" during startup
+CONTEXT:  SQL function "_final_median2" during startup
 -- start_ignore
 drop table qp_misc_jiras.tbl9613;
 DROP AGGREGATE "median"(numeric);

--- a/src/test/regress/expected/qp_misc_rio.out
+++ b/src/test/regress/expected/qp_misc_rio.out
@@ -567,8 +567,7 @@ AS $$
 $$ LANGUAGE plpythonu;
 INSERT INTO testdata_in SELECT * FROM func_plpythonu(2);
 ERROR:  plpy.SPIError: function cannot execute on a QE slice because it accesses relation "qp_misc_rio.testdata_in"  (entry db krajaraman:15432 pid=63091)
-DETAIL:  
-Traceback (most recent call last):
+CONTEXT:  Traceback (most recent call last):
   PL/Python function "func_plpythonu", line 3, in <module>
     return plpy.execute(sqlstm);
 PL/Python function "func_plpythonu"

--- a/src/test/regress/expected/qp_with_functional_inlining.out
+++ b/src/test/regress/expected/qp_with_functional_inlining.out
@@ -373,8 +373,7 @@ SELECT v1.a, v2.b
 FROM v AS v1, v AS v2
 WHERE v1.a < v2.a ORDER BY 1,2;
 psql:sql/qp_with_functional.sql:242: ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg1 slice1 127.0.0.1:25433 pid=32057)
-DETAIL:  
-SQL statement "UPDATE foobar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE foobar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "cte_func1" line 2 at SQL statement
 -- @description test15e: CTE with a user-defined function [STABLE READS SQL DATA]
 CREATE OR REPLACE FUNCTION cte_func1(a int) RETURNS int
@@ -393,8 +392,7 @@ SELECT v1.a, v2.b
 FROM v AS v1, v AS v2
 WHERE v1.a < v2.a ORDER BY 1,2;
 psql:sql/qp_with_functional.sql:260: ERROR:  function cannot execute on a QE slice because it accesses relation "qp_with_functional_inlining.foobar"  (seg0 slice1 127.0.0.1:25432 pid=53270)
-DETAIL:  
-SQL statement "SELECT d FROM foobar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM foobar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "cte_func1" line 4 at SQL statement
 -- @description test15g: CTE with a user-defined function [VOLATILE NO SQL]
 CREATE OR REPLACE FUNCTION cte_func1(a int) RETURNS int 
@@ -456,8 +454,7 @@ SELECT v1.a, v2.b
 FROM v AS v1, v AS v2
 WHERE v1.a < v2.a ORDER BY 1,2;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_with_functional.foobar"
-DETAIL:  
-SQL statement "SELECT d FROM foobar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM foobar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "cte_func1" line 4 at SQL statement
 -- @description test15j: CTE with a user-defined function [VOLATILE MODIFIES SQL DATA]
 CREATE OR REPLACE FUNCTION cte_func1(a int) RETURNS int 
@@ -474,8 +471,7 @@ SELECT v1.a, v2.b
 FROM v AS v1, v AS v2
 WHERE v1.a < v2.a ORDER BY 1,2;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement
-DETAIL:  
-SQL statement "UPDATE foobar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE foobar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "cte_func1" line 2 at SQL statement
 -- @description test16a: CTE within a user-defined function
 -- Hide Traceback and error context information. This can throw a different
@@ -516,8 +512,7 @@ $$ language plpgsql READS SQL DATA;
 WITH v(a, b) AS (SELECT cte_func2() as a, b FROM foo WHERE b < 5)
 SELECT * from v ORDER BY 1;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_with_functional.foo"
-DETAIL:  
-SQL statement "SELECT (SELECT COUNT(*) FROM (WITH v AS (SELECT a, b FROM foo WHERE b < 9),
+CONTEXT:  SQL statement "SELECT (SELECT COUNT(*) FROM (WITH v AS (SELECT a, b FROM foo WHERE b < 9),
 w AS (SELECT * FROM v WHERE a < 5)
 SELECT v1.a, w1.b b1, w2.b b2
 FROM v AS v1, v as v2, w AS w1, w AS w2

--- a/src/test/regress/expected/qp_with_functional_noinlining.out
+++ b/src/test/regress/expected/qp_with_functional_noinlining.out
@@ -372,8 +372,7 @@ SELECT v1.a, v2.b
 FROM v AS v1, v AS v2
 WHERE v1.a < v2.a ORDER BY 1,2;
 psql:sql/qp_with_functional.sql:242: ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg1 slice2 127.0.0.1:25433 pid=32357)
-DETAIL:  
-SQL statement "UPDATE foobar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE foobar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "cte_func1" line 2 at SQL statement
 -- @description test15e: CTE with a user-defined function [STABLE READS SQL DATA]
 CREATE OR REPLACE FUNCTION cte_func1(a int) RETURNS int
@@ -392,8 +391,7 @@ SELECT v1.a, v2.b
 FROM v AS v1, v AS v2
 WHERE v1.a < v2.a ORDER BY 1,2;
 psql:sql/qp_with_functional.sql:260: ERROR:  function cannot execute on a QE slice because it accesses relation "qp_with_functional_noinlining.foobar"  (seg0 slice2 127.0.0.1:25432 pid=53837)
-DETAIL:  
-SQL statement "SELECT d FROM foobar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM foobar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "cte_func1" line 4 at SQL statement
 -- @description test15g: CTE with a user-defined function [VOLATILE NO SQL]
 CREATE OR REPLACE FUNCTION cte_func1(a int) RETURNS int 
@@ -455,8 +453,7 @@ SELECT v1.a, v2.b
 FROM v AS v1, v AS v2
 WHERE v1.a < v2.a ORDER BY 1,2;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_with_functional.foobar"
-DETAIL:  
-SQL statement "SELECT d FROM foobar WHERE c = $1 LIMIT 1"
+CONTEXT:  SQL statement "SELECT d FROM foobar WHERE c = $1 LIMIT 1"
 PL/pgSQL function "cte_func1" line 4 at SQL statement
 -- @description test15j: CTE with a user-defined function [VOLATILE MODIFIES SQL DATA]
 CREATE OR REPLACE FUNCTION cte_func1(a int) RETURNS int 
@@ -473,8 +470,7 @@ SELECT v1.a, v2.b
 FROM v AS v1, v AS v2
 WHERE v1.a < v2.a ORDER BY 1,2;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement
-DETAIL:  
-SQL statement "UPDATE foobar SET d = d+1 WHERE c = $1"
+CONTEXT:  SQL statement "UPDATE foobar SET d = d+1 WHERE c = $1"
 PL/pgSQL function "cte_func1" line 2 at SQL statement
 -- @description test16a: CTE within a user-defined function
 -- Hide Traceback and error context information. This can throw a different
@@ -515,8 +511,7 @@ $$ language plpgsql READS SQL DATA;
 WITH v(a, b) AS (SELECT cte_func2() as a, b FROM foo WHERE b < 5)
 SELECT * from v ORDER BY 1;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_with_functional.foo"
-DETAIL:  
-SQL statement "SELECT (SELECT COUNT(*) FROM (WITH v AS (SELECT a, b FROM foo WHERE b < 9),
+CONTEXT:  SQL statement "SELECT (SELECT COUNT(*) FROM (WITH v AS (SELECT a, b FROM foo WHERE b < 9),
 w AS (SELECT * FROM v WHERE a < 5)
 SELECT v1.a, w1.b b1, w2.b b2
 FROM v AS v1, v as v2, w AS w1, w AS w2

--- a/src/test/regress/expected/rangefuncs.out
+++ b/src/test/regress/expected/rangefuncs.out
@@ -26,15 +26,15 @@ LINE 1: select * from foo2, foot(foo2.fooid) z where foo2.f2 = z.f2;
 -- function in subselect
 select * from foo2 where f2 in (select f2 from foot(foo2.fooid) z where z.fooid = foo2.fooid) ORDER BY 1,2;
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.foo2"
-DETAIL:  SQL function "foot" during startup
+CONTEXT:  SQL function "foot" during startup
 -- function in subselect
 select * from foo2 where f2 in (select f2 from foot(1) z where z.fooid = foo2.fooid) ORDER BY 1,2;
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.foo2"
-DETAIL:  SQL function "foot" during startup
+CONTEXT:  SQL function "foot" during startup
 -- function in subselect
 select * from foo2 where f2 in (select f2 from foot(foo2.fooid) z where z.fooid = 1) ORDER BY 1,2;
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.foo2"
-DETAIL:  SQL function "foot" during startup
+CONTEXT:  SQL function "foot" during startup
 -- nested functions
 select foot.fooid, foot.f2 from foot(sin(pi()/2)::int) ORDER BY 1,2;
  fooid | f2  
@@ -291,18 +291,18 @@ CREATE FUNCTION foorescan(int) RETURNS setof foorescan AS 'SELECT * FROM fooresc
 --invokes ExecFunctionReScan with chgParam != NULL
 SELECT f.* FROM barrescan b, foorescan f WHERE f.fooid = b.fooid AND b.fooid IN (SELECT fooid FROM foorescan(b.fooid)) ORDER BY 1,2;
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.foorescan"
-DETAIL:  SQL function "foorescan" during startup
+CONTEXT:  SQL function "foorescan" during startup
 SELECT b.fooid, max(f.foosubid) FROM barrescan b, foorescan f WHERE f.fooid = b.fooid AND b.fooid IN (SELECT fooid FROM foorescan(b.fooid)) GROUP BY b.fooid ORDER BY 1,2;
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.foorescan"
-DETAIL:  SQL function "foorescan" during startup
+CONTEXT:  SQL function "foorescan" during startup
 CREATE VIEW fooview1 AS SELECT f.* FROM barrescan b, foorescan f WHERE f.fooid = b.fooid AND b.fooid IN (SELECT fooid FROM foorescan(b.fooid)) ORDER BY 1,2;
 SELECT * FROM fooview1 AS fv WHERE fv.fooid = 5004;
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.foorescan"
-DETAIL:  SQL function "foorescan" during startup
+CONTEXT:  SQL function "foorescan" during startup
 CREATE VIEW fooview2 AS SELECT b.fooid, max(f.foosubid) AS maxsubid FROM barrescan b, foorescan f WHERE f.fooid = b.fooid AND b.fooid IN (SELECT fooid FROM foorescan(b.fooid)) GROUP BY b.fooid ORDER BY 1,2;
 SELECT * FROM fooview2 AS fv WHERE fv.maxsubid = 5;
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.foorescan"
-DETAIL:  SQL function "foorescan" during startup
+CONTEXT:  SQL function "foorescan" during startup
 DROP VIEW vw_foorescan;
 DROP VIEW fooview1;
 DROP VIEW fooview2;

--- a/src/test/regress/expected/rangefuncs_optimizer.out
+++ b/src/test/regress/expected/rangefuncs_optimizer.out
@@ -31,7 +31,7 @@ CONTEXT:  SQL function "foot" statement 1
 -- function in subselect
 select * from foo2 where f2 in (select f2 from foot(1) z where z.fooid = foo2.fooid) ORDER BY 1,2;
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.foo2"
-DETAIL:  SQL function "foot" during startup
+CONTEXT:  SQL function "foot" during startup
 -- function in subselect
 select * from foo2 where f2 in (select f2 from foot(foo2.fooid) z where z.fooid = 1) ORDER BY 1,2;
 ERROR:  query plan with multiple segworker groups is not supported
@@ -273,12 +273,12 @@ CREATE FUNCTION foorescan(int,int) RETURNS setof foorescan AS 'SELECT * FROM foo
 --invokes ExecFunctionReScan
 SELECT * FROM foorescan f WHERE f.fooid IN (SELECT fooid FROM foorescan(5002,5004)) ORDER BY 1,2;
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.foorescan"
-DETAIL:  SQL function "foorescan" during startup
+CONTEXT:  SQL function "foorescan" during startup
 CREATE VIEW vw_foorescan AS SELECT * FROM foorescan(5002,5004);
 --invokes ExecFunctionReScan
 SELECT * FROM foorescan f WHERE f.fooid IN (SELECT fooid FROM vw_foorescan) ORDER BY 1,2;
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.foorescan"
-DETAIL:  SQL function "foorescan" during startup
+CONTEXT:  SQL function "foorescan" during startup
 CREATE TABLE barrescan (fooid int primary key);
 NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "barrescan_pkey" for table "barrescan"
 INSERT INTO barrescan values(5003);
@@ -291,18 +291,18 @@ CREATE FUNCTION foorescan(int) RETURNS setof foorescan AS 'SELECT * FROM fooresc
 --invokes ExecFunctionReScan with chgParam != NULL
 SELECT f.* FROM barrescan b, foorescan f WHERE f.fooid = b.fooid AND b.fooid IN (SELECT fooid FROM foorescan(b.fooid)) ORDER BY 1,2;
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.foorescan"
-DETAIL:  SQL function "foorescan" during startup
+CONTEXT:  SQL function "foorescan" during startup
 SELECT b.fooid, max(f.foosubid) FROM barrescan b, foorescan f WHERE f.fooid = b.fooid AND b.fooid IN (SELECT fooid FROM foorescan(b.fooid)) GROUP BY b.fooid ORDER BY 1,2;
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.foorescan"
-DETAIL:  SQL function "foorescan" during startup
+CONTEXT:  SQL function "foorescan" during startup
 CREATE VIEW fooview1 AS SELECT f.* FROM barrescan b, foorescan f WHERE f.fooid = b.fooid AND b.fooid IN (SELECT fooid FROM foorescan(b.fooid)) ORDER BY 1,2;
 SELECT * FROM fooview1 AS fv WHERE fv.fooid = 5004;
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.foorescan"
-DETAIL:  SQL function "foorescan" during startup
+CONTEXT:  SQL function "foorescan" during startup
 CREATE VIEW fooview2 AS SELECT b.fooid, max(f.foosubid) AS maxsubid FROM barrescan b, foorescan f WHERE f.fooid = b.fooid AND b.fooid IN (SELECT fooid FROM foorescan(b.fooid)) GROUP BY b.fooid ORDER BY 1,2;
 SELECT * FROM fooview2 AS fv WHERE fv.maxsubid = 5;
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.foorescan"
-DETAIL:  SQL function "foorescan" during startup
+CONTEXT:  SQL function "foorescan" during startup
 DROP VIEW vw_foorescan;
 DROP VIEW fooview1;
 DROP VIEW fooview2;

--- a/src/test/regress/expected/sirv_functions.out
+++ b/src/test/regress/expected/sirv_functions.out
@@ -923,8 +923,7 @@ $$
 --ctas with nested calls in the from clause
 create table sirv_test7_result2 as select * from sirv_test7_fun3(sirv_test7_fun2(2,1000,1000),3,2000,2000) as field1 distributed by (field1);
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db pbld2:12010 pid=29278)
-DETAIL:  
-SQL statement "CREATE  TABLE countries_results (country_code text, country_name text, lang_count int, area float, gnp float) distributed by (country_code)"
+CONTEXT:  SQL statement "CREATE  TABLE countries_results (country_code text, country_name text, lang_count int, area float, gnp float) distributed by (country_code)"
 PL/pgSQL function "sirv_test7_fun3" line 7 at EXECUTE statement
 select * from sirv_test7_result2;
 ERROR:  relation "sirv_test7_result2" does not exist
@@ -1095,8 +1094,7 @@ $$
 create table sirv_test8_result2 (field1 text, field2 int) distributed by (field2);
 insert into sirv_test8_result2 select * from sirv_test8_fun3(sirv_test8_fun2(2,1000,1000),3,2000,2000),(select 1) FOO;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db pbld2:12010 pid=29278)
-DETAIL:  
-SQL statement "CREATE  TABLE countries_results (country_code text, country_name text, lang_count int, area float, gnp float) distributed by (country_code)"
+CONTEXT:  SQL statement "CREATE  TABLE countries_results (country_code text, country_name text, lang_count int, area float, gnp float) distributed by (country_code)"
 PL/pgSQL function "sirv_test8_fun3" line 7 at EXECUTE statement
 select * from sirv_test8_result2 order by field2;
  field1 | field2 
@@ -1245,13 +1243,11 @@ create table sirv_test10_result1(field1 countries,country_code text,country_name
 --start_ignore 
 insert into sirv_test10_result1 select sirv_test10_srf1(2,1000,1000);
 ERROR:  function cannot execute on a QE slice because it accesses relation "sirv_functions.country"  (seg0 slice1 pbld2:12011 pid=29727)
-DETAIL:  
-SQL statement " ( with lang_total as ( select count(*) as lang_count,country.code,countrylanguage.countrycode from country join countrylanguage on (country.code=countrylanguage.countrycode) group by country.code,countrylanguage.countrycode order by country.code ) select country.code,country.name, lang_count, country.surfacearea, country.gnp from country left outer join lang_total on (lang_total.code = country.code) where lang_count >  $1  and country.surfacearea >  $2  and country.gnp >  $3  order by lang_total.lang_count desc )"
+CONTEXT:  SQL statement " ( with lang_total as ( select count(*) as lang_count,country.code,countrylanguage.countrycode from country join countrylanguage on (country.code=countrylanguage.countrycode) group by country.code,countrylanguage.countrycode order by country.code ) select country.code,country.name, lang_count, country.surfacearea, country.gnp from country left outer join lang_total on (lang_total.code = country.code) where lang_count >  $1  and country.surfacearea >  $2  and country.gnp >  $3  order by lang_total.lang_count desc )"
 PL/pgSQL function "sirv_test10_srf1" line 8 at for over select rows
 insert into sirv_test10_result1 select sirv_test10_srf1 from sirv_test10_srf1(2,1000,1000);
 ERROR:  function cannot execute on a QE slice because it accesses relation "sirv_functions.country"  (entry db pbld2:12010 pid=29278)
-DETAIL:  
-SQL statement " ( with lang_total as ( select count(*) as lang_count,country.code,countrylanguage.countrycode from country join countrylanguage on (country.code=countrylanguage.countrycode) group by country.code,countrylanguage.countrycode order by country.code ) select country.code,country.name, lang_count, country.surfacearea, country.gnp from country left outer join lang_total on (lang_total.code = country.code) where lang_count >  $1  and country.surfacearea >  $2  and country.gnp >  $3  order by lang_total.lang_count desc )"
+CONTEXT:  SQL statement " ( with lang_total as ( select count(*) as lang_count,country.code,countrylanguage.countrycode from country join countrylanguage on (country.code=countrylanguage.countrycode) group by country.code,countrylanguage.countrycode order by country.code ) select country.code,country.name, lang_count, country.surfacearea, country.gnp from country left outer join lang_total on (lang_total.code = country.code) where lang_count >  $1  and country.surfacearea >  $2  and country.gnp >  $3  order by lang_total.lang_count desc )"
 PL/pgSQL function "sirv_test10_srf1" line 8 at for over select rows
 --end_ignore
 select * from sirv_test10_result1; --should return 0 rows
@@ -1306,13 +1302,11 @@ create table sirv_test10_result2(res text) distributed by (res);
 --start_ignore
 insert into sirv_test10_result2 select sirv_test10_srf2('result',2,1000,1000);
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 pbld2:12011 pid=29759)
-DETAIL:  
-SQL statement "CREATE  TABLE countries_results (country_code text, country_name text, lang_count int, area float, gnp float) distributed by (country_code)"
+CONTEXT:  SQL statement "CREATE  TABLE countries_results (country_code text, country_name text, lang_count int, area float, gnp float) distributed by (country_code)"
 PL/pgSQL function "sirv_test10_srf2" line 8 at EXECUTE statement
 insert into sirv_test10_result2 select * from sirv_test10_srf2('result',2,1000,1000);
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (entry db pbld2:12010 pid=29278)
-DETAIL:  
-SQL statement "CREATE  TABLE countries_results (country_code text, country_name text, lang_count int, area float, gnp float) distributed by (country_code)"
+CONTEXT:  SQL statement "CREATE  TABLE countries_results (country_code text, country_name text, lang_count int, area float, gnp float) distributed by (country_code)"
 PL/pgSQL function "sirv_test10_srf2" line 8 at EXECUTE statement
 --end_ignore
 select * from sirv_test10_result2; --should return 0 rows
@@ -1414,13 +1408,11 @@ create table sirv_test12_result1 (res text) distributed by (res);
 --start_ignore
 insert into sirv_test12_result1 select sirv_test12(lang_count::int,surfacearea::float,gnp::float) from sirv_test12_input;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg1 slice1 pbld2:12012 pid=27128)
-DETAIL:  
-SQL statement "CREATE  TABLE countries_results (country_code text, country_name text, lang_count int, area float, gnp float) distributed by(country_code)"
+CONTEXT:  SQL statement "CREATE  TABLE countries_results (country_code text, country_name text, lang_count int, area float, gnp float) distributed by(country_code)"
 PL/pgSQL function "sirv_test12" line 7 at EXECUTE statement
 insert into sirv_test12_result1 select * from (select sirv_test12(lang_count::int,surfacearea::float,gnp::float) from sirv_test12_input) FOO;
 ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg1 slice1 pbld2:12012 pid=27159)
-DETAIL:  
-SQL statement "CREATE  TABLE countries_results (country_code text, country_name text, lang_count int, area float, gnp float) distributed by(country_code)"
+CONTEXT:  SQL statement "CREATE  TABLE countries_results (country_code text, country_name text, lang_count int, area float, gnp float) distributed by(country_code)"
 PL/pgSQL function "sirv_test12" line 7 at EXECUTE statement
 --end_ignore
 select * from sirv_test12_result1;

--- a/src/test/regress/expected/spi.out
+++ b/src/test/regress/expected/spi.out
@@ -50,7 +50,6 @@ end
 $$ language plpgsql READS SQL DATA;
 select * from (select refcursor (1, 10)) t1, test;
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.test"  (seg0 slice1 usensimiobmbp.corp.emc.com:18506 pid=17309)
-DETAIL:  
-SQL statement "select * from test where a > param1 and b > param2"
+CONTEXT:  SQL statement "select * from test where a > param1 and b > param2"
 PL/pgSQL function "refcursor" line 6 at OPEN
 drop function refcursor(int, int);

--- a/src/test/regress/expected/udf_exception_blocks.out
+++ b/src/test/regress/expected/udf_exception_blocks.out
@@ -741,8 +741,7 @@ SET debug_dtm_action_nestinglevel=0;
 DROP TABLE IF EXISTS employees;
 NOTICE:  table "employees" does not exist, skipping
 select test_protocol_allseg(1, 2,'f');
-ERROR:  DTM error (gathered results from cmd 'Rollback Current Subtransaction') (cdbtm.c:2040)
-DETAIL:  Raise error for debug_dtm_action = 3, debug_dtm_action_protocol = Rollback Current Subtransaction  (seg0 127.0.1.1:25432 pid=24104)
+ERROR:  Raise error for debug_dtm_action = 3, debug_dtm_action_protocol = Rollback Current Subtransaction  (seg0 127.0.1.1:25432 pid=24104)
 CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 17 during exception cleanup
 select * from employees;
 ERROR:  relation "employees" does not exist
@@ -759,8 +758,7 @@ DROP TABLE IF EXISTS employees;
 NOTICE:  table "employees" does not exist, skipping
 select test_protocol_allseg(1, 2,'f');
 NOTICE:  catching the exception ...2
-ERROR:  DTM error (gathered results from cmd 'Rollback Current Subtransaction') (cdbtm.c:2040)
-DETAIL:  transaction 1518031192-0000000602 at level 1 already processed (current level 1) (cdbtm.c:3456)  (seg1 127.0.1.1:25433 pid=24105)
+ERROR:  transaction 1518031192-0000000602 at level 1 already processed (current level 1) (cdbtm.c:3456)  (seg1 127.0.1.1:25433 pid=24105)
 CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 8 during exception cleanup
 select * from employees;
 ERROR:  relation "employees" does not exist
@@ -797,8 +795,7 @@ SET debug_dtm_action=fail_begin_command;
 SET debug_dtm_action_nestinglevel=0;
 DROP TABLE IF EXISTS employees;
 select test_protocol_allseg(1, 2,'f');
-ERROR:  DTM error (gathered results from cmd ' Begin Internal Subtransaction') (cdbtm.c:2040)
-DETAIL:  Raise ERROR for debug_dtm_action = 2, debug_dtm_action_protocol =  Begin Internal Subtransaction  (seg0 127.0.1.1:25432 pid=24104)
+ERROR:  Raise ERROR for debug_dtm_action = 2, debug_dtm_action_protocol =  Begin Internal Subtransaction  (seg0 127.0.1.1:25432 pid=24104)
 CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 8 during statement block entry
 select * from employees;
 ERROR:  relation "employees" does not exist
@@ -835,8 +832,7 @@ SET debug_dtm_action=fail_end_command;
 SET debug_dtm_action_nestinglevel=0;
 DROP TABLE IF EXISTS employees;
 select test_protocol_allseg(1, 2,'f');
-ERROR:  DTM error (gathered results from cmd ' Begin Internal Subtransaction') (cdbtm.c:2040)
-DETAIL:  Raise error for debug_dtm_action = 3, debug_dtm_action_protocol =  Begin Internal Subtransaction  (seg0 127.0.1.1:25432 pid=24104)
+ERROR:  Raise error for debug_dtm_action = 3, debug_dtm_action_protocol =  Begin Internal Subtransaction  (seg0 127.0.1.1:25432 pid=24104)
 CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 8 during statement block entry
 select * from employees;
 ERROR:  relation "employees" does not exist
@@ -874,8 +870,7 @@ SET debug_dtm_action_nestinglevel=0;
 DROP TABLE IF EXISTS employees;
 select test_protocol_allseg(1, 2,'f');
 NOTICE:  catching the exception ...2
-ERROR:  DTM error (gathered results from cmd 'Rollback Current Subtransaction') (cdbtm.c:2040)
-DETAIL:  transaction 1518031192-0000000650 at level 1 already processed (current level 1) (cdbtm.c:3456)  (seg0 127.0.1.1:25432 pid=24104)
+ERROR:  transaction 1518031192-0000000650 at level 1 already processed (current level 1) (cdbtm.c:3456)  (seg0 127.0.1.1:25432 pid=24104)
 CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 8 during exception cleanup
 select * from employees;
 ERROR:  relation "employees" does not exist
@@ -912,8 +907,7 @@ SET debug_dtm_action=fail_begin_command;
 SET debug_dtm_action_nestinglevel=0;
 DROP TABLE IF EXISTS employees;
 select test_protocol_allseg(1, 2,'f');
-ERROR:  DTM error (gathered results from cmd 'Rollback Current Subtransaction') (cdbtm.c:2040)
-DETAIL:  Raise ERROR for debug_dtm_action = 2, debug_dtm_action_protocol = Rollback Current Subtransaction  (seg0 127.0.1.1:25432 pid=24104)
+ERROR:  Raise ERROR for debug_dtm_action = 2, debug_dtm_action_protocol = Rollback Current Subtransaction  (seg0 127.0.1.1:25432 pid=24104)
 CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 17 during exception cleanup
 select * from employees;
 ERROR:  relation "employees" does not exist

--- a/src/test/regress/input/constraints.source
+++ b/src/test/regress/input/constraints.source
@@ -353,9 +353,6 @@ INSERT INTO unique_tbl VALUES (3, 'three'), (1, 'five'), (5, 'one'), (4, 'two'),
 BEGIN;
 INSERT INTO unique_tbl VALUES (3, 'Three'); -- should succeed for now
 COMMIT; -- should fail
--- GPDB_90_MERGE_FIXME: The error handling code loses the original "duplicate
--- key" error that the segment throws, and replaces it with this generic
--- message. We should work on that.
 
 -- make constraint check immediate
 BEGIN;

--- a/src/test/regress/output/constraints.source
+++ b/src/test/regress/output/constraints.source
@@ -487,12 +487,8 @@ INSERT INTO unique_tbl VALUES (3, 'three'), (1, 'five'), (5, 'one'), (4, 'two'),
 BEGIN;
 INSERT INTO unique_tbl VALUES (3, 'Three'); -- should succeed for now
 COMMIT; -- should fail
-WARNING:  the distributed transaction 'Abort [Prepared]' broadcast failed to one or more segments for gid = 1517942707-0000000164.  Retrying ... try 0
-NOTICE:  Releasing segworker groups to retry broadcast.
-ERROR:  The distributed transaction 'Prepare' broadcast failed to one or more segments for gid = 1517942707-0000000164. (cdbtm.c:692)
--- GPDB_90_MERGE_FIXME: The error handling code loses the original "duplicate
--- key" error that the segment throws, and replaces it with this generic
--- message. We should work on that.
+ERROR:  duplicate key value violates unique constraint "unique_tbl_i_key"
+DETAIL:  Key (i)=(3) already exists.
 -- make constraint check immediate
 BEGIN;
 SET CONSTRAINTS ALL IMMEDIATE;
@@ -514,9 +510,8 @@ BEGIN;
 INSERT INTO unique_tbl VALUES (3, 'Three'); -- should succeed for now
 UPDATE unique_tbl SET t = 'THREE' WHERE i = 3 AND t = 'Three';
 COMMIT; -- should fail
-WARNING:  the distributed transaction 'Abort [Prepared]' broadcast failed to one or more segments for gid = 1517942707-0000000931.  Retrying ... try 0
-NOTICE:  Releasing segworker groups to retry broadcast.
-ERROR:  The distributed transaction 'Prepare' broadcast failed to one or more segments for gid = 1517942707-0000000931. (cdbtm.c:692)
+ERROR:  duplicate key value violates unique constraint "unique_tbl_i_key"
+DETAIL:  Key (i)=(3) already exists.
 SELECT * FROM unique_tbl;
  i |   t   
 ---+-------
@@ -595,22 +590,19 @@ NOTICE:  CREATE TABLE / EXCLUDE will create implicit index "deferred_excl_f1_exc
 INSERT INTO deferred_excl VALUES(1);
 INSERT INTO deferred_excl VALUES(2);
 INSERT INTO deferred_excl VALUES(1); -- fail
-WARNING:  the distributed transaction 'Abort [Prepared]' broadcast failed to one or more segments for gid = 1517942707-0000002484.  Retrying ... try 0
-NOTICE:  Releasing segworker groups to retry broadcast.
-ERROR:  The distributed transaction 'Prepare' broadcast failed to one or more segments for gid = 1517942707-0000002484. (cdbtm.c:692)
+ERROR:  conflicting key value violates exclusion constraint "deferred_excl_f1_exclusion"
+DETAIL:  Key (f1)=(1) conflicts with existing key (f1)=(1).
 BEGIN;
 INSERT INTO deferred_excl VALUES(2); -- no fail here
 COMMIT; -- should fail here
-WARNING:  the distributed transaction 'Abort [Prepared]' broadcast failed to one or more segments for gid = 1517942707-0000002485.  Retrying ... try 0
-NOTICE:  Releasing segworker groups to retry broadcast.
-ERROR:  The distributed transaction 'Prepare' broadcast failed to one or more segments for gid = 1517942707-0000002485. (cdbtm.c:692)
+ERROR:  conflicting key value violates exclusion constraint "deferred_excl_f1_exclusion"
+DETAIL:  Key (f1)=(2) conflicts with existing key (f1)=(2).
 BEGIN;
 INSERT INTO deferred_excl VALUES(3);
 INSERT INTO deferred_excl VALUES(3); -- no fail here
 COMMIT; -- should fail here
-WARNING:  the distributed transaction 'Abort [Prepared]' broadcast failed to one or more segments for gid = 1517942707-0000002486.  Retrying ... try 0
-NOTICE:  Releasing segworker groups to retry broadcast.
-ERROR:  The distributed transaction 'Prepare' broadcast failed to one or more segments for gid = 1517942707-0000002486. (cdbtm.c:692)
+ERROR:  conflicting key value violates exclusion constraint "deferred_excl_f1_exclusion"
+DETAIL:  Key (f1)=(3) conflicts with existing key (f1)=(3).
 ALTER TABLE deferred_excl DROP CONSTRAINT deferred_excl_con;
 -- This should fail, but worth testing because of HOT updates
 UPDATE deferred_excl SET f1 = 3;

--- a/src/test/regress/output/constraints.source
+++ b/src/test/regress/output/constraints.source
@@ -497,19 +497,17 @@ ERROR:  The distributed transaction 'Prepare' broadcast failed to one or more se
 BEGIN;
 SET CONSTRAINTS ALL IMMEDIATE;
 INSERT INTO unique_tbl VALUES (3, 'Three'); -- should fail
+ERROR:  duplicate key value violates unique constraint "unique_tbl_i_key"
+DETAIL:  Key (i)=(3) already exists.
 COMMIT;
-WARNING:  the distributed transaction 'Abort [Prepared]' broadcast failed to one or more segments for gid = 1517942707-0000000738.  Retrying ... try 0
-NOTICE:  Releasing segworker groups to retry broadcast.
-ERROR:  The distributed transaction 'Prepare' broadcast failed to one or more segments for gid = 1517942707-0000000738. (cdbtm.c:692)
 -- forced check when SET CONSTRAINTS is called
 BEGIN;
 SET CONSTRAINTS ALL DEFERRED;
 INSERT INTO unique_tbl VALUES (3, 'Three'); -- should succeed for now
 SET CONSTRAINTS ALL IMMEDIATE; -- should fail
+ERROR:  duplicate key value violates unique constraint "unique_tbl_i_key"
+DETAIL:  Key (i)=(3) already exists.
 COMMIT;
-WARNING:  the distributed transaction 'Abort [Prepared]' broadcast failed to one or more segments for gid = 1517942707-0000000739.  Retrying ... try 0
-NOTICE:  Releasing segworker groups to retry broadcast.
-ERROR:  The distributed transaction 'Prepare' broadcast failed to one or more segments for gid = 1517942707-0000000739. (cdbtm.c:692)
 -- test a HOT update that invalidates the conflicting tuple.
 -- the trigger should still fire and catch the violation
 BEGIN;

--- a/src/test/regress/output/constraints_optimizer.source
+++ b/src/test/regress/output/constraints_optimizer.source
@@ -487,12 +487,8 @@ INSERT INTO unique_tbl VALUES (3, 'three'), (1, 'five'), (5, 'one'), (4, 'two'),
 BEGIN;
 INSERT INTO unique_tbl VALUES (3, 'Three'); -- should succeed for now
 COMMIT; -- should fail
-WARNING:  the distributed transaction 'Abort [Prepared]' broadcast failed to one or more segments for gid = 1517942707-0000000164.  Retrying ... try 0
-NOTICE:  Releasing segworker groups to retry broadcast.
-ERROR:  The distributed transaction 'Prepare' broadcast failed to one or more segments for gid = 1517942707-0000000164. (cdbtm.c:692)
--- GPDB_90_MERGE_FIXME: The error handling code loses the original "duplicate
--- key" error that the segment throws, and replaces it with this generic
--- message. We should work on that.
+ERROR:  duplicate key value violates unique constraint "unique_tbl_i_key"
+DETAIL:  Key (i)=(3) already exists.
 -- make constraint check immediate
 BEGIN;
 SET CONSTRAINTS ALL IMMEDIATE;
@@ -514,9 +510,8 @@ BEGIN;
 INSERT INTO unique_tbl VALUES (3, 'Three'); -- should succeed for now
 UPDATE unique_tbl SET t = 'THREE' WHERE i = 3 AND t = 'Three';
 COMMIT; -- should fail
-WARNING:  the distributed transaction 'Abort [Prepared]' broadcast failed to one or more segments for gid = 1517942707-0000000931.  Retrying ... try 0
-NOTICE:  Releasing segworker groups to retry broadcast.
-ERROR:  The distributed transaction 'Prepare' broadcast failed to one or more segments for gid = 1517942707-0000000931. (cdbtm.c:692)
+ERROR:  duplicate key value violates unique constraint "unique_tbl_i_key"
+DETAIL:  Key (i)=(3) already exists.
 SELECT * FROM unique_tbl;
  i |   t   
 ---+-------
@@ -595,22 +590,19 @@ NOTICE:  CREATE TABLE / EXCLUDE will create implicit index "deferred_excl_f1_exc
 INSERT INTO deferred_excl VALUES(1);
 INSERT INTO deferred_excl VALUES(2);
 INSERT INTO deferred_excl VALUES(1); -- fail
-WARNING:  the distributed transaction 'Abort [Prepared]' broadcast failed to one or more segments for gid = 1517942707-0000002484.  Retrying ... try 0
-NOTICE:  Releasing segworker groups to retry broadcast.
-ERROR:  The distributed transaction 'Prepare' broadcast failed to one or more segments for gid = 1517942707-0000002484. (cdbtm.c:692)
+ERROR:  conflicting key value violates exclusion constraint "deferred_excl_f1_exclusion"
+DETAIL:  Key (f1)=(1) conflicts with existing key (f1)=(1).
 BEGIN;
 INSERT INTO deferred_excl VALUES(2); -- no fail here
 COMMIT; -- should fail here
-WARNING:  the distributed transaction 'Abort [Prepared]' broadcast failed to one or more segments for gid = 1517942707-0000002485.  Retrying ... try 0
-NOTICE:  Releasing segworker groups to retry broadcast.
-ERROR:  The distributed transaction 'Prepare' broadcast failed to one or more segments for gid = 1517942707-0000002485. (cdbtm.c:692)
+ERROR:  conflicting key value violates exclusion constraint "deferred_excl_f1_exclusion"
+DETAIL:  Key (f1)=(2) conflicts with existing key (f1)=(2).
 BEGIN;
 INSERT INTO deferred_excl VALUES(3);
 INSERT INTO deferred_excl VALUES(3); -- no fail here
 COMMIT; -- should fail here
-WARNING:  the distributed transaction 'Abort [Prepared]' broadcast failed to one or more segments for gid = 1517942707-0000002486.  Retrying ... try 0
-NOTICE:  Releasing segworker groups to retry broadcast.
-ERROR:  The distributed transaction 'Prepare' broadcast failed to one or more segments for gid = 1517942707-0000002486. (cdbtm.c:692)
+ERROR:  conflicting key value violates exclusion constraint "deferred_excl_f1_exclusion"
+DETAIL:  Key (f1)=(3) conflicts with existing key (f1)=(3).
 ALTER TABLE deferred_excl DROP CONSTRAINT deferred_excl_con;
 -- This should fail, but worth testing because of HOT updates
 UPDATE deferred_excl SET f1 = 3;

--- a/src/test/regress/output/constraints_optimizer.source
+++ b/src/test/regress/output/constraints_optimizer.source
@@ -497,19 +497,17 @@ ERROR:  The distributed transaction 'Prepare' broadcast failed to one or more se
 BEGIN;
 SET CONSTRAINTS ALL IMMEDIATE;
 INSERT INTO unique_tbl VALUES (3, 'Three'); -- should fail
+ERROR:  duplicate key value violates unique constraint "unique_tbl_i_key"
+DETAIL:  Key (i)=(3) already exists.
 COMMIT;
-WARNING:  the distributed transaction 'Abort [Prepared]' broadcast failed to one or more segments for gid = 1517942707-0000000738.  Retrying ... try 0
-NOTICE:  Releasing segworker groups to retry broadcast.
-ERROR:  The distributed transaction 'Prepare' broadcast failed to one or more segments for gid = 1517942707-0000000738. (cdbtm.c:692)
 -- forced check when SET CONSTRAINTS is called
 BEGIN;
 SET CONSTRAINTS ALL DEFERRED;
 INSERT INTO unique_tbl VALUES (3, 'Three'); -- should succeed for now
 SET CONSTRAINTS ALL IMMEDIATE; -- should fail
+ERROR:  duplicate key value violates unique constraint "unique_tbl_i_key"
+DETAIL:  Key (i)=(3) already exists.
 COMMIT;
-WARNING:  the distributed transaction 'Abort [Prepared]' broadcast failed to one or more segments for gid = 1517942707-0000000739.  Retrying ... try 0
-NOTICE:  Releasing segworker groups to retry broadcast.
-ERROR:  The distributed transaction 'Prepare' broadcast failed to one or more segments for gid = 1517942707-0000000739. (cdbtm.c:692)
 -- test a HOT update that invalidates the conflicting tuple.
 -- the trigger should still fire and catch the violation
 BEGIN;

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -593,7 +593,7 @@ LOG ERRORS SEGMENT REJECT LIMIT 2;
 -- should error out as segment reject limit will be reached
 SELECT * FROM exttab_basic_3;
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: missing data for column "j"  (seg0 slice1 @hostname@:40000 pid=95343)
-DETAIL:  External table exttab_basic_3, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
+CONTEXT:  External table exttab_basic_3, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
 -- Error log should be populated
 select count(*) > 0 from gp_read_error_log('exttab_basic_3');
  ?column? 
@@ -624,7 +624,7 @@ LOG ERRORS SEGMENT REJECT LIMIT 5;
 -- Insert should fail
 INSERT INTO exttab_insert_1 select * from exttab_basic_5;
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: missing data for column "j"  (seg0 slice1 @hostname@:40000 pid=95610)
-DETAIL:  External table exttab_basic_5, line 18 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
+CONTEXT:  External table exttab_basic_5, line 18 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
 SELECT * from exttab_insert_1 order by i;
  i  |     j     
 ----+-----------
@@ -694,7 +694,7 @@ CREATE TABLE exttab_ctas_2 AS select * from exttab_basic_7;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: missing data for column "j"  (seg0 slice1 @hostname@:40000 pid=95610)
-DETAIL:  External table exttab_basic_7, line 18 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
+CONTEXT:  External table exttab_basic_7, line 18 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
 -- Table should not exist
 SELECT * from exttab_ctas_2 order by i;
 ERROR:  relation "exttab_ctas_2" does not exist
@@ -795,7 +795,7 @@ WHERE e1.i = e2.i ORDER BY e1.i
 )
 SELECT * FROM cte1 ORDER BY cte1.i;
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: missing data for column "j"  (seg0 slice2 @hostname@:40000 pid=95621)
-DETAIL:  External table exttab_cte_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
+CONTEXT:  External table exttab_cte_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
 select count(*) from gp_read_error_log('exttab_cte_2');
  count 
 -------
@@ -881,7 +881,7 @@ SELECT e1.i, e2.j from exttab_cursor_2 e1 INNER JOIN exttab_cursor_2 e2 ON e1.i 
 -- The test is here to track the issue.
 FETCH exttab_cur1;
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: missing data for column "j"  (seg0 slice1 subraa4-mac:40000 pid=70279)
-DETAIL:  External table exttab_cursor_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
+CONTEXT:  External table exttab_cursor_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
 COMMIT;
 -- This should have errors populated already
 SELECT count(*) > 0 FROM gp_read_error_log('exttab_cursor_2');
@@ -987,7 +987,7 @@ NOTICE:  Found 2 data formatting errors (2 or more input rows). Rejected related
 
 SELECT COUNT(*) FROM exttab_permissions_2;
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: missing data for column "j"  (seg0 slice1 @hostname@:40000 pid=51006)
-DETAIL:  External table exttab_permissions_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
+CONTEXT:  External table exttab_permissions_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
 -- Only superuser can do gp_truncate_error_log('*.*')
 DROP ROLE IF EXISTS exttab_non_superuser;
 CREATE ROLE exttab_non_superuser WITH NOSUPERUSER LOGIN CREATEDB;
@@ -1195,7 +1195,7 @@ SELECT sum(distinct e1.i), sum(distinct e2.i), e1.j FROM
 (SELECT i, j FROM exttab_subq_2 WHERE i < 10) e2
 group by e1.j;
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: missing data for column "j"  (seg0 slice2 @hostname@:40000 pid=66875)
-DETAIL:  External table exttab_subq_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
+CONTEXT:  External table exttab_subq_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
 SELECT COUNT(*) > 0 FROM
 (
 SELECT * FROM gp_read_error_log('exttab_subq_1')
@@ -1225,7 +1225,7 @@ SELECT sum(distinct e1.i), sum(distinct e2.i), e1.j FROM
 group by e1.j
 HAVING sum(distinct e1.i) > (SELECT max(i) FROM exttab_subq_2);
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: missing data for column "j"  (seg0 slice4 @hostname@:40000 pid=66866)
-DETAIL:  External table exttab_subq_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
+CONTEXT:  External table exttab_subq_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
 SELECT COUNT(*) > 0 FROM
 (
 SELECT * FROM gp_read_error_log('exttab_subq_1')
@@ -1321,7 +1321,7 @@ SELECT ( SELECT i FROM exttab_subq_2 WHERE i <= e1.i) as i, e1.j
 FROM exttab_subq_2 e1, exttab_subq_1 e2
 WHERE e1.i = e2.i;
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: missing data for column "j"  (seg0 slice2 @hostname@:40000 pid=49348)
-DETAIL:  External table exttab_subq_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
+CONTEXT:  External table exttab_subq_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
 -- CSQ
 SELECT gp_truncate_error_log('exttab_subq_1');
  gp_truncate_error_log 
@@ -1340,7 +1340,7 @@ exttab_subq_1 e1, exttab_subq_1 e2
 WHERE e1.j = e2.j and
 e1.i + 1 IN ( SELECT i from exttab_subq_2 WHERE i <= e1.i);
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: missing data for column "j"  (seg0 slice1 @hostname@:40000 pid=66875)
-DETAIL:  External table exttab_subq_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
+CONTEXT:  External table exttab_subq_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
 SELECT COUNT(*) > 0 FROM
 (
 SELECT * FROM gp_read_error_log('exttab_subq_1')
@@ -1368,7 +1368,7 @@ SELECT ( SELECT i FROM exttab_subq_2 WHERE i <= e1.i) as i, e1.j
 FROM exttab_subq_2 e1, exttab_subq_1 e2
 WHERE e1.i = e2.i;
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: missing data for column "j"  (seg0 slice2 @hostname@:40000 pid=66866)
-DETAIL:  External table exttab_subq_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
+CONTEXT:  External table exttab_subq_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
 SELECT COUNT(*) > 0 FROM
 (
 SELECT * FROM gp_read_error_log('exttab_subq_1')
@@ -1496,7 +1496,7 @@ SELECT e1.i, e2.j FROM
 (SELECT i, j FROM exttab_subtxs_2 WHERE i < 10) e2
 WHERE e1.i = e2.i;
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: missing data for column "j"  (seg0 slice1 @hostname@:40000 pid=70905)
-DETAIL:  External table exttab_subtxs_2, line 7 of file://@hostname@:@abs_srcdir@/data/exttab_more_errors.data: "error_1"
+CONTEXT:  External table exttab_subtxs_2, line 7 of file://@hostname@:@abs_srcdir@/data/exttab_more_errors.data: "error_1"
 COMMIT;
 -- Error logs should not have been rolled back.
 -- Check that number of errors is greater than 12 instead of checking for
@@ -1632,7 +1632,7 @@ SELECT e1.i, e2.j FROM
 (SELECT i, j FROM exttab_txs_2 WHERE i < 10) e2
 WHERE e1.i = e2.i;
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: missing data for column "j"  (seg0 slice2 @hostname@:40000 pid=76719)
-DETAIL:  External table exttab_txs_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
+CONTEXT:  External table exttab_txs_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
 COMMIT;
 -- Additional error rows should have been inserted into the error logs even if the tx is aborted.
 -- Truncate of error logs should not be rolled back even if the transaction is aborted. All operation on error logs are persisted.
@@ -1703,7 +1703,7 @@ SELECT e1.i, e2.j FROM
 (SELECT i, j FROM exttab_txs_4 WHERE i < 10) e2
 WHERE e1.i = e2.i order by e1.i;
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: missing data for column "j"  (seg0 slice1 @hostname@:40000 pid=76727)
-DETAIL:  External table exttab_txs_3, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
+CONTEXT:  External table exttab_txs_3, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
 COMMIT;
 -- Error logs should not exist for these tables that would have been rolled back
 SELECT count(*) FROM gp_read_error_log('exttab_txs_3');
@@ -1751,8 +1751,8 @@ LANGUAGE plpgsql volatile;
 -- Should fail
 SELECT * FROM exttab_udfs_func1();
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: missing data for column "j"  (seg0 slice2 @hostname@:40000 pid=77376)
-DETAIL:  External table exttab_udfs_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
-CONTEXT:  SQL statement "SELECT sum(distinct e1.i) as sum_i, sum(distinct e2.i) as sum_j, e1.j as j FROM
+CONTEXT:  External table exttab_udfs_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
+SQL statement "SELECT sum(distinct e1.i) as sum_i, sum(distinct e2.i) as sum_j, e1.j as j FROM
 	   (SELECT i, j FROM exttab_udfs_1 WHERE i < 5 ) e1,
 	   (SELECT i, j FROM exttab_udfs_2 WHERE i < 10) e2
 	   group by e1.j"
@@ -1790,8 +1790,8 @@ SELECT gp_truncate_error_log('exttab_udfs_2');
 -- Should fail
 INSERT INTO exttab_udfs_insert_1 SELECT * FROM exttab_udfs_func1();
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: missing data for column "j"  (seg0 slice2 @hostname@:40000 pid=77376)
-DETAIL:  External table exttab_udfs_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
-CONTEXT:  SQL statement "SELECT sum(distinct e1.i) as sum_i, sum(distinct e2.i) as sum_j, e1.j as j FROM
+CONTEXT:  External table exttab_udfs_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
+SQL statement "SELECT sum(distinct e1.i) as sum_i, sum(distinct e2.i) as sum_j, e1.j as j FROM
 	   (SELECT i, j FROM exttab_udfs_1 WHERE i < 5 ) e1,
 	   (SELECT i, j FROM exttab_udfs_2 WHERE i < 10) e2
 	   group by e1.j"
@@ -1878,8 +1878,8 @@ CONTEXT:  SQL statement "INSERT INTO exttab_udfs_insert_2
   SELECT i, j from exttab_udfs_1"
 PL/pgSQL function "exttab_udfs_func2" line 8 at SQL statement
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: missing data for column "j"  (seg0 @hostname@:40000 pid=63695)
-DETAIL:  External table exttab_udfs_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
-CONTEXT:  SQL statement "INSERT INTO exttab_udfs_insert_2
+CONTEXT:  External table exttab_udfs_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
+SQL statement "INSERT INTO exttab_udfs_insert_2
   SELECT i, j from exttab_udfs_2"
 PL/pgSQL function "exttab_udfs_func2" line 24 at SQL statement
 SELECT COUNT(*) > 0 FROM
@@ -1911,8 +1911,8 @@ CONTEXT:  SQL statement "INSERT INTO exttab_udfs_insert_2
   SELECT i, j from exttab_udfs_1"
 PL/pgSQL function "exttab_udfs_func2" line 8 at SQL statement
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: missing data for column "j"  (seg0 @hostname@:40000 pid=63695)
-DETAIL:  External table exttab_udfs_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
-CONTEXT:  SQL statement "INSERT INTO exttab_udfs_insert_2
+CONTEXT:  External table exttab_udfs_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
+SQL statement "INSERT INTO exttab_udfs_insert_2
   SELECT i, j from exttab_udfs_2"
 PL/pgSQL function "exttab_udfs_func2" line 24 at SQL statement
 SELECT COUNT(*) > 0 FROM
@@ -1944,8 +1944,8 @@ CONTEXT:  SQL statement "INSERT INTO exttab_udfs_insert_2
   SELECT i, j from exttab_udfs_1"
 PL/pgSQL function "exttab_udfs_func2" line 8 at SQL statement
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: missing data for column "j"  (seg0 @hostname@:40000 pid=63695)
-DETAIL:  External table exttab_udfs_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
-CONTEXT:  SQL statement "INSERT INTO exttab_udfs_insert_2
+CONTEXT:  External table exttab_udfs_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
+SQL statement "INSERT INTO exttab_udfs_insert_2
   SELECT i, j from exttab_udfs_2"
 PL/pgSQL function "exttab_udfs_func2" line 24 at SQL statement
 SELECT COUNT(*) > 0 FROM
@@ -1979,8 +1979,8 @@ CONTEXT:  SQL statement "INSERT INTO exttab_udfs_insert_2
   SELECT i, j from exttab_udfs_1"
 PL/pgSQL function "exttab_udfs_func2" line 8 at SQL statement
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: missing data for column "j"  (seg0 @hostname@:40000 pid=63695)
-DETAIL:  External table exttab_udfs_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
-CONTEXT:  SQL statement "INSERT INTO exttab_udfs_insert_2
+CONTEXT:  External table exttab_udfs_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
+SQL statement "INSERT INTO exttab_udfs_insert_2
   SELECT i, j from exttab_udfs_2"
 PL/pgSQL function "exttab_udfs_func2" line 24 at SQL statement
 SELECT COUNT(*) > 0 FROM
@@ -2020,7 +2020,7 @@ SELECT * FROM exttab_union_2
 ) FOO
 order by FOO.i;
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: missing data for column "j"  (seg0 slice1 @hostname@:40000 pid=78596)
-DETAIL:  External table exttab_union_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
+CONTEXT:  External table exttab_union_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
 -- Error table count
 select count(*) > 0 from
 (
@@ -2055,7 +2055,7 @@ SELECT e1.i, e2.j from exttab_union_2 e1 INNER JOIN exttab_union_2 e2 ON e1.i = 
 UNION ALL
 SELECT e1.i, e2.j from exttab_union_2 e1 INNER JOIN exttab_union_2 e2 ON e1.i = e2.i;
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: missing data for column "j"  (seg0 slice4 @hostname@:40000 pid=78649)
-DETAIL:  External table exttab_union_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
+CONTEXT:  External table exttab_union_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
 -- should return 0 rows
 SELECT * from exttab_union_insert_1;
  i | j 
@@ -2141,7 +2141,7 @@ SELECT gp_truncate_error_log('exttab_views_2');
 -- This should error out
 SELECT * FROM exttab_views_3;
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: missing data for column "j"  (seg0 slice2 @hostname@:40000 pid=79499)
-DETAIL:  External table exttab_views_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
+CONTEXT:  External table exttab_views_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
 -- Error table should be populated
 SELECT count(*) > 0 FROM
 (
@@ -2175,7 +2175,7 @@ SELECT gp_truncate_error_log('exttab_views_2');
 -- Should fail
 INSERT INTO exttab_views_insert_1 SELECT * FROM exttab_views_3;
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: missing data for column "j"  (seg0 slice2 @hostname@:40000 pid=79496)
-DETAIL:  External table exttab_views_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
+CONTEXT:  External table exttab_views_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
 -- should not have any rows
 SELECT * FROM exttab_views_insert_1;
  i | j | k 
@@ -2214,7 +2214,7 @@ CREATE TABLE exttab_views_ctas_1 AS SELECT * FROM exttab_views_3 where length(j)
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'j' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: missing data for column "j"  (seg0 slice2 @hostname@:40000 pid=79505)
-DETAIL:  External table exttab_views_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
+CONTEXT:  External table exttab_views_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
 SELECT * FROM exttab_views_ctas_1;
 ERROR:  relation "exttab_views_ctas_1" does not exist
 LINE 1: SELECT * FROM exttab_views_ctas_1;
@@ -2251,7 +2251,7 @@ CREATE TABLE exttab_views_ctas_1 AS SELECT * FROM exttab_views_3;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'j' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: missing data for column "j"  (seg0 slice2 @hostname@:40000 pid=79499)
-DETAIL:  External table exttab_views_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
+CONTEXT:  External table exttab_views_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
 -- Relation should not exist
 SELECT * FROM exttab_views_ctas_1;
 ERROR:  relation "exttab_views_ctas_1" does not exist
@@ -2365,7 +2365,7 @@ WHERE c1.i = c2.i
 ORDER BY c1.i
 limit 5;
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: missing data for column "j"  (seg0 slice6 @hostname@:40000 pid=79568)
-DETAIL:  External table exttab_windows_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
+CONTEXT:  External table exttab_windows_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
 SELECT COUNT(*) > 0
 FROM
 (
@@ -2399,7 +2399,7 @@ WHERE e1.i = e2.i LIMIT 5
 )
 SELECT * FROM cte1, exttab_limit_2 e3 where cte1.i = e3.i ORDER BY cte1.i LIMIT 3;
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: missing data for column "j"  (seg0 slice4 @hostname@:40000 pid=49348)
-DETAIL:  External table exttab_limit_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
+CONTEXT:  External table exttab_limit_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
 SELECT count(*) FROM gp_read_error_log('exttab_limit_2');
  count 
 -------
@@ -2474,7 +2474,7 @@ WHERE e1.i = e2.i LIMIT 3
 )
 SELECT * FROM cte1, exttab_limit_2 e3 where cte1.i = e3.i ORDER BY cte1.i LIMIT 5;
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: missing data for column "j"  (seg0 slice2 @hostname@:40000 pid=35568)
-DETAIL:  External table exttab_limit_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
+CONTEXT:  External table exttab_limit_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
 SELECT count(*) > 0 FROM gp_read_error_log('exttab_limit_2');
  ?column? 
 ----------
@@ -2548,7 +2548,7 @@ SELECT gp_truncate_error_log('exttab_limit_2');
 
 SELECT * FROM exttab_limit_1 e1, exttab_limit_2 e2 where e1.i = e2.i LIMIT 3;
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: missing data for column "j"  (seg0 slice2 @hostname@:40000 pid=9815)
-DETAIL:  External table exttab_limit_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
+CONTEXT:  External table exttab_limit_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
 SELECT count(*) > 0 FROM
 (
 SELECT * FROM gp_read_error_log('exttab_limit_1')
@@ -2579,7 +2579,7 @@ LOG ERRORS SEGMENT REJECT LIMIT 20000;
 -- should fail with an appropriate error message
 SELECT COUNT(*) FROM exttab_first_reject_limit_1;
 ERROR:  All 1000 first rows in this segment were rejected. Aborting operation regardless of REJECT LIMIT value. Last error was: missing data for column "j"  (seg0 slice1 @hostname@:40000 pid=28213)
-DETAIL:  External table exttab_first_reject_limit_1, line 1000 of file://@hostname@@abs_srcdir@/data/exttab_first_errors.data: "error_0"
+CONTEXT:  External table exttab_first_reject_limit_1, line 1000 of file://@hostname@@abs_srcdir@/data/exttab_first_errors.data: "error_0"
 SELECT COUNT(*) > 0 FROM gp_read_error_log('exttab_first_reject_limit_1');
  ?column? 
 ----------
@@ -2617,7 +2617,7 @@ LOG ERRORS SEGMENT REJECT LIMIT 500;
 SET gp_initial_bad_row_limit = 2;
 SELECT COUNT(*) FROM exttab_first_reject_limit_2;
 ERROR:  All 2 first rows in this segment were rejected. Aborting operation regardless of REJECT LIMIT value. Last error was: missing data for column "j"  (seg0 slice1 @hostname@:40000 pid=28213)
-DETAIL:  External table exttab_first_reject_limit_2, line 2 of file://@hostname@@abs_srcdir@/data/exttab_first_errors.data: "error_0"
+CONTEXT:  External table exttab_first_reject_limit_2, line 2 of file://@hostname@@abs_srcdir@/data/exttab_first_errors.data: "error_0"
 SELECT COUNT(*) > 0 from gp_read_error_log('exttab_first_reject_limit_2');
  ?column? 
 ----------
@@ -2634,7 +2634,7 @@ SELECT gp_truncate_error_log('exttab_first_reject_limit_2');
 
 SELECT COUNT(*) FROM exttab_first_reject_limit_2;
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: missing data for column "j"  (seg0 slice1 @hostname@:40000 pid=28213)
-DETAIL:  External table exttab_first_reject_limit_2, line 500 of file://@hostname@@abs_srcdir@/data/exttab_first_errors.data: "error_0"
+CONTEXT:  External table exttab_first_reject_limit_2, line 500 of file://@hostname@@abs_srcdir@/data/exttab_first_errors.data: "error_0"
 SELECT COUNT(*) > 0 from gp_read_error_log('exttab_first_reject_limit_2');
  ?column? 
 ----------
@@ -2651,7 +2651,7 @@ SELECT gp_truncate_error_log('exttab_first_reject_limit_2');
 
 SELECT COUNT(*) FROM exttab_first_reject_limit_2;
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: missing data for column "j"  (seg0 slice1 @hostname@:40000 pid=28213)
-DETAIL:  External table exttab_first_reject_limit_2, line 500 of file://@hostname@@abs_srcdir@/data/exttab_first_errors.data: "error_0"
+CONTEXT:  External table exttab_first_reject_limit_2, line 500 of file://@hostname@@abs_srcdir@/data/exttab_first_errors.data: "error_0"
 SELECT COUNT(*) > 0 from gp_read_error_log('exttab_first_reject_limit_2');
  ?column? 
 ----------
@@ -2892,8 +2892,8 @@ LANGUAGE plpgSQL READS SQL DATA;
 SET gp_log_gang TO DEBUG;
 SELECT * FROM exttab_error_context_callback_func();
 ERROR:  missing data for column "c2"  (seg1 slice2 @hostname@:25532 pid=20960)
-DETAIL:  External table exttab_error_context_callback, line 1 of file://@hostname@@abs_srcdir@/data/exttab.data: "1|1_number"
-CONTEXT:  PL/pgSQL function "exttab_error_context_callback_func" line 4 at FOR over SELECT rows
+CONTEXT:  External table exttab_error_context_callback, line 1 of file://@hostname@@abs_srcdir@/data/exttab.data: "1|1_number"
+PL/pgSQL function "exttab_error_context_callback_func" line 4 at FOR over SELECT rows
 SET gp_log_gang TO DEFAULT;
 DROP FUNCTION exttab_error_context_callback_func();
 DROP EXTERNAL TABLE exttab_error_context_callback;

--- a/src/test/regress/output/misc.source
+++ b/src/test/regress/output/misc.source
@@ -452,13 +452,13 @@ SELECT class, aa, a FROM a_star*;
 --
 SELECT p.name, name(p.hobbies) FROM ONLY person p;
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.hobbies_r"
-DETAIL:  SQL function "hobbies" during startup
+CONTEXT:  SQL function "hobbies" during startup
 --
 -- as above, but jeff also does post_hacking.
 --
 SELECT p.name, name(p.hobbies) FROM person* p;
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.hobbies_r"
-DETAIL:  SQL function "hobbies" during startup
+CONTEXT:  SQL function "hobbies" during startup
 --
 -- the next two queries demonstrate how functions generate bogus duplicates.
 -- this is a "feature" ..
@@ -466,10 +466,10 @@ DETAIL:  SQL function "hobbies" during startup
 SELECT DISTINCT hobbies_r.name, name(hobbies_r.equipment) FROM hobbies_r
   ORDER BY 1,2;
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.equipment_r"
-DETAIL:  SQL function "equipment" during startup
+CONTEXT:  SQL function "equipment" during startup
 SELECT hobbies_r.name, (hobbies_r.equipment).name FROM hobbies_r;
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.equipment_r"
-DETAIL:  SQL function "equipment" during startup
+CONTEXT:  SQL function "equipment" during startup
 --
 -- mike needs advil and peet's coffee,
 -- joe and sally need hightops, and
@@ -477,29 +477,29 @@ DETAIL:  SQL function "equipment" during startup
 --
 SELECT p.name, name(p.hobbies), name(equipment(p.hobbies)) FROM ONLY person p;
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.hobbies_r"
-DETAIL:  SQL function "hobbies" during startup
+CONTEXT:  SQL function "hobbies" during startup
 --
 -- as above, but jeff needs advil and peet's coffee as well.
 --
 SELECT p.name, name(p.hobbies), name(equipment(p.hobbies)) FROM person* p;
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.hobbies_r"
-DETAIL:  SQL function "hobbies" during startup
+CONTEXT:  SQL function "hobbies" during startup
 --
 -- just like the last two, but make sure that the target list fixup and
 -- unflattening is being done correctly.
 --
 SELECT name(equipment(p.hobbies)), p.name, name(p.hobbies) FROM ONLY person p;
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.hobbies_r"
-DETAIL:  SQL function "hobbies" during startup
+CONTEXT:  SQL function "hobbies" during startup
 SELECT (p.hobbies).equipment.name, p.name, name(p.hobbies) FROM person* p;
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.hobbies_r"
-DETAIL:  SQL function "hobbies" during startup
+CONTEXT:  SQL function "hobbies" during startup
 SELECT (p.hobbies).equipment.name, name(p.hobbies), p.name FROM ONLY person p;
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.hobbies_r"
-DETAIL:  SQL function "hobbies" during startup
+CONTEXT:  SQL function "hobbies" during startup
 SELECT name(equipment(p.hobbies)), name(p.hobbies), p.name FROM person* p;
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.hobbies_r"
-DETAIL:  SQL function "hobbies" during startup
+CONTEXT:  SQL function "hobbies" during startup
 SELECT user_relns() AS user_relns
    ORDER BY user_relns;
                user_relns               
@@ -698,10 +698,10 @@ SELECT name(equipment(ROW('skywalking', 'mer')));
 
 SELECT *, name(equipment(h.*)) FROM hobbies_r h;
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.equipment_r"
-DETAIL:  SQL function "equipment" during startup
+CONTEXT:  SQL function "equipment" during startup
 SELECT *, (equipment(CAST((h.*) AS hobbies_r))).name FROM hobbies_r h;
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.equipment_r"
-DETAIL:  SQL function "equipment" during startup
+CONTEXT:  SQL function "equipment" during startup
 --
 -- check that old-style C functions work properly with TOASTed values
 --

--- a/src/test/regress/output/sreh.source
+++ b/src/test/regress/output/sreh.source
@@ -293,10 +293,10 @@ FORMAT 'text' (delimiter '|')
 SEGMENT REJECT LIMIT 2;
 SELECT * FROM sreh_ext ORDER BY a;
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: missing data for column "c"  (seg1 slice1 @hostname@:11002 pid=68457)
-DETAIL:  External table sreh_ext, line 3 of gpfdist://@hostname@:8080/bad_data1.data: "3|"
+CONTEXT:  External table sreh_ext, line 3 of gpfdist://@hostname@:8080/bad_data1.data: "3|"
 INSERT INTO sreh_target SELECT * FROM sreh_ext;
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: missing data for column "c"  (seg1 slice1 @hostname@:11002 pid=68459)
-DETAIL:  External table sreh_ext, line 3 of gpfdist://@hostname@:8080/bad_data1.data: "3|"
+CONTEXT:  External table sreh_ext, line 3 of gpfdist://@hostname@:8080/bad_data1.data: "3|"
 SELECT count(*) FROM sreh_target;
  count 
 -------
@@ -451,14 +451,14 @@ FORMAT 'text' (delimiter '|')
 SEGMENT REJECT LIMIT 2 PERCENT;
 SELECT count(*) FROM sreh_ext_2percent; -- fail
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: invalid input syntax for integer: "BAD", column a  (seg0 slice1 @hostname@:11001 pid=68456)
-DETAIL:  External table sreh_ext_2percent, line 107 of gpfdist://@hostname@:8080/bad_data3.data, column a
+CONTEXT:  External table sreh_ext_2percent, line 107 of gpfdist://@hostname@:8080/bad_data3.data, column a
 --
 -- test PERCENT reject limit logic with custom threshold 10 (only practical for test purposes)
 --
 set gp_reject_percent_threshold = 10;
 SELECT count(*) FROM sreh_ext_10percent; -- fail
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: invalid input syntax for integer: "BAD", column a  (seg0 slice1 @hostname@:11001 pid=68456)
-DETAIL:  External table sreh_ext_10percent, line 15 of gpfdist://@hostname@:8080/bad_data3.data, column a
+CONTEXT:  External table sreh_ext_10percent, line 15 of gpfdist://@hostname@:8080/bad_data3.data, column a
 CREATE EXTERNAL TABLE sreh_ext_20percent(a int, b int, c int)
 LOCATION ('gpfdist://@hostname@:8080/bad_data3.data' )
 FORMAT 'text' (delimiter '|')


### PR DESCRIPTION
    If an error happens in the prepare phase of two-phase commit, relay the
    original error back to the client, instead of the fairly opaque
    "Abort [Prepared]' broadcast failed to one or more segments" message you
    got previously. A lot of things happen during the prepare phase that
    can legitimately fail, like checking deferred constraints, like in the
    'constraints' regression test. But even without that, there can be
    triggers, ON COMMIT actions, etc., any of which can fail.
    
    This commit consists of several parts:
    
    * Pass 'true' for the 'raiseError' argument when dispatching the prepare
      dtx command in doPrepareTransaction(), so that the error is emitted to
      the client.
    
    * Bubble up an ErrorData struct, with as many fields intact as possible,
      to the caller,  when dispatching a dtx command. (Instead of constructing
      a message in a StringInfo). So that we can re-throw the message to
      the client, with its original formatting.
    
    * Don't throw an error in performDtxProtocolCommand(), if we try to abort
      a prepared transaction that doesn't exist. That is business-as-usual,
      if a transaction throws an error before finishing the prepare phase.
    
    * Suppress the "NOTICE: Releasing segworker groups to retry broadcast."
      message, when aborting a prepared transaction.
    
    Put together, the effect is if an error happens during prepare phase, the
    client receives a message that is largely indistinguishable from the
    message you'd get if the same failure happened while running a normal
    statement.
    
    Fixes github issue #4530.
