### PR TITLE
Catch exceptions but don't catch errors in EXPLAIN (dxl) ..

### DIFF
--- a/src/backend/gpopt/CGPOptimizer.cpp
+++ b/src/backend/gpopt/CGPOptimizer.cpp
@@ -113,7 +113,18 @@ CGPOptimizer::SzDXLPlan
 	Query *pquery
 	)
 {
-	return COptTasks::SzOptimize(pquery);
+	GPOS_TRY;
+	{
+		return COptTasks::SzOptimize(pquery);
+	}
+	GPOS_CATCH_EX(ex);
+	{
+		errstart(ERROR, ex.SzFilename(), ex.UlLine(), NULL, TEXTDOMAIN);
+		errfinish(errcode(ERRCODE_INTERNAL_ERROR),
+				errmsg("Optimizer failed to produce plan"));
+	}
+	GPOS_CATCH_END;
+	return NULL;
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
Commit ca4c29d removed the error deferring from `EXPLAIN` such that it attempted to return results even in case of errors, but missed the DXL case. This removes the TRY/CATCH wraps from `EXPLAIN (dxl)` to match the rest of the `EXPLAIN` code. Some level of copyediting of the code style was also performed here (variable declaration and comment style etc).

Also start catching the C++ exceptions from ORCA to keep `EXPLAIN (dxl)` from dumping cores on fallback queries. 