### PR TITLE
Skip some planning process for pruned partition

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -1646,6 +1646,17 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 		else
 			best_path = sorted_path;
 
+		/* if dummy pathlist of partition, make result plan here and return */
+		if (best_path->pathtype == T_Append && ((AppendPath *)best_path)->subpaths == NIL)
+		{
+			/* Generate a Result plan with constant-FALSE gating qual */
+			return (Plan *) make_result(root,
+										tlist,
+										(Node *) list_make1(makeBoolConst(false,
+																		  false)),
+										NULL);
+		}
+		
 		/*
 		 * CDB:  For now, we either - construct a general parallel plan, - let
 		 * the sequential planner handle the situation, or - construct a


### PR DESCRIPTION
Currently, partitions are eliminated one-by-one by comparing the partition constraint (and any other constraints) against the query to determine which partitions can't possibly contain any matching rows.  This means that the time to prune partitions is proportional to the number of partitions.  

relation_excluded_by_constraints() check if planner can exclude relation. If true set dummy pathlist, that is add a AppendPath who's subpath=NIL to RelOptInfo.
And then create_plan() will generate a Result plan with constant-FALSE gating qual. Planner decide wheather skip this partition or not accroding to the result of is_dummy_plan(), which checks the Result plan.

I think if already set dummy pathlist in query_planner(), no need to do the rest of planning, just generate a Result plan with constant-FALSE gating qual and return. This can reduce some planning time for the scenario of pruning a lot of partitions.