### PR TITLE
Pass optimizer_nestloop_factor to DXL through optimizer config

### DIFF
--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -121,7 +121,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v2.55.10/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/sambitesh/gporca/releases/download/v2.55.12/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -748,6 +748,7 @@ COptTasks::PoconfCreate
 	ULONG ulArrayExpansionThreshold = (ULONG) optimizer_array_expansion_threshold;
 	ULONG ulJoinOrderThreshold = (ULONG) optimizer_join_order_threshold;
 	ULONG ulBroadcastThreshold = (ULONG) optimizer_penalize_broadcast_threshold;
+	ULONG ulNestloopFactor = (ULONG) optimizer_nestloop_factor;
 
 	return GPOS_NEW(pmp) COptimizerConfig
 						(
@@ -762,6 +763,7 @@ COptTasks::PoconfCreate
 								ulArrayExpansionThreshold,
 								ulJoinOrderThreshold,
 								ulBroadcastThreshold,
+								ulNestloopFactor,
 								false /* don't create Assert nodes for constraints, we'll
 								      * enforce them ourselves in the executor */
 								),
@@ -861,22 +863,6 @@ COptTasks::SetCostModelParams
 	)
 {
 	GPOS_ASSERT(NULL != pcm);
-
-	if (optimizer_nestloop_factor > 1.0)
-	{
-		// change NLJ cost factor
-		ICostModelParams::SCostParam *pcp = NULL;
-		if (OPTIMIZER_GPDB_CALIBRATED == optimizer_cost_model)
-		{
-			pcp = pcm->Pcp()->PcpLookup(CCostModelParamsGPDB::EcpNLJFactor);
-		}
-		else
-		{
-			pcp = pcm->Pcp()->PcpLookup(CCostModelParamsGPDBLegacy::EcpNLJFactor);
-		}
-		CDouble dNLJFactor(optimizer_nestloop_factor);
-		pcm->Pcp()->SetParam(pcp->UlId(), dNLJFactor, dNLJFactor - 0.5, dNLJFactor + 0.5);
-	}
 
 	if (optimizer_sort_factor > 1.0 || optimizer_sort_factor < 1.0)
 	{


### PR DESCRIPTION
Earlier we were accounting for `optimizer_nestloop_factor` while translating
back from DXL in GPDB side in COptTasks::SetCostModelParams. Now it is being
taken care in GPORCA side.

Signed-off-by: Bhuvnesh Chaudhary <bchaudhary@pivotal.io>