### PR TITLE
Add a GUC to ignore the [INTO error-table] clause for backward compatibility

### DIFF
--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -4987,7 +4987,26 @@ OptSingleRowErrorHandling:
 		;
 	
 OptLogErrorTable:
-		LOG_P ERRORS                        { $$ = TRUE; }
+		LOG_P ERRORS INTO qualified_name
+		{
+			if (gp_ignore_error_table) /* ignore the [INTO error-table] clause for backward compatibility */
+			{
+			ereport(WARNING,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("Error table is not supported, use gp_read_error_log() and gp_truncate_error_log()"
+					 " to view and manage the internal error log associated with your table.")));
+			}
+			else
+			{
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("Error table is not supported."),
+					 errhint("Set gp_ignore_error_table to ignore the [INTO error-table] clause for backward compatibility."),
+					 parser_errposition(@3)));
+			}
+			$$ = TRUE;
+		}
+		| LOG_P ERRORS                        { $$ = TRUE; }
 		| /*EMPTY*/							{ $$ = FALSE; }
 		;
 	

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -312,6 +312,8 @@ int			password_hash_algorithm = PASSWORD_HASH_MD5;
 /* include file/line information to stack traces */
 bool		gp_log_stack_trace_lines;
 
+/* ignore INTO error-table clauses for backwards compatibility */
+bool		gp_ignore_error_table = false;
 
 /*
  * If set to true, we will silently insert into the correct leaf
@@ -2783,6 +2785,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		&vmem_process_interrupt,
 		false, NULL, NULL
 	},
+
 	{
 		{"execute_pruned_plan", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Prune plan to discard unwanted plan nodes for each slice before execution"),
@@ -2792,6 +2795,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		&execute_pruned_plan,
 		true, NULL, NULL
 	},
+
 	{
 		{"pljava_classpath_insecure", PGC_POSTMASTER, CUSTOM_OPTIONS,
 			gettext_noop("Allow pljava_classpath to be set by user per session"),
@@ -2801,6 +2805,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		&pljava_classpath_insecure,
 		false, assign_pljava_classpath_insecure, NULL
 	},
+
 	{
 		{"gp_enable_segment_copy_checking", PGC_USERSET, CUSTOM_OPTIONS,
 			gettext_noop("Enable check the distribution key restriction on segment for command \"COPY FROM ON SEGMENT\"."),
@@ -2810,6 +2815,17 @@ struct config_bool ConfigureNamesBool_gp[] =
 		&gp_enable_segment_copy_checking,
 		true, NULL, NULL
 	},
+
+	{
+		{"gp_ignore_error_table", PGC_USERSET, COMPAT_OPTIONS_PREVIOUS,
+			gettext_noop("Ignore INTO error-table in external table and COPY."),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+		},
+		&gp_ignore_error_table,
+		false, NULL, NULL
+	},
+
 	/* End-of-list marker */
 	{
 		{NULL, 0, 0, NULL, NULL}, NULL, false, NULL, NULL

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -278,6 +278,8 @@ extern bool gp_allow_rename_relation_without_lock;
 
 extern bool gp_ignore_window_exclude;
 
+extern bool gp_ignore_error_table;
+
 extern bool rle_type_compression_stats;
 
 extern bool	Debug_print_server_processes;

--- a/src/test/regress/input/sreh.source
+++ b/src/test/regress/input/sreh.source
@@ -36,7 +36,11 @@ SELECT * FROM sreh_copy ORDER BY a,b,c;
 -- error logs
 --
 DROP TABLE IF EXISTS sreh_copy; CREATE TABLE sreh_copy(a int, b int, c int) distributed by(a);
-COPY sreh_copy FROM '@abs_srcdir@/data/bad_data1.data' DELIMITER '|' LOG ERRORS SEGMENT REJECT LIMIT 1000;
+COPY sreh_copy FROM '@abs_srcdir@/data/bad_data1.data' DELIMITER '|' LOG ERRORS INTO WHATEVER SEGMENT REJECT LIMIT 1000;
+
+SET gp_ignore_error_table=true;
+
+COPY sreh_copy FROM '@abs_srcdir@/data/bad_data1.data' DELIMITER '|' LOG ERRORS INTO WHATEVER SEGMENT REJECT LIMIT 1000;
 SELECT * FROM sreh_copy ORDER BY a,b,c;
 WITH error_log AS (SELECT gp_read_error_log('sreh_copy')) select count(*) from error_log;
 
@@ -170,6 +174,15 @@ DROP EXTERNAL TABLE sreh_ext;
 -- 
 -- error logs
 --
+CREATE EXTERNAL TABLE sreh_ext_err_tbl(a int, b int, c int)
+LOCATION ('gpfdist://@hostname@:8080/bad_data1.data' )
+FORMAT 'text' (delimiter '|')
+LOG ERRORS INTO WHATEVER
+SEGMENT REJECT LIMIT 1000;
+
+SELECT * FROM sreh_ext_err_tbl ORDER BY a;
+WITH error_log AS (SELECT gp_read_error_log('sreh_ext_err_tbl')) select count(*) from error_log;
+
 CREATE EXTERNAL TABLE sreh_ext(a int, b int, c int)
 LOCATION ('gpfdist://@hostname@:8080/bad_data1.data' )
 FORMAT 'text' (delimiter '|')
@@ -193,6 +206,7 @@ INSERT INTO sreh_target SELECT * FROM sreh_ext;
 SELECT count(*) FROM sreh_target;
 TRUNCATE sreh_target;
 DROP EXTERNAL TABLE sreh_ext;
+DROP EXTERNAL TABLE sreh_ext_err_tbl;
 
 --
 -- constraint errors - data is rolled back from both target and error tables (CHECK)

--- a/src/test/regress/output/sreh.source
+++ b/src/test/regress/output/sreh.source
@@ -53,7 +53,14 @@ SELECT * FROM sreh_copy ORDER BY a,b,c;
 -- error logs
 --
 DROP TABLE IF EXISTS sreh_copy; CREATE TABLE sreh_copy(a int, b int, c int) distributed by(a);
-COPY sreh_copy FROM '@abs_srcdir@/data/bad_data1.data' DELIMITER '|' LOG ERRORS SEGMENT REJECT LIMIT 1000;
+COPY sreh_copy FROM '@abs_srcdir@/data/bad_data1.data' DELIMITER '|' LOG ERRORS INTO WHATEVER SEGMENT REJECT LIMIT 1000;
+ERROR:  Error table is not supported.
+LINE 1: ...ess/data/bad_data1.data' DELIMITER '|' LOG ERRORS INTO WHATE...
+                                                             ^
+HINT:  Set gp_ignore_error_table to ignore the [INTO error-table] clause for backward compatibility.
+SET gp_ignore_error_table=true;
+COPY sreh_copy FROM '@abs_srcdir@/data/bad_data1.data' DELIMITER '|' LOG ERRORS INTO WHATEVER SEGMENT REJECT LIMIT 1000;
+WARNING:  Error table is not supported, use gp_read_error_log() and gp_truncate_error_log() to view and manage the internal error log associated with your table.
 NOTICE:  Found 10 data formatting errors (10 or more input rows). Rejected related input data.
 SELECT * FROM sreh_copy ORDER BY a,b,c;
  a  | b  | c  
@@ -308,6 +315,30 @@ DROP EXTERNAL TABLE sreh_ext;
 -- 
 -- error logs
 --
+CREATE EXTERNAL TABLE sreh_ext_err_tbl(a int, b int, c int)
+LOCATION ('gpfdist://@hostname@:8080/bad_data1.data' )
+FORMAT 'text' (delimiter '|')
+LOG ERRORS INTO WHATEVER
+SEGMENT REJECT LIMIT 1000;
+WARNING:  Error table is not supported, use gp_read_error_log() and gp_truncate_error_log() to view and manage the internal error log associated with your table.
+SELECT * FROM sreh_ext_err_tbl ORDER BY a;
+NOTICE:  Found 10 data formatting errors (10 or more input rows). Rejected related input data.
+ a  | b  | c  
+----+----+----
+  1 |  1 |  1
+  5 |  5 |  5
+  6 |  6 |  6
+  9 |  9 |  9
+ 10 | 10 | 10
+ 14 | 14 | 14
+(6 rows)
+
+WITH error_log AS (SELECT gp_read_error_log('sreh_ext_err_tbl')) select count(*) from error_log;
+ count 
+-------
+    10
+(1 row)
+
 CREATE EXTERNAL TABLE sreh_ext(a int, b int, c int)
 LOCATION ('gpfdist://@hostname@:8080/bad_data1.data' )
 FORMAT 'text' (delimiter '|')
@@ -400,6 +431,7 @@ SELECT count(*) FROM sreh_target;
 
 TRUNCATE sreh_target;
 DROP EXTERNAL TABLE sreh_ext;
+DROP EXTERNAL TABLE sreh_ext_err_tbl;
 --
 -- constraint errors - data is rolled back from both target and error tables (CHECK)
 --


### PR DESCRIPTION
Greenplum Database now stores the error information only internally and no
longer supports using the [INTO error-table] clause in CREATE EXTERNAL TABLE
and COPY command LOG ERRORS statements.

To be compatible with users' existing SQL, add a GUC to allow but ignore
the [INTO error-table] clause, with a warning.

Signed-off-by: Tingfang Bao <bbao@pivotal.io>