### PR TITLE
Window merge changed the plan generated by Planner

### DIFF
--- a/src/test/regress/expected/olap_window_seq.out
+++ b/src/test/regress/expected/olap_window_seq.out
@@ -7883,8 +7883,6 @@ select count(*) over (partition by 1 order by cn rows between 1 preceding and 1 
 
 -- End MPP-12913
 -- MPP-13710
--- GPDB_84_MERGE_FIXME: Postgres does not generate a plan which removes redundant SORT operators
--- while GPDB did generate such plans
 create table redundant_sort_check (i int, j int, k int) distributed by (i);
 explain select count(*) over (order by i), count(*) over (partition by i order by j) from redundant_sort_check;
                                                QUERY PLAN                                               
@@ -8167,11 +8165,6 @@ CREATE TABLE foo (a int, b int, c int, d int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into foo select i,i,i,i from generate_series(1, 10) i;
--- Check that the planner can spot ORDER BYs that are supersets of each
--- other, and sort directly to the longest sort order. This query can
--- be satisfied with just two Sorts.
--- GPDB_84_MERGE_FIXME: Postgres does not generate a plan which removes
--- redundant SORT operators, while GPDB did generate such plans
 EXPLAIN SELECT count(*) over (PARTITION BY a ORDER BY b, c, d) as count1,
        count(*) over (PARTITION BY a ORDER BY b, c) as count2,
        count(*) over (PARTITION BY a ORDER BY b) as count3,

--- a/src/test/regress/expected/olap_window_seq_optimizer.out
+++ b/src/test/regress/expected/olap_window_seq_optimizer.out
@@ -7889,8 +7889,6 @@ select count(*) over (partition by 1 order by cn rows between 1 preceding and 1 
 
 -- End MPP-12913
 -- MPP-13710
--- GPDB_84_MERGE_FIXME: Postgres does not generate a plan which removes redundant SORT operators
--- while GPDB did generate such plans
 create table redundant_sort_check (i int, j int, k int) distributed by (i);
 explain select count(*) over (order by i), count(*) over (partition by i order by j) from redundant_sort_check;
                                                  QUERY PLAN                                                  
@@ -8181,11 +8179,6 @@ CREATE TABLE foo (a int, b int, c int, d int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into foo select i,i,i,i from generate_series(1, 10) i;
--- Check that the planner can spot ORDER BYs that are supersets of each
--- other, and sort directly to the longest sort order. This query can
--- be satisfied with just two Sorts.
--- GPDB_84_MERGE_FIXME: Postgres does not generate a plan which removes
--- redundant SORT operators, while GPDB did generate such plans
 EXPLAIN SELECT count(*) over (PARTITION BY a ORDER BY b, c, d) as count1,
        count(*) over (PARTITION BY a ORDER BY b, c) as count2,
        count(*) over (PARTITION BY a ORDER BY b) as count3,

--- a/src/test/regress/sql/olap_window_seq.sql
+++ b/src/test/regress/sql/olap_window_seq.sql
@@ -1496,8 +1496,6 @@ group by
 select count(*) over (partition by 1 order by cn rows between 1 preceding and 1 preceding) from sale;
 -- End MPP-12913
 -- MPP-13710
--- GPDB_84_MERGE_FIXME: Postgres does not generate a plan which removes redundant SORT operators
--- while GPDB did generate such plans
 create table redundant_sort_check (i int, j int, k int) distributed by (i);
 explain select count(*) over (order by i), count(*) over (partition by i order by j) from redundant_sort_check;
 -- End of MPP-13710
@@ -1654,11 +1652,6 @@ drop table foo, bar;
 CREATE TABLE foo (a int, b int, c int, d int);
 insert into foo select i,i,i,i from generate_series(1, 10) i;
 
--- Check that the planner can spot ORDER BYs that are supersets of each
--- other, and sort directly to the longest sort order. This query can
--- be satisfied with just two Sorts.
--- GPDB_84_MERGE_FIXME: Postgres does not generate a plan which removes
--- redundant SORT operators, while GPDB did generate such plans
 EXPLAIN SELECT count(*) over (PARTITION BY a ORDER BY b, c, d) as count1,
        count(*) over (PARTITION BY a ORDER BY b, c) as count2,
        count(*) over (PARTITION BY a ORDER BY b) as count3,


### PR DESCRIPTION
Instead of a single Window operator, Planner now similar to GPORCA
generates a plan with cascades of window operation. The sort operation
needed is based on the order in which the window functions are specified
in the query. This is an expected behavior change. So removing the
fixmes.