### PR TITLE
Fix getaddrinfo compatibility problem on Mac OS X

### DIFF
--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -1076,7 +1076,7 @@ PostmasterMain(int argc, char *argv[])
 		}
 
 		/* If there are more than one listen address, backend bind on all addresses*/
-		if (list_length(elemlist) > 1)
+		if (list_length(elemlist) > 1 || strcmp(ListenAddresses, "*") == 0)
 			BackendListenAddress = NULL;
 		else
 			BackendListenAddress = ListenAddresses;


### PR DESCRIPTION
The first parameter "node" of getaddrinfo can be "*" on Linux but doesn't
work on Mac OS X.