### PR TITLE
Add FAULT_INJECTOR #ifdef around SPI fault injection tests

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -993,6 +993,7 @@ standard_ExecutorRun(QueryDesc *queryDesc,
 	PG_END_TRY();
 
 
+#ifdef FAULT_INJECTOR
 	/*
 	 * Allow testing of very high number of processed rows, without spending
 	 * hours actually processing that many rows.
@@ -1016,6 +1017,7 @@ standard_ExecutorRun(QueryDesc *queryDesc,
 			estate->es_processed = UINT_MAX - 10;
 		}
 	}
+#endif /* FAULT_INJECTOR */
 
 	/*
 	 * shutdown tuple receiver, if we started it
@@ -2614,6 +2616,7 @@ ExecutePlan(EState *estate,
 		{
 			(estate->es_processed)++;
 
+#ifdef FAULT_INJECTOR
 			/*
 			 * bump es_processed using the fault injector, but only if the number rows is in a certain range
 			 * this avoids bumping the counter every time after we bumped it once
@@ -2632,6 +2635,7 @@ ExecutePlan(EState *estate,
 					estate->es_processed = UINT_MAX - 10;
 				}
 			}
+#endif /* FAULT_INJECTOR */
 		}
 
 		/*

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -2319,6 +2319,7 @@ _SPI_pquery(QueryDesc *queryDesc, bool fire_triggers, int64 tcount)
 		_SPI_current->lastoid = queryDesc->es_lastoid;
 		if (checkTuples)
 		{
+#ifdef FAULT_INJECTOR
 			/*
 			 * only check number tuples if the SPI 64 bit test is NOT running
 			 */
@@ -2327,9 +2328,12 @@ _SPI_pquery(QueryDesc *queryDesc, bool fire_triggers, int64 tcount)
 										   "" /* databaseName */,
 										   "" /* tableName */))
 			{
+#endif /* FAULT_INJECTOR */
 				if (_SPI_checktuples())
 					elog(ERROR, "consistency check on SPI tuple count failed");
+#ifdef FAULT_INJECTOR
 			}
+#endif /* FAULT_INJECTOR */
 		}
 
 		gp_enable_gpperfmon = orig_gp_enable_gpperfmon;

--- a/src/test/regress/expected/spi_processed64bit.out
+++ b/src/test/regress/expected/spi_processed64bit.out
@@ -1,4 +1,6 @@
+-- start_ignore
 CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+-- end_ignore
 DROP TABLE IF EXISTS public.spi64bittest;
 NOTICE:  table "spi64bittest" does not exist, skipping
 -- use a sequence as primary key, so we can update the data later on

--- a/src/test/regress/sql/spi_processed64bit.sql
+++ b/src/test/regress/sql/spi_processed64bit.sql
@@ -1,4 +1,6 @@
+-- start_ignore
 CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+-- end_ignore
 
 DROP TABLE IF EXISTS public.spi64bittest;
 -- use a sequence as primary key, so we can update the data later on


### PR DESCRIPTION
This adds #ifdef for the already existing SPI tests.
Also add ignore blocks for unimportant parts of the regression tests.

As advised in #4153 by @ashwinstar.