### PR TITLE
docs - adding dblink limitations section; listing disabled functions

### DIFF
--- a/gpdb-doc/dita/utility_guide/dblink.xml
+++ b/gpdb-doc/dita/utility_guide/dblink.xml
@@ -13,18 +13,43 @@
     <p><codeph>dblink</codeph> is intended for database users to perform short ad hoc queries in
       other databases. <codeph>dblink</codeph> is not intended for use as a replacement for external
       tables or for administrative tools such as <codeph>gptransfer</codeph>.</p>
-    <p>The following procedure identifies the basic steps for configuring and using
-        <codeph>dblink</codeph> in Greenplum Database. Refer to <xref
-        href="https://www.postgresql.org/docs/8.4/static/dblink.html" format="html" scope="external"
-        >dblink</xref> in the PostgreSQL documentation for more information about individual
-      <codeph>dblink</codeph> functions. </p>
-    <note>You must specify both a hostname and a password to connect with <codeph>dblink</codeph> as
-      a non-superuser.</note>
-    <ol id="ol_nhg_f1q_fz">
-      <li>Begin by creating a sample table to query using the <codeph>dblink</codeph> functions.
-        These commands create a small table in the <codeph>postgres</codeph> database, which you
-        will later query from the <codeph>gpadmin</codeph> database using
-        <codeph>dblink</codeph>:<codeblock>$ <b>psql -d postgres</b>
+  </body>
+  <topic id="topic_ikh_dsm_bdb">
+    <title>Limitations</title>
+    <body>
+      <p>In this release of Greenplum Database, statements that modify table data cannot use named
+        or implicit <codeph>dblink</codeph> connections. Instead, you must provide the connection
+        string directly in the <codeph>dblink()</codeph> function. For
+        example:<codeblock>gpadmin=# <b>CREATE TABLE testdbllocal (a int, b text) DISTRIBUTED BY (a);</b>
+CREATE TABLE
+gpadmin=# <b>INSERT INTO testdbllocal select * FROM dblink('dbname=postgres', 'SELECT * FROM testdblink') AS dbltab(id int, product text);</b>
+INSERT 0 2</codeblock></p>
+      <p>The Greenplum Database version of <codeph>dblink</codeph> disables the following
+        asynchronous functions:<ul id="ul_ajr_lsm_bdb">
+          <li><codeph>dblink_send_query()</codeph></li>
+          <li><codeph>dblink_is_busy()</codeph></li>
+          <li><codeph>dblink_get_result()</codeph></li>
+        </ul></p>
+      <p>See <xref href="https://www.postgresql.org/docs/8.3/static/dblink.html" format="html"
+          scope="external">dblink</xref> in the PostgreSQL documentation for more information about
+        individual functions.</p>
+    </body>
+  </topic>
+  <topic id="topic_tvb_csm_bdb">
+    <title>Using dblink</title>
+    <body>
+      <p>The following procedure identifies the basic steps for configuring and using
+          <codeph>dblink</codeph> in Greenplum Database. Refer to <xref
+          href="https://www.postgresql.org/docs/8.4/static/dblink.html" format="html"
+          scope="external">dblink</xref> in the PostgreSQL documentation for more information about
+        individual <codeph>dblink</codeph> functions. </p>
+      <note>You must specify both a hostname and a password to connect with <codeph>dblink</codeph>
+        as a non-superuser.</note>
+      <ol id="ol_axw_csm_bdb">
+        <li>Begin by creating a sample table to query using the <codeph>dblink</codeph> functions.
+          These commands create a small table in the <codeph>postgres</codeph> database, which you
+          will later query from the <codeph>gpadmin</codeph> database using
+          <codeph>dblink</codeph>:<codeblock>$ <b>psql -d postgres</b>
 psql (8.3.23)
 Type "help" for help.
 
@@ -36,11 +61,11 @@ postgres=# <b>INSERT INTO testdblink VALUES (2, 'Fish');</b>
 INSERT 0 1
 postgres=# <b>\q
 </b>$</codeblock></li>
-      <li>Log into a different database (<codeph>gpadmin</codeph> in this example) and install the
-          <codeph>dblink</codeph> functions if they are not already available.  You install the
-          <codeph>dblink</codeph> functions using the
-          <codeph>$GPHOME/share/postgresql/contrib/dblink.sql</codeph>
-        script:<codeblock>$ <b>psql -d gpadmin</b>
+        <li>Log into a different database (<codeph>gpadmin</codeph> in this example) and install the
+            <codeph>dblink</codeph> functions if they are not already available. You install the
+            <codeph>dblink</codeph> functions using the
+            <codeph>$GPHOME/share/postgresql/contrib/dblink.sql</codeph>
+          script:<codeblock>$ <b>psql -d gpadmin</b>
 psql (8.3.23)
 Type "help" for help.
 
@@ -55,38 +80,32 @@ REVOKE
 CREATE FUNCTION
 CREATE FUNCTION
 ...</codeblock></li>
-      <li>Use the <codeph>dblink_connect()</codeph> function to create both implicit and named
-        connections to other databases. The connection string that you provide should be a
-        libpq-style keyword/value string. For example, to create a named connection to the
-          <codeph>postgres</codeph> database on the local Greenplum Database
-          system:<codeblock>gpadmin=# <b>SELECT dblink_connect('mylocalconn', 'dbname=postgres');</b>
+        <li>Use the <codeph>dblink_connect()</codeph> function to create both implicit and named
+          connections to other databases. The connection string that you provide should be a
+          libpq-style keyword/value string. For example, to create a named connection to the
+            <codeph>postgres</codeph> database on the local Greenplum Database
+            system:<codeblock>gpadmin=# <b>SELECT dblink_connect('mylocalconn', 'dbname=postgres');</b>
  dblink_connect
 ----------------
  OK
 (1 row)</codeblock><p>To
-          make a connection to a remote database system, simply include host and port information in
-          the connection string. For example, to create an implicit <codeph>dblink</codeph>
-          connection to a remote
-          system:<codeblock>gpadmin=# <b>SELECT dblink_connect('host=remotehost port=5432 dbname=postgres');</b></codeblock></p><note>You
-          must specify both a hostname and a password in the connection string to connect as a
-          non-superuser.</note></li>
-      <li>Use the basic <codeph>dblink()</codeph> function to query a database using a configured
-        connection. Keep in mind that this function returns a record type, so
-        you must assign the columns returned in the <codeph>dblink()</codeph> query. For example, the
-        following command uses the named connection to query the table you created in Step
+            make a connection to a remote database system, simply include host and port information
+            in the connection string. For example, to create an implicit <codeph>dblink</codeph>
+            connection to a remote
+            system:<codeblock>gpadmin=# <b>SELECT dblink_connect('host=remotehost port=5432 dbname=postgres');</b></codeblock></p><note>You
+            must specify both a hostname and a password in the connection string to connect as a
+            non-superuser.</note></li>
+        <li>Use the basic <codeph>dblink()</codeph> function to query a database using a configured
+          connection. Keep in mind that this function returns a record type, so you must assign the
+          columns returned in the <codeph>dblink()</codeph> query. For example, the following
+          command uses the named connection to query the table you created in Step
           1:<codeblock>gpadmin=# <b>SELECT * FROM dblink('mylocalconn', 'SELECT * FROM testdblink') AS dbltab(id int, product text);</b>
  id | product
 ----+---------
   1 | Cheese
   2 | Fish
-(2 rows)</codeblock><p>In
-          this release of Greenplum Database, statements that modify table data cannot use named or
-          implicit <codeph>dblink</codeph> connections. Instead, you must provide the connection
-          string directly in the <codeph>dblink()</codeph> function. For
-          example:<codeblock>gpadmin=# <b>CREATE TABLE testdbllocal (a int, b text) DISTRIBUTED BY (a);</b>
-CREATE TABLE
-gpadmin=# <b>INSERT INTO testdbllocal select * FROM dblink('dbname=postgres', 'SELECT * FROM testdblink') AS dbltab(id int, product text);</b>
-INSERT 0 2</codeblock></p></li>
-    </ol>
-  </body>
+(2 rows)</codeblock></li>
+      </ol>
+    </body>
+  </topic>
 </topic>


### PR DESCRIPTION
Refactored page to include a "limitations" and "using" sections. Restored info about disabled async functions.