### PR TITLE
Add ignore blocks around language creation

### DIFF
--- a/src/test/regress/expected/union_gp.out
+++ b/src/test/regress/expected/union_gp.out
@@ -230,7 +230,9 @@ CREATE TABLE T_random (c1 int, c2 int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO T_random SELECT i, i%5 from generate_series(1,30) i;
+--start_ignore
 create language plpythonu;
+--end_ignore
 create or replace function count_operator(query text, operator text) returns int as
 $$
 rv = plpy.execute('EXPLAIN ' + query)

--- a/src/test/regress/sql/union_gp.sql
+++ b/src/test/regress/sql/union_gp.sql
@@ -80,7 +80,9 @@ INSERT INTO T_b2 SELECT i, i%5 from generate_series(1,20) i;
 CREATE TABLE T_random (c1 int, c2 int);
 INSERT INTO T_random SELECT i, i%5 from generate_series(1,30) i;
 
+--start_ignore
 create language plpythonu;
+--end_ignore
 
 create or replace function count_operator(query text, operator text) returns int as
 $$


### PR DESCRIPTION
Another regression test will create the language earlier,
but this test should still run standalone.