### PR TITLE
docs: update to GPORCA limitations

### DIFF
--- a/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-limitations.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-limitations.xml
@@ -20,7 +20,6 @@
       <p>These are unsupported features when GPORCA is enabled (the default): <ul id="ul_ndm_gyl_vp">
           <li>Indexed expressions (an index defined as expression based on one or more columns of
             the table)</li>
-          <li><cmdname>PERCENTILE</cmdname> window function</li>
           <li>External parameters</li>
           <li>These types of partitioned tables:<ul id="ul_v2m_mmc_bt">
               <li>Non-uniform partitioned tables.</li>
@@ -39,6 +38,7 @@
               <li><cmdname>FIELDSELECT</cmdname></li>
             </ul></li>
           <li>Multiple <cmdname>DISTINCT</cmdname> qualified aggregate functions </li>
+          <li>Aggregate functions that take set operators as input arguments</li>
           <li>Inverse distribution functions</li>
         </ul></p>
     </body>
@@ -46,9 +46,9 @@
   <topic id="topic_u4t_vxl_vp">
     <title>Performance Regressions</title>
     <body>
-      <p>The following features are known performance regressions that occur with GPORCA
-          enabled:<ul id="ul_zp2_4yl_vp">
-           <li>Short running queries - For GPORCA, short running queries might encounter additional
+      <p>The following features are known performance regressions that occur with GPORCA enabled:<ul
+          id="ul_zp2_4yl_vp">
+          <li>Short running queries - For GPORCA, short running queries might encounter additional
             overhead due to GPORCA enhancements for determining an optimal query execution
             plan.</li>
           <li><cmdname>ANALYZE</cmdname> - For GPORCA, the <cmdname>ANALYZE</cmdname> command

--- a/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-limitations.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-limitations.xml
@@ -20,6 +20,7 @@
       <p>These are unsupported features when GPORCA is enabled (the default): <ul id="ul_ndm_gyl_vp">
           <li>Indexed expressions (an index defined as expression based on one or more columns of
             the table)</li>
+          <li><cmdname>PERCENTILE</cmdname> window function</li>
           <li>External parameters</li>
           <li>These types of partitioned tables:<ul id="ul_v2m_mmc_bt">
               <li>Non-uniform partitioned tables.</li>

--- a/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-limitations.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-limitations.xml
@@ -38,7 +38,6 @@
               <li><cmdname>ROWCOMPARE</cmdname></li>
               <li><cmdname>FIELDSELECT</cmdname></li>
             </ul></li>
-          <li>Multiple <cmdname>DISTINCT</cmdname> qualified aggregate functions </li>
           <li>Aggregate functions that take set operators as input arguments</li>
           <li>Inverse distribution functions</li>
         </ul></p>


### PR DESCRIPTION
~~-removed window function limitation~~ (this is for 6.0 only)
-added limitation - aggregate functions with set operators as input
-removed limitation - multiple DISTINCT qualified aggregate functions

PR for 5X_STABLE
Will be ported to MAIN