### PR TITLE
docs: add real-time query metrics GUCs to reference

### DIFF
--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -341,8 +341,6 @@
             <li>
               <xref href="#gp_interconnect_type"/>
             </li>
-            <li><xref href="#gp_log_interconnect"/>
-            </li>
             <li>
               <xref href="#gp_log_format"/>
             </li>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -3444,32 +3444,32 @@
         Greenplum Database collects metrics during query execution. The default is off.</p> 
       <p>After changing this configuration parameter, Greenplum Database must be restarted for the 
         change to take effect.</p>
-      <p>The Greenplum Database metrics collection extension<sup>1</sup>, when enabled, sends the
-      collected metrics over UDP to a Pivotal Greenplum Command Center<sup>1</sup> agent. </p>
-      <note><sup>1</sup> The metrics collection extension is included in the commercial
-        version of Greenplum Database. Pivotal Greenplum Command Center is supported only with the
-        commercial version of Greenplum Database.</note>
-        <table id="gp_enable_query_metrics">
-          <tgroup cols="3">
-            <colspec colnum="1" colname="col1" colwidth="1*"/>
-            <colspec colnum="2" colname="col2" colwidth="1*"/>
-            <colspec colnum="3" colname="col3" colwidth="1*"/>
-            <thead>
-              <row>
-                <entry colname="col1">Value Range</entry>
-                <entry colname="col2">Default</entry>
-                <entry colname="col3">Set Classifications</entry>
-              </row>
-            </thead>
-            <tbody>
-              <row>
-                <entry colname="col1">Boolean</entry>
-                <entry colname="col2">off</entry>
-                <entry colname="col3">master<p>system</p><p>restart</p></entry>
-              </row>
-            </tbody>
-          </tgroup>
-        </table>
+      <p>The Greenplum Database metrics collection extension, when enabled, sends the
+      collected metrics over UDP to a Pivotal Greenplum Command Center agent<sup>1</sup>. </p>
+      <note><sup>1</sup> The metrics collection extension is included in Pivotal's commercial 
+      version of Greenplum Database. Pivotal Greenplum Command Center is supported only with 
+        Pivotal Greenplum Database.</note>
+      <table id="gp_enable_query_metrics">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">Boolean</entry>
+              <entry colname="col2">off</entry>
+              <entry colname="col3">master<p>system</p><p>restart</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
     </body>
   </topic>
   <topic id="gp_enable_relsize_collection">

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -256,6 +256,9 @@
               <xref href="#gp_enable_preunique"/>
             </li>
             <li>
+              <xref href="#gp_enable_query_metrics"/>
+            </li>
+            <li>
               <xref href="#gp_enable_relsize_collection" format="dita"/></li>
             <li>
               <xref href="#gp_enable_segment_copy_checking" format="dita"/></li>
@@ -313,6 +316,9 @@
             </li>
             <li>
               <xref href="#topic_lvm_ttc_3p"/>
+            </li>
+            <li>
+              <xref href="#gp_instrument_shmem_size"/>
             </li>
             <li>
               <xref href="#gp_interconnect_debug_retry_interval"/>
@@ -3431,6 +3437,41 @@
       </table>
     </body>
   </topic>
+  <topic id="gp_enable_query_metrics">
+    <title>gp_enable_query_metrics</title>
+    <body>
+      <p>Enables collection of query metrics. When query metrics collection is enabled, 
+        Greenplum Database collects metrics during query execution. The default is off.</p> 
+      <p>After changing this configuration parameter, Greenplum Database must be restarted for the 
+        change to take effect.</p>
+      <p>The Greenplum Database metrics collection extension<sup>1</sup>, when enabled, sends the
+      collected metrics over UDP to a Pivotal Greenplum Command Center<sup>1</sup> agent. </p>
+      <note><sup>1</sup> The metrics collection extension is included in the commercial
+        version of Greenplum Database. Pivotal Greenplum Command Center is supported only with the
+        commercial version of Greenplum Database.</note>
+        <table id="gp_enable_query_metrics">
+          <tgroup cols="3">
+            <colspec colnum="1" colname="col1" colwidth="1*"/>
+            <colspec colnum="2" colname="col2" colwidth="1*"/>
+            <colspec colnum="3" colname="col3" colwidth="1*"/>
+            <thead>
+              <row>
+                <entry colname="col1">Value Range</entry>
+                <entry colname="col2">Default</entry>
+                <entry colname="col3">Set Classifications</entry>
+              </row>
+            </thead>
+            <tbody>
+              <row>
+                <entry colname="col1">Boolean</entry>
+                <entry colname="col2">off</entry>
+                <entry colname="col3">master<p>system</p><p>restart</p></entry>
+              </row>
+            </tbody>
+          </tgroup>
+        </table>
+    </body>
+  </topic>
   <topic id="gp_enable_relsize_collection">
     <title>gp_enable_relsize_collection</title>
     <body>
@@ -4100,6 +4141,44 @@
               <entry colname="col2">1000</entry>
               <entry colname="col3">master<p>session</p><p>reload</p></entry>
             </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
+  <topic id="gp_instrument_shmem_size">
+    <title>gp_instrument_shmem_size</title>
+    <body>
+      <p>The amount of shared memory, in kilobytes, allocated for query metrics.
+      The default is 5120 and the maximum is 131072. At startup, if
+      <codeph><xref href="#gp_enable_query_metrics"
+      format="dita">gp_enable_query_metrics</xref></codeph> is set to on,
+      Greenplum Database allocates space in shared memory to save query metrics.
+      This memory is organized as a header and a list of slots. The number of
+      slots needed depends on the number of concurrent queries and the number of
+      execution plan nodes per query. The default value, 5120, is based on a
+      Greenplum Database system that executes a maximum of about 250 concurrent
+      queries with 120 nodes per query. If the
+      <codeph>gp_enable_query_metrics</codeph> configuration parameter is off,
+      or if the slots are exhausted, the metrics are maintained in local memory
+      instead of in shared memory. </p>
+      <table id="gp_instrument_shmem_size">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">integer <codeph>0 - 131072</codeph></entry>
+              <entry colname="col2">5120</entry>
+              <entry colname="col3">master<p>system</p><p>restart</p></entry></row>
           </tbody>
         </tgroup>
       </table>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -896,10 +896,10 @@
       </body>
     </topic>
     <topic id="topic36" xml:lang="en">
-      <title>Greenplum Command Center Agent</title>
+      <title>Greenplum Performance Database</title>
       <body>
         <p>The following parameters configure the data collection agents that populate the
-            <codeph>gpperfmon</codeph> database for Greenplum Command Center.</p>
+            <codeph>gpperfmon</codeph> database.</p>
         <simpletable id="kh171891" frame="none">
           <strow>
             <stentry>
@@ -919,6 +919,31 @@
               </p>
               <p>
                 <xref href="guc-list.xml#gpperfmon_port" type="section">gpperfmon_port</xref>
+              </p>
+            </stentry>
+          </strow>
+        </simpletable>
+      </body>
+    </topic>
+    <topic id="query-metrics">
+      <title>Query Metrics Collection Parameters</title>
+      <body>
+        <p>These parameters enable and configure query metrics collection. When enabled, 
+          Greenplum Database saves metrics to shared memory during query execution. These
+          metrics are used by Greenplum Command Center, which is included with the 
+          commercial version of Pivotal Greenplum Database.</p>
+        <simpletable id="query-metrics" frame="none">
+          <strow>
+            <stentry>
+              <p>
+                <xref href="guc-list.xml#gp_enable_query_metrics" type="section"
+                  >gp_enable_query_metrics</xref>
+              </p>
+            </stentry>
+            <stentry>
+              <p>
+                <xref href="guc-list.xml#gp_instrument_shmem_size" type="section"
+                  >gp_instrument_shmem_size</xref>
               </p>
             </stentry>
           </strow>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -930,8 +930,8 @@
       <body>
         <p>These parameters enable and configure query metrics collection. When enabled, 
           Greenplum Database saves metrics to shared memory during query execution. These
-          metrics are used by Greenplum Command Center, which is included with the 
-          commercial version of Pivotal Greenplum Database.</p>
+          metrics are used by Pivotal Greenplum Command Center, which is included with 
+          Pivotal's commercial version of Greenplum Database.</p> 
         <simpletable id="query-metrics" frame="none">
           <strow>
             <stentry>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -88,6 +88,7 @@
             <topicref href="guc-list.xml#gp_enable_multiphase_agg"/>
             <topicref href="guc-list.xml#gp_enable_predicate_propagation"/>
             <topicref href="guc-list.xml#gp_enable_preunique"/>
+            <topicref href="guc-list.xml#gp_enable_query_metrics"/>
             <topicref href="guc-list.xml#gp_enable_relsize_collection"/>
             <topicref href="guc-list.xml#gp_enable_segment_copy_checking"/>
             <topicref href="guc-list.xml#gp_enable_sort_distinct"/>
@@ -107,6 +108,7 @@
             <topicref href="guc-list.xml#gp_hadoop_target_version"/>
             <topicref href="guc-list.xml#gp_hashjoin_tuples_per_bucket"/>
             <topicref href="guc-list.xml#topic_lvm_ttc_3p"/>
+            <topicref href="guc-list.xml#gp_instrument_shmem_size"/>
             <topicref href="guc-list.xml#gp_interconnect_debug_retry_interval"/>
             <topicref href="guc-list.xml#gp_interconnect_fc_method"/>
             <topicref href="guc-list.xml#gp_interconnect_hash_multiplier"/>


### PR DESCRIPTION
Adds gp_enable_query_metrics and gp_instrument_shmem_size GUCs to reference guide