### PR TITLE
Optimize partition query in pg_dump

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -11839,7 +11839,7 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 			int i_partitionrank = 0;
 			resetPQExpBuffer(query);
 			appendPQExpBuffer(query, "SELECT c.relname, pr.parname,"
-					"CASE WHEN p.parkind <> 'r'::\"char\" OR pr.parisdefault THEN NULL::bigint "
+					"CASE WHEN p.parkind <> '%c'::char OR pr.parisdefault THEN NULL::bigint "
 					"ELSE pg_catalog.rank() OVER ( "
 					"PARTITION BY p.oid, cc.relname, p.parlevel, cl3.relname "
 					"ORDER BY pr.parisdefault, pr.parruleord) "
@@ -11850,7 +11850,7 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 					"LEFT JOIN pg_partition_rule pr2 ON pr.parparentrule = pr2.oid "
 					"LEFT JOIN pg_class cl3 ON pr2.parchildrelid = cl3.oid "
 					"WHERE pr.paroid = p.oid "
-					"AND p.parrelid = %u AND c.relstorage = '%c';", tbinfo->dobj.catId.oid, RELSTORAGE_EXTERNAL);
+					"AND p.parrelid = %u AND c.relstorage = '%c';", RELKIND_RELATION, tbinfo->dobj.catId.oid, RELSTORAGE_EXTERNAL);
 
 			res = PQexec(g_conn, query->data);
 			check_sql_result(res, g_conn, query->data, PGRES_TUPLES_OK);

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -11838,14 +11838,19 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 			int i_parname = 0;
 			int i_partitionrank = 0;
 			resetPQExpBuffer(query);
-
-			appendPQExpBuffer(query, "SELECT DISTINCT cc.relname, ps.partitionrank, pp.parname "
+			appendPQExpBuffer(query, "SELECT c.relname, pr.parname,"
+					"CASE WHEN p.parkind <> 'r'::\"char\" OR pr.parisdefault THEN NULL::bigint "
+					"ELSE pg_catalog.rank() OVER ( "
+					"PARTITION BY p.oid, cc.relname, p.parlevel, cl3.relname "
+					"ORDER BY pr.parisdefault, pr.parruleord) "
+					"END AS partitionrank "
 					"FROM pg_partition p "
-					"JOIN pg_class c on (p.parrelid = c.oid) "
-					"JOIN pg_partitions ps on (c.relname = ps.tablename) "
-					"JOIN pg_class cc on (ps.partitiontablename = cc.relname) "
-					"JOIN pg_partition_rule pp on (cc.oid = pp.parchildrelid) "
-					"WHERE p.parrelid = %u AND cc.relstorage = '%c';", tbinfo->dobj.catId.oid, RELSTORAGE_EXTERNAL);
+					"JOIN pg_class cc ON (p.parrelid = cc.oid), pg_class c "
+					"JOIN pg_partition_rule pr ON (c.oid = pr.parchildrelid) "
+					"LEFT JOIN pg_partition_rule pr2 ON pr.parparentrule = pr2.oid "
+					"LEFT JOIN pg_class cl3 ON pr2.parchildrelid = cl3.oid "
+					"WHERE pr.paroid = p.oid "
+					"AND p.parrelid = %u AND c.relstorage = '%c';", tbinfo->dobj.catId.oid, RELSTORAGE_EXTERNAL);
 
 			res = PQexec(g_conn, query->data);
 			check_sql_result(res, g_conn, query->data, PGRES_TUPLES_OK);


### PR DESCRIPTION
Commit 708a042 added logic to dump unnamed exchange partitions for range
partition tables. However, the join on pg_partitions (the view, not the pg_partition
catalog) is very expensive and slowed pg_dump significantly. Now, we
don't query pg_partitions but instead include only the necessary logic in the
query itself. This will be backported to 5X_STABLE.

On 5X_STABLE, dumping the regression database went from 72 to 10 seconds on my machine with this change and the pg_dump output was equivalent.

I'd appreciate another set of eyes on this query. For example, are pr2 and cl3 actually necessary or can we remove them? The pg_partitions view includes this join; however, I wasn't able to produce a case where it created different dump output.

Authored-by: Chris Hajas <chajas@pivotal.io>