### PR TITLE
Check buffer size before allocating memory in copy

### DIFF
--- a/src/test/regress/input/gpcopy.source
+++ b/src/test/regress/input/gpcopy.source
@@ -1100,3 +1100,6 @@ COPY lineitem TO '/tmp/aborted.data';
 CREATE TABLE lineitem_aborted (LIKE lineitem);
 COPY lineitem_aborted FROM '/tmp/aborted.data';
 SELECT count(*) < 57190 FROM lineitem_aborted;
+
+CREATE TABLE cp_oom_errors (c text);
+copy cp_oom_errors from program 'dd if=/dev/zero bs=1074790400 count=1';

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -1304,3 +1304,7 @@ SELECT count(*) < 57190 FROM lineitem_aborted;
  t
 (1 row)
 
+CREATE TABLE cp_oom_errors (c text);
+copy cp_oom_errors from program 'dd if=/dev/zero bs=1074790400 count=1';
+ERROR:  Line is longer than the max allocable size 1073741823 bytes
+CONTEXT:  COPY cp_oom_errors, line 0


### PR DESCRIPTION
Copy doesn't support tuples whose size are larger than 1GB,
because the enlargeStringInfo function can't reallocate
memory to more than 1GB.

This reports error before OOM.