### PR TITLE
Rename GPDB_84_MERGE_FIXME to RECURSIVE_CTE_FIXME

### DIFF
--- a/src/backend/executor/nodeRecursiveunion.c
+++ b/src/backend/executor/nodeRecursiveunion.c
@@ -91,7 +91,7 @@ ExecRecursiveUnion(RecursiveUnionState *node)
 			if (TupIsNull(slot))
 				break;
 			/*
-			 * GPDB_84_MERGE_FIXME: It suppose plan->numCols should be 0 if we don't
+			 * RECURSIVE_CTE_FIXME: It suppose plan->numCols should be 0 if we don't
 			 * support recursive union. QP should fix this later.
 			 */
 			if (plan->numCols > 0)
@@ -143,7 +143,7 @@ ExecRecursiveUnion(RecursiveUnionState *node)
 		}
 
 		/*
-		 * GPDB_84_MERGE_FIXME: It suppose plan->numCols should be 0 if we don't
+		 * RECURSIVE_CTE_FIXME: It suppose plan->numCols should be 0 if we don't
 		 * support recursive union. QP should fix this later.
 		 */
 		if (plan->numCols > 0)
@@ -207,7 +207,7 @@ ExecInitRecursiveUnion(RecursiveUnion *node, EState *estate, int eflags)
 	 * kept in the per-query context because we want to be able to throw it
 	 * away when rescanning.
 	 *
-	 * GPDB_84_MERGE_FIXME: It suppose plan->numCols should be 0 if we don't
+	 * RECURSIVE_CTE_FIXME: It suppose plan->numCols should be 0 if we don't
 	 * support recursive union. QP should fix this later.
 	 */
 	if (node->numCols > 0)
@@ -267,7 +267,7 @@ ExecInitRecursiveUnion(RecursiveUnion *node, EState *estate, int eflags)
 	 * If hashing, precompute fmgr lookup data for inner loop, and create the
 	 * hash table.
 	 *
-	 * GPDB_84_MERGE_FIXME: It suppose plan->numCols should be 0 if we don't
+	 * RECURSIVE_CTE_FIXME: It suppose plan->numCols should be 0 if we don't
 	 * support recursive union. QP should fix this later.
 	 */
 	if (node->numCols > 0)
@@ -348,7 +348,7 @@ ExecRecursiveUnionReScan(RecursiveUnionState *node, ExprContext *exprCtxt)
 
 	/* And rebuild empty hashtable if needed */
 	/*
-	 * GPDB_84_MERGE_FIXME: It suppose plan->numCols should be 0 if we don't
+	 * RECURSIVE_CTE_FIXME: It suppose plan->numCols should be 0 if we don't
 	 * support recursive union. QP should fix this later.
 	 */
 	if (plan->numCols > 0)

--- a/src/backend/executor/nodeWorktablescan.c
+++ b/src/backend/executor/nodeWorktablescan.c
@@ -51,7 +51,7 @@ WorkTableScanNext(WorkTableScanState *node)
 	estate = node->ss.ps.state;
 
 	/*
-	 * GPDB_84_MERGE_FIXME: Double check we don't have backward scan required by
+	 * RECURSIVE_CTE_FIXME: Double check we don't have backward scan required by
 	 * plan (both planner and ORCA).
 	 */
 	Assert(ScanDirectionIsForward(estate->es_direction));
@@ -138,7 +138,7 @@ ExecInitWorkTableScan(WorkTableScan *node, EState *estate, int eflags)
 
 	/* check for unsupported flags */
 	/*
-	 * GPDB_84_MERGE_FIXME: Make sure we don't require EXEC_FLAG_BACKWARD
+	 * RECURSIVE_CTE_FIXME: Make sure we don't require EXEC_FLAG_BACKWARD
 	 * in GPDB.
 	 */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));


### PR DESCRIPTION
GA-ing Recursive CTE is not a blocker for GPDB 6, so renaming the
comment to reflect this.