### PR TITLE
docs - correct pxf http header prefix for profile attr

### DIFF
--- a/gpdb-doc/markdown/pxf/troubleshooting_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/troubleshooting_pxf.html.md.erb
@@ -96,10 +96,11 @@ DEBUG2:  churl http header: cell #20: X-GP-URL-PORT: 5888  (seg0 slice1 127.0.0.
 CONTEXT:  External table hdfstest, file pxf://data/dir/hdfsfile?PROFILE=HdfsTextSimple
 DEBUG2:  churl http header: cell #21: X-GP-DATA-DIR: data/dir/hdfsfile  (seg0 slice1 127.0.0.1:40000 pid=3981)
 CONTEXT:  External table hdfstest, file pxf://data/dir/hdfsfile?PROFILE=HdfsTextSimple
-DEBUG2:  churl http header: cell #22: X-GP-PROFILE: HdfsTextSimple  (seg0 slice1 127.0.0.1:40000 pid=3981)
+DEBUG2:  churl http header: cell #22: X-GP-OPTIONS-PROFILE: HdfsTextSimple  (seg0 slice1 127.0.0.1:40000 pid=3981)
 CONTEXT:  External table hdfstest, file pxf://data/dir/hdfsfile?PROFILE=HdfsTextSimple
 DEBUG2:  churl http header: cell #23: X-GP-URI: pxf://data/dir/hdfsfile?PROFILE=HdfsTextSimple  (seg0 slice1 127.0.0.1:40000 pid=3981)
 CONTEXT:  External table hdfstest, file pxf://data/dir/hdfsfile?PROFILE=HdfsTextSimple
+...
 ```
 
 Examine/collect the log messages from `stdout`.


### PR DESCRIPTION
pxf changed a few http header prefixes.  update relevant logging output in the pxf troubleshooting section.