### PR TITLE
Don't access relcache entry after closing it.

### DIFF
--- a/src/backend/commands/sequence.c
+++ b/src/backend/commands/sequence.c
@@ -579,13 +579,15 @@ nextval_internal(Oid relid)
 
 	if (is_overflow)
 	{
+		char	   *relname = pstrdup(RelationGetRelationName(seqrel));
+
 		relation_close(seqrel, NoLock);
 
 		ereport(ERROR,
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				 errmsg("nextval: reached %s value of sequence \"%s\" (" INT64_FORMAT ")",
                         elm->increment>0 ? "maximum":"minimum",
-                        RelationGetRelationName(seqrel), elm->last)));
+                        relname, elm->last)));
 	}
 	else
 		elm->last_valid = true;


### PR DESCRIPTION
This is essentially a use-after-free bug. Found by running regression
tests with CLOBBER_CACHE_ALWAYS and RELCACHE_FORCE_RELEASE.