### PR TITLE
Fix getaddrinfo compatibility problem on Mac OS X

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -440,7 +440,7 @@ class SendFilerepTransitionMessage(Command):
         return cmd
 
     @staticmethod
-    def buildTransitionMessageCommand(transitionData, dir, port):
+    def buildTransitionMessageCommand(transitionData, dir, port, remoteHost=None):
         dbData = transitionData["dbsByPort"][int(port)]
         targetMode = dbData["targetMode"]
 
@@ -466,7 +466,7 @@ class SendFilerepTransitionMessage(Command):
         inputFile = os.path.join( dir, "gp_pmtransition_args" )
         writeLinesToFile(inputFile, argsArr)
 
-        return SendFilerepTransitionMessage("Changing seg at dir %s" % dir, inputFile, port=port, dataDir=dir)
+        return SendFilerepTransitionMessage("Changing seg at dir %s" % dir, inputFile, port=port, dataDir=dir, remoteHost=remoteHost)
 
 class SendFilerepTransitionStatusMessage(Command):
     def __init__(self, name, msg, dataDir=None, port=None,ctxt=LOCAL, remoteHost=None):
@@ -813,7 +813,7 @@ class GpSegChangeMirrorModeCmd(Command):
         for db in dbs:
             datadir = db.getSegmentDataDirectory()
             port = db.getSegmentPort()
-            self.dirlist.append(datadir + ':' + str(port))
+            self.dirlist.append(datadir + ':' + str(remoteHost) + ':' + str(port))
 
         dirstr=" -D ".join(self.dirlist)
         if verbose:

--- a/gpMgmt/sbin/gpgetstatususingtransition.py
+++ b/gpMgmt/sbin/gpgetstatususingtransition.py
@@ -48,7 +48,7 @@ class GpSegStatusProgram:
             return None
 
         cmd = gp.SendFilerepTransitionStatusMessage("Check Status", statusRequest, seg.getSegmentDataDirectory(),
-                                                seg.getSegmentPort())
+                                                seg.getSegmentPort(), remoteHost=seg.getSegmentHostName())
 
         cmd.run()
         return cmd.unpackSuccessLine()

--- a/gpMgmt/sbin/gpsegstart.py
+++ b/gpMgmt/sbin/gpsegstart.py
@@ -339,7 +339,8 @@ class GpSegStart:
             # (look for the protocol message type PRIMARY_MIRROR_TRANSITION_REQUEST_CODE )
             #
             port = seg.getSegmentPort()
-            cmd  = gp.SendFilerepTransitionMessage.buildTransitionMessageCommand(transitionData, datadir, port)
+            host = seg.getSegmentHostName()
+            cmd  = gp.SendFilerepTransitionMessage.buildTransitionMessageCommand(transitionData, datadir, port, remoteHost=host)
 
             self.pool.addCommand(cmd)
         self.pool.join()
@@ -446,9 +447,10 @@ class GpSegStart:
                 name      = "Check Status"
                 statusmsg = "getCollationAndDataDirSettings"
                 port      = seg.getSegmentPort()
+                host      = seg.getSegmentHostName()
 
                 self.logger.info("Checking %s, port %s" % (datadir, port))
-                cmd       = gp.SendFilerepTransitionStatusMessage(name, statusmsg, datadir, port)
+                cmd       = gp.SendFilerepTransitionStatusMessage(name, statusmsg, datadir, port, remoteHost=host)
 
                 dataDirToCmd[datadir] = cmd
                 self.pool.addCommand(cmd)

--- a/gpMgmt/sbin/gpsegtoprimaryormirror.py
+++ b/gpMgmt/sbin/gpsegtoprimaryormirror.py
@@ -85,17 +85,18 @@ class GpSegToPrimaryMirror():
     def run(self):
         results=[]
         failures=False
-        dirportmap = {}
+        diraddrmap = {}
 
         for itm in self.dblist:
-            (dir, port) = itm.split(':')
-            dirportmap[dir] = port
+            (dir, addr) = itm.split(':', 1)
+            diraddrmap[dir] = addr 
 
         transitionData = pickle.loads(base64.urlsafe_b64decode(self.pickledTransitionData))
             
         logger.info("Changing segments...")
-        for dir, port in dirportmap.iteritems():
-            cmd = gp.SendFilerepTransitionMessage.buildTransitionMessageCommand(transitionData, dir, port)
+        for dir, addr in diraddrmap.iteritems():
+            (host, port) = addr.split(':')
+            cmd = gp.SendFilerepTransitionMessage.buildTransitionMessageCommand(transitionData, dir, port, remoteHost=host)
             self.pool.addCommand(cmd)
               
         self.pool.join()
@@ -109,7 +110,7 @@ class GpSegToPrimaryMirror():
                             (res.stdout.replace("\n", " "), res.stderr.replace("\n", " "))
                 status=SegToPrimaryMirrorStatus(cmd.dataDir,False, reason)
                 results.append(status)
-                del dirportmap[cmd.dataDir]
+                del diraddrmap[cmd.dataDir]
                 failures=True
 
         #
@@ -117,7 +118,7 @@ class GpSegToPrimaryMirror():
         #       transition because the fault prober is paused at this point.  If stuff fails just after conversion
         #       then we could block on a connect call, waiting for the prober to unstick the process
         #
-        for datadir,port in dirportmap.iteritems():
+        for datadir,addr in diraddrmap.iteritems():
             results.append(SegToPrimaryMirrorStatus(datadir,True,"Conversion Succeeded"))
                 
         #Log the results!

--- a/gpMgmt/sbin/gpsegtoprimaryormirror.py
+++ b/gpMgmt/sbin/gpsegtoprimaryormirror.py
@@ -89,7 +89,7 @@ class GpSegToPrimaryMirror():
 
         for itm in self.dblist:
             (dir, addr) = itm.split(':', 1)
-            diraddrmap[dir] = addr 
+            diraddrmap[dir] = addr
 
         transitionData = pickle.loads(base64.urlsafe_b64decode(self.pickledTransitionData))
             

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -1325,7 +1325,7 @@ PostmasterMain(int argc, char *argv[])
 		}
 
 		/* If there are more than one listen address, backend bind on all addresses*/
-		if (list_length(elemlist) > 1)
+		if (list_length(elemlist) > 1 || strcmp(ListenAddresses, "*") == 0)
 			BackendListenAddress = NULL;
 		else
 			BackendListenAddress = ListenAddresses;


### PR DESCRIPTION
The first parameter "node" of getaddrinfo can be "*" on Linux but doesn't
work on Mac OS X.