### PR TITLE
Fix SyncRepWaitForLSN() to ignore QueryCancelPending

### DIFF
--- a/src/backend/replication/syncrep.c
+++ b/src/backend/replication/syncrep.c
@@ -44,6 +44,7 @@
 #include "tcop/tcopprot.h"
 #include "utils/builtins.h"
 #include "utils/ps_status.h"
+#include "utils/faultinjector.h"
 #include "pgstat.h"
 #include "cdb/cdbvars.h"
 /* User-settable parameters for sync rep */
@@ -299,19 +300,25 @@ SyncRepWaitForLSN(XLogRecPtr XactCommitLSN)
 		}
 
 		/*
-		 * It's unclear what to do if a query cancel interrupt arrives.  We
-		 * can't actually abort at this point, but ignoring the interrupt
-		 * altogether is not helpful, so we just terminate the wait with a
-		 * suitable warning.
+		 * GPDB: There are multiple code paths going through this function,
+		 * e.g. prepare, commit, and abort. To ensure MPP cluster consistency,
+		 * if primary already changed, then this backend has to wait for the
+		 * xlog record replicate to the mirror to avoid inconsistency between
+		 * the primary and the mirror, since they are under synced replication.
+		 *
+		 * If the mirror is indeed offline and prevents xlog to be synced, FTS
+		 * will detect the mirror goes down, and failure handling will kick-in
+		 * and mark the mirror down and out-of-sync with the primary to prevent
+		 * failover. Then the syncrep will be turned off by the FTS to unblock
+		 * backends waiting here.
 		 */
 		if (QueryCancelPending)
 		{
 			QueryCancelPending = false;
 			ereport(WARNING,
-					(errmsg("canceling wait for synchronous replication due to user request"),
-					 errdetail("The transaction has already committed locally, but might not have been replicated to the standby.")));
-			SyncRepCancelWait();
-			break;
+					(errmsg("ignoring query cancel request for synchronous replication to ensure cluster consistency."),
+					 errdetail("The transaction has already changed locally, it has to be replicated to standby.")));
+			SIMPLE_FAULT_INJECTOR(SyncRepQueryCancel);
 		}
 
 		/*

--- a/src/backend/replication/walsender.c
+++ b/src/backend/replication/walsender.c
@@ -68,6 +68,7 @@
 #include "utils/ps_status.h"
 #include "utils/resowner.h"
 #include "utils/timestamp.h"
+#include "utils/faultinjector.h"
 #include "cdb/cdbvars.h"
 
 /* Array of WalSnds in shared memory */
@@ -555,6 +556,8 @@ WalSndLoop(void)
 	/* Loop forever, unless we get an error */
 	for (;;)
 	{
+		SIMPLE_FAULT_INJECTOR(WalSenderLoop);
+
 		/* Clear any already-pending wakeups */
 		ResetLatch(&MyWalSnd->latch);
 

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -733,6 +733,7 @@ FaultInjector_NewHashEntry(
 			case ExecutorRunHighProcessed:
 			case FtsProbe:
 			case AppendOnlySkipCompression:
+			case SyncRepQueryCancel:
 
 				break;
 			default:

--- a/src/include/utils/faultinjector_lists.h
+++ b/src/include/utils/faultinjector_lists.h
@@ -216,6 +216,10 @@ FI_IDENT(ResGroupAssignedOnMaster, "resgroup_assigned_on_master")
 FI_IDENT(BeforeReadCommand, "before_read_command")
 /* inject fault before get checkpoint dtx information */
 FI_IDENT(CheckPointDtxInfo, "checkpoint_dtx_info")
+/* inject fault at WalSndLoop() function */
+FI_IDENT(WalSenderLoop, "wal_sender_loop")
+/* inject fault at SyncRepWaitForLSN function for QueryCancelPending */
+FI_IDENT(SyncRepQueryCancel, "sync_rep_query_cancel")
 #endif
 
 /*

--- a/src/test/isolation2/expected/segwalrep/cancel_commit_pending_replication.out
+++ b/src/test/isolation2/expected/segwalrep/cancel_commit_pending_replication.out
@@ -1,0 +1,93 @@
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+CREATE
+
+select gp_inject_fault('sync_rep_query_cancel', 'reset', 2);
+gp_inject_fault
+---------------
+t              
+(1 row)
+select gp_inject_fault('wal_sender_loop', 'reset', 2);
+gp_inject_fault
+---------------
+t              
+(1 row)
+
+create or replace function wait_for_replication(iterations int) returns bool as $$ begin /* in func */ for i in 1 .. iterations loop /* in func */ if exists (select waiting_reason from pg_stat_activity where sess_id in (select sess_id from store_session_id) and waiting_reason = 'replication') then /* in func */ return true; /* in func */ end if; /* in func */ perform pg_sleep(0.1); /* in func */ perform pg_stat_clear_snapshot(); /* in func */ end loop; /* in func */ return false; /* in func */ end; /* in func */ $$ language plpgsql VOLATILE;
+CREATE
+
+create table store_session_id(a int, sess_id int);
+CREATE
+-- adding `0` as first column as the distribution column and add this tuple to segment 0
+1: insert into store_session_id select 0, sess_id from pg_stat_activity where procpid = pg_backend_pid();
+INSERT 1
+-- suspend to hit commit-prepared point on segment (as we are
+-- interested in testing Commit here and not really Prepare)
+select gp_inject_fault('finish_prepared_start_of_function', 'suspend', 2);
+gp_inject_fault
+---------------
+t              
+(1 row)
+-- Expect: `create table` should be blocked until reset
+-- `wal_sender_loop`. We also verify the `sync_rep_query_cancel` is
+-- triggered by query cancel request.
+1&: create table cancel_commit_pending_replication(a int, b int);  <waiting ...>
+select gp_inject_fault('finish_prepared_start_of_function', 'wait_until_triggered', 2);
+gp_inject_fault
+---------------
+t              
+(1 row)
+-- now pause the wal sender on primary for content 0
+select gp_inject_fault('wal_sender_loop', 'suspend', 2);
+gp_inject_fault
+---------------
+t              
+(1 row)
+-- let the transaction move forward with the commit
+select gp_inject_fault('finish_prepared_start_of_function', 'reset', 2);
+gp_inject_fault
+---------------
+t              
+(1 row)
+-- loop to reach waiting_reason=replication
+0U: select wait_for_replication(200);
+wait_for_replication
+--------------------
+t                   
+(1 row)
+-- hitting this fault, is checked for test validation
+select gp_inject_fault('sync_rep_query_cancel', 'skip', 2);
+gp_inject_fault
+---------------
+t              
+(1 row)
+0U: select pg_cancel_backend(procpid) from pg_stat_activity where waiting_reason='replication' and sess_id in (select sess_id from store_session_id);
+pg_cancel_backend
+-----------------
+t                
+(1 row)
+-- EXPECT: hit this fault for QueryCancelPending
+select gp_inject_fault('sync_rep_query_cancel', 'wait_until_triggered', 2);
+gp_inject_fault
+---------------
+t              
+(1 row)
+-- EXPECT: the query is still in waiting mode, to verify the cancel is ignored.
+0U: select waiting_reason from pg_stat_activity where sess_id in (select sess_id from store_session_id);
+waiting_reason
+--------------
+replication   
+(1 row)
+-- resume the primary on content 0
+select gp_inject_fault('wal_sender_loop', 'reset', 2);
+gp_inject_fault
+---------------
+t              
+(1 row)
+1<:  <... completed>
+CREATE
+-- cleanup
+select gp_inject_fault('sync_rep_query_cancel', 'reset', 2);
+gp_inject_fault
+---------------
+t              
+(1 row)

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -103,6 +103,7 @@ test: vacuum_after_vacuum_skip_drop_column
 test: segwalrep/commit_blocking
 test: segwalrep/fts_unblock_primary
 test: segwalrep/mirror_promotion
+test: segwalrep/cancel_commit_pending_replication
 
 # Tests for crash recovery
 test: crash_recovery

--- a/src/test/isolation2/sql/segwalrep/cancel_commit_pending_replication.sql
+++ b/src/test/isolation2/sql/segwalrep/cancel_commit_pending_replication.sql
@@ -1,0 +1,48 @@
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+
+select gp_inject_fault('sync_rep_query_cancel', 'reset', 2);
+select gp_inject_fault('wal_sender_loop', 'reset', 2);
+
+create or replace function wait_for_replication(iterations int)
+returns bool as $$
+begin /* in func */
+	for i in 1 .. iterations loop /* in func */
+	    if exists (select waiting_reason from pg_stat_activity where sess_id in (select sess_id from store_session_id) and waiting_reason = 'replication') then /* in func */
+	       return true; /* in func */
+	    end if; /* in func */
+	    perform pg_sleep(0.1); /* in func */
+	    perform pg_stat_clear_snapshot(); /* in func */
+	end loop; /* in func */
+	return false; /* in func */
+end; /* in func */
+$$ language plpgsql VOLATILE;
+
+create table store_session_id(a int, sess_id int);
+-- adding `0` as first column as the distribution column and add this tuple to segment 0
+1: insert into store_session_id select 0, sess_id from pg_stat_activity where procpid = pg_backend_pid();
+-- suspend to hit commit-prepared point on segment (as we are
+-- interested in testing Commit here and not really Prepare)
+select gp_inject_fault('finish_prepared_start_of_function', 'suspend', 2);
+-- Expect: `create table` should be blocked until reset
+-- `wal_sender_loop`. We also verify the `sync_rep_query_cancel` is
+-- triggered by query cancel request.
+1&: create table cancel_commit_pending_replication(a int, b int);
+select gp_inject_fault('finish_prepared_start_of_function', 'wait_until_triggered', 2);
+-- now pause the wal sender on primary for content 0
+select gp_inject_fault('wal_sender_loop', 'suspend', 2);
+-- let the transaction move forward with the commit
+select gp_inject_fault('finish_prepared_start_of_function', 'reset', 2);
+-- loop to reach waiting_reason=replication
+0U: select wait_for_replication(200);
+-- hitting this fault, is checked for test validation
+select gp_inject_fault('sync_rep_query_cancel', 'skip', 2);
+0U: select pg_cancel_backend(procpid) from pg_stat_activity where waiting_reason='replication' and sess_id in (select sess_id from store_session_id);
+-- EXPECT: hit this fault for QueryCancelPending
+select gp_inject_fault('sync_rep_query_cancel', 'wait_until_triggered', 2);
+-- EXPECT: the query is still in waiting mode, to verify the cancel is ignored.
+0U: select waiting_reason from pg_stat_activity where sess_id in (select sess_id from store_session_id);
+-- resume the primary on content 0
+select gp_inject_fault('wal_sender_loop', 'reset', 2);
+1<:
+-- cleanup
+select gp_inject_fault('sync_rep_query_cancel', 'reset', 2);


### PR DESCRIPTION
Under MPP setting, we cannot allow primary go out of sync with mirror
because that will cause the segment inconsistent with rest of segments
in the cluster.

Hence instead of honoring the query cancel request and mirror not be 
in sync with primary, the primary will actually ignore the query cancel
request after primary commits.

If such out of sync caused by mirror failure, regular FTS failure
handling will handle it.

NOTE: the `ProcDiePending` also got the similar issue, and it will be 
handled separately since it cannot be ignored.

Co-authored-by: Ashwin Agrawal <aagrawal@pivotal.io>
Co-authored-by: Xin Zhang <xzhang@pivotal.io>