### PR TITLE
Fix libpq link to psql by reverting to upstream Makefile order

### DIFF
--- a/src/bin/psql/Makefile
+++ b/src/bin/psql/Makefile
@@ -43,7 +43,7 @@ LIBS := $(filter-out -lresolv -lbz2, $(LIBS))
 all: submake-libpq submake-libpgport psql
 
 psql: $(OBJS) $(libpq_builddir)/libpq.a
-	$(CC) $(CFLAGS) $(LDFLAGS) $(LDFLAGS_EX) $(OBJS) $(libpq_pgport) $(LIBS) -o $@$(X)
+	$(CC) $(CFLAGS) $(OBJS) $(libpq_pgport) $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@$(X)
 
 help.o: sql_help.h
 


### PR DESCRIPTION
`libpq_pgport` needs to take precedence over `LDFLAGS`, so that we link
against our built libpq instead of other libpq versions hiding in `-L`
paths. For example, on macOS, configuring `--with-libxml` will put the
system's libpq path into `LDFLAGS`. This later leads to

    psql: could not connect to server: No such file or directory
        Is the server running locally and accepting
        connections on Unix domain socket "/var/pgsql_socket/.s.PGSQL.5432"?

during psql execution, because it's linked against the wrong libpq.

Strangely, this is already the order used in Postgres's psql Makefile,
as well as several other src/bin Makefiles in GPDB. It's not clear to me
why this was changed in our version of psql.

Fixes #3215.