### PR TITLE
Fix distributed snapshots to include just-started transactions.

### DIFF
--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -1253,11 +1253,13 @@ CreateDistributedSnapshot(DistributedSnapshotWithLocalMapping *distribSnapshotWi
 		if (gxid == InvalidDistributedTransactionId)
 			continue;
 
-		if (gxact_candidate->state == DTX_STATE_ACTIVE_NOT_DISTRIBUTED)
-			continue;
+		/*
+		 * NB: We must include transactions in DTX_STATE_ACTIVE_NOT_DISTRIBUTED
+		 * state. All transactions start in that state, even if they become
+		 * distribute later on.
+		 */
 
-		Assert(gxact_candidate->state != DTX_STATE_ACTIVE_NOT_DISTRIBUTED &&
-			   gxact_candidate->state != DTX_STATE_NONE);
+		Assert(gxact_candidate->state != DTX_STATE_NONE);
 
 		/* Update globalXminDistributedSnapshots to be the smallest valid dxid */
 		dxid = gxact_candidate->xminDistributedSnapshot;


### PR DESCRIPTION
All in-progress transactions, even those in DTX_STATE_ACTIVE_NOT_DISTRIBUTED
state, must be included in a distributed snapshot. All transactions begin
in DTX_STATE_ACTIVE_NOT_DISTRIBUTED state, and can become distributed later
on.

This bug was introduced in commit ff97c70b82b, which added the ill-advised
optimization to skip DTX_STATE_ACTIVE_NOT_DISTRIBUTED transactions.

This showed up occasionally in the regression tests as a failure in the
'oidjoins' test, as a failure like this:

```
@@ -230,9 +230,17 @@
 SELECT	ctid, attrelid
 FROM	pg_catalog.pg_attribute fk
 WHERE    attrelid != 0 AND
     NOT EXISTS(SELECT 1 FROM pg_catalog.pg_class pk WHERE pk.oid = fk.attrelid);
- ctid | attrelid
-------+----------
-(0 rows)
+  ctid   | attrelid
+---------+----------
+ (20,10) |    17107
+ (20,11) |    17107
+ (20,12) |    17107
+ (20,13) |    17107
+ (20,14) |    17107
+ (20,15) |    17107
+ (20,8)  |    17107
+ (20,9)  |    17107
+(8 rows)
```

The plan for that is a hash anti-join, with 'pg_class' in the inner side,
and 'pg_attribute' on the outer side. If a table was created concurrently
with that query (with oid 17107 in the above case), you could get the
failure. What happens is that the concurrent CREATE TABLE transaction was
assigned a distributed XID that was incorrectly not included in the
distributed snapshot that the query took. Hence, the transaction became
visible to the query immediately, as soon as it committed. If the CREATE
TABLE transaction committed between the full scan of pg_class, and the
scan on pg_attribute, the query would not see the just-inserted pg_class
row, but would see the pg_attribute rows.