### PR TITLE
Make test case less sensitive to number of databases and roles.

### DIFF
--- a/src/test/regress/expected/subselect_gp2.out
+++ b/src/test/regress/expected/subselect_gp2.out
@@ -31,22 +31,26 @@ where (select count(*) from echotable as i where i.c2 = o.c2) >= 2;
 (2 rows)
 
 -- Planner test to make sure the initplan is not removed for function scan
-explain select sess_id from pg_stat_activity where current_query = (select current_query());
-                                       QUERY PLAN                                       
-----------------------------------------------------------------------------------------
- Hash Join  (cost=2.08..3.42 rows=4 width=4)
-   Hash Cond: s.datid = d.oid
+explain (costs off)
+select sess_id from pg_stat_activity
+where current_query = (select current_query())
+and usename='xxx' and datname='xxx';
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Hash Join
+   Hash Cond: s.usesysid = u.oid
    InitPlan 1 (returns $0)
-     ->  Result  (cost=0.00..0.01 rows=1 width=0)
-   ->  Hash Join  (cost=1.02..2.31 rows=4 width=8)
-         Hash Cond: s.usesysid = u.oid
-         ->  Function Scan on pg_stat_get_activity s  (cost=0.00..1.25 rows=1 width=12)
+     ->  Result
+   ->  Hash Join
+         Hash Cond: s.datid = d.oid
+         ->  Function Scan on pg_stat_get_activity s
                Filter: current_query = $0
-         ->  Hash  (cost=1.01..1.01 rows=1 width=4)
-               ->  Seq Scan on pg_authid u  (cost=0.00..1.01 rows=1 width=4)
-   ->  Hash  (cost=1.02..1.02 rows=1 width=4)
-         ->  Seq Scan on pg_database d  (cost=0.00..1.02 rows=2 width=4)
- Settings:  optimizer=off
- Optimizer status: legacy query optimizer
-(14 rows)
+         ->  Hash
+               ->  Seq Scan on pg_database d
+                     Filter: datname = 'xxx'::name
+   ->  Hash
+         ->  Seq Scan on pg_authid u
+               Filter: rolname = 'xxx'::name
+ Optimizer: legacy query optimizer
+(15 rows)
 

--- a/src/test/regress/sql/subselect_gp2.sql
+++ b/src/test/regress/sql/subselect_gp2.sql
@@ -22,4 +22,7 @@ select * from test_ext_foo as o
 where (select count(*) from echotable as i where i.c2 = o.c2) >= 2;
 
 -- Planner test to make sure the initplan is not removed for function scan
-explain select sess_id from pg_stat_activity where current_query = (select current_query());
+explain (costs off)
+select sess_id from pg_stat_activity
+where current_query = (select current_query())
+and usename='xxx' and datname='xxx';


### PR DESCRIPTION
The number of databases and roles in the system affected the join order
that the planner chose. I sometimes saw failures because of that, depending
on what other tests I had run before. Add WHERE clause on datname, to make
it less sensitive.