### PR TITLE
Mirror should not get marked as DOWN after primary recovery.

### DIFF
--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -334,6 +334,9 @@ static PMState pmState = PM_INIT;
 
 /* CDB */
 
+/* Set at database system is ready to accept connections */
+pg_time_t PMAcceptingConnectionsStartTime = 0;
+
 typedef enum PMSUBPROC_FLAGS
 {
 	PMSUBPROC_FLAG_QD 					= 0x1,
@@ -2903,6 +2906,8 @@ reaper(SIGNAL_ARGS)
 						(errmsg("database system is ready to accept connections"),
 						 errdetail("%s",version),
 						 errSendAlert(true)));
+
+				PMAcceptingConnectionsStartTime = (pg_time_t) time(NULL);
 			}
 
 			continue;

--- a/src/backend/replication/test/gp_replication_test.c
+++ b/src/backend/replication/test/gp_replication_test.c
@@ -30,6 +30,31 @@ expect_lwlock(LWLockMode lockmode)
 }
 
 static void
+expect_elog()
+{
+	expect_any(elog_start, filename);
+	expect_any(elog_start, lineno);
+	expect_any(elog_start, funcname);
+	will_be_called(elog_start);
+
+	expect_any(elog_finish, elevel);
+	expect_any(elog_finish, fmt);
+	will_be_called(elog_finish);
+}
+
+static void
+expect_ereport()
+{
+	expect_any(errstart, elevel);
+	expect_any(errstart, filename);
+	expect_any(errstart, lineno);
+	expect_any(errstart, funcname);
+	expect_any(errstart, domain);
+
+	will_be_called(errstart);
+}
+
+static void
 test_setup(WalSndCtlData *data, WalSndState state)
 {
 	max_wal_senders = 1;
@@ -56,9 +81,99 @@ test_GetMirrorStatus_Pid_Zero(void **state)
 	data.walsnds[0].marked_pid_zero_at_time =
 		((pg_time_t) time(NULL)) - FTS_MARKING_MIRROR_DOWN_GRACE_PERIOD;
 
+	/*
+	 * Ensure the recovery finished before wal sender died.
+	 */
+	PMAcceptingConnectionsStartTime = data.walsnds[0].marked_pid_zero_at_time - 1;
+
 	expect_lwlock(LW_SHARED);
 	GetMirrorStatus(&response);
 
+	assert_false(response.RequestRetry);
+	assert_false(response.IsMirrorUp);
+	assert_false(response.IsInSync);
+}
+
+void
+test_GetMirrorStatus_RequestRetry(void **state)
+{
+	FtsResponse response;
+	WalSndCtlData data;
+
+	max_wal_senders = 1;
+	WalSndCtl = &data;
+	data.walsnds[0].pid = 0;
+	/*
+	 * Make the pid zero time within the grace period.
+	 */
+	data.walsnds[0].marked_pid_zero_at_time =
+		((pg_time_t) time(NULL)) - FTS_MARKING_MIRROR_DOWN_GRACE_PERIOD/2;
+
+	/*
+	 * Ensure recovery finished before wal sender died.
+	 */
+	PMAcceptingConnectionsStartTime = data.walsnds[0].marked_pid_zero_at_time - FTS_MARKING_MIRROR_DOWN_GRACE_PERIOD;
+
+	expect_lwlock(LW_SHARED);
+	expect_ereport();
+	GetMirrorStatus(&response);
+
+	assert_true(response.RequestRetry);
+}
+
+/*
+ * Verify the logic the grace period will exclude the recovery time.
+ */
+void
+test_GetMirrorStatus_Delayed_AcceptingConnectionsStartTime(void **state)
+{
+	FtsResponse response;
+	WalSndCtlData data;
+
+	max_wal_senders = 1;
+	WalSndCtl = &data;
+	data.walsnds[0].pid = 0;
+	/*
+	 * wal sender pid zero time over the grace period
+	 * Mirror will be marked down, and no retry.
+	 */
+	data.walsnds[0].marked_pid_zero_at_time =
+		((pg_time_t) time(NULL)) - FTS_MARKING_MIRROR_DOWN_GRACE_PERIOD;
+
+	/*
+	 * However the database was in recovery, hence
+	 * we are still within the grace period, and
+	 * we should retry.
+	 */
+	PMAcceptingConnectionsStartTime = ((pg_time_t) time(NULL)) - FTS_MARKING_MIRROR_DOWN_GRACE_PERIOD/2;
+
+	expect_lwlock(LW_SHARED);
+	expect_ereport();
+	GetMirrorStatus(&response);
+
+	assert_true(response.RequestRetry);
+}
+
+void
+test_GetMirrorStatus_Overflow(void **state)
+{
+	FtsResponse response;
+	WalSndCtlData data;
+
+	max_wal_senders = 1;
+	WalSndCtl = &data;
+	data.walsnds[0].pid = 0;
+	/*
+	 * This would make sure Mirror is reported as DOWN, as grace period
+	 * duration is taken into account.
+	 */
+	data.walsnds[0].marked_pid_zero_at_time = INT64_MAX;
+	PMAcceptingConnectionsStartTime = ((pg_time_t) time(NULL));
+
+	expect_lwlock(LW_SHARED);
+	GetMirrorStatus(&response);
+
+	assert_false(response.RequestRetry);
 	assert_false(response.IsMirrorUp);
 	assert_false(response.IsInSync);
 }
@@ -122,6 +237,9 @@ main(int argc, char* argv[])
 
 	const UnitTest tests[] = {
 		unit_test(test_GetMirrorStatus_Pid_Zero),
+		unit_test(test_GetMirrorStatus_RequestRetry),
+		unit_test(test_GetMirrorStatus_Delayed_AcceptingConnectionsStartTime),
+		unit_test(test_GetMirrorStatus_Overflow),
 		unit_test(test_GetMirrorStatus_WALSNDSTATE_STARTUP),
 		unit_test(test_GetMirrorStatus_WALSNDSTATE_BACKUP),
 		unit_test(test_GetMirrorStatus_WALSNDSTATE_CATCHUP),

--- a/src/include/utils/timestamp.h
+++ b/src/include/utils/timestamp.h
@@ -207,10 +207,6 @@ extern TimestampTz PgStartTime;
 /* Set at configuration reload */
 extern TimestampTz PgReloadTime;
 
-/* Set at configuration reload */
-extern TimestampTz PgReloadTime;
-
-
 /*
  * timestamp.c prototypes
  */


### PR DESCRIPTION
Added additional global timestamp to track the end of recovery where
database server is ready to accept connections in variable
PMAcceptingConnectionsStartTime.

During checking mirror status, we compute the grace period not only
based on when last wal sender died, but also based on when recovery
process finished.

This will fix the issue where the mirror is marked down due to long
recovery time on the primary.

Co-authored-by: Ashwin Agrawal <aagrawal@pivotal.io>
Co-authored-by: Xin Zhang <xzhang@pivotal.io>