### PR TITLE
Avoid checking fault_name for "skip" fault type.

### DIFF
--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -719,38 +719,6 @@ FaultInjector_NewHashEntry(
 		
 		goto exit;
 	}
-	
-	if (entry->faultInjectorType == FaultInjectorTypeSkip)
-	{
-		switch (entry->faultInjectorIdentifier)
-		{
-			case Checkpoint:
-			case FsyncCounter:
-			case BgBufferSyncDefaultLogic:
-
-			case InterconnectStopAckIsLost:
-			case SendQEDetailsInitBackend:
-			case ExecutorRunHighProcessed:
-			case FtsProbe:
-			case AppendOnlySkipCompression:
-			case SyncRepQueryCancel:
-
-				break;
-			default:
-				
-				FiLockRelease();
-				status = STATUS_ERROR;
-				ereport(WARNING,
-						(errmsg("could not insert fault injection, fault type not supported"
-								"fault name:'%s' fault type:'%s' ",
-								entry->faultName,
-								FaultInjectorTypeEnumToString[entry->faultInjectorType])));
-				snprintf(entry->bufOutput, sizeof(entry->bufOutput), 
-						 "could not insert fault injection, fault type not supported");
-				
-				goto exit;
-		}
-	}
 
 	entryLocal = FaultInjector_InsertHashEntry(entry->faultName, &exists);
 		


### PR DESCRIPTION
Can't find rational for perfmoring strict checks on which all faults
are supported for skip fault. Skip fault type is like any other fault
type should just work for any fault, shouldn't be treated
specially. Having this checking just needs extra place to update for
any type wish to use skip fault.