### PR TITLE
Add watchdog to gpfdist

### DIFF
--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -32,6 +32,7 @@
 #include <netinet/in.h>
 #include <netdb.h>
 #include <arpa/inet.h>
+#include <pthread.h>
 #define SOCKET int
 #ifndef closesocket
 #define closesocket(x)   close(x)
@@ -203,6 +204,7 @@ static struct
 	BIO 			*bio_err;	/* for SSL */
 	SSL_CTX 		*server_ctx;/* for SSL */
 #endif
+	int 			wdtimer; /* Kill gpfdist after k seconds of inactivity. 0 to disable. */
 } gcb;
 
 /*  A session */
@@ -367,6 +369,12 @@ static void * pcalloc_safe(request_t *r, apr_pool_t *pool, apr_size_t size, cons
 static void process_term_signal(int sig,short event,void* arg);
 int gpfdist_init(int argc, const char* const argv[]);
 int gpfdist_run(void);
+
+static void delay_watchdog_timer(void);
+#ifndef WIN32
+static apr_time_t shutdown_time;
+static void* watchdog_thread(void*);
+#endif
 
 /*
  * block_fill_header
@@ -1305,6 +1313,7 @@ session_get_block(const request_t* r, block_t* retblock, char* line_delim_str, i
 	/* read data from our filestream as a chunk with whole data rows */
 
 	size = fstream_read(session->fstream, retblock->data, opt.m, &fos, whole_rows, line_delim_str, line_delim_length);
+	delay_watchdog_timer();
 
 	if (size == 0)
 	{
@@ -1575,6 +1584,7 @@ static int session_attach(request_t* r)
 		/* try opening the fstream */
 		gprintlnif(r, "new session trying to open the data stream");
 		fstream = fstream_open(r->path, &fstream_options, &response_code, &response_string);
+		delay_watchdog_timer();
 
 		if (!fstream)
 		{
@@ -2999,6 +3009,7 @@ static void handle_post_request(request_t *r, int header_end)
 		if(r->in.davailable == 0)
 		{
 			wrote = fstream_write(session->fstream, r->in.dbuf, data_bytes_in_req, 1, r->line_delim_str, r->line_delim_length);
+			delay_watchdog_timer();
 			if(wrote == -1)
 			{
 				/* write error */
@@ -3066,6 +3077,7 @@ static void handle_post_request(request_t *r, int header_end)
 				/* only write up to end of last row */
 				wrote = fstream_write(session->fstream, r->in.dbuf, r->in.dbuftop, 1, r->line_delim_str, r->line_delim_length);
 				gdebug(r, "wrote %d bytes to file", wrote);
+				delay_watchdog_timer();
 
 				if (wrote == -1)
 				{
@@ -3571,6 +3583,21 @@ int gpfdist_init(int argc, const char* const argv[])
 	 * must identify errors in calls above and return non-zero for them
 	 * behaviour required for the Windows service case
 	 */
+
+#ifndef WIN32
+	char* wd = getenv("GPFDIST_WATCHDOG_TIMER");
+	if (wd != NULL)
+	{
+		gcb.wdtimer = atoi(wd);
+		if (gcb.wdtimer > 0)
+		{
+			gprintln(NULL, "Watchdog enabled, abort in %d seconds if no activity", gcb.wdtimer);
+			shutdown_time = apr_time_now() + gcb.wdtimer * APR_USEC_PER_SEC;
+			static pthread_t watchdog;
+			pthread_create(&watchdog, 0, watchdog_thread, 0);
+		}
+	}
+#endif
 	return 0;
 }
 
@@ -4326,3 +4353,27 @@ pcalloc_safe(request_t *r, apr_pool_t *pool, apr_size_t size, const char *fmt, .
 
 	return result;
 }
+
+#ifndef WIN32
+static void* watchdog_thread(void* p)
+{
+	while(apr_time_now() < shutdown_time)
+	{
+		sleep(1);
+	}
+	gprintln(NULL, "Watchdog timer expired, abort gpfdist");
+	abort();
+}
+
+static void delay_watchdog_timer()
+{
+	if (gcb.wdtimer > 0)
+	{
+		shutdown_time = apr_time_now() + gcb.wdtimer * APR_USEC_PER_SEC;
+	}
+}
+#else
+static void delay_watchdog_timer()
+{
+}
+#endif

--- a/src/bin/gpfdist/regress/Makefile
+++ b/src/bin/gpfdist/regress/Makefile
@@ -11,9 +11,12 @@ endif
 PSQLDIR = $(prefix)/bin
 REGRESS_OPTS = --init-file=init_file
 
-installcheck:
+installcheck: watchdog
 	@-cp -rf $(MASTER_DATA_DIRECTORY)/gpfdists data/gpfdist_ssl/certs_matching
 	$(top_builddir)/src/test/regress/pg_regress --psqldir=$(PSQLDIR) --dbname=gpfdist_regression $(REGRESS) $(REGRESS_OPTS)
+
+watchdog:
+	sh test_watchdog.sh
 
 clean:
 	rm -rf regression.* sql results expected

--- a/src/bin/gpfdist/regress/test_watchdog.sh
+++ b/src/bin/gpfdist/regress/test_watchdog.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+GPFDIST_PID=gpfdist.pid
+
+export GPFDIST_WATCHDOG_TIMER=3
+gpfdist &
+PID=$!
+
+sleep 5
+ps -p $PID
+if [ $? -eq 0 ]; then
+# gpfdist not aborted by watchdog, failed
+kill -9 $PID
+wait $PID
+echo "gpfdist still running, failed"
+exit 1
+fi
+
+# gpfdist aborted by watchdog, passed
+wait $PID
+echo "gpfdist stop by watchdog, success"
+exit 0


### PR DESCRIPTION
Watchdog mechanism will prevent gpfdist from hanging forever, this
is a workaround for hang issues that are difficult to reproduce.
set environment variable GPFDIST_WATCHDOG_TIMER to enable.