### PR TITLE
Fix command tag for ALTER EXTERNAL TABLE.

### DIFF
--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -2209,20 +2209,11 @@ CreateCommandTag(Node *parsetree)
 		case T_AlterTableStmt:
 			switch (((AlterTableStmt *) parsetree)->relkind)
 			{
-				AlterTableStmt *stmt = (AlterTableStmt *) parsetree;
-
-				/*
-				 * We might be supporting ALTER INDEX here, so set the
-				 * completion tag appropriately. Catch all other possibilities
-				 * with ALTER TABLE
-				 */
-
-				if (stmt->relkind == OBJECT_INDEX)
-					tag = "ALTER INDEX";
-				else if (stmt->relkind == OBJECT_EXTTABLE)
-					tag = "ALTER EXTERNAL TABLE";
 				case OBJECT_TABLE:
 					tag = "ALTER TABLE";
+					break;
+				case OBJECT_EXTTABLE:
+					tag = "ALTER EXTERNAL TABLE";
 					break;
 				case OBJECT_INDEX:
 					tag = "ALTER INDEX";


### PR DESCRIPTION
The code was quite confused on whether this was a switch-case or an if-else
statement..

The command tag is unfortunately not included in pg_regress output, so this
is not reflected in regression tests, even though we have ALTER EXTERNAL
TABLE commands in the test suite.

Fixes github issue 4377.