### PR TITLE
Add a test case for autovacuum on template0.

### DIFF
--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -208,4 +208,6 @@ test: psql_gp_commands pg_resetxlog
 # Check for shmem leak for instrumentation slots
 test: instr_in_shmem_verify
 
+test: autovacuum-template0
+
 # end of tests

--- a/src/test/regress/input/autovacuum-template0.source
+++ b/src/test/regress/input/autovacuum-template0.source
@@ -1,0 +1,32 @@
+create or replace function test_consume_xids(int4) returns void
+as '@abs_srcdir@/regress.so', 'test_consume_xids'
+language C;
+
+set debug_burn_xids=on;
+
+-- Autovacuum should take care of anti-XID wraparounds of 'template0'. Because
+-- of that, the age of template0 should not go much above
+-- autovacuum_freeze_max_age (we assume the default of 200 million here).
+select age(datfrozenxid) < 200 * 1000000 from pg_database where datname='template0';
+
+select test_consume_xids(100 * 1000000);
+select test_consume_xids(100 * 1000000);
+select test_consume_xids(10 * 1000000);
+
+-- Wait until autovacuum has processed template0. (But give up after 2 minutes)
+do $$
+begin
+  for i in 1..120 loop
+    if (select age(datfrozenxid) < 200 * 1000000 from pg_database where datname='template0') then
+      raise notice 'template0 is young again';
+      return;
+    end if;
+    perform pg_sleep(1);
+  end loop;
+  raise notice 'FAIL: template0 is not being frozen!';
+end;
+$$;
+
+-- But autovacuum should not touch other databases. Hence, our database
+-- should be well above the 200 million mark.
+select age(datfrozenxid) > 200 * 1000000 from pg_database where datname=current_database();

--- a/src/test/regress/output/autovacuum-template0.source
+++ b/src/test/regress/output/autovacuum-template0.source
@@ -1,0 +1,53 @@
+create or replace function test_consume_xids(int4) returns void
+as '@abs_srcdir@/regress.so', 'test_consume_xids'
+language C;
+set debug_burn_xids=on;
+-- Autovacuum should take care of anti-XID wraparounds of 'template0'. Because
+-- of that, the age of template0 should not go much above
+-- autovacuum_freeze_max_age (we assume the default of 200 million here).
+select age(datfrozenxid) < 200 * 1000000 from pg_database where datname='template0';
+ ?column? 
+----------
+ t
+(1 row)
+
+select test_consume_xids(100 * 1000000);
+ test_consume_xids 
+-------------------
+ 
+(1 row)
+
+select test_consume_xids(100 * 1000000);
+ test_consume_xids 
+-------------------
+ 
+(1 row)
+
+select test_consume_xids(10 * 1000000);
+ test_consume_xids 
+-------------------
+ 
+(1 row)
+
+-- Wait until autovacuum has processed template0. (But give up after 2 minutes)
+do $$
+begin
+  for i in 1..120 loop
+    if (select age(datfrozenxid) < 200 * 1000000 from pg_database where datname='template0') then
+      raise notice 'template0 is young again';
+      return;
+    end if;
+    perform pg_sleep(1);
+  end loop;
+  raise notice 'FAIL: template0 is not being frozen!';
+end;
+$$;
+NOTICE:  template0 is young again
+-- But autovacuum should not touch other databases. Hence, our database
+-- should be well above the 200 million mark.
+select age(datfrozenxid) > 200 * 1000000 from pg_database where datname=current_database();
+ ?column? 
+----------
+ t
+(1 row)
+


### PR DESCRIPTION
Commit 4e655714 enabled autovacuum for template0, but didn't include any
tests to check that autovacuum really runs on template0. This commit adds
that.