### PR TITLE
Re-enable RETURNING tests.

### DIFF
--- a/src/test/regress/expected/rangefuncs.out
+++ b/src/test/regress/expected/rangefuncs.out
@@ -488,12 +488,6 @@ DROP FUNCTION foo(int);
 --
 -- some tests on SQL functions with RETURNING
 --
--- start_ignore
--- GPDB_90_MERGE_FIXME: GPDB doesn't currently support the RETURNING clause.
--- These tests have therefore been disabled. I'm marking this as a FIXME for
--- the 9.0 merge, because I think we'll tackle the RETURNING clause and try
--- to make that work again at that time, once we merge the ModifyTable node
--- from the upstream.
 create temp table tt(f1 serial, data text);
 NOTICE:  CREATE TABLE will create implicit sequence "tt_f1_seq" for serial column "tt.f1"
 create function insert_tt(text) returns int as
@@ -667,8 +661,6 @@ select * from tt_log;
  16 | barlog
 (2 rows)
 
--- end of disabled RETURNING tests.
--- end_ignore
 -- test case for a whole-row-variable bug
 create function foo1(n integer, out a text, out b text)
   returns setof record
@@ -715,8 +707,6 @@ select * from array_to_set(array['one', 'two']); -- fail
 ERROR:  a column definition list is required for functions returning "record"
 LINE 1: select * from array_to_set(array['one', 'two']);
                       ^
--- start_ignore
--- GPDB_90_MERGE_FIXME: disable RETURNING clause tests (see above).
 create temp table foo(f1 int8, f2 int8);
 create function testfoo() returns record as $$
   insert into foo values (1,2) returning *;
@@ -760,8 +750,6 @@ ERROR:  a column definition list is required for functions returning "record"
 LINE 1: select * from testfoo();
                       ^
 drop function testfoo();
--- end of disabled RETURNING tests.
--- end_ignore
 --
 -- Check some cases involving dropped columns in a rowtype result
 --

--- a/src/test/regress/expected/rangefuncs_optimizer.out
+++ b/src/test/regress/expected/rangefuncs_optimizer.out
@@ -488,12 +488,6 @@ DROP FUNCTION foo(int);
 --
 -- some tests on SQL functions with RETURNING
 --
--- start_ignore
--- GPDB_90_MERGE_FIXME: GPDB doesn't currently support the RETURNING clause.
--- These tests have therefore been disabled. I'm marking this as a FIXME for
--- the 9.0 merge, because I think we'll tackle the RETURNING clause and try
--- to make that work again at that time, once we merge the ModifyTable node
--- from the upstream.
 create temp table tt(f1 serial, data text);
 NOTICE:  CREATE TABLE will create implicit sequence "tt_f1_seq" for serial column "tt.f1"
 create function insert_tt(text) returns int as
@@ -667,8 +661,6 @@ select * from tt_log;
  16 | barlog
 (2 rows)
 
--- end of disabled RETURNING tests.
--- end_ignore
 -- test case for a whole-row-variable bug
 create function foo1(n integer, out a text, out b text)
   returns setof record
@@ -715,8 +707,6 @@ select * from array_to_set(array['one', 'two']); -- fail
 ERROR:  a column definition list is required for functions returning "record"
 LINE 1: select * from array_to_set(array['one', 'two']);
                       ^
--- start_ignore
--- GPDB_90_MERGE_FIXME: disable RETURNING clause tests (see above).
 create temp table foo(f1 int8, f2 int8);
 create function testfoo() returns record as $$
   insert into foo values (1,2) returning *;
@@ -760,8 +750,6 @@ ERROR:  a column definition list is required for functions returning "record"
 LINE 1: select * from testfoo();
                       ^
 drop function testfoo();
--- end of disabled RETURNING tests.
--- end_ignore
 --
 -- Check some cases involving dropped columns in a rowtype result
 --

--- a/src/test/regress/sql/rangefuncs.sql
+++ b/src/test/regress/sql/rangefuncs.sql
@@ -290,12 +290,6 @@ DROP FUNCTION foo(int);
 -- some tests on SQL functions with RETURNING
 --
 
--- start_ignore
--- GPDB_90_MERGE_FIXME: GPDB doesn't currently support the RETURNING clause.
--- These tests have therefore been disabled. I'm marking this as a FIXME for
--- the 9.0 merge, because I think we'll tackle the RETURNING clause and try
--- to make that work again at that time, once we merge the ModifyTable node
--- from the upstream.
 create temp table tt(f1 serial, data text);
 
 create function insert_tt(text) returns int as
@@ -351,9 +345,6 @@ select * from tt;
 -- which is expected.
 select * from tt_log;
 
--- end of disabled RETURNING tests.
--- end_ignore
-
 -- test case for a whole-row-variable bug
 create function foo1(n integer, out a text, out b text)
   returns setof record
@@ -379,8 +370,6 @@ select array_to_set(array['one', 'two']);
 select * from array_to_set(array['one', 'two']) as t(f1 int,f2 text);
 select * from array_to_set(array['one', 'two']); -- fail
 
--- start_ignore
--- GPDB_90_MERGE_FIXME: disable RETURNING clause tests (see above).
 create temp table foo(f1 int8, f2 int8);
 
 create function testfoo() returns record as $$
@@ -402,8 +391,6 @@ select * from testfoo() as t(f1 int8,f2 int8);
 select * from testfoo(); -- fail
 
 drop function testfoo();
--- end of disabled RETURNING tests.
--- end_ignore
 
 --
 -- Check some cases involving dropped columns in a rowtype result


### PR DESCRIPTION
Commit 8a736a5fb2 made INSERT/UPDATE/DELETE RETURNING work again. But
forgot to also re-enable these upstream regression tests.