### PR TITLE
Get rid of pg_exttable.fmterrtbl

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -3959,7 +3959,7 @@ class GPObject:
                 for issue in issues:
                     # Get schemaname.tablename corresponding to oid
                     for key in issue.pkeys:
-                        if 'relid' in key or key in ['ev_class', 'reloid', 'fmterrtbl']:
+                        if 'relid' in key or key in ['ev_class', 'reloid']:
                             table_list = db.query(oid_query % issue.pkeys[key]).getresult()
                             if table_list:
                                 if issue.type == 'missing':

--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -2040,9 +2040,9 @@ class gpload:
         sql = sqlFormat % (joinStr, conditionStr)
 
         if log_errors:
-            sql += " WHERE pgext.fmterrtbl = pgext.reloid "
+            sql += " WHERE pgext.logerrors "
         else:
-            sql += " WHERE pgext.fmterrtbl IS NULL "
+            sql += " WHERE NOT pgext.logerrors "
 
         for i, l in enumerate(self.locations):
             sql += " and pgext.urilocation[%s] = %s\n" % (i + 1, quote(l))

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpload.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpload.py
@@ -42,14 +42,14 @@ class GpLoadTestCase(unittest.TestCase):
         self.assertEqual(self.begin, expected_begin_value)
         self.assertEqual(self.commit, expected_commit_value)
 
-    def test_reuse_exttbl_with_errtbl_and_limit(self):
+    def test_reuse_exttbl_with_logerrors_and_limit(self):
         gploader = gpload(['-f', os.path.join(os.path.dirname(__file__), 'gpload_merge.yml')])
         gploader.read_config()
         gploader.locations = [ 'gpfdist://localhost:8080/test' ]
         rejectLimit = '9999'
 
         sql = gploader.get_reuse_exttable_query('csv', 'header', None, {}, None, False)
-        self.assertTrue('pgext.fmterrtbl IS NULL' in sql)
+        self.assertTrue('NOT pgext.logerrors' in sql)
         self.assertTrue('pgext.rejectlimit IS NULL' in sql)
 
     def test_case_merge_transaction(self):

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
@@ -133,7 +133,6 @@ Feature: gpcheckcat tests
         Examples:
           | attrname   | tablename     |
           | reloid     | pg_exttable   |
-          | fmterrtbl  | pg_exttable   |
           | conrelid   | pg_constraint |
 
     @miss_attr_table

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_exttable.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_exttable.xml
@@ -82,12 +82,10 @@
               rows.</entry>
           </row>
           <row>
-            <entry colname="col1"><codeph>fmterrtbl</codeph></entry>
-            <entry colname="col2">oid</entry>
-            <entry colname="col3">pg_class.oid</entry>
-            <entry colname="col4">The object id of the error table where format errors will be
-                  logged.<p><b>NOTE:</b> This column is no longer used and will be removed in a
-                future release.</p></entry>
+            <entry colname="col1"><codeph>logerrors</codeph></entry>
+            <entry colname="col2">bool</entry>
+	    <entry colname="col3"/>
+	    <entry colname="col4"><codeph>1</codeph> to log errors, <codeph>0</codeph> to not.</entry>
           </row>
           <row>
             <entry colname="col1"><codeph>encoding</codeph></entry>

--- a/src/backend/executor/nodeExternalscan.c
+++ b/src/backend/executor/nodeExternalscan.c
@@ -269,7 +269,7 @@ ExecInitExternalScan(ExternalScan *node, EState *estate, int eflags)
 									 node->isMasterOnly,
 									 node->rejLimit,
 									 node->rejLimitInRows,
-									 node->fmterrtbl,
+									 node->logErrors,
 									 node->encoding);
 
 	externalstate->ss.ss_currentRelation = currentRelation;

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -459,18 +459,9 @@ CTranslatorDXLToPlStmt::PtsFromDXLTblScan
 		pes->fmtType = pextentry->fmtcode;
 		pes->isMasterOnly = isMasterOnly;
 		GPOS_ASSERT((IMDRelation::EreldistrMasterOnly == pmdrelext->Ereldistribution()) == isMasterOnly);
+		pes->logErrors = pextentry->logerrors;
 		pes->rejLimit = pmdrelext->IRejectLimit();
 		pes->rejLimitInRows = pmdrelext->FRejLimitInRows();
-
-		IMDId *pmdidFmtErrTbl = pmdrelext->PmdidFmtErrRel();
-		if (NULL == pmdidFmtErrTbl)
-		{
-			pes->fmterrtbl = InvalidOid;
-		}
-		else
-		{
-			pes->fmterrtbl = CMDIdGPDB::PmdidConvert(pmdidFmtErrTbl)->OidObjectId();
-		}
 
 		pes->encoding = pextentry->encoding;
 		pes->scancounter = m_ulExternalScanCounter++;

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -660,13 +660,6 @@ CTranslatorRelcacheToDXL::Pmdrel
 	{
 		ExtTableEntry *extentry = gpdb::Pexttable(oid);
 
-		// get format error table id
-		IMDId *pmdidFmtErrTbl = NULL;
-		if (InvalidOid != extentry->fmterrtbl)
-		{
-			pmdidFmtErrTbl = GPOS_NEW(pmp) CMDIdGPDB(extentry->fmterrtbl);
-		}
-
 		pmdrel = GPOS_NEW(pmp) CMDRelationExternalGPDB
 							(
 							pmp,
@@ -682,7 +675,11 @@ CTranslatorRelcacheToDXL::Pmdrel
 							pdrgpmdidCheckConstraints,
 							extentry->rejectlimit,
 							('r' == extentry->rejectlimittype),
-							pmdidFmtErrTbl
+							NULL /* it's sufficient to pass NULL here since ORCA
+								doesn't really make use of the logerrors value.
+								In case of converting the DXL returned from to
+								PlanStmt, currently the code looks up the information
+								from catalog and fill in the required values into the ExternalScan */
 							);
 	}
 	else

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -534,7 +534,7 @@ _copyExternalScan(ExternalScan *from)
 	COPY_SCALAR_FIELD(isMasterOnly);
 	COPY_SCALAR_FIELD(rejLimit);
 	COPY_SCALAR_FIELD(rejLimitInRows);
-	COPY_SCALAR_FIELD(fmterrtbl);
+	COPY_SCALAR_FIELD(logErrors);
 	COPY_SCALAR_FIELD(encoding);
 	COPY_SCALAR_FIELD(scancounter);
 

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -578,7 +578,7 @@ _outExternalScan(StringInfo str, ExternalScan *node)
 	WRITE_BOOL_FIELD(isMasterOnly);
 	WRITE_INT_FIELD(rejLimit);
 	WRITE_BOOL_FIELD(rejLimitInRows);
-	WRITE_OID_FIELD(fmterrtbl);
+	WRITE_BOOL_FIELD(logErrors);
 	WRITE_INT_FIELD(encoding);
 	WRITE_INT_FIELD(scancounter);
 }

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -1684,7 +1684,7 @@ _readExternalScan(void)
 	READ_BOOL_FIELD(isMasterOnly);
 	READ_INT_FIELD(rejLimit);
 	READ_BOOL_FIELD(rejLimitInRows);
-	READ_OID_FIELD(fmterrtbl);
+	READ_BOOL_FIELD(logErrors);
 	READ_INT_FIELD(encoding);
 	READ_INT_FIELD(scancounter);
 

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -120,7 +120,7 @@ static ExternalScan *make_externalscan(List *qptlist,
 				  bool ismasteronly,
 				  int rejectlimit,
 				  bool rejectlimitinrows,
-				  Oid fmterrtableOid,
+				  bool logerrors,
 				  int encoding);
 static IndexScan *make_indexscan(List *qptlist, List *qpqual, Index scanrelid,
 			   Oid indexid, List *indexqual, List *indexqualorig,
@@ -1210,7 +1210,7 @@ create_externalscan_plan(PlannerInfo *root, Path *best_path,
 	bool		ismasteronly = false;
 	bool		islimitinrows = false;
 	int			rejectlimit = -1;
-	Oid			fmtErrTblOid = InvalidOid;
+	bool		logerrors = false;
 	ExtTableEntry *ext = rel->extEntry;
 	List	   *fmtopts;
 
@@ -1250,7 +1250,7 @@ create_externalscan_plan(PlannerInfo *root, Path *best_path,
 	{
 		islimitinrows = (ext->rejectlimittype == 'r' ? true : false);
 		rejectlimit = ext->rejectlimit;
-		fmtErrTblOid = ext->fmterrtbl;
+		logerrors = ext->logerrors;
 	}
 
 	scan_plan = make_externalscan(tlist,
@@ -1262,7 +1262,7 @@ create_externalscan_plan(PlannerInfo *root, Path *best_path,
 								  ismasteronly,
 								  rejectlimit,
 								  islimitinrows,
-								  fmtErrTblOid,
+								  logerrors,
 								  ext->encoding);
 
 	copy_path_costsize(root, &scan_plan->scan.plan, best_path);
@@ -3847,7 +3847,7 @@ make_externalscan(List *qptlist,
 				  bool ismasteronly,
 				  int rejectlimit,
 				  bool rejectlimitinrows,
-				  Oid fmterrtableOid,
+				  bool logerrors,
 				  int encoding)
 {
 	ExternalScan *node = makeNode(ExternalScan);
@@ -3868,7 +3868,7 @@ make_externalscan(List *qptlist,
 	node->isMasterOnly = ismasteronly;
 	node->rejLimit = rejectlimit;
 	node->rejLimitInRows = rejectlimitinrows;
-	node->fmterrtbl = fmterrtableOid;
+	node->logErrors = logerrors;
 	node->encoding = encoding;
 	node->scancounter = scancounter++;
 

--- a/src/include/access/fileam.h
+++ b/src/include/access/fileam.h
@@ -57,7 +57,7 @@ extern FileScanDesc external_beginscan(Relation relation,
 				   uint32 scancounter, List *uriList,
 				   List *fmtOpts, char fmtType, bool isMasterOnly,
 				   int rejLimit, bool rejLimitInRows,
-				   Oid fmterrtbl, int encoding);
+				   bool logErrors, int encoding);
 extern void external_rescan(FileScanDesc scan);
 extern void external_endscan(FileScanDesc scan);
 extern void external_stopscan(FileScanDesc scan);

--- a/src/include/catalog/pg_exttable.h
+++ b/src/include/catalog/pg_exttable.h
@@ -41,14 +41,13 @@ CATALOG(pg_exttable,6040) BKI_WITHOUT_OIDS
 	text	command;			/* the command string to EXECUTE */
 	int4	rejectlimit;		/* error count reject limit per segment */
 	char	rejectlimittype;	/* 'r' (rows) or 'p' (percent) */
-	Oid		fmterrtbl;			/* the data format error table oid in pg_class */
+	bool	logerrors;			/* 't' to log errors into file */
 	int4	encoding;			/* character encoding of this external table */
 	bool	writable;			/* 't' if writable, 'f' if readable */
 } FormData_pg_exttable;
 
 /* GPDB added foreign key definitions for gpcheckcat. */
 FOREIGN_KEY(reloid REFERENCES pg_class(oid));
-FOREIGN_KEY(fmterrtbl REFERENCES pg_class(oid));
 
 /* ----------------
  *		Form_pg_exttable corresponds to a pointer to a tuple with
@@ -72,7 +71,7 @@ typedef FormData_pg_exttable *Form_pg_exttable;
 #define Anum_pg_exttable_command			7
 #define Anum_pg_exttable_rejectlimit		8
 #define Anum_pg_exttable_rejectlimittype	9
-#define Anum_pg_exttable_fmterrtbl			10
+#define Anum_pg_exttable_logerrors			10
 #define Anum_pg_exttable_encoding			11
 #define Anum_pg_exttable_writable			12
 
@@ -91,7 +90,7 @@ typedef struct ExtTableEntry
 	char*	command;
 	int		rejectlimit;
 	char	rejectlimittype;
-	Oid		fmterrtbl;
+	bool	logerrors;
     int		encoding;
     bool	iswritable;
     bool	isweb;		/* extra state, not cataloged */
@@ -107,7 +106,7 @@ extern void InsertExtTableEntry(Oid 	tbloid,
 					char	rejectlimittype,
 					char*	commandString,
 					int		rejectlimit,
-					Oid		fmtErrTblOid,
+					bool	logerrors,
 					int		encoding,
 					Datum	formatOptStr,
 					Datum	optionsStr,

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -725,7 +725,7 @@ typedef struct ExternalScan
 	bool		isMasterOnly;   /* true for EXECUTE on master seg only */
 	int			rejLimit;       /* reject limit (-1 for no sreh)      */
 	bool		rejLimitInRows; /* true if ROWS false if PERCENT      */
-	Oid			fmterrtbl;      /* format error table, InvalidOid if none */
+	bool		logErrors;      /* true to log errors into file       */
 	int			encoding;		/* encoding of external table data    */
 	uint32      scancounter;	/* counter incr per scan node created */
 

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -418,13 +418,6 @@ CREATE TABLE exttab_ctas_2 AS select * from exttab_basic_7;
 SELECT * from exttab_ctas_2 order by i;
 -- Error table should have additional rows that were rejected by the above query
 SELECT count(*) from gp_read_error_log('exttab_basic_7');
--- pg_exttable.fmterrtbl references to itself for external table with error logs
-CREATE EXTERNAL TABLE exttab_error_log( i int, j text )
-LOCATION ('file://@hostname@@abs_srcdir@/data/exttab.data') FORMAT 'TEXT' (DELIMITER '|')
-LOG ERRORS SEGMENT REJECT LIMIT 2;
-SELECT reloid = fmterrtbl FROM pg_exttable
-WHERE reloid = (SELECT oid from pg_class where relname ilike 'exttab_error_log');
-
 -- Drop external table gets rid off error logs
 DROP EXTERNAL TABLE IF EXISTS exttab_error_log;
 CREATE EXTERNAL TABLE exttab_error_log( i int, j text )

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -707,17 +707,6 @@ SELECT count(*) from gp_read_error_log('exttab_basic_7');
      4
 (1 row)
 
--- pg_exttable.fmterrtbl references to itself for external table with error logs
-CREATE EXTERNAL TABLE exttab_error_log( i int, j text )
-LOCATION ('file://@hostname@@abs_srcdir@/data/exttab.data') FORMAT 'TEXT' (DELIMITER '|')
-LOG ERRORS SEGMENT REJECT LIMIT 2;
-SELECT reloid = fmterrtbl FROM pg_exttable
-WHERE reloid = (SELECT oid from pg_class where relname ilike 'exttab_error_log');
- ?column? 
-----------
- t
-(1 row)
-
 -- Drop external table gets rid off error logs
 DROP EXTERNAL TABLE IF EXISTS exttab_error_log;
 NOTICE:  table "exttab_error_log" does not exist, skipping

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/queries/basic/exttab/errlog/expected/basic.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/queries/basic/exttab/errlog/expected/basic.ans
@@ -243,34 +243,6 @@ SELECT count(*) from gp_read_error_log('exttab_basic_7');
      4
 (1 row)
 
--- Test that pg_exttable.fmterrtbl references to itself for external table with error logs
-DROP EXTERNAL TABLE IF EXISTS exttab_error_log;
-DROP EXTERNAL TABLE
-CREATE EXTERNAL TABLE exttab_error_log( i int, j text ) 
-LOCATION ('gpfdist://@host@:@port@/exttab_union_1.tbl') FORMAT 'TEXT' (DELIMITER '|') 
-LOG ERRORS SEGMENT REJECT LIMIT 2;
-CREATE EXTERNAL TABLE
-SELECT reloid = fmterrtbl FROM pg_exttable
-WHERE reloid = (SELECT oid from pg_class where relname ilike 'exttab_error_log');
- ?column? 
-----------
- t
-(1 row)
-
-DROP EXTERNAL TABLE IF EXISTS exttab_error_tbl;
-DROP EXTERNAL TABLE
-CREATE EXTERNAL TABLE exttab_error_tbl( i int, j text ) 
-LOCATION ('gpfdist://@host@:@port@/exttab_union_1.tbl') FORMAT 'TEXT' (DELIMITER '|') 
-LOG ERRORS INTO sample_errtbl SEGMENT REJECT LIMIT 2;
-CREATE EXTERNAL TABLE
--- Should be False
-SELECT reloid = fmterrtbl FROM pg_exttable
-WHERE reloid = (SELECT oid from pg_class where relname ilike 'exttab_error_tbl');
- ?column? 
-----------
- f
-(1 row)
-
 -- Test that drop external table gets rid off error logs
 DROP EXTERNAL TABLE IF EXISTS exttab_error_log;
 DROP EXTERNAL TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/queries/basic/exttab/errlog/sql/basic.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/queries/basic/exttab/errlog/sql/basic.sql
@@ -133,28 +133,6 @@ SELECT * from exttab_ctas_2 order by i;
 -- Error table should have additional rows that were rejected by the above query
 SELECT count(*) from gp_read_error_log('exttab_basic_7');
 
-
--- Test that pg_exttable.fmterrtbl references to itself for external table with error logs
-DROP EXTERNAL TABLE IF EXISTS exttab_error_log;
-
-CREATE EXTERNAL TABLE exttab_error_log( i int, j text ) 
-LOCATION ('gpfdist://@host@:@port@/exttab_union_1.tbl') FORMAT 'TEXT' (DELIMITER '|') 
-LOG ERRORS SEGMENT REJECT LIMIT 2;
-
-SELECT reloid = fmterrtbl FROM pg_exttable
-WHERE reloid = (SELECT oid from pg_class where relname ilike 'exttab_error_log');
-
-DROP EXTERNAL TABLE IF EXISTS exttab_error_tbl;
-
-CREATE EXTERNAL TABLE exttab_error_tbl( i int, j text ) 
-LOCATION ('gpfdist://@host@:@port@/exttab_union_1.tbl') FORMAT 'TEXT' (DELIMITER '|') 
-LOG ERRORS INTO sample_errtbl SEGMENT REJECT LIMIT 2;
-
--- Should be False
-SELECT reloid = fmterrtbl FROM pg_exttable
-WHERE reloid = (SELECT oid from pg_class where relname ilike 'exttab_error_tbl');
-
-
 -- Test that drop external table gets rid off error logs
 DROP EXTERNAL TABLE IF EXISTS exttab_error_log;
 


### PR DESCRIPTION
The pg_exttable.fmterrtbl column stored the OID of the error table, but
without an error table it is just set to the OID of the external table.
That is not necessary, there are other columns which indicate if error
logging is enabled. Therefore this column can be removed.