### PR TITLE
Remove now-unnecessary get_rewrite_freeze_xid() function.

### DIFF
--- a/src/backend/access/heap/rewriteheap.c
+++ b/src/backend/access/heap/rewriteheap.c
@@ -671,10 +671,3 @@ raw_heap_insert(RewriteState state, HeapTuple tup)
 	if (heaptup != tup)
 		heap_freetuple(heaptup);
 }
-
-TransactionId
-get_rewrite_freeze_xid(RewriteState state)
-{
-	Assert(state != NULL);
-	return state->rs_freeze_xid;
-}

--- a/src/backend/commands/cluster.c
+++ b/src/backend/commands/cluster.c
@@ -1093,9 +1093,6 @@ copy_heap_data(Oid OIDNewHeap, Oid OIDOldHeap, Oid OIDOldIndex,
 	else
 		heap_endscan(heapScan);
 
-	/* Update FreezeXid based on adjustments made by heap_freeze_tuple() */
-	FreezeXid = get_rewrite_freeze_xid(rwstate);
-
 	/* Write out any remaining tuples, and fsync if needed */
 	end_heap_rewrite(rwstate);
 

--- a/src/include/access/rewriteheap.h
+++ b/src/include/access/rewriteheap.h
@@ -26,6 +26,5 @@ extern void end_heap_rewrite(RewriteState state);
 extern void rewrite_heap_tuple(RewriteState state, HeapTuple oldTuple,
 				   HeapTuple newTuple);
 extern void rewrite_heap_dead_tuple(RewriteState state, HeapTuple oldTuple);
-extern TransactionId get_rewrite_freeze_xid(RewriteState state);
 
 #endif   /* REWRITE_HEAP_H */


### PR DESCRIPTION
This function was made unnecessary by commit b3f300b945, which changed
GetOldestXmin() to "include" any distributed snapshots, too. rewriteheap.c
no longer changes the freezeXid it's given, so there's no need for a
function to get the new value back from it.