### PR TITLE
docs - perms for hdfs files backing pxf ext tbls are for gp user

### DIFF
--- a/gpdb-doc/markdown/pxf/cfginitstart_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/cfginitstart_pxf.html.md.erb
@@ -56,7 +56,7 @@ You must explicitly initialize the PXF service instance. This one-time initializ
 Before initializing PXF in your Greenplum Database cluster, ensure that you have:
 
 - Installed and configured the required Hadoop clients on each Greenplum Database segment host. Refer to [Installing and Configuring Hadoop Clients for PXF](client_instcfg.html) for instructions.
-- Granted read permission to the HDFS files and directories that will be accessed as external tables in Greenplum Database. If user impersonation is enabled (the default), You must grant this permission to each Greenplum Database user/role name that will use external tables that reference the HDFS files. If user impersonation is not enabled, you must grant this permission to the `gpadmin` user.
+- Granted read permission to the HDFS files and directories that will be accessed as external tables in Greenplum Database. If user impersonation is enabled (the default), you must grant this permission to each Greenplum Database user/role name that will use external tables that reference the HDFS files. If user impersonation is not enabled, you must grant this permission to the `gpadmin` user.
  
 ### <a id="init-pxf-steps"></a>Procedure
 

--- a/gpdb-doc/markdown/pxf/cfginitstart_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/cfginitstart_pxf.html.md.erb
@@ -113,7 +113,7 @@ Perform the following procedure to start PXF on each segment host in your Greenp
 
 ## <a id="stop_pxf"></a>Stopping PXF
 
-You must explicitly stop PXF on each segment host in your Greenplum Database cluster when you upgrade PXF. Only the `gpadmin` user can stop the PXF service.
+If you must stop PXF, for example if you are upgrading PXF, you must explicitly stop PXF on each segment host in your Greenplum Database cluster. Only the `gpadmin` user can stop the PXF service.
 
 Perform the following procedure to stop PXF on each segment host in your Greenplum Database cluster.  You will use the `gpssh` command and a `seghostfile` to run the command on multiple hosts.
 

--- a/gpdb-doc/markdown/pxf/cfginitstart_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/cfginitstart_pxf.html.md.erb
@@ -56,7 +56,7 @@ You must explicitly initialize the PXF service instance. This one-time initializ
 Before initializing PXF in your Greenplum Database cluster, ensure that you have:
 
 - Installed and configured the required Hadoop clients on each Greenplum Database segment host. Refer to [Installing and Configuring Hadoop Clients for PXF](client_instcfg.html) for instructions.
-- Granted read permission to the HDFS files and directories that will be accessed as external tables in Greenplum Database. You must grant this permission to all Greenplum Database users that will use external tables that reference the HDFS files.
+- Granted read permission to the HDFS files and directories that will be accessed as external tables in Greenplum Database. If user impersonation is enabled (the default), You must grant this permission to each Greenplum Database user/role name that will use external tables that reference the HDFS files. If user impersonation is not enabled, you must grant this permission to the `gpadmin` user.
  
 ### <a id="init-pxf-steps"></a>Procedure
 

--- a/gpdb-doc/markdown/pxf/cfginitstart_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/cfginitstart_pxf.html.md.erb
@@ -124,10 +124,10 @@ Perform the following procedure to stop PXF on each segment host in your Greenpl
     gpadmin@gpmaster$ . /usr/local/greenplum-db/greenplum_path.sh
     ```
 
-3. Run the `pxf start` command to start PXF on each segment host. For example, if `seghostfile` contains a list, one-host-per-line, of the segment hosts in your Greenplum Database cluster:
+3. Run the `pxf stop` command to stop PXF on each segment host. For example, if `seghostfile` contains a list, one-host-per-line, of the segment hosts in your Greenplum Database cluster:
 
     ```shell
-    $ gpadmin@gpmaster$ gpssh -e -v -f seghostfile "/usr/local/greenplum-db/pxf/bin/pxf start"
+    $ gpadmin@gpmaster$ gpssh -e -v -f seghostfile "/usr/local/greenplum-db/pxf/bin/pxf stop"
     ```
 
 ## <a id="pxf_svc_mgmt"></a>PXF Service Management

--- a/gpdb-doc/markdown/pxf/cfginitstart_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/cfginitstart_pxf.html.md.erb
@@ -56,7 +56,7 @@ You must explicitly initialize the PXF service instance. This one-time initializ
 Before initializing PXF in your Greenplum Database cluster, ensure that you have:
 
 - Installed and configured the required Hadoop clients on each Greenplum Database segment host. Refer to [Installing and Configuring Hadoop Clients for PXF](client_instcfg.html) for instructions.
-- Granted the `gpadmin` operating system user read permission on the relevant portions of your HDFS file system.
+- Granted read permission to the HDFS files and directories that will be accessed as external tables in Greenplum Database. You must grant this permission to all Greenplum Database users that will use external tables that reference the HDFS files.
  
 ### <a id="init-pxf-steps"></a>Procedure
 

--- a/gpdb-doc/markdown/pxf/hdfs_read_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_read_pxf.html.md.erb
@@ -31,7 +31,7 @@ Before working with HDFS data using PXF, ensure that:
 
 - You have installed and configured a Hadoop client on each Greenplum Database segment host. Refer to [Installing and Configuring Hadoop Clients for PXF](client_instcfg.html) for instructions. If you plan to access JSON format data stored in a Cloudera Hadoop cluster, PXF requires a Cloudera version 5.8 or later Hadoop distribution.
 - You have initialized PXF on your Greenplum Database segment hosts, and PXF is running on each host. See [Configuring, Initializing, and Managing PXF](cfginitstart_pxf.html) for PXF initialization, configuration, and startup information.
-- You have granted the `gpadmin` user read permission on the relevant portions of your HDFS file system.
+- You have granted read permission to the HDFS files and directories that will be accessed as external tables in Greenplum Database. You must grant this permission to all Greenplum Database users that will use external tables that reference the HDFS files.
 
 
 ## <a id="hdfs_fileformats"></a>HDFS Data Formats

--- a/gpdb-doc/markdown/pxf/hdfs_read_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_read_pxf.html.md.erb
@@ -31,7 +31,7 @@ Before working with HDFS data using PXF, ensure that:
 
 - You have installed and configured a Hadoop client on each Greenplum Database segment host. Refer to [Installing and Configuring Hadoop Clients for PXF](client_instcfg.html) for instructions. If you plan to access JSON format data stored in a Cloudera Hadoop cluster, PXF requires a Cloudera version 5.8 or later Hadoop distribution.
 - You have initialized PXF on your Greenplum Database segment hosts, and PXF is running on each host. See [Configuring, Initializing, and Managing PXF](cfginitstart_pxf.html) for PXF initialization, configuration, and startup information.
-- You have granted read permission to the HDFS files and directories that will be accessed as external tables in Greenplum Database. You must grant this permission to all Greenplum Database users that will use external tables that reference the HDFS files.
+- If user impersonation is enabled (the default), you have granted read permission to the HDFS files and directories that will be accessed as external tables in Greenplum Database to each Greenplum Database user/role name that will access the HDFS files and directories. If user impersonation is not enabled, you must grant this permission to the `gpadmin` user.
 
 
 ## <a id="hdfs_fileformats"></a>HDFS Data Formats

--- a/gpdb-doc/markdown/pxf/hdfs_write_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_write_pxf.html.md.erb
@@ -33,7 +33,7 @@ Before writing HDFS data using PXF, ensure that:
 
 -  You have installed and configured a Hadoop client on each Greenplum Database segment host. Refer to [Installing and Configuring Hadoop Clients for PXF](client_instcfg.html) for instructions.
 - You have initialized and started PXF on your Greenplum Database segment hosts. See [Configuring, Initializing, and Managing PXF](cfginitstart_pxf.html) for PXF initialization, configuration, and startup information.
-- You have granted the `gpadmin` user *read and write* permissions to the appropriate directories in your HDFS file system.
+- You have granted both *read and write* permissions to the HDFS files and directories that will be accessed as external tables in Greenplum Database. You must grant these permissions to all Greenplum Database users that will use external tables that reference the HDFS files.
 
 
 ## <a id="hdfswrite_writeextdata"></a>Writing to PXF External Tables

--- a/gpdb-doc/markdown/pxf/hdfs_write_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_write_pxf.html.md.erb
@@ -33,7 +33,7 @@ Before writing HDFS data using PXF, ensure that:
 
 -  You have installed and configured a Hadoop client on each Greenplum Database segment host. Refer to [Installing and Configuring Hadoop Clients for PXF](client_instcfg.html) for instructions.
 - You have initialized and started PXF on your Greenplum Database segment hosts. See [Configuring, Initializing, and Managing PXF](cfginitstart_pxf.html) for PXF initialization, configuration, and startup information.
-- You have granted both *read and write* permissions to the HDFS files and directories that will be accessed as external tables in Greenplum Database. You must grant these permissions to all Greenplum Database users that will use external tables that reference the HDFS files.
+- You have granted both *read and write* permissions to the HDFS directories that will be accessed as external tables in Greenplum Database. If user impersonation is enabled (the default), you must grant these permissions to each Greenplum Database user/role name that will use external tables that reference the HDFS files. If user impersonation is not enabled, you must grant this permission to the `gpadmin` user.
 
 
 ## <a id="hdfswrite_writeextdata"></a>Writing to PXF External Tables

--- a/gpdb-doc/markdown/pxf/upgrade_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/upgrade_pxf.html.md.erb
@@ -71,7 +71,7 @@ After you upgrade to the new version of Greenplum Database, perform the followin
     
 3. Initialize PXF on each segment host as described in [Initializing PXF](cfginitstart_pxf.html#init_pxf).
 
-4. If you updated any of the `pxf-profiles.xml`, `pxf-log4j.properties`, `pxf-private.classpath`, or `pxf-public.classpath` configuration files in your *PXF.from* installation, re-apply those changes and copy the updated file(s) to all segment hosts. Refer to Step 2 above for a similar `gpscp` command.
+4. If you updated any of the `pxf-profiles.xml`, `pxf-log4j.properties`, `pxf-private.classpath`, or `pxf-public.classpath` configuration files in your *PXF.from* installation, re-apply those changes and copy the updated file(s) to all segment hosts. Refer to Step 3 above for a similar `gpscp` command.
 
 5. If you added additional JAR files to your *PXF.from* installation, copy them to the corresponding directory in your *PXF.to* installation **on each segment host**.
  


### PR DESCRIPTION
now that pxf supports user impersonation, assign permissions to hdfs files backing pxf external tables to greenplum users rather than gpadmin.
- updated 3 locations in the content

(also snuck a fix to an incorrect reference in this PR.)