### PR TITLE
Add timezone test for gpinitsystem

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
@@ -78,3 +78,33 @@ Feature: gpinitsystem tests
         And gpinitsystem should print "Log file scan check passed" to stdout
         And sql "select * from gp_toolkit.__gp_user_namespaces" is executed in "postgres" db
 
+    @gpinitsystem_verify_default_timezone
+    Scenario: gpinitsystem creates a cluster in default timezone
+        Given the database is not running
+        And the environment variable "TZ" is not set
+		And the system timezone is saved
+		And the user runs command "rm -rf ../gpAux/gpdemo/datadirs/*"
+		And the user runs command "mkdir ../gpAux/gpdemo/datadirs/qddir; mkdir ../gpAux/gpdemo/datadirs/dbfast1; mkdir ../gpAux/gpdemo/datadirs/dbfast2; mkdir ../gpAux/gpdemo/datadirs/dbfast3"
+		And the user runs command "mkdir ../gpAux/gpdemo/datadirs/dbfast_mirror1; mkdir ../gpAux/gpdemo/datadirs/dbfast_mirror2; mkdir ../gpAux/gpdemo/datadirs/dbfast_mirror3"
+		And the user runs command "rm -rf /tmp/gpinitsystemtest && mkdir /tmp/gpinitsystemtest"
+		When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -l /tmp/gpinitsystemtest -P 21100 -h ../gpAux/gpdemo/hostfile"
+		And gpinitsystem should return a return code of 0
+		Then the database timezone is saved
+		And the database timezone matches the system timezone
+		And the startup timezone is saved
+		And the startup timezone matches the system timezone
+
+    @gpinitsystem_verify_timezone_setting
+    Scenario: gpinitsystem creates a cluster using TZ
+        Given the database is not running
+        And the environment variable "TZ" is set to "US/Hawaii"
+		And the user runs command "rm -rf ../gpAux/gpdemo/datadirs/*"
+		And the user runs command "mkdir ../gpAux/gpdemo/datadirs/qddir; mkdir ../gpAux/gpdemo/datadirs/dbfast1; mkdir ../gpAux/gpdemo/datadirs/dbfast2; mkdir ../gpAux/gpdemo/datadirs/dbfast3"
+		And the user runs command "mkdir ../gpAux/gpdemo/datadirs/dbfast_mirror1; mkdir ../gpAux/gpdemo/datadirs/dbfast_mirror2; mkdir ../gpAux/gpdemo/datadirs/dbfast_mirror3"
+		And the user runs command "rm -rf /tmp/gpinitsystemtest && mkdir /tmp/gpinitsystemtest"
+		When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -l /tmp/gpinitsystemtest -P 21100 -h ../gpAux/gpdemo/hostfile"
+		And gpinitsystem should return a return code of 0
+		Then the database timezone is saved
+		And the database timezone matches "HST"
+		And the startup timezone is saved
+		And the startup timezone matches "HST"

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -5292,3 +5292,53 @@ def impl(context, command, target):
             contents += line
     if target not in contents:
         raise Exception("cannot find %s in %s" % (target, filename))
+
+@given('the system timezone is saved')
+def impl(context):
+    cmd = Command(name='Get system timezone',
+                  cmdStr='date +"%Z"')
+    cmd.run(validateAfter=True)
+    context.system_timezone = cmd.get_stdout()
+
+@then('the database timezone is saved')
+def impl(context):
+    cmd = Command(name='Get database timezone',
+                  cmdStr='psql -d template1 -c "show time zone" -t')
+    cmd.run(validateAfter=True)
+    tz = cmd.get_stdout()
+    cmd = Command(name='Get abbreviated database timezone',
+                  cmdStr='psql -d template1 -c "select abbrev from pg_timezone_names where name=\'%s\';" -t' % tz)
+    cmd.run(validateAfter=True)
+    context.database_timezone = cmd.get_stdout()
+
+@then('the database timezone matches the system timezone')
+def step_impl(context):
+    if context.database_timezone != context.system_timezone:
+        raise Exception("Expected database timezone to be %s, but it was %s" % (context.system_timezone, context.database_timezone))
+
+@then('the database timezone matches "{abbreviated_timezone}"')
+def step_impl(context, abbreviated_timezone):
+    if context.database_timezone != abbreviated_timezone:
+        raise Exception("Expected database timezone to be %s, but it was %s" % (abbreviated_timezone, context.database_timezone))
+
+@then('the startup timezone is saved')
+def step_impl(context):
+    logfile = "%s/pg_log/startup.log" % os.getenv("MASTER_DATA_DIRECTORY")
+    timezone = ""
+    with open(logfile) as l:
+        first_line = l.readline()
+        timestamp = first_line.split(",")[0]
+        timezone = timestamp[-3:]
+    if timezone == "":
+        raise Exception("Could not find timezone information in startup.log")
+    context.startup_timezone = timezone
+
+@then('the startup timezone matches the system timezone')
+def step_impl(context):
+    if context.startup_timezone != context.system_timezone:
+        raise Exception("Expected timezone in startup.log to be %s, but it was %s" % (context.system_timezone, context.startup_timezone))
+
+@then('the startup timezone matches "{abbreviated_timezone}"')
+def step_impl(context, abbreviated_timezone):
+    if context.startup_timezone != abbreviated_timezone:
+        raise Exception("Expected timezone in startup.log to be %s, but it was %s" % (abbreviated_timezone, context.startup_timezone))


### PR DESCRIPTION
This PR contains tests for the timezone issues addressed by PR 4646 https://github.com/greenplum-db/gpdb/pull/4646.  It will be merged to 5X_STABLE and master after PR 4646 is backported to 5X_STABLE and is intended to ensure that those issues don't come up again in the future.