### PR TITLE
pg_upgrade: fixes for older GPDB version checks

### DIFF
--- a/contrib/pg_upgrade/controldata.c
+++ b/contrib/pg_upgrade/controldata.c
@@ -127,11 +127,11 @@ get_control_data(migratorContext *ctx, ClusterInfo *cluster, bool live_check)
 	/*
 	 * In PostgreSQL, checksums were introduced in 9.3 so the test for checksum
 	 * version applies to <= 9.2. Greenplum backported checksums into 5.x which
-	 * is based on PostgreSQL 8.3 so this test need to go on <= 8.3 instead.
+	 * is based on PostgreSQL 8.3 so this test need to go on <= 8.2 instead.
 	 */
-	if (GET_MAJOR_VERSION(cluster->major_version) <= 803)
+	if (GET_MAJOR_VERSION(cluster->major_version) <= 802)
 	{
-		cluster->controldata.data_checksum_version = false;
+		cluster->controldata.data_checksum_version = 0;
 		got_data_checksums = true;
 	}
 

--- a/contrib/pg_upgrade/info.c
+++ b/contrib/pg_upgrade/info.c
@@ -532,7 +532,8 @@ get_rel_infos(migratorContext *ctx, const DbInfo *dbinfo,
 			 (GET_MAJOR_VERSION(ctx->old.major_version) <= 804) ?
 			 "" : ", 'pg_largeobject_metadata', 'pg_largeobject_metadata_oid_index'",
 	/* see the comment at the top of old_8_3_create_sequence_script() */
-			 (GET_MAJOR_VERSION(ctx->old.major_version) <= 803) ?
+			 (GET_MAJOR_VERSION(ctx->old.major_version) <= 803
+			  && GET_MAJOR_VERSION(ctx->new.major_version) >= 804) ?
 			 "" : ", 'S'",
 			 (GET_MAJOR_VERSION(ctx->old.major_version) <= 802) ?
 			 "" : " AND i.indisvalid IS DISTINCT FROM false AND i.indisready IS DISTINCT FROM false "
@@ -854,7 +855,8 @@ get_rel_infos(migratorContext *ctx, const DbInfo *dbinfo,
 		}
 
 		if (relstorage == 'h' && /* RELSTORAGE_HEAP */
-			(relkind == 'r' || relkind == 't')) /* RELKIND_RELATION or RELKIND_TOASTVALUE */
+			(relkind == 'r' || relkind == 't' || relkind == 'S'))
+			/* RELKIND_RELATION, RELKIND_TOASTVALUE, or RELKIND_SEQUENCE */
 		{
 			char		hquery[QUERY_ALLOC];
 			PGresult   *hres;

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -291,7 +291,6 @@ static bool
 isGPDB4300OrLater(void)
 {
 	static int	value = -1;		/* -1 = not known yet, 0 = no, 1 = yes */
-	bool	retValue = false;
 
 	/* Query the server on first call, and cache the result */
 	if (value == -1)
@@ -319,7 +318,7 @@ isGPDB4300OrLater(void)
 			value = 0;
 	}
 
-	return retValue;
+	return (value == 1) ? true : false;
 }
 
 /*
@@ -359,7 +358,7 @@ isGPDB5000OrLater(void)
 		return false;		/* Not Greenplum at all. */
 
 	/* GPDB 5 is based on PostgreSQL 8.3 */
-	return g_fout->remoteVersion >= 80400;
+	return g_fout->remoteVersion >= 80300;
 }
 
 


### PR DESCRIPTION
Fix bugs in the version checks for pg_dump and pg_upgrade, some of which appear to be simply typos, and some of which are legitimate differences between GPDB and upstream (due to backports, support for upgrades from 8.2, etc.). See the commit log.

These issues were found by the (still in development) GPDB 4->5 upgrade CI. All patches here, as well as the commits they're based on, need to be backported to `5X_STABLE`.