### PR TITLE
Fix pg_dump for 4.x EXTERNAL tables with ON clauses

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -11341,7 +11341,7 @@ dumpExternal(TableInfo *tbinfo, PQExpBuffer query, PQExpBuffer q, PQExpBuffer de
 			options = "";
 
 			if (command && strlen(command) > 0)
-				on_clause = command;
+				on_clause = urilocations;
 			else
 				on_clause = NULL;
 		}


### PR DESCRIPTION
Follow-up to 4f4e5a5c. In GPDB 4, the ON clause information is stored in `pg_exttable.location`, not `.command`. This led to complaints of `illegal ON clause catalog information` during dump.