### PR TITLE
Upgrade: accept more missing pre-assigned OIDs

### DIFF
--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1471,7 +1471,8 @@ heap_create_with_catalog(const char *relname,
 		 */
 		if (Gp_role == GP_ROLE_EXECUTE || IsBinaryUpgrade)
 		{
-			new_array_oid = GetPreassignedOidForType(relnamespace, relarrayname);
+			new_array_oid = GetPreassignedOidForType(relnamespace, relarrayname,
+													 true);
 
 			if (new_array_oid == InvalidOid && IsBinaryUpgrade)
 				new_array_oid = GetNewOid(pg_type);

--- a/src/backend/catalog/oid_dispatch.c
+++ b/src/backend/catalog/oid_dispatch.c
@@ -702,6 +702,9 @@ GetPreassignedOidForRelation(Oid namespaceOid, const char *relname)
 			if (namespaceOid == PG_BITMAPINDEX_NAMESPACE)
 				return InvalidOid;
 
+			if (namespaceOid == PG_TOAST_NAMESPACE)
+				return InvalidOid;
+
 			if (namespaceOid == PG_AOSEGMENT_NAMESPACE)
 				return InvalidOid;
 		}

--- a/src/backend/catalog/oid_dispatch.c
+++ b/src/backend/catalog/oid_dispatch.c
@@ -713,9 +713,13 @@ GetPreassignedOidForRelation(Oid namespaceOid, const char *relname)
 /*
  * A specialized version of GetPreassignedOidForTuple(). To be used when we don't
  * have a whole pg_type tuple yet.
+ *
+ * The caller should set allowMissing if it can handle a missing preassignment
+ * for the type. This is useful in upgrade scenarios as new types are added.
  */
 Oid
-GetPreassignedOidForType(Oid namespaceOid, const char *typname)
+GetPreassignedOidForType(Oid namespaceOid, const char *typname,
+						 bool allowMissing)
 {
 	OidAssignment searchkey;
 	Oid			oid;
@@ -725,7 +729,7 @@ GetPreassignedOidForType(Oid namespaceOid, const char *typname)
 	searchkey.namespaceOid = namespaceOid;
 	searchkey.objname = (char *) typname;
 
-	if ((oid = GetPreassignedOid(&searchkey)) == InvalidOid)
+	if ((oid = GetPreassignedOid(&searchkey)) == InvalidOid && !allowMissing)
 		elog(ERROR, "no pre-assigned OID for type \"%s\"", typname);
 	return oid;
 }

--- a/src/backend/commands/typecmds.c
+++ b/src/backend/commands/typecmds.c
@@ -571,8 +571,14 @@ DefineType(List *names, List *parameters)
 	/* Preassign array type OID so we can insert it in pg_type.typarray */
 	if (Gp_role == GP_ROLE_EXECUTE || IsBinaryUpgrade)
 	{
-		array_oid = GetPreassignedOidForType(typeNamespace, array_type);
+		array_oid = GetPreassignedOidForType(typeNamespace, array_type, true);
 
+		/*
+		 * If we are expected to get a preassigned Oid but receive InvalidOid,
+		 * get a new Oid. This can happen during upgrades from GPDB4 to 5 where
+		 * array types over relation rowtypes were introduced so there are no
+		 * pre-existing array types to dump from the old cluster
+		 */
 		if (array_oid == InvalidOid && IsBinaryUpgrade)
 			array_oid = AssignTypeArrayOid();
 	}
@@ -1224,8 +1230,9 @@ DefineEnum(CreateEnumStmt *stmt)
 	/* Preassign array type OID so we can insert it in pg_type.typarray */
 	if (Gp_role == GP_ROLE_EXECUTE || IsBinaryUpgrade)
 	{
-		enumTypeOid = GetPreassignedOidForType(enumNamespace, enumName);
-		enumArrayOid = GetPreassignedOidForType(enumNamespace, enumArrayName);
+		enumTypeOid = GetPreassignedOidForType(enumNamespace, enumName, false);
+		enumArrayOid = GetPreassignedOidForType(enumNamespace, enumArrayName,
+											    false);
 	}
 	else
 	{

--- a/src/include/catalog/oid_dispatch.h
+++ b/src/include/catalog/oid_dispatch.h
@@ -25,7 +25,8 @@ extern void AddPreassignedOidFromBinaryUpgrade(Oid oid, Oid catalog,
 			char *objname, Oid namespaceOid, Oid keyOid1, Oid keyOid2);
 extern Oid GetPreassignedOidForTuple(Relation catalogrel, HeapTuple tuple);
 extern Oid GetPreassignedOidForRelation(Oid namespaceOid, const char *relname);
-extern Oid GetPreassignedOidForType(Oid namespaceOid, const char *typname);
+extern Oid GetPreassignedOidForType(Oid namespaceOid, const char *typname,
+									bool allowMissing);
 extern Oid GetPreassignedOidForDatabase(const char *datname);
 
 /* Functions used in binary upgrade */


### PR DESCRIPTION
Two cases found by the 4->5 upgrade CI:

- Rowtype arrays are new to GPDB 5/Postgres 8.3 and will not have preassigned OIDs coming from a GPDB 4 cluster. Luckily, we already have code to handle this case; we just need to reenable it after it was disabled by commit f51f2f5.

- If an attribute used by an upgraded relation isn't toastable in the old GPDB version, but is toastable in the new GPDB version, then we won't already have a toast table for that relation, and we will need to create one during upgrade. Allow missing toast table OIDs for that reason.