### PR TITLE
Fix double-free during AO tuple upgrade from GPDB 4

### DIFF
--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -931,7 +931,7 @@ upgrade_tuple(AppendOnlyExecutorReadBlock *executorReadBlock,
 		if (values)
 			pfree(values);
 		if (isnull)
-			pfree(values);
+			pfree(isnull);
 		values = (Datum *) MemoryContextAlloc(TopMemoryContext, natts * sizeof(Datum));
 		isnull = (bool *) MemoryContextAlloc(TopMemoryContext, natts * sizeof(bool));
 		nallocated = natts;


### PR DESCRIPTION
We were double-freeing the `values` array and crashing after a 4->5 upgrade of an AO table.