### PR TITLE
Remove SYNC_REP_DISABLED state

### DIFF
--- a/src/backend/replication/syncrep.c
+++ b/src/backend/replication/syncrep.c
@@ -116,21 +116,6 @@ SyncRepWaitForLSN(XLogRecPtr XactCommitLSN)
 		return;
 	}
 
-	/*
-	 * XXX: Some processes (e.g. auxiliary processes) don't need even
-	 * check the walsenders.  We just stay away from any of the shared
-	 * memory values.  When we move to fully-synchronous replication,
-	 * any xlog change needs to be considered to be synchronous,
-	 * but for now this is acceptable.
-	 */
-	if (MyProc->syncRepState == SYNC_REP_DISABLED)
-	{
-		elogif(debug_walrepl_syncrep, LOG,
-				"syncrep wait -- Not waiting for syncrep as synrep state for this process is disabled.");
-
-		return;
-	}
-
 	if (GpIdentity.segindex != MASTER_CONTENT_ID)
 	{
 		/* Fast exit if user has not requested sync replication. */

--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -598,13 +598,6 @@ InitAuxiliaryProcess(void)
 		SHMQueueInit(&(MyProc->myProcLocks[i]));
 
 	/*
-	 * Auxiliary process doesn't bother with sync rep.  Though it was
-	 * originally supposed to not do transaction work, but it does in GPDB,
-	 * we mark it and avoid sync rep work.
-	 */
-	MyProc->syncRepState = SYNC_REP_DISABLED;
-
-	/*
 	 * Acquire ownership of the PGPROC's latch, so that we can use WaitLatch.
 	 * Note that there's no particular need to do ResetLatch here.
 	 */

--- a/src/include/replication/syncrep.h
+++ b/src/include/replication/syncrep.h
@@ -27,7 +27,6 @@
 #define NUM_SYNC_REP_WAIT_MODE	2
 
 /* syncRepState */
-#define SYNC_REP_DISABLED			-1
 #define SYNC_REP_NOT_WAITING		0
 #define SYNC_REP_WAITING			1
 #define SYNC_REP_WAIT_COMPLETE		2


### PR DESCRIPTION
This state was meant to prevent auxiliary processes from waiting from syncrep.
As far as we can tell, auxiliary process should not be calling
SyncRepWaitForLSN() unless it is committing a transaction.  And if it is
committing a transaction, it better wait for mirror to flush XLOG upto the
commit LSN.  One example of an auxiliary process committing a transaction is
FTS, when it updates cluster configuration on master.

Co-authored-by: Asim R P <apraveen@pivotal.io>