### PR TITLE
Add a hook for idle session killing

### DIFF
--- a/src/backend/cdb/dispatcher/README.md
+++ b/src/backend/cdb/dispatcher/README.md
@@ -1,6 +1,10 @@
 ## Dispatcher API
-This document illustrates the interfaces of a GPDB component called dispatcher, which is responsible for 1) building connections from master node to segments,
-2) managing query/plan dispatching, 3) and collecting query execution results. The implementation of dispatcher is mainly located under this directory
+This document illustrates the interfaces of a GPDB component called dispatcher, which is responsible for
+1) building connections from master node to segments,
+2) managing query/plan dispatching, and
+3) collecting query execution results.
+
+The implementation of dispatcher is mainly located under this directory.
 
 ### Terms Used:
 * Gang: Gang refers to a group of processes on segments. There are 4 types of Gang:

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -1267,6 +1267,52 @@ disconnectAndDestroyIdleReaderGangs(void)
 }
 
 /*
+ * Destroy all idle (i.e available) reader gangs.
+ * It is always safe to get rid of the reader gangs.
+ *
+ * If we are not in a transaction and we do not have a TempNamespace, destroy
+ * writer gangs as well.
+ *
+ * call only from an idle session.
+ */
+void DisconnectAndDestroyUnusedGangs(void)
+{
+	/*
+	 * Free gangs to free up resources on the segDBs.
+	 */
+	if (GangsExist())
+	{
+		if (IsTransactionOrTransactionBlock() || TempNamespaceOidIsValid())
+		{
+			/*
+			 * If we are in a transaction, we can't release the writer gang,
+			 * as this will abort the transaction.
+			 *
+			 * If we have a TempNameSpace, we can't release the writer gang, as this
+			 * would drop any temp tables we own.
+			 *
+			 * Since we are idle, any reader gangs will be available but not allocated.
+			 */
+			disconnectAndDestroyIdleReaderGangs();
+		}
+		else
+		{
+			/*
+			 * Get rid of ALL gangs... Readers and primary writer.
+			 * After this, we have no resources being consumed on the segDBs at all.
+			 *
+			 * Our session wasn't destroyed due to an fatal error or FTS action, so
+			 * we don't need to do anything special.  Specifically, we DON'T want
+			 * to act like we are now in a new session, since that would be confusing
+			 * in the log.
+			 *
+			 */
+			DisconnectAndDestroyAllGangs(false);
+		}
+	}
+}
+
+/*
  * Cleanup a Gang, make it recyclable.
  *
  * A return value of "true" means that the gang was intact (or NULL).

--- a/src/backend/tcop/Makefile
+++ b/src/backend/tcop/Makefile
@@ -14,6 +14,9 @@ include $(top_builddir)/src/Makefile.global
 
 OBJS= dest.o fastpath.o postgres.o pquery.o utility.o
 
+# Greenplum objects
+OBJS+= idle_resource_cleaner.o
+
 ifneq (,$(filter $(PORTNAME),cygwin win32))
 override CPPFLAGS += -DWIN32_STACK_RLIMIT=$(WIN32_STACK_RLIMIT)
 endif

--- a/src/backend/tcop/idle_resource_cleaner.c
+++ b/src/backend/tcop/idle_resource_cleaner.c
@@ -1,0 +1,97 @@
+/*-------------------------------------------------------------------------
+ *
+ * idle_resource_cleaner.c
+ *
+ *
+ * Portions Copyright (c) 2012-Present Pivotal Software, Inc.
+ *
+ *
+ * IDENTIFICATION
+ *	    src/backend/tcop/idle_resource_cleaner.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include "cdb/cdbgang.h"
+#include "storage/proc.h"
+#include "tcop/idle_resource_cleaner.h"
+
+int IdleSessionGangTimeout = 18000;
+
+static int
+get_idle_gang_timeout(void)
+{
+	return GangsExist() ? IdleSessionGangTimeout : 0;
+}
+
+static void
+idle_gang_timeout_action(void)
+{
+	DisconnectAndDestroyUnusedGangs();
+}
+
+/*
+ * We want to check to see if our session goes "idle" (nobody sending us work to
+ * do). We decide this is true if after waiting a while, we don't get a message
+ * from the client.
+ * We can then free resources (right now, just the gangs on the segDBs).
+ *
+ * A bit ugly:  We share the sig alarm timer with the deadlock detection.
+ * We know which it is (deadlock detection needs to run or idle
+ * session resource release) based on the DoingCommandRead flag.
+ *
+ * Note we don't need to worry about the statement timeout timer
+ * because it can't be running when we are idle.
+ *
+ * We want the time value to be long enough so we don't free gangs prematurely.
+ * This means giving the end user enough time to type in the next SQL statement
+ *
+ *
+ * GPDB_93_MERGE_FIXME: replace the enable_sig_alarm() calls with the
+ * new functionality provided in timeout.c from PG 9.3.
+ */
+void StartIdleResourceCleanupTimers()
+{
+	int sigalarm_timeout = get_idle_gang_timeout();
+
+	if (sigalarm_timeout > 0)
+	{
+		if (!enable_sig_alarm(sigalarm_timeout, false))
+			elog(FATAL, "could not set timer for client wait timeout");
+	}
+}
+
+/*
+ * We get here when a session has been idle for a while (waiting for the client
+ * to send us SQL to execute). The idea is to consume less resources while
+ * sitting idle, so we can support more sessions being logged on.
+ *
+ * The expectation is that if the session is logged on, but nobody is sending us
+ * work to do, we want to free up whatever resources we can. Usually it means
+ * there is a human being at the other end of the connection, and that person
+ * has walked away from their terminal, or just hasn't decided what to do next.
+ * We could be idle for a very long time (many hours).
+ *
+ * Of course, freeing gangs means that the next time the user does send in an
+ * SQL statement, we need to allocate gangs (at least the writer gang) to do
+ * anything. This entails extra work, so we don't want to do this if we don't
+ * think the session has gone idle.
+ *
+ * PS: Is there anything we can free up on the master (QD) side? I can't
+ * think of anything.
+ *
+ */
+void
+DoIdleResourceCleanup(void)
+{
+	elog(DEBUG2,"DoIdleResourceCleanup");
+
+	/*
+	 * Cancel the timer, as there is no reason we need it to go off again
+	 * (setitimer repeats by default).
+	 */
+	disable_sig_alarm(false);
+
+	idle_gang_timeout_action();
+}

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -101,6 +101,7 @@
 
 #include "utils/session_state.h"
 #include "utils/vmem_tracker.h"
+#include "tcop/idle_resource_cleaner.h"
 
 extern char *optarg;
 extern int	optind;
@@ -5132,37 +5133,17 @@ PostgresMain(int argc, char *argv[],
 
 		/*
 		 * (2b) Check for temp table delete reset session work.
+		 * Also clean up idle resources.
 		 */
 		if (Gp_role == GP_ROLE_DISPATCH)
+		{
 			CheckForResetSession();
+			StartIdleResourceCleanupTimers();
+		}
 
 		/*
 		 * (3) read a command (loop blocks here)
 		 */
-		if (Gp_role == GP_ROLE_DISPATCH)
-		{
-			/*
-			 * We want to check to see if our session goes "idle" (nobody sending us work to do)
-			 * We decide this it true if after waiting a while, we don't get a message from the client.
-			 * We can then free resources (right now, just the gangs on the segDBs).
-			 *
-			 * A Bit ugly:  We share the sig alarm timer with the deadlock detection.
-			 * We know which it is (deadlock detection needs to run or idle
-			 * session resource release) based on the DoingCommandRead flag.
-			 *
-			 * Perhaps instead of calling enable_sig_alarm, we should just call
-			 * setitimer() directly (we don't need to worry about the statement timeout timer
-			 * because it can't be running when we are idle).
-			 *
-			 * We want the time value to be long enough so we don't free gangs prematurely.
-			 * This means giving the end user enough time to type in the next SQL statement
-			 *
-			 */
-			if (IdleSessionGangTimeout > 0 && GangsExist())
-				if (!enable_sig_alarm( IdleSessionGangTimeout /* ms */, false))
-					elog(FATAL, "could not set timer for client wait timeout");
-		}
-
 		firstchar = ReadCommand(&input_message);
 
 		/*

--- a/src/backend/tcop/test/Makefile
+++ b/src/backend/tcop/test/Makefile
@@ -2,7 +2,7 @@ subdir=src/backend/tcop
 top_builddir=../../../..
 include $(top_builddir)/src/Makefile.global
 
-TARGETS=postgres
+TARGETS=postgres idle_resource_cleaner
 
 include $(top_builddir)/src/backend/mock.mk
 
@@ -10,3 +10,7 @@ postgres.t: \
 	$(MOCK_DIR)/backend/commands/async_mock.o \
 	$(MOCK_DIR)/backend/storage/ipc/sinval_mock.o \
 	$(MOCK_DIR)/backend/utils/error/elog_mock.o
+
+idle_resource_cleaner.t: \
+	$(MOCK_DIR)/backend/cdb/dispatcher/cdbgang_mock.o \
+	$(MOCK_DIR)/backend/storage/lmgr/proc_mock.o

--- a/src/backend/tcop/test/idle_resource_cleaner_test.c
+++ b/src/backend/tcop/test/idle_resource_cleaner_test.c
@@ -1,0 +1,48 @@
+#include "../idle_resource_cleaner.c"
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include "cmockery.h"
+
+void
+test__StartIdleResourceCleanupTimersWhenNoGangsExist(
+	void **state)
+{
+	IdleSessionGangTimeout = 10000;
+
+	will_return(GangsExist, false);
+	/* cmockery implicitly asserts that enable_sig_alarm is not called */
+
+	StartIdleResourceCleanupTimers();
+}
+
+void
+test__StartIdleResourceCleanupTimersWhenGangsExist(
+	void **state)
+{
+	IdleSessionGangTimeout = 10000;
+
+	will_return(GangsExist, true);
+	/* cmockery implicitly asserts that enable_sig_alarm is not called */
+	will_return(enable_sig_alarm, true);
+
+	expect_value(enable_sig_alarm, delayms, 10000);
+	expect_value(enable_sig_alarm, is_statement_timeout, false);
+
+	StartIdleResourceCleanupTimers();
+}
+
+int
+main(int argc, char *argv[])
+{
+	cmockery_parse_arguments(argc, argv);
+
+	const UnitTest tests[] = {
+		unit_test(test__StartIdleResourceCleanupTimersWhenNoGangsExist),
+		unit_test(test__StartIdleResourceCleanupTimersWhenGangsExist),
+
+	};
+
+	run_tests(tests);
+}

--- a/src/backend/tcop/test/idle_resource_cleaner_test.c
+++ b/src/backend/tcop/test/idle_resource_cleaner_test.c
@@ -3,13 +3,60 @@
 #include <stdarg.h>
 #include <stddef.h>
 #include <setjmp.h>
+
 #include "cmockery.h"
 
+int			idle_session_timeout_action_calls = 0;
+
 void
-test__StartIdleResourceCleanupTimersWhenNoGangsExist(
-	void **state)
+idle_session_timeout_action_spy()
+{
+	idle_session_timeout_action_calls++;
+}
+
+int
+returns1000_stub(void)
+{
+	return 1000;
+}
+
+#define test_with_setup_and_teardown(test_func) \
+	unit_test_setup_teardown(test_func, setup, teardown)
+
+void
+setup(void **state)
+{
+	idle_session_timeout_action_hook = idle_session_timeout_action_spy;
+	idle_session_timeout_action_calls = 0;
+}
+
+void
+teardown(void **state)
+{
+	idle_session_timeout_action_calls = 0;
+}
+
+void
+test__StartIdleResourceCleanupTimersWhenIdleGangTimeoutIs0AndNoSessionTimeoutHook(
+																				  void **state)
+{
+	IdleSessionGangTimeout = 0;
+	get_idle_session_timeout_hook = NULL;
+
+	/*
+	 * cmockery implicitly asserts that GangsExist and enable_sig_alarm are
+	 * not called
+	 */
+
+	StartIdleResourceCleanupTimers();
+}
+
+void
+test__StartIdleResourceCleanupTimersWhenNoGangsExistAndNoSessionTimeoutHook(
+																			void **state)
 {
 	IdleSessionGangTimeout = 10000;
+	get_idle_session_timeout_hook = NULL;
 
 	will_return(GangsExist, false);
 	/* cmockery implicitly asserts that enable_sig_alarm is not called */
@@ -18,19 +65,186 @@ test__StartIdleResourceCleanupTimersWhenNoGangsExist(
 }
 
 void
-test__StartIdleResourceCleanupTimersWhenGangsExist(
-	void **state)
+test__StartIdleResourceCleanupTimersWhenGangsExistAndNoSessionTimeoutHook(
+																		  void **state)
 {
 	IdleSessionGangTimeout = 10000;
+	get_idle_session_timeout_hook = NULL;
+
+	NextTimeoutAction = -1;
 
 	will_return(GangsExist, true);
-	/* cmockery implicitly asserts that enable_sig_alarm is not called */
-	will_return(enable_sig_alarm, true);
-
 	expect_value(enable_sig_alarm, delayms, 10000);
 	expect_value(enable_sig_alarm, is_statement_timeout, false);
+	will_return(enable_sig_alarm, true);
 
 	StartIdleResourceCleanupTimers();
+
+	assert_int_equal(NextTimeoutAction, GANG_TIMEOUT);
+}
+
+void
+test__StartIdleResourceCleanupTimersWhenGangsExistAndSessionTimeoutEnabled(
+																		   void **state)
+{
+	IdleSessionGangTimeout = 10000;
+	get_idle_session_timeout_hook = returns1000_stub;
+	NextTimeoutAction = -1;
+
+	will_return(GangsExist, true);
+	expect_value(enable_sig_alarm, delayms, 10000);
+	expect_value(enable_sig_alarm, is_statement_timeout, false);
+	will_return(enable_sig_alarm, true);
+
+	StartIdleResourceCleanupTimers();
+
+	assert_int_equal(NextTimeoutAction, GANG_TIMEOUT);
+}
+
+void
+test__StartIdleResourceCleanupTimersWhenGangTimeoutIsDisabledAndSessionTimeoutEnabled(
+																					  void **state)
+{
+	IdleSessionGangTimeout = 0;
+	get_idle_session_timeout_hook = returns1000_stub;
+
+	expect_value(enable_sig_alarm, delayms, 1000);
+	expect_value(enable_sig_alarm, is_statement_timeout, false);
+	will_return(enable_sig_alarm, true);
+
+	StartIdleResourceCleanupTimers();
+
+	assert_int_equal(NextTimeoutAction, IDLE_SESSION_TIMEOUT);
+}
+
+void
+test__DoIdleResourceCleanup_HandlesGangTimeoutWhenSessionTimeoutIsLater(
+																		void **state)
+{
+	IdleSessionGangTimeout = 20000;
+	IdleSessionTimeoutCached = 25000;
+	NextTimeoutAction = GANG_TIMEOUT;
+
+	will_be_called(DisconnectAndDestroyUnusedGangs);
+	expect_value(disable_sig_alarm, is_statement_timeout, false);
+	will_return(disable_sig_alarm, true);
+	expect_value(enable_sig_alarm, delayms, 5000);
+	expect_value(enable_sig_alarm, is_statement_timeout, false);
+	will_return(enable_sig_alarm, true);
+
+	DoIdleResourceCleanup();
+
+	assert_int_equal(0, idle_session_timeout_action_calls);
+	assert_int_equal(IDLE_SESSION_TIMEOUT, NextTimeoutAction);
+}
+
+void
+test__DoIdleResourceCleanup_HandlesSessionTimeoutWhenGangTimeoutIsLater(
+																		void **state)
+{
+	IdleSessionGangTimeout = 24000;
+	IdleSessionTimeoutCached = 19000;
+	NextTimeoutAction = GANG_TIMEOUT;
+
+	will_be_called(DisconnectAndDestroyUnusedGangs);
+	expect_value(disable_sig_alarm, is_statement_timeout, false);
+	will_return(disable_sig_alarm, true);
+	/* cmockery implicitly asserts that enable_sig_alarm is not called */
+
+	DoIdleResourceCleanup();
+
+	/*
+	 * TODO: tell Jing behavior; the idle session timmeout action will be
+	 * called after 19000
+	 */
+	assert_int_equal(1, idle_session_timeout_action_calls);
+}
+
+void
+test__DoIdleResourceCleanup_HandlesSessionTimeoutWithSimultaneousGangTimeout(
+																			 void **state)
+{
+	IdleSessionGangTimeout = 24000;
+	IdleSessionTimeoutCached = 24000;
+	NextTimeoutAction = GANG_TIMEOUT;
+
+	will_be_called(DisconnectAndDestroyUnusedGangs);
+	expect_value(disable_sig_alarm, is_statement_timeout, false);
+	will_return(disable_sig_alarm, true);
+
+	DoIdleResourceCleanup();
+
+	assert_int_equal(1, idle_session_timeout_action_calls);
+}
+void
+test__DoIdleResourceCleanup_HandlesSessionTimeoutWithSimultaneousGangTimeoutButNullActionHook(
+																							  void **state)
+{
+	IdleSessionGangTimeout = 20000;
+	IdleSessionTimeoutCached = 20000;
+	NextTimeoutAction = GANG_TIMEOUT;
+
+	idle_session_timeout_action_hook = NULL;
+
+	will_be_called(DisconnectAndDestroyUnusedGangs);
+	expect_value(disable_sig_alarm, is_statement_timeout, false);
+	will_return(disable_sig_alarm, true);
+
+	DoIdleResourceCleanup();
+
+	/* doesn't segfault */
+}
+
+void
+test__DoIdleResourceCleanup_HandlesIdleSessionTimeoutAfterGangTimeout(void **state)
+{
+	IdleSessionGangTimeout = 5000;
+	IdleSessionTimeoutCached = 15000;
+	NextTimeoutAction = IDLE_SESSION_TIMEOUT;
+
+	/* not called: DisconnectAndDestroyUnusedGangs, enable_sig_alarm; */
+	expect_value(disable_sig_alarm, is_statement_timeout, false);
+	will_return(disable_sig_alarm, true);
+
+	DoIdleResourceCleanup();
+
+	assert_int_equal(1, idle_session_timeout_action_calls);
+}
+
+void
+test__DoIdleResourceCleanup_HandlesIdleSessionTimeoutAfterGangTimeoutWithNullActionHook(
+																						void **state)
+{
+	IdleSessionGangTimeout = 5000;
+	IdleSessionTimeoutCached = 15000;
+	NextTimeoutAction = IDLE_SESSION_TIMEOUT;
+
+	idle_session_timeout_action_hook = NULL;
+
+	/* not called: DisconnectAndDestroyUnusedGangs, enable_sig_alarm; */
+	expect_value(disable_sig_alarm, is_statement_timeout, false);
+	will_return(disable_sig_alarm, true);
+
+	DoIdleResourceCleanup();
+
+	/* doesn't segfault */
+}
+
+void
+test__DoIdleResourceCleanup_HandlesGangTimeoutWhenSessionTimeoutDisabled(void **state)
+{
+	IdleSessionGangTimeout = 24000;
+	IdleSessionTimeoutCached = 0;
+	NextTimeoutAction = GANG_TIMEOUT;
+
+	/* not called: enable_sig_alarm */
+	will_be_called(DisconnectAndDestroyUnusedGangs);
+	expect_value(disable_sig_alarm, is_statement_timeout, false);
+	will_return(disable_sig_alarm, true);
+
+	DoIdleResourceCleanup();
+
+	assert_int_equal(0, idle_session_timeout_action_calls);
 }
 
 int
@@ -38,10 +252,19 @@ main(int argc, char *argv[])
 {
 	cmockery_parse_arguments(argc, argv);
 
-	const UnitTest tests[] = {
-		unit_test(test__StartIdleResourceCleanupTimersWhenNoGangsExist),
-		unit_test(test__StartIdleResourceCleanupTimersWhenGangsExist),
-
+	const		UnitTest tests[] = {
+		unit_test(test__StartIdleResourceCleanupTimersWhenIdleGangTimeoutIs0AndNoSessionTimeoutHook),
+		unit_test(test__StartIdleResourceCleanupTimersWhenNoGangsExistAndNoSessionTimeoutHook),
+		unit_test(test__StartIdleResourceCleanupTimersWhenGangsExistAndNoSessionTimeoutHook),
+		unit_test(test__StartIdleResourceCleanupTimersWhenGangsExistAndSessionTimeoutEnabled),
+		unit_test(test__StartIdleResourceCleanupTimersWhenGangTimeoutIsDisabledAndSessionTimeoutEnabled),
+		test_with_setup_and_teardown(test__DoIdleResourceCleanup_HandlesGangTimeoutWhenSessionTimeoutIsLater),
+		test_with_setup_and_teardown(test__DoIdleResourceCleanup_HandlesSessionTimeoutWhenGangTimeoutIsLater),
+		test_with_setup_and_teardown(test__DoIdleResourceCleanup_HandlesSessionTimeoutWithSimultaneousGangTimeout),
+		test_with_setup_and_teardown(test__DoIdleResourceCleanup_HandlesSessionTimeoutWithSimultaneousGangTimeoutButNullActionHook),
+		test_with_setup_and_teardown(test__DoIdleResourceCleanup_HandlesIdleSessionTimeoutAfterGangTimeout),
+		test_with_setup_and_teardown(test__DoIdleResourceCleanup_HandlesIdleSessionTimeoutAfterGangTimeoutWithNullActionHook),
+		test_with_setup_and_teardown(test__DoIdleResourceCleanup_HandlesGangTimeoutWhenSessionTimeoutDisabled),
 	};
 
 	run_tests(tests);

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -39,6 +39,7 @@
 #include "replication/walsender.h"
 #include "storage/bfz.h"
 #include "storage/proc.h"
+#include "tcop/idle_resource_cleaner.h"
 #include "utils/builtins.h"
 #include "utils/guc_tables.h"
 #include "utils/inval.h"

--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -86,6 +86,7 @@ extern void freeGangsForPortal(char *portal_name);
 
 extern void DisconnectAndDestroyGang(Gang *gp);
 extern void DisconnectAndDestroyAllGangs(bool resetSession);
+extern void DisconnectAndDestroyUnusedGangs(void);
 
 extern void CheckForResetSession(void);
 

--- a/src/include/storage/proc.h
+++ b/src/include/storage/proc.h
@@ -238,7 +238,6 @@ typedef struct PROC_HDR
 extern int	DeadlockTimeout;
 extern int	StatementTimeout;
 extern bool log_lock_waits;
-extern int IdleSessionGangTimeout;
 
 extern volatile bool cancel_from_timeout;
 

--- a/src/include/tcop/idle_resource_cleaner.h
+++ b/src/include/tcop/idle_resource_cleaner.h
@@ -1,0 +1,25 @@
+/*-------------------------------------------------------------------------
+ *
+ * idle_resource_cleaner.h
+ *	  Functions used to clean up resources on idle sessions.
+ *
+ *
+ * Portions Copyright (c) 2012-Present Pivotal Software, Inc.
+ *
+ *
+ * IDENTIFICATION
+ *	    src/include/tcop/idle_resource_cleaner.h
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef IDLE_RESOURCE_CLEANER_H
+#define IDLE_RESOURCE_CLEANER_H
+
+
+void StartIdleResourceCleanupTimers(void);
+
+void DoIdleResourceCleanup(void);
+
+extern int IdleSessionGangTimeout;
+
+#endif /* IDLE_RESOURCE_CLEANER_H */

--- a/src/include/tcop/idle_resource_cleaner.h
+++ b/src/include/tcop/idle_resource_cleaner.h
@@ -3,7 +3,7 @@
  * idle_resource_cleaner.h
  *	  Functions used to clean up resources on idle sessions.
  *
- *
+ * Portions Copyright (c) 2005-2008, Greenplum inc
  * Portions Copyright (c) 2012-Present Pivotal Software, Inc.
  *
  *
@@ -16,10 +16,13 @@
 #define IDLE_RESOURCE_CLEANER_H
 
 
-void StartIdleResourceCleanupTimers(void);
+void		StartIdleResourceCleanupTimers(void);
 
-void DoIdleResourceCleanup(void);
+void		DoIdleResourceCleanup(void);
 
-extern int IdleSessionGangTimeout;
+extern int	IdleSessionGangTimeout;
+
+extern int	(*get_idle_session_timeout_hook) (void);
+extern void (*idle_session_timeout_action_hook) (void);
 
 #endif /* IDLE_RESOURCE_CLEANER_H */

--- a/src/test/regress/hooktest/hook_test.c
+++ b/src/test/regress/hooktest/hook_test.c
@@ -2,39 +2,62 @@
 
 #include "fmgr.h"
 #include "optimizer/planner.h"
+#include "tcop/idle_resource_cleaner.h"
 
 PG_MODULE_MAGIC;
 
-static planner_hook_type	prev_planner_hook = NULL;
+static planner_hook_type prev_planner_hook = NULL;
 
-static PlannedStmt * test_hook(Query *parse, int cursorOptions, ParamListInfo boundParams);
-void _PG_init(void);
-void _PG_fini(void);
+static PlannedStmt *test_planner_hook(Query *parse, int cursorOptions, ParamListInfo boundParams);
+
+static int	test_get_idle_session_timeout(void);
+static void test_idle_session_timeout_action(void);
+
+void		_PG_init(void);
+void		_PG_fini(void);
 
 void
 _PG_init(void)
 {
 	prev_planner_hook = planner_hook;
-	planner_hook = test_hook;
+	planner_hook = test_planner_hook;
+
+	get_idle_session_timeout_hook = test_get_idle_session_timeout;
+	idle_session_timeout_action_hook = test_idle_session_timeout_action;
 }
 
 void
 _PG_fini(void)
 {
 	planner_hook = prev_planner_hook;
+
+	get_idle_session_timeout_hook = NULL;
+	idle_session_timeout_action_hook = NULL;
 }
 
 static PlannedStmt *
-test_hook(Query *parse, int cursorOptions, ParamListInfo boundParams)
+test_planner_hook(Query *parse, int cursorOptions, ParamListInfo boundParams)
 {
 	PlannedStmt *stmt;
 
-	elog(LOG, "In test_hook");
+	elog(LOG, "In test_planner_hook");
 
 	if (prev_planner_hook)
-		stmt = (* prev_planner_hook)(parse, cursorOptions, boundParams);
+		stmt = (*prev_planner_hook) (parse, cursorOptions, boundParams);
 	else
 		stmt = standard_planner(parse, cursorOptions, boundParams);
 
 	return stmt;
+}
+
+static int
+test_get_idle_session_timeout(void)
+{
+	return 50;					/* ms */
+}
+
+static void
+test_idle_session_timeout_action(void)
+{
+	elog(LOG, "In test_idle_session_timeout_action");
 }

--- a/src/test/regress/input/hooktest.source
+++ b/src/test/regress/input/hooktest.source
@@ -1,3 +1,16 @@
 LOAD '@abs_builddir@/hooktest/test_hook@DLSUFFIX@';
+-----------------------------------
+-- Test planner hook
+-----------------------------------
 SET client_min_messages='log';
 SELECT 1 AS a;
+
+-----------------------------------
+-- Test idle_session_timeout hooks
+-----------------------------------
+-- Disable the gang timeout so we don't have to wait a long time for the idle
+-- session timeout
+SET gp_vmem_idle_resource_timeout = 0;
+-- Make the session idle for 100ms to trigger the idle session timeout
+\!sleep 0.1s
+SELECT 1;

--- a/src/test/regress/output/hooktest.source
+++ b/src/test/regress/output/hooktest.source
@@ -1,10 +1,31 @@
 LOAD '@abs_builddir@/hooktest/test_hook@DLSUFFIX@';
+-----------------------------------
+-- Test planner hook
+-----------------------------------
 SET client_min_messages='log';
 SELECT 1 AS a;
 LOG:  statement: SELECT 1 AS a;
-LOG:  In test_hook
+LOG:  In test_planner_hook
  a 
 ---
  1
+(1 row)
+
+-----------------------------------
+-- Test idle_session_timeout hooks
+-----------------------------------
+-- Disable the gang timeout so we don't have to wait a long time for the idle
+-- session timeout
+SET gp_vmem_idle_resource_timeout = 0;
+LOG:  statement: SET gp_vmem_idle_resource_timeout = 0;
+-- Make the session idle for 100ms to trigger the idle session timeout
+\!sleep 0.1s
+SELECT 1;
+LOG:  In test_idle_session_timeout_action
+LOG:  statement: SELECT 1;
+LOG:  In test_planner_hook
+ ?column? 
+----------
+        1
 (1 row)
 


### PR DESCRIPTION
We've included an example implementation of the hook functions so you can see the intended usage of the new GPDB interface. We'll remove `idle_session_timeout_hook_example` before this PR is merged.

Co-authored-by: David Sharp <dsharp@pivotal.io>
Co-authored-by: Ben Christel <bchristel@pivotal.io>
Co-authored-by: Amil Khanzada <akhanzada@pivotal.io>