### PR TITLE
bfv_aggregate 8.4 MERGE fixme

### DIFF
--- a/src/test/regress/expected/bfv_aggregate.out
+++ b/src/test/regress/expected/bfv_aggregate.out
@@ -300,7 +300,7 @@ select string_agg(b || 'txt') over (partition by a+1) from foo order by 1;
  ccctxt
 (3 rows)
 
--- fall back and planner's plan produces unsupported execution
+-- fall back
 select string_agg(b) over (partition by a order by a) from foo order by 1;
  string_agg 
 ------------

--- a/src/test/regress/expected/bfv_aggregate_optimizer.out
+++ b/src/test/regress/expected/bfv_aggregate_optimizer.out
@@ -299,7 +299,7 @@ select string_agg(b || 'txt') over (partition by a+1) from foo order by 1;
  ccctxt
 (3 rows)
 
--- fall back and planner's plan produces unsupported execution
+-- fall back
 select string_agg(b) over (partition by a order by a) from foo order by 1;
  string_agg 
 ------------

--- a/src/test/regress/sql/bfv_aggregate.sql
+++ b/src/test/regress/sql/bfv_aggregate.sql
@@ -47,10 +47,6 @@ create aggregate mysum1(int4) (sfunc = int4_sum, prefunc=int8pl, stype=bigint);
 create aggregate mysum2(int4) (sfunc = int4_sum, stype=bigint);
 
 -- TEST
--- start_ignore
--- GPDB_84_MERGE_FIXME: QP team should look at this query (the implementation
--- changed in the window func merge)
--- end_ignore
 select
    id, val,
    sum(val) over (w),
@@ -182,11 +178,7 @@ select count_operator('select max(b) over (partition by a) from foo order by 1;'
 select string_agg(b) over (partition by a+1) from foo order by 1;
 select string_agg(b || 'txt') over (partition by a) from foo order by 1;
 select string_agg(b || 'txt') over (partition by a+1) from foo order by 1;
--- fall back and planner's plan produces unsupported execution
--- start_ignore
--- GPDB_84_MERGE_FIXME: QP team should look at these three queries (the
--- implementation changed in the window func merge)
--- end_ignore
+-- fall back
 select string_agg(b) over (partition by a order by a) from foo order by 1;
 select string_agg(b || 'txt') over (partition by a,b order by a,b) from foo order by 1;
 select '1' || string_agg(b) over (partition by a+1 order by a+1) from foo;


### PR DESCRIPTION
Remove the 8.4 merge fixme for window function related tests. Before the merge,
ORCA and planner would both error out if the aggregate used in the window did
not have preliminary functions associated with it. After the merge, ORCA still
falls back to the planner, but the planner produces the correct plan.