### PR TITLE
Revert "XLOG_HINT integration with persistent table (PT)"

### DIFF
--- a/src/backend/access/gist/gistget.c
+++ b/src/backend/access/gist/gistget.c
@@ -44,7 +44,7 @@ killtuple(Relation r, GISTScanOpaque so, ItemPointer iptr)
 		/* page unchanged, so all is simple */
 		offset = ItemPointerGetOffsetNumber(iptr);
 		ItemIdMarkDead(PageGetItemId(p, offset));
-		MarkBufferDirtyHint(so->curbuf, r);
+		MarkBufferDirtyHint(so->curbuf);
 	}
 	else
 	{
@@ -58,7 +58,7 @@ killtuple(Relation r, GISTScanOpaque so, ItemPointer iptr)
 			{
 				/* found */
 				ItemIdMarkDead(PageGetItemId(p, offset));
-				MarkBufferDirtyHint(so->curbuf, r);
+				MarkBufferDirtyHint(so->curbuf);
 				break;
 			}
 		}

--- a/src/backend/access/hash/hash.c
+++ b/src/backend/access/hash/hash.c
@@ -272,7 +272,7 @@ hashgettuple(PG_FUNCTION_ARGS)
 			/*
 			 * Since this can be redone later if needed, mark as a hint.
 			 */
-			MarkBufferDirtyHint(so->hashso_curbuf, rel);
+			MarkBufferDirtyHint(so->hashso_curbuf);
 		}
 
 		/*

--- a/src/backend/access/heap/pruneheap.c
+++ b/src/backend/access/heap/pruneheap.c
@@ -270,7 +270,7 @@ heap_page_prune(Relation relation, Buffer buffer, TransactionId OldestXmin,
 		{
 			((PageHeader) page)->pd_prune_xid = prstate.new_prune_xid;
 			PageClearFull(page);
-			MarkBufferDirtyHint(buffer, relation);
+			MarkBufferDirtyHint(buffer);
 		}
 	}
 

--- a/src/backend/access/nbtree/nbtinsert.c
+++ b/src/backend/access/nbtree/nbtinsert.c
@@ -499,9 +499,9 @@ _bt_check_unique(Relation rel, IndexTuple itup, Relation heapRel,
 						opaque->btpo_flags |= BTP_HAS_GARBAGE;
 						/* be sure to mark the proper buffer dirty... */
 						if (nbuf != InvalidBuffer)
-							MarkBufferDirtyHint(nbuf, rel);
+							MarkBufferDirtyHint(nbuf);
 						else
-							MarkBufferDirtyHint(buf, rel);
+							MarkBufferDirtyHint(buf);
 					}
 				}
 			}

--- a/src/backend/access/nbtree/nbtree.c
+++ b/src/backend/access/nbtree/nbtree.c
@@ -1165,7 +1165,7 @@ restart:
 				opaque->btpo_cycleid == vstate->cycleid)
 			{
 				opaque->btpo_cycleid = 0;
-				MarkBufferDirtyHint(buf, rel);
+				MarkBufferDirtyHint(buf);
 			}
 		}
 

--- a/src/backend/access/nbtree/nbtutils.c
+++ b/src/backend/access/nbtree/nbtutils.c
@@ -1190,7 +1190,6 @@ _bt_killitems(IndexScanDesc scan, bool haveLock)
 	OffsetNumber maxoff;
 	int			i;
 	bool		killedsomething = false;
-	Relation rel = scan->indexRelation;
 
 	Assert(BufferIsValid(so->currPos.buf));
 
@@ -1237,7 +1236,7 @@ _bt_killitems(IndexScanDesc scan, bool haveLock)
 	if (killedsomething)
 	{
 		opaque->btpo_flags |= BTP_HAS_GARBAGE;
-		MarkBufferDirtyHint(so->currPos.buf, rel);
+		MarkBufferDirtyHint(so->currPos.buf);
 	}
 
 	if (!haveLock)

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -9734,7 +9734,7 @@ RequestXLogSwitch(void)
  * i.e. those for which buffer_std == true
  */
 XLogRecPtr
-XLogSaveBufferForHint(Buffer buffer, Relation relation)
+XLogSaveBufferForHint(Buffer buffer) 
 {
 	XLogRecPtr recptr = InvalidXLogRecPtr;
 	XLogRecPtr lsn;

--- a/src/backend/commands/sequence.c
+++ b/src/backend/commands/sequence.c
@@ -1189,7 +1189,7 @@ read_seq_tuple(SeqTable elm, Relation rel, Buffer *buf, HeapTuple seqtuple)
 		HeapTupleHeaderSetXmax(seqtuple->t_data, InvalidTransactionId);
 		seqtuple->t_data->t_infomask &= ~HEAP_XMAX_COMMITTED;
 		seqtuple->t_data->t_infomask |= HEAP_XMAX_INVALID;
-		MarkBufferDirtyHint(*buf, rel);
+		MarkBufferDirtyHint(*buf);
 	}
 
 	seq = (Form_pg_sequence) GETSTRUCT(seqtuple);

--- a/src/backend/storage/buffer/bufmgr.c
+++ b/src/backend/storage/buffer/bufmgr.c
@@ -2430,6 +2430,7 @@ IncrBufferRefCount(Buffer buffer)
 		PrivateRefCount[buffer - 1]++;
 }
 
+
 /*
  * MarkBufferDirtyHint
  *
@@ -2445,7 +2446,7 @@ IncrBufferRefCount(Buffer buffer)
  *    (due to a race condition), so it cannot be used for important changes.
  */
 void
-MarkBufferDirtyHint(Buffer buffer, Relation relation)
+MarkBufferDirtyHint(Buffer buffer)
 {
 	volatile BufferDesc *bufHdr;
 	Page	page = BufferGetPage(buffer);
@@ -2532,10 +2533,7 @@ MarkBufferDirtyHint(Buffer buffer, Relation relation)
 			Assert(MyProc);
 			saved_inCommit = MyProc->inCommit;
 			MyProc->inCommit = true;
-			if (!relation->rd_istemp)
-			{
-				lsn = XLogSaveBufferForHint(buffer, relation);
-			}
+			lsn = XLogSaveBufferForHint(buffer);
 		}
 
 		LockBufHdr(bufHdr);

--- a/src/backend/utils/time/tqual.c
+++ b/src/backend/utils/time/tqual.c
@@ -91,7 +91,9 @@ markDirty(Buffer buffer, Relation relation, HeapTupleHeader tuple, bool isXmin)
 
 	if (!gp_disable_tuple_hints)
 	{
-		MarkBufferDirtyHint(buffer, relation);
+		if (!relation->rd_istemp)
+			MarkBufferDirtyHint(buffer);
+		return;
 	}
 
 	/*
@@ -103,7 +105,7 @@ markDirty(Buffer buffer, Relation relation, HeapTupleHeader tuple, bool isXmin)
 	if (relation->rd_issyscat)
 	{
 		/* Assume we want to always mark the buffer dirty */
-		MarkBufferDirtyHint(buffer, relation);
+		MarkBufferDirtyHint(buffer);
 		return;
 	}
 
@@ -117,7 +119,7 @@ markDirty(Buffer buffer, Relation relation, HeapTupleHeader tuple, bool isXmin)
 
 	if (xid == InvalidTransactionId)
 	{
-		MarkBufferDirtyHint(buffer, relation);
+		MarkBufferDirtyHint(buffer);
 		return;
 	}
 
@@ -126,7 +128,7 @@ markDirty(Buffer buffer, Relation relation, HeapTupleHeader tuple, bool isXmin)
 	 */
 	if (CLOGTransactionIsOld(xid))
 	{
-		MarkBufferDirtyHint(buffer, relation);
+		MarkBufferDirtyHint(buffer);
 		return;
 	}
 }

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -301,7 +301,7 @@ extern int	XLogFileOpen(uint32 log, uint32 seg);
 
 extern void XLogGetLastRemoved(uint32 *log, uint32 *seg);
 extern void XLogSetAsyncCommitLSN(XLogRecPtr record);
-extern XLogRecPtr XLogSaveBufferForHint(Buffer buffer, Relation relation);
+extern XLogRecPtr XLogSaveBufferForHint(Buffer buffer);
 
 extern void RestoreBkpBlocks(XLogRecPtr lsn, XLogRecord *record, bool cleanup);
 

--- a/src/include/storage/bufmgr.h
+++ b/src/include/storage/bufmgr.h
@@ -202,7 +202,7 @@ extern Size BufferShmemSize(void);
 extern void BufferGetTag(Buffer buffer, RelFileNode *rnode,
 			 ForkNumber *forknum, BlockNumber *blknum);
 
-extern void MarkBufferDirtyHint(Buffer buffer, Relation relation);
+extern void MarkBufferDirtyHint(Buffer buffer);
 
 extern void UnlockBuffers(void);
 extern void LockBuffer(Buffer buffer, int mode);


### PR DESCRIPTION
This reverts commit a21da89e4fae7b7f35e9efaf94e9839da8b52053. These
changes are obsolete now that persistent tables have been removed.

Co-authored-by: Asim R P <apraveen@pivotal.io>