### PR TITLE
Remove allowNotFound argument from mdtruncate function

### DIFF
--- a/src/backend/storage/smgr/md.c
+++ b/src/backend/storage/smgr/md.c
@@ -943,17 +943,11 @@ mdnblocks(SMgrRelation reln, ForkNumber forknum)
  */
 void
 mdtruncate(SMgrRelation reln, ForkNumber forknum, BlockNumber nblocks,
-		   bool isTemp, bool allowNotFound)
+		   bool isTemp)
 {
 	MdfdVec    *v;
 	BlockNumber curnblk;
 	BlockNumber priorblocks;
-
-	if (allowNotFound)
-	{
-		if (mdopen(reln, forknum, EXTENSION_RETURN_NULL) == NULL)
-			return;
-	}
 
 	/*
 	 * NOTE: mdnblocks makes sure we have opened all active segments, so that
@@ -963,7 +957,7 @@ mdtruncate(SMgrRelation reln, ForkNumber forknum, BlockNumber nblocks,
 	if (nblocks > curnblk)
 	{
 		/* Bogus request ... but no complaint if InRecovery */
-		if (InRecovery || allowNotFound)
+		if (InRecovery)
 			return;
 		ereport(ERROR,
 				(errmsg("could not truncate file \"%s\" to %u blocks: it's only %u blocks now",

--- a/src/backend/storage/smgr/smgr.c
+++ b/src/backend/storage/smgr/smgr.c
@@ -409,8 +409,7 @@ smgrtruncate(SMgrRelation reln, ForkNumber forknum, BlockNumber nblocks,
 	/*
 	 * Do the truncation.
 	 */
-	// GPDB_84_MERGE_FIXME: is allowedNotFound = false correct here?
-	mdtruncate(reln, forknum, nblocks, isLocalBuf, false /* allowedNotFound */);
+	mdtruncate(reln, forknum, nblocks, isLocalBuf);
 }
 
 /*

--- a/src/include/storage/smgr.h
+++ b/src/include/storage/smgr.h
@@ -118,8 +118,7 @@ extern void mdwrite(SMgrRelation reln, ForkNumber forknum,
 		BlockNumber blocknum, char *buffer, bool isTemp);
 extern BlockNumber mdnblocks(SMgrRelation reln, ForkNumber forknum);
 extern void mdtruncate(SMgrRelation reln, ForkNumber forknum,
-					   BlockNumber nblocks, bool isTemp,
-					   bool allowedNotFound);
+					   BlockNumber nblocks, bool isTemp);
 extern void mdimmedsync(SMgrRelation reln, ForkNumber forknum);
 extern void mdpreckpt(void);
 extern void mdsync(void);


### PR DESCRIPTION
This argument was introduced when master/standby WAL replication was
implemented to handle persistent table cases.  Since persistent tables
have been removed, we no longer need this argument to mdtruncate.
This takes care of a GPDB_84_MERGE_FIXME.