### PR TITLE
WIP: enable syslog facility in GPDB

### DIFF
--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -1382,8 +1382,8 @@ PostmasterMain(int argc, char *argv[])
 	if (!(Log_destination & LOG_DESTINATION_STDERR))
 		ereport(LOG,
 				(errmsg("ending log output to stderr"),
-			  errhint("Future log output will go to log destination \"%s\".",
-					  Log_destination_string)));
+				 errhint("Future log output will go to log destination \"%s\".",
+						 Log_destination_string)));
 
 	whereToSendOutput = DestNone;
 

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -156,6 +156,8 @@ int			Log_error_verbosity = PGERROR_VERBOSE;
 char	   *Log_line_prefix = NULL;		/* format for extra log line info */
 int			Log_destination = LOG_DESTINATION_STDERR;
 char	   *Log_destination_string = NULL;
+bool		syslog_sequence_numbers = true;
+bool		syslog_split_messages = true;
 
 #ifdef HAVE_SYSLOG
 

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -3054,7 +3054,7 @@ static struct config_string ConfigureNamesString[] =
 			gettext_noop("Valid values are combinations of \"stderr\", "
 						 "\"syslog\", \"csvlog\", and \"eventlog\", "
 						 "depending on the platform."),
-                        GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+                        GUC_LIST_INPUT | GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&Log_destination_string,
 		"stderr",

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -3049,23 +3049,23 @@ static struct config_string ConfigureNamesString[] =
 	},
 
 	{
-		{"log_destination", PGC_SIGHUP, DEFUNCT_OPTIONS,
+		{"log_destination", PGC_SIGHUP, LOGGING_WHERE,
 			gettext_noop("Defunct: Sets the destination for server log output."),
 			gettext_noop("Valid values are combinations of \"stderr\", "
 						 "\"syslog\", \"csvlog\", and \"eventlog\", "
 						 "depending on the platform."),
-			GUC_LIST_INPUT | GUC_NO_SHOW_ALL
+                        GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&Log_destination_string,
 		"stderr",
 		check_log_destination, assign_log_destination, NULL
 	},
 	{
-		{"log_directory", PGC_SIGHUP, DEFUNCT_OPTIONS,
+		{"log_directory", PGC_SIGHUP, LOGGING_WHERE,
 			gettext_noop("Defunct: Sets the destination directory for log files."),
 			gettext_noop("Can be specified as relative to the data directory "
 						 "or as absolute path."),
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL
+			GUC_SUPERUSER_ONLY
 		},
 		&Log_directory,
 		"pg_log",
@@ -3083,14 +3083,14 @@ static struct config_string ConfigureNamesString[] =
 	},
 
 	{
-		{"syslog_ident", PGC_SIGHUP, DEFUNCT_OPTIONS,
+		{"syslog_ident", PGC_SIGHUP, LOGGING_WHERE,
 			gettext_noop("Sets the program name used to identify PostgreSQL "
 						 "messages in syslog."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+                        GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&syslog_ident_str,
-		"postgres",
+		"greenplum", 
 		NULL, assign_syslog_ident, NULL
 	},
 
@@ -3482,11 +3482,11 @@ static struct config_enum ConfigureNamesEnum[] =
 	},
 
 	{
-		{"syslog_facility", PGC_SIGHUP, DEFUNCT_OPTIONS,
+		{"syslog_facility", PGC_SIGHUP, LOGGING_WHAT,
 			gettext_noop("Sets the syslog \"facility\" to be used when syslog enabled."),
 			gettext_noop("Valid values are LOCAL0, LOCAL1, LOCAL2, LOCAL3, "
 						 "LOCAL4, LOCAL5, LOCAL6, LOCAL7."),
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&syslog_facility,
 #ifdef HAVE_SYSLOG

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -3075,7 +3075,7 @@ static struct config_string ConfigureNamesString[] =
 		{"log_filename", PGC_SIGHUP, LOGGING_WHERE,
 			gettext_noop("Sets the file name pattern for log files."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY
 		},
 		&Log_filename,
 		"gpdb-%Y-%m-%d_%H%M%S.csv",

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -3050,11 +3050,11 @@ static struct config_string ConfigureNamesString[] =
 
 	{
 		{"log_destination", PGC_SIGHUP, LOGGING_WHERE,
-			gettext_noop("Defunct: Sets the destination for server log output."),
+			gettext_noop("Sets the destination for server log output."),
 			gettext_noop("Valid values are combinations of \"stderr\", "
 						 "\"syslog\", \"csvlog\", and \"eventlog\", "
 						 "depending on the platform."),
-                        GUC_LIST_INPUT | GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+                        GUC_LIST_INPUT
 		},
 		&Log_destination_string,
 		"stderr",
@@ -3062,7 +3062,7 @@ static struct config_string ConfigureNamesString[] =
 	},
 	{
 		{"log_directory", PGC_SIGHUP, LOGGING_WHERE,
-			gettext_noop("Defunct: Sets the destination directory for log files."),
+			gettext_noop("Sets the destination directory for log files."),
 			gettext_noop("Can be specified as relative to the data directory "
 						 "or as absolute path."),
 			GUC_SUPERUSER_ONLY
@@ -3084,7 +3084,7 @@ static struct config_string ConfigureNamesString[] =
 
 	{
 		{"syslog_ident", PGC_SIGHUP, LOGGING_WHERE,
-			gettext_noop("Sets the program name used to identify PostgreSQL "
+			gettext_noop("Sets the program name used to identify Greenplum "
 						 "messages in syslog."),
 			NULL,
                         GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
@@ -3482,11 +3482,9 @@ static struct config_enum ConfigureNamesEnum[] =
 	},
 
 	{
-		{"syslog_facility", PGC_SIGHUP, LOGGING_WHAT,
+		{"syslog_facility", PGC_SIGHUP, LOGGING_WHERE,
 			gettext_noop("Sets the syslog \"facility\" to be used when syslog enabled."),
-			gettext_noop("Valid values are LOCAL0, LOCAL1, LOCAL2, LOCAL3, "
-						 "LOCAL4, LOCAL5, LOCAL6, LOCAL7."),
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+                        NULL
 		},
 		&syslog_facility,
 #ifdef HAVE_SYSLOG
@@ -9538,7 +9536,7 @@ static void
 assign_syslog_facility(int newval, void *extra)
 {
 #ifdef HAVE_SYSLOG
-	set_syslog_parameters(syslog_ident_str ? syslog_ident_str : "postgres",
+	set_syslog_parameters(syslog_ident_str ? syslog_ident_str : "greenplum",
 						  newval);
 #endif
 	/* Without syslog support, just ignore it */

--- a/src/backend/utils/misc/postgresql.conf.sample
+++ b/src/backend/utils/misc/postgresql.conf.sample
@@ -326,6 +326,22 @@ optimizer_analyze_root_partition = on # stats collection on root partitions
 
 # - Where to Log -
 
+#log_destination = 'stderr'		# Valid values are combinations of
+					# stderr, csvlog, syslog, and eventlog,
+					# depending on platform.  csvlog
+					# requires logging_collector to be on.
+
+# This is used when logging to stderr:
+#logging_collector = on			# Enable capturing of stderr and csvlog
+					# into log files. Required to be on for
+					# csvlogs.
+					# (change requires restart)
+
+# These are only used if logging_collector is on:
+#log_directory = 'pg_log'		# directory where log files are written,
+					# can be absolute or relative to PGDATA
+#log_filename = 'gpdb-%Y-%m-%d_%H%M%S.log'	# log file name pattern,
+					# can include strftime() escapes
 #log_file_mode = 0600			# creation mode for log files,
 					# begin with 0 to use octal notation
 #log_truncate_on_rotation = off		# If on, an existing log file with the
@@ -341,6 +357,10 @@ optimizer_analyze_root_partition = on # stats collection on root partitions
 #log_rotation_size = 10MB		# Automatic rotation of logfiles will
 					# happen after that much log output.
 					# 0 disables.
+
+# These are relevant when logging to syslog:
+#syslog_facility = 'LOCAL0'
+#syslog_ident = 'greenplum'
 
 # - When to Log -
 

--- a/src/include/utils/elog.h
+++ b/src/include/utils/elog.h
@@ -597,6 +597,8 @@ extern int	Log_error_verbosity;
 extern char *Log_line_prefix;
 extern int	Log_destination;
 extern char *Log_destination_string;
+extern bool syslog_sequence_numbers;
+extern bool syslog_split_messages;
 
 /* Log destination bitmap */
 #define LOG_DESTINATION_STDERR	 1


### PR DESCRIPTION
Can we turn on syslog in GPDB and not break the world? It could be handy for pushing the info to a secure location or message collector