### PR TITLE
Remove GPDB_84_MERGE_FIXME from outfuncs.c

### DIFF
--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -2189,21 +2189,6 @@ _outIndexOptInfo(StringInfo str, IndexOptInfo *node)
 
 #ifndef COMPILING_BINARY_FUNCS
 static void
-_outCdbRelColumnInfo(StringInfo str, CdbRelColumnInfo *node)
-{
-	WRITE_NODE_TYPE("CdbRelColumnInfo");
-
-    WRITE_INT_FIELD(pseudoattno);
-    WRITE_INT_FIELD(targetresno);
-	WRITE_INT_FIELD(attr_width);
-	WRITE_BITMAPSET_FIELD(where_needed);
-    WRITE_STRING_FIELD(colname);
-	WRITE_NODE_FIELD(defexpr);
-}
-#endif /* COMPILING_BINARY_FUNCS */
-
-#ifndef COMPILING_BINARY_FUNCS
-static void
 _outEquivalenceClass(StringInfo str, EquivalenceClass *node)
 {
 	/*
@@ -3781,9 +3766,6 @@ _outRangeTblEntry(StringInfo str, RangeTblEntry *node)
 	 * pseudocols is intentionally not serialized. It's only used in the planning
 	 * stage, so no need to transfer it to the QEs.
 	 */
-	/* GPDB_84_MERGE_FIXME: um, pick either "serialized" or "not serialized".
-	   Then update the fast serialization functions to match. */
-    WRITE_NODE_FIELD(pseudocols);                                       /*CDB*/
 }
 #endif /* COMPILING_BINARY_FUNCS */
 
@@ -4798,9 +4780,6 @@ _outNode(StringInfo str, void *obj)
 				break;
 			case T_IndexOptInfo:
 				_outIndexOptInfo(str, obj);
-				break;
-			case T_CdbRelColumnInfo:
-				_outCdbRelColumnInfo(str, obj);
 				break;
 			case T_EquivalenceClass:
 				_outEquivalenceClass(str, obj);

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -2151,8 +2151,7 @@ _readRangeTblEntry(void)
 	READ_BITMAPSET_FIELD(modifiedCols);
 
 	READ_BOOL_FIELD(forceDistRandom);
-	READ_NODE_FIELD(pseudocols);
-
+	/* 'pseudocols' is intentionally missing, see out function */
 	READ_DONE();
 }
 #endif /* COMPILING_BINARY_FUNCS */


### PR DESCRIPTION
The pseudocols field was added to RangeTblEntry to avoid duplicates in the
target list. When the field was added, a WRITE_NODE_FIELD was added in
_outRangeTblEntry(), but a corresponding READ_NODE_FIELD was not added in the
_readRangeTblEntry(). Additionally, this field was not added to the readfast
and outfast functions either since this field was not used after the planning
stage and did not have to be dispatched to the QE's.  Later, in
fd6741f, a corresponding READ_NODE_FIELD was
added along with a FIXME to decide whether or not to serialize/deserialize.
After confirming that this field is not used after planning, we have decided to
remove any serialization/deserialization of the pseudocols member of
RangeTblEntry

Signed-off-by: Abhijit Subramanya <asubramanya@pivotal.io>