### PR TITLE
Fix storing of nextLocalTransactionId into shared memory

### DIFF
--- a/src/backend/storage/ipc/sinvaladt.c
+++ b/src/backend/storage/ipc/sinvaladt.c
@@ -351,7 +351,7 @@ CleanupInvalidationState(int status, Datum arg)
 	stateP = &segP->procState[MyBackendId - 1];
 
 	/* Update next local transaction ID for next holder of this backendID */
-	nextLocalTransactionId = stateP->nextLXID;
+	stateP->nextLXID = nextLocalTransactionId;
 
 	/* Mark myself inactive */
 	stateP->procPid = 0;


### PR DESCRIPTION
This seems to have been introduced during the Postgres 8.3 merge as
part of the introduction of lazy xids.  The line to store
nextLocalTransactionId into shared memory seems to have been
accidentally reversed.  This may cause reuse of local transaction ids
when the corresponding backend slot is reused in very rare cases.  It
doesn't seem to be too critical but we should change it back to what
it was originally.

This was caught during the Postgres 8.4 merge as a merge conflict
which was then turned into a GPDB_84_MERGE_FIXME.