### PR TITLE
Remove GPDB_84_MERGE_FIXME from sinvaladt.c

### DIFF
--- a/src/backend/storage/ipc/sinvaladt.c
+++ b/src/backend/storage/ipc/sinvaladt.c
@@ -351,8 +351,6 @@ CleanupInvalidationState(int status, Datum arg)
 	stateP = &segP->procState[MyBackendId - 1];
 
 	/* Update next local transaction ID for next holder of this backendID */
-	/* GPDB_84_MERGE_FIXME: this assignment was reversed in the 8.3 merge; does
-	 * this change need to be backported to 4/5? */
 	stateP->nextLXID = nextLocalTransactionId;
 
 	/* Mark myself inactive */


### PR DESCRIPTION
The fixme comment was placed here to warn that the implementation
might be backwards on Greenplum 4.X and 5.X.  The concern is not valid
for Greenplum 4.X because there is no lazy xids.  However, the concern
is indeed valid for Greenplum 5.x.  This is noted and will be changed
on the 5X_STABLE branch.

[ci skip]