### PR TITLE
Skip marking mirror down by FTS if retryRequested.

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -139,11 +139,6 @@ int			gp_fts_probe_interval = 60;
  */
 int			gp_fts_probe_threadcount = 16;
 
-/*
- * Controls parallel segment transition (failover).
- */
-bool		gp_fts_transition_parallel = true;
-
 /* The number of retries to request a segment state transition. */
 int			gp_fts_transition_retries = 5;
 

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -134,17 +134,11 @@ int			gp_fts_probe_timeout = 20;
 int			gp_fts_probe_interval = 60;
 
 /*
- * Number of threads to use for probe of segments (it is a good idea to have this
- * larger than the number of segments per host.
+ * If mirror disconnects and re-connects between this period, or just takes
+ * this much time during initial connection of cluster start, it will not get
+ * reported as down to FTS.
  */
-int			gp_fts_probe_threadcount = 16;
-
-/* The number of retries to request a segment state transition. */
-int			gp_fts_transition_retries = 5;
-
-/* Timeout to request a segment state transition. */
-int			gp_fts_transition_timeout = 3600;
-
+int gp_fts_mark_mirror_down_grace_period = 30;
 
 /*
  * When we have certain types of failures during gang creation which indicate

--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -607,7 +607,6 @@ void FtsLoop()
 
 	prober_sleep:
 		{
-
 			/* check if we need to sleep before starting next iteration */
 			elapsed = time(NULL) - probe_start_time;
 			if (elapsed < gp_fts_probe_interval && !shutdown_requested)

--- a/src/backend/replication/test/gp_replication_test.c
+++ b/src/backend/replication/test/gp_replication_test.c
@@ -79,7 +79,7 @@ test_GetMirrorStatus_Pid_Zero(void **state)
 	 * duration is taken into account.
 	 */
 	data.walsnds[0].marked_pid_zero_at_time =
-		((pg_time_t) time(NULL)) - FTS_MARKING_MIRROR_DOWN_GRACE_PERIOD;
+		((pg_time_t) time(NULL)) - gp_fts_mark_mirror_down_grace_period;
 
 	/*
 	 * Ensure the recovery finished before wal sender died.
@@ -107,12 +107,12 @@ test_GetMirrorStatus_RequestRetry(void **state)
 	 * Make the pid zero time within the grace period.
 	 */
 	data.walsnds[0].marked_pid_zero_at_time =
-		((pg_time_t) time(NULL)) - FTS_MARKING_MIRROR_DOWN_GRACE_PERIOD/2;
+		((pg_time_t) time(NULL)) - gp_fts_mark_mirror_down_grace_period/2;
 
 	/*
 	 * Ensure recovery finished before wal sender died.
 	 */
-	PMAcceptingConnectionsStartTime = data.walsnds[0].marked_pid_zero_at_time - FTS_MARKING_MIRROR_DOWN_GRACE_PERIOD;
+	PMAcceptingConnectionsStartTime = data.walsnds[0].marked_pid_zero_at_time - gp_fts_mark_mirror_down_grace_period;
 
 	expect_lwlock(LW_SHARED);
 	expect_ereport();
@@ -138,14 +138,14 @@ test_GetMirrorStatus_Delayed_AcceptingConnectionsStartTime(void **state)
 	 * Mirror will be marked down, and no retry.
 	 */
 	data.walsnds[0].marked_pid_zero_at_time =
-		((pg_time_t) time(NULL)) - FTS_MARKING_MIRROR_DOWN_GRACE_PERIOD;
+		((pg_time_t) time(NULL)) - gp_fts_mark_mirror_down_grace_period;
 
 	/*
 	 * However the database was in recovery, hence
 	 * we are still within the grace period, and
 	 * we should retry.
 	 */
-	PMAcceptingConnectionsStartTime = ((pg_time_t) time(NULL)) - FTS_MARKING_MIRROR_DOWN_GRACE_PERIOD/2;
+	PMAcceptingConnectionsStartTime = ((pg_time_t) time(NULL)) - gp_fts_mark_mirror_down_grace_period/2;
 
 	expect_lwlock(LW_SHARED);
 	expect_ereport();

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -1041,16 +1041,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"gp_fts_transition_parallel", PGC_POSTMASTER, GP_ARRAY_TUNING,
-			gettext_noop("Activate parallel segment transition."),
-			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&gp_fts_transition_parallel,
-		true, NULL, NULL
-	},
-
-	{
 		{"gp_debug_pgproc", PGC_POSTMASTER, DEVELOPER_OPTIONS,
 			gettext_noop("Print debug info relevant to PGPROC."),
 			NULL /* long description */ ,
@@ -3483,7 +3473,7 @@ struct config_int ConfigureNamesInt_gp[] =
 	},
 
 	{
-		{"gp_fts_probe_retries", PGC_POSTMASTER, GP_ARRAY_TUNING,
+		{"gp_fts_probe_retries", PGC_SIGHUP, GP_ARRAY_TUNING,
 			gettext_noop("Number of retries for FTS to complete probing a segment."),
 			gettext_noop("Used by the fts-probe process."),
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
@@ -3493,7 +3483,7 @@ struct config_int ConfigureNamesInt_gp[] =
 	},
 
 	{
-		{"gp_fts_probe_timeout", PGC_USERSET, GP_ARRAY_TUNING,
+		{"gp_fts_probe_timeout", PGC_SIGHUP, GP_ARRAY_TUNING,
 			gettext_noop("Maximum time (in seconds) allowed for FTS to complete probing a segment."),
 			gettext_noop("Used by the fts-probe process."),
 			GUC_UNIT_S
@@ -3503,7 +3493,7 @@ struct config_int ConfigureNamesInt_gp[] =
 	},
 
 	{
-		{"gp_fts_probe_interval", PGC_POSTMASTER, GP_ARRAY_TUNING,
+		{"gp_fts_probe_interval", PGC_SIGHUP, GP_ARRAY_TUNING,
 			gettext_noop("A complete probe of all segments starts each time a timer with this period expires."),
 			gettext_noop("Used by the fts-probe process. "),
 			GUC_UNIT_S

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -3503,6 +3503,16 @@ struct config_int ConfigureNamesInt_gp[] =
 	},
 
 	{
+		{"gp_fts_mark_mirror_down_grace_period", PGC_SIGHUP, GP_ARRAY_TUNING,
+			gettext_noop("Time (in seconds) allowed to mirror after disconnection, to reconnect before being marked as down in configuration by FTS."),
+			gettext_noop("Used by the fts-probe process."),
+			GUC_UNIT_S
+		},
+		&gp_fts_mark_mirror_down_grace_period,
+		30, 0, 3600, NULL, NULL
+	},
+
+	{
 		{"gp_gang_creation_retry_count", PGC_USERSET, GP_ARRAY_TUNING,
 			gettext_noop("After a gang-creation fails, retry the number of times if failure is retryable."),
 			gettext_noop("A value of zero disables retries."),

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -346,7 +346,7 @@ extern int	gp_snapshotadd_timeout; /* GUC var - timeout specifier for snapshot-c
 extern int	gp_fts_probe_retries; /* GUC var - specifies probe number of retries for FTS */
 extern int	gp_fts_probe_timeout; /* GUC var - specifies probe timeout for FTS */
 extern int	gp_fts_probe_interval; /* GUC var - specifies polling interval for FTS */
-extern int	gp_fts_probe_threadcount; /* GUC var - specifies number of threads to use for FTS probes */
+extern int gp_fts_mark_mirror_down_grace_period;
 
 extern int gp_gang_creation_retry_count; /* How many retries ? */
 extern int gp_gang_creation_retry_timer; /* How long between retries */

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -347,7 +347,6 @@ extern int	gp_fts_probe_retries; /* GUC var - specifies probe number of retries 
 extern int	gp_fts_probe_timeout; /* GUC var - specifies probe timeout for FTS */
 extern int	gp_fts_probe_interval; /* GUC var - specifies polling interval for FTS */
 extern int	gp_fts_probe_threadcount; /* GUC var - specifies number of threads to use for FTS probes */
-extern bool	gp_fts_transition_parallel; /* GUC var - controls parallel segment transition for FTS */
 
 extern int gp_gang_creation_retry_count; /* How many retries ? */
 extern int gp_gang_creation_retry_timer; /* How long between retries */

--- a/src/test/isolation2/expected/segwalrep/fts_unblock_primary.out
+++ b/src/test/isolation2/expected/segwalrep/fts_unblock_primary.out
@@ -29,6 +29,11 @@ synchronous_standby_names
 -------------------------
 *                        
 (1 row)
+2U: show gp_fts_mark_mirror_down_grace_period;
+gp_fts_mark_mirror_down_grace_period
+------------------------------------
+30s                                 
+(1 row)
 
 -- create table and show commits are not blocked
 create table fts_unblock_primary (a int) distributed by (a);
@@ -89,7 +94,37 @@ gp_inject_fault
 t              
 (1 row)
 
---trigger fts probe and check to see primary marked n/u and mirror n/d
+-- trigger fts probe and check to see primary marked n/u and mirror still n/u as
+-- still should be in mirror down grace period.
+select gp_request_fts_probe_scan();
+gp_request_fts_probe_scan
+-------------------------
+t                        
+(1 row)
+select content, role, preferred_role, mode, status from gp_segment_configuration where content=2;
+content|role|preferred_role|mode|status
+-------+----+--------------+----+------
+2      |p   |p             |s   |u     
+2      |m   |m             |s   |u     
+(2 rows)
+
+-- set mirror down grace period to zero to instantly mark mirror down
+!\retcode gpconfig -c gp_fts_mark_mirror_down_grace_period -v 0;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -u;
+-- start_ignore
+-- end_ignore
+(exited with code 1)
+
+2U: show gp_fts_mark_mirror_down_grace_period;
+gp_fts_mark_mirror_down_grace_period
+------------------------------------
+0                                   
+(1 row)
+
+-- trigger fts probe and check to see primary marked n/u and mirror n/d
 select gp_request_fts_probe_scan();
 gp_request_fts_probe_scan
 -------------------------
@@ -141,4 +176,18 @@ INSERT 10
 synchronous_standby_names
 -------------------------
 *                        
+(1 row)
+
+!\retcode gpconfig -r gp_fts_mark_mirror_down_grace_period;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -u;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+2U: show gp_fts_mark_mirror_down_grace_period;
+gp_fts_mark_mirror_down_grace_period
+------------------------------------
+30s                                 
 (1 row)


### PR DESCRIPTION
Mirror is provided with grace period before being marked as down. FTS probes
during this grace period interval, return retryRequested to probe request. Based
on `retryRequested` should retry probes to primary and incase number of retries
reach retry limit of `gp_fts_probe_retries` must skip marking such mirror down
as still primary has not given go ahead to mark it down. Only when
`retryRequested=false`, mirror must be marked down.
