### PR TITLE
Remove GPDB_84_MERGE_FIXME from postmaster.c

### DIFF
--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -2216,8 +2216,7 @@ retry1:
 					 errmsg("sorry, too many clients already")));
 			break;
 		case CAC_WAITBACKUP:
-			/* GPDB_84_MERGE_FIXME: we don't have a WAITBACKUP state. 
-			 * Do we want to just remove this case entirely? */
+			/* Greenplum does not currently use WAITBACKUP state. */
 			Assert(port->canAcceptConnections != CAC_WAITBACKUP);
 			break;
 		case CAC_MIRROR_READY:


### PR DESCRIPTION
The FIXME comment asked whether or not we wanted to remove the check
on CAC_WAITBACKUP.  It is true that we do not currently use WAITBACKUP
state, but we should continue to have the code.  It will prevent some
merge conflicts during postgres merge, and we may use it sometime in
the future if applicable to any future Greenplum features.