### PR TITLE
FtsNotifyProber() shouldn't wait infinitely for FTS probes.

### DIFF
--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -2335,9 +2335,6 @@ recoverTM(void)
 {
 	bool		dtmRecoveryDeferred;
 
-	/* intialize fts sync count */
-	verifyFtsSyncCount();
-
 	elog(DTM_DEBUG3, "Starting to Recover DTM...");
 
 	/*

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -372,7 +372,7 @@ getComponentDatabases(void)
 	Assert(Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_UTILITY);
 	Assert(GangContext != NULL);
 
-	uint64		ftsVersion = getFtsVersion();
+	uint8		ftsVersion = getFtsVersion();
 	MemoryContext oldContext = MemoryContextSwitchTo(GangContext);
 
 	if (cdb_component_dbs == NULL)

--- a/src/backend/cdb/dispatcher/test/cdbgang_test.c
+++ b/src/backend/cdb/dispatcher/test/cdbgang_test.c
@@ -140,7 +140,7 @@ static void
 test__createWriterGang(void **state)
 {
 	int			segmentCount = TOTOAL_SEGMENTS;
-	int			ftsVersion = 1;
+	uint8		ftsVersion = 1;
 	PGconn	   *conn = &pgconn;
 	uint32		motionListener = 10000;
 	int			qePid = 2000;
@@ -192,7 +192,7 @@ static void
 test__createReaderGang(void **state)
 {
 	int			segmentCount = TOTOAL_SEGMENTS;
-	int			ftsVersion = 1;
+	uint8		ftsVersion = 1;
 	PGconn	   *conn = &pgconn;
 	const char *portalName = "portal1";
 	uint32		motionListener = 10000;

--- a/src/backend/fts/test/Makefile
+++ b/src/backend/fts/test/Makefile
@@ -19,6 +19,7 @@ ftsmessagehandler.t: \
 
 ftsprobe.t: \
     $(MOCK_DIR)/backend/fts/fts_mock.o \
+    $(MOCK_DIR)/backend/cdb/cdbfts_mock.o \
     $(MOCK_DIR)/backend/libpq/fe-exec_mock.o \
     $(MOCK_DIR)/backend/libpq/fe-connect_mock.o \
     $(MOCK_DIR)/backend/access/transam/xact_mock.o \

--- a/src/backend/fts/test/ftsprobe_test.c
+++ b/src/backend/fts/test/ftsprobe_test.c
@@ -192,6 +192,8 @@ PrimaryOrMirrorWillBeUpdated(int count)
 	will_be_called_count(StartTransactionCommand, count);
 	will_be_called_count(GetTransactionSnapshot, count);
 	will_be_called_count(CommitTransactionCommand, count);
+	will_be_called_count(ftsLock, count);
+	will_be_called_count(ftsUnlock, count);
 }
 
 /*

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -180,7 +180,6 @@ static Dllist *BackendList;
 typedef enum pmsub_type
 {
 	SeqServerProc = 0,
-	WalRedoServerProc,
 	FtsProbeProc,
 	PerfmonProc,
 	BackoffProc,
@@ -377,6 +376,8 @@ static PMSubProc PMSubProcList[MaxPMSubType] =
 	(PMSubStartCallback*)&perfmon_segmentinfo_start,
 	"stats sender process", PMSUBPROC_FLAG_QD_AND_QE, true},
 };
+
+static PMSubProc *FTSSubProc = &PMSubProcList[FtsProbeProc];
 
 static bool ReachedNormalRunning = false;		/* T if we've reached PM_RUN */
 
@@ -2911,7 +2912,6 @@ reaper(SIGNAL_ARGS)
 			if (subProc->pid != 0 && pid == subProc->pid)
 			{
 				subProc->pid = 0;
-
 				if (!EXIT_STATUS_0(exitstatus))
 					LogChildExit(LOG, subProc->procName, pid, exitstatus);
 
@@ -4994,6 +4994,12 @@ sigusr1_handler(SIGNAL_ARGS)
 	{
 		/* The autovacuum launcher wants us to start a worker process. */
 		StartAutovacuumWorker();
+	}
+
+	Assert(FTSSubProc->procType == FtsProbeProc);
+	if (CheckPostmasterSignal(PMSIGNAL_WAKEN_FTS) && FTSSubProc->pid != 0)
+	{
+		signal_child(FTSSubProc->pid, SIGINT);
 	}
 
 	/*

--- a/src/include/cdb/cdbfts.h
+++ b/src/include/cdb/cdbfts.h
@@ -32,10 +32,8 @@
 
 typedef struct FtsProbeInfo
 {
-	volatile uint32		fts_probePid;
-	volatile uint64		fts_probeScanRequested;
-	volatile uint64		fts_statusVersion;
-	volatile bool       fts_status_initialized;
+	volatile uint8		fts_statusVersion;
+	volatile uint8      probeTick;
 	volatile uint8		fts_status[FTS_MAX_DBS];
 } FtsProbeInfo;
 
@@ -43,8 +41,6 @@ typedef struct FtsProbeInfo
 
 typedef struct FtsControlBlock
 {
-	bool		ftsShutdownMaster;
-
 	LWLockId	ControlLock;
 
 	bool		ftsReadOnlyFlag;
@@ -54,7 +50,7 @@ typedef struct FtsControlBlock
 
 }	FtsControlBlock;
 
-extern FtsProbeInfo *ftsProbeInfo;
+extern volatile FtsProbeInfo *ftsProbeInfo;
 
 extern int	FtsShmemSize(void);
 extern void FtsShmemInit(void);
@@ -72,7 +68,7 @@ extern void ftsUnlock(void);
 extern void FtsNotifyProber(void);
 
 extern bool isFtsReadOnlySet(void);
-extern uint64 getFtsVersion(void);
+extern uint8 getFtsVersion(void);
 
 /* markStandbyStatus forces persistent state change ?! */
 #define markStandbyStatus(dbid, state) (markSegDBPersistentState((dbid), (state)))

--- a/src/include/cdb/cdbutil.h
+++ b/src/include/cdb/cdbutil.h
@@ -99,7 +99,7 @@ typedef struct CdbComponentDatabases
 	int			my_dbid;		/* the dbid of this database */
 	int			my_segindex;	/* the content of this database */
 	bool		my_isprimary;	/* the isprimary flag of this database */
-	int		fts_version;	/* the version of fts */
+	uint8		fts_version;	/* the version of fts */
 } CdbComponentDatabases;
 
 /*

--- a/src/include/storage/pmsignal.h
+++ b/src/include/storage/pmsignal.h
@@ -30,6 +30,8 @@ typedef enum
 	PMSIGNAL_START_AUTOVAC_WORKER,		/* start an autovacuum worker */
 	PMSIGNAL_START_WALRECEIVER, /* start a walreceiver */
 
+	PMSIGNAL_WAKEN_FTS,         /* wake up FTS to probe segments */
+
 	NUM_PMSIGNALS				/* Must be last value of enum! */
 } PMSignalReason;
 


### PR DESCRIPTION
- Use standard PMSignal mechanism to trigger FTS probes from
  dispatcher.

- Use statusVersion flag only to indicate if a probe cycle resulted in
configuration update. This was overloaded to also unblock callers
waiting for FTS probe to be triggered and finished.

- Use a separate flag "probeTick" for this purpose.

Co-authored-by: Ashwin Agrawal <aagrawal@pivotal.io>