### PR TITLE
Remove GPDB_84_MERGE_FIXME from heap.h

### DIFF
--- a/src/include/catalog/heap.h
+++ b/src/include/catalog/heap.h
@@ -19,11 +19,7 @@
 #include "parser/parse_node.h"
 #include "catalog/indexing.h"
 
-/*
- * GPDB_84_MERGE_FIXME: the new constraints work in tablecmds use RawColumnDefault
- * which has been removed from GPDB in the past. Re-added for now but perhaps
- * there is a bigger rewrite looming in tablecmds.c
- */
+
 typedef struct RawColumnDefault
 {
 	AttrNumber	attnum;			/* attribute to attach default to */


### PR DESCRIPTION
RawColumnDefault was removed previously as part of a commit that fixed
pg_attrdef oid inconsistency between the master and primaries.  This
is not an issue anymore since we send pre-assigned oids during
dispatch since Greenplum 5X and have checks around it in the code.  We
also have an oid_consistency test in src/test/regress that passes, and
gpcheckcat doesn't complain.  It seems like we're covered here.