### PR TITLE
docs - gpbackup, gprestore to use dash-dash for options

### DIFF
--- a/gpdb-doc/dita/admin_guide/managing/backup-boostfs.xml
+++ b/gpdb-doc/dita/admin_guide/managing/backup-boostfs.xml
@@ -13,7 +13,7 @@
          a Data Domain system as a standard file system mount point. With direct access to a BoostFS
          mount point, <codeph>gpbackup</codeph> and <codeph>gprestore</codeph> can leverage the
          storage and network efficiencies of the DD Boost protocol for backup and recovery.</p>
-      <p>To back up or restore with BoostFS, you include the option <codeph>-backup-dir</codeph>
+      <p>To back up or restore with BoostFS, you include the option <codeph>--backup-dir</codeph>
          with the <codeph>gpbackup</codeph> or <codeph>gprestore</codeph> command to access the Data
          Domain system.</p>
    </body>
@@ -47,7 +47,7 @@
                point.<codeblock>&lt;<varname>mounted_directory</varname>> is a mountpoint</codeblock></li>
          </ol>
          <p>You can now run <codeph>gpbackup</codeph> and <codeph>gprestore</codeph> with the
-               <codeph>-backup-dir</codeph> option to back up a database to
+               <codeph>--backup-dir</codeph> option to back up a database to
                   <codeph>&lt;<varname>mounted_directory</varname>></codeph> on the Data Domain
             system and restore data from the Data Domain system. </p>
       </body>
@@ -57,26 +57,26 @@
       <body>
          <p>These are required <codeph>gpbackup</codeph> options when backing up data to a Data
             Domain system with BoostFS.<ul id="ul_h3t_pcb_cdb">
-               <li><codeph>-backup-dir</codeph> - Specify the mounted Data Domain storage unit.</li>
-               <li><codeph>-no-compression</codeph> - Disable compression. Data compression
+               <li><codeph>--backup-dir</codeph> - Specify the mounted Data Domain storage unit.</li>
+               <li><codeph>--no-compression</codeph> - Disable compression. Data compression
                   interferes with DD Boost data de-duplication.</li>
-               <li><codeph>-single-data-file</codeph> - Create a single data file on each segment
+               <li><codeph>--single-data-file</codeph> - Create a single data file on each segment
                   host. A single data file avoids a BoostFS stream limitation.</li>
             </ul></p>
          <p>When you use <codeph>gprestore</codeph> to restore a backup from a Data Domain system
             with BoostFS, you must specify the mounted Data Domain storage unit with the option
-               <codeph>-backup-dir</codeph>.</p>
-         <p>When you use the <codeph>gpbackup</codeph> option <codeph>-single-data-file</codeph>,
-            you cannot specify the <codeph>-jobs</codeph> option to perform a parallel restore
+               <codeph>--backup-dir</codeph>.</p>
+         <p>When you use the <codeph>gpbackup</codeph> option <codeph>--single-data-file</codeph>,
+            you cannot specify the <codeph>--jobs</codeph> option to perform a parallel restore
             operation with <codeph>gprestore</codeph>.</p>
          <p>This example <codeph>gpbackup</codeph> command backs up the database
                <codeph>test</codeph>. The example assumes that the directory
                <codeph>/boostfs-test</codeph> is the mounted Data Domain storage unit.
-            <codeblock>$ gpbackup -dbname test -backup-dir /boostfs-test/ -single-data-file -no-compression</codeblock></p>
+            <codeblock>$ gpbackup --dbname test --backup-dir /boostfs-test/ --single-data-file --no-compression</codeblock></p>
          <p>These commands drop the database <codeph>test</codeph> and restore the database from the
             backup.
             <codeblock>$ dropdb test
-$ gprestore -backup-dir /boostfs-test/ -timestamp 20171103153156 -create-db</codeblock></p>
+$ gprestore --backup-dir /boostfs-test/ --timestamp 20171103153156 --create-db</codeblock></p>
          <p>The value <codeph>20171103153156</codeph> is the timestamp of the
                <codeph>gpbackup</codeph> backup set to restore. For information about how
                <codeph>gpbackup</codeph> uses timesamps when creating backups, see <xref

--- a/gpdb-doc/dita/admin_guide/managing/backup-gpbackup.xml
+++ b/gpdb-doc/dita/admin_guide/managing/backup-gpbackup.xml
@@ -17,7 +17,7 @@
         format="dita"/> for more information.) Storing the table data in CSV files also provides
       opportunities for using other restore utilities, such as <codeph>gpload</codeph>, to load the
       data either in the same cluster or another cluster. By default, one file is created for each
-      table on the segment. You can specify the <codeph>-leaf-partition-data</codeph> option with
+      table on the segment. You can specify the <codeph>--leaf-partition-data</codeph> option with
         <codeph>gpbackup</codeph> to create one data file per leaf partition of a partitioned table,
       instead of a single file. This option also enables you to filter backup sets by leaf
       partitions.</p>
@@ -47,13 +47,13 @@
           <li>You can execute multiple instances of <codeph>gpbackup</codeph>, but each execution
             requires a distinct timestamp.</li>
           <li>Database object filtering is currently limited to schemas and tables.</li>
-          <li>If you use the <codeph>gpbackup -single-data-file</codeph> option to combine table
+          <li>If you use the <codeph>gpbackup --single-data-file</codeph> option to combine table
             backups into a single file per segment, you cannot perform a parallel restore operation
-            with <codeph>gprestore</codeph> (cannot set <codeph>-jobs</codeph> to a value higher
+            with <codeph>gprestore</codeph> (cannot set <codeph>--jobs</codeph> to a value higher
             than 1).</li>
-          <li>You cannot use the <codeph>-exclude-table-file</codeph> with
-              <codeph>-leaf-partition-data</codeph>. Although you can specify leaf partition names
-            in a file specified with <codeph>-exclude-table-file</codeph>, <codeph>gpbackup</codeph>
+          <li>You cannot use the <codeph>--exclude-table-file</codeph> with
+              <codeph>--leaf-partition-data</codeph>. Although you can specify leaf partition names
+            in a file specified with <codeph>--exclude-table-file</codeph>, <codeph>gpbackup</codeph>
             ignores the partition names.</li>
           <li>Incremental backups are not supported.</li>
         </ul></p>
@@ -64,9 +64,9 @@
     <body>
       <p>The following table lists the objects that are backed up and restored with
           <codeph>gpbackup</codeph> and <codeph>gprestore</codeph>. Database objects are backed up
-        for the database you specify with the <codeph>-dbname</codeph> option. Global objects
+        for the database you specify with the <codeph>--dbname</codeph> option. Global objects
         (Greenplum Database system objects) are also backed up by default, but they are restored
-        only if you include the <codeph>-with-globals</codeph> option to
+        only if you include the <codeph>--with-globals</codeph> option to
           <codeph>gprestore</codeph>.<table frame="all" rowsep="1" colsep="1" id="table_vqq_3rj_tbb">
           <title>Objects that are backed up and restored</title>
           <tgroup cols="2">
@@ -74,8 +74,8 @@
             <colspec colname="c2" colnum="2" colwidth="1.0*"/>
             <thead>
               <row>
-                <entry>Database (for database specified with <codeph>-dbname</codeph>)</entry>
-                <entry>Global (requires the <codeph>-with-globals</codeph> option to
+                <entry>Database (for database specified with <codeph>--dbname</codeph>)</entry>
+                <entry>Global (requires the <codeph>--with-globals</codeph> option to
                   restore)</entry>
               </row>
             </thead>
@@ -136,7 +136,7 @@
         </ul><p>When restoring to an existing database, <codeph>gprestore</codeph> assumes the
             <codeph>public</codeph> schema exists when restoring objects to the
             <codeph>public</codeph> schema. When restoring to a new database (with the
-            <codeph>-create-db</codeph> option), <codeph>gprestore</codeph> creates the
+            <codeph>--create-db</codeph> option), <codeph>gprestore</codeph> creates the
             <codeph>public</codeph> schema automatically when creating a database with the
             <codeph>CREATE DATABASE</codeph> command. The command uses the
             <codeph>template0</codeph> database that contains the <codeph>public</codeph>
@@ -148,9 +148,9 @@
     <title>Performing Basic Backup and Restore Operations</title>
     <body>
       <p>To perform a complete backup of a database, as well as Greenplum Database system metadata,
-        use the command: <codeblock>$ gpbackup -dbname &lt;database_name></codeblock></p>
+        use the command: <codeblock>$ gpbackup --dbname &lt;database_name></codeblock></p>
       <p>For
-        example:<codeblock>$ <b>gpbackup -dbname demo</b>
+        example:<codeblock>$ <b>gpbackup --dbname demo</b>
 20180105:11:27:54 gpbackup:gpadmin:centos6.localdomain:002182-[INFO]:-Starting backup of database demo
 20180105:11:27:54 gpbackup:gpadmin:centos6.localdomain:002182-[INFO]:-Backup Timestamp = 20180105112754
 20180105:11:27:54 gpbackup:gpadmin:centos6.localdomain:002182-[INFO]:-Backup Database = demo
@@ -183,8 +183,8 @@ gpbackup_20180105112754_metadata.sql  gpbackup_20180105112754_toc.yaml</codebloc
 gpbackup_0_20180105112754_17166.gz  gpbackup_0_20180105112754_26303.gz
 gpbackup_0_20180105112754_21816.gz</codeblock></p>
       <p>To consolidate all backup files into a single directory, include the
-          <codeph>-backup-dir</codeph> option. Note that you must specify an absolute path with this
-        option:<codeblock>$ <b>gpbackup -dbname demo -backup-dir /home/gpadmin/backups</b>
+          <codeph>--backup-dir</codeph> option. Note that you must specify an absolute path with this
+        option:<codeblock>$ <b>gpbackup --dbname demo --backup-dir /home/gpadmin/backups</b>
 20171103:15:31:56 gpbackup:gpadmin:0ee2f5fb02c9:017586-[INFO]:-Starting backup of database demo
 ...
 20171103:15:31:58 gpbackup:gpadmin:0ee2f5fb02c9:017586-[INFO]:-Backup completed successfully
@@ -205,11 +205,11 @@ $ <b>find /home/gpadmin/backups/ -type f</b>
       <section>
         <title>Restoring from Backup</title>
         <p>To use <codeph>gprestore</codeph> to restore from a backup set, you must use the
-            <codeph>-timestamp</codeph> option to specify the exact timestamp value
-            (<codeph>YYYYMMDDHHMMSS</codeph>) to restore. Include the <codeph>-create-db</codeph>
+            <codeph>--timestamp</codeph> option to specify the exact timestamp value
+            (<codeph>YYYYMMDDHHMMSS</codeph>) to restore. Include the <codeph>--create-db</codeph>
           option if the database does not exist in the cluster. For
           example:<codeblock>$ <b>dropdb demo</b>
-$ <b>gprestore -timestamp 20171103152558 -create-db</b>
+$ <b>gprestore --timestamp 20171103152558 --create-db</b>
 20171103:15:45:30 gprestore:gpadmin:0ee2f5fb02c9:017714-[INFO]:-Restore Key = 20171103152558
 20171103:15:45:31 gprestore:gpadmin:0ee2f5fb02c9:017714-[INFO]:-Creating database
 20171103:15:45:44 gprestore:gpadmin:0ee2f5fb02c9:017714-[INFO]:-Database creation complete
@@ -219,26 +219,26 @@ $ <b>gprestore -timestamp 20171103152558 -create-db</b>
 20171103:15:45:45 gprestore:gpadmin:0ee2f5fb02c9:017714-[INFO]:-Data restore complete
 20171103:15:45:45 gprestore:gpadmin:0ee2f5fb02c9:017714-[INFO]:-Restoring post-data metadata from /gpmaster/gpsne-1/backups/20171103/20171103152558/gpbackup_20171103152558_postdata.sql
 20171103:15:45:45 gprestore:gpadmin:0ee2f5fb02c9:017714-[INFO]:-Post-data metadata restore complete</codeblock></p>
-        <p>If you specified a custom <codeph>-backup-dir</codeph> to consolidate the backup files,
-          include the same <codeph>-backup-dir</codeph> option when using <codeph>gprestore</codeph>
+        <p>If you specified a custom <codeph>--backup-dir</codeph> to consolidate the backup files,
+          include the same <codeph>--backup-dir</codeph> option when using <codeph>gprestore</codeph>
           to locate the backup
           files:<codeblock>$ <b>dropdb demo</b>
-$ <b>gprestore -backup-dir /home/gpadmin/backups/ -timestamp 20171103153156 -create-db</b>
+$ <b>gprestore --backup-dir /home/gpadmin/backups/ --timestamp 20171103153156 --create-db</b>
 20171103:15:51:02 gprestore:gpadmin:0ee2f5fb02c9:017819-[INFO]:-Restore Key = 20171103153156
 ...
 20171103:15:51:17 gprestore:gpadmin:0ee2f5fb02c9:017819-[INFO]:-Post-data metadata restore complete</codeblock></p>
         <p><codeph>gprestore</codeph> does not attempt to restore global metadata for the Greenplum
-          System by default. If this is required, include the <codeph>-with-globals</codeph>
+          System by default. If this is required, include the <codeph>--with-globals</codeph>
           argument.</p>
         <p>By default, <codeph>gprestore</codeph> uses 1 connection to restore table data. If you
           have a large backup set, you can improve performance of the restore by increasing the
-          number of parallel connections with the <codeph>-jobs</codeph> option. For
-          example:<codeblock>$ <b>gprestore -backup-dir /home/gpadmin/backups/ -timestamp 20171103153156 -create-db -jobs 8</b></codeblock></p>
+          number of parallel connections with the <codeph>--jobs</codeph> option. For
+          example:<codeblock>$ <b>gprestore --backup-dir /home/gpadmin/backups/ --timestamp 20171103153156 --create-db --jobs 8</b></codeblock></p>
         <p>Test the number of parallel connections with your backup set to determine the ideal
           number for fast data recovery. </p>
         <note>You cannot perform a parallel restore operation with <codeph>gprestore</codeph> if the
           backup combined table backups into a single file per segment with the
-            <codeph>gpbackup</codeph> option <codeph>-single-data-file</codeph>.</note>
+            <codeph>gpbackup</codeph> option <codeph>--single-data-file</codeph>.</note>
       </section>
       <section id="report_files"><title>Report Files</title><p>When performing a backup or restore
           operation, <codeph>gpbackup</codeph> and <codeph>gprestore</codeph> generate a report
@@ -271,7 +271,7 @@ GPDB Version: 5.4.1+dev.8.g9f83645 build commit:9f836456b00f855959d52749d5790ed1
 gprestore Version: 1.0.0-alpha.3+dev.73.g0406681
 
 Database Name: test
-Command Line: gprestore -timestamp 20180213114446 --with-globals --createdb
+Command Line: gprestore --timestamp 20180213114446 --with-globals --createdb
 
 Start Time: 2018-02-13 11:54:26
 End Time: 2018-02-13 11:54:31
@@ -297,22 +297,22 @@ Restore Status: Success</codeblock></section>
       <p><codeph>gpbackup</codeph> backs up all schemas and tables in the specified database, unless
         you exclude or include individual schema or table objects with schema level or table level
         filter options.</p>
-      <p> The schema level options are <codeph>-include-schema</codeph> or
-          <codeph>-exclude-schema</codeph> command-line options to <codeph>gpbackup</codeph>. For
+      <p> The schema level options are <codeph>--include-schema</codeph> or
+          <codeph>--exclude-schema</codeph> command-line options to <codeph>gpbackup</codeph>. For
         example, if the "demo" database includes only two schemas, "wikipedia" and "twitter," both
         of the following commands back up only the "wikipedia"
-        schema:<codeblock>$ <b>gpbackup -dbname demo -include-schema wikipedia</b>
-$ <b>gpbackup -dbname demo -exclude-schema twitter</b></codeblock></p>
-      <p>You can include multiple <codeph>-include-schema</codeph> options in a
+        schema:<codeblock>$ <b>gpbackup --dbname demo --include-schema wikipedia</b>
+$ <b>gpbackup --dbname demo --exclude-schema twitter</b></codeblock></p>
+      <p>You can include multiple <codeph>--include-schema</codeph> options in a
           <codeph>gpbackup</codeph>
-        <i>or</i> multiple <codeph>-exclude-schema</codeph> options. For
-        example:<codeblock>$ <b>gpbackup -dbname demo -include-schema wikipedia -include-schema twitter</b></codeblock></p>
+        <i>or</i> multiple <codeph>--exclude-schema</codeph> options. For
+        example:<codeblock>$ <b>gpbackup --dbname demo --include-schema wikipedia --include-schema twitter</b></codeblock></p>
       <p>To filter the individual tables that are included in a backup set, or excluded from a
-        backup set, specify individual tables with the <codeph>-include-table</codeph> option or the
-          <codeph>-exclude-table</codeph> option. The table must be schema qualified,
+        backup set, specify individual tables with the <codeph>--include-table</codeph> option or the
+          <codeph>--exclude-table</codeph> option. The table must be schema qualified,
           <codeph>&lt;schema-name>.&lt;table-name></codeph>. The individual table filtering options
-        can be specified multiple times. However, <codeph>-include-table</codeph> and
-          <codeph>-exclude-table</codeph> cannot both be used in the same command. </p>
+        can be specified multiple times. However, <codeph>--include-table</codeph> and
+          <codeph>--exclude-table</codeph> cannot both be used in the same command. </p>
       <p>You can create a list of qualified table names in a text file. When listing tables in a
         file, each line in the text file must define a single table using the format
           <codeph>&lt;schema-name>.&lt;table-name></codeph>. The file must not include trailing
@@ -325,21 +325,21 @@ twitter.message</codeblock></p>
 "Wine"."sauvignon blanc"
 water.tonic</codeblock></p>
       <p>After creating the file, you can use it either to include or exclude tables with the
-          <codeph>gpbackup</codeph> options <codeph>-include-table-file</codeph> or
-          <codeph>-exclude-table-file</codeph>. For
-        example:<codeblock>$ <b>gpbackup -dbname demo -include-table-file /home/gpadmin/table-list.txt</b></codeblock></p>
-      <p>You can combine <codeph>-include schema</codeph> with <codeph>-exclude-table</codeph> or
-          <codeph>-exclude-table-file</codeph> for a backup. This example uses
-          <codeph>-include-schema</codeph> with <codeph>-exclude-table</codeph> to back up a schema
+          <codeph>gpbackup</codeph> options <codeph>--include-table-file</codeph> or
+          <codeph>--exclude-table-file</codeph>. For
+        example:<codeblock>$ <b>gpbackup --dbname demo --include-table-file /home/gpadmin/table-list.txt</b></codeblock></p>
+      <p>You can combine <codeph>-include schema</codeph> with <codeph>--exclude-table</codeph> or
+          <codeph>--exclude-table-file</codeph> for a backup. This example uses
+          <codeph>--include-schema</codeph> with <codeph>--exclude-table</codeph> to back up a schema
         except for a single table. </p>
-      <codeblock>$ <b>gpbackup -dbname demo -include-schema mydata -exclude-table mydata.addresses</b></codeblock>
-      <p>You cannot combine <codeph>-include-schema</codeph> with <codeph>-include-table</codeph> or
-          <codeph>-include-table-file</codeph>, and you cannot combine
-          <codeph>-exclude-schema</codeph> with any table filtering option such as
-          <codeph>-exclude-table</codeph> or <codeph>-include-table</codeph>.</p>
+      <codeblock>$ <b>gpbackup --dbname demo --include-schema mydata --exclude-table mydata.addresses</b></codeblock>
+      <p>You cannot combine <codeph>--include-schema</codeph> with <codeph>--include-table</codeph> or
+          <codeph>--include-table-file</codeph>, and you cannot combine
+          <codeph>--exclude-schema</codeph> with any table filtering option such as
+          <codeph>--exclude-table</codeph> or <codeph>--include-table</codeph>.</p>
       <section id="section_ddf_gyn_5bb"><title>Filtering by Leaf Partition</title><p>By default,
             <codeph>gpbackup</codeph> creates one file for each table on a segment. You can specify
-          the <codeph>-leaf-partition-data</codeph> option to create one data file per leaf
+          the <codeph>--leaf-partition-data</codeph> option to create one data file per leaf
           partition of a partitioned table, instead of a single file. You can also filter backups to
           specific leaf partitions by listing the leaf partition names in a text file to include.
           For example, consider a table that was created using the
@@ -377,44 +377,44 @@ CREATE TABLE</codeblock></p><p>To
           name:<codeblock>public.sales_1_prt_oct17
 public.sales_1_prt_nov17
 public.sales_1_prt_dec17 </codeblock></p><p>Then
-          specify the file with the <codeph>-include-table-file</codeph> option to generate one data
+          specify the file with the <codeph>--include-table-file</codeph> option to generate one data
           file per leaf
-          partition:<codeblock>$ <b>gpbackup -dbname demo -include-table-file last-quarter.txt -leaf-partition-data</b></codeblock></p>When
-        you specify <codeph>-leaf-partition-data</codeph>, <codeph>gpbackup</codeph> generates one
+          partition:<codeblock>$ <b>gpbackup --dbname demo --include-table-file last-quarter.txt --leaf-partition-data</b></codeblock></p>When
+        you specify <codeph>--leaf-partition-data</codeph>, <codeph>gpbackup</codeph> generates one
         data file per leaf partition when backing up a partitioned table. For example, this command
         generates one data file for each leaf
-          partition:<codeblock>$ <b>gpbackup -dbname demo -include-table public.sales -leaf-partition-data</b></codeblock><p>When
+          partition:<codeblock>$ <b>gpbackup --dbname demo --include-table public.sales --leaf-partition-data</b></codeblock><p>When
           leaf partitions are backed up, the leaf partition data is backed up along with the
           metadata for the entire partitioned table.</p><note>You cannot use the
-            <codeph>-exclude-table-file</codeph> option with <codeph>-leaf-partition-data</codeph>.
+            <codeph>--exclude-table-file</codeph> option with <codeph>--leaf-partition-data</codeph>.
           Although you can specify leaf partition names in a file specified with
-            <codeph>-exclude-table-file</codeph>, <codeph>gpbackup</codeph> ignores the partition
+            <codeph>--exclude-table-file</codeph>, <codeph>gpbackup</codeph> ignores the partition
           names.</note></section>
       <section>
         <title>Filtering with gprestore</title>
         <p>After creating a backup set with <codeph>gpbackup</codeph>, you can filter the schemas
           and tables that you want to restore from the backup set using the
             <codeph>gprestore</codeph>
-          <codeph>-include-schema</codeph> and <codeph>-include-table-file</codeph> options. These
+          <codeph>--include-schema</codeph> and <codeph>--include-table-file</codeph> options. These
           options work in the same way as their <codeph>gpbackup</codeph> counterparts, but have the
           following restrictions:<ul id="ul_hts_clc_ccb">
             <li>The tables that you attempt to restore must not already exist in the database.</li>
             <li>If you attempt to restore a schema or table that does not exist in the backup set,
               the <codeph>gprestore</codeph> does not execute.</li>
-            <li>If you use the <codeph>-include-schema</codeph> option, <codeph>gprestore</codeph>
+            <li>If you use the <codeph>--include-schema</codeph> option, <codeph>gprestore</codeph>
               cannot restore objects that have dependencies on multiple schemas.</li>
-            <li>If you use the <codeph>-include-table-file</codeph> option,
+            <li>If you use the <codeph>--include-table-file</codeph> option,
                 <codeph>gprestore</codeph> does not create roles or set the owner of the tables. The
               utility restores table indexes and rules. Triggers are also restored but are not
               supported in Greenplum Database.</li>
-            <li>The file that you specify with <codeph>-include-table-file</codeph> cannot include a
+            <li>The file that you specify with <codeph>--include-table-file</codeph> cannot include a
               leaf partition name, as it can when you specify this option with
                 <codeph>gpbackup</codeph>. If you specified leaf partitions in the backup set,
               specify the partitioned table to restore the leaf partition data. <p>When restoring a
                 backup set that contains data from some leaf partitions of a partitioned table, the
                 partitioned table is restored along with the data for the leaf partitions. For
                 example, you create a backup with the <codeph>gpbackup</codeph> option
-                  <codeph>-include-table-file</codeph> and the text file lists some leaf partitions
+                  <codeph>--include-table-file</codeph> and the text file lists some leaf partitions
                 of a partitioned table. Restoring the backup creates the partitioned table and
                 restores the data only for the leaf partitions listed in the file. </p></li>
           </ul></p>
@@ -595,7 +595,7 @@ public.sales_1_prt_dec17 </codeblock></p><p>Then
                     <li>DDL for objects that are global to the Greenplum Database cluster, and not
                       owned by a specific database within the cluster.</li>
                     <li>DDL for objects in the backed-up database (specified with
-                        <codeph>-dbname)</codeph> that must be created <i>before</i> to restoring
+                        <codeph>--dbname)</codeph> that must be created <i>before</i> to restoring
                       the actual data, and DDL for objects that must be created <i>after</i>
                       restoring the data.</li>
                   </ul>Global objects include:<ul id="ul_f1b_dhj_tbb">
@@ -607,7 +607,7 @@ public.sales_1_prt_dec17 </codeblock></p><p>Then
                     <li>Roles</li>
                     <li><codeph>GRANT</codeph> assignments of roles to databases</li>
                   </ul><p><b>Note:</b> Global metadata is not restored by default. You must include
-                    the <codeph>-with-globals</codeph> option to the <codeph>gprestore</codeph>
+                    the <codeph>--with-globals</codeph> option to the <codeph>gprestore</codeph>
                     command to restore global metadata.</p>Database-specific objects that must be
                   created <i>before</i> to restoring the actual data include:<ul id="ul_vqn_vsv_scb">
                     <li>Session-level configuration parameter settings (GUCs)</li>
@@ -659,9 +659,9 @@ public.sales_1_prt_dec17 </codeblock></p><p>Then
                     <li dir="ltr">Database name</li>
                     <li dir="ltr">Greenplum Database version</li>
                     <li dir="ltr">Additional option settings such as
-                        <codeph>-no-compression</codeph>, <codeph>-compression-level</codeph>,
-                        <codeph>-metadata-only</codeph>, <codeph>-data-only</codeph>, and
-                        <codeph>-with-stats</codeph>.</li>
+                        <codeph>--no-compression</codeph>, <codeph>--compression-level</codeph>,
+                        <codeph>--metadata-only</codeph>, <codeph>--data-only</codeph>, and
+                        <codeph>--with-stats</codeph>.</li>
                   </ul></entry>
               </row>
             </tbody>
@@ -670,12 +670,12 @@ public.sales_1_prt_dec17 </codeblock></p><p>Then
       <section id="section_oys_cpj_tbb">
         <title>Segment Data Files</title>
         <p>By default, each segment creates one compressed CSV file for each table that is backed up
-          on the segment. You can optionally specify the <codeph>-single-data-file</codeph> option
+          on the segment. You can optionally specify the <codeph>--single-data-file</codeph> option
           to create a single data file on each segment. The files are stored in
             <filepath>&lt;seg_dir>/backups/YYYYMMDD/YYYYMMDDHHMMSS/</filepath>. </p>
         <p>If you specify a custom backup directory, segment data files are copied to this same file
           path as a subdirectory of the backup directory. If you include the
-            <codeph>-leaf-partition-data</codeph> option, <codeph>gpbackup</codeph> creates one data
+            <codeph>--leaf-partition-data</codeph> option, <codeph>gpbackup</codeph> creates one data
           file for each leaf partition of a partitioned table, instead of just one table for
           file.</p>
         <p>Each data file uses the file name format
@@ -690,8 +690,8 @@ public.sales_1_prt_dec17 </codeblock></p><p>Then
               schema.</li>
           </ul></p>
         <p>You can optionally specify the gzip compression level (from 1-9) using the
-            <codeph>-compression-level</codeph> option, or disable compression entirely with
-            <codeph>-no-compression</codeph>. If you do not specify a compression level,
+            <codeph>--compression-level</codeph> option, or disable compression entirely with
+            <codeph>--no-compression</codeph>. If you do not specify a compression level,
             <codeph>gpbackup</codeph> uses compression level 1 by default.</p>
       </section>
     </body>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpbackup.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpbackup.xml
@@ -8,25 +8,25 @@
       Linux Enterprise Server build of Pivotal Greenplum Database.</note>
     <section>
       <title>Synopsis</title>
-      <codeblock><b>gpbackup -dbname</b> <varname>database_name</varname>
-   [<b>-backup-dir</b> <varname>directory</varname>]
-   [<b>-compression-level</b> <varname>level</varname>]
-   [<b>-data-only</b>]
-   [<b>-debug</b>]
-   [<b>-exclude-schema</b> <varname>schema_name</varname>]
-   [<b>-exclude-table</b> <varname>schema.table</varname>]
-   [<b>-exclude-table-file</b> <varname>file_name</varname>]
-   [<b>-include-schema</b> <varname>schema_name</varname>]
-   [<b>-include-table</b> <varname>schema.table</varname>]
-   [<b>-include-table-file</b> <varname>file_name</varname>]
-   [<b>-leaf-partition-data</b>]
-   [<b>-metadata-only</b>]
-   [<b>-no-compression</b>]
-   [<b>-quiet</b>]
-   [<b>-single-data-file]</b>
-   [<b>-verbose</b>]
-   [<b>-version</b>]
-   [<b>-with-stats</b>]</codeblock>
+      <codeblock><b>gpbackup --dbname</b> <varname>database_name</varname>
+   [<b>--backup-dir</b> <varname>directory</varname>]
+   [<b>--compression-level</b> <varname>level</varname>]
+   [<b>--data-only</b>]
+   [<b>--debug</b>]
+   [<b>--exclude-schema</b> <varname>schema_name</varname>]
+   [<b>--exclude-table</b> <varname>schema.table</varname>]
+   [<b>--exclude-table-file</b> <varname>file_name</varname>]
+   [<b>--include-schema</b> <varname>schema_name</varname>]
+   [<b>--include-table</b> <varname>schema.table</varname>]
+   [<b>--include-table-file</b> <varname>file_name</varname>]
+   [<b>--leaf-partition-data</b>]
+   [<b>--metadata-only</b>]
+   [<b>--no-compression</b>]
+   [<b>--quiet</b>]
+   [<b>--single-data-file]</b>
+   [<b>--verbose</b>]
+   [<b>--version</b>]
+   [<b>--with-stats</b>]</codeblock>
     </section>
     <section><title>Description</title><p>The <codeph>gpbackup</codeph> utility backs up the
         contents of a database into a collection of metadata files and data files that can be used
@@ -35,7 +35,7 @@
         tables. For example, you can combine schema level and table level options to back up all the
         tables in a schema except for a single table. </p><p>By default, <codeph>gpbackup</codeph>
         backs up objects in the specified database as well as global Greenplum Database system
-        objects. You can optionally supply the <codeph>-with-globals</codeph> option with
+        objects. You can optionally supply the <codeph>--with-globals</codeph> option with
           <codeph>gprestore</codeph> to restore global objects. See <xref
           href="../../admin_guide/managing/backup-gpbackup.xml#topic_x3s_lqj_tbb"/> for additional
         information.</p><p><codeph>gpbackup</codeph> stores the object metadata files and DDL files
@@ -43,7 +43,7 @@
         segments use the <codeph>COPY ... ON SEGMENT</codeph> command to store their data for
         backed-up tables in compressed CSV data files, located in each segment's data directory. See
           <xref href="../../admin_guide/managing/backup-gpbackup.xml#topic_xnj_b4c_tbb"/> for
-        additional information.</p><p>You can add the <codeph>-backup-dir</codeph> option to copy
+        additional information.</p><p>You can add the <codeph>--backup-dir</codeph> option to copy
         all backup files from the Greenplum Database master and segment hosts to an absolute path
         for later use. Additional options are provided to filter the backup set in order to include
         or exclude specific tables.</p><p>Each <codeph>gpbackup</codeph> task uses a single
@@ -67,7 +67,7 @@
       </parml>
       <parml>
         <plentry>
-          <pt><b>-backup-dir</b>
+          <pt><b>--backup-dir</b>
             <varname>directory</varname></pt>
           <pd>Optional. Copies all required backup files (metadata files and data files) to the
             specified directory. You must specify <varname>directory</varname> as an absolute path
@@ -82,7 +82,7 @@
       </parml>
       <parml>
         <plentry>
-          <pt><b>-compression-level</b>
+          <pt><b>--compression-level</b>
             <varname>level</varname></pt>
           <pd>Optional. Specifies the gzip compression level (from 1 to 9) used to compress data
             files. The default is 1. Note that <codeph>gpbackup</codeph> uses compression by
@@ -91,38 +91,38 @@
       </parml>
       <parml>
         <plentry>
-          <pt><b>-data-only</b></pt>
+          <pt><b>--data-only</b></pt>
           <pd>Optional. Backs up only the table data into CSV files, but does not backup metadata
             files needed to recreate the tables and other database objects.</pd>
         </plentry>
       </parml>
       <parml>
         <plentry>
-          <pt><b>-debug</b></pt>
+          <pt><b>--debug</b></pt>
           <pd>Optional. Displays verbose debug messages during operation.</pd>
         </plentry>
       </parml>
       <parml>
         <plentry>
-          <pt><b>-exclude-schema</b>
+          <pt><b>--exclude-schema</b>
             <varname>schema_name</varname></pt>
           <pd>Optional. Specifies a database schema to exclude from the backup. You can specify this
             option multiple times to exclude multiple schemas. You cannot combine this option with
-            the option <codeph>-include-schema</codeph>, or a table filtering option such as
-              <codeph>-include-table</codeph>. See <xref
+            the option <codeph>--include-schema</codeph>, or a table filtering option such as
+              <codeph>--include-table</codeph>. See <xref
               href="../../admin_guide/managing/backup-gpbackup.xml#topic_et4_b5d_tbb"/> for more
             information.</pd>
         </plentry>
         <plentry>
-          <pt><b>-exclude-table</b>
+          <pt><b>--exclude-table</b>
             <varname>schema.table</varname></pt>
           <pd>Optional. Specifies a table to exclude from the backup. The table must be in the
             format <codeph>&lt;schema-name>.&lt;table-name></codeph>. If a table or schema name uses
             any character other than a lowercase letter, number, or an underscore character, then
             you must include that name in double quotes. You can specify this option multiple times.
-            You cannot combine this option with the option <codeph>-exclude-schema</codeph>, or
-            another a table filtering option such as <codeph>-include-table</codeph>.</pd>
-          <pd>You cannot use this option in combination with <codeph>-leaf-partition-data</codeph>.
+            You cannot combine this option with the option <codeph>--exclude-schema</codeph>, or
+            another a table filtering option such as <codeph>--include-table</codeph>.</pd>
+          <pd>You cannot use this option in combination with <codeph>--leaf-partition-data</codeph>.
             Although you can specify leaf partition names, <codeph>gpbackup</codeph> ignores the
             partition names.</pd>
           <pd>See <xref href="../../admin_guide/managing/backup-gpbackup.xml#topic_et4_b5d_tbb"/>
@@ -131,18 +131,18 @@
       </parml>
       <parml>
         <plentry>
-          <pt><b>-exclude-table-file</b>
+          <pt><b>--exclude-table-file</b>
             <varname>file_name</varname></pt>
           <pd>Optional. Specifies a text file containing a list of tables to exclude from the
             backup. Each line in the text file must define a single table using the format
               <codeph>&lt;schema-name>.&lt;table-name></codeph>. The file must not include trailing
             lines. If a table or schema name uses any character other than a lowercase letter,
             number, or an underscore character, then you must include that name in double quotes.
-            You cannot combine this option with the option <codeph>-exclude-schema</codeph>, or
-            another a table filtering option such as <codeph>-include-table</codeph>.</pd>
-          <pd>You cannot use this option in combination with <codeph>-leaf-partition-data</codeph>.
+            You cannot combine this option with the option <codeph>--exclude-schema</codeph>, or
+            another a table filtering option such as <codeph>--include-table</codeph>.</pd>
+          <pd>You cannot use this option in combination with <codeph>--leaf-partition-data</codeph>.
             Although you can specify leaf partition names in a file specified with
-              <codeph>-exclude-table-file</codeph>, <codeph>gpbackup</codeph> ignores the partition
+              <codeph>--exclude-table-file</codeph>, <codeph>gpbackup</codeph> ignores the partition
             names.</pd>
           <pd>See <xref href="../../admin_guide/managing/backup-gpbackup.xml#topic_et4_b5d_tbb"/>
             for more information.</pd>
@@ -150,32 +150,32 @@
       </parml>
       <parml>
         <plentry>
-          <pt><b>-include-schema</b>
+          <pt><b>--include-schema</b>
             <varname>schema_name</varname></pt>
           <pd>Optional. Specifies a database schema to include in the backup. You can specify this
             option multiple times to include multiple schemas. If you specify this option, any
-            schemas that are not included in subsequent <codeph>-include-schema</codeph> options are
+            schemas that are not included in subsequent <codeph>--include-schema</codeph> options are
             omitted from the backup set. You cannot combine this option with the options
-              <codeph>-exclude-schema</codeph>, <codeph>-include-table</codeph>, or
-              <codeph>-include-table-file</codeph>. See <xref
+              <codeph>--exclude-schema</codeph>, <codeph>--include-table</codeph>, or
+              <codeph>--include-table-file</codeph>. See <xref
               href="../../admin_guide/managing/backup-gpbackup.xml#topic_et4_b5d_tbb"/> for more
             information.</pd>
         </plentry>
       </parml>
       <parml>
         <plentry>
-          <pt><b>-include-table</b>
+          <pt><b>--include-table</b>
             <varname>schema.table</varname></pt>
           <pd>Optional. Specifies a table to include in the backup. The table must be in the format
               <codeph>&lt;schema-name>.&lt;table-name></codeph>. If a table or schema name uses any
             character other than a lowercase letter, number, or an underscore character, then you
             must include that name in double quotes. You can specify this option multiple times. You
             cannot combine this option with a schema filtering option such as
-              <codeph>-include-schema</codeph>, or another table filtering option such as
-              <codeph>-exclude-table-file</codeph>.</pd>
+              <codeph>--include-schema</codeph>, or another table filtering option such as
+              <codeph>--exclude-table-file</codeph>.</pd>
           <pd>You can optionally specify a table leaf partition name in place of the table name, to
             include only specific leaf partitions in a backup with the
-              <codeph>-leaf-partition-data</codeph> option. When a leaf partition is backed up, the
+              <codeph>--leaf-partition-data</codeph> option. When a leaf partition is backed up, the
             leaf partition data is backed up along with the metadata for the partitioned table.</pd>
           <pd>See <xref href="../../admin_guide/managing/backup-gpbackup.xml#topic_et4_b5d_tbb"/>
             for more information.</pd>
@@ -183,7 +183,7 @@
       </parml>
       <parml>
         <plentry>
-          <pt><b>-include-table-file</b>
+          <pt><b>--include-table-file</b>
             <varname>file_name</varname></pt>
           <pd>Optional. Specifies a text file containing a list of tables to include in the backup.
             Each line in the text file must define a single table using the format
@@ -191,11 +191,11 @@
             lines. If a table or schema name uses any character other than a lowercase letter,
             number, or an underscore character, then you must include that name in double quotes.
             Any tables not listed in this file are omitted from the backup set. You cannot combine
-            this option with a schema filtering option such as <codeph>-include-schema</codeph>, or
-            another table filtering option such as <codeph>-exclude-table-file</codeph>.</pd>
+            this option with a schema filtering option such as <codeph>--include-schema</codeph>, or
+            another table filtering option such as <codeph>--exclude-table-file</codeph>.</pd>
           <pd>You can optionally specify a table leaf partition name in place of the table name, to
             include only specific leaf partitions in a backup with the
-              <codeph>-leaf-partition-data</codeph> option. When a leaf partition is backed up, the
+              <codeph>--leaf-partition-data</codeph> option. When a leaf partition is backed up, the
             leaf partition data is backed up along with the metadata for the partitioned table.</pd>
           <pd>See <xref href="../../admin_guide/managing/backup-gpbackup.xml#topic_et4_b5d_tbb"/>
             for more information.</pd>
@@ -203,40 +203,40 @@
       </parml>
       <parml>
         <plentry>
-          <pt><b>-leaf-partition-data</b></pt>
+          <pt><b>--leaf-partition-data</b></pt>
           <pd>Optional. For partitioned tables, creates one data file per leaf partition instead of
             one data file for the entire table (the default). Using this option also enables you to
             specify individual leaf partitions to include in a backup, with the
-              <codeph>-include-table-file</codeph> option. You cannot use this option in combination
-            with <codeph>-exclude-table-file</codeph> or <codeph>-exclude-table</codeph>.</pd>
+              <codeph>--include-table-file</codeph> option. You cannot use this option in combination
+            with <codeph>--exclude-table-file</codeph> or <codeph>--exclude-table</codeph>.</pd>
         </plentry>
       </parml>
       <parml>
         <plentry>
-          <pt><b>-metadata-only</b></pt>
+          <pt><b>--metadata-only</b></pt>
           <pd>Optional. Creates only the metadata files (DDL) needed to recreate the database
             objects, but does not back up the actual table data.</pd>
         </plentry>
       </parml>
       <parml>
         <plentry>
-          <pt><b>-no-compression</b></pt>
+          <pt><b>--no-compression</b></pt>
           <pd>Optional. Do not compress the table data CSV files.</pd>
         </plentry>
       </parml>
       <parml>
         <plentry>
-          <pt><b>-quiet</b></pt>
+          <pt><b>--quiet</b></pt>
           <pd>Optional. Suppress all non-warning, non-error log messages.</pd>
         </plentry>
       </parml>
       <parml>
         <plentry>
-          <pt><b>-single-data-file</b></pt>
+          <pt><b>--single-data-file</b></pt>
           <pd>Optional. Create a single data file on each segment host for all tables backed up on
             that segment. By default, each <codeph>gpbackup</codeph> creates one compressed CSV file
             for each table that is backed up on the segment.<note>If you use the
-                <codeph>-single-data-file</codeph> option to combine table backups into a single
+                <codeph>--single-data-file</codeph> option to combine table backups into a single
               file per segment, you cannot set the <codeph>gprestore</codeph> option
                 <codeph>-jobs</codeph> to a value higher than 1 to perform a parallel restore
               operation.</note></pd>
@@ -244,19 +244,19 @@
       </parml>
       <parml>
         <plentry>
-          <pt><b>-verbose</b></pt>
+          <pt><b>--verbose</b></pt>
           <pd>Optional. Print verbose log messages.</pd>
         </plentry>
       </parml>
       <parml>
         <plentry>
-          <pt><b>-version</b></pt>
+          <pt><b>--version</b></pt>
           <pd>Optional. Print the version number and exit.</pd>
         </plentry>
       </parml>
       <parml>
         <plentry>
-          <pt><b>-with-stats</b></pt>
+          <pt><b>--with-stats</b></pt>
           <pd>Optional. Include query plan statistics in the backup set.</pd>
         </plentry>
       </parml>
@@ -276,18 +276,18 @@
       <p>Backup all schemas and tables in the "demo" database, including global Greenplum Database
         system objects statistics:<codeblock>$ gpbackup -dbname demo</codeblock></p>
       <p>Backup all schemas and tables in the "demo" database except for the "twitter"
-        schema:<codeblock>$ gpbackup -dbname demo -exclude-schema twitter</codeblock></p>
+        schema:<codeblock>$ gpbackup -dbname demo --exclude-schema twitter</codeblock></p>
       <p>Backup only the "twitter" schema in the "demo"
-        database:<codeblock>$ gpbackup -dbname demo -include-schema twitter</codeblock></p>
+        database:<codeblock>$ gpbackup -dbname demo --include-schema twitter</codeblock></p>
       <p>Backup all schemas and tables in the "demo" database, including global Greenplum Database
         system objects and query statistics, and copy all backup files to the
           <filepath>/home/gpadmin/backup</filepath>
-        directory:<codeblock>$ gpbackup -dbname demo -with-stats -backup-dir /home/gpadmin/backup</codeblock></p>
-      <p>This example uses <codeph>-include-schema</codeph> with <codeph>-exclude-table</codeph> to
+        directory:<codeblock>$ gpbackup -dbname demo --with-stats --backup-dir /home/gpadmin/backup</codeblock></p>
+      <p>This example uses <codeph>--include-schema</codeph> with <codeph>--exclude-table</codeph> to
         back up a schema except for a single table. </p>
-      <codeblock>$ gpbackup -dbname demo -include-schema mydata -exclude-table mydata.addresses</codeblock>
-      <p>You cannot use the option <codeph>-exclude-schema</codeph> with a table filtering option
-        such as <codeph>-include-table</codeph>.</p>
+      <codeblock>$ gpbackup -dbname demo --include-schema mydata --exclude-table mydata.addresses</codeblock>
+      <p>You cannot use the option <codeph>--exclude-schema</codeph> with a table filtering option
+        such as <codeph>--include-table</codeph>.</p>
     </section>
     <section id="section9">
       <title>See Also</title>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gprestore.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gprestore.xml
@@ -11,54 +11,54 @@
       Linux Enterprise Server build of Pivotal Greenplum Database.</note>
     <section>
       <title>Synopsis</title>
-      <codeblock><b>gprestore -timestamp</b> <varname>YYYYMMDDHHMMSS</varname>
-   [<b>-backup-dir</b> <varname>directory</varname>]
-   [<b>-create-db</b>]
-   [<b>-debug</b>]
-   [<b>-exclude-schema</b> <varname>schema_name</varname>]
-   [<b>-exclude-table</b> <varname>schema.table</varname>]
-   [<b>-exclude-table-file</b> <varname>file_name</varname>]
-   [<b>-include-schema</b> <varname>schema_name</varname>]
-   [<b>-include-table</b> <varname>schema.table</varname>]
-   [<b>-include-table-file</b> <varname>file_name</varname>]
-   [<b>-jobs</b> <varname>int</varname>]
-   [<b>-quiet</b>]
-   [<b>-redirect-db</b> <varname>database_name</varname>]
-   [<b>-verbose</b>]
-   [<b>-version</b>]
-   [<b>-with-globals</b>]
-   [<b>-with-stats</b>]</codeblock>
+      <codeblock><b>gprestore --timestamp</b> <varname>YYYYMMDDHHMMSS</varname>
+   [<b>--backup-dir</b> <varname>directory</varname>]
+   [<b>--create-db</b>]
+   [<b>--debug</b>]
+   [<b>--exclude-schema</b> <varname>schema_name</varname>]
+   [<b>--exclude-table</b> <varname>schema.table</varname>]
+   [<b>--exclude-table-file</b> <varname>file_name</varname>]
+   [<b>--include-schema</b> <varname>schema_name</varname>]
+   [<b>--include-table</b> <varname>schema.table</varname>]
+   [<b>--include-table-file</b> <varname>file_name</varname>]
+   [<b>--jobs</b> <varname>int</varname>]
+   [<b>--quiet</b>]
+   [<b>--redirect-db</b> <varname>database_name</varname>]
+   [<b>--verbose</b>]
+   [<b>--version</b>]
+   [<b>--with-globals</b>]
+   [<b>--with-stats</b>]</codeblock>
     </section>
     <section>
       <title>Description</title>
       <p>To use <codeph>gprestore</codeph> to restore from a backup set, you must include the
-          <codeph>-timestamp</codeph> option to specify the exact timestamp value
+          <codeph>--timestamp</codeph> option to specify the exact timestamp value
           (<codeph>YYYYMMDDHHMMSS</codeph>) of the backup set to restore. If you specified a custom
-          <codeph>-backup-dir</codeph> to consolidate the backup files, include the same
-          <codeph>-backup-dir</codeph> option with <codeph>gprestore</codeph> to locate the backup
+          <codeph>--backup-dir</codeph> to consolidate the backup files, include the same
+          <codeph>--backup-dir</codeph> option with <codeph>gprestore</codeph> to locate the backup
         files.</p>
       <p>When restoring from a backup set, <codeph>gprestore</codeph> restores to a database with
         same name as the name specified when creating the backup set. If the target database exists
         and a table being restored exists in the database, the restore operation fails. Include the
-          <codeph>-create-db</codeph> option if the target database does not exist in the cluster.
+          <codeph>--create-db</codeph> option if the target database does not exist in the cluster.
         You can optionally restore a backup set to a different database by using the
-          <codeph>-redirect-db</codeph> option.</p>
+          <codeph>--redirect-db</codeph> option.</p>
       <p>When restoring a backup set that contains data from some leaf partitions of a partitioned
         tables, the partitioned table is restored along with the data for the leaf partitions. For
         example, you create a backup with the <codeph>gpbackup</codeph> option
-          <codeph>-include-table-file</codeph> and the text file lists some leaf partitions of a
+          <codeph>--include-table-file</codeph> and the text file lists some leaf partitions of a
         partitioned table. Restoring the backup creates the partitioned table and restores the data
         only for the leaf partitions listed in the file. </p>
       <p>Greenplum Database system objects are automatically included in a <codeph>gpbackup</codeph>
         backup set, but these objects are only restored if you include the
-          <codeph>-with-globals</codeph> option to <codeph>gprestore</codeph>. Similarly, if you
-        backed up query plan statistics using the <codeph>-with-stats</codeph> option, you can
-        restore those statistics by providing <codeph>-with-stats</codeph> to
+          <codeph>--with-globals</codeph> option to <codeph>gprestore</codeph>. Similarly, if you
+        backed up query plan statistics using the <codeph>--with-stats</codeph> option, you can
+        restore those statistics by providing <codeph>--with-stats</codeph> to
           <codeph>gprestore</codeph>. By default, only database objects in the backup set are
         restored.</p>
       <p>Performance of restore operations can be improved by creating multiple parallel connections
         to restore table data. By default <codeph>gprestore</codeph> uses 1 connection, but you can
-        increase this number with the <codeph>-jobs</codeph> option for large restore
+        increase this number with the <codeph>--jobs</codeph> option for large restore
         operations.</p>
       <p>When a restore operation completes, <codeph>gprestore</codeph> returns a status code. See
           <xref href="#topic_phj_g5j_tbb/return_codes" format="dita"/>.</p>
@@ -72,7 +72,7 @@
       <title>Options</title>
       <parml>
         <plentry>
-          <pt><b>-timestamp</b>
+          <pt><b>--timestamp</b>
             <varname>YYYYMMDDHHMMSS</varname></pt>
           <pd>Required. Specifies the timestamp of the <codeph>gpbackup</codeph> backup set to
             restore. By default <codeph>gprestore</codeph> tries to locate metadata files for the
@@ -85,7 +85,7 @@
       </parml>
       <parml>
         <plentry>
-          <pt><b>-backup-dir</b>
+          <pt><b>--backup-dir</b>
             <varname>directory</varname></pt>
           <pd>Optional. Sources all backup files (metadata files and data files) from the specified
             directory. You must specify <varname>directory</varname> as an absolute path (not
@@ -100,7 +100,7 @@
       </parml>
       <parml>
         <plentry>
-          <pt><b>-create-db</b></pt>
+          <pt><b>--create-db</b></pt>
           <pd>Optional. Creates the database before restoring the database object metadata.</pd>
           <pd>The database is created by cloning the empty standard system database
               <codeph>template0</codeph>.</pd>
@@ -108,21 +108,21 @@
       </parml>
       <parml>
         <plentry>
-          <pt><b>-debug</b></pt>
+          <pt><b>--debug</b></pt>
           <pd>Optional. Displays verbose debug messages during operation.</pd>
         </plentry>
       </parml>
       <parml>
         <plentry>
-          <pt><b>-exclude-schema</b>
+          <pt><b>--exclude-schema</b>
             <varname>schema_name</varname></pt>
           <pd>Optional. Specifies a database schema to exclude from the restore operation. You can
             specify this option multiple times to exclude multiple schemas. You cannot combine this
-            option with the option <codeph>-include-schema</codeph>, or a table filtering option
-            such as <codeph>-include-table</codeph>. </pd>
+            option with the option <codeph>--include-schema</codeph>, or a table filtering option
+            such as <codeph>--include-table</codeph>. </pd>
         </plentry>
         <plentry>
-          <pt><b>-exclude-table</b>
+          <pt><b>--exclude-table</b>
             <varname>schema.table</varname></pt>
           <pd>Optional. Specifies a table to exclude from the restore operation. The table must be
             in the format <codeph>&lt;schema-name>.&lt;table-name></codeph>. If a table or schema
@@ -130,11 +130,11 @@
             character, then you must include that name in double quotes. You can specify this option
             multiple times. If the table is not in the backup set, the restore operation fails. You
             cannot specify a leaf partition of a partitioned table.</pd>
-          <pd>You cannot combine this option with the option <codeph>-exclude-schema</codeph>, or
-            another a table filtering option such as <codeph>-include-table</codeph>.</pd>
+          <pd>You cannot combine this option with the option <codeph>--exclude-schema</codeph>, or
+            another a table filtering option such as <codeph>--include-table</codeph>.</pd>
         </plentry>
         <plentry>
-          <pt><b>-exclude-table-file</b>
+          <pt><b>--exclude-table-file</b>
             <varname>file_name</varname></pt>
           <pd>Optional. Specifies a text file containing a list of tables to exclude from the
             restore operation. Each line in the text file must define a single table using the
@@ -143,18 +143,18 @@
             letter, number, or an underscore character, then you must include that name in double
             quotes. If a table is not in the backup set, the restore operation fails. You cannot
             specify a leaf partition of a partitioned table.</pd>
-          <pd>You cannot combine this option with the option <codeph>-exclude-schema</codeph>, or
-            another a table filtering option such as <codeph>-include-table</codeph>.</pd>
+          <pd>You cannot combine this option with the option <codeph>--exclude-schema</codeph>, or
+            another a table filtering option such as <codeph>--include-table</codeph>.</pd>
         </plentry>
       </parml>
       <parml>
         <plentry>
-          <pt><b>-include-schema</b>
+          <pt><b>--include-schema</b>
             <varname>schema_name</varname></pt>
           <pd>Optional. Specifies a database schema to restore. You can specify this option multiple
             times to include multiple schemas. If you specify this option, any schemas that you
             specify must be available in the backup set. Any schemas that are not included in
-            subsequent <codeph>-include-schema</codeph> options are omitted from the restore
+            subsequent <codeph>--include-schema</codeph> options are omitted from the restore
             operation. </pd>
           <pd>If a schema that you specify for inclusion exists in the database, the utility issues
             an error and continues the operation. The utility fails if a table being restored exists
@@ -165,7 +165,7 @@
       </parml>
       <parml>
         <plentry>
-          <pt><b>-include-table</b>
+          <pt><b>--include-table</b>
             <varname>schema.table</varname></pt>
           <pd>Optional. Specifies a table to restore. The table must be in the format
               <codeph>&lt;schema-name>.&lt;table-name></codeph>. If a table or schema name uses any
@@ -173,11 +173,11 @@
             must include that name in double quotes. You can specify this option multiple times. You
             cannot specify a leaf partition of a partitioned table.</pd>
           <pd>You cannot combine this option with a schema filtering option such as
-              <codeph>-include-schema</codeph>, or another table filtering option such as
-              <codeph>-exclude-table-file</codeph>.</pd>
+              <codeph>--include-schema</codeph>, or another table filtering option such as
+              <codeph>--exclude-table-file</codeph>.</pd>
         </plentry>
         <plentry>
-          <pt><b>-include-table-file</b>
+          <pt><b>--include-table-file</b>
             <varname>file_name</varname></pt>
           <pd>Optional. Specifies a text file containing a list of tables to restore. Each line in
             the text file must define a single table using the format
@@ -186,7 +186,7 @@
             number, or an underscore character, then you must include that name in double quotes.
             Any tables not listed in this file are omitted from the restore operation. You cannot
             specify a leaf partition of a partitioned table.</pd>
-          <pd>If you use the <codeph>-include-table-file</codeph> option, <codeph>gprestore</codeph>
+          <pd>If you use the <codeph>--include-table-file</codeph> option, <codeph>gprestore</codeph>
             does not create roles or set the owner of the tables. The utility restores table indexes
             and rules. Triggers are also restored but are not supported in Greenplum Database.</pd>
           <pd>See <xref href="../../admin_guide/managing/backup-gpbackup.xml#topic_et4_b5d_tbb"/>
@@ -195,25 +195,25 @@
       </parml>
       <parml>
         <plentry>
-          <pt><b>-jobs</b>
+          <pt><b>--jobs</b>
             <varname>int</varname></pt>
           <pd>Optional. Specifies the number of parallel connections to use when restoring table
             data. By default, <codeph>gprestore</codeph> uses 1 connection. Increasing this number
             can improve the speed of restoring data.<note>If you used the <codeph>gpbackup
-                -single-data-file</codeph> option to combine table backups into a single file per
-              segment, you cannot set <codeph>-jobs</codeph> to a value higher than 1 to perform a
+                --single-data-file</codeph> option to combine table backups into a single file per
+              segment, you cannot set <codeph>--jobs</codeph> to a value higher than 1 to perform a
               parallel restore operation.</note></pd>
         </plentry>
       </parml>
       <parml>
         <plentry>
-          <pt><b>-quiet</b></pt>
+          <pt><b>--quiet</b></pt>
           <pd>Optional. Suppress all non-warning, non-error log messages.</pd>
         </plentry>
       </parml>
       <parml>
         <plentry>
-          <pt><b>-redirect-db</b>
+          <pt><b>--redirect-db</b>
             <varname>database_name</varname></pt>
           <pd>Optional. Restore to the specified <varname>database_name</varname> instead of to the
             database that was backed up.</pd>
@@ -221,19 +221,19 @@
       </parml>
       <parml>
         <plentry>
-          <pt><b>-verbose</b></pt>
+          <pt><b>--verbose</b></pt>
           <pd>Optional. Print verbose log messages.</pd>
         </plentry>
       </parml>
       <parml>
         <plentry>
-          <pt><b>-version</b></pt>
+          <pt><b>--version</b></pt>
           <pd>Optional. Print the version number and exit.</pd>
         </plentry>
       </parml>
       <parml>
         <plentry>
-          <pt><b>-with-globals</b></pt>
+          <pt><b>--with-globals</b></pt>
           <pd>Optional. Restores Greenplum Database system objects in the backup set, in addition to
             database objects. See <xref
               href="../../admin_guide/managing/backup-gpbackup.xml#topic_x3s_lqj_tbb"/>.</pd>
@@ -241,7 +241,7 @@
       </parml>
       <parml>
         <plentry>
-          <pt><b>-with-stats</b></pt>
+          <pt><b>--with-stats</b></pt>
           <pd>Optional. Restore query plan statistics from the backup set.</pd>
         </plentry>
       </parml>
@@ -261,20 +261,20 @@
       <p>Create the demo database and restore all schemas and tables in the backup set for the
         indicated
         timestamp:<codeblock>$ dropdb demo
-$ gprestore -timestamp 20171103152558 -create-db</codeblock></p>
+$ gprestore --timestamp 20171103152558 --create-db</codeblock></p>
       <p>Restore the backup set to the "demo2" database instead of the "demo" database that was
         backed
         up:<codeblock>$ createdb demo2
-$ gprestore -timestamp 20171103152558 -redirect-db demo2</codeblock></p>
+$ gprestore --timestamp 20171103152558 --redirect-db demo2</codeblock></p>
       <p>Restore global Greenplum Database metadata and query plan statistics in addition to the
         database
-        objects:<codeblock>$ gprestore -timestamp 20171103152558 -create-db -with-globals -with-stats</codeblock></p>
+        objects:<codeblock>$ gprestore --timestamp 20171103152558 --create-db --with-globals --with-stats</codeblock></p>
       <p>Restore, using backup files that were created in the
           <filepath>/home/gpadmin/backup</filepath> directory, creating 8 parallel
-        connections:<codeblock>$ gprestore -backup-dir /home/gpadmin/backups/ -timestamp 20171103153156 -create-db -jobs 8</codeblock></p>
+        connections:<codeblock>$ gprestore --backup-dir /home/gpadmin/backups/ --timestamp 20171103153156 --create-db --jobs 8</codeblock></p>
       <p>Restore only the "wikipedia" schema included in the backup
         set:<codeblock>$ dropdb demo
-$ gprestore -include-schema wikipedia -backup-dir /home/gpadmin/backups/ -timestamp 20171103153156 -create-db</codeblock></p>
+$ gprestore --include-schema wikipedia --backup-dir /home/gpadmin/backups/ --timestamp 20171103153156 --create-db</codeblock></p>
     </section>
     <section id="section9">
       <title>See Also</title>


### PR DESCRIPTION
use dash dash for gpbackup and gprestore word options ((i.e. --single-data-file) instead of single dash.

i think i got all of em.