### PR TITLE
Fix ps display issues

### DIFF
--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -72,6 +72,7 @@
 /* maximum number of segments */
 #define MAX_NUM_OF_SEGMENTS  32768
 
+bool am_ftsprobe = false;
 bool am_ftshandler = false;
 
 #define GpConfigHistoryRelName    "gp_configuration_history"
@@ -81,7 +82,6 @@ bool am_ftshandler = false;
  * STATIC VARIABLES
  */
 
-static bool am_ftsprobe = false;
 static bool skipFtsProbe = false;
 
 static volatile bool shutdown_requested = false;

--- a/src/backend/storage/ipc/standby.c
+++ b/src/backend/storage/ipc/standby.c
@@ -218,7 +218,7 @@ ResolveRecoveryConflictWithVirtualXIDs(VirtualTransactionId *waitlist,
 				const char *old_status;
 				int			len;
 
-				old_status = get_ps_display(&len);
+				old_status = get_real_act_ps_display(&len);
 				new_status = (char *) palloc(len + 8 + 1);
 				memcpy(new_status, old_status, len);
 				strcpy(new_status + len, " waiting");

--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -277,11 +277,12 @@ InitProcess(void)
 	int			i;
 
 	/*
-	 * Autovacuum, WAL sender and FTS handler processes are marked as
-	 * GP_ROLE_UTILITY to prevent unwanted GP_ROLE_DISPATCH MyProc settings
+	 * Autovacuum, WAL sender, FTS handler and FTS daemon processes are marked
+	 * as GP_ROLE_UTILITY to prevent unwanted GP_ROLE_DISPATCH MyProc settings
 	 * such as mppSessionId being valid and mppIsWriter set to true.
 	 */
-	if (IsAutoVacuumWorkerProcess() || am_walsender || am_ftshandler)
+	if (IsAutoVacuumWorkerProcess() || am_walsender || am_ftshandler ||
+		am_ftsprobe)
 		Gp_role = GP_ROLE_UTILITY;
 
 	/*

--- a/src/backend/utils/resscheduler/resqueue.c
+++ b/src/backend/utils/resscheduler/resqueue.c
@@ -1022,7 +1022,7 @@ ResWaitOnLock(LOCALLOCK *locallock, ResourceOwner owner, ResPortalIncrement *inc
 	/* Report change to waiting status */
 	if (update_process_title)
 	{
-		old_status = get_ps_display(&len);
+		old_status = get_real_act_ps_display(&len);
 		new_status = (char *) palloc(len + 8 + 1);
 		memcpy(new_status, old_status, len);
 		strcpy(new_status + len, " queuing");

--- a/src/include/postmaster/fts.h
+++ b/src/include/postmaster/fts.h
@@ -43,6 +43,7 @@ typedef struct FtsResponse
 	bool RequestRetry;
 } FtsResponse;
 
+extern bool am_ftsprobe;
 extern bool am_ftshandler;
 extern bool am_mirror;
 


### PR DESCRIPTION
Without this change, ps display of postmaster child processes may get
mangled.  E.g.

```
postgres: 15432, gpadmin isolation2test [local] con14 cmd52 con14 cm?~??????X???
```

This change uses the GPDB specific function get_real_act_ps_display()
to get the ps display string before it is modified.

This change also sets Gp_role of FTS daemon process to utility instead
of the default value of dispatch.  That prevents appending "conXXX" to
FTS daemon's ps display.

Co-authored-by: Asim R P <apraveen@pivotal.io>