### PR TITLE
Cleanup some fts functions and also remove gp_set_read_only

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -344,8 +344,6 @@ static void DispatchRollbackToSavepoint(char *name);
 
 static bool IsCurrentTransactionIdForReader(TransactionId xid);
 
-extern void FtsCondSetTxnReadOnly(bool *);
-
 /* ----------------------------------------------------------------
  *	transaction state accessors
  * ----------------------------------------------------------------
@@ -2147,9 +2145,6 @@ StartTransaction(void)
 	forceSyncCommit = false;
 	MyXactAccessedTempRel = false;
 	seqXlogWrite = false;
-
-	/* set read only by fts, if any fts action is read only */
-	FtsCondSetTxnReadOnly(&XactReadOnly);
 
 	/*
 	 * reinitialize within-transaction counters

--- a/src/backend/cdb/cdbfts.c
+++ b/src/backend/cdb/cdbfts.c
@@ -133,16 +133,11 @@ FtsNotifyProber(void)
  * dispatcher: ONLY CALL THREADSAFE FUNCTIONS -- elog() is NOT threadsafe.
  */
 bool
-FtsTestConnection(CdbComponentDatabaseInfo *failedDBInfo, bool fullScan)
+FtsIsSegmentUp(CdbComponentDatabaseInfo *dBInfo)
 {
 	/* master is always reported as alive */
-	if (failedDBInfo->segindex == MASTER_SEGMENT_ID)
-	{
+	if (dBInfo->segindex == MASTER_SEGMENT_ID)
 		return true;
-	}
-
-	if (fullScan)
-		FtsNotifyProber();
 
 	/*
 	 * If fullscan is not requested, caller is just trying to optimize on the
@@ -153,41 +148,8 @@ FtsTestConnection(CdbComponentDatabaseInfo *failedDBInfo, bool fullScan)
 	 * checking against uninitialzed variable.
 	 */
 	return ftsProbeInfo->fts_statusVersion ?
-		FTS_STATUS_IS_UP(ftsProbeInfo->fts_status[failedDBInfo->dbid]) :
+		FTS_STATUS_IS_UP(ftsProbeInfo->fts_status[dBInfo->dbid]) :
 		true;
-}
-
-/*
- * Re-Configure the system: if someone has noticed that the status
- * version has been updated, they call this to verify that they've got
- * the right configuration.
- *
- * NOTE: This *always* destroys gangs. And also attempts to inform the
- * fault-prober to do a full scan.
- */
-void
-FtsReConfigureMPP(bool create_new_gangs)
-{
-	/* need to scan to pick up the latest view */
-	FtsNotifyProber();
-
-	ereport(LOG, (errmsg_internal("FTS: reconfiguration is in progress"),
-				  errSendAlert(true)));
-	DisconnectAndDestroyAllGangs(true);
-
-	/* Caller should throw an error. */
-	return;
-}
-
-void
-FtsHandleNetFailure(SegmentDatabaseDescriptor **segDB, int numOfFailed)
-{
-	elog(LOG, "FtsHandleNetFailure: numOfFailed %d", numOfFailed);
-
-	FtsReConfigureMPP(true);
-
-	ereport(ERROR, (errmsg_internal("MPP detected %d segment failures, system is reconnected", numOfFailed),
-					errSendAlert(true)));
 }
 
 /*
@@ -199,7 +161,6 @@ bool
 FtsTestSegmentDBIsDown(SegmentDatabaseDescriptor *segdbDesc, int size)
 {
 	int			i = 0;
-	bool		forceRescan = true;
 
 	for (i = 0; i < size; i++)
 	{
@@ -207,20 +168,16 @@ FtsTestSegmentDBIsDown(SegmentDatabaseDescriptor *segdbDesc, int size)
 
 		elog(DEBUG2, "FtsTestSegmentDBIsDown: looking for real fault on segment dbid %d", segInfo->dbid);
 
-		if (!FtsTestConnection(segInfo, forceRescan))
+		if (!FtsIsSegmentUp(segInfo))
 		{
 			ereport(LOG, (errmsg_internal("FTS: found fault with segment dbid %d. "
 										  "Reconfiguration is in progress", segInfo->dbid)));
 			return true;
 		}
-
-		/* only force the rescan on the first call. */
-		forceRescan = false;
 	}
 
 	return false;
 }
-
 
 void
 FtsCondSetTxnReadOnly(bool *XactFlag)

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -1472,13 +1472,6 @@ initTM(void)
 			 */
 			PG_TRY();
 			{
-				/*
-				 * FtsNotifyProber could throw ERROR, so we should catch it if
-				 * it happens.
-				 */
-				if (!first)
-					FtsNotifyProber();
-
 				initTM_recover_as_needed();
 				succeeded = true;
 			}

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -52,7 +52,6 @@
 GpRoleValue Gp_role;			/* Role paid by this Greenplum Database
 								 * backend */
 char	   *gp_role_string;		/* Staging area for guc.c */
-bool		gp_set_read_only;	/* Staging area for guc.c */
 
 GpRoleValue Gp_session_role;	/* Role paid by this Greenplum Database
 								 * backend */

--- a/src/backend/cdb/dispatcher/cdbdisp_thread.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_thread.c
@@ -936,7 +936,7 @@ cdbdisp_checkSegmentDBAlive(DispatchCommandParms *pParms)
 		WRITE_LOG_DISPATCHER_DEBUG("testing connection %d of %d %s stillRunning %d",
 								   i + 1, pParms->db_count, segdbDesc->whoami, dispatchResult->stillRunning);
 
-		if (!FtsTestConnection(segdbDesc->segment_database_info, false))
+		if (!FtsIsSegmentUp(segdbDesc->segment_database_info))
 		{
 			cdbdisp_appendMessage(dispatchResult, LOG,
 								  "Lost connection to %s. FTS detected segment failures.",

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -537,7 +537,7 @@ buildGangDefinition(GangType type, int gang_id, int size, int content)
 
 			if (size != segCount)
 			{
-				FtsReConfigureMPP(false);
+				DisconnectAndDestroyAllGangs(true);
 				elog(ERROR, "Not all primary segment instances are active and connected");
 			}
 			break;
@@ -1317,7 +1317,7 @@ cleanupGang(Gang *gp)
 			return false;
 
 		/* if segment is down, the gang can not be reused */
-		if (!FtsTestConnection(segdbDesc->segment_database_info, false))
+		if (!FtsIsSegmentUp(segdbDesc->segment_database_info))
 			return false;
 
 		/* Note, we cancel all "still running" queries */
@@ -1827,7 +1827,7 @@ GangOK(Gang *gp)
 
 		if (cdbconn_isBadConnection(segdbDesc))
 			return false;
-		if (!FtsTestConnection(segdbDesc->segment_database_info, false))
+		if (!FtsIsSegmentUp(segdbDesc->segment_database_info))
 			return false;
 	}
 

--- a/src/backend/cdb/dispatcher/cdbgang_async.c
+++ b/src/backend/cdb/dispatcher/cdbgang_async.c
@@ -297,6 +297,7 @@ create_gang_retry:
 	{
 		MemoryContextSwitchTo(GangContext);
 
+		FtsNotifyProber();
 		/* FTS shows some segment DBs are down */
 		if (FtsTestSegmentDBIsDown(newGangDefinition->db_descriptors, size))
 		{

--- a/src/backend/cdb/dispatcher/cdbgang_thread.c
+++ b/src/backend/cdb/dispatcher/cdbgang_thread.c
@@ -223,6 +223,7 @@ create_gang_retry:
 
 	/* there'er failed connections */
 
+	FtsNotifyProber();
 	/* FTS shows some segment DBs are down, destroy all gangs. */
 	if (FtsTestSegmentDBIsDown(newGangDefinition->db_descriptors, size))
 	{

--- a/src/backend/utils/gp/segadmin.c
+++ b/src/backend/utils/gp/segadmin.c
@@ -229,13 +229,6 @@ mirroring_sanity_check(int flags, const char *func)
 			elog(ERROR, "%s can only be run by a superuser", func);
 	}
 
-	if ((flags & READ_ONLY) == READ_ONLY)
-	{
-		if (gp_set_read_only != true)
-			elog(ERROR, "%s can only be run if the system is in read only mode",
-				 func);
-	}
-
 	if ((flags & SEGMENT_ONLY) == SEGMENT_ONLY)
 	{
 		if (GpIdentity.dbid == UNINITIALIZED_GP_IDENTITY_VALUE)

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -1141,16 +1141,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"gp_set_read_only", PGC_SUSET, GP_ARRAY_CONFIGURATION,
-			gettext_noop("Sets the system read only"),
-			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&gp_set_read_only,
-		false, NULL, NULL
-	},
-
-	{
 		{"gp_set_proc_affinity", PGC_POSTMASTER, RESOURCES_KERNEL,
 			gettext_noop("On postmaster startup, attempt to bind postmaster to a processor"),
 			NULL

--- a/src/include/cdb/cdbfts.h
+++ b/src/include/cdb/cdbfts.h
@@ -55,9 +55,7 @@ extern volatile FtsProbeInfo *ftsProbeInfo;
 extern int	FtsShmemSize(void);
 extern void FtsShmemInit(void);
 
-extern bool FtsTestConnection(CdbComponentDatabaseInfo *db_to_test, bool full_scan);
-extern void FtsReConfigureMPP(bool create_new_gangs);
-extern void FtsHandleNetFailure(SegmentDatabaseDescriptor **, int);
+extern bool FtsIsSegmentUp(CdbComponentDatabaseInfo *dBInfo);
 extern bool FtsTestSegmentDBIsDown(SegmentDatabaseDescriptor *, int);
 
 extern bool verifyFtsSyncCount(void);

--- a/src/include/cdb/cdbfts.h
+++ b/src/include/cdb/cdbfts.h
@@ -42,12 +42,7 @@ typedef struct FtsProbeInfo
 typedef struct FtsControlBlock
 {
 	LWLockId	ControlLock;
-
-	bool		ftsReadOnlyFlag;
-	bool		ftsAdminRequestedRO;
-
 	FtsProbeInfo fts_probe_info;
-
 }	FtsControlBlock;
 
 extern volatile FtsProbeInfo *ftsProbeInfo;
@@ -59,16 +54,8 @@ extern bool FtsIsSegmentUp(CdbComponentDatabaseInfo *dBInfo);
 extern bool FtsTestSegmentDBIsDown(SegmentDatabaseDescriptor *, int);
 
 extern bool verifyFtsSyncCount(void);
-extern void FtsCondSetTxnReadOnly(bool *);
 extern void ftsLock(void);
 extern void ftsUnlock(void);
-
 extern void FtsNotifyProber(void);
-
-extern bool isFtsReadOnlySet(void);
 extern uint8 getFtsVersion(void);
-
-/* markStandbyStatus forces persistent state change ?! */
-#define markStandbyStatus(dbid, state) (markSegDBPersistentState((dbid), (state)))
-
 #endif   /* CDBFTS_H */

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -336,8 +336,6 @@ extern int32 gp_subtrans_warn_limit;
 
 extern bool assign_gp_write_shared_snapshot(bool newval, bool doit, GucSource source);
 
-extern bool gp_set_read_only;
-
 extern const char *role_to_string(GpRoleValue role);
 
 extern int	gp_segment_connect_timeout; /* GUC var - timeout specifier for gang creation */


### PR DESCRIPTION
Cleanup functions used by dispatcher to interact with FTS. Plus removes `gp_set_read_only` and corresponding FTS code. I am not sure on usage of this GUC gp_set_read_only. When set it sets FTS to read-only which is then used while starting any transaction and converted to read-only. Seems better to achieve the same result using GUC `default_transaction_read_only` or `transaction_read_only`, which can be used at session-level as well instead of full system-wide setting Or if needed via some other mechanism. Achieving this via FTS doesn't seem optimal at all.

Here I am looking for feedback on what behavior might be better as currently when gang creation fails, it triggers full FTS probes. Which helps to provide good error message, plus early detection of failed segments if any. (Basically `createGang_async()` if fails to create gang or `checkDispatchResult()` if poll timeout, performs FTS probe which in failed case will also take time to timeout and  then command will error-out). So, basically in failed segment case the error is reported late after going via FTS probing of all the segments. Is waiting for full fts probe to complete before declaring failure better or just initiate fts probe but not wait for probe results ?
