### PR TITLE
Rename GPDB specific waiting status API

### DIFF
--- a/src/backend/postmaster/pgstat.c
+++ b/src/backend/postmaster/pgstat.c
@@ -2557,9 +2557,22 @@ pgstat_fetch_resgroup_queue_timestamp(void)
  * NB: this *must* be able to survive being called before MyBEEntry has been
  * initialized.
  * ----------
+ *
+ * In GPDB, this interface is modified to accept a reason for waiting while in
+ * upstream, it just accepts a boolean value.  The interface is renamed in GPDB
+ * to "gpstat_report_waiting(char waiting)" in order to catch future uses of
+ * the interface when merged from upstream.
  */
+#if 0
 void
-pgstat_report_waiting(char waiting)
+pgstat_report_waiting(bool waiting)
+{
+	Assert(false);
+}
+#endif
+
+void
+gpstat_report_waiting(char reason)
 {
 	volatile PgBackendStatus *beentry = MyBEEntry;
 
@@ -2571,7 +2584,7 @@ pgstat_report_waiting(char waiting)
 	 * may modify, there seems no need to bother with the st_changecount
 	 * protocol.  The update must appear atomic in any case.
 	 */
-	beentry->st_waiting = waiting;
+	beentry->st_waiting = reason;
 }
 
 /* ----------

--- a/src/backend/replication/syncrep.c
+++ b/src/backend/replication/syncrep.c
@@ -217,7 +217,7 @@ SyncRepWaitForLSN(XLogRecPtr XactCommitLSN)
 	}
 
 	/* Inform this backend is waiting for replication to pg_stat_activity */
-	pgstat_report_waiting(PGBE_WAITING_REPLICATION);
+	gpstat_report_waiting(PGBE_WAITING_REPLICATION);
 
 	/*
 	 * Wait for specified LSN to be confirmed.
@@ -348,7 +348,7 @@ SyncRepWaitForLSN(XLogRecPtr XactCommitLSN)
 	}
 
 	/* Now inform no more waiting for replication */
-	pgstat_report_waiting(PGBE_WAITING_NONE);
+	gpstat_report_waiting(PGBE_WAITING_NONE);
 }
 
 /*

--- a/src/backend/storage/ipc/standby.c
+++ b/src/backend/storage/ipc/standby.c
@@ -196,7 +196,7 @@ ResolveRecoveryConflictWithVirtualXIDs(VirtualTransactionId *waitlist,
 		TimestampTz waitStart;
 		char	   *new_status;
 
-		pgstat_report_waiting(true);
+		gpstat_report_waiting(PGBE_WAITING_LOCK);
 
 		waitStart = GetCurrentTimestamp();
 		new_status = NULL;		/* we haven't changed the ps display */
@@ -252,7 +252,7 @@ ResolveRecoveryConflictWithVirtualXIDs(VirtualTransactionId *waitlist,
 			set_ps_display(new_status, false);
 			pfree(new_status);
 		}
-		pgstat_report_waiting(false);
+		gpstat_report_waiting(PGBE_WAITING_NONE);
 
 		/* The virtual transaction is gone now, wait for the next one */
 		waitlist++;

--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -1423,7 +1423,7 @@ WaitOnLock(LOCALLOCK *locallock, ResourceOwner owner)
 		set_ps_display(new_status, false);
 		new_status[len] = '\0'; /* truncate off " waiting" */
 	}
-	pgstat_report_waiting(PGBE_WAITING_LOCK);
+	gpstat_report_waiting(PGBE_WAITING_LOCK);
 
 	awaitedLock = locallock;
 	awaitedOwner = owner;
@@ -1471,7 +1471,7 @@ WaitOnLock(LOCALLOCK *locallock, ResourceOwner owner)
 		/* In this path, awaitedLock remains set until LockWaitCancel */
 
 		/* Report change to non-waiting status */
-		pgstat_report_waiting(PGBE_WAITING_NONE);
+		gpstat_report_waiting(PGBE_WAITING_NONE);
 		if (update_process_title)
 		{
 			set_ps_display(new_status, false);
@@ -1486,7 +1486,7 @@ WaitOnLock(LOCALLOCK *locallock, ResourceOwner owner)
 	awaitedLock = NULL;
 
 	/* Report change to non-waiting status */
-	pgstat_report_waiting(PGBE_WAITING_NONE);
+	gpstat_report_waiting(PGBE_WAITING_NONE);
 	if (update_process_title)
 	{
 		set_ps_display(new_status, false);

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -2331,7 +2331,7 @@ waitOnGroup(ResGroupData *group)
 
 	groupAwaited = NULL;
 
-	pgstat_report_waiting(PGBE_WAITING_NONE);
+	gpstat_report_waiting(PGBE_WAITING_NONE);
 }
 
 /*
@@ -2524,7 +2524,7 @@ groupWaitCancel(void)
 	LWLockRelease(ResGroupLock);
 
 	groupAwaited = NULL;
-	pgstat_report_waiting(PGBE_WAITING_NONE);
+	gpstat_report_waiting(PGBE_WAITING_NONE);
 }
 
 static void

--- a/src/backend/utils/resscheduler/resqueue.c
+++ b/src/backend/utils/resscheduler/resqueue.c
@@ -1029,7 +1029,7 @@ ResWaitOnLock(LOCALLOCK *locallock, ResourceOwner owner, ResPortalIncrement *inc
 		set_ps_display(new_status, false);		/* truncate off " queuing" */
 		new_status[len] = '\0';
 	}
-	pgstat_report_waiting(PGBE_WAITING_LOCK);
+	gpstat_report_waiting(PGBE_WAITING_LOCK);
 
 	awaitedLock = locallock;
 	awaitedOwner = owner;
@@ -1056,7 +1056,7 @@ ResWaitOnLock(LOCALLOCK *locallock, ResourceOwner owner, ResPortalIncrement *inc
 		set_ps_display(new_status, false);
 		pfree(new_status);
 	}
-	pgstat_report_waiting(PGBE_WAITING_NONE);
+	gpstat_report_waiting(PGBE_WAITING_NONE);
 
 	return;
 }
@@ -1360,7 +1360,7 @@ ResCheckSelfDeadLock(LOCK *lock, PROCLOCK *proclock, ResPortalIncrement *increme
 		if (lock->nRequested > lock->nGranted)
 		{
 			/* we're no longer waiting. */
-			pgstat_report_waiting(PGBE_WAITING_NONE);
+			gpstat_report_waiting(PGBE_WAITING_NONE);
 			ResGrantLock(lock, proclock);
 			ResLockUpdateLimit(lock, proclock, incrementSet, true, true);
 		}

--- a/src/backend/utils/resscheduler/resscheduler.c
+++ b/src/backend/utils/resscheduler/resscheduler.c
@@ -702,7 +702,7 @@ ResLockPortal(Portal portal, QueryDesc *qDesc)
 				ResLockWaitCancel();
 		
 				/* Change status to no longer waiting for lock */
-				pgstat_report_waiting(PGBE_WAITING_NONE);
+				gpstat_report_waiting(PGBE_WAITING_NONE);
 
 				/* If we had acquired the resource queue lock, release it and clean up */	
 				ResLockRelease(&tag, portal->portalId);
@@ -813,7 +813,7 @@ ResLockUtilityPortal(Portal portal, float4 ignoreCostLimit)
 			ResLockWaitCancel();
 
 			/* Change status to no longer waiting for lock */
-			pgstat_report_waiting(PGBE_WAITING_NONE);
+			gpstat_report_waiting(PGBE_WAITING_NONE);
 
 			/* If we had acquired the resource queue lock, release it and clean up */
 			ResLockRelease(&tag, portal->portalId);

--- a/src/include/pgstat.h
+++ b/src/include/pgstat.h
@@ -767,7 +767,10 @@ extern void pgstat_bestart(void);
 
 extern void pgstat_report_activity(const char *cmd_str);
 extern void pgstat_report_txn_timestamp(TimestampTz tstamp);
-extern void pgstat_report_waiting(char reason);
+#if 0
+extern void pgstat_report_waiting(bool waiting);
+#endif
+extern void gpstat_report_waiting(char reason);
 
 extern void pgstat_report_appname(const char *appname);
 extern void pgstat_report_xact_timestamp(TimestampTz tstamp);


### PR DESCRIPTION
The GPDB specific API for `pgstat_report_waiting()` accepts waiting
reason unlike the upstream counterpart, which accepts only a boolean
flag.  Renaming the API to `gpstat_report_waiting()` allows us to catch
new uses of the API introduced from upstream merges.

Co-authored-by: Asim R P <apraveen@pivotal.io>