### PR TITLE
Fix SIGSEGV issue when freeing gangs

### DIFF
--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -1219,6 +1219,13 @@ DisconnectAndDestroyAllGangs(bool resetSession)
 
 	ELOG_DISPATCHER_DEBUG("DisconnectAndDestroyAllGangs");
 
+	/* Destroy CurrentGangCreating before GangContext is reset */
+	if (CurrentGangCreating != NULL)
+	{
+		DisconnectAndDestroyGang(CurrentGangCreating);
+		CurrentGangCreating = NULL;
+	}
+
 	/* for now, destroy all readers, regardless of the portal that owns them */
 	disconnectAndDestroyAllReaderGangs(true);
 


### PR DESCRIPTION
Previously, to avoid the leak of the gang if someone terminates
the query in the middle of gang creation, we added a global pointer
named CurrentGangCreating so the partially created gang can also be
destroyed at the end of the transaction. However, the memory context
named GangContext where CurrentGangCreating was created may be reset
before CurrentGangCreating is actually destroyed and a SIGSEGV may
occur. So this commit makes sure that CurrentGangCreating is destroyed
ahead of other created gangs and the reset of GangContext.

This is a temp fix to make pipeline happy, @xiong-gang is working on cleaning up
gangs using resource owner which should be a better way to resolve this issue,
but that story may take a while.