### PR TITLE
Remove not supported concurrent bitmap index test.

### DIFF
--- a/src/test/regress/expected/bitmap_index.out
+++ b/src/test/regress/expected/bitmap_index.out
@@ -275,11 +275,6 @@ select t from bm_test where n ISNULL;
  
 (1 row)
 
--- bitmap index builds do not support concurrent building (even with
--- gp_create_index_concurrently=on), test for this
-set gp_create_index_concurrently=true;
-create index concurrently should_not_work on bm_test using bitmap(a);
-ERROR:  CONCURRENTLY is not supported when creating bitmap indexes
 -- test updates
 update bm_test set i4 = 3;
 -- should return nothing

--- a/src/test/regress/expected/bitmap_index_optimizer.out
+++ b/src/test/regress/expected/bitmap_index_optimizer.out
@@ -275,11 +275,6 @@ select t from bm_test where n ISNULL;
  
 (1 row)
 
--- bitmap index builds do not support concurrent building (even with
--- gp_create_index_concurrently=on), test for this
-set gp_create_index_concurrently=true;
-create index concurrently should_not_work on bm_test using bitmap(a);
-ERROR:  CONCURRENTLY is not supported when creating bitmap indexes
 -- test updates
 update bm_test set i4 = 3;
 -- should return nothing

--- a/src/test/regress/sql/bitmap_index.sql
+++ b/src/test/regress/sql/bitmap_index.sql
@@ -81,10 +81,6 @@ select a.t from bm_test a where d in(select d from bm_test b where a.g=b.g);
 -- functional and predicate indexes
 select t from bm_test where upper(t3) = 'FOO';
 select t from bm_test where n ISNULL;
--- bitmap index builds do not support concurrent building (even with
--- gp_create_index_concurrently=on), test for this
-set gp_create_index_concurrently=true;
-create index concurrently should_not_work on bm_test using bitmap(a);
 -- test updates
 update bm_test set i4 = 3;
 -- should return nothing


### PR DESCRIPTION
Concurrent index builds are not supoorted in greenplum. Seems there exist GUC
gp_create_index_concurrently under which we still allow the creations. But still
with the same for bitmap indexes CONCURRENTLY cannot be supported.

This test keeps failing randomly in CI due to "WARNING: ignoring query cancel
request for synchronous replication to ensure cluster consistency." This happens
as during bitmap index creation it locally commits on each segment and then one
of the segment errors during index build with "ERROR: CONCURRENTLY is not
supported when creating bitmap indexes", issues cancelation message to other
segments.