### PR TITLE
docs - add cancel/term backend content

### DIFF
--- a/gpdb-doc/dita/admin_guide/managing/startstop.xml
+++ b/gpdb-doc/dita/admin_guide/managing/startstop.xml
@@ -153,7 +153,7 @@
     <title>Stopping Client Processes</title>
     <body>
       <p>Greenplum Database launches a new backend process for each client connection. A Greenplum Database user with <codeph>SUPERUSER</codeph> privileges can cancel and terminate these client backend processes.</p>
-      <p>Cancelling a backend process with the <codeph>pg_cancel_backend()</codeph> function ends a specific queued or active client query. Terminating a backend process with the <codeph>pg_terminate_backend()</codeph> function terminates a client connection to a database.</p>
+      <p>Canceling a backend process with the <codeph>pg_cancel_backend()</codeph> function ends a specific queued or active client query. Terminating a backend process with the <codeph>pg_terminate_backend()</codeph> function terminates a client connection to a database.</p>
       <p>The <codeph>pg_cancel_backend()</codeph> function has two signatures:<ul>
         <li><codeph>pg_cancel_backend( pid int4 )</codeph></li>
         <li><codeph>pg_cancel_backend( pid int4, msg text )</codeph></li>
@@ -174,10 +174,10 @@
       <p>Use the output to identify the process id (<codeph>procpid</codeph>) of the query
         or client connection. </p>
       <p>For example, to cancel the pending query identified in the sample output above
-        and include "Admin cancelled ong-running query." in the message returned to the client:</p>
+        and include "Admin canceled long-running query." in the message returned to the client:</p>
       <p>
-        <codeblock>=# SELECT pg_cancel_backend(31905 ,'Admin cancelled long-running query.');
-ERROR:  canceling statement due to user request: "Admin cancelled long-running query."</codeblock>
+        <codeblock>=# SELECT pg_cancel_backend(31905 ,'Admin canceled long-running query.');
+ERROR:  canceling statement due to user request: "Admin canceled long-running query."</codeblock>
       </p>
     </body>
   </topic>

--- a/gpdb-doc/dita/admin_guide/managing/startstop.xml
+++ b/gpdb-doc/dita/admin_guide/managing/startstop.xml
@@ -149,4 +149,36 @@
       </steps-unordered>
     </taskbody>
   </task>
+  <topic id="topic13">
+    <title>Stopping Client Processes</title>
+    <body>
+      <p>Greenplum Database launches a new backend process for each client connection. A Greenplum Database user with <codeph>SUPERUSER</codeph> privileges can cancel and terminate these client backend processes.</p>
+      <p>Cancelling a backend process with the <codeph>pg_cancel_backend()</codeph> function ends a specific queued or active client query. Terminating a backend process with the <codeph>pg_terminate_backend()</codeph> function terminates a client connection to a Greenplum Database database.</p>
+      <p>The <codeph>pg_cancel_backend()</codeph> function has two signatures:<ul>
+        <li><codeph>pg_cancel_backend( pid int4 )</codeph></li>
+        <li><codeph>pg_cancel_backend( pid int4, msg text )</codeph></li>
+      </ul></p>
+      <p>The <codeph>pg_terminate_backend()</codeph> function has two similar signatures:<ul>
+        <li><codeph>pg_terminate_backend( pid int4 )</codeph></li>
+        <li><codeph>pg_terminate_backend( pid int4, msg text )</codeph></li>
+      </ul></p>
+      <p>If you provide a <codeph>msg</codeph>, Greenplum Database includes the text in the cancel message returned to the client.</p>
+      <p>The <codeph>pg_cancel_backend()</codeph> and <codeph>pg_terminate_backend()</codeph> functions return <codeph>true</codeph> if successful, and <codeph>false</codeph> otherwise.</p>
+      <p>To cancel or terminate a backend process, you must first identify the process ID of the backend. You can obtain the process ID from the <codeph>procpid</codeph> column of the <codeph>pg_stat_activity</codeph> view. For example, to view the process information associated with all running and queued queries: <codeblock>=# SELECT usename, procpid, waiting, current_query, datname
+     FROM pg_stat_activity;</codeblock></p>
+      <p>Sample partial query output:</p>
+        <codeblock> usename |  procpid | waiting |     current_query     | datname
+---------+----------+---------+-----------------------+---------
+  sammy  |   31861  |    f    | &lt;IDLE&gt; in transaction | testdb
+  billy  |   31905  |    t    | SELECT * FROM topten; | testdb</codeblock>
+      <p>Use the output to identify the process id (<codeph>procpid</codeph>) of the query
+        or client connection. </p>
+      <p>For example, to cancel the pending query identified in the sample output above
+        and include "Admin cancelled ong-running query." in the message returned to the client:</p>
+      <p>
+        <codeblock>=# SELECT pg_cancel_backend(31905 ,'Admin cancelled long-running query.');
+ERROR:  canceling statement due to user request: "Admin cancelled long-running query."</codeblock>
+      </p>
+    </body>
+  </topic>
 </topic>

--- a/gpdb-doc/dita/admin_guide/managing/startstop.xml
+++ b/gpdb-doc/dita/admin_guide/managing/startstop.xml
@@ -153,7 +153,7 @@
     <title>Stopping Client Processes</title>
     <body>
       <p>Greenplum Database launches a new backend process for each client connection. A Greenplum Database user with <codeph>SUPERUSER</codeph> privileges can cancel and terminate these client backend processes.</p>
-      <p>Cancelling a backend process with the <codeph>pg_cancel_backend()</codeph> function ends a specific queued or active client query. Terminating a backend process with the <codeph>pg_terminate_backend()</codeph> function terminates a client connection to a Greenplum Database database.</p>
+      <p>Cancelling a backend process with the <codeph>pg_cancel_backend()</codeph> function ends a specific queued or active client query. Terminating a backend process with the <codeph>pg_terminate_backend()</codeph> function terminates a client connection to a database.</p>
       <p>The <codeph>pg_cancel_backend()</codeph> function has two signatures:<ul>
         <li><codeph>pg_cancel_backend( pid int4 )</codeph></li>
         <li><codeph>pg_cancel_backend( pid int4, msg text )</codeph></li>
@@ -162,7 +162,7 @@
         <li><codeph>pg_terminate_backend( pid int4 )</codeph></li>
         <li><codeph>pg_terminate_backend( pid int4, msg text )</codeph></li>
       </ul></p>
-      <p>If you provide a <codeph>msg</codeph>, Greenplum Database includes the text in the cancel message returned to the client.</p>
+      <p>If you provide a <codeph>msg</codeph>, Greenplum Database includes the text in the cancel message returned to the client. <codeph>msg</codeph> is limited to 128 bytes; Greenplum Database truncates anything longer.</p>
       <p>The <codeph>pg_cancel_backend()</codeph> and <codeph>pg_terminate_backend()</codeph> functions return <codeph>true</codeph> if successful, and <codeph>false</codeph> otherwise.</p>
       <p>To cancel or terminate a backend process, you must first identify the process ID of the backend. You can obtain the process ID from the <codeph>procpid</codeph> column of the <codeph>pg_stat_activity</codeph> view. For example, to view the process information associated with all running and queued queries: <codeblock>=# SELECT usename, procpid, waiting, current_query, datname
      FROM pg_stat_activity;</codeblock></p>

--- a/gpdb-doc/dita/admin_guide/query/topics/functions-operators.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/functions-operators.xml
@@ -502,7 +502,7 @@ SELECT foo();</codeblock>
                                 </xref>
                             </entry>
                             <entry colname="col2"
-                                    >set_config<p>pg_cancel_backend</p><p>pg_reload_conf</p><p>pg_rotate_logfile</p><p>pg_start_backup</p><p>pg_stop_backup</p><p>pg_size_pretty</p><p>pg_ls_dir</p><p>pg_read_file</p><p>pg_stat_file</p></entry>
+                                    >set_config<p>pg_cancel_backend</p><p>pg_terminate_backend</p><p>pg_reload_conf</p><p>pg_rotate_logfile</p><p>pg_start_backup</p><p>pg_stop_backup</p><p>pg_size_pretty</p><p>pg_ls_dir</p><p>pg_read_file</p><p>pg_stat_file</p></entry>
                             <entry colname="col3">current_setting<p><i>All database object size
                                         functions</i></p></entry>
                             <entry colname="col4"><b>Note:</b> The function


### PR DESCRIPTION
docs reference pg_cancel_backend() in a few spots.  no references to pg_terminate_backend().  
- added some content that describes the two signatures of these functions.
- added an example.
- added new topic "Stopping Client Processes" to "Starting and Stopping Greenplum Database" for lack of a better place.

link to new section on docs review site:
- http://docs-gpdb-review-staging.cfapps.io/550/admin_guide/managing/startstop.html#topic13