### PR TITLE
Remove FIXME about group_id in Distinct HashAgg

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -2410,13 +2410,6 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 									   result_plan->total_cost,
 									   current_pathkeys,
 									   dNumDistinctRows);
-
-			/* GPDB_84_MERGE_FIXME: The hash Agg we build for DISTINCT currently
-			 * loses the GROUP_ID() information, so don't use it if there's a
-			 * GROUP_ID().
-			 */
-			if (use_hashed_distinct && contain_group_id((Node *) result_plan->targetlist))
-				use_hashed_distinct = false;
 		}
 
 		/*

--- a/src/backend/optimizer/plan/setrefs.c
+++ b/src/backend/optimizer/plan/setrefs.c
@@ -1727,9 +1727,16 @@ set_upper_references(PlannerGlobal *glob, Plan *plan, int rtoffset)
 		TargetEntry *tle = (TargetEntry *) lfirst(l);
 		Node	   *newexpr;
 
-		if (IsA(tle->expr, Grouping) ||
-				IsA(tle->expr, GroupId))
+		if (IsA(plan, Repeat) &&
+			(IsA(tle->expr, Grouping) || IsA(tle->expr, GroupId)))
+		{
+			/*
+			 * CDB: group_id() & grouping() rely on Repeat to generate non-zero
+			 * values for repeated grouping columns. So, always compute them, rather
+			 * than using OUTER refs from subplan.
+			 */
 			newexpr = copyObject(tle->expr);
+		}
 		else
 		{
 			/* If it's a non-Var sort/group item, first try to match by sortref */


### PR DESCRIPTION
With the 8.4 merge, planner considers using HashAgg to implement
DISTINCT. At the end of planning, we replace the expressions in the
targetlist of certain operators (including Agg) into OUTER references
in targetlist of its lefttree (see set_plan_refs() >
set_upper_references()).
But, as per the code, in the case when grouping() or group_id() are
present in the target list of Agg, it skips the replacement and this is
problematic in case the Agg is implementing DISTINCT.

It seems that the Agg's targetlist need not compute grouping() or
group_id() when its lefttree is computing it. In that case, it may
simply refer to it. This would then also apply to other operators
WindowAgg, Result & PartitionSelector.

However, the Repeat node needs to compute these functions at each stage
because group_id is derived from RepeatState::repeat_count. Thus, it
connot be replaced by an OUTER reference.

Hence, this commit removes the special case for these functions for all
operators except Repeat. Then, a DISTINCT HashAgg produces the correct
results.

Signed-off-by: Shreedhar Hardikar <shardikar@pivotal.io>

As a side note, we did try other approaches for this FIXME:
1. Pass a boolean flag (`ignore_grpext` or similar) to `set_upper_references()` to distinguish `Repeat` from the rest. This did work, but was more code changes with a risk for upstream merge conflicts.
2. Add a flag (`is_distinct` say) in Agg denote when it's purpose to implement DISTINCT. This also worked, but it complicates the operator and also we have to make decisions on the correct value to pass (true/false) at every place we call `make_agg()`.
3. Leave the code as and just remove the FIXME comments. This means we will not have a HashAgg for DISTINCT when group_id() is present.

With that in mind, we settled on the current approach.

- Dhanashree & Shreedhar