### PR TITLE
Fix several pg_upgrade issues related to greenplum partition tables. [WIP]

### DIFF
--- a/contrib/pg_upgrade/Makefile
+++ b/contrib/pg_upgrade/Makefile
@@ -37,4 +37,4 @@ installcheck: test_gpdb.sh all
 	bash $< -o $(top_builddir)/gpAux/gpdemo/datadirs/ -b $(DESTDIR)$(bindir)
 
 check: test_gpdb.sh all
-	bash $< -C -s -o $(top_builddir)/gpAux/gpdemo/datadirs/ -b $(DESTDIR)$(bindir)
+	bash $< -C -r -o $(top_builddir)/gpAux/gpdemo/datadirs/ -b $(DESTDIR)$(bindir)

--- a/contrib/pg_upgrade/Makefile
+++ b/contrib/pg_upgrade/Makefile
@@ -21,7 +21,7 @@ PG_LIBS = $(libpq_pgport)
 # We don't need to add tmp_check to the EXTRA_CLEAN since it's a default name
 # and thus already handled by PGXS "make clean"
 EXTRA_CLEAN = clusterConfigPostgresAddonsFile clusterConfigFile gpdemo-env.sh \
-              hostfile
+              hostfile regression.diffs
 
 ifdef USE_PGXS
 PG_CONFIG = pg_config
@@ -37,4 +37,4 @@ installcheck: test_gpdb.sh all
 	bash $< -o $(top_builddir)/gpAux/gpdemo/datadirs/ -b $(DESTDIR)$(bindir)
 
 check: test_gpdb.sh all
-	bash $< -C -r -o $(top_builddir)/gpAux/gpdemo/datadirs/ -b $(DESTDIR)$(bindir)
+	bash $< -C -s -o $(top_builddir)/gpAux/gpdemo/datadirs/ -b $(DESTDIR)$(bindir)

--- a/contrib/pg_upgrade/check.c
+++ b/contrib/pg_upgrade/check.c
@@ -160,7 +160,8 @@ check_old_cluster(migratorContext *ctx, bool live_check,
 	 */
 	if (!ctx->check)
 	{
-		if (ctx->dispatcher_mode) {
+		if (ctx->dispatcher_mode)
+		{
 			get_old_oids(ctx);
 
 			report_progress(ctx, CLUSTER_OLD, SCHEMA_DUMP, "Creating catalog dump");

--- a/contrib/pg_upgrade/check.c
+++ b/contrib/pg_upgrade/check.c
@@ -160,11 +160,13 @@ check_old_cluster(migratorContext *ctx, bool live_check,
 	 */
 	if (!ctx->check)
 	{
-		if (ctx->dispatcher_mode)
+		if (ctx->dispatcher_mode) {
 			get_old_oids(ctx);
 
-		report_progress(ctx, CLUSTER_OLD, SCHEMA_DUMP, "Creating catalog dump");
-		generate_old_dump(ctx);
+			report_progress(ctx, CLUSTER_OLD, SCHEMA_DUMP, "Creating catalog dump");
+			generate_old_dump(ctx);
+		}
+
 		split_old_dump(ctx);
 	}
 

--- a/contrib/pg_upgrade/pg_upgrade.c
+++ b/contrib/pg_upgrade/pg_upgrade.c
@@ -25,7 +25,8 @@ static void copy_distributedlog(migratorContext *ctx);
 static void set_frozenxids(migratorContext *ctx);
 static void setup(migratorContext *ctx, char *argv0, bool live_check);
 static void cleanup(migratorContext *ctx);
-static void	get_restricted_token(const char *progname);
+static void get_restricted_token(const char *progname);
+static void truncate_pg_partition(migratorContext *ctx);
 
 #ifdef WIN32
 static char * pg_strdupn(const char *str);
@@ -433,6 +434,10 @@ create_new_objects(migratorContext *ctx)
 			  );
 	check_ok(ctx);
 
+	/* For QE node, we do not need partition related systable entries. */
+	if (!ctx->dispatcher_mode)
+		truncate_pg_partition(ctx);
+
 	/* Restore contents of AO auxiliary tables */
 	restore_aosegment_tables(ctx);
 
@@ -463,6 +468,31 @@ create_new_objects(migratorContext *ctx)
 		dump_new_oids(ctx);
 
 	stop_postmaster(ctx, false, false);
+}
+
+/*
+ * GPDB does not store partition related catalog information on QE
+ * so we safely delete them.
+ */
+static void
+truncate_pg_partition(migratorContext *ctx)
+{
+	PGconn	*conn_template1;
+
+	conn_template1 = connectToServer(ctx, "template1", CLUSTER_NEW);
+
+	PQclear(executeQueryOrDie(ctx, conn_template1,
+							  "set allow_system_table_mods='dml'"));
+	PQclear(executeQueryOrDie(ctx, conn_template1,
+							  "delete from pg_catalog.pg_partition"));
+	PQclear(executeQueryOrDie(ctx, conn_template1,
+							  "delete from pg_catalog.pg_partition_rule"));
+	PQclear(executeQueryOrDie(ctx, conn_template1,
+							  "delete from pg_catalog.pg_partition_encoding"));
+	PQclear(executeQueryOrDie(ctx, conn_template1,
+							  "reset allow_system_table_mods"));
+
+	PQfinish(conn_template1);
 }
 
 /*
@@ -684,8 +714,6 @@ cleanup(migratorContext *ctx)
 	if (ctx->debug)
 		return;
 
-	snprintf(filename, sizeof(filename), "%s/%s", ctx->cwd, ALL_DUMP_FILE);
-	unlink(filename);
 	snprintf(filename, sizeof(filename), "%s/%s", ctx->cwd, GLOBALS_DUMP_FILE);
 	unlink(filename);
 	snprintf(filename, sizeof(filename), "%s/%s", ctx->cwd, DB_DUMP_FILE);

--- a/contrib/pg_upgrade/test_gpdb.sh
+++ b/contrib/pg_upgrade/test_gpdb.sh
@@ -303,13 +303,13 @@ export MASTER_DATA_DIRECTORY="${OLD_DATADIR}/qddir/demoDataDir-1"
 # shouldn't be a cause of difference in the files but it is. Partitioning info
 # is generated via backend functionality in the cluster being dumped, and not
 # in pg_dump, so whitespace changes can trip up the diff.
-rm -f dump_sql.diff
 if diff "$temp_root/dump1.sql" "$temp_root/dump2.sql" >/dev/null; then
+	rm -f regression.diffs
 	echo "Passed"
 	exit 0
 else
 	# To aid debugging in pipelines, print the diff to stdout
-	diff -du "$temp_root/dump1.sql" "$temp_root/dump2.sql" | tee dump_sql.diff
+	diff -du "$temp_root/dump1.sql" "$temp_root/dump2.sql" | tee regression.diffs
 	echo "Error: before and after dumps differ"
 	exit 1
 fi

--- a/contrib/pg_upgrade/test_gpdb.sh
+++ b/contrib/pg_upgrade/test_gpdb.sh
@@ -113,8 +113,9 @@ upgrade_segment()
 {
 	mkdir -p $1
 
-	# Copy the OID files from the QD to segments.
+	# Copy the OID and schema files from the QD to segments.
 	cp $qddir/pg_upgrade_dump_*_oids.sql $1
+	cp $qddir/pg_upgrade_dump_all.sql $1
 
 	# Run pg_upgrade
 	pushd $1
@@ -302,12 +303,13 @@ export MASTER_DATA_DIRECTORY="${OLD_DATADIR}/qddir/demoDataDir-1"
 # shouldn't be a cause of difference in the files but it is. Partitioning info
 # is generated via backend functionality in the cluster being dumped, and not
 # in pg_dump, so whitespace changes can trip up the diff.
-if diff -w "$temp_root/dump1.sql" "$temp_root/dump2.sql" >/dev/null; then
+rm -f dump_sql.diff
+if diff "$temp_root/dump1.sql" "$temp_root/dump2.sql" >/dev/null; then
 	echo "Passed"
 	exit 0
 else
 	# To aid debugging in pipelines, print the diff to stdout
-	diff "$temp_root/dump1.sql" "$temp_root/dump2.sql"
+	diff -du "$temp_root/dump1.sql" "$temp_root/dump2.sql" | tee dump_sql.diff
 	echo "Error: before and after dumps differ"
 	exit 1
 fi

--- a/contrib/pg_upgrade/test_gpdb_pre.sql
+++ b/contrib/pg_upgrade/test_gpdb_pre.sql
@@ -1,15 +1,3 @@
-DROP TABLE IF EXISTS alter_ao_part_tables_column.sto_altap3 CASCADE;
-DROP TABLE IF EXISTS alter_ao_part_tables_row.sto_altap3 CASCADE;
-DROP TABLE IF EXISTS co_cr_sub_partzlib8192_1_2 CASCADE;
-DROP TABLE IF EXISTS co_cr_sub_partzlib8192_1 CASCADE;
-DROP TABLE IF EXISTS co_wt_sub_partrle_type8192_1_2 CASCADE;
-DROP TABLE IF EXISTS co_wt_sub_partrle_type8192_1 CASCADE;
-DROP TABLE IF EXISTS ao_wt_sub_partzlib8192_5 CASCADE;
-DROP TABLE IF EXISTS ao_wt_sub_partzlib8192_5_2 CASCADE;
-DROP TABLE IF EXISTS constraint_pt1 CASCADE;
-DROP TABLE IF EXISTS constraint_pt2 CASCADE;
-DROP TABLE IF EXISTS constraint_pt3 CASCADE;
-DROP TABLE IF EXISTS contest_inherit CASCADE;
 
 -- Greenplum pg_upgrade doesn't support indexes on partitions since they can't
 -- be reliably dump/restored in all situations. Drop all such indexes before

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -12947,8 +12947,7 @@ ATPExecPartAdd(AlteredTableInfo *tab,
 	PartitionElem *pelem;
 	List	   *colencs = NIL;
 
-	/* This whole function is QD only. */
-	if (Gp_role != GP_ROLE_DISPATCH)
+	if (!(Gp_role == GP_ROLE_DISPATCH || IsBinaryUpgrade))
 		return;
 
 	if (att == AT_PartAddForSplit)
@@ -13133,7 +13132,8 @@ ATPExecPartAlter(List **wqueue, AlteredTableInfo *tab, Relation rel,
 	if (!(atc->subtype == AT_PartExchange ||
 		  atc->subtype == AT_PartSplit ||
 		  atc->subtype == AT_SetDistributedBy) &&
-		Gp_role != GP_ROLE_DISPATCH)
+		  Gp_role != GP_ROLE_DISPATCH &&
+		  !IsBinaryUpgrade)
 		return;
 
 	switch (atc->subtype)
@@ -13176,7 +13176,7 @@ ATPExecPartAlter(List **wqueue, AlteredTableInfo *tab, Relation rel,
 							RelationGetRelationName(rel))));
 	}
 
-	if (Gp_role == GP_ROLE_DISPATCH)
+	if (Gp_role == GP_ROLE_DISPATCH || IsBinaryUpgrade)
 	{
 		pid2->idtype = AT_AP_IDList;
 		pid2->partiddef = (Node *)pidlst;
@@ -14053,7 +14053,7 @@ ATPExecPartSetTemplate(AlteredTableInfo *tab,
 	PgPartRule			*prule = NULL;
 	int					 lvl   = 1;
 
-	if (Gp_role != GP_ROLE_DISPATCH)
+	if (!(Gp_role == GP_ROLE_DISPATCH || IsBinaryUpgrade))
 		return;
 
 	/* set template for top level table */

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -7660,22 +7660,22 @@ partition_rule_def_worker(PartitionRule *rule, Node *start,
 			{
 				if (!reloptions)
 				{
-					appendStringInfoString(&sid1, ", appendonly=false ");
+					appendStringInfoString(&sid1, ", appendonly=false");
 				}
 				else
 				{
 					if (!strstr(reloptions, "appendonly="))
-						appendStringInfoString(&sid1, ", appendonly=false ");
+						appendStringInfoString(&sid1, ", appendonly=false");
 
 					if ((!strstr(reloptions, "orientation=")) &&
 						strstr(reloptions, "appendonly=true"))
-						appendStringInfoString(&sid1, ", orientation=row ");
+						appendStringInfoString(&sid1, ", orientation=row");
 				}
 			}
 
 			if (reloptions)
 			{
-				appendStringInfo(&sid1, ", %s ", reloptions);
+				appendStringInfo(&sid1, ", %s", reloptions);
 
 				pfree(reloptions);
 			}

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -11998,11 +11998,27 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 									  tbinfo->attlen[j],
 									  tbinfo->attalign[j]);
 					appendStringLiteralAH(q, tbinfo->attnames[j], fout);
-					appendPQExpBuffer(q, "\n  AND attrelid = ");
-					appendStringLiteralAH(q, fmtId(tbinfo->dobj.name), fout);
-					appendPQExpBuffer(q, "::pg_catalog.regclass;\n");
-
-					appendPQExpBuffer(q, "ALTER TABLE ONLY %s ",
+					if (gp_partitioning_available)
+					{
+						/*
+						 * Do for all descendants of a partition table.
+						 * No hurt if this is not a table with partitions.
+						 */
+						appendPQExpBuffer(q, "\n  AND attrelid IN (SELECT %u UNION "
+										  "SELECT pr.parchildrelid FROM "
+										  "pg_catalog.pg_partition_rule pr, "
+										  "pg_catalog.pg_partition p WHERE "
+										  "pr.parchildrelid != 0 AND "
+										  "pr.paroid = p.oid AND p.parrelid=%u);\n",
+										  tbinfo->dobj.catId.oid, tbinfo->dobj.catId.oid);
+					}
+					else
+					{
+						appendPQExpBuffer(q, "\n  AND attrelid = ");
+						appendStringLiteralAH(q, fmtId(tbinfo->dobj.name), fout);
+						appendPQExpBuffer(q, "::pg_catalog.regclass;\n");
+					}
+					appendPQExpBuffer(q, "ALTER TABLE %s ",
 									  fmtId(tbinfo->dobj.name));
 					appendPQExpBuffer(q, "DROP COLUMN %s;\n",
 									  fmtId(tbinfo->attnames[j]));

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -4641,648 +4641,648 @@ start (date '2013-01-01') end (date '2014-01-01') WITH (appendonly=true);
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3" for table "mpp5992"
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l1" for table "mpp5992_1_prt_foo3"
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll1" for table "mpp5992_1_prt_foo3_2_prt_l1"
-NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll2" for table "mpp5992_1_prt_foo3_2_prt_l1"
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll1_4_prt_lll1" for table "mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll1"
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll1_4_prt_lll2" for table "mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll1"
+NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll2" for table "mpp5992_1_prt_foo3_2_prt_l1"
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll2_4_prt_lll1" for table "mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll2"
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll2_4_prt_lll2" for table "mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll2"
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l2" for table "mpp5992_1_prt_foo3"
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll1" for table "mpp5992_1_prt_foo3_2_prt_l2"
-NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll2" for table "mpp5992_1_prt_foo3_2_prt_l2"
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll1_4_prt_lll1" for table "mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll1"
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll1_4_prt_lll2" for table "mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll1"
+NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll2" for table "mpp5992_1_prt_foo3_2_prt_l2"
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll2_4_prt_lll1" for table "mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll2"
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll2_4_prt_lll2" for table "mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll2"
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l3" for table "mpp5992_1_prt_foo3"
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll1" for table "mpp5992_1_prt_foo3_2_prt_l3"
-NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll2" for table "mpp5992_1_prt_foo3_2_prt_l3"
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll1_4_prt_lll1" for table "mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll1"
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll1_4_prt_lll2" for table "mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll1"
+NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll2" for table "mpp5992_1_prt_foo3_2_prt_l3"
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll2_4_prt_lll1" for table "mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll2"
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll2_4_prt_lll2" for table "mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll2"
 select pg_get_partition_def('mpp5992'::regclass,true, true);
-                                                                            pg_get_partition_def                                                                            
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- PARTITION BY RANGE(b)                                                                                                                                                     +
-           SUBPARTITION BY LIST(a)                                                                                                                                         +
-                   SUBPARTITION BY LIST(e)                                                                                                                                 +
-                           SUBPARTITION BY LIST(c)                                                                                                                         +
-           (                                                                                                                                                               +
-           START ('01-01-2007'::date) END ('01-01-2008'::date) EVERY ('@ 1 year'::interval) WITH (tablename='mpp5992_1_prt_1', orientation=column, appendonly=true )       +
-                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                   (                                                                                                                                                       +
-                   SUBPARTITION l1 VALUES(1, 2, 3, 4, 5) WITH (tablename='mpp5992_1_prt_1_2_prt_l1', orientation=column, appendonly=true )                                 +
-                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                           (                                                                                                                                               +
-                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_1_2_prt_l1_3_prt_ll1', orientation=column, appendonly=true )              +
-                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_1_2_prt_l1_3_prt_ll1_4_prt_lll1', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                      +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_1_2_prt_l1_3_prt_ll1_4_prt_lll2', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                   ),                                                                                                                                      +
-                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_1_2_prt_l1_3_prt_ll2', orientation=column, appendonly=true )                       +
-                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_1_2_prt_l1_3_prt_ll2_4_prt_lll1', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                      +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_1_2_prt_l1_3_prt_ll2_4_prt_lll2', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                   )                                                                                                                                       +
-                           ),                                                                                                                                              +
-                   SUBPARTITION l2 VALUES(6, 7, 8, 9, 10) WITH (tablename='mpp5992_1_prt_1_2_prt_l2', orientation=column, appendonly=true )                                +
-                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                           (                                                                                                                                               +
-                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_1_2_prt_l2_3_prt_ll1', orientation=column, appendonly=true )              +
-                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_1_2_prt_l2_3_prt_ll1_4_prt_lll1', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                      +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_1_2_prt_l2_3_prt_ll1_4_prt_lll2', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                   ),                                                                                                                                      +
-                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_1_2_prt_l2_3_prt_ll2', orientation=column, appendonly=true )                       +
-                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_1_2_prt_l2_3_prt_ll2_4_prt_lll1', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                      +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_1_2_prt_l2_3_prt_ll2_4_prt_lll2', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                   )                                                                                                                                       +
-                           )                                                                                                                                               +
-                   ),                                                                                                                                                      +
-           START ('01-01-2008'::date) END ('01-01-2009'::date) EVERY ('@ 1 year'::interval) WITH (tablename='mpp5992_1_prt_2', orientation=column, appendonly=true )       +
-                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                   (                                                                                                                                                       +
-                   SUBPARTITION l1 VALUES(1, 2, 3, 4, 5) WITH (tablename='mpp5992_1_prt_2_2_prt_l1', orientation=column, appendonly=true )                                 +
-                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                           (                                                                                                                                               +
-                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_2_2_prt_l1_3_prt_ll1', orientation=column, appendonly=true )              +
-                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_2_2_prt_l1_3_prt_ll1_4_prt_lll1', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                      +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_2_2_prt_l1_3_prt_ll1_4_prt_lll2', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                   ),                                                                                                                                      +
-                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_2_2_prt_l1_3_prt_ll2', orientation=column, appendonly=true )                       +
-                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_2_2_prt_l1_3_prt_ll2_4_prt_lll1', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                      +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_2_2_prt_l1_3_prt_ll2_4_prt_lll2', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                   )                                                                                                                                       +
-                           ),                                                                                                                                              +
-                   SUBPARTITION l2 VALUES(6, 7, 8, 9, 10) WITH (tablename='mpp5992_1_prt_2_2_prt_l2', orientation=column, appendonly=true )                                +
-                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                           (                                                                                                                                               +
-                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_2_2_prt_l2_3_prt_ll1', orientation=column, appendonly=true )              +
-                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_2_2_prt_l2_3_prt_ll1_4_prt_lll1', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                      +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_2_2_prt_l2_3_prt_ll1_4_prt_lll2', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                   ),                                                                                                                                      +
-                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_2_2_prt_l2_3_prt_ll2', orientation=column, appendonly=true )                       +
-                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_2_2_prt_l2_3_prt_ll2_4_prt_lll1', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                      +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_2_2_prt_l2_3_prt_ll2_4_prt_lll2', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                   )                                                                                                                                       +
-                           )                                                                                                                                               +
-                   ),                                                                                                                                                      +
-           START ('01-01-2009'::date) END ('01-01-2010'::date) EVERY ('@ 1 year'::interval) WITH (tablename='mpp5992_1_prt_3', orientation=column, appendonly=true )       +
-                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                   (                                                                                                                                                       +
-                   SUBPARTITION l1 VALUES(1, 2, 3, 4, 5) WITH (tablename='mpp5992_1_prt_3_2_prt_l1', orientation=column, appendonly=true )                                 +
-                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                           (                                                                                                                                               +
-                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_3_2_prt_l1_3_prt_ll1', orientation=column, appendonly=true )              +
-                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_3_2_prt_l1_3_prt_ll1_4_prt_lll1', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                      +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_3_2_prt_l1_3_prt_ll1_4_prt_lll2', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                   ),                                                                                                                                      +
-                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_3_2_prt_l1_3_prt_ll2', orientation=column, appendonly=true )                       +
-                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_3_2_prt_l1_3_prt_ll2_4_prt_lll1', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                      +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_3_2_prt_l1_3_prt_ll2_4_prt_lll2', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                   )                                                                                                                                       +
-                           ),                                                                                                                                              +
-                   SUBPARTITION l2 VALUES(6, 7, 8, 9, 10) WITH (tablename='mpp5992_1_prt_3_2_prt_l2', orientation=column, appendonly=true )                                +
-                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                           (                                                                                                                                               +
-                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_3_2_prt_l2_3_prt_ll1', orientation=column, appendonly=true )              +
-                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_3_2_prt_l2_3_prt_ll1_4_prt_lll1', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                      +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_3_2_prt_l2_3_prt_ll1_4_prt_lll2', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                   ),                                                                                                                                      +
-                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_3_2_prt_l2_3_prt_ll2', orientation=column, appendonly=true )                       +
-                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_3_2_prt_l2_3_prt_ll2_4_prt_lll1', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                      +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_3_2_prt_l2_3_prt_ll2_4_prt_lll2', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                   )                                                                                                                                       +
-                           )                                                                                                                                               +
-                   ),                                                                                                                                                      +
-           PARTITION foo1 START ('01-01-2011'::date) END ('01-01-2012'::date) WITH (tablename='mpp5992_1_prt_foo1', appendonly=false )                                     +
-                   (                                                                                                                                                       +
-                   SUBPARTITION l1 VALUES(1, 2, 3) WITH (tablename='mpp5992_1_prt_foo1_2_prt_l1', appendonly=false )                                                       +
-                           (                                                                                                                                               +
-                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l1_3_prt_ll1', appendonly=false )                              +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l1_3_prt_ll1_4_prt_lll1', appendonly=false ),                   +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l1_3_prt_ll1_4_prt_lll2', appendonly=false )                    +
-                                   ),                                                                                                                                      +
-                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l1_3_prt_ll2', appendonly=false )                                       +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l1_3_prt_ll2_4_prt_lll1', appendonly=false ),                   +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l1_3_prt_ll2_4_prt_lll2', appendonly=false )                    +
-                                   )                                                                                                                                       +
-                           ),                                                                                                                                              +
-                   SUBPARTITION l2 VALUES(4, 5, 6) WITH (tablename='mpp5992_1_prt_foo1_2_prt_l2', appendonly=false )                                                       +
-                           (                                                                                                                                               +
-                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l2_3_prt_ll1', appendonly=false )                              +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l2_3_prt_ll1_4_prt_lll1', appendonly=false ),                   +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l2_3_prt_ll1_4_prt_lll2', appendonly=false )                    +
-                                   ),                                                                                                                                      +
-                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l2_3_prt_ll2', appendonly=false )                                       +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l2_3_prt_ll2_4_prt_lll1', appendonly=false ),                   +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l2_3_prt_ll2_4_prt_lll2', appendonly=false )                    +
-                                   )                                                                                                                                       +
-                           ),                                                                                                                                              +
-                   SUBPARTITION l3 VALUES(7, 8, 9, 10) WITH (tablename='mpp5992_1_prt_foo1_2_prt_l3', appendonly=false )                                                   +
-                           (                                                                                                                                               +
-                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l3_3_prt_ll1', appendonly=false )                              +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l3_3_prt_ll1_4_prt_lll1', appendonly=false ),                   +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l3_3_prt_ll1_4_prt_lll2', appendonly=false )                    +
-                                   ),                                                                                                                                      +
-                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l3_3_prt_ll2', appendonly=false )                                       +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l3_3_prt_ll2_4_prt_lll1', appendonly=false ),                   +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l3_3_prt_ll2_4_prt_lll2', appendonly=false )                    +
-                                   )                                                                                                                                       +
-                           )                                                                                                                                               +
-                   ),                                                                                                                                                      +
-           PARTITION foo2 START ('01-01-2012'::date) END ('01-01-2013'::date) WITH (tablename='mpp5992_1_prt_foo2', orientation=column, appendonly=true )                  +
-                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                   (                                                                                                                                                       +
-                   SUBPARTITION l1 VALUES(1, 2, 3) WITH (tablename='mpp5992_1_prt_foo2_2_prt_l1', orientation=column, appendonly=true )                                    +
-                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                           (                                                                                                                                               +
-                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l1_3_prt_ll1', orientation=column, appendonly=true )           +
-                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l1_3_prt_ll1_4_prt_lll1', orientation=column, appendonly=true ) +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                      +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l1_3_prt_ll1_4_prt_lll2', orientation=column, appendonly=true ) +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                   ),                                                                                                                                      +
-                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l1_3_prt_ll2', orientation=column, appendonly=true )                    +
-                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l1_3_prt_ll2_4_prt_lll1', orientation=column, appendonly=true ) +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                      +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l1_3_prt_ll2_4_prt_lll2', orientation=column, appendonly=true ) +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                   )                                                                                                                                       +
-                           ),                                                                                                                                              +
-                   SUBPARTITION l2 VALUES(4, 5, 6) WITH (tablename='mpp5992_1_prt_foo2_2_prt_l2', orientation=column, appendonly=true )                                    +
-                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                           (                                                                                                                                               +
-                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l2_3_prt_ll1', orientation=column, appendonly=true )           +
-                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l2_3_prt_ll1_4_prt_lll1', orientation=column, appendonly=true ) +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                      +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l2_3_prt_ll1_4_prt_lll2', orientation=column, appendonly=true ) +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                   ),                                                                                                                                      +
-                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l2_3_prt_ll2', orientation=column, appendonly=true )                    +
-                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l2_3_prt_ll2_4_prt_lll1', orientation=column, appendonly=true ) +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                      +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l2_3_prt_ll2_4_prt_lll2', orientation=column, appendonly=true ) +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                   )                                                                                                                                       +
-                           ),                                                                                                                                              +
-                   SUBPARTITION l3 VALUES(7, 8, 9, 10) WITH (tablename='mpp5992_1_prt_foo2_2_prt_l3', orientation=column, appendonly=true )                                +
-                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                           (                                                                                                                                               +
-                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l3_3_prt_ll1', orientation=column, appendonly=true )           +
-                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l3_3_prt_ll1_4_prt_lll1', orientation=column, appendonly=true ) +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                      +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l3_3_prt_ll1_4_prt_lll2', orientation=column, appendonly=true ) +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                   ),                                                                                                                                      +
-                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l3_3_prt_ll2', orientation=column, appendonly=true )                    +
-                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l3_3_prt_ll2_4_prt_lll1', orientation=column, appendonly=true ) +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                      +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l3_3_prt_ll2_4_prt_lll2', orientation=column, appendonly=true ) +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                   )                                                                                                                                       +
-                           )                                                                                                                                               +
-                   ),                                                                                                                                                      +
-           PARTITION foo3 START ('01-01-2013'::date) END ('01-01-2014'::date) WITH (tablename='mpp5992_1_prt_foo3', orientation=row , appendonly=true )                    +
-                   (                                                                                                                                                       +
-                   SUBPARTITION l1 VALUES(1, 2, 3) WITH (tablename='mpp5992_1_prt_foo3_2_prt_l1', orientation=row , appendonly=true )                                      +
-                           (                                                                                                                                               +
-                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll1', orientation=row , appendonly=true )             +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll1_4_prt_lll1', orientation=row , appendonly=true ),  +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll1_4_prt_lll2', orientation=row , appendonly=true )   +
-                                   ),                                                                                                                                      +
-                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll2', orientation=row , appendonly=true )                      +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll2_4_prt_lll1', orientation=row , appendonly=true ),  +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll2_4_prt_lll2', orientation=row , appendonly=true )   +
-                                   )                                                                                                                                       +
-                           ),                                                                                                                                              +
-                   SUBPARTITION l2 VALUES(4, 5, 6) WITH (tablename='mpp5992_1_prt_foo3_2_prt_l2', orientation=row , appendonly=true )                                      +
-                           (                                                                                                                                               +
-                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll1', orientation=row , appendonly=true )             +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll1_4_prt_lll1', orientation=row , appendonly=true ),  +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll1_4_prt_lll2', orientation=row , appendonly=true )   +
-                                   ),                                                                                                                                      +
-                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll2', orientation=row , appendonly=true )                      +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll2_4_prt_lll1', orientation=row , appendonly=true ),  +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll2_4_prt_lll2', orientation=row , appendonly=true )   +
-                                   )                                                                                                                                       +
-                           ),                                                                                                                                              +
-                   SUBPARTITION l3 VALUES(7, 8, 9, 10) WITH (tablename='mpp5992_1_prt_foo3_2_prt_l3', orientation=row , appendonly=true )                                  +
-                           (                                                                                                                                               +
-                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll1', orientation=row , appendonly=true )             +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll1_4_prt_lll1', orientation=row , appendonly=true ),  +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll1_4_prt_lll2', orientation=row , appendonly=true )   +
-                                   ),                                                                                                                                      +
-                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll2', orientation=row , appendonly=true )                      +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll2_4_prt_lll1', orientation=row , appendonly=true ),  +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll2_4_prt_lll2', orientation=row , appendonly=true )   +
-                                   )                                                                                                                                       +
-                           )                                                                                                                                               +
-                   )                                                                                                                                                       +
+                                                                           pg_get_partition_def                                                                            
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ PARTITION BY RANGE(b)                                                                                                                                                    +
+           SUBPARTITION BY LIST(a)                                                                                                                                        +
+                   SUBPARTITION BY LIST(e)                                                                                                                                +
+                           SUBPARTITION BY LIST(c)                                                                                                                        +
+           (                                                                                                                                                              +
+           START ('01-01-2007'::date) END ('01-01-2008'::date) EVERY ('@ 1 year'::interval) WITH (tablename='mpp5992_1_prt_1', orientation=column, appendonly=true)       +
+                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                   (                                                                                                                                                      +
+                   SUBPARTITION l1 VALUES(1, 2, 3, 4, 5) WITH (tablename='mpp5992_1_prt_1_2_prt_l1', orientation=column, appendonly=true)                                 +
+                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                           (                                                                                                                                              +
+                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_1_2_prt_l1_3_prt_ll1', orientation=column, appendonly=true)              +
+                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_1_2_prt_l1_3_prt_ll1_4_prt_lll1', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                     +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_1_2_prt_l1_3_prt_ll1_4_prt_lll2', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                   ),                                                                                                                                     +
+                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_1_2_prt_l1_3_prt_ll2', orientation=column, appendonly=true)                       +
+                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_1_2_prt_l1_3_prt_ll2_4_prt_lll1', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                     +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_1_2_prt_l1_3_prt_ll2_4_prt_lll2', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                   )                                                                                                                                      +
+                           ),                                                                                                                                             +
+                   SUBPARTITION l2 VALUES(6, 7, 8, 9, 10) WITH (tablename='mpp5992_1_prt_1_2_prt_l2', orientation=column, appendonly=true)                                +
+                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                           (                                                                                                                                              +
+                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_1_2_prt_l2_3_prt_ll1', orientation=column, appendonly=true)              +
+                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_1_2_prt_l2_3_prt_ll1_4_prt_lll1', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                     +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_1_2_prt_l2_3_prt_ll1_4_prt_lll2', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                   ),                                                                                                                                     +
+                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_1_2_prt_l2_3_prt_ll2', orientation=column, appendonly=true)                       +
+                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_1_2_prt_l2_3_prt_ll2_4_prt_lll1', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                     +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_1_2_prt_l2_3_prt_ll2_4_prt_lll2', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                   )                                                                                                                                      +
+                           )                                                                                                                                              +
+                   ),                                                                                                                                                     +
+           START ('01-01-2008'::date) END ('01-01-2009'::date) EVERY ('@ 1 year'::interval) WITH (tablename='mpp5992_1_prt_2', orientation=column, appendonly=true)       +
+                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                   (                                                                                                                                                      +
+                   SUBPARTITION l1 VALUES(1, 2, 3, 4, 5) WITH (tablename='mpp5992_1_prt_2_2_prt_l1', orientation=column, appendonly=true)                                 +
+                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                           (                                                                                                                                              +
+                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_2_2_prt_l1_3_prt_ll1', orientation=column, appendonly=true)              +
+                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_2_2_prt_l1_3_prt_ll1_4_prt_lll1', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                     +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_2_2_prt_l1_3_prt_ll1_4_prt_lll2', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                   ),                                                                                                                                     +
+                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_2_2_prt_l1_3_prt_ll2', orientation=column, appendonly=true)                       +
+                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_2_2_prt_l1_3_prt_ll2_4_prt_lll1', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                     +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_2_2_prt_l1_3_prt_ll2_4_prt_lll2', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                   )                                                                                                                                      +
+                           ),                                                                                                                                             +
+                   SUBPARTITION l2 VALUES(6, 7, 8, 9, 10) WITH (tablename='mpp5992_1_prt_2_2_prt_l2', orientation=column, appendonly=true)                                +
+                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                           (                                                                                                                                              +
+                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_2_2_prt_l2_3_prt_ll1', orientation=column, appendonly=true)              +
+                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_2_2_prt_l2_3_prt_ll1_4_prt_lll1', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                     +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_2_2_prt_l2_3_prt_ll1_4_prt_lll2', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                   ),                                                                                                                                     +
+                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_2_2_prt_l2_3_prt_ll2', orientation=column, appendonly=true)                       +
+                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_2_2_prt_l2_3_prt_ll2_4_prt_lll1', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                     +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_2_2_prt_l2_3_prt_ll2_4_prt_lll2', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                   )                                                                                                                                      +
+                           )                                                                                                                                              +
+                   ),                                                                                                                                                     +
+           START ('01-01-2009'::date) END ('01-01-2010'::date) EVERY ('@ 1 year'::interval) WITH (tablename='mpp5992_1_prt_3', orientation=column, appendonly=true)       +
+                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                   (                                                                                                                                                      +
+                   SUBPARTITION l1 VALUES(1, 2, 3, 4, 5) WITH (tablename='mpp5992_1_prt_3_2_prt_l1', orientation=column, appendonly=true)                                 +
+                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                           (                                                                                                                                              +
+                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_3_2_prt_l1_3_prt_ll1', orientation=column, appendonly=true)              +
+                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_3_2_prt_l1_3_prt_ll1_4_prt_lll1', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                     +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_3_2_prt_l1_3_prt_ll1_4_prt_lll2', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                   ),                                                                                                                                     +
+                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_3_2_prt_l1_3_prt_ll2', orientation=column, appendonly=true)                       +
+                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_3_2_prt_l1_3_prt_ll2_4_prt_lll1', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                     +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_3_2_prt_l1_3_prt_ll2_4_prt_lll2', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                   )                                                                                                                                      +
+                           ),                                                                                                                                             +
+                   SUBPARTITION l2 VALUES(6, 7, 8, 9, 10) WITH (tablename='mpp5992_1_prt_3_2_prt_l2', orientation=column, appendonly=true)                                +
+                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                           (                                                                                                                                              +
+                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_3_2_prt_l2_3_prt_ll1', orientation=column, appendonly=true)              +
+                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_3_2_prt_l2_3_prt_ll1_4_prt_lll1', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                     +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_3_2_prt_l2_3_prt_ll1_4_prt_lll2', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                   ),                                                                                                                                     +
+                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_3_2_prt_l2_3_prt_ll2', orientation=column, appendonly=true)                       +
+                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_3_2_prt_l2_3_prt_ll2_4_prt_lll1', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                     +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_3_2_prt_l2_3_prt_ll2_4_prt_lll2', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                   )                                                                                                                                      +
+                           )                                                                                                                                              +
+                   ),                                                                                                                                                     +
+           PARTITION foo1 START ('01-01-2011'::date) END ('01-01-2012'::date) WITH (tablename='mpp5992_1_prt_foo1', appendonly=false)                                     +
+                   (                                                                                                                                                      +
+                   SUBPARTITION l1 VALUES(1, 2, 3) WITH (tablename='mpp5992_1_prt_foo1_2_prt_l1', appendonly=false)                                                       +
+                           (                                                                                                                                              +
+                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l1_3_prt_ll1', appendonly=false)                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l1_3_prt_ll1_4_prt_lll1', appendonly=false),                   +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l1_3_prt_ll1_4_prt_lll2', appendonly=false)                    +
+                                   ),                                                                                                                                     +
+                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l1_3_prt_ll2', appendonly=false)                                       +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l1_3_prt_ll2_4_prt_lll1', appendonly=false),                   +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l1_3_prt_ll2_4_prt_lll2', appendonly=false)                    +
+                                   )                                                                                                                                      +
+                           ),                                                                                                                                             +
+                   SUBPARTITION l2 VALUES(4, 5, 6) WITH (tablename='mpp5992_1_prt_foo1_2_prt_l2', appendonly=false)                                                       +
+                           (                                                                                                                                              +
+                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l2_3_prt_ll1', appendonly=false)                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l2_3_prt_ll1_4_prt_lll1', appendonly=false),                   +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l2_3_prt_ll1_4_prt_lll2', appendonly=false)                    +
+                                   ),                                                                                                                                     +
+                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l2_3_prt_ll2', appendonly=false)                                       +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l2_3_prt_ll2_4_prt_lll1', appendonly=false),                   +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l2_3_prt_ll2_4_prt_lll2', appendonly=false)                    +
+                                   )                                                                                                                                      +
+                           ),                                                                                                                                             +
+                   SUBPARTITION l3 VALUES(7, 8, 9, 10) WITH (tablename='mpp5992_1_prt_foo1_2_prt_l3', appendonly=false)                                                   +
+                           (                                                                                                                                              +
+                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l3_3_prt_ll1', appendonly=false)                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l3_3_prt_ll1_4_prt_lll1', appendonly=false),                   +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l3_3_prt_ll1_4_prt_lll2', appendonly=false)                    +
+                                   ),                                                                                                                                     +
+                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l3_3_prt_ll2', appendonly=false)                                       +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l3_3_prt_ll2_4_prt_lll1', appendonly=false),                   +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l3_3_prt_ll2_4_prt_lll2', appendonly=false)                    +
+                                   )                                                                                                                                      +
+                           )                                                                                                                                              +
+                   ),                                                                                                                                                     +
+           PARTITION foo2 START ('01-01-2012'::date) END ('01-01-2013'::date) WITH (tablename='mpp5992_1_prt_foo2', orientation=column, appendonly=true)                  +
+                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                   (                                                                                                                                                      +
+                   SUBPARTITION l1 VALUES(1, 2, 3) WITH (tablename='mpp5992_1_prt_foo2_2_prt_l1', orientation=column, appendonly=true)                                    +
+                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                           (                                                                                                                                              +
+                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l1_3_prt_ll1', orientation=column, appendonly=true)           +
+                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l1_3_prt_ll1_4_prt_lll1', orientation=column, appendonly=true) +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                     +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l1_3_prt_ll1_4_prt_lll2', orientation=column, appendonly=true) +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                   ),                                                                                                                                     +
+                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l1_3_prt_ll2', orientation=column, appendonly=true)                    +
+                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l1_3_prt_ll2_4_prt_lll1', orientation=column, appendonly=true) +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                     +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l1_3_prt_ll2_4_prt_lll2', orientation=column, appendonly=true) +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                   )                                                                                                                                      +
+                           ),                                                                                                                                             +
+                   SUBPARTITION l2 VALUES(4, 5, 6) WITH (tablename='mpp5992_1_prt_foo2_2_prt_l2', orientation=column, appendonly=true)                                    +
+                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                           (                                                                                                                                              +
+                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l2_3_prt_ll1', orientation=column, appendonly=true)           +
+                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l2_3_prt_ll1_4_prt_lll1', orientation=column, appendonly=true) +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                     +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l2_3_prt_ll1_4_prt_lll2', orientation=column, appendonly=true) +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                   ),                                                                                                                                     +
+                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l2_3_prt_ll2', orientation=column, appendonly=true)                    +
+                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l2_3_prt_ll2_4_prt_lll1', orientation=column, appendonly=true) +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                     +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l2_3_prt_ll2_4_prt_lll2', orientation=column, appendonly=true) +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                   )                                                                                                                                      +
+                           ),                                                                                                                                             +
+                   SUBPARTITION l3 VALUES(7, 8, 9, 10) WITH (tablename='mpp5992_1_prt_foo2_2_prt_l3', orientation=column, appendonly=true)                                +
+                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                           (                                                                                                                                              +
+                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l3_3_prt_ll1', orientation=column, appendonly=true)           +
+                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l3_3_prt_ll1_4_prt_lll1', orientation=column, appendonly=true) +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                     +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l3_3_prt_ll1_4_prt_lll2', orientation=column, appendonly=true) +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                   ),                                                                                                                                     +
+                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l3_3_prt_ll2', orientation=column, appendonly=true)                    +
+                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l3_3_prt_ll2_4_prt_lll1', orientation=column, appendonly=true) +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                     +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l3_3_prt_ll2_4_prt_lll2', orientation=column, appendonly=true) +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                   )                                                                                                                                      +
+                           )                                                                                                                                              +
+                   ),                                                                                                                                                     +
+           PARTITION foo3 START ('01-01-2013'::date) END ('01-01-2014'::date) WITH (tablename='mpp5992_1_prt_foo3', orientation=row, appendonly=true)                     +
+                   (                                                                                                                                                      +
+                   SUBPARTITION l1 VALUES(1, 2, 3) WITH (tablename='mpp5992_1_prt_foo3_2_prt_l1', orientation=row, appendonly=true)                                       +
+                           (                                                                                                                                              +
+                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll1', orientation=row, appendonly=true)              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll1_4_prt_lll1', orientation=row, appendonly=true),   +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll1_4_prt_lll2', orientation=row, appendonly=true)    +
+                                   ),                                                                                                                                     +
+                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll2', orientation=row, appendonly=true)                       +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll2_4_prt_lll1', orientation=row, appendonly=true),   +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll2_4_prt_lll2', orientation=row, appendonly=true)    +
+                                   )                                                                                                                                      +
+                           ),                                                                                                                                             +
+                   SUBPARTITION l2 VALUES(4, 5, 6) WITH (tablename='mpp5992_1_prt_foo3_2_prt_l2', orientation=row, appendonly=true)                                       +
+                           (                                                                                                                                              +
+                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll1', orientation=row, appendonly=true)              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll1_4_prt_lll1', orientation=row, appendonly=true),   +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll1_4_prt_lll2', orientation=row, appendonly=true)    +
+                                   ),                                                                                                                                     +
+                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll2', orientation=row, appendonly=true)                       +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll2_4_prt_lll1', orientation=row, appendonly=true),   +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll2_4_prt_lll2', orientation=row, appendonly=true)    +
+                                   )                                                                                                                                      +
+                           ),                                                                                                                                             +
+                   SUBPARTITION l3 VALUES(7, 8, 9, 10) WITH (tablename='mpp5992_1_prt_foo3_2_prt_l3', orientation=row, appendonly=true)                                   +
+                           (                                                                                                                                              +
+                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll1', orientation=row, appendonly=true)              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll1_4_prt_lll1', orientation=row, appendonly=true),   +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll1_4_prt_lll2', orientation=row, appendonly=true)    +
+                                   ),                                                                                                                                     +
+                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll2', orientation=row, appendonly=true)                       +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll2_4_prt_lll1', orientation=row, appendonly=true),   +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll2_4_prt_lll2', orientation=row, appendonly=true)    +
+                                   )                                                                                                                                      +
+                           )                                                                                                                                              +
+                   )                                                                                                                                                      +
            )
 (1 row)
 

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -4640,648 +4640,648 @@ start (date '2013-01-01') end (date '2014-01-01') WITH (appendonly=true);
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3" for table "mpp5992"
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l1" for table "mpp5992_1_prt_foo3"
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll1" for table "mpp5992_1_prt_foo3_2_prt_l1"
-NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll2" for table "mpp5992_1_prt_foo3_2_prt_l1"
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll1_4_prt_lll1" for table "mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll1"
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll1_4_prt_lll2" for table "mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll1"
+NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll2" for table "mpp5992_1_prt_foo3_2_prt_l1"
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll2_4_prt_lll1" for table "mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll2"
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll2_4_prt_lll2" for table "mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll2"
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l2" for table "mpp5992_1_prt_foo3"
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll1" for table "mpp5992_1_prt_foo3_2_prt_l2"
-NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll2" for table "mpp5992_1_prt_foo3_2_prt_l2"
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll1_4_prt_lll1" for table "mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll1"
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll1_4_prt_lll2" for table "mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll1"
+NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll2" for table "mpp5992_1_prt_foo3_2_prt_l2"
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll2_4_prt_lll1" for table "mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll2"
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll2_4_prt_lll2" for table "mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll2"
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l3" for table "mpp5992_1_prt_foo3"
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll1" for table "mpp5992_1_prt_foo3_2_prt_l3"
-NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll2" for table "mpp5992_1_prt_foo3_2_prt_l3"
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll1_4_prt_lll1" for table "mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll1"
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll1_4_prt_lll2" for table "mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll1"
+NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll2" for table "mpp5992_1_prt_foo3_2_prt_l3"
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll2_4_prt_lll1" for table "mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll2"
 NOTICE:  CREATE TABLE will create partition "mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll2_4_prt_lll2" for table "mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll2"
 select pg_get_partition_def('mpp5992'::regclass,true, true);
-                                                                            pg_get_partition_def                                                                            
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- PARTITION BY RANGE(b)                                                                                                                                                     +
-           SUBPARTITION BY LIST(a)                                                                                                                                         +
-                   SUBPARTITION BY LIST(e)                                                                                                                                 +
-                           SUBPARTITION BY LIST(c)                                                                                                                         +
-           (                                                                                                                                                               +
-           START ('01-01-2007'::date) END ('01-01-2008'::date) EVERY ('@ 1 year'::interval) WITH (tablename='mpp5992_1_prt_1', orientation=column, appendonly=true )       +
-                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                   (                                                                                                                                                       +
-                   SUBPARTITION l1 VALUES(1, 2, 3, 4, 5) WITH (tablename='mpp5992_1_prt_1_2_prt_l1', orientation=column, appendonly=true )                                 +
-                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                           (                                                                                                                                               +
-                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_1_2_prt_l1_3_prt_ll1', orientation=column, appendonly=true )              +
-                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_1_2_prt_l1_3_prt_ll1_4_prt_lll1', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                      +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_1_2_prt_l1_3_prt_ll1_4_prt_lll2', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                   ),                                                                                                                                      +
-                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_1_2_prt_l1_3_prt_ll2', orientation=column, appendonly=true )                       +
-                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_1_2_prt_l1_3_prt_ll2_4_prt_lll1', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                      +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_1_2_prt_l1_3_prt_ll2_4_prt_lll2', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                   )                                                                                                                                       +
-                           ),                                                                                                                                              +
-                   SUBPARTITION l2 VALUES(6, 7, 8, 9, 10) WITH (tablename='mpp5992_1_prt_1_2_prt_l2', orientation=column, appendonly=true )                                +
-                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                           (                                                                                                                                               +
-                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_1_2_prt_l2_3_prt_ll1', orientation=column, appendonly=true )              +
-                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_1_2_prt_l2_3_prt_ll1_4_prt_lll1', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                      +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_1_2_prt_l2_3_prt_ll1_4_prt_lll2', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                   ),                                                                                                                                      +
-                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_1_2_prt_l2_3_prt_ll2', orientation=column, appendonly=true )                       +
-                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_1_2_prt_l2_3_prt_ll2_4_prt_lll1', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                      +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_1_2_prt_l2_3_prt_ll2_4_prt_lll2', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                   )                                                                                                                                       +
-                           )                                                                                                                                               +
-                   ),                                                                                                                                                      +
-           START ('01-01-2008'::date) END ('01-01-2009'::date) EVERY ('@ 1 year'::interval) WITH (tablename='mpp5992_1_prt_2', orientation=column, appendonly=true )       +
-                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                   (                                                                                                                                                       +
-                   SUBPARTITION l1 VALUES(1, 2, 3, 4, 5) WITH (tablename='mpp5992_1_prt_2_2_prt_l1', orientation=column, appendonly=true )                                 +
-                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                           (                                                                                                                                               +
-                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_2_2_prt_l1_3_prt_ll1', orientation=column, appendonly=true )              +
-                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_2_2_prt_l1_3_prt_ll1_4_prt_lll1', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                      +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_2_2_prt_l1_3_prt_ll1_4_prt_lll2', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                   ),                                                                                                                                      +
-                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_2_2_prt_l1_3_prt_ll2', orientation=column, appendonly=true )                       +
-                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_2_2_prt_l1_3_prt_ll2_4_prt_lll1', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                      +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_2_2_prt_l1_3_prt_ll2_4_prt_lll2', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                   )                                                                                                                                       +
-                           ),                                                                                                                                              +
-                   SUBPARTITION l2 VALUES(6, 7, 8, 9, 10) WITH (tablename='mpp5992_1_prt_2_2_prt_l2', orientation=column, appendonly=true )                                +
-                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                           (                                                                                                                                               +
-                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_2_2_prt_l2_3_prt_ll1', orientation=column, appendonly=true )              +
-                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_2_2_prt_l2_3_prt_ll1_4_prt_lll1', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                      +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_2_2_prt_l2_3_prt_ll1_4_prt_lll2', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                   ),                                                                                                                                      +
-                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_2_2_prt_l2_3_prt_ll2', orientation=column, appendonly=true )                       +
-                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_2_2_prt_l2_3_prt_ll2_4_prt_lll1', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                      +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_2_2_prt_l2_3_prt_ll2_4_prt_lll2', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                   )                                                                                                                                       +
-                           )                                                                                                                                               +
-                   ),                                                                                                                                                      +
-           START ('01-01-2009'::date) END ('01-01-2010'::date) EVERY ('@ 1 year'::interval) WITH (tablename='mpp5992_1_prt_3', orientation=column, appendonly=true )       +
-                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                   (                                                                                                                                                       +
-                   SUBPARTITION l1 VALUES(1, 2, 3, 4, 5) WITH (tablename='mpp5992_1_prt_3_2_prt_l1', orientation=column, appendonly=true )                                 +
-                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                           (                                                                                                                                               +
-                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_3_2_prt_l1_3_prt_ll1', orientation=column, appendonly=true )              +
-                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_3_2_prt_l1_3_prt_ll1_4_prt_lll1', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                      +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_3_2_prt_l1_3_prt_ll1_4_prt_lll2', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                   ),                                                                                                                                      +
-                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_3_2_prt_l1_3_prt_ll2', orientation=column, appendonly=true )                       +
-                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_3_2_prt_l1_3_prt_ll2_4_prt_lll1', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                      +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_3_2_prt_l1_3_prt_ll2_4_prt_lll2', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                   )                                                                                                                                       +
-                           ),                                                                                                                                              +
-                   SUBPARTITION l2 VALUES(6, 7, 8, 9, 10) WITH (tablename='mpp5992_1_prt_3_2_prt_l2', orientation=column, appendonly=true )                                +
-                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                           (                                                                                                                                               +
-                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_3_2_prt_l2_3_prt_ll1', orientation=column, appendonly=true )              +
-                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_3_2_prt_l2_3_prt_ll1_4_prt_lll1', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                      +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_3_2_prt_l2_3_prt_ll1_4_prt_lll2', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                   ),                                                                                                                                      +
-                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_3_2_prt_l2_3_prt_ll2', orientation=column, appendonly=true )                       +
-                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_3_2_prt_l2_3_prt_ll2_4_prt_lll1', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                      +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_3_2_prt_l2_3_prt_ll2_4_prt_lll2', orientation=column, appendonly=true )    +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                   )                                                                                                                                       +
-                           )                                                                                                                                               +
-                   ),                                                                                                                                                      +
-           PARTITION foo1 START ('01-01-2011'::date) END ('01-01-2012'::date) WITH (tablename='mpp5992_1_prt_foo1', appendonly=false )                                     +
-                   (                                                                                                                                                       +
-                   SUBPARTITION l1 VALUES(1, 2, 3) WITH (tablename='mpp5992_1_prt_foo1_2_prt_l1', appendonly=false )                                                       +
-                           (                                                                                                                                               +
-                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l1_3_prt_ll1', appendonly=false )                              +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l1_3_prt_ll1_4_prt_lll1', appendonly=false ),                   +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l1_3_prt_ll1_4_prt_lll2', appendonly=false )                    +
-                                   ),                                                                                                                                      +
-                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l1_3_prt_ll2', appendonly=false )                                       +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l1_3_prt_ll2_4_prt_lll1', appendonly=false ),                   +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l1_3_prt_ll2_4_prt_lll2', appendonly=false )                    +
-                                   )                                                                                                                                       +
-                           ),                                                                                                                                              +
-                   SUBPARTITION l2 VALUES(4, 5, 6) WITH (tablename='mpp5992_1_prt_foo1_2_prt_l2', appendonly=false )                                                       +
-                           (                                                                                                                                               +
-                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l2_3_prt_ll1', appendonly=false )                              +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l2_3_prt_ll1_4_prt_lll1', appendonly=false ),                   +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l2_3_prt_ll1_4_prt_lll2', appendonly=false )                    +
-                                   ),                                                                                                                                      +
-                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l2_3_prt_ll2', appendonly=false )                                       +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l2_3_prt_ll2_4_prt_lll1', appendonly=false ),                   +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l2_3_prt_ll2_4_prt_lll2', appendonly=false )                    +
-                                   )                                                                                                                                       +
-                           ),                                                                                                                                              +
-                   SUBPARTITION l3 VALUES(7, 8, 9, 10) WITH (tablename='mpp5992_1_prt_foo1_2_prt_l3', appendonly=false )                                                   +
-                           (                                                                                                                                               +
-                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l3_3_prt_ll1', appendonly=false )                              +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l3_3_prt_ll1_4_prt_lll1', appendonly=false ),                   +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l3_3_prt_ll1_4_prt_lll2', appendonly=false )                    +
-                                   ),                                                                                                                                      +
-                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l3_3_prt_ll2', appendonly=false )                                       +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l3_3_prt_ll2_4_prt_lll1', appendonly=false ),                   +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l3_3_prt_ll2_4_prt_lll2', appendonly=false )                    +
-                                   )                                                                                                                                       +
-                           )                                                                                                                                               +
-                   ),                                                                                                                                                      +
-           PARTITION foo2 START ('01-01-2012'::date) END ('01-01-2013'::date) WITH (tablename='mpp5992_1_prt_foo2', orientation=column, appendonly=true )                  +
-                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                               +
-                   (                                                                                                                                                       +
-                   SUBPARTITION l1 VALUES(1, 2, 3) WITH (tablename='mpp5992_1_prt_foo2_2_prt_l1', orientation=column, appendonly=true )                                    +
-                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                           (                                                                                                                                               +
-                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l1_3_prt_ll1', orientation=column, appendonly=true )           +
-                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l1_3_prt_ll1_4_prt_lll1', orientation=column, appendonly=true ) +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                      +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l1_3_prt_ll1_4_prt_lll2', orientation=column, appendonly=true ) +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                   ),                                                                                                                                      +
-                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l1_3_prt_ll2', orientation=column, appendonly=true )                    +
-                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l1_3_prt_ll2_4_prt_lll1', orientation=column, appendonly=true ) +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                      +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l1_3_prt_ll2_4_prt_lll2', orientation=column, appendonly=true ) +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                   )                                                                                                                                       +
-                           ),                                                                                                                                              +
-                   SUBPARTITION l2 VALUES(4, 5, 6) WITH (tablename='mpp5992_1_prt_foo2_2_prt_l2', orientation=column, appendonly=true )                                    +
-                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                           (                                                                                                                                               +
-                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l2_3_prt_ll1', orientation=column, appendonly=true )           +
-                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l2_3_prt_ll1_4_prt_lll1', orientation=column, appendonly=true ) +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                      +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l2_3_prt_ll1_4_prt_lll2', orientation=column, appendonly=true ) +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                   ),                                                                                                                                      +
-                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l2_3_prt_ll2', orientation=column, appendonly=true )                    +
-                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l2_3_prt_ll2_4_prt_lll1', orientation=column, appendonly=true ) +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                      +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l2_3_prt_ll2_4_prt_lll2', orientation=column, appendonly=true ) +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                   )                                                                                                                                       +
-                           ),                                                                                                                                              +
-                   SUBPARTITION l3 VALUES(7, 8, 9, 10) WITH (tablename='mpp5992_1_prt_foo2_2_prt_l3', orientation=column, appendonly=true )                                +
-                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                       +
-                           (                                                                                                                                               +
-                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l3_3_prt_ll1', orientation=column, appendonly=true )           +
-                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l3_3_prt_ll1_4_prt_lll1', orientation=column, appendonly=true ) +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                      +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l3_3_prt_ll1_4_prt_lll2', orientation=column, appendonly=true ) +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                   ),                                                                                                                                      +
-                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l3_3_prt_ll2', orientation=column, appendonly=true )                    +
-                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                               +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l3_3_prt_ll2_4_prt_lll1', orientation=column, appendonly=true ) +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                      +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l3_3_prt_ll2_4_prt_lll2', orientation=column, appendonly=true ) +
-                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                       +
-                                   )                                                                                                                                       +
-                           )                                                                                                                                               +
-                   ),                                                                                                                                                      +
-           PARTITION foo3 START ('01-01-2013'::date) END ('01-01-2014'::date) WITH (tablename='mpp5992_1_prt_foo3', orientation=row , appendonly=true )                    +
-                   (                                                                                                                                                       +
-                   SUBPARTITION l1 VALUES(1, 2, 3) WITH (tablename='mpp5992_1_prt_foo3_2_prt_l1', orientation=row , appendonly=true )                                      +
-                           (                                                                                                                                               +
-                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll1', orientation=row , appendonly=true )             +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll1_4_prt_lll1', orientation=row , appendonly=true ),  +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll1_4_prt_lll2', orientation=row , appendonly=true )   +
-                                   ),                                                                                                                                      +
-                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll2', orientation=row , appendonly=true )                      +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll2_4_prt_lll1', orientation=row , appendonly=true ),  +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll2_4_prt_lll2', orientation=row , appendonly=true )   +
-                                   )                                                                                                                                       +
-                           ),                                                                                                                                              +
-                   SUBPARTITION l2 VALUES(4, 5, 6) WITH (tablename='mpp5992_1_prt_foo3_2_prt_l2', orientation=row , appendonly=true )                                      +
-                           (                                                                                                                                               +
-                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll1', orientation=row , appendonly=true )             +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll1_4_prt_lll1', orientation=row , appendonly=true ),  +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll1_4_prt_lll2', orientation=row , appendonly=true )   +
-                                   ),                                                                                                                                      +
-                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll2', orientation=row , appendonly=true )                      +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll2_4_prt_lll1', orientation=row , appendonly=true ),  +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll2_4_prt_lll2', orientation=row , appendonly=true )   +
-                                   )                                                                                                                                       +
-                           ),                                                                                                                                              +
-                   SUBPARTITION l3 VALUES(7, 8, 9, 10) WITH (tablename='mpp5992_1_prt_foo3_2_prt_l3', orientation=row , appendonly=true )                                  +
-                           (                                                                                                                                               +
-                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll1', orientation=row , appendonly=true )             +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll1_4_prt_lll1', orientation=row , appendonly=true ),  +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll1_4_prt_lll2', orientation=row , appendonly=true )   +
-                                   ),                                                                                                                                      +
-                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll2', orientation=row , appendonly=true )                      +
-                                   (                                                                                                                                       +
-                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll2_4_prt_lll1', orientation=row , appendonly=true ),  +
-                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll2_4_prt_lll2', orientation=row , appendonly=true )   +
-                                   )                                                                                                                                       +
-                           )                                                                                                                                               +
-                   )                                                                                                                                                       +
+                                                                           pg_get_partition_def                                                                            
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ PARTITION BY RANGE(b)                                                                                                                                                    +
+           SUBPARTITION BY LIST(a)                                                                                                                                        +
+                   SUBPARTITION BY LIST(e)                                                                                                                                +
+                           SUBPARTITION BY LIST(c)                                                                                                                        +
+           (                                                                                                                                                              +
+           START ('01-01-2007'::date) END ('01-01-2008'::date) EVERY ('@ 1 year'::interval) WITH (tablename='mpp5992_1_prt_1', orientation=column, appendonly=true)       +
+                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                   (                                                                                                                                                      +
+                   SUBPARTITION l1 VALUES(1, 2, 3, 4, 5) WITH (tablename='mpp5992_1_prt_1_2_prt_l1', orientation=column, appendonly=true)                                 +
+                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                           (                                                                                                                                              +
+                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_1_2_prt_l1_3_prt_ll1', orientation=column, appendonly=true)              +
+                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_1_2_prt_l1_3_prt_ll1_4_prt_lll1', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                     +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_1_2_prt_l1_3_prt_ll1_4_prt_lll2', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                   ),                                                                                                                                     +
+                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_1_2_prt_l1_3_prt_ll2', orientation=column, appendonly=true)                       +
+                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_1_2_prt_l1_3_prt_ll2_4_prt_lll1', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                     +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_1_2_prt_l1_3_prt_ll2_4_prt_lll2', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                   )                                                                                                                                      +
+                           ),                                                                                                                                             +
+                   SUBPARTITION l2 VALUES(6, 7, 8, 9, 10) WITH (tablename='mpp5992_1_prt_1_2_prt_l2', orientation=column, appendonly=true)                                +
+                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                           (                                                                                                                                              +
+                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_1_2_prt_l2_3_prt_ll1', orientation=column, appendonly=true)              +
+                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_1_2_prt_l2_3_prt_ll1_4_prt_lll1', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                     +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_1_2_prt_l2_3_prt_ll1_4_prt_lll2', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                   ),                                                                                                                                     +
+                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_1_2_prt_l2_3_prt_ll2', orientation=column, appendonly=true)                       +
+                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_1_2_prt_l2_3_prt_ll2_4_prt_lll1', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                     +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_1_2_prt_l2_3_prt_ll2_4_prt_lll2', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                   )                                                                                                                                      +
+                           )                                                                                                                                              +
+                   ),                                                                                                                                                     +
+           START ('01-01-2008'::date) END ('01-01-2009'::date) EVERY ('@ 1 year'::interval) WITH (tablename='mpp5992_1_prt_2', orientation=column, appendonly=true)       +
+                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                   (                                                                                                                                                      +
+                   SUBPARTITION l1 VALUES(1, 2, 3, 4, 5) WITH (tablename='mpp5992_1_prt_2_2_prt_l1', orientation=column, appendonly=true)                                 +
+                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                           (                                                                                                                                              +
+                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_2_2_prt_l1_3_prt_ll1', orientation=column, appendonly=true)              +
+                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_2_2_prt_l1_3_prt_ll1_4_prt_lll1', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                     +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_2_2_prt_l1_3_prt_ll1_4_prt_lll2', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                   ),                                                                                                                                     +
+                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_2_2_prt_l1_3_prt_ll2', orientation=column, appendonly=true)                       +
+                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_2_2_prt_l1_3_prt_ll2_4_prt_lll1', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                     +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_2_2_prt_l1_3_prt_ll2_4_prt_lll2', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                   )                                                                                                                                      +
+                           ),                                                                                                                                             +
+                   SUBPARTITION l2 VALUES(6, 7, 8, 9, 10) WITH (tablename='mpp5992_1_prt_2_2_prt_l2', orientation=column, appendonly=true)                                +
+                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                           (                                                                                                                                              +
+                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_2_2_prt_l2_3_prt_ll1', orientation=column, appendonly=true)              +
+                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_2_2_prt_l2_3_prt_ll1_4_prt_lll1', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                     +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_2_2_prt_l2_3_prt_ll1_4_prt_lll2', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                   ),                                                                                                                                     +
+                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_2_2_prt_l2_3_prt_ll2', orientation=column, appendonly=true)                       +
+                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_2_2_prt_l2_3_prt_ll2_4_prt_lll1', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                     +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_2_2_prt_l2_3_prt_ll2_4_prt_lll2', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                   )                                                                                                                                      +
+                           )                                                                                                                                              +
+                   ),                                                                                                                                                     +
+           START ('01-01-2009'::date) END ('01-01-2010'::date) EVERY ('@ 1 year'::interval) WITH (tablename='mpp5992_1_prt_3', orientation=column, appendonly=true)       +
+                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                   (                                                                                                                                                      +
+                   SUBPARTITION l1 VALUES(1, 2, 3, 4, 5) WITH (tablename='mpp5992_1_prt_3_2_prt_l1', orientation=column, appendonly=true)                                 +
+                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                           (                                                                                                                                              +
+                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_3_2_prt_l1_3_prt_ll1', orientation=column, appendonly=true)              +
+                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_3_2_prt_l1_3_prt_ll1_4_prt_lll1', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                     +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_3_2_prt_l1_3_prt_ll1_4_prt_lll2', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                   ),                                                                                                                                     +
+                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_3_2_prt_l1_3_prt_ll2', orientation=column, appendonly=true)                       +
+                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_3_2_prt_l1_3_prt_ll2_4_prt_lll1', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                     +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_3_2_prt_l1_3_prt_ll2_4_prt_lll2', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                   )                                                                                                                                      +
+                           ),                                                                                                                                             +
+                   SUBPARTITION l2 VALUES(6, 7, 8, 9, 10) WITH (tablename='mpp5992_1_prt_3_2_prt_l2', orientation=column, appendonly=true)                                +
+                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                           (                                                                                                                                              +
+                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_3_2_prt_l2_3_prt_ll1', orientation=column, appendonly=true)              +
+                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_3_2_prt_l2_3_prt_ll1_4_prt_lll1', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                     +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_3_2_prt_l2_3_prt_ll1_4_prt_lll2', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                   ),                                                                                                                                     +
+                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_3_2_prt_l2_3_prt_ll2', orientation=column, appendonly=true)                       +
+                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_3_2_prt_l2_3_prt_ll2_4_prt_lll1', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                     +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_3_2_prt_l2_3_prt_ll2_4_prt_lll2', orientation=column, appendonly=true)    +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                   )                                                                                                                                      +
+                           )                                                                                                                                              +
+                   ),                                                                                                                                                     +
+           PARTITION foo1 START ('01-01-2011'::date) END ('01-01-2012'::date) WITH (tablename='mpp5992_1_prt_foo1', appendonly=false)                                     +
+                   (                                                                                                                                                      +
+                   SUBPARTITION l1 VALUES(1, 2, 3) WITH (tablename='mpp5992_1_prt_foo1_2_prt_l1', appendonly=false)                                                       +
+                           (                                                                                                                                              +
+                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l1_3_prt_ll1', appendonly=false)                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l1_3_prt_ll1_4_prt_lll1', appendonly=false),                   +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l1_3_prt_ll1_4_prt_lll2', appendonly=false)                    +
+                                   ),                                                                                                                                     +
+                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l1_3_prt_ll2', appendonly=false)                                       +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l1_3_prt_ll2_4_prt_lll1', appendonly=false),                   +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l1_3_prt_ll2_4_prt_lll2', appendonly=false)                    +
+                                   )                                                                                                                                      +
+                           ),                                                                                                                                             +
+                   SUBPARTITION l2 VALUES(4, 5, 6) WITH (tablename='mpp5992_1_prt_foo1_2_prt_l2', appendonly=false)                                                       +
+                           (                                                                                                                                              +
+                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l2_3_prt_ll1', appendonly=false)                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l2_3_prt_ll1_4_prt_lll1', appendonly=false),                   +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l2_3_prt_ll1_4_prt_lll2', appendonly=false)                    +
+                                   ),                                                                                                                                     +
+                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l2_3_prt_ll2', appendonly=false)                                       +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l2_3_prt_ll2_4_prt_lll1', appendonly=false),                   +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l2_3_prt_ll2_4_prt_lll2', appendonly=false)                    +
+                                   )                                                                                                                                      +
+                           ),                                                                                                                                             +
+                   SUBPARTITION l3 VALUES(7, 8, 9, 10) WITH (tablename='mpp5992_1_prt_foo1_2_prt_l3', appendonly=false)                                                   +
+                           (                                                                                                                                              +
+                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l3_3_prt_ll1', appendonly=false)                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l3_3_prt_ll1_4_prt_lll1', appendonly=false),                   +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l3_3_prt_ll1_4_prt_lll2', appendonly=false)                    +
+                                   ),                                                                                                                                     +
+                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l3_3_prt_ll2', appendonly=false)                                       +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l3_3_prt_ll2_4_prt_lll1', appendonly=false),                   +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo1_2_prt_l3_3_prt_ll2_4_prt_lll2', appendonly=false)                    +
+                                   )                                                                                                                                      +
+                           )                                                                                                                                              +
+                   ),                                                                                                                                                     +
+           PARTITION foo2 START ('01-01-2012'::date) END ('01-01-2013'::date) WITH (tablename='mpp5992_1_prt_foo2', orientation=column, appendonly=true)                  +
+                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                              +
+                   (                                                                                                                                                      +
+                   SUBPARTITION l1 VALUES(1, 2, 3) WITH (tablename='mpp5992_1_prt_foo2_2_prt_l1', orientation=column, appendonly=true)                                    +
+                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                           (                                                                                                                                              +
+                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l1_3_prt_ll1', orientation=column, appendonly=true)           +
+                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l1_3_prt_ll1_4_prt_lll1', orientation=column, appendonly=true) +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                     +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l1_3_prt_ll1_4_prt_lll2', orientation=column, appendonly=true) +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                   ),                                                                                                                                     +
+                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l1_3_prt_ll2', orientation=column, appendonly=true)                    +
+                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l1_3_prt_ll2_4_prt_lll1', orientation=column, appendonly=true) +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                     +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l1_3_prt_ll2_4_prt_lll2', orientation=column, appendonly=true) +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                   )                                                                                                                                      +
+                           ),                                                                                                                                             +
+                   SUBPARTITION l2 VALUES(4, 5, 6) WITH (tablename='mpp5992_1_prt_foo2_2_prt_l2', orientation=column, appendonly=true)                                    +
+                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                           (                                                                                                                                              +
+                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l2_3_prt_ll1', orientation=column, appendonly=true)           +
+                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l2_3_prt_ll1_4_prt_lll1', orientation=column, appendonly=true) +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                     +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l2_3_prt_ll1_4_prt_lll2', orientation=column, appendonly=true) +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                   ),                                                                                                                                     +
+                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l2_3_prt_ll2', orientation=column, appendonly=true)                    +
+                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l2_3_prt_ll2_4_prt_lll1', orientation=column, appendonly=true) +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                     +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l2_3_prt_ll2_4_prt_lll2', orientation=column, appendonly=true) +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                   )                                                                                                                                      +
+                           ),                                                                                                                                             +
+                   SUBPARTITION l3 VALUES(7, 8, 9, 10) WITH (tablename='mpp5992_1_prt_foo2_2_prt_l3', orientation=column, appendonly=true)                                +
+                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                                      +
+                           (                                                                                                                                              +
+                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l3_3_prt_ll1', orientation=column, appendonly=true)           +
+                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l3_3_prt_ll1_4_prt_lll1', orientation=column, appendonly=true) +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                     +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l3_3_prt_ll1_4_prt_lll2', orientation=column, appendonly=true) +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                   ),                                                                                                                                     +
+                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l3_3_prt_ll2', orientation=column, appendonly=true)                    +
+                                     COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                     COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l3_3_prt_ll2_4_prt_lll1', orientation=column, appendonly=true) +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0),                                                     +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo2_2_prt_l3_3_prt_ll2_4_prt_lll2', orientation=column, appendonly=true) +
+                                             COLUMN a ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN b ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN c ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN d ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN e ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                             COLUMN f ENCODING (compresstype=none, blocksize=32768, compresslevel=0)                                                      +
+                                   )                                                                                                                                      +
+                           )                                                                                                                                              +
+                   ),                                                                                                                                                     +
+           PARTITION foo3 START ('01-01-2013'::date) END ('01-01-2014'::date) WITH (tablename='mpp5992_1_prt_foo3', orientation=row, appendonly=true)                     +
+                   (                                                                                                                                                      +
+                   SUBPARTITION l1 VALUES(1, 2, 3) WITH (tablename='mpp5992_1_prt_foo3_2_prt_l1', orientation=row, appendonly=true)                                       +
+                           (                                                                                                                                              +
+                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll1', orientation=row, appendonly=true)              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll1_4_prt_lll1', orientation=row, appendonly=true),   +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll1_4_prt_lll2', orientation=row, appendonly=true)    +
+                                   ),                                                                                                                                     +
+                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll2', orientation=row, appendonly=true)                       +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll2_4_prt_lll1', orientation=row, appendonly=true),   +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l1_3_prt_ll2_4_prt_lll2', orientation=row, appendonly=true)    +
+                                   )                                                                                                                                      +
+                           ),                                                                                                                                             +
+                   SUBPARTITION l2 VALUES(4, 5, 6) WITH (tablename='mpp5992_1_prt_foo3_2_prt_l2', orientation=row, appendonly=true)                                       +
+                           (                                                                                                                                              +
+                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll1', orientation=row, appendonly=true)              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll1_4_prt_lll1', orientation=row, appendonly=true),   +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll1_4_prt_lll2', orientation=row, appendonly=true)    +
+                                   ),                                                                                                                                     +
+                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll2', orientation=row, appendonly=true)                       +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll2_4_prt_lll1', orientation=row, appendonly=true),   +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l2_3_prt_ll2_4_prt_lll2', orientation=row, appendonly=true)    +
+                                   )                                                                                                                                      +
+                           ),                                                                                                                                             +
+                   SUBPARTITION l3 VALUES(7, 8, 9, 10) WITH (tablename='mpp5992_1_prt_foo3_2_prt_l3', orientation=row, appendonly=true)                                   +
+                           (                                                                                                                                              +
+                           SUBPARTITION ll1 VALUES('Engineering') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll1', orientation=row, appendonly=true)              +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll1_4_prt_lll1', orientation=row, appendonly=true),   +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll1_4_prt_lll2', orientation=row, appendonly=true)    +
+                                   ),                                                                                                                                     +
+                           SUBPARTITION ll2 VALUES('QA') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll2', orientation=row, appendonly=true)                       +
+                                   (                                                                                                                                      +
+                                   SUBPARTITION lll1 VALUES('M') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll2_4_prt_lll1', orientation=row, appendonly=true),   +
+                                   SUBPARTITION lll2 VALUES('F') WITH (tablename='mpp5992_1_prt_foo3_2_prt_l3_3_prt_ll2_4_prt_lll2', orientation=row, appendonly=true)    +
+                                   )                                                                                                                                      +
+                           )                                                                                                                                              +
+                   )                                                                                                                                                      +
            )
 (1 row)
 


### PR DESCRIPTION
Since we do not store partition definition on QE so there will be some
issues in pg_upgrade for greenplum partition implementation.

1. Create a table with partitions and then rename a partition via
   'alter table ... rename partition'. In greenplum, the constraint names
   are not renamed. Since on QD the dump (replay) sql reconstructs the partition
   definition with the renamed partition name and thus the constraint names
   will all be the renamed ones, but on QE, the dump sql just reconstructs
   the table definition using previous constraint names, without knowing the
   partition definition. This will lead to constraint name mismatch during pg_upgrade.

   In this patch, we copy QD dump sql files to QE and let QE filters
   partition related system table entries later. In theory, we could have another
   solution: add a constraintname parameter in partition definition for
   upgrade only in the dump sql, just like MPP-6297 (search the code with
   this keyword), however the solution above is faster since we just need
   to dump the sql file one time (i.e. on QD only).

2. We need to allow some partition code to run on both QD and QE in the so
   called BindaryUpgrade mode, else there will be various misleading outputs.

Co-authored-by: Max Yang <myang@pivotal.io>