### PR TITLE
Apply DEB_BUILD_OPTIONS for debuild command

### DIFF
--- a/concourse/scripts/deb_create_package.bash
+++ b/concourse/scripts/deb_create_package.bash
@@ -26,6 +26,6 @@ popd
 # yes | mk-build-deps -i ${SRC_DIR}/debian/control
 
 pushd ${SRC_DIR}
-    debuild -us -uc -b > debuild.log
+    DEB_BUILD_OPTIONS='nocheck parallel=6' debuild -us -uc -b > debuild.log
 popd
 cp greenplum-db*.deb deb_package_ubuntu16/greenplum-db.deb


### PR DESCRIPTION
- Use nocheck to skip `make check` in test
- Use parallel to use 6 parallel processes