### PR TITLE
Fix xlog comparison logic in missing_xlog tests.

### DIFF
--- a/src/test/walrep/expected/missing_xlog.out
+++ b/src/test/walrep/expected/missing_xlog.out
@@ -27,6 +27,14 @@ returns text as $$
 
 	return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '')
 $$ language plpythonu;
+create or replace function hex_to_dec(text)
+returns bigint as $$
+	declare r bigint;
+	begin
+	execute E'select x\''||$1|| E'\'::bigint' into r;
+	return r;
+end
+$$ language plpgsql;
 -- Issue a checkpoint, and wait for it to be replayed on all segments.
 create or replace function checkpoint_and_wait_for_replication_replay (retries int) returns bool as
 $$
@@ -62,17 +70,13 @@ begin
 	loop
 		all_caught_up = true;
 		for r in select gp_segment_id, replay_location as loc from gp_stat_replication loop
-			-- XXX: Using text comparison to compare XLOG positions
-			-- is not quite right. Comparing 10/12345678 with
-			-- 9/12345678 would yield incorrect result, for
-			-- example. Ignore that for now, because this test is
-			-- executed in a fresh test cluster, which surely
-			-- hasn't written enough WAL yet to hit that problem.
-			-- With WAL positions smaller than 10/00000000, this
-			-- should work. PostgreSQL 9.4 got a pg_lsn datatype
-			-- that we could use here, once we merge up to 9.4.
+			-- PostgreSQL 9.4 got a pg_lsn datatype that we could
+			-- use here, once we merge up to 9.4. Till then need to
+			-- live with this little complicated logic to drop "/"
+			-- from xlog location and then convert hex to decimal
+			-- for comparison, which serves current test purpose.
 			replay_locs[r.gp_segment_id] = r.loc;
-			if r.loc < checkpoint_locs[r.gp_segment_id] then
+			if hex_to_dec(translate(r.loc, '/', '')) < hex_to_dec(translate(checkpoint_locs[r.gp_segment_id], '/', '')) then
 				all_caught_up = false;
 				failed_for_segment[r.gp_segment_id] = 1;
 			else

--- a/src/test/walrep/sql/missing_xlog.sql
+++ b/src/test/walrep/sql/missing_xlog.sql
@@ -30,6 +30,15 @@ returns text as $$
 	return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '')
 $$ language plpythonu;
 
+create or replace function hex_to_dec(text)
+returns bigint as $$
+	declare r bigint;
+	begin
+	execute E'select x\''||$1|| E'\'::bigint' into r;
+	return r;
+end
+$$ language plpgsql;
+
 -- Issue a checkpoint, and wait for it to be replayed on all segments.
 create or replace function checkpoint_and_wait_for_replication_replay (retries int) returns bool as
 $$
@@ -65,17 +74,13 @@ begin
 	loop
 		all_caught_up = true;
 		for r in select gp_segment_id, replay_location as loc from gp_stat_replication loop
-			-- XXX: Using text comparison to compare XLOG positions
-			-- is not quite right. Comparing 10/12345678 with
-			-- 9/12345678 would yield incorrect result, for
-			-- example. Ignore that for now, because this test is
-			-- executed in a fresh test cluster, which surely
-			-- hasn't written enough WAL yet to hit that problem.
-			-- With WAL positions smaller than 10/00000000, this
-			-- should work. PostgreSQL 9.4 got a pg_lsn datatype
-			-- that we could use here, once we merge up to 9.4.
+			-- PostgreSQL 9.4 got a pg_lsn datatype that we could
+			-- use here, once we merge up to 9.4. Till then need to
+			-- live with this little complicated logic to drop "/"
+			-- from xlog location and then convert hex to decimal
+			-- for comparison, which serves current test purpose.
 			replay_locs[r.gp_segment_id] = r.loc;
-			if r.loc < checkpoint_locs[r.gp_segment_id] then
+			if hex_to_dec(translate(r.loc, '/', '')) < hex_to_dec(translate(checkpoint_locs[r.gp_segment_id], '/', '')) then
 				all_caught_up = false;
 				failed_for_segment[r.gp_segment_id] = 1;
 			else


### PR DESCRIPTION
Test failed few times randomly in CI and newly added debug log revealed flaw
with text comparison of xlog location. For example text comparison considers
this "1/103BE80" xlog location as smaller than "1/FEE230" and hence test
fails. So, instead replaced the logic with other hack to convert the location to
hex and then compare, which should serve th purpose till we get to 9.4.