### PR TITLE
Cleanup code around commit transaction a little bit.

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -1151,7 +1151,6 @@ RecordTransactionCommit(void)
 	SharedInvalidationMessage *invalMessages = NULL;
 	bool		RelcacheInitFileInval;
 	bool		isDtxPrepared = 0;
-	bool		omitCommitRecordForDirtyQEReader;
 	TMGXACT_LOG gxact_log;
 	XLogRecPtr	recptr = {0,0};
 
@@ -1172,31 +1171,7 @@ RecordTransactionCommit(void)
 												 &RelcacheInitFileInval);
 
 	isDtxPrepared = isPreparedDtxTransaction();
-	omitCommitRecordForDirtyQEReader = false;
-	if (markXidCommitted)
-	{
-		/* Safety check in case our assumption is ever broken. */
-		if (Gp_role == GP_ROLE_EXECUTE && !Gp_is_writer && !seqXlogWrite)
-		{
-			/* with the introduction of the new DTM system, we have
-			 * more coherent state information, local-only changes
-			 * should be OK. */
-			if (DistributedTransactionContext == DTX_CONTEXT_LOCAL_ONLY)
-			{
-				/* MPP-1687: readers may under some circumstances extend the CLOG */
-				elog(LOG, "Reader qExec committing LOCAL-ONLY changes.");
-			}
-			else
-			{
-				/*
-				 * We are allowing the QE Reader to write to support error tables.
-				 */
-				elog(DEBUG1, "omitting logging commit record for Reader qExec that has written changes.");
-				omitCommitRecordForDirtyQEReader = true;
-			}
-		}
-	}
-	
+
 	/*
 	 * If we haven't been assigned an XID yet, we neither can, nor do we want
 	 * to write a COMMIT record.
@@ -1215,54 +1190,6 @@ RecordTransactionCommit(void)
 		/* Can't have child XIDs either; AssignTransactionId enforces this */
 		Assert(nchildren == 0);
 
-		/* add global transaction information */
-		if (isDtxPrepared)
-		{
-			XLogRecData rdata[2];
-			xl_xact_commit xlrec;
-
-			SetCurrentTransactionStopTimestamp();
-			xlrec.xact_time = xactStopTimestamp;
-			xlrec.nrels = 0;
-			xlrec.nsubxacts = 0;
-			xlrec.nmsgs = 0;
-			rdata[0].data = (char *) (&xlrec);
-			rdata[0].len = MinSizeOfXactCommit;
-			rdata[0].buffer = InvalidBuffer;
-
-			getDtxLogInfo(&gxact_log);
-
-			rdata[0].next = &(rdata[1]);
-			rdata[1].data = (char *) &gxact_log;
-			rdata[1].len = sizeof(gxact_log);
-			rdata[1].buffer = InvalidBuffer;
-
-			rdata[1].next = NULL;
-
-			/*
-			 * Checkpoint process should hold off obtaining the REDO
-			 * pointer while a backend is writing distributed commit
-			 * xlog record and changing state of the distributed
-			 * trasaction.  Otherwise, it is possible that a commit
-			 * record is written by a transaction and the checkpointer
-			 * determines REDO pointer to be after this commit record.
-			 * But the transaction is yet to chance its state to
-			 * INSERTED_DISRIBUTED_COMMITTED and the checkpoint process
-			 * fails to record this transaction in the checkpoint.
-			 * Crash recovery will never see the commit record for this
-			 * transaction and the second phase of 2PC will never
-			 * happen.  The inCommit flag avoids the situation by
-			 * blocking checkpointer untill a backend has finished
-			 * updating the state.
-			 */
-			save_inCommit = MyProc->inCommit;
-			MyProc->inCommit = true;
-			insertingDistributedCommitted();
-			recptr = XLogInsert(RM_XACT_ID, XLOG_XACT_DISTRIBUTED_COMMIT, rdata);
-			insertedDistributedCommitted();
-			MyProc->inCommit = save_inCommit;
-		}
-
 		/*
 		 * If we didn't create XLOG entries, we're done here; otherwise we
 		 * should flush those entries the same as a commit record.	(An
@@ -1273,7 +1200,13 @@ RecordTransactionCommit(void)
 		if (!isDtxPrepared && XactLastRecEnd.xrecoff == 0)
 			goto cleanup;
 	}
-	else
+
+	/*
+	 * A QD may write distributed commit record even when it didn't have a
+	 * valid local XID if the distributed transaction changed data only on
+	 * segments (e.g. DML statement).
+	 */
+	if (markXidCommitted || isDtxPrepared)
 	{
 		/*
 		 * Begin commit critical section and insert the commit XLOG record.
@@ -1283,7 +1216,8 @@ RecordTransactionCommit(void)
 		xl_xact_commit xlrec;
 
 		/* Tell bufmgr and smgr to prepare for commit */
-		BufmgrCommit();
+		if (markXidCommitted)
+			BufmgrCommit();
 
 		/*
 		 * Set flags required for recovery processing of commits.
@@ -1313,6 +1247,19 @@ RecordTransactionCommit(void)
 		 * holding the ProcArrayLock, since we're the only one modifying it.
 		 * This makes checkpoint's determination of which xacts are inCommit a
 		 * bit fuzzy, but it doesn't matter.
+		 *
+		 * In GPDB, if this is a distributed transaction, checkpoint process
+		 * should hold off obtaining the REDO pointer while a backend is
+		 * writing distributed commit xlog record and changing state of the
+		 * distributed transaction.  Otherwise, it is possible that a commit
+		 * record is written by a transaction and the checkpointer determines
+		 * REDO pointer to be after this commit record.  But the transaction is
+		 * yet to change its state to INSERTED_DISRIBUTED_COMMITTED and the
+		 * checkpoint process fails to record this transaction in the
+		 * checkpoint.  Crash recovery will never see the commit record for
+		 * this transaction and the second phase of 2PC will never happen.  The
+		 * inCommit flag avoids this situation by blocking checkpointer until a
+		 * backend has finished updating the state.
 		 */
 		START_CRIT_SECTION();
 		save_inCommit = MyProc->inCommit;
@@ -1353,23 +1300,21 @@ RecordTransactionCommit(void)
 			rdata[3].buffer = InvalidBuffer;
 			lastrdata = 3;
 		}
-		/* add global transaction information */
-		if (isDtxPrepared)
-		{
-			getDtxLogInfo(&gxact_log);
-
-			rdata[lastrdata].next = &(rdata[4]);
-			rdata[4].data = (char *) &gxact_log;
-			rdata[4].len = sizeof(gxact_log);
-			rdata[4].buffer = InvalidBuffer;
-			lastrdata = 4;
-		}
 		rdata[lastrdata].next = NULL;
 
 		SIMPLE_FAULT_INJECTOR(OnePhaseTransactionCommit);
 
 		if (isDtxPrepared)
 		{
+			/* add global transaction information */
+			getDtxLogInfo(&gxact_log);
+
+			rdata[lastrdata].next = &(rdata[4]);
+			rdata[4].data = (char *) &gxact_log;
+			rdata[4].len = sizeof(gxact_log);
+			rdata[4].buffer = InvalidBuffer;
+			rdata[4].next = NULL;
+
 			insertingDistributedCommitted();
 
 			/*
@@ -1517,7 +1462,7 @@ RecordTransactionCommit(void)
 	 * If we entered a commit critical section, leave it now, and let
 	 * checkpoints proceed.
 	 */
-	if (markXidCommitted)
+	if (markXidCommitted || isDtxPrepared)
 	{
 		MyProc->inCommit = save_inCommit;
 		END_CRIT_SECTION();
@@ -1529,7 +1474,7 @@ RecordTransactionCommit(void)
 	 * Note that at this stage we have marked clog, but still show as running
 	 * in the procarray and continue to hold locks.
 	 */
-	if (markXidCommitted)
+	if (markXidCommitted || isDtxPrepared)
 	{
 		Assert(recptr.xrecoff != 0);
 		SyncRepWaitForLSN(recptr);
@@ -2424,7 +2369,6 @@ CommitTransaction(void)
 	TransactionState s = CurrentTransactionState;
 	TransactionId latestXid;
 
-	TransactionId localXid;
 	bool needNotifyCommittedDtxTransaction = false;
 
 	ShowTransactionState("CommitTransaction");
@@ -2533,20 +2477,6 @@ CommitTransaction(void)
 	 * commit processing
 	 */
 	s->state = TRANS_COMMIT;
-
-	/*
-	 * If we're a QE reader, we share the same top-level as the QE writer, but we
-	 * should't write a commit record because the QE writer will do that. We also
-	 * haven't advertised that XID in the proc array, so we don't need to clean
-	 * that up here either.
-	 */
-	if (DistributedTransactionContext == DTX_CONTEXT_QE_READER ||
-		DistributedTransactionContext == DTX_CONTEXT_QE_ENTRY_DB_SINGLETON)
-	{
-		localXid = InvalidTransactionId;
-	}
-	else
-		localXid = GetTopTransactionIdIfAny();
 
 	/*
 	 * Here is where we really truly commit.
@@ -3008,8 +2938,6 @@ AbortTransaction(void)
 	TransactionState s = CurrentTransactionState;
 	TransactionId latestXid;
 
-	TransactionId localXid = GetTopTransactionIdIfAny();
-
 	SIMPLE_FAULT_INJECTOR(AbortTransactionFail);
 
 	/* Prevent cancel/die interrupt while cleaning up */
@@ -3084,15 +3012,6 @@ AbortTransaction(void)
 	AtAbort_Notify();
 	AtEOXact_RelationMap(false);
 	AtAbort_Twophase();
-
-	/* Like in CommitTransaction(), treat a QE reader as if there was no XID */
-	if (DistributedTransactionContext == DTX_CONTEXT_QE_READER ||
-		DistributedTransactionContext == DTX_CONTEXT_QE_ENTRY_DB_SINGLETON)
-	{
-		localXid = InvalidTransactionId;
-	}
-	else
-		localXid = GetTopTransactionIdIfAny();
 
 	/*
 	 * Advertise the fact that we aborted in pg_clog (assuming that we got as

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -1398,9 +1398,6 @@ RecordTransactionCommit(void)
 		if (max_wal_senders > 0)
 			WalSndWakeup();
 
-		if (isDtxPrepared)
-			forcedDistributedCommitted(&recptr);
-
 		/*
 		 * Now we may update the CLOG, if we wrote a COMMIT record above
 		 */

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -777,7 +777,7 @@ doNotifyingCommitPrepared(void)
 
 	copyDirectDispatchFromTransaction(&direct);
 
-	Assert(currentGxact->state == DTX_STATE_FORCED_COMMITTED);
+	Assert(currentGxact->state == DTX_STATE_INSERTED_COMMITTED);
 	setCurrentGxactState(DTX_STATE_NOTIFYING_COMMIT_PREPARED);
 
 	if (strlen(currentGxact->gid) >= TMGIDSIZE)
@@ -1212,7 +1212,6 @@ rollbackDtxTransaction(void)
 				 currentGxact->gid);
 			break;
 
-		case DTX_STATE_FORCED_COMMITTED:
 		case DTX_STATE_NOTIFYING_COMMIT_PREPARED:
 		case DTX_STATE_INSERTING_COMMITTED:
 		case DTX_STATE_INSERTED_COMMITTED:
@@ -2257,21 +2256,6 @@ insertedDistributedCommitted(void)
 
 	Assert(currentGxact->state == DTX_STATE_INSERTING_COMMITTED);
 	setCurrentGxactState(DTX_STATE_INSERTED_COMMITTED);
-}
-
-
-/*
- * Change state to DTX_STATE_FORCED_COMMITTED.
- */
-void
-forcedDistributedCommitted(XLogRecPtr *recptr)
-{
-	elog(DTM_DEBUG5,
-		 "forcedDistributedCommitted entering in state = %s for gid = %s (xlog record %X/%X)",
-		 DtxStateToString(currentGxact->state), currentGxact->gid, recptr->xlogid, recptr->xrecoff);
-
-	Assert(currentGxact->state == DTX_STATE_INSERTED_COMMITTED);
-	setCurrentGxactState(DTX_STATE_FORCED_COMMITTED);
 }
 
 /* generate global transaction id */

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -306,7 +306,6 @@ extern DistributedTransactionId getMaxDistributedXid(void);
 extern bool includeInCheckpointIsNeeded(TMGXACT *gxact);
 extern void insertingDistributedCommitted(void);
 extern void insertedDistributedCommitted(void);
-extern void forcedDistributedCommitted(XLogRecPtr *recptr);
 
 extern void redoDtxCheckPoint(TMGXACT_CHECKPOINT *gxact_checkpoint);
 extern void redoDistributedCommitRecord(TMGXACT_LOG *gxact_log);


### PR DESCRIPTION
This patch removes unused code, aligning xact.c a bit closer to upstream.