### PR TITLE
Use hard kill in gpload to avoid unexpected gpfdist hang

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -2745,7 +2745,7 @@ class gpload:
                                          stderr=subprocess.PIPE)
 
                     else:
-                        os.kill(a.pid, signal.SIGTERM)
+                        os.kill(a.pid, signal.SIGKILL)
                 except OSError:
                     pass
         self.log(self.LOG, 'terminating all threads')

--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -2567,7 +2567,7 @@ process_term_signal(int sig,short event,void* arg)
 			{
 				closesocket(gcb.listen_socks[i]);
 			}
-		exit(1);
+		_exit(1);
 }
 
 


### PR DESCRIPTION
When gpload finishes its query, it will send SIGTERM to gpfdist.
gpfdist handle SIGTERM with exit(1), which will invoke registered
apr handlers and cleanup all apr resources including apr_pool. If
this happens just during normal destruction of apr_pool in
do_close, gpfdist will hang.

Call _exit in gpfdist to avoid any cleanup handlers, and let gpload
send SIGKILL to perform hard kill.