### PR TITLE
Use SessionUserIsSuperuser instead of superuser_arg() in buildGpQuery…

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -912,8 +912,6 @@ buildGpQueryString(struct CdbDispatcherState *ds,
 	Oid			sessionUserId = GetSessionUserId();
 	Oid			outerUserId = GetOuterUserId();
 	Oid			currentUserId = GetUserId();
-	bool		sessionUserIsSuper = superuser_arg(GetSessionUserId());
-	bool		outerUserIsSuper = superuser_arg(GetSessionUserId());
 	StringInfoData resgroupInfo;
 
 	int			tmp,
@@ -923,8 +921,6 @@ buildGpQueryString(struct CdbDispatcherState *ds,
 	int			total_query_len;
 	char	   *shared_query,
 			   *pos;
-	char		one = 1;
-	char		zero = 0;
 
 	initStringInfo(&resgroupInfo);
 	if (IsResGroupActivated())
@@ -933,8 +929,8 @@ buildGpQueryString(struct CdbDispatcherState *ds,
 	total_query_len = 1 /* 'M' */ +
 		sizeof(len) /* message length */ +
 		sizeof(gp_command_count) +
-		sizeof(sessionUserId) + 1 /* sessionUserIsSuper */ +
-		sizeof(outerUserId) + 1 /* outerUserIsSuper */ +
+		sizeof(sessionUserId) /* sessionUserIsSuper */ +
+		sizeof(outerUserId) /* outerUserIsSuper */ +
 		sizeof(currentUserId) +
 		sizeof(rootIdx) +
 		sizeof(n32) * 2 /* currentStatementStartTimestamp */ +
@@ -982,20 +978,9 @@ buildGpQueryString(struct CdbDispatcherState *ds,
 	memcpy(pos, &tmp, sizeof(sessionUserId));
 	pos += sizeof(sessionUserId);
 
-	if (sessionUserIsSuper)
-		*pos++ = one;
-	else
-		*pos++ = zero;
-
-
 	tmp = htonl(outerUserId);
 	memcpy(pos, &tmp, sizeof(outerUserId));
 	pos += sizeof(outerUserId);
-
-	if (outerUserIsSuper)
-		*pos++ = one;
-	else
-		*pos++ = zero;
 
 	tmp = htonl(currentUserId);
 	memcpy(pos, &tmp, sizeof(currentUserId));

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -5263,8 +5263,6 @@ PostgresMain(int argc, char *argv[],
 					Oid suid;
 					Oid ouid;
 					Oid cuid;
-					bool suid_is_super = false;
-					bool ouid_is_super = false;
 
 					int unusedFlags;
 
@@ -5283,12 +5281,7 @@ PostgresMain(int argc, char *argv[],
 
 					/* Get the userid info  (session, outer, current) */
 					suid = pq_getmsgint(&input_message, 4);
-					if(pq_getmsgbyte(&input_message) == 1)
-						suid_is_super = true;
-
 					ouid = pq_getmsgint(&input_message, 4);
-					if(pq_getmsgbyte(&input_message) == 1)
-						ouid_is_super = true;
 					cuid = pq_getmsgint(&input_message, 4);
 
 					rootIdx = pq_getmsgint(&input_message, 4);
@@ -5363,11 +5356,17 @@ PostgresMain(int argc, char *argv[],
 					if (IsResGroupActivated() && resgroupInfoLen > 0)
 						SwitchResGroupOnSegment(resgroupInfoBuf, resgroupInfoLen);
 
+					/*
+					 * GUC "is_supersuer" only provide value for SHOW to display,
+					 * so it's useless on segments. SessionUserIsSuperuser is
+					 * also designed to determine the value of is_superuser, so
+					 * setting it to false on segments is fine.
+					 */
 					if (suid > 0)
-						SetSessionUserId(suid, suid_is_super); /* Set the session UserId */
+						SetSessionUserId(suid, false); /* Set the session UserId */
 
 					if (ouid > 0 && ouid != GetSessionUserId())
-						SetCurrentRoleId(ouid, ouid_is_super); /* Set the outer UserId */
+						SetCurrentRoleId(ouid, false); /* Set the outer UserId */
 
 					setupQEDtxContext(&TempDtxContextInfo);
 


### PR DESCRIPTION
…String()

GPDB used to dispatch a command within empty transaction and resource owner
to define an index concurrently. However, a syscache access in superuser_arg()
may report a SIGSEGV because CurrentResourceOwner is NULL, this commit use
SessionUserIsSuperuser instead of superuser_arg() to avoid such error.