### PR TITLE
Fix pushing down of quals below subqueries with set operations

### DIFF
--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -79,7 +79,7 @@ static bool recurse_pushdown_safe(Node *setOp, Query *topquery,
 					  bool *differentTypes);
 static void compare_tlist_datatypes(List *tlist, List *colTypes,
 						bool *differentTypes);
-static bool qual_is_pushdown_safe(Query *subquery, Index rti, Node *qual,
+static bool qual_is_pushdown_safe(Query *subquery, RangeTblEntry *rte, Index rti, Node *qual,
 					  bool *differentTypes);
 static void subquery_push_qual(Query *subquery,
 				   RangeTblEntry *rte, Index rti, Node *qual);
@@ -1358,7 +1358,7 @@ push_down_restrict(PlannerInfo *root, RelOptInfo *rel,
 			Node	   *clause = (Node *) rinfo->clause;
 
 			if (!rinfo->pseudoconstant &&
-				qual_is_pushdown_safe(subquery, rti, clause, differentTypes))
+				qual_is_pushdown_safe(subquery, rte, rti, clause, differentTypes))
 			{
 				/* Push it down */
 				subquery_push_qual(subquery, rte, rti, clause);
@@ -1389,19 +1389,23 @@ push_down_restrict(PlannerInfo *root, RelOptInfo *rel,
  * 1. If the subquery has a LIMIT clause, we must not push down any quals,
  * since that could change the set of rows returned.
  *
- * 2. If the subquery contains any window functions, we can't push quals
- * into it, because that would change the results.
- *
- * 3. If the subquery contains EXCEPT or EXCEPT ALL set ops we cannot push
+ * 2. If the subquery contains EXCEPT or EXCEPT ALL set ops we cannot push
  * quals into it, because that would change the results.
  *
- * 4. For subqueries using UNION/UNION ALL/INTERSECT/INTERSECT ALL, we can
+ * 3. For subqueries using UNION/UNION ALL/INTERSECT/INTERSECT ALL, we can
  * push quals into each component query, but the quals can only reference
  * subquery columns that suffer no type coercions in the set operation.
  * Otherwise there are possible semantic gotchas.  So, we check the
  * component queries to see if any of them have different output types;
  * differentTypes[k] is set true if column k has different type in any
  * component.
+ *
+ * 4. If the subquery target list has expressions containing calls to
+ * window functions, we must not push down any quals since this could
+ * change the meaning of the query.  At runtime, window functions refer
+ * to the executor state of their Window node.  If a pushed-down qual
+ * removed a tuple, the state seen by later tuples (hence the values
+ * of window functions) could be affected.
  *
  * 5. Do not push down quals if the subquery is a grouping extension
  * query, since this may change the meaning of the query.
@@ -1414,10 +1418,6 @@ subquery_is_pushdown_safe(Query *subquery, Query *topquery,
 
 	/* Check point 1 */
 	if (subquery->limitOffset != NULL || subquery->limitCount != NULL)
-		return false;
-
-	/* Check point 2 */
-	if (subquery->hasWindFuncs)
 		return false;
 
 	/* Targetlist must not contain SRF */
@@ -1523,6 +1523,71 @@ compare_tlist_datatypes(List *tlist, List *colTypes,
 }
 
 
+
+/*
+ * does qual include a reference to windowref node?
+ */
+static bool
+qual_contains_winref(Query *subquery, RangeTblEntry *rte, Index rti, Node *qual)
+{
+	bool result = false;
+	if (NULL != subquery && NIL != subquery->windowClause)
+	{
+		 /*
+		  * qual needs to be resolved first to map qual columns
+		  * to the underlying set of produced columns,
+		  * e.g., if we work on a setop child
+		 */
+		Node *qualNew = ResolveNew(qual, rti, 0, rte,
+								subquery->targetList,
+								CMD_SELECT, 0);
+
+		result = contain_windowref(qualNew, NULL);
+		pfree(qualNew);
+	}
+
+	return result;
+}
+
+
+/*
+ * is a particular qual safe to push down under set operation?
+ * if the qual contains references to windowref node, its not 
+ * safe to push it down.
+ */
+static bool
+qual_is_pushdown_safe_set_operation(RangeTblEntry *rte, Index rti, Node *qual)
+{
+
+	Query *subquery = rte->subquery;
+	Assert(subquery);
+
+	SetOperationStmt *setop = (SetOperationStmt *)subquery->setOperations;
+	Assert(setop);
+
+	/*
+	 * for queries of the form:
+	 *   SELECT * from (SELECT max(i) over () as w from X Union Select 1 as w) as foo where w > 0
+	 * the qual (w > 0) is not push_down_safe since it uses a window ref
+	 *
+	 * we check if this is the case for either left or right set operation inputs.
+	 * The check for window function is only at the top level of the set
+	 * operation inputs. It does not recurse deep inside the set operation
+	 * child for resolving the qual reference for queries of the form:
+	 *  SELECT w FROM ( (SELECT w FROM Y, Z, (SELECT max(i) over () as w from X) AS bar) UNION SELECT 1 AS w) AS foo WHERE w > 0;
+	 *
+	 */
+	RangeTblEntry *rteLeft = rt_fetch(((RangeTblRef *)setop->larg)->rtindex, subquery->rtable);
+	RangeTblEntry *rteRight = rt_fetch(((RangeTblRef *)setop->rarg)->rtindex, subquery->rtable);
+	if (qual_contains_winref(rteLeft->subquery, rte, rti, qual) ||
+		qual_contains_winref(rteRight->subquery, rte, rti, qual))
+	{
+		return false;
+	}
+
+	return true;
+}
+
 /*
  * qual_is_pushdown_safe - is a particular qual safe to push down?
  *
@@ -1562,7 +1627,7 @@ compare_tlist_datatypes(List *tlist, List *colTypes,
  * to multiple evaluation of a volatile function.
  */
 static bool
-qual_is_pushdown_safe(Query *subquery, Index rti, Node *qual,
+qual_is_pushdown_safe(Query *subquery, RangeTblEntry *rte, Index rti, Node *qual,
 					  bool *differentTypes)
 {
 	bool		safe = true;
@@ -1575,11 +1640,15 @@ qual_is_pushdown_safe(Query *subquery, Index rti, Node *qual,
 		return false;
 
 	/*
-	 * It would be unsafe to push down window function calls, but at least for
-	 * the moment we could never see any in a qual anyhow.  (The same applies
-	 * to aggregates, which we check for in pull_var_clause below.)
+	 * (point 2)
+	 * if we try to push quals below set operation, make
+	 * sure that qual is pushable to below set operation children
 	 */
-	Assert(!contain_window_functions(qual));
+	if (NULL != subquery->setOperations &&
+		!qual_is_pushdown_safe_set_operation(rte, rti, qual))
+	{
+		return false;
+	}
 
 	/*
 	 * Examine all Vars used in clause; since it's a restriction clause, all

--- a/src/test/regress/expected/olap_window.out
+++ b/src/test/regress/expected/olap_window.out
@@ -8309,8 +8309,6 @@ i | sum
 6 |   6
 (4 rows)
 
--- Should not push-down predicates referring to window functions in the subquery which is the source for the insertion
-insert into window_preds select k from ( select row_number() over() as k from window_preds union all select row_number() over() as k from window_preds) as t where k = 1;
 -- MPP-19964
 drop table if exists customers_test;
 NOTICE:  table "customers_test" does not exist, skipping

--- a/src/test/regress/expected/olap_window_optimizer.out
+++ b/src/test/regress/expected/olap_window_optimizer.out
@@ -8312,8 +8312,6 @@ select * from (select i, sum(i) over(partition by j) from (select i,j, row_numbe
  6 |   6
 (4 rows)
 
--- Should not push-down predicates referring to window functions in the subquery which is the source for the insertion
-insert into window_preds select k from ( select row_number() over() as k from window_preds union all select row_number() over() as k from window_preds) as t where k = 1;
 -- MPP-19964
 drop table if exists customers_test;
 NOTICE:  table "customers_test" does not exist, skipping

--- a/src/test/regress/expected/olap_window_seq.out
+++ b/src/test/regress/expected/olap_window_seq.out
@@ -8324,3 +8324,152 @@ SELECT bar.*, count(*) OVER() AS e FROM foo, bar where foo.b = bar.d;
 
 reset optimizer_segments;
 drop table foo, bar;
+-- test predicate push down in subqueries for quals containing windowref nodes
+-- start_ignore
+drop table if exists window_preds;
+NOTICE:  table "window_preds" does not exist, skipping
+create table window_preds(i int, j int, k int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into window_preds values(1,2,3);
+insert into window_preds values(2,3,4);
+insert into window_preds values(3,4,5);
+insert into window_preds values(4,5,6);
+insert into window_preds values(5,6,7);
+insert into window_preds values(6,7,8);
+-- end_ignore
+-- for planner qual k = 1 should not be pushed down in the subquery as it has window refs at top level of subquery. orca is able to push down the predicate to appropriate node
+explain select k from ( select row_number() over()+2 as k from window_preds union all select row_number() over()+2 as k from window_preds) as t where k = 3;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Subquery Scan t  (cost=0.00..2.11 rows=1 width=8)
+   Filter: k = 3
+   ->  Append  (cost=0.00..2.08 rows=2 width=0)
+         ->  Subquery Scan "*SELECT* 1"  (cost=0.00..1.04 rows=1 width=0)
+               ->  Window  (cost=0.00..1.03 rows=1 width=0)
+                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=0)
+                           ->  Seq Scan on window_preds  (cost=0.00..1.01 rows=1 width=0)
+         ->  Subquery Scan "*SELECT* 2"  (cost=0.00..1.04 rows=1 width=0)
+               ->  Window  (cost=0.00..1.03 rows=1 width=0)
+                     ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1.03 rows=1 width=0)
+                           ->  Seq Scan on window_preds  (cost=0.00..1.01 rows=1 width=0)
+ Settings:  gp_enable_sequential_window_plans=on
+ Optimizer status: legacy query optimizer
+(13 rows)
+
+select k from ( select row_number() over()+2 as k from window_preds union all select row_number() over()+2 as k from window_preds) as t where k = 3;
+ k 
+---
+ 3
+ 3
+(2 rows)
+
+explain insert into window_preds select k from ( select row_number() over()+2 as k from window_preds union all select row_number() over()+2 as k from window_preds) as t where k = 3;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Insert (slice0; segments: 3)  (rows=1 width=8)
+   ->  Redistribute Motion 1:3  (slice3; segments: 1)  (cost=0.00..2.11 rows=1 width=8)
+         Hash Key: i
+         ->  Subquery Scan t  (cost=0.00..2.11 rows=1 width=8)
+               Filter: k = 3
+               ->  Append  (cost=0.00..2.08 rows=2 width=0)
+                     ->  Subquery Scan "*SELECT* 1"  (cost=0.00..1.04 rows=1 width=0)
+                           ->  Window  (cost=0.00..1.03 rows=1 width=0)
+                                 ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=0)
+                                       ->  Seq Scan on window_preds  (cost=0.00..1.01 rows=1 width=0)
+                     ->  Subquery Scan "*SELECT* 2"  (cost=0.00..1.04 rows=1 width=0)
+                           ->  Window  (cost=0.00..1.03 rows=1 width=0)
+                                 ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1.03 rows=1 width=0)
+                                       ->  Seq Scan on window_preds  (cost=0.00..1.01 rows=1 width=0)
+ Settings:  gp_enable_sequential_window_plans=on
+ Optimizer status: legacy query optimizer
+(16 rows)
+
+insert into window_preds select k from ( select row_number() over()+2 as k from window_preds union all select row_number() over()+2 as k from window_preds) as t where k = 3;
+explain SELECT t.k FROM window_preds p1, window_preds p2, (SELECT ROW_NUMBER() OVER() AS k FROM window_preds union all SELECT ROW_NUMBER() OVER() AS k FROM window_preds) AS t WHERE t.k = 1 limit 1;
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=2.06..2.72 rows=1 width=8)
+   ->  Nested Loop  (cost=2.06..4.25 rows=4 width=8)
+         ->  Nested Loop  (cost=1.03..3.16 rows=4 width=8)
+               ->  Subquery Scan t  (cost=0.00..2.10 rows=1 width=8)
+                     Filter: k = 1
+                     ->  Append  (cost=0.00..2.08 rows=2 width=0)
+                           ->  Subquery Scan "*SELECT* 1"  (cost=0.00..1.04 rows=1 width=0)
+                                 ->  Window  (cost=0.00..1.03 rows=1 width=0)
+                                       ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=0)
+                                             ->  Seq Scan on window_preds  (cost=0.00..1.01 rows=1 width=0)
+                           ->  Subquery Scan "*SELECT* 2"  (cost=0.00..1.04 rows=1 width=0)
+                                 ->  Window  (cost=0.00..1.03 rows=1 width=0)
+                                       ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1.03 rows=1 width=0)
+                                             ->  Seq Scan on window_preds  (cost=0.00..1.01 rows=1 width=0)
+               ->  Materialize  (cost=1.03..1.04 rows=1 width=0)
+                     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1.03 rows=1 width=0)
+                           ->  Seq Scan on window_preds p1  (cost=0.00..1.01 rows=1 width=0)
+         ->  Materialize  (cost=1.03..1.04 rows=1 width=0)
+               ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1.03 rows=1 width=0)
+                     ->  Seq Scan on window_preds p2  (cost=0.00..1.01 rows=1 width=0)
+ Settings:  gp_enable_sequential_window_plans=on
+ Optimizer status: legacy query optimizer
+(22 rows)
+
+SELECT t.k FROM window_preds p1, window_preds p2, (SELECT ROW_NUMBER() OVER() AS k FROM window_preds union all SELECT ROW_NUMBER() OVER() AS k FROM window_preds) AS t WHERE t.k = 1 limit 1;
+ k 
+---
+ 1
+(1 row)
+
+-- qual k = 1 should be pushed down
+explain select k from ( select k from (select row_number() over() as k from window_preds) f union all select 1::bigint as k from window_preds) as t where k = 1;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..2.07 rows=2 width=4)
+   ->  Append  (cost=0.00..2.07 rows=1 width=4)
+         ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=0.00..1.05 rows=1 width=8)
+               Hash Key: "*SELECT* 1".k
+               ->  Subquery Scan f  (cost=0.00..1.04 rows=1 width=8)
+                     Filter: k = 1
+                     ->  Window  (cost=0.00..1.03 rows=1 width=0)
+                           ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=0)
+                                 ->  Seq Scan on window_preds  (cost=0.00..1.01 rows=1 width=0)
+         ->  Seq Scan on window_preds  (cost=0.00..1.01 rows=1 width=0)
+ Settings:  gp_enable_sequential_window_plans=on
+ Optimizer status: legacy query optimizer
+(12 rows)
+
+select k from ( select k from (select row_number() over() as k from window_preds) f union all select 1::bigint as k from window_preds) as t where k = 1;
+ k 
+---
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+(9 rows)
+
+explain insert into window_preds select k from ( select k from (select row_number() over() as k from window_preds) f union all select 1::bigint as k from window_preds) as t where k = 1;
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Insert (slice0; segments: 3)  (rows=1 width=8)
+   ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..2.10 rows=1 width=8)
+         Hash Key: i
+         ->  Subquery Scan t  (cost=0.00..2.10 rows=1 width=8)
+               ->  Append  (cost=0.00..2.07 rows=1 width=4)
+                     ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=0.00..1.05 rows=1 width=8)
+                           Hash Key: "*SELECT* 1".k
+                           ->  Subquery Scan f  (cost=0.00..1.04 rows=1 width=8)
+                                 Filter: k = 1
+                                 ->  Window  (cost=0.00..1.03 rows=1 width=0)
+                                       ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=0)
+                                             ->  Seq Scan on window_preds  (cost=0.00..1.01 rows=1 width=0)
+                     ->  Seq Scan on window_preds  (cost=0.00..1.01 rows=1 width=0)
+ Settings:  gp_enable_sequential_window_plans=on
+ Optimizer status: legacy query optimizer
+(15 rows)
+
+insert into window_preds select k from ( select k from (select row_number() over() as k from window_preds) f union all select 1::bigint as k from window_preds) as t where k = 1;
+-- End of Test

--- a/src/test/regress/expected/olap_window_seq_optimizer.out
+++ b/src/test/regress/expected/olap_window_seq_optimizer.out
@@ -8337,3 +8337,161 @@ SELECT bar.*, count(*) OVER() AS e FROM foo, bar where foo.b = bar.d;
 
 reset optimizer_segments;
 drop table foo, bar;
+-- test predicate push down in subqueries for quals containing windowref nodes
+-- start_ignore
+drop table if exists window_preds;
+NOTICE:  table "window_preds" does not exist, skipping
+create table window_preds(i int, j int, k int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into window_preds values(1,2,3);
+insert into window_preds values(2,3,4);
+insert into window_preds values(3,4,5);
+insert into window_preds values(4,5,6);
+insert into window_preds values(5,6,7);
+insert into window_preds values(6,7,8);
+-- end_ignore
+-- for planner qual k = 1 should not be pushed down in the subquery as it has window refs at top level of subquery. orca is able to push down the predicate to appropriate node
+explain select k from ( select row_number() over()+2 as k from window_preds union all select row_number() over()+2 as k from window_preds) as t where k = 3;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Append  (cost=0.00..862.00 rows=1 width=8)
+   ->  Result  (cost=0.00..431.00 rows=1 width=8)
+         Filter: k = 3
+         ->  Result  (cost=0.00..431.00 rows=1 width=8)
+               ->  Window  (cost=0.00..431.00 rows=1 width=8)
+                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+                           ->  Table Scan on window_preds  (cost=0.00..431.00 rows=1 width=1)
+   ->  Result  (cost=0.00..431.00 rows=1 width=8)
+         Filter: k = 3
+         ->  Result  (cost=0.00..431.00 rows=1 width=8)
+               ->  Window  (cost=0.00..431.00 rows=1 width=8)
+                     ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+                           ->  Table Scan on window_preds  (cost=0.00..431.00 rows=1 width=1)
+ Settings:  gp_enable_sequential_window_plans=on; optimizer=on
+ Optimizer status: PQO version 2.55.12
+(15 rows)
+
+select k from ( select row_number() over()+2 as k from window_preds union all select row_number() over()+2 as k from window_preds) as t where k = 3;
+ k 
+---
+ 3
+ 3
+(2 rows)
+
+explain insert into window_preds select k from ( select row_number() over()+2 as k from window_preds union all select row_number() over()+2 as k from window_preds) as t where k = 3;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Insert  (cost=0.00..862.04 rows=1 width=4)
+   ->  Redistribute Motion 1:3  (slice3)  (cost=0.00..862.00 rows=2 width=16)
+         Hash Key: i
+         ->  Result  (cost=0.00..862.00 rows=1 width=16)
+               ->  Append  (cost=0.00..862.00 rows=1 width=8)
+                     ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                           Filter: k = 3
+                           ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                 ->  Window  (cost=0.00..431.00 rows=1 width=8)
+                                       ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+                                             ->  Table Scan on window_preds  (cost=0.00..431.00 rows=1 width=1)
+                     ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                           Filter: k = 3
+                           ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                 ->  Window  (cost=0.00..431.00 rows=1 width=8)
+                                       ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+                                             ->  Table Scan on window_preds  (cost=0.00..431.00 rows=1 width=1)
+ Settings:  gp_enable_sequential_window_plans=on; optimizer=on
+ Optimizer status: PQO version 2.55.12
+(19 rows)
+
+insert into window_preds select k from ( select row_number() over()+2 as k from window_preds union all select row_number() over()+2 as k from window_preds) as t where k = 3;
+explain SELECT t.k FROM window_preds p1, window_preds p2, (SELECT ROW_NUMBER() OVER() AS k FROM window_preds union all SELECT ROW_NUMBER() OVER() AS k FROM window_preds) AS t WHERE t.k = 1 limit 1;
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Limit  (cost=0.00..1357132839.11 rows=1 width=8)
+   ->  Nested Loop  (cost=0.00..1357132839.11 rows=1 width=8)
+         Join Filter: true
+         ->  Append  (cost=0.00..862.00 rows=1 width=8)
+               ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                     Filter: k = 1
+                     ->  Window  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+                                 ->  Table Scan on window_preds  (cost=0.00..431.00 rows=1 width=1)
+               ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                     Filter: k = 1
+                     ->  Window  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+                                 ->  Table Scan on window_preds  (cost=0.00..431.00 rows=1 width=1)
+         ->  Materialize  (cost=0.00..1324032.04 rows=1 width=1)
+               ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324032.04 rows=1 width=1)
+                     ->  Nested Loop  (cost=0.00..1324032.04 rows=1 width=1)
+                           Join Filter: true
+                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+                                 ->  Table Scan on window_preds  (cost=0.00..431.00 rows=1 width=1)
+                           ->  Table Scan on window_preds  (cost=0.00..431.00 rows=1 width=1)
+ Settings:  gp_enable_sequential_window_plans=on; optimizer=on
+ Optimizer status: PQO version 2.55.12
+(23 rows)
+
+SELECT t.k FROM window_preds p1, window_preds p2, (SELECT ROW_NUMBER() OVER() AS k FROM window_preds union all SELECT ROW_NUMBER() OVER() AS k FROM window_preds) AS t WHERE t.k = 1 limit 1;
+ k 
+---
+ 1
+(1 row)
+
+-- qual k = 1 should be pushed down
+explain select k from ( select k from (select row_number() over() as k from window_preds) f union all select 1::bigint as k from window_preds) as t where k = 1;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Append  (cost=0.00..862.00 rows=1 width=8)
+   ->  Result  (cost=0.00..431.00 rows=1 width=8)
+         Filter: k = 1
+         ->  Window  (cost=0.00..431.00 rows=1 width=8)
+               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+                     ->  Table Scan on window_preds  (cost=0.00..431.00 rows=1 width=1)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+         ->  Result  (cost=0.00..431.00 rows=1 width=8)
+               Filter: k = 1
+               ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                     ->  Table Scan on window_preds  (cost=0.00..431.00 rows=1 width=1)
+ Settings:  gp_enable_sequential_window_plans=on; optimizer=on
+ Optimizer status: PQO version 2.55.12
+(13 rows)
+
+select k from ( select k from (select row_number() over() as k from window_preds) f union all select 1::bigint as k from window_preds) as t where k = 1;
+ k 
+---
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+(9 rows)
+
+explain insert into window_preds select k from ( select k from (select row_number() over() as k from window_preds) f union all select 1::bigint as k from window_preds) as t where k = 1;
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Insert  (cost=0.00..862.04 rows=1 width=4)
+   ->  Redistribute Motion 1:3  (slice3)  (cost=0.00..862.00 rows=2 width=16)
+         Hash Key: i
+         ->  Result  (cost=0.00..862.00 rows=1 width=16)
+               ->  Append  (cost=0.00..862.00 rows=1 width=8)
+                     ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                           Filter: k = 1
+                           ->  Window  (cost=0.00..431.00 rows=1 width=8)
+                                 ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+                                       ->  Table Scan on window_preds  (cost=0.00..431.00 rows=1 width=1)
+                     ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                 Filter: k = 1
+                                 ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                       ->  Table Scan on window_preds  (cost=0.00..431.00 rows=1 width=1)
+ Settings:  gp_enable_sequential_window_plans=on; optimizer=on
+ Optimizer status: PQO version 2.55.12
+(17 rows)
+
+insert into window_preds select k from ( select k from (select row_number() over() as k from window_preds) f union all select 1::bigint as k from window_preds) as t where k = 1;
+-- End of Test

--- a/src/test/regress/sql/olap_window.sql
+++ b/src/test/regress/sql/olap_window.sql
@@ -1605,9 +1605,6 @@ select * from (select i,j,k, sum(i) over(partition by i,j), row_number() over(pa
 select * from (select i,j,k, sum(i) over(partition by i,j), row_number() over(partition by i,j), rank() over(partition by i,j order by i) from window_preds) as foo where i+j>2 order by sum;
 select * from (select i, sum(i) over(partition by j) from (select i,j, row_number() over(partition by i) from window_preds) as bar) as foo where i>2 order by sum;
 
--- Should not push-down predicates referring to window functions in the subquery which is the source for the insertion
-insert into window_preds select k from ( select row_number() over() as k from window_preds union all select row_number() over() as k from window_preds) as t where k = 1;
-
 -- MPP-19964
 drop table if exists customers_test;
 create table customers_test(name text, device_model text, device_id integer, ppp numeric) distributed by (device_id);

--- a/src/test/regress/sql/olap_window_seq.sql
+++ b/src/test/regress/sql/olap_window_seq.sql
@@ -1665,3 +1665,31 @@ SELECT bar.*, count(*) OVER() AS e FROM foo, bar where foo.b = bar.d;
 
 reset optimizer_segments;
 drop table foo, bar;
+
+-- test predicate push down in subqueries for quals containing windowref nodes
+-- start_ignore
+drop table if exists window_preds;
+create table window_preds(i int, j int, k int);
+insert into window_preds values(1,2,3);
+insert into window_preds values(2,3,4);
+insert into window_preds values(3,4,5);
+insert into window_preds values(4,5,6);
+insert into window_preds values(5,6,7);
+insert into window_preds values(6,7,8);
+-- end_ignore
+
+-- for planner qual k = 1 should not be pushed down in the subquery as it has window refs at top level of subquery. orca is able to push down the predicate to appropriate node
+explain select k from ( select row_number() over()+2 as k from window_preds union all select row_number() over()+2 as k from window_preds) as t where k = 3;
+select k from ( select row_number() over()+2 as k from window_preds union all select row_number() over()+2 as k from window_preds) as t where k = 3;
+explain insert into window_preds select k from ( select row_number() over()+2 as k from window_preds union all select row_number() over()+2 as k from window_preds) as t where k = 3;
+insert into window_preds select k from ( select row_number() over()+2 as k from window_preds union all select row_number() over()+2 as k from window_preds) as t where k = 3;
+explain SELECT t.k FROM window_preds p1, window_preds p2, (SELECT ROW_NUMBER() OVER() AS k FROM window_preds union all SELECT ROW_NUMBER() OVER() AS k FROM window_preds) AS t WHERE t.k = 1 limit 1;
+SELECT t.k FROM window_preds p1, window_preds p2, (SELECT ROW_NUMBER() OVER() AS k FROM window_preds union all SELECT ROW_NUMBER() OVER() AS k FROM window_preds) AS t WHERE t.k = 1 limit 1;
+
+-- qual k = 1 should be pushed down
+explain select k from ( select k from (select row_number() over() as k from window_preds) f union all select 1::bigint as k from window_preds) as t where k = 1;
+select k from ( select k from (select row_number() over() as k from window_preds) f union all select 1::bigint as k from window_preds) as t where k = 1;
+explain insert into window_preds select k from ( select k from (select row_number() over() as k from window_preds) f union all select 1::bigint as k from window_preds) as t where k = 1;
+insert into window_preds select k from ( select k from (select row_number() over() as k from window_preds) f union all select 1::bigint as k from window_preds) as t where k = 1;
+
+-- End of Test


### PR DESCRIPTION
As part of the commit 7cc12d9, the check for
`qual_is_pushdown_safe_set_operation()` was removed and a check was
added in `subquery_is_pushdown_safe()` to bail out from pushing down
qual if the subquery->hasFuncs was true. However, the check was
too restrictive and prohibited pushdown of those quals which do not
contain any window reference resulting in performance regression.

This commit performs 2 things:
1. Revert the commit 7cc12d9
2. Fix `qual_is_pushdown_safe_set_operation` to correctly resolve the
qual vars and identify if there are any window references in the top
level of the set operation's left or right subqueries.  Before commit
b8002a9, instead of starting with rte of the level where the qual is
attached we started scanning the rte of the subqueries of the left and
right args of setop to identify the qual. However, because of this the
varno didn't match to the corresponding RTE due to which the quals
couldn't be resolved to winref and were incorrectly pushed down. This
caused the planner to return an error during execution.

Adding relevant tests.

Signed-off-by: Ekta Khanna <ekhanna@pivotal.io>