### PR TITLE
Avoid FTS hang in case of ftsPoll() timeout and avoid undesirable mirror promotion

### DIFF
--- a/gpMgmt/bin/gppylib/commands/pg.py
+++ b/gpMgmt/bin/gppylib/commands/pg.py
@@ -289,6 +289,8 @@ class PgBaseBackup(Command):
             cmd_tokens.append('./gpperfmon/data')
             cmd_tokens.append('-E')
             cmd_tokens.append('./gpperfmon/logs')
+            cmd_tokens.append('-E')
+            cmd_tokens.append('./promote')
         else:
             for path in excludePaths:
                 cmd_tokens.append('-E')

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -7609,6 +7609,8 @@ StartupXLOG(void)
 		Assert(ControlFile->state == DB_IN_STANDBY_MODE);
 		StandbyMode = false;
 
+		elog(LOG, "updating pg_control to state DB_IN_STANDBY_PROMOTED");
+
 		/* Transition to promoted mode */
 		ControlFile->state = DB_IN_STANDBY_PROMOTED;
 		ControlFile->time = (pg_time_t) time(NULL);
@@ -7741,7 +7743,10 @@ StartupXLOG(void)
 	 * This could happen if the promoted standby goes through a restart.
 	 */
 	if (ControlFile->state == DB_IN_STANDBY_PROMOTED)
+	{
+		elog(LOG, "pg_control state is DB_IN_STANDBY_PROMOTED hence renaming recovery file");
 		renameRecoveryFile();
+	}
 
 	/*
 	 * Prepare to write WAL starting at EndOfLog position, and init xlog

--- a/src/backend/fts/ftsmessagehandler.c
+++ b/src/backend/fts/ftsmessagehandler.c
@@ -270,6 +270,15 @@ HandleFtsWalRepProbe(void)
 			/* Syncrep is enabled now, so respond accordingly. */
 			response.IsSyncRepEnabled = true;
 		}
+
+		/*
+		 * Precautionary action: Unlink PROMOTE_SIGNAL_FILE if incase it
+		 * exists. This is to avoid driving to any incorrect conclusions when
+		 * this segment starts acting as mirror or gets copied over using
+		 * pg_basebackup.
+		 */
+		if (CheckPromoteSignal(true))
+			elog(LOG, "found and hence deleted '%s' file", PROMOTE_SIGNAL_FILE);
 	}
 
 	/*

--- a/src/backend/fts/ftsprobe.c
+++ b/src/backend/fts/ftsprobe.c
@@ -326,7 +326,6 @@ static void
 ftsCheckTimeout(fts_segment_info *ftsInfo, pg_time_t now)
 {
 	if (!IsFtsMessageStateSuccess(ftsInfo->state) &&
-		ftsInfo->retry_count < gp_fts_probe_retries &&
 		(int) (now - ftsInfo->startTime) > gp_fts_probe_timeout)
 	{
 		elog(LOG,
@@ -380,7 +379,6 @@ ftsPoll(fts_context *context)
 	{
 		elogif(gp_log_fts == GPVARS_VERBOSITY_DEBUG, LOG,
 			   "FTS: ftsPoll() timed out, nfds %d", nfds);
-		return;
 	}
 
 	elogif(gp_log_fts == GPVARS_VERBOSITY_DEBUG, LOG,
@@ -393,6 +391,11 @@ ftsPoll(fts_context *context)
 	for (i = 0; i < context->num_pairs; i++)
 	{
 		fts_segment_info *ftsInfo = &context->perSegInfos[i];
+
+		/* skip segments not considered for polling */
+		if (ftsInfo->fd_index == -1)
+			continue;
+
 		if (ftsInfo->poll_events & (POLLIN|POLLOUT))
 		{
 			Assert(PollFds[ftsInfo->fd_index].fd == PQsocket(ftsInfo->conn));
@@ -433,10 +436,7 @@ ftsPoll(fts_context *context)
 					 ftsInfo->retry_count, ftsInfo->conn->status,
 					 ftsInfo->conn->asyncStatus);
 			}
-		}
-		else
-		{
-			ftsInfo->poll_revents = 0;
+			/* If poll timed-out above, check timeout */
 			ftsCheckTimeout(ftsInfo, now);
 		}
 	}
@@ -529,7 +529,7 @@ probeRecordResponse(fts_segment_info *ftsInfo, PGresult *result)
 	ftsInfo->result.isMirrorAlive = *isMirrorAlive;
 
 	int *isInSync = (int *) PQgetvalue(result, 0,
-									   Anum_fts_message_response_is_in_sync);
+								   Anum_fts_message_response_is_in_sync);
 	Assert (isInSync);
 	ftsInfo->result.isInSync = *isInSync;
 

--- a/src/backend/fts/ftsprobe.c
+++ b/src/backend/fts/ftsprobe.c
@@ -319,8 +319,8 @@ ftsConnect(fts_context *context)
 /*
  * Timeout is said to have occurred if greater than gp_fts_probe_timeout
  * seconds have elapsed since connection start and a response is not received.
- * Segments for which a response is received already or that have failed with
- * all retries exhausted are exempted from timeout evaluation.
+ * Segments for which a response is received already are exempted from timeout
+ * evaluation.
  */
 static void
 ftsCheckTimeout(fts_segment_info *ftsInfo, pg_time_t now)
@@ -392,10 +392,6 @@ ftsPoll(fts_context *context)
 	{
 		fts_segment_info *ftsInfo = &context->perSegInfos[i];
 
-		/* skip segments not considered for polling */
-		if (ftsInfo->fd_index == -1)
-			continue;
-
 		if (ftsInfo->poll_events & (POLLIN|POLLOUT))
 		{
 			Assert(PollFds[ftsInfo->fd_index].fd == PQsocket(ftsInfo->conn));
@@ -408,7 +404,6 @@ ftsPoll(fts_context *context)
 			if (ftsInfo->poll_revents & ftsInfo->poll_events)
 			{
 				ftsInfo->poll_events = 0;
-				ftsCheckTimeout(ftsInfo, now);
 			}
 			else if (ftsInfo->poll_revents & (POLLHUP | POLLERR))
 			{

--- a/src/backend/fts/test/ftsmessagehandler_test.c
+++ b/src/backend/fts/test/ftsmessagehandler_test.c
@@ -83,6 +83,9 @@ test_HandleFtsWalRepProbePrimary(void **state)
 
 	will_be_called(SetSyncStandbysDefined);
 
+	expect_value(CheckPromoteSignal, do_unlink, true);
+	will_be_called(CheckPromoteSignal);
+
 	/* SyncRep should be enabled as soon as we found mirror is up. */
 	mockresponse.IsSyncRepEnabled = true;
 	expectSendFtsResponse(FTS_MSG_PROBE, &mockresponse);

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -433,6 +433,7 @@ FaultInjector_InjectFaultNameIfSet(
 			for (ii=0; ii < cnt; ii++)
 			{
 				pg_usleep(1000000L); // sleep for 1 sec (1 sec * 3600 = 1 hour)
+				CHECK_FOR_INTERRUPTS();
 			}
 			break;
 		case FaultInjectorTypeDataCorruption:

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -3476,7 +3476,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_fts_probe_retries", PGC_SIGHUP, GP_ARRAY_TUNING,
 			gettext_noop("Number of retries for FTS to complete probing a segment."),
 			gettext_noop("Used by the fts-probe process."),
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_UNIT_S
 		},
 		&gp_fts_probe_retries,
 		5, 0, 100, NULL, NULL

--- a/src/test/isolation2/expected/segwalrep/commit_blocking.out
+++ b/src/test/isolation2/expected/segwalrep/commit_blocking.out
@@ -5,9 +5,7 @@ create language plpythonu;
 CREATE
 -- end_ignore
 
-create or replace function pg_ctl(datadir text, command text, port int, contentid int) returns text as $$ import subprocess 
-cmd = 'pg_ctl -D %s ' % datadir if command in ('stop', 'restart'): cmd = cmd + '-w -m immediate %s' % command elif command == 'start': opts = '-p %d -\-gp_dbid=0 -\-silent-mode=true -i -\-gp_contentid=%d -\-gp_num_contents_in_cluster=3' % (port, contentid) cmd = cmd + '-o "%s" start' % opts else: return 'Invalid command input' 
-return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '') $$ language plpythonu;
+create or replace function pg_ctl(datadir text, command text, port int, contentid int, dbid int) returns text as $$ import subprocess cmd = 'pg_ctl -D %s ' % datadir if command in ('stop', 'restart'): cmd = cmd + '-w -m immediate %s' % command elif command == 'start': opts = '-p %d -\-gp_dbid=%d -\-silent-mode=true -i -\-gp_contentid=%d -\-gp_num_contents_in_cluster=3' % (port, dbid, contentid) cmd = cmd + '-o "%s" start' % opts else: return 'Invalid command input' return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '') $$ language plpythonu;
 CREATE
 
 -- make sure we are in-sync for the primary we will be testing with
@@ -58,7 +56,7 @@ t
 (1 row)
 
 -- stop a mirror and show commit on dbid 2 will block
--1U: select pg_ctl((select datadir from gp_segment_configuration c where c.role='m' and c.content=0), 'stop', NULL, NULL);
+-1U: select pg_ctl((select datadir from gp_segment_configuration c where c.role='m' and c.content=0), 'stop', NULL, NULL, NULL);
 pg_ctl                                              
 ----------------------------------------------------
 waiting for server to shut down done
@@ -68,7 +66,7 @@ server stopped
 0U&: insert into segwalrep_commit_blocking values (1);  <waiting ...>
 
 -- restart primary dbid 2
--1U: select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=0), 'restart', NULL, NULL);
+-1U: select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=0), 'restart', NULL, NULL, NULL);
 pg_ctl                                                                                              
 ----------------------------------------------------------------------------------------------------
 waiting for server to shut down done
@@ -104,7 +102,7 @@ INSERT 1
 INSERT 1
 
 -- bring the mirror back up
--1U: select pg_ctl((select datadir from gp_segment_configuration c where c.role='m' and c.content=0), 'start', (select port from gp_segment_configuration where content = 0 and preferred_role = 'm'), 0);
+-1U: select pg_ctl((select datadir from gp_segment_configuration c where c.role='m' and c.content=0), 'start', (select port from gp_segment_configuration where content = 0 and preferred_role = 'm'), 0, (select dbid from gp_segment_configuration c where c.role='m' and c.content=0));
 pg_ctl          
 ----------------
 server starting

--- a/src/test/isolation2/expected/segwalrep/fts_unblock_primary.out
+++ b/src/test/isolation2/expected/segwalrep/fts_unblock_primary.out
@@ -9,9 +9,7 @@ create language plpythonu;
 CREATE
 -- end_ignore
 
-create or replace function pg_ctl(datadir text, command text, port int, contentid int) returns text as $$ import subprocess 
-cmd = 'pg_ctl -D %s ' % datadir if command in ('stop', 'restart'): cmd = cmd + '-w -m immediate %s' % command elif command == 'start': opts = '-p %d -\-gp_dbid=0 -\-silent-mode=true -i -\-gp_contentid=%d -\-gp_num_contents_in_cluster=3' % (port, contentid) cmd = cmd + '-o "%s" start' % opts else: return 'Invalid command input' 
-return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '') $$ language plpythonu;
+create or replace function pg_ctl(datadir text, command text, port int, contentid int, dbid int) returns text as $$ import subprocess cmd = 'pg_ctl -D %s ' % datadir if command in ('stop', 'restart'): cmd = cmd + '-w -m immediate %s' % command elif command == 'start': opts = '-p %d -\-gp_dbid=%d -\-silent-mode=true -i -\-gp_contentid=%d -\-gp_num_contents_in_cluster=3' % (port, dbid, contentid) cmd = cmd + '-o "%s" start' % opts else: return 'Invalid command input' return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '') $$ language plpythonu;
 CREATE
 
 -- make sure we are in-sync for the primary we will be testing with
@@ -68,7 +66,7 @@ t
 (1 row)
 
 -- stop a mirror
--1U: select pg_ctl((select datadir from gp_segment_configuration c where c.role='m' and c.content=2), 'stop', NULL, NULL);
+-1U: select pg_ctl((select datadir from gp_segment_configuration c where c.role='m' and c.content=2), 'stop', NULL, NULL, NULL);
 pg_ctl                                              
 ----------------------------------------------------
 waiting for server to shut down done
@@ -149,7 +147,7 @@ synchronous_standby_names
 (1 row)
 
 -- bring the mirror back up and see primary s/u and mirror s/u
--1U: select pg_ctl((select datadir from gp_segment_configuration c where c.role='m' and c.content=2), 'start', (select port from gp_segment_configuration where content = 2 and preferred_role = 'm'), 2);
+-1U: select pg_ctl((select datadir from gp_segment_configuration c where c.role='m' and c.content=2), 'start', (select port from gp_segment_configuration where content = 2 and preferred_role = 'm'), 2, (select dbid from gp_segment_configuration c where c.role='m' and c.content=2));
 pg_ctl          
 ----------------
 server starting

--- a/src/test/isolation2/expected/segwalrep/mirror_promotion.out
+++ b/src/test/isolation2/expected/segwalrep/mirror_promotion.out
@@ -1,15 +1,30 @@
+-- Tests mirror promotion triggered by FTS in 2 different scenarios.
+--
+-- 1st: Shut-down of primary and hence unavailability of primary
+-- leading to mirror promotion. In this case the connection between
+-- primary and mirror is disconnected prior to promotion and
+-- walreceiver doesn't exist.
+--
+-- 2nd: Primary is alive but using fault injector simulated to not
+-- respond to fts. This helps to validate fts time-out logic for
+-- probes. Plus also mirror promotion triggered while connection
+-- between primary and mirror is still alive and hence walreceiver
+-- also exist during promotion.
+
 -- start_ignore
 create language plpythonu;
-CREATE
+ERROR:  language "plpythonu" already exists
 -- end_ignore
 
-create or replace function pg_ctl(datadir text, command text, port int, contentid int) returns text as $$ import subprocess 
-cmd = 'pg_ctl -D %s ' % datadir if command in ('stop', 'restart'): cmd = cmd + '-w -m immediate %s' % command elif command == 'start': opts = '-p %d -\-gp_dbid=0 -\-silent-mode=true -i -\-gp_contentid=%d -\-gp_num_contents_in_cluster=3' % (port, contentid) cmd = cmd + '-o "%s" start' % opts else: return 'Invalid command input' 
+create extension if not exists gp_inject_fault;
+CREATE
+create or replace function pg_ctl(datadir text, command text) returns text as $$ import subprocess 
+cmd = 'pg_ctl -D %s ' % datadir if command in ('stop'): cmd = cmd + '-w -m immediate %s' % command else: return 'Invalid command input' 
 return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '') $$ language plpythonu;
 CREATE
 
 -- stop a primary in order to trigger a mirror promotion
-select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=0), 'stop', NULL, NULL);
+select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=0), 'stop');
 pg_ctl                                              
 ----------------------------------------------------
 waiting for server to shut down done
@@ -48,7 +63,11 @@ content|preferred_role|role|status|mode
 -- end_ignore
 (exited with code 0)
 
--- expect: to see the new rebuilt mirror up and in sync
+-- loop while segments come in sync
+do $$ begin /* in func */ for i in 1..120 loop /* in func */ if (select mode = 's' from gp_segment_configuration where content = 0 limit 1) then /* in func */ return; /* in func */ end if; /* in func */ perform gp_request_fts_probe_scan(); /* in func */ end loop; /* in func */ end; /* in func */ $$;
+DO
+
+-- expect: to see roles flipped and in sync
 select content, preferred_role, role, status, mode from gp_segment_configuration where content = 0;
 content|preferred_role|role|status|mode
 -------+--------------+----+------+----
@@ -56,16 +75,44 @@ content|preferred_role|role|status|mode
 0      |p             |m   |u     |s   
 (2 rows)
 
--- now, let's stop the new primary, so that we can restore original role
-select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=0), 'stop', NULL, NULL);
-pg_ctl                                              
-----------------------------------------------------
-waiting for server to shut down done
-server stopped
+-- set GUCs to speed-up the test
+!\retcode gpconfig -c gp_fts_probe_retries -v 2 --masteronly;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+!\retcode gpconfig -c gp_fts_probe_timeout -v 5 --masteronly;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -u;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
 
+-- start_ignore
+select dbid from gp_segment_configuration where content = 0 and role = 'p';
+dbid
+----
+5   
+(1 row)
+-- end_ignore
+
+select gp_inject_fault('fts_handle_message', 'infinite_loop', '', '', '', -1, 0, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+gp_inject_fault
+---------------
+t              
 (1 row)
 
 -- trigger failover
+select gp_request_fts_probe_scan();
+gp_request_fts_probe_scan
+-------------------------
+t                        
+(1 row)
+
+-- trigger one more probe right away which mostly results in sending
+-- promotion request again to mirror, while its going through
+-- promotion, which is nice condition to test as well.
 select gp_request_fts_probe_scan();
 gp_request_fts_probe_scan
 -------------------------
@@ -80,18 +127,36 @@ content|preferred_role|role|status|mode
 0      |p             |p   |u     |n   
 (2 rows)
 
--- wait for content 0 (earlier mirror, now primary) to finish the promotion
+-- set GUCs to speed-up the test
+!\retcode gpconfig -r gp_fts_probe_retries --masteronly;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+!\retcode gpconfig -r gp_fts_probe_timeout --masteronly;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -u;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+
+-- -- wait for content 0 (earlier mirror, now primary) to finish the promotion
 0U: select 1;
 ?column?
 --------
 1       
 (1 row)
 
--- now, let's fully recover the mirror
+-- -- now, let's fully recover the mirror
 !\retcode gprecoverseg -aF;
 -- start_ignore
 -- end_ignore
 (exited with code 0)
+
+-- loop while segments come in sync
+do $$ begin /* in func */ for i in 1..120 loop /* in func */ if (select mode = 's' from gp_segment_configuration where content = 0 limit 1) then /* in func */ return; /* in func */ end if; /* in func */ perform gp_request_fts_probe_scan(); /* in func */ end loop; /* in func */ end; /* in func */ $$;
+DO
 
 -- now, the content 0 primary and mirror should be at their preferred role
 -- and up and in-sync

--- a/src/test/isolation2/sql/segwalrep/commit_blocking.sql
+++ b/src/test/isolation2/sql/segwalrep/commit_blocking.sql
@@ -4,19 +4,17 @@
 create language plpythonu;
 -- end_ignore
 
-create or replace function pg_ctl(datadir text, command text, port int, contentid int)
+create or replace function pg_ctl(datadir text, command text, port int, contentid int, dbid int)
 returns text as $$
     import subprocess
-
     cmd = 'pg_ctl -D %s ' % datadir
     if command in ('stop', 'restart'):
         cmd = cmd + '-w -m immediate %s' % command
     elif command == 'start':
-        opts = '-p %d -\-gp_dbid=0 -\-silent-mode=true -i -\-gp_contentid=%d -\-gp_num_contents_in_cluster=3' % (port, contentid)
+        opts = '-p %d -\-gp_dbid=%d -\-silent-mode=true -i -\-gp_contentid=%d -\-gp_num_contents_in_cluster=3' % (port, dbid, contentid)
         cmd = cmd + '-o "%s" start' % opts
     else:
         return 'Invalid command input'
-
     return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '')
 $$ language plpythonu;
 
@@ -40,11 +38,11 @@ select gp_request_fts_probe_scan();
 select gp_inject_fault('fts_probe', 'status', 1);
 
 -- stop a mirror and show commit on dbid 2 will block
--1U: select pg_ctl((select datadir from gp_segment_configuration c where c.role='m' and c.content=0), 'stop', NULL, NULL);
+-1U: select pg_ctl((select datadir from gp_segment_configuration c where c.role='m' and c.content=0), 'stop', NULL, NULL, NULL);
 0U&: insert into segwalrep_commit_blocking values (1);
 
 -- restart primary dbid 2
--1U: select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=0), 'restart', NULL, NULL);
+-1U: select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=0), 'restart', NULL, NULL, NULL);
 
 -- should show dbid 2 utility mode connection closed because of primary restart
 0U<:
@@ -62,7 +60,7 @@ select gp_inject_fault('fts_probe', 'status', 1);
 4: insert into segwalrep_commit_blocking values (3);
 
 -- bring the mirror back up
--1U: select pg_ctl((select datadir from gp_segment_configuration c where c.role='m' and c.content=0), 'start', (select port from gp_segment_configuration where content = 0 and preferred_role = 'm'), 0);
+-1U: select pg_ctl((select datadir from gp_segment_configuration c where c.role='m' and c.content=0), 'start', (select port from gp_segment_configuration where content = 0 and preferred_role = 'm'), 0, (select dbid from gp_segment_configuration c where c.role='m' and c.content=0));
 
 -- should unblock and commit now that mirror is back up and in-sync
 3<:

--- a/src/test/isolation2/sql/segwalrep/fts_unblock_primary.sql
+++ b/src/test/isolation2/sql/segwalrep/fts_unblock_primary.sql
@@ -21,19 +21,17 @@ $$ language plpgsql;
 create language plpythonu;
 -- end_ignore
 
-create or replace function pg_ctl(datadir text, command text, port int, contentid int)
+create or replace function pg_ctl(datadir text, command text, port int, contentid int, dbid int)
 returns text as $$
     import subprocess
-
     cmd = 'pg_ctl -D %s ' % datadir
     if command in ('stop', 'restart'):
         cmd = cmd + '-w -m immediate %s' % command
     elif command == 'start':
-        opts = '-p %d -\-gp_dbid=0 -\-silent-mode=true -i -\-gp_contentid=%d -\-gp_num_contents_in_cluster=3' % (port, contentid)
+        opts = '-p %d -\-gp_dbid=%d -\-silent-mode=true -i -\-gp_contentid=%d -\-gp_num_contents_in_cluster=3' % (port, dbid, contentid)
         cmd = cmd + '-o "%s" start' % opts
     else:
         return 'Invalid command input'
-
     return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '')
 $$ language plpythonu;
 
@@ -59,7 +57,7 @@ select gp_request_fts_probe_scan();
 select gp_inject_fault('fts_probe', 'status', 1);
 
 -- stop a mirror
--1U: select pg_ctl((select datadir from gp_segment_configuration c where c.role='m' and c.content=2), 'stop', NULL, NULL);
+-1U: select pg_ctl((select datadir from gp_segment_configuration c where c.role='m' and c.content=2), 'stop', NULL, NULL, NULL);
 
 -- this should block since mirror is not up and sync replication is on
 2: begin;
@@ -94,7 +92,7 @@ select content, role, preferred_role, mode, status from gp_segment_configuration
 2U: show synchronous_standby_names;
 
 -- bring the mirror back up and see primary s/u and mirror s/u
--1U: select pg_ctl((select datadir from gp_segment_configuration c where c.role='m' and c.content=2), 'start', (select port from gp_segment_configuration where content = 2 and preferred_role = 'm'), 2);
+-1U: select pg_ctl((select datadir from gp_segment_configuration c where c.role='m' and c.content=2), 'start', (select port from gp_segment_configuration where content = 2 and preferred_role = 'm'), 2, (select dbid from gp_segment_configuration c where c.role='m' and c.content=2));
 select wait_for_streaming(2::smallint);
 select content, role, preferred_role, mode, status from gp_segment_configuration where content=2;
 


### PR DESCRIPTION
- FTS went in infinite loop without this fix on probe if primary failed to respond back to probe request. Encountered the issue using suspend fault for fts message handler.

- If primary has promote file and pg_basebackup copies over the same, then due to existency of the same mirror gets auto-promoted which is very dangerous. Hence avoid copying over promote file. Add promote file to pg_basebackup exclude list.

(Note: In-porcess of coding to also unlink `promote` file on FTS probes if acting as primary)