### PR TITLE
Add GetResGroupMemAuditorForId to retrieve MemAuditor type.

### DIFF
--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -528,6 +528,17 @@ GetResGroupCapabilities(Relation rel, Oid groupId, ResGroupCaps *resgroupCaps)
 	}
 }
 
+
+int32 GetResGroupMemAuditorForId(Oid groupId, LOCKMODE lockmode)
+{
+	ResGroupCaps		caps;
+	Relation pg_resgroupcapability_rel = heap_open(
+			ResGroupCapabilityRelationId, lockmode);
+	GetResGroupCapabilities(pg_resgroupcapability_rel, groupId, &caps);
+	heap_close(pg_resgroupcapability_rel, AccessShareLock);
+	return caps.memAuditor;
+}
+
 /*
  * Get resource group id for a role in pg_authid.
  *

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -529,7 +529,12 @@ GetResGroupCapabilities(Relation rel, Oid groupId, ResGroupCaps *resgroupCaps)
 }
 
 
-int32 GetResGroupMemAuditorForId(Oid groupId, LOCKMODE lockmode)
+/*
+ * GetResGroupMemAuditorForId -- Return the resource group memory auditor
+ * for a groupId
+ */
+int32
+GetResGroupMemAuditorForId(Oid groupId, LOCKMODE lockmode)
 {
 	ResGroupCaps		caps;
 	Relation pg_resgroupcapability_rel = heap_open(

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -535,7 +535,7 @@ int32 GetResGroupMemAuditorForId(Oid groupId, LOCKMODE lockmode)
 	Relation pg_resgroupcapability_rel = heap_open(
 			ResGroupCapabilityRelationId, lockmode);
 	GetResGroupCapabilities(pg_resgroupcapability_rel, groupId, &caps);
-	heap_close(pg_resgroupcapability_rel, AccessShareLock);
+	heap_close(pg_resgroupcapability_rel, lockmode);
 	return caps.memAuditor;
 }
 

--- a/src/include/commands/resgroupcmds.h
+++ b/src/include/commands/resgroupcmds.h
@@ -40,4 +40,6 @@ extern void GetResGroupCapabilities(Relation rel,
 									ResGroupCaps *resgroupCaps);
 extern void ResGroupCheckForRole(Oid groupId);
 
+extern int32 GetResGroupMemAuditorForId(Oid groupId, LOCKMODE lockmode);
+
 #endif   /* RESGROUPCMDS_H */


### PR DESCRIPTION
gpdb master contains this interface, but 5X_stable lacks it.
MemAuditor is stored at different catalog table for master and 5X
So we use a separate function to retrieve this value.