### PR TITLE
Sort the outputs when dumping role settings.

### DIFF
--- a/src/bin/pg_dump/pg_dumpall.c
+++ b/src/bin/pg_dump/pg_dumpall.c
@@ -1792,7 +1792,7 @@ dumpDbRoleConfig(PGconn *conn)
 
 	printfPQExpBuffer(buf, "SELECT rolname, datname, unnest(setconfig) "
 					  "FROM pg_db_role_setting, pg_authid, pg_database "
-		  "WHERE setrole = pg_authid.oid AND setdatabase = pg_database.oid");
+		  "WHERE setrole = pg_authid.oid AND setdatabase = pg_database.oid ORDER BY 1,2");
 	res = executeQuery(conn, buf->data);
 
 	if (PQntuples(res) > 0)


### PR DESCRIPTION
By default when dumping role settings in function
dumpDbRoleConfig(), the outputs are not sorted. That
could make outputs differ before and after upgrade and
cause pg_upgrade test failure.

In this PR, an 'ORDER BY' is applied to fix it.