### PR TITLE
Fix bug for dropped columns in partition table in pg_dump.

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -12000,11 +12000,27 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 									  tbinfo->attlen[j],
 									  tbinfo->attalign[j]);
 					appendStringLiteralAH(q, tbinfo->attnames[j], fout);
-					appendPQExpBuffer(q, "\n  AND attrelid = ");
-					appendStringLiteralAH(q, fmtId(tbinfo->dobj.name), fout);
-					appendPQExpBuffer(q, "::pg_catalog.regclass;\n");
-
-					appendPQExpBuffer(q, "ALTER TABLE ONLY %s ",
+					if (gp_partitioning_available)
+					{
+						/*
+						 * Do for all descendants of a partition table.
+						 * No hurt if this is not a table with partitions.
+						 */
+						appendPQExpBuffer(q, "\n  AND attrelid IN (SELECT %u UNION "
+										  "SELECT pr.parchildrelid FROM "
+										  "pg_catalog.pg_partition_rule pr, "
+										  "pg_catalog.pg_partition p WHERE "
+										  "pr.parchildrelid != 0 AND "
+										  "pr.paroid = p.oid AND p.parrelid=%u);\n",
+										  tbinfo->dobj.catId.oid, tbinfo->dobj.catId.oid);
+					}
+					else
+					{
+						appendPQExpBuffer(q, "\n  AND attrelid = ");
+						appendStringLiteralAH(q, fmtId(tbinfo->dobj.name), fout);
+						appendPQExpBuffer(q, "::pg_catalog.regclass;\n");
+					}
+					appendPQExpBuffer(q, "ALTER TABLE %s ",
 									  fmtId(tbinfo->dobj.name));
 					appendPQExpBuffer(q, "DROP COLUMN %s;\n",
 									  fmtId(tbinfo->attnames[j]));

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -12006,13 +12006,16 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 						 * Do for all descendants of a partition table.
 						 * No hurt if this is not a table with partitions.
 						 */
-						appendPQExpBuffer(q, "\n  AND attrelid IN (SELECT %u UNION "
-										  "SELECT pr.parchildrelid FROM "
+						appendPQExpBuffer(q, "\n  AND attrelid IN (SELECT ");
+						appendStringLiteralAH(q, fmtId(tbinfo->dobj.name), fout);
+						appendPQExpBuffer(q, "::pg_catalog.regclass ");
+						appendPQExpBuffer(q, "UNION SELECT pr.parchildrelid FROM "
 										  "pg_catalog.pg_partition_rule pr, "
 										  "pg_catalog.pg_partition p WHERE "
 										  "pr.parchildrelid != 0 AND "
-										  "pr.paroid = p.oid AND p.parrelid=%u);\n",
-										  tbinfo->dobj.catId.oid, tbinfo->dobj.catId.oid);
+										  "pr.paroid = p.oid AND p.parrelid = ");
+						appendStringLiteralAH(q, fmtId(tbinfo->dobj.name), fout);
+						appendPQExpBuffer(q, "::pg_catalog.regclass);\n");
 					}
 					else
 					{


### PR DESCRIPTION
pg_dump creates dummy column for previously dropped column, and
then reconstructs some column values in pg_attribute and
finally drops the dummy column. The code does not handle the case of
gp partition table. For gp partition table, the root table and all its
inherited tables should go through the same steps.

