### PR TITLE
 tuptoaster: ensure toast index validity

### DIFF
--- a/src/test/isolation2/expected/invalidated_toast_index.out
+++ b/src/test/isolation2/expected/invalidated_toast_index.out
@@ -1,0 +1,59 @@
+--
+-- Test to make sure the error for an invalidated toast index is sane. This is
+-- done as an isolation2 test to make it easy to update the catalogs on all
+-- segments.
+--
+
+CREATE TABLE toastable_heap(a text, b varchar, c int);
+CREATE
+
+-- Force external storage for toasted columns.
+ALTER TABLE toastable_heap ALTER COLUMN a SET STORAGE EXTERNAL;
+ALTER
+ALTER TABLE toastable_heap ALTER COLUMN b SET STORAGE EXTERNAL;
+ALTER
+
+-- Insert two values that we know will be toasted.
+INSERT INTO toastable_heap VALUES(repeat('a',100000), repeat('b',100001), 1);
+INSERT 1
+INSERT INTO toastable_heap VALUES(repeat('A',100000), repeat('B',100001), 2);
+INSERT 1
+
+-- start_ignore
+--
+-- Invalidate the index of the toast table for our relation. Because this is a
+-- catalog change, we have to execute it on the master and all segments.
+--
+-- This is done in an ignore block so it can run correctly with any number of
+-- segments.
+*U: SET allow_system_table_mods = 'DML';
+SET
+
+SET
+
+SET
+
+SET
+*U: UPDATE pg_index SET indisvalid = false FROM pg_class heap, pg_class toast WHERE indexrelid = toast.reltoastidxid AND toast.oid  = heap.reltoastrelid AND heap.oid   = 'toastable_heap'::regclass;
+UPDATE 1
+
+UPDATE 1
+
+UPDATE 1
+
+UPDATE 1
+-- end_ignore
+
+-- Fetch, slice, save, and delete should all fail.
+SELECT * FROM toastable_heap;
+ERROR:  no valid index found for toast relation with Oid 107484 (tuptoaster.c:101)  (seg0 slice1 127.0.0.1:25432 pid=41177) (cdbdisp.c:254)
+SELECT substr(a, 500, 1) FROM toastable_heap;
+ERROR:  no valid index found for toast relation with Oid 107484 (tuptoaster.c:101)  (seg0 slice1 127.0.0.1:25432 pid=41177) (cdbdisp.c:254)
+UPDATE toastable_heap SET b = repeat('b',100001) WHERE c = 2;
+ERROR:  no valid index found for toast relation with Oid 107484 (tuptoaster.c:101)  (seg0 127.0.0.1:25432 pid=41177) (cdbdisp.c:254)
+DELETE FROM toastable_heap WHERE c = 1;
+ERROR:  no valid index found for toast relation with Oid 107484 (tuptoaster.c:101)  (seg2 127.0.0.1:25434 pid=41179) (cdbdisp.c:254)
+
+-- Don't leave an unusable table in the DB for others to trip over.
+DROP TABLE toastable_heap;
+DROP

--- a/src/test/isolation2/init_file_isolation2
+++ b/src/test/isolation2/init_file_isolation2
@@ -6,4 +6,8 @@ s/\s+\(entry db(.*)+\spid=\d+\)//
 # remove beginning output of gpconfig
 m/^\d+.*gpconfig.*-\[INFO\]:-/
 s/^\d+.*gpconfig.*-\[INFO\]:-//
+
+# ignore OID and file/line number diffs for invalid toast indexes
+m/^ERROR:  no valid index found for toast relation/
+s/with Oid \d+ \(.*\)/with Oid OID/
 -- end_matchsubs

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -6,6 +6,7 @@ test: commit_transaction_block_checkpoint
 test: instr_in_shmem_setup
 test: instr_in_shmem_terminate
 test: vacuum_recently_dead_tuple_due_to_distributed_snapshot
+test: invalidated_toast_index
 
 test: setup
 # Tests on Append-Optimized tables (row-oriented).

--- a/src/test/isolation2/sql/invalidated_toast_index.sql
+++ b/src/test/isolation2/sql/invalidated_toast_index.sql
@@ -1,0 +1,40 @@
+--
+-- Test to make sure the error for an invalidated toast index is sane. This is
+-- done as an isolation2 test to make it easy to update the catalogs on all
+-- segments.
+--
+
+CREATE TABLE toastable_heap(a text, b varchar, c int);
+
+-- Force external storage for toasted columns.
+ALTER TABLE toastable_heap ALTER COLUMN a SET STORAGE EXTERNAL;
+ALTER TABLE toastable_heap ALTER COLUMN b SET STORAGE EXTERNAL;
+
+-- Insert two values that we know will be toasted.
+INSERT INTO toastable_heap VALUES(repeat('a',100000), repeat('b',100001), 1);
+INSERT INTO toastable_heap VALUES(repeat('A',100000), repeat('B',100001), 2);
+
+-- start_ignore
+--
+-- Invalidate the index of the toast table for our relation. Because this is a
+-- catalog change, we have to execute it on the master and all segments.
+--
+-- This is done in an ignore block so it can run correctly with any number of
+-- segments.
+*U: SET allow_system_table_mods = 'DML';
+*U: UPDATE pg_index
+        SET indisvalid = false
+        FROM pg_class heap, pg_class toast
+        WHERE indexrelid = toast.reltoastidxid
+          AND toast.oid  = heap.reltoastrelid
+          AND heap.oid   = 'toastable_heap'::regclass;
+-- end_ignore
+
+-- Fetch, slice, save, and delete should all fail.
+SELECT * FROM toastable_heap;
+SELECT substr(a, 500, 1) FROM toastable_heap;
+UPDATE toastable_heap SET b = repeat('b',100001) WHERE c = 2;
+DELETE FROM toastable_heap WHERE c = 1;
+
+-- Don't leave an unusable table in the DB for others to trip over.
+DROP TABLE toastable_heap;

--- a/src/test/isolation2/sql_isolation_testcase.py
+++ b/src/test/isolation2/sql_isolation_testcase.py
@@ -40,7 +40,7 @@ class SQLIsolationExecutor(object):
         # The re.S flag makes the "." in the regex match newlines.
         # When matched against a command in process_command(), all
         # lines in the command are matched and sent as SQL query.
-        self.command_pattern = re.compile(r"^(-?\d+)([&\\<\\>Uq]*?)\:(.*)", re.S)
+        self.command_pattern = re.compile(r"^(-?\d+|[*])([&\\<\\>Uq]*?)\:(.*)", re.S)
         if dbname:
             self.dbname = dbname
         else:
@@ -258,6 +258,20 @@ class SQLIsolationExecutor(object):
         self.processes[(name, utility_mode)].quit()
         del self.processes[(name, utility_mode)]
 
+    def get_all_primary_contentids(self, dbname):
+        """
+        Retrieves all primary content IDs (including the master). Intended for
+        use by *U queries.
+        """
+        if not dbname:
+            dbname = self.dbname
+
+        con = pygresql.pg.connect(dbname=dbname)
+        result = con.query("SELECT content FROM gp_segment_configuration WHERE role = 'p'").getresult()
+        if len(result) == 0:
+            raise Exception("Invalid gp_segment_configuration contents")
+        return [int(content[0]) for content in result]
+
     def process_command(self, command, output_file):
         """
             Processes the given command.
@@ -328,7 +342,13 @@ class SQLIsolationExecutor(object):
                 raise Exception("No query should be given on quit")
             self.quit_process(output_file, process_name, dbname=dbname)
         elif flag == "U":
-            self.get_process(output_file, process_name, utility_mode=True, dbname=dbname).query(sql.strip())
+            if process_name == '*':
+                process_names = [str(content) for content in self.get_all_primary_contentids(dbname)]
+            else:
+                process_names = [process_name]
+
+            for name in process_names:
+                self.get_process(output_file, name, utility_mode=True, dbname=dbname).query(sql.strip())
         elif flag == "U&":
             self.get_process(output_file, process_name, utility_mode=True, dbname=dbname).fork(sql.strip(), True)
         elif flag == "U<":
@@ -384,7 +404,10 @@ class SQLIsolationTestCase:
         executing transactions. This is mainly used to test isolation behavior.
 
         [<#>[flag]:] <sql> | ! <shell scripts or command>
-        #: just any integer indicating an unique session or content-id if followed by U
+        #: either an integer indicating an unique session, or a content-id if
+           followed by U (for utility-mode connections). In 'U' mode, the
+           content-id can alternatively be an asterisk '*' to perform a
+           utility-mode query on the master and all primaries.
         flag:
             &: expect blocking behavior
             >: running in background without blocking
@@ -392,8 +415,8 @@ class SQLIsolationTestCase:
             q: quit the given session
 
             U: connect in utility mode to primary contentid from gp_segment_configuration
-            U&: expect blocking behavior in utility mode
-            U<: join an existing utility mode session
+            U&: expect blocking behavior in utility mode (does not currently support an asterisk target)
+            U<: join an existing utility mode session (does not currently support an asterisk target)
 
         An example is:
 
@@ -477,6 +500,22 @@ class SQLIsolationTestCase:
         2q:  ---> Will quit the session established with test2db.
 
         The subsequent 2: @db_name test: <sql> will open a new session with the database test and execute the sql against that session.
+
+        Catalog Modification:
+
+        Some tests are easier to write if it's possible to modify a system
+        catalog across the *entire* cluster. To perform a utility-mode query on
+        all segments and the master, you can use *U commands:
+
+        *U: SET allow_system_table_mods = 'DML';
+        *U: UPDATE pg_catalog.<table> SET <column> = <value> WHERE <cond>;
+
+        Since the number of query results returned by a *U command depends on
+        the developer's cluster configuration, it can be useful to wrap them in
+        a start_/end_ignore block. (Unfortunately, this also hides legitimate
+        failures; a better long-term solution is needed.)
+
+        Block/join flags are not currently supported with *U.
     """
 
     def run_sql_file(self, sql_file, out_file = None, out_dir = None, optimizer = None):


### PR DESCRIPTION
After a pg_upgrade from GPDB 4, toast table indexes in the cluster are invalidated. If an admin forgets to reindex, an incredibly confusing error message is printed when we try to make use of that index:

    missing chunk number 0 for toast value <> in pg_toast_<>

Postgres 9.4 (specifically, commit 2ef085d) added a helpful error message for this case. Backport that piece here, and add an isolation2 test case for it.

This adds a new feature to isolation2: the `*U:` command flag will execute its query on the master and all segments.