### PR TITLE
Remove ResultRelInfo.ri_partSlot field.

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14264,8 +14264,6 @@ split_rows(Relation intoa, Relation intob, Relation temprel)
 	 * slot/tupdesc should look same between A and B, but here we don't
 	 * assume so just in case, to be safe.
 	 */
-	rria->ri_partSlot = MakeSingleTupleTableSlot(RelationGetDescr(intoa));
-	rrib->ri_partSlot = MakeSingleTupleTableSlot(RelationGetDescr(intob));
 	map_part_attrs(temprel, intoa, &rria->ri_partInsertMap, true);
 	map_part_attrs(temprel, intob, &rrib->ri_partInsertMap, true);
 	Assert(NULL != rria->ri_RelationDesc);
@@ -14480,8 +14478,6 @@ split_rows(Relation intoa, Relation intob, Relation temprel)
 
 	MemoryContextSwitchTo(oldCxt);
 	ExecDropSingleTupleTableSlot(slotT);
-	ExecDropSingleTupleTableSlot(rria->ri_partSlot);
-	ExecDropSingleTupleTableSlot(rrib->ri_partSlot);
 
 	/*
 	 * We created our target result tuple table slots upfront.

--- a/src/backend/executor/execDML.c
+++ b/src/backend/executor/execDML.c
@@ -101,23 +101,13 @@ reconstructMatchingTupleSlot(TupleTableSlot *slot, ResultRelInfo *resultRelInfo)
 	isnull = slot_get_isnull(slot);
 
 	/*
-	 * Get the target slot ready. If this is a child partition table,
-	 * set target slot to ri_partSlot. Otherwise, use ri_resultSlot.
+	 * Get the target slot ready.
 	 */
-	if (map != NULL)
+	if (resultRelInfo->ri_resultSlot == NULL)
 	{
-		Assert(resultRelInfo->ri_partSlot != NULL);
-		partslot = resultRelInfo->ri_partSlot;
+		resultRelInfo->ri_resultSlot = MakeSingleTupleTableSlot(resultTupDesc);
 	}
-	else
-	{
-		if (resultRelInfo->ri_resultSlot == NULL)
-		{
-			resultRelInfo->ri_resultSlot = MakeSingleTupleTableSlot(resultTupDesc);
-		}
-
-		partslot = resultRelInfo->ri_resultSlot;
-	}
+	partslot = resultRelInfo->ri_resultSlot;
 
 	partslot = ExecStoreAllNullTuple(partslot);
 	partvalues = slot_get_values(partslot);

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -372,7 +372,6 @@ typedef struct ResultRelInfo
 	int			ri_aosegno;
 	uint64		ri_aoprocessed; /* tuples added/deleted for AO */
 	struct AttrMap *ri_partInsertMap;
-	TupleTableSlot *ri_partSlot;
 	TupleTableSlot *ri_resultSlot;
 	/* Parent relation in checkPartitionUpdate */
 	Relation	ri_PartitionParent;


### PR DESCRIPTION
It's redundant with ri_resultSlot. The rule was that we used ri_resultSlot
for the main target table, and ri_partSlot for partitions under the main
target table. That seems like an unnecessary distinction, let's just use
ri_resultSlot all the time.

In the loop in ExecModifyTable, make sure that es_result_relation_info
points to the parent table, between calls to ExecInsert / ExecUpdate /
ExecDelete. That apparently haven't caused problems so far, but it looks
scary not to.