### PR TITLE
Re-enable MIN/MAX optimization.

### DIFF
--- a/src/backend/optimizer/plan/planmain.c
+++ b/src/backend/optimizer/plan/planmain.c
@@ -546,6 +546,7 @@ PlannerConfig *DefaultPlannerConfig(void)
 	c1->mpp_trying_fallback_plan = false;
 	c1->constraint_exclusion = constraint_exclusion;
 
+	c1->gp_enable_minmax_optimization = gp_enable_minmax_optimization;
 	c1->gp_enable_multiphase_agg = gp_enable_multiphase_agg;
 	c1->gp_enable_preunique = gp_enable_preunique;
 	c1->gp_eager_preunique = gp_eager_preunique;

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -1670,6 +1670,25 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 			best_path = sorted_path;
 
 		/*
+		 * Check to see if it's possible to optimize MIN/MAX aggregates.
+		 * If so, we will forget all the work we did so far to choose a
+		 * "regular" path ... but we had to do it anyway to be able to
+		 * tell which way is cheaper.
+		 */
+		result_plan = optimize_minmax_aggregates(root,
+												 tlist,
+												 best_path);
+		if (result_plan != NULL)
+		{
+			/*
+			 * optimize_minmax_aggregates generated the full plan, with the
+			 * right tlist, and it has no sort order.
+			 */
+			current_pathkeys = NIL;
+			mark_plan_entry(result_plan);
+		}
+
+		/*
 		 * CDB:  For now, we either - construct a general parallel plan, - let
 		 * the sequential planner handle the situation, or - construct a
 		 * sequential plan using the mix-max index optimization.
@@ -1677,7 +1696,7 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 		 * Eventually we should add a parallel version of the min-max
 		 * optimization.  For now, it's either-or.
 		 */
-		if (Gp_role == GP_ROLE_DISPATCH)
+		if (Gp_role == GP_ROLE_DISPATCH && result_plan == NULL)
 		{
 			bool		querynode_changed = false;
 			bool		pass_subtlist = agg_counts.hasOrderedAggs;
@@ -1754,30 +1773,8 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 													  true);
 			}
 		}
-		else	/* Not GP_ROLE_DISPATCH */
-		{
-			/*
-			 * Check to see if it's possible to optimize MIN/MAX aggregates.
-			 * If so, we will forget all the work we did so far to choose a
-			 * "regular" path ... but we had to do it anyway to be able to
-			 * tell which way is cheaper.
-			 */
-			result_plan = optimize_minmax_aggregates(root,
-													 tlist,
-													 best_path);
-			if (result_plan != NULL)
-			{
-				/*
-				 * optimize_minmax_aggregates generated the full plan, with
-				 * the right tlist, and it has no sort order.
-				 */
-				current_pathkeys = NIL;
-				mark_plan_entry(result_plan);
-			}
 
-		}
-
-		if (result_plan == NULL)
+		if (result_plan == NULL)	/* Not GP_ROLE_DISPATCH */
 		{
 			/*
 			 * Normal case --- create a plan according to query_planner's

--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -506,6 +506,14 @@ make_subplan(PlannerInfo *root, Query *orig_subquery, SubLinkType subLinkType,
 		config->gp_enable_multiphase_agg = false;
 
 		/*
+		 * The MIN/MAX optimization works by inserting a subplan with LIMIT 1.
+		 * That effectively turns a correlated subquery into a multi-level
+		 * correlated subquery, which we don't currently support. (See check
+		 * above.)
+		 */
+		config->gp_enable_minmax_optimization = false;
+
+		/*
 		 * Only create subplans with sequential scans
 		 */
 		config->enable_indexscan = false;

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -325,6 +325,7 @@ bool		dml_ignore_target_partition_check = false;
 bool		gp_enable_hashjoin_size_heuristic = false;
 bool		gp_enable_fallback_plan = true;
 bool		gp_enable_predicate_propagation = false;
+bool		gp_enable_minmax_optimization = true;
 bool		gp_enable_multiphase_agg = true;
 bool		gp_enable_preunique = TRUE;
 bool		gp_eager_preunique = FALSE;
@@ -755,6 +756,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 		},
 		&gp_create_index_concurrently,
 		false, NULL, NULL
+	},
+
+	{
+		{"gp_enable_minmax_optimization", PGC_USERSET, QUERY_TUNING_METHOD,
+			gettext_noop("Enables the planner's use of index scans with limit to implement MIN/MAX."),
+			NULL,
+			GUC_NOT_IN_SAMPLE
+		},
+		&gp_enable_minmax_optimization,
+		true, NULL, NULL
 	},
 
 	{

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -588,6 +588,12 @@ extern double   gp_motion_cost_per_row;
 extern int      gp_segments_for_planner;
 
 /*
+ * Enable/disable the special optimization of MIN/MAX aggregates as
+ * Index Scan with limit.
+ */
+extern bool gp_enable_minmax_optimization;
+
+/*
  * "gp_enable_multiphase_agg"
  *
  * Unlike some other enable... vars, gp_enable_multiphase_agg is not cost based.

--- a/src/include/nodes/plannerconfig.h
+++ b/src/include/nodes/plannerconfig.h
@@ -30,6 +30,7 @@ typedef struct PlannerConfig
 	int			cdbpath_segments;
 	int			constraint_exclusion;
 
+	bool		gp_enable_minmax_optimization;
 	bool		gp_enable_multiphase_agg;
 	bool		gp_enable_preunique;
 	bool		gp_eager_preunique;

--- a/src/test/regress/expected/aggregates.out
+++ b/src/test/regress/expected/aggregates.out
@@ -521,9 +521,14 @@ select max(unique2) from tenk1 order by max(unique2)+1;
  9999
 (1 row)
 
--- MPP: This works in Postgres
 select max(unique2), generate_series(1,3) as g from tenk1 order by g desc;
-ERROR:  set-valued function called in context that cannot accept a set
+ max  | g 
+------+---
+ 9999 | 3
+ 9999 | 2
+ 9999 | 1
+(3 rows)
+
 -- check for correct detection of nested-aggregate errors
 select max(min(unique1)) from tenk1;
 ERROR:  aggregate function calls cannot be nested

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -534,7 +534,6 @@ select max(unique2) from tenk1 order by max(unique2)+1;
  9999
 (1 row)
 
--- MPP: This works in Postgres
 select max(unique2), generate_series(1,3) as g from tenk1 order by g desc;
  max  | g 
 ------+---

--- a/src/test/regress/expected/gp_aggregates_optimizer.out
+++ b/src/test/regress/expected/gp_aggregates_optimizer.out
@@ -284,4 +284,10 @@ select max(unique2), generate_series(1,3) as g from tenk1 order by g desc;
 -- Same test with avg(), so that the optimization doesn't apply. Fails,
 -- currently.
 select avg(unique2), generate_series(1,3) as g from tenk1 order by g desc;
-ERROR:  set-valued function called in context that cannot accept a set
+  avg   | g 
+--------+---
+ 4999.5 | 3
+ 4999.5 | 2
+ 4999.5 | 1
+(3 rows)
+

--- a/src/test/regress/sql/aggregates.sql
+++ b/src/test/regress/sql/aggregates.sql
@@ -233,8 +233,6 @@ select distinct max(unique2) from tenk1;
 select max(unique2) from tenk1 order by 1;
 select max(unique2) from tenk1 order by max(unique2);
 select max(unique2) from tenk1 order by max(unique2)+1;
-
--- MPP: This works in Postgres
 select max(unique2), generate_series(1,3) as g from tenk1 order by g desc;
 
 -- check for correct detection of nested-aggregate errors

--- a/src/test/regress/sql/gp_aggregates.sql
+++ b/src/test/regress/sql/gp_aggregates.sql
@@ -89,3 +89,12 @@ reset enable_hashjoin;
 reset enable_mergejoin;
 
 drop table l, ps;
+
+-- This wouldn't work in GPDB, if the MIN/MAX optimization in the planner
+-- didn't turn this into an index scan with a Limit.
+-- This is the same test we have in the upstream 'aggregates' test.
+select max(unique2), generate_series(1,3) as g from tenk1 order by g desc;
+
+-- Same test with avg(), so that the optimization doesn't apply. Fails,
+-- currently.
+select avg(unique2), generate_series(1,3) as g from tenk1 order by g desc;


### PR DESCRIPTION
I'm not sure why it's been disabled. It's not very hard to make it work, so
let's do it. Might not be a very common query type, but if you happen to
have a query where it helps, it helps a lot.

This adds a GUC, gp_enable_minmax_optimization, to enable/disable the
optimization. There's no such GUC in upstream, but we need at least a flag
in PlannerConfig for it, so that we can disable the optimization for
correlated subqueries, along with some other optimizer tricks. Seems best
to also have a GUC for it, for consistency with other flags in
PlannerConfig.