### PR TITLE
Refactor creation of PartitionSelectors to use a Path node.

### DIFF
--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -53,7 +53,6 @@
 #include "cdb/cdbvars.h"
 
 
-static Plan *create_subplan(PlannerInfo *root, Path *best_path);		/* CDB */
 static Plan *create_scan_plan(PlannerInfo *root, Path *best_path);
 static bool use_physical_tlist(PlannerInfo *root, RelOptInfo *rel);
 static void disuse_physical_tlist(Plan *plan, Path *path);
@@ -250,6 +249,9 @@ create_subplan(PlannerInfo *root, Path *best_path)
 			break;
 		case T_Motion:
 			plan = create_motion_plan(root, (CdbMotionPath *) best_path);
+			break;
+		case T_PartitionSelector:
+			plan = create_partition_selector_plan(root, (PartitionSelectorPath *) best_path);
 			break;
 		default:
 			elog(ERROR, "unrecognized node type: %d",
@@ -620,20 +622,14 @@ create_join_plan(PlannerInfo *root, JoinPath *best_path)
 	Plan	   *plan;
 	bool		partition_selector_created;
 
-	Assert(best_path->outerjoinpath);
-	Assert(best_path->innerjoinpath);
-
-	inner_plan = create_subplan(root, best_path->innerjoinpath);
-
 	/*
 	 * Try to inject Partition Selectors.
 	 */
 	partition_selector_created =
-		inject_partition_selectors_for_join(root,
-												best_path,
-												&inner_plan);
+		inject_partition_selectors_for_join(root, best_path);
 
 	outer_plan = create_subplan(root, best_path->outerjoinpath);
+	inner_plan = create_subplan(root, best_path->innerjoinpath);
 
 	switch (best_path->path.pathtype)
 	{
@@ -2807,48 +2803,50 @@ create_nestloop_plan(PlannerInfo *root,
 	 * NOTE: materialize_finished_plan() does *almost* what we want -- except
 	 * we aren't finished.
 	 */
-	if (!IsA(best_path->innerjoinpath, MaterialPath) &&
-		(best_path->innerjoinpath->motionHazard ||
-		 !best_path->innerjoinpath->rescannable))
+	if (best_path->innerjoinpath->motionHazard ||
+		!best_path->innerjoinpath->rescannable)
 	{
+		Plan	   *p;
 		Material   *mat;
-		Path		matpath;	/* dummy for cost fixup */
 
-		mat = make_material(inner_plan);
+		p = inner_plan;
+		while (IsA(p, PartitionSelector))
+			p = p->lefttree;
+		if (IsA(p, Material))
+		{
+			mat = (Material *) p;
+		}
+		else
+		{
+			Path		matpath;	/* dummy for cost fixup */
 
-		/* Set cost data */
-		cost_material(&matpath,
-					  root,
-					  inner_plan->startup_cost,
-					  inner_plan->total_cost,
-					  inner_plan->plan_rows,
-					  inner_plan->plan_width);
-		mat->plan.startup_cost = matpath.startup_cost;
-		mat->plan.total_cost = matpath.total_cost;
-		mat->plan.plan_rows = inner_plan->plan_rows;
-		mat->plan.plan_width = inner_plan->plan_width;
+			/* Set cost data */
+			cost_material(&matpath,
+						  root,
+						  inner_plan->startup_cost,
+						  inner_plan->total_cost,
+						  inner_plan->plan_rows,
+						  inner_plan->plan_width);
 
+			mat = make_material(inner_plan);
+
+			mat->plan.startup_cost = matpath.startup_cost;
+			mat->plan.total_cost = matpath.total_cost;
+			mat->plan.plan_rows = inner_plan->plan_rows;
+			mat->plan.plan_width = inner_plan->plan_width;
+
+			inner_plan = (Plan *) mat;
+		}
+
+		/*
+		 * MPP-1657: Even if there is already a materialize here, we
+		 * may need to update its strictness.
+		 */
 		if (best_path->outerjoinpath->motionHazard)
 		{
 			mat->cdb_strict = true;
 			prefetch = true;
 		}
-
-		inner_plan = (Plan *) mat;
-	}
-
-	/*
-	 * MPP-1657: if there is already a materialize here, we may need to update
-	 * its strictness.
-	 */
-	else if (IsA(best_path->innerjoinpath, MaterialPath) &&
-			 best_path->innerjoinpath->motionHazard &&
-			 best_path->outerjoinpath->motionHazard)
-	{
-		Material   *mat = (Material *) inner_plan;
-
-		prefetch = true;
-		mat->cdb_strict = true;
 	}
 
 	/*

--- a/src/backend/optimizer/plan/planpartition.c
+++ b/src/backend/optimizer/plan/planpartition.c
@@ -15,6 +15,7 @@
 
 #include "postgres.h"
 
+#include "optimizer/planmain.h"
 #include "optimizer/planpartition.h"
 #include "optimizer/paths.h"
 #include "optimizer/pathnode.h"
@@ -28,11 +29,16 @@
 
 static Expr *FindEqKey(PlannerInfo *root, Bitmapset *inner_relids, DynamicScanInfo *dyninfo, int partKeyAttno);
 
-static PartitionSelector *create_partition_selector(PlannerInfo *root, DynamicScanInfo *dsinfo, Plan *subplan, List *partTabTargetlist, Expr *printablePredicate);
-
 static void add_restrictinfos(PlannerInfo *root, DynamicScanInfo *dsinfo, Bitmapset *childrelids);
 
 static bool IsPartKeyVar(Expr *expr, int partVarno, int partKeyAttno);
+
+static Path *create_partition_selector_path(PlannerInfo *root,
+							   Path *subpath,
+							   DynamicScanInfo *dsinfo,
+							   List *partKeyExprs,
+							   List *partKeyAttnos);
+
 
 /*
  * Try to perform "partition selection" on a join.
@@ -79,27 +85,23 @@ static bool IsPartKeyVar(Expr *expr, int partVarno, int partKeyAttno);
  * for. The One-Time Filters act as "gates" that eliminate those
  * partitions altogether.
  *
- *
- * The caller should have already built the Plan for the inner side,
- * but *not* for the outer side. This function adds quals to rels in
- * the outer side, they will become One-Time Filters when the Plan
- * is created for the inner side. For the inner side, this function
- * wraps the outer Plan with Partition Selectors.
+ * If such a plan is possible, this function returns 'true', and modifies
+ * the given JoinPath to implement it. It wraps the inner child path with
+ * suitable PartitionSelectorPaths, and adds quals to the rels in the outer
+ * side, which will become One-Time Filters when the Plan is created for
+ * the outer side.
  *
  * If any partition selectors were created, returns 'true'.
  */
 bool
-inject_partition_selectors_for_join(PlannerInfo *root, JoinPath *join_path,
-									Plan **inner_plan_p)
+inject_partition_selectors_for_join(PlannerInfo *root, JoinPath *join_path)
 {
 	ListCell   *lc;
 	Path	   *outerpath = join_path->outerjoinpath;
 	Path	   *innerpath = join_path->innerjoinpath;
 	Bitmapset  *inner_relids = innerpath->parent->relids;
 	bool		any_selectors_created = false;
-	bool		good_type;
-	Plan	   *inner_parent;
-	Plan	   *inner_child;
+	bool		good_type = false;
 
 	if (Gp_role != GP_ROLE_DISPATCH || !root->config->gp_dynamic_partition_pruning)
 		return false;
@@ -112,8 +114,6 @@ inject_partition_selectors_for_join(PlannerInfo *root, JoinPath *join_path,
 	if (join_path->path.pathtype == T_HashJoin)
 	{
 		good_type = true;
-		inner_parent = NULL;
-		inner_child = *inner_plan_p;
 	}
 	/*
 	 * If we're doing a merge join, and will sort the inner side, then the sort
@@ -123,24 +123,30 @@ inject_partition_selectors_for_join(PlannerInfo *root, JoinPath *join_path,
 	else if (join_path->path.pathtype == T_MergeJoin && ((MergePath *) join_path)->innersortkeys)
 	{
 		good_type = true;
-		inner_parent = NULL;
-		inner_child = *inner_plan_p;
 	}
 	/*
-	 * For a nested loop or a merge join, if there happens to be a Material
-	 * or Sort node on the inner side, then we can place the Partition Selector
-	 * below it. Even though a nested loop join will rescan the inner side,
-	 * the Material or Sort will be executed all in one go.
+	 * For a nested loop join, if there happens to be a Material node on the inner
+	 * side, then we can place the Partition Selector below it. Even though a nested
+	 * loop join will rescan the inner side, the Material or Sort will be executed
+	 * all in one go.
+	 *
+	 * We could add a Material node, if there isn't one already, but a Material
+	 * node is expensive. It would almost certainly make this plan worse than
+	 * something else that the planner considered and rejected.
 	 */
-	else if ((join_path->path.pathtype == T_NestLoop && !path_contains_inner_index(innerpath)) ||
-			 join_path->path.pathtype == T_MergeJoin)
+	else if (join_path->path.pathtype == T_NestLoop && !path_contains_inner_index(innerpath))
 	{
-		if (IsA(*inner_plan_p, Material) || IsA(*inner_plan_p, Sort))
-		{
+		if (IsA(innerpath, MaterialPath))
 			good_type = true;
-			inner_parent = *inner_plan_p;
-			inner_child = inner_parent->lefttree;
-		}
+		else
+			good_type = false;
+	}
+	else if (join_path->path.pathtype == T_MergeJoin)
+	{
+		if (IsA(innerpath, MaterialPath))
+			good_type = true;
+		else if (((MergePath *) join_path)->innersortkeys)
+			good_type = true;
 		else
 			good_type = false;
 	}
@@ -152,22 +158,23 @@ inject_partition_selectors_for_join(PlannerInfo *root, JoinPath *join_path,
 
 	/*
 	 * Cannot do it, if there inner and outer sides are not in the same slice.
+	 * (This is just a quick check to see if there is any hope. We will check
+	 * individual relations in the loop below.)
 	 */
 	if (bms_is_empty(outerpath->sameslice_relids))
 		return false;
 
 	/*
-	 * NOTE: The equivalence class logic ensures that we don't get fooled
-	 * by outer join conditions. The sides of an outer join equality are not
-	 * put in the same equivalence class.
+	 * Loop through all dynamic scans in the plan. For each one, check if
+	 * the inner side of this join can provide values to the scan on the
+	 * outer side.
 	 */
 	foreach(lc, root->dynamicScans)
 	{
 		DynamicScanInfo *dyninfo = (DynamicScanInfo *) lfirst(lc);
 		ListCell   *lpk;
-		Expr	  **partKeyExprs = NULL;
-		int			max_attr = -1;
-		List	   *printablePredicate = NIL;
+		List	   *partKeyAttnos = NIL;
+		List	   *partKeyExprs = NIL;
 		Bitmapset  *childrelids;
 
 		/*
@@ -179,6 +186,10 @@ inject_partition_selectors_for_join(PlannerInfo *root, JoinPath *join_path,
 		if (bms_is_empty(childrelids))
 			continue;
 
+		/*
+		 * Find equivalence conditions between the partitioning keys and
+		 * the relations on the inner side of the join.
+		 */
 		foreach(lpk, dyninfo->partKeyAttnos)
 		{
 			int			partKeyAttno = lfirst_int(lpk);
@@ -186,81 +197,112 @@ inject_partition_selectors_for_join(PlannerInfo *root, JoinPath *join_path,
 
 			expr = FindEqKey(root, inner_relids, dyninfo, partKeyAttno);
 
-			if (!expr)
-				continue;
-
-			if (!partKeyExprs)
+			if (expr)
 			{
-				max_attr = find_base_rel(root, dyninfo->rtindex)->max_attr;
-				partKeyExprs = palloc0((max_attr + 1) * sizeof(Expr *));
+				partKeyAttnos = lappend_int(partKeyAttnos, partKeyAttno);
+				partKeyExprs = lappend(partKeyExprs, expr);
 			}
-			if (partKeyAttno > max_attr)
-				elog(ERROR, "invalid partitioning key attribute number");
-
-			partKeyExprs[partKeyAttno] = expr;
-
-			printablePredicate = lappend(printablePredicate, expr);
 		}
 
 		if (partKeyExprs)
 		{
 			/*
-			 * This can be computed from the inner side.
+			 * Found some partitioning keys that can be computed from the inner
+			 * side.
 			 *
 			 * Build a partition selector and put it on the inner side.
-			 * Add RestrictInfos on the partition scans.
+			 *
+			 * If the inner side contains a Material, then we put the
+			 * partition selector under the Material node. The Material
+			 * will shield us from rescanning, and ensures that the inner
+			 * side is scanned fully, before the outer side.
 			 */
-			List	   *partTabTargetlist = NIL;
-			int			attno;
-			PartitionSelector *partSelector;
-
-			for (attno = 1; attno <= max_attr; attno++)
+			if (IsA(innerpath, MaterialPath))
 			{
-				Expr	   *expr = partKeyExprs[attno];
-				char		attname[20];
+				MaterialPath *matsubpath = (MaterialPath *) innerpath;
 
-				if (!expr)
-					expr = (Expr *) makeBoolConst(false, true);
+				matsubpath->subpath =
+					create_partition_selector_path(root,
+												   matsubpath->subpath,
+												   dyninfo,
+												   partKeyExprs,
+												   partKeyAttnos);
 
-				snprintf(attname, sizeof(attname), "partcol_%d", attno);
-
-				partTabTargetlist = lappend(partTabTargetlist,
-											makeTargetEntry(expr,
-															attno,
-															pstrdup(attname),
-															false));
+				/*
+				 * The inner side, with the Partition Selector, must be fully
+				 * executed before the outer side.
+				 */
+				matsubpath->cdb_strict = true;
+			}
+			else
+			{
+				innerpath = create_partition_selector_path(root,
+														   innerpath,
+														   dyninfo,
+														   partKeyExprs,
+														   partKeyAttnos);
 			}
 
-			partSelector = create_partition_selector(root,
-													 dyninfo,
-													 inner_child,
-													 partTabTargetlist,
-													 (Expr *) printablePredicate);
-			inner_child = (Plan *) partSelector;
+			/*
+			 * Add RestrictInfos on the partition scans on the outer side.
+			 *
+			 * NB: This modifies the global RelOptInfo structures! Therefore,
+			 * if you tried to create the plan from some other Path, where
+			 * the partition selector cannot be used, you'll nevertheless get
+			 * the PartSelectExpr gates in the partition scans. Because of this,
+			 * this function must only be used just before turning a path into
+			 * plan.
+			 */
 			if (!dyninfo->hasSelector)
 			{
 				dyninfo->hasSelector = true;
 
 				add_restrictinfos(root, dyninfo, childrelids);
 			}
+
 			any_selectors_created = true;
 		}
 	}
 
 	if (any_selectors_created)
 	{
-		if (inner_parent)
-		{
-			inner_parent->lefttree = inner_child;
-			if (IsA(inner_parent, Material))
-				((Material *)inner_parent)->cdb_strict = true;
-		}
-		else
-			*inner_plan_p = inner_child;
+		join_path->innerjoinpath = innerpath;
 		return true;
 	}
 	else
 		return false;
+}
+
+/*
+ * Create a PartitionSelectorPath, for the inner side of a join.
+ */
+static Path *
+create_partition_selector_path(PlannerInfo *root,
+							   Path *subpath,
+							   DynamicScanInfo *dsinfo,
+							   List *partKeyExprs,
+							   List *partKeyAttnos)
+{
+	PartitionSelectorPath *pathnode = makeNode(PartitionSelectorPath);
+
+	pathnode->path.pathtype = T_PartitionSelector;
+	pathnode->path.parent = subpath->parent;
+
+	pathnode->path.startup_cost = subpath->startup_cost;
+	pathnode->path.total_cost = subpath->total_cost;
+	pathnode->path.pathkeys = subpath->pathkeys;
+
+	pathnode->path.locus = subpath->locus;
+	pathnode->path.motionHazard = subpath->motionHazard;
+	pathnode->path.rescannable = subpath->rescannable;
+	pathnode->path.sameslice_relids = subpath->sameslice_relids;
+
+	pathnode->subpath = subpath;
+	pathnode->dsinfo = dsinfo;
+	pathnode->partKeyExprs = partKeyExprs;
+	pathnode->partKeyAttnos = partKeyAttnos;
+
+	return (Path *) pathnode;
 }
 
 static Expr *
@@ -271,6 +313,11 @@ FindEqKey(PlannerInfo *root, Bitmapset *inner_relids,
 	ListCell   *lem2;
 	ListCell   *lec;
 
+	/*
+	 * NOTE: The equivalence class logic ensures that we don't get fooled
+	 * by outer join conditions. The sides of an outer join equality are not
+	 * put in the same equivalence class.
+	 */
 	foreach(lec, root->eq_classes)
 	{
 		EquivalenceClass *cur_ec = (EquivalenceClass *) lfirst(lec);
@@ -338,12 +385,57 @@ FindEqKey(PlannerInfo *root, Bitmapset *inner_relids,
 	return NULL;
 }
 
-static PartitionSelector *
-create_partition_selector(PlannerInfo *root, DynamicScanInfo *dsinfo,
-						  Plan *subplan, List *partTabTargetlist,
-						  Expr *printablePredicate)
+/*
+ * Create a PartitionSelector plan from a Path.
+ *
+ * This would logically belong in createplan.c, but let's keep everything
+ * related to Partition Selectors in this file.
+ */
+Plan *
+create_partition_selector_plan(PlannerInfo *root, PartitionSelectorPath *best_path)
 {
 	PartitionSelector *ps;
+	Plan	   *subplan;
+	ListCell   *lc_attno;
+	ListCell   *lc_expr;
+	List	   *partTabTargetlist;
+	int			max_attr;
+	int			attno;
+	Expr	  **partKeyExprs;
+
+	subplan = create_subplan(root, best_path->subpath);
+
+	max_attr = find_base_rel(root, best_path->dsinfo->rtindex)->max_attr;
+	partKeyExprs = palloc0((max_attr + 1) * sizeof(Expr *));
+
+	forboth(lc_attno, best_path->partKeyAttnos, lc_expr, best_path->partKeyExprs)
+	{
+		int			partKeyAttno = lfirst_int(lc_attno);
+		Expr	   *partKeyExpr = (Expr *) lfirst(lc_expr);
+
+		if (partKeyAttno > max_attr)
+			elog(ERROR, "invalid partitioning key attribute number");
+
+		partKeyExprs[partKeyAttno] = partKeyExpr;
+	}
+
+	partTabTargetlist = NIL;
+	for (attno = 1; attno <= max_attr; attno++)
+	{
+		Expr	   *expr = partKeyExprs[attno];
+		char		attname[20];
+
+		if (!expr)
+			expr = (Expr *) makeBoolConst(false, true);
+
+		snprintf(attname, sizeof(attname), "partcol_%d", attno);
+
+		partTabTargetlist = lappend(partTabTargetlist,
+									makeTargetEntry(expr,
+													attno,
+													pstrdup(attname),
+													false));
+	}
 
 	ps = makeNode(PartitionSelector);
 	ps->plan.targetlist = subplan->targetlist;
@@ -356,14 +448,14 @@ create_partition_selector(PlannerInfo *root, DynamicScanInfo *dsinfo,
 	ps->plan.plan_rows = subplan->plan_rows;
 	ps->plan.plan_width = subplan->plan_width;
 
-	ps->relid = dsinfo->parentOid;
+	ps->relid = best_path->dsinfo->parentOid;
 	ps->nLevels = 1;
-	ps->scanId = dsinfo->dynamicScanId;
+	ps->scanId = best_path->dsinfo->dynamicScanId;
 	ps->selectorId = -1;
 	ps->partTabTargetlist = partTabTargetlist;
 	ps->levelExpressions = NIL;
 	ps->residualPredicate = NULL;
-	ps->printablePredicate = (Node *) printablePredicate;
+	ps->printablePredicate = (Node *) best_path->partKeyExprs;
 	ps->staticSelection = false;
 	ps->staticPartOids = NIL;
 	ps->staticScanIds = NIL;
@@ -371,9 +463,13 @@ create_partition_selector(PlannerInfo *root, DynamicScanInfo *dsinfo,
 	ps->propagationExpression = (Node *)
 		makeConst(INT4OID, -1, 4, Int32GetDatum(ps->scanId), false, true);
 
-	return ps;
+	return (Plan *) ps;
 }
 
+/*
+ * Add RestrictInfos representing PartSelectedExpr gating quals for
+ * all the scans of each partition in a dynamic scan.
+ */
 static void
 add_restrictinfos(PlannerInfo *root, DynamicScanInfo *dsinfo, Bitmapset *childrelids)
 {

--- a/src/include/nodes/nodes.h
+++ b/src/include/nodes/nodes.h
@@ -325,6 +325,7 @@ typedef enum NodeTag
 
     /* Tags for MPP planner nodes (relation.h) */
     T_CdbMotionPath = 580,
+	T_PartitionSelectorPath,
     T_CdbRelColumnInfo,
 
 	/*

--- a/src/include/nodes/relation.h
+++ b/src/include/nodes/relation.h
@@ -856,6 +856,20 @@ typedef struct ExternalPath
 	/* for now it's pretty plain.. */
 } ExternalPath;
 
+/*
+ * PartitionSelectorPath is used for injection of partition selectors
+ */
+typedef struct PartitionSelectorPath
+{
+	Path		path;
+
+	Path	   *subpath;
+
+	DynamicScanInfo *dsinfo;
+	List	   *partKeyExprs;
+	List	   *partKeyAttnos;
+} PartitionSelectorPath;
+
 
 /*----------
  * IndexPath represents an index scan over a single index.

--- a/src/include/optimizer/planmain.h
+++ b/src/include/optimizer/planmain.h
@@ -122,6 +122,7 @@ extern bool contain_group_id(Node *node);
  * prototypes for plan/createplan.c
  */
 extern Plan *create_plan(PlannerInfo *root, Path *best_path);
+extern Plan *create_subplan(PlannerInfo *root, Path *best_path);		/* CDB */
 extern Node *fix_indexqual_operand(Node *node, IndexOptInfo *index);
 extern SubqueryScan *make_subqueryscan(PlannerInfo *root, List *qptlist, List *qpqual,
 				  Index scanrelid, Plan *subplan,

--- a/src/include/optimizer/planpartition.h
+++ b/src/include/optimizer/planpartition.h
@@ -19,7 +19,10 @@
 #include "nodes/plannodes.h"
 #include "nodes/relation.h"
 
-extern bool inject_partition_selectors_for_join(PlannerInfo *root, JoinPath *join_path, Plan **inner_plan_p);
+extern bool inject_partition_selectors_for_join(PlannerInfo *root,
+									JoinPath *join_path);
+
+extern Plan *create_partition_selector_plan(PlannerInfo *root, PartitionSelectorPath *pspath);
 
 extern RestrictInfo *make_mergeclause(Node *outer, Node *inner);
 


### PR DESCRIPTION
The old way, where inject_partition_selectors_for_join() was called with a
pre-created Plan for the inner side, but no Plan for the outer side, was a
bit weird. It was extra inconvenient for the caller, because in the
upstream, we always build the outer Plan first, so we had to reverse that
in GPDB. With the upcoming 9.1 merge, it a bigger problem, because changes
to the way Nested Loop params are passed from the outer side to the inner
side require that the outer Plan is generated before the inner Plan.

To clean that up, and to prepare for the 9.1 merge, refactor
inject_partition_selectors_for_join() so that it doesn't require a
pre-created Plan for the inner side. It now works purely on the Path
representation.