### PR TITLE
Make error handling in seqserver more robust.

### DIFF
--- a/src/backend/postmaster/seqserver.c
+++ b/src/backend/postmaster/seqserver.c
@@ -851,11 +851,20 @@ processSequenceRequest(int sockfd )
 	}
 	PG_CATCH();
 	{
+		AbortOutOfAnyTransaction();
 		if (!elog_demote(LOG))
 		{
     		elog(LOG, "unable to demote error");
 			PG_RE_THROW();
 		}
+
+		/*
+		 * Report the error to the server log. It would be nice to deliver
+		 * it to the client somehow, but we have no mechanism for that.
+		 */
+		EmitErrorReport();
+
+		FlushErrorState();
 		return false;
 	}
 	PG_END_TRY();


### PR DESCRIPTION
While working on the upcoming 9.1 merge, I was getting a PANIC because the
error recursion limit was reached. The root cause that threw the original
error and started the recursion was a silly bug, but it revealed that the
error handling in the seqserver is not very robust as it is. If an error
happens when processing a request, we should not crash.

Also, let's log the error to the server log, so that you can figure out
what happened. It would be nice to relay the message to the calling
backend, and to the client, but that'd require bigger changes.