### PR TITLE
 Add gp_wait_until_triggered_fault interface

### DIFF
--- a/contrib/gp_inject_fault/gp_inject_fault--1.0.sql
+++ b/contrib/gp_inject_fault/gp_inject_fault--1.0.sql
@@ -25,3 +25,14 @@ CREATE FUNCTION gp_inject_fault(
 RETURNS boolean
 AS $$ select gp_inject_fault($1, $2, '', '', '', 1, 0, $3) $$
 LANGUAGE SQL;
+
+-- Simpler version to avoid confusion for wait_until_triggered fault.
+-- occurrence in call below defines wait until number of times the
+-- fault hits.
+CREATE FUNCTION gp_wait_until_triggered_fault(
+  faultname text,
+  numtimestriggered int4,
+  db_id int4)
+RETURNS boolean
+AS $$ select gp_inject_fault($1, 'wait_until_triggered', '', '', '', $2, 0, $3) $$
+LANGUAGE SQL;

--- a/src/test/isolation2/expected/commit_transaction_block_checkpoint.out
+++ b/src/test/isolation2/expected/commit_transaction_block_checkpoint.out
@@ -20,10 +20,10 @@ CREATE
 2&: commit;  <waiting ...>
 
 -- wait for the fault to trigger since following checkpoint could be faster
-select gp_inject_fault('twophase_transaction_commit_prepared', 'wait_until_triggered', '', '', '', 1, 0, 3);
-gp_inject_fault
----------------
-t              
+select gp_wait_until_triggered_fault('twophase_transaction_commit_prepared', 1, 3);
+gp_wait_until_triggered_fault
+-----------------------------
+t                            
 (1 row)
 
 -- do checkpoint on segment content 1 in utility mode, and it should block
@@ -60,10 +60,10 @@ DROP
 2&: commit;  <waiting ...>
 
 -- wait for the fault to trigger since following checkpoint could be faster
-select gp_inject_fault('onephase_transaction_commit', 'wait_until_triggered', '', '', '', 1, 0, 1);
-gp_inject_fault
----------------
-t              
+select gp_wait_until_triggered_fault('onephase_transaction_commit', 1, 1);
+gp_wait_until_triggered_fault
+-----------------------------
+t                            
 (1 row)
 
 -- do checkpoint on master in utility mode, and it should block

--- a/src/test/isolation2/expected/crash_recovery.out
+++ b/src/test/isolation2/expected/crash_recovery.out
@@ -13,10 +13,10 @@ t
 3&:create table crash_test_ddl(c1 int);  <waiting ...>
 
 -- wait session 2 and session 3 hit inject point
-1:select gp_inject_fault('dtm_broadcast_commit_prepared', 'wait_until_triggered', '', '', '', 2, 0, 1);
-gp_inject_fault
----------------
-t              
+1:select gp_wait_until_triggered_fault('dtm_broadcast_commit_prepared', 2, 1);
+gp_wait_until_triggered_fault
+-----------------------------
+t                            
 (1 row)
 1:CHECKPOINT;
 CHECKPOINT
@@ -25,10 +25,10 @@ CHECKPOINT
 4&:insert into crash_test_table values (2);  <waiting ...>
 
 -- wait session 4 hit inject point
-1:select gp_inject_fault('dtm_broadcast_commit_prepared', 'wait_until_triggered', '', '', '', 3, 0, 1);
-gp_inject_fault
----------------
-t              
+1:select gp_wait_until_triggered_fault('dtm_broadcast_commit_prepared', 3, 1);
+gp_wait_until_triggered_fault
+-----------------------------
+t                            
 (1 row)
 
 -- transaction of session 5 didn't insert 'COMMIT' record
@@ -40,10 +40,10 @@ t
 5&:INSERT INTO crash_test_table VALUES (3);  <waiting ...>
 
 -- wait session 5 hit inject point
-1:select gp_inject_fault('transaction_abort_after_distributed_prepared', 'wait_until_triggered', '', '', '', 1, 0, 1);
-gp_inject_fault
----------------
-t              
+1:select gp_wait_until_triggered_fault('transaction_abort_after_distributed_prepared', 1, 1);
+gp_wait_until_triggered_fault
+-----------------------------
+t                            
 (1 row)
 
 -- check injector status

--- a/src/test/isolation2/expected/reindex.out
+++ b/src/test/isolation2/expected/reindex.out
@@ -12,10 +12,10 @@ t
 1:@db_name reindexdb1: CREATE TABLE heap1(a INT, b INT);
 CREATE
 1&:REINDEX DATABASE reindexdb1;  <waiting ...>
-SELECT gp_inject_fault('reindex_db', 'wait_until_triggered', '', '', '', 0, 0, 1);
-gp_inject_fault
----------------
-t              
+SELECT gp_wait_until_triggered_fault('reindex_db', 1, 1);
+gp_wait_until_triggered_fault
+-----------------------------
+t                            
 (1 row)
 2:@db_name reindexdb1:DROP TABLE heap1;
 DROP
@@ -48,10 +48,10 @@ gp_inject_fault
 t              
 (1 row)
 3&: REINDEX TABLE reindex_index1;  <waiting ...>
-SELECT gp_inject_fault('reindex_relation', 'wait_until_triggered', '', '', '', 0, 0, 1);
-gp_inject_fault
----------------
-t              
+SELECT gp_wait_until_triggered_fault('reindex_relation', 1, 1);
+gp_wait_until_triggered_fault
+-----------------------------
+t                            
 (1 row)
 -- create one more index
 CREATE INDEX reindex_index1_idx2 on reindex_index1 (a);

--- a/src/test/isolation2/expected/reindex_gpfastsequence.out
+++ b/src/test/isolation2/expected/reindex_gpfastsequence.out
@@ -18,10 +18,10 @@ t
 
 -- The reindex_relation fault should be hit
 1&: reindex table gp_fastsequence;  <waiting ...>
-2: select gp_inject_fault('reindex_relation', 'wait_until_triggered', 2);
-gp_inject_fault
----------------
-t              
+2: select gp_wait_until_triggered_fault('reindex_relation', 1, 2);
+gp_wait_until_triggered_fault
+-----------------------------
+t                            
 (1 row)
 -- The insert should for reindex in session 1
 2&: insert into test_fastseqence select i , 'aa'||i from generate_series(1,100) i;  <waiting ...>

--- a/src/test/isolation2/expected/segwalrep/cancel_commit_pending_replication.out
+++ b/src/test/isolation2/expected/segwalrep/cancel_commit_pending_replication.out
@@ -31,10 +31,10 @@ t
 -- `wal_sender_loop`. We also verify the `sync_rep_query_cancel` is
 -- triggered by query cancel request.
 1&: create table cancel_commit_pending_replication(a int, b int);  <waiting ...>
-select gp_inject_fault('finish_prepared_start_of_function', 'wait_until_triggered', 2);
-gp_inject_fault
----------------
-t              
+select gp_wait_until_triggered_fault('finish_prepared_start_of_function', 1, 2);
+gp_wait_until_triggered_fault
+-----------------------------
+t                            
 (1 row)
 -- now pause the wal sender on primary for content 0
 select gp_inject_fault('wal_sender_loop', 'suspend', 2);
@@ -66,10 +66,10 @@ pg_cancel_backend
 t                
 (1 row)
 -- EXPECT: hit this fault for QueryCancelPending
-select gp_inject_fault('sync_rep_query_cancel', 'wait_until_triggered', 2);
-gp_inject_fault
----------------
-t              
+select gp_wait_until_triggered_fault('sync_rep_query_cancel', 1, 2);
+gp_wait_until_triggered_fault
+-----------------------------
+t                            
 (1 row)
 -- EXPECT: the query is still in waiting mode, to verify the cancel is ignored.
 0U: select waiting_reason from pg_stat_activity where sess_id in (select sess_id from store_session_id);

--- a/src/test/isolation2/expected/uao_crash_compaction_column.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_column.out
@@ -74,27 +74,27 @@ t
 -- wait for suspend faults to trigger and then proceed to run next
 -- command which would trigger panic fault and help test
 -- crash_recovery
-3:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'wait_until_triggered', '', '', 'crash_before_cleanup_phase', 0, 0, 2);
-gp_inject_fault
----------------
-t              
+3:SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 2);
+gp_wait_until_triggered_fault
+-----------------------------
+t                            
 (1 row)
-3:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'wait_until_triggered', '', '', 'crash_before_segmentfile_drop', 0, 0, 2);
-gp_inject_fault
----------------
-t              
+3:SELECT gp_wait_until_triggered_fault('compaction_before_segmentfile_drop', 1, 2);
+gp_wait_until_triggered_fault
+-----------------------------
+t                            
 (1 row)
 3:VACUUM crash_vacuum_in_appendonly_insert;
-ERROR:  fault triggered, fault name:'appendonly_insert' fault type:'panic'  (seg0 127.0.1.1:25432 pid=11542)
+ERROR:  fault triggered, fault name:'appendonly_insert' fault type:'panic'  (seg0 127.0.1.1:25432 pid=7142)
 ERROR:  could not connect to segment: initialization of segworker group failed
 1<:  <... completed>
-ERROR:  Error on receive from seg0 127.0.1.1:25432 pid=11554: server closed the connection unexpectedly
+ERROR:  Error on receive from seg0 127.0.1.1:25432 pid=7153: server closed the connection unexpectedly
 DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
 ERROR:  could not connect to segment: initialization of segworker group failed
 2<:  <... completed>
-ERROR:  Error on receive from seg0 127.0.1.1:25432 pid=11564: server closed the connection unexpectedly
+ERROR:  Error on receive from seg0 127.0.1.1:25432 pid=7162: server closed the connection unexpectedly
 DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
@@ -339,10 +339,10 @@ t
 -- wait for suspend faults to trigger and then proceed to run next
 -- command which would trigger panic fault and help test
 -- crash_recovery
-SELECT gp_inject_fault('compaction_before_cleanup_phase', 'wait_until_triggered', '', '', 'crash_master_before_cleanup_phase', 0, 0, 1);
-gp_inject_fault
----------------
-t              
+SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 1);
+gp_wait_until_triggered_fault
+-----------------------------
+t                            
 (1 row)
 2:VACUUM crash_master_before_segmentfile_drop;
 PANIC:  fault triggered, fault name:'compaction_before_segmentfile_drop' fault type:'panic'

--- a/src/test/isolation2/expected/uao_crash_compaction_row.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_row.out
@@ -74,27 +74,27 @@ t
 -- wait for suspend faults to trigger and then proceed to run next
 -- command which would trigger panic fault and help test
 -- crash_recovery
-3:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'wait_until_triggered', '', '', 'crash_before_cleanup_phase', 0, 0, 2);
-gp_inject_fault
----------------
-t              
+3:SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 2);
+gp_wait_until_triggered_fault
+-----------------------------
+t                            
 (1 row)
-3:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'wait_until_triggered', '', '', 'crash_before_segmentfile_drop', 0, 0, 2);
-gp_inject_fault
----------------
-t              
+3:SELECT gp_wait_until_triggered_fault('compaction_before_segmentfile_drop', 1, 2);
+gp_wait_until_triggered_fault
+-----------------------------
+t                            
 (1 row)
 3:VACUUM crash_vacuum_in_appendonly_insert;
-ERROR:  fault triggered, fault name:'appendonly_insert' fault type:'panic'  (seg0 127.0.1.1:25432 pid=9756)
+ERROR:  fault triggered, fault name:'appendonly_insert' fault type:'panic'  (seg0 127.0.1.1:25432 pid=7037)
 ERROR:  could not connect to segment: initialization of segworker group failed
 1<:  <... completed>
-ERROR:  Error on receive from seg0 127.0.1.1:25432 pid=9768: server closed the connection unexpectedly
+ERROR:  Error on receive from seg0 127.0.1.1:25432 pid=7048: server closed the connection unexpectedly
 DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
 ERROR:  could not connect to segment: initialization of segworker group failed
 2<:  <... completed>
-ERROR:  Error on receive from seg0 127.0.1.1:25432 pid=9779: server closed the connection unexpectedly
+ERROR:  Error on receive from seg0 127.0.1.1:25432 pid=7057: server closed the connection unexpectedly
 DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
@@ -313,10 +313,10 @@ t
 -- wait for suspend faults to trigger and then proceed to run next
 -- command which would trigger panic fault and help test
 -- crash_recovery
-SELECT gp_inject_fault('compaction_before_cleanup_phase', 'wait_until_triggered', '', '', 'crash_master_before_cleanup_phase', 0, 0, 1);
-gp_inject_fault
----------------
-t              
+SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 1);
+gp_wait_until_triggered_fault
+-----------------------------
+t                            
 (1 row)
 2:VACUUM crash_master_before_segmentfile_drop;
 PANIC:  fault triggered, fault name:'compaction_before_segmentfile_drop' fault type:'panic'

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -1,6 +1,7 @@
 test: pg_terminate_backend deadlock_under_entry_db_singleton starve_case pg_views_concurrent_drop alter_blocks_for_update_and_viceversa drop_rename reader_waits_for_lock resource_queue
 
 test: reindex
+test: reindex_gpfastsequence
 test: commit_transaction_block_checkpoint
 test: instr_in_shmem_setup
 test: instr_in_shmem_terminate

--- a/src/test/isolation2/sql/commit_transaction_block_checkpoint.sql
+++ b/src/test/isolation2/sql/commit_transaction_block_checkpoint.sql
@@ -12,7 +12,7 @@ select gp_inject_fault('twophase_transaction_commit_prepared', 'suspend', 3);
 2&: commit;
 
 -- wait for the fault to trigger since following checkpoint could be faster
-select gp_inject_fault('twophase_transaction_commit_prepared', 'wait_until_triggered', '', '', '', 1, 0, 3);
+select gp_wait_until_triggered_fault('twophase_transaction_commit_prepared', 1, 3);
 
 -- do checkpoint on segment content 1 in utility mode, and it should block
 1U&: checkpoint;
@@ -35,7 +35,7 @@ select gp_inject_fault('onephase_transaction_commit', 'suspend', 1);
 2&: commit;
 
 -- wait for the fault to trigger since following checkpoint could be faster
-select gp_inject_fault('onephase_transaction_commit', 'wait_until_triggered', '', '', '', 1, 0, 1);
+select gp_wait_until_triggered_fault('onephase_transaction_commit', 1, 1);
 
 -- do checkpoint on master in utility mode, and it should block
 -1U&: checkpoint;

--- a/src/test/isolation2/sql/crash_recovery.sql
+++ b/src/test/isolation2/sql/crash_recovery.sql
@@ -7,21 +7,21 @@
 3&:create table crash_test_ddl(c1 int);
 
 -- wait session 2 and session 3 hit inject point
-1:select gp_inject_fault('dtm_broadcast_commit_prepared', 'wait_until_triggered', '', '', '', 2, 0, 1);
+1:select gp_wait_until_triggered_fault('dtm_broadcast_commit_prepared', 2, 1);
 1:CHECKPOINT;
 
 -- transaction of session 4 inserted 'COMMIT' record after checkpoint
 4&:insert into crash_test_table values (2);
 
 -- wait session 4 hit inject point
-1:select gp_inject_fault('dtm_broadcast_commit_prepared', 'wait_until_triggered', '', '', '', 3, 0, 1);
+1:select gp_wait_until_triggered_fault('dtm_broadcast_commit_prepared', 3, 1);
 
 -- transaction of session 5 didn't insert 'COMMIT' record
 1:select gp_inject_fault('transaction_abort_after_distributed_prepared', 'suspend', 1);
 5&:INSERT INTO crash_test_table VALUES (3);
 
 -- wait session 5 hit inject point
-1:select gp_inject_fault('transaction_abort_after_distributed_prepared', 'wait_until_triggered', '', '', '', 1, 0, 1);
+1:select gp_wait_until_triggered_fault('transaction_abort_after_distributed_prepared', 1, 1);
 
 -- check injector status
 1:select gp_inject_fault('dtm_broadcast_commit_prepared', 'status', 1);

--- a/src/test/isolation2/sql/reindex.sql
+++ b/src/test/isolation2/sql/reindex.sql
@@ -5,7 +5,7 @@ CREATE DATABASE reindexdb1 TEMPLATE template1;
 SELECT gp_inject_fault('reindex_db', 'suspend', '', '', '', 0, 0, 1);
 1:@db_name reindexdb1: CREATE TABLE heap1(a INT, b INT);
 1&:REINDEX DATABASE reindexdb1;
-SELECT gp_inject_fault('reindex_db', 'wait_until_triggered', '', '', '', 0, 0, 1);
+SELECT gp_wait_until_triggered_fault('reindex_db', 1, 1);
 2:@db_name reindexdb1:DROP TABLE heap1;
 SELECT gp_inject_fault('reindex_db', 'reset', '', '', '', 0, 0, 1);
 -- reindex should complete fine
@@ -22,7 +22,7 @@ insert into reindex_index1 select i,i+1 from generate_series(1, 10)i;
 COMMIT;
 SELECT gp_inject_fault('reindex_relation', 'suspend', '', '', '', 0, 0, 1);
 3&: REINDEX TABLE reindex_index1;
-SELECT gp_inject_fault('reindex_relation', 'wait_until_triggered', '', '', '', 0, 0, 1);
+SELECT gp_wait_until_triggered_fault('reindex_relation', 1, 1);
 -- create one more index
 CREATE INDEX reindex_index1_idx2 on reindex_index1 (a);
 SELECT gp_inject_fault('reindex_relation', 'reset', '', '', '', 0, 0, 1);

--- a/src/test/isolation2/sql/reindex_gpfastsequence.sql
+++ b/src/test/isolation2/sql/reindex_gpfastsequence.sql
@@ -10,7 +10,7 @@ select gp_inject_fault('reindex_relation', 'suspend', 2);
 
 -- The reindex_relation fault should be hit
 1&: reindex table gp_fastsequence;
-2: select gp_inject_fault('reindex_relation', 'wait_until_triggered', 2);
+2: select gp_wait_until_triggered_fault('reindex_relation', 1, 2);
 -- The insert should for reindex in session 1
 2&: insert into test_fastseqence select i , 'aa'||i from generate_series(1,100) i;
 

--- a/src/test/isolation2/sql/segwalrep/cancel_commit_pending_replication.sql
+++ b/src/test/isolation2/sql/segwalrep/cancel_commit_pending_replication.sql
@@ -27,7 +27,7 @@ select gp_inject_fault('finish_prepared_start_of_function', 'suspend', 2);
 -- `wal_sender_loop`. We also verify the `sync_rep_query_cancel` is
 -- triggered by query cancel request.
 1&: create table cancel_commit_pending_replication(a int, b int);
-select gp_inject_fault('finish_prepared_start_of_function', 'wait_until_triggered', 2);
+select gp_wait_until_triggered_fault('finish_prepared_start_of_function', 1, 2);
 -- now pause the wal sender on primary for content 0
 select gp_inject_fault('wal_sender_loop', 'suspend', 2);
 -- let the transaction move forward with the commit
@@ -38,7 +38,7 @@ select gp_inject_fault('finish_prepared_start_of_function', 'reset', 2);
 select gp_inject_fault('sync_rep_query_cancel', 'skip', 2);
 0U: select pg_cancel_backend(procpid) from pg_stat_activity where waiting_reason='replication' and sess_id in (select sess_id from store_session_id);
 -- EXPECT: hit this fault for QueryCancelPending
-select gp_inject_fault('sync_rep_query_cancel', 'wait_until_triggered', 2);
+select gp_wait_until_triggered_fault('sync_rep_query_cancel', 1, 2);
 -- EXPECT: the query is still in waiting mode, to verify the cancel is ignored.
 0U: select waiting_reason from pg_stat_activity where sess_id in (select sess_id from store_session_id);
 -- resume the primary on content 0

--- a/src/test/isolation2/sql/uao_crash_compaction_column.sql
+++ b/src/test/isolation2/sql/uao_crash_compaction_column.sql
@@ -41,8 +41,8 @@
 -- wait for suspend faults to trigger and then proceed to run next
 -- command which would trigger panic fault and help test
 -- crash_recovery
-3:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'wait_until_triggered', '', '', 'crash_before_cleanup_phase', 0, 0, 2);
-3:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'wait_until_triggered', '', '', 'crash_before_segmentfile_drop', 0, 0, 2);
+3:SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 2);
+3:SELECT gp_wait_until_triggered_fault('compaction_before_segmentfile_drop', 1, 2);
 3:VACUUM crash_vacuum_in_appendonly_insert;
 1<:
 2<:
@@ -110,7 +110,7 @@
 -- wait for suspend faults to trigger and then proceed to run next
 -- command which would trigger panic fault and help test
 -- crash_recovery
-SELECT gp_inject_fault('compaction_before_cleanup_phase', 'wait_until_triggered', '', '', 'crash_master_before_cleanup_phase', 0, 0, 1);
+SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 1);
 2:VACUUM crash_master_before_segmentfile_drop;
 1<:
 

--- a/src/test/isolation2/sql/uao_crash_compaction_row.sql
+++ b/src/test/isolation2/sql/uao_crash_compaction_row.sql
@@ -41,8 +41,8 @@
 -- wait for suspend faults to trigger and then proceed to run next
 -- command which would trigger panic fault and help test
 -- crash_recovery
-3:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'wait_until_triggered', '', '', 'crash_before_cleanup_phase', 0, 0, 2);
-3:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'wait_until_triggered', '', '', 'crash_before_segmentfile_drop', 0, 0, 2);
+3:SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 2);
+3:SELECT gp_wait_until_triggered_fault('compaction_before_segmentfile_drop', 1, 2);
 3:VACUUM crash_vacuum_in_appendonly_insert;
 1<:
 2<:
@@ -110,7 +110,7 @@
 -- wait for suspend faults to trigger and then proceed to run next
 -- command which would trigger panic fault and help test
 -- crash_recovery
-SELECT gp_inject_fault('compaction_before_cleanup_phase', 'wait_until_triggered', '', '', 'crash_master_before_cleanup_phase', 0, 0, 1);
+SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 1);
 2:VACUUM crash_master_before_segmentfile_drop;
 1<:
 

--- a/src/test/regress/expected/fts_error.out
+++ b/src/test/regress/expected/fts_error.out
@@ -19,7 +19,7 @@ NOTICE:  Success:
 -- injected on content 0 primary.
 select gp_inject_fault('fts_handle_message', 'error', '', '', '', -1, 0, dbid)
 from gp_segment_configuration where content = 0 and role = 'p';
-NOTICE:  Success:  (seg0 10.64.6.27:25432 pid=42073)
+NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=15439)
  gp_inject_fault 
 -----------------
  t
@@ -28,16 +28,16 @@ NOTICE:  Success:  (seg0 10.64.6.27:25432 pid=42073)
 -- Upon failure to probe content 0 primary, FTS will try to update the
 -- configuration.  The update to configuration will hit error due to
 -- the "fts_update_config" fault.
-select gp_inject_fault('fts_update_config', 'wait_until_triggered', 1);
+select gp_wait_until_triggered_fault('fts_update_config', 1, 1);
 NOTICE:  Success:
- gp_inject_fault 
------------------
+ gp_wait_until_triggered_fault 
+-------------------------------
  t
 (1 row)
 
 select gp_inject_fault('fts_handle_message', 'reset', dbid)
 from gp_segment_configuration where content = 0 and role = 'p';
-NOTICE:  Success:  (seg0 10.64.6.27:25432 pid=42073)
+NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=15439)
  gp_inject_fault 
 -----------------
  t

--- a/src/test/regress/expected/query_finish_pending.out
+++ b/src/test/regress/expected/query_finish_pending.out
@@ -1,4 +1,5 @@
 CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+NOTICE:  extension "gp_inject_fault" already exists, skipping
 drop table if exists _tmp_table;
 NOTICE:  table "_tmp_table" does not exist, skipping
 create table _tmp_table (i1 int, i2 int, i3 int, i4 int);
@@ -10,7 +11,7 @@ set statement_mem="2MB";
 set gp_enable_mk_sort=on;
 set gp_cte_sharing=on;
 select gp_inject_fault('execsort_mksort_mergeruns', 'reset', 2);
-NOTICE:  Success:
+NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=15470)
  gp_inject_fault 
 -----------------
  t
@@ -18,7 +19,7 @@ NOTICE:  Success:
 
 -- set QueryFinishPending=true in sort mergeruns. This will stop sort and set result_tape to NULL
 select gp_inject_fault('execsort_mksort_mergeruns', 'finish_pending', 2);
-NOTICE:  Success:
+NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=15470)
  gp_inject_fault 
 -----------------
  t
@@ -32,7 +33,7 @@ select DISTINCT S from (select row_number() over(partition by i1 order by i2) AS
 (1 row)
 
 select gp_inject_fault('execsort_mksort_mergeruns', 'status', 2);
-NOTICE:  Success: fault name:'execsort_mksort_mergeruns' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'completed'  num times hit:'1'
+NOTICE:  Success: fault name:'execsort_mksort_mergeruns' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'completed'  num times hit:'1'  (seg0 127.0.1.1:25432 pid=15470)
  gp_inject_fault 
 -----------------
  t
@@ -56,7 +57,7 @@ set gp_enable_mk_sort=off;
 -- planner on the other hand does not.
 set optimizer=off;
 select gp_inject_fault('execshare_input_next', 'reset', 2);
-NOTICE:  Success:
+NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=15470)
  gp_inject_fault 
 -----------------
  t
@@ -65,7 +66,7 @@ NOTICE:  Success:
 -- Set QueryFinishPending to true after SharedInputScan has retrieved the first tuple. 
 -- This will eagerly free the memory context of shared input scan's child node.  
 select gp_inject_fault('execshare_input_next', 'finish_pending', 2);
-NOTICE:  Success:
+NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=15470)
  gp_inject_fault 
 -----------------
  t
@@ -80,7 +81,7 @@ select * from cte c1, cte c2 limit 2;
 (2 rows)
 
 select gp_inject_fault('execshare_input_next', 'status', 2);
-NOTICE:  Success: fault name:'execshare_input_next' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'completed'  num times hit:'1'
+NOTICE:  Success: fault name:'execshare_input_next' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'completed'  num times hit:'1'  (seg0 127.0.1.1:25432 pid=15470)
  gp_inject_fault 
 -----------------
  t
@@ -90,7 +91,7 @@ NOTICE:  Success: fault name:'execshare_input_next' fault type:'finish_pending' 
 -- where the child is a Sort node and sort_mk algorithm is used
 set gp_enable_mk_sort=on;
 select gp_inject_fault('execshare_input_next', 'reset', 2);
-NOTICE:  Success:
+NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=15470)
  gp_inject_fault 
 -----------------
  t
@@ -99,7 +100,7 @@ NOTICE:  Success:
 -- Set QueryFinishPending to true after SharedInputScan has retrieved the first tuple. 
 -- This will eagerly free the memory context of shared input scan's child node.  
 select gp_inject_fault('execshare_input_next', 'finish_pending', 2);
-NOTICE:  Success:
+NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=15470)
  gp_inject_fault 
 -----------------
  t
@@ -114,7 +115,7 @@ select * from cte c1, cte c2 limit 2;
 (2 rows)
 
 select gp_inject_fault('execshare_input_next', 'status', 2);
-NOTICE:  Success: fault name:'execshare_input_next' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'completed'  num times hit:'1'
+NOTICE:  Success: fault name:'execshare_input_next' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'completed'  num times hit:'1'  (seg0 127.0.1.1:25432 pid=15470)
  gp_inject_fault 
 -----------------
  t
@@ -123,14 +124,14 @@ NOTICE:  Success: fault name:'execshare_input_next' fault type:'finish_pending' 
 reset gp_enable_mk_sort;
 -- Disable faultinjectors
 select gp_inject_fault('execsort_mksort_mergeruns', 'reset', 2);
-NOTICE:  Success:
+NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=15470)
  gp_inject_fault 
 -----------------
  t
 (1 row)
 
 select gp_inject_fault('execshare_input_next', 'reset', 2);
-NOTICE:  Success:
+NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=15470)
  gp_inject_fault 
 -----------------
  t
@@ -160,16 +161,16 @@ select gp_request_fts_probe_scan();
  t
 (1 row)
 
-select gp_inject_fault('fts_probe', 'wait_until_triggered', 1);
+select gp_wait_until_triggered_fault('fts_probe', 1, 1);
 NOTICE:  Success:
- gp_inject_fault 
------------------
+ gp_wait_until_triggered_fault 
+-------------------------------
  t
 (1 row)
 
 -- make one QE sleep before reading command
 select gp_inject_fault('before_read_command', 'sleep', '', '', '', 1, 50, 2::smallint);
-NOTICE:  Success:
+NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=15470)
  gp_inject_fault 
 -----------------
  t
@@ -177,10 +178,10 @@ NOTICE:  Success:
 
 begin;
 select count(*) from _tmp_table1, _tmp_table2 where 100 / _tmp_table2.c2 > 1;
-ERROR:  division by zero  (seg0 slice1 172.17.0.2:25433 pid=31180)
+ERROR:  division by zero  (seg0 slice1 127.0.1.1:25432 pid=15478)
 end;
 select gp_inject_fault('before_read_command', 'reset', 2);
-NOTICE:  Success:
+NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=15470)
  gp_inject_fault 
 -----------------
  t

--- a/src/test/regress/input/aocs.source
+++ b/src/test/regress/input/aocs.source
@@ -561,8 +561,8 @@ from gp_segment_configuration where role = 'p' and content = 0;
 insert into aocs_small_and_dense_content select i,i from
 generate_series(1,800000)i;
 
-select gp_inject_fault('appendonly_skip_compression',
-'wait_until_triggered', dbid) from gp_segment_configuration where
+select gp_wait_until_triggered_fault('appendonly_skip_compression', 1, dbid)
+from gp_segment_configuration where
 role = 'p' and content = 0;
 
 -- This should not fail if small content or bulk dense content headers

--- a/src/test/regress/output/aocs.source
+++ b/src/test/regress/output/aocs.source
@@ -1086,11 +1086,11 @@ from gp_segment_configuration where role = 'p' and content = 0;
 
 insert into aocs_small_and_dense_content select i,i from
 generate_series(1,800000)i;
-select gp_inject_fault('appendonly_skip_compression',
-'wait_until_triggered', dbid) from gp_segment_configuration where
+select gp_wait_until_triggered_fault('appendonly_skip_compression', 1, dbid)
+from gp_segment_configuration where
 role = 'p' and content = 0;
- gp_inject_fault 
------------------
+ gp_wait_until_triggered_fault 
+-------------------------------
  t
 (1 row)
 

--- a/src/test/regress/sql/fts_error.sql
+++ b/src/test/regress/sql/fts_error.sql
@@ -11,7 +11,7 @@ from gp_segment_configuration where content = 0 and role = 'p';
 -- Upon failure to probe content 0 primary, FTS will try to update the
 -- configuration.  The update to configuration will hit error due to
 -- the "fts_update_config" fault.
-select gp_inject_fault('fts_update_config', 'wait_until_triggered', 1);
+select gp_wait_until_triggered_fault('fts_update_config', 1, 1);
 
 select gp_inject_fault('fts_handle_message', 'reset', dbid)
 from gp_segment_configuration where content = 0 and role = 'p';

--- a/src/test/regress/sql/query_finish_pending.sql
+++ b/src/test/regress/sql/query_finish_pending.sql
@@ -73,7 +73,7 @@ create table _tmp_table2 as select i as c1, 0 as c2 from generate_series(0, 10) 
 -- interval.
 select gp_inject_fault('fts_probe', 'skip', '', '', '', -1, 0, 1);
 select gp_request_fts_probe_scan();
-select gp_inject_fault('fts_probe', 'wait_until_triggered', 1);
+select gp_wait_until_triggered_fault('fts_probe', 1, 1);
 
 -- make one QE sleep before reading command
 select gp_inject_fault('before_read_command', 'sleep', '', '', '', 1, 50, 2::smallint);

--- a/src/test/walrep/expected/missing_xlog.out
+++ b/src/test/walrep/expected/missing_xlog.out
@@ -133,10 +133,10 @@ select gp_request_fts_probe_scan();
  t
 (1 row)
 
-select gp_inject_fault('fts_probe', 'wait_until_triggered', 1);
+select gp_wait_until_triggered_fault('fts_probe', 1, 1);
 NOTICE:  Success:
- gp_inject_fault 
------------------
+ gp_wait_until_triggered_fault 
+-------------------------------
  t
 (1 row)
 

--- a/src/test/walrep/sql/missing_xlog.sql
+++ b/src/test/walrep/sql/missing_xlog.sql
@@ -123,7 +123,7 @@ create extension if not exists gp_inject_fault;
 -- interval.
 select gp_inject_fault('fts_probe', 'skip', '', '', '', -1, 0, 1);
 select gp_request_fts_probe_scan();
-select gp_inject_fault('fts_probe', 'wait_until_triggered', 1);
+select gp_wait_until_triggered_fault('fts_probe', 1, 1);
 
 -- stop a mirror
 select pg_ctl((select datadir from gp_segment_configuration c where c.role='m' and c.content=0), 'stop', NULL, NULL);


### PR DESCRIPTION
`wait_until_triggered` fault behaves differently compared to other faults. Mainly the occurence argument to it has special meaning, which defines wait till fault hits that many times. So, to clearly clarify the usage having simler interface for the same which avoid need for passing ignored arguments is helpful.