### PR TITLE
Fixed an issue of AO tables with 2MB blocksize, and removed unused ma…

### DIFF
--- a/src/backend/cdb/cdbappendonlystorage.c
+++ b/src/backend/cdb/cdbappendonlystorage.c
@@ -26,8 +26,8 @@ AppendOnlyStorage_GetUsableBlockSize(int32 configBlockSize)
 {
 	int32		result;
 
-	if (configBlockSize > AOSmallContentHeader_MaxLength)
-		result = AOSmallContentHeader_MaxLength;
+	if (configBlockSize > MAX_APPENDONLY_BLOCK_SIZE)
+		result = MAX_APPENDONLY_BLOCK_SIZE;
 	else
 		result = configBlockSize;
 

--- a/src/include/cdb/cdbappendonlystorage.h
+++ b/src/include/cdb/cdbappendonlystorage.h
@@ -24,42 +24,10 @@
 										   // 14 bits, or 16,383 (16k-1).
 										   // Maximum row count for small content.
 										   
-#define AOSmallContentHeader_MaxLength   0x1FFFFF 
-										   // 21 bits, or 2,097,151 (2 Mb-1).
-										   // Maximum blocksize.  Does not include
-										   // Append-Only Storage Header overhead...
-
-/*
- * Large Content.
- */
-#define AOLargeContentHeader_MaxLargeRowCount 0x1FFFFFF 
-										   // 25 bits, or 33,554,431, or (2^25-1)
-										   // Maximum row count for large content.
-
-#define AOLargeContentHeader_MaxLargeContentLength   0x3FFFFFFF 
-										  // 30 bits, or 1,073,741,823 (1Gb-1).
-
 /*
  * Non-Bulk Dense Content.
  */
-#define AONonBulkDenseContentHeader_MaxLength   0x1FFFFF 
-											   // 21 bits, or 2,097,151 (2 Mb-1).
-											   // Maximum blocksize.  Does not include
-											   // Append-Only Storage Header overhead...
-	
 #define AONonBulkDenseContentHeader_MaxLargeRowCount 0x3FFFFFFF 
-										   // 30 bits, or 1,073,741,823, or (2^30-1)
-										   // Maximum row count for dense content.
-
-/*
- * Bulk Dense Content.
- */
-#define AOBulkDenseContentHeader_MaxLength   0x1FFFFF 
-											   // 21 bits, or 2,097,151 (2 Mb-1).
-											   // Maximum blocksize.  Does not include
-											   // Append-Only Storage Header overhead...
-	
-#define AOBulkDenseContentHeader_MaxLargeRowCount 0x3FFFFFFF 
 										   // 30 bits, or 1,073,741,823, or (2^30-1)
 										   // Maximum row count for dense content.
 


### PR DESCRIPTION
Here is a little bit about this issue and the PR.

When the blocksize is 2MB, the function AppendOnlyStorage_GetUsableBlockSize would give out the wrong usable block size. The expected result is 2MB. But the return value of the function call would give out (2M -4). This is because the macro AOSmallContentHeader_MaxLength is defined as (2M -1). After rounding down to 4 byte aligned, the result is (2M - 4).

I could conduct a re-producing case (actually this was the second time when we encountered this issue in our customers' environments) which can throw errors as follows:

    ERROR: Used length 2097152 greater than bufferLen 2097148 at position 8388592 in table 'xxxx'

However, since the root cause is so straightforward, I just pushed PR without re-producing cases.

In this PR, I also removed some related, but unused macro variables, just for cleaning up codes related to Ao storage.