### PR TITLE
Fix fallback test in gporca.sql

### DIFF
--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -9969,10 +9969,41 @@ create table foo(a int, b int) distributed by (a);
 set log_statement='none';
 set log_min_duration_statement=-1;
 set client_min_messages='log';
-select count(*) from foo group by cube(a,b);
- count 
--------
-(0 rows)
+explain select count(*) from foo group by cube(a,b);
+                                                                   QUERY PLAN                                                                   
+------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=10489.33..21118.58 rows=40897 width=28)
+   ->  Append  (cost=10489.33..21118.58 rows=13633 width=28)
+         ->  HashAggregate  (cost=10489.33..10909.06 rows=9328 width=28)
+               Group Key: "rollup".unnamed_attr_2, "rollup".unnamed_attr_1, "rollup"."grouping", "rollup"."group_id"
+               ->  Subquery Scan on "rollup"  (cost=8552.10..10424.75 rows=1435 width=28)
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=8552.10..10381.70 rows=1435 width=28)
+                           Hash Key: "rollup".unnamed_attr_2, "rollup".unnamed_attr_1, (Grouping), group_id()
+                           ->  GroupAggregate  (cost=8552.10..10295.60 rows=1435 width=28)
+                                 Group Key: "rollup"."grouping", "rollup"."group_id"
+                                 ->  Subquery Scan on "rollup"  (cost=8552.10..10134.17 rows=2153 width=28)
+                                       ->  GroupAggregate  (cost=8552.10..10069.60 rows=2153 width=28)
+                                             Group Key: "rollup".unnamed_attr_2, "rollup"."grouping", "rollup"."group_id"
+                                             ->  Subquery Scan on "rollup"  (cost=8552.10..9843.60 rows=2870 width=28)
+                                                   ->  GroupAggregate  (cost=8552.10..9757.50 rows=2870 width=28)
+                                                         Group Key: share0_ref1.b, share0_ref1.a
+                                                         ->  Sort  (cost=8552.10..8767.35 rows=28700 width=8)
+                                                               Sort Key: share0_ref1.b, share0_ref1.a
+                                                               ->  Shared Scan (share slice:id 1:0)  (cost=1391.50..1494.60 rows=28700 width=8)
+                                                                     ->  Materialize  (cost=0.00..1391.50 rows=28700 width=8)
+                                                                           ->  Seq Scan on foo  (cost=0.00..961.00 rows=28700 width=8)
+         ->  HashAggregate  (cost=9886.65..10080.37 rows=4305 width=28)
+               Group Key: "rollup".unnamed_attr_1, "rollup".unnamed_attr_2, "rollup"."grouping", "rollup"."group_id"
+               ->  Subquery Scan on "rollup"  (cost=8552.10..9822.07 rows=1435 width=28)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=8552.10..9779.02 rows=1435 width=28)
+                           Hash Key: share0_ref2.a, share0_ref2.b, (Grouping), group_id()
+                           ->  GroupAggregate  (cost=8552.10..9692.92 rows=1435 width=28)
+                                 Group Key: share0_ref2.a
+                                 ->  Sort  (cost=8552.10..8767.35 rows=28700 width=8)
+                                       Sort Key: share0_ref2.a, share0_ref2.b
+                                       ->  Shared Scan (share slice:id 2:0)  (cost=1391.50..1494.60 rows=28700 width=8)
+ Optimizer: legacy query optimizer
+(31 rows)
 
 reset client_min_messages;
 reset log_statement;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -10016,13 +10016,44 @@ create table foo(a int, b int) distributed by (a);
 set log_statement='none';
 set log_min_duration_statement=-1;
 set client_min_messages='log';
-select count(*) from foo group by cube(a,b);
-LOG:  2016-08-19 10:46:53:360703 PDT,THD000,NOTICE,"Feature not supported by the Pivotal Query Optimizer: Cube",
+explain select count(*) from foo group by cube(a,b);
+LOG:  2018-03-29 10:22:52:869837 PDT,THD000,NOTICE,"Feature not supported by the Pivotal Query Optimizer: Cube",
 INFO:  GPORCA failed to produce a plan, falling back to planner
 LOG:  Planner produced plan :0
- count 
--------
-(0 rows)
+                                                                   QUERY PLAN                                                                   
+------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=10489.33..21118.58 rows=40897 width=28)
+   ->  Append  (cost=10489.33..21118.58 rows=13633 width=28)
+         ->  HashAggregate  (cost=10489.33..10909.06 rows=9328 width=28)
+               Group Key: "rollup".unnamed_attr_2, "rollup".unnamed_attr_1, "rollup"."grouping", "rollup"."group_id"
+               ->  Subquery Scan on "rollup"  (cost=8552.10..10424.75 rows=1435 width=28)
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=8552.10..10381.70 rows=1435 width=28)
+                           Hash Key: "rollup".unnamed_attr_2, "rollup".unnamed_attr_1, (Grouping), group_id()
+                           ->  GroupAggregate  (cost=8552.10..10295.60 rows=1435 width=28)
+                                 Group Key: "rollup"."grouping", "rollup"."group_id"
+                                 ->  Subquery Scan on "rollup"  (cost=8552.10..10134.17 rows=2153 width=28)
+                                       ->  GroupAggregate  (cost=8552.10..10069.60 rows=2153 width=28)
+                                             Group Key: "rollup".unnamed_attr_2, "rollup"."grouping", "rollup"."group_id"
+                                             ->  Subquery Scan on "rollup"  (cost=8552.10..9843.60 rows=2870 width=28)
+                                                   ->  GroupAggregate  (cost=8552.10..9757.50 rows=2870 width=28)
+                                                         Group Key: share0_ref1.b, share0_ref1.a
+                                                         ->  Sort  (cost=8552.10..8767.35 rows=28700 width=8)
+                                                               Sort Key: share0_ref1.b, share0_ref1.a
+                                                               ->  Shared Scan (share slice:id 1:0)  (cost=1391.50..1494.60 rows=28700 width=8)
+                                                                     ->  Materialize  (cost=0.00..1391.50 rows=28700 width=8)
+                                                                           ->  Seq Scan on foo  (cost=0.00..961.00 rows=28700 width=8)
+         ->  HashAggregate  (cost=9886.65..10080.37 rows=4305 width=28)
+               Group Key: "rollup".unnamed_attr_1, "rollup".unnamed_attr_2, "rollup"."grouping", "rollup"."group_id"
+               ->  Subquery Scan on "rollup"  (cost=8552.10..9822.07 rows=1435 width=28)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=8552.10..9779.02 rows=1435 width=28)
+                           Hash Key: share0_ref2.a, share0_ref2.b, (Grouping), group_id()
+                           ->  GroupAggregate  (cost=8552.10..9692.92 rows=1435 width=28)
+                                 Group Key: share0_ref2.a
+                                 ->  Sort  (cost=8552.10..8767.35 rows=28700 width=8)
+                                       Sort Key: share0_ref2.a, share0_ref2.b
+                                       ->  Shared Scan (share slice:id 2:0)  (cost=1391.50..1494.60 rows=28700 width=8)
+ Optimizer: legacy query optimizer
+(31 rows)
 
 reset client_min_messages;
 reset log_statement;

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -1353,7 +1353,7 @@ create table foo(a int, b int) distributed by (a);
 set log_statement='none';
 set log_min_duration_statement=-1;
 set client_min_messages='log';
-select count(*) from foo group by cube(a,b);
+explain select count(*) from foo group by cube(a,b);
 reset client_min_messages;
 reset log_statement;
 reset log_min_duration_statement;


### PR DESCRIPTION
This test was added to ensure proper logging of ORCA fall-back messages. The query contains CUBE grouping extension which is currently not supported by ORCA causing ORCA to fall back to planner with following log messages:
```
LOG:  NOTICE,"Feature not supported by the Pivotal Query Optimizer: Cube",
LOG:  Planner produced plan :0
```
The planner generated plan contains a Shared Scan node.  During execution of this, sometimes, there is an extra log message generated indicating that Shared Scan writer is waiting for an acknowledgement from Shared Scan readers:
```
LOG: SISC WRITER (shareid=0, slice=1): notify still wait for an answer, errno 4
```
The query returns successfully however this intermittently generated log message causes test to fail. Fix the flake by converting this to an EXPLAIN test, which is sufficient to demonstrate the fall back logging.