### PR TITLE
Allow Concourse Ubuntu compilation to take in configure flags

### DIFF
--- a/concourse/scripts/compile_gpdb_open_source_ubuntu.bash
+++ b/concourse/scripts/compile_gpdb_open_source_ubuntu.bash
@@ -28,7 +28,8 @@ function build_gpdb() {
       --with-python \
       --with-libraries=${CWD}/depends/build/lib \
       --with-includes=${CWD}/depends/build/include \
-      --prefix=${GREENPLUM_INSTALL_DIR}
+      --prefix=${GREENPLUM_INSTALL_DIR} \
+      ${CONFIGURE_FLAGS}
     make -j4 -s
     LD_LIBRARY_PATH=${CWD}/depends/build/lib make install
     popd


### PR DESCRIPTION
This will allow us to add assertions for the Ubuntu jobs in the main
Greenplum pipeline. This is needed to assist debugging intermittent
test failures on Ubuntu.