### PR TITLE
Revert Resource Group Update

### DIFF
--- a/src/backend/catalog/gp_toolkit.sql
+++ b/src/backend/catalog/gp_toolkit.sql
@@ -1845,30 +1845,25 @@ CREATE VIEW gp_toolkit.gp_resgroup_config AS
         T4.value    AS memory_shared_quota,
         T4.proposed AS proposed_memory_shared_quota,
         T5.value    AS memory_spill_ratio,
-        T5.proposed AS proposed_memory_spill_ratio,
-        T6.value    AS memory_auditor,
-        T6.proposed AS proposed_memory_auditor
+        T5.proposed AS proposed_memory_spill_ratio
     FROM
         pg_resgroup G,
         pg_resgroupcapability T1,
         pg_resgroupcapability T2,
         pg_resgroupcapability T3,
         pg_resgroupcapability T4,
-        pg_resgroupcapability T5,
-        pg_resgroupcapability T6
+        pg_resgroupcapability T5
     WHERE
         G.oid = T1.resgroupid
     AND G.oid = T2.resgroupid
     AND G.oid = T3.resgroupid
     AND G.oid = T4.resgroupid
     AND G.oid = T5.resgroupid
-    AND G.oid = T6.resgroupid
     AND T1.reslimittype = 1
     AND T2.reslimittype = 2
     AND T3.reslimittype = 3
     AND T4.reslimittype = 4
     AND T5.reslimittype = 5
-    AND T6.reslimittype = 6
     ;
 
 GRANT SELECT ON gp_toolkit.gp_resgroup_config TO public;

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -42,9 +42,6 @@
 #define RESGROUP_DEFAULT_MEM_SHARED_QUOTA (20)
 #define RESGROUP_DEFAULT_MEM_SPILL_RATIO (20)
 
-#define RESGROUP_DEFAULT_MEM_AUDITOR (RESGROUP_MEMORY_AUDITOR_VMTRACKER)
-#define RESGROUP_INVALID_MEM_AUDITOR (-1)
-
 #define RESGROUP_MIN_CONCURRENCY	(0)
 #define RESGROUP_MAX_CONCURRENCY	(MaxConnections)
 
@@ -61,30 +58,19 @@
 #define RESGROUP_MAX_MEMORY_SPILL_RATIO		(100)
 
 /*
- * The names must be in the same order as ResGroupMemAuditorType.
- */
-static const char *ResGroupMemAuditorName[] =
-{
-	"vmtracker",	// RESGROUP_MEMORY_AUDITOR_VMTRACKER
-	"cgroup"		// RESGROUP_MEMORY_AUDITOR_CGROUP
-};
-
-/*
  * The context to pass to callback in ALTER resource group
  */
 typedef struct {
 	Oid		groupid;
-	ResGroupLimitType	limittype;
+	int		limittype;
 	ResGroupCaps	caps;
-	ResGroupCap		memLimitGap;
 } ResourceGroupAlterCallbackContext;
 
 static int str2Int(const char *str, const char *prop);
 static ResGroupLimitType getResgroupOptionType(const char* defname);
-static ResGroupCap getResgroupOptionValue(DefElem *defel, int type);
+static ResGroupCap getResgroupOptionValue(DefElem *defel);
 static const char *getResgroupOptionName(ResGroupLimitType type);
 static void checkResgroupCapLimit(ResGroupLimitType type, ResGroupCap value);
-static void checkResgroupMemAuditor(ResGroupCaps *caps);
 static void parseStmtOptions(CreateResourceGroupStmt *stmt, ResGroupCaps *caps);
 static void validateCapabilities(Relation rel, Oid groupid, ResGroupCaps *caps, bool newGroup);
 static void insertResgroupCapabilityEntry(Relation rel, Oid groupid, uint16 type, char *value);
@@ -98,7 +84,6 @@ static void checkAuthIdForDrop(Oid groupId);
 static void createResgroupCallback(XactEvent event, void *arg);
 static void dropResgroupCallback(XactEvent event, void *arg);
 static void alterResgroupCallback(XactEvent event, void *arg);
-static int getResGroupMemAuditor(char *name);
 
 /*
  * CREATE RESOURCE GROUP
@@ -235,7 +220,6 @@ CreateResourceGroup(CreateResourceGroupStmt *stmt)
 		/* Create os dependent part for this resource group */
 		ResGroupOps_CreateGroup(groupid);
 		ResGroupOps_SetCpuRateLimit(groupid, caps.cpuRateLimit);
-		ResGroupOps_SetMemoryLimit(groupid, caps.memLimit);
 	}
 	else if (Gp_role == GP_ROLE_DISPATCH)
 		ereport(WARNING,
@@ -373,7 +357,7 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("option \"%s\" not recognized", defel->defname)));
 
-	value = getResgroupOptionValue(defel, limitType);
+	value = getResgroupOptionValue(defel);
 	checkResgroupCapLimit(limitType, value);
 
 	/*
@@ -412,8 +396,6 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 	oldValue = capArray[limitType];
 	capArray[limitType] = value;
 
-	checkResgroupMemAuditor(&caps);
-
 	if ((limitType == RESGROUP_LIMIT_TYPE_CPU ||
 		 limitType == RESGROUP_LIMIT_TYPE_MEMORY) &&
 		oldValue < value)
@@ -449,8 +431,6 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 		callbackCtx->groupid = groupid;
 		callbackCtx->limittype = limitType;
 		callbackCtx->caps = caps;
-		callbackCtx->memLimitGap = (limitType == RESGROUP_LIMIT_TYPE_MEMORY) ?
-			(oldValue - value) : 0;
 		RegisterXactCallbackOnce(alterResgroupCallback, (void *)callbackCtx);
 	}
 }
@@ -504,10 +484,8 @@ GetResGroupCapabilities(Relation rel, Oid groupId, ResGroupCaps *resgroupCaps)
 		type = (ResGroupLimitType) DatumGetInt16(typeDatum);
 
 		Assert(type > RESGROUP_LIMIT_TYPE_UNKNOWN);
+		Assert(type < RESGROUP_LIMIT_TYPE_COUNT);
 		Assert(!(mask & (1 << type)));
-
-		if (type >= RESGROUP_LIMIT_TYPE_COUNT)
-			continue;
 
 		mask |= 1 << type;
 
@@ -666,29 +644,6 @@ GetResGroupNameForId(Oid oid, LOCKMODE lockmode)
 }
 
 /*
- * Check to see if the group can be assigned with role
- */
-void
-ResGroupCheckForRole(Oid groupId)
-{
-	Relation pg_resgroupcapability_rel;
-	ResGroupCaps caps;
-
-	pg_resgroupcapability_rel = heap_open(ResGroupCapabilityRelationId,
-										  AccessShareLock);
-
-	/* Load current resource group capabilities */
-	GetResGroupCapabilities(pg_resgroupcapability_rel, groupId, &caps);
-	if (caps.memAuditor == RESGROUP_MEMORY_AUDITOR_CGROUP)
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("You cannot assign a role to this resource group because "
-					    "the memory_auditor property for this group is not the default.")));
-
-	heap_close(pg_resgroupcapability_rel, AccessShareLock);
-}
-
-/*
  * Get the option type from a name string.
  *
  * @param defname  the name string
@@ -708,8 +663,6 @@ getResgroupOptionType(const char* defname)
 		return RESGROUP_LIMIT_TYPE_MEMORY_SHARED_QUOTA;
 	else if (strcmp(defname, "memory_spill_ratio") == 0)
 		return RESGROUP_LIMIT_TYPE_MEMORY_SPILL_RATIO;
-	else if (strcmp(defname, "memory_auditor") == 0)
-		return RESGROUP_LIMIT_TYPE_MEMORY_AUDITOR;
 	else
 		return RESGROUP_LIMIT_TYPE_UNKNOWN;
 }
@@ -718,20 +671,9 @@ getResgroupOptionType(const char* defname)
  * Get capability value from DefElem, convert from int64 to int
  */
 static ResGroupCap
-getResgroupOptionValue(DefElem *defel, int type)
+getResgroupOptionValue(DefElem *defel)
 {
-	int64 value;
-
-	if (type == RESGROUP_LIMIT_TYPE_MEMORY_AUDITOR)
-	{
-		char *auditor_name = defGetString(defel);
-		value = getResGroupMemAuditor(auditor_name);
-	}
-	else
-	{
-		value = defGetInt64(defel);
-	}
-
+	int64 value = defGetInt64(defel);
 	if (value < INT_MIN || value > INT_MAX)
 		ereport(ERROR,
 				(errcode(ERRCODE_SYNTAX_ERROR),
@@ -823,35 +765,10 @@ checkResgroupCapLimit(ResGroupLimitType type, int value)
 								   RESGROUP_MAX_MEMORY_SPILL_RATIO)));
 				break;
 
-			case RESGROUP_LIMIT_TYPE_MEMORY_AUDITOR:
-				if (value != RESGROUP_MEMORY_AUDITOR_VMTRACKER &&
-					value != RESGROUP_MEMORY_AUDITOR_CGROUP)
-					ereport(ERROR,
-							(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-							errmsg("memory_auditor should be \"%s\" or \"%s\"",
-								   ResGroupMemAuditorName[RESGROUP_MEMORY_AUDITOR_VMTRACKER],
-								   ResGroupMemAuditorName[RESGROUP_MEMORY_AUDITOR_CGROUP])));
-				break;
-
 			default:
 				Assert(!"unexpected options");
 				break;
 		}
-}
-
-/*
- * Check to see if concurrency is not zero for resource group
- * with cgroup memory auditor.
- */
-static void
-checkResgroupMemAuditor(ResGroupCaps *caps)
-{
-	if (caps->memAuditor == RESGROUP_MEMORY_AUDITOR_CGROUP &&
-		caps->concurrency != 0)
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				errmsg("resource group concurrency must be 0 when group memory_auditor is %s",
-					ResGroupMemAuditorName[RESGROUP_MEMORY_AUDITOR_CGROUP])));
 }
 
 /*
@@ -886,7 +803,7 @@ parseStmtOptions(CreateResourceGroupStmt *stmt, ResGroupCaps *caps)
 		else
 			mask |= 1 << type;
 
-		value = getResgroupOptionValue(defel, type);
+		value = getResgroupOptionValue(defel);
 		checkResgroupCapLimit(type, value);
 
 		capArray[type] = value;
@@ -906,11 +823,6 @@ parseStmtOptions(CreateResourceGroupStmt *stmt, ResGroupCaps *caps)
 
 	if (!(mask & (1 << RESGROUP_LIMIT_TYPE_MEMORY_SPILL_RATIO)))
 		caps->memSpillRatio = RESGROUP_DEFAULT_MEM_SPILL_RATIO;
-
-	if (!(mask & (1 << RESGROUP_LIMIT_TYPE_MEMORY_AUDITOR)))
-		caps->memAuditor = RESGROUP_DEFAULT_MEM_AUDITOR;
-
-	checkResgroupMemAuditor(caps);
 }
 
 /*
@@ -963,8 +875,7 @@ alterResgroupCallback(XactEvent event, void *arg)
 		(ResourceGroupAlterCallbackContext *) arg;
 
 	if (event == XACT_EVENT_COMMIT)
-		ResGroupAlterOnCommit(ctx->groupid, ctx->limittype, &ctx->caps,
-				ctx->memLimitGap);
+		ResGroupAlterOnCommit(ctx->groupid, ctx->limittype, &ctx->caps);
 
 	pfree(arg);
 }
@@ -1007,10 +918,6 @@ insertResgroupCapabilities(Relation rel, Oid groupId, ResGroupCaps *caps)
 	sprintf(value, "%d", caps->memSpillRatio);
 	insertResgroupCapabilityEntry(rel, groupId,
 								  RESGROUP_LIMIT_TYPE_MEMORY_SPILL_RATIO, value);
-
-	sprintf(value, "%d", caps->memAuditor);
-	insertResgroupCapabilityEntry(rel, groupId,
-								  RESGROUP_LIMIT_TYPE_MEMORY_AUDITOR, value);
 }
 
 /*
@@ -1272,21 +1179,4 @@ str2Int(const char *str, const char *prop)
 				errmsg("%s requires a numeric value", prop)));
 
 	return floor(val);
-}
-
-/*
- * Get memory auditor from auditor name.
- */
-static int
-getResGroupMemAuditor(char *name)
-{
-	int index;
-
-	for (index = 0; index < RESGROUP_MEMORY_AUDITOR_COUNT; index ++)
-	{
-		if (strcmp(ResGroupMemAuditorName[index], name) == 0)
-			return index;
-	}
-
-	return RESGROUP_INVALID_MEM_AUDITOR;
 }

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -528,22 +528,6 @@ GetResGroupCapabilities(Relation rel, Oid groupId, ResGroupCaps *resgroupCaps)
 	}
 }
 
-
-/*
- * GetResGroupMemAuditorForId -- Return the resource group memory auditor
- * for a groupId
- */
-int32
-GetResGroupMemAuditorForId(Oid groupId, LOCKMODE lockmode)
-{
-	ResGroupCaps		caps;
-	Relation pg_resgroupcapability_rel = heap_open(
-			ResGroupCapabilityRelationId, lockmode);
-	GetResGroupCapabilities(pg_resgroupcapability_rel, groupId, &caps);
-	heap_close(pg_resgroupcapability_rel, lockmode);
-	return caps.memAuditor;
-}
-
 /*
  * Get resource group id for a role in pg_authid.
  *

--- a/src/backend/commands/user.c
+++ b/src/backend/commands/user.c
@@ -544,8 +544,6 @@ CreateRole(CreateRoleStmt *stmt)
 					(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 					 errmsg("only superuser can be assigned to admin resgroup")));
 
-		ResGroupCheckForRole(rsgid);
-
 		new_record[Anum_pg_authid_rolresgroup - 1] = ObjectIdGetDatum(rsgid);
 		if (!IsResGroupActivated() && Gp_role == GP_ROLE_DISPATCH)
 			ereport(WARNING,
@@ -1205,7 +1203,6 @@ AlterRole(AlterRoleStmt *stmt)
 			ereport(ERROR,
 					(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 					 errmsg("only superuser can be assigned to admin resgroup")));
-		ResGroupCheckForRole(rsgid);
 		new_record[Anum_pg_authid_rolresgroup - 1] =
 			ObjectIdGetDatum(rsgid);
 		new_record_repl[Anum_pg_authid_rolresgroup - 1] = true;

--- a/src/backend/utils/mmgr/vmem_tracker.c
+++ b/src/backend/utils/mmgr/vmem_tracker.c
@@ -370,13 +370,6 @@ VmemTracker_ConvertVmemChunksToBytes(int chunks)
 	return CHUNKS_TO_BYTES(chunks);
 }
 
-/* Converts bytes to chunks */
-int32
-VmemTracker_ConvertVmemBytesToChunks(int64 bytes)
-{
-	return BYTES_TO_CHUNKS(bytes);
-}
-
 /*
  * Returns the maximum vmem consumed by current process in "chunks" unit.
  */

--- a/src/backend/utils/resgroup/resgroup-ops-dummy.c
+++ b/src/backend/utils/resgroup/resgroup-ops-dummy.c
@@ -101,7 +101,7 @@ ResGroupOps_AssignGroup(Oid group, int pid)
  * ResGroupOps_UnLockGroup() to unblock it.
  */
 int
-ResGroupOps_LockGroup(Oid group, const char *comp, bool block)
+ResGroupOps_LockGroup(Oid group, bool block)
 {
 	unsupported_system();
 	return -1;
@@ -130,57 +130,11 @@ ResGroupOps_SetCpuRateLimit(Oid group, int cpu_rate_limit)
 }
 
 /*
- * Set the memory limit for the OS group by rate.
- *
- * memory_limit should be within [0, 100].
- */
-void
-ResGroupOps_SetMemoryLimit(Oid group, int memory_limit)
-{
-	unsupported_system();
-}
-
-/*
- * Set the memory limit for the OS group by value.
- *
- * memory_limit is the limit value in chunks
- */
-void
-ResGroupOps_SetMemoryLimitByValue(Oid group, int32 memory_limit)
-{
-	unsupported_system();
-}
-
-/*
  * Get the cpu usage of the OS group, that is the total cpu time obtained
  * by this OS group, in nano seconds.
  */
 int64
 ResGroupOps_GetCpuUsage(Oid group)
-{
-	unsupported_system();
-	return 0;
-}
-
-/*
- * Get the memory usage of the OS group
- *
- * memory usage is returned in chunks
- */
-int32
-ResGroupOps_GetMemoryUsage(Oid group)
-{
-	unsupported_system();
-	return 0;
-}
-
-/*
- * Get the memory limit of the OS group
- *
- * memory limit is returned in chunks
- */
-int32
-ResGroupOps_GetMemoryLimit(Oid group)
 {
 	unsupported_system();
 	return 0;

--- a/src/backend/utils/resgroup/resgroup-ops-linux.c
+++ b/src/backend/utils/resgroup/resgroup-ops-linux.c
@@ -54,7 +54,7 @@ static char * buildPath(Oid group, const char *base, const char *comp, const cha
 static int lockDir(const char *path, bool block);
 static void unassignGroup(Oid group, const char *comp, int fddir);
 static bool createDir(Oid group, const char *comp);
-static bool removeDir(Oid group, const char *comp, const char *prop, bool unassign);
+static bool removeDir(Oid group, const char *comp, bool unassign);
 static int getCpuCores(void);
 static size_t readData(const char *path, char *data, size_t datasize);
 static void writeData(const char *path, char *data, size_t datasize);
@@ -65,11 +65,9 @@ static void getMemoryInfo(unsigned long *ram, unsigned long *swap);
 static void getCgMemoryInfo(uint64 *cgram, uint64 *cgmemsw);
 static int getOvercommitRatio(void);
 static void detectCgroupMountPoint(void);
-static void detectCgroupMemSwap(void);
 
 static Oid currentGroupIdInCGroup = InvalidOid;
 static char cgdir[MAXPGPATH];
-static bool cgmemswap = false;
 
 /*
  * Build path string with parameters.
@@ -241,7 +239,7 @@ lockDir(const char *path, bool block)
 	}
 
 	int flags = LOCK_EX;
-	if (!block)
+	if (block)
 		flags |= LOCK_NB;
 
 	while (flock(fddir, flags))
@@ -319,7 +317,7 @@ createDir(Oid group, const char *comp)
  * - if unassign is true then unassign all the processes first before removal;
  */
 static bool
-removeDir(Oid group, const char *comp, const char *prop, bool unassign)
+removeDir(Oid group, const char *comp, bool unassign)
 {
 	char path[MAXPGPATH];
 	size_t pathsize = sizeof(path);
@@ -337,12 +335,6 @@ removeDir(Oid group, const char *comp, const char *prop, bool unassign)
 		/* the dir is already removed */
 		return true;
 	}
-
-	/*
-	 * Reset the corresponding control file to zero
-	 */
-	if (prop)
-		writeInt64(group, NULL, comp, prop, 0);
 
 	if (unassign)
 		unassignGroup(group, comp, fddir);
@@ -539,18 +531,6 @@ checkPermission(Oid group, bool report)
 	__CHECK("cpuacct.usage", R_OK);
 	__CHECK("cpuacct.stat", R_OK);
 
-	comp = "memory";
-
-	__CHECK("", R_OK | W_OK | X_OK);
-	__CHECK("memory.limit_in_bytes", R_OK | W_OK);
-	__CHECK("memory.usage_in_bytes", R_OK);
-
-	if (cgmemswap)
-	{
-		__CHECK("memory.memsw.limit_in_bytes", R_OK | W_OK);
-		__CHECK("memory.memsw.usage_in_bytes", R_OK);
-	}
-
 #undef __CHECK
 
 	return true;
@@ -590,24 +570,6 @@ getOvercommitRatio(void)
 		elog(ERROR, "invalid number '%s' in '%s'", data, path);
 
 	return ratio;
-}
-
-/*
- * detect if cgroup supports swap memory limit
- */
-static void
-detectCgroupMemSwap(void)
-{
-	char path[MAXPGPATH];
-	size_t pathsize = sizeof(path);
-
-	buildPath(RESGROUP_ROOT_ID, "",
-			"memory", "memory.memsw.limit_in_bytes", path, pathsize);
-
-	if (access(path, F_OK))
-		cgmemswap = false;
-	else
-		cgmemswap = true;
 }
 
 /* detect cgroup mount point */
@@ -667,7 +629,6 @@ ResGroupOps_Bless(void)
 		return;
 
 	detectCgroupMountPoint();
-	detectCgroupMemSwap();
 	checkPermission(RESGROUP_ROOT_ID, true);
 
 	/*
@@ -729,9 +690,7 @@ ResGroupOps_CreateGroup(Oid group)
 {
 	int retry = 0;
 
-	if (!createDir(group, "cpu")
-		|| !createDir(group, "cpuacct")
-		|| !createDir(group, "memory"))
+	if (!createDir(group, "cpu") || !createDir(group, "cpuacct"))
 	{
 		CGROUP_ERROR("can't create cgroup for resgroup '%d': %s",
 					 group, strerror(errno));
@@ -762,9 +721,7 @@ ResGroupOps_CreateGroup(Oid group)
 void
 ResGroupOps_DestroyGroup(Oid group)
 {
-	if (!removeDir(group, "cpu", "cpu.shares", true)
-		|| !removeDir(group, "cpuacct", NULL, true)
-		|| !removeDir(group, "memory", "memory.limit_in_bytes", true))
+	if (!removeDir(group, "cpu", true) || !removeDir(group, "cpuacct", true))
 	{
 		CGROUP_ERROR("can't remove cgroup for resgroup '%d': %s",
 			 group, strerror(errno));
@@ -787,10 +744,6 @@ ResGroupOps_AssignGroup(Oid group, int pid)
 	writeInt64(group, NULL, "cpu", "cgroup.procs", pid);
 	writeInt64(group, NULL, "cpuacct", "cgroup.procs", pid);
 
-	/*
-	 * Do not assign the process to cgroup/memory for now.
-	 */
-
 	currentGroupIdInCGroup = group;
 }
 
@@ -805,12 +758,12 @@ ResGroupOps_AssignGroup(Oid group, int pid)
  * ResGroupOps_UnLockGroup() to unblock it.
  */
 int
-ResGroupOps_LockGroup(Oid group, const char *comp, bool block)
+ResGroupOps_LockGroup(Oid group, bool block)
 {
 	char path[MAXPGPATH];
 	size_t pathsize = sizeof(path);
 
-	buildPath(group, NULL, comp, "", path, pathsize);
+	buildPath(group, NULL, "cpu", "", path, pathsize);
 
 	return lockDir(path, block);
 }
@@ -844,73 +797,6 @@ ResGroupOps_SetCpuRateLimit(Oid group, int cpu_rate_limit)
 }
 
 /*
- * Set the memory limit for the OS group by rate.
- *
- * memory_limit should be within [0, 100].
- */
-void
-ResGroupOps_SetMemoryLimit(Oid group, int memory_limit)
-{
-	int fd;
-	int32 memory_limit_in_chunks;
-
-	memory_limit_in_chunks = ResGroupGetVmemLimitChunks() * memory_limit / 100;
-	memory_limit_in_chunks *= ResGroupGetSegmentNum();
-
-	fd = ResGroupOps_LockGroup(group, "memory", true);
-	ResGroupOps_SetMemoryLimitByValue(group, memory_limit_in_chunks);
-	ResGroupOps_UnLockGroup(group, fd);
-}
-
-/*
- * Set the memory limit for the OS group by value.
- *
- * memory_limit is the limit value in chunks
- *
- * If cgroup supports memory swap, we will write the same limit to
- * memory.memsw.limit and memory.limit.
- */
-void
-ResGroupOps_SetMemoryLimitByValue(Oid group, int32 memory_limit)
-{
-	const char *comp = "memory";
-	int64 memory_limit_in_bytes;
-
-	memory_limit_in_bytes = VmemTracker_ConvertVmemChunksToBytes(memory_limit);
-
-	if (cgmemswap == false)
-	{
-		writeInt64(group, NULL, comp, "memory.limit_in_bytes",
-				memory_limit_in_bytes);
-	}
-	else
-	{
-		int64 memory_limit_in_bytes_old;
-
-		memory_limit_in_bytes_old = readInt64(group, NULL,
-				comp, "memory.limit_in_bytes");
-
-		if (memory_limit_in_bytes == memory_limit_in_bytes_old)
-			return;
-
-		if (memory_limit_in_bytes > memory_limit_in_bytes_old)
-		{
-			writeInt64(group, NULL, comp, "memory.memsw.limit_in_bytes",
-					memory_limit_in_bytes);
-			writeInt64(group, NULL, comp, "memory.limit_in_bytes",
-					memory_limit_in_bytes);
-		}
-		else
-		{
-			writeInt64(group, NULL, comp, "memory.limit_in_bytes",
-					memory_limit_in_bytes);
-			writeInt64(group, NULL, comp, "memory.memsw.limit_in_bytes",
-					memory_limit_in_bytes);
-		}
-	}
-}
-
-/*
  * Get the cpu usage of the OS group, that is the total cpu time obtained
  * by this OS group, in nano seconds.
  */
@@ -920,42 +806,6 @@ ResGroupOps_GetCpuUsage(Oid group)
 	const char *comp = "cpuacct";
 
 	return readInt64(group, NULL, comp, "cpuacct.usage");
-}
-
-/*
- * Get the memory usage of the OS group
- *
- * memory usage is returned in chunks
- */
-int32
-ResGroupOps_GetMemoryUsage(Oid group)
-{
-	const char *comp = "memory";
-	int64 memory_usage_in_bytes;
-	char *prop;
-
-	prop = cgmemswap ? "memory.memsw.usage_in_bytes" : "memory.usage_in_bytes";
-
-	memory_usage_in_bytes = readInt64(group, NULL, comp, prop);
-
-	return VmemTracker_ConvertVmemBytesToChunks(memory_usage_in_bytes);
-}
-
-/*
- * Get the memory limit of the OS group
- *
- * memory limit is returned in chunks
- */
-int32
-ResGroupOps_GetMemoryLimit(Oid group)
-{
-	const char *comp = "memory";
-	int64 memory_limit_in_bytes;
-
-	memory_limit_in_bytes = readInt64(group, NULL,
-			comp, "memory.limit_in_bytes");
-
-	return VmemTracker_ConvertVmemBytesToChunks(memory_limit_in_bytes);
 }
 
 /*

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -147,20 +147,6 @@ struct ResGroupSlotData
 };
 
 /*
- * Resource group operations for memory.
- *
- * Groups with different memory auditor will have different
- * operations.
- */
-typedef struct ResGroupMemOperations
-{
-	void (*group_mem_on_create) (Oid groupId, ResGroupData *group);
-	void (*group_mem_on_alter) (Oid groupId, ResGroupData *group);
-	void (*group_mem_on_drop) (Oid groupId, ResGroupData *group);
-	void (*group_mem_on_notify) (ResGroupData *group);
-} ResGroupMemOperations;
-
-/*
  * Resource group information.
  */
 struct ResGroupData
@@ -175,15 +161,6 @@ struct ResGroupData
 
 	bool		lockedForDrop;  /* true if resource group is dropped but not committed yet */
 
-	/*
-	 * memGap is calculated as:
-	 * 	(memory limit (before alter) - memory expected (after alter))
-	 *
-	 * It stands for how many memory (in chunks) this group should
-	 * give back to MEM POOL.
-	 */
-	int32       memGap;
-
 	int32		memExpected;		/* expected memory chunks according to current caps */
 	int32		memQuotaGranted;	/* memory chunks for quota part */
 	int32		memSharedGranted;	/* memory chunks for shared part */
@@ -197,11 +174,6 @@ struct ResGroupData
 	 */
 	int32		memUsage;
 	int32		memSharedUsage;
-
-	/*
-	 * operation functions for resource group
-	 */
-	const ResGroupMemOperations *groupMemOps;
 };
 
 struct ResGroupControl
@@ -260,15 +232,14 @@ static int32 slotGetMemQuotaExpected(const ResGroupCaps *caps);
 static int32 slotGetMemQuotaOnQE(const ResGroupCaps *caps, ResGroupData *group);
 static int32 slotGetMemSpill(const ResGroupCaps *caps);
 static void wakeupSlots(ResGroupData *group, bool grant);
-static void notifyGroupsOnMem(Oid skipGroupId);
+static void wakeupGroups(Oid skipGroupId);
 static int32 mempoolAutoRelease(ResGroupData *group);
 static int32 mempoolAutoReserve(ResGroupData *group, const ResGroupCaps *caps);
 static ResGroupData *groupHashNew(Oid groupId);
 static ResGroupData *groupHashFind(Oid groupId, bool raise);
-static ResGroupData *groupHashRemove(Oid groupId);
+static void groupHashRemove(Oid groupId);
 static void waitOnGroup(ResGroupData *group);
 static ResGroupData *createGroup(Oid groupId, const ResGroupCaps *caps);
-static void removeGroup(Oid groupId);
 static void AtProcExit_ResGroup(int code, Datum arg);
 static void groupWaitCancel(void);
 static int32 groupReserveMemQuota(ResGroupData *group);
@@ -324,17 +295,6 @@ static void sessionSetSlot(ResGroupSlotData *slot);
 static ResGroupSlotData *sessionGetSlot(void);
 static void sessionResetSlot(void);
 
-static void bindGroupOperation(ResGroupData *group);
-static void groupMemOnAlterForVmtracker(Oid groupId, ResGroupData *group);
-static void groupMemOnDropForVmtracker(Oid groupId, ResGroupData *group);
-static void groupMemOnNotifyForVmtracker(ResGroupData *group);
-
-static void groupMemOnAlterForCgroup(Oid groupId, ResGroupData *group);
-static void groupMemOnDropForCgroup(Oid groupId, ResGroupData *group);
-static void groupMemOnNotifyForCgroup(ResGroupData *group);
-static void groupApplyCgroupMemInc(ResGroupData *group);
-static void groupApplyCgroupMemDec(ResGroupData *group);
-
 #ifdef USE_ASSERT_CHECKING
 static bool selfHasGroup(void);
 static bool selfHasSlot(void);
@@ -344,26 +304,6 @@ static bool slotIsInUse(const ResGroupSlotData *slot);
 static bool groupIsNotDropped(const ResGroupData *group);
 static bool groupWaitQueueFind(ResGroupData *group, const PGPROC *proc);
 #endif /* USE_ASSERT_CHECKING */
-
-/*
- * Operations of memory for resource groups with vmtracker memory auditor.
- */
-static const ResGroupMemOperations resgroup_memory_operations_vmtracker = {
-	.group_mem_on_create	= NULL,
-	.group_mem_on_alter		= groupMemOnAlterForVmtracker,
-	.group_mem_on_drop		= groupMemOnDropForVmtracker,
-	.group_mem_on_notify	= groupMemOnNotifyForVmtracker,
-};
-
-/*
- * Operations of memory for resource groups with cgroup memory auditor.
- */
-static const ResGroupMemOperations resgroup_memory_operations_cgroup = {
-	.group_mem_on_create	= NULL,
-	.group_mem_on_alter		= groupMemOnAlterForCgroup,
-	.group_mem_on_drop		= groupMemOnDropForCgroup,
-	.group_mem_on_notify	= groupMemOnNotifyForCgroup,
-};
 
 /*
  * Estimate size the resource group structures will need in
@@ -552,7 +492,6 @@ InitResGroups(void)
 
 		ResGroupOps_CreateGroup(groupId);
 		ResGroupOps_SetCpuRateLimit(groupId, cpuRateLimit);
-		ResGroupOps_SetMemoryLimit(groupId, caps.memLimit);
 
 		numGroups++;
 		Assert(numGroups <= MaxResourceGroups);
@@ -641,7 +580,7 @@ ResGroupDropFinish(Oid groupId, bool isCommit)
 
 		if (isCommit)
 		{
-			removeGroup(groupId);
+			groupHashRemove(groupId);
 			ResGroupOps_DestroyGroup(groupId);
 		}
 	}
@@ -678,7 +617,7 @@ ResGroupCreateOnAbort(Oid groupId)
 	PG_TRY();
 	{
 		savedInterruptHoldoffCount = InterruptHoldoffCount;
-		removeGroup(groupId);
+		groupHashRemove(groupId);
 		/* remove the os dependent part for this resource group */
 		ResGroupOps_DestroyGroup(groupId);
 	}
@@ -705,10 +644,10 @@ ResGroupCreateOnAbort(Oid groupId)
 void
 ResGroupAlterOnCommit(Oid groupId,
 					  ResGroupLimitType limittype,
-					  const ResGroupCaps *caps,
-					  ResGroupCap memLimitGap)
+					  const ResGroupCaps *caps)
 {
 	ResGroupData	*group;
+	bool			shouldWakeUp;
 	volatile int	savedInterruptHoldoffCount;
 
 	Assert(caps != NULL);
@@ -728,12 +667,11 @@ ResGroupAlterOnCommit(Oid groupId,
 		}
 		else if (limittype != RESGROUP_LIMIT_TYPE_MEMORY_SPILL_RATIO)
 		{
-			Assert(pResGroupControl->totalChunks > 0);
-			group->memGap += pResGroupControl->totalChunks * memLimitGap / 100;
+			shouldWakeUp = groupApplyMemCaps(group);
 
-			Assert(group->groupMemOps != NULL);
-			if (group->groupMemOps->group_mem_on_alter)
-				group->groupMemOps->group_mem_on_alter(groupId, group);
+			wakeupSlots(group, true);
+			if (shouldWakeUp)
+				wakeupGroups(groupId);
 		}
 	}
 	PG_CATCH();
@@ -821,15 +759,6 @@ ResGroupGetStat(Oid groupId, ResGroupStatType type)
 	LWLockRelease(ResGroupLock);
 
 	return result;
-}
-
-/*
- * Get the number of primary segments on this host
- */
-int
-ResGroupGetSegmentNum()
-{
-	return (Gp_role == GP_ROLE_EXECUTE ? host_segments : pResGroupControl->segmentsOnMaster);
 }
 
 static char *
@@ -1029,28 +958,6 @@ ResourceGroupGetQueryMemoryLimit(void)
 }
 
 /*
- * removeGroup -- remove resource group from share memory and
- * reclaim the group's memory back to MEM POOL.
- */
-static void
-removeGroup(Oid groupId)
-{
-	ResGroupData *group;
-
-	Assert(LWLockHeldExclusiveByMe(ResGroupLock));
-	Assert(OidIsValid(groupId));
-
-	group = groupHashRemove(groupId);
-
-	Assert(group->groupMemOps != NULL);
-	if (group->groupMemOps->group_mem_on_drop)
-		group->groupMemOps->group_mem_on_drop(groupId, group);
-
-	group->groupId = InvalidOid;
-	notifyGroupsOnMem(groupId);
-}
-
-/*
  * createGroup -- initialize the elements for a resource group.
  *
  * Notes:
@@ -1075,11 +982,9 @@ createGroup(Oid groupId, const ResGroupCaps *caps)
 	ProcQueueInit(&group->waitProcs);
 	group->totalExecuted = 0;
 	group->totalQueued = 0;
-	group->memGap = 0;
 	group->memUsage = 0;
 	group->memSharedUsage = 0;
 	group->memQuotaUsed = 0;
-	group->groupMemOps = NULL;
 	memset(&group->totalQueuedTime, 0, sizeof(group->totalQueuedTime));
 	group->lockedForDrop = false;
 
@@ -1090,27 +995,7 @@ createGroup(Oid groupId, const ResGroupCaps *caps)
 	chunks = mempoolReserve(groupId, group->memExpected);
 	groupRebalanceQuota(group, chunks, caps);
 
-	bindGroupOperation(group);
-
 	return group;
-}
-
-/*
- * Bind operation to resource group according to memory auditor.
- */
-static void
-bindGroupOperation(ResGroupData *group)
-{
-	Assert(LWLockHeldExclusiveByMe(ResGroupLock));
-
-	if (group->caps.memAuditor == RESGROUP_MEMORY_AUDITOR_VMTRACKER)
-		group->groupMemOps = &resgroup_memory_operations_vmtracker;
-	else if (group->caps.memAuditor == RESGROUP_MEMORY_AUDITOR_CGROUP)
-		group->groupMemOps = &resgroup_memory_operations_cgroup;
-	else
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("invalid memory auditor: %d", group->caps.memAuditor)));
 }
 
 /*
@@ -1371,7 +1256,7 @@ groupPutSlot(ResGroupData *group, ResGroupSlotData *slot)
 	/* And finally release the overused memory quota */
 	released = mempoolAutoRelease(group);
 	if (released > 0)
-		notifyGroupsOnMem(group->groupId);
+		wakeupGroups(group->groupId);
 
 	/*
 	 * Once we have waken up other groups then the slot we just released
@@ -1814,22 +1699,23 @@ wakeupSlots(ResGroupData *group, bool grant)
 }
 
 /*
- * When a group returns chunks to MEM POOL, we need to:
- * 1. For groups with vmtracker memory auditor, wake up the
- *    transactions waiting on them for memory quota.
- * 2. For groups with cgroup memory auditor, increase their
- *    memory limit if needed.
+ * When a group returns chunks to MEM POOL, we need to wake up
+ * the transactions waiting on other groups for memory quota.
  */
 static void
-notifyGroupsOnMem(Oid skipGroupId)
+wakeupGroups(Oid skipGroupId)
 {
 	int				i;
+
+	if (Gp_role != GP_ROLE_DISPATCH)
+		return;
 
 	Assert(LWLockHeldExclusiveByMe(ResGroupLock));
 
 	for (i = 0; i < MaxResourceGroups; i++)
 	{
 		ResGroupData	*group = &pResGroupControl->groups[i];
+		int32			delta;
 
 		if (group->groupId == InvalidOid)
 			continue;
@@ -1837,9 +1723,17 @@ notifyGroupsOnMem(Oid skipGroupId)
 		if (group->groupId == skipGroupId)
 			continue;
 
-		Assert(group->groupMemOps != NULL);
-		if (group->groupMemOps->group_mem_on_notify)
-			group->groupMemOps->group_mem_on_notify(group);
+		if (group->lockedForDrop)
+			continue;
+
+		if (groupWaitQueueIsEmpty(group))
+			continue;
+
+		delta = group->memExpected - group->memQuotaGranted - group->memSharedGranted;
+		if (delta <= 0)
+			continue;
+
+		wakeupSlots(group, true);
 
 		if (!pResGroupControl->freeChunks)
 			break;
@@ -2185,8 +2079,6 @@ UnassignResGroup(void)
 	}
 	else if (slot->nProcs == 0)
 	{
-		int32 released;
-
 		Assert(Gp_role == GP_ROLE_EXECUTE);
 
 		group->memQuotaUsed -= slot->memQuota;
@@ -2201,10 +2093,7 @@ UnassignResGroup(void)
 		group->nRunning--;
 
 		/* And finally release the overused memory quota */
-		released = mempoolAutoRelease(group);
-		if (released > 0)
-			notifyGroupsOnMem(group->groupId);
-
+		mempoolAutoRelease(group);
 	}
 
 	LWLockRelease(ResGroupLock);
@@ -2408,7 +2297,7 @@ groupHashFind(Oid groupId, bool raise)
  *	The resource group lightweight lock (ResGroupLock) *must* be held for
  *	this operation.
  */
-static ResGroupData *
+static void
 groupHashRemove(Oid groupId)
 {
 	bool		found;
@@ -2428,8 +2317,12 @@ groupHashRemove(Oid groupId)
 						groupId)));
 
 	group = &pResGroupControl->groups[entry->index];
+	mempoolRelease(groupId, group->memQuotaGranted + group->memSharedGranted);
+	group->memQuotaGranted = 0;
+	group->memSharedGranted = 0;
+	group->groupId = InvalidOid;
 
-	return group;
+	wakeupGroups(groupId);
 }
 
 /* Process exit without waiting for slot or received SIGTERM */
@@ -3216,178 +3109,4 @@ sessionResetSlot(void)
 	Assert(MySessionState->resGroupSlot != NULL);
 
 	MySessionState->resGroupSlot = NULL;
-}
-
-/*
- * Operation for resource groups with vmtracker memory auditor
- * when alter its memory limit.
- */
-static void
-groupMemOnAlterForVmtracker(Oid groupId, ResGroupData *group)
-{
-	bool shouldNotify;
-
-	Assert(LWLockHeldExclusiveByMe(ResGroupLock));
-
-	shouldNotify = groupApplyMemCaps(group);
-
-	wakeupSlots(group, true);
-	if (shouldNotify)
-		notifyGroupsOnMem(groupId);
-}
-
-/*
- * Operation for resource groups with vmtracker memory auditor
- * when reclaiming its memory back to MEM POOL.
- */
-static void
-groupMemOnDropForVmtracker(Oid groupId, ResGroupData *group)
-{
-	Assert(LWLockHeldExclusiveByMe(ResGroupLock));
-
-	mempoolRelease(groupId, group->memQuotaGranted + group->memSharedGranted);
-	group->memQuotaGranted = 0;
-	group->memSharedGranted = 0;
-}
-
-/*
- * Operation for resource groups with vmtracker memory auditor
- * when memory in MEM POOL is increased.
- */
-static void
-groupMemOnNotifyForVmtracker(ResGroupData *group)
-{
-	int32			delta;
-
-	Assert(LWLockHeldExclusiveByMe(ResGroupLock));
-
-	if (Gp_role != GP_ROLE_DISPATCH)
-		return;
-
-	if (group->lockedForDrop)
-		return;
-
-	if (groupWaitQueueIsEmpty(group))
-		return;
-
-	delta = group->memExpected - group->memQuotaGranted - group->memSharedGranted;
-	if (delta <= 0)
-		return;
-
-	wakeupSlots(group, true);
-}
-
-/*
- * Operation for resource groups with cgroup memory auditor
- * when alter its memory limit.
- */
-static void
-groupMemOnAlterForCgroup(Oid groupId, ResGroupData *group)
-{
-	Assert(LWLockHeldExclusiveByMe(ResGroupLock));
-
-	/*
-	 * If memGap is positive, it indicates this group should
-	 * give back these many memory back to MEM POOL.
-	 *
-	 * If memGap is negative, it indicates this group should
-	 * retrieve these many memory from MEM POOL.
-	 *
-	 * If memGap is zero, this group is holding the same memory
-	 * as it expects.
-	 */
-	if (group->memGap == 0)
-		return;
-
-	if (group->memGap > 0)
-		groupApplyCgroupMemDec(group);
-	else
-		groupApplyCgroupMemInc(group);
-}
-
-/*
- * Increase a resource group's cgroup memory limit
- *
- * This may not take effect immediately.
- */
-static void
-groupApplyCgroupMemInc(ResGroupData *group)
-{
-	int32 memory_limit;
-	int32 memory_inc;
-	int fd;
-
-	Assert(LWLockHeldExclusiveByMe(ResGroupLock));
-	Assert(group->memGap < 0);
-
-	memory_inc = mempoolReserve(group->groupId, group->memGap * -1);
-
-	if (memory_inc <= 0)
-		return;
-
-	fd = ResGroupOps_LockGroup(group->groupId, "memory", true);
-	memory_limit = ResGroupOps_GetMemoryLimit(group->groupId);
-	ResGroupOps_SetMemoryLimitByValue(group->groupId, memory_limit + memory_inc);
-	ResGroupOps_UnLockGroup(group->groupId, fd);
-
-	group->memGap += memory_inc;
-}
-
-/*
- * Decrease a resource group's cgroup memory limit
- *
- * This will take effect immediately for now.
- */
-static void
-groupApplyCgroupMemDec(ResGroupData *group)
-{
-	int32 memory_limit;
-	int32 memory_dec;
-	int fd;
-
-	Assert(LWLockHeldExclusiveByMe(ResGroupLock));
-	Assert(group->memGap > 0);
-
-	fd = ResGroupOps_LockGroup(group->groupId, "memory", true);
-	memory_limit = ResGroupOps_GetMemoryLimit(group->groupId);
-	Assert(memory_limit > group->memGap);
-
-	memory_dec = group->memGap;
-
-	ResGroupOps_SetMemoryLimitByValue(group->groupId, memory_limit - memory_dec);
-	ResGroupOps_UnLockGroup(group->groupId, fd);
-
-	mempoolRelease(group->groupId, memory_dec);
-	notifyGroupsOnMem(group->groupId);
-
-	group->memGap -= memory_dec;
-}
-
-/*
- * Operation for resource groups with cgroup memory auditor
- * when reclaiming its memory back to MEM POOL.
- */
-static void
-groupMemOnDropForCgroup(Oid groupId, ResGroupData *group)
-{
-	int32 memory_expected;
-
-	Assert(LWLockHeldExclusiveByMe(ResGroupLock));
-
-	memory_expected = groupGetMemExpected(&group->caps);
-
-	mempoolRelease(groupId, memory_expected + group->memGap);
-}
-
-/*
- * Operation for resource groups with cgroup memory auditor
- * when memory in MEM POOL is increased.
- */
-static void
-groupMemOnNotifyForCgroup(ResGroupData *group)
-{
-	Assert(LWLockHeldExclusiveByMe(ResGroupLock));
-
-	if (group->memGap < 0)
-		groupApplyCgroupMemInc(group);
 }

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -158,7 +158,6 @@ typedef struct ResGroupMemOperations
 	void (*group_mem_on_alter) (Oid groupId, ResGroupData *group);
 	void (*group_mem_on_drop) (Oid groupId, ResGroupData *group);
 	void (*group_mem_on_notify) (ResGroupData *group);
-	void (*group_mem_on_dump) (ResGroupData *group, StringInfo str);
 } ResGroupMemOperations;
 
 /*
@@ -329,12 +328,10 @@ static void bindGroupOperation(ResGroupData *group);
 static void groupMemOnAlterForVmtracker(Oid groupId, ResGroupData *group);
 static void groupMemOnDropForVmtracker(Oid groupId, ResGroupData *group);
 static void groupMemOnNotifyForVmtracker(ResGroupData *group);
-static void groupMemOnDumpForVmtracker(ResGroupData *group, StringInfo str);
 
 static void groupMemOnAlterForCgroup(Oid groupId, ResGroupData *group);
 static void groupMemOnDropForCgroup(Oid groupId, ResGroupData *group);
 static void groupMemOnNotifyForCgroup(ResGroupData *group);
-static void groupMemOnDumpForCgroup(ResGroupData *group, StringInfo str);
 static void groupApplyCgroupMemInc(ResGroupData *group);
 static void groupApplyCgroupMemDec(ResGroupData *group);
 
@@ -356,7 +353,6 @@ static const ResGroupMemOperations resgroup_memory_operations_vmtracker = {
 	.group_mem_on_alter		= groupMemOnAlterForVmtracker,
 	.group_mem_on_drop		= groupMemOnDropForVmtracker,
 	.group_mem_on_notify	= groupMemOnNotifyForVmtracker,
-	.group_mem_on_dump		= groupMemOnDumpForVmtracker,
 };
 
 /*
@@ -367,7 +363,6 @@ static const ResGroupMemOperations resgroup_memory_operations_cgroup = {
 	.group_mem_on_alter		= groupMemOnAlterForCgroup,
 	.group_mem_on_drop		= groupMemOnDropForCgroup,
 	.group_mem_on_notify	= groupMemOnNotifyForCgroup,
-	.group_mem_on_dump		= groupMemOnDumpForCgroup,
 };
 
 /*
@@ -844,9 +839,33 @@ groupDumpMemUsage(ResGroupData *group)
 
 	initStringInfo(&memUsage);
 
-	Assert(group->groupMemOps != NULL);
-	if (group->groupMemOps->group_mem_on_dump)
-		group->groupMemOps->group_mem_on_dump(group, &memUsage);
+	appendStringInfo(&memUsage, "{");
+	appendStringInfo(&memUsage, "\"used\":%d, ",
+					 VmemTracker_ConvertVmemChunksToMB(group->memUsage));
+	appendStringInfo(&memUsage, "\"available\":%d, ",
+					 VmemTracker_ConvertVmemChunksToMB(
+						group->memQuotaGranted + group->memSharedGranted - group->memUsage));
+	appendStringInfo(&memUsage, "\"quota_used\":%d, ",
+					 VmemTracker_ConvertVmemChunksToMB(group->memQuotaUsed));
+	appendStringInfo(&memUsage, "\"quota_available\":%d, ",
+					 VmemTracker_ConvertVmemChunksToMB(
+						group->memQuotaGranted - group->memQuotaUsed));
+	appendStringInfo(&memUsage, "\"quota_granted\":%d, ",
+					 VmemTracker_ConvertVmemChunksToMB(group->memQuotaGranted));
+	appendStringInfo(&memUsage, "\"quota_proposed\":%d, ",
+					 VmemTracker_ConvertVmemChunksToMB(
+						groupGetMemQuotaExpected(&group->caps)));
+	appendStringInfo(&memUsage, "\"shared_used\":%d, ",
+					 VmemTracker_ConvertVmemChunksToMB(group->memSharedUsage));
+	appendStringInfo(&memUsage, "\"shared_available\":%d, ",
+					 VmemTracker_ConvertVmemChunksToMB(
+						group->memSharedGranted - group->memSharedUsage));
+	appendStringInfo(&memUsage, "\"shared_granted\":%d, ",
+					 VmemTracker_ConvertVmemChunksToMB(group->memSharedGranted));
+	appendStringInfo(&memUsage, "\"shared_proposed\":%d",
+					 VmemTracker_ConvertVmemChunksToMB(
+						groupGetMemSharedExpected(&group->caps)));
+	appendStringInfo(&memUsage, "}");
 
 	return memUsage.data;
 }
@@ -3259,42 +3278,6 @@ groupMemOnNotifyForVmtracker(ResGroupData *group)
 }
 
 /*
- * Operation for resource groups with vmtracker memory auditor
- * when dump memory statistics.
- */
-static void
-groupMemOnDumpForVmtracker(ResGroupData *group, StringInfo str)
-{
-	appendStringInfo(str, "{");
-	appendStringInfo(str, "\"used\":%d, ",
-			VmemTracker_ConvertVmemChunksToMB(group->memUsage));
-	appendStringInfo(str, "\"available\":%d, ",
-			VmemTracker_ConvertVmemChunksToMB(
-				group->memQuotaGranted + group->memSharedGranted - group->memUsage));
-	appendStringInfo(str, "\"quota_used\":%d, ",
-			VmemTracker_ConvertVmemChunksToMB(group->memQuotaUsed));
-	appendStringInfo(str, "\"quota_available\":%d, ",
-			VmemTracker_ConvertVmemChunksToMB(
-				group->memQuotaGranted - group->memQuotaUsed));
-	appendStringInfo(str, "\"quota_granted\":%d, ",
-			VmemTracker_ConvertVmemChunksToMB(group->memQuotaGranted));
-	appendStringInfo(str, "\"quota_proposed\":%d, ",
-			VmemTracker_ConvertVmemChunksToMB(
-				groupGetMemQuotaExpected(&group->caps)));
-	appendStringInfo(str, "\"shared_used\":%d, ",
-			VmemTracker_ConvertVmemChunksToMB(group->memSharedUsage));
-	appendStringInfo(str, "\"shared_available\":%d, ",
-			VmemTracker_ConvertVmemChunksToMB(
-				group->memSharedGranted - group->memSharedUsage));
-	appendStringInfo(str, "\"shared_granted\":%d, ",
-			VmemTracker_ConvertVmemChunksToMB(group->memSharedGranted));
-	appendStringInfo(str, "\"shared_proposed\":%d",
-			VmemTracker_ConvertVmemChunksToMB(
-				groupGetMemSharedExpected(&group->caps)));
-	appendStringInfo(str, "}");
-}
-
-/*
  * Operation for resource groups with cgroup memory auditor
  * when alter its memory limit.
  */
@@ -3407,21 +3390,4 @@ groupMemOnNotifyForCgroup(ResGroupData *group)
 
 	if (group->memGap < 0)
 		groupApplyCgroupMemInc(group);
-}
-
-/*
- * Operation for resource groups with cgroup memory auditor
- * when dump memory statistics.
- */
-static void
-groupMemOnDumpForCgroup(ResGroupData *group, StringInfo str)
-{
-	appendStringInfo(str, "{");
-	appendStringInfo(str, "\"usage\":%d, ",
-			VmemTracker_ConvertVmemChunksToMB(
-				ResGroupOps_GetMemoryUsage(group->groupId) / ResGroupGetSegmentNum()));
-	appendStringInfo(str, "\"limit\":%d",
-			VmemTracker_ConvertVmemChunksToMB(
-				ResGroupOps_GetMemoryLimit(group->groupId) / ResGroupGetSegmentNum()));
-	appendStringInfo(str, "}");
 }

--- a/src/include/catalog/pg_resgroup.h
+++ b/src/include/catalog/pg_resgroup.h
@@ -73,7 +73,6 @@ typedef enum ResGroupLimitType
 	RESGROUP_LIMIT_TYPE_MEMORY,
 	RESGROUP_LIMIT_TYPE_MEMORY_SHARED_QUOTA,
 	RESGROUP_LIMIT_TYPE_MEMORY_SPILL_RATIO,
-	RESGROUP_LIMIT_TYPE_MEMORY_AUDITOR,
 
 	RESGROUP_LIMIT_TYPE_COUNT,
 } ResGroupLimitType;
@@ -122,8 +121,6 @@ DATA(insert ( 6437, 4, 50, 50 ));
 
 DATA(insert ( 6437, 5, 20, 20 ));
 
-DATA(insert ( 6437, 6, 0, 0 ));
-
 DATA(insert ( 6438, 1, 10, 10 ));
 
 DATA(insert ( 6438, 2, 10, 10 ));
@@ -133,7 +130,5 @@ DATA(insert ( 6438, 3, 10, 10 ));
 DATA(insert ( 6438, 4, 50, 50 ));
 
 DATA(insert ( 6438, 5, 20, 20 ));
-
-DATA(insert ( 6438, 6, 0, 0 ));
 
 #endif   /* PG_RESGROUP_H */

--- a/src/include/commands/resgroupcmds.h
+++ b/src/include/commands/resgroupcmds.h
@@ -40,6 +40,4 @@ extern void GetResGroupCapabilities(Relation rel,
 									ResGroupCaps *resgroupCaps);
 extern void ResGroupCheckForRole(Oid groupId);
 
-extern int32 GetResGroupMemAuditorForId(Oid groupId, LOCKMODE lockmode);
-
 #endif   /* RESGROUPCMDS_H */

--- a/src/include/commands/resgroupcmds.h
+++ b/src/include/commands/resgroupcmds.h
@@ -19,14 +19,6 @@
 #include "utils/resgroup.h"
 #include "utils/relcache.h"
 
-typedef enum ResGroupMemAuditorType
-{
-	RESGROUP_MEMORY_AUDITOR_VMTRACKER = 0,
-	RESGROUP_MEMORY_AUDITOR_CGROUP,
-
-	RESGROUP_MEMORY_AUDITOR_COUNT,
-} ResGroupMemAuditorType;
-
 extern void CreateResourceGroup(CreateResourceGroupStmt *stmt);
 extern void DropResourceGroup(DropResourceGroupStmt *stmt);
 extern void AlterResourceGroup(AlterResourceGroupStmt *stmt);
@@ -38,6 +30,4 @@ extern Oid GetResGroupIdForRole(Oid roleid);
 extern void GetResGroupCapabilities(Relation rel,
 									Oid groupId,
 									ResGroupCaps *resgroupCaps);
-extern void ResGroupCheckForRole(Oid groupId);
-
 #endif   /* RESGROUPCMDS_H */

--- a/src/include/utils/resgroup-ops.h
+++ b/src/include/utils/resgroup-ops.h
@@ -26,14 +26,10 @@ extern void ResGroupOps_AdjustGUCs(void);
 extern void ResGroupOps_CreateGroup(Oid group);
 extern void ResGroupOps_DestroyGroup(Oid group);
 extern void ResGroupOps_AssignGroup(Oid group, int pid);
-extern int ResGroupOps_LockGroup(Oid group, const char *comp, bool block);
+extern int ResGroupOps_LockGroup(Oid group, bool block);
 extern void ResGroupOps_UnLockGroup(Oid group, int fd);
 extern void ResGroupOps_SetCpuRateLimit(Oid group, int cpu_rate_limit);
-extern void ResGroupOps_SetMemoryLimit(Oid group, int memory_limit);
-extern void ResGroupOps_SetMemoryLimitByValue(Oid group, int32 memory_limit);
 extern int64 ResGroupOps_GetCpuUsage(Oid group);
-extern int32 ResGroupOps_GetMemoryUsage(Oid group);
-extern int32 ResGroupOps_GetMemoryLimit(Oid group);
 extern int ResGroupOps_GetCpuCores(void);
 extern int ResGroupOps_GetTotalMemory(void);
 

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -54,7 +54,6 @@ typedef struct ResGroupCaps
 	ResGroupCap		memLimit;
 	ResGroupCap		memSharedQuota;
 	ResGroupCap		memSpillRatio;
-	ResGroupCap		memAuditor;
 } ResGroupCaps;
 
 /*
@@ -128,8 +127,7 @@ extern void ResGroupDropFinish(Oid groupId, bool isCommit);
 extern void ResGroupCreateOnAbort(Oid groupId);
 extern void ResGroupAlterOnCommit(Oid groupId,
 								  ResGroupLimitType limittype,
-								  const ResGroupCaps *caps,
-								  ResGroupCap memLimitGap);
+								  const ResGroupCaps *caps);
 extern void ResGroupCheckForDrop(Oid groupId, char *name);
 
 extern int32 ResGroupGetVmemLimitChunks(void);
@@ -142,8 +140,6 @@ extern void ResGroupGetMemInfo(int *memLimit, int *slotQuota, int *sharedQuota);
 extern int64 ResourceGroupGetQueryMemoryLimit(void);
 
 extern void ResGroupDumpInfo(StringInfo str);
-
-extern int ResGroupGetSegmentNum(void);
 
 #define LOG_RESGROUP_DEBUG(...) \
 	do {if (Debug_resource_group) elog(__VA_ARGS__); } while(false);

--- a/src/include/utils/vmem_tracker.h
+++ b/src/include/utils/vmem_tracker.h
@@ -43,7 +43,6 @@ extern int runaway_detector_activation_percent;
 extern int32 VmemTracker_ConvertVmemChunksToMB(int chunks);
 extern int32 VmemTracker_ConvertVmemMBToChunks(int mb);
 extern int64 VmemTracker_ConvertVmemChunksToBytes(int chunks);
-extern int32 VmemTracker_ConvertVmemBytesToChunks(int64 bytes);
 extern int32 VmemTracker_GetReservedVmemChunks(void);
 extern int64 VmemTracker_GetReservedVmemBytes(void);
 extern int64 VmemTracker_GetMaxReservedVmemChunks(void);

--- a/src/test/isolation2/expected/resgroup/resgroup_syntax.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_syntax.out
@@ -80,10 +80,10 @@ ERROR:  resource group "rg_test_group" does not exist
 --end_ignore
 
 SELECT * FROM gp_toolkit.gp_resgroup_config;
-groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio|memory_auditor|proposed_memory_auditor
--------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------+--------------+-----------------------
-6437   |default_group|20         |20                  |30            |30          |30                   |50                 |50                          |20                |20                         |0             |0                      
-6438   |admin_group  |2          |2                   |10            |10          |10                   |50                 |50                          |20                |20                         |0             |0                      
+groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
+-------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
+6437   |default_group|20         |20                  |30            |30          |30                   |50                 |50                          |20                |20                         
+6438   |admin_group  |2          |2                   |10            |10          |10                   |50                 |50                          |20                |20                         
 (2 rows)
 
 -- negative
@@ -169,12 +169,6 @@ CREATE RESOURCE GROUP rg_test_group WITH (concurrency=-1, cpu_rate_limit=10, mem
 ERROR:  concurrency range is [0, 'max_connections']
 CREATE RESOURCE GROUP rg_test_group WITH (concurrency=26, cpu_rate_limit=10, memory_limit=10);
 ERROR:  concurrency range is [0, 'max_connections']
--- negative: memory_auditor should be 'vmtracker' or 'cgroup'
-CREATE RESOURCE GROUP rg_test_group WITH (concurrency=0, cpu_rate_limit=10, memory_limit=10, memory_auditor="randomtext");
-ERROR:  memory_auditor should be "vmtracker" or "cgroup"
--- negative: concurrency should be zero for cgroup audited resource group
-CREATE RESOURCE GROUP rg_test_group WITH (concurrency=1, cpu_rate_limit=10, memory_limit=10, memory_auditor="cgroup");
-ERROR:  resource group concurrency must be 0 when group memory_auditor is cgroup
 
 -- memory_spill_ratio range is [0, 100]
 -- no limit on the sum of memory_shared_quota and memory_spill_ratio
@@ -244,11 +238,6 @@ CREATE
 DROP RESOURCE GROUP rg1_test_group;
 DROP
 DROP RESOURCE GROUP rg2_test_group;
-DROP
--- positive: concurrency should be zero for cgroup audited resource group
-CREATE RESOURCE GROUP rg_test_group WITH (concurrency=0, cpu_rate_limit=10, memory_limit=10, memory_auditor="cgroup");
-CREATE
-DROP RESOURCE GROUP rg_test_group;
 DROP
 
 -- memory_spill_ratio range is [0, 100]
@@ -379,18 +368,3 @@ DROP
 DROP RESOURCE GROUP rg2_test_group;
 DROP
 
-CREATE RESOURCE GROUP cgroup_audited_group WITH (concurrency=0, cpu_rate_limit=10, memory_limit=10, memory_auditor="cgroup");
-CREATE
--- negative: memory_auditor cannot be altered
-ALTER RESOURCE GROUP cgroup_audited_group SET MEMORY_AUDITOR "default";
-ERROR:  syntax error at or near "MEMORY_AUDITOR"
-LINE 1: ALTER RESOURCE GROUP cgroup_audited_group SET MEMORY_AUDITOR...
-                                                      ^
--- negative: concurrency should be zero for cgroup audited resource group
-ALTER RESOURCE GROUP cgroup_audited_group SET CONCURRENCY 10;
-ERROR:  resource group concurrency must be 0 when group memory_auditor is cgroup
--- negative: role should not be assigned to a cgroup audited resource group
-CREATE ROLE cgroup_audited_role RESOURCE GROUP cgroup_audited_group;
-ERROR:  You cannot assign a role to this resource group because the memory_auditor property for this group is not the default.
-DROP RESOURCE GROUP cgroup_audited_group;
-DROP

--- a/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
@@ -90,10 +90,6 @@ CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=1.9);
 -- negative: concurrency should be in [1, max_connections]
 CREATE RESOURCE GROUP rg_test_group WITH (concurrency=-1, cpu_rate_limit=10, memory_limit=10);
 CREATE RESOURCE GROUP rg_test_group WITH (concurrency=26, cpu_rate_limit=10, memory_limit=10);
--- negative: memory_auditor should be 'vmtracker' or 'cgroup'
-CREATE RESOURCE GROUP rg_test_group WITH (concurrency=0, cpu_rate_limit=10, memory_limit=10, memory_auditor="randomtext");
--- negative: concurrency should be zero for cgroup audited resource group
-CREATE RESOURCE GROUP rg_test_group WITH (concurrency=1, cpu_rate_limit=10, memory_limit=10, memory_auditor="cgroup");
 
 -- memory_spill_ratio range is [0, 100]
 -- no limit on the sum of memory_shared_quota and memory_spill_ratio
@@ -132,9 +128,6 @@ CREATE RESOURCE GROUP rg1_test_group WITH (concurrency=1, cpu_rate_limit=30, mem
 CREATE RESOURCE GROUP rg2_test_group WITH (concurrency=1, cpu_rate_limit=30, memory_limit=30);
 DROP RESOURCE GROUP rg1_test_group;
 DROP RESOURCE GROUP rg2_test_group;
--- positive: concurrency should be zero for cgroup audited resource group
-CREATE RESOURCE GROUP rg_test_group WITH (concurrency=0, cpu_rate_limit=10, memory_limit=10, memory_auditor="cgroup");
-DROP RESOURCE GROUP rg_test_group;
 
 -- memory_spill_ratio range is [0, 100]
 -- no limit on the sum of memory_shared_quota and memory_spill_ratio
@@ -196,11 +189,3 @@ ALTER RESOURCE GROUP rg2_test_group SET CPU_RATE_LIMIT 30;
 DROP RESOURCE GROUP rg1_test_group;
 DROP RESOURCE GROUP rg2_test_group;
 
-CREATE RESOURCE GROUP cgroup_audited_group WITH (concurrency=0, cpu_rate_limit=10, memory_limit=10, memory_auditor="cgroup");
--- negative: memory_auditor cannot be altered
-ALTER RESOURCE GROUP cgroup_audited_group SET MEMORY_AUDITOR "default";
--- negative: concurrency should be zero for cgroup audited resource group
-ALTER RESOURCE GROUP cgroup_audited_group SET CONCURRENCY 10;
--- negative: role should not be assigned to a cgroup audited resource group
-CREATE ROLE cgroup_audited_role RESOURCE GROUP cgroup_audited_group;
-DROP RESOURCE GROUP cgroup_audited_group;


### PR DESCRIPTION
Reverting some commits to resource groups.  These introduced a change that could prevent a database from starting after upgrade unless the user made some configuration changes prior.  Because this impacts user expected behavior we're reverting this for now.

Commits that are reverted: 
-  4354d33
- 8ede074
- 140d4d2