### PR TITLE
Address GPDB_84_MERGE_FIXME in `simplify_EXISTS_query()`

### DIFF
--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -1302,6 +1302,27 @@ select * from A where A.i in (select C.j from C,B where B.i in (select i from C)
  1 | 1
 (2 rows)
 
+explain select * from A where not exists (select sum(c.i) from C where C.i = A.i group by C.i having c.i > 3);
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=3.18..6.29 rows=4 width=8)
+   ->  Hash Anti Join  (cost=3.18..6.29 rows=2 width=8)
+         Hash Cond: a.i = c.i
+         ->  Seq Scan on a  (cost=0.00..3.05 rows=2 width=8)
+         ->  Hash  (cost=3.11..3.11 rows=2 width=4)
+               ->  Seq Scan on c  (cost=0.00..3.11 rows=2 width=4)
+                     Filter: i > 3
+ Optimizer: legacy query optimizer
+(8 rows)
+
+select * from A where not exists (select sum(c.i) from C where C.i = A.i group by C.i having c.i > 3);
+ i  | j 
+----+---
+ 19 | 5
+  1 | 1
+  1 | 1
+(3 rows)
+
 -- ----------------------------------------------------------------------
 -- Test:  Correlated Subquery: CSQ using DML (Heap) 
 -- ----------------------------------------------------------------------

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -1445,6 +1445,31 @@ select * from A where A.i in (select C.j from C,B where B.i in (select i from C)
  1 | 1
 (2 rows)
 
+explain select * from A where not exists (select sum(c.i) from C where C.i = A.i group by C.i having c.i > 3);
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=2 width=8)
+   ->  Hash Anti Join  (cost=0.00..862.00 rows=1 width=8)
+         Hash Cond: a.i = c.i
+         ->  Table Scan on a  (cost=0.00..431.00 rows=2 width=8)
+         ->  Hash  (cost=431.00..431.00 rows=2 width=4)
+               ->  GroupAggregate  (cost=0.00..431.00 rows=2 width=4)
+                     Group Key: c.i
+                     ->  Sort  (cost=0.00..431.00 rows=2 width=4)
+                           Sort Key: c.i
+                           ->  Table Scan on c  (cost=0.00..431.00 rows=2 width=4)
+                                 Filter: i > 3
+ Optimizer: PQO version 2.55.13
+(12 rows)
+
+select * from A where not exists (select sum(c.i) from C where C.i = A.i group by C.i having c.i > 3);
+ i  | j 
+----+---
+  1 | 1
+  1 | 1
+ 19 | 5
+(3 rows)
+
 -- ----------------------------------------------------------------------
 -- Test:  Correlated Subquery: CSQ using DML (Heap) 
 -- ----------------------------------------------------------------------

--- a/src/test/regress/sql/qp_correlated_query.sql
+++ b/src/test/regress/sql/qp_correlated_query.sql
@@ -253,6 +253,8 @@ explain select * from B where not exists (select * from C,A where C.i in (select
 select * from B where not exists (select * from C,A where C.i in (select C.i from C where C.i = A.i and C.i != 10) AND B.i = C.i);
 explain select * from A where A.i in (select C.j from C,B where B.i in (select i from C));
 select * from A where A.i in (select C.j from C,B where B.i in (select i from C));
+explain select * from A where not exists (select sum(c.i) from C where C.i = A.i group by C.i having c.i > 3);
+select * from A where not exists (select sum(c.i) from C where C.i = A.i group by C.i having c.i > 3);
 
 
 -- ----------------------------------------------------------------------


### PR DESCRIPTION
This FIXME is two-fold:
- Handling LIMIT 0
  The LIMIT is already handled in the caller, `convert_EXISTS_sublink_to_join()`:
  When an existential sublink contains an aggregate without GROUP BY or
  HAVING, we can safely replace it by a one-time TRUE/FALSE filter based
  on the type of sublink since the result of aggregate is always going
  to be one row even if it's input rows are 0.  However this assumption
  is incorrect when sublink contains LIMIT/OFFSET, such as, if the final
  limit count after applying the offset is 0.

- Rules for demoting HAVING to WHERE
  previously, `simplify_EXISTS_query()` only disallowed demoting HAVING
  quals to WHERE, if it did not contain any aggregates. To determine the
  same, previously it used `query->hasAggs`, which is incorrect
  since hasAggs indicates that aggregate is present either in targetlist
  or HAVING.  This penalized the queries, wherein HAVING did not contain
  the agg but targetlist did (as demonstrated in the newly added test).
  This check is now replaced by `contain_aggs_of_level()`.  Also, do not
  demote if HAVING contains volatile functions since they need to be
  evaluated once per group.

Signed-off-by: Dhanashree Kashid <dkashid@pivotal.io>