### PR TITLE
Fix setting relfrozenxid during upgrade.

### DIFF
--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -3368,6 +3368,12 @@ insert_ordered_unique_oid(List *list, Oid datum)
 	return list;
 }
 
+/*
+ * Note: when modifying this function, make sure to modify the query
+ * updating 'relfrozenxid' in function set_frozenxids() too.
+ * This is to keep consistent behavior for relfrozenxid before
+ * and after upgrade.
+ */
 bool
 should_have_valid_relfrozenxid(char relkind, char relstorage)
 {


### PR DESCRIPTION
Relations with external storage, as well as AO and CO
should have InvalidTransactionId in relfrozenxid during
upgrade.

The idea here is to keep the same logic with function
should_have_valid_relfrozenxid().