### PR TITLE
Metadata tracking for ALTER ROLE IN DATABASE

### DIFF
--- a/src/backend/catalog/pg_db_role_setting.c
+++ b/src/backend/catalog/pg_db_role_setting.c
@@ -171,8 +171,7 @@ AlterSetting(Oid databaseid, Oid roleid, VariableSetStmt *setstmt)
 
 	systable_endscan(scan);
 
-	/* MPP-6929: metadata tracking */
-	/* GPDB_90_MERGE_FIXME: What should we report for database-role-combinations? */
+	/* update pg_stat_last_shoperation for metadata tracking */
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
 		char	   *alter_subtype;
@@ -183,8 +182,10 @@ AlterSetting(Oid databaseid, Oid roleid, VariableSetStmt *setstmt)
 			alter_subtype = "RESET";
 		else
 			alter_subtype = "SET";
+
+		/* roleoid is only valid for ALTER ROLE */
 		MetaTrackUpdObject(DatabaseRelationId,
-						   databaseid,
+						   OidIsValid(roleid) ? roleid : databaseid,
 						   GetUserId(),
 						   "ALTER", alter_subtype);
 	}

--- a/src/test/regress/expected/pg_stat_last_shoperation.out
+++ b/src/test/regress/expected/pg_stat_last_shoperation.out
@@ -1,0 +1,63 @@
+-- Check if pg_stat_last_shoperation stores CREATE of global objects
+CREATE DATABASE shoperation;
+CREATE ROLE shoperation_user;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+SELECT count(*) FROM pg_stat_last_shoperation
+WHERE staactionname = 'CREATE' AND stasubtype = 'DATABASE'
+AND objid = (SELECT oid FROM pg_database WHERE datname = 'shoperation');
+ count 
+-------
+     1
+(1 row)
+
+SELECT count(*) FROM pg_stat_last_shoperation
+WHERE staactionname = 'CREATE' AND stasubtype = 'ROLE'
+AND objid = (SELECT oid FROM pg_authid WHERE rolname = 'shoperation_user');
+ count 
+-------
+     1
+(1 row)
+
+-- Check if pg_stat_last_shoperation stores ALTER SET of global objects
+ALTER DATABASE shoperation SET enable_seqscan TO on;
+ALTER ROLE shoperation_user SET enable_seqscan TO on;
+SELECT count(*) FROM pg_stat_last_shoperation
+WHERE staactionname = 'ALTER' AND stasubtype = 'SET'
+AND objid = (SELECT oid FROM pg_database WHERE datname = 'shoperation');
+ count 
+-------
+     1
+(1 row)
+
+SELECT count(*) FROM pg_stat_last_shoperation
+WHERE staactionname = 'ALTER' AND stasubtype = 'SET'
+AND objid = (SELECT oid FROM pg_authid WHERE rolname = 'shoperation_user');
+ count 
+-------
+     1
+(1 row)
+
+-- Check if ALTER ROLE IN DATABASE updates role object in pg_stat_last_shoperation
+SET allow_system_table_mods=dml;
+DELETE FROM pg_stat_last_shoperation WHERE staactionname = 'ALTER' AND stasubtype = 'SET' AND objid = (SELECT oid FROM pg_authid WHERE rolname = 'shoperation_user');
+RESET allow_system_table_mods;
+SELECT count(*) FROM pg_stat_last_shoperation
+WHERE staactionname = 'ALTER' AND stasubtype = 'SET'
+AND objid = (SELECT oid FROM pg_authid WHERE rolname = 'shoperation_user');
+ count 
+-------
+     0
+(1 row)
+
+ALTER ROLE shoperation_user IN DATABASE shoperation SET enable_seqscan TO off;
+SELECT count(*) FROM pg_stat_last_shoperation
+WHERE staactionname = 'ALTER' AND stasubtype = 'SET'
+AND objid = (SELECT oid FROM pg_authid WHERE rolname = 'shoperation_user');
+ count 
+-------
+     1
+(1 row)
+
+-- Clean up since we don't want these lingering
+DROP ROLE shoperation_user;
+DROP DATABASE shoperation;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -93,7 +93,7 @@ test: resource_queue_stat
 test: resource_group
 test: wrkloadadmin
 
-test: gp_toolkit_ao_funcs trig auth_constraint role portals_updatable plpgsql_cache timeseries pg_stat_last_operation gp_numeric_agg partindex_test partition_pruning runtime_stats
+test: gp_toolkit_ao_funcs trig auth_constraint role portals_updatable plpgsql_cache timeseries pg_stat_last_operation pg_stat_last_shoperation gp_numeric_agg partindex_test partition_pruning runtime_stats
 test: rle rle_delta dsp not_out_of_shmem_exit_slots
 
 # direct dispatch tests

--- a/src/test/regress/sql/pg_stat_last_shoperation.sql
+++ b/src/test/regress/sql/pg_stat_last_shoperation.sql
@@ -1,0 +1,42 @@
+-- Check if pg_stat_last_shoperation stores CREATE of global objects
+CREATE DATABASE shoperation;
+CREATE ROLE shoperation_user;
+
+SELECT count(*) FROM pg_stat_last_shoperation
+WHERE staactionname = 'CREATE' AND stasubtype = 'DATABASE'
+AND objid = (SELECT oid FROM pg_database WHERE datname = 'shoperation');
+
+SELECT count(*) FROM pg_stat_last_shoperation
+WHERE staactionname = 'CREATE' AND stasubtype = 'ROLE'
+AND objid = (SELECT oid FROM pg_authid WHERE rolname = 'shoperation_user');
+
+-- Check if pg_stat_last_shoperation stores ALTER SET of global objects
+ALTER DATABASE shoperation SET enable_seqscan TO on;
+ALTER ROLE shoperation_user SET enable_seqscan TO on;
+
+SELECT count(*) FROM pg_stat_last_shoperation
+WHERE staactionname = 'ALTER' AND stasubtype = 'SET'
+AND objid = (SELECT oid FROM pg_database WHERE datname = 'shoperation');
+
+SELECT count(*) FROM pg_stat_last_shoperation
+WHERE staactionname = 'ALTER' AND stasubtype = 'SET'
+AND objid = (SELECT oid FROM pg_authid WHERE rolname = 'shoperation_user');
+
+-- Check if ALTER ROLE IN DATABASE updates role object in pg_stat_last_shoperation
+SET allow_system_table_mods=dml;
+DELETE FROM pg_stat_last_shoperation WHERE staactionname = 'ALTER' AND stasubtype = 'SET' AND objid = (SELECT oid FROM pg_authid WHERE rolname = 'shoperation_user');
+RESET allow_system_table_mods;
+
+SELECT count(*) FROM pg_stat_last_shoperation
+WHERE staactionname = 'ALTER' AND stasubtype = 'SET'
+AND objid = (SELECT oid FROM pg_authid WHERE rolname = 'shoperation_user');
+
+ALTER ROLE shoperation_user IN DATABASE shoperation SET enable_seqscan TO off;
+
+SELECT count(*) FROM pg_stat_last_shoperation
+WHERE staactionname = 'ALTER' AND stasubtype = 'SET'
+AND objid = (SELECT oid FROM pg_authid WHERE rolname = 'shoperation_user');
+
+-- Clean up since we don't want these lingering
+DROP ROLE shoperation_user;
+DROP DATABASE shoperation;


### PR DESCRIPTION
There was a GPDB_90_MERGE_FIXME regarding what we should report for
ALTER ROLE IN DATABASE in pg_stat_last_shoperation table for metadata
tracking. We should always report that the role object was altered if
coming from ALTER ROLE code path. To do this, we just check if the
role oid is valid because the call to AlterSetting from ALTER DATABASE
uses InvalidOid for role oid. While we're at it, we might as well add
some tests for pg_stat_last_shoperation.