### PR TITLE
Fix issue converting server encoding to client encoding

### DIFF
--- a/src/backend/utils/mb/mbutils.c
+++ b/src/backend/utils/mb/mbutils.c
@@ -568,7 +568,7 @@ pg_server_to_client(const char *s, int len)
 {
 	Assert(ClientEncoding);
 
-	return pg_any_to_server(s, len, ClientEncoding->encoding);
+	return pg_server_to_any(s, len, ClientEncoding->encoding);
 }
 
 /*


### PR DESCRIPTION
This was found when server encoding was WIN1251 but the client
encoding was UTF8. The conversion is valid for these character sets
but the client would receive an "invalid byte sequence for encoding"
error. We fix the issue by calling the correct conversion function. It
was switched up during a postgres backport last year.

Thanks to Heikki for debugging the issue.

This will need to be backported to 5X_STABLE as well.