### PR TITLE
GetOldestXmin: fix VACUUM FREEZE during binary upgrade

### DIFF
--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -1212,8 +1212,12 @@ GetOldestXmin(bool allDbs, bool ignoreVacuum)
 	/*
 	 * In QD node, all distributed transactions have an entry in the proc array,
 	 * so we're done.
+	 *
+	 * During binary upgrade, we don't have distributed transactions, so we're
+	 * done there too. This ensures correct operation of VACUUM FREEZE during
+	 * pg_upgrade.
 	 */
-	if (!IS_QUERY_DISPATCHER())
+	if (!IS_QUERY_DISPATCHER() && !IsBinaryUpgrade)
 	{
 		TransactionId distribOldestXmin;
 


### PR DESCRIPTION
`VACUUM FREEZE` must function correctly during binary upgrade so that the new cluster's catalogs don't contain bogus transaction IDs. Currently, the freeze fails because there is no distributed transaction for `GetOldestXmin` to check, and it conservatively refuses to vacuum tuples. We don't need to be that conservative during upgrade, where there are no distributed transactions to interfere with a vacuum.

As a regression test, query the age of all the rows in `gp_segment_configuration` during our pg_upgrade test script.