### PR TITLE
pg_upgrade: Fix dump file diff caused by default value with type bit …

### DIFF
--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -6235,7 +6235,7 @@ get_const_expr(Const *constval, deparse_context *context, int showtype)
 
 		case BITOID:
 		case VARBITOID:
-			appendStringInfo(buf, "B'%s'", extval);
+			appendStringInfo(buf, "'%s'", extval);
 			break;
 
 		case BOOLOID:


### PR DESCRIPTION
…varying in column of a relation.

Here is the repro case:
psql -X -d regression -c "CREATE TABLE t111 ( a40 bit varying(5) DEFAULT '1');"
psql -X -d regression -c "CREATE TABLE t222 ( a40 bit varying(5) DEFAULT B'1');"

After pg_upgrade testing, we will see failure and the diff of dump sql files looks like this:

 CREATE TABLE t111 (
-    a40 bit varying(5) DEFAULT B'1'::bit varying
+    a40 bit varying(5) DEFAULT (B'1'::"bit")::bit varying
 ) DISTRIBUTED BY (a40);

No diff for the table t222. From perspective of functionality, the difference
seems to mean nothing, but it is annoying for CI.

This issue exists on latest pg also. We sent an email to upstream a couple days ago,
however I do not expect a quick completion, so I'm submitting the PR here just to
prevent us from forgetting this issue.

Co-authored-by: Richard Guo <riguo@pivotal.io>