### PR TITLE
Add stack protection to --enable-cassert

### DIFF
--- a/configure
+++ b/configure
@@ -6150,6 +6150,125 @@ fi
 
 
 
+# If assertions are enabled, also attempt to enable stack protection. Try
+# enabling -strong protection first, then the slower -all, and then finally fall
+# back to the standard -fstack-protector.
+if test "$enable_cassert" = yes; then
+	CFLAGS_STACK=
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -fstack-protector-strong" >&5
+$as_echo_n "checking whether $CC supports -fstack-protector-strong... " >&6; }
+if ${pgac_cv_prog_cc_cflags__fstack_protector_strong+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  pgac_save_CFLAGS=$CFLAGS
+CFLAGS="$pgac_save_CFLAGS -fstack-protector-strong"
+ac_save_c_werror_flag=$ac_c_werror_flag
+ac_c_werror_flag=yes
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  pgac_cv_prog_cc_cflags__fstack_protector_strong=yes
+else
+  pgac_cv_prog_cc_cflags__fstack_protector_strong=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+ac_c_werror_flag=$ac_save_c_werror_flag
+CFLAGS="$pgac_save_CFLAGS"
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $pgac_cv_prog_cc_cflags__fstack_protector_strong" >&5
+$as_echo "$pgac_cv_prog_cc_cflags__fstack_protector_strong" >&6; }
+if test x"$pgac_cv_prog_cc_cflags__fstack_protector_strong" = x"yes"; then
+  CFLAGS_STACK="${CFLAGS_STACK} -fstack-protector-strong"
+fi
+
+
+	if test x"$CFLAGS_STACK" = x""; then
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -fstack-protector-all" >&5
+$as_echo_n "checking whether $CC supports -fstack-protector-all... " >&6; }
+if ${pgac_cv_prog_cc_cflags__fstack_protector_all+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  pgac_save_CFLAGS=$CFLAGS
+CFLAGS="$pgac_save_CFLAGS -fstack-protector-all"
+ac_save_c_werror_flag=$ac_c_werror_flag
+ac_c_werror_flag=yes
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  pgac_cv_prog_cc_cflags__fstack_protector_all=yes
+else
+  pgac_cv_prog_cc_cflags__fstack_protector_all=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+ac_c_werror_flag=$ac_save_c_werror_flag
+CFLAGS="$pgac_save_CFLAGS"
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $pgac_cv_prog_cc_cflags__fstack_protector_all" >&5
+$as_echo "$pgac_cv_prog_cc_cflags__fstack_protector_all" >&6; }
+if test x"$pgac_cv_prog_cc_cflags__fstack_protector_all" = x"yes"; then
+  CFLAGS_STACK="${CFLAGS_STACK} -fstack-protector-all"
+fi
+
+	fi
+	if test x"$CFLAGS_STACK" = x""; then
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -fstack-protector" >&5
+$as_echo_n "checking whether $CC supports -fstack-protector... " >&6; }
+if ${pgac_cv_prog_cc_cflags__fstack_protector+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  pgac_save_CFLAGS=$CFLAGS
+CFLAGS="$pgac_save_CFLAGS -fstack-protector"
+ac_save_c_werror_flag=$ac_c_werror_flag
+ac_c_werror_flag=yes
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  pgac_cv_prog_cc_cflags__fstack_protector=yes
+else
+  pgac_cv_prog_cc_cflags__fstack_protector=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+ac_c_werror_flag=$ac_save_c_werror_flag
+CFLAGS="$pgac_save_CFLAGS"
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $pgac_cv_prog_cc_cflags__fstack_protector" >&5
+$as_echo "$pgac_cv_prog_cc_cflags__fstack_protector" >&6; }
+if test x"$pgac_cv_prog_cc_cflags__fstack_protector" = x"yes"; then
+  CFLAGS_STACK="${CFLAGS_STACK} -fstack-protector"
+fi
+
+	fi
+
+	CFLAGS="$CFLAGS $CFLAGS_STACK"
+fi
+
 # Enable debug ntuplestore
 
 

--- a/configure.in
+++ b/configure.in
@@ -757,6 +757,23 @@ PGAC_ARG_BOOL(enable, cassert, no, [enable assertion checks (for debugging)],
               [AC_DEFINE([USE_ASSERT_CHECKING], 1,
                          [Define to 1 to build with assertion checks. (--enable-cassert)])])
 
+# If assertions are enabled, also attempt to enable stack protection. Try
+# enabling -strong protection first, then the slower -all, and then finally fall
+# back to the standard -fstack-protector.
+if test "$enable_cassert" = yes; then
+	CFLAGS_STACK=
+	PGAC_PROG_CC_VAR_OPT(CFLAGS_STACK, [-fstack-protector-strong])
+
+	if test x"$CFLAGS_STACK" = x""; then
+		PGAC_PROG_CC_VAR_OPT(CFLAGS_STACK, [-fstack-protector-all])
+	fi
+	if test x"$CFLAGS_STACK" = x""; then
+		PGAC_PROG_CC_VAR_OPT(CFLAGS_STACK, [-fstack-protector])
+	fi
+
+	CFLAGS="$CFLAGS $CFLAGS_STACK"
+fi
+
 # Enable debug ntuplestore
 PGAC_ARG_BOOL(enable, debugntuplestore, no, [enable debug_ntuplestore (for debugging)],
               [AC_DEFINE([USE_DEBUG_NTUPLESTORE], 1,


### PR DESCRIPTION
When assertions are enabled, try to also catch stack smashing with a variant of `-fstack-protector`. `strong` is preferred, followed by `all` and then standard.