### PR TITLE
Disable large objects

### DIFF
--- a/src/backend/catalog/aclchk.c
+++ b/src/backend/catalog/aclchk.c
@@ -779,11 +779,10 @@ objectNamesToOids(GrantObjectType objtype, List *objnames)
 			}
 			break;
 		case ACL_OBJECT_LARGEOBJECT:
-			/*
-			 * GPDB_90_MERGE_FIXME: large objects are a mess in GPDB. There's no
-			 * enforcement of where they get created. Here, we assume that they
-			 * only exist in the QD node. Hence do nothing in a QE node:
-			 */
+			ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("large objects are not supported")));
+
 			if (Gp_role == GP_ROLE_EXECUTE)
 				break;
 			foreach(cell, objnames)

--- a/src/backend/libpq/be-fsstubs.c
+++ b/src/backend/libpq/be-fsstubs.c
@@ -101,6 +101,10 @@ lo_open(PG_FUNCTION_ARGS)
 	LargeObjectDesc *lobjDesc;
 	int			fd;
 
+	ereport(ERROR,
+		(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+		 errmsg("large objects are not supported")));
+
 #if FSDB
 	elog(DEBUG4, "lo_open(%u,%d)", lobjId, mode);
 #endif
@@ -126,6 +130,10 @@ Datum
 lo_close(PG_FUNCTION_ARGS)
 {
 	int32		fd = PG_GETARG_INT32(0);
+
+	ereport(ERROR,
+		(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+		 errmsg("large objects are not supported")));
 
 	if (fd < 0 || fd >= cookies_size || cookies[fd] == NULL)
 		ereport(ERROR,
@@ -219,6 +227,10 @@ lo_lseek(PG_FUNCTION_ARGS)
 	int32		whence = PG_GETARG_INT32(2);
 	int			status;
 
+	ereport(ERROR,
+		(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+		 errmsg("large objects are not supported")));
+
 	if (fd < 0 || fd >= cookies_size || cookies[fd] == NULL)
 		ereport(ERROR,
 				(errcode(ERRCODE_UNDEFINED_OBJECT),
@@ -233,6 +245,10 @@ Datum
 lo_creat(PG_FUNCTION_ARGS)
 {
 	Oid			lobjId;
+
+	ereport(ERROR,
+		(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+		 errmsg("large objects are not supported")));
 
 	/*
 	 * We don't actually need to store into fscxt, but create it anyway to
@@ -250,6 +266,10 @@ lo_create(PG_FUNCTION_ARGS)
 {
 	Oid			lobjId = PG_GETARG_OID(0);
 
+	ereport(ERROR,
+		(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+		 errmsg("large objects are not supported")));
+
 	/*
 	 * We don't actually need to store into fscxt, but create it anyway to
 	 * ensure that AtEOXact_LargeObject knows there is state to clean up
@@ -266,6 +286,10 @@ lo_tell(PG_FUNCTION_ARGS)
 {
 	int32		fd = PG_GETARG_INT32(0);
 
+	ereport(ERROR,
+		(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+		 errmsg("large objects are not supported")));
+
 	if (fd < 0 || fd >= cookies_size || cookies[fd] == NULL)
 		ereport(ERROR,
 				(errcode(ERRCODE_UNDEFINED_OBJECT),
@@ -278,6 +302,10 @@ Datum
 lo_unlink(PG_FUNCTION_ARGS)
 {
 	Oid			lobjId = PG_GETARG_OID(0);
+
+	ereport(ERROR,
+		(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+		 errmsg("large objects are not supported")));
 
 	/* Must be owner of the largeobject */
 	if (!lo_compat_privileges &&
@@ -322,6 +350,10 @@ loread(PG_FUNCTION_ARGS)
 	bytea	   *retval;
 	int			totalread;
 
+	ereport(ERROR,
+		(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+		 errmsg("large objects are not supported")));
+
 	if (len < 0)
 		len = 0;
 
@@ -339,6 +371,10 @@ lowrite(PG_FUNCTION_ARGS)
 	bytea	   *wbuf = PG_GETARG_BYTEA_P(1);
 	int			bytestowrite;
 	int			totalwritten;
+
+	ereport(ERROR,
+		(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+		 errmsg("large objects are not supported")));
 
 	bytestowrite = VARSIZE(wbuf) - VARHDRSZ;
 	totalwritten = lo_write(fd, VARDATA(wbuf), bytestowrite);
@@ -358,6 +394,10 @@ lo_import(PG_FUNCTION_ARGS)
 {
 	text	   *filename = PG_GETARG_TEXT_PP(0);
 
+	ereport(ERROR,
+		(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+		 errmsg("large objects are not supported")));
+
 	PG_RETURN_OID(lo_import_internal(filename, InvalidOid));
 }
 
@@ -370,6 +410,10 @@ lo_import_with_oid(PG_FUNCTION_ARGS)
 {
 	text	   *filename = PG_GETARG_TEXT_PP(0);
 	Oid			oid = PG_GETARG_OID(1);
+
+	ereport(ERROR,
+		(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+		 errmsg("large objects are not supported")));
 
 	PG_RETURN_OID(lo_import_internal(filename, oid));
 }
@@ -451,6 +495,10 @@ lo_export(PG_FUNCTION_ARGS)
 	LargeObjectDesc *lobj;
 	mode_t		oumask;
 
+	ereport(ERROR,
+		(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+		 errmsg("large objects are not supported")));
+
 #ifndef ALLOW_DANGEROUS_LO_FUNCTIONS
 	if (!superuser())
 		ereport(ERROR,
@@ -511,6 +559,10 @@ lo_truncate(PG_FUNCTION_ARGS)
 {
 	int32		fd = PG_GETARG_INT32(0);
 	int32		len = PG_GETARG_INT32(1);
+
+	ereport(ERROR,
+		(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+		 errmsg("large objects are not supported")));
 
 	if (fd < 0 || fd >= cookies_size || cookies[fd] == NULL)
 		ereport(ERROR,

--- a/src/test/regress/expected/privileges.out
+++ b/src/test/regress/expected/privileges.out
@@ -13,11 +13,13 @@ DROP ROLE IF EXISTS regressuser3;
 DROP ROLE IF EXISTS regressuser4;
 DROP ROLE IF EXISTS regressuser5;
 DROP ROLE IF EXISTS regressuser6;
+-- start_ignore
 SELECT lo_unlink(oid) FROM pg_largeobject_metadata;
  lo_unlink 
 -----------
 (0 rows)
 
+-- end_ignore
 RESET client_min_messages;
 -- test proper begins here
 CREATE USER regressuser1;
@@ -900,6 +902,7 @@ SELECT has_sequence_privilege('x_seq', 'USAGE');
 -- largeobject privilege tests
 \c -
 SET SESSION AUTHORIZATION regressuser1;
+-- start_ignore
 SELECT lo_create(1001);
  lo_create 
 -----------
@@ -941,8 +944,10 @@ GRANT SELECT, UPDATE ON LARGE OBJECT 1001 TO nosuchuser;	-- to be failed
 ERROR:  role "nosuchuser" does not exist
 GRANT SELECT, UPDATE ON LARGE OBJECT  999 TO PUBLIC;	-- to be failed
 ERROR:  large object 999 does not exist
+-- end_ignore
 \c -
 SET SESSION AUTHORIZATION regressuser2;
+-- start_ignore
 SELECT lo_create(2001);
  lo_create 
 -----------
@@ -1005,7 +1010,9 @@ SELECT lo_unlink(2002);
          1
 (1 row)
 
+-- end_ignore
 \c -
+-- start_ignore
 -- confirm ACL setting
 SELECT oid, pg_get_userbyid(lomowner) ownername, lomacl FROM pg_largeobject_metadata;
  oid  |  ownername   |                                          lomacl                                          
@@ -1018,7 +1025,9 @@ SELECT oid, pg_get_userbyid(lomowner) ownername, lomacl FROM pg_largeobject_meta
  2001 | regressuser2 | {regressuser2=rw/regressuser2,regressuser3=rw/regressuser2}
 (6 rows)
 
+-- end_ignore
 SET SESSION AUTHORIZATION regressuser3;
+-- start_ignore
 SELECT loread(lo_open(1001, x'40000'::int), 32);
    loread   
 ------------
@@ -1041,10 +1050,12 @@ SELECT lo_truncate(lo_open(2001, x'20000'::int), 10);
            0
 (1 row)
 
+-- end_ignore
 -- compatibility mode in largeobject permission
 \c -
 SET lo_compat_privileges = false;	-- default setting
 SET SESSION AUTHORIZATION regressuser4;
+-- start_ignore
 SELECT loread(lo_open(1002, x'40000'::int), 32);	-- to be denied
 ERROR:  permission denied for large object 1002
 SELECT lowrite(lo_open(1002, x'20000'::int), 'abcd');	-- to be denied
@@ -1056,9 +1067,11 @@ ERROR:  must be owner of large object 1002
 SELECT lo_export(1001, '/dev/null');			-- to be denied
 ERROR:  must be superuser to use server-side lo_export()
 HINT:  Anyone can use the client-side lo_export() provided by libpq.
+-- end_ignore
 \c -
 SET lo_compat_privileges = true;	-- compatibility mode
 SET SESSION AUTHORIZATION regressuser4;
+-- start_ignore
 SELECT loread(lo_open(1002, x'40000'::int), 32);
  loread 
 --------
@@ -1086,6 +1099,7 @@ SELECT lo_unlink(1002);
 SELECT lo_export(1001, '/dev/null');			-- to be denied
 ERROR:  must be superuser to use server-side lo_export()
 HINT:  Anyone can use the client-side lo_export() provided by libpq.
+-- end_ignore
 -- don't allow unpriv users to access pg_largeobject contents
 \c -
 SELECT * FROM pg_largeobject LIMIT 0;
@@ -1333,6 +1347,7 @@ DROP TABLE atest6;
 DROP TABLE atestc;
 DROP TABLE atestp1;
 DROP TABLE atestp2;
+-- start_ignore
 SELECT lo_unlink(oid) FROM pg_largeobject_metadata;
  lo_unlink 
 -----------
@@ -1343,6 +1358,7 @@ SELECT lo_unlink(oid) FROM pg_largeobject_metadata;
          1
 (5 rows)
 
+-- end_ignore
 DROP GROUP regressgroup1;
 DROP GROUP regressgroup2;
 -- these are needed to clean up permissions

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -134,7 +134,7 @@ test: select_views portals_p2 cluster dependency guc bitmapops tsearch tsdicts f
 # ----------
 test: plancache limit plpgsql copy2 temp domain rangefuncs prepare without_oid conversion truncate alter_table sequence polymorphism rowtypes with xml
 
-# GPDB_83_MERGE_FIXME: the largeobject test is temporarily disabled due to test errors
+# large objects are not supported by GPDB
 # test: largeobject
 
 # INSERT RETURNING is not supported by GPDB

--- a/src/test/regress/sql/privileges.sql
+++ b/src/test/regress/sql/privileges.sql
@@ -17,7 +17,9 @@ DROP ROLE IF EXISTS regressuser4;
 DROP ROLE IF EXISTS regressuser5;
 DROP ROLE IF EXISTS regressuser6;
 
+-- start_ignore
 SELECT lo_unlink(oid) FROM pg_largeobject_metadata;
+-- end_ignore
 
 RESET client_min_messages;
 
@@ -518,6 +520,7 @@ SELECT has_sequence_privilege('x_seq', 'USAGE');
 \c -
 SET SESSION AUTHORIZATION regressuser1;
 
+-- start_ignore
 SELECT lo_create(1001);
 SELECT lo_create(1002);
 SELECT lo_create(1003);
@@ -533,10 +536,12 @@ GRANT SELECT ON LARGE OBJECT 1005 TO regressuser2 WITH GRANT OPTION;
 GRANT SELECT, INSERT ON LARGE OBJECT 1001 TO PUBLIC;	-- to be failed
 GRANT SELECT, UPDATE ON LARGE OBJECT 1001 TO nosuchuser;	-- to be failed
 GRANT SELECT, UPDATE ON LARGE OBJECT  999 TO PUBLIC;	-- to be failed
+-- end_ignore
 
 \c -
 SET SESSION AUTHORIZATION regressuser2;
 
+-- start_ignore
 SELECT lo_create(2001);
 SELECT lo_create(2002);
 
@@ -557,40 +562,49 @@ GRANT ALL ON LARGE OBJECT 2001 TO regressuser3;
 
 SELECT lo_unlink(1001);		-- to be denied
 SELECT lo_unlink(2002);
+-- end_ignore
 
 \c -
+-- start_ignore
 -- confirm ACL setting
 SELECT oid, pg_get_userbyid(lomowner) ownername, lomacl FROM pg_largeobject_metadata;
+-- end_ignore
 
 SET SESSION AUTHORIZATION regressuser3;
 
+-- start_ignore
 SELECT loread(lo_open(1001, x'40000'::int), 32);
 SELECT loread(lo_open(1003, x'40000'::int), 32);	-- to be denied
 SELECT loread(lo_open(1005, x'40000'::int), 32);
 
 SELECT lo_truncate(lo_open(1005, x'20000'::int), 10);	-- to be denied
 SELECT lo_truncate(lo_open(2001, x'20000'::int), 10);
+-- end_ignore
 
 -- compatibility mode in largeobject permission
 \c -
 SET lo_compat_privileges = false;	-- default setting
 SET SESSION AUTHORIZATION regressuser4;
 
+-- start_ignore
 SELECT loread(lo_open(1002, x'40000'::int), 32);	-- to be denied
 SELECT lowrite(lo_open(1002, x'20000'::int), 'abcd');	-- to be denied
 SELECT lo_truncate(lo_open(1002, x'20000'::int), 10);	-- to be denied
 SELECT lo_unlink(1002);					-- to be denied
 SELECT lo_export(1001, '/dev/null');			-- to be denied
+-- end_ignore
 
 \c -
 SET lo_compat_privileges = true;	-- compatibility mode
 SET SESSION AUTHORIZATION regressuser4;
 
+-- start_ignore
 SELECT loread(lo_open(1002, x'40000'::int), 32);
 SELECT lowrite(lo_open(1002, x'20000'::int), 'abcd');
 SELECT lo_truncate(lo_open(1002, x'20000'::int), 10);
 SELECT lo_unlink(1002);
 SELECT lo_export(1001, '/dev/null');			-- to be denied
+-- end_ignore
 
 -- don't allow unpriv users to access pg_largeobject contents
 \c -
@@ -748,7 +762,9 @@ DROP TABLE atestc;
 DROP TABLE atestp1;
 DROP TABLE atestp2;
 
+-- start_ignore
 SELECT lo_unlink(oid) FROM pg_largeobject_metadata;
+-- end_ignore
 
 DROP GROUP regressgroup1;
 DROP GROUP regressgroup2;


### PR DESCRIPTION
Large objects are currently not supported in Greenplum. Rather than deceive the
user with a non-functional large object api, we disable them for now.

We disable the large object tests in privileges regress test by using ignore
blocks instead of commenting them out or deleting them to reduce merge
conflicts in future postgres merges.

Co-authored-by: Jimmy Yih <jyih@pivotal.io>