### PR TITLE
Fix Analyze privilege issue when executed by superuser

### DIFF
--- a/src/test/regress/expected/vacuum_gp.out
+++ b/src/test/regress/expected/vacuum_gp.out
@@ -274,3 +274,16 @@ insert into ao_t1 select i, i from generate_series(1, 10000) i;
 update ao_t1 set b = b + 1;
 vacuum full ao_t1;
 drop table ao_t1;
+-- superuser must be able to vacuum analyze the table
+CREATE ROLE r_priv_test;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+CREATE SCHEMA s_priv_test;
+CREATE TABLE s_priv_test.t_priv_table(a INT);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO s_priv_test.t_priv_table SELECT i FROM generate_series(1, 10)i;
+ALTER TABLE s_priv_test.t_priv_table OWNER TO r_priv_test;
+VACUUM ANALYZE s_priv_test.t_priv_table;
+DROP SCHEMA s_priv_test CASCADE;
+NOTICE:  drop cascades to table s_priv_test.t_priv_table
+DROP ROLE r_priv_test;

--- a/src/test/regress/sql/vacuum_gp.sql
+++ b/src/test/regress/sql/vacuum_gp.sql
@@ -178,3 +178,13 @@ insert into ao_t1 select i, i from generate_series(1, 10000) i;
 update ao_t1 set b = b + 1;
 vacuum full ao_t1;
 drop table ao_t1;
+
+-- superuser must be able to vacuum analyze the table
+CREATE ROLE r_priv_test;
+CREATE SCHEMA s_priv_test;
+CREATE TABLE s_priv_test.t_priv_table(a INT);
+INSERT INTO s_priv_test.t_priv_table SELECT i FROM generate_series(1, 10)i;
+ALTER TABLE s_priv_test.t_priv_table OWNER TO r_priv_test;
+VACUUM ANALYZE s_priv_test.t_priv_table;
+DROP SCHEMA s_priv_test CASCADE;
+DROP ROLE r_priv_test;


### PR DESCRIPTION
The patch 62aba76568e58698ad5eaa6153bc45186aacbde2 from upstream fixed
the CVE-2009-4136 (security vulnerability) with the intent to properly
manage session-local state during execution of an index function by a
database superuser, which in some cases allowed remote authenticated
users to gain privileges via a table with crafted index functions.

Looking into the details of the CVE-2009-4136 and related CVE-2007-6600,
the patch should ideally have limited the scope while we calculate the
stats on the index expressions, where we run functions to evaluate the
expression and could potentially present a security threat.

However, the patch changed the user to table owner before collecting the
sample, due to which even if analyze was run by superuser the sample
couldn't be collected as the table owner did not had sufficient
privileges to access the table. With this commit, we switch back to the
original user while collecting the sample as it does not deal with
indexes, or function call which was the original intention of the patch.

Upstream did not face the privilege issue, as it does block sampling
instead of issuing a query.

Signed-off-by: Sambitesh Dash <sdash@pivotal.io>