### PR TITLE
Maintain oldest xmin among distributed snapshots separately on QD

### DIFF
--- a/src/include/access/distributedlog.h
+++ b/src/include/access/distributedlog.h
@@ -57,10 +57,10 @@ extern bool DistributedLog_ScanForPrevCommitted(
 									TransactionId *indexXid,
 									DistributedTransactionTimeStamp *distribTimeStamp,
 									DistributedTransactionId *distribXid);
-
 extern TransactionId DistributedLog_AdvanceOldestXmin(TransactionId oldestInProgressLocalXid,
 								 DistributedTransactionTimeStamp distribTimeStamp,
 								 DistributedTransactionId oldestDistribXid);
+extern void DistributedLog_AdvanceOldestXminOnQD(TransactionId oldestLocalXmin);
 extern TransactionId DistributedLog_GetOldestXmin(TransactionId oldestLocalXmin);
 
 extern Size DistributedLog_ShmemSize(void);


### PR DESCRIPTION
Commit b3f300b945735d introduced the novel idea tracking oldest xmin among all distributed snapshots on QEs.  However, the idea is not applicable to QD because all distributed transactions can be found in ProcArray on QD.  Local oldest xmin is therefore the oldest xmin among all distributed snapshots on QD.  This patch fixes the maintenance of oldest xmin on QD by avoiding DistributedLog_AdvanceOldestXmin() and all the heavy-lifting that it performs.  Calling this on QD was also hitting the "local snapshot's xmin is older than recorded distributed oldestxmin" error occasionally in CI.