### PR TITLE
Avoid collision w std macros use enum

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("2.56.", GPORCA_VERSION_STRING, 5);
+return strncmp("2.57.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 2.56.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 2.57.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -13050,7 +13050,7 @@ int
 main ()
 {
 
-return strncmp("2.56.", GPORCA_VERSION_STRING, 5);
+return strncmp("2.57.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -13060,7 +13060,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 2.56.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 2.57.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v2.56.3@gpdb/stable
+orca/v2.57.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -121,7 +121,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v2.56.3/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v2.57.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -543,7 +543,7 @@ CTranslatorDXLToPlStmt::FSetIndexVarAttno
 		const IMDRelation *pmdrel = pctxtidxvarattno->m_pmdrel;
 		const IMDIndex *pmdindex = pctxtidxvarattno->m_pmdindex;
 
-		ULONG ulIndexColPos = ULONG_MAX;
+		ULONG ulIndexColPos = gpos::ulong_max;
 		const ULONG ulArity = pmdrel->UlColumns();
 		for (ULONG ulColPos = 0; ulColPos < ulArity; ulColPos++)
 		{
@@ -555,7 +555,7 @@ CTranslatorDXLToPlStmt::FSetIndexVarAttno
 			}
 		}
 
-		if (ULONG_MAX > ulIndexColPos)
+		if (gpos::ulong_max > ulIndexColPos)
 		{
 			((Var *)pnode)->varattno =  1 + pmdindex->UlPosInKey(ulIndexColPos);
 		}
@@ -2023,7 +2023,7 @@ CTranslatorDXLToPlStmt::PplanResultHashFilters
 			CDXLNode *pdxlnHashExpr = (*pdxlnHashExprList)[ul];
 			CDXLNode *pdxlnExpr = (*pdxlnHashExpr)[0];
 			
-			INT iResno = INT_MAX;
+			INT iResno = gpos::int_max;
 			if (EdxlopScalarIdent == pdxlnExpr->Pdxlop()->Edxlop())
 			{
 				ULONG ulColId = CDXLScalarIdent::PdxlopConvert(pdxlnExpr->Pdxlop())->Pdxlcr()->UlID();
@@ -2060,7 +2060,7 @@ CTranslatorDXLToPlStmt::PplanResultHashFilters
 
 				iResno = pte->resno;
 			}
-			GPOS_ASSERT(INT_MAX != iResno);
+			GPOS_ASSERT(gpos::int_max != iResno);
 			
 			presult->hashList = gpdb::PlAppendInt(presult->hashList, iResno);
 		}

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -3084,7 +3084,7 @@ CTranslatorQueryToDXL::PdxlnFromValues
 			Expr *pexpr = (Expr *) lfirst(plcColumn);
 
 			CHAR *szColName = (CHAR *) strVal(gpdb::PvListNth(plColnames, ulColPos));
-			ULONG ulColId = ULONG_MAX;	
+			ULONG ulColId = gpos::ulong_max;
 			if (IsA(pexpr, Const))
 			{
 				// extract the datum
@@ -3144,7 +3144,7 @@ CTranslatorQueryToDXL::PdxlnFromValues
 				}
 			}
 
-			GPOS_ASSERT(ULONG_MAX != ulColId);
+			GPOS_ASSERT(gpos::ulong_max != ulColId);
 
 			pdrgpulColIds->Append(GPOS_NEW(m_pmp) ULONG(ulColId));
 			ulColPos++;

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -748,7 +748,7 @@ CTranslatorRelcacheToDXL::Pdrgpmdcol
 			pdxlnDefault = PdxlnDefaultColumnValue(pmp, pmda, rel->rd_att, att->attnum);
 		}
 
-		ULONG ulColLen = ULONG_MAX;
+		ULONG ulColLen = gpos::ulong_max;
 		CMDIdGPDB *pmdidCol = GPOS_NEW(pmp) CMDIdGPDB(att->atttypid);
 		HeapTuple heaptupleStats = gpdb::HtAttrStats(rel->rd_id, ul+1);
 
@@ -1488,7 +1488,7 @@ CTranslatorRelcacheToDXL::UlPosition
 {
 	ULONG ulIndex = (ULONG) (GPDXL_SYSTEM_COLUMNS + iAttno);
 	ULONG ulPos = pul[ulIndex];
-	GPOS_ASSERT(ULONG_MAX != ulPos);
+	GPOS_ASSERT(gpos::ulong_max != ulPos);
 
 	return ulPos;
 }
@@ -1517,7 +1517,7 @@ CTranslatorRelcacheToDXL::PulAttnoPositionMap
 
 	for (ULONG ul = 0; ul < ulSize; ul++)
 	{
-		pul[ul] = ULONG_MAX;
+		pul[ul] = gpos::ulong_max;
 	}
 
 	for (ULONG ul = 0;  ul < ulIncludedCols; ul++)
@@ -2659,7 +2659,7 @@ CTranslatorRelcacheToDXL::UlTableCount
 {
        GPOS_ASSERT(InvalidOid != oidRelation);
 
-       ULONG ulTableCount = ULONG_MAX;
+       ULONG ulTableCount = gpos::ulong_max;
        if (gpdb::FRelPartIsNone(oidRelation))
        {
     	   // not a partitioned table
@@ -2674,7 +2674,7 @@ CTranslatorRelcacheToDXL::UlTableCount
        {
            ulTableCount = gpdb::UlLeafPartitions(oidRelation);
        }
-       GPOS_ASSERT(ULONG_MAX != ulTableCount);
+       GPOS_ASSERT(gpos::ulong_max != ulTableCount);
 
        return ulTableCount;
 }
@@ -3222,10 +3222,10 @@ CTranslatorRelcacheToDXL::PulAttnoMapping
 	const ULONG ulCols = pdrgpmdcol->UlLength();
 	ULONG *pul = GPOS_NEW_ARRAY(pmp, ULONG, ulMaxCols);
 
-	// initialize all positions to ULONG_MAX
+	// initialize all positions to gpos::ulong_max
 	for (ULONG ul = 0;  ul < ulMaxCols; ul++)
 	{
-		pul[ul] = ULONG_MAX;
+		pul[ul] = gpos::ulong_max;
 	}
 	
 	for (ULONG ul = 0;  ul < ulCols; ul++)

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -933,7 +933,7 @@ CTranslatorUtils::UlSystemColLength
 				gpdxl::ExmiPlStmt2DXLConversion,
 				GPOS_WSZ_LIT("Invalid attribute number")
 				);
-			return ULONG_MAX;
+			return gpos::ulong_max;
 	}
 }
 
@@ -1374,7 +1374,7 @@ CTranslatorUtils::PdrgpulGenerateColIds
 		OID oidExprType = gpdb::OidExprType((Node*) pte->expr);
 		if (!pte->resjunk)
 		{
-			ULONG ulColId = ULONG_MAX;
+			ULONG ulColId = gpos::ulong_max;
 			IMDId *pmdid = (*pdrgpmdidInput)[ulColPos];
 			if (CMDIdGPDB::PmdidConvert(pmdid)->OidObjectId() != oidExprType || 
 				pfOuterRef[ulColPos])
@@ -1389,7 +1389,7 @@ CTranslatorUtils::PdrgpulGenerateColIds
 				// use the column identifier of the input
 				ulColId = *(*pdrgpulInput)[ulColPos];
 			}
-			GPOS_ASSERT(ULONG_MAX != ulColId);
+			GPOS_ASSERT(gpos::ulong_max != ulColId);
 			
 			pdrgpul->Append(GPOS_NEW(pmp) ULONG(ulColId));
 
@@ -1606,7 +1606,7 @@ CTranslatorUtils::Pdxlcd
 	)
 {
 	GPOS_ASSERT(NULL != pte);
-	GPOS_ASSERT(ULONG_MAX != ulColId);
+	GPOS_ASSERT(gpos::ulong_max != ulColId);
 
 	CMDName *pmdname = NULL;
 	if (NULL == pte->resname)

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -757,7 +757,7 @@ COptTasks::PoconfCreate
 						pcm,
 						GPOS_NEW(pmp) CHint
 								(
-								INT_MAX /* optimizer_parts_to_force_sort_on_insert */,
+								gpos::int_max /* optimizer_parts_to_force_sort_on_insert */,
 								ulJoinArityForAssociativityCommutativity,
 								ulArrayExpansionThreshold,
 								ulJoinOrderThreshold,
@@ -1744,7 +1744,7 @@ COptTasks::DumpMDObjs
 	const char *szFilename
 	)
 {
-	SContextRelcacheToDXL ctxrelcache(plistOids, ULONG_MAX /*ulCmpt*/, szFilename);
+	SContextRelcacheToDXL ctxrelcache(plistOids, gpos::ulong_max /*ulCmpt*/, szFilename);
 	Execute(&PvDXLFromMDObjsTask, &ctxrelcache);
 }
 
@@ -1763,7 +1763,7 @@ COptTasks::SzMDObjs
 	List *plistOids
 	)
 {
-	SContextRelcacheToDXL ctxrelcache(plistOids, ULONG_MAX /*ulCmpt*/, NULL /*szFilename*/);
+	SContextRelcacheToDXL ctxrelcache(plistOids, gpos::ulong_max /*ulCmpt*/, NULL /*szFilename*/);
 	Execute(&PvDXLFromMDObjsTask, &ctxrelcache);
 
 	return ctxrelcache.m_szDXL;
@@ -1783,7 +1783,7 @@ COptTasks::SzMDCast
 	List *plistOids
 	)
 {
-	SContextRelcacheToDXL ctxrelcache(plistOids, ULONG_MAX /*ulCmpt*/, NULL /*szFilename*/);
+	SContextRelcacheToDXL ctxrelcache(plistOids, gpos::ulong_max /*ulCmpt*/, NULL /*szFilename*/);
 	Execute(&PvMDCast, &ctxrelcache);
 
 	return ctxrelcache.m_szDXL;
@@ -1825,7 +1825,7 @@ COptTasks::SzRelStats
 	List *plistOids
 	)
 {
-	SContextRelcacheToDXL ctxrelcache(plistOids, ULONG_MAX /*ulCmpt*/, NULL /*szFilename*/);
+	SContextRelcacheToDXL ctxrelcache(plistOids, gpos::ulong_max /*ulCmpt*/, NULL /*szFilename*/);
 	Execute(&PvDXLFromRelStatsTask, &ctxrelcache);
 
 	return ctxrelcache.m_szDXL;

--- a/src/include/gpopt/translate/CQueryMutators.h
+++ b/src/include/gpopt/translate/CQueryMutators.h
@@ -84,22 +84,18 @@ namespace gpdxl
 				BOOL m_fFallbackToPlanner;
 
 				// ctor
-				SContextHavingQualMutator
-					(
-					IMemoryPool *pmp,
-					CMDAccessor *pmda,
-					ULONG ulTECount,
-					List *plTENewGroupByQuery
-					)
-					:
-					m_pmp(pmp),
-					m_pmda(pmda),
-					m_ulTECount(ulTECount),
-					m_plTENewGroupByQuery(plTENewGroupByQuery),
-					m_ulCurrLevelsUp(0),
-					m_fAggregateArg(false),
-					m_ulAggregateLevelUp(ULONG_MAX),
-					m_fFallbackToPlanner(false)
+				SContextHavingQualMutator(IMemoryPool *pmp,
+										  CMDAccessor *pmda,
+										  ULONG ulTECount,
+										  List *plTENewGroupByQuery)
+					: m_pmp(pmp),
+					  m_pmda(pmda),
+					  m_ulTECount(ulTECount),
+					  m_plTENewGroupByQuery(plTENewGroupByQuery),
+					  m_ulCurrLevelsUp(0),
+					  m_fAggregateArg(false),
+					  m_ulAggregateLevelUp(gpos::ulong_max),
+					  m_fFallbackToPlanner(false)
 				{
 					GPOS_ASSERT(NULL != plTENewGroupByQuery);
 				}


### PR DESCRIPTION
Fixes issue mentioned in: https://github.com/greenplum-db/gporca/issues/358.
Corresponding ORCA PR: https://github.com/greenplum-db/gporca/pull/365