### PR TITLE
Optimize gprecoverseg mirror state check.

### DIFF
--- a/gpMgmt/bin/gppylib/programs/test/unit/test_cluster_clsrecoversegment.py
+++ b/gpMgmt/bin/gppylib/programs/test/unit/test_cluster_clsrecoversegment.py
@@ -216,29 +216,29 @@ class GpRecoverSegmentProgramTestCase(GpTestCase):
         assert not self.subject.logger.warn.called
 
     def test_is_segment_mirror_state_mismatched_cluster_mirroring_enabled_segment_mirroring_disabled(self):
-        self.execSqlResult.fetchall.return_value = [[3], [1]]
+        self.execSqlResult.fetchall.return_value = [[0, 3], [0, 1]]
         gparray_mock = Mock(spec=GpArray)
         gparray_mock.getFaultStrategy.return_value = gparray.FAULT_STRATEGY_FILE_REPLICATION
-        segment_mock = Mock(spec=GpDB)
-        segment_mock.getSegmentContentId.return_value = 0
-        mismatched = self.subject.is_segment_mirror_state_mismatched(gparray_mock, segment_mock)
+        segment_mock = 0
+        states_mock = {0: [3, 1]}
+        mismatched = self.subject.is_segment_mirror_state_mismatched(gparray_mock, states_mock, segment_mock)
         self.assertTrue(mismatched)
 
     def test_is_segment_mirror_state_mismatched_cluster_and_segments_mirroring_enabled(self):
-        self.execSqlResult.fetchall.return_value = [[3]]
+        self.execSqlResult.fetchall.return_value = [[0, 3]]
         gparray_mock = Mock(spec=GpArray)
         gparray_mock.getFaultStrategy.return_value = gparray.FAULT_STRATEGY_FILE_REPLICATION
-        segment_mock = Mock(spec=GpDB)
-        segment_mock.getSegmentContentId.return_value = 0
-        mismatched = self.subject.is_segment_mirror_state_mismatched(gparray_mock, segment_mock)
+        segment_mock = 0
+        states_mock = {0: [3]}
+        mismatched = self.subject.is_segment_mirror_state_mismatched(gparray_mock, states_mock, segment_mock)
         self.assertFalse(mismatched)
 
     def test_is_segment_mirror_state_mismatched_cluster_and_segments_mirroring_disabled(self):
         gparray_mock = Mock(spec=GpArray)
         gparray_mock.getFaultStrategy.return_value = gparray.FAULT_STRATEGY_NONE
-        segment_mock = Mock(spec=GpDB)
-        segment_mock.getSegmentDbId.return_value = 0
-        mismatched = self.subject.is_segment_mirror_state_mismatched(gparray_mock, segment_mock)
+        segment_mock = 0
+        states_mock = {0: []}
+        mismatched = self.subject.is_segment_mirror_state_mismatched(gparray_mock, states_mock, segment_mock)
         self.assertFalse(mismatched)
 
     def test__run__when_no_replication_is_setup__raises(self):

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
@@ -40,6 +40,8 @@ class GpRecoversegTestCase(GpTestCase):
             config_file.write("")
 
         self.conn = Mock()
+        # We need to explicitly mock __enter__ and __exit__ to be able to use self.conn in with statements
+        self.conn.__enter__, self.conn.__exit__ = self.conn.open, self.conn.close
         self.cursor = FakeCursor()
         self.db_singleton = Mock()
 


### PR DESCRIPTION
Previously, gprecoverseg ran a query for an individual segment's mirror state
sequentially against individual segments, which was noticeably slow for large
clusters.  This commit modifies the check to run a single query up front to
get the mirror state for all segments at once and speed things up.