### PR TITLE
Increase the default GPORCA array expansion threshold to 100

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("2.55.", GPORCA_VERSION_STRING, 5);
+return strncmp("2.56.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 2.55.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 2.56.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -13050,7 +13050,7 @@ int
 main ()
 {
 
-return strncmp("2.55.", GPORCA_VERSION_STRING, 5);
+return strncmp("2.56.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -13060,7 +13060,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 2.55.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 2.56.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v2.55.20@gpdb/stable
+orca/v2.56.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -121,7 +121,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v2.55.20/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v2.56.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -2070,16 +2070,19 @@ fold_constants(PlannerGlobal *glob, Query *q, ParamListInfo boundParams, Size ma
 /*
  * Transform a small array constant to an ArrayExpr.
  *
- * This used by ORCA, to transform the array argument of a ScalarArrayExpr
- * into an ArrayExpr. If a ScalarArrayExpr has an ArrayExpr argument, ORCA
- * can perform some optimizations - partition pruning at least - based on
- * the elements in the ArrayExpr. It doesn't currently know how to extract
- * elements from an Array const, however, so to enable those optimizations
- * in ORCA, we convert small Array Consts into corresponding ArrayExprs.
+ * This is used by ORCA, to transform the array argument of a ScalarArrayExpr
+ * into an ArrayExpr. If a ScalarArrayExpr has an ArrayExpr argument, ORCA can
+ * perform some optimizations - partition pruning at least - by first expanding
+ * the ArrayExpr into its disjunctive normal form and then deriving constraints
+ * based on the elements in the ArrayExpr. It doesn't currently know how to
+ * extract elements from an Array const, however, so to enable those
+ * optimizations in ORCA, we convert small Array Consts into corresponding
+ * ArrayExprs.
  *
  * If the argument is not an array constant or the number of elements in the
  * array is greater than optimizer_array_expansion_threshold, returns the
- * original Const unmodified.
+ * original Const unmodified since it is expensive to derive constraints for
+ * large arrays.
  */
 Expr *
 transform_array_Const_to_ArrayExpr(Const *c)

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -3930,12 +3930,12 @@ struct config_int ConfigureNamesInt_gp[] =
 
 	{
 		{"optimizer_array_expansion_threshold", PGC_USERSET, QUERY_TUNING_METHOD,
-			gettext_noop("Item limit for expansion of arrays in WHERE clause to disjunctive form."),
+			gettext_noop("Item limit for expansion of arrays in WHERE clause for constraint derivation."),
 			NULL,
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_array_expansion_threshold,
-		25, 0, INT_MAX, NULL, NULL
+		100, 0, INT_MAX, NULL, NULL
 	},
 
 	{


### PR DESCRIPTION
It is common to have large IN/NOT IN list in user queries hence 25 seems to be quite low.
After running several experiments with large number of IN lists (ranging from 100 to 1000), 100 turned out to be good threshold value for this GUC:

Threshold = 25

  #IN elems|optimization time in ms
-----------|----------------- 
  100|68.959
  200|51.143
  300|41.278
  400|45.140
  500|40.135
 1000|98.662


Threshold = 1000

 #IN elems|optimization time in ms
-----------|----------------- 
100|223.573
200 |1288.311
300|1359.358
400|2914.829
500|3525.040
1000|14758.833

With threshold of 200+, there is manifold increase in the optimization time for above IN lists taking upto a few seconds instead of ms. Hence 100 seems to be a good enough value.
Signed-off-by: Sambitesh Dash <sdash@pivotal.io>