### PR TITLE
Revert "Fix bug that planner generates redundant motion for joins on distribution key"

### DIFF
--- a/src/backend/optimizer/path/equivclass.c
+++ b/src/backend/optimizer/path/equivclass.c
@@ -401,14 +401,6 @@ get_eclass_for_sort_expr(PlannerInfo *root,
 	EquivalenceMember *newem;
 	ListCell   *lc1;
 	MemoryContext oldcontext;
-	Expr *sort_expr = expr;
-	Oid sort_datatype = expr_datatype;
-
-	if (IsA(sort_expr, RelabelType))
-	{
-		sort_expr = ((RelabelType *) sort_expr)->arg;
-		sort_datatype = exprType((Node *) sort_expr);
-	}
 
 	/*
 	 * Scan through the existing EquivalenceClasses for a match
@@ -432,8 +424,6 @@ get_eclass_for_sort_expr(PlannerInfo *root,
 		foreach(lc2, cur_ec->ec_members)
 		{
 			EquivalenceMember *cur_em = (EquivalenceMember *) lfirst(lc2);
-			Expr	*em_expr = cur_em->em_expr;
-			Oid	em_datatype = cur_em->em_datatype;
 
 			/*
 			 * If below an outer join, don't match constants: they're not as
@@ -443,14 +433,8 @@ get_eclass_for_sort_expr(PlannerInfo *root,
 				cur_em->em_is_const)
 				continue;
 
-			if (IsA(em_expr, RelabelType))
-			{
-				em_expr = ((RelabelType *) em_expr)->arg;
-				em_datatype = exprType((Node *) em_expr);
-			}
-
-			if (sort_datatype == em_datatype &&
-				equal(sort_expr, em_expr))
+			if (expr_datatype == cur_em->em_datatype &&
+				equal(expr, cur_em->em_expr))
 				return cur_ec;	/* Match! */
 		}
 	}

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -339,36 +339,6 @@ select * from foo where a not in (select c from bar where c <= 5);
 set enable_nestloop to off;
 set enable_hashjoin to on;
 set enable_mergejoin to off;
-CREATE TABLE R(a varchar(20), b int) DISTRIBUTED BY (a);
-CREATE TABLE S(a varchar(20), b int) DISTRIBUTED BY (a);
--- Make sure there is no motion to redistribute or broadcast any table,
--- because the join keys are also the distribution key of the 2 tables.
-EXPLAIN SELECT * FROM R, S WHERE R.a = S.a;
-                                        QUERY PLAN
--------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=898.75..171576.25 rows=1260250 width=124)
-   ->  Hash Join  (cost=898.75..171576.25 rows=420084 width=124)
-         Hash Cond: r.a::text = s.a::text
-         ->  Seq Scan on r  (cost=0.00..455.00 rows=11834 width=62)
-         ->  Hash  (cost=455.00..455.00 rows=11834 width=62)
-               ->  Seq Scan on s  (cost=0.00..455.00 rows=11834 width=62)
- Settings:  enable_hashjoin=on; enable_mergejoin=off; enable_nestloop=off; optimizer=off
- Optimizer status: legacy query optimizer
-(8 rows)
-
-EXPLAIN SELECT * FROM R LEFT OUTER JOIN S ON R.a = S.a;
-                                        QUERY PLAN                                         
--------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=898.75..171576.25 rows=1260250 width=124)
-   ->  Hash Left Join  (cost=898.75..171576.25 rows=420084 width=124)
-         Hash Cond: r.a::text = s.a::text
-         ->  Seq Scan on r  (cost=0.00..455.00 rows=11834 width=62)
-         ->  Hash  (cost=455.00..455.00 rows=11834 width=62)
-               ->  Seq Scan on s  (cost=0.00..455.00 rows=11834 width=62)
- Settings:  enable_hashjoin=on; enable_mergejoin=off; enable_nestloop=off; optimizer=off
- Optimizer status: legacy query optimizer
-(8 rows)
-
 create table dept
 (
 	id int,

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -350,35 +350,6 @@ select * from foo where a not in (select c from bar where c <= 5);
 set enable_nestloop to off;
 set enable_hashjoin to on;
 set enable_mergejoin to off;
-CREATE TABLE R(a varchar(20), b int) DISTRIBUTED BY (a);
-CREATE TABLE S(a varchar(20), b int) DISTRIBUTED BY (a);
--- Make sure there is no motion to redistribute or broadcast any table,
--- because the join keys are also the distribution key of the 2 tables.
-EXPLAIN SELECT * FROM R, S WHERE R.a = S.a;
-                                       QUERY PLAN
-----------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=24)
-   ->  Hash Join  (cost=0.00..862.00 rows=1 width=24)
-         Hash Cond: r.a::text = s.a::text
-         ->  Table Scan on r  (cost=0.00..431.00 rows=1 width=12)
-         ->  Hash  (cost=431.00..431.00 rows=1 width=12)
-               ->  Table Scan on s  (cost=0.00..431.00 rows=1 width=12)
- Settings:  enable_hashjoin=on; enable_mergejoin=off; enable_nestloop=off; optimizer=on
- Optimizer status: PQO version 2.53.4
-(8 rows)
-
-EXPLAIN SELECT * FROM R LEFT OUTER JOIN S ON R.a = S.a;
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=2 width=24)
-   ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=24)
-         Hash Cond: r.a::text = s.a::text
-         ->  Table Scan on r  (cost=0.00..431.00 rows=1 width=12)
-         ->  Hash  (cost=431.00..431.00 rows=1 width=12)
-               ->  Table Scan on s  (cost=0.00..431.00 rows=1 width=12)
- Optimizer: PQO version 2.55.10
-(7 rows)
-
 create table dept
 (
 	id int,

--- a/src/test/regress/sql/join_gp.sql
+++ b/src/test/regress/sql/join_gp.sql
@@ -173,13 +173,6 @@ set enable_nestloop to off;
 set enable_hashjoin to on;
 set enable_mergejoin to off;
 
-CREATE TABLE R(a varchar(20), b int) DISTRIBUTED BY (a);
-CREATE TABLE S(a varchar(20), b int) DISTRIBUTED BY (a);
--- Make sure there is no motion to redistribute or broadcast any table,
--- because the join keys are also the distribution key of the 2 tables.
-EXPLAIN SELECT * FROM R, S WHERE R.a = S.a;
-EXPLAIN SELECT * FROM R LEFT OUTER JOIN S ON R.a = S.a;
-
 create table dept
 (
 	id int,


### PR DESCRIPTION
This reverts commit 8b0a7fed62fe23aadcde5c109927cbdf9a9a7428.

Due to this commit, full join queries with condition on varchar columns
started failing due to the below error. It is expected that there is a
relabelnode on top of varchar columns while looking up the sort
operator, however because of the said commit we removed the relabelnode.

```sql
create table foo(a varchar(30), b varchar(30));
postgres=# select X.a from foo X full join (select a from foo group by 1) Y ON X.a = Y.a;
ERROR:  could not find member 1(1043,1043) of opfamily 1994 (createplan.c:4664)
```

Will reopen the issue #4175 which brought this patch as we need to rethink the solution.