### PR TITLE
Remove FIXME in statistic computation of planner

### DIFF
--- a/src/backend/utils/adt/selfuncs.c
+++ b/src/backend/utils/adt/selfuncs.c
@@ -1217,12 +1217,7 @@ patternsel(PG_FUNCTION_ARGS, Pattern_Type ptype, bool negate)
 		 * them by applying the pattern operator, so there's no reason to
 		 * approximate.  (If the MCVs cover a significant part of the total
 		 * population, this gives us a big leg up in accuracy.)
-		 *
-		 * GPDB_84_MERGE_FIXME: this entire function is a massive conflict
-		 * because of the confusing backports and merges throughout its history.
-		 * At Venky's suggestion we have replaced this section with the 8.4
-		 * logic and removed CDB-specific pieces. Revisit.
-		 */
+		 /
 		Selectivity selec;
 		int			hist_size;
 		FmgrInfo	opproc;

--- a/src/backend/utils/adt/selfuncs.c
+++ b/src/backend/utils/adt/selfuncs.c
@@ -1217,7 +1217,7 @@ patternsel(PG_FUNCTION_ARGS, Pattern_Type ptype, bool negate)
 		 * them by applying the pattern operator, so there's no reason to
 		 * approximate.  (If the MCVs cover a significant part of the total
 		 * population, this gives us a big leg up in accuracy.)
-		 /
+		 */
 		Selectivity selec;
 		int			hist_size;
 		FmgrInfo	opproc;


### PR DESCRIPTION
Changes in 8.4 for statistics computation is comprehensive. Will fix any fallouts of this change as we observe them. Current tests show that things are kosher so removing the fix me.