### PR TITLE
Remove AppendOnlyStorage_GetUsableBlockSize().

### DIFF
--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -1584,7 +1584,7 @@ appendonly_beginrangescan_internal(Relation relation,
 	scan->aos_filenamepath_maxlen = AOSegmentFilePathNameLen(relation) + 1;
 	scan->aos_filenamepath = (char *) palloc(scan->aos_filenamepath_maxlen);
 	scan->aos_filenamepath[0] = '\0';
-	scan->usableBlockSize = AppendOnlyStorage_GetUsableBlockSize(relation->rd_appendonly->blocksize);
+	scan->usableBlockSize = relation->rd_appendonly->blocksize;
 	scan->aos_rd = relation;
 	scan->appendOnlyMetaDataSnapshot = appendOnlyMetaDataSnapshot;
 	scan->snapshot = snapshot;
@@ -2143,9 +2143,7 @@ appendonly_fetch_init(Relation relation,
 	attr->compressLevel = relation->rd_appendonly->compresslevel;
 	attr->checksum = relation->rd_appendonly->checksum;
 	attr->safeFSWriteSize = relation->rd_appendonly->safefswritesize;
-
-	aoFetchDesc->usableBlockSize =
-		AppendOnlyStorage_GetUsableBlockSize(relation->rd_appendonly->blocksize);
+	aoFetchDesc->usableBlockSize = relation->rd_appendonly->blocksize;
 
 	/*
 	 * Get information about all the file segments we need to scan
@@ -2643,7 +2641,7 @@ appendonly_insert_init(Relation rel, int segno, bool update_mode)
 /* 	aoInsertDesc->useNoToast = aoentry->notoast; */
 	aoInsertDesc->useNoToast = Debug_appendonly_use_no_toast;
 
-	aoInsertDesc->usableBlockSize = AppendOnlyStorage_GetUsableBlockSize(rel->rd_appendonly->blocksize);
+	aoInsertDesc->usableBlockSize = rel->rd_appendonly->blocksize;
 
 	attr = &aoInsertDesc->storageAttributes;
 

--- a/src/backend/cdb/cdbappendonlystorage.c
+++ b/src/backend/cdb/cdbappendonlystorage.c
@@ -20,25 +20,6 @@
 
 #include "cdb/cdbappendonlyam.h"
 
-
-int32
-AppendOnlyStorage_GetUsableBlockSize(int32 configBlockSize)
-{
-	int32		result;
-
-	if (configBlockSize > AOSmallContentHeader_MaxLength)
-		result = AOSmallContentHeader_MaxLength;
-	else
-		result = configBlockSize;
-
-	/*
-	 * Round down to 32-bit boundary.
-	 */
-	result = (result / sizeof(uint32)) * sizeof(uint32);
-
-	return result;
-}
-
 void
 appendonly_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record)
 {

--- a/src/backend/utils/datumstream/datumstream.c
+++ b/src/backend/utils/datumstream/datumstream.c
@@ -24,6 +24,7 @@
 #include "access/tuptoaster.h"
 
 #include "catalog/pg_attribute_encoding.h"
+#include "cdb/cdbappendonlyam.h"
 #include "cdb/cdbappendonlyblockdirectory.h"
 #include "cdb/cdbappendonlystoragelayer.h"
 #include "cdb/cdbappendonlystorageread.h"
@@ -369,7 +370,8 @@ init_datumstream_info(
 	/*
 	 * Adjust maxsz for Append-Only Storage.
 	 */
-	*maxAoBlockSize = AppendOnlyStorage_GetUsableBlockSize(maxsz);
+	Assert(maxsz <= MAX_APPENDONLY_BLOCK_SIZE);
+	*maxAoBlockSize = maxsz;
 
 	/*
 	 * Assume the folowing unless modified below.

--- a/src/include/cdb/cdbappendonlystorage.h
+++ b/src/include/cdb/cdbappendonlystorage.h
@@ -24,42 +24,10 @@
 										   // 14 bits, or 16,383 (16k-1).
 										   // Maximum row count for small content.
 										   
-#define AOSmallContentHeader_MaxLength   0x1FFFFF 
-										   // 21 bits, or 2,097,151 (2 Mb-1).
-										   // Maximum blocksize.  Does not include
-										   // Append-Only Storage Header overhead...
-
-/*
- * Large Content.
- */
-#define AOLargeContentHeader_MaxLargeRowCount 0x1FFFFFF 
-										   // 25 bits, or 33,554,431, or (2^25-1)
-										   // Maximum row count for large content.
-
-#define AOLargeContentHeader_MaxLargeContentLength   0x3FFFFFFF 
-										  // 30 bits, or 1,073,741,823 (1Gb-1).
-
 /*
  * Non-Bulk Dense Content.
  */
-#define AONonBulkDenseContentHeader_MaxLength   0x1FFFFF 
-											   // 21 bits, or 2,097,151 (2 Mb-1).
-											   // Maximum blocksize.  Does not include
-											   // Append-Only Storage Header overhead...
-	
 #define AONonBulkDenseContentHeader_MaxLargeRowCount 0x3FFFFFFF 
-										   // 30 bits, or 1,073,741,823, or (2^30-1)
-										   // Maximum row count for dense content.
-
-/*
- * Bulk Dense Content.
- */
-#define AOBulkDenseContentHeader_MaxLength   0x1FFFFF 
-											   // 21 bits, or 2,097,151 (2 Mb-1).
-											   // Maximum blocksize.  Does not include
-											   // Append-Only Storage Header overhead...
-	
-#define AOBulkDenseContentHeader_MaxLargeRowCount 0x3FFFFFFF 
 										   // 30 bits, or 1,073,741,823, or (2^30-1)
 										   // Maximum row count for dense content.
 
@@ -164,8 +132,5 @@ typedef enum AOHeaderCheckError
 	AOHeaderCheckInvalidOverallBlockLen,
 	AOHeaderCheckLargeContentLenIsZero,
 } AOHeaderCheckError;
-
-extern int32 AppendOnlyStorage_GetUsableBlockSize(
-	int32 configBlockSize);
 
 #endif   /* CDBAPPENDONLYSTORAGE_H */


### PR DESCRIPTION
When the blocksize is 2MB, the function AppendOnlyStorage_GetUsableBlockSize
would give out the wrong usable block size. The expected result is 2MB. But the
return value of the function call would give out (2M -4). This is because the
macro AOSmallContentHeader_MaxLength is defined as (2M -1). After rounding down
to 4 byte aligned, the result is (2M - 4).

Without the fix can encounter errors as follows: "ERROR: Used length 2097152
greater than bufferLen 2097148 at position 8388592 in table 'xxxx'".

Also removed some related, but unused macro variables, just for cleaning up
codes related to AO storage.

Co-authored-by: Lirong Jian <jian@hashdata.cn>

Note: This is slight modification to original fix proposed and discussed PR #4796.