### PR TITLE
Fix 'distribution_policy' issue on replicated table by gpcheckcat

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -461,7 +461,7 @@ def checkDistribPolicy():
       join pg_class rel on (pk.conrelid = rel.oid)
       join pg_namespace n on (rel.relnamespace = n.oid)
       join gp_distribution_policy d on (rel.oid = d.localoid)
-    where pk.contype in('p', 'u') and d.attrnums is null
+    where pk.contype in('p', 'u') and d.policytype = 'p' and d.attrnums is null
     '''
 
     db = connect2(GV.cfg[1])
@@ -502,7 +502,7 @@ def checkDistribPolicy():
       join  pg_class rel on (pk.conrelid = rel.oid)
       join  pg_namespace n on (rel.relnamespace = n.oid)
       join  gp_distribution_policy d on (rel.oid = d.localoid)
-    where pk.contype in ('p', 'u') and
+    where pk.contype in ('p', 'u') and d.policytype = 'p' and
           (d.attrnums is null or not
            d.attrnums operator(pg_catalog.<@) pk.conkey)
     '''


### PR DESCRIPTION
'distribution_policy' test do constraints check on randomly-distributed
tables, however, attrnums = null in gp_distribution_policy is no longer
effective to identify a randomly distributed table after we involved new
replicated distributed policy, so add more filter to make things right.