### PR TITLE
Refactor interconnect and dispatcher resource cleanup

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -26,6 +26,7 @@
 #include "cdb/cdbmutate.h"
 #include "cdb/cdbsrlz.h"
 #include "cdb/tupleremap.h"
+#include "nodes/execnodes.h"
 #include "tcop/tcopprot.h"
 #include "utils/datum.h"
 #include "utils/guc.h"
@@ -112,32 +113,21 @@ static void cdbdisp_dispatchCommandInternal(const char *strCommand,
 								int flags,
 								CdbPgResults *cdb_pgresults);
 
-static void cdbdisp_dispatchSetCommandToAllGangs(const char *strCommand,
-									 char *serializedQuerytree,
-									 int serializedQuerytreelen,
-									 char *serializedPlantree,
-									 int serializedPlantreelen,
-									 bool cancelOnError,
-									 struct CdbDispatcherState *ds);
-
 static int fillSliceVector(SliceTable *sliceTable,
 				int sliceIndex,
 				SliceVec *sliceVector,
 				int len);
 
-static char *buildGpQueryString(struct CdbDispatcherState *ds,
-				   DispatchCommandQueryParms *pQueryParms,
+static char *buildGpQueryString(DispatchCommandQueryParms *pQueryParms,
 				   int *finalLen);
 
 static DispatchCommandQueryParms *cdbdisp_buildPlanQueryParms(struct QueryDesc *queryDesc, bool planRequiresTxn);
 
-static void
-			cdbdisp_destroyQueryParms(DispatchCommandQueryParms *pQueryParms);
+static void cdbdisp_destroyQueryParms(DispatchCommandQueryParms *pQueryParms);
 
 static void cdbdisp_dispatchX(DispatchCommandQueryParms *pQueryParms,
-				  bool cancelOnError,
-				  struct SliceTable *sliceTbl,
-				  struct CdbDispatcherState *ds);
+				  struct EState *estate,
+				  bool cancelOnError);
 
 static int *buildSliceIndexGangIdMap(SliceVec *sliceVec, int numSlices, int numTotalSlices);
 
@@ -185,10 +175,8 @@ static char *serializeParamListInfo(ParamListInfo paramLI, int *len_p);
 void
 CdbDispatchPlan(struct QueryDesc *queryDesc,
 				bool planRequiresTxn,
-				bool cancelOnError, struct CdbDispatcherState *ds)
+				bool cancelOnError)
 {
-	SliceTable *sliceTbl;
-	int			oldLocalSlice;
 	PlannedStmt *stmt;
 	bool		is_SRI = false;
 	DispatchCommandQueryParms *pQueryParms;
@@ -197,23 +185,10 @@ CdbDispatchPlan(struct QueryDesc *queryDesc,
 	Assert(queryDesc != NULL && queryDesc->estate != NULL);
 
 	/*
-	 * Later we'll need to operate with the slice table provided via the
-	 * EState structure in the argument QueryDesc. Cache this information
-	 * locally and assert our expectations about it.
-	 */
-	sliceTbl = queryDesc->estate->es_sliceTable;
-	Assert(sliceTbl != NULL);
-
-	/*
 	 * This function is called only for planned statements.
 	 */
 	stmt = queryDesc->plannedstmt;
 	Assert(stmt);
-
-	/*
-	 * Keep old value so we can restore it. We use this field as a parameter.
-	 */
-	oldLocalSlice = sliceTbl->localSlice;
 
 	/*
 	 * Let's evaluate STABLE functions now, so we get consistent values on the
@@ -274,24 +249,59 @@ CdbDispatchPlan(struct QueryDesc *queryDesc,
 
 	pQueryParms = cdbdisp_buildPlanQueryParms(queryDesc, planRequiresTxn);
 
-	ds->primaryResults = NULL;
-	ds->dispatchParams = NULL;
-
-	cdbdisp_dispatchX(pQueryParms, cancelOnError, sliceTbl, ds);
+	cdbdisp_dispatchX(pQueryParms, queryDesc->estate, cancelOnError);
 
 	cdbdisp_destroyQueryParms(pQueryParms);
-
-	sliceTbl->localSlice = oldLocalSlice;
 }
 
 /*
  * Special for sending SET commands that change GUC variables, so they go to all
  * gangs, both reader and writer
+ *
+ * Can not dispatch SET commands to busy reader gangs (allocated by cursors) directly because another
+ * command is already in progress.
+ * Cursors only allocate reader gangs, so primary writer and idle reader gangs can be dispatched to.
  */
 void
 CdbDispatchSetCommand(const char *strCommand, bool cancelOnError)
 {
-	volatile CdbDispatcherState ds = {NULL, NULL, NULL};
+	CdbDispatcherState *ds;
+	DispatchCommandQueryParms *pQueryParms;
+	char	   *queryText;
+	int		queryTextLength;
+	Gang	   *primaryGang;
+	List	   *idleReaderGangs;
+	List	   *allocatedReaderGangs;
+	ListCell   *le;
+	int			gangCount;
+	MemoryContext oldContext;
+
+	primaryGang = AllocateWriterGang();
+	Assert(primaryGang);
+	idleReaderGangs = getAllIdleReaderGangs();
+	allocatedReaderGangs = getAllAllocatedReaderGangs();
+	gangCount = 1 + list_length(idleReaderGangs) + list_length(allocatedReaderGangs);
+
+	pQueryParms = palloc0(sizeof(*pQueryParms));
+	pQueryParms->strCommand = strCommand;
+	/*
+	 * serialized a version of our snapshot
+	 */
+	pQueryParms->serializedDtxContextInfo =
+		qdSerializeDtxContextInfo(&pQueryParms->serializedDtxContextInfolen,
+								  false /* withSnapshot */ ,
+								  false /* cursor */ ,
+								  mppTxnOptions(false), /* no two-phase commit needed for SET */
+								  "CdbDispatchSetCommand");
+
+	ds = cdbdisp_makeDispatcherState();
+	oldContext = MemoryContextSwitchTo(DispatcherContext);
+	queryText = buildGpQueryString(pQueryParms, &queryTextLength);
+	ds->primaryResults = cdbdisp_makeDispatchResults(gangCount, cancelOnError);
+	ds->dispatchParams = cdbdisp_makeDispatchParams (gangCount, queryText, queryTextLength);
+	ds->primaryResults->writer_gang = primaryGang;
+	MemoryContextSwitchTo(oldContext);
+	cdbdisp_destroyQueryParms(pQueryParms);
 
 	elog((Debug_print_full_dtm ? LOG : DEBUG5),
 		 "CdbDispatchSetCommand for command = '%s'",
@@ -302,31 +312,41 @@ CdbDispatchSetCommand(const char *strCommand, bool cancelOnError)
 				  false, /* no snapshot needed for SET */
 				  false /* inCursor */ );
 
-	PG_TRY();
+	cdbdisp_dispatchToGang(ds, primaryGang, -1, DEFAULT_DISP_DIRECT);
+
+	foreach(le, idleReaderGangs)
 	{
-		cdbdisp_dispatchSetCommandToAllGangs(strCommand, NULL, 0, NULL, 0,
-											 cancelOnError,
-											 (CdbDispatcherState *) &ds);
+		Gang	   *rg = lfirst(le);
 
-		/*
-		 * Wait for all QEs to finish. If not all of our QEs were successful,
-		 * report the error and throw up.
-		 */
-		cdbdisp_finishCommand((struct CdbDispatcherState *) &ds);
+		cdbdisp_dispatchToGang(ds, rg, -1, DEFAULT_DISP_DIRECT);
 	}
-	PG_CATCH();
+
+	/*
+	 * Can not send set command to busy gangs, so those gangs can not be
+	 * reused because their GUC is not set.
+	 */
+	foreach(le, allocatedReaderGangs)
 	{
-		/*
-		 * Something happend, clean up after ourselves
-		 */
-		CdbCheckDispatchResult((struct CdbDispatcherState *) &ds,
-							   DISPATCH_WAIT_CANCEL);
+		Gang	   *rg = lfirst(le);
 
-		cdbdisp_destroyDispatcherState((struct CdbDispatcherState *) &ds);
-
-		PG_RE_THROW();
+		if (rg->portal_name != NULL)
+		{
+			/*
+			 * For named portal (like CURSOR), SET command will not be
+			 * dispatched. Meanwhile such gang should not be reused because
+			 * it's guc was not set.
+			 */
+			rg->noReuse = true;
+		}
+		else
+		{
+			cdbdisp_dispatchToGang(ds, rg, -1, DEFAULT_DISP_DIRECT);
+		}
 	}
-	PG_END_TRY();
+
+	cdbdisp_waitDispatchFinish(ds);
+
+	cdbdisp_finishCommand(ds, NULL, NULL, true);
 }
 
 /*
@@ -441,14 +461,13 @@ cdbdisp_dispatchCommandInternal(const char *strCommand,
 								int flags,
 								CdbPgResults *cdb_pgresults)
 {
-	struct CdbDispatcherState ds = {NULL, NULL, NULL};
-	CdbDispatchResults *dispatchresults = NULL;
-
+	struct CdbDispatcherState *ds;
+	MemoryContext oldContext;
 	DispatchCommandQueryParms *pQueryParms;
-	Gang	   *primaryGang;
+	Gang		*primaryGang;
 	CdbComponentDatabaseInfo *qdinfo;
-	char	   *queryText = NULL;
-	int			queryTextLength = 0;
+	char		*queryText = NULL;
+	int		queryTextLength = 0;
 
 	if (log_dispatch_stats)
 		ResetUsage();
@@ -480,7 +499,6 @@ cdbdisp_dispatchCommandInternal(const char *strCommand,
 	 * Allocate a primary QE for every available segDB in the system.
 	 */
 	primaryGang = AllocateWriterGang();
-
 	Assert(primaryGang);
 
 	/*
@@ -504,55 +522,20 @@ cdbdisp_dispatchCommandInternal(const char *strCommand,
 	/*
 	 * Dispatch the command.
 	 */
-	ds.primaryResults = NULL;
-	ds.dispatchParams = NULL;
-	queryText = buildGpQueryString(&ds, pQueryParms, &queryTextLength);
+	ds = cdbdisp_makeDispatcherState();
+	oldContext = MemoryContextSwitchTo(DispatcherContext);
+	queryText = buildGpQueryString(pQueryParms, &queryTextLength);
+	ds->primaryResults = cdbdisp_makeDispatchResults(1, cancelOnError);
+	ds->dispatchParams = cdbdisp_makeDispatchParams (1, queryText, queryTextLength);
+	ds->primaryResults->writer_gang = primaryGang;
+	MemoryContextSwitchTo(oldContext);
 	cdbdisp_destroyQueryParms(pQueryParms);
-	cdbdisp_makeDispatcherState(&ds, /* slice count */ 1, cancelOnError, queryText, queryTextLength);
-	ds.primaryResults->writer_gang = primaryGang;
 
-	PG_TRY();
-	{
-		ErrorData *qeError;
+	cdbdisp_dispatchToGang(ds, primaryGang, -1, DEFAULT_DISP_DIRECT);
 
-		cdbdisp_dispatchToGang(&ds, primaryGang, -1, DEFAULT_DISP_DIRECT);
+	cdbdisp_waitDispatchFinish(ds);
 
-		cdbdisp_waitDispatchFinish(&ds);
-
-		/*
-		 * Block until valid results is available or one or more QEs got
-		 * errors.
-		 */
-		dispatchresults = cdbdisp_getDispatchResults(&ds, &qeError);
-
-		/*
-		 * If QEs have errors, throw it up
-		 */
-		if (!dispatchresults)
-		{
-			if (qeError)
-				ReThrowError(qeError);
-			else
-				ereport(ERROR,
-						(errmsg("could not execute command on QE"),
-						 errdetail("Command: \"%s\"", strCommand)));
-		}
-
-		if (cdb_pgresults)
-		{
-			cdbdisp_returnResults(dispatchresults, cdb_pgresults);
-		}
-
-	}
-	PG_CATCH();
-	{
-		cdbdisp_cancelDispatch(&ds);
-		cdbdisp_destroyDispatcherState(&ds);
-		PG_RE_THROW();
-	}
-	PG_END_TRY();
-
-	cdbdisp_destroyDispatcherState(&ds);
+	cdbdisp_finishCommand(ds, NULL, cdb_pgresults, true);
 }
 
 static DispatchCommandQueryParms *
@@ -885,8 +868,7 @@ fillSliceVector(SliceTable *sliceTbl, int rootIdx,
  * Build a query string to be dispatched to QE.
  */
 static char *
-buildGpQueryString(struct CdbDispatcherState *ds,
-				   DispatchCommandQueryParms *pQueryParms,
+buildGpQueryString(DispatchCommandQueryParms *pQueryParms,
 				   int *finalLen)
 {
 	const char *command = pQueryParms->strCommand;
@@ -959,14 +941,8 @@ buildGpQueryString(struct CdbDispatcherState *ds,
 		sizeof(resgroupInfo.len) +
 		resgroupInfo.len;
 
-	if (ds->dispatchStateContext == NULL)
-		ds->dispatchStateContext = AllocSetContextCreate(TopMemoryContext,
-														 "Dispatch Context",
-														 ALLOCSET_DEFAULT_MINSIZE,
-														 ALLOCSET_DEFAULT_INITSIZE,
-														 ALLOCSET_DEFAULT_MAXSIZE);
 
-	shared_query = MemoryContextAlloc(ds->dispatchStateContext, total_query_len);
+	shared_query = palloc0(total_query_len);
 
 	pos = shared_query;
 
@@ -1141,9 +1117,8 @@ buildGpQueryString(struct CdbDispatcherState *ds,
  */
 static void
 cdbdisp_dispatchX(DispatchCommandQueryParms *pQueryParms,
-				  bool cancelOnError,
-				  struct SliceTable *sliceTbl,
-				  struct CdbDispatcherState *ds)
+				  struct EState *estate,
+				  bool cancelOnError)
 {
 	SliceVec   *sliceVector = NULL;
 	int			nSlices = 1;	/* slices this dispatch cares about */
@@ -1153,10 +1128,13 @@ cdbdisp_dispatchX(DispatchCommandQueryParms *pQueryParms,
 	int			rootIdx = pQueryParms->rootIdx;
 	char	   *queryText = NULL;
 	int			queryTextLength = 0;
+	struct SliceTable *sliceTbl;
+	CdbDispatcherState *ds;
 
 	if (log_dispatch_stats)
 		ResetUsage();
 
+	sliceTbl = estate->es_sliceTable;
 	Assert(sliceTbl != NULL);
 	Assert(rootIdx == 0 ||
 		   (rootIdx > sliceTbl->nMotions &&
@@ -1177,10 +1155,15 @@ cdbdisp_dispatchX(DispatchCommandQueryParms *pQueryParms,
 	/*
 	 * Allocate result array with enough slots for QEs of primary gangs.
 	 */
-	ds->primaryResults = NULL;
-	ds->dispatchParams = NULL;
-	queryText = buildGpQueryString(ds, pQueryParms, &queryTextLength);
-	cdbdisp_makeDispatcherState(ds, nTotalSlices, cancelOnError, queryText, queryTextLength);
+	ds = cdbdisp_makeDispatcherState();
+	MemoryContext oldContext = NULL;
+	oldContext = MemoryContextSwitchTo(DispatcherContext);
+	queryText = buildGpQueryString(pQueryParms, &queryTextLength);
+	ds->primaryResults = cdbdisp_makeDispatchResults(nTotalSlices, cancelOnError);
+	ds->dispatchParams = cdbdisp_makeDispatchParams(nTotalSlices, queryText, queryTextLength);
+	MemoryContextSwitchTo(oldContext);
+
+	estate->dispatcherState = ds;
 
 	cdb_total_plans++;
 	cdb_total_slices += nSlices;
@@ -1197,7 +1180,7 @@ cdbdisp_dispatchX(DispatchCommandQueryParms *pQueryParms,
 			case 2:
 				ereport(LOG,
 						(errmsg("duration to start of dispatch send (root %d): %s ms",
-								pQueryParms->rootIdx, msec_str)));
+								rootIdx, msec_str)));
 				break;
 		}
 	}
@@ -1295,13 +1278,13 @@ cdbdisp_dispatchX(DispatchCommandQueryParms *pQueryParms,
 		/*
 		 * Cancel any QEs still running, and wait for them to terminate.
 		 */
-		CdbCheckDispatchResult(ds, DISPATCH_WAIT_CANCEL);
+		cdbdisp_cancelDispatch(ds);
 
 		/*
 		 * Check and free the results of all gangs. If any QE had an error,
 		 * report it and exit via PG_THROW.
 		 */
-		cdbdisp_finishCommand(ds);
+		cdbdisp_finishCommand(ds, NULL, NULL, true);
 
 		/*
 		 * Wasn't an error, must have been an interrupt.
@@ -1325,110 +1308,10 @@ cdbdisp_dispatchX(DispatchCommandQueryParms *pQueryParms,
 			case 2:
 				ereport(LOG,
 						(errmsg("duration to dispatch out (root %d): %s ms",
-								pQueryParms->rootIdx, msec_str)));
+								rootIdx, msec_str)));
 				break;
 		}
 	}
-}
-
-/*
- * Dispatch SET command to all gangs.
- *
- * Can not dispatch SET commands to busy reader gangs (allocated by cursors) directly because another
- * command is already in progress.
- * Cursors only allocate reader gangs, so primary writer and idle reader gangs can be dispatched to.
- */
-static void
-cdbdisp_dispatchSetCommandToAllGangs(const char *strCommand,
-									 char *serializedQuerytree,
-									 int serializedQuerytreelen,
-									 char *serializedPlantree,
-									 int serializedPlantreelen,
-									 bool cancelOnError,
-									 struct CdbDispatcherState *ds)
-{
-	DispatchCommandQueryParms *pQueryParms;
-
-	Gang	   *primaryGang;
-	List	   *idleReaderGangs;
-	List	   *allocatedReaderGangs;
-	ListCell   *le;
-	char	   *queryText = NULL;
-	int			queryTextLength;
-	int			gangCount;
-
-	pQueryParms = palloc0(sizeof(*pQueryParms));
-	pQueryParms->strCommand = strCommand;
-	pQueryParms->serializedQuerytree = serializedQuerytree;
-	pQueryParms->serializedQuerytreelen = serializedQuerytreelen;
-	pQueryParms->serializedPlantree = serializedPlantree;
-	pQueryParms->serializedPlantreelen = serializedPlantreelen;
-
-	/*
-	 * Allocate a primary QE for every available segDB in the system.
-	 */
-	primaryGang = AllocateWriterGang();
-
-	Assert(primaryGang);
-
-	/*
-	 * serialized a version of our snapshot
-	 */
-	pQueryParms->serializedDtxContextInfo =
-		qdSerializeDtxContextInfo(&pQueryParms->serializedDtxContextInfolen,
-								  false /* withSnapshot */ ,
-								  false /* cursor */ ,
-								  mppTxnOptions(false), /* no two-phase commit needed for SET */
-								  "cdbdisp_dispatchSetCommandToAllGangs");
-
-	idleReaderGangs = getAllIdleReaderGangs();
-	allocatedReaderGangs = getAllAllocatedReaderGangs();
-
-	/*
-	 * Dispatch the command.
-	 */
-	gangCount = 1 + list_length(idleReaderGangs) + list_length(allocatedReaderGangs);
-
-	ds->primaryResults = NULL;
-	ds->dispatchParams = NULL;
-	queryText = buildGpQueryString(ds, pQueryParms, &queryTextLength);
-	cdbdisp_destroyQueryParms(pQueryParms);
-	cdbdisp_makeDispatcherState(ds, gangCount, cancelOnError, queryText, queryTextLength);
-	ds->primaryResults->writer_gang = primaryGang;
-
-	cdbdisp_dispatchToGang(ds, primaryGang, -1, DEFAULT_DISP_DIRECT);
-
-	foreach(le, idleReaderGangs)
-	{
-		Gang	   *rg = lfirst(le);
-
-		cdbdisp_dispatchToGang(ds, rg, -1, DEFAULT_DISP_DIRECT);
-	}
-
-	/*
-	 * Can not send set command to busy gangs, so those gangs can not be
-	 * reused because their GUC is not set.
-	 */
-	foreach(le, allocatedReaderGangs)
-	{
-		Gang	   *rg = lfirst(le);
-
-		if (rg->portal_name != NULL)
-		{
-			/*
-			 * For named portal (like CURSOR), SET command will not be
-			 * dispatched. Meanwhile such gang should not be reused because
-			 * it's guc was not set.
-			 */
-			rg->noReuse = true;
-		}
-		else
-		{
-			cdbdisp_dispatchToGang(ds, rg, -1, DEFAULT_DISP_DIRECT);
-		}
-	}
-
-	cdbdisp_waitDispatchFinish(ds);
 }
 
 static int *

--- a/src/backend/cdb/dispatcher/cdbdispatchresult.c
+++ b/src/backend/cdb/dispatcher/cdbdispatchresult.c
@@ -871,7 +871,6 @@ cdbdisp_returnResults(CdbDispatchResults *primaryResults, CdbPgResults *cdb_pgre
 
 	/* tell the caller how many sets we're returning. */
 	cdb_pgresults->numResults = nresults;
-
 }
 
 /*

--- a/src/backend/cdb/motion/cdbmotion.c
+++ b/src/backend/cdb/motion/cdbmotion.c
@@ -600,7 +600,7 @@ SendEndOfStream(MotionLayerState *mlStates,
 	 */
 	pMNEntry = getMotionNodeEntry(mlStates, motNodeID, "SendEndOfStream");
 
-	transportStates->SendEos(mlStates, transportStates, motNodeID, s_eos_chunk_data);
+	transportStates->SendEos(transportStates, motNodeID, s_eos_chunk_data);
 
 	/*
 	 * We increment our own "stream-ends received" count when we send our own,

--- a/src/backend/cdb/motion/ic_common.c
+++ b/src/backend/cdb/motion/ic_common.c
@@ -20,6 +20,7 @@
 #include "libpq/libpq-be.h"
 #include "libpq/ip.h"
 #include "utils/builtins.h"
+#include "utils/memutils.h"
 
 #include "cdb/ml_ipc.h"
 #include "cdb/cdbvars.h"
@@ -50,7 +51,14 @@
 /*=========================================================================
  * STRUCTS
  */
+typedef struct interconnect_handle_t
+{
+	ChunkTransportState	*interconnect_context; /* Interconnect state */
 
+	ResourceOwner owner;	/* owner of this handle */
+	struct interconnect_handle_t *next;
+	struct interconnect_handle_t *prev;
+} interconnect_handle_t;
 
 /*=========================================================================
  * GLOBAL STATE VARIABLES
@@ -65,11 +73,23 @@ static int	savedSeqServerFd = -1;
 static char *savedSeqServerHost = NULL;
 static uint16 savedSeqServerPort = 0;
 
+static interconnect_handle_t *open_interconnect_handles;
+static bool interconnect_resowner_callback_registered;
+
 /*=========================================================================
  * FUNCTIONS PROTOTYPES
  */
 
 static void setupSeqServerConnection(char *hostname, uint16 port);
+
+static void interconnect_abort_callback(ResourceReleasePhase phase,
+								   bool isCommit,
+								   bool isTopLevel,
+								   void *arg);
+static void cleanup_interconnect_handle(interconnect_handle_t *h);
+static interconnect_handle_t *allocate_interconnect_handle(void);
+static void destroy_interconnect_handle(interconnect_handle_t *h);
+static interconnect_handle_t *find_interconnect_handle(ChunkTransportState *icContext);
 
 #ifdef AMS_VERBOSE_LOGGING
 static void dumpEntryConnections(int elevel, ChunkTransportStateEntry *pEntry);
@@ -660,10 +680,39 @@ setupSeqServerConnection(char *seqServerHost, uint16 seqServerPort)
 void
 SetupInterconnect(EState *estate)
 {
+	interconnect_handle_t *h;
+	ChunkTransportState *icContext = NULL;
+	MemoryContext oldContext;
+
+	if (estate->interconnect_context)
+	{
+		elog(FATAL, "SetupInterconnect: already initialized.");
+	}
+	else if (!estate->es_sliceTable)
+	{
+		elog(FATAL, "SetupInterconnect: no slice table ?");
+	}
+
+	h = allocate_interconnect_handle();
+
+	Assert(InterconnectContext != NULL);
+	oldContext = MemoryContextSwitchTo(InterconnectContext);
+
 	if (Gp_interconnect_type == INTERCONNECT_TYPE_UDPIFC)
-		SetupUDPIFCInterconnect(estate);
+		icContext = SetupUDPIFCInterconnect(estate->es_sliceTable, estate->motionlayer_context);
 	else if (Gp_interconnect_type == INTERCONNECT_TYPE_TCP)
-		SetupTCPInterconnect(estate);
+		icContext = SetupTCPInterconnect(estate->es_sliceTable, estate->motionlayer_context);
+	else
+		Assert("unsupported expected interconnect type");
+
+	/* add back-pointer for dispatch check. */
+	icContext->estate = estate;
+
+	MemoryContextSwitchTo(oldContext);
+
+	h->interconnect_context = icContext;
+	estate->interconnect_context = icContext;
+	estate->es_interconnect_is_setup = true;
 }
 
 /*
@@ -671,8 +720,7 @@ SetupInterconnect(EState *estate)
  * tons of stuff volatile in TeardownInterconnect().
  */
 void
-forceEosToPeers(MotionLayerState *mlStates,
-				ChunkTransportState *transportStates,
+forceEosToPeers(ChunkTransportState *transportStates,
 				int motNodeID)
 {
 	if (!transportStates)
@@ -682,7 +730,7 @@ forceEosToPeers(MotionLayerState *mlStates,
 
 	transportStates->teardownActive = true;
 
-	transportStates->SendEos(mlStates, transportStates, motNodeID, get_eos_tuplechunklist());
+	transportStates->SendEos(transportStates, motNodeID, get_eos_tuplechunklist());
 
 	transportStates->teardownActive = false;
 }
@@ -694,17 +742,21 @@ forceEosToPeers(MotionLayerState *mlStates,
  */
 void
 TeardownInterconnect(ChunkTransportState *transportStates,
-					 MotionLayerState *mlStates,
 					 bool forceEOS, bool hasError)
 {
+	interconnect_handle_t *h = find_interconnect_handle(transportStates);
+
 	if (Gp_interconnect_type == INTERCONNECT_TYPE_UDPIFC)
 	{
-		TeardownUDPIFCInterconnect(transportStates, mlStates, forceEOS);
+		TeardownUDPIFCInterconnect(transportStates, forceEOS);
 	}
 	else if (Gp_interconnect_type == INTERCONNECT_TYPE_TCP)
 	{
-		TeardownTCPInterconnect(transportStates, mlStates, forceEOS, hasError);
+		TeardownTCPInterconnect(transportStates, forceEOS, hasError);
 	}
+
+	if (h != NULL)
+		destroy_interconnect_handle(h);
 }
 
 /*=========================================================================
@@ -925,5 +977,104 @@ WaitInterconnectQuit(void)
 	if (Gp_interconnect_type == INTERCONNECT_TYPE_UDPIFC)
 	{
 		WaitInterconnectQuitUDPIFC();
+	}
+}
+
+interconnect_handle_t *
+allocate_interconnect_handle(void)
+{
+	interconnect_handle_t	*h;
+
+	if (InterconnectContext == NULL)
+		InterconnectContext = AllocSetContextCreate(TopMemoryContext,
+												   "Interconnect Context",
+												   ALLOCSET_DEFAULT_MINSIZE,
+												   ALLOCSET_DEFAULT_INITSIZE,
+												   ALLOCSET_DEFAULT_MAXSIZE);
+
+	h = MemoryContextAllocZero(InterconnectContext, sizeof(interconnect_handle_t));
+
+	h->owner = CurrentResourceOwner;
+	h->next = open_interconnect_handles;
+	h->prev = NULL;
+	if (open_interconnect_handles)
+		open_interconnect_handles->prev = h;
+	open_interconnect_handles = h;
+
+	if (!interconnect_resowner_callback_registered)
+	{
+		RegisterResourceReleaseCallback(interconnect_abort_callback, NULL);
+		interconnect_resowner_callback_registered = true;
+	}
+	return h;
+}
+
+static void
+destroy_interconnect_handle(interconnect_handle_t *h)
+{
+	h->interconnect_context = NULL;
+	/* unlink from linked list first */
+	if (h->prev)
+		h->prev->next = h->next;
+	else
+		open_interconnect_handles = h->next;
+	if (h->next)
+		h->next->prev = h->prev;
+
+	pfree(h);
+
+	if (open_interconnect_handles == NULL)
+		MemoryContextReset(InterconnectContext);
+}
+
+static interconnect_handle_t *
+find_interconnect_handle(ChunkTransportState *icContext)
+{
+	interconnect_handle_t *head = open_interconnect_handles;
+	while (head != NULL)
+	{
+		if (head->interconnect_context == icContext)
+			return head;
+		head = head->next;
+	}
+	return NULL;
+}
+
+static void
+cleanup_interconnect_handle(interconnect_handle_t *h)
+{
+	if (h->interconnect_context == NULL)
+	{
+		destroy_interconnect_handle(h);
+		return;
+	}
+	TeardownInterconnect(h->interconnect_context, true /* force EOS */, true);
+}
+
+static void
+interconnect_abort_callback(ResourceReleasePhase phase,
+					   bool isCommit,
+					   bool isTopLevel,
+					   void *arg)
+{
+	interconnect_handle_t *curr;
+	interconnect_handle_t *next;
+
+	if (phase != RESOURCE_RELEASE_AFTER_LOCKS)
+		return;
+
+	next = open_interconnect_handles;
+	while (next)
+	{
+		curr = next;
+		next = curr->next;
+
+		if (curr->owner == CurrentResourceOwner)
+		{
+			if (isCommit)
+				elog(WARNING, "interconnect reference leak: %p still referenced", curr);
+
+			cleanup_interconnect_handle(curr);
+		}
 	}
 }

--- a/src/backend/cdb/motion/ic_common.c
+++ b/src/backend/cdb/motion/ic_common.c
@@ -335,7 +335,7 @@ SendTupleChunkToAMS(MotionLayerState *mlStates,
 
 		if (targetRoute == BROADCAST_SEGIDX)
 		{
-			doBroadcast(mlStates, transportStates, pEntry, currItem, &recount);
+			doBroadcast(transportStates, pEntry, currItem, &recount);
 		}
 		else
 		{
@@ -344,7 +344,7 @@ SendTupleChunkToAMS(MotionLayerState *mlStates,
 			/* only send to interested connections */
 			if (conn->stillActive)
 			{
-				transportStates->SendChunk(mlStates, transportStates, pEntry, conn, currItem, motNodeID);
+				transportStates->SendChunk(transportStates, pEntry, conn, currItem, motNodeID);
 				if (!conn->stillActive)
 					recount = 1;
 			}
@@ -699,9 +699,9 @@ SetupInterconnect(EState *estate)
 	oldContext = MemoryContextSwitchTo(InterconnectContext);
 
 	if (Gp_interconnect_type == INTERCONNECT_TYPE_UDPIFC)
-		icContext = SetupUDPIFCInterconnect(estate->es_sliceTable, estate->motionlayer_context);
+		icContext = SetupUDPIFCInterconnect(estate->es_sliceTable);
 	else if (Gp_interconnect_type == INTERCONNECT_TYPE_TCP)
-		icContext = SetupTCPInterconnect(estate->es_sliceTable, estate->motionlayer_context);
+		icContext = SetupTCPInterconnect(estate->es_sliceTable);
 	else
 		Assert("unsupported expected interconnect type");
 

--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -155,7 +155,7 @@ static TupleChunkListItem RecvTupleChunkFromTCP(ChunkTransportState *transportSt
 					  int16 motNodeID,
 					  int16 srcRoute);
 
-static void SendEosTCP(MotionLayerState *mlStates, ChunkTransportState *transportStates,
+static void SendEosTCP(ChunkTransportState *transportStates,
 		   int motNodeID, TupleChunkListItem tcItem);
 
 static bool SendChunkTCP(MotionLayerState *mlStates, ChunkTransportState *transportStates,
@@ -1383,8 +1383,8 @@ acceptIncomingConnection(void)
 }								/* acceptIncomingConnection */
 
 /* See ml_ipc.h */
-void
-SetupTCPInterconnect(EState *estate)
+ChunkTransportState *
+SetupTCPInterconnect(SliceTable *sliceTable, MotionLayerState *mlStates)
 {
 	int			i,
 				index,
@@ -1404,55 +1404,41 @@ SetupTCPInterconnect(EState *estate)
 
 	/* we can have at most one of these. */
 	ChunkTransportStateEntry *sendingChunkTransportState = NULL;
-
-	if (estate->interconnect_context)
-	{
-		elog(FATAL, "SetupTCPInterconnect: already initialized.");
-	}
-	else if (!estate->es_sliceTable)
-	{
-		elog(FATAL, "SetupTCPInterconnect: no slice table ?");
-	}
+	ChunkTransportState *interconnect_context;
 
 	SIMPLE_FAULT_INJECTOR(InterconnectSetupPalloc);
-	estate->interconnect_context = palloc0(sizeof(ChunkTransportState));
-
-	estate->interconnect_context->estate = estate;
+	interconnect_context = palloc0(sizeof(ChunkTransportState));
 
 	/* initialize state variables */
-	Assert(estate->interconnect_context->size == 0);
-	estate->interconnect_context->size = CTS_INITIAL_SIZE;
-	estate->interconnect_context->states = palloc0(CTS_INITIAL_SIZE * sizeof(ChunkTransportStateEntry));
+	Assert(interconnect_context->size == 0);
+	interconnect_context->size = CTS_INITIAL_SIZE;
+	interconnect_context->states = palloc0(CTS_INITIAL_SIZE * sizeof(ChunkTransportStateEntry));
 
-	estate->interconnect_context->teardownActive = false;
-	estate->interconnect_context->activated = false;
-	estate->interconnect_context->incompleteConns = NIL;
-	estate->interconnect_context->sliceTable = NULL;
-	estate->interconnect_context->sliceId = -1;
+	interconnect_context->teardownActive = false;
+	interconnect_context->activated = false;
+	interconnect_context->incompleteConns = NIL;
+	interconnect_context->sliceTable = copyObject(sliceTable);
+	interconnect_context->sliceId = sliceTable->localSlice;
 
-	estate->interconnect_context->sliceTable = estate->es_sliceTable;
+	interconnect_context->RecvTupleChunkFrom = RecvTupleChunkFromTCP;
+	interconnect_context->RecvTupleChunkFromAny = RecvTupleChunkFromAnyTCP;
+	interconnect_context->SendEos = SendEosTCP;
+	interconnect_context->SendChunk = SendChunkTCP;
+	interconnect_context->doSendStopMessage = doSendStopMessageTCP;
 
-	estate->interconnect_context->sliceId = LocallyExecutingSliceIndex(estate);
+	mySlice = (Slice *) list_nth(interconnect_context->sliceTable->slices, sliceTable->localSlice);
 
-	estate->interconnect_context->RecvTupleChunkFrom = RecvTupleChunkFromTCP;
-	estate->interconnect_context->RecvTupleChunkFromAny = RecvTupleChunkFromAnyTCP;
-	estate->interconnect_context->SendEos = SendEosTCP;
-	estate->interconnect_context->SendChunk = SendChunkTCP;
-	estate->interconnect_context->doSendStopMessage = doSendStopMessageTCP;
-
-	mySlice = (Slice *) list_nth(estate->interconnect_context->sliceTable->slices, LocallyExecutingSliceIndex(estate));
-
-	Assert(estate->es_sliceTable &&
+	Assert(sliceTable &&
 		   IsA(mySlice, Slice) &&
-		   mySlice->sliceIndex == LocallyExecutingSliceIndex(estate));
+		   mySlice->sliceIndex == sliceTable->localSlice);
 
-	gp_interconnect_id = estate->interconnect_context->sliceTable->ic_instance_id;
+	gp_interconnect_id = interconnect_context->sliceTable->ic_instance_id;
 
 	gp_set_monotonic_begin_time(&startTime);
 
 	/* Initiate outgoing connections. */
 	if (mySlice->parentIndex != -1)
-		sendingChunkTransportState = startOutgoingConnections(estate->interconnect_context, mySlice, &expectedTotalOutgoing);
+		sendingChunkTransportState = startOutgoingConnections(interconnect_context, mySlice, &expectedTotalOutgoing);
 
 	/* now we'll do some setup for each of our Receiving Motion Nodes. */
 	foreach(cell, mySlice->children)
@@ -1465,7 +1451,7 @@ SetupTCPInterconnect(EState *estate)
 		elog(DEBUG5, "Setting up RECEIVING motion node %d", childId);
 #endif
 
-		aSlice = (Slice *) list_nth(estate->interconnect_context->sliceTable->slices, childId);
+		aSlice = (Slice *) list_nth(interconnect_context->sliceTable->slices, childId);
 
 		/*
 		 * If we're using directed-dispatch we have dummy primary-process
@@ -1482,10 +1468,10 @@ SetupTCPInterconnect(EState *estate)
 				activeNumProcs++;
 		}
 
-		(void) createChunkTransportState(estate->interconnect_context, aSlice, mySlice, totalNumProcs);
+		(void) createChunkTransportState(interconnect_context, aSlice, mySlice, totalNumProcs);
 
 		/* let cdbmotion now how many receivers to expect. */
-		setExpectedReceivers(estate->motionlayer_context, childId, activeNumProcs);
+		setExpectedReceivers(mlStates, childId, activeNumProcs);
 
 		expectedTotalIncoming += activeNumProcs;
 	}
@@ -1534,7 +1520,7 @@ SetupTCPInterconnect(EState *estate)
 		}
 
 		/* Inbound connections awaiting registration message */
-		foreach(cell, estate->interconnect_context->incompleteConns)
+		foreach(cell, interconnect_context->incompleteConns)
 		{
 			conn = (MotionConn *) lfirst(cell);
 
@@ -1578,7 +1564,7 @@ SetupTCPInterconnect(EState *estate)
 			if (conn->state == mcsSetupOutgoingConnection &&
 				conn->wakeup_ms <= elapsed_ms + 20)
 			{
-				setupOutgoingConnection(estate->interconnect_context, sendingChunkTransportState, conn);
+				setupOutgoingConnection(interconnect_context, sendingChunkTransportState, conn);
 				switch (conn->state)
 				{
 					case mcsSetupOutgoingConnection:
@@ -1587,7 +1573,7 @@ SetupTCPInterconnect(EState *estate)
 						break;
 					case mcsConnecting:
 						/* Set time limit for connect() to complete. */
-						if (estate->interconnect_context->aggressiveRetry)
+						if (interconnect_context->aggressiveRetry)
 							conn->wakeup_ms = CONNECT_AGGRESSIVERETRY_MS + elapsed_ms;
 						else
 							conn->wakeup_ms = CONNECT_RETRY_MS + elapsed_ms;
@@ -1687,9 +1673,9 @@ SetupTCPInterconnect(EState *estate)
 			/* Wait until earliest wakeup time or overall timeout. */
 			if (timeout_ms > 0)
 			{
-				ML_CHECK_FOR_INTERRUPTS(estate->interconnect_context->teardownActive);
+				ML_CHECK_FOR_INTERRUPTS(interconnect_context->teardownActive);
 				pg_usleep(timeout_ms * 1000);
-				ML_CHECK_FOR_INTERRUPTS(estate->interconnect_context->teardownActive);
+				ML_CHECK_FOR_INTERRUPTS(interconnect_context->teardownActive);
 			}
 
 			/* Back to top of loop and look again. */
@@ -1732,9 +1718,9 @@ SetupTCPInterconnect(EState *estate)
 			MemSet(&logbuf, 0, sizeof(logbuf));
 		}
 
-		ML_CHECK_FOR_INTERRUPTS(estate->interconnect_context->teardownActive);
+		ML_CHECK_FOR_INTERRUPTS(interconnect_context->teardownActive);
 		n = select(highsock + 1, (fd_set *) &rset, (fd_set *) &wset, (fd_set *) &eset, &timeout);
-		ML_CHECK_FOR_INTERRUPTS(estate->interconnect_context->teardownActive);
+		ML_CHECK_FOR_INTERRUPTS(interconnect_context->teardownActive);
 
 		elapsed_ms = gp_get_elapsed_ms(&startTime);
 
@@ -1789,7 +1775,7 @@ SetupTCPInterconnect(EState *estate)
 		 * expectedTotalIncoming, but that causes problems if some connections
 		 * are left over -- better to just process them here.
 		 */
-		cell = list_head(estate->interconnect_context->incompleteConns);
+		cell = list_head(interconnect_context->incompleteConns);
 		while (n > 0 && cell != NULL)
 		{
 			conn = (MotionConn *) lfirst(cell);
@@ -1803,14 +1789,14 @@ SetupTCPInterconnect(EState *estate)
 			if (MPP_FD_ISSET(conn->sockfd, &rset))
 			{
 				n--;
-				if (readRegisterMessage(estate->interconnect_context, conn))
+				if (readRegisterMessage(interconnect_context, conn))
 				{
 					/*
 					 * We're done with this connection (either it is bogus
 					 * (and has been dropped), or we've added it to the
 					 * appropriate hash table)
 					 */
-					estate->interconnect_context->incompleteConns = list_delete_ptr(estate->interconnect_context->incompleteConns, conn);
+					interconnect_context->incompleteConns = list_delete_ptr(interconnect_context->incompleteConns, conn);
 
 					/* is the connection ready ? */
 					if (conn->sockfd != -1)
@@ -1841,7 +1827,7 @@ SetupTCPInterconnect(EState *estate)
 				conn->msgPos = conn->pBuff;
 				conn->remapper = CreateTupleRemapper();
 
-				estate->interconnect_context->incompleteConns = lappend(estate->interconnect_context->incompleteConns, conn);
+				interconnect_context->incompleteConns = lappend(interconnect_context->incompleteConns, conn);
 			}
 		}
 
@@ -1862,7 +1848,7 @@ SetupTCPInterconnect(EState *estate)
 						MPP_FD_ISSET(conn->sockfd, &eset))
 					{
 						n--;
-						updateOutgoingConnection(estate->interconnect_context, sendingChunkTransportState, conn, -1);
+						updateOutgoingConnection(interconnect_context, sendingChunkTransportState, conn, -1);
 						switch (conn->state)
 						{
 							case mcsSetupOutgoingConnection:
@@ -1888,7 +1874,7 @@ SetupTCPInterconnect(EState *estate)
 					if (MPP_FD_ISSET(conn->sockfd, &wset))
 					{
 						n--;
-						sendRegisterMessage(estate->interconnect_context, sendingChunkTransportState, conn);
+						sendRegisterMessage(interconnect_context, sendingChunkTransportState, conn);
 						if (conn->state == mcsStarted)
 							outgoing_count++;
 					}
@@ -1915,13 +1901,13 @@ SetupTCPInterconnect(EState *estate)
 	 * out here. It would obviously be better if we could avoid these
 	 * connections in the first place!
 	 */
-	if (list_length(estate->interconnect_context->incompleteConns) != 0)
+	if (list_length(interconnect_context->incompleteConns) != 0)
 	{
 		if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG)
 			elog(DEBUG2, "Incomplete connections after known connections done, cleaning %d",
-				 list_length(estate->interconnect_context->incompleteConns));
+				 list_length(interconnect_context->incompleteConns));
 
-		while ((cell = list_head(estate->interconnect_context->incompleteConns)) != NULL)
+		while ((cell = list_head(interconnect_context->incompleteConns)) != NULL)
 		{
 			conn = (MotionConn *) lfirst(cell);
 
@@ -1933,7 +1919,7 @@ SetupTCPInterconnect(EState *estate)
 				conn->sockfd = -1;
 			}
 
-			estate->interconnect_context->incompleteConns = list_delete_ptr(estate->interconnect_context->incompleteConns, conn);
+			interconnect_context->incompleteConns = list_delete_ptr(interconnect_context->incompleteConns, conn);
 
 			if (conn->pBuff)
 				pfree(conn->pBuff);
@@ -1941,7 +1927,7 @@ SetupTCPInterconnect(EState *estate)
 		}
 	}
 
-	estate->interconnect_context->activated = true;
+	interconnect_context->activated = true;
 
 	if (gp_log_interconnect >= GPVARS_VERBOSITY_TERSE)
 	{
@@ -1952,6 +1938,7 @@ SetupTCPInterconnect(EState *estate)
 				 "%d outgoing routes.",
 				 elapsed_ms, incoming_count, outgoing_count);
 	}
+	return interconnect_context;
 }								/* SetupInterconnect */
 
 /* TeardownInterconnect() function is used to cleanup interconnect resources that
@@ -1972,7 +1959,6 @@ SetupTCPInterconnect(EState *estate)
  */
 void
 TeardownTCPInterconnect(ChunkTransportState *transportStates,
-						MotionLayerState *mlStates,
 						bool forceEOS, bool hasError)
 {
 	ListCell   *cell;
@@ -2092,7 +2078,7 @@ TeardownTCPInterconnect(ChunkTransportState *transportStates,
 		getChunkTransportState(transportStates, mySlice->sliceIndex, &pEntry);
 
 		if (forceEOS && !hasError)
-			forceEosToPeers(mlStates, transportStates, mySlice->sliceIndex);
+			forceEosToPeers(transportStates, mySlice->sliceIndex);
 
 		for (i = 0; i < pEntry->numConns; i++)
 		{
@@ -2759,8 +2745,7 @@ RecvTupleChunkFromAnyTCP(MotionLayerState *mlStates,
 
 /* See ml_ipc.h */
 static void
-SendEosTCP(MotionLayerState *mlStates,
-		   ChunkTransportState *transportStates,
+SendEosTCP(ChunkTransportState *transportStates,
 		   int motNodeID,
 		   TupleChunkListItem tcItem)
 {
@@ -2790,7 +2775,7 @@ SendEosTCP(MotionLayerState *mlStates,
 	 * we want to add our tcItem onto each of the outgoing buffers -- this is
 	 * guaranteed to leave things in a state where a flush is *required*.
 	 */
-	doBroadcast(mlStates, transportStates, pEntry, tcItem, NULL);
+	doBroadcast(NULL, transportStates, pEntry, tcItem, NULL);
 
 	/* now flush all of the buffers. */
 	for (i = 0; i < pEntry->numConns; i++)
@@ -2798,7 +2783,7 @@ SendEosTCP(MotionLayerState *mlStates,
 		conn = pEntry->conns + i;
 
 		if (conn->sockfd >= 0 && conn->state == mcsStarted)
-			flushBuffer(mlStates, transportStates, pEntry, conn, motNodeID);
+			flushBuffer(NULL, transportStates, pEntry, conn, motNodeID);
 
 #ifdef AMS_VERBOSE_LOGGING
 		elog(DEBUG5, "SendEosTCP() Leaving");
@@ -2813,7 +2798,7 @@ flushBuffer(MotionLayerState *mlStates, ChunkTransportState *transportStates,
 			ChunkTransportStateEntry *pEntry, MotionConn *conn, int16 motionId)
 {
 	char	   *sendptr;
-	MotionNodeEntry *pMNEntry;
+	MotionNodeEntry *pMNEntry = NULL;
 	int			n,
 				sent = 0;
 	mpp_fd_set	wset;
@@ -2829,7 +2814,8 @@ flushBuffer(MotionLayerState *mlStates, ChunkTransportState *transportStates,
 	}
 #endif
 
-	pMNEntry = getMotionNodeEntry(mlStates, motionId, "flushBuffer");
+	if (mlStates != NULL)
+		pMNEntry = getMotionNodeEntry(mlStates, motionId, "flushBuffer");
 
 	/* first set header length */
 	*(uint32 *) conn->pBuff = conn->msgSize;
@@ -2881,7 +2867,8 @@ flushBuffer(MotionLayerState *mlStates, ChunkTransportState *transportStates,
 					MPP_FD_SET(conn->sockfd, &wset);
 					MPP_FD_SET(conn->sockfd, &rset);
 					n = select(conn->sockfd + 1, (fd_set *) &rset, (fd_set *) &wset, NULL, &timeout);
-					pMNEntry->sel_wr_wait += (tval.tv_sec - timeout.tv_sec) * 1000000 + (tval.tv_usec - timeout.tv_usec);
+					if (pMNEntry != NULL)
+						pMNEntry->sel_wr_wait += (tval.tv_sec - timeout.tv_sec) * 1000000 + (tval.tv_usec - timeout.tv_usec);
 					if (n < 0)
 					{
 						if (errno == EINTR)

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -695,7 +695,7 @@ static void icBufferListFree(ICBufferList *list);
 static inline ICBuffer *icBufferListAppend(ICBufferList *list, ICBuffer *buf);
 static void icBufferListReturn(ICBufferList *list, bool inExpirationQueue);
 
-static void SetupUDPIFCInterconnect_Internal(EState *estate);
+static ChunkTransportState *SetupUDPIFCInterconnect_Internal(SliceTable *sliceTable, MotionLayerState *mlStates);
 static inline TupleChunkListItem RecvTupleChunkFromAnyUDPIFC_Internal(MotionLayerState *mlStates,
 									 ChunkTransportState *transportStates,
 									 int16 motNodeID,
@@ -704,7 +704,6 @@ static inline TupleChunkListItem RecvTupleChunkFromUDPIFC_Internal(ChunkTranspor
 								  int16 motNodeID,
 								  int16 srcRoute);
 static void TeardownUDPIFCInterconnect_Internal(ChunkTransportState *transportStates,
-									MotionLayerState *mlStates,
 									bool forceEOS);
 
 static void freeDisorderedPackets(MotionConn *conn);
@@ -721,7 +720,7 @@ static TupleChunkListItem RecvTupleChunkFromUDPIFC(ChunkTransportState *transpor
 static TupleChunkListItem receiveChunksUDPIFC(ChunkTransportState *pTransportStates, ChunkTransportStateEntry *pEntry,
 					int16 motNodeID, int16 *srcRoute, MotionConn *conn);
 
-static void SendEosUDPIFC(MotionLayerState *mlStates, ChunkTransportState *transportStates,
+static void SendEosUDPIFC(ChunkTransportState *transportStates,
 			  int motNodeID, TupleChunkListItem tcItem);
 static bool SendChunkUDPIFC(MotionLayerState *mlStates, ChunkTransportState *transportStates,
 				ChunkTransportStateEntry *pEntry, MotionConn *conn, TupleChunkListItem tcItem, int16 motionId);
@@ -2953,8 +2952,8 @@ handleCachedPackets(void)
  * SetupUDPIFCInterconnect_Internal
  * 		Internal function for setting up UDP interconnect.
  */
-static void
-SetupUDPIFCInterconnect_Internal(EState *estate)
+static ChunkTransportState *
+SetupUDPIFCInterconnect_Internal(SliceTable *sliceTable, MotionLayerState *mlStates)
 {
 	int			i,
 				n;
@@ -2968,44 +2967,38 @@ SetupUDPIFCInterconnect_Internal(EState *estate)
 	int			expectedTotalOutgoing = 0;
 
 	ChunkTransportStateEntry *sendingChunkTransportState = NULL;
+	ChunkTransportState *interconnect_context;
 
 	pthread_mutex_lock(&ic_control_info.lock);
 
-	gp_interconnect_id = estate->es_sliceTable->ic_instance_id;
+	gp_interconnect_id = sliceTable->ic_instance_id;
 
 	Assert(gp_interconnect_id > 0);
 
-	estate->interconnect_context = palloc0(sizeof(ChunkTransportState));
-
-	/* add back-pointer for dispatch check. */
-	estate->interconnect_context->estate = estate;
+	interconnect_context = palloc0(sizeof(ChunkTransportState));
 
 	/* initialize state variables */
-	Assert(estate->interconnect_context->size == 0);
-	estate->interconnect_context->size = CTS_INITIAL_SIZE;
-	estate->interconnect_context->states = palloc0(CTS_INITIAL_SIZE * sizeof(ChunkTransportStateEntry));
+	Assert(interconnect_context->size == 0);
+	interconnect_context->size = CTS_INITIAL_SIZE;
+	interconnect_context->states = palloc0(CTS_INITIAL_SIZE * sizeof(ChunkTransportStateEntry));
 
-	estate->interconnect_context->teardownActive = false;
-	estate->interconnect_context->activated = false;
-	estate->interconnect_context->incompleteConns = NIL;
-	estate->interconnect_context->sliceTable = NULL;
-	estate->interconnect_context->sliceId = -1;
+	interconnect_context->teardownActive = false;
+	interconnect_context->activated = false;
+	interconnect_context->incompleteConns = NIL;
+	interconnect_context->sliceTable = copyObject(sliceTable);
+	interconnect_context->sliceId = sliceTable->localSlice;
 
-	estate->interconnect_context->sliceTable = estate->es_sliceTable;
+	interconnect_context->RecvTupleChunkFrom = RecvTupleChunkFromUDPIFC;
+	interconnect_context->RecvTupleChunkFromAny = RecvTupleChunkFromAnyUDPIFC;
+	interconnect_context->SendEos = SendEosUDPIFC;
+	interconnect_context->SendChunk = SendChunkUDPIFC;
+	interconnect_context->doSendStopMessage = doSendStopMessageUDPIFC;
 
-	estate->interconnect_context->sliceId = LocallyExecutingSliceIndex(estate);
-
-	estate->interconnect_context->RecvTupleChunkFrom = RecvTupleChunkFromUDPIFC;
-	estate->interconnect_context->RecvTupleChunkFromAny = RecvTupleChunkFromAnyUDPIFC;
-	estate->interconnect_context->SendEos = SendEosUDPIFC;
-	estate->interconnect_context->SendChunk = SendChunkUDPIFC;
-	estate->interconnect_context->doSendStopMessage = doSendStopMessageUDPIFC;
-
-	mySlice = (Slice *) list_nth(estate->interconnect_context->sliceTable->slices, LocallyExecutingSliceIndex(estate));
+	mySlice = (Slice *) list_nth(interconnect_context->sliceTable->slices, sliceTable->localSlice);
 
 	Assert(mySlice &&
 		   IsA(mySlice, Slice) &&
-		   mySlice->sliceIndex == LocallyExecutingSliceIndex(estate));
+		   mySlice->sliceIndex == sliceTable->localSlice);
 
 #ifdef USE_ASSERT_CHECKING
 	set_test_mode();
@@ -3046,14 +3039,14 @@ SetupUDPIFCInterconnect_Internal(EState *estate)
 		ChunkTransportStateEntry *pEntry = NULL;
 		int			numValidProcs = 0;
 
-		aSlice = (Slice *) list_nth(estate->interconnect_context->sliceTable->slices, childId);
+		aSlice = (Slice *) list_nth(interconnect_context->sliceTable->slices, childId);
 		numProcs = list_length(aSlice->primaryProcesses);
 
 		if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG)
 			elog(DEBUG1, "Setup recving connections: my slice %d, childId %d",
 				 mySlice->sliceIndex, childId);
 
-		pEntry = createChunkTransportState(estate->interconnect_context, aSlice, mySlice, numProcs);
+		pEntry = createChunkTransportState(interconnect_context, aSlice, mySlice, numProcs);
 
 		Assert(pEntry);
 		Assert(pEntry->valid);
@@ -3115,7 +3108,7 @@ SetupUDPIFCInterconnect_Internal(EState *estate)
 		expectedTotalIncoming += numValidProcs;
 
 		/* let cdbmotion know how many receivers to expect. */
-		setExpectedReceivers(estate->motionlayer_context, childId, numValidProcs);
+		setExpectedReceivers(mlStates, childId, numValidProcs);
 	}
 
 	snd_control_info.cwnd = 0;
@@ -3132,7 +3125,7 @@ SetupUDPIFCInterconnect_Internal(EState *estate)
 		ic_control_info.lastPacketSendTime = ic_control_info.lastExpirationCheckTime;
 		ic_control_info.lastDeadlockCheckTime = ic_control_info.lastExpirationCheckTime;
 
-		sendingChunkTransportState = startOutgoingUDPConnections(estate->interconnect_context, mySlice, &expectedTotalOutgoing);
+		sendingChunkTransportState = startOutgoingUDPConnections(interconnect_context, mySlice, &expectedTotalOutgoing);
 		n = sendingChunkTransportState->numConns;
 
 		for (i = 0; i < n; i++)
@@ -3141,7 +3134,7 @@ SetupUDPIFCInterconnect_Internal(EState *estate)
 
 			if (conn->cdbProc)
 			{
-				setupOutgoingUDPConnection(estate->interconnect_context, sendingChunkTransportState, conn);
+				setupOutgoingUDPConnection(interconnect_context, sendingChunkTransportState, conn);
 				outgoing_count++;
 			}
 		}
@@ -3173,30 +3166,23 @@ SetupUDPIFCInterconnect_Internal(EState *estate)
 	if (gp_interconnect_cache_future_packets)
 		handleCachedPackets();
 
-	estate->interconnect_context->activated = true;
+	interconnect_context->activated = true;
 
 	pthread_mutex_unlock(&ic_control_info.lock);
+	return interconnect_context;
 }
 
 /*
  * SetupUDPIFCInterconnect
  * 		setup UDP interconnect.
  */
-void
-SetupUDPIFCInterconnect(EState *estate)
+ChunkTransportState *
+SetupUDPIFCInterconnect(SliceTable *sliceTable, MotionLayerState *mlStates)
 {
-	if (estate->interconnect_context)
-	{
-		elog(FATAL, "SetupUDPInterconnect: already initialized.");
-	}
-	else if (!estate->es_sliceTable)
-	{
-		elog(FATAL, "SetupUDPInterconnect: no slice table ?");
-	}
-
+	ChunkTransportState *icContext = NULL;
 	PG_TRY();
 	{
-		SetupUDPIFCInterconnect_Internal(estate);
+		icContext = SetupUDPIFCInterconnect_Internal(sliceTable, mlStates);
 
 		/* Internal error if we locked the mutex but forgot to unlock it. */
 		Assert(pthread_mutex_unlock(&ic_control_info.lock) != 0);
@@ -3207,6 +3193,7 @@ SetupUDPIFCInterconnect(EState *estate)
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
+	return icContext;
 }
 
 
@@ -3282,7 +3269,6 @@ computeNetworkStatistics(uint64 value, uint64 *min, uint64 *max, double *sum)
  */
 static void
 TeardownUDPIFCInterconnect_Internal(ChunkTransportState *transportStates,
-									MotionLayerState *mlStates,
 									bool forceEOS)
 {
 	ChunkTransportStateEntry *pEntry = NULL;
@@ -3591,12 +3577,11 @@ TeardownUDPIFCInterconnect_Internal(ChunkTransportState *transportStates,
  */
 void
 TeardownUDPIFCInterconnect(ChunkTransportState *transportStates,
-						   MotionLayerState *mlStates,
 						   bool forceEOS)
 {
 	PG_TRY();
 	{
-		TeardownUDPIFCInterconnect_Internal(transportStates, mlStates, forceEOS);
+		TeardownUDPIFCInterconnect_Internal(transportStates, forceEOS);
 
 		Assert(pthread_mutex_unlock(&ic_control_info.errorLock) != 0);
 		Assert(pthread_mutex_unlock(&ic_control_info.lock) != 0);
@@ -5406,8 +5391,7 @@ SendChunkUDPIFC(MotionLayerState *mlStates,
  *
  */
 static void
-SendEosUDPIFC(MotionLayerState *mlStates,
-			  ChunkTransportState *transportStates,
+SendEosUDPIFC(ChunkTransportState *transportStates,
 			  int motNodeID,
 			  TupleChunkListItem tcItem)
 {
@@ -5443,7 +5427,7 @@ SendEosUDPIFC(MotionLayerState *mlStates,
 	 * we want to add our tcItem onto each of the outgoing buffers -- this is
 	 * guaranteed to leave things in a state where a flush is *required*.
 	 */
-	doBroadcast(mlStates, transportStates, pEntry, tcItem, NULL);
+	doBroadcast(NULL, transportStates, pEntry, tcItem, NULL);
 
 	pEntry->sendingEos = true;
 

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -528,6 +528,7 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 
 				Assert(!estate->interconnect_context);
 				SetupInterconnect(estate);
+				UpdateMotionExpectedReceivers(estate->motionlayer_context, estate->es_sliceTable);
 
 				SIMPLE_FAULT_INJECTOR(QEGotSnapshotAndInterconnect);
 				Assert(estate->interconnect_context);
@@ -746,6 +747,7 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 				Assert(!estate->interconnect_context);
 				SetupInterconnect(estate);
 				Assert(estate->interconnect_context);
+				UpdateMotionExpectedReceivers(estate->motionlayer_context, estate->es_sliceTable);
 			}
 
 			if (estate->es_interconnect_is_setup)

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -711,7 +711,7 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 			 * finish unless an error is detected before all slices have been
 			 * dispatched.
 			 */
-			CdbDispatchPlan(queryDesc, needDtxTwoPhase, true, estate->dispatcherState);
+			CdbDispatchPlan(queryDesc, needDtxTwoPhase, true);
 		}
 
 		/*

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -526,8 +526,6 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 					InitMotionLayerNode(estate->motionlayer_context, i);
 				}
 
-				estate->es_interconnect_is_setup = true;
-
 				Assert(!estate->interconnect_context);
 				SetupInterconnect(estate);
 
@@ -745,12 +743,11 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 			if (queryDesc->planstate != NULL &&
 				queryDesc->planstate->plan->nMotionNodes > 0 && !estate->es_interconnect_is_setup)
 			{
-				estate->es_interconnect_is_setup = true;
-
 				Assert(!estate->interconnect_context);
 				SetupInterconnect(estate);
 				Assert(estate->interconnect_context);
 			}
+
 			if (estate->es_interconnect_is_setup)
 			{
 				ExecUpdateTransportState(queryDesc->planstate,

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -2355,7 +2355,7 @@ void mppExecutorFinishup(QueryDesc *queryDesc)
 		 * mark the estate to "cancelUnfinished" and then try to do a
 		 * normal interconnect teardown).
 		 */
-		TeardownInterconnect(estate->interconnect_context, estate->motionlayer_context, estate->cancelUnfinished, false);
+		TeardownInterconnect(estate->interconnect_context, estate->cancelUnfinished, false);
 		estate->es_interconnect_is_setup = false;
 	}
 }
@@ -2427,7 +2427,7 @@ void mppExecutorCleanup(QueryDesc *queryDesc)
 	/* Clean up the interconnect. */
 	if (estate->es_interconnect_is_setup)
 	{
-		TeardownInterconnect(estate->interconnect_context, estate->motionlayer_context, true /* force EOS */, true);
+		TeardownInterconnect(estate->interconnect_context, true /* force EOS */, true);
 		estate->es_interconnect_is_setup = false;
 	}
 

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -190,7 +190,7 @@ CreateExecutorState(void)
 	estate->es_got_eos = false;
 	estate->cancelUnfinished = false;
 
-	estate->dispatcherState = palloc0(sizeof(struct CdbDispatcherState));
+	estate->dispatcherState = NULL;
 
 	estate->currentSliceIdInPlan = 0;
 	estate->currentExecutingSliceId = 0;
@@ -267,11 +267,7 @@ FreeExecutorState(EState *estate)
 		/* FreeExprContext removed the list link for us */
 	}
 
-	if (estate->dispatcherState)
-	{
-		pfree(estate->dispatcherState);
-		estate->dispatcherState = NULL;
-	}
+	estate->dispatcherState = NULL;
 
 	/*
 	 * Free dynamicTableScanInfo.
@@ -2248,7 +2244,7 @@ void mppExecutorFinishup(QueryDesc *queryDesc)
 	/*
 	 * If QD, wait for QEs to finish and check their results.
 	 */
-	if (estate->dispatcherState->primaryResults)
+	if (estate->dispatcherState && estate->dispatcherState->primaryResults)
 	{
 		CdbDispatchResults *pr = estate->dispatcherState->primaryResults;
 		HTAB 			   *aopartcounts = NULL;
@@ -2346,7 +2342,7 @@ void mppExecutorFinishup(QueryDesc *queryDesc)
 		 * error, report it and exit to our error handler via PG_THROW.
 		 * NB: This call doesn't wait, because we already waited above.
 		 */
-		cdbdisp_finishCommand(estate->dispatcherState);
+		cdbdisp_finishCommand(estate->dispatcherState, NULL, NULL, true);
 	}
 
 	/* Teardown the Interconnect */
@@ -2901,6 +2897,7 @@ int RootSliceIndex(EState *estate)
 
 	return result;
 }
+
 
 #ifdef USE_ASSERT_CHECKING
 /**

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -1196,10 +1196,9 @@ PG_CATCH();
 	{
 		cdbexplain_localExecStats(planstate, econtext->ecxt_estate->showstatctx);
 		if (!explainRecvStats &&
-			shouldDispatch)
+			shouldDispatch &&
+			queryDesc->estate->dispatcherState)
 		{
-			Assert(queryDesc != NULL &&
-				   queryDesc->estate != NULL);
 			/* Wait for all gangs to finish.  Cancel slowpokes. */
 			cdbdisp_cancelDispatch(queryDesc->estate->dispatcherState);
 

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -996,6 +996,8 @@ PG_TRY();
 		SetupInterconnect(queryDesc->estate);
 		Assert((queryDesc->estate->interconnect_context));
 
+		UpdateMotionExpectedReceivers(queryDesc->estate->motionlayer_context, queryDesc->estate->es_sliceTable);
+
 		ExecUpdateTransportState(planstate, queryDesc->estate->interconnect_context);
 
 		/*

--- a/src/backend/executor/test/nodeSubplan_test.c
+++ b/src/backend/executor/test/nodeSubplan_test.c
@@ -37,10 +37,15 @@ cdbexplain_sendExecStats(QueryDesc *queryDesc)
 	mock();
 }
 
+void
+cdbdispatch_succeed(EState *estate)
+{
+	estate->dispatcherState = (CdbDispatcherState *) palloc(sizeof(CdbDispatcherState));
+}
 /* Function passed to testing framework
  * in order to force SetupInterconnect to fail */ 
 void
-_RETHROW( )
+setupinterconnect_fail(void)
 {
 	PG_RE_THROW();
 }
@@ -88,21 +93,18 @@ test__ExecSetParamPlan__Check_Dispatch_Results(void **state)
 	expect_any(CdbDispatchPlan,queryDesc);
 	expect_any(CdbDispatchPlan,planRequiresTxn);
 	expect_any(CdbDispatchPlan,cancelOnError);
-	expect_any(CdbDispatchPlan,ds);
-	will_be_called(CdbDispatchPlan);
+	will_be_called_with_sideeffect(CdbDispatchPlan, &cdbdispatch_succeed, queryDesc->estate);
 
 	expect_any(SetupInterconnect,estate);
 	/* Force SetupInterconnect to fail */
-	will_be_called_with_sideeffect(SetupInterconnect,&_RETHROW,NULL);
-
+	will_be_called_with_sideeffect(SetupInterconnect, &setupinterconnect_fail, NULL);
 
 	expect_any(cdbexplain_localExecStats,planstate);
 	expect_any(cdbexplain_localExecStats,showstatctx);
 	will_be_called(cdbexplain_localExecStats);
 
-	expect_any(CdbCheckDispatchResult,ds);
-	expect_any(CdbCheckDispatchResult,waitMode);
-	will_be_called(CdbCheckDispatchResult);
+	expect_any(cdbdisp_cancelDispatch,ds);
+	will_be_called(cdbdisp_cancelDispatch);
 
 	expect_any(cdbexplain_recvExecStats,planstate);
 	expect_any(cdbexplain_recvExecStats,dispatchResults);
@@ -111,12 +113,6 @@ test__ExecSetParamPlan__Check_Dispatch_Results(void **state)
 	will_be_called(cdbexplain_recvExecStats);
 
 	will_be_called(TeardownSequenceServer);
-
-	expect_any(TeardownInterconnect,transportStates);
-	expect_any(TeardownInterconnect,mlStates);
-	expect_any(TeardownInterconnect,forceEOS);
-	expect_any(TeardownInterconnect,hasError);
-	will_be_called(TeardownInterconnect);
 
 	/* Catch PG_RE_THROW(); after cleaning with CdbCheckDispatchResult */
 	PG_TRY();

--- a/src/backend/executor/test/nodeSubplan_test.c
+++ b/src/backend/executor/test/nodeSubplan_test.c
@@ -106,6 +106,9 @@ test__ExecSetParamPlan__Check_Dispatch_Results(void **state)
 	expect_any(cdbdisp_cancelDispatch,ds);
 	will_be_called(cdbdisp_cancelDispatch);
 
+	expect_any(CdbDispatchHandleError, ds);
+	will_be_called(CdbDispatchHandleError);
+
 	expect_any(cdbexplain_recvExecStats,planstate);
 	expect_any(cdbexplain_recvExecStats,dispatchResults);
 	expect_any(cdbexplain_recvExecStats,sliceIndex);

--- a/src/backend/utils/mmgr/mcxt.c
+++ b/src/backend/utils/mmgr/mcxt.c
@@ -72,6 +72,7 @@ MemoryContext MessageContext = NULL;
 MemoryContext TopTransactionContext = NULL;
 MemoryContext CurTransactionContext = NULL;
 MemoryContext MemoryAccountMemoryContext = NULL;
+MemoryContext DispatcherContext = NULL;
 
 /* This is a transient link to the active portal's memory context: */
 MemoryContext PortalContext = NULL;

--- a/src/backend/utils/mmgr/mcxt.c
+++ b/src/backend/utils/mmgr/mcxt.c
@@ -73,6 +73,7 @@ MemoryContext TopTransactionContext = NULL;
 MemoryContext CurTransactionContext = NULL;
 MemoryContext MemoryAccountMemoryContext = NULL;
 MemoryContext DispatcherContext = NULL;
+MemoryContext InterconnectContext = NULL;
 
 /* This is a transient link to the active portal's memory context: */
 MemoryContext PortalContext = NULL;

--- a/src/include/cdb/cdbdisp.h
+++ b/src/include/cdb/cdbdisp.h
@@ -23,6 +23,7 @@
 #define CDB_MOTION_LOST_CONTACT_STRING "Interconnect error master lost contact with segment."
 
 struct CdbDispatchResults; /* #include "cdb/cdbdispatchresult.h" */
+struct CdbPgResults;
 struct Gang; /* #include "cdb/cdbgang.h" */
 
 /*
@@ -49,7 +50,6 @@ typedef struct CdbDispatcherState
 {
 	struct CdbDispatchResults *primaryResults;
 	void *dispatchParams;
-	MemoryContext dispatchStateContext;
 } CdbDispatcherState;
 
 typedef struct DispatcherInternalFuncs
@@ -143,7 +143,10 @@ cdbdisp_getDispatchResults(struct CdbDispatcherState *ds, ErrorData **qeError);
  * instead call CdbCheckDispatchResult(), etc., directly.
  */
 void
-cdbdisp_finishCommand(struct CdbDispatcherState *ds);
+cdbdisp_finishCommand(struct CdbDispatcherState *ds,
+					 ErrorData **qeError,
+					 struct CdbPgResults *cdb_pgresults,
+					 bool throwError);
 
 /*
  * CdbDispatchHandleError
@@ -169,15 +172,8 @@ cdbdisp_cancelDispatch(CdbDispatcherState *ds);
  * Allocate memory and initialize CdbDispatcherState.
  *
  * Call cdbdisp_destroyDispatcherState to free it.
- *
- *   maxSlices: max number of slices of the query/command.
  */
-void
-cdbdisp_makeDispatcherState(CdbDispatcherState *ds,
-							int maxSlices,
-							bool cancelOnError,
-							char *queryText,
-							int queryTextLen);
+CdbDispatcherState * cdbdisp_makeDispatcherState(void);
 
 /*
  * Free memory in CdbDispatcherState
@@ -186,6 +182,11 @@ cdbdisp_makeDispatcherState(CdbDispatcherState *ds,
  * Free dispatcher memory context.
  */
 void cdbdisp_destroyDispatcherState(CdbDispatcherState *ds);
+
+void *
+cdbdisp_makeDispatchParams(int maxSlices,
+						  char *queryText,
+						  int queryTextLen);
 
 bool cdbdisp_checkForCancel(CdbDispatcherState * ds);
 int cdbdisp_getWaitSocketFd(CdbDispatcherState *ds);

--- a/src/include/cdb/cdbdisp_query.h
+++ b/src/include/cdb/cdbdisp_query.h
@@ -58,8 +58,7 @@ struct CdbPgResults;
 void
 CdbDispatchPlan(struct QueryDesc *queryDesc,
 					 bool planRequiresTxn,
-					 bool cancelOnError,
-					 struct CdbDispatcherState *ds);
+					 bool cancelOnError);
 
 /*
  * Special for sending SET commands that change GUC variables, so they go to all

--- a/src/include/cdb/cdbinterconnect.h
+++ b/src/include/cdb/cdbinterconnect.h
@@ -530,7 +530,7 @@ typedef struct ChunkTransportState
 	TupleChunkListItem (*RecvTupleChunkFrom)(struct ChunkTransportState *transportStates, int16 motNodeID, int16 srcRoute);
 	TupleChunkListItem (*RecvTupleChunkFromAny)(MotionLayerState *mlStates, struct ChunkTransportState *transportStates, int16 motNodeID, int16 *srcRoute);
 	void (*doSendStopMessage)(struct ChunkTransportState *transportStates, int16 motNodeID);
-	void (*SendEos)(MotionLayerState *mlStates, struct ChunkTransportState *transportStates, int motNodeID, TupleChunkListItem tcItem);
+	void (*SendEos)(struct ChunkTransportState *transportStates, int motNodeID, TupleChunkListItem tcItem);
 } ChunkTransportState;
 
 extern void dumpICBufferList(ICBufferList *list, const char *fname);

--- a/src/include/cdb/cdbinterconnect.h
+++ b/src/include/cdb/cdbinterconnect.h
@@ -522,13 +522,13 @@ typedef struct ChunkTransportState
 	struct SliceTable  *sliceTable;
 	int			sliceId;
 
-	/* Estate pointer for this statement (UDP-IC specific) */
+	/* Estate pointer for this statement */
 	struct EState *estate;
 
 	/* Function pointers to our send/receive functions */
-	bool (*SendChunk)(MotionLayerState *mlStates, struct ChunkTransportState *transportStates, ChunkTransportStateEntry *pEntry, MotionConn *conn, TupleChunkListItem tcItem, int16 motionId);
+	bool (*SendChunk)(struct ChunkTransportState *transportStates, ChunkTransportStateEntry *pEntry, MotionConn *conn, TupleChunkListItem tcItem, int16 motionId);
 	TupleChunkListItem (*RecvTupleChunkFrom)(struct ChunkTransportState *transportStates, int16 motNodeID, int16 srcRoute);
-	TupleChunkListItem (*RecvTupleChunkFromAny)(MotionLayerState *mlStates, struct ChunkTransportState *transportStates, int16 motNodeID, int16 *srcRoute);
+	TupleChunkListItem (*RecvTupleChunkFromAny)(struct ChunkTransportState *transportStates, int16 motNodeID, int16 *srcRoute);
 	void (*doSendStopMessage)(struct ChunkTransportState *transportStates, int16 motNodeID);
 	void (*SendEos)(struct ChunkTransportState *transportStates, int motNodeID, TupleChunkListItem tcItem);
 } ChunkTransportState;

--- a/src/include/cdb/cdbmotion.h
+++ b/src/include/cdb/cdbmotion.h
@@ -145,7 +145,8 @@ extern void SendStopMessage(MotionLayerState *mlStates,
  * This is used by cdbmotion to keep track of when its seen enough EndOfStream
  * messages.
  */
-extern void setExpectedReceivers(MotionLayerState *mlStates, int16 motNodeID, int expectedReceivers);
+extern void UpdateMotionExpectedReceivers(MotionLayerState *mlStates,
+										  struct SliceTable *sliceTable);
 
 /*
  * Return a pointer to the internal "end-of-stream" message

--- a/src/include/cdb/ml_ipc.h
+++ b/src/include/cdb/ml_ipc.h
@@ -122,7 +122,6 @@ extern void SetupInterconnect(struct EState *estate);
  *
  */
 extern void TeardownInterconnect(ChunkTransportState *transportStates,
-								 MotionLayerState *mlStates,
 								 bool forceEOS, bool hasError);
 
 extern void WaitInterconnectQuit(void);
@@ -313,8 +312,7 @@ extern ChunkTransportStateEntry *createChunkTransportState(ChunkTransportState *
 extern ChunkTransportStateEntry *removeChunkTransportState(ChunkTransportState *transportStates,
 														   int16 motNodeID);
 
-extern void forceEosToPeers(MotionLayerState       *mlStates,
-							ChunkTransportState    *transportStates,
+extern void forceEosToPeers(ChunkTransportState    *transportStates,
 							int                     motNodeID);
 
 extern TupleChunkListItem RecvTupleChunk(MotionConn *conn, ChunkTransportState *transportStates);
@@ -325,13 +323,11 @@ extern void markUDPConnInactiveIFC(MotionConn *conn);
 extern void CleanupMotionTCP(void);
 extern void CleanupMotionUDPIFC(void);
 extern void WaitInterconnectQuitUDPIFC(void);
-extern void SetupTCPInterconnect(struct EState *estate);
-extern void SetupUDPIFCInterconnect(struct EState *estate);
+extern ChunkTransportState *SetupTCPInterconnect(SliceTable *sliceTable, MotionLayerState *mlStates);
+extern ChunkTransportState *SetupUDPIFCInterconnect(SliceTable *sliceTable, MotionLayerState *mlStates);
 extern void TeardownTCPInterconnect(ChunkTransportState *transportStates,
-								 MotionLayerState *mlStates,
 								 bool forceEOS, bool hasError);
 extern void TeardownUDPIFCInterconnect(ChunkTransportState *transportStates,
-								 MotionLayerState *mlStates,
 								 bool forceEOS);
 
 extern uint32 getActiveMotionConns(void);

--- a/src/include/cdb/ml_ipc.h
+++ b/src/include/cdb/ml_ipc.h
@@ -279,7 +279,7 @@ extern void putTransportDirectBuffer(ChunkTransportState *transportStates,
  *	 pEntry - ChunkTransportState context that contains everything we need to send.
  *	 tcItem - TupleChunk to send.
  */
-#define doBroadcast(mlStates, transportStates, pEntry, tcItem, inactiveCountPtr) \
+#define doBroadcast(transportStates, pEntry, tcItem, inactiveCountPtr) \
 	do { \
 		MotionConn *conn; \
 		int			*p_inactive = inactiveCountPtr; \
@@ -294,7 +294,7 @@ extern void putTransportDirectBuffer(ChunkTransportState *transportStates,
 			/* only send to still interested receivers. */ \
 			if (conn->stillActive) \
 			{ \
-				transportStates->SendChunk(mlStates, transportStates, pEntry, conn, tcItem, pEntry->motNodeId); \
+				transportStates->SendChunk(transportStates, pEntry, conn, tcItem, pEntry->motNodeId); \
 				if (!conn->stillActive) \
 					inactive++; \
 			} \
@@ -323,8 +323,8 @@ extern void markUDPConnInactiveIFC(MotionConn *conn);
 extern void CleanupMotionTCP(void);
 extern void CleanupMotionUDPIFC(void);
 extern void WaitInterconnectQuitUDPIFC(void);
-extern ChunkTransportState *SetupTCPInterconnect(SliceTable *sliceTable, MotionLayerState *mlStates);
-extern ChunkTransportState *SetupUDPIFCInterconnect(SliceTable *sliceTable, MotionLayerState *mlStates);
+extern ChunkTransportState *SetupTCPInterconnect(SliceTable *sliceTable);
+extern ChunkTransportState *SetupUDPIFCInterconnect(SliceTable *sliceTable);
 extern void TeardownTCPInterconnect(ChunkTransportState *transportStates,
 								 bool forceEOS, bool hasError);
 extern void TeardownUDPIFCInterconnect(ChunkTransportState *transportStates,

--- a/src/include/utils/memutils.h
+++ b/src/include/utils/memutils.h
@@ -184,6 +184,7 @@ extern PGDLLIMPORT MemoryContext CurTransactionContext;
 extern PGDLLIMPORT MemoryContext MemoryAccountMemoryContext;
 extern PGDLLIMPORT MemoryContext MemoryAccountDebugContext;
 extern PGDLLIMPORT MemoryContext DispatcherContext;
+extern PGDLLIMPORT MemoryContext InterconnectContext;
 
 /* This is a transient link to the active portal's memory context: */
 extern PGDLLIMPORT MemoryContext PortalContext;

--- a/src/include/utils/memutils.h
+++ b/src/include/utils/memutils.h
@@ -183,6 +183,7 @@ extern PGDLLIMPORT MemoryContext TopTransactionContext;
 extern PGDLLIMPORT MemoryContext CurTransactionContext;
 extern PGDLLIMPORT MemoryContext MemoryAccountMemoryContext;
 extern PGDLLIMPORT MemoryContext MemoryAccountDebugContext;
+extern PGDLLIMPORT MemoryContext DispatcherContext;
 
 /* This is a transient link to the active portal's memory context: */
 extern PGDLLIMPORT MemoryContext PortalContext;


### PR DESCRIPTION
Refactor to clean up resources such that they are not dependent on `ExecutorEnd` #4761