### PR TITLE
sgml docs - create resource group page - memory_auditor limit

### DIFF
--- a/doc/src/sgml/ref/create_resource_group.sgml
+++ b/doc/src/sgml/ref/create_resource_group.sgml
@@ -28,6 +28,7 @@ where group_attribute is:
    [ CONCURRENCY=integer ]
    [ MEMORY_SHARED_QUOTA=integer ]
    [ MEMORY_SPILL_RATIO=integer ]
+   [ MEMORY_AUDITOR= {vmtracker | cgroup} ]
 
 </synopsis>
  </refsynopsisdiv>


### PR DESCRIPTION
update the CREATE RESOURCE GROUP sgml doc page to include the new MEMORY_AUDITOR property.
