### PR TITLE
Build backend/parser/scan.l and interfaces/ecpg/preproc/pgc.l standalone

### DIFF
--- a/src/backend/parser/Makefile
+++ b/src/backend/parser/Makefile
@@ -12,7 +12,7 @@ include $(top_builddir)/src/Makefile.global
 
 override CPPFLAGS := -I. -I$(srcdir) $(CPPFLAGS)
 
-OBJS= analyze.o gram.o keywords.o kwlookup.o parser.o \
+OBJS= analyze.o gram.o scan.o keywords.o kwlookup.o parser.o \
       parse_agg.o parse_clause.o parse_coerce.o parse_cte.o parse_expr.o \
       parse_func.o parse_node.o parse_oper.o parse_param.o parse_relation.o \
       parse_target.o parse_type.o parse_utilcmd.o scansup.o
@@ -23,12 +23,9 @@ FLEXFLAGS = -CF
 include $(top_srcdir)/src/backend/common.mk
 
 
-# scan is compiled as part of gram
-gram.o: scan.c
-
 # Latest flex causes warnings in this file.
 ifeq ($(GCC),yes)
-gram.o: CFLAGS += -Wno-error
+scan.o: CFLAGS += -Wno-error
 endif
 
 
@@ -59,7 +56,7 @@ endif
 
 
 # Force these dependencies to be known even without dependency info built:
-gram.o keywords.o parser.o: gram.h
+gram.o scan.o keywords.o parser.o: gram.h
 
 
 # gram.c, gram.h, and scan.c are in the distribution tarball, so they

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -15455,13 +15455,3 @@ makeIsNotDistinctFromNode(Node *expr, int position)
 	 													"=", NULL, expr, position), position);
 	return n;
 }
-
-/*
- * Must undefine this stuff before including scan.c, since it has different
- * definitions for these macros.
- */
-#undef yyerror
-#undef yylval
-#undef yylloc
-
-#include "scan.c"

--- a/src/backend/parser/scan.l
+++ b/src/backend/parser/scan.l
@@ -1,4 +1,4 @@
-%{
+%top{
 /*-------------------------------------------------------------------------
  *
  * scan.l
@@ -6,7 +6,7 @@
  *
  * NOTE NOTE NOTE:
  *
- * The rules in this file must be kept in sync with psql's lexer!!!
+ * The rules in this file must be kept in sync with psql's psqlscan.l!
  *
  * The rules are designed so that the scanner never has to backtrack,
  * in the sense that there is always a rule that can match the input
@@ -33,11 +33,13 @@
 #include <ctype.h>
 #include <unistd.h>
 
+#include "parser/gramparse.h"
 #include "parser/parser.h"				/* only needed for GUC variables */
-#include "parser/scanner.h"
 #include "parser/scansup.h"
 #include "mb/pg_wchar.h"
+}
 
+%{
 #define unify_version(a,b,c) ((a<<16)+(b<<8)+c)
 #if unify_version(YY_FLEX_MAJOR_VERSION,YY_FLEX_MINOR_VERSION,YY_FLEX_SUBMINOR_VERSION) < unify_version(2,5,35)
 int base_yyget_lineno  (void);

--- a/src/interfaces/ecpg/preproc/Makefile
+++ b/src/interfaces/ecpg/preproc/Makefile
@@ -34,7 +34,7 @@ override CFLAGS +=  $(PTHREAD_CFLAGS) -DECPG_COMPILE -Wno-unused-label -Wno-erro
 endif
 override CFLAGS += $(PTHREAD_CFLAGS) -DECPG_COMPILE
 
-OBJS=	preproc.o type.o ecpg.o output.o parser.o \
+OBJS=	preproc.o pgc.o type.o ecpg.o output.o parser.o \
 	keywords.o c_keywords.o ecpg_keywords.o kwlookup.o ../ecpglib/typename.o descriptor.o variable.o \
 	$(WIN32RES)
 
@@ -42,9 +42,6 @@ all: submake-libpgport ecpg
 
 ecpg: $(OBJS)
 	$(CC) $(CFLAGS) $(LDFLAGS) $(LDFLAGS_EX) $^ $(LIBS) $(PTHREAD_LIBS) -o $@$(X)
-
-# pgc is compiled as part of preproc
-preproc.o: pgc.c
 
 preproc.h: preproc.c ;
 
@@ -66,7 +63,7 @@ preproc.y: ../../../backend/parser/gram.y parse.pl ecpg.addons ecpg.header ecpg.
 	$(PERL) $(srcdir)/parse.pl $(srcdir) < $< > $@ 
 	$(PERL) $(srcdir)/check_rules.pl $(srcdir) $<
 
-ecpg_keywords.o c_keywords.o keywords.o preproc.o parser.o: preproc.h
+ecpg_keywords.o c_keywords.o keywords.o preproc.o pgc.o parser.o: preproc.h
 
 kwlookup.c: % : $(top_srcdir)/src/backend/parser/%
 	rm -f $@ && $(LN_S) $< .

--- a/src/interfaces/ecpg/preproc/ecpg.trailer
+++ b/src/interfaces/ecpg/preproc/ecpg.trailer
@@ -1891,11 +1891,3 @@ void parser_init(void)
 {
  /* This function is empty. It only exists for compatibility with the backend parser right now. */
 }
-
-/*
- * Must undefine base_yylex before including pgc.c, since we want it
- * to create the function base_yylex not filtered_base_yylex.
- */
-#undef base_yylex
-
-#include "pgc.c"

--- a/src/interfaces/ecpg/preproc/pgc.l
+++ b/src/interfaces/ecpg/preproc/pgc.l
@@ -1,4 +1,4 @@
-%{
+%top{
 /*-------------------------------------------------------------------------
  *
  * pgc.l
@@ -23,7 +23,19 @@
 #include <limits.h>
 
 #include "extern.h"
+#include "preproc.h"
 
+/*
+ * Change symbol names as expected by preproc.l.  It'd be better to do this
+ * with %option prefix="base_yy", but that affects some other names that
+ * various files expect *not* to be prefixed with "base_".  Cleaning it up
+ * is not worth the trouble right now.
+ */
+#define yylex           base_yylex
+#define yylval          base_yylval
+}
+
+%{
 extern YYSTYPE yylval;
 
 static int		xcdepth = 0;	/* depth of nesting in slash-star comments */


### PR DESCRIPTION
We are developing on a machine with flex 2.6.4 and we couldn't build.
This was fixed in 72b1e3a2 in upstream (9.6 at the time) in 2016, but
wasn't backported to 9.1 or older.

Original commit message:
> Now that we know about the %top{} trick, we can revert to building flex
> lexers as separate .o files.  This is worth doing for a couple of reasons
> besides sheer cleanliness.  We can narrow the scope of the -Wno-error flag
> that's forced on scan.c.  Also, since these grammar and lexer files are
> so large, splitting them into separate build targets should have some
> advantages in build speed, particularly in parallel or ccache'd builds.
>
> We have quite a few other .l files that could be changed likewise, but the
> above arguments don't apply to them, so the benefit of fixing them seems
> pretty minimal.  Leave the rest for some other day.

(cherry picked from commit 72b1e3a21f0540ffa5c1f8f474b6c52097a368bb)

Fixes greenplum-db/gpdb#4863
Co-authored-by: Jesse Zhang <sbjesse@gmail.com>
