### PR TITLE
Fix gpsd to account newly added column in pg_statistic

### DIFF
--- a/gpMgmt/bin/gpsd
+++ b/gpMgmt/bin/gpsd
@@ -90,6 +90,7 @@ def dumpStats(cur):
         'INSERT INTO pg_statistic VALUES (\n' \
         '{2});\n\n'
     types = ['smallint',  # staattnum
+             'boolean',
              'real',
              'integer',
              'real',


### PR DESCRIPTION
Recent postgres merge introduced a new column `stainherit` to
`pg_statistic` table. When `gpsd` dumps the pg_statistic not only a
column is missing but also all the other columns are shifted and saved
in wrong column index. This causes failure on reloading the gpsd.

This PR fixes the issue and adds the missing column.