### PR TITLE
resgroup: dump cgroup memory limit with _granted suffix.

### DIFF
--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -3477,7 +3477,7 @@ groupMemOnDumpForCgroup(ResGroupData *group, StringInfo str)
 	appendStringInfo(str, "\"usage\":%d, ",
 			VmemTracker_ConvertVmemChunksToMB(
 				ResGroupOps_GetMemoryUsage(group->groupId) / ResGroupGetSegmentNum()));
-	appendStringInfo(str, "\"limit\":%d",
+	appendStringInfo(str, "\"limit_granted\":%d",
 			VmemTracker_ConvertVmemChunksToMB(
 				ResGroupOps_GetMemoryLimit(group->groupId) / ResGroupGetSegmentNum()));
 	appendStringInfo(str, "}");

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -3474,7 +3474,7 @@ static void
 groupMemOnDumpForCgroup(ResGroupData *group, StringInfo str)
 {
 	appendStringInfo(str, "{");
-	appendStringInfo(str, "\"usage\":%d, ",
+	appendStringInfo(str, "\"used\":%d, ",
 			VmemTracker_ConvertVmemChunksToMB(
 				ResGroupOps_GetMemoryUsage(group->groupId) / ResGroupGetSegmentNum()));
 	appendStringInfo(str, "\"limit_granted\":%d",


### PR DESCRIPTION
This is to make the dump message consistent between 'vmtracker' and
'cgroup' resgroups.