### PR TITLE
resgroup: fix an access to uninitialized address.

### DIFF
--- a/src/backend/utils/resgroup/resgroup-ops-linux.c
+++ b/src/backend/utils/resgroup/resgroup-ops-linux.c
@@ -99,9 +99,6 @@ static bool detectCgroupMountPoint(void);
 static Oid currentGroupIdInCGroup = InvalidOid;
 static char cgdir[MAXPGPATH];
 
-bool gp_resource_group_enable_cgroup_memory = false;
-bool gp_resource_group_enable_cgroup_swap = false;
-
 /*
  * These checks should keep in sync with gpMgmt/bin/gpcheckresgroupimpl
  */

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -641,9 +641,10 @@ ResGroupDropFinish(Oid groupId, bool isCommit)
 	{
 		savedInterruptHoldoffCount = InterruptHoldoffCount;
 
+		group = groupHashFind(groupId, true);
+
 		if (Gp_role == GP_ROLE_DISPATCH)
 		{
-			group = groupHashFind(groupId, true);
 			wakeupSlots(group, false);
 			unlockResGroupForDrop(group);
 		}
@@ -652,10 +653,10 @@ ResGroupDropFinish(Oid groupId, bool isCommit)
 		{
 			bool		migrate;
 
-			removeGroup(groupId);
-
 			/* Only migrate processes out of vmtracker groups */
 			migrate = group->memAuditor == RESGROUP_MEMORY_AUDITOR_VMTRACKER;
+
+			removeGroup(groupId);
 
 			ResGroupOps_DestroyGroup(groupId, migrate);
 		}

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -232,6 +232,9 @@ struct ResGroupControl
 	ResGroupData	groups[1];
 };
 
+bool gp_resource_group_enable_cgroup_memory = false;
+bool gp_resource_group_enable_cgroup_swap = false;
+
 /* hooks */
 resgroup_assign_hook_type resgroup_assign_hook = NULL;
 


### PR DESCRIPTION
In ResGroupDropFinish() uninitialized memory address can be accessed due
to some reasons:

1. the group pointer is not initialized on segments;
2. the hash table node pointed by group is recycled in removeGroup();

This invalid access can cause crash issue on segments.