### PR TITLE
Adds gometalinter unparam

### DIFF
--- a/gpMgmt/go-utils/src/gp_upgrade/agent/services/agent_server_test.go
+++ b/gpMgmt/go-utils/src/gp_upgrade/agent/services/agent_server_test.go
@@ -3,20 +3,20 @@ package services_test
 import (
 	"gp_upgrade/utils"
 
+	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"gp_upgrade/agent/services"
 	"gp_upgrade/testutils"
 	"io/ioutil"
 	"os"
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 )
 
 var _ = Describe("AgentServer", func() {
 	var (
-		dir         string
-		agentConf   services.AgentConfig
-		exists      func() bool
+		dir       string
+		agentConf services.AgentConfig
+		exists    func() bool
 	)
 
 	BeforeEach(func() {

--- a/gpMgmt/go-utils/src/gp_upgrade/agent/services/ping_agents_test.go
+++ b/gpMgmt/go-utils/src/gp_upgrade/agent/services/ping_agents_test.go
@@ -9,16 +9,11 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gbytes"
 )
 
 var _ = Describe("CommandListener", func() {
-	var (
-		testLogFile *gbytes.Buffer
-	)
-
 	BeforeEach(func() {
-		_, _, testLogFile = testhelper.SetupTestLogger()
+		testhelper.SetupTestLogger()
 	})
 
 	AfterEach(func() {

--- a/gpMgmt/go-utils/src/gp_upgrade/cli/commanders/check_disk_usage.go
+++ b/gpMgmt/go-utils/src/gp_upgrade/cli/commanders/check_disk_usage.go
@@ -15,7 +15,7 @@ func NewDiskUsageChecker(client pb.CliToHubClient) DiskUsageChecker {
 	return DiskUsageChecker{client: client}
 }
 
-func (req DiskUsageChecker) Execute(dbPort int) error {
+func (req DiskUsageChecker) Execute() error {
 	reply, err := req.client.CheckDiskUsage(context.Background(),
 		&pb.CheckDiskUsageRequest{})
 	if err != nil {

--- a/gpMgmt/go-utils/src/gp_upgrade/cli/commanders/check_disk_usage_test.go
+++ b/gpMgmt/go-utils/src/gp_upgrade/cli/commanders/check_disk_usage_test.go
@@ -39,7 +39,7 @@ var _ = Describe("object count tests", func() {
 			).Return(&pb.CheckDiskUsageReply{}, errors.New("couldn't connect to hub"))
 
 			request := commanders.NewDiskUsageChecker(client)
-			err := request.Execute(9999)
+			err := request.Execute()
 
 			Expect(err).ToNot(BeNil())
 			Expect(string(testLogFile.Contents())).To(ContainSubstring("ERROR - gRPC call to hub failed"))
@@ -59,7 +59,7 @@ var _ = Describe("object count tests", func() {
 			).Return(&pb.CheckDiskUsageReply{SegmentFileSysUsage: expectedFilesystemsUsage}, nil)
 
 			request := commanders.NewDiskUsageChecker(client)
-			err := request.Execute(9999)
+			err := request.Execute()
 
 			Expect(err).To(BeNil())
 			Expect(string(testStdout.Contents())).To(ContainSubstring("diskspace check - hostC  - Couldn't connect"))

--- a/gpMgmt/go-utils/src/gp_upgrade/cli/commanders/reporter_test.go
+++ b/gpMgmt/go-utils/src/gp_upgrade/cli/commanders/reporter_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"gp_upgrade/cli/commanders"
 	pb "gp_upgrade/idl"
-	mockpb "gp_upgrade/mock_idl"
 
 	"github.com/golang/mock/gomock"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
@@ -20,7 +19,6 @@ var _ = Describe("Reporter", func() {
 		spyClient   *spyCliToHubClient
 		testLogFile *gbytes.Buffer
 		reporter    *commanders.Reporter
-		client      *mockpb.MockCliToHubClient
 		ctrl        *gomock.Controller
 	)
 
@@ -29,7 +27,6 @@ var _ = Describe("Reporter", func() {
 		_, _, testLogFile = testhelper.SetupTestLogger()
 		reporter = commanders.NewReporter(spyClient)
 		ctrl = gomock.NewController(GinkgoT())
-		client = mockpb.NewMockCliToHubClient(ctrl)
 	})
 
 	AfterEach(func() {

--- a/gpMgmt/go-utils/src/gp_upgrade/cli/commands.go
+++ b/gpMgmt/go-utils/src/gp_upgrade/cli/commands.go
@@ -207,7 +207,7 @@ var subDiskSpace = &cobra.Command{
 			os.Exit(1)
 		}
 		client := pb.NewCliToHubClient(conn)
-		return commanders.NewDiskUsageChecker(client).Execute(dbPort)
+		return commanders.NewDiskUsageChecker(client).Execute()
 	},
 }
 

--- a/gpMgmt/go-utils/src/gp_upgrade/gometalinter.config
+++ b/gpMgmt/go-utils/src/gp_upgrade/gometalinter.config
@@ -1,10 +1,16 @@
 {
   "DisableAll": true,
-  "Enable": ["golint"],
+  "Enable": [
+    "golint",
+    "unparam",
+    "vet",
+    "varcheck"
+    ],
   "Exclude": [
     "should have comment",
     "comment on exported",
     "should not use dot imports",
-    "don't use ALL_CAPS in Go names; use CamelCase"
+    "don't use ALL_CAPS in Go names; use CamelCase",
+    "literal copies lock value from"
   ]
 }

--- a/gpMgmt/go-utils/src/gp_upgrade/hub/cluster/cluster_pair_test.go
+++ b/gpMgmt/go-utils/src/gp_upgrade/hub/cluster/cluster_pair_test.go
@@ -34,9 +34,7 @@ const (
 
 var _ = Describe("ClusterPair", func() {
 	var (
-		dir              string
-		mockedOutput     string
-		mockedExitStatus int
+		dir string
 
 		filesLaidDown []string
 		commandExecer *testutils.FakeCommandExecer
@@ -83,9 +81,6 @@ var _ = Describe("ClusterPair", func() {
 		})
 
 		It("Logs successfully when things work", func() {
-			mockedExitStatus = 0
-			mockedOutput = "Something that's not bad"
-
 			outChan <- []byte("some output")
 
 			subject := cluster.Pair{}
@@ -118,9 +113,6 @@ var _ = Describe("ClusterPair", func() {
 		})
 
 		It("puts Stop failures in the log and leaves files to mark the error", func() {
-			mockedExitStatus = 127
-			mockedOutput = "gpstop failed us" // what gpstop puts in its own logs
-
 			errChan <- errors.New("failed")
 
 			subject := cluster.Pair{}

--- a/gpMgmt/go-utils/src/gp_upgrade/hub/configutils/config.go
+++ b/gpMgmt/go-utils/src/gp_upgrade/hub/configutils/config.go
@@ -24,7 +24,7 @@ type Segment struct {
 	Dbid          int    `json:"dbid"`
 	Hostname      string `json:"hostname"`
 	Mode          string `json:"mode"`
-	Status        string `json:"status""`
+	Status        string `json:"status"`
 	Port          int    `json:"port"`
 	PreferredRole string `json:"preferred_role" db:"preferred_role"`
 	Role          string `json:"role"`

--- a/gpMgmt/go-utils/src/gp_upgrade/hub/services/bootstrapper.go
+++ b/gpMgmt/go-utils/src/gp_upgrade/hub/services/bootstrapper.go
@@ -30,6 +30,8 @@ func NewBootstrapper(hg HostnameGetter, r RemoteExecutor) *Bootstrapper {
 	}
 }
 
+// grpc generated function signature requires ctx and in params.
+// nolint: unparam
 func (s *Bootstrapper) CheckSeginstall(ctx context.Context, in *pb.CheckSeginstallRequest) (*pb.CheckSeginstallReply, error) {
 	gplog.Info("starting CheckSeginstall()")
 
@@ -43,6 +45,8 @@ func (s *Bootstrapper) CheckSeginstall(ctx context.Context, in *pb.CheckSeginsta
 	return &pb.CheckSeginstallReply{}, nil
 }
 
+// grpc generated function signature requires ctx and in params.
+// nolint: unparam
 func (s *Bootstrapper) PrepareStartAgents(ctx context.Context,
 	in *pb.PrepareStartAgentsRequest) (*pb.PrepareStartAgentsReply, error) {
 

--- a/gpMgmt/go-utils/src/gp_upgrade/hub/services/hub.go
+++ b/gpMgmt/go-utils/src/gp_upgrade/hub/services/hub.go
@@ -54,8 +54,9 @@ type HubClient struct {
 }
 
 type Connection struct {
-	Conn     *grpc.ClientConn
-	Hostname string
+	Conn          *grpc.ClientConn
+	Hostname      string
+	CancelContext func()
 }
 
 type HubConfig struct {
@@ -142,15 +143,17 @@ func (h *HubClient) AgentConns() ([]*Connection, error) {
 	}
 
 	for _, host := range hostnames {
-		ctx, _ := context.WithTimeout(context.Background(), DialTimeout)
+		ctx, cancelFunc := context.WithTimeout(context.Background(), DialTimeout)
 		conn, err := h.grpcDialer(ctx, host+":"+strconv.Itoa(h.conf.HubToAgentPort), grpc.WithInsecure(), grpc.WithBlock())
 		if err != nil {
 			gplog.Error("grpcDialer failed: ", err)
+			cancelFunc()
 			return nil, err
 		}
 		h.agentConns = append(h.agentConns, &Connection{
-			Conn:     conn,
-			Hostname: host,
+			Conn:          conn,
+			Hostname:      host,
+			CancelContext: cancelFunc,
 		})
 	}
 
@@ -181,6 +184,7 @@ func (h *HubClient) ensureConnsAreReady() error {
 
 func (h *HubClient) closeConns() {
 	for _, conn := range h.agentConns {
+		defer conn.CancelContext()
 		err := conn.Conn.Close()
 		if err != nil {
 			gplog.Info(fmt.Sprintf("Error closing hub to agent connection. host: %s, err: %s", conn.Hostname, err.Error()))

--- a/gpMgmt/go-utils/src/gp_upgrade/hub/services/hub_check_disk_usage.go
+++ b/gpMgmt/go-utils/src/gp_upgrade/hub/services/hub_check_disk_usage.go
@@ -14,7 +14,6 @@ import (
 
 const (
 	// todo generalize to any host
-	address               = "localhost"
 	diskUsageWarningLimit = 80
 )
 

--- a/gpMgmt/go-utils/src/gp_upgrade/hub/services/hub_ping_agents_test.go
+++ b/gpMgmt/go-utils/src/gp_upgrade/hub/services/hub_ping_agents_test.go
@@ -28,9 +28,9 @@ var _ = Describe("hub pings agents test", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		client = mockpb.NewMockAgentClient(ctrl)
 		pingerManager = &services.PingerManager{
-			[]configutils.ClientAndHostname{{Client: client, Hostname: "doesnotexist"}},
-			10,
-			1 * time.Millisecond,
+			RPCClients:       []configutils.ClientAndHostname{{Client: client, Hostname: "doesnotexist"}},
+			NumRetries:       10,
+			PauseBeforeRetry: 1 * time.Millisecond,
 		}
 	})
 

--- a/gpMgmt/go-utils/src/gp_upgrade/hub/services/hub_upgrade_convert_master.go
+++ b/gpMgmt/go-utils/src/gp_upgrade/hub/services/hub_upgrade_convert_master.go
@@ -18,7 +18,7 @@ func (h *HubClient) UpgradeConvertMaster(ctx context.Context, in *pb.UpgradeConv
 	gplog.Info("Starting master upgrade")
 	//need to remember where we ran, i.e. pathToUpgradeWD, b/c pg_upgrade generates some files that need to be copied to QE nodes later
 	//this is also where the 1.done, 2.inprogress ... files will be written
-	err := h.convertMaster("pg_upgrade", in)
+	err := h.convertMaster(in)
 	if err != nil {
 		gplog.Error("%v", err)
 		return &pb.UpgradeConvertMasterReply{}, err
@@ -27,7 +27,8 @@ func (h *HubClient) UpgradeConvertMaster(ctx context.Context, in *pb.UpgradeConv
 	return &pb.UpgradeConvertMasterReply{}, nil
 }
 
-func (h *HubClient) convertMaster(upgradeFileName string, in *pb.UpgradeConvertMasterRequest) error {
+func (h *HubClient) convertMaster(in *pb.UpgradeConvertMasterRequest) error {
+	upgradeFileName := "pg_upgrade"
 	pathToUpgradeWD := filepath.Join(h.conf.StateDir, upgradeFileName)
 	err := utils.System.MkdirAll(pathToUpgradeWD, 0700)
 	if err != nil {

--- a/gpMgmt/go-utils/src/gp_upgrade/hub/services/hub_upgrade_convert_primaries_test.go
+++ b/gpMgmt/go-utils/src/gp_upgrade/hub/services/hub_upgrade_convert_primaries_test.go
@@ -26,9 +26,9 @@ var _ = Describe("hub.UpgradeConvertPrimaries()", func() {
 		mockAgent     *testutils.MockAgentServer
 		segmentConfs  chan configutils.SegmentConfiguration
 		port          int
-		request 	  *pb.UpgradeConvertPrimariesRequest
-		oldConf			configutils.SegmentConfiguration
-		newConf			configutils.SegmentConfiguration
+		request       *pb.UpgradeConvertPrimariesRequest
+		oldConf       configutils.SegmentConfiguration
+		newConf       configutils.SegmentConfiguration
 	)
 
 	BeforeEach(func() {


### PR DESCRIPTION
The following items should be resolved before merging:

cli/commanders/check_disk_usage.go:18:37:  parameter dbPort is unused (unparam)
hub/services/bootstrapper.go:33:40: parameter ctx is unused (unparam)
hub/services/bootstrapper.go:33:61: parameter in is unused (unparam)
hub/services/bootstrapper.go:46:43: parameter ctx is unused (unparam)
hub/services/bootstrapper.go:47:2: parameter in is unused (unparam)
hub/services/hub_upgrade_convert_master.go:30:35: parameter upgradeFileName always receives "pg_upgrade" (unparam)
make: *** [lint] Error 1

Reboot of the pull request https://github.com/greenplum-db/gpdb/pull/4453