### PR TITLE
docs: gpbackup/gprestore S3 plugin

### DIFF
--- a/gpdb-doc/dita/admin_guide/managing/backup-gpbackup.xml
+++ b/gpdb-doc/dita/admin_guide/managing/backup-gpbackup.xml
@@ -53,8 +53,8 @@
             than 1).</li>
           <li>You cannot use the <codeph>--exclude-table-file</codeph> with
               <codeph>--leaf-partition-data</codeph>. Although you can specify leaf partition names
-            in a file specified with <codeph>--exclude-table-file</codeph>, <codeph>gpbackup</codeph>
-            ignores the partition names.</li>
+            in a file specified with <codeph>--exclude-table-file</codeph>,
+              <codeph>gpbackup</codeph> ignores the partition names.</li>
           <li>Incremental backups are not supported.</li>
         </ul></p>
     </body>
@@ -90,6 +90,7 @@
                     <li>Sequences</li>
                     <li dir="ltr">Comments</li>
                     <li dir="ltr">Tables</li>
+                    <li>Indexes</li>
                     <li dir="ltr">Owners</li>
                     <li dir="ltr">Writable External Tables (DDL only) </li>
                     <li dir="ltr">Readable External Tables (DDL only) </li>
@@ -183,7 +184,8 @@ gpbackup_20180105112754_metadata.sql  gpbackup_20180105112754_toc.yaml</codebloc
 gpbackup_0_20180105112754_17166.gz  gpbackup_0_20180105112754_26303.gz
 gpbackup_0_20180105112754_21816.gz</codeblock></p>
       <p>To consolidate all backup files into a single directory, include the
-          <codeph>--backup-dir</codeph> option. Note that you must specify an absolute path with this
+          <codeph>--backup-dir</codeph> option. Note that you must specify an absolute path with
+        this
         option:<codeblock>$ <b>gpbackup --dbname demo --backup-dir /home/gpadmin/backups</b>
 20171103:15:31:56 gpbackup:gpadmin:0ee2f5fb02c9:017586-[INFO]:-Starting backup of database demo
 ...
@@ -220,8 +222,8 @@ $ <b>gprestore --timestamp 20171103152558 --create-db</b>
 20171103:15:45:45 gprestore:gpadmin:0ee2f5fb02c9:017714-[INFO]:-Restoring post-data metadata from /gpmaster/gpsne-1/backups/20171103/20171103152558/gpbackup_20171103152558_postdata.sql
 20171103:15:45:45 gprestore:gpadmin:0ee2f5fb02c9:017714-[INFO]:-Post-data metadata restore complete</codeblock></p>
         <p>If you specified a custom <codeph>--backup-dir</codeph> to consolidate the backup files,
-          include the same <codeph>--backup-dir</codeph> option when using <codeph>gprestore</codeph>
-          to locate the backup
+          include the same <codeph>--backup-dir</codeph> option when using
+            <codeph>gprestore</codeph> to locate the backup
           files:<codeblock>$ <b>dropdb demo</b>
 $ <b>gprestore --backup-dir /home/gpadmin/backups/ --timestamp 20171103153156 --create-db</b>
 20171103:15:51:02 gprestore:gpadmin:0ee2f5fb02c9:017819-[INFO]:-Restore Key = 20171103153156
@@ -230,9 +232,9 @@ $ <b>gprestore --backup-dir /home/gpadmin/backups/ --timestamp 20171103153156 --
         <p><codeph>gprestore</codeph> does not attempt to restore global metadata for the Greenplum
           System by default. If this is required, include the <codeph>--with-globals</codeph>
           argument.</p>
-        <p>By default, <codeph>gprestore</codeph> uses 1 connection to restore table data. If you
-          have a large backup set, you can improve performance of the restore by increasing the
-          number of parallel connections with the <codeph>--jobs</codeph> option. For
+        <p>By default, <codeph>gprestore</codeph> uses 1 connection to restore table data and
+          metadata. If you have a large backup set, you can improve performance of the restore by
+          increasing the number of parallel connections with the <codeph>--jobs</codeph> option. For
           example:<codeblock>$ <b>gprestore --backup-dir /home/gpadmin/backups/ --timestamp 20171103153156 --create-db --jobs 8</b></codeblock></p>
         <p>Test the number of parallel connections with your backup set to determine the ideal
           number for fast data recovery. </p>
@@ -308,8 +310,8 @@ $ <b>gpbackup --dbname demo --exclude-schema twitter</b></codeblock></p>
         <i>or</i> multiple <codeph>--exclude-schema</codeph> options. For
         example:<codeblock>$ <b>gpbackup --dbname demo --include-schema wikipedia --include-schema twitter</b></codeblock></p>
       <p>To filter the individual tables that are included in a backup set, or excluded from a
-        backup set, specify individual tables with the <codeph>--include-table</codeph> option or the
-          <codeph>--exclude-table</codeph> option. The table must be schema qualified,
+        backup set, specify individual tables with the <codeph>--include-table</codeph> option or
+        the <codeph>--exclude-table</codeph> option. The table must be schema qualified,
           <codeph>&lt;schema-name>.&lt;table-name></codeph>. The individual table filtering options
         can be specified multiple times. However, <codeph>--include-table</codeph> and
           <codeph>--exclude-table</codeph> cannot both be used in the same command. </p>
@@ -330,11 +332,11 @@ water.tonic</codeblock></p>
         example:<codeblock>$ <b>gpbackup --dbname demo --include-table-file /home/gpadmin/table-list.txt</b></codeblock></p>
       <p>You can combine <codeph>-include schema</codeph> with <codeph>--exclude-table</codeph> or
           <codeph>--exclude-table-file</codeph> for a backup. This example uses
-          <codeph>--include-schema</codeph> with <codeph>--exclude-table</codeph> to back up a schema
-        except for a single table. </p>
+          <codeph>--include-schema</codeph> with <codeph>--exclude-table</codeph> to back up a
+        schema except for a single table. </p>
       <codeblock>$ <b>gpbackup --dbname demo --include-schema mydata --exclude-table mydata.addresses</b></codeblock>
-      <p>You cannot combine <codeph>--include-schema</codeph> with <codeph>--include-table</codeph> or
-          <codeph>--include-table-file</codeph>, and you cannot combine
+      <p>You cannot combine <codeph>--include-schema</codeph> with <codeph>--include-table</codeph>
+        or <codeph>--include-table-file</codeph>, and you cannot combine
           <codeph>--exclude-schema</codeph> with any table filtering option such as
           <codeph>--exclude-table</codeph> or <codeph>--include-table</codeph>.</p>
       <section id="section_ddf_gyn_5bb"><title>Filtering by Leaf Partition</title><p>By default,
@@ -377,8 +379,8 @@ CREATE TABLE</codeblock></p><p>To
           name:<codeblock>public.sales_1_prt_oct17
 public.sales_1_prt_nov17
 public.sales_1_prt_dec17 </codeblock></p><p>Then
-          specify the file with the <codeph>--include-table-file</codeph> option to generate one data
-          file per leaf
+          specify the file with the <codeph>--include-table-file</codeph> option to generate one
+          data file per leaf
           partition:<codeblock>$ <b>gpbackup --dbname demo --include-table-file last-quarter.txt --leaf-partition-data</b></codeblock></p>When
         you specify <codeph>--leaf-partition-data</codeph>, <codeph>gpbackup</codeph> generates one
         data file per leaf partition when backing up a partitioned table. For example, this command
@@ -386,10 +388,10 @@ public.sales_1_prt_dec17 </codeblock></p><p>Then
           partition:<codeblock>$ <b>gpbackup --dbname demo --include-table public.sales --leaf-partition-data</b></codeblock><p>When
           leaf partitions are backed up, the leaf partition data is backed up along with the
           metadata for the entire partitioned table.</p><note>You cannot use the
-            <codeph>--exclude-table-file</codeph> option with <codeph>--leaf-partition-data</codeph>.
-          Although you can specify leaf partition names in a file specified with
-            <codeph>--exclude-table-file</codeph>, <codeph>gpbackup</codeph> ignores the partition
-          names.</note></section>
+            <codeph>--exclude-table-file</codeph> option with
+          <codeph>--leaf-partition-data</codeph>. Although you can specify leaf partition names in a
+          file specified with <codeph>--exclude-table-file</codeph>, <codeph>gpbackup</codeph>
+          ignores the partition names.</note></section>
       <section>
         <title>Filtering with gprestore</title>
         <p>After creating a backup set with <codeph>gpbackup</codeph>, you can filter the schemas
@@ -407,8 +409,8 @@ public.sales_1_prt_dec17 </codeblock></p><p>Then
                 <codeph>gprestore</codeph> does not create roles or set the owner of the tables. The
               utility restores table indexes and rules. Triggers are also restored but are not
               supported in Greenplum Database.</li>
-            <li>The file that you specify with <codeph>--include-table-file</codeph> cannot include a
-              leaf partition name, as it can when you specify this option with
+            <li>The file that you specify with <codeph>--include-table-file</codeph> cannot include
+              a leaf partition name, as it can when you specify this option with
                 <codeph>gpbackup</codeph>. If you specified leaf partitions in the backup set,
               specify the partitioned table to restore the leaf partition data. <p>When restoring a
                 backup set that contains data from some leaf partitions of a partitioned table, the
@@ -675,8 +677,8 @@ public.sales_1_prt_dec17 </codeblock></p><p>Then
             <filepath>&lt;seg_dir>/backups/YYYYMMDD/YYYYMMDDHHMMSS/</filepath>. </p>
         <p>If you specify a custom backup directory, segment data files are copied to this same file
           path as a subdirectory of the backup directory. If you include the
-            <codeph>--leaf-partition-data</codeph> option, <codeph>gpbackup</codeph> creates one data
-          file for each leaf partition of a partitioned table, instead of just one table for
+            <codeph>--leaf-partition-data</codeph> option, <codeph>gpbackup</codeph> creates one
+          data file for each leaf partition of a partitioned table, instead of just one table for
           file.</p>
         <p>Each data file uses the file name format
             <filepath>gpbackup_&lt;content_id>_&lt;YYYYMMDDHHMMSS>_&lt;oid>.gz</filepath> where:<ul

--- a/gpdb-doc/dita/admin_guide/managing/backup-s3-plugin.xml
+++ b/gpdb-doc/dita/admin_guide/managing/backup-s3-plugin.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="topic_isj_khw_sbs">
+  <title>Using the S3 Plugin with gpbackup and gprestore</title>
+  <body>
+    <draft-comment author="msk" otherprops="op-hidden">
+      <xref href="https://www.pivotaltracker.com/story/show/155484512" format="html"
+        scope="external">155484512</xref>
+      <xref href="https://www.pivotaltracker.com/story/show/155484367" format="html"
+        scope="external">155484367</xref>
+      <xref href="https://github.com/greenplum-db/gpbackup/tree/master/plugins" format="html"
+        scope="external">plugin README</xref>
+      <xref href="https://github.com/greenplum-db/gpbackup-s3-plugin" format="html" scope="external"
+        >S3 plugin</xref></draft-comment>
+    <note type="warning">The S3 plugin for <systemoutput>gpbackup</systemoutput> and
+        <systemoutput>gprestore</systemoutput> is an experimental feature is not intended for use in
+      a production environment. Experimental features are subject to change without notice in future
+      releases.</note>
+    <p>The S3 plugin application lets you use an Amazon Simple Storage Service (Amazon S3) location
+      to store and retrieve backups when you run <codeph><xref
+          href="../../utility_guide/admin_utilities/gpbackup.xml">gpbackup</xref></codeph> and
+          <codeph><xref href="../../utility_guide/admin_utilities/gprestore.xml"
+        >gprestore</xref></codeph>. Amazon S3 provides secure, durable, highly-scalable object
+      storage. For information about Amazon S3, see <xref href="https://aws.amazon.com/s3/"
+        format="html" scope="external">Amazon S3</xref>. </p>
+    <p>To use the S3 plugin application, you specify the location of the plugin and the Amazon Web
+      Services (AWS) login and backup location in a configuration file. When you run
+        <codeph>gpbackup</codeph> or <codeph>gprestore</codeph>, you specify the configuration file
+      with the option <codeph>--plugin-config</codeph>. For information about the configuration
+      file, see <xref href="#topic_isj_khw_sbs/s3-plugin-config" format="dita"/>.</p>
+    <p>If you perform a backup operation with the <codeph>gpbackup</codeph> option
+        <codeph>--plugin-config</codeph>, you must also specify the <codeph>--plugin-config</codeph>
+      option when you restore the backup with <codeph>gprestore</codeph>. </p>
+    <section id="s3-plugin-config">
+      <title>S3 Plugin Configuration File Format</title>
+      <p>The configuration file specifies the location of the Greenplum Database S3 plugin, AWS
+        connection credentials, and S3 location and login information. </p>
+      <p>The S3 plugin configuration file uses the <xref href="http://yaml.org/spec/1.1/"
+          scope="external" format="html">YAML 1.1</xref> document format and implements its own
+        schema for specifying the location of the Greenplum Database S3 plugin, AWS connection
+        credentials, and S3 location and login information. </p>
+      <ul id="ul_g2h_2qn_ndb">
+        <li>For information about Amazon S3 regions and endpoints, see <xref
+            href="http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region" format="html"
+            scope="external"
+            >http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region</xref>.</li>
+        <li>For information about S3 buckets and folders, see the Amazon S3 documentation <xref
+            href="https://aws.amazon.com/documentation/s3/" format="html" scope="external"
+            >https://aws.amazon.com/documentation/s3/</xref>. </li>
+      </ul>
+      <p>The configuration file must be a valid YAML document. The <codeph>gpbackup</codeph> and
+          <codeph>gprestore</codeph> utilities process the control file document in order and use
+        indentation (spaces) to determine the document hierarchy and the relationships of the
+        sections to one another. The use of white space is significant. White space should not be
+        used simply for formatting purposes, and tabs should not be used at all.</p>
+      <p>This is the structure of a S3 plugin configuration file.</p>
+      <codeblock><xref href="#topic_ur2_fsn_ndb/s3-exe-path" format="dita">executablepath</xref>: &lt;<varname>full-path-to-gp_s3plugin</varname>>
+<xref href="#topic_ur2_fsn_ndb/s3-options" format="dita">options</xref>: 
+  <xref href="#topic_ur2_fsn_ndb/s3-region" format="dita">region</xref>: &lt;<varname>aws-region</varname>>
+  <xref href="#topic_ur2_fsn_ndb/s3-id" format="dita">aws_access_key_id</xref>: &lt;<varname>aws-user-id</varname>>
+  <xref href="#topic_ur2_fsn_ndb/s3-key" format="dita">aws_secret_access_key</xref>: &lt;<varname>aws-user-id-key</varname>>
+  <xref href="#topic_ur2_fsn_ndb/s3-bucket" format="dita">bucket</xref>: &lt;<varname>s3-bucket</varname>>
+  <xref href="#topic_ur2_fsn_ndb/s3-location" format="dita">backupdir</xref>: &lt;<varname>s3-location</varname>></codeblock>
+      <parml id="s3-exe-path">
+        <plentry>
+          <pt>executablepath</pt>
+          <pd>Required. Absolute path to the plugin executable. The default location is
+              <codeph>$GPHOME/bin/gp_s3plugin</codeph>.</pd>
+          <pd>
+            <parml>
+              <plentry id="s3-options">
+                <pt>options</pt>
+                <pd>Required. Begins the S3 plugin options section.<parml>
+                    <plentry id="s3-region">
+                      <pt>region</pt>
+                      <pd>Required. The AWS region. </pd>
+                    </plentry>
+                    <plentry id="s3-id">
+                      <pt>aws_access_key_id</pt>
+                      <pd>Required. The AWS S3 ID to access the S3 bucket location that stores
+                        backup files.</pd>
+                    </plentry>
+                    <plentry id="s3-key">
+                      <pt>aws_secret_access_key</pt>
+                      <pd>Required. AWS S3 passcode for the S3 ID to access the S3 bucket
+                        location.</pd>
+                    </plentry>
+                    <plentry id="s3-bucket">
+                      <pt>bucket</pt>
+                      <pd>Required. The name of the S3 bucket in the AWS region. The bucket must
+                        exist. </pd>
+                    </plentry>
+                    <plentry id="s3-location">
+                      <pt>backupdir</pt>
+                      <pd>Required. The S3 location for backups. During a backup operation, the S3
+                        location is created if it does not exist in the S3 bucket. </pd>
+                    </plentry>
+                  </parml></pd>
+              </plentry>
+            </parml>
+          </pd>
+        </plentry>
+      </parml>
+    </section>
+    <section>
+      <title>Example</title>
+      <p>This is an example S3 plugin configuration file that is used in the next
+          <codeph>gpbackup</codeph> example command. The name of the file is
+          <codeph>s3-test</codeph>.</p>
+      <codeblock>executablepath: $GPHOME/bin/gp_s3plugin
+options: 
+  region: us-west-2
+  aws_access_key_id: test-s3-user
+  aws_secret_access_key: asdf1234asdf
+  bucket: gpdb-backup
+  backupdir: test/backup3</codeblock>
+      <p>This <codeph>gpbackup</codeph> example backs up the database demo using the S3 plugin. The
+        absolute path to the S3 plugin configuration file is
+        <codeph>/home/gpadmin/s3-test</codeph>.<codeblock>gpbackup --dbname demo --single-data-file --plugin-config /home/gpadmin/s3-test</codeblock></p>
+      <p>The backup is stored in this S3 location in the AWS region us-west-2. </p>
+      <p>
+        <codeblock>gpdb-backup/test/backup3/backups/<varname>YYYYMMDD</varname>/<varname>YYYYMMDDHHMMSS</varname>/</codeblock>
+      </p>
+    </section>
+    <section>
+      <title>Notes</title>
+      <draft-comment author="msk">Support for S3 server side encryption? endpoint vs.
+        region?</draft-comment>
+      <p>The S3 plugin application must be in the same location on every Greenplum Database host.
+        The configuration file is required only on the master host.</p>
+      <p>When running <codeph>gpbackup</codeph>, the <codeph>--plugin-config</codeph> option is
+        supported only with <codeph>--single-data-file</codeph> or
+        <codeph>--metadata-only</codeph>.</p>
+      <p>When you perform a backup with the S3 plugin, the plugin stores the backup files in this
+        location in the S3 bucket. </p>
+      <codeblock>&lt;<varname>backupdir</varname>>/backups/&lt;<varname>datestamp</varname>>/&lt;<varname>timestamp</varname>></codeblock>
+      <p>Where <varname>backupdir</varname> is the location you specified in the S3 configuration
+        file, and <varname>datestamp</varname> and <varname>timestamp</varname> are the backup date
+        and time stamps. </p>
+      <p>Using Amazon S3 to back up and restore data requires an Amazon AWS account with access to
+        the Amazon S3 bucket. These are the Amazon S3 bucket permissions required for backing up and
+        restoring data.<ul id="ul_qsv_yh5_ndb">
+          <li><systemoutput>Upload/Delete</systemoutput> for the S3 user ID that uploads the
+            files</li>
+          <li><systemoutput>Open/Download</systemoutput> and <systemoutput>View</systemoutput> for
+            the S3 user ID that accesses the files</li>
+        </ul></p>
+    </section>
+  </body>
+</topic>

--- a/gpdb-doc/dita/admin_guide/managing/backup-s3-plugin.xml
+++ b/gpdb-doc/dita/admin_guide/managing/backup-s3-plugin.xml
@@ -35,7 +35,7 @@
         sections to one another. The use of white space is significant. White space should not be
         used simply for formatting purposes, and tabs should not be used at all.</p>
       <p>This is the structure of a S3 storage plugin configuration file.</p>
-      <codeblock><xref href="#topic_ur2_fsn_ndb/s3-exe-path" format="dita">executablepath</xref>: &lt;<varname>absolute-path-to-gp_s3plugin</varname>>
+      <codeblock><xref href="#topic_ur2_fsn_ndb/s3-exe-path" format="dita">executablepath</xref>: &lt;<varname>absolute-path-to-gpbackup_s3_plugin</varname>>
 <xref href="#topic_ur2_fsn_ndb/s3-options" format="dita">options</xref>: 
   <xref href="#topic_ur2_fsn_ndb/s3-region" format="dita">region</xref>: &lt;<varname>aws-region</varname>>
   <xref href="#topic_ur2_fsn_ndb/s3-id" format="dita">aws_access_key_id</xref>: &lt;<varname>aws-user-id</varname>>
@@ -46,7 +46,7 @@
         <plentry>
           <pt>executablepath</pt>
           <pd>Required. Absolute path to the plugin executable. For example, the Pivotal Greenplum
-            Database installation location is <codeph>$GPHOME/bin/gp_s3plugin</codeph>.</pd>
+            Database installation location is <codeph>$GPHOME/bin/gpbackup_s3_plugin</codeph>.</pd>
           <pd>
             <parml>
               <plentry id="s3-options">
@@ -88,7 +88,7 @@
       <p>This is an example S3 storage plugin configuration file that is used in the next
           <codeph>gpbackup</codeph> example command. The name of the file is
           <codeph>s3-test-config.yaml</codeph>.</p>
-      <codeblock>executablepath: $GPHOME/bin/gp_s3plugin
+      <codeblock>executablepath: $GPHOME/bin/gpbackup_s3_plugin
 options: 
   region: us-west-2
   aws_access_key_id: test-s3-user

--- a/gpdb-doc/dita/admin_guide/managing/backup-s3-plugin.xml
+++ b/gpdb-doc/dita/admin_guide/managing/backup-s3-plugin.xml
@@ -111,7 +111,7 @@ options:
       <p>When running <codeph>gpbackup</codeph>, the <codeph>--plugin-config</codeph> option is
         supported only with <codeph>--single-data-file</codeph> or
         <codeph>--metadata-only</codeph>.</p>
-      <p>When you perform a backup with the S3 sorage plugin, the plugin stores the backup files in
+      <p>When you perform a backup with the S3 storage plugin, the plugin stores the backup files in
         this location in the S3 bucket. </p>
       <codeblock>&lt;<varname>backupdir</varname>>/backups/&lt;<varname>datestamp</varname>>/&lt;<varname>timestamp</varname>></codeblock>
       <p>Where <varname>backupdir</varname> is the location you specified in the S3 configuration

--- a/gpdb-doc/dita/admin_guide/managing/backup-s3-plugin.xml
+++ b/gpdb-doc/dita/admin_guide/managing/backup-s3-plugin.xml
@@ -1,30 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <topic id="topic_isj_khw_sbs">
-  <title>Using the S3 Plugin with gpbackup and gprestore</title>
+  <title>Using the S3 Storage Plugin with gpbackup and gprestore</title>
   <body>
-    <draft-comment author="msk" otherprops="op-hidden">
-      <xref href="https://www.pivotaltracker.com/story/show/155484512" format="html"
-        scope="external">155484512</xref>
-      <xref href="https://www.pivotaltracker.com/story/show/155484367" format="html"
-        scope="external">155484367</xref>
-      <xref href="https://github.com/greenplum-db/gpbackup/tree/master/plugins" format="html"
-        scope="external">plugin README</xref>
-      <xref href="https://github.com/greenplum-db/gpbackup-s3-plugin" format="html" scope="external"
-        >S3 plugin</xref></draft-comment>
-    <note type="warning">The S3 plugin for <systemoutput>gpbackup</systemoutput> and
-        <systemoutput>gprestore</systemoutput> is an experimental feature is not intended for use in
-      a production environment. Experimental features are subject to change without notice in future
-      releases.</note>
-    <p>The S3 plugin application lets you use an Amazon Simple Storage Service (Amazon S3) location
-      to store and retrieve backups when you run <codeph><xref
+    <note type="warning">The S3 storage plugin for <systemoutput>gpbackup</systemoutput> and
+        <systemoutput>gprestore</systemoutput> is an experimental feature and is not intended for
+      use in a production environment. Experimental features are subject to change without notice in
+      future releases.</note>
+    <p>The S3 storage plugin application lets you use an Amazon Simple Storage Service (Amazon S3)
+      location to store and retrieve backups when you run <codeph><xref
           href="../../utility_guide/admin_utilities/gpbackup.xml">gpbackup</xref></codeph> and
           <codeph><xref href="../../utility_guide/admin_utilities/gprestore.xml"
         >gprestore</xref></codeph>. Amazon S3 provides secure, durable, highly-scalable object
-      storage. For information about Amazon S3, see <xref href="https://aws.amazon.com/s3/"
-        format="html" scope="external">Amazon S3</xref>. </p>
-    <p>To use the S3 plugin application, you specify the location of the plugin and the Amazon Web
-      Services (AWS) login and backup location in a configuration file. When you run
+      storage.</p>
+    <p>To use the S3 storage plugin application, you specify the location of the plugin and the
+      Amazon Web Services (AWS) login and backup location in a configuration file. When you run
         <codeph>gpbackup</codeph> or <codeph>gprestore</codeph>, you specify the configuration file
       with the option <codeph>--plugin-config</codeph>. For information about the configuration
       file, see <xref href="#topic_isj_khw_sbs/s3-plugin-config" format="dita"/>.</p>
@@ -32,29 +22,20 @@
         <codeph>--plugin-config</codeph>, you must also specify the <codeph>--plugin-config</codeph>
       option when you restore the backup with <codeph>gprestore</codeph>. </p>
     <section id="s3-plugin-config">
-      <title>S3 Plugin Configuration File Format</title>
-      <p>The configuration file specifies the location of the Greenplum Database S3 plugin, AWS
-        connection credentials, and S3 location and login information. </p>
-      <p>The S3 plugin configuration file uses the <xref href="http://yaml.org/spec/1.1/"
+      <title>S3 Storage Plugin Configuration File Format</title>
+      <p>The configuration file specifies the absolute path to the Greenplum Database S3 storage
+        plugin executable, AWS connection credentials, and S3 location. </p>
+      <p>The S3 storage plugin configuration file uses the <xref href="http://yaml.org/spec/1.1/"
           scope="external" format="html">YAML 1.1</xref> document format and implements its own
-        schema for specifying the location of the Greenplum Database S3 plugin, AWS connection
-        credentials, and S3 location and login information. </p>
-      <ul id="ul_g2h_2qn_ndb">
-        <li>For information about Amazon S3 regions and endpoints, see <xref
-            href="http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region" format="html"
-            scope="external"
-            >http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region</xref>.</li>
-        <li>For information about S3 buckets and folders, see the Amazon S3 documentation <xref
-            href="https://aws.amazon.com/documentation/s3/" format="html" scope="external"
-            >https://aws.amazon.com/documentation/s3/</xref>. </li>
-      </ul>
+        schema for specifying the location of the Greenplum Database S3 storage plugin, AWS
+        connection credentials, and S3 location and login information. </p>
       <p>The configuration file must be a valid YAML document. The <codeph>gpbackup</codeph> and
           <codeph>gprestore</codeph> utilities process the control file document in order and use
         indentation (spaces) to determine the document hierarchy and the relationships of the
         sections to one another. The use of white space is significant. White space should not be
         used simply for formatting purposes, and tabs should not be used at all.</p>
-      <p>This is the structure of a S3 plugin configuration file.</p>
-      <codeblock><xref href="#topic_ur2_fsn_ndb/s3-exe-path" format="dita">executablepath</xref>: &lt;<varname>full-path-to-gp_s3plugin</varname>>
+      <p>This is the structure of a S3 storage plugin configuration file.</p>
+      <codeblock><xref href="#topic_ur2_fsn_ndb/s3-exe-path" format="dita">executablepath</xref>: &lt;<varname>absolute-path-to-gp_s3plugin</varname>>
 <xref href="#topic_ur2_fsn_ndb/s3-options" format="dita">options</xref>: 
   <xref href="#topic_ur2_fsn_ndb/s3-region" format="dita">region</xref>: &lt;<varname>aws-region</varname>>
   <xref href="#topic_ur2_fsn_ndb/s3-id" format="dita">aws_access_key_id</xref>: &lt;<varname>aws-user-id</varname>>
@@ -64,13 +45,13 @@
       <parml id="s3-exe-path">
         <plentry>
           <pt>executablepath</pt>
-          <pd>Required. Absolute path to the plugin executable. The default location is
-              <codeph>$GPHOME/bin/gp_s3plugin</codeph>.</pd>
+          <pd>Required. Absolute path to the plugin executable. For example, the Pivotal Greenplum
+            Database installation location is <codeph>$GPHOME/bin/gp_s3plugin</codeph>.</pd>
           <pd>
             <parml>
               <plentry id="s3-options">
                 <pt>options</pt>
-                <pd>Required. Begins the S3 plugin options section.<parml>
+                <pd>Required. Begins the S3 storage plugin options section.<parml>
                     <plentry id="s3-region">
                       <pt>region</pt>
                       <pd>Required. The AWS region. </pd>
@@ -92,8 +73,8 @@
                     </plentry>
                     <plentry id="s3-location">
                       <pt>backupdir</pt>
-                      <pd>Required. The S3 location for backups. During a backup operation, the S3
-                        location is created if it does not exist in the S3 bucket. </pd>
+                      <pd>Required. The S3 location for backups. During a backup operation, the
+                        plugin creates the S3 location if it does not exist in the S3 bucket. </pd>
                     </plentry>
                   </parml></pd>
               </plentry>
@@ -104,9 +85,9 @@
     </section>
     <section>
       <title>Example</title>
-      <p>This is an example S3 plugin configuration file that is used in the next
+      <p>This is an example S3 storage plugin configuration file that is used in the next
           <codeph>gpbackup</codeph> example command. The name of the file is
-          <codeph>s3-test</codeph>.</p>
+          <codeph>s3-test-config.yaml</codeph>.</p>
       <codeblock>executablepath: $GPHOME/bin/gp_s3plugin
 options: 
   region: us-west-2
@@ -114,25 +95,24 @@ options:
   aws_secret_access_key: asdf1234asdf
   bucket: gpdb-backup
   backupdir: test/backup3</codeblock>
-      <p>This <codeph>gpbackup</codeph> example backs up the database demo using the S3 plugin. The
-        absolute path to the S3 plugin configuration file is
-        <codeph>/home/gpadmin/s3-test</codeph>.<codeblock>gpbackup --dbname demo --single-data-file --plugin-config /home/gpadmin/s3-test</codeblock></p>
-      <p>The backup is stored in this S3 location in the AWS region us-west-2. </p>
+      <p>This <codeph>gpbackup</codeph> example backs up the database demo using the S3 storage
+        plugin. The absolute path to the S3 storage plugin configuration file is
+          <codeph>/home/gpadmin/s3-test</codeph>.<codeblock>gpbackup --dbname demo --single-data-file --plugin-config /home/gpadmin/s3-test-config.yaml</codeblock></p>
+      <p>The S3 storage plugin writes the backup files to this S3 location in the AWS region
+        us-west-2. </p>
       <p>
         <codeblock>gpdb-backup/test/backup3/backups/<varname>YYYYMMDD</varname>/<varname>YYYYMMDDHHMMSS</varname>/</codeblock>
       </p>
     </section>
     <section>
       <title>Notes</title>
-      <draft-comment author="msk">Support for S3 server side encryption? endpoint vs.
-        region?</draft-comment>
-      <p>The S3 plugin application must be in the same location on every Greenplum Database host.
-        The configuration file is required only on the master host.</p>
+      <p>The S3 storage plugin application must be in the same location on every Greenplum Database
+        host. The configuration file is required only on the master host.</p>
       <p>When running <codeph>gpbackup</codeph>, the <codeph>--plugin-config</codeph> option is
         supported only with <codeph>--single-data-file</codeph> or
         <codeph>--metadata-only</codeph>.</p>
-      <p>When you perform a backup with the S3 plugin, the plugin stores the backup files in this
-        location in the S3 bucket. </p>
+      <p>When you perform a backup with the S3 sorage plugin, the plugin stores the backup files in
+        this location in the S3 bucket. </p>
       <codeblock>&lt;<varname>backupdir</varname>>/backups/&lt;<varname>datestamp</varname>>/&lt;<varname>timestamp</varname>></codeblock>
       <p>Where <varname>backupdir</varname> is the location you specified in the S3 configuration
         file, and <varname>datestamp</varname> and <varname>timestamp</varname> are the backup date
@@ -144,6 +124,16 @@ options:
             files</li>
           <li><systemoutput>Open/Download</systemoutput> and <systemoutput>View</systemoutput> for
             the S3 user ID that accesses the files</li>
+        </ul></p>
+      <p>For information about Amazon S3, see <xref href="https://aws.amazon.com/s3/" format="html"
+          scope="external">Amazon S3</xref>.<ul id="ul_g2h_2qn_ndb">
+          <li>For information about Amazon S3 regions and endpoints, see <xref
+              href="http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region" format="html"
+              scope="external"
+              >http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region</xref>.</li>
+          <li>For information about S3 buckets and folders, see the Amazon S3 documentation <xref
+              href="https://aws.amazon.com/documentation/s3/" format="html" scope="external"
+              >https://aws.amazon.com/documentation/s3/</xref>. </li>
         </ul></p>
     </section>
   </body>

--- a/gpdb-doc/dita/admin_guide/managing/backup.ditamap
+++ b/gpdb-doc/dita/admin_guide/managing/backup.ditamap
@@ -29,6 +29,7 @@
         <topicref href="backup-boostfs.xml#topic_zp4_mvv_bdb"/>
         <topicref href="backup-boostfs.xml#topic_t4z_tvv_bdb"/>
       </topicref>
+      <topicref href="backup-s3-plugin.xml"/>
     </topicref>
   </topicref>
 </map>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpbackup.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpbackup.xml
@@ -205,14 +205,14 @@
           <pt><b>--plugin-config</b>
             <varname>config-file_location</varname></pt>
           <pd>Specify the location of the <codeph>gpbackup</codeph> plugin configuration file, a
-            text file. The file contains configuration information for the plugin application that
-              <codeph>gpbackup</codeph> uses during the backup operation.</pd>
+            YAML-formatted text file. The file contains configuration information for the plugin
+            application that <codeph>gpbackup</codeph> uses during the backup operation.</pd>
           <pd>This option is supported only with <codeph>--single-data-file</codeph> or
               <codeph>--metadata-only</codeph>.</pd>
           <pd>If you specify the <codeph>--plugin-config</codeph> option when you back up a
             database, you must specify this option with configuration information for a
             corresponding plugin application when you restore the database from the backup.</pd>
-          <pd>For information about using the S3 plugin application, see <xref
+          <pd>For information about using the S3 storage plugin application, see <xref
               href="../../admin_guide/managing/backup-s3-plugin.xml"/>.</pd>
         </plentry>
         <plentry>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpbackup.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpbackup.xml
@@ -20,6 +20,7 @@
    [<b>--leaf-partition-data</b>]
    [<b>--metadata-only</b>]
    [<b>--no-compression</b>]
+   [<b>--plugin-config</b> <varname>config_file_location</varname>
    [<b>--quiet</b>]
    [<b>--single-data-file]</b>
    [<b>--verbose</b>]
@@ -60,11 +61,10 @@
       <title>Options</title>
       <parml>
         <plentry>
-          <pt><b>-dbname</b>
+          <pt><b>--dbname</b>
             <varname>database_name</varname></pt>
           <pd>Required. Specifies the database to back up.</pd>
         </plentry>
-
         <plentry>
           <pt><b>--backup-dir</b>
             <varname>directory</varname></pt>
@@ -78,7 +78,6 @@
             specify a custom backup directory, files are copied to these paths in subdirectories of
             the backup directory.</pd>
         </plentry>
-
         <plentry>
           <pt><b>--compression-level</b>
             <varname>level</varname></pt>
@@ -86,18 +85,15 @@
             files. The default is 1. Note that <codeph>gpbackup</codeph> uses compression by
             default.</pd>
         </plentry>
-
         <plentry>
           <pt><b>--data-only</b></pt>
           <pd>Optional. Backs up only the table data into CSV files, but does not backup metadata
             files needed to recreate the tables and other database objects.</pd>
         </plentry>
-
         <plentry>
           <pt><b>--debug</b></pt>
           <pd>Optional. Displays verbose debug messages during operation.</pd>
         </plentry>
-
         <plentry>
           <pt><b>--exclude-schema</b>
             <varname>schema_name</varname></pt>
@@ -123,7 +119,6 @@
           <pd>See <xref href="../../admin_guide/managing/backup-gpbackup.xml#topic_et4_b5d_tbb"/>
             for more information.</pd>
         </plentry>
-
         <plentry>
           <pt><b>--exclude-table-file</b>
             <varname>file_name</varname></pt>
@@ -141,7 +136,6 @@
           <pd>See <xref href="../../admin_guide/managing/backup-gpbackup.xml#topic_et4_b5d_tbb"/>
             for more information.</pd>
         </plentry>
-
         <plentry>
           <pt><b>--include-schema</b>
             <varname>schema_name</varname></pt>
@@ -154,7 +148,6 @@
               href="../../admin_guide/managing/backup-gpbackup.xml#topic_et4_b5d_tbb"/> for more
             information.</pd>
         </plentry>
-
         <plentry>
           <pt><b>--include-table</b>
             <varname>schema.table</varname></pt>
@@ -172,7 +165,6 @@
           <pd>See <xref href="../../admin_guide/managing/backup-gpbackup.xml#topic_et4_b5d_tbb"/>
             for more information.</pd>
         </plentry>
-
         <plentry>
           <pt><b>--include-table-file</b>
             <varname>file_name</varname></pt>
@@ -191,7 +183,6 @@
           <pd>See <xref href="../../admin_guide/managing/backup-gpbackup.xml#topic_et4_b5d_tbb"/>
             for more information.</pd>
         </plentry>
-
         <plentry>
           <pt><b>--leaf-partition-data</b></pt>
           <pd>Optional. For partitioned tables, creates one data file per leaf partition instead of
@@ -201,23 +192,33 @@
             combination with <codeph>--exclude-table-file</codeph> or
               <codeph>--exclude-table</codeph>.</pd>
         </plentry>
-
         <plentry>
           <pt><b>--metadata-only</b></pt>
           <pd>Optional. Creates only the metadata files (DDL) needed to recreate the database
             objects, but does not back up the actual table data.</pd>
         </plentry>
-
         <plentry>
           <pt><b>--no-compression</b></pt>
           <pd>Optional. Do not compress the table data CSV files.</pd>
         </plentry>
-
+        <plentry>
+          <pt><b>--plugin-config</b>
+            <varname>config-file_location</varname></pt>
+          <pd>Specify the location of the <codeph>gpbackup</codeph> plugin configuration file, a
+            text file. The file contains configuration information for the plugin application that
+              <codeph>gpbackup</codeph> uses during the backup operation.</pd>
+          <pd>This option is supported only with <codeph>--single-data-file</codeph> or
+              <codeph>--metadata-only</codeph>.</pd>
+          <pd>If you specify the <codeph>--plugin-config</codeph> option when you back up a
+            database, you must specify this option with configuration information for a
+            corresponding plugin application when you restore the database from the backup.</pd>
+          <pd>For information about using the S3 plugin application, see <xref
+              href="../../admin_guide/managing/backup-s3-plugin.xml"/>.</pd>
+        </plentry>
         <plentry>
           <pt><b>--quiet</b></pt>
           <pd>Optional. Suppress all non-warning, non-error log messages.</pd>
         </plentry>
-
         <plentry>
           <pt><b>--single-data-file</b></pt>
           <pd>Optional. Create a single data file on each segment host for all tables backed up on
@@ -225,20 +226,17 @@
             for each table that is backed up on the segment.<note>If you use the
                 <codeph>--single-data-file</codeph> option to combine table backups into a single
               file per segment, you cannot set the <codeph>gprestore</codeph> option
-                <codeph>-jobs</codeph> to a value higher than 1 to perform a parallel restore
+                <codeph>--jobs</codeph> to a value higher than 1 to perform a parallel restore
               operation.</note></pd>
         </plentry>
-
         <plentry>
           <pt><b>--verbose</b></pt>
           <pd>Optional. Print verbose log messages.</pd>
         </plentry>
-
         <plentry>
           <pt><b>--version</b></pt>
           <pd>Optional. Print the version number and exit.</pd>
         </plentry>
-
         <plentry>
           <pt><b>--with-stats</b></pt>
           <pd>Optional. Include query plan statistics in the backup set.</pd>
@@ -262,18 +260,18 @@
     <section>
       <title>Examples</title>
       <p>Backup all schemas and tables in the "demo" database, including global Greenplum Database
-        system objects statistics:<codeblock>$ gpbackup -dbname demo</codeblock></p>
+        system objects statistics:<codeblock>$ gpbackup --dbname demo</codeblock></p>
       <p>Backup all schemas and tables in the "demo" database except for the "twitter"
-        schema:<codeblock>$ gpbackup -dbname demo --exclude-schema twitter</codeblock></p>
+        schema:<codeblock>$ gpbackup --dbname demo --exclude-schema twitter</codeblock></p>
       <p>Backup only the "twitter" schema in the "demo"
-        database:<codeblock>$ gpbackup -dbname demo --include-schema twitter</codeblock></p>
+        database:<codeblock>$ gpbackup --dbname demo --include-schema twitter</codeblock></p>
       <p>Backup all schemas and tables in the "demo" database, including global Greenplum Database
         system objects and query statistics, and copy all backup files to the
           <filepath>/home/gpadmin/backup</filepath>
-        directory:<codeblock>$ gpbackup -dbname demo --with-stats --backup-dir /home/gpadmin/backup</codeblock></p>
+        directory:<codeblock>$ gpbackup --dbname demo --with-stats --backup-dir /home/gpadmin/backup</codeblock></p>
       <p>This example uses <codeph>--include-schema</codeph> with <codeph>--exclude-table</codeph>
         to back up a schema except for a single table. </p>
-      <codeblock>$ gpbackup -dbname demo --include-schema mydata --exclude-table mydata.addresses</codeblock>
+      <codeblock>$ gpbackup --dbname demo --include-schema mydata --exclude-table mydata.addresses</codeblock>
       <p>You cannot use the option <codeph>--exclude-schema</codeph> with a table filtering option
         such as <codeph>--include-table</codeph>.</p>
     </section>
@@ -281,7 +279,8 @@
       <title>See Also</title>
       <p>
         <codeph><xref href="./gprestore.xml" type="topic" format="dita"/></codeph>, <xref
-          href="../../admin_guide/managing/backup-gpbackup.xml" format="dita"/></p>
+          href="../../admin_guide/managing/backup-gpbackup.xml" format="dita"/> and <xref
+          href="../../admin_guide/managing/backup-s3-plugin.xml"/></p>
     </section>
   </body>
 </topic>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gprestore.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gprestore.xml
@@ -198,12 +198,12 @@
           <pt><b>--plugin-config</b>
             <varname>config-file_location</varname></pt>
           <pd>Specify the location of the <codeph>gpbackup</codeph> plugin configuration file, a
-            text file. The file contains configuration information for the plugin application that
-              <codeph>gprestore</codeph> uses during the restore operation.</pd>
-          <pd>If you specified the <codeph>--plugin-config</codeph> option when you back up a
+            YAML-formatted text file. The file contains configuration information for the plugin
+            application that <codeph>gprestore</codeph> uses during the restore operation.</pd>
+          <pd>If you specify the <codeph>--plugin-config</codeph> option when you back up a
             database, you must specify this option with configuration information for a
             corresponding plugin application when you restore the database from the backup.</pd>
-          <pd>For information about using the S3 plugin application, see <xref
+          <pd>For information about using the S3 storage plugin application, see <xref
               href="../../admin_guide/managing/backup-s3-plugin.xml"/>.</pd>
         </plentry>
         <plentry>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gprestore.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gprestore.xml
@@ -20,6 +20,7 @@
    [<b>--include-table</b> <varname>schema.table</varname>]
    [<b>--include-table-file</b> <varname>file_name</varname>]
    [<b>--jobs</b> <varname>int</varname>]
+   [<b>--plugin-config</b> <varname>config_file_location</varname>
    [<b>--quiet</b>]
    [<b>--redirect-db</b> <varname>database_name</varname>]
    [<b>--verbose</b>]
@@ -57,8 +58,8 @@
           <codeph>gprestore</codeph>. By default, only database objects in the backup set are
         restored.</p>
       <p>Performance of restore operations can be improved by creating multiple parallel connections
-        to restore table data. By default <codeph>gprestore</codeph> uses 1 connection, but you can
-        increase this number with the <codeph>--jobs</codeph> option for large restore
+        to restore table data and metadata. By default <codeph>gprestore</codeph> uses 1 connection,
+        but you can increase this number with the <codeph>--jobs</codeph> option for large restore
         operations.</p>
       <p>When a restore operation completes, <codeph>gprestore</codeph> returns a status code. See
           <xref href="#topic_phj_g5j_tbb/return_codes" format="dita"/>.</p>
@@ -82,7 +83,6 @@
               <filepath>&lt;seg_dir>/backups/YYYYMMDD/YYYYMMDDhhmmss/</filepath> directory of each
             segment host.</pd>
         </plentry>
-
         <plentry>
           <pt><b>--backup-dir</b>
             <varname>directory</varname></pt>
@@ -96,19 +96,16 @@
             this option when you specify a custom backup directory with
             <codeph>gpbackup</codeph>.</pd>
         </plentry>
-
         <plentry>
           <pt><b>--create-db</b></pt>
           <pd>Optional. Creates the database before restoring the database object metadata.</pd>
           <pd>The database is created by cloning the empty standard system database
               <codeph>template0</codeph>.</pd>
         </plentry>
-
         <plentry>
           <pt><b>--debug</b></pt>
           <pd>Optional. Displays verbose debug messages during operation.</pd>
         </plentry>
-
         <plentry>
           <pt><b>--exclude-schema</b>
             <varname>schema_name</varname></pt>
@@ -142,7 +139,6 @@
           <pd>You cannot combine this option with the option <codeph>--exclude-schema</codeph>, or
             another a table filtering option such as <codeph>--include-table</codeph>.</pd>
         </plentry>
-
         <plentry>
           <pt><b>--include-schema</b>
             <varname>schema_name</varname></pt>
@@ -156,8 +152,9 @@
             in the database. </pd>
           <pd>You cannot use this option if objects in the backup set have dependencies on multiple
             schemas.</pd>
+          <pd>See <xref href="../../admin_guide/managing/backup-gpbackup.xml#topic_et4_b5d_tbb"
+              >Filtering the Contents of a Backup or Restore</xref> for more information.</pd>
         </plentry>
-
         <plentry>
           <pt><b>--include-table</b>
             <varname>schema.table</varname></pt>
@@ -187,47 +184,52 @@
           <pd>See <xref href="../../admin_guide/managing/backup-gpbackup.xml#topic_et4_b5d_tbb"/>
             for more information.</pd>
         </plentry>
-
         <plentry>
           <pt><b>--jobs</b>
             <varname>int</varname></pt>
           <pd>Optional. Specifies the number of parallel connections to use when restoring table
-            data. By default, <codeph>gprestore</codeph> uses 1 connection. Increasing this number
-            can improve the speed of restoring data.<note>If you used the <codeph>gpbackup
-                --single-data-file</codeph> option to combine table backups into a single file per
-              segment, you cannot set <codeph>--jobs</codeph> to a value higher than 1 to perform a
-              parallel restore operation.</note></pd>
+            data and metadata. By default, <codeph>gprestore</codeph> uses 1 connection. Increasing
+            this number can improve the speed of restoring data.<note>If you used the
+                <codeph>gpbackup --single-data-file</codeph> option to combine table backups into a
+              single file per segment, you cannot set <codeph>--jobs</codeph> to a value higher than
+              1 to perform a parallel restore operation.</note></pd>
         </plentry>
-
+        <plentry>
+          <pt><b>--plugin-config</b>
+            <varname>config-file_location</varname></pt>
+          <pd>Specify the location of the <codeph>gpbackup</codeph> plugin configuration file, a
+            text file. The file contains configuration information for the plugin application that
+              <codeph>gprestore</codeph> uses during the restore operation.</pd>
+          <pd>If you specified the <codeph>--plugin-config</codeph> option when you back up a
+            database, you must specify this option with configuration information for a
+            corresponding plugin application when you restore the database from the backup.</pd>
+          <pd>For information about using the S3 plugin application, see <xref
+              href="../../admin_guide/managing/backup-s3-plugin.xml"/>.</pd>
+        </plentry>
         <plentry>
           <pt><b>--quiet</b></pt>
           <pd>Optional. Suppress all non-warning, non-error log messages.</pd>
         </plentry>
-
         <plentry>
           <pt><b>--redirect-db</b>
             <varname>database_name</varname></pt>
           <pd>Optional. Restore to the specified <varname>database_name</varname> instead of to the
             database that was backed up.</pd>
         </plentry>
-
         <plentry>
           <pt><b>--verbose</b></pt>
           <pd>Optional. Print verbose log messages.</pd>
         </plentry>
-
         <plentry>
           <pt><b>--version</b></pt>
           <pd>Optional. Print the version number and exit.</pd>
         </plentry>
-
         <plentry>
           <pt><b>--with-globals</b></pt>
           <pd>Optional. Restores Greenplum Database system objects in the backup set, in addition to
             database objects. See <xref
               href="../../admin_guide/managing/backup-gpbackup.xml#topic_x3s_lqj_tbb"/>.</pd>
         </plentry>
-
         <plentry>
           <pt><b>--with-stats</b></pt>
           <pd>Optional. Restore query plan statistics from the backup set.</pd>
@@ -272,7 +274,8 @@ $ gprestore --include-schema wikipedia --backup-dir /home/gpadmin/backups/ --tim
       <title>See Also</title>
       <p>
         <codeph><xref href="./gpbackup.xml" type="topic" format="dita"/></codeph>, <xref
-          href="../../admin_guide/managing/backup-gpbackup.xml" format="dita"/></p>
+          href="../../admin_guide/managing/backup-gpbackup.xml" format="dita"/> and <xref
+          href="../../admin_guide/managing/backup-s3-plugin.xml"/></p>
     </section>
   </body>
 </topic>


### PR DESCRIPTION
-add gpbackup/gprestore --plugin-config option
-add S3 plugin information
-other minor fixes: add index as object, support table data and metadata for --jobs > 1

PR for 5X_STABLE
Will be ported to MAIN

HTML format in the docs review site.

S3 plugin
http://docs-gpdb-review-staging.cfapps.io/review/admin_guide/managing/backup-s3-plugin.html

gpbackup/gprestore
http://docs-gpdb-review-staging.cfapps.io/review/utility_guide/admin_utilities/gpbackup.html
http://docs-gpdb-review-staging.cfapps.io/review/utility_guide/admin_utilities/gprestore.html

