### PR TITLE
docs: add missing disk_wb_rate row in gpperfmon system table reference

### DIFF
--- a/gpdb-doc/dita/ref_guide/gpperfmon/db-system.xml
+++ b/gpdb-doc/dita/ref_guide/gpperfmon/db-system.xml
@@ -174,6 +174,13 @@
                      <codeph>disk_rb_rate</codeph>
                   </entry>
                   <entry>bigint</entry>
+                  <entry>Bytes per second for disk read operations.</entry>
+               </row>
+               <row>
+                  <entry>
+                     <codeph>disk_wb_rate</codeph>
+                  </entry>
+                  <entry>bigint</entry>
                   <entry>Bytes per second for disk write operations.</entry>
                </row>
                <row>


### PR DESCRIPTION
The disk_rb_rate and disk_wb_rate rows in the system table reference were combined into one row.  