### PR TITLE
docs - updates to resgroup "using" page for memory_auditor

### DIFF
--- a/gpdb-doc/dita/admin_guide/wlmgmt.xml
+++ b/gpdb-doc/dita/admin_guide/wlmgmt.xml
@@ -88,6 +88,11 @@
               certain operators and functions</entry>
             <entry colname="col3">Limits are not enforced on <codeph>SET</codeph>, <codeph>RESET</codeph>, and <codeph>SHOW</codeph> commands</entry>
           </row>
+          <row>
+            <entry colname="col1">External Components</entry>
+            <entry colname="col2">None</entry>
+            <entry colname="col3">Manage PL/Container CPU and memory resources</entry>
+          </row>
         </tbody>
       </tgroup>
     </table>

--- a/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
@@ -331,7 +331,7 @@ rg_perseg_mem = ((RAM * (vm.overcommit_ratio / 100) + SWAP) * gp_resource_group_
       <topic id="topic833cons" xml:lang="en">
         <title>Other Memory Considerations</title>
         <body>
-        <p>Resource groups for roles track all Greenplum Database memory allocated via the <codeph>palloc()</codeph> function. Memory that you allocate using the Linux <codeph>malloc()</codeph> function is not managed by these resource groups. To ensure that resource groups for roles are accurately tracking memory usage, avoid <codeph>malloc()</codeph>ing large amounts of memory in custom Greenplum Database user-defined functions.</p>
+        <p>Resource groups for roles track all Greenplum Database memory allocated via the <codeph>palloc()</codeph> function. Memory that you allocate using the Linux <codeph>malloc()</codeph> function is not managed by these resource groups. To ensure that resource groups for roles are accurately tracking memory usage, avoid using <codeph>malloc()</codeph> to allocate large amounts of memory in custom Greenplum Database user-defined functions.</p>
         </body>
       </topic>
   </topic>
@@ -394,7 +394,7 @@ rg_perseg_mem = ((RAM * (vm.overcommit_ratio / 100) + SWAP) * gp_resource_group_
      memory {
      }
  } </codeblock>
-            <p>This content configures CPU, CPU accounting, and memory  control groups
+            <p>This content configures CPU, CPU accounting, and memory control groups
               managed by the <codeph>gpadmin</codeph> user. Greenplum Database uses
               the memory control group only for those resource groups created with the
               <codeph>cgroup</codeph> <codeph>MEMORY_AUDITOR</codeph>.</p>

--- a/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
@@ -4,9 +4,26 @@
 <topic id="topic1" xml:lang="en">
   <title id="iz173472">Using Resource Groups</title>
   <body>
-    <p>You can use resource groups to manage the number of active queries that may execute
-      concurrently in your Greenplum Database cluster. With resource groups, you can also manage the
+    <p>Greenplum Database supports two types of resource groups: groups that manage resources for roles, and groups that manage resources for external components such as PL/Container.</p>
+    <p><b>Resource groups for roles</b>: You can use resource groups for roles to manage the number of active queries that may execute
+      concurrently in your Greenplum Database cluster. With resource groups for roles, you can also manage the
       amount of CPU and memory resources Greenplum allocates to each query.</p>
+    <p>Resource groups for roles use Linux control groups (cgroups) for CPU resource management. Greenplum Database tracks virtual memory internally for resource groups for roles.</p>
+    <p>When the user executes a query, Greenplum Database evaluates the query against a set of
+      limits defined for the resource group. Greenplum Database executes the query immediately if
+      the group's resource limits have not yet been reached and the query does not cause the group
+      to exceed the concurrent transaction limit. If these conditions are not met, Greenplum
+      Database queues the query. For example, if the maximum number of concurrent transactions for
+      the resource group has already been reached, a subsequent query is queued and must wait until
+      other queries complete before it runs. Greenplum Database may also execute a pending query
+      when the resource group's concurrency and memory limits are altered to large enough
+      values.</p>
+    <p>Within a resource group for roles, transactions are evaluated on a first in, first out basis. Greenplum
+      Database periodically assesses the active workload of the system, reallocating resources and
+      starting/queuing jobs as necessary.</p>
+    <p><b>Resource groups for external components</b>: You can use resource groups for external components such as PL/Container to manage the CPU and memory resources used by an instance of the component.</p>
+      <p>Resource groups for external components use Linux cgroups to manage the total CPU and memory resources for the component. As Greenplum Database has no concept of a transaction at the component level, a concurrency limit is not applicable.</p> 
+      <p>An external component may optionally define and further refine a more granular level of memory management.</p>
     <p>This topic includes the following subtopics:</p>
     <ul id="ul_wjf_1wy_sp">
       <li id="im168064">
@@ -44,23 +61,14 @@
     </ul>
   </body>
   <topic id="topic8339intro" xml:lang="en">
-    <title>Introduction</title>
+    <title>Introduction to Resource Group Attributes and Limits</title>
     <body>
-    <p>When the user executes a query, Greenplum Database evaluates the query against a set of
-      limits defined for the resource group. Greenplum Database executes the query immediately if
-      the group's resource limits have not yet been reached and the query does not cause the group
-      to exceed the concurrent transaction limit. If these conditions are not met, Greenplum
-      Database queues the query. For example, if the maximum number of concurrent transactions for
-      the resource group has already been reached, a subsequent query is queued and must wait until
-      other queries complete before it runs. Greenplum Database may also execute a pending query
-      when the resource group's concurrency and memory limits are altered to large enough
-      values.</p>
-    <p>Within a resource group, transactions are evaluated on a first in, first out basis. Greenplum
-      Database periodically assesses the active workload of the system, reallocating resources and
-      starting/queuing jobs as necessary.</p>
-    <p>When you create a resource group, you provide a set of limits that determine the amount of
-      CPU and memory resources available to transactions executed within the group. These limits
-      are:</p>
+    <p>When you create a resource group, you:</p><ul>
+      <li>Identify the type of resource group.</li>
+      <li>Provide a set of limits that determine the amount of CPU and memory resources available to the group.</li>
+    </ul>
+
+    <p>Resource group attributes and limits:</p>
     <table id="resgroup_limit_descriptions">
       <tgroup cols="3">
         <colspec colnum="1" colname="col1" colwidth="1*"/>
@@ -73,9 +81,14 @@
         </thead>
         <tbody>
           <row>
+            <entry colname="col1">MEMORY_AUDITOR</entry>
+            <entry colname="col2">The memory auditor in use for the resource group;
+              <codeph>vmtracker</codeph> (default; resource groups for roles) or <codeph>cgroup</codeph> (resource groups for external components).</entry>
+          </row>
+          <row>
             <entry colname="col1">CONCURRENCY</entry>
             <entry colname="col2">The maximum number of concurrent transactions, including active
-              and idle transactions, that are permitted for this resource group. </entry>
+              and idle transactions, that are permitted for a resource group for roles.</entry>
           </row>
           <row>
             <entry colname="col1">CPU_RATE_LIMIT</entry>
@@ -104,14 +117,69 @@
     </body>
   </topic>
 
+  <topic id="topic8339777" xml:lang="en">
+    <title>Memory Auditor</title>
+    <body>
+      <p>The <codeph>MEMORY_AUDITOR</codeph> attribute identifies the type of resource
+        group. A resource group that specifies the <codeph>vmtracker</codeph>
+        <codeph>MEMORY_AUDITOR</codeph> identifies a resource group for roles. A resource
+        group specifying the <codeph>cgroup</codeph> <codeph>MEMORY_AUDITOR</codeph>
+        identifies a resource group for external components.</p>
+      <p>The default <codeph>MEMORY_AUDITOR</codeph> is <codeph>vmtracker</codeph>.</p>
+      <p>The <codeph>MEMORY_AUDITOR</codeph> that you specify for a resource group determines if and how Greenplum Database uses the limit attributes to manage CPU and memory resources:</p>
+    <table id="resgroup_limit_descriptions">
+      <tgroup cols="3">
+        <colspec colnum="1" colname="col1" colwidth="1*"/>
+        <colspec colnum="2" colname="col2" colwidth="1*"/>
+        <colspec colnum="3" colname="col3" colwidth="1*"/>
+        <thead>
+          <row>
+            <entry colname="col1">Limit Type</entry>
+            <entry colname="col2">Resource Group for Roles</entry>
+            <entry colname="col3">Resource Group for External Components</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry colname="col1">CONCURRENCY</entry>
+            <entry colname="col2">Yes</entry>
+            <entry colname="col3">No; must be zero (0)</entry>
+          </row>
+          <row>
+            <entry colname="col1">CPU_RATE_LIMIT</entry>
+            <entry colname="col2">Yes</entry>
+            <entry colname="col3">Yes</entry>
+          </row>
+          <row>
+            <entry colname="col1">MEMORY_LIMIT</entry>
+            <entry colname="col2">Yes</entry>
+            <entry colname="col3">Yes</entry>
+          </row>
+          <row>
+            <entry colname="col1">MEMORY_SHARED_QUOTA</entry>
+            <entry colname="col2">Yes</entry>
+            <entry colname="col2">Component-specific</entry>
+          </row>
+          <row>
+            <entry colname="col1">MEMORY_SPILL_RATIO</entry>
+            <entry colname="col2">Yes</entry>
+            <entry colname="col2">Component-specific</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+    </body>
+  </topic>
+
   <topic id="topic8339717179" xml:lang="en">
     <title>Transaction Concurrency Limit</title>
     <body>
       <p>The <codeph>CONCURRENCY</codeph> limit controls the maximum number of concurrent
-        transactions permitted for the resource group. Each resource group is logically divided into
+        transactions permitted for a resource group for roles. The <codeph>CONCURRENCY</codeph> limit is not applicable to resource groups for external components and must be set to zero (0) for such groups.</p>
+      <p>Each resource group for roles is logically divided into
         a fixed number of slots equal to the <codeph>CONCURRENCY</codeph> limit. Greenplum Database
         allocates these slots an equal, fixed percentage of memory resources.</p>
-      <p>The default <codeph>CONCURRENCY</codeph> limit value for a resource group is 20.</p>
+      <p>The default <codeph>CONCURRENCY</codeph> limit value for a resource group for roles is 20.</p>
       <p>Greenplum Database queues any transactions submitted after the resource group reaches its
           <codeph>CONCURRENCY</codeph> limit. When a running transaction completes, Greenplum
         Database un-queues and executes the earliest queued transaction if sufficient memory
@@ -139,10 +207,10 @@
       <p>The Greenplum Database node CPU percentage is further divided equally among each segment on
         the Greenplum node. Each resource group reserves a percentage of the segment CPU for
         resource management. You identify this percentage via the <codeph>CPU_RATE_LIMIT</codeph>
-        value you provide when you create the resource group.</p>
+        value that you provide when you create the resource group.</p>
       <p>The minimum <codeph>CPU_RATE_LIMIT</codeph> percentage you can specify for a resource group
         is 1, the maximum is 100.</p>
-      <p>The sum of <codeph>CPU_RATE_LIMIT</codeph>s specified for all resource groups you define in
+      <p>The sum of <codeph>CPU_RATE_LIMIT</codeph>s specified for all resource groups that you define in
         your Greenplum Database cluster must not exceed 100.</p>
       <p>CPU resource assignment is elastic in that Greenplum Database may allocate the CPU
         resources of an idle resource group to a busier one(s). In such situations, CPU resources
@@ -158,7 +226,7 @@
     <title>Memory Limits</title>
     <body>
       <p>When resource groups are enabled, memory usage is managed at the Greenplum Database node,
-        segment, resource group, and transaction levels.</p>
+        segment, and resource group levels. You can also manage memory at the transaction level with a resource group for roles.</p>
 
       <p>The <codeph><xref
             href="../ref_guide/config_params/guc-list.xml#gp_resource_group_memory_limit"
@@ -176,23 +244,27 @@
 rg_perseg_mem = ((RAM * (vm.overcommit_ratio / 100) + SWAP) * gp_resource_group_memory_limit) / num_active_primary_segments</codeblock></p>
       <p>Each resource group reserves a percentage of the segment memory
         for resource management. You identify this percentage via the <codeph>MEMORY_LIMIT</codeph>
-        value you specify when you create the resource group. The minimum
+        value that you specify when you create the resource group. The minimum
           <codeph>MEMORY_LIMIT</codeph> percentage you can specify for a resource group is 1, the
         maximum is 100.</p>
-      <p>The sum of <codeph>MEMORY_LIMIT</codeph>s specified for all resource groups you define in
+      <p>The sum of <codeph>MEMORY_LIMIT</codeph>s specified for all resource groups that you define in
         your Greenplum Database cluster must not exceed 100.</p>
-      <p>The memory reserved by the resource group is divided into fixed and shared components. The
-          <codeph>MEMORY_SHARED_QUOTA</codeph> value you specify when you create the resource group
+    </body>
+    <topic id="mem_roles" xml:lang="en">
+      <title>Additional Memory Limits for Resource Groups for Roles</title>
+      <body>
+      <p>The memory reserved by a resource group for roles is further divided into fixed and shared components. The
+          <codeph>MEMORY_SHARED_QUOTA</codeph> value that you specify when you create the resource group
         identifies the percentage of reserved resource group memory that may be shared among the
         currently running transactions. This memory is allotted on a first-come, first-served basis.
         A running transaction may use none, some, or all of the
         <codeph>MEMORY_SHARED_QUOTA</codeph>.</p>
 
-      <p>The minimum <codeph>MEMORY_SHARED_QUOTA</codeph> you can specify is 0, the maximum is 100.
+      <p>The minimum <codeph>MEMORY_SHARED_QUOTA</codeph> that you can specify is 0, the maximum is 100.
         The default <codeph>MEMORY_SHARED_QUOTA</codeph> is 20.</p>
 
       <p>As mentioned previously, <codeph>CONCURRENCY</codeph> identifies the maximum number of
-        concurrently running transactions permitted in the resource group. The fixed memory reserved
+        concurrently running transactions permitted in a resource group for roles. The fixed memory reserved
         by a resource group is divided into <codeph>CONCURRENCY</codeph> number of transaction
         slots. Each slot is allocated a fixed, equal amount of resource group memory. Greenplum
         Database guarantees this fixed memory to each transaction. <fig id="fig_py5_1sl_wlrg">
@@ -207,9 +279,11 @@ rg_perseg_mem = ((RAM * (vm.overcommit_ratio / 100) + SWAP) * gp_resource_group_
         in resource groups. A transaction submitted in a resource group will fail and exit
         when memory usage exceeds its fixed memory allotment, no available resource group
         shared memory exists, and the transaction requests more memory.</note>
+      </body>
 
-      <section id="topic833sp" xml:lang="en">
+      <topic id="topic833sp" xml:lang="en">
         <title>Query Operator Memory</title>
+        <body>
         <p>Most query operators are non-memory-intensive; that is, during processing, Greenplum
           Database can hold their data in allocated memory. When memory-intensive query operators
           such as join and sort process more data than can be held in memory, data is spilled to
@@ -229,19 +303,22 @@ rg_perseg_mem = ((RAM * (vm.overcommit_ratio / 100) + SWAP) * gp_resource_group_
           threshold, it spills to disk. Greenplum Database uses the
             <codeph>MEMORY_SPILL_RATIO</codeph> to determine the initial memory to allocate to a
           transaction.</p>
-        <p> The minimum <codeph>MEMORY_SPILL_RATIO</codeph> percentage you can specify for a
+        <p> The minimum <codeph>MEMORY_SPILL_RATIO</codeph> percentage that you can specify for a
           resource group is 0. The maximum is 100. The default <codeph>MEMORY_SPILL_RATIO</codeph>
           is 20.</p>
-        <p>You define the <codeph>MEMORY_SPILL_RATIO</codeph> when you create a resource group. You
+        <p>You define the <codeph>MEMORY_SPILL_RATIO</codeph> when you create a resource group for roles. You
           can selectively set this limit on a per-query basis at the session level with the
               <codeph><xref href="../ref_guide/config_params/guc-list.xml#memory_spill_ratio"
               type="section"/></codeph> server configuration parameter.</p>
-      </section>
-      <section id="topic833cons" xml:lang="en">
+        </body>
+      </topic>
+      </topic>
+      <topic id="topic833cons" xml:lang="en">
         <title>Other Memory Considerations</title>
-        <p>Resource groups track all Greenplum Database memory allocated via the <codeph>palloc()</codeph> function. Memory that you allocate using the Linux <codeph>malloc()</codeph> function is not managed by resource groups. To ensure that resource groups are accurately tracking memory usage, avoid <codeph>malloc()</codeph>ing large amounts of memory in custom Greenplum Database user-defined functions.</p>
-      </section>
-    </body>
+        <body>
+        <p>Resource groups for roles track all Greenplum Database memory allocated via the <codeph>palloc()</codeph> function. Memory that you allocate using the Linux <codeph>malloc()</codeph> function is not managed by these resource groups. To ensure that resource groups for roles are accurately tracking memory usage, avoid <codeph>malloc()</codeph>ing large amounts of memory in custom Greenplum Database user-defined functions.</p>
+        </body>
+      </topic>
   </topic>
 
   <topic id="topic71717999" xml:lang="en">
@@ -260,9 +337,9 @@ rg_perseg_mem = ((RAM * (vm.overcommit_ratio / 100) + SWAP) * gp_resource_group_
       <section id="topic833" xml:lang="en">
         <title>Prerequisite</title>
         <p>Greenplum Database resource groups use Linux Control Groups (cgroups) to manage CPU
-          resources. (cgroups are <b>not</b> used for resource group memory management.) 
-          With cgroups, Greenplum isolates the CPU usage of your Greenplum processes from
-          other processes on the node. This allows Greenplum to support CPU usage restrictions on a
+          resources. Greenplum Database also uses cgroups to manage memory for resource groups for external components.
+          With cgroups, Greenplum isolates the CPU and external component memory usage of your Greenplum processes from
+          other processes on the node. This allows Greenplum to support CPU and external component memory usage restrictions on a
           per-resource-group basis.</p>
         <p>For detailed information about cgroups, refer to the Control Groups documentation for
           your Linux distribution.</p>
@@ -302,12 +379,13 @@ rg_perseg_mem = ((RAM * (vm.overcommit_ratio / 100) + SWAP) * gp_resource_group_
      memory {
      }
  } </codeblock>
-            <p>This content configures CPU and CPU accounting control groups managed by the
-                <codeph>gpadmin</codeph> user. The <i>memory</i> control group is required,
-                though currently unused.</p>
+            <p>This content configures CPU, CPU accounting, and memory  control groups
+              managed by the <codeph>gpadmin</codeph> user. Greenplum Database uses
+              the memory control group only for those resource groups defined with the
+              <codeph>cgroup</codeph> <codeph>MEMORY_AUDITOR</codeph>.</p>
           </li>
           <li>If not already installed and running, install the Control Groups operating system
-            package and start the cgroups service on each Greenplum Database node. The commands you
+            package and start the cgroups service on each Greenplum Database node. The commands that you
             run to perform these tasks will differ based on the operating system installed on the
             node. You must be the superuser or have <codeph>sudo</codeph> access to run these
             commands: <ul>
@@ -332,7 +410,8 @@ sudo cgconfigparser -l /etc/cgconfig.d/gpdb.conf </codeblock>
           <li>Verify that you set up the Greenplum Database cgroups configuration correctly by
             running the following commands. Replace &lt;cgroup_mount_point&gt; with the
             mount point that you identified in the previous step: <codeblock>ls -l &lt;cgroup_mount_point&gt;/cpu/gpdb
-ls -l &lt;cgroup_mount_point&gt;/cpuacct/gpdb</codeblock>
+ls -l &lt;cgroup_mount_point&gt;/cpuacct/gpdb
+ls -l &lt;cgroup_mount_point&gt;/memory/gpdb</codeblock>
             <p>If these directories exist and are owned by <codeph>gpadmin:gpadmin</codeph>, you
               have successfully configured cgroups for Greenplum Database CPU resource
               management.</p>
@@ -396,8 +475,8 @@ gpstart
       </ol>
       <p>Once enabled, any transaction submitted by a role is directed to the resource group
         assigned to the role, and is governed by that resource group's concurrency, memory, and CPU
-        limits.</p>
-      <p>Greenplum Database creates two default resource groups named <codeph>admin_group</codeph>
+        limits. Similarly, CPU and memory usage by an external component is governed by the CPU and memory limits configured for the resource group assigned to the component.</p>
+      <p>Greenplum Database creates two default resource groups for roles named <codeph>admin_group</codeph>
         and <codeph>default_group</codeph>. When you enable resources groups, any role that was not
         explicitly assigned a resource group is assigned the default group for the role's
         capability. <codeph>SUPERUSER</codeph> roles are assigned the <codeph>admin_group</codeph>,
@@ -457,11 +536,11 @@ gpstart
   <topic id="topic10" xml:lang="en">
     <title id="iz139857">Creating Resource Groups</title>
     <body>
-      <p>When you create a resource group, you provide a name, CPU limit, and memory limit. You can
+      <p><i>When you create a resource group for a role</i>, you provide a name, CPU limit, and memory limit. You can
         optionally provide a concurrent transaction limit and memory shared quota and spill ratio.
         Use the <codeph><xref href="../ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml#topic1"
             type="topic" format="dita"/></codeph> command to create a new resource group. </p>
-      <p id="iz152723">When you create a resource group, you must provide
+      <p id="iz152723">When you create a resource group for a role, you must provide
           <codeph>CPU_RATE_LIMIT</codeph> and <codeph>MEMORY_LIMIT</codeph> limit values. These
         limits identify the percentage of Greenplum Database resources to allocate to this resource
         group. For example, to create a resource group named <i>rgroup1</i> with a CPU limit of 20
@@ -472,14 +551,23 @@ gpstart
       </p>
       <p>The CPU limit of 20 is shared by every role to which <codeph>rgroup1</codeph> is assigned.
         Similarly, the memory limit of 25 is shared by every role to which <codeph>rgroup1</codeph>
-        is assigned. <codeph>rgroup1</codeph> utilizes the default <codeph>CONCURRENCY</codeph>
+        is assigned. <codeph>rgroup1</codeph> utilizes the default <codeph>MEMORY_AUDITOR</codeph> <codeph>vmtracker</codeph> and the default <codeph>CONCURRENCY</codeph>
         setting of 20.</p>
+      <p id="iz1527231"><i>When you create a resource group for an external component</i>, you must provide
+          <codeph>CPU_RATE_LIMIT</codeph> and <codeph>MEMORY_LIMIT</codeph> limit values. You
+        must also provide the <codeph>MEMORY_AUDITOR</codeph> and explicitly set <codeph>CONCURRENCY</codeph> to zero (0). For example, to create a resource group named <i>rgroup_extcomp</i> with a CPU limit of 10
+        and a memory limit of 15:</p>
+      <p>
+        <codeblock>=# CREATE RESOURCE GROUP <i>rgroup_extcomp</i> WITH (MEMORY_AUDITOR=cgroup, CONNCURENCY=0,
+     CPU_RATE_LIMIT=10, MEMORY_LIMIT=15);
+</codeblock>
+      </p>
       <p>The <codeph><xref href="../ref_guide/sql_commands/ALTER_RESOURCE_GROUP.xml#topic1"
             type="topic" format="dita"/></codeph> command updates the limits of a resource group. To
-        change the limits of a resource group, specify the new values you want for the group. For
+        change the limits of a resource group, specify the new values that you want for the group. For
         example:</p>
       <p>
-        <codeblock>=# ALTER RESOURCE GROUP <i>rg_light</i> SET CONCURRENCY 7;
+        <codeblock>=# ALTER RESOURCE GROUP <i>rg_role_light</i> SET CONCURRENCY 7;
 =# ALTER RESOURCE GROUP <i>exec</i> SET MEMORY_LIMIT 25;
 </codeblock>
       </p>
@@ -487,8 +575,9 @@ gpstart
           <codeph>admin_group</codeph> to zero (0).</note>
       <p>The <codeph><xref href="../ref_guide/sql_commands/DROP_RESOURCE_GROUP.xml#topic1"
             type="topic" format="dita"/></codeph> command drops a resource group. To drop a resource
-        group, the group cannot be assigned to any role, nor can there be any transactions active or
-        waiting in the resource group. To drop a resource group:</p>
+        group for a role, the group cannot be assigned to any role, nor can there be any transactions active or
+        waiting in the resource group. Dropping a resource group for an external component in which there are running instances kills the running instances.</p>
+      <p>To drop a resource group:</p>
       <p>
         <codeblock>=# DROP RESOURCE GROUP <i>exec</i>; </codeblock>
       </p>
@@ -498,7 +587,7 @@ gpstart
   <topic id="topic17" xml:lang="en">
     <title id="iz172210">Assigning a Resource Group to a Role</title>
     <body>
-      <p id="iz172211">When you create a resource group, the group is available for assignment to
+      <p id="iz172211">When you create a resource group with the default <codeph>MEMORY_AUDITOR</codeph> <codeph>vmtracker</codeph>, the group is available for assignment to
         one or more roles (users). You assign a resource group to a database role using the
           <codeph>RESOURCE GROUP</codeph> clause of the <codeph><xref
             href="../ref_guide/sql_commands/CREATE_ROLE.xml#topic1" type="topic" format="dita"
@@ -517,6 +606,7 @@ gpstart
       <p>You can assign a resource group to one or more roles. If you have defined a role hierarchy,
         assigning a resource group to a parent role does not propagate down to the members of that
         role group.</p>
+      <p>You cannot assign a resource group you create for an external component to a role.</p>
       <p>If you wish to remove a resource group assignment from a role and assign the role the
         default group, change the role's group name assignment to <codeph>NONE</codeph>. For
         example:</p>
@@ -612,6 +702,9 @@ gpstart
           <codeblock>=# SELECT current_query, waiting, rsgname, rsgqueueduration 
      FROM pg_stat_activity;
 </codeblock>
+        </p>
+        <p>
+          <codeph>pg_stat_activity</codeph> displays information about the user/role that initiated a query. A query that uses the PL/Container external component has two parts: the Greenplum Database query operator processing and the UDF running in a PL/Container instance. Greenplum Database processes the query operators under the resource group assigned to the role that initiated the query. A UDF running in a PL/Container instance runs under the resource group assigned to the PL/Container runtime. The latter is not represented in the <codeph>pg_stat_activity</codeph> view; Greenplum Database does not have any insight into how PL/Container manages its memory among running instances.
         </p>
       </body>
     </topic>

--- a/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
@@ -54,10 +54,10 @@
     <title>Understanding Role and Component Resource Groups</title>
     <body>
     <p>Greenplum Database supports two types of resource groups: groups that manage resources for roles, and groups that manage resources for external components such as PL/Container.</p>
-    <p>The most common application for resource groups is to manage the number of active queries that may execute
+    <p>The most common application for resource groups is to manage the number of active queries that different roles may execute
       concurrently in your Greenplum Database cluster. You can also manage the
       amount of CPU and memory resources that Greenplum allocates to each query.</p>
-    <p>Resource groups for roles use Linux control groups (cgroups) for CPU resource management. Greenplum Database tracks virtual memory internally for these resource groups.</p>
+    <p>Resource groups for roles use Linux control groups (cgroups) for CPU resource management. Greenplum Database tracks virtual memory internally for these resource groups using a memory auditor referred to as <codeph>vmtracker</codeph>.</p>
     <p>When the user executes a query, Greenplum Database evaluates the query against a set of
       limits defined for the resource group. Greenplum Database executes the query immediately if
       the group's resource limits have not yet been reached and the query does not cause the group
@@ -719,7 +719,7 @@ gpstart
 </codeblock>
         </p>
         <p>
-          <codeph>pg_stat_activity</codeph> displays information about the user/role that initiated a query. A query that uses an external component such as PL/Container is composed of two parts: the Greenplum Database query operator processing and the UDF running in a PL/Container instance. Greenplum Database processes the query operators under the resource group assigned to the role that initiated the query. A UDF running in a PL/Container instance runs under the resource group assigned to the PL/Container runtime. The latter is not represented in the <codeph>pg_stat_activity</codeph> view; Greenplum Database does not have any insight into how external components such as PL/Container manage memory among running instances.
+          <codeph>pg_stat_activity</codeph> displays information about the user/role that initiated a query. A query that uses an external component such as PL/Container is composed of two parts: the Greenplum Database query operator that runs in Greenplum Database and the UDF that runs in a PL/Container instance. Greenplum Database processes the query operators under the resource group assigned to the role that initiated the query. A UDF running in a PL/Container instance runs under the resource group assigned to the PL/Container runtime. The latter is not represented in the <codeph>pg_stat_activity</codeph> view; Greenplum Database does not have any insight into how external components such as PL/Container manage memory in running instances.
         </p>
       </body>
     </topic>

--- a/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
@@ -719,7 +719,7 @@ gpstart
 </codeblock>
         </p>
         <p>
-          <codeph>pg_stat_activity</codeph> displays information about the user/role that initiated a query. A query that uses an external component such as PL/Container is composed of two parts: the Greenplum Database query operator that runs in Greenplum Database and the UDF that runs in a PL/Container instance. Greenplum Database processes the query operators under the resource group assigned to the role that initiated the query. A UDF running in a PL/Container instance runs under the resource group assigned to the PL/Container runtime. The latter is not represented in the <codeph>pg_stat_activity</codeph> view; Greenplum Database does not have any insight into how external components such as PL/Container manage memory in running instances.
+          <codeph>pg_stat_activity</codeph> displays information about the user/role that initiated a query. A query that uses an external component such as PL/Container is composed of two parts: the query operator that runs in Greenplum Database and the UDF that runs in a PL/Container instance. Greenplum Database processes the query operators under the resource group assigned to the role that initiated the query. A UDF running in a PL/Container instance runs under the resource group assigned to the PL/Container runtime. The latter is not represented in the <codeph>pg_stat_activity</codeph> view; Greenplum Database does not have any insight into how external components such as PL/Container manage memory in running instances.
         </p>
       </body>
     </topic>

--- a/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
@@ -4,30 +4,19 @@
 <topic id="topic1" xml:lang="en">
   <title id="iz173472">Using Resource Groups</title>
   <body>
-    <p>Greenplum Database supports two types of resource groups: groups that manage resources for roles, and groups that manage resources for external components such as PL/Container.</p>
-    <p><b>Resource groups for roles</b>: You can use resource groups for roles to manage the number of active queries that may execute
-      concurrently in your Greenplum Database cluster. With resource groups for roles, you can also manage the
-      amount of CPU and memory resources Greenplum allocates to each query.</p>
-    <p>Resource groups for roles use Linux control groups (cgroups) for CPU resource management. Greenplum Database tracks virtual memory internally for resource groups for roles.</p>
-    <p>When the user executes a query, Greenplum Database evaluates the query against a set of
-      limits defined for the resource group. Greenplum Database executes the query immediately if
-      the group's resource limits have not yet been reached and the query does not cause the group
-      to exceed the concurrent transaction limit. If these conditions are not met, Greenplum
-      Database queues the query. For example, if the maximum number of concurrent transactions for
-      the resource group has already been reached, a subsequent query is queued and must wait until
-      other queries complete before it runs. Greenplum Database may also execute a pending query
-      when the resource group's concurrency and memory limits are altered to large enough
-      values.</p>
-    <p>Within a resource group for roles, transactions are evaluated on a first in, first out basis. Greenplum
-      Database periodically assesses the active workload of the system, reallocating resources and
-      starting/queuing jobs as necessary.</p>
-    <p><b>Resource groups for external components</b>: You can use resource groups for external components such as PL/Container to manage the CPU and memory resources used by an instance of the component.</p>
-      <p>Resource groups for external components use Linux cgroups to manage the total CPU and memory resources for the component. As Greenplum Database has no concept of a transaction at the component level, a concurrency limit is not applicable.</p> 
-      <p>An external component may optionally define and further refine a more granular level of memory management.</p>
+    <p>You use resource groups to set and enforce CPU, memory, and concurrent transaction limits in Greenplum Database. After you define a resource group, you can then assign the group to one or more Greenplum Database roles, or to an external component such as PL/Container, in order to control the resources used by those roles or components.</p>
+    <p>When you assign a resource group to a role (a role-based resource group), the resource limits that you define for the group apply to all of the roles to which you assign the group. For example, the CPU limit for a resource group identifies the maximum CPU usage for all running transactions submitted by Greenplum Database users in all roles to which you assign the group.</p>
+    <p>Similarly, when you assign a resource group to an external component, the group limits apply to all running instances of the component. For example, if you create a resource group for a PL/Container external component, the memory limit that you define for the group specifies the maximum memory usage for all running instances of each PL/Container runtime to which you assign the group.</p>
+
     <p>This topic includes the following subtopics:</p>
     <ul id="ul_wjf_1wy_sp">
       <li id="im168064">
         <xref href="#topic8339intro" type="topic" format="dita"/>
+      </li>
+      <li id="im168064x">
+        <xref href="#topic8339introattrlim" type="topic" format="dita"/><ul>
+      <li id="im16806az">
+        <xref href="#topic8339777" type="topic" format="dita"/>
       </li>
       <li id="im16806a">
         <xref href="#topic8339717179" type="topic" format="dita"/>
@@ -38,6 +27,7 @@
       <li id="im16806c">
         <xref href="#topic8339717" type="topic" format="dita"/>
       </li>
+      </ul></li>
       <li id="im16806d">
         <xref href="#topic71717999" type="topic" format="dita"/>
         <ul id="ul_wjf_1wy_spXX">
@@ -61,10 +51,34 @@
     </ul>
   </body>
   <topic id="topic8339intro" xml:lang="en">
-    <title>Introduction to Resource Group Attributes and Limits</title>
+    <title>Understanding Role and Component Resource Groups</title>
+    <body>
+    <p>Greenplum Database supports two types of resource groups: groups that manage resources for roles, and groups that manage resources for external components such as PL/Container.</p>
+    <p>The most common application for resource groups is to manage the number of active queries that may execute
+      concurrently in your Greenplum Database cluster. You can also manage the
+      amount of CPU and memory resources that Greenplum allocates to each query.</p>
+    <p>Resource groups for roles use Linux control groups (cgroups) for CPU resource management. Greenplum Database tracks virtual memory internally for these resource groups.</p>
+    <p>When the user executes a query, Greenplum Database evaluates the query against a set of
+      limits defined for the resource group. Greenplum Database executes the query immediately if
+      the group's resource limits have not yet been reached and the query does not cause the group
+      to exceed the concurrent transaction limit. If these conditions are not met, Greenplum
+      Database queues the query. For example, if the maximum number of concurrent transactions for
+      the resource group has already been reached, a subsequent query is queued and must wait until
+      other queries complete before it runs. Greenplum Database may also execute a pending query
+      when the resource group's concurrency and memory limits are altered to large enough
+      values.</p>
+    <p>Within a resource group for roles, transactions are evaluated on a first in, first out basis. Greenplum
+      Database periodically assesses the active workload of the system, reallocating resources and
+      starting/queuing jobs as necessary.</p>
+    <p>You can also use resource groups to manage the CPU and memory resources of external components such as PL/Container. Resource groups for external components use Linux cgroups to manage both the total CPU and total memory resources for the component.</p> 
+    </body>
+  </topic>
+
+  <topic id="topic8339introattrlim" xml:lang="en">
+    <title>Resource Group Attributes and Limits</title>
     <body>
     <p>When you create a resource group, you:</p><ul>
-      <li>Identify the type of resource group.</li>
+      <li>Specify the type of resource group by identifying how memory for the group is audited.</li>
       <li>Provide a set of limits that determine the amount of CPU and memory resources available to the group.</li>
     </ul>
 
@@ -82,13 +96,13 @@
         <tbody>
           <row>
             <entry colname="col1">MEMORY_AUDITOR</entry>
-            <entry colname="col2">The memory auditor in use for the resource group;
-              <codeph>vmtracker</codeph> (default; resource groups for roles) or <codeph>cgroup</codeph> (resource groups for external components).</entry>
+            <entry colname="col2">The memory auditor in use for the resource group.
+              <codeph>vmtracker</codeph> (the default) is required if you want to assign the resource group to roles. Specify <codeph>cgroup</codeph> to assign the resource group to an external component.</entry>
           </row>
           <row>
             <entry colname="col1">CONCURRENCY</entry>
             <entry colname="col2">The maximum number of concurrent transactions, including active
-              and idle transactions, that are permitted for a resource group for roles.</entry>
+              and idle transactions, that are permitted in the resource group.</entry>
           </row>
           <row>
             <entry colname="col1">CPU_RATE_LIMIT</entry>
@@ -120,8 +134,8 @@
   <topic id="topic8339777" xml:lang="en">
     <title>Memory Auditor</title>
     <body>
-      <p>The <codeph>MEMORY_AUDITOR</codeph> attribute identifies the type of resource
-        group. A resource group that specifies the <codeph>vmtracker</codeph>
+      <p>The <codeph>MEMORY_AUDITOR</codeph> attribute specifies the type of resource
+        group by identifying the memory auditor for the group. A resource group that specifies the <codeph>vmtracker</codeph>
         <codeph>MEMORY_AUDITOR</codeph> identifies a resource group for roles. A resource
         group specifying the <codeph>cgroup</codeph> <codeph>MEMORY_AUDITOR</codeph>
         identifies a resource group for external components.</p>
@@ -175,7 +189,8 @@
     <title>Transaction Concurrency Limit</title>
     <body>
       <p>The <codeph>CONCURRENCY</codeph> limit controls the maximum number of concurrent
-        transactions permitted for a resource group for roles. The <codeph>CONCURRENCY</codeph> limit is not applicable to resource groups for external components and must be set to zero (0) for such groups.</p>
+        transactions permitted for a resource group for roles.
+      <note>The <codeph>CONCURRENCY</codeph> limit is not applicable to resource groups for external components and must be set to zero (0) for such groups.</note></p>
       <p>Each resource group for roles is logically divided into
         a fixed number of slots equal to the <codeph>CONCURRENCY</codeph> limit. Greenplum Database
         allocates these slots an equal, fixed percentage of memory resources.</p>
@@ -218,7 +233,7 @@
         active. If multiple resource groups are busy, they are allocated the CPU resources of any
         idle resource groups based on the ratio of their <codeph>CPU_RATE_LIMIT</codeph>s. For
         example, a resource group created with a <codeph>CPU_RATE_LIMIT</codeph> of 40 will be
-        allocated twice as much extra CPU resource as a resource group you create with a
+        allocated twice as much extra CPU resource as a resource group that you create with a
           <codeph>CPU_RATE_LIMIT</codeph> of 20.</p>
     </body>
   </topic>
@@ -251,7 +266,7 @@ rg_perseg_mem = ((RAM * (vm.overcommit_ratio / 100) + SWAP) * gp_resource_group_
         your Greenplum Database cluster must not exceed 100.</p>
     </body>
     <topic id="mem_roles" xml:lang="en">
-      <title>Additional Memory Limits for Resource Groups for Roles</title>
+      <title>Additional Memory Limits for Role-based Resource Groups</title>
       <body>
       <p>The memory reserved by a resource group for roles is further divided into fixed and shared components. The
           <codeph>MEMORY_SHARED_QUOTA</codeph> value that you specify when you create the resource group
@@ -381,7 +396,7 @@ rg_perseg_mem = ((RAM * (vm.overcommit_ratio / 100) + SWAP) * gp_resource_group_
  } </codeblock>
             <p>This content configures CPU, CPU accounting, and memory  control groups
               managed by the <codeph>gpadmin</codeph> user. Greenplum Database uses
-              the memory control group only for those resource groups defined with the
+              the memory control group only for those resource groups created with the
               <codeph>cgroup</codeph> <codeph>MEMORY_AUDITOR</codeph>.</p>
           </li>
           <li>If not already installed and running, install the Control Groups operating system
@@ -606,7 +621,7 @@ gpstart
       <p>You can assign a resource group to one or more roles. If you have defined a role hierarchy,
         assigning a resource group to a parent role does not propagate down to the members of that
         role group.</p>
-      <p>You cannot assign a resource group you create for an external component to a role.</p>
+      <note>You cannot assign a resource group that you create for an external component to a role.</note>
       <p>If you wish to remove a resource group assignment from a role and assign the role the
         default group, change the role's group name assignment to <codeph>NONE</codeph>. For
         example:</p>
@@ -704,7 +719,7 @@ gpstart
 </codeblock>
         </p>
         <p>
-          <codeph>pg_stat_activity</codeph> displays information about the user/role that initiated a query. A query that uses the PL/Container external component has two parts: the Greenplum Database query operator processing and the UDF running in a PL/Container instance. Greenplum Database processes the query operators under the resource group assigned to the role that initiated the query. A UDF running in a PL/Container instance runs under the resource group assigned to the PL/Container runtime. The latter is not represented in the <codeph>pg_stat_activity</codeph> view; Greenplum Database does not have any insight into how PL/Container manages its memory among running instances.
+          <codeph>pg_stat_activity</codeph> displays information about the user/role that initiated a query. A query that uses an external component such as PL/Container is composed of two parts: the Greenplum Database query operator processing and the UDF running in a PL/Container instance. Greenplum Database processes the query operators under the resource group assigned to the role that initiated the query. A UDF running in a PL/Container instance runs under the resource group assigned to the PL/Container runtime. The latter is not represented in the <codeph>pg_stat_activity</codeph> view; Greenplum Database does not have any insight into how external components such as PL/Container manage memory among running instances.
         </p>
       </body>
     </topic>


### PR DESCRIPTION
updates to "using resource groups" page for cgroup memory auditor:
- discuss the now two types of resource groups
- add table to identify which of the resource group limits is applicable to each type of group
- qualify where content is really "resource group for roles"
- add "resource group for external components" content where applicable

questions:
- anything to document about cgroup supporting memory swap?
- is it important to identify what specific cgroup memory properties are used?  i.e. memory.memsw.limit_in_bytes

link to doc review site:
- http://docs-gpdb-lisa-review.cfapps.io/600/admin_guide/wlmgmt.html - new table entry for external components
- http://docs-gpdb-lisa-review.cfapps.io/600/admin_guide/workload_mgmt_resgroups.html - misc updates throughout the page
