### PR TITLE
Refactor resgroup memory auditor

### DIFF
--- a/concourse/pipelines/gpdb_master-generated.yml
+++ b/concourse/pipelines/gpdb_master-generated.yml
@@ -1432,6 +1432,9 @@ jobs:
     - get: bin_gpdb_sles11
       passed:
       - compile_gpdb_sles11
+    - get: gpdb_src
+      resource: gpdb_src_binary_swap
+      trigger: true
 
 - name: resource_group_centos6
   plan:
@@ -1445,7 +1448,7 @@ jobs:
     - get: ccp_src
     - get: centos-gpdb-dev-6
     - get: binary_swap_gpdb
-      passed: [compile_gpdb_binary_swap_centos6]
+      passed: [gate_resource_groups_start]
       resource: binary_swap_gpdb_centos6
       trigger: true
   - put: terraform
@@ -1482,7 +1485,7 @@ jobs:
     - get: ccp_src
     - get: centos-gpdb-dev-6
     - get: binary_swap_gpdb
-      passed: [compile_gpdb_binary_swap_centos6]
+      passed: [gate_resource_groups_start]
       resource: binary_swap_gpdb_centos6
       trigger: true
   - put: terraform

--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -1581,6 +1581,9 @@ jobs:
       passed:
       - compile_gpdb_sles11
 {% endif %}
+    - get: gpdb_src
+      resource: gpdb_src_binary_swap
+      trigger: true
 
 - name: resource_group_centos6
   plan:
@@ -1594,7 +1597,7 @@ jobs:
     - get: ccp_src
     - get: centos-gpdb-dev-6
     - get: binary_swap_gpdb
-      passed: [compile_gpdb_binary_swap_centos6]
+      passed: [gate_resource_groups_start]
       resource: binary_swap_gpdb_centos6
       trigger: [[ test_trigger ]]
   - put: terraform
@@ -1632,7 +1635,7 @@ jobs:
     - get: ccp_src
     - get: centos-gpdb-dev-6
     - get: binary_swap_gpdb
-      passed: [compile_gpdb_binary_swap_centos6]
+      passed: [gate_resource_groups_start]
       resource: binary_swap_gpdb_centos6
       trigger: [[ test_trigger ]]
   - put: terraform

--- a/src/backend/catalog/gp_toolkit.sql
+++ b/src/backend/catalog/gp_toolkit.sql
@@ -1763,37 +1763,29 @@ GRANT SELECT ON gp_toolkit.gp_resqueue_status TO public;
 --------------------------------------------------------------------------------
 
 CREATE VIEW gp_toolkit.gp_resgroup_config AS
-    SELECT
-        G.oid        AS groupid,
-        G.rsgname    AS groupname,
-        G.memauditor AS memauditor,
-        T1.value     AS concurrency,
-        T1.proposed  AS proposed_concurrency,
-        T2.value     AS cpu_rate_limit,
-        T3.value     AS memory_limit,
-        T3.proposed  AS proposed_memory_limit,
-        T4.value     AS memory_shared_quota,
-        T4.proposed  AS proposed_memory_shared_quota,
-        T5.value     AS memory_spill_ratio,
-        T5.proposed  AS proposed_memory_spill_ratio
-    FROM
-        pg_resgroup G,
-        pg_resgroupcapability T1,
-        pg_resgroupcapability T2,
-        pg_resgroupcapability T3,
-        pg_resgroupcapability T4,
-        pg_resgroupcapability T5
-    WHERE
-        G.oid = T1.resgroupid
-    AND G.oid = T2.resgroupid
-    AND G.oid = T3.resgroupid
-    AND G.oid = T4.resgroupid
-    AND G.oid = T5.resgroupid
-    AND T1.reslimittype = 1
-    AND T2.reslimittype = 2
-    AND T3.reslimittype = 3
-    AND T4.reslimittype = 4
-    AND T5.reslimittype = 5
+    SELECT G.oid       AS groupid
+         , G.rsgname   AS groupname
+         , T1.value    AS concurrency
+         , T1.proposed AS proposed_concurrency
+         , T2.value    AS cpu_rate_limit
+         , T3.value    AS memory_limit
+         , T3.proposed AS proposed_memory_limit
+         , T4.value    AS memory_shared_quota
+         , T4.proposed AS proposed_memory_shared_quota
+         , T5.value    AS memory_spill_ratio
+         , T5.proposed AS proposed_memory_spill_ratio
+         , CASE WHEN T6.value IS NULL THEN 'vmtracker'
+                WHEN T6.value='0'     THEN 'vmtracker'
+                WHEN T6.value='1'     THEN 'cgroup'
+                ELSE 'unknown'
+           END         AS memory_auditor
+    FROM pg_resgroup G
+         JOIN pg_resgroupcapability T1 ON G.oid = T1.resgroupid AND T1.reslimittype = 1
+         JOIN pg_resgroupcapability T2 ON G.oid = T2.resgroupid AND T2.reslimittype = 2
+         JOIN pg_resgroupcapability T3 ON G.oid = T3.resgroupid AND T3.reslimittype = 3
+         JOIN pg_resgroupcapability T4 ON G.oid = T4.resgroupid AND T4.reslimittype = 4
+         JOIN pg_resgroupcapability T5 ON G.oid = T5.resgroupid AND T5.reslimittype = 5
+    LEFT JOIN pg_resgroupcapability T6 ON G.oid = T6.resgroupid AND T6.reslimittype = 6
     ;
 
 GRANT SELECT ON gp_toolkit.gp_resgroup_config TO public;

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -185,7 +185,6 @@ struct ResGroupData
 	 * give back to MEM POOL.
 	 */
 	int32       memGap;
-	int32		memAuditor;
 
 	int32		memExpected;		/* expected memory chunks according to current caps */
 	int32		memQuotaGranted;	/* memory chunks for quota part */
@@ -275,7 +274,7 @@ static ResGroupData *groupHashNew(Oid groupId);
 static ResGroupData *groupHashFind(Oid groupId, bool raise);
 static ResGroupData *groupHashRemove(Oid groupId);
 static void waitOnGroup(ResGroupData *group);
-static ResGroupData *createGroup(Oid groupId, const ResGroupOptions *groupOptions);
+static ResGroupData *createGroup(Oid groupId, const ResGroupCaps *caps);
 static void removeGroup(Oid groupId);
 static void AtProcExit_ResGroup(int code, Datum arg);
 static void groupWaitCancel(void);
@@ -472,13 +471,13 @@ error_out:
  * Allocate a resource group entry from a hash table
  */
 void
-AllocResGroupEntry(Oid groupId, const ResGroupOptions *groupOptions)
+AllocResGroupEntry(Oid groupId, const ResGroupCaps *caps)
 {
 	ResGroupData	*group;
 
 	LWLockAcquire(ResGroupLock, LW_EXCLUSIVE);
 
-	group = createGroup(groupId, groupOptions);
+	group = createGroup(groupId, caps);
 	Assert(group != NULL);
 
 	LWLockRelease(ResGroupLock);
@@ -497,6 +496,7 @@ InitResGroups(void)
 	int			numGroups;
 	CdbComponentDatabases *cdbComponentDBs;
 	CdbComponentDatabaseInfo *qdinfo;
+	ResGroupCaps		caps;
 	Relation			relResGroup;
 	Relation			relResGroupCapability;
 
@@ -552,19 +552,18 @@ InitResGroups(void)
 	while (HeapTupleIsValid(tuple = systable_getnext(sscan)))
 	{
 		ResGroupData	*group;
-		ResGroupOptions groupOptions;
+		int cpuRateLimit;
 		Oid groupId = HeapTupleGetOid(tuple);
 
-		groupOptions.memAuditor = GetResGroupMemAuditorFromTuple(relResGroup, tuple);
+		GetResGroupCapabilities(relResGroupCapability, groupId, &caps);
+		cpuRateLimit = caps.cpuRateLimit;
 
-		GetResGroupCapabilities(relResGroupCapability, groupId, &groupOptions.caps);
-
-		group = createGroup(groupId, &groupOptions);
+		group = createGroup(groupId, &caps);
 		Assert(group != NULL);
 
 		ResGroupOps_CreateGroup(groupId);
-		ResGroupOps_SetCpuRateLimit(groupId, groupOptions.caps.cpuRateLimit);
-		ResGroupOps_SetMemoryLimit(groupId, groupOptions.caps.memLimit);
+		ResGroupOps_SetCpuRateLimit(groupId, cpuRateLimit);
+		ResGroupOps_SetMemoryLimit(groupId, caps.memLimit);
 
 		numGroups++;
 		Assert(numGroups <= MaxResourceGroups);
@@ -657,7 +656,7 @@ ResGroupDropFinish(Oid groupId, bool isCommit)
 			bool		migrate;
 
 			/* Only migrate processes out of vmtracker groups */
-			migrate = group->memAuditor == RESGROUP_MEMORY_AUDITOR_VMTRACKER;
+			migrate = group->caps.memAuditor == RESGROUP_MEMORY_AUDITOR_VMTRACKER;
 
 			removeGroup(groupId);
 
@@ -1056,7 +1055,7 @@ removeGroup(Oid groupId)
  *	calling this - unless we are the startup process.
  */
 static ResGroupData *
-createGroup(Oid groupId, const ResGroupOptions *groupOptions)
+createGroup(Oid groupId, const ResGroupCaps *caps)
 {
 	ResGroupData	*group;
 	int32			chunks;
@@ -1068,13 +1067,12 @@ createGroup(Oid groupId, const ResGroupOptions *groupOptions)
 	Assert(group != NULL);
 
 	group->groupId = groupId;
-	group->caps = groupOptions->caps;
+	group->caps = *caps;
 	group->nRunning = 0;
 	ProcQueueInit(&group->waitProcs);
 	group->totalExecuted = 0;
 	group->totalQueued = 0;
 	group->memGap = 0;
-	group->memAuditor = groupOptions->memAuditor;
 	group->memUsage = 0;
 	group->memSharedUsage = 0;
 	group->memQuotaUsed = 0;
@@ -1084,10 +1082,10 @@ createGroup(Oid groupId, const ResGroupOptions *groupOptions)
 
 	group->memQuotaGranted = 0;
 	group->memSharedGranted = 0;
-	group->memExpected = groupGetMemExpected(&groupOptions->caps);
+	group->memExpected = groupGetMemExpected(caps);
 
 	chunks = mempoolReserve(groupId, group->memExpected);
-	groupRebalanceQuota(group, chunks, &groupOptions->caps);
+	groupRebalanceQuota(group, chunks, caps);
 
 	bindGroupOperation(group);
 
@@ -1102,14 +1100,14 @@ bindGroupOperation(ResGroupData *group)
 {
 	Assert(LWLockHeldExclusiveByMe(ResGroupLock));
 
-	if (group->memAuditor == RESGROUP_MEMORY_AUDITOR_VMTRACKER)
+	if (group->caps.memAuditor == RESGROUP_MEMORY_AUDITOR_VMTRACKER)
 		group->groupMemOps = &resgroup_memory_operations_vmtracker;
-	else if (group->memAuditor == RESGROUP_MEMORY_AUDITOR_CGROUP)
+	else if (group->caps.memAuditor == RESGROUP_MEMORY_AUDITOR_CGROUP)
 		group->groupMemOps = &resgroup_memory_operations_cgroup;
 	else
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("invalid memory auditor: %d", group->memAuditor)));
+				 errmsg("invalid memory auditor: %d", group->caps.memAuditor)));
 }
 
 /*

--- a/src/include/catalog/pg_resgroup.h
+++ b/src/include/catalog/pg_resgroup.h
@@ -28,8 +28,6 @@ CATALOG(pg_resgroup,6436) BKI_SHARED_RELATION
 	NameData	rsgname;		/* name of resource group */
 
 	Oid		parent;			/* parent resource group */
-
-	int4	memauditor;
 } FormData_pg_resgroup;
 
 /* no foreign keys */
@@ -45,16 +43,15 @@ typedef FormData_pg_resgroup *Form_pg_resgroup;
  *	compiler constants for pg_resqueue
  * ----------------
  */
-#define Natts_pg_resgroup			3
+#define Natts_pg_resgroup			2
 #define Anum_pg_resgroup_rsgname		1
 #define Anum_pg_resgroup_parent			2
-#define Anum_pg_resgroup_memauditor		3
 
 /* Create initial default resource group */
 
-DATA(insert OID = 6437 ( default_group, 0, 0 ));
+DATA(insert OID = 6437 ( default_group, 0 ));
 
-DATA(insert OID = 6438 ( admin_group, 0, 0 ));
+DATA(insert OID = 6438 ( admin_group, 0 ));
 
 #define DEFAULTRESGROUP_OID 	6437
 #define ADMINRESGROUP_OID 	6438
@@ -75,6 +72,7 @@ typedef enum ResGroupLimitType
 	RESGROUP_LIMIT_TYPE_MEMORY,
 	RESGROUP_LIMIT_TYPE_MEMORY_SHARED_QUOTA,
 	RESGROUP_LIMIT_TYPE_MEMORY_SPILL_RATIO,
+	RESGROUP_LIMIT_TYPE_MEMORY_AUDITOR,
 
 	RESGROUP_LIMIT_TYPE_COUNT,
 } ResGroupLimitType;

--- a/src/include/catalog/pg_resgroupcapability.h
+++ b/src/include/catalog/pg_resgroupcapability.h
@@ -60,6 +60,8 @@ DATA(insert ( 6437, 4, 50, 50 ));
 
 DATA(insert ( 6437, 5, 20, 20 ));
 
+DATA(insert ( 6437, 6, 0, 0 ));
+
 DATA(insert ( 6438, 1, 10, 10 ));
 
 DATA(insert ( 6438, 2, 10, 10 ));
@@ -69,5 +71,7 @@ DATA(insert ( 6438, 3, 10, 10 ));
 DATA(insert ( 6438, 4, 50, 50 ));
 
 DATA(insert ( 6438, 5, 20, 20 ));
+
+DATA(insert ( 6438, 6, 0, 0 ));
 
 #endif   /* PG_RESGROUPCAPABILITY_H */

--- a/src/include/commands/resgroupcmds.h
+++ b/src/include/commands/resgroupcmds.h
@@ -34,12 +34,12 @@ extern void AlterResourceGroup(AlterResourceGroupStmt *stmt);
 /* catalog access function */
 extern Oid GetResGroupIdForName(const char *name);
 extern char *GetResGroupNameForId(Oid oid);
-extern int32 GetResGroupMemAuditorFromTuple(Relation rel, HeapTuple tuple);
-extern int32 GetResGroupMemAuditorForId(Oid groupId, LOCKMODE lockmode);
 extern Oid GetResGroupIdForRole(Oid roleid);
 extern void GetResGroupCapabilities(Relation rel,
 									Oid groupId,
 									ResGroupCaps *resgroupCaps);
 extern void ResGroupCheckForRole(Oid groupId);
+
+extern int32 GetResGroupMemAuditorForId(Oid groupId, LOCKMODE lockmode);
 
 #endif   /* RESGROUPCMDS_H */

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -54,16 +54,8 @@ typedef struct ResGroupCaps
 	ResGroupCap		memLimit;
 	ResGroupCap		memSharedQuota;
 	ResGroupCap		memSpillRatio;
+	ResGroupCap		memAuditor;
 } ResGroupCaps;
-
-/*
- * Resource group options
- */
-typedef struct ResGroupOptions
-{
-	ResGroupCaps caps;
-	int32 memAuditor;
-} ResGroupOptions;
 
 /*
  * GUC variables.
@@ -114,7 +106,7 @@ extern void ResGroupControlInit(void);
 /* Load resource group information from catalog */
 extern void	InitResGroups(void);
 
-extern void AllocResGroupEntry(Oid groupId, const ResGroupOptions *groupOptions);
+extern void AllocResGroupEntry(Oid groupId, const ResGroupCaps *caps);
 
 extern void SerializeResGroupInfo(StringInfo str);
 extern void DeserializeResGroupInfo(struct ResGroupCaps *capsOut,

--- a/src/test/isolation2/expected/resgroup/resgroup_syntax.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_syntax.out
@@ -80,10 +80,10 @@ ERROR:  resource group "rg_test_group" does not exist
 --end_ignore
 
 SELECT * FROM gp_toolkit.gp_resgroup_config;
-groupid|groupname    |memauditor|concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
--------+-------------+----------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
-6437   |default_group|0         |20         |20                  |30            |30          |30                   |50                 |50                          |20                |20                         
-6438   |admin_group  |0         |2          |2                   |10            |10          |10                   |50                 |50                          |20                |20                         
+groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio|memory_auditor
+-------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------+--------------
+6437   |default_group|20         |20                  |30            |30          |30                   |50                 |50                          |20                |20                         |vmtracker     
+6438   |admin_group  |2          |2                   |10            |10          |10                   |50                 |50                          |20                |20                         |vmtracker     
 (2 rows)
 
 -- negative


### PR DESCRIPTION
We used to implement the memory auditor feature differently on master and 5X, on master the attribute is stored in `pg_resgroup` while on 5X it's stored in `pg_resgroupcapability`. This increases the maintenance effort significantly. So we refactor this feature on master to minimize the difference between these two branches.

We doing this refactor by reverting the related commits on master and reapplying the ones from 5X, with some extra changes such as catalog changes which are not included on 5X.

We do not introduce new tests for this PR as current test cases are sufficient.