### PR TITLE
resgroup: add back guc gp_resgroup_memory_policy.

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4734,6 +4734,15 @@ struct config_enum ConfigureNamesEnum_gp[] =
 	},
 
 	{
+		{"gp_resgroup_memory_policy", PGC_SUSET, RESOURCES_MGM,
+			gettext_noop("Sets the policy for memory allocation of queries."),
+			gettext_noop("Valid values are AUTO, EAGER_FREE.")
+		},
+		&gp_resgroup_memory_policy,
+		RESMANAGER_MEMORY_POLICY_EAGER_FREE, gp_resqueue_memory_policies, NULL, NULL
+	},
+
+	{
 		{"gp_workfile_type_hashjoin", PGC_USERSET, QUERY_TUNING_OTHER,
 			gettext_noop("Specify the type of work files to use for executing hash join plans."),
 			gettext_noop("Valid values are \"BFZ\", \"BUFFILE\"."),

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -73,7 +73,7 @@
  * GUC variables.
  */
 char                		*gp_resgroup_memory_policy_str = NULL;
-ResManagerMemoryPolicy     	gp_resgroup_memory_policy = RESMANAGER_MEMORY_POLICY_NONE;
+int							gp_resgroup_memory_policy = RESMANAGER_MEMORY_POLICY_NONE;
 bool						gp_log_resgroup_memory = false;
 int							gp_resgroup_memory_policy_auto_fixed_mem;
 bool						gp_resgroup_print_operator_memory_limits = false;

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -72,7 +72,6 @@
 /*
  * GUC variables.
  */
-char                		*gp_resgroup_memory_policy_str = NULL;
 int							gp_resgroup_memory_policy = RESMANAGER_MEMORY_POLICY_NONE;
 bool						gp_log_resgroup_memory = false;
 int							gp_resgroup_memory_policy_auto_fixed_mem;

--- a/src/backend/utils/resource_manager/resource_manager.c
+++ b/src/backend/utils/resource_manager/resource_manager.c
@@ -96,7 +96,7 @@ InitResManager(void)
 		 * checkpointer, ftsprobe and filerep processes. Wal sender acts like a backend,
 		 * so we also need to exclude it.
 		 */
-		gp_resmanager_memory_policy = &gp_resgroup_memory_policy;
+		gp_resmanager_memory_policy = (ResManagerMemoryPolicy *) &gp_resgroup_memory_policy;
 		gp_log_resmanager_memory = &gp_log_resgroup_memory;
 		gp_resmanager_memory_policy_auto_fixed_mem = &gp_resgroup_memory_policy_auto_fixed_mem;
 		gp_resmanager_print_operator_memory_limits = &gp_resgroup_print_operator_memory_limits;

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -68,7 +68,6 @@ typedef struct ResGroupOptions
 /*
  * GUC variables.
  */
-extern char                		*gp_resgroup_memory_policy_str;
 extern bool						gp_log_resgroup_memory;
 extern int						gp_resgroup_memory_policy_auto_fixed_mem;
 extern bool						gp_resgroup_print_operator_memory_limits;

--- a/src/include/utils/resscheduler.h
+++ b/src/include/utils/resscheduler.h
@@ -27,7 +27,7 @@
 /*
  * GUC variables.
  */
-extern ResManagerMemoryPolicy   gp_resgroup_memory_policy;
+extern int						gp_resgroup_memory_policy;
 extern int						gp_resqueue_memory_policy;
 extern bool						gp_log_resqueue_memory;
 extern int						gp_resqueue_memory_policy_auto_fixed_mem;

--- a/src/test/regress/expected/resource_group_gucs.out
+++ b/src/test/regress/expected/resource_group_gucs.out
@@ -1,0 +1,57 @@
+-- verify that resource group gucs all exist,
+-- in case any of them are removed by accident.
+-- do not care about the values / ranges / types
+-- start_ignore
+\! gpconfig -s gp_resgroup_print_operator_memory_limits;
+Values on all segments are consistent
+GUC          : gp_resgroup_print_operator_memory_limits
+Master  value: off
+Segment value: off
+-- end_ignore
+\! echo $?;
+0
+-- start_ignore
+\! gpconfig -s gp_resgroup_memory_policy_auto_fixed_mem;
+Values on all segments are consistent
+GUC          : gp_resgroup_memory_policy_auto_fixed_mem
+Master  value: 100kB
+Segment value: 100kB
+-- end_ignore
+\! echo $?;
+0
+-- start_ignore
+\! gpconfig -s gp_resgroup_memory_policy;
+Values on all segments are consistent
+GUC          : gp_resgroup_memory_policy
+Master  value: eager_free
+Segment value: eager_free
+-- end_ignore
+\! echo $?;
+0
+-- start_ignore
+\! gpconfig -s gp_resource_group_cpu_priority;
+Values on all segments are consistent
+GUC          : gp_resource_group_cpu_priority
+Master  value: 10
+Segment value: 10
+-- end_ignore
+\! echo $?;
+0
+-- start_ignore
+\! gpconfig -s gp_resource_group_cpu_limit;
+Values on all segments are consistent
+GUC          : gp_resource_group_cpu_limit
+Master  value: 0.9
+Segment value: 0.9
+-- end_ignore
+\! echo $?;
+0
+-- start_ignore
+\! gpconfig -s gp_resource_group_memory_limit;
+Values on all segments are consistent
+GUC          : gp_resource_group_memory_limit
+Master  value: 0.6924
+Segment value: 0.6924
+-- end_ignore
+\! echo $?;
+0

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -91,6 +91,7 @@ test: resource_queue
 test: resource_queue_function
 test: resource_queue_stat
 test: resource_group
+test: resource_group_gucs
 test: wrkloadadmin
 
 test: gp_toolkit_ao_funcs trig auth_constraint role portals_updatable plpgsql_cache timeseries pg_stat_last_operation pg_stat_last_shoperation gp_numeric_agg partindex_test partition_pruning runtime_stats

--- a/src/test/regress/sql/resource_group_gucs.sql
+++ b/src/test/regress/sql/resource_group_gucs.sql
@@ -1,0 +1,33 @@
+-- verify that resource group gucs all exist,
+-- in case any of them are removed by accident.
+-- do not care about the values / ranges / types
+
+-- start_ignore
+\! gpconfig -s gp_resgroup_print_operator_memory_limits;
+-- end_ignore
+\! echo $?;
+
+-- start_ignore
+\! gpconfig -s gp_resgroup_memory_policy_auto_fixed_mem;
+-- end_ignore
+\! echo $?;
+
+-- start_ignore
+\! gpconfig -s gp_resgroup_memory_policy;
+-- end_ignore
+\! echo $?;
+
+-- start_ignore
+\! gpconfig -s gp_resource_group_cpu_priority;
+-- end_ignore
+\! echo $?;
+
+-- start_ignore
+\! gpconfig -s gp_resource_group_cpu_limit;
+-- end_ignore
+\! echo $?;
+
+-- start_ignore
+\! gpconfig -s gp_resource_group_memory_limit;
+-- end_ignore
+\! echo $?;


### PR DESCRIPTION
This guc was removed by accident in 5cc0ec507d6defa3b19cae77937b220fdfe7d518.

In case we remove the gucs by accident in the future, we also added a testcase to check for the existence of the resgroup gucs.