### PR TITLE
Fix crash while generating planning percentile func on partition tables

### DIFF
--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -5104,24 +5104,6 @@ choose_deduplicate(PlannerInfo *root, List *sortExprs,
 	naive_cost = dummy_path.total_cost;
 
 	/*
-	 * Make a flattened version of the rangetable. estimate_num_groups()
-	 * needs it. It is normally created later in the planning process,
-	 * in query_planner(), but since we want to call estimate_num_groups()
-	 * before query_planner(), we have to build it here.
-	 */
-	root->simple_rel_array_size = list_length(root->parse->rtable) + 1;
-	root->simple_rte_array = (RangeTblEntry **)
-		palloc0(root->simple_rel_array_size * sizeof(RangeTblEntry *));
-	int rti = 1;
-	ListCell *lc;
-	foreach(lc, root->parse->rtable)
-	{
-		RangeTblEntry *rte = (RangeTblEntry *) lfirst(lc);
-
-		root->simple_rte_array[rti++] = rte;
-	}
-
-	/*
 	 * Next, calculate cost of deduplicate.
 	 * The first aggregate calculates number of duplicate for
 	 * each unique sort key, then we add cost of sort after
@@ -5141,8 +5123,6 @@ choose_deduplicate(PlannerInfo *root, List *sortExprs,
 			  num_distinct,
 			  width, -1.0);
 	dedup_cost = dummy_path.total_cost;
-
-	pfree(root->simple_rte_array);
 
 	if (numGroups)
 		*numGroups = num_distinct;

--- a/src/test/regress/expected/percentile.out
+++ b/src/test/regress/expected/percentile.out
@@ -1248,6 +1248,84 @@ group by d1, d2;
      55 |     1
 (1 row)
 
+-- planner must not crash while creating multistage agg plan for median function on partitioned table columns.
+-- orca falls back for median function, so this test only applies to planner.
+DROP TABLE IF EXISTS t_multistage;
+NOTICE:  table "t_multistage" does not exist, skipping
+CREATE TABLE t_multistage (a int, b int)
+PARTITION BY RANGE(b) (START(1) END (18) EVERY(1));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "t_multistage_1_prt_1" for table "t_multistage"
+NOTICE:  CREATE TABLE will create partition "t_multistage_1_prt_2" for table "t_multistage"
+NOTICE:  CREATE TABLE will create partition "t_multistage_1_prt_3" for table "t_multistage"
+NOTICE:  CREATE TABLE will create partition "t_multistage_1_prt_4" for table "t_multistage"
+NOTICE:  CREATE TABLE will create partition "t_multistage_1_prt_5" for table "t_multistage"
+NOTICE:  CREATE TABLE will create partition "t_multistage_1_prt_6" for table "t_multistage"
+NOTICE:  CREATE TABLE will create partition "t_multistage_1_prt_7" for table "t_multistage"
+NOTICE:  CREATE TABLE will create partition "t_multistage_1_prt_8" for table "t_multistage"
+NOTICE:  CREATE TABLE will create partition "t_multistage_1_prt_9" for table "t_multistage"
+NOTICE:  CREATE TABLE will create partition "t_multistage_1_prt_10" for table "t_multistage"
+NOTICE:  CREATE TABLE will create partition "t_multistage_1_prt_11" for table "t_multistage"
+NOTICE:  CREATE TABLE will create partition "t_multistage_1_prt_12" for table "t_multistage"
+NOTICE:  CREATE TABLE will create partition "t_multistage_1_prt_13" for table "t_multistage"
+NOTICE:  CREATE TABLE will create partition "t_multistage_1_prt_14" for table "t_multistage"
+NOTICE:  CREATE TABLE will create partition "t_multistage_1_prt_15" for table "t_multistage"
+NOTICE:  CREATE TABLE will create partition "t_multistage_1_prt_16" for table "t_multistage"
+NOTICE:  CREATE TABLE will create partition "t_multistage_1_prt_17" for table "t_multistage"
+INSERT INTO t_multistage SELECT i, (i%14)+1 FROM generate_series(1,100)i;
+EXPLAIN SELECT median(b) from t_multistage;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=23845.23..23845.24 rows=1 width=8)
+   ->  Nested Loop  (cost=23780.23..23842.73 rows=1000 width=0)
+         ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=23780.23..23822.73 rows=1000 width=16)
+               Merge Key: share0_ref1.unnamed_attr_1
+               ->  Sort  (cost=23780.23..23782.73 rows=334 width=16)
+                     Sort Key: share0_ref1.unnamed_attr_1
+                     ->  Shared Scan (share slice:id 2:0)  (cost=23729.00..23730.40 rows=334 width=16)
+                           ->  Materialize  (cost=23719.00..23729.00 rows=334 width=16)
+                                 ->  Subquery Scan deduplicate  (cost=23695.50..23718.00 rows=334 width=16)
+                                       ->  HashAggregate  (cost=23695.50..23708.00 rows=334 width=16)
+                                             Group By: (float8(public.t_multistage.b))
+                                             ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=23655.50..23680.50 rows=334 width=16)
+                                                   Hash Key: (float8(public.t_multistage.b))
+                                                   ->  HashAggregate  (cost=23655.50..23660.50 rows=334 width=16)
+                                                         Group By: float8(public.t_multistage.b)
+                                                         ->  Result  (cost=0.00..16337.00 rows=487900 width=4)
+                                                               ->  Append  (cost=0.00..16337.00 rows=487900 width=4)
+                                                                     ->  Seq Scan on t_multistage_1_prt_1 t_multistage  (cost=0.00..961.00 rows=28700 width=4)
+                                                                     ->  Seq Scan on t_multistage_1_prt_2 t_multistage  (cost=0.00..961.00 rows=28700 width=4)
+                                                                     ->  Seq Scan on t_multistage_1_prt_3 t_multistage  (cost=0.00..961.00 rows=28700 width=4)
+                                                                     ->  Seq Scan on t_multistage_1_prt_4 t_multistage  (cost=0.00..961.00 rows=28700 width=4)
+                                                                     ->  Seq Scan on t_multistage_1_prt_5 t_multistage  (cost=0.00..961.00 rows=28700 width=4)
+                                                                     ->  Seq Scan on t_multistage_1_prt_6 t_multistage  (cost=0.00..961.00 rows=28700 width=4)
+                                                                     ->  Seq Scan on t_multistage_1_prt_7 t_multistage  (cost=0.00..961.00 rows=28700 width=4)
+                                                                     ->  Seq Scan on t_multistage_1_prt_8 t_multistage  (cost=0.00..961.00 rows=28700 width=4)
+                                                                     ->  Seq Scan on t_multistage_1_prt_9 t_multistage  (cost=0.00..961.00 rows=28700 width=4)
+                                                                     ->  Seq Scan on t_multistage_1_prt_10 t_multistage  (cost=0.00..961.00 rows=28700 width=4)
+                                                                     ->  Seq Scan on t_multistage_1_prt_11 t_multistage  (cost=0.00..961.00 rows=28700 width=4)
+                                                                     ->  Seq Scan on t_multistage_1_prt_12 t_multistage  (cost=0.00..961.00 rows=28700 width=4)
+                                                                     ->  Seq Scan on t_multistage_1_prt_13 t_multistage  (cost=0.00..961.00 rows=28700 width=4)
+                                                                     ->  Seq Scan on t_multistage_1_prt_14 t_multistage  (cost=0.00..961.00 rows=28700 width=4)
+                                                                     ->  Seq Scan on t_multistage_1_prt_15 t_multistage  (cost=0.00..961.00 rows=28700 width=4)
+                                                                     ->  Seq Scan on t_multistage_1_prt_16 t_multistage  (cost=0.00..961.00 rows=28700 width=4)
+                                                                     ->  Seq Scan on t_multistage_1_prt_17 t_multistage  (cost=0.00..961.00 rows=28700 width=4)
+         ->  Materialize  (cost=0.00..0.00 rows=0 width=0)
+               ->  Aggregate  (cost=23732.97..23732.98 rows=1 width=8)
+                     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=23732.90..23732.95 rows=1 width=32)
+                           ->  Aggregate  (cost=23732.90..23732.91 rows=1 width=32)
+                                 ->  Shared Scan (share slice:id 3:0)  (cost=23729.00..23730.40 rows=334 width=16)
+ Optimizer status: legacy query optimizer
+(40 rows)
+
+SELECT median(b) from t_multistage;
+ median 
+--------
+      7
+(1 row)
+
+DROP TABLE IF EXISTS t_multistage;
 drop view percv2;
 drop view percv;
 drop table perct;

--- a/src/test/regress/sql/percentile.sql
+++ b/src/test/regress/sql/percentile.sql
@@ -275,6 +275,16 @@ from  mpp_22413
 where d2 ='55'
 group by d1, d2;
 
+-- planner must not crash while creating multistage agg plan for median function on partitioned table columns.
+-- orca falls back for median function, so this test only applies to planner.
+DROP TABLE IF EXISTS t_multistage;
+CREATE TABLE t_multistage (a int, b int)
+PARTITION BY RANGE(b) (START(1) END (18) EVERY(1));
+INSERT INTO t_multistage SELECT i, (i%14)+1 FROM generate_series(1,100)i;
+EXPLAIN SELECT median(b) from t_multistage;
+SELECT median(b) from t_multistage;
+DROP TABLE IF EXISTS t_multistage;
+
 drop view percv2;
 drop view percv;
 drop table perct;


### PR DESCRIPTION
Fix crash while generarting multistage agg plan using percentile func on partition tables

Function within_agg_make_baseplan() invokes choose_deduplicate() which creates a
flattened rte with the assumption that it is generated later in
query_planner and releases it before returning.
However,  within_agg_make_baseplan() takes care of releasing the memory
during deduplicate optimization and it crashes while trying to release it again.

Also, before this function is invoked, query_planner has already
generated the flattened rte as it is not going to change, so we need not
generate it again in choose_deduplicate() as its already available.

In GPDB4, choose_deduplicate() method does not has the code removed in
this commit as well and the issue reported in 5 does not exists in
GPDB4. In GPDB Master, this portion of the code has significantly
changed due to merge from upstream and choose_deduplicate() method does
not exist nor the issue.

This code was earlier added during postgres 8.3 merge via commit a453004.

Adding tests to validate the change.