### PR TITLE
Fix flakiness in uao_crash_compaction_*

### DIFF
--- a/src/test/isolation2/expected/uao_crash_compaction_column.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_column.out
@@ -52,49 +52,55 @@ INSERT 10
 3:UPDATE crash_vacuum_in_appendonly_insert SET b = 2;
 UPDATE 10
 
--- suspend at intended points
-3:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'suspend', '', '', 'crash_before_cleanup_phase', 0, 0, 2);
-gp_inject_fault
----------------
-t              
-(1 row)
-1&:VACUUM crash_before_cleanup_phase;  <waiting ...>
+-- suspend at intended points.
 3:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'suspend', '', '', 'crash_before_segmentfile_drop', 0, 0, 2);
 gp_inject_fault
 ---------------
 t              
 (1 row)
 2&:VACUUM crash_before_segmentfile_drop;  <waiting ...>
+3:SELECT gp_wait_until_triggered_fault('compaction_before_segmentfile_drop', 1, 2);
+gp_wait_until_triggered_fault
+-----------------------------
+t                            
+(1 row)
 3:SELECT gp_inject_fault('appendonly_insert', 'panic', '', '', 'crash_vacuum_in_appendonly_insert', 0, 0, 2);
 gp_inject_fault
 ---------------
 t              
 (1 row)
 
--- wait for suspend faults to trigger and then proceed to run next
--- command which would trigger panic fault and help test
--- crash_recovery
+-- Only one AO table can be in drop phase at a time. VACUUM on
+-- crash_before_cleanup_phase will end up skipping the drop phase because
+-- previous VACUUM on crash_before_segmentfile_drop is suspended in drop
+-- phase. This results in segment file 1 remaining in drop pending state which
+-- results in segment file 1 not being scheduled for any new inserts.
+3:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'suspend', '', '', 'crash_before_cleanup_phase', 0, 0, 2);
+gp_inject_fault
+---------------
+t              
+(1 row)
+1&:VACUUM crash_before_cleanup_phase;  <waiting ...>
 3:SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 2);
 gp_wait_until_triggered_fault
 -----------------------------
 t                            
 (1 row)
-3:SELECT gp_wait_until_triggered_fault('compaction_before_segmentfile_drop', 1, 2);
-gp_wait_until_triggered_fault
------------------------------
-t                            
-(1 row)
+
+-- we already waited for suspend faults to trigger and hence we can proceed to
+-- run next command which would trigger panic fault and help test
+-- crash_recovery
 3:VACUUM crash_vacuum_in_appendonly_insert;
-ERROR:  fault triggered, fault name:'appendonly_insert' fault type:'panic'  (seg0 127.0.1.1:25432 pid=7142)
+ERROR:  fault triggered, fault name:'appendonly_insert' fault type:'panic'  (seg0 127.0.0.1:25432 pid=21988)
 ERROR:  could not connect to segment: initialization of segworker group failed
 1<:  <... completed>
-ERROR:  Error on receive from seg0 127.0.1.1:25432 pid=7153: server closed the connection unexpectedly
+ERROR:  Error on receive from seg0 127.0.0.1:25432 pid=21999: server closed the connection unexpectedly
 DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
 ERROR:  could not connect to segment: initialization of segworker group failed
 2<:  <... completed>
-ERROR:  Error on receive from seg0 127.0.1.1:25432 pid=7162: server closed the connection unexpectedly
+ERROR:  Error on receive from seg0 127.0.0.1:25432 pid=21994: server closed the connection unexpectedly
 DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
@@ -126,6 +132,16 @@ t
 
 -- perform post crash validation checks
 -- for crash_before_cleanup_phase
+1:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg_name('crash_before_cleanup_phase');
+segno|column_num|physical_segno|tupcount|modcount|state
+-----+----------+--------------+--------+--------+-----
+1    |0         |1             |10      |2       |1    
+1    |1         |129           |10      |2       |1    
+1    |2         |257           |10      |2       |1    
+2    |0         |2             |4       |0       |1    
+2    |1         |130           |4       |0       |1    
+2    |2         |258           |4       |0       |1    
+(6 rows)
 1:INSERT INTO crash_before_cleanup_phase VALUES(1, 1, 'c'), (25, 6, 'c');
 INSERT 2
 1:UPDATE crash_before_cleanup_phase SET b = b+10 WHERE a=25;
@@ -146,27 +162,29 @@ a |b |c
 1:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg_name('crash_before_cleanup_phase');
 segno|column_num|physical_segno|tupcount|modcount|state
 -----+----------+--------------+--------+--------+-----
-1    |0         |1             |6       |4       |1    
-1    |1         |129           |6       |4       |1    
-1    |2         |257           |6       |4       |1    
-2    |0         |2             |4       |0       |1    
-2    |1         |130           |4       |0       |1    
-2    |2         |258           |4       |0       |1    
+1    |0         |1             |10      |2       |1    
+1    |1         |129           |10      |2       |1    
+1    |2         |257           |10      |2       |1    
+2    |0         |2             |7       |2       |1    
+2    |1         |130           |7       |2       |1    
+2    |2         |258           |7       |2       |1    
 (6 rows)
+-- This VACUUM removes the previous drop pending state for segment file 1 which
+-- will make it available for future inserts.
 1:VACUUM crash_before_cleanup_phase;
 VACUUM
 1:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg_name('crash_before_cleanup_phase');
 segno|column_num|physical_segno|tupcount|modcount|state
 -----+----------+--------------+--------+--------+-----
-1    |0         |1             |1       |4       |1    
-1    |1         |129           |1       |4       |1    
-1    |2         |257           |1       |4       |1    
-2    |0         |2             |4       |0       |1    
-2    |1         |130           |4       |0       |1    
-2    |2         |258           |4       |0       |1    
-3    |0         |3             |4       |0       |1    
-3    |1         |131           |4       |0       |1    
-3    |2         |259           |4       |0       |1    
+1    |0         |1             |3       |2       |1    
+1    |1         |129           |3       |2       |1    
+1    |2         |257           |3       |2       |1    
+2    |0         |2             |5       |2       |1    
+2    |1         |130           |5       |2       |1    
+2    |2         |258           |5       |2       |1    
+3    |0         |3             |1       |0       |1    
+3    |1         |131           |1       |0       |1    
+3    |2         |259           |1       |0       |1    
 (9 rows)
 1:INSERT INTO crash_before_cleanup_phase VALUES(21, 1, 'c'), (26, 1, 'c');
 INSERT 2
@@ -188,6 +206,16 @@ a |b |c
 26|11|c                   
 (11 rows)
 -- for crash_before_segmentfile_drop
+1:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg_name('crash_before_segmentfile_drop');
+segno|column_num|physical_segno|tupcount|modcount|state
+-----+----------+--------------+--------+--------+-----
+1    |0         |1             |10      |2       |1    
+1    |1         |129           |10      |2       |1    
+1    |2         |257           |10      |2       |1    
+2    |0         |2             |4       |0       |1    
+2    |1         |130           |4       |0       |1    
+2    |2         |258           |4       |0       |1    
+(6 rows)
 1:INSERT INTO crash_before_segmentfile_drop VALUES(1, 1, 'c'), (25, 6, 'c');
 INSERT 2
 1:UPDATE crash_before_segmentfile_drop SET b = b+10 WHERE a=25;
@@ -330,19 +358,19 @@ gp_inject_fault
 t              
 (1 row)
 1&:VACUUM crash_master_before_cleanup_phase;  <waiting ...>
-2:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'panic', '', '', 'crash_master_before_segmentfile_drop', 0, 0, 1);
-gp_inject_fault
----------------
-t              
+SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 1);
+gp_wait_until_triggered_fault
+-----------------------------
+t                            
 (1 row)
 
 -- wait for suspend faults to trigger and then proceed to run next
 -- command which would trigger panic fault and help test
 -- crash_recovery
-SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 1);
-gp_wait_until_triggered_fault
------------------------------
-t                            
+2:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'panic', '', '', 'crash_master_before_segmentfile_drop', 0, 0, 1);
+gp_inject_fault
+---------------
+t              
 (1 row)
 2:VACUUM crash_master_before_segmentfile_drop;
 PANIC:  fault triggered, fault name:'compaction_before_segmentfile_drop' fault type:'panic'
@@ -368,6 +396,16 @@ t
 
 -- perform post crash validation checks
 -- for crash_master_before_cleanup_phase
+4:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg_name('crash_master_before_cleanup_phase');
+segno|column_num|physical_segno|tupcount|modcount|state
+-----+----------+--------------+--------+--------+-----
+1    |0         |1             |3       |2       |1    
+1    |1         |129           |3       |2       |1    
+1    |2         |257           |3       |2       |1    
+2    |0         |2             |4       |0       |1    
+2    |1         |130           |4       |0       |1    
+2    |2         |258           |4       |0       |1    
+(6 rows)
 4:INSERT INTO crash_master_before_cleanup_phase VALUES(1, 1, 'c'), (25, 6, 'c');
 INSERT 2
 4:UPDATE crash_master_before_cleanup_phase SET b = b+10 WHERE a=25;
@@ -430,6 +468,16 @@ a |b |c
 26|11|c                   
 (11 rows)
 -- for crash_master_before_segmentfile_drop
+4:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg_name('crash_master_before_segmentfile_drop');
+segno|column_num|physical_segno|tupcount|modcount|state
+-----+----------+--------------+--------+--------+-----
+1    |0         |1             |10      |2       |1    
+1    |1         |129           |10      |2       |1    
+1    |2         |257           |10      |2       |1    
+2    |0         |2             |4       |0       |1    
+2    |1         |130           |4       |0       |1    
+2    |2         |258           |4       |0       |1    
+(6 rows)
 4:INSERT INTO crash_master_before_segmentfile_drop VALUES(1, 1, 'c'), (25, 6, 'c');
 INSERT 2
 4:UPDATE crash_master_before_segmentfile_drop SET b = b+10 WHERE a=25;

--- a/src/test/isolation2/expected/uao_crash_compaction_row.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_row.out
@@ -52,49 +52,52 @@ INSERT 10
 3:UPDATE crash_vacuum_in_appendonly_insert SET b = 2;
 UPDATE 10
 
--- suspend at intended points
+-- suspend at intended points. Only one AO table can be in drop phase in a
+-- system at a time hence we must wait for this table's VACUUM to reach cleanup
+-- phase before triggering another VACUUM.
 3:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'suspend', '', '', 'crash_before_cleanup_phase', 0, 0, 2);
 gp_inject_fault
 ---------------
 t              
 (1 row)
 1&:VACUUM crash_before_cleanup_phase;  <waiting ...>
+3:SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 2);
+gp_wait_until_triggered_fault
+-----------------------------
+t                            
+(1 row)
+
 3:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'suspend', '', '', 'crash_before_segmentfile_drop', 0, 0, 2);
 gp_inject_fault
 ---------------
 t              
 (1 row)
 2&:VACUUM crash_before_segmentfile_drop;  <waiting ...>
-3:SELECT gp_inject_fault('appendonly_insert', 'panic', '', '', 'crash_vacuum_in_appendonly_insert', 0, 0, 2);
-gp_inject_fault
----------------
-t              
-(1 row)
-
--- wait for suspend faults to trigger and then proceed to run next
--- command which would trigger panic fault and help test
--- crash_recovery
-3:SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 2);
-gp_wait_until_triggered_fault
------------------------------
-t                            
-(1 row)
 3:SELECT gp_wait_until_triggered_fault('compaction_before_segmentfile_drop', 1, 2);
 gp_wait_until_triggered_fault
 -----------------------------
 t                            
 (1 row)
+
+-- we already waited for suspend faults to trigger and hence we can proceed to
+-- run next command which would trigger panic fault and help test
+-- crash_recovery
+3:SELECT gp_inject_fault('appendonly_insert', 'panic', '', '', 'crash_vacuum_in_appendonly_insert', 0, 0, 2);
+gp_inject_fault
+---------------
+t              
+(1 row)
 3:VACUUM crash_vacuum_in_appendonly_insert;
-ERROR:  fault triggered, fault name:'appendonly_insert' fault type:'panic'  (seg0 127.0.1.1:25432 pid=7037)
+ERROR:  fault triggered, fault name:'appendonly_insert' fault type:'panic'  (seg0 127.0.0.1:25432 pid=21369)
 ERROR:  could not connect to segment: initialization of segworker group failed
 1<:  <... completed>
-ERROR:  Error on receive from seg0 127.0.1.1:25432 pid=7048: server closed the connection unexpectedly
+ERROR:  Error on receive from seg0 127.0.0.1:25432 pid=21379: server closed the connection unexpectedly
 DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
 ERROR:  could not connect to segment: initialization of segworker group failed
 2<:  <... completed>
-ERROR:  Error on receive from seg0 127.0.1.1:25432 pid=7057: server closed the connection unexpectedly
+ERROR:  Error on receive from seg0 127.0.0.1:25432 pid=21384: server closed the connection unexpectedly
 DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
@@ -126,6 +129,12 @@ t
 
 -- perform post crash validation checks
 -- for crash_before_cleanup_phase
+1:SELECT * FROM gp_toolkit.__gp_aoseg_name('crash_before_cleanup_phase');
+segno|eof|tupcount|varblockcount|eof_uncompressed|modcount|formatversion|state
+-----+---+--------+-------------+----------------+--------+-------------+-----
+1    |0  |3       |0            |0               |2       |3            |1    
+2    |0  |4       |0            |0               |0       |3            |1    
+(2 rows)
 1:INSERT INTO crash_before_cleanup_phase VALUES(1, 1, 'c'), (25, 6, 'c');
 INSERT 2
 1:UPDATE crash_before_cleanup_phase SET b = b+10 WHERE a=25;
@@ -178,6 +187,12 @@ a |b |c
 26|11|c                   
 (11 rows)
 -- for crash_before_segmentfile_drop
+1:SELECT * FROM gp_toolkit.__gp_aoseg_name('crash_before_segmentfile_drop');
+segno|eof|tupcount|varblockcount|eof_uncompressed|modcount|formatversion|state
+-----+---+--------+-------------+----------------+--------+-------------+-----
+1    |0  |10      |0            |0               |2       |3            |1    
+2    |0  |4       |0            |0               |0       |3            |1    
+(2 rows)
 1:INSERT INTO crash_before_segmentfile_drop VALUES(1, 1, 'c'), (25, 6, 'c');
 INSERT 2
 1:UPDATE crash_before_segmentfile_drop SET b = b+10 WHERE a=25;
@@ -342,6 +357,12 @@ t
 
 -- perform post crash validation checks
 -- for crash_master_before_cleanup_phase
+4:SELECT * FROM gp_toolkit.__gp_aoseg_name('crash_master_before_cleanup_phase');
+segno|eof|tupcount|varblockcount|eof_uncompressed|modcount|formatversion|state
+-----+---+--------+-------------+----------------+--------+-------------+-----
+1    |0  |3       |0            |0               |2       |3            |1    
+2    |0  |4       |0            |0               |0       |3            |1    
+(2 rows)
 4:INSERT INTO crash_master_before_cleanup_phase VALUES(1, 1, 'c'), (25, 6, 'c');
 INSERT 2
 4:UPDATE crash_master_before_cleanup_phase SET b = b+10 WHERE a=25;
@@ -394,6 +415,12 @@ a |b |c
 26|11|c                   
 (11 rows)
 -- for crash_master_before_segmentfile_drop
+4:SELECT * FROM gp_toolkit.__gp_aoseg_name('crash_master_before_segmentfile_drop');
+segno|eof|tupcount|varblockcount|eof_uncompressed|modcount|formatversion|state
+-----+---+--------+-------------+----------------+--------+-------------+-----
+1    |0  |10      |0            |0               |2       |3            |1    
+2    |0  |4       |0            |0               |0       |3            |1    
+(2 rows)
 4:INSERT INTO crash_master_before_segmentfile_drop VALUES(1, 1, 'c'), (25, 6, 'c');
 INSERT 2
 4:UPDATE crash_master_before_segmentfile_drop SET b = b+10 WHERE a=25;

--- a/src/test/isolation2/sql/uao_crash_compaction_column.sql
+++ b/src/test/isolation2/sql/uao_crash_compaction_column.sql
@@ -31,18 +31,24 @@
 3:INSERT INTO crash_vacuum_in_appendonly_insert SELECT i AS a, 1 AS b, 'hello world' AS c FROM generate_series(1, 10) AS i;
 3:UPDATE crash_vacuum_in_appendonly_insert SET b = 2;
 
--- suspend at intended points
-3:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'suspend', '', '', 'crash_before_cleanup_phase', 0, 0, 2);
-1&:VACUUM crash_before_cleanup_phase;
+-- suspend at intended points.
 3:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'suspend', '', '', 'crash_before_segmentfile_drop', 0, 0, 2);
 2&:VACUUM crash_before_segmentfile_drop;
+3:SELECT gp_wait_until_triggered_fault('compaction_before_segmentfile_drop', 1, 2);
 3:SELECT gp_inject_fault('appendonly_insert', 'panic', '', '', 'crash_vacuum_in_appendonly_insert', 0, 0, 2);
 
--- wait for suspend faults to trigger and then proceed to run next
--- command which would trigger panic fault and help test
--- crash_recovery
+-- Only one AO table can be in drop phase at a time. VACUUM on
+-- crash_before_cleanup_phase will end up skipping the drop phase because
+-- previous VACUUM on crash_before_segmentfile_drop is suspended in drop
+-- phase. This results in segment file 1 remaining in drop pending state which
+-- results in segment file 1 not being scheduled for any new inserts.
+3:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'suspend', '', '', 'crash_before_cleanup_phase', 0, 0, 2);
+1&:VACUUM crash_before_cleanup_phase;
 3:SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 2);
-3:SELECT gp_wait_until_triggered_fault('compaction_before_segmentfile_drop', 1, 2);
+
+-- we already waited for suspend faults to trigger and hence we can proceed to
+-- run next command which would trigger panic fault and help test
+-- crash_recovery
 3:VACUUM crash_vacuum_in_appendonly_insert;
 1<:
 2<:
@@ -57,16 +63,20 @@
 
 -- perform post crash validation checks
 -- for crash_before_cleanup_phase
+1:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg_name('crash_before_cleanup_phase');
 1:INSERT INTO crash_before_cleanup_phase VALUES(1, 1, 'c'), (25, 6, 'c');
 1:UPDATE crash_before_cleanup_phase SET b = b+10 WHERE a=25;
 1:SELECT * FROM crash_before_cleanup_phase ORDER BY a,b;
 1:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg_name('crash_before_cleanup_phase');
+-- This VACUUM removes the previous drop pending state for segment file 1 which
+-- will make it available for future inserts.
 1:VACUUM crash_before_cleanup_phase;
 1:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg_name('crash_before_cleanup_phase');
 1:INSERT INTO crash_before_cleanup_phase VALUES(21, 1, 'c'), (26, 1, 'c');
 1:UPDATE crash_before_cleanup_phase SET b = b+10 WHERE a=26;
 1:SELECT * FROM crash_before_cleanup_phase ORDER BY a,b;
 -- for crash_before_segmentfile_drop
+1:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg_name('crash_before_segmentfile_drop');
 1:INSERT INTO crash_before_segmentfile_drop VALUES(1, 1, 'c'), (25, 6, 'c');
 1:UPDATE crash_before_segmentfile_drop SET b = b+10 WHERE a=25;
 1:SELECT * FROM crash_before_segmentfile_drop ORDER BY a,b;
@@ -105,12 +115,12 @@
 -- suspend at intended points
 2:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'suspend', '', '', 'crash_master_before_cleanup_phase', 0, 0, 1);
 1&:VACUUM crash_master_before_cleanup_phase;
-2:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'panic', '', '', 'crash_master_before_segmentfile_drop', 0, 0, 1);
+SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 1);
 
 -- wait for suspend faults to trigger and then proceed to run next
 -- command which would trigger panic fault and help test
 -- crash_recovery
-SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 1);
+2:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'panic', '', '', 'crash_master_before_segmentfile_drop', 0, 0, 1);
 2:VACUUM crash_master_before_segmentfile_drop;
 1<:
 
@@ -120,6 +130,7 @@ SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 1);
 
 -- perform post crash validation checks
 -- for crash_master_before_cleanup_phase
+4:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg_name('crash_master_before_cleanup_phase');
 4:INSERT INTO crash_master_before_cleanup_phase VALUES(1, 1, 'c'), (25, 6, 'c');
 4:UPDATE crash_master_before_cleanup_phase SET b = b+10 WHERE a=25;
 4:SELECT * FROM crash_master_before_cleanup_phase ORDER BY a,b;
@@ -130,6 +141,7 @@ SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 1);
 4:UPDATE crash_master_before_cleanup_phase SET b = b+10 WHERE a=26;
 4:SELECT * FROM crash_master_before_cleanup_phase ORDER BY a,b;
 -- for crash_master_before_segmentfile_drop
+4:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg_name('crash_master_before_segmentfile_drop');
 4:INSERT INTO crash_master_before_segmentfile_drop VALUES(1, 1, 'c'), (25, 6, 'c');
 4:UPDATE crash_master_before_segmentfile_drop SET b = b+10 WHERE a=25;
 4:SELECT * FROM crash_master_before_segmentfile_drop ORDER BY a,b;


### PR DESCRIPTION
The flakiness was due to concurrent VACUUMs.  If there is another parallel drop
transaction (on any relation) active, the drop is skipped. This is to avoid
upgrade deadlock as the other drop transaction might be on the same relation.

We added additional test coverage for scenario of skipping the drop phase
during concurrent vacuum and crash recovery with file in drop pending state.

Co-authored-by: Ashwin Agrawal <aagrawal@pivotal.io>