### PR TITLE
resgroup: no warning in Probe()

### DIFF
--- a/src/backend/utils/resgroup/resgroup-ops-dummy.c
+++ b/src/backend/utils/resgroup/resgroup-ops-dummy.c
@@ -27,7 +27,7 @@
  */
 
 #define unsupported_system() \
-	elog(WARNING, "cpu rate limitation for resource group is unsupported on this system")
+	elog(WARNING, "resource group is not supported on this system")
 
 /* Return the name for the OS group implementation */
 const char *

--- a/src/backend/utils/resgroup/resgroup-ops-dummy.c
+++ b/src/backend/utils/resgroup/resgroup-ops-dummy.c
@@ -45,7 +45,6 @@ ResGroupOps_Name(void)
 bool
 ResGroupOps_Probe(void)
 {
-	unsupported_system();
 	return false;
 }
 


### PR DESCRIPTION
The resgroup dummy backend currently generate a warning in the Probe() call, this
is not supposed as this function is designed to be called no matter
resgroup is enabled or not.

Removed the warning message from dummy Probe().

Also update warning messages in dummy backend.

It used to generate warning messages like below in the dummy backend:

    cpu rate limitation for resource group is unsupported on this system.

This message was originally introduced when resgroup supported only cpu
rate limitation, but as now there are more supported capabilities we
should have this message updated.