### PR TITLE
FTS detects when primary is in recovery avoiding config change

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -11992,3 +11992,21 @@ WakeupRecovery(void)
 {
 	SetLatch(&XLogCtl->recoveryWakeupLatch);
 }
+
+/*
+ * Report the last WAL replay location
+ */
+XLogRecPtr
+last_xlog_replay_location()
+{
+	/* use volatile pointer to prevent code rearrangement */
+	volatile XLogCtlData *xlogctl = XLogCtl;
+	Assert(xlogctl != NULL);
+	XLogRecPtr	recptr;
+
+	SpinLockAcquire(&xlogctl->info_lck);
+	recptr = xlogctl->recoveryLastRecPtr;
+	SpinLockRelease(&xlogctl->info_lck);
+
+	return recptr;
+}

--- a/src/backend/fts/test/ftsprobe_test.c
+++ b/src/backend/fts/test/ftsprobe_test.c
@@ -265,8 +265,9 @@ test_ftsConnect_one_failure_one_success(void **state)
 	PGconn *failure_pgconn = palloc(sizeof(PGconn));
 	failure_pgconn->status = CONNECTION_BAD;
 	will_return(PQconnectStart, failure_pgconn);
+
 	expect_value(PQerrorMessage, conn, failure_pgconn);
-	will_be_called(PQerrorMessage);
+	will_return(PQerrorMessage, "");
 
 	ftsConnect(&context);
 
@@ -461,7 +462,7 @@ test_ftsReceive_when_fts_handler_FATAL(void **state)
 	will_return(PQconsumeInput, 0);
 
 	expect_value(PQerrorMessage, conn, ftsInfo->conn);
-	will_be_called(PQerrorMessage);
+	will_return(PQerrorMessage, "");
 
 	/*
 	 * TEST

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -3504,7 +3504,6 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_fts_probe_retries", PGC_SIGHUP, GP_ARRAY_TUNING,
 			gettext_noop("Number of retries for FTS to complete probing a segment."),
 			gettext_noop("Used by the fts-probe process."),
-			GUC_UNIT_S
 		},
 		&gp_fts_probe_retries,
 		5, 0, 100, NULL, NULL

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -390,4 +390,7 @@ extern void do_pg_abort_backup(void);
 extern bool
 IsBkpBlockApplied(XLogRecord *record, uint8 block_id);
 
+extern XLogRecPtr
+last_xlog_replay_location(void);
+
 #endif   /* XLOG_H */

--- a/src/include/postmaster/ftsprobe.h
+++ b/src/include/postmaster/ftsprobe.h
@@ -13,6 +13,7 @@
  */
 #ifndef FTSPROBE_H
 #define FTSPROBE_H
+#include "access/xlogdefs.h"
 
 typedef struct
 {
@@ -81,6 +82,8 @@ typedef struct
 	int16 probe_errno;            /* saved errno from the latest system call */
 	struct pg_conn *conn;         /* libpq connection object */
 	int retry_count;
+	XLogRecPtr xlogrecptr;
+	bool recovery_making_progress;
 } fts_segment_info;
 
 typedef struct

--- a/src/include/postmaster/postmaster.h
+++ b/src/include/postmaster/postmaster.h
@@ -47,6 +47,7 @@ extern int	postmaster_alive_fds[2];
 
 #define POSTMASTER_IN_STARTUP_MSG "the database system is starting up"
 #define POSTMASTER_IN_RECOVERY_MSG "the database system is in recovery mode"
+#define POSTMASTER_IN_RECOVERY_DETAIL_MSG "last replayed record at"
 
 extern const char *progname;
 

--- a/src/include/utils/faultinjector_lists.h
+++ b/src/include/utils/faultinjector_lists.h
@@ -224,6 +224,14 @@ FI_IDENT(SyncRepQueryCancel, "sync_rep_query_cancel")
 FI_IDENT(DistributedLogAdvanceOldestXmin, "distributedlog_advance_oldest_xmin")
 /* inject fault at initialization of wal sender */
 FI_IDENT(InitializeWalSender, "initialize_wal_sender")
+/* inject fault when fts connection is received on primary/mirror */
+FI_IDENT(FTSConnStartupPacket, "fts_conn_startup_packet")
+/*
+ * inject fault to report recovery is hung to FTS. This fault only works with
+ * FTSConnStartupPacket fault set to skip.
+ */
+FI_IDENT(FTSRecoveryInProgress, "fts_recovery_in_progress")
+
 #endif
 
 /*

--- a/src/test/regress/expected/fts_recovery_in_progress.out
+++ b/src/test/regress/expected/fts_recovery_in_progress.out
@@ -1,0 +1,150 @@
+-- Test to make sure FTS doesn't mark primary down if its recovering. Fault
+-- 'fts_conn_startup_packet' is used to simulate the primary responding
+-- in-recovery to FTS, primary is not actually going through crash-recovery in
+-- test.
+create extension if not exists gp_inject_fault;
+select role, preferred_role, mode from gp_segment_configuration where content = 0;
+ role | preferred_role | mode 
+------+----------------+------
+ p    | p              | s
+ m    | m              | s
+(2 rows)
+
+select gp_inject_fault('fts_conn_startup_packet', 'skip', '', '', '', -1, 0, dbid)
+from gp_segment_configuration where content = 0 and role = 'p';
+NOTICE:  Success:  (seg0 127.0.0.1:25432 pid=26540)
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+-- to make test deterministic and fast
+-- start_ignore
+\!gpconfig -c gp_fts_probe_retries -v 2 --masteronly
+\!gpstop -u
+-- end_ignore
+show gp_fts_probe_retries;
+ gp_fts_probe_retries 
+----------------------
+ 2
+(1 row)
+
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t
+(1 row)
+
+select gp_wait_until_triggered_fault('fts_conn_startup_packet', 3, dbid)
+from gp_segment_configuration where content = 0 and role = 'p';
+NOTICE:  Success:  (seg0 127.0.0.1:25432 pid=26540)
+ gp_wait_until_triggered_fault 
+-------------------------------
+ t
+(1 row)
+
+select role, preferred_role, mode from gp_segment_configuration where content = 0;
+ role | preferred_role | mode 
+------+----------------+------
+ p    | p              | s
+ m    | m              | s
+(2 rows)
+
+-- test other scenario where recovery on primary is hung and hence FTS marks
+-- primary down and promotes mirror. When 'fts_recovery_in_progress' is set to
+-- skip it mimics the behavior of hung recovery on primary.
+select gp_inject_fault('fts_recovery_in_progress', 'skip', '', '', '', -1, 0, dbid)
+from gp_segment_configuration where content = 0 and role = 'p';
+NOTICE:  Success:  (seg0 127.0.0.1:25432 pid=26540)
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+-- We call gp_request_fts_probe_scan twice to guarantee that the scan happens
+-- after the fts_recovery_in_progress fault has been injected. If periodic fts
+-- probe is running when the first request scan is run it is possible to not
+-- see the effect due to the fault.
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t
+(1 row)
+
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t
+(1 row)
+
+select role, preferred_role, mode from gp_segment_configuration where content = 0;
+ role | preferred_role | mode 
+------+----------------+------
+ m    | p              | n
+ p    | m              | n
+(2 rows)
+
+-- The remaining steps are to bring back the cluster to original state.
+-- start_ignore
+\! gprecoverseg -aF
+-- end_ignore
+-- loop while segments come in sync
+do $$
+begin
+  for i in 1..120 loop
+    if (select count(*) = 0 from gp_segment_configuration where content = 0 and mode != 's') then
+      return;
+    end if;
+    perform gp_request_fts_probe_scan();
+  end loop;
+end;
+$$;
+select role, preferred_role, mode from gp_segment_configuration where content = 0;
+ role | preferred_role | mode 
+------+----------------+------
+ p    | m              | s
+ m    | p              | s
+(2 rows)
+
+-- start_ignore
+\! gprecoverseg -ar
+-- end_ignore
+-- loop while segments come in sync
+do $$
+begin
+  for i in 1..120 loop
+    if (select count(*) = 0 from gp_segment_configuration where content = 0 and mode != 's') then
+      return;
+    end if;
+    perform gp_request_fts_probe_scan();
+  end loop;
+end;
+$$;
+select role, preferred_role, mode from gp_segment_configuration where content = 0;
+ role | preferred_role | mode 
+------+----------------+------
+ p    | p              | s
+ m    | m              | s
+(2 rows)
+
+-- start_ignore
+\!gpconfig -r gp_fts_probe_retries --masteronly
+\!gpstop -u
+-- end_ignore
+-- cleanup steps
+select gp_inject_fault('fts_recovery_in_progress', 'reset', '', '', '', -1, 0, dbid)
+from gp_segment_configuration where content = 0 and role = 'p';
+NOTICE:  Success:  (seg0 127.0.0.1:25432 pid=27127)
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+select gp_inject_fault('fts_conn_startup_packet', 'reset', '', '', '', -1, 0, dbid)
+from gp_segment_configuration where content = 0 and role = 'p';
+NOTICE:  Success:  (seg0 127.0.0.1:25432 pid=27127)
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -208,6 +208,9 @@ test: psql_gp_commands pg_resetxlog
 # Check for shmem leak for instrumentation slots
 test: instr_in_shmem_verify
 
+# fts_recovery_in_progresss uses fault injectors to simulate FTS fault states,
+# hence it should be run in isolation.
+test: fts_recovery_in_progress
 test: autovacuum-template0
 
 # end of tests

--- a/src/test/regress/sql/fts_recovery_in_progress.sql
+++ b/src/test/regress/sql/fts_recovery_in_progress.sql
@@ -1,0 +1,77 @@
+-- Test to make sure FTS doesn't mark primary down if its recovering. Fault
+-- 'fts_conn_startup_packet' is used to simulate the primary responding
+-- in-recovery to FTS, primary is not actually going through crash-recovery in
+-- test.
+create extension if not exists gp_inject_fault;
+select role, preferred_role, mode from gp_segment_configuration where content = 0;
+select gp_inject_fault('fts_conn_startup_packet', 'skip', '', '', '', -1, 0, dbid)
+from gp_segment_configuration where content = 0 and role = 'p';
+-- to make test deterministic and fast
+-- start_ignore
+\!gpconfig -c gp_fts_probe_retries -v 2 --masteronly
+\!gpstop -u
+-- end_ignore
+show gp_fts_probe_retries;
+select gp_request_fts_probe_scan();
+select gp_wait_until_triggered_fault('fts_conn_startup_packet', 3, dbid)
+from gp_segment_configuration where content = 0 and role = 'p';
+select role, preferred_role, mode from gp_segment_configuration where content = 0;
+
+-- test other scenario where recovery on primary is hung and hence FTS marks
+-- primary down and promotes mirror. When 'fts_recovery_in_progress' is set to
+-- skip it mimics the behavior of hung recovery on primary.
+select gp_inject_fault('fts_recovery_in_progress', 'skip', '', '', '', -1, 0, dbid)
+from gp_segment_configuration where content = 0 and role = 'p';
+-- We call gp_request_fts_probe_scan twice to guarantee that the scan happens
+-- after the fts_recovery_in_progress fault has been injected. If periodic fts
+-- probe is running when the first request scan is run it is possible to not
+-- see the effect due to the fault.
+select gp_request_fts_probe_scan();
+select gp_request_fts_probe_scan();
+select role, preferred_role, mode from gp_segment_configuration where content = 0;
+
+-- The remaining steps are to bring back the cluster to original state.
+-- start_ignore
+\! gprecoverseg -aF
+-- end_ignore
+
+-- loop while segments come in sync
+do $$
+begin
+  for i in 1..120 loop
+    if (select count(*) = 0 from gp_segment_configuration where content = 0 and mode != 's') then
+      return;
+    end if;
+    perform gp_request_fts_probe_scan();
+  end loop;
+end;
+$$;
+select role, preferred_role, mode from gp_segment_configuration where content = 0;
+
+-- start_ignore
+\! gprecoverseg -ar
+-- end_ignore
+
+-- loop while segments come in sync
+do $$
+begin
+  for i in 1..120 loop
+    if (select count(*) = 0 from gp_segment_configuration where content = 0 and mode != 's') then
+      return;
+    end if;
+    perform gp_request_fts_probe_scan();
+  end loop;
+end;
+$$;
+select role, preferred_role, mode from gp_segment_configuration where content = 0;
+
+-- start_ignore
+\!gpconfig -r gp_fts_probe_retries --masteronly
+\!gpstop -u
+-- end_ignore
+
+-- cleanup steps
+select gp_inject_fault('fts_recovery_in_progress', 'reset', '', '', '', -1, 0, dbid)
+from gp_segment_configuration where content = 0 and role = 'p';
+select gp_inject_fault('fts_conn_startup_packet', 'reset', '', '', '', -1, 0, dbid)
+from gp_segment_configuration where content = 0 and role = 'p';


### PR DESCRIPTION
Previous behavior when primary is in crash recovery FTS probe fails and hence
primary is marked down. This change provides a recovery progress metric so that
FTS can detect progress. We added last replayed LSN number inside the error
message to determine recovery progress. This allows FTS to distinguish between
recovery in progress and recovery hang or rolling panics. Only when FTS detects
recovery is not making progress then FTS marks primary down.

For testing a new fault injector is added to allow simulation of recovery hang
and recovery in progress.

Co-authored-by: David Kimura <dkimura@pivotal.io>