### PR TITLE
DOCS: clarify GPORCA index support

### DIFF
--- a/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-limitations.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-limitations.xml
@@ -20,6 +20,8 @@
       <p>These are unsupported features when GPORCA is enabled (the default): <ul id="ul_ndm_gyl_vp">
           <li>Indexed expressions (an index defined as expression based on one or more columns of
             the table)</li>
+          <li>GIN and GIST indexing methods. GPORCA supports only B-tree and bitmap indexes. GPORCA
+            ignores indexes created with unsupported methods.</li>
           <li><cmdname>PERCENTILE</cmdname> window function</li>
           <li>External parameters</li>
           <li>These types of partitioned tables:<ul id="ul_v2m_mmc_bt">

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_INDEX.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_INDEX.xml
@@ -91,6 +91,13 @@
                                                   <codeph>btree</codeph>, <codeph>bitmap</codeph>,
                                                   <codeph>gist</codeph>, and <codeph>gin</codeph>.
                                                 The default method is <codeph>btree</codeph>. </pd>
+                                        <pd>Currently, only the B-tree, GiST and GIN index methods
+                                                support multicolumn indexes. Up to 32 fields can be
+                                                specified by default. Only B-tree currently supports
+                                                unique indexes.</pd>
+                                        <pd>GPORCA supports only B-tree and bitmap indexes. GPORCA
+                                                ignores indexes created with unsupported indexing
+                                                methods.</pd>
                                 </plentry>
                                 <plentry>
                                         <pt>
@@ -212,11 +219,6 @@
                 </section>
                 <section id="section5">
                         <title>Notes</title>
-                        <p>Currently, only the B-tree, GiST and GIN index methods support
-                                multicolumn indexes. Up to 32 fields can be specified by default.
-                                Only B-tree currently supports unique indexes.</p>
-                        <p>GPORCA supports only B-tree and bitmap indexes. GPORCA ignores indexes
-                                created with unsupported indexing methods.</p>
                         <p>An <i>operator class</i> can be specified for each column of an index.
                                 The operator class identifies the operators to be used by the index
                                 for that column. For example, a B-tree index on four-byte integers

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_INDEX.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_INDEX.xml
@@ -29,9 +29,9 @@
                                 For example, an index computed on <codeph>upper(col)</codeph> would
                                 allow the clause <codeph>WHERE upper(col) = 'JIM'</codeph> to use an
                                 index. </p>
-                        <p>Greenplum Database provides the index methods B-tree, bitmap, GiST, and GIN.
-                                Users can also define their own index methods, but that is fairly
-                                complicated. </p>
+                        <p>Greenplum Database provides the index methods B-tree, bitmap, GiST, and
+                                GIN. Users can also define their own index methods, but that is
+                                fairly complicated. </p>
                         <p>When the <codeph>WHERE</codeph> clause is present, a partial index is
                                 created. A partial index is an index that contains entries for only
                                 a portion of a table, usually a portion that is more useful for
@@ -89,8 +89,8 @@
                                         </pt>
                                         <pd>The name of the index method to be used. Choices are
                                                   <codeph>btree</codeph>, <codeph>bitmap</codeph>,
-                                                <codeph>gist</codeph>, and <codeph>gin</codeph>. The default method is
-                                                  <codeph>btree</codeph>. </pd>
+                                                  <codeph>gist</codeph>, and <codeph>gin</codeph>.
+                                                The default method is <codeph>btree</codeph>. </pd>
                                 </plentry>
                                 <plentry>
                                         <pt>
@@ -179,8 +179,7 @@
                                                 tables a smaller fillfactor is better to minimize
                                                 the need for page splits. The other index methods
                                                 use fillfactor in different but roughly analogous
-                                                ways; the default fillfactor varies between methods.
-                                        </pd>
+                                                ways; the default fillfactor varies between methods. </pd>
                                         <pd><codeph>FASTUPDATE</codeph> is a Boolean parameter that
                                                 disables or enables the GIN index fast update
                                                 technique. A value of ON enables fast update (the
@@ -216,6 +215,8 @@
                         <p>Currently, only the B-tree, GiST and GIN index methods support
                                 multicolumn indexes. Up to 32 fields can be specified by default.
                                 Only B-tree currently supports unique indexes.</p>
+                        <p>GPORCA supports only B-tree and bitmap indexes. GPORCA ignores indexes
+                                created with unsupported indexing methods.</p>
                         <p>An <i>operator class</i> can be specified for each column of an index.
                                 The operator class identifies the operators to be used by the index
                                 for that column. For example, a B-tree index on four-byte integers
@@ -285,8 +286,7 @@
                                         href="https://www.postgresql.org/docs/8.3/static/indexes-types.html"
                                         scope="external" format="html">PostgreSQL
                                         documentation</xref>.</p>
-                        <p>The use of hash indexes has been disabled in Greenplum
-                                Database.</p>
+                        <p>The use of hash indexes has been disabled in Greenplum Database.</p>
                 </section>
                 <section id="section6">
                         <title>Examples</title>


### PR DESCRIPTION
-only B-tree and bitmap indexes are supported. GPORCA ignores indexes created with unsupported indexing methods.

Will be backported to 5X_STABLE. (need to remove GIN information for 5.x)