### PR TITLE
Fix flaky dispatcher test case

### DIFF
--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -233,14 +233,18 @@ select gp_inject_fault('send_qe_details_init_backend', 'reset', 2);
 -- Test createGang timeout.
 -- gp_segment_connect_timeout = 0 : wait forever
 -- gp_segment_connect_timeout = 1 : wait 1 second
-select cleanupAllGangs();
 
 select gp_inject_fault('process_startup_packet', 'sleep', '', '', '', 1, 5, 2::smallint);
 set gp_segment_connect_timeout to 1;
 
+select cleanupAllGangs();
+
 -- expect timeout failure
 select * from dispatch_test_t1, dispatch_test_t2, dispatch_test_t3
 where dispatch_test_t1.c2 = dispatch_test_t2.c2 and dispatch_test_t2.c3 = dispatch_test_t3.c3;
+
+-- Wait process_startup_packet to finish sleep
+select pg_sleep(5);
 
 set gp_segment_connect_timeout to 0;
 select gp_inject_fault('process_startup_packet', 'reset', 2);

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -432,12 +432,6 @@ NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11284)
 -- Test createGang timeout.
 -- gp_segment_connect_timeout = 0 : wait forever
 -- gp_segment_connect_timeout = 1 : wait 1 second
-select cleanupAllGangs();
- cleanupallgangs 
------------------
- t
-(1 row)
-
 select gp_inject_fault('process_startup_packet', 'sleep', '', '', '', 1, 5, 2::smallint);
 NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11314)
  gp_inject_fault 
@@ -446,12 +440,25 @@ NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11314)
 (1 row)
 
 set gp_segment_connect_timeout to 1;
+select cleanupAllGangs();
+ cleanupallgangs 
+-----------------
+ t
+(1 row)
+
 -- expect timeout failure
 select * from dispatch_test_t1, dispatch_test_t2, dispatch_test_t3
 where dispatch_test_t1.c2 = dispatch_test_t2.c2 and dispatch_test_t2.c3 = dispatch_test_t3.c3;
 ERROR:  failed to acquire resources on one or more segments
 DETAIL:  timeout expired
  (seg0 127.0.0.1:40000)
+-- Wait process_startup_packet to finish sleep
+select pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
 set gp_segment_connect_timeout to 0;
 select gp_inject_fault('process_startup_packet', 'reset', 2);
 NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11314)


### PR DESCRIPTION
We added a fault injector to sleep 5 seconds in segment to simulate
a non-respond case so we can test GUC gp_segment_connect_timeout can
take effect when creating a gang. Previously, a reader gang triggered
the fault injector and it may report a FATAL error unexpectedly because
the writer gang was destroyed.

To fix this, we let a writer gang to trigger the fault injector and
let the case wait another 5 seconds so the writer gang can exit
normally.