### PR TITLE
Reserse answer file and output file in gpdiff command in tinc tests.

### DIFF
--- a/src/test/tinc/tinctest/lib/__init__.py
+++ b/src/test/tinc/tinctest/lib/__init__.py
@@ -48,7 +48,7 @@ class Gpdiff(Command):
         if match_sub:
             cmd_str += ' -gpd_init '
             cmd_str += ' -gpd_init '.join(match_sub)
-        cmd_str += ' %s %s' % (out_file, ans_file)
+        cmd_str += ' %s %s' % (ans_file, out_file)
         Command.__init__(self, 'run gpdiff', cmd_str)
 
     @staticmethod 


### PR DESCRIPTION
This makes the diff format align with that in pg_regression tests.
Personally I think the pg_regression format is more human understandable.