### PR TITLE
docs - resgroup memory_auditor cat/view updates for 5x

### DIFF
--- a/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
@@ -303,6 +303,12 @@ rg_perseg_mem = ((RAM * (vm.overcommit_ratio / 100) + SWAP) * gp_resource_group_
             <p>This content configures CPU and CPU accounting control groups managed by the
                 <codeph>gpadmin</codeph> user.</p>
           </li>
+          <li>If you plan to use resource groups to manage PL/Container instances, you must add a memory block to the <codeph>gpdb.conf</codeph> file. Be sure to add the block before the closing curly-brace (<codeph>}</codeph>):<codeblock>     cpuacct {
+     }
+     <b>memory {
+     }</b>
+ }</codeblock>
+          </li>
           <li>If not already installed and running, install the Control Groups operating system
             package and start the cgroups service on each Greenplum Database node. The commands you
             run to perform these tasks will differ based on the operating system installed on the

--- a/gpdb-doc/dita/ref_guide/gp_toolkit.xml
+++ b/gpdb-doc/dita/ref_guide/gp_toolkit.xml
@@ -1704,11 +1704,11 @@
           is the same.</p> 
         <p id="json_field_info2">The <codeph>memory_usage</codeph> field is also a JSON-formatted,
           key:value string. The string contents differ depending upon the type of resource
-          group. For each resource group that you assign to a role, this string
+          group. For each resource group that you assign to a role (default memory auditor <codeph>vmtracker</codeph>), this string
           identifies the used, available, granted, and proposed fixed and shared memory
           quota allocations on each segment. The key is segment id. The values are 
           memory values displayed in MB units. The following example shows
-          <codeph>memory_usage</codeph> column output for a role resource group for a single segment:<codeblock>
+          <codeph>memory_usage</codeph> column output for a single segment for a resource group that you assign to a role:<codeblock>
 "0":{"used":0, "available":76, "quota_used":-1, "quota_available":60, "quota_granted":60, "quota_proposed":60, "shared_used":0, "shared_available":16, "shared_granted":16, "shared_proposed":16}</codeblock>
          For each resource group that you assign to
           an external component, the <codeph>memory_usage</codeph> JSON-formatted string identifies the memory used

--- a/gpdb-doc/dita/ref_guide/gp_toolkit.xml
+++ b/gpdb-doc/dita/ref_guide/gp_toolkit.xml
@@ -1703,13 +1703,17 @@
           <codeph>1</codeph> are running on the same host; their CPU usage
           is the same.</p> 
         <p id="json_field_info2">The <codeph>memory_usage</codeph> field is also a JSON-formatted,
-          key:value string. This string identifies, for each resource group, the
-          used, available, granted, and proposed fixed and shared memory quota 
-          allocations on each segment. The key is segment id. The values are 
-          memory values displayed in MB units. Example
-          <codeph>memory_usage</codeph> column output for a
-          single segment:<codeblock>
-"0":{"used":0, "available":76, "quota_used":-1, "quota_available":60, "quota_granted":60, "quota_proposed":60, "shared_used":0, "shared_available":16, "shared_granted":16, "shared_proposed":16}</codeblock></p>
+          key:value string. The string contents differ depending upon the type of resource
+          group. For each resource group that you assign to a role, this string
+          identifies the used, available, granted, and proposed fixed and shared memory
+          quota allocations on each segment. The key is segment id. The values are 
+          memory values displayed in MB units. The following example shows
+          <codeph>memory_usage</codeph> column output for a role resource group for a single segment:<codeblock>
+"0":{"used":0, "available":76, "quota_used":-1, "quota_available":60, "quota_granted":60, "quota_proposed":60, "shared_used":0, "shared_available":16, "shared_granted":16, "shared_proposed":16}</codeblock>
+         For each resource group that you assign to
+          an external component, the <codeph>memory_usage</codeph> JSON-formatted string identifies the memory used
+          and the memory limit on each segment.  The following example shows
+          <codeph>memory_usage</codeph> column output for an external component resource group for a single segment: <codeblock>"1":{"used":11, "limit_granted":15}</codeblock></p>
       </body>
     </topic>
   </topic>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_resgroupcapability.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_resgroupcapability.xml
@@ -47,7 +47,7 @@
             <entry colname="col3">
               <codeph></codeph>
             </entry>
-            <entry colname="col4">The resource group limit type:<p>0 - Unknown</p><p>1 - Concurrency</p><p>2 - CPU</p><p>3 - Memory</p><p>4 - Memory shared quota</p><p>5 - Memory spill ratio</p>
+            <entry colname="col4">The resource group limit type:<p>0 - Unknown</p><p>1 - Concurrency</p><p>2 - CPU</p><p>3 - Memory</p><p>4 - Memory shared quota</p><p>5 - Memory spill ratio</p><p>6 - Memory auditor</p>
             </entry>
           </row>
           <row>


### PR DESCRIPTION
- pg_resgroupcapability - added memory_auditor limit
- gp_resgroup_config - no columns updates, added memory usage output for external components

- "using resource groups" page, enable topic - instruct the user to add a memory {} block to the gpdb.conf file if they want to use resource groups to manage pl/container instances