### PR TITLE
gppylib: Don't get username from the environment

### DIFF
--- a/gpMgmt/bin/gppylib/commands/unix.py
+++ b/gpMgmt/bin/gppylib/commands/unix.py
@@ -8,6 +8,7 @@ Set of Classes for executing unix commands.
 import os
 import platform
 import psutil
+import pwd
 import socket
 import signal
 import uuid
@@ -74,7 +75,7 @@ def getLocalHostname():
 
 
 def getUserName():
-    return os.environ.get('LOGNAME') or os.environ.get('USER')
+    return pwd.getpwuid(os.getuid()).pw_name
 
 
 def check_pid_on_remotehost(pid, host):


### PR DESCRIPTION
Sometimes, these are not set. Other times, they can be set incorrectly
by the user, or a malicious actor.

Co-authored-by: Xin Zhang <xzhang@pivotal.io>
Co-authored-by: David Sharp <dsharp@pivotal.io>