### PR TITLE
Don't pfree() the new tuple generated by triggers

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -5004,7 +5004,7 @@ PROCESS_SEGMENT_DATA:
 						skip_tuple = true;
 					else if (newtuple != tuple) /* modified by Trigger(s) */
 					{
-						ExecStoreHeapTuple(newtuple, slot, InvalidBuffer, true);
+						ExecStoreHeapTuple(newtuple, slot, InvalidBuffer, false);
 					}
 				}
 

--- a/src/test/regress/expected/tsearch.out
+++ b/src/test/regress/expected/tsearch.out
@@ -1072,3 +1072,5 @@ SELECT count(*) FROM test_tsvector WHERE a @@ to_tsquery('345&qwerty');
      1
 (1 row)
 
+COPY test_tsvector TO '/tmp/test_tsvector.txt';
+COPY test_tsvector FROM '/tmp/test_tsvector.txt';

--- a/src/test/regress/sql/tsearch.sql
+++ b/src/test/regress/sql/tsearch.sql
@@ -374,3 +374,6 @@ SELECT count(*) FROM test_tsvector WHERE a @@ to_tsquery('345&qwerty');
 INSERT INTO test_tsvector (t) VALUES ('345 qwerty');
 
 SELECT count(*) FROM test_tsvector WHERE a @@ to_tsquery('345&qwerty');
+
+COPY test_tsvector TO '/tmp/test_tsvector.txt';
+COPY test_tsvector FROM '/tmp/test_tsvector.txt';


### PR DESCRIPTION
ExecBRInsertTriggers() uses the per tuple memory context, which might be
reset and pfree() SEGV.