### PR TITLE
docs: clarify GPORCA index support -backport from master

### DIFF
--- a/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-limitations.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-limitations.xml
@@ -20,6 +20,8 @@
       <p>These are unsupported features when GPORCA is enabled (the default): <ul id="ul_ndm_gyl_vp">
           <li>Indexed expressions (an index defined as expression based on one or more columns of
             the table)</li>
+          <li>GIST indexing method. GPORCA supports only B-tree and bitmap indexes. GPORCA ignores
+            indexes created with unsupported methods.</li>
           <li><cmdname>PERCENTILE</cmdname> window function</li>
           <li>External parameters</li>
           <li>These types of partitioned tables:<ul id="ul_v2m_mmc_bt">

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_INDEX.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_INDEX.xml
@@ -91,6 +91,9 @@
                                                   <codeph>btree</codeph>, <codeph>bitmap</codeph>,
                                                 and <codeph>gist</codeph>. The default method is
                                                   <codeph>btree</codeph>. </pd>
+                                        <pd>GPORCA supports only B-tree and bitmap indexes. GPORCA
+                                                ignores indexes created with unsupported indexing
+                                                methods.</pd>
                                 </plentry>
                                 <plentry>
                                         <pt>


### PR DESCRIPTION
-only B-tree and bitmap indexes are supported. GPORCA ignores indexes created with unsupported indexing methods.

see PR https://github.com/greenplum-db/gpdb/pull/4916