### PR TITLE
docs - add pl/container resource mgmt info

### DIFF
--- a/gpdb-doc/dita/ref_guide/extensions/pl_container.xml
+++ b/gpdb-doc/dita/ref_guide/extensions/pl_container.xml
@@ -73,38 +73,37 @@
     <body>
       <p>Greenplum Database runs PL/Container user-defined functions in Docker
         containers. The Docker containers and the Greenplum Database server share
-        CPU and memory resources on the same host. In the default case, Greenplum
-        Database is unaware of the resources consumed by running PL/Container instances.</p>
+        CPU and memory resources on the same hosts. In the default case, Greenplum
+        Database is unaware of the resources consumed by running PL/Container instances. In PL/Container version 1.2 and later, you can use Greenplum Database resource
+         groups to control overall CPU and memory resource usage for running PL/Container
+         instances, as described in the following section.</p>
       <p>PL/Container manages resource usage at two levels - the container level and
         the runtime level. You can control container-level CPU and memory resources
         with the <codeph>memory_mb</codeph> and
         <codeph>cpu_share</codeph> settings that you configure for the PL/Container
         runtime. <codeph>memory_mb</codeph> governs the memory resources available
-        to each container instance of the runtime. The <codeph>cpu_share</codeph>
-        setting identifies the relative weighting of CPU usage compared to other
+        to each container instance. The <codeph>cpu_share</codeph>
+        setting identifies the relative weighting of a container's CPU usage compared to other
         containers. Refer to <xref href="#topic_ojn_r2s_dw" format="dita"/> 
         for PL/Container configuration information.</p>
       <p>You cannot by default restrict the number of executing PL/Container
         container instances, nor can you restrict the total amount of memory or CPU
         resources that they consume.</p>
-      <p>In PL/Container version 1.2 and later, you can use Greenplum Database resource
-         groups to control overall CPU and memory resource usage for running PL/Container
-         instances, as described in the following section.</p>
 
     </body>
   <topic id="topic_resgroup">
     <title>Using Resource Groups to Manage PL/Container Resources</title>
     <body>
       <p>In PL/Container version 1.2.0 and later, you can use Greenplum Database
-        resource groups to manage and limit the CPU and memory resources of 
-        PL/Container runtimes. For more information about enabling, configuring,
+        resource groups to manage and limit the total CPU and memory resources of 
+        containers in PL/Container runtimes. For more information about enabling, configuring,
         and using Greenplum Database resource groups, refer to <xref href="../../admin_guide/workload_mgmt_resgroups.xml" format="dita" scope="peer">Using Resource Groups</xref>
         in the <cite>Greenplum Database Administrator Guide</cite>.</p>
 
       <note>If you do not explicitly configure resource groups for a PL/Container
         runtime, its container instances are limited only by system resources. The containers may consume resources at the expense of the Greenplum Database server.</note>
 
-      <p>Resource groups for external components such as PL/Container use Linux control groups (cgroups) to manage component-level use of memory and CPU resources. When you manage PL/Container resources with resource groups, you configure both a memory limit and a CPU limit that Greenplum Database applies to all container instances that share the same PL/Container runtime defintion.</p>
+      <p>Resource groups for external components such as PL/Container use Linux control groups (cgroups) to manage component-level use of memory and CPU resources. When you manage PL/Container resources with resource groups, you configure both a memory limit and a CPU limit that Greenplum Database applies to all container instances that share the same PL/Container runtime configuration.</p>
 
       <p>When you create a resource group to manage the resources of a PL/Container
         runtime, you must specify <codeph>MEMORY_AUDITOR=cgroup</codeph> and
@@ -117,7 +116,7 @@
       <p>PL/Container does not use the <codeph>MEMORY_SHARED_QUOTA</codeph> and
         <codeph>MEMORY_SPILL_RATIO</codeph> resource group memory limits. Refer to
         the <xref href="../../ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml" format="dita" scope="peer">CREATE RESOURCE GROUP</xref>
-        reference page for detailed information on this SQL command.</p>
+        reference page for detailed information about this SQL command.</p>
 
       <p>You can create one or more resource groups to manage your running PL/Container
         instances. After you create a resource group for PL/Container, you assign
@@ -134,7 +133,7 @@
  plpy_run1_rg |   16391
 (1 row)</codeblock></p>
 
-      <p>You assign a resource group to a PL/Container runtime definition by specifying the
+      <p>You assign a resource group to a PL/Container runtime configuration by specifying the
         <codeph>-s resource_group_id=<varname>rg_groupid</varname></codeph> option to
         the <codeph>plcontainer runtime-add</codeph> (new runtime) or
         <codeph>plcontainer runtime-replace</codeph> (existing runtime) commands.
@@ -148,7 +147,7 @@
         <xref href="#topic_rw3_52s_dw" format="dita"/>.</p>
 
       <p>After you assign a resource group to a PL/Container runtime, all
-        container instances that share the same runtime definition are
+        container instances that share the same runtime configuration are
         subject to the memory limit and the CPU limit that
         you configured for the group. If you decrease the memory limit of a
         PL/Container resource group, queries executing in running containers
@@ -165,7 +164,7 @@
       <note>If you downgrade to Greenplum Database version 5.7 or earlier after you
         configure resource groups for PL/Container, you must also downgrade PL/Container
         to version 1.1 and remove all <codeph>resource_group_id</codeph> settings from
-        your PL/Container runtime definitions.</note>
+        your PL/Container runtime configurations.</note>
     </body>
     <topic id="topic_resgroupcfg_proc">
       <title>Procedure</title>
@@ -182,18 +181,15 @@
             <codeph>gpdb.conf</codeph> cgroups configuration file includes a
             <codeph>memory { }</codeph> block as described in the previous link.</note></li>
           <li>Analyze the resource usage of your Greenplum Database deployment.
-            Determine the amount of CPU and memory resources that you want to
-            allocate to PL/Container Docker containers.<p><b>Result</b>: You identify the percentages
-            of resource group memory and CPU resources for PL/Container.</p></li>
-          <li>Examine the PL/Container runtime definitions that you have configured
-            or plan to configure in your Greenplum Database deployment. Determine
-            how you want to distribute the total PL/Container CPU and memory
+            Determine the percentage of resource group CPU and memory resources that
+            you want to allocate to PL/Container Docker containers.</li>
+          <li>Determine how you want to distribute the total PL/Container CPU and memory
             resources that you identified in the step above among the PL/Container
-            runtimes.<p><b>Result</b>: You identify:<ul>
+            runtimes. Identify:<ul>
             <li>The number of PL/Container resource group(s) that you require.</li>
             <li>The percentage of memory and CPU resources to allocate to each resource group.</li>
              <li>The resource-group-to-PL/Container-runtime assignment(s).</li>
-           </ul></p></li>
+           </ul></li>
           <li>Create the PL/Container resource groups that you identified in the
             step above. For example, suppose that you choose to allocate 25% of
             both memory and CPU Greenplum Database resources to PL/Container. If
@@ -212,8 +208,8 @@ CREATE RESOURCE GROUP plpy_run1_rg WITH (MEMORY_AUDITOR=cgroup, CONCURRENCY=0,
  plr_run1_rg  |   16393
 (1 row)</codeblock></li>
           <li>Assign each resource group that you created to the desired
-            PL/Container runtime(s). If you have not yet created the runtime
-            definition, use the <codeph>plcontainer runtime-add</codeph> command.
+            PL/Container runtime configuration. If you have not yet created the runtime
+            configuration, use the <codeph>plcontainer runtime-add</codeph> command.
             If the runtime already exists, use the
             <codeph>plcontainer runtime-replace</codeph> or
             <codeph>plcontainer runtime-edit</codeph> command to add the 
@@ -866,15 +862,15 @@ $$ LANGUAGE plcontainer;</codeblock></p>
                         format="dita">settings</xref></codeph> element in the PL/Container
                     configuration file. These are valid parameters.<ul id="ul_dsz_j4w_gcb">
                       <li><codeph>cpu_share</codeph> - Set the CPU limit for each container
-                        of the runtime. The default value is 1024. The value is a
+                        in the runtime configuration. The default value is 1024. The value is a
                         relative weighting of CPU usage compared to other containers.</li>
                       <li><codeph>memory_mb</codeph> - Set the memory limit for each container
-                        of the runtime. The default value is 1024.
+                        in the runtime configuration. The default value is 1024.
                         The value is an integer that specifies the amount of memory in MB. </li>
-                      <li><codeph>resource_group_id</codeph> - Assign the specified resource group to the runtime.
+                      <li><codeph>resource_group_id</codeph> - Assign the specified resource group to the runtime configuration.
                         The resource group limits the total CPU and memory resource
-                        usage for all running containers that share this runtime
-                        definition. You must specify the <codeph>groupid</codeph>
+                        usage for all containers that share this runtime
+                        configuration. You must specify the <codeph>groupid</codeph>
                          of the resource group.
                          For information about managing PL/Container resources,
                          see <xref href="#topic_resmgmt" format="dita"
@@ -1211,10 +1207,10 @@ $$ LANGUAGE plcontainer;</codeblock></p>
                           group to assign to the PL/Container runtime.
                           The resource group limits the total CPU and memory resource
                           usage for all running containers that share this runtime
-                          definition. You must specify the <codeph>groupid</codeph>
+                          configuration. You must specify the <codeph>groupid</codeph>
                           of the resource group. If you do not assign a 
-                          resource group to a PL/Container runtime, its container instances
-                          are limited only by system resources.
+                          resource group to a PL/Container runtime configuration, its
+                          container instances are limited only by system resources.
                           For information about managing PL/Container resources,
                           see <xref href="#topic_resmgmt" format="dita"
                           >About PL/Container Resource Management</xref>.</pd>

--- a/gpdb-doc/dita/ref_guide/extensions/pl_container.xml
+++ b/gpdb-doc/dita/ref_guide/extensions/pl_container.xml
@@ -74,10 +74,10 @@
       <p>Greenplum Database runs PL/Container user-defined functions in Docker
         containers. The Docker containers and the Greenplum Database server share
         CPU and memory resources on the same host. In the default case, Greenplum
-        Database is unaware of the resources consumed by PL/Container instances.</p>
-      <p>PL/Container consumes resources at two levels - the container level and
-        the runtime level. By default, running instances of a PL/Container
-        container are constrained only by the <codeph>memory_mb</codeph> and
+        Database is unaware of the resources consumed by running PL/Container instances.</p>
+      <p>PL/Container manages resource usage at two levels - the container level and
+        the runtime level. You can control container-level CPU and memory resources
+        with the <codeph>memory_mb</codeph> and
         <codeph>cpu_share</codeph> settings that you configure for the PL/Container
         runtime. <codeph>memory_mb</codeph> governs the memory resources available
         to each container instance of the runtime. The <codeph>cpu_share</codeph>
@@ -85,8 +85,11 @@
         containers. Refer to <xref href="#topic_ojn_r2s_dw" format="dita"/> 
         for PL/Container configuration information.</p>
       <p>You cannot by default restrict the number of executing PL/Container
-        container instances, nor can you restrict the amount of memory or CPU
-        resources that they collectively consume.</p>
+        container instances, nor can you restrict the total amount of memory or CPU
+        resources that they consume.</p>
+      <p>In PL/Container version 1.2 and later, you can use Greenplum Database resource
+         groups to control overall CPU and memory resource usage for running PL/Container
+         instances, as described in the following section.</p>
 
     </body>
   <topic id="topic_resgroup">
@@ -99,9 +102,9 @@
         in the <cite>Greenplum Database Administrator Guide</cite>.</p>
 
       <note>If you do not explicitly configure resource groups for a PL/Container
-        runtime, its container instances run unconstrained as described above.</note>
+        runtime, its container instances are limited only by system resources. The containers may consume resources at the expense of the Greenplum Database server.</note>
 
-      <p>Resource groups for external components such as PL/Container use Linux control groups (cgroups) to manage component-level use of memory and CPU resources. When you manage PL/Container resources with resource groups, you configure both a memory limit and a CPU limit that Greenplum Database applies to all running container instances of a PL/Container runtime.</p>
+      <p>Resource groups for external components such as PL/Container use Linux control groups (cgroups) to manage component-level use of memory and CPU resources. When you manage PL/Container resources with resource groups, you configure both a memory limit and a CPU limit that Greenplum Database applies to all container instances that share the same PL/Container runtime defintion.</p>
 
       <p>When you create a resource group to manage the resources of a PL/Container
         runtime, you must specify <codeph>MEMORY_AUDITOR=cgroup</codeph> and
@@ -116,25 +119,27 @@
         the <xref href="../../ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml" format="dita" scope="peer">CREATE RESOURCE GROUP</xref>
         reference page for detailed information on this SQL command.</p>
 
-      <p>You can create one or more resource groups to manage your PL/Container
-        runtimes. After you create a resource group for PL/Container, you assign
+      <p>You can create one or more resource groups to manage your running PL/Container
+        instances. After you create a resource group for PL/Container, you assign
         the resource group to one or more PL/Container runtimes. You make this
-        assignment using the object identifier (oid) of the resource group. You
-        can determine the oid for a given resource group name from the
-        <codeph>pg_resgroup</codeph> system catalog table. For example, the
-        following query displays the oid of a resource group named
-        <codeph>plpy_run1_rg</codeph>:<codeblock>SELECT rsgname, oid FROM pg_resgroup WHERE rsgname='plpy_run1_rg';
-    rsgname   |  oid  
---------------+-------
- plpy_run1_rg | 16391
+        assignment using the <codeph>groupid</codeph> of the resource group. You
+        can determine the <codeph>groupid</codeph> for a given resource group name from the
+        <codeph>gp_resgroup_config</codeph> <codeph>gp_toolkit</codeph> view. For example, the
+        following query displays the <codeph>groupid</codeph> of a resource group named
+        <codeph>plpy_run1_rg</codeph>:<codeblock>SELECT groupname, groupid FROM gp_toolkit.gp_resgroup_config
+     WHERE groupname='plpy_run1_rg';
+
+  groupname   |  groupid  
+--------------+----------
+ plpy_run1_rg |   16391
 (1 row)</codeblock></p>
 
-      <p>You assign a resource group to a PL/Container runtime by specifying the
-        <codeph>-s resource_group_id=<varname>rg_oid</varname></codeph> option to
+      <p>You assign a resource group to a PL/Container runtime definition by specifying the
+        <codeph>-s resource_group_id=<varname>rg_groupid</varname></codeph> option to
         the <codeph>plcontainer runtime-add</codeph> (new runtime) or
         <codeph>plcontainer runtime-replace</codeph> (existing runtime) commands.
         For example, to assign the <codeph>plpy_run1_rg</codeph> resource group
-        to a PL/Container runtime named <codeph>python_run1</codeph>:
+        to a new PL/Container runtime named <codeph>python_run1</codeph>:
         <codeblock>plcontainer runtime-add -r python_run1 -i pivotaldata/plcontainer_python_shared:devel -l python -s resource_group_id=16391</codeblock></p>
 
       <p>You can also assign a resource group to a PL/Container runtime using the
@@ -142,60 +147,69 @@
         the <codeph>plcontainer</codeph> command, see
         <xref href="#topic_rw3_52s_dw" format="dita"/>.</p>
 
-      <p>After you assign a resource group to a PL/Container runtime, all running
-        container instances are subject to the memory limit and the CPU limit that
+      <p>After you assign a resource group to a PL/Container runtime, all
+        container instances that share the same runtime definition are
+        subject to the memory limit and the CPU limit that
         you configured for the group. If you decrease the memory limit of a
-        PL/Container resource group, queries executing in running container
-        instances in the group may fail with an out of memory error. If you drop
+        PL/Container resource group, queries executing in running containers
+        in the group may fail with an out of memory error. If you drop
         a PL/Container resource group while there are running container instances,
         Greenplum Database kills the running containers.</p>
     </body>
   </topic>
   <topic id="topic_resgroupcfg">
-    <title>Procedure</title>
+    <title>Configuring Resource Groups for PL/Container</title>
     <body>
+      <p>To use Greenplum Database resource groups to manage PL/Container resources,
+        you must explicitly configure both resource groups and PL/Container.</p>
+      <note>If you downgrade to Greenplum Database version 5.7 or earlier after you
+        configure resource groups for PL/Container, you must also downgrade PL/Container
+        to version 1.1 and remove all <codeph>resource_group_id</codeph> settings from
+        your PL/Container runtime definitions.</note>
+    </body>
+    <topic id="topic_resgroupcfg_proc">
+      <title>Procedure</title>
+      <body>
         <p>Perform the following procedure to configure PL/Container to use
-          Greenplum Database resource groups:</p><ol>
+          Greenplum Database resource groups for CPU and memory resource management:</p><ol>
           <li>If you have not already configured and enabled resource groups in
-            your Greenplum Database cluster, configure cgroups and enable Greenplum
+            your Greenplum Database deployment, configure cgroups and enable Greenplum
             Database resource groups as described in
             <xref href="../../admin_guide/workload_mgmt_resgroups.xml#topic71717999" format="dita" scope="peer">Using Resource Groups</xref>
-            in the <cite>Greenplum Database Administrator Guide</cite>. If you have
-            previously configured and enabled resource groups in your cluster,
+            in the <cite>Greenplum Database Administrator Guide</cite>.<note>If you have
+            previously configured and enabled resource groups in your deployment,
             ensure that the Greenplum Database resource group
             <codeph>gpdb.conf</codeph> cgroups configuration file includes a
-            <codeph>memory { }</codeph> block as described in the previous link.</li>
-          <li>Analyze the resource usage of your Greenplum Database cluster.
+            <codeph>memory { }</codeph> block as described in the previous link.</note></li>
+          <li>Analyze the resource usage of your Greenplum Database deployment.
             Determine the amount of CPU and memory resources that you want to
-            allocate to PL/Container.<p><b>Result</b>: You identify the percentage
+            allocate to PL/Container Docker containers.<p><b>Result</b>: You identify the percentages
             of resource group memory and CPU resources for PL/Container.</p></li>
           <li>Examine the PL/Container runtime definitions that you have configured
             or plan to configure in your Greenplum Database deployment. Determine
-            if/how you want to distribute the global PL/Container CPU and memory
+            how you want to distribute the total PL/Container CPU and memory
             resources that you identified in the step above among the PL/Container
             runtimes.<p><b>Result</b>: You identify:<ul>
             <li>The number of PL/Container resource group(s) that you require.</li>
-            <li>The percentage of memory and CPU resources to allot to each resource group.</li>
+            <li>The percentage of memory and CPU resources to allocate to each resource group.</li>
              <li>The resource-group-to-PL/Container-runtime assignment(s).</li>
            </ul></p></li>
           <li>Create the PL/Container resource groups that you identified in the
             step above. For example, suppose that you choose to allocate 25% of
             both memory and CPU Greenplum Database resources to PL/Container. If
             you further split these resources among 2 resource groups 60/40, the
-            following SQL commands create the groups:<codeblock>CREATE RESOURCE GROUP plr_run1_rg WITH (MEMORY_AUDITOR=cgroup, CONCURRENCY=0,
-     CPU_RATE_LIMIT=15, MEMORY_LIMIT=15);
+            following SQL commands create the resource groups:<codeblock>CREATE RESOURCE GROUP plr_run1_rg WITH (MEMORY_AUDITOR=cgroup, CONCURRENCY=0,
+    CPU_RATE_LIMIT=15, MEMORY_LIMIT=15);
 CREATE RESOURCE GROUP plpy_run1_rg WITH (MEMORY_AUDITOR=cgroup, CONCURRENCY=0,
-     CPU_RATE_LIMIT=10, MEMORY_LIMIT=10);</codeblock></li>
-          <li>Locate and note the object identifier of each resource group that
-            you created. For example:<codeblock>SELECT rsgname, oid FROM pg_resgroup WHERE rsgname='plpy_run1_rg';
-    rsgname   |  oid
---------------+-------
- plpy_run1_rg | 16391
-(1 row)
-SELECT rsgname, oid FROM pg_resgroup WHERE rsgname='plr_run1_rg';
-   rsgname   |  oid
--------------+-------
- plr_run1_rg | 16393
+    CPU_RATE_LIMIT=10, MEMORY_LIMIT=10);</codeblock></li>
+          <li>Find and note the <codeph>groupid</codeph> associated with each resource group that
+            you created. For example:<codeblock>SELECT groupname, groupid FROM gp_toolkit.gp_resgroup_config 
+    WHERE groupname IN ('plpy_run1_rg', 'plr_run1_rg');
+
+  groupname   |  groupid
+--------------+----------
+ plpy_run1_rg |   16391
+ plr_run1_rg  |   16393
 (1 row)</codeblock></li>
           <li>Assign each resource group that you created to the desired
             PL/Container runtime(s). If you have not yet created the runtime
@@ -203,12 +217,13 @@ SELECT rsgname, oid FROM pg_resgroup WHERE rsgname='plr_run1_rg';
             If the runtime already exists, use the
             <codeph>plcontainer runtime-replace</codeph> or
             <codeph>plcontainer runtime-edit</codeph> command to add the 
-            resource group to the runtime configuration. For example:
+            resource group assignment to the runtime configuration. For example:
             <codeblock>plcontainer runtime-add -r python_run1 -i pivotaldata/plcontainer_python_shared:devel -l python -s resource_group_id=16391
 plcontainer runtime-replace -r r_run1 -i pivotaldata/plcontainer_r_shared:devel -l r -s resource_group_id=16393</codeblock><p>For information about the
           <codeph>plcontainer</codeph> command, see <xref href="#topic_rw3_52s_dw" format="dita"/>.</p></li>
         </ol>
     </body>
+  </topic>
   </topic>
   </topic>
   <topic id="topic_tcm_htd_gw">
@@ -850,15 +865,19 @@ $$ LANGUAGE plcontainer;</codeblock></p>
                     the XML attribute of the <codeph><xref href="#topic_ojn_r2s_dw/plc_settings"
                         format="dita">settings</xref></codeph> element in the PL/Container
                     configuration file. These are valid parameters.<ul id="ul_dsz_j4w_gcb">
-                      <li><codeph>cpu_share</codeph> - Set the weighting of CPU usage
-                        for the runtime. The default value is 1024. The value is a
+                      <li><codeph>cpu_share</codeph> - Set the CPU limit for each container
+                        of the runtime. The default value is 1024. The value is a
                         relative weighting of CPU usage compared to other containers.</li>
-                      <li><codeph>memory_mb</codeph> - Set the memory allocated for the container.
-                        The default value is 1024.
+                      <li><codeph>memory_mb</codeph> - Set the memory limit for each container
+                        of the runtime. The default value is 1024.
                         The value is an integer that specifies the amount of memory in MB. </li>
                       <li><codeph>resource_group_id</codeph> - Assign the specified resource group to the runtime.
-                        You must specify the object identifier of the resource group.
-                         For information about resource management, see <xref href="#topic_resmgmt" format="dita"
+                        The resource group limits the total CPU and memory resource
+                        usage for all running containers that share this runtime
+                        definition. You must specify the <codeph>groupid</codeph>
+                         of the resource group.
+                         For information about managing PL/Container resources,
+                         see <xref href="#topic_resmgmt" format="dita"
                           >About PL/Container Resource Management</xref>.</li>
                       <li><codeph>use_container_logging</codeph> - Enable or disable Docker logging
                         for the container. The value is either <codeph>yes</codeph> (enable logging)
@@ -1169,7 +1188,8 @@ $$ LANGUAGE plcontainer;</codeblock></p>
                   <pd>These are the valid attributes.<parml>
                       <plentry>
                         <pt>cpu_share</pt>
-                        <pd>Optional. Specify the CPU usage for a PL/Container container. The value
+                        <pd>Optional. Specify the CPU usage for each PL/Container container
+                          in the runtime. The value
                           of the element is a positive integer. The default value is 1024. The value
                           is a relative weighting of CPU usage compared to other containers. </pd>
                         <pd>For example, a container with a <codeph>cpu_share</codeph> of 2048 is
@@ -1178,7 +1198,7 @@ $$ LANGUAGE plcontainer;</codeblock></p>
                       </plentry>
                       <plentry>
                         <pt>memory_mb="<varname>size</varname>"</pt>
-                        <pd>Optional. The value specifies the amount of memory, in MB, that a
+                        <pd>Optional. The value specifies the amount of memory, in MB, that each
                           container is allowed to use. Each container starts with this amount of RAM
                           and twice the amount of swap space. The container memory consumption is
                           limited by the host system <codeph>cgroups</codeph> configuration, which
@@ -1186,12 +1206,17 @@ $$ LANGUAGE plcontainer;</codeblock></p>
                           system.</pd>
                       </plentry>
                       <plentry>
-                        <pt>resource_group_id="<varname>rg_oid</varname>"</pt>
-                        <pd>Optional. The value specifies the object identifier of the resource
-                          group to assign to the PL/Container runtime. If you do not assign a 
-                          resource group to a PL/Container runtime, container instances run
-                          collectively unconstrained.
-                          For information about resource management, see <xref href="#topic_resmgmt" format="dita"
+                        <pt>resource_group_id="<varname>rg_groupid</varname>"</pt>
+                        <pd>Optional. The value specifies the <codeph>groupid</codeph> of the resource
+                          group to assign to the PL/Container runtime.
+                          The resource group limits the total CPU and memory resource
+                          usage for all running containers that share this runtime
+                          definition. You must specify the <codeph>groupid</codeph>
+                          of the resource group. If you do not assign a 
+                          resource group to a PL/Container runtime, its container instances
+                          are limited only by system resources.
+                          For information about managing PL/Container resources,
+                          see <xref href="#topic_resmgmt" format="dita"
                           >About PL/Container Resource Management</xref>.</pd>
                       </plentry>
                       <plentry>

--- a/gpdb-doc/dita/ref_guide/extensions/pl_container.xml
+++ b/gpdb-doc/dita/ref_guide/extensions/pl_container.xml
@@ -7,6 +7,7 @@
     <p>This section includes the following information about PL/Container 1.1 and later:</p>
     <ul>
       <li id="pz219023"><xref href="#topic2" type="topic" format="dita"/></li>
+      <li><xref href="#topic_resmgmt" format="dita"/></li>
       <li>
         <xref href="#topic_tcm_htd_gw" format="dita"/></li>
       <li id="pz213664" otherprops="pivotal"><xref href="#topic3" type="topic" format="dita"/></li>
@@ -52,7 +53,7 @@
         segments, and applies a transformation to the data using a PL/Container function. In this
         case, Greenplum Database would start the Docker container only once on each segment, and
         then contact the running container to obtain the results.</p>
-      <p>After starting a full cycle of a query execution. the executor sends a call to the
+      <p>After starting a full cycle of a query execution, the executor sends a call to the
         container. The container might respond with an SPI - SQL query executed by the container to
         get some data back from the database, returning the result to the query executor.</p>
       <p>The container shuts down when the connection to it is closed. This occurs when you close
@@ -66,6 +67,149 @@
           href="https://github.com/greenplum-db/plcontainer" format="html" scope="external"
           >https://github.com/greenplum-db/plcontainer</xref>.</p>
     </body>
+  </topic>
+  <topic id="topic_resmgmt">
+    <title>About PL/Container Resource Management</title>
+    <body>
+      <p>Greenplum Database runs PL/Container user-defined functions in Docker
+        containers. The Docker containers and the Greenplum Database server share
+        CPU and memory resources on the same host. In the default case, Greenplum
+        Database is unaware of the resources consumed by PL/Container instances.</p>
+      <p>PL/Container consumes resources at two levels - the container level and
+        the runtime level. By default, running instances of a PL/Container
+        container are constrained only by the <codeph>memory_mb</codeph> and
+        <codeph>cpu_share</codeph> settings that you configure for the PL/Container
+        runtime. <codeph>memory_mb</codeph> governs the memory resources available
+        to each container instance of the runtime. The <codeph>cpu_share</codeph>
+        setting identifies the relative weighting of CPU usage compared to other
+        containers. Refer to <xref href="#topic_ojn_r2s_dw" format="dita"/> 
+        for PL/Container configuration information.</p>
+      <p>You cannot by default restrict the number of executing PL/Container
+        container instances, nor can you restrict the amount of memory or CPU
+        resources that they collectively consume.</p>
+
+    </body>
+  <topic id="topic_resgroup">
+    <title>Using Resource Groups to Manage PL/Container Resources</title>
+    <body>
+      <p>In PL/Container version 1.2.0 and later, you can use Greenplum Database
+        resource groups to manage and limit the CPU and memory resources of 
+        PL/Container runtimes. For more information about enabling, configuring,
+        and using Greenplum Database resource groups, refer to <xref href="../../admin_guide/workload_mgmt_resgroups.xml" format="dita" scope="peer">Using Resource Groups</xref>
+        in the <cite>Greenplum Database Administrator Guide</cite>.</p>
+
+      <note>If you do not explicitly configure resource groups for a PL/Container
+        runtime, its container instances run unconstrained as described above.</note>
+
+      <p>Resource groups for external components such as PL/Container use Linux control groups (cgroups) to manage component-level use of memory and CPU resources. When you manage PL/Container resources with resource groups, you configure both a memory limit and a CPU limit that Greenplum Database applies to all running container instances of a PL/Container runtime.</p>
+
+      <p>When you create a resource group to manage the resources of a PL/Container
+        runtime, you must specify <codeph>MEMORY_AUDITOR=cgroup</codeph> and
+        <codeph>CONCURRENCY=0</codeph> in addition to the required CPU and memory
+        limits. For example, the following command creates a resource group named
+        <codeph>plpy_run1_rg</codeph> for a PL/Container runtime:
+        <codeblock>CREATE RESOURCE GROUP plpy_run1_rg WITH (MEMORY_AUDITOR=cgroup, CONCURRENCY=0,
+     CPU_RATE_LIMIT=10, MEMORY_LIMIT=10);</codeblock></p>
+
+      <p>PL/Container does not use the <codeph>MEMORY_SHARED_QUOTA</codeph> and
+        <codeph>MEMORY_SPILL_RATIO</codeph> resource group memory limits. Refer to
+        the <xref href="../../ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml" format="dita" scope="peer">CREATE RESOURCE GROUP</xref>
+        reference page for detailed information on this SQL command.</p>
+
+      <p>You can create one or more resource groups to manage your PL/Container
+        runtimes. After you create a resource group for PL/Container, you assign
+        the resource group to one or more PL/Container runtimes. You make this
+        assignment using the object identifier (oid) of the resource group. You
+        can determine the oid for a given resource group name from the
+        <codeph>pg_resgroup</codeph> system catalog table. For example, the
+        following query displays the oid of a resource group named
+        <codeph>plpy_run1_rg</codeph>:<codeblock>SELECT rsgname, oid FROM pg_resgroup WHERE rsgname='plpy_run1_rg';
+    rsgname   |  oid  
+--------------+-------
+ plpy_run1_rg | 16391
+(1 row)</codeblock></p>
+
+      <p>You assign a resource group to a PL/Container runtime by specifying the
+        <codeph>-s resource_group_id=<varname>rg_oid</varname></codeph> option to
+        the <codeph>plcontainer runtime-add</codeph> (new runtime) or
+        <codeph>plcontainer runtime-replace</codeph> (existing runtime) commands.
+        For example, to assign the <codeph>plpy_run1_rg</codeph> resource group
+        to a PL/Container runtime named <codeph>python_run1</codeph>:
+        <codeblock>plcontainer runtime-add -r python_run1 -i pivotaldata/plcontainer_python_shared:devel -l python -s resource_group_id=16391</codeblock></p>
+
+      <p>You can also assign a resource group to a PL/Container runtime using the
+        <codeph>plcontainer runtime-edit</codeph> command. For information about
+        the <codeph>plcontainer</codeph> command, see
+        <xref href="#topic_rw3_52s_dw" format="dita"/>.</p>
+
+      <p>After you assign a resource group to a PL/Container runtime, all running
+        container instances are subject to the memory limit and the CPU limit that
+        you configured for the group. If you decrease the memory limit of a
+        PL/Container resource group, queries executing in running container
+        instances in the group may fail with an out of memory error. If you drop
+        a PL/Container resource group while there are running container instances,
+        Greenplum Database kills the running containers.</p>
+    </body>
+  </topic>
+  <topic id="topic_resgroupcfg">
+    <title>Procedure</title>
+    <body>
+        <p>Perform the following procedure to configure PL/Container to use
+          Greenplum Database resource groups:</p><ol>
+          <li>If you have not already configured and enabled resource groups in
+            your Greenplum Database cluster, configure cgroups and enable Greenplum
+            Database resource groups as described in
+            <xref href="../../admin_guide/workload_mgmt_resgroups.xml#topic71717999" format="dita" scope="peer">Using Resource Groups</xref>
+            in the <cite>Greenplum Database Administrator Guide</cite>. If you have
+            previously configured and enabled resource groups in your cluster,
+            ensure that the Greenplum Database resource group
+            <codeph>gpdb.conf</codeph> cgroups configuration file includes a
+            <codeph>memory { }</codeph> block as described in the previous link.</li>
+          <li>Analyze the resource usage of your Greenplum Database cluster.
+            Determine the amount of CPU and memory resources that you want to
+            allocate to PL/Container.<p><b>Result</b>: You identify the percentage
+            of resource group memory and CPU resources for PL/Container.</p></li>
+          <li>Examine the PL/Container runtime definitions that you have configured
+            or plan to configure in your Greenplum Database deployment. Determine
+            if/how you want to distribute the global PL/Container CPU and memory
+            resources that you identified in the step above among the PL/Container
+            runtimes.<p><b>Result</b>: You identify:<ul>
+            <li>The number of PL/Container resource group(s) that you require.</li>
+            <li>The percentage of memory and CPU resources to allot to each resource group.</li>
+             <li>The resource-group-to-PL/Container-runtime assignment(s).</li>
+           </ul></p></li>
+          <li>Create the PL/Container resource groups that you identified in the
+            step above. For example, suppose that you choose to allocate 25% of
+            both memory and CPU Greenplum Database resources to PL/Container. If
+            you further split these resources among 2 resource groups 60/40, the
+            following SQL commands create the groups:<codeblock>CREATE RESOURCE GROUP plr_run1_rg WITH (MEMORY_AUDITOR=cgroup, CONCURRENCY=0,
+     CPU_RATE_LIMIT=15, MEMORY_LIMIT=15);
+CREATE RESOURCE GROUP plpy_run1_rg WITH (MEMORY_AUDITOR=cgroup, CONCURRENCY=0,
+     CPU_RATE_LIMIT=10, MEMORY_LIMIT=10);</codeblock></li>
+          <li>Locate and note the object identifier of each resource group that
+            you created. For example:<codeblock>SELECT rsgname, oid FROM pg_resgroup WHERE rsgname='plpy_run1_rg';
+    rsgname   |  oid
+--------------+-------
+ plpy_run1_rg | 16391
+(1 row)
+SELECT rsgname, oid FROM pg_resgroup WHERE rsgname='plr_run1_rg';
+   rsgname   |  oid
+-------------+-------
+ plr_run1_rg | 16393
+(1 row)</codeblock></li>
+          <li>Assign each resource group that you created to the desired
+            PL/Container runtime(s). If you have not yet created the runtime
+            definition, use the <codeph>plcontainer runtime-add</codeph> command.
+            If the runtime already exists, use the
+            <codeph>plcontainer runtime-replace</codeph> or
+            <codeph>plcontainer runtime-edit</codeph> command to add the 
+            resource group to the runtime configuration. For example:
+            <codeblock>plcontainer runtime-add -r python_run1 -i pivotaldata/plcontainer_python_shared:devel -l python -s resource_group_id=16391
+plcontainer runtime-replace -r r_run1 -i pivotaldata/plcontainer_r_shared:devel -l r -s resource_group_id=16393</codeblock><p>For information about the
+          <codeph>plcontainer</codeph> command, see <xref href="#topic_rw3_52s_dw" format="dita"/>.</p></li>
+        </ol>
+    </body>
+  </topic>
   </topic>
   <topic id="topic_tcm_htd_gw">
     <title>PL/Container Docker Images</title>
@@ -363,9 +507,9 @@
     </topic>
   </topic>
   <topic id="topic_rh3_p3q_dw">
-    <title>Using PL/Container</title>
+    <title>Using PL/Container Functions</title>
     <body>
-      <p>When you enable PL/Container in database of a Greenplum Database system, the language
+      <p>When you enable PL/Container in a database of a Greenplum Database system, the language
           <codeph>plcontainer</codeph> is registered in the database. You can create and run
         user-defined functions in the procedural languages supported by the PL/Container Docker
         images when you specify <codeph>plcontainer</codeph> as a language in a UDF definition.</p>
@@ -387,8 +531,8 @@
         function in each Greenplum Database session that runs PL/Container functions. You can force
         the configuration file to be re-read by performing a <codeph>SELECT</codeph> command on the
         view <codeph>plcontainer_refresh_config</codeph> during the session. For example, this
-          <codeph>SELECT</codeph> command forces a the configuration file to be read.</p>
-      <codeblock>select * from plcontainer_refresh_config;</codeblock>
+          <codeph>SELECT</codeph> command forces the configuration file to be read.</p>
+      <codeblock>SELECT * FROM plcontainer_refresh_config;</codeblock>
       <p>Running the command executes a PL/Container function that updates the configuration on the
         master and segment instances and returns the status of the
         refresh.<codeblock> gp_segment_id | plcontainer_refresh_local_config
@@ -400,7 +544,7 @@
       <p>Also, you can show all the configurations in the session by performing a
           <codeph>SELECT</codeph> command on the view <codeph>plcontainer_show_config</codeph>. For
         example, this <codeph>SELECT</codeph> command returns the PL/Container configurations. </p>
-      <codeblock>select * from plcontainer_show_config;</codeblock>
+      <codeblock>SELECT * FROM plcontainer_show_config;</codeblock>
       <p>Running the command executes a PL/Container function that displays configuration
         information from the master and segment instances. This is an example of the start and end
         of the view
@@ -428,7 +572,7 @@ gp_segment_id | plcontainer_show_local_config
              1 | ok</codeblock></p>
       <p>The PL/Container function <codeph>plcontainer_containers_summary()</codeph> displays
         information about the currently running Docker
-        containers.<codeblock>select * from plcontainer_containers_summary();</codeblock></p>
+        containers.<codeblock>SELECT * FROM plcontainer_containers_summary();</codeblock></p>
       <p>If a normal (non-superuser) Greenplum Database user runs the function, the function
         displays information only for containers created by the user. If a Greenplum Database
         superuser runs the function, information for all containers created by Greenplum Database
@@ -578,7 +722,7 @@ $$ LANGUAGE plcontainer;</codeblock></p>
         Greenplum Database segments. However, PL/Container configurations of currently running
         sessions use the configuration that existed during session start up. To update the
         PL/Container configuration in a running session, execute this command in the session.</p>
-      <codeblock>select * from plcontainer_refresh_config;</codeblock>
+      <codeblock>SELECT * FROM plcontainer_refresh_config;</codeblock>
       <p>Running the command executes a PL/Container function that updates the session configuration
         on the master and segment instances.</p>
     </body>
@@ -611,11 +755,11 @@ $$ LANGUAGE plcontainer;</codeblock></p>
   runtime-add {<b>-r</b> | <b>--runtime</b>} <varname>runtime_id</varname>
      {<b>-i</b> | <b>--image</b>} <varname>image_name</varname> {<b>-l | --language</b>} {python | r}
      [{<b>-v</b> | <b>--volume</b>} <varname>shared_volume</varname> [{<b>-v</b>| <b>--volume</b>} <varname>shared_volume</varname>...]]
-     [{<b>-s</b> | <b>--setting</b>} <varname>param_value</varname> [{<b>-s</b> | <b>--setting</b>} <varname>param_value</varname> ...]]
+     [{<b>-s</b> | <b>--setting</b>} <varname>param=value</varname> [{<b>-s</b> | <b>--setting</b>} <varname>param=value</varname> ...]]
   runtime-replace {<b>-r</b> | <b>--runtime</b>} <varname>runtime_id</varname>
      {<b>-i</b> | <b>--image</b>} <varname>image_name</varname> <b>-l</b> {r | python}
      [{<b>-v</b> | <b>--volume</b>} <varname>shared_volume</varname> [{<b>-v</b> | <b>--volume</b>} <varname>shared_volume</varname>...]]
-     [{<b>-s</b> | <b>--setting</b>} <varname>param_value</varname> [{<b>-s</b> | <b>--setting</b>} <varname>param_value</varname> ...]]
+     [{<b>-s</b> | <b>--setting</b>} <varname>param=value</varname> [{<b>-s</b> | <b>--setting</b>} <varname>param=value</varname> ...]]
   runtime-show {<b>-r</b> | <b>--runtime</b>} <varname>runtime_id</varname>
   runtime-delete {<b>-r</b> | <b>--runtime</b>} <varname>runtime_id</varname>
   runtime-edit [{<b>-e</b> | <b>--editor</b>} <varname>editor</varname>]
@@ -706,11 +850,16 @@ $$ LANGUAGE plcontainer;</codeblock></p>
                     the XML attribute of the <codeph><xref href="#topic_ojn_r2s_dw/plc_settings"
                         format="dita">settings</xref></codeph> element in the PL/Container
                     configuration file. These are valid parameters.<ul id="ul_dsz_j4w_gcb">
-                      <li><codeph>cpu_share</codeph> - Set relative waiting of CPU usage CPU usage
-                        compared to other containers. The default value is 1024. The value is a
+                      <li><codeph>cpu_share</codeph> - Set the weighting of CPU usage
+                        for the runtime. The default value is 1024. The value is a
                         relative weighting of CPU usage compared to other containers.</li>
                       <li><codeph>memory_mb</codeph> - Set the memory allocated for the container.
+                        The default value is 1024.
                         The value is an integer that specifies the amount of memory in MB. </li>
+                      <li><codeph>resource_group_id</codeph> - Assign the specified resource group to the runtime.
+                        You must specify the object identifier of the resource group.
+                         For information about resource management, see <xref href="#topic_resmgmt" format="dita"
+                          >About PL/Container Resource Management</xref>.</li>
                       <li><codeph>use_container_logging</codeph> - Enable or disable Docker logging
                         for the container. The value is either <codeph>yes</codeph> (enable logging)
                         or <codeph>no</codeph> (disable logging, the default). <p>The Greenplum
@@ -911,6 +1060,7 @@ $$ LANGUAGE plcontainer;</codeblock></p>
         &lt;setting memory_mb="512"/>
         &lt;setting use_container_logging="yes"/>
         &lt;setting cpu_share="1024"/>
+        &lt;setting resource_group_id="16391"/>
     &lt;/runtime>
     &lt;runtime>
         &lt;id>plc_r_example&lt;/id>
@@ -1036,6 +1186,15 @@ $$ LANGUAGE plcontainer;</codeblock></p>
                           system.</pd>
                       </plentry>
                       <plentry>
+                        <pt>resource_group_id="<varname>rg_oid</varname>"</pt>
+                        <pd>Optional. The value specifies the object identifier of the resource
+                          group to assign to the PL/Container runtime. If you do not assign a 
+                          resource group to a PL/Container runtime, container instances run
+                          collectively unconstrained.
+                          For information about resource management, see <xref href="#topic_resmgmt" format="dita"
+                          >About PL/Container Resource Management</xref>.</pd>
+                      </plentry>
+                      <plentry>
                         <pt> use_container_logging="{yes | no}"</pt>
                         <pd>Optional. Enables or disables Docker logging for the container. The
                           attribute value <codeph>yes</codeph> enables logging. The attribute value
@@ -1092,6 +1251,7 @@ $$ LANGUAGE plcontainer;</codeblock></p>
     &lt;command>./client&lt;/command>
     &lt;shared_directory access="ro" container="/clientdir" host="/usr/local/gpdb/bin/plcontainer_clients"/>
     &lt;setting memory_mb="256"/>
+    &lt;setting resource_group_id="16391"/>
   &lt;/runtime>
 &lt;configuration></codeblock>
       </body>


### PR DESCRIPTION
- created a new subtopic "About PL/Container Resource Management" - content:
    - default resource management in pl/container
    - using resource groups to manage pl/container runtimes
    - includes a procedure to configure pl/container to use resource groups 
- this PR assumes doc updates to the "Using Resource Groups" page that are proposed in https://github.com/greenplum-db/gpdb/pull/4888 and https://github.com/greenplum-db/gpdb/pull/4921.
- a few misc edits and fixes

question - the python and r images that i downloaded from pivnet use the tag "devel".  is this correct?  the docs say the tag is supposed to be the version number.

doc review site link:
- http://docs-gpdb-review-staging.cfapps.io/review/ref_guide/extensions/pl_container.html#topic_resmgmt
