### PR TITLE
Fix Coverity Scan Warning(CID 185437).

### DIFF
--- a/src/backend/utils/gdd/gddbackend.c
+++ b/src/backend/utils/gdd/gddbackend.c
@@ -571,7 +571,6 @@ buildWaitGraph(GddCtx *ctx)
 	}
 	PG_END_TRY();
 
-	Assert(connected);
 	SPI_finish();
 	/* Make sure we are in gddContext */
 	MemoryContextSwitchTo(gddContext);


### PR DESCRIPTION
This commit is just to fix coverity scan warning. All tests are included in isolation2/sql/gdd. No test is needed for this commit.