### PR TITLE
Make text array type GPDB hashable.

### DIFF
--- a/src/backend/executor/nodeResult.c
+++ b/src/backend/executor/nodeResult.c
@@ -289,19 +289,9 @@ static bool TupleMatchesHashFilter(Result *resultNode, TupleTableSlot *resultSlo
 
 				/* CdbHash treats all array-types as ANYARRAYOID, it doesn't know how to hash
 				 * the individual types (why is this ?) */
-				switch (att_type)
-				{
-					case INT2ARRAYOID:
-					case INT4ARRAYOID:
-					case INT8ARRAYOID:
-					case FLOAT4ARRAYOID:
-					case FLOAT8ARRAYOID:
-					case REGTYPEARRAYOID:
-						att_type = ANYARRAYOID;
-						/* fall through */
-					default:
-						break;
-				}
+				if (typeIsArrayType(att_type))
+					att_type = ANYARRAYOID;
+
 				cdbhash(hash, hAttr, att_type);
 			}
 			else

--- a/src/test/regress/expected/arrays.out
+++ b/src/test/regress/expected/arrays.out
@@ -1316,6 +1316,19 @@ ORDER BY l.id;
                  924 | {7,14,21,28,42,77,84,154,231,308,462,924}
 (12 rows)
 
+-- Array types are GPDB hashable
+CREATE TEMP TABLE text_array_table (t text[]) DISTRIBUTED BY ( t );
+INSERT INTO text_array_table VALUES ('{foo}');
+CREATE TEMP TABLE int2_array_table (f1 int2[]) DISTRIBUTED BY (f1);
+INSERT INTO int2_array_table VALUES ('{1,2,3}');
+CREATE TEMP TABLE int4_array_table (f1 int4[]) DISTRIBUTED BY (f1);
+INSERT INTO int4_array_table VALUES ('{1,2,3}');
+CREATE TEMP TABLE int8_array_table (f1 int8[]) DISTRIBUTED BY (f1);
+INSERT INTO int8_array_table VALUES ('{1,2,3}');
+CREATE TEMP TABLE float4_array_table (f1 float4[]) DISTRIBUTED BY (f1);
+INSERT INTO float4_array_table VALUES ('{1.1,2.1,3.1}');
+CREATE TEMP TABLE float8_array_table (f1 float8[]) DISTRIBUTED BY (f1);
+INSERT INTO float8_array_table VALUES ('{1.1,2.1,3.1}');
 -- clean up
 -- start_ignore
 -- Drop above three functions

--- a/src/test/regress/sql/arrays.sql
+++ b/src/test/regress/sql/arrays.sql
@@ -498,6 +498,25 @@ WHERE l.id % r.id = 0
 GROUP BY l.id
 ORDER BY l.id;
 
+-- Array types are GPDB hashable
+CREATE TEMP TABLE text_array_table (t text[]) DISTRIBUTED BY ( t );
+INSERT INTO text_array_table VALUES ('{foo}');
+
+CREATE TEMP TABLE int2_array_table (f1 int2[]) DISTRIBUTED BY (f1);
+INSERT INTO int2_array_table VALUES ('{1,2,3}');
+
+CREATE TEMP TABLE int4_array_table (f1 int4[]) DISTRIBUTED BY (f1);
+INSERT INTO int4_array_table VALUES ('{1,2,3}');
+
+CREATE TEMP TABLE int8_array_table (f1 int8[]) DISTRIBUTED BY (f1);
+INSERT INTO int8_array_table VALUES ('{1,2,3}');
+
+CREATE TEMP TABLE float4_array_table (f1 float4[]) DISTRIBUTED BY (f1);
+INSERT INTO float4_array_table VALUES ('{1.1,2.1,3.1}');
+
+CREATE TEMP TABLE float8_array_table (f1 float8[]) DISTRIBUTED BY (f1);
+INSERT INTO float8_array_table VALUES ('{1.1,2.1,3.1}');
+
 -- clean up
 -- start_ignore
 -- Drop above three functions


### PR DESCRIPTION
By design, all array types should be hashable by GPDB.
Issue #3741 shows that GPDB suffers from text array type
being not hashable error.

This commit fixes that.