### PR TITLE
gpload_test: improve output on failure

### DIFF
--- a/gpMgmt/bin/gpload_test/gpload/TEST.py
+++ b/gpMgmt/bin/gpload_test/gpload/TEST.py
@@ -370,7 +370,7 @@ class GPLoad_Env_TestCase(unittest.TestCase):
         (ok, out) = runfile(file)
         self.check_result(file)
 
-    def check_result(self,ifile, optionalFlags = "", outputPath = ""):
+    def check_result(self,ifile, optionalFlags = "-U3", outputPath = ""):
         """
         PURPOSE: compare the actual and expected output files and report an
             error if they don't match.
@@ -381,10 +381,11 @@ class GPLoad_Env_TestCase(unittest.TestCase):
                 figure out the proper names of the .out and .ans files.
             optionalFlags: command-line options (if any) for diff.
                 For example, pass " -B " (with the blank spaces) to ignore
-                blank lines.
+                blank lines. By default, diffs are unified with 3 lines of
+                context (i.e. optionalFlags is "-U3").
         """
-        f1 = outFile(ifile, outputPath=outputPath)
-        f2 = gpdbAnsFile(ifile)
+        f1 = gpdbAnsFile(ifile)
+        f2 = outFile(ifile, outputPath=outputPath)
 
         result = isFileEqual(f1, f2, optionalFlags, outputPath=outputPath)
         self.failUnless(result)

--- a/gpMgmt/bin/gpload_test/gpload/TEST.py
+++ b/gpMgmt/bin/gpload_test/gpload/TEST.py
@@ -200,6 +200,15 @@ def isFileEqual( f1, f2, optionalFlags = "", outputPath = "", myinitfile = ""):
         os.unlink( dfile )
     return ok
 
+def read_diff(ifile, outputPath):
+    """
+    Opens the diff file that is assocated with the given input file and returns
+    its contents as a string.
+    """
+    dfile = diffFile(ifile, outputPath)
+    with open(dfile, 'r') as diff:
+        return diff.read()
+
 def write_config_file(database='gptest',user='',host='localhost',port='',table='lineitem',file='lineitem.tbl.small'):
     if (not user or user == '') and (not os.environ.get('PGUSER') or os.environ.get('PGUSER') == ''):
         user = os.environ.get('USER')
@@ -388,7 +397,8 @@ class GPLoad_Env_TestCase(unittest.TestCase):
         f2 = outFile(ifile, outputPath=outputPath)
 
         result = isFileEqual(f1, f2, optionalFlags, outputPath=outputPath)
-        self.failUnless(result)
+        diff = None if result else read_diff(ifile, outputPath)
+        self.assertTrue(result, "query resulted in diff:\n{}".format(diff))
 
         return True
 

--- a/gpMgmt/bin/gpload_test/gpload2/TEST.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST.py
@@ -393,7 +393,7 @@ class PSQLError(Exception):
 
 class GPLoad_FormatOpts_TestCase(unittest.TestCase):
 
-    def check_result(self,ifile, optionalFlags = "", outputPath = ""):
+    def check_result(self,ifile, optionalFlags = "-U3", outputPath = ""):
         """
         PURPOSE: compare the actual and expected output files and report an
             error if they don't match.
@@ -404,10 +404,11 @@ class GPLoad_FormatOpts_TestCase(unittest.TestCase):
                 figure out the proper names of the .out and .ans files.
             optionalFlags: command-line options (if any) for diff.
                 For example, pass " -B " (with the blank spaces) to ignore
-                blank lines.
+                blank lines. By default, diffs are unified with 3 lines of
+                context (i.e. optionalFlags is "-U3").
         """
-        f1 = outFile(ifile, outputPath=outputPath)
-        f2 = gpdbAnsFile(ifile)
+        f1 = gpdbAnsFile(ifile)
+        f2 = outFile(ifile, outputPath=outputPath)
 
         result = isFileEqual(f1, f2, optionalFlags, outputPath=outputPath)
         self.failUnless(result)

--- a/gpMgmt/bin/gpload_test/gpload2/TEST.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST.py
@@ -322,6 +322,15 @@ def isFileEqual( f1, f2, optionalFlags = "", outputPath = "", myinitfile = ""):
         os.unlink( dfile )
     return ok
 
+def read_diff(ifile, outputPath):
+    """
+    Opens the diff file that is assocated with the given input file and returns
+    its contents as a string.
+    """
+    dfile = diffFile(ifile, outputPath)
+    with open(dfile, 'r') as diff:
+        return diff.read()
+
 def modify_sql_file(num):
     file = mkpath('query%d.sql' % num)
     user = os.environ.get('USER')
@@ -411,7 +420,8 @@ class GPLoad_FormatOpts_TestCase(unittest.TestCase):
         f2 = outFile(ifile, outputPath=outputPath)
 
         result = isFileEqual(f1, f2, optionalFlags, outputPath=outputPath)
-        self.failUnless(result)
+        diff = None if result else read_diff(ifile, outputPath)
+        self.assertTrue(result, "query resulted in diff:\n{}".format(diff))
 
         return True
 

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_REMOTE.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_REMOTE.py
@@ -256,6 +256,15 @@ def isFileEqual( f1, f2, optionalFlags = "", outputPath = "", myinitfile = ""):
         os.unlink( dfile )
     return ok
 
+def read_diff(ifile, outputPath):
+    """
+    Opens the diff file that is assocated with the given input file and returns
+    its contents as a string.
+    """
+    dfile = diffFile(ifile, outputPath)
+    with open(dfile, 'r') as diff:
+        return diff.read()
+
 def copy_data(source='',target=''):
     cmd = 'cp '+ mkpath('data/' + source) + ' ' + mkpath(target)
     p = subprocess.Popen(cmd,shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE)
@@ -332,7 +341,8 @@ class GPLoad_FormatOpts_TestCase(unittest.TestCase):
         f2 = outFile(ifile, outputPath=outputPath)
 
         result = isFileEqual(f1, f2, optionalFlags, outputPath=outputPath)
-        self.failUnless(result)
+        diff = None if result else read_diff(ifile, outputPath)
+        self.assertTrue(result, "query resulted in diff:\n{}".format(diff))
 
         return True
 

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_REMOTE.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_REMOTE.py
@@ -314,7 +314,7 @@ class PSQLError(Exception):
 
 class GPLoad_FormatOpts_TestCase(unittest.TestCase):
 
-    def check_result(self,ifile, optionalFlags = "", outputPath = ""):
+    def check_result(self,ifile, optionalFlags = "-U3", outputPath = ""):
         """
         PURPOSE: compare the actual and expected output files and report an
             error if they don't match.
@@ -325,10 +325,11 @@ class GPLoad_FormatOpts_TestCase(unittest.TestCase):
                 figure out the proper names of the .out and .ans files.
             optionalFlags: command-line options (if any) for diff.
                 For example, pass " -B " (with the blank spaces) to ignore
-                blank lines.
+                blank lines. By default, diffs are unified with 3 lines of
+                context (i.e. optionalFlags is "-U3").
         """
-        f1 = outFile(ifile, outputPath=outputPath)
-        f2 = gpdbAnsFile(ifile)
+        f1 = gpdbAnsFile(ifile)
+        f2 = outFile(ifile, outputPath=outputPath)
 
         result = isFileEqual(f1, f2, optionalFlags, outputPath=outputPath)
         self.failUnless(result)


### PR DESCRIPTION
Two commits:
1. Match the rest of the ICW diff format by comparing actual to expected output (instead of the other way around) and using unified format with three lines of context.
2. Print the test diff file on failure, instead of `False is not True`.

Here's some example output:
```
======================================================================
FAIL: testQuery05 (__main__.GPLoad_Env_TestCase)
5  only specify port
----------------------------------------------------------------------
Traceback (most recent call last):
  File "./TEST.py", line 439, in testQuery05
    self.doTest(5)
  File "./TEST.py", line 380, in doTest
    self.check_result(file)
  File "./TEST.py", line 401, in check_result
    self.assertTrue(result, "query resulted in diff:\n{}".format(diff))
AssertionError: query resulted in diff:
--- /Users/pchampion/workspace/gpdb/gpMgmt/bin/gpload_test/gpload/query5.ans	2018-05-07 09:19:18.000000000 -0700
+++ /Users/pchampion/workspace/gpdb/gpMgmt/bin/gpload_test/gpload/query5.out	2018-05-07 09:19:18.000000000 -0700
@@ -1,8 +1,10 @@
 GP_IGNORE: formatted by atmsort.pm
 TODAYS_DATE1|INFO|gpload session started TODAYS_DATE2
+GP_IGNORE:
 TODAYS_DATE1|INFO|GP_IGNORE: started gpfdist -p 8000 -P 9000 -f CONFIG_FILE
-TODAYS_DATE1|INFO|running time: RUNNING_TIME seconds
-TODAYS_DATE1|INFO|rows Inserted          = 1
+TODAYS_DATE1|ERROR|ERROR:  connection with gpfdist failed for gpfdist://HOST:PORT/PATH_TO_FILE
+ encountered while running INSERT INTO lineitem ("l_orderkey","l_partkey","l_suppkey","l_linenumber","l_quantity","l_extendedprice","l_discount","l_tax","l_returnflag","l_linestatus","l_shipdate","l_commitdate","l_receiptdate","l_shipinstruct","l_shipmode","l_comment" SELECT "l_orderkey","l_partkey","l_suppkey","l_linenumber","l_quantity","l_extendedprice","l_discount","l_tax","l_returnflag","l_linestatus","l_shipdate","l_commitdate","l_receiptdate","l_shipinstruct","l_shipmode","l_comment" FROM ext_gpload_64822a4f_5212_11e8_b0ea_784f439ba583
+TODAYS_DATE1|INFO|rows Inserted          = 0
 TODAYS_DATE1|INFO|rows Updated           = 0
 TODAYS_DATE1|INFO|data formatting errors = 0
-TODAYS_DATE1|INFO|gpload succeeded
+TODAYS_DATE1|INFO|gpload failed
```
This output style helped us debug gpload failures during the current merge iteration.