### PR TITLE
src/test: install test utilities as part of installcheck

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -160,9 +160,9 @@ distclean maintainer-clean:
 # a running server. This is what the CI pipeline runs.
 installcheck-world:
 	$(MAKE) -C src/test installcheck-good
-	$(MAKE) -C src/test/fsync install && $(MAKE) -C src/test/fsync installcheck
-	$(MAKE) -C src/test/walrep install && $(MAKE) -C src/test/walrep installcheck
-	$(MAKE) -C src/test/heap_checksum install && $(MAKE) -C src/test/heap_checksum installcheck
+	$(MAKE) -C src/test/fsync installcheck
+	$(MAKE) -C src/test/walrep installcheck
+	$(MAKE) -C src/test/heap_checksum installcheck
 	$(MAKE) -C src/test/isolation installcheck
 	$(MAKE) -C src/test/isolation2 installcheck
 	$(MAKE) -C src/pl installcheck

--- a/src/test/fsync/Makefile
+++ b/src/test/fsync/Makefile
@@ -11,3 +11,7 @@ include $(top_builddir)/src/Makefile.global
 
 NO_PGXS = 1
 include $(top_srcdir)/src/makefiles/pgxs.mk
+
+# Ease the top-level Makefile's job a little bit, and install supporting
+# libraries as part of installcheck.
+installcheck: install

--- a/src/test/heap_checksum/Makefile
+++ b/src/test/heap_checksum/Makefile
@@ -11,3 +11,7 @@ include $(top_builddir)/src/Makefile.global
 
 NO_PGXS = 1
 include $(top_srcdir)/src/makefiles/pgxs.mk
+
+# Ease the top-level Makefile's job a little bit, and install supporting
+# libraries as part of installcheck.
+installcheck: install

--- a/src/test/walrep/Makefile
+++ b/src/test/walrep/Makefile
@@ -20,3 +20,7 @@ REGRESS_OPTS = --dbname="walrep_regression"
 
 NO_PGXS = 1
 include $(top_srcdir)/src/makefiles/pgxs.mk
+
+# Ease the top-level Makefile's job a little bit, and install supporting
+# libraries as part of installcheck.
+installcheck: install


### PR DESCRIPTION
`make --keep-going` support for ICW is coming as part of the 9.1 merge. To get this working smoothly, each folder that needs to be tested should have a single test target (`installcheck` or `installcheck-good` or whatever).

Currently, `fsync`, `walrep`, and `heap_checksum` violate this rule. So instead of making the top-level Makefile run `make install` as part of its test run, make installation a prerequisite for `installcheck` for those three tests. (isolation2 already does this.)

It's probably more correct to have `installcheck-world` test only what is actually installed with `install-world`, but I think this is a good step forward without changing too much about the current build system.