### PR TITLE
QE readers should check abort status of their subxids

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -796,9 +796,8 @@ TransactionIdIsCurrentTransactionIdInternal(TransactionId xid)
  * - case 3: if overflowed, check topmostxid from pg_subtrans with writer's top transaction id
  */
 static
-bool IsCurrentTransactionIdForReader(TransactionId xid) {
-	TransactionId topxid;
-
+bool IsCurrentTransactionIdForReader(TransactionId xid)
+{
 	Assert(!Gp_is_writer);
 
 	Assert(SharedLocalSnapshotSlot);
@@ -810,12 +809,12 @@ bool IsCurrentTransactionIdForReader(TransactionId xid) {
 	if (!writer_proc)
 	{
 		LWLockRelease(SharedLocalSnapshotSlot->slotLock);
-		elog(ERROR, "SharedLocalSnapshotSlot is not initialized with writer_proc.");
+		elog(ERROR, "reference to writer proc not found in shared snapshot");
 	}
 	else if (!writer_proc->pid)
 	{
 		LWLockRelease(SharedLocalSnapshotSlot->slotLock);
-		elog(ERROR, "SharedLocalSnapshotSlot->writer_proc is invalid.");
+		elog(ERROR, "writer proc reference shared with reader is invalid");
 	}
 
 	TransactionId writer_xid = writer_proc->xid;
@@ -830,8 +829,7 @@ bool IsCurrentTransactionIdForReader(TransactionId xid) {
 		if (TransactionIdEquals(xid, writer_xid))
 		{
 			ereportif(Debug_print_full_dtm, LOG,
-					  (errmsg("qExec Reader, xid = %d matches writer's top xid",
-							  xid)));
+					  (errmsg("reader encountered writer's top xid %u", xid)));
 			isCurrent = true;
 		}
 		else
@@ -857,15 +855,31 @@ bool IsCurrentTransactionIdForReader(TransactionId xid) {
 	if (!isCurrent && overflowed)
 	{
 		Assert(TransactionIdIsValid(writer_xid));
-
-		topxid = SubTransGetTopmostTransaction(xid);
-		Assert(TransactionIdIsValid(topxid));
-
-		if (TransactionIdEquals(topxid, writer_xid))
+		/*
+		 * QE readers don't have access to writer's transaction state.
+		 * Therefore, unlike writer, readers have to lookup pg_subtrans, which
+		 * is more expensive than searching for an xid in transaction state.  If
+		 * xid is older than the oldest running transaction we know of, it is
+		 * definitely not current and we can skip pg_subtrans.  Note that
+		 * pg_subtrans is not guaranteed to exist for transactions that are
+		 * known to be finished.
+		 */
+		if (TransactionIdFollowsOrEquals(xid, TransactionXmin) &&
+			TransactionIdEquals(SubTransGetTopmostTransaction(xid), writer_xid))
 		{
-			isCurrent = true;
+			/*
+			 * xid is a subtransaction of current transaction.  Did it abort?
+			 * If this was a writer, TransactionIdIsCurrentTransactionId()
+			 * returns false for aborted subtransactions.  We must therefore
+			 * consult clog.  In a writer, this information is available in
+			 * CurrentTransactionState.
+			 */
+			isCurrent = TransactionIdDidAbort(xid) ? false : true;
 		}
 	}
+
+	ereportif(isCurrent && Debug_print_full_dtm, LOG,
+			  (errmsg("reader encountered writer's subxact ID %u", xid)));
 
 	return isCurrent;
 }

--- a/src/test/regress/expected/subtransaction_visibility.out
+++ b/src/test/regress/expected/subtransaction_visibility.out
@@ -2,7 +2,12 @@
 -- presence of subtransactions
 drop table if exists subxact1;
 NOTICE:  table "subxact1" does not exist, skipping
-create table subxact1(a int) distributed by (a);
+drop table if exists subxact2;
+NOTICE:  table "subxact2" does not exist, skipping
+create table subxact1(a int, b int) distributed by (a);
+create table subxact2(a int, b int) distributed by (a);
+insert into subxact2 select i,i from generate_series(1, 12)i;
+analyze subxact2;
 --
 -- Plpgsql functions
 --
@@ -18,7 +23,7 @@ begin
    if i > 0 then
       perform recurse(i, value, abortme);
    end if;
-   execute 'insert into subxact1 values ('|| value ||')';
+   execute 'insert into subxact1 values ('|| value || ',' || value || ')';
    if abortme = true then
       raise exception 'abort me';
    end if;
@@ -32,53 +37,53 @@ $$
 language plpgsql;
 -- TEST: all subtransactions committed without overflow
 begin;
-select recurse(10, 0, false);
+select recurse(10, 1, false);
  recurse 
 ---------
  
 (1 row)
 
-select count(*) = 10 as passed from subxact1 where a = 0;
+select count(*) = 10 as passed from subxact1 where a = 1;
  passed 
 --------
  t
 (1 row)
 
 savepoint subtx_no_overflow;
--- create a reader gang, and all tuples inserted by previous subtransactions
--- should be visible.
-insert into subxact1 select * from subxact1;
-select count(*) = 20 as passed from subxact1 where a = 0;
- passed 
---------
- t
+-- Create a reader gang, and all tuples inserted by previous subtransactions
+-- should be visible.  The MPP plan must be such that the subxact1 table is
+-- scanned by the reader gang.  Analyzing subxact1 here causes such a plan to
+-- be generated.  If analyze is omitted, the plan is such that reader gangs
+-- scan subxact2, which will not result in the intended test scenario.
+analyze subxact1;
+select count(*) from subxact2 t2, subxact1 t1 where t2.a = t1.b;
+ count 
+-------
+    10
 (1 row)
 
 commit;
 -- TEST: all subtransactions committed with overflow
 -- Recurse to a depth greater than PGPROC_MAX_CACHED_SUBXIDS
 begin;
-select recurse(65, -1, false);
+select recurse(80, 2, false);
  recurse 
 ---------
  
 (1 row)
 
-select count(*) = 65 as passed from subxact1 where a = -1;
+select count(*) = 80 as passed from subxact1 where a = 2;
  passed 
 --------
  t
 (1 row)
 
-savepoint subtx_with_overflow;
 -- create a reader gang, and all tuples inserted by previous subtransactions
 -- should be visible.
-insert into subxact1 select * from subxact1;
-release subtx_with_overflow;
-select count(*) = 130 as passed from subxact1 where a = -1;
- passed 
---------
- t
+select count(*) from subxact2 t2, subxact1 t1 where t2.a = t1.b;
+ count 
+-------
+    90
 (1 row)
 
 commit;
@@ -87,14 +92,16 @@ commit;
 -- commit.  Tuples inserted by aborted subtransactions should not be
 -- visible.
 begin;
-select recurse(30, -2, false); -- committed
+-- Keeping the value to be inserted (second argument) same is needed so that all
+-- inserts are dispatched to the same segment.
+select recurse(40, 3, false); -- committed
  recurse 
 ---------
  
 (1 row)
 
-select recurse(10, -3, true); -- aborted
-NOTICE:  abort me -3
+select recurse(10, 3, true); -- aborted
+NOTICE:  abort me 3
 CONTEXT:  SQL statement "SELECT recurse(i, value, abortme)"
 PL/pgSQL function "recurse" line 6 at PERFORM
 SQL statement "SELECT recurse(i, value, abortme)"
@@ -113,7 +120,7 @@ SQL statement "SELECT recurse(i, value, abortme)"
 PL/pgSQL function "recurse" line 6 at PERFORM
 SQL statement "SELECT recurse(i, value, abortme)"
 PL/pgSQL function "recurse" line 6 at PERFORM
-NOTICE:  abort me -3
+NOTICE:  abort me 3
 CONTEXT:  SQL statement "SELECT recurse(i, value, abortme)"
 PL/pgSQL function "recurse" line 6 at PERFORM
 SQL statement "SELECT recurse(i, value, abortme)"
@@ -130,7 +137,7 @@ SQL statement "SELECT recurse(i, value, abortme)"
 PL/pgSQL function "recurse" line 6 at PERFORM
 SQL statement "SELECT recurse(i, value, abortme)"
 PL/pgSQL function "recurse" line 6 at PERFORM
-NOTICE:  abort me -3
+NOTICE:  abort me 3
 CONTEXT:  SQL statement "SELECT recurse(i, value, abortme)"
 PL/pgSQL function "recurse" line 6 at PERFORM
 SQL statement "SELECT recurse(i, value, abortme)"
@@ -145,7 +152,7 @@ SQL statement "SELECT recurse(i, value, abortme)"
 PL/pgSQL function "recurse" line 6 at PERFORM
 SQL statement "SELECT recurse(i, value, abortme)"
 PL/pgSQL function "recurse" line 6 at PERFORM
-NOTICE:  abort me -3
+NOTICE:  abort me 3
 CONTEXT:  SQL statement "SELECT recurse(i, value, abortme)"
 PL/pgSQL function "recurse" line 6 at PERFORM
 SQL statement "SELECT recurse(i, value, abortme)"
@@ -158,7 +165,7 @@ SQL statement "SELECT recurse(i, value, abortme)"
 PL/pgSQL function "recurse" line 6 at PERFORM
 SQL statement "SELECT recurse(i, value, abortme)"
 PL/pgSQL function "recurse" line 6 at PERFORM
-NOTICE:  abort me -3
+NOTICE:  abort me 3
 CONTEXT:  SQL statement "SELECT recurse(i, value, abortme)"
 PL/pgSQL function "recurse" line 6 at PERFORM
 SQL statement "SELECT recurse(i, value, abortme)"
@@ -169,7 +176,7 @@ SQL statement "SELECT recurse(i, value, abortme)"
 PL/pgSQL function "recurse" line 6 at PERFORM
 SQL statement "SELECT recurse(i, value, abortme)"
 PL/pgSQL function "recurse" line 6 at PERFORM
-NOTICE:  abort me -3
+NOTICE:  abort me 3
 CONTEXT:  SQL statement "SELECT recurse(i, value, abortme)"
 PL/pgSQL function "recurse" line 6 at PERFORM
 SQL statement "SELECT recurse(i, value, abortme)"
@@ -178,35 +185,34 @@ SQL statement "SELECT recurse(i, value, abortme)"
 PL/pgSQL function "recurse" line 6 at PERFORM
 SQL statement "SELECT recurse(i, value, abortme)"
 PL/pgSQL function "recurse" line 6 at PERFORM
-NOTICE:  abort me -3
+NOTICE:  abort me 3
 CONTEXT:  SQL statement "SELECT recurse(i, value, abortme)"
 PL/pgSQL function "recurse" line 6 at PERFORM
 SQL statement "SELECT recurse(i, value, abortme)"
 PL/pgSQL function "recurse" line 6 at PERFORM
 SQL statement "SELECT recurse(i, value, abortme)"
 PL/pgSQL function "recurse" line 6 at PERFORM
-NOTICE:  abort me -3
+NOTICE:  abort me 3
 CONTEXT:  SQL statement "SELECT recurse(i, value, abortme)"
 PL/pgSQL function "recurse" line 6 at PERFORM
 SQL statement "SELECT recurse(i, value, abortme)"
 PL/pgSQL function "recurse" line 6 at PERFORM
-NOTICE:  abort me -3
+NOTICE:  abort me 3
 CONTEXT:  SQL statement "SELECT recurse(i, value, abortme)"
 PL/pgSQL function "recurse" line 6 at PERFORM
-NOTICE:  abort me -3
+NOTICE:  abort me 3
  recurse 
 ---------
  
 (1 row)
 
-declare c1 cursor for select count(*) = 30 passed from subxact1 where a in (-2, -3);
-select recurse(35, -2, false); -- committed
+select recurse(40, 3, false); -- committed
  recurse 
 ---------
  
 (1 row)
 
-savepoint subtx_with_overflow_mixed_abort;
+declare c1 cursor for select count(*) = 80 as passed from subxact1 where a = 3;
 -- Validate that rows inserted by committed subtransactions are
 -- visible and rows inserted by aborted subtransactions aren't.
 fetch all in c1;
@@ -215,14 +221,8 @@ fetch all in c1;
  t
 (1 row)
 
-release subtx_with_overflow_mixed_abort;
-select count(*) = 65 as passed from subxact1 where a = -2;
- passed 
---------
- t
-(1 row)
-
-select count(*) = 0 as passed from subxact1 where a = -3;
+select count(*) = 80 as passed from subxact2 t2, subxact1 t1
+ where t2.a = t1.b and t1.a = 3;
  passed 
 --------
  t

--- a/src/test/regress/sql/subtransaction_visibility.sql
+++ b/src/test/regress/sql/subtransaction_visibility.sql
@@ -2,7 +2,11 @@
 -- presence of subtransactions
 
 drop table if exists subxact1;
-create table subxact1(a int) distributed by (a);
+drop table if exists subxact2;
+create table subxact1(a int, b int) distributed by (a);
+create table subxact2(a int, b int) distributed by (a);
+insert into subxact2 select i,i from generate_series(1, 12)i;
+analyze subxact2;
 
 --
 -- Plpgsql functions
@@ -20,7 +24,7 @@ begin
    if i > 0 then
       perform recurse(i, value, abortme);
    end if;
-   execute 'insert into subxact1 values ('|| value ||')';
+   execute 'insert into subxact1 values ('|| value || ',' || value || ')';
    if abortme = true then
       raise exception 'abort me';
    end if;
@@ -35,26 +39,26 @@ language plpgsql;
 
 -- TEST: all subtransactions committed without overflow
 begin;
-select recurse(10, 0, false);
-select count(*) = 10 as passed from subxact1 where a = 0;
+select recurse(10, 1, false);
+select count(*) = 10 as passed from subxact1 where a = 1;
 savepoint subtx_no_overflow;
--- create a reader gang, and all tuples inserted by previous subtransactions
--- should be visible.
-insert into subxact1 select * from subxact1;
-select count(*) = 20 as passed from subxact1 where a = 0;
+-- Create a reader gang, and all tuples inserted by previous subtransactions
+-- should be visible.  The MPP plan must be such that the subxact1 table is
+-- scanned by the reader gang.  Analyzing subxact1 here causes such a plan to
+-- be generated.  If analyze is omitted, the plan is such that reader gangs
+-- scan subxact2, which will not result in the intended test scenario.
+analyze subxact1;
+select count(*) from subxact2 t2, subxact1 t1 where t2.a = t1.b;
 commit;
 
 -- TEST: all subtransactions committed with overflow
 -- Recurse to a depth greater than PGPROC_MAX_CACHED_SUBXIDS
 begin;
-select recurse(65, -1, false);
-select count(*) = 65 as passed from subxact1 where a = -1;
-savepoint subtx_with_overflow;
+select recurse(80, 2, false);
+select count(*) = 80 as passed from subxact1 where a = 2;
 -- create a reader gang, and all tuples inserted by previous subtransactions
 -- should be visible.
-insert into subxact1 select * from subxact1;
-release subtx_with_overflow;
-select count(*) = 130 as passed from subxact1 where a = -1;
+select count(*) from subxact2 t2, subxact1 t1 where t2.a = t1.b;
 commit;
 
 -- TEST: some subtransactions aborted with reader gang for cursor
@@ -62,15 +66,15 @@ commit;
 -- commit.  Tuples inserted by aborted subtransactions should not be
 -- visible.
 begin;
-select recurse(30, -2, false); -- committed
-select recurse(10, -3, true); -- aborted
-declare c1 cursor for select count(*) = 30 passed from subxact1 where a in (-2, -3);
-select recurse(35, -2, false); -- committed
-savepoint subtx_with_overflow_mixed_abort;
+-- Keeping the value to be inserted (second argument) same is needed so that all
+-- inserts are dispatched to the same segment.
+select recurse(40, 3, false); -- committed
+select recurse(10, 3, true); -- aborted
+select recurse(40, 3, false); -- committed
+declare c1 cursor for select count(*) = 80 as passed from subxact1 where a = 3;
 -- Validate that rows inserted by committed subtransactions are
 -- visible and rows inserted by aborted subtransactions aren't.
 fetch all in c1;
-release subtx_with_overflow_mixed_abort;
-select count(*) = 65 as passed from subxact1 where a = -2;
-select count(*) = 0 as passed from subxact1 where a = -3;
+select count(*) = 80 as passed from subxact2 t2, subxact1 t1
+ where t2.a = t1.b and t1.a = 3;
 commit;


### PR DESCRIPTION
QE readers incorrectly return true for TransactionIdIsCurrentTransactionId() when passed with an xid that is an aborted subtransaction of current transaction.  The end effect is wrong results because tuples inserted by the aborted subtransaction are seen (treated as visible according to MVCC rules) by
a reader.  Current patch fixes the bug by looking up abort status of an XID from pg_clog.  In a QE writer, just like in upstream PostgreSQL, subtransaction information is available in CurrentTransactionState (even when subxip cache has overflown).  This information is not maintained in shared memory, making it unavailable to a reader.  Readers must resort to a longer route to get the same information - pg_subtrans and pg_clog.

The test case also needed a fix because the SQL query (insert into select *) didn't result in a reader gang being created.  The SQL is changed to a join on a non-distribution column so as to achieve reader gang creation.

In fact, it started with the incorrect test case.  After fixing the test to bring about the correct reader gangs, the case with aborted subtransactions started failing with incorrect results.