### PR TITLE
Teach heap_truncate_one_rel to handle AO tables as well

### DIFF
--- a/src/include/commands/tablecmds.h
+++ b/src/include/commands/tablecmds.h
@@ -75,8 +75,6 @@ extern void AlterRelationNamespaceInternal(Relation classRel, Oid relOid,
 
 extern void CheckTableNotInUse(Relation rel, const char *stmt);
 
-extern void TruncateRelfiles(Relation rel, SubTransactionId mysubid);
-
 extern void ExecuteTruncate(TruncateStmt *stmt);
 
 extern void renameatt(Oid myrelid,

--- a/src/test/regress/input/aocs.source
+++ b/src/test/regress/input/aocs.source
@@ -512,6 +512,24 @@ insert into aocs_compress_results values (pg_relation_size('aocs_compress_table'
 
 select count(*) from (select distinct * from aocs_compress_results) temp; -- should give 2 after reclaiming space
 
+-- Same transaction truncate multiple times. This performs unsafe truncate means
+-- direct file truncate and not flipping the relfilenode.
+
+create table aocs_truncate_multiple_times(a int, b int) with (appendonly=true, orientation=column);
+insert into aocs_truncate_multiple_times select i,i from generate_series(0, 9)i;
+begin;
+select * from aocs_truncate_multiple_times;
+truncate table aocs_truncate_multiple_times;
+select * from aocs_truncate_multiple_times;
+insert into aocs_truncate_multiple_times select i from generate_series(10, 19)i;
+select * from aocs_truncate_multiple_times;
+truncate table aocs_truncate_multiple_times;
+select * from aocs_truncate_multiple_times;
+insert into aocs_truncate_multiple_times select i,i from generate_series(20, 29)i;
+select * from aocs_truncate_multiple_times;
+abort;
+select * from aocs_truncate_multiple_times;
+
 -- test case for append optimized columnar bitmap scan when row level bitmap is promoted to page level
 
 drop table if exists bms_ao_bug;

--- a/src/test/regress/input/appendonly.source
+++ b/src/test/regress/input/appendonly.source
@@ -545,6 +545,24 @@ insert into ao_compress_results values (pg_relation_size('ao_compress_table'), p
 
 select count(*) from (select distinct * from ao_compress_results) temp; -- should give 2 after reclaiming space
 
+-- Same transaction truncate multiple times. This performs unsafe truncate means
+-- direct file truncate and not flipping the relfilenode.
+
+create table ao_truncate_multiple_times(a int) with (appendonly=true);
+insert into ao_truncate_multiple_times select * from generate_series(0, 9);
+begin;
+select * from ao_truncate_multiple_times;
+truncate table ao_truncate_multiple_times;
+select * from ao_truncate_multiple_times;
+insert into ao_truncate_multiple_times select * from generate_series(10, 19);
+select * from ao_truncate_multiple_times;
+truncate table ao_truncate_multiple_times;
+select * from ao_truncate_multiple_times;
+insert into ao_truncate_multiple_times select * from generate_series(20, 29);
+select * from ao_truncate_multiple_times;
+abort;
+select * from ao_truncate_multiple_times;
+
 -------------------- 
 -- supported sql 
 --------------------

--- a/src/test/regress/output/aocs.source
+++ b/src/test/regress/output/aocs.source
@@ -1034,6 +1034,86 @@ select count(*) from (select distinct * from aocs_compress_results) temp; -- sho
      2
 (1 row)
 
+-- Same transaction truncate multiple times. This performs unsafe truncate means
+-- direct file truncate and not flipping the relfilenode.
+create table aocs_truncate_multiple_times(a int, b int) with (appendonly=true, orientation=column);
+insert into aocs_truncate_multiple_times select i,i from generate_series(0, 9)i;
+begin;
+select * from aocs_truncate_multiple_times;
+ a | b 
+---+---
+ 8 | 8
+ 9 | 9
+ 0 | 0
+ 1 | 1
+ 2 | 2
+ 3 | 3
+ 4 | 4
+ 5 | 5
+ 6 | 6
+ 7 | 7
+(10 rows)
+
+truncate table aocs_truncate_multiple_times;
+select * from aocs_truncate_multiple_times;
+ a | b 
+---+---
+(0 rows)
+
+insert into aocs_truncate_multiple_times select i from generate_series(10, 19)i;
+select * from aocs_truncate_multiple_times;
+ a  | b 
+----+---
+ 10 |  
+ 11 |  
+ 12 |  
+ 18 |  
+ 19 |  
+ 13 |  
+ 14 |  
+ 15 |  
+ 16 |  
+ 17 |  
+(10 rows)
+
+truncate table aocs_truncate_multiple_times;
+select * from aocs_truncate_multiple_times;
+ a | b 
+---+---
+(0 rows)
+
+insert into aocs_truncate_multiple_times select i,i from generate_series(20, 29)i;
+select * from aocs_truncate_multiple_times;
+ a  | b  
+----+----
+ 28 | 28
+ 29 | 29
+ 23 | 23
+ 24 | 24
+ 25 | 25
+ 26 | 26
+ 27 | 27
+ 20 | 20
+ 21 | 21
+ 22 | 22
+(10 rows)
+
+abort;
+select * from aocs_truncate_multiple_times;
+ a | b 
+---+---
+ 0 | 0
+ 1 | 1
+ 2 | 2
+ 8 | 8
+ 9 | 9
+ 3 | 3
+ 4 | 4
+ 5 | 5
+ 6 | 6
+ 7 | 7
+(10 rows)
+
 -- test case for append optimized columnar bitmap scan when row level bitmap is promoted to page level
 drop table if exists bms_ao_bug;
 create table bms_ao_bug

--- a/src/test/regress/output/appendonly.source
+++ b/src/test/regress/output/appendonly.source
@@ -1174,6 +1174,88 @@ select count(*) from (select distinct * from ao_compress_results) temp; -- shoul
      2
 (1 row)
 
+-- Same transaction truncate multiple times. This performs unsafe truncate means
+-- direct file truncate and not flipping the relfilenode.
+create table ao_truncate_multiple_times(a int) with (appendonly=true);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into ao_truncate_multiple_times select * from generate_series(0, 9);
+begin;
+select * from ao_truncate_multiple_times;
+ a 
+---
+ 8
+ 9
+ 3
+ 4
+ 5
+ 6
+ 7
+ 0
+ 1
+ 2
+(10 rows)
+
+truncate table ao_truncate_multiple_times;
+select * from ao_truncate_multiple_times;
+ a 
+---
+(0 rows)
+
+insert into ao_truncate_multiple_times select * from generate_series(10, 19);
+select * from ao_truncate_multiple_times;
+ a  
+----
+ 18
+ 19
+ 13
+ 14
+ 15
+ 16
+ 17
+ 10
+ 11
+ 12
+(10 rows)
+
+truncate table ao_truncate_multiple_times;
+select * from ao_truncate_multiple_times;
+ a 
+---
+(0 rows)
+
+insert into ao_truncate_multiple_times select * from generate_series(20, 29);
+select * from ao_truncate_multiple_times;
+ a  
+----
+ 28
+ 29
+ 23
+ 24
+ 25
+ 26
+ 27
+ 20
+ 21
+ 22
+(10 rows)
+
+abort;
+select * from ao_truncate_multiple_times;
+ a 
+---
+ 0
+ 1
+ 2
+ 8
+ 9
+ 3
+ 4
+ 5
+ 6
+ 7
+(10 rows)
+
 -------------------- 
 -- supported sql 
 --------------------


### PR DESCRIPTION
Upstream commit cab9a0656 introduced an optimization to truncate tables
in scenarios that permit "unsafe" operations where we don't have to
churn on the relfilenode for the underlying tables. AO table got a free
ride but for the wrong reason.

This patch teaches heap_truncate_one_rel() to perform the unsafe /
optimal truncation on AO tables. This allows us to converge the callers
back to how they look like in Postgres 9.0.

Specifically, we're now able to inline TruncateRelfiles() back into
ExecuteTruncate() .

One caveat introduced by this patch though, is the "optimal" / unsafe
truncation of an AO table can potentially leak some disk space: we are
not performing a real file-level truncate, merely seeking back to offset
0 -- because the aoseg auxiliary table is truncated -- on the next
write, therefore the space after the EOF mark is wasted in some sense.

Co-authored-by: Jesse Zhang <sbjesse@gmail.com>