### PR TITLE
Eliminate distributed transaction log creation and maintenance on QD.

### DIFF
--- a/src/backend/cdb/cdbdistributedsnapshot.c
+++ b/src/backend/cdb/cdbdistributedsnapshot.c
@@ -40,6 +40,8 @@ DistributedSnapshotWithLocalMapping_CommittedTest(
 	uint32		i;
 	DistributedTransactionId distribXid = InvalidDistributedTransactionId;
 
+	Assert(!IS_QUERY_DISPATCHER());
+
 	/*
 	 * Return early if local xid is not normal as it cannot have distributed
 	 * xid associated with it.

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -1269,7 +1269,7 @@ GetOldestXmin(bool allDbs, bool ignoreVacuum)
 	 * In QD node, all distributed transactions have an entry in the proc array,
 	 * so we're done.
 	 */
-	if (Gp_role != GP_ROLE_DISPATCH)
+	if (!IS_QUERY_DISPATCHER())
 	{
 		TransactionId distribOldestXmin;
 
@@ -1637,7 +1637,7 @@ getDtxCheckPointInfo(char **result, int *result_size)
 	int			actual;
 	ProcArrayStruct *arrayP = procArray;
 
-	if (GpIdentity.segindex != MASTER_CONTENT_ID)
+	if (!IS_QUERY_DISPATCHER())
 	{
 		gxact_checkpoint = palloc(TMGXACT_CHECKPOINT_BYTES(0));
 		gxact_checkpoint->committedCount = 0;
@@ -1868,12 +1868,15 @@ CreateDistributedSnapshot(DistributedSnapshotWithLocalMapping *distribSnapshotWi
 	distribSnapshotWithLocalMapping->minCachedLocalXid = InvalidTransactionId;
 	distribSnapshotWithLocalMapping->maxCachedLocalXid = InvalidTransactionId;
 
-	Assert(distribSnapshotWithLocalMapping->maxLocalXidsCount != 0);
-	Assert(distribSnapshotWithLocalMapping->inProgressMappedLocalXids != NULL);
+	if (!IS_QUERY_DISPATCHER())
+	{
+		Assert(distribSnapshotWithLocalMapping->maxLocalXidsCount != 0);
+		Assert(distribSnapshotWithLocalMapping->inProgressMappedLocalXids != NULL);
 
-	memset(distribSnapshotWithLocalMapping->inProgressMappedLocalXids,
-		   InvalidTransactionId,
-		   sizeof(TransactionId) * distribSnapshotWithLocalMapping->maxLocalXidsCount);
+		memset(distribSnapshotWithLocalMapping->inProgressMappedLocalXids,
+			   InvalidTransactionId,
+			   sizeof(TransactionId) * distribSnapshotWithLocalMapping->maxLocalXidsCount);
+	}
 
 	return true;
 }
@@ -1983,17 +1986,22 @@ GetSnapshotData(Snapshot snapshot)
 			}
 			snapshot->distribSnapshotWithLocalMapping.ds.maxCount = maxCount;
 
-			/*
-			 * Allocate memory for local xid cache, currently allocating it
-			 * same size as distributed, not necessary.
-			 */
-			snapshot->distribSnapshotWithLocalMapping.inProgressMappedLocalXids =
-				(TransactionId*)malloc(maxCount * sizeof(TransactionId));
-			if (snapshot->distribSnapshotWithLocalMapping.inProgressMappedLocalXids == NULL)
+			if (!IS_QUERY_DISPATCHER())
 			{
-				ereport(ERROR, (errcode(ERRCODE_OUT_OF_MEMORY), errmsg("out of memory")));
+				/*
+				 * Allocate memory for local xid cache, currently allocating it
+				 * same size as distributed, not necessary.
+				 */
+				snapshot->distribSnapshotWithLocalMapping.inProgressMappedLocalXids =
+					(TransactionId*)malloc(maxCount * sizeof(TransactionId));
+				if (snapshot->distribSnapshotWithLocalMapping.inProgressMappedLocalXids == NULL)
+				{
+					ereport(ERROR, (errcode(ERRCODE_OUT_OF_MEMORY), errmsg("out of memory")));
+				}
+				snapshot->distribSnapshotWithLocalMapping.maxLocalXidsCount = maxCount;
 			}
-			snapshot->distribSnapshotWithLocalMapping.maxLocalXidsCount = maxCount;
+			else
+				snapshot->distribSnapshotWithLocalMapping.maxLocalXidsCount = 0;
 		}
 	}
 
@@ -2420,11 +2428,7 @@ GetSnapshotData(Snapshot snapshot)
 	if (TransactionIdPrecedes(xmin, globalxmin))
 		globalxmin = xmin;
 
-	if (DistributedTransactionContext == DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE)
-	{
-		DistributedLog_AdvanceOldestXminOnQD(globalxmin);
-	}
-	else
+	if (!IS_QUERY_DISPATCHER())
 	{
 		/*
 		 * Fill in the distributed snapshot information we received from the

--- a/src/backend/utils/time/snapmgr.c
+++ b/src/backend/utils/time/snapmgr.c
@@ -36,6 +36,7 @@
 #include "utils/tqual.h"
 
 #include "cdb/cdbtm.h"
+#include "cdb/cdbvars.h"
 #include "utils/guc.h"
 
 
@@ -283,6 +284,9 @@ CopySnapshot(Snapshot snapshot)
 			   snapshot->distribSnapshotWithLocalMapping.ds.count *
 			   sizeof(DistributedTransactionId));
 
+		Assert(snapshot->distribSnapshotWithLocalMapping.ds.count ==
+			   newsnap->distribSnapshotWithLocalMapping.ds.count);
+
 		/* Store -1 as the maxCount, to indicate that the array was not malloc'd */
 		newsnap->distribSnapshotWithLocalMapping.ds.maxCount = -1;
 
@@ -294,15 +298,23 @@ CopySnapshot(Snapshot snapshot)
 			sizeof(DistributedTransactionId);
 
 		/* Copy the local xid cache */
-		newsnap->distribSnapshotWithLocalMapping.inProgressMappedLocalXids =
-			(TransactionId*) ((char *) newsnap + dsoff);
-		memcpy(newsnap->distribSnapshotWithLocalMapping.inProgressMappedLocalXids,
-			   snapshot->distribSnapshotWithLocalMapping.inProgressMappedLocalXids,
-			   snapshot->distribSnapshotWithLocalMapping.currentLocalXidsCount *
-			   sizeof(TransactionId));
-
-		newsnap->distribSnapshotWithLocalMapping.maxLocalXidsCount =
-			snapshot->distribSnapshotWithLocalMapping.currentLocalXidsCount;
+		if (IS_QUERY_DISPATCHER())
+		{
+			newsnap->distribSnapshotWithLocalMapping.inProgressMappedLocalXids = NULL;
+			newsnap->distribSnapshotWithLocalMapping.maxLocalXidsCount = 0;
+			newsnap->distribSnapshotWithLocalMapping.currentLocalXidsCount = 0;
+		}
+		else
+		{
+			newsnap->distribSnapshotWithLocalMapping.inProgressMappedLocalXids =
+				(TransactionId*) ((char *) newsnap + dsoff);
+			memcpy(newsnap->distribSnapshotWithLocalMapping.inProgressMappedLocalXids,
+				   snapshot->distribSnapshotWithLocalMapping.inProgressMappedLocalXids,
+				   snapshot->distribSnapshotWithLocalMapping.currentLocalXidsCount *
+				   sizeof(TransactionId));
+			newsnap->distribSnapshotWithLocalMapping.maxLocalXidsCount =
+				snapshot->distribSnapshotWithLocalMapping.currentLocalXidsCount;
+		}
 	}
 	else
 	{

--- a/src/backend/utils/time/tqual.c
+++ b/src/backend/utils/time/tqual.c
@@ -1351,7 +1351,7 @@ XidInMVCCSnapshot(TransactionId xid, Snapshot snapshot,
 	 * as the corresponding local ones, so we can rely on the local XIDs.
 	 */
 	if (snapshot->haveDistribSnapshot && !distributedSnapshotIgnore &&
-		Gp_segment != -1)
+		!IS_QUERY_DISPATCHER())
 	{
 		DistributedSnapshotCommitted	distributedSnapshotCommitted;
 

--- a/src/backend/utils/time/visibility_summary.c
+++ b/src/backend/utils/time/visibility_summary.c
@@ -20,6 +20,7 @@
 #include "access/distributedlog.h"
 #include "access/transam.h"
 #include "access/xact.h"
+#include "cdb/cdbvars.h"
 #include "lib/stringinfo.h"
 #include "utils/builtins.h"
 #include "utils/tqual.h"
@@ -236,7 +237,8 @@ GetTupleVisibilityDistribId(TransactionId xid,
 
 		case TupleTransactionStatus_HintCommitted:
 		case TupleTransactionStatus_CLogCommitted:
-			if (DistributedLog_CommittedCheck(xid,
+			if ((!IS_QUERY_DISPATCHER()) &&
+				DistributedLog_CommittedCheck(xid,
 											  &distribTimeStamp,
 											  &distribXid))
 			{

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -959,7 +959,7 @@ typedef struct GpId
  */
 extern GpId GpIdentity;
 #define UNINITIALIZED_GP_IDENTITY_VALUE (-10000)
-
+#define IS_QUERY_DISPATCHER() (GpIdentity.segindex == MASTER_CONTENT_ID)
 
 /* Stores the listener port that this process uses to listen for incoming
  * Interconnect connections from other Motion nodes.


### PR DESCRIPTION
Commit b3f300b9457 eliminated consulting distributed log in
XidInMVCCSnapshot(). This was based on in the QD, the distributed transactions
become visible at the same time as the corresponding local ones, so we can rely
on the local XIDs only. So, given QD never consults distributed transaction log,
lets completely eliminate its creation and maintenance on QD.

Note, during initdb identity (QD or QE) is currently not known and hence still
32k initial zero-filled distributed log file gets created on QD.

This patch introduces new macro for checking if QD, will be adding follow-up commit to address all places such check is performed throughout the code to bring consistency, uniformity, also correctness at some places.