### PR TITLE
docs - clarify settings for low memory queries

### DIFF
--- a/gpdb-doc/dita/admin_guide/workload_mgmt.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt.xml
@@ -241,11 +241,12 @@
         utilization controls, see <xref href="#topic12" type="topic" format="dita"/>.</p>
     <section id="topic113x" xml:lang="en">
       <title>statement_mem and Low Memory Queries</title>
-        <p>A <codeph>statement_mem</codeph> setting in the 1MB range has been shown
+        <p>A low <codeph>statement_mem</codeph> setting (for example, in the 
+          1-3MB range) has been shown
           to increase the performance of queries with low memory requirements. Use
           the <codeph>statement_mem</codeph> server configuration parameter to
           override the setting on a per-query basis. For example:
-          <codeblock>SET statement_mem='1MB';</codeblock></p>
+          <codeblock>SET statement_mem='2MB';</codeblock></p>
     </section>
     </body>
   </topic>

--- a/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
@@ -345,7 +345,8 @@ rg_perseg_mem = ((RAM * (vm.overcommit_ratio / 100) + SWAP) * gp_resource_group_
 
         <section id="topic833low" xml:lang="en">
           <title>memory_spill_ratio and Low Memory Queries </title>
-            <p>A <codeph>memory_spill_ratio</codeph> setting of zero (0) has been shown
+            <p>A low <codeph>memory_spill_ratio</codeph> setting (for example,
+              in the 0-10 range) has been shown
               to increase the performance of queries with low memory requirements. Use
               the <codeph>memory_spill_ratio</codeph> server configuration parameter
               to override the setting on a per-query basis. For example:

--- a/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
@@ -346,7 +346,7 @@ rg_perseg_mem = ((RAM * (vm.overcommit_ratio / 100) + SWAP) * gp_resource_group_
         <section id="topic833low" xml:lang="en">
           <title>memory_spill_ratio and Low Memory Queries </title>
             <p>A low <codeph>memory_spill_ratio</codeph> setting (for example,
-              in the 0-10 range) has been shown
+              in the 0-2 range) has been shown
               to increase the performance of queries with low memory requirements. Use
               the <codeph>memory_spill_ratio</codeph> server configuration parameter
               to override the setting on a per-query basis. For example:

--- a/gpdb-doc/dita/best_practices/workloads.xml
+++ b/gpdb-doc/dita/best_practices/workloads.xml
@@ -61,11 +61,12 @@ VM Protect failed to allocate 4096 bytes, 0 MB available</codeblock></p>
     </section>
     <section id="section113x" xml:lang="en">
       <title>Low Memory Queries</title>
-        <p>A <codeph>statement_mem</codeph> setting in the 1MB range has been shown
+        <p>A low <codeph>statement_mem</codeph> setting (for example, in the
+          1-3MB range) has been shown
           to increase the performance of queries with low memory requirements. Use
           the <codeph>statement_mem</codeph> server configuration parameter to
           override the setting on a per-query basis. For example:
-          <codeblock>SET statement_mem='1MB';</codeblock></p>
+          <codeblock>SET statement_mem='2MB';</codeblock></p>
     </section>
     <section id="section_r52_rbl_zt">
       <title>Configuring Memory for Greenplum Database</title>


### PR DESCRIPTION
the previous text incorrectly inferred there was a single low setting.